### PR TITLE
chore(reference-video): PR8 a11y/perf + executor duration 单一真相源 + timeline 跨项目隔离 (#375 #377 #382)

### DIFF
--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -468,7 +468,10 @@ export function StudioCanvasRouter() {
                   />
                 ) : (
                   <TimelineCanvas
-                    key={epNum}
+                    // 和 ReferenceVideoCanvas (上方) 同理：同 epNum 跨项目不 remount
+                    // 会让 TimelineCanvas 内部的 useState / useRef（选中 scene、草稿缓冲、
+                    // 滚动位置等）残留上一个项目的值。key 带上 projectName 天然按项目隔离。
+                    key={`${currentProjectName}::${epNum}`}
                     projectName={currentProjectName}
                     episode={epNum}
                     episodeTitle={episode?.title}

--- a/frontend/src/components/canvas/reference/ReferencePanel.tsx
+++ b/frontend/src/components/canvas/reference/ReferencePanel.tsx
@@ -82,7 +82,7 @@ const Pill = memo(function Pill({
         {...attributes}
         {...listeners}
         aria-label={t("reference_panel_drag_aria", { name: refItem.name })}
-        className="absolute left-1 top-1 z-10 cursor-grab rounded bg-black/40 p-0.5 text-gray-200 opacity-0 transition group-hover/pill:opacity-100 focus-visible:opacity-100 focus-ring"
+        className="absolute left-1 top-1 z-10 cursor-grab rounded bg-black/40 p-0.5 text-gray-200 opacity-0 transition group-hover/pill:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 focus-ring"
       >
         <GripVertical className="h-3 w-3" aria-hidden="true" />
       </button>
@@ -90,7 +90,7 @@ const Pill = memo(function Pill({
         type="button"
         onClick={() => onRemove(refItem)}
         aria-label={t("reference_panel_remove_aria", { name: refItem.name })}
-        className="absolute right-1 top-1 z-10 rounded-full bg-black/50 p-0.5 text-gray-200 opacity-0 transition hover:text-red-400 group-hover/pill:opacity-100 focus-visible:opacity-100 focus-ring"
+        className="absolute right-1 top-1 z-10 rounded-full bg-black/50 p-0.5 text-gray-200 opacity-0 transition hover:text-red-400 group-hover/pill:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 focus-ring"
       >
         <X className="h-3 w-3" aria-hidden="true" />
       </button>

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -399,6 +399,8 @@ export function ReferenceVideoCanvas({ projectName, episode, episodeTitle }: Ref
             <button
               type="button"
               role="tab"
+              id="reference-tab-editor-btn"
+              aria-controls="reference-tab-editor"
               aria-selected={smallTab === "editor"}
               onClick={() => setSmallTab("editor")}
               className={`rounded-t border-b-2 px-3 py-2 text-xs transition-colors focus-ring ${
@@ -412,6 +414,8 @@ export function ReferenceVideoCanvas({ projectName, episode, episodeTitle }: Ref
             <button
               type="button"
               role="tab"
+              id="reference-tab-preview-btn"
+              aria-controls="reference-tab-preview"
               aria-selected={smallTab === "preview"}
               onClick={() => setSmallTab("preview")}
               className={`rounded-t border-b-2 px-3 py-2 text-xs transition-colors focus-ring ${
@@ -424,6 +428,9 @@ export function ReferenceVideoCanvas({ projectName, episode, episodeTitle }: Ref
             </button>
           </div>
           <div
+            role="tabpanel"
+            id="reference-tab-editor"
+            aria-labelledby="reference-tab-editor-btn"
             className={`min-h-0 flex-1 flex-col overflow-hidden border-r border-gray-800 bg-gray-950/30 @4xl:flex ${
               smallTab === "editor" ? "flex" : "hidden"
             }`}
@@ -454,6 +461,9 @@ export function ReferenceVideoCanvas({ projectName, episode, episodeTitle }: Ref
             )}
           </div>
           <div
+            role="tabpanel"
+            id="reference-tab-preview"
+            aria-labelledby="reference-tab-preview-btn"
             className={`min-h-0 overflow-hidden @4xl:block ${smallTab === "preview" ? "block" : "hidden"}`}
           >
             <UnitPreviewPanel

--- a/frontend/src/components/canvas/reference/ReferenceVideoCard.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCard.tsx
@@ -129,6 +129,14 @@ export function ReferenceVideoCard({
 
   const tokens = useShotPromptHighlight(currentText, lookup);
 
+  // pickerOpen=false 是绝对多数路径（打字时 picker 只在 @ 触发短暂打开）。
+  // tokens 已被 useShotPromptHighlight memo 化，这里再把 tokens→ReactNode 列表缓存一层，
+  // 父组件或其他 state 引起的 re-render 就不会重新跑 renderHighlightedTokens 的 forEach。
+  const staticHighlightedNodes = useMemo(
+    () => renderHighlightedTokens(tokens, null, () => {}),
+    [tokens],
+  );
+
   const unknownMentions = useMemo(() => {
     const seen = new Set<string>();
     const out: string[] = [];
@@ -305,7 +313,9 @@ export function ReferenceVideoCard({
           aria-hidden
           className="pointer-events-none absolute inset-0 m-0 overflow-hidden whitespace-pre-wrap break-words p-3 font-mono text-sm leading-6"
         >
-          {renderHighlightedTokens(tokens, pickerOpen ? atStart : null, setAnchorEl)}
+          {pickerOpen
+            ? renderHighlightedTokens(tokens, atStart, setAnchorEl)
+            : staticHighlightedNodes}
           {currentText.endsWith("\n") ? "\u200b" : null}
         </pre>
 

--- a/lib/reference_video/limits.py
+++ b/lib/reference_video/limits.py
@@ -1,8 +1,12 @@
 """参考生视频模式的供应商能力上限（单一真相源）。
 
-Spec §附录 B。被 `lib/script_generator.py:_resolve_max_refs()`（prompt 构建阶段）
-和 `server/services/reference_video_tasks.py:_PROVIDER_LIMITS`（executor 强制阶段）
-共享，防止两处硬编码漂移。
+Spec §附录 B。目前只保留 **provider 粒度** 的 `PROVIDER_MAX_REFS`（参考图数量上限）——
+该口径目前仍是 provider 级别不区分 model。被 `ConfigResolver._resolve_video_capabilities_from_project`
+（返回 caps.max_reference_images）和 `lib/script_generator._resolve_max_refs` 共用。
+
+Duration（单次视频时长）上限的单一真相源是 **model 粒度的 `model.supported_durations`**，
+由 `ConfigResolver.video_capabilities_for_project(project)` 以 `caps["max_duration"]` 暴露，
+不在本模块维护（见 issue #377：删除了老的 `PROVIDER_MAX_DURATION` provider 级常量以消除双源漂移）。
 
 Provider id 归一化说明：`PROVIDER_REGISTRY` 把 Gemini 拆成 `gemini-aistudio` 和
 `gemini-vertex` 两个条目，而 executor 侧的 `backend.name` 已归一化为 `"gemini"`。
@@ -19,13 +23,6 @@ PROVIDER_MAX_REFS: dict[str, int] = {
 }
 
 DEFAULT_MAX_REFS = 9
-
-PROVIDER_MAX_DURATION: dict[str, int] = {
-    "gemini": 8,
-    "openai": 12,
-    "grok": 15,
-    "ark": 15,
-}
 
 
 def normalize_provider_id(raw: str) -> str:

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -198,13 +198,29 @@ async def execute_reference_video_task(
     # 4. 解析 model 粒度能力上限（单一真相源：model.supported_durations）。
     #    失败时 fallback 到 None（不裁剪，交由 backend 自行报错），与
     #    ScriptGenerator._fetch_video_capabilities 的口径保持一致。
+    #
+    #    注意：caps 基于 `project.json.video_backend` 解析；但自定义 provider 的 model
+    #    被禁用时，`_create_custom_backend` 会静默回退到默认启用 model（见
+    #    server/services/generation_tasks.py:99-122）。为避免"按旧模型 clamp、按新模型生成"
+    #    的错位，下面校验 caps.model 与 backend.model 是否一致；不一致就 skip clamp，
+    #    把决策推给 backend 自报错。根治需要 `VideoCapabilities` 协议暴露 `max_duration`，
+    #    本 PR 范围内先缓解。
     max_refs: int | None = None
     max_duration: int | None = None
     try:
         resolver = ConfigResolver(async_session_factory)
         caps = await resolver.video_capabilities_for_project(project)
-        max_refs = caps.get("max_reference_images")
-        max_duration = caps.get("max_duration")
+        caps_model = caps.get("model")
+        if model_name and caps_model and caps_model != model_name:
+            logger.warning(
+                "project.json video_backend model (%s) 与实际 backend model (%s) 不一致，"
+                "跳过 executor clamp 以避免按错误模型裁剪（常见于自定义模型禁用回退）。",
+                caps_model,
+                model_name,
+            )
+        else:
+            max_refs = caps.get("max_reference_images")
+            max_duration = caps.get("max_duration")
     except (ValueError, SQLAlchemyError) as exc:
         logger.info("无法解析 video_capabilities，跳过 executor clamp：%s", exc)
 
@@ -219,8 +235,14 @@ async def execute_reference_video_task(
         duration_seconds=base_duration,
     )
 
-    # 6. 渲染 prompt（@→[图N]）
-    rendered_prompt = _render_unit_prompt(unit)
+    # 6. 渲染 prompt（@→[图N]）。必须按 `constrained_refs` 的长度裁 `unit.references`
+    #    再渲染，保证 [图N] 的 1-based 索引与 backend 实际收到的 reference_images
+    #    长度严格对齐；否则裁剪后的 `@clipped_name` 会被替成 `[图N]` 指向不存在的图。
+    unit_for_prompt = unit
+    unit_refs = unit.get("references") or []
+    if len(constrained_refs) < len(unit_refs):
+        unit_for_prompt = {**unit, "references": unit_refs[: len(constrained_refs)]}
+    rendered_prompt = _render_unit_prompt(unit_for_prompt)
 
     # 7. 压缩到临时文件（2048px/q=85）→ 首次调用
     tmp_refs: list[Path] = await asyncio.to_thread(_compress_references_to_tempfiles, constrained_refs)

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -12,12 +12,15 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from lib.asset_types import BUCKET_KEY, SHEET_KEY
+from lib.config.resolver import ConfigResolver
+from lib.db import async_session_factory
 from lib.db.base import DEFAULT_USER_ID
 from lib.image_utils import compress_image_bytes
 from lib.reference_video import render_prompt_for_backend
 from lib.reference_video.errors import MissingReferenceError, RequestPayloadTooLargeError
-from lib.reference_video.limits import PROVIDER_MAX_DURATION, PROVIDER_MAX_REFS
 from lib.script_models import ReferenceResource
 from lib.thumbnail import extract_video_thumbnail
 from server.services.generation_tasks import get_media_generator, get_project_manager
@@ -58,29 +61,6 @@ def _resolve_unit_references(
     if missing:
         raise MissingReferenceError(missing=missing)
     return resolved
-
-
-# 供应商能力上限（数值来源：lib/reference_video/limits.py 单一真相源）。
-# 这里保留 (provider, model_prefix) 粒度是因为同一 provider 不同模型上限一致，
-# 单键即可命中；若未来出现 provider 内差异，再扩展 model_prefix。
-_PROVIDER_LIMITS: dict[tuple[str, str | None], dict[str, int]] = {
-    ("gemini", "veo"): {"max_refs": PROVIDER_MAX_REFS["gemini"], "max_duration": PROVIDER_MAX_DURATION["gemini"]},
-    ("openai", "sora"): {"max_refs": PROVIDER_MAX_REFS["openai"], "max_duration": PROVIDER_MAX_DURATION["openai"]},
-    ("grok", None): {"max_refs": PROVIDER_MAX_REFS["grok"], "max_duration": PROVIDER_MAX_DURATION["grok"]},
-    ("ark", None): {"max_refs": PROVIDER_MAX_REFS["ark"], "max_duration": PROVIDER_MAX_DURATION["ark"]},
-}
-
-
-def _lookup_provider_limits(provider: str, model: str | None) -> dict[str, int]:
-    """查找供应商 / 模型对应的参考图 + duration 上限。找不到返回空 dict（不裁剪）。"""
-    provider = (provider or "").lower()
-    model = (model or "").lower()
-    for (p, prefix), limits in _PROVIDER_LIMITS.items():
-        if p != provider:
-            continue
-        if prefix is None or model.startswith(prefix):
-            return limits
-    return {}
 
 
 def _compress_references_to_tempfiles(
@@ -130,15 +110,19 @@ def _apply_provider_constraints(
     *,
     provider: str,
     model: str | None,
+    max_refs: int | None,
+    max_duration: int | None,
     references: list[Path],
     duration_seconds: int,
 ) -> tuple[list[Path], int, list[dict]]:
-    """按供应商上限裁剪 references / duration；回传 warnings（i18n key + 参数）。"""
+    """按供应商上限裁剪 references / duration；回传 warnings（i18n key + 参数）。
+
+    `max_refs` / `max_duration` 由调用方从 `ConfigResolver.video_capabilities_for_project`
+    取得（model 粒度，单一真相源）；任意一项为 None 表示不做对应裁剪。
+    """
     warnings: list[dict] = []
-    limits = _lookup_provider_limits(provider, model)
 
     new_duration = duration_seconds
-    max_duration = limits.get("max_duration")
     if max_duration is not None and duration_seconds > max_duration:
         new_duration = max_duration
         warnings.append(
@@ -153,7 +137,6 @@ def _apply_provider_constraints(
         )
 
     new_refs = list(references)
-    max_refs = limits.get("max_refs")
     if max_refs is not None and len(references) > max_refs:
         new_refs = references[:max_refs]
         # Sora 单图走专门的 warning key，其他走通用
@@ -212,19 +195,34 @@ async def execute_reference_video_task(
     provider_name = getattr(backend, "name", "") if backend else ""
     model_name = getattr(backend, "model", "") if backend else ""
 
-    # 4. Provider 特判：裁 refs + duration
+    # 4. 解析 model 粒度能力上限（单一真相源：model.supported_durations）。
+    #    失败时 fallback 到 None（不裁剪，交由 backend 自行报错），与
+    #    ScriptGenerator._fetch_video_capabilities 的口径保持一致。
+    max_refs: int | None = None
+    max_duration: int | None = None
+    try:
+        resolver = ConfigResolver(async_session_factory)
+        caps = await resolver.video_capabilities_for_project(project)
+        max_refs = caps.get("max_reference_images")
+        max_duration = caps.get("max_duration")
+    except (ValueError, SQLAlchemyError) as exc:
+        logger.info("无法解析 video_capabilities，跳过 executor clamp：%s", exc)
+
+    # 5. Provider 特判：裁 refs + duration
     base_duration = int(unit.get("duration_seconds") or 8)
     constrained_refs, effective_duration, warnings = _apply_provider_constraints(
         provider=provider_name,
         model=model_name,
+        max_refs=max_refs,
+        max_duration=max_duration,
         references=source_refs,
         duration_seconds=base_duration,
     )
 
-    # 5. 渲染 prompt（@→[图N]）
+    # 6. 渲染 prompt（@→[图N]）
     rendered_prompt = _render_unit_prompt(unit)
 
-    # 6. 压缩到临时文件（2048px/q=85）→ 首次调用
+    # 7. 压缩到临时文件（2048px/q=85）→ 首次调用
     tmp_refs: list[Path] = await asyncio.to_thread(_compress_references_to_tempfiles, constrained_refs)
     output_path: Path | None = None
     version = 0
@@ -263,7 +261,7 @@ async def execute_reference_video_task(
             with contextlib.suppress(Exception):
                 p.unlink(missing_ok=True)
 
-    # 7. 首帧缩略图
+    # 8. 首帧缩略图
     if output_path is None:
         raise RuntimeError("generate_video_async returned None output_path")
     thumb_dir = project_path / "reference_videos" / "thumbnails"
@@ -275,7 +273,7 @@ async def execute_reference_video_task(
         thumb_path.unlink(missing_ok=True)
         thumb_rel = None
 
-    # 8. 更新 unit.generated_assets（简单读改写 episode script）
+    # 9. 更新 unit.generated_assets（简单读改写 episode script）
     def _update_unit_assets():
         pm = get_project_manager()
         script = pm.load_script(project_name, script_file)

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -157,10 +157,14 @@ def test_render_unit_prompt_replaces_mentions_in_order():
 
 
 def test_apply_provider_constraints_veo_clamps_duration_and_refs():
+    # caps 由调用方从 ConfigResolver.video_capabilities_for_project 取得；
+    # 这里直接提供 model 级上限模拟已 resolve 的结果。
     refs = [Path(f"/tmp/ref{i}.png") for i in range(5)]
     new_refs, new_duration, warnings = _apply_provider_constraints(
         provider="gemini",
         model="veo-3.1-generate-preview",
+        max_refs=3,
+        max_duration=8,
         references=refs,
         duration_seconds=12,
     )
@@ -175,6 +179,8 @@ def test_apply_provider_constraints_sora_single_ref():
     new_refs, _, warnings = _apply_provider_constraints(
         provider="openai",
         model="sora-2",
+        max_refs=1,
+        max_duration=12,
         references=refs,
         duration_seconds=8,
     )
@@ -187,12 +193,50 @@ def test_apply_provider_constraints_ark_keeps_nine():
     new_refs, new_duration, warnings = _apply_provider_constraints(
         provider="ark",
         model="doubao-seedance-2-0-260128",
+        max_refs=9,
+        max_duration=15,
         references=refs,
         duration_seconds=12,
     )
     assert len(new_refs) == 9
     assert new_duration == 12
     assert warnings == []
+
+
+def test_apply_provider_constraints_none_caps_skip_clamp():
+    """当 ConfigResolver 解析失败（例如无 DB 的 CI 环境），调用方传 None →
+    不裁剪任何维度，把决策推到 backend 自己去报错。"""
+    refs = [Path(f"/tmp/ref{i}.png") for i in range(5)]
+    new_refs, new_duration, warnings = _apply_provider_constraints(
+        provider="grok",
+        model="grok-imagine-video",
+        max_refs=None,
+        max_duration=None,
+        references=refs,
+        duration_seconds=30,
+    )
+    assert new_refs == refs
+    assert new_duration == 30
+    assert warnings == []
+
+
+def test_apply_provider_constraints_custom_provider_model_granular():
+    """Custom provider 场景：max_duration 由自定义 model.supported_durations 决定，
+    无需 PROVIDER_MAX_DURATION 常量查表。用 max_duration=10 模拟 `supported_durations=[4,8,10]`
+    的 custom model，传入 duration=18 应被裁到 10。"""
+    refs = [Path(f"/tmp/ref{i}.png") for i in range(2)]
+    new_refs, new_duration, warnings = _apply_provider_constraints(
+        provider="custom-openai",
+        model="my-custom-video",
+        max_refs=9,
+        max_duration=10,
+        references=refs,
+        duration_seconds=18,
+    )
+    assert new_refs == refs
+    assert new_duration == 10
+    assert any(w["key"] == "ref_duration_exceeded" for w in warnings)
+    assert not any(w["key"] == "ref_too_many_images" for w in warnings)
 
 
 @pytest.mark.asyncio
@@ -431,3 +475,89 @@ async def test_execute_reference_video_task_payload_too_large_retries(tmp_path: 
     )
     assert call_count["n"] == 2
     assert result["resource_id"] == "E1U1"
+
+
+@pytest.mark.asyncio
+async def test_execute_reference_video_task_clamps_via_resolver(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """回归守门：executor 的 duration/refs clamp 必须走 ConfigResolver 的 model 粒度 caps，
+    不再走老的 PROVIDER_MAX_DURATION provider 级常量。
+
+    Monkeypatch `ConfigResolver.video_capabilities_for_project` 返自定义 caps
+    (max_duration=6, max_reference_images=1)，传入 duration_seconds=15 / 2 张 refs，
+    期望 generate_video_async 实际收到 duration=6 且 reference_images 只有 1 张。
+    """
+    proj_dir = _write_project(tmp_path)
+
+    # 改造 unit 让它有 2 张 refs + 15s duration，便于验证 clamp
+    script_path = proj_dir / "scripts" / "episode_1.json"
+    script = json.loads(script_path.read_text(encoding="utf-8"))
+    script["video_units"][0]["duration_seconds"] = 15
+    # characters 已有 张三 sheet；scenes 已有 酒馆 sheet —— refs 已是 2 张
+    script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
+
+    from server.services import reference_video_tasks as rvt
+
+    fake_pm = MagicMock()
+    fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
+    fake_pm.get_project_path.return_value = proj_dir
+    fake_pm.load_script.side_effect = lambda *_a: json.loads(script_path.read_text(encoding="utf-8"))
+    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
+
+    captured: dict = {}
+
+    async def _fake_generate_video_async(**kwargs):
+        captured.update(kwargs)
+        out = proj_dir / "reference_videos" / "E1U1.mp4"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\x00")
+        return out, 1, None, None
+
+    fake_generator = MagicMock()
+    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
+    fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-17T10:00:00"}]}
+    fake_video_backend = MagicMock()
+    fake_video_backend.name = "custom-openai"
+    fake_video_backend.model = "my-custom-video"
+    fake_generator._video_backend = fake_video_backend
+
+    async def _fake_get_media_generator(*_a, **_kw):
+        return fake_generator
+
+    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+
+    async def _fake_extract(*_a, **_k):
+        return True
+
+    monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
+
+    # 注入假 caps —— 模拟 "supported_durations=[2,4,6]", max_reference_images=1
+    # 的 custom model。用 AsyncMock 直接替换实例方法。
+    from lib.config.resolver import ConfigResolver
+
+    async def _fake_caps(self, project):
+        return {
+            "provider_id": "custom-openai",
+            "model": "my-custom-video",
+            "supported_durations": [2, 4, 6],
+            "max_duration": 6,
+            "max_reference_images": 1,
+            "source": "custom",
+            "default_duration": None,
+            "content_mode": "reference_video",
+            "generation_mode": "reference_video",
+        }
+
+    monkeypatch.setattr(ConfigResolver, "video_capabilities_for_project", _fake_caps)
+
+    await rvt.execute_reference_video_task(
+        "demo",
+        "E1U1",
+        {"script_file": "scripts/episode_1.json"},
+        user_id="u1",
+    )
+
+    assert captured["duration_seconds"] == 6
+    assert len(captured["reference_images"]) == 1

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -561,3 +561,189 @@ async def test_execute_reference_video_task_clamps_via_resolver(
 
     assert captured["duration_seconds"] == 6
     assert len(captured["reference_images"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_reference_video_task_prompt_matches_clipped_refs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """回归守门：prompt 里的 [图N] 索引必须与 backend 收到的 reference_images 对齐。
+
+    原实现用整条 `unit.references` 渲染 prompt，裁剪后 [图N] 会越界（例如 5 张裁到 1 张，
+    prompt 里仍出现 [图5]）。修复后应当按 `constrained_refs` 长度重新 slice references。
+    """
+    proj_dir = _write_project(tmp_path)
+
+    # 新增一个道具 sheet，让 unit 拥有 3 张 refs（1 character + 1 scene + 1 prop）。
+    (proj_dir / "props").mkdir()
+    (proj_dir / "props" / "瓶子.png").write_bytes(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x04\x00\x00\x00\x04"
+        b"\x08\x02\x00\x00\x00&\x93\t)\x00\x00\x00\x13IDATx\x9cc<\x91b\xc4\x00"
+        b"\x03Lp\x16^\x0e\x00E\xf6\x01f\xac\xf5\x15\xfa\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    project_path = proj_dir / "project.json"
+    project = json.loads(project_path.read_text(encoding="utf-8"))
+    project["props"] = {"瓶子": {"description": "x", "prop_sheet": "props/瓶子.png"}}
+    project_path.write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
+
+    script_path = proj_dir / "scripts" / "episode_1.json"
+    script = json.loads(script_path.read_text(encoding="utf-8"))
+    script["video_units"][0]["shots"] = [{"duration": 3, "text": "Shot 1 (3s): @张三 在 @酒馆 拿起 @瓶子"}]
+    script["video_units"][0]["references"] = [
+        {"type": "character", "name": "张三"},
+        {"type": "scene", "name": "酒馆"},
+        {"type": "prop", "name": "瓶子"},
+    ]
+    script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
+
+    from server.services import reference_video_tasks as rvt
+
+    fake_pm = MagicMock()
+    fake_pm.load_project.return_value = json.loads(project_path.read_text(encoding="utf-8"))
+    fake_pm.get_project_path.return_value = proj_dir
+    fake_pm.load_script.side_effect = lambda *_a: json.loads(script_path.read_text(encoding="utf-8"))
+    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
+
+    captured: dict = {}
+
+    async def _fake_generate_video_async(**kwargs):
+        captured.update(kwargs)
+        out = proj_dir / "reference_videos" / "E1U1.mp4"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\x00")
+        return out, 1, None, None
+
+    fake_generator = MagicMock()
+    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
+    fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-17T10:00:00"}]}
+    fake_video_backend = MagicMock()
+    fake_video_backend.name = "openai"
+    fake_video_backend.model = "sora-2"
+    fake_generator._video_backend = fake_video_backend
+
+    async def _fake_get_media_generator(*_a, **_kw):
+        return fake_generator
+
+    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+
+    async def _fake_extract(*_a, **_k):
+        return True
+
+    monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
+
+    # Sora 上限 1 张（provider_id=openai, model=sora-2）
+    from lib.config.resolver import ConfigResolver
+
+    async def _fake_caps(self, project):
+        return {
+            "provider_id": "openai",
+            "model": "sora-2",
+            "supported_durations": [4, 8, 12],
+            "max_duration": 12,
+            "max_reference_images": 1,
+            "source": "registry",
+            "default_duration": None,
+            "content_mode": "reference_video",
+            "generation_mode": "reference_video",
+        }
+
+    monkeypatch.setattr(ConfigResolver, "video_capabilities_for_project", _fake_caps)
+
+    await rvt.execute_reference_video_task(
+        "demo",
+        "E1U1",
+        {"script_file": "scripts/episode_1.json"},
+        user_id="u1",
+    )
+
+    # 3 张裁到 1 张，prompt 里只能出现 [图1]，不能出现 [图2]/[图3]
+    assert len(captured["reference_images"]) == 1
+    prompt = captured["prompt"]
+    assert "[图1]" in prompt
+    assert "[图2]" not in prompt
+    assert "[图3]" not in prompt
+    # 被裁掉的 @酒馆 / @瓶子 按 render_prompt_for_backend 的 "未注册保留原样" fallback 保留
+    assert "@酒馆" in prompt or "@瓶子" in prompt
+
+
+@pytest.mark.asyncio
+async def test_execute_reference_video_task_skips_clamp_when_backend_model_diverges(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """回归守门：caps 解析出的 model 与真实 backend.model 不一致时（自定义 provider
+    model 禁用回退的典型场景）必须 skip clamp，避免按错误模型的上限裁剪。
+    """
+    proj_dir = _write_project(tmp_path)
+
+    script_path = proj_dir / "scripts" / "episode_1.json"
+    script = json.loads(script_path.read_text(encoding="utf-8"))
+    script["video_units"][0]["duration_seconds"] = 20
+    script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
+
+    from server.services import reference_video_tasks as rvt
+
+    fake_pm = MagicMock()
+    fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
+    fake_pm.get_project_path.return_value = proj_dir
+    fake_pm.load_script.side_effect = lambda *_a: json.loads(script_path.read_text(encoding="utf-8"))
+    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
+
+    captured: dict = {}
+
+    async def _fake_generate_video_async(**kwargs):
+        captured.update(kwargs)
+        out = proj_dir / "reference_videos" / "E1U1.mp4"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\x00")
+        return out, 1, None, None
+
+    fake_generator = MagicMock()
+    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
+    fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-17T10:00:00"}]}
+    fake_video_backend = MagicMock()
+    # 模拟 fallback：project.json 记录的是 "禁用模型"，backend 实际回退到 "默认模型"
+    fake_video_backend.name = "custom-openai"
+    fake_video_backend.model = "active-default-video"
+    fake_generator._video_backend = fake_video_backend
+
+    async def _fake_get_media_generator(*_a, **_kw):
+        return fake_generator
+
+    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+
+    async def _fake_extract(*_a, **_k):
+        return True
+
+    monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
+
+    # caps 解析出来的 model 是 project.json 里那个（已禁用）的：与 backend.model 不一致
+    from lib.config.resolver import ConfigResolver
+
+    async def _fake_caps(self, project):
+        return {
+            "provider_id": "custom-openai",
+            "model": "disabled-old-video",  # ← 与 backend.model 不一致
+            "supported_durations": [2, 4],
+            "max_duration": 4,
+            "max_reference_images": 1,
+            "source": "custom",
+            "default_duration": None,
+            "content_mode": "reference_video",
+            "generation_mode": "reference_video",
+        }
+
+    monkeypatch.setattr(ConfigResolver, "video_capabilities_for_project", _fake_caps)
+
+    await rvt.execute_reference_video_task(
+        "demo",
+        "E1U1",
+        {"script_file": "scripts/episode_1.json"},
+        user_id="u1",
+    )
+
+    # skip clamp：duration 保持 20（未被 caps.max_duration=4 裁到 4）
+    assert captured["duration_seconds"] == 20
+    # refs 也保留原数（2 张，未被 caps.max_reference_images=1 裁到 1）
+    assert len(captured["reference_images"]) == 2


### PR DESCRIPTION
## Summary

三个独立 follow-up 合并到一个 PR（都围绕 reference-video，低风险 cleanup）：

- **#375** PR8 简化审查遗留 3 条
  - A. ReferencePanel grip/× 按钮 `[@media(hover:none)]:opacity-100`，触屏不再无法触达
  - B. ReferenceVideoCanvas 小屏 tab 按钮加 `id`/`aria-controls`，panel 容器加 `role=tabpanel`/`aria-labelledby`
  - C. ReferenceVideoCard `pickerOpen=false` 路径用 `useMemo` 缓存高亮节点，长 prompt 打字不再每字符重跑 `renderHighlightedTokens`
- **#377** executor duration clamp 迁移至 `ConfigResolver.video_capabilities_for_project`（model 粒度单一真相源），删除 `PROVIDER_MAX_DURATION` provider 级常量。同 provider 多 model 天然隔离、custom provider 自动走 `supported_durations`，从此不再有双源漂移风险
- **#382** `TimelineCanvas` key 从 `epNum` 改为 \`\${projectName}::\${epNum}\`，消除跨项目同集号切换时 `useState`/`useRef` 残留（与 PR #378 的 `ReferenceVideoCanvas` 修复对齐）

## Test plan

自动化（已跑）：

- [x] \`uv run pytest tests/server/test_reference_video_tasks.py\` → 16 pass（新增 3 条：None caps / custom provider model 粒度 / executor resolver 集成）
- [x] \`uv run pytest -k \"reference_branch or script_generator or projects_router\"\` → 53 pass
- [x] \`uv run ruff check + format --check\` → 3 files clean
- [x] \`cd frontend && pnpm check\` → typecheck + lint + 388 vitest pass

手工回归（reviewer 请酌情执行）：

- [ ] iPad Safari（或 DevTools iPad 仿真）：ReferencePanel pill 无悬停可见 grip/×，触屏可点 × 删除、长按 grip 拖拽
- [ ] Chrome axe DevTools 在容器 <896px（手机视口）对 ReferenceVideoCanvas 跑一遍，确认无 \"Tab has no accessible relationship with tabpanel\" 告警
- [ ] React DevTools Profiler：≥500 字 + 数个 mention 的 prompt，连续打字 20 keystroke，commit <5ms
- [ ] 切 \`default_video_backend\` 到 \`grok/grok-imagine-video\`，unit duration_seconds=30 跑 generate：后端日志 \`ref_duration_exceeded\` warning，实际请求 duration=15
- [ ] 项目 A↔B 同 episode 号切换：TimelineCanvas 本地 state（选中 scene、滚动位置等）初始化干净

## 关闭的 issue

Closes #375, closes #377, closes #382.