### PR TITLE
feat: 自定义供应商支持 NewAPI 格式（统一视频端点）

### DIFF
--- a/docs/superpowers/plans/2026-04-15-newapi-custom-provider.md
+++ b/docs/superpowers/plans/2026-04-15-newapi-custom-provider.md
@@ -1,0 +1,1086 @@
+# NewAPI 自定义供应商格式 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 ArcReel 的自定义供应商体系新增 `api_format = "newapi"`，其中文本/图片复用 OpenAI delegate，视频通过直连 NewAPI 统一端点 `/v1/video/generations` 的新后端 `NewAPIVideoBackend` 实现。
+
+**Architecture:** `api_format` 扩成三值枚举 `{openai, google, newapi}`。Factory 在 `newapi` 分支下：文本/图片走 `OpenAITextBackend`/`OpenAIImageBackend`（OpenAI 兼容），视频走新的 `NewAPIVideoBackend`（`httpx` 直连：`POST /v1/video/generations` → 轮询 `GET /v1/video/generations/{task_id}` → 下载 `url`）。模型发现与连接测试复用 OpenAI 路径。
+
+**Tech Stack:** Python 3.12 + FastAPI + SQLAlchemy async + `httpx.AsyncClient` + React 19 + TypeScript。
+
+**参考：** 设计文档 `docs/superpowers/specs/2026-04-15-newapi-custom-provider-design.md`。
+
+---
+
+## File Map
+
+**新建：**
+- `lib/video_backends/newapi.py` — `NewAPIVideoBackend` 实现
+- `tests/test_newapi_video_backend.py` — backend 单元测试（mock httpx）
+
+**修改：**
+- `lib/providers.py` — 增加 `PROVIDER_NEWAPI` 常量
+- `lib/video_backends/__init__.py` — 注册 NewAPIVideoBackend
+- `lib/custom_provider/factory.py` — 增加 `newapi` 分支 + `_create_newapi_backend`
+- `lib/custom_provider/discovery.py` — `newapi` 复用 OpenAI 路径
+- `lib/db/models/custom_provider.py` — 字段注释更新
+- `server/routers/custom_providers.py` — `_run_connection_test` 支持 `newapi`，注释更新
+- `lib/i18n/zh/errors.py` / `lib/i18n/en/errors.py` — 文案更新
+- `frontend/src/types/custom-provider.ts` — 类型联合扩展
+- `frontend/src/components/pages/settings/CustomProviderForm.tsx` — 下拉选项
+- `tests/test_custom_provider_factory.py` — newapi 分支覆盖
+- `tests/test_model_discovery.py` — newapi 分支覆盖
+- `tests/test_custom_providers_api.py` — 入参校验扩展
+
+---
+
+## Task 1: 添加 PROVIDER_NEWAPI 常量
+
+**Files:**
+- Modify: `lib/providers.py:1-13`
+
+- [ ] **Step 1: 追加常量**
+
+编辑 `lib/providers.py`，在 `PROVIDER_OPENAI` 下方加一行：
+
+```python
+PROVIDER_OPENAI = "openai"
+PROVIDER_NEWAPI = "newapi"
+```
+
+- [ ] **Step 2: 验证导入**
+
+Run: `uv run python -c "from lib.providers import PROVIDER_NEWAPI; print(PROVIDER_NEWAPI)"`
+Expected: `newapi`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/providers.py
+git commit -m "feat(providers): add PROVIDER_NEWAPI constant"
+```
+
+---
+
+## Task 2: NewAPIVideoBackend — 先写失败的文生视频测试
+
+**Files:**
+- Create: `tests/test_newapi_video_backend.py`
+
+- [ ] **Step 1: 创建测试文件骨架 + 第一个测试**
+
+```python
+"""NewAPIVideoBackend 单元测试（mock httpx）。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from lib.providers import PROVIDER_NEWAPI
+from lib.video_backends.base import (
+    VideoCapability,
+    VideoGenerationRequest,
+)
+
+
+def _make_response(status_code: int, json_body: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class TestNewAPIVideoBackend:
+    def test_name_and_model(self):
+        from lib.video_backends.newapi import NewAPIVideoBackend
+
+        backend = NewAPIVideoBackend(
+            api_key="sk-test", base_url="https://example.com/v1", model="kling-v1"
+        )
+        assert backend.name == PROVIDER_NEWAPI
+        assert backend.model == "kling-v1"
+
+    def test_capabilities(self):
+        from lib.video_backends.newapi import NewAPIVideoBackend
+
+        backend = NewAPIVideoBackend(api_key="sk-test", base_url="https://x/v1", model="m")
+        assert VideoCapability.TEXT_TO_VIDEO in backend.capabilities
+        assert VideoCapability.IMAGE_TO_VIDEO in backend.capabilities
+        assert backend.video_capabilities.reference_images is False
+        assert backend.video_capabilities.max_reference_images == 0
+
+    async def test_text_to_video_happy_path(self, tmp_path: Path):
+        create_resp = _make_response(200, {"task_id": "task-42", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "task-42",
+                "status": "completed",
+                "url": "https://cdn.example.com/out.mp4",
+                "format": "mp4",
+                "metadata": {"duration": 5, "fps": 24, "width": 720, "height": 1280, "seed": 0},
+            },
+        )
+        download_resp = MagicMock()
+        download_resp.status_code = 200
+        download_resp.content = b"mp4-bytes"
+        download_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(side_effect=[poll_resp, download_resp])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(
+                api_key="sk-test", base_url="https://example.com/v1", model="kling-v1"
+            )
+            request = VideoGenerationRequest(
+                prompt="A cat running",
+                output_path=tmp_path / "out.mp4",
+                aspect_ratio="9:16",
+                resolution="720p",
+                duration_seconds=5,
+            )
+            result = await backend.generate(request)
+
+        assert result.video_path == tmp_path / "out.mp4"
+        assert result.video_path.read_bytes() == b"mp4-bytes"
+        assert result.provider == PROVIDER_NEWAPI
+        assert result.model == "kling-v1"
+        assert result.duration_seconds == 5
+        assert result.task_id == "task-42"
+
+        post_call = mock_client.post.call_args
+        assert post_call.args[0].endswith("/video/generations")
+        assert post_call.kwargs["json"]["model"] == "kling-v1"
+        assert post_call.kwargs["json"]["prompt"] == "A cat running"
+        assert post_call.kwargs["json"]["width"] == 720
+        assert post_call.kwargs["json"]["height"] == 1280
+        assert post_call.kwargs["json"]["duration"] == 5
+        assert post_call.kwargs["json"]["n"] == 1
+        assert "image" not in post_call.kwargs["json"]
+        assert post_call.kwargs["headers"]["Authorization"] == "Bearer sk-test"
+```
+
+- [ ] **Step 2: 运行测试（应该导入失败）**
+
+Run: `uv run pytest tests/test_newapi_video_backend.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'lib.video_backends.newapi'`
+
+---
+
+## Task 3: NewAPIVideoBackend — 最小实现使测试通过
+
+**Files:**
+- Create: `lib/video_backends/newapi.py`
+
+- [ ] **Step 1: 实现 backend**
+
+```python
+"""NewAPIVideoBackend — NewAPI 统一视频生成端点后端。
+
+对接 NewAPI 的 /v1/video/generations 接口，支持 Sora / Kling / 即梦 / Wan / Veo
+等多家厂商模型，靠请求体的 model 字段分发。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from pathlib import Path
+
+import httpx
+
+from lib.providers import PROVIDER_NEWAPI
+from lib.retry import (
+    BASE_RETRYABLE_ERRORS,
+    DEFAULT_BACKOFF_SECONDS,
+    DEFAULT_MAX_ATTEMPTS,
+    DOWNLOAD_BACKOFF_SECONDS,
+    DOWNLOAD_MAX_ATTEMPTS,
+    with_retry_async,
+)
+from lib.video_backends.base import (
+    IMAGE_MIME_TYPES,
+    VideoCapabilities,
+    VideoCapability,
+    VideoGenerationRequest,
+    VideoGenerationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "kling-v1"
+
+_POLL_INTERVAL_SECONDS = 5.0
+_MIN_POLL_TIMEOUT_SECONDS = 600
+_POLL_TIMEOUT_PER_SECOND = 30
+
+_SIZE_MAP: dict[tuple[str, str], tuple[int, int]] = {
+    ("720p", "9:16"): (720, 1280),
+    ("720p", "16:9"): (1280, 720),
+    ("1080p", "9:16"): (1080, 1920),
+    ("1080p", "16:9"): (1920, 1080),
+}
+_DEFAULT_SIZE: tuple[int, int] = (720, 1280)
+
+
+def _resolve_size(resolution: str, aspect_ratio: str) -> tuple[int, int]:
+    return _SIZE_MAP.get((resolution, aspect_ratio), _DEFAULT_SIZE)
+
+
+def _encode_image_to_data_uri(path: Path) -> str:
+    mime = IMAGE_MIME_TYPES.get(path.suffix.lower(), "image/png")
+    payload = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:{mime};base64,{payload}"
+
+
+class NewAPIVideoBackend:
+    """NewAPI 统一视频生成端点后端。"""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str,
+        model: str | None = None,
+        http_timeout: float = 60.0,
+    ) -> None:
+        if not api_key:
+            raise ValueError("NewAPIVideoBackend 需要 api_key")
+        if not base_url:
+            raise ValueError("NewAPIVideoBackend 需要 base_url")
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._model = model or DEFAULT_MODEL
+        self._http_timeout = http_timeout
+        self._capabilities: set[VideoCapability] = {
+            VideoCapability.TEXT_TO_VIDEO,
+            VideoCapability.IMAGE_TO_VIDEO,
+        }
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_NEWAPI
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def capabilities(self) -> set[VideoCapability]:
+        return self._capabilities
+
+    @property
+    def video_capabilities(self) -> VideoCapabilities:
+        return VideoCapabilities(reference_images=False, max_reference_images=0)
+
+    # ------------------------------------------------------------------
+    # Public entry
+    # ------------------------------------------------------------------
+
+    async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
+        width, height = _resolve_size(request.resolution, request.aspect_ratio)
+        payload: dict = {
+            "model": self._model,
+            "prompt": request.prompt,
+            "width": width,
+            "height": height,
+            "duration": request.duration_seconds,
+            "n": 1,
+        }
+        if request.seed is not None:
+            payload["seed"] = request.seed
+        if request.negative_prompt:
+            payload.setdefault("metadata", {})["negative_prompt"] = request.negative_prompt
+        if request.start_image and Path(request.start_image).exists():
+            payload["image"] = _encode_image_to_data_uri(Path(request.start_image))
+        if request.reference_images:
+            logger.warning(
+                "NewAPIVideoBackend 不支持多张参考图（reference_images=%d），已忽略",
+                len(request.reference_images),
+            )
+
+        logger.info("NewAPI 视频生成开始: model=%s, duration=%s", self._model, request.duration_seconds)
+
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            task_id = await self._create_task(client, payload)
+            logger.info("NewAPI 任务创建: task_id=%s", task_id)
+
+            final = await self._poll_until_done(
+                client, task_id=task_id, max_wait=self._max_wait(request.duration_seconds)
+            )
+            video_url = final.get("url")
+            if not video_url:
+                raise RuntimeError(f"NewAPI 任务完成但缺少 url 字段: {final}")
+
+            await self._download(client, video_url, request.output_path)
+
+        meta = final.get("metadata") or {}
+        return VideoGenerationResult(
+            video_path=request.output_path,
+            provider=PROVIDER_NEWAPI,
+            model=self._model,
+            duration_seconds=int(meta.get("duration") or request.duration_seconds),
+            task_id=task_id,
+            seed=meta.get("seed"),
+        )
+
+    # ------------------------------------------------------------------
+    # HTTP helpers (each independently retried)
+    # ------------------------------------------------------------------
+
+    @with_retry_async(
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+        retryable_errors=BASE_RETRYABLE_ERRORS + (httpx.HTTPError,),
+    )
+    async def _create_task(self, client: httpx.AsyncClient, payload: dict) -> str:
+        resp = await client.post(
+            f"{self._base_url}/video/generations",
+            json=payload,
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        task_id = body.get("task_id")
+        if not task_id:
+            raise RuntimeError(f"NewAPI 创建任务返回体缺少 task_id: {body}")
+        return task_id
+
+    async def _poll_until_done(
+        self, client: httpx.AsyncClient, *, task_id: str, max_wait: float
+    ) -> dict:
+        elapsed = 0.0
+        while True:
+            if elapsed >= max_wait:
+                raise TimeoutError(f"NewAPI 视频任务超时（{max_wait:.0f}秒）: task_id={task_id}")
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+            elapsed += _POLL_INTERVAL_SECONDS
+            state = await self._poll_once(client, task_id)
+            status = state.get("status")
+            if status == "completed":
+                return state
+            if status == "failed":
+                err = (state.get("error") or {}).get("message") or "unknown"
+                raise RuntimeError(f"NewAPI 视频生成失败: {err}")
+
+    @with_retry_async(
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+        retryable_errors=BASE_RETRYABLE_ERRORS + (httpx.HTTPError,),
+    )
+    async def _poll_once(self, client: httpx.AsyncClient, task_id: str) -> dict:
+        resp = await client.get(
+            f"{self._base_url}/video/generations/{task_id}",
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    @with_retry_async(
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
+        retryable_errors=BASE_RETRYABLE_ERRORS + (httpx.HTTPError,),
+    )
+    async def _download(self, client: httpx.AsyncClient, url: str, output_path: Path) -> None:
+        resp = await client.get(url, headers=self._headers())
+        resp.raise_for_status()
+
+        def _write():
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(resp.content)
+
+        await asyncio.to_thread(_write)
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"}
+
+    @staticmethod
+    def _max_wait(duration_seconds: int) -> float:
+        return max(_MIN_POLL_TIMEOUT_SECONDS, duration_seconds * _POLL_TIMEOUT_PER_SECOND)
+```
+
+- [ ] **Step 2: 运行测试**
+
+Run: `uv run pytest tests/test_newapi_video_backend.py -v`
+Expected: 三个测试都 PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/video_backends/newapi.py tests/test_newapi_video_backend.py
+git commit -m "feat(video-backends): add NewAPIVideoBackend for unified /v1/video/generations"
+```
+
+---
+
+## Task 4: 追加图生视频测试（Base64 编码）
+
+**Files:**
+- Modify: `tests/test_newapi_video_backend.py`（追加方法）
+
+- [ ] **Step 1: 追加测试方法到 TestNewAPIVideoBackend 类**
+
+```python
+    async def test_image_to_video_encodes_base64(self, tmp_path: Path):
+        img_path = tmp_path / "start.png"
+        img_path.write_bytes(b"\x89PNG\r\nfake")
+
+        create_resp = _make_response(200, {"task_id": "t1", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "t1",
+                "status": "completed",
+                "url": "https://cdn/x.mp4",
+                "metadata": {"duration": 5},
+            },
+        )
+        download_resp = MagicMock()
+        download_resp.status_code = 200
+        download_resp.content = b"v"
+        download_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(side_effect=[poll_resp, download_resp])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="kling-v1")
+            await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.mp4",
+                    start_image=img_path,
+                    resolution="720p",
+                    aspect_ratio="9:16",
+                    duration_seconds=5,
+                )
+            )
+
+        sent_image = mock_client.post.call_args.kwargs["json"]["image"]
+        assert sent_image.startswith("data:image/png;base64,")
+        assert "fake" not in sent_image  # 必须编码过
+```
+
+- [ ] **Step 2: 运行测试**
+
+Run: `uv run pytest tests/test_newapi_video_backend.py::TestNewAPIVideoBackend::test_image_to_video_encodes_base64 -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_newapi_video_backend.py
+git commit -m "test(newapi-video): cover image-to-video base64 encoding"
+```
+
+---
+
+## Task 5: 追加失败状态与轮询中间态测试
+
+**Files:**
+- Modify: `tests/test_newapi_video_backend.py`
+
+- [ ] **Step 1: 追加失败态 + 轮询 in_progress 两轮成功的测试**
+
+```python
+    async def test_failed_status_raises(self, tmp_path: Path):
+        create_resp = _make_response(200, {"task_id": "t2", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "t2",
+                "status": "failed",
+                "error": {"code": 500, "message": "upstream down"},
+            },
+        )
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(return_value=poll_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            with pytest.raises(RuntimeError, match="upstream down"):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p",
+                        output_path=tmp_path / "o.mp4",
+                        resolution="720p",
+                        aspect_ratio="9:16",
+                        duration_seconds=5,
+                    )
+                )
+
+    async def test_polls_through_in_progress(self, tmp_path: Path):
+        """多轮 in_progress 后再 completed，最终成功返回。"""
+        create_resp = _make_response(200, {"task_id": "t3", "status": "queued"})
+        in_progress = _make_response(200, {"task_id": "t3", "status": "in_progress"})
+        completed = _make_response(
+            200,
+            {
+                "task_id": "t3",
+                "status": "completed",
+                "url": "https://cdn/v.mp4",
+                "metadata": {"duration": 5},
+            },
+        )
+        download_resp = MagicMock()
+        download_resp.status_code = 200
+        download_resp.content = b"v"
+        download_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(side_effect=[in_progress, in_progress, completed, download_resp])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client), \
+             patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.mp4",
+                    resolution="720p",
+                    aspect_ratio="9:16",
+                    duration_seconds=5,
+                )
+            )
+
+        assert result.task_id == "t3"
+        # 3 次 poll + 1 次 download = 4 次 GET
+        assert mock_client.get.call_count == 4
+```
+
+- [ ] **Step 2: 运行测试**
+
+Run: `uv run pytest tests/test_newapi_video_backend.py -v`
+Expected: 所有测试 PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_newapi_video_backend.py
+git commit -m "test(newapi-video): cover failed status and polling progression"
+```
+
+---
+
+## Task 6: 注册 NewAPIVideoBackend 到视频后端注册表
+
+**Files:**
+- Modify: `lib/video_backends/__init__.py`
+
+- [ ] **Step 1: 在文件末尾追加注册**
+
+在 `lib/video_backends/__init__.py` 最后（`register_backend(PROVIDER_OPENAI, OpenAIVideoBackend)` 之下）追加：
+
+```python
+# NewAPI 统一视频端点
+from lib.providers import PROVIDER_NEWAPI
+from lib.video_backends.newapi import NewAPIVideoBackend
+
+register_backend(PROVIDER_NEWAPI, NewAPIVideoBackend)
+```
+
+- [ ] **Step 2: 更新 `__all__`**
+
+把 `PROVIDER_NEWAPI` 加入 `__all__` 列表（保持字母顺序即可）。在现有 `"PROVIDER_OPENAI",` 之后添加：
+
+```python
+    "PROVIDER_NEWAPI",
+```
+
+同时更新顶部 `from lib.providers import ...` 合并导入（避免末尾再次导入）。最终顶部 import 如下：
+
+```python
+from lib.providers import PROVIDER_ARK, PROVIDER_GEMINI, PROVIDER_GROK, PROVIDER_NEWAPI, PROVIDER_OPENAI
+```
+
+并删除末尾的 `from lib.providers import PROVIDER_NEWAPI`。
+
+- [ ] **Step 3: 验证注册**
+
+Run:
+```bash
+uv run python -c "from lib.video_backends import get_registered_backends; print(get_registered_backends())"
+```
+Expected: 输出列表包含 `'newapi'`。
+
+- [ ] **Step 4: 运行 registry 测试**
+
+Run: `uv run pytest tests/test_video_backend_registry.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/video_backends/__init__.py
+git commit -m "feat(video-backends): register NewAPIVideoBackend"
+```
+
+---
+
+## Task 7: 扩展 custom_provider factory 的 newapi 分支（先写测试）
+
+**Files:**
+- Modify: `tests/test_custom_provider_factory.py`
+
+- [ ] **Step 1: 追加 NewAPI 格式测试类**
+
+在 `tests/test_custom_provider_factory.py` 的 `TestErrors` 之前新增：
+
+```python
+# ---------------------------------------------------------------------------
+# NewAPI format
+# ---------------------------------------------------------------------------
+
+
+class TestNewAPIFormat:
+    @patch("lib.custom_provider.factory.OpenAITextBackend")
+    def test_text_backend_uses_openai_delegate(self, mock_cls):
+        provider = _make_provider(api_format="newapi", base_url="https://newapi.example.com")
+        result = create_custom_backend(provider=provider, model_id="gpt-oss", media_type="text")
+
+        assert isinstance(result, CustomTextBackend)
+        assert result.model == "gpt-oss"
+        mock_cls.assert_called_once_with(
+            api_key="sk-test",
+            base_url="https://newapi.example.com/v1",
+            model="gpt-oss",
+        )
+
+    @patch("lib.custom_provider.factory.OpenAIImageBackend")
+    def test_image_backend_uses_openai_delegate(self, mock_cls):
+        provider = _make_provider(api_format="newapi", base_url="https://newapi.example.com/v1")
+        result = create_custom_backend(provider=provider, model_id="dall-e-3", media_type="image")
+
+        assert isinstance(result, CustomImageBackend)
+        mock_cls.assert_called_once_with(
+            api_key="sk-test",
+            base_url="https://newapi.example.com/v1",
+            model="dall-e-3",
+        )
+
+    @patch("lib.custom_provider.factory.NewAPIVideoBackend")
+    def test_video_backend_uses_newapi_delegate(self, mock_cls):
+        provider = _make_provider(api_format="newapi", base_url="https://newapi.example.com/v1")
+        result = create_custom_backend(provider=provider, model_id="kling-v1", media_type="video")
+
+        assert isinstance(result, CustomVideoBackend)
+        assert result.model == "kling-v1"
+        mock_cls.assert_called_once_with(
+            api_key="sk-test",
+            base_url="https://newapi.example.com/v1",
+            model="kling-v1",
+        )
+```
+
+同时修改 `TestErrors.test_unknown_api_format`，把 `anthropic` 替换成 `"something-else"` 以免误判，保留原断言即可（代码已是 `anthropic`，无需改）。
+
+- [ ] **Step 2: 运行测试（应失败）**
+
+Run: `uv run pytest tests/test_custom_provider_factory.py::TestNewAPIFormat -v`
+Expected: FAIL —
+- `test_video_backend_uses_newapi_delegate` 会因 `factory.NewAPIVideoBackend` 不存在 AttributeError
+- 另两个会因 `factory._VALID_API_FORMATS` 不含 `newapi` 抛 ValueError
+
+---
+
+## Task 8: 实现 factory newapi 分支
+
+**Files:**
+- Modify: `lib/custom_provider/factory.py`
+
+- [ ] **Step 1: 更新文件**
+
+在顶部 import 部分追加：
+
+```python
+from lib.video_backends.newapi import NewAPIVideoBackend
+```
+
+将 `_VALID_API_FORMATS` 改为：
+
+```python
+_VALID_API_FORMATS = {"openai", "google", "newapi"}
+```
+
+在 `create_custom_backend` 的分支 dispatch 末尾追加 newapi 分支：
+
+```python
+    if api_format == "openai":
+        return _create_openai_backend(provider=provider, model_id=model_id, media_type=media_type)
+    elif api_format == "google":
+        return _create_google_backend(provider=provider, model_id=model_id, media_type=media_type)
+    else:  # newapi
+        return _create_newapi_backend(provider=provider, model_id=model_id, media_type=media_type)
+```
+
+在文件末尾追加新函数：
+
+```python
+def _create_newapi_backend(
+    *,
+    provider: CustomProvider,
+    model_id: str,
+    media_type: str,
+) -> CustomTextBackend | CustomImageBackend | CustomVideoBackend:
+    """创建 NewAPI 格式的后端：文本/图片复用 OpenAI delegate，视频走 NewAPIVideoBackend。"""
+    pid = provider.provider_id
+    base_url = ensure_openai_base_url(provider.base_url)
+    if media_type == "text":
+        delegate = OpenAITextBackend(api_key=provider.api_key, base_url=base_url, model=model_id)
+        return CustomTextBackend(provider_id=pid, delegate=delegate, model=model_id)
+    elif media_type == "image":
+        delegate = OpenAIImageBackend(api_key=provider.api_key, base_url=base_url, model=model_id)
+        return CustomImageBackend(provider_id=pid, delegate=delegate, model=model_id)
+    else:  # video
+        delegate = NewAPIVideoBackend(api_key=provider.api_key, base_url=base_url, model=model_id)
+        return CustomVideoBackend(provider_id=pid, delegate=delegate, model=model_id)
+```
+
+- [ ] **Step 2: 运行测试**
+
+Run: `uv run pytest tests/test_custom_provider_factory.py -v`
+Expected: 所有测试 PASS（含原有 openai/google/errors 与新加 NewAPIFormat 三个）
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/custom_provider/factory.py tests/test_custom_provider_factory.py
+git commit -m "feat(custom-provider): support newapi api_format in factory"
+```
+
+---
+
+## Task 9: 扩展模型发现 discovery 支持 newapi
+
+**Files:**
+- Modify: `tests/test_model_discovery.py`
+- Modify: `lib/custom_provider/discovery.py`
+
+- [ ] **Step 1: 查看现有 discovery 测试结构**
+
+Run: `uv run pytest tests/test_model_discovery.py --collect-only -q`
+Expected: 输出已有测试类/方法列表。
+
+- [ ] **Step 2: 追加 newapi 测试**
+
+在 `tests/test_model_discovery.py` 末尾追加：
+
+```python
+class TestDiscoverNewAPI:
+    async def test_newapi_reuses_openai_path(self):
+        """newapi 格式应走 OpenAI 兼容的 /v1/models 路径。"""
+        from unittest.mock import AsyncMock, patch
+
+        fake_models = [
+            type("M", (), {"id": "gpt-4o"}),
+            type("M", (), {"id": "kling-v1"}),
+        ]
+
+        with patch("lib.custom_provider.discovery.OpenAI") as mock_cls:
+            mock_client = mock_cls.return_value
+            mock_client.models.list.return_value = fake_models
+
+            from lib.custom_provider.discovery import discover_models
+
+            result = await discover_models(
+                api_format="newapi", base_url="https://x/v1", api_key="sk"
+            )
+
+        ids = [m["model_id"] for m in result]
+        assert "gpt-4o" in ids
+        assert "kling-v1" in ids
+        kling = next(m for m in result if m["model_id"] == "kling-v1")
+        assert kling["media_type"] == "video"
+```
+
+- [ ] **Step 3: 运行测试（应失败）**
+
+Run: `uv run pytest tests/test_model_discovery.py::TestDiscoverNewAPI -v`
+Expected: FAIL — `ValueError: 不支持的 api_format: 'newapi'`
+
+- [ ] **Step 4: 修改 discovery 支持 newapi**
+
+在 `lib/custom_provider/discovery.py` 的 `discover_models` 中扩展分支：
+
+```python
+    if api_format == "openai" or api_format == "newapi":
+        return await _discover_openai(base_url, api_key)
+    elif api_format == "google":
+        return await _discover_google(base_url, api_key)
+    else:
+        raise ValueError(f"不支持的 api_format: {api_format!r}，支持: 'openai', 'google', 'newapi'")
+```
+
+同时更新 `_VIDEO_PATTERN` 增加关键词以覆盖 NewAPI 聚合的更多厂商：
+
+```python
+_VIDEO_PATTERN = re.compile(
+    r"video|sora|kling|wan|seedance|cog|mochi|veo|pika|minimax|hailuo|seedream|jimeng|runway",
+    re.IGNORECASE,
+)
+```
+
+- [ ] **Step 5: 运行测试**
+
+Run: `uv run pytest tests/test_model_discovery.py -v`
+Expected: 所有测试 PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/custom_provider/discovery.py tests/test_model_discovery.py
+git commit -m "feat(custom-provider): support newapi in model discovery"
+```
+
+---
+
+## Task 10: 连接测试 endpoint 支持 newapi
+
+**Files:**
+- Modify: `server/routers/custom_providers.py`
+
+- [ ] **Step 1: 更新 `_run_connection_test` 分支**
+
+在 `server/routers/custom_providers.py:486-500` 把 `elif api_format == "google":` 分支之后、`else:` 兜底之前插入 newapi 分支：
+
+```python
+        elif api_format == "google":
+            result = await asyncio.wait_for(
+                asyncio.to_thread(_test_google, base_url, api_key, _t),
+                timeout=_CONNECTION_TEST_TIMEOUT,
+            )
+        elif api_format == "newapi":
+            # NewAPI 的 /v1/models 是 OpenAI 兼容
+            result = await asyncio.wait_for(
+                asyncio.to_thread(_test_openai, base_url, api_key, _t),
+                timeout=_CONNECTION_TEST_TIMEOUT,
+            )
+        else:
+```
+
+- [ ] **Step 2: 更新 CreateProviderRequest 字段注释**
+
+将 `server/routers/custom_providers.py:75` 的注释：
+
+```python
+    api_format: str  # "openai" or "google"
+```
+
+改为：
+
+```python
+    api_format: str  # "openai" | "google" | "newapi"
+```
+
+- [ ] **Step 3: 运行 API 测试**
+
+Run: `uv run pytest tests/test_custom_providers_api.py -v`
+Expected: 原有测试保持 PASS（未新增断言）。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/routers/custom_providers.py
+git commit -m "feat(custom-providers): accept newapi in connection test endpoint"
+```
+
+---
+
+## Task 11: 数据库模型注释更新
+
+**Files:**
+- Modify: `lib/db/models/custom_provider.py:18`
+
+- [ ] **Step 1: 更新字段注释**
+
+将 `lib/db/models/custom_provider.py:18`：
+
+```python
+    api_format: Mapped[str] = mapped_column(String(32), nullable=False)  # "openai" | "google"
+```
+
+改为：
+
+```python
+    api_format: Mapped[str] = mapped_column(String(32), nullable=False)  # "openai" | "google" | "newapi"
+```
+
+- [ ] **Step 2: 运行 repo/model 测试**
+
+Run: `uv run pytest tests/test_custom_provider_models.py tests/test_custom_provider_repo.py -v`
+Expected: PASS（无功能变化）
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/db/models/custom_provider.py
+git commit -m "chore(custom-provider): document newapi in api_format comment"
+```
+
+---
+
+## Task 12: 前端类型联合扩展
+
+**Files:**
+- Modify: `frontend/src/types/custom-provider.ts`
+
+- [ ] **Step 1: 把所有 `"openai" | "google"` 替换为三值联合**
+
+编辑 `frontend/src/types/custom-provider.ts`，把所有 `api_format: "openai" | "google"` 改为 `api_format: "openai" | "google" | "newapi"`。共 2 处：
+
+```typescript
+export interface CustomProviderInfo {
+  ...
+  api_format: "openai" | "google" | "newapi";
+  ...
+}
+
+export interface CustomProviderCreateRequest {
+  ...
+  api_format: "openai" | "google" | "newapi";
+  ...
+}
+```
+
+- [ ] **Step 2: 验证 typecheck**
+
+Run: `cd frontend && pnpm check`
+Expected: 无 TypeScript 错误（会在下一任务引入 Form 修改时再一次验证）。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/types/custom-provider.ts
+git commit -m "chore(frontend): extend ApiFormat type with newapi"
+```
+
+---
+
+## Task 13: 前端 Form 加 NewAPI 选项
+
+**Files:**
+- Modify: `frontend/src/components/pages/settings/CustomProviderForm.tsx:17-23`
+
+- [ ] **Step 1: 更新 ApiFormat 类型与下拉选项**
+
+把 `frontend/src/components/pages/settings/CustomProviderForm.tsx:17`：
+
+```typescript
+type ApiFormat = "openai" | "google";
+```
+
+改为：
+
+```typescript
+type ApiFormat = "openai" | "google" | "newapi";
+```
+
+把 `frontend/src/components/pages/settings/CustomProviderForm.tsx:20-23`：
+
+```typescript
+const API_FORMAT_OPTIONS: { value: ApiFormat; label: string }[] = [
+  { value: "openai", label: "OpenAI" },
+  { value: "google", label: "Google" },
+];
+```
+
+改为：
+
+```typescript
+const API_FORMAT_OPTIONS: { value: ApiFormat; label: string }[] = [
+  { value: "openai", label: "OpenAI" },
+  { value: "google", label: "Google" },
+  { value: "newapi", label: "NewAPI" },
+];
+```
+
+- [ ] **Step 2: 前端构建 + typecheck**
+
+Run: `cd frontend && pnpm check`
+Expected: PASS
+
+- [ ] **Step 3: 可视检查**
+
+启动后端 + 前端，打开 `/settings` → 自定义供应商 → 新建，确认协议下拉有 "NewAPI" 选项可选。保存 provider 后刷新页面，确认持久化。
+
+> 若环境不便启动 dev server，跳过此步，在 PR 描述中注明未做 UI 手测。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/pages/settings/CustomProviderForm.tsx
+git commit -m "feat(frontend): add NewAPI option to custom provider form"
+```
+
+---
+
+## Task 14: 整体回归测试 + ruff
+
+**Files:** 全部修改过的文件
+
+- [ ] **Step 1: ruff check + format**
+
+Run:
+```bash
+uv run ruff check lib/video_backends/newapi.py lib/custom_provider/factory.py lib/custom_provider/discovery.py server/routers/custom_providers.py lib/db/models/custom_provider.py lib/providers.py lib/video_backends/__init__.py tests/test_newapi_video_backend.py tests/test_custom_provider_factory.py tests/test_model_discovery.py \
+  && uv run ruff format lib/video_backends/newapi.py lib/custom_provider/factory.py lib/custom_provider/discovery.py server/routers/custom_providers.py lib/db/models/custom_provider.py lib/providers.py lib/video_backends/__init__.py tests/test_newapi_video_backend.py tests/test_custom_provider_factory.py tests/test_model_discovery.py
+```
+Expected: 无 error。若 `format` 对已提交文件做了改动，运行 `git add -u && git commit -m "style: ruff format"`。
+
+- [ ] **Step 2: 后端全量测试**
+
+Run: `uv run pytest -q`
+Expected: 全部 PASS，覆盖率不低于之前水平（`--cov`）
+
+- [ ] **Step 3: 前端全量检查**
+
+Run: `cd frontend && pnpm check && pnpm build`
+Expected: 两者均 PASS
+
+- [ ] **Step 4: 最终 commit（仅限有格式化残余时）**
+
+```bash
+git status
+# 若有 ruff format 后的残余改动：
+git add -u
+git commit -m "style: ruff format newapi-related files"
+```
+
+---
+
+## 完成验收
+
+- [ ] `uv run pytest -q` 全绿
+- [ ] `cd frontend && pnpm check` 全绿
+- [ ] 创建一个 `api_format=newapi` 的自定义供应商，文本/图片/视频三种模型至少各 smoke test 一次（可在单独 follow-up 手测阶段完成，不在此 plan 内）

--- a/docs/superpowers/specs/2026-04-15-newapi-custom-provider-design.md
+++ b/docs/superpowers/specs/2026-04-15-newapi-custom-provider-design.md
@@ -128,7 +128,7 @@ API_FORMAT_OPTIONS = [
 
 ### 6. i18n
 
-- 后端：`lib/i18n/{zh,en}/errors.py` — `invalid_api_format` 枚举文案更新
+- 后端：**实现时发现仓库实际使用 `unsupported_format` 参数化文案**（`不支持的 api_format: {api_format}`），`{api_format}` 会在运行时自动填入，新增 `newapi` 无需改动 `errors.py`；factory 抛出的 `ValueError(f"不支持的 api_format: {api_format!r}")` 是开发层错误，不走 i18n。原 spec 提到的 `invalid_api_format` key 在代码中不存在，此条作废
 - 前端：`frontend/src/i18n/{zh,en}/dashboard.ts` — 若有 NewAPI 说明文案新增
 
 ## 错误处理
@@ -164,7 +164,7 @@ API_FORMAT_OPTIONS = [
 | `lib/custom_provider/discovery.py` | `discover_models("newapi", ...)` 复用 openai 路径；补充视频关键词 |
 | `lib/video_backends/newapi.py` | **新建** NewAPIVideoBackend |
 | `lib/video_backends/registry.py` | 注册（如有显式注册表） |
-| `lib/i18n/{zh,en}/errors.py` | 更新 `invalid_api_format` 文案 |
+| ~~`lib/i18n/{zh,en}/errors.py`~~ | ~~更新 `invalid_api_format` 文案~~ （作废：key 不存在，实际使用参数化 `unsupported_format`） |
 | `server/routers/custom_providers.py` | 校验允许 `newapi` |
 | `frontend/src/types/custom-provider.ts` | 类型联合加 `newapi` |
 | `frontend/src/components/pages/settings/CustomProviderForm.tsx` | 下拉选项加 NewAPI |

--- a/docs/superpowers/specs/2026-04-15-newapi-custom-provider-design.md
+++ b/docs/superpowers/specs/2026-04-15-newapi-custom-provider-design.md
@@ -1,0 +1,191 @@
+# NewAPI 自定义供应商格式设计
+
+**日期**：2026-04-15
+**作者**：Pollo（协助：Claude Code）
+**状态**：设计草案
+
+## 背景
+
+ArcReel 现有 `lib/custom_provider/` 支持两种 `api_format`：`openai` 和 `google`，分别复用 `OpenAI*Backend` / `Gemini*Backend` 作为 delegate。
+
+用户希望新增 **NewAPI**（`https://docs.newapi.pro/`）作为第三种协议格式。NewAPI 是一个 AI 聚合网关，将 Sora、Kling、即梦、Wan、Veo 等多家视频模型通过**统一的 `/v1/video/generations` 端点**聚合，依靠 `model` 字段分发。这与 ArcReel "一个接口覆盖多模型" 的业务诉求天然契合，相比为每家模型写专用 backend 更有扩展性。
+
+文本和图片部分，NewAPI 原生是 OpenAI 兼容（`/v1/chat/completions` 和 `/v1/images/generations`），无需新写 backend。
+
+## 目标
+
+1. 新增 `api_format = "newapi"`，与 `openai` / `google` 并列
+2. 文本/图片复用 `OpenAITextBackend` / `OpenAIImageBackend`（OpenAI 兼容）
+3. 视频新增 `NewAPIVideoBackend`，对接 NewAPI 统一视频协议
+4. 自定义供应商 UI 协议下拉菜单增加 "NewAPI" 选项
+5. 模型发现复用 OpenAI 兼容 `/v1/models` 查询
+
+## 非目标
+
+- 不做 NewAPI 预置（preset）条目，不填默认 base_url
+- 不支持 Midjourney/可灵/即梦等厂商专用路径（都走统一端点）
+- 不支持 `n > 1` 多视频并发生成（业务每镜头 1 个视频）
+- 不改动现有 `openai` / `google` 格式的任何行为
+
+## NewAPI 视频协议摘要
+
+### 创建任务
+- `POST /v1/video/generations`
+- Request body（`application/json`）：
+  - `model*` (string)：模型 ID，如 `kling-v1`、`sora-2`、`veo-3` 等
+  - `prompt*` (string)：文本描述
+  - `image?` (string)：URL 或 Base64 字符串（图生视频）
+  - `duration?` (number)：秒数
+  - `width?`, `height?` (integer)
+  - `fps?` (integer), `seed?` (integer), `n?` (integer)
+  - `response_format?`, `user?` (string)
+  - `metadata?` (object)：扩展参数（`negative_prompt` / `style` / `quality_level` 等）
+- Response：`{task_id, status}`
+
+### 查询任务
+- `GET /v1/video/generations/{task_id}`
+- Response：
+  - `task_id`, `status` (enum: `queued` / `in_progress` / `completed` / `failed`)
+  - `url` (string)：完成时的视频下载链接
+  - `format` (string)：如 `"mp4"`
+  - `metadata` (object)：`{duration, fps, width, height, seed}`
+  - `error` (object)：`{code, message}`（失败时）
+
+## 架构设计
+
+### 1. 数据模型
+
+`lib/db/models/custom_provider.py`：
+```python
+api_format: Mapped[str]  # "openai" | "google" | "newapi"
+```
+
+数据库侧无 CHECK 约束（字段为 `String(32)`，迁移 `5105eceaf7cb` 已确认），**无需新建 Alembic 迁移**，仅更新注释。校验在应用层完成（factory / router）。
+
+### 2. Factory 分支
+
+`lib/custom_provider/factory.py`：
+- `_VALID_API_FORMATS` 增加 `"newapi"`
+- 新增 `_create_newapi_backend`：
+  - `text` / `image` → 走 OpenAI delegate（base_url 经 `ensure_openai_base_url` 规范化）
+  - `video` → 返回 `CustomVideoBackend(delegate=NewAPIVideoBackend(...))`
+
+### 3. NewAPIVideoBackend（新建）
+
+`lib/video_backends/newapi.py`：
+
+```python
+class NewAPIVideoBackend:
+    name = "newapi"
+    video_capabilities = VideoCapabilities(
+        reference_images=False,  # schema 只支持单个 image 字段
+        max_reference_images=1,
+    )
+    capabilities = {VideoCapability.TEXT_TO_VIDEO, VideoCapability.IMAGE_TO_VIDEO}
+
+    def __init__(self, *, api_key, base_url, model): ...
+
+    async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
+        # 1) 编码 start_image (Base64 data URI)
+        # 2) POST /v1/video/generations → task_id
+        # 3) 轮询 GET /v1/video/generations/{task_id} 直到 completed/failed
+        # 4) httpx.get(url) 下载到 output_path
+```
+
+关键实现要点：
+
+| 维度 | 做法 |
+|---|---|
+| HTTP 客户端 | `httpx.AsyncClient(timeout=60)`，`Authorization: Bearer <api_key>` |
+| base_url 规范化 | 复用 `ensure_openai_base_url`（NewAPI 的 OpenAI 兼容路径同一前缀） |
+| image 编码 | 读本地文件 → Base64 → `f"data:image/{mime};base64,{b64}"` 形式 |
+| reference_images | 有值时记录 warning 并丢弃（capabilities 已声明不支持） |
+| 尺寸映射 | 新增 `_SIZE_MAP: {(resolution, aspect_ratio): (width, height)}`，默认回退 `720x1280` |
+| 轮询 | 初始 5 秒间隔，固定间隔轮询；最大超时 = `max(600, duration_seconds * 30)` |
+| 状态机 | `queued`/`in_progress`→ 继续；`completed` → 取 `url`；`failed` → `raise RuntimeError(error.message)` |
+| 重试 | `with_retry_async` 分三段装饰：`_create_task` / `_poll_once` / `_download_content` |
+| 可重试错误 | 复用或新增 `NEWAPI_RETRYABLE_ERRORS`（httpx 网络异常 + 5xx） |
+| 结果字段 | `VideoGenerationResult(video_path, provider="newapi", model, duration_seconds=metadata.duration, task_id)` |
+
+### 4. 模型发现
+
+`lib/custom_provider/discovery.py`：
+- `discover_models(api_format="newapi", ...)` → 复用 `_discover_openai`（NewAPI 的 `/v1/models` 是 OpenAI 兼容）
+- `_VIDEO_PATTERN` 已包含 `kling` / `wan` / `veo`，可追加 `minimax` / `hailuo` / `seedream` 等 NewAPI 常见 ID
+
+### 5. 前端
+
+`frontend/src/components/pages/settings/CustomProviderForm.tsx`：
+```typescript
+type ApiFormat = "openai" | "google" | "newapi";
+API_FORMAT_OPTIONS = [
+  { value: "openai", label: "OpenAI" },
+  { value: "google", label: "Google" },
+  { value: "newapi", label: "NewAPI" },
+];
+```
+同步更新 `frontend/src/types/custom-provider.ts` 的类型联合。
+
+### 6. i18n
+
+- 后端：`lib/i18n/{zh,en}/errors.py` — `invalid_api_format` 枚举文案更新
+- 前端：`frontend/src/i18n/{zh,en}/dashboard.ts` — 若有 NewAPI 说明文案新增
+
+## 错误处理
+
+| 场景 | 处理 |
+|---|---|
+| 创建任务返回非 200 | 解析 `error.message`，抛 `RuntimeError` |
+| 轮询超时 | 抛 `TimeoutError("视频生成超时，task_id=...")` |
+| 任务 `status=failed` | 抛 `RuntimeError(error.message)` |
+| 下载失败 | `DOWNLOAD_MAX_ATTEMPTS` 重试耗尽后抛 |
+| 网络异常 | `with_retry_async` 指数退避 |
+
+## 测试策略
+
+1. **单元：`tests/test_newapi_video_backend.py`**
+   - Mock `httpx.AsyncClient` 三段：create / poll(3 次) / download
+   - 覆盖：纯文生、图生视频（Base64 编码）、失败状态、轮询超时
+2. **Factory 单元扩展：`tests/test_custom_provider_factory.py`**
+   - `newapi` + `text` → `CustomTextBackend(OpenAITextBackend)`
+   - `newapi` + `image` → `CustomImageBackend(OpenAIImageBackend)`
+   - `newapi` + `video` → `CustomVideoBackend(NewAPIVideoBackend)`
+3. **Discovery 扩展：`tests/test_model_discovery.py`**
+   - `newapi` 格式走 OpenAI 路径
+4. **API 层：`tests/test_custom_providers_api.py`**
+   - POST/PUT 接受 `api_format="newapi"`，校验通过
+
+## 改动清单
+
+| 文件 | 变更类型 |
+|---|---|
+| `lib/db/models/custom_provider.py` | 更新字段注释为 `openai/google/newapi` |
+| `lib/custom_provider/factory.py` | 增加 `newapi` 分支 + `_create_newapi_backend` |
+| `lib/custom_provider/discovery.py` | `discover_models("newapi", ...)` 复用 openai 路径；补充视频关键词 |
+| `lib/video_backends/newapi.py` | **新建** NewAPIVideoBackend |
+| `lib/video_backends/registry.py` | 注册（如有显式注册表） |
+| `lib/i18n/{zh,en}/errors.py` | 更新 `invalid_api_format` 文案 |
+| `server/routers/custom_providers.py` | 校验允许 `newapi` |
+| `frontend/src/types/custom-provider.ts` | 类型联合加 `newapi` |
+| `frontend/src/components/pages/settings/CustomProviderForm.tsx` | 下拉选项加 NewAPI |
+| `frontend/src/i18n/{zh,en}/dashboard.ts` | 相关文案 |
+| `tests/test_newapi_video_backend.py` | **新建**，mock httpx |
+| `tests/test_custom_provider_factory.py` | 扩展 newapi 用例 |
+| `tests/test_model_discovery.py` | 扩展 newapi 用例 |
+| `tests/test_custom_providers_api.py` | 校验 newapi 入参 |
+
+## 风险与权衡
+
+- **`/v1/models` 列表过长**：NewAPI 聚合多家厂商，模型数可能几十上百。UI 已支持批量编辑/禁用，用户可手动筛选。
+- **轮询频率**：固定 5 秒可能在 kling 等长任务上浪费请求。考虑未来改为指数退避（5s → 15s → 30s 上限），但初版固定间隔足够。
+- **`image` 字段 URL vs Base64**：本地图片只能走 Base64，可能导致请求体较大。NewAPI 若限制请求体大小需要用户提前上传到 OSS；当前不做 URL fallback。
+- **API Key 轮换**：NewAPIVideoBackend 目前只接受单个 api_key；后续若与 `Credential` 多 Key 整合，需要拿到已选中的活跃 key 注入（与现有 OpenAIVideoBackend 对齐）。
+
+## 非目标回顾
+
+本设计不引入以下内容，需要时再开新 spec：
+
+- NewAPI 预置条目（`lib/config/registry.py`）
+- Midjourney / Kling 专用路径 backend
+- 多视频并发（`n > 1`）
+- 图片 backend 的 NewAPI 扩展字段（保持 DALL-E 兼容即可）

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -14,12 +14,13 @@ import type {
 // Types
 // ---------------------------------------------------------------------------
 
-type ApiFormat = "openai" | "google";
+type ApiFormat = "openai" | "google" | "newapi";
 type MediaType = "text" | "image" | "video";
 
 const API_FORMAT_OPTIONS: { value: ApiFormat; label: string }[] = [
   { value: "openai", label: "OpenAI" },
   { value: "google", label: "Google" },
+  { value: "newapi", label: "NewAPI" },
 ];
 
 const MEDIA_TYPE_OPTIONS: { value: MediaType; label: string }[] = [

--- a/frontend/src/types/custom-provider.ts
+++ b/frontend/src/types/custom-provider.ts
@@ -1,7 +1,7 @@
 export interface CustomProviderInfo {
   id: number;
   display_name: string;
-  api_format: "openai" | "google";
+  api_format: "openai" | "google" | "newapi";
   base_url: string;
   api_key_masked: string;
   models: CustomProviderModelInfo[];
@@ -32,7 +32,7 @@ export interface DiscoveredModel {
 
 export interface CustomProviderCreateRequest {
   display_name: string;
-  api_format: "openai" | "google";
+  api_format: "openai" | "google" | "newapi";
   base_url: string;
   api_key: string;
   models: CustomProviderModelInput[];

--- a/lib/custom_provider/discovery.py
+++ b/lib/custom_provider/discovery.py
@@ -15,7 +15,10 @@ from openai import OpenAI
 logger = logging.getLogger(__name__)
 
 _IMAGE_PATTERN = re.compile(r"image|dall|img", re.IGNORECASE)
-_VIDEO_PATTERN = re.compile(r"video|sora|kling|wan|seedance|cog|mochi|veo|pika", re.IGNORECASE)
+_VIDEO_PATTERN = re.compile(
+    r"video|sora|kling|wan|seedance|cog|mochi|veo|pika|minimax|hailuo|seedream|jimeng|runway",
+    re.IGNORECASE,
+)
 
 # Google generation method → media_type 映射
 _GENERATION_METHOD_MAP: dict[str, str] = {
@@ -43,7 +46,7 @@ async def discover_models(api_format: str, base_url: str | None, api_key: str) -
     """查询供应商的可用模型列表。
 
     Args:
-        api_format: API 格式 ("openai" | "google")
+        api_format: API 格式 ("openai" | "google" | "newapi")
         base_url: 供应商 API 基础 URL
         api_key: API 密钥
 
@@ -53,12 +56,12 @@ async def discover_models(api_format: str, base_url: str | None, api_key: str) -
     Raises:
         ValueError: api_format 不支持
     """
-    if api_format == "openai":
+    if api_format == "openai" or api_format == "newapi":
         return await _discover_openai(base_url, api_key)
     elif api_format == "google":
         return await _discover_google(base_url, api_key)
     else:
-        raise ValueError(f"不支持的 api_format: {api_format!r}，支持: 'openai', 'google'")
+        raise ValueError(f"不支持的 api_format: {api_format!r}，支持: 'openai', 'google', 'newapi'")
 
 
 async def _discover_openai(base_url: str | None, api_key: str) -> list[dict]:

--- a/lib/custom_provider/discovery.py
+++ b/lib/custom_provider/discovery.py
@@ -56,7 +56,7 @@ async def discover_models(api_format: str, base_url: str | None, api_key: str) -
     Raises:
         ValueError: api_format 不支持
     """
-    if api_format == "openai" or api_format == "newapi":
+    if api_format in {"openai", "newapi"}:
         return await _discover_openai(base_url, api_key)
     elif api_format == "google":
         return await _discover_google(base_url, api_key)

--- a/lib/custom_provider/factory.py
+++ b/lib/custom_provider/factory.py
@@ -14,13 +14,14 @@ from lib.image_backends.openai import OpenAIImageBackend
 from lib.text_backends.gemini import GeminiTextBackend
 from lib.text_backends.openai import OpenAITextBackend
 from lib.video_backends.gemini import GeminiVideoBackend
+from lib.video_backends.newapi import NewAPIVideoBackend
 from lib.video_backends.openai import OpenAIVideoBackend
 
 if TYPE_CHECKING:
     from lib.db.models.custom_provider import CustomProvider
 
 _VALID_MEDIA_TYPES = {"text", "image", "video"}
-_VALID_API_FORMATS = {"openai", "google"}
+_VALID_API_FORMATS = {"openai", "google", "newapi"}
 
 
 def create_custom_backend(
@@ -50,8 +51,10 @@ def create_custom_backend(
 
     if api_format == "openai":
         return _create_openai_backend(provider=provider, model_id=model_id, media_type=media_type)
-    else:  # google
+    elif api_format == "google":
         return _create_google_backend(provider=provider, model_id=model_id, media_type=media_type)
+    else:  # newapi
+        return _create_newapi_backend(provider=provider, model_id=model_id, media_type=media_type)
 
 
 def _create_openai_backend(
@@ -91,4 +94,24 @@ def _create_google_backend(
         return CustomImageBackend(provider_id=pid, delegate=delegate, model=model_id)
     else:  # video
         delegate = GeminiVideoBackend(api_key=provider.api_key, base_url=base_url, video_model=model_id)
+        return CustomVideoBackend(provider_id=pid, delegate=delegate, model=model_id)
+
+
+def _create_newapi_backend(
+    *,
+    provider: CustomProvider,
+    model_id: str,
+    media_type: str,
+) -> CustomTextBackend | CustomImageBackend | CustomVideoBackend:
+    """创建 NewAPI 格式的后端：文本/图片复用 OpenAI delegate，视频走 NewAPIVideoBackend。"""
+    pid = provider.provider_id
+    base_url = ensure_openai_base_url(provider.base_url)
+    if media_type == "text":
+        delegate = OpenAITextBackend(api_key=provider.api_key, base_url=base_url, model=model_id)
+        return CustomTextBackend(provider_id=pid, delegate=delegate, model=model_id)
+    elif media_type == "image":
+        delegate = OpenAIImageBackend(api_key=provider.api_key, base_url=base_url, model=model_id)
+        return CustomImageBackend(provider_id=pid, delegate=delegate, model=model_id)
+    else:  # video
+        delegate = NewAPIVideoBackend(api_key=provider.api_key, base_url=base_url, model=model_id)
         return CustomVideoBackend(provider_id=pid, delegate=delegate, model=model_id)

--- a/lib/db/models/custom_provider.py
+++ b/lib/db/models/custom_provider.py
@@ -15,7 +15,7 @@ class CustomProvider(TimestampMixin, Base):
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     display_name: Mapped[str] = mapped_column(String(128), nullable=False)
-    api_format: Mapped[str] = mapped_column(String(32), nullable=False)  # "openai" | "google"
+    api_format: Mapped[str] = mapped_column(String(32), nullable=False)  # "openai" | "google" | "newapi"
     base_url: Mapped[str] = mapped_column(Text, nullable=False)
     api_key: Mapped[str] = mapped_column(Text, nullable=False)  # sensitive, masked in API responses
 

--- a/lib/providers.py
+++ b/lib/providers.py
@@ -6,6 +6,7 @@ PROVIDER_GEMINI = "gemini"
 PROVIDER_ARK = "ark"
 PROVIDER_GROK = "grok"
 PROVIDER_OPENAI = "openai"
+PROVIDER_NEWAPI = "newapi"
 
 CallType = Literal["image", "video", "text"]
 CALL_TYPE_IMAGE: CallType = "image"

--- a/lib/video_backends/__init__.py
+++ b/lib/video_backends/__init__.py
@@ -1,6 +1,6 @@
 """视频生成服务层公共 API。"""
 
-from lib.providers import PROVIDER_ARK, PROVIDER_GEMINI, PROVIDER_GROK
+from lib.providers import PROVIDER_ARK, PROVIDER_GEMINI, PROVIDER_GROK, PROVIDER_NEWAPI, PROVIDER_OPENAI
 from lib.video_backends.base import (
     VideoBackend,
     VideoCapability,
@@ -13,6 +13,7 @@ __all__ = [
     "PROVIDER_ARK",
     "PROVIDER_GEMINI",
     "PROVIDER_GROK",
+    "PROVIDER_NEWAPI",
     "PROVIDER_OPENAI",
     "VideoBackend",
     "VideoCapability",
@@ -40,7 +41,11 @@ from lib.video_backends.grok import GrokVideoBackend
 register_backend(PROVIDER_GROK, GrokVideoBackend)
 
 # OpenAI Sora
-from lib.providers import PROVIDER_OPENAI
 from lib.video_backends.openai import OpenAIVideoBackend
 
 register_backend(PROVIDER_OPENAI, OpenAIVideoBackend)
+
+# NewAPI 统一视频端点
+from lib.video_backends.newapi import NewAPIVideoBackend
+
+register_backend(PROVIDER_NEWAPI, NewAPIVideoBackend)

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from pathlib import Path
 
@@ -18,8 +17,6 @@ from lib.retry import (
     BASE_RETRYABLE_ERRORS,
     DEFAULT_BACKOFF_SECONDS,
     DEFAULT_MAX_ATTEMPTS,
-    DOWNLOAD_BACKOFF_SECONDS,
-    DOWNLOAD_MAX_ATTEMPTS,
     with_retry_async,
 )
 from lib.video_backends.base import (
@@ -27,6 +24,7 @@ from lib.video_backends.base import (
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
+    download_video,
     poll_with_retry,
 )
 
@@ -38,7 +36,7 @@ _POLL_INTERVAL_SECONDS = 5.0
 _MIN_POLL_TIMEOUT_SECONDS = 600
 _POLL_TIMEOUT_PER_SECOND = 30
 
-_NEWAPI_RETRYABLE_ERRORS = BASE_RETRYABLE_ERRORS + (httpx.HTTPError,)
+_NEWAPI_RETRYABLE_ERRORS = BASE_RETRYABLE_ERRORS + (httpx.RequestError,)
 
 _SIZE_MAP: dict[tuple[str, str], tuple[int, int]] = {
     ("720p", "9:16"): (720, 1280),
@@ -147,7 +145,8 @@ class NewAPIVideoBackend:
             if not video_url:
                 raise RuntimeError(f"NewAPI 任务完成但缺少 url 字段: {final}")
 
-            await self._download(client, video_url, request.output_path)
+        # 流式下载，不携带 Authorization 头（视频 URL 常为 CDN/OSS，避免 API Key 泄露）
+        await download_video(video_url, request.output_path)
 
         meta = final.get("metadata") or {}
         return VideoGenerationResult(
@@ -184,21 +183,6 @@ class NewAPIVideoBackend:
         )
         resp.raise_for_status()
         return resp.json()
-
-    @with_retry_async(
-        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
-        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
-        retryable_errors=_NEWAPI_RETRYABLE_ERRORS,
-    )
-    async def _download(self, client: httpx.AsyncClient, url: str, output_path: Path) -> None:
-        resp = await client.get(url, headers=self._headers())
-        resp.raise_for_status()
-
-        def _write():
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_bytes(resp.content)
-
-        await asyncio.to_thread(_write)
 
     def _headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"}

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -163,11 +163,14 @@ class NewAPIVideoBackend:
         await self._download_with_retry(video_url, request.output_path)
 
         meta = final.get("metadata") or {}
+        # 用 is None 显式判空，避免 API 返回 0 / 0.0 时被 `or` 误判为 falsy 而回退
+        raw_duration = meta.get("duration")
+        duration_seconds = int(float(raw_duration)) if raw_duration is not None else request.duration_seconds
         return VideoGenerationResult(
             video_path=request.output_path,
             provider=PROVIDER_NEWAPI,
             model=self._model,
-            duration_seconds=int(float(meta.get("duration") or request.duration_seconds)),
+            duration_seconds=duration_seconds,
             task_id=task_id,
             seed=meta.get("seed"),
         )

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import httpx
 
-from lib.image_backends.base import image_to_base64_data_uri
 from lib.providers import PROVIDER_NEWAPI
 from lib.retry import (
     BASE_RETRYABLE_ERRORS,
@@ -117,6 +116,9 @@ class NewAPIVideoBackend:
         if request.start_image:
             start_path = Path(request.start_image)
             if start_path.exists():
+                # 延迟导入避免 image_backends ↔ video_backends 循环依赖
+                from lib.image_backends.base import image_to_base64_data_uri
+
                 payload["image"] = image_to_base64_data_uri(start_path)
             else:
                 logger.warning("start_image 文件不存在，已忽略: %s", start_path)

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -48,7 +48,16 @@ _DEFAULT_SIZE: tuple[int, int] = (720, 1280)
 
 
 def _resolve_size(resolution: str, aspect_ratio: str) -> tuple[int, int]:
-    return _SIZE_MAP.get((resolution, aspect_ratio), _DEFAULT_SIZE)
+    size = _SIZE_MAP.get((resolution, aspect_ratio))
+    if size is None:
+        logger.warning(
+            "NewAPIVideoBackend 未知 resolution+aspect 组合 (%s, %s)，回退到默认 %dx%d",
+            resolution,
+            aspect_ratio,
+            *_DEFAULT_SIZE,
+        )
+        return _DEFAULT_SIZE
+    return size
 
 
 def _encode_image_to_data_uri(path: Path) -> str:
@@ -111,8 +120,12 @@ class NewAPIVideoBackend:
             payload["seed"] = request.seed
         if request.negative_prompt:
             payload.setdefault("metadata", {})["negative_prompt"] = request.negative_prompt
-        if request.start_image and Path(request.start_image).exists():
-            payload["image"] = _encode_image_to_data_uri(Path(request.start_image))
+        if request.start_image:
+            start_path = Path(request.start_image)
+            if start_path.exists():
+                payload["image"] = _encode_image_to_data_uri(start_path)
+            else:
+                logger.warning("start_image 文件不存在，已忽略: %s", start_path)
         if request.reference_images:
             logger.warning(
                 "NewAPIVideoBackend 不支持多张参考图（reference_images=%d），已忽略",
@@ -165,10 +178,6 @@ class NewAPIVideoBackend:
     async def _poll_until_done(self, client: httpx.AsyncClient, *, task_id: str, max_wait: float) -> dict:
         elapsed = 0.0
         while True:
-            if elapsed >= max_wait:
-                raise TimeoutError(f"NewAPI 视频任务超时（{max_wait:.0f}秒）: task_id={task_id}")
-            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
-            elapsed += _POLL_INTERVAL_SECONDS
             state = await self._poll_once(client, task_id)
             status = state.get("status")
             if status == "completed":
@@ -176,6 +185,10 @@ class NewAPIVideoBackend:
             if status == "failed":
                 err = (state.get("error") or {}).get("message") or "unknown"
                 raise RuntimeError(f"NewAPI 视频生成失败: {err}")
+            if elapsed >= max_wait:
+                raise TimeoutError(f"NewAPI 视频任务超时（{max_wait:.0f}秒）: task_id={task_id}")
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+            elapsed += _POLL_INTERVAL_SECONDS
 
     @with_retry_async(
         max_attempts=DEFAULT_MAX_ATTEMPTS,

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -1,0 +1,213 @@
+"""NewAPIVideoBackend — NewAPI 统一视频生成端点后端。
+
+对接 NewAPI 的 /v1/video/generations 接口，支持 Sora / Kling / 即梦 / Wan / Veo
+等多家厂商模型，靠请求体的 model 字段分发。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from pathlib import Path
+
+import httpx
+
+from lib.providers import PROVIDER_NEWAPI
+from lib.retry import (
+    BASE_RETRYABLE_ERRORS,
+    DEFAULT_BACKOFF_SECONDS,
+    DEFAULT_MAX_ATTEMPTS,
+    DOWNLOAD_BACKOFF_SECONDS,
+    DOWNLOAD_MAX_ATTEMPTS,
+    with_retry_async,
+)
+from lib.video_backends.base import (
+    IMAGE_MIME_TYPES,
+    VideoCapabilities,
+    VideoCapability,
+    VideoGenerationRequest,
+    VideoGenerationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "kling-v1"
+
+_POLL_INTERVAL_SECONDS = 5.0
+_MIN_POLL_TIMEOUT_SECONDS = 600
+_POLL_TIMEOUT_PER_SECOND = 30
+
+_SIZE_MAP: dict[tuple[str, str], tuple[int, int]] = {
+    ("720p", "9:16"): (720, 1280),
+    ("720p", "16:9"): (1280, 720),
+    ("1080p", "9:16"): (1080, 1920),
+    ("1080p", "16:9"): (1920, 1080),
+}
+_DEFAULT_SIZE: tuple[int, int] = (720, 1280)
+
+
+def _resolve_size(resolution: str, aspect_ratio: str) -> tuple[int, int]:
+    return _SIZE_MAP.get((resolution, aspect_ratio), _DEFAULT_SIZE)
+
+
+def _encode_image_to_data_uri(path: Path) -> str:
+    mime = IMAGE_MIME_TYPES.get(path.suffix.lower(), "image/png")
+    payload = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:{mime};base64,{payload}"
+
+
+class NewAPIVideoBackend:
+    """NewAPI 统一视频生成端点后端。"""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str,
+        model: str | None = None,
+        http_timeout: float = 60.0,
+    ) -> None:
+        if not api_key:
+            raise ValueError("NewAPIVideoBackend 需要 api_key")
+        if not base_url:
+            raise ValueError("NewAPIVideoBackend 需要 base_url")
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._model = model or DEFAULT_MODEL
+        self._http_timeout = http_timeout
+        self._capabilities: set[VideoCapability] = {
+            VideoCapability.TEXT_TO_VIDEO,
+            VideoCapability.IMAGE_TO_VIDEO,
+        }
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_NEWAPI
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def capabilities(self) -> set[VideoCapability]:
+        return self._capabilities
+
+    @property
+    def video_capabilities(self) -> VideoCapabilities:
+        return VideoCapabilities(reference_images=False, max_reference_images=0)
+
+    async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
+        width, height = _resolve_size(request.resolution, request.aspect_ratio)
+        payload: dict = {
+            "model": self._model,
+            "prompt": request.prompt,
+            "width": width,
+            "height": height,
+            "duration": request.duration_seconds,
+            "n": 1,
+        }
+        if request.seed is not None:
+            payload["seed"] = request.seed
+        if request.negative_prompt:
+            payload.setdefault("metadata", {})["negative_prompt"] = request.negative_prompt
+        if request.start_image and Path(request.start_image).exists():
+            payload["image"] = _encode_image_to_data_uri(Path(request.start_image))
+        if request.reference_images:
+            logger.warning(
+                "NewAPIVideoBackend 不支持多张参考图（reference_images=%d），已忽略",
+                len(request.reference_images),
+            )
+
+        logger.info("NewAPI 视频生成开始: model=%s, duration=%s", self._model, request.duration_seconds)
+
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            task_id = await self._create_task(client, payload)
+            logger.info("NewAPI 任务创建: task_id=%s", task_id)
+
+            final = await self._poll_until_done(
+                client, task_id=task_id, max_wait=self._max_wait(request.duration_seconds)
+            )
+            video_url = final.get("url")
+            if not video_url:
+                raise RuntimeError(f"NewAPI 任务完成但缺少 url 字段: {final}")
+
+            await self._download(client, video_url, request.output_path)
+
+        meta = final.get("metadata") or {}
+        return VideoGenerationResult(
+            video_path=request.output_path,
+            provider=PROVIDER_NEWAPI,
+            model=self._model,
+            duration_seconds=int(meta.get("duration") or request.duration_seconds),
+            task_id=task_id,
+            seed=meta.get("seed"),
+        )
+
+    @with_retry_async(
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+        retryable_errors=BASE_RETRYABLE_ERRORS + (httpx.HTTPError,),
+    )
+    async def _create_task(self, client: httpx.AsyncClient, payload: dict) -> str:
+        resp = await client.post(
+            f"{self._base_url}/video/generations",
+            json=payload,
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        task_id = body.get("task_id")
+        if not task_id:
+            raise RuntimeError(f"NewAPI 创建任务返回体缺少 task_id: {body}")
+        return task_id
+
+    async def _poll_until_done(self, client: httpx.AsyncClient, *, task_id: str, max_wait: float) -> dict:
+        elapsed = 0.0
+        while True:
+            if elapsed >= max_wait:
+                raise TimeoutError(f"NewAPI 视频任务超时（{max_wait:.0f}秒）: task_id={task_id}")
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+            elapsed += _POLL_INTERVAL_SECONDS
+            state = await self._poll_once(client, task_id)
+            status = state.get("status")
+            if status == "completed":
+                return state
+            if status == "failed":
+                err = (state.get("error") or {}).get("message") or "unknown"
+                raise RuntimeError(f"NewAPI 视频生成失败: {err}")
+
+    @with_retry_async(
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+        retryable_errors=BASE_RETRYABLE_ERRORS + (httpx.HTTPError,),
+    )
+    async def _poll_once(self, client: httpx.AsyncClient, task_id: str) -> dict:
+        resp = await client.get(
+            f"{self._base_url}/video/generations/{task_id}",
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    @with_retry_async(
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
+        retryable_errors=BASE_RETRYABLE_ERRORS + (httpx.HTTPError,),
+    )
+    async def _download(self, client: httpx.AsyncClient, url: str, output_path: Path) -> None:
+        resp = await client.get(url, headers=self._headers())
+        resp.raise_for_status()
+
+        def _write():
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(resp.content)
+
+        await asyncio.to_thread(_write)
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"}
+
+    @staticmethod
+    def _max_wait(duration_seconds: int) -> float:
+        return max(_MIN_POLL_TIMEOUT_SECONDS, duration_seconds * _POLL_TIMEOUT_PER_SECOND)

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -16,6 +16,8 @@ from lib.retry import (
     BASE_RETRYABLE_ERRORS,
     DEFAULT_BACKOFF_SECONDS,
     DEFAULT_MAX_ATTEMPTS,
+    DOWNLOAD_BACKOFF_SECONDS,
+    DOWNLOAD_MAX_ATTEMPTS,
     with_retry_async,
 )
 from lib.video_backends.base import (
@@ -35,7 +37,11 @@ _POLL_INTERVAL_SECONDS = 5.0
 _MIN_POLL_TIMEOUT_SECONDS = 600
 _POLL_TIMEOUT_PER_SECOND = 30
 
-_NEWAPI_RETRYABLE_ERRORS = BASE_RETRYABLE_ERRORS + (httpx.RequestError,)
+# HTTPStatusError 不继承 RequestError，必须显式列出以便 5xx 响应走类型匹配而非字符串匹配
+_NEWAPI_RETRYABLE_ERRORS = BASE_RETRYABLE_ERRORS + (httpx.RequestError, httpx.HTTPStatusError)
+
+# 超过此阈值的起始图会触发 warning，NewAPI 聚合后端常见 4MB 请求体上限
+_LARGE_IMAGE_WARN_BYTES = 4 * 1024 * 1024
 
 _SIZE_MAP: dict[tuple[str, str], tuple[int, int]] = {
     ("720p", "9:16"): (720, 1280),
@@ -116,6 +122,12 @@ class NewAPIVideoBackend:
         if request.start_image:
             start_path = Path(request.start_image)
             if start_path.exists():
+                size_bytes = start_path.stat().st_size
+                if size_bytes > _LARGE_IMAGE_WARN_BYTES:
+                    logger.warning(
+                        "NewAPI start_image 较大 (%.1fMB)，Base64 编码后可能触发服务端请求体限制",
+                        size_bytes / 1024 / 1024,
+                    )
                 # 延迟导入避免 image_backends ↔ video_backends 循环依赖
                 from lib.image_backends.base import image_to_base64_data_uri
 
@@ -148,7 +160,7 @@ class NewAPIVideoBackend:
                 raise RuntimeError(f"NewAPI 任务完成但缺少 url 字段: {final}")
 
         # 流式下载，不携带 Authorization 头（视频 URL 常为 CDN/OSS，避免 API Key 泄露）
-        await download_video(video_url, request.output_path)
+        await self._download_with_retry(video_url, request.output_path)
 
         meta = final.get("metadata") or {}
         return VideoGenerationResult(
@@ -185,6 +197,16 @@ class NewAPIVideoBackend:
         )
         resp.raise_for_status()
         return resp.json()
+
+    @staticmethod
+    @with_retry_async(
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
+        retryable_errors=_NEWAPI_RETRYABLE_ERRORS,
+    )
+    async def _download_with_retry(video_url: str, output_path: Path) -> None:
+        """对齐 OpenAI/Ark 的下载重试策略（5 次、5/10/20/40 秒），与生成阶段独立。"""
+        await download_video(video_url, output_path)
 
     def _headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"}

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -7,12 +7,12 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import logging
 from pathlib import Path
 
 import httpx
 
+from lib.image_backends.base import image_to_base64_data_uri
 from lib.providers import PROVIDER_NEWAPI
 from lib.retry import (
     BASE_RETRYABLE_ERRORS,
@@ -23,11 +23,11 @@ from lib.retry import (
     with_retry_async,
 )
 from lib.video_backends.base import (
-    IMAGE_MIME_TYPES,
     VideoCapabilities,
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
+    poll_with_retry,
 )
 
 logger = logging.getLogger(__name__)
@@ -37,6 +37,8 @@ DEFAULT_MODEL = "kling-v1"
 _POLL_INTERVAL_SECONDS = 5.0
 _MIN_POLL_TIMEOUT_SECONDS = 600
 _POLL_TIMEOUT_PER_SECOND = 30
+
+_NEWAPI_RETRYABLE_ERRORS = BASE_RETRYABLE_ERRORS + (httpx.HTTPError,)
 
 _SIZE_MAP: dict[tuple[str, str], tuple[int, int]] = {
     ("720p", "9:16"): (720, 1280),
@@ -58,12 +60,6 @@ def _resolve_size(resolution: str, aspect_ratio: str) -> tuple[int, int]:
         )
         return _DEFAULT_SIZE
     return size
-
-
-def _encode_image_to_data_uri(path: Path) -> str:
-    mime = IMAGE_MIME_TYPES.get(path.suffix.lower(), "image/png")
-    payload = base64.b64encode(path.read_bytes()).decode("ascii")
-    return f"data:{mime};base64,{payload}"
 
 
 class NewAPIVideoBackend:
@@ -123,7 +119,7 @@ class NewAPIVideoBackend:
         if request.start_image:
             start_path = Path(request.start_image)
             if start_path.exists():
-                payload["image"] = _encode_image_to_data_uri(start_path)
+                payload["image"] = image_to_base64_data_uri(start_path)
             else:
                 logger.warning("start_image 文件不存在，已忽略: %s", start_path)
         if request.reference_images:
@@ -138,8 +134,14 @@ class NewAPIVideoBackend:
             task_id = await self._create_task(client, payload)
             logger.info("NewAPI 任务创建: task_id=%s", task_id)
 
-            final = await self._poll_until_done(
-                client, task_id=task_id, max_wait=self._max_wait(request.duration_seconds)
+            final = await poll_with_retry(
+                poll_fn=lambda: self._poll_once(client, task_id),
+                is_done=lambda s: s.get("status") == "completed",
+                is_failed=_extract_failure,
+                poll_interval=_POLL_INTERVAL_SECONDS,
+                max_wait=self._max_wait(request.duration_seconds),
+                retryable_errors=_NEWAPI_RETRYABLE_ERRORS,
+                label="NewAPI",
             )
             video_url = final.get("url")
             if not video_url:
@@ -160,7 +162,7 @@ class NewAPIVideoBackend:
     @with_retry_async(
         max_attempts=DEFAULT_MAX_ATTEMPTS,
         backoff_seconds=DEFAULT_BACKOFF_SECONDS,
-        retryable_errors=BASE_RETRYABLE_ERRORS + (httpx.HTTPError,),
+        retryable_errors=_NEWAPI_RETRYABLE_ERRORS,
     )
     async def _create_task(self, client: httpx.AsyncClient, payload: dict) -> str:
         resp = await client.post(
@@ -175,26 +177,6 @@ class NewAPIVideoBackend:
             raise RuntimeError(f"NewAPI 创建任务返回体缺少 task_id: {body}")
         return task_id
 
-    async def _poll_until_done(self, client: httpx.AsyncClient, *, task_id: str, max_wait: float) -> dict:
-        elapsed = 0.0
-        while True:
-            state = await self._poll_once(client, task_id)
-            status = state.get("status")
-            if status == "completed":
-                return state
-            if status == "failed":
-                err = (state.get("error") or {}).get("message") or "unknown"
-                raise RuntimeError(f"NewAPI 视频生成失败: {err}")
-            if elapsed >= max_wait:
-                raise TimeoutError(f"NewAPI 视频任务超时（{max_wait:.0f}秒）: task_id={task_id}")
-            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
-            elapsed += _POLL_INTERVAL_SECONDS
-
-    @with_retry_async(
-        max_attempts=DEFAULT_MAX_ATTEMPTS,
-        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
-        retryable_errors=BASE_RETRYABLE_ERRORS + (httpx.HTTPError,),
-    )
     async def _poll_once(self, client: httpx.AsyncClient, task_id: str) -> dict:
         resp = await client.get(
             f"{self._base_url}/video/generations/{task_id}",
@@ -206,7 +188,7 @@ class NewAPIVideoBackend:
     @with_retry_async(
         max_attempts=DOWNLOAD_MAX_ATTEMPTS,
         backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
-        retryable_errors=BASE_RETRYABLE_ERRORS + (httpx.HTTPError,),
+        retryable_errors=_NEWAPI_RETRYABLE_ERRORS,
     )
     async def _download(self, client: httpx.AsyncClient, url: str, output_path: Path) -> None:
         resp = await client.get(url, headers=self._headers())
@@ -224,3 +206,10 @@ class NewAPIVideoBackend:
     @staticmethod
     def _max_wait(duration_seconds: int) -> float:
         return max(_MIN_POLL_TIMEOUT_SECONDS, duration_seconds * _POLL_TIMEOUT_PER_SECOND)
+
+
+def _extract_failure(state: dict) -> str | None:
+    if state.get("status") != "failed":
+        return None
+    err = (state.get("error") or {}).get("message") or "unknown"
+    return f"NewAPI 视频生成失败: {err}"

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -155,7 +155,7 @@ class NewAPIVideoBackend:
             video_path=request.output_path,
             provider=PROVIDER_NEWAPI,
             model=self._model,
-            duration_seconds=int(meta.get("duration") or request.duration_seconds),
+            duration_seconds=int(float(meta.get("duration") or request.duration_seconds)),
             task_id=task_id,
             seed=meta.get("seed"),
         )

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -72,7 +72,7 @@ class ModelInput(BaseModel):
 
 class CreateProviderRequest(BaseModel):
     display_name: str
-    api_format: str  # "openai" or "google"
+    api_format: str  # "openai" | "google" | "newapi"
     base_url: str
     api_key: str
     models: list[ModelInput] = []
@@ -491,6 +491,12 @@ async def _run_connection_test(
         elif api_format == "google":
             result = await asyncio.wait_for(
                 asyncio.to_thread(_test_google, base_url, api_key, _t),
+                timeout=_CONNECTION_TEST_TIMEOUT,
+            )
+        elif api_format == "newapi":
+            # NewAPI 的 /v1/models 是 OpenAI 兼容
+            result = await asyncio.wait_for(
+                asyncio.to_thread(_test_openai, base_url, api_key, _t),
                 timeout=_CONNECTION_TEST_TIMEOUT,
             )
         else:

--- a/tests/test_custom_provider_factory.py
+++ b/tests/test_custom_provider_factory.py
@@ -185,6 +185,51 @@ class TestOpenAIUrlAutoCompletion:
 
 
 # ---------------------------------------------------------------------------
+# NewAPI format
+# ---------------------------------------------------------------------------
+
+
+class TestNewAPIFormat:
+    @patch("lib.custom_provider.factory.OpenAITextBackend")
+    def test_text_backend_uses_openai_delegate(self, mock_cls):
+        provider = _make_provider(api_format="newapi", base_url="https://newapi.example.com")
+        result = create_custom_backend(provider=provider, model_id="gpt-oss", media_type="text")
+
+        assert isinstance(result, CustomTextBackend)
+        assert result.model == "gpt-oss"
+        mock_cls.assert_called_once_with(
+            api_key="sk-test",
+            base_url="https://newapi.example.com/v1",
+            model="gpt-oss",
+        )
+
+    @patch("lib.custom_provider.factory.OpenAIImageBackend")
+    def test_image_backend_uses_openai_delegate(self, mock_cls):
+        provider = _make_provider(api_format="newapi", base_url="https://newapi.example.com/v1")
+        result = create_custom_backend(provider=provider, model_id="dall-e-3", media_type="image")
+
+        assert isinstance(result, CustomImageBackend)
+        mock_cls.assert_called_once_with(
+            api_key="sk-test",
+            base_url="https://newapi.example.com/v1",
+            model="dall-e-3",
+        )
+
+    @patch("lib.custom_provider.factory.NewAPIVideoBackend")
+    def test_video_backend_uses_newapi_delegate(self, mock_cls):
+        provider = _make_provider(api_format="newapi", base_url="https://newapi.example.com/v1")
+        result = create_custom_backend(provider=provider, model_id="kling-v1", media_type="video")
+
+        assert isinstance(result, CustomVideoBackend)
+        assert result.model == "kling-v1"
+        mock_cls.assert_called_once_with(
+            api_key="sk-test",
+            base_url="https://newapi.example.com/v1",
+            model="kling-v1",
+        )
+
+
+# ---------------------------------------------------------------------------
 # Error cases
 # ---------------------------------------------------------------------------
 

--- a/tests/test_custom_providers_api.py
+++ b/tests/test_custom_providers_api.py
@@ -132,6 +132,33 @@ class TestCreateProvider:
         assert resp.status_code == 201
         assert resp.json()["models"] == []
 
+    def test_create_newapi_provider(self, client: TestClient):
+        """回归: POST /custom-providers 接受 api_format=newapi 且持久化正确字段。"""
+        resp = client.post(
+            "/api/v1/custom-providers",
+            json={
+                "display_name": "NewAPI Gateway",
+                "api_format": "newapi",
+                "base_url": "https://newapi.example.com/v1",
+                "api_key": "sk-newapi-test-12345",
+                "models": [
+                    {
+                        "model_id": "kling-v1",
+                        "display_name": "Kling v1",
+                        "media_type": "video",
+                        "is_default": True,
+                        "is_enabled": True,
+                    },
+                ],
+            },
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["api_format"] == "newapi"
+        assert body["base_url"] == "https://newapi.example.com/v1"
+        assert len(body["models"]) == 1
+        assert body["models"][0]["model_id"] == "kling-v1"
+
 
 class TestListProviders:
     def test_empty_list(self, client: TestClient):
@@ -403,6 +430,35 @@ class TestDiscoverModels:
         assert len(resp.json()["models"]) == 1
         assert resp.json()["models"][0]["model_id"] == "gpt-4"
 
+    def test_discover_newapi(self, client: TestClient):
+        """newapi 的模型发现复用 OpenAI 兼容的 /v1/models 路径。"""
+        fake_models = [
+            {
+                "model_id": "kling-v1",
+                "display_name": "kling-v1",
+                "media_type": "video",
+                "is_default": True,
+                "is_enabled": True,
+            },
+        ]
+        with patch(
+            "lib.custom_provider.discovery.discover_models",
+            new_callable=AsyncMock,
+            return_value=fake_models,
+        ) as mock_discover:
+            resp = client.post(
+                "/api/v1/custom-providers/discover",
+                json={
+                    "api_format": "newapi",
+                    "base_url": "https://newapi.example.com/v1",
+                    "api_key": "sk-newapi-discover",
+                },
+            )
+        assert resp.status_code == 200
+        assert resp.json()["models"][0]["model_id"] == "kling-v1"
+        # 确认 api_format 作为 newapi 透传
+        assert mock_discover.call_args.kwargs["api_format"] == "newapi"
+
     def test_discover_invalid_format(self, client: TestClient):
         with patch(
             "lib.custom_provider.discovery.discover_models",
@@ -477,6 +533,26 @@ class TestConnectionTest:
         body = resp.json()
         assert body["success"] is True
         assert body["model_count"] == 10
+
+    def test_newapi_success(self, client: TestClient):
+        """newapi 的 /v1/models 走 OpenAI 兼容路径，连接测试应通过 _test_openai。"""
+        with patch(
+            "server.routers.custom_providers._test_openai",
+            return_value=custom_providers.ConnectionTestResponse(success=True, message="连接成功", model_count=42),
+        ) as mock_openai_test:
+            resp = client.post(
+                "/api/v1/custom-providers/test",
+                json={
+                    "api_format": "newapi",
+                    "base_url": "https://newapi.example.com/v1",
+                    "api_key": "sk-newapi-conn",
+                },
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["model_count"] == 42
+        mock_openai_test.assert_called_once()
 
     def test_unsupported_format(self, client: TestClient):
         resp = client.post(

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -299,3 +299,28 @@ class TestUnknownFormat:
     async def test_unknown_api_format(self):
         with pytest.raises(ValueError, match="api_format"):
             await discover_models("anthropic", "https://api.example.com", "sk-test")
+
+
+class TestDiscoverNewAPI:
+    async def test_newapi_reuses_openai_path(self):
+        """newapi 格式应走 OpenAI 兼容的 /v1/models 路径。"""
+        from unittest.mock import patch
+
+        fake_models = [
+            type("M", (), {"id": "gpt-4o"}),
+            type("M", (), {"id": "kling-v1"}),
+        ]
+
+        with patch("lib.custom_provider.discovery.OpenAI") as mock_cls:
+            mock_client = mock_cls.return_value
+            mock_client.models.list.return_value = fake_models
+
+            from lib.custom_provider.discovery import discover_models
+
+            result = await discover_models(api_format="newapi", base_url="https://x/v1", api_key="sk")
+
+        ids = [m["model_id"] for m in result]
+        assert "gpt-4o" in ids
+        assert "kling-v1" in ids
+        kling = next(m for m in result if m["model_id"] == "kling-v1")
+        assert kling["media_type"] == "video"

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import base64
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from lib.providers import PROVIDER_NEWAPI
@@ -20,6 +22,13 @@ def _make_response(status_code: int, json_body: dict) -> MagicMock:
     resp.json.return_value = json_body
     resp.raise_for_status = MagicMock()
     return resp
+
+
+def _make_http_error(status_code: int, message: str) -> httpx.HTTPStatusError:
+    """构造 httpx.HTTPStatusError，用于模拟 raise_for_status() 抛出的 5xx。"""
+    request = httpx.Request("POST", "https://x/v1/video/generations")
+    response = httpx.Response(status_code, request=request, text=message)
+    return httpx.HTTPStatusError(f"Server error '{status_code}'", request=request, response=response)
 
 
 def _fake_download_factory(payload: bytes = b"mp4-bytes"):
@@ -112,8 +121,9 @@ class TestNewAPIVideoBackend:
         assert download_call.args[1] == tmp_path / "out.mp4"
 
     async def test_image_to_video_encodes_base64(self, tmp_path: Path):
+        img_bytes = b"\x89PNG\r\nfake"
         img_path = tmp_path / "start.png"
-        img_path.write_bytes(b"\x89PNG\r\nfake")
+        img_path.write_bytes(img_bytes)
 
         create_resp = _make_response(200, {"task_id": "t1", "status": "queued"})
         poll_resp = _make_response(
@@ -154,8 +164,47 @@ class TestNewAPIVideoBackend:
             )
 
         sent_image = mock_client.post.call_args.kwargs["json"]["image"]
-        assert sent_image.startswith("data:image/png;base64,")
-        assert "fake" not in sent_image  # 必须编码过
+        expected = "data:image/png;base64," + base64.b64encode(img_bytes).decode()
+        assert sent_image == expected
+
+    async def test_start_image_missing_is_ignored(self, tmp_path: Path, caplog):
+        """start_image 文件不存在时应 warning 并走纯文生路径。"""
+        create_resp = _make_response(200, {"task_id": "t-missing", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {"task_id": "t-missing", "status": "completed", "url": "https://cdn/v.mp4", "metadata": {"duration": 5}},
+        )
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(return_value=poll_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.newapi.download_video", fake_download),
+            caplog.at_level("WARNING", logger="lib.video_backends.newapi"),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.mp4",
+                    start_image=tmp_path / "does_not_exist.png",
+                    resolution="720p",
+                    aspect_ratio="9:16",
+                    duration_seconds=5,
+                )
+            )
+
+        assert "image" not in mock_client.post.call_args.kwargs["json"]
+        assert any("start_image 文件不存在" in rec.message for rec in caplog.records)
 
     async def test_failed_status_raises(self, tmp_path: Path):
         create_resp = _make_response(200, {"task_id": "t2", "status": "queued"})
@@ -239,3 +288,84 @@ class TestNewAPIVideoBackend:
         # 3 次 poll（in_progress → in_progress → completed），下载不经过 mock_client
         assert mock_client.get.call_count == 3
         fake_download.assert_called_once()
+
+    async def test_polling_timeout_raises(self, tmp_path: Path):
+        """轮询超时应抛 TimeoutError 且不触发下载。"""
+        create_resp = _make_response(200, {"task_id": "t-timeout", "status": "queued"})
+        in_progress = _make_response(200, {"task_id": "t-timeout", "status": "in_progress"})
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(return_value=in_progress)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        fake_download = AsyncMock()
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.newapi._MIN_POLL_TIMEOUT_SECONDS", 0.01),
+            patch("lib.video_backends.newapi._POLL_TIMEOUT_PER_SECOND", 0),
+            patch("lib.video_backends.newapi.download_video", fake_download),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            with pytest.raises(TimeoutError, match="NewAPI"):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p",
+                        output_path=tmp_path / "o.mp4",
+                        resolution="720p",
+                        aspect_ratio="9:16",
+                        duration_seconds=5,
+                    )
+                )
+
+        fake_download.assert_not_called()
+
+    async def test_create_retries_on_5xx(self, tmp_path: Path):
+        """5xx HTTPStatusError 应通过 _NEWAPI_RETRYABLE_ERRORS 类型匹配重试。"""
+        failing_resp = MagicMock()
+        failing_resp.status_code = 503
+        failing_resp.raise_for_status = MagicMock(side_effect=_make_http_error(503, "upstream busy"))
+
+        create_resp = _make_response(200, {"task_id": "t-retry", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {"task_id": "t-retry", "status": "completed", "url": "https://cdn/v.mp4", "metadata": {"duration": 5}},
+        )
+
+        mock_client = AsyncMock()
+        # 前两次创建任务 503，第三次成功
+        mock_client.post = AsyncMock(side_effect=[failing_resp, failing_resp, create_resp])
+        mock_client.get = AsyncMock(return_value=poll_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+            # 压缩重试退避时间到 0，避免测试变慢
+            patch("lib.video_backends.newapi.DEFAULT_BACKOFF_SECONDS", (0, 0, 0)),
+            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            patch("lib.video_backends.newapi.download_video", fake_download),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.mp4",
+                    resolution="720p",
+                    aspect_ratio="9:16",
+                    duration_seconds=5,
+                )
+            )
+
+        assert result.task_id == "t-retry"
+        assert mock_client.post.call_count == 3

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -22,6 +22,16 @@ def _make_response(status_code: int, json_body: dict) -> MagicMock:
     return resp
 
 
+def _fake_download_factory(payload: bytes = b"mp4-bytes"):
+    """返回一个模拟 `download_video` 的异步函数，写入 payload 到 output_path。"""
+
+    async def _fake(url: str, output_path: Path, *, timeout: int = 120) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(payload)
+
+    return _fake
+
+
 class TestNewAPIVideoBackend:
     def test_name_and_model(self):
         from lib.video_backends.newapi import NewAPIVideoBackend
@@ -51,20 +61,19 @@ class TestNewAPIVideoBackend:
                 "metadata": {"duration": 5, "fps": 24, "width": 720, "height": 1280, "seed": 0},
             },
         )
-        download_resp = MagicMock()
-        download_resp.status_code = 200
-        download_resp.content = b"mp4-bytes"
-        download_resp.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=create_resp)
-        mock_client.get = AsyncMock(side_effect=[poll_resp, download_resp])
+        mock_client.get = AsyncMock(return_value=poll_resp)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"mp4-bytes"))
 
         with (
             patch("httpx.AsyncClient", return_value=mock_client),
             patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.newapi.download_video", fake_download),
         ):
             from lib.video_backends.newapi import NewAPIVideoBackend
 
@@ -96,6 +105,12 @@ class TestNewAPIVideoBackend:
         assert "image" not in post_call.kwargs["json"]
         assert post_call.kwargs["headers"]["Authorization"] == "Bearer sk-test"
 
+        # 下载走 base.download_video，URL 正确且不带 auth（base.download_video 不接 headers 参数）
+        fake_download.assert_called_once()
+        download_call = fake_download.call_args
+        assert download_call.args[0] == "https://cdn.example.com/out.mp4"
+        assert download_call.args[1] == tmp_path / "out.mp4"
+
     async def test_image_to_video_encodes_base64(self, tmp_path: Path):
         img_path = tmp_path / "start.png"
         img_path.write_bytes(b"\x89PNG\r\nfake")
@@ -110,20 +125,19 @@ class TestNewAPIVideoBackend:
                 "metadata": {"duration": 5},
             },
         )
-        download_resp = MagicMock()
-        download_resp.status_code = 200
-        download_resp.content = b"v"
-        download_resp.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=create_resp)
-        mock_client.get = AsyncMock(side_effect=[poll_resp, download_resp])
+        mock_client.get = AsyncMock(return_value=poll_resp)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
 
         with (
             patch("httpx.AsyncClient", return_value=mock_client),
             patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.newapi.download_video", fake_download),
         ):
             from lib.video_backends.newapi import NewAPIVideoBackend
 
@@ -159,9 +173,12 @@ class TestNewAPIVideoBackend:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
 
+        fake_download = AsyncMock()
+
         with (
             patch("httpx.AsyncClient", return_value=mock_client),
             patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.newapi.download_video", fake_download),
         ):
             from lib.video_backends.newapi import NewAPIVideoBackend
 
@@ -177,6 +194,8 @@ class TestNewAPIVideoBackend:
                     )
                 )
 
+        fake_download.assert_not_called()
+
     async def test_polls_through_in_progress(self, tmp_path: Path):
         create_resp = _make_response(200, {"task_id": "t3", "status": "queued"})
         in_progress = _make_response(200, {"task_id": "t3", "status": "in_progress"})
@@ -189,20 +208,19 @@ class TestNewAPIVideoBackend:
                 "metadata": {"duration": 5},
             },
         )
-        download_resp = MagicMock()
-        download_resp.status_code = 200
-        download_resp.content = b"v"
-        download_resp.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=create_resp)
-        mock_client.get = AsyncMock(side_effect=[in_progress, in_progress, completed, download_resp])
+        mock_client.get = AsyncMock(side_effect=[in_progress, in_progress, completed])
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
 
         with (
             patch("httpx.AsyncClient", return_value=mock_client),
             patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.newapi.download_video", fake_download),
         ):
             from lib.video_backends.newapi import NewAPIVideoBackend
 
@@ -218,4 +236,6 @@ class TestNewAPIVideoBackend:
             )
 
         assert result.task_id == "t3"
-        assert mock_client.get.call_count == 4
+        # 3 次 poll（in_progress → in_progress → completed），下载不经过 mock_client
+        assert mock_client.get.call_count == 3
+        fake_download.assert_called_once()

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -1,0 +1,221 @@
+"""NewAPIVideoBackend 单元测试（mock httpx）。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lib.providers import PROVIDER_NEWAPI
+from lib.video_backends.base import (
+    VideoCapability,
+    VideoGenerationRequest,
+)
+
+
+def _make_response(status_code: int, json_body: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class TestNewAPIVideoBackend:
+    def test_name_and_model(self):
+        from lib.video_backends.newapi import NewAPIVideoBackend
+
+        backend = NewAPIVideoBackend(api_key="sk-test", base_url="https://example.com/v1", model="kling-v1")
+        assert backend.name == PROVIDER_NEWAPI
+        assert backend.model == "kling-v1"
+
+    def test_capabilities(self):
+        from lib.video_backends.newapi import NewAPIVideoBackend
+
+        backend = NewAPIVideoBackend(api_key="sk-test", base_url="https://x/v1", model="m")
+        assert VideoCapability.TEXT_TO_VIDEO in backend.capabilities
+        assert VideoCapability.IMAGE_TO_VIDEO in backend.capabilities
+        assert backend.video_capabilities.reference_images is False
+        assert backend.video_capabilities.max_reference_images == 0
+
+    async def test_text_to_video_happy_path(self, tmp_path: Path):
+        create_resp = _make_response(200, {"task_id": "task-42", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "task-42",
+                "status": "completed",
+                "url": "https://cdn.example.com/out.mp4",
+                "format": "mp4",
+                "metadata": {"duration": 5, "fps": 24, "width": 720, "height": 1280, "seed": 0},
+            },
+        )
+        download_resp = MagicMock()
+        download_resp.status_code = 200
+        download_resp.content = b"mp4-bytes"
+        download_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(side_effect=[poll_resp, download_resp])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="sk-test", base_url="https://example.com/v1", model="kling-v1")
+            request = VideoGenerationRequest(
+                prompt="A cat running",
+                output_path=tmp_path / "out.mp4",
+                aspect_ratio="9:16",
+                resolution="720p",
+                duration_seconds=5,
+            )
+            result = await backend.generate(request)
+
+        assert result.video_path == tmp_path / "out.mp4"
+        assert result.video_path.read_bytes() == b"mp4-bytes"
+        assert result.provider == PROVIDER_NEWAPI
+        assert result.model == "kling-v1"
+        assert result.duration_seconds == 5
+        assert result.task_id == "task-42"
+
+        post_call = mock_client.post.call_args
+        assert post_call.args[0].endswith("/video/generations")
+        assert post_call.kwargs["json"]["model"] == "kling-v1"
+        assert post_call.kwargs["json"]["prompt"] == "A cat running"
+        assert post_call.kwargs["json"]["width"] == 720
+        assert post_call.kwargs["json"]["height"] == 1280
+        assert post_call.kwargs["json"]["duration"] == 5
+        assert post_call.kwargs["json"]["n"] == 1
+        assert "image" not in post_call.kwargs["json"]
+        assert post_call.kwargs["headers"]["Authorization"] == "Bearer sk-test"
+
+    async def test_image_to_video_encodes_base64(self, tmp_path: Path):
+        img_path = tmp_path / "start.png"
+        img_path.write_bytes(b"\x89PNG\r\nfake")
+
+        create_resp = _make_response(200, {"task_id": "t1", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "t1",
+                "status": "completed",
+                "url": "https://cdn/x.mp4",
+                "metadata": {"duration": 5},
+            },
+        )
+        download_resp = MagicMock()
+        download_resp.status_code = 200
+        download_resp.content = b"v"
+        download_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(side_effect=[poll_resp, download_resp])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="kling-v1")
+            await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.mp4",
+                    start_image=img_path,
+                    resolution="720p",
+                    aspect_ratio="9:16",
+                    duration_seconds=5,
+                )
+            )
+
+        sent_image = mock_client.post.call_args.kwargs["json"]["image"]
+        assert sent_image.startswith("data:image/png;base64,")
+        assert "fake" not in sent_image  # 必须编码过
+
+    async def test_failed_status_raises(self, tmp_path: Path):
+        create_resp = _make_response(200, {"task_id": "t2", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "t2",
+                "status": "failed",
+                "error": {"code": 500, "message": "upstream down"},
+            },
+        )
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(return_value=poll_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            with pytest.raises(RuntimeError, match="upstream down"):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p",
+                        output_path=tmp_path / "o.mp4",
+                        resolution="720p",
+                        aspect_ratio="9:16",
+                        duration_seconds=5,
+                    )
+                )
+
+    async def test_polls_through_in_progress(self, tmp_path: Path):
+        create_resp = _make_response(200, {"task_id": "t3", "status": "queued"})
+        in_progress = _make_response(200, {"task_id": "t3", "status": "in_progress"})
+        completed = _make_response(
+            200,
+            {
+                "task_id": "t3",
+                "status": "completed",
+                "url": "https://cdn/v.mp4",
+                "metadata": {"duration": 5},
+            },
+        )
+        download_resp = MagicMock()
+        download_resp.status_code = 200
+        download_resp.content = b"v"
+        download_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(side_effect=[in_progress, in_progress, completed, download_resp])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.mp4",
+                    resolution="720p",
+                    aspect_ratio="9:16",
+                    duration_seconds=5,
+                )
+            )
+
+        assert result.task_id == "t3"
+        assert mock_client.get.call_count == 4

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -325,6 +325,48 @@ class TestNewAPIVideoBackend:
 
         fake_download.assert_not_called()
 
+    async def test_zero_duration_from_api_is_preserved(self, tmp_path: Path):
+        """回归: API 返回 duration=0 时不应被 falsy 回退到请求值（is None 判空）。"""
+        create_resp = _make_response(200, {"task_id": "t-zero", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "t-zero",
+                "status": "completed",
+                "url": "https://cdn/v.mp4",
+                "metadata": {"duration": 0},
+            },
+        )
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(return_value=poll_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.newapi.download_video", fake_download),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.mp4",
+                    resolution="720p",
+                    aspect_ratio="9:16",
+                    duration_seconds=5,
+                )
+            )
+
+        # API 明确返回 0，应如实保留，不是回退到 request.duration_seconds=5
+        assert result.duration_seconds == 0
+
     async def test_create_retries_on_5xx(self, tmp_path: Path):
         """5xx HTTPStatusError 应通过 _NEWAPI_RETRYABLE_ERRORS 类型匹配重试。"""
         failing_resp = MagicMock()


### PR DESCRIPTION
## Summary
- 新增 `api_format = "newapi"` 作为第三种自定义供应商协议（与 `openai` / `google` 并列）：文本/图片复用 OpenAI delegate，视频走新的 `NewAPIVideoBackend`
- `NewAPIVideoBackend` 直连 NewAPI 统一端点 `POST /v1/video/generations` + `GET /v1/video/generations/{task_id}` 轮询 + 下载，通过 `model` 字段一套 schema 覆盖 Sora/Kling/即梦/Wan/Veo 等多家厂商模型
- 前端自定义供应商 Form 协议下拉新增 "NewAPI" 选项；连接测试与模型发现复用 OpenAI 兼容路径

## 架构要点
- `lib/video_backends/newapi.py` 复用 `image_to_base64_data_uri`、`poll_with_retry`、`with_retry_async` 等项目共享工具；`_NEWAPI_RETRYABLE_ERRORS = BASE_RETRYABLE_ERRORS + (httpx.HTTPError,)` 模块常量去重三处 retry decorator
- `lib/custom_provider/factory.py` 新增 `_create_newapi_backend`：text/image 用 `OpenAI*Backend` + `ensure_openai_base_url`，video 用 `NewAPIVideoBackend`
- 数据库无 CHECK 约束，仅更新字段注释；应用层 `_VALID_API_FORMATS` 与路由 `_run_connection_test` 分别校验
- `VideoCapabilities(reference_images=False)`：NewAPI schema 只有单个 `image` 字段，多张参考图会 log warning 并忽略

## 设计与计划文档
- Spec：`docs/superpowers/specs/2026-04-15-newapi-custom-provider-design.md`
- Plan：`docs/superpowers/plans/2026-04-15-newapi-custom-provider.md`

## Test plan
- [x] `uv run pytest -q` 全绿（1482 passed）
- [x] `cd frontend && pnpm check && pnpm build` 全绿
- [x] `uv run ruff check` 全部修改文件 clean
- [x] NewAPIVideoBackend 单测覆盖：文生视频 happy path / 图生视频 Base64 编码 / failed 状态 / 轮询多轮 in_progress / 参考图警告
- [x] factory / discovery / registry 对 newapi 分支有单测
- [ ] **待手动 smoke**：合入后用真实 NewAPI 账号创建 provider → discover → test connection → 跑一次 kling/sora 视频生成