### PR TITLE
fix(frontend): deduplicate and merge assistant turns with draft content

### DIFF
--- a/frontend/src/react/hooks/use-assistant-state.js
+++ b/frontend/src/react/hooks/use-assistant-state.js
@@ -168,6 +168,33 @@ function findTailPrefixOverlap(committedContent, draftContent) {
     return 0;
 }
 
+function overlapIncludesMatchingToolUse(committedContent, draftContent, overlap) {
+    if (!Array.isArray(committedContent) || !Array.isArray(draftContent) || overlap <= 0) {
+        return false;
+    }
+
+    for (let offset = 0; offset < overlap; offset += 1) {
+        const committedIndex = committedContent.length - overlap + offset;
+        const committedBlock = committedContent[committedIndex];
+        const draftBlock = draftContent[offset];
+        if (
+            committedBlock
+            && typeof committedBlock === "object"
+            && committedBlock.type === "tool_use"
+            && typeof committedBlock.id === "string"
+            && committedBlock.id
+            && draftBlock
+            && typeof draftBlock === "object"
+            && draftBlock.type === "tool_use"
+            && committedBlock.id === draftBlock.id
+        ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 function collectCommittedToolUseIds(turns) {
     const ids = new Set();
     if (!Array.isArray(turns) || turns.length === 0) {
@@ -214,9 +241,10 @@ function mergeAssistantContentWithDraft(committedContent, draftContent, committe
     });
 
     const overlap = findTailPrefixOverlap(merged, draftContent);
-    if (overlap > 0) {
-        for (let i = 0; i < overlap; i += 1) {
-            const committedIndex = merged.length - overlap + i;
+    const effectiveOverlap = overlapIncludesMatchingToolUse(merged, draftContent, overlap) ? overlap : 0;
+    if (effectiveOverlap > 0) {
+        for (let i = 0; i < effectiveOverlap; i += 1) {
+            const committedIndex = merged.length - effectiveOverlap + i;
             const committedBlock = merged[committedIndex];
             const draftBlock = draftContent[i];
             if (
@@ -234,7 +262,7 @@ function mergeAssistantContentWithDraft(committedContent, draftContent, committe
         }
     }
 
-    draftContent.slice(overlap).forEach((block) => {
+    draftContent.slice(effectiveOverlap).forEach((block) => {
         if (
             block
             && typeof block === "object"

--- a/frontend/tests/assistant-compose-turns.test.mjs
+++ b/frontend/tests/assistant-compose-turns.test.mjs
@@ -131,3 +131,30 @@ test("composeAssistantTurnsWithDraft should drop duplicated text and tool_use wh
     assert.equal(toolBlocks.length, 1);
     assert.equal(toolBlocks[0].input.timeout, 600000);
 });
+
+test("composeAssistantTurnsWithDraft should keep repeated leading text when overlap has no tool_use", () => {
+    const turns = [
+        {
+            type: "assistant",
+            content: [
+                { type: "text", text: "OK" },
+            ],
+        },
+    ];
+
+    const draftTurn = {
+        type: "assistant",
+        content: [
+            { type: "text", text: "OK" },
+            { type: "text", text: "next" },
+        ],
+    };
+
+    const composed = composeAssistantTurnsWithDraft(turns, draftTurn);
+
+    assert.deepEqual(composed[0].content, [
+        { type: "text", text: "OK" },
+        { type: "text", text: "OK" },
+        { type: "text", text: "next" },
+    ]);
+});


### PR DESCRIPTION
## Summary

- Replace naive content concatenation in `composeAssistantTurnsWithDraft` with proper overlap detection and tool_use block merging
- Add `findTailPrefixOverlap` to detect when draft content overlaps with the tail of committed content, preventing duplicate blocks during streaming
- Add `mergeToolUseBlocks` to deep-merge tool_use blocks (preserving `input`, `result`, `is_error`, `skill_content` from committed data when absent in draft)
- Track committed tool_use IDs across all turns to skip already-committed blocks in draft content
- Export `composeAssistantTurnsWithDraft` for testability; add comprehensive unit tests

## Test plan

- [x] Unit tests added in `frontend/tests/assistant-compose-turns.test.mjs`
- [ ] Verify streaming assistant responses show no duplicate tool_use blocks
- [ ] Verify tool results are preserved when draft snapshots lack them