### PR TITLE
fix: OpenAI 视频内容下载 502 失败时不再重新触发视频生成

### DIFF
--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import random
 from pathlib import Path
 
 from lib.openai_shared import OPENAI_RETRYABLE_ERRORS, create_openai_client
 from lib.providers import PROVIDER_OPENAI
-from lib.retry import _should_retry, with_retry_async
+from lib.retry import with_retry_async
 from lib.video_backends.base import (
     IMAGE_MIME_TYPES,
     VideoCapability,
@@ -96,29 +94,14 @@ class OpenAIVideoBackend:
         """视频生成（create_and_poll），带独立重试。"""
         return await self._client.videos.create_and_poll(**kwargs)
 
-    async def _download_content_with_retry(
-        self, video_id: str, *, max_attempts: int = 5, backoff: tuple[int, ...] = (4, 8, 15, 30)
-    ):
+    @with_retry_async(
+        max_attempts=5,
+        backoff_seconds=(4, 8, 15, 30),
+        retryable_errors=OPENAI_RETRYABLE_ERRORS,
+    )
+    async def _download_content_with_retry(self, video_id: str):
         """单独重试内容下载，避免因下载失败重新触发视频生成。"""
-        for attempt in range(max_attempts):
-            try:
-                return await self._client.videos.download_content(video_id)
-            except Exception as e:
-                if not _should_retry(e, OPENAI_RETRYABLE_ERRORS):
-                    raise
-                if attempt < max_attempts - 1:
-                    wait = backoff[min(attempt, len(backoff) - 1)] + random.uniform(0, 2)
-                    logger.warning(
-                        "视频内容下载失败 (尝试 %d/%d): %s — %.1f 秒后重试",
-                        attempt + 1,
-                        max_attempts,
-                        str(e)[:200],
-                        wait,
-                    )
-                    await asyncio.sleep(wait)
-                else:
-                    raise
-        raise RuntimeError(f"_download_content_with_retry: max_attempts={max_attempts}，未执行任何尝试")
+        return await self._client.videos.download_content(video_id)
 
 
 def _map_duration(seconds: int) -> str:

--- a/tests/test_openai_video_backend.py
+++ b/tests/test_openai_video_backend.py
@@ -220,7 +220,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.openai.asyncio.sleep", new_callable=AsyncMock),
+            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -253,7 +253,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.openai.asyncio.sleep", new_callable=AsyncMock),
+            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -286,7 +286,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.openai.asyncio.sleep", mock_sleep),
+            patch("lib.retry.asyncio.sleep", mock_sleep),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 


### PR DESCRIPTION
## Summary

- OpenAI 视频后端内容下载（`/content` 端点）返回 502 时，原有 `@with_retry_async` 会重试整个 `generate()` 方法，导致 `create_and_poll()` 被重复调用，浪费 Sora 生成配额
- 新增 `_download_content_with_retry()` 将下载重试与生成重试分离：下载专用重试 5 次，退避 4s→8s→15s→30s
- 根因：上游代理 newapi 解析 Vertex 视频 URL 存在瞬态延迟，需要更长退避窗口

## Test plan

- [x] 新增测试：内容下载失败后仅重试下载，`create_and_poll` 只调用 1 次
- [x] 新增测试：下载重试全部耗尽后正确抛出异常
- [x] 既有 11 个测试全部通过
- [x] ruff lint + format 通过