### PR TITLE
fix(image-split): ImageCapabilityError i18n + grids T2I/I2I metadata

### DIFF
--- a/server/routers/grids.py
+++ b/server/routers/grids.py
@@ -153,9 +153,8 @@ async def generate_grid(
                 if chunk_layout is None:
                     continue
 
-                # 从 T2I 槽提取 provider/model 元数据（格式：provider/model）
-                _t2i_raw = backend_snapshot.get("image_provider_t2i", "")
-                _t2i_parts = _t2i_raw.split("/", 1) if "/" in _t2i_raw else [_t2i_raw, ""]
+                # provider/model 由 execute_grid_task 在 _resolve_effective_image_backend
+                # 之后回填，因为只有 task 层能根据 reference_images 判断走 T2I 还是 I2I 槽
                 grid = GridGeneration.create(
                     episode=episode,
                     script_file=req.script_file,
@@ -163,8 +162,8 @@ async def generate_grid(
                     rows=chunk_layout.rows,
                     cols=chunk_layout.cols,
                     grid_size=chunk_layout.grid_size,
-                    provider=_t2i_parts[0],
-                    model=_t2i_parts[1] if len(_t2i_parts) > 1 else "",
+                    provider="",
+                    model="",
                 )
 
                 prompt = build_grid_prompt(
@@ -275,6 +274,9 @@ async def regenerate_grid(project_name: str, grid_id: str, _user: CurrentUser):
 
         grid.status = "pending"
         grid.error_message = None
+        # 清空旧 metadata，由 execute_grid_task 按 needs_i2i 重新回填
+        grid.provider = ""
+        grid.model = ""
         gm.save(grid)
 
         project = get_project_manager().load_project(project_name)

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -1208,6 +1208,10 @@ async def execute_grid_task(
         image_provider_id, image_model_id = await _resolve_effective_image_backend(
             project, payload, needs_i2i=_needs_i2i
         )
+        # 回填 grid metadata：route 层创建/重建时无法预知 needs_i2i，由此处补齐
+        grid.provider = image_provider_id
+        grid.model = image_model_id
+        grid_manager.save(grid)
         image_size = await resolve_resolution(project, image_provider_id, image_model_id) or "2K"  # 宫格图保底高分辨率
 
         image_path, version = await generator.generate_image_async(

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -18,6 +18,9 @@ from lib.config.registry import PROVIDER_REGISTRY
 from lib.custom_provider import is_custom_provider
 from lib.db.base import DEFAULT_USER_ID
 from lib.gemini_shared import get_shared_rate_limiter
+from lib.i18n import DEFAULT_LOCALE
+from lib.i18n import _ as i18n_translate
+from lib.image_backends.base import ImageCapabilityError
 from lib.media_generator import MediaGenerator
 from lib.project_change_hints import emit_project_change_batch, project_change_source
 from lib.project_manager import ProjectManager
@@ -1319,7 +1322,13 @@ async def execute_generation_task(task: dict[str, Any]) -> dict[str, Any]:
         raise ValueError(f"unsupported task_type: {task_type}")
 
     with project_change_source("worker"):
-        result = await executor(project_name, resource_id, payload, user_id=user_id)
+        try:
+            result = await executor(project_name, resource_id, payload, user_id=user_id)
+        except ImageCapabilityError as err:
+            # Worker 后台无 request 上下文，按 DEFAULT_LOCALE 渲染稳定的 i18n 文案
+            # 落到 task.error_message，前端轮询时即可看到本地化提示
+            message = i18n_translate(err.code, locale=DEFAULT_LOCALE, **err.params)
+            raise RuntimeError(message) from err
         _emit_generation_success_batch(
             task_type=task_type,
             project_name=project_name,

--- a/tests/test_generation_tasks_dispatch.py
+++ b/tests/test_generation_tasks_dispatch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from lib.image_backends.base import ImageCapabilityError
 from server.services.generation_tasks import _TASK_CHANGE_SPECS, _TASK_EXECUTORS
 
 
@@ -28,6 +29,78 @@ async def test_execute_generation_task_rejects_unknown_type():
                 "task_type": "unknown_xyz",
                 "project_name": "demo",
                 "resource_id": "x",
+                "payload": {},
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_task_translates_image_endpoint_mismatch(monkeypatch):
+    from server.services.generation_tasks import execute_generation_task
+
+    async def fake_executor(*_args, **_kwargs):
+        raise ImageCapabilityError("image_endpoint_mismatch_no_t2i", model="gpt-image-1")
+
+    monkeypatch.setitem(_TASK_EXECUTORS, "storyboard", fake_executor)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await execute_generation_task(
+            {
+                "task_type": "storyboard",
+                "project_name": "demo",
+                "resource_id": "scene-1",
+                "payload": {},
+            }
+        )
+
+    message = str(exc_info.value)
+    # 必须是已翻译的 zh 文案，而不是裸 code
+    assert "image_endpoint_mismatch_no_t2i" not in message
+    assert "gpt-image-1" in message
+    assert "图生图" in message  # zh 文案关键字
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_task_translates_capability_missing_i2i(monkeypatch):
+    from server.services.generation_tasks import execute_generation_task
+
+    async def fake_executor(*_args, **_kwargs):
+        raise ImageCapabilityError("image_capability_missing_i2i", provider="openai", model="gpt-image-1")
+
+    monkeypatch.setitem(_TASK_EXECUTORS, "storyboard", fake_executor)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await execute_generation_task(
+            {
+                "task_type": "storyboard",
+                "project_name": "demo",
+                "resource_id": "scene-1",
+                "payload": {},
+            }
+        )
+
+    message = str(exc_info.value)
+    assert "image_capability_missing_i2i" not in message
+    assert "openai" in message
+    assert "gpt-image-1" in message
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_task_propagates_other_exceptions(monkeypatch):
+    """非 ImageCapabilityError 的异常应原样冒泡，不被 i18n 分支吞掉"""
+    from server.services.generation_tasks import execute_generation_task
+
+    async def fake_executor(*_args, **_kwargs):
+        raise ValueError("unrelated business error")
+
+    monkeypatch.setitem(_TASK_EXECUTORS, "storyboard", fake_executor)
+
+    with pytest.raises(ValueError, match="unrelated business error"):
+        await execute_generation_task(
+            {
+                "task_type": "storyboard",
+                "project_name": "demo",
+                "resource_id": "scene-1",
                 "payload": {},
             }
         )

--- a/tests/test_grid_executor.py
+++ b/tests/test_grid_executor.py
@@ -301,3 +301,95 @@ class TestTaskExecutorsRegistry:
 
         assert "grid" in _TASK_EXECUTORS
         assert _TASK_EXECUTORS["grid"] is execute_grid_task
+
+
+class TestGridMetadataT2II2ISlotSelection:
+    """Bug 2 回归：execute_grid_task 必须按 reference_images 是否非空决定写 T2I 还是 I2I 槽。"""
+
+    @pytest.fixture
+    def grid_with_empty_metadata(self, project_with_script):
+        """模拟 route 层修复后的状态：grid 创建时 provider/model 为空，由 task 层回填。"""
+        from lib.grid.models import GridGeneration
+
+        grid = GridGeneration.create(
+            episode=1,
+            script_file="episode_1.json",
+            scene_ids=["E1S01", "E1S02", "E1S03"],
+            rows=2,
+            cols=2,
+            grid_size="2K",
+            provider="",
+            model="",
+            prompt="test grid prompt",
+        )
+        grid_path = project_with_script / "grids" / f"{grid.id}.json"
+        grid_path.write_text(json.dumps(grid.to_dict(), ensure_ascii=False, indent=2))
+        return grid
+
+    async def _run_grid_task(self, project_with_script, grid, payload):
+        """Helper：mock 掉 generator 与 project manager，运行 execute_grid_task。"""
+        from PIL import Image
+
+        from server.services.generation_tasks import execute_grid_task
+
+        fake_grid_image = Image.new("RGB", (400, 400), color=(128, 128, 128))
+        grid_image_path = project_with_script / "grids" / f"{grid.id}.png"
+        fake_grid_image.save(grid_image_path, format="PNG")
+
+        mock_generator = MagicMock()
+        mock_generator.generate_image_async = AsyncMock(return_value=(grid_image_path, 1))
+
+        with (
+            patch("server.services.generation_tasks.get_project_manager") as mock_pm_fn,
+            patch("server.services.generation_tasks.get_media_generator", new_callable=AsyncMock) as mock_get_gen,
+        ):
+            mock_pm = MagicMock()
+            mock_pm.get_project_path.return_value = project_with_script
+            mock_pm.load_project.return_value = json.loads((project_with_script / "project.json").read_text())
+            mock_pm.update_scene_asset.return_value = {}
+            mock_pm_fn.return_value = mock_pm
+            mock_get_gen.return_value = mock_generator
+
+            await execute_grid_task("test-project", grid.id, payload, user_id="test-user")
+
+    async def test_uses_t2i_slot_when_no_reference_images(self, project_with_script, grid_with_empty_metadata):
+        """无 character/scene/prop sheet → reference_images 为空 → 写 T2I 槽配置"""
+        grid = grid_with_empty_metadata
+        payload = {
+            "prompt": "test grid prompt",
+            "script_file": "episode_1.json",
+            "image_provider_t2i": "openai/gpt-image-t2i",
+            "image_provider_i2i": "openai/gpt-image-i2i",
+        }
+
+        await self._run_grid_task(project_with_script, grid, payload)
+
+        updated = json.loads((project_with_script / "grids" / f"{grid.id}.json").read_text())
+        assert updated["provider"] == "openai"
+        assert updated["model"] == "gpt-image-t2i"
+
+    async def test_uses_i2i_slot_when_reference_images_present(self, project_with_script, grid_with_empty_metadata):
+        """有 character sheet 且 segment 引用了角色 → reference_images 非空 → 写 I2I 槽配置"""
+        # 给 project + script 注入 character sheet，让 _collect_grid_reference_images 返回非空
+        project_data = json.loads((project_with_script / "project.json").read_text())
+        project_data["characters"]["hero"] = {"character_sheet": "characters/hero.png"}
+        (project_with_script / "project.json").write_text(json.dumps(project_data))
+        (project_with_script / "characters" / "hero.png").write_bytes(b"fake-image")
+
+        script = json.loads((project_with_script / "scripts" / "episode_1.json").read_text())
+        script["segments"][0]["characters_in_segment"] = ["hero"]
+        (project_with_script / "scripts" / "episode_1.json").write_text(json.dumps(script))
+
+        grid = grid_with_empty_metadata
+        payload = {
+            "prompt": "test grid prompt",
+            "script_file": "episode_1.json",
+            "image_provider_t2i": "openai/gpt-image-t2i",
+            "image_provider_i2i": "openai/gpt-image-i2i",
+        }
+
+        await self._run_grid_task(project_with_script, grid, payload)
+
+        updated = json.loads((project_with_script / "grids" / f"{grid.id}.json").read_text())
+        assert updated["provider"] == "openai"
+        assert updated["model"] == "gpt-image-i2i"


### PR DESCRIPTION
Follow-up to #454。等 base 合并后会自然 rebase 到 main。

## Summary

- **Bug 1 (i18n)**: `ImageCapabilityError`（`lib/image_backends/openai.py` / `lib/media_generator.py` 共 4 处抛出）之前没有任何 except 分支，被 `GenerationWorker` 当成裸 code 字符串落到 `task.error_message`，`lib/i18n/{zh,en}/errors.py` 中 4 条翻译 key 永不渲染。在 `execute_generation_task` dispatcher 入口包 try/except，按 `DEFAULT_LOCALE` 翻译后 re-raise `RuntimeError`，让 worker 既有失败路径直接落已翻译文案。
- **Bug 2 (grids metadata)**: `server/routers/grids.py` 的 `generate_grid` / `regenerate_grid` 在创建 / 重置 `GridGeneration` 时硬编码读 `image_provider_t2i` 槽。但 `reference_images` 在 route 层拿不到——它们由 `_collect_grid_reference_images()` 在 task 执行时从 character/scene/prop sheets 自动收集。改为 route 层留空 provider/model，`execute_grid_task` 在 `_resolve_effective_image_backend(needs_i2i=...)` 之后立即回填并保存。

## 设计选择

- **翻译 locale**：worker 后台无 request 上下文，硬编码 `DEFAULT_LOCALE`（`zh`，符合本项目主受众）。不引入结构化 error_message schema 以避免侵入 ORM 与所有 reader。
- **metadata 写入位置**：route 层无法预知 `needs_i2i`，所以 metadata 写入必须在 task 层 `_resolve_effective_image_backend` 之后。`generate_grid` 与 `regenerate_grid` 两条入口对齐。
- **`_split_pair` 不外提**：新方案 route 层不再需要解析 provider/model 字符串，唯一调用点仍在 `_resolve_effective_image_backend` 内部，外提是 speculative 重构。

## Test plan

- [x] 新增 `tests/test_generation_tasks_dispatch.py` 3 条测试：`image_endpoint_mismatch_no_t2i` 翻译、`image_capability_missing_i2i` 翻译、非 `ImageCapabilityError` 原样冒泡
- [x] 新增 `tests/test_grid_executor.py::TestGridMetadataT2II2ISlotSelection` 2 条回归：含 reference_images 走 I2I 槽 / 无 reference_images 走 T2I 槽
- [x] 全量 `pytest`：2079 passed
- [x] `ruff check` + `ruff format --check`：clean
- [ ] 端到端冒烟（reviewer 视情况）：配仅支持 T2I 的模型作为 i2i 槽，触发宫格生成（带 character sheet），观察 task error_message 是否为 zh 翻译文案；GridGeneration 记录 provider/model 是否对应正确槽