### PR TITLE
fix(image-backends): OpenAI/Ark 图片响应按 b64_json/url 降级解析

### DIFF
--- a/lib/image_backends/ark.py
+++ b/lib/image_backends/ark.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import logging
 from pathlib import Path
 
@@ -13,6 +12,7 @@ from lib.image_backends.base import (
     ImageGenerationRequest,
     ImageGenerationResult,
     image_to_base64_data_uri,
+    save_image_from_response_item,
 )
 from lib.providers import PROVIDER_ARK
 from lib.retry import with_retry_async
@@ -57,7 +57,6 @@ class ArkImageBackend:
         kwargs: dict = {
             "model": self._model,
             "prompt": request.prompt,
-            "response_format": "b64_json",
         }
 
         # I2I: 读取参考图并转为 base64 data URI
@@ -75,14 +74,7 @@ class ArkImageBackend:
             **kwargs,
         )
 
-        # 解码并保存（磁盘写入 offload 到线程）
-        image_data = base64.b64decode(response.data[0].b64_json)
-
-        def _write():
-            request.output_path.parent.mkdir(parents=True, exist_ok=True)
-            request.output_path.write_bytes(image_data)
-
-        await asyncio.to_thread(_write)
+        await save_image_from_response_item(response.data[0], request.output_path)
 
         return ImageGenerationResult(
             image_path=request.output_path,

--- a/lib/image_backends/base.py
+++ b/lib/image_backends/base.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 from typing import Protocol
+
+import httpx
 
 from lib.video_backends.base import IMAGE_MIME_TYPES
 
@@ -18,6 +21,33 @@ def image_to_base64_data_uri(image_path: Path) -> str:
     image_data = image_path.read_bytes()
     b64 = base64.b64encode(image_data).decode("ascii")
     return f"data:{mime_type};base64,{b64}"
+
+
+async def download_image_to_path(url: str, output_path: Path, *, timeout: int = 60) -> None:
+    """从 URL 异步下载图片到本地文件。"""
+    await asyncio.to_thread(output_path.parent.mkdir, parents=True, exist_ok=True)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, timeout=timeout)
+        resp.raise_for_status()
+        await asyncio.to_thread(output_path.write_bytes, resp.content)
+
+
+async def save_image_from_response_item(item, output_path: Path) -> None:
+    """从 OpenAI 兼容 SDK 的 ``response.data[i]`` 提取图片并写入本地路径。
+
+    优先 ``b64_json``；为空降级到 ``url`` 下载；两者皆空抛 ``ValueError``。
+    """
+    b64 = getattr(item, "b64_json", None)
+    if b64:
+        image_bytes = base64.b64decode(b64)
+        await asyncio.to_thread(output_path.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(output_path.write_bytes, image_bytes)
+        return
+    url = getattr(item, "url", None)
+    if url:
+        await download_image_to_path(url, output_path)
+        return
+    raise ValueError("图片生成响应既无 b64_json 也无 url")
 
 
 class ImageCapability(StrEnum):

--- a/lib/image_backends/base.py
+++ b/lib/image_backends/base.py
@@ -25,11 +25,16 @@ def image_to_base64_data_uri(image_path: Path) -> str:
 
 async def download_image_to_path(url: str, output_path: Path, *, timeout: int = 60) -> None:
     """从 URL 异步下载图片到本地文件。"""
-    await asyncio.to_thread(output_path.parent.mkdir, parents=True, exist_ok=True)
     async with httpx.AsyncClient() as client:
         resp = await client.get(url, timeout=timeout)
         resp.raise_for_status()
-        await asyncio.to_thread(output_path.write_bytes, resp.content)
+        content = resp.content
+
+    def _save() -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(content)
+
+    await asyncio.to_thread(_save)
 
 
 async def save_image_from_response_item(item, output_path: Path) -> None:
@@ -39,9 +44,14 @@ async def save_image_from_response_item(item, output_path: Path) -> None:
     """
     b64 = getattr(item, "b64_json", None)
     if b64:
-        image_bytes = base64.b64decode(b64)
-        await asyncio.to_thread(output_path.parent.mkdir, parents=True, exist_ok=True)
-        await asyncio.to_thread(output_path.write_bytes, image_bytes)
+
+        def _decode_and_save() -> None:
+            # 解码 + 写盘统一 offload 到线程，避免在事件循环内做 CPU 密集 base64 解码
+            image_bytes = base64.b64decode(b64)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(image_bytes)
+
+        await asyncio.to_thread(_decode_and_save)
         return
     url = getattr(item, "url", None)
     if url:

--- a/lib/image_backends/grok.py
+++ b/lib/image_backends/grok.py
@@ -2,17 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from pathlib import Path
-
-import httpx
 
 from lib.grok_shared import create_grok_client, grok_should_retry
 from lib.image_backends.base import (
     ImageCapability,
     ImageGenerationRequest,
     ImageGenerationResult,
+    download_image_to_path,
     image_to_base64_data_uri,
 )
 from lib.providers import PROVIDER_GROK
@@ -105,7 +103,7 @@ class GrokImageBackend:
             raise RuntimeError("Grok 图片生成被内容审核拒绝")
 
         # 下载图片到本地
-        await _download_image(response.url, request.output_path)
+        await download_image_to_path(response.url, request.output_path)
 
         logger.info("Grok 图片下载完成: %s", request.output_path)
 
@@ -115,12 +113,3 @@ class GrokImageBackend:
             model=self._model,
             image_uri=response.url,
         )
-
-
-async def _download_image(url: str, output_path: Path, *, timeout: int = 60) -> None:
-    """从 URL 下载图片到本地文件。"""
-    await asyncio.to_thread(output_path.parent.mkdir, parents=True, exist_ok=True)
-    async with httpx.AsyncClient() as http_client:
-        resp = await http_client.get(url, timeout=timeout)
-        resp.raise_for_status()
-        await asyncio.to_thread(output_path.write_bytes, resp.content)

--- a/lib/image_backends/openai.py
+++ b/lib/image_backends/openai.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import logging
 from contextlib import ExitStack
 from pathlib import Path
@@ -12,6 +11,7 @@ from lib.image_backends.base import (
     ImageCapability,
     ImageGenerationRequest,
     ImageGenerationResult,
+    save_image_from_response_item,
 )
 from lib.openai_shared import OPENAI_RETRYABLE_ERRORS, create_openai_client
 from lib.providers import PROVIDER_OPENAI
@@ -107,12 +107,11 @@ class OpenAIImageBackend:
         kwargs = {
             "model": self._model,
             "prompt": request.prompt,
-            "response_format": "b64_json",
             "n": 1,
         }
         kwargs.update(_resolve_openai_params(request.image_size, request.aspect_ratio))
         response = await self._client.images.generate(**kwargs)
-        return await asyncio.to_thread(self._save_and_return, response, request)
+        return await self._save_and_return(response, request)
 
     async def _generate_edit(self, request: ImageGenerationRequest) -> ImageGenerationResult:
         refs = request.reference_images
@@ -146,16 +145,13 @@ class OpenAIImageBackend:
                 model=self._model,
                 image=image_files,
                 prompt=request.prompt,
-                response_format="b64_json",
             )
         finally:
             stack.close()
-        return await asyncio.to_thread(self._save_and_return, response, request)
+        return await self._save_and_return(response, request)
 
-    def _save_and_return(self, response, request: ImageGenerationRequest) -> ImageGenerationResult:
-        image_bytes = base64.b64decode(response.data[0].b64_json)
-        request.output_path.parent.mkdir(parents=True, exist_ok=True)
-        request.output_path.write_bytes(image_bytes)
+    async def _save_and_return(self, response, request: ImageGenerationRequest) -> ImageGenerationResult:
+        await save_image_from_response_item(response.data[0], request.output_path)
         logger.info("OpenAI 图片生成完成: %s", request.output_path)
         quality = _QUALITY_MAP.get(request.image_size) if request.image_size else None
         return ImageGenerationResult(

--- a/tests/test_image_backends/test_ark.py
+++ b/tests/test_image_backends/test_ark.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -131,7 +131,8 @@ class TestArkImageBackendGenerate:
         call_kwargs = client.images.generate.call_args
         assert call_kwargs.kwargs["model"] == "doubao-seedream-5-0-lite-260128"
         assert call_kwargs.kwargs["prompt"] == "a cat"
-        assert call_kwargs.kwargs["response_format"] == "b64_json"
+        # 部分兼容网关即便吃 response_format 仍返回 url，所以请求端不再传该参数
+        assert "response_format" not in call_kwargs.kwargs
         assert "image" not in call_kwargs.kwargs
 
         # Result
@@ -205,3 +206,35 @@ class TestArkImageBackendGenerate:
         await backend.generate(request)
 
         assert output.exists()
+
+    async def test_t2i_url_fallback(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        """网关只返回 url 时，应走 httpx 下载分支。"""
+        monkeypatch.delenv("ARK_API_KEY", raising=False)
+        client = MagicMock()
+        client.images.generate.return_value = _FakeImagesResponse(
+            data=[_FakeImageData(b64_json=None, url="https://gateway/img.png")]
+        )
+        downloaded = b"downloaded-from-gateway"
+
+        with patch("lib.image_backends.ark.create_ark_client", return_value=client):
+            from lib.image_backends.ark import ArkImageBackend
+
+            backend = ArkImageBackend(api_key="test-key")
+            output = tmp_path / "out.png"
+            request = ImageGenerationRequest(prompt="a cat", output_path=output)
+
+            with patch("lib.image_backends.base.httpx.AsyncClient") as MockHttpClient:
+                mock_http = AsyncMock()
+                MockHttpClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
+                MockHttpClient.return_value.__aexit__ = AsyncMock(return_value=False)
+                mock_resp = MagicMock()
+                mock_resp.content = downloaded
+                mock_resp.raise_for_status = MagicMock()
+                mock_http.get = AsyncMock(return_value=mock_resp)
+
+                result = await backend.generate(request)
+
+            mock_http.get.assert_awaited_once_with("https://gateway/img.png", timeout=60)
+
+        assert result.image_path == output
+        assert output.read_bytes() == downloaded

--- a/tests/test_image_backends/test_grok.py
+++ b/tests/test_image_backends/test_grok.py
@@ -94,7 +94,7 @@ class TestGenerateT2I:
 
         fake_image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
 
-        with patch("lib.image_backends.grok.httpx.AsyncClient") as MockHttpClient:
+        with patch("lib.image_backends.base.httpx.AsyncClient") as MockHttpClient:
             mock_http = AsyncMock()
             MockHttpClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
             MockHttpClient.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -145,7 +145,7 @@ class TestGenerateI2I:
 
         fake_image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
 
-        with patch("lib.image_backends.grok.httpx.AsyncClient") as MockHttpClient:
+        with patch("lib.image_backends.base.httpx.AsyncClient") as MockHttpClient:
             mock_http = AsyncMock()
             MockHttpClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
             MockHttpClient.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -183,7 +183,7 @@ class TestGenerateI2I:
 
         fake_image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
 
-        with patch("lib.image_backends.grok.httpx.AsyncClient") as MockHttpClient:
+        with patch("lib.image_backends.base.httpx.AsyncClient") as MockHttpClient:
             mock_http = AsyncMock()
             MockHttpClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
             MockHttpClient.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -215,7 +215,7 @@ class TestGenerateI2I:
 
         fake_image_bytes = b"\x89PNG\r\n\x1a\n"
 
-        with patch("lib.image_backends.grok.httpx.AsyncClient") as MockHttpClient:
+        with patch("lib.image_backends.base.httpx.AsyncClient") as MockHttpClient:
             mock_http = AsyncMock()
             MockHttpClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
             MockHttpClient.return_value.__aexit__ = AsyncMock(return_value=False)

--- a/tests/test_openai_image_backend.py
+++ b/tests/test_openai_image_backend.py
@@ -14,10 +14,11 @@ from lib.image_backends.base import (
 from lib.providers import PROVIDER_OPENAI
 
 
-def _make_mock_image_response(b64_data: str = "aW1hZ2VfZGF0YQ=="):
-    """构造 mock ImagesResponse。"""
+def _make_mock_image_response(b64_data: str | None = "aW1hZ2VfZGF0YQ==", url: str | None = None):
+    """构造 mock ImagesResponse。默认只含 b64_json；传 url 则模拟兼容网关的 URL 返回。"""
     datum = MagicMock()
     datum.b64_json = b64_data
+    datum.url = url
 
     response = MagicMock()
     response.data = [datum]
@@ -77,7 +78,8 @@ class TestOpenAIImageBackend:
         assert call_kwargs["model"] == "gpt-image-1.5"
         assert call_kwargs["size"] == "1024x1792"  # 9:16
         assert call_kwargs["quality"] == "medium"  # 1K
-        assert call_kwargs["response_format"] == "b64_json"
+        # gpt-image-1 家族不支持 response_format；严格兼容网关会 400，因此绝不能传
+        assert "response_format" not in call_kwargs
 
     async def test_image_to_image(self, tmp_path: Path):
         """I2I 路径应调用 images.edit()。"""
@@ -104,6 +106,45 @@ class TestOpenAIImageBackend:
         assert output_path.read_bytes() == b"edited-image"
         mock_client.images.edit.assert_awaited_once()
         mock_client.images.generate.assert_not_awaited()
+        edit_kwargs = mock_client.images.edit.call_args[1]
+        assert "response_format" not in edit_kwargs
+
+    async def test_text_to_image_url_fallback(self, tmp_path: Path):
+        """网关只返回 url 时，应走 httpx 下载分支。"""
+        mock_client = AsyncMock()
+        mock_client.images.generate = AsyncMock(
+            return_value=_make_mock_image_response(b64_data=None, url="https://gateway/img.png")
+        )
+
+        downloaded = b"downloaded-from-gateway"
+
+        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.image_backends.openai import OpenAIImageBackend
+
+            backend = OpenAIImageBackend(api_key="test-key")
+            output_path = tmp_path / "output.png"
+            request = ImageGenerationRequest(
+                prompt="A beautiful sunset",
+                output_path=output_path,
+                aspect_ratio="9:16",
+                image_size="1K",
+            )
+
+            with patch("lib.image_backends.base.httpx.AsyncClient") as MockHttpClient:
+                mock_http = AsyncMock()
+                MockHttpClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
+                MockHttpClient.return_value.__aexit__ = AsyncMock(return_value=False)
+                mock_resp = MagicMock()
+                mock_resp.content = downloaded
+                mock_resp.raise_for_status = MagicMock()
+                mock_http.get = AsyncMock(return_value=mock_resp)
+
+                result = await backend.generate(request)
+
+            mock_http.get.assert_awaited_once_with("https://gateway/img.png", timeout=60)
+
+        assert result.image_path == output_path
+        assert output_path.read_bytes() == downloaded
 
     async def test_size_mapping(self, tmp_path: Path):
         """验证 (image_size, aspect_ratio) → size 复合 key 映射。"""


### PR DESCRIPTION
## Summary
- OpenAI / Ark 图片后端不再硬编码 `response_format="b64_json"`（gpt-image-1 家族及严格兼容网关会 400 reject）
- 响应端改为 polymorphic 解析：`data[0].b64_json` 非空直接解码；否则 httpx 异步下载 `data[0].url`（修复部分兼容网关返回 url 导致 `b64_decode(None)` 崩溃）
- 自定义供应商的 OpenAI / NewAPI 格式走同一个 `OpenAIImageBackend` delegate，自动受益
- `grok.py` 顺带 DRY 化，复用抽到 `base.py` 的 `download_image_to_path`

## Test plan
- [ ] ``uv run python -m pytest tests/test_openai_image_backend.py tests/test_image_backends/ -v``
- [ ] ``uv run ruff check lib/image_backends/ tests/``
- [ ] 手工：在 `/settings` 配一个已知返回 url 的 OpenAI 兼容网关，跑一次分镜生成，确认图片落盘且尺寸非 0