### PR TITLE
perf(backend): 消除 _serialize_value 对 Pydantic 的双遍历

### DIFF
--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -1930,10 +1930,9 @@ class SessionManager:
         if isinstance(value, (list, tuple)):
             return [self._serialize_value(item) for item in value]
 
-        # Pydantic models
+        # Pydantic models — mode="json" 一次产出 JSON 安全结构，避免再次递归
         if hasattr(value, "model_dump"):
-            dumped = value.model_dump()
-            return self._serialize_value(dumped)
+            return value.model_dump(mode="json")
 
         # Dataclasses or objects with __dict__
         if hasattr(value, "__dict__"):

--- a/tests/test_session_manager_serialize.py
+++ b/tests/test_session_manager_serialize.py
@@ -1,6 +1,7 @@
 """Unit tests for SessionManager._serialize_value method."""
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
 
 from pydantic import BaseModel
 
@@ -71,6 +72,16 @@ class TestSerializeValue:
         block = DataclassBlock(kind="text", value="content")
         result = session_manager._serialize_value(block)
         assert result == {"kind": "text", "value": "content"}
+
+    def test_serialize_pydantic_with_json_mode_types(self, session_manager):
+        """Pydantic dump must go through mode='json' (datetime → ISO string)."""
+
+        class Event(BaseModel):
+            ts: datetime
+
+        ts = datetime(2026, 4, 19, 12, 0, 0, tzinfo=UTC)
+        result = session_manager._serialize_value(Event(ts=ts))
+        assert result == {"ts": "2026-04-19T12:00:00Z"}
 
     def test_serialize_unknown_object_to_string(self, session_manager):
         """Objects without model_dump or __dict__ are converted to string."""


### PR DESCRIPTION
## Summary
- \`server/agent_runtime/session_manager.py::_serialize_value\` 的 Pydantic 分支改用 \`model_dump(mode=\"json\")\`，一次性产出 JSON 安全结构，取消对 dumped dict 的二次递归（O(2n) → O(n)）
- 新增 \`test_serialize_pydantic_with_json_mode_types\`：构造含 \`datetime\` 字段的 Pydantic 模型，断言结果为 ISO 字符串，锁定 \`mode=\"json\"\` 语义以防未来回退

Closes #298

## Test plan
- [x] \`uv run python -m pytest tests/test_session_manager_serialize.py -v\`（8 passed）
- [x] \`uv run python -m pytest tests/test_session_manager_more.py tests/test_session_manager_sdk_session_id.py\`（全部通过）
- [x] \`uv run ruff check server/agent_runtime/session_manager.py tests/test_session_manager_serialize.py\`
- [x] \`uv run ruff format --check\`（已格式化）