### PR TITLE
fix: 修复供应商详情页无限刷新

### DIFF
--- a/frontend/src/components/pages/CredentialList.tsx
+++ b/frontend/src/components/pages/CredentialList.tsx
@@ -428,11 +428,16 @@ export function CredentialList({ providerId, onChanged }: Props) {
     try {
       const { credentials: creds } = await API.listCredentials(providerId);
       setCredentials(creds);
-      onChangedRef.current?.();
     } finally {
       setLoading(false);
     }
   }, [providerId]);
+
+  // 用户操作后：刷新列表 + 通知父组件
+  const handleChanged = useCallback(async () => {
+    await refresh();
+    onChangedRef.current?.();
+  }, [refresh]);
 
   useEffect(() => {
     setLoading(true);
@@ -483,7 +488,7 @@ export function CredentialList({ providerId, onChanged }: Props) {
             cred={c}
             providerId={providerId}
             isVertex={isVertex}
-            onChanged={refresh}
+            onChanged={handleChanged}
           />
         ))}
       </div>
@@ -495,7 +500,7 @@ export function CredentialList({ providerId, onChanged }: Props) {
             isVertex={isVertex}
             onCreated={() => {
               setShowAdd(false);
-              void refresh();
+              void handleChanged();
             }}
             onCancel={() => setShowAdd(false)}
           />

--- a/frontend/src/components/pages/ProviderDetail.tsx
+++ b/frontend/src/components/pages/ProviderDetail.tsx
@@ -180,12 +180,13 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
   const [draft, setDraft] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
-  const [refreshKey, setRefreshKey] = useState(0);
 
-  const handleCredentialChanged = useCallback(() => {
-    setRefreshKey((k) => k + 1);
+  const handleCredentialChanged = useCallback(async () => {
+    // 静默刷新配置（不清除 detail，避免 loading 闪烁和子组件重挂）
+    const updated = await API.getProviderConfig(providerId);
+    setDetail(updated);
     onSaved?.();
-  }, [onSaved]);
+  }, [providerId, onSaved]);
 
   useEffect(() => {
     let disposed = false;
@@ -195,7 +196,7 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
       if (!disposed) setDetail(res);
     });
     return () => { disposed = true; };
-  }, [providerId, refreshKey]);
+  }, [providerId]);
 
   const handleSave = useCallback(async () => {
     if (Object.keys(draft).length === 0) return;


### PR DESCRIPTION
## Summary
- 供应商详情页（ProviderDetail + CredentialList）因 `onChanged` 回调在初始加载时被触发，形成 `refresh → onChanged → refreshKey++ → unmount/remount → refresh` 无限循环
- 拆分 `CredentialList.refresh()`（纯取数据）和 `handleChanged()`（取数据 + 通知父组件），初始加载只调用 `refresh()`
- `ProviderDetail` 移除 `refreshKey` 状态，改为静默刷新配置（不清除 `detail`），避免 loading 闪烁和子组件重挂

## Test plan
- [x] TypeScript 类型检查通过
- [x] 全部 125 个前端测试通过
- [ ] 手动验证：打开供应商设置页，确认详情不再反复刷新
- [ ] 手动验证：添加/删除/激活密钥后，供应商状态正确更新