### PR TITLE
fix(generate): 补充 prompt str 分支的空字符串校验

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -26,6 +26,7 @@ MESSAGES = {
     "prompt_must_be_string_or_scene_object": "prompt must be a string or an object containing scene/composition",
     "prompt_scene_empty": "prompt.scene cannot be empty",
     "prompt_must_be_string_or_object": "prompt must be a string or an object",
+    "prompt_text_empty": "prompt must not be empty",
     "storyboard_task_submitted": "Storyboard generation task for '{segment_id}' submitted",
     "generate_storyboard_first": "Please generate storyboard scene_{segment_id}.png first",
     "video_prompt_must_be_string_or_action_object": "prompt must be a string or an object containing action/camera_motion",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -26,6 +26,7 @@ MESSAGES = {
     "prompt_must_be_string_or_scene_object": "prompt 必须是字符串或包含 scene/composition 的对象",
     "prompt_scene_empty": "prompt.scene 不能为空",
     "prompt_must_be_string_or_object": "prompt 必须是字符串或对象",
+    "prompt_text_empty": "prompt 不能为空",
     "storyboard_task_submitted": "分镜「{segment_id}」生成任务已提交",
     "generate_storyboard_first": "请先生成分镜图 scene_{segment_id}.png",
     "video_prompt_must_be_string_or_action_object": "prompt 必须是字符串或包含 action/camera_motion 的对象",

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -136,7 +136,10 @@ async def generate_storyboard(
             scene_text = str(req.prompt.get("scene", "")).strip()
             if not scene_text:
                 raise HTTPException(status_code=400, detail=_t("prompt_scene_empty"))
-        elif not isinstance(req.prompt, str):
+        elif isinstance(req.prompt, str):
+            if not req.prompt.strip():
+                raise HTTPException(status_code=400, detail=_t("prompt_text_empty"))
+        else:
             raise HTTPException(status_code=400, detail=_t("prompt_must_be_string_or_object"))
 
         # 入队
@@ -232,7 +235,10 @@ async def generate_video(
             dialogue = req.prompt.get("dialogue", [])
             if dialogue is not None and not isinstance(dialogue, list):
                 raise HTTPException(status_code=400, detail=_t("video_prompt_dialogue_array"))
-        elif not isinstance(req.prompt, str):
+        elif isinstance(req.prompt, str):
+            if not req.prompt.strip():
+                raise HTTPException(status_code=400, detail=_t("prompt_text_empty"))
+        else:
             raise HTTPException(status_code=400, detail=_t("prompt_must_be_string_or_object"))
 
         # 入队（provider 由服务层根据配置自动解析，调用方无需传递）

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -375,6 +375,8 @@ def get_aspect_ratio(project: dict, resource_type: str) -> str:
 
 def _normalize_storyboard_prompt(prompt: str | dict, style: str) -> str:
     if isinstance(prompt, str):
+        if not prompt.strip():
+            raise ValueError("prompt must not be empty")
         return prompt
 
     if not isinstance(prompt, dict):
@@ -401,6 +403,8 @@ def _normalize_storyboard_prompt(prompt: str | dict, style: str) -> str:
 
 def _normalize_video_prompt(prompt: str | dict) -> str:
     if isinstance(prompt, str):
+        if not prompt.strip():
+            raise ValueError("prompt must not be empty")
         return prompt
 
     if not isinstance(prompt, dict):

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -297,6 +297,22 @@ class TestGenerateRouter:
             )
             assert bad_video_prompt.status_code in (400, 500)
 
+            # Empty string prompt for storyboard route (segment exists, prompt is empty str)
+            empty_storyboard_prompt = client.post(
+                "/api/v1/projects/demo/generate/storyboard/E1S02",
+                json={"script_file": "episode_1.json", "prompt": ""},
+            )
+            assert empty_storyboard_prompt.status_code == 400
+
+            # Whitespace-only string prompt for video route — ensure storyboard exists first
+            # so we hit the prompt check, not the missing-storyboard check
+            (project_path / "storyboards" / "scene_E1S02.png").write_bytes(b"png")
+            empty_video_prompt = client.post(
+                "/api/v1/projects/demo/generate/video/E1S02",
+                json={"script_file": "episode_1.json", "prompt": "   "},
+            )
+            assert empty_video_prompt.status_code == 400
+
             # Missing character
             fake_pm.project["characters"] = {}
             missing_char = client.post(

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -165,6 +165,12 @@ class TestGenerationTasks:
         with pytest.raises(ValueError):
             generation_tasks._normalize_storyboard_prompt({"scene": ""}, "Anime")
 
+        with pytest.raises(ValueError):
+            generation_tasks._normalize_storyboard_prompt("", "Anime")
+
+        with pytest.raises(ValueError):
+            generation_tasks._normalize_storyboard_prompt("   ", "Anime")
+
         video_yaml = generation_tasks._normalize_video_prompt(
             {
                 "action": "行走",
@@ -177,6 +183,12 @@ class TestGenerationTasks:
 
         with pytest.raises(ValueError):
             generation_tasks._normalize_video_prompt({"action": ""})
+
+        with pytest.raises(ValueError):
+            generation_tasks._normalize_video_prompt("")
+
+        with pytest.raises(ValueError):
+            generation_tasks._normalize_video_prompt("   ")
 
     async def test_execute_task_dispatch(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)


### PR DESCRIPTION
## Summary

- `_normalize_storyboard_prompt` / `_normalize_video_prompt`（`server/services/generation_tasks.py`）以及对应路由（`server/routers/generate.py`）在 `prompt` 为 `str` 类型时只校验类型不校验内容，空字符串会原样穿透到上游 API 网关，触发含糊的 5xx
- dict 路径已有完整校验（空 `scene` / `action` 抛错），本次给 str 分支补齐两层防御：worker 层抛 `ValueError`，路由层返回 400 + i18n key `prompt_text_empty`
- 新增中英文 `prompt_text_empty` 翻译，加单元测试与路由集成测试覆盖 `""` 与 `"   "` 两种入参

## Test plan

- [x] `uv run python -m pytest tests/test_generation_tasks_service.py tests/test_generate_router.py -v`（18 passed）
- [x] `uv run python -m pytest tests/test_i18n_consistency.py -v`（8 passed）
- [x] `uv run ruff check` & `ruff format --check`（无问题）
- [ ] CI 全量测试通过