### PR TITLE
fix(agent): JSON validation hook 增加 PostToolUse 兜底和诊断日志

### DIFF
--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -713,10 +713,12 @@ class SessionManager:
                 return {}
             except json.JSONDecodeError as exc:
                 # File is corrupt — restore from backup if available
+                restored = False
                 if backup:
                     backup_path, backup_content = backup
                     try:
                         backup_path.write_text(backup_content, encoding="utf-8")
+                        restored = True
                         logger.warning(
                             "PostToolUse JSON 校验拦截并恢复: file=%s tool=%s "
                             "error=%s backup_restored=True",
@@ -733,14 +735,24 @@ class SessionManager:
                         file_path, tool_name, exc,
                     )
 
+                if restored:
+                    ctx = (
+                        f"⚠ JSON 损坏已检测并回滚：{tool_name} 导致 "
+                        f"{file_path} 变成无效 JSON（{exc}）。"
+                        "文件已恢复到编辑前状态，请修正后重试。"
+                    )
+                else:
+                    ctx = (
+                        f"⚠ JSON 损坏已检测但无法恢复：{tool_name} 导致 "
+                        f"{file_path} 变成无效 JSON（{exc}）。"
+                        "文件当前仍为损坏状态（无可用备份或恢复写入失败），"
+                        "请先读取文件确认内容，再手动修正为合法 JSON。"
+                    )
+
                 return {
                     "hookSpecificOutput": {
                         "hookEventName": "PostToolUse",
-                        "additionalContext": (
-                            f"⚠ JSON 损坏已检测并回滚：{tool_name} 导致 "
-                            f"{file_path} 变成无效 JSON（{exc}）。"
-                            "文件已恢复到编辑前状态，请修正后重试。"
-                        ),
+                        "additionalContext": ctx,
                     },
                 }
 

--- a/tests/test_session_manager_more.py
+++ b/tests/test_session_manager_more.py
@@ -854,7 +854,9 @@ class TestJsonPostValidationHook:
             json_backups={},
         )
 
-        assert "additionalContext" in result.get("hookSpecificOutput", {})
+        ctx = result.get("hookSpecificOutput", {}).get("additionalContext", "")
+        assert "无法恢复" in ctx
+        assert "回滚" not in ctx
 
     # --- Non-.json file → skip ---
 


### PR DESCRIPTION
## Summary

- 新增 **PostToolUse hook** 作为 JSON 校验的第二道防线：编辑完成后读取实际文件做 `json.loads()` 验证，失败则从备份恢复文件并通过 `additionalContext` 通知 agent
- PreToolUse hook 每个分支增加 **info 级别诊断日志**，记录跳过原因、匹配结果、验证结果，方便定位绕过原因
- Pre/Post 通过共享 `json_backups` 字典传递文件备份，自动清理防止内存泄漏

## Background

PreToolUse 的模拟式验证（`str.replace()` + `json.loads()`）存在结构性盲区——当 `old_string` 与文件内容不匹配或转义层级差异导致模拟结果与实际不一致时，无效编辑会绕过检测直接写入文件。

## Test plan

- [x] 原有 12 个 PreToolUse 测试全部通过
- [x] 新增 5 个 PostToolUse 测试：验证通过、备份恢复、无备份报错、非 JSON 跳过、备份清理
- [x] 完整测试套件 34 passed