### PR TITLE
ci: add CI pipeline (ruff + pytest ≥80% + pnpm + i18n gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,114 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  # ──────────────────────────────────────────────────────────
+  # Backend: ruff + pytest (≥80% coverage)
+  # ──────────────────────────────────────────────────────────
+  backend:
+    name: Backend (ruff + pytest)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg mediainfo
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint (ruff check)
+        run: uv run ruff check .
+
+      - name: Format check (ruff format)
+        run: uv run ruff format --check .
+
+      - name: Run tests with coverage
+        run: |
+          uv run python -m pytest \
+            --cov=lib \
+            --cov=server \
+            --cov-report=term-missing \
+            --cov-report=xml \
+            --cov-fail-under=80 \
+            -v
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-xml
+          path: coverage.xml
+
+  # ──────────────────────────────────────────────────────────
+  # Frontend: typecheck + lint + tests
+  # ──────────────────────────────────────────────────────────
+  frontend:
+    name: Frontend (pnpm check)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        working-directory: frontend
+        run: pnpm typecheck
+
+      - name: Lint
+        working-directory: frontend
+        run: pnpm lint
+
+      - name: Run tests
+        working-directory: frontend
+        run: pnpm test:coverage
+
+  # ──────────────────────────────────────────────────────────
+  # i18n consistency gate
+  # ──────────────────────────────────────────────────────────
+  i18n-check:
+    name: i18n key consistency (zh/en/vi)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Check i18n key consistency
+        run: uv run python -m pytest tests/test_i18n_consistency.py -v


### PR DESCRIPTION
## Summary
Adds `.github/workflows/ci.yml` with 3 jobs running on every push/PR.

**Jobs:**
- `backend`: ruff check + ruff format --check + pytest --cov ≥80%
- `frontend`: pnpm typecheck + pnpm lint + pnpm test:coverage  
- `i18n-check`: `test_i18n_consistency.py` (zh/en/vi key drift gate)

**Enables CI badge** in README.vi.md and README.en.md pointing to this workflow.

Closes part of #306