### PR TITLE
chore(logging): 降低任务轮询接口日志噪声

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -216,6 +216,17 @@ app.add_middleware(
 )
 
 
+# 前端每 3s 轮询下述接口获取任务状态；稳态下成功响应会把真正的错误/慢请求淹没，
+# 所以对 2xx + 快速响应降级到 DEBUG，异常/慢响应仍走 INFO 保证可观测。
+_QUIET_POLL_ENDPOINTS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("GET", "/api/v1/tasks"),
+        ("GET", "/api/v1/tasks/stats"),
+    }
+)
+_QUIET_SLOW_THRESHOLD_MS = 500.0
+
+
 @app.middleware("http")
 async def request_logging_middleware(request: Request, call_next):
     start = time.perf_counter()
@@ -235,7 +246,13 @@ async def request_logging_middleware(request: Request, call_next):
         raise
     if not _skip_log:
         elapsed_ms = (time.perf_counter() - start) * 1000
-        logger.info(
+        is_quiet = (
+            (request.method, path) in _QUIET_POLL_ENDPOINTS
+            and response.status_code < 400
+            and elapsed_ms < _QUIET_SLOW_THRESHOLD_MS
+        )
+        log = logger.debug if is_quiet else logger.info
+        log(
             "%s %s %d %.0fms",
             request.method,
             path,

--- a/tests/test_request_logging_middleware.py
+++ b/tests/test_request_logging_middleware.py
@@ -1,0 +1,87 @@
+"""验证 request_logging_middleware 对高频轮询接口的静默策略。"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from server.app import request_logging_middleware
+
+_ACCESS_LOG_FMT = "%s %s %d %.0fms"
+
+
+def _access_log_records(records: list[logging.LogRecord]) -> list[logging.LogRecord]:
+    return [r for r in records if r.name == "server.app" and r.msg == _ACCESS_LOG_FMT]
+
+
+def _build_app_with_ok_routes() -> FastAPI:
+    app = FastAPI()
+    app.middleware("http")(request_logging_middleware)
+
+    @app.get("/api/v1/tasks")
+    async def _tasks() -> dict:
+        return {"tasks": []}
+
+    @app.get("/api/v1/tasks/stats")
+    async def _tasks_stats() -> dict:
+        return {"stats": {}}
+
+    @app.get("/api/v1/projects")
+    async def _projects() -> dict:
+        return {"projects": []}
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_quiet_endpoint_fast_200_is_debug(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.DEBUG, logger="server.app")
+    app = _build_app_with_ok_routes()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp_list = await client.get("/api/v1/tasks")
+        resp_stats = await client.get("/api/v1/tasks/stats")
+
+    assert resp_list.status_code == 200
+    assert resp_stats.status_code == 200
+
+    records = _access_log_records(caplog.records)
+    assert len(records) == 2
+    assert all(r.levelno == logging.DEBUG for r in records)
+
+
+@pytest.mark.asyncio
+async def test_quiet_endpoint_5xx_still_info(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.DEBUG, logger="server.app")
+    app = FastAPI()
+    app.middleware("http")(request_logging_middleware)
+
+    @app.get("/api/v1/tasks")
+    async def _tasks_error() -> dict:
+        raise HTTPException(status_code=500, detail="boom")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/v1/tasks")
+
+    assert resp.status_code == 500
+    records = _access_log_records(caplog.records)
+    assert len(records) == 1
+    assert records[0].levelno == logging.INFO
+
+
+@pytest.mark.asyncio
+async def test_non_quiet_endpoint_200_still_info(caplog: pytest.LogCaptureFixture) -> None:
+    """回归保护：非静默路径的行为不变。"""
+    caplog.set_level(logging.DEBUG, logger="server.app")
+    app = _build_app_with_ok_routes()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/v1/projects")
+
+    assert resp.status_code == 200
+    records = _access_log_records(caplog.records)
+    assert len(records) == 1
+    assert records[0].levelno == logging.INFO


### PR DESCRIPTION
## Summary
- 前端 `useTasksSSE` 每 3s 轮询 `GET /api/v1/tasks` 与 `/api/v1/tasks/stats`，稳态下大量 200 访问日志把生成任务、错误、慢请求淹没
- `request_logging_middleware` 新增静默名单（精确 method+path 匹配），对 2xx + 响应时间 <500ms 的请求降级到 DEBUG
- 4xx/5xx、≥500ms 慢响应、未处理异常仍保留 INFO，其他接口日志行为不变

## Test plan
- [x] `uv run ruff check server/app.py tests/test_request_logging_middleware.py`
- [x] `uv run python -m pytest tests/test_request_logging_middleware.py tests/test_app_module.py tests/test_logging_config.py -v`（11 通过）
- [ ] 手动：启动 uvicorn 后让前端停在 Dashboard 30s，确认 `/api/v1/tasks` 轮询不再刷屏；同时触发一次生成，确认其他接口日志仍正常
- [ ] 反向：临时让 handler \`raise HTTPException(503)\`，确认静默路径在异常下仍打出 INFO