### PR TITLE
fix(agent): 修复 task notification 显示为用户消息 + 允许读取 task output

### DIFF
--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -827,6 +827,16 @@ class SessionManager:
         ):
             return True
 
+        # 5. Read tools: allow SDK task output files.
+        #    Background tasks (Agent/Bash run_in_background) write their
+        #    output to /tmp/claude-{N}/{encoded-cwd}/tasks/{id}.output.
+        #    The SDK instructs the agent to Read the file after the task
+        #    completes.  Only the tasks/ subdirectory is allowed.
+        _SDK_TMP_PREFIX = "/tmp/claude-"
+        resolved_str = str(resolved)
+        if resolved_str.startswith(_SDK_TMP_PREFIX) and "tasks" in resolved.parts:
+            return True
+
         return False
 
     async def _handle_ask_user_question(

--- a/server/agent_runtime/turn_grouper.py
+++ b/server/agent_runtime/turn_grouper.py
@@ -5,6 +5,7 @@ Conversation turn grouping shared by history loading and live SSE streaming.
 from __future__ import annotations
 
 import copy
+import re
 from typing import Any, Optional
 
 from server.agent_runtime.turn_schema import (
@@ -35,6 +36,52 @@ _SUBAGENT_CONTEXT_KEYS = (
     "agent_id",
 )
 _SUBAGENT_BOOLEAN_KEYS = ("isSidechain", "is_sidechain")
+
+
+# Regex for SDK-injected task notification user messages.
+_TASK_NOTIFICATION_RE = re.compile(
+    r"<task-notification>\s*.*?</task-notification>", re.DOTALL
+)
+
+
+def _extract_task_notification(content: Any) -> Optional[dict[str, str]]:
+    """Extract task notification fields from SDK-injected user message.
+
+    The SDK injects task completion/failure notifications as plain user
+    messages with ``<task-notification>`` XML.  This helper detects them
+    and returns parsed fields, or *None* if the content is not a task
+    notification.
+    """
+    if isinstance(content, list):
+        texts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                texts.append(block.get("text", ""))
+            elif isinstance(block, str):
+                texts.append(block)
+        text = "\n".join(texts)
+    elif isinstance(content, str):
+        text = content
+    else:
+        return None
+
+    match = _TASK_NOTIFICATION_RE.search(text)
+    if not match:
+        return None
+
+    xml = match.group(0)
+
+    def _tag(name: str) -> str:
+        m = re.search(rf"<{name}>(.*?)</{name}>", xml, re.DOTALL)
+        return m.group(1).strip() if m else ""
+
+    return {
+        "task_id": _tag("task-id"),
+        "tool_use_id": _tag("tool-use-id"),
+        "status": _tag("status"),
+        "summary": _tag("summary"),
+        "output_file": _tag("output-file"),
+    }
 
 
 def _is_skill_content_text(text: str) -> bool:
@@ -315,6 +362,48 @@ def group_messages_into_turns(raw_messages: list[dict[str, Any]]) -> list[dict[s
 
         if msg_type == "user":
             content = msg.get("content", "")
+
+            # SDK injects task notifications as user messages in the
+            # transcript; convert to task_progress blocks so they render
+            # identically to live TaskNotificationMessage events.
+            task_info = _extract_task_notification(content)
+            if task_info is not None:
+                task_id = task_info["task_id"]
+                task_block = {
+                    "type": "task_progress",
+                    "task_id": task_id,
+                    "status": "task_notification",
+                    "description": "",
+                    "summary": task_info["summary"] or None,
+                    "task_status": task_info["status"] or None,
+                    "tool_use_id": task_info["tool_use_id"] or None,
+                }
+                if task_id:
+                    existing = (
+                        _find_task_block(current_turn, task_id)
+                        if current_turn
+                        else None
+                    )
+                    if existing is not None:
+                        existing["status"] = "task_notification"
+                        if task_block.get("summary"):
+                            existing["summary"] = task_block["summary"]
+                        if task_block.get("task_status"):
+                            existing["task_status"] = task_block["task_status"]
+                        continue
+                if current_turn and current_turn.get("type") == "assistant":
+                    current_turn.get("content", []).append(task_block)
+                else:
+                    if current_turn:
+                        turns.append(current_turn)
+                    current_turn = {
+                        "type": "system",
+                        "content": [task_block],
+                        "uuid": msg.get("uuid"),
+                        "timestamp": msg.get("timestamp"),
+                    }
+                continue
+
             has_subagent_metadata = _has_subagent_user_metadata(msg)
             is_system_injected = (
                 _is_system_injected_user_message(content)

--- a/tests/test_session_manager_more.py
+++ b/tests/test_session_manager_more.py
@@ -537,6 +537,36 @@ class TestSessionManagerMore:
 
         await engine.dispose()
 
+    @pytest.mark.asyncio
+    async def test_file_access_hook_allows_read_sdk_task_output(self, tmp_path, monkeypatch):
+        """Hook allows Read for SDK task output files under /tmp/claude-*."""
+        hook, _, _, engine = await self._make_sdk_hook_env(tmp_path, monkeypatch)
+
+        # SDK task output path pattern: /tmp/claude-{N}/{encoded}/tasks/{id}.output
+        task_output = "/tmp/claude-0/-app-projects-alpha-abc123/tasks/bdgaof0ba.output"
+        result = await hook(
+            {"tool_name": "Read", "tool_input": {"file_path": task_output}},
+            None, None,
+        )
+        assert result.get("continue_") is True
+
+        # Write to task output — denied (write tools only allow project_cwd)
+        result = await hook(
+            {"tool_name": "Write", "tool_input": {"file_path": task_output}},
+            None, None,
+        )
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+        # /tmp/claude-* path WITHOUT tasks/ segment — denied
+        non_task_path = "/tmp/claude-0/-app-projects-alpha/sessions/abc.jsonl"
+        result = await hook(
+            {"tool_name": "Read", "tool_input": {"file_path": non_task_path}},
+            None, None,
+        )
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+        await engine.dispose()
+
 
 class TestJsonValidationHook:
     """Tests for the PreToolUse JSON validation hook."""

--- a/tests/test_turn_grouper.py
+++ b/tests/test_turn_grouper.py
@@ -1,6 +1,7 @@
 """Unit tests for shared turn grouper."""
 
 from server.agent_runtime.turn_grouper import (
+    _extract_task_notification,
     build_turn_patch,
     group_messages_into_turns,
 )
@@ -464,3 +465,125 @@ class TestTurnGrouper:
         assert turns[0]["type"] == "user"
         assert turns[1]["type"] == "system"
         assert turns[1]["content"][0]["type"] == "task_progress"
+
+    def test_task_notification_user_message_converted_to_task_progress(self):
+        """SDK-injected <task-notification> user message becomes task_progress block."""
+        xml_content = (
+            '<task-notification>\n'
+            '<task-id>bdgaof0ba</task-id>\n'
+            '<tool-use-id>toolu_016arH6Ny81xuwipeci3ic5e</tool-use-id>\n'
+            '<output-file>/tmp/claude-0/tasks/bdgaof0ba.output</output-file>\n'
+            '<status>failed</status>\n'
+            '<summary>Background command failed with exit code 2</summary>\n'
+            '</task-notification>\n'
+            'Read the output file to retrieve the result.'
+        )
+        raw_messages = [
+            {"type": "user", "content": "run this in background"},
+            {
+                "type": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "agent-1", "name": "Agent", "input": {}},
+                ],
+            },
+            {
+                "type": "system",
+                "subtype": "task_started",
+                "description": "Running command",
+                "task_id": "bdgaof0ba",
+                "tool_use_id": "agent-1",
+            },
+            # SDK transcript stores the notification as a user message
+            {"type": "user", "content": xml_content},
+        ]
+        turns = group_messages_into_turns(raw_messages)
+        assert [turn["type"] for turn in turns] == ["user", "assistant"]
+        assistant_content = turns[1]["content"]
+        task_blocks = [b for b in assistant_content if b.get("type") == "task_progress"]
+        assert len(task_blocks) == 1
+        assert task_blocks[0]["status"] == "task_notification"
+        assert task_blocks[0]["task_status"] == "failed"
+        assert task_blocks[0]["summary"] == "Background command failed with exit code 2"
+
+    def test_task_notification_user_message_list_content(self):
+        """Task notification in list-of-blocks content format is also detected."""
+        xml_text = (
+            '<task-notification>\n'
+            '<task-id>abc123</task-id>\n'
+            '<tool-use-id>toolu_xyz</tool-use-id>\n'
+            '<output-file>/tmp/claude-0/tasks/abc123.output</output-file>\n'
+            '<status>completed</status>\n'
+            '<summary>Task finished successfully</summary>\n'
+            '</task-notification>'
+        )
+        raw_messages = [
+            {"type": "user", "content": "start"},
+            {
+                "type": "assistant",
+                "content": [{"type": "text", "text": "working on it"}],
+            },
+            # Content as list of text blocks (SDK format)
+            {
+                "type": "user",
+                "content": [{"type": "text", "text": xml_text}],
+            },
+        ]
+        turns = group_messages_into_turns(raw_messages)
+        # Should NOT appear as a user turn
+        user_turns = [t for t in turns if t["type"] == "user"]
+        assert len(user_turns) == 1  # only the initial "start"
+        # The task_progress block should be on the assistant turn
+        assistant_content = turns[1]["content"]
+        task_blocks = [b for b in assistant_content if b.get("type") == "task_progress"]
+        assert len(task_blocks) == 1
+        assert task_blocks[0]["task_status"] == "completed"
+
+    def test_task_notification_without_prior_turn_creates_system_turn(self):
+        """Task notification user message without assistant turn creates system turn."""
+        xml_content = (
+            '<task-notification>\n'
+            '<task-id>solo-task</task-id>\n'
+            '<tool-use-id>toolu_solo</tool-use-id>\n'
+            '<output-file>/tmp/tasks/solo-task.output</output-file>\n'
+            '<status>completed</status>\n'
+            '<summary>Done</summary>\n'
+            '</task-notification>'
+        )
+        raw_messages = [
+            {"type": "user", "content": xml_content},
+        ]
+        turns = group_messages_into_turns(raw_messages)
+        assert len(turns) == 1
+        assert turns[0]["type"] == "system"
+        assert turns[0]["content"][0]["type"] == "task_progress"
+
+
+class TestExtractTaskNotification:
+    """Tests for _extract_task_notification helper."""
+
+    def test_extracts_all_fields(self):
+        xml = (
+            '<task-notification>\n'
+            '<task-id>abc</task-id>\n'
+            '<tool-use-id>toolu_1</tool-use-id>\n'
+            '<output-file>/tmp/out.txt</output-file>\n'
+            '<status>completed</status>\n'
+            '<summary>All good</summary>\n'
+            '</task-notification>'
+        )
+        result = _extract_task_notification(xml)
+        assert result is not None
+        assert result["task_id"] == "abc"
+        assert result["tool_use_id"] == "toolu_1"
+        assert result["output_file"] == "/tmp/out.txt"
+        assert result["status"] == "completed"
+        assert result["summary"] == "All good"
+
+    def test_returns_none_for_normal_text(self):
+        assert _extract_task_notification("hello world") is None
+
+    def test_handles_list_content(self):
+        blocks = [{"type": "text", "text": "<task-notification><task-id>x</task-id><status>ok</status></task-notification>"}]
+        result = _extract_task_notification(blocks)
+        assert result is not None
+        assert result["task_id"] == "x"


### PR DESCRIPTION
## Summary

- **问题 1**：SDK transcript 中 `TaskNotificationMessage` 被存为 `type: "user"` 消息（含 `<task-notification>` XML），`turn_grouper` 无法识别，导致在 snapshot 中渲染为用户消息气泡
- **问题 2**：智能体无法读取 `/tmp/claude-{UID}/.../tasks/*.output` 下的后台任务输出文件，`_is_path_allowed` 缺少对应规则

### 修复内容

- `turn_grouper.py`：新增 `_extract_task_notification()` 检测 `<task-notification>` XML 用户消息，转换为 `task_progress` block，与 live streaming 的 `TaskNotificationMessage` 处理路径一致
- `session_manager.py`：`_is_path_allowed` 新增规则 5，允许 Read 工具访问 `/tmp/claude-*/.../tasks/` 路径（Write 仍拒绝）

## Test plan

- [x] `test_task_notification_user_message_converted_to_task_progress` — 字符串格式 XML 转换
- [x] `test_task_notification_user_message_list_content` — 列表格式 content 检测
- [x] `test_task_notification_without_prior_turn_creates_system_turn` — 无前置 assistant turn 时创建 system turn
- [x] `TestExtractTaskNotification` — 字段提取、普通文本返回 None、列表 content
- [x] `test_file_access_hook_allows_read_sdk_task_output` — Read 允许 / Write 拒绝 / 无 tasks 段拒绝
- [x] 全部 48 个测试通过