### PR TITLE
fix(popover): 修复 ref 挂父节点时弹框定位到视窗左上角

### DIFF
--- a/frontend/src/components/ui/Popover.test.tsx
+++ b/frontend/src/components/ui/Popover.test.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Popover } from "./Popover";
 
 class MockResizeObserver {
@@ -17,6 +18,27 @@ function RefHarness({ onClose }: { onClose?: () => void }) {
         anchor
       </button>
       <Popover open anchorRef={anchorRef} onClose={onClose}>
+        <div data-testid="panel-content">hello</div>
+      </Popover>
+    </div>
+  );
+}
+
+/**
+ * Parent-as-anchor pattern (GlobalHeader / ProjectsPage 等业务实际用法):
+ * ref 挂在 Popover 的父节点上，而不是兄弟节点。
+ * 此模式下 Popover 作为子 fiber 的 layout effect 在父 fiber 的 ref attach 之前执行,
+ * 如果 effect 只跑一次，会读到 null 并导致 floating-ui 无 reference、定位到左上角。
+ */
+function ParentRefHarness() {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  return (
+    <div ref={anchorRef} data-testid="parent-anchor">
+      <button type="button" onClick={() => setOpen(true)}>
+        open
+      </button>
+      <Popover open={open} anchorRef={anchorRef} onClose={() => setOpen(false)}>
         <div data-testid="panel-content">hello</div>
       </Popover>
     </div>
@@ -134,6 +156,38 @@ describe("Popover", () => {
     // floating-ui writes top/left to 0 and uses transform for position
     expect(panel.style.top).toBe("0px");
     expect(panel.style.left).toBe("0px");
+  });
+
+  it("binds reference when opening a Popover whose anchorRef is on a parent node (regression: left-top anchoring)", async () => {
+    // 业务里最常见的用法——ref 挂在父节点上，open 从 false 切到 true。
+    // 如果 Popover 的 layout effect 只跑一次，首次执行时父节点 ref 还没 attach
+    // (React commit phase post-order)，setReference(null) 就被锁死，
+    // floating-ui 没有 reference，面板停在左上角 (transform 为空)。
+    //
+    // jsdom 默认 getBoundingClientRect 全 0，绑定与否 transform 都是 translate(0,0)。
+    // 给 anchor 节点注入一个非零 rect，差异才能显现：绑定成功时 transform
+    // 按非零锚点计算；未绑定时 floating-ui 默认 translate(0,0)。
+    vi.spyOn(HTMLDivElement.prototype, "getBoundingClientRect").mockReturnValue({
+      x: 300,
+      y: 400,
+      width: 80,
+      height: 40,
+      top: 400,
+      left: 300,
+      right: 380,
+      bottom: 440,
+      toJSON() {
+        return this;
+      },
+    } as DOMRect);
+
+    const user = userEvent.setup();
+    render(<ParentRefHarness />);
+    await user.click(screen.getByText("open"));
+    const panel = screen.getByTestId("panel-content").parentElement!;
+    // 绑定成功时 floating-ui 至少会输出非零 translate。
+    expect(panel.style.transform).not.toBe("translate(0px, 0px)");
+    expect(panel.style.transform).not.toBe("");
   });
 
   it("accepts maxHeight prop without throwing (size middleware opt-in)", () => {

--- a/frontend/src/components/ui/Popover.tsx
+++ b/frontend/src/components/ui/Popover.tsx
@@ -104,14 +104,15 @@ export function Popover({
   const dismiss = useDismiss(context, { outsidePress: true, escapeKey: true });
   const { getFloatingProps } = useInteractions([dismiss]);
 
-  // 在布局阶段同步 reference——若放在 useEffect（paint 之后）里，open=true 首次
-  // 挂载的弹层会先以未绑定 reference 的 floating-ui 默认坐标渲染一帧再跳到正位。
-  // anchorRef 模式只在 mount 时读一次 .current（仓库所有现有消费方都是这种静态
-  // 引用）；动态 anchor（caret-tracking 等）走 anchorElement，是 state，变化会
-  // 触发本组件 re-render 从而同步。
+  // 在布局阶段同步 reference——paint 之前绑定避免首帧错位。
+  // 依赖里必须包含 open：常见用法是 <div ref={anchorRef}>…<Popover anchorRef={anchorRef}/></div>
+  // （ref 挂父节点），而 React commit phase 是 post-order，子 Popover 的 layout effect
+  // 早于父节点的 ref attach，首次执行时 anchorRef.current 仍是 null。若依赖只含
+  // 稳定引用，setReference(null) 就被锁死，floating-ui 无 reference 把面板钉在视窗
+  // 左上角。把 open 加进依赖后，open: false→true 时 effect 重跑，此时父 ref 早已 attach。
   useLayoutEffect(() => {
     refs.setReference(anchorElement ?? anchorRef?.current ?? null);
-  }, [anchorElement, anchorRef, refs]);
+  }, [open, anchorElement, anchorRef, refs]);
 
   if (!open) return null;
 


### PR DESCRIPTION
## Summary
- 修复 Popover 迁移到 @floating-ui/react (#381) 后，业务里 10+ 消费方（GlobalHeader/ProjectsPage 等）弹框全部钉在视窗左上角的回归
- 根因：`useLayoutEffect` 依赖都是稳定引用只在 initial mount 执行一次；业务 ref 挂父节点 (`<div ref={anchorRef}>…<Popover anchorRef/></div>`)，React commit phase post-order 让 Popover 子 fiber 的 layout effect 早于父节点 ref attach，`setReference(null)` 被锁死，floating-ui 无 reference 把面板钉在 `top:0/left:0`
- 修复：把 `open` 加进依赖，open: false→true 时 effect 重跑，此时父 ref 已 attach；更新注释说明时序陷阱
- 新增 parent-as-anchor 回归测试，mock `getBoundingClientRect` 返回非零 rect 区分「绑定成功」vs「未绑定」

## Test plan
- [x] `pnpm check` 通过：typecheck + 394 测试 / 59 文件
- [x] 新回归测试在修复前失败（`transform: translate(0px, 0px)`）、修复后通过
- [ ] 浏览器手动验证：GlobalHeader 的 TaskHud / UsageDrawer / NotificationDrawer / ExportDialog 点开后正确锚定到按钮下方