### PR TITLE
fix(frontend): 项目设置页 header 与内容左对齐

### DIFF
--- a/frontend/src/components/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.tsx
@@ -325,15 +325,17 @@ export function ProjectSettingsPage() {
   return (
     <div className="fixed inset-0 z-50 bg-gray-950 overflow-y-auto">
       {/* Header */}
-      <div className="sticky top-0 z-10 flex items-center gap-3 border-b border-gray-800 bg-gray-950/95 px-6 py-4 backdrop-blur">
-        <button
-          onClick={() => guardedNavigate(`/app/projects/${projectName}`)}
-          className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-800 hover:text-gray-200 focus-ring"
-          aria-label={t("back_to_project")}
-        >
-          <ArrowLeft className="h-5 w-5" />
-        </button>
-        <h1 className="text-lg font-semibold text-gray-100">{t("project_settings")}</h1>
+      <div className="sticky top-0 z-10 border-b border-gray-800 bg-gray-950/95 backdrop-blur">
+        <div className="mx-auto flex max-w-2xl items-center gap-3 px-6 py-4">
+          <button
+            onClick={() => guardedNavigate(`/app/projects/${projectName}`)}
+            className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-800 hover:text-gray-200 focus-ring"
+            aria-label={t("back_to_project")}
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+          <h1 className="text-lg font-semibold text-gray-100">{t("project_settings")}</h1>
+        </div>
       </div>
 
       {/* Content */}


### PR DESCRIPTION
## Summary
- 修复 `/app/projects/:projectName/settings` 在宽屏下顶部"← 项目设置"贴左、下方卡片被 `max-w-2xl` 居中导致的左右错位
- sticky header 拆成两层：外层 `sticky border-b bg backdrop-blur` 全宽贯穿背景与底边线；内层 `mx-auto max-w-2xl px-6 py-4` 与下方 Content 同宽，标题与卡片严格左对齐

## Test plan
- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过（仅遗留无关 warning）
- [x] `vitest run` 388 / 388 通过
- [ ] dev server 宽屏（>1280px）目视确认箭头/标题与"模型配置"卡片左边界对齐
- [ ] 窄屏（<720px）无横向滚动；sticky header 滚动时背景与底边横跨视口
- [ ] 返回箭头仍跳到 `/app/projects/${projectName}`，focus ring 与 aria-label 行为不变