### PR TITLE
fix: use asyncio.to_thread for file upload to avoid blocking event loop

### DIFF
--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -102,12 +102,17 @@ async def import_project_archive(
         fd, upload_path = tempfile.mkstemp(prefix="arcreel-upload-", suffix=".zip")
         os.close(fd)
 
-        with open(upload_path, "wb") as target:
-            while True:
-                chunk = await file.read(1024 * 1024)
-                if not chunk:
-                    break
-                target.write(chunk)
+        raw_file = file.file
+
+        def _write_upload() -> None:
+            with open(upload_path, "wb") as target:
+                while True:
+                    chunk = raw_file.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    target.write(chunk)
+
+        await asyncio.to_thread(_write_upload)
 
         def _sync():
             return get_archive_service().import_project_archive(


### PR DESCRIPTION
Fixes #230

## Problem

In `POST /projects/import`, the upload loop called `target.write(chunk)` synchronously after each `await file.read(1MB)`, briefly blocking the event loop. Under large files or concurrent requests this can cause noticeable latency spikes for other async operations.

## Solution

Extract the underlying synchronous file object (`file.file`) and move the entire read/write loop into `asyncio.to_thread()`. This offloads all blocking I/O to a thread pool worker without holding the event loop, keeping the same 1 MB chunk size and no new dependencies.

```python
raw_file = file.file

def _write_upload() -> None:
    with open(upload_path, "wb") as target:
        while True:
            chunk = raw_file.read(1024 * 1024)
            if not chunk:
                break
            target.write(chunk)

await asyncio.to_thread(_write_upload)
```

## Testing

All existing archive route tests pass (`tests/test_projects_archive_routes.py`, 9 tests). Ruff lint check also passes.