### PR TITLE
fix: 宫格预览面板重构与 UI 改进

### DIFF
--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -25,6 +25,8 @@ export interface GridPreviewPanelProps {
   sceneIds: string[];
   /** Called after a regeneration is submitted (for parent to refresh grids list). */
   onRegenerated?: () => void;
+  /** Changed when grids list is refreshed, triggers re-fetch of panel data. */
+  refreshKey?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -203,6 +205,7 @@ export function GridPreviewPanel({
   gridId,
   sceneIds,
   onRegenerated,
+  refreshKey = 0,
 }: GridPreviewPanelProps) {
   const [expanded, setExpanded] = useState(false);
   const [grid, setGrid] = useState<GridGeneration | null>(null);
@@ -235,7 +238,7 @@ export function GridPreviewPanel({
     return () => {
       cancelled = true;
     };
-  }, [expanded, gridId, projectName]);
+  }, [expanded, gridId, projectName, refreshKey]);
 
   const imageUrl =
     grid?.grid_image_path

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -9,11 +9,12 @@ import {
   CheckCircle2,
   Clock,
   Scissors,
-  ArrowRight,
+  User,
+  Search,
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { API } from "@/api";
-import type { GridGeneration, FrameCell } from "@/types/grid";
+import type { GridGeneration, ReferenceImage } from "@/types/grid";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -21,7 +22,7 @@ import type { GridGeneration, FrameCell } from "@/types/grid";
 
 export interface GridPreviewPanelProps {
   projectName: string;
-  gridId: string | null;
+  gridIds: string[];
   /** Called after a regeneration is submitted (for parent to refresh grids list). */
   onRegenerated?: () => void;
   /** Changed when grids list is refreshed, triggers re-fetch of panel data. */
@@ -29,7 +30,7 @@ export interface GridPreviewPanelProps {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// StatusBadge
 // ---------------------------------------------------------------------------
 
 type GridStatus = GridGeneration["status"];
@@ -78,119 +79,62 @@ function StatusBadge({ status }: { status: GridStatus }) {
   );
 }
 
-const FRAME_TYPE_CONFIGS = {
-  first: {
-    label: "首帧",
-    cls: "bg-amber-900/50 text-amber-300 border-amber-700/40",
-  },
-  transition: {
-    label: "过渡",
-    cls: "bg-sky-900/50 text-sky-300 border-sky-700/40",
-  },
-  placeholder: {
-    label: "占位",
-    cls: "bg-gray-800/80 text-gray-500 border-gray-700/40",
-  },
-} as const;
-
-function FrameTypeBadge({ type }: { type: FrameCell["frame_type"] }) {
-  const { label, cls } = FRAME_TYPE_CONFIGS[type];
-  return (
-    <span
-      className={`inline-flex items-center rounded border px-1 py-px text-[9px] font-semibold uppercase tracking-wider ${cls}`}
-    >
-      {label}
-    </span>
-  );
-}
-
-/** Derive a display name from scene id by truncating for readability. */
-function sceneShortId(id: string): string {
-  if (!id) return "—";
-  const parts = id.split("_");
-  if (parts.length >= 2) return `${parts[parts.length - 2]}_${parts[parts.length - 1]}`;
-  return id.length > 10 ? `…${id.slice(-8)}` : id;
-}
-
 // ---------------------------------------------------------------------------
-// FrameChainList
+// ReferenceImageStrip
 // ---------------------------------------------------------------------------
 
-function FrameChainList({ frames }: { frames: FrameCell[] }) {
-  if (frames.length === 0) {
-    return (
-      <div className="py-4 text-center text-xs text-gray-600">暂无帧链数据</div>
-    );
-  }
-
+function ReferenceImageStrip({
+  references,
+  projectName,
+  refreshKey,
+}: {
+  references: ReferenceImage[];
+  projectName: string;
+  refreshKey: number;
+}) {
   return (
-    <div className="flex flex-col gap-px overflow-hidden rounded-md border border-gray-800/60">
-      {/* Header row */}
-      <div className="grid grid-cols-[2rem_1fr_auto_auto] items-center gap-2 border-b border-gray-800/60 bg-gray-900/50 px-3 py-1.5">
-        <span className="text-[9px] font-semibold uppercase tracking-widest text-gray-600">
-          #
-        </span>
-        <span className="text-[9px] font-semibold uppercase tracking-widest text-gray-600">
-          场景映射
-        </span>
-        <span className="text-[9px] font-semibold uppercase tracking-widest text-gray-600">
-          类型
-        </span>
-        <span className="text-[9px] font-semibold uppercase tracking-widest text-gray-600">
-          位置
-        </span>
-      </div>
-
-      {frames.map((frame, idx) => (
-        <motion.div
-          key={frame.index}
-          initial={{ opacity: 0, x: -4 }}
-          animate={{ opacity: 1, x: 0 }}
-          transition={{ delay: idx * 0.02, duration: 0.2 }}
-          className={`grid grid-cols-[2rem_1fr_auto_auto] items-center gap-2 px-3 py-2 text-xs transition-colors hover:bg-gray-800/30 ${
-            idx % 2 === 0 ? "bg-gray-900/20" : "bg-transparent"
-          }`}
-        >
-          {/* Index */}
-          <span className="font-mono text-[11px] font-semibold tabular-nums text-gray-500">
-            {String(frame.index + 1).padStart(2, "0")}
-          </span>
-
-          {/* Scene mapping */}
-          <div className="flex min-w-0 items-center gap-1.5">
-            {frame.prev_scene_id ? (
+    <div className="flex gap-2.5 overflow-x-auto pb-1 scrollbar-thin">
+      {references.map((ref, idx) => {
+        const isChar = ref.ref_type === "character";
+        return (
+          <motion.div
+            key={ref.path}
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: idx * 0.05, duration: 0.2 }}
+            className="group flex w-14 shrink-0 flex-col items-center gap-1"
+          >
+            <div
+              className={`w-full overflow-hidden rounded border bg-gray-900/50 transition-all duration-200 ${
+                isChar
+                  ? "border-amber-800/30 group-hover:border-amber-500/50"
+                  : "border-sky-800/30 group-hover:border-sky-500/50"
+              }`}
+            >
+              <img
+                src={API.getFileUrl(projectName, ref.path, refreshKey)}
+                alt={ref.name}
+                className="block aspect-square w-full object-cover transition-transform duration-200 group-hover:scale-105"
+              />
+            </div>
+            <div className="flex max-w-full items-center gap-0.5">
+              {isChar ? (
+                <User className="h-2 w-2 shrink-0 text-amber-500/50" />
+              ) : (
+                <Search className="h-2 w-2 shrink-0 text-sky-500/50" />
+              )}
               <span
-                className="truncate font-mono text-[10px] text-gray-400"
-                title={frame.prev_scene_id}
+                className={`truncate text-[8px] leading-tight ${
+                  isChar ? "text-amber-400/50" : "text-sky-400/50"
+                }`}
+                title={ref.name}
               >
-                {sceneShortId(frame.prev_scene_id)}
+                {ref.name}
               </span>
-            ) : null}
-            {frame.prev_scene_id && frame.next_scene_id ? (
-              <ArrowRight className="h-2.5 w-2.5 shrink-0 text-gray-600" />
-            ) : null}
-            {frame.next_scene_id ? (
-              <span
-                className="truncate font-mono text-[10px] text-amber-400/80"
-                title={frame.next_scene_id}
-              >
-                {sceneShortId(frame.next_scene_id)}
-              </span>
-            ) : null}
-            {!frame.prev_scene_id && !frame.next_scene_id ? (
-              <span className="text-[10px] text-gray-600">—</span>
-            ) : null}
-          </div>
-
-          {/* Frame type badge */}
-          <FrameTypeBadge type={frame.frame_type} />
-
-          {/* Grid position */}
-          <span className="font-mono text-[10px] tabular-nums text-gray-600">
-            R{frame.row + 1}C{frame.col + 1}
-          </span>
-        </motion.div>
-      ))}
+            </div>
+          </motion.div>
+        );
+      })}
     </div>
   );
 }
@@ -201,26 +145,39 @@ function FrameChainList({ frames }: { frames: FrameCell[] }) {
 
 export function GridPreviewPanel({
   projectName,
-  gridId,
+  gridIds,
   onRegenerated,
   refreshKey = 0,
 }: GridPreviewPanelProps) {
   const [expanded, setExpanded] = useState(false);
+  const [selectedIdx, setSelectedIdx] = useState(0);
   const [grid, setGrid] = useState<GridGeneration | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [regenerating, setRegenerating] = useState(false);
 
-  // Fetch grid data when expanded and gridId is available
+  const hasGrids = gridIds.length > 0;
+  const multipleGrids = gridIds.length > 1;
+  const safeIdx = Math.min(selectedIdx, Math.max(0, gridIds.length - 1));
+  const selectedGridId = gridIds[safeIdx] ?? null;
+
+  // Clamp selection when grid list changes
   useEffect(() => {
-    if (!expanded || !gridId) return;
+    if (selectedIdx >= gridIds.length && gridIds.length > 0) {
+      setSelectedIdx(0);
+    }
+  }, [gridIds.length, selectedIdx]);
+
+  // Fetch grid data when expanded and selectedGridId is available
+  useEffect(() => {
+    if (!expanded || !selectedGridId) return;
 
     let cancelled = false;
-    // Only show loading spinner on initial load, not on refresh
-    if (!grid) setLoading(true);
+    // Only show loading spinner when we have no data for this grid
+    if (!grid || grid.id !== selectedGridId) setLoading(true);
     setError(null);
 
-    API.getGrid(projectName, gridId)
+    API.getGrid(projectName, selectedGridId)
       .then((data) => {
         if (!cancelled) {
           setGrid(data);
@@ -237,7 +194,7 @@ export function GridPreviewPanel({
     return () => {
       cancelled = true;
     };
-  }, [expanded, gridId, projectName, refreshKey]);
+  }, [expanded, selectedGridId, projectName, refreshKey]);
 
   const isInProgress =
     grid?.status === "pending" || grid?.status === "generating" || grid?.status === "splitting";
@@ -247,14 +204,16 @@ export function GridPreviewPanel({
       ? API.getFileUrl(projectName, grid.grid_image_path, refreshKey)
       : null;
 
+  const refs = grid?.reference_images ?? [];
+
   return (
-    <div className="my-3 overflow-hidden rounded-lg border border-amber-900/20 bg-amber-950/10">
+    <div>
       {/* Toggle header */}
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
-        className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-amber-900/10 focus:outline-none"
+        className="flex w-full items-center gap-2 border-t border-amber-800/20 px-4 py-1.5 text-left transition-colors hover:bg-amber-900/10 focus:outline-none"
       >
         <motion.span
           animate={{ rotate: expanded ? 90 : 0 }}
@@ -268,8 +227,14 @@ export function GridPreviewPanel({
 
         <span className="text-xs font-medium text-amber-400/70">宫格预览</span>
 
-        {!gridId && (
+        {!hasGrids && (
           <span className="ml-1 text-[10px] text-gray-600">尚未生成</span>
+        )}
+
+        {multipleGrids && !expanded && (
+          <span className="ml-1 text-[10px] text-gray-600">
+            {gridIds.length} 批
+          </span>
         )}
       </button>
 
@@ -284,9 +249,9 @@ export function GridPreviewPanel({
             transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
             className="overflow-hidden"
           >
-            <div className="border-t border-amber-900/20 px-3 py-3">
+            <div className="px-4 pb-3 pt-2">
               {/* No grid yet */}
-              {!gridId ? (
+              {!hasGrids ? (
                 <div className="flex flex-col items-center gap-2 py-6 text-center">
                   <Grid2x2 className="h-8 w-8 text-gray-700" />
                   <p className="text-xs text-gray-600">尚未生成宫格</p>
@@ -294,8 +259,8 @@ export function GridPreviewPanel({
                     点击上方「生成宫格」按钮开始
                   </p>
                 </div>
-              ) : loading ? (
-                /* Loading state */
+              ) : loading && !grid ? (
+                /* Loading state (initial) */
                 <div className="flex items-center justify-center gap-2 py-8">
                   <Loader2 className="h-4 w-4 animate-spin text-amber-500/50" />
                   <span className="text-xs text-gray-600">加载宫格数据...</span>
@@ -308,13 +273,34 @@ export function GridPreviewPanel({
                 </div>
               ) : grid ? (
                 /* Grid loaded */
-                <div className="flex flex-col gap-4">
-                  {/* Top bar: status + meta + regen button */}
+                <div className="flex flex-col gap-3">
+                  {/* Top bar: batch pills + status + regen */}
                   <div className="flex items-center gap-2">
+                    {multipleGrids && (
+                      <div className="flex items-center gap-0.5 rounded-md bg-gray-900/50 p-0.5">
+                        {gridIds.map((_, idx) => (
+                          <button
+                            key={idx}
+                            type="button"
+                            onClick={() => setSelectedIdx(idx)}
+                            className={`inline-flex h-5 min-w-[1.375rem] items-center justify-center rounded px-1 text-[10px] font-medium tabular-nums transition-all duration-150 ${
+                              idx === safeIdx
+                                ? "bg-amber-700/50 text-amber-200 shadow-sm"
+                                : "text-gray-500 hover:text-gray-300 hover:bg-gray-800/60"
+                            }`}
+                          >
+                            {idx + 1}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+
                     <StatusBadge status={grid.status} />
+
                     <span className="text-[10px] text-gray-600">
                       {grid.model}
                     </span>
+
                     {grid.error_message && (
                       <span
                         className="truncate text-[10px] text-red-400/70"
@@ -323,13 +309,14 @@ export function GridPreviewPanel({
                         {grid.error_message}
                       </span>
                     )}
+
                     <motion.button
                       type="button"
                       disabled={regenerating || isInProgress}
                       onClick={() => {
-                        if (!gridId || regenerating || isInProgress) return;
+                        if (!selectedGridId || regenerating || isInProgress) return;
                         setRegenerating(true);
-                        API.regenerateGrid(projectName, gridId)
+                        API.regenerateGrid(projectName, selectedGridId)
                           .then(() => {
                             setGrid((prev) => prev ? { ...prev, status: "pending" } : prev);
                             onRegenerated?.();
@@ -349,49 +336,46 @@ export function GridPreviewPanel({
                     </motion.button>
                   </div>
 
-                  {/* Main content: image + frame chain */}
-                  <div className="grid grid-cols-[auto_1fr] gap-3">
-                    {/* Composite grid image */}
-                    <div className="flex flex-col gap-1.5">
-                      <span className="text-[9px] font-semibold uppercase tracking-widest text-gray-600">
-                        合成图
-                      </span>
-                      {imageUrl ? (
-                        <div className="overflow-hidden rounded-md border border-gray-800/50 bg-gray-900/50">
-                          <img
-                            src={imageUrl}
-                            alt="宫格合成图"
-                            className="block w-40 object-cover"
-                            style={{ imageRendering: "pixelated" }}
-                          />
-                          {/* Grid overlay indicator */}
-                          <div className="border-t border-gray-800/60 px-2 py-1">
-                            <span className="font-mono text-[9px] text-gray-600">
-                              {grid.cell_count} 格 · {grid.grid_size}
-                            </span>
-                          </div>
-                        </div>
-                      ) : (
-                        <div className="flex h-24 w-40 items-center justify-center rounded-md border border-gray-800/40 bg-gray-900/30">
-                          <span className="text-[10px] text-gray-700">
-                            {grid.status === "generating" || grid.status === "pending"
-                              ? "生成中..."
-                              : "无图像"}
-                          </span>
-                        </div>
-                      )}
-                    </div>
-
-                    {/* Frame chain */}
-                    <div className="flex min-w-0 flex-col gap-1.5">
-                      <span className="text-[9px] font-semibold uppercase tracking-widest text-gray-600">
-                        帧链映射 ({grid.frame_chain.length} 帧)
-                      </span>
-                      <div className="max-h-52 overflow-y-auto rounded-md scrollbar-thin">
-                        <FrameChainList frames={grid.frame_chain} />
+                  {/* Composite image + metadata */}
+                  {imageUrl ? (
+                    <div className="overflow-hidden rounded-md border border-gray-800/50 bg-gray-900/40">
+                      <img
+                        src={imageUrl}
+                        alt="宫格合成图"
+                        className="block max-h-64 w-full object-contain bg-black/20"
+                      />
+                      <div className="flex items-center gap-2 border-t border-gray-800/50 px-2.5 py-1.5">
+                        <span className="font-mono text-[10px] text-gray-500">
+                          {grid.cell_count} 格 · {grid.grid_size}
+                        </span>
+                        <span className="text-[10px] text-gray-700">
+                          {grid.rows}×{grid.cols}
+                        </span>
                       </div>
                     </div>
-                  </div>
+                  ) : (
+                    <div className="flex h-24 items-center justify-center rounded-md border border-gray-800/40 bg-gray-900/30">
+                      <span className="text-[10px] text-gray-700">
+                        {grid.status === "generating" || grid.status === "pending"
+                          ? "生成中..."
+                          : "无图像"}
+                      </span>
+                    </div>
+                  )}
+
+                  {/* Reference images strip */}
+                  {refs.length > 0 && (
+                    <div className="flex flex-col gap-1.5">
+                      <span className="text-[9px] font-medium uppercase tracking-widest text-gray-600">
+                        参考图
+                      </span>
+                      <ReferenceImageStrip
+                        references={refs}
+                        projectName={projectName}
+                        refreshKey={refreshKey}
+                      />
+                    </div>
+                  )}
                 </div>
               ) : null}
             </div>

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -23,7 +23,8 @@ export interface GridPreviewPanelProps {
   projectName: string;
   gridId: string | null;
   sceneIds: string[];
-  onRegenerate: () => void;
+  /** Called after a regeneration is submitted (for parent to refresh grids list). */
+  onRegenerated?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -201,12 +202,13 @@ export function GridPreviewPanel({
   projectName,
   gridId,
   sceneIds,
-  onRegenerate,
+  onRegenerated,
 }: GridPreviewPanelProps) {
   const [expanded, setExpanded] = useState(false);
   const [grid, setGrid] = useState<GridGeneration | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [regenerating, setRegenerating] = useState(false);
 
   // Fetch grid data when expanded and gridId is available
   useEffect(() => {
@@ -335,12 +337,25 @@ export function GridPreviewPanel({
                     <div className="ml-auto">
                       <motion.button
                         type="button"
-                        onClick={onRegenerate}
-                        className="inline-flex items-center gap-1 rounded border border-amber-800/30 bg-amber-950/30 px-2 py-1 text-[10px] font-medium text-amber-400/80 transition-colors hover:bg-amber-900/40 hover:text-amber-300"
-                        whileTap={{ scale: 0.95 }}
+                        disabled={regenerating}
+                        onClick={() => {
+                          if (!gridId || regenerating) return;
+                          setRegenerating(true);
+                          API.regenerateGrid(projectName, gridId)
+                            .then(() => {
+                              setGrid((prev) => prev ? { ...prev, status: "pending" } : prev);
+                              onRegenerated?.();
+                            })
+                            .catch(() => {})
+                            .finally(() => setRegenerating(false));
+                        }}
+                        className={`inline-flex items-center gap-1 rounded border border-amber-800/30 bg-amber-950/30 px-2 py-1 text-[10px] font-medium text-amber-400/80 transition-colors ${
+                          regenerating ? "opacity-50 cursor-not-allowed" : "hover:bg-amber-900/40 hover:text-amber-300"
+                        }`}
+                        whileTap={regenerating ? {} : { scale: 0.95 }}
                       >
-                        <RefreshCw className="h-3 w-3" />
-                        重新生成
+                        <RefreshCw className={`h-3 w-3 ${regenerating ? "animate-spin" : ""}`} />
+                        {regenerating ? "提交中..." : "重新生成"}
                       </motion.button>
                     </div>
                   </div>

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -22,7 +22,6 @@ import type { GridGeneration, FrameCell } from "@/types/grid";
 export interface GridPreviewPanelProps {
   projectName: string;
   gridId: string | null;
-  sceneIds: string[];
   /** Called after a regeneration is submitted (for parent to refresh grids list). */
   onRegenerated?: () => void;
   /** Changed when grids list is refreshed, triggers re-fetch of panel data. */
@@ -203,7 +202,6 @@ function FrameChainList({ frames }: { frames: FrameCell[] }) {
 export function GridPreviewPanel({
   projectName,
   gridId,
-  sceneIds,
   onRegenerated,
   refreshKey = 0,
 }: GridPreviewPanelProps) {
@@ -266,24 +264,8 @@ export function GridPreviewPanel({
 
         <span className="text-xs font-medium text-amber-400/70">宫格预览</span>
 
-        {gridId && grid ? (
-          <span className="ml-1">
-            <StatusBadge status={grid.status} />
-          </span>
-        ) : gridId ? (
-          <span className="ml-1 text-[10px] text-gray-600">
-            {sceneIds.length} 场景
-          </span>
-        ) : (
+        {!gridId && (
           <span className="ml-1 text-[10px] text-gray-600">尚未生成</span>
-        )}
-
-        {/* Grid info pill */}
-        {grid && (
-          <span className="ml-auto flex items-center gap-1 font-mono text-[10px] text-gray-500">
-            <Grid2x2 className="h-3 w-3" />
-            {grid.rows}×{grid.cols}
-          </span>
         )}
       </button>
 

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -173,8 +173,11 @@ export function GridPreviewPanel({
     if (!expanded || !selectedGridId) return;
 
     let cancelled = false;
-    // Only show loading spinner when we have no data for this grid
-    if (!grid || grid.id !== selectedGridId) setLoading(true);
+    // Clear stale data and show spinner when switching batches
+    if (!grid || grid.id !== selectedGridId) {
+      setLoading(true);
+      setGrid(null);
+    }
     setError(null);
 
     API.getGrid(projectName, selectedGridId)

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -331,7 +331,9 @@ export function GridPreviewPanel({
                               setGrid((prev) => prev ? { ...prev, status: "pending" } : prev);
                               onRegenerated?.();
                             })
-                            .catch(() => {})
+                            .catch((err: unknown) => {
+                              setError(err instanceof Error ? err.message : "重新生成失败");
+                            })
                             .finally(() => setRegenerating(false));
                         }}
                         className={`inline-flex items-center gap-1 rounded border border-amber-800/30 bg-amber-950/30 px-2 py-1 text-[10px] font-medium text-amber-400/80 transition-colors ${

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -216,7 +216,8 @@ export function GridPreviewPanel({
     if (!expanded || !gridId) return;
 
     let cancelled = false;
-    setLoading(true);
+    // Only show loading spinner on initial load, not on refresh
+    if (!grid) setLoading(true);
     setError(null);
 
     API.getGrid(projectName, gridId)
@@ -238,9 +239,12 @@ export function GridPreviewPanel({
     };
   }, [expanded, gridId, projectName, refreshKey]);
 
+  const isInProgress =
+    grid?.status === "pending" || grid?.status === "generating" || grid?.status === "splitting";
+
   const imageUrl =
     grid?.grid_image_path
-      ? API.getFileUrl(projectName, grid.grid_image_path)
+      ? API.getFileUrl(projectName, grid.grid_image_path, refreshKey)
       : null;
 
   return (
@@ -319,32 +323,30 @@ export function GridPreviewPanel({
                         {grid.error_message}
                       </span>
                     )}
-                    <div className="ml-auto">
-                      <motion.button
-                        type="button"
-                        disabled={regenerating}
-                        onClick={() => {
-                          if (!gridId || regenerating) return;
-                          setRegenerating(true);
-                          API.regenerateGrid(projectName, gridId)
-                            .then(() => {
-                              setGrid((prev) => prev ? { ...prev, status: "pending" } : prev);
-                              onRegenerated?.();
-                            })
-                            .catch((err: unknown) => {
-                              setError(err instanceof Error ? err.message : "重新生成失败");
-                            })
-                            .finally(() => setRegenerating(false));
-                        }}
-                        className={`inline-flex items-center gap-1 rounded border border-amber-800/30 bg-amber-950/30 px-2 py-1 text-[10px] font-medium text-amber-400/80 transition-colors ${
-                          regenerating ? "opacity-50 cursor-not-allowed" : "hover:bg-amber-900/40 hover:text-amber-300"
-                        }`}
-                        whileTap={regenerating ? {} : { scale: 0.95 }}
-                      >
-                        <RefreshCw className={`h-3 w-3 ${regenerating ? "animate-spin" : ""}`} />
-                        {regenerating ? "提交中..." : "重新生成"}
-                      </motion.button>
-                    </div>
+                    <motion.button
+                      type="button"
+                      disabled={regenerating || isInProgress}
+                      onClick={() => {
+                        if (!gridId || regenerating || isInProgress) return;
+                        setRegenerating(true);
+                        API.regenerateGrid(projectName, gridId)
+                          .then(() => {
+                            setGrid((prev) => prev ? { ...prev, status: "pending" } : prev);
+                            onRegenerated?.();
+                          })
+                          .catch((err: unknown) => {
+                            setError(err instanceof Error ? err.message : "重新生成失败");
+                          })
+                          .finally(() => setRegenerating(false));
+                      }}
+                      className={`ml-auto shrink-0 whitespace-nowrap inline-flex items-center gap-1 rounded border border-amber-800/30 bg-amber-950/30 px-2 py-1 text-[10px] font-medium text-amber-400/80 transition-colors ${
+                        regenerating || isInProgress ? "opacity-50 cursor-not-allowed" : "hover:bg-amber-900/40 hover:text-amber-300"
+                      }`}
+                      whileTap={regenerating || isInProgress ? {} : { scale: 0.95 }}
+                    >
+                      <RefreshCw className={`h-3 w-3 ${regenerating || isInProgress ? "animate-spin" : ""}`} />
+                      {regenerating ? "提交中..." : isInProgress ? "生成中..." : "重新生成"}
+                    </motion.button>
                   </div>
 
                   {/* Main content: image + frame chain */}

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -241,7 +241,7 @@ export function GridPreviewPanel({
       : null;
 
   return (
-    <div className="mt-2.5 overflow-hidden rounded-lg border border-amber-900/20 bg-amber-950/10">
+    <div className="my-3 overflow-hidden rounded-lg border border-amber-900/20 bg-amber-950/10">
       {/* Toggle header */}
       <button
         type="button"

--- a/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
+++ b/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
@@ -24,6 +24,8 @@ export interface GridSegmentGroupProps {
   gridIds?: string[];
   /** Project name — required when gridIds is provided */
   projectName?: string;
+  /** Called after a single grid is regenerated (to refresh the grids list). */
+  onGridRegenerated?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -66,6 +68,7 @@ export function GridSegmentGroup({
   children,
   gridIds = [],
   projectName = "",
+  onGridRegenerated,
 }: GridSegmentGroupProps) {
   const { t } = useTranslation("dashboard");
   const label = groupLabel(groupIndex);
@@ -162,7 +165,7 @@ export function GridSegmentGroup({
               projectName={projectName}
               gridId={gid}
               sceneIds={sceneIds}
-              onRegenerate={onGenerateGrid}
+              onRegenerated={onGridRegenerated}
             />
           ))
         : projectName && (
@@ -170,7 +173,7 @@ export function GridSegmentGroup({
               projectName={projectName}
               gridId={null}
               sceneIds={sceneIds}
-              onRegenerate={onGenerateGrid}
+              onRegenerated={onGridRegenerated}
             />
           )}
 

--- a/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
+++ b/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
@@ -26,6 +26,8 @@ export interface GridSegmentGroupProps {
   projectName?: string;
   /** Called after a single grid is regenerated (to refresh the grids list). */
   onGridRegenerated?: () => void;
+  /** Incremented when the grids list is refreshed, to trigger panel re-fetch. */
+  gridsVersion?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -69,6 +71,7 @@ export function GridSegmentGroup({
   gridIds = [],
   projectName = "",
   onGridRegenerated,
+  gridsVersion = 0,
 }: GridSegmentGroupProps) {
   const { t } = useTranslation("dashboard");
   const label = groupLabel(groupIndex);
@@ -166,6 +169,7 @@ export function GridSegmentGroup({
               gridId={gid}
               sceneIds={sceneIds}
               onRegenerated={onGridRegenerated}
+              refreshKey={gridsVersion}
             />
           ))
         : projectName && (
@@ -174,6 +178,7 @@ export function GridSegmentGroup({
               gridId={null}
               sceneIds={sceneIds}
               onRegenerated={onGridRegenerated}
+              refreshKey={gridsVersion}
             />
           )}
 

--- a/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
+++ b/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
@@ -154,10 +154,7 @@ export function GridSegmentGroup({
         </motion.button>
       </div>
 
-      {/* ---- Children (SegmentCards) ---- */}
-      <div className="flex flex-col gap-4">{children}</div>
-
-      {/* ---- Grid Preview Panel ---- */}
+      {/* ---- Grid Preview Panel (above cards, collapsible) ---- */}
       {projectName && (
         <GridPreviewPanel
           projectName={projectName}
@@ -166,6 +163,9 @@ export function GridSegmentGroup({
           onRegenerate={onGenerateGrid}
         />
       )}
+
+      {/* ---- Children (SegmentCards) ---- */}
+      <div className="flex flex-col gap-4">{children}</div>
     </div>
   );
 }

--- a/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
+++ b/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
@@ -80,100 +80,92 @@ export function GridSegmentGroup({
 
   return (
     <div className="mb-6">
-      {/* ---- Group header ---- */}
-      <div className="mb-3 flex items-center justify-between rounded-lg border border-amber-800/30 bg-amber-950/20 px-4 py-2.5">
-        <div className="flex items-center gap-2.5">
-          <Grid2x2 className="h-4 w-4 text-amber-500/70" />
-          <span className="text-sm font-medium text-amber-400/90">
-            Segment {label}
-          </span>
-          <span className="text-xs text-gray-500">
-            {t("grid_scene_count", { count: sceneCount })}
-            {gridInfo && batchCount > 1 ? (
-              <>
-                {" \u2192 "}
-                <span className="font-mono text-amber-500/70">{t("grid_batch_count", { count: batchCount })}</span>
-                <span className="text-gray-600">{" "}({gridInfo})</span>
-              </>
-            ) : gridInfo ? (
-              <>
-                {" \u2192 "}
-                <span className="font-mono text-amber-500/70">{gridInfo}</span>
-              </>
-            ) : null}
-          </span>
+      {/* ---- Group header + preview (unified container) ---- */}
+      <div className="mb-3 overflow-hidden rounded-lg border border-amber-800/30 bg-amber-950/20">
+        <div className="flex items-center justify-between px-4 py-2.5">
+          <div className="flex items-center gap-2.5">
+            <Grid2x2 className="h-4 w-4 text-amber-500/70" />
+            <span className="text-sm font-medium text-amber-400/90">
+              Segment {label}
+            </span>
+            <span className="text-xs text-gray-500">
+              {t("grid_scene_count", { count: sceneCount })}
+              {gridInfo && batchCount > 1 ? (
+                <>
+                  {" \u2192 "}
+                  <span className="font-mono text-amber-500/70">{t("grid_batch_count", { count: batchCount })}</span>
+                  <span className="text-gray-600">{" "}({gridInfo})</span>
+                </>
+              ) : gridInfo ? (
+                <>
+                  {" \u2192 "}
+                  <span className="font-mono text-amber-500/70">{gridInfo}</span>
+                </>
+              ) : null}
+            </span>
+          </div>
+
+          {/* Generate grid button */}
+          <motion.button
+            type="button"
+            onClick={onGenerateGrid}
+            disabled={!canGenerate || generatingGrid}
+            title={!canGenerate ? t("insufficient_scenes_for_grid") : undefined}
+            className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+              generatingGrid
+                ? "bg-blue-700 text-white"
+                : canGenerate
+                  ? "bg-blue-600 text-white hover:bg-blue-500"
+                  : "bg-gray-800 text-gray-600 cursor-not-allowed"
+            } ${!canGenerate || generatingGrid ? "opacity-50 cursor-not-allowed" : ""}`}
+            animate={
+              generatingGrid
+                ? { opacity: [0.7, 1, 0.7] }
+                : { opacity: !canGenerate ? 0.5 : 1 }
+            }
+            transition={
+              generatingGrid
+                ? { duration: 1.5, repeat: Infinity, ease: "easeInOut" }
+                : { duration: 0.3 }
+            }
+          >
+            <AnimatePresence mode="wait" initial={false}>
+              {generatingGrid ? (
+                <motion.span
+                  key="loader"
+                  initial={{ opacity: 0, rotate: -90 }}
+                  animate={{ opacity: 1, rotate: 0 }}
+                  exit={{ opacity: 0, rotate: 90 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                </motion.span>
+              ) : (
+                <motion.span
+                  key="sparkles"
+                  initial={{ opacity: 0, scale: 0.5 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.5 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <Sparkles className="h-3.5 w-3.5" />
+                </motion.span>
+              )}
+            </AnimatePresence>
+            <span>{generatingGrid ? t("generating_grid") : t("generate_grid_btn")}</span>
+          </motion.button>
         </div>
 
-        {/* Generate grid button */}
-        <motion.button
-          type="button"
-          onClick={onGenerateGrid}
-          disabled={!canGenerate || generatingGrid}
-          title={!canGenerate ? t("insufficient_scenes_for_grid") : undefined}
-          className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
-            generatingGrid
-              ? "bg-blue-700 text-white"
-              : canGenerate
-                ? "bg-blue-600 text-white hover:bg-blue-500"
-                : "bg-gray-800 text-gray-600 cursor-not-allowed"
-          } ${!canGenerate || generatingGrid ? "opacity-50 cursor-not-allowed" : ""}`}
-          animate={
-            generatingGrid
-              ? { opacity: [0.7, 1, 0.7] }
-              : { opacity: !canGenerate ? 0.5 : 1 }
-          }
-          transition={
-            generatingGrid
-              ? { duration: 1.5, repeat: Infinity, ease: "easeInOut" }
-              : { duration: 0.3 }
-          }
-        >
-          <AnimatePresence mode="wait" initial={false}>
-            {generatingGrid ? (
-              <motion.span
-                key="loader"
-                initial={{ opacity: 0, rotate: -90 }}
-                animate={{ opacity: 1, rotate: 0 }}
-                exit={{ opacity: 0, rotate: 90 }}
-                transition={{ duration: 0.2 }}
-              >
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              </motion.span>
-            ) : (
-              <motion.span
-                key="sparkles"
-                initial={{ opacity: 0, scale: 0.5 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0, scale: 0.5 }}
-                transition={{ duration: 0.2 }}
-              >
-                <Sparkles className="h-3.5 w-3.5" />
-              </motion.span>
-            )}
-          </AnimatePresence>
-          <span>{generatingGrid ? t("generating_grid") : t("generate_grid_btn")}</span>
-        </motion.button>
+        {/* Grid Preview (integrated, no separate border) */}
+        {projectName && (
+          <GridPreviewPanel
+            projectName={projectName}
+            gridIds={gridIds}
+            onRegenerated={onGridRegenerated}
+            refreshKey={gridsVersion}
+          />
+        )}
       </div>
-
-      {/* ---- Grid Preview Panels (one per batch, above cards) ---- */}
-      {projectName && gridIds.length > 0
-        ? gridIds.map((gid) => (
-            <GridPreviewPanel
-              key={gid}
-              projectName={projectName}
-              gridId={gid}
-              onRegenerated={onGridRegenerated}
-              refreshKey={gridsVersion}
-            />
-          ))
-        : projectName && (
-            <GridPreviewPanel
-              projectName={projectName}
-              gridId={null}
-              onRegenerated={onGridRegenerated}
-              refreshKey={gridsVersion}
-            />
-          )}
 
       {/* ---- Children (SegmentCards) ---- */}
       <div className="flex flex-col gap-4">{children}</div>

--- a/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
+++ b/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
@@ -78,11 +78,6 @@ export function GridSegmentGroup({
   const gridInfo = gridSize ? GRID_LABEL[gridSize] ?? gridSize : null;
   const canGenerate = gridSize !== null;
 
-  // Derive scene IDs for the preview panel
-  const sceneIds = scenes.map((s) =>
-    "scene_id" in s ? (s as DramaScene).scene_id : (s as NarrationSegment).segment_id
-  );
-
   return (
     <div className="mb-6">
       {/* ---- Group header ---- */}
@@ -167,7 +162,6 @@ export function GridSegmentGroup({
               key={gid}
               projectName={projectName}
               gridId={gid}
-              sceneIds={sceneIds}
               onRegenerated={onGridRegenerated}
               refreshKey={gridsVersion}
             />
@@ -176,7 +170,6 @@ export function GridSegmentGroup({
             <GridPreviewPanel
               projectName={projectName}
               gridId={null}
-              sceneIds={sceneIds}
               onRegenerated={onGridRegenerated}
               refreshKey={gridsVersion}
             />

--- a/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
+++ b/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
@@ -20,9 +20,9 @@ export interface GridSegmentGroupProps {
   onGenerateGrid: () => void;
   generatingGrid: boolean;
   children: React.ReactNode;
-  /** Optional grid ID for showing the preview panel */
-  gridId?: string | null;
-  /** Project name — required when gridId is provided */
+  /** Grid IDs for showing preview panels (one per batch) */
+  gridIds?: string[];
+  /** Project name — required when gridIds is provided */
   projectName?: string;
 }
 
@@ -64,7 +64,7 @@ export function GridSegmentGroup({
   onGenerateGrid,
   generatingGrid,
   children,
-  gridId = null,
+  gridIds = [],
   projectName = "",
 }: GridSegmentGroupProps) {
   const { t } = useTranslation("dashboard");
@@ -154,15 +154,25 @@ export function GridSegmentGroup({
         </motion.button>
       </div>
 
-      {/* ---- Grid Preview Panel (above cards, collapsible) ---- */}
-      {projectName && (
-        <GridPreviewPanel
-          projectName={projectName}
-          gridId={gridId}
-          sceneIds={sceneIds}
-          onRegenerate={onGenerateGrid}
-        />
-      )}
+      {/* ---- Grid Preview Panels (one per batch, above cards) ---- */}
+      {projectName && gridIds.length > 0
+        ? gridIds.map((gid) => (
+            <GridPreviewPanel
+              key={gid}
+              projectName={projectName}
+              gridId={gid}
+              sceneIds={sceneIds}
+              onRegenerate={onGenerateGrid}
+            />
+          ))
+        : projectName && (
+            <GridPreviewPanel
+              projectName={projectName}
+              gridId={null}
+              sceneIds={sceneIds}
+              onRegenerate={onGenerateGrid}
+            />
+          )}
 
       {/* ---- Children (SegmentCards) ---- */}
       <div className="flex flex-col gap-4">{children}</div>

--- a/frontend/src/components/canvas/timeline/SegmentCard.tsx
+++ b/frontend/src/components/canvas/timeline/SegmentCard.tsx
@@ -149,6 +149,8 @@ interface SegmentCardProps {
   clues: Record<string, Clue>;
   projectName: string;
   durationOptions?: number[];
+  /** When true, hides the per-scene "生成分镜" button (grid mode manages storyboards). */
+  isGridMode?: boolean;
   onUpdatePrompt?: (
     segmentId: string,
     field: string,
@@ -541,6 +543,7 @@ function MediaColumn({
   aspectRatio,
   projectName,
   segmentId,
+  isGridMode,
   onGenerateStoryboard,
   onGenerateVideo,
   onRestoreStoryboard,
@@ -552,6 +555,7 @@ function MediaColumn({
   aspectRatio: string;
   projectName: string;
   segmentId: string;
+  isGridMode?: boolean;
   onGenerateStoryboard?: (segmentId: string) => void;
   onGenerateVideo?: (segmentId: string) => void;
   onRestoreStoryboard?: () => Promise<void> | void;
@@ -564,9 +568,6 @@ function MediaColumn({
   const storyboardFp = useProjectsStore(
     (s) => assets?.storyboard_image ? s.getAssetFingerprint(assets.storyboard_image) : null,
   );
-  const lastFrameFp = useProjectsStore(
-    (s) => assets?.storyboard_last_image ? s.getAssetFingerprint(assets.storyboard_last_image) : null,
-  );
   const videoFp = useProjectsStore(
     (s) => assets?.video_clip ? s.getAssetFingerprint(assets.video_clip) : null,
   );
@@ -576,18 +577,12 @@ function MediaColumn({
   const storyboardUrl = assets?.storyboard_image
     ? API.getFileUrl(projectName, assets.storyboard_image, storyboardFp)
     : null;
-  const lastFrameUrl = assets?.storyboard_last_image
-    ? API.getFileUrl(projectName, assets.storyboard_last_image, lastFrameFp)
-    : null;
   const videoUrl = assets?.video_clip
     ? API.getFileUrl(projectName, assets.video_clip, videoFp)
     : null;
   const thumbnailUrl = assets?.video_thumbnail
     ? API.getFileUrl(projectName, assets.video_thumbnail, thumbnailFp)
     : null;
-
-  // Detect grid mode: segment has a last frame image
-  const hasLastFrame = !!assets?.storyboard_last_image;
 
   // Normalize aspect ratio to the union type expected by AspectFrame
   const normalizedRatio = (
@@ -611,94 +606,33 @@ function MediaColumn({
           />
         </div>
 
-        {hasLastFrame ? (
-          /* Grid mode: vertical stack of first frame + last frame */
-          <div className="flex flex-col gap-1.5">
-            {/* First frame */}
-            <div>
-              <div className="mb-1 flex items-center gap-1">
-                <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/30">
-                  {t("first_frame")}
-                </span>
-              </div>
-              <PreviewableImageFrame src={storyboardUrl} alt={`${segmentId} ${t("first_frame")}`}>
-                <AspectFrame ratio={normalizedRatio}>
-                  <ImageFlipReveal
-                    src={storyboardUrl}
-                    alt={`${segmentId} ${t("first_frame")}`}
-                    loading="lazy"
-                    className="h-full w-full object-cover"
-                    fallback={
-                      <div className="flex h-full w-full flex-col items-center justify-center gap-2 text-gray-600">
-                        <ImageIcon className="h-8 w-8" />
-                        <span className="text-xs">{t("no_first_frame")}</span>
-                      </div>
-                    }
-                  />
-                </AspectFrame>
-              </PreviewableImageFrame>
-            </div>
+        <PreviewableImageFrame src={storyboardUrl} alt={`${segmentId} ${t("storyboard_section")}`}>
+          <AspectFrame ratio={normalizedRatio}>
+            <ImageFlipReveal
+              src={storyboardUrl}
+              alt={`${segmentId} ${t("storyboard_section")}`}
+              loading="lazy"
+              className="h-full w-full object-cover"
+              fallback={
+                <div className="flex h-full w-full flex-col items-center justify-center gap-2 text-gray-600">
+                  <ImageIcon className="h-8 w-8" />
+                  <span className="text-xs">{t("no_storyboard")}</span>
+                </div>
+              }
+            />
+          </AspectFrame>
+        </PreviewableImageFrame>
 
-            {/* Arrow connector */}
-            <div className="flex items-center justify-center gap-2 py-0.5">
-              <div className="flex-1 border-t border-dashed border-emerald-700/40" />
-              <span className="text-sm text-emerald-500/70 select-none">↓</span>
-              <div className="flex-1 border-t border-dashed border-emerald-700/40" />
-            </div>
-
-            {/* Last frame */}
-            <div>
-              <div className="mb-1 flex items-center gap-1">
-                <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold bg-purple-500/20 text-purple-400 ring-1 ring-purple-500/30">
-                  {t("last_frame")}
-                </span>
-              </div>
-              <PreviewableImageFrame src={lastFrameUrl} alt={`${segmentId} ${t("last_frame")}`}>
-                <AspectFrame ratio={normalizedRatio}>
-                  <ImageFlipReveal
-                    src={lastFrameUrl}
-                    alt={`${segmentId} ${t("last_frame")}`}
-                    loading="lazy"
-                    className="h-full w-full object-cover"
-                    fallback={
-                      <div className="flex h-full w-full flex-col items-center justify-center gap-2 text-gray-600">
-                        <ImageIcon className="h-8 w-8" />
-                        <span className="text-xs">{t("no_last_frame")}</span>
-                      </div>
-                    }
-                  />
-                </AspectFrame>
-              </PreviewableImageFrame>
-            </div>
+        {!isGridMode && (
+          <div className="mt-2">
+            <GenerateButton
+              onClick={() => onGenerateStoryboard?.(segmentId)}
+              loading={generatingStoryboard}
+              label={t("generate_storyboard")}
+              className="w-full justify-center"
+            />
           </div>
-        ) : (
-          /* Single mode: existing storyboard display */
-          <PreviewableImageFrame src={storyboardUrl} alt={`${segmentId} ${t("storyboard_section")}`}>
-            <AspectFrame ratio={normalizedRatio}>
-              <ImageFlipReveal
-                src={storyboardUrl}
-                alt={`${segmentId} ${t("storyboard_section")}`}
-                loading="lazy"
-                className="h-full w-full object-cover"
-                fallback={
-                  <div className="flex h-full w-full flex-col items-center justify-center gap-2 text-gray-600">
-                    <ImageIcon className="h-8 w-8" />
-                    <span className="text-xs">{t("no_storyboard")}</span>
-                  </div>
-                }
-              />
-            </AspectFrame>
-          </PreviewableImageFrame>
         )}
-
-        <div className="mt-2">
-          <GenerateButton
-            onClick={() => onGenerateStoryboard?.(segmentId)}
-            loading={generatingStoryboard}
-            label={t("generate_storyboard")}
-            className="w-full justify-center"
-          />
-        </div>
       </div>
 
       {/* ---- Video (shown when available or as placeholder) ---- */}
@@ -730,7 +664,7 @@ function MediaColumn({
           <GenerateButton
             onClick={() => onGenerateVideo?.(segmentId)}
             loading={generatingVideo}
-            label={hasLastFrame ? t("generate_video_first_last") : t("generate_video_btn")}
+            label={t("generate_video_btn")}
             className="w-full justify-center"
             disabled={!assets?.storyboard_image}
           />
@@ -752,6 +686,7 @@ export function SegmentCard({
   clues,
   projectName,
   durationOptions,
+  isGridMode,
   onUpdatePrompt,
   onGenerateStoryboard,
   onGenerateVideo,
@@ -841,6 +776,7 @@ export function SegmentCard({
             aspectRatio={aspectRatio}
             projectName={projectName}
             segmentId={segmentId}
+            isGridMode={isGridMode}
             onGenerateStoryboard={onGenerateStoryboard}
             onGenerateVideo={onGenerateVideo}
             onRestoreStoryboard={onRestoreStoryboard}

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -203,21 +203,14 @@ export function TimelineCanvas({
   }, [refreshGrids, episodeScript]);
 
   /**
-   * Build a map from sorted-scene-key → gridId for matching groups.
-   * Uses the grid's scene_ids set intersection with a group's scene IDs.
+   * Find all grid IDs whose scene_ids are a subset of the given group.
+   * Handles batched grids: a group with 32 scenes may have 4 grids of ~9 each.
    */
-  const gridIdByGroupScenes = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const grid of grids) {
-      const key = [...grid.scene_ids].sort().join(",");
-      map.set(key, grid.id);
-    }
-    return map;
-  }, [grids]);
-
-  function getGridIdForGroup(groupScenes: Segment[]): string | null {
-    const key = groupScenes.map((s) => getSegmentId(s, contentMode)).sort().join(",");
-    return gridIdByGroupScenes.get(key) ?? null;
+  function getGridIdsForGroup(groupScenes: Segment[]): string[] {
+    const groupIdSet = new Set(groupScenes.map((s) => getSegmentId(s, contentMode)));
+    return grids
+      .filter((g) => g.scene_ids.length > 0 && g.scene_ids.every((id) => groupIdSet.has(id)))
+      .map((g) => g.id);
   }
 
   const handleGenerateGroupGrid = useCallback(
@@ -425,7 +418,7 @@ export function TimelineCanvas({
                     batchCount={gridResult.batchCount}
                     onGenerateGrid={() => handleGenerateGroupGrid(groupIdx, group)}
                     generatingGrid={generatingGridGroups.has(groupIdx)}
-                    gridId={getGridIdForGroup(group)}
+                    gridIds={getGridIdsForGroup(group)}
                     projectName={projectName}
                   >
                     {group.map((segment) => {

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -212,11 +212,26 @@ export function TimelineCanvas({
   /**
    * Find all grid IDs whose scene_ids are a subset of the given group.
    * Handles batched grids: a group with 32 scenes may have 4 grids of ~9 each.
+   * Deduplicates by scene_ids key — keeps only the newest grid per unique batch.
    */
   function getGridIdsForGroup(groupScenes: Segment[]): string[] {
     const groupIdSet = new Set(groupScenes.map((s) => getSegmentId(s, contentMode)));
-    return grids
-      .filter((g) => g.scene_ids.length > 0 && g.scene_ids.every((id) => groupIdSet.has(id)))
+    const matched = grids.filter((g) =>
+      g.episode === episode &&
+      g.scene_ids.length > 0 &&
+      g.scene_ids.every((id) => groupIdSet.has(id)),
+    );
+    // Deduplicate: for grids with identical scene_ids, keep the newest one
+    const byKey = new Map<string, typeof matched[number]>();
+    for (const g of matched) {
+      const key = [...g.scene_ids].sort().join(",");
+      const existing = byKey.get(key);
+      if (!existing || g.created_at > existing.created_at) {
+        byKey.set(key, g);
+      }
+    }
+    return Array.from(byKey.values())
+      .sort((a, b) => a.created_at.localeCompare(b.created_at))
       .map((g) => g.id);
   }
 

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -191,10 +191,14 @@ export function TimelineCanvas({
   const [generatingGridGroups, setGeneratingGridGroups] = useState<Set<number>>(new Set());
   const [generatingAllGrids, setGeneratingAllGrids] = useState(false);
   const [grids, setGrids] = useState<GridGeneration[]>([]);
+  const [gridsVersion, setGridsVersion] = useState(0);
 
   const refreshGrids = useCallback(() => {
     if (!isGridMode || !projectName) return;
-    API.listGrids(projectName).then(setGrids).catch(() => {/* silently ignore */});
+    API.listGrids(projectName).then((data) => {
+      setGrids(data);
+      setGridsVersion((v) => v + 1);
+    }).catch(() => {/* silently ignore */});
   }, [isGridMode, projectName]);
 
   // Fetch grids list for the current episode when in grid mode
@@ -421,6 +425,7 @@ export function TimelineCanvas({
                     gridIds={getGridIdsForGroup(group)}
                     projectName={projectName}
                     onGridRegenerated={refreshGrids}
+                    gridsVersion={gridsVersion}
                   >
                     {group.map((segment) => {
                       const segId = getSegmentId(segment, contentMode);

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -192,11 +192,15 @@ export function TimelineCanvas({
   const [generatingAllGrids, setGeneratingAllGrids] = useState(false);
   const [grids, setGrids] = useState<GridGeneration[]>([]);
 
-  // Fetch grids list for the current episode when in grid mode
-  useEffect(() => {
+  const refreshGrids = useCallback(() => {
     if (!isGridMode || !projectName) return;
     API.listGrids(projectName).then(setGrids).catch(() => {/* silently ignore */});
-  }, [isGridMode, projectName, episodeScript]);
+  }, [isGridMode, projectName]);
+
+  // Fetch grids list for the current episode when in grid mode
+  useEffect(() => {
+    refreshGrids();
+  }, [refreshGrids, episodeScript]);
 
   /**
    * Build a map from sorted-scene-key → gridId for matching groups.
@@ -230,6 +234,7 @@ export function TimelineCanvas({
           next.delete(groupIndex);
           return next;
         });
+        refreshGrids();
       }, 3000);
     },
     [onGenerateGrid, scriptFile, contentMode, episode],
@@ -239,8 +244,11 @@ export function TimelineCanvas({
     if (!onGenerateGrid || !scriptFile) return;
     setGeneratingAllGrids(true);
     onGenerateGrid(episode, scriptFile);
-    setTimeout(() => setGeneratingAllGrids(false), 3000);
-  }, [onGenerateGrid, scriptFile, episode]);
+    setTimeout(() => {
+      setGeneratingAllGrids(false);
+      refreshGrids();
+    }, 3000);
+  }, [onGenerateGrid, scriptFile, episode, refreshGrids]);
 
   const virtualizer = useVirtualizer({
     count: segments.length,
@@ -361,10 +369,10 @@ export function TimelineCanvas({
                     type="button"
                     onClick={handleGenerateAllGrids}
                     disabled={generatingAllGrids}
-                    className={`inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors ${
+                    className={`inline-flex items-center gap-1.5 rounded-lg border px-4 py-2 text-sm font-medium transition-colors ${
                       generatingAllGrids
-                        ? "bg-blue-700 opacity-70 cursor-not-allowed"
-                        : "bg-blue-600 hover:bg-blue-500"
+                        ? "border-blue-700 text-blue-400 opacity-70 cursor-not-allowed"
+                        : "border-blue-600 text-blue-400 hover:bg-blue-600/10"
                     }`}
                     animate={
                       generatingAllGrids
@@ -432,6 +440,7 @@ export function TimelineCanvas({
                             clues={projectData.clues}
                             projectName={projectName}
                             durationOptions={durationOptions}
+                            isGridMode
                             onUpdatePrompt={onUpdatePrompt && ((id, field, value) => onUpdatePrompt(id, field, value, scriptFile))}
                             onGenerateStoryboard={onGenerateStoryboard && ((id) => onGenerateStoryboard(id, scriptFile))}
                             onGenerateVideo={onGenerateVideo && ((id) => onGenerateVideo(id, scriptFile))}

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -420,6 +420,7 @@ export function TimelineCanvas({
                     generatingGrid={generatingGridGroups.has(groupIdx)}
                     gridIds={getGridIdsForGroup(group)}
                     projectName={projectName}
+                    onGridRegenerated={refreshGrids}
                   >
                     {group.map((segment) => {
                       const segId = getSegmentId(segment, contentMode);

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -234,7 +234,7 @@ export function TimelineCanvas({
         refreshGrids();
       }, 3000);
     },
-    [onGenerateGrid, scriptFile, contentMode, episode],
+    [onGenerateGrid, scriptFile, contentMode, episode, refreshGrids],
   );
 
   const handleGenerateAllGrids = useCallback(() => {

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -7,6 +7,7 @@ import { SegmentCard } from "./SegmentCard";
 import { GridSegmentGroup } from "./GridSegmentGroup";
 import { PreprocessingView } from "./PreprocessingView";
 import { useScrollTarget } from "@/hooks/useScrollTarget";
+import { useAppStore } from "@/stores/app-store";
 import { useCostStore } from "@/stores/cost-store";
 import { formatCost, totalBreakdown } from "@/utils/cost-format";
 import { API } from "@/api";
@@ -183,6 +184,7 @@ export function TimelineCanvas({
   );
 
   // Grid mode state
+  const gridsRevision = useAppStore((s) => s.gridsRevision);
   const isGridMode = projectData?.generation_mode === "grid";
   const segmentGroups = useMemo(
     () => (isGridMode ? groupBySegmentBreak(segments) : []),
@@ -202,9 +204,10 @@ export function TimelineCanvas({
   }, [isGridMode, projectName]);
 
   // Fetch grids list for the current episode when in grid mode
+  // Also re-fetch when gridsRevision changes (triggered by grid_ready SSE events)
   useEffect(() => {
     refreshGrids();
-  }, [refreshGrids, episodeScript]);
+  }, [refreshGrids, episodeScript, gridsRevision]);
 
   /**
    * Find all grid IDs whose scene_ids are a subset of the given group.

--- a/frontend/src/hooks/useProjectEventsSSE.ts
+++ b/frontend/src/hooks/useProjectEventsSSE.ts
@@ -28,17 +28,18 @@ const CHANGE_PRIORITY: Record<string, number> = {
   "draft:created": 6.5,
   storyboard_ready: 7,
   video_ready: 8,
+  grid_ready: 9,
 };
 
 function getChangePriority(change: ProjectChange): number {
-  if (change.action === "storyboard_ready" || change.action === "video_ready") {
+  if (change.action === "storyboard_ready" || change.action === "video_ready" || change.action === "grid_ready") {
     return CHANGE_PRIORITY[change.action] ?? Number.MAX_SAFE_INTEGER;
   }
   return CHANGE_PRIORITY[`${change.entity_type}:${change.action}`] ?? Number.MAX_SAFE_INTEGER;
 }
 
 function isNavigableChange(change: ProjectChange): boolean {
-  if (change.action === "storyboard_ready" || change.action === "video_ready") {
+  if (change.action === "storyboard_ready" || change.action === "video_ready" || change.action === "grid_ready") {
     return false;
   }
   return Boolean(change.focus?.anchor_type && change.focus?.anchor_id);
@@ -291,6 +292,11 @@ export function useProjectEventsSSE(projectName?: string | null): void {
           );
           if (hasGenerationEvent && projectName) {
             useCostStore.getState().debouncedFetch(projectName);
+          }
+
+          // Refresh grid list when a grid completes
+          if (payload.changes.some((c) => c.action === "grid_ready")) {
+            useAppStore.getState().invalidateGrids();
           }
         },
         onError() {

--- a/frontend/src/stores/app-store.ts
+++ b/frontend/src/stores/app-store.ts
@@ -58,6 +58,10 @@ interface AppState {
   sourceFilesVersion: number;
   invalidateSourceFiles: () => void;
 
+  // Grid list invalidation signal (incremented on grid_ready SSE events)
+  gridsRevision: number;
+  invalidateGrids: () => void;
+
   // Entity-scoped invalidation signal for cache-busted asset URLs
   entityRevisions: Record<string, number>;
   invalidateEntities: (keys: string[]) => void;
@@ -157,6 +161,9 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   sourceFilesVersion: 0,
   invalidateSourceFiles: () => set((s) => ({ sourceFilesVersion: s.sourceFilesVersion + 1 })),
+
+  gridsRevision: 0,
+  invalidateGrids: () => set((s) => ({ gridsRevision: s.gridsRevision + 1 })),
 
   entityRevisions: {},
   invalidateEntities: (keys) =>

--- a/frontend/src/types/grid.ts
+++ b/frontend/src/types/grid.ts
@@ -4,6 +4,12 @@
  * Maps to backend models in lib/grid_manager.py and server/routers/grids.py.
  */
 
+export interface ReferenceImage {
+  path: string;
+  name: string;
+  ref_type: "character" | "clue";
+}
+
 export interface FrameCell {
   index: number;
   row: number;
@@ -31,4 +37,5 @@ export interface GridGeneration {
   grid_size: string;
   created_at: string;
   error_message: string | null;
+  reference_images?: ReferenceImage[] | null;
 }

--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -9,13 +9,14 @@ export interface ProjectChangeFocus {
 }
 
 export interface ProjectChange {
-  entity_type: "project" | "character" | "clue" | "segment" | "episode" | "overview" | "draft";
+  entity_type: "project" | "character" | "clue" | "segment" | "episode" | "overview" | "draft" | "grid";
   action:
     | "created"
     | "updated"
     | "deleted"
     | "storyboard_ready"
-    | "video_ready";
+    | "video_ready"
+    | "grid_ready";
   entity_id: string;
   label: string;
   script_file?: string;

--- a/frontend/src/utils/project-changes.ts
+++ b/frontend/src/utils/project-changes.ts
@@ -10,6 +10,7 @@ const ENTITY_LABELS: Record<ProjectChange["entity_type"], string> = {
   episode: "剧集",
   overview: "项目概览",
   draft: "预处理",
+  grid: "宫格",
 };
 
 export interface GroupedProjectChange {
@@ -69,6 +70,9 @@ function getEntityLabel(group: GroupedProjectChange): string {
   if (group.action === "video_ready") {
     return "视频";
   }
+  if (group.action === "grid_ready") {
+    return "宫格";
+  }
   return ENTITY_LABELS[group.entityType] ?? "内容";
 }
 
@@ -96,6 +100,9 @@ function formatSingleNotificationText(change: ProjectChange): string {
   if (change.action === "video_ready") {
     return `${change.label}的视频已生成`;
   }
+  if (change.action === "grid_ready") {
+    return `${change.label}已生成`;
+  }
   if (change.action === "created") {
     return `${change.label}已创建`;
   }
@@ -111,6 +118,9 @@ function formatSingleDeferredText(change: ProjectChange): string {
   }
   if (change.action === "video_ready") {
     return `AI 刚生成了 ${change.label} 的视频，点击查看`;
+  }
+  if (change.action === "grid_ready") {
+    return `${change.label} 已生成`;
   }
   if (change.action === "created") {
     return `AI 刚新增了 ${change.label}，点击查看`;
@@ -132,7 +142,7 @@ export function formatGroupedNotificationText(
   const entityLabel = getEntityLabel(group);
   const summary = summarizeGroupNames(group);
 
-  if (group.action === "storyboard_ready" || group.action === "video_ready") {
+  if (group.action === "storyboard_ready" || group.action === "video_ready" || group.action === "grid_ready") {
     return `已生成 ${count} 个${entityLabel}：${summary}`;
   }
   if (group.action === "created") {
@@ -155,7 +165,7 @@ export function formatGroupedDeferredText(
   const entityLabel = getEntityLabel(group);
   const summary = summarizeGroupNames(group);
 
-  if (group.action === "storyboard_ready" || group.action === "video_ready") {
+  if (group.action === "storyboard_ready" || group.action === "video_ready" || group.action === "grid_ready") {
     return `AI 刚生成了 ${count} 个${entityLabel}：${summary}，点击查看`;
   }
   if (group.action === "created") {

--- a/lib/grid/models.py
+++ b/lib/grid/models.py
@@ -9,6 +9,26 @@ from typing import Literal
 
 
 @dataclass
+class ReferenceImage:
+    """Metadata for a reference image used during grid generation."""
+
+    path: str  # Relative path from project root (e.g. "characters/hero/sheet.png")
+    name: str  # Display name (character or clue name)
+    ref_type: str  # "character" or "clue"
+
+    def to_dict(self) -> dict:
+        return {"path": self.path, "name": self.name, "ref_type": self.ref_type}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ReferenceImage:
+        return cls(
+            path=data["path"],
+            name=data["name"],
+            ref_type=data.get("ref_type", "character"),
+        )
+
+
+@dataclass
 class FrameCell:
     """Represents a single cell in a grid frame chain."""
 
@@ -113,6 +133,7 @@ class GridGeneration:
     grid_size: str
     created_at: str
     error_message: str | None = None
+    reference_images: list[ReferenceImage] | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -132,6 +153,7 @@ class GridGeneration:
             "grid_size": self.grid_size,
             "created_at": self.created_at,
             "error_message": self.error_message,
+            "reference_images": [r.to_dict() for r in self.reference_images] if self.reference_images else None,
         }
 
     @classmethod
@@ -153,6 +175,9 @@ class GridGeneration:
             grid_size=data["grid_size"],
             created_at=data["created_at"],
             error_message=data.get("error_message"),
+            reference_images=[ReferenceImage.from_dict(r) for r in data["reference_images"]]
+            if data.get("reference_images")
+            else None,
         )
 
     @classmethod

--- a/lib/grid_manager.py
+++ b/lib/grid_manager.py
@@ -31,6 +31,18 @@ class GridManager:
             return None
         return GridGeneration.from_dict(json.loads(path.read_text(encoding="utf-8")))
 
+    def delete(self, grid_id: str) -> bool:
+        """Delete a grid record and its image file. Returns True if found and deleted."""
+        path = self._path(grid_id)
+        if not path.exists():
+            return False
+        # Also remove the grid image if it exists
+        image_path = self._dir / f"{grid_id}.png"
+        if image_path.exists():
+            image_path.unlink()
+        path.unlink()
+        return True
+
     def list_all(self) -> list[GridGeneration]:
         """Return all grids sorted by created_at ascending."""
         grids = []

--- a/lib/grok_shared.py
+++ b/lib/grok_shared.py
@@ -5,9 +5,40 @@ Grok (xAI) 共享工具模块
 
 包含：
 - create_grok_client — xAI AsyncClient 客户端工厂
+- grok_should_retry — gRPC 感知的重试谓词
 """
 
 from __future__ import annotations
+
+from lib.retry import BASE_RETRYABLE_ERRORS, _should_retry
+
+# gRPC 瞬态状态码（等价于 HTTP 429/500/502/503/504）
+_GRPC_RETRYABLE_CODES: set | None = None
+
+try:
+    import grpc
+
+    _GRPC_RETRYABLE_CODES = {
+        grpc.StatusCode.UNAVAILABLE,  # 503 — 连接中断 / Socket closed
+        grpc.StatusCode.DEADLINE_EXCEEDED,  # 504 — 超时
+        grpc.StatusCode.RESOURCE_EXHAUSTED,  # 429 — 限流
+        grpc.StatusCode.ABORTED,  # 冲突重试
+    }
+except ImportError:
+    pass
+
+
+def grok_should_retry(exc: Exception) -> bool:
+    """Grok 专用重试谓词：精确匹配 gRPC 瞬态状态码，其余回退默认模式匹配。"""
+    if _GRPC_RETRYABLE_CODES is not None:
+        try:
+            from grpc.aio import AioRpcError
+
+            if isinstance(exc, AioRpcError):
+                return exc.code() in _GRPC_RETRYABLE_CODES
+        except ImportError:
+            pass
+    return _should_retry(exc, BASE_RETRYABLE_ERRORS)
 
 
 def create_grok_client(*, api_key: str | None = None):

--- a/lib/grok_shared.py
+++ b/lib/grok_shared.py
@@ -25,7 +25,7 @@ try:
         grpc.StatusCode.ABORTED,  # 冲突重试
     }
 except ImportError:
-    pass
+    pass  # grpc is optional; fall back to pattern-based retry below
 
 
 def grok_should_retry(exc: Exception) -> bool:
@@ -37,7 +37,7 @@ def grok_should_retry(exc: Exception) -> bool:
             if isinstance(exc, AioRpcError):
                 return exc.code() in _GRPC_RETRYABLE_CODES
         except ImportError:
-            pass
+            pass  # grpc available at module level but aio submodule missing; fall through
     return _should_retry(exc, BASE_RETRYABLE_ERRORS)
 
 

--- a/lib/image_backends/grok.py
+++ b/lib/image_backends/grok.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import httpx
 
-from lib.grok_shared import create_grok_client
+from lib.grok_shared import create_grok_client, grok_should_retry
 from lib.image_backends.base import (
     ImageCapability,
     ImageGenerationRequest,
@@ -74,7 +74,7 @@ class GrokImageBackend:
     def capabilities(self) -> set[ImageCapability]:
         return self._capabilities
 
-    @with_retry_async()
+    @with_retry_async(retry_if=grok_should_retry)
     async def generate(self, request: ImageGenerationRequest) -> ImageGenerationResult:
         """生成图片（T2I 或 I2I）。"""
         generate_kwargs: dict = {

--- a/lib/text_backends/grok.py
+++ b/lib/text_backends/grok.py
@@ -6,7 +6,7 @@ import logging
 
 from xai_sdk import chat as xai_chat
 
-from lib.grok_shared import create_grok_client
+from lib.grok_shared import create_grok_client, grok_should_retry
 from lib.providers import PROVIDER_GROK
 from lib.retry import with_retry_async
 from lib.text_backends.base import (
@@ -44,7 +44,7 @@ class GrokTextBackend:
     def capabilities(self) -> set[TextCapability]:
         return self._capabilities
 
-    @with_retry_async()
+    @with_retry_async(retry_if=grok_should_retry)
     async def generate(self, request: TextGenerationRequest) -> TextGenerationResult:
         chat = self._client.chat.create(model=self._model)
 

--- a/lib/video_backends/grok.py
+++ b/lib/video_backends/grok.py
@@ -7,7 +7,7 @@ import logging
 from datetime import timedelta
 from pathlib import Path
 
-from lib.grok_shared import create_grok_client
+from lib.grok_shared import create_grok_client, grok_should_retry
 from lib.providers import PROVIDER_GROK
 from lib.retry import with_retry_async
 from lib.video_backends.base import (
@@ -75,7 +75,7 @@ class GrokVideoBackend:
             generate_audio=True,
         )
 
-    @with_retry_async()
+    @with_retry_async(retry_if=grok_should_retry)
     async def _create_video(self, request: VideoGenerationRequest):
         """创建视频生成任务（带独立重试）。"""
         generate_kwargs = {

--- a/server/routers/grids.py
+++ b/server/routers/grids.py
@@ -113,12 +113,21 @@ async def generate_grid(
         queue = get_generation_queue()
         gm = GridManager(project_path)
 
+        # Pre-load existing grids for cleanup
+        existing_grids = gm.list_all()
+
         for group in groups:
             all_scene_ids = [item[id_field] for item in group]
             n = len(all_scene_ids)
             layout = calculate_grid_layout(n, aspect_ratio)
             if layout is None:
                 continue
+
+            # 清理该组旧的 grid 记录（scene_ids 是当前组子集的旧 grid）
+            group_id_set = set(all_scene_ids)
+            for old_grid in existing_grids:
+                if old_grid.scene_ids and set(old_grid.scene_ids) <= group_id_set:
+                    gm.delete(old_grid.id)
 
             # 将大分组拆分为多个宫格批次（余下不足4个的场景也用 grid_4 + 占位符）
             chunks: list[list] = []

--- a/server/routers/grids.py
+++ b/server/routers/grids.py
@@ -123,10 +123,15 @@ async def generate_grid(
             if layout is None:
                 continue
 
-            # 清理该组旧的 grid 记录（scene_ids 是当前组子集的旧 grid）
+            # 清理该组旧的 grid 记录（限定同脚本同集，scene_ids 是当前组子集的旧 grid）
             group_id_set = set(all_scene_ids)
             for old_grid in existing_grids:
-                if old_grid.scene_ids and set(old_grid.scene_ids) <= group_id_set:
+                if (
+                    old_grid.script_file == req.script_file
+                    and old_grid.episode == episode
+                    and old_grid.scene_ids
+                    and set(old_grid.scene_ids) <= group_id_set
+                ):
                     gm.delete(old_grid.id)
 
             # 将大分组拆分为多个宫格批次（余下不足4个的场景也用 grid_4 + 占位符）

--- a/server/routers/grids.py
+++ b/server/routers/grids.py
@@ -124,11 +124,13 @@ async def generate_grid(
                 continue
 
             # 清理该组旧的 grid 记录（限定同脚本同集，scene_ids 是当前组子集的旧 grid）
+            # 跳过 pending/generating 状态的记录，避免 worker 执行时找不到资源
             group_id_set = set(all_scene_ids)
             for old_grid in existing_grids:
                 if (
                     old_grid.script_file == req.script_file
                     and old_grid.episode == episode
+                    and old_grid.status not in ("pending", "generating")
                     and old_grid.scene_ids
                     and set(old_grid.scene_ids) <= group_id_set
                 ):

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -936,15 +936,17 @@ def _collect_grid_reference_images(
     project_path: Path,
     payload: dict[str, Any],
     scene_ids: list[str],
-) -> list[object] | None:
-    """Collect character_sheet and clue_sheet images referenced by grid scenes.
+) -> tuple[list[object] | None, list[dict]]:
+    """Collect character/clue sheet images referenced by grid scenes.
 
-    Reads project.json, iterates the scenes matching ``scene_ids`` in the
-    script, and returns up to 6 unique reference image paths.
+    Returns a tuple of ``(image_paths, metadata)``:
+    - *image_paths*: up to 6 :class:`~pathlib.Path` objects for the generation API.
+    - *metadata*: list of dicts ``{path, name, ref_type}`` for persisting in
+      :class:`~lib.grid.models.GridGeneration`.
     """
     project_json = project_path / "project.json"
     if not project_json.exists():
-        return None
+        return None, []
 
     import json
 
@@ -952,11 +954,11 @@ def _collect_grid_reference_images(
 
     script_file = payload.get("script_file")
     if not script_file:
-        return None
+        return None, []
 
     script_path = project_path / "scripts" / script_file
     if not script_path.exists():
-        return None
+        return None, []
 
     script = json.loads(script_path.read_text(encoding="utf-8"))
 
@@ -965,16 +967,35 @@ def _collect_grid_reference_images(
     scene_id_set = set(scene_ids)
     matched_items = [item for item in items if str(item.get(id_field, "")) in scene_id_set]
 
-    paths, _ = _collect_sheet_paths(
-        project,
-        project_path,
-        matched_items,
-        char_field=char_field,
-        clue_field=clue_field,
-        max_count=6,
-    )
+    characters = project.get("characters", {})
+    clues = project.get("clues", {})
 
-    return list(paths[:6]) or None
+    seen: set[str] = set()
+    paths: list[Path] = []
+    metadata: list[dict] = []
+    max_count = 6
+
+    for item in matched_items:
+        for char_name in item.get(char_field, []):
+            sheet = characters.get(char_name, {}).get("character_sheet")
+            if sheet and sheet not in seen:
+                p = project_path / sheet
+                if p.exists():
+                    paths.append(p)
+                    seen.add(sheet)
+                    metadata.append({"path": sheet, "name": char_name, "ref_type": "character"})
+        for clue_name in item.get(clue_field, []):
+            sheet = clues.get(clue_name, {}).get("clue_sheet")
+            if sheet and sheet not in seen:
+                p = project_path / sheet
+                if p.exists():
+                    paths.append(p)
+                    seen.add(sheet)
+                    metadata.append({"path": sheet, "name": clue_name, "ref_type": "clue"})
+        if len(paths) >= max_count:
+            break
+
+    return list(paths[:max_count]) or None, metadata[:max_count]
 
 
 async def execute_grid_task(
@@ -1010,10 +1031,15 @@ async def execute_grid_task(
         grid.error_message = None
         grid_manager.save(grid)
 
-        # c) Build reference images
-        reference_images = await asyncio.to_thread(
+        # c) Build reference images + metadata
+        from lib.grid.models import ReferenceImage
+
+        reference_images, ref_metadata = await asyncio.to_thread(
             _collect_grid_reference_images, project_path, payload, grid.scene_ids
         )
+        if ref_metadata:
+            grid.reference_images = [ReferenceImage.from_dict(m) for m in ref_metadata]
+            grid_manager.save(grid)
 
         # d) Generate grid image
         prompt_text = payload.get("prompt") or grid.prompt

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -756,7 +756,7 @@ async def execute_video_task(
     if not duration_seconds:
         duration_seconds = _get_model_default_duration(registry_provider_id, model_name)
 
-    end_image = _resolve_video_end_image(project_path, item)
+    end_image = None  # 宫格模式不再使用首尾帧，统一走普通图生视频
 
     _, version, _, video_uri = await generator.generate_video_async(
         prompt=prompt_text,

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -540,6 +540,13 @@ def _compute_affected_fingerprints(project_name: str, task_type: str, resource_i
                 project_path / "clues" / f"{resource_id}.png",
             )
         )
+    elif task_type == "grid":
+        paths.append(
+            (
+                f"grids/{resource_id}.png",
+                project_path / "grids" / f"{resource_id}.png",
+            )
+        )
 
     result: dict[str, int] = {}
     for rel, abs_path in paths:
@@ -555,6 +562,7 @@ _TASK_CHANGE_SPECS: dict[str, tuple] = {
     "video": ("segment", "video_ready", "分镜「{}」", True),
     "character": ("character", "updated", "角色「{}」设计图", False),
     "clue": ("clue", "updated", "线索「{}」设计图", False),
+    "grid": ("grid", "grid_ready", "宫格「{}」", True),
 }
 
 

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -671,18 +671,6 @@ async def execute_storyboard_task(
     }
 
 
-def _resolve_video_end_image(project_path: Path, item: dict) -> Path | None:
-    """Check if scene has a last frame image for first_last video mode."""
-    assets = item.get("generated_assets", {})
-    if isinstance(assets, str):
-        return None
-    last_img = assets.get("storyboard_last_image")
-    if not last_img:
-        return None
-    path = project_path / last_img
-    return path if path.exists() else None
-
-
 async def execute_video_task(
     project_name: str, resource_id: str, payload: dict[str, Any], *, user_id: str = DEFAULT_USER_ID
 ) -> dict[str, Any]:

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -1037,9 +1037,8 @@ async def execute_grid_task(
         reference_images, ref_metadata = await asyncio.to_thread(
             _collect_grid_reference_images, project_path, payload, grid.scene_ids
         )
-        if ref_metadata:
-            grid.reference_images = [ReferenceImage.from_dict(m) for m in ref_metadata]
-            grid_manager.save(grid)
+        grid.reference_images = [ReferenceImage.from_dict(m) for m in ref_metadata] if ref_metadata else []
+        grid_manager.save(grid)
 
         # d) Generate grid image
         prompt_text = payload.get("prompt") or grid.prompt

--- a/tests/test_grid_executor.py
+++ b/tests/test_grid_executor.py
@@ -100,12 +100,13 @@ class TestCollectGridReferenceImages:
     def test_no_references(self, project_with_script):
         from server.services.generation_tasks import _collect_grid_reference_images
 
-        result = _collect_grid_reference_images(
+        paths, metadata = _collect_grid_reference_images(
             project_with_script,
             {"script_file": "episode_1.json"},
             ["E1S01", "E1S02"],
         )
-        assert result is None
+        assert paths is None
+        assert metadata == []
 
     def test_with_character_sheet(self, project_with_script):
         from server.services.generation_tasks import _collect_grid_reference_images
@@ -121,14 +122,17 @@ class TestCollectGridReferenceImages:
         script["segments"][0]["characters_in_segment"] = ["hero"]
         (project_with_script / "scripts" / "episode_1.json").write_text(json.dumps(script))
 
-        result = _collect_grid_reference_images(
+        paths, metadata = _collect_grid_reference_images(
             project_with_script,
             {"script_file": "episode_1.json"},
             ["E1S01"],
         )
-        assert result is not None
-        assert len(result) == 1
-        assert Path(str(result[0])).name == "hero.png"
+        assert paths is not None
+        assert len(paths) == 1
+        assert Path(str(paths[0])).name == "hero.png"
+        assert len(metadata) == 1
+        assert metadata[0]["name"] == "hero"
+        assert metadata[0]["ref_type"] == "character"
 
     def test_deduplicates_references(self, project_with_script):
         from server.services.generation_tasks import _collect_grid_reference_images
@@ -144,13 +148,14 @@ class TestCollectGridReferenceImages:
         script["segments"][1]["characters_in_segment"] = ["hero"]
         (project_with_script / "scripts" / "episode_1.json").write_text(json.dumps(script))
 
-        result = _collect_grid_reference_images(
+        paths, metadata = _collect_grid_reference_images(
             project_with_script,
             {"script_file": "episode_1.json"},
             ["E1S01", "E1S02"],
         )
-        assert result is not None
-        assert len(result) == 1  # Deduplicated
+        assert paths is not None
+        assert len(paths) == 1  # Deduplicated
+        assert len(metadata) == 1  # Deduplicated
 
 
 class TestExecuteGridTask:

--- a/tests/test_grid_executor.py
+++ b/tests/test_grid_executor.py
@@ -244,27 +244,3 @@ class TestTaskExecutorsRegistry:
 
         assert "grid" in _TASK_EXECUTORS
         assert _TASK_EXECUTORS["grid"] is execute_grid_task
-
-
-class TestResolveVideoEndImage:
-    def test_returns_path_when_exists(self, tmp_path):
-        from server.services.generation_tasks import _resolve_video_end_image
-
-        (tmp_path / "storyboards").mkdir()
-        (tmp_path / "storyboards" / "scene_E1S01_last.png").write_bytes(b"fake")
-        item = {"generated_assets": {"storyboard_last_image": "storyboards/scene_E1S01_last.png"}}
-        result = _resolve_video_end_image(tmp_path, item)
-        assert result is not None
-        assert "last" in str(result)
-
-    def test_returns_none_when_no_field(self, tmp_path):
-        from server.services.generation_tasks import _resolve_video_end_image
-
-        item = {"generated_assets": {"storyboard_image": "x.png"}}
-        assert _resolve_video_end_image(tmp_path, item) is None
-
-    def test_returns_none_when_file_missing(self, tmp_path):
-        from server.services.generation_tasks import _resolve_video_end_image
-
-        item = {"generated_assets": {"storyboard_last_image": "storyboards/missing.png"}}
-        assert _resolve_video_end_image(tmp_path, item) is None

--- a/tests/test_grok_shared.py
+++ b/tests/test_grok_shared.py
@@ -1,0 +1,101 @@
+"""lib/grok_shared.py grok_should_retry 重试谓词测试。"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import grpc
+import grpc.aio
+import pytest
+
+from lib.grok_shared import grok_should_retry
+from lib.retry import with_retry_async
+
+
+def _make_aio_rpc_error(code: grpc.StatusCode, details: str = "") -> grpc.aio.AioRpcError:
+    """构造一个 AioRpcError 用于测试。"""
+    return grpc.aio.AioRpcError(
+        code=code,
+        initial_metadata=grpc.aio.Metadata(),
+        trailing_metadata=grpc.aio.Metadata(),
+        details=details,
+        debug_error_string=f"test: {details}",
+    )
+
+
+class TestGrokShouldRetry:
+    """grok_should_retry 谓词测试。"""
+
+    def test_unavailable_is_retryable(self):
+        exc = _make_aio_rpc_error(grpc.StatusCode.UNAVAILABLE, "Socket closed")
+        assert grok_should_retry(exc) is True
+
+    def test_deadline_exceeded_is_retryable(self):
+        exc = _make_aio_rpc_error(grpc.StatusCode.DEADLINE_EXCEEDED, "timeout")
+        assert grok_should_retry(exc) is True
+
+    def test_resource_exhausted_is_retryable(self):
+        exc = _make_aio_rpc_error(grpc.StatusCode.RESOURCE_EXHAUSTED, "quota exceeded")
+        assert grok_should_retry(exc) is True
+
+    def test_aborted_is_retryable(self):
+        exc = _make_aio_rpc_error(grpc.StatusCode.ABORTED, "conflict")
+        assert grok_should_retry(exc) is True
+
+    def test_invalid_argument_not_retryable(self):
+        exc = _make_aio_rpc_error(grpc.StatusCode.INVALID_ARGUMENT, "bad request")
+        assert grok_should_retry(exc) is False
+
+    def test_permission_denied_not_retryable(self):
+        exc = _make_aio_rpc_error(grpc.StatusCode.PERMISSION_DENIED, "forbidden")
+        assert grok_should_retry(exc) is False
+
+    def test_unauthenticated_not_retryable(self):
+        exc = _make_aio_rpc_error(grpc.StatusCode.UNAUTHENTICATED, "bad key")
+        assert grok_should_retry(exc) is False
+
+    def test_not_found_not_retryable(self):
+        exc = _make_aio_rpc_error(grpc.StatusCode.NOT_FOUND, "no such resource")
+        assert grok_should_retry(exc) is False
+
+    def test_non_grpc_connection_error_retryable(self):
+        """非 gRPC 异常回退到默认 _should_retry 逻辑。"""
+        assert grok_should_retry(ConnectionError("reset")) is True
+
+    def test_non_grpc_timeout_error_retryable(self):
+        assert grok_should_retry(TimeoutError("deadline")) is True
+
+    def test_non_grpc_unrelated_error_not_retryable(self):
+        assert grok_should_retry(ValueError("bad input")) is False
+
+
+class TestGrokRetryIntegration:
+    """验证 grok_should_retry 与 with_retry_async 集成。"""
+
+    async def test_grpc_unavailable_triggers_retry(self):
+        """gRPC UNAVAILABLE 应触发重试并最终成功。"""
+        exc = _make_aio_rpc_error(grpc.StatusCode.UNAVAILABLE, "Socket closed")
+        mock_fn = AsyncMock(side_effect=[exc, "ok"])
+
+        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0), retry_if=grok_should_retry)
+        async def fn():
+            return await mock_fn()
+
+        with patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
+            result = await fn()
+
+        assert result == "ok"
+        assert mock_fn.call_count == 2
+
+    async def test_grpc_invalid_argument_no_retry(self):
+        """gRPC INVALID_ARGUMENT 不应重试，直接抛出。"""
+        exc = _make_aio_rpc_error(grpc.StatusCode.INVALID_ARGUMENT, "bad prompt")
+        mock_fn = AsyncMock(side_effect=exc)
+
+        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0), retry_if=grok_should_retry)
+        async def fn():
+            return await mock_fn()
+
+        with pytest.raises(grpc.aio.AioRpcError):
+            await fn()
+        assert mock_fn.call_count == 1


### PR DESCRIPTION
## Summary

- 宫格预览面板重构：移除首尾帧（FrameChain）显示，新增参考图（角色/线索）展示
- 多个预览面板合并为单面板 + 批次 pill 导航，减少垂直空间占用
- Segment header 与预览面板合并为统一容器，消除视觉割裂
- 后端 `execute_grid_task` 收集参考图元数据并持久化到 `GridGeneration.reference_images`
- `getGridIdsForGroup` 增加 episode 过滤 + scene_ids 去重，修复跨集/重复生成导致的批次数翻倍问题
- 宫格预览折叠头部精简，移除冗余状态和场景数显示
- 宫格生成完成后预览面板自动刷新（SSE 联动）
- 「一键生成全部宫格」与单组「生成宫格」按钮视觉区分
- 宫格模式下隐藏分镜卡片的「生成分镜」按钮

## Test plan

- [ ] 生成宫格后预览面板显示正确批次数（32 场景 grid_9 → 4 批）
- [ ] 参考图（角色/线索）在预览面板中正确显示
- [ ] 多集项目下批次不会跨集交叉匹配
- [ ] 重复生成后不会出现重复批次 pill
- [ ] `pnpm build` 通过