### PR TITLE
refactor(notifications): toast 与持久通知解耦 (#351)

### DIFF
--- a/docs/superpowers/plans/2026-04-23-toast-notification-split.md
+++ b/docs/superpowers/plans/2026-04-23-toast-notification-split.md
@@ -1,0 +1,514 @@
+# Toast 与持久通知拆分 · 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 `useAppStore` 中把瞬时 toast 与持久 drawer 通知解耦成 `pushToast` / `pushWorkspaceNotification` / `pushNotification` 三个入口，并按规则迁移全部现有调用点。
+
+**Architecture:** `pushToast` 的副作用（强制写入 `workspaceNotifications`）是 bug 根因。收窄 `pushToast` 签名只写 `toast`；新增 `pushNotification` 作为组合便利函数（内部调 `pushToast + pushWorkspaceNotification`）；`pushWorkspaceNotification` 保持不动。调用点按「后台任务失败 → `pushNotification`；其余 → `pushToast`」规则迁移。
+
+**Tech Stack:** React + zustand（`frontend/src/stores/app-store.ts`），vitest（单测）。
+
+**Spec:** `docs/superpowers/specs/2026-04-23-toast-notification-split-design.md`
+
+**Preflight check（全仓零 `pushToast(_, _, { target })` 调用点）**：此次签名收窄不会使任何现有调用点编译失败，每个调用点的迁移都是语义决策，不是类型修复。
+
+---
+
+## Task 1：Store API 重构 + 单测
+
+**Files:**
+- Modify: `frontend/src/stores/app-store.ts`
+- Modify: `frontend/src/stores/stores.test.ts`
+
+- [ ] **Step 1：改写 stores.test.ts 既有 `pushToast("hello")` 块 + 新增三断言**
+
+位置：`frontend/src/stores/stores.test.ts:73-81`（"hello" 区段）。把现有 block：
+
+```ts
+app.pushToast("hello");
+expect(useAppStore.getState().toast?.text).toBe("hello");
+expect(useAppStore.getState().toast?.tone).toBe("info");
+expect(useAppStore.getState().workspaceNotifications[0]).toEqual(
+  expect.objectContaining({
+    text: "hello",
+    tone: "info",
+  }),
+);
+app.clearToast();
+expect(useAppStore.getState().toast).toBeNull();
+```
+
+替换为：
+
+```ts
+// pushToast 只写 toast，不再副作用写入 workspaceNotifications（issue #351 根因回归）
+app.pushToast("hello");
+expect(useAppStore.getState().toast?.text).toBe("hello");
+expect(useAppStore.getState().toast?.tone).toBe("info");
+expect(useAppStore.getState().workspaceNotifications).toHaveLength(0);
+app.clearToast();
+expect(useAppStore.getState().toast).toBeNull();
+
+// pushNotification 同时写两者，tone 与 target 正确传递
+app.pushNotification("task failed", "error", {
+  target: { type: "segment", id: "S1", route: "/episodes/1" },
+});
+expect(useAppStore.getState().toast).toEqual(
+  expect.objectContaining({ text: "task failed", tone: "error" }),
+);
+expect(useAppStore.getState().workspaceNotifications[0]).toEqual(
+  expect.objectContaining({
+    text: "task failed",
+    tone: "error",
+    target: expect.objectContaining({ id: "S1" }),
+  }),
+);
+app.clearToast();
+useAppStore.setState({ workspaceNotifications: [] });
+```
+
+保持下方（原 L85 起）`pushWorkspaceNotification` 测试段不变——这正好覆盖"pushWorkspaceNotification 只写 drawer、不写 toast"：它已经先 `clearToast()`，并在 block 内不再断言 toast 被写入。补一条显式断言以防回归：
+
+```ts
+// pushWorkspaceNotification 只写 drawer，不触动 toast
+app.pushWorkspaceNotification({
+  text: "AI 刚更新了角色「hero」，点击查看",
+  target: {
+    type: "character",
+    id: "hero",
+    route: "/characters",
+  },
+});
+expect(useAppStore.getState().toast).toBeNull();  // 新增
+const notification = useAppStore.getState().workspaceNotifications[0];
+expect(notification.target?.id).toBe("hero");
+```
+
+- [ ] **Step 2：运行测试，应失败**
+
+Run: `pnpm -C frontend exec vitest run src/stores/stores.test.ts`
+Expected: FAIL。`pushNotification is not a function`；且 `pushToast("hello")` 后 `workspaceNotifications` 长度为 1（当前 bug 行为）导致新断言 `toHaveLength(0)` 失败。
+
+- [ ] **Step 3：改写 `frontend/src/stores/app-store.ts`**
+
+1. 删除 `ToastOptions` 接口（第 16-18 行）
+2. 在文件顶部的 type imports 下方、`MAX_WORKSPACE_NOTIFICATIONS` 常量之前，插入规则注释：
+
+```ts
+/**
+ * 通知系统分工规则（issue #351）：
+ *
+ * - pushToast(text, tone)
+ *     用于：用户主动操作的即时反馈。
+ *     典型：表单保存/校验、导入/删除/切换/上传成功、scroll target 未找到、
+ *          后台任务提交成功回执（task_submitted）、轻量错误提示。
+ *
+ * - pushWorkspaceNotification({ text, tone, target })
+ *     用于：后台异步产生的事件，用户可能不在当前页。
+ *     典型：SSE 单条事件留痕（如 agent_update_scene）。
+ *
+ * - pushNotification(text, tone, options?)
+ *     用于：用户需要后续回看的重要结果。
+ *     典型：后台任务失败（剪映/ZIP 导出失败、项目 regenerate 失败、
+ *          参考生视频失败、storyboard/video/character/scene/prop 生成失败）、
+ *          SSE grouped_notification。
+ *
+ * 判断口诀：
+ *   1. 用户现在不在场 → 需要持久
+ *   2. 后台任务"失败"需要留痕排查 → 需要持久
+ *   3. 其余 → 仅 toast
+ *
+ * pushToast 不接受 { persist: true } 之类逃生门，强制调用点三选一，意图显式。
+ */
+```
+
+3. 修改 `AppState` 接口中 `pushToast` 与新增 `pushNotification`：
+
+```ts
+// Toast
+toast: Toast | null;
+pushToast: (text: string, tone?: Toast["tone"]) => void;
+pushNotification: (
+  text: string,
+  tone?: Toast["tone"],
+  options?: { target?: WorkspaceNotificationTarget | null },
+) => void;
+clearToast: () => void;
+workspaceNotifications: WorkspaceNotification[];
+pushWorkspaceNotification: (input: WorkspaceNotificationInput) => void;
+// ... 其余不变
+```
+
+4. 修改 `pushToast` 实现（当前 L116-127），去掉对 `workspaceNotifications` 的副作用与 `options` 参数：
+
+```ts
+pushToast: (text, tone = "info") =>
+  set({
+    toast: { id: `${Date.now()}-${Math.random()}`, text, tone },
+  }),
+```
+
+5. 新增 `pushNotification` 实现，紧跟 `pushToast` 之后、`clearToast` 之前：
+
+```ts
+pushNotification: (text, tone = "info", options) => {
+  get().pushToast(text, tone);
+  get().pushWorkspaceNotification({
+    text,
+    tone,
+    target: options?.target ?? null,
+  });
+},
+```
+
+（`get` 已在 `create<AppState>((set, get) => ({...}))` 签名中。）
+
+- [ ] **Step 4：运行测试，应通过**
+
+Run: `pnpm -C frontend exec vitest run src/stores/stores.test.ts`
+Expected: PASS。
+
+- [ ] **Step 5：确认 typecheck 不挂**
+
+Run: `pnpm -C frontend exec tsc --noEmit`
+Expected: 无错误。由于全仓无 3-arg `pushToast` 调用，签名收窄不触发 fallout。
+
+- [ ] **Step 6：Commit**
+
+```bash
+git add frontend/src/stores/app-store.ts frontend/src/stores/stores.test.ts
+git commit -m "refactor(app-store): toast 与持久通知入口解耦 (#351)
+
+pushToast 只写 toast，新增 pushNotification 组合便利，pushWorkspaceNotification 不变。
+store 头部写入分工规则注释。"
+```
+
+---
+
+## Task 2：迁移 GlobalHeader（剪映 / ZIP 导出失败）
+
+**Files:**
+- Modify: `frontend/src/components/layout/GlobalHeader.tsx`
+
+- [ ] **Step 1：替换 L194 剪映导出失败**
+
+原（L194）：
+```tsx
+useAppStore.getState().pushToast(t("dashboard:jianying_export_failed", { message: errMsg(err) }), "error");
+```
+
+改为：
+```tsx
+useAppStore.getState().pushNotification(t("dashboard:jianying_export_failed", { message: errMsg(err) }), "error");
+```
+
+- [ ] **Step 2：替换 L221-223 ZIP 导出失败**
+
+原：
+```tsx
+useAppStore
+  .getState()
+  .pushToast(t("dashboard:export_failed", { message: errMsg(err) }), "error");
+```
+
+改为：
+```tsx
+useAppStore
+  .getState()
+  .pushNotification(t("dashboard:export_failed", { message: errMsg(err) }), "error");
+```
+
+L192、L213、L218 成功/警告三处保持 `pushToast` 不动。
+
+- [ ] **Step 3：跑前端 check**
+
+Run: `pnpm -C frontend check`
+Expected: PASS（typecheck + test）。`GlobalHeader.test.tsx:113` 用的是 `pushWorkspaceNotification`，不受影响。
+
+- [ ] **Step 4：Commit**
+
+```bash
+git add frontend/src/components/layout/GlobalHeader.tsx
+git commit -m "refactor(global-header): 剪映/ZIP 导出失败改用 pushNotification (#351)"
+```
+
+---
+
+## Task 3：迁移 OverviewCanvas（regenerate 失败）
+
+**Files:**
+- Modify: `frontend/src/components/canvas/OverviewCanvas.tsx`
+
+- [ ] **Step 1：替换 L120-122 regenerate 失败**
+
+原：
+```tsx
+useAppStore
+  .getState()
+  .pushToast(`${tRef.current("regenerate_failed")}${errMsg(err)}`, "error");
+```
+
+改为：
+```tsx
+useAppStore
+  .getState()
+  .pushNotification(`${tRef.current("regenerate_failed")}${errMsg(err)}`, "error");
+```
+
+L80 素材导入 toast 与 L118 regenerate 成功保持 `pushToast`。
+
+- [ ] **Step 2：跑前端 check**
+
+Run: `pnpm -C frontend check`
+Expected: PASS。
+
+- [ ] **Step 3：Commit**
+
+```bash
+git add frontend/src/components/canvas/OverviewCanvas.tsx
+git commit -m "refactor(overview-canvas): regenerate 失败改用 pushNotification (#351)"
+```
+
+---
+
+## Task 4：迁移 StudioCanvasRouter（所有 `_failed` 分支）
+
+**Files:**
+- Modify: `frontend/src/components/canvas/StudioCanvasRouter.tsx`
+
+把以下 13 处 `pushToast(...,"error")` 整体替换为 `pushNotification(...,"error")`。全部保留其他参数与文本不变，**只换方法名**。
+
+- [ ] **Step 1：逐行替换**
+
+| 行 | key |
+|---|---|
+| L159 | `update_prompt_failed` |
+| L176 | `generate_storyboard_failed` |
+| L194 | `generate_video_failed` |
+| L230 | `update_character_failed` |
+| L246 | `submit_failed`（character） |
+| L271 | `add_failed`（character） |
+| L283 | `update_scene_failed` |
+| L293 | `submit_failed`（scene） |
+| L304 | `add_failed`（scene） |
+| L316 | `update_prop_failed` |
+| L326 | `submit_failed`（prop） |
+| L337 | `add_failed`（prop） |
+| L348 | `grid_generation_failed` |
+
+示例（L159）：
+```tsx
+// before
+useAppStore.getState().pushToast(tRef.current("update_prompt_failed", { message: errMsg(err) }), "error");
+// after
+useAppStore.getState().pushNotification(tRef.current("update_prompt_failed", { message: errMsg(err) }), "error");
+```
+
+**保持不动的**：task_submitted（L174/192/244/291/324/335）、character/scene/prop `_added` 与 `_updated`（L228/269/302）、grid 成功（L346）——全部继续用 `pushToast`。
+
+- [ ] **Step 2：核对替换数量**
+
+Run: `grep -n "pushNotification" frontend/src/components/canvas/StudioCanvasRouter.tsx | wc -l`
+Expected: `13`。
+
+Run: `grep -cn 'pushToast(.*, *"error")' frontend/src/components/canvas/StudioCanvasRouter.tsx`
+Expected: `0`。
+
+- [ ] **Step 3：跑前端 check**
+
+Run: `pnpm -C frontend check`
+Expected: PASS。
+
+- [ ] **Step 4：Commit**
+
+```bash
+git add frontend/src/components/canvas/StudioCanvasRouter.tsx
+git commit -m "refactor(studio-canvas): 生成失败路径改用 pushNotification (#351)"
+```
+
+---
+
+## Task 5：迁移 ReferenceVideoCanvas（后台任务失败 polling）
+
+**Files:**
+- Modify: `frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx`
+
+- [ ] **Step 1：替换 L134 task 轮询检测到失败的 toast**
+
+原（L128-141 片段，焦点是 L134）：
+```tsx
+if (tk.status === "failed" && before !== undefined && before !== "failed") {
+  useAppStore.getState().pushToast(
+    t("reference_generation_task_failed", {
+      unitId: tk.resource_id,
+      reason: tk.error_message ?? t("reference_status_failed"),
+    }),
+    "error",
+  );
+}
+```
+
+改为（仅方法名改为 `pushNotification`）：
+```tsx
+if (tk.status === "failed" && before !== undefined && before !== "failed") {
+  useAppStore.getState().pushNotification(
+    t("reference_generation_task_failed", {
+      unitId: tk.resource_id,
+      reason: tk.error_message ?? t("reference_status_failed"),
+    }),
+    "error",
+  );
+}
+```
+
+- [ ] **Step 2：确认 L56 `toastError` 工具与 L186 queued/deduped 保持不动**
+
+`toastError`（L52-57）服务于 `handleAdd` / `handleGenerate` 的 POST 即时失败，属于用户操作即时反馈 → 继续用 `pushToast`。
+L186 `reference_generate_queued` / `reference_generate_deduped` 是 POST 成功反馈 → 继续用 `pushToast`。
+
+核对：`grep -n "pushToast\|pushNotification" frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx`
+Expected：两处 `pushToast`（L56 `toastError` + L186 queued/deduped）+ 一处 `pushNotification`（L134）。
+
+- [ ] **Step 3：跑前端 check**
+
+Run: `pnpm -C frontend check`
+Expected: PASS。
+
+- [ ] **Step 4：Commit**
+
+```bash
+git add frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+git commit -m "refactor(reference-video): 任务轮询检测到失败改用 pushNotification (#351)"
+```
+
+---
+
+## Task 6：迁移 useProjectEventsSSE（同步失败 + grouped_notification）
+
+**Files:**
+- Modify: `frontend/src/hooks/useProjectEventsSSE.ts`
+
+注意：L250 的 `grouped_notification` 在当前代码里依赖的是 `pushToast` 的 bug 副作用写入 drawer。Store API 收敛后它只会出 toast 不再入 drawer——必须迁移到 `pushNotification` 才能保持既有的 toast + 持久行为。
+
+- [ ] **Step 1：替换 L174 同步失败**
+
+原：
+```ts
+pushToast(`同步项目变更失败: ${errMsg(err)}`, "warning");
+```
+
+改为：
+```ts
+pushNotification(`同步项目变更失败: ${errMsg(err)}`, "warning");
+```
+
+- [ ] **Step 2：替换 L250 grouped_notification**
+
+原（L245-252 片段）：
+```ts
+if (payload.source !== "webui") {
+  for (const group of groupedChanges) {
+    if (!hasImportantChanges(group)) {
+      continue;
+    }
+    pushToast(formatGroupedNotificationText(group), "success");
+  }
+}
+```
+
+改为：
+```ts
+if (payload.source !== "webui") {
+  for (const group of groupedChanges) {
+    if (!hasImportantChanges(group)) {
+      continue;
+    }
+    pushNotification(formatGroupedNotificationText(group), "success");
+  }
+}
+```
+
+- [ ] **Step 3：导入与 selector 更新**
+
+在 hook 顶部现有的 `const pushToast = useAppStore((s) => s.pushToast);` 附近（约 L122-123）新增：
+
+```ts
+const pushNotification = useAppStore((s) => s.pushNotification);
+```
+
+并把 `pushNotification` 加入 useEffect 的依赖数组（约 L335-342）。检查：
+- `pushToast` 若在 hook 内不再被使用，同时删除该 selector 与依赖；
+- 若仍在别处使用（例如 SSE 连接失败也用 pushToast？），grep 核对后保留。
+
+Run: `grep -n "pushToast\|pushNotification" frontend/src/hooks/useProjectEventsSSE.ts`
+按实际使用裁剪 selector 和依赖数组，避免 eslint-react-hooks 抱怨。
+
+- [ ] **Step 4：跑前端 check**
+
+Run: `pnpm -C frontend check`
+Expected: PASS。
+
+- [ ] **Step 5：Commit**
+
+```bash
+git add frontend/src/hooks/useProjectEventsSSE.ts
+git commit -m "refactor(project-events): grouped_notification 与同步失败改用 pushNotification (#351)
+
+前者过去依赖 pushToast 的 bug 副作用写入 drawer，store 解耦后需显式 pushNotification 才能保持持久化。"
+```
+
+---
+
+## Task 7：最终验证
+
+**Files:** 无修改（仅验证）。
+
+- [ ] **Step 1：grep 确认 pushNotification 使用位点**
+
+Run:
+```bash
+grep -rn "pushNotification" frontend/src --include="*.ts" --include="*.tsx" | grep -v test
+```
+Expected 行数 ≈ 19（1 store 定义 + 1 GlobalHeader + 1 OverviewCanvas + 13 StudioCanvasRouter + 1 ReferenceVideoCanvas + 2 useProjectEventsSSE）。允许偏差 ±2。
+
+- [ ] **Step 2：grep 确认没有 pushToast(..., { target })**
+
+Run:
+```bash
+grep -rnE "pushToast\([^)]*,[^)]*,\s*\{\s*target" frontend/src --include="*.ts" --include="*.tsx"
+```
+Expected: 无输出。
+
+- [ ] **Step 3：全套 check + build**
+
+```bash
+pnpm -C frontend check
+pnpm -C frontend build
+```
+Expected: PASS / 构建成功。
+
+- [ ] **Step 4：手工验证清单**
+
+启动 dev（后端 + 前端），按顺序过：
+1. 编辑剧本保存（PreprocessingView）→ toast 出现，drawer **不新增** ✓
+2. 切换剧集模式（EpisodeModeSwitcher）→ toast，drawer 不新增 ✓
+3. 触发剪映导出失败（断网或改坏 API key）→ toast + drawer 均留痕 ✓
+4. 触发项目 regenerate 失败 → toast + drawer 均留痕 ✓
+5. 后台 SSE grouped_notification（等 agent 改动落盘）→ toast + drawer 均留痕 ✓
+
+如任一 broken，回到对应 Task 复查。
+
+- [ ] **Step 5：若 Step 4 全部通过，无需再 commit（本任务无文件改动）**
+
+至此 issue #351 DoD 三项全部达成。
+
+---
+
+## Self-Review 备忘
+
+本计划对齐 spec 的三项验收：
+1. **API 解耦** — Task 1 完成。
+2. **分工规则** — Task 1 注释 + spec 固化。
+3. **调用点迁移** — Task 2-6 覆盖 spec §迁移映射的所有具名位点；其余调用点保留 `pushToast` 语义不动（Task 7 Step 2 兜底）。
+
+**回归防护**：Task 1 的三条断言直接覆盖 issue 根因（`pushToast` 不再写 drawer）+ 两条组合函数语义。

--- a/docs/superpowers/specs/2026-04-23-toast-notification-split-design.md
+++ b/docs/superpowers/specs/2026-04-23-toast-notification-split-design.md
@@ -91,8 +91,9 @@ pushNotification: (
 - task_submitted（L174/192/244/291/324）和 grid 成功（L346）保持 `pushToast`
 
 **`frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx`**
-- L56 统一 `showError` → `pushNotification`
-- L134 / L186 需逐条判断：失败分支用 `pushNotification`，成功分支用 `pushToast`（迁移时读取上下文决定）
+- L134 task-poll 检测到后台任务失败（`reference_generation_task_failed`）→ `pushNotification`
+- L56 `toastError` 工具 —— 仅用于 `handleAdd` / `handleGenerate` 的 POST 即时失败，属于用户操作即时反馈 → 保持 `pushToast`（不动）
+- L186 `reference_generate_queued` / `reference_generate_deduped` 属于用户操作成功反馈 → 保持 `pushToast`（不动）
 
 **`frontend/src/hooks/useProjectEventsSSE.ts`**
 - L174 同步项目变更失败 → `pushNotification`

--- a/docs/superpowers/specs/2026-04-23-toast-notification-split-design.md
+++ b/docs/superpowers/specs/2026-04-23-toast-notification-split-design.md
@@ -1,0 +1,183 @@
+# Toast 与持久通知拆分（Issue #351）
+
+## 背景
+
+`frontend/src/stores/app-store.ts:116-127` 的 `pushToast` 在每次调用时强制写入 `workspaceNotifications`，导致瞬时 toast 与 drawer 持久通知的分工失效。全仓 60+ 非测试调用点都走这同一条 API，drawer 被保存成功、模式切换这类日常即时反馈塞爆。
+
+这是「剧本生成阶段弹出耗时提示通知」feature 的前置依赖。
+
+## 目标与非目标
+
+**目标**
+1. 在 store 层把瞬时（toast）与持久（drawer）通知解耦，提供三个语义清晰的入口
+2. 按既定规则迁移全部现有调用点，无功能回归
+3. 沉淀分类规则，避免后续新加调用点再次混用
+
+**非目标**
+- 不调整 drawer UI / 通知项样式
+- 不调整 toast 显示时长、堆叠、动画
+- 不改动 `WorkspaceNotification` / `WorkspaceNotificationInput` 数据结构
+- 不重写 SSE 层的通知生成逻辑
+
+## 架构
+
+### Store API（`frontend/src/stores/app-store.ts`）
+
+```ts
+// 入口一：仅瞬时 toast（不再触达 workspaceNotifications）
+pushToast: (text: string, tone?: Toast["tone"]) => void
+
+// 入口二：仅持久（已存在，保留，不改）
+pushWorkspaceNotification: (input: WorkspaceNotificationInput) => void
+
+// 入口三：组合便利——同时 toast + 写入 drawer（新增）
+pushNotification: (
+  text: string,
+  tone?: Toast["tone"],
+  options?: { target?: WorkspaceNotificationTarget | null },
+) => void
+```
+
+实现关系：`pushNotification` 内部调用 `pushToast` 与 `pushWorkspaceNotification`，不是第三条独立数据路径。
+
+**签名收窄**：`pushToast` 原签名的第三个参数 `options: { target }` 被移除；`target` 只对持久化有意义，随 `pushNotification` / `pushWorkspaceNotification` 传递。
+
+**类型清理**：删除 `ToastOptions` interface（仅有 target 字段，语义已并入 `pushNotification`）。
+
+### 分类规则
+
+写入 `frontend/src/stores/app-store.ts` 顶部注释（紧邻三个 API 定义），作为长期指南：
+
+| API | 用于 | 典型场景 |
+|---|---|---|
+| `pushToast` | 用户主动操作的即时反馈 | 表单保存/校验（成功 + 失败）、导入/删除/切换/上传、scroll target 未找到、后台任务提交成功回执、轻量错误 |
+| `pushWorkspaceNotification` | 后台异步事件留痕（用户可能不在当前页） | SSE 单条事件（如 `agent_update_scene`） |
+| `pushNotification` | 用户需要后续回看的重要结果 | 后台任务**失败**、SSE grouped_notification |
+
+**判断口诀**
+1. 用户现在不在场 → 需要持久
+2. 后台任务"失败"需要留痕排查 → 需要持久
+3. 其余 → 仅 toast
+
+**不提供逃生门**：`pushToast` 不接受 `{ persist: true }` 之类选项，强制调用点三选一，意图显式。
+
+## 迁移映射
+
+### → `pushNotification`（toast + 持久）
+
+**`frontend/src/components/layout/GlobalHeader.tsx`**
+- L194 剪映导出失败
+- L223 ZIP 导出失败
+- L192/213/218 的**成功**保持 `pushToast`
+
+**`frontend/src/components/canvas/OverviewCanvas.tsx`**
+- L122 regenerate 失败
+- L80/L118 保持 `pushToast`
+
+**`frontend/src/components/canvas/StudioCanvasRouter.tsx`** — 所有 `_failed` 失败分支
+- L159 `update_prompt_failed`
+- L176 `generate_storyboard_failed`
+- L194 `generate_video_failed`
+- L230 `update_character_failed`
+- L246 `submit_failed`（character）
+- L271 `add_failed`（character）
+- L283 `update_scene_failed`
+- L293 `submit_failed`（scene）
+- L304 `add_failed`（scene）
+- L316 `update_prop_failed`
+- L326 `submit_failed`（prop）
+- L337 `add_failed`（prop）
+- L348 `grid_generation_failed`
+- task_submitted（L174/192/244/291/324）和 grid 成功（L346）保持 `pushToast`
+
+**`frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx`**
+- L56 统一 `showError` → `pushNotification`
+- L134 / L186 需逐条判断：失败分支用 `pushNotification`，成功分支用 `pushToast`（迁移时读取上下文决定）
+
+**`frontend/src/hooks/useProjectEventsSSE.ts`**
+- L174 同步项目变更失败 → `pushNotification`
+- L250 grouped_notification → `pushNotification`（取代当前「pushToast + 强制持久」的副作用链）
+- L280 已是 `pushWorkspaceNotification`，不动
+
+### → `pushToast`（仅瞬时）
+
+其余全部调用点一律迁移为 `pushToast`。包括但不限于：
+- `EpisodeModeSwitcher.tsx`、`VersionTimeMachine.tsx`
+- `PreprocessingView.tsx`、`ProjectSettingsPage.tsx`、`AgentConfigTab.tsx`
+- `settings/MediaModelSection.tsx`、`settings/CustomProviderForm.tsx`、`settings/CustomProviderDetail.tsx`
+- `ApiKeysTab.tsx`
+- `lorebook/CharacterCard.tsx` / `SceneCard.tsx` / `PropCard.tsx`
+- `lorebook/CharactersPage.tsx` / `ScenesPage.tsx` / `PropsPage.tsx`
+- `AddToLibraryButton.tsx`、`AssetLibraryPage.tsx`、`AssetSidebar.tsx`
+- `CreateProjectModal.tsx`、`ProjectsPage.tsx`（含 L262 删除失败——前台操作即时反馈归 toast）
+- `useScrollTarget.ts`
+
+### 测试文件同步更新
+
+- `frontend/src/stores/stores.test.ts`
+- `frontend/src/components/layout/GlobalHeader.test.tsx`
+- `frontend/src/components/canvas/EpisodeModeSwitcher.test.tsx`
+
+任何 spy `pushToast` 并验证「同时写入 workspaceNotifications」的断言需要移除——那是当前 bug 行为，不是规范。
+
+## 数据流
+
+```
+pushToast(text, tone)
+   └─→ set({ toast: {...} })
+                           （workspaceNotifications 不动）
+
+pushWorkspaceNotification(input)
+   └─→ set({ workspaceNotifications: [...] })
+                           （toast 不动）
+
+pushNotification(text, tone, options)
+   ├─→ pushToast(text, tone)
+   └─→ pushWorkspaceNotification({ text, tone, target })
+```
+
+## 错误处理
+
+此重构不涉及运行时错误处理。迁移若出错（漏改、类型不匹配）在 typecheck 阶段暴露：`pushToast` 签名收窄后，旧的 `pushToast(text, tone, { target })` 调用会编译失败，迫使调用点显式选择新 API。
+
+## 测试策略
+
+### 单元测试（`stores.test.ts`）新增三个关键断言
+
+1. `pushToast` 只写 `toast`，**不**写 `workspaceNotifications` — 直接覆盖 issue 根因
+2. `pushWorkspaceNotification` 只写 `workspaceNotifications`，**不**写 `toast`
+3. `pushNotification` 两者都写；tone 与 target 正确传递
+
+### 已有测试修正
+
+- `EpisodeModeSwitcher.test.tsx` — spy 调用点语义不变，但若存在对 workspaceNotifications 的隐式断言需移除
+- `GlobalHeader.test.tsx` — L113 用 `pushWorkspaceNotification`，不受影响
+
+### 手工验证清单（迁移完成后过一遍）
+
+- 编辑剧本保存 → 只弹 toast，drawer 不新增
+- 导出剪映失败 → toast + drawer 留痕
+- 切换剧集模式 → 只弹 toast
+- 项目 regenerate 失败 → toast + drawer
+- SSE grouped_notification → toast + drawer（回归保持）
+- drawer 通知数量不再被日常操作塞爆
+
+### 不做的测试
+
+- 不为每个调用点写专属单测（YAGNI）
+- 不做 e2e——手工验证覆盖足够，改动集中在 store 层 + 调用点简单替换
+
+## 实施顺序（给 writing-plans 参考）
+
+1. 改 `app-store.ts`：收窄 `pushToast` 签名、新增 `pushNotification`、删除 `ToastOptions`、写规则注释
+2. 补 `stores.test.ts` 三个关键断言
+3. 批量迁移调用点（按上文清单分文件替换）
+4. 修复已有测试文件
+5. `pnpm check` + `pnpm build` 过 typecheck / test
+6. 手工验证清单过一遍
+
+## 验收清单（Issue DoD 对齐）
+
+- [x] 瞬时（toast）与持久（drawer）通知 API 解耦，可独立调用 — §Store API
+- [x] 明确按通知类型的分工规则 — §分类规则
+- [x] 现有调用点按规则迁移，无功能回归 — §迁移映射 + §测试策略

--- a/docs/superpowers/specs/2026-04-23-toast-notification-split-design.md
+++ b/docs/superpowers/specs/2026-04-23-toast-notification-split-design.md
@@ -74,21 +74,25 @@ pushNotification: (
 - L122 regenerate 失败
 - L80/L118 保持 `pushToast`
 
-**`frontend/src/components/canvas/StudioCanvasRouter.tsx`** — 所有 `_failed` 失败分支
-- L159 `update_prompt_failed`
-- L176 `generate_storyboard_failed`
-- L194 `generate_video_failed`
-- L230 `update_character_failed`
-- L246 `submit_failed`（character）
+**`frontend/src/components/canvas/StudioCanvasRouter.tsx`** — 仅**后台异步生成任务**失败分支（修正：同步 CRUD 失败属于即时反馈归 `pushToast`，详见下方）
+- L176 `generate_storyboard_failed`（async backend 任务）
+- L194 `generate_video_failed`（async backend 任务）
+- L246 `submit_failed`（character LLM 生成）
 - L271 `add_failed`（character）
-- L283 `update_scene_failed`
-- L293 `submit_failed`（scene）
-- L304 `add_failed`（scene）
-- L316 `update_prop_failed`
-- L326 `submit_failed`（prop）
-- L337 `add_failed`（prop）
+- L293 `submit_failed`（scene LLM 生成）
+- L326 `submit_failed`（prop LLM 生成）
 - L348 `grid_generation_failed`
-- task_submitted（L174/192/244/291/324）和 grid 成功（L346）保持 `pushToast`
+
+**修正说明（相对初稿）**：以下 7 处属于同步 CRUD（直接写 project.json 或 DB），按「用户主动操作的即时反馈」规则归 `pushToast` 而非 `pushNotification`：
+- L159 `update_prompt_failed`（`API.updateSegment` / `API.updateScene`）
+- L230 `update_character_failed`（`API.updateCharacter`）
+- L271 `add_failed`（character，`API.addCharacter`）
+- L283 `update_scene_failed`（`API.updateProjectScene`）
+- L304 `add_failed`（scene，`API.addProjectScene`）
+- L316 `update_prop_failed`（`API.updateProjectProp`）
+- L337 `add_failed`（prop，`API.addProjectProp`）
+
+task_submitted（L174/192/244/291/324）和 grid 成功（L346）保持 `pushToast`。
 
 **`frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx`**
 - L134 task-poll 检测到后台任务失败（`reference_generation_task_failed`）→ `pushNotification`

--- a/frontend/src/components/canvas/OverviewCanvas.tsx
+++ b/frontend/src/components/canvas/OverviewCanvas.tsx
@@ -119,7 +119,7 @@ export function OverviewCanvas({ projectName, projectData }: OverviewCanvasProps
     } catch (err) {
       useAppStore
         .getState()
-        .pushNotification(`${tRef.current("regenerate_failed")}${errMsg(err)}`, "error");
+        .pushNotification(tRef.current("regenerate_failed", { message: errMsg(err) }), "error");
     } finally {
       setRegenerating(false);
     }

--- a/frontend/src/components/canvas/OverviewCanvas.tsx
+++ b/frontend/src/components/canvas/OverviewCanvas.tsx
@@ -238,7 +238,7 @@ export function OverviewCanvas({ projectName, projectData }: OverviewCanvasProps
             )}
             {costError && (
               <div className="rounded-xl border border-red-900/50 bg-red-950/30 p-4">
-                <p className="text-sm text-red-400">{t("cost_estimate_failed")}{costError}</p>
+                <p className="text-sm text-red-400">{t("cost_estimate_failed", { message: costError })}</p>
               </div>
             )}
 

--- a/frontend/src/components/canvas/OverviewCanvas.tsx
+++ b/frontend/src/components/canvas/OverviewCanvas.tsx
@@ -119,7 +119,7 @@ export function OverviewCanvas({ projectName, projectData }: OverviewCanvasProps
     } catch (err) {
       useAppStore
         .getState()
-        .pushToast(`${tRef.current("regenerate_failed")}${errMsg(err)}`, "error");
+        .pushNotification(`${tRef.current("regenerate_failed")}${errMsg(err)}`, "error");
     } finally {
       setRegenerating(false);
     }

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -156,7 +156,7 @@ export function StudioCanvasRouter() {
       }
       await refreshProject();
     } catch (err) {
-      useAppStore.getState().pushToast(tRef.current("update_prompt_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(tRef.current("update_prompt_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName, currentProjectData, refreshProject]);
 
@@ -173,7 +173,7 @@ export function StudioCanvasRouter() {
       );
       useAppStore.getState().pushToast(tRef.current("storyboard_task_submitted_toast", { id: segmentId }), "success");
     } catch (err) {
-      useAppStore.getState().pushToast(tRef.current("generate_storyboard_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(tRef.current("generate_storyboard_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName, currentScripts]);
 
@@ -191,7 +191,7 @@ export function StudioCanvasRouter() {
       );
       useAppStore.getState().pushToast(tRef.current("video_task_submitted_toast", { id: segmentId }), "success");
     } catch (err) {
-      useAppStore.getState().pushToast(tRef.current("generate_video_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(tRef.current("generate_video_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName, currentScripts]);
 
@@ -227,7 +227,7 @@ export function StudioCanvasRouter() {
       );
       useAppStore.getState().pushToast(tRef.current("character_updated_toast", { name }), "success");
     } catch (err) {
-      useAppStore.getState().pushToast(tRef.current("update_character_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(tRef.current("update_character_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName, refreshProject]);
 
@@ -243,7 +243,7 @@ export function StudioCanvasRouter() {
         .getState()
         .pushToast(tRef.current("character_task_submitted_toast", { name }), "success");
     } catch (err) {
-      useAppStore.getState().pushToast(tRef.current("submit_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(tRef.current("submit_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName, currentProjectData]);
 
@@ -268,7 +268,7 @@ export function StudioCanvasRouter() {
       );
       useAppStore.getState().pushToast(tRef.current("character_added_toast", { name }), "success");
     } catch (err) {
-      useAppStore.getState().pushToast(tRef.current("add_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(tRef.current("add_failed", { message: errMsg(err) }), "error");
       throw err; // AssetFormModal onSubmit 消费：失败时阻止 setAdding(false) 关闭对话框
     }
   }, [currentProjectName, refreshProject]);
@@ -280,7 +280,7 @@ export function StudioCanvasRouter() {
       await API.updateProjectScene(currentProjectName, name, updates);
       await refreshProject();
     } catch (err) {
-      useAppStore.getState().pushToast(tRef.current("update_scene_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(tRef.current("update_scene_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName, refreshProject]);
 
@@ -290,7 +290,7 @@ export function StudioCanvasRouter() {
       await API.generateProjectScene(currentProjectName, name, currentProjectData?.scenes?.[name]?.description ?? "");
       useAppStore.getState().pushToast(tRef.current("scene_task_submitted_toast", { name }), "success");
     } catch (err) {
-      useAppStore.getState().pushToast(tRef.current("submit_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(tRef.current("submit_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName, currentProjectData]);
 
@@ -301,7 +301,7 @@ export function StudioCanvasRouter() {
       await refreshProject();
       useAppStore.getState().pushToast(tRef.current("scene_added_toast", { name }), "success");
     } catch (err) {
-      useAppStore.getState().pushToast(tRef.current("add_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(tRef.current("add_failed", { message: errMsg(err) }), "error");
       throw err; // AssetFormModal onSubmit 消费：失败时阻止 setAdding(false) 关闭对话框
     }
   }, [currentProjectName, refreshProject]);
@@ -313,7 +313,7 @@ export function StudioCanvasRouter() {
       await API.updateProjectProp(currentProjectName, name, updates);
       await refreshProject();
     } catch (err) {
-      useAppStore.getState().pushToast(tRef.current("update_prop_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(tRef.current("update_prop_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName, refreshProject]);
 
@@ -323,7 +323,7 @@ export function StudioCanvasRouter() {
       await API.generateProjectProp(currentProjectName, name, currentProjectData?.props?.[name]?.description ?? "");
       useAppStore.getState().pushToast(tRef.current("prop_task_submitted_toast", { name }), "success");
     } catch (err) {
-      useAppStore.getState().pushToast(tRef.current("submit_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(tRef.current("submit_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName, currentProjectData]);
 
@@ -334,7 +334,7 @@ export function StudioCanvasRouter() {
       await refreshProject();
       useAppStore.getState().pushToast(tRef.current("prop_added_toast", { name }), "success");
     } catch (err) {
-      useAppStore.getState().pushToast(tRef.current("add_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(tRef.current("add_failed", { message: errMsg(err) }), "error");
       throw err; // AssetFormModal onSubmit 消费：失败时阻止 setAdding(false) 关闭对话框
     }
   }, [currentProjectName, refreshProject]);
@@ -345,7 +345,7 @@ export function StudioCanvasRouter() {
       const result = await API.generateGrid(currentProjectName, episode, scriptFile, sceneIds);
       useAppStore.getState().pushToast(result.message, "success");
     } catch (err) {
-      useAppStore.getState().pushToast(tRef.current("grid_generation_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(tRef.current("grid_generation_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName]);
 

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -156,7 +156,7 @@ export function StudioCanvasRouter() {
       }
       await refreshProject();
     } catch (err) {
-      useAppStore.getState().pushNotification(tRef.current("update_prompt_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushToast(tRef.current("update_prompt_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName, currentProjectData, refreshProject]);
 
@@ -227,7 +227,7 @@ export function StudioCanvasRouter() {
       );
       useAppStore.getState().pushToast(tRef.current("character_updated_toast", { name }), "success");
     } catch (err) {
-      useAppStore.getState().pushNotification(tRef.current("update_character_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushToast(tRef.current("update_character_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName, refreshProject]);
 
@@ -268,7 +268,7 @@ export function StudioCanvasRouter() {
       );
       useAppStore.getState().pushToast(tRef.current("character_added_toast", { name }), "success");
     } catch (err) {
-      useAppStore.getState().pushNotification(tRef.current("add_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushToast(tRef.current("add_failed", { message: errMsg(err) }), "error");
       throw err; // AssetFormModal onSubmit 消费：失败时阻止 setAdding(false) 关闭对话框
     }
   }, [currentProjectName, refreshProject]);
@@ -280,7 +280,7 @@ export function StudioCanvasRouter() {
       await API.updateProjectScene(currentProjectName, name, updates);
       await refreshProject();
     } catch (err) {
-      useAppStore.getState().pushNotification(tRef.current("update_scene_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushToast(tRef.current("update_scene_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName, refreshProject]);
 
@@ -301,7 +301,7 @@ export function StudioCanvasRouter() {
       await refreshProject();
       useAppStore.getState().pushToast(tRef.current("scene_added_toast", { name }), "success");
     } catch (err) {
-      useAppStore.getState().pushNotification(tRef.current("add_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushToast(tRef.current("add_failed", { message: errMsg(err) }), "error");
       throw err; // AssetFormModal onSubmit 消费：失败时阻止 setAdding(false) 关闭对话框
     }
   }, [currentProjectName, refreshProject]);
@@ -313,7 +313,7 @@ export function StudioCanvasRouter() {
       await API.updateProjectProp(currentProjectName, name, updates);
       await refreshProject();
     } catch (err) {
-      useAppStore.getState().pushNotification(tRef.current("update_prop_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushToast(tRef.current("update_prop_failed", { message: errMsg(err) }), "error");
     }
   }, [currentProjectName, refreshProject]);
 
@@ -334,7 +334,7 @@ export function StudioCanvasRouter() {
       await refreshProject();
       useAppStore.getState().pushToast(tRef.current("prop_added_toast", { name }), "success");
     } catch (err) {
-      useAppStore.getState().pushNotification(tRef.current("add_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushToast(tRef.current("add_failed", { message: errMsg(err) }), "error");
       throw err; // AssetFormModal onSubmit 消费：失败时阻止 setAdding(false) 关闭对话框
     }
   }, [currentProjectName, refreshProject]);

--- a/frontend/src/components/canvas/WelcomeCanvas.tsx
+++ b/frontend/src/components/canvas/WelcomeCanvas.tsx
@@ -81,7 +81,7 @@ export function WelcomeCanvas({
       try {
         await onUpload(file);
       } catch (err) {
-        setError(`${t("upload_failed")}${errMsg(err)}`);
+        setError(t("upload_failed", { message: errMsg(err) }));
         setPhase(sourceFiles.length > 0 ? "has_sources" : "idle");
         return;
       }
@@ -97,7 +97,7 @@ export function WelcomeCanvas({
           await onAnalyze();
           setPhase("done");
         } catch (err) {
-          setError(`${t("analysis_failed")}${errMsg(err)}`);
+          setError(t("analysis_failed", { message: errMsg(err) }));
           setPhase("has_sources");
         }
         return;
@@ -116,7 +116,7 @@ export function WelcomeCanvas({
       await onAnalyze();
       setPhase("done");
     } catch (err) {
-      setError(`${t("analysis_failed")}${errMsg(err)}`);
+      setError(t("analysis_failed", { message: errMsg(err) }));
       setPhase("has_sources");
     }
   }, [onAnalyze, t]);

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -131,7 +131,7 @@ export function ReferenceVideoCanvas({ projectName, episode, episodeTitle }: Ref
     for (const tk of relevantTasks) {
       const before = prev.get(tk.task_id);
       if (tk.status === "failed" && before !== undefined && before !== "failed") {
-        useAppStore.getState().pushToast(
+        useAppStore.getState().pushNotification(
           t("reference_generation_task_failed", {
             unitId: tk.resource_id,
             reason: tk.error_message ?? t("reference_status_failed"),

--- a/frontend/src/components/layout/GlobalHeader.tsx
+++ b/frontend/src/components/layout/GlobalHeader.tsx
@@ -191,7 +191,7 @@ export function GlobalHeader({ onNavigateBack }: GlobalHeaderProps) {
       setExportDialogOpen(false);
       useAppStore.getState().pushToast(t("dashboard:jianying_export_started"), "success");
     } catch (err) {
-      useAppStore.getState().pushToast(t("dashboard:jianying_export_failed", { message: errMsg(err) }), "error");
+      useAppStore.getState().pushNotification(t("dashboard:jianying_export_failed", { message: errMsg(err) }), "error");
     } finally {
       setJianyingExporting(false);
     }
@@ -220,7 +220,7 @@ export function GlobalHeader({ onNavigateBack }: GlobalHeaderProps) {
     } catch (err) {
       useAppStore
         .getState()
-        .pushToast(t("dashboard:export_failed", { message: errMsg(err) }), "error");
+        .pushNotification(t("dashboard:export_failed", { message: errMsg(err) }), "error");
     } finally {
       setExportingProject(false);
     }

--- a/frontend/src/components/pages/AgentConfigTab.tsx
+++ b/frontend/src/components/pages/AgentConfigTab.tsx
@@ -242,7 +242,7 @@ export function AgentConfigTab({ visible }: AgentConfigTabProps) {
         voidCall(useConfigStatusStore.getState().refresh());
         useAppStore.getState().pushToast(`${t(`dashboard:${label}`)} ${t("field_cleared")}`, "success");
       } catch (err) {
-        useAppStore.getState().pushToast(`${t("clear_failed")}${errMsg(err)}`, "error");
+        useAppStore.getState().pushToast(t("clear_failed", { message: errMsg(err) }), "error");
       } finally {
         setClearingField(null);
       }
@@ -256,7 +256,7 @@ export function AgentConfigTab({ visible }: AgentConfigTabProps) {
   if (loadError) {
     return (
       <div className={visible ? "px-6 py-8" : "hidden"}>
-        <div className="text-sm text-rose-400">{t("load_failed")}{loadError}</div>
+        <div className="text-sm text-rose-400">{t("load_failed", { message: loadError })}</div>
         <button
           type="button"
           onClick={() => void load()}

--- a/frontend/src/components/pages/ApiKeysTab.tsx
+++ b/frontend/src/components/pages/ApiKeysTab.tsx
@@ -81,7 +81,7 @@ function CreateModal({ onClose, onCreated }: CreateModalProps) {
         last_used_at: null,
       });
     } catch (err) {
-      useAppStore.getState().pushToast(`${t("create_failed")}${errMsg(err)}`, "error");
+      useAppStore.getState().pushToast(t("create_failed", { message: errMsg(err) }), "error");
     } finally {
       setCreating(false);
     }
@@ -247,7 +247,7 @@ export function ApiKeysTab() {
       const res = await API.listApiKeys();
       setApiKeys(res);
     } catch (err) {
-      useAppStore.getState().pushToast(`${tRef.current("load_failed")}${errMsg(err)}`, "error");
+      useAppStore.getState().pushToast(tRef.current("load_failed", { message: errMsg(err) }), "error");
     } finally {
       setLoading(false);
     }
@@ -268,7 +268,7 @@ export function ApiKeysTab() {
         setApiKeys((prev) => prev.filter((k) => k.id !== key.id));
         useAppStore.getState().pushToast(tRef.current("key_deleted_success"), "success");
       } catch (err) {
-        useAppStore.getState().pushToast(`${tRef.current("delete_failed")}${errMsg(err)}`, "error");
+        useAppStore.getState().pushToast(tRef.current("delete_failed", { message: errMsg(err) }), "error");
       } finally {
         setDeletingId(null);
       }

--- a/frontend/src/components/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.tsx
@@ -237,7 +237,7 @@ export function ProjectSettingsPage() {
       initialStyleRef.current = nextStyle;
       useAppStore.getState().pushToast(t("saved"), "success");
     } catch (e: unknown) {
-      useAppStore.getState().pushToast(errMsg(e, t("save_failed")), "error");
+      useAppStore.getState().pushToast(t("save_failed", { message: errMsg(e) }), "error");
     } finally {
       setSavingStyle(false);
     }
@@ -274,7 +274,7 @@ export function ProjectSettingsPage() {
       };
       useAppStore.getState().pushToast(t("saved"), "success");
     } catch (e: unknown) {
-      useAppStore.getState().pushToast(errMsg(e, t("save_failed")), "error");
+      useAppStore.getState().pushToast(t("save_failed", { message: errMsg(e) }), "error");
     } finally {
       setSaving(false);
     }

--- a/frontend/src/components/pages/settings/CustomProviderDetail.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderDetail.tsx
@@ -61,7 +61,7 @@ export function CustomProviderDetail({ providerId, onDeleted, onSaved }: CustomP
       await API.deleteCustomProvider(providerId);
       onDeleted();
     } catch (e) {
-      showError(errMsg(e, t("delete_failed")));
+      showError(t("delete_failed", { message: errMsg(e) }));
     } finally {
       setDeleting(false);
       setConfirmDelete(false);

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -249,7 +249,7 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
       }
       onSaved();
     } catch (e) {
-      showError(errMsg(e, t("save_failed")));
+      showError(t("save_failed", { message: errMsg(e) }));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/components/pages/settings/MediaModelSection.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.tsx
@@ -56,7 +56,7 @@ export function MediaModelSection() {
       void useConfigStatusStore.getState().refresh();
       useAppStore.getState().pushToast(t("media_config_saved"), "success");
     } catch (err) {
-      useAppStore.getState().pushToast(`${t("save_failed")}${errMsg(err)}`, "error");
+      useAppStore.getState().pushToast(t("save_failed", { message: errMsg(err) }), "error");
     } finally {
       setSaving(false);
     }

--- a/frontend/src/hooks/useProjectEventsSSE.ts
+++ b/frontend/src/hooks/useProjectEventsSSE.ts
@@ -119,7 +119,7 @@ export function useProjectEventsSSE(projectName?: string | null): void {
   const invalidateEntities = useAppStore((s) => s.invalidateEntities);
   const triggerScrollTo = useAppStore((s) => s.triggerScrollTo);
   const clearScrollTarget = useAppStore((s) => s.clearScrollTarget);
-  const pushToast = useAppStore((s) => s.pushToast);
+  const pushNotification = useAppStore((s) => s.pushNotification);
   const pushWorkspaceNotification = useAppStore((s) => s.pushWorkspaceNotification);
   const clearWorkspaceNotifications = useAppStore((s) => s.clearWorkspaceNotifications);
   const setAssistantToolActivitySuppressed = useAppStore(
@@ -171,7 +171,7 @@ export function useProjectEventsSSE(projectName?: string | null): void {
       const res = await API.getProject(projectName);
       setCurrentProject(projectName, res.project, res.scripts ?? {}, res.asset_fingerprints);
     } catch (err) {
-      pushToast(`同步项目变更失败: ${errMsg(err)}`, "warning");
+      pushNotification(`同步项目变更失败: ${errMsg(err)}`, "warning");
     } finally {
       refreshingRef.current = false;
     }
@@ -181,7 +181,7 @@ export function useProjectEventsSSE(projectName?: string | null): void {
       return;
     }
     flushQueuedFocus();
-  }, [flushQueuedFocus, projectName, pushToast, setCurrentProject]);
+  }, [flushQueuedFocus, projectName, pushNotification, setCurrentProject]);
 
   useEffect(() => {
     lastFingerprintRef.current = null;
@@ -247,7 +247,7 @@ export function useProjectEventsSSE(projectName?: string | null): void {
               if (!hasImportantChanges(group)) {
                 continue;
               }
-              pushToast(formatGroupedNotificationText(group), "success");
+              pushNotification(formatGroupedNotificationText(group), "success");
             }
           }
 
@@ -336,9 +336,9 @@ export function useProjectEventsSSE(projectName?: string | null): void {
     clearWorkspaceNotifications,
     invalidateEntities,
     projectName,
+    pushNotification,
     pushWorkspaceNotification,
     refreshProject,
-    pushToast,
     setAssistantToolActivitySuppressed,
     setLocation,
   ]);

--- a/frontend/src/hooks/useProjectEventsSSE.ts
+++ b/frontend/src/hooks/useProjectEventsSSE.ts
@@ -1,4 +1,5 @@
 import { startTransition, useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { useLocation } from "wouter";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
@@ -114,6 +115,9 @@ function isWorkspaceEditing(): boolean {
 }
 
 export function useProjectEventsSSE(projectName?: string | null): void {
+  const { t } = useTranslation("dashboard");
+  const tRef = useRef(t);
+  tRef.current = t;
   const [, setLocation] = useLocation();
   const setCurrentProject = useProjectsStore((s) => s.setCurrentProject);
   const invalidateEntities = useAppStore((s) => s.invalidateEntities);
@@ -171,7 +175,7 @@ export function useProjectEventsSSE(projectName?: string | null): void {
       const res = await API.getProject(projectName);
       setCurrentProject(projectName, res.project, res.scripts ?? {}, res.asset_fingerprints);
     } catch (err) {
-      pushNotification(`同步项目变更失败: ${errMsg(err)}`, "warning");
+      pushNotification(tRef.current("project_sync_failed", { message: errMsg(err) }), "warning");
     } finally {
       refreshingRef.current = false;
     }

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -22,7 +22,7 @@ export default {
   'export_diagnostics': 'Export Diagnostics',
   'project_title_required': 'Project title cannot be empty',
   'style_upload_failed_hint': 'Style reference image upload failed, you can upload it later in project settings',
-  'create_project_failed': 'Failed to create project: ',
+  'create_project_failed': 'Failed to create project: {{message}}',
   'project_id_auto_gen_hint': 'The system will automatically generate an internal project ID used for URLs and storage',
   'narration_visuals': 'Narration Mode',
   'drama_animation': 'Drama Mode',
@@ -367,15 +367,15 @@ export default {
   'actual_scenes': 'Scenes',
   'actual_props': 'Props',
   'regenerate_failed': 'Regeneration failed: {{message}}',
-  'upload_failed': 'Upload failed: ',
-  'delete_failed': 'Delete failed: ',
-  'update_failed': 'Update failed: ',
+  'upload_failed': 'Upload failed: {{message}}',
+  'delete_failed': 'Delete failed: {{message}}',
+  'update_failed': 'Update failed: {{message}}',
 
   // ApiKeysTab
-  'create_failed': 'Creation failed: ',
+  'create_failed': 'Creation failed: {{message}}',
   'save_key_warning': 'Make sure to copy and save this key securely now.',
   'key_not_viewable_again': 'For security reasons, you will not be able to see it again.',
-  'load_failed': 'Failed to load: ',
+  'load_failed': 'Failed to load: {{message}}',
 
   // AgentConfigTab
   'api_credentials': 'API Credentials',
@@ -399,7 +399,7 @@ export default {
   'session_cleanup_delay_desc': 'Wait this long after session ends before releasing resources. Sessions auto-resume on next conversation.',
   'max_concurrent_sessions_label': 'Max Concurrent Sessions',
   'max_concurrent_sessions_desc': 'Maximum active agent sessions. Excess sessions auto-release the least recently used ones (cleaned sessions are persisted and resume on next conversation).',
-  'clear_failed': 'Failed to clear: ',
+  'clear_failed': 'Failed to clear: {{message}}',
   'clear_input': 'Clear input',
   'hide_key': 'Hide key',
   'show_key': 'Show key',
@@ -407,14 +407,14 @@ export default {
   'clear_model_input': 'Clear model configuration input',
 
   // WelcomeCanvas
-  'analysis_failed': 'Analysis failed: ',
+  'analysis_failed': 'Analysis failed: {{message}}',
   'uploaded_source_files': 'Uploaded Source Files',
   'add_more_files': 'Add more files',
   'drop_more_files_here': 'Or drag and drop more files here',
   'uploading': 'Uploading...',
 
   // MediaModelSection
-  'save_failed': 'Failed to save: ',
+  'save_failed': 'Failed to save: {{message}}',
 
   // UsageStatsSection
   'last_7_days': 'Last 7 days',
@@ -458,7 +458,7 @@ export default {
   'genre_prefix': 'Genre: ',
   'theme_prefix': 'Theme: ',
   'calculating_cost': 'Calculating cost...',
-  'cost_estimate_failed': 'Cost estimation failed: ',
+  'cost_estimate_failed': 'Cost estimation failed: {{message}}',
   'episodes_title': 'Episodes',
   'no_episodes_ai_hint': 'No episodes yet. Use the AI assistant to generate scripts.',
   'segments_and_status': '{{count}} segments · {{status}}',

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -145,6 +145,7 @@ export default {
   'ai_will_analyze_desc': 'AI will analyze your novel and extract characters, scenes, props, and world settings',
   'overview_gen_desc': 'A project overview will be generated, then you can start creating scripts and storyboards',
   'project_overview_regenerated': 'Project overview regenerated',
+  'project_sync_failed': 'Failed to sync project changes: {{message}}',
   'synopsis': 'Synopsis',
   'genre': 'Genre',
   'theme': 'Theme',

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -365,7 +365,7 @@ export default {
   'actual_characters': 'Chars',
   'actual_scenes': 'Scenes',
   'actual_props': 'Props',
-  'regenerate_failed': 'Regeneration failed: ',
+  'regenerate_failed': 'Regeneration failed: {{message}}',
   'upload_failed': 'Upload failed: ',
   'delete_failed': 'Delete failed: ',
   'update_failed': 'Update failed: ',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -146,6 +146,7 @@ export default {
   'ai_will_analyze_desc': 'AI 将分析您的小说，提取角色、场景、道具和世界观设定',
   'overview_gen_desc': '自动生成项目概述，然后您可以开始创建剧本和分镜',
   'project_overview_regenerated': '项目概述已重新生成',
+  'project_sync_failed': '同步项目变更失败: {{message}}',
   'synopsis': '故事梗概',
   'genre': '题材',
   'theme': '主题',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -366,7 +366,7 @@ export default {
   'actual_characters': '角色',
   'actual_scenes': '场景',
   'actual_props': '道具',
-  'regenerate_failed': '重新生成失败: ',
+  'regenerate_failed': '重新生成失败: {{message}}',
   'upload_failed': '上传失败: ',
   'delete_failed': '删除失败: ',
   'update_failed': '更新失败: ',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -23,7 +23,7 @@ export default {
   'export_diagnostics': '导出诊断',
   'project_title_required': '项目标题不能为空',
   'style_upload_failed_hint': '风格参考图上传失败，可稍后在项目设置中重新上传',
-  'create_project_failed': '创建项目失败: ',
+  'create_project_failed': '创建项目失败: {{message}}',
   'project_id_auto_gen_hint': '系统会自动生成内部项目标识并用于 URL 与文件存储',
   'narration_visuals': '旁白模式',
   'drama_animation': '剧集模式',
@@ -368,15 +368,15 @@ export default {
   'actual_scenes': '场景',
   'actual_props': '道具',
   'regenerate_failed': '重新生成失败: {{message}}',
-  'upload_failed': '上传失败: ',
-  'delete_failed': '删除失败: ',
-  'update_failed': '更新失败: ',
+  'upload_failed': '上传失败: {{message}}',
+  'delete_failed': '删除失败: {{message}}',
+  'update_failed': '更新失败: {{message}}',
 
   // ApiKeysTab
-  'create_failed': '创建失败: ',
+  'create_failed': '创建失败: {{message}}',
   'save_key_warning': '请务必立即复制并安全保存此密钥',
   'key_not_viewable_again': '出于安全考虑，你将无法再次查看它。',
-  'load_failed': '加载失败: ',
+  'load_failed': '加载失败: {{message}}',
 
   // AgentConfigTab
   'api_credentials': 'API 凭证',
@@ -400,7 +400,7 @@ export default {
   'session_cleanup_delay_desc': '会话结束后等待此时间再释放资源，再次对话时会自动恢复',
   'max_concurrent_sessions_label': '最大并发会话数',
   'max_concurrent_sessions_desc': '同时保持活跃的智能体会话上限，超出时自动释放最久未使用的会话（清理的会话会持久化，下次对话时恢复）',
-  'clear_failed': '清除失败: ',
+  'clear_failed': '清除失败: {{message}}',
   'clear_input': '清除输入',
   'hide_key': '隐藏密钥',
   'show_key': '显示密钥',
@@ -408,14 +408,14 @@ export default {
   'clear_model_input': '清除模型配置输入',
 
   // WelcomeCanvas
-  'analysis_failed': '分析失败: ',
+  'analysis_failed': '分析失败: {{message}}',
   'uploaded_source_files': '已上传的源文件',
   'add_more_files': '添加更多文件',
   'drop_more_files_here': '或拖拽更多文件到此处',
   'uploading': '上传中...',
 
   // MediaModelSection
-  'save_failed': '保存失败: ',
+  'save_failed': '保存失败: {{message}}',
 
   // UsageStatsSection
   'last_7_days': '最近 7 天',
@@ -459,7 +459,7 @@ export default {
   'genre_prefix': '题材: ',
   'theme_prefix': '主题: ',
   'calculating_cost': '正在计算费用...',
-  'cost_estimate_failed': '费用估算失败: ',
+  'cost_estimate_failed': '费用估算失败: {{message}}',
   'episodes_title': '剧集',
   'no_episodes_ai_hint': '暂无剧集。使用 AI 助手生成剧本。',
   'segments_and_status': '{{count}} 片段 · {{status}}',

--- a/frontend/src/stores/app-store.ts
+++ b/frontend/src/stores/app-store.ts
@@ -13,10 +13,6 @@ interface Toast {
   tone: "info" | "success" | "error" | "warning";
 }
 
-interface ToastOptions {
-  target?: WorkspaceNotificationTarget | null;
-}
-
 interface FocusedContext {
   type: "character" | "scene" | "prop" | "segment";
   id: string;
@@ -38,7 +34,12 @@ interface AppState {
 
   // Toast
   toast: Toast | null;
-  pushToast: (text: string, tone?: Toast["tone"], options?: ToastOptions) => void;
+  pushToast: (text: string, tone?: Toast["tone"]) => void;
+  pushNotification: (
+    text: string,
+    tone?: Toast["tone"],
+    options?: { target?: WorkspaceNotificationTarget | null },
+  ) => void;
   clearToast: () => void;
   workspaceNotifications: WorkspaceNotification[];
   pushWorkspaceNotification: (input: WorkspaceNotificationInput) => void;
@@ -69,6 +70,31 @@ interface AppState {
   getEntityRevision: (key: string) => number;
 }
 
+/**
+ * 通知系统分工规则（issue #351）：
+ *
+ * - pushToast(text, tone)
+ *     用于：用户主动操作的即时反馈。
+ *     典型：表单保存/校验、导入/删除/切换/上传成功、scroll target 未找到、
+ *          后台任务提交成功回执（task_submitted）、轻量错误提示。
+ *
+ * - pushWorkspaceNotification({ text, tone, target })
+ *     用于：后台异步产生的事件，用户可能不在当前页。
+ *     典型：SSE 单条事件留痕（如 agent_update_scene）。
+ *
+ * - pushNotification(text, tone, options?)
+ *     用于：用户需要后续回看的重要结果。
+ *     典型：后台任务失败（剪映/ZIP 导出失败、项目 regenerate 失败、
+ *          参考生视频失败、storyboard/video/character/scene/prop 生成失败）、
+ *          SSE grouped_notification。
+ *
+ * 判断口诀：
+ *   1. 用户现在不在场 → 需要持久
+ *   2. 后台任务"失败"需要留痕排查 → 需要持久
+ *   3. 其余 → 仅 toast
+ *
+ * pushToast 不接受 { persist: true } 之类逃生门，强制调用点三选一，意图显式。
+ */
 const MAX_WORKSPACE_NOTIFICATIONS = 40;
 
 function buildWorkspaceNotification(
@@ -113,18 +139,18 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({ assistantToolActivitySuppressed: suppressed }),
 
   toast: null,
-  pushToast: (text, tone = "info", options) =>
-    set((s) => ({
+  pushToast: (text, tone = "info") =>
+    set({
       toast: { id: `${Date.now()}-${Math.random()}`, text, tone },
-      workspaceNotifications: [
-        buildWorkspaceNotification({
-          text,
-          tone,
-          target: options?.target ?? null,
-        }),
-        ...s.workspaceNotifications,
-      ].slice(0, MAX_WORKSPACE_NOTIFICATIONS),
-    })),
+    }),
+  pushNotification: (text, tone = "info", options) => {
+    get().pushToast(text, tone);
+    get().pushWorkspaceNotification({
+      text,
+      tone,
+      target: options?.target ?? null,
+    });
+  },
   clearToast: () => set({ toast: null }),
   workspaceNotifications: [],
   pushWorkspaceNotification: (input) =>

--- a/frontend/src/stores/app-store.ts
+++ b/frontend/src/stores/app-store.ts
@@ -143,14 +143,14 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({
       toast: { id: `${Date.now()}-${Math.random()}`, text, tone },
     }),
-  pushNotification: (text, tone = "info", options) => {
-    get().pushToast(text, tone);
-    get().pushWorkspaceNotification({
-      text,
-      tone,
-      target: options?.target ?? null,
-    });
-  },
+  pushNotification: (text, tone = "info", options) =>
+    set((s) => ({
+      toast: { id: `${Date.now()}-${Math.random()}`, text, tone },
+      workspaceNotifications: [
+        buildWorkspaceNotification({ text, tone, target: options?.target ?? null }),
+        ...s.workspaceNotifications,
+      ].slice(0, MAX_WORKSPACE_NOTIFICATIONS),
+    })),
   clearToast: () => set({ toast: null }),
   workspaceNotifications: [],
   pushWorkspaceNotification: (input) =>

--- a/frontend/src/stores/stores.test.ts
+++ b/frontend/src/stores/stores.test.ts
@@ -70,17 +70,30 @@ describe("stores", () => {
     app.setAssistantToolActivitySuppressed(true);
     expect(useAppStore.getState().assistantToolActivitySuppressed).toBe(true);
 
+    // pushToast 只写 toast，不再副作用写入 workspaceNotifications（issue #351 根因回归）
     app.pushToast("hello");
     expect(useAppStore.getState().toast?.text).toBe("hello");
     expect(useAppStore.getState().toast?.tone).toBe("info");
+    expect(useAppStore.getState().workspaceNotifications).toHaveLength(0);
+    app.clearToast();
+    expect(useAppStore.getState().toast).toBeNull();
+
+    // pushNotification 同时写两者，tone 与 target 正确传递
+    app.pushNotification("task failed", "error", {
+      target: { type: "segment", id: "S1", route: "/episodes/1" },
+    });
+    expect(useAppStore.getState().toast).toEqual(
+      expect.objectContaining({ text: "task failed", tone: "error" }),
+    );
     expect(useAppStore.getState().workspaceNotifications[0]).toEqual(
       expect.objectContaining({
-        text: "hello",
-        tone: "info",
+        text: "task failed",
+        tone: "error",
+        target: expect.objectContaining({ id: "S1" }),
       }),
     );
     app.clearToast();
-    expect(useAppStore.getState().toast).toBeNull();
+    useAppStore.setState({ workspaceNotifications: [] });
 
     app.pushWorkspaceNotification({
       text: "AI 刚更新了角色「hero」，点击查看",
@@ -90,6 +103,7 @@ describe("stores", () => {
         route: "/characters",
       },
     });
+    expect(useAppStore.getState().toast).toBeNull();
     const notification = useAppStore.getState().workspaceNotifications[0];
     expect(notification.target?.id).toBe("hero");
     app.markWorkspaceNotificationRead(notification.id);


### PR DESCRIPTION
## Summary
- 解耦 zustand 通知入口：`pushToast`（瞬时）/ `pushWorkspaceNotification`（持久）/ `pushNotification`（组合）三选一
- 在 `app-store.ts` 头部写入分工规则注释 + 判断口诀，约束后续调用点意图
- 按规则迁移 17 个运行时调用点：后台任务失败走 `pushNotification`；用户即时操作反馈走 `pushToast`
- 修复 issue #351 根因：`pushToast` 不再副作用写入 drawer，解决瞬时/持久通知分工失效

## Test plan
- [x] `pnpm -C frontend check` 383/383 通过（含 3 条回归断言：`pushToast` 不写 drawer、`pushNotification` 双写、`pushWorkspaceNotification` 不触 toast）
- [x] `pnpm -C frontend build` 构建成功
- [x] typecheck / eslint 干净
- [ ] 手工验证：编辑剧本保存仅 toast、导出剪映失败 toast + drawer、项目 regenerate 失败 toast + drawer、SSE grouped_notification toast + drawer
- [ ] drawer 不再被日常操作（保存/切换/上传）塞爆

## Closes
Closes #351

## Design docs
- Spec: `docs/superpowers/specs/2026-04-23-toast-notification-split-design.md`
- Plan: `docs/superpowers/plans/2026-04-23-toast-notification-split.md`