### PR TITLE
test: strengthen unit tests and coverage gates (backend 80% / frontend 65%)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         run: uv sync
 
       - name: Run tests with coverage
-        run: uv run python -m pytest --cov --cov-report=term-missing
+        run: uv run python -m pytest --cov=lib --cov=webui/server --cov-report=term-missing --cov-report=xml --cov-fail-under=80
 
   frontend-tests:
     runs-on: ubuntu-latest
@@ -46,4 +46,4 @@ jobs:
 
       - name: Run tests
         working-directory: frontend
-        run: node --test tests/*.test.mjs
+        run: node --test --experimental-test-coverage tests/*.test.mjs --test-coverage-lines=65 --test-coverage-include=src/react/components/landing-page.js --test-coverage-include=src/react/components/app-shell.js --test-coverage-include=src/react/pages/assistant-question-wizard.js --test-coverage-include=src/react/pages/projects-page.js --test-coverage-include=src/react/pages/workspace-review-helpers.js

--- a/frontend/src/react/pages/workspace-page.js
+++ b/frontend/src/react/pages/workspace-page.js
@@ -4,6 +4,27 @@ import htm from "htm";
 import { PROJECT_TABS } from "../constants.js";
 import { cn, progressPercent } from "../utils.js";
 import { Badge, Button, Card, EmptyState } from "../components/primitives.js";
+import {
+    buildReviewTargetFromSelection,
+    getSafeReviewSelection,
+    getReviewSelectionResult,
+    normalizeReviewMediaError,
+    buildReviewVideoUrl,
+    isReviewItemSelected,
+    getReviewMediaVersionForSelection,
+    bumpReviewMediaVersionForItem,
+} from "./workspace-review-helpers.js";
+
+export {
+    buildReviewTargetFromSelection,
+    getSafeReviewSelection,
+    getReviewSelectionResult,
+    normalizeReviewMediaError,
+    buildReviewVideoUrl,
+    isReviewItemSelected,
+    getReviewMediaVersionForSelection,
+    bumpReviewMediaVersionForItem,
+} from "./workspace-review-helpers.js";
 
 const html = htm.bind(React.createElement);
 
@@ -201,109 +222,6 @@ function getDraftSteps(contentMode) {
         { step: 2, label: "镜头预算" },
         { step: 3, label: "角色线索表" },
     ];
-}
-
-export function buildReviewTargetFromSelection(currentScripts, selectedReview, uploadedStoryboardMap = {}) {
-    if (!selectedReview?.scriptFile || !selectedReview?.itemId) {
-        return null;
-    }
-
-    const script = currentScripts?.[selectedReview.scriptFile];
-    if (!script) {
-        return null;
-    }
-
-    const isNarration = script.content_mode === "narration" && Array.isArray(script.segments);
-    const items = isNarration ? script.segments || [] : script.scenes || [];
-    const idField = isNarration ? "segment_id" : "scene_id";
-    const item = items.find((entry) => entry[idField] === selectedReview.itemId);
-    if (!item) {
-        return null;
-    }
-
-    const assets = item.generated_assets || {};
-    const key = itemKey(selectedReview.scriptFile, selectedReview.itemId);
-
-    return {
-        scriptFile: selectedReview.scriptFile,
-        itemId: selectedReview.itemId,
-        item,
-        isNarration,
-        videoPath: assets.video_clip || "",
-        storyboardPath: assets.storyboard_image || uploadedStoryboardMap[key] || "",
-        status: assets.status || "pending",
-        duration: item.duration_seconds || 4,
-    };
-}
-
-export function getSafeReviewSelection(currentScripts, selectedReview, uploadedStoryboardMap = {}) {
-    const target = buildReviewTargetFromSelection(currentScripts, selectedReview, uploadedStoryboardMap);
-    if (!target?.videoPath) {
-        return null;
-    }
-    return selectedReview;
-}
-
-export function getReviewSelectionResult(currentScripts, selectedReview, uploadedStoryboardMap = {}) {
-    const target = buildReviewTargetFromSelection(currentScripts, selectedReview, uploadedStoryboardMap);
-    if (!target) {
-        return { ok: false, error: "找不到对应片段/场景", target: null };
-    }
-    if (!target.videoPath) {
-        return { ok: false, error: "该场景暂无可播放视频", target };
-    }
-    return { ok: true, error: "", target };
-}
-
-export function normalizeReviewMediaError(message) {
-    if (message === null || message === undefined) {
-        return "视频加载失败";
-    }
-    return String(message).trim();
-}
-
-export function buildReviewVideoUrl(videoUrl, mediaVersion = 0) {
-    if (!videoUrl) {
-        return "";
-    }
-    if (!mediaVersion || mediaVersion <= 0) {
-        return videoUrl;
-    }
-    const separator = String(videoUrl).includes("?") ? "&" : "?";
-    return `${videoUrl}${separator}rev=${mediaVersion}`;
-}
-
-export function isReviewItemSelected(selectedReview, scriptFile, itemId) {
-    if (!selectedReview) {
-        return false;
-    }
-    return selectedReview.scriptFile === scriptFile && selectedReview.itemId === itemId;
-}
-
-export function getReviewMediaVersionForSelection(reviewMediaVersions, selectedReview) {
-    if (!selectedReview?.scriptFile || !selectedReview?.itemId) {
-        return 0;
-    }
-    const key = itemKey(selectedReview.scriptFile, selectedReview.itemId);
-    const value = Number(reviewMediaVersions?.[key] || 0);
-    if (!Number.isFinite(value) || value <= 0) {
-        return 0;
-    }
-    return value;
-}
-
-export function bumpReviewMediaVersionForItem(reviewMediaVersions, scriptFile, itemId) {
-    if (!scriptFile || !itemId) {
-        return reviewMediaVersions || {};
-    }
-    const key = itemKey(scriptFile, itemId);
-    const base = reviewMediaVersions || {};
-    const current = Number(base[key] || 0);
-    const nextValue = Number.isFinite(current) && current > 0 ? current + 1 : 1;
-    return {
-        ...base,
-        [key]: nextValue,
-    };
 }
 
 function ProjectOverview({

--- a/frontend/src/react/pages/workspace-review-helpers.js
+++ b/frontend/src/react/pages/workspace-review-helpers.js
@@ -1,0 +1,106 @@
+function itemKey(scriptFile, itemId) {
+    return `${scriptFile}::${itemId}`;
+}
+
+export function buildReviewTargetFromSelection(currentScripts, selectedReview, uploadedStoryboardMap = {}) {
+    if (!selectedReview?.scriptFile || !selectedReview?.itemId) {
+        return null;
+    }
+
+    const script = currentScripts?.[selectedReview.scriptFile];
+    if (!script) {
+        return null;
+    }
+
+    const isNarration = script.content_mode === "narration" && Array.isArray(script.segments);
+    const items = isNarration ? script.segments || [] : script.scenes || [];
+    const idField = isNarration ? "segment_id" : "scene_id";
+    const item = items.find((entry) => entry[idField] === selectedReview.itemId);
+    if (!item) {
+        return null;
+    }
+
+    const assets = item.generated_assets || {};
+    const key = itemKey(selectedReview.scriptFile, selectedReview.itemId);
+
+    return {
+        scriptFile: selectedReview.scriptFile,
+        itemId: selectedReview.itemId,
+        item,
+        isNarration,
+        videoPath: assets.video_clip || "",
+        storyboardPath: assets.storyboard_image || uploadedStoryboardMap[key] || "",
+        status: assets.status || "pending",
+        duration: item.duration_seconds || 4,
+    };
+}
+
+export function getSafeReviewSelection(currentScripts, selectedReview, uploadedStoryboardMap = {}) {
+    const target = buildReviewTargetFromSelection(currentScripts, selectedReview, uploadedStoryboardMap);
+    if (!target?.videoPath) {
+        return null;
+    }
+    return selectedReview;
+}
+
+export function getReviewSelectionResult(currentScripts, selectedReview, uploadedStoryboardMap = {}) {
+    const target = buildReviewTargetFromSelection(currentScripts, selectedReview, uploadedStoryboardMap);
+    if (!target) {
+        return { ok: false, error: "找不到对应片段/场景", target: null };
+    }
+    if (!target.videoPath) {
+        return { ok: false, error: "该场景暂无可播放视频", target };
+    }
+    return { ok: true, error: "", target };
+}
+
+export function normalizeReviewMediaError(message) {
+    if (message === null || message === undefined) {
+        return "视频加载失败";
+    }
+    return String(message).trim();
+}
+
+export function buildReviewVideoUrl(videoUrl, mediaVersion = 0) {
+    if (!videoUrl) {
+        return "";
+    }
+    if (!mediaVersion || mediaVersion <= 0) {
+        return videoUrl;
+    }
+    const separator = String(videoUrl).includes("?") ? "&" : "?";
+    return `${videoUrl}${separator}rev=${mediaVersion}`;
+}
+
+export function isReviewItemSelected(selectedReview, scriptFile, itemId) {
+    if (!selectedReview) {
+        return false;
+    }
+    return selectedReview.scriptFile === scriptFile && selectedReview.itemId === itemId;
+}
+
+export function getReviewMediaVersionForSelection(reviewMediaVersions, selectedReview) {
+    if (!selectedReview?.scriptFile || !selectedReview?.itemId) {
+        return 0;
+    }
+    const key = itemKey(selectedReview.scriptFile, selectedReview.itemId);
+    const value = Number(reviewMediaVersions?.[key] || 0);
+    if (!Number.isFinite(value) || value <= 0) {
+        return 0;
+    }
+    return value;
+}
+
+export function bumpReviewMediaVersionForItem(reviewMediaVersions, scriptFile, itemId) {
+    if (!scriptFile || !itemId) {
+        return reviewMediaVersions || {};
+    }
+    const key = itemKey(scriptFile, itemId);
+    const base = reviewMediaVersions || {};
+    const current = Number(base[key] || 0);
+    const nextValue = Number.isFinite(current) && current > 0 ? current + 1 : 1;
+    return {
+        ...base,
+        [key]: nextValue,
+    };
+}

--- a/frontend/tests/workspace-review-helpers.test.mjs
+++ b/frontend/tests/workspace-review-helpers.test.mjs
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+    buildReviewTargetFromSelection,
+    getReviewMediaVersionForSelection,
+    getReviewSelectionResult,
+    bumpReviewMediaVersionForItem,
+} from "../src/react/pages/workspace-review-helpers.js";
+
+const narrationScripts = {
+    "episode_2.json": {
+        content_mode: "narration",
+        segments: [
+            {
+                segment_id: "E2S01",
+                duration_seconds: 4,
+                generated_assets: {
+                    storyboard_image: "",
+                    video_clip: "videos/scene_E2S01.mp4",
+                },
+            },
+        ],
+    },
+};
+
+test("workspace review helpers should support narration segments and storyboard fallback", () => {
+    const selectedReview = { scriptFile: "episode_2.json", itemId: "E2S01" };
+    const target = buildReviewTargetFromSelection(narrationScripts, selectedReview, {
+        "episode_2.json::E2S01": "storyboards/scene_E2S01.png",
+    });
+
+    assert.equal(target.isNarration, true);
+    assert.equal(target.storyboardPath, "storyboards/scene_E2S01.png");
+    assert.equal(target.videoPath, "videos/scene_E2S01.mp4");
+});
+
+test("workspace review helpers should normalize invalid media version values", () => {
+    const selectedReview = { scriptFile: "episode_2.json", itemId: "E2S01" };
+    assert.equal(
+        getReviewMediaVersionForSelection(
+            { "episode_2.json::E2S01": "not-a-number" },
+            selectedReview
+        ),
+        0
+    );
+
+    const bumped = bumpReviewMediaVersionForItem(undefined, "episode_2.json", "E2S01");
+    assert.equal(bumped["episode_2.json::E2S01"], 1);
+});
+
+test("workspace review helpers should return explicit not-found error", () => {
+    const result = getReviewSelectionResult({}, { scriptFile: "missing.json", itemId: "S1" }, {});
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "找不到对应片段/场景");
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,12 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 
 [tool.coverage.run]
-source = ["lib", "webui"]
-omit = [".claude/skills/*"]
+source = ["lib", "webui/server"]
 
 [tool.coverage.report]
 show_missing = true
 skip_empty = true
+exclude_lines = [
+    'if __name__ == "__main__":',
+    "if __name__ == '__main__':",
+]

--- a/tests/test_app_module.py
+++ b/tests/test_app_module.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import webui.server.app as app_module
+
+
+class _FakeWorker:
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+
+    async def start(self):
+        self.started = True
+
+    async def stop(self):
+        self.stopped = True
+
+
+class TestAppModule:
+    def test_serve_frontend_index_returns_503_when_missing(self, monkeypatch):
+        monkeypatch.setattr(app_module, "frontend_index_file", Path("/tmp/__not_exists__/index.html"))
+        resp = app_module._serve_frontend_index()
+        assert resp.status_code == 503
+
+    def test_create_generation_worker(self, monkeypatch):
+        worker = _FakeWorker()
+        monkeypatch.setattr(app_module, "GenerationWorker", lambda: worker)
+        created = app_module.create_generation_worker()
+        assert created is worker
+
+    @pytest.mark.asyncio
+    async def test_startup_and_shutdown_generation_worker(self, monkeypatch):
+        worker = _FakeWorker()
+        monkeypatch.setattr(app_module, "create_generation_worker", lambda: worker)
+
+        app_module.app.state = SimpleNamespace()
+        await app_module.startup_generation_worker()
+        assert worker.started
+
+        await app_module.shutdown_generation_worker()
+        assert worker.stopped

--- a/tests/test_assistant_router_full.py
+++ b/tests/test_assistant_router_full.py
@@ -1,0 +1,182 @@
+import asyncio
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tests.factories import make_session_meta
+from webui.server.routers import assistant
+
+
+class _FakeService:
+    def __init__(self):
+        self.sessions = {"session-1": make_session_meta(id="session-1")}
+
+    async def create_session(self, project_name, title):
+        if project_name == "missing":
+            raise FileNotFoundError(project_name)
+        return make_session_meta(id="session-new", project_name=project_name, title=title or "")
+
+    def list_sessions(self, **kwargs):
+        return [make_session_meta(id="session-1", project_name=kwargs.get("project_name") or "demo")]
+
+    def get_session(self, session_id):
+        if session_id == "error":
+            raise RuntimeError("boom")
+        return self.sessions.get(session_id)
+
+    def update_session_title(self, session_id, title):
+        if title == "bad":
+            raise ValueError("bad title")
+        if session_id not in self.sessions:
+            return None
+        session = make_session_meta(id=session_id, title=title)
+        self.sessions[session_id] = session
+        return session
+
+    async def delete_session(self, session_id):
+        return session_id in self.sessions
+
+    async def get_snapshot(self, session_id):
+        if session_id == "missing":
+            raise FileNotFoundError(session_id)
+        return {"session_id": session_id, "status": "running", "turns": [], "pending_questions": []}
+
+    async def send_message(self, session_id, content):
+        if session_id == "missing":
+            raise FileNotFoundError(session_id)
+        if content == "bad":
+            raise ValueError("bad")
+        return {"status": "accepted", "session_id": session_id}
+
+    async def interrupt_session(self, session_id):
+        if session_id == "missing":
+            raise FileNotFoundError(session_id)
+        if session_id == "bad":
+            raise ValueError("bad")
+        return {"status": "accepted", "session_id": session_id, "session_status": "interrupted"}
+
+    async def answer_user_question(self, session_id, question_id, answers):
+        if session_id == "missing":
+            raise FileNotFoundError(session_id)
+        if question_id == "bad":
+            raise ValueError("bad question")
+        return {"status": "accepted", "session_id": session_id, "question_id": question_id, "answers": answers}
+
+    async def stream_events(self, session_id):
+        yield "event: snapshot\ndata: {}\n\n"
+        await asyncio.sleep(0)
+
+    def list_available_skills(self, project_name=None):
+        if project_name == "missing":
+            raise FileNotFoundError(project_name)
+        return [{"name": "skill-a"}]
+
+
+def _client(monkeypatch):
+    fake = _FakeService()
+    monkeypatch.setattr(assistant, "get_assistant_service", lambda: fake)
+    app = FastAPI()
+    app.include_router(assistant.router, prefix="/api/v1/assistant")
+    return TestClient(app)
+
+
+class TestAssistantRouterFull:
+    def test_full_endpoints_and_errors(self, monkeypatch):
+        with _client(monkeypatch) as client:
+            create_ok = client.post("/api/v1/assistant/sessions", json={"project_name": "demo", "title": "T"})
+            assert create_ok.status_code == 200
+            assert create_ok.json()["id"] == "session-new"
+
+            create_missing = client.post("/api/v1/assistant/sessions", json={"project_name": "missing", "title": "T"})
+            assert create_missing.status_code == 404
+
+            listed = client.get("/api/v1/assistant/sessions?project_name=demo")
+            assert listed.status_code == 200
+            assert listed.json()["sessions"][0]["id"] == "session-1"
+
+            get_ok = client.get("/api/v1/assistant/sessions/session-1")
+            assert get_ok.status_code == 200
+
+            get_missing = client.get("/api/v1/assistant/sessions/missing")
+            assert get_missing.status_code == 404
+
+            update_ok = client.patch("/api/v1/assistant/sessions/session-1", json={"title": "new"})
+            assert update_ok.status_code == 200
+            assert update_ok.json()["session"]["title"] == "new"
+
+            update_bad = client.patch("/api/v1/assistant/sessions/session-1", json={"title": "bad"})
+            assert update_bad.status_code == 400
+
+            update_missing = client.patch("/api/v1/assistant/sessions/no", json={"title": "x"})
+            assert update_missing.status_code == 404
+
+            delete_ok = client.delete("/api/v1/assistant/sessions/session-1")
+            assert delete_ok.status_code == 200
+
+            delete_missing = client.delete("/api/v1/assistant/sessions/no")
+            assert delete_missing.status_code == 404
+
+            messages = client.get("/api/v1/assistant/sessions/session-1/messages")
+            assert messages.status_code == 410
+
+            snapshot_ok = client.get("/api/v1/assistant/sessions/session-1/snapshot")
+            assert snapshot_ok.status_code == 200
+
+            snapshot_missing = client.get("/api/v1/assistant/sessions/missing/snapshot")
+            assert snapshot_missing.status_code == 404
+
+            send_ok = client.post("/api/v1/assistant/sessions/session-1/messages", json={"content": "hello"})
+            assert send_ok.status_code == 200
+
+            send_missing = client.post("/api/v1/assistant/sessions/missing/messages", json={"content": "hello"})
+            assert send_missing.status_code == 404
+
+            send_bad = client.post("/api/v1/assistant/sessions/session-1/messages", json={"content": "bad"})
+            assert send_bad.status_code == 400
+
+            interrupt_ok = client.post("/api/v1/assistant/sessions/session-1/interrupt")
+            assert interrupt_ok.status_code == 200
+
+            interrupt_missing = client.post("/api/v1/assistant/sessions/missing/interrupt")
+            assert interrupt_missing.status_code == 404
+
+            interrupt_bad = client.post("/api/v1/assistant/sessions/bad/interrupt")
+            assert interrupt_bad.status_code == 400
+
+            answer_empty = client.post(
+                "/api/v1/assistant/sessions/session-1/questions/q1/answer",
+                json={"answers": {}},
+            )
+            assert answer_empty.status_code == 400
+
+            answer_ok = client.post(
+                "/api/v1/assistant/sessions/session-1/questions/q1/answer",
+                json={"answers": {"Q": "A"}},
+            )
+            assert answer_ok.status_code == 200
+
+            answer_missing = client.post(
+                "/api/v1/assistant/sessions/missing/questions/q1/answer",
+                json={"answers": {"Q": "A"}},
+            )
+            assert answer_missing.status_code == 404
+
+            answer_bad = client.post(
+                "/api/v1/assistant/sessions/session-1/questions/bad/answer",
+                json={"answers": {"Q": "A"}},
+            )
+            assert answer_bad.status_code == 400
+
+            stream_missing = client.get("/api/v1/assistant/sessions/no/stream")
+            assert stream_missing.status_code == 404
+
+            stream_ok = client.get("/api/v1/assistant/sessions/session-1/stream")
+            assert stream_ok.status_code == 200
+            assert "text/event-stream" in stream_ok.headers["content-type"]
+
+            skills_ok = client.get("/api/v1/assistant/skills")
+            assert skills_ok.status_code == 200
+            assert skills_ok.json()["skills"][0]["name"] == "skill-a"
+
+            skills_missing = client.get("/api/v1/assistant/skills?project_name=missing")
+            assert skills_missing.status_code == 404

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -1,0 +1,358 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tests.factories import make_session_meta
+from webui.server.agent_runtime.service import AssistantService
+from webui.server.agent_runtime.stream_projector import AssistantStreamProjector
+
+
+class _FakePM:
+    def __init__(self, valid_project="demo"):
+        self.valid_project = valid_project
+
+    def get_project_path(self, project_name):
+        if project_name != self.valid_project:
+            raise FileNotFoundError(project_name)
+        return Path("/tmp") / project_name
+
+
+class _FakeMetaStore:
+    def __init__(self, metas=None):
+        self.metas = {m.id: m for m in (metas or [])}
+
+    def get(self, session_id):
+        return self.metas.get(session_id)
+
+    def list(self, project_name=None, status=None, limit=50, offset=0):
+        return list(self.metas.values())
+
+    def update_title(self, session_id, title):
+        meta = self.metas.get(session_id)
+        if not meta:
+            return False
+        self.metas[session_id] = make_session_meta(**{**meta.model_dump(), "title": title})
+        return True
+
+    def delete(self, session_id):
+        return self.metas.pop(session_id, None) is not None
+
+
+class _FakeSessionManager:
+    def __init__(self):
+        self.sessions = {}
+        self.created = []
+        self.sent = []
+        self.answered = []
+        self.interrupted = []
+        self.unsubscribed = []
+        self.status = "running"
+        self.buffer = []
+        self.pending = []
+
+    async def create_session(self, project_name, title):
+        self.created.append((project_name, title))
+        return make_session_meta(id="s-created", project_name=project_name, title=title)
+
+    def get_status(self, session_id):
+        return self.status
+
+    def get_buffered_messages(self, session_id):
+        return list(self.buffer)
+
+    async def get_pending_questions_snapshot(self, session_id):
+        return list(self.pending)
+
+    async def send_message(self, session_id, content):
+        self.sent.append((session_id, content))
+
+    async def answer_user_question(self, session_id, question_id, answers):
+        self.answered.append((session_id, question_id, answers))
+
+    async def interrupt_session(self, session_id):
+        self.interrupted.append(session_id)
+        return "interrupted"
+
+    async def subscribe(self, session_id, replay_buffer=True):
+        q = asyncio.Queue()
+        for m in self.buffer:
+            q.put_nowait(m)
+        return q
+
+    async def unsubscribe(self, session_id, queue):
+        self.unsubscribed.append(session_id)
+
+    async def shutdown_gracefully(self):
+        return None
+
+
+class _FakeTranscriptReader:
+    def __init__(self, history=None):
+        self.history = history or []
+
+    def read_raw_messages(self, session_id, sdk_session_id, project_name):
+        return list(self.history)
+
+
+class _ManagedForDelete:
+    def __init__(self, disconnect_raises=False):
+        self.cancelled = False
+        self.consumer_task = asyncio.create_task(asyncio.sleep(3600))
+        self.client = SimpleNamespace(disconnect=self._disconnect)
+        self._disconnect_raises = disconnect_raises
+
+    def cancel_pending_questions(self, _reason):
+        self.cancelled = True
+
+    async def _disconnect(self):
+        if self._disconnect_raises:
+            raise RuntimeError("disconnect failed")
+
+
+class TestAssistantServiceMore:
+    @pytest.mark.asyncio
+    async def test_crud_and_message_validation(self, tmp_path):
+        service = AssistantService(project_root=tmp_path)
+        meta = make_session_meta(id="s1", status="idle")
+
+        sm = _FakeSessionManager()
+        service.pm = _FakePM(valid_project="demo")
+        service.session_manager = sm
+        service.meta_store = _FakeMetaStore([meta])
+
+        created = await service.create_session("demo", "  ")
+        assert created.title == "demo 会话"
+        assert sm.created == [("demo", "demo 会话")]
+
+        listed = service.list_sessions()
+        assert len(listed) == 1
+
+        fetched = service.get_session("s1")
+        assert fetched.status == "idle"
+        sm.sessions["s1"] = SimpleNamespace(status="running")
+        fetched_live = service.get_session("s1")
+        assert fetched_live.status == "running"
+
+        assert service.update_session_title("missing", "x") is None
+        updated = service.update_session_title("s1", "  ")
+        assert updated.title == "未命名会话"
+
+        with pytest.raises(ValueError):
+            await service.send_message("s1", "   ")
+
+        with pytest.raises(FileNotFoundError):
+            await service.send_message("missing", "hello")
+        accepted = await service.send_message("s1", " hello ")
+        assert accepted == {"status": "accepted", "session_id": "s1"}
+        assert sm.sent == [("s1", "hello")]
+
+        with pytest.raises(FileNotFoundError):
+            await service.answer_user_question("missing", "q1", {"a": "b"})
+        await service.answer_user_question("s1", "q1", {"a": "b"})
+        assert sm.answered == [("s1", "q1", {"a": "b"})]
+
+        with pytest.raises(FileNotFoundError):
+            await service.interrupt_session("missing")
+        interrupted = await service.interrupt_session("s1")
+        assert interrupted["session_status"] == "interrupted"
+
+    @pytest.mark.asyncio
+    async def test_delete_session_handles_active_and_disconnect_error(self, tmp_path):
+        service = AssistantService(project_root=tmp_path)
+        meta = make_session_meta(id="s1")
+        service.meta_store = _FakeMetaStore([meta])
+        sm = _FakeSessionManager()
+        managed = _ManagedForDelete(disconnect_raises=True)
+        sm.sessions["s1"] = managed
+        service.session_manager = sm
+
+        ok = await service.delete_session("s1")
+        assert ok is True
+        assert managed.cancelled is True
+        assert "s1" not in sm.sessions
+
+        missing = await service.delete_session("missing")
+        assert missing is False
+
+    @pytest.mark.asyncio
+    async def test_snapshot_and_stream_helpers(self, tmp_path):
+        service = AssistantService(project_root=tmp_path)
+        meta = make_session_meta(id="s1", status="running")
+        service.meta_store = _FakeMetaStore([meta])
+        sm = _FakeSessionManager()
+        sm.status = "running"
+        sm.buffer = [{"type": "runtime_status", "status": "running"}]
+        sm.pending = [{"type": "ask_user_question", "question_id": "aq-1"}]
+        service.session_manager = sm
+        service.transcript_reader = _FakeTranscriptReader(history=[])
+
+        with pytest.raises(FileNotFoundError):
+            await service.get_snapshot("missing")
+
+        snapshot = await service.get_snapshot("s1")
+        assert snapshot["status"] == "running"
+        assert snapshot["pending_questions"][0]["question_id"] == "aq-1"
+
+        replayed, overflow = service._drain_replay(asyncio.Queue())
+        assert replayed == []
+        assert overflow is False
+        q = asyncio.Queue()
+        q.put_nowait({"type": "_queue_overflow"})
+        replayed2, overflow2 = service._drain_replay(q)
+        assert replayed2 == []
+        assert overflow2 is True
+
+        projector = AssistantStreamProjector(initial_messages=[])
+        events, should_break = service._dispatch_live_message(
+            {"type": "_queue_overflow"},
+            projector,
+            "s1",
+        )
+        assert should_break is True
+        assert events == []
+
+        events2, stop2 = service._dispatch_live_message(
+            {"type": "system", "subtype": "compact_boundary"},
+            projector,
+            "s1",
+        )
+        assert stop2 is False
+        assert any("event: compact" in event for event in events2)
+
+        events3, stop3 = service._dispatch_live_message(
+            {"type": "runtime_status", "status": "interrupted"},
+            projector,
+            "s1",
+        )
+        assert stop3 is True
+        assert any("event: status" in event for event in events3)
+
+        events4, stop4 = service._dispatch_live_message(
+            {"type": "result", "subtype": "success", "is_error": False},
+            projector,
+            "s1",
+        )
+        assert stop4 is True
+        assert any("event: status" in event for event in events4)
+
+        assert service._check_runtime_status_terminal({"status": "???."}, "s1") is None
+        assert service._handle_heartbeat_timeout("s1", "running", projector) is None
+        sm.status = "completed"
+        status_event = service._handle_heartbeat_timeout("s1", "running", projector)
+        assert "event: status" in status_event
+        assert service._sse_keepalive_comment().strip() == ": keepalive"
+        assert "event: patch" in service._sse_event("patch", {"x": 1})
+
+    def test_merge_and_dedup_helpers(self, tmp_path):
+        service = AssistantService(project_root=tmp_path)
+
+        assert service._message_key({"uuid": "u1"}) == "uuid:u1"
+        fallback_key = service._message_key({"type": "assistant", "content": []})
+        assert fallback_key.startswith("{")
+
+        assert service._content_key({"type": "assistant", "content": [{"text": "A"}]}) == "content:assistant:t:A"
+        result_key = service._content_key(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "session_id": "s1",
+                "timestamp": "2026-02-01T00:00:00Z",
+            }
+        )
+        assert result_key.startswith("content:result:success:False:s1:")
+        assert service._content_key({"type": "user", "content": "x"}) is None
+
+        seen_keys, seen_content = service._build_seen_sets([{"uuid": "u1"}, "bad"])
+        assert "uuid:u1" in seen_keys
+        assert isinstance(seen_content, set)
+
+        assert service._is_duplicate({"uuid": "u1"}, {"uuid:u1"}, set()) is True
+        assert (
+            service._is_duplicate(
+                {"type": "assistant", "content": [{"text": "A"}]},
+                set(),
+                {"content:assistant:t:A"},
+            )
+            is True
+        )
+
+        assert service._parse_iso_datetime(None) is None
+        assert service._parse_iso_datetime("bad") is None
+        naive = service._parse_iso_datetime("2026-02-01T00:00:00")
+        assert naive.tzinfo is not None
+        assert service._parse_iso_datetime("2026-02-01T00:00:00Z") is not None
+
+        history = [{"type": "user", "content": "hello", "timestamp": "2026-02-01T00:00:01Z"}]
+        local_echo = {
+            "type": "user",
+            "content": "hello",
+            "local_echo": True,
+            "timestamp": "2026-02-01T00:00:00Z",
+        }
+        assert service._should_skip_local_echo(local_echo, history) is True
+        assert service._should_skip_local_echo({"type": "assistant"}, history) is False
+
+        merged = service._merge_raw_messages(
+            [{"type": "assistant", "uuid": "a1", "content": [{"text": "Hi"}]}],
+            [
+                {"type": "assistant", "content": [{"text": "Hi"}]},
+                {"type": "user", "content": "new", "uuid": "u2"},
+                "bad",
+            ],
+        )
+        assert any(msg.get("uuid") == "u2" for msg in merged)
+        assert sum(1 for msg in merged if msg.get("type") == "assistant") == 1
+
+        assert service._extract_plain_user_content({"type": "assistant"}) is None
+        assert (
+            service._extract_plain_user_content(
+                {"type": "user", "content": [{"type": "text", "text": " ok "}]}
+            )
+            == "ok"
+        )
+        assert service._is_groupable_message("bad") is False  # type: ignore[arg-type]
+
+        assert service._resolve_result_status({"session_status": "interrupted"}) == "interrupted"
+        assert service._resolve_result_status({"subtype": "error_x", "is_error": True}) == "error"
+        payload = service._build_status_event_payload("error", "s1", None)
+        assert payload["status"] == "error"
+        assert payload["subtype"] == "error"
+        assert payload["is_error"] is True
+
+    def test_skill_listing_and_metadata_parsing(self, tmp_path, monkeypatch):
+        service = AssistantService(project_root=tmp_path)
+        service.pm = _FakePM(valid_project="demo")
+
+        project_skill = tmp_path / ".claude" / "skills" / "s1"
+        project_skill.mkdir(parents=True)
+        (project_skill / "SKILL.md").write_text(
+            "---\nname: project-skill\ndescription: from frontmatter\n---\n# body\n",
+            encoding="utf-8",
+        )
+
+        fake_home = tmp_path / "home"
+        user_skill = fake_home / ".claude" / "skills" / "s2"
+        user_skill.mkdir(parents=True)
+        (user_skill / "SKILL.md").write_text(
+            "first non heading line\n# heading\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+        all_skills = service.list_available_skills()
+        names = {item["name"] for item in all_skills}
+        assert "project-skill" in names
+        assert "s2" in names
+
+        for_project = service.list_available_skills(project_name="demo")
+        assert len(for_project) >= 1
+
+        fallback = service._load_skill_metadata(user_skill / "SKILL.md", "fallback")
+        assert fallback["name"] == "fallback"
+        assert fallback["description"] == "first non heading line"
+
+        # no .env => no-op path
+        service._load_project_env(tmp_path / "missing")

--- a/tests/test_characters_router.py
+++ b/tests/test_characters_router.py
@@ -1,0 +1,90 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from webui.server.routers import characters
+
+
+class _FakePM:
+    def __init__(self):
+        self.projects = {
+            "demo": {
+                "characters": {
+                    "Alice": {
+                        "description": "old",
+                        "voice_style": "soft",
+                        "character_sheet": "",
+                        "reference_image": "",
+                    }
+                }
+            }
+        }
+
+    def add_project_character(self, project_name, name, description, voice_style):
+        if project_name not in self.projects:
+            raise FileNotFoundError(project_name)
+        self.projects[project_name]["characters"][name] = {
+            "description": description,
+            "voice_style": voice_style,
+        }
+        return self.projects[project_name]
+
+    def load_project(self, project_name):
+        if project_name not in self.projects:
+            raise FileNotFoundError(project_name)
+        return self.projects[project_name]
+
+    def save_project(self, project_name, project):
+        self.projects[project_name] = project
+
+
+def _client(monkeypatch, fake_pm):
+    monkeypatch.setattr(characters, "get_project_manager", lambda: fake_pm)
+    app = FastAPI()
+    app.include_router(characters.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+class TestCharactersRouter:
+    def test_add_update_delete_character(self, monkeypatch):
+        fake_pm = _FakePM()
+        with _client(monkeypatch, fake_pm) as client:
+            add_resp = client.post(
+                "/api/v1/projects/demo/characters",
+                json={"name": "Bob", "description": "new char", "voice_style": "calm"},
+            )
+            assert add_resp.status_code == 200
+            assert add_resp.json()["character"]["description"] == "new char"
+
+            patch_resp = client.patch(
+                "/api/v1/projects/demo/characters/Alice",
+                json={
+                    "description": "updated",
+                    "voice_style": "strong",
+                    "character_sheet": "characters/Alice.png",
+                    "reference_image": "characters/refs/Alice.png",
+                },
+            )
+            assert patch_resp.status_code == 200
+            assert patch_resp.json()["character"]["description"] == "updated"
+
+            delete_resp = client.delete("/api/v1/projects/demo/characters/Bob")
+            assert delete_resp.status_code == 200
+            assert "已删除" in delete_resp.json()["message"]
+
+    def test_error_mapping(self, monkeypatch):
+        fake_pm = _FakePM()
+        with _client(monkeypatch, fake_pm) as client:
+            not_found = client.post(
+                "/api/v1/projects/missing/characters",
+                json={"name": "Bob", "description": "x", "voice_style": "y"},
+            )
+            assert not_found.status_code == 404
+
+            missing_char = client.patch(
+                "/api/v1/projects/demo/characters/Nope",
+                json={"description": "x"},
+            )
+            assert missing_char.status_code == 404
+
+            missing_delete = client.delete("/api/v1/projects/demo/characters/Nope")
+            assert missing_delete.status_code == 404

--- a/tests/test_clues_router.py
+++ b/tests/test_clues_router.py
@@ -1,0 +1,96 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from webui.server.routers import clues
+
+
+class _FakePM:
+    def __init__(self):
+        self.projects = {
+            "demo": {
+                "clues": {
+                    "玉佩": {
+                        "type": "prop",
+                        "description": "old",
+                        "importance": "major",
+                        "clue_sheet": "",
+                    }
+                }
+            }
+        }
+
+    def add_clue(self, project_name, name, clue_type, description, importance):
+        if project_name not in self.projects:
+            raise FileNotFoundError(project_name)
+        if clue_type not in ("prop", "location"):
+            raise ValueError("invalid")
+        self.projects[project_name]["clues"][name] = {
+            "type": clue_type,
+            "description": description,
+            "importance": importance,
+        }
+        return self.projects[project_name]
+
+    def load_project(self, project_name):
+        if project_name not in self.projects:
+            raise FileNotFoundError(project_name)
+        return self.projects[project_name]
+
+    def save_project(self, project_name, project):
+        self.projects[project_name] = project
+
+
+def _client(monkeypatch, fake_pm):
+    monkeypatch.setattr(clues, "get_project_manager", lambda: fake_pm)
+    app = FastAPI()
+    app.include_router(clues.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+class TestCluesRouter:
+    def test_add_update_delete(self, monkeypatch):
+        fake_pm = _FakePM()
+        with _client(monkeypatch, fake_pm) as client:
+            add_resp = client.post(
+                "/api/v1/projects/demo/clues",
+                json={"name": "祠堂", "clue_type": "location", "description": "阴森", "importance": "major"},
+            )
+            assert add_resp.status_code == 200
+            assert add_resp.json()["clue"]["type"] == "location"
+
+            patch_resp = client.patch(
+                "/api/v1/projects/demo/clues/玉佩",
+                json={"clue_type": "prop", "description": "new", "importance": "minor", "clue_sheet": "clues/a.png"},
+            )
+            assert patch_resp.status_code == 200
+            assert patch_resp.json()["clue"]["importance"] == "minor"
+
+            delete_resp = client.delete("/api/v1/projects/demo/clues/祠堂")
+            assert delete_resp.status_code == 200
+
+    def test_error_mapping(self, monkeypatch):
+        fake_pm = _FakePM()
+        with _client(monkeypatch, fake_pm) as client:
+            bad_type = client.post(
+                "/api/v1/projects/demo/clues",
+                json={"name": "x", "clue_type": "bad", "description": "x", "importance": "major"},
+            )
+            assert bad_type.status_code == 400
+
+            missing = client.patch(
+                "/api/v1/projects/demo/clues/missing",
+                json={"description": "x"},
+            )
+            assert missing.status_code == 404
+
+            bad_patch_type = client.patch(
+                "/api/v1/projects/demo/clues/玉佩",
+                json={"clue_type": "bad"},
+            )
+            assert bad_patch_type.status_code == 400
+
+            bad_importance = client.patch(
+                "/api/v1/projects/demo/clues/玉佩",
+                json={"importance": "bad"},
+            )
+            assert bad_importance.status_code == 400

--- a/tests/test_cost_calculator.py
+++ b/tests/test_cost_calculator.py
@@ -1,0 +1,23 @@
+import pytest
+
+from lib.cost_calculator import CostCalculator, cost_calculator
+
+
+class TestCostCalculator:
+    def test_calculate_image_cost_known_and_default(self):
+        calculator = CostCalculator()
+        assert calculator.calculate_image_cost("1k") == 0.134
+        assert calculator.calculate_image_cost("2K") == 0.134
+        assert calculator.calculate_image_cost("4K") == 0.24
+        assert calculator.calculate_image_cost("unknown") == 0.134
+
+    def test_calculate_video_cost_known_and_default(self):
+        calculator = CostCalculator()
+        assert calculator.calculate_video_cost(8, "1080p", True) == pytest.approx(3.2)
+        assert calculator.calculate_video_cost(8, "1080p", False) == pytest.approx(1.6)
+        assert calculator.calculate_video_cost(6, "4k", True) == pytest.approx(3.6)
+        assert calculator.calculate_video_cost(6, "4k", False) == pytest.approx(2.4)
+        assert calculator.calculate_video_cost(5, "unknown", True) == pytest.approx(2.0)
+
+    def test_singleton_instance(self):
+        assert isinstance(cost_calculator, CostCalculator)

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -1,0 +1,165 @@
+import json
+from pathlib import Path
+
+from lib.data_validator import DataValidator, validate_episode, validate_project
+
+
+def _write_json(path: Path, payload: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _project_payload(content_mode: str = "narration") -> dict:
+    return {
+        "title": "Demo",
+        "content_mode": content_mode,
+        "style": "Anime",
+        "characters": {
+            "姜月茴": {"description": "女主"},
+        },
+        "clues": {
+            "玉佩": {
+                "type": "prop",
+                "description": "关键线索",
+                "importance": "major",
+            }
+        },
+    }
+
+
+class TestDataValidator:
+    def test_validate_project_success(self, tmp_path):
+        project_dir = tmp_path / "projects" / "demo"
+        _write_json(project_dir / "project.json", _project_payload())
+
+        validator = DataValidator(projects_root=str(tmp_path / "projects"))
+        result = validator.validate_project("demo")
+
+        assert result.valid
+        assert result.errors == []
+        assert "验证通过" in str(result)
+
+    def test_validate_project_reports_missing_and_invalid_fields(self, tmp_path):
+        project_dir = tmp_path / "projects" / "demo"
+        _write_json(
+            project_dir / "project.json",
+            {
+                "title": "",
+                "content_mode": "invalid",
+                "style": "",
+                "characters": {"A": []},
+                "clues": {
+                    "X": {
+                        "type": "bad",
+                        "description": "",
+                        "importance": "wrong",
+                    }
+                },
+            },
+        )
+
+        result = DataValidator(projects_root=str(tmp_path / "projects")).validate_project("demo")
+
+        assert not result.valid
+        assert any("title" in error for error in result.errors)
+        assert any("content_mode" in error for error in result.errors)
+        assert any("角色 'A' 数据格式错误" in error for error in result.errors)
+        assert any("type 值无效" in error for error in result.errors)
+
+    def test_validate_episode_narration_success_with_warnings(self, tmp_path):
+        project_dir = tmp_path / "projects" / "demo"
+        _write_json(project_dir / "project.json", _project_payload("narration"))
+        _write_json(
+            project_dir / "scripts" / "episode_1.json",
+            {
+                "episode": 1,
+                "title": "第一集",
+                "content_mode": "narration",
+                "characters_in_episode": ["姜月茴"],
+                "clues_in_episode": ["玉佩"],
+                "segments": [
+                    {
+                        "segment_id": "E1S01",
+                        "novel_text": "原文",
+                        "characters_in_segment": ["姜月茴"],
+                        "clues_in_segment": ["玉佩"],
+                        "image_prompt": "img",
+                        "video_prompt": "vid",
+                    }
+                ],
+            },
+        )
+
+        result = DataValidator(projects_root=str(tmp_path / "projects")).validate_episode(
+            "demo", "episode_1.json"
+        )
+
+        assert result.valid
+        assert any("characters_in_episode 字段已废弃" in w for w in result.warnings)
+        assert any("clues_in_episode 字段已废弃" in w for w in result.warnings)
+        assert any("缺少 duration_seconds" in w for w in result.warnings)
+
+    def test_validate_episode_reports_invalid_references_and_fields(self, tmp_path):
+        project_dir = tmp_path / "projects" / "demo"
+        _write_json(project_dir / "project.json", _project_payload("narration"))
+        _write_json(
+            project_dir / "scripts" / "episode_1.json",
+            {
+                "episode": "bad",
+                "title": "",
+                "content_mode": "narration",
+                "segments": [
+                    {
+                        "segment_id": "bad-id",
+                        "duration_seconds": 5,
+                        "novel_text": "",
+                        "characters_in_segment": ["未知角色"],
+                        "clues_in_segment": ["未知线索"],
+                        "image_prompt": "",
+                        "video_prompt": "",
+                    }
+                ],
+            },
+        )
+
+        result = DataValidator(projects_root=str(tmp_path / "projects")).validate_episode(
+            "demo", "episode_1.json"
+        )
+
+        assert not result.valid
+        assert any("episode (整数)" in error for error in result.errors)
+        assert any("segment_id 格式错误" in error for error in result.errors)
+        assert any("duration_seconds 值无效" in error for error in result.errors)
+        assert any("不存在于 project.json 的角色" in error for error in result.errors)
+        assert any("不存在于 project.json 的线索" in error for error in result.errors)
+
+    def test_validate_episode_drama_mode(self, tmp_path):
+        project_dir = tmp_path / "projects" / "demo"
+        _write_json(project_dir / "project.json", _project_payload("drama"))
+        _write_json(
+            project_dir / "scripts" / "episode_2.json",
+            {
+                "episode": 2,
+                "title": "第二集",
+                "content_mode": "drama",
+                "scenes": [
+                    {
+                        "scene_id": "E2S01",
+                        "scene_type": "剧情",
+                        "duration_seconds": 8,
+                        "characters_in_scene": ["姜月茴"],
+                        "clues_in_scene": ["玉佩"],
+                        "image_prompt": "img",
+                        "video_prompt": "vid",
+                    }
+                ],
+            },
+        )
+
+        result = validate_episode("demo", "episode_2.json", projects_root=str(tmp_path / "projects"))
+        assert result.valid
+
+    def test_validate_helpers_on_missing_files(self, tmp_path):
+        result = validate_project("missing", projects_root=str(tmp_path / "projects"))
+        assert not result.valid
+        assert any("无法加载 project.json" in error for error in result.errors)

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -1,0 +1,285 @@
+from io import BytesIO
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from lib.project_manager import ProjectManager
+from webui.server.routers import files
+
+
+class _FakeGeminiClient:
+    def analyze_style_image(self, image_path):
+        return "cinematic, high contrast"
+
+
+def _img_bytes(fmt="JPEG"):
+    image = Image.new("RGB", (8, 8), (255, 0, 0))
+    buf = BytesIO()
+    image.save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def _client(monkeypatch, tmp_path):
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+    pm.add_character("demo", "Alice", "desc")
+    pm.add_clue("demo", "玉佩", "prop", "desc", "major")
+
+    monkeypatch.setattr(files, "get_project_manager", lambda: pm)
+    monkeypatch.setattr(files, "GeminiClient", _FakeGeminiClient)
+
+    app = FastAPI()
+    app.include_router(files.router, prefix="/api/v1")
+    return TestClient(app), pm
+
+
+class TestFilesRouter:
+    def test_source_and_file_endpoints(self, tmp_path, monkeypatch):
+        client, _ = _client(monkeypatch, tmp_path)
+
+        with client:
+            upload = client.post(
+                "/api/v1/projects/demo/upload/source",
+                files={"file": ("chapter.txt", "hello", "text/plain")},
+            )
+            assert upload.status_code == 200
+            path = upload.json()["path"]
+            assert path == "source/chapter.txt"
+
+            listed = client.get("/api/v1/projects/demo/files")
+            assert listed.status_code == 200
+            assert any(item["name"] == "chapter.txt" for item in listed.json()["files"]["source"])
+
+            served = client.get("/api/v1/files/demo/source/chapter.txt")
+            assert served.status_code == 200
+            assert served.text == "hello"
+
+            get_source = client.get("/api/v1/projects/demo/source/chapter.txt")
+            assert get_source.status_code == 200
+            assert get_source.text == "hello"
+
+            update_source = client.put(
+                "/api/v1/projects/demo/source/chapter.txt",
+                content="updated",
+                headers={"content-type": "text/plain"},
+            )
+            assert update_source.status_code == 200
+
+            delete_source = client.delete("/api/v1/projects/demo/source/chapter.txt")
+            assert delete_source.status_code == 200
+
+            missing = client.get("/api/v1/projects/demo/source/missing.txt")
+            assert missing.status_code == 404
+
+    def test_upload_assets_and_drafts(self, tmp_path, monkeypatch):
+        client, pm = _client(monkeypatch, tmp_path)
+
+        with client:
+            character = client.post(
+                "/api/v1/projects/demo/upload/character?name=Alice",
+                files={"file": ("alice.jpg", _img_bytes("JPEG"), "image/jpeg")},
+            )
+            assert character.status_code == 200
+            assert character.json()["path"] == "characters/Alice.png"
+
+            character_ref = client.post(
+                "/api/v1/projects/demo/upload/character_ref?name=Alice",
+                files={"file": ("alice_ref.webp", _img_bytes("WEBP"), "image/webp")},
+            )
+            assert character_ref.status_code == 200
+            assert character_ref.json()["path"] == "characters/refs/Alice.png"
+
+            clue = client.post(
+                "/api/v1/projects/demo/upload/clue?name=玉佩",
+                files={"file": ("clue.jpg", _img_bytes("JPEG"), "image/jpeg")},
+            )
+            assert clue.status_code == 200
+            assert clue.json()["path"] == "clues/玉佩.png"
+
+            storyboard = client.post(
+                "/api/v1/projects/demo/upload/storyboard?name=E1S01",
+                files={"file": ("storyboard.jpg", _img_bytes("JPEG"), "image/jpeg")},
+            )
+            assert storyboard.status_code == 200
+            assert storyboard.json()["path"] == "storyboards/scene_E1S01.png"
+
+            invalid_ext = client.post(
+                "/api/v1/projects/demo/upload/source",
+                files={"file": ("bad.exe", b"x", "application/octet-stream")},
+            )
+            assert invalid_ext.status_code == 400
+
+            bad_type = client.post(
+                "/api/v1/projects/demo/upload/unknown",
+                files={"file": ("x.txt", b"x", "text/plain")},
+            )
+            assert bad_type.status_code == 400
+
+            bad_image = client.post(
+                "/api/v1/projects/demo/upload/character?name=Alice",
+                files={"file": ("bad.png", b"not-image", "image/png")},
+            )
+            assert bad_image.status_code == 400
+
+            # drafts API
+            update_draft = client.put(
+                "/api/v1/projects/demo/drafts/1/step1",
+                content="draft content",
+                headers={"content-type": "text/plain"},
+            )
+            assert update_draft.status_code == 200
+
+            list_drafts = client.get("/api/v1/projects/demo/drafts")
+            assert list_drafts.status_code == 200
+            assert "1" in list_drafts.json()["drafts"]
+
+            get_draft = client.get("/api/v1/projects/demo/drafts/1/step1")
+            assert get_draft.status_code == 200
+            assert "draft content" in get_draft.text
+
+            bad_step = client.get("/api/v1/projects/demo/drafts/1/step99")
+            assert bad_step.status_code == 400
+
+            delete_draft = client.delete("/api/v1/projects/demo/drafts/1/step1")
+            assert delete_draft.status_code == 200
+
+            missing_draft = client.get("/api/v1/projects/demo/drafts/1/step1")
+            assert missing_draft.status_code == 404
+
+            # confirm metadata updated for character/clue
+            project = pm.load_project("demo")
+            assert project["characters"]["Alice"]["character_sheet"] == "characters/Alice.png"
+            assert project["characters"]["Alice"]["reference_image"] == "characters/refs/Alice.png"
+            assert project["clues"]["玉佩"]["clue_sheet"] == "clues/玉佩.png"
+
+    def test_style_image_endpoints(self, tmp_path, monkeypatch):
+        client, pm = _client(monkeypatch, tmp_path)
+
+        with client:
+            upload_style = client.post(
+                "/api/v1/projects/demo/style-image",
+                files={"file": ("style.jpg", _img_bytes("JPEG"), "image/jpeg")},
+            )
+            assert upload_style.status_code == 200
+            assert upload_style.json()["style_description"] == "cinematic, high contrast"
+
+            patch_style = client.patch(
+                "/api/v1/projects/demo/style-description",
+                json={"style_description": "manual style"},
+            )
+            assert patch_style.status_code == 200
+            assert patch_style.json()["style_description"] == "manual style"
+
+            delete_style = client.delete("/api/v1/projects/demo/style-image")
+            assert delete_style.status_code == 200
+
+            project = pm.load_project("demo")
+            assert "style_image" not in project
+            assert "style_description" not in project
+
+            bad_style_ext = client.post(
+                "/api/v1/projects/demo/style-image",
+                files={"file": ("style.gif", b"gif", "image/gif")},
+            )
+            assert bad_style_ext.status_code == 400
+
+    def test_security_and_error_paths(self, tmp_path, monkeypatch):
+        client, _ = _client(monkeypatch, tmp_path)
+
+        outside = tmp_path / "projects" / "outside.txt"
+        outside.write_text("outside", encoding="utf-8")
+
+        with client:
+            traverse = client.get("/api/v1/files/demo/%2E%2E/outside.txt")
+            assert traverse.status_code == 403
+
+            missing_project = client.get("/api/v1/projects/missing/files")
+            assert missing_project.status_code == 404
+
+            missing_source = client.put(
+                "/api/v1/projects/missing/source/a.txt",
+                content="x",
+                headers={"content-type": "text/plain"},
+            )
+            assert missing_source.status_code == 404
+
+            style_missing_project = client.delete("/api/v1/projects/missing/style-image")
+            assert style_missing_project.status_code == 404
+
+    def test_upload_without_name_and_keyerror_tolerance(self, tmp_path, monkeypatch):
+        client, _ = _client(monkeypatch, tmp_path)
+        with client:
+            ref_no_name = client.post(
+                "/api/v1/projects/demo/upload/character_ref",
+                files={"file": ("no_name.jpg", _img_bytes("JPEG"), "image/jpeg")},
+            )
+            assert ref_no_name.status_code == 200
+            assert ref_no_name.json()["path"] == "characters/refs/no_name.png"
+
+            clue_missing_entity = client.post(
+                "/api/v1/projects/demo/upload/clue?name=不存在线索",
+                files={"file": ("x.jpg", _img_bytes("JPEG"), "image/jpeg")},
+            )
+            assert clue_missing_entity.status_code == 200
+            assert clue_missing_entity.json()["path"] == "clues/不存在线索.png"
+
+            character_missing_entity = client.post(
+                "/api/v1/projects/demo/upload/character?name=不存在人物",
+                files={"file": ("x.jpg", _img_bytes("JPEG"), "image/jpeg")},
+            )
+            assert character_missing_entity.status_code == 200
+            assert character_missing_entity.json()["path"] == "characters/不存在人物.png"
+
+            storyboard_no_name = client.post(
+                "/api/v1/projects/demo/upload/storyboard",
+                files={"file": ("board.jpg", _img_bytes("JPEG"), "image/jpeg")},
+            )
+            assert storyboard_no_name.status_code == 200
+            assert storyboard_no_name.json()["path"] == "storyboards/board.png"
+
+    def test_source_decode_and_draft_mode_helpers(self, tmp_path, monkeypatch):
+        client, pm = _client(monkeypatch, tmp_path)
+        project_dir = pm.get_project_path("demo")
+        source_dir = project_dir / "source"
+        source_dir.mkdir(parents=True, exist_ok=True)
+        (source_dir / "binary.txt").write_bytes(b"\xff\xfe")
+
+        with client:
+            bad_encoding = client.get("/api/v1/projects/demo/source/binary.txt")
+            assert bad_encoding.status_code == 400
+
+            # switch content_mode to drama so step files use normalized-script mapping
+            project_json = project_dir / "project.json"
+            payload = json.loads(project_json.read_text(encoding="utf-8"))
+            payload["content_mode"] = "drama"
+            project_json.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+            update_drama = client.put(
+                "/api/v1/projects/demo/drafts/2/step1",
+                content="drama draft",
+                headers={"content-type": "text/plain"},
+            )
+            assert update_drama.status_code == 200
+            assert update_drama.json()["path"] == "drafts/episode_2/step1_normalized_script.md"
+
+            missing_step = client.delete("/api/v1/projects/demo/drafts/2/step9")
+            assert missing_step.status_code == 400
+
+            unknown_draft = client.delete("/api/v1/projects/demo/drafts/9/step1")
+            assert unknown_draft.status_code == 404
+
+    def test_files_helper_functions(self, tmp_path):
+        assert files._extract_step_number("step12_x.md") == 12
+        assert files._extract_step_number("not-match.md") == 0
+        assert files._get_step_files("narration")[1] == "step1_segments.md"
+        assert files._get_step_files("drama")[2] == "step2_shot_budget.md"
+        assert files._get_step_title("step2_grid_plan.md") == "宫格切分规划"
+        assert files._get_step_title("unknown.md") == "unknown.md"
+
+        assert files._get_content_mode(tmp_path) == "drama"
+        project_json = tmp_path / "project.json"
+        project_json.write_text('{"content_mode":"narration"}', encoding="utf-8")
+        assert files._get_content_mode(tmp_path) == "narration"

--- a/tests/test_gemini_client_more.py
+++ b/tests/test_gemini_client_more.py
@@ -1,0 +1,442 @@
+import asyncio
+import io
+import os
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from lib import gemini_client as gemini_module
+from lib.gemini_client import GeminiClient, RateLimiter, get_shared_rate_limiter, with_retry, with_retry_async
+
+
+class _FakeTypes:
+    class Image:
+        def __init__(self, image_bytes=None, mime_type=None):
+            self.image_bytes = image_bytes
+            self.mime_type = mime_type
+
+    class Video:
+        def __init__(self, uri=None, video_bytes=None, mime_type=None):
+            self.uri = uri
+            self.video_bytes = video_bytes
+            self.mime_type = mime_type
+
+        def save(self, path):
+            Path(path).write_bytes(self.video_bytes or b"saved")
+
+    class ImageConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class GenerateContentConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class GenerateVideosConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class GenerateVideosSource:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+
+class _FakeRateLimiter:
+    def __init__(self):
+        self.sync_calls = []
+        self.async_calls = []
+
+    def acquire(self, model):
+        self.sync_calls.append(model)
+
+    async def acquire_async(self, model):
+        self.async_calls.append(model)
+
+
+class _FakeOperation:
+    def __init__(self, done=True, response=None, error=None):
+        self.done = done
+        self.response = response
+        self.error = error
+
+
+class _FakeAioModels:
+    def __init__(self, content_response=None, video_operation=None):
+        self.content_response = content_response
+        self.video_operation = video_operation
+        self.content_calls = []
+        self.video_calls = []
+
+    async def generate_content(self, **kwargs):
+        self.content_calls.append(kwargs)
+        return self.content_response
+
+    async def generate_videos(self, **kwargs):
+        self.video_calls.append(kwargs)
+        return self.video_operation
+
+
+class _FakeModels:
+    def __init__(self, content_response=None, video_operation=None):
+        self.content_response = content_response
+        self.video_operation = video_operation
+        self.content_calls = []
+        self.video_calls = []
+
+    def generate_content(self, **kwargs):
+        self.content_calls.append(kwargs)
+        return self.content_response
+
+    def generate_videos(self, **kwargs):
+        self.video_calls.append(kwargs)
+        return self.video_operation
+
+
+class _FakeOperations:
+    def __init__(self, next_operation):
+        self.next_operation = next_operation
+        self.calls = 0
+
+    def get(self, operation):
+        self.calls += 1
+        return self.next_operation
+
+
+class _FakeAioOperations:
+    def __init__(self, next_operation):
+        self.next_operation = next_operation
+        self.calls = 0
+
+    async def get(self, operation):
+        self.calls += 1
+        return self.next_operation
+
+
+def _build_client(models=None, aio_models=None, operations=None, aio_operations=None):
+    client = object.__new__(GeminiClient)
+    client.types = _FakeTypes
+    client.rate_limiter = _FakeRateLimiter()
+    client.backend = "aistudio"
+    client.credentials = None
+    client.project_id = None
+    client.gcs_bucket = None
+    client.IMAGE_MODEL = "image-model"
+    client.VIDEO_MODEL = "video-model"
+    client.client = SimpleNamespace(
+        models=models or _FakeModels(),
+        aio=SimpleNamespace(
+            models=aio_models or _FakeAioModels(),
+            operations=aio_operations or _FakeAioOperations(_FakeOperation()),
+        ),
+        operations=operations or _FakeOperations(_FakeOperation()),
+        files=SimpleNamespace(download=lambda file: None),
+    )
+    return client
+
+
+def _image_response():
+    img = Image.new("RGB", (4, 4), (255, 0, 0))
+
+    class _Part:
+        inline_data = object()
+
+        @staticmethod
+        def as_image():
+            return img.copy()
+
+    return SimpleNamespace(parts=[_Part()])
+
+
+class TestGeminiClientMore:
+    def test_retry_wrappers(self, monkeypatch):
+        sleep_calls = []
+        monkeypatch.setattr(gemini_module.time, "sleep", lambda seconds: sleep_calls.append(seconds))
+        monkeypatch.setattr(gemini_module.random, "uniform", lambda a, b: 0.0)
+
+        state = {"count": 0}
+
+        @with_retry(max_attempts=3, backoff_seconds=(0, 0, 0), retryable_errors=(RuntimeError,))
+        def _fn(output_path=None):
+            state["count"] += 1
+            if state["count"] < 3:
+                raise RuntimeError("503 temporary")
+            return "ok"
+
+        assert _fn(output_path="x.txt") == "ok"
+        assert state["count"] == 3
+        assert len(sleep_calls) == 2
+
+        @with_retry(max_attempts=2, backoff_seconds=(0,), retryable_errors=(RuntimeError,))
+        def _bad():
+            raise ValueError("fatal")
+
+        with pytest.raises(ValueError):
+            _bad()
+
+    @pytest.mark.asyncio
+    async def test_retry_async_wrapper(self, monkeypatch):
+        sleep_calls = []
+
+        async def _fake_sleep(seconds):
+            sleep_calls.append(seconds)
+
+        monkeypatch.setattr(gemini_module.asyncio, "sleep", _fake_sleep)
+        monkeypatch.setattr(gemini_module.random, "uniform", lambda a, b: 0.0)
+
+        state = {"count": 0}
+
+        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0), retryable_errors=(RuntimeError,))
+        async def _fn_async(output_path=None):
+            state["count"] += 1
+            if state["count"] < 3:
+                raise RuntimeError("429 retry")
+            return "ok"
+
+        assert await _fn_async(output_path="y.txt") == "ok"
+        assert state["count"] == 3
+        assert len(sleep_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_rate_limiter_and_shared_limiter(self, monkeypatch):
+        limiter = RateLimiter({"m": 1})
+        monkeypatch.setenv("GEMINI_REQUEST_GAP", "0")
+        time_values = iter([0.0, 0.0, 61.0, 61.0])
+        monkeypatch.setattr(gemini_module.time, "time", lambda: next(time_values))
+        monkeypatch.setattr(gemini_module.time, "sleep", lambda _s: None)
+        limiter.acquire("m")
+        limiter.acquire("m")
+        assert len(limiter.request_logs["m"]) == 1
+
+        limiter2 = RateLimiter({"m": 2})
+        limiter2.request_logs["m"] = deque([0.0])
+        monkeypatch.setenv("GEMINI_REQUEST_GAP", "1")
+        async_time_values = iter([0.2, 1.2])
+        monkeypatch.setattr(gemini_module.time, "time", lambda: next(async_time_values))
+
+        async_waits = []
+
+        async def _fake_sleep(seconds):
+            async_waits.append(seconds)
+
+        monkeypatch.setattr(gemini_module.asyncio, "sleep", _fake_sleep)
+        await limiter2.acquire_async("m")
+        assert async_waits and async_waits[0] > 0
+
+        monkeypatch.setenv("GEMINI_IMAGE_RPM", "12")
+        monkeypatch.setenv("GEMINI_VIDEO_RPM", "8")
+        gemini_module._shared_rate_limiter = None
+        shared_1 = get_shared_rate_limiter()
+        shared_2 = get_shared_rate_limiter()
+        assert shared_1 is shared_2
+        assert shared_1.limits[gemini_module._SHARED_IMAGE_MODEL_NAME] == 12
+        assert shared_1.limits[gemini_module._SHARED_VIDEO_MODEL_NAME] == 8
+
+        monkeypatch.setenv("GEMINI_IMAGE_RPM", "bad")
+        gemini_module._shared_rate_limiter = None
+        shared_3 = get_shared_rate_limiter()
+        assert shared_3.limits[gemini_module._SHARED_IMAGE_MODEL_NAME] == 15
+
+    def test_prepare_param_and_config_helpers(self, tmp_path):
+        client = _build_client()
+
+        jpg = tmp_path / "ref.jpg"
+        Image.new("RGB", (6, 6), (0, 0, 255)).save(jpg)
+        image_param = client._prepare_image_param(jpg)
+        assert image_param.mime_type == "image/jpeg"
+
+        pil_image = Image.new("RGB", (6, 6), (0, 255, 0))
+        image_param2 = client._prepare_image_param(pil_image)
+        assert image_param2.mime_type == "image/png"
+        assert isinstance(image_param2.image_bytes, bytes)
+
+        raw_obj = object()
+        assert client._prepare_image_param(raw_obj) is raw_obj
+        assert client._prepare_image_param(None) is None
+
+        mp4 = tmp_path / "clip.mp4"
+        mp4.write_bytes(b"video-bytes")
+        video_param, video_bytes = client._prepare_video_param(mp4)
+        assert video_param.mime_type == "video/mp4"
+        assert video_bytes == b"video-bytes"
+
+        uri_video, uri_bytes = client._prepare_video_param("gs://bucket/file.mp4")
+        assert uri_video.uri == "gs://bucket/file.mp4"
+        assert uri_bytes is None
+
+        direct_video = _FakeTypes.Video(video_bytes=b"abc", mime_type="video/mp4")
+        direct_param, direct_bytes = client._prepare_video_param(direct_video)
+        assert direct_param is direct_video
+        assert direct_bytes == b"abc"
+
+        with pytest.raises(ValueError):
+            client._prepare_video_param("not-found.mp4")
+
+        image_cfg = client._prepare_image_config("9:16", "2K")
+        assert image_cfg.kwargs["response_modalities"] == ["IMAGE"]
+
+        video_gen_cfg = client._prepare_video_generate_config("9:16", "1080p", "8", "none")
+        assert video_gen_cfg.kwargs["resolution"] == "1080p"
+        video_ext_cfg = client._prepare_video_extend_config("gs://bucket/out.mp4")
+        assert video_ext_cfg.kwargs["output_gcs_uri"] == "gs://bucket/out.mp4"
+
+        assert client._prepare_text_config(None) is None
+        schema_cfg = client._prepare_text_config({"type": "object"})
+        assert schema_cfg["response_mime_type"] == "application/json"
+        assert client._process_text_response(SimpleNamespace(text="hello")) == "hello"
+
+        assert client._extract_name_from_path("characters/Alice.png") == "Alice"
+        assert client._extract_name_from_path("storyboards/scene_001.png") is None
+        assert client._extract_name_from_path(Image.new("RGB", (1, 1))) is None
+
+        contents = client._build_contents_with_labeled_refs(
+            "prompt",
+            reference_images=[jpg, pil_image],
+        )
+        assert contents[-1] == "prompt"
+        assert any(item == "ref" for item in contents if isinstance(item, str))
+
+    def test_process_image_and_download_video(self, tmp_path, monkeypatch):
+        client = _build_client(models=_FakeModels(content_response=_image_response()))
+        output = tmp_path / "out.png"
+        image = client._process_image_response(_image_response(), output)
+        assert image.size == (4, 4)
+        assert output.exists()
+
+        with pytest.raises(RuntimeError):
+            client._process_image_response(SimpleNamespace(parts=[SimpleNamespace(inline_data=None)]))
+
+        # AI Studio path
+        video_ref = _FakeTypes.Video(video_bytes=b"v")
+        client._download_video(video_ref, tmp_path / "a.mp4")
+
+        # Vertex bytes path
+        client.backend = "vertex"
+        v_out = tmp_path / "vertex-bytes.mp4"
+        client._download_video(_FakeTypes.Video(video_bytes=b"vertex"), v_out)
+        assert v_out.read_bytes() == b"vertex"
+
+        # Vertex URI path
+        downloaded = {}
+
+        def _fake_urlretrieve(uri, output_path):
+            downloaded["uri"] = uri
+            Path(output_path).write_bytes(b"uri-video")
+
+        monkeypatch.setattr("urllib.request.urlretrieve", _fake_urlretrieve)
+        uri_out = tmp_path / "vertex-uri.mp4"
+        client._download_video(_FakeTypes.Video(uri="https://example.com/video.mp4"), uri_out)
+        assert downloaded["uri"] == "https://example.com/video.mp4"
+        assert uri_out.exists()
+
+        with pytest.raises(RuntimeError):
+            client._download_video(SimpleNamespace(), tmp_path / "bad.mp4")
+
+    @pytest.mark.asyncio
+    async def test_text_and_video_generation_paths(self, tmp_path, monkeypatch):
+        text_response = SimpleNamespace(text="text-output")
+        video_ref = _FakeTypes.Video(uri="https://video", video_bytes=b"bin", mime_type="video/mp4")
+        generated = SimpleNamespace(video=video_ref)
+        video_response = SimpleNamespace(generated_videos=[generated])
+        done_operation = _FakeOperation(done=True, response=video_response)
+
+        models = _FakeModels(content_response=text_response, video_operation=done_operation)
+        aio_models = _FakeAioModels(content_response=text_response, video_operation=done_operation)
+        client = _build_client(
+            models=models,
+            aio_models=aio_models,
+            operations=_FakeOperations(done_operation),
+            aio_operations=_FakeAioOperations(done_operation),
+        )
+
+        assert client.generate_text("hello", response_schema={"type": "object"}) == "text-output"
+        assert await client.generate_text_async("hello-async") == "text-output"
+
+        img = tmp_path / "start.png"
+        Image.new("RGB", (5, 5), (1, 2, 3)).save(img)
+
+        # sync generate mode
+        downloaded = {"count": 0}
+
+        def _fake_download(_video, _path):
+            downloaded["count"] += 1
+
+        client._download_video = _fake_download  # type: ignore[method-assign]
+        out_path = tmp_path / "sync-video.mp4"
+        sync_out, sync_ref, sync_uri = client.generate_video(
+            prompt="gen video",
+            start_image=img,
+            output_path=out_path,
+            poll_interval=0,
+            max_wait_time=10,
+        )
+        assert sync_out == out_path
+        assert sync_ref is video_ref
+        assert sync_uri == "https://video"
+        assert downloaded["count"] == 1
+
+        # async generate mode
+        async_out, async_ref, async_uri = await client.generate_video_async(
+            prompt="async gen",
+            start_image=img,
+            output_path=None,
+            poll_interval=0,
+            max_wait_time=10,
+        )
+        assert async_out is None
+        assert async_ref is video_ref
+        assert async_uri == "https://video"
+
+        # timeout branch (sync)
+        never_done = _FakeOperation(done=False, response=video_response)
+        client.client.models.generate_videos = lambda **kwargs: never_done
+        with pytest.raises(TimeoutError):
+            client.generate_video(
+                prompt="timeout",
+                start_image=img,
+                poll_interval=0,
+                max_wait_time=0,
+            )
+
+        # async vertex extend validation branch
+        client.backend = "vertex"
+        client.gcs_bucket = None
+        with pytest.raises(ValueError):
+            await client.generate_video_async(
+                prompt="extend",
+                video=tmp_path / "input.mp4",
+                output_path=None,
+                poll_interval=0,
+                max_wait_time=10,
+            )
+
+    def test_process_video_result_and_style_image(self, tmp_path):
+        video_ref = _FakeTypes.Video(uri="gs://bucket/out.mp4", video_bytes=b"v")
+        generated = SimpleNamespace(video=video_ref)
+        ok_operation = _FakeOperation(done=True, response=SimpleNamespace(generated_videos=[generated]))
+        client = _build_client()
+
+        saved = {"called": False}
+        client._download_video = lambda ref, output: saved.__setitem__("called", True)  # type: ignore[method-assign]
+        out, ref, uri = client._process_video_result(ok_operation, tmp_path / "v.mp4", is_extend_mode=False)
+        assert out == tmp_path / "v.mp4"
+        assert ref is video_ref
+        assert uri == "gs://bucket/out.mp4"
+        assert saved["called"] is True
+
+        with pytest.raises(RuntimeError):
+            client._process_video_result(_FakeOperation(done=True, response=None), None, is_extend_mode=False)
+
+        with pytest.raises(RuntimeError):
+            client._process_video_result(
+                _FakeOperation(done=True, response=SimpleNamespace(generated_videos=[]), error="E"),
+                None,
+                is_extend_mode=True,
+            )
+
+        style_response = SimpleNamespace(text=" cinematic ")
+        style_client = _build_client(models=_FakeModels(content_response=style_response))
+        image = Image.new("RGB", (3, 3), (100, 100, 100))
+        assert style_client.analyze_style_image(image) == "cinematic"

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -1,0 +1,207 @@
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from webui.server.routers import generate
+
+
+class _FakeVersions:
+    def get_versions(self, resource_type, resource_id):
+        return {"versions": [{"created_at": "2026-02-01T00:00:00Z"}]}
+
+
+class _FakeGenerator:
+    def __init__(self):
+        self.versions = _FakeVersions()
+        self.image_calls = []
+        self.video_calls = []
+
+    async def generate_image_async(self, **kwargs):
+        self.image_calls.append(kwargs)
+        return Path("/tmp/out.png"), 1
+
+    async def generate_video_async(self, **kwargs):
+        self.video_calls.append(kwargs)
+        return Path("/tmp/out.mp4"), 2, "ref", "video-uri"
+
+
+class _FakePM:
+    def __init__(self, project_path: Path):
+        self.project_path = project_path
+        self.project = {
+            "style": "Anime",
+            "style_description": "cinematic",
+            "content_mode": "narration",
+            "characters": {
+                "Alice": {
+                    "character_sheet": "characters/Alice.png",
+                    "reference_image": "characters/refs/Alice_ref.png",
+                    "description": "hero",
+                }
+            },
+            "clues": {
+                "玉佩": {
+                    "type": "prop",
+                    "clue_sheet": "clues/玉佩.png",
+                    "description": "clue",
+                }
+            },
+        }
+        self.script = {
+            "content_mode": "narration",
+            "segments": [
+                {
+                    "segment_id": "E1S01",
+                    "duration_seconds": 4,
+                    "characters_in_segment": ["Alice"],
+                    "clues_in_segment": ["玉佩"],
+                    "generated_assets": {},
+                }
+            ],
+        }
+        self.updated = []
+
+    def load_project(self, project_name):
+        return self.project
+
+    def get_project_path(self, project_name):
+        return self.project_path
+
+    def load_script(self, project_name, script_file):
+        return self.script
+
+    def update_scene_asset(self, **kwargs):
+        self.updated.append(kwargs)
+
+    def save_project(self, project_name, project):
+        self.project = project
+
+
+
+def _prepare_files(tmp_path: Path) -> Path:
+    project_path = tmp_path / "projects" / "demo"
+    (project_path / "storyboards").mkdir(parents=True, exist_ok=True)
+    (project_path / "characters").mkdir(parents=True, exist_ok=True)
+    (project_path / "characters" / "refs").mkdir(parents=True, exist_ok=True)
+    (project_path / "clues").mkdir(parents=True, exist_ok=True)
+
+    (project_path / "storyboards" / "scene_E1S01.png").write_bytes(b"png")
+    (project_path / "characters" / "Alice.png").write_bytes(b"png")
+    (project_path / "characters" / "refs" / "Alice_ref.png").write_bytes(b"png")
+    (project_path / "clues" / "玉佩.png").write_bytes(b"png")
+    return project_path
+
+
+def _client(monkeypatch, fake_pm, fake_generator):
+    monkeypatch.setattr(generate, "get_project_manager", lambda: fake_pm)
+    monkeypatch.setattr(generate, "get_media_generator", lambda _project: fake_generator)
+    monkeypatch.setattr(generate, "_get_video_semaphore", lambda: __import__("asyncio").Semaphore(1))
+
+    app = FastAPI()
+    app.include_router(generate.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+class TestGenerateRouter:
+    def test_storyboard_video_character_clue_success(self, tmp_path, monkeypatch):
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        client = _client(monkeypatch, fake_pm, fake_generator)
+
+        with client:
+            sb = client.post(
+                "/api/v1/projects/demo/generate/storyboard/E1S01",
+                json={
+                    "script_file": "episode_1.json",
+                    "prompt": {
+                        "scene": "雨夜",
+                        "composition": {"shot_type": "Medium Shot", "lighting": "暖光", "ambiance": "薄雾"},
+                    },
+                },
+            )
+            assert sb.status_code == 200
+            assert sb.json()["version"] == 1
+
+            video = client.post(
+                "/api/v1/projects/demo/generate/video/E1S01",
+                json={
+                    "script_file": "episode_1.json",
+                    "duration_seconds": 5,
+                    "prompt": {
+                        "action": "奔跑",
+                        "camera_motion": "Static",
+                        "ambiance_audio": "雨声",
+                        "dialogue": [{"speaker": "Alice", "line": "快走"}],
+                    },
+                },
+            )
+            assert video.status_code == 200
+            assert video.json()["version"] == 2
+
+            character = client.post(
+                "/api/v1/projects/demo/generate/character/Alice",
+                json={"prompt": "女主，冷静"},
+            )
+            assert character.status_code == 200
+            assert character.json()["file_path"] == "characters/Alice.png"
+
+            clue = client.post(
+                "/api/v1/projects/demo/generate/clue/玉佩",
+                json={"prompt": "古朴玉佩"},
+            )
+            assert clue.status_code == 200
+            assert clue.json()["file_path"] == "clues/玉佩.png"
+
+            assert fake_pm.updated
+
+    def test_error_paths(self, tmp_path, monkeypatch):
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        client = _client(monkeypatch, fake_pm, fake_generator)
+
+        with client:
+            bad_prompt = client.post(
+                "/api/v1/projects/demo/generate/storyboard/E1S01",
+                json={"script_file": "episode_1.json", "prompt": {"composition": {}}},
+            )
+            assert bad_prompt.status_code == 400
+
+            # remove storyboard so video endpoint hits pre-check error
+            (project_path / "storyboards" / "scene_E1S01.png").unlink()
+            no_storyboard = client.post(
+                "/api/v1/projects/demo/generate/video/E1S01",
+                json={"script_file": "episode_1.json", "prompt": "text"},
+            )
+            assert no_storyboard.status_code == 400
+
+            bad_video_prompt = client.post(
+                "/api/v1/projects/demo/generate/video/E1S01",
+                json={"script_file": "episode_1.json", "prompt": {"action": ""}},
+            )
+            assert bad_video_prompt.status_code in (400, 500)
+
+            fake_pm.project["characters"] = {}
+            missing_char = client.post(
+                "/api/v1/projects/demo/generate/character/Alice",
+                json={"prompt": "x"},
+            )
+            assert missing_char.status_code == 404
+
+            fake_pm.project["clues"] = {}
+            missing_clue = client.post(
+                "/api/v1/projects/demo/generate/clue/玉佩",
+                json={"prompt": "x"},
+            )
+            assert missing_clue.status_code == 404
+
+    def test_helper_functions(self):
+        assert generate.get_aspect_ratio({"content_mode": "narration"}, "storyboards") == "9:16"
+        assert generate.get_aspect_ratio({"content_mode": "drama"}, "storyboards") == "16:9"
+        assert generate.get_aspect_ratio({"aspect_ratio": {"videos": "4:3"}}, "videos") == "4:3"
+
+        assert generate.normalize_veo_duration_seconds(None) == "4"
+        assert generate.normalize_veo_duration_seconds(6) == "6"
+        assert generate.normalize_veo_duration_seconds(99) == "8"

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -1,0 +1,216 @@
+from pathlib import Path
+
+import pytest
+
+from webui.server.services import generation_tasks
+
+
+class _FakePM:
+    def __init__(self, project_path: Path):
+        self.project_path = project_path
+        self.project = {
+            "content_mode": "narration",
+            "style": "Anime",
+            "style_description": "cinematic",
+            "characters": {
+                "Alice": {
+                    "character_sheet": "characters/Alice.png",
+                    "reference_image": "characters/refs/Alice-ref.png",
+                }
+            },
+            "clues": {"玉佩": {"type": "prop", "clue_sheet": "clues/玉佩.png"}},
+        }
+        self.script = {
+            "content_mode": "narration",
+            "segments": [
+                {
+                    "segment_id": "E1S01",
+                    "duration_seconds": 4,
+                    "characters_in_segment": ["Alice"],
+                    "clues_in_segment": ["玉佩"],
+                    "image_prompt": {
+                        "scene": "在雨夜街道",
+                        "composition": {
+                            "shot_type": "Medium Shot",
+                            "lighting": "暖光",
+                            "ambiance": "薄雾",
+                        },
+                    },
+                }
+            ],
+        }
+        self.updated_assets = []
+
+    def load_project(self, project_name: str):
+        return self.project
+
+    def get_project_path(self, project_name: str):
+        return self.project_path
+
+    def load_script(self, project_name: str, script_file: str):
+        return self.script
+
+    def update_scene_asset(self, **kwargs):
+        self.updated_assets.append(kwargs)
+
+    def save_project(self, project_name: str, project: dict):
+        self.project = project
+
+    def project_exists(self, project_name: str) -> bool:
+        return True
+
+
+class _FakeGenerator:
+    def __init__(self):
+        self.image_calls = []
+        self.video_calls = []
+        self.versions = self
+
+    def generate_image(self, **kwargs):
+        self.image_calls.append(kwargs)
+        return Path("/tmp/image.png"), 1
+
+    def generate_video(self, **kwargs):
+        self.video_calls.append(kwargs)
+        return Path("/tmp/video.mp4"), 2, "ref", "uri"
+
+    def get_versions(self, resource_type, resource_id):
+        return {"versions": [{"created_at": "2026-01-01T00:00:00Z"}]}
+
+
+class _FakeGeminiClient:
+    def __init__(self, rate_limiter=None):
+        self.calls = []
+
+    def generate_image(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+def _prepare_files(tmp_path: Path):
+    project_path = tmp_path / "projects" / "demo"
+    (project_path / "storyboards").mkdir(parents=True, exist_ok=True)
+    (project_path / "characters").mkdir(parents=True, exist_ok=True)
+    (project_path / "characters" / "refs").mkdir(parents=True, exist_ok=True)
+    (project_path / "clues").mkdir(parents=True, exist_ok=True)
+    (project_path / "storyboards" / "scene_E1S01.png").write_bytes(b"png")
+    (project_path / "characters" / "Alice.png").write_bytes(b"png")
+    (project_path / "characters" / "refs" / "Alice-ref.png").write_bytes(b"png")
+    (project_path / "clues" / "玉佩.png").write_bytes(b"png")
+    return project_path
+
+
+class TestGenerationTasks:
+    def test_helper_functions(self, tmp_path):
+        assert generation_tasks.normalize_veo_duration_seconds(None) == "4"
+        assert generation_tasks.normalize_veo_duration_seconds(5) == "6"
+        assert generation_tasks.normalize_veo_duration_seconds(9) == "8"
+
+        mode_items = generation_tasks._get_items_from_script({"content_mode": "drama", "scenes": []})
+        assert mode_items[1] == "scene_id"
+
+        prompt = generation_tasks._normalize_storyboard_prompt("text", "Anime")
+        assert prompt == "text"
+
+        with pytest.raises(ValueError):
+            generation_tasks._normalize_storyboard_prompt({"scene": ""}, "Anime")
+
+        video_yaml = generation_tasks._normalize_video_prompt(
+            {
+                "action": "行走",
+                "camera_motion": "",
+                "ambiance_audio": "风声",
+                "dialogue": [{"speaker": "Alice", "line": "hello"}],
+            }
+        )
+        assert "Camera_Motion" in video_yaml
+
+        with pytest.raises(ValueError):
+            generation_tasks._normalize_video_prompt({"action": ""})
+
+        assert generation_tasks._get_grid_layout(4)[2] == "2x2 四宫格"
+        assert generation_tasks._get_grid_layout(5)[2] == "2x3 六宫格"
+
+    def test_execute_task_dispatch_and_storyboard_grid(self, tmp_path, monkeypatch):
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "get_media_generator", lambda _p: fake_generator)
+        monkeypatch.setattr(generation_tasks, "GeminiClient", _FakeGeminiClient)
+
+        storyboard_result = generation_tasks.execute_storyboard_task(
+            "demo",
+            "E1S01",
+            {"script_file": "episode_1.json", "prompt": "direct prompt", "extra_reference_images": ["characters/Alice.png"]},
+        )
+        assert storyboard_result["resource_type"] == "storyboards"
+
+        video_result = generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {"script_file": "episode_1.json", "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []}},
+        )
+        assert video_result["resource_type"] == "videos"
+        assert video_result["video_uri"] == "uri"
+
+        character_result = generation_tasks.execute_character_task(
+            "demo",
+            "Alice",
+            {"prompt": "角色描述"},
+        )
+        assert character_result["resource_type"] == "characters"
+        assert fake_pm.project["characters"]["Alice"]["character_sheet"] == "characters/Alice.png"
+
+        clue_result = generation_tasks.execute_clue_task(
+            "demo",
+            "玉佩",
+            {"prompt": "线索描述"},
+        )
+        assert clue_result["resource_type"] == "clues"
+
+        grid_result = generation_tasks.execute_storyboard_grid_task(
+            "demo",
+            {"script_file": "episode_1.json", "batch_id": 1, "scene_ids": ["E1S01"]},
+        )
+        assert grid_result["resource_type"] == "storyboard_grid"
+
+        dispatch = generation_tasks.execute_generation_task(
+            {
+                "task_type": "storyboard",
+                "project_name": "demo",
+                "resource_id": "E1S01",
+                "payload": {"script_file": "episode_1.json", "prompt": "text"},
+            }
+        )
+        assert dispatch["resource_type"] == "storyboards"
+
+        with pytest.raises(ValueError):
+            generation_tasks.execute_generation_task({"task_type": "unknown", "project_name": "demo", "resource_id": "x", "payload": {}})
+
+    def test_execute_task_validation_errors(self, tmp_path, monkeypatch):
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "get_media_generator", lambda _p: _FakeGenerator())
+
+        with pytest.raises(ValueError):
+            generation_tasks.execute_storyboard_task("demo", "E1S01", {"prompt": "x"})
+
+        with pytest.raises(ValueError):
+            generation_tasks.execute_video_task("demo", "E1S01", {"script_file": "episode_1.json"})
+
+        (project_path / "storyboards" / "scene_E1S01.png").unlink()
+        with pytest.raises(ValueError):
+            generation_tasks.execute_video_task(
+                "demo", "E1S01", {"script_file": "episode_1.json", "prompt": "x"}
+            )
+
+        with pytest.raises(ValueError):
+            generation_tasks.execute_character_task("demo", "Alice", {"prompt": ""})
+
+        with pytest.raises(ValueError):
+            generation_tasks.execute_clue_task("demo", "玉佩", {"prompt": ""})
+
+        with pytest.raises(ValueError):
+            generation_tasks.execute_storyboard_grid_task("demo", {"script_file": "episode_1.json", "batch_id": "bad", "scene_ids": []})

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -1,0 +1,77 @@
+import asyncio
+
+import pytest
+
+from lib.generation_worker import GenerationWorker, _read_int_env
+
+
+class _FakeQueue:
+    def __init__(self):
+        self.released = False
+        self.succeeded = []
+        self.failed = []
+        self._lease_calls = 0
+
+    def acquire_or_renew_worker_lease(self, name, owner_id, ttl_seconds):
+        self._lease_calls += 1
+        return True
+
+    def release_worker_lease(self, name, owner_id):
+        self.released = True
+
+    def requeue_running_tasks(self):
+        return 0
+
+    def claim_next_task(self, media_type):
+        return None
+
+    def mark_task_succeeded(self, task_id, result):
+        self.succeeded.append((task_id, result))
+
+    def mark_task_failed(self, task_id, error):
+        self.failed.append((task_id, error))
+
+
+class TestGenerationWorker:
+    def test_read_int_env(self, monkeypatch):
+        monkeypatch.delenv("ARCREEL_INT", raising=False)
+        assert _read_int_env("ARCREEL_INT", 3, minimum=1) == 3
+
+        monkeypatch.setenv("ARCREEL_INT", "bad")
+        assert _read_int_env("ARCREEL_INT", 3, minimum=1) == 3
+
+        monkeypatch.setenv("ARCREEL_INT", "0")
+        assert _read_int_env("ARCREEL_INT", 3, minimum=2) == 2
+
+    @pytest.mark.asyncio
+    async def test_process_task_success_and_failure(self, monkeypatch):
+        queue = _FakeQueue()
+        worker = GenerationWorker(queue=queue)
+
+        monkeypatch.setattr(
+            "webui.server.services.generation_tasks.execute_generation_task",
+            lambda task: {"ok": task["task_id"]},
+        )
+        await worker._process_task({"task_id": "t1"})
+        assert queue.succeeded == [("t1", {"ok": "t1"})]
+
+        def _raise(_task):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("webui.server.services.generation_tasks.execute_generation_task", _raise)
+        await worker._process_task({"task_id": "t2"})
+        assert queue.failed and queue.failed[0][0] == "t2"
+
+    @pytest.mark.asyncio
+    async def test_start_stop_run_loop_releases_lease(self):
+        queue = _FakeQueue()
+        worker = GenerationWorker(queue=queue)
+        worker.heartbeat_interval = 0.01
+        worker.poll_interval = 0.01
+
+        await worker.start()
+        await asyncio.sleep(0.05)
+        await worker.stop()
+
+        assert queue.released
+        assert worker._main_task is None

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -1,0 +1,129 @@
+from pathlib import Path
+
+import pytest
+
+from lib.media_generator import MediaGenerator
+
+
+class _FakeGemini:
+    IMAGE_MODEL = "img-model"
+    VIDEO_MODEL = "video-model"
+
+    def __init__(self):
+        self.image_calls = []
+        self.video_calls = []
+
+    def generate_image(self, **kwargs):
+        self.image_calls.append(kwargs)
+
+    async def generate_image_async(self, **kwargs):
+        self.image_calls.append(kwargs)
+
+    def generate_video(self, **kwargs):
+        self.video_calls.append(kwargs)
+        return None, "video-ref", "video-uri"
+
+    async def generate_video_async(self, **kwargs):
+        self.video_calls.append(kwargs)
+        return None, "video-ref", "video-uri"
+
+
+class _FakeVersions:
+    def __init__(self):
+        self.ensure_calls = []
+        self.add_calls = []
+
+    def ensure_current_tracked(self, **kwargs):
+        self.ensure_calls.append(kwargs)
+
+    def add_version(self, **kwargs):
+        self.add_calls.append(kwargs)
+        return len(self.add_calls)
+
+    def get_versions(self, resource_type, resource_id):
+        return {
+            "current_version": len(self.add_calls),
+            "versions": [{"created_at": "2026-01-01T00:00:00Z"}] * max(1, len(self.add_calls)),
+        }
+
+
+class _FakeUsage:
+    def __init__(self):
+        self.started = []
+        self.finished = []
+
+    def start_call(self, **kwargs):
+        self.started.append(kwargs)
+        return len(self.started)
+
+    def finish_call(self, **kwargs):
+        self.finished.append(kwargs)
+
+
+def _build_generator(tmp_path: Path) -> MediaGenerator:
+    gen = object.__new__(MediaGenerator)
+    gen.project_path = tmp_path / "projects" / "demo"
+    gen.project_path.mkdir(parents=True, exist_ok=True)
+    gen.project_name = "demo"
+    gen.gemini = _FakeGemini()
+    gen.versions = _FakeVersions()
+    gen.usage_tracker = _FakeUsage()
+    return gen
+
+
+class TestMediaGenerator:
+    def test_get_output_path_and_invalid_type(self, tmp_path):
+        gen = _build_generator(tmp_path)
+        assert gen._get_output_path("storyboards", "E1S01").name == "scene_E1S01.png"
+        assert gen._get_output_path("videos", "E1S01").name == "scene_E1S01.mp4"
+        assert gen._get_output_path("characters", "Alice").name == "Alice.png"
+        with pytest.raises(ValueError):
+            gen._get_output_path("bad", "x")
+
+    def test_generate_image_success_and_failure(self, tmp_path):
+        gen = _build_generator(tmp_path)
+        output_path, version = gen.generate_image(
+            prompt="p",
+            resource_type="storyboards",
+            resource_id="E1S01",
+            aspect_ratio="9:16",
+        )
+
+        assert output_path.name == "scene_E1S01.png"
+        assert version == 1
+        assert gen.usage_tracker.started[0]["call_type"] == "image"
+        assert gen.usage_tracker.finished[0]["status"] == "success"
+
+        def _raise(**kwargs):
+            raise RuntimeError("boom")
+
+        gen.gemini.generate_image = _raise
+        with pytest.raises(RuntimeError):
+            gen.generate_image(prompt="p", resource_type="characters", resource_id="A")
+
+        assert any(item["status"] == "failed" for item in gen.usage_tracker.finished)
+
+    @pytest.mark.asyncio
+    async def test_generate_video_sync_and_async(self, tmp_path):
+        gen = _build_generator(tmp_path)
+
+        video_path, version, video_ref, video_uri = gen.generate_video(
+            prompt="p",
+            resource_type="videos",
+            resource_id="E1S01",
+            duration_seconds="bad",
+        )
+        assert video_path.name == "scene_E1S01.mp4"
+        assert version == 1
+        assert video_ref == "video-ref"
+        assert video_uri == "video-uri"
+
+        video_path2, version2, _, _ = await gen.generate_video_async(
+            prompt="p",
+            resource_type="videos",
+            resource_id="E1S02",
+            duration_seconds="6",
+        )
+        assert video_path2.name == "scene_E1S02.mp4"
+        assert version2 == 2
+        assert gen.usage_tracker.started[-1]["call_type"] == "video"

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -1,0 +1,253 @@
+import json
+import warnings
+from pathlib import Path
+
+import pytest
+
+from lib.project_manager import ProjectManager
+
+
+def _write(path: Path, text: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class _FakeGeminiClient:
+    async def generate_text_async(self, prompt, model, response_schema):
+        return json.dumps(
+            {
+                "synopsis": "故事梗概",
+                "genre": "悬疑",
+                "theme": "真相",
+                "world_setting": "古代",
+            },
+            ensure_ascii=False,
+        )
+
+
+class TestProjectManagerMore:
+    def test_project_and_status_lifecycle(self, tmp_path):
+        pm = ProjectManager(tmp_path / "projects")
+        project_dir = pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        _write(project_dir / "source" / "a.txt", "source")
+        _write(project_dir / "scripts" / "episode_1.json", "{}")
+        _write(project_dir / "characters" / "alice.png", "x")
+        _write(project_dir / "clues" / "clue.png", "x")
+        _write(project_dir / "storyboards" / "scene_1.png", "x")
+        _write(project_dir / "videos" / "scene_1.mp4", "x")
+        _write(project_dir / "output" / "final.mp4", "x")
+
+        assert "demo" in pm.list_projects()
+        status = pm.get_project_status("demo")
+        assert status["current_stage"] == "completed"
+        assert status["source_files"] == ["a.txt"]
+
+        assert pm.project_exists("demo")
+        loaded = pm.load_project("demo")
+        assert loaded["title"] == "Demo"
+
+        loaded["style"] = "Noir"
+        pm.save_project("demo", loaded)
+        assert pm.load_project("demo")["style"] == "Noir"
+
+    def test_script_operations_and_scene_updates(self, tmp_path):
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        script = {
+            "episode": 1,
+            "title": "第一集",
+            "content_mode": "narration",
+            "segments": [{"segment_id": "E1S01", "duration_seconds": 4}],
+        }
+        path = pm.save_script("demo", script, "episode_1.json")
+        assert path.name == "episode_1.json"
+
+        loaded = pm.load_script("demo", "episode_1.json")
+        assert loaded["metadata"]["total_scenes"] == 1
+        assert loaded["metadata"]["estimated_duration_seconds"] == 4
+        assert pm.list_scripts("demo") == ["episode_1.json"]
+
+        synced = pm.sync_episode_from_script("demo", "episode_1.json")
+        assert synced["episodes"][0]["episode"] == 1
+
+        # add_scene (drama format)
+        drama_script = {
+            "episode": 2,
+            "title": "第二集",
+            "content_mode": "drama",
+            "scenes": [],
+        }
+        pm.save_script("demo", drama_script, "episode_2.json")
+        pm.add_scene("demo", "episode_2.json", {"duration_seconds": 8, "generated_assets": {}})
+        loaded_drama = pm.load_script("demo", "episode_2.json")
+        assert loaded_drama["scenes"][0]["scene_id"] == "001"
+
+        # update_scene_asset + pending helpers
+        narration_script = pm.load_script("demo", "episode_1.json")
+        narration_script["segments"][0]["generated_assets"] = {}
+        pm.save_script("demo", narration_script, "episode_1.json")
+
+        pm.update_scene_asset(
+            "demo",
+            "episode_1.json",
+            "E1S01",
+            "storyboard_image",
+            "storyboards/scene_E1S01.png",
+        )
+        updated = pm.load_script("demo", "episode_1.json")
+        assert updated["segments"][0]["generated_assets"]["status"] == "storyboard_ready"
+
+        pending_video = pm.get_pending_scenes("demo", "episode_1.json", "video_clip")
+        assert len(pending_video) == 1
+
+        # get_scenes_needing_individual
+        drama = pm.load_script("demo", "episode_2.json")
+        drama["scenes"][0]["generated_assets"] = {"storyboard_grid": "storyboards/grid_001.png", "storyboard_image": None}
+        pm.save_script("demo", drama, "episode_2.json")
+        assert len(pm.get_scenes_needing_individual("demo", "episode_2.json")) == 1
+
+        with pytest.raises(KeyError):
+            pm.update_scene_asset("demo", "episode_1.json", "NOT_FOUND", "video_clip", "x.mp4")
+
+    def test_normalize_and_templates(self, tmp_path):
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "drama")
+
+        scene = {"scene_id": "S1", "generated_assets": {"storyboard_grid": "g.png"}}
+        normalized = pm.normalize_scene(scene, episode=3)
+        assert normalized["episode"] == 3
+        assert normalized["generated_assets"]["status"] == "pending"
+
+        assert pm.update_scene_status({"generated_assets": {"video_clip": "v.mp4"}}) == "completed"
+        assert pm.update_scene_status({"generated_assets": {"storyboard_image": "s.png"}}) == "storyboard_ready"
+        assert (
+            pm.update_scene_status(
+                {"generated_assets": {"storyboard_grid": "g.png"}},
+                content_mode="drama",
+            )
+            == "in_progress"
+        )
+
+        raw_script = {
+            "novel": {"chapter": "chapter"},
+            "scenes": [{"scene_id": "001"}],
+            "characters": {"A": {"description": "desc"}},
+            "clues": {"C": {"type": "prop", "description": "d", "importance": "major"}},
+        }
+        _write(tmp_path / "projects" / "demo" / "scripts" / "legacy.json", json.dumps(raw_script, ensure_ascii=False))
+
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(pm, "sync_characters_from_script", lambda *args, **kwargs: None, raising=False)
+        monkeypatch.setattr(pm, "sync_clues_from_script", lambda *args, **kwargs: None, raising=False)
+        normalized_script = pm.normalize_script("demo", "legacy.json", save=False)
+        monkeypatch.undo()
+
+        assert "metadata" in normalized_script
+        assert normalized_script["duration_seconds"] >= 0
+
+    def test_entity_and_batch_management_and_paths(self, tmp_path):
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo")
+
+        pm.add_project_character("demo", "Alice", "hero", "soft")
+        pm.update_project_character_sheet("demo", "Alice", "characters/Alice.png")
+        pm.update_character_reference_image("demo", "Alice", "characters/refs/Alice.png")
+        assert pm.get_project_character("demo", "Alice")["reference_image"].endswith("Alice.png")
+
+        pm.add_clues_batch("demo", {"玉佩": {"type": "prop", "description": "d", "importance": "major"}})
+        pm.update_clue_sheet("demo", "玉佩", "clues/玉佩.png")
+        assert pm.get_clue("demo", "玉佩")["clue_sheet"].endswith("玉佩.png")
+
+        project_dir = pm.get_project_path("demo")
+        (project_dir / "clues" / "玉佩.png").write_bytes(b"png")
+        assert pm.get_pending_clues("demo") == []
+
+        # direct add_* return bool
+        assert pm.add_character("demo", "Bob", "side", "") is True
+        assert pm.add_character("demo", "Bob", "side", "") is False
+        assert pm.add_clue("demo", "线索X", "prop", "desc", "minor") is True
+        assert pm.add_clue("demo", "线索X", "prop", "desc", "minor") is False
+
+        added_chars = pm.add_characters_batch("demo", {"Bob": {"description": "d"}, "C": {"description": "d"}})
+        assert added_chars == 1
+        added_clues = pm.add_clues_batch("demo", {"线索X": {"type": "prop"}, "线索Y": {"type": "location"}})
+        assert added_clues == 1
+
+        pm.add_episode("demo", 1, "第一集", "scripts/episode_1.json")
+        pm.add_episode("demo", 1, "第一集-改", "scripts/episode_1.json")
+        assert pm.load_project("demo")["episodes"][0]["title"].startswith("第一集")
+
+        assert str(pm.get_source_path("demo", "a.txt")).endswith("/source/a.txt")
+        assert str(pm.get_character_path("demo", "a.png")).endswith("/characters/a.png")
+        assert str(pm.get_storyboard_path("demo", "a.png")).endswith("/storyboards/a.png")
+        assert str(pm.get_video_path("demo", "a.mp4")).endswith("/videos/a.mp4")
+        assert str(pm.get_output_path("demo", "a.mp4")).endswith("/output/a.mp4")
+        assert str(pm.get_clue_path("demo", "a.png")).endswith("/clues/a.png")
+
+        with pytest.raises(KeyError):
+            pm.get_project_character("demo", "none")
+        with pytest.raises(KeyError):
+            pm.update_project_character_sheet("demo", "none", "x")
+        with pytest.raises(KeyError):
+            pm.update_character_reference_image("demo", "none", "x")
+        with pytest.raises(KeyError):
+            pm.get_clue("demo", "none")
+        with pytest.raises(KeyError):
+            pm.update_clue_sheet("demo", "none", "x")
+
+    @pytest.mark.asyncio
+    async def test_reference_read_source_and_generate_overview(self, tmp_path, monkeypatch):
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo")
+
+        pm.add_character("demo", "Alice", "hero")
+        pm.add_clues_batch("demo", {"玉佩": {"type": "prop", "description": "d", "importance": "major"}})
+
+        project_dir = pm.get_project_path("demo")
+        (project_dir / "characters" / "Alice.png").write_bytes(b"png")
+        (project_dir / "clues" / "玉佩.png").write_bytes(b"png")
+
+        project = pm.load_project("demo")
+        project["characters"]["Alice"]["character_sheet"] = "characters/Alice.png"
+        project["clues"]["玉佩"]["clue_sheet"] = "clues/玉佩.png"
+        pm.save_project("demo", project)
+
+        refs = pm.collect_reference_images(
+            "demo",
+            {"characters_in_scene": ["Alice"], "clues_in_scene": ["玉佩"]},
+        )
+        assert len(refs) == 2
+
+        _write(project_dir / "source" / "1.txt", "a" * 10)
+        _write(project_dir / "source" / "2.md", "b" * 10)
+        _write(project_dir / "source" / "3.bin", "ignored")
+        content = pm._read_source_files("demo", max_chars=15)
+        assert "1.txt" in content
+
+        monkeypatch.setattr("lib.gemini_client.GeminiClient", _FakeGeminiClient)
+        overview = await pm.generate_overview("demo")
+        assert overview["genre"] == "悬疑"
+        assert "generated_at" in overview
+
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            project_data = pm.sync_project_status("demo")
+        assert captured
+        assert project_data["title"] == "Demo"
+
+        pm_empty = ProjectManager(tmp_path / "projects-empty")
+        pm_empty.create_project("demo")
+        pm_empty.create_project_metadata("demo", "Demo")
+        with pytest.raises(ValueError):
+            await pm_empty.generate_overview("demo")

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1,0 +1,232 @@
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from webui.server.routers import projects
+
+
+class _FakePM:
+    def __init__(self, base: Path):
+        self.base = base
+        self.project_data = {
+            "ready": {
+                "title": "Ready",
+                "style": "Anime",
+                "episodes": [{"episode": 1, "script_file": "scripts/episode_1.json"}],
+                "overview": {"synopsis": "old"},
+            },
+            "broken": {
+                "title": "Broken",
+                "style": "",
+                "episodes": [],
+            },
+        }
+        self.scripts = {
+            ("ready", "episode_1.json"): {
+                "content_mode": "drama",
+                "scenes": [{"scene_id": "001", "duration_seconds": 8}],
+            },
+            ("ready", "narration.json"): {
+                "content_mode": "narration",
+                "segments": [{"segment_id": "E1S01", "duration_seconds": 4}],
+            },
+        }
+        self.created = set()
+        (self.base / "ready" / "storyboards").mkdir(parents=True, exist_ok=True)
+        (self.base / "ready" / "storyboards" / "scene_E1S01.png").write_bytes(b"png")
+        (self.base / "empty").mkdir(parents=True, exist_ok=True)
+        (self.base / "remove-me").mkdir(parents=True, exist_ok=True)
+
+    def list_projects(self):
+        return ["ready", "empty", "broken"]
+
+    def project_exists(self, name):
+        return name in {"ready", "broken"}
+
+    def load_project(self, name):
+        if name == "broken":
+            raise RuntimeError("broken")
+        if name not in self.project_data:
+            raise FileNotFoundError(name)
+        return self.project_data[name]
+
+    def get_project_path(self, name):
+        path = self.base / name
+        if not path.exists():
+            raise FileNotFoundError(name)
+        return path
+
+    def get_project_status(self, name):
+        return {"current_stage": "source_ready"}
+
+    def create_project(self, name):
+        if name == "exists":
+            raise FileExistsError(name)
+        self.created.add(name)
+        (self.base / name).mkdir(parents=True, exist_ok=True)
+
+    def create_project_metadata(self, name, title, style, content_mode):
+        payload = {"title": title, "style": style or "", "content_mode": content_mode, "episodes": []}
+        self.project_data[name] = payload
+        return payload
+
+    def save_project(self, name, payload):
+        self.project_data[name] = payload
+
+    def load_script(self, name, script_file):
+        key = (name, script_file)
+        if key not in self.scripts:
+            raise FileNotFoundError(script_file)
+        return self.scripts[key]
+
+    def save_script(self, name, payload, script_file):
+        self.scripts[(name, script_file)] = payload
+
+    async def generate_overview(self, name):
+        if name == "ready":
+            return {"synopsis": "generated"}
+        raise ValueError("source missing")
+
+
+class _FakeCalc:
+    def calculate_project_progress(self, name):
+        return {
+            "characters": {"total": 1, "completed": 0},
+            "clues": {"total": 1, "completed": 0},
+            "storyboards": {"total": 2, "completed": 1},
+            "videos": {"total": 2, "completed": 0},
+        }
+
+    def calculate_current_phase(self, progress):
+        return "storyboard"
+
+    def enrich_project(self, name, project):
+        project = dict(project)
+        project["status"] = {"progress": self.calculate_project_progress(name), "current_phase": "storyboard"}
+        return project
+
+    def enrich_script(self, script):
+        script = dict(script)
+        script["metadata"] = {"total_scenes": 1, "estimated_duration_seconds": 8}
+        return script
+
+
+def _client(monkeypatch, fake_pm, fake_calc):
+    monkeypatch.setattr(projects, "get_project_manager", lambda: fake_pm)
+    monkeypatch.setattr(projects, "get_status_calculator", lambda: fake_calc)
+
+    app = FastAPI()
+    app.include_router(projects.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+class TestProjectsRouter:
+    def test_list_and_create_and_delete(self, tmp_path, monkeypatch):
+        client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
+        with client:
+            listed = client.get("/api/v1/projects")
+            assert listed.status_code == 200
+            names = [p["name"] for p in listed.json()["projects"]]
+            assert names == ["ready", "empty", "broken"]
+            broken = [p for p in listed.json()["projects"] if p["name"] == "broken"][0]
+            assert broken["current_phase"] == "error"
+
+            create_ok = client.post(
+                "/api/v1/projects",
+                json={"name": "new", "title": "New", "style": "Real", "content_mode": "narration"},
+            )
+            assert create_ok.status_code == 200
+
+            create_exists = client.post(
+                "/api/v1/projects",
+                json={"name": "exists", "title": "Dup", "style": "", "content_mode": "narration"},
+            )
+            assert create_exists.status_code == 400
+
+            delete_ok = client.delete("/api/v1/projects/remove-me")
+            assert delete_ok.status_code == 200
+
+    def test_project_details_and_updates(self, tmp_path, monkeypatch):
+        fake_pm = _FakePM(tmp_path)
+        client = _client(monkeypatch, fake_pm, _FakeCalc())
+
+        with client:
+            detail = client.get("/api/v1/projects/ready")
+            assert detail.status_code == 200
+            assert "status" in detail.json()["project"]
+            assert "episode_1.json" in detail.json()["scripts"]
+
+            missing = client.get("/api/v1/projects/missing")
+            assert missing.status_code == 404
+
+            update = client.patch(
+                "/api/v1/projects/ready",
+                json={"title": "Updated", "style": "Noir", "content_mode": "drama", "aspect_ratio": {"videos": "16:9"}},
+            )
+            assert update.status_code == 200
+            assert update.json()["project"]["title"] == "Updated"
+
+            get_script = client.get("/api/v1/projects/ready/scripts/episode_1.json")
+            assert get_script.status_code == 200
+
+            get_script_missing = client.get("/api/v1/projects/ready/scripts/missing.json")
+            assert get_script_missing.status_code == 404
+
+    def test_scene_segment_and_overview_endpoints(self, tmp_path, monkeypatch):
+        fake_pm = _FakePM(tmp_path)
+        fake_pm.scripts[("ready", "episode_1.json")] = {
+            "content_mode": "drama",
+            "scenes": [{"scene_id": "001", "duration_seconds": 8, "image_prompt": {}, "video_prompt": {}}],
+        }
+        fake_pm.scripts[("ready", "narration.json")] = {
+            "content_mode": "narration",
+            "segments": [{"segment_id": "E1S01", "duration_seconds": 4}],
+        }
+
+        client = _client(monkeypatch, fake_pm, _FakeCalc())
+
+        with client:
+            patch_scene = client.patch(
+                "/api/v1/projects/ready/scenes/001",
+                json={"script_file": "episode_1.json", "updates": {"duration_seconds": 6, "segment_break": True}},
+            )
+            assert patch_scene.status_code == 200
+            assert patch_scene.json()["scene"]["duration_seconds"] == 6
+
+            patch_scene_missing = client.patch(
+                "/api/v1/projects/ready/scenes/404",
+                json={"script_file": "episode_1.json", "updates": {}},
+            )
+            assert patch_scene_missing.status_code == 404
+
+            patch_segment = client.patch(
+                "/api/v1/projects/ready/segments/E1S01",
+                json={"script_file": "narration.json", "duration_seconds": 8, "segment_break": True},
+            )
+            assert patch_segment.status_code == 200
+
+            not_narration = client.patch(
+                "/api/v1/projects/ready/segments/001",
+                json={"script_file": "episode_1.json", "duration_seconds": 8},
+            )
+            assert not_narration.status_code == 400
+
+            segment_missing = client.patch(
+                "/api/v1/projects/ready/segments/E9S99",
+                json={"script_file": "narration.json", "duration_seconds": 8},
+            )
+            assert segment_missing.status_code == 404
+
+            gen_overview_ok = client.post("/api/v1/projects/ready/generate-overview")
+            assert gen_overview_ok.status_code == 200
+
+            gen_overview_bad = client.post("/api/v1/projects/bad/generate-overview")
+            assert gen_overview_bad.status_code == 400
+
+            update_overview = client.patch(
+                "/api/v1/projects/ready/overview",
+                json={"synopsis": "new synopsis", "genre": "悬疑", "theme": "真相", "world_setting": "古代"},
+            )
+            assert update_overview.status_code == 200
+            assert update_overview.json()["overview"]["synopsis"] == "new synopsis"

--- a/tests/test_prompt_builders.py
+++ b/tests/test_prompt_builders.py
@@ -1,0 +1,46 @@
+from lib.prompt_builders import (
+    build_character_prompt,
+    build_clue_prompt,
+    build_location_prompt,
+    build_prop_prompt,
+    build_storyboard_suffix,
+    build_style_prompt,
+)
+
+
+class TestPromptBuilders:
+    def test_build_character_prompt_includes_style_and_description(self):
+        prompt = build_character_prompt(
+            "姜月茴",
+            "黑发，冷静神态。",
+            style="古风",
+            style_description="Cinematic, low-key lighting",
+        )
+        assert "Visual style: Cinematic, low-key lighting" in prompt
+        assert "人物设计参考图，古风" in prompt
+        assert "姜月茴" in prompt
+        assert "黑发，冷静神态。" in prompt
+
+    def test_build_clue_prompt_dispatches_by_type(self):
+        prop_prompt = build_clue_prompt("玉佩", "古朴", clue_type="prop", style="写实")
+        location_prompt = build_clue_prompt("祠堂", "昏暗", clue_type="location", style="写实")
+
+        assert prop_prompt == build_prop_prompt("玉佩", "古朴", "写实", "")
+        assert location_prompt == build_location_prompt("祠堂", "昏暗", "写实", "")
+
+    def test_build_storyboard_suffix(self):
+        assert build_storyboard_suffix("narration") == "竖屏构图。"
+        assert build_storyboard_suffix("drama") == ""
+
+    def test_build_style_prompt_combines_available_parts(self):
+        project_data = {
+            "style": "Anime",
+            "style_description": "soft pastel, hand-drawn",
+        }
+        result = build_style_prompt(project_data)
+        assert "Style: Anime" in result
+        assert "Visual style: soft pastel, hand-drawn" in result
+
+    def test_build_style_prompt_handles_empty_values(self):
+        assert build_style_prompt({}) == ""
+        assert build_style_prompt({"style": ""}) == ""

--- a/tests/test_prompt_builders_script.py
+++ b/tests/test_prompt_builders_script.py
@@ -1,0 +1,53 @@
+from lib.prompt_builders_script import (
+    _format_character_names,
+    _format_clue_names,
+    build_drama_prompt,
+    build_narration_prompt,
+)
+
+
+class TestPromptBuildersScript:
+    def test_formatters_emit_bullet_lists(self):
+        assert _format_character_names({"A": {}, "B": {}}) == "- A\n- B"
+        assert _format_clue_names({"玉佩": {}, "祠堂": {}}) == "- 玉佩\n- 祠堂"
+
+    def test_build_narration_prompt_contains_constraints_and_inputs(self):
+        prompt = build_narration_prompt(
+            project_overview={
+                "synopsis": "一段悬疑故事",
+                "genre": "悬疑",
+                "theme": "真相",
+                "world_setting": "古代县城",
+            },
+            style="古风",
+            style_description="misty, cinematic",
+            characters={"姜月茴": {}, "沈砚": {}},
+            clues={"玉佩": {}, "药包": {}},
+            segments_md="E1S01 | 文本",
+        )
+
+        assert "所有输出内容必须使用中文" in prompt
+        assert "<segments>" in prompt
+        assert "姜月茴" in prompt
+        assert "玉佩" in prompt
+        assert "E1S01 | 文本" in prompt
+
+    def test_build_drama_prompt_mentions_16_9_and_scene_fields(self):
+        prompt = build_drama_prompt(
+            project_overview={
+                "synopsis": "动作戏",
+                "genre": "动作",
+                "theme": "成长",
+                "world_setting": "近未来",
+            },
+            style="赛博",
+            style_description="high contrast",
+            characters={"林": {}},
+            clues={"芯片": {}},
+            scenes_md="E1S01 | 追逐",
+        )
+
+        assert "16:9 横屏构图" in prompt
+        assert "characters_in_scene" in prompt
+        assert "clues_in_scene" in prompt
+        assert "E1S01 | 追逐" in prompt

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -1,0 +1,64 @@
+import yaml
+
+from lib.prompt_utils import (
+    image_prompt_to_yaml,
+    video_prompt_to_yaml,
+    is_structured_image_prompt,
+    is_structured_video_prompt,
+    validate_style,
+    validate_shot_type,
+    validate_camera_motion,
+)
+
+
+class TestPromptUtils:
+    def test_image_prompt_to_yaml_keeps_expected_shape(self):
+        data = {
+            "scene": "夜雨中的街道",
+            "composition": {
+                "shot_type": "Medium Shot",
+                "lighting": "路灯暖光",
+                "ambiance": "薄雾",
+            },
+        }
+
+        text = image_prompt_to_yaml(data, "Anime")
+        parsed = yaml.safe_load(text)
+        assert parsed["Style"] == "Anime"
+        assert parsed["Scene"] == "夜雨中的街道"
+        assert parsed["Composition"]["shot_type"] == "Medium Shot"
+
+    def test_video_prompt_to_yaml_includes_dialogue_conditionally(self):
+        with_dialogue = {
+            "action": "抬头观察",
+            "camera_motion": "Static",
+            "ambiance_audio": "雨声",
+            "dialogue": [{"speaker": "姜月茴", "line": "有人吗"}],
+        }
+        without_dialogue = {
+            "action": "快步前进",
+            "camera_motion": "Pan Left",
+            "ambiance_audio": "脚步声",
+            "dialogue": [],
+        }
+
+        parsed_a = yaml.safe_load(video_prompt_to_yaml(with_dialogue))
+        parsed_b = yaml.safe_load(video_prompt_to_yaml(without_dialogue))
+
+        assert parsed_a["Action"] == "抬头观察"
+        assert parsed_a["Dialogue"][0]["Speaker"] == "姜月茴"
+        assert "Dialogue" not in parsed_b
+
+    def test_structured_checks(self):
+        assert is_structured_image_prompt({"scene": "x"})
+        assert not is_structured_image_prompt("text")
+        assert is_structured_video_prompt({"action": "x"})
+        assert not is_structured_video_prompt([])
+
+    def test_validators(self):
+        assert validate_style("Anime")
+        assert not validate_style("Unknown")
+        assert validate_shot_type("Close-up")
+        assert not validate_shot_type("Bad Shot")
+        assert validate_camera_motion("Zoom In")
+        assert not validate_camera_motion("Teleport")

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -1,0 +1,160 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from lib.script_generator import ScriptGenerator
+
+
+def _write(path: Path, text: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_json(path: Path, payload: dict):
+    _write(path, json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+def _valid_narration_response() -> dict:
+    return {
+        "episode": 1,
+        "title": "第一集",
+        "content_mode": "narration",
+        "duration_seconds": 4,
+        "summary": "摘要",
+        "novel": {"title": "小说", "chapter": "1", "source_file": "source.md"},
+        "characters_in_episode": ["姜月茴"],
+        "clues_in_episode": ["玉佩"],
+        "segments": [
+            {
+                "segment_id": "E1S01",
+                "episode": 1,
+                "duration_seconds": 4,
+                "segment_break": False,
+                "novel_text": "原文",
+                "characters_in_segment": ["姜月茴"],
+                "clues_in_segment": ["玉佩"],
+                "image_prompt": {
+                    "scene": "场景",
+                    "composition": {
+                        "shot_type": "Medium Shot",
+                        "lighting": "暖光",
+                        "ambiance": "薄雾",
+                    },
+                },
+                "video_prompt": {
+                    "action": "转身",
+                    "camera_motion": "Static",
+                    "ambiance_audio": "风声",
+                    "dialogue": [],
+                },
+            }
+        ],
+    }
+
+
+class _FakeGeminiClient:
+    def __init__(self, response_text: str):
+        self._response_text = response_text
+        self.calls = []
+
+    def generate_text(self, prompt, model, response_schema):
+        self.calls.append((prompt, model, response_schema))
+        return self._response_text
+
+
+class TestScriptGenerator:
+    def test_build_prompt_uses_step1_content(self, tmp_path, monkeypatch):
+        project_path = tmp_path / "demo"
+        _write_json(
+            project_path / "project.json",
+            {
+                "title": "项目",
+                "content_mode": "narration",
+                "overview": {"synopsis": "概述"},
+                "characters": {"姜月茴": {}},
+                "clues": {"玉佩": {}},
+                "style": "古风",
+                "style_description": "cinematic",
+            },
+        )
+        _write(project_path / "drafts" / "episode_1" / "step1_segments.md", "E1S01 | 片段")
+
+        fake = _FakeGeminiClient(json.dumps(_valid_narration_response(), ensure_ascii=False))
+        monkeypatch.setattr("lib.script_generator.GeminiClient", lambda: fake)
+
+        generator = ScriptGenerator(project_path)
+        prompt = generator.build_prompt(1)
+
+        assert "E1S01 | 片段" in prompt
+        assert "姜月茴" in prompt
+
+    def test_load_step1_falls_back_when_primary_missing(self, tmp_path, monkeypatch):
+        project_path = tmp_path / "demo"
+        _write_json(
+            project_path / "project.json",
+            {
+                "title": "项目",
+                "content_mode": "narration",
+                "overview": {},
+                "characters": {},
+                "clues": {},
+            },
+        )
+        _write(project_path / "drafts" / "episode_1" / "step1_normalized_script.md", "fallback")
+
+        fake = _FakeGeminiClient(json.dumps(_valid_narration_response(), ensure_ascii=False))
+        monkeypatch.setattr("lib.script_generator.GeminiClient", lambda: fake)
+
+        generator = ScriptGenerator(project_path)
+        content = generator._load_step1(1)
+        assert content == "fallback"
+
+    def test_parse_response_invalid_json_raises(self, tmp_path, monkeypatch):
+        project_path = tmp_path / "demo"
+        _write_json(project_path / "project.json", {"title": "项目"})
+        fake = _FakeGeminiClient("{}")
+        monkeypatch.setattr("lib.script_generator.GeminiClient", lambda: fake)
+
+        generator = ScriptGenerator(project_path)
+        with pytest.raises(ValueError):
+            generator._parse_response("not-json", 1)
+
+    def test_parse_response_validation_error_returns_raw_data(self, tmp_path, monkeypatch):
+        project_path = tmp_path / "demo"
+        _write_json(project_path / "project.json", {"title": "项目"})
+        fake = _FakeGeminiClient("{}")
+        monkeypatch.setattr("lib.script_generator.GeminiClient", lambda: fake)
+
+        generator = ScriptGenerator(project_path)
+        parsed = generator._parse_response('{"foo": "bar"}', 1)
+        assert parsed == {"foo": "bar"}
+
+    def test_generate_writes_script_and_metadata(self, tmp_path, monkeypatch):
+        project_path = tmp_path / "demo"
+        _write_json(
+            project_path / "project.json",
+            {
+                "title": "项目",
+                "content_mode": "narration",
+                "overview": {},
+                "characters": {"姜月茴": {}},
+                "clues": {"玉佩": {}},
+                "style": "古风",
+                "style_description": "cinematic",
+            },
+        )
+        _write(project_path / "drafts" / "episode_1" / "step1_segments.md", "E1S01 | 片段")
+
+        fake = _FakeGeminiClient(json.dumps(_valid_narration_response(), ensure_ascii=False))
+        monkeypatch.setattr("lib.script_generator.GeminiClient", lambda: fake)
+
+        generator = ScriptGenerator(project_path)
+        output = generator.generate(1)
+
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        assert output == project_path / "scripts" / "episode_1.json"
+        assert payload["episode"] == 1
+        assert payload["duration_seconds"] == 4
+        assert payload["metadata"]["generator"] == ScriptGenerator.MODEL
+        assert "created_at" in payload["metadata"]

--- a/tests/test_script_models.py
+++ b/tests/test_script_models.py
@@ -1,0 +1,107 @@
+import pytest
+from pydantic import ValidationError
+
+from lib.script_models import (
+    Dialogue,
+    Composition,
+    ImagePrompt,
+    VideoPrompt,
+    NarrationSegment,
+    NarrationEpisodeScript,
+    DramaScene,
+    DramaEpisodeScript,
+)
+
+
+class TestScriptModels:
+    def test_narration_segment_defaults_and_validation(self):
+        segment = NarrationSegment(
+            segment_id="E1S01",
+            episode=1,
+            duration_seconds=4,
+            novel_text="原文",
+            characters_in_segment=["姜月茴"],
+            clues_in_segment=["玉佩"],
+            image_prompt=ImagePrompt(
+                scene="场景",
+                composition=Composition(
+                    shot_type="Medium Shot",
+                    lighting="暖光",
+                    ambiance="薄雾",
+                ),
+            ),
+            video_prompt=VideoPrompt(
+                action="转身",
+                camera_motion="Static",
+                ambiance_audio="风声",
+                dialogue=[Dialogue(speaker="姜月茴", line="等等")],
+            ),
+        )
+
+        assert segment.transition_to_next == "cut"
+        assert segment.generated_assets.status == "pending"
+
+    def test_invalid_duration_raises_validation_error(self):
+        with pytest.raises(ValidationError):
+            NarrationSegment(
+                segment_id="E1S01",
+                episode=1,
+                duration_seconds=5,
+                novel_text="原文",
+                characters_in_segment=["姜月茴"],
+                image_prompt=ImagePrompt(
+                    scene="场景",
+                    composition=Composition(
+                        shot_type="Medium Shot",
+                        lighting="暖光",
+                        ambiance="薄雾",
+                    ),
+                ),
+                video_prompt=VideoPrompt(
+                    action="转身",
+                    camera_motion="Static",
+                    ambiance_audio="风声",
+                ),
+            )
+
+    def test_episode_models_build_successfully(self):
+        narration = NarrationEpisodeScript(
+            episode=1,
+            title="第一集",
+            summary="摘要",
+            novel={"title": "小说", "chapter": "1", "source_file": "a.md"},
+            characters_in_episode=["姜月茴"],
+            clues_in_episode=["玉佩"],
+            segments=[],
+        )
+        drama = DramaEpisodeScript(
+            episode=1,
+            title="第一集",
+            summary="摘要",
+            novel={"title": "小说", "chapter": "1", "source_file": "a.md"},
+            characters_in_episode=["姜月茴"],
+            clues_in_episode=["玉佩"],
+            scenes=[
+                DramaScene(
+                    scene_id="E1S01",
+                    characters_in_scene=["姜月茴"],
+                    image_prompt=ImagePrompt(
+                        scene="场景",
+                        composition=Composition(
+                            shot_type="Medium Shot",
+                            lighting="暖光",
+                            ambiance="薄雾",
+                        ),
+                    ),
+                    video_prompt=VideoPrompt(
+                        action="前进",
+                        camera_motion="Static",
+                        ambiance_audio="雨声",
+                    ),
+                )
+            ],
+        )
+
+        assert narration.content_mode == "narration"
+        assert drama.content_mode == "drama"
+        assert drama.scenes[0].duration_seconds == 8

--- a/tests/test_session_manager_more.py
+++ b/tests/test_session_manager_more.py
@@ -1,0 +1,277 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from tests.fakes import FakeSDKClient
+from webui.server.agent_runtime import session_manager as sm_mod
+from webui.server.agent_runtime.session_manager import ManagedSession
+
+
+class _FakeOptions:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _FakeClaudeClient:
+    def __init__(self, options):
+        self.options = options
+        self.connected = False
+
+    async def connect(self):
+        self.connected = True
+
+
+class _InterruptibleClient:
+    def __init__(self, disconnect_raises=False):
+        self.interrupted = False
+        self.disconnect_raises = disconnect_raises
+
+    async def interrupt(self):
+        self.interrupted = True
+
+    async def disconnect(self):
+        if self.disconnect_raises:
+            raise RuntimeError("disconnect failed")
+
+    async def receive_response(self):
+        if False:
+            yield None
+
+
+class _CancelClient:
+    async def receive_response(self):
+        raise asyncio.CancelledError
+        if False:
+            yield None
+
+
+class _ErrorClient:
+    async def receive_response(self):
+        raise RuntimeError("stream failed")
+        if False:
+            yield None
+
+
+class _FakeAllow:
+    def __init__(self, updated_input):
+        self.updated_input = updated_input
+
+
+class _FakeDeny:
+    def __init__(self, message, interrupt):
+        self.message = message
+        self.interrupt = interrupt
+
+
+class TestSessionManagerMore:
+    def test_managed_session_buffer_and_queue_overflow(self):
+        managed = ManagedSession(session_id="s1", client=object(), buffer_max_size=2)
+        managed.message_buffer = [
+            {"type": "stream_event", "id": "a"},
+            {"type": "assistant", "id": "b"},
+        ]
+        managed.add_message({"type": "assistant", "id": "c"})
+        assert len(managed.message_buffer) == 2
+        assert all(msg["id"] != "a" for msg in managed.message_buffer)
+
+        queue = asyncio.Queue(maxsize=1)
+        queue.put_nowait({"type": "stream_event"})
+        managed.subscribers = {queue}
+        managed.add_message({"type": "result", "uuid": "r1"})
+        assert queue.get_nowait()["type"] == "result"
+
+        # queue has only critical message; next critical should overflow and drop subscriber
+        stale_queue = asyncio.Queue(maxsize=1)
+        stale_queue.put_nowait({"type": "result"})
+        managed.subscribers = {stale_queue}
+        managed.add_message({"type": "assistant"})
+        assert stale_queue.get_nowait()["type"] == "_queue_overflow"
+        assert stale_queue not in managed.subscribers
+
+    @pytest.mark.asyncio
+    async def test_pending_question_lifecycle(self):
+        managed = ManagedSession(session_id="s1", client=object())
+        pending = managed.add_pending_question({"type": "ask_user_question", "questions": []})
+        assert pending.question_id
+        assert managed.resolve_pending_question(pending.question_id, {"Q": "A"})
+        assert await pending.answer_future == {"Q": "A"}
+        assert not managed.resolve_pending_question("missing", {})
+
+        pending2 = managed.add_pending_question({"type": "ask_user_question"})
+        managed.cancel_pending_questions("closed")
+        with pytest.raises(RuntimeError):
+            await pending2.answer_future
+        assert managed.get_pending_question_payloads() == []
+
+    @pytest.mark.asyncio
+    async def test_build_options_and_connect_paths(self, session_manager, meta_store, tmp_path, monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sm_mod, "SDK_AVAILABLE", False)
+            with pytest.raises(RuntimeError):
+                session_manager._build_options("demo")
+
+        projects_demo = tmp_path / "projects" / "demo"
+        projects_demo.mkdir(parents=True)
+        meta = meta_store.create("demo", "title")
+
+        with monkeypatch.context() as m:
+            m.setattr(sm_mod, "SDK_AVAILABLE", True)
+            m.setattr(sm_mod, "ClaudeAgentOptions", _FakeOptions)
+            m.setattr(sm_mod, "ClaudeSDKClient", _FakeClaudeClient)
+            m.setattr(sm_mod, "HookMatcher", None)
+            managed = await session_manager.get_or_connect(meta.id)
+            assert managed.client.connected
+            assert managed is await session_manager.get_or_connect(meta.id)
+
+        assert await session_manager._keep_stream_open_hook({}, None, None) == {"continue_": True}
+
+    def test_resolve_project_scope_and_status_helpers(self, session_manager, tmp_path, meta_store):
+        (tmp_path / "projects").mkdir(parents=True, exist_ok=True)
+        with pytest.raises(ValueError):
+            session_manager._resolve_project_cwd("../evil")
+
+        assert session_manager.get_status("missing") is None
+        meta = meta_store.create("demo", "title")
+        assert session_manager.get_status(meta.id) == "idle"
+
+    @pytest.mark.asyncio
+    async def test_send_message_and_interrupt_branches(self, session_manager, meta_store):
+        meta = meta_store.create("demo", "title")
+        managed_running = ManagedSession(session_id=meta.id, client=FakeSDKClient(), status="running")
+        session_manager.sessions[meta.id] = managed_running
+        with pytest.raises(ValueError):
+            await session_manager.send_message(meta.id, "blocked")
+
+        session_manager.sessions.pop(meta.id)
+        client = FakeSDKClient()
+
+        async def _boom(_content):
+            raise RuntimeError("query failed")
+
+        client.query = _boom  # type: ignore[method-assign]
+        managed = ManagedSession(session_id=meta.id, client=client, status="idle")
+        session_manager.sessions[meta.id] = managed
+        with pytest.raises(RuntimeError):
+            await session_manager.send_message(meta.id, "hello")
+        assert managed.status == "error"
+        assert meta_store.get(meta.id).status == "error"
+
+        with pytest.raises(FileNotFoundError):
+            await session_manager.interrupt_session("missing")
+
+        meta2 = meta_store.create("demo", "title2")
+        meta_store.update_status(meta2.id, "running")
+        assert await session_manager.interrupt_session(meta2.id) == "interrupted"
+        assert meta_store.get(meta2.id).status == "interrupted"
+
+        meta3 = meta_store.create("demo", "title3")
+        assert await session_manager.interrupt_session(meta3.id) == "idle"
+
+        managed_idle = ManagedSession(session_id=meta3.id, client=FakeSDKClient(), status="completed")
+        session_manager.sessions[meta3.id] = managed_idle
+        assert await session_manager.interrupt_session(meta3.id) == "completed"
+
+    @pytest.mark.asyncio
+    async def test_consume_messages_terminal_paths(self, session_manager, meta_store):
+        meta = meta_store.create("demo", "title")
+        managed_cancel = ManagedSession(session_id=meta.id, client=_CancelClient(), status="running")
+        session_manager.sessions[meta.id] = managed_cancel
+        meta_store.update_status(meta.id, "running")
+        with pytest.raises(asyncio.CancelledError):
+            await session_manager._consume_messages(managed_cancel)
+        assert managed_cancel.status == "interrupted"
+
+        meta2 = meta_store.create("demo", "title2")
+        managed_error = ManagedSession(session_id=meta2.id, client=_ErrorClient(), status="running")
+        session_manager.sessions[meta2.id] = managed_error
+        meta_store.update_status(meta2.id, "running")
+        with pytest.raises(RuntimeError):
+            await session_manager._consume_messages(managed_error)
+        assert managed_error.status == "error"
+
+    @pytest.mark.asyncio
+    async def test_can_use_tool_callback_branches(self, session_manager, monkeypatch):
+        monkeypatch.setattr(sm_mod, "PermissionResultAllow", _FakeAllow)
+        monkeypatch.setattr(sm_mod, "PermissionResultDeny", _FakeDeny)
+
+        allow_cb = session_manager._build_can_use_tool_callback("unknown-session")
+        result = await allow_cb("Read", {"x": 1}, None)
+        assert result.updated_input == {"x": 1}
+        result2 = await allow_cb("AskUserQuestion", {"questions": []}, None)
+        assert result2.updated_input == {"questions": []}
+
+        managed = ManagedSession(session_id="s1", client=FakeSDKClient(), status="running")
+        session_manager.sessions["s1"] = managed
+        ask_cb = session_manager._build_can_use_tool_callback("s1")
+
+        task = asyncio.create_task(ask_cb("AskUserQuestion", {"questions": [{"question": "Q"}]}, None))
+        await asyncio.sleep(0)
+        assert managed.pending_questions
+        managed.cancel_pending_questions("user interrupted")
+        deny = await task
+        assert deny.interrupt is True
+        assert "user interrupted" in deny.message
+
+    def test_misc_helpers_and_serialization(self, session_manager):
+        assert sm_mod.SessionManager._extract_plain_user_content({"type": "user", "content": " hi "}) == "hi"
+        assert sm_mod.SessionManager._extract_plain_user_content(
+            {"type": "user", "content": [{"type": "text", "text": " hello "}]}
+        ) == "hello"
+        assert sm_mod.SessionManager._extract_plain_user_content({"type": "assistant"}) is None
+
+        msg = {}
+        raw = SimpleNamespace(session_id="sdk-1")
+        assert session_manager._extract_sdk_session_id(raw, msg) == "sdk-1"
+        assert session_manager._extract_sdk_session_id(raw, {"sessionId": "sdk-2"}) == "sdk-2"
+
+        status = session_manager._build_runtime_status_message("error", "s1")
+        assert status["type"] == "runtime_status"
+        assert status["is_error"] is True
+
+        managed = ManagedSession(
+            session_id="s1",
+            client=object(),
+            message_buffer=[{"type": "stream_event"}, {"type": "assistant"}, {"type": "custom"}],
+        )
+        session_manager._prune_transient_buffer(managed)
+        assert managed.message_buffer == [{"type": "custom"}]
+        managed.clear_buffer()
+        assert managed.message_buffer == []
+
+        assert session_manager._resolve_result_status({"subtype": "error_timeout"}) == "error"
+        assert (
+            session_manager._resolve_result_status(
+                {"subtype": "success", "is_error": False},
+                interrupt_requested=True,
+            )
+            == "completed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_buffer_snapshots_subscribe_and_shutdown(self, session_manager, meta_store):
+        assert await session_manager.get_message_buffer_snapshot("missing") == []
+        assert session_manager.get_buffered_messages("missing") == []
+        assert await session_manager.get_pending_questions_snapshot("missing") == []
+        with pytest.raises(ValueError):
+            await session_manager.answer_user_question("missing", "q", {"a": "b"})
+
+        meta = meta_store.create("demo", "title")
+        client = _InterruptibleClient(disconnect_raises=True)
+        managed = ManagedSession(
+            session_id=meta.id,
+            client=client,
+            status="running",
+            message_buffer=[{"type": "assistant", "uuid": "a1"}],
+        )
+        managed.consumer_task = asyncio.create_task(asyncio.sleep(3600))
+        session_manager.sessions[meta.id] = managed
+
+        queue = await session_manager.subscribe(meta.id, replay_buffer=True)
+        assert queue.get_nowait()["uuid"] == "a1"
+        await session_manager.unsubscribe(meta.id, queue)
+        assert queue not in managed.subscribers
+
+        await session_manager.shutdown_gracefully(timeout=0.01)
+        assert client.interrupted is True
+        assert session_manager.sessions == {}

--- a/tests/test_status_calculator.py
+++ b/tests/test_status_calculator.py
@@ -1,0 +1,139 @@
+from pathlib import Path
+
+from lib.status_calculator import StatusCalculator
+
+
+class _FakePM:
+    def __init__(self, project_root: Path, project: dict, scripts: dict[str, dict]):
+        self._project_root = project_root
+        self._project = project
+        self._scripts = scripts
+
+    def load_project(self, project_name: str):
+        return self._project
+
+    def get_project_path(self, project_name: str):
+        return self._project_root / project_name
+
+    def load_script(self, project_name: str, filename: str):
+        if filename not in self._scripts:
+            raise FileNotFoundError(filename)
+        return self._scripts[filename]
+
+
+class TestStatusCalculator:
+    def test_select_content_mode_and_items(self):
+        mode, items = StatusCalculator._select_content_mode_and_items(
+            {"content_mode": "narration", "segments": [{"segment_id": "E1S01"}]}
+        )
+        assert mode == "narration"
+        assert len(items) == 1
+
+        mode2, items2 = StatusCalculator._select_content_mode_and_items({"scenes": [{"scene_id": "E1S01"}]})
+        assert mode2 == "drama"
+        assert len(items2) == 1
+
+    def test_calculate_episode_stats_statuses(self, tmp_path):
+        calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
+
+        draft = calc.calculate_episode_stats("demo", {"content_mode": "narration", "segments": [{"duration_seconds": 4}]})
+        in_prod = calc.calculate_episode_stats(
+            "demo",
+            {
+                "content_mode": "narration",
+                "segments": [{"generated_assets": {"storyboard_image": "a.png"}, "duration_seconds": 6}],
+            },
+        )
+        completed = calc.calculate_episode_stats(
+            "demo",
+            {
+                "content_mode": "drama",
+                "scenes": [{"generated_assets": {"video_clip": "a.mp4"}, "duration_seconds": 8}],
+            },
+        )
+
+        assert draft["status"] == "draft"
+        assert in_prod["status"] == "in_production"
+        assert completed["status"] == "completed"
+
+    def test_calculate_project_progress_and_phase(self, tmp_path):
+        project_root = tmp_path / "projects"
+        project_path = project_root / "demo"
+        project_path.mkdir(parents=True)
+
+        (project_path / "characters").mkdir(parents=True)
+        (project_path / "clues").mkdir(parents=True)
+        (project_path / "characters" / "A.png").write_bytes(b"ok")
+        (project_path / "clues" / "C.png").write_bytes(b"ok")
+
+        project = {
+            "characters": {"A": {"character_sheet": "characters/A.png"}, "B": {"character_sheet": ""}},
+            "clues": {
+                "C": {"importance": "major", "clue_sheet": "clues/C.png"},
+                "D": {"importance": "minor", "clue_sheet": ""},
+            },
+            "episodes": [
+                {"script_file": "scripts/episode_1.json"},
+                {"script_file": "scripts/missing.json"},
+            ],
+        }
+        scripts = {
+            "episode_1.json": {
+                "content_mode": "narration",
+                "segments": [
+                    {
+                        "segment_id": "E1S01",
+                        "duration_seconds": 4,
+                        "generated_assets": {
+                            "storyboard_image": "storyboards/scene_E1S01.png",
+                            "video_clip": "videos/scene_E1S01.mp4",
+                        },
+                    }
+                ],
+            }
+        }
+
+        calc = StatusCalculator(_FakePM(project_root, project, scripts))
+        progress = calc.calculate_project_progress("demo")
+
+        assert progress["characters"] == {"total": 2, "completed": 1}
+        assert progress["clues"] == {"total": 1, "completed": 1}
+        assert progress["storyboards"]["completed"] == 1
+        assert progress["videos"]["completed"] == 1
+        assert calc.calculate_current_phase(progress) == "compose"
+
+    def test_enrich_project_and_enrich_script(self, tmp_path):
+        project_root = tmp_path / "projects"
+        project_root.mkdir(parents=True)
+        project = {
+            "episodes": [
+                {"script_file": "scripts/episode_1.json"},
+                {"script_file": "scripts/missing.json"},
+            ],
+            "characters": {},
+            "clues": {},
+        }
+        script = {
+            "content_mode": "narration",
+            "segments": [
+                {
+                    "segment_id": "E1S01",
+                    "duration_seconds": 6,
+                    "characters_in_segment": ["A", "B"],
+                    "clues_in_segment": ["C"],
+                    "generated_assets": {},
+                }
+            ],
+        }
+        calc = StatusCalculator(_FakePM(project_root, project, {"episode_1.json": script}))
+
+        enriched_project = calc.enrich_project("demo", {**project})
+        assert "status" in enriched_project
+        assert enriched_project["episodes"][0]["scenes_count"] == 1
+        assert enriched_project["episodes"][1]["status"] == "missing"
+
+        enriched_script = calc.enrich_script({**script})
+        assert enriched_script["metadata"]["total_scenes"] == 1
+        assert enriched_script["metadata"]["estimated_duration_seconds"] == 6
+        assert enriched_script["characters_in_episode"] == ["A", "B"]
+        assert enriched_script["clues_in_episode"] == ["C"]

--- a/tests/test_stream_projector_more.py
+++ b/tests/test_stream_projector_more.py
@@ -1,0 +1,148 @@
+from webui.server.agent_runtime import stream_projector as projector_mod
+
+
+class TestStreamProjectorMore:
+    def test_helpers_and_non_groupable_paths(self):
+        assert projector_mod._coerce_index(True) is None
+        assert projector_mod._coerce_index(3) == 3
+        assert projector_mod._coerce_index(" 4 ") == 4
+        assert projector_mod._coerce_index("x") is None
+        assert projector_mod._safe_json_parse('{"a":1}') == {"a": 1}
+        assert projector_mod._safe_json_parse("{bad}") is None
+
+        projector = projector_mod.AssistantStreamProjector()
+        # non-dict message is ignored
+        update = projector.apply_message("not-a-dict")  # type: ignore[arg-type]
+        assert update == {"patch": None, "delta": None, "question": None}
+
+        question = {"type": "ask_user_question", "question_id": "aq-1", "questions": []}
+        update = projector.apply_message(question)
+        assert update["question"]["question_id"] == "aq-1"
+
+    def test_draft_projector_stream_event_delta_variants(self):
+        draft = projector_mod.DraftAssistantProjector()
+
+        # Invalid payload is ignored
+        assert draft.apply_stream_event({"event": "bad"}) is None
+
+        # start + block start fallback to default text block
+        assert (
+            draft.apply_stream_event(
+                {
+                    "session_id": "sdk-1",
+                    "event": {"type": "message_start"},
+                }
+            )
+            is None
+        )
+        assert (
+            draft.apply_stream_event(
+                {
+                    "session_id": "sdk-1",
+                    "event": {"type": "content_block_start", "index": "0", "content_block": None},
+                }
+            )
+            is None
+        )
+
+        # empty text chunk ignored
+        assert (
+            draft.apply_stream_event(
+                {
+                    "session_id": "sdk-1",
+                    "event": {
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {"type": "text_delta", "text": ""},
+                    },
+                }
+            )
+            is None
+        )
+
+        # text delta
+        text_delta = draft.apply_stream_event(
+            {
+                "session_id": "sdk-1",
+                "event": {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "Hello"},
+                },
+            }
+        )
+        assert text_delta["delta_type"] == "text_delta"
+        assert text_delta["text"] == "Hello"
+
+        # tool_use json delta: first incomplete then complete
+        first_json = draft.apply_stream_event(
+            {
+                "session_id": "sdk-1",
+                "event": {
+                    "type": "content_block_delta",
+                    "index": "1",
+                    "delta": {"type": "input_json_delta", "partial_json": '{"a":'},
+                },
+            }
+        )
+        assert first_json["delta_type"] == "input_json_delta"
+        second_json = draft.apply_stream_event(
+            {
+                "session_id": "sdk-1",
+                "event": {
+                    "type": "content_block_delta",
+                    "index": "1",
+                    "delta": {"type": "input_json_delta", "partial_json": "1}"},
+                },
+            }
+        )
+        assert second_json["delta_type"] == "input_json_delta"
+
+        # thinking delta
+        thinking_delta = draft.apply_stream_event(
+            {
+                "session_id": "sdk-1",
+                "event": {
+                    "type": "content_block_delta",
+                    "index": 2,
+                    "delta": {"type": "thinking_delta", "thinking": "hmm"},
+                },
+            }
+        )
+        assert thinking_delta["delta_type"] == "thinking_delta"
+        assert thinking_delta["thinking"] == "hmm"
+
+        # unknown delta type -> ignored
+        assert (
+            draft.apply_stream_event(
+                {
+                    "session_id": "sdk-1",
+                    "event": {
+                        "type": "content_block_delta",
+                        "index": 3,
+                        "delta": {"type": "other"},
+                    },
+                }
+            )
+            is None
+        )
+
+        turn = draft.build_turn()
+        assert turn is not None
+        assert turn["uuid"] == "draft-sdk-1"
+        assert len(turn["content"]) >= 2
+
+    def test_draft_build_turn_visibility_rules(self):
+        draft = projector_mod.DraftAssistantProjector()
+        assert draft.build_turn() is None
+
+        draft._blocks_by_index[0] = {"type": "text", "text": "   "}
+        assert draft.build_turn() is None
+
+        draft._blocks_by_index[0] = {"type": "thinking", "thinking": "  "}
+        assert draft.build_turn() is None
+
+        draft._blocks_by_index[1] = {"type": "tool_use", "input": {}}
+        visible = draft.build_turn()
+        assert visible is not None
+        assert visible["type"] == "assistant"

--- a/tests/test_tasks_router_more.py
+++ b/tests/test_tasks_router_more.py
@@ -1,0 +1,151 @@
+import asyncio
+import json
+import itertools
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from webui.server.routers import tasks as tasks_router
+
+
+class _FakeRequest:
+    def __init__(self, disconnect_after: int):
+        self._calls = 0
+        self._disconnect_after = disconnect_after
+
+    async def is_disconnected(self):
+        self._calls += 1
+        return self._calls > self._disconnect_after
+
+
+class _FakeQueue:
+    def __init__(self, *, latest=0, snapshot=None, stats=None, events=None, task=None):
+        self.latest = latest
+        self.snapshot = snapshot or []
+        self.stats = stats or {"pending": 0}
+        self.events = list(events or [])
+        self.task = task
+        self.cursors = []
+
+    def get_latest_event_id(self, project_name=None):
+        return self.latest
+
+    def get_recent_tasks_snapshot(self, project_name=None, limit=1000):
+        return self.snapshot
+
+    def get_task_stats(self, project_name=None):
+        return self.stats
+
+    def get_events_since(self, last_event_id, project_name=None, limit=200):
+        self.cursors.append(last_event_id)
+        if self.events:
+            events = self.events
+            self.events = []
+            return events
+        return []
+
+    def get_task(self, task_id):
+        return self.task
+
+
+def _decode_sse(chunk):
+    text = chunk.decode("utf-8") if isinstance(chunk, (bytes, bytearray)) else str(chunk)
+    event = ""
+    event_id = None
+    payload = None
+    for line in text.splitlines():
+        if line.startswith("event: "):
+            event = line[len("event: "):]
+        elif line.startswith("id: "):
+            event_id = int(line[len("id: "):])
+        elif line.startswith("data: "):
+            payload = json.loads(line[len("data: "):])
+    return event, event_id, payload
+
+
+class TestTasksRouterMore:
+    def test_parse_last_event_id_and_format(self):
+        assert tasks_router._parse_last_event_id(None) is None
+        assert tasks_router._parse_last_event_id("  ") is None
+        assert tasks_router._parse_last_event_id("oops") is None
+        assert tasks_router._parse_last_event_id("-10") == 0
+        assert tasks_router._parse_last_event_id("7") == 7
+
+        sse = tasks_router._format_sse("task", {"x": 1}, event_id=12)
+        assert "id: 12" in sse
+        assert "event: task" in sse
+        assert 'data: {"x": 1}' in sse
+
+    @pytest.mark.asyncio
+    async def test_stream_tasks_emits_snapshot_and_task_event(self, monkeypatch):
+        queue = _FakeQueue(
+            latest=10,
+            snapshot=[{"task_id": "t1"}],
+            stats={"running": 1},
+            events=[{"id": 11, "event_type": "updated", "task_id": "t1"}],
+        )
+        monkeypatch.setattr(tasks_router, "get_task_queue", lambda: queue)
+        monkeypatch.setattr(tasks_router, "read_queue_poll_interval", lambda: 0.0)
+
+        request = _FakeRequest(disconnect_after=2)
+        response = await tasks_router.stream_tasks(
+            request=request,
+            project_name="demo",
+            last_event_id=None,
+            last_event_header=" 7 ",
+        )
+
+        chunks = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk)
+
+        assert len(chunks) >= 2
+        snapshot_event, _, snapshot_payload = _decode_sse(chunks[0])
+        assert snapshot_event == "snapshot"
+        assert snapshot_payload["last_event_id"] == 10
+        assert snapshot_payload["stats"]["running"] == 1
+
+        task_event, event_id, task_payload = _decode_sse(chunks[1])
+        assert task_event == "task"
+        assert event_id == 11
+        assert task_payload["task_id"] == "t1"
+        assert queue.cursors[0] == 10
+
+    @pytest.mark.asyncio
+    async def test_stream_tasks_emits_heartbeat_when_idle(self, monkeypatch):
+        queue = _FakeQueue(latest=0)
+        monkeypatch.setattr(tasks_router, "get_task_queue", lambda: queue)
+        monkeypatch.setattr(tasks_router, "read_queue_poll_interval", lambda: 0.0)
+        monkeypatch.setattr(tasks_router, "TASK_SSE_HEARTBEAT_SEC", 5)
+
+        monotonic_values = itertools.chain([0.0, 10.0, 10.0, 11.0], itertools.repeat(11.0))
+        monkeypatch.setattr(tasks_router.time, "monotonic", lambda: next(monotonic_values))
+
+        request = _FakeRequest(disconnect_after=1)
+        response = await tasks_router.stream_tasks(
+            request=request,
+            project_name="demo",
+            last_event_id=0,
+            last_event_header=None,
+        )
+
+        chunks = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk)
+
+        assert len(chunks) >= 2
+        assert _decode_sse(chunks[0])[0] == "snapshot"
+        heartbeat_event, _, heartbeat_payload = _decode_sse(chunks[1])
+        assert heartbeat_event == "heartbeat"
+        assert heartbeat_payload["last_event_id"] == 0
+
+    def test_get_task_not_found(self, monkeypatch):
+        monkeypatch.setattr(tasks_router, "get_task_queue", lambda: _FakeQueue(task=None))
+        app = FastAPI()
+        app.include_router(tasks_router.router, prefix="/api/v1")
+
+        with TestClient(app) as client:
+            resp = client.get("/api/v1/tasks/missing-task")
+            assert resp.status_code == 404
+            assert "不存在" in resp.json()["detail"]

--- a/tests/test_usage_router.py
+++ b/tests/test_usage_router.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from webui.server.routers import usage
+
+
+class _FakeTracker:
+    def get_stats(self, **kwargs):
+        return {"total_cost": 1.2, "image_count": 1, "video_count": 2, "failed_count": 0, "total_count": 3}
+
+    def get_calls(self, **kwargs):
+        return {"items": [{"id": 1}], "total": 1, "page": kwargs["page"], "page_size": kwargs["page_size"]}
+
+    def get_projects_list(self):
+        return ["demo", "demo2"]
+
+
+def _client(monkeypatch):
+    monkeypatch.setattr(usage, "get_usage_tracker", lambda: _FakeTracker())
+    app = FastAPI()
+    app.include_router(usage.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+class TestUsageRouter:
+    def test_usage_endpoints(self, monkeypatch):
+        with _client(monkeypatch) as client:
+            stats = client.get("/api/v1/usage/stats?project_name=demo&start_date=2026-02-01&end_date=2026-02-10")
+            assert stats.status_code == 200
+            assert stats.json()["total_count"] == 3
+
+            calls = client.get("/api/v1/usage/calls?page=2&page_size=10")
+            assert calls.status_code == 200
+            assert calls.json()["page"] == 2
+            assert calls.json()["page_size"] == 10
+
+            projects = client.get("/api/v1/usage/projects")
+            assert projects.status_code == 200
+            assert projects.json()["projects"] == ["demo", "demo2"]

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -1,0 +1,95 @@
+from datetime import datetime, timedelta
+
+from lib.usage_tracker import UsageTracker
+
+
+class TestUsageTracker:
+    def test_start_and_finish_image_call_success(self, tmp_path):
+        tracker = UsageTracker(tmp_path / "usage.db")
+
+        call_id = tracker.start_call(
+            project_name="demo",
+            call_type="image",
+            model="gemini-3-pro-image-preview",
+            prompt="x" * 700,
+            resolution="2K",
+        )
+        tracker.finish_call(call_id, status="success", output_path="a.png")
+
+        result = tracker.get_calls(project_name="demo")
+        item = result["items"][0]
+        assert item["id"] == call_id
+        assert item["status"] == "success"
+        assert item["cost_usd"] == 0.134
+        assert len(item["prompt"]) == 500
+
+    def test_finish_video_and_failed_call(self, tmp_path):
+        tracker = UsageTracker(tmp_path / "usage.db")
+
+        video_id = tracker.start_call(
+            project_name="demo",
+            call_type="video",
+            model="veo-3.1-generate-preview",
+            resolution="4k",
+            duration_seconds=6,
+            generate_audio=False,
+        )
+        fail_id = tracker.start_call(
+            project_name="demo",
+            call_type="image",
+            model="gemini-3-pro-image-preview",
+            resolution="1K",
+        )
+
+        tracker.finish_call(video_id, status="success", output_path="v.mp4")
+        tracker.finish_call(fail_id, status="failed", error_message="e" * 700)
+
+        stats = tracker.get_stats(project_name="demo")
+        assert stats["video_count"] == 1
+        assert stats["failed_count"] == 1
+        assert stats["total_count"] == 2
+        assert stats["total_cost"] == 2.4
+
+        failed = tracker.get_calls(status="failed")["items"][0]
+        assert len(failed["error_message"]) == 500
+        assert failed["cost_usd"] == 0
+
+    def test_stats_with_date_range_and_project_filter(self, tmp_path):
+        tracker = UsageTracker(tmp_path / "usage.db")
+
+        tracker.finish_call(
+            tracker.start_call("p1", "image", "m", resolution="1K"),
+            status="success",
+        )
+        tracker.finish_call(
+            tracker.start_call("p2", "video", "m", resolution="1080p", duration_seconds=4),
+            status="success",
+        )
+
+        today = datetime.now()
+        stats_all = tracker.get_stats(start_date=today - timedelta(days=1), end_date=today)
+        stats_p1 = tracker.get_stats(project_name="p1", start_date=today - timedelta(days=1), end_date=today)
+
+        assert stats_all["total_count"] == 2
+        assert stats_p1["total_count"] == 1
+        assert stats_p1["image_count"] == 1
+
+    def test_get_calls_pagination_and_projects_list(self, tmp_path):
+        tracker = UsageTracker(tmp_path / "usage.db")
+
+        for idx in range(5):
+            call_id = tracker.start_call(
+                project_name="demo-a" if idx % 2 == 0 else "demo-b",
+                call_type="image",
+                model="m",
+            )
+            tracker.finish_call(call_id, status="success")
+
+        page1 = tracker.get_calls(page=1, page_size=2)
+        page2 = tracker.get_calls(page=2, page_size=2)
+        assert page1["total"] == 5
+        assert len(page1["items"]) == 2
+        assert len(page2["items"]) == 2
+
+        projects = tracker.get_projects_list()
+        assert projects == ["demo-a", "demo-b"]

--- a/tests/test_version_manager_more.py
+++ b/tests/test_version_manager_more.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+import pytest
+
+from lib.version_manager import VersionManager, _get_versions_file_lock
+
+
+class TestVersionManagerMore:
+    def test_lock_is_reused_for_same_file(self, tmp_path):
+        file_a = tmp_path / "a" / "versions.json"
+        file_a.parent.mkdir(parents=True)
+        lock1 = _get_versions_file_lock(file_a)
+        lock2 = _get_versions_file_lock(file_a)
+        assert lock1 is lock2
+
+    def test_get_versions_invalid_type_and_helpers(self, tmp_path):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+
+        with pytest.raises(ValueError):
+            vm.get_versions("bad", "x")
+
+        assert vm.get_current_version("characters", "Alice") == 0
+        assert vm.get_version_file_url("characters", "Alice", 1) is None
+        assert vm.get_version_prompt("characters", "Alice", 1) is None
+        assert vm.has_versions("characters", "Alice") is False
+
+    def test_add_backup_restore_paths(self, tmp_path):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+
+        current = project / "characters" / "Alice.png"
+        current.parent.mkdir(parents=True, exist_ok=True)
+        current.write_bytes(b"png-v1")
+
+        assert vm.backup_current("characters", "Alice", current, "p1") == 1
+        assert vm.ensure_current_tracked("characters", "Alice", current, "p2") is None
+
+        # create v2
+        current.write_bytes(b"png-v2")
+        assert vm.add_version("characters", "Alice", "p2", source_file=current) == 2
+
+        info = vm.get_versions("characters", "Alice")
+        assert info["current_version"] == 2
+        assert len(info["versions"]) == 2
+        assert vm.get_version_file_url("characters", "Alice", 2)
+        assert vm.get_version_prompt("characters", "Alice", 2) == "p2"
+        assert vm.has_versions("characters", "Alice")
+
+        restored = vm.restore_version("characters", "Alice", 1, current)
+        assert restored["restored_version"] == 1
+        assert restored["new_current_version"] == 3
+
+    def test_restore_errors_and_missing_current(self, tmp_path):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+        current = project / "characters" / "Alice.png"
+
+        assert vm.backup_current("characters", "Alice", current, "p") is None
+        assert vm.ensure_current_tracked("characters", "Alice", current, "p") is None
+
+        current.parent.mkdir(parents=True, exist_ok=True)
+        current.write_bytes(b"png")
+        with pytest.raises(ValueError):
+            vm.ensure_current_tracked("bad", "Alice", current, "p")
+
+        with pytest.raises(ValueError):
+            vm.restore_version("characters", "missing", 1, current)
+
+        # create record and delete version file to hit FileNotFoundError branch
+        vm.add_version("characters", "Alice", "p", source_file=current)
+        version_file = project / vm.get_versions("characters", "Alice")["versions"][0]["file"]
+        version_file.unlink()
+
+        with pytest.raises(FileNotFoundError):
+            vm.restore_version("characters", "Alice", 1, current)
+
+        with pytest.raises(ValueError):
+            vm.restore_version("characters", "Alice", 99, current)

--- a/tests/test_versions_router.py
+++ b/tests/test_versions_router.py
@@ -1,0 +1,138 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from webui.server.routers import versions
+
+
+class _FakePM:
+    def __init__(self):
+        self.updated = []
+
+    def get_project_path(self, project_name):
+        from pathlib import Path
+
+        return Path("/tmp") / project_name
+
+    def update_project_character_sheet(self, *args):
+        self.updated.append(("character", args))
+
+    def update_clue_sheet(self, *args):
+        self.updated.append(("clue", args))
+
+    def update_scene_asset(self, *args, **kwargs):
+        self.updated.append(("scene", args, kwargs))
+
+
+class _FakeVM:
+    def __init__(self, project_path=None):
+        self.project_path = project_path
+
+    def get_versions(self, resource_type, resource_id):
+        if resource_type == "bad":
+            raise ValueError("bad type")
+        return {
+            "current_version": 1,
+            "versions": [{"version": 1, "file": f"versions/{resource_type}/{resource_id}.png"}],
+        }
+
+    def restore_version(self, resource_type, resource_id, version, current_file):
+        if version == 404:
+            raise FileNotFoundError("missing")
+        if version == 400:
+            raise ValueError("bad")
+        return {
+            "restored_version": version,
+            "new_current_version": version + 1,
+            "prompt": "p",
+        }
+
+
+class _StoryboardSyncPM:
+    def __init__(self, project_path):
+        self.project_path = project_path
+        self.update_calls = []
+
+    def get_project_path(self, project_name):
+        return self.project_path
+
+    def update_scene_asset(self, project_name, script_filename, scene_id, asset_type, asset_path):
+        self.update_calls.append(script_filename)
+        if script_filename == "a.json":
+            raise KeyError("missing scene")
+        if script_filename == "b.json":
+            raise RuntimeError("bad script")
+
+
+def _client(monkeypatch):
+    fake_pm = _FakePM()
+    monkeypatch.setattr(versions, "get_project_manager", lambda: fake_pm)
+    monkeypatch.setattr(versions, "get_version_manager", lambda project_name: _FakeVM())
+
+    app = FastAPI()
+    app.include_router(versions.router, prefix="/api/v1")
+    return TestClient(app), fake_pm
+
+
+class TestVersionsRouter:
+    def test_get_versions_and_restore(self, monkeypatch):
+        client, fake_pm = _client(monkeypatch)
+        with client:
+            get_resp = client.get("/api/v1/projects/demo/versions/characters/Alice")
+            assert get_resp.status_code == 200
+            assert get_resp.json()["current_version"] == 1
+
+            restore_resp = client.post("/api/v1/projects/demo/versions/characters/Alice/restore/1")
+            assert restore_resp.status_code == 200
+            assert restore_resp.json()["new_current_version"] == 2
+            assert any(item[0] == "character" for item in fake_pm.updated)
+
+    def test_restore_error_mapping(self, monkeypatch):
+        client, _ = _client(monkeypatch)
+        with client:
+            bad_type = client.get("/api/v1/projects/demo/versions/bad/Alice")
+            assert bad_type.status_code == 400
+
+            not_found = client.post("/api/v1/projects/demo/versions/characters/Alice/restore/404")
+            assert not_found.status_code == 404
+
+            bad_value = client.post("/api/v1/projects/demo/versions/characters/Alice/restore/400")
+            assert bad_value.status_code == 400
+
+            unsupported = client.post("/api/v1/projects/demo/versions/unknown/Alice/restore/1")
+            assert unsupported.status_code == 400
+
+    def test_storyboard_restore_syncs_scripts_with_error_tolerance(self, tmp_path, monkeypatch):
+        project_path = tmp_path / "demo"
+        scripts_dir = project_path / "scripts"
+        scripts_dir.mkdir(parents=True)
+        for name in ("a.json", "b.json", "c.json"):
+            (scripts_dir / name).write_text("{}", encoding="utf-8")
+
+        fake_pm = _StoryboardSyncPM(project_path)
+        monkeypatch.setattr(versions, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(versions, "get_version_manager", lambda project_name: _FakeVM())
+
+        app = FastAPI()
+        app.include_router(versions.router, prefix="/api/v1")
+        with TestClient(app) as client:
+            resp = client.post("/api/v1/projects/demo/versions/storyboards/E1S01/restore/1")
+            assert resp.status_code == 200
+            assert resp.json()["file_path"] == "storyboards/scene_E1S01.png"
+
+        assert sorted(fake_pm.update_calls) == ["a.json", "b.json", "c.json"]
+
+    def test_get_versions_unexpected_error_maps_to_500(self, monkeypatch):
+        fake_pm = _FakePM()
+        monkeypatch.setattr(versions, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(
+            versions,
+            "get_version_manager",
+            lambda project_name: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+
+        app = FastAPI()
+        app.include_router(versions.router, prefix="/api/v1")
+        with TestClient(app) as client:
+            resp = client.get("/api/v1/projects/demo/versions/characters/Alice")
+            assert resp.status_code == 500
+            assert "boom" in resp.json()["detail"]

--- a/webui/server/app.py
+++ b/webui/server/app.py
@@ -120,6 +120,10 @@ def _serve_frontend_index():
     )
 
 
+def create_generation_worker() -> GenerationWorker:
+    return GenerationWorker()
+
+
 @app.get("/", include_in_schema=False)
 async def serve_root():
     """服务 React 前端入口"""
@@ -144,7 +148,7 @@ async def health_check():
 async def startup_generation_worker():
     """启动任务 worker（单活由 lease 控制）。"""
     logger.info("启动 GenerationWorker...")
-    worker = GenerationWorker()
+    worker = create_generation_worker()
     app.state.generation_worker = worker
     await worker.start()
     logger.info("GenerationWorker 已启动")

--- a/webui/server/routers/assistant.py
+++ b/webui/server/routers/assistant.py
@@ -20,6 +20,10 @@ project_root = Path(__file__).parent.parent.parent.parent
 assistant_service = AssistantService(project_root=project_root)
 
 
+def get_assistant_service() -> AssistantService:
+    return assistant_service
+
+
 class CreateSessionRequest(BaseModel):
     project_name: str = Field(min_length=1)
     title: Optional[str] = ""
@@ -40,10 +44,13 @@ class UpdateSessionRequest(BaseModel):
 @router.post("/sessions")
 async def create_session(req: CreateSessionRequest):
     try:
-        session = await assistant_service.create_session(req.project_name, req.title or "")
+        service = get_assistant_service()
+        session = await service.create_session(req.project_name, req.title or "")
         return {"id": session.id, "status": session.status, "created_at": session.created_at}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{req.project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(exc))
@@ -57,10 +64,12 @@ async def list_sessions(
     offset: int = Query(default=0, ge=0),
 ):
     try:
-        sessions = assistant_service.list_sessions(
+        sessions = get_assistant_service().list_sessions(
             project_name=project_name, status=status, limit=limit, offset=offset
         )
         return {"sessions": [s.model_dump() for s in sessions]}
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(exc))
@@ -69,7 +78,7 @@ async def list_sessions(
 @router.get("/sessions/{session_id}")
 async def get_session(session_id: str):
     try:
-        session = assistant_service.get_session(session_id)
+        session = get_assistant_service().get_session(session_id)
         if session is None:
             raise HTTPException(status_code=404, detail=f"会话 '{session_id}' 不存在")
         return session.model_dump()
@@ -83,7 +92,7 @@ async def get_session(session_id: str):
 @router.patch("/sessions/{session_id}")
 async def update_session(session_id: str, req: UpdateSessionRequest):
     try:
-        session = assistant_service.update_session_title(session_id, req.title)
+        session = get_assistant_service().update_session_title(session_id, req.title)
         if session is None:
             raise HTTPException(status_code=404, detail=f"会话 '{session_id}' 不存在")
         return {"success": True, "session": session.model_dump()}
@@ -99,7 +108,7 @@ async def update_session(session_id: str, req: UpdateSessionRequest):
 @router.delete("/sessions/{session_id}")
 async def delete_session(session_id: str):
     try:
-        deleted = await assistant_service.delete_session(session_id)
+        deleted = await get_assistant_service().delete_session(session_id)
         if not deleted:
             raise HTTPException(status_code=404, detail=f"会话 '{session_id}' 不存在")
         return {"success": True}
@@ -121,10 +130,12 @@ async def list_messages(session_id: str):
 @router.get("/sessions/{session_id}/snapshot")
 async def get_snapshot(session_id: str):
     try:
-        snapshot = await assistant_service.get_snapshot(session_id)
+        snapshot = await get_assistant_service().get_snapshot(session_id)
         return snapshot
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"会话 '{session_id}' 不存在")
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(exc))
@@ -133,12 +144,14 @@ async def get_snapshot(session_id: str):
 @router.post("/sessions/{session_id}/messages")
 async def send_message(session_id: str, req: SendMessageRequest):
     try:
-        result = await assistant_service.send_message(session_id, req.content)
+        result = await get_assistant_service().send_message(session_id, req.content)
         return result
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"会话 '{session_id}' 不存在")
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(exc))
@@ -147,12 +160,14 @@ async def send_message(session_id: str, req: SendMessageRequest):
 @router.post("/sessions/{session_id}/interrupt")
 async def interrupt_session(session_id: str):
     try:
-        result = await assistant_service.interrupt_session(session_id)
+        result = await get_assistant_service().interrupt_session(session_id)
         return result
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"会话 '{session_id}' 不存在")
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(exc))
@@ -163,7 +178,7 @@ async def answer_question(session_id: str, question_id: str, req: AnswerQuestion
     if not req.answers:
         raise HTTPException(status_code=400, detail="answers 不能为空")
     try:
-        result = await assistant_service.answer_user_question(
+        result = await get_assistant_service().answer_user_question(
             session_id=session_id,
             question_id=question_id,
             answers=req.answers,
@@ -173,6 +188,8 @@ async def answer_question(session_id: str, question_id: str, req: AnswerQuestion
         raise HTTPException(status_code=404, detail=f"会话 '{session_id}' 不存在")
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(exc))
@@ -181,12 +198,13 @@ async def answer_question(session_id: str, question_id: str, req: AnswerQuestion
 @router.get("/sessions/{session_id}/stream")
 async def stream_events(session_id: str):
     try:
-        session = assistant_service.get_session(session_id)
+        service = get_assistant_service()
+        session = service.get_session(session_id)
         if session is None:
             raise HTTPException(status_code=404, detail=f"会话 '{session_id}' 不存在")
 
         return StreamingResponse(
-            assistant_service.stream_events(session_id),
+            service.stream_events(session_id),
             media_type="text/event-stream; charset=utf-8",
             headers={
                 "Cache-Control": "no-cache",
@@ -204,10 +222,12 @@ async def stream_events(session_id: str):
 @router.get("/skills")
 async def list_skills(project_name: Optional[str] = None):
     try:
-        skills = assistant_service.list_available_skills(project_name=project_name)
+        skills = get_assistant_service().list_available_skills(project_name=project_name)
         return {"skills": skills}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(exc))

--- a/webui/server/routers/characters.py
+++ b/webui/server/routers/characters.py
@@ -20,6 +20,10 @@ project_root = Path(__file__).parent.parent.parent.parent
 pm = ProjectManager(project_root / "projects")
 
 
+def get_project_manager() -> ProjectManager:
+    return pm
+
+
 class CreateCharacterRequest(BaseModel):
     name: str
     description: str
@@ -37,12 +41,14 @@ class UpdateCharacterRequest(BaseModel):
 async def add_character(project_name: str, req: CreateCharacterRequest):
     """添加人物"""
     try:
-        project = pm.add_project_character(
+        project = get_project_manager().add_project_character(
             project_name, req.name, req.description, req.voice_style
         )
         return {"success": True, "character": project["characters"][req.name]}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -54,7 +60,8 @@ async def update_character(
 ):
     """更新人物"""
     try:
-        project = pm.load_project(project_name)
+        manager = get_project_manager()
+        project = manager.load_project(project_name)
 
         if char_name not in project["characters"]:
             raise HTTPException(status_code=404, detail=f"人物 '{char_name}' 不存在")
@@ -69,10 +76,12 @@ async def update_character(
         if req.reference_image is not None:
             char["reference_image"] = req.reference_image
 
-        pm.save_project(project_name, project)
+        manager.save_project(project_name, project)
         return {"success": True, "character": char}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -82,16 +91,19 @@ async def update_character(
 async def delete_character(project_name: str, char_name: str):
     """删除人物"""
     try:
-        project = pm.load_project(project_name)
+        manager = get_project_manager()
+        project = manager.load_project(project_name)
 
         if char_name not in project["characters"]:
             raise HTTPException(status_code=404, detail=f"人物 '{char_name}' 不存在")
 
         del project["characters"][char_name]
-        pm.save_project(project_name, project)
+        manager.save_project(project_name, project)
         return {"success": True, "message": f"人物 '{char_name}' 已删除"}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))

--- a/webui/server/routers/clues.py
+++ b/webui/server/routers/clues.py
@@ -19,6 +19,10 @@ project_root = Path(__file__).parent.parent.parent.parent
 pm = ProjectManager(project_root / "projects")
 
 
+def get_project_manager() -> ProjectManager:
+    return pm
+
+
 class CreateClueRequest(BaseModel):
     name: str
     clue_type: str  # 'prop' 或 'location'
@@ -37,7 +41,7 @@ class UpdateClueRequest(BaseModel):
 async def add_clue(project_name: str, req: CreateClueRequest):
     """添加线索"""
     try:
-        project = pm.add_clue(
+        project = get_project_manager().add_clue(
             project_name,
             req.name,
             req.clue_type,
@@ -49,6 +53,8 @@ async def add_clue(project_name: str, req: CreateClueRequest):
         raise HTTPException(status_code=400, detail=str(e))
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -58,7 +64,8 @@ async def add_clue(project_name: str, req: CreateClueRequest):
 async def update_clue(project_name: str, clue_name: str, req: UpdateClueRequest):
     """更新线索"""
     try:
-        project = pm.load_project(project_name)
+        manager = get_project_manager()
+        project = manager.load_project(project_name)
 
         if clue_name not in project["clues"]:
             raise HTTPException(status_code=404, detail=f"线索 '{clue_name}' 不存在")
@@ -77,10 +84,12 @@ async def update_clue(project_name: str, clue_name: str, req: UpdateClueRequest)
         if req.clue_sheet is not None:
             clue["clue_sheet"] = req.clue_sheet
 
-        pm.save_project(project_name, project)
+        manager.save_project(project_name, project)
         return {"success": True, "clue": clue}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -90,16 +99,19 @@ async def update_clue(project_name: str, clue_name: str, req: UpdateClueRequest)
 async def delete_clue(project_name: str, clue_name: str):
     """删除线索"""
     try:
-        project = pm.load_project(project_name)
+        manager = get_project_manager()
+        project = manager.load_project(project_name)
 
         if clue_name not in project["clues"]:
             raise HTTPException(status_code=404, detail=f"线索 '{clue_name}' 不存在")
 
         del project["clues"][clue_name]
-        pm.save_project(project_name, project)
+        manager.save_project(project_name, project)
         return {"success": True, "message": f"线索 '{clue_name}' 已删除"}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))

--- a/webui/server/routers/files.py
+++ b/webui/server/routers/files.py
@@ -25,6 +25,10 @@ router = APIRouter()
 project_root = Path(__file__).parent.parent.parent.parent
 pm = ProjectManager(project_root / "projects")
 
+
+def get_project_manager() -> ProjectManager:
+    return pm
+
 # 允许的文件类型
 ALLOWED_EXTENSIONS = {
     "source": [".txt", ".md", ".doc", ".docx"],
@@ -39,7 +43,7 @@ ALLOWED_EXTENSIONS = {
 async def serve_project_file(project_name: str, path: str):
     """服务项目内的静态文件（图片/视频）"""
     try:
-        project_dir = pm.get_project_path(project_name)
+        project_dir = get_project_manager().get_project_path(project_name)
         file_path = project_dir / path
 
         if not file_path.exists():
@@ -81,7 +85,7 @@ async def upload_file(
         )
 
     try:
-        project_dir = pm.get_project_path(project_name)
+        project_dir = get_project_manager().get_project_path(project_name)
 
         # 确定目标目录
         if upload_type == "source":
@@ -147,7 +151,7 @@ async def upload_file(
 
         if upload_type == "character" and name:
             try:
-                pm.update_project_character_sheet(
+                get_project_manager().update_project_character_sheet(
                     project_name, name, f"characters/{filename}"
                 )
             except KeyError:
@@ -155,7 +159,7 @@ async def upload_file(
 
         if upload_type == "character_ref" and name:
             try:
-                pm.update_character_reference_image(
+                get_project_manager().update_character_reference_image(
                     project_name, name, f"characters/refs/{filename}"
                 )
             except KeyError:
@@ -163,7 +167,7 @@ async def upload_file(
 
         if upload_type == "clue" and name:
             try:
-                pm.update_clue_sheet(project_name, name, f"clues/{filename}")
+                get_project_manager().update_clue_sheet(project_name, name, f"clues/{filename}")
             except KeyError:
                 pass  # 线索不存在，忽略
 
@@ -176,6 +180,8 @@ async def upload_file(
 
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -185,7 +191,7 @@ async def upload_file(
 async def list_project_files(project_name: str):
     """列出项目中的所有文件"""
     try:
-        project_dir = pm.get_project_path(project_name)
+        project_dir = get_project_manager().get_project_path(project_name)
 
         files = {
             "source": [],
@@ -213,6 +219,8 @@ async def list_project_files(project_name: str):
 
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -222,7 +230,7 @@ async def list_project_files(project_name: str):
 async def get_source_file(project_name: str, filename: str):
     """获取 source 文件的文本内容"""
     try:
-        project_dir = pm.get_project_path(project_name)
+        project_dir = get_project_manager().get_project_path(project_name)
         source_path = project_dir / "source" / filename
 
         if not source_path.exists():
@@ -241,6 +249,8 @@ async def get_source_file(project_name: str, filename: str):
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
     except UnicodeDecodeError:
         raise HTTPException(status_code=400, detail="文件编码错误，无法读取")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -252,7 +262,7 @@ async def update_source_file(
 ):
     """更新或创建 source 文件"""
     try:
-        project_dir = pm.get_project_path(project_name)
+        project_dir = get_project_manager().get_project_path(project_name)
         source_dir = project_dir / "source"
         source_dir.mkdir(parents=True, exist_ok=True)
         source_path = source_dir / filename
@@ -268,6 +278,8 @@ async def update_source_file(
 
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -277,7 +289,7 @@ async def update_source_file(
 async def delete_source_file(project_name: str, filename: str):
     """删除 source 文件"""
     try:
-        project_dir = pm.get_project_path(project_name)
+        project_dir = get_project_manager().get_project_path(project_name)
         source_path = project_dir / "source" / filename
 
         # 安全检查：确保路径在项目目录内
@@ -294,6 +306,8 @@ async def delete_source_file(project_name: str, filename: str):
 
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -306,7 +320,7 @@ async def delete_source_file(project_name: str, filename: str):
 async def list_drafts(project_name: str):
     """列出项目的所有草稿目录和文件"""
     try:
-        project_dir = pm.get_project_path(project_name)
+        project_dir = get_project_manager().get_project_path(project_name)
         drafts_dir = project_dir / "drafts"
 
         result = {}
@@ -385,7 +399,7 @@ def _get_content_mode(project_dir: Path) -> str:
 async def get_draft_content(project_name: str, episode: int, step_num: int):
     """获取特定步骤的草稿内容"""
     try:
-        project_dir = pm.get_project_path(project_name)
+        project_dir = get_project_manager().get_project_path(project_name)
         content_mode = _get_content_mode(project_dir)
         step_files = _get_step_files(content_mode)
 
@@ -415,7 +429,7 @@ async def update_draft_content(
 ):
     """更新草稿内容"""
     try:
-        project_dir = pm.get_project_path(project_name)
+        project_dir = get_project_manager().get_project_path(project_name)
         content_mode = _get_content_mode(project_dir)
         step_files = _get_step_files(content_mode)
 
@@ -438,7 +452,7 @@ async def update_draft_content(
 async def delete_draft(project_name: str, episode: int, step_num: int):
     """删除草稿文件"""
     try:
-        project_dir = pm.get_project_path(project_name)
+        project_dir = get_project_manager().get_project_path(project_name)
         content_mode = _get_content_mode(project_dir)
         step_files = _get_step_files(content_mode)
 
@@ -480,7 +494,7 @@ async def upload_style_image(project_name: str, file: UploadFile = File(...)):
         )
 
     try:
-        project_dir = pm.get_project_path(project_name)
+        project_dir = get_project_manager().get_project_path(project_name)
 
         # 保存图片（统一转换为 PNG）
         content = await file.read()
@@ -498,10 +512,10 @@ async def upload_style_image(project_name: str, file: UploadFile = File(...)):
         style_description = client.analyze_style_image(output_path)
 
         # 更新 project.json
-        project_data = pm.load_project(project_name)
+        project_data = get_project_manager().load_project(project_name)
         project_data["style_image"] = "style_reference.png"
         project_data["style_description"] = style_description
-        pm.save_project(project_name, project_data)
+        get_project_manager().save_project(project_name, project_data)
 
         return {
             "success": True,
@@ -512,6 +526,8 @@ async def upload_style_image(project_name: str, file: UploadFile = File(...)):
 
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -523,7 +539,7 @@ async def delete_style_image(project_name: str):
     删除风格参考图及相关字段
     """
     try:
-        project_dir = pm.get_project_path(project_name)
+        project_dir = get_project_manager().get_project_path(project_name)
 
         # 删除图片文件
         image_path = project_dir / "style_reference.png"
@@ -531,15 +547,17 @@ async def delete_style_image(project_name: str):
             image_path.unlink()
 
         # 清除 project.json 中的相关字段
-        project_data = pm.load_project(project_name)
+        project_data = get_project_manager().load_project(project_name)
         project_data.pop("style_image", None)
         project_data.pop("style_description", None)
-        pm.save_project(project_name, project_data)
+        get_project_manager().save_project(project_name, project_data)
 
         return {"success": True}
 
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -553,14 +571,16 @@ async def update_style_description(
     更新风格描述（手动编辑）
     """
     try:
-        project_data = pm.load_project(project_name)
+        project_data = get_project_manager().load_project(project_name)
         project_data["style_description"] = style_description
-        pm.save_project(project_name, project_data)
+        get_project_manager().save_project(project_name, project_data)
 
         return {"success": True, "style_description": style_description}
 
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{project_name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))

--- a/webui/server/routers/generate.py
+++ b/webui/server/routers/generate.py
@@ -37,6 +37,10 @@ pm = ProjectManager(project_root / "projects")
 # 初始化限流器（共享给 MediaGenerator）
 rate_limiter = get_shared_rate_limiter()
 
+
+def get_project_manager() -> ProjectManager:
+    return pm
+
 _video_semaphore: Optional[asyncio.Semaphore] = None
 _video_semaphore_lock = threading.Lock()
 
@@ -75,7 +79,7 @@ def _get_video_semaphore() -> asyncio.Semaphore:
 
 def get_media_generator(project_name: str) -> MediaGenerator:
     """获取项目的媒体生成器（带自动版本管理）"""
-    project_path = pm.get_project_path(project_name)
+    project_path = get_project_manager().get_project_path(project_name)
     return MediaGenerator(project_path, rate_limiter=rate_limiter)
 
 
@@ -159,15 +163,15 @@ async def generate_storyboard(
     使用 MediaGenerator 自动处理版本管理。
     """
     try:
-        project = pm.load_project(project_name)
-        project_path = pm.get_project_path(project_name)
+        project = get_project_manager().load_project(project_name)
+        project_path = get_project_manager().get_project_path(project_name)
         generator = get_media_generator(project_name)
 
         # 获取画面比例
         aspect_ratio = get_aspect_ratio(project, "storyboards")
 
         # 加载剧本获取参考图
-        script = pm.load_script(project_name, req.script_file)
+        script = get_project_manager().load_script(project_name, req.script_file)
         content_mode = script.get(
             "content_mode", project.get("content_mode", "narration")
         )
@@ -256,7 +260,7 @@ async def generate_storyboard(
         )
 
         # 更新剧本中的 generated_assets
-        pm.update_scene_asset(
+        get_project_manager().update_scene_asset(
             project_name=project_name,
             script_filename=req.script_file,
             scene_id=segment_id,
@@ -275,6 +279,8 @@ async def generate_storyboard(
 
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -294,8 +300,8 @@ async def generate_video(project_name: str, segment_id: str, req: GenerateVideoR
     sem = _get_video_semaphore()
     await sem.acquire()
     try:
-        project = pm.load_project(project_name)
-        project_path = pm.get_project_path(project_name)
+        project = get_project_manager().load_project(project_name)
+        project_path = get_project_manager().get_project_path(project_name)
         generator = get_media_generator(project_name)
 
         # 获取画面比例
@@ -361,7 +367,7 @@ async def generate_video(project_name: str, segment_id: str, req: GenerateVideoR
         )
 
         # 更新剧本中的 generated_assets
-        pm.update_scene_asset(
+        get_project_manager().update_scene_asset(
             project_name=project_name,
             script_filename=req.script_file,
             scene_id=segment_id,
@@ -371,7 +377,7 @@ async def generate_video(project_name: str, segment_id: str, req: GenerateVideoR
 
         # 保存 video_uri 用于后续扩展
         if video_uri:
-            pm.update_scene_asset(
+            get_project_manager().update_scene_asset(
                 project_name=project_name,
                 script_filename=req.script_file,
                 scene_id=segment_id,
@@ -390,6 +396,8 @@ async def generate_video(project_name: str, segment_id: str, req: GenerateVideoR
 
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -411,8 +419,8 @@ async def generate_character(
     若人物有 reference_image，自动作为参考图传入。
     """
     try:
-        project = pm.load_project(project_name)
-        project_path = pm.get_project_path(project_name)
+        project = get_project_manager().load_project(project_name)
+        project_path = get_project_manager().get_project_path(project_name)
         generator = get_media_generator(project_name)
 
         # 检查人物是否存在
@@ -453,7 +461,7 @@ async def generate_character(
         project["characters"][char_name]["character_sheet"] = (
             f"characters/{char_name}.png"
         )
-        pm.save_project(project_name, project)
+        get_project_manager().save_project(project_name, project)
 
         return {
             "success": True,
@@ -466,6 +474,8 @@ async def generate_character(
 
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -482,7 +492,7 @@ async def generate_clue(project_name: str, clue_name: str, req: GenerateClueRequ
     使用 MediaGenerator 自动处理版本管理。
     """
     try:
-        project = pm.load_project(project_name)
+        project = get_project_manager().load_project(project_name)
         generator = get_media_generator(project_name)
 
         # 检查线索是否存在
@@ -513,7 +523,7 @@ async def generate_clue(project_name: str, clue_name: str, req: GenerateClueRequ
 
         # 更新 project.json 中的 clue_sheet
         project["clues"][clue_name]["clue_sheet"] = f"clues/{clue_name}.png"
-        pm.save_project(project_name, project)
+        get_project_manager().save_project(project_name, project)
 
         return {
             "success": True,
@@ -526,6 +536,8 @@ async def generate_clue(project_name: str, clue_name: str, req: GenerateClueRequ
 
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))

--- a/webui/server/routers/projects.py
+++ b/webui/server/routers/projects.py
@@ -24,6 +24,14 @@ pm = ProjectManager(project_root / "projects")
 calc = StatusCalculator(pm)
 
 
+def get_project_manager() -> ProjectManager:
+    return pm
+
+
+def get_status_calculator() -> StatusCalculator:
+    return calc
+
+
 class CreateProjectRequest(BaseModel):
     name: str
     title: str
@@ -41,14 +49,16 @@ class UpdateProjectRequest(BaseModel):
 @router.get("/projects")
 async def list_projects():
     """列出所有项目"""
+    manager = get_project_manager()
+    calculator = get_status_calculator()
     projects = []
-    for name in pm.list_projects():
+    for name in manager.list_projects():
         try:
             # 尝试加载项目元数据
-            if pm.project_exists(name):
-                project = pm.load_project(name)
+            if manager.project_exists(name):
+                project = manager.load_project(name)
                 # 获取缩略图（第一个分镜图）
-                project_dir = pm.get_project_path(name)
+                project_dir = manager.get_project_path(name)
                 storyboards_dir = project_dir / "storyboards"
                 thumbnail = None
                 if storyboards_dir.exists():
@@ -57,8 +67,8 @@ async def list_projects():
                         thumbnail = f"/api/v1/files/{name}/storyboards/{scene_images[0].name}"
 
                 # 使用 StatusCalculator 计算进度（读时计算）
-                progress = calc.calculate_project_progress(name)
-                current_phase = calc.calculate_current_phase(progress)
+                progress = calculator.calculate_project_progress(name)
+                current_phase = calculator.calculate_current_phase(progress)
 
                 projects.append({
                     "name": name,
@@ -70,7 +80,7 @@ async def list_projects():
                 })
             else:
                 # 没有 project.json 的项目
-                status = pm.get_project_status(name)
+                status = manager.get_project_status(name)
                 projects.append({
                     "name": name,
                     "title": name,
@@ -99,13 +109,16 @@ async def list_projects():
 async def create_project(req: CreateProjectRequest):
     """创建新项目"""
     try:
+        manager = get_project_manager()
         # 创建项目目录结构
-        pm.create_project(req.name)
+        manager.create_project(req.name)
         # 创建项目元数据
-        project = pm.create_project_metadata(req.name, req.title, req.style, req.content_mode)
+        project = manager.create_project_metadata(req.name, req.title, req.style, req.content_mode)
         return {"success": True, "project": project}
     except FileExistsError:
         raise HTTPException(status_code=400, detail=f"项目 '{req.name}' 已存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -115,13 +128,15 @@ async def create_project(req: CreateProjectRequest):
 async def get_project(name: str):
     """获取项目详情（含实时计算字段）"""
     try:
-        if not pm.project_exists(name):
+        manager = get_project_manager()
+        calculator = get_status_calculator()
+        if not manager.project_exists(name):
             raise HTTPException(status_code=404, detail=f"项目 '{name}' 不存在或未初始化")
 
-        project = pm.load_project(name)
+        project = manager.load_project(name)
 
         # 注入计算字段（不写入 JSON，仅用于 API 响应）
-        project = calc.enrich_project(name, project)
+        project = calculator.enrich_project(name, project)
 
         # 加载所有剧本并注入计算字段
         scripts = {}
@@ -129,8 +144,8 @@ async def get_project(name: str):
             script_file = ep.get("script_file", "").replace("scripts/", "")
             if script_file:
                 try:
-                    script = pm.load_script(name, script_file)
-                    script = calc.enrich_script(script)
+                    script = manager.load_script(name, script_file)
+                    script = calculator.enrich_script(script)
                     scripts[script_file] = script
                 except FileNotFoundError:
                     pass
@@ -141,6 +156,8 @@ async def get_project(name: str):
         }
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -150,7 +167,8 @@ async def get_project(name: str):
 async def update_project(name: str, req: UpdateProjectRequest):
     """更新项目元数据"""
     try:
-        project = pm.load_project(name)
+        manager = get_project_manager()
+        project = manager.load_project(name)
 
         if req.title is not None:
             project["title"] = req.title
@@ -161,10 +179,12 @@ async def update_project(name: str, req: UpdateProjectRequest):
         if req.aspect_ratio is not None:
             project["aspect_ratio"] = req.aspect_ratio
 
-        pm.save_project(name, project)
+        manager.save_project(name, project)
         return {"success": True, "project": project}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -174,11 +194,13 @@ async def update_project(name: str, req: UpdateProjectRequest):
 async def delete_project(name: str):
     """删除项目"""
     try:
-        project_dir = pm.get_project_path(name)
+        project_dir = get_project_manager().get_project_path(name)
         shutil.rmtree(project_dir)
         return {"success": True, "message": f"项目 '{name}' 已删除"}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -188,10 +210,12 @@ async def delete_project(name: str):
 async def get_script(name: str, script_file: str):
     """获取剧本内容"""
     try:
-        script = pm.load_script(name, script_file)
+        script = get_project_manager().load_script(name, script_file)
         return {"script": script}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"剧本 '{script_file}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -206,7 +230,8 @@ class UpdateSceneRequest(BaseModel):
 async def update_scene(name: str, scene_id: str, req: UpdateSceneRequest):
     """更新场景"""
     try:
-        script = pm.load_script(name, req.script_file)
+        manager = get_project_manager()
+        script = manager.load_script(name, req.script_file)
 
         # 找到并更新场景
         scene_found = False
@@ -225,10 +250,12 @@ async def update_scene(name: str, scene_id: str, req: UpdateSceneRequest):
         if not scene_found:
             raise HTTPException(status_code=404, detail=f"场景 '{scene_id}' 不存在")
 
-        pm.save_script(name, script, req.script_file)
+        manager.save_script(name, script, req.script_file)
         return {"success": True, "scene": scene}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"剧本不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -254,7 +281,8 @@ class UpdateOverviewRequest(BaseModel):
 async def update_segment(name: str, segment_id: str, req: UpdateSegmentRequest):
     """更新说书模式片段"""
     try:
-        script = pm.load_script(name, req.script_file)
+        manager = get_project_manager()
+        script = manager.load_script(name, req.script_file)
 
         # 检查是否为说书模式
         if script.get('content_mode') != 'narration' and 'segments' not in script:
@@ -281,10 +309,12 @@ async def update_segment(name: str, segment_id: str, req: UpdateSegmentRequest):
         if not segment_found:
             raise HTTPException(status_code=404, detail=f"片段 '{segment_id}' 不存在")
 
-        pm.save_script(name, script, req.script_file)
+        manager.save_script(name, script, req.script_file)
         return {"success": True, "segment": segment}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"剧本不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -296,12 +326,14 @@ async def update_segment(name: str, segment_id: str, req: UpdateSegmentRequest):
 async def generate_overview(name: str):
     """使用 AI 生成项目概述"""
     try:
-        overview = await pm.generate_overview(name)
+        overview = await get_project_manager().generate_overview(name)
         return {"success": True, "overview": overview}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{name}' 不存在")
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))
@@ -311,7 +343,8 @@ async def generate_overview(name: str):
 async def update_overview(name: str, req: UpdateOverviewRequest):
     """更新项目概述（手动编辑）"""
     try:
-        project = pm.load_project(name)
+        manager = get_project_manager()
+        project = manager.load_project(name)
 
         # 确保 overview 字段存在
         if "overview" not in project:
@@ -327,10 +360,12 @@ async def update_overview(name: str, req: UpdateOverviewRequest):
         if req.world_setting is not None:
             project["overview"]["world_setting"] = req.world_setting
 
-        pm.save_project(name, project)
+        manager.save_project(name, project)
         return {"success": True, "overview": project["overview"]}
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"项目 '{name}' 不存在")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))

--- a/webui/server/routers/tasks.py
+++ b/webui/server/routers/tasks.py
@@ -23,6 +23,10 @@ from lib.generation_queue import (
 router = APIRouter()
 
 
+def get_task_queue():
+    return get_generation_queue()
+
+
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -55,7 +59,7 @@ def _format_sse(event: str, data: Any, event_id: Optional[int] = None) -> str:
 
 @router.get("/tasks/stats")
 async def get_task_stats(project_name: Optional[str] = None):
-    queue = get_generation_queue()
+    queue = get_task_queue()
     stats = queue.get_task_stats(project_name=project_name)
     return {"stats": stats}
 
@@ -69,7 +73,7 @@ async def list_tasks(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=50, ge=1, le=500),
 ):
-    queue = get_generation_queue()
+    queue = get_task_queue()
     return queue.list_tasks(
         project_name=project_name,
         status=status,
@@ -89,7 +93,7 @@ async def list_project_tasks(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=50, ge=1, le=500),
 ):
-    queue = get_generation_queue()
+    queue = get_task_queue()
     return queue.list_tasks(
         project_name=project_name,
         status=status,
@@ -107,7 +111,7 @@ async def stream_tasks(
     last_event_id: Optional[int] = Query(default=None, ge=0),
     last_event_header: Optional[str] = Header(default=None, alias="Last-Event-ID"),
 ):
-    queue = get_generation_queue()
+    queue = get_task_queue()
     heartbeat_sec = max(5.0, float(TASK_SSE_HEARTBEAT_SEC))
     poll_interval = read_queue_poll_interval()
 
@@ -173,7 +177,7 @@ async def stream_tasks(
 
 @router.get("/tasks/{task_id}")
 async def get_task(task_id: str):
-    queue = get_generation_queue()
+    queue = get_task_queue()
     task = queue.get_task(task_id)
     if not task:
         raise HTTPException(status_code=404, detail=f"任务 '{task_id}' 不存在")

--- a/webui/server/routers/versions.py
+++ b/webui/server/routers/versions.py
@@ -20,9 +20,13 @@ project_root = Path(__file__).parent.parent.parent.parent
 pm = ProjectManager(project_root / "projects")
 
 
+def get_project_manager() -> ProjectManager:
+    return pm
+
+
 def get_version_manager(project_name: str) -> VersionManager:
     """获取项目的版本管理器"""
-    project_path = pm.get_project_path(project_name)
+    project_path = get_project_manager().get_project_path(project_name)
     return VersionManager(project_path)
 
 
@@ -83,7 +87,8 @@ async def restore_version(
     """
     try:
         vm = get_version_manager(project_name)
-        project_path = pm.get_project_path(project_name)
+        manager = get_project_manager()
+        project_path = manager.get_project_path(project_name)
 
         # 确定当前文件路径
         if resource_type == "storyboards":
@@ -112,12 +117,12 @@ async def restore_version(
         # 同步元数据，确保引用指向统一的 PNG（避免 jpg/png 不一致导致 UI 仍显示旧图）
         if resource_type == "characters":
             try:
-                pm.update_project_character_sheet(project_name, resource_id, file_path)
+                get_project_manager().update_project_character_sheet(project_name, resource_id, file_path)
             except KeyError:
                 pass
         elif resource_type == "clues":
             try:
-                pm.update_clue_sheet(project_name, resource_id, file_path)
+                get_project_manager().update_clue_sheet(project_name, resource_id, file_path)
             except KeyError:
                 pass
         elif resource_type == "storyboards":
@@ -125,7 +130,7 @@ async def restore_version(
             if scripts_dir.exists():
                 for script_file in scripts_dir.glob("*.json"):
                     try:
-                        pm.update_scene_asset(
+                        get_project_manager().update_scene_asset(
                             project_name=project_name,
                             script_filename=script_file.name,
                             scene_id=resource_id,
@@ -148,6 +153,8 @@ async def restore_version(
         raise HTTPException(status_code=400, detail=str(e))
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(e))

--- a/webui/server/services/generation_tasks.py
+++ b/webui/server/services/generation_tasks.py
@@ -24,8 +24,12 @@ pm = ProjectManager(project_root / "projects")
 rate_limiter = get_shared_rate_limiter()
 
 
+def get_project_manager() -> ProjectManager:
+    return pm
+
+
 def get_media_generator(project_name: str) -> MediaGenerator:
-    project_path = pm.get_project_path(project_name)
+    project_path = get_project_manager().get_project_path(project_name)
     return MediaGenerator(project_path, rate_limiter=rate_limiter)
 
 
@@ -215,9 +219,9 @@ def execute_storyboard_task(project_name: str, resource_id: str, payload: Dict[s
     if prompt is None:
         raise ValueError("prompt is required for storyboard task")
 
-    project = pm.load_project(project_name)
-    project_path = pm.get_project_path(project_name)
-    script = pm.load_script(project_name, script_file)
+    project = get_project_manager().load_project(project_name)
+    project_path = get_project_manager().get_project_path(project_name)
+    script = get_project_manager().load_script(project_name, script_file)
     items, id_field, char_field, clue_field = _get_items_from_script(script)
 
     target_item = None
@@ -251,7 +255,7 @@ def execute_storyboard_task(project_name: str, resource_id: str, payload: Dict[s
         image_size="2K",
     )
 
-    pm.update_scene_asset(
+    get_project_manager().update_scene_asset(
         project_name=project_name,
         script_filename=script_file,
         scene_id=resource_id,
@@ -281,8 +285,8 @@ def execute_video_task(project_name: str, resource_id: str, payload: Dict[str, A
     if prompt is None:
         raise ValueError("prompt is required for video task")
 
-    project = pm.load_project(project_name)
-    project_path = pm.get_project_path(project_name)
+    project = get_project_manager().load_project(project_name)
+    project_path = get_project_manager().get_project_path(project_name)
     generator = get_media_generator(project_name)
 
     storyboard_file = project_path / "storyboards" / f"scene_{resource_id}.png"
@@ -302,7 +306,7 @@ def execute_video_task(project_name: str, resource_id: str, payload: Dict[str, A
         duration_seconds=duration_seconds,
     )
 
-    pm.update_scene_asset(
+    get_project_manager().update_scene_asset(
         project_name=project_name,
         script_filename=script_file,
         scene_id=resource_id,
@@ -311,7 +315,7 @@ def execute_video_task(project_name: str, resource_id: str, payload: Dict[str, A
     )
 
     if video_uri:
-        pm.update_scene_asset(
+        get_project_manager().update_scene_asset(
             project_name=project_name,
             script_filename=script_file,
             scene_id=resource_id,
@@ -338,8 +342,8 @@ def execute_character_task(project_name: str, resource_id: str, payload: Dict[st
     if not prompt:
         raise ValueError("prompt is required for character task")
 
-    project = pm.load_project(project_name)
-    project_path = pm.get_project_path(project_name)
+    project = get_project_manager().load_project(project_name)
+    project_path = get_project_manager().get_project_path(project_name)
 
     if resource_id not in project.get("characters", {}):
         raise ValueError(f"character not found: {resource_id}")
@@ -369,7 +373,7 @@ def execute_character_task(project_name: str, resource_id: str, payload: Dict[st
     )
 
     project["characters"][resource_id]["character_sheet"] = f"characters/{resource_id}.png"
-    pm.save_project(project_name, project)
+    get_project_manager().save_project(project_name, project)
 
     created_at = generator.versions.get_versions("characters", resource_id)["versions"][-1][
         "created_at"
@@ -389,7 +393,7 @@ def execute_clue_task(project_name: str, resource_id: str, payload: Dict[str, An
     if not prompt:
         raise ValueError("prompt is required for clue task")
 
-    project = pm.load_project(project_name)
+    project = get_project_manager().load_project(project_name)
 
     if resource_id not in project.get("clues", {}):
         raise ValueError(f"clue not found: {resource_id}")
@@ -412,7 +416,7 @@ def execute_clue_task(project_name: str, resource_id: str, payload: Dict[str, An
     )
 
     project["clues"][resource_id]["clue_sheet"] = f"clues/{resource_id}.png"
-    pm.save_project(project_name, project)
+    get_project_manager().save_project(project_name, project)
 
     created_at = generator.versions.get_versions("clues", resource_id)["versions"][-1][
         "created_at"
@@ -439,9 +443,9 @@ def execute_storyboard_grid_task(project_name: str, payload: Dict[str, Any]) -> 
     if not isinstance(scene_ids, list) or not scene_ids:
         raise ValueError("scene_ids must be a non-empty list")
 
-    script = pm.load_script(project_name, script_file)
-    project = pm.load_project(project_name) if pm.project_exists(project_name) else {}
-    project_path = pm.get_project_path(project_name)
+    script = get_project_manager().load_script(project_name, script_file)
+    project = get_project_manager().load_project(project_name) if get_project_manager().project_exists(project_name) else {}
+    project_path = get_project_manager().get_project_path(project_name)
 
     items, id_field, char_field, clue_field = _get_items_from_script(script)
     scene_lookup = {str(item.get(id_field)): item for item in items}
@@ -495,7 +499,7 @@ def execute_storyboard_grid_task(project_name: str, payload: Dict[str, Any]) -> 
 
     relative_path = f"storyboards/grid_{batch_id:03d}.png"
     for scene in selected_scenes:
-        pm.update_scene_asset(
+        get_project_manager().update_scene_asset(
             project_name=project_name,
             script_filename=script_file,
             scene_id=str(scene.get(id_field)),


### PR DESCRIPTION
## Summary
- Add meaningful unit tests across backend logic, service, worker, router, and agent runtime modules
- Extract workspace review pure helpers into a dedicated frontend module and add focused tests
- Add testability hooks for router/service dependencies and preserve `HTTPException` passthrough behavior
- Enforce coverage gates in CI:
  - Backend: `pytest --cov=lib --cov=webui/server --cov-fail-under=80` with term+xml reports
  - Frontend: Node test coverage with core-module include and `--test-coverage-lines=65`

## Key Files
- `.github/workflows/test.yml`
- `pyproject.toml`
- `webui/server/routers/*` (testability and exception passthrough adjustments)
- `webui/server/app.py`
- `webui/server/services/generation_tasks.py`
- `frontend/src/react/pages/workspace-review-helpers.js`
- `frontend/src/react/pages/workspace-page.js`
- `tests/*.py` (new backend tests)
- `frontend/tests/workspace-review-helpers.test.mjs`

## Validation
- Backend:
  - `uv run python -m pytest --cov=lib --cov=webui/server --cov-report=term-missing --cov-report=xml --cov-fail-under=80`
  - Result: pass, total coverage 83.96%
- Frontend:
  - `node --test --experimental-test-coverage tests/*.test.mjs --test-coverage-lines=65 --test-coverage-include=src/react/components/landing-page.js --test-coverage-include=src/react/components/app-shell.js --test-coverage-include=src/react/pages/assistant-question-wizard.js --test-coverage-include=src/react/pages/projects-page.js --test-coverage-include=src/react/pages/workspace-review-helpers.js`
  - Result: pass
