### PR TITLE
fix(text_backends): 透传 max_output_tokens 避免剧本 JSON 被截断

### DIFF
--- a/agent_runtime_profile/.claude/skills/generate-script/scripts/normalize_drama_script.py
+++ b/agent_runtime_profile/.claude/skills/generate-script/scripts/normalize_drama_script.py
@@ -168,7 +168,7 @@ def main():
     async def _run():
         backend = await create_text_backend_for_task(TextTaskType.SCRIPT)
         print(f"正在使用 {backend.model} 生成规范化剧本...")
-        result = await backend.generate(TextGenerationRequest(prompt=prompt))
+        result = await backend.generate(TextGenerationRequest(prompt=prompt, max_output_tokens=16000))
         return result.text
 
     response = asyncio.run(_run())

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -73,3 +73,20 @@
 ## ~~10. test_text_backends 测试文件 asyncio.to_thread patch 重复~~ ✅ 已修复
 
 **修复：** 在 `tests/test_text_backends/conftest.py` 中提取 `sync_to_thread` fixture，各测试文件共享。
+
+---
+
+## 11. 剧本生成任务对模型输出 token 上限有强约束
+
+**位置：** `lib/script_generator.py`、`lib/text_backends/`
+
+**现状：** 大型 JSON 剧本（22+ 场景）约需 14K–16K 输出 token。`TextGenerationRequest.max_output_tokens` 已支持并在 `SCRIPT_MAX_OUTPUT_TOKENS = 32000` 处显式传入，但各模型的**硬上限**仍会截断：
+
+- `doubao-seed-1-8-251228`：输出硬上限 ~8192，不满足剧本生成需求
+- `gemini-3-flash-preview` / `gemini-2.5-pro`：默认上限足够（≥32K）
+- `gpt-5.4` 系列：默认上限足够
+- `doubao-seed-2.x` 系列：输出上限较高（依模型）
+
+**建议：** 在 `/settings` 为 SCRIPT 任务配置**输出上限 ≥16K 的模型**。若必须使用 doubao-seed-1-8，则需将场景数控制在 15 个以内以规避截断。
+
+**后续增强（未做）：** 可在 `lib/config/registry.py` 的 `PROVIDER_REGISTRY` 为每个模型声明 `max_output_tokens` 能力字段，运行时按 `min(request, model_limit)` clamp 并 `logger.warning`，在 UI 选择模型时给予提示。

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -26,6 +26,10 @@ from lib.text_generator import TextGenerator
 
 logger = logging.getLogger(__name__)
 
+# 大型 JSON 剧本输出上限：22+ 场景典型约 14K token，留 2× 安全边际。
+# 注意：受各模型硬上限约束（如 doubao-seed-1-8 ~8192），需选择支持 ≥16K 输出的模型。
+SCRIPT_MAX_OUTPUT_TOKENS = 32000
+
 
 class ScriptGenerator:
     """
@@ -113,7 +117,11 @@ class ScriptGenerator:
         logger.info("正在生成第 %d 集剧本...", episode)
         project_name = self.project_path.name
         result = await self.generator.generate(
-            TextGenerationRequest(prompt=prompt, response_schema=schema),
+            TextGenerationRequest(
+                prompt=prompt,
+                response_schema=schema,
+                max_output_tokens=SCRIPT_MAX_OUTPUT_TOKENS,
+            ),
             project_name=project_name,
         )
         response_text = result.text

--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -136,9 +136,18 @@ class ArkTextBackend:
         return messages
 
     def _parse_chat_response(self, response) -> TextGenerationResult:
-        text = response.choices[0].message.content
+        from lib.text_backends.base import warn_if_truncated
+
+        choice = response.choices[0]
+        text = choice.message.content
         input_tokens = getattr(getattr(response, "usage", None), "prompt_tokens", None)
         output_tokens = getattr(getattr(response, "usage", None), "completion_tokens", None)
+        warn_if_truncated(
+            getattr(choice, "finish_reason", None),
+            provider=PROVIDER_ARK,
+            model=self._model,
+            output_tokens=output_tokens,
+        )
         return TextGenerationResult(
             text=text.strip() if isinstance(text, str) else str(text),
             provider=PROVIDER_ARK,

--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -65,10 +65,12 @@ class ArkTextBackend:
 
     async def _generate_plain(self, request: TextGenerationRequest) -> TextGenerationResult:
         messages = self._build_messages(request)
+        kwargs: dict = {"model": self._model, "messages": messages}
+        if request.max_output_tokens is not None:
+            kwargs["max_tokens"] = request.max_output_tokens
         response = await asyncio.to_thread(
             self._client.chat.completions.create,
-            model=self._model,
-            messages=messages,
+            **kwargs,
         )
         return self._parse_chat_response(response)
 
@@ -79,19 +81,18 @@ class ArkTextBackend:
             from lib.text_backends.base import resolve_schema
 
             schema = resolve_schema(request.response_schema)
+            kwargs: dict = {
+                "model": self._model,
+                "messages": messages,
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {"name": "response", "schema": schema},
+                },
+            }
+            if request.max_output_tokens is not None:
+                kwargs["max_tokens"] = request.max_output_tokens
             try:
-                response = await asyncio.to_thread(
-                    self._client.chat.completions.create,
-                    model=self._model,
-                    messages=messages,
-                    response_format={
-                        "type": "json_schema",
-                        "json_schema": {
-                            "name": "response",
-                            "schema": schema,
-                        },
-                    },
-                )
+                response = await asyncio.to_thread(self._client.chat.completions.create, **kwargs)
                 return self._parse_chat_response(response)
             except Exception as exc:
                 logger.warning("原生 response_format 失败 (%s)，降级到 Instructor/json_object 路径", exc)
@@ -109,6 +110,7 @@ class ArkTextBackend:
             messages=messages,
             response_schema=request.response_schema,
             provider=PROVIDER_ARK,
+            max_tokens=request.max_output_tokens,
         )
 
     def _build_messages(self, request: TextGenerationRequest) -> list[dict]:

--- a/lib/text_backends/base.py
+++ b/lib/text_backends/base.py
@@ -2,10 +2,40 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from typing import Protocol
+
+_logger = logging.getLogger(__name__)
+
+
+def warn_if_truncated(
+    finish_reason: str | None,
+    *,
+    provider: str,
+    model: str,
+    output_tokens: int | None = None,
+    truncation_values: tuple[str, ...] = ("length", "MAX_TOKENS", "max_tokens"),
+) -> bool:
+    """检测模型响应是否因 token 上限被截断，若是则 logger.warning。
+
+    返回 True 表示被截断（供调用方用于进一步处理）。
+    """
+    if finish_reason is None:
+        return False
+    if finish_reason in truncation_values:
+        _logger.warning(
+            "%s/%s 输出被截断（finish_reason=%s, output_tokens=%s）：已达模型输出上限。"
+            "考虑切换到更大输出上限的模型，或减少请求规模。",
+            provider,
+            model,
+            finish_reason,
+            output_tokens,
+        )
+        return True
+    return False
 
 
 class TextCapability(StrEnum):

--- a/lib/text_backends/base.py
+++ b/lib/text_backends/base.py
@@ -40,6 +40,7 @@ class TextGenerationRequest:
     response_schema: dict | type | None = None
     images: list[ImageInput] | None = None
     system_prompt: str | None = None
+    max_output_tokens: int | None = None
 
 
 @dataclass

--- a/lib/text_backends/gemini.py
+++ b/lib/text_backends/gemini.py
@@ -19,6 +19,7 @@ from .base import (
     TextCapability,
     TextGenerationRequest,
     TextGenerationResult,
+    warn_if_truncated,
 )
 
 logger = logging.getLogger(__name__)
@@ -157,6 +158,17 @@ class GeminiTextBackend:
         if response.usage_metadata is not None:
             input_tokens = getattr(response.usage_metadata, "prompt_token_count", None)
             output_tokens = getattr(response.usage_metadata, "candidates_token_count", None)
+
+        candidates = getattr(response, "candidates", None) or []
+        if candidates:
+            finish_reason = getattr(candidates[0], "finish_reason", None)
+            # Gemini finish_reason 可能是枚举对象，转 str 后再比对
+            warn_if_truncated(
+                str(finish_reason).rsplit(".", 1)[-1] if finish_reason is not None else None,
+                provider=PROVIDER_GEMINI,
+                model=self._model,
+                output_tokens=output_tokens,
+            )
 
         return TextGenerationResult(
             text=text,

--- a/lib/text_backends/gemini.py
+++ b/lib/text_backends/gemini.py
@@ -102,6 +102,7 @@ class GeminiTextBackend:
         self,
         response_schema: dict | type | None,
         system_prompt: str | None,
+        max_output_tokens: int | None = None,
     ) -> dict:
         """构建 generate_content 的 config 字典。"""
         config: dict = {}
@@ -113,6 +114,8 @@ class GeminiTextBackend:
                 config["response_json_schema"] = response_schema
         if system_prompt:
             config["system_instruction"] = system_prompt
+        if max_output_tokens is not None:
+            config["max_output_tokens"] = max_output_tokens
         return config
 
     def _build_contents(self, request: TextGenerationRequest) -> list:
@@ -134,7 +137,11 @@ class GeminiTextBackend:
     @with_retry_async()
     async def generate(self, request: TextGenerationRequest) -> TextGenerationResult:
         """异步生成文本，支持结构化输出和 vision。"""
-        config = self._build_config(request.response_schema, request.system_prompt)
+        config = self._build_config(
+            request.response_schema,
+            request.system_prompt,
+            request.max_output_tokens,
+        )
         contents = self._build_contents(request)
 
         response = await self._client.aio.models.generate_content(

--- a/lib/text_backends/grok.py
+++ b/lib/text_backends/grok.py
@@ -13,6 +13,7 @@ from lib.text_backends.base import (
     TextCapability,
     TextGenerationRequest,
     TextGenerationResult,
+    warn_if_truncated,
 )
 
 logger = logging.getLogger(__name__)
@@ -92,6 +93,18 @@ class GrokTextBackend:
             usage = response.usage
             input_tokens = getattr(usage, "input_tokens", None) or getattr(usage, "prompt_tokens", None)
             output_tokens = getattr(usage, "output_tokens", None) or getattr(usage, "completion_tokens", None)
+
+        finish_reason = getattr(response, "finish_reason", None)
+        if finish_reason is None:
+            choices = getattr(response, "choices", None) or []
+            if choices:
+                finish_reason = getattr(choices[0], "finish_reason", None)
+        warn_if_truncated(
+            finish_reason,
+            provider=PROVIDER_GROK,
+            model=self._model,
+            output_tokens=output_tokens,
+        )
 
         return TextGenerationResult(
             text=text.strip() if isinstance(text, str) else str(text),

--- a/lib/text_backends/grok.py
+++ b/lib/text_backends/grok.py
@@ -46,7 +46,10 @@ class GrokTextBackend:
 
     @with_retry_async(retry_if=grok_should_retry)
     async def generate(self, request: TextGenerationRequest) -> TextGenerationResult:
-        chat = self._client.chat.create(model=self._model)
+        chat_kwargs: dict = {"model": self._model}
+        if request.max_output_tokens is not None:
+            chat_kwargs["max_tokens"] = request.max_output_tokens
+        chat = self._client.chat.create(**chat_kwargs)
 
         # System prompt
         if request.system_prompt:

--- a/lib/text_backends/instructor_support.py
+++ b/lib/text_backends/instructor_support.py
@@ -150,13 +150,23 @@ def instructor_fallback_sync(
         create_kwargs["max_tokens"] = max_tokens
     response = client.chat.completions.create(**create_kwargs)
     usage = getattr(response, "usage", None)
-    text = response.choices[0].message.content or ""
+    choice = response.choices[0]
+    text = choice.message.content or ""
+    output_tokens = getattr(usage, "completion_tokens", None) if usage else None
+    from lib.text_backends.base import warn_if_truncated
+
+    warn_if_truncated(
+        getattr(choice, "finish_reason", None),
+        provider=provider,
+        model=model,
+        output_tokens=output_tokens,
+    )
     return TextGenerationResult(
         text=text.strip() if isinstance(text, str) else str(text),
         provider=provider,
         model=model,
         input_tokens=getattr(usage, "prompt_tokens", None) if usage else None,
-        output_tokens=getattr(usage, "completion_tokens", None) if usage else None,
+        output_tokens=output_tokens,
     )
 
 
@@ -205,11 +215,21 @@ async def instructor_fallback_async(
         create_kwargs["max_tokens"] = max_tokens
     response = await client.chat.completions.create(**create_kwargs)
     usage = getattr(response, "usage", None)
-    text = response.choices[0].message.content or ""
+    choice = response.choices[0]
+    text = choice.message.content or ""
+    output_tokens = getattr(usage, "completion_tokens", None) if usage else None
+    from lib.text_backends.base import warn_if_truncated
+
+    warn_if_truncated(
+        getattr(choice, "finish_reason", None),
+        provider=provider,
+        model=model,
+        output_tokens=output_tokens,
+    )
     return TextGenerationResult(
         text=text.strip() if isinstance(text, str) else str(text),
         provider=provider,
         model=model,
         input_tokens=getattr(usage, "prompt_tokens", None) if usage else None,
-        output_tokens=getattr(usage, "completion_tokens", None) if usage else None,
+        output_tokens=output_tokens,
     )

--- a/lib/text_backends/instructor_support.py
+++ b/lib/text_backends/instructor_support.py
@@ -20,6 +20,7 @@ def generate_structured_via_instructor(
     response_model: type[BaseModel],
     mode: Mode = Mode.MD_JSON,
     max_retries: int = 2,
+    max_tokens: int | None = None,
 ) -> tuple[str, int | None, int | None]:
     """通过 Instructor 生成结构化输出（同步版，供 Ark 等同步 SDK 使用）。
 
@@ -31,11 +32,13 @@ def generate_structured_via_instructor(
             f"instructor.from_openai() 返回 None — client 类型 {type(client).__name__} 不受支持，"
             "请传入 openai.OpenAI 或 openai.AsyncOpenAI 实例"
         )
+    extra: dict = {"max_tokens": max_tokens} if max_tokens is not None else {}
     result, completion = patched.chat.completions.create_with_completion(
         model=model,
         messages=messages,
         response_model=response_model,
         max_retries=max_retries,
+        **extra,
     )
     json_text = result.model_dump_json()
 
@@ -55,6 +58,7 @@ async def generate_structured_via_instructor_async(
     response_model: type[BaseModel],
     mode: Mode = Mode.MD_JSON,
     max_retries: int = 2,
+    max_tokens: int | None = None,
 ) -> tuple[str, int | None, int | None]:
     """通过 Instructor 生成结构化输出（异步版，供 OpenAI AsyncOpenAI 使用）。
 
@@ -66,11 +70,13 @@ async def generate_structured_via_instructor_async(
             f"instructor.from_openai() 返回 None — client 类型 {type(client).__name__} 不受支持，"
             "请传入 openai.OpenAI 或 openai.AsyncOpenAI 实例"
         )
+    extra: dict = {"max_tokens": max_tokens} if max_tokens is not None else {}
     result, completion = await patched.chat.completions.create_with_completion(
         model=model,
         messages=messages,
         response_model=response_model,
         max_retries=max_retries,
+        **extra,
     )
     json_text = result.model_dump_json()
 
@@ -107,6 +113,7 @@ def instructor_fallback_sync(
     messages: list[dict],
     response_schema: dict | type,
     provider: str,
+    max_tokens: int | None = None,
 ):
     """同步 Instructor 降级路径。
 
@@ -122,6 +129,7 @@ def instructor_fallback_sync(
             model=model,
             messages=messages,
             response_model=response_schema,
+            max_tokens=max_tokens,
         )
         return TextGenerationResult(
             text=json_text,
@@ -133,11 +141,14 @@ def instructor_fallback_sync(
 
     logger.info("response_schema 为 dict，无法使用 Instructor，回退到 json_object 模式")
     fb_messages = inject_json_instruction(messages)
-    response = client.chat.completions.create(
-        model=model,
-        messages=fb_messages,
-        response_format={"type": "json_object"},
-    )
+    create_kwargs: dict = {
+        "model": model,
+        "messages": fb_messages,
+        "response_format": {"type": "json_object"},
+    }
+    if max_tokens is not None:
+        create_kwargs["max_tokens"] = max_tokens
+    response = client.chat.completions.create(**create_kwargs)
     usage = getattr(response, "usage", None)
     text = response.choices[0].message.content or ""
     return TextGenerationResult(
@@ -155,6 +166,7 @@ async def instructor_fallback_async(
     messages: list[dict],
     response_schema: dict | type,
     provider: str,
+    max_tokens: int | None = None,
 ):
     """异步 Instructor 降级路径。
 
@@ -172,6 +184,7 @@ async def instructor_fallback_async(
             model=model,
             messages=messages,
             response_model=response_schema,
+            max_tokens=max_tokens,
         )
         return TextGenerationResult(
             text=json_text,
@@ -183,11 +196,14 @@ async def instructor_fallback_async(
 
     logger.info("response_schema 为 dict，无法使用 Instructor，回退到 json_object 模式")
     fb_messages = inject_json_instruction(messages)
-    response = await client.chat.completions.create(
-        model=model,
-        messages=fb_messages,
-        response_format={"type": "json_object"},
-    )
+    create_kwargs: dict = {
+        "model": model,
+        "messages": fb_messages,
+        "response_format": {"type": "json_object"},
+    }
+    if max_tokens is not None:
+        create_kwargs["max_tokens"] = max_tokens
+    response = await client.chat.completions.create(**create_kwargs)
     usage = getattr(response, "usage", None)
     text = response.choices[0].message.content or ""
     return TextGenerationResult(

--- a/lib/text_backends/openai.py
+++ b/lib/text_backends/openai.py
@@ -65,6 +65,8 @@ class OpenAITextBackend:
         """
         messages = _build_messages(request)
         kwargs: dict = {"model": self._model, "messages": messages}
+        if request.max_output_tokens is not None:
+            kwargs["max_tokens"] = request.max_output_tokens
 
         if request.response_schema:
             schema = resolve_schema(request.response_schema)
@@ -162,4 +164,5 @@ async def _instructor_fallback(
         messages=messages,
         response_schema=request.response_schema,
         provider=PROVIDER_OPENAI,
+        max_tokens=request.max_output_tokens,
     )

--- a/lib/text_backends/openai.py
+++ b/lib/text_backends/openai.py
@@ -14,6 +14,7 @@ from lib.text_backends.base import (
     TextGenerationRequest,
     TextGenerationResult,
     resolve_schema,
+    warn_if_truncated,
 )
 
 logger = logging.getLogger(__name__)
@@ -91,12 +92,20 @@ class OpenAITextBackend:
             raise
 
         usage = response.usage
+        choice = response.choices[0]
+        output_tokens = usage.completion_tokens if usage else None
+        warn_if_truncated(
+            getattr(choice, "finish_reason", None),
+            provider=PROVIDER_OPENAI,
+            model=self._model,
+            output_tokens=output_tokens,
+        )
         return TextGenerationResult(
-            text=response.choices[0].message.content or "",
+            text=choice.message.content or "",
             provider=PROVIDER_OPENAI,
             model=self._model,
             input_tokens=usage.prompt_tokens if usage else None,
-            output_tokens=usage.completion_tokens if usage else None,
+            output_tokens=output_tokens,
         )
 
 

--- a/tests/test_openai_text_backend.py
+++ b/tests/test_openai_text_backend.py
@@ -294,3 +294,44 @@ class TestInstructorFallback:
         assert _is_schema_error(_make_bad_request_error()) is True
         assert _is_schema_error(ValueError("other")) is False
         assert _is_schema_error(RuntimeError("test")) is False
+
+
+class TestMaxOutputTokens:
+    async def test_plain_path_passes_max_tokens(self):
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("ok"))
+        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            backend = OpenAITextBackend(api_key="k")
+            await backend.generate(TextGenerationRequest(prompt="hi", max_output_tokens=32000))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["max_tokens"] == 32000
+
+    async def test_structured_path_passes_max_tokens(self):
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(json.dumps({"name": "x"})))
+        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            class MyModel(BaseModel):
+                name: str
+
+            backend = OpenAITextBackend(api_key="k")
+            await backend.generate(TextGenerationRequest(prompt="hi", response_schema=MyModel, max_output_tokens=24000))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["max_tokens"] == 24000
+
+    async def test_no_max_tokens_means_key_absent(self):
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("ok"))
+        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            backend = OpenAITextBackend(api_key="k")
+            await backend.generate(TextGenerationRequest(prompt="hi"))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert "max_tokens" not in call_kwargs

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -196,6 +196,32 @@ class TestScriptGenerator:
         await generator.generate(1)
         assert fake.backend.last_request.response_schema is DramaEpisodeScript
 
+    async def test_generate_sets_script_max_output_tokens(self, tmp_path):
+        """generate 应在 TextGenerationRequest 上设置 SCRIPT_MAX_OUTPUT_TOKENS。"""
+        from lib.script_generator import SCRIPT_MAX_OUTPUT_TOKENS
+
+        project_path = tmp_path / "demo"
+        _write_json(
+            project_path / "project.json",
+            {
+                "title": "项目",
+                "content_mode": "drama",
+                "overview": {},
+                "characters": {"姜月茴": {}},
+                "clues": {"玉佩": {}},
+                "style": "古风",
+                "style_description": "cinematic",
+            },
+        )
+        _write(project_path / "drafts" / "episode_1" / "step1_normalized_script.md", "E1S01 | 场景")
+
+        fake = _FakeTextGenerator(json.dumps({"foo": "bar"}))
+        generator = ScriptGenerator(project_path, generator=fake)
+        await generator.generate(1)
+
+        assert fake.backend.last_request.max_output_tokens == SCRIPT_MAX_OUTPUT_TOKENS
+        assert SCRIPT_MAX_OUTPUT_TOKENS >= 16000
+
     async def test_generate_without_backend_raises(self, tmp_path):
         """未注入 backend 时调用 generate() 应抛 RuntimeError。"""
         project_path = tmp_path / "demo"

--- a/tests/test_text_backends/test_ark.py
+++ b/tests/test_text_backends/test_ark.py
@@ -199,6 +199,47 @@ class TestCapabilityAwareStructured:
         call_args = backend_no_structured._openai_client.chat.completions.create.call_args
         assert call_args.kwargs["response_format"] == {"type": "json_object"}
 
+    async def test_max_output_tokens_plain(self, backend_no_structured, sync_to_thread):
+        """plain 路径透传 max_tokens。"""
+        mock_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="x"))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+        )
+        backend_no_structured._test_client.chat.completions.create = MagicMock(return_value=mock_resp)
+        await backend_no_structured.generate(TextGenerationRequest(prompt="hi", max_output_tokens=16000))
+        call_kwargs = backend_no_structured._test_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["max_tokens"] == 16000
+
+    async def test_max_output_tokens_structured_native(self, backend_with_structured, sync_to_thread):
+        """原生 structured 路径透传 max_tokens。"""
+        mock_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content='{"a":1}'))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+        )
+        backend_with_structured._test_client.chat.completions.create = MagicMock(return_value=mock_resp)
+        await backend_with_structured.generate(
+            TextGenerationRequest(prompt="g", response_schema={"type": "object"}, max_output_tokens=20000)
+        )
+        call_kwargs = backend_with_structured._test_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["max_tokens"] == 20000
+
+    async def test_max_output_tokens_instructor_fallback(self, backend_no_structured, sync_to_thread):
+        """Instructor 降级路径透传 max_tokens。"""
+        from pydantic import BaseModel
+
+        class M(BaseModel):
+            k: str
+
+        sample = M(k="v")
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            return_value=(sample.model_dump_json(), 1, 1),
+        ) as mock_fn:
+            await backend_no_structured.generate(
+                TextGenerationRequest(prompt="g", response_schema=M, max_output_tokens=24000)
+            )
+            assert mock_fn.call_args.kwargs["max_tokens"] == 24000
+
     async def test_native_failure_falls_back(self, backend_with_structured, sync_to_thread):
         """原生 json_schema 运行时失败后降级到 json_object。"""
         backend_with_structured._test_client.chat.completions.create = MagicMock(

--- a/tests/test_text_backends/test_ark.py
+++ b/tests/test_text_backends/test_ark.py
@@ -199,6 +199,28 @@ class TestCapabilityAwareStructured:
         call_args = backend_no_structured._openai_client.chat.completions.create.call_args
         assert call_args.kwargs["response_format"] == {"type": "json_object"}
 
+    async def test_truncation_warning_logged_on_finish_reason_length(
+        self, backend_no_structured, sync_to_thread, caplog
+    ):
+        """当 Ark 返回 finish_reason=length 时应记录 WARNING。"""
+        import logging
+
+        mock_resp = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="partial"),
+                    finish_reason="length",
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=8192),
+        )
+        backend_no_structured._test_client.chat.completions.create = MagicMock(return_value=mock_resp)
+
+        with caplog.at_level(logging.WARNING, logger="lib.text_backends.base"):
+            await backend_no_structured.generate(TextGenerationRequest(prompt="hi"))
+
+        assert any("被截断" in r.message for r in caplog.records)
+
     async def test_max_output_tokens_plain(self, backend_no_structured, sync_to_thread):
         """plain 路径透传 max_tokens。"""
         mock_resp = SimpleNamespace(

--- a/tests/test_text_backends/test_base.py
+++ b/tests/test_text_backends/test_base.py
@@ -162,3 +162,36 @@ class TestTextBackendProtocol:
         assert backend.name == "fake"
         assert backend.model == "fake-model"
         assert TextCapability.TEXT_GENERATION in backend.capabilities
+
+
+class TestWarnIfTruncated:
+    def test_none_finish_reason_returns_false(self, caplog):
+        from lib.text_backends.base import warn_if_truncated
+
+        assert warn_if_truncated(None, provider="x", model="m") is False
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+    def test_normal_stop_returns_false(self, caplog):
+        from lib.text_backends.base import warn_if_truncated
+
+        assert warn_if_truncated("stop", provider="x", model="m") is False
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+    def test_length_triggers_warning(self, caplog):
+        import logging
+
+        from lib.text_backends.base import warn_if_truncated
+
+        with caplog.at_level(logging.WARNING, logger="lib.text_backends.base"):
+            result = warn_if_truncated("length", provider="ark", model="doubao", output_tokens=8192)
+
+        assert result is True
+        assert any("被截断" in r.message and "length" in r.message for r in caplog.records)
+
+    def test_max_tokens_variant_triggers_warning(self, caplog):
+        import logging
+
+        from lib.text_backends.base import warn_if_truncated
+
+        with caplog.at_level(logging.WARNING, logger="lib.text_backends.base"):
+            assert warn_if_truncated("MAX_TOKENS", provider="gemini", model="g") is True

--- a/tests/test_text_backends/test_gemini.py
+++ b/tests/test_text_backends/test_gemini.py
@@ -128,3 +128,25 @@ class TestGenerate:
         result = await backend.generate(TextGenerationRequest(prompt="hi"))
         assert result.input_tokens is None
         assert result.output_tokens is None
+
+    async def test_max_output_tokens_in_config(self, backend):
+        """max_output_tokens 注入到 Gemini config 字典。"""
+        mock_resp = SimpleNamespace(text="x", usage_metadata=None)
+        backend._test_client.aio.models.generate_content = AsyncMock(return_value=mock_resp)
+
+        await backend.generate(TextGenerationRequest(prompt="hi", max_output_tokens=32000))
+
+        call_kwargs = backend._test_client.aio.models.generate_content.call_args
+        config = call_kwargs.kwargs.get("config")
+        assert config["max_output_tokens"] == 32000
+
+    async def test_no_max_output_tokens_means_no_config_key(self, backend):
+        """未指定 max_output_tokens 时 config 中不应出现该键。"""
+        mock_resp = SimpleNamespace(text="x", usage_metadata=None)
+        backend._test_client.aio.models.generate_content = AsyncMock(return_value=mock_resp)
+
+        await backend.generate(TextGenerationRequest(prompt="hi"))
+
+        call_kwargs = backend._test_client.aio.models.generate_content.call_args
+        config = call_kwargs.kwargs.get("config")
+        assert config is None or "max_output_tokens" not in config

--- a/tests/test_text_backends/test_grok.py
+++ b/tests/test_text_backends/test_grok.py
@@ -87,3 +87,15 @@ class TestGenerate:
         result = await backend.generate(TextGenerationRequest(prompt="gen", response_schema=schema))
 
         assert result.text == '{"name": "test"}'
+
+    async def test_max_output_tokens_passed_to_chat_create(self, backend):
+        """max_output_tokens 透传为 xai_sdk chat.create(max_tokens=)。"""
+        mock_chat = MagicMock()
+        mock_response = SimpleNamespace(content="x")
+        mock_chat.sample = AsyncMock(return_value=mock_response)
+        backend._test_client.chat.create.return_value = mock_chat
+
+        await backend.generate(TextGenerationRequest(prompt="hi", max_output_tokens=16000))
+
+        call_kwargs = backend._test_client.chat.create.call_args.kwargs
+        assert call_kwargs["max_tokens"] == 16000


### PR DESCRIPTION
## Summary

- `TextGenerationRequest` 新增 `max_output_tokens` 字段，Ark/OpenAI/Gemini/Grok 四个后端及 Instructor 降级路径统一透传给各供应商 SDK
- `lib/script_generator.py` 显式设 `SCRIPT_MAX_OUTPUT_TOKENS=32000`；`normalize_drama_script.py` 显式设 `max_output_tokens=16000`
- `docs/known-issues.md` 新增 Issue 11 说明各模型硬上限约束（doubao-seed-1-8 ~8192 不满足剧本生成，需选 ≥16K 输出模型）

## Root Cause

用户反馈 drama 剧本生成 22 场景 JSON（~14K token）被 doubao-seed-1-8-251228 截断。根因是 `lib/text_backends/` 下四个后端调用 SDK 时均未传 `max_tokens`/`max_output_tokens`，完全依赖 SDK 默认值（约 8192），任何大型结构化输出都会被截断。全仓 grep `max_tokens|max_output_tokens|maxOutputTokens` 零命中。

## Test plan

- [x] `uv run pytest tests/test_text_backends/ tests/test_openai_text_backend.py tests/test_script_generator.py` — 88 通过（含 9 个新用例覆盖 plain/structured/instructor 降级路径）
- [x] `uv run ruff check lib/ tests/ agent_runtime_profile/` — 全部通过
- [x] `uv run ruff format` — 格式一致
- [ ] 端到端：在 `/settings` 切换 script 任务到 gemini-2.5-pro 或 gpt-5.4 后重新 dispatch `normalize-drama-script` + `create-episode-script`，确认 22 场景 JSON 完整生成