### PR TITLE
fix: 导出 zip 时排除 .claude 软连接和 CLAUDE.md

### DIFF
--- a/server/services/project_archive.py
+++ b/server/services/project_archive.py
@@ -157,6 +157,7 @@ class ProjectArchiveService:
         "clues": ".png",
     }
     _ROOT_VISIBLE_ENTRIES = frozenset(DataValidator.ALLOWED_ROOT_ENTRIES)
+    _AGENT_RUNTIME_EXCLUDES = frozenset({".claude", "CLAUDE.md"})
     _PLACEHOLDER_CHARACTER_DESCRIPTION = "Imported placeholder character"
 
     def __init__(self, project_manager: ProjectManager):
@@ -382,11 +383,13 @@ class ProjectArchiveService:
 
         for current_dir, dirnames, filenames in os.walk(snapshot_dir):
             current_path = Path(current_dir)
+            is_root = current_path == snapshot_dir
             dirnames[:] = [
                 name
                 for name in sorted(dirnames)
                 if not name.startswith(".")
                 and not (current_path / name).is_symlink()
+                and not (is_root and name in self._AGENT_RUNTIME_EXCLUDES)
             ]
 
             relative_dir = current_path.relative_to(snapshot_dir)
@@ -402,6 +405,7 @@ class ProjectArchiveService:
                 for name in sorted(filenames)
                 if not name.startswith(".")
                 and not (current_path / name).is_symlink()
+                and not (is_root and name in self._AGENT_RUNTIME_EXCLUDES)
             ]
 
             if relative_dir != Path("."):
@@ -456,11 +460,13 @@ class ProjectArchiveService:
         target_dir.mkdir(parents=True, exist_ok=True)
         for current_dir, dirnames, filenames in os.walk(source_dir):
             current_path = Path(current_dir)
+            is_root = current_path == source_dir
             dirnames[:] = [
                 name
                 for name in sorted(dirnames)
                 if not name.startswith(".")
                 and not (current_path / name).is_symlink()
+                and not (is_root and name in self._AGENT_RUNTIME_EXCLUDES)
             ]
             relative_dir = current_path.relative_to(source_dir)
             destination_dir = target_dir / relative_dir
@@ -469,6 +475,8 @@ class ProjectArchiveService:
             for filename in sorted(filenames):
                 source_path = current_path / filename
                 if filename.startswith(".") or source_path.is_symlink():
+                    continue
+                if is_root and filename in self._AGENT_RUNTIME_EXCLUDES:
                     continue
                 destination_path = destination_dir / filename
                 destination_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1003,6 +1011,8 @@ class ProjectArchiveService:
 
         for child in sorted(project_dir.iterdir(), key=lambda item: item.name):
             if self._is_hidden_path(Path(child.name)):
+                continue
+            if child.name in self._AGENT_RUNTIME_EXCLUDES:
                 continue
             if child.name not in self._ROOT_VISIBLE_ENTRIES:
                 entries.append(child.name)

--- a/tests/test_project_archive_service.py
+++ b/tests/test_project_archive_service.py
@@ -123,6 +123,20 @@ def _create_project(
     return project_dir
 
 
+def _add_agent_runtime_symlinks(project_dir: Path) -> None:
+    """Create agent_runtime_profile and symlinks mimicking production layout."""
+    # projects_root is project_dir.parent; project_root is projects_root.parent
+    project_root = project_dir.parent.parent
+    profile_claude = project_root / "agent_runtime_profile" / ".claude"
+    profile_claude.mkdir(parents=True, exist_ok=True)
+    (profile_claude / "settings.json").write_text("{}", encoding="utf-8")
+    profile_md = project_root / "agent_runtime_profile" / "CLAUDE.md"
+    profile_md.write_text("# Agent Runtime", encoding="utf-8")
+
+    (project_dir / ".claude").symlink_to(Path("../../agent_runtime_profile/.claude"))
+    (project_dir / "CLAUDE.md").symlink_to(Path("../../agent_runtime_profile/CLAUDE.md"))
+
+
 def _make_manual_zip(project_dir: Path, zip_path: Path) -> None:
     with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for item in sorted(project_dir.rglob("*")):
@@ -162,6 +176,59 @@ class TestProjectArchiveService:
             assert "demo/style_reference.png" in names
             assert "demo/.DS_Store" not in names
             assert "demo/.hidden/secret.txt" not in names
+
+    def test_export_excludes_agent_runtime_symlinks(self, tmp_path):
+        pm = ProjectManager(tmp_path / "projects")
+        project_dir = _create_project(pm)
+        _add_agent_runtime_symlinks(project_dir)
+
+        assert (project_dir / ".claude").is_symlink()
+        assert (project_dir / "CLAUDE.md").is_symlink()
+
+        service = ProjectArchiveService(pm)
+        archive_path, _ = service.export_project("demo")
+
+        with zipfile.ZipFile(archive_path) as archive:
+            names = set(archive.namelist())
+            assert not any(".claude" in n for n in names)
+            assert not any("CLAUDE.md" in n for n in names)
+            assert "demo/project.json" in names
+            assert "demo/source/chapter.txt" in names
+
+    def test_export_excludes_agent_runtime_real_files(self, tmp_path):
+        pm = ProjectManager(tmp_path / "projects")
+        project_dir = _create_project(pm)
+        (project_dir / "CLAUDE.md").write_text("# Agent", encoding="utf-8")
+
+        service = ProjectArchiveService(pm)
+        archive_path, _ = service.export_project("demo")
+
+        with zipfile.ZipFile(archive_path) as archive:
+            names = set(archive.namelist())
+            assert not any("CLAUDE.md" in n for n in names)
+            assert "demo/project.json" in names
+
+    def test_export_excludes_broken_agent_runtime_symlinks(self, tmp_path):
+        pm = ProjectManager(tmp_path / "projects")
+        project_dir = _create_project(pm)
+        # Create broken symlinks (targets don't exist)
+        (project_dir / ".claude").symlink_to(
+            Path("../../agent_runtime_profile/.claude")
+        )
+        (project_dir / "CLAUDE.md").symlink_to(
+            Path("../../agent_runtime_profile/CLAUDE.md")
+        )
+
+        assert (project_dir / ".claude").is_symlink()
+        assert not (project_dir / ".claude").exists()
+
+        service = ProjectArchiveService(pm)
+        archive_path, _ = service.export_project("demo")
+
+        with zipfile.ZipFile(archive_path) as archive:
+            names = set(archive.namelist())
+            assert not any(".claude" in n for n in names)
+            assert not any("CLAUDE.md" in n for n in names)
 
     def test_import_official_export_round_trip(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")


### PR DESCRIPTION
## Summary
- 导出项目 zip 时，`.claude` 目录软连接和 `CLAUDE.md` 文件软连接会被包含在 zip 中，导致解压报错
- 添加显式排除列表 `_AGENT_RUNTIME_EXCLUDES`，在项目根目录级别过滤 agent runtime 相关条目
- 三层纵深防御：`_copy_visible_tree`、`_write_snapshot_members`、`_collect_pass_through_entries` 均增加排除检查

## Test plan
- [x] `test_export_excludes_agent_runtime_symlinks` — 验证正常软连接被排除
- [x] `test_export_excludes_agent_runtime_real_files` — 验证 CLAUDE.md 实体文件也被排除
- [x] `test_export_excludes_broken_agent_runtime_symlinks` — 验证断开的软连接不崩溃且被排除
- [x] 全部 30 个测试通过