### PR TITLE
fix(reference-video): 补 OUTPUT_PATTERNS 白名单修复生成视频 P0 失败

### DIFF
--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -47,6 +47,7 @@ class MediaGenerator:
         "scenes": "scenes/{resource_id}.png",
         "props": "props/{resource_id}.png",
         "grids": "grids/{resource_id}.png",
+        "reference_videos": "reference_videos/{resource_id}.mp4",
     }
 
     def __init__(

--- a/lib/version_manager.py
+++ b/lib/version_manager.py
@@ -29,7 +29,7 @@ class VersionManager:
     """版本管理器"""
 
     # 支持的资源类型
-    RESOURCE_TYPES = ("storyboards", "videos", "characters", "scenes", "props", "grids")
+    RESOURCE_TYPES = ("storyboards", "videos", "characters", "scenes", "props", "grids", "reference_videos")
 
     # 资源类型对应的文件扩展名
     EXTENSIONS = {
@@ -39,6 +39,7 @@ class VersionManager:
         "scenes": ".png",
         "props": ".png",
         "grids": ".png",
+        "reference_videos": ".mp4",
     }
 
     def __init__(self, project_path: Path):

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -275,6 +275,114 @@ async def test_execute_reference_video_task_missing_reference_fails(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """回归守门：executor 必须走真实 MediaGenerator._get_output_path 白名单。
+
+    只 mock 最外层的 VideoBackend.generate — 若未来哪次又漏注册新 resource_type
+    到 OUTPUT_PATTERNS，这条测试会立刻爆 ValueError。
+    参见 issue #364。
+    """
+    from lib.media_generator import MediaGenerator
+    from lib.video_backends.base import VideoCapabilities, VideoGenerationResult
+    from server.services import reference_video_tasks as rvt
+
+    proj_dir = _write_project(tmp_path)
+
+    fake_pm = MagicMock()
+    fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
+    fake_pm.get_project_path.return_value = proj_dir
+    fake_pm.load_script.side_effect = lambda *_a: json.loads(
+        (proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8")
+    )
+    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
+
+    # --- 内联假依赖，避开真实 DB / VersionManager ---
+    captured_requests: list = []
+
+    class _FakeVideoBackend:
+        name = "ark"
+        model = "doubao-seedance-2-0-260128"
+        capabilities: set = set()
+
+        @property
+        def video_capabilities(self):
+            return VideoCapabilities(reference_images=True, max_reference_images=9)
+
+        async def generate(self, request):
+            captured_requests.append(request)
+            request.output_path.parent.mkdir(parents=True, exist_ok=True)
+            request.output_path.write_bytes(b"\x00\x00\x00 ftypmp42")
+            return VideoGenerationResult(
+                video_path=request.output_path,
+                provider=self.name,
+                model=self.model,
+                duration_seconds=request.duration_seconds,
+                video_uri="uri-x",
+                usage_tokens=0,
+                generate_audio=False,
+            )
+
+    class _FakeVersions:
+        def ensure_current_tracked(self, **_kwargs):
+            pass
+
+        def add_version(self, **_kwargs):
+            return 1
+
+        def get_versions(self, _rtype, _rid):
+            return {"versions": [{"created_at": "2026-04-21T10:00:00"}]}
+
+    class _FakeUsage:
+        async def start_call(self, **_kwargs):
+            return 1
+
+        async def finish_call(self, **_kwargs):
+            pass
+
+    class _FakeConfigResolver:
+        async def video_generate_audio(self, _project_name=None):
+            return False
+
+    # object.__new__ 绕过 MediaGenerator.__init__（避开真实 DB session / VersionManager 文件）
+    real_gen = object.__new__(MediaGenerator)
+    real_gen.project_path = proj_dir
+    real_gen.project_name = "demo"
+    real_gen._rate_limiter = None
+    real_gen._image_backend = None
+    real_gen._video_backend = _FakeVideoBackend()
+    real_gen._user_id = "u1"
+    real_gen._config = _FakeConfigResolver()
+    real_gen.versions = _FakeVersions()
+    real_gen.usage_tracker = _FakeUsage()
+
+    async def _fake_get_media_generator(*_a, **_kw):
+        return real_gen
+
+    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+
+    async def _fake_extract(*_a, **_k):
+        return True
+
+    monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
+
+    result = await rvt.execute_reference_video_task(
+        "demo",
+        "E1U1",
+        {"script_file": "scripts/episode_1.json"},
+        user_id="u1",
+    )
+
+    # Backend 被真实调用一次，且 output_path 走 OUTPUT_PATTERNS["reference_videos"] 模板
+    assert len(captured_requests) == 1
+    req = captured_requests[0]
+    assert req.output_path == (proj_dir / "reference_videos" / "E1U1.mp4")
+    # 真实文件落盘
+    assert (proj_dir / "reference_videos" / "E1U1.mp4").exists()
+    assert result["file_path"] == "reference_videos/E1U1.mp4"
+    assert result["video_uri"] == "uri-x"
+
+
+@pytest.mark.asyncio
 async def test_execute_reference_video_task_payload_too_large_retries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     proj_dir = _write_project(tmp_path)
 

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -283,6 +283,7 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
     参见 issue #364。
     """
     from lib.media_generator import MediaGenerator
+    from lib.version_manager import VersionManager
     from lib.video_backends.base import VideoCapabilities, VideoGenerationResult
     from server.services import reference_video_tasks as rvt
 
@@ -296,7 +297,10 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
     )
     monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
 
-    # --- 内联假依赖，避开真实 DB / VersionManager ---
+    # 只 mock 最外层：VideoBackend（唯一的真外部依赖）+ UsageTracker/ConfigResolver
+    # （这俩摸 DB，测试无 DB）。VersionManager 用真实实现 —— 这样 VersionManager
+    # 自己的白名单（RESOURCE_TYPES / EXTENSIONS）也被这条路径守住，
+    # 任何一处三张注册表漏登记都会在此爆 ValueError。
     captured_requests: list = []
 
     class _FakeVideoBackend:
@@ -322,16 +326,6 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
                 generate_audio=False,
             )
 
-    class _FakeVersions:
-        def ensure_current_tracked(self, **_kwargs):
-            pass
-
-        def add_version(self, **_kwargs):
-            return 1
-
-        def get_versions(self, _rtype, _rid):
-            return {"versions": [{"created_at": "2026-04-21T10:00:00"}]}
-
     class _FakeUsage:
         async def start_call(self, **_kwargs):
             return 1
@@ -343,7 +337,7 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
         async def video_generate_audio(self, _project_name=None):
             return False
 
-    # object.__new__ 绕过 MediaGenerator.__init__（避开真实 DB session / VersionManager 文件）
+    # object.__new__ 绕过 MediaGenerator.__init__（避开 __init__ 里的 UsageTracker 对 DB 的初始化）
     real_gen = object.__new__(MediaGenerator)
     real_gen.project_path = proj_dir
     real_gen.project_name = "demo"
@@ -352,7 +346,7 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
     real_gen._video_backend = _FakeVideoBackend()
     real_gen._user_id = "u1"
     real_gen._config = _FakeConfigResolver()
-    real_gen.versions = _FakeVersions()
+    real_gen.versions = VersionManager(proj_dir)
     real_gen.usage_tracker = _FakeUsage()
 
     async def _fake_get_media_generator(*_a, **_kw):
@@ -380,6 +374,10 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
     assert (proj_dir / "reference_videos" / "E1U1.mp4").exists()
     assert result["file_path"] == "reference_videos/E1U1.mp4"
     assert result["video_uri"] == "uri-x"
+    # 真实 VersionManager 闭环：版本文件落入 versions/reference_videos/
+    version_dir = proj_dir / "versions" / "reference_videos"
+    assert version_dir.exists()
+    assert any(p.suffix == ".mp4" for p in version_dir.iterdir())
 
 
 @pytest.mark.asyncio

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -108,6 +108,7 @@ class TestMediaGenerator:
         assert gen._get_output_path("storyboards", "E1S01").name == "scene_E1S01.png"
         assert gen._get_output_path("videos", "E1S01").name == "scene_E1S01.mp4"
         assert gen._get_output_path("characters", "Alice").name == "Alice.png"
+        assert gen._get_output_path("reference_videos", "E1U1").name == "E1U1.mp4"
         with pytest.raises(ValueError):
             gen._get_output_path("bad", "x")
 


### PR DESCRIPTION
## Summary

- `MediaGenerator.OUTPUT_PATTERNS` 注册 `reference_videos` → `reference_videos/{resource_id}.mp4`，修复参考生视频点击「生成」立即爆 `ValueError: 不支持的资源类型: reference_videos` 的 P0 阻塞 bug。
- 新增**两层防回归测试**，堵住 PR3 "mock 画太浅 → 契约漂移" 的根因：
  - `test_get_output_path_and_invalid_type` 加一行白名单契约断言（单元层）
  - 新增 `test_execute_reference_video_task_uses_real_media_generator`：走**真实 MediaGenerator**，只 mock 最外层 `VideoBackend.generate`（executor 层）

守门验证：临时去掉 `OUTPUT_PATTERNS["reference_videos"]` 跑，两条测试立刻爆，栈正是线上 issue 的同一条路径（`lib/media_generator.py:113`）；恢复后 37 条全绿。

Fixes #364

## Test plan

- [x] `uv run python -m pytest tests/test_media_generator_module.py tests/server/test_reference_video_tasks.py tests/server/test_reference_video_e2e_backend.py tests/server/test_reference_videos_router.py tests/integration/test_reference_video_e2e.py` → 37 passed
- [x] `uv run ruff check lib/media_generator.py tests/test_media_generator_module.py tests/server/test_reference_video_tasks.py` → All checks passed
- [x] 守门验证：临时注释 `OUTPUT_PATTERNS["reference_videos"]` 行 → 两条新测试均爆 `ValueError: 不支持的资源类型: reference_videos`（同线上栈）
- [ ] 手测：启 uvicorn + pnpm dev，浏览器选「参考生视频」模式 → 建 unit → 点「生成视频」→ 确认 `reference_videos/<uid>.mp4` + thumbnail 落盘，unit 卡片正常渲染