### PR TITLE
feat(ai): add token limit awareness to text generator

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -11,6 +11,7 @@ class ModelInfo:
     default: bool = False
     supported_durations: list[int] = field(default_factory=list)
     duration_resolution_constraints: dict[str, list[int]] = field(default_factory=dict)
+    max_output_tokens: int | None = None  # text models only; None = unknown/unlimited
 
 
 @dataclass(frozen=True)
@@ -44,17 +45,20 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="Gemini 3.1 Pro",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                max_output_tokens=65536,
             ),
             "gemini-3-flash-preview": ModelInfo(
                 display_name="Gemini 3 Flash",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
                 default=True,
+                max_output_tokens=65536,
             ),
             "gemini-3.1-flash-lite-preview": ModelInfo(
                 display_name="Gemini 3.1 Flash Lite",
                 media_type="text",
                 capabilities=["text_generation", "structured_output"],
+                max_output_tokens=65536,
             ),
             # --- image ---
             "gemini-3-pro-image-preview": ModelInfo(
@@ -105,17 +109,20 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="Gemini 3.1 Pro",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                max_output_tokens=65536,
             ),
             "gemini-3-flash-preview": ModelInfo(
                 display_name="Gemini 3 Flash",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
                 default=True,
+                max_output_tokens=65536,
             ),
             "gemini-3.1-flash-lite-preview": ModelInfo(
                 display_name="Gemini 3.1 Flash Lite",
                 media_type="text",
                 capabilities=["text_generation", "structured_output"],
+                max_output_tokens=65536,
             ),
             # --- image ---
             "gemini-3-pro-image-preview": ModelInfo(
@@ -157,22 +164,26 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="豆包 Seed 2.0 Pro",
                 media_type="text",
                 capabilities=["text_generation", "vision"],
+                max_output_tokens=16384,
             ),
             "doubao-seed-2-0-lite-260215": ModelInfo(
                 display_name="豆包 Seed 2.0 Lite",
                 media_type="text",
                 capabilities=["text_generation", "vision"],
                 default=True,
+                max_output_tokens=16384,
             ),
             "doubao-seed-2-0-mini-260215": ModelInfo(
                 display_name="豆包 Seed 2.0 Mini",
                 media_type="text",
                 capabilities=["text_generation", "vision"],
+                max_output_tokens=16384,
             ),
             "doubao-seed-1-8-251228": ModelInfo(
                 display_name="豆包 Seed 1.8",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                max_output_tokens=8192,
             ),
             # --- image ---
             "doubao-seedream-5-0-lite-260128": ModelInfo(
@@ -230,22 +241,26 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="Grok 4.20 Reasoning",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                max_output_tokens=32768,
             ),
             "grok-4.20-0309-non-reasoning": ModelInfo(
                 display_name="Grok 4.20 Non-Reasoning",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                max_output_tokens=32768,
             ),
             "grok-4-1-fast-reasoning": ModelInfo(
                 display_name="Grok 4.1 Fast Reasoning",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
                 default=True,
+                max_output_tokens=32768,
             ),
             "grok-4-1-fast-non-reasoning": ModelInfo(
                 display_name="Grok 4.1 Fast (Non-Reasoning)",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                max_output_tokens=32768,
             ),
             # --- image ---
             "grok-imagine-image-pro": ModelInfo(
@@ -281,17 +296,20 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="GPT-5.4",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                max_output_tokens=16384,
             ),
             "gpt-5.4-mini": ModelInfo(
                 display_name="GPT-5.4 Mini",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
                 default=True,
+                max_output_tokens=16384,
             ),
             "gpt-5.4-nano": ModelInfo(
                 display_name="GPT-5.4 Nano",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                max_output_tokens=16384,
             ),
             # --- image ---
             "gpt-image-1.5": ModelInfo(
@@ -322,3 +340,18 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
         },
     ),
 }
+
+
+def get_model_max_output_tokens(provider_id: str, model_id: str) -> int | None:
+    """查询指定 provider/model 的 max_output_tokens 上限。
+
+    Returns:
+        int 表示已知上限；None 表示 Registry 中未注册或未设置。
+    """
+    provider = PROVIDER_REGISTRY.get(provider_id)
+    if provider is None:
+        return None
+    model = provider.models.get(model_id)
+    if model is None:
+        return None
+    return model.max_output_tokens

--- a/lib/text_generator.py
+++ b/lib/text_generator.py
@@ -51,7 +51,33 @@ class TextGenerator:
         request: TextGenerationRequest,
         project_name: str | None = None,
     ) -> TextGenerationResult:
-        """生成文本并自动记录用量。"""
+        """生成文本并自动记录用量。
+
+        若 request.max_output_tokens 超过 registry 中该模型的硬上限，
+        自动 clamp 并 warning，避免输出被静默截断。
+        """
+        # --- clamp max_output_tokens ---
+        if request.max_output_tokens is not None:
+            from lib.config.registry import get_model_max_output_tokens
+
+            model_limit = get_model_max_output_tokens(self.backend.name, self.backend.model)
+            if model_limit is not None and request.max_output_tokens > model_limit:
+                logger.warning(
+                    "请求 max_output_tokens=%d 超过 %s/%s 上限 %d，已自动 clamp。"
+                    "建议切换到更大输出上限的模型。",
+                    request.max_output_tokens,
+                    self.backend.name,
+                    self.backend.model,
+                    model_limit,
+                )
+                request = TextGenerationRequest(
+                    prompt=request.prompt,
+                    response_schema=request.response_schema,
+                    images=request.images,
+                    system_prompt=request.system_prompt,
+                    max_output_tokens=model_limit,
+                )
+
         call_id = await self.usage_tracker.start_call(
             project_name=project_name or "",
             call_type="text",
@@ -75,3 +101,4 @@ class TextGenerator:
                 error_message=str(e)[:500],
             )
             raise
+

--- a/tests/test_token_limit_clamp.py
+++ b/tests/test_token_limit_clamp.py
@@ -1,0 +1,94 @@
+"""test_token_limit_clamp.py — verify TextGenerator clamps max_output_tokens."""
+
+import logging
+from unittest.mock import AsyncMock, PropertyMock
+
+import pytest
+
+from lib.config.registry import get_model_max_output_tokens
+from lib.text_backends.base import TextGenerationRequest, TextGenerationResult
+from lib.text_generator import TextGenerator
+
+
+# ── Registry lookup ──
+
+
+class TestGetModelMaxOutputTokens:
+    def test_known_model(self):
+        limit = get_model_max_output_tokens("ark", "doubao-seed-1-8-251228")
+        assert limit == 8192
+
+    def test_known_model_high(self):
+        limit = get_model_max_output_tokens("gemini-aistudio", "gemini-3-flash-preview")
+        assert limit == 65536
+
+    def test_unknown_provider(self):
+        assert get_model_max_output_tokens("nonexistent", "foo") is None
+
+    def test_unknown_model(self):
+        assert get_model_max_output_tokens("ark", "nonexistent-model") is None
+
+    def test_image_model_has_no_limit(self):
+        limit = get_model_max_output_tokens("ark", "doubao-seedream-5-0-lite-260128")
+        assert limit is None
+
+
+# ── TextGenerator clamp ──
+
+
+def _make_generator(provider: str = "ark", model: str = "doubao-seed-1-8-251228"):
+    """Create a TextGenerator with a mock backend."""
+    backend = AsyncMock()
+    type(backend).name = PropertyMock(return_value=provider)
+    type(backend).model = PropertyMock(return_value=model)
+    backend.generate.return_value = TextGenerationResult(
+        text="ok", provider=provider, model=model, input_tokens=10, output_tokens=100
+    )
+    tracker = AsyncMock()
+    tracker.start_call.return_value = "call-1"
+    return TextGenerator(backend, tracker)
+
+
+class TestTextGeneratorClamp:
+    @pytest.mark.asyncio
+    async def test_clamp_when_exceeds(self, caplog):
+        gen = _make_generator("ark", "doubao-seed-1-8-251228")
+        req = TextGenerationRequest(prompt="hello", max_output_tokens=32000)
+
+        with caplog.at_level(logging.WARNING):
+            await gen.generate(req, project_name="test")
+
+        # Verify the backend was called with clamped value
+        call_args = gen.backend.generate.call_args[0][0]
+        assert call_args.max_output_tokens == 8192
+        assert "clamp" in caplog.text.lower() or "已自动" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_no_clamp_within_limit(self):
+        gen = _make_generator("gemini-aistudio", "gemini-3-flash-preview")
+        req = TextGenerationRequest(prompt="hello", max_output_tokens=32000)
+
+        await gen.generate(req, project_name="test")
+
+        call_args = gen.backend.generate.call_args[0][0]
+        assert call_args.max_output_tokens == 32000  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_no_clamp_when_none(self):
+        gen = _make_generator("ark", "doubao-seed-1-8-251228")
+        req = TextGenerationRequest(prompt="hello")  # max_output_tokens=None
+
+        await gen.generate(req, project_name="test")
+
+        call_args = gen.backend.generate.call_args[0][0]
+        assert call_args.max_output_tokens is None
+
+    @pytest.mark.asyncio
+    async def test_no_clamp_unknown_model(self):
+        gen = _make_generator("unknown-provider", "unknown-model")
+        req = TextGenerationRequest(prompt="hello", max_output_tokens=99999)
+
+        await gen.generate(req, project_name="test")
+
+        call_args = gen.backend.generate.call_args[0][0]
+        assert call_args.max_output_tokens == 99999  # unchanged


### PR DESCRIPTION
## Summary
Adds proactive token limit clamping to prevent over-limit API errors.

- `lib/config/registry.py`: add `get_model_max_output_tokens()` to PROVIDER_REGISTRY
- `lib/text_generator.py`: clamp `max_tokens` before sending request (immutable rebuild)
- `tests/test_token_limit_clamp.py`: 94-line test suite with comprehensive coverage

Closes part of #306