### PR TITLE
Fix image file descriptor leaks in Gemini client

### DIFF
--- a/lib/gemini_client.py
+++ b/lib/gemini_client.py
@@ -439,6 +439,16 @@ class GeminiClient:
         self.IMAGE_MODEL = "gemini-3-pro-image-preview"
         self.VIDEO_MODEL = "veo-3.1-generate-preview"
 
+    @staticmethod
+    def _load_image_detached(image_path: Union[str, Path]) -> Image.Image:
+        """
+        从路径加载图片并与底层文件句柄解绑。
+
+        返回的 Image 对象驻留内存，不再持有打开的文件描述符。
+        """
+        with Image.open(image_path) as img:
+            return img.copy()
+
     def _extract_name_from_path(
         self, image: Union[str, Path, Image.Image]
     ) -> Optional[str]:
@@ -503,7 +513,7 @@ class GeminiClient:
 
                 # 加载图片
                 if isinstance(img, (str, Path)):
-                    loaded_img = Image.open(img)
+                    loaded_img = self._load_image_detached(img)
                 else:
                     loaded_img = img
                 contents.append(loaded_img)
@@ -1181,9 +1191,12 @@ class GeminiClient:
         Returns:
             风格描述文字（逗号分隔的描述词列表）
         """
+        close_after_use = False
+
         # 准备图片
         if isinstance(image, (str, Path)):
-            img = Image.open(image)
+            img = self._load_image_detached(image)
+            close_after_use = True
         else:
             img = image
 
@@ -1197,12 +1210,15 @@ class GeminiClient:
             "suitable for an image generation prompt."
         )
 
-        # 调用 API
-        response = self.client.models.generate_content(
-            model=model, contents=[img, prompt]
-        )
-
-        return response.text.strip()
+        try:
+            # 调用 API
+            response = self.client.models.generate_content(
+                model=model, contents=[img, prompt]
+            )
+            return response.text.strip()
+        finally:
+            if close_after_use:
+                img.close()
 
     def _download_video(self, video_ref, output_path: Path) -> None:
         """

--- a/tests/test_gemini_client_fd_unittest.py
+++ b/tests/test_gemini_client_fd_unittest.py
@@ -1,0 +1,84 @@
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+
+from PIL import Image
+
+from lib.gemini_client import GeminiClient
+
+
+def _fd_count() -> int:
+    """Return current process file descriptor count, or -1 if unavailable."""
+    for fd_dir in ("/dev/fd", "/proc/self/fd"):
+        try:
+            return len(os.listdir(fd_dir))
+        except OSError:
+            continue
+    return -1
+
+
+class _FakeModels:
+    def __init__(self):
+        self.observed_fps = []
+
+    def generate_content(self, model, contents):
+        image_obj = contents[0]
+        self.observed_fps.append(getattr(image_obj, "fp", None))
+        return SimpleNamespace(text="cinematic, dramatic lighting")
+
+
+class _FakeClient:
+    def __init__(self):
+        self.models = _FakeModels()
+
+
+class TestGeminiClientFdSafety(unittest.TestCase):
+    def test_build_contents_with_labeled_refs_does_not_keep_file_handles_open(self):
+        with TemporaryDirectory() as tmpdir:
+            img_path = Path(tmpdir) / "ref.png"
+            Image.new("RGB", (16, 16), (255, 0, 0)).save(img_path)
+
+            client = object.__new__(GeminiClient)
+            client.SKIP_NAME_PATTERNS = GeminiClient.SKIP_NAME_PATTERNS
+
+            baseline = _fd_count()
+            retained_contents = []
+            for _ in range(40):
+                retained_contents.append(
+                    client._build_contents_with_labeled_refs("test prompt", [img_path])
+                )
+            after = _fd_count()
+
+            # Allow a small buffer for unrelated runtime FDs.
+            if baseline >= 0 and after >= 0:
+                self.assertLessEqual(
+                    after,
+                    baseline + 5,
+                    f"FD count grew unexpectedly: baseline={baseline}, after={after}",
+                )
+
+            # Explicit cleanup for test process hygiene.
+            for content in retained_contents:
+                for item in content:
+                    if isinstance(item, Image.Image):
+                        item.close()
+
+    def test_analyze_style_image_uses_detached_image_when_input_is_path(self):
+        with TemporaryDirectory() as tmpdir:
+            img_path = Path(tmpdir) / "style.png"
+            Image.new("RGB", (8, 8), (0, 128, 255)).save(img_path)
+
+            client = object.__new__(GeminiClient)
+            client.client = _FakeClient()
+
+            result = client.analyze_style_image(img_path, model="fake-model")
+
+            self.assertEqual(result, "cinematic, dramatic lighting")
+            self.assertEqual(len(client.client.models.observed_fps), 1)
+            self.assertIsNone(client.client.models.observed_fps[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add detached image loading helper so path-based reference images do not keep file handles open
- update generate-image reference loading and style-image analysis to avoid retaining open image descriptors
- add regression tests to guard against FD growth and ensure detached image inputs

## Verification
- .venv/bin/python -m unittest tests.test_gemini_client_fd_unittest -v
