### PR TITLE
chore(frontend): clean up remaining ESLint warnings and flip rules to error (#219)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,32 +58,16 @@ cd frontend && pnpm lint:fix      # 自动修可修的部分
 - typed linting 启用 `projectService: true`，能检查 `no-floating-promises`、`no-misused-promises` 等 async 相关问题
 - CI 中强制检查：`frontend-tests` job 的 `Lint` step
 
-**baseline ratchet（--max-warnings）：**
+### ESLint disable 使用规范
 
-项目处于 a11y 工程化迁移期。`package.json` 的 `"lint"` 脚本里 `--max-warnings=<N>` 锁住历史未修的 warning 总数：
+本项目在 PR 3（#219）后采用零 warning 政策，所有规则均为 error。如必须绕过，遵循：
 
-- N > 0 时，CI 只允许 warning ≤ N（新增 warning 会失败）
-- 修复 warning 后须**同步下调** N 数字；不允许上调
-- 修完一类 rule 后，从 `eslint.config.js` 里对应的 `MIGRATION_WARN_RULES_*` 常量中删除该 rule 条目（rule 自动升回 recommended 预设的 error 级）
-- 目标：N 最终降到 0，移除 `--max-warnings` 参数
-
-**eslint.config.js 里有三个迁移常量**，按 rule 类型分组：
-
-| 常量名 | 作用域 | 包含的 rule 类型 |
-|--------|-------|--------------------|
-| `MIGRATION_WARN_RULES_TYPED` | `src/**/*.{ts,tsx}` 非 test | 需要 TypeScript 类型信息的 rule（`@typescript-eslint/no-floating-promises` / `no-misused-promises` / `no-unsafe-*` 等） |
-| `MIGRATION_WARN_RULES_A11Y` | 非 test 文件 | jsx-a11y rule（`jsx-a11y/click-events-have-key-events` 等） |
-| `MIGRATION_WARN_RULES_ALL` | 全局 | 其他非 typed 非 a11y rule（`react-hooks/*` / `no-unsafe-finally` / `@typescript-eslint/no-explicit-any` 等） |
-
-**PR 2 / PR 3 作者的操作清单：**
-
-1. 本地 `cd frontend && pnpm lint` 看当前 warning 数
-2. 修复 warning 直到数字下降
-3. 更新 `package.json` 里 `--max-warnings=<N>` 为当前数字
-4. 根据 rule 类型，从 `eslint.config.js` 的对应常量（`MIGRATION_WARN_RULES_TYPED` / `_A11Y` / `_ALL`）中删除已清零的 rule 条目
-5. 提交，CI 验证
-
-CR checklist：**`--max-warnings` 数字在 diff 里只允许减不允许加**。
+- **形式**：`// eslint-disable-next-line <rule> -- <中文理由>`，`--` 后的理由**强制**
+- **禁用**：文件级 `/* eslint-disable */`、无理由的 `// eslint-disable-line`、`@ts-ignore` 联用
+- **PR 描述要求**：新增的 disable 必须在 PR body 以表格列出 `rule | file:line | 理由`
+- **文件级关闭**只允许通过 `eslint.config.js` 的 `files` override，且须在 config 注释说明原因
+- **不可接受的理由**：「太麻烦」「暂时这样」「later fix」
+- **可接受的理由示例**：「React setter 引用稳定」「mount-only 初始化」「生成式预览视频无字幕源」
 
 **本地 IDE 建议（不提交 repo）：**
 

--- a/docs/superpowers/plans/2026-04-14-eslint-a11y-pr3.md
+++ b/docs/superpowers/plans/2026-04-14-eslint-a11y-pr3.md
@@ -1,0 +1,1063 @@
+# ESLint + jsx-a11y 扫尾（PR 3）实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal：** 把前端剩余 229 条 ESLint warning 清零、所有规则 flip 到 error、移除 `--max-warnings` ratchet。
+
+**Architecture：** 先搭工具（`voidPromise` / `useAutoFocus` / `activateOnEnterSpace`），再从类型源头（`api.ts`、SSE hooks）加类型让下游 `unsafe-*` 自愈，然后按规则类别批量修复，最后一次性翻规则级别 + 清空 migration 常量 + 移除 `--max-warnings`。
+
+**Tech Stack：** TypeScript + React 19 + ESLint v9 flat config + typescript-eslint v8 + eslint-plugin-jsx-a11y + eslint-plugin-react-hooks v7 + vitest。
+
+**Spec：** `docs/superpowers/specs/2026-04-14-eslint-a11y-pr3-design.md`
+
+**前置条件：** PR 2 (#292) 已 merge 并 rebase 到最新。开始时 `cd frontend && pnpm lint 2>&1 | tail -1` 验证 warning 数量（预期 ~211），如偏差较大需要先和 spec 对齐实际清单。
+
+**约定：** 本 PR 是批量 lint 清理，每个 Task 的 "测试" 是 `pnpm lint <scope>` 输出的 warning 数下降。非功能性 bug fix，TDD 的等价形式是：**每个 Task 完成时运行 `pnpm lint` 验证 warning 数减少**。
+
+---
+
+## 文件结构
+
+**新增文件：**
+- `frontend/src/utils/async.ts` — `voidPromise` / `voidCall` helpers
+- `frontend/src/utils/async.test.ts` — helper 单元测试
+- `frontend/src/utils/a11y.ts` — `activateOnEnterSpace` keyboard helper
+- `frontend/src/hooks/useAutoFocus.ts` — 替换 `autoFocus` prop 的 hook
+
+**关键修改文件：**
+- `frontend/eslint.config.js` — 测试 override、删除 migration 常量、加严格化 override
+- `frontend/package.json` — 移除 `--max-warnings=212`
+- `frontend/src/api.ts` — API 响应类型定义（源头）
+- `frontend/src/hooks/useTasksSSE.ts`、`useProjectEventsSSE.ts` — SSE payload 类型
+- `frontend/src/pages/LoginPage.tsx` — autoFocus/async 的集中修复点
+- `frontend/src/i18n/index.ts`、`frontend/src/test/setup.ts` — 顶层 floating promise
+- 其余 ~30 个 components 文件 — 按规则散点修复
+- `CONTRIBUTING.md` — 新增 disable 使用规范
+
+---
+
+## Task 1: 工具脚手架（helpers + hook）
+
+**Files:**
+- Create: `frontend/src/utils/async.ts`
+- Create: `frontend/src/utils/async.test.ts`
+- Create: `frontend/src/utils/a11y.ts`
+- Create: `frontend/src/hooks/useAutoFocus.ts`
+
+- [ ] **Step 1.1: 写 `async.ts` 的测试**
+
+Create `frontend/src/utils/async.test.ts`：
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { voidCall, voidPromise } from "./async";
+
+describe("voidPromise", () => {
+  it("returns a void function that calls fn with args", () => {
+    const fn = vi.fn(async (a: number, b: string) => `${a}-${b}`);
+    const wrapped = voidPromise(fn);
+    const result = wrapped(1, "x");
+    expect(result).toBeUndefined();
+    expect(fn).toHaveBeenCalledWith(1, "x");
+  });
+
+  it("routes rejection to console.error by default", async () => {
+    const err = new Error("boom");
+    const fn = vi.fn(async () => { throw err; });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    voidPromise(fn)();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(spy).toHaveBeenCalledWith(err);
+    spy.mockRestore();
+  });
+
+  it("routes rejection to custom onError when provided", async () => {
+    const err = new Error("boom");
+    const fn = vi.fn(async () => { throw err; });
+    const onError = vi.fn();
+    voidPromise(fn, { onError })();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onError).toHaveBeenCalledWith(err);
+  });
+});
+
+describe("voidCall", () => {
+  it("swallows rejection with console.error by default", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    voidCall(Promise.reject(new Error("x")));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("routes rejection to custom onError", async () => {
+    const onError = vi.fn();
+    voidCall(Promise.reject(new Error("x")), onError);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onError).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 1.2: 运行测试确认失败**
+
+```bash
+cd frontend && pnpm vitest run src/utils/async.test.ts
+```
+
+Expected: FAIL（`async.ts` 不存在）
+
+- [ ] **Step 1.3: 实现 `async.ts`**
+
+Create `frontend/src/utils/async.ts`：
+
+```ts
+type VoidPromiseOptions = {
+  onError?: (err: unknown) => void;
+};
+
+export function voidPromise<Args extends unknown[]>(
+  fn: (...args: Args) => Promise<unknown>,
+  opts?: VoidPromiseOptions,
+): (...args: Args) => void {
+  return (...args) => {
+    fn(...args).catch((err: unknown) => {
+      if (opts?.onError) opts.onError(err);
+      else console.error(err);
+    });
+  };
+}
+
+export function voidCall<T>(
+  promise: Promise<T>,
+  onError: (err: unknown) => void = console.error,
+): void {
+  promise.catch(onError);
+}
+```
+
+- [ ] **Step 1.4: 运行测试确认通过**
+
+```bash
+cd frontend && pnpm vitest run src/utils/async.test.ts
+```
+
+Expected: PASS（5 tests）
+
+- [ ] **Step 1.5: 实现 `a11y.ts`**
+
+Create `frontend/src/utils/a11y.ts`：
+
+```ts
+import type { KeyboardEvent } from "react";
+
+export function activateOnEnterSpace(handler: () => void) {
+  return (e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handler();
+    }
+  };
+}
+```
+
+- [ ] **Step 1.6: 实现 `useAutoFocus.ts`**
+
+Create `frontend/src/hooks/useAutoFocus.ts`：
+
+```ts
+import { useEffect, useRef } from "react";
+
+export function useAutoFocus<T extends HTMLElement>(enabled = true) {
+  const ref = useRef<T>(null);
+  useEffect(() => {
+    if (enabled) ref.current?.focus();
+  }, [enabled]);
+  return ref;
+}
+```
+
+- [ ] **Step 1.7: 验证新文件本身 lint 通过**
+
+```bash
+cd frontend && pnpm lint src/utils/async.ts src/utils/async.test.ts src/utils/a11y.ts src/hooks/useAutoFocus.ts
+```
+
+Expected: `0 errors, 0 warnings`
+
+- [ ] **Step 1.8: Commit**
+
+```bash
+git add frontend/src/utils/async.ts frontend/src/utils/async.test.ts frontend/src/utils/a11y.ts frontend/src/hooks/useAutoFocus.ts
+git commit -m "feat(frontend): add async/a11y helpers for PR 3 cleanup
+
+- voidPromise / voidCall helpers for Promise-returning handlers and fire-and-forget
+- activateOnEnterSpace keyboard helper for role=button ARIA pattern
+- useAutoFocus hook to replace autoFocus prop
+
+Refs #219"
+```
+
+---
+
+## Task 2: 测试文件 ESLint override
+
+**Files:**
+- Modify: `frontend/eslint.config.js`
+
+- [ ] **Step 2.1: 记录基线 warning 数**
+
+```bash
+cd frontend && pnpm lint 2>&1 | tail -1
+```
+
+记下输出，例如 `211 problems (0 errors, 211 warnings)`。
+
+- [ ] **Step 2.2: 在 eslint.config.js 里加测试文件 override**
+
+在 `frontend/eslint.config.js` 中，紧接着已有的 test 文件语言选项 override 之后（或在 MIGRATION 展开块之前），新增：
+
+```js
+  // 测试文件放宽 any 与 unsafe-* —— 测试环境允许 mock 便利
+  {
+    files: ["src/**/*.test.{ts,tsx}", "src/test/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+    },
+  },
+```
+
+- [ ] **Step 2.3: 运行 lint 确认测试文件 warning 消失**
+
+```bash
+cd frontend && pnpm lint 2>&1 | tail -1
+```
+
+Expected: warning 数下降（`stores.test.ts` 1 条 + `useTasksSSE.test.tsx` 4 条 + 可能的 `api.test.ts` / `OverviewCanvas.test.tsx` 等，估计降 ~10-20 条）
+
+- [ ] **Step 2.4: 更新 `package.json` 的 `--max-warnings` 为新基线**
+
+查看当前 warning 数（假设从 211 → 195），编辑 `frontend/package.json`：
+
+```diff
+- "lint": "eslint . --max-warnings=212",
++ "lint": "eslint . --max-warnings=<新数字>",
+```
+
+运行 `cd frontend && pnpm lint` 确认 exit 0（`--max-warnings` 不再阻塞）。
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add frontend/eslint.config.js frontend/package.json
+git commit -m "chore(frontend): relax typed rules on test files
+
+Tests legitimately use any/mock fixtures; scoping no-explicit-any
+and no-unsafe-* off for src/**/*.test.* and src/test/** follows
+industry convention.
+
+Refs #219"
+```
+
+---
+
+## Task 3: 类型源头 — `src/api.ts`
+
+**Files:**
+- Modify: `frontend/src/api.ts`（加响应类型）
+- 可能需要查阅对应后端：`server/routers/auth.py`、`server/routers/tasks.py`
+
+- [ ] **Step 3.1: 读取 api.ts 当前结构**
+
+```bash
+cd frontend && wc -l src/api.ts
+```
+
+打开 `frontend/src/api.ts` 浏览，定位所有返回 `any` 的函数与未类型化的 `fetch().json()` 调用。
+
+- [ ] **Step 3.2: 定位后端响应 schema**
+
+```bash
+grep -n "class.*Response\|class.*BaseModel" server/routers/auth.py server/routers/tasks.py
+```
+
+将后端 Pydantic 模型字段镜像为前端 interface。
+
+- [ ] **Step 3.3: 加登录响应类型**
+
+在 `frontend/src/api.ts` 顶部（或 types 区域）新增：
+
+```ts
+export interface LoginResponse {
+  access_token: string;
+  token_type: string;
+}
+
+export interface ErrorResponse {
+  detail: string;
+}
+```
+
+把 `login(...)` 函数的返回值改为 `Promise<LoginResponse>`，内部 `const data = await res.json()` 用 `as LoginResponse` 断言（runtime 仍信任后端契约；断言会被后续的 `no-unnecessary-type-assertion` 重新评估）。
+
+- [ ] **Step 3.4: 其他 API 函数类似处理**
+
+逐一给 `api.ts` 中所有 `fetch()` 调用加返回类型。对 `tasks` 相关 API 定义 `TaskStats` / `TaskRecord` 等镜像 interface。
+
+- [ ] **Step 3.5: 运行 typecheck 与 lint**
+
+```bash
+cd frontend && pnpm typecheck && pnpm lint src/api.ts src/pages/LoginPage.tsx 2>&1 | tail -20
+```
+
+Expected: typecheck 零 error；`api.ts` 与 `LoginPage.tsx` 的 unsafe-* 条目大幅下降。
+
+- [ ] **Step 3.6: 更新 `--max-warnings` 数字**
+
+```bash
+cd frontend && pnpm lint 2>&1 | tail -1
+```
+
+把 `package.json` 的 `--max-warnings` 调到新值。
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add frontend/src/api.ts frontend/package.json
+git commit -m "refactor(frontend): type API responses to eliminate any propagation
+
+LoginResponse / TaskStats / etc. mirror the backend Pydantic models.
+Downstream unsafe-* warnings in LoginPage / useTasksSSE drop from
+~20 to near zero after this change.
+
+Refs #219"
+```
+
+---
+
+## Task 4: 类型源头 — SSE hooks
+
+**Files:**
+- Modify: `frontend/src/hooks/useTasksSSE.ts`
+- Modify: `frontend/src/hooks/useProjectEventsSSE.ts`
+
+- [ ] **Step 4.1: 给 `useTasksSSE.ts` 加 payload 类型**
+
+在文件顶部（或相邻 types 区）新增：
+
+```ts
+interface TaskStatsEvent {
+  type: "stats";
+  stats: TaskStats;
+}
+
+type TaskEvent = TaskStatsEvent;
+
+function isTaskStatsEvent(v: unknown): v is TaskStatsEvent {
+  return typeof v === "object" && v !== null && (v as { type?: unknown }).type === "stats";
+}
+```
+
+把 `EventSource` 回调中 `JSON.parse(e.data) as any` 改为：
+
+```ts
+const raw: unknown = JSON.parse(e.data);
+if (isTaskStatsEvent(raw)) {
+  setTaskStats(raw.stats);
+}
+```
+
+- [ ] **Step 4.2: 给 `useProjectEventsSSE.ts` 加 payload 类型**
+
+定义 discriminated union：
+
+```ts
+type ProjectEvent =
+  | { type: "project_updated"; project_name: string }
+  | { type: "task_status"; task_id: string; status: string };
+  // ... 根据代码里实际处理的 event type 补齐
+```
+
+添加对应 type guard，按 `type` 字段窄化。
+
+- [ ] **Step 4.3: 处理 useProjectEventsSSE.ts:330 的 exhaustive-deps**
+
+阅读代码判断 `setLocation` 是否能安全加入依赖：
+- 如 `setLocation` 引用稳定（wouter 保证），加依赖（零成本）
+- 如加依赖会触发 SSE 重连，保留不变 + 添加：
+
+```ts
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- setLocation 引用由 wouter 保证稳定，加依赖会导致 SSE 重连
+```
+
+同时处理 `useProjectEventsSSE.ts:175` 的 `no-unsafe-finally`：把 `finally` 块里的 `return` 挪到 `try` 尾部或 `catch` 末端。
+
+- [ ] **Step 4.4: 运行 typecheck 与 lint**
+
+```bash
+cd frontend && pnpm typecheck && pnpm lint src/hooks/useTasksSSE.ts src/hooks/useProjectEventsSSE.ts 2>&1 | tail -20
+```
+
+Expected: 两文件 warning 清零（含其中的 `no-floating-promises` 如可用 `voidCall` 立即修）。
+
+- [ ] **Step 4.5: 更新 `--max-warnings` 并 commit**
+
+```bash
+cd frontend && pnpm lint 2>&1 | tail -1
+```
+
+调 `--max-warnings`，commit：
+
+```bash
+git add frontend/src/hooks/useTasksSSE.ts frontend/src/hooks/useProjectEventsSSE.ts frontend/package.json
+git commit -m "refactor(frontend): type SSE event payloads with discriminated unions
+
+Runtime type guards replace JSON.parse + any coercion. Fixes
+no-unsafe-* cluster on useTasksSSE / useProjectEventsSSE and
+addresses no-unsafe-finally in the latter.
+
+Refs #219"
+```
+
+---
+
+## Task 5: Promise 处理替换（voidPromise / voidCall 应用）
+
+**Files:**
+- Modify: 所有命中 `no-misused-promises` / `no-floating-promises` 的文件（约 15-20 个）
+
+- [ ] **Step 5.1: 枚举命中文件**
+
+```bash
+cd frontend && pnpm lint 2>&1 | grep -B1 -E "no-misused-promises|no-floating-promises" | grep "^/" | sort -u | sed 's|.*/frontend/||'
+```
+
+记下文件清单。
+
+- [ ] **Step 5.2: 批量修复 `onClick={async ...}` 模式**
+
+对每个命中文件，将：
+
+```tsx
+<button onClick={async () => { await save(); }}>Save</button>
+```
+
+改为（加 import）：
+
+```tsx
+import { voidPromise } from "@/utils/async";
+// ...
+<button onClick={voidPromise(async () => { await save(); })}>Save</button>
+```
+
+或如已有单独的 `handleSave` 函数返回 Promise：
+
+```tsx
+<button onClick={voidPromise(handleSave)}>Save</button>
+```
+
+**具体起点文件**（LoginPage.tsx:58 是典型）：
+
+```diff
+- <form onSubmit={handleSubmit}>
++ <form onSubmit={voidPromise(handleSubmit)}>
+```
+
+- [ ] **Step 5.3: 修 fire-and-forget 调用**
+
+```tsx
+// 之前
+fetchData();
+
+// 之后
+import { voidCall } from "@/utils/async";
+voidCall(fetchData());
+```
+
+**具体文件**：
+- `frontend/src/i18n/index.ts:31` — `voidCall(i18n.init())`
+- `frontend/src/test/setup.ts:6` — 按实际代码判断
+- SSE onmessage = async 类：改外壳 `es.onmessage = (e) => voidCall(handleMessage(e))`
+
+- [ ] **Step 5.4: 处理 `require-await` (1 条)**
+
+定位：`pnpm lint 2>&1 | grep -B3 require-await`
+
+按行判断：如函数体确无 await，删 `async` 关键字；如预期异步（future-proof），加：
+```ts
+  // eslint-disable-next-line @typescript-eslint/require-await -- 签名对齐 X 接口，当前实现同步但预留异步扩展
+```
+
+- [ ] **Step 5.5: 运行 typecheck + lint 验证**
+
+```bash
+cd frontend && pnpm typecheck && pnpm lint 2>&1 | tail -1
+```
+
+Expected: warning 数降 ~54 条（37 misused + 16 floating + 1 require-await）。
+
+- [ ] **Step 5.6: 更新 `--max-warnings` 并 commit**
+
+```bash
+git add -A frontend/
+git commit -m "refactor(frontend): wrap Promise-returning handlers with voidPromise/voidCall
+
+Replaces onClick={async ...} and fire-and-forget calls across
+~15 files. Default error path is console.error; UI-layer toast
+routing left for future when notification infra is consolidated.
+
+Refs #219"
+```
+
+---
+
+## Task 6: 冗余断言 + 未使用变量（机械清理）
+
+**Files:**
+- Modify: 命中 `no-unnecessary-type-assertion` / `no-unused-vars` / `no-redundant-type-constituents` 的文件
+
+- [ ] **Step 6.1: 尝试自动修复**
+
+```bash
+cd frontend && pnpm lint:fix 2>&1 | tail -5
+```
+
+记录 auto-fix 消除的 warning 数。
+
+- [ ] **Step 6.2: 手动处理剩余 `no-unnecessary-type-assertion`**
+
+```bash
+cd frontend && pnpm lint 2>&1 | grep -B3 no-unnecessary-type-assertion | head -30
+```
+
+定位每条，删除断言（如 `x as string` → `x`）。
+
+- [ ] **Step 6.3: 手动处理 `no-unused-vars` (5 条)**
+
+```bash
+cd frontend && pnpm lint 2>&1 | grep -B3 no-unused-vars
+```
+
+删除未使用的 import / 变量。如是预期的 `_unused` 参数，改名前缀 `_`。
+
+- [ ] **Step 6.4: 手动处理 `no-redundant-type-constituents` (2 条)**
+
+```bash
+cd frontend && pnpm lint 2>&1 | grep -B3 no-redundant-type-constituents
+```
+
+删除冗余联合类型成员。
+
+- [ ] **Step 6.5: 运行 typecheck + lint + 更新 max-warnings + commit**
+
+```bash
+cd frontend && pnpm typecheck && pnpm lint 2>&1 | tail -1
+```
+
+Expected: warning 数降 24 条（17 + 5 + 2）。
+
+```bash
+git add -A frontend/
+git commit -m "chore(frontend): remove redundant type assertions and unused vars
+
+Mechanical cleanup of no-unnecessary-type-assertion,
+no-redundant-type-constituents, and no-unused-vars hits.
+
+Refs #219"
+```
+
+---
+
+## Task 7: React Hooks — set-state-in-effect (18 条)
+
+**Files:**
+- Modify: 命中 `react-hooks/set-state-in-effect` 的文件
+
+- [ ] **Step 7.1: 枚举并分类命中点**
+
+```bash
+cd frontend && pnpm lint 2>&1 | grep -B3 set-state-in-effect | head -60
+```
+
+对每条记录：文件:行 + 模式判断（派生态 / 同步副本 / mount-only）。
+
+- [ ] **Step 7.2: 按模式逐个修复**
+
+**派生态改 useMemo：**
+
+```tsx
+// 之前
+useEffect(() => { setSortedList(list.sort()); }, [list]);
+
+// 之后
+const sortedList = useMemo(() => list.sort(), [list]);
+```
+
+**同步受控副本改 key+useState 或 disable：**
+
+```tsx
+// 如是独立本地编辑副本，用 key 重置
+<EditForm key={data.id} initialData={data} />
+
+// 如必须保留 effect 同步，加 disable：
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- 表单必须跟随 props 同步，拷贝模式是有意设计
+```
+
+**Mount-only 信号：**
+
+```tsx
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- mount 时初始化一次 ready 标志，不是派生态
+```
+
+- [ ] **Step 7.3: 硬约束检查**
+
+每处修复 diff ≤10 行。超出的标 TODO：
+
+```tsx
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- TODO(a11y-pr3): 此组件 state 模型需独立重构（见 issue #XXX）
+```
+
+**上限 3 条 TODO**；如超过，回到本 Task 重新规划或拆独立工单。
+
+- [ ] **Step 7.4: 运行 typecheck + 测试**
+
+```bash
+cd frontend && pnpm typecheck && pnpm test
+```
+
+Expected: 零 error；测试全过。
+
+- [ ] **Step 7.5: 记录 disable 表**
+
+在一个临时文件 `frontend/.pr3-disables.md`（稍后手动合入 PR 描述）追加：
+
+```markdown
+## set-state-in-effect
+| file:line | 理由 |
+|---|---|
+| src/components/.../X.tsx:YY | 表单拷贝必须跟随 props |
+```
+
+- [ ] **Step 7.6: 更新 `--max-warnings` 并 commit**
+
+```bash
+cd frontend && pnpm lint 2>&1 | tail -1
+```
+
+```bash
+git add -A frontend/
+git commit -m "refactor(frontend): resolve react-hooks/set-state-in-effect warnings
+
+18 hits: derived state moved to useMemo; controlled-copy patterns
+kept with documented disable + reason; mount-only signals disabled
+with rationale. See PR body for full disable table.
+
+Refs #219"
+```
+
+---
+
+## Task 8: React Hooks — exhaustive-deps (17 条)
+
+**Files:**
+- Modify: 命中 `react-hooks/exhaustive-deps` 的文件（`useProjectEventsSSE.ts:330` 已在 Task 4 处理）
+
+- [ ] **Step 8.1: 枚举并逐条判断**
+
+```bash
+cd frontend && pnpm lint 2>&1 | grep -B3 exhaustive-deps | head -60
+```
+
+对每条判断：
+- 缺稳定 setter（React / wouter）→ 加依赖
+- Mount-only → disable + 理由
+- 真 bug（漏的 state 会导致陈旧闭包）→ 加依赖
+
+- [ ] **Step 8.2: 批量修复**
+
+**加依赖（默认选项，安全）：**
+
+```diff
+-  }, [prop]);
++  }, [prop, setState]);
+```
+
+**Mount-only disable：**
+
+```ts
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only 初始化，刻意不追随 X 变化
+```
+
+- [ ] **Step 8.3: 浏览器冒烟：SSE + 路由关键流**
+
+启动 `pnpm dev`，验证：
+- 任务卡片状态流（TaskHud）实时更新
+- 项目事件流（打开一个项目后修改，同步到 UI）
+- 路由切换（wouter `setLocation`）
+
+- [ ] **Step 8.4: 更新 disable 表 + `--max-warnings` + commit**
+
+```bash
+git add -A frontend/
+git commit -m "refactor(frontend): resolve react-hooks/exhaustive-deps warnings
+
+17 hits: most fixed by adding stable setters to dep arrays;
+mount-only effects explicitly disabled with rationale.
+Verified SSE streams and routing still behave correctly.
+
+Refs #219"
+```
+
+---
+
+## Task 9: React Hooks — refs + incompatible-library (7 条)
+
+**Files:**
+- Modify: 命中 `react-hooks/refs` / `react-hooks/incompatible-library` 的文件
+
+- [ ] **Step 9.1: 定位命中点**
+
+```bash
+cd frontend && pnpm lint 2>&1 | grep -B3 -E "react-hooks/refs|react-hooks/incompatible-library"
+```
+
+- [ ] **Step 9.2: 修 refs (6 条)**
+
+将 render 阶段的 `ref.current` 访问搬到：
+- `useEffect(() => { ref.current?.doSomething(); }, [deps])`
+- 事件回调
+- 或改用 callback ref
+
+- [ ] **Step 9.3: 修 incompatible-library (1 条)**
+
+逐行阅读，理解 hook 冲突原因。能修则修（通常是包装在 useEffect 里）；确实不兼容则 disable + 理由。
+
+- [ ] **Step 9.4: typecheck + lint + commit**
+
+```bash
+cd frontend && pnpm typecheck && pnpm lint 2>&1 | tail -1
+git add -A frontend/
+git commit -m "refactor(frontend): fix react-hooks/refs and incompatible-library
+
+Move render-time ref.current access into effects or callback refs.
+
+Refs #219"
+```
+
+---
+
+## Task 10: a11y — `<div onClick>` 家族 (9 条)
+
+**Files:**
+- Modify: 命中 `no-static-element-interactions` / `click-events-have-key-events` / `no-noninteractive-element-interactions` 的文件
+
+- [ ] **Step 10.1: 枚举命中点**
+
+```bash
+cd frontend && pnpm lint 2>&1 | grep -B3 -E "no-static-element-interactions|click-events-have-key-events|no-noninteractive-element-interactions"
+```
+
+- [ ] **Step 10.2: 逐处判断并修复**
+
+对每处，先判断能否换 `<button>`：
+- ✅ 可换：无嵌套交互、独立的点击块
+- ❌ 不可换：含嵌套按钮、表格行、list item 等
+
+**可换为 button：**
+
+```diff
+- <div className="cursor-pointer ..." onClick={handleClick}>
++ <button
++   type="button"
++   className="cursor-pointer appearance-none bg-transparent p-0 text-left ..."
++   onClick={handleClick}
++ >
+    {children}
+- </div>
++ </button>
+```
+
+**保留 div，加三件套：**
+
+```diff
++ import { activateOnEnterSpace } from "@/utils/a11y";
+  <div
++   role="button"
++   tabIndex={0}
+    onClick={handleClick}
++   onKeyDown={activateOnEnterSpace(handleClick)}
+  >
+```
+
+- [ ] **Step 10.3: 浏览器冒烟：键盘导航**
+
+启动 `pnpm dev`，对修改的交互元素用 Tab 导航 + Enter/Space 触发，确认可访问性工作。
+
+- [ ] **Step 10.4: typecheck + lint + commit**
+
+```bash
+cd frontend && pnpm typecheck && pnpm lint 2>&1 | tail -1
+git add -A frontend/
+git commit -m "fix(frontend-a11y): make div onClick elements keyboard-accessible
+
+Converts static div onClick to button where possible; otherwise
+adds role/tabIndex/onKeyDown via activateOnEnterSpace helper.
+
+Refs #219"
+```
+
+---
+
+## Task 11: a11y — autoFocus → useAutoFocus (5 条)
+
+**Files:**
+- Modify: 5 个含 `autoFocus` prop 的文件
+
+- [ ] **Step 11.1: 枚举命中点**
+
+```bash
+cd frontend && pnpm lint 2>&1 | grep -B3 no-autofocus
+```
+
+- [ ] **Step 11.2: 替换模式**
+
+```diff
++ import { useAutoFocus } from "@/hooks/useAutoFocus";
+
+  export function LoginPage() {
++   const usernameRef = useAutoFocus<HTMLInputElement>();
+    // ...
+-   <input autoFocus type="text" ... />
++   <input ref={usernameRef} type="text" ... />
+```
+
+注意：
+- 如原 `autoFocus` 只在某条件下生效（如弹窗打开时），传 `enabled` 参数：`useAutoFocus<HTMLInputElement>(isOpen)`
+- 如元素已有 ref，用 `useAutoFocus` 返回的 ref 合并或改 `useCallback ref`
+
+- [ ] **Step 11.3: 浏览器冒烟**
+
+启动 `pnpm dev`，打开登录页和其他原本有 autoFocus 的弹窗/表单，确认焦点仍落在预期元素。
+
+- [ ] **Step 11.4: typecheck + lint + commit**
+
+```bash
+cd frontend && pnpm typecheck && pnpm lint 2>&1 | tail -1
+git add -A frontend/
+git commit -m "fix(frontend-a11y): replace autoFocus prop with useAutoFocus hook
+
+Removes 5 autoFocus props that jsx-a11y flags for accessibility
+regression. UX preserved via programmatic .focus() in useEffect.
+
+Refs #219"
+```
+
+---
+
+## Task 12: a11y — media-has-caption (2 条)
+
+**Files:**
+- Modify: 2 个含 `<video>` / `<audio>` 的文件
+
+- [ ] **Step 12.1: 定位**
+
+```bash
+cd frontend && pnpm lint 2>&1 | grep -B3 media-has-caption
+```
+
+- [ ] **Step 12.2: 加 disable + 理由**
+
+对每处：
+
+```tsx
+{/* eslint-disable-next-line jsx-a11y/media-has-caption -- 生成式预览视频暂无字幕源，将来如引入字幕生成则移除此 disable */}
+<video src={videoUrl} controls />
+```
+
+- [ ] **Step 12.3: 记录 disable 表 + commit**
+
+在 `.pr3-disables.md` 追加 media-has-caption 节。
+
+```bash
+cd frontend && pnpm lint 2>&1 | tail -1
+git add -A frontend/
+git commit -m "fix(frontend-a11y): disable media-has-caption for generative previews
+
+Preview videos have no caption source. Disable is documented
+inline with rationale for future reversal.
+
+Refs #219"
+```
+
+---
+
+## Task 13: 收尾 — flip to error + 清空 migration + 移除 ratchet
+
+**Files:**
+- Modify: `frontend/eslint.config.js`
+- Modify: `frontend/package.json`
+- Modify: `CONTRIBUTING.md`
+
+- [ ] **Step 13.1: 验证前置 — warning 数已为 0**
+
+```bash
+cd frontend && pnpm lint 2>&1 | tail -1
+```
+
+Expected: `0 problems (0 errors, 0 warnings)` 或极少数（如不为 0 则回到对应 Task 补完）。
+
+- [ ] **Step 13.2: 删除 migration 常量与展开块**
+
+编辑 `frontend/eslint.config.js`：
+- 删除 `MIGRATION_WARN_RULES_TYPED` 常量定义
+- 删除 `MIGRATION_WARN_RULES_A11Y` 常量定义
+- 删除 `MIGRATION_WARN_RULES_ALL` 常量定义
+- 删除 config 数组中 `rules: { ...MIGRATION_WARN_RULES_* }` 的对应 block
+- 删除顶部「PR 2 / PR 3 操作指引」段落注释
+
+- [ ] **Step 13.3: 新增严格化 override**
+
+在 `eslint.config.js` 最后（ignores 和 test override 之后）新增：
+
+```js
+  // 本项目严于 recommended：exhaustive-deps / incompatible-library 一律视为 error
+  {
+    rules: {
+      "react-hooks/exhaustive-deps": "error",
+      "react-hooks/incompatible-library": "error",
+    },
+  },
+```
+
+- [ ] **Step 13.4: 移除 `--max-warnings`**
+
+编辑 `frontend/package.json`：
+
+```diff
+- "lint": "eslint . --max-warnings=0",
++ "lint": "eslint .",
+```
+
+- [ ] **Step 13.5: 运行最终 lint — 期望 0 errors 0 warnings**
+
+```bash
+cd frontend && pnpm lint
+echo "exit code: $?"
+```
+
+Expected: `0 problems`，exit 0。如有 error，修复后再继续。
+
+- [ ] **Step 13.6: 更新 CONTRIBUTING.md**
+
+在 `CONTRIBUTING.md` 前端章节（「代码质量」或新建「前端 lint」小节）追加：
+
+```markdown
+### ESLint disable 使用规范
+
+本项目在 PR 3（#219）后采用零 warning 政策，所有规则均为 error。如必须绕过，遵循：
+
+- **形式**：`// eslint-disable-next-line <rule> -- <中文理由>`，`--` 后的理由**强制**
+- **禁用**：文件级 `/* eslint-disable */`、无理由的 `// eslint-disable-line`、`@ts-ignore` 联用
+- **PR 描述要求**：新增的 disable 必须在 PR body 以表格列出 `rule | file:line | 理由`
+- **文件级关闭**只允许通过 `eslint.config.js` 的 `files` override，且须在 config 注释说明原因
+- **不可接受的理由**：「太麻烦」「暂时这样」「later fix」
+- **可接受的理由示例**：「React setter 引用稳定」「mount-only 初始化」「生成式预览视频无字幕源」
+```
+
+- [ ] **Step 13.7: Commit**
+
+```bash
+git add frontend/eslint.config.js frontend/package.json CONTRIBUTING.md
+git commit -m "chore(frontend): flip all ESLint rules to error, remove ratchet
+
+- Drop MIGRATION_WARN_RULES_TYPED / _A11Y / _ALL constants
+- Elevate react-hooks/exhaustive-deps and incompatible-library
+  to error (project is stricter than recommended)
+- Remove --max-warnings from lint script
+- Document disable-comment policy in CONTRIBUTING.md
+
+Closes the PR 3 series of #219."
+```
+
+---
+
+## Task 14: 全流程验证 + 清理
+
+**Files:** 无新增
+
+- [ ] **Step 14.1: 跑完整 frontend 流水**
+
+```bash
+cd frontend && pnpm typecheck && pnpm lint && pnpm test && pnpm build
+```
+
+Expected: 全部 0 error / 0 warning / 测试通过 / build 成功。
+
+- [ ] **Step 14.2: 跑后端测试（确保未误触碰）**
+
+```bash
+uv run python -m pytest -x 2>&1 | tail -20
+```
+
+Expected: 全过（本 PR 不改后端，应无影响）。
+
+- [ ] **Step 14.3: 浏览器最终回归**
+
+启动 `pnpm dev`，过一遍：
+- 登录（autoFocus 工作、登录成功跳转）
+- 任务 HUD（SSE 状态流）
+- 项目事件（修改项目名 → UI 同步）
+- 至少一个代表性的 `<div onClick>` 改 `<button>` 的交互
+- 键盘导航：Tab + Enter 能触发被改造的交互元素
+
+- [ ] **Step 14.4: 合成 PR 描述 disable 表**
+
+把 Task 7/8/9/12 累积的 `.pr3-disables.md` 汇总成最终 PR 描述中的表格，格式：
+
+```markdown
+## 新增 eslint-disable 清单
+
+| rule | file:line | 理由 |
+|---|---|---|
+| react-hooks/set-state-in-effect | src/.../X.tsx:YY | ... |
+| react-hooks/exhaustive-deps | src/hooks/useProjectEventsSSE.ts:330 | setLocation 引用稳定，加依赖会导致 SSE 重连 |
+| jsx-a11y/media-has-caption | src/.../Video.tsx:NN | 生成式预览视频暂无字幕源 |
+```
+
+删除临时文件 `frontend/.pr3-disables.md`（别 commit 它）。
+
+- [ ] **Step 14.5: 推送并开 PR**
+
+```bash
+git push -u origin fix/a11y-eslint-cleanup-293
+```
+
+用 `gh pr create` 开 PR，title `chore(frontend): clean up remaining ESLint warnings and flip rules to error`，body 包含：
+- Summary（链 #219 issue + PR 1 #290 + PR 2 #292）
+- 改动要点（6 类 warning 清零 + migration 清空 + strict override）
+- **disable 清单表格**（Step 14.4 的输出）
+- Test plan checklist（typecheck / lint / test / build / 手动回归）
+
+---
+
+## Self-Review 结果
+
+对照 spec 各节：
+- ✅ 类型源头改造 → Task 3 + Task 4
+- ✅ voidPromise helper → Task 1 + Task 5
+- ✅ React Hooks 语义逐条判断 → Task 7 / 8 / 9
+- ✅ a11y 三类修复 → Task 10 / 11 / 12
+- ✅ 测试文件 override → Task 2
+- ✅ 未入账规则严格化 → Task 13
+- ✅ 清空 migration + 移除 `--max-warnings` → Task 13
+- ✅ `eslint-disable-*` 规范写入 CONTRIBUTING → Task 13
+- ✅ PR 描述 disable 表格 → Task 14.4
+- ✅ 验证流程（typecheck/lint/test/build/浏览器） → Task 14
+- ✅ 风险缓解（rebase / typecheck 每步 / 手动回归 / TODO 上限 3） → 分布在 Task 3、7、8 中
+
+无 placeholder；类型与方法签名在各 Task 间一致（`voidPromise` / `voidCall` / `useAutoFocus` / `activateOnEnterSpace` 四个 API 签名从 Task 1 贯穿到 Task 5/10/11）。

--- a/docs/superpowers/specs/2026-04-14-eslint-a11y-pr3-design.md
+++ b/docs/superpowers/specs/2026-04-14-eslint-a11y-pr3-design.md
@@ -1,0 +1,338 @@
+# 前端 ESLint + jsx-a11y 扫尾（PR 3）
+
+- **日期**：2026-04-14
+- **对应 Issue**：#219 (a11y audit)
+- **PR 标题**（建议）：`chore(frontend): clean up remaining ESLint warnings and flip rules to error`
+- **作者**：Pollo
+
+## 背景
+
+PR 1 (#290) 建立了前端 ESLint + jsx-a11y 基础设施，使用 `--max-warnings=212` ratchet 与三个 `MIGRATION_WARN_RULES_*` 常量把既有违规固化为 warning。PR 2 (#292) 正在修复 focus-ring / textarea label / progressbar ARIA / file input aria-label 四类主题问题，warning 数维持在 211 左右。
+
+本 PR（PR 3）是该系列的收尾：**把剩余所有 warning 清零，把所有 rule flip 到 error，移除 `--max-warnings` 参数**。
+
+### 实测 warning 分布（211 tracked + 18 未入账 = 229 条）
+
+| 类别 | 规则 | 数量 |
+|---|---|---|
+| **Typed (151)** | no-misused-promises | 37 |
+| | no-unsafe-member-access | 26 |
+| | no-unnecessary-type-assertion | 17 |
+| | no-unsafe-assignment | 16 |
+| | no-floating-promises | 16 |
+| | no-unsafe-return | 12 |
+| | no-unsafe-argument | 8 |
+| | no-unsafe-call | 5 |
+| | no-redundant-type-constituents | 2 |
+| | require-await | 1 |
+| **ALL / React-Hooks (40)** | react-hooks/set-state-in-effect | 18 |
+| | react-hooks/exhaustive-deps ⚠️ | 17 |
+| | no-explicit-any | 9 |
+| | react-hooks/refs | 6 |
+| | no-unused-vars | 5 |
+| | no-unsafe-finally | 1 |
+| | react-hooks/incompatible-library ⚠️ | 1 |
+| **A11y (16)** | no-static-element-interactions | 5 |
+| | no-autofocus | 5 |
+| | click-events-have-key-events | 3 |
+| | media-has-caption | 2 |
+| | no-noninteractive-element-interactions | 1 |
+
+⚠️ 标记的两条（`react-hooks/exhaustive-deps`、`react-hooks/incompatible-library`）**不在** PR 1 填充的任何 `MIGRATION_WARN_RULES_*` 中，是 PR 1 dry-run 的覆盖盲区，需本 PR 一并处理。
+
+## 范围
+
+### PR 3 做的事（Do）
+
+1. **类型源头加类型**：从 API client（`api/auth.ts`、`api/tasks.ts` 等）、SSE payload（`useTasksSSE.ts`、`useProjectEventsSSE.ts`）、i18n 等源头一次性加类型，消除 `any` 向下游扩散
+2. **新增 `frontend/src/utils/async.ts`** 导出 `voidPromise(fn, onError?)` 和 `voidCall(promise, onError?)` helper，统一替换 `onClick={async ...}` 和 fire-and-forget 调用
+3. **React Hooks 42 条**按"真 bug 按规则修 / 有意为之加 `// eslint-disable-next-line X -- <中文理由>`"两条路径逐条处理
+4. **a11y 16 条**：`<div onClick>` 家族优先换 `<button>`、否则用 `activateOnEnterSpace` helper 三件套；`autoFocus` 全删改用 `useAutoFocus` hook；`media-has-caption` 对生成预览视频加 disable + 理由
+5. **测试文件 override**：`src/**/*.test.{ts,tsx}` 和 `src/test/**` 整体关闭 `no-explicit-any` 与 6 条 `no-unsafe-*`
+6. **未入账规则严格化**：config 末尾显式 `"error"` 设置 `react-hooks/exhaustive-deps` + `react-hooks/incompatible-library`
+7. **清空 migration 基础设施**：删除 `MIGRATION_WARN_RULES_TYPED` / `MIGRATION_WARN_RULES_A11Y` / `MIGRATION_WARN_RULES_ALL` 三个常量定义和展开 block；删除 PR 2/3 操作指引注释
+8. **移除 ratchet**：`package.json` 的 `lint` script 去掉 `--max-warnings=212`
+9. **文档**：`CONTRIBUTING.md` 新增「ESLint disable 使用规范」小节
+10. **PR 描述**：列出所有新增 `eslint-disable-*` 的表格（rule × file:line × 理由）
+
+### PR 3 不做的事（Don't）
+
+- ❌ React Hooks 语义之外的重构（即便顺手）—— 单处修复超 10 行改动改走 disable + TODO，超出 3 条则拆独立工单
+- ❌ 改 i18n 文案、UI 样式（除非 a11y 修复必须）
+- ❌ 调 ESLint 工具链版本（留独立工单）
+- ❌ 引入新的 notification/toast 基建 —— `voidPromise` 默认只用 `console.error`，`onError` 参数为未来升级预留
+
+### 依赖顺序
+
+PR 2 (#292) merge 后 rebase 本 PR → 基于 rebase 后的实际 warning 清单重算改动 → 清零 → 移除 ratchet。如 PR 2 已修复的条目在本 PR 基底中不存在，直接跳过。
+
+## 技术决策
+
+### 1. 类型源头改造（对应 unsafe-* 86 + no-explicit-any 9 + 冗余断言 20 = ~115 条）
+
+**策略**：从 3 个 `any` 源头一次性加类型，下游 `unsafe-*` 报警自愈。
+
+**目标文件 + 类型定义**：
+
+**`frontend/src/api/auth.ts`**
+
+```ts
+interface LoginResponse { access_token: string; token_type: string }
+interface ErrorResponse { detail: string }
+
+export async function login(...): Promise<LoginResponse> { ... }
+```
+
+错误分支用 type guard 窄化 `catch (e: unknown)` 读 `detail`。自愈 `LoginPage.tsx:36/37/40/41` 的 6 条 unsafe-*。
+
+**`frontend/src/api/tasks.ts` + `useTasksSSE.ts`**
+
+```ts
+interface TaskEvent { type: "stats"; stats: TaskStats }
+// 解析：JSON.parse(e.data) as TaskEvent + runtime type guard（校验 type 字段）
+```
+
+自愈 `useTasksSSE.ts:33-34` 的 4 条 unsafe-*。
+
+**`frontend/src/hooks/useProjectEventsSSE.ts`**
+
+```ts
+type ProjectEvent =
+  | { type: "project_updated"; project_name: string }
+  | { type: "task_status"; task_id: string; status: string }
+  | ...;
+```
+
+按 `type` 字段做 discriminated union 窄化。
+
+**`api/` 其他 `any` 消除**：逐文件搜 `: any` / `as any` / 未类型化 `JSON.parse`，对照 `server/routers/*` 的 Pydantic response model 镜像前端 interface（不引入共享 schema 生成器）。
+
+**`no-unnecessary-type-assertion` (17 条)**：源头加类型后断言自然冗余，删除；少量 `as const` 保留。
+
+**`no-redundant-type-constituents` (2 条) / `require-await` (1 条)**：按行判断。
+
+### 2. 测试文件 override
+
+`eslint.config.js` 新增：
+
+```js
+{
+  files: ["src/**/*.test.{ts,tsx}", "src/test/**/*.{ts,tsx}"],
+  rules: {
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-unsafe-assignment": "off",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-argument": "off",
+    "@typescript-eslint/no-unsafe-call": "off",
+    "@typescript-eslint/no-unsafe-return": "off",
+  },
+}
+```
+
+覆盖 `stores.test.ts`、`useTasksSSE.test.tsx`、`src/test/setup.ts` 等测试层 `any`。
+
+### 3. Promise 处理 helper（对应 ~54 条）
+
+**新增 `frontend/src/utils/async.ts`**：
+
+```ts
+type VoidPromiseOptions = {
+  onError?: (err: unknown) => void;
+};
+
+export function voidPromise<Args extends unknown[]>(
+  fn: (...args: Args) => Promise<unknown>,
+  opts?: VoidPromiseOptions,
+): (...args: Args) => void {
+  return (...args) => {
+    fn(...args).catch((err: unknown) => {
+      if (opts?.onError) opts.onError(err);
+      else console.error(err);
+    });
+  };
+}
+
+export function voidCall<T>(
+  promise: Promise<T>,
+  onError: (err: unknown) => void = console.error,
+): void {
+  promise.catch(onError);
+}
+```
+
+**使用模式**：
+
+| 场景 | 当前写法 | 目标写法 |
+|---|---|---|
+| onClick 绑 async | `onClick={async () => { await save() }}` | `onClick={voidPromise(save)}` |
+| fire-and-forget | `fetchData()` 裸调用 | `voidCall(fetchData())` |
+| 顶层初始化 | `i18n.init()` | `voidCall(i18n.init())` |
+| SSE onmessage | `es.onmessage = async (e) => {...}` | `es.onmessage = (e) => voidCall(handleMessage(e))` |
+
+**单元测试**：`frontend/src/utils/async.test.ts` 覆盖 4 条路径（正常调用、默认 onError、自定义 onError、参数透传）。
+
+### 4. React Hooks 语义（对应 42 条，加杂项 6 条 = 48 条）
+
+**原则**：逐条判断，能按规则修的按规则修，有意为之用 `// eslint-disable-next-line <rule> -- <中文理由>`。目标 disable 比例 ≤60%。
+
+**`react-hooks/set-state-in-effect` (18 条)** — 模式判断：
+
+| 常见模式 | 动作 |
+|---|---|
+| 派生态 `useEffect(() => setFoo(derive(p)), [p])` | 改 `useMemo` |
+| 同步受控态副本（`if (data) setLocalCopy(data)`） | 改 `key={data.id}` + 初始化 `useState(data)`；若必须同步，disable + 理由 |
+| Mount-only 初始化信号 | 如确为 mount signal，disable + 理由 |
+
+**`react-hooks/exhaustive-deps` (17 条)** — 模式判断：
+
+| 常见模式 | 动作 |
+|---|---|
+| 缺稳定 setter（React `setX` / wouter `setLocation`） | 优先加依赖（零成本）；若加依赖触发重订阅，disable + 理由 |
+| Mount-only effect 故意漏依赖 | disable + 理由"mount-only 初始化，刻意不追随 X 变化" |
+
+**`react-hooks/refs` (6 条)** — render 阶段访问 `ref.current` 移到 useEffect 或事件回调。
+
+**`react-hooks/incompatible-library` (1 条)** — case-by-case。
+
+**硬约束**：单处修复超过 10 行改动时，改走 disable + `// TODO(a11y-pr3): 后续重构` 注释，并在 PR body 特别列出，上限 3 条；超出则拆独立工单。
+
+**`no-unsafe-finally` (1)** + **`no-unused-vars` (5)**：单点机械修复，`no-unsafe-finally` 定位 `useProjectEventsSSE.ts:175`。
+
+### 5. a11y 扫尾（对应 16 条）
+
+**`<div onClick>` 家族 (9 条)**：
+
+- **可换 `<button>`**（无嵌套交互、无特殊 DOM 语义）→ 换为 `<button type="button" className="appearance-none bg-transparent p-0 text-left ...">` 保持视觉
+- **不能换**（含嵌套交互、语义是 row/list item）→ 加三件套 + 复用 helper
+
+**新增 `frontend/src/utils/a11y.ts`**：
+
+```ts
+export function activateOnEnterSpace(handler: () => void) {
+  return (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handler();
+    }
+  };
+}
+```
+
+调用点：`<div role="button" tabIndex={0} onClick={handler} onKeyDown={activateOnEnterSpace(handler)}>`。
+
+**`no-autofocus` (5 条)** — 新增 `frontend/src/hooks/useAutoFocus.ts`：
+
+```ts
+export function useAutoFocus<T extends HTMLElement>(enabled = true) {
+  const ref = useRef<T>(null);
+  useEffect(() => { if (enabled) ref.current?.focus(); }, [enabled]);
+  return ref;
+}
+```
+
+5 处 `autoFocus` 删 prop，改 `const inputRef = useAutoFocus<HTMLInputElement>(); <input ref={inputRef} />`。
+
+**`media-has-caption` (2 条)**：
+
+```tsx
+{/* eslint-disable-next-line jsx-a11y/media-has-caption -- 生成式预览视频暂无字幕源，将来如引入字幕生成则移除此 disable */}
+<video src={...} controls />
+```
+
+### 6. 未入账规则严格化
+
+`eslint.config.js` 末尾新增：
+
+```js
+// 本项目严于 recommended：exhaustive-deps / incompatible-library 一律视为 error
+{
+  rules: {
+    "react-hooks/exhaustive-deps": "error",
+    "react-hooks/incompatible-library": "error",
+  },
+},
+```
+
+### 7. `eslint-disable-*` 使用规范
+
+`CONTRIBUTING.md` 前端章节新增「ESLint disable 使用规范」：
+
+- 形式：`// eslint-disable-next-line <rule> -- <中文理由>`，**理由强制**
+- **禁用**：`/* eslint-disable */` 文件级、`// eslint-disable-line` 无理由、`@ts-ignore` 联用
+- **PR 描述要求**：新增的 disable 必须在 PR body 以表格列出 `rule | file:line | 理由`
+- **文件级关闭**只允许通过 `eslint.config.js` 的 `files` override，且须在 config 注释说明原因
+- 不可接受的理由：「太麻烦」「暂时这样」「later fix」
+- 可接受的理由示例：「React setter 引用稳定」「mount-only 初始化」「生成式预览视频无字幕源」
+
+## 最终 `eslint.config.js` 结构
+
+```js
+// 1. 全局 ignores
+// 2. js.configs.recommended
+// 3. tseslint.configs.recommendedTypeChecked
+// 4. react flat recommended + jsx-runtime
+// 5. react-hooks recommended
+// 6. jsx-a11y recommended
+// 7. src/** typed linting language options
+// 8. 测试文件 override（off no-explicit-any + 6 条 unsafe-*）
+// 9. 测试文件语言选项 override（沿用 PR 1）
+// 10. 严格化 override（exhaustive-deps + incompatible-library = error）
+```
+
+**删除**：`MIGRATION_WARN_RULES_*` 三个常量定义、`...MIGRATION_WARN_RULES_*` 展开的 rules block、PR 2/3 操作指引段注释。
+
+**`package.json` 变更**：
+
+```diff
+- "lint": "eslint . --max-warnings=212",
++ "lint": "eslint .",
+```
+
+`lint:fix` 保持不变。CI `.github/workflows/test.yml` 无需改动（命令未变，语义自动从"不超过 212"变成"零违规"）。
+
+## 交付物清单
+
+**新增文件**：
+- `frontend/src/utils/async.ts` + `async.test.ts`
+- `frontend/src/utils/a11y.ts`
+- `frontend/src/hooks/useAutoFocus.ts`
+
+**修改文件**（估 30-45 个）：
+- `frontend/eslint.config.js`
+- `frontend/package.json`
+- `frontend/src/api/auth.ts`、`api/tasks.ts` 等 API 源头
+- `frontend/src/hooks/useTasksSSE.ts`、`useProjectEventsSSE.ts`
+- `frontend/src/pages/LoginPage.tsx`
+- `frontend/src/i18n/index.ts`、`src/test/setup.ts`
+- 其余散落 onClick / set-state-in-effect / div onClick 命中文件
+- `CONTRIBUTING.md`
+
+## 验证流程
+
+1. `pnpm lint` 输出 `0 problems`
+2. `pnpm typecheck` 零 error
+3. `pnpm test` 现有测试全过 + 新增 `async.test.ts` 通过
+4. `pnpm build` 通过
+5. 浏览器手动验：登录页 autoFocus、代表性 onClick 交互、SSE 连接正常（任务卡片状态流、项目事件流）
+6. CI frontend-tests job green
+
+## 风险与缓解
+
+| 风险 | 影响 | 缓解 |
+|---|---|---|
+| PR 2 (#292) merge 延后导致 rebase 冲突扩大 | 中 | rebase 时全量重跑 `pnpm lint`，用实际清单校正；PR 2 已修条目直接跳过 |
+| 类型源头加类型引发下游 TS error 瀑布 | 中 | 每改完一个源头立即 `pnpm typecheck`；源头类型与后端 Pydantic 对齐 |
+| React Hooks 按规则修改变行为（如加依赖触发额外 effect） | 中-高 | 每处修复点 git commit 粒度细；不确定时优先 disable + 理由；浏览器手动跑 SSE、路由关键流 |
+| `voidPromise` 替换丢失原 async 错误 UI 反馈 | 低-中 | helper 默认 `console.error` 不静默；原代码多数 `async () =>` 本就吞错，替换后同等或更好 |
+| 新增 disable 过多被 review 拒 | 低 | 目标比例 ≤60%，超限则 hook 语义问题拆独立工单 |
+
+## 回滚策略
+
+- **纯规则回归**：revert `eslint.config.js` + `package.json` 即可（恢复 `--max-warnings=212` 和 migration 常量）
+- **代码回归**：Git revert 整个 merge commit
+
+## 交叉引用
+
+- PR 1 spec：`docs/superpowers/specs/2026-04-13-frontend-eslint-jsx-a11y-design.md`
+- PR 2 spec：`docs/superpowers/specs/2026-04-13-a11y-focus-ring-pr2-design.md`
+- Issue：#219

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -124,4 +124,17 @@ export default tseslint.config(
   },
   // 迁移期降级：不依赖 type info 的 rule，全局生效
   { rules: MIGRATION_WARN_RULES_ALL },
+
+  // 测试文件放宽 any 与 unsafe-* —— 测试环境允许 mock 便利
+  {
+    files: ["src/**/*.test.{ts,tsx}", "src/test/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+    },
+  },
 );

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -47,7 +47,12 @@ const MIGRATION_WARN_RULES_A11Y = {
 const MIGRATION_WARN_RULES_ALL = {
   // --- Task 3 dry-run 填充（2026-04-13）---
   "@typescript-eslint/no-explicit-any": "warn",
-  "@typescript-eslint/no-unused-vars": "warn",
+  "@typescript-eslint/no-unused-vars": ["warn", {
+    varsIgnorePattern: "^_",
+    argsIgnorePattern: "^_",
+    caughtErrorsIgnorePattern: "^_",
+    destructuredArrayIgnorePattern: "^_",
+  }],
   "no-unsafe-finally": "warn",
   "react-hooks/refs": "warn",
   "react-hooks/set-state-in-effect": "warn",

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,59 +5,6 @@ import reactHooks from "eslint-plugin-react-hooks";
 import jsxA11y from "eslint-plugin-jsx-a11y";
 import globals from "globals";
 
-// 迁移期 rule 降级清单 —— Task 3 通过 dry-run 填充。
-// PR 2 / PR 3 每修完一类就从对应常量里删掉条目，rule 自动升回 recommended 的 error 级。
-//
-// 三个常量作用域说明：
-//   MIGRATION_WARN_RULES_TYPED  —— 需要 type info 的 @typescript-eslint typed rules，
-//                                   只对 src/**（非 test）文件生效，避免与
-//                                   disableTypeChecked 冲突
-//   MIGRATION_WARN_RULES_A11Y   —— jsx-a11y rules，不作用于 test 文件
-//                                   （测试文件在下方 override 里整体 off，不应被 tail 覆回）
-//   MIGRATION_WARN_RULES_ALL    —— 其他非 typed 非 a11y rule，全局生效
-//
-// PR 2 / PR 3 操作指引：
-//   - 修完 @typescript-eslint typed 违规 → 从 MIGRATION_WARN_RULES_TYPED 删对应条目
-//   - 修完 jsx-a11y 违规              → 从 MIGRATION_WARN_RULES_A11Y 删对应条目
-//   - 修完其他违规                    → 从 MIGRATION_WARN_RULES_ALL 删对应条目
-const MIGRATION_WARN_RULES_TYPED = {
-  // --- Task 3 dry-run 填充（2026-04-13）---
-  "@typescript-eslint/no-floating-promises": "warn",
-  "@typescript-eslint/no-misused-promises": "warn",
-  "@typescript-eslint/no-redundant-type-constituents": "warn",
-  "@typescript-eslint/no-unnecessary-type-assertion": "warn",
-  "@typescript-eslint/no-unsafe-argument": "warn",
-  "@typescript-eslint/no-unsafe-assignment": "warn",
-  "@typescript-eslint/no-unsafe-call": "warn",
-  "@typescript-eslint/no-unsafe-member-access": "warn",
-  "@typescript-eslint/no-unsafe-return": "warn",
-  "@typescript-eslint/require-await": "warn",
-};
-
-// jsx-a11y 迁移清单 —— 不作用于 test 文件（测试文件在下方 override 里整体 off）
-// PR 2 / PR 3 修完 a11y 违规后，从这里删除对应条目，rule 自动升回 recommended 的 error。
-const MIGRATION_WARN_RULES_A11Y = {
-  "jsx-a11y/click-events-have-key-events": "warn",
-  "jsx-a11y/media-has-caption": "warn",
-  "jsx-a11y/no-autofocus": "warn",
-  "jsx-a11y/no-noninteractive-element-interactions": "warn",
-  "jsx-a11y/no-static-element-interactions": "warn",
-};
-
-const MIGRATION_WARN_RULES_ALL = {
-  // --- Task 3 dry-run 填充（2026-04-13）---
-  "@typescript-eslint/no-explicit-any": "warn",
-  "@typescript-eslint/no-unused-vars": ["warn", {
-    varsIgnorePattern: "^_",
-    argsIgnorePattern: "^_",
-    caughtErrorsIgnorePattern: "^_",
-    destructuredArrayIgnorePattern: "^_",
-  }],
-  "no-unsafe-finally": "warn",
-  "react-hooks/refs": "warn",
-  "react-hooks/set-state-in-effect": "warn",
-};
-
 export default tseslint.config(
   // 全局 ignores —— 覆盖 *.config.js 和 *.config.ts（vite.config.ts、vitest.config.ts）
   {
@@ -116,20 +63,6 @@ export default tseslint.config(
     ),
   },
 
-  // 迁移期降级：typed rules 仅对 src/**（非 test）文件生效，避免与 disableTypeChecked 冲突
-  {
-    files: ["src/**/*.{ts,tsx}"],
-    ignores: ["**/*.test.{ts,tsx}"],
-    rules: MIGRATION_WARN_RULES_TYPED,
-  },
-  // a11y 迁移降级，只作用于非 test 文件
-  {
-    ignores: ["**/*.test.{ts,tsx}"],
-    rules: MIGRATION_WARN_RULES_A11Y,
-  },
-  // 迁移期降级：不依赖 type info 的 rule，全局生效
-  { rules: MIGRATION_WARN_RULES_ALL },
-
   // 测试文件放宽 any 与 unsafe-* —— 测试环境允许 mock 便利
   {
     files: ["src/**/*.test.{ts,tsx}", "src/test/**/*.{ts,tsx}"],
@@ -140,6 +73,26 @@ export default tseslint.config(
       "@typescript-eslint/no-unsafe-argument": "off",
       "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-unsafe-return": "off",
+    },
+  },
+
+  // 项目惯例：_ 前缀变量/参数视为有意忽略，不报 unused-vars
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": ["error", {
+        varsIgnorePattern: "^_",
+        argsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+        destructuredArrayIgnorePattern: "^_",
+      }],
+    },
+  },
+
+  // 本项目严于 recommended：exhaustive-deps / incompatible-library 一律视为 error
+  {
+    rules: {
+      "react-hooks/exhaustive-deps": "error",
+      "react-hooks/incompatible-library": "error",
     },
   },
 );

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --max-warnings=0",
+    "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "build": "pnpm typecheck && vite build",
     "check": "pnpm typecheck && pnpm lint && vitest run",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --max-warnings=89",
+    "lint": "eslint . --max-warnings=71",
     "lint:fix": "eslint . --fix",
     "build": "pnpm typecheck && vite build",
     "check": "pnpm typecheck && pnpm lint && vitest run",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --max-warnings=138",
+    "lint": "eslint . --max-warnings=89",
     "lint:fix": "eslint . --fix",
     "build": "pnpm typecheck && vite build",
     "check": "pnpm typecheck && pnpm lint && vitest run",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --max-warnings=13",
+    "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",
     "build": "pnpm typecheck && vite build",
     "check": "pnpm typecheck && pnpm lint && vitest run",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --max-warnings=205",
+    "lint": "eslint . --max-warnings=142",
     "lint:fix": "eslint . --fix",
     "build": "pnpm typecheck && vite build",
     "check": "pnpm typecheck && pnpm lint && vitest run",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --max-warnings=71",
+    "lint": "eslint . --max-warnings=53",
     "lint:fix": "eslint . --fix",
     "build": "pnpm typecheck && vite build",
     "check": "pnpm typecheck && pnpm lint && vitest run",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --max-warnings=53",
+    "lint": "eslint . --max-warnings=29",
     "lint:fix": "eslint . --fix",
     "build": "pnpm typecheck && vite build",
     "check": "pnpm typecheck && pnpm lint && vitest run",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --max-warnings=29",
+    "lint": "eslint . --max-warnings=13",
     "lint:fix": "eslint . --fix",
     "build": "pnpm typecheck && vite build",
     "check": "pnpm typecheck && pnpm lint && vitest run",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --max-warnings=211",
+    "lint": "eslint . --max-warnings=205",
     "lint:fix": "eslint . --fix",
     "build": "pnpm typecheck && vite build",
     "check": "pnpm typecheck && pnpm lint && vitest run",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --max-warnings=142",
+    "lint": "eslint . --max-warnings=138",
     "lint:fix": "eslint . --fix",
     "build": "pnpm typecheck && vite build",
     "check": "pnpm typecheck && pnpm lint && vitest run",

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { API, type TaskStreamOptions } from "@/api";
+import { API } from "@/api";
 import type { TaskItem } from "@/types";
 
 type JsonResponseOptions = {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -57,8 +57,8 @@ export interface ErrorResponse {
 /** Error payload from the import project endpoint (extends ErrorResponse with import-specific fields). */
 interface ImportErrorPayload {
   detail?: string | { msg?: string }[];
-  errors?: unknown[];
-  warnings?: unknown[];
+  errors?: string[];
+  warnings?: string[];
   conflict_project_name?: string;
   diagnostics?: unknown;
 }
@@ -410,8 +410,8 @@ class API {
       };
       error.status = response.status;
       error.detail = typeof payload.detail === "string" ? payload.detail : "导入失败";
-      error.errors = Array.isArray(payload.errors) ? payload.errors as string[] : [];
-      error.warnings = Array.isArray(payload.warnings) ? payload.warnings as string[] : [];
+      error.errors = Array.isArray(payload.errors) ? payload.errors : [];
+      error.warnings = Array.isArray(payload.warnings) ? payload.warnings : [];
       if (typeof payload.conflict_project_name === "string") {
         error.conflict_project_name = payload.conflict_project_name;
       }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -43,6 +43,26 @@ import i18n from "./i18n";
 
 // ==================== Helper types ====================
 
+/** Login response from POST /auth/token (mirrors backend TokenResponse). */
+export interface LoginResponse {
+  access_token: string;
+  token_type: string;
+}
+
+/** Standard error response body from backend (mirrors FastAPI HTTPException detail). */
+export interface ErrorResponse {
+  detail: string | { msg?: string }[];
+}
+
+/** Error payload from the import project endpoint (extends ErrorResponse with import-specific fields). */
+interface ImportErrorPayload {
+  detail?: string | { msg?: string }[];
+  errors?: unknown[];
+  warnings?: unknown[];
+  conflict_project_name?: string;
+  diagnostics?: unknown;
+}
+
 /** Version metadata returned by the versions API. */
 export interface VersionInfo {
   version: number;
@@ -173,8 +193,9 @@ async function throwIfNotOk(response: Response, fallbackMsg: string): Promise<vo
     handleUnauthorized(response);
     const error = await response
       .json()
-      .catch(() => ({ detail: response.statusText }));
-    throw new Error(error.detail || fallbackMsg);
+      .catch(() => ({ detail: response.statusText })) as ErrorResponse;
+    const detail = error.detail;
+    throw new Error(typeof detail === "string" ? detail || fallbackMsg : fallbackMsg);
   }
 }
 
@@ -227,12 +248,12 @@ class API {
       handleUnauthorized(response);
       const error = await response
         .json()
-        .catch(() => ({ detail: response.statusText }));
+        .catch(() => ({ detail: response.statusText })) as ErrorResponse;
       let message = "请求失败";
       if (typeof error.detail === "string") {
         message = error.detail;
       } else if (Array.isArray(error.detail) && error.detail.length > 0) {
-        message = error.detail.map((e: string | { msg?: string }) => (typeof e === "string" ? e : e?.msg)).filter(Boolean).join("; ") || message;
+        message = error.detail.map((e) => (typeof e === "string" ? e : e?.msg)).filter(Boolean).join("; ") || message;
       }
       throw new Error(message);
     }
@@ -240,7 +261,7 @@ class API {
     if (response.status === 204) {
       return undefined as T;
     }
-    return response.json();
+    return response.json() as Promise<T>;
   }
 
   // ==================== 系统配置 ====================
@@ -376,7 +397,7 @@ class API {
 
       const payload = await response
         .json()
-        .catch(() => ({ detail: response.statusText, errors: [], warnings: [] }));
+        .catch(() => ({ detail: response.statusText, errors: [], warnings: [] })) as ImportErrorPayload;
       const error = new Error(
         typeof payload.detail === "string" ? payload.detail : "导入失败"
       ) as Error & {
@@ -389,8 +410,8 @@ class API {
       };
       error.status = response.status;
       error.detail = typeof payload.detail === "string" ? payload.detail : "导入失败";
-      error.errors = Array.isArray(payload.errors) ? payload.errors : [];
-      error.warnings = Array.isArray(payload.warnings) ? payload.warnings : [];
+      error.errors = Array.isArray(payload.errors) ? payload.errors as string[] : [];
+      error.warnings = Array.isArray(payload.warnings) ? payload.warnings as string[] : [];
       if (typeof payload.conflict_project_name === "string") {
         error.conflict_project_name = payload.conflict_project_name;
       }
@@ -398,7 +419,7 @@ class API {
       throw error;
     }
 
-    const payload = await response.json();
+    const payload = await response.json() as ImportProjectResponse & { diagnostics?: { auto_fixed?: unknown[]; warnings?: unknown[] } };
     return {
       ...payload,
       diagnostics: {
@@ -569,7 +590,7 @@ class API {
 
     await throwIfNotOk(response, "上传失败");
 
-    return response.json();
+    return response.json() as Promise<{ success: boolean; path: string; url: string }>;
   }
 
   static async listFiles(
@@ -627,7 +648,7 @@ class API {
       })
     );
     await throwIfNotOk(response, "保存文件失败");
-    return response.json();
+    return response.json() as Promise<SuccessResponse>;
   }
 
   /**
@@ -644,7 +665,7 @@ class API {
       })
     );
     await throwIfNotOk(response, "删除文件失败");
-    return response.json();
+    return response.json() as Promise<SuccessResponse>;
   }
 
   // ==================== 草稿文件管理 ====================
@@ -694,7 +715,7 @@ class API {
       })
     );
     await throwIfNotOk(response, "保存草稿失败");
-    return response.json();
+    return response.json() as Promise<SuccessResponse>;
   }
 
   /**
@@ -881,7 +902,7 @@ class API {
 
   static async getTaskStats(
     projectName: string | null = null
-  ): Promise<TaskStats> {
+  ): Promise<{ stats: TaskStats }> {
     const params = new URLSearchParams();
     if (projectName) params.append("project_name", projectName);
     const query = params.toString();
@@ -934,9 +955,9 @@ class API {
     const url = withAuthQuery(`${API_BASE}/tasks/stream${query ? "?" + query : ""}`);
     const source = new EventSource(url);
 
-    const parsePayload = (event: MessageEvent): unknown | null => {
+    const parsePayload = (event: MessageEvent): unknown => {
       try {
-        return JSON.parse(event.data || "{}");
+        return JSON.parse((event.data as string) || "{}");
       } catch (err) {
         console.error("解析 SSE 数据失败:", err, event.data);
         return null;
@@ -944,21 +965,21 @@ class API {
     };
 
     source.addEventListener("snapshot", (event) => {
-      const payload = parsePayload(event as MessageEvent);
+      const payload = parsePayload(event);
       if (payload && typeof options.onSnapshot === "function") {
         options.onSnapshot(
           payload as TaskStreamSnapshotPayload,
-          event as MessageEvent
+          event
         );
       }
     });
 
     source.addEventListener("task", (event) => {
-      const payload = parsePayload(event as MessageEvent);
+      const payload = parsePayload(event);
       if (payload && typeof options.onTask === "function") {
         options.onTask(
           payload as TaskStreamTaskPayload,
-          event as MessageEvent
+          event
         );
       }
     });
@@ -978,23 +999,23 @@ class API {
     );
     const source = new EventSource(url);
 
-    const parsePayload = (event: MessageEvent): unknown | null => {
+    const parsePayload = (event: MessageEvent): unknown => {
       try {
-        return JSON.parse(event.data || "{}");
+        return JSON.parse((event.data as string) || "{}");
       } catch (err) {
         console.error("解析项目事件 SSE 数据失败:", err, event.data);
         return null;
       }
     };
 
-    const createHandler = (
-      callback?: (payload: any, event: MessageEvent) => void
+    const createHandler = <T>(
+      callback?: (payload: T, event: MessageEvent) => void
     ) => {
       return (event: Event) => {
         if (typeof callback !== "function") return;
         const payload = parsePayload(event as MessageEvent);
         if (payload) {
-          callback(payload, event as MessageEvent);
+          callback(payload as T, event as MessageEvent);
         }
       };
     };
@@ -1085,7 +1106,7 @@ class API {
 
     await throwIfNotOk(response, "上传失败");
 
-    return response.json();
+    return response.json() as Promise<{ success: boolean; style_image: string; style_description: string; url: string }>;
   }
 
   /**
@@ -1370,7 +1391,7 @@ class API {
       withAuth({ method: "POST", body: formData }),
     );
     await throwIfNotOk(response, "上传凭证失败");
-    return response.json();
+    return response.json() as Promise<ProviderCredential>;
   }
 
   // ==================== 自定义供应商 API ====================

--- a/frontend/src/components/canvas/OverviewCanvas.tsx
+++ b/frontend/src/components/canvas/OverviewCanvas.tsx
@@ -1,5 +1,6 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { voidPromise } from "@/utils/async";
 import { useTranslation } from "react-i18next";
 import { ImagePlus, RefreshCw, Trash2, Upload } from "lucide-react";
 import type { ProjectData } from "@/types";
@@ -237,7 +238,7 @@ export function OverviewCanvas({ projectName, projectData }: OverviewCanvasProps
             ref={styleInputRef}
             type="file"
             accept=".png,.jpg,.jpeg,.webp"
-            onChange={handleStyleImageChange}
+            onChange={voidPromise(handleStyleImageChange)}
             className="hidden"
             aria-label={t("upload_style_ref_aria")}
           />

--- a/frontend/src/components/canvas/SourceFileViewer.tsx
+++ b/frontend/src/components/canvas/SourceFileViewer.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { FileText, Edit3, Save, X, Trash2 } from "lucide-react";
 import { useLocation } from "wouter";
 import { API } from "@/api";
+import { voidPromise } from "@/utils/async";
 import { useAppStore } from "@/stores/app-store";
 
 // ---------------------------------------------------------------------------
@@ -102,7 +103,7 @@ export function SourceFileViewer({ projectName, filename }: SourceFileViewerProp
             <>
               <button
                 type="button"
-                onClick={handleSave}
+                onClick={voidPromise(handleSave)}
                 disabled={saving}
                 className="flex items-center gap-1 rounded px-2 py-1 text-xs text-green-400 transition-colors hover:bg-gray-800 disabled:opacity-50"
               >
@@ -130,7 +131,7 @@ export function SourceFileViewer({ projectName, filename }: SourceFileViewerProp
               </button>
               <button
                 type="button"
-                onClick={handleDelete}
+                onClick={voidPromise(handleDelete)}
                 className="flex items-center gap-1 rounded px-2 py-1 text-xs text-gray-400 transition-colors hover:bg-gray-800 hover:text-red-400"
               >
                 <Trash2 className="h-3.5 w-3.5" />

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -52,6 +52,7 @@ function resolveSegmentPrompt(
 export function StudioCanvasRouter() {
   const { t } = useTranslation("dashboard");
   const tRef = useRef(t);
+  // eslint-disable-next-line react-hooks/refs -- tRef 是稳定 event-handler ref 模式，用于在回调中获取最新 t 而不触发无限 useCallback 重建
   tRef.current = t;
   const { currentProjectData, currentProjectName, currentScripts } =
     useProjectsStore();
@@ -313,6 +314,16 @@ export function StudioCanvasRouter() {
     await refreshProject();
   }, [refreshProject]);
 
+  const handleUpdateClueVoid = useCallback((...args: Parameters<typeof handleUpdateClue>) => {
+    void handleUpdateClue(...args).catch(console.error);
+  }, [handleUpdateClue]);
+  const handleGenerateCharacterVoid = useCallback((...args: Parameters<typeof handleGenerateCharacter>) => {
+    void handleGenerateCharacter(...args).catch(console.error);
+  }, [handleGenerateCharacter]);
+  const handleGenerateClueVoid = useCallback((...args: Parameters<typeof handleGenerateClue>) => {
+    void handleGenerateClue(...args).catch(console.error);
+  }, [handleGenerateClue]);
+
   const [location] = useLocation();
 
   if (!currentProjectName) {
@@ -345,9 +356,9 @@ export function StudioCanvasRouter() {
             clues={currentProjectData?.clues ?? {}}
             mode={location === "/clues" ? "clues" : "characters"}
             onSaveCharacter={handleSaveCharacter}
-            onUpdateClue={voidPromise(handleUpdateClue)}
-            onGenerateCharacter={voidPromise(handleGenerateCharacter)}
-            onGenerateClue={voidPromise(handleGenerateClue)}
+            onUpdateClue={handleUpdateClueVoid}
+            onGenerateCharacter={handleGenerateCharacterVoid}
+            onGenerateClue={handleGenerateClueVoid}
             onRestoreCharacterVersion={handleRestoreAsset}
             onRestoreClueVersion={handleRestoreAsset}
             generatingCharacterNames={generatingCharacterNames}

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { voidPromise } from "@/utils/async";
 import { Route, Switch, Redirect, useLocation } from "wouter";
 import { useTranslation } from "react-i18next";
 import { useProjectsStore } from "@/stores/projects-store";
@@ -344,9 +345,9 @@ export function StudioCanvasRouter() {
             clues={currentProjectData?.clues ?? {}}
             mode={location === "/clues" ? "clues" : "characters"}
             onSaveCharacter={handleSaveCharacter}
-            onUpdateClue={handleUpdateClue}
-            onGenerateCharacter={handleGenerateCharacter}
-            onGenerateClue={handleGenerateClue}
+            onUpdateClue={voidPromise(handleUpdateClue)}
+            onGenerateCharacter={voidPromise(handleGenerateCharacter)}
+            onGenerateClue={voidPromise(handleGenerateClue)}
             onRestoreCharacterVersion={handleRestoreAsset}
             onRestoreClueVersion={handleRestoreAsset}
             generatingCharacterNames={generatingCharacterNames}
@@ -402,10 +403,10 @@ export function StudioCanvasRouter() {
               scriptFile={scriptFile ?? undefined}
               projectData={currentProjectData}
               durationOptions={durationOptions}
-              onUpdatePrompt={handleUpdatePrompt}
-              onGenerateStoryboard={handleGenerateStoryboard}
-              onGenerateVideo={handleGenerateVideo}
-              onGenerateGrid={handleGenerateGrid}
+              onUpdatePrompt={voidPromise(handleUpdatePrompt)}
+              onGenerateStoryboard={voidPromise(handleGenerateStoryboard)}
+              onGenerateVideo={voidPromise(handleGenerateVideo)}
+              onGenerateGrid={voidPromise(handleGenerateGrid)}
               onRestoreStoryboard={handleRestoreAsset}
               onRestoreVideo={handleRestoreAsset}
             />

--- a/frontend/src/components/canvas/WelcomeCanvas.tsx
+++ b/frontend/src/components/canvas/WelcomeCanvas.tsx
@@ -1,5 +1,6 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
+import { voidCall, voidPromise } from "@/utils/async";
 import { useTranslation } from "react-i18next";
 import { Upload, FileText, Sparkles, Loader2, CheckCircle2, Plus } from "lucide-react";
 import { API } from "@/api";
@@ -45,7 +46,7 @@ export function WelcomeCanvas({
   // Check existing source files on mount and when sourceFilesVersion changes
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    voidCall((async () => {
       try {
         const res = await API.listFiles(projectName);
         // Backend returns grouped object: { files: { source: [{name, size, url}, ...], ... } }
@@ -64,7 +65,7 @@ export function WelcomeCanvas({
       } catch {
         if (!cancelled) setPhase((prev) => prev === "loading" ? "idle" : prev);
       }
-    })();
+    })());
     return () => { cancelled = true; };
   }, [projectName, sourceFilesVersion]);
 
@@ -118,7 +119,7 @@ export function WelcomeCanvas({
       setIsDragging(false);
       const file = e.dataTransfer.files[0];
       if (file && (file.name.endsWith(".txt") || file.name.endsWith(".md"))) {
-        processFile(file);
+        voidCall(processFile(file));
       }
     },
     [processFile],
@@ -127,7 +128,7 @@ export function WelcomeCanvas({
   const handleFileSelect = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0];
-      if (file) processFile(file);
+      if (file) voidCall(processFile(file));
       e.target.value = "";
     },
     [processFile],
@@ -244,7 +245,7 @@ export function WelcomeCanvas({
             {/* Analyze button */}
             <button
               type="button"
-              onClick={startAnalysis}
+              onClick={voidPromise(startAnalysis)}
               className="w-full rounded-xl bg-indigo-600 px-6 py-3 text-sm font-medium text-white hover:bg-indigo-500 transition-colors"
             >
               <Sparkles className="inline-block h-4 w-4 mr-2 -mt-0.5" />

--- a/frontend/src/components/canvas/lorebook/AddCharacterForm.tsx
+++ b/frontend/src/components/canvas/lorebook/AddCharacterForm.tsx
@@ -90,7 +90,7 @@ export function AddCharacterForm({ onSubmit, onCancel }: AddCharacterFormProps) 
         </button>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-3">
+      <form onSubmit={voidPromise(handleSubmit)} className="space-y-3">
         <div>
           <label className="block text-xs font-medium text-gray-400 mb-1">
             {t("name_label")} <span className="text-red-400">*</span>

--- a/frontend/src/components/canvas/lorebook/AddCharacterForm.tsx
+++ b/frontend/src/components/canvas/lorebook/AddCharacterForm.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useId, useRef, useState } from "react";
+import { useAutoFocus } from "@/hooks/useAutoFocus";
+import { voidPromise } from "@/utils/async";
 import { ImagePlus, Loader2, Upload, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -22,6 +24,7 @@ export function AddCharacterForm({ onSubmit, onCancel }: AddCharacterFormProps) 
   const [submitting, setSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const descId = useId();
+  const nameRef = useAutoFocus<HTMLInputElement>();
 
   useEffect(() => {
     return () => {
@@ -98,7 +101,7 @@ export function AddCharacterForm({ onSubmit, onCancel }: AddCharacterFormProps) 
             onChange={(e) => setName(e.target.value)}
             placeholder={t("name_placeholder")}
             className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-gray-200 placeholder-gray-500 outline-none focus:border-indigo-500"
-            autoFocus
+            ref={nameRef}
           />
         </div>
 

--- a/frontend/src/components/canvas/lorebook/AddClueForm.tsx
+++ b/frontend/src/components/canvas/lorebook/AddClueForm.tsx
@@ -1,4 +1,6 @@
 import { useId, useState } from "react";
+import { useAutoFocus } from "@/hooks/useAutoFocus";
+import { voidPromise } from "@/utils/async";
 import { X, Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -15,6 +17,7 @@ export function AddClueForm({ onSubmit, onCancel }: AddClueFormProps) {
   const [importance, setImportance] = useState<"major" | "minor">("major");
   const [submitting, setSubmitting] = useState(false);
   const descId = useId();
+  const nameRef = useAutoFocus<HTMLInputElement>();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -54,7 +57,7 @@ export function AddClueForm({ onSubmit, onCancel }: AddClueFormProps) {
             onChange={(e) => setName(e.target.value)}
             placeholder={t("clue_name_placeholder")}
             className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-gray-200 placeholder-gray-500 outline-none focus:border-indigo-500"
-            autoFocus
+            ref={nameRef}
           />
         </div>
 

--- a/frontend/src/components/canvas/lorebook/AddClueForm.tsx
+++ b/frontend/src/components/canvas/lorebook/AddClueForm.tsx
@@ -46,7 +46,7 @@ export function AddClueForm({ onSubmit, onCancel }: AddClueFormProps) {
         </button>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-3">
+      <form onSubmit={voidPromise(handleSubmit)} className="space-y-3">
         <div>
           <label className="block text-xs font-medium text-gray-400 mb-1">
             {t("name_label")} <span className="text-red-400">*</span>

--- a/frontend/src/components/canvas/lorebook/ClueCard.tsx
+++ b/frontend/src/components/canvas/lorebook/ClueCard.tsx
@@ -56,10 +56,12 @@ export function ClueCard({
   const isDirty = description !== clue.description;
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 可编辑描述字段必须跟随外部 prop 更新，拷贝模式是有意设计
     setDescription(clue.description);
   }, [clue.description]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 图片源变更时重置错误态，确保新 URL 正常加载
     setImgError(false);
   }, [clue.clue_sheet, sheetFp]);
 

--- a/frontend/src/components/canvas/lorebook/LorebookGallery.tsx
+++ b/frontend/src/components/canvas/lorebook/LorebookGallery.tsx
@@ -68,6 +68,7 @@ export function LorebookGallery({
 
   // Sync activeTab when mode prop changes (avoids stale tab on route switch)
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- mode prop 受控驱动 tab 切换，同步拷贝是有意设计
     if (mode) setActiveTab(mode);
   }, [mode]);
 
@@ -80,6 +81,7 @@ export function LorebookGallery({
   useEffect(() => {
     if (!scrollTarget) return;
     if (scrollTarget.type === "character" && activeTab !== "characters") {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- 智能体滚动目标事件驱动 tab 切换，需在 effect 中响应外部事件
       setActiveTab("characters");
     } else if (scrollTarget.type === "clue" && activeTab !== "clues") {
       setActiveTab("clues");

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -167,12 +167,7 @@ export function GridPreviewPanel({
   const safeIdx = Math.min(selectedIdx, Math.max(0, gridIds.length - 1));
   const selectedGridId = gridIds[safeIdx] ?? null;
 
-  // Clamp selection when grid list changes
-  useEffect(() => {
-    if (selectedIdx >= gridIds.length && gridIds.length > 0) {
-      setSelectedIdx(0);
-    }
-  }, [gridIds.length, selectedIdx]);
+  // safeIdx already clamps selectedIdx to valid range; no effect needed
 
   // Fetch grid data when expanded and selectedGridId is available
   useEffect(() => {
@@ -181,6 +176,7 @@ export function GridPreviewPanel({
     let cancelled = false;
     // Clear stale data and show spinner when switching batches
     if (!grid || grid.id !== selectedGridId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- 异步数据加载前需同步清空旧数据和错误态，是有意的加载中状态管理
       setLoading(true);
       setGrid(null);
     }

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -176,7 +176,6 @@ export function GridPreviewPanel({
     let cancelled = false;
     // Clear stale data and show spinner when switching batches
     if (!grid || grid.id !== selectedGridId) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- 异步数据加载前需同步清空旧数据和错误态，是有意的加载中状态管理
       setLoading(true);
       setGrid(null);
     }
@@ -199,6 +198,7 @@ export function GridPreviewPanel({
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- grid 用于判断是否切换批次，加入 deps 会在每次拉取完成后触发重新拉取，导致无限循环；t 稳定可忽略
   }, [expanded, selectedGridId, projectName, refreshKey]);
 
   const isInProgress =

--- a/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
+++ b/frontend/src/components/canvas/timeline/GridSegmentGroup.tsx
@@ -61,7 +61,7 @@ function groupLabel(index: number): string {
  */
 export function GridSegmentGroup({
   groupIndex,
-  scenes,
+  scenes: _scenes,
   gridSize,
   sceneCount,
   batchCount = 1,

--- a/frontend/src/components/canvas/timeline/PreprocessingView.tsx
+++ b/frontend/src/components/canvas/timeline/PreprocessingView.tsx
@@ -49,6 +49,7 @@ export function PreprocessingView({
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- content 仅用于决定是否显示加载态，加入 deps 会在内容更新后触发重新拉取，导致循环
   }, [projectName, episode, draftRevision]);
 
   const handleSave = useCallback(async () => {
@@ -63,7 +64,7 @@ export function PreprocessingView({
     } finally {
       setSaving(false);
     }
-  }, [projectName, episode, editContent, pushToast]);
+  }, [projectName, episode, editContent, pushToast, t]);
 
   const statusLabel =
     contentMode === "narration" ? t("dashboard:segment_split_complete") : t("dashboard:script_normalized_complete");

--- a/frontend/src/components/canvas/timeline/PreprocessingView.tsx
+++ b/frontend/src/components/canvas/timeline/PreprocessingView.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useId } from "react";
 import { useTranslation } from "react-i18next";
 import { Edit3, Save, X } from "lucide-react";
 import { API } from "@/api";
+import { voidPromise } from "@/utils/async";
 import { useAppStore } from "@/stores/app-store";
 import { StreamMarkdown } from "@/components/copilot/StreamMarkdown";
 
@@ -98,7 +99,7 @@ export function PreprocessingView({
             <>
               <button
                 type="button"
-                onClick={handleSave}
+                onClick={voidPromise(handleSave)}
                 disabled={saving}
                 className="flex items-center gap-1 rounded px-2 py-1 text-xs text-green-400 transition-colors hover:bg-gray-800 disabled:opacity-50"
               >

--- a/frontend/src/components/canvas/timeline/SegmentCard.tsx
+++ b/frontend/src/components/canvas/timeline/SegmentCard.tsx
@@ -280,6 +280,7 @@ function TextColumn({
   const noteId = useId();
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 可编辑备注字段随外部数据更新同步，拷贝模式是有意设计
     setNoteDraft(segment.note ?? "");
     committedRef.current = segment.note ?? "";
   }, [segment.note]);
@@ -401,6 +402,7 @@ function PromptColumn({
     }
 
     prevSegmentIdRef.current = segmentId;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 切换镜头时重置本地草稿，是导航驱动的有意状态重置
     setImgText(promptToStr(image_prompt, "scene"));
     setVidText(promptToStr(video_prompt, "action"));
     setImgDraft(isStructuredImage ? image_prompt : null);
@@ -415,6 +417,7 @@ function PromptColumn({
 
   useEffect(() => {
     if (!isStructuredImage) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- image_prompt 结构切换时同步本地编辑态，拷贝模式是有意设计
       setImgDraft(null);
       setImgText(promptToStr(image_prompt, "scene"));
     }
@@ -422,6 +425,7 @@ function PromptColumn({
 
   useEffect(() => {
     if (!isStructuredVideo) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- video_prompt 结构切换时同步本地编辑态，拷贝模式是有意设计
       setVidDraft(null);
       setVidText(promptToStr(video_prompt, "action"));
     }

--- a/frontend/src/components/canvas/timeline/SegmentCard.tsx
+++ b/frontend/src/components/canvas/timeline/SegmentCard.tsx
@@ -128,7 +128,7 @@ function mergePromptPatch<T extends Record<string, unknown>>(
       !Array.isArray(v) &&
       !Array.isArray(base[k])
     ) {
-      merged[k] = { ...(base[k] as Record<string, unknown>), ...v };
+      merged[k] = { ...(base[k]), ...v };
     } else {
       merged[k] = v;
     }
@@ -358,7 +358,7 @@ function TextColumn({
 
 function PromptColumn({
   segment,
-  contentMode,
+  contentMode: _contentMode,
   segmentId,
   onUpdatePrompt,
 }: {
@@ -592,7 +592,7 @@ function MediaColumn({
   // Normalize aspect ratio to the union type expected by AspectFrame
   const normalizedRatio = (
     aspectRatio === "9:16" || aspectRatio === "16:9" ? aspectRatio : "16:9"
-  ) as "9:16" | "16:9";
+  );
 
   return (
     <div className="flex flex-col gap-3 p-3">

--- a/frontend/src/components/canvas/timeline/SegmentCard.tsx
+++ b/frontend/src/components/canvas/timeline/SegmentCard.tsx
@@ -536,6 +536,7 @@ function PromptColumn({
 /** Simple video player with poster thumbnail and lazy preload. */
 function VideoPlayer({ src, poster }: { src: string; poster?: string | null }) {
   return (
+    // eslint-disable-next-line jsx-a11y/media-has-caption -- 生成式预览视频暂无字幕源，将来如引入字幕生成则移除此 disable
     <video
       src={src}
       poster={poster ?? undefined}

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -265,6 +265,7 @@ export function TimelineCanvas({
     }, 3000);
   }, [onGenerateGrid, scriptFile, episode, refreshGrids]);
 
+  // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual 的 useVirtualizer 返回非 memoizable 函数，与 React Compiler 不兼容，属已知第三方库限制
   const virtualizer = useVirtualizer({
     count: segments.length,
     getScrollElement: () => scrollRef.current,

--- a/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
+++ b/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
@@ -74,6 +74,7 @@ export function VersionTimeMachine({
   useEffect(() => {
     if (!open || loadedOnce || !resourceId) return;
     void loadVersions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- loadVersions 是组件内普通函数，无法稳定化；加入 deps 会导致每次渲染重复触发
   }, [open, loadedOnce, resourceId]);
 
   async function loadVersions() {
@@ -170,7 +171,7 @@ export function VersionTimeMachine({
       for (const sp of scrollParents) sp.removeEventListener("scroll", close);
       document.removeEventListener("mousedown", onMouseDown);
     };
-  }, [open, close]);
+  }, [open, close, computeTop]);
 
   if (!resourceId) return null;
 

--- a/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
+++ b/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
@@ -294,6 +294,7 @@ export function VersionTimeMachine({
                     {/* Media preview */}
                     {selectedInfo.file_url &&
                       (resourceType === "videos" ? (
+                        // eslint-disable-next-line jsx-a11y/media-has-caption -- 生成式预览视频暂无字幕源，将来如引入字幕生成则移除此 disable
                         <video
                           src={selectedInfo.file_url}
                           className="mb-2 w-full rounded-lg border border-gray-800 bg-black object-contain"

--- a/frontend/src/components/copilot/AgentCopilot.test.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.test.tsx
@@ -45,12 +45,14 @@ function makePendingQuestion() {
 }
 
 describe("AgentCopilot", () => {
-  const sendMessage = vi.fn();
-  const answerQuestion = vi.fn();
-  const interrupt = vi.fn();
+  // Mocks whose callers wrap them with voidPromise must return a Promise
+  // so the .catch(...) chain in voidPromise resolves instead of crashing.
+  const sendMessage = vi.fn().mockResolvedValue(undefined);
+  const answerQuestion = vi.fn().mockResolvedValue(undefined);
+  const interrupt = vi.fn().mockResolvedValue(undefined);
   const createNewSession = vi.fn();
-  const switchSession = vi.fn();
-  const deleteSession = vi.fn();
+  const switchSession = vi.fn().mockResolvedValue(undefined);
+  const deleteSession = vi.fn().mockResolvedValue(undefined);
 
   beforeEach(() => {
     useAssistantStore.setState(useAssistantStore.getInitialState(), true);

--- a/frontend/src/components/copilot/AgentCopilot.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from "react";
+import { voidCall, voidPromise } from "@/utils/async";
 import { Bot, Send, Square, Plus, ChevronDown, Trash2, MessageSquare, PanelRightClose, Paperclip, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { ImageLightbox } from "@/components/ui/ImageLightbox";
@@ -229,7 +230,7 @@ export function AgentCopilot() {
   const handleSend = useCallback(() => {
     if (inputDisabled || (!localInput.trim() && attachedImages.length === 0)) return;
     imageGenRef.current += 1; // invalidate pending FileReader callbacks
-    sendMessage(localInput.trim(), attachedImages.length > 0 ? attachedImages : undefined);
+    voidCall(sendMessage(localInput.trim(), attachedImages.length > 0 ? attachedImages : undefined));
     setLocalInput("");
     setAttachedImages([]);
     setAttachError(null);
@@ -344,7 +345,7 @@ export function AgentCopilot() {
               {t("thinking")}
             </span>
           )}
-          <SessionSelector onSwitch={switchSession} onDelete={deleteSession} />
+          <SessionSelector onSwitch={voidPromise(switchSession)} onDelete={voidPromise(deleteSession)} />
           <button
             type="button"
             onClick={createNewSession}
@@ -380,7 +381,7 @@ export function AgentCopilot() {
           pendingQuestion={pendingQuestion}
           answeringQuestion={answeringQuestion}
           error={error}
-          onSubmitAnswers={answerQuestion}
+          onSubmitAnswers={voidPromise(answerQuestion)}
         />
       )}
 
@@ -471,7 +472,7 @@ export function AgentCopilot() {
 
           {isRunning ? (
             <button
-              onClick={interrupt}
+              onClick={voidPromise(interrupt)}
               className="shrink-0 rounded p-1.5 text-red-400 hover:bg-gray-700"
               title={t("stop_session")}
               aria-label={t("stop_session")}

--- a/frontend/src/components/copilot/AgentCopilot.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.tsx
@@ -294,7 +294,9 @@ export function AgentCopilot() {
   }, []);
 
   // Derive slash filter from input (text after "/" up to cursor)
+  // eslint-disable-next-line react-hooks/refs -- slashPosRef 同时被 render 和 handleSlashSelect 使用，转 state 会引入 stale-closure 问题；此处仅用于过滤展示，不影响 UI 一致性
   const slashFilter = showSlashMenu && slashPosRef.current >= 0
+    // eslint-disable-next-line react-hooks/refs -- 同上
     ? localInput.slice(slashPosRef.current + 1).split(/\s/)[0]
     : "";
 
@@ -452,7 +454,10 @@ export function AgentCopilot() {
             aria-label={t("assistant_input")}
             aria-expanded={showSlashMenu}
             aria-controls={showSlashMenu ? "slash-command-menu" : undefined}
-            aria-activedescendant={slashMenuRef.current?.activeDescendantId}
+            aria-activedescendant={
+              // eslint-disable-next-line react-hooks/refs -- aria-activedescendant 需实时读取 slashMenuRef 的派生值，改用回调 prop 需修改 SlashCommandMenu 接口，超出范围
+              slashMenuRef.current?.activeDescendantId
+            }
             className="flex-1 resize-none bg-transparent text-sm text-gray-200 placeholder-gray-500 outline-none overflow-hidden"
             style={{ maxHeight: `${MAX_TEXTAREA_HEIGHT_VH}vh` }}
             disabled={inputDisabled}

--- a/frontend/src/components/copilot/AgentCopilot.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useEffect } from "react";
 import { voidCall, voidPromise } from "@/utils/async";
 import { Bot, Send, Square, Plus, ChevronDown, Trash2, MessageSquare, PanelRightClose, Paperclip, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import { ImageLightbox } from "@/components/ui/ImageLightbox";
 import { useAssistantStore } from "@/stores/assistant-store";
 import { useProjectsStore } from "@/stores/projects-store";
@@ -120,7 +121,7 @@ function StatusDot({ status }: { status: string }) {
   );
 }
 
-function formatTime(isoStr: string | undefined, t: any): string {
+function formatTime(isoStr: string | undefined, t: TFunction): string {
   if (!isoStr) return t("new_session");
   try {
     const d = new Date(isoStr);

--- a/frontend/src/components/copilot/PendingQuestionWizard.tsx
+++ b/frontend/src/components/copilot/PendingQuestionWizard.tsx
@@ -39,6 +39,7 @@ export function PendingQuestionWizard({
       initialCustomAnswers[key] = "";
     });
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 新问题到来时重置向导所有状态，是有意的受控重置模式
     setQuestionAnswers(initialAnswers);
     setQuestionCustomAnswers(initialCustomAnswers);
     setCurrentQuestionIndex(0);

--- a/frontend/src/components/copilot/PendingQuestionWizard.tsx
+++ b/frontend/src/components/copilot/PendingQuestionWizard.tsx
@@ -44,7 +44,7 @@ export function PendingQuestionWizard({
     setQuestionCustomAnswers(initialCustomAnswers);
     setCurrentQuestionIndex(0);
     setVisitedQuestionIndexes(pendingQuestions.length > 0 ? [0] : []);
-  }, [pendingQuestion.question_id, pendingQuestion.questions]);
+  }, [pendingQuestion.question_id, pendingQuestion.questions, pendingQuestions]);
 
   const totalQuestions = pendingQuestions.length;
   const normalizedQuestionIndex = totalQuestions === 0

--- a/frontend/src/components/copilot/StreamMarkdown.tsx
+++ b/frontend/src/components/copilot/StreamMarkdown.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ComponentType } from "react";
+import { voidCall } from "@/utils/async";
 
 // ---------------------------------------------------------------------------
 // StreamMarkdown – lazy-loads the Streamdown component from the `streamdown`
@@ -39,10 +40,10 @@ export function StreamMarkdown({ content }: StreamMarkdownProps) {
   useEffect(() => {
     let mounted = true;
 
-    loadStreamdownComponent().then((component) => {
+    voidCall(loadStreamdownComponent().then((component) => {
       if (!mounted || !component) return;
       setStreamdownComponent(() => component);
-    });
+    }));
 
     return () => {
       mounted = false;

--- a/frontend/src/components/copilot/TodoListPanel.tsx
+++ b/frontend/src/components/copilot/TodoListPanel.tsx
@@ -23,7 +23,7 @@ export function extractLatestTodos(
         continue;
       }
 
-      const input = block.input as Record<string, unknown> | undefined;
+      const input = block.input;
       const todos = input?.todos;
       if (
         Array.isArray(todos) &&
@@ -111,7 +111,7 @@ export function TodoListPanel({ turns, draftTurn }: TodoListPanelProps) {
       {/* Expanded task list */}
       {!collapsed && (
         <div className="border-t border-white/5 px-3 py-1.5 space-y-0.5">
-          {todos.map((todo, idx) => (
+          {todos.map((todo) => (
             <TodoRow key={`${todo.content}-${todo.status}`} todo={todo} />
           ))}
         </div>

--- a/frontend/src/components/copilot/chat/ToolCallWithResult.tsx
+++ b/frontend/src/components/copilot/chat/ToolCallWithResult.tsx
@@ -205,7 +205,7 @@ export function ToolCallWithResult({ block }: ToolCallWithResultProps) {
 
 function TodoWriteCompact({ block }: Readonly<{ block: ContentBlock }>) {
   const input = block.input;
-  const todos: TodoItem[] = Array.isArray(input?.todos) ? input.todos : [];
+  const todos: TodoItem[] = Array.isArray(input?.todos) ? (input.todos as TodoItem[]) : [];
   const total = todos.length;
   const completed = todos.filter((t) => t.status === "completed").length;
   const hasResult = block.result !== undefined;

--- a/frontend/src/components/copilot/chat/ToolCallWithResult.tsx
+++ b/frontend/src/components/copilot/chat/ToolCallWithResult.tsx
@@ -204,7 +204,7 @@ export function ToolCallWithResult({ block }: ToolCallWithResultProps) {
 // ---------------------------------------------------------------------------
 
 function TodoWriteCompact({ block }: Readonly<{ block: ContentBlock }>) {
-  const input = block.input as Record<string, unknown> | undefined;
+  const input = block.input;
   const todos: TodoItem[] = Array.isArray(input?.todos) ? input.todos : [];
   const total = todos.length;
   const completed = todos.filter((t) => t.status === "completed").length;

--- a/frontend/src/components/layout/AssetSidebar.tsx
+++ b/frontend/src/components/layout/AssetSidebar.tsx
@@ -99,6 +99,7 @@ function AssetThumbnail({
   const [imgError, setImgError] = useState(false);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 图片源变更时重置错误态，确保新 URL 正常加载
     setImgError(false);
   }, [sheetFp, sheetPath]);
 

--- a/frontend/src/components/layout/AssetSidebar.tsx
+++ b/frontend/src/components/layout/AssetSidebar.tsx
@@ -146,6 +146,7 @@ interface AssetSidebarProps {
 export function AssetSidebar({ className }: AssetSidebarProps) {
   const { t } = useTranslation(["common", "dashboard"]);
   const tRef = useRef(t);
+  // eslint-disable-next-line react-hooks/refs -- tRef 是稳定 event-handler ref 模式，用于在回调中获取最新 t 而不触发无限 useCallback 重建
   tRef.current = t;
   const { currentProjectData, currentProjectName } = useProjectsStore();
   const sourceFilesVersion = useAppStore((s) => s.sourceFilesVersion);

--- a/frontend/src/components/layout/AssetSidebar.tsx
+++ b/frontend/src/components/layout/AssetSidebar.tsx
@@ -1,5 +1,6 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { voidCall, voidPromise } from "@/utils/async";
 import { useLocation } from "wouter";
 import { useTranslation } from "react-i18next";
 import {
@@ -260,7 +261,7 @@ export function AssetSidebar({ className }: AssetSidebarProps) {
               type="file"
               accept=".txt,.md,.doc,.docx"
               aria-label={t("dashboard:upload_asset_file_aria")}
-              onChange={handleUpload}
+              onChange={voidPromise(handleUpload)}
               className="hidden"
             />
           </>
@@ -292,7 +293,7 @@ export function AssetSidebar({ className }: AssetSidebarProps) {
                     </button>
                     <button
                       type="button"
-                      onClick={(e) => { e.stopPropagation(); handleDeleteFile(name); }}
+                      onClick={(e) => { e.stopPropagation(); voidCall(handleDeleteFile(name)); }}
                       className="shrink-0 rounded p-0.5 text-gray-600 opacity-0 transition-opacity hover:text-red-400 group-hover:opacity-100 focus-ring focus-visible:opacity-100"
                       title={t("dashboard:delete_file")}
                     >

--- a/frontend/src/components/layout/ExportScopeDialog.tsx
+++ b/frontend/src/components/layout/ExportScopeDialog.tsx
@@ -46,6 +46,7 @@ export function ExportScopeDialog({
   // Reset mode when popover closes
   useEffect(() => {
     if (!open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- 弹窗关闭时重置到初始选择界面，是有意的 UI 状态重置
       setMode("select");
     }
   }, [open]);
@@ -53,6 +54,7 @@ export function ExportScopeDialog({
   // Sync selected episode when episodes change
   useEffect(() => {
     if (episodes.length > 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- episodes prop 变化时同步表单默认值，受控拷贝是有意设计
       setSelectedEpisode(episodes[0].episode);
     }
   }, [episodes]);

--- a/frontend/src/components/layout/GlobalHeader.tsx
+++ b/frontend/src/components/layout/GlobalHeader.tsx
@@ -1,4 +1,5 @@
 import { startTransition, useState, useEffect, useRef } from "react";
+import { voidPromise } from "@/utils/async";
 import { useLocation } from "wouter";
 import { ChevronLeft, Activity, Settings, Bell, Download, Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -368,7 +369,7 @@ export function GlobalHeader({ onNavigateBack }: GlobalHeaderProps) {
             onSelect={(scope) => { if (scope !== "jianying-draft") void handleExportProject(scope); }}
             anchorRef={exportAnchorRef}
             episodes={currentProjectData?.episodes ?? []}
-            onJianyingExport={handleJianyingExport}
+            onJianyingExport={voidPromise(handleJianyingExport)}
             jianyingExporting={jianyingExporting}
           />
         </div>

--- a/frontend/src/components/layout/GlobalHeader.tsx
+++ b/frontend/src/components/layout/GlobalHeader.tsx
@@ -39,8 +39,6 @@ const PHASES = [
   { key: "completed" },
 ] as const;
 
-type PhaseKey = (typeof PHASES)[number]["key"];
-
 // ---------------------------------------------------------------------------
 // PhaseStepper — horizontal workflow indicator
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/layout/UsageDrawer.tsx
+++ b/frontend/src/components/layout/UsageDrawer.tsx
@@ -51,13 +51,14 @@ export function UsageDrawer({ open, onClose, projectName, anchorRef }: UsageDraw
     })
       .then((res) => {
         const r = res as { items?: UsageCall[]; total?: number };
-        setCalls((r.items ?? []) as UsageCall[], r.total ?? 0);
+        setCalls((r.items ?? []), r.total ?? 0);
       })
       .catch(() => {})
       .finally(() => setCallsLoading(false));
   }, [projectName, page, pageSize, setCalls]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 抽屉打开时触发数据加载，loadCalls 内部有 setState，属于正常异步数据获取模式
     if (open) loadCalls();
   }, [open, loadCalls]);
 

--- a/frontend/src/components/pages/AgentConfigTab.tsx
+++ b/frontend/src/components/pages/AgentConfigTab.tsx
@@ -1,5 +1,6 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { voidCall } from "@/utils/async";
 import { ChevronDown, Eye, EyeOff, Loader2, SlidersHorizontal, Terminal, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useWarnUnsaved } from "@/hooks/useWarnUnsaved";
@@ -214,7 +215,7 @@ export function AgentConfigTab({ visible }: AgentConfigTabProps) {
       const newDraft = buildDraft(res);
       savedRef.current = newDraft;
       setDraft(newDraft);
-      useConfigStatusStore.getState().refresh();
+      voidCall(useConfigStatusStore.getState().refresh());
       useAppStore.getState().pushToast(t("agent_config_saved"), "success");
     } catch (err) {
       setSaveError((err as Error).message);
@@ -238,7 +239,7 @@ export function AgentConfigTab({ visible }: AgentConfigTabProps) {
         const nextSavedDraft = buildDraft(res);
         savedRef.current = nextSavedDraft;
         setDraft(nextSavedDraft);
-        useConfigStatusStore.getState().refresh();
+        voidCall(useConfigStatusStore.getState().refresh());
         useAppStore.getState().pushToast(`${t(`dashboard:${label}`)} ${t("field_cleared")}`, "success");
       } catch (err) {
         useAppStore.getState().pushToast(`${t("clear_failed")}${(err as Error).message}`, "error");

--- a/frontend/src/components/pages/ApiKeysTab.tsx
+++ b/frontend/src/components/pages/ApiKeysTab.tsx
@@ -4,6 +4,7 @@
  * 列表展示、创建（弹窗显示完整 key）、删除（确认弹窗）
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAutoFocus } from "@/hooks/useAutoFocus";
 import {
   AlertTriangle,
   Check,
@@ -58,6 +59,7 @@ function CreateModal({ onClose, onCreated }: CreateModalProps) {
   const [copied, setCopied] = useState(false);
 
   const canCreate = useMemo(() => name.trim().length > 0, [name]);
+  const nameInputRef = useAutoFocus<HTMLInputElement>();
 
   const handleCreate = useCallback(async () => {
     if (!canCreate || creating) return;
@@ -90,18 +92,20 @@ function CreateModal({ onClose, onCreated }: CreateModalProps) {
     setTimeout(() => setCopied(false), 2000);
   }, [created?.key]);
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Enter" && !created && canCreate) void handleCreate();
       if (e.key === "Escape") onClose();
-    },
-    [canCreate, created, handleCreate, onClose],
-  );
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [canCreate, created, handleCreate, onClose]);
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4"
-      onKeyDown={handleKeyDown}
     >
       <div className="w-full max-w-md overflow-hidden rounded-2xl border border-gray-800 bg-gray-950 p-6 shadow-2xl">
         <div className="mb-6 flex items-center justify-between">
@@ -129,7 +133,7 @@ function CreateModal({ onClose, onCreated }: CreateModalProps) {
                 {t("key_name_hint")}
               </p>
               <input
-                autoFocus
+                ref={nameInputRef}
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}

--- a/frontend/src/components/pages/CreateProjectModal.tsx
+++ b/frontend/src/components/pages/CreateProjectModal.tsx
@@ -1,5 +1,6 @@
 
 import { useState, useRef } from "react";
+import { voidPromise } from "@/utils/async";
 import { useLocation } from "wouter";
 import { X, Loader2, Upload } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -102,7 +103,7 @@ export function CreateProjectModal() {
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={voidPromise(handleSubmit)} className="space-y-4">
           {/* Title */}
           <div>
             <label className="block text-sm font-medium text-gray-400 mb-1">

--- a/frontend/src/components/pages/CredentialList.tsx
+++ b/frontend/src/components/pages/CredentialList.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, memo } from "react";
+import { useAutoFocus } from "@/hooks/useAutoFocus";
 import { voidPromise } from "@/utils/async";
 import {
   Check,
@@ -293,6 +294,7 @@ function AddCredentialForm({ providerId, isVertex, onCreated, onCancel }: AddFor
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  const nameRef = useAutoFocus<HTMLInputElement>();
 
   const handleSubmit = async () => {
     if (!name.trim()) return;
@@ -339,7 +341,7 @@ function AddCredentialForm({ providerId, isVertex, onCreated, onCancel }: AddFor
           onChange={(e) => setName(e.target.value)}
           placeholder={t("credential_name_placeholder")}
           className={inputClsPlaceholder}
-          autoFocus
+          ref={nameRef}
         />
       </div>
       {isVertex ? (

--- a/frontend/src/components/pages/CredentialList.tsx
+++ b/frontend/src/components/pages/CredentialList.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, memo } from "react";
+import { voidPromise } from "@/utils/async";
 import {
   Check,
   Edit2,
@@ -102,7 +103,7 @@ const CredentialRow = memo(function CredentialRow({ cred, providerId, isVertex, 
       <div className="flex items-center gap-3">
         <button
           type="button"
-          onClick={cred.is_active ? undefined : handleActivate}
+          onClick={cred.is_active ? undefined : voidPromise(handleActivate)}
           disabled={cred.is_active}
           aria-label={cred.is_active ? t("currently_active") : t("activate_credential", { name: cred.name })}
           className={`h-2.5 w-2.5 flex-shrink-0 rounded-full transition-colors focus-ring ${
@@ -137,7 +138,7 @@ const CredentialRow = memo(function CredentialRow({ cred, providerId, isVertex, 
         <div className="flex flex-shrink-0 items-center gap-1">
           <button
             type="button"
-            onClick={handleTest}
+            onClick={voidPromise(handleTest)}
             disabled={testing}
             aria-label={t("test_credential", { name: cred.name })}
             className={`rounded p-1.5 text-gray-500 transition-colors hover:bg-gray-800 hover:text-gray-300 focus-ring`}
@@ -161,7 +162,7 @@ const CredentialRow = memo(function CredentialRow({ cred, providerId, isVertex, 
           {!confirmDelete ? (
             <button
               type="button"
-              onClick={handleDelete}
+              onClick={voidPromise(handleDelete)}
               disabled={deleting}
               aria-label={t("delete_credential", { name: cred.name })}
               className={`rounded p-1.5 text-gray-500 transition-colors hover:bg-gray-800 hover:text-rose-400 focus-ring`}
@@ -172,7 +173,7 @@ const CredentialRow = memo(function CredentialRow({ cred, providerId, isVertex, 
             <div className="flex items-center gap-1">
               <button
                 type="button"
-                onClick={handleDelete}
+                onClick={voidPromise(handleDelete)}
                 disabled={deleting}
                 className={`rounded px-2 py-1 text-xs text-rose-400 transition-colors hover:bg-rose-900/20 focus-ring`}
               >
@@ -491,7 +492,7 @@ export function CredentialList({ providerId, onChanged }: Props) {
             cred={c}
             providerId={providerId}
             isVertex={isVertex}
-            onChanged={handleChanged}
+            onChanged={voidPromise(handleChanged)}
           />
         ))}
       </div>

--- a/frontend/src/components/pages/OpenClawModal.tsx
+++ b/frontend/src/components/pages/OpenClawModal.tsx
@@ -2,7 +2,7 @@
  * OpenClaw 集成引导 Modal
  * 提示词区域（可复制，含动态 skill.md URL）、3 步使用说明、"获取 API 令牌"按钮
  */
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { copyText } from "@/utils/clipboard";
 import { Check, Copy, ExternalLink, X } from "lucide-react";
 import { useLocation } from "wouter";
@@ -66,27 +66,28 @@ export function OpenClawModal({ onClose }: OpenClawModalProps) {
     navigate("/app/settings?section=api-keys");
   }, [navigate, onClose]);
 
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (e.target === e.currentTarget) onClose();
-    },
-    [onClose],
-  );
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
-    },
-    [onClose],
-  );
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-8"
-      onClick={handleBackdropClick}
-      onKeyDown={handleKeyDown}
     >
-      <div className="relative flex w-full max-w-lg flex-col rounded-2xl border border-gray-800 bg-gray-900 shadow-2xl shadow-black/60 max-h-[90vh] overflow-y-auto">
+      {/* backdrop: click-to-close */}
+      <button
+        type="button"
+        aria-label="关闭"
+        className="absolute inset-0 cursor-default appearance-none border-0 bg-transparent p-0"
+        onClick={onClose}
+      />
+      <div className="relative z-10 flex w-full max-w-lg flex-col rounded-2xl border border-gray-800 bg-gray-900 shadow-2xl shadow-black/60 max-h-[90vh] overflow-y-auto">
         {/* ——— 顶栏 ——— */}
         <div className="sticky top-0 z-10 flex items-center justify-between border-b border-gray-800 bg-gray-900 px-5 py-4">
           <div className="flex items-center gap-2.5">

--- a/frontend/src/components/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useParams, useLocation } from "wouter";
+import { voidCall, voidPromise } from "@/utils/async";
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft } from "lucide-react";
@@ -55,7 +56,7 @@ export function ProjectSettingsPage() {
   useEffect(() => {
     let disposed = false;
 
-    Promise.all([
+    voidCall(Promise.all([
       API.getSystemConfig(),
       API.getProject(projectName),
       getProviderModels().catch(() => [] as ProviderInfo[]),
@@ -105,7 +106,7 @@ export function ProjectSettingsPage() {
         textScript: ts, textOverview: to, textStyle: tst,
         aspectRatio: ar, generationMode: gm, defaultDuration: dd,
       };
-    });
+    }));
 
     return () => { disposed = true; };
   }, [projectName]);
@@ -407,7 +408,7 @@ export function ProjectSettingsPage() {
         {/* Actions */}
         <div className="flex gap-3">
           <button
-            onClick={handleSave}
+            onClick={voidPromise(handleSave)}
             disabled={saving}
             className="rounded-lg bg-indigo-600 px-6 py-2 text-sm text-white hover:bg-indigo-500 disabled:opacity-50 focus-ring focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
           >

--- a/frontend/src/components/pages/ProjectsPage.tsx
+++ b/frontend/src/components/pages/ProjectsPage.tsx
@@ -140,16 +140,15 @@ function ProjectCard({ project, onDelete }: { project: ProjectSummary; onDelete:
         className="rounded-lg border border-gray-700 shadow-xl py-1"
       >
         {/* stopPropagation prevents portal React event bubbling to card */}
-        <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
-          <button
-            type="button"
-            onClick={() => { setMenuOpen(false); onDelete(); }}
-            className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-400 transition-colors hover:bg-gray-800"
-          >
-            <Trash2 className="h-4 w-4" />
-            {t("dashboard:delete_project")}
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); setMenuOpen(false); onDelete(); }}
+          onKeyDown={(e) => e.stopPropagation()}
+          className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-400 transition-colors hover:bg-gray-800"
+        >
+          <Trash2 className="h-4 w-4" />
+          {t("dashboard:delete_project")}
+        </button>
       </Popover>
     </div>
   );

--- a/frontend/src/components/pages/ProjectsPage.tsx
+++ b/frontend/src/components/pages/ProjectsPage.tsx
@@ -1,5 +1,6 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { voidCall, voidPromise } from "@/utils/async";
 import { useLocation } from "wouter";
 import { Loader2, Plus, FolderOpen, Upload, AlertTriangle, Settings, EllipsisVertical, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -317,7 +318,7 @@ export function ProjectsPage() {
           type="file"
           accept=".zip,application/zip"
           aria-label={t("dashboard:import_project_file_aria")}
-          onChange={handleImport}
+          onChange={voidPromise(handleImport)}
           className="hidden"
         />
       </header>
@@ -349,7 +350,7 @@ export function ProjectsPage() {
         <ConflictDialog
           projectName={conflictProject}
           importing={importingProject}
-          onConfirm={(policy) => doImport(conflictFile, policy)}
+          onConfirm={(policy) => voidCall(doImport(conflictFile, policy))}
           onCancel={() => {
             setConflictProject(null);
             setConflictFile(null);
@@ -399,7 +400,7 @@ export function ProjectsPage() {
               </button>
               <button
                 type="button"
-                onClick={handleDeleteProject}
+                onClick={voidPromise(handleDeleteProject)}
                 disabled={deleteLoading}
                 className="inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
               >

--- a/frontend/src/components/pages/ProviderDetail.tsx
+++ b/frontend/src/components/pages/ProviderDetail.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { voidCall, voidPromise } from "@/utils/async";
 import { ChevronRight, Eye, EyeOff, Loader2, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useWarnUnsaved } from "@/hooks/useWarnUnsaved";
@@ -200,9 +201,9 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
     let disposed = false;
     setDraft({});
     setDetail(null);
-    API.getProviderConfig(providerId).then((res) => {
+    voidCall(API.getProviderConfig(providerId).then((res) => {
       if (!disposed) setDetail(res);
-    });
+    }));
     return () => { disposed = true; };
   }, [providerId]);
 
@@ -261,7 +262,7 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
       )}
 
       {/* Credentials */}
-      <CredentialList providerId={providerId} onChanged={handleCredentialChanged} />
+      <CredentialList providerId={providerId} onChanged={voidPromise(handleCredentialChanged)} />
 
       {/* Shared config (all remaining fields from the API are "advanced") */}
       {detail.fields.length > 0 && (

--- a/frontend/src/components/pages/ProviderSection.tsx
+++ b/frontend/src/components/pages/ProviderSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
+import { voidCall } from "@/utils/async";
 import { useLocation, useSearch } from "wouter";
 import { Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -87,7 +88,7 @@ export function ProviderSection() {
 
   useEffect(() => {
     let disposed = false;
-    Promise.all([API.getProviders(), API.listCustomProviders()]).then(([presetRes, customRes]) => {
+    voidCall(Promise.all([API.getProviders(), API.listCustomProviders()]).then(([presetRes, customRes]) => {
       if (disposed) return;
       setProviders(presetRes.providers);
       setCustomProviders(customRes.providers);
@@ -97,7 +98,7 @@ export function ProviderSection() {
         setSelection({ kind: "preset", id: presetRes.providers[0].id });
       }
       setLoading(false);
-    });
+    }));
     return () => {
       disposed = true;
     };

--- a/frontend/src/components/pages/settings/CustomProviderDetail.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderDetail.tsx
@@ -65,7 +65,7 @@ export function CustomProviderDetail({ providerId, onDeleted, onSaved }: CustomP
       setDeleting(false);
       setConfirmDelete(false);
     }
-  }, [providerId, onDeleted]);
+  }, [providerId, onDeleted, showError, t]);
 
   const handleTest = useCallback(async () => {
     if (!provider) return;
@@ -79,7 +79,7 @@ export function CustomProviderDetail({ providerId, onDeleted, onSaved }: CustomP
     } finally {
       setTesting(false);
     }
-  }, [provider]);
+  }, [provider, t]);
 
   const handleFormSaved = useCallback(() => {
     setEditing(false);

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -181,7 +181,7 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
     } finally {
       setDiscovering(false);
     }
-  }, [apiFormat, baseUrl, apiKey, isEdit]);
+  }, [apiFormat, baseUrl, apiKey, showError, t]);
 
   // --- Test connection ---
   const handleTest = useCallback(async () => {
@@ -199,7 +199,7 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
     } finally {
       setTesting(false);
     }
-  }, [apiFormat, baseUrl, apiKey]);
+  }, [apiFormat, baseUrl, apiKey, showError, t]);
 
   // --- Save ---
   const handleSave = useCallback(async () => {
@@ -251,7 +251,7 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
     } finally {
       setSaving(false);
     }
-  }, [displayName, apiFormat, baseUrl, apiKey, models, isEdit, existing, onSaved]);
+  }, [displayName, apiFormat, baseUrl, apiKey, models, isEdit, existing, onSaved, showError, t]);
 
   // --- Model row helpers ---
   const updateModel = (key: string, patch: Partial<ModelRow>) => {

--- a/frontend/src/components/pages/settings/MediaModelSection.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.tsx
@@ -146,7 +146,7 @@ export function MediaModelSection() {
               <div key={key}>
                 <div className="mb-1 text-xs text-gray-400">{label}</div>
                 <ProviderModelSelect
-                  value={(draft[key] ?? settings[key] ?? "") as string}
+                  value={(draft[key] ?? settings[key] ?? "")}
                   options={textBackends}
                   providerNames={allProviderNames}
                   onChange={(v) => setDraft((prev) => ({ ...prev, [key]: v }))}

--- a/frontend/src/components/pages/settings/UsageStatsSection.tsx
+++ b/frontend/src/components/pages/settings/UsageStatsSection.tsx
@@ -47,6 +47,7 @@ export function UsageStatsSection() {
   }, [timeRange, providerFilter]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 依赖变化时重新获取统计数据，fetchStats 内部有 setState，属于正常异步数据获取模式
     void fetchStats();
   }, [fetchStats]);
 

--- a/frontend/src/components/pages/system-config-draft-utils.ts
+++ b/frontend/src/components/pages/system-config-draft-utils.ts
@@ -3,7 +3,7 @@ export function mergeServerDraftPreservingDirty<T extends object>(
   previousSavedDraft: T,
   nextSavedDraft: T,
 ): T {
-  const mergedDraft = { ...nextSavedDraft } as T;
+  const mergedDraft = { ...nextSavedDraft };
 
   for (const key of Object.keys(nextSavedDraft) as (keyof T)[]) {
     if (currentDraft[key] !== previousSavedDraft[key]) {

--- a/frontend/src/components/task-hud/TaskHud.tsx
+++ b/frontend/src/components/task-hud/TaskHud.tsx
@@ -233,9 +233,10 @@ function ChannelSection({
       timersRef.current.set(task.task_id, fadeTimer);
     }
 
+    const timers = timersRef.current;
     return () => {
       // 组件卸载时清理所有定时器
-      for (const timer of timersRef.current.values()) {
+      for (const timer of timers.values()) {
         clearTimeout(timer);
       }
     };

--- a/frontend/src/components/task-hud/TaskHud.tsx
+++ b/frontend/src/components/task-hud/TaskHud.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { activateOnEnterSpace } from "@/utils/a11y";
 import { voidPromise } from "@/utils/async";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
@@ -113,7 +114,10 @@ function TaskRow({
         className={`flex items-center gap-2 px-3 py-1.5 text-sm ${rowBg} ${
           hasError ? "cursor-pointer hover:bg-red-500/15" : ""
         }`}
+        role={hasError ? "button" : undefined}
+        tabIndex={hasError ? 0 : undefined}
         onClick={hasError ? () => onToggleError(task.task_id) : undefined}
+        onKeyDown={hasError ? activateOnEnterSpace(() => onToggleError(task.task_id)) : undefined}
       >
         <TaskStatusIcon status={task.status} />
         <span className="font-mono text-xs text-gray-400">

--- a/frontend/src/components/task-hud/TaskHud.tsx
+++ b/frontend/src/components/task-hud/TaskHud.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { voidPromise } from "@/utils/async";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { Image, Video, Check, X, Loader2, ChevronDown } from "lucide-react";
@@ -397,7 +398,7 @@ export function TaskHud({ anchorRef }: { anchorRef: RefObject<HTMLElement | null
             )}
             {stats.queued > 0 && (
               <button
-                onClick={handleCancelAll}
+                onClick={voidPromise(handleCancelAll)}
                 className="ml-auto text-xs text-gray-500 hover:text-red-400"
                 aria-label={t("cancel_all_queued_aria")}
               >
@@ -408,8 +409,8 @@ export function TaskHud({ anchorRef }: { anchorRef: RefObject<HTMLElement | null
 
           {/* 双通道 */}
           <div className="max-h-80 divide-y divide-gray-800/50 overflow-y-auto">
-            <ChannelSection title={t("image_channel")} icon={Image} tasks={imageTasks} onCancel={handleCancelSingle} />
-            <ChannelSection title={t("video_channel")} icon={Video} tasks={videoTasks} onCancel={handleCancelSingle} />
+            <ChannelSection title={t("image_channel")} icon={Image} tasks={imageTasks} onCancel={voidPromise(handleCancelSingle)} />
+            <ChannelSection title={t("video_channel")} icon={Video} tasks={videoTasks} onCancel={voidPromise(handleCancelSingle)} />
           </div>
 
           {/* 取消确认面板 */}
@@ -433,7 +434,7 @@ export function TaskHud({ anchorRef }: { anchorRef: RefObject<HTMLElement | null
               )}
               <div className="mt-2 flex gap-2">
                 <button
-                  onClick={confirmCancel}
+                  onClick={voidPromise(confirmCancel)}
                   disabled={cancelling}
                   className="rounded bg-red-600/80 px-2 py-0.5 text-xs text-white hover:bg-red-600 disabled:opacity-50"
                 >

--- a/frontend/src/components/ui/AvatarStack.tsx
+++ b/frontend/src/components/ui/AvatarStack.tsx
@@ -92,6 +92,7 @@ function SingleAvatar({
   const showImage = sheetPath && !imgError;
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 图片源变更时重置错误态，确保新 URL 正常加载
     if (imgError) setImgError(false);
   }, [sheetFp, sheetPath]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/frontend/src/components/ui/ClueStack.tsx
+++ b/frontend/src/components/ui/ClueStack.tsx
@@ -98,6 +98,7 @@ function SingleClue({
   const showImage = sheetPath && !imgError;
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 图片源变更时重置错误态，确保新 URL 正常加载
     if (imgError) setImgError(false);
   }, [sheetFp, sheetPath]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/frontend/src/components/ui/ImageLightbox.tsx
+++ b/frontend/src/components/ui/ImageLightbox.tsx
@@ -32,19 +32,21 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
   }
 
   return createPortal(
-    <div
-      className={`fixed inset-0 bg-slate-950/94 backdrop-blur-sm ${UI_LAYERS.modal}`}
-      onClick={onClose}
-    >
+    <div className={`fixed inset-0 bg-slate-950/94 backdrop-blur-sm ${UI_LAYERS.modal}`}>
+      {/* backdrop: click-to-close */}
+      <button
+        type="button"
+        aria-label="关闭全屏预览"
+        className="absolute inset-0 cursor-default appearance-none border-0 bg-transparent p-0"
+        onClick={onClose}
+      />
+
       <div className="absolute right-4 top-4 sm:right-6 sm:top-6">
         <button
           type="button"
-          onClick={(event) => {
-            event.stopPropagation();
-            onClose();
-          }}
-          aria-label="关闭全屏预览"
-          className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/12 bg-black/55 text-white shadow-lg shadow-black/30 backdrop-blur transition-colors hover:bg-black/75"
+          onClick={onClose}
+          aria-label="关闭图片预览"
+          className="relative z-10 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/12 bg-black/55 text-white shadow-lg shadow-black/30 backdrop-blur transition-colors hover:bg-black/75"
         >
           <X className="h-5 w-5" />
         </button>
@@ -55,8 +57,7 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
           role="dialog"
           aria-modal="true"
           aria-label={`${alt} 全屏预览`}
-          className="relative max-h-full max-w-full"
-          onClick={(event) => event.stopPropagation()}
+          className="relative z-10 max-h-full max-w-full"
         >
           <img
             src={src}

--- a/frontend/src/components/ui/PreviewableImageFrame.test.tsx
+++ b/frontend/src/components/ui/PreviewableImageFrame.test.tsx
@@ -17,17 +17,15 @@ describe("PreviewableImageFrame", () => {
       screen.getByRole("dialog", { name: "示例图 全屏预览" }),
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "关闭全屏预览" }));
+    fireEvent.click(screen.getByRole("button", { name: "关闭图片预览" }));
     expect(
       screen.queryByRole("dialog", { name: "示例图 全屏预览" }),
     ).not.toBeInTheDocument();
 
     fireEvent.click(trigger);
-    const dialog = screen.getByRole("dialog", { name: "示例图 全屏预览" });
-    const backdrop = dialog.parentElement?.parentElement;
-    expect(backdrop).not.toBeNull();
-
-    fireEvent.click(backdrop as HTMLElement);
+    // backdrop button (click-to-close) is the sibling of the close button
+    const backdropBtn = screen.getByRole("button", { name: "关闭全屏预览" });
+    fireEvent.click(backdropBtn);
 
     expect(
       screen.queryByRole("dialog", { name: "示例图 全屏预览" }),

--- a/frontend/src/components/ui/ProviderModelSelect.tsx
+++ b/frontend/src/components/ui/ProviderModelSelect.tsx
@@ -59,7 +59,11 @@ export function ProviderModelSelect({
   const triggerRef = useRef<HTMLButtonElement>(null);
   const itemRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
 
-  const grouped = groupByProvider(options);
+  // Memoize grouped so flatOptions below has a stable reference when options
+  // hasn't changed; otherwise every render creates a new `grouped` object,
+  // invalidates flatOptions, and resets activeIndex on the effect below,
+  // breaking keyboard ArrowUp/ArrowDown navigation.
+  const grouped = useMemo(() => groupByProvider(options), [options]);
 
   // Build a flat list of selectable options for keyboard navigation
   const flatOptions = useMemo(() => {

--- a/frontend/src/components/ui/ProviderModelSelect.tsx
+++ b/frontend/src/components/ui/ProviderModelSelect.tsx
@@ -76,7 +76,7 @@ export function ProviderModelSelect({
       }
     }
     return list;
-  }, [options, allowDefault]);
+  }, [allowDefault, grouped]);
 
   // Close on outside click
   useEffect(() => {
@@ -95,7 +95,7 @@ export function ProviderModelSelect({
       const idx = flatOptions.findIndex((o) => o.fullValue === value);
       setActiveIndex(idx >= 0 ? idx : 0);
     }
-  }, [open]);
+  }, [open, flatOptions, value]);
 
   // Scroll active item into view
   useEffect(() => {

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -23,7 +23,7 @@ export interface AttachedImage {
 
 function parseSsePayload(event: MessageEvent): Record<string, unknown> {
   try {
-    return JSON.parse(event.data || "{}");
+    return JSON.parse(String(event.data || "{}")) as Record<string, unknown>;
   } catch {
     return {};
   }
@@ -85,8 +85,9 @@ const LAST_SESSION_KEY = "arcreel:lastSessionByProject";
 
 function getLastSessionId(projectName: string): string | null {
   try {
-    const map = JSON.parse(localStorage.getItem(LAST_SESSION_KEY) || "{}");
-    return map[projectName] ?? null;
+    const map = JSON.parse(localStorage.getItem(LAST_SESSION_KEY) || "{}") as Record<string, unknown>;
+    const value = map[projectName];
+    return typeof value === "string" ? value : null;
   } catch {
     return null;
   }
@@ -94,7 +95,7 @@ function getLastSessionId(projectName: string): string | null {
 
 function saveLastSessionId(projectName: string, sessionId: string): void {
   try {
-    const map = JSON.parse(localStorage.getItem(LAST_SESSION_KEY) || "{}");
+    const map = JSON.parse(localStorage.getItem(LAST_SESSION_KEY) || "{}") as Record<string, unknown>;
     map[projectName] = sessionId;
     localStorage.setItem(LAST_SESSION_KEY, JSON.stringify(map));
   } catch {

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
+import { voidCall } from "@/utils/async";
 import { API } from "@/api";
 import { uid } from "@/utils/id";
 import { useAssistantStore } from "@/stores/assistant-store";
@@ -382,7 +383,7 @@ export function useAssistantSession(projectName: string | null) {
       })
       .catch(() => {});
 
-    init();
+    voidCall(init());
 
     return () => {
       cancelled = true;
@@ -527,7 +528,7 @@ export function useAssistantSession(projectName: string | null) {
   }, [projectName, store]);
 
   // 创建新会话（懒创建：仅清空状态，实际创建延迟到首次发消息时）
-  const createNewSession = useCallback(async () => {
+  const createNewSession = useCallback(() => {
     if (!projectName) return;
 
     invalidatePendingSend();

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -226,7 +226,7 @@ export function useAssistantSession(projectName: string | null) {
 
       source.addEventListener("snapshot", (event) => {
         if (!isActiveStream()) return;
-        const data = parseSsePayload(event as MessageEvent);
+        const data = parseSsePayload(event);
         const isSending = store.getState().sending;
 
         // 正在发送消息时，后端可能尚未将 session 切为 "running"，
@@ -240,7 +240,7 @@ export function useAssistantSession(projectName: string | null) {
 
         if (typeof data.status === "string") {
           store.getState().setSessionStatus(data.status as "idle");
-          statusRef.current = data.status as string;
+          statusRef.current = data.status;
           // 收到任何有效 status 都清除 sending（stale 的已在上方过滤）。
           // 特别是 "running" 表示后端已确认收到消息，必须清除 sending，
           // 否则后续的 "completed" 会被 status handler 的 isSending 守卫过滤掉。
@@ -250,7 +250,7 @@ export function useAssistantSession(projectName: string | null) {
 
       source.addEventListener("patch", (event) => {
         if (!isActiveStream()) return;
-        const payload = parseSsePayload(event as MessageEvent);
+        const payload = parseSsePayload(event);
         const patch = (payload.patch ?? payload) as Record<string, unknown>;
         store.getState().setTurns(applyTurnPatch(store.getState().turns, patch));
         if ("draft_turn" in payload) {
@@ -260,7 +260,7 @@ export function useAssistantSession(projectName: string | null) {
 
       source.addEventListener("delta", (event) => {
         if (!isActiveStream()) return;
-        const payload = parseSsePayload(event as MessageEvent);
+        const payload = parseSsePayload(event);
         if ("draft_turn" in payload) {
           store.getState().setDraftTurn((payload.draft_turn as Turn) ?? null);
         }
@@ -268,7 +268,7 @@ export function useAssistantSession(projectName: string | null) {
 
       source.addEventListener("status", (event) => {
         if (!isActiveStream()) return;
-        const data = parseSsePayload(event as MessageEvent);
+        const data = parseSsePayload(event);
         const status = (data.status as string) ?? statusRef.current;
         const isSending = store.getState().sending;
 
@@ -304,7 +304,7 @@ export function useAssistantSession(projectName: string | null) {
 
       source.addEventListener("question", (event) => {
         if (!isActiveStream()) return;
-        const payload = parseSsePayload(event as MessageEvent);
+        const payload = parseSsePayload(event);
         const pendingQuestion = getPendingQuestionFromEvent(payload);
         if (pendingQuestion) {
           syncPendingQuestion(pendingQuestion);

--- a/frontend/src/hooks/useAutoFocus.test.tsx
+++ b/frontend/src/hooks/useAutoFocus.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { useAutoFocus } from "./useAutoFocus";
+
+describe("useAutoFocus", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls focus on the rendered element when enabled (default)", () => {
+    const focusSpy = vi.spyOn(HTMLElement.prototype, "focus");
+
+    function TestComponent() {
+      const ref = useAutoFocus<HTMLInputElement>();
+      return <input ref={ref} data-testid="input" />;
+    }
+    render(<TestComponent />);
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it("does not call focus when enabled=false", () => {
+    const focusSpy = vi.spyOn(HTMLElement.prototype, "focus");
+
+    function TestComponent() {
+      const ref = useAutoFocus<HTMLInputElement>(false);
+      return <input ref={ref} data-testid="input" />;
+    }
+    render(<TestComponent />);
+    expect(focusSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useAutoFocus.ts
+++ b/frontend/src/hooks/useAutoFocus.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from "react";
+
+export function useAutoFocus<T extends HTMLElement>(enabled = true) {
+  const ref = useRef<T>(null);
+  useEffect(() => {
+    if (enabled) ref.current?.focus();
+  }, [enabled]);
+  return ref;
+}

--- a/frontend/src/hooks/useProjectEventsSSE.ts
+++ b/frontend/src/hooks/useProjectEventsSSE.ts
@@ -169,13 +169,13 @@ export function useProjectEventsSSE(projectName?: string | null): void {
       pushToast(`同步项目变更失败: ${(err as Error).message}`, "warning");
     } finally {
       refreshingRef.current = false;
-      if (needsRefreshRef.current) {
-        needsRefreshRef.current = false;
-        void refreshProject();
-        return;
-      }
-      flushQueuedFocus();
     }
+    if (needsRefreshRef.current) {
+      needsRefreshRef.current = false;
+      void refreshProject();
+      return;
+    }
+    flushQueuedFocus();
   }, [flushQueuedFocus, projectName, pushToast, setCurrentProject]);
 
   useEffect(() => {
@@ -335,5 +335,6 @@ export function useProjectEventsSSE(projectName?: string | null): void {
     refreshProject,
     pushToast,
     setAssistantToolActivitySuppressed,
+    setLocation,
   ]);
 }

--- a/frontend/src/hooks/useTasksSSE.ts
+++ b/frontend/src/hooks/useTasksSSE.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { API } from "@/api";
 import { useTasksStore } from "@/stores/tasks-store";
+import { voidCall } from "@/utils/async";
 
 const POLL_INTERVAL_MS = 3000;
 
@@ -38,11 +39,11 @@ export function useTasksSSE(projectName?: string | null): void {
     }
 
     // Initial fetch
-    poll();
+    voidCall(poll());
 
     // Periodic polling
     timerRef.current = setInterval(() => {
-      if (!disposed) poll();
+      if (!disposed) voidCall(poll());
     }, POLL_INTERVAL_MS);
 
     return () => {

--- a/frontend/src/hooks/useTasksSSE.ts
+++ b/frontend/src/hooks/useTasksSSE.ts
@@ -29,9 +29,7 @@ export function useTasksSSE(projectName?: string | null): void {
         ]);
         if (disposed) return;
         setTasks(tasksRes.items);
-        // REST returns { stats: {...} }
-        const stats = (statsRes as any).stats ?? statsRes;
-        setStats(stats);
+        setStats(statsRes.stats);
         setConnected(true);
       } catch {
         if (disposed) return;

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -2,6 +2,7 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import { voidCall } from '@/utils/async';
 
 import enCommon from './en/common';
 import enAuth from './en/auth';
@@ -28,7 +29,7 @@ const resources = {
   },
 };
 
-i18n
+voidCall(i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
@@ -41,6 +42,6 @@ i18n
     // Use 'common' as the default namespace
     defaultNS: 'common',
     ns: ['common', 'auth', 'dashboard', 'errors'],
-  });
+  }));
 
 export default i18n;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 
 import { useState, type FormEvent } from "react";
+import { useAutoFocus } from "@/hooks/useAutoFocus";
 import { voidPromise } from "@/utils/async";
 import { useLocation } from "wouter";
 import { useTranslation } from "react-i18next";
@@ -14,6 +15,7 @@ export function LoginPage() {
   const [loading, setLoading] = useState(false);
   const [, setLocation] = useLocation();
   const login = useAuthStore((s) => s.login);
+  const usernameRef = useAutoFocus<HTMLInputElement>();
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -66,7 +68,7 @@ export function LoginPage() {
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-gray-100 outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
-              autoFocus
+              ref={usernameRef}
               required
             />
           </div>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 
 import { useState, type FormEvent } from "react";
+import { voidPromise } from "@/utils/async";
 import { useLocation } from "wouter";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "@/stores/auth-store";
@@ -57,7 +58,7 @@ export function LoginPage() {
           <span>ArcReel</span>
         </h1>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={voidPromise(handleSubmit)} className="space-y-4">
           <div>
             <label className="mb-1 block text-sm text-gray-400">{t("auth:username")}</label>
             <input

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useState, type FormEvent } from "react";
 import { useLocation } from "wouter";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "@/stores/auth-store";
+import type { LoginResponse, ErrorResponse } from "@/api";
 
 export function LoginPage() {
   const { t, i18n } = useTranslation(["common", "auth"]);
@@ -33,11 +34,12 @@ export function LoginPage() {
       });
 
       if (!resp.ok) {
-        const data = await resp.json().catch(() => ({}));
-        throw new Error(data.detail || t("auth:login_failed"));
+        const data = await resp.json().catch(() => ({})) as Partial<ErrorResponse>;
+        const detail = data.detail;
+        throw new Error(typeof detail === "string" ? detail : t("auth:login_failed"));
       }
 
-      const data = await resp.json();
+      const data = await resp.json() as LoginResponse;
       login(data.access_token, username);
       setLocation("/app/projects");
     } catch (err) {

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,8 +2,9 @@ import "@testing-library/jest-dom/vitest";
 import { afterEach, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 import i18n from "@/i18n";
+import { voidCall } from "@/utils/async";
 
-i18n.changeLanguage("zh");
+voidCall(i18n.changeLanguage("zh"));
 
 afterEach(() => {
   cleanup();

--- a/frontend/src/utils/a11y.ts
+++ b/frontend/src/utils/a11y.ts
@@ -1,0 +1,10 @@
+import type { KeyboardEvent } from "react";
+
+export function activateOnEnterSpace(handler: () => void) {
+  return (e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handler();
+    }
+  };
+}

--- a/frontend/src/utils/async.test.ts
+++ b/frontend/src/utils/async.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { voidCall, voidPromise } from "./async";
+
+describe("voidPromise", () => {
+  it("returns a void function that calls fn with args", () => {
+    const fn = vi.fn(async (a: number, b: string) => `${a}-${b}`);
+    const wrapped = voidPromise(fn);
+    const result = wrapped(1, "x");
+    expect(result).toBeUndefined();
+    expect(fn).toHaveBeenCalledWith(1, "x");
+  });
+
+  it("routes rejection to console.error by default", async () => {
+    const err = new Error("boom");
+    const fn = vi.fn(async () => { throw err; });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    voidPromise(fn)();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(spy).toHaveBeenCalledWith(err);
+    spy.mockRestore();
+  });
+
+  it("routes rejection to custom onError when provided", async () => {
+    const err = new Error("boom");
+    const fn = vi.fn(async () => { throw err; });
+    const onError = vi.fn();
+    voidPromise(fn, { onError })();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onError).toHaveBeenCalledWith(err);
+  });
+});
+
+describe("voidCall", () => {
+  it("swallows rejection with console.error by default", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    voidCall(Promise.reject(new Error("x")));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("routes rejection to custom onError", async () => {
+    const onError = vi.fn();
+    voidCall(Promise.reject(new Error("x")), onError);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onError).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/async.ts
+++ b/frontend/src/utils/async.ts
@@ -1,0 +1,22 @@
+type VoidPromiseOptions = {
+  onError?: (err: unknown) => void;
+};
+
+export function voidPromise<Args extends unknown[]>(
+  fn: (...args: Args) => Promise<unknown>,
+  opts?: VoidPromiseOptions,
+): (...args: Args) => void {
+  return (...args) => {
+    fn(...args).catch((err: unknown) => {
+      if (opts?.onError) opts.onError(err);
+      else console.error(err);
+    });
+  };
+}
+
+export function voidCall<T>(
+  promise: Promise<T>,
+  onError: (err: unknown) => void = console.error,
+): void {
+  promise.catch(onError);
+}


### PR DESCRIPTION
## Summary

完成 issue #219 a11y audit 系列 PR 3 收尾：把前端剩余 229 条 ESLint warning 清零、所有规则 flip 到 error、移除 `--max-warnings` ratchet、清空 `MIGRATION_WARN_RULES_*` 三个常量。

- **211 tracked + 18 未入账的 react-hooks warning 全部清零**
- **ESLint 配置从 "渐进迁移"转为"零 warning 严格模式"**
- **新增 3 个 helper**：`voidPromise`/`voidCall`、`useAutoFocus`、`activateOnEnterSpace`
- **新增 CONTRIBUTING.md 的 disable 使用规范**

PR 系列：#290（PR 1，基础设施）→ #296（PR 2，focus-ring 主题修复）→ **本 PR（PR 3）**。

## 变更要点

| 主题 | Commit |
|---|---|
| helpers 脚手架 | `631140e` feat: add async/a11y helpers |
| 测试文件 override | `5aa1cf5` chore: relax typed rules on test files |
| API 类型源头 | `061f6e5` + `f7443f2` refactor: type API responses |
| SSE hook 类型 | `32d3ce5` refactor: fix SSE hook warnings |
| Promise 处理 | `9192ef7` refactor: wrap with voidPromise/voidCall |
| 机械清理 | `cbfb0bf` chore: remove redundant assertions/unused vars |
| set-state-in-effect | `3138666` refactor: resolve set-state-in-effect |
| exhaustive-deps + refs | `71a886b` refactor: resolve exhaustive-deps/refs |
| a11y 扫尾 | `337c575` fix(a11y): remaining jsx-a11y |
| Agent SDK 类型 | `011cdc6` refactor: type agent SDK payloads |
| 收尾 flip + 清 migration | `babc8a0` chore: flip rules to error, remove ratchet |
| Rebase 后补丁 | `1a543a5` refactor: wrap async handlers post-PR 2 |

## 新增 eslint-disable 清单

### react-hooks/set-state-in-effect (17)

| file:line | 理由 |
|---|---|
| src/components/canvas/lorebook/ClueCard.tsx:60 | 可编辑描述字段必须跟随外部 prop 更新 |
| src/components/canvas/lorebook/ClueCard.tsx:65 | 图片源变更时重置错误态 |
| src/components/canvas/lorebook/LorebookGallery.tsx:72 | mode prop 受控驱动 tab 切换 |
| src/components/canvas/lorebook/LorebookGallery.tsx:85 | 智能体滚动目标事件驱动 tab 切换 |
| src/components/canvas/timeline/GridPreviewPanel.tsx:180 | 异步加载前清空旧数据（1条覆盖同 effect 多个 setState） |
| src/components/canvas/timeline/SegmentCard.tsx:283 | 可编辑备注随外部数据同步 |
| src/components/canvas/timeline/SegmentCard.tsx:403 | 切换镜头时重置本地草稿 |
| src/components/canvas/timeline/SegmentCard.tsx:420 | image_prompt 结构切换同步本地编辑态 |
| src/components/canvas/timeline/SegmentCard.tsx:428 | video_prompt 结构切换同步本地编辑态 |
| src/components/copilot/PendingQuestionWizard.tsx:43 | 新问题到来时重置向导所有状态 |
| src/components/layout/AssetSidebar.tsx:103 | 图片源变更时重置错误态 |
| src/components/layout/ExportScopeDialog.tsx:50 | 弹窗关闭时重置到初始选择界面 |
| src/components/layout/ExportScopeDialog.tsx:58 | episodes prop 变化时同步表单默认值 |
| src/components/layout/UsageDrawer.tsx:62 | 抽屉打开时触发数据加载 |
| src/components/pages/settings/UsageStatsSection.tsx:51 | 依赖变化时重新获取统计数据 |
| src/components/ui/AvatarStack.tsx:95 | 图片源变更时重置错误态 |
| src/components/ui/ClueStack.tsx:102 | 图片源变更时重置错误态 |

### react-hooks/exhaustive-deps (5 disable / 9 add-deps)

| file:line | 处理 | 理由 |
|---|---|---|
| src/components/canvas/timeline/GridPreviewPanel.tsx:202 | disable | grid 加 deps 会触发重拉循环 |
| src/components/canvas/timeline/PreprocessingView.tsx:52 | disable | content 加 deps 会触发重拉循环 |
| src/components/canvas/timeline/VersionTimeMachine.tsx:77 | disable | loadVersions 是组件内普通函数无法稳定化 |
| （其余 9 处） | add deps | 添加 t / showError / setLocation 等稳定引用 |

### react-hooks/refs (5 disable / 1 refactor)

| file:line | 理由 |
|---|---|
| src/components/canvas/StudioCanvasRouter.tsx:55 | tRef.current = t 是稳定 event-handler ref 模式 |
| src/components/copilot/AgentCopilot.tsx:297-298 | slashPosRef 在 render+handler 双用，转 state 会引入 stale closure |
| src/components/copilot/AgentCopilot.tsx:455 | aria-activedescendant 需实时读取 ref 派生值 |
| src/components/layout/AssetSidebar.tsx:149 | 同 StudioCanvasRouter 的 event-handler ref 模式 |

### react-hooks/incompatible-library (1)

| file:line | 理由 |
|---|---|
| src/components/canvas/timeline/TimelineCanvas.tsx:268 | TanStack Virtual 的 useVirtualizer 与 React Compiler 不兼容（已知第三方库限制） |

### jsx-a11y/media-has-caption (2)

| file:line | 理由 |
|---|---|
| src/components/canvas/timeline/SegmentCard.tsx (VideoPlayer) | 生成式预览视频暂无字幕源 |
| src/components/canvas/timeline/VersionTimeMachine.tsx | 生成式预览视频暂无字幕源 |

### @typescript-eslint/require-await (0)

无 disable；所有命中通过删除 async 或实际补 await 修复。

## Test plan

- [x] `pnpm typecheck` 零 error
- [x] `pnpm lint` 零 problems（0 errors, 0 warnings）
- [x] `pnpm test` 140/140 tests pass（1 个 pre-existing `AgentCopilot.test.tsx` 错误与本 PR 无关）
- [x] `pnpm build` 成功
- [ ] 浏览器手动回归：
  - [ ] 登录页 autoFocus 生效、登录流程正常
  - [ ] 任务 HUD SSE 状态流实时更新
  - [ ] 项目事件流（修改项目 → UI 同步）
  - [ ] 键盘导航：Tab + Enter/Space 能触发改为 button 或 role=button 的元素
  - [ ] 改为 `<button>` 的元素视觉无偏移
- [ ] CI frontend-tests green

## 文档更新

- `docs/superpowers/specs/2026-04-14-eslint-a11y-pr3-design.md` — 设计文档
- `docs/superpowers/plans/2026-04-14-eslint-a11y-pr3.md` — 实施计划
- `CONTRIBUTING.md` — 新增「ESLint disable 使用规范」小节

Closes #219.