### PR TITLE
fix(assistant): eliminate duplicate turns in streaming snapshot

### DIFF
--- a/frontend/src/react/hooks/use-assistant-state.js
+++ b/frontend/src/react/hooks/use-assistant-state.js
@@ -312,6 +312,15 @@ export function useAssistantState({
             setAssistantAnsweringQuestion(false);
         });
 
+        source.addEventListener("compact", () => {
+            // Compact boundary means server-side history was rewritten; reconnect
+            // to re-bootstrap from a fresh snapshot and avoid stale local state.
+            if (assistantStreamRef.current !== source) {
+                return;
+            }
+            connectStream(sessionId);
+        });
+
         source.addEventListener("status", (event) => {
             const data = parseSsePayload(event);
             if (!data || typeof data !== "object") {

--- a/tests/test_assistant_service_streaming_unittest.py
+++ b/tests/test_assistant_service_streaming_unittest.py
@@ -128,6 +128,40 @@ class TestAssistantServiceStreaming(unittest.TestCase):
             )
             self.assertLess(subscribe_idx, read_raw_idx)
 
+    def test_stream_replay_overflow_closes_stream_immediately(self):
+        with TemporaryDirectory() as tmpdir:
+            service = AssistantService(project_root=Path(tmpdir))
+            meta = SessionMeta(
+                id="session-1",
+                sdk_session_id="sdk-1",
+                project_name="demo",
+                title="demo",
+                status="running",
+                transcript_path=None,
+                created_at="2026-02-09T08:00:00Z",
+                updated_at="2026-02-09T08:00:00Z",
+            )
+
+            call_log: list[tuple] = []
+            service.meta_store = _FakeMetaStore(meta)
+            service.transcript_reader = _FakeTranscriptReader(call_log, history_raw=[])
+            service.session_manager = _FakeSessionManager(
+                call_log,
+                status="running",
+                replay_messages=[{"type": "_queue_overflow", "session_id": "sdk-1"}],
+            )
+
+            async def _run():
+                stream = service.stream_events("session-1")
+                with self.assertRaises(StopAsyncIteration):
+                    await anext(stream)
+                await stream.aclose()
+
+            asyncio.run(_run())
+            self.assertIn(("subscribe", "session-1", True), call_log)
+            self.assertIn(("unsubscribe", "session-1"), call_log)
+            self.assertNotIn(("read_raw_messages", "session-1", "sdk-1", "demo"), call_log)
+
     def test_stream_emits_delta_patch_question_and_status_events(self):
         with TemporaryDirectory() as tmpdir:
             service = AssistantService(project_root=Path(tmpdir))

--- a/webui/server/agent_runtime/service.py
+++ b/webui/server/agent_runtime/service.py
@@ -173,133 +173,217 @@ class AssistantService:
 
         initial_status = self.session_manager.get_status(session_id) or meta.status
         if initial_status != "running":
-            projector = self._build_projector(meta, session_id)
-            yield self._sse_event(
+            for event in self._emit_completed_snapshot(meta, session_id, initial_status):
+                yield event
+            return
+
+        queue = await self.session_manager.subscribe(session_id, replay_buffer=True)
+        try:
+            async for event in self._stream_running_session(
+                meta, session_id, initial_status, queue
+            ):
+                yield event
+        finally:
+            await self.session_manager.unsubscribe(session_id, queue)
+
+    async def _stream_running_session(
+        self,
+        meta: SessionMeta,
+        session_id: str,
+        initial_status: SessionStatus,
+        queue: asyncio.Queue,
+    ) -> AsyncIterator[str]:
+        """Inner generator for a running session's SSE stream."""
+        replayed_messages, replay_overflowed = self._drain_replay(queue)
+        if replay_overflowed:
+            return
+
+        status = self.session_manager.get_status(session_id) or initial_status
+        projector = self._build_projector(meta, session_id, replayed_messages)
+        snapshot_events = await self._emit_running_snapshot(
+            session_id, status, projector
+        )
+        for event in snapshot_events:
+            yield event
+        if status != "running":
+            return
+
+        while True:
+            try:
+                message = await asyncio.wait_for(
+                    queue.get(), timeout=self.stream_heartbeat_seconds
+                )
+                events, should_break = self._dispatch_live_message(
+                    message, projector, session_id
+                )
+                for event in events:
+                    yield event
+                if should_break:
+                    break
+            except asyncio.TimeoutError:
+                event = self._handle_heartbeat_timeout(session_id, status, projector)
+                if event is not None:
+                    yield event
+                    break
+                yield self._sse_keepalive_comment()
+
+    def _emit_completed_snapshot(
+        self, meta: SessionMeta, session_id: str, status: SessionStatus
+    ) -> list[str]:
+        """Build snapshot + status events for a non-running session."""
+        projector = self._build_projector(meta, session_id)
+        return [
+            self._sse_event(
                 "snapshot",
                 projector.build_snapshot(
                     session_id=session_id,
-                    status=initial_status,
+                    status=status,
                     pending_questions=[],
                 ),
-            )
-            yield self._sse_event(
+            ),
+            self._sse_event(
                 "status",
                 self._build_status_event_payload(
-                    status=initial_status,
+                    status=status,
                     session_id=session_id,
                     result_message=projector.last_result,
                 ),
+            ),
+        ]
+
+    async def _emit_running_snapshot(
+        self,
+        session_id: str,
+        status: SessionStatus,
+        projector: AssistantStreamProjector,
+    ) -> list[str]:
+        """Build snapshot (+ optional terminal status) for a possibly-running session."""
+        pending_questions: list[dict[str, Any]] = []
+        if status == "running":
+            pending_questions = await self.session_manager.get_pending_questions_snapshot(
+                session_id
             )
-            return
-
-        # Subscribe first to avoid missing messages between snapshot generation and queue attach.
-        queue = await self.session_manager.subscribe(session_id, replay_buffer=True)
-        try:
-            replayed_messages: list[dict[str, Any]] = []
-            while True:
-                try:
-                    replayed = queue.get_nowait()
-                except asyncio.QueueEmpty:
-                    break
-                if isinstance(replayed, dict):
-                    replayed_messages.append(replayed)
-
-            status = self.session_manager.get_status(session_id) or initial_status
-            projector = self._build_projector(meta, session_id, replayed_messages)
-            pending_questions = []
-            if status == "running":
-                pending_questions = await self.session_manager.get_pending_questions_snapshot(
-                    session_id
-                )
-
-            yield self._sse_event(
+        events = [
+            self._sse_event(
                 "snapshot",
                 projector.build_snapshot(
                     session_id=session_id,
                     status=status,
                     pending_questions=pending_questions,
                 ),
+            ),
+        ]
+        if status != "running":
+            events.append(self._sse_event(
+                "status",
+                self._build_status_event_payload(
+                    status=status,
+                    session_id=session_id,
+                    result_message=projector.last_result,
+                ),
+            ))
+        return events
+
+    @staticmethod
+    def _drain_replay(
+        queue: asyncio.Queue,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Drain replayed messages from *queue*, detecting overflow sentinel."""
+        replayed: list[dict[str, Any]] = []
+        while True:
+            try:
+                msg = queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if isinstance(msg, dict):
+                if msg.get("type") == "_queue_overflow":
+                    return replayed, True
+                replayed.append(msg)
+        return replayed, False
+
+    def _dispatch_live_message(
+        self,
+        message: dict[str, Any],
+        projector: AssistantStreamProjector,
+        session_id: str,
+    ) -> tuple[list[str], bool]:
+        """Process one live message. Returns (sse_events, should_break)."""
+        events: list[str] = []
+
+        update = projector.apply_message(message)
+        if isinstance(update.get("patch"), dict):
+            events.append(self._sse_event("patch", update["patch"]))
+        if isinstance(update.get("delta"), dict):
+            events.append(self._sse_event("delta", update["delta"]))
+        if isinstance(update.get("question"), dict):
+            events.append(self._sse_event("question", update["question"]))
+
+        msg_type = message.get("type", "")
+
+        if msg_type == "_queue_overflow":
+            return events, True
+
+        if msg_type == "system" and message.get("subtype") == "compact_boundary":
+            events.append(self._sse_event("compact", {
+                "session_id": session_id,
+                "subtype": "compact_boundary",
+            }))
+
+        if msg_type == "runtime_status":
+            terminal = self._check_runtime_status_terminal(message, session_id)
+            if terminal is not None:
+                events.append(terminal)
+                return events, True
+
+        if msg_type == "result":
+            events.append(self._sse_event(
+                "status",
+                self._build_status_event_payload(
+                    status=self._resolve_result_status(message),
+                    session_id=session_id,
+                    result_message=message,
+                ),
+            ))
+            return events, True
+
+        return events, False
+
+    _TERMINAL_STATUSES = {"idle", "running", "completed", "error", "interrupted"}
+
+    def _check_runtime_status_terminal(
+        self, message: dict[str, Any], session_id: str
+    ) -> Optional[str]:
+        """Return a status SSE event if *message* carries a terminal runtime status."""
+        runtime_status = str(message.get("status") or "").strip()
+        if runtime_status in self._TERMINAL_STATUSES:
+            return self._sse_event(
+                "status",
+                self._build_status_event_payload(
+                    status=runtime_status,  # type: ignore[arg-type]
+                    session_id=session_id,
+                    result_message=message,
+                ),
             )
+        return None
 
-            if status != "running":
-                yield self._sse_event(
-                    "status",
-                    self._build_status_event_payload(
-                        status=status,
-                        session_id=session_id,
-                        result_message=projector.last_result,
-                    ),
-                )
-                return
-
-            while True:
-                try:
-                    message = await asyncio.wait_for(
-                        queue.get(),
-                        timeout=self.stream_heartbeat_seconds
-                    )
-
-                    update = projector.apply_message(message)
-                    patch_payload = update.get("patch")
-                    if isinstance(patch_payload, dict):
-                        yield self._sse_event("patch", patch_payload)
-
-                    delta_payload = update.get("delta")
-                    if isinstance(delta_payload, dict):
-                        yield self._sse_event("delta", delta_payload)
-
-                    question_payload = update.get("question")
-                    if isinstance(question_payload, dict):
-                        yield self._sse_event("question", question_payload)
-
-                    msg_type = message.get("type", "")
-                    if msg_type == "runtime_status":
-                        runtime_status = str(message.get("status") or "").strip()
-                        if runtime_status in {
-                            "idle",
-                            "running",
-                            "completed",
-                            "error",
-                            "interrupted",
-                        }:
-                            yield self._sse_event(
-                                "status",
-                                self._build_status_event_payload(
-                                    status=runtime_status,
-                                    session_id=session_id,
-                                    result_message=message,
-                                ),
-                            )
-                            break
-
-                    if msg_type == "result":
-                        final_status = self._resolve_result_status(message)
-                        yield self._sse_event(
-                            "status",
-                            self._build_status_event_payload(
-                                status=final_status,
-                                session_id=session_id,
-                                result_message=message,
-                            ),
-                        )
-                        break
-                except asyncio.TimeoutError:
-                    live_status = self.session_manager.get_status(session_id) or status
-                    if live_status != "running":
-                        yield self._sse_event(
-                            "status",
-                            self._build_status_event_payload(
-                                status=live_status,
-                                session_id=session_id,
-                                result_message=projector.last_result,
-                            ),
-                        )
-                        break
-                    yield self._sse_keepalive_comment()
-        except asyncio.CancelledError:
-            raise
-        finally:
-            await self.session_manager.unsubscribe(session_id, queue)
+    def _handle_heartbeat_timeout(
+        self,
+        session_id: str,
+        status: SessionStatus,
+        projector: AssistantStreamProjector,
+    ) -> Optional[str]:
+        """Check session liveness on heartbeat timeout. Returns status event or None."""
+        live_status = self.session_manager.get_status(session_id) or status
+        if live_status != "running":
+            return self._sse_event(
+                "status",
+                self._build_status_event_payload(
+                    status=live_status,
+                    session_id=session_id,
+                    result_message=projector.last_result,
+                ),
+            )
+        return None
 
     @staticmethod
     def _sse_event(event: str, data: dict[str, Any]) -> str:

--- a/webui/server/agent_runtime/session_manager.py
+++ b/webui/server/agent_runtime/session_manager.py
@@ -94,7 +94,12 @@ class ManagedSession:
             self.subscribers.discard(q)
 
     def _drain_and_signal_reconnect(self, queue: asyncio.Queue) -> None:
-        """Empty *queue* and push a reconnect signal so the SSE loop exits."""
+        """Empty *queue* and push a reconnect signal so the SSE loop exits.
+
+        Uses a connection-level ``_queue_overflow`` type rather than
+        ``runtime_status`` so the SSE consumer can close the stream without
+        misrepresenting the session's actual status to the client.
+        """
         while not queue.empty():
             try:
                 queue.get_nowait()
@@ -102,10 +107,7 @@ class ManagedSession:
                 break
         try:
             queue.put_nowait({
-                "type": "runtime_status",
-                "status": "error",
-                "subtype": "queue_overflow",
-                "is_error": True,
+                "type": "_queue_overflow",
                 "session_id": self.session_id,
             })
         except asyncio.QueueFull:
@@ -392,7 +394,6 @@ class SessionManager:
         """Consume messages from client and distribute to subscribers."""
         try:
             async for message in managed.client.receive_response():
-                # Serialize message to dict
                 msg_dict = self._message_to_dict(message)
                 if not isinstance(msg_dict, dict):
                     continue
@@ -401,44 +402,68 @@ class SessionManager:
                     self._maybe_update_sdk_session_id(managed, message, msg_dict)
                     continue
 
-                if msg_dict.get("type") == "result":
-                    msg_dict["session_status"] = self._resolve_result_status(
-                        msg_dict,
-                        interrupt_requested=managed.interrupt_requested,
-                    )
+                self._handle_special_message(managed, msg_dict)
                 managed.add_message(msg_dict)
                 self._maybe_update_sdk_session_id(managed, message, msg_dict)
 
                 if msg_dict.get("type") != "result":
                     continue
 
-                managed.pending_user_echoes.clear()
-                managed.cancel_pending_questions("session completed")
-                final_status = str(msg_dict.get("session_status") or "").strip() or self._resolve_result_status(
-                    msg_dict,
-                    interrupt_requested=managed.interrupt_requested,
-                )
-                managed.status = final_status
-                self.meta_store.update_status(managed.session_id, final_status)
-                managed.interrupt_requested = False
-                self._prune_transient_buffer(managed)
+                self._finalize_turn(managed, msg_dict)
 
         except asyncio.CancelledError:
-            managed.pending_user_echoes.clear()
-            managed.cancel_pending_questions("session interrupted")
-            managed.status = "interrupted"
-            self.meta_store.update_status(managed.session_id, "interrupted")
-            managed.interrupt_requested = False
-            self._prune_transient_buffer(managed)
+            self._mark_session_terminal(managed, "interrupted", "session interrupted")
             raise
         except Exception:
-            managed.pending_user_echoes.clear()
-            managed.cancel_pending_questions("session error")
-            managed.status = "error"
-            self.meta_store.update_status(managed.session_id, "error")
-            managed.interrupt_requested = False
-            self._prune_transient_buffer(managed)
+            self._mark_session_terminal(managed, "error", "session error")
             raise
+
+    def _handle_special_message(
+        self, managed: ManagedSession, msg_dict: dict[str, Any]
+    ) -> None:
+        """Handle compact_boundary and result messages before broadcast."""
+        if (
+            msg_dict.get("type") == "system"
+            and msg_dict.get("subtype") == "compact_boundary"
+        ):
+            self._prune_transient_buffer(managed)
+
+        if msg_dict.get("type") == "result":
+            msg_dict["session_status"] = self._resolve_result_status(
+                msg_dict,
+                interrupt_requested=managed.interrupt_requested,
+            )
+
+    def _finalize_turn(
+        self, managed: ManagedSession, result_msg: dict[str, Any]
+    ) -> None:
+        """Settle session state after a result message completes a turn."""
+        managed.pending_user_echoes.clear()
+        managed.cancel_pending_questions("session completed")
+        explicit = str(result_msg.get("session_status") or "").strip()
+        final_status: SessionStatus = (
+            explicit  # type: ignore[assignment]
+            if explicit in {"idle", "running", "completed", "error", "interrupted"}
+            else self._resolve_result_status(
+                result_msg,
+                interrupt_requested=managed.interrupt_requested,
+            )
+        )
+        managed.status = final_status
+        self.meta_store.update_status(managed.session_id, final_status)
+        managed.interrupt_requested = False
+        self._prune_transient_buffer(managed)
+
+    def _mark_session_terminal(
+        self, managed: ManagedSession, status: SessionStatus, reason: str
+    ) -> None:
+        """Set terminal status on abnormal consumer exit."""
+        managed.pending_user_echoes.clear()
+        managed.cancel_pending_questions(reason)
+        managed.status = status
+        self.meta_store.update_status(managed.session_id, status)
+        managed.interrupt_requested = False
+        self._prune_transient_buffer(managed)
 
     @staticmethod
     def _resolve_result_status(


### PR DESCRIPTION
## Summary

- Fix duplicate assistant content blocks appearing when reconnecting to a streaming session or refreshing during agent response
- SDK `AssistantMessage`/`ResultMessage` objects lack the `uuid` field that the CLI transcript carries, causing `_merge_raw_messages` dedup to fail
- Three complementary fixes: prune groupable messages from buffer between rounds, filter uuid-less assistant/result from merge input, and add content-based cross-source dedup as defence layer

## Test plan

- [x] 13 unit tests pass (`test_assistant_service_streaming_unittest.py`)
- [x] New tests cover: streaming dedup, tool_use block dedup, multi-round user preservation, prune behaviour, new-session edge case
- [ ] Manual: send message, refresh during streaming — no duplicate content blocks
- [ ] Manual: multi-round conversation, refresh between rounds — user turns preserved