### PR TITLE
fix(grid-mode): 修复宫格生视频报错并清理首尾帧命名遗留

### DIFF
--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -190,9 +190,30 @@ async def generate_video(
     try:
 
         def _sync():
-            get_project_manager().load_project(project_name)
-            project_path = get_project_manager().get_project_path(project_name)
-            storyboard_file = project_path / "storyboards" / f"scene_{segment_id}.png"
+            pm_local = get_project_manager()
+            pm_local.load_project(project_name)
+            project_path = pm_local.get_project_path(project_name)
+
+            # 与 worker 一致：优先读取 generated_assets.storyboard_image，回退默认路径。
+            # 旧宫格项目 storyboard_image 指向 scene_{id}_first.png，仍可正常解析。
+            storyboard_rel: str | None = None
+            try:
+                script = pm_local.load_script(project_name, req.script_file)
+                items, id_field, _, _, _ = get_storyboard_items(script)
+                resolved = find_storyboard_item(items, id_field, segment_id)
+                if resolved:
+                    assets = resolved[0].get("generated_assets") or {}
+                    if isinstance(assets, dict):
+                        storyboard_rel = assets.get("storyboard_image")
+            except FileNotFoundError:
+                # 脚本不存在交由后续流程报错；此处只负责存在性检查
+                pass
+
+            storyboard_file = (
+                project_path / storyboard_rel
+                if storyboard_rel
+                else project_path / "storyboards" / f"scene_{segment_id}.png"
+            )
             if not storyboard_file.exists():
                 raise HTTPException(status_code=400, detail=_t("generate_storyboard_first", segment_id=segment_id))
 

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -758,7 +758,8 @@ async def execute_video_task(
     project, project_path, item = await asyncio.to_thread(_load)
     generator = await get_media_generator(project_name, payload=payload, user_id=user_id)
 
-    # 优先从 generated_assets.storyboard_image 读取（宫格模式写 _first.png），回退到默认路径
+    # 优先读取 generated_assets.storyboard_image，回退默认路径。
+    # 旧宫格项目 storyboard_image 指向 scene_{id}_first.png，仍可正常解析。
     assets = item.get("generated_assets", {})
     storyboard_rel = assets.get("storyboard_image") if isinstance(assets, dict) else None
     if storyboard_rel:
@@ -1177,43 +1178,25 @@ async def execute_grid_task(
         storyboards_dir.mkdir(parents=True, exist_ok=True)
 
         def _assign_cells():
-            import shutil
-
             asset_updates: list[tuple[str, str, str]] = []
 
+            # 宫格已统一走普通图生视频（不再使用 first_last 模式），cell 仅作为
+            # next_scene_id 的起始分镜图，文件名与普通分镜对齐为 scene_{id}.png。
             for cell, frame in zip(cells, grid.frame_chain):
                 if frame.frame_type == "placeholder":
                     continue
+                if frame.frame_type not in ("first", "transition"):
+                    continue
+                if not frame.next_scene_id:
+                    continue
 
-                if frame.frame_type == "first" and frame.next_scene_id:
-                    # Save as first frame (storyboard_image) for next_scene_id
-                    cell_path = storyboards_dir / f"scene_{frame.next_scene_id}_first.png"
-                    cell.save(cell_path, format="PNG")
-                    frame.image_path = f"storyboards/scene_{frame.next_scene_id}_first.png"
-                    asset_updates.append((frame.next_scene_id, "storyboard_image", frame.image_path))
-                    # Write grid provenance
-                    asset_updates.append((frame.next_scene_id, "grid_id", resource_id))
-                    asset_updates.append((frame.next_scene_id, "grid_cell_index", frame.index))
-
-                elif frame.frame_type == "transition":
-                    # Save as last frame of prev scene
-                    if frame.prev_scene_id:
-                        last_path = storyboards_dir / f"scene_{frame.prev_scene_id}_last.png"
-                        cell.save(last_path, format="PNG")
-                        last_rel = f"storyboards/scene_{frame.prev_scene_id}_last.png"
-                        asset_updates.append((frame.prev_scene_id, "storyboard_last_image", last_rel))
-                    # Copy as first frame of next scene (same image, avoid re-encoding)
-                    if frame.next_scene_id:
-                        first_path = storyboards_dir / f"scene_{frame.next_scene_id}_first.png"
-                        if frame.prev_scene_id:
-                            shutil.copy2(last_path, first_path)
-                        else:
-                            cell.save(first_path, format="PNG")
-                        frame.image_path = f"storyboards/scene_{frame.next_scene_id}_first.png"
-                        asset_updates.append((frame.next_scene_id, "storyboard_image", frame.image_path))
-                        # Write grid provenance
-                        asset_updates.append((frame.next_scene_id, "grid_id", resource_id))
-                        asset_updates.append((frame.next_scene_id, "grid_cell_index", frame.index))
+                cell_rel = f"storyboards/scene_{frame.next_scene_id}.png"
+                cell_path = storyboards_dir / f"scene_{frame.next_scene_id}.png"
+                cell.save(cell_path, format="PNG")
+                frame.image_path = cell_rel
+                asset_updates.append((frame.next_scene_id, "storyboard_image", cell_rel))
+                asset_updates.append((frame.next_scene_id, "grid_id", resource_id))
+                asset_updates.append((frame.next_scene_id, "grid_cell_index", frame.index))
 
             # Batch-write all asset updates in one script read+write pass
             if asset_updates:

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -175,6 +175,29 @@ class TestGenerateRouter:
             assert call["media_type"] == "video"
             assert call["payload"]["duration_seconds"] == 5
 
+    def test_video_enqueue_grid_mode_uses_first_frame(self, tmp_path, monkeypatch):
+        """宫格模式：storyboard 写入 _first.png 并记录于 generated_assets，路由应识别该路径。"""
+        project_path = _prepare_files(tmp_path)
+        # 只保留宫格模式产物，删除默认路径
+        (project_path / "storyboards" / "scene_E1S01.png").unlink()
+        (project_path / "storyboards" / "scene_E1S02_first.png").write_bytes(b"png")
+
+        fake_pm = _FakePM(project_path)
+        fake_pm.script["segments"][1]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S02_first.png"}
+        fake_queue = _FakeQueue()
+        client = _client(monkeypatch, fake_pm, fake_queue)
+
+        with client:
+            video = client.post(
+                "/api/v1/projects/demo/generate/video/E1S02",
+                json={
+                    "script_file": "episode_1.json",
+                    "prompt": "宫格切片后的动作",
+                },
+            )
+            assert video.status_code == 200, video.text
+            assert video.json()["success"] is True
+
     def test_character_enqueue_success(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)

--- a/tests/test_grid_executor.py
+++ b/tests/test_grid_executor.py
@@ -225,6 +225,57 @@ class TestExecuteGridTask:
         assert updated_grid_data["status"] == "completed"
         assert updated_grid_data["grid_image_path"] == f"grids/{grid.id}.png"
 
+    async def test_execute_grid_task_writes_clean_filenames(self, project_with_script, grid_json):
+        """切割后 cell 文件名为 scene_{id}.png（无 _first/_last 后缀），且不再更新 storyboard_last_image。"""
+        from PIL import Image
+
+        from server.services.generation_tasks import execute_grid_task
+
+        grid = grid_json
+
+        fake_grid_image = Image.new("RGB", (400, 400), color=(0, 0, 0))
+        grid_image_path = project_with_script / "grids" / f"{grid.id}.png"
+        fake_grid_image.save(grid_image_path, format="PNG")
+
+        mock_generator = MagicMock()
+        mock_generator.generate_image_async = AsyncMock(return_value=(grid_image_path, 1))
+
+        with (
+            patch("server.services.generation_tasks.get_project_manager") as mock_pm_fn,
+            patch("server.services.generation_tasks.get_media_generator", new_callable=AsyncMock) as mock_get_gen,
+        ):
+            mock_pm = MagicMock()
+            mock_pm.get_project_path.return_value = project_with_script
+            mock_pm.load_project.return_value = json.loads((project_with_script / "project.json").read_text())
+            mock_pm_fn.return_value = mock_pm
+            mock_get_gen.return_value = mock_generator
+
+            await execute_grid_task(
+                "test-project",
+                grid.id,
+                {"prompt": "p", "script_file": "episode_1.json"},
+                user_id="test-user",
+            )
+
+        storyboards_dir = project_with_script / "storyboards"
+        # grid 由 fixture 配置 scene_ids=[E1S01,E1S02,E1S03]，rows=cols=2
+        for sid in ("E1S01", "E1S02", "E1S03"):
+            assert (storyboards_dir / f"scene_{sid}.png").exists(), f"missing scene_{sid}.png"
+            assert not (storyboards_dir / f"scene_{sid}_first.png").exists(), "legacy _first.png must not be written"
+            assert not (storyboards_dir / f"scene_{sid}_last.png").exists(), "legacy _last.png must not be written"
+
+        mock_pm.batch_update_scene_assets.assert_called_once()
+        updates = mock_pm.batch_update_scene_assets.call_args.kwargs["updates"]
+        asset_types = {asset_type for _, asset_type, _ in updates}
+        assert "storyboard_last_image" not in asset_types
+        # 每个有效 scene 应写入 storyboard_image / grid_id / grid_cell_index
+        sb_paths = {sid: path for sid, asset_type, path in updates if asset_type == "storyboard_image"}
+        assert sb_paths == {
+            "E1S01": "storyboards/scene_E1S01.png",
+            "E1S02": "storyboards/scene_E1S02.png",
+            "E1S03": "storyboards/scene_E1S03.png",
+        }
+
     async def test_execute_grid_task_not_found(self):
         from server.services.generation_tasks import execute_grid_task
 


### PR DESCRIPTION
## Summary
- 修复宫格模式下点击"生成视频"误报「请先生成分镜图」：路由前置检查现在与 worker 一致，优先读 `generated_assets.storyboard_image`，回退默认路径
- 清理 #254 移除"首尾帧模式"后未收尾的命名遗留：宫格切割统一写 `scene_{id}.png`，删除 `_last.png` 写入和无消费方的 `storyboard_last_image` 更新
- 兼容旧项目：worker/router 保留 fallback 逻辑，旧的 `_first.png` 仍可解析；`storyboard_last_image` schema 字段保留以兼容旧数据反序列化

## Root cause
PR #249 设计的"首尾帧"宫格模式中，每格命名 `_first.png` / `_last.png`。PR #254 改回普通图生视频后只改了视频调用方（`end_image=None`），切割端文件名和 `storyboard_last_image` 写入留下，路由前置检查也没跟上 worker 的双路径解析，于是宫格生成完毕后视频接口直接 400。

## Test plan
- [x] `tests/test_generate_router.py::test_video_enqueue_grid_mode_uses_first_frame` 覆盖旧项目 `_first.png` 兼容
- [x] `tests/test_grid_executor.py::test_execute_grid_task_writes_clean_filenames` 覆盖新项目仅写 `scene_{id}.png` 且无 `storyboard_last_image`
- [x] 全套 1951 测试通过
- [x] ruff check + format
- [ ] 手测：在已有宫格项目上重新生成宫格 + 生成视频