### PR TITLE
fix: Ark vision 改用 chat.completions 避免推理模型解析失败

### DIFF
--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
 
 from lib.ark_shared import ARK_BASE_URL, create_ark_client, resolve_ark_api_key
 from lib.providers import PROVIDER_ARK
@@ -60,9 +59,7 @@ class ArkTextBackend:
 
     @with_retry_async()
     async def generate(self, request: TextGenerationRequest) -> TextGenerationResult:
-        if request.images:
-            return await self._generate_vision(request)
-        if request.response_schema:
+        if request.response_schema and not request.images:
             return await self._generate_structured(request)
         return await self._generate_plain(request)
 
@@ -114,47 +111,26 @@ class ArkTextBackend:
             provider=PROVIDER_ARK,
         )
 
-    async def _generate_vision(self, request: TextGenerationRequest) -> TextGenerationResult:
-        content: list[dict[str, Any]] = []
-        for img in request.images or []:
-            if img.path:
-                from lib.image_backends.base import image_to_base64_data_uri
-
-                data_uri = image_to_base64_data_uri(img.path)
-                content.append({"type": "input_image", "image_url": data_uri})
-            elif img.url:
-                content.append({"type": "input_image", "image_url": img.url})
-
-        content.append({"type": "input_text", "text": request.prompt})
-
-        messages: list[dict] = []
-        if request.system_prompt:
-            messages.append({"role": "system", "content": request.system_prompt})
-        messages.append({"role": "user", "content": content})
-
-        response = await asyncio.to_thread(
-            self._client.responses.create,
-            model=self._model,
-            input=messages,
-        )
-
-        text = response.output_text if hasattr(response, "output_text") else str(response)
-        input_tokens = getattr(getattr(response, "usage", None), "input_tokens", None)
-        output_tokens = getattr(getattr(response, "usage", None), "output_tokens", None)
-
-        return TextGenerationResult(
-            text=text.strip() if isinstance(text, str) else str(text),
-            provider=PROVIDER_ARK,
-            model=self._model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-        )
-
     def _build_messages(self, request: TextGenerationRequest) -> list[dict]:
         messages: list[dict] = []
         if request.system_prompt:
             messages.append({"role": "system", "content": request.system_prompt})
-        messages.append({"role": "user", "content": request.prompt})
+
+        if request.images:
+            from lib.image_backends.base import image_to_base64_data_uri
+
+            content: list[dict] = []
+            for img in request.images:
+                if img.path:
+                    data_uri = image_to_base64_data_uri(img.path)
+                    content.append({"type": "image_url", "image_url": {"url": data_uri}})
+                elif img.url:
+                    content.append({"type": "image_url", "image_url": {"url": img.url}})
+            content.append({"type": "text", "text": request.prompt})
+            messages.append({"role": "user", "content": content})
+        else:
+            messages.append({"role": "user", "content": request.prompt})
+
         return messages
 
     def _parse_chat_response(self, response) -> TextGenerationResult:

--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -59,7 +59,7 @@ class ArkTextBackend:
 
     @with_retry_async()
     async def generate(self, request: TextGenerationRequest) -> TextGenerationResult:
-        if request.response_schema and not request.images:
+        if request.response_schema:
             return await self._generate_structured(request)
         return await self._generate_plain(request)
 

--- a/tests/test_text_backends/test_ark.py
+++ b/tests/test_text_backends/test_ark.py
@@ -62,6 +62,59 @@ class TestGenerate:
         assert result.output_tokens == 8
 
 
+class TestVision:
+    async def test_vision_uses_chat_completions(self, mock_ark, sync_to_thread):
+        """vision 路径走 chat.completions.create，与 plain 共用响应解析。"""
+        from lib.text_backends.base import ImageInput
+
+        _, mock_client = mock_ark
+        b = ArkTextBackend(api_key="k")
+
+        mock_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="  style description  "))],
+            usage=SimpleNamespace(prompt_tokens=100, completion_tokens=50),
+        )
+        mock_client.chat.completions.create = MagicMock(return_value=mock_resp)
+
+        result = await b.generate(
+            TextGenerationRequest(prompt="describe style", images=[ImageInput(url="https://example.com/img.jpg")])
+        )
+
+        assert result.text == "style description"
+        assert result.input_tokens == 100
+        assert result.output_tokens == 50
+        # 确认走的是 chat.completions 而不是 responses API
+        mock_client.chat.completions.create.assert_called_once()
+
+    async def test_vision_message_format(self, mock_ark, sync_to_thread):
+        """vision 请求构建 image_url 格式的多模态消息。"""
+        from lib.text_backends.base import ImageInput
+
+        _, mock_client = mock_ark
+        b = ArkTextBackend(api_key="k")
+
+        mock_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+            usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5),
+        )
+        mock_client.chat.completions.create = MagicMock(return_value=mock_resp)
+
+        await b.generate(
+            TextGenerationRequest(
+                prompt="describe",
+                system_prompt="you are helpful",
+                images=[ImageInput(url="https://example.com/img.jpg")],
+            )
+        )
+
+        call_args = mock_client.chat.completions.create.call_args
+        messages = call_args.kwargs["messages"]
+        assert messages[0] == {"role": "system", "content": "you are helpful"}
+        user_content = messages[1]["content"]
+        assert user_content[0] == {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}}
+        assert user_content[1] == {"type": "text", "text": "describe"}
+
+
 class TestCapabilityAwareStructured:
     """测试基于模型能力的结构化输出路径选择。"""
 


### PR DESCRIPTION
## Summary
- Ark SDK 的 `Response` 类没有 `output_text` 属性，使用推理模型（如 `doubao-seed-2-0-mini`）时 fallback 到 `str(response)`，返回包含推理链的完整对象字符串
- 将 vision 路径从 `responses.create` 重构为 `chat.completions.create`，与 plain/structured 路径及其他后端（OpenAI/Grok）统一
- 删除 `_generate_vision` 和 `_extract_response_text`，vision 图片处理合并到 `_build_messages`，复用 `_parse_chat_response`

## Test plan
- [x] `test_vision_uses_chat_completions` — 确认 vision 走 chat.completions 路径并正确解析
- [x] `test_vision_message_format` — 确认构建 `image_url` 格式的多模态消息
- [x] 既有 13 个测试全部通过