### PR TITLE
docs: 明确 Windows 原生不支持，建议使用 WSL2 或 Docker Desktop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 
 ```bash
 # 前置要求：Python 3.12+, Node.js 20+, uv, pnpm, ffmpeg
+# 操作系统：Linux / MacOS / Windows WSL（Windows 原生不支持）
 
 # 安装依赖
 uv sync

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 ```bash
 # 前置要求：Python 3.12+, Node.js 20+, uv, pnpm, ffmpeg
-# 操作系统：Linux / MacOS / Windows WSL（Windows 原生不支持）
+# 操作系统：Linux / MacOS / Windows WSL2（Windows 原生不支持）
 
 # 安装依赖
 uv sync

--- a/README.en.md
+++ b/README.en.md
@@ -87,7 +87,7 @@ graph TD
 
 ## Quick Start
 
-> ⚠️ **OS**: Linux / MacOS / Windows WSL (the Claude Agent SDK and several dependencies are POSIX-only; native Windows is not supported — use Docker Desktop or WSL2)
+> ⚠️ **OS**: Linux / MacOS / Windows WSL2 (the Claude Agent SDK and several dependencies are POSIX-only; native Windows is not supported — use Docker Desktop or WSL2)
 
 ### Default Deployment (SQLite)
 

--- a/README.en.md
+++ b/README.en.md
@@ -87,6 +87,8 @@ graph TD
 
 ## Quick Start
 
+> ⚠️ **OS**: Linux / MacOS / Windows WSL (the Claude Agent SDK and several dependencies are POSIX-only; native Windows is not supported — use Docker Desktop or WSL2)
+
 ### Default Deployment (SQLite)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ graph TD
 
 ## 快速开始
 
-> ⚠️ **操作系统**：Linux / MacOS / Windows WSL（Claude Agent SDK 及部分依赖仅兼容 POSIX 环境，Windows 原生暂不支持，请使用 Docker Desktop 或 WSL2）
+> ⚠️ **操作系统**：Linux / MacOS / Windows WSL2（Claude Agent SDK 及部分依赖仅兼容 POSIX 环境，Windows 原生暂不支持，请使用 Docker Desktop 或 WSL2）
 
 ### 默认部署（SQLite）
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ graph TD
 
 ## 快速开始
 
+> ⚠️ **操作系统**：Linux / MacOS / Windows WSL（Claude Agent SDK 及部分依赖仅兼容 POSIX 环境，Windows 原生暂不支持，请使用 Docker Desktop 或 WSL2）
+
 ### 默认部署（SQLite）
 
 ```bash


### PR DESCRIPTION
## Summary

- 在 README.md / README.en.md 快速开始顶部增加一行系统要求提示
- 在 CONTRIBUTING.md 本地开发前置要求中补充操作系统说明
- 与 `docs/getting-started.md` 已有的 "Linux / MacOS / Windows WSL" 表述保持一致

## Context

#250 报告 Windows 下 `fcntl` 导入失败。由于 Claude Agent SDK 及部分依赖均为 POSIX-only，Windows 原生运行本就不在支持范围内。本 PR 不新增代码适配，仅在文档中显式声明系统要求，关闭该 issue。

Closes #250

## Test plan

- [x] `README.md` 渲染后 blockquote 正常显示
- [x] `README.en.md` 同步更新
- [x] `CONTRIBUTING.md` 注释行不影响 bash 代码块示意