### PR TITLE
fix: add_characters_clues 改用 from_cwd() 自动推断项目

### DIFF
--- a/agent_runtime_profile/.claude/skills/manage-project/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/manage-project/SKILL.md
@@ -63,12 +63,14 @@ cd projects/{project_name} && python ../../.claude/skills/manage-project/scripts
 
 ## 角色/线索批量写入
 
+从项目目录内执行，自动检测项目名称：
+
 ```bash
 # 通过命令行参数（⚠️ 必须单行，JSON 使用紧凑格式，不可用 \ 换行）
-python .claude/skills/manage-project/scripts/add_characters_clues.py {project_name} --characters '{"角色名": {"description": "...", "voice_style": "..."}}' --clues '{"线索名": {"type": "prop", "description": "...", "importance": "major"}}'
+python .claude/skills/manage-project/scripts/add_characters_clues.py --characters '{"角色名": {"description": "...", "voice_style": "..."}}' --clues '{"线索名": {"type": "prop", "description": "...", "importance": "major"}}'
 
 # 通过 stdin（推荐用于大量角色/线索）
-echo '{"characters": {...}, "clues": {...}}' | python .claude/skills/manage-project/scripts/add_characters_clues.py {project_name} --stdin
+echo '{"characters": {...}, "clues": {...}}' | python .claude/skills/manage-project/scripts/add_characters_clues.py --stdin
 ```
 
 ## 字数统计规则

--- a/agent_runtime_profile/.claude/skills/manage-project/scripts/add_characters_clues.py
+++ b/agent_runtime_profile/.claude/skills/manage-project/scripts/add_characters_clues.py
@@ -2,13 +2,13 @@
 """
 add_characters_clues.py - 批量添加角色/线索到 project.json
 
-用法:
-    python add_characters_clues.py {project_name} \
+用法（需从项目目录内执行）:
+    python .claude/skills/manage-project/scripts/add_characters_clues.py \
         --characters '{"角色名": {"description": "...", "voice_style": "..."}}' \
         --clues '{"线索名": {"type": "prop", "description": "...", "importance": "major"}}'
 
     # 通过 stdin 接收 JSON
-    echo '{"characters": {...}, "clues": {...}}' | python add_characters_clues.py {project_name} --stdin
+    echo '{"characters": {...}, "clues": {...}}' | python .claude/skills/manage-project/scripts/add_characters_clues.py --stdin
 """
 
 import argparse
@@ -32,14 +32,13 @@ def main():
         description="批量添加角色/线索到 project.json",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-示例:
-    %(prog)s my_project --characters '{"李白": {"description": "白衣剑客", "voice_style": "豪放"}}'
-    %(prog)s my_project --clues '{"玉佩": {"type": "prop", "description": "温润白玉", "importance": "major"}}'
-    echo '{"characters": {...}}' | %(prog)s my_project --stdin
+示例（需从项目目录内执行）:
+    %(prog)s --characters '{"李白": {"description": "白衣剑客", "voice_style": "豪放"}}'
+    %(prog)s --clues '{"玉佩": {"type": "prop", "description": "温润白玉", "importance": "major"}}'
+    echo '{"characters": {...}}' | %(prog)s --stdin
         """,
     )
 
-    parser.add_argument("project_name", help="项目名称")
     parser.add_argument(
         "--characters",
         type=str,
@@ -77,30 +76,30 @@ def main():
         print("❌ 未提供角色或线索数据")
         sys.exit(1)
 
-    pm = ProjectManager()
+    pm, project_name = ProjectManager.from_cwd()
 
     # 添加角色
     chars_added = 0
     chars_skipped = 0
     if characters:
-        project = pm.load_project(args.project_name)
+        project = pm.load_project(project_name)
         existing = project.get("characters", {})
         chars_skipped = sum(1 for name in characters if name in existing)
-        chars_added = pm.add_characters_batch(args.project_name, characters)
+        chars_added = pm.add_characters_batch(project_name, characters)
         print(f"角色: 新增 {chars_added} 个，跳过 {chars_skipped} 个（已存在）")
 
     # 添加线索
     clues_added = 0
     clues_skipped = 0
     if clues:
-        project = pm.load_project(args.project_name)
+        project = pm.load_project(project_name)
         existing = project.get("clues", {})
         clues_skipped = sum(1 for name in clues if name in existing)
-        clues_added = pm.add_clues_batch(args.project_name, clues)
+        clues_added = pm.add_clues_batch(project_name, clues)
         print(f"线索: 新增 {clues_added} 个，跳过 {clues_skipped} 个（已存在）")
 
     # 数据验证
-    result = validate_project(args.project_name)
+    result = validate_project(project_name, projects_root=str(pm.projects_root))
     if result.valid:
         print("✅ 数据验证通过")
     else:


### PR DESCRIPTION
## Summary
- 移除 `add_characters_clues.py` 的 `project_name` 位置参数，改用 `ProjectManager.from_cwd()` 从 CWD 自动推断项目名称和 `projects_root`
- 与仓库内所有其他 skill 脚本（generate_character、generate_clue、generate_storyboard 等）保持一致
- 同步更新 SKILL.md 调用示例

## Root Cause
Agent 运行时 CWD 始终为 `/app/projects/{project_name}/`，但脚本要求传入 `project_name` 位置参数。当 agent 传入中文项目标题时，`normalize_project_name` 的正则 `^[A-Za-z0-9-]+$` 拒绝了它。此外裸 `ProjectManager()` 默认 `projects_root="projects"`（相对路径），在项目目录内运行时解析路径也不正确。

## Test plan
- [x] `pytest tests/ -k "character"` — 9 tests passed
- [x] 语法检查通过