### PR TITLE
fix(assets): 资产库返回按钮跟随来源页面

### DIFF
--- a/frontend/src/components/layout/GlobalHeader.tsx
+++ b/frontend/src/components/layout/GlobalHeader.tsx
@@ -15,6 +15,7 @@ import { ExportScopeDialog } from "./ExportScopeDialog";
 
 import { API } from "@/api";
 import { ArchiveDiagnosticsDialog } from "@/components/shared/ArchiveDiagnosticsDialog";
+import { rememberAssetLibraryReturnTo } from "@/components/pages/AssetLibraryPage";
 import type { ExportDiagnostics, WorkspaceNotification } from "@/types";
 
 /** 通过隐藏 <a> 触发浏览器下载，避免 window.open 产生空白标签页 */
@@ -375,7 +376,10 @@ export function GlobalHeader({ onNavigateBack }: GlobalHeaderProps) {
         {/* Asset library */}
         <button
           type="button"
-          onClick={() => setLocation("~/app/assets")}
+          onClick={() => {
+            rememberAssetLibraryReturnTo(window.location.pathname);
+            setLocation("~/app/assets");
+          }}
           className="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-gray-800 hover:text-gray-200"
           title={t("assets:library_title")}
           aria-label={t("assets:library_title")}

--- a/frontend/src/components/pages/AssetLibraryPage.tsx
+++ b/frontend/src/components/pages/AssetLibraryPage.tsx
@@ -11,6 +11,15 @@ import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { errMsg } from "@/utils/async";
 import type { Asset, AssetType } from "@/types/asset";
 
+const ASSET_LIBRARY_RETURN_TO_KEY = "assetLibrary:returnTo";
+
+/** 入口按钮点击前调用，记录返回目标。只接受应用内部路径，避免 open redirect 风险。 */
+export function rememberAssetLibraryReturnTo(pathname: string) {
+  if (pathname.startsWith("/app/")) {
+    sessionStorage.setItem(ASSET_LIBRARY_RETURN_TO_KEY, pathname);
+  }
+}
+
 interface TabDef {
   type: AssetType;
   icon: React.ComponentType<{ className?: string }>;
@@ -101,7 +110,11 @@ export function AssetLibraryPage() {
           <div className="flex items-start gap-3">
             <button
               type="button"
-              onClick={() => navigate("/app/projects")}
+              onClick={() => {
+                const returnTo = sessionStorage.getItem(ASSET_LIBRARY_RETURN_TO_KEY);
+                sessionStorage.removeItem(ASSET_LIBRARY_RETURN_TO_KEY);
+                navigate(returnTo && returnTo.startsWith("/app/") ? returnTo : "/app/projects");
+              }}
               aria-label={t("back_to_projects")}
               title={t("back_to_projects")}
               className="mt-1 rounded-full border border-gray-800 bg-gray-900/60 p-1.5 text-gray-400 transition-colors hover:border-indigo-500/40 hover:text-indigo-200"

--- a/frontend/src/components/pages/ProjectsPage.tsx
+++ b/frontend/src/components/pages/ProjectsPage.tsx
@@ -13,6 +13,7 @@ import { Popover } from "@/components/ui/Popover";
 import { ProgressBar } from "@/components/ui/ProgressBar";
 import { CreateProjectModal } from "./CreateProjectModal";
 import { OpenClawModal } from "./OpenClawModal";
+import { rememberAssetLibraryReturnTo } from "./AssetLibraryPage";
 import type { ProjectStatus, ProjectSummary, ImportConflictPolicy, ImportFailureDiagnostics } from "@/types";
 
 // ---------------------------------------------------------------------------
@@ -294,7 +295,10 @@ export function ProjectsPage() {
             {/* Asset library pill */}
             <button
               type="button"
-              onClick={() => navigate("/app/assets")}
+              onClick={() => {
+                rememberAssetLibraryReturnTo(window.location.pathname);
+                navigate("/app/assets");
+              }}
               className="inline-flex items-center gap-1.5 rounded-lg border border-indigo-500/20 bg-indigo-500/10 px-3 py-1.5 text-sm text-indigo-200 transition-colors hover:border-indigo-400/40 hover:bg-indigo-500/15 hover:text-white"
               title={t("assets:library_title")}
             >


### PR DESCRIPTION
## Summary
- 资产库返回按钮原先硬编码跳回 `/app/projects`，工作台进入后返回会被"吞"到项目大厅
- 入口（[ProjectsPage](frontend/src/components/pages/ProjectsPage.tsx)、[GlobalHeader](frontend/src/components/layout/GlobalHeader.tsx)）点击前通过 `sessionStorage` 记录来源路径
- [AssetLibraryPage](frontend/src/components/pages/AssetLibraryPage.tsx) 返回按钮优先跳回该路径，缺失或非 `/app/` 开头时 fallback 至 `/app/projects`（防 open redirect）

## Test plan
- [ ] 项目大厅 → 资产库 → 返回 → 回到项目大厅
- [ ] 工作台 `/app/projects/{name}/...` → 资产库 → 返回 → 回到原工作台路径
- [ ] 直接通过 URL/书签访问 `/app/assets` → 返回 → fallback 至 `/app/projects`
- [x] `pnpm check`（typecheck + lint + 394 tests）通过