### PR TITLE
fix(frontend): 配置检测支持自定义供应商

### DIFF
--- a/frontend/src/stores/config-status-store.test.ts
+++ b/frontend/src/stores/config-status-store.test.ts
@@ -60,6 +60,7 @@ describe("config-status-store", () => {
 
   it("reports anthropic and provider issues when both unconfigured", async () => {
     vi.spyOn(API, "getProviders").mockResolvedValue(makeProviders());
+    vi.spyOn(API, "listCustomProviders").mockResolvedValue({ providers: [] });
     vi.spyOn(API, "getSystemConfig").mockResolvedValue(makeConfigResponse());
 
     await useConfigStatusStore.getState().fetch();
@@ -78,6 +79,7 @@ describe("config-status-store", () => {
     vi.spyOn(API, "getProviders").mockResolvedValue(
       makeProviders([{ id: "gemini", display_name: "Google Gemini", status: "ready", media_types: ["image", "video", "text"], capabilities: [], configured_keys: ["api_key"], missing_keys: [], models: {} }]),
     );
+    vi.spyOn(API, "listCustomProviders").mockResolvedValue({ providers: [] });
     vi.spyOn(API, "getSystemConfig").mockResolvedValue(
       makeConfigResponse({ anthropic_api_key: { is_set: true, masked: "sk-ant-***" } }),
     );
@@ -93,6 +95,7 @@ describe("config-status-store", () => {
     vi.spyOn(API, "getProviders")
       .mockRejectedValueOnce(new Error("temporary failure"))
       .mockResolvedValueOnce(makeProviders());
+    vi.spyOn(API, "listCustomProviders").mockResolvedValue({ providers: [] });
     vi.spyOn(API, "getSystemConfig").mockResolvedValue(makeConfigResponse());
 
     await useConfigStatusStore.getState().fetch();

--- a/frontend/src/stores/config-status-store.ts
+++ b/frontend/src/stores/config-status-store.ts
@@ -14,8 +14,9 @@ export interface ConfigIssue {
 async function getConfigIssues(): Promise<ConfigIssue[]> {
   const issues: ConfigIssue[] = [];
 
-  const [{ providers }, configRes] = await Promise.all([
+  const [{ providers }, { providers: customProviders }, configRes] = await Promise.all([
     API.getProviders(),
+    API.listCustomProviders(),
     API.getSystemConfig(),
   ]);
 
@@ -33,8 +34,16 @@ async function getConfigIssues(): Promise<ConfigIssue[]> {
   // 2. Check any provider supports each media type
   const readyProviders = providers.filter((p) => p.status === "ready");
 
-  const hasMediaType = (type: string) =>
-    readyProviders.some((p) => p.media_types.includes(type));
+  const hasMediaType = (type: string) => {
+    // Check preset providers
+    const hasPresetProvider = readyProviders.some((p) => p.media_types.includes(type));
+    if (hasPresetProvider) return true;
+
+    // Check custom providers for enabled models of this media type
+    return customProviders.some((cp) =>
+      cp.models.some((m) => m.media_type === type && m.is_enabled)
+    );
+  };
 
   if (!hasMediaType("video")) {
     issues.push({


### PR DESCRIPTION
issue:
<img width="900" height="222" alt="企业微信截图_17768254978026" src="https://github.com/user-attachments/assets/16b101a0-32cc-40ad-85a8-e626734c47e9" />

方案:
扩展 config-status-store 的检测逻辑，使其同时检查预置供应商和自定义供应商的媒体类型支持情况。只有已启用的自定义供应商模型才会计入配置状态。

## 范围

前端的配置检查提醒

## 变更

frontend/src/stores/config-status-store.ts


## 验收清单

<!-- Merge 前必须勾完。CI 绿不等于可合。 -->

- [x] 本地已跑相关测试 :pnpm test src/stores/config-status-store.test.ts
- [x] 手动验证了改动所声称的行为
- [x] 新增面向用户文案已加 zh/en 翻译（如适用）
- [x] 无新增 ESLint disable；若有，已在本 PR 底部以表格列出 `rule | file:line | 理由`
- [x] CODEOWNERS 要求的 review 已请求

