### PR TITLE
feat: 模型选择器支持搜索

### DIFF
--- a/frontend/src/components/ui/ProviderModelSelect.test.tsx
+++ b/frontend/src/components/ui/ProviderModelSelect.test.tsx
@@ -274,6 +274,70 @@ describe("ProviderModelSelect – search", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it("uses unique ARIA ids for sibling instances on the same page", async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <ProviderModelSelect
+          value=""
+          options={MANY_OPTIONS}
+          providerNames={MANY_PROVIDER_NAMES}
+          onChange={() => {}}
+          aria-label="first"
+        />
+        <ProviderModelSelect
+          value=""
+          options={MANY_OPTIONS}
+          providerNames={MANY_PROVIDER_NAMES}
+          onChange={() => {}}
+          aria-label="second"
+        />
+      </div>,
+    );
+    const [first, second] = screen.getAllByRole("combobox");
+    expect(first.getAttribute("aria-controls")).toBeTruthy();
+    expect(first.getAttribute("aria-controls")).not.toBe(second.getAttribute("aria-controls"));
+
+    // Open both and verify their listbox ids differ
+    await user.click(first);
+    const firstListbox = document.getElementById(first.getAttribute("aria-controls")!);
+    expect(firstListbox).not.toBeNull();
+    await user.click(second);
+    const secondListbox = document.getElementById(second.getAttribute("aria-controls")!);
+    expect(secondListbox).not.toBeNull();
+    expect(firstListbox).not.toBe(secondListbox);
+  });
+
+  it("does not apply stale query filtering when search input is hidden", async () => {
+    const user = userEvent.setup();
+    // Start with searchable enabled so user can type a query
+    const { rerender } = render(
+      <ProviderModelSelect
+        value=""
+        options={MANY_OPTIONS}
+        providerNames={MANY_PROVIDER_NAMES}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText(/搜索模型或供应商/), "veo");
+    expect(screen.getAllByRole("option")).toHaveLength(2);
+
+    // Re-render with searchable disabled — search box hides; list must not
+    // remain filtered by the now-invisible query.
+    rerender(
+      <ProviderModelSelect
+        value=""
+        options={MANY_OPTIONS}
+        providerNames={MANY_PROVIDER_NAMES}
+        onChange={() => {}}
+        searchable={false}
+      />,
+    );
+    expect(screen.queryByPlaceholderText(/搜索模型或供应商/)).toBeNull();
+    expect(screen.getAllByRole("option")).toHaveLength(MANY_OPTIONS.length);
+  });
+
   it("clears query when an option is selected", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/frontend/src/components/ui/ProviderModelSelect.test.tsx
+++ b/frontend/src/components/ui/ProviderModelSelect.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
 import "@/i18n";
 import { ProviderModelSelect } from "./ProviderModelSelect";
 
@@ -65,5 +66,187 @@ describe("ProviderModelSelect – trigger display", () => {
     expect(trigger).not.toHaveTextContent(/跟随全局默认/);
     expect(trigger).toHaveTextContent(/Ark/);
     expect(trigger).toHaveTextContent(/seedance/);
+  });
+});
+
+const MANY_OPTIONS = [
+  "gemini-aistudio/veo-3.1-generate-001",
+  "gemini-aistudio/veo-2.0-generate",
+  "gemini-aistudio/imagen-4",
+  "ark/seedance",
+  "ark/seedream",
+  "ark/jimeng",
+  "openai/sora",
+];
+const MANY_PROVIDER_NAMES = {
+  "gemini-aistudio": "Gemini AI Studio",
+  ark: "火山方舟",
+  openai: "OpenAI",
+};
+
+describe("ProviderModelSelect – search", () => {
+  it("does not render search input when option count is below threshold", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderModelSelect
+        value=""
+        options={OPTIONS}
+        providerNames={PROVIDER_NAMES}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.queryByPlaceholderText(/搜索模型或供应商/)).toBeNull();
+  });
+
+  it("renders search input when option count meets threshold", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderModelSelect
+        value=""
+        options={MANY_OPTIONS}
+        providerNames={MANY_PROVIDER_NAMES}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByPlaceholderText(/搜索模型或供应商/)).toBeInTheDocument();
+  });
+
+  it("filters options by model name substring", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderModelSelect
+        value=""
+        options={MANY_OPTIONS}
+        providerNames={MANY_PROVIDER_NAMES}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText(/搜索模型或供应商/), "veo");
+    const visible = screen.getAllByRole("option").map((el) => el.textContent ?? "");
+    expect(visible).toHaveLength(2);
+    expect(visible.every((text) => text.includes("veo"))).toBe(true);
+  });
+
+  it("matches provider display name and shows all of its models", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderModelSelect
+        value=""
+        options={MANY_OPTIONS}
+        providerNames={MANY_PROVIDER_NAMES}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText(/搜索模型或供应商/), "Gemini");
+    const visible = screen.getAllByRole("option").map((el) => el.textContent ?? "");
+    expect(visible).toHaveLength(3);
+    expect(visible.some((text) => text.includes("veo-3.1-generate-001"))).toBe(true);
+    expect(visible.some((text) => text.includes("veo-2.0-generate"))).toBe(true);
+    expect(visible.some((text) => text.includes("imagen-4"))).toBe(true);
+  });
+
+  it("matches case-insensitively", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderModelSelect
+        value=""
+        options={MANY_OPTIONS}
+        providerNames={MANY_PROVIDER_NAMES}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText(/搜索模型或供应商/), "OPENAI");
+    const visible = screen.getAllByRole("option").map((el) => el.textContent ?? "");
+    expect(visible).toHaveLength(1);
+    expect(visible[0]).toContain("sora");
+  });
+
+  it("shows empty state when nothing matches", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderModelSelect
+        value=""
+        options={MANY_OPTIONS}
+        providerNames={MANY_PROVIDER_NAMES}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText(/搜索模型或供应商/), "zzz-no-match");
+    expect(screen.queryAllByRole("option")).toHaveLength(0);
+    expect(screen.getByRole("status")).toHaveTextContent(/未找到匹配模型/);
+  });
+
+  it("hides default option while query is active", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderModelSelect
+        value=""
+        options={MANY_OPTIONS}
+        providerNames={MANY_PROVIDER_NAMES}
+        onChange={() => {}}
+        allowDefault
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByText(/跟随全局默认/)).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText(/搜索模型或供应商/), "veo");
+    expect(screen.queryByText(/跟随全局默认/)).toBeNull();
+  });
+
+  it("does not render search input when searchable is false", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderModelSelect
+        value=""
+        options={MANY_OPTIONS}
+        providerNames={MANY_PROVIDER_NAMES}
+        onChange={() => {}}
+        searchable={false}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.queryByPlaceholderText(/搜索模型或供应商/)).toBeNull();
+  });
+
+  it("respects custom searchThreshold", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderModelSelect
+        value=""
+        options={OPTIONS}
+        providerNames={PROVIDER_NAMES}
+        onChange={() => {}}
+        searchThreshold={2}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByPlaceholderText(/搜索模型或供应商/)).toBeInTheDocument();
+  });
+
+  it("clears query when an option is selected", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ProviderModelSelect
+        value=""
+        options={MANY_OPTIONS}
+        providerNames={MANY_PROVIDER_NAMES}
+        onChange={onChange}
+      />,
+    );
+    const trigger = screen.getByRole("combobox");
+    await user.click(trigger);
+    await user.type(screen.getByPlaceholderText(/搜索模型或供应商/), "sora");
+    await user.click(screen.getByRole("option", { name: /sora/ }));
+    expect(onChange).toHaveBeenCalledWith("openai/sora");
+    // Reopen — search input should be empty again
+    await user.click(trigger);
+    expect(screen.getByPlaceholderText(/搜索模型或供应商/)).toHaveValue("");
   });
 });

--- a/frontend/src/components/ui/ProviderModelSelect.test.tsx
+++ b/frontend/src/components/ui/ProviderModelSelect.test.tsx
@@ -229,6 +229,51 @@ describe("ProviderModelSelect – search", () => {
     expect(screen.getByPlaceholderText(/搜索模型或供应商/)).toBeInTheDocument();
   });
 
+  it("clears query when closing via trigger click", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderModelSelect
+        value=""
+        options={MANY_OPTIONS}
+        providerNames={MANY_PROVIDER_NAMES}
+        onChange={() => {}}
+      />,
+    );
+    const trigger = screen.getByRole("combobox");
+    await user.click(trigger);
+    await user.type(screen.getByPlaceholderText(/搜索模型或供应商/), "sora");
+    // Close by clicking the trigger again
+    await user.click(trigger);
+    // Reopen — search input should be empty
+    await user.click(trigger);
+    expect(screen.getByPlaceholderText(/搜索模型或供应商/)).toHaveValue("");
+  });
+
+  it("ignores Enter while IME composition is active", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ProviderModelSelect
+        value=""
+        options={MANY_OPTIONS}
+        providerNames={MANY_PROVIDER_NAMES}
+        onChange={onChange}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    const input = screen.getByPlaceholderText(/搜索模型或供应商/);
+    // Simulate IME composition: keydown with isComposing=true should not trigger select
+    input.focus();
+    const keydownEvent = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(keydownEvent, "isComposing", { value: true });
+    input.dispatchEvent(keydownEvent);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it("clears query when an option is selected", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/frontend/src/components/ui/ProviderModelSelect.tsx
+++ b/frontend/src/components/ui/ProviderModelSelect.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo, useId } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, Check, Search } from "lucide-react";
 import { ProviderIcon } from "@/components/ui/ProviderIcon";
@@ -43,8 +43,6 @@ function groupByProvider(options: string[]): Record<string, string[]> {
   return groups;
 }
 
-const LISTBOX_ID = "provider-model-listbox";
-
 export function ProviderModelSelect({
   value,
   options,
@@ -62,6 +60,12 @@ export function ProviderModelSelect({
 }: ProviderModelSelectProps) {
   const { t } = useTranslation("dashboard");
   const resolvedPlaceholder = placeholder ?? t("select_model_placeholder");
+  // Per-instance ARIA id prefix — without this, multiple ProviderModelSelect
+  // instances on the same page (e.g. ImageModelDualSelect's T2I/I2I dual slots)
+  // would all share the same listbox/option ids, breaking aria-controls and
+  // aria-activedescendant relationships for screen readers.
+  const reactId = useId();
+  const listboxId = `provider-model-listbox-${reactId}`;
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const [query, setQuery] = useState("");
@@ -78,8 +82,12 @@ export function ProviderModelSelect({
   // breaking keyboard ArrowUp/ArrowDown navigation.
   const grouped = useMemo(() => groupByProvider(options), [options]);
 
-  // Apply search filter to grouped options.
+  // Apply search filter to grouped options. When the search input is hidden
+  // (searchable=false or option count below threshold), any stale `query`
+  // value must NOT continue filtering the list — otherwise users would see
+  // an "invisibly filtered" list with no visible search box to clear.
   const filteredGrouped = useMemo(() => {
+    if (!showSearch) return grouped;
     const q = query.trim().toLowerCase();
     if (!q) return grouped;
     const out: Record<string, string[]> = {};
@@ -93,9 +101,9 @@ export function ProviderModelSelect({
       if (matched.length > 0) out[providerId] = matched;
     }
     return out;
-  }, [grouped, query, providerNames]);
+  }, [grouped, query, providerNames, showSearch]);
 
-  const hasQuery = query.trim().length > 0;
+  const hasQuery = showSearch && query.trim().length > 0;
   const showDefault = !!allowDefault && !hasQuery;
 
   // Build a flat list of selectable options for keyboard navigation
@@ -142,6 +150,12 @@ export function ProviderModelSelect({
       return () => cancelAnimationFrame(id);
     }
   }, [open, showSearch]);
+
+  // Clear stale query whenever the search input is hidden, so a later
+  // showSearch flip back to true cannot resurface a forgotten query.
+  useEffect(() => {
+    if (!showSearch) setQuery("");
+  }, [showSearch]);
 
   // Scroll active item into view
   useEffect(() => {
@@ -243,7 +257,7 @@ export function ProviderModelSelect({
       : resolvedPlaceholder;
 
   const activeDescendantId =
-    open && flatOptions.length > 0 ? `${LISTBOX_ID}-option-${activeIndex}` : undefined;
+    open && flatOptions.length > 0 ? `${listboxId}-option-${activeIndex}` : undefined;
 
   // Track flat index across grouped rendering
   let flatIdx = showDefault ? 1 : 0;
@@ -257,7 +271,7 @@ export function ProviderModelSelect({
         role="combobox"
         aria-expanded={open}
         aria-haspopup="listbox"
-        aria-controls={LISTBOX_ID}
+        aria-controls={listboxId}
         aria-activedescendant={activeDescendantId}
         aria-label={ariaLabel}
         onClick={() => {
@@ -292,7 +306,7 @@ export function ProviderModelSelect({
                 onKeyDown={handleListKeyDown}
                 placeholder={t("search_model_placeholder")}
                 aria-label={t("search_model_aria")}
-                aria-controls={LISTBOX_ID}
+                aria-controls={listboxId}
                 aria-activedescendant={activeDescendantId}
                 autoComplete="off"
                 spellCheck={false}
@@ -302,7 +316,7 @@ export function ProviderModelSelect({
           )}
 
           <div
-            id={LISTBOX_ID}
+            id={listboxId}
             role="listbox"
             aria-label={t("select_model_aria")}
             className="max-h-60 overflow-y-auto"
@@ -313,7 +327,7 @@ export function ProviderModelSelect({
                   if (el) itemRefs.current.set(0, el);
                   else itemRefs.current.delete(0);
                 }}
-                id={`${LISTBOX_ID}-option-0`}
+                id={`${listboxId}-option-0`}
                 role="option"
                 aria-selected={value === ""}
                 type="button"
@@ -353,7 +367,7 @@ export function ProviderModelSelect({
                         if (el) itemRefs.current.set(currentFlatIdx, el);
                         else itemRefs.current.delete(currentFlatIdx);
                       }}
-                      id={`${LISTBOX_ID}-option-${currentFlatIdx}`}
+                      id={`${listboxId}-option-${currentFlatIdx}`}
                       role="option"
                       aria-selected={isSelected}
                       type="button"

--- a/frontend/src/components/ui/ProviderModelSelect.tsx
+++ b/frontend/src/components/ui/ProviderModelSelect.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronDown, Check } from "lucide-react";
+import { ChevronDown, Check, Search } from "lucide-react";
 import { ProviderIcon } from "@/components/ui/ProviderIcon";
 
 interface ProviderModelSelectProps {
@@ -19,6 +19,10 @@ interface ProviderModelSelectProps {
   fallbackValue?: string;
   /** Accessible label for the trigger button */
   "aria-label"?: string;
+  /** Enable in-dropdown search input. Defaults to true. */
+  searchable?: boolean;
+  /** Minimum option count to actually render the search input. Defaults to 6. */
+  searchThreshold?: number;
 }
 
 interface FlatOption {
@@ -53,14 +57,20 @@ export function ProviderModelSelect({
   defaultHint,
   fallbackValue,
   "aria-label": ariaLabel,
+  searchable = true,
+  searchThreshold = 6,
 }: ProviderModelSelectProps) {
   const { t } = useTranslation("dashboard");
   const resolvedPlaceholder = placeholder ?? t("select_model_placeholder");
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [query, setQuery] = useState("");
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const itemRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
+
+  const showSearch = searchable && options.length >= searchThreshold;
 
   // Memoize grouped so flatOptions below has a stable reference when options
   // hasn't changed; otherwise every render creates a new `grouped` object,
@@ -68,13 +78,33 @@ export function ProviderModelSelect({
   // breaking keyboard ArrowUp/ArrowDown navigation.
   const grouped = useMemo(() => groupByProvider(options), [options]);
 
+  // Apply search filter to grouped options.
+  const filteredGrouped = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return grouped;
+    const out: Record<string, string[]> = {};
+    for (const [providerId, models] of Object.entries(grouped)) {
+      const providerLabel = (providerNames[providerId] || providerId).toLowerCase();
+      if (providerLabel.includes(q)) {
+        out[providerId] = models;
+        continue;
+      }
+      const matched = models.filter((m) => m.toLowerCase().includes(q));
+      if (matched.length > 0) out[providerId] = matched;
+    }
+    return out;
+  }, [grouped, query, providerNames]);
+
+  const hasQuery = query.trim().length > 0;
+  const showDefault = !!allowDefault && !hasQuery;
+
   // Build a flat list of selectable options for keyboard navigation
   const flatOptions = useMemo(() => {
     const list: FlatOption[] = [];
-    if (allowDefault) {
+    if (showDefault) {
       list.push({ type: "default", fullValue: "" });
     }
-    for (const [providerId, models] of Object.entries(grouped)) {
+    for (const [providerId, models] of Object.entries(filteredGrouped)) {
       for (const model of models) {
         list.push({
           type: "option",
@@ -83,13 +113,14 @@ export function ProviderModelSelect({
       }
     }
     return list;
-  }, [allowDefault, grouped]);
+  }, [showDefault, filteredGrouped]);
 
   // Close on outside click
   useEffect(() => {
     const handler = (e: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setOpen(false);
+        setQuery("");
       }
     };
     document.addEventListener("mousedown", handler);
@@ -104,6 +135,14 @@ export function ProviderModelSelect({
     }
   }, [open, flatOptions, value]);
 
+  // Auto-focus search input when opening (if visible)
+  useEffect(() => {
+    if (open && showSearch) {
+      const id = requestAnimationFrame(() => inputRef.current?.focus());
+      return () => cancelAnimationFrame(id);
+    }
+  }, [open, showSearch]);
+
   // Scroll active item into view
   useEffect(() => {
     if (open) {
@@ -115,12 +154,53 @@ export function ProviderModelSelect({
     (optValue: string) => {
       onChange(optValue);
       setOpen(false);
+      setQuery("");
       triggerRef.current?.focus();
     },
     [onChange],
   );
 
-  const handleKeyDown = useCallback(
+  const handleListKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          if (flatOptions.length > 0) {
+            setActiveIndex((prev) => (prev + 1) % flatOptions.length);
+          }
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          if (flatOptions.length > 0) {
+            setActiveIndex((prev) => (prev - 1 + flatOptions.length) % flatOptions.length);
+          }
+          break;
+        case "Home":
+          e.preventDefault();
+          setActiveIndex(0);
+          break;
+        case "End":
+          e.preventDefault();
+          setActiveIndex(Math.max(0, flatOptions.length - 1));
+          break;
+        case "Enter": {
+          e.preventDefault();
+          const opt = flatOptions[activeIndex];
+          if (opt) selectOption(opt.fullValue);
+          break;
+        }
+        case "Escape":
+          e.preventDefault();
+          setOpen(false);
+          setQuery("");
+          triggerRef.current?.focus();
+          break;
+      }
+    },
+    [flatOptions, activeIndex, selectOption],
+  );
+
+  const handleTriggerKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (!open) {
         if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === " ") {
@@ -130,39 +210,17 @@ export function ProviderModelSelect({
         }
         return;
       }
-
-      switch (e.key) {
-        case "ArrowDown":
-          e.preventDefault();
-          setActiveIndex((prev) => (prev + 1) % flatOptions.length);
-          break;
-        case "ArrowUp":
-          e.preventDefault();
-          setActiveIndex((prev) => (prev - 1 + flatOptions.length) % flatOptions.length);
-          break;
-        case "Home":
-          e.preventDefault();
-          setActiveIndex(0);
-          break;
-        case "End":
-          e.preventDefault();
-          setActiveIndex(flatOptions.length - 1);
-          break;
-        case "Enter":
-        case " ": {
-          e.preventDefault();
-          const opt = flatOptions[activeIndex];
-          if (opt) selectOption(opt.fullValue);
-          break;
-        }
-        case "Escape":
-          e.preventDefault();
-          setOpen(false);
-          triggerRef.current?.focus();
-          break;
+      // When search is hidden, the trigger button retains focus and handles
+      // navigation directly. With search visible, focus moves to the input.
+      if (e.key === " ") {
+        e.preventDefault();
+        const opt = flatOptions[activeIndex];
+        if (opt) selectOption(opt.fullValue);
+        return;
       }
+      handleListKeyDown(e);
     },
-    [open, flatOptions, activeIndex, selectOption],
+    [open, flatOptions, activeIndex, selectOption, handleListKeyDown],
   );
 
   const slashIdx = value ? value.indexOf("/") : -1;
@@ -184,7 +242,7 @@ export function ProviderModelSelect({
     open && flatOptions.length > 0 ? `${LISTBOX_ID}-option-${activeIndex}` : undefined;
 
   // Track flat index across grouped rendering
-  let flatIdx = allowDefault ? 1 : 0;
+  let flatIdx = showDefault ? 1 : 0;
 
   return (
     <div ref={containerRef} className={`relative ${className || ""}`}>
@@ -199,7 +257,7 @@ export function ProviderModelSelect({
         aria-activedescendant={activeDescendantId}
         aria-label={ariaLabel}
         onClick={() => setOpen(!open)}
-        onKeyDown={handleKeyDown}
+        onKeyDown={handleTriggerKeyDown}
         className="flex w-full items-center justify-between gap-2 rounded-lg border border-gray-700 bg-gray-900/80 px-3 py-2 text-sm text-gray-200 transition-colors hover:border-gray-600 hover:bg-gray-800/80 focus-ring focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900"
       >
         <span className={`truncate ${showFallback ? "text-gray-400" : ""}`}>{displayText}</span>
@@ -210,81 +268,111 @@ export function ProviderModelSelect({
 
       {/* Dropdown panel */}
       {open && (
-        <div
-          id={LISTBOX_ID}
-          role="listbox"
-          aria-label={t("select_model_aria")}
-          className="absolute z-50 mt-1 w-full max-h-60 overflow-y-auto rounded-lg border border-gray-700 bg-gray-900 shadow-xl"
-        >
-          {allowDefault && (
-            <button
-              ref={(el) => {
-                if (el) itemRefs.current.set(0, el);
-                else itemRefs.current.delete(0);
-              }}
-              id={`${LISTBOX_ID}-option-0`}
-              role="option"
-              aria-selected={value === ""}
-              type="button"
-              onClick={() => selectOption("")}
-              onMouseEnter={() => setActiveIndex(0)}
-              className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
-                activeIndex === 0 ? "bg-gray-800 text-white" : "text-gray-300 hover:bg-gray-800/50"
-              }`}
-            >
-              <span>{defaultLabel ?? t("follow_global_default")}</span>
-              {defaultHint && (
-                <span className="ml-auto text-xs text-gray-500">{defaultHint}</span>
-              )}
-            </button>
+        <div className="absolute z-50 mt-1 w-full rounded-lg border border-gray-700 bg-gray-900 shadow-xl">
+          {showSearch && (
+            <div className="relative border-b border-gray-800 p-2">
+              <Search className="pointer-events-none absolute left-4 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-500" />
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setActiveIndex(0);
+                }}
+                onKeyDown={handleListKeyDown}
+                placeholder={t("search_model_placeholder")}
+                aria-label={t("search_model_aria")}
+                aria-controls={LISTBOX_ID}
+                autoComplete="off"
+                spellCheck={false}
+                className="w-full rounded-md border border-gray-700 bg-gray-950/80 py-1.5 pl-8 pr-2 text-sm text-gray-200 placeholder:text-gray-600 focus:border-indigo-500/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/60"
+              />
+            </div>
           )}
 
-          {Object.entries(grouped).map(([providerId, models]) => (
-            <div key={providerId} role="presentation">
-              {/* Group header */}
-              <div
-                role="presentation"
-                className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider text-gray-500 bg-gray-950/50"
+          <div
+            id={LISTBOX_ID}
+            role="listbox"
+            aria-label={t("select_model_aria")}
+            className="max-h-60 overflow-y-auto"
+          >
+            {showDefault && (
+              <button
+                ref={(el) => {
+                  if (el) itemRefs.current.set(0, el);
+                  else itemRefs.current.delete(0);
+                }}
+                id={`${LISTBOX_ID}-option-0`}
+                role="option"
+                aria-selected={value === ""}
+                type="button"
+                onClick={() => selectOption("")}
+                onMouseEnter={() => setActiveIndex(0)}
+                className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+                  activeIndex === 0 ? "bg-gray-800 text-white" : "text-gray-300 hover:bg-gray-800/50"
+                }`}
               >
-                <ProviderIcon providerId={providerId} className="h-3.5 w-3.5" />
-                {providerNames[providerId] || providerId}
+                <span>{defaultLabel ?? t("follow_global_default")}</span>
+                {defaultHint && (
+                  <span className="ml-auto text-xs text-gray-500">{defaultHint}</span>
+                )}
+              </button>
+            )}
+
+            {Object.entries(filteredGrouped).map(([providerId, models]) => (
+              <div key={providerId} role="presentation">
+                {/* Group header */}
+                <div
+                  role="presentation"
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider text-gray-500 bg-gray-950/50"
+                >
+                  <ProviderIcon providerId={providerId} className="h-3.5 w-3.5" />
+                  {providerNames[providerId] || providerId}
+                </div>
+                {/* Model options */}
+                {models.map((model) => {
+                  const currentFlatIdx = flatIdx++;
+                  const fullValue = `${providerId}/${model}`;
+                  const isSelected = fullValue === value;
+                  const isActive = currentFlatIdx === activeIndex;
+                  return (
+                    <button
+                      key={fullValue}
+                      ref={(el) => {
+                        if (el) itemRefs.current.set(currentFlatIdx, el);
+                        else itemRefs.current.delete(currentFlatIdx);
+                      }}
+                      id={`${LISTBOX_ID}-option-${currentFlatIdx}`}
+                      role="option"
+                      aria-selected={isSelected}
+                      type="button"
+                      onClick={() => selectOption(fullValue)}
+                      onMouseEnter={() => setActiveIndex(currentFlatIdx)}
+                      className={`flex w-full items-center gap-1.5 px-3 py-2 pl-6 text-left text-sm transition-colors ${
+                        isActive
+                          ? "bg-gray-800 text-white"
+                          : "text-gray-300 hover:bg-gray-800/50"
+                      }`}
+                    >
+                      {isSelected ? (
+                        <Check className="h-3.5 w-3.5 shrink-0" />
+                      ) : (
+                        <span className="h-3.5 w-3.5 shrink-0" />
+                      )}
+                      <span className="truncate">{model}</span>
+                    </button>
+                  );
+                })}
               </div>
-              {/* Model options */}
-              {models.map((model) => {
-                const currentFlatIdx = flatIdx++;
-                const fullValue = `${providerId}/${model}`;
-                const isSelected = fullValue === value;
-                const isActive = currentFlatIdx === activeIndex;
-                return (
-                  <button
-                    key={fullValue}
-                    ref={(el) => {
-                      if (el) itemRefs.current.set(currentFlatIdx, el);
-                      else itemRefs.current.delete(currentFlatIdx);
-                    }}
-                    id={`${LISTBOX_ID}-option-${currentFlatIdx}`}
-                    role="option"
-                    aria-selected={isSelected}
-                    type="button"
-                    onClick={() => selectOption(fullValue)}
-                    onMouseEnter={() => setActiveIndex(currentFlatIdx)}
-                    className={`flex w-full items-center gap-1.5 px-3 py-2 pl-6 text-left text-sm transition-colors ${
-                      isActive
-                        ? "bg-gray-800 text-white"
-                        : "text-gray-300 hover:bg-gray-800/50"
-                    }`}
-                  >
-                    {isSelected ? (
-                      <Check className="h-3.5 w-3.5 shrink-0" />
-                    ) : (
-                      <span className="h-3.5 w-3.5 shrink-0" />
-                    )}
-                    <span className="truncate">{model}</span>
-                  </button>
-                );
-              })}
-            </div>
-          ))}
+            ))}
+
+            {flatOptions.length === 0 && (
+              <div role="status" className="px-3 py-3 text-center text-sm text-gray-500">
+                {t("no_models_match")}
+              </div>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/components/ui/ProviderModelSelect.tsx
+++ b/frontend/src/components/ui/ProviderModelSelect.tsx
@@ -184,6 +184,10 @@ export function ProviderModelSelect({
           setActiveIndex(Math.max(0, flatOptions.length - 1));
           break;
         case "Enter": {
+          // Ignore Enter while an IME composition is in progress (e.g. selecting
+          // a Chinese/Japanese candidate). Otherwise the candidate confirmation
+          // would be hijacked into selecting a model.
+          if (e.nativeEvent.isComposing) return;
           e.preventDefault();
           const opt = flatOptions[activeIndex];
           if (opt) selectOption(opt.fullValue);
@@ -256,7 +260,12 @@ export function ProviderModelSelect({
         aria-controls={LISTBOX_ID}
         aria-activedescendant={activeDescendantId}
         aria-label={ariaLabel}
-        onClick={() => setOpen(!open)}
+        onClick={() => {
+          // Closing via the trigger should also clear any active query so the
+          // next open starts fresh — matches Escape / outside-click / select.
+          if (open) setQuery("");
+          setOpen(!open);
+        }}
         onKeyDown={handleTriggerKeyDown}
         className="flex w-full items-center justify-between gap-2 rounded-lg border border-gray-700 bg-gray-900/80 px-3 py-2 text-sm text-gray-200 transition-colors hover:border-gray-600 hover:bg-gray-800/80 focus-ring focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900"
       >
@@ -284,6 +293,7 @@ export function ProviderModelSelect({
                 placeholder={t("search_model_placeholder")}
                 aria-label={t("search_model_aria")}
                 aria-controls={LISTBOX_ID}
+                aria-activedescendant={activeDescendantId}
                 autoComplete="off"
                 spellCheck={false}
                 className="w-full rounded-md border border-gray-700 bg-gray-950/80 py-1.5 pl-8 pr-2 text-sm text-gray-200 placeholder:text-gray-600 focus:border-indigo-500/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/60"

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -841,6 +841,9 @@ export default {
   // ProviderModelSelect
   'select_model_placeholder': 'Select model...',
   'select_model_aria': 'Select model',
+  'search_model_placeholder': 'Search models or providers...',
+  'search_model_aria': 'Search models or providers',
+  'no_models_match': 'No matching models',
 
   // ImagePromptEditor / VideoPromptEditor / DialogueListEditor
   'composition_params': 'Composition',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -842,6 +842,9 @@ export default {
   // ProviderModelSelect
   'select_model_placeholder': '选择模型…',
   'select_model_aria': '选择模型',
+  'search_model_placeholder': '搜索模型或供应商…',
+  'search_model_aria': '搜索模型或供应商',
+  'no_models_match': '未找到匹配模型',
 
   // ImagePromptEditor / VideoPromptEditor / DialogueListEditor
   'composition_params': '构图参数',


### PR DESCRIPTION
## 范围

- 改动：`frontend/src/components/ui/ProviderModelSelect.tsx`（主体）、对应 test、`frontend/src/i18n/{zh,en}/dashboard.ts`
- 不动：`ModelCombobox`（智能体配置已有搜索）、`EndpointSelect`（端点选择，非模型）、所有调用方（自动获益）、后端

## 变更

- `ProviderModelSelect` 内嵌搜索框，按模型名 / 供应商显示名子串匹配（不区分大小写），分组结构、Provider 图标、Check 选中标记保留
- 新增 props：`searchable`（默认 `true`）、`searchThreshold`（默认 `6`）；`options.length >= searchThreshold` 时自动启用
- 打开下拉自动 focus 搜索框；ArrowUp/Down/Home/End/Enter/Escape 键盘导航完整可用
- Enter 检查 `e.nativeEvent.isComposing`，中/日文 IME 选字不会误触发选中
- 搜索 input 携带 `aria-activedescendant`，屏幕阅读器可追踪高亮项
- trigger onClick / Escape / 外部点击 / 选中四条关闭路径统一清空 query
- 新增 zh/en i18n key：`search_model_placeholder` / `search_model_aria` / `no_models_match`

## 验收清单

- [x] 本地已跑相关测试：`pnpm check`（typecheck + ESLint + 451 个测试）通过；`uv run pytest tests/test_i18n_consistency.py tests/test_i18n_assets_namespace.py` 通过
- [x] 手动验证了改动所声称的行为（系统设置 → 媒体模型 / 项目设置 → 模型配置 / `ImageModelDualSelect` 双槽 / 键盘走查 / IME 输入法搜索）
- [x] 新增面向用户文案已加 zh/en 翻译（`search_model_placeholder` / `search_model_aria` / `no_models_match`）
- [x] 无新增 ESLint disable
- [x] CODEOWNERS 要求的 review 已请求

## 已知 defer

无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在模型选择器中新增内置可搜索下拉，可按模型或提供商名称过滤，并支持启用/禁用与阈值控制搜索显示。

* **交互与可访问性**
  * 打开时自动聚焦搜索框，改进键盘导航、IME 行为及焦点/清空逻辑；每个实例使用唯一可访问性 id。

* **本地化**
  * 添加中/英文搜索占位、aria 描述与“无匹配模型”文案。

* **测试**
  * 补充全面单元测试，覆盖搜索、过滤和交互场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->