### PR TITLE
fix(reference-video): Grok 生成默认 1080p 被 xai_sdk 拒绝

### DIFF
--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -23,7 +23,7 @@ from lib.reference_video import render_prompt_for_backend
 from lib.reference_video.errors import MissingReferenceError, RequestPayloadTooLargeError
 from lib.script_models import ReferenceResource
 from lib.thumbnail import extract_video_thumbnail
-from server.services.generation_tasks import get_media_generator, get_project_manager
+from server.services.generation_tasks import DEFAULT_VIDEO_RESOLUTION, get_media_generator, get_project_manager
 
 logger = logging.getLogger(__name__)
 
@@ -235,6 +235,14 @@ async def execute_reference_video_task(
         duration_seconds=base_duration,
     )
 
+    # 5.1 解析 resolution（与分镜视频流 generation_tasks.py 保持同一优先级：
+    #     project.video_model_settings[model].resolution > DEFAULT_VIDEO_RESOLUTION[provider]）。
+    #     若直接回退到 MediaGenerator 的硬编码默认 "1080p"，会被 xai_sdk 拒绝
+    #     （VideoResolutionMap 仅支持 480p/720p）。
+    video_model_settings = project.get("video_model_settings") or {}
+    model_resolution_setting = video_model_settings.get(model_name, {}) if model_name else {}
+    resolution = model_resolution_setting.get("resolution") or DEFAULT_VIDEO_RESOLUTION.get(provider_name, "1080p")
+
     # 6. 渲染 prompt（@→[图N]）。必须按 `constrained_refs` 的长度裁 `unit.references`
     #    再渲染，保证 [图N] 的 1-based 索引与 backend 实际收到的 reference_images
     #    长度严格对齐；否则裁剪后的 `@clipped_name` 会被替成 `[图N]` 指向不存在的图。
@@ -258,6 +266,7 @@ async def execute_reference_video_task(
                 reference_images=tmp_refs,
                 aspect_ratio=project.get("aspect_ratio", "9:16"),
                 duration_seconds=effective_duration,
+                resolution=resolution,
             )
         except RequestPayloadTooLargeError:
             # 二次压缩重试（1024px/q=70）
@@ -277,6 +286,7 @@ async def execute_reference_video_task(
                 reference_images=tmp_refs,
                 aspect_ratio=project.get("aspect_ratio", "9:16"),
                 duration_seconds=effective_duration,
+                resolution=resolution,
             )
     finally:
         for p in tmp_refs:

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -295,6 +295,127 @@ async def test_execute_reference_video_task_success(tmp_path: Path, monkeypatch:
 
 
 @pytest.mark.asyncio
+async def test_execute_reference_video_task_grok_uses_provider_default_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression: Grok 视频生成必须用 720p（xai_sdk 的 VideoResolutionMap 只接受 480p/720p；
+    参考视频 executor 若回退到 MediaGenerator 默认 1080p，会在 SDK 抛 `Invalid video resolution 1080p`）。
+    Executor 必须与生产分镜视频流一致，按 `DEFAULT_VIDEO_RESOLUTION[grok]=720p` 解析。
+    """
+    proj_dir = _write_project(tmp_path)
+
+    from server.services import reference_video_tasks as rvt
+
+    fake_pm = MagicMock()
+    fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
+    fake_pm.get_project_path.return_value = proj_dir
+    fake_pm.load_script.side_effect = lambda *_a: json.loads(
+        (proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8")
+    )
+    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
+
+    captured: dict = {}
+
+    async def _fake_generate_video_async(**kwargs):
+        captured.update(kwargs)
+        out = proj_dir / "reference_videos" / "E1U1.mp4"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\x00\x00\x00 ftypmp42")
+        return out, 1, None, None
+
+    fake_generator = MagicMock()
+    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
+    fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-21T22:00:00"}]}
+    fake_video_backend = MagicMock()
+    fake_video_backend.name = "grok"
+    fake_video_backend.model = "grok-imagine-video"
+    fake_generator._video_backend = fake_video_backend
+
+    async def _fake_get_media_generator(*_a, **_kw):
+        return fake_generator
+
+    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+
+    async def _fake_extract(*_a, **_k):
+        return True
+
+    monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
+
+    await rvt.execute_reference_video_task(
+        "demo",
+        "E1U1",
+        {"script_file": "scripts/episode_1.json"},
+        user_id="u1",
+    )
+
+    assert captured.get("resolution") == "720p", (
+        f"Grok executor 必须显式传 720p，否则 MediaGenerator 默认 1080p 会被 xai_sdk 拒绝。"
+        f"实际收到: {captured.get('resolution')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_reference_video_task_respects_project_model_settings_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """project.video_model_settings[model].resolution 必须覆盖 provider 默认值，
+    与 generation_tasks.py 的分镜视频流保持一致的优先级。"""
+    proj_dir = _write_project(tmp_path)
+    project_path = proj_dir / "project.json"
+    project = json.loads(project_path.read_text(encoding="utf-8"))
+    project["video_model_settings"] = {"doubao-seedance-2-0-260128": {"resolution": "1080p"}}
+    project_path.write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
+
+    from server.services import reference_video_tasks as rvt
+
+    fake_pm = MagicMock()
+    fake_pm.load_project.return_value = json.loads(project_path.read_text(encoding="utf-8"))
+    fake_pm.get_project_path.return_value = proj_dir
+    fake_pm.load_script.side_effect = lambda *_a: json.loads(
+        (proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8")
+    )
+    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
+
+    captured: dict = {}
+
+    async def _fake_generate_video_async(**kwargs):
+        captured.update(kwargs)
+        out = proj_dir / "reference_videos" / "E1U1.mp4"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\x00\x00\x00 ftypmp42")
+        return out, 1, None, None
+
+    fake_generator = MagicMock()
+    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
+    fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-21T22:00:00"}]}
+    fake_video_backend = MagicMock()
+    fake_video_backend.name = "ark"
+    fake_video_backend.model = "doubao-seedance-2-0-260128"
+    fake_generator._video_backend = fake_video_backend
+
+    async def _fake_get_media_generator(*_a, **_kw):
+        return fake_generator
+
+    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+
+    async def _fake_extract(*_a, **_k):
+        return True
+
+    monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
+
+    await rvt.execute_reference_video_task(
+        "demo",
+        "E1U1",
+        {"script_file": "scripts/episode_1.json"},
+        user_id="u1",
+    )
+
+    assert captured.get("resolution") == "1080p"
+
+
+@pytest.mark.asyncio
 async def test_execute_reference_video_task_missing_reference_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     proj_dir = _write_project(tmp_path)
     (proj_dir / "characters" / "张三.png").unlink()


### PR DESCRIPTION
## Summary

- reference_video executor 调用 `generate_video_async` 时漏传 `resolution`，退回到 MediaGenerator 硬编码默认 `"1080p"`，被 xai_sdk `VideoResolutionMap` 拒绝（仅支持 `480p`/`720p`），生成任务失败并抛 `ValueError: Invalid video resolution 1080p`。
- 复用 `generation_tasks.py` 分镜视频流的两级优先级 `project.video_model_settings[model].resolution > DEFAULT_VIDEO_RESOLUTION[provider]`，使 Grok 默认得到 `720p`，与分镜视频流共享同一真相源。
- 新增 2 条回归测试：Grok backend → `720p` 默认、`video_model_settings[model].resolution` 可覆盖。

## Root cause

`server/services/reference_video_tasks.py:254,273` 调用 `generator.generate_video_async(...)` 未传 `resolution` → 命中 `lib/media_generator.py:337` 默认 `"1080p"` → 传给 xai_sdk (`.venv/.../xai_sdk/types/video.py:36` `VideoResolutionMap` 仅支持 `480p`/`720p`)。

## Fix scope

- `server/services/reference_video_tasks.py`
  - 新 import `DEFAULT_VIDEO_RESOLUTION`
  - 新增步骤 5.1 解析 resolution
  - 两处 `generate_video_async`（首调 + `RequestPayloadTooLargeError` 二次压缩重试）都传 `resolution=resolution`

## Test plan

- [x] `uv run python -m pytest tests/server/test_reference_video_tasks.py` — 20 passed（含 2 条新增回归）
- [x] `uv run python -m pytest tests/server/` — 50 passed
- [x] `uv run python -m pytest tests/server/test_reference_video_e2e_backend.py tests/integration/test_reference_video_e2e.py tests/server/test_reference_videos_router.py` — 18 passed
- [x] `uv run ruff check` + `ruff format --check` — All checks passed
- [ ] 手工端到端：切 Grok + grok-imagine-video，触发参考生视频单元生成，确认不再报 `Invalid video resolution 1080p`