### PR TITLE
fix: 任务完成后自动刷新工作台右上角费用显示

### DIFF
--- a/frontend/src/components/layout/GlobalHeader.tsx
+++ b/frontend/src/components/layout/GlobalHeader.tsx
@@ -118,7 +118,8 @@ export function GlobalHeader({ onNavigateBack }: GlobalHeaderProps) {
     currentProjectData?.title?.trim() || currentProjectName || "未选择项目";
   const unreadNotificationCount = workspaceNotifications.filter((item) => !item.read).length;
 
-  // 加载费用统计数据
+  // 加载费用统计数据（任务完成时自动刷新）
+  const completedTaskCount = stats.succeeded + stats.failed;
   useEffect(() => {
     API.getUsageStats(currentProjectName ? { projectName: currentProjectName } : {})
       .then((res) => {
@@ -132,7 +133,7 @@ export function GlobalHeader({ onNavigateBack }: GlobalHeaderProps) {
         });
       })
       .catch(() => {});
-  }, [currentProjectName, setUsageStats]);
+  }, [currentProjectName, completedTaskCount, setUsageStats]);
 
   useEffect(() => {
     void fetchConfigStatus();


### PR DESCRIPTION
## Summary
- GlobalHeader 的费用 useEffect 仅依赖 `currentProjectName`，导致图片/视频生成完成后金额不刷新
- 新增 `completedTaskCount`（`stats.succeeded + stats.failed`）作为 useEffect 依赖，任务轮询检测到完成数变化时自动重新获取费用统计

## Test plan
- [x] TypeScript 类型检查通过
- [x] 全部 125 个前端测试通过
- [ ] 手动验证：触发图片/视频生成，完成后确认右上角金额自动更新