### PR TITLE
fix(assistant): stabilize chat rendering and list keys

### DIFF
--- a/frontend/src/react/components/chat/ChatMessage.js
+++ b/frontend/src/react/components/chat/ChatMessage.js
@@ -1,6 +1,6 @@
 import React from "react";
 import htm from "htm";
-import { cn, getRoleLabel } from "../../utils.js";
+import { cn, getRoleLabel, mapWithUniqueKeys } from "../../utils.js";
 import { ContentBlockRenderer } from "./ContentBlockRenderer.js";
 
 const html = htm.bind(React.createElement);
@@ -22,6 +22,7 @@ export function ChatMessage({ message }) {
 
     // Normalize content to array
     const blocks = normalizeContent(content);
+    const renderBlocks = mapWithUniqueKeys(blocks, (block) => block?.id, "block");
 
     // Skip empty messages
     if (blocks.length === 0) {
@@ -44,8 +45,8 @@ export function ChatMessage({ message }) {
                 ${getRoleLabel(messageType)}
             </div>
             <div className="text-sm text-slate-100 leading-6">
-                ${blocks.map((block, index) => html`
-                    <${ContentBlockRenderer} key=${block.id || index} block=${block} index=${index} />
+                ${renderBlocks.map(({ item: block, key, index }) => html`
+                    <${ContentBlockRenderer} key=${key} block=${block} index=${index} />
                 `)}
             </div>
         </article>

--- a/frontend/src/react/components/chat/ContentBlockRenderer.js
+++ b/frontend/src/react/components/chat/ContentBlockRenderer.js
@@ -7,6 +7,40 @@ import { SkillContentBlock } from "./SkillContentBlock.js";
 
 const html = htm.bind(React.createElement);
 
+function stringifySafely(value) {
+    try {
+        return JSON.stringify(value, null, 2);
+    } catch {
+        return String(value);
+    }
+}
+
+function normalizeToolResultContent(content) {
+    if (typeof content === "string") {
+        return content;
+    }
+
+    if (content === null || content === undefined) {
+        return "";
+    }
+
+    if (Array.isArray(content)) {
+        const textParts = content
+            .map((item) => normalizeToolResultContent(item))
+            .filter((item) => typeof item === "string" && item.trim().length > 0);
+        return textParts.length > 0 ? textParts.join("\n") : stringifySafely(content);
+    }
+
+    if (typeof content === "object") {
+        if (typeof content.text === "string") {
+            return content.text;
+        }
+        return stringifySafely(content);
+    }
+
+    return String(content);
+}
+
 /**
  * ContentBlockRenderer - Renders a single content block within a turn.
  *
@@ -38,13 +72,14 @@ export function ContentBlockRenderer({ block, index }) {
         case "tool_result":
             // Standalone tool_result (should be rare - usually attached to tool_use)
             // Render as a simple result block
+            const normalizedResultText = normalizeToolResultContent(block.content);
             return html`
                 <div key=${key} className="my-1.5 rounded-lg border border-white/10 bg-ink-800/30 px-3 py-2">
                     <div className="text-[10px] uppercase tracking-wide text-slate-500 mb-1">
                         ${block.is_error ? "执行失败" : "工具结果"}
                     </div>
                     <pre className="text-xs text-slate-300 overflow-x-auto whitespace-pre-wrap">
-                        ${block.content || ""}
+                        ${normalizedResultText}
                     </pre>
                 </div>
             `;

--- a/frontend/src/react/main.js
+++ b/frontend/src/react/main.js
@@ -252,6 +252,7 @@ function App() {
 
     return html`
         <${AppShell}
+            key="app-shell"
             route=${route}
             dashboardKind=${dashboardKind}
             selectedProjectItem=${selectedProjectItem}
@@ -265,6 +266,7 @@ function App() {
         <//>
 
             <${AssistantFloatingMount}
+                key="assistant-floating-mount"
                 open=${assistantPanelOpen}
                 onClose=${() => setAssistantPanelOpen(false)}
                 onNavigate=${navigate}
@@ -279,6 +281,7 @@ function App() {
             />
 
             <${CreateProjectModal}
+                key="create-project-modal"
                 open=${showCreateModal}
                 createForm=${createForm}
                 setCreateForm=${setCreateForm}
@@ -288,6 +291,7 @@ function App() {
             />
 
             <${AssistantSessionDialog}
+                key="assistant-session-dialog"
                 open=${sessionDialogOpen}
                 mode=${sessionDialogMode}
                 title=${sessionDialogTitle}
@@ -298,6 +302,7 @@ function App() {
             />
 
             <${AssistantDeleteSessionDialog}
+                key="assistant-delete-session-dialog"
                 open=${deleteDialogOpen}
                 sessionTitle=${deleteDialogSessionTitle}
                 submitting=${deleteDialogSubmitting}
@@ -305,7 +310,7 @@ function App() {
                 onConfirm=${confirmDeleteSession}
             />
 
-            <${AppToast} toast=${toast} />
+            <${AppToast} key="app-toast" toast=${toast} />
     `;
 }
 

--- a/frontend/src/react/pages/assistant-page.js
+++ b/frontend/src/react/pages/assistant-page.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import htm from "htm";
 
-import { cn } from "../utils.js";
+import { cn, mapWithUniqueKeys } from "../utils.js";
 import { ChatMessage } from "../components/chat/index.js";
 import { Badge, Button, Card } from "../components/primitives.js";
 import {
@@ -130,6 +130,19 @@ export function AssistantMessageArea({
             })
             .slice(0, 8);
     }, [assistantSkills, slashQuery]);
+
+    const renderMessages = useMemo(
+        () => mapWithUniqueKeys(assistantComposedMessages, (message) => message?.uuid, "turn"),
+        [assistantComposedMessages]
+    );
+    const renderSkills = useMemo(
+        () => mapWithUniqueKeys(
+            filteredSkills,
+            (skill) => (skill?.name ? `${skill.scope || "project"}:${skill.name}` : ""),
+            "skill"
+        ),
+        [filteredSkills]
+    );
 
     useEffect(() => {
         setActiveSkillIndex(0);
@@ -345,10 +358,10 @@ export function AssistantMessageArea({
             <div ref=${assistantChatScrollRef} className="flex-1 min-h-0 overflow-y-auto p-3 space-y-3">
                 ${assistantMessagesLoading
                     ? html`<p className="text-sm text-slate-400">消息加载中...</p>`
-                    : assistantComposedMessages.length === 0
+                    : renderMessages.length === 0
                         ? html`<p className="text-sm text-slate-400">还没有消息，先发送一条吧。</p>`
-                        : assistantComposedMessages.map((message, index) => html`
-                              <${ChatMessage} key=${message.uuid || `turn-${index}`} message=${message} />
+                        : renderMessages.map(({ item: message, key }) => html`
+                              <${ChatMessage} key=${key} message=${message} />
                           `)}
             </div>
             ${hasPendingQuestion
@@ -497,10 +510,11 @@ export function AssistantMessageArea({
                                   <div className="max-h-56 overflow-y-auto">
                                       ${assistantSkillsLoading
                                           ? html`<p className="px-3 py-3 text-sm text-slate-400">技能加载中...</p>`
-                                          : filteredSkills.length === 0
+                                          : renderSkills.length === 0
                                               ? html`<p className="px-3 py-3 text-sm text-slate-400">没有匹配到技能</p>`
-                                              : filteredSkills.map((skill, index) => html`
+                                              : renderSkills.map(({ item: skill, key, index }) => html`
                                                     <button
+                                                        key=${key}
                                                         type="button"
                                                         onMouseDown=${(event) => {
                                                             event.preventDefault();

--- a/frontend/src/react/pages/usage-page.js
+++ b/frontend/src/react/pages/usage-page.js
@@ -130,7 +130,7 @@ export function UsagePage({
                                 : usageCalls.length === 0
                                     ? html`<tr><td colSpan="8" className="px-4 py-10 text-center text-slate-400">暂无调用记录</td></tr>`
                                     : usageCalls.map((call) => html`
-                                          <tr className="hover:bg-white/5">
+                                          <tr key=${call.id || `${call.project_name || "project"}-${call.started_at || call.created_at || "unknown"}`} className="hover:bg-white/5">
                                               <td className="px-4 py-3 text-slate-300">${formatDateTime(call.started_at || call.created_at)}</td>
                                               <td className="px-4 py-3">${call.project_name || "-"}</td>
                                               <td className="px-4 py-3">

--- a/frontend/src/react/utils.js
+++ b/frontend/src/react/utils.js
@@ -63,3 +63,25 @@ export function getRoleLabel(role) {
     if (role === "unknown") return "消息";
     return role || "消息";
 }
+
+export function mapWithUniqueKeys(items, getBaseKey, fallbackPrefix = "item") {
+    const list = Array.isArray(items) ? items : [];
+    const seen = new Map();
+
+    return list.map((item, index) => {
+        const rawBase = getBaseKey ? getBaseKey(item, index) : "";
+        const normalizedRaw = rawBase === null || rawBase === undefined
+            ? ""
+            : String(rawBase).trim();
+        const base = normalizedRaw || `${fallbackPrefix}-${index}`;
+        const count = seen.get(base) || 0;
+        seen.set(base, count + 1);
+        const key = count === 0 ? base : `${base}-${count}`;
+
+        return {
+            item,
+            index,
+            key,
+        };
+    });
+}

--- a/frontend/tests/chat-message-tool-result-rendering.test.mjs
+++ b/frontend/tests/chat-message-tool-result-rendering.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ChatMessage } from "../src/react/components/chat/ChatMessage.js";
+
+function renderMessage(message) {
+    return renderToStaticMarkup(React.createElement(ChatMessage, { message }));
+}
+
+test("standalone tool_result with object content should not crash", () => {
+    const message = {
+        type: "assistant",
+        content: [
+            {
+                type: "tool_result",
+                tool_use_id: "tool-1",
+                content: { type: "text", text: "hello object result" },
+            },
+        ],
+    };
+
+    const markup = renderMessage(message);
+    assert.ok(markup.includes("hello object result"));
+});
+
+test("standalone tool_result with array content should not crash", () => {
+    const message = {
+        type: "assistant",
+        content: [
+            {
+                type: "tool_result",
+                tool_use_id: "tool-2",
+                content: [
+                    { type: "text", text: "line A" },
+                    { type: "text", text: "line B" },
+                ],
+            },
+        ],
+    };
+
+    const markup = renderMessage(message);
+    assert.ok(markup.includes("line A"));
+    assert.ok(markup.includes("line B"));
+});

--- a/frontend/tests/render-key-utils.test.mjs
+++ b/frontend/tests/render-key-utils.test.mjs
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { mapWithUniqueKeys } from "../src/react/utils.js";
+
+test("mapWithUniqueKeys should deduplicate repeated base keys", () => {
+    const items = [
+        { id: "AskUserQuestion-1770723118597829356-799" },
+        { id: "AskUserQuestion-1770723118597829356-799" },
+    ];
+    const mapped = mapWithUniqueKeys(items, (item) => item.id, "block");
+    assert.deepEqual(
+        mapped.map((entry) => entry.key),
+        [
+            "AskUserQuestion-1770723118597829356-799",
+            "AskUserQuestion-1770723118597829356-799-1",
+        ]
+    );
+});
+
+test("mapWithUniqueKeys should fallback when base key is empty", () => {
+    const items = [{}, { id: "" }];
+    const mapped = mapWithUniqueKeys(items, (item) => item.id, "turn");
+    assert.deepEqual(
+        mapped.map((entry) => entry.key),
+        ["turn-0", "turn-1"]
+    );
+});


### PR DESCRIPTION
## Summary
- normalize standalone `tool_result` content before rendering to prevent React child type crashes
- stabilize message/block/skill list key generation to eliminate duplicate/missing key warnings
- add regression tests for tool_result rendering and key dedup logic

## Test Plan
- [x] `node --test tests/*.mjs` in `frontend/`