### PR TITLE
Fix SQLite connection leak in generation queue

### DIFF
--- a/lib/generation_queue.py
+++ b/lib/generation_queue.py
@@ -9,9 +9,10 @@ import sqlite3
 import threading
 import time
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 ACTIVE_TASK_STATUSES = ("queued", "running")
 TERMINAL_TASK_STATUSES = ("succeeded", "failed")
@@ -60,13 +61,17 @@ class GenerationQueue:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._init_db()
 
-    def _connect(self) -> sqlite3.Connection:
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
         conn = sqlite3.connect(self.db_path, timeout=30, isolation_level=None)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA busy_timeout=30000")
         conn.execute("PRAGMA foreign_keys=OFF")
-        return conn
+        try:
+            yield conn
+        finally:
+            conn.close()
 
     def _init_db(self) -> None:
         with self._connect() as conn:

--- a/tests/test_generation_queue_unittest.py
+++ b/tests/test_generation_queue_unittest.py
@@ -1,5 +1,6 @@
 import time
 import unittest
+import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -7,6 +8,15 @@ from lib.generation_queue import GenerationQueue
 
 
 class TestGenerationQueue(unittest.TestCase):
+    @staticmethod
+    def _fd_count() -> int:
+        for fd_dir in ("/dev/fd", "/proc/self/fd"):
+            try:
+                return len(os.listdir(fd_dir))
+            except OSError:
+                continue
+        return -1
+
     def _create_queue(self) -> GenerationQueue:
         tmp = TemporaryDirectory(ignore_cleanup_errors=True)
         self.addCleanup(tmp.cleanup)
@@ -147,6 +157,33 @@ class TestGenerationQueue(unittest.TestCase):
 
         events = queue.get_events_since(last_event_id=0)
         self.assertTrue(any(event["event_type"] == "requeued" for event in events))
+
+    def test_get_events_since_does_not_leak_sqlite_file_descriptors(self):
+        queue = self._create_queue()
+
+        # Ensure there is at least one event row.
+        queue.enqueue_task(
+            project_name="demo",
+            task_type="storyboard",
+            media_type="image",
+            resource_id="E1S01",
+            payload={"prompt": "test"},
+            script_file="episode_01.json",
+            source="webui",
+        )
+
+        baseline = self._fd_count()
+        for _ in range(120):
+            queue.get_events_since(last_event_id=0, limit=10)
+        after = self._fd_count()
+
+        if baseline >= 0 and after >= 0:
+            # Allow small runtime fluctuations, but prevent linear FD growth.
+            self.assertLessEqual(
+                after,
+                baseline + 10,
+                f"FD count grew unexpectedly: baseline={baseline}, after={after}",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix GenerationQueue._connect() to use a real context manager that always closes sqlite connections
- keep existing call sites unchanged while ensuring every query path releases file descriptors
- add regression test to ensure repeated get_events_since() calls do not leak FDs

## Verification
- .venv/bin/python -m unittest tests.test_generation_queue_unittest tests.test_tasks_sse_unittest -v
