### PR TITLE
ci: add pytest markers, import smoke, registry consistency tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: uv run ruff check . && uv run ruff format --check .
 
       - name: Run tests with coverage
-        run: uv run python -m pytest --cov=lib --cov=server --cov-report=term-missing --cov-report=xml --cov-fail-under=80
+        run: uv run python -m pytest -m "not e2e" --cov=lib --cov=server --cov-report=term-missing --cov-report=xml --cov-fail-under=80
 
   frontend-tests:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ packages = ["lib", "server"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "unit: 快速、隔离、不触达真实 I/O 或外部服务的测试",
+    "integration: 跨模块真实协作测试；禁止 mock 被测 module 的公共入口（否则是在测 mock 本身）",
+    "e2e: 端到端、依赖真实外部资源（远程 API、大模型调用、重型 ffmpeg 等）的测试；CI 默认跳过",
+]
 
 [tool.coverage.run]
 source = ["lib", "server"]

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,72 @@
+"""Import smoke test — catches circular deps and import-time side effects.
+
+参数化遍历 lib/ 与 server/ 下核心子模块，每个 importlib.import_module 一次。
+任何循环依赖、缺失依赖、顶层副作用崩溃都会在此红。
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# 核心子模块白名单。新增包时请在此追加（而不是用 pkgutil.walk_packages，
+# 以避免意外拉起 lib.i18n.zh/en 的翻译数据包和 alembic.versions 迁移脚本）。
+MODULES = [
+    # lib 顶层单文件模块
+    "lib.ark_shared",
+    "lib.asset_fingerprints",
+    "lib.cost_calculator",
+    "lib.data_validator",
+    "lib.gemini_shared",
+    "lib.generation_queue",
+    "lib.generation_queue_client",
+    "lib.generation_worker",
+    "lib.grid_manager",
+    "lib.grok_shared",
+    "lib.image_utils",
+    "lib.logging_config",
+    "lib.media_generator",
+    "lib.openai_shared",
+    "lib.project_change_hints",
+    "lib.project_manager",
+    "lib.prompt_builders",
+    "lib.prompt_builders_script",
+    "lib.prompt_utils",
+    "lib.providers",
+    "lib.retry",
+    "lib.script_generator",
+    "lib.script_models",
+    "lib.status_calculator",
+    "lib.storyboard_sequence",
+    "lib.style_templates",
+    "lib.system_config",
+    "lib.text_generator",
+    "lib.thumbnail",
+    "lib.usage_tracker",
+    "lib.version_manager",
+    # lib 子包
+    "lib.config",
+    "lib.custom_provider",
+    "lib.db",
+    "lib.db.models",
+    "lib.db.repositories",
+    "lib.grid",
+    "lib.image_backends",
+    "lib.text_backends",
+    "lib.video_backends",
+    # server
+    "server",
+    "server.agent_runtime",
+    "server.app",
+    "server.auth",
+    "server.dependencies",
+    "server.routers",
+    "server.services",
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name", MODULES)
+def test_module_imports_cleanly(module_name: str) -> None:
+    importlib.import_module(module_name)

--- a/tests/test_registry_consistency.py
+++ b/tests/test_registry_consistency.py
@@ -1,0 +1,30 @@
+"""Registry consistency — 三张资源注册表的 keys 必须互相一致。
+
+断言 MediaGenerator.OUTPUT_PATTERNS / VersionManager.RESOURCE_TYPES /
+VersionManager.EXTENSIONS 三者的 keys 集合相等。
+
+不预置 canonical 白名单：任何未来新增的资源类型只要三处都登记，测试自动通过；
+只登记到 1~2 处（漏登记）会立刻红。这样新增资源类型不需要修改本测试。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lib.media_generator import MediaGenerator
+from lib.version_manager import VersionManager
+
+
+@pytest.mark.unit
+def test_resource_registries_have_consistent_keys() -> None:
+    patterns_keys = set(MediaGenerator.OUTPUT_PATTERNS.keys())
+    types_keys = set(VersionManager.RESOURCE_TYPES)
+    ext_keys = set(VersionManager.EXTENSIONS.keys())
+
+    assert patterns_keys == types_keys == ext_keys, (
+        "资源注册表 keys 漂移：\n"
+        f"  MediaGenerator.OUTPUT_PATTERNS keys = {sorted(patterns_keys)}\n"
+        f"  VersionManager.RESOURCE_TYPES     = {sorted(types_keys)}\n"
+        f"  VersionManager.EXTENSIONS keys    = {sorted(ext_keys)}\n"
+        "新增资源类型时三处都要同步登记。"
+    )


### PR DESCRIPTION
## 范围

动：`pyproject.toml`（pytest markers）、`tests/`（新增两个 unit 测试）、`.github/workflows/test.yml`（CI 过滤 e2e）。不动：任何功能代码；不批量给现有测试打 marker。

## 变更

- `pyproject.toml` `[tool.pytest.ini_options].markers` 新增 `unit / integration / e2e` 定义，integration 明确禁止 mock 被测 module 的公共入口
- 新增 `tests/test_imports.py`：参数化 \`importlib.import_module\` 遍历 lib/server 核心子模块（共 48 项），捕获循环依赖与 import-time 副作用崩溃
- 新增 `tests/test_registry_consistency.py`：断言 `MediaGenerator.OUTPUT_PATTERNS` / `VersionManager.RESOURCE_TYPES` / `VersionManager.EXTENSIONS` 三者 keys 互相一致。**不预置白名单**——只要三处都登记，任何新增资源类型自动通过；漏登记一处立刻红
- `.github/workflows/test.yml` backend-tests 的 pytest 命令追加 \`-m \"not e2e\"\`

## 验收清单

- [x] 本地 \`uv run python -m pytest tests/test_imports.py tests/test_registry_consistency.py -v\` 48 passed
- [x] \`uv run python -m pytest -m \"not e2e\" --collect-only -q\` 无未知 marker 警告（1520 tests collected）
- [x] 未批量回溯打 marker，仅新增两个文件使用 \`@pytest.mark.unit\`
- [x] 未顺手注册 \`reference_videos\`（那是功能 PR 的职责）

## 已知 defer

无。

## 关于 reference_videos

调研确认 `reference_videos` 目前仅存在于 worktree `feature/seedance2-reference-to-video`，主分支的 `OUTPUT_PATTERNS` / `RESOURCE_TYPES` / `EXTENSIONS` 三者 keys 一致 = `{storyboards, videos, characters, clues, grids}`，测试绿。功能 PR 合入时只要三处都登记，本测试自然绿；只登记到 1~2 处就会红，正是本测试想拦的漏网。