### PR TITLE
Fix create project modal rendering on ProjectsPage

### DIFF
--- a/frontend/src/components/pages/ProjectsPage.test.tsx
+++ b/frontend/src/components/pages/ProjectsPage.test.tsx
@@ -81,11 +81,12 @@ describe("ProjectsPage", () => {
 
     renderPage();
     await screen.findByText("暂无项目");
+    expect(screen.queryByTestId("create-project-modal")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "创建项目" }));
 
     await waitFor(() => {
-      expect(useProjectsStore.getState().showCreateModal).toBe(true);
+      expect(screen.getByTestId("create-project-modal")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/pages/ProjectsPage.tsx
+++ b/frontend/src/components/pages/ProjectsPage.tsx
@@ -9,6 +9,7 @@ import { useAppStore } from "@/stores/app-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
 import { ArchiveDiagnosticsDialog } from "@/components/shared/ArchiveDiagnosticsDialog";
 import { Popover } from "@/components/ui/Popover";
+import { CreateProjectModal } from "./CreateProjectModal";
 import { OpenClawModal } from "./OpenClawModal";
 import type { ProjectStatus, ProjectSummary, ImportConflictPolicy, ImportFailureDiagnostics } from "@/types";
 
@@ -373,6 +374,7 @@ export function ProjectsPage() {
         />
       )}
       {showOpenClaw && <OpenClawModal onClose={() => setShowOpenClaw(false)} />}
+      {showCreateModal && <CreateProjectModal />}
 
       {/* Delete project confirmation dialog */}
       {deletingProject && (


### PR DESCRIPTION
## Summary
- render `CreateProjectModal` from `ProjectsPage` when `showCreateModal` is enabled
- restore the create project flow so clicking the button opens the modal again
- strengthen the page test to assert the modal appears in the DOM instead of only checking store state

## Testing
- Not run (not requested)