### PR TITLE
fix(docs,ci): address review feedback from PR #310-314

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: ruff-check
         name: ruff check (python staged)
-        entry: uv run ruff check
+        entry: uv run ruff check --fix
         language: system
         types: [python]
         pass_filenames: true
@@ -17,7 +17,7 @@ repos:
 
       - id: frontend-eslint
         name: eslint (frontend staged)
-        entry: bash -c 'files=(); for f in "$@"; do files+=("${f#frontend/}"); done; cd frontend && ./node_modules/.bin/eslint "${files[@]}"' --
+        entry: bash -c 'files=(); for f in "$@"; do files+=("${f#frontend/}"); done; cd frontend && ./node_modules/.bin/eslint --fix "${files[@]}"' --
         language: system
         files: ^frontend/.*\.(ts|tsx|js|jsx)$
         pass_filenames: true
@@ -26,5 +26,5 @@ repos:
         name: block pull_request_target in workflows
         entry: bash -c 'files=$(grep -rlE "(^|[^a-zA-Z_])pull_request_target" .github/workflows/ 2>/dev/null || true); if [ -n "$files" ]; then echo "pull_request_target 被禁止（权限放大风险）:" >&2; echo "$files" >&2; exit 1; fi'
         language: system
+        files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: false
-        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,14 +166,13 @@ chore: 构建/工具变更
 |-------------|---------|-----------|
 | `feat`      | minor   | ✨ 新功能 |
 | `fix`       | patch   | 🐛 Bug 修复 |
-| `perf`      | patch   | ⚡ 性能优化 |
-| `refactor`  | patch   | ♻️ 重构 |
-| `docs`      | patch   | 📚 文档 |
-| `revert`    | patch   | ↩️ 回滚 |
-| `chore` / `ci` / `build` / `test` / `style` | 不步进 | 隐藏 |
 | `feat!` / 任意 type + `!` / footer 含 `BREAKING CHANGE:` | **major** | ⚠️ BREAKING CHANGES（changelog 置顶） |
+| `perf` / `refactor` / `docs` / `revert` | 不步进 | 显示（⚡ / ♻️ / 📚 / ↩️） |
+| `chore` / `ci` / `build` / `test` / `style` | 不步进 | 隐藏 |
 
-文件中的 `version` 字段固定为 `0.1.0`（见 `pyproject.toml` 的 `# managed by release-please` 注释），实际版本状态以 git tag + `.release-please-manifest.json` 为准。
+> release-please 默认只有 `feat` 和 `fix`（以及破坏性变更）触发版本 bump。把 `perf`/`refactor`/`docs`/`revert` 配成 `hidden: false` 只影响 changelog 呈现，不会使它们触发 patch bump。如果一轮迭代只有这几类 commit，不会产出 Release PR，直到下一个 `fix`/`feat` commit 到来。
+
+`pyproject.toml` 和 `frontend/package.json` 的 `version` 字段由 release-please 自动维护（见 `pyproject.toml` 的 `# managed by release-please` 注释），**开发者视为只读**。`uv.lock` 同样由 release-please workflow 在 Release PR 分支上自动 `uv lock` 同步。实际版本状态以 git tag + `.release-please-manifest.json` 为准。
 
 ### commit 示例
 


### PR DESCRIPTION
## 范围

处理 PR #310~#314 自动 code review（gemini-code-assist + codex）里经过评估后值得采纳的意见。不处理误判、过时或架构级的跟进项（在本 PR 末尾列出）。

## 变更

### CONTRIBUTING.md — 发版章节事实更正（gemini medium，PR #311）

原表格把 \`perf\` / \`refactor\` / \`docs\` / \`revert\` 都列为 "patch 步进"——**不准确**。release-please 默认只有 \`feat\`(minor)、\`fix\`(patch) 和破坏性变更(major) 触发版本 bump，其他 type 即便 \`hidden: false\` 在 changelog 里显示，也不触发 bump。

- 重新分组：feat/fix/BREAKING 触发步进；perf/refactor/docs/revert "不步进+显示"；chore/ci/build/test/style "不步进+隐藏"
- 补充警示：一轮只有 perf/refactor 类 commit 不会产出 Release PR，需等 fix/feat

### CONTRIBUTING.md — version 字段描述修正（gemini medium，PR #312）

原文 "文件中的 \`version\` 字段固定为 \`0.1.0\`" 已被 PR6 的决策反转，改为：
- 说明 \`pyproject.toml\` / \`frontend/package.json\` / \`uv.lock\` **全部由 release-please/workflow 自动维护**，开发者视为只读
- 指向 \`# managed by release-please\` 注释
- 点明 uv.lock 由 release-please workflow 的 auto-sync step 处理

### .pre-commit-config.yaml — 加 \`--fix\`（gemini medium ×2，PR #310）

- \`ruff check\` → \`ruff check --fix\`
- \`eslint ...\` → \`eslint --fix ...\`

理由：README 的贡献节原本就说 "避免把可被自动修复的问题推到 CI"，加 \`--fix\` 才兑现这个承诺。

### .pre-commit-config.yaml — tripwire 加 files filter（gemini medium，PR #310）

\`no-pull-request-target\` 原本 \`always_run: true\`，每次 commit 都扫（即便只改文档）。改为 \`files: ^\\.github/workflows/.*\\.ya?ml\$\` —— 只在动 workflow 时扫，速度显著提升。覆盖面等价（workflow 按 GitHub 约定必须在此目录）。

## 验收清单

- [x] \`uv run pre-commit run --all-files\` 4 个 hook 全绿
- [x] tripwire 拦截验证：把含 \`pull_request_target\` 的 yaml 放入 \`.github/workflows/\` → Failed；对无关文件（如 CONTRIBUTING.md）→ Skipped（files filter 工作正常）
- [x] ruff / eslint 的 \`--fix\` 语义本地验证无副作用（本 PR 改动都已通过）
- [x] CONTRIBUTING 事实陈述与 release-please 官方默认行为一致

## 故意不处理（已评估）

**PR #309 — test_imports.py**
- gemini 建议 "改用 \`pkgutil.iter_modules\` 自动发现"：当时选硬编码是为排除 \`lib.i18n.{zh,en}\` 数据包与 alembic 迁移脚本，trade-off 不同；如要切换需同时引入黑名单，单独跟进更清晰
- gemini 质疑 \`@pytest.mark.unit\` 不严谨（import server.app 会触发 env 读取等 I/O）：有道理，但 \"unit vs smoke\" 归类需要先在 pyproject 定义 smoke marker，单独跟进

**PR #311 codex P1 / PR #312 codex P1**
- 跨 PR 策略导致的窗口期担忧 / bootstrap-sha 位置建议：窗口期已过；bootstrap-sha 问题已通过 PR6 将 manifest baseline 从 0.1.0 改到 0.9.0 解决

**PR #314 gemini 两条 high**
- 误判（"workflow 改动不在 diff 里" / "uv.lock 像手动编辑"）：实际 merge commit 5 个文件齐全，\`uv.lock\` 确经 \`uv lock\` 生成

## 已知 defer

- test_imports.py 的 marker 与模块发现机制独立跟进
- astral-sh/setup-uv 升到 v8（等其打出 \`v8\` 滑动 tag，同时升 test.yml 和 release-please.yml）