### PR TITLE
fix: 替换 crypto.randomUUID 为 uid()，修复 HTTP+IP 访问报错

### DIFF
--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo } from "react";
 import { Loader2, Plus, Trash2, Eye, EyeOff, CheckCircle2, XCircle, Search } from "lucide-react";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
+import { uid } from "@/utils/id";
 import type {
   CustomProviderInfo,
   CustomProviderModelInput,
@@ -41,7 +42,7 @@ interface ModelRow {
 
 function newModelRow(partial?: Partial<ModelRow>): ModelRow {
   return {
-    key: crypto.randomUUID(),
+    key: uid(),
     model_id: "",
     display_name: "",
     media_type: "text",


### PR DESCRIPTION
crypto.randomUUID() 仅在安全上下文（HTTPS/localhost）下可用，
通过 HTTP+IP 访问时会抛出 TypeError。改用项目已有的 uid() 工具函数。

https://claude.ai/code/session_01DvmTBuuCLoujAdkUsgixxg