### PR TITLE
refactor: PR #307 tech-debt follow-up（P1 + P2 低风险）

### DIFF
--- a/frontend/src/components/assets/AssetCard.tsx
+++ b/frontend/src/components/assets/AssetCard.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import { Edit2, Trash2, User as UserIcon, Landmark, Package } from "lucide-react";
 import { API } from "@/api";
 import type { Asset } from "@/types/asset";
+import { AssetThumb } from "./AssetThumb";
 
 interface Props {
   asset: Asset;
@@ -18,13 +19,12 @@ export function AssetCard({ asset, onEdit, onDelete }: Props) {
 
   return (
     <div className="group bg-gray-900 border border-gray-800 rounded-lg overflow-hidden hover:border-gray-600 transition-colors">
-      <div className="aspect-[3/4] bg-gradient-to-br from-gray-800 to-gray-700 flex items-center justify-center">
-        {imageUrl ? (
-          <img src={imageUrl} alt={asset.name} loading="lazy" decoding="async" className="h-full w-full object-cover" />
-        ) : (
-          <Icon className="h-10 w-10 text-gray-600" />
-        )}
-      </div>
+      <AssetThumb
+        imageUrl={imageUrl}
+        alt={asset.name}
+        fallback={<Icon className="h-10 w-10 text-gray-600" />}
+        variant="display"
+      />
       <div className="p-3">
         <div className="flex items-start gap-2">
           <div className="flex-1 min-w-0">

--- a/frontend/src/components/assets/AssetFormModal.tsx
+++ b/frontend/src/components/assets/AssetFormModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { AlertTriangle, ImagePlus, Landmark, Package, User, X } from "lucide-react";
 import type { Asset, AssetType } from "@/types/asset";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
+import { useEscapeClose } from "@/hooks/useEscapeClose";
 import { sanitizeImageSrc } from "@/utils/safe-url";
 
 type Mode = "create" | "edit" | "import";
@@ -48,13 +49,7 @@ export function AssetFormModal({
     nameRef.current?.focus();
   }, []);
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  useEscapeClose(onClose);
 
   useEffect(() => {
     if (!image) {

--- a/frontend/src/components/assets/AssetPickerModal.tsx
+++ b/frontend/src/components/assets/AssetPickerModal.tsx
@@ -4,7 +4,9 @@ import { Search, X } from "lucide-react";
 import { API } from "@/api";
 import type { Asset, AssetType } from "@/types/asset";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
+import { useEscapeClose } from "@/hooks/useEscapeClose";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { AssetThumb } from "./AssetThumb";
 
 interface Props {
   type: AssetType;
@@ -26,13 +28,7 @@ export function AssetPickerModal({ type, existingNames, onClose, onImport }: Pro
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef);
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  useEscapeClose(onClose);
 
   useEffect(() => {
     const ctrl = new AbortController();
@@ -133,9 +129,7 @@ export function AssetPickerModal({ type, existingNames, onClose, onImport }: Pro
                       : "border-gray-700 bg-gray-800 hover:border-gray-600"
                 }`}
               >
-                <div className="aspect-[3/4] bg-gray-700 rounded flex items-center justify-center text-gray-500 text-xs">
-                  {url ? <img src={url} alt={a.name} loading="lazy" decoding="async" className="h-full w-full object-cover rounded" /> : "—"}
-                </div>
+                <AssetThumb imageUrl={url} alt={a.name} fallback="—" variant="picker" />
                 <div className="mt-1 text-xs font-semibold text-white truncate">{a.name}</div>
                 {a.description && <div className="text-[10px] text-gray-400 truncate">{a.description}</div>}
                 {dup && (

--- a/frontend/src/components/assets/AssetThumb.tsx
+++ b/frontend/src/components/assets/AssetThumb.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+type Variant = "display" | "picker";
+
+interface Props {
+  imageUrl: string | null | undefined;
+  alt: string;
+  fallback: ReactNode;
+  variant: Variant;
+}
+
+export function AssetThumb({ imageUrl, alt, fallback, variant }: Props) {
+  const containerClass =
+    variant === "display"
+      ? "aspect-[3/4] bg-gradient-to-br from-gray-800 to-gray-700 flex items-center justify-center"
+      : "aspect-[3/4] bg-gray-700 rounded flex items-center justify-center text-gray-500 text-xs";
+  const imgClass =
+    variant === "display"
+      ? "h-full w-full object-cover"
+      : "h-full w-full object-cover rounded";
+  return (
+    <div className={containerClass}>
+      {imageUrl ? (
+        <img
+          src={imageUrl}
+          alt={alt}
+          loading="lazy"
+          decoding="async"
+          className={imgClass}
+        />
+      ) : (
+        fallback
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/pages/ApiKeysTab.tsx
+++ b/frontend/src/components/pages/ApiKeysTab.tsx
@@ -5,6 +5,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAutoFocus } from "@/hooks/useAutoFocus";
+import { useEscapeClose } from "@/hooks/useEscapeClose";
 import {
   AlertTriangle,
   Check,
@@ -92,14 +93,15 @@ function CreateModal({ onClose, onCreated }: CreateModalProps) {
     setTimeout(() => setCopied(false), 2000);
   }, [created?.key]);
 
+  useEscapeClose(onClose);
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Enter" && !created && canCreate) void handleCreate();
-      if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [canCreate, created, handleCreate, onClose]);
+  }, [canCreate, created, handleCreate]);
 
   return (
     <div

--- a/frontend/src/components/pages/CreateProjectModal.tsx
+++ b/frontend/src/components/pages/CreateProjectModal.tsx
@@ -11,6 +11,7 @@ import { useAppStore } from "@/stores/app-store";
 import { DEFAULT_TEMPLATE_ID } from "@/data/style-templates";
 import { PROVIDER_NAMES } from "@/components/ui/ProviderIcon";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
+import { useEscapeClose } from "@/hooks/useEscapeClose";
 import { WizardStep1Basics, type WizardStep1Value } from "./create-project/WizardStep1Basics";
 import { WizardStep2Models, type WizardStep2Data } from "./create-project/WizardStep2Models";
 import { WizardStep3Style, type WizardStep3Value } from "./create-project/WizardStep3Style";
@@ -155,13 +156,7 @@ export function CreateProjectModal() {
     setShowCreateModal(false);
   };
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setShowCreateModal(false);
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [setShowCreateModal]);
+  useEscapeClose(() => setShowCreateModal(false));
 
   // 背景 inert：打开期间屏蔽 #root 内容（modal 通过 portal 挂到 body，
   // 不在 #root 子树内，因此不会被 inert 传染）。

--- a/frontend/src/components/pages/OpenClawModal.tsx
+++ b/frontend/src/components/pages/OpenClawModal.tsx
@@ -2,10 +2,11 @@
  * OpenClaw 集成引导 Modal
  * 提示词区域（可复制，含动态 skill.md URL）、3 步使用说明、"获取 API 令牌"按钮
  */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { copyText } from "@/utils/clipboard";
 import { Check, Copy, ExternalLink, X } from "lucide-react";
 import { useLocation } from "wouter";
+import { useEscapeClose } from "@/hooks/useEscapeClose";
 
 // 🦞 SVG lobster icon (inline, no external dep)
 function LobsterIcon({ className }: { className?: string }) {
@@ -66,13 +67,7 @@ export function OpenClawModal({ onClose }: OpenClawModalProps) {
     navigate("/app/settings?section=api-keys");
   }, [navigate, onClose]);
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [onClose]);
+  useEscapeClose(onClose);
 
   return (
     <div

--- a/frontend/src/components/task-hud/TaskHud.tsx
+++ b/frontend/src/components/task-hud/TaskHud.tsx
@@ -6,6 +6,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Image, Video, Check, X, Loader2, ChevronDown } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useAnchoredPopover } from "@/hooks/useAnchoredPopover";
+import { useEscapeClose } from "@/hooks/useEscapeClose";
 import { useAppStore } from "@/stores/app-store";
 import { useTasksStore } from "@/stores/tasks-store";
 import { API } from "@/api";
@@ -345,17 +346,7 @@ export function TaskHud({ anchorRef }: { anchorRef: RefObject<HTMLElement | null
     }
   }, [cancelConfirm]);
 
-  // Escape 键关闭确认面板
-  useEffect(() => {
-    if (!cancelConfirm) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setCancelConfirm(null);
-      }
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [cancelConfirm]);
+  useEscapeClose(() => setCancelConfirm(null), Boolean(cancelConfirm));
 
   const imageTasks = tasks.filter((t) => t.media_type === "image");
   const videoTasks = tasks.filter((t) => t.media_type === "video");

--- a/frontend/src/components/ui/ImageLightbox.tsx
+++ b/frontend/src/components/ui/ImageLightbox.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 import { UI_LAYERS } from "@/utils/ui-layers";
+import { useEscapeClose } from "@/hooks/useEscapeClose";
 
 export interface ImageLightboxProps {
   src: string;
@@ -10,22 +11,15 @@ export interface ImageLightboxProps {
 }
 
 export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
+  useEscapeClose(onClose);
+
   useEffect(() => {
     const previousOverflow = document.body.style.overflow;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    };
-
     document.body.style.overflow = "hidden";
-    document.addEventListener("keydown", handleKeyDown);
-
     return () => {
       document.body.style.overflow = previousOverflow;
-      document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [onClose]);
+  }, []);
 
   if (typeof document === "undefined") {
     return null;

--- a/frontend/src/hooks/useEscapeClose.ts
+++ b/frontend/src/hooks/useEscapeClose.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+
+export function useEscapeClose(onClose: () => void, enabled = true) {
+  useEffect(() => {
+    if (!enabled) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose, enabled]);
+}

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -6,11 +6,12 @@
 
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+from lib.json_io import load_json_or_none
 
 
 @dataclass
@@ -75,14 +76,6 @@ class DataValidator:
         if projects_root is None:
             projects_root = os.environ.get("AI_ANIME_PROJECTS", "projects")
         self.projects_root = Path(projects_root)
-
-    def _load_json(self, file_path: Path) -> dict[str, Any] | None:
-        """加载 JSON 文件"""
-        try:
-            with open(file_path, encoding="utf-8") as handle:
-                return json.load(handle)
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-            return None
 
     @staticmethod
     def _is_hidden_path(path: Path) -> bool:
@@ -208,40 +201,57 @@ class DataValidator:
         if project.get("clues") is not None:
             errors.append("project.json 含已废弃字段 clues，请等待自动迁移或手动重启服务")
 
-        self._validate_project_scenes(project.get("scenes") or {}, errors)
-        self._validate_project_props(project.get("props") or {}, errors)
+        self._validate_project_catalog(
+            project.get("scenes") or {},
+            errors,
+            field_label="scenes",
+            kind_label="场景",
+        )
+        self._validate_project_catalog(
+            project.get("props") or {},
+            errors,
+            field_label="props",
+            kind_label="道具",
+        )
 
-    def _validate_project_scenes(
+    def _validate_project_catalog(
         self,
-        scenes: dict[str, Any],
+        catalog: Any,
         errors: list[str],
+        *,
+        field_label: str,
+        kind_label: str,
     ) -> None:
-        """验证 project.json 顶层 scenes 字典"""
-        if not isinstance(scenes, dict):
-            errors.append("scenes 必须是对象")
+        if not isinstance(catalog, dict):
+            errors.append(f"{field_label} 必须是对象")
             return
-        for scene_name, scene_data in scenes.items():
-            if not isinstance(scene_data, dict):
-                errors.append(f"场景 '{scene_name}' 数据格式错误，应为对象")
+        for name, data in catalog.items():
+            if not isinstance(data, dict):
+                errors.append(f"{kind_label} '{name}' 数据格式错误，应为对象")
                 continue
-            if not scene_data.get("description"):
-                errors.append(f"场景 '{scene_name}' 缺少必填字段: description")
+            if not data.get("description"):
+                errors.append(f"{kind_label} '{name}' 缺少必填字段: description")
 
-    def _validate_project_props(
+    def _validate_segment_refs(
         self,
-        props: dict[str, Any],
+        prefix: str,
+        refs: Any,
+        valid_set: set[str],
         errors: list[str],
+        warnings: list[str],
+        *,
+        field_label: str,
+        kind_label: str,
     ) -> None:
-        """验证 project.json 顶层 props 字典"""
-        if not isinstance(props, dict):
-            errors.append("props 必须是对象")
+        if refs is None:
+            warnings.append(f"{prefix}: 缺少 {field_label}，将使用默认空数组")
             return
-        for prop_name, prop_data in props.items():
-            if not isinstance(prop_data, dict):
-                errors.append(f"道具 '{prop_name}' 数据格式错误，应为对象")
-                continue
-            if not prop_data.get("description"):
-                errors.append(f"道具 '{prop_name}' 缺少必填字段: description")
+        if not isinstance(refs, list):
+            errors.append(f"{prefix}: {field_label} 必须是数组")
+            return
+        invalid = set(refs) - valid_set
+        if invalid:
+            errors.append(f"{prefix}: {field_label} 引用了不存在于 project.json 的{kind_label}: {invalid}")
 
     def validate_project(self, project_name: str) -> ValidationResult:
         """验证 project.json"""
@@ -253,7 +263,7 @@ class DataValidator:
         warnings: list[str] = []
 
         project_path = Path(project_dir) / "project.json"
-        project = self._load_json(project_path)
+        project = load_json_or_none(project_path)
         if project is None:
             return ValidationResult(
                 valid=False,
@@ -350,25 +360,24 @@ class DataValidator:
                 if invalid:
                     errors.append(f"{prefix}: characters_in_segment 引用了不存在于 project.json 的角色: {invalid}")
 
-            scenes_in_segment = segment.get("scenes")
-            if scenes_in_segment is None:
-                warnings.append(f"{prefix}: 缺少 scenes，将使用默认空数组")
-            elif not isinstance(scenes_in_segment, list):
-                errors.append(f"{prefix}: scenes 必须是数组")
-            else:
-                invalid = set(scenes_in_segment) - project_scenes
-                if invalid:
-                    errors.append(f"{prefix}: scenes 引用了不存在于 project.json 的场景: {invalid}")
-
-            props_in_segment = segment.get("props")
-            if props_in_segment is None:
-                warnings.append(f"{prefix}: 缺少 props，将使用默认空数组")
-            elif not isinstance(props_in_segment, list):
-                errors.append(f"{prefix}: props 必须是数组")
-            else:
-                invalid = set(props_in_segment) - project_props
-                if invalid:
-                    errors.append(f"{prefix}: props 引用了不存在于 project.json 的道具: {invalid}")
+            self._validate_segment_refs(
+                prefix,
+                segment.get("scenes"),
+                project_scenes,
+                errors,
+                warnings,
+                field_label="scenes",
+                kind_label="场景",
+            )
+            self._validate_segment_refs(
+                prefix,
+                segment.get("props"),
+                project_props,
+                errors,
+                warnings,
+                field_label="props",
+                kind_label="道具",
+            )
 
             if not segment.get("image_prompt"):
                 errors.append(f"{prefix}: 缺少必填字段 image_prompt")
@@ -536,7 +545,7 @@ class DataValidator:
 
         project_dir = Path(project_dir)
         project_path = project_dir / "project.json"
-        project = self._load_json(project_path)
+        project = load_json_or_none(project_path)
         if project is None:
             return ValidationResult(
                 valid=False,
@@ -555,7 +564,7 @@ class DataValidator:
             )
 
         episode_path = project_dir / resolved_episode_path
-        episode = self._load_json(episode_path)
+        episode = load_json_or_none(episode_path)
         if episode is None:
             return ValidationResult(
                 valid=False,
@@ -577,7 +586,7 @@ class DataValidator:
         warnings = list(project_result.warnings)
 
         project_path = project_dir / "project.json"
-        project = self._load_json(project_path)
+        project = load_json_or_none(project_path)
         if project is None:
             return ValidationResult(valid=False, errors=errors, warnings=warnings)
 
@@ -654,7 +663,7 @@ class DataValidator:
                 if not resolved_path:
                     continue
 
-                episode = self._load_json(project_dir / resolved_path)
+                episode = load_json_or_none(project_dir / resolved_path)
                 if episode is None:
                     errors.append(f"无法加载剧本文件: {project_dir / resolved_path}")
                     continue

--- a/lib/json_io.py
+++ b/lib/json_io.py
@@ -35,8 +35,8 @@ def atomic_write_json(path: Path, data: Any) -> None:
             suffix=".tmp",
             delete=False,
         ) as tmp:
-            json.dump(data, tmp, ensure_ascii=False, indent=2)
             tmp_path = Path(tmp.name)
+            json.dump(data, tmp, ensure_ascii=False, indent=2)
         os.replace(tmp_path, path)
         tmp_path = None
     finally:

--- a/lib/json_io.py
+++ b/lib/json_io.py
@@ -1,0 +1,47 @@
+"""统一的 JSON 读写工具，提供严格加载与原子写入。"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> Any:
+    """严格加载 JSON。异常直接抛出，调用方按业务需要做 try/except。"""
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_json_or_none(path: Path) -> Any | None:
+    """容错加载 JSON：读取或解析失败返回 None。"""
+    try:
+        return load_json(path)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+
+def atomic_write_json(path: Path, data: Any) -> None:
+    """同目录 tempfile + os.replace 原子写入 JSON。"""
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=str(path.parent),
+            prefix=".project.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            json.dump(data, tmp, ensure_ascii=False, indent=2)
+            tmp_path = Path(tmp.name)
+        os.replace(tmp_path, path)
+        tmp_path = None
+    finally:
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -10,7 +10,6 @@ import logging
 import os
 import re
 import secrets
-import tempfile
 import unicodedata
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -20,6 +19,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from lib.json_io import atomic_write_json
 from lib.project_change_hints import emit_project_change_hint
 from lib.style_templates import LEGACY_STYLE_MAP, resolve_template_prompt
 
@@ -395,7 +395,7 @@ class ProjectManager:
         output_path = Path(real)
 
         with self._script_lock(project_name, filename):
-            self._atomic_write_json(output_path, script)
+            atomic_write_json(output_path, script)
 
             # 在同一把锁内同步到 project.json，保证 script 写入与元数据同步是单一事务
             if self.project_exists(project_name) and isinstance(script.get("episode"), int):
@@ -1001,9 +1001,8 @@ class ProjectManager:
             with open(project_file, encoding="utf-8") as f:
                 project = json.load(f)
             if self._migrate_legacy_style(project):
-                # 用 _atomic_write_json 保证一致性，不走 save_project 是为了
-                # 避免触发 _touch_metadata 污染 updated_at。
-                self._atomic_write_json(project_file, project)
+                # 不走 save_project 以避免触发 _touch_metadata 污染 updated_at。
+                atomic_write_json(project_file, project)
                 migrated = True
         if migrated:
             emit_project_change_hint(
@@ -1058,30 +1057,6 @@ class ProjectManager:
             fcntl.flock(fd, fcntl.LOCK_UN)
             fd.close()
 
-    @staticmethod
-    def _atomic_write_json(path: Path, data: dict) -> None:
-        """通过临时文件 + os.replace 原子写入 JSON。"""
-        tmp_path = None
-        try:
-            with tempfile.NamedTemporaryFile(
-                mode="w",
-                encoding="utf-8",
-                dir=str(path.parent),
-                prefix=".project.",
-                suffix=".tmp",
-                delete=False,
-            ) as tmp:
-                json.dump(data, tmp, ensure_ascii=False, indent=2)
-                tmp_path = Path(tmp.name)
-            os.replace(tmp_path, path)
-            tmp_path = None
-        finally:
-            if tmp_path is not None:
-                try:
-                    tmp_path.unlink()
-                except OSError:
-                    pass
-
     def save_project(self, project_name: str, project: dict) -> Path:
         """
         保存项目元数据
@@ -1098,7 +1073,7 @@ class ProjectManager:
         self._touch_metadata(project)
 
         with self._project_lock(project_name):
-            self._atomic_write_json(project_file, project)
+            atomic_write_json(project_file, project)
 
         emit_project_change_hint(
             project_name,
@@ -1127,7 +1102,7 @@ class ProjectManager:
                 project = json.load(f)
             mutate_fn(project)
             self._touch_metadata(project)
-            self._atomic_write_json(project_file, project)
+            atomic_write_json(project_file, project)
 
         emit_project_change_hint(
             project_name,

--- a/lib/project_migrations/runner.py
+++ b/lib/project_migrations/runner.py
@@ -21,6 +21,16 @@ CURRENT_SCHEMA_VERSION = 1
 MIGRATORS: dict[int, Callable[[Path], None]] = {}
 
 
+def _versioned_backup_name(base_name: str, from_version: int, ts: int) -> str:
+    """生成单个版本化备份名，例如 project.json → project.json.bak.v0-1712345678。"""
+    return f"{base_name}.bak.v{from_version}-{ts}"
+
+
+def _backup_glob_pattern(base_name: str) -> str:
+    """生成 cleanup 用 glob，例如 project.json → project.json.bak.v*-*。"""
+    return f"{base_name}.bak.v*-*"
+
+
 @dataclass
 class MigrationSummary:
     migrated: list[str] = field(default_factory=list)
@@ -45,7 +55,7 @@ def _backup_project_json(project_dir: Path, from_version: int) -> None:
     if not pj.exists():
         return
     ts = int(time.time())
-    bak = project_dir / f"project.json.bak.v{from_version}-{ts}"
+    bak = project_dir / _versioned_backup_name("project.json", from_version, ts)
     bak.write_bytes(pj.read_bytes())
 
 
@@ -55,7 +65,7 @@ def _hardlink_backup_clues(project_dir: Path, from_version: int) -> None:
     if not src.is_dir():
         return
     ts = int(time.time())
-    bak = project_dir / f"clues.bak.v{from_version}-{ts}"
+    bak = project_dir / _versioned_backup_name("clues", from_version, ts)
     if bak.exists():
         return
     try:
@@ -129,13 +139,13 @@ def cleanup_stale_backups(projects_root: Path, max_age_days: int = 7) -> None:
     for project_dir in projects_root.iterdir():
         if not project_dir.is_dir():
             continue
-        for bak in project_dir.glob("project.json.bak.v*-*"):
+        for bak in project_dir.glob(_backup_glob_pattern("project.json")):
             try:
                 if bak.stat().st_mtime < cutoff:
                     bak.unlink()
             except OSError:
                 logger.warning("无法删除备份：%s", bak)
-        for bak_dir in project_dir.glob("clues.bak.v*-*"):
+        for bak_dir in project_dir.glob(_backup_glob_pattern("clues")):
             if not bak_dir.is_dir():
                 continue
             try:

--- a/lib/project_migrations/v0_to_v1_clues_to_scenes_props.py
+++ b/lib/project_migrations/v0_to_v1_clues_to_scenes_props.py
@@ -2,21 +2,11 @@
 
 from __future__ import annotations
 
-import json
-import os
 import shutil
 from pathlib import Path
 from typing import Any
 
-
-def _load_json(path: Path) -> Any:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _atomic_write_json(path: Path, data: Any) -> None:
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
-    os.replace(tmp, path)
+from lib.json_io import atomic_write_json, load_json
 
 
 def _split_clues(clues: dict[str, dict]) -> tuple[dict[str, dict], dict[str, dict]]:
@@ -94,7 +84,7 @@ def _migrate_scripts(project_dir: Path, old_clues: dict[str, dict]) -> None:
 
     for sp in scripts_dir.glob("*.json"):
         try:
-            data = _load_json(sp)
+            data = load_json(sp)
         except Exception:
             continue
         if data.get("schema_version", 0) >= 1:
@@ -126,7 +116,7 @@ def _migrate_scripts(project_dir: Path, old_clues: dict[str, dict]) -> None:
                 item["props"] = props_list
 
         data["schema_version"] = 1
-        _atomic_write_json(sp, data)
+        atomic_write_json(sp, data)
 
 
 def _reconstruct_old_clues_from_v1(data: dict) -> dict[str, dict]:
@@ -152,7 +142,7 @@ def migrate_v0_to_v1(project_dir: Path) -> None:
     pj = project_dir / "project.json"
     if not pj.exists():
         return
-    data = _load_json(pj)
+    data = load_json(pj)
     current_version = data.get("schema_version", 0)
 
     # 自愈：schema_version>=1 但 clues/ 仍存在 → 补跑文件/剧本迁移
@@ -184,4 +174,4 @@ def migrate_v0_to_v1(project_dir: Path) -> None:
         data.setdefault("props", {})
     data.pop("clues", None)
     data["schema_version"] = 1
-    _atomic_write_json(pj, data)
+    atomic_write_json(pj, data)

--- a/server/services/project_archive.py
+++ b/server/services/project_archive.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from lib.data_validator import DataValidator, ValidationResult
+from lib.json_io import load_json
 from lib.project_change_hints import emit_project_change_hint
 from lib.project_manager import ProjectManager
 
@@ -1082,17 +1083,13 @@ class ProjectArchiveService:
         real = os.path.realpath(path)
         base = os.path.realpath(self.project_manager.projects_root) + os.sep
         tmp = os.path.realpath(tempfile.gettempdir()) + os.sep
+        if not (real.startswith(base) or real.startswith(tmp)):
+            logger.warning("路径越界，拒绝读取: %s", real)
+            return None
         try:
-            if real.startswith(base):
-                with open(real, encoding="utf-8") as handle:  # noqa: PTH123
-                    return json.load(handle)
-            if real.startswith(tmp):
-                with open(real, encoding="utf-8") as handle:  # noqa: PTH123
-                    return json.load(handle)
+            return load_json(Path(real))
         except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             return None
-        logger.warning("路径越界，拒绝读取: %s", real)
-        return None
 
     def _write_json_file(self, path: Path, payload: dict[str, Any]) -> None:
         real = os.path.realpath(path)


### PR DESCRIPTION
## Summary
- 消除 PR #307 合并后 `/simplify` 审查识别出的"逐字复制粘贴"技术债（issue #326 的 P1 + P2 低风险子集）
- 后端抽 `lib/json_io.py` 统一 JSON 读写，scenes/props 校验镜像合并，migration 备份路径抽 helper
- 前端新增 `useEscapeClose` hook（7 处去重）与 `<AssetThumb>` 缩略图子组件

## 改动范围

**新增**
- `lib/json_io.py`：`load_json` / `load_json_or_none` / `atomic_write_json`
- `frontend/src/hooks/useEscapeClose.ts`
- `frontend/src/components/assets/AssetThumb.tsx`

**后端重构**
- `ProjectManager` / `DataValidator` / `project_archive` / `v0_to_v1` migration 全部接入 `lib.json_io`（含删除 `ProjectManager._atomic_write_json` / `DataValidator._load_json` 两个 thin wrapper）
- `data_validator.py`：`_validate_project_catalog` + `_validate_segment_refs` 合并 scenes/props 镜像
- `project_migrations/runner.py`：`_versioned_backup_name` / `_backup_glob_pattern` helper

**前端重构**
- 7 处 Escape 监听迁移到 `useEscapeClose`
- `AssetCard` + `AssetPickerModal` 缩略图改用 `<AssetThumb>`

## 明确不在本 PR 范围
- issue #326 的 **P0**（前端 Scene/Prop 组件合并、ProjectManager scene/prop 方法重构、characters 接入 router factory）—— 风险面大，分支名约束
- 后端 P2-1（`scenes.py` / `props.py` lambda → getattr）：现状已是 method reference，issue 描述过时
- 后端 P2-2（动态 Pydantic schema）：收益低
- 前端 P2-1（`AssetGrid` 内联）：语义清晰且利于未来扩展

## Test plan
- [x] \`uv run ruff check lib/ server/\` 通过
- [x] \`uv run ruff format --check lib/ server/\` 通过
- [x] \`uv run pytest tests/\` — 1612 passed
- [x] \`pnpm typecheck\` 通过
- [x] \`pnpm lint\` 通过
- [x] \`pnpm vitest run\` — 239 passed
- [ ] 手动 UI 验证：7 处 Escape 监听逐一测试（含 TaskHud 的 \`cancelConfirm\` 条件启用、ApiKeysTab 的 Enter 仍生效）
- [ ] 手动 UI 验证：AssetCard / AssetPickerModal 缩略图四态（normal / hover / selected / disabled）视觉对比

Refs #326