### PR TITLE
fix(project-cover): 修复混入空 video_units 导致封面退到 scene_sheet

### DIFF
--- a/server/services/project_cover.py
+++ b/server/services/project_cover.py
@@ -77,8 +77,12 @@ def resolve_project_cover(
             continue
 
     def _iter_items(script: dict):
-        # 兼容 storyboard 的 segments 与 reference 的 video_units 两种集级结构。
-        return script.get("video_units") or script.get("segments") or []
+        # 合并 segments（storyboard/grid）与 video_units（reference）两种集级结构。
+        # 旧实现 `video_units or segments` 在两者共存时会永久丢弃后者——
+        # storyboard 项目被误塞入空 video_units 时，segments 里的真实 video_thumbnail /
+        # storyboard_image 被整体跳过，封面退化到 scene_sheet（见回归测试）。
+        # 合并遍历 + `if thumb`/`if sb` 的 falsy 过滤，天然忽略空壳 item。
+        return [*(script.get("segments") or []), *(script.get("video_units") or [])]
 
     for script in scripts:
         for item in _iter_items(script):

--- a/tests/server/test_project_cover.py
+++ b/tests/server/test_project_cover.py
@@ -177,6 +177,31 @@ def test_preloaded_scripts_falls_back_to_manager_for_missing_entries():
     assert called_files == {"scripts/episode_2.json"}
 
 
+def test_mixed_segments_and_video_units_do_not_shadow_each_other():
+    """回归：storyboard 模式 script 被误塞入空 video_units 时，不应让 segments 里的真实
+    video_thumbnail / storyboard_image 被跳过退到 scene_sheet。
+    暴君1.0 复现现场：segments 里 2 个 video_thumbnail + 49 个 storyboard_image，
+    video_units 里 7 个 status:pending 空壳；旧逻辑 `video_units or segments` 让后者整体丢弃。"""
+    project = {
+        "episodes": [{"script_file": "scripts/episode_1.json"}],
+        "scenes": {"选秀大殿": {"scene_sheet": "scenes/选秀大殿.png"}},
+    }
+    scripts = {
+        "scripts/episode_1.json": {
+            "segments": [
+                {"generated_assets": {"storyboard_image": "storyboards/scene_E1S1.png"}},
+                {"generated_assets": {"video_thumbnail": "thumbnails/scene_E1S1.jpg"}},
+            ],
+            "video_units": [
+                {"unit_id": "E1U1", "generated_assets": {"status": "pending"}},
+                {"unit_id": "E1U2", "generated_assets": {"status": "pending"}},
+            ],
+        }
+    }
+    url = resolve_project_cover(_mk_manager(scripts), "proj", project)
+    assert url == "/api/v1/files/proj/thumbnails/scene_E1S1.jpg"
+
+
 @pytest.mark.parametrize(
     "sheet_value",
     [None, "", 0],


### PR DESCRIPTION
## Summary
- \`project_cover._iter_items\` 改为合并 \`segments\` + \`video_units\` 遍历，修复 storyboard/grid 项目被误塞空 video_units 时封面退到 scene_sheet 的 bug
- 新增回归测试直接复刻暴君1.0 数据形态（segments 含真实 thumbnail/storyboard_image + video_units 全 pending 空壳）
- 脏数据按约定不修；\`reference_videos\` add_unit 的 mode 校验留到后续

## Root cause
旧 \`video_units or segments\` fallback 假设两种集级结构互斥。但 \`reference_videos\` 路由的 \`script.setdefault("video_units", []).append(unit)\` 没有校验 generation_mode，任何 script 都能被塞 units，加上 Pydantic schema 把两者都声明为字段——一旦共存，\`video_units\` 非空就会永久屏蔽 segments 扫描。

## Test plan
- [x] \`uv run python -m pytest tests/server/test_project_cover.py -v\` → 15/15 通过
- [x] 暴君1.0 真实数据验证：封面 \`scenes/选秀大殿.png\` → \`thumbnails/scene_E1S1.jpg\`
- [x] \`uv run ruff check && ruff format\` 通过