### PR TITLE
refactor(frontend): 合并 AssetSidebar 缩略图 + 提取 StudioCanvasRouter 段查找 (#215, #213)

### DIFF
--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -32,14 +32,10 @@ function resolveSegmentPrompt(
   if (!resolvedFile) return null;
   const script = scripts[resolvedFile];
   if (!script) return null;
-  const segments =
-    ("segments" in script ? script.segments : undefined) ??
-    ("scenes" in script ? script.scenes : undefined) ??
-    [];
-  const seg = segments.find((s) => {
-    const id = "segment_id" in s ? s.segment_id : (s as { scene_id?: string }).scene_id ?? "";
-    return id === segmentId;
-  });
+  const seg =
+    script.content_mode === "narration"
+      ? script.segments.find((s) => s.segment_id === segmentId)
+      : script.scenes.find((s) => s.scene_id === segmentId);
   return {
     resolvedFile,
     prompt: seg?.[field] ?? "",

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -14,6 +14,38 @@ import { API } from "@/api";
 import { buildEntityRevisionKey } from "@/utils/project-changes";
 import { getProviderModels, getCustomProviderModels, lookupSupportedDurations } from "@/utils/provider-models";
 import type { Clue, CustomProviderInfo, ProviderInfo } from "@/types";
+import type { EpisodeScript } from "@/types/script";
+
+// ---------------------------------------------------------------------------
+// resolveSegmentPrompt — shared segment lookup for generate storyboard/video
+// ---------------------------------------------------------------------------
+
+type PromptField = "image_prompt" | "video_prompt";
+
+function resolveSegmentPrompt(
+  scripts: Record<string, EpisodeScript>,
+  segmentId: string,
+  field: PromptField,
+  scriptFile?: string,
+): { resolvedFile: string; prompt: unknown; duration: number } | null {
+  const resolvedFile = scriptFile ?? Object.keys(scripts)[0];
+  if (!resolvedFile) return null;
+  const script = scripts[resolvedFile];
+  if (!script) return null;
+  const segments =
+    ("segments" in script ? script.segments : undefined) ??
+    ("scenes" in script ? script.scenes : undefined) ??
+    [];
+  const seg = segments.find((s) => {
+    const id = "segment_id" in s ? s.segment_id : (s as { scene_id?: string }).scene_id ?? "";
+    return id === segmentId;
+  });
+  return {
+    resolvedFile,
+    prompt: seg?.[field] ?? "",
+    duration: seg?.duration_seconds ?? 4,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // StudioCanvasRouter — reads Zustand store data and renders the correct
@@ -120,19 +152,15 @@ export function StudioCanvasRouter() {
 
   const handleGenerateStoryboard = useCallback(async (segmentId: string, scriptFile?: string) => {
     if (!currentProjectName || !currentScripts) return;
-    const resolvedFile = scriptFile ?? Object.keys(currentScripts)[0];
-    if (!resolvedFile) return;
-    const script = currentScripts[resolvedFile];
-    if (!script) return;
-    const segments = ("segments" in script ? script.segments : undefined) ??
-                     ("scenes" in script ? script.scenes : undefined) ?? [];
-    const seg = segments.find((s) => {
-      const id = "segment_id" in s ? s.segment_id : (s as { scene_id?: string }).scene_id ?? "";
-      return id === segmentId;
-    });
-    const prompt = seg?.image_prompt ?? "";
+    const resolved = resolveSegmentPrompt(currentScripts, segmentId, "image_prompt", scriptFile);
+    if (!resolved) return;
     try {
-      await API.generateStoryboard(currentProjectName, segmentId, prompt as string | Record<string, unknown>, resolvedFile);
+      await API.generateStoryboard(
+        currentProjectName,
+        segmentId,
+        resolved.prompt as string | Record<string, unknown>,
+        resolved.resolvedFile,
+      );
       useAppStore.getState().pushToast(tRef.current("storyboard_task_submitted_toast", { id: segmentId }), "success");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("generate_storyboard_failed", { message: (err as Error).message }), "error");
@@ -141,20 +169,16 @@ export function StudioCanvasRouter() {
 
   const handleGenerateVideo = useCallback(async (segmentId: string, scriptFile?: string) => {
     if (!currentProjectName || !currentScripts) return;
-    const resolvedFile = scriptFile ?? Object.keys(currentScripts)[0];
-    if (!resolvedFile) return;
-    const script = currentScripts[resolvedFile];
-    if (!script) return;
-    const segments = ("segments" in script ? script.segments : undefined) ??
-                     ("scenes" in script ? script.scenes : undefined) ?? [];
-    const seg = segments.find((s) => {
-      const id = "segment_id" in s ? s.segment_id : (s as { scene_id?: string }).scene_id ?? "";
-      return id === segmentId;
-    });
-    const prompt = seg?.video_prompt ?? "";
-    const duration = seg?.duration_seconds ?? 4;
+    const resolved = resolveSegmentPrompt(currentScripts, segmentId, "video_prompt", scriptFile);
+    if (!resolved) return;
     try {
-      await API.generateVideo(currentProjectName, segmentId, prompt as string | Record<string, unknown>, resolvedFile, duration);
+      await API.generateVideo(
+        currentProjectName,
+        segmentId,
+        resolved.prompt as string | Record<string, unknown>,
+        resolved.resolvedFile,
+        resolved.duration,
+      );
       useAppStore.getState().pushToast(tRef.current("video_task_submitted_toast", { id: segmentId }), "success");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("generate_video_failed", { message: (err as Error).message }), "error");

--- a/frontend/src/components/layout/AssetSidebar.tsx
+++ b/frontend/src/components/layout/AssetSidebar.tsx
@@ -76,17 +76,21 @@ function CollapsibleSection({
 }
 
 // ---------------------------------------------------------------------------
-// CharacterThumbnail — round avatar with fallback
+// AssetThumbnail — shared thumbnail for characters (circle) and clues (square)
 // ---------------------------------------------------------------------------
 
-function CharacterThumbnail({
+function AssetThumbnail({
   name,
   sheetPath,
   projectName,
+  shape,
+  FallbackIcon,
 }: {
   name: string;
   sheetPath: string | undefined;
   projectName: string;
+  shape: "circle" | "square";
+  FallbackIcon: React.ComponentType<{ className?: string }>;
 }) {
   const sheetFp = useProjectsStore((s) =>
     sheetPath ? s.getAssetFingerprint(sheetPath) : null,
@@ -97,10 +101,12 @@ function CharacterThumbnail({
     setImgError(false);
   }, [sheetFp, sheetPath]);
 
+  const roundedClass = shape === "circle" ? "rounded-full" : "rounded";
+
   if (!sheetPath || imgError) {
     return (
-      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-700 text-gray-400">
-        <User className="h-3.5 w-3.5" />
+      <span className={`flex h-6 w-6 shrink-0 items-center justify-center ${roundedClass} bg-gray-700 text-gray-400`}>
+        <FallbackIcon className="h-3.5 w-3.5" />
       </span>
     );
   }
@@ -109,47 +115,7 @@ function CharacterThumbnail({
     <img
       src={API.getFileUrl(projectName, sheetPath, sheetFp)}
       alt={name}
-      className="h-6 w-6 shrink-0 rounded-full object-cover"
-      onError={() => setImgError(true)}
-    />
-  );
-}
-
-// ---------------------------------------------------------------------------
-// ClueThumbnail — square icon with fallback
-// ---------------------------------------------------------------------------
-
-function ClueThumbnail({
-  name,
-  sheetPath,
-  projectName,
-}: {
-  name: string;
-  sheetPath: string | undefined;
-  projectName: string;
-}) {
-  const sheetFp = useProjectsStore((s) =>
-    sheetPath ? s.getAssetFingerprint(sheetPath) : null,
-  );
-  const [imgError, setImgError] = useState(false);
-
-  useEffect(() => {
-    setImgError(false);
-  }, [sheetFp, sheetPath]);
-
-  if (!sheetPath || imgError) {
-    return (
-      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded bg-gray-700 text-gray-400">
-        <Puzzle className="h-3.5 w-3.5" />
-      </span>
-    );
-  }
-
-  return (
-    <img
-      src={API.getFileUrl(projectName, sheetPath, sheetFp)}
-      alt={name}
-      className="h-6 w-6 shrink-0 rounded object-cover"
+      className={`h-6 w-6 shrink-0 ${roundedClass} object-cover`}
       onError={() => setImgError(true)}
     />
   );
@@ -365,10 +331,12 @@ export function AssetSidebar({ className }: AssetSidebarProps) {
                         : "text-gray-300 hover:bg-gray-800/50 hover:text-white"
                     }`}
                   >
-                    <CharacterThumbnail
+                    <AssetThumbnail
                       name={name}
                       sheetPath={char.character_sheet}
                       projectName={projectName}
+                      shape="circle"
+                      FallbackIcon={User}
                     />
                     <span className="truncate">{name}</span>
                   </button>
@@ -399,10 +367,12 @@ export function AssetSidebar({ className }: AssetSidebarProps) {
                         : "text-gray-300 hover:bg-gray-800/50 hover:text-white"
                     }`}
                   >
-                    <ClueThumbnail
+                    <AssetThumbnail
                       name={name}
                       sheetPath={clue.clue_sheet}
                       projectName={projectName}
+                      shape="square"
+                      FallbackIcon={Puzzle}
                     />
                     <span className="truncate">{name}</span>
                   </button>


### PR DESCRIPTION
## Summary

- **#215** — 合并 `AssetSidebar.tsx` 中 `CharacterThumbnail` / `ClueThumbnail` 为单个 `AssetThumbnail` 组件，通过 `shape: "circle" | "square"` 和 `FallbackIcon` props 区分形态。
- **#213** — 在 `StudioCanvasRouter.tsx` 中提取 module-level 辅助函数 `resolveSegmentPrompt(scripts, segmentId, field, scriptFile)`，由 `handleGenerateStoryboard` 和 `handleGenerateVideo` 共享 script/segments/scenes 查找逻辑。

两处变更均为等价重构，不改变运行时行为、UI 样式或 API 调用 payload。

Closes #215
Closes #213

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm check`（vitest run）29 files / 126 tests 全部通过
- [ ] 手工冒烟：角色仍为圆形头像、线索仍为方形图标；fallback icon 分别为 `User` / `Puzzle`
- [ ] 手工冒烟：Timeline 中"生成分镜"、"生成视频"在 narration 和 drama 两种模式下 toast 与 API payload 正常

https://claude.ai/code/session_01RQXQ9vCseiJz74W64GgaQq