### PR TITLE
fix: video polling timer accuracy and logging

### DIFF
--- a/lib/gemini_client.py
+++ b/lib/gemini_client.py
@@ -958,11 +958,12 @@ class GeminiClient:
                 raise TimeoutError(f"视频{mode_text}超时（{max_wait_time}秒）")
             time.sleep(poll_interval)
             operation = self.client.operations.get(operation)
-            elapsed = time.monotonic() - start_time
-            logger.info(
-                "视频%s中... 已等待 %.0f 秒 (operation=%s)",
-                mode_text, elapsed, op_name,
-            )
+            if not operation.done:
+                elapsed = time.monotonic() - start_time
+                logger.info(
+                    "视频%s中... 已等待 %.0f 秒 (operation=%s)",
+                    mode_text, elapsed, op_name,
+                )
 
         total_elapsed = time.monotonic() - start_time
         logger.info("视频%s完成, 总耗时 %.0f 秒, operation=%s", mode_text, total_elapsed, op_name)
@@ -1248,11 +1249,12 @@ class GeminiClient:
                 raise TimeoutError(f"视频{mode_text}超时（{max_wait_time}秒）")
             await asyncio.sleep(poll_interval)
             operation = await self.client.aio.operations.get(operation)
-            elapsed = time.monotonic() - start_time
-            logger.info(
-                "视频%s中... 已等待 %.0f 秒 (operation=%s)",
-                mode_text, elapsed, op_name,
-            )
+            if not operation.done:
+                elapsed = time.monotonic() - start_time
+                logger.info(
+                    "视频%s中... 已等待 %.0f 秒 (operation=%s)",
+                    mode_text, elapsed, op_name,
+                )
 
         return self._process_video_result(
             operation, output_path, is_extend_mode, output_gcs_uri

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -172,11 +172,12 @@ class GeminiVideoBackend:
                 raise TimeoutError(f"视频生成超时（{max_wait_time}秒）")
             await asyncio.sleep(poll_interval)
             operation = await self._client.aio.operations.get(operation)
-            elapsed = time.monotonic() - start_time
-            logger.info(
-                "视频生成中... 已等待 %.0f 秒 (operation=%s)",
-                elapsed, op_name,
-            )
+            if not operation.done:
+                elapsed = time.monotonic() - start_time
+                logger.info(
+                    "视频生成中... 已等待 %.0f 秒 (operation=%s)",
+                    elapsed, op_name,
+                )
 
         total_elapsed = time.monotonic() - start_time
         logger.info("视频生成完成, 总耗时 %.0f 秒, operation=%s", total_elapsed, op_name)


### PR DESCRIPTION
## Summary

- **修复计时偏差**：视频生成轮询中 `elapsed` 使用 `+= poll_interval` 累加，完全忽略了 `operations.get()` API 调用耗时（~10s/次），导致日志显示的等待时间恒定为实际墙钟时间的一半。改用 `time.monotonic()` 精确计时。
- **增强日志信息**：在提交、轮询、完成、失败各阶段记录 operation ID；失败时额外记录 `error` 和 `metadata` 详情，便于排查空结果问题。
- **调整轮询间隔**：`GeminiVideoBackend` 的 `poll_interval` 从 10s 调整为 20s，与 Google 官方文档推荐一致，减少无效 API 调用。
- 修改覆盖所有 3 处轮询代码（video backend + legacy sync/async in gemini_client）。

## Test plan

- [x] `pytest tests/test_video_backend_gemini.py` — 16 tests passed
- [ ] 部署后触发视频生成，验证日志时间戳与 elapsed 一致（不再 2 倍偏差）
- [ ] 确认失败场景日志包含 operation ID 和 error 详情