### PR TITLE
refactor(custom-provider): 收敛 endpoint 元数据为运行时 catalog API

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -36,6 +36,7 @@ import type {
   CustomProviderCreateRequest,
   CustomProviderModelInput,
   DiscoveredModel,
+  EndpointDescriptor,
   CostEstimateResponse,
   ReferenceVideoUnit,
   ReferenceResource,
@@ -1509,6 +1510,10 @@ class API {
 
   static async listCustomProviders(): Promise<{ providers: CustomProviderInfo[] }> {
     return this.request("/custom-providers");
+  }
+
+  static async listEndpointCatalog(): Promise<{ endpoints: EndpointDescriptor[] }> {
+    return this.request("/custom-providers/endpoints");
   }
 
   static async createCustomProvider(data: CustomProviderCreateRequest): Promise<CustomProviderInfo> {

--- a/frontend/src/components/pages/settings/CustomProviderDetail.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderDetail.tsx
@@ -5,7 +5,7 @@ import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
 import { errMsg } from "@/utils/async";
 import type { CustomProviderInfo } from "@/types";
-import { ENDPOINT_TO_MEDIA_TYPE } from "@/types";
+import { useEndpointCatalogStore } from "@/stores/endpoint-catalog-store";
 import { CustomProviderForm } from "./CustomProviderForm";
 
 // ---------------------------------------------------------------------------
@@ -30,6 +30,11 @@ interface CustomProviderDetailProps {
 
 export function CustomProviderDetail({ providerId, onDeleted, onSaved }: CustomProviderDetailProps) {
   const { t } = useTranslation("dashboard");
+  const endpointToMediaType = useEndpointCatalogStore((s) => s.endpointToMediaType);
+  const fetchEndpointCatalog = useEndpointCatalogStore((s) => s.fetch);
+  useEffect(() => {
+    void fetchEndpointCatalog();
+  }, [fetchEndpointCatalog]);
   const [provider, setProvider] = useState<CustomProviderInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [editing, setEditing] = useState(false);
@@ -182,7 +187,7 @@ export function CustomProviderDetail({ providerId, onDeleted, onSaved }: CustomP
                 <span className="min-w-0 flex-1 truncate font-mono text-xs">{m.model_id}</span>
                 <span className="rounded bg-gray-800 px-1.5 py-0.5 text-xs text-gray-400">
                   {(() => {
-                    const media = ENDPOINT_TO_MEDIA_TYPE[m.endpoint];
+                    const media = endpointToMediaType[m.endpoint];
                     return MEDIA_LABELS[media] ? t(MEDIA_LABELS[media]) : media;
                   })()}
                 </span>

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -1,8 +1,9 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import { Loader2, Plus, Trash2, Eye, EyeOff, CheckCircle2, XCircle, Search } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
+import { useEndpointCatalogStore } from "@/stores/endpoint-catalog-store";
 import { uid } from "@/utils/id";
 import { errMsg } from "@/utils/async";
 import type {
@@ -11,7 +12,6 @@ import type {
   DiscoveredModel,
   EndpointKey,
 } from "@/types";
-import { ENDPOINT_TO_MEDIA_TYPE } from "@/types";
 import { priceLabel, urlPreviewFor, toggleDefaultReducer, type DiscoveryFormat } from "./customProviderHelpers";
 import { EndpointSelect } from "./EndpointSelect";
 import { ResolutionPicker } from "@/components/shared/ResolutionPicker";
@@ -110,6 +110,13 @@ interface CustomProviderFormProps {
 export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProviderFormProps) {
   const { t } = useTranslation("dashboard");
   const isEdit = !!existing;
+
+  // Endpoint catalog（后端单一真相源）：mediaType 推断、price/default 互斥分组都从这里读。
+  const endpointToMediaType = useEndpointCatalogStore((s) => s.endpointToMediaType);
+  const fetchEndpointCatalog = useEndpointCatalogStore((s) => s.fetch);
+  useEffect(() => {
+    void fetchEndpointCatalog();
+  }, [fetchEndpointCatalog]);
 
   // --- Form state ---
   const [displayName, setDisplayName] = useState(existing?.display_name ?? "");
@@ -421,8 +428,8 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
             )}
             <div className="space-y-2">
               {filteredModels.map((m) => {
-                const pl = priceLabel(m.endpoint, t);
-                const media = ENDPOINT_TO_MEDIA_TYPE[m.endpoint];
+                const pl = priceLabel(m.endpoint, endpointToMediaType, t);
+                const media = endpointToMediaType[m.endpoint];
                 return (
                   <div
                     key={m.key}
@@ -460,7 +467,7 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
                       {/* Default toggle */}
                       <button
                         type="button"
-                        onClick={() => setModels((prev) => toggleDefaultReducer(prev, m.key))}
+                        onClick={() => setModels((prev) => toggleDefaultReducer(prev, m.key, endpointToMediaType))}
                         className={`rounded-lg px-2 py-1 text-xs transition-colors ${
                           m.is_default
                             ? "bg-indigo-600 text-white"

--- a/frontend/src/components/pages/settings/EndpointSelect.tsx
+++ b/frontend/src/components/pages/settings/EndpointSelect.tsx
@@ -47,7 +47,9 @@ export function EndpointSelect({ value, onChange, ariaLabel, disabled }: Endpoin
 
   const endpoints = useEndpointCatalogStore((s) => s.endpoints);
   const initialized = useEndpointCatalogStore((s) => s.initialized);
+  const loading = useEndpointCatalogStore((s) => s.loading);
   const fetchCatalog = useEndpointCatalogStore((s) => s.fetch);
+  const refreshCatalog = useEndpointCatalogStore((s) => s.refresh);
 
   // catalog 未就绪时 trigger 一次 fetch；store 自身有 short-circuit，重复挂载安全。
   useEffect(() => {
@@ -98,7 +100,10 @@ export function EndpointSelect({ value, onChange, ariaLabel, disabled }: Endpoin
     [options],
   );
 
-  const selected = options.find((o) => o.value === value) ?? options[0];
+  // 不要 fallback 到 options[0]：value 不在 catalog 时（漂移 / 后端临时移除 / catalog 未加载）
+  // 必须显式 undefined，下方 triggerLabel 才能走原始 key 分支，否则用户会看到与已存值无关的
+  // 第一项 label，UI 严重误导。
+  const selected = options.find((o) => o.value === value);
   // trigger 中的简短路径提示：剥去前导 `/v1`、`/v1beta/models/`，更省宽。
   const triggerHint = selected
     ? selected.path.replace(/^\/v1beta\/models\//, "/").replace(/^\/v1/, "")
@@ -128,14 +133,24 @@ export function EndpointSelect({ value, onChange, ariaLabel, disabled }: Endpoin
   };
 
   const onTriggerClick = () => {
+    // catalog 未就绪：作为「重试加载」按钮使用，避免 fetch 失败后下拉永久禁用。
+    // store.refresh 内部对 loading 短路，连点不会重复发请求。
+    if (!catalogReady) {
+      void refreshCatalog();
+      return;
+    }
     if (open) setOpen(false);
     else openMenu();
   };
 
   const onTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-    if (disabled || !catalogReady) return;
+    if (disabled) return;
     if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
       e.preventDefault();
+      if (!catalogReady) {
+        void refreshCatalog();
+        return;
+      }
       openMenu();
     }
   };
@@ -168,7 +183,8 @@ export function EndpointSelect({ value, onChange, ariaLabel, disabled }: Endpoin
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
-        disabled={disabled || !catalogReady}
+        disabled={disabled}
+        aria-busy={loading || undefined}
         onClick={onTriggerClick}
         onKeyDown={onTriggerKeyDown}
         className={[

--- a/frontend/src/components/pages/settings/EndpointSelect.tsx
+++ b/frontend/src/components/pages/settings/EndpointSelect.tsx
@@ -3,7 +3,7 @@ import { ChevronDown, Type, Image as ImageIcon, Film } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Popover } from "@/components/ui/Popover";
 import type { EndpointKey, MediaType } from "@/types";
-import { ENDPOINT_PATHS } from "./customProviderHelpers";
+import { useEndpointCatalogStore } from "@/stores/endpoint-catalog-store";
 
 // ---------------------------------------------------------------------------
 // EndpointSelect — 自定义供应商「调用端点」选择器
@@ -11,22 +11,15 @@ import { ENDPOINT_PATHS } from "./customProviderHelpers";
 // 设计目标：
 //  * trigger 紧凑（适配 model row），右侧用 mono 字体显示路径前缀作为提示。
 //  * 弹层双行展示「显示名 + POST /path」让用户立刻识别具体接口。
-//  * 类型分组用纯排版徽章，无 emoji；保持 dark theme 一致。
+//  * 选项 / 路径 / 媒体类型分组 全部从 endpoint-catalog-store 派生（后端单一真相源）。
 
 interface EndpointOption {
   value: EndpointKey;
   labelKey: string;
   mediaType: MediaType;
+  method: string;
+  path: string;
 }
-
-const OPTIONS: EndpointOption[] = [
-  { value: "openai-chat", labelKey: "endpoint_openai_chat_display", mediaType: "text" },
-  { value: "gemini-generate", labelKey: "endpoint_gemini_generate_display", mediaType: "text" },
-  { value: "openai-images", labelKey: "endpoint_openai_images_display", mediaType: "image" },
-  { value: "gemini-image", labelKey: "endpoint_gemini_image_display", mediaType: "image" },
-  { value: "openai-video", labelKey: "endpoint_openai_video_display", mediaType: "video" },
-  { value: "newapi-video", labelKey: "endpoint_newapi_video_display", mediaType: "video" },
-];
 
 const MEDIA_META: Record<MediaType, { Icon: typeof Type; labelKey: string }> = {
   text: { Icon: Type, labelKey: "endpoint_text_group" },
@@ -35,14 +28,6 @@ const MEDIA_META: Record<MediaType, { Icon: typeof Type; labelKey: string }> = {
 };
 
 const MEDIA_ORDER: MediaType[] = ["text", "image", "video"];
-
-/** 把 EndpointKey 解析为 OPTIONS 索引；若 value 不在已知 OPTIONS 内（数据
- *  漂移：后端推未知 endpoint 字符串），回退到 0，避免 `OPTIONS[-1]` 在键盘
- *  选中（Enter/空格）时抛 TypeError 中断弹层交互。 */
-function indexOfValue(val: EndpointKey): number {
-  const idx = OPTIONS.findIndex((o) => o.value === val);
-  return idx >= 0 ? idx : 0;
-}
 
 interface EndpointSelectProps {
   value: EndpointKey;
@@ -60,26 +45,66 @@ export function EndpointSelect({ value, onChange, ariaLabel, disabled }: Endpoin
   const listboxId = useId();
   const [open, setOpen] = useState(false);
 
-  // 弹层打开时把焦点转到 listbox 接收键盘事件。用 useEffect 而非 inline
-  // ref callback —— 后者会因每次 render 重新创建 callback 闭包而被 React
-  // 反复调用 (null, el)，引发不必要的重复 focus 与 scroll-into-view 抖动。
+  const endpoints = useEndpointCatalogStore((s) => s.endpoints);
+  const initialized = useEndpointCatalogStore((s) => s.initialized);
+  const fetchCatalog = useEndpointCatalogStore((s) => s.fetch);
+
+  // catalog 未就绪时 trigger 一次 fetch；store 自身有 short-circuit，重复挂载安全。
   useEffect(() => {
-    if (open) listboxRef.current?.focus();
-  }, [open]);
+    if (!initialized) void fetchCatalog();
+  }, [initialized, fetchCatalog]);
+
+  // 把 catalog 数据投影成 EndpointOption[]，按 MEDIA_ORDER 顺序排列以获得稳定的键盘导航。
+  const options = useMemo<EndpointOption[]>(() => {
+    const ordered: EndpointOption[] = [];
+    for (const media of MEDIA_ORDER) {
+      for (const e of endpoints) {
+        if (e.media_type === media) {
+          ordered.push({
+            value: e.key,
+            labelKey: e.display_name_key,
+            mediaType: e.media_type,
+            method: e.request_method,
+            path: e.request_path_template,
+          });
+        }
+      }
+    }
+    return ordered;
+  }, [endpoints]);
 
   const grouped = useMemo(() => {
     return MEDIA_ORDER.map((m) => ({
       mediaType: m,
-      options: OPTIONS.filter((o) => o.mediaType === m),
+      options: options.filter((o) => o.mediaType === m),
     }));
-  }, []);
+  }, [options]);
 
-  const selected = OPTIONS.find((o) => o.value === value) ?? OPTIONS[0];
-  const selectedPath = ENDPOINT_PATHS[selected.value];
+  // catalog 未就绪：trigger 显示 placeholder，点击不展开（避免空 listbox 让键盘焦点卡死）。
+  const catalogReady = options.length > 0;
+
+  // 弹层打开时把焦点转到 listbox。
+  useEffect(() => {
+    if (open) listboxRef.current?.focus();
+  }, [open]);
+
+  /** 把 EndpointKey 解析为 options 索引；value 不在 catalog 内时回退到 0，避免
+   *  键盘选中（Enter/空格）时取 options[-1] 抛 TypeError 中断弹层交互。 */
+  const indexOfValue = useCallback(
+    (val: EndpointKey): number => {
+      const idx = options.findIndex((o) => o.value === val);
+      return idx >= 0 ? idx : 0;
+    },
+    [options],
+  );
+
+  const selected = options.find((o) => o.value === value) ?? options[0];
   // trigger 中的简短路径提示：剥去前导 `/v1`、`/v1beta/models/`，更省宽。
-  const triggerHint = selectedPath.path
-    .replace(/^\/v1beta\/models\//, "/")
-    .replace(/^\/v1/, "");
+  const triggerHint = selected
+    ? selected.path.replace(/^\/v1beta\/models\//, "/").replace(/^\/v1/, "")
+    : "";
+  // 已选 endpoint 不在当前 catalog（数据漂移或后端临时移除）：用原始 key 兜底显示。
+  const triggerLabel = selected ? t(selected.labelKey) : value || t("endpoint_catalog_loading");
 
   const handleSelect = useCallback(
     (next: EndpointKey) => {
@@ -92,9 +117,12 @@ export function EndpointSelect({ value, onChange, ariaLabel, disabled }: Endpoin
   );
 
   // 键盘：弹层中支持上下键切换、Enter 选中、Escape 关闭。
-  const [activeIndex, setActiveIndex] = useState<number>(() => indexOfValue(value));
+  // 初始值是 0，正确值在 openMenu() 中按当前 value 设置；catalog 未就绪时
+  // catalogReady 为 false，trigger 是 disabled，listbox 永远打不开，0 不会被读到。
+  const [activeIndex, setActiveIndex] = useState<number>(0);
 
   const openMenu = () => {
+    if (!catalogReady) return;
     setActiveIndex(indexOfValue(value));
     setOpen(true);
   };
@@ -105,7 +133,7 @@ export function EndpointSelect({ value, onChange, ariaLabel, disabled }: Endpoin
   };
 
   const onTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-    if (disabled) return;
+    if (disabled || !catalogReady) return;
     if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       openMenu();
@@ -115,19 +143,19 @@ export function EndpointSelect({ value, onChange, ariaLabel, disabled }: Endpoin
   const onListKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setActiveIndex((i) => (i + 1) % OPTIONS.length);
+      setActiveIndex((i) => (i + 1) % options.length);
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
-      setActiveIndex((i) => (i - 1 + OPTIONS.length) % OPTIONS.length);
+      setActiveIndex((i) => (i - 1 + options.length) % options.length);
     } else if (e.key === "Home") {
       e.preventDefault();
       setActiveIndex(0);
     } else if (e.key === "End") {
       e.preventDefault();
-      setActiveIndex(OPTIONS.length - 1);
+      setActiveIndex(options.length - 1);
     } else if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
-      handleSelect(OPTIONS[activeIndex].value);
+      handleSelect(options[activeIndex].value);
     }
   };
 
@@ -140,7 +168,7 @@ export function EndpointSelect({ value, onChange, ariaLabel, disabled }: Endpoin
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
-        disabled={disabled}
+        disabled={disabled || !catalogReady}
         onClick={onTriggerClick}
         onKeyDown={onTriggerKeyDown}
         className={[
@@ -151,13 +179,15 @@ export function EndpointSelect({ value, onChange, ariaLabel, disabled }: Endpoin
           "disabled:cursor-not-allowed disabled:opacity-50",
         ].join(" ")}
       >
-        <span className="truncate">{t(selected.labelKey)}</span>
-        <span
-          aria-hidden="true"
-          className="hidden font-mono text-[11px] tracking-tight text-emerald-400/70 sm:inline"
-        >
-          {triggerHint}
-        </span>
+        <span className="truncate">{triggerLabel}</span>
+        {triggerHint && (
+          <span
+            aria-hidden="true"
+            className="hidden font-mono text-[11px] tracking-tight text-emerald-400/70 sm:inline"
+          >
+            {triggerHint}
+          </span>
+        )}
         <ChevronDown
           aria-hidden="true"
           className={`h-3.5 w-3.5 shrink-0 text-gray-500 transition-transform ${open ? "rotate-180" : ""}`}
@@ -184,6 +214,7 @@ export function EndpointSelect({ value, onChange, ariaLabel, disabled }: Endpoin
           className="max-h-[420px] overflow-y-auto py-1.5 outline-none"
         >
           {grouped.map((group, gIdx) => {
+            if (group.options.length === 0) return null;
             const meta = MEDIA_META[group.mediaType];
             const Icon = meta.Icon;
             return (
@@ -201,9 +232,8 @@ export function EndpointSelect({ value, onChange, ariaLabel, disabled }: Endpoin
                 </div>
                 <ul className="px-1.5">
                   {group.options.map((opt) => {
-                    const path = ENDPOINT_PATHS[opt.value];
                     const isSelected = opt.value === value;
-                    const flatIdx = OPTIONS.findIndex((o) => o.value === opt.value);
+                    const flatIdx = options.findIndex((o) => o.value === opt.value);
                     const isActive = flatIdx === activeIndex;
                     return (
                       <li key={opt.value}>
@@ -228,10 +258,8 @@ export function EndpointSelect({ value, onChange, ariaLabel, disabled }: Endpoin
                             {t(opt.labelKey)}
                           </div>
                           <div className="mt-0.5 flex items-baseline gap-1.5 font-mono text-[11px] leading-none">
-                            <span className="text-gray-500">{path.method}</span>
-                            <span className="truncate text-emerald-400/80">
-                              {path.path}
-                            </span>
+                            <span className="text-gray-500">{opt.method}</span>
+                            <span className="truncate text-emerald-400/80">{opt.path}</span>
                           </div>
                         </button>
                       </li>

--- a/frontend/src/components/pages/settings/customProviderHelpers.test.ts
+++ b/frontend/src/components/pages/settings/customProviderHelpers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { MediaType } from "@/types";
 import {
   priceLabel,
   urlPreviewFor,
@@ -7,18 +8,28 @@ import {
 
 const id = (k: string) => k;
 
+// 测试 fixture：模拟从 endpoint-catalog-store 派生的 endpoint→media map。
+const ENDPOINT_TO_MEDIA: Record<string, MediaType> = {
+  "openai-chat": "text",
+  "gemini-generate": "text",
+  "openai-images": "image",
+  "gemini-image": "image",
+  "openai-video": "video",
+  "newapi-video": "video",
+};
+
 describe("priceLabel", () => {
   it("video endpoint → per-second label", () => {
-    expect(priceLabel("newapi-video", id).input).toBe("price_per_second");
-    expect(priceLabel("openai-video", id).output).toBe("");
+    expect(priceLabel("newapi-video", ENDPOINT_TO_MEDIA, id).input).toBe("price_per_second");
+    expect(priceLabel("openai-video", ENDPOINT_TO_MEDIA, id).output).toBe("");
   });
   it("image endpoint → per-image label", () => {
-    expect(priceLabel("openai-images", id).input).toBe("price_per_image");
-    expect(priceLabel("gemini-image", id).output).toBe("");
+    expect(priceLabel("openai-images", ENDPOINT_TO_MEDIA, id).input).toBe("price_per_image");
+    expect(priceLabel("gemini-image", ENDPOINT_TO_MEDIA, id).output).toBe("");
   });
   it("text endpoint → per-M-token labels", () => {
-    expect(priceLabel("openai-chat", id).input).toBe("price_per_m_input");
-    expect(priceLabel("gemini-generate", id).output).toBe("price_per_m_output");
+    expect(priceLabel("openai-chat", ENDPOINT_TO_MEDIA, id).input).toBe("price_per_m_input");
+    expect(priceLabel("gemini-generate", ENDPOINT_TO_MEDIA, id).output).toBe("price_per_m_output");
   });
 });
 
@@ -57,18 +68,18 @@ describe("urlPreviewFor", () => {
 describe("toggleDefaultReducer", () => {
   it("toggles target row and clears siblings within same media_type", () => {
     const rows = [
-      { key: "a", endpoint: "openai-chat" as const, is_default: true },
-      { key: "b", endpoint: "gemini-generate" as const, is_default: false },
-      { key: "c", endpoint: "openai-images" as const, is_default: true },
+      { key: "a", endpoint: "openai-chat", is_default: true },
+      { key: "b", endpoint: "gemini-generate", is_default: false },
+      { key: "c", endpoint: "openai-images", is_default: true },
     ];
-    const result = toggleDefaultReducer(rows, "b");
+    const result = toggleDefaultReducer(rows, "b", ENDPOINT_TO_MEDIA);
     expect(result.find((r) => r.key === "a")?.is_default).toBe(false);
     expect(result.find((r) => r.key === "b")?.is_default).toBe(true);
     expect(result.find((r) => r.key === "c")?.is_default).toBe(true);
   });
 
   it("toggling already-default row turns it off", () => {
-    const rows = [{ key: "a", endpoint: "openai-chat" as const, is_default: true }];
-    expect(toggleDefaultReducer(rows, "a")[0].is_default).toBe(false);
+    const rows = [{ key: "a", endpoint: "openai-chat", is_default: true }];
+    expect(toggleDefaultReducer(rows, "a", ENDPOINT_TO_MEDIA)[0].is_default).toBe(false);
   });
 });

--- a/frontend/src/components/pages/settings/customProviderHelpers.test.ts
+++ b/frontend/src/components/pages/settings/customProviderHelpers.test.ts
@@ -82,4 +82,28 @@ describe("toggleDefaultReducer", () => {
     const rows = [{ key: "a", endpoint: "openai-chat", is_default: true }];
     expect(toggleDefaultReducer(rows, "a", ENDPOINT_TO_MEDIA)[0].is_default).toBe(false);
   });
+
+  it("falls back to single-row toggle when catalog map is empty (catalog not loaded)", () => {
+    // 回归：catalog 未加载时 endpointToMediaType={}，所有行 mediaType 都是 undefined。
+    // 必须降级为单行 toggle，不能因 undefined === undefined 把不同媒体类型行当作同组互斥。
+    const rows = [
+      { key: "a", endpoint: "openai-chat", is_default: true },
+      { key: "b", endpoint: "openai-images", is_default: true },
+      { key: "c", endpoint: "newapi-video", is_default: true },
+    ];
+    const result = toggleDefaultReducer(rows, "b", {});
+    expect(result.find((r) => r.key === "a")?.is_default).toBe(true);
+    expect(result.find((r) => r.key === "b")?.is_default).toBe(false);
+    expect(result.find((r) => r.key === "c")?.is_default).toBe(true);
+  });
+
+  it("falls back to single-row toggle when target endpoint is not in catalog", () => {
+    const rows = [
+      { key: "a", endpoint: "openai-chat", is_default: true },
+      { key: "b", endpoint: "anthropic-messages", is_default: false },
+    ];
+    const result = toggleDefaultReducer(rows, "b", ENDPOINT_TO_MEDIA);
+    expect(result.find((r) => r.key === "a")?.is_default).toBe(true);
+    expect(result.find((r) => r.key === "b")?.is_default).toBe(true);
+  });
 });

--- a/frontend/src/components/pages/settings/customProviderHelpers.ts
+++ b/frontend/src/components/pages/settings/customProviderHelpers.ts
@@ -28,7 +28,9 @@ export function urlPreviewFor(format: DiscoveryFormat, rawBaseUrl: string): stri
 }
 
 /** 切 default：仅同 media_type 内互斥；本行 toggle。
- *  endpointToMediaType 由调用方注入（来自 endpoint-catalog-store）。 */
+ *  endpointToMediaType 由调用方注入（来自 endpoint-catalog-store）。
+ *  catalog 未加载或 endpoint 不在映射内时降级为「单行 toggle」——避免所有 endpoint
+ *  都解析成 undefined 时被当作同组，误清掉其他媒体类型的默认项。 */
 export function toggleDefaultReducer<T extends ModelLike>(
   rows: T[],
   targetKey: string,
@@ -37,6 +39,9 @@ export function toggleDefaultReducer<T extends ModelLike>(
   const target = rows.find((r) => r.key === targetKey);
   if (!target) return rows;
   const targetMedia = endpointToMediaType[target.endpoint];
+  if (targetMedia === undefined) {
+    return rows.map((r) => (r.key === targetKey ? { ...r, is_default: !r.is_default } : r));
+  }
   return rows.map((r) => {
     if (endpointToMediaType[r.endpoint] !== targetMedia) return r;
     if (r.key === targetKey) return { ...r, is_default: !r.is_default };

--- a/frontend/src/components/pages/settings/customProviderHelpers.ts
+++ b/frontend/src/components/pages/settings/customProviderHelpers.ts
@@ -1,28 +1,15 @@
-import { ENDPOINT_TO_MEDIA_TYPE, type EndpointKey } from "@/types";
+import type { EndpointKey, MediaType } from "@/types";
 
 export type DiscoveryFormat = "openai" | "google";
 export type ModelLike = { key: string; endpoint: EndpointKey; is_default: boolean };
 
-/** 各 endpoint 在请求 base_url 之后实际拼接的 HTTP 方法与路径片段。
- *  与 lib/custom_provider/endpoints.py 中各 build_backend 对应的真实接口一致：
- *   - openai-images 根据是否带参考图自动分发到 /generations 或 /edits（用 brace 表达两条路径）
- *   - gemini-* 路径中的 ":generateContent" 是动作后缀（按 Google 规范）
- *   - openai-video 主入口 POST /v1/videos（轮询/下载用 GET /v1/videos/:id[/content]） */
-export const ENDPOINT_PATHS: Record<EndpointKey, { method: string; path: string }> = {
-  "openai-chat": { method: "POST", path: "/v1/chat/completions" },
-  "gemini-generate": { method: "POST", path: "/v1beta/models/{model}:generateContent" },
-  "openai-images": { method: "POST", path: "/v1/images/{generations,edits}" },
-  "gemini-image": { method: "POST", path: "/v1beta/models/{model}:generateContent" },
-  "openai-video": { method: "POST", path: "/v1/videos" },
-  "newapi-video": { method: "POST", path: "/v1/video/generations" },
-};
-
-/** 价格行标签（按 endpoint 推算 media_type）。 */
+/** 价格行标签 —— mediaType 由调用方从 endpoint-catalog-store 读出注入。 */
 export function priceLabel(
   endpoint: EndpointKey,
+  endpointToMediaType: Record<string, MediaType>,
   t: (key: string) => string,
 ): { input: string; output: string } {
-  const media = ENDPOINT_TO_MEDIA_TYPE[endpoint];
+  const media = endpointToMediaType[endpoint];
   if (media === "video") return { input: t("price_per_second"), output: "" };
   if (media === "image") return { input: t("price_per_image"), output: "" };
   return { input: t("price_per_m_input"), output: t("price_per_m_output") };
@@ -40,13 +27,18 @@ export function urlPreviewFor(format: DiscoveryFormat, rawBaseUrl: string): stri
   return `${base}/v1beta/models`;
 }
 
-/** 切 default：仅同 media_type 内互斥；本行 toggle。 */
-export function toggleDefaultReducer<T extends ModelLike>(rows: T[], targetKey: string): T[] {
+/** 切 default：仅同 media_type 内互斥；本行 toggle。
+ *  endpointToMediaType 由调用方注入（来自 endpoint-catalog-store）。 */
+export function toggleDefaultReducer<T extends ModelLike>(
+  rows: T[],
+  targetKey: string,
+  endpointToMediaType: Record<string, MediaType>,
+): T[] {
   const target = rows.find((r) => r.key === targetKey);
   if (!target) return rows;
-  const targetMedia = ENDPOINT_TO_MEDIA_TYPE[target.endpoint];
+  const targetMedia = endpointToMediaType[target.endpoint];
   return rows.map((r) => {
-    if (ENDPOINT_TO_MEDIA_TYPE[r.endpoint] !== targetMedia) return r;
+    if (endpointToMediaType[r.endpoint] !== targetMedia) return r;
     if (r.key === targetKey) return { ...r, is_default: !r.is_default };
     return { ...r, is_default: false };
   });

--- a/frontend/src/components/shared/ModelConfigSection.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ProviderModelSelect } from "@/components/ui/ProviderModelSelect";
 import { DEFAULT_DURATIONS, lookupSupportedDurations, lookupResolutions } from "@/utils/provider-models";
 import { ResolutionPicker } from "./ResolutionPicker";
+import { useEndpointCatalogStore } from "@/stores/endpoint-catalog-store";
 import type { ProviderInfo } from "@/types/provider";
 import type { CustomProviderInfo } from "@/types/custom-provider";
 
@@ -72,6 +73,13 @@ export function ModelConfigSection({
 }: ModelConfigSectionProps) {
   const { t } = useTranslation("templates");
 
+  // 自定义 provider 的 resolution picker 需要从 endpoint 推 mediaType；catalog 即时拉取。
+  const endpointToMediaType = useEndpointCatalogStore((s) => s.endpointToMediaType);
+  const fetchEndpointCatalog = useEndpointCatalogStore((s) => s.fetch);
+  useEffect(() => {
+    if (customProviders.length > 0) void fetchEndpointCatalog();
+  }, [customProviders.length, fetchEndpointCatalog]);
+
   const showVideo = enable?.video !== false;
   const showImage = enable?.image !== false;
   const showText = enable?.text !== false;
@@ -111,7 +119,7 @@ export function ModelConfigSection({
   };
 
   const renderResolutionField = (backend: string, resolution: string | null, onResolutionChange: (v: string | null) => void) => {
-    const res = lookupResolutions(providers, backend, customProviders);
+    const res = lookupResolutions(providers, backend, customProviders, endpointToMediaType);
     if (res.options.length === 0) return null;
     return (
       <div className="mt-3 flex items-center gap-2">

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -670,6 +670,7 @@ export default {
   'endpoint_gemini_image_display': 'Google Gemini Image',
   'endpoint_openai_video_display': 'OpenAI Video (Sora)',
   'endpoint_newapi_video_display': 'NewAPI Unified Video',
+  'endpoint_catalog_loading': 'Loading endpoint catalog…',
   'api_key_not_set': 'Not set',
   'model_disabled': 'Disabled',
   'confirm_delete_provider': 'Confirm Delete',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -671,6 +671,7 @@ export default {
   'endpoint_gemini_image_display': 'Google Gemini Image',
   'endpoint_openai_video_display': 'OpenAI Video (Sora)',
   'endpoint_newapi_video_display': 'NewAPI Unified Video',
+  'endpoint_catalog_loading': '加载端点目录…',
   'api_key_not_set': '未设置',
   'model_disabled': '已禁用',
   'confirm_delete_provider': '确认删除',

--- a/frontend/src/stores/config-status-store.ts
+++ b/frontend/src/stores/config-status-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { API } from "@/api";
-import { ENDPOINT_TO_MEDIA_TYPE } from "@/types";
+import { useEndpointCatalogStore } from "./endpoint-catalog-store";
 
 // ---------------------------------------------------------------------------
 // ConfigIssue
@@ -35,6 +35,13 @@ async function getConfigIssues(): Promise<ConfigIssue[]> {
   // 2. Check any provider supports each media type
   const readyProviders = providers.filter((p) => p.status === "ready");
 
+  // 自定义 provider 的 endpoint→mediaType 映射要从 catalog 派生：仅在有自定义 provider 时
+  // 才需要 fetch（否则空映射也不会被读到，避免给已运行的旧用户加一次无谓 HTTP）。
+  if (customProviders.length > 0) {
+    await useEndpointCatalogStore.getState().fetch();
+  }
+  const endpointToMediaType = useEndpointCatalogStore.getState().endpointToMediaType;
+
   const hasMediaType = (type: string) => {
     // Check preset providers
     const hasPresetProvider = readyProviders.some((p) => p.media_types.includes(type));
@@ -42,7 +49,7 @@ async function getConfigIssues(): Promise<ConfigIssue[]> {
 
     // Check custom providers for enabled models of this media type
     return customProviders.some((cp) =>
-      cp.models.some((m) => ENDPOINT_TO_MEDIA_TYPE[m.endpoint] === type && m.is_enabled)
+      cp.models.some((m) => endpointToMediaType[m.endpoint] === type && m.is_enabled)
     );
   };
 

--- a/frontend/src/stores/endpoint-catalog-store.test.ts
+++ b/frontend/src/stores/endpoint-catalog-store.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { API } from "@/api";
+import type { EndpointDescriptor } from "@/types";
+import { useEndpointCatalogStore } from "./endpoint-catalog-store";
+
+const FIXTURE: EndpointDescriptor[] = [
+  {
+    key: "openai-chat",
+    media_type: "text",
+    family: "openai",
+    display_name_key: "endpoint_openai_chat_display",
+    request_method: "POST",
+    request_path_template: "/v1/chat/completions",
+  },
+  {
+    key: "newapi-video",
+    media_type: "video",
+    family: "newapi",
+    display_name_key: "endpoint_newapi_video_display",
+    request_method: "POST",
+    request_path_template: "/v1/video/generations",
+  },
+];
+
+describe("endpoint-catalog-store", () => {
+  beforeEach(() => {
+    useEndpointCatalogStore.setState(useEndpointCatalogStore.getInitialState(), true);
+    vi.restoreAllMocks();
+  });
+
+  it("fetch populates endpoints + derives maps", async () => {
+    vi.spyOn(API, "listEndpointCatalog").mockResolvedValue({ endpoints: FIXTURE });
+
+    await useEndpointCatalogStore.getState().fetch();
+
+    const s = useEndpointCatalogStore.getState();
+    expect(s.initialized).toBe(true);
+    expect(s.endpoints).toEqual(FIXTURE);
+    expect(s.endpointToMediaType).toEqual({
+      "openai-chat": "text",
+      "newapi-video": "video",
+    });
+    expect(s.endpointPaths).toEqual({
+      "openai-chat": { method: "POST", path: "/v1/chat/completions" },
+      "newapi-video": { method: "POST", path: "/v1/video/generations" },
+    });
+  });
+
+  it("fetch short-circuits after initialized", async () => {
+    const spy = vi.spyOn(API, "listEndpointCatalog").mockResolvedValue({ endpoints: FIXTURE });
+
+    await useEndpointCatalogStore.getState().fetch();
+    await useEndpointCatalogStore.getState().fetch();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("refresh re-fetches even after initialized", async () => {
+    const spy = vi.spyOn(API, "listEndpointCatalog").mockResolvedValue({ endpoints: FIXTURE });
+
+    await useEndpointCatalogStore.getState().fetch();
+    await useEndpointCatalogStore.getState().refresh();
+
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("fetch keeps initialized=false on transient error so it can retry", async () => {
+    vi.spyOn(API, "listEndpointCatalog")
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ endpoints: FIXTURE });
+
+    await useEndpointCatalogStore.getState().fetch();
+    expect(useEndpointCatalogStore.getState().initialized).toBe(false);
+
+    await useEndpointCatalogStore.getState().fetch();
+    expect(useEndpointCatalogStore.getState().initialized).toBe(true);
+    expect(useEndpointCatalogStore.getState().endpoints).toEqual(FIXTURE);
+  });
+});

--- a/frontend/src/stores/endpoint-catalog-store.ts
+++ b/frontend/src/stores/endpoint-catalog-store.ts
@@ -1,0 +1,73 @@
+import { create } from "zustand";
+import { API } from "@/api";
+import type { EndpointDescriptor, MediaType } from "@/types";
+
+// ---------------------------------------------------------------------------
+// EndpointCatalog —— 自定义供应商 endpoint 元数据的 FE 端缓存。
+// 真相源在后端 lib/custom_provider/endpoints.py:ENDPOINT_REGISTRY，
+// 由 GET /api/v1/custom-providers/endpoints 拉取，FE 不再硬编码 endpoint 列表/路径/媒体类型 map。
+// ---------------------------------------------------------------------------
+
+export interface EndpointPath {
+  method: string;
+  path: string;
+}
+
+interface EndpointCatalogState {
+  endpoints: EndpointDescriptor[];
+  /** key → media_type，组件层不再每次重 derive。 */
+  endpointToMediaType: Record<string, MediaType>;
+  /** key → { method, path }，给 EndpointSelect 显示路径前缀。 */
+  endpointPaths: Record<string, EndpointPath>;
+  loading: boolean;
+  initialized: boolean;
+  /** 短路：已初始化或加载中 → 直接 return；否则触发一次 refresh。 */
+  fetch: () => Promise<void>;
+  /** 强制刷新（设置页主动重拉时用）。 */
+  refresh: () => Promise<void>;
+}
+
+function deriveMaps(endpoints: EndpointDescriptor[]): {
+  endpointToMediaType: Record<string, MediaType>;
+  endpointPaths: Record<string, EndpointPath>;
+} {
+  const endpointToMediaType: Record<string, MediaType> = {};
+  const endpointPaths: Record<string, EndpointPath> = {};
+  for (const e of endpoints) {
+    endpointToMediaType[e.key] = e.media_type;
+    endpointPaths[e.key] = { method: e.request_method, path: e.request_path_template };
+  }
+  return { endpointToMediaType, endpointPaths };
+}
+
+export const useEndpointCatalogStore = create<EndpointCatalogState>((set, get) => ({
+  endpoints: [],
+  endpointToMediaType: {},
+  endpointPaths: {},
+  loading: false,
+  initialized: false,
+
+  fetch: async () => {
+    if (get().initialized || get().loading) return;
+    await get().refresh();
+  },
+
+  refresh: async () => {
+    if (get().loading) return;
+    set({ loading: true });
+    try {
+      const res = await API.listEndpointCatalog();
+      const { endpointToMediaType, endpointPaths } = deriveMaps(res.endpoints);
+      set({
+        endpoints: res.endpoints,
+        endpointToMediaType,
+        endpointPaths,
+        loading: false,
+        initialized: true,
+      });
+    } catch {
+      // 失败时保持 initialized=false，组件可降级显示 placeholder；下次 fetch 仍会重试。
+      set({ loading: false });
+    }
+  },
+}));

--- a/frontend/src/types/custom-provider.ts
+++ b/frontend/src/types/custom-provider.ts
@@ -1,12 +1,18 @@
-export type EndpointKey =
-  | "openai-chat"
-  | "gemini-generate"
-  | "openai-images"
-  | "gemini-image"
-  | "openai-video"
-  | "newapi-video";
+// Endpoint key 改用 string 别名 —— 真相源在后端 ENDPOINT_REGISTRY，
+// 前端通过 GET /api/v1/custom-providers/endpoints 拉运行时 catalog。
+// 放弃编译期窄类型换取「新增 endpoint 不再需要改前端类型」。
+export type EndpointKey = string;
 
 export type MediaType = "text" | "image" | "video";
+
+export interface EndpointDescriptor {
+  key: string;
+  media_type: MediaType;
+  family: string;
+  display_name_key: string;
+  request_method: string;
+  request_path_template: string;
+}
 
 export interface CustomProviderInfo {
   id: number;
@@ -62,12 +68,3 @@ export interface CustomProviderModelInput {
   supported_durations?: number[] | null;
   resolution?: string | null;
 }
-
-export const ENDPOINT_TO_MEDIA_TYPE: Record<EndpointKey, MediaType> = {
-  "openai-chat": "text",
-  "gemini-generate": "text",
-  "openai-images": "image",
-  "gemini-image": "image",
-  "openai-video": "video",
-  "newapi-video": "video",
-};

--- a/frontend/src/utils/provider-models.ts
+++ b/frontend/src/utils/provider-models.ts
@@ -1,6 +1,5 @@
 import { API } from "@/api";
-import type { CustomProviderInfo, ProviderInfo } from "@/types";
-import { ENDPOINT_TO_MEDIA_TYPE } from "@/types";
+import type { CustomProviderInfo, MediaType, ProviderInfo } from "@/types";
 
 export const DEFAULT_DURATIONS: readonly number[] = [4, 6, 8];
 
@@ -113,11 +112,14 @@ export function lookupSupportedDurations(
 export const IMAGE_STANDARD_RESOLUTIONS = ["512px", "1K", "2K", "4K"];
 export const VIDEO_STANDARD_RESOLUTIONS = ["480p", "720p", "1080p", "4K"];
 
-/** 返回该 (provider, model) 下的分辨率候选 + 是否自定义供应商（决定 picker 模式）。 */
+/** 返回该 (provider, model) 下的分辨率候选 + 是否自定义供应商（决定 picker 模式）。
+ *  自定义 provider 路径需要从 endpoint 推 media_type 选标准分辨率集；该 map 由调用方
+ *  从 endpoint-catalog-store 读出注入（保持本文件无 store 副作用）。 */
 export function lookupResolutions(
   providers: ProviderInfo[],
   backend: string,
   customProviders?: CustomProviderInfo[],
+  endpointToMediaType?: Record<string, MediaType>,
 ): { options: string[]; isCustom: boolean } {
   const slashIdx = backend.indexOf("/");
   if (slashIdx === -1) return { options: [], isCustom: false };
@@ -129,7 +131,7 @@ export function lookupResolutions(
     const cp = customProviders.find((p) => p.id === dbId);
     const model = cp?.models?.find((m) => m.model_id === modelId);
     if (!model) return { options: [], isCustom: true };
-    const media = ENDPOINT_TO_MEDIA_TYPE[model.endpoint];
+    const media = endpointToMediaType?.[model.endpoint];
     const standard =
       media === "image"
         ? IMAGE_STANDARD_RESOLUTIONS

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -1,14 +1,16 @@
 """ENDPOINT_REGISTRY — 自定义供应商可用 endpoint 单一真相源。
 
-每条 endpoint 是一个 EndpointSpec，绑定 media_type、family 与 build_backend 闭包。
-factory.create_custom_backend 通过 endpoint 字符串查表派发。
+每条 endpoint 是一个 EndpointSpec，绑定 media_type、family、HTTP 调用形态与 build_backend 闭包。
+factory.create_custom_backend 通过 endpoint 字符串查表派发；
+server.routers.custom_providers 通过 GET /custom-providers/endpoints 把目录暴露给前端，
+让前端的下拉选项、路径展示完全派生自此真相源。
 """
 
 from __future__ import annotations
 
 import re
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
 
 from lib.config.url_utils import ensure_google_base_url, ensure_openai_base_url
@@ -35,6 +37,8 @@ class EndpointSpec:
     media_type: str  # "text" | "image" | "video"
     family: str  # "openai" | "google" | "newapi"
     display_name_key: str  # 前端 i18n key（dashboard ns）
+    request_method: str  # "POST"
+    request_path_template: str  # "/v1/chat/completions"，可含 {model} 等占位
     build_backend: Callable[[CustomProvider, str], CustomTextBackend | CustomImageBackend | CustomVideoBackend]
 
 
@@ -86,6 +90,8 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         media_type="text",
         family="openai",
         display_name_key="endpoint_openai_chat_display",
+        request_method="POST",
+        request_path_template="/v1/chat/completions",
         build_backend=_build_openai_chat,
     ),
     "gemini-generate": EndpointSpec(
@@ -93,6 +99,8 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         media_type="text",
         family="google",
         display_name_key="endpoint_gemini_generate_display",
+        request_method="POST",
+        request_path_template="/v1beta/models/{model}:generateContent",
         build_backend=_build_gemini_generate,
     ),
     "openai-images": EndpointSpec(
@@ -100,6 +108,9 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         media_type="image",
         family="openai",
         display_name_key="endpoint_openai_images_display",
+        request_method="POST",
+        # /generations 与 /edits 由是否传参考图自动派发，brace 表达两条路径
+        request_path_template="/v1/images/{generations,edits}",
         build_backend=_build_openai_images,
     ),
     "gemini-image": EndpointSpec(
@@ -107,6 +118,8 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         media_type="image",
         family="google",
         display_name_key="endpoint_gemini_image_display",
+        request_method="POST",
+        request_path_template="/v1beta/models/{model}:generateContent",
         build_backend=_build_gemini_image,
     ),
     "openai-video": EndpointSpec(
@@ -114,6 +127,8 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         media_type="video",
         family="openai",
         display_name_key="endpoint_openai_video_display",
+        request_method="POST",
+        request_path_template="/v1/videos",
         build_backend=_build_openai_video,
     ),
     "newapi-video": EndpointSpec(
@@ -121,6 +136,8 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         media_type="video",
         family="newapi",
         display_name_key="endpoint_newapi_video_display",
+        request_method="POST",
+        request_path_template="/v1/video/generations",
         build_backend=_build_newapi_video,
     ),
 }
@@ -148,6 +165,13 @@ def endpoint_to_media_type(endpoint: str) -> str:
 
 def list_endpoints_by_media_type(media_type: str) -> list[EndpointSpec]:
     return [ENDPOINT_REGISTRY[k] for k in ENDPOINT_KEYS_BY_MEDIA_TYPE.get(media_type, ())]
+
+
+def endpoint_spec_to_dict(spec: EndpointSpec) -> dict:
+    """把 EndpointSpec 转成可序列化的纯数据 dict（剥掉不可 JSON 化的 build_backend 闭包）。"""
+    data = asdict(spec)
+    data.pop("build_backend", None)
+    return data
 
 
 # ── 启发式：从 model_id + discovery_format 推默认 endpoint ─────────

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -10,26 +10,27 @@ import asyncio
 import json
 import logging
 from collections.abc import Callable
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import AfterValidator, BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lib.config.repository import mask_secret
 from lib.custom_provider import make_provider_id
-from lib.custom_provider.endpoints import endpoint_to_media_type
+from lib.custom_provider.endpoints import ENDPOINT_REGISTRY, endpoint_spec_to_dict, endpoint_to_media_type
 
-# Endpoint / discovery_format 字面量类型 —— Pydantic 自动按枚举校验，
-# 与 lib/custom_provider/endpoints.py:ENDPOINT_REGISTRY 的键集合保持同步。
-EndpointLiteral = Literal[
-    "openai-chat",
-    "gemini-generate",
-    "openai-images",
-    "gemini-image",
-    "openai-video",
-    "newapi-video",
-]
+
+def _validate_endpoint(value: str) -> str:
+    """Endpoint 校验：值必须存在于 ENDPOINT_REGISTRY，避免硬编码 Literal 漂移。"""
+    if value not in ENDPOINT_REGISTRY:
+        raise ValueError(f"unknown endpoint: {value!r}")
+    return value
+
+
+# 写入路径上的 endpoint 字段统一走运行时校验，键集合自动跟随 ENDPOINT_REGISTRY；
+# 响应路径不需校验，直接 str。
+EndpointType = Annotated[str, AfterValidator(_validate_endpoint)]
 DiscoveryFormatLiteral = Literal["openai", "google"]
 from lib.db import get_async_session
 from lib.db.base import dt_to_iso
@@ -60,7 +61,7 @@ _BACKEND_SETTING_KEYS = (
 class ModelInput(BaseModel):
     model_id: str
     display_name: str
-    endpoint: EndpointLiteral
+    endpoint: EndpointType
     is_default: bool = False
     is_enabled: bool = True
     price_unit: str | None = None
@@ -146,6 +147,21 @@ class ConnectionTestResponse(BaseModel):
 
 class DiscoverResponse(BaseModel):
     models: list[dict]
+
+
+class EndpointDescriptor(BaseModel):
+    """前端从 catalog API 拿到的单条 endpoint 描述（与 lib.custom_provider.endpoints.EndpointSpec 对齐，去掉闭包）。"""
+
+    key: str
+    media_type: str
+    family: str
+    display_name_key: str
+    request_method: str
+    request_path_template: str
+
+
+class EndpointCatalogResponse(BaseModel):
+    endpoints: list[EndpointDescriptor]
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +277,15 @@ async def list_providers(
     repo = CustomProviderRepository(session)
     pairs = await repo.list_providers_with_models()
     return {"providers": [_provider_to_response(p, models) for p, models in pairs]}
+
+
+# /endpoints 必须先于 /{provider_id} 注册，否则 FastAPI 会把字符串 "endpoints" 当作 provider_id。
+@router.get("/endpoints", response_model=EndpointCatalogResponse)
+async def list_endpoint_catalog(_user: CurrentUser) -> EndpointCatalogResponse:
+    """暴露 ENDPOINT_REGISTRY 作为前端单一真相源：渲染下拉、显示路径与分组都派生自此返回值。"""
+    return EndpointCatalogResponse(
+        endpoints=[EndpointDescriptor(**endpoint_spec_to_dict(spec)) for spec in ENDPOINT_REGISTRY.values()],
+    )
 
 
 @router.post("", status_code=201)

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -6,6 +6,7 @@ import pytest
 
 from lib.custom_provider.endpoints import (
     ENDPOINT_REGISTRY,
+    endpoint_spec_to_dict,
     endpoint_to_media_type,
     get_endpoint_spec,
     infer_endpoint,
@@ -31,6 +32,21 @@ class TestRegistry:
             assert spec.family in {"openai", "google", "newapi"}
             assert spec.display_name_key.startswith("endpoint_")
             assert callable(spec.build_backend)
+            assert spec.request_method == "POST"
+            assert spec.request_path_template.startswith("/")
+
+    def test_endpoint_spec_to_dict_drops_closure(self):
+        spec = ENDPOINT_REGISTRY["openai-chat"]
+        d = endpoint_spec_to_dict(spec)
+        assert "build_backend" not in d
+        assert d == {
+            "key": "openai-chat",
+            "media_type": "text",
+            "family": "openai",
+            "display_name_key": "endpoint_openai_chat_display",
+            "request_method": "POST",
+            "request_path_template": "/v1/chat/completions",
+        }
 
     def test_media_type_groups(self):
         text_keys = {s.key for s in ENDPOINT_REGISTRY.values() if s.media_type == "text"}

--- a/tests/test_custom_providers_api.py
+++ b/tests/test_custom_providers_api.py
@@ -194,6 +194,44 @@ class TestListProviders:
         assert body[1]["display_name"] == "Provider B"
 
 
+class TestEndpointCatalog:
+    """GET /endpoints 暴露 ENDPOINT_REGISTRY 作为前端单一真相源。"""
+
+    def test_lists_all_six_endpoints(self, client: TestClient):
+        resp = client.get("/api/v1/custom-providers/endpoints")
+        assert resp.status_code == 200
+        body = resp.json()
+        keys = {e["key"] for e in body["endpoints"]}
+        assert keys == {
+            "openai-chat",
+            "gemini-generate",
+            "openai-images",
+            "gemini-image",
+            "openai-video",
+            "newapi-video",
+        }
+
+    def test_descriptor_shape(self, client: TestClient):
+        resp = client.get("/api/v1/custom-providers/endpoints")
+        assert resp.status_code == 200
+        for entry in resp.json()["endpoints"]:
+            assert set(entry.keys()) == {
+                "key",
+                "media_type",
+                "family",
+                "display_name_key",
+                "request_method",
+                "request_path_template",
+            }
+            assert entry["request_method"] == "POST"
+            assert entry["request_path_template"].startswith("/")
+
+    def test_endpoint_route_not_shadowed_by_provider_id(self, client: TestClient):
+        """回归：/endpoints 必须先于 /{provider_id} 注册，不能被解析为整型 provider_id。"""
+        resp = client.get("/api/v1/custom-providers/endpoints")
+        assert resp.status_code == 200, resp.text
+
+
 class TestGetProvider:
     def test_returns_provider(self, client: TestClient):
         create_resp = client.post(
@@ -800,6 +838,31 @@ class TestEmptyModelIdRejected:
                 },
             )
         assert resp.status_code == 422
+
+
+class TestUnknownEndpointRejected:
+    """回归：写入路径用未注册 endpoint key 应被 AfterValidator 拦下，返回 422。"""
+
+    def test_create_with_unknown_endpoint(self, client: TestClient):
+        resp = client.post(
+            "/api/v1/custom-providers",
+            json={
+                "display_name": "Unknown Endpoint",
+                "discovery_format": "openai",
+                "base_url": "https://api.example.com/v1",
+                "api_key": "sk-key",
+                "models": [
+                    {
+                        "model_id": "m1",
+                        "display_name": "M",
+                        "endpoint": "anthropic-messages",
+                        "is_enabled": True,
+                    },
+                ],
+            },
+        )
+        assert resp.status_code == 422
+        assert "unknown endpoint" in resp.text
 
 
 class TestDuplicateModelIdRejected:


### PR DESCRIPTION
## Summary

- 后端 `EndpointSpec` 扩展 `request_method` / `request_path_template`，新增 `GET /api/v1/custom-providers/endpoints` 路由暴露目录；写入路径上的 endpoint 用 `Annotated[str, AfterValidator]` 替换硬编码 `Literal`，自动跟随 `ENDPOINT_REGISTRY`
- 前端 `EndpointKey` 收敛为 `string` 别名，删除 `ENDPOINT_TO_MEDIA_TYPE` / `ENDPOINT_PATHS` / `EndpointSelect.OPTIONS` 三处 FE 镜像；新增 `endpoint-catalog-store` 缓存运行时数据，`Form`/`Detail`/`EndpointSelect`/`config-status-store`/`provider-models.lookupResolutions` 全部改读 store
- 重构后新增 endpoint 仅需改 2 处：`lib/custom_provider/endpoints.py`（后端真相源）+ `frontend/src/i18n/{zh,en}/dashboard.ts`（翻译文案）

Closes #414

## Test plan

- [x] \`uv run python -m pytest\`：1998 passed（含新增 catalog API + 未知 endpoint 422 回归）
- [x] \`uv run ruff check . && uv run ruff format --check\`：全过
- [x] \`pnpm check\`：tsc + eslint + 423 tests passed（含新增 endpoint-catalog-store 单测：fetch 短路 / refresh 重拉 / 错误重试）
- [x] \`pnpm build\`：通过
- [ ] 手动：启动 dev server，打开设置页 → DevTools 应看到 \`GET /custom-providers/endpoints\` 返回 6 条；EndpointSelect 下拉按 text/image/video 分组渲染正确
- [ ] 手动：模拟新增一条 endpoint —— 只改 \`endpoints.py\` + \`dashboard.ts\`，前端刷新后下拉立即出现新选项