### PR TITLE
feat(obs): OpenTelemetry tracing + Prometheus metrics with active call sites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,14 @@
 # 此文件仅保留启动级/基础设施配置。
 
 # ============================================================
+# Environment / Môi trường / 运行环境
+# ============================================================
+# Set to "development" to enable permissive CORS (*) and relax other security defaults
+# Đặt "development" để bật CORS rộng và tắt các cảnh báo bảo mật khác
+# 设置 "development" 以启用宽松 CORS (*) 并放宽其他安全默认值
+# ENV=development
+
+# ============================================================
 # Authentication / 认证配置
 # ============================================================
 # Login username (default: admin)
@@ -26,13 +34,19 @@ AUTH_PASSWORD=
 AUTH_TOKEN_SECRET=
 
 # ============================================================
-# Database Configuration / 数据库配置
+# Database Configuration / 数据库配置 / Cấu hình cơ sở dữ liệu
 # ============================================================
 # Default: SQLite (for development / single-machine deployment)
 # 默认使用 SQLite（开发/单机）
+# Mặc định: SQLite (phát triển / triển khai đơn máy)
 # SQLite:     sqlite+aiosqlite:///./projects/.arcreel.db
 # PostgreSQL: postgresql+asyncpg://user:pass@host:5432/arcreel
 # DATABASE_URL=sqlite+aiosqlite:///./projects/.arcreel.db
+
+# PostgreSQL password for Docker Compose deployment
+# Docker Compose 部署用 PostgreSQL 密码
+# Mật khẩu PostgreSQL cho triển khai Docker Compose
+# POSTGRES_PASSWORD=your_secure_password
 
 # ============================================================
 # Logging / 日志配置
@@ -40,6 +54,21 @@ AUTH_TOKEN_SECRET=
 # Log level (default: INFO, options: DEBUG, WARNING, ERROR)
 # 日志级别（默认: INFO，可选: DEBUG, WARNING, ERROR）
 # LOG_LEVEL=INFO
+
+# ============================================================
+# CORS / 跨域配置 / Cấu hình CORS
+# ============================================================
+# Comma-separated list of allowed origins. Default: * (allow all)
+# Production example: https://arcreel.example.com,https://admin.example.com
+# CORS_ORIGINS=*
+
+# ============================================================
+# Rate Limiting / 限流配置 / Giới hạn tốc độ
+# ============================================================
+# RATE_LIMIT_AGENT=30/minute
+# RATE_LIMIT_GENERATE=60/minute
+# RATE_LIMIT_UPLOAD=20/minute
+# RATE_LIMIT_DEFAULT=200/minute
 
 # ============================================================
 # Video Provider / 视频供应商
@@ -56,3 +85,16 @@ AUTH_TOKEN_SECRET=
 # Public URL of the project file service (Seedance image upload requires public access)
 # 项目文件服务公网地址（Seedance 图片上传需要公网访问）
 # FILE_SERVICE_BASE_URL=
+
+# ============================================================
+# Observability / Quan sat he thong / 
+# ============================================================
+# Prometheus metrics always available at GET /metrics (no auth required).
+# Install: uv sync --group observability
+#
+# OpenTelemetry tracing - forward spans to Jaeger / Tempo / Grafana Cloud
+# gRPC OTLP endpoint (leave empty to disable - zero overhead)
+# OTLP_ENDPOINT=
+#
+# Service name in traces (default: arcreel)
+# OTEL_SERVICE_NAME=arcreel

--- a/frontend/src/components/copilot/ContextBanner.tsx
+++ b/frontend/src/components/copilot/ContextBanner.tsx
@@ -1,7 +1,23 @@
+import { useState, useEffect } from "react";
 import { useAppStore } from "@/stores/app-store";
+import { useAssistantStore } from "@/stores/assistant-store";
 import { X, User, Puzzle, Film } from "lucide-react";
 
+/**
+ * ContextBanner — Two stacked sub-banners:
+ * 1. FocusedContextBanner: shows when a character/clue/segment is "in focus"
+ * 2. ContextLengthBanner: warns when conversation is approaching model context limit
+ */
 export function ContextBanner() {
+  return (
+    <>
+      <FocusedContextBanner />
+      <ContextLengthBanner />
+    </>
+  );
+}
+
+function FocusedContextBanner() {
   const { focusedContext, setFocusedContext } = useAppStore();
 
   if (!focusedContext) return null;
@@ -20,6 +36,41 @@ export function ContextBanner() {
         className="ml-auto rounded p-0.5 text-gray-500 hover:bg-gray-800 hover:text-gray-300"
       >
         <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
+function ContextLengthBanner() {
+  const { contextLong, turnsCount } = useAssistantStore();
+  const [dismissed, setDismissed] = useState(false);
+
+  // Auto-reset dismissed when context_long flips off (new session)
+  useEffect(() => {
+    if (!contextLong) setDismissed(false);
+  }, [contextLong]);
+
+  if (!contextLong || dismissed) return null;
+
+  return (
+    <div
+      role="alert"
+      className="flex items-center justify-between gap-2 border-b border-amber-500/20 bg-amber-500/10 px-3 py-1.5"
+    >
+      <p className="text-[11px] leading-snug text-amber-400/90">
+        <span className="mr-1">⚡</span>
+        Long conversation ({turnsCount} turns) — context nearing model limit.
+        Consider starting a{" "}
+        <span className="font-medium text-amber-300">new session</span>.
+      </p>
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        className="shrink-0 rounded px-1 text-[10px] text-amber-500/60 transition-colors hover:text-amber-400"
+        title="Dismiss"
+        aria-label="Dismiss context warning"
+      >
+        ✕
       </button>
     </div>
   );

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -5,6 +5,7 @@ import { uid } from "@/utils/id";
 import { useAssistantStore } from "@/stores/assistant-store";
 import type {
   AssistantSnapshot,
+  PendingApproval,
   PendingQuestion,
   SessionMeta,
   SessionStatus,
@@ -127,9 +128,18 @@ export function useAssistantSession(projectName: string | null) {
     store.getState().setAnsweringQuestion(false);
   }, [store]);
 
+  const syncPendingApproval = useCallback((approval: PendingApproval | null) => {
+    store.getState().setPendingApproval(approval);
+    store.getState().setDecidingApproval(false);
+  }, [store]);
+
   const clearPendingQuestion = useCallback(() => {
     syncPendingQuestion(null);
   }, [syncPendingQuestion]);
+
+  const clearPendingApproval = useCallback(() => {
+    syncPendingApproval(null);
+  }, [syncPendingApproval]);
 
   const invalidatePendingSend = useCallback(() => {
     pendingSendVersionRef.current += 1;
@@ -187,7 +197,11 @@ export function useAssistantSession(projectName: string | null) {
 
     store.getState().setDraftTurn((snapshot.draft_turn as Turn) ?? null);
     syncPendingQuestion(getPendingQuestionFromSnapshot(snapshot));
-  }, [store, syncPendingQuestion]);
+    syncPendingApproval(getPendingApprovalFromSnapshot(snapshot));
+    // Context length awareness — propagate to store
+    store.getState().setContextLong(snapshot.context_long ?? false);
+    store.getState().setTurnsCount(snapshot.turns_count ?? snapshotTurns.length);
+  }, [store, syncPendingQuestion, syncPendingApproval]);
 
   // 关闭流
   const closeStream = useCallback(() => {
@@ -288,6 +302,7 @@ export function useAssistantSession(projectName: string | null) {
           store.getState().setSending(false);
           store.getState().setInterrupting(false);
           clearPendingQuestion();
+          clearPendingApproval();
           if (status !== "interrupted") {
             store.getState().setDraftTurn(null);
           }
@@ -312,6 +327,15 @@ export function useAssistantSession(projectName: string | null) {
         }
       });
 
+      source.addEventListener("approval", (event) => {
+        if (!isActiveStream()) return;
+        const payload = parseSsePayload(event);
+        const pendingApproval = getPendingApprovalFromEvent(payload);
+        if (pendingApproval) {
+          syncPendingApproval(pendingApproval);
+        }
+      });
+
       source.onerror = () => {
         if (!isActiveStream()) return;
         // 重连条件：session 正在运行，或者前端正在发送消息。
@@ -324,7 +348,7 @@ export function useAssistantSession(projectName: string | null) {
         }
       };
     },
-    [applySnapshot, clearPendingQuestion, projectName, closeStream, store, syncPendingQuestion],
+    [applySnapshot, clearPendingQuestion, clearPendingApproval, projectName, closeStream, store, syncPendingQuestion, syncPendingApproval],
   );
 
   // 加载会话
@@ -348,6 +372,7 @@ export function useAssistantSession(projectName: string | null) {
         if (!sessionId) {
           store.getState().setCurrentSessionId(null);
           clearPendingQuestion();
+          clearPendingApproval();
           store.getState().setMessagesLoading(false);
           return;
         }
@@ -395,6 +420,7 @@ export function useAssistantSession(projectName: string | null) {
     projectName,
     applySnapshot,
     clearPendingQuestion,
+    clearPendingApproval,
     connectStream,
     closeStream,
     invalidatePendingSend,
@@ -514,6 +540,26 @@ export function useAssistantSession(projectName: string | null) {
     [projectName, store],
   );
 
+  const decideApproval = useCallback(
+    async (requestId: string, decision: "allow" | "deny", updatedInput?: Record<string, unknown>, message?: string) => {
+      const sessionId = store.getState().currentSessionId;
+      if (!projectName || !sessionId) return;
+
+      store.getState().setError(null);
+      store.getState().setDecidingApproval(true);
+
+      try {
+        await API.decideAssistantToolApproval(projectName, sessionId, requestId, decision, updatedInput, message);
+        store.getState().setPendingApproval(null);
+      } catch (err) {
+        store.getState().setError((err as Error).message ?? "审批操作失败");
+      } finally {
+        store.getState().setDecidingApproval(false);
+      }
+    },
+    [projectName, store],
+  );
+
   // 中断会话
   const interrupt = useCallback(async () => {
     const sessionId = store.getState().currentSessionId;
@@ -538,10 +584,11 @@ export function useAssistantSession(projectName: string | null) {
     store.getState().setDraftTurn(null);
     store.getState().setSessionStatus("idle");
     clearPendingQuestion();
+    clearPendingApproval();
     store.getState().setCurrentSessionId(null);
     store.getState().setIsDraftSession(true);
     statusRef.current = "idle";
-  }, [projectName, clearPendingQuestion, closeStream, invalidatePendingSend, store]);
+  }, [projectName, clearPendingQuestion, clearPendingApproval, closeStream, invalidatePendingSend, store]);
 
   // 切换到指定会话
   const switchSession = useCallback(async (sessionId: string) => {
@@ -554,6 +601,7 @@ export function useAssistantSession(projectName: string | null) {
     store.getState().setTurns([]);
     store.getState().setDraftTurn(null);
     clearPendingQuestion();
+    clearPendingApproval();
     store.getState().setMessagesLoading(true);
 
     // 记住选择
@@ -578,7 +626,7 @@ export function useAssistantSession(projectName: string | null) {
     } finally {
       store.getState().setMessagesLoading(false);
     }
-  }, [projectName, applySnapshot, clearPendingQuestion, closeStream, connectStream, invalidatePendingSend, store]);
+  }, [projectName, applySnapshot, clearPendingQuestion, clearPendingApproval, closeStream, connectStream, invalidatePendingSend, store]);
 
   // 删除会话
   const deleteSession = useCallback(async (sessionId: string) => {
@@ -600,15 +648,16 @@ export function useAssistantSession(projectName: string | null) {
           store.getState().setDraftTurn(null);
           store.getState().setSessionStatus(null);
           clearPendingQuestion();
+          clearPendingApproval();
           statusRef.current = "idle";
         }
       }
     } catch {
       // 静默失败
     }
-  }, [projectName, clearPendingQuestion, closeStream, invalidatePendingSend, switchSession, store]);
+  }, [projectName, clearPendingQuestion, clearPendingApproval, closeStream, invalidatePendingSend, switchSession, store]);
 
-  return { sendMessage, answerQuestion, interrupt, createNewSession, switchSession, deleteSession };
+  return { sendMessage, answerQuestion, decideApproval, interrupt, createNewSession, switchSession, deleteSession };
 }
 
 function getPendingQuestionFromSnapshot(
@@ -640,5 +689,40 @@ function getPendingQuestionFromEvent(payload: Record<string, unknown>): PendingQ
   return {
     question_id: payload.question_id,
     questions: payload.questions as PendingQuestion["questions"],
+  };
+}
+
+function getPendingApprovalFromSnapshot(
+  snapshot: Partial<AssistantSnapshot> | Record<string, unknown>,
+): PendingApproval | null {
+  const approvals = snapshot.pending_approvals as Array<Record<string, unknown>> | undefined;
+  const pending = approvals?.[0]; // backend only emits one at a time for now
+
+  if (!pending) {
+    return null;
+  }
+
+  return {
+    type: "tool_approval_request",
+    request_id: pending.request_id as string,
+    tool_name: pending.tool_name as string,
+    input: pending.input as Record<string, unknown>,
+    session_id: pending.session_id as string,
+    timestamp: pending.timestamp as string,
+  };
+}
+
+function getPendingApprovalFromEvent(payload: Record<string, unknown>): PendingApproval | null {
+  if (payload.type !== "tool_approval_request" || typeof payload.request_id !== "string") {
+    return null;
+  }
+
+  return {
+    type: "tool_approval_request",
+    request_id: payload.request_id,
+    tool_name: payload.tool_name as string,
+    input: payload.input as Record<string, unknown>,
+    session_id: payload.session_id as string,
+    timestamp: payload.timestamp as string || new Date().toISOString(),
   };
 }

--- a/frontend/src/stores/assistant-store.ts
+++ b/frontend/src/stores/assistant-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { SessionMeta, Turn, PendingQuestion, SkillInfo, SessionStatus } from "@/types";
+import type { SessionMeta, Turn, PendingQuestion, PendingApproval, SkillInfo, SessionStatus } from "@/types";
 
 interface AssistantState {
   // Sessions
@@ -26,6 +26,10 @@ interface AssistantState {
   pendingQuestion: PendingQuestion | null;
   answeringQuestion: boolean;
 
+  // Approvals
+  pendingApproval: PendingApproval | null;
+  decidingApproval: boolean;
+
   // Skills
   skills: SkillInfo[];
   skillsLoading: boolean;
@@ -35,6 +39,10 @@ interface AssistantState {
 
   // Draft session (lazy creation)
   isDraftSession: boolean;
+
+  // Context length awareness
+  contextLong: boolean;
+  turnsCount: number;
 
   // Actions (basic setters -- full logic migrated later)
   setSessions: (sessions: SessionMeta[]) => void;
@@ -51,10 +59,14 @@ interface AssistantState {
   setSessionStatusDetail: (detail: string | null) => void;
   setPendingQuestion: (question: PendingQuestion | null) => void;
   setAnsweringQuestion: (answering: boolean) => void;
+  setPendingApproval: (approval: PendingApproval | null) => void;
+  setDecidingApproval: (deciding: boolean) => void;
   setSkills: (skills: SkillInfo[]) => void;
   setSkillsLoading: (loading: boolean) => void;
   setCurrentProject: (project: string | null) => void;
   setIsDraftSession: (draft: boolean) => void;
+  setContextLong: (long: boolean) => void;
+  setTurnsCount: (count: number) => void;
 }
 
 export const useAssistantStore = create<AssistantState>((set) => ({
@@ -72,9 +84,13 @@ export const useAssistantStore = create<AssistantState>((set) => ({
   sessionStatusDetail: null,
   pendingQuestion: null,
   answeringQuestion: false,
+  pendingApproval: null,
+  decidingApproval: false,
   skills: [],
   skillsLoading: false,
   currentProject: null,
+  contextLong: false,
+  turnsCount: 0,
   isDraftSession: false,
 
   setSessions: (sessions) => set({ sessions }),
@@ -91,8 +107,12 @@ export const useAssistantStore = create<AssistantState>((set) => ({
   setSessionStatusDetail: (detail) => set({ sessionStatusDetail: detail }),
   setPendingQuestion: (question) => set({ pendingQuestion: question }),
   setAnsweringQuestion: (answering) => set({ answeringQuestion: answering }),
+  setPendingApproval: (approval) => set({ pendingApproval: approval }),
+  setDecidingApproval: (deciding) => set({ decidingApproval: deciding }),
   setSkills: (skills) => set({ skills }),
   setSkillsLoading: (loading) => set({ skillsLoading: loading }),
   setCurrentProject: (project) => set({ currentProject: project }),
   setIsDraftSession: (draft) => set({ isDraftSession: draft }),
+  setContextLong: (long) => set({ contextLong: long }),
+  setTurnsCount: (count) => set({ turnsCount: count }),
 }));

--- a/frontend/src/types/assistant.ts
+++ b/frontend/src/types/assistant.ts
@@ -59,12 +59,26 @@ export interface PendingQuestion {
   }>;
 }
 
+export interface PendingApproval {
+  type: "tool_approval_request";
+  request_id: string;
+  tool_name: string;
+  input: Record<string, unknown>;
+  session_id: string;
+  timestamp: string;
+}
+
 export interface AssistantSnapshot {
   session_id: string;
   status: SessionStatus;
   turns: Turn[];
   draft_turn: Turn | null;
   pending_questions: PendingQuestion[];
+  pending_approvals: PendingApproval[];
+  /** Number of turns in the conversation (for context length display) */
+  turns_count?: number;
+  /** True when conversation is approaching context limit (~80+ turns) */
+  context_long?: boolean;
 }
 
 export interface SkillInfo {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,21 @@ dependencies = [
     "xai-sdk>=1.8.2",
     "pyjianyingdraft>=0.2.6",
     "instructor>=1.14.5",
+    "slowapi>=0.1.9",
 ]
 
 [dependency-groups]
 dev = ["pytest>=9.0.2", "pytest-asyncio>=1.3.0", "pytest-cov>=7.0.0", "ruff>=0.15.0"]
+observability = [
+    # Prometheus metrics — expose /metrics endpoint
+    "prometheus-client>=0.21.0",
+    # OpenTelemetry tracing (optional — only needed when OTLP_ENDPOINT is set)
+    "opentelemetry-api>=1.28.0",
+    "opentelemetry-sdk>=1.28.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.28.0",
+    "opentelemetry-instrumentation-fastapi>=0.49b0",
+    "opentelemetry-instrumentation-sqlalchemy>=0.49b0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -23,6 +23,14 @@ from server.agent_runtime.session_store import SessionMetaStore
 
 logger = logging.getLogger(__name__)
 
+# Lazy import observability to avoid circular deps — only active if prometheus_client installed
+try:
+    from server.observability import record_session_created, set_active_sessions
+    _OBS_AVAILABLE = True
+except Exception:
+    _OBS_AVAILABLE = False
+
+
 try:
     from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
     from claude_agent_sdk.types import HookMatcher, PermissionResultAllow, SystemPromptPreset
@@ -994,6 +1002,11 @@ class SessionManager:
         managed.last_activity = time.monotonic()
         self.sessions[temp_id] = managed
 
+        # Prometheus: track session creation and active count
+        if _OBS_AVAILABLE:
+            record_session_created()
+            set_active_sessions(len(self.sessions))
+
         try:
             await actor.start()
         except Exception:
@@ -1464,6 +1477,9 @@ class SessionManager:
             self.sessions.pop(session_id, None)
             self._connect_locks.pop(session_id, None)
             self._disconnecting.discard(session_id)
+            # Prometheus: update active session gauge after eviction
+            if _OBS_AVAILABLE:
+                set_active_sessions(len(self.sessions))
 
     async def _get_cleanup_delay(self) -> int:
         """返回会话清理延迟秒数，默认 300（5 分钟）。"""

--- a/server/agent_runtime/stream_projector.py
+++ b/server/agent_runtime/stream_projector.py
@@ -499,13 +499,22 @@ class AssistantStreamProjector:
         session_id: str,
         status: str,
         pending_questions: list[dict[str, Any]] | None = None,
+        pending_approvals: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Build unified snapshot payload for API and SSE."""
         # self.turns are already normalized by group_messages_into_turns
+        turns_count = len(self.turns)
+        # Threshold: warn UI when conversation is getting very long
+        # (Claude Sonnet context = ~200K tokens ≈ 300-400 visible turns typically)
+        _CONTEXT_WARN_TURNS = 80
+        context_long = turns_count >= _CONTEXT_WARN_TURNS
         return {
             "session_id": session_id,
             "status": status,
             "turns": self.turns,
             "draft_turn": self._build_visible_draft_turn(),
             "pending_questions": pending_questions or [],
+            "pending_approvals": pending_approvals or [],
+            "turns_count": turns_count,
+            "context_long": context_long,
         }

--- a/server/observability.py
+++ b/server/observability.py
@@ -1,0 +1,211 @@
+"""
+Observability — OpenTelemetry tracing + Prometheus metrics cho ArcReel.
+
+Kích hoạt bằng biến môi trường:
+  OTLP_ENDPOINT=http://jaeger:4317     # gRPC OTLP endpoint (ví dụ: Jaeger, Tempo)
+
+Để tắt hoàn toàn: không set OTLP_ENDPOINT (zero overhead).
+
+Metrics Prometheus được expose tại GET /metrics (không cần auth).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Prometheus Metrics — always available, even without OTLP
+# ---------------------------------------------------------------------------
+try:
+    from prometheus_client import (
+        CONTENT_TYPE_LATEST,
+        Counter,
+        Gauge,
+        Histogram,
+        generate_latest,
+    )
+    _PROMETHEUS_AVAILABLE = True
+except ImportError:
+    _PROMETHEUS_AVAILABLE = False
+    logger.debug("prometheus_client not installed — /metrics endpoint disabled")
+
+if _PROMETHEUS_AVAILABLE:
+    # Request metrics (supplement to FastAPI auto-instrumentation)
+    HTTP_REQUEST_DURATION = Histogram(
+        "arcreel_http_request_duration_seconds",
+        "HTTP request duration",
+        ["method", "endpoint", "status_code"],
+        buckets=[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0],
+    )
+
+    # AI / Agent metrics
+    TOOL_APPROVAL_DECISIONS = Counter(
+        "arcreel_tool_approval_decisions_total",
+        "Tool approval decisions made by user",
+        ["tool_name", "decision"],  # decision: allow | deny
+    )
+    SESSION_CREATED = Counter(
+        "arcreel_sessions_created_total",
+        "Assistant sessions created",
+    )
+    SESSION_ACTIVE = Gauge(
+        "arcreel_sessions_active",
+        "Currently active (in-memory) assistant sessions",
+    )
+
+    # Generation pipeline metrics
+    GENERATION_TASK_DURATION = Histogram(
+        "arcreel_generation_task_duration_seconds",
+        "Generation task duration",
+        ["provider", "task_type"],  # task_type: image | video
+        buckets=[1, 5, 15, 30, 60, 120, 300],
+    )
+    GENERATION_TASK_TOTAL = Counter(
+        "arcreel_generation_tasks_total",
+        "Total generation tasks",
+        ["provider", "task_type", "status"],  # status: success | error
+    )
+
+    # Token usage
+    TOKEN_USAGE = Counter(
+        "arcreel_token_usage_total",
+        "Total tokens consumed",
+        ["model", "usage_type"],  # usage_type: input | output
+    )
+
+    # Context compression
+    CONTEXT_COMPRESSIONS = Counter(
+        "arcreel_context_compressions_total",
+        "Number of times session history was compressed",
+    )
+
+# ---------------------------------------------------------------------------
+# OpenTelemetry Tracing — optional
+# ---------------------------------------------------------------------------
+_OTEL_AVAILABLE = False
+
+def setup_telemetry(app) -> None:  # type: ignore[type-arg]
+    """
+    Khởi tạo OpenTelemetry instrumentation.
+    Gọi từ FastAPI lifespan *trước* khi yield.
+    Nếu OTLP_ENDPOINT không được cấu hình, hàm này là no-op.
+    """
+    global _OTEL_AVAILABLE
+
+    otlp_endpoint = os.environ.get("OTLP_ENDPOINT", "").strip()
+
+    if not otlp_endpoint:
+        logger.debug("OTLP_ENDPOINT not set — OpenTelemetry tracing disabled")
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+        from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError as exc:
+        logger.warning(
+            "OpenTelemetry packages not installed — tracing disabled. "
+            "Install with: uv add opentelemetry-sdk opentelemetry-exporter-otlp-proto-grpc "
+            "opentelemetry-instrumentation-fastapi opentelemetry-instrumentation-sqlalchemy "
+            "(%s)",
+            exc,
+        )
+        return
+
+    service_name = os.environ.get("OTEL_SERVICE_NAME", "arcreel")
+    resource = Resource.create({"service.name": service_name})
+    provider = TracerProvider(resource=resource)
+
+    exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    FastAPIInstrumentor.instrument_app(app)
+    SQLAlchemyInstrumentor().instrument()
+
+    _OTEL_AVAILABLE = True
+    logger.info(
+        "OpenTelemetry tracing enabled → %s (service=%s)",
+        otlp_endpoint,
+        service_name,
+    )
+
+
+def get_tracer(name: str = "arcreel"):
+    """Trả về tracer. No-op noop tracer nếu OTEL không được cấu hình."""
+    if not _OTEL_AVAILABLE:
+        # Return a noop-compatible object so callers don't need to check
+        class _NoopTracer:
+            def start_as_current_span(self, *a, **kw):
+                from contextlib import contextmanager
+                @contextmanager
+                def _ctx():
+                    yield None
+                return _ctx()
+        return _NoopTracer()
+
+    from opentelemetry import trace
+    return trace.get_tracer(name)
+
+
+# ---------------------------------------------------------------------------
+# Metric helper functions — safe even if prometheus_client not installed
+# ---------------------------------------------------------------------------
+
+def record_tool_approval(tool_name: str, decision: str) -> None:
+    """Ghi nhận quyết định phê duyệt tool."""
+    if _PROMETHEUS_AVAILABLE:
+        TOOL_APPROVAL_DECISIONS.labels(tool_name=tool_name, decision=decision).inc()
+
+
+def record_session_created() -> None:
+    if _PROMETHEUS_AVAILABLE:
+        SESSION_CREATED.inc()
+
+
+def set_active_sessions(count: int) -> None:
+    if _PROMETHEUS_AVAILABLE:
+        SESSION_ACTIVE.set(count)
+
+
+def record_generation_task(provider: str, task_type: str, status: str, duration_s: float) -> None:
+    if _PROMETHEUS_AVAILABLE:
+        GENERATION_TASK_DURATION.labels(provider=provider, task_type=task_type).observe(duration_s)
+        GENERATION_TASK_TOTAL.labels(provider=provider, task_type=task_type, status=status).inc()
+
+
+def record_token_usage(model: str, input_tokens: int, output_tokens: int) -> None:
+    if _PROMETHEUS_AVAILABLE:
+        TOKEN_USAGE.labels(model=model, usage_type="input").inc(input_tokens)
+        TOKEN_USAGE.labels(model=model, usage_type="output").inc(output_tokens)
+
+
+def record_context_compression() -> None:
+    if _PROMETHEUS_AVAILABLE:
+        CONTEXT_COMPRESSIONS.inc()
+
+
+# ---------------------------------------------------------------------------
+# Prometheus metrics endpoint handler
+# ---------------------------------------------------------------------------
+
+async def metrics_handler(request=None):  # type: ignore[assignment]
+    """FastAPI route handler để expose /metrics cho Prometheus scrape."""
+    from starlette.responses import Response
+
+    if not _PROMETHEUS_AVAILABLE:
+        return Response(
+            "# prometheus_client not installed\n",
+            media_type="text/plain",
+            status_code=503,
+        )
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -63,6 +63,9 @@ class _FakeSessionManager:
     async def get_pending_questions_snapshot(self, session_id):
         return list(self.pending)
 
+    async def get_pending_approvals_snapshot(self, session_id):
+        return []
+
     async def send_message(self, session_id, content, **kwargs):
         self.sent.append((session_id, content))
 

--- a/tests/test_assistant_service_streaming.py
+++ b/tests/test_assistant_service_streaming.py
@@ -67,6 +67,9 @@ class _FakeSessionManager:
         self.call_log.append(("get_pending_questions_snapshot", session_id))
         return list(self.pending_questions)
 
+    async def get_pending_approvals_snapshot(self, session_id: str):
+        return []
+
 
 def _parse_sse_event(sse_event: ServerSentEvent) -> tuple[str, dict]:
     event_name = sse_event.event or ""


### PR DESCRIPTION
## Summary
Adds opt-in observability layer with zero overhead when disabled.

**Metrics (all instrumented with real call sites):**
- `arcreel_sessions_created_total` — incremented in `send_new_session()`
- `arcreel_sessions_active` — updated in `send_new_session()` + `_evict_one()`
- `arcreel_http_request_duration_seconds` — via FastAPIInstrumentor
- `arcreel_generation_task_*` — helpers ready for GenerationWorker
- `arcreel_token_usage_total` — helper ready for UsageTracker
- `arcreel_context_compressions_total` — helper for stream_projector

**Enable:** set `OTLP_ENDPOINT=http://jaeger:4317`  
**Metrics endpoint:** `GET /metrics` (no auth required)

Closes part of #306