### PR TITLE
fix: 视频 provider_id 全链路一致性修复

### DIFF
--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -405,7 +405,7 @@ class MediaGenerator:
         else:
             video_client = self._get_gemini_video()
             model_name = video_client.VIDEO_MODEL
-            provider_name = "gemini"
+            provider_name = f"gemini-{self._gemini_video_backend_type}"
             configured_generate_audio = self._resolve_video_generate_audio()
             effective_generate_audio = (
                 configured_generate_audio if self._gemini_video_backend_type == "vertex" else True
@@ -551,7 +551,7 @@ class MediaGenerator:
         else:
             video_client = self._get_gemini_video()
             model_name = video_client.VIDEO_MODEL
-            provider_name = "gemini"
+            provider_name = f"gemini-{self._gemini_video_backend_type}"
             configured_generate_audio = self._resolve_video_generate_audio()
             effective_generate_audio = (
                 configured_generate_audio if self._gemini_video_backend_type == "vertex" else True

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -100,7 +100,7 @@ class GeminiVideoBackend:
 
     @property
     def name(self) -> str:
-        return PROVIDER_GEMINI
+        return f"gemini-{self._backend_type}"
 
     @property
     def model(self) -> str:

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -59,6 +59,18 @@ class GenerateClueRequest(BaseModel):
     prompt: str
 
 
+_LEGACY_PROVIDER_NAMES: dict[str, str] = {
+    "gemini": "gemini-aistudio",
+    "aistudio": "gemini-aistudio",
+    "vertex": "gemini-vertex",
+}
+
+
+def _normalize_provider_id(raw: str) -> str:
+    """将旧格式 provider 名称归一化为标准 provider_id。"""
+    return _LEGACY_PROVIDER_NAMES.get(raw, raw)
+
+
 def _snapshot_image_backend(project_name: str) -> dict:
     """快照图片供应商配置，返回可合并到 payload 的字典。
 
@@ -69,7 +81,7 @@ def _snapshot_image_backend(project_name: str) -> dict:
     if project_image_backend and "/" in project_image_backend:
         image_provider, image_model = project_image_backend.split("/", 1)
     elif project_image_backend:
-        image_provider = project_image_backend
+        image_provider = _normalize_provider_id(project_image_backend)
         image_model = ""
     else:
         return {}  # 无项目级覆盖，使用全局默认
@@ -195,7 +207,7 @@ async def generate_video(project_name: str, segment_id: str, req: GenerateVideoR
         if project_video_backend and "/" in project_video_backend:
             video_provider, video_model = project_video_backend.split("/", 1)
         elif project_video_backend:
-            video_provider = project_video_backend
+            video_provider = _normalize_provider_id(project_video_backend)
             video_model = ""
         else:
             from server.services.generation_tasks import _load_all_config

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -193,8 +193,9 @@ def _resolve_video_backend(
         project = get_project_manager().load_project(project_name)
         provider_name = project.get("video_provider")
         if not provider_name:
-            provider_name = _PROVIDER_ID_TO_BACKEND.get(default_video_provider_id, default_video_provider_id)
-            if provider_name == PROVIDER_GEMINI:
+            provider_name = default_video_provider_id
+            mapped = _PROVIDER_ID_TO_BACKEND.get(provider_name, provider_name)
+            if mapped == PROVIDER_GEMINI:
                 video_backend_type = "vertex" if default_video_provider_id == "gemini-vertex" else "aistudio"
         provider_settings = project.get("video_provider_settings", {}).get(provider_name, {})
         video_backend = _get_or_create_video_backend(

--- a/tests/test_video_backend_gemini.py
+++ b/tests/test_video_backend_gemini.py
@@ -40,7 +40,7 @@ def backend(mock_rate_limiter):
 
 class TestGeminiVideoBackendProperties:
     def test_name(self, backend):
-        assert backend.name == "gemini"
+        assert backend.name == "gemini-aistudio"
 
     def test_capabilities_aistudio(self, backend):
         caps = backend.capabilities


### PR DESCRIPTION
## Summary

- **`_resolve_video_backend` 丢失 vertex 标识**：回退到全局默认时，`default_video_provider_id`（如 `gemini-vertex`）被 `_PROVIDER_ID_TO_BACKEND` 映射为通用名 `gemini`，传给 `_get_or_create_video_backend` 后无法匹配 `gemini-vertex` 分支，默认走 `aistudio`，导致 Vertex AI 模型 404
- **费用统计无法区分 aistudio/vertex**：`GeminiVideoBackend.name` 统一返回 `gemini`，改为返回 `gemini-aistudio` / `gemini-vertex`，UI 可按供应商筛选
- **project.json 旧格式兼容**：`video_backend` / `image_backend` 可能存储旧格式（如 `vertex`、`aistudio`），新增归一化函数防止后端创建失败

## Test plan

- [x] 全部 660 测试通过（7 个预存 auth error 不受影响）
- [ ] 手动验证：系统设置选择 Vertex AI 模型后，视频生成任务使用 vertex 后端
- [ ] 手动验证：费用统计页面可按 gemini-aistudio / gemini-vertex 分别筛选