### PR TITLE
fix(agent): 修复 get_video_capabilities skill 无权调用脚本问题

### DIFF
--- a/agent_runtime_profile/.claude/settings.json
+++ b/agent_runtime_profile/.claude/settings.json
@@ -22,6 +22,7 @@
       "Bash(python .claude/skills/generate-script/scripts/generate_script.py:*)",
       "Bash(python .claude/skills/generate-script/scripts/normalize_drama_script.py:*)",
       "Bash(python .claude/skills/manage-project/scripts/add_assets.py:*)",
+      "Bash(python .claude/skills/manage-project/scripts/get_video_capabilities.py:*)",
       "Bash(python .claude/skills/manage-project/scripts/peek_split_point.py:*)",
       "Bash(python .claude/skills/manage-project/scripts/split_episode.py:*)",
       "Bash(python .claude/skills/generate-grid/scripts/generate_grid.py:*)",


### PR DESCRIPTION
## 范围

agent_runtime_profile 配置文件

## 变更

- 在 `.claude/settings.json` 中注册 `get_video_capabilities.py` 脚本为可用技能
- 允许 agent 通过 Bash 调用 `manage-project` 技能下的视频能力查询脚本

## 验收清单

- [x] 本地已跑相关测试（配置文件语法验证）
- [x] 手动验证了改动所声称的行为（确认脚本路径正确）
- [ ] 新增面向用户文案已加 zh/en 翻译（不适用）
- [x] 无新增 ESLint disable
- [ ] CODEOWNERS 要求的 review 已请求

## 已知 defer

无

https://claude.ai/code/session_01EcoBiJfrCmeVABZZo2wVPZ