### PR TITLE
fix(agent): JSON hook 增加弯引号前置检查防止绕过

### DIFF
--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -476,6 +476,13 @@ class SessionManager:
             if not file_path or not file_path.endswith(".json"):
                 return {}
 
+            # --- Reject curly/smart quotes that would corrupt JSON ---
+            _CURLY_QUOTES = "\u201c\u201d\u201e\u201f"  # ""„‟
+
+            def _has_curly_quotes(text: str) -> bool:
+                """Return True if *text* contains Unicode curly/smart quotes."""
+                return any(ch in _CURLY_QUOTES for ch in text)
+
             # --- Simulate the result without touching the file ---
             simulated: str | None = None
 
@@ -486,6 +493,34 @@ class SessionManager:
                 new_string = tool_input.get("new_string", "")
                 if not old_string:
                     return {}
+
+                # Detect curly quotes early — Claude Code may normalise
+                # old_string internally (allowing the edit to succeed) while
+                # the hook's exact-match ``old_string not in current`` check
+                # below would skip validation, letting curly quotes slip into
+                # the file and corrupt JSON.
+                if _has_curly_quotes(new_string):
+                    curly_found = [
+                        f"U+{ord(ch):04X}" for ch in new_string
+                        if ch in _CURLY_QUOTES
+                    ]
+                    logger.warning(
+                        "PreToolUse JSON 校验拦截(弯引号): file=%s curly=%s",
+                        file_path, curly_found[:5],
+                    )
+                    return {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "permissionDecision": "deny",
+                            "permissionDecisionReason": (
+                                "操作被阻止：new_string 包含弯引号"
+                                "（\u201c 或 \u201d），"
+                                "这会破坏 JSON 格式。"
+                                "请将所有弯引号替换为标准 ASCII "
+                                "双引号 (U+0022) 后重试。"
+                            ),
+                        },
+                    }
 
                 p = Path(file_path)
                 resolved = (

--- a/tests/test_session_manager_more.py
+++ b/tests/test_session_manager_more.py
@@ -713,3 +713,53 @@ class TestJsonValidationHook:
             "new_string": "replacement",
         })
         assert result == {}
+
+    # --- Edit: curly/smart quotes in new_string → deny ---
+
+    async def test_edit_curly_quotes_in_new_string_denies(self, tmp_path):
+        """Edit whose new_string contains curly quotes is denied even when
+        old_string doesn't exactly match the file (Claude Code may normalise
+        quotes internally, bypassing the hook's str.replace simulation)."""
+        json_file = tmp_path / "ep.json"
+        json_file.write_text('{"segment_break": true, "title": "test"}')
+        manager = self._make_manager(tmp_path)
+
+        # old_string uses curly quotes (won't match file via Python str `in`),
+        # but new_string also has curly quotes → must be blocked.
+        result = await self._call_hook(manager, {
+            "file_path": str(json_file),
+            "old_string": "\u201csegment_break\u201d: true",
+            "new_string": "\u201csegment_break\u201d: false",
+        })
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "弯引号" in result["hookSpecificOutput"]["permissionDecisionReason"]
+
+    async def test_edit_curly_quotes_old_only_is_allowed(self, tmp_path):
+        """If only old_string has curly quotes but new_string is clean,
+        don't block (edit will likely fail on its own)."""
+        json_file = tmp_path / "ep.json"
+        json_file.write_text('{"segment_break": true}')
+        manager = self._make_manager(tmp_path)
+
+        result = await self._call_hook(manager, {
+            "file_path": str(json_file),
+            "old_string": "\u201csegment_break\u201d: true",
+            "new_string": '"segment_break": false',
+        })
+        # old_string not in file → hook skips → allowed
+        assert result == {}
+
+    async def test_edit_curly_quotes_in_new_string_straight_old_denies(self, tmp_path):
+        """Edit with straight-quote old_string that matches file but
+        curly-quote new_string is denied via the early curly-quote check."""
+        json_file = tmp_path / "ep.json"
+        json_file.write_text('{"segment_break": true, "title": "test"}')
+        manager = self._make_manager(tmp_path)
+
+        result = await self._call_hook(manager, {
+            "file_path": str(json_file),
+            "old_string": '"segment_break": true',
+            "new_string": "\u201csegment_break\u201d: false",
+        })
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "弯引号" in result["hookSpecificOutput"]["permissionDecisionReason"]


### PR DESCRIPTION
## Summary

- LLM 生成 Edit `new_string` 时可能使用弯引号 `"` `"` (U+201C/U+201D) 替代 JSON 直引号 (U+0022)
- Claude Code CLI 内部做引号标准化匹配使编辑成功，但 hook 的 `str.replace` 模拟因 `old_string` 不匹配文件而跳过验证，弯引号写入文件破坏 JSON
- 在 `old_string not in current` 检查之前增加 `new_string` 弯引号检测，一旦发现立即 deny 并提示智能体修正

## Test plan

- [x] 新增 3 个测试覆盖弯引号场景（old+new 弯引号 → deny、仅 old 弯引号 → skip、仅 new 弯引号 → deny）
- [x] 原有 9 个 JSON hook 测试全部通过（共 12/12）
- [x] 完整 session_manager 测试 29/29 通过