### PR TITLE
fix(cost-calculator): 修正预设供应商文本模型定价

### DIFF
--- a/docs/google-genai-docs/pricing.md
+++ b/docs/google-genai-docs/pricing.md
@@ -1,0 +1,1019 @@
+> [!IMPORTANT]
+> We have updated our [Terms of Service](https://ai.google.dev/gemini-api/terms).
+
+Start building free of charge with generous limits, then scale up with
+prepaid then pay-as-you-go pricing for your production ready applications.
+
+### Free
+
+For developers and small projects getting started with the Gemini API.
+
+- check_circleLimited access to certain models
+- check_circleFree input \& output tokens
+- check_circleGoogle AI Studio access
+- check_circleContent used to improve our products[\*](https://ai.google.dev/gemini-api/terms)
+
+[Get started for Free](https://aistudio.google.com)
+
+### Paid
+
+For production applications that require higher volumes and advanced features.
+
+- check_circleHigher rate limits for production deployments
+- check_circleAccess to Context caching
+- check_circleBatch API (50% cost reduction)
+- check_circleAccess to Google's most advanced models
+- check_circleContent **not** used to improve our products[\*](https://ai.google.dev/gemini-api/terms)
+
+[Upgrade to Paid](https://aistudio.google.com/api-keys)
+
+### Enterprise
+
+For large-scale deployments with custom needs for security, support, and compliance, powered by [Vertex AI](https://cloud.google.com/vertex-ai).
+
+- check_circleAll features in Paid, plus optional access to:
+- check_circleDedicated support channels
+- check_circleAdvanced security \& compliance
+- check_circleProvisioned throughput
+- check_circleVolume-based discounts (based on usage)
+- check_circleML ops, model garden and more
+
+[Contact Sales](https://cloud.google.com/contact)
+
+## Gemini 3.1 Pro Preview
+
+*`gemini-3.1-pro-preview` and `gemini-3.1-pro-preview-customtools`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com/prompts/new_chat?model=gemini-3.1-pro-preview)
+
+The latest performance, intelligence, and usability improvements to the best
+model family in the world for multimodal understanding,
+agentic capabilities, and vibe-coding.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $2.00, prompts \<= 200k tokens $4.00, prompts \> 200k tokens |
+| Output price (including thinking tokens) | Not available | $12.00, prompts \<= 200k tokens $18.00, prompts \> 200k |
+| Context caching price | Not available | $0.20, prompts \<= 200k tokens $0.40, prompts \> 200k $4.50 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search^\*^ | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Grounding with Google Maps | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $1.00, prompts \<= 200k tokens $2.00, prompts \> 200k tokens |
+| Output price (including thinking tokens) | Not available | $6.00, prompts \<= 200k tokens $9.00, prompts \> 200k |
+| Context caching price | Not available | $0.20, prompts \<= 200k tokens $0.40, prompts \> 200k $4.50 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search^\*^ | Not available | 5,000 RPD (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Grounding with Google Maps | Not available | 5,000 RPD (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Flex
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $1.00, prompts \<= 200k tokens $2.00, prompts \> 200k tokens |
+| Output price (including thinking tokens) | Not available | $6.00, prompts \<= 200k tokens $9.00, prompts \> 200k |
+| Context caching price | Not available | $0.20, prompts \<= 200k tokens $0.40, prompts \> 200k $4.50 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search^\*^ | Not available | 5,000 RPD (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Grounding with Google Maps | Not available | 5,000 RPD (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Priority
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $3.60, prompts \<= 200k tokens $7.20, prompts \> 200k tokens |
+| Output price (including thinking tokens) | Not available | $21.60, prompts \<= 200k tokens $32.40, prompts \> 200k |
+| Context caching price | Not available | $0.36, prompts \<= 200k tokens $0.72, prompts \> 200k $8.10 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search^\*^ | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Grounding with Google Maps | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+^\*^ A customer-submitted request to Gemini may result in one or more
+queries to Google Search. You will be charged for each individual search query
+performed.
+
+## Gemini 3.1 Flash-Lite Preview
+
+*`gemini-3.1-flash-lite-preview`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com/prompts/new_chat?model=gemini-3.1-flash-lite-preview)
+
+Our most cost-efficient model, optimized for high-volume agentic tasks,
+translation, and simple data processing.
+
+Preview models may change before becoming stable and have more restrictive rate
+limits.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.25 (text / image / video) $0.50 (audio) |
+| Output price (including thinking tokens) | Free of charge | $1.50 |
+| Context caching price | Not available | $0.025 (text / image / video) $0.05 (audio) $1.00 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search^\*^ | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Grounding with Google Maps | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.125 (text / image / video) $0.25 (audio) |
+| Output price (including thinking tokens) | Free of charge | $0.75 |
+| Context caching price | Not available | $0.0125 (text / image / video) $0.025 (audio) $0.50 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search^\*^ | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Grounding with Google Maps | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Flex
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.125 (text / image / video) $0.25 (audio) |
+| Output price (including thinking tokens) | Free of charge | $0.75 |
+| Context caching price | Not available | $0.0125 (text / image / video) $0.025 (audio) $0.50 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search^\*^ | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Grounding with Google Maps | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Priority
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.45 (text / image / video) $0.90 (audio) |
+| Output price (including thinking tokens) | Free of charge | $2.70 |
+| Context caching price | Not available | $0.045 (text / image / video) $0.09 (audio) $1.80 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search^\*^ | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Grounding with Google Maps | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+^\*^ A customer-submitted request to Gemini may result in one or more
+queries to Google Search. You will be charged for each individual search query
+performed.
+
+## Gemini 3.1 Flash Live Preview
+
+*`gemini-3.1-flash-live-preview`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com/prompts/new_chat?model=gemini-3.1-flash-live-preview)
+
+Our low-latency, audio-to-audio model optimized for real-time dialogue with
+acoustic nuance detection, numeric precision, and multimodal awareness.
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.75 (text) $3.00 or $0.005/min (audio) $1.00 or $0.002/min (image/video) |
+| Output price (including thinking tokens) | Free of charge | $4.50 (text) $12.00 or $0.018/min (audio) |
+| Grounding with Google Search^\*^ | Supported | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+^\*^ A customer-submitted request to Gemini may result in one or more
+queries to Google Search. You will be charged for each individual search query
+performed.
+
+## Gemini 3.1 Flash Image Preview 🍌
+
+*`gemini-3.1-flash-image-preview`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com/prompts/new_chat?model=gemini-3.1-flash-image-preview)
+
+Designed for speed and efficiency, the Gemini 3.1 Flash Image generation model is
+effective for quick, interactive responses and high throughput.
+
+Preview models may change before becoming stable and have more restrictive rate
+limits.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.50 (text/image) |
+| Output price | Not available | $3 (text and thinking) $60.00 (images) Equivalent to $0.045 per 0.5K image^\*^ $0.067 per 1K image^\*^, $0.101 per 2K image^\*^, and $0.151 per 4K image^\*^. |
+| Grounding with Google Search^\*\*^ | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries for text and image-based grounding. |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.25 (text, image) |
+| Output price | Not available | $1.50 (text and thinking) $30.00 (images) Equivalent to $0.022 per 0.5K image^\*^ $0.034 per 1K image^\*^, $0.050 per 2K image^\*^, and $0.076 per 4K image^\*^. |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+^\*^ Image output is priced at $60 per 1,000,000 tokens.
+Output images at 0.5K (512px) consume 747 tokens and are equivalent to $0.045 per
+image. Output images at 1K (1024x1024px) consume 1120 tokens and are equivalent
+to $0.067 per image. Output images at 2K (2048x2048px) consume 1680 tokens and
+are equivalent to $0.101 per image. Output images at 4K (4096x4096px) consume
+2520 tokens and are equivalent to $0.151 per image.
+
+^\*\*^ A customer-submitted request to Gemini may result in one or more
+queries to Google Search. You will be charged for each individual search query
+performed. Retrieved context (text or images) provided by Grounding with Google
+Search is not charged as input tokens.
+
+## Gemini 3.1 Flash TTS Preview
+
+*`gemini-3.1-flash-tts-preview`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com/prompts/new_chat?model=gemini-3.1-flash-tts-preview)
+
+Our 3.1 Flash Text-to-Speech audio model optimized for price-performant,
+low-latency, controllable speech generation.
+
+Preview models may change before becoming stable and have more restrictive rate
+limits.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $1.00 (text) |
+| Output price | Free of charge | $20.00 (audio) |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.50 (text) |
+| Output price | Not available | $10.00 (audio) |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+^\*^ Audio tokens correspond to 25 tokens per second of audio.
+
+## Gemini 3 Flash Preview
+
+*`gemini-3-flash-preview`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com?model=gemini-3-flash-preview)
+
+Our most intelligent model built for speed, combining frontier intelligence with
+superior search and grounding.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.50 (text / image / video) $1.00 (audio) |
+| Output price (including thinking tokens) | Free of charge | $3.00 |
+| Context caching price | Free of charge | $0.05 (text / image / video) $0.10 (audio) $1.00 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search^\*^ | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Grounding with Google Maps | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.25 (text / image / video) $0.50 (audio) |
+| Output price (including thinking tokens) | Not available | $1.50 |
+| Context caching price | Not available | *Same as Standard, Batch pricing not yet implemented* $0.05 (text / image / video) $0.10 (audio) $1.00 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search^\*^ | Not available | 5,000 RPD (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Grounding with Google Maps | Not available | 5,000 RPD (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Flex
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.25 (text / image / video) $0.50 (audio) |
+| Output price (including thinking tokens) | Not available | $1.50 |
+| Context caching price | Not available | *Same as Standard, Batch pricing not yet implemented* $0.05 (text / image / video) $0.10 (audio) $1.00 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search^\*^ | Not available | 5,000 RPD (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Grounding with Google Maps | Not available | 5,000 RPD (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Priority
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.90 (text / image / video) $1.80 (audio) |
+| Output price (including thinking tokens) | Free of charge | $5.40 |
+| Context caching price | Free of charge | $0.09 (text / image / video) $0.18 (audio) $1.80 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search^\*^ | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Grounding with Google Maps | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+^\*^ A customer-submitted request to Gemini may result in one or more
+queries to Google Search. You will be charged for each individual search query
+performed.
+
+## Gemini 3 Pro Image Preview 🍌
+
+*`gemini-3-pro-image-preview`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com?model=gemini-3-pro-image-preview)
+
+Our native image generation model, optimized for speed, flexibility, and
+contextual understanding. **Text input and output** is priced the same as
+[Gemini 3.1 Pro](https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-pro-preview).
+
+Preview models may change before becoming stable and have more restrictive rate
+limits.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $2.00 (text/image), equivalent to $0.0011 per image^\*^ |
+| Output price | Not available | $12.00 (text and thinking) $120.00 (images) Equivalent to $0.134 per 1K/2K image^\*\*^ and $0.24 per 4K image^\*\*^ |
+| Grounding with Google Web and Image Search^\*\*\*^ | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $1.00 (text), $0.0006 (image)^\*^ |
+| Output price | Not available | $6.00 (text and thinking) $0.067 per 1K/2K image^\*\*^ $0.12 per 4K image^\*\*^ |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Flex
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $1.00 (text), $0.0006 (image)^\*^ |
+| Output price | Not available | $6.00 (text and thinking) $0.067 per 1K/2K image^\*\*^ $0.12 per 4K image^\*\*^ |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Priority
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $3.60 (text/image) |
+| Output price | Not available | $21.60 (text and thinking) $216.00 (images) |
+| Grounding with Google Web and Image Search^\*\*\*^ | Not available | 5,000 prompts per month (free, shared across Gemini 3), then $14 / 1,000 search queries |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+^\*^ Image input is set at 560 tokens or $0.0011 per image.
+
+^\*\*^ Image output is priced at $120 per 1,000,000 tokens. Output
+images from 1024x1024px (1K) and up to 2048x2048px (2K) consume 1120 tokens and
+are equivalent to $0.134 per image. Output images up to 4096x4096px (4K) consume
+2000 tokens and are equivalent to $0.24 per image.
+
+^\*\*\*^ A customer-submitted request to Gemini may result in one or more
+queries to Google Search. You will be charged for each individual search query
+performed.
+
+## Gemini 2.5 Pro
+
+*`gemini-2.5-pro`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com?model=gemini-2.5-pro)
+
+Our state-of-the-art multipurpose model, which excels at coding and complex
+reasoning tasks.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $1.25, prompts \<= 200k tokens $2.50, prompts \> 200k tokens |
+| Output price (including thinking tokens) | Free of charge | $10.00, prompts \<= 200k tokens $15.00, prompts \> 200k |
+| Context caching price | Not available | $0.125, prompts \<= 200k tokens $0.25, prompts \> 200k $4.50 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Not available | 1,500 RPD (free), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | Not available | 10,000 RPD (free), then $25 / 1,000 grounded prompts |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.625, prompts \<= 200k tokens $1.25, prompts \> 200k tokens |
+| Output price (including thinking tokens) | Not available | $5.00, prompts \<= 200k tokens $7.50, prompts \> 200k |
+| Context caching price | Not available | $0.125, prompts \<= 200k tokens $0.25, prompts \> 200k $4.50 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Not available | 1,500 RPD (free), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | Not available | Not available |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Flex
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.625, prompts \<= 200k tokens $1.25, prompts \> 200k tokens |
+| Output price (including thinking tokens) | Not available | $5.00, prompts \<= 200k tokens $7.50, prompts \> 200k |
+| Context caching price | Not available | $0.125, prompts \<= 200k tokens $0.25, prompts \> 200k $4.50 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Not available | 1,500 RPD (free), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | Not available | Not available |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Priority
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $2.25, prompts \<= 200k tokens $4.50, prompts \> 200k tokens |
+| Output price (including thinking tokens) | Free of charge | $18.00, prompts \<= 200k tokens $27.00, prompts \> 200k |
+| Context caching price | Not available | $0.225, prompts \<= 200k tokens $0.45, prompts \> 200k $8.10 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Not available | 1,500 RPD (free), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | Not available | 10,000 RPD (free), then $25 / 1,000 grounded prompts |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Gemini 2.5 Flash
+
+*`gemini-2.5-flash`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com?model=gemini-2.5-flash)
+
+Our first hybrid reasoning model which supports a 1M token context window and
+has thinking budgets.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.30 (text / image / video) $1.00 (audio) |
+| Output price (including thinking tokens) | Free of charge | $2.50 |
+| Context caching price | Not available | $0.03 (text / image / video) $0.1 (audio) $1.00 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Free of charge, up to 500 RPD (limit shared with Flash-Lite RPD) | 1,500 RPD (free, limit shared with Flash-Lite RPD), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | 500 RPD | 1,500 RPD (free), then $25 / 1,000 grounded prompts |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.15 (text / image / video) $0.50 (audio) |
+| Output price (including thinking tokens) | Not available | $1.25 |
+| Context caching price | Not available | $0.03 (text / image / video) $0.1 (audio) $1.00 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Not available | 1,500 RPD (free, limit shared with Flash-Lite RPD), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | Not available | Not available |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Flex
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.15 (text / image / video) $0.50 (audio) |
+| Output price (including thinking tokens) | Not available | $1.25 |
+| Context caching price | Not available | $0.03 (text / image / video) $0.1 (audio) $1.00 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Not available | 1,500 RPD (free, limit shared with Flash-Lite RPD), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | Not available | Not available |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Priority
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.54 (text / image / video) $1.80 (audio) |
+| Output price (including thinking tokens) | Free of charge | $4.50 |
+| Context caching price | Not available | $0.054 (text / image / video) $0.18 (audio) $1.80 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Free of charge, up to 500 RPD (limit shared with Flash-Lite RPD) | 1,500 RPD (free, limit shared with Flash-Lite RPD), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | 500 RPD | 1,500 RPD (free), then $25 / 1,000 grounded prompts |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Gemini 2.5 Flash-Lite
+
+*`gemini-2.5-flash-lite`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com?model=gemini-2.5-flash-lite)
+
+Our smallest and most cost effective model, built for at scale usage.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price (text, image, video) | Free of charge | $0.10 (text / image / video) $0.30 (audio) |
+| Output price (including thinking tokens) | Free of charge | $0.40 |
+| Context caching price | Not available | $0.01 (text / image / video) $0.03 (audio) $1.00 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Free of charge, up to 500 RPD (limit shared with Flash RPD) | 1,500 RPD (free, limit shared with Flash RPD), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | 500 RPD | 1,500 RPD (free), then $25 / 1,000 grounded prompts |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price (text, image, video) | Not available | $0.05 (text / image / video) $0.15 (audio) |
+| Output price (including thinking tokens) | Not available | $0.20 |
+| Context caching price | Not available | $0.01 (text / image / video) $0.03 (audio) $1.00 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Not available | 1,500 RPD (free, limit shared with Flash RPD), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | Not available | Not available |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Flex
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price (text, image, video) | Not available | $0.05 (text / image / video) $0.15 (audio) |
+| Output price (including thinking tokens) | Not available | $0.20 |
+| Context caching price | Not available | $0.01 (text / image / video) $0.03 (audio) $1.00 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Not available | 1,500 RPD (free, limit shared with Flash RPD), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | Not available | Not available |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Priority
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price (text, image, video) | Free of charge | $0.18 (text / image / video) $0.54 (audio) |
+| Output price (including thinking tokens) | Free of charge | $0.72 |
+| Context caching price | Not available | $0.018 (text / image / video) $0.054 (audio) $1.80 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Free of charge, up to 500 RPD (limit shared with Flash RPD) | 1,500 RPD (free, limit shared with Flash RPD), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | 500 RPD | 1,500 RPD (free), then $25 / 1,000 grounded prompts |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Gemini 2.5 Flash-Lite Preview
+
+*`gemini-2.5-flash-lite-preview-09-2025`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com?model=gemini-2.5-flash-lite-preview-09-2025)
+
+The latest model based on Gemini 2.5 Flash lite optimized for cost-efficiency,
+high throughput and high quality.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price (text, image, video) | Free of charge | $0.10 (text / image / video) $0.30 (audio) |
+| Output price (including thinking tokens) | Free of charge | $0.40 |
+| Context caching price | Not available | $0.01 (text / image / video) $0.03 (audio) $1.00 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Free of charge, up to 500 RPD (limit shared with Flash RPD) | 1,500 RPD (free, limit shared with Flash RPD), then $35 / 1,000 grounded prompts |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price (text, image, video) | Not available | $0.05 (text / image / video) $0.15 (audio) |
+| Output price (including thinking tokens) | Not available | $0.20 |
+| Context caching price | Not available | $0.01 (text / image / video) $0.03 (audio) $1.00 / 1,000,000 tokens per hour (storage price) |
+| Grounding with Google Search | Not available | 1,500 RPD (free, limit shared with Flash RPD), then $35 / 1,000 grounded prompts |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Gemini 2.5 Flash Native Audio (Live API)
+
+*`gemini-2.5-flash-native-audio-preview-12-2025`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com/app/live#gemini-2.5-flash-native-audio-preview-12-2025)
+
+Our [Live API](https://ai.google.dev/gemini-api/docs/live) native audio models optimized for higher
+quality audio outputs with better pacing, voice naturalness, verbosity, and
+mood.
+
+Preview models may change before becoming stable and have more restrictive rate
+limits.
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.50 (text) $3.00 (audio / video) |
+| Output price (including thinking tokens) | Free of charge | $2.00 (text) $12.00 (audio) |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Gemini 2.5 Flash Image 🍌
+
+*`gemini-2.5-flash-image`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com?model=gemini-2.5-flash-image)
+
+Our native image generation model, optimized for speed, flexibility, and
+contextual understanding. Text input and output is priced the same as
+[2.5 Flash](https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash).
+
+Preview models may change before becoming stable and have more restrictive rate
+limits.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.30 (text / image) |
+| Output price | Not available | $0.039 per image\* |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.15 (text / image) |
+| Output price | Not available | $0.0195 per image\* |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Flex
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.15 (text / image) |
+| Output price | Not available | $0.0195 per image\* |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Priority
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.54 (text / image) |
+| Output price | Not available | $0.0702 per image\* |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+\[\*\] Image output is priced at $30 per 1,000,000 tokens. Output images up to
+1024x1024px consume 1290 tokens and are equivalent to $0.039 per image.
+
+## Gemini 2.5 Flash Preview TTS
+
+*`gemini-2.5-flash-preview-tts`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com/generate-speech)
+
+Our 2.5 Flash text-to-speech audio model optimized for price-performant,
+low-latency, controllable speech generation.
+
+Preview models may change before becoming stable and have more restrictive rate
+limits.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.50 (text) |
+| Output price | Free of charge | $10.00 (audio) |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.25 (text) |
+| Output price | Not available | $5.00 (audio) |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Gemini 2.5 Pro Preview TTS
+
+*`gemini-2.5-pro-preview-tts`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com/generate-speech)
+
+Our 2.5 Pro text-to-speech audio model optimized for powerful, low-latency
+speech generation for more natural outputs and easier to steer prompts.
+
+Preview models may change before becoming stable and have more restrictive rate
+limits.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $1.00 (text) |
+| Output price | Not available | $20.00 (audio) |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.50 (text) |
+| Output price | Not available | $10.00 (audio) |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Gemini 2.0 Flash
+
+*`gemini-2.0-flash`*
+
+> [!WARNING]
+> **Warning:** Gemini 2.0 Flash is [deprecated](https://ai.google.dev/gemini-api/docs/deprecations) and will be shut down June 1, 2026. Migrate to [a newer model](https://ai.google.dev/gemini-api/docs/models) to avoid service disruption.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.10 (text / image / video) $0.70 (audio) |
+| Output price | Free of charge | $0.40 |
+| Context caching price | Free of charge | $0.025 / 1,000,000 tokens (text/image/video) $0.175 / 1,000,000 tokens (audio) |
+| Context caching (storage) | Not available | $1.00 / 1,000,000 tokens per hour |
+| Image generation pricing | Not available ([shut down](https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models)) | Not available ([shut down](https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models)) |
+| Tuning price | Not available | Not available |
+| Grounding with Google Search | Free of charge, up to 500 RPD | 1,500 RPD (free), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | 500 RPD | 1,500 RPD (free), then $25 / 1,000 grounded prompts |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.05 (text / image / video) $0.35 (audio) |
+| Output price | Not available | $0.20 |
+| Context caching price | Not available | $0.025 / 1,000,000 tokens (text/image/video) $0.175 / 1,000,000 tokens (audio) |
+| Context caching (storage) | Not available | $1.00 / 1,000,000 tokens per hour |
+| Image generation pricing | Not available ([shut down](https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models)) | Not available ([shut down](https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models)) |
+| Tuning price | Not available | Not available |
+| Grounding with Google Search | Not available | 1,500 RPD (free), then $35 / 1,000 grounded prompts |
+| Grounding with Google Maps | Not available | Not available |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+\[\*\] Image output is priced at $30 per 1,000,000 tokens. Output images up to
+1024x1024px consume 1290 tokens and are equivalent to $0.039 per image.
+
+## Gemini 2.0 Flash-Lite
+
+*`gemini-2.0-flash-lite`*
+
+> [!WARNING]
+> **Warning:** Gemini 2.0 Flash-Lite is [deprecated](https://ai.google.dev/gemini-api/docs/deprecations) and will be shut down June 1, 2026. Migrate to [a newer model](https://ai.google.dev/gemini-api/docs/models) to avoid service disruption.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.075 |
+| Output price | Free of charge | $0.30 |
+| Context caching price | Not available | Not available |
+| Context caching (storage) | Not available | Not available |
+| Tuning price | Not available | Not available |
+| Grounding with Google Search | Not available | Not available |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.0375 |
+| Output price | Not available | $0.15 |
+| Context caching price | Not available | Not available |
+| Context caching (storage) | Not available | Not available |
+| Tuning price | Not available | Not available |
+| Grounding with Google Search | Not available | Not available |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Imagen 4
+
+*`imagen-4.0-generate-001`, `imagen-4.0-ultra-generate-001`, `imagen-4.0-fast-generate-001`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com/generate-image)
+
+Our latest image generation model, with significantly better text rendering and
+better overall image quality.
+
+Preview models may change before becoming stable and have more restrictive rate
+limits.
+
+|   | Free Tier | Paid Tier, per Image in USD |
+|---|---|---|
+| Imagen 4 Fast image price | Not available | $0.02 |
+| Imagen 4 Standard image price | Not available | $0.04 |
+| Imagen 4 Ultra image price | Not available | $0.06 |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Veo 3.1
+
+*`veo-3.1-generate-preview`, `veo-3.1-fast-generate-preview`, `veo-3.1-lite-generate-preview`*
+
+
+[Try Veo 3.1](https://deepmind.google/models/veo/)
+
+Our latest video generation model, available to developers on the
+paid tier of the Gemini API.
+
+Preview models may change before becoming stable and have more restrictive rate
+limits.
+
+|   | Free Tier | Paid Tier, per second in USD |
+|---|---|---|
+| Veo 3.1 Standard video with audio price (default) | Not available | $0.40 (720p and 1080p) $0.60 (4k) |
+| Veo 3.1 Fast video with audio price (default) | Not available | $0.10 (720p) $0.12 (1080p) $0.30 (4k) |
+| Veo 3.1 Lite video with audio price (default) | Not available | $0.05 (720p) $0.08 (1080p) (4k output not supported) |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+> [!NOTE]
+> **Note:** In some cases, an audio processing issue may prevent a video from being generated. You will only be charged if your video is successfully generated.
+
+## Veo 3
+
+*`veo-3.0-generate-001`, `veo-3.0-fast-generate-001`*
+
+
+[Try Veo 3](https://deepmind.google/models/veo/)
+
+Our stable video generation model, available to developers on the
+paid tier of the Gemini API.
+
+|   | Free Tier | Paid Tier, per second in USD |
+|---|---|---|
+| Veo 3 Standard video with audio price (default) | Not available | $0.40 |
+| Veo 3 Fast video with audio price (default) | Not available | $0.10 (720p) $0.12 (1080p) $0.30 (4k) |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+> [!NOTE]
+> **Note:** In some cases, an audio processing issue may prevent a video from being generated. You will only be charged if your video is successfully generated.
+
+## Veo 2
+
+*`veo-2.0-generate-001`*
+
+
+[Try the API](https://ai.google.dev/gemini-api/docs/video)
+
+Our state-of-the-art video generation model, available to developers on the
+paid tier of the Gemini API.
+
+|   | Free Tier | Paid Tier, per second in USD |
+|---|---|---|
+| Video price | Not available | $0.35 |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Lyria 3
+
+*`lyria-3-clip-preview` and `lyria-3-pro-preview`*
+
+Google's family of music generation models. Preview models may change
+before becoming stable and have more restrictive rate limits.
+
+|   | Free Tier | Paid Tier, per request in USD |
+|---|---|---|
+| Lyria 3 Clip Preview (30s) | Not available | $0.04 per song |
+| Lyria 3 Pro Preview (Full Song) | Not available | $0.08 per song |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Gemini Embedding 2 Preview
+
+*`gemini-embedding-2-preview`*
+
+
+[Try the API](https://ai.google.dev/gemini-api/docs/embeddings)
+
+Our first multimodal embedding model, mapping text, images, video, audio, and
+PDFs into a unified embedding space.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Text input price | Free of charge | $0.20 |
+| Image input price | Free of charge | $0.45 ($0.00012 per image) |
+| Audio input price | Free of charge | $6.50 ($0.00016 per second) |
+| Video input price | Free of charge | $12.00 ($0.00079 per frame) |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Text input price | Not available | Not available |
+| Image input price | Not available | Not available |
+| Audio input price | Not available | Not available |
+| Video input price | Not available | Not available |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Gemini Embedding
+
+*`gemini-embedding-001`*
+
+
+[Try the API](https://ai.google.dev/gemini-api/docs/embeddings)
+
+Our Gemini Embeddings model for text-only use cases, available to developers on the free and paid tiers of the Gemini API.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.15 |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.075 |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Gemini Robotics-ER 1.6 Preview
+
+*`gemini-robotics-er-1.6-preview`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com?model=gemini-robotics-er-1.6-preview)
+
+Gemini Robotics-ER, short for Gemini Robotics-Embodied Reasoning, is a thinking
+model that enhances robots' abilities to understand and interact with the
+physical world.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $1.00 (text / image / video) $2.00 (audio) |
+| Output price (including thinking tokens) | Free of charge | $5.00 |
+| Grounding with Google Search | Free of charge, up to 1500 RPD (limit shared with Flash RPD) | 5,000 RPD (free, limit shared with Flash RPD), then $14 / 1,000 search queries for text and image-based grounding. |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $0.50 (text / image / video) $1.00 (audio) |
+| Output price (including thinking tokens) | Not available | $2.50 |
+| Grounding with Google Search | Not available | Not available |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Gemini Robotics-ER 1.5 Preview
+
+*`gemini-robotics-er-1.5-preview`*
+
+
+[Try it in Google AI Studio](https://aistudio.google.com?model=gemini-robotics-er-1.5-preview)
+
+Gemini Robotics-ER, short for Gemini Robotics-Embodied Reasoning, is a thinking
+model that enhances robots' abilities to understand and interact with the
+physical world.
+
+### Standard
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | $0.30 (text / image / video) $1.00 (audio) |
+| Output price (including thinking tokens) | Free of charge | $2.50 |
+| Grounding with Google Search | Free of charge, up to 500 RPD (limit shared with Flash-Lite RPD) | 1,500 RPD (free, limit shared with Flash-Lite RPD), then $35 / 1,000 grounded prompts |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+### Batch
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | Not available |
+| Output price (including thinking tokens) | Not available | Not available |
+| Grounding with Google Search | Not available | Not available |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Gemini 2.5 Computer Use Preview
+
+*`gemini-2.5-computer-use-preview-10-2025`*
+
+Our Computer Use model optimized for building browser control agents that
+automate tasks.
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Not available | $1.25, prompts \<= 200k tokens $2.50, prompts \> 200k token |
+| Output price | Not available | $10.00, prompts \<= 200k tokens $15.00, prompts \> 200k |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Gemma 4
+
+Our lightweight, state-of the art, open model built from the same technology
+that powers our Gemini models.
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| Input price | Free of charge | Not available |
+| Output price | Free of charge | Not available |
+| Context caching price | Free of charge | Not available |
+| Context caching (storage) | Free of charge | Not available |
+| Tuning price | Not available | Not available |
+| Grounding with Google Search | Not available | Not available |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
+## Pricing for tools
+
+Tools are priced at their own rates, applied to the model using them.
+Check the [Models](https://ai.google.dev/gemini-api/docs/models) page for which tools are available
+to each model.
+
+|   | Free Tier | Paid Tier, per 1M tokens in USD |
+|---|---|---|
+| [Google Search](https://ai.google.dev/gemini-api/docs/google-search#pricing) | 500 RPD free (limit shared for Flash and Flash-Lite). Not available for Pro. | Gemini 2.5 models: 1,500 RPD free (limit shared for Flash and Flash-Lite). Then $35 / 1,000 grounded prompts Gemini 3 models: 5,000 prompts per month (free), then $14 / 1,000 search queries |
+| [Google Maps](https://ai.google.dev/gemini-api/docs/maps-grounding#pricing_and_rate_limits) | 500 RPD Not available for Pro. | 1,500 RPD free (limit shared for Flash and Flash-Lite) 10,000 RPD free for Pro. Then $25 / 1,000 grounded prompts |
+| [Code execution](https://ai.google.dev/gemini-api/docs/code-execution#billing) | Free of charge | Code execution is billed at the standard token rates for the selected model. Costs are determined solely by the tool's usage, no charges are accrued for the session runtime. The generated code and execution results are billed as **Output tokens** when created, and as **Input tokens** when the model uses them as part of its iterative reasoning process. |
+| [URL context](https://ai.google.dev/gemini-api/docs/url-context#limitations) | Free of charge | Charged as input tokens per model pricing. |
+| [Computer use](https://ai.google.dev/gemini-api/docs/computer-use) | Not available | See [Gemini 2.5 Computer Use Preview](https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-computer-use-preview-10-2025) pricing table. |
+| [File search](https://ai.google.dev/gemini-api/docs/file-search#pricing) | Free of charge | Charged for [embeddings](https://ai.google.dev/gemini-api/docs/pricing#gemini-embedding) at $0.15 / 1M tokens. Retrieved document tokens charged as regular tokens per model pricing. |
+| [Custom Tools endpoint (Gemini 3.1 Pro Preview)](https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview) | Not available | Same as [Gemini 3.1 Pro Preview](https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-pro-preview) pricing |
+
+## Pricing for agents
+
+Agent usage costs are calculated based on the underlying token
+consumption and usage of the tools.
+
+|   | Model | Tools |
+|---|---|---|
+| [Gemini Deep Research Agent](https://ai.google.dev/gemini-api/docs/deep-research) | All model inference is charged at standard Gemini list rates, including input, output, and intermediate input / reasoning tokens generated during agentic loops. | Tool usage fees apply per existing pricing structure, maintaining standard distinctions for Search Grounding (retrieved tokens excluded) versus Url_context / File Search (retrieved tokens included in all other tools). |
+
+## Notes
+
+- Google AI Studio usage is free of charge in all [available regions](https://ai.google.dev/gemini-api/docs/available-regions). See [Billing FAQs](https://ai.google.dev/gemini-api/docs/billing) for details.
+- Prices may differ from the prices listed here and the prices offered on Vertex AI. For Vertex prices, see the [Vertex AI pricing page](https://cloud.google.com/vertex-ai/generative-ai/pricing).
+- If you are using [dynamic retrieval](https://ai.google.dev/gemini-api/docs/grounding) to optimize costs, only requests that contain at least one grounding support URL from the web in their response are charged for Grounding with Google Search. Costs for Gemini always apply. Rate limits are subject to change.

--- a/lib/cost_calculator.py
+++ b/lib/cost_calculator.py
@@ -127,19 +127,31 @@ class CostCalculator:
     }
     DEFAULT_GROK_IMAGE_MODEL = "grok-imagine-image"
 
-    # Gemini 文本 token 费率（美元/百万 token）
+    # Gemini 文本 token 费率（美元/百万 token），Standard paid tier、prompt ≤200K 区间
+    # 来源：docs/google-genai-docs/pricing.md
     GEMINI_TEXT_COST = {
-        "gemini-3-flash-preview": {"input": 0.10, "output": 0.40},
+        "gemini-3.1-pro-preview": {"input": 2.00, "output": 12.00},
+        "gemini-3-flash-preview": {"input": 0.50, "output": 3.00},
+        "gemini-3.1-flash-lite-preview": {"input": 0.25, "output": 1.50},
     }
 
-    # Ark 文本 token 费率（元/百万 token）
+    # Ark 文本 token 费率（元/百万 token），在线推理、输入 [0, 32k] 区间
+    # 来源：docs/ark-docs/火山方舟费用参考.md
+    # 注：doubao-seed-1-8 输出价格分段（[0,0.2]k: 2.00；超出: 8.00），此处按基础价 2.00 计
     ARK_TEXT_COST = {
-        "doubao-seed-2-0-lite-260215": {"input": 0.30, "output": 0.60},
+        "doubao-seed-2-0-pro-260215": {"input": 3.20, "output": 16.00},
+        "doubao-seed-2-0-lite-260215": {"input": 0.60, "output": 3.60},
+        "doubao-seed-2-0-mini-260215": {"input": 0.20, "output": 2.00},
+        "doubao-seed-1-8-251228": {"input": 0.80, "output": 2.00},
     }
 
     # Grok 文本 token 费率（美元/百万 token）
+    # 来源：docs/grok-docs/models.md
     GROK_TEXT_COST = {
-        "grok-4-1-fast-reasoning": {"input": 2.00, "output": 10.00},
+        "grok-4-1-fast-reasoning": {"input": 0.20, "output": 0.50},
+        "grok-4-1-fast-non-reasoning": {"input": 0.20, "output": 0.50},
+        "grok-4.20-0309-reasoning": {"input": 2.00, "output": 6.00},
+        "grok-4.20-0309-non-reasoning": {"input": 2.00, "output": 6.00},
     }
 
     # OpenAI 文本 token 费率（美元/百万 token）

--- a/tests/test_cost_calculator_text.py
+++ b/tests/test_cost_calculator_text.py
@@ -8,17 +8,17 @@ class TestTextCost:
     def test_gemini_cost(self):
         amount, currency = self.calc.calculate_text_cost(1000, 500, "gemini")
         assert currency == "USD"
-        assert amount == (1000 * 0.10 + 500 * 0.40) / 1_000_000
+        assert amount == (1000 * 0.50 + 500 * 3.00) / 1_000_000
 
     def test_ark_cost(self):
         amount, currency = self.calc.calculate_text_cost(1000, 500, "ark")
         assert currency == "CNY"
-        assert amount == (1000 * 0.30 + 500 * 0.60) / 1_000_000
+        assert amount == (1000 * 0.60 + 500 * 3.60) / 1_000_000
 
     def test_grok_cost(self):
         amount, currency = self.calc.calculate_text_cost(1000, 500, "grok")
         assert currency == "USD"
-        assert amount == (1000 * 2.00 + 500 * 10.00) / 1_000_000
+        assert amount == (1000 * 0.20 + 500 * 0.50) / 1_000_000
 
     def test_unknown_provider_defaults_to_gemini(self):
         amount, currency = self.calc.calculate_text_cost(1000, 500, "unknown")

--- a/tests/test_text_generator.py
+++ b/tests/test_text_generator.py
@@ -60,7 +60,7 @@ class TestTextGenerator:
         assert item["input_tokens"] == 100
         assert item["output_tokens"] == 50
         assert item["provider"] == "gemini"
-        assert item["cost_amount"] == pytest.approx((100 * 0.10 + 50 * 0.40) / 1_000_000)
+        assert item["cost_amount"] == pytest.approx((100 * 0.50 + 50 * 3.00) / 1_000_000)
 
     async def test_generate_records_usage_on_failure(self, tracker):
         backend = _make_backend()

--- a/tests/test_usage_repo.py
+++ b/tests/test_usage_repo.py
@@ -192,8 +192,8 @@ class TestMultiProviderUsage:
         assert item["input_tokens"] == 1000
         assert item["output_tokens"] == 500
         assert item["currency"] == "USD"
-        # cost = (1000 * 0.10 + 500 * 0.40) / 1_000_000 = 0.0003
-        assert item["cost_amount"] == pytest.approx(0.0003)
+        # cost = (1000 * 0.50 + 500 * 3.00) / 1_000_000 = 0.002
+        assert item["cost_amount"] == pytest.approx((1000 * 0.50 + 500 * 3.00) / 1_000_000)
 
     async def test_text_call_ark_cost(self, db_session):
         repo = UsageRepository(db_session)
@@ -215,8 +215,8 @@ class TestMultiProviderUsage:
         calls = await repo.get_calls(project_name="demo")
         item = calls["items"][0]
         assert item["currency"] == "CNY"
-        # cost = (2000 * 0.30 + 1000 * 0.60) / 1_000_000 = 0.0012
-        assert item["cost_amount"] == pytest.approx(0.0012)
+        # cost = (2000 * 0.60 + 1000 * 3.60) / 1_000_000 = 0.0048
+        assert item["cost_amount"] == pytest.approx((2000 * 0.60 + 1000 * 3.60) / 1_000_000)
 
     async def test_text_call_failed_zero_cost(self, db_session):
         repo = UsageRepository(db_session)

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -124,7 +124,7 @@ class TestUsageTracker:
         assert item["call_type"] == "text"
         assert item["input_tokens"] == 1000
         assert item["output_tokens"] == 500
-        assert item["cost_amount"] == pytest.approx(0.0003)
+        assert item["cost_amount"] == pytest.approx((1000 * 0.50 + 500 * 3.00) / 1_000_000)
 
         stats = await tracker.get_stats(project_name="demo")
         assert stats["text_count"] == 1


### PR DESCRIPTION
## Summary

修正 5 个预设供应商文本模型定价错误与缺失，使 registry 暴露的每个预设模型都在 cost 表中有对应的正确价格。

- **Grok**：`grok-4-1-fast-reasoning` 由 \$2.00/\$10.00 修正为 \$0.20/\$0.50；补齐 `grok-4-1-fast-non-reasoning`、`grok-4.20-0309-reasoning`、`grok-4.20-0309-non-reasoning`
- **Gemini**：`gemini-3-flash-preview` 由 \$0.10/\$0.40 修正为 \$0.50/\$3.00；补齐 `gemini-3.1-pro-preview`（\$2.00/\$12.00）与 `gemini-3.1-flash-lite-preview`（\$0.25/\$1.50）
- **Ark**：`doubao-seed-2-0-lite-260215` 由 ¥0.30/¥0.60 修正为 ¥0.60/¥3.60；补齐 `doubao-seed-2-0-pro-260215`、`doubao-seed-2-0-mini-260215`、`doubao-seed-1-8-251228`（seed-1-8 按基础档 [0,0.2]k 输出价计）

同步下载 `docs/google-genai-docs/pricing.md` 作为 Gemini 定价的本仓库单一真相源，并更新 `test_cost_calculator_text.py` 中对应断言。

## Test plan

- [x] `uv run pytest tests/test_cost_calculator_text.py tests/test_cost_calculator.py -q` 39 个断言全部通过
- [x] 交叉脚本校验：5 个预设供应商的 text/image/video 模型集合与各自 cost 表一一对应，无缺失无多余
- [x] `uv run ruff check lib/cost_calculator.py tests/test_cost_calculator_text.py` 通过