### PR TITLE
fix(video): seedance-2.0 模型不传 service_tier 参数

### DIFF
--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -136,8 +136,10 @@ class ArkVideoBackend:
             "resolution": request.resolution,
             "generate_audio": request.generate_audio,
             "watermark": False,
-            "service_tier": request.service_tier,
         }
+        # seedance-2.0 等模型不接受 service_tier，仅在声明 FLEX_TIER 能力时传入
+        if VideoCapability.FLEX_TIER in self._capabilities:
+            create_params["service_tier"] = request.service_tier
         if request.seed is not None:
             create_params["seed"] = request.seed
 

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -320,3 +320,64 @@ class TestArkModelCapabilities:
             b = ArkVideoBackend(api_key="test", model="some-future-model")
         caps = b.capabilities
         assert VideoCapability.FLEX_TIER in caps
+
+
+class TestArkServiceTierParam:
+    """service_tier 只对声明了 FLEX_TIER 能力的模型传入，否则 API 会报错。"""
+
+    async def test_seedance_2_does_not_send_service_tier(self, tmp_path):
+        output = tmp_path / "out.mp4"
+        mock_client = MagicMock()
+        mock_client.content_generation = MagicMock()
+        mock_client.content_generation.tasks = MagicMock()
+
+        with patch("lib.video_backends.ark.create_ark_client", return_value=mock_client):
+            backend = ArkVideoBackend(api_key="test", model="doubao-seedance-2-0-260128")
+        backend._client = mock_client
+
+        create_result = MagicMock()
+        create_result.id = "cgt-seedance2"
+        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+
+        get_result = MagicMock()
+        get_result.status = "succeeded"
+        get_result.content = MagicMock()
+        get_result.content.video_url = "https://cdn.example.com/v.mp4"
+        get_result.seed = None
+        get_result.usage = None
+        backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
+
+        patcher = _mock_httpx_stream()
+        try:
+            request = VideoGenerationRequest(prompt="test", output_path=output)
+            await backend.generate(request)
+        finally:
+            patcher.stop()
+
+        create_kwargs = backend._client.content_generation.tasks.create.call_args.kwargs
+        assert "service_tier" not in create_kwargs
+
+    async def test_seedance_1_5_sends_service_tier(self, backend, tmp_path):
+        output = tmp_path / "out.mp4"
+
+        create_result = MagicMock()
+        create_result.id = "cgt-seedance15"
+        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+
+        get_result = MagicMock()
+        get_result.status = "succeeded"
+        get_result.content = MagicMock()
+        get_result.content.video_url = "https://cdn.example.com/v.mp4"
+        get_result.seed = None
+        get_result.usage = None
+        backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
+
+        patcher = _mock_httpx_stream()
+        try:
+            request = VideoGenerationRequest(prompt="test", output_path=output)
+            await backend.generate(request)
+        finally:
+            patcher.stop()
+
+        create_kwargs = backend._client.content_generation.tasks.create.call_args.kwargs
+        assert create_kwargs.get("service_tier") == "default"

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -350,7 +350,8 @@ class TestArkServiceTierParam:
         patcher = _mock_httpx_stream()
         try:
             request = VideoGenerationRequest(prompt="test", output_path=output)
-            await backend.generate(request)
+            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+                await backend.generate(request)
         finally:
             patcher.stop()
 
@@ -375,7 +376,8 @@ class TestArkServiceTierParam:
         patcher = _mock_httpx_stream()
         try:
             request = VideoGenerationRequest(prompt="test", output_path=output)
-            await backend.generate(request)
+            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+                await backend.generate(request)
         finally:
             patcher.stop()
 


### PR DESCRIPTION
## Summary
- Ark backend 原本无条件注入 \`service_tier\`，doubao-seedance-2-0-* 模型被方舟 API 拒绝（"该模型不支持 service_tier，要求必须为空"），整批镜头视频生成失败
- 改为仅在模型声明 \`VideoCapability.FLEX_TIER\` 时注入，与 \`_MODEL_CAPABILITIES\` 注册表保持一致
- 新增 \`TestArkServiceTierParam\` 覆盖 seedance-2.0 不传 / seedance-1.5 传入 \`default\` 两种路径

## Test plan
- [x] \`uv run python -m pytest tests/test_video_backend_ark.py -v\`（16 passed）
- [x] \`uv run python -m pytest tests/test_video_backend_base.py tests/test_video_backend_capabilities.py\`（20 passed）
- [x] \`uv run ruff check lib/video_backends/ark.py tests/test_video_backend_ark.py\`
- [ ] 在真实项目上执行"继续"从断点续生 seedance-2.0 镜头视频