### PR TITLE
Offload blocking I/O operations to thread pool

### DIFF
--- a/lib/config/migration.py
+++ b/lib/config/migration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -65,7 +66,8 @@ async def migrate_json_to_db(session: AsyncSession, json_path: Path) -> None:
         return
 
     logger.info("Migrating %s to database...", json_path)
-    data = json.loads(json_path.read_text())
+    text = await asyncio.to_thread(json_path.read_text)
+    data = json.loads(text)
     overrides: dict = data.get("overrides", {})
 
     provider_repo = ProviderConfigRepository(session)

--- a/lib/image_backends/ark.py
+++ b/lib/image_backends/ark.py
@@ -75,10 +75,14 @@ class ArkImageBackend:
             **kwargs,
         )
 
-        # 解码并保存
+        # 解码并保存（磁盘写入 offload 到线程）
         image_data = base64.b64decode(response.data[0].b64_json)
-        request.output_path.parent.mkdir(parents=True, exist_ok=True)
-        request.output_path.write_bytes(image_data)
+
+        def _write():
+            request.output_path.parent.mkdir(parents=True, exist_ok=True)
+            request.output_path.write_bytes(image_data)
+
+        await asyncio.to_thread(_write)
 
         return ImageGenerationResult(
             image_path=request.output_path,

--- a/lib/image_backends/grok.py
+++ b/lib/image_backends/grok.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -128,8 +129,8 @@ def _map_image_size_to_resolution(image_size: str) -> str:
 
 async def _download_image(url: str, output_path: Path, *, timeout: int = 60) -> None:
     """从 URL 下载图片到本地文件。"""
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    await asyncio.to_thread(output_path.parent.mkdir, parents=True, exist_ok=True)
     async with httpx.AsyncClient() as http_client:
         resp = await http_client.get(url, timeout=timeout)
         resp.raise_for_status()
-        output_path.write_bytes(resp.content)
+        await asyncio.to_thread(output_path.write_bytes, resp.content)

--- a/lib/image_backends/openai.py
+++ b/lib/image_backends/openai.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+from contextlib import ExitStack
 from pathlib import Path
 
 from lib.image_backends.base import (
@@ -83,17 +84,24 @@ class OpenAIImageBackend:
             logger.warning("参考图数量 %d 超过上限 %d，截断", len(refs), _MAX_REFERENCE_IMAGES)
             refs = refs[:_MAX_REFERENCE_IMAGES]
 
-        def _open_refs() -> list:
-            files = []
-            for ref in refs:
-                ref_path = Path(ref.path)
-                try:
-                    files.append(open(ref_path, "rb"))  # noqa: SIM115
-                except FileNotFoundError:
-                    logger.warning("参考图不存在，跳过: %s", ref_path)
-            return files
+        def _open_refs() -> tuple[ExitStack, list]:
+            """在 ExitStack 内打开所有参考图，保证部分 open 失败时已打开句柄被释放。"""
+            stack = ExitStack()
+            try:
+                files = []
+                for ref in refs:
+                    ref_path = Path(ref.path)
+                    try:
+                        files.append(stack.enter_context(open(ref_path, "rb")))
+                    except FileNotFoundError:
+                        logger.warning("参考图不存在，跳过: %s", ref_path)
+                # 把已打开的句柄所有权移交给调用者
+                return stack.pop_all(), files
+            except BaseException:
+                stack.close()
+                raise
 
-        image_files = await asyncio.to_thread(_open_refs)
+        stack, image_files = await asyncio.to_thread(_open_refs)
         try:
             if not image_files:
                 logger.warning("所有参考图均无效，回退到 T2I")
@@ -105,8 +113,7 @@ class OpenAIImageBackend:
                 response_format="b64_json",
             )
         finally:
-            for f in image_files:
-                f.close()
+            stack.close()
         return await asyncio.to_thread(self._save_and_return, response, request)
 
     def _save_and_return(self, response, request: ImageGenerationRequest) -> ImageGenerationResult:

--- a/lib/image_backends/openai.py
+++ b/lib/image_backends/openai.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import logging
 from pathlib import Path
@@ -74,21 +75,26 @@ class OpenAIImageBackend:
             response_format="b64_json",
             n=1,
         )
-        return self._save_and_return(response, request)
+        return await asyncio.to_thread(self._save_and_return, response, request)
 
     async def _generate_edit(self, request: ImageGenerationRequest) -> ImageGenerationResult:
         refs = request.reference_images
         if len(refs) > _MAX_REFERENCE_IMAGES:
             logger.warning("参考图数量 %d 超过上限 %d，截断", len(refs), _MAX_REFERENCE_IMAGES)
             refs = refs[:_MAX_REFERENCE_IMAGES]
-        image_files = []
-        try:
+
+        def _open_refs() -> list:
+            files = []
             for ref in refs:
                 ref_path = Path(ref.path)
                 try:
-                    image_files.append(open(ref_path, "rb"))  # noqa: SIM115
+                    files.append(open(ref_path, "rb"))  # noqa: SIM115
                 except FileNotFoundError:
                     logger.warning("参考图不存在，跳过: %s", ref_path)
+            return files
+
+        image_files = await asyncio.to_thread(_open_refs)
+        try:
             if not image_files:
                 logger.warning("所有参考图均无效，回退到 T2I")
                 return await self._generate_create(request)
@@ -101,7 +107,7 @@ class OpenAIImageBackend:
         finally:
             for f in image_files:
                 f.close()
-        return self._save_and_return(response, request)
+        return await asyncio.to_thread(self._save_and_return, response, request)
 
     def _save_and_return(self, response, request: ImageGenerationRequest) -> ImageGenerationResult:
         image_bytes = base64.b64decode(response.data[0].b64_json)

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -89,9 +89,18 @@ async def download_video(url: str, output_path: Path, *, timeout: int = 120) -> 
                 # 流式模式下需先读取响应体，否则 HTTPStatusError.response.text 不可用
                 await resp.aread()
             resp.raise_for_status()
-            with open(output_path, "wb") as f:
-                async for chunk in resp.aiter_bytes(chunk_size=65536):
-                    await asyncio.to_thread(f.write, chunk)
+            # 异步流式读取所有 chunk，然后一次 to_thread 完成整段写入，
+            # 避免对每个 64KB 分片调度一次线程池任务（评审反馈 #279）。
+            chunks: list[bytes] = []
+            async for chunk in resp.aiter_bytes(chunk_size=65536):
+                chunks.append(chunk)
+
+            def _write_all() -> None:
+                with open(output_path, "wb") as f:
+                    for chunk in chunks:
+                        f.write(chunk)
+
+            await asyncio.to_thread(_write_all)
 
 
 @dataclass

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -82,7 +82,7 @@ async def poll_with_retry[T](
 @with_retry_async()
 async def download_video(url: str, output_path: Path, *, timeout: int = 120) -> None:
     """从 URL 流式下载视频到本地文件（含瞬态错误重试）。"""
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    await asyncio.to_thread(output_path.parent.mkdir, parents=True, exist_ok=True)
     async with httpx.AsyncClient() as http_client:
         async with http_client.stream("GET", url, timeout=timeout) as resp:
             if resp.status_code >= 400:
@@ -91,7 +91,7 @@ async def download_video(url: str, output_path: Path, *, timeout: int = 120) -> 
             resp.raise_for_status()
             with open(output_path, "wb") as f:
                 async for chunk in resp.aiter_bytes(chunk_size=65536):
-                    f.write(chunk)
+                    await asyncio.to_thread(f.write, chunk)
 
 
 @dataclass

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -146,22 +146,27 @@ class GeminiVideoBackend:
 
         # end_image → last_frame（帧插值）
         if request.end_image is not None:
-            config_params["last_frame"] = self._prepare_image_param(request.end_image)
+            config_params["last_frame"] = await asyncio.to_thread(self._prepare_image_param, request.end_image)
 
         # reference_images → reference_images（参考图列表，type=ASSET）
         if request.reference_images:
+            prepared_refs = [
+                await asyncio.to_thread(self._prepare_image_param, img) for img in request.reference_images
+            ]
             config_params["reference_images"] = [
                 self._types.VideoGenerationReferenceImage(
-                    image=self._prepare_image_param(img),
+                    image=prepared,
                     reference_type=self._types.VideoGenerationReferenceType.ASSET,
                 )
-                for img in request.reference_images
+                for prepared in prepared_refs
             ]
 
         config = self._types.GenerateVideosConfig(**config_params)
 
         # 4. 准备 source（prompt + 可选起始帧）
-        image_param = self._prepare_image_param(request.start_image) if request.start_image else None
+        image_param = (
+            await asyncio.to_thread(self._prepare_image_param, request.start_image) if request.start_image else None
+        )
         source = self._types.GenerateVideosSource(prompt=request.prompt, image=image_param)
 
         # 5. 调用 API
@@ -210,7 +215,7 @@ class GeminiVideoBackend:
         video_ref = generated_video.video
         video_uri = video_ref.uri if video_ref else None
 
-        request.output_path.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(request.output_path.parent.mkdir, parents=True, exist_ok=True)
         await self._download_video_with_retry(video_ref, request.output_path)
 
         return VideoGenerationResult(

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -150,9 +150,9 @@ class GeminiVideoBackend:
 
         # reference_images → reference_images（参考图列表，type=ASSET）
         if request.reference_images:
-            prepared_refs = [
-                await asyncio.to_thread(self._prepare_image_param, img) for img in request.reference_images
-            ]
+            prepared_refs = await asyncio.gather(
+                *[asyncio.to_thread(self._prepare_image_param, img) for img in request.reference_images]
+            )
             config_params["reference_images"] = [
                 self._types.VideoGenerationReferenceImage(
                     image=prepared,

--- a/lib/video_backends/grok.py
+++ b/lib/video_backends/grok.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import logging
 from datetime import timedelta
@@ -88,24 +89,21 @@ class GrokVideoBackend:
             "interval": timedelta(seconds=5),
         }
 
+        def _encode_to_data_uri(path: Path) -> str:
+            suffix = path.suffix.lower()
+            mime_type = IMAGE_MIME_TYPES.get(suffix, "image/png")
+            b64 = base64.b64encode(path.read_bytes()).decode("ascii")
+            return f"data:{mime_type};base64,{b64}"
+
         if request.start_image and Path(request.start_image).exists():
             image_path = Path(request.start_image)
-            suffix = image_path.suffix.lower()
-            mime_type = IMAGE_MIME_TYPES.get(suffix, "image/png")
-            image_data = image_path.read_bytes()
-            b64 = base64.b64encode(image_data).decode("ascii")
-            generate_kwargs["image_url"] = f"data:{mime_type};base64,{b64}"
+            generate_kwargs["image_url"] = await asyncio.to_thread(_encode_to_data_uri, image_path)
 
         if request.reference_images:
-            ref_urls = []
-            for ref_path in request.reference_images:
-                p = Path(ref_path) if not isinstance(ref_path, Path) else ref_path
-                if p.exists():
-                    suffix = p.suffix.lower()
-                    mime_type = IMAGE_MIME_TYPES.get(suffix, "image/png")
-                    b64 = base64.b64encode(p.read_bytes()).decode("ascii")
-                    ref_urls.append(f"data:{mime_type};base64,{b64}")
-            if ref_urls:
+            ref_paths = [Path(p) if not isinstance(p, Path) else p for p in request.reference_images]
+            existing_paths = [p for p in ref_paths if p.exists()]
+            if existing_paths:
+                ref_urls = [await asyncio.to_thread(_encode_to_data_uri, p) for p in existing_paths]
                 generate_kwargs["reference_image_urls"] = ref_urls
 
         logger.info("Grok 视频生成开始: model=%s, duration=%ds", self._model, request.duration_seconds)

--- a/lib/video_backends/grok.py
+++ b/lib/video_backends/grok.py
@@ -103,8 +103,8 @@ class GrokVideoBackend:
             ref_paths = [Path(p) if not isinstance(p, Path) else p for p in request.reference_images]
             existing_paths = [p for p in ref_paths if p.exists()]
             if existing_paths:
-                ref_urls = [await asyncio.to_thread(_encode_to_data_uri, p) for p in existing_paths]
-                generate_kwargs["reference_image_urls"] = ref_urls
+                ref_urls = await asyncio.gather(*[asyncio.to_thread(_encode_to_data_uri, p) for p in existing_paths])
+                generate_kwargs["reference_image_urls"] = list(ref_urls)
 
         logger.info("Grok 视频生成开始: model=%s, duration=%ds", self._model, request.duration_seconds)
         return await self._client.video.generate(**generate_kwargs)

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -91,8 +92,12 @@ class OpenAIVideoBackend:
             raise RuntimeError(f"Sora 视频生成失败: {video.error}")
 
         content = await self._download_content_with_retry(video.id)
-        request.output_path.parent.mkdir(parents=True, exist_ok=True)
-        request.output_path.write_bytes(content.content)
+
+        def _write():
+            request.output_path.parent.mkdir(parents=True, exist_ok=True)
+            request.output_path.write_bytes(content.content)
+
+        await asyncio.to_thread(_write)
 
         logger.info("OpenAI 视频下载完成: %s", request.output_path)
 

--- a/server/app.py
+++ b/server/app.py
@@ -6,6 +6,7 @@
     uv run uvicorn server.app:app --reload --port 1241
 """
 
+import asyncio
 import logging
 import time
 from contextlib import asynccontextmanager
@@ -203,10 +204,15 @@ async def serve_skill_md(request: Request) -> Response:
     from starlette.responses import PlainTextResponse
 
     template_path = PROJECT_ROOT / "public" / "skill.md.template"
-    if not template_path.exists():
-        return PlainTextResponse("skill.md 模板不存在", status_code=404)
 
-    template = template_path.read_text(encoding="utf-8")
+    def _read() -> tuple[bool, str]:
+        if not template_path.exists():
+            return False, ""
+        return True, template_path.read_text(encoding="utf-8")
+
+    exists, template = await asyncio.to_thread(_read)
+    if not exists:
+        return PlainTextResponse("skill.md 模板不存在", status_code=404)
 
     # 从请求推断 base URL；仅信任 x-forwarded-proto（反向代理标准头），
     # host 使用连接实际目标地址，不接受可被用户伪造的 x-forwarded-host。

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -107,12 +107,19 @@ async def import_project_archive(
         fd, upload_path = tempfile.mkstemp(prefix="arcreel-upload-", suffix=".zip")
         os.close(fd)
 
-        with open(upload_path, "wb") as target:
-            while True:
-                chunk = await file.read(1024 * 1024)
-                if not chunk:
-                    break
-                target.write(chunk)
+        # 使用底层 SpooledTemporaryFile 的同步句柄，整循环 offload 到线程，
+        # 避免 async 读取 + 同步写入的混合模式阻塞事件循环 (#230)
+        raw_file = file.file
+
+        def _write_upload():
+            with open(upload_path, "wb") as target:
+                while True:
+                    chunk = raw_file.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    target.write(chunk)
+
+        await asyncio.to_thread(_write_upload)
 
         def _sync():
             return get_archive_service().import_project_archive(


### PR DESCRIPTION
Closes #239, #230

## Summary
This PR systematically offloads blocking I/O operations (file reads/writes, directory creation) to the thread pool using `asyncio.to_thread()` to prevent blocking the event loop and improve async performance.

## Key Changes

- **Image/Video backends**: Wrapped file I/O operations in `asyncio.to_thread()` calls:
  - `grok.py` (image & video): Data URI encoding, image downloads, and file writes
  - `openai.py` (image & video): Image file operations and video file writes
  - `ark.py`: Image file writes
  - `gemini.py`: Image parameter preparation and directory creation

- **Server routes**:
  - `projects.py`: Offloaded file upload loop to thread pool to avoid mixing async reads with sync writes (#230)
  - `app.py`: Moved template file existence check and read to thread pool

- **Configuration & utilities**:
  - `migration.py`: Offloaded JSON file read to thread pool
  - `base.py`: Offloaded directory creation and file writes in video download function

## Implementation Details

- Used `asyncio.to_thread()` for CPU-bound operations like base64 encoding and file I/O
- Extracted blocking operations into helper functions where needed (e.g., `_encode_to_data_uri`, `_write_upload`, `_open_refs`)
- Maintained the same functional behavior while improving event loop responsiveness
- Added comments explaining the rationale for thread offloading in critical paths

## Review Follow-ups

- OpenAI image backend `_generate_edit`: use `contextlib.ExitStack` to guarantee reference-image file handles are released even if `open()` raises mid-loop
- Gemini / Grok video backends: parallelize reference-image preparation via `asyncio.gather`
- `download_video`: accumulate async stream chunks then single `to_thread` write pass (avoids per-64KB executor scheduling)

https://claude.ai/code/session_01LHSo86J7Z1Zx6yRQntB7Am