### PR TITLE
fix: avoid assistant fab overlapping chat send button

### DIFF
--- a/frontend/src/react/components/app-shell.js
+++ b/frontend/src/react/components/app-shell.js
@@ -20,6 +20,7 @@ export function AppShell({
 }) {
     const fixedViewportLayout =
         route.kind === ROUTE_KIND.ASSISTANT || route.kind === ROUTE_KIND.WORKSPACE || route.kind === ROUTE_KIND.TASKS;
+    const showAssistantTrigger = route.kind !== ROUTE_KIND.ASSISTANT;
     const currentWorkspaceTabLabel =
         PROJECT_TABS.find((item) => item.key === route.tab)?.label || PROJECT_TABS[0].label;
     const workspaceTitle = selectedProjectItem?.title || route.projectName || "未选择项目";
@@ -144,13 +145,17 @@ export function AppShell({
                 </section>
             </main>
 
-            <button
-                onClick=${onToggleAssistantPanel}
-                className="fixed right-5 bottom-5 z-50 w-14 h-14 rounded-full bg-neon-500 text-ink-950 shadow-glow hover:bg-neon-400 transition-colors flex items-center justify-center"
-                title="助手工作台"
-            >
-                <${IconSpark} />
-            </button>
+            ${showAssistantTrigger
+                ? html`
+                      <button
+                          onClick=${onToggleAssistantPanel}
+                          className="fixed right-5 bottom-5 z-50 w-14 h-14 rounded-full bg-neon-500 text-ink-950 shadow-glow hover:bg-neon-400 transition-colors flex items-center justify-center"
+                          title="助手工作台"
+                      >
+                          <${IconSpark} />
+                      </button>
+                  `
+                : null}
         </div>
     `;
 }

--- a/frontend/tests/app-shell-floating-button.test.mjs
+++ b/frontend/tests/app-shell-floating-button.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ROUTE_KIND } from "../src/react/constants.js";
+import { AppShell } from "../src/react/components/app-shell.js";
+
+function renderShell(routeKind) {
+    return renderToStaticMarkup(
+        React.createElement(AppShell, {
+            route: { kind: routeKind, tab: "overview", projectName: "test" },
+            dashboardKind: routeKind,
+            selectedProjectItem: null,
+            projectsCount: 1,
+            totalCalls: 0,
+            onNavigate: () => {},
+            onToggleAssistantPanel: () => {},
+            headerActions: null,
+            children: React.createElement("div", null, "body"),
+        })
+    );
+}
+
+const assistantMarkup = renderShell(ROUTE_KIND.ASSISTANT);
+assert(
+    !assistantMarkup.includes('title="助手工作台"'),
+    "Expected assistant route to hide floating assistant trigger button."
+);
+
+const workspaceMarkup = renderShell(ROUTE_KIND.WORKSPACE);
+assert(
+    workspaceMarkup.includes('title="助手工作台"'),
+    "Expected non-assistant routes to keep floating assistant trigger button."
+);
+
+console.log("app-shell-floating-button.test passed");


### PR DESCRIPTION
## Summary
- hide floating assistant trigger button on the assistant page to avoid overlapping the send button
- keep floating assistant trigger button on non-assistant pages
- add regression test for AppShell floating trigger visibility by route

## Test Plan
- node frontend/tests/app-shell-floating-button.test.mjs
- npm --prefix frontend run build
