### PR TITLE
feat(script-models): 参考生视频数据模型 + shot parser (PR2/7)

### DIFF
--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from lib.asset_types import ASSET_TYPES
 from lib.json_io import load_json_or_none
 
 
@@ -520,7 +521,7 @@ class DataValidator:
                     continue
                 rtype = ref.get("type")
                 rname = ref.get("name")
-                if rtype not in {"character", "scene", "prop"}:
+                if rtype not in ASSET_TYPES:
                     errors.append(f"{prefix}: reference.type 无效: {rtype!r}")
                     continue
                 bucket = bucket_by_type.get(rtype, set())

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -508,6 +508,17 @@ class DataValidator:
             shots = unit.get("shots")
             if not isinstance(shots, list) or not shots:
                 errors.append(f"{prefix}: shots 必须是非空数组")
+            else:
+                for si, shot in enumerate(shots):
+                    sp = f"{prefix}.shots[{si}]"
+                    if not isinstance(shot, dict):
+                        errors.append(f"{sp}: 必须是对象")
+                        continue
+                    duration = shot.get("duration")
+                    if not isinstance(duration, int) or duration < 1 or duration > 15:
+                        errors.append(f"{sp}: duration 必须是 1-15 之间的整数")
+                    if not isinstance(shot.get("text"), str):
+                        errors.append(f"{sp}: text 必须是字符串")
 
             refs = unit.get("references")
             if refs is None:
@@ -523,6 +534,9 @@ class DataValidator:
                 rname = ref.get("name")
                 if rtype not in ASSET_TYPES:
                     errors.append(f"{prefix}: reference.type 无效: {rtype!r}")
+                    continue
+                if not isinstance(rname, str) or not rname:
+                    errors.append(f"{prefix}: reference.name 必须是非空字符串: {rname!r}")
                     continue
                 bucket = bucket_by_type.get(rtype, set())
                 if rname not in bucket:

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -508,22 +508,24 @@ class DataValidator:
             if not isinstance(shots, list) or not shots:
                 errors.append(f"{prefix}: shots 必须是非空数组")
 
-            refs = unit.get("references") or []
-            if not isinstance(refs, list):
+            refs = unit.get("references")
+            if refs is None:
+                refs = []
+            elif not isinstance(refs, list):
                 errors.append(f"{prefix}: references 必须是数组")
-            else:
-                for ref in refs:
-                    if not isinstance(ref, dict):
-                        errors.append(f"{prefix}: reference 条目必须是对象")
-                        continue
-                    rtype = ref.get("type")
-                    rname = ref.get("name")
-                    if rtype not in {"character", "scene", "prop"}:
-                        errors.append(f"{prefix}: reference.type 无效: {rtype!r}")
-                        continue
-                    bucket = bucket_by_type.get(rtype, set())
-                    if rname not in bucket:
-                        errors.append(f"{prefix}: 引用的{rtype} '{rname}' 不在 project.json 对应 bucket 中")
+                refs = []
+            for ref in refs:
+                if not isinstance(ref, dict):
+                    errors.append(f"{prefix}: reference 条目必须是对象")
+                    continue
+                rtype = ref.get("type")
+                rname = ref.get("name")
+                if rtype not in {"character", "scene", "prop"}:
+                    errors.append(f"{prefix}: reference.type 无效: {rtype!r}")
+                    continue
+                bucket = bucket_by_type.get(rtype, set())
+                if rname not in bucket:
+                    errors.append(f"{prefix}: 引用的{rtype} '{rname}' 不在 project.json 对应 bucket 中")
 
             if project_dir is not None:
                 self._validate_generated_assets(

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -39,7 +39,7 @@ class ValidationResult:
 class DataValidator:
     """数据验证器"""
 
-    VALID_CONTENT_MODES = {"narration", "drama"}
+    VALID_CONTENT_MODES = {"narration", "drama", "reference_video"}
     VALID_DURATIONS = {4, 6, 8}
     VALID_SCENE_TYPES = {"剧情", "空镜"}
     ID_PATTERN = re.compile(r"^E\d+S\d+(?:_\d+)?$")
@@ -56,6 +56,7 @@ class DataValidator:
         "characters",
         "scenes",
         "props",
+        "reference_videos",
         "storyboards",
         "videos",
         "thumbnails",
@@ -472,6 +473,66 @@ class DataValidator:
                     errors,
                 )
 
+    def _validate_reference_video_script(
+        self,
+        video_units: list[dict[str, Any]] | Any,
+        project_characters: set[str],
+        project_scenes: set[str],
+        project_props: set[str],
+        errors: list[str],
+        warnings: list[str],
+        *,
+        project_dir: Path | None = None,
+    ) -> None:
+        """验证 video_units（reference_video 模式）"""
+        if not isinstance(video_units, list) or not video_units:
+            errors.append("reference_video 脚本缺少 video_units 数组或为空")
+            return
+
+        bucket_by_type = {
+            "character": project_characters,
+            "scene": project_scenes,
+            "prop": project_props,
+        }
+
+        for index, unit in enumerate(video_units):
+            prefix = f"video_units[{index}]"
+            if not isinstance(unit, dict):
+                errors.append(f"{prefix}: 必须是对象")
+                continue
+
+            if not unit.get("unit_id"):
+                errors.append(f"{prefix}: 缺少 unit_id")
+
+            shots = unit.get("shots")
+            if not isinstance(shots, list) or not shots:
+                errors.append(f"{prefix}: shots 必须是非空数组")
+
+            refs = unit.get("references") or []
+            if not isinstance(refs, list):
+                errors.append(f"{prefix}: references 必须是数组")
+            else:
+                for ref in refs:
+                    if not isinstance(ref, dict):
+                        errors.append(f"{prefix}: reference 条目必须是对象")
+                        continue
+                    rtype = ref.get("type")
+                    rname = ref.get("name")
+                    if rtype not in {"character", "scene", "prop"}:
+                        errors.append(f"{prefix}: reference.type 无效: {rtype!r}")
+                        continue
+                    bucket = bucket_by_type.get(rtype, set())
+                    if rname not in bucket:
+                        errors.append(f"{prefix}: 引用的{rtype} '{rname}' 不在 project.json 对应 bucket 中")
+
+            if project_dir is not None:
+                self._validate_generated_assets(
+                    project_dir,
+                    prefix,
+                    unit.get("generated_assets"),
+                    errors,
+                )
+
     def _validate_episode_payload(
         self,
         project_dir: Path,
@@ -512,6 +573,16 @@ class DataValidator:
         if content_mode == "narration":
             self._validate_segments(
                 episode.get("segments", []),
+                project_characters,
+                project_scenes,
+                project_props,
+                errors,
+                warnings,
+                project_dir=project_dir,
+            )
+        elif content_mode == "reference_video":
+            self._validate_reference_video_script(
+                episode.get("video_units", []),
                 project_characters,
                 project_scenes,
                 project_props,

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -43,6 +43,7 @@ class DataValidator:
     VALID_CONTENT_MODES = {"narration", "drama", "reference_video"}
     VALID_DURATIONS = {4, 6, 8}
     VALID_SCENE_TYPES = {"剧情", "空镜"}
+    VALID_SHOT_DURATION_RANGE = (1, 15)
     ID_PATTERN = re.compile(r"^E\d+S\d+(?:_\d+)?$")
     EXTERNAL_URI_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://")
     ALLOWED_ROOT_ENTRIES = {
@@ -515,8 +516,9 @@ class DataValidator:
                         errors.append(f"{sp}: 必须是对象")
                         continue
                     duration = shot.get("duration")
-                    if not isinstance(duration, int) or duration < 1 or duration > 15:
-                        errors.append(f"{sp}: duration 必须是 1-15 之间的整数")
+                    low, high = self.VALID_SHOT_DURATION_RANGE
+                    if not isinstance(duration, int) or duration < low or duration > high:
+                        errors.append(f"{sp}: duration 必须是 {low}-{high} 之间的整数")
                     if not isinstance(shot.get("text"), str):
                         errors.append(f"{sp}: text 必须是字符串")
 

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -28,6 +28,24 @@ logger = logging.getLogger(__name__)
 PROJECT_NAME_PATTERN = re.compile(r"^[A-Za-z0-9-]+$")
 PROJECT_SLUG_SANITIZER = re.compile(r"[^a-zA-Z0-9]+")
 
+_VALID_GENERATION_MODES = {"storyboard", "grid", "reference_video"}
+_DEFAULT_GENERATION_MODE = "storyboard"
+
+
+def effective_mode(*, project: dict, episode: dict) -> str:
+    """按 episode → project → 默认 storyboard 回退解析 generation_mode。
+
+    Spec §4.6。未知值一律回退到默认，兼容旧项目/脏数据。
+    """
+    ep_mode = episode.get("generation_mode")
+    if ep_mode in _VALID_GENERATION_MODES:
+        return ep_mode
+    proj_mode = project.get("generation_mode")
+    if proj_mode in _VALID_GENERATION_MODES:
+        return proj_mode
+    return _DEFAULT_GENERATION_MODE
+
+
 # ==================== 数据模型 ====================
 
 

--- a/lib/reference_video/__init__.py
+++ b/lib/reference_video/__init__.py
@@ -2,6 +2,12 @@ from lib.reference_video.shot_parser import (
     compute_duration_from_shots,
     parse_prompt,
     render_prompt_for_backend,
+    resolve_references,
 )
 
-__all__ = ["compute_duration_from_shots", "parse_prompt", "render_prompt_for_backend"]
+__all__ = [
+    "compute_duration_from_shots",
+    "parse_prompt",
+    "render_prompt_for_backend",
+    "resolve_references",
+]

--- a/lib/reference_video/__init__.py
+++ b/lib/reference_video/__init__.py
@@ -1,0 +1,3 @@
+from lib.reference_video.shot_parser import parse_prompt, render_prompt_for_backend
+
+__all__ = ["parse_prompt", "render_prompt_for_backend"]

--- a/lib/reference_video/__init__.py
+++ b/lib/reference_video/__init__.py
@@ -1,3 +1,7 @@
-from lib.reference_video.shot_parser import parse_prompt, render_prompt_for_backend
+from lib.reference_video.shot_parser import (
+    compute_duration_from_shots,
+    parse_prompt,
+    render_prompt_for_backend,
+)
 
-__all__ = ["parse_prompt", "render_prompt_for_backend"]
+__all__ = ["compute_duration_from_shots", "parse_prompt", "render_prompt_for_backend"]

--- a/lib/reference_video/shot_parser.py
+++ b/lib/reference_video/shot_parser.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 
+from lib.asset_types import BUCKET_KEY
 from lib.script_models import ReferenceResource, Shot
 
 _SHOT_HEADER_RE = re.compile(
@@ -80,3 +81,31 @@ def render_prompt_for_backend(text: str, references: list[ReferenceResource]) ->
 def compute_duration_from_shots(shots: list[Shot]) -> int:
     """把 shots 时长求和，返回整数秒。"""
     return sum(s.duration for s in shots)
+
+
+def resolve_references(
+    names: list[str],
+    project: dict,
+) -> tuple[list[ReferenceResource], list[str]]:
+    """按 project.json 三 bucket 把 mention 名字分派成 ReferenceResource。
+
+    Returns:
+        (refs, missing): refs 保持入参顺序；missing 是没在任何 bucket 找到的名字
+    """
+    buckets: dict[str, dict] = {
+        "character": project.get(BUCKET_KEY["character"]) or {},
+        "scene": project.get(BUCKET_KEY["scene"]) or {},
+        "prop": project.get(BUCKET_KEY["prop"]) or {},
+    }
+    refs: list[ReferenceResource] = []
+    missing: list[str] = []
+    for name in names:
+        resolved = False
+        for rtype, bucket in buckets.items():
+            if name in bucket:
+                refs.append(ReferenceResource(type=rtype, name=name))
+                resolved = True
+                break
+        if not resolved:
+            missing.append(name)
+    return refs, missing

--- a/lib/reference_video/shot_parser.py
+++ b/lib/reference_video/shot_parser.py
@@ -60,12 +60,14 @@ def parse_prompt(text: str) -> tuple[list[Shot], list[str], bool]:
 
 
 def _extract_mentions(text: str) -> list[str]:
-    seen: list[str] = []
+    seen: set[str] = set()
+    result: list[str] = []
     for m in _MENTION_RE.finditer(text):
         name = m.group(1)
         if name not in seen:
-            seen.append(name)
-    return seen
+            seen.add(name)
+            result.append(name)
+    return result
 
 
 def render_prompt_for_backend(text: str, references: list[ReferenceResource]) -> str:

--- a/lib/reference_video/shot_parser.py
+++ b/lib/reference_video/shot_parser.py
@@ -1,0 +1,77 @@
+"""参考视频 prompt 解析器：prompt ↔ Shot[]/references 双向转换。
+
+Spec: docs/superpowers/specs/2026-04-15-reference-to-video-mode-design.md §4.3
+"""
+
+from __future__ import annotations
+
+import re
+
+from lib.script_models import ReferenceResource, Shot
+
+_SHOT_HEADER_RE = re.compile(
+    r"""^Shot\s+\d+\s*\(\s*(\d+)\s*s\s*\)\s*:\s*(.*)$""",
+    re.IGNORECASE,
+)
+
+# @名称：Unicode 字母/数字/下划线；不吞 @ 之前的字符
+_MENTION_RE = re.compile(r"@([\w\u4e00-\u9fff]+)")
+
+
+def parse_prompt(text: str) -> tuple[list[Shot], list[str], bool]:
+    """把用户书写的 prompt 文本拆为 (shots, mention_names, duration_override)。
+
+    返回的第二项是 prompt 中出现的名字列表（保持首次出现的顺序、去重），
+    由 caller 结合 project.json 分派成 ReferenceResource（本函数不区分 type）。
+
+    - 有 `Shot N (Xs):` header → 按 header 切分；override=False
+    - 无 header → 整段视为单镜头、duration 由 caller 指定；override=True
+    """
+    lines = text.splitlines()
+    segments: list[tuple[int, str]] = []
+    current_duration: int | None = None
+    current_buf: list[str] = []
+
+    for line in lines:
+        m = _SHOT_HEADER_RE.match(line.strip())
+        if m:
+            if current_duration is not None:
+                segments.append((current_duration, "\n".join(current_buf).strip()))
+            current_duration = int(m.group(1))
+            current_buf = [m.group(2)]
+        else:
+            current_buf.append(line)
+
+    if current_duration is not None:
+        segments.append((current_duration, "\n".join(current_buf).strip()))
+
+    if not segments:
+        # 无 header → 单镜头
+        return [Shot(duration=1, text=text.strip())], _extract_mentions(text), True
+
+    shots = [Shot(duration=d, text=t) for d, t in segments]
+    mentions = _extract_mentions(text)
+    return shots, mentions, False
+
+
+def _extract_mentions(text: str) -> list[str]:
+    seen: list[str] = []
+    for m in _MENTION_RE.finditer(text):
+        name = m.group(1)
+        if name not in seen:
+            seen.append(name)
+    return seen
+
+
+def render_prompt_for_backend(text: str, references: list[ReferenceResource]) -> str:
+    """把 prompt 中的 @名称 替换为 [图N]，其中 N 是 references 列表中 1-based 序号。"""
+    index_by_name: dict[str, int] = {}
+    for i, ref in enumerate(references, start=1):
+        index_by_name[ref.name] = i
+
+    def _repl(m: re.Match[str]) -> str:
+        name = m.group(1)
+        idx = index_by_name.get(name)
+        return f"[图{idx}]" if idx else m.group(0)  # 未注册 → 保留原样
+
+    return _MENTION_RE.sub(_repl, text)

--- a/lib/reference_video/shot_parser.py
+++ b/lib/reference_video/shot_parser.py
@@ -75,3 +75,8 @@ def render_prompt_for_backend(text: str, references: list[ReferenceResource]) ->
         return f"[图{idx}]" if idx else m.group(0)  # 未注册 → 保留原样
 
     return _MENTION_RE.sub(_repl, text)
+
+
+def compute_duration_from_shots(shots: list[Shot]) -> int:
+    """把 shots 时长求和，返回整数秒。"""
+    return sum(s.duration for s in shots)

--- a/lib/reference_video/shot_parser.py
+++ b/lib/reference_video/shot_parser.py
@@ -42,8 +42,12 @@ def parse_prompt(text: str) -> tuple[list[Shot], list[str], bool]:
         if m:
             if current_duration is not None:
                 segments.append((current_duration, "\n".join(current_buf).strip()))
+                current_buf = [m.group(2)]
+            else:
+                # 首个 header 之前的非空文本保留，前置到首镜头 text
+                pre_header = "\n".join(current_buf).strip()
+                current_buf = [pre_header, m.group(2)] if pre_header else [m.group(2)]
             current_duration = int(m.group(1))
-            current_buf = [m.group(2)]
         else:
             current_buf.append(line)
 

--- a/lib/reference_video/shot_parser.py
+++ b/lib/reference_video/shot_parser.py
@@ -27,6 +27,10 @@ def parse_prompt(text: str) -> tuple[list[Shot], list[str], bool]:
 
     - 有 `Shot N (Xs):` header → 按 header 切分；override=False
     - 无 header → 整段视为单镜头、duration 由 caller 指定；override=True
+
+    Raises:
+        pydantic.ValidationError: 当 header 中的 duration 超出 Shot.duration 的 [1, 15]
+            范围时由 Shot 构造抛出；调用方（PR3 executor）须捕获并映射为用户友好错误。
     """
     lines = text.splitlines()
     segments: list[tuple[int, str]] = []
@@ -88,6 +92,8 @@ def resolve_references(
     project: dict,
 ) -> tuple[list[ReferenceResource], list[str]]:
     """按 project.json 三 bucket 把 mention 名字分派成 ReferenceResource。
+
+    当同一名称同时存在于多个 bucket 时，优先级为 character → scene → prop。
 
     Returns:
         (refs, missing): refs 保持入参顺序；missing 是没在任何 bucket 找到的名字

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -35,6 +35,12 @@ CameraMotion = Literal[
     "Tracking Shot",
 ]
 
+TransitionType = Literal[
+    "cut",
+    "fade",
+    "dissolve",
+]
+
 
 class Dialogue(BaseModel):
     """对话条目"""
@@ -95,7 +101,7 @@ class NarrationSegment(BaseModel):
     props: list[str] = Field(default_factory=list, description="出场道具名称列表")
     image_prompt: ImagePrompt = Field(description="分镜图生成提示词")
     video_prompt: VideoPrompt = Field(description="视频生成提示词")
-    transition_to_next: Literal["cut", "fade", "dissolve"] = Field(default="cut", description="转场类型")
+    transition_to_next: TransitionType = Field(default="cut", description="转场类型")
     note: str | None = Field(default=None, description="用户备注（不参与生成）")
     generated_assets: GeneratedAssets = Field(default_factory=GeneratedAssets, description="生成资源状态")
 
@@ -134,7 +140,7 @@ class DramaScene(BaseModel):
     props: list[str] = Field(default_factory=list, description="出场道具名称列表")
     image_prompt: ImagePrompt = Field(description="分镜图生成提示词")
     video_prompt: VideoPrompt = Field(description="视频生成提示词")
-    transition_to_next: Literal["cut", "fade", "dissolve"] = Field(default="cut", description="转场类型")
+    transition_to_next: TransitionType = Field(default="cut", description="转场类型")
     note: str | None = Field(default=None, description="用户备注（不参与生成）")
     generated_assets: GeneratedAssets = Field(default_factory=GeneratedAssets, description="生成资源状态")
 
@@ -179,7 +185,7 @@ class ReferenceVideoUnit(BaseModel):
     )
     duration_seconds: int = Field(description="派生字段：所有 shot 时长之和")
     duration_override: bool = Field(default=False, description="true 时停止自动派生")
-    transition_to_next: Literal["cut", "fade", "dissolve"] = Field(default="cut", description="转场类型")
+    transition_to_next: TransitionType = Field(default="cut", description="转场类型")
     note: str | None = Field(default=None, description="用户备注")
     generated_assets: GeneratedAssets = Field(default_factory=GeneratedAssets, description="生成资源状态")
 

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -8,7 +8,7 @@ script_models.py - 剧本数据模型
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # ============ 枚举类型定义 ============
 
@@ -188,6 +188,17 @@ class ReferenceVideoUnit(BaseModel):
     transition_to_next: TransitionType = Field(default="cut", description="转场类型")
     note: str | None = Field(default=None, description="用户备注")
     generated_assets: GeneratedAssets = Field(default_factory=GeneratedAssets, description="生成资源状态")
+
+    @model_validator(mode="after")
+    def _check_duration_consistency(self) -> "ReferenceVideoUnit":
+        if not self.duration_override:
+            expected = sum(s.duration for s in self.shots)
+            if self.duration_seconds != expected:
+                raise ValueError(
+                    f"duration_seconds ({self.duration_seconds}) 与 shots 总时长 ({expected}) 不符；"
+                    "如需手动指定请置 duration_override=True"
+                )
+        return self
 
 
 class ReferenceVideoScript(BaseModel):

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -149,3 +149,20 @@ class DramaEpisodeScript(BaseModel):
     summary: str = Field(description="剧集摘要")
     novel: NovelInfo = Field(description="小说来源信息")
     scenes: list[DramaScene] = Field(description="场景列表")
+
+
+# ============ 参考生视频模式（Reference Video） ============
+
+
+class Shot(BaseModel):
+    """参考视频单元内的一个镜头。"""
+
+    duration: int = Field(ge=1, le=15, description="该镜头时长（秒）")
+    text: str = Field(description="镜头描述，可包含 @角色/@场景/@道具 引用")
+
+
+class ReferenceResource(BaseModel):
+    """参考图引用——只存名称 + 类型，具体路径从 project.json 对应 bucket 读时解析。"""
+
+    type: Literal["character", "scene", "prop"] = Field(description="引用的资源类型")
+    name: str = Field(description="角色/场景/道具名称，必须在 project.json 对应 bucket 中已注册")

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -166,3 +166,31 @@ class ReferenceResource(BaseModel):
 
     type: Literal["character", "scene", "prop"] = Field(description="引用的资源类型")
     name: str = Field(description="角色/场景/道具名称，必须在 project.json 对应 bucket 中已注册")
+
+
+class ReferenceVideoUnit(BaseModel):
+    """参考视频单元——一个视频文件的最小生成粒度。"""
+
+    unit_id: str = Field(description="格式 E{集}U{序号}")
+    shots: list[Shot] = Field(min_length=1, description="1-4 个 shot")
+    references: list[ReferenceResource] = Field(
+        default_factory=list,
+        description="按顺序决定 [图N] 编号",
+    )
+    duration_seconds: int = Field(description="派生字段：所有 shot 时长之和")
+    duration_override: bool = Field(default=False, description="true 时停止自动派生")
+    transition_to_next: Literal["cut", "fade", "dissolve"] = Field(default="cut")
+    note: str | None = Field(default=None, description="用户备注")
+    generated_assets: GeneratedAssets = Field(default_factory=GeneratedAssets)
+
+
+class ReferenceVideoScript(BaseModel):
+    """参考生视频模式剧集脚本。"""
+
+    episode: int = Field(description="剧集编号")
+    title: str = Field(description="剧集标题")
+    content_mode: Literal["reference_video"] = Field(default="reference_video")
+    duration_seconds: int = Field(default=0, description="总时长（秒）")
+    summary: str = Field(description="剧集摘要")
+    novel: NovelInfo = Field(description="小说来源信息")
+    video_units: list[ReferenceVideoUnit] = Field(description="视频单元列表")

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -172,16 +172,16 @@ class ReferenceVideoUnit(BaseModel):
     """参考视频单元——一个视频文件的最小生成粒度。"""
 
     unit_id: str = Field(description="格式 E{集}U{序号}")
-    shots: list[Shot] = Field(min_length=1, description="1-4 个 shot")
+    shots: list[Shot] = Field(min_length=1, max_length=4, description="1-4 个 shot")
     references: list[ReferenceResource] = Field(
         default_factory=list,
         description="按顺序决定 [图N] 编号",
     )
     duration_seconds: int = Field(description="派生字段：所有 shot 时长之和")
     duration_override: bool = Field(default=False, description="true 时停止自动派生")
-    transition_to_next: Literal["cut", "fade", "dissolve"] = Field(default="cut")
+    transition_to_next: Literal["cut", "fade", "dissolve"] = Field(default="cut", description="转场类型")
     note: str | None = Field(default=None, description="用户备注")
-    generated_assets: GeneratedAssets = Field(default_factory=GeneratedAssets)
+    generated_assets: GeneratedAssets = Field(default_factory=GeneratedAssets, description="生成资源状态")
 
 
 class ReferenceVideoScript(BaseModel):
@@ -189,7 +189,7 @@ class ReferenceVideoScript(BaseModel):
 
     episode: int = Field(description="剧集编号")
     title: str = Field(description="剧集标题")
-    content_mode: Literal["reference_video"] = Field(default="reference_video")
+    content_mode: Literal["reference_video"] = Field(default="reference_video", description="内容模式")
     duration_seconds: int = Field(default=0, description="总时长（秒）")
     summary: str = Field(description="剧集摘要")
     novel: NovelInfo = Field(description="小说来源信息")

--- a/tests/lib/test_data_validator_reference.py
+++ b/tests/lib/test_data_validator_reference.py
@@ -103,3 +103,45 @@ def test_validator_allows_reference_videos_dir(tmp_path: Path):
     v = DataValidator()
     result = v.validate_project_tree(tmp_path)
     assert result.valid, result.errors
+
+
+def test_validator_rejects_non_string_reference_name(tmp_path: Path):
+    project = {
+        "title": "T",
+        "content_mode": "reference_video",
+        "style": "s",
+        "episodes": [{"episode": 1, "title": "E1", "script_file": "scripts/episode_1.json"}],
+        "characters": {},
+        "scenes": {},
+        "props": {},
+    }
+    script = _valid_reference_script()
+    script["video_units"][0]["references"] = [{"type": "character", "name": {"bad": "dict"}}]
+    _write(tmp_path, "project.json", project)
+    _write(tmp_path, "scripts/episode_1.json", script)
+
+    v = DataValidator()
+    result = v.validate_project_tree(tmp_path)
+    assert not result.valid
+    assert any("reference.name 必须是非空字符串" in e for e in result.errors)
+
+
+def test_validator_rejects_invalid_shot_duration(tmp_path: Path):
+    project = {
+        "title": "T",
+        "content_mode": "reference_video",
+        "style": "s",
+        "episodes": [{"episode": 1, "title": "E1", "script_file": "scripts/episode_1.json"}],
+        "characters": {"张三": {"description": "x"}},
+        "scenes": {"酒馆": {"description": "x"}},
+        "props": {},
+    }
+    script = _valid_reference_script()
+    script["video_units"][0]["shots"][0]["duration"] = 99  # 超出 [1,15]
+    _write(tmp_path, "project.json", project)
+    _write(tmp_path, "scripts/episode_1.json", script)
+
+    v = DataValidator()
+    result = v.validate_project_tree(tmp_path)
+    assert not result.valid
+    assert any("duration 必须是 1-15" in e for e in result.errors)

--- a/tests/lib/test_data_validator_reference.py
+++ b/tests/lib/test_data_validator_reference.py
@@ -83,6 +83,7 @@ def test_validator_rejects_unknown_mention(tmp_path: Path):
     result = v.validate_project_tree(tmp_path)
     assert not result.valid
     assert any("张三" in e for e in result.errors)
+    assert any("酒馆" in e for e in result.errors)
 
 
 def test_validator_allows_reference_videos_dir(tmp_path: Path):

--- a/tests/lib/test_data_validator_reference.py
+++ b/tests/lib/test_data_validator_reference.py
@@ -1,0 +1,104 @@
+import json
+from pathlib import Path
+
+from lib.data_validator import DataValidator
+
+
+def _write(dir: Path, path: str, data: dict) -> Path:
+    full = dir / path
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+    return full
+
+
+def _valid_reference_script(episode: int = 1) -> dict:
+    return {
+        "episode": episode,
+        "title": "E1",
+        "content_mode": "reference_video",
+        "summary": "x",
+        "novel": {"title": "t", "chapter": "c"},
+        "duration_seconds": 8,
+        "video_units": [
+            {
+                "unit_id": f"E{episode}U1",
+                "shots": [
+                    {"duration": 3, "text": "Shot 1 (3s): @张三 推门"},
+                    {"duration": 5, "text": "Shot 2 (5s): @酒馆 全景"},
+                ],
+                "references": [
+                    {"type": "character", "name": "张三"},
+                    {"type": "scene", "name": "酒馆"},
+                ],
+                "duration_seconds": 8,
+                "duration_override": False,
+                "transition_to_next": "cut",
+                "note": None,
+                "generated_assets": {
+                    "storyboard_image": None,
+                    "storyboard_last_image": None,
+                    "grid_id": None,
+                    "grid_cell_index": None,
+                    "video_clip": None,
+                    "video_uri": None,
+                    "status": "pending",
+                },
+            },
+        ],
+    }
+
+
+def test_validator_accepts_reference_video_content_mode(tmp_path: Path):
+    project = {
+        "title": "T",
+        "content_mode": "reference_video",
+        "style": "s",
+        "episodes": [{"episode": 1, "title": "E1", "script_file": "scripts/episode_1.json"}],
+        "characters": {"张三": {"description": "x"}},
+        "scenes": {"酒馆": {"description": "x"}},
+        "props": {},
+    }
+    _write(tmp_path, "project.json", project)
+    _write(tmp_path, "scripts/episode_1.json", _valid_reference_script())
+
+    v = DataValidator()
+    result = v.validate_project_tree(tmp_path)
+    assert result.valid, result.errors
+
+
+def test_validator_rejects_unknown_mention(tmp_path: Path):
+    project = {
+        "title": "T",
+        "content_mode": "reference_video",
+        "style": "s",
+        "episodes": [{"episode": 1, "title": "E1", "script_file": "scripts/episode_1.json"}],
+        "characters": {},
+        "scenes": {},
+        "props": {},
+    }
+    _write(tmp_path, "project.json", project)
+    _write(tmp_path, "scripts/episode_1.json", _valid_reference_script())
+
+    v = DataValidator()
+    result = v.validate_project_tree(tmp_path)
+    assert not result.valid
+    assert any("张三" in e for e in result.errors)
+
+
+def test_validator_allows_reference_videos_dir(tmp_path: Path):
+    project = {
+        "title": "T",
+        "content_mode": "reference_video",
+        "style": "s",
+        "episodes": [],
+        "characters": {},
+        "scenes": {},
+        "props": {},
+    }
+    _write(tmp_path, "project.json", project)
+    (tmp_path / "reference_videos").mkdir()
+    (tmp_path / "reference_videos" / "E1U1.mp4").write_bytes(b"\x00")
+
+    v = DataValidator()
+    result = v.validate_project_tree(tmp_path)
+    assert result.valid, result.errors

--- a/tests/lib/test_project_manager_effective_mode.py
+++ b/tests/lib/test_project_manager_effective_mode.py
@@ -1,0 +1,44 @@
+from lib.project_manager import effective_mode
+
+
+def test_effective_mode_defaults_to_storyboard():
+    assert effective_mode(project={}, episode={}) == "storyboard"
+
+
+def test_effective_mode_reads_project_level():
+    assert effective_mode(project={"generation_mode": "grid"}, episode={}) == "grid"
+
+
+def test_effective_mode_episode_overrides_project():
+    assert (
+        effective_mode(
+            project={"generation_mode": "grid"},
+            episode={"generation_mode": "reference_video"},
+        )
+        == "reference_video"
+    )
+
+
+def test_effective_mode_episode_none_falls_back():
+    assert (
+        effective_mode(
+            project={"generation_mode": "grid"},
+            episode={"generation_mode": None},
+        )
+        == "grid"
+    )
+
+
+def test_effective_mode_empty_episode_string_falls_back():
+    assert (
+        effective_mode(
+            project={"generation_mode": "grid"},
+            episode={"generation_mode": ""},
+        )
+        == "grid"
+    )
+
+
+def test_effective_mode_rejects_unknown_value_fallback():
+    # 未知值应回退到 storyboard，不抛异常（兼容旧项目的脏数据）
+    assert effective_mode(project={"generation_mode": "invalid"}, episode={}) == "storyboard"

--- a/tests/lib/test_script_models_reference.py
+++ b/tests/lib/test_script_models_reference.py
@@ -1,0 +1,28 @@
+import pytest
+from pydantic import ValidationError
+
+from lib.script_models import ReferenceResource, Shot
+
+
+def test_shot_valid():
+    s = Shot(duration=5, text="中远景，主角推门进酒馆")
+    assert s.duration == 5
+    assert "酒馆" in s.text
+
+
+def test_shot_duration_range():
+    with pytest.raises(ValidationError):
+        Shot(duration=0, text="x")
+    with pytest.raises(ValidationError):
+        Shot(duration=16, text="x")
+
+
+def test_reference_resource_valid_types():
+    for t in ("character", "scene", "prop"):
+        r = ReferenceResource(type=t, name="张三")
+        assert r.type == t
+
+
+def test_reference_resource_rejects_clue():
+    with pytest.raises(ValidationError):
+        ReferenceResource(type="clue", name="张三")

--- a/tests/lib/test_script_models_reference.py
+++ b/tests/lib/test_script_models_reference.py
@@ -99,3 +99,13 @@ def test_reference_video_unit_rejects_more_than_four_shots():
     many_shots = [Shot(duration=1, text=f"s{i}") for i in range(5)]
     with pytest.raises(ValidationError):
         _make_unit(shots=many_shots)
+
+
+def test_reference_video_unit_rejects_duration_mismatch():
+    with pytest.raises(ValidationError):
+        _make_unit(duration_seconds=99)  # shots 3+5=8, 99 ≠ 8
+
+
+def test_reference_video_unit_allows_mismatch_with_override():
+    u = _make_unit(duration_seconds=99, duration_override=True)
+    assert u.duration_seconds == 99

--- a/tests/lib/test_script_models_reference.py
+++ b/tests/lib/test_script_models_reference.py
@@ -1,7 +1,13 @@
 import pytest
 from pydantic import ValidationError
 
-from lib.script_models import ReferenceResource, Shot
+from lib.script_models import (
+    NovelInfo,
+    ReferenceResource,
+    ReferenceVideoScript,
+    ReferenceVideoUnit,
+    Shot,
+)
 
 
 def test_shot_valid():
@@ -26,3 +32,64 @@ def test_reference_resource_valid_types():
 def test_reference_resource_rejects_clue():
     with pytest.raises(ValidationError):
         ReferenceResource(type="clue", name="张三")
+
+
+def _make_unit(**overrides):
+    defaults = dict(
+        unit_id="E1U1",
+        shots=[Shot(duration=3, text="Shot 1"), Shot(duration=5, text="Shot 2")],
+        references=[ReferenceResource(type="character", name="张三")],
+        duration_seconds=8,
+    )
+    defaults.update(overrides)
+    return ReferenceVideoUnit(**defaults)
+
+
+def test_reference_video_unit_minimal():
+    u = _make_unit()
+    assert u.unit_id == "E1U1"
+    assert len(u.shots) == 2
+    assert u.duration_seconds == 8
+    assert u.duration_override is False
+    assert u.transition_to_next == "cut"
+
+
+def test_reference_video_unit_requires_at_least_one_shot():
+    with pytest.raises(ValidationError):
+        _make_unit(shots=[])
+
+
+def test_reference_video_unit_duration_override_flag():
+    u = _make_unit(duration_override=True)
+    assert u.duration_override is True
+
+
+def test_reference_video_unit_transition_enum():
+    with pytest.raises(ValidationError):
+        _make_unit(transition_to_next="wipe")
+
+
+def test_reference_video_script_valid():
+    script = ReferenceVideoScript(
+        episode=1,
+        title="江湖夜话",
+        content_mode="reference_video",
+        duration_seconds=8,
+        summary="主角闯江湖。",
+        novel=NovelInfo(title="江湖行", chapter="第一回"),
+        video_units=[_make_unit()],
+    )
+    assert script.content_mode == "reference_video"
+    assert len(script.video_units) == 1
+
+
+def test_reference_video_script_rejects_wrong_content_mode():
+    with pytest.raises(ValidationError):
+        ReferenceVideoScript(
+            episode=1,
+            title="x",
+            content_mode="narration",
+            summary="x",
+            novel=NovelInfo(title="x", chapter="x"),
+            video_units=[_make_unit()],
+        )

--- a/tests/lib/test_script_models_reference.py
+++ b/tests/lib/test_script_models_reference.py
@@ -93,3 +93,9 @@ def test_reference_video_script_rejects_wrong_content_mode():
             novel=NovelInfo(title="x", chapter="x"),
             video_units=[_make_unit()],
         )
+
+
+def test_reference_video_unit_rejects_more_than_four_shots():
+    many_shots = [Shot(duration=1, text=f"s{i}") for i in range(5)]
+    with pytest.raises(ValidationError):
+        _make_unit(shots=many_shots)

--- a/tests/lib/test_shot_parser.py
+++ b/tests/lib/test_shot_parser.py
@@ -1,4 +1,10 @@
-from lib.reference_video.shot_parser import parse_prompt
+from lib.reference_video.shot_parser import (
+    compute_duration_from_shots,
+    parse_prompt,
+    render_prompt_for_backend,
+    resolve_references,
+)
+from lib.script_models import ReferenceResource, Shot
 
 
 def test_parse_single_shot_no_header():
@@ -34,10 +40,6 @@ def test_parse_empty_returns_empty_text_as_single_shot():
     assert len(shots) == 1
     assert shots[0].text == ""
     assert override is True
-
-
-from lib.reference_video.shot_parser import render_prompt_for_backend
-from lib.script_models import ReferenceResource, Shot
 
 
 def test_extract_mentions_ordered_unique():
@@ -78,9 +80,6 @@ def test_render_prompt_multi_shot_text():
     assert "Shot 1 (3s):" in rendered  # header 保留
 
 
-from lib.reference_video.shot_parser import compute_duration_from_shots
-
-
 def test_compute_duration_sums_shots():
     shots = [Shot(duration=3, text="a"), Shot(duration=5, text="b"), Shot(duration=2, text="c")]
     assert compute_duration_from_shots(shots) == 10
@@ -92,9 +91,6 @@ def test_compute_duration_single_shot():
 
 def test_compute_duration_empty_list():
     assert compute_duration_from_shots([]) == 0
-
-
-from lib.reference_video.shot_parser import resolve_references
 
 
 def _proj(characters=None, scenes=None, props=None):

--- a/tests/lib/test_shot_parser.py
+++ b/tests/lib/test_shot_parser.py
@@ -37,7 +37,7 @@ def test_parse_empty_returns_empty_text_as_single_shot():
 
 
 from lib.reference_video.shot_parser import render_prompt_for_backend
-from lib.script_models import ReferenceResource
+from lib.script_models import ReferenceResource, Shot
 
 
 def test_extract_mentions_ordered_unique():
@@ -76,3 +76,19 @@ def test_render_prompt_multi_shot_text():
     rendered = render_prompt_for_backend(text, refs)
     assert rendered.count("[图1]") == 2
     assert "Shot 1 (3s):" in rendered  # header 保留
+
+
+from lib.reference_video.shot_parser import compute_duration_from_shots
+
+
+def test_compute_duration_sums_shots():
+    shots = [Shot(duration=3, text="a"), Shot(duration=5, text="b"), Shot(duration=2, text="c")]
+    assert compute_duration_from_shots(shots) == 10
+
+
+def test_compute_duration_single_shot():
+    assert compute_duration_from_shots([Shot(duration=7, text="x")]) == 7
+
+
+def test_compute_duration_empty_list():
+    assert compute_duration_from_shots([]) == 0

--- a/tests/lib/test_shot_parser.py
+++ b/tests/lib/test_shot_parser.py
@@ -1,0 +1,36 @@
+from lib.reference_video.shot_parser import parse_prompt
+
+
+def test_parse_single_shot_no_header():
+    shots, refs, override = parse_prompt("中景，主角走进房间。")
+    assert len(shots) == 1
+    assert shots[0].text == "中景，主角走进房间。"
+    assert override is True  # 无 header → 单镜头，override 模式
+    assert refs == []
+
+
+def test_parse_multi_shot():
+    text = "Shot 1 (3s): 中远景，主角推门进酒馆。\nShot 2 (5s): 近景，对面的张三抬眼。\n"
+    shots, refs, override = parse_prompt(text)
+    assert len(shots) == 2
+    assert shots[0].duration == 3
+    assert shots[0].text == "中远景，主角推门进酒馆。"
+    assert shots[1].duration == 5
+    assert shots[1].text == "近景，对面的张三抬眼。"
+    assert override is False  # 有 header → 派生模式
+
+
+def test_parse_three_shots_mixed_whitespace():
+    text = """Shot 1 (2s):  开场
+Shot 2 (4s):   中段
+Shot 3 (3s): 收尾"""
+    shots, _refs, _ = parse_prompt(text)
+    durations = [s.duration for s in shots]
+    assert durations == [2, 4, 3]
+
+
+def test_parse_empty_returns_empty_text_as_single_shot():
+    shots, refs, override = parse_prompt("")
+    assert len(shots) == 1
+    assert shots[0].text == ""
+    assert override is True

--- a/tests/lib/test_shot_parser.py
+++ b/tests/lib/test_shot_parser.py
@@ -92,3 +92,49 @@ def test_compute_duration_single_shot():
 
 def test_compute_duration_empty_list():
     assert compute_duration_from_shots([]) == 0
+
+
+from lib.reference_video.shot_parser import resolve_references
+
+
+def _proj(characters=None, scenes=None, props=None):
+    return {
+        "characters": characters or {},
+        "scenes": scenes or {},
+        "props": props or {},
+    }
+
+
+def test_resolve_references_character():
+    proj = _proj(characters={"张三": {}})
+    refs, missing = resolve_references(["张三"], proj)
+    assert len(refs) == 1
+    assert refs[0].type == "character"
+    assert refs[0].name == "张三"
+    assert missing == []
+
+
+def test_resolve_references_scene_and_prop():
+    proj = _proj(scenes={"酒馆": {}}, props={"长剑": {}})
+    refs, missing = resolve_references(["酒馆", "长剑"], proj)
+    types = {r.name: r.type for r in refs}
+    assert types == {"酒馆": "scene", "长剑": "prop"}
+    assert missing == []
+
+
+def test_resolve_references_missing_reports_name():
+    refs, missing = resolve_references(["张三", "未知"], _proj(characters={"张三": {}}))
+    assert len(refs) == 1
+    assert missing == ["未知"]
+
+
+def test_resolve_references_preserves_order():
+    proj = _proj(characters={"B": {}}, scenes={"A": {}}, props={"C": {}})
+    refs, _ = resolve_references(["A", "B", "C"], proj)
+    assert [r.name for r in refs] == ["A", "B", "C"]
+
+
+def test_resolve_references_empty_input():
+    refs, missing = resolve_references([], _proj())
+    assert refs == []
+    assert missing == []

--- a/tests/lib/test_shot_parser.py
+++ b/tests/lib/test_shot_parser.py
@@ -134,3 +134,19 @@ def test_resolve_references_empty_input():
     refs, missing = resolve_references([], _proj())
     assert refs == []
     assert missing == []
+
+
+def test_parse_multi_shot_preserves_pre_header_text():
+    text = (
+        "开场说明：这段剧本的整体基调偏紧张。\n"
+        "Shot 1 (3s): 中远景，主角推门进酒馆。\n"
+        "Shot 2 (5s): 近景，对面的张三抬眼。\n"
+    )
+    shots, _refs, override = parse_prompt(text)
+    assert len(shots) == 2
+    assert override is False
+    # Pre-header text 前置到首 shot
+    assert "开场说明" in shots[0].text
+    assert "中远景" in shots[0].text
+    # 第二个 shot 不受影响
+    assert shots[1].text == "近景，对面的张三抬眼。"

--- a/tests/lib/test_shot_parser.py
+++ b/tests/lib/test_shot_parser.py
@@ -34,3 +34,45 @@ def test_parse_empty_returns_empty_text_as_single_shot():
     assert len(shots) == 1
     assert shots[0].text == ""
     assert override is True
+
+
+from lib.reference_video.shot_parser import render_prompt_for_backend
+from lib.script_models import ReferenceResource
+
+
+def test_extract_mentions_ordered_unique():
+    text = "Shot 1 (3s): @张三 看向 @酒馆\nShot 2 (5s): @张三 拔剑 @长剑"
+    _shots, refs, _ = parse_prompt(text)
+    assert refs == ["张三", "酒馆", "长剑"]
+
+
+def test_extract_mentions_empty_prompt():
+    _shots, refs, _ = parse_prompt("没有任何提及")
+    assert refs == []
+
+
+def test_render_prompt_replaces_mentions():
+    text = "中景，@张三 走进 @酒馆 找 @长剑。"
+    refs = [
+        ReferenceResource(type="character", name="张三"),
+        ReferenceResource(type="scene", name="酒馆"),
+        ReferenceResource(type="prop", name="长剑"),
+    ]
+    rendered = render_prompt_for_backend(text, refs)
+    assert rendered == "中景，[图1] 走进 [图2] 找 [图3]。"
+
+
+def test_render_prompt_unknown_mention_kept():
+    text = "@张三 和 @未知 对话"
+    refs = [ReferenceResource(type="character", name="张三")]
+    rendered = render_prompt_for_backend(text, refs)
+    assert "[图1]" in rendered
+    assert "@未知" in rendered  # 未注册保留
+
+
+def test_render_prompt_multi_shot_text():
+    text = "Shot 1 (3s): @张三 推门\nShot 2 (5s): @张三 坐下"
+    refs = [ReferenceResource(type="character", name="张三")]
+    rendered = render_prompt_for_backend(text, refs)
+    assert rendered.count("[图1]") == 2
+    assert "Shot 1 (3s):" in rendered  # header 保留


### PR DESCRIPTION
## Summary

PR2 · M2 数据模型 + `shot_parser` 落地（参考生视频 7-PR roadmap 第 2 个 PR）。纯数据层，不碰路由/前端/Agent。

- 新增 `Shot` / `ReferenceResource` / `ReferenceVideoUnit` / `ReferenceVideoScript` Pydantic 模型
- 新增 `lib/reference_video/shot_parser.py`：prompt ↔ `Shot[]` / references 双向解析，含 `parse_prompt` / `render_prompt_for_backend` / `compute_duration_from_shots` / `resolve_references`
- `DataValidator` 接受 `content_mode=reference_video`，允许 `reference_videos/` 顶层目录
- `effective_mode(project, episode)` 解析 `generation_mode` 回退链（episode → project → storyboard 默认）
- 抽取 `TransitionType` 共享 Literal 别名；`_validate_reference_video_script` 使用 `ASSET_TYPES`

## 依赖 & 影响

- 前置：无（与 PR1 SDK 验证并行可做）
- 旧项目零影响：`generation_mode` 缺失自动回退 storyboard；未 bump `schema_version`（保持 v1）
- 后续 PR3 后端 executor 消费这套模型

## Spec 覆盖

`docs/superpowers/specs/2026-04-15-reference-to-video-mode-design.md` §4 数据模型、§4.1 project.json、§4.2 Pydantic、§4.3 parser、§4.5 映射表、§4.6 effective_mode、§11 schema_version 策略

## Test plan

- [x] `uv run pytest tests/lib/ -v` — 37 tests PASS
- [x] 全量回归 `uv run pytest tests/` — 1649 tests PASS
- [x] 覆盖率 `lib/reference_video/` + `lib/script_models.py` = **100%**
- [x] `uv run ruff check . && uv run ruff format --check .` 干净
- [x] `schema_version` 未 bump

## Out of scope

- 路由 / queue / worker / executor → PR3
- 前端 `ReferenceVideoCanvas` / `MentionPicker` → PR4-5
- Agent `split-reference-video-units` subagent → PR6
- E2E 集成测试 → PR7