### PR TITLE
fix: Ark/Grok 视频下载与生成分离重试，避免下载失败重试生成浪费额度

### DIFF
--- a/lib/retry.py
+++ b/lib/retry.py
@@ -1,7 +1,8 @@
 """通用重试装饰器，带指数退避和随机抖动。
 
 不依赖任何特定供应商 SDK，可被所有后端复用。
-各供应商可通过 retryable_errors 参数注入自己的可重试异常类型。
+各供应商可通过 retryable_errors 参数注入自己的可重试异常类型，
+或通过 retry_if 谓词实现精细化的条件重试。
 """
 
 from __future__ import annotations
@@ -10,6 +11,7 @@ import asyncio
 import functools
 import logging
 import random
+from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +43,10 @@ RETRYABLE_STATUS_PATTERNS = (
 DEFAULT_MAX_ATTEMPTS = 3
 DEFAULT_BACKOFF_SECONDS: tuple[int, ...] = (2, 4, 8)
 
+# 下载阶段重试配置（比生成阶段更宽容，因为下载失败不会浪费生成额度）
+DOWNLOAD_MAX_ATTEMPTS = 5
+DOWNLOAD_BACKOFF_SECONDS: tuple[int, ...] = (5, 10, 20, 40)
+
 
 def _should_retry(exc: Exception, retryable_errors: tuple[type[Exception], ...]) -> bool:
     """判断异常是否应当重试。"""
@@ -54,8 +60,15 @@ def with_retry_async(
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
     backoff_seconds: tuple[int, ...] = DEFAULT_BACKOFF_SECONDS,
     retryable_errors: tuple[type[Exception], ...] = BASE_RETRYABLE_ERRORS,
+    retry_if: Callable[[Exception], bool] | None = None,
 ):
-    """异步函数重试装饰器，带指数退避和随机抖动。"""
+    """异步函数重试装饰器，带指数退避和随机抖动。
+
+    当指定 retry_if 时，用该谓词替代默认的 _should_retry 进行重试判定，
+    允许调用方精确控制哪些异常应当重试（如仅重试特定 HTTP 状态码）。
+    """
+
+    predicate = retry_if if retry_if is not None else lambda e: _should_retry(e, retryable_errors)
 
     def decorator(func):
         @functools.wraps(func)
@@ -64,31 +77,22 @@ def with_retry_async(
                 try:
                     return await func(*args, **kwargs)
                 except Exception as e:
-                    if not _should_retry(e, retryable_errors):
+                    is_last = attempt >= max_attempts - 1
+                    if is_last or not predicate(e):
                         raise
-
-                    if attempt < max_attempts - 1:
-                        backoff_idx = min(attempt, len(backoff_seconds) - 1)
-                        base_wait = backoff_seconds[backoff_idx]
-                        jitter = random.uniform(0, 2)
-                        wait_time = base_wait + jitter
-                        logger.warning(
-                            "API 调用异常: %s - %s",
-                            type(e).__name__,
-                            str(e)[:200],
-                        )
-                        logger.warning(
-                            "重试 %d/%d, %.1f 秒后...",
-                            attempt + 1,
-                            max_attempts - 1,
-                            wait_time,
-                        )
-                        await asyncio.sleep(wait_time)
-                    else:
-                        raise
+                    wait_time = _compute_wait(attempt, backoff_seconds)
+                    logger.warning("API 调用异常: %s - %s", type(e).__name__, str(e)[:200])
+                    logger.warning("重试 %d/%d, %.1f 秒后...", attempt + 1, max_attempts - 1, wait_time)
+                    await asyncio.sleep(wait_time)
 
             raise RuntimeError(f"with_retry_async: max_attempts={max_attempts}，未执行任何尝试")
 
         return wrapper
 
     return decorator
+
+
+def _compute_wait(attempt: int, backoff_seconds: tuple[int, ...]) -> float:
+    """计算第 attempt 次重试的等待时间（含随机抖动）。"""
+    backoff_idx = min(attempt, len(backoff_seconds) - 1)
+    return backoff_seconds[backoff_idx] + random.uniform(0, 2)

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -9,12 +9,13 @@ import httpx
 
 from lib.ark_shared import create_ark_client
 from lib.providers import PROVIDER_ARK
-from lib.retry import BASE_RETRYABLE_ERRORS, _should_retry, with_retry_async
+from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
 from lib.video_backends.base import (
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
+    poll_with_retry,
 )
 
 logger = logging.getLogger(__name__)
@@ -115,66 +116,43 @@ class ArkVideoBackend:
         return create_result.id
 
     @staticmethod
+    @with_retry_async(
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
+        retry_if=lambda e: (
+            isinstance(e, httpx.HTTPStatusError)
+            and e.response.status_code == 400
+            and "video_not_ready" in str(e.response.text)
+        ),
+    )
     async def _download_video_with_retry(video_url: str, output_path) -> None:
         """单独重试视频下载，避免下载失败导致重新生成视频而浪费额度。
 
         Ark 的视频 URL 在任务 succeeded 后可能仍未就绪（返回 400 video_not_ready），
         仅针对该瞬态状态重试；其余 HTTP 错误及网络瞬态错误由内层 download_video 处理。
         """
-        backoff_seconds = (5, 10, 20, 40)
-        max_attempts = len(backoff_seconds) + 1
-        for attempt in range(max_attempts):
-            try:
-                await download_video(video_url, output_path)
-                return
-            except httpx.HTTPStatusError as e:
-                if e.response.status_code != 400 or "video_not_ready" not in str(e.response.text):
-                    raise
-                if attempt < max_attempts - 1:
-                    wait = backoff_seconds[attempt]
-                    logger.warning("Ark 视频未就绪，%d 秒后重试 (%d/%d)", wait, attempt + 1, max_attempts - 1)
-                    await asyncio.sleep(wait)
-                else:
-                    raise
+        await download_video(video_url, output_path)
 
     async def _poll_until_done(self, task_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
         """轮询任务状态直到完成，瞬态错误仅重试当次轮询请求。"""
         poll_interval = 10 if request.service_tier == "default" else 60
         max_wait_time = 600 if request.service_tier == "default" else 3600
-        elapsed = 0
 
-        while True:
-            try:
-                result = await asyncio.to_thread(
-                    self._client.content_generation.tasks.get,
-                    task_id=task_id,
-                )
-            except Exception as e:
-                if _should_retry(e, BASE_RETRYABLE_ERRORS):
-                    logger.warning("Ark 轮询异常（将重试）: %s - %s", type(e).__name__, str(e)[:200])
-                    elapsed += poll_interval
-                    if elapsed >= max_wait_time:
-                        raise
-                    await asyncio.sleep(poll_interval)
-                    continue
-                raise
-
-            if result.status == "succeeded":
-                break
-            elif result.status in ("failed", "expired"):
-                error_msg = getattr(result, "error", None) or "Unknown error"
-                raise RuntimeError(f"Ark 视频生成失败: {error_msg}")
-
-            elapsed += poll_interval
-            if elapsed >= max_wait_time:
-                raise TimeoutError(f"Ark 视频生成超时（{max_wait_time}秒）")
-
-            logger.info(
-                "Ark 视频生成中... 状态: %s, 已等待 %d 秒",
-                result.status,
-                elapsed,
-            )
-            await asyncio.sleep(poll_interval)
+        result = await poll_with_retry(
+            poll_fn=lambda: asyncio.to_thread(self._client.content_generation.tasks.get, task_id=task_id),
+            is_done=lambda r: r.status == "succeeded",
+            is_failed=lambda r: (
+                f"Ark 视频生成失败: {getattr(r, 'error', None) or 'Unknown error'}"
+                if r.status in ("failed", "expired")
+                else None
+            ),
+            poll_interval=poll_interval,
+            max_wait=max_wait_time,
+            label="Ark",
+            on_progress=lambda r, elapsed: logger.info(
+                "Ark 视频生成中... 状态: %s, 已等待 %d 秒", r.status, int(elapsed)
+            ),
+        )
 
         # Download video
         video_url = result.content.video_url

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 
+import httpx
+
 from lib.ark_shared import create_ark_client
 from lib.providers import PROVIDER_ARK
 from lib.retry import BASE_RETRYABLE_ERRORS, _should_retry, with_retry_async
@@ -112,6 +114,20 @@ class ArkVideoBackend:
         logger.info("Ark 任务已创建: %s", create_result.id)
         return create_result.id
 
+    @staticmethod
+    @with_retry_async(
+        max_attempts=5,
+        backoff_seconds=(5, 10, 20, 40),
+        retryable_errors=(*BASE_RETRYABLE_ERRORS, httpx.HTTPStatusError),
+    )
+    async def _download_video_with_retry(video_url: str, output_path) -> None:
+        """单独重试视频下载，避免下载失败导致重新生成视频而浪费额度。
+
+        Ark 的视频 URL 在任务 succeeded 后可能仍未就绪（返回 400 video_not_ready），
+        需要独立重试而非让整个任务失败。
+        """
+        await download_video(video_url, output_path)
+
     async def _poll_until_done(self, task_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
         """轮询任务状态直到完成，瞬态错误仅重试当次轮询请求。"""
         poll_interval = 10 if request.service_tier == "default" else 60
@@ -153,7 +169,7 @@ class ArkVideoBackend:
 
         # Download video
         video_url = result.content.video_url
-        await download_video(video_url, request.output_path)
+        await self._download_video_with_retry(video_url, request.output_path)
 
         # Extract result metadata
         seed = getattr(result, "seed", None)

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -115,18 +115,27 @@ class ArkVideoBackend:
         return create_result.id
 
     @staticmethod
-    @with_retry_async(
-        max_attempts=5,
-        backoff_seconds=(5, 10, 20, 40),
-        retryable_errors=(*BASE_RETRYABLE_ERRORS, httpx.HTTPStatusError),
-    )
     async def _download_video_with_retry(video_url: str, output_path) -> None:
         """单独重试视频下载，避免下载失败导致重新生成视频而浪费额度。
 
         Ark 的视频 URL 在任务 succeeded 后可能仍未就绪（返回 400 video_not_ready），
-        需要独立重试而非让整个任务失败。
+        仅针对该瞬态状态重试；其余 HTTP 错误及网络瞬态错误由内层 download_video 处理。
         """
-        await download_video(video_url, output_path)
+        backoff_seconds = (5, 10, 20, 40)
+        max_attempts = len(backoff_seconds) + 1
+        for attempt in range(max_attempts):
+            try:
+                await download_video(video_url, output_path)
+                return
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code != 400 or "video_not_ready" not in str(e.response.text):
+                    raise
+                if attempt < max_attempts - 1:
+                    wait = backoff_seconds[attempt]
+                    logger.warning("Ark 视频未就绪，%d 秒后重试 (%d/%d)", wait, attempt + 1, max_attempts - 1)
+                    await asyncio.sleep(wait)
+                else:
+                    raise
 
     async def _poll_until_done(self, task_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
         """轮询任务状态直到完成，瞬态错误仅重试当次轮询请求。"""

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -85,6 +85,9 @@ async def download_video(url: str, output_path: Path, *, timeout: int = 120) -> 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     async with httpx.AsyncClient() as http_client:
         async with http_client.stream("GET", url, timeout=timeout) as resp:
+            if resp.status_code >= 400:
+                # 流式模式下需先读取响应体，否则 HTTPStatusError.response.text 不可用
+                await resp.aread()
             resp.raise_for_status()
             with open(output_path, "wb") as f:
                 async for chunk in resp.aiter_bytes(chunk_size=65536):

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -1,7 +1,11 @@
-"""视频生成服务层核心接口定义。"""
+"""视频生成服务层核心接口定义与共享工具。"""
 
 from __future__ import annotations
 
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -9,7 +13,9 @@ from typing import Protocol
 
 import httpx
 
-from lib.retry import with_retry_async
+from lib.retry import BASE_RETRYABLE_ERRORS, _should_retry, with_retry_async
+
+logger = logging.getLogger(__name__)
 
 # 图片后缀 → MIME 类型映射（多个后端共用）
 IMAGE_MIME_TYPES: dict[str, str] = {
@@ -19,6 +25,58 @@ IMAGE_MIME_TYPES: dict[str, str] = {
     ".gif": "image/gif",
     ".webp": "image/webp",
 }
+
+
+async def poll_with_retry[T](
+    *,
+    poll_fn: Callable[[], Awaitable[T]],
+    is_done: Callable[[T], bool],
+    is_failed: Callable[[T], str | None],
+    poll_interval: float,
+    max_wait: float,
+    retryable_errors: tuple[type[Exception], ...] = BASE_RETRYABLE_ERRORS,
+    label: str = "",
+    on_progress: Callable[[T, float], None] | None = None,
+) -> T:
+    """通用异步轮询辅助函数，带瞬态错误重试和超时控制。
+
+    Args:
+        poll_fn: 每次轮询调用的异步函数，返回最新状态。
+        is_done: 判断轮询结果是否表示任务完成。
+        is_failed: 判断轮询结果是否表示任务失败，返回错误信息或 None。
+        poll_interval: 两次轮询之间的间隔（秒）。
+        max_wait: 最大等待时间（秒），超时抛出 TimeoutError。
+        retryable_errors: 可重试的异常类型元组。
+        label: 日志前缀（如 "Ark"、"Gemini"）。
+        on_progress: 可选的进度回调，每次非终态轮询后调用。
+    """
+    start = time.monotonic()
+    prefix = f"{label} " if label else ""
+
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed >= max_wait:
+            raise TimeoutError(f"{prefix}任务超时（{max_wait:.0f}秒）")
+
+        await asyncio.sleep(poll_interval)
+
+        try:
+            result = await poll_fn()
+        except Exception as e:
+            if _should_retry(e, retryable_errors):
+                logger.warning("%s轮询异常（将重试）: %s - %s", prefix, type(e).__name__, str(e)[:200])
+                continue
+            raise
+
+        error_msg = is_failed(result)
+        if error_msg is not None:
+            raise RuntimeError(error_msg)
+
+        if is_done(result):
+            return result
+
+        if on_progress is not None:
+            on_progress(result, time.monotonic() - start)
 
 
 @with_retry_async()

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -6,21 +6,21 @@ import asyncio
 import io
 import logging
 import os
-import time
 from pathlib import Path
 from typing import Any
 
 from PIL import Image
 
 from lib.config.url_utils import normalize_base_url
-from lib.gemini_shared import VERTEX_SCOPES, RateLimiter, get_shared_rate_limiter, with_retry_async
+from lib.gemini_shared import VERTEX_SCOPES, RateLimiter, get_shared_rate_limiter
 from lib.providers import PROVIDER_GEMINI
-from lib.retry import BASE_RETRYABLE_ERRORS, _should_retry
+from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
 from lib.system_config import resolve_vertex_credentials_path
 from lib.video_backends.base import (
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
+    poll_with_retry,
 )
 
 logger = logging.getLogger(__name__)
@@ -155,42 +155,31 @@ class GeminiVideoBackend:
         op_name = getattr(operation, "name", "unknown")
         logger.info("开始轮询 operation=%s ...", op_name)
 
-        start_time = time.monotonic()
-        poll_interval = 20  # 与 Google 官方推荐一致
-        max_wait_time = 600
-        while not operation.done:
-            elapsed = time.monotonic() - start_time
-            if elapsed >= max_wait_time:
-                raise TimeoutError(f"视频生成超时（{max_wait_time}秒）")
-            await asyncio.sleep(poll_interval)
-            try:
-                operation = await self._client.aio.operations.get(operation)
-            except Exception as e:
-                if _should_retry(e, BASE_RETRYABLE_ERRORS):
-                    logger.warning("Gemini 轮询异常（将重试）: %s - %s", type(e).__name__, str(e)[:200])
-                    continue
-                raise
-            if not operation.done:
-                elapsed = time.monotonic() - start_time
-                logger.info(
-                    "视频生成中... 已等待 %.0f 秒 (operation=%s)",
-                    elapsed,
-                    op_name,
-                )
+        if not operation.done:
+            operation = await poll_with_retry(
+                # SDK 通过 operation.name 查询状态并返回新对象，闭包捕获初始 operation 即可
+                poll_fn=lambda: self._client.aio.operations.get(operation),
+                is_done=lambda op: op.done,
+                is_failed=lambda op: None,  # Gemini 在轮询完成后检查失败
+                poll_interval=20,  # 与 Google 官方推荐一致
+                max_wait=600,
+                label="Gemini",
+                on_progress=lambda op, elapsed: logger.info(
+                    "视频生成中... 已等待 %.0f 秒 (operation=%s)", elapsed, op_name
+                ),
+            )
 
-        total_elapsed = time.monotonic() - start_time
-        logger.info("视频生成完成, 总耗时 %.0f 秒, operation=%s", total_elapsed, op_name)
+        logger.info("视频生成完成 (operation=%s)", op_name)
 
         # 检查结果
         if not operation.response or not operation.response.generated_videos:
             error_detail = getattr(operation, "error", None)
             metadata = getattr(operation, "metadata", None)
             logger.error(
-                "视频生成返回空结果: operation=%s, error=%s, metadata=%s, elapsed=%.0f秒",
+                "视频生成返回空结果: operation=%s, error=%s, metadata=%s",
                 op_name,
                 error_detail,
                 metadata,
-                total_elapsed,
             )
             if error_detail:
                 raise RuntimeError(f"视频生成失败: {error_detail}")
@@ -245,7 +234,7 @@ class GeminiVideoBackend:
         else:
             return image
 
-    @with_retry_async()
+    @with_retry_async(max_attempts=DOWNLOAD_MAX_ATTEMPTS, backoff_seconds=DOWNLOAD_BACKOFF_SECONDS)
     async def _download_video_with_retry(self, video_ref, output_path: Path) -> None:
         """下载视频（含瞬态错误重试）。"""
         await asyncio.to_thread(self._download_video, video_ref, output_path)

--- a/lib/video_backends/grok.py
+++ b/lib/video_backends/grok.py
@@ -93,4 +93,3 @@ class GrokVideoBackend:
 
         logger.info("Grok 视频生成开始: model=%s, duration=%ds", self._model, request.duration_seconds)
         return await self._client.video.generate(**generate_kwargs)
-

--- a/lib/video_backends/grok.py
+++ b/lib/video_backends/grok.py
@@ -51,9 +51,29 @@ class GrokVideoBackend:
     def capabilities(self) -> set[VideoCapability]:
         return self._capabilities
 
-    @with_retry_async()
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
-        """生成视频。"""
+        """生成视频。生成与下载分离重试，避免下载失败导致重新生成浪费额度。"""
+        response = await self._create_video(request)
+
+        video_url = response.url
+        actual_duration = getattr(response, "duration", request.duration_seconds)
+
+        await self._download_video_with_retry(video_url, request.output_path)
+
+        logger.info("Grok 视频下载完成: %s", request.output_path)
+
+        return VideoGenerationResult(
+            video_path=request.output_path,
+            provider=PROVIDER_GROK,
+            model=self._model,
+            duration_seconds=actual_duration,
+            video_uri=video_url,
+            generate_audio=True,
+        )
+
+    @with_retry_async()
+    async def _create_video(self, request: VideoGenerationRequest):
+        """创建视频生成任务（带独立重试）。"""
         generate_kwargs = {
             "prompt": request.prompt,
             "model": self._model,
@@ -73,20 +93,13 @@ class GrokVideoBackend:
             generate_kwargs["image_url"] = f"data:{mime_type};base64,{b64}"
 
         logger.info("Grok 视频生成开始: model=%s, duration=%ds", self._model, request.duration_seconds)
-        response = await self._client.video.generate(**generate_kwargs)
+        return await self._client.video.generate(**generate_kwargs)
 
-        video_url = response.url
-        actual_duration = getattr(response, "duration", request.duration_seconds)
-
-        await download_video(video_url, request.output_path)
-
-        logger.info("Grok 视频下载完成: %s", request.output_path)
-
-        return VideoGenerationResult(
-            video_path=request.output_path,
-            provider=PROVIDER_GROK,
-            model=self._model,
-            duration_seconds=actual_duration,
-            video_uri=video_url,
-            generate_audio=True,
-        )
+    @staticmethod
+    @with_retry_async(
+        max_attempts=5,
+        backoff_seconds=(4, 8, 15, 30),
+    )
+    async def _download_video_with_retry(video_url: str, output_path) -> None:
+        """单独重试视频下载，避免下载失败导致重新生成视频而浪费额度。"""
+        await download_video(video_url, output_path)

--- a/lib/video_backends/grok.py
+++ b/lib/video_backends/grok.py
@@ -58,8 +58,7 @@ class GrokVideoBackend:
         video_url = response.url
         actual_duration = getattr(response, "duration", request.duration_seconds)
 
-        await self._download_video_with_retry(video_url, request.output_path)
-
+        await download_video(video_url, request.output_path)
         logger.info("Grok 视频下载完成: %s", request.output_path)
 
         return VideoGenerationResult(
@@ -95,11 +94,3 @@ class GrokVideoBackend:
         logger.info("Grok 视频生成开始: model=%s, duration=%ds", self._model, request.duration_seconds)
         return await self._client.video.generate(**generate_kwargs)
 
-    @staticmethod
-    @with_retry_async(
-        max_attempts=5,
-        backoff_seconds=(4, 8, 15, 30),
-    )
-    async def _download_video_with_retry(video_url: str, output_path) -> None:
-        """单独重试视频下载，避免下载失败导致重新生成视频而浪费额度。"""
-        await download_video(video_url, output_path)

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from lib.openai_shared import OPENAI_RETRYABLE_ERRORS, create_openai_client
 from lib.providers import PROVIDER_OPENAI
-from lib.retry import with_retry_async
+from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
 from lib.video_backends.base import (
     IMAGE_MIME_TYPES,
     VideoCapability,
@@ -95,8 +95,8 @@ class OpenAIVideoBackend:
         return await self._client.videos.create_and_poll(**kwargs)
 
     @with_retry_async(
-        max_attempts=5,
-        backoff_seconds=(4, 8, 15, 30),
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
         retryable_errors=OPENAI_RETRYABLE_ERRORS,
     )
     async def _download_content_with_retry(self, video_id: str):

--- a/tests/test_grok_video_backend.py
+++ b/tests/test_grok_video_backend.py
@@ -69,6 +69,7 @@ class TestGrokVideoBackend:
             backend = GrokVideoBackend(api_key="test-key")
 
             mock_http_response = AsyncMock()
+            mock_http_response.status_code = 200
             mock_http_response.raise_for_status = MagicMock()
             mock_http_response.aiter_bytes = lambda chunk_size=None: _async_iter([b"fake-video-data"])
 
@@ -122,6 +123,7 @@ class TestGrokVideoBackend:
             backend = GrokVideoBackend(api_key="test-key")
 
             mock_http_response = AsyncMock()
+            mock_http_response.status_code = 200
             mock_http_response.raise_for_status = MagicMock()
             mock_http_response.aiter_bytes = lambda chunk_size=None: _async_iter([b"fake-video-data"])
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -8,6 +8,8 @@ import pytest
 
 from lib.retry import (
     BASE_RETRYABLE_ERRORS,
+    DOWNLOAD_BACKOFF_SECONDS,
+    DOWNLOAD_MAX_ATTEMPTS,
     RETRYABLE_STATUS_PATTERNS,
     _should_retry,
     with_retry_async,
@@ -193,3 +195,60 @@ class TestWithRetryAsync:
 
         # attempt 0→backoff[0]=1, attempt 1→backoff[1]=2, attempt 2→backoff[1]=2 (clamped), attempt 3→backoff[1]=2
         assert sleep_values == [1, 2, 2, 2]
+
+    async def test_retry_if_true_triggers_retry(self):
+        """retry_if 返回 True 时应触发重试。"""
+        mock_fn = AsyncMock(side_effect=[ValueError("transient"), "ok"])
+
+        @with_retry_async(
+            max_attempts=3,
+            backoff_seconds=(0, 0, 0),
+            retry_if=lambda e: isinstance(e, ValueError),
+        )
+        async def fn():
+            return await mock_fn()
+
+        with patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
+            result = await fn()
+
+        assert result == "ok"
+        assert mock_fn.call_count == 2
+
+    async def test_retry_if_false_raises_immediately(self):
+        """retry_if 返回 False 时应立即抛出，即使 _should_retry 会返回 True。"""
+        mock_fn = AsyncMock(side_effect=ConnectionError("reset"))
+
+        @with_retry_async(
+            max_attempts=3,
+            backoff_seconds=(0, 0, 0),
+            retry_if=lambda e: False,  # 始终不重试
+        )
+        async def fn():
+            return await mock_fn()
+
+        with pytest.raises(ConnectionError, match="reset"):
+            await fn()
+        assert mock_fn.call_count == 1
+
+    async def test_retry_if_none_uses_default_should_retry(self):
+        """retry_if=None（默认）应保持原有 _should_retry 行为。"""
+        mock_fn = AsyncMock(side_effect=[ConnectionError("reset"), "ok"])
+
+        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0), retry_if=None)
+        async def fn():
+            return await mock_fn()
+
+        with patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
+            result = await fn()
+
+        assert result == "ok"
+        assert mock_fn.call_count == 2
+
+
+class TestDownloadConstants:
+    """下载重试常量测试。"""
+
+    def test_download_constants_values(self):
+        assert DOWNLOAD_MAX_ATTEMPTS == 5
+        assert DOWNLOAD_BACKOFF_SECONDS == (5, 10, 20, 40)
+        assert len(DOWNLOAD_BACKOFF_SECONDS) == DOWNLOAD_MAX_ATTEMPTS - 1

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -37,6 +37,7 @@ def _mock_httpx_stream(data: bytes = b"fake-mp4-data"):
     mock_httpx = patcher.start()
 
     mock_stream_response = MagicMock()
+    mock_stream_response.status_code = 200
     mock_stream_response.raise_for_status = MagicMock()
 
     async def _aiter_bytes(chunk_size=65536):

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -225,7 +225,7 @@ class TestArkRetryBehavior:
         patcher = _mock_httpx_stream()
         try:
             request = VideoGenerationRequest(prompt="test", output_path=output)
-            with patch("lib.video_backends.ark.asyncio.sleep", new_callable=AsyncMock):
+            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
                 result = await backend.generate(request)
         finally:
             patcher.stop()
@@ -259,7 +259,7 @@ class TestArkRetryBehavior:
         try:
             request = VideoGenerationRequest(prompt="test", output_path=output)
             with (
-                patch("lib.video_backends.ark.asyncio.sleep", new_callable=AsyncMock),
+                patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
                 patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
             ):
                 result = await backend.generate(request)
@@ -282,7 +282,7 @@ class TestArkRetryBehavior:
 
         request = VideoGenerationRequest(prompt="test", output_path=output)
         with pytest.raises(ValueError, match="invalid response"):
-            with patch("lib.video_backends.ark.asyncio.sleep", new_callable=AsyncMock):
+            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
                 await backend.generate(request)
 
         # 创建只调用一次，轮询只尝试一次就抛出

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -1,9 +1,13 @@
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from lib.video_backends.base import (
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
+    poll_with_retry,
 )
 
 
@@ -77,3 +81,122 @@ class TestVideoGenerationResult:
         )
         assert result.usage_tokens == 246840
         assert result.task_id == "cgt-20250101"
+
+
+class TestPollWithRetry:
+    """poll_with_retry 通用轮询辅助函数测试。"""
+
+    async def test_immediate_done(self):
+        """poll_fn 首次返回即完成。"""
+        poll_fn = AsyncMock(return_value="done_result")
+
+        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+            result = await poll_with_retry(
+                poll_fn=poll_fn,
+                is_done=lambda r: r == "done_result",
+                is_failed=lambda r: None,
+                poll_interval=1,
+                max_wait=10,
+            )
+
+        assert result == "done_result"
+        assert poll_fn.await_count == 1
+
+    async def test_polls_until_done(self):
+        """多次轮询后完成。"""
+        poll_fn = AsyncMock(side_effect=["pending", "pending", "done"])
+
+        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+            result = await poll_with_retry(
+                poll_fn=poll_fn,
+                is_done=lambda r: r == "done",
+                is_failed=lambda r: None,
+                poll_interval=1,
+                max_wait=60,
+            )
+
+        assert result == "done"
+        assert poll_fn.await_count == 3
+
+    async def test_transient_error_retries(self):
+        """轮询瞬态错误后重试成功。"""
+        poll_fn = AsyncMock(side_effect=[ConnectionError("reset"), "done"])
+
+        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+            result = await poll_with_retry(
+                poll_fn=poll_fn,
+                is_done=lambda r: r == "done",
+                is_failed=lambda r: None,
+                poll_interval=1,
+                max_wait=60,
+            )
+
+        assert result == "done"
+        assert poll_fn.await_count == 2
+
+    async def test_non_retryable_error_propagates(self):
+        """不可重试的错误立即抛出。"""
+        poll_fn = AsyncMock(side_effect=ValueError("invalid"))
+
+        with pytest.raises(ValueError, match="invalid"):
+            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+                await poll_with_retry(
+                    poll_fn=poll_fn,
+                    is_done=lambda r: True,
+                    is_failed=lambda r: None,
+                    poll_interval=1,
+                    max_wait=60,
+                )
+
+        assert poll_fn.await_count == 1
+
+    async def test_timeout_raises(self):
+        """超时抛出 TimeoutError。"""
+        poll_fn = AsyncMock(return_value="pending")
+
+        # 用 monotonic mock 模拟时间流逝
+        times = iter([0, 0, 100, 100])  # 第二轮超时
+
+        with (
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            patch("lib.video_backends.base.time.monotonic", side_effect=times),
+        ):
+            with pytest.raises(TimeoutError, match="超时"):
+                await poll_with_retry(
+                    poll_fn=poll_fn,
+                    is_done=lambda r: False,
+                    is_failed=lambda r: None,
+                    poll_interval=1,
+                    max_wait=10,
+                )
+
+    async def test_failed_status_raises(self):
+        """is_failed 返回错误信息时抛出 RuntimeError。"""
+        poll_fn = AsyncMock(return_value="failed_result")
+
+        with pytest.raises(RuntimeError, match="任务失败"):
+            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+                await poll_with_retry(
+                    poll_fn=poll_fn,
+                    is_done=lambda r: False,
+                    is_failed=lambda r: "任务失败" if r == "failed_result" else None,
+                    poll_interval=1,
+                    max_wait=60,
+                )
+
+    async def test_on_progress_called(self):
+        """on_progress 回调被调用。"""
+        poll_fn = AsyncMock(side_effect=["pending", "done"])
+        progress_calls = []
+
+        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+            await poll_with_retry(
+                poll_fn=poll_fn,
+                is_done=lambda r: r == "done",
+                is_failed=lambda r: None,
+                poll_interval=1,
+                max_wait=60,
+                on_progress=lambda r, elapsed: progress_calls.append(r),
+            )
+
+        assert progress_calls == ["pending"]

--- a/tests/test_video_backend_gemini.py
+++ b/tests/test_video_backend_gemini.py
@@ -157,7 +157,7 @@ class TestGeminiVideoBackendGenerate:
         )
 
         # patch asyncio.sleep 以避免实际等待
-        with patch("lib.video_backends.gemini.asyncio.sleep", new_callable=AsyncMock):
+        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
             result = await backend.generate(request)
 
         assert result.provider == "gemini"
@@ -253,7 +253,7 @@ class TestGeminiRetryBehavior:
         backend._client.aio.operations.get = AsyncMock(side_effect=[ConnectionError("connection reset"), done_op])
 
         request = VideoGenerationRequest(prompt="test", output_path=output)
-        with patch("lib.video_backends.gemini.asyncio.sleep", new_callable=AsyncMock):
+        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
             result = await backend.generate(request)
 
         assert result.provider == "gemini"
@@ -274,7 +274,7 @@ class TestGeminiRetryBehavior:
 
         request = VideoGenerationRequest(prompt="test", output_path=output)
         with (
-            patch("lib.video_backends.gemini.asyncio.sleep", new_callable=AsyncMock),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
             patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
         ):
             result = await backend.generate(request)
@@ -295,7 +295,7 @@ class TestGeminiRetryBehavior:
 
         request = VideoGenerationRequest(prompt="test", output_path=output)
         with pytest.raises(ValueError, match="invalid response"):
-            with patch("lib.video_backends.gemini.asyncio.sleep", new_callable=AsyncMock):
+            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
                 await backend.generate(request)
 
         # 创建只调用一次


### PR DESCRIPTION
## Summary
- **Ark**: 任务 succeeded 后视频 URL 可能仍未就绪（返回 400 `video_not_ready`），原实现下载失败会导致整个任务失败，用户重试时重新生成视频并再次扣费。新增 `_download_video_with_retry` 手动重试循环，仅针对 400 `video_not_ready` 重试，其余 HTTP 错误直接透传
- **Grok**: 原实现 `generate()` 整体被 `@with_retry_async` 包裹，下载失败会自动重新生成视频。拆分为 `_create_video`（生成，独立重试）+ `download_video`（下载，内置瞬态重试）

## Test plan
- [x] 176 个 Ark/Grok 相关测试全部通过
- [ ] 使用 Ark/Seedance 供应商实际生成视频，验证 `video_not_ready` 场景下重试成功