### PR TITLE
ci(release-please): 使用 GitHub App token 触发下游 workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -17,8 +18,11 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,9 +12,16 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -27,6 +34,7 @@ jobs:
         with:
           ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up uv
         if: ${{ steps.release.outputs.pr }}


### PR DESCRIPTION
## Summary

- release-please 原本用默认 `GITHUB_TOKEN` 推 tag，GitHub Actions 规定该 token 引发的事件不触发其他 workflow，导致 `v0.10.0` tag 没触发 `docker.yml`，ghcr 上缺失 `latest` / semver 镜像。
- 改用 `actions/create-github-app-token@v2` 通过 GitHub App 签发安装 token，release-please 以 App 身份推 tag，可正常触发下游 workflow。
- checkout 同步 `uv.lock` 那步也换用 App token，保证 `release-please-...` 分支上的后续 commit 也由 App 身份签署。

## 合并前置

需要先在 repo secrets 里添加：
- `RELEASE_PLEASE_APP_ID`
- `RELEASE_PLEASE_APP_PRIVATE_KEY`

并确认对应的 GitHub App（`arcreel-release-please`）已 install 到 `ArcReel/ArcReel`。缺任何一项合并后 release-please 会失败。

## Test plan

- [ ] 两个 secret 已在 repo 配置完毕
- [ ] GitHub App 已 install 到本仓库
- [ ] 合并后下一次 release PR 合并时，观察到 `docker.yml` 出现 `head_branch = v0.x.y` 且 `event = push` 的新 run
- [ ] 确认 `ghcr.io/arcreel/arcreel:latest` 与 `:0.x.y` 被推送成功