### PR TITLE
ci(deps): switch to uv ecosystem and consolidate frontend groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,14 @@
 
 version: 2
 updates:
-  # Python dependencies (pyproject.toml)
-  - package-ecosystem: "pip"
+  # Python dependencies via uv (pyproject.toml + uv.lock)
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
-    versioning-strategy: increase
+    versioning-strategy: lockfile-only
     labels:
       - "dependencies"
       - "python"
@@ -53,6 +53,7 @@ updates:
         patterns:
           - "pytest*"
           - "ruff"
+          - "pre-commit"
         update-types:
           - "minor"
           - "patch"
@@ -96,16 +97,6 @@ updates:
           - "@vitest/*"
           - "@testing-library/*"
           - "jsdom"
-      dnd-kit:
-        patterns:
-          - "@dnd-kit/*"
-      i18n-packages:
-        patterns:
-          - "i18next*"
-          - "react-i18next"
-      types:
-        patterns:
-          - "@types/*"
       dev-dependencies:
         dependency-type: "development"
         patterns:


### PR DESCRIPTION
## Summary

- **Python ecosystem**: `pip` → `uv` (matches GitHub's auto-detection against `uv.lock`, fixes double-ecosystem PRs like #294).
- **Python strategy**: `versioning-strategy: increase` → `lockfile-only`. With `pyproject.toml` using `>=` constraints, `increase` produced manifest-only lower-bound bumps that bypass `groups`. That's the root cause of the recent leaks (#262 pytest-cov, #266 sqlalchemy, #268 ruff, #272 pillow, #288 pytest). Now all updates land in `uv.lock` and participate in groups.
- **Frontend**: removed `i18n-packages`, `dnd-kit`, and `types` — they each had <3 members and sometimes leaked as single-package PRs (e.g. #275 i18next). `minor-and-patch` / `dev-dependencies` now absorb them.
- Added `pre-commit` to Python `dev-dependencies` group.

Context: there are currently ~15 open Dependabot PRs against a config that defined 13 groups — the leaks above explain the gap.

## Test plan

- [ ] YAML syntax valid (`python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — verified locally)
- [ ] Next Monday's Dependabot run produces ≤6 PRs total (Python ≤3, frontend ≤3)
- [ ] All Python PR branches prefixed `dependabot/uv/`, none `dependabot/pip/`
- [ ] PR titles follow `bump the <group-name> group` format (no more `update X requirement from Y to Z`)
- [ ] After merge, manually close stale leaked PRs (#262, #266, #268, #272, #275, #288, #294, #222) so Dependabot regenerates consolidated versions