### PR TITLE
fix: align SSE task event structure with frontend contract

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -51,7 +51,8 @@ export interface TaskStreamTaskPayload {
 }
 
 export interface TaskStreamHeartbeatPayload {
-  timestamp: string;
+  last_event_id: number;
+  generated_at: string;
 }
 
 /** Filters for {@link API.listTasks} and {@link API.listProjectTasks}. */

--- a/tests/test_tasks_router_more.py
+++ b/tests/test_tasks_router_more.py
@@ -83,7 +83,7 @@ class TestTasksRouterMore:
             latest=10,
             snapshot=[{"task_id": "t1"}],
             stats={"running": 1},
-            events=[{"id": 11, "event_type": "updated", "task_id": "t1"}],
+            events=[{"id": 11, "event_type": "running", "task_id": "t1", "data": {"task_id": "t1", "status": "running"}}],
         )
         monkeypatch.setattr(tasks_router, "get_task_queue", lambda: queue)
         monkeypatch.setattr(tasks_router, "read_queue_poll_interval", lambda: 0.0)
@@ -109,7 +109,9 @@ class TestTasksRouterMore:
         task_event, event_id, task_payload = _decode_sse(chunks[1])
         assert task_event == "task"
         assert event_id == 11
-        assert task_payload["task_id"] == "t1"
+        assert task_payload["action"] == "updated"
+        assert task_payload["task"]["task_id"] == "t1"
+        assert task_payload["stats"] == {"running": 1}
         assert queue.cursors[0] == 10
 
     @pytest.mark.asyncio
@@ -149,3 +151,19 @@ class TestTasksRouterMore:
             resp = client.get("/api/v1/tasks/missing-task")
             assert resp.status_code == 404
             assert "不存在" in resp.json()["detail"]
+
+    def test_transform_task_event_queued_maps_to_created(self):
+        raw = {"event_type": "queued", "data": {"task_id": "t1", "status": "queued"}}
+        stats = {"queued": 1, "running": 0, "succeeded": 0, "failed": 0, "total": 1}
+        result = tasks_router._transform_task_event(raw, stats)
+        assert result["action"] == "created"
+        assert result["task"]["task_id"] == "t1"
+        assert result["stats"] is stats
+
+    def test_transform_task_event_non_queued_maps_to_updated(self):
+        for event_type in ("running", "succeeded", "failed", "requeued"):
+            raw = {"event_type": event_type, "data": {"task_id": "t1", "status": event_type}}
+            stats = {"queued": 0, "running": 1, "succeeded": 0, "failed": 0, "total": 1}
+            result = tasks_router._transform_task_event(raw, stats)
+            assert result["action"] == "updated", f"expected 'updated' for {event_type}"
+            assert result["task"]["task_id"] == "t1"

--- a/tests/test_tasks_sse.py
+++ b/tests/test_tasks_sse.py
@@ -47,3 +47,32 @@ class TestTaskRouterAndEvents:
         incremental = queue.get_events_since(last_event_id=last_running_id, project_name="demo")
         assert all(event["id"] > last_running_id for event in incremental)
         assert any(event["event_type"] == "failed" for event in incremental)
+
+    def test_sse_task_event_has_frontend_shape(self, generation_queue):
+        """SSE task 事件应匹配前端 TaskStreamTaskPayload 结构。"""
+        from webui.server.routers.tasks import _transform_task_event
+
+        queue = generation_queue
+        task = queue.enqueue_task(
+            project_name="demo",
+            task_type="storyboard",
+            media_type="image",
+            resource_id="E1S02",
+            payload={"prompt": "p"},
+            script_file="episode_01.json",
+            source="webui",
+        )
+
+        events = queue.get_events_since(last_event_id=0, project_name="demo")
+        assert len(events) >= 1
+
+        stats = queue.get_task_stats(project_name="demo")
+        transformed = _transform_task_event(events[0], stats)
+
+        assert transformed["action"] == "created"
+        assert transformed["task"]["task_id"] == task["task_id"]
+        assert transformed["task"]["status"] == "queued"
+        assert "queued" in transformed["stats"]
+        assert "running" in transformed["stats"]
+        assert "total" in transformed["stats"]
+        assert transformed["stats"]["queued"] >= 1

--- a/webui/server/routers/tasks.py
+++ b/webui/server/routers/tasks.py
@@ -57,6 +57,17 @@ def _format_sse(event: str, data: Any, event_id: Optional[int] = None) -> str:
     return "\n".join(lines) + "\n\n"
 
 
+def _transform_task_event(raw_event: dict, stats: dict) -> dict:
+    """将原始 task_events 行转换为前端期望的 TaskStreamTaskPayload 结构。"""
+    event_type = raw_event.get("event_type", "")
+    action = "created" if event_type == "queued" else "updated"
+    return {
+        "action": action,
+        "task": raw_event.get("data", {}),
+        "stats": stats,
+    }
+
+
 @router.get("/tasks/stats")
 async def get_task_stats(project_name: Optional[str] = None):
     queue = get_task_queue()
@@ -148,9 +159,11 @@ async def stream_tasks(
                 limit=200,
             )
             if events:
+                batch_stats = queue.get_task_stats(project_name=project_name)
                 for event in events:
                     cursor = int(event["id"])
-                    yield _format_sse("task", event, event_id=cursor)
+                    transformed = _transform_task_event(event, batch_stats)
+                    yield _format_sse("task", transformed, event_id=cursor)
                 last_heartbeat = time.monotonic()
                 continue
 


### PR DESCRIPTION
## Summary

- Backend SSE `task` events were sending raw `task_events` DB rows (`{id, task_id, event_type, data: {TaskItem}, ...}`) but the frontend expected `{action, task, stats}` (`TaskStreamTaskPayload`)
- This caused `payload.task` to be `undefined`, crashing `upsertTask()` in the Zustand store, and `payload.stats` to be `undefined`, producing `NaN` in the GlobalHeader badge
- Added `_transform_task_event()` in `tasks.py` to convert raw events to the frontend-expected shape: maps `event_type` to `action` (`queued→created`, others→`updated`), extracts task from `data` field, attaches batch stats
- Fixed `TaskStreamHeartbeatPayload` TypeScript type to match backend fields (`last_event_id` + `generated_at` instead of `timestamp`)

## Test plan

- [x] All 8 task-related tests pass (`test_tasks_router_more.py` + `test_tasks_sse.py`)
- [x] Frontend builds successfully (`pnpm build`)
- [ ] Manual: start backend + frontend, trigger a generation task, verify SSE task events render correctly in TaskHud without crashes