### PR TITLE
fix: tool_result content 数组导致前端 React Error #31 崩溃

### DIFF
--- a/frontend/src/components/copilot/chat/ContentBlockRenderer.tsx
+++ b/frontend/src/components/copilot/chat/ContentBlockRenderer.tsx
@@ -57,7 +57,11 @@ export function ContentBlockRenderer({ block, index }: ContentBlockRendererProps
             {block.is_error ? "执行失败" : "工具结果"}
           </div>
           <pre className="text-xs text-slate-300 overflow-x-auto whitespace-pre-wrap">
-            {block.content || ""}
+            {typeof block.content === "string"
+              ? block.content
+              : block.content
+                ? JSON.stringify(block.content, null, 2)
+                : ""}
           </pre>
         </div>
       );
@@ -109,9 +113,11 @@ export function ContentBlockRenderer({ block, index }: ContentBlockRendererProps
       return null;
 
     default: {
-      // Fallback: render as text
-      const text = block.text || block.content || JSON.stringify(block);
-      return <TextBlock key={block.id ?? `block-${index}`} text={text} />;
+      // Fallback: render as text (content may be non-string from SDK)
+      const fallback = block.text
+        || (typeof block.content === "string" ? block.content : null)
+        || JSON.stringify(block);
+      return <TextBlock key={block.id ?? `block-${index}`} text={fallback} />;
     }
   }
 }

--- a/server/agent_runtime/turn_grouper.py
+++ b/server/agent_runtime/turn_grouper.py
@@ -8,6 +8,7 @@ import re
 from typing import Any
 
 from server.agent_runtime.turn_schema import (
+    _stringify_content,
     infer_block_type,
     normalize_turn,
 )
@@ -111,7 +112,7 @@ def _normalize_tool_result_block(block: dict[str, Any]) -> dict[str, Any]:
     return {
         "type": "tool_result",
         "tool_use_id": block.get("tool_use_id"),
-        "content": block.get("content", ""),
+        "content": _stringify_content(block.get("content", "")),
         "is_error": block.get("is_error", False),
     }
 

--- a/server/agent_runtime/turn_schema.py
+++ b/server/agent_runtime/turn_schema.py
@@ -34,6 +34,30 @@ import copy
 from typing import Any
 
 
+def _stringify_content(content: Any) -> str:
+    """Ensure tool_result content is always a string.
+
+    The Claude SDK may send tool_result content as a list of content blocks
+    (e.g. ``[{"type": "text", "text": "..."}]``).  The frontend expects a
+    plain string, so we flatten arrays here.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict):
+                parts.append(item.get("text", ""))
+            elif isinstance(item, str):
+                parts.append(item)
+            else:
+                parts.append(str(item))
+        return "\n".join(parts)
+    if content is None:
+        return ""
+    return str(content)
+
+
 def infer_block_type(block: dict[str, Any]) -> str:
     """Infer content block type when SDK omits explicit ``type``.
 
@@ -89,6 +113,8 @@ def normalize_block(block: Any) -> dict[str, Any]:
     elif block_type == "tool_use":
         if not isinstance(normalized.get("input"), dict):
             normalized["input"] = {}
+    elif block_type == "tool_result":
+        normalized["content"] = _stringify_content(normalized.get("content", ""))
     elif block_type == "image":
         pass  # image blocks pass through as-is (source field preserved by deepcopy)
 

--- a/server/agent_runtime/turn_schema.py
+++ b/server/agent_runtime/turn_schema.py
@@ -48,8 +48,6 @@ def _stringify_content(content: Any) -> str:
         for item in content:
             if isinstance(item, dict):
                 parts.append(str(item.get("text") or ""))
-            elif isinstance(item, str):
-                parts.append(item)
             else:
                 parts.append(str(item))
         return "\n".join(parts)

--- a/server/agent_runtime/turn_schema.py
+++ b/server/agent_runtime/turn_schema.py
@@ -47,7 +47,7 @@ def _stringify_content(content: Any) -> str:
         parts = []
         for item in content:
             if isinstance(item, dict):
-                parts.append(item.get("text", ""))
+                parts.append(str(item.get("text") or ""))
             elif isinstance(item, str):
                 parts.append(item)
             else:

--- a/tests/test_turn_schema.py
+++ b/tests/test_turn_schema.py
@@ -217,6 +217,11 @@ class TestStringifyContent:
         content = [{"type": "text", "text": "dict"}, "plain", 99]
         assert _stringify_content(content) == "dict\nplain\n99"
 
+    def test_dict_with_none_text(self):
+        """SDK may send {type: text, text: null} — must not TypeError on join."""
+        content = [{"type": "text", "text": None}]
+        assert _stringify_content(content) == ""
+
 
 class TestToolResultContentNormalization:
     """Verify tool_result blocks always have string content after normalization."""

--- a/tests/test_turn_schema.py
+++ b/tests/test_turn_schema.py
@@ -1,6 +1,7 @@
 """Unit tests for turn_schema shared normalization."""
 
 from server.agent_runtime.turn_schema import (
+    _stringify_content,
     infer_block_type,
     normalize_block,
     normalize_content,
@@ -190,3 +191,69 @@ class TestNormalizeTurns:
 
     def test_empty_list(self):
         assert normalize_turns([]) == []
+
+
+class TestStringifyContent:
+    def test_string_passthrough(self):
+        assert _stringify_content("hello") == "hello"
+
+    def test_list_of_text_blocks(self):
+        content = [{"type": "text", "text": "line1"}, {"type": "text", "text": "line2"}]
+        assert _stringify_content(content) == "line1\nline2"
+
+    def test_list_with_plain_strings(self):
+        assert _stringify_content(["a", "b"]) == "a\nb"
+
+    def test_empty_list(self):
+        assert _stringify_content([]) == ""
+
+    def test_none(self):
+        assert _stringify_content(None) == ""
+
+    def test_non_string_non_list(self):
+        assert _stringify_content(42) == "42"
+
+    def test_mixed_list(self):
+        content = [{"type": "text", "text": "dict"}, "plain", 99]
+        assert _stringify_content(content) == "dict\nplain\n99"
+
+
+class TestToolResultContentNormalization:
+    """Verify tool_result blocks always have string content after normalization."""
+
+    def test_normalize_block_tool_result_with_list_content(self):
+        """SDK sends content as [{type: text, text: ...}] — must be flattened."""
+        block = {
+            "type": "tool_result",
+            "tool_use_id": "t1",
+            "content": [{"type": "text", "text": "result here"}],
+        }
+        result = normalize_block(block)
+        assert result["type"] == "tool_result"
+        assert isinstance(result["content"], str)
+        assert result["content"] == "result here"
+
+    def test_normalize_block_tool_result_with_string_content(self):
+        block = {
+            "type": "tool_result",
+            "tool_use_id": "t1",
+            "content": "already string",
+        }
+        result = normalize_block(block)
+        assert result["content"] == "already string"
+
+    def test_normalize_turn_with_tool_result_list_content(self):
+        """End-to-end: turn containing tool_result with array content."""
+        turn = {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "t1",
+                    "content": [{"type": "text", "text": "ok"}],
+                }
+            ],
+        }
+        result = normalize_turn(turn)
+        assert isinstance(result["content"][0]["content"], str)
+        assert result["content"][0]["content"] == "ok"


### PR DESCRIPTION
## Summary

- Claude SDK 的 `tool_result.content` 可能是 `[{type, text}]` 数组格式，后端未转为字符串就透传给前端，违反 Turn Contract (`content: str`)，导致 React 渲染对象时崩溃 (Error #31)
- 后端新增 `_stringify_content()` 在 `normalize_block()` 和 `_normalize_tool_result_block()` 中将数组展平为字符串
- 前端 `ContentBlockRenderer` 添加防御性类型检查作为纵深防御
- 新增 10 个测试覆盖 content 序列化和 tool_result 规范化

## Test plan

- [x] `test_turn_schema.py` 全部 47 个测试通过（含 10 个新增）
- [x] 全部 179 个 turn 相关测试通过，无回归
- [x] 前端 `pnpm build` 构建成功
- [ ] 手动验证：重新进入工作台页面不再崩溃