### PR TITLE
feat: support URL retrieval in ArkImageBackend and remove response_fo…

### DIFF
--- a/lib/image_backends/ark.py
+++ b/lib/image_backends/ark.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import urllib.request
 from pathlib import Path
 
 from lib.ark_shared import create_ark_client
@@ -57,7 +58,6 @@ class ArkImageBackend:
         kwargs: dict = {
             "model": self._model,
             "prompt": request.prompt,
-            "response_format": "b64_json",
         }
 
         # I2I: 读取参考图并转为 base64 data URI
@@ -75,10 +75,14 @@ class ArkImageBackend:
             **kwargs,
         )
 
-        # 解码并保存
-        image_data = base64.b64decode(response.data[0].b64_json)
+        # 解码并保存 — Ark API returns b64_json or url depending on model
+        item = response.data[0]
         request.output_path.parent.mkdir(parents=True, exist_ok=True)
-        request.output_path.write_bytes(image_data)
+        if getattr(item, "b64_json", None):
+            image_data = base64.b64decode(item.b64_json)
+            request.output_path.write_bytes(image_data)
+        else:
+            urllib.request.urlretrieve(item.url, request.output_path)  # noqa: S310
 
         return ImageGenerationResult(
             image_path=request.output_path,

--- a/lib/image_backends/openai.py
+++ b/lib/image_backends/openai.py
@@ -71,7 +71,6 @@ class OpenAIImageBackend:
             prompt=request.prompt,
             size=_SIZE_MAP.get(request.aspect_ratio, "1024x1792"),
             quality=_QUALITY_MAP.get(request.image_size, "medium"),
-            response_format="b64_json",
             n=1,
         )
         return self._save_and_return(response, request)
@@ -96,7 +95,6 @@ class OpenAIImageBackend:
                 model=self._model,
                 image=image_files,
                 prompt=request.prompt,
-                response_format="b64_json",
             )
         finally:
             for f in image_files:


### PR DESCRIPTION
Problem
Both ArkImageBackend and OpenAIImageBackend were passing response_format="b64_json" to their respective image generation APIs. Neither API supports this parameter, causing a 400 error on every image generation call — blocking character design, clue design, storyboard, and video generation entirely.

Changes
lib/image_backends/ark.py

Removed "response_format": "b64_json" from the API request payload
Updated response parsing to handle both b64_json and url response formats, since the Ark API returns a URL rather than base64 data — falls back to urllib.request.urlretrieve when b64_json is absent
lib/image_backends/openai.py

Removed response_format="b64_json" from both images.generate() and images.edit() calls
gpt-image-1 and gpt-image-1.5 return base64 by default, so existing response parsing is unaffected
Impact
Fixes all image generation stages (characters, clues, storyboard) and unblocks downstream video generation.