### PR TITLE
fix: 全局默认视频模型传递到所有 VideoBackend + 图片任务传递 payload

### DIFF
--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -106,7 +106,7 @@ def _get_or_create_video_backend(
     provider_settings: dict,
     bulk: _BulkConfig,
     *,
-    default_video_model: str = "",
+    default_video_model: Optional[str] = None,
 ):
     """获取或创建 VideoBackend 实例（带缓存）。
 


### PR DESCRIPTION
## Summary
- `_get_or_create_video_backend` 新增 `default_video_model` 参数，当 `provider_settings` 无 model 时用全局默认兜底，Gemini/Seedance/Grok 统一使用 `effective_model`
- `_resolve_video_backend` 调用时传入 `video_model` 作为 fallback
- `execute_storyboard_task`/`execute_character_task`/`execute_clue_task` 传 payload 给 `get_media_generator`，使项目级图片模型覆盖生效

## 根因
Agent skill 触发视频生成时，payload 中无 `video_provider_settings`，project.json 也无相关配置，`provider_settings` 为空 dict，`provider_settings.get("model")` 返回 None，各后端回退到硬编码默认值，全局设置被忽略。

## Test plan
- [x] 668 个现有测试全部通过
- [ ] 设置页选全局默认视频模型 → agent 生成视频 → 确认使用所选模型
- [ ] 设置页选全局默认图片模型 → agent 生成分镜图 → 确认使用所选模型
- [ ] 项目级覆盖视频/图片模型 → 确认优先于全局默认