### PR TITLE
feat: add global ToastOverlay component for toast notifications

### DIFF
--- a/frontend/src/components/layout/ToastOverlay.tsx
+++ b/frontend/src/components/layout/ToastOverlay.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useRef } from "react";
+import { CircleCheck, CircleX, Info, TriangleAlert, X } from "lucide-react";
+import { useAppStore } from "@/stores/app-store";
+import { UI_LAYERS } from "@/utils/ui-layers";
+
+const ICON_MAP = {
+  info: Info,
+  success: CircleCheck,
+  error: CircleX,
+  warning: TriangleAlert,
+} as const;
+
+const TONE_STYLES = {
+  info: "bg-gray-800/90 border-gray-600/60 text-gray-100",
+  success: "bg-emerald-950/90 border-emerald-500/50 text-emerald-100",
+  error: "bg-red-950/90 border-red-500/50 text-red-100",
+  warning: "bg-amber-950/90 border-amber-500/50 text-amber-100",
+} as const;
+
+const ICON_COLORS = {
+  info: "text-gray-400",
+  success: "text-emerald-400",
+  error: "text-red-400",
+  warning: "text-amber-400",
+} as const;
+
+const AUTO_DISMISS_MS = 4000;
+
+export function ToastOverlay() {
+  const toast = useAppStore((s) => s.toast);
+  const clearToast = useAppStore((s) => s.clearToast);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const startTimer = useCallback(() => {
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(clearToast, AUTO_DISMISS_MS);
+  }, [clearToast]);
+
+  const pauseTimer = useCallback(() => {
+    clearTimeout(timerRef.current);
+  }, []);
+
+  useEffect(() => {
+    if (!toast) return;
+    startTimer();
+    return () => clearTimeout(timerRef.current);
+  }, [toast, startTimer]);
+
+  if (!toast) return null;
+
+  const Icon = ICON_MAP[toast.tone];
+
+  return (
+    <div
+      className={`fixed top-14 left-1/2 -translate-x-1/2 ${UI_LAYERS.toast} pointer-events-none`}
+    >
+      <div
+        key={toast.id}
+        onMouseEnter={pauseTimer}
+        onMouseLeave={startTimer}
+        className={`toast-enter pointer-events-auto flex items-center gap-2.5 rounded-lg border px-4 py-2.5 shadow-lg backdrop-blur-sm text-sm ${TONE_STYLES[toast.tone]}`}
+      >
+        <Icon className={`h-4 w-4 shrink-0 ${ICON_COLORS[toast.tone]}`} />
+        <span className="max-w-sm">{toast.text}</span>
+        <button
+          type="button"
+          onClick={clearToast}
+          className="ml-1 shrink-0 rounded p-0.5 opacity-50 hover:opacity-100 transition-opacity cursor-pointer"
+          aria-label="关闭提示"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/css/app.css
+++ b/frontend/src/css/app.css
@@ -80,12 +80,18 @@ body {
 }
 
 .toast-enter {
-    animation: slide-up 0.24s ease-out;
+    animation: slide-down 0.24s ease-out;
 }
 
-@keyframes slide-up {
+@media (prefers-reduced-motion: reduce) {
+    .toast-enter {
+        animation: none;
+    }
+}
+
+@keyframes slide-down {
     from {
-        transform: translateY(8px);
+        transform: translateY(-8px);
         opacity: 0;
     }
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -6,6 +6,7 @@ import { StudioLayout } from "@/components/layout";
 import { StudioCanvasRouter } from "@/components/canvas/StudioCanvasRouter";
 import { ProjectsPage } from "@/components/pages/ProjectsPage";
 import { LoginPage } from "@/pages/LoginPage";
+import { ToastOverlay } from "@/components/layout/ToastOverlay";
 import { API } from "@/api";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useAssistantStore } from "@/stores/assistant-store";
@@ -91,40 +92,43 @@ function StudioWorkspace() {
 
 export function AppRoutes() {
   return (
-    <Switch>
-      {/* Login page */}
-      <Route path="/login" component={LoginPage} />
+    <>
+      <Switch>
+        {/* Login page */}
+        <Route path="/login" component={LoginPage} />
 
-      {/* Root redirects to projects list */}
-      <Route path="/">
-        <Redirect to="/app/projects" />
-      </Route>
+        {/* Root redirects to projects list */}
+        <Route path="/">
+          <Redirect to="/app/projects" />
+        </Route>
 
-      {/* /app and /app/ also redirect to projects list */}
-      <Route path="/app">
-        <Redirect to="/app/projects" />
-      </Route>
+        {/* /app and /app/ also redirect to projects list */}
+        <Route path="/app">
+          <Redirect to="/app/projects" />
+        </Route>
 
-      {/* Projects list */}
-      <Route path="/app/projects">
-        <AuthGuard>
-          <ProjectsPage />
-        </AuthGuard>
-      </Route>
+        {/* Projects list */}
+        <Route path="/app/projects">
+          <AuthGuard>
+            <ProjectsPage />
+          </AuthGuard>
+        </Route>
 
-      {/* Studio workspace (three-column layout) */}
-      <Route path="/app/projects/:projectName" nest>
-        <AuthGuard>
-          <StudioWorkspace />
-        </AuthGuard>
-      </Route>
+        {/* Studio workspace (three-column layout) */}
+        <Route path="/app/projects/:projectName" nest>
+          <AuthGuard>
+            <StudioWorkspace />
+          </AuthGuard>
+        </Route>
 
-      {/* 404 */}
-      <Route>
-        <div className="flex h-screen items-center justify-center bg-gray-950 text-gray-400">
-          404 — 页面未找到
-        </div>
-      </Route>
-    </Switch>
+        {/* 404 */}
+        <Route>
+          <div className="flex h-screen items-center justify-center bg-gray-950 text-gray-400">
+            404 — 页面未找到
+          </div>
+        </Route>
+      </Switch>
+      <ToastOverlay />
+    </>
   );
 }

--- a/frontend/src/utils/ui-layers.ts
+++ b/frontend/src/utils/ui-layers.ts
@@ -3,4 +3,5 @@ export const UI_LAYERS = {
   workspaceFloating: "z-30",
   workspacePopover: "z-40",
   modal: "z-50",
+  toast: "z-60",
 } as const;


### PR DESCRIPTION
## Summary

- **Root cause**: `pushToast()` was setting toast state in zustand store but no UI component was rendering it — all toast notifications (import errors, export status, generation updates) were silently lost
- **Fix**: Add `ToastOverlay` component mounted at `AppRoutes` level, consuming `toast` state from `useAppStore`
- **Design**: 4 tone variants (info/success/error/warning), top-center positioning below GlobalHeader, auto-dismiss with hover-pause, `prefers-reduced-motion` support, z-60 layer above modals

## Test plan
- [x] TypeScript compiles with no errors
- [x] All 89 existing tests pass (24 test files)
- [ ] Manual: trigger import failure on ProjectsPage → toast appears at top center
- [ ] Manual: hover over toast → timer pauses; mouse leave → timer resumes
- [ ] Manual: click X button → toast dismissed immediately
- [ ] Manual: verify toast renders on both ProjectsPage and Studio workspace