### PR TITLE
fix(script): 修复 AI 生成剧本集号幻觉污染 project.json

### DIFF
--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -374,6 +374,10 @@ class ProjectManager:
             chapter = script["novel"].get("chapter", "chapter_01")
             filename = f"{chapter.replace(' ', '_')}_script.json"
 
+        # 先做 filename/内部 episode 一致性校验，避免写盘后才在 sync 阶段抛错，
+        # 造成"脚本文件已落盘、project.json 未同步"的部分提交（codex 指出的原子性缺口）。
+        self._require_filename_episode_consistency(script, filename)
+
         # 更新元数据（兼容旧脚本：可能缺少 metadata，或 narration 使用 segments）
         now = datetime.now().isoformat()
         metadata = script.get("metadata")
@@ -428,6 +432,26 @@ class ProjectManager:
         return output_path
 
     @staticmethod
+    def _require_filename_episode_consistency(script: dict, script_filename: str) -> None:
+        """校验脚本内 `episode` 字段与文件名隐含的集号一致；不一致则 raise ValueError。
+
+        filename 缺集号模式或脚本内无 `episode` int 时静默放行（兼容旧数据）。
+        """
+        base_name = script_filename[len("scripts/") :] if script_filename.startswith("scripts/") else script_filename
+        filename_match = re.search(r"episode[-_\s]*(\d+)", base_name, re.IGNORECASE)
+        if filename_match is None:
+            return
+        script_episode = script.get("episode")
+        if not isinstance(script_episode, int):
+            return
+        filename_episode = int(filename_match.group(1))
+        if script_episode != filename_episode:
+            raise ValueError(
+                f"脚本 {base_name} 内部 episode={script_episode} 与文件名隐含的 "
+                f"episode={filename_episode} 不一致，拒绝操作以避免污染 project.json"
+            )
+
+    @staticmethod
     def resolve_episode_from_script(script: dict, script_filename: str) -> int:
         """从剧本解析集号。
 
@@ -466,22 +490,15 @@ class ProjectManager:
         project = self.load_project(project_name)
 
         base_name = script_filename[len("scripts/") :] if script_filename.startswith("scripts/") else script_filename
-        filename_match = re.search(r"episode[-_\s]*(\d+)", base_name, re.IGNORECASE)
-        filename_episode = int(filename_match.group(1)) if filename_match else None
+        # 防御纵深：SSE 扫描路径直接调用此函数（不经 save_script），同样需要校验
+        self._require_filename_episode_consistency(script, base_name)
+
         script_episode = script.get("episode")
-
-        if filename_episode is not None and isinstance(script_episode, int) and script_episode != filename_episode:
-            raise ValueError(
-                f"脚本 {base_name} 内部 episode={script_episode} 与文件名隐含的 "
-                f"episode={filename_episode} 不一致，拒绝同步以避免污染 project.json"
-            )
-
         if isinstance(script_episode, int):
             episode_num = script_episode
-        elif filename_episode is not None:
-            episode_num = filename_episode
         else:
-            episode_num = 1
+            filename_match = re.search(r"episode[-_\s]*(\d+)", base_name, re.IGNORECASE)
+            episode_num = int(filename_match.group(1)) if filename_match else 1
         episode_title = script.get("title", "")
         script_file = f"scripts/{base_name}"
 

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -456,13 +456,34 @@ class ProjectManager:
 
         Returns:
             更新后的 project 字典
+
+        Raises:
+            ValueError: 当文件名隐含的集号与脚本内 `episode` 字段不一致时抛出，
+                避免错误的脚本数据覆盖真实集号条目（例如 episode_10.json 内部
+                错写为 episode=1，会覆盖第 1 集）。
         """
         script = self.load_script(project_name, script_filename)
         project = self.load_project(project_name)
 
-        episode_num = script.get("episode", 1)
+        base_name = script_filename[len("scripts/") :] if script_filename.startswith("scripts/") else script_filename
+        filename_match = re.search(r"episode[-_\s]*(\d+)", base_name, re.IGNORECASE)
+        filename_episode = int(filename_match.group(1)) if filename_match else None
+        script_episode = script.get("episode")
+
+        if filename_episode is not None and isinstance(script_episode, int) and script_episode != filename_episode:
+            raise ValueError(
+                f"脚本 {base_name} 内部 episode={script_episode} 与文件名隐含的 "
+                f"episode={filename_episode} 不一致，拒绝同步以避免污染 project.json"
+            )
+
+        if isinstance(script_episode, int):
+            episode_num = script_episode
+        elif filename_episode is not None:
+            episode_num = filename_episode
+        else:
+            episode_num = 1
         episode_title = script.get("title", "")
-        script_file = f"scripts/{script_filename}"
+        script_file = f"scripts/{base_name}"
 
         # 查找或创建 episode 条目
         episodes = project.setdefault("episodes", [])

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -348,8 +348,9 @@ class ScriptGenerator:
             补充元数据后的剧本数据
         """
         gen_mode = self._effective_generation_mode(episode)
-        # 确保基本字段存在
-        script_data.setdefault("episode", episode)
+        # CLI 参数 --episode 是集号唯一真相源。schema 已从 AI 输出中移除 episode 字段，
+        # 这里负责落盘前补上。
+        script_data["episode"] = int(episode)
         if gen_mode == "reference_video":
             script_data["content_mode"] = "reference_video"
         else:

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -114,9 +114,13 @@ class NovelInfo(BaseModel):
 
 
 class NarrationEpisodeScript(BaseModel):
-    """说书模式剧集脚本"""
+    """说书模式剧集脚本
 
-    episode: int = Field(description="剧集编号")
+    注意：`episode` 字段不在 schema 中。CLI 参数 `--episode N` 是集号的唯一真相源，
+    由 `ScriptGenerator._add_metadata` 写入。不让 AI 生成该字段，避免幻觉写错集号
+    进而污染 project.json（曾导致 episode_10.json 内部 episode=1 覆盖第 1 集条目）。
+    """
+
     title: str = Field(description="剧集标题")
     content_mode: Literal["narration"] = Field(default="narration", description="内容模式")
     duration_seconds: int = Field(default=0, description="总时长（秒）")
@@ -146,9 +150,12 @@ class DramaScene(BaseModel):
 
 
 class DramaEpisodeScript(BaseModel):
-    """剧集动画模式剧集脚本"""
+    """剧集动画模式剧集脚本
 
-    episode: int = Field(description="剧集编号")
+    注意：`episode` 字段不在 schema 中，集号由 CLI 真相源通过 `_add_metadata` 写入。
+    详见 `NarrationEpisodeScript` docstring。
+    """
+
     title: str = Field(description="剧集标题")
     content_mode: Literal["drama"] = Field(default="drama", description="内容模式")
     duration_seconds: int = Field(default=0, description="总时长（秒）")
@@ -202,9 +209,12 @@ class ReferenceVideoUnit(BaseModel):
 
 
 class ReferenceVideoScript(BaseModel):
-    """参考生视频模式剧集脚本。"""
+    """参考生视频模式剧集脚本。
 
-    episode: int = Field(description="剧集编号")
+    注意：`episode` 字段不在 schema 中，集号由 CLI 真相源通过 `_add_metadata` 写入。
+    详见 `NarrationEpisodeScript` docstring。
+    """
+
     title: str = Field(description="剧集标题")
     content_mode: Literal["reference_video"] = Field(default="reference_video", description="内容模式")
     duration_seconds: int = Field(default=0, description="总时长（秒）")

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -89,10 +89,14 @@ class GeneratedAssets(BaseModel):
 
 
 class NarrationSegment(BaseModel):
-    """说书模式的片段"""
+    """说书模式的片段
+
+    注意：不设独立 `episode` 字段。集号已经编码在 `segment_id`（格式 E{集}S{序号}）中，
+    与 `DramaScene.scene_id` / `ReferenceVideoUnit.unit_id` 保持一致。避免 AI 在每个
+    segment 上重复生成集号造成幻觉污染（详见 `NarrationEpisodeScript` docstring）。
+    """
 
     segment_id: str = Field(description="片段 ID，格式 E{集}S{序号} 或 E{集}S{序号}_{子序号}")
-    episode: int = Field(description="所属剧集")
     duration_seconds: int = Field(ge=1, le=60, description="片段时长（秒）")
     segment_break: bool = Field(default=False, description="是否为场景切换点")
     novel_text: str = Field(description="小说原文（必须原样保留，用于后期配音）")

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -370,8 +370,19 @@ class ProjectEventService:
             if existing and existing["title"] == title and existing["script_file"] == expected_script_file:
                 continue
 
-            with project_change_source("filesystem"):
-                self.pm.sync_episode_from_script(project_name, script_path.name)
+            try:
+                with project_change_source("filesystem"):
+                    self.pm.sync_episode_from_script(project_name, script_path.name)
+            except ValueError as exc:
+                # filename 与脚本内 episode 字段不一致：跳过同步避免污染 project.json，
+                # 同时避免 SSE 扫描循环无限重试导致 metadata.updated_at 抖动。
+                logger.warning(
+                    "剧集集号不一致，跳过同步 project=%s file=%s reason=%s",
+                    project_name,
+                    script_path.name,
+                    exc,
+                )
+                continue
             current_episodes[episode] = {
                 "title": title,
                 "script_file": expected_script_file,

--- a/tests/lib/test_script_models_reference.py
+++ b/tests/lib/test_script_models_reference.py
@@ -71,7 +71,6 @@ def test_reference_video_unit_transition_enum():
 
 def test_reference_video_script_valid():
     script = ReferenceVideoScript(
-        episode=1,
         title="江湖夜话",
         content_mode="reference_video",
         duration_seconds=8,
@@ -86,7 +85,6 @@ def test_reference_video_script_valid():
 def test_reference_video_script_rejects_wrong_content_mode():
     with pytest.raises(ValidationError):
         ReferenceVideoScript(
-            episode=1,
             title="x",
             content_mode="narration",
             summary="x",

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -161,6 +161,44 @@ class TestProjectManagerMore:
         with pytest.raises(KeyError):
             pm.update_scene_asset("demo", "episode_1.json", "NOT_FOUND", "video_clip", "x.mp4")
 
+    def test_sync_episode_rejects_filename_episode_mismatch(self, tmp_path):
+        """文件名隐含集号与脚本内 episode 字段不一致时必须拒绝同步。
+
+        回归：AI 生成 episode_10.json 但内部 episode=1 曾导致第 1 集条目被覆盖、
+        第 10 集丢失，并触发 SSE 循环不停 touch metadata.updated_at。
+        """
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        ep1 = {
+            "episode": 1,
+            "title": "第一集原标题",
+            "content_mode": "narration",
+            "segments": [{"segment_id": "E1S01", "duration_seconds": 4}],
+        }
+        pm.save_script("demo", ep1, "episode_1.json")
+
+        # 伪造错误脚本：文件名是 episode_10.json，但内部 episode=1（AI 幻觉场景）
+        corrupted = {
+            "episode": 1,
+            "title": "第十集错误标题",
+            "content_mode": "narration",
+            "segments": [{"segment_id": "E10S01", "duration_seconds": 4}],
+        }
+        # 绕过 save_script 的潜在未来校验，直接落盘模拟历史产物
+        scripts_dir = pm.get_project_path("demo") / "scripts"
+        (scripts_dir / "episode_10.json").write_text(json.dumps(corrupted, ensure_ascii=False), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="不一致"):
+            pm.sync_episode_from_script("demo", "episode_10.json")
+
+        # project.json 中第 1 集条目必须保持不被污染
+        proj = pm.load_project("demo")
+        ep1_entry = next(ep for ep in proj["episodes"] if ep["episode"] == 1)
+        assert ep1_entry["title"] == "第一集原标题"
+        assert ep1_entry["script_file"] == "scripts/episode_1.json"
+
     def test_load_script_strips_scripts_prefix(self, tmp_path):
         """load_script / save_script / update_scene_asset 应兼容带 scripts/ 前缀的文件名"""
         pm = ProjectManager(tmp_path / "projects")

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -161,6 +161,29 @@ class TestProjectManagerMore:
         with pytest.raises(KeyError):
             pm.update_scene_asset("demo", "episode_1.json", "NOT_FOUND", "video_clip", "x.mp4")
 
+    def test_save_script_rejects_mismatch_before_write(self, tmp_path):
+        """save_script 在 filename/内部 episode 不一致时必须写盘前 fail-fast。
+
+        回归（codex 评审）：旧版把校验放在 sync_episode_from_script，会造成
+        脚本文件已原子写、project.json 未同步的部分提交状态。
+        """
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        bad = {
+            "episode": 1,  # 与文件名 episode_10.json 错配
+            "title": "第十集错误标题",
+            "content_mode": "narration",
+            "segments": [],
+        }
+        with pytest.raises(ValueError, match="不一致"):
+            pm.save_script("demo", bad, "episode_10.json")
+
+        # 关键断言：文件不应被写入磁盘（原子性保持）
+        scripts_dir = pm.get_project_path("demo") / "scripts"
+        assert not (scripts_dir / "episode_10.json").exists()
+
     def test_sync_episode_rejects_filename_episode_mismatch(self, tmp_path):
         """文件名隐含集号与脚本内 episode 字段不一致时必须拒绝同步。
 

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -171,6 +171,40 @@ class TestScriptGenerator:
         assert payload["metadata"]["generator"] == "fake-model"
         assert "created_at" in payload["metadata"]
 
+    async def test_generate_overrides_hallucinated_episode_field(self, tmp_path):
+        """AI 返回带错误 episode 字段时，CLI 参数 episode 必须胜出。
+
+        回归：AI 幻觉在 episode_10.json 内部写 episode=1，导致 project.json 第 1 集
+        条目被覆盖。修复后 schema 已移除 episode 字段，_add_metadata 强制盖章 CLI 值。
+        """
+        project_path = tmp_path / "demo"
+        _write_json(
+            project_path / "project.json",
+            {
+                "title": "项目",
+                "content_mode": "narration",
+                "overview": {},
+                "characters": {"姜月茴": {}},
+                "clues": {"玉佩": {}},
+                "style": "古风",
+                "style_description": "cinematic",
+            },
+        )
+        _write(project_path / "drafts" / "episode_10" / "step1_segments.md", "E10S01 | 片段")
+
+        # 模拟 AI 响应：内部错误地填了 episode=1
+        hallucinated = _valid_narration_response()
+        hallucinated["episode"] = 1
+        hallucinated["title"] = "第十集"
+        fake = _FakeTextGenerator(json.dumps(hallucinated, ensure_ascii=False))
+        generator = ScriptGenerator(project_path, generator=fake)
+
+        output = await generator.generate(10)
+
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        assert output == project_path / "scripts" / "episode_10.json"
+        assert payload["episode"] == 10
+
     async def test_generate_passes_pydantic_class_as_schema(self, tmp_path):
         """generate 应传入 Pydantic 类而非 model_json_schema() dict。"""
         project_path = tmp_path / "demo"

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -26,7 +26,6 @@ def _valid_narration_response() -> dict:
         "segments": [
             {
                 "segment_id": "E1S01",
-                "episode": 1,
                 "duration_seconds": 4,
                 "segment_break": False,
                 "novel_text": "原文",

--- a/tests/test_script_models.py
+++ b/tests/test_script_models.py
@@ -121,14 +121,12 @@ class TestScriptModels:
 
     def test_episode_models_build_successfully(self):
         narration = NarrationEpisodeScript(
-            episode=1,
             title="第一集",
             summary="摘要",
             novel={"title": "小说", "chapter": "1"},
             segments=[],
         )
         drama = DramaEpisodeScript(
-            episode=1,
             title="第一集",
             summary="摘要",
             novel={"title": "小说", "chapter": "1"},

--- a/tests/test_script_models.py
+++ b/tests/test_script_models.py
@@ -17,7 +17,6 @@ class TestScriptModels:
     def test_narration_segment_defaults_and_validation(self):
         segment = NarrationSegment(
             segment_id="E1S01",
-            episode=1,
             duration_seconds=4,
             novel_text="原文",
             characters_in_segment=["姜月茴"],
@@ -65,7 +64,6 @@ class TestScriptModels:
         """duration_seconds 接受 1-60 范围内任意整数。"""
         segment = NarrationSegment(
             segment_id="E1S01",
-            episode=1,
             duration_seconds=10,  # 之前会被 DurationSeconds 拒绝
             novel_text="原文",
             characters_in_segment=["姜月茴"],
@@ -82,7 +80,6 @@ class TestScriptModels:
         with pytest.raises(ValidationError):
             NarrationSegment(
                 segment_id="E1S01",
-                episode=1,
                 duration_seconds=0,
                 novel_text="原文",
                 characters_in_segment=["姜月茴"],
@@ -95,7 +92,6 @@ class TestScriptModels:
         with pytest.raises(ValidationError):
             NarrationSegment(
                 segment_id="E1S01",
-                episode=1,
                 duration_seconds=61,
                 novel_text="原文",
                 characters_in_segment=["姜月茴"],


### PR DESCRIPTION
## Summary
- Gemini 结构化输出 schema 要求生成 `episode` 字段，但 prompt 未告知集号，AI 幻觉写入 `episode=1` 被 SSE 扫描循环反复同步，覆盖已有集条目、丢失目标集，并持续抖动 `metadata.updated_at` 使智能体 Edit `project.json` 反复 race。
- 端掉根因：三个脚本 schema 去掉 `episode` 字段，集号以 CLI `--episode N` 为唯一真相源，由 `_add_metadata` 强制写入。
- 纵深防御：`sync_episode_from_script` 在 filename/内部 episode 不一致时 fail-fast；SSE 扫描循环捕获异常告警并跳过，打破污染自愈循环。

## Test plan
- [x] `uv run python -m pytest tests/test_script_generator.py tests/test_script_models.py tests/lib/test_script_models_reference.py tests/test_project_manager_more.py tests/lib/test_script_generator_reference_branch.py`（68 passed）
- [x] `uv run ruff check` & `ruff format` 无违规
- [ ] 在测试项目上跑 `/manga-workflow` 生成第 10 集，确认不再覆盖第 1 集