### PR TITLE
fix: pass video_generate_audio setting to MediaGenerator

### DIFF
--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -227,7 +227,10 @@ async def get_media_generator(project_name: str, payload: dict | None = None) ->
     project = get_project_manager().load_project(project_name)
     project_audio_override = project.get("video_generate_audio")
     if project_audio_override is not None:
-        video_generate_audio = bool(project_audio_override)
+        if isinstance(project_audio_override, str):
+            video_generate_audio = project_audio_override.lower() in ("true", "1", "yes")
+        else:
+            video_generate_audio = bool(project_audio_override)
 
     return MediaGenerator(
         project_path,


### PR DESCRIPTION
## Summary

- `video_generate_audio` 设置在前端和数据库中正确存储，但 `get_media_generator()` 创建 `MediaGenerator` 时从未传递该参数，导致始终使用默认值 `True`（即始终生成音频）
- 在 `_BulkConfig` 中新增 `video_generate_audio` 字段，从 DB 加载全局设置，并在 `get_media_generator()` 中解析项目级覆盖后传递给 `MediaGenerator`
- 优先级链路：项目级设置 > 全局设置 > 默认值 (True)

## Test plan

- [x] 现有测试通过 (`test_generation_tasks_service`, `test_media_generator_module`)
- [ ] 在全局设置中关闭「生成音频」，生成视频验证无音频
- [ ] 在项目设置中覆盖为「开启」，验证项目级覆盖生效
- [ ] 在项目设置中选择「跟随全局默认」，验证回退到全局设置