### PR TITLE
fix: 导出警告弹窗无法关闭、project.lock 泄漏及 None 补全噪音

### DIFF
--- a/frontend/src/components/layout/GlobalHeader.tsx
+++ b/frontend/src/components/layout/GlobalHeader.tsx
@@ -224,6 +224,7 @@ export function GlobalHeader({ onNavigateBack }: GlobalHeaderProps) {
   };
 
   return (
+    <>
     <header className="flex h-12 shrink-0 items-center justify-between border-b border-gray-800 bg-gray-900/80 px-4 backdrop-blur-sm">
       {/* ---- Left section ---- */}
       <div className="flex items-center gap-3">
@@ -388,19 +389,20 @@ export function GlobalHeader({ onNavigateBack }: GlobalHeaderProps) {
         </button>
 
       </div>
-
-      {exportDiagnostics !== null && (
-        <ArchiveDiagnosticsDialog
-          title="导出诊断"
-          description="导出已完成预检查并生成 ZIP。以下问题在导出包中被检测到。"
-          sections={[
-            { key: "blocking", title: "阻断问题", tone: "border-red-400/25 bg-red-500/10 text-red-100", items: exportDiagnostics.blocking },
-            { key: "auto_fixed", title: "已自动修复", tone: "border-indigo-400/25 bg-indigo-500/10 text-indigo-100", items: exportDiagnostics.auto_fixed },
-            { key: "warnings", title: "警告", tone: "border-amber-400/25 bg-amber-500/10 text-amber-100", items: exportDiagnostics.warnings },
-          ]}
-          onClose={() => setExportDiagnostics(null)}
-        />
-      )}
     </header>
+
+    {exportDiagnostics !== null && (
+      <ArchiveDiagnosticsDialog
+        title="导出诊断"
+        description="导出已完成预检查并生成 ZIP。以下问题在导出包中被检测到。"
+        sections={[
+          { key: "blocking", title: "阻断问题", tone: "border-red-400/25 bg-red-500/10 text-red-100", items: exportDiagnostics.blocking },
+          { key: "auto_fixed", title: "已自动修复", tone: "border-indigo-400/25 bg-indigo-500/10 text-indigo-100", items: exportDiagnostics.auto_fixed },
+          { key: "warnings", title: "警告", tone: "border-amber-400/25 bg-amber-500/10 text-amber-100", items: exportDiagnostics.warnings },
+        ]}
+        onClose={() => setExportDiagnostics(null)}
+      />
+    )}
+    </>
   );
 }

--- a/server/services/project_archive.py
+++ b/server/services/project_archive.py
@@ -475,6 +475,8 @@ class ProjectArchiveService:
                     continue
                 if is_root and filename in self._AGENT_RUNTIME_EXCLUDES:
                     continue
+                if is_root and filename not in self._ROOT_VISIBLE_ENTRIES:
+                    continue
                 destination_path = destination_dir / filename
                 destination_path.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(source_path, destination_path)
@@ -712,12 +714,15 @@ class ProjectArchiveService:
                     for key in missing_keys:
                         assets[key] = template[key]
                     script_changed = True
-                    diagnostics.add(
-                        "auto_fixed",
-                        "generated_assets_defaults",
-                        (f"{items_key}[{index}].generated_assets: 补全默认字段 {', '.join(sorted(missing_keys))}"),
-                        location=f"{location_prefix}.generated_assets",
-                    )
+                    # 补全值非 None 的才报诊断，避免 no-op 补全产生噪音
+                    non_null_keys = sorted(k for k in missing_keys if template[k] is not None)
+                    if non_null_keys:
+                        diagnostics.add(
+                            "auto_fixed",
+                            "generated_assets_defaults",
+                            (f"{items_key}[{index}].generated_assets: 补全默认字段 {', '.join(non_null_keys)}"),
+                            location=f"{location_prefix}.generated_assets",
+                        )
 
             characters = item.get(chars_field)
             if isinstance(characters, list):


### PR DESCRIPTION
## Summary

- **Dialog 无法关闭/透明**：`ArchiveDiagnosticsDialog` 渲染在 `<header>` 内部，`backdrop-blur-sm` 创建新的包含块导致 `fixed` 定位失效，移到 `<header>` 外解决
- **project.lock 泄漏到导出包**：`_copy_visible_tree` 只过滤了非标准目录，没过滤非标准文件，补上根级文件的白名单检查
- **补全 None 值噪音**：`generated_assets` 缺失字段补全值为 `None` 时（如 `video_thumbnail`）不产生 `auto_fixed` 诊断

## Test plan

- [x] 后端 archive 相关 39 个测试全部通过
- [x] 前端 TypeScript 构建通过
- [ ] 手动验证导出弹窗可正常关闭
- [ ] 手动验证导出包不含 project.lock