### PR TITLE
Unify video model endpoints to openai-video

### DIFF
--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -182,22 +182,18 @@ _VIDEO_PATTERN = re.compile(
     r"video|sora|kling|wan|seedance|cog|mochi|veo|pika|minimax|hailuo|jimeng-?video|runway",
     re.IGNORECASE,
 )
-_SORA_PATTERN = re.compile(r"sora", re.IGNORECASE)
 
 
 def infer_endpoint(model_id: str, discovery_format: str) -> str:
     """根据模型 id 与 discovery_format 推默认 endpoint。
 
-    1) 视频家族:
-       - sora-* 且 discovery_format=openai → "openai-video"
-       - 其他视频家族 → "newapi-video" (中转站最常见，google 直连本无视频也兜底)
+    1) 视频家族 → 一律 "openai-video"（OpenAI /v1/videos 协议为首选默认，
+       newapi-video 仅在用户手动选择时使用）
     2) 图像家族 → discovery_format=google 走 "gemini-image" 否则 "openai-images"
     3) 文本（默认）→ discovery_format=google 走 "gemini-generate" 否则 "openai-chat"
     """
     if _VIDEO_PATTERN.search(model_id):
-        if discovery_format == "openai" and _SORA_PATTERN.search(model_id):
-            return "openai-video"
-        return "newapi-video"
+        return "openai-video"
     if _IMAGE_PATTERN.search(model_id):
         if discovery_format == "google":
             return "gemini-image"

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -93,15 +93,15 @@ class TestInferEndpoint:
             ("imagen-4", "openai", "openai-images"),
             ("flux-pro", "openai", "openai-images"),
             ("sora-2", "openai", "openai-video"),
-            ("kling-v2", "openai", "newapi-video"),
-            ("veo-3", "openai", "newapi-video"),
-            ("veo-3", "google", "newapi-video"),  # google 直连无视频端点 → 兜底 newapi
-            ("seedance-1.0", "openai", "newapi-video"),
-            ("hailuo-02", "openai", "newapi-video"),
+            ("kling-v2", "openai", "openai-video"),
+            ("veo-3", "openai", "openai-video"),
+            ("veo-3", "google", "openai-video"),  # 视频家族一律默认 openai-video
+            ("seedance-1.0", "openai", "openai-video"),
+            ("hailuo-02", "openai", "openai-video"),
             ("seedream-3.0", "openai", "openai-images"),
             ("jimeng-3.0", "openai", "openai-images"),
-            ("jimeng-video-3.0", "openai", "newapi-video"),
-            ("jimengvideo-3.0", "openai", "newapi-video"),
+            ("jimeng-video-3.0", "openai", "openai-video"),
+            ("jimengvideo-3.0", "openai", "openai-video"),
             ("SORA-2", "openai", "openai-video"),
         ],
     )

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -28,7 +28,7 @@ class TestInferEndpointSmoke:
     def test_video_model(self):
         from lib.custom_provider.endpoints import infer_endpoint
 
-        assert infer_endpoint("kling-v2", "openai") == "newapi-video"
+        assert infer_endpoint("kling-v2", "openai") == "openai-video"
 
     def test_google_text(self):
         from lib.custom_provider.endpoints import infer_endpoint
@@ -239,7 +239,7 @@ class TestDiscoverModelsGoogle:
         by_id = {m["model_id"]: m for m in result}
         assert by_id["gemini-3-flash"]["endpoint"] == "gemini-generate"
         assert by_id["gemini-3-flash-image-preview"]["endpoint"] == "gemini-image"
-        assert by_id["veo-3"]["endpoint"] == "newapi-video"
+        assert by_id["veo-3"]["endpoint"] == "openai-video"
 
     @patch("lib.custom_provider.discovery.genai")
     async def test_default_marking_google(self, mock_genai):
@@ -364,8 +364,8 @@ def test_discover_openai_returns_endpoints(monkeypatch):
     )
     by_id = {m["model_id"]: m for m in result}
     assert by_id["gpt-4o"]["endpoint"] == "openai-chat"
-    assert by_id["kling-v2"]["endpoint"] == "newapi-video"
+    assert by_id["kling-v2"]["endpoint"] == "openai-video"
     assert by_id["dall-e-3"]["endpoint"] == "openai-images"
     # 每种 media_type 仅一个 default
     defaults = [m for m in result if m["is_default"]]
-    assert {m["endpoint"] for m in defaults} == {"openai-chat", "newapi-video", "openai-images"}
+    assert {m["endpoint"] for m in defaults} == {"openai-chat", "openai-video", "openai-images"}


### PR DESCRIPTION
## 范围

修改视频模型的端点推断逻辑，涉及：
- `lib/custom_provider/endpoints.py` - 端点推断函数
- `tests/test_custom_provider_endpoints.py` - 端点推断测试
- `tests/test_model_discovery.py` - 模型发现测试

## 变更

- 简化 `infer_endpoint()` 函数：所有视频家族模型（video/sora/kling/veo/seedance 等）统一默认使用 `openai-video` 端点，而非之前的条件判断（仅 sora 用 openai-video，其他用 newapi-video）
- 移除 `_SORA_PATTERN` 正则表达式（不再需要）
- 更新文档注释：明确视频家族一律默认 openai-video，newapi-video 仅在用户手动选择时使用
- 更新所有相关测试用例，将预期端点从 `newapi-video` 改为 `openai-video`：
  - kling-v2, veo-3, seedance-1.0, hailuo-02, jimeng-video-3.0, jimengvideo-3.0 等模型

## 验收清单

- [x] 本地已跑相关测试（`pytest tests/test_custom_provider_endpoints.py::TestInferEndpoint` 和 `pytest tests/test_model_discovery.py`）
- [x] 改动逻辑清晰：视频模型端点推断规则统一化
- [x] 无新增文案翻译需求
- [x] 无 ESLint 相关改动
- [x] 仅涉及后端逻辑和测试

## 已知 defer

无

https://claude.ai/code/session_01QyfhbpKfHu2ph3GArt74ob