### PR TITLE
fix(project_manager): 剧本写入加文件锁+原子写，消除并发 PATCH 损坏 JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ frontend/.vite/
 htmlcov/
 .coverage
 
+# File locks (project_manager 原子写产物)
+**/*.lock
+
 # Docker runtime data
 claude_data/
 

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -377,20 +377,21 @@ class ProjectManager:
         total_duration = sum(item.get("duration_seconds", default_duration) for item in items)
         metadata["estimated_duration_seconds"] = total_duration
 
-        # 保存文件（含路径遍历防护）
+        # 保存文件（含路径遍历防护）+ 文件锁 + 原子写，避免并发 PATCH 导致 JSON 损坏
         real = self._safe_subpath(scripts_dir, filename)
-        with open(real, "w", encoding="utf-8") as f:  # noqa: PTH123
-            json.dump(script, f, ensure_ascii=False, indent=2)
         output_path = Path(real)
+
+        with self._script_lock(project_name, filename):
+            self._atomic_write_json(output_path, script)
+
+            # 在同一把锁内同步到 project.json，保证 script 写入与元数据同步是单一事务
+            if self.project_exists(project_name) and isinstance(script.get("episode"), int):
+                self.sync_episode_from_script(project_name, filename)
 
         emit_project_change_hint(
             project_name,
             changed_paths=[f"scripts/{output_path.name}"],
         )
-
-        # 自动同步到 project.json
-        if self.project_exists(project_name) and isinstance(script.get("episode"), int):
-            self.sync_episode_from_script(project_name, filename)
 
         return output_path
 
@@ -976,7 +977,30 @@ class ProjectManager:
         使用独立的 .project.json.lock 而非数据文件本身，避免 os.replace
         更换 inode 后锁失效的问题。
         """
-        lock_path = self._get_project_file_path(project_name).with_suffix(".lock")
+        project_file = self._get_project_file_path(project_name)
+        lock_path = project_file.parent / f".{project_file.name}.lock"
+        lock_path.touch(exist_ok=True)
+        fd = open(lock_path)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            fd.close()
+
+    @contextmanager
+    def _script_lock(self, project_name: str, script_filename: str):
+        """通过 scripts 目录下的隐藏 lock file 获取剧本文件的排他锁。
+
+        lock 文件命名为 `.{script_filename}.lock`（以 `.` 开头），被
+        `list_scripts()` 的 `*.json` glob 与 `project_archive` 的
+        `name.startswith(".")` 过滤自动排除。
+        """
+        scripts_dir = self.get_project_path(project_name) / "scripts"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        if script_filename.startswith("scripts/"):
+            script_filename = script_filename[len("scripts/") :]
+        lock_path = scripts_dir / f".{script_filename}.lock"
         lock_path.touch(exist_ok=True)
         fd = open(lock_path)
         try:

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -990,17 +990,23 @@ class ProjectManager:
 
     @contextmanager
     def _script_lock(self, project_name: str, script_filename: str):
-        """通过 scripts 目录下的隐藏 lock file 获取剧本文件的排他锁。
+        """通过隐藏 lock file 获取剧本文件的排他锁。
 
-        lock 文件命名为 `.{script_filename}.lock`（以 `.` 开头），被
-        `list_scripts()` 的 `*.json` glob 与 `project_archive` 的
-        `name.startswith(".")` 过滤自动排除。
+        lock 文件命名为 `.{basename}.lock`（以 `.` 开头），位于规范化后剧本的
+        parent 目录下，自动被 `list_scripts()` 的 `*.json` glob 与
+        `project_archive` 的 `name.startswith(".")` 过滤排除。
+
+        **关键**：用 `_safe_subpath` 规范化 filename 再派生 lock key，避免
+        `./episode_1.json` 与 `episode_1.json` 解析到同一个 real path 却拿到
+        不同锁、从而绕过互斥的别名问题。
         """
         scripts_dir = self.get_project_path(project_name) / "scripts"
         scripts_dir.mkdir(parents=True, exist_ok=True)
         if script_filename.startswith("scripts/"):
             script_filename = script_filename[len("scripts/") :]
-        lock_path = scripts_dir / f".{script_filename}.lock"
+        real = Path(self._safe_subpath(scripts_dir, script_filename))
+        lock_path = real.parent / f".{real.name}.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
         lock_path.touch(exist_ok=True)
         fd = open(lock_path)
         try:

--- a/tests/test_project_manager_concurrent_save.py
+++ b/tests/test_project_manager_concurrent_save.py
@@ -1,0 +1,195 @@
+"""剧本并发写入竞态防护测试。
+
+覆盖 `save_script` 在并发 PATCH 下的原子性，以及 lock 文件命名不会泄露到
+`list_scripts()` 或项目导出 ZIP。
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from lib.project_manager import ProjectManager
+from server.services.project_archive import ProjectArchiveService
+
+
+def _seed_project(pm: ProjectManager, name: str) -> None:
+    """创建一个最小可用的项目 + 初始 episode_1 剧本。"""
+    pm.create_project(name)
+    pm.save_project(
+        name,
+        {
+            "name": name,
+            "episodes": [],
+            "metadata": {"created_at": "2025-01-01", "updated_at": "2025-01-01"},
+        },
+    )
+
+
+def _make_script(episode: int, payload_size: int) -> dict:
+    """构造一个说书模式剧本，segment 数量决定 JSON 体积。"""
+    return {
+        "episode": episode,
+        "title": f"Episode {episode}",
+        "content_mode": "narration",
+        "segments": [
+            {
+                "segment_id": f"E{episode}S{i}",
+                "duration_seconds": 4,
+                "image_prompt": "图像提示词 " * (payload_size // 10),
+                "video_prompt": "视频提示词 " * (payload_size // 10),
+            }
+            for i in range(payload_size)
+        ],
+    }
+
+
+class TestSaveScriptConcurrency:
+    def test_concurrent_save_script_no_corruption(self, tmp_path: Path) -> None:
+        """并发写入同一 script 文件，最终应可被 json.load 成功解析。"""
+        pm = ProjectManager(tmp_path)
+        name = "proj-concurrent"
+        _seed_project(pm, name)
+
+        # 预置一次，确保文件存在
+        pm.save_script(name, _make_script(1, payload_size=40), "episode_1.json")
+
+        def _writer(i: int) -> int:
+            script = _make_script(1, payload_size=40 + (i % 7))  # 各线程 JSON 长度不同
+            script["segments"][0]["note"] = f"writer-{i}"
+            pm.save_script(name, script, "episode_1.json")
+            return i
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(_writer, i) for i in range(32)]
+            for fut in as_completed(futures):
+                fut.result()  # 任一写入抛异常即失败
+
+        # 最终文件必须是完整合法的 JSON 且结构完整
+        loaded = pm.load_script(name, "episode_1.json")
+        assert loaded["episode"] == 1
+        assert isinstance(loaded["segments"], list)
+        assert len(loaded["segments"]) >= 40
+
+    def test_save_script_atomicity_during_read(self, tmp_path: Path) -> None:
+        """写入流程中并发 load_script 不应看到半写入/损坏状态。"""
+        pm = ProjectManager(tmp_path)
+        name = "proj-rw"
+        _seed_project(pm, name)
+        pm.save_script(name, _make_script(1, payload_size=60), "episode_1.json")
+
+        stop = threading.Event()
+        errors: list[Exception] = []
+
+        def _writer() -> None:
+            i = 0
+            while not stop.is_set():
+                i += 1
+                try:
+                    pm.save_script(name, _make_script(1, payload_size=40 + (i % 30)), "episode_1.json")
+                except Exception as e:  # noqa: BLE001
+                    errors.append(e)
+
+        def _reader() -> None:
+            while not stop.is_set():
+                try:
+                    pm.load_script(name, "episode_1.json")
+                except Exception as e:  # noqa: BLE001
+                    errors.append(e)
+
+        threads = [threading.Thread(target=_writer), threading.Thread(target=_reader), threading.Thread(target=_reader)]
+        for t in threads:
+            t.start()
+        time.sleep(0.8)
+        stop.set()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert errors == [], f"并发读写中出现异常：{errors[:3]}"
+
+
+class TestLockFileNaming:
+    def test_script_lock_is_hidden_and_not_listed(self, tmp_path: Path) -> None:
+        """script lock 文件应以 `.` 开头并不出现在 list_scripts 结果中。"""
+        pm = ProjectManager(tmp_path)
+        name = "proj-lock"
+        _seed_project(pm, name)
+        pm.save_script(name, _make_script(1, payload_size=10), "episode_1.json")
+
+        scripts_dir = pm.get_project_path(name) / "scripts"
+        entries = {p.name for p in scripts_dir.iterdir()}
+        assert ".episode_1.json.lock" in entries, f"期望找到隐藏锁文件，实际 {entries}"
+        assert "episode_1.json.lock" not in entries
+        assert "episode_1.lock" not in entries
+
+        assert pm.list_scripts(name) == ["episode_1.json"]
+
+    def test_project_lock_is_hidden(self, tmp_path: Path) -> None:
+        """project.json 的 lock 文件也应为隐藏命名（与注释一致）。"""
+        pm = ProjectManager(tmp_path)
+        name = "proj-proj-lock"
+        _seed_project(pm, name)
+        pm.save_project(name, pm.load_project(name))
+
+        project_dir = pm.get_project_path(name)
+        names = {p.name for p in project_dir.iterdir()}
+        assert ".project.json.lock" in names, f"期望 .project.json.lock，实际 {names}"
+        assert "project.lock" not in names
+
+
+class TestArchiveExcludesLocks:
+    def test_is_hidden_member_filters_lock_and_tmp(self) -> None:
+        """导出 ZIP 的隐藏成员判定应覆盖 lock 与原子写入的 tmp 残留。"""
+        assert ProjectArchiveService._is_hidden_member((".project.json.lock",))
+        assert ProjectArchiveService._is_hidden_member(("scripts", ".episode_1.json.lock"))
+        assert ProjectArchiveService._is_hidden_member((".project.abc.tmp",))
+        assert ProjectArchiveService._is_hidden_member(("scripts", ".project.xyz.tmp"))
+        # 正常文件不被过滤
+        assert not ProjectArchiveService._is_hidden_member(("scripts", "episode_1.json"))
+        assert not ProjectArchiveService._is_hidden_member(("project.json",))
+
+
+class TestSyncAfterConcurrentWrite:
+    def test_project_json_reflects_last_script_after_concurrent_writes(self, tmp_path: Path) -> None:
+        """并发 save_script 后 project.json 的 episode 条目应与 script 一致。"""
+        pm = ProjectManager(tmp_path)
+        name = "proj-sync"
+        _seed_project(pm, name)
+
+        def _writer(i: int) -> None:
+            script = _make_script(1, payload_size=20)
+            script["title"] = f"Title-{i}"
+            pm.save_script(name, script, "episode_1.json")
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            list(pool.map(_writer, range(12)))
+
+        project = pm.load_project(name)
+        episodes = project.get("episodes", [])
+        assert len(episodes) == 1
+        assert episodes[0]["episode"] == 1
+        assert episodes[0]["script_file"] == "scripts/episode_1.json"
+        # title 应来自某一次写入，非空且符合模式
+        assert episodes[0]["title"].startswith("Title-")
+
+        # 剧本仍然是合法 JSON
+        loaded = pm.load_script(name, "episode_1.json")
+        assert loaded["title"] == episodes[0]["title"]
+
+
+def test_loaded_json_not_extra_data_after_save_script(tmp_path: Path) -> None:
+    """回归：save_script 后磁盘内容必须是单个 JSON 对象，不能有 Extra data。"""
+    pm = ProjectManager(tmp_path)
+    name = "proj-regress"
+    _seed_project(pm, name)
+    pm.save_script(name, _make_script(1, payload_size=50), "episode_1.json")
+
+    raw = (pm.get_project_path(name) / "scripts" / "episode_1.json").read_bytes().decode("utf-8")
+    # 直接用 json.loads 解析整个文件——若末尾多 `}` 会抛 Extra data
+    json.loads(raw)
+    assert raw.strip().endswith("}")
+    # 末尾不应连续两个及以上 `}` 字符（排除合法嵌套尾巴，最内层 items 数组收尾为 "]\n}"）
+    assert not raw.rstrip().endswith("}}")

--- a/tests/test_project_manager_concurrent_save.py
+++ b/tests/test_project_manager_concurrent_save.py
@@ -140,6 +140,34 @@ class TestLockFileNaming:
         assert "project.lock" not in names
 
 
+class TestLockPathAliasing:
+    def test_aliased_filenames_share_single_lock(self, tmp_path: Path) -> None:
+        """`./episode_1.json`、`episode_1.json`、`scripts/episode_1.json` 必须解析到同一把锁文件。"""
+        pm = ProjectManager(tmp_path)
+        name = "proj-alias"
+        _seed_project(pm, name)
+        pm.save_script(name, _make_script(1, payload_size=10), "episode_1.json")
+
+        scripts_dir = pm.get_project_path(name) / "scripts"
+
+        # 分别用三种别名进入 _script_lock 并检查拿到的 lock_path 相同
+        lock_paths = set()
+        for alias in ["episode_1.json", "./episode_1.json", "scripts/episode_1.json"]:
+            with pm._script_lock(name, alias):
+                # 锁持有期间断言 scripts 下应存在唯一的隐藏锁文件
+                hidden = [p for p in scripts_dir.iterdir() if p.name.startswith(".") and p.name.endswith(".lock")]
+                assert len(hidden) == 1, f"期望唯一锁文件，实际 {[p.name for p in hidden]}"
+                lock_paths.add(hidden[0].resolve())
+
+        assert len(lock_paths) == 1, f"别名应共享同一锁文件，实际产生 {lock_paths}"
+        # 项目根目录不应出现 script 相关锁的逸出（防止 `./ep.json` 造成 scripts/../.ep.json.lock）
+        project_dir = pm.get_project_path(name)
+        strays = [
+            p.name for p in project_dir.iterdir() if p.is_file() and p.name.endswith(".lock") and "episode" in p.name
+        ]
+        assert strays == [], f"项目根目录不应出现 script 锁文件残留，实际 {strays}"
+
+
 class TestArchiveExcludesLocks:
     def test_is_hidden_member_filters_lock_and_tmp(self) -> None:
         """导出 ZIP 的隐藏成员判定应覆盖 lock 与原子写入的 tmp 残留。"""


### PR DESCRIPTION
## Summary
- 并发 PATCH /segments/{id} 时 save_script 用裸 open(\"w\")+json.dump 交错写入同一文件，较短 JSON 先 close 后较长流程的尾部 } 残留，触发 JSONDecodeError: Extra data，导致整集读路径（get_project/status_calculator/project_events）连环 500
- save_script 改用新增 _script_lock + 现成 _atomic_write_json，把 sync_episode_from_script 纳入同锁以保证 script 文件写入与 project.json 同步是单事务
- 顺手修正 _project_lock 命名 project.lock → .project.json.lock（原注释已如此描述），让 project_archive 现有 startswith(\".\") 过滤自动排除 lock 文件，避免导出 ZIP 泄露

## Test plan
- [x] uv run python -m pytest tests/test_project_manager_concurrent_save.py -v （7/7 通过）
- [x] uv run python -m pytest tests/ -k \"project_manager or archive or project_events\" -v （86/86 通过）
- [x] uv run ruff check / format --check lib/project_manager.py tests/test_project_manager_concurrent_save.py
- [ ] 手动冒烟：Web 端连续快速保存同一 segment 提示词 5+ 次，检查后端日志无 JSONDecodeError
- [ ] 手动冒烟：导出项目 ZIP，unzip -l 检查无 *.lock / *.tmp 入档