### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -321,4 +321,25 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             ),
         },
     ),
+    "minimax": ProviderMeta(
+        display_name="MiniMax",
+        description="MiniMax 开放平台，支持 MiniMax-M2.7 文本生成。",
+        required_keys=["api_key"],
+        optional_keys=["base_url"],
+        secret_keys=["api_key"],
+        models={
+            # --- text ---
+            "MiniMax-M2.7": ModelInfo(
+                display_name="MiniMax-M2.7",
+                media_type="text",
+                capabilities=["text_generation", "structured_output", "vision"],
+                default=True,
+            ),
+            "MiniMax-M2.7-highspeed": ModelInfo(
+                display_name="MiniMax-M2.7 High Speed",
+                media_type="text",
+                capabilities=["text_generation", "structured_output", "vision"],
+            ),
+        },
+    ),
 }

--- a/lib/providers.py
+++ b/lib/providers.py
@@ -6,6 +6,7 @@ PROVIDER_GEMINI = "gemini"
 PROVIDER_ARK = "ark"
 PROVIDER_GROK = "grok"
 PROVIDER_OPENAI = "openai"
+PROVIDER_MINIMAX = "minimax"
 
 CallType = Literal["image", "video", "text"]
 CALL_TYPE_IMAGE: CallType = "image"

--- a/lib/text_backends/__init__.py
+++ b/lib/text_backends/__init__.py
@@ -42,3 +42,8 @@ from lib.providers import PROVIDER_OPENAI
 from lib.text_backends.openai import OpenAITextBackend
 
 register_backend(PROVIDER_OPENAI, OpenAITextBackend)
+
+from lib.providers import PROVIDER_MINIMAX
+from lib.text_backends.minimax import MiniMaxTextBackend
+
+register_backend(PROVIDER_MINIMAX, MiniMaxTextBackend)

--- a/lib/text_backends/factory.py
+++ b/lib/text_backends/factory.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from lib.config.resolver import ConfigResolver
 from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.db import async_session_factory
-from lib.providers import PROVIDER_OPENAI
+from lib.providers import PROVIDER_MINIMAX, PROVIDER_OPENAI
 from lib.text_backends.base import TextBackend, TextTaskType
 from lib.text_backends.registry import create_backend
 
@@ -15,6 +15,7 @@ PROVIDER_ID_TO_BACKEND: dict[str, str] = {
     "ark": "ark",
     "grok": "grok",
     "openai": "openai",
+    "minimax": "minimax",
 }
 
 
@@ -72,7 +73,7 @@ async def create_text_backend_for_task(
         kwargs["gcs_bucket"] = provider_config.get("gcs_bucket")
     else:
         kwargs["api_key"] = provider_config.get("api_key")
-        if provider_id in ("gemini-aistudio", PROVIDER_OPENAI):
+        if provider_id in ("gemini-aistudio", PROVIDER_OPENAI, PROVIDER_MINIMAX):
             kwargs["base_url"] = provider_config.get("base_url")
 
     return create_backend(backend_name, **kwargs)

--- a/lib/text_backends/minimax.py
+++ b/lib/text_backends/minimax.py
@@ -1,0 +1,142 @@
+"""MiniMaxTextBackend — MiniMax 文本生成后端（OpenAI 兼容接口）。"""
+
+from __future__ import annotations
+
+import logging
+
+from lib.openai_shared import OPENAI_RETRYABLE_ERRORS, create_openai_client
+from lib.providers import PROVIDER_MINIMAX
+from lib.retry import with_retry_async
+from lib.text_backends.base import (
+    TextCapability,
+    TextGenerationRequest,
+    TextGenerationResult,
+    resolve_schema,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "MiniMax-M2.7"
+DEFAULT_BASE_URL = "https://api.minimax.io/v1"
+
+
+class MiniMaxTextBackend:
+    """MiniMax 文本生成后端，使用 OpenAI 兼容接口。"""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+    ):
+        self._client = create_openai_client(
+            api_key=api_key,
+            base_url=base_url or DEFAULT_BASE_URL,
+            max_retries=0,
+        )
+        self._model = model or DEFAULT_MODEL
+        self._capabilities: set[TextCapability] = {
+            TextCapability.TEXT_GENERATION,
+            TextCapability.STRUCTURED_OUTPUT,
+            TextCapability.VISION,
+        }
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_MINIMAX
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def capabilities(self) -> set[TextCapability]:
+        return self._capabilities
+
+    @with_retry_async(max_attempts=4, backoff_seconds=(2, 4, 8), retryable_errors=OPENAI_RETRYABLE_ERRORS)
+    async def generate(self, request: TextGenerationRequest) -> TextGenerationResult:
+        """生成文本回复。"""
+        messages = _build_messages(request)
+        kwargs: dict = {
+            "model": self._model,
+            "messages": messages,
+            "temperature": 1.0,  # MiniMax 要求 temperature 在 (0.0, 1.0]
+        }
+
+        if request.response_schema:
+            schema = resolve_schema(request.response_schema)
+            kwargs["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "response",
+                    "strict": True,
+                    "schema": schema,
+                },
+            }
+
+        try:
+            response = await self._client.chat.completions.create(**kwargs)
+        except Exception as exc:
+            if request.response_schema and _is_schema_error(exc):
+                logger.warning(
+                    "原生 response_format 失败 (%s)，降级到 json_object 模式",
+                    exc,
+                )
+                kwargs["response_format"] = {"type": "json_object"}
+                response = await self._client.chat.completions.create(**kwargs)
+            else:
+                raise
+
+        usage = response.usage
+        return TextGenerationResult(
+            text=response.choices[0].message.content or "",
+            provider=PROVIDER_MINIMAX,
+            model=self._model,
+            input_tokens=usage.prompt_tokens if usage else None,
+            output_tokens=usage.completion_tokens if usage else None,
+        )
+
+
+def _build_messages(request: TextGenerationRequest) -> list[dict]:
+    """将 TextGenerationRequest 转为 OpenAI messages 格式。"""
+    messages: list[dict] = []
+
+    if request.system_prompt:
+        messages.append({"role": "system", "content": request.system_prompt})
+
+    if request.images:
+        from lib.image_backends.base import image_to_base64_data_uri
+
+        content: list[dict] = []
+        for img in request.images:
+            if img.path:
+                data_uri = image_to_base64_data_uri(img.path)
+                content.append({"type": "image_url", "image_url": {"url": data_uri}})
+            elif img.url:
+                content.append({"type": "image_url", "image_url": {"url": img.url}})
+        content.append({"type": "text", "text": request.prompt})
+        messages.append({"role": "user", "content": content})
+    else:
+        messages.append({"role": "user", "content": request.prompt})
+
+    return messages
+
+
+_SCHEMA_ERROR_KEYWORDS = (
+    "response_schema",
+    "json_schema",
+    "Unknown name",
+    "Cannot find field",
+    "Invalid JSON payload",
+)
+
+
+def _is_schema_error(exc: BaseException) -> bool:
+    """判断异常是否为 JSON Schema 不兼容导致的错误。"""
+    from openai import BadRequestError
+
+    if isinstance(exc, BadRequestError):
+        return True
+    error_str = str(exc)
+    return any(kw in error_str for kw in _SCHEMA_ERROR_KEYWORDS)

--- a/tests/test_minimax_text_backend.py
+++ b/tests/test_minimax_text_backend.py
@@ -1,0 +1,206 @@
+"""MiniMaxTextBackend 单元测试。"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from lib.providers import PROVIDER_MINIMAX
+from lib.text_backends.base import (
+    TextCapability,
+    TextGenerationRequest,
+)
+from lib.text_backends.minimax import DEFAULT_BASE_URL, DEFAULT_MODEL
+
+
+def _make_mock_response(content="Hello", input_tokens=10, output_tokens=5):
+    """构造 mock ChatCompletion 响应。"""
+    usage = MagicMock()
+    usage.prompt_tokens = input_tokens
+    usage.completion_tokens = output_tokens
+
+    message = MagicMock()
+    message.content = content
+
+    choice = MagicMock()
+    choice.message = message
+
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = usage
+    return response
+
+
+class TestMiniMaxTextBackend:
+    def test_name_and_model(self):
+        with patch("lib.openai_shared.AsyncOpenAI"):
+            from lib.text_backends.minimax import MiniMaxTextBackend
+
+            backend = MiniMaxTextBackend(api_key="test-key")
+            assert backend.name == PROVIDER_MINIMAX
+            assert backend.model == DEFAULT_MODEL
+
+    def test_custom_model(self):
+        with patch("lib.openai_shared.AsyncOpenAI"):
+            from lib.text_backends.minimax import MiniMaxTextBackend
+
+            backend = MiniMaxTextBackend(api_key="test-key", model="MiniMax-M2.7-highspeed")
+            assert backend.model == "MiniMax-M2.7-highspeed"
+
+    def test_default_base_url(self):
+        with patch("lib.openai_shared.AsyncOpenAI") as mock_cls:
+            from lib.text_backends.minimax import MiniMaxTextBackend
+
+            MiniMaxTextBackend(api_key="test-key")
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs["base_url"] == DEFAULT_BASE_URL
+            assert DEFAULT_BASE_URL.startswith("https://api.minimax.io")
+
+    def test_custom_base_url(self):
+        custom_url = "https://custom.minimax.io/v1"
+        with patch("lib.openai_shared.AsyncOpenAI") as mock_cls:
+            from lib.text_backends.minimax import MiniMaxTextBackend
+
+            MiniMaxTextBackend(api_key="test-key", base_url=custom_url)
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs["base_url"] == custom_url
+
+    def test_capabilities(self):
+        with patch("lib.openai_shared.AsyncOpenAI"):
+            from lib.text_backends.minimax import MiniMaxTextBackend
+
+            backend = MiniMaxTextBackend(api_key="test-key")
+            assert TextCapability.TEXT_GENERATION in backend.capabilities
+            assert TextCapability.STRUCTURED_OUTPUT in backend.capabilities
+            assert TextCapability.VISION in backend.capabilities
+
+    async def test_generate_plain_text(self):
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("Hello world", 15, 8))
+
+        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.text_backends.minimax import MiniMaxTextBackend
+
+            backend = MiniMaxTextBackend(api_key="test-key")
+            request = TextGenerationRequest(prompt="Say hello")
+            result = await backend.generate(request)
+
+        assert result.text == "Hello world"
+        assert result.provider == PROVIDER_MINIMAX
+        assert result.model == DEFAULT_MODEL
+        assert result.input_tokens == 15
+        assert result.output_tokens == 8
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == DEFAULT_MODEL
+        assert call_kwargs["temperature"] == 1.0
+        assert call_kwargs["messages"][-1]["role"] == "user"
+
+    async def test_generate_with_system_prompt(self):
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("OK"))
+
+        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.text_backends.minimax import MiniMaxTextBackend
+
+            backend = MiniMaxTextBackend(api_key="test-key")
+            request = TextGenerationRequest(
+                prompt="Do something",
+                system_prompt="You are helpful",
+            )
+            await backend.generate(request)
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["messages"][0]["role"] == "system"
+        assert call_kwargs["messages"][0]["content"] == "You are helpful"
+        assert call_kwargs["messages"][1]["role"] == "user"
+
+    async def test_temperature_always_set(self):
+        """temperature 必须始终为 1.0，不能为 0。"""
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("OK"))
+
+        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.text_backends.minimax import MiniMaxTextBackend
+
+            backend = MiniMaxTextBackend(api_key="test-key")
+            await backend.generate(TextGenerationRequest(prompt="test"))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["temperature"] == 1.0
+        assert call_kwargs["temperature"] > 0  # MiniMax 不接受 temperature=0
+
+    async def test_generate_usage_none_tolerant(self):
+        """usage 为 None 时不应崩溃。"""
+        response = _make_mock_response("OK")
+        response.usage = None
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=response)
+
+        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.text_backends.minimax import MiniMaxTextBackend
+
+            backend = MiniMaxTextBackend(api_key="test-key")
+            result = await backend.generate(TextGenerationRequest(prompt="Hi"))
+
+        assert result.text == "OK"
+        assert result.input_tokens is None
+        assert result.output_tokens is None
+
+    async def test_schema_error_falls_back_to_json_object(self):
+        """response_format 报错时降级为 json_object 模式。"""
+        import httpx
+        from openai import BadRequestError
+
+        bad_request = BadRequestError(
+            message="schema error",
+            response=httpx.Response(400, request=httpx.Request("POST", "https://api.minimax.io/v1/chat/completions")),
+            body={"error": {"message": "schema error"}},
+        )
+        fallback_response = _make_mock_response('{"result": "ok"}')
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=[bad_request, fallback_response])
+
+        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.text_backends.minimax import MiniMaxTextBackend
+
+            backend = MiniMaxTextBackend(api_key="test-key")
+            result = await backend.generate(
+                TextGenerationRequest(
+                    prompt="Extract",
+                    response_schema={
+                        "type": "object",
+                        "properties": {"result": {"type": "string"}},
+                    },
+                )
+            )
+
+        assert result.text == '{"result": "ok"}'
+        second_call_kwargs = mock_client.chat.completions.create.call_args_list[1][1]
+        assert second_call_kwargs["response_format"] == {"type": "json_object"}
+
+
+class TestMiniMaxRegistry:
+    def test_minimax_registered(self):
+        """MiniMax 后端已注册到 registry。"""
+        from lib.text_backends.registry import get_registered_backends
+
+        assert "minimax" in get_registered_backends()
+
+    def test_minimax_in_provider_registry(self):
+        """MiniMax 已在 PROVIDER_REGISTRY 中注册。"""
+        from lib.config.registry import PROVIDER_REGISTRY
+
+        assert "minimax" in PROVIDER_REGISTRY
+        meta = PROVIDER_REGISTRY["minimax"]
+        assert "MiniMax-M2.7" in meta.models
+        assert "MiniMax-M2.7-highspeed" in meta.models
+        assert meta.models["MiniMax-M2.7"].default is True
+
+    def test_minimax_in_factory_mapping(self):
+        """MiniMax 已在 factory 的 PROVIDER_ID_TO_BACKEND 中映射。"""
+        from lib.text_backends.factory import PROVIDER_ID_TO_BACKEND
+
+        assert "minimax" in PROVIDER_ID_TO_BACKEND
+        assert PROVIDER_ID_TO_BACKEND["minimax"] == "minimax"


### PR DESCRIPTION
## Summary

Add MiniMax as a built-in text provider using the OpenAI-compatible API.

### Changes

- Add `PROVIDER_MINIMAX = "minimax"` constant to `lib/providers.py`
- Create `lib/text_backends/minimax.py` — MiniMaxTextBackend using OpenAI-compatible interface
- Register MiniMax in `lib/text_backends/__init__.py`
- Add `"minimax"` mapping in `lib/text_backends/factory.py`
- Add MiniMax entry to `PROVIDER_REGISTRY` in `lib/config/registry.py`
- Add 13 unit tests in `tests/test_minimax_text_backend.py`

### Models

| Model ID | Type |
|----------|------|
| `MiniMax-M2.7` | Default |
| `MiniMax-M2.7-highspeed` | High speed |

### API Details

- **Interface**: OpenAI-compatible (`https://api.minimax.io/v1`)
- **Auth**: `MINIMAX_API_KEY` via provider config
- **Temperature**: Always set to `1.0` (MiniMax constraint: value must be in `(0.0, 1.0]`)
- **Structured output**: Supports `response_format` with automatic fallback to `json_object` mode

### References

- Chat API (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api