### PR TITLE
fix(ci): pin setup-uv to v7 in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Set up uv
         if: ${{ steps.release.outputs.pr }}
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 


### PR DESCRIPTION
## 范围

单行修正 PR6 引入的坏 action 引用。

## 变更

- \`.github/workflows/release-please.yml\`：\`astral-sh/setup-uv@v8\` → \`@v7\`

## 原因

\`astral-sh/setup-uv\` 仓库没有 \`v8\` 的滑动 major tag——它只有具体 \`v8.0.0\` 和 \`v8.1.0\`（\`gh api repos/astral-sh/setup-uv/tags\` 可验证）。PR6 merge 后 release-please workflow 直接 \`Unable to resolve action astral-sh/setup-uv@v8, unable to find version v8\` 失败。

改回 \`@v7\`（test.yml 也是 v7，避免 drift）。升级到 v8 作为 follow-up，届时同时升 test.yml。

## 验收清单

- [x] YAML 语法合法
- [ ] Merge 后新 release-please run 成功执行
- [ ] 新 Release PR 基于 baseline 0.9.0 开出（\`chore(main): release 0.10.0\` 或类似）

## 已知 defer

- setup-uv 升到 v8：该 repo 发布了 v8.1.0 但无 major tag。follow-up 待仓库打出 \`v8\` 后同时升 test.yml 和 release-please.yml