### PR TITLE
fix: 项目级视频/图片模型配置未生效

### DIFF
--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -71,10 +71,12 @@ class ProviderPool:
 
 
 def _project_level_provider(project: dict, task_type: str) -> str | None:
-    """Read project-level provider override, if any."""
-    if task_type == "video":
-        return project.get("video_provider")
-    project_backend = project.get("image_backend")
+    """Read project-level provider override, if any.
+
+    video/image 均统一从 ``video_backend`` / ``image_backend``（"provider/model" 格式）解析。
+    """
+    field = "video_backend" if task_type == "video" else "image_backend"
+    project_backend = project.get(field)
     if project_backend and "/" in project_backend:
         return project_backend.split("/", 1)[0]
     return project_backend

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -296,8 +296,9 @@ async def get_media_generator(
                 project = await asyncio.to_thread(get_project_manager().load_project, project_name)
                 proj_provider, proj_model = _parse_project_backend(project.get("image_backend"))
                 if proj_provider:
+                    # 仅当 provider 相同时才复用全局默认 model，避免跨 provider model 不匹配
+                    image_model = proj_model or (image_model if proj_provider == image_provider_id else None)
                     image_provider_id = proj_provider
-                    image_model = proj_model or image_model
             image_backend = await _get_or_create_image_backend(
                 image_provider_id,
                 {},

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -151,7 +151,7 @@ class TestExtractProvider:
         assert await _extract_provider(task) == "gemini-vertex"
 
     async def test_project_level_video_provider_takes_precedence(self, monkeypatch):
-        """项目级 video_provider 优先于全局默认。"""
+        """项目级 video_backend 优先于全局默认。"""
 
         async def should_not_be_called(self):
             raise AssertionError("ConfigResolver should not be called")
@@ -162,7 +162,7 @@ class TestExtractProvider:
         )
         monkeypatch.setattr(
             "lib.config.resolver.get_project_manager",
-            lambda: type("PM", (), {"load_project": lambda self, name: {"video_provider": "ark"}})(),
+            lambda: type("PM", (), {"load_project": lambda self, name: {"video_backend": "ark"}})(),
         )
         task = {"payload": {}, "project_name": "test", "task_type": "video"}
         assert await _extract_provider(task) == "ark"
@@ -200,7 +200,10 @@ class TestExtractProvider:
 
 class TestProjectLevelProvider:
     def test_video_provider(self):
-        assert _project_level_provider({"video_provider": "ark"}, "video") == "ark"
+        assert _project_level_provider({"video_backend": "ark"}, "video") == "ark"
+
+    def test_video_backend_with_slash(self):
+        assert _project_level_provider({"video_backend": "grok/grok-imagine-video"}, "video") == "grok"
 
     def test_video_no_override(self):
         assert _project_level_provider({}, "video") is None


### PR DESCRIPTION
## Summary

- `_resolve_video_backend()` 读取不存在的 `video_provider` / `video_provider_settings` 字段，导致项目级视频模型始终回退到全局默认。实际前端保存的是 `video_backend`（`"provider/model"` 格式）
- 新增 `_parse_project_backend()` 统一解析 `"provider/model"` 格式
- 修复 `_resolve_video_backend()` 从 `project.json` 的 `video_backend` 字段正确解析 provider 和 model
- 增强 `get_media_generator()` 图片后端在 payload 无 `image_provider` 时也从 `project.json` 读取 `image_backend`

## Test plan

- [x] 全部 1234 个测试通过
- [x] ruff check & format 通过
- [ ] 手动测试：项目设置自定义视频供应商后生成视频，验证使用的是项目级模型而非全局默认
- [ ] 手动测试：项目设置自定义图片供应商后生成分镜图，验证使用的是项目级模型