### PR TITLE
fix: resolve script_file path prefix duplication causing 404 errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ projects/.agent_data/sessions.db
 .env.*
 !.env.example
 service-account.json
+CLAUDE.local.md
 
 # Local Codex runtime metadata
 .codex/

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -59,7 +59,7 @@ export function StudioCanvasRouter() {
     if (!currentProjectName || !currentScripts) return;
     const resolvedFile = scriptFile ?? Object.keys(currentScripts)[0];
     if (!resolvedFile) return;
-    const script = currentScripts[resolvedFile] ?? currentScripts[resolvedFile.replace(/^scripts\//, "")];
+    const script = currentScripts[resolvedFile];
     if (!script) return;
     const segments = ("segments" in script ? script.segments : undefined) ??
                      ("scenes" in script ? script.scenes : undefined) ?? [];
@@ -80,7 +80,7 @@ export function StudioCanvasRouter() {
     if (!currentProjectName || !currentScripts) return;
     const resolvedFile = scriptFile ?? Object.keys(currentScripts)[0];
     if (!resolvedFile) return;
-    const script = currentScripts[resolvedFile] ?? currentScripts[resolvedFile.replace(/^scripts\//, "")];
+    const script = currentScripts[resolvedFile];
     if (!script) return;
     const segments = ("segments" in script ? script.segments : undefined) ??
                      ("scenes" in script ? script.scenes : undefined) ?? [];
@@ -232,12 +232,9 @@ export function StudioCanvasRouter() {
           const episode = currentProjectData?.episodes?.find(
             (e) => e.episode === epNum,
           );
-          const scriptFile = episode?.script_file;
-          // Backend strips "scripts/" prefix from keys, so try both forms
+          const scriptFile = episode?.script_file?.replace(/^scripts\//, "");
           const script = scriptFile
-            ? (currentScripts[scriptFile] ??
-               currentScripts[scriptFile.replace(/^scripts\//, "")] ??
-               null)
+            ? (currentScripts[scriptFile] ?? null)
             : null;
 
           return (

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -217,6 +217,9 @@ class ProjectManager:
         project_dir = self.get_project_path(project_name)
         scripts_dir = project_dir / "scripts"
 
+        if filename is not None and filename.startswith("scripts/"):
+            filename = filename[len("scripts/"):]
+
         if filename is None:
             chapter = script["novel"].get("chapter", "chapter_01")
             filename = f"{chapter.replace(' ', '_')}_script.json"
@@ -320,6 +323,8 @@ class ProjectManager:
             剧本字典
         """
         project_dir = self.get_project_path(project_name)
+        if filename.startswith("scripts/"):
+            filename = filename[len("scripts/"):]
         script_path = (project_dir / "scripts" / filename).resolve()
         try:
             script_path.relative_to(project_dir.resolve())

--- a/lib/status_calculator.py
+++ b/lib/status_calculator.py
@@ -111,7 +111,7 @@ class StatusCalculator:
         sb_total, sb_done, vid_total, vid_done = 0, 0, 0, 0
 
         for ep in project.get('episodes', []):
-            script_file = ep.get('script_file', '').replace('scripts/', '')
+            script_file = ep.get('script_file', '')
             if script_file:
                 try:
                     script = self.pm.load_script(project_name, script_file)
@@ -182,7 +182,7 @@ class StatusCalculator:
 
         # 为每个 episode 注入计算字段
         for ep in project.get('episodes', []):
-            script_file = ep.get('script_file', '').replace('scripts/', '')
+            script_file = ep.get('script_file', '')
             if script_file:
                 try:
                     script = self.pm.load_script(project_name, script_file)

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -140,12 +140,14 @@ async def get_project(name: str):
         # 加载所有剧本并注入计算字段
         scripts = {}
         for ep in project.get("episodes", []):
-            script_file = ep.get("script_file", "").replace("scripts/", "")
+            script_file = ep.get("script_file", "")
             if script_file:
                 try:
                     script = manager.load_script(name, script_file)
                     script = calculator.enrich_script(script)
-                    scripts[script_file] = script
+                    # 使用纯文件名作为 key（去掉 scripts/ 前缀）
+                    key = script_file.replace("scripts/", "", 1) if script_file.startswith("scripts/") else script_file
+                    scripts[key] = script
                 except FileNotFoundError:
                     pass
 

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -117,6 +117,41 @@ class TestProjectManagerMore:
         with pytest.raises(KeyError):
             pm.update_scene_asset("demo", "episode_1.json", "NOT_FOUND", "video_clip", "x.mp4")
 
+    def test_load_script_strips_scripts_prefix(self, tmp_path):
+        """load_script / save_script / update_scene_asset 应兼容带 scripts/ 前缀的文件名"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        script = {
+            "episode": 1,
+            "title": "第一集",
+            "content_mode": "narration",
+            "segments": [{"segment_id": "E1S01", "duration_seconds": 4, "generated_assets": {}}],
+        }
+        pm.save_script("demo", script, "episode_1.json")
+
+        # 纯文件名
+        loaded1 = pm.load_script("demo", "episode_1.json")
+        assert loaded1["episode"] == 1
+
+        # 带 scripts/ 前缀（前端传入的格式）
+        loaded2 = pm.load_script("demo", "scripts/episode_1.json")
+        assert loaded2["episode"] == 1
+
+        # save_script 也应兼容带前缀的文件名
+        script["title"] = "修改后"
+        pm.save_script("demo", script, "scripts/episode_1.json")
+        loaded3 = pm.load_script("demo", "episode_1.json")
+        assert loaded3["title"] == "修改后"
+
+        # update_scene_asset 也应兼容
+        pm.update_scene_asset(
+            "demo", "scripts/episode_1.json", "E1S01", "storyboard_image", "storyboards/scene_E1S01.png"
+        )
+        updated = pm.load_script("demo", "episode_1.json")
+        assert updated["segments"][0]["generated_assets"]["storyboard_image"] == "storyboards/scene_E1S01.png"
+
     def test_normalize_and_templates(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -75,6 +75,8 @@ class _FakePM:
         self.project_data[name] = payload
 
     def load_script(self, name, script_file):
+        if script_file.startswith("scripts/"):
+            script_file = script_file[len("scripts/"):]
         key = (name, script_file)
         if key not in self.scripts:
             raise FileNotFoundError(script_file)

--- a/tests/test_status_calculator.py
+++ b/tests/test_status_calculator.py
@@ -16,6 +16,8 @@ class _FakePM:
         return self._project_root / project_name
 
     def load_script(self, project_name: str, filename: str):
+        if filename.startswith("scripts/"):
+            filename = filename[len("scripts/"):]
         if filename not in self._scripts:
             raise FileNotFoundError(filename)
         return self._scripts[filename]


### PR DESCRIPTION
## Summary

- `project.json` stores `episodes[].script_file` as `"scripts/episode_1.json"`, but `load_script()`/`save_script()` internally prepend `scripts/`, producing `scripts/scripts/episode_1.json` → 404
- Added defensive `scripts/` prefix stripping in `load_script()` and `save_script()` entry points (`lib/project_manager.py`)
- Removed 3 scattered `.replace("scripts/", "")` workarounds in `status_calculator.py` and `projects.py` router
- Fixed frontend `StudioCanvasRouter.tsx` to strip prefix at the source (`episode.script_file`) and clean up fallback lookups

## Test plan

- [x] Backend: `python -m pytest` — 218 passed
- [x] Frontend: `npx vitest run` — 36 passed (7 test files)
- [x] New test `test_load_script_strips_scripts_prefix` verifies both `"episode_1.json"` and `"scripts/episode_1.json"` work for `load_script`, `save_script`, and `update_scene_asset`
- [x] Manual: trigger storyboard generation from WebUI to confirm 404 is resolved