### PR TITLE
chore(deps): 修正 dependabot label 与兜底分组

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,11 +49,21 @@ updates:
           - "Pillow"
           - "ffmpeg-python"
           - "pyjianyingdraft"
+      document-parsing:
+        patterns:
+          - "pymupdf"
+          - "mammoth"
+          - "docx2txt"
+          - "ebooklib"
+          - "beautifulsoup4"
+          - "lxml"
+          - "charset-normalizer"
       dev-dependencies:
         patterns:
           - "pytest*"
           - "ruff"
           - "pre-commit"
+          - "python-docx"
         update-types:
           - "minor"
           - "patch"
@@ -80,6 +90,22 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
+      i18n:
+        patterns:
+          - "i18next"
+          - "i18next-*"
+          - "react-i18next"
+      dnd-kit:
+        patterns:
+          - "@dnd-kit/*"
+      ui-libs:
+        patterns:
+          - "framer-motion"
+          - "lucide-react"
+          - "@floating-ui/*"
+          - "@lobehub/*"
+          - "@tanstack/react-virtual"
+          - "streamdown"
       vite-tailwind:
         patterns:
           - "vite"
@@ -94,6 +120,13 @@ updates:
           - "@vitest/*"
           - "@testing-library/*"
           - "jsdom"
+      eslint-stack:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "globals"
       dev-dependencies:
         dependency-type: "development"
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     versioning-strategy: lockfile-only
     labels:
       - "dependencies"
-      - "python"
+      - "python:uv"
     commit-message:
       prefix: "chore(deps)"
     groups:
@@ -57,12 +57,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      minor-and-patch:
+      all-other:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
 
   # Frontend npm dependencies (pnpm)
   - package-ecosystem: "npm"
@@ -104,12 +101,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      minor-and-patch:
+      all-other:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

### Bug 修复
- **L18 `python` → `python:uv`**：仓库实际 label 名为 `python:uv`，导致 dependabot 在 PR #348 报错 "label could not be found"
- **兜底组 `minor-and-patch` → `all-other`**：去掉 `update-types` 限制。原配置只接 minor/patch，pymupdf 这种 4 段版本号（1.27.2.2 → 1.27.2.3，PR #424）不属于标准 SemVer 任一类型，被排除在所有分组外形成孤儿 PR。改为无类型限制后能真正兜底
- 前端 npm 块兜底组对齐相同处理

另：`ci` label 已通过 `gh label create` 补建，github-actions 块无需改配置。

### 分组重设计（一并清理）

对照 `pyproject.toml` 与 `frontend/package.json` 系统评估后，新增分组减轻 `all-other` 噪音：

**uv 块**
- 新增 `document-parsing`：`pymupdf` / `mammoth` / `docx2txt` / `ebooklib` / `beautifulsoup4` / `lxml` / `charset-normalizer` —— 文档解析链路上的 7 个依赖（pymupdf 一周一发，charset-normalizer 也很活跃）独立成组
- `dev-dependencies` 模式补齐 `python-docx`：原本作为 dev 真依赖却落入 `all-other`，现修正

**npm 块**
- 新增 `i18n`：`i18next` 三件套必须协同升级，否则破环
- 新增 `dnd-kit`：`@dnd-kit/*` 同 monorepo 系列必须协同
- 新增 `ui-libs`：`framer-motion` / `lucide-react` / `@floating-ui/*` / `@lobehub/*` / `@tanstack/react-virtual` / `streamdown`
- 新增 `eslint-stack`：`eslint` / `eslint-*` / `@eslint/*` / `typescript-eslint` / `globals`

`wouter` / `zustand` / `PyYAML` / `packaging` 等独立工具继续留在 `all-other`，合理。

### 不在本 PR 范围
- `pnpm` 错放在 `frontend/package.json:32` 的 `dependencies`（应是 `devDependencies` 或不需要）—— 单独 PR 处理

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(...)"` 验证 YAML 语法
- [x] 人工对照清单：pyproject.toml 与 package.json 所有依赖逐个映射到目标分组，无遗漏、无意外重叠
- [ ] 等待下次 dependabot 周一调度（或仓库 Insights → Dependency graph → Dependabot 手动触发）
- [ ] 验证新生成的 uv PR 上正确带有 `dependencies` + `python:uv` label
- [ ] 验证 `i18next` 系若有更新出现在同一个 `i18n` group PR 内
- [ ] 验证 `pymupdf` / `mammoth` 等若有更新落入 `document-parsing` group 而非孤立 PR