### PR TITLE
fix(video): 修复自定义供应商生成视频立即报 400 "Task is not completed yet" 的问题

### DIFF
--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -53,30 +53,26 @@ async def poll_with_retry[T](
     start = time.monotonic()
     prefix = f"{label} " if label else ""
 
+    # 先查询再等待：已完成/缓存命中的任务立刻返回，不被 poll_interval 白等一轮。
     while True:
-        elapsed = time.monotonic() - start
-        if elapsed >= max_wait:
-            raise TimeoutError(f"{prefix}任务超时（{max_wait:.0f}秒）")
-
-        await asyncio.sleep(poll_interval)
-
         try:
             result = await poll_fn()
         except Exception as e:
-            if _should_retry(e, retryable_errors):
-                logger.warning("%s轮询异常（将重试）: %s - %s", prefix, type(e).__name__, str(e)[:200])
-                continue
-            raise
+            if not _should_retry(e, retryable_errors):
+                raise
+            logger.warning("%s轮询异常（将重试）: %s - %s", prefix, type(e).__name__, str(e)[:200])
+        else:
+            error_msg = is_failed(result)
+            if error_msg is not None:
+                raise RuntimeError(error_msg)
+            if is_done(result):
+                return result
+            if on_progress is not None:
+                on_progress(result, time.monotonic() - start)
 
-        error_msg = is_failed(result)
-        if error_msg is not None:
-            raise RuntimeError(error_msg)
-
-        if is_done(result):
-            return result
-
-        if on_progress is not None:
-            on_progress(result, time.monotonic() - start)
+        if time.monotonic() - start >= max_wait:
+            raise TimeoutError(f"{prefix}任务超时（{max_wait:.0f}秒）")
+        await asyncio.sleep(poll_interval)
 
 
 @with_retry_async()

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -135,13 +135,6 @@ class OpenAIVideoBackend:
         不复用 SDK 的 client.videos.poll：它仅识别 in_progress/queued/completed/failed，
         对接返回非标状态（如 NOT_START）的 OpenAI 兼容网关时会提前退出，导致下载未就绪任务。
         """
-        # poll_with_retry 循环首轮也会先 sleep，已完成/缓存命中场景会被白等一轮——先查一次再决定
-        first = await self._client.videos.retrieve(video_id)
-        if first.status == "completed":
-            return first
-        if first.status == "failed":
-            raise RuntimeError(f"Sora 视频生成失败: {getattr(first, 'error', None)}")
-
         max_wait = max(_MIN_POLL_TIMEOUT_SECONDS, float(duration_seconds) * _POLL_TIMEOUT_PER_SECOND)
 
         return await poll_with_retry(

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -135,6 +135,13 @@ class OpenAIVideoBackend:
         不复用 SDK 的 client.videos.poll：它仅识别 in_progress/queued/completed/failed，
         对接返回非标状态（如 NOT_START）的 OpenAI 兼容网关时会提前退出，导致下载未就绪任务。
         """
+        # poll_with_retry 循环首轮也会先 sleep，已完成/缓存命中场景会被白等一轮——先查一次再决定
+        first = await self._client.videos.retrieve(video_id)
+        if first.status == "completed":
+            return first
+        if first.status == "failed":
+            raise RuntimeError(f"Sora 视频生成失败: {getattr(first, 'error', None)}")
+
         max_wait = max(_MIN_POLL_TIMEOUT_SECONDS, float(duration_seconds) * _POLL_TIMEOUT_PER_SECOND)
 
         return await poll_with_retry(

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -15,7 +15,12 @@ from lib.video_backends.base import (
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
+    poll_with_retry,
 )
+
+_POLL_INTERVAL_SECONDS = 5.0
+_MIN_POLL_TIMEOUT_SECONDS = 600.0
+_POLL_TIMEOUT_PER_SECOND = 30.0
 
 logger = logging.getLogger(__name__)
 
@@ -99,11 +104,9 @@ class OpenAIVideoBackend:
         logger.info("OpenAI 视频生成开始: model=%s, seconds=%s", self._model, kwargs["seconds"])
 
         video = await self._create_video(**kwargs)
+        final = await self._poll_until_complete(video.id, request.duration_seconds)
 
-        if video.status == "failed":
-            raise RuntimeError(f"Sora 视频生成失败: {video.error}")
-
-        content = await self._download_content_with_retry(video.id)
+        content = await self._download_content_with_retry(final.id)
 
         def _write():
             request.output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -117,14 +120,35 @@ class OpenAIVideoBackend:
             video_path=request.output_path,
             provider=PROVIDER_OPENAI,
             model=self._model,
-            duration_seconds=int(video.seconds if video.seconds is not None else kwargs["seconds"]),
-            task_id=video.id,
+            duration_seconds=int(final.seconds if final.seconds is not None else kwargs["seconds"]),
+            task_id=final.id,
         )
 
     @with_retry_async(retryable_errors=OPENAI_RETRYABLE_ERRORS)
     async def _create_video(self, **kwargs):
-        """视频生成（create_and_poll），带独立重试。"""
-        return await self._client.videos.create_and_poll(**kwargs)
+        """仅创建视频任务（带重试）；轮询交由 _poll_until_complete 自管。"""
+        return await self._client.videos.create(**kwargs)
+
+    async def _poll_until_complete(self, video_id: str, duration_seconds: int):
+        """轮询任务直到 status=='completed'。
+
+        不复用 SDK 的 client.videos.poll：它仅识别 in_progress/queued/completed/failed，
+        对接返回非标状态（如 NOT_START）的 OpenAI 兼容网关时会提前退出，导致下载未就绪任务。
+        """
+        max_wait = max(_MIN_POLL_TIMEOUT_SECONDS, float(duration_seconds) * _POLL_TIMEOUT_PER_SECOND)
+
+        return await poll_with_retry(
+            poll_fn=lambda: self._client.videos.retrieve(video_id),
+            is_done=lambda v: v.status == "completed",
+            is_failed=lambda v: f"Sora 视频生成失败: {getattr(v, 'error', None)}" if v.status == "failed" else None,
+            poll_interval=_POLL_INTERVAL_SECONDS,
+            max_wait=max_wait,
+            retryable_errors=OPENAI_RETRYABLE_ERRORS,
+            label="OpenAI",
+            on_progress=lambda v, elapsed: logger.info(
+                "OpenAI 视频生成中... 状态: %s, 已等待 %d 秒", v.status, int(elapsed)
+            ),
+        )
 
     @with_retry_async(
         max_attempts=DOWNLOAD_MAX_ATTEMPTS,

--- a/tests/test_openai_video_backend.py
+++ b/tests/test_openai_video_backend.py
@@ -32,6 +32,15 @@ def _make_mock_content(data: bytes = b"fake-video-data"):
     return content
 
 
+def _stub_client_completed(client: AsyncMock, *, seconds="8", video_id="vid_123", data=b"fake-video-data"):
+    """常用 stub：create→queued、retrieve→completed、download_content→data。"""
+    client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued", seconds=seconds, video_id=video_id))
+    client.videos.retrieve = AsyncMock(
+        return_value=_make_mock_video(status="completed", seconds=seconds, video_id=video_id)
+    )
+    client.videos.download_content = AsyncMock(return_value=_make_mock_content(data))
+
+
 class TestOpenAIVideoBackend:
     def test_name_and_model(self):
         with patch("lib.openai_shared.AsyncOpenAI"):
@@ -62,10 +71,12 @@ class TestOpenAIVideoBackend:
     async def test_text_to_video(self, tmp_path: Path):
         video_data = b"mp4-video-content"
         mock_client = AsyncMock()
-        mock_client.videos.create_and_poll = AsyncMock(return_value=_make_mock_video(seconds="8"))
-        mock_client.videos.download_content = AsyncMock(return_value=_make_mock_content(video_data))
+        _stub_client_completed(mock_client, seconds="8", data=video_data)
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+        ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key")
@@ -86,7 +97,7 @@ class TestOpenAIVideoBackend:
         assert result.task_id == "vid_123"
         assert output_path.read_bytes() == video_data
 
-        call_kwargs = mock_client.videos.create_and_poll.call_args[1]
+        call_kwargs = mock_client.videos.create.call_args[1]
         assert call_kwargs["prompt"] == "A cat walking in the park"
         assert call_kwargs["model"] == "sora-2"
         assert call_kwargs["seconds"] == "8"
@@ -98,10 +109,12 @@ class TestOpenAIVideoBackend:
         start_image.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
 
         mock_client = AsyncMock()
-        mock_client.videos.create_and_poll = AsyncMock(return_value=_make_mock_video(seconds="4"))
-        mock_client.videos.download_content = AsyncMock(return_value=_make_mock_content(b"video"))
+        _stub_client_completed(mock_client, seconds="4")
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+        ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key")
@@ -115,7 +128,7 @@ class TestOpenAIVideoBackend:
             result = await backend.generate(request)
 
         assert result.duration_seconds == 4
-        call_kwargs = mock_client.videos.create_and_poll.call_args[1]
+        call_kwargs = mock_client.videos.create.call_args[1]
         ref = call_kwargs["input_reference"]
         assert isinstance(ref, tuple)
         assert ref[0] == "start.png"
@@ -129,9 +142,14 @@ class TestOpenAIVideoBackend:
         failed_video.error = error
 
         mock_client = AsyncMock()
-        mock_client.videos.create_and_poll = AsyncMock(return_value=failed_video)
+        mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))
+        mock_client.videos.retrieve = AsyncMock(return_value=failed_video)
+        mock_client.videos.download_content = AsyncMock()
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+        ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key")
@@ -143,12 +161,17 @@ class TestOpenAIVideoBackend:
             with pytest.raises(RuntimeError, match="Sora 视频生成失败"):
                 await backend.generate(request)
 
+        # 失败应该在轮询阶段抛出，不会进入下载
+        mock_client.videos.download_content.assert_not_called()
+
     async def test_duration_mapping(self, tmp_path: Path):
         mock_client = AsyncMock()
-        mock_client.videos.create_and_poll = AsyncMock(return_value=_make_mock_video(seconds="4"))
-        mock_client.videos.download_content = AsyncMock(return_value=_make_mock_content(b"v"))
+        _stub_client_completed(mock_client, seconds="4")
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+        ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key")
@@ -161,16 +184,18 @@ class TestOpenAIVideoBackend:
                     duration_seconds=seconds,
                 )
                 await backend.generate(request)
-                call_kwargs = mock_client.videos.create_and_poll.call_args[1]
+                call_kwargs = mock_client.videos.create.call_args[1]
                 assert call_kwargs["seconds"] == expected, f"duration={seconds}"
 
     async def test_video_seconds_none_fallback(self, tmp_path: Path):
         """当 API 返回 video.seconds=None 时，应回退到请求的 duration。"""
         mock_client = AsyncMock()
-        mock_client.videos.create_and_poll = AsyncMock(return_value=_make_mock_video(seconds=None))
-        mock_client.videos.download_content = AsyncMock(return_value=_make_mock_content(b"v"))
+        _stub_client_completed(mock_client, seconds=None)
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+        ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key")
@@ -187,10 +212,12 @@ class TestOpenAIVideoBackend:
 
     async def test_size_mapping(self, tmp_path: Path):
         mock_client = AsyncMock()
-        mock_client.videos.create_and_poll = AsyncMock(return_value=_make_mock_video(seconds="4"))
-        mock_client.videos.download_content = AsyncMock(return_value=_make_mock_content(b"v"))
+        _stub_client_completed(mock_client, seconds="4")
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+        ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key")
@@ -204,23 +231,25 @@ class TestOpenAIVideoBackend:
                     resolution="720p",
                 )
                 await backend.generate(request)
-                call_kwargs = mock_client.videos.create_and_poll.call_args[1]
+                call_kwargs = mock_client.videos.create.call_args[1]
                 assert call_kwargs["size"] == expected_size, f"aspect={aspect}"
 
     async def test_content_download_retry_does_not_regenerate(self, tmp_path: Path):
-        """内容下载 502 失败后应单独重试下载，而非重新调用 create_and_poll。"""
+        """内容下载 502 失败后应单独重试下载，而非重新创建任务。"""
         error = InternalServerError(
             message="Failed to resolve Vertex video URL",
             response=MagicMock(status_code=502, headers={}),
             body=None,
         )
         mock_client = AsyncMock()
-        mock_client.videos.create_and_poll = AsyncMock(return_value=_make_mock_video(seconds="8"))
+        mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))
+        mock_client.videos.retrieve = AsyncMock(return_value=_make_mock_video(status="completed", seconds="8"))
         mock_client.videos.download_content = AsyncMock(side_effect=[error, error, _make_mock_content(b"video-data")])
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
             patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -235,8 +264,8 @@ class TestOpenAIVideoBackend:
 
         assert result.video_path == output_path
         assert output_path.read_bytes() == b"video-data"
-        # create_and_poll 只调用 1 次，不因下载失败重新生成
-        assert mock_client.videos.create_and_poll.call_count == 1
+        # create 只调用 1 次，不因下载失败重新创建任务
+        assert mock_client.videos.create.call_count == 1
         # download_content 调用 3 次（2 次失败 + 1 次成功）
         assert mock_client.videos.download_content.call_count == 3
 
@@ -248,12 +277,14 @@ class TestOpenAIVideoBackend:
             body=None,
         )
         mock_client = AsyncMock()
-        mock_client.videos.create_and_poll = AsyncMock(return_value=_make_mock_video(seconds="8"))
+        mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))
+        mock_client.videos.retrieve = AsyncMock(return_value=_make_mock_video(status="completed", seconds="8"))
         mock_client.videos.download_content = AsyncMock(side_effect=error)
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
             patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -267,8 +298,8 @@ class TestOpenAIVideoBackend:
             with pytest.raises(InternalServerError):
                 await backend.generate(request)
 
-        # 即使下载重试耗尽，也只生成 1 次视频
-        assert mock_client.videos.create_and_poll.call_count == 1
+        # 即使下载重试耗尽，也只创建 1 次任务
+        assert mock_client.videos.create.call_count == 1
 
     async def test_content_download_non_retryable_error_fails_immediately(self, tmp_path: Path):
         """不可重试的下载错误（如 4xx）应立即失败，不浪费退避时间。"""
@@ -280,13 +311,15 @@ class TestOpenAIVideoBackend:
             body=None,
         )
         mock_client = AsyncMock()
-        mock_client.videos.create_and_poll = AsyncMock(return_value=_make_mock_video(seconds="8"))
+        mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))
+        mock_client.videos.retrieve = AsyncMock(return_value=_make_mock_video(status="completed", seconds="8"))
         mock_client.videos.download_content = AsyncMock(side_effect=error)
         mock_sleep = AsyncMock()
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
             patch("lib.retry.asyncio.sleep", mock_sleep),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -300,6 +333,83 @@ class TestOpenAIVideoBackend:
             with pytest.raises(AuthenticationError):
                 await backend.generate(request)
 
-        # 不可重试错误：只调用 1 次下载，无 sleep
+        # 不可重试错误：只调用 1 次下载，无 retry sleep
         assert mock_client.videos.download_content.call_count == 1
         mock_sleep.assert_not_called()
+
+    async def test_polls_until_completed_for_nonstandard_status(self, tmp_path: Path):
+        """OpenAI 兼容网关返回非标 status（如 NOT_START / running）时，必须继续轮询直到 completed。
+
+        回归 issue：grok-imagine 走自定义供应商时，retrieve 返回 NOT_START，但 SDK 内置 poll
+        仅识别 4 种标准状态，会提前退出导致下载未就绪任务（400 Task is not completed yet）。
+        """
+        mock_client = AsyncMock()
+        mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))
+        # 模拟非标状态序列：NOT_START → running → in_progress → completed
+        mock_client.videos.retrieve = AsyncMock(
+            side_effect=[
+                _make_mock_video(status="NOT_START"),
+                _make_mock_video(status="running"),
+                _make_mock_video(status="in_progress"),
+                _make_mock_video(status="completed", seconds="8"),
+            ]
+        )
+        mock_client.videos.download_content = AsyncMock(return_value=_make_mock_content(b"v"))
+
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
+            from lib.video_backends.openai import OpenAIVideoBackend
+
+            backend = OpenAIVideoBackend(api_key="test-key")
+            output_path = tmp_path / "output.mp4"
+            request = VideoGenerationRequest(
+                prompt="test",
+                output_path=output_path,
+                duration_seconds=8,
+            )
+            result = await backend.generate(request)
+
+        # 必须轮询 4 次（3 次非完成 + 1 次完成）才得到结果
+        assert mock_client.videos.retrieve.call_count == 4
+        # 中间至少 sleep 了 3 次（每次轮询前都 sleep）
+        assert mock_sleep.await_count >= 3
+        # 下载只在完成后调用一次
+        assert mock_client.videos.download_content.call_count == 1
+        assert result.video_path == output_path
+
+    async def test_polls_failed_status_raises_without_download(self, tmp_path: Path):
+        """轮询期间出现 status='failed' 应直接抛错，不进入下载。"""
+        err = MagicMock()
+        err.message = "moderation rejected"
+        failed = _make_mock_video(status="failed")
+        failed.error = err
+
+        mock_client = AsyncMock()
+        mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))
+        mock_client.videos.retrieve = AsyncMock(
+            side_effect=[
+                _make_mock_video(status="in_progress"),
+                failed,
+            ]
+        )
+        mock_client.videos.download_content = AsyncMock()
+
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            from lib.video_backends.openai import OpenAIVideoBackend
+
+            backend = OpenAIVideoBackend(api_key="test-key")
+            output_path = tmp_path / "output.mp4"
+            request = VideoGenerationRequest(
+                prompt="bad",
+                output_path=output_path,
+                duration_seconds=8,
+            )
+            with pytest.raises(RuntimeError, match="Sora 视频生成失败"):
+                await backend.generate(request)
+
+        mock_client.videos.download_content.assert_not_called()

--- a/tests/test_openai_video_backend.py
+++ b/tests/test_openai_video_backend.py
@@ -379,6 +379,64 @@ class TestOpenAIVideoBackend:
         assert mock_client.videos.download_content.call_count == 1
         assert result.video_path == output_path
 
+    async def test_first_retrieve_completed_skips_polling_sleep(self, tmp_path: Path):
+        """首次 retrieve 即返回 completed 时应 fast-path 直接返回，不进入 poll_with_retry 的固定 sleep。"""
+        mock_client = AsyncMock()
+        mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))
+        mock_client.videos.retrieve = AsyncMock(return_value=_make_mock_video(status="completed", seconds="8"))
+        mock_client.videos.download_content = AsyncMock(return_value=_make_mock_content(b"v"))
+
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
+            from lib.video_backends.openai import OpenAIVideoBackend
+
+            backend = OpenAIVideoBackend(api_key="test-key")
+            output_path = tmp_path / "output.mp4"
+            request = VideoGenerationRequest(
+                prompt="test",
+                output_path=output_path,
+                duration_seconds=8,
+            )
+            await backend.generate(request)
+
+        # fast-path：只查一次，不进入 poll_with_retry → 不 sleep
+        assert mock_client.videos.retrieve.call_count == 1
+        mock_sleep.assert_not_awaited()
+
+    async def test_first_retrieve_failed_skips_polling(self, tmp_path: Path):
+        """首次 retrieve 即返回 failed 时应 fast-path 直接抛错，不进入 poll_with_retry 的 sleep。"""
+        err = MagicMock()
+        err.message = "moderation rejected"
+        failed = _make_mock_video(status="failed")
+        failed.error = err
+
+        mock_client = AsyncMock()
+        mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))
+        mock_client.videos.retrieve = AsyncMock(return_value=failed)
+        mock_client.videos.download_content = AsyncMock()
+
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
+            from lib.video_backends.openai import OpenAIVideoBackend
+
+            backend = OpenAIVideoBackend(api_key="test-key")
+            output_path = tmp_path / "output.mp4"
+            request = VideoGenerationRequest(
+                prompt="bad",
+                output_path=output_path,
+                duration_seconds=8,
+            )
+            with pytest.raises(RuntimeError, match="Sora 视频生成失败"):
+                await backend.generate(request)
+
+        assert mock_client.videos.retrieve.call_count == 1
+        mock_sleep.assert_not_awaited()
+        mock_client.videos.download_content.assert_not_called()
+
     async def test_polls_failed_status_raises_without_download(self, tmp_path: Path):
         """轮询期间出现 status='failed' 应直接抛错，不进入下载。"""
         err = MagicMock()

--- a/tests/test_openai_video_resolution.py
+++ b/tests/test_openai_video_resolution.py
@@ -25,7 +25,7 @@ async def test_resolution_none_omits_size(tmp_path):
         captured.update(kwargs)
         raise RuntimeError("stop")
 
-    backend._client.videos.create_and_poll = fake_create
+    backend._client.videos.create = fake_create
 
     req = VideoGenerationRequest(
         prompt="x",
@@ -49,7 +49,7 @@ async def test_resolution_token_maps_to_size(tmp_path):
         captured.update(kwargs)
         raise RuntimeError("stop")
 
-    backend._client.videos.create_and_poll = fake_create
+    backend._client.videos.create = fake_create
 
     req = VideoGenerationRequest(
         prompt="x",
@@ -73,7 +73,7 @@ async def test_unknown_resolution_passthrough(tmp_path):
         captured.update(kwargs)
         raise RuntimeError("stop")
 
-    backend._client.videos.create_and_poll = fake_create
+    backend._client.videos.create = fake_create
 
     req = VideoGenerationRequest(
         prompt="x",


### PR DESCRIPTION
## 问题

自定义供应商（如 custom-7 → grok-imagine-1.0-video）走 OpenAI 兼容协议时，视频生成会立刻 400 失败：

```
POST /v1/videos → 200
GET  /v1/videos/{id} → 200
GET  /v1/videos/{id}/content → 400 Task is not completed yet, current status: NOT_START
```

但 NewAPI 网关后台显示任务状态从"进行中"正常变为"成功"——任务在服务端**确实在执行**，只是客户端提前下载了。

## 根因

`lib/video_backends/openai.py:101` 调用了 OpenAI SDK 的 `client.videos.create_and_poll()`。SDK 内置 `poll()`（`openai/resources/videos.py:706`）仅识别 4 种 OpenAI Sora 标准状态：

```python
if video.status == "in_progress" or video.status == "queued":
    await self._sleep(...)
elif video.status == "completed" or video.status == "failed":
    return video
else:
    if TYPE_CHECKING:        # 运行时是 no-op
        assert_never(video.status)
```

OpenAI 兼容网关代理非 OpenAI Sora 模型时，retrieve 接口返回的 status 可能是 `NOT_START` / `running` / `processing` 等非标值，SDK 落入 else 分支后行为异常，提前退出 poll，立即拉 content 接口 → 任务未启动 → 400。

## 修复

参考 `lib/video_backends/{ark,newapi}.py` 已有模式：

- `_create_video` 改为只调 `videos.create()`（不再走 SDK 的 create_and_poll）
- 新增 `_poll_until_complete()` 用 `lib/video_backends/base.py` 的 `poll_with_retry`：
  - `is_done`: 仅当 `status == "completed"` 才结束
  - `is_failed`: 仅当 `status == "failed"` 才抛错
  - 其它任意状态（NOT_START / 网关自定义值）一律视为未完成继续轮询
- 默认 5 秒间隔，`max(600s, duration*30s)` 超时上限

`lib/custom_provider/factory.py:76` 用 OpenAIVideoBackend 包装自定义供应商，本修复直接覆盖到这条路径。

## Test plan

- [x] 14 个 test_openai_video_backend.py 单测全过（含两个新增回归用例）
  - test_polls_until_completed_for_nonstandard_status：模拟 NOT_START → running → in_progress → completed 序列，验证 4 次轮询后才下载
  - test_polls_failed_status_raises_without_download：轮询期间 failed 立即抛错且不进入下载
- [x] test_openai_video_resolution.py 同步 mock 名（create_and_poll → create）
- [x] pytest -k 'video or openai or custom_provider' 共 468 个相关测试全过
- [x] ruff check + ruff format 全通过
- [ ] 实机验证：在自定义供应商上重新触发视频生成，应等到任务真正完成后才下载