### PR TITLE
fix: 配置页保存 Anthropic API Key 后同步到环境变量

### DIFF
--- a/lib/config/service.py
+++ b/lib/config/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Literal
 
@@ -10,6 +11,31 @@ from lib.config.repository import ProviderConfigRepository, SystemSettingReposit
 
 _DEFAULT_VIDEO_BACKEND = "gemini-aistudio/veo-3.1-generate-preview"
 _DEFAULT_IMAGE_BACKEND = "gemini-aistudio/gemini-3.1-flash-image-preview"
+
+# DB setting key → environment variable name
+_ANTHROPIC_ENV_MAP: dict[str, str] = {
+    "anthropic_api_key": "ANTHROPIC_API_KEY",
+    "anthropic_base_url": "ANTHROPIC_BASE_URL",
+    "anthropic_model": "ANTHROPIC_MODEL",
+    "anthropic_default_haiku_model": "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "anthropic_default_opus_model": "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "anthropic_default_sonnet_model": "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "claude_code_subagent_model": "CLAUDE_CODE_SUBAGENT_MODEL",
+}
+
+
+def sync_anthropic_env(all_settings: dict[str, str]) -> None:
+    """Sync Anthropic-related DB settings to environment variables.
+
+    The Claude Agent SDK reads config from os.environ, so DB values
+    must be mirrored to env vars for the SDK to pick them up.
+    """
+    for db_key, env_key in _ANTHROPIC_ENV_MAP.items():
+        value = all_settings.get(db_key, "").strip()
+        if value:
+            os.environ[env_key] = value
+        else:
+            os.environ.pop(env_key, None)
 
 
 @dataclass

--- a/server/app.py
+++ b/server/app.py
@@ -66,12 +66,11 @@ async def lifespan(app: FastAPI):
 
     # Sync Anthropic DB settings to env vars (Claude Agent SDK reads from os.environ)
     try:
-        from server.routers.system_config import _sync_anthropic_env
+        from lib.config.service import ConfigService, sync_anthropic_env
         async with async_session_factory() as session:
-            from lib.config.service import ConfigService
             svc = ConfigService(session)
             all_settings = await svc.get_all_settings()
-            _sync_anthropic_env(all_settings)
+            sync_anthropic_env(all_settings)
     except Exception as exc:
         logger.warning("DB→env Anthropic config sync failed (non-fatal): %s", exc)
 

--- a/server/routers/system_config.py
+++ b/server/routers/system_config.py
@@ -9,7 +9,6 @@ is managed by the providers router.
 from __future__ import annotations
 
 import logging
-import os
 from typing import Annotated, Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -20,6 +19,7 @@ from lib.config.repository import mask_secret
 from lib.config.registry import PROVIDER_REGISTRY
 from lib.config.service import (
     ConfigService,
+    sync_anthropic_env,
     _DEFAULT_IMAGE_BACKEND,
     _DEFAULT_VIDEO_BACKEND,
 )
@@ -108,30 +108,6 @@ _STRING_SETTINGS = (
     "claude_code_subagent_model",
 )
 
-# DB setting key → environment variable name
-_ANTHROPIC_ENV_MAP: dict[str, str] = {
-    "anthropic_api_key": "ANTHROPIC_API_KEY",
-    "anthropic_base_url": "ANTHROPIC_BASE_URL",
-    "anthropic_model": "ANTHROPIC_MODEL",
-    "anthropic_default_haiku_model": "ANTHROPIC_DEFAULT_HAIKU_MODEL",
-    "anthropic_default_opus_model": "ANTHROPIC_DEFAULT_OPUS_MODEL",
-    "anthropic_default_sonnet_model": "ANTHROPIC_DEFAULT_SONNET_MODEL",
-    "claude_code_subagent_model": "CLAUDE_CODE_SUBAGENT_MODEL",
-}
-
-
-def _sync_anthropic_env(all_settings: dict[str, str]) -> None:
-    """Sync Anthropic-related DB settings to environment variables.
-
-    The Claude Agent SDK reads config from os.environ, so DB values
-    must be mirrored to env vars for the SDK to pick them up.
-    """
-    for db_key, env_key in _ANTHROPIC_ENV_MAP.items():
-        value = all_settings.get(db_key, "").strip()
-        if value:
-            os.environ[env_key] = value
-        else:
-            os.environ.pop(env_key, None)
 
 # ---------------------------------------------------------------------------
 # GET /system/config
@@ -227,7 +203,7 @@ async def patch_system_config(
 
     # Sync Anthropic settings to env vars so Claude Agent SDK picks them up
     all_settings = await svc.get_all_settings()
-    _sync_anthropic_env(all_settings)
+    sync_anthropic_env(all_settings)
 
     # Return updated config
     return await get_system_config(_user=_user, svc=svc)


### PR DESCRIPTION
## Summary
- 配置页重构后 `anthropic_api_key` 只写入 DB（`ConfigService.set_setting()`），未同步到 `os.environ["ANTHROPIC_API_KEY"]`，导致 Claude Agent SDK 读不到环境变量而报 "not logged in"
- 新增 `_sync_anthropic_env()` 函数，在 PATCH 写入 DB 后及应用启动时将 Anthropic 相关设置同步到环境变量
- 所有 22 个 system_config 相关测试通过

## Test plan
- [ ] 在配置页保存 Anthropic API Key 后，验证智能体对话不再报 "not logged in"
- [ ] 重启服务器后，验证已保存的 API Key 仍然生效
- [ ] 清除 API Key 后，验证环境变量也被正确移除