### PR TITLE
fix(settings): 自定义供应商编辑时 base_url 变更需重输 API Key 才能发现模型

### DIFF
--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -146,11 +146,14 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
       showError(t("fill_base_url_first"));
       return;
     }
-    // 编辑模式下若用户未输入新 key，则用已存储凭证（by-id 端点）发现模型；
-    // 创建模式必须明文 api_key，无 by-id 路径可走。
-    const useStoredCredential = isEdit && !!existing && !apiKey;
+    // base_url 相对存储值是否变更：变更后必须用 UI 上的新地址 + 新 key 走明文路径，
+    // 否则 by-id 端点会用 DB 中的旧 base_url 发现模型，与保存的新地址错位。
+    const baseUrlChanged = isEdit && !!existing && baseUrl.trim() !== existing.base_url;
+    // 编辑模式下若用户未输入新 key 且 base_url 未变更，则用已存储凭证（by-id 端点）发现模型；
+    // 创建模式或 base_url 变更时必须明文 api_key。
+    const useStoredCredential = isEdit && !!existing && !apiKey && !baseUrlChanged;
     if (!useStoredCredential && !apiKey) {
-      showError(t("fill_api_key_first"));
+      showError(t(baseUrlChanged ? "base_url_changed_reenter_key" : "fill_api_key_first"));
       return;
     }
     setDiscovering(true);

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -648,6 +648,7 @@ export default {
   'fetch_models_failed': 'Failed to fetch model list',
   'fill_base_url_first': 'Please fill in Base URL first',
   'fill_api_key_first': 'Please fill in API Key first',
+  'base_url_changed_reenter_key': 'Base URL has changed — re-enter API Key to discover models',
   'fill_provider_name': 'Please fill in provider name',
   'fill_base_url': 'Please fill in Base URL',
   'fill_api_key': 'Please fill in API Key',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -649,6 +649,7 @@ export default {
   'fetch_models_failed': '获取模型列表失败',
   'fill_base_url_first': '请先填写 Base URL',
   'fill_api_key_first': '请先填写 API Key',
+  'base_url_changed_reenter_key': 'Base URL 已修改，请重新输入 API Key 后再发现模型',
   'fill_provider_name': '请填写供应商名称',
   'fill_base_url': '请填写 Base URL',
   'fill_api_key': '请填写 API Key',


### PR DESCRIPTION
## Summary

- 修复 `CustomProviderForm` 编辑模式下，用户改了 `base_url` 但未重输 API Key 时，"Discover Models" 仍走 by-id 端点用 **DB 中旧 `base_url`** 拉模型，导致保存后新地址 + 旧端点发现的模型错位、生成时 4xx / model_not_found（issue #439）。
- 把 `useStoredCredential` 判定从"key 为空"收紧为"key 为空 **且** `base_url` 未变更"。`base_url` 一旦变更，强制走明文 `/api/v1/custom-providers/discover` 路径（需重输 key），并以独立文案 `base_url_changed_reenter_key` 提示用户。
- 同步新增 zh / en 翻译 key，未触动后端。

## Test plan

- [x] `cd frontend && pnpm check`（typecheck + lint + 419 个单测全过）
- [ ] 手动复现验证（启动后端 + `pnpm dev`）：
  - [ ] 编辑已存在自定义供应商 P，把 `base_url` 改成新地址、不输入新 key → 点 Discover：弹出"Base URL 已修改，请重新输入 API Key 后再发现模型"，DevTools Network 无请求发出
  - [ ] 输入新 key 后再 Discover → 走明文 `/custom-providers/discover`，请求体 `base_url` 为新地址
  - [ ] `base_url` 不变、清空 key → Discover 仍走 `/custom-providers/{id}/discover`（旧便利路径未回归）
  - [ ] 新建模式不输 key 点 Discover → 仍弹 `fill_api_key_first`

Closes #439

https://claude.ai/code/session_01PMohBRxoHbMz8nzLL1aYfq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMohBRxoHbMz8nzLL1aYfq)_