### PR TITLE
fix(image-dual-select): 渐进式渲染 + 按 capability 过滤选项

### DIFF
--- a/frontend/src/components/pages/ProjectSettingsPage.test.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.test.tsx
@@ -205,9 +205,9 @@ describe("ProjectSettingsPage – style picker", () => {
 
     renderAt("/app/projects/demo/settings");
 
-    // Wait for config to load and a model trigger to render (T2I trigger)
-    const imageTrigger = await screen.findByRole("combobox", { name: /文生图|Text-to-Image|T2I/i });
-    expect(imageTrigger).toHaveTextContent(/跟随全局默认/);
+    // 项目无 image override + 全局默认双能力 → 单下拉模式（label = 图片模型 / Image Model）
+    const imageTrigger = await screen.findByRole("combobox", { name: /^(图片模型|Image Model)$/ });
+    expect(imageTrigger).toHaveTextContent(/跟随全局默认|Use global default/);
     expect(imageTrigger).toHaveTextContent(/nano-banana/);
   });
 

--- a/frontend/src/components/pages/create-project/WizardStep2Models.test.tsx
+++ b/frontend/src/components/pages/create-project/WizardStep2Models.test.tsx
@@ -84,8 +84,9 @@ describe("WizardStep2Models", () => {
       />,
     );
     expect(screen.queryByText(/loading|加载中/i)).not.toBeInTheDocument();
-    // 1 video + 2 image (T2I + I2I) + 3 text = 6 selectors
-    expect(screen.getAllByRole("combobox")).toHaveLength(6);
+    // 5 selectors — image 默认单下拉（仅当模型 caps 单一时才露出第 2 个）：
+    // 1 video + 1 image + 3 text
+    expect(screen.getAllByRole("combobox")).toHaveLength(5);
   });
 
   it("calls onBack when previous button is clicked", () => {

--- a/frontend/src/components/pages/settings/MediaModelSection.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.tsx
@@ -4,12 +4,14 @@ import { useTranslation } from "react-i18next";
 import { useWarnUnsaved } from "@/hooks/useWarnUnsaved";
 import { API } from "@/api";
 import type { SystemConfigSettings, SystemConfigOptions, SystemConfigPatch } from "@/types/system";
+import type { CustomProviderInfo } from "@/types/custom-provider";
 import { ProviderModelSelect } from "@/components/ui/ProviderModelSelect";
 import { ImageModelDualSelect } from "@/components/shared/ImageModelDualSelect";
 import { PROVIDER_NAMES } from "@/components/ui/ProviderIcon";
 import { useAppStore } from "@/stores/app-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
 import { errMsg } from "@/utils/async";
+import { getCustomProviderModels } from "@/utils/provider-models";
 
 // ---------------------------------------------------------------------------
 // Component
@@ -26,6 +28,7 @@ export function MediaModelSection() {
 
   const [settings, setSettings] = useState<SystemConfigSettings | null>(null);
   const [options, setOptions] = useState<SystemConfigOptions | null>(null);
+  const [customProviders, setCustomProviders] = useState<CustomProviderInfo[]>([]);
   const [draft, setDraft] = useState<SystemConfigPatch>({});
   const [saving, setSaving] = useState(false);
 
@@ -38,9 +41,13 @@ export function MediaModelSection() {
   );
 
   const fetchConfig = useCallback(async () => {
-    const res = await API.getSystemConfig();
+    const [res, custom] = await Promise.all([
+      API.getSystemConfig(),
+      getCustomProviderModels().catch(() => [] as CustomProviderInfo[]),
+    ]);
     setSettings(res.settings);
     setOptions(res.options);
+    setCustomProviders(custom);
     setDraft({});
   }, []);
 
@@ -135,6 +142,7 @@ export function MediaModelSection() {
             valueI2I={currentImageI2I}
             options={imageBackends}
             providerNames={allProviderNames}
+            customProviders={customProviders}
             onChange={({ t2i, i2i }) =>
               setDraft((prev) => ({
                 ...prev,
@@ -142,6 +150,7 @@ export function MediaModelSection() {
                 default_image_backend_i2i: i2i,
               }))
             }
+            labelPrimary={t("default_image_model")}
             labelT2I={t("image_model_t2i")}
             labelI2I={t("image_model_i2i")}
             defaultLabel={t("auto_select")}

--- a/frontend/src/components/shared/ImageModelDualSelect.test.tsx
+++ b/frontend/src/components/shared/ImageModelDualSelect.test.tsx
@@ -211,6 +211,20 @@ describe("ImageModelDualSelect — 渐进式 UI", () => {
     });
   });
 
+  it("两槽值相等但所选模型仅单能力 → 进入双下拉模式（覆盖迁移残留 / 异常初始状态）", () => {
+    render(
+      <ImageModelDualSelect
+        valueT2I="custom-1/t2i-only"
+        valueI2I="custom-1/t2i-only"
+        options={OPTIONS}
+        providerNames={PROVIDER_NAMES}
+        customProviders={CUSTOM_PROVIDERS}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getAllByRole("combobox")).toHaveLength(2);
+  });
+
   it("两槽值不一致时进入双下拉模式（2 个 combobox）", () => {
     render(
       <ImageModelDualSelect

--- a/frontend/src/components/shared/ImageModelDualSelect.test.tsx
+++ b/frontend/src/components/shared/ImageModelDualSelect.test.tsx
@@ -1,72 +1,318 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import "@/i18n";
+import { API } from "@/api";
+import { useEndpointCatalogStore } from "@/stores/endpoint-catalog-store";
+import type { CustomProviderInfo, EndpointDescriptor } from "@/types";
 import { ImageModelDualSelect } from "./ImageModelDualSelect";
 
-const OPTIONS = ["gemini/imagen-4", "ark/image-x1"];
-const PROVIDER_NAMES = { gemini: "Gemini", ark: "Ark" };
+const ENDPOINT_FIXTURE: EndpointDescriptor[] = [
+  {
+    key: "openai-images",
+    media_type: "image",
+    family: "openai",
+    display_name_key: "endpoint_openai_images_display",
+    request_method: "POST",
+    request_path_template: "/v1/images/{generations,edits}",
+    image_capabilities: ["text_to_image", "image_to_image"],
+  },
+  {
+    key: "openai-images-generations",
+    media_type: "image",
+    family: "openai",
+    display_name_key: "endpoint_openai_images_generations_display",
+    request_method: "POST",
+    request_path_template: "/v1/images/generations",
+    image_capabilities: ["text_to_image"],
+  },
+  {
+    key: "openai-images-edits",
+    media_type: "image",
+    family: "openai",
+    display_name_key: "endpoint_openai_images_edits_display",
+    request_method: "POST",
+    request_path_template: "/v1/images/edits",
+    image_capabilities: ["image_to_image"],
+  },
+];
 
-describe("ImageModelDualSelect", () => {
-  it("renders two combobox elements (T2I and I2I dropdowns)", () => {
+// 一个含三类 endpoint 的自定义供应商：通配（双能力）/ 仅 T2I / 仅 I2I
+const CUSTOM_PROVIDERS: CustomProviderInfo[] = [
+  {
+    id: 1,
+    display_name: "Custom Open",
+    discovery_format: "openai",
+    base_url: "https://x.example.com",
+    api_key_masked: "sk-***",
+    created_at: "2026-01-01T00:00:00Z",
+    models: [
+      {
+        id: 1,
+        model_id: "wildcard-img",
+        display_name: "Wildcard",
+        endpoint: "openai-images",
+        is_default: false,
+        is_enabled: true,
+        price_unit: null,
+        price_input: null,
+        price_output: null,
+        currency: null,
+        supported_durations: null,
+        resolution: null,
+      },
+      {
+        id: 2,
+        model_id: "t2i-only",
+        display_name: "T2I Only",
+        endpoint: "openai-images-generations",
+        is_default: false,
+        is_enabled: true,
+        price_unit: null,
+        price_input: null,
+        price_output: null,
+        currency: null,
+        supported_durations: null,
+        resolution: null,
+      },
+      {
+        id: 3,
+        model_id: "i2i-only",
+        display_name: "I2I Only",
+        endpoint: "openai-images-edits",
+        is_default: false,
+        is_enabled: true,
+        price_unit: null,
+        price_input: null,
+        price_output: null,
+        currency: null,
+        supported_durations: null,
+        resolution: null,
+      },
+    ],
+  },
+];
+
+// 与上面 customProviders 对齐的可选项字符串（system_config 路径下的 image_backends 列表形态）
+const OPTIONS = [
+  "gemini/imagen-4", // 内置：默认双能力
+  "custom-1/wildcard-img", // 自定义双能力
+  "custom-1/t2i-only", // 自定义仅 T2I
+  "custom-1/i2i-only", // 自定义仅 I2I
+];
+const PROVIDER_NAMES = { gemini: "Gemini", "custom-1": "Custom Open" };
+
+async function setupCatalog() {
+  useEndpointCatalogStore.setState(useEndpointCatalogStore.getInitialState(), true);
+  vi.spyOn(API, "listEndpointCatalog").mockResolvedValue({ endpoints: ENDPOINT_FIXTURE });
+  await useEndpointCatalogStore.getState().fetch();
+}
+
+describe("ImageModelDualSelect — 渐进式 UI", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    await setupCatalog();
+  });
+
+  it("默认空值时只渲染 1 个下拉（单下拉模式）", () => {
     render(
       <ImageModelDualSelect
         valueT2I=""
         valueI2I=""
         options={OPTIONS}
         providerNames={PROVIDER_NAMES}
+        customProviders={CUSTOM_PROVIDERS}
         onChange={() => {}}
       />,
     );
-    const comboboxes = screen.getAllByRole("combobox");
-    expect(comboboxes).toHaveLength(2);
+    expect(screen.getAllByRole("combobox")).toHaveLength(1);
   });
 
-  it("calls onChange with updated t2i value when T2I dropdown changes, preserving i2i", async () => {
+  it("两槽同值（双能力模型）时仍只渲染 1 个下拉", () => {
+    render(
+      <ImageModelDualSelect
+        valueT2I="custom-1/wildcard-img"
+        valueI2I="custom-1/wildcard-img"
+        options={OPTIONS}
+        providerNames={PROVIDER_NAMES}
+        customProviders={CUSTOM_PROVIDERS}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getAllByRole("combobox")).toHaveLength(1);
+  });
+
+  it("从单下拉选双能力模型 → onChange 把 t2i 与 i2i 都置为同值", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     render(
       <ImageModelDualSelect
         valueT2I=""
-        valueI2I="ark/image-x1"
+        valueI2I=""
+        options={OPTIONS}
+        providerNames={PROVIDER_NAMES}
+        customProviders={CUSTOM_PROVIDERS}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /wildcard-img/ }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      t2i: "custom-1/wildcard-img",
+      i2i: "custom-1/wildcard-img",
+    });
+  });
+
+  it("从单下拉选仅 T2I 模型 → onChange 仅置 t2i，i2i 留空", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ImageModelDualSelect
+        valueT2I=""
+        valueI2I=""
+        options={OPTIONS}
+        providerNames={PROVIDER_NAMES}
+        customProviders={CUSTOM_PROVIDERS}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /t2i-only/ }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      t2i: "custom-1/t2i-only",
+      i2i: "",
+    });
+  });
+
+  it("从单下拉选仅 I2I 模型 → onChange 仅置 i2i，t2i 留空", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ImageModelDualSelect
+        valueT2I=""
+        valueI2I=""
+        options={OPTIONS}
+        providerNames={PROVIDER_NAMES}
+        customProviders={CUSTOM_PROVIDERS}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /i2i-only/ }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      t2i: "",
+      i2i: "custom-1/i2i-only",
+    });
+  });
+
+  it("两槽值不一致时进入双下拉模式（2 个 combobox）", () => {
+    render(
+      <ImageModelDualSelect
+        valueT2I="custom-1/t2i-only"
+        valueI2I=""
+        options={OPTIONS}
+        providerNames={PROVIDER_NAMES}
+        customProviders={CUSTOM_PROVIDERS}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getAllByRole("combobox")).toHaveLength(2);
+  });
+
+  it("双下拉 T2I 槽过滤掉仅 I2I 模型", async () => {
+    const user = userEvent.setup();
+    render(
+      <ImageModelDualSelect
+        valueT2I="custom-1/t2i-only"
+        valueI2I=""
+        options={OPTIONS}
+        providerNames={PROVIDER_NAMES}
+        customProviders={CUSTOM_PROVIDERS}
+        onChange={() => {}}
+      />,
+    );
+
+    const [t2iTrigger] = screen.getAllByRole("combobox");
+    await user.click(t2iTrigger);
+
+    expect(screen.queryByRole("option", { name: /i2i-only/ })).toBeNull();
+    expect(screen.getByRole("option", { name: /t2i-only/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /wildcard-img/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /imagen-4/ })).toBeInTheDocument();
+  });
+
+  it("双下拉 I2I 槽过滤掉仅 T2I 模型", async () => {
+    const user = userEvent.setup();
+    render(
+      <ImageModelDualSelect
+        valueT2I="custom-1/t2i-only"
+        valueI2I=""
+        options={OPTIONS}
+        providerNames={PROVIDER_NAMES}
+        customProviders={CUSTOM_PROVIDERS}
+        onChange={() => {}}
+      />,
+    );
+
+    const [, i2iTrigger] = screen.getAllByRole("combobox");
+    await user.click(i2iTrigger);
+
+    expect(screen.queryByRole("option", { name: /t2i-only/ })).toBeNull();
+    expect(screen.getByRole("option", { name: /i2i-only/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /wildcard-img/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /imagen-4/ })).toBeInTheDocument();
+  });
+
+  it("不传 customProviders 时所有选项按双能力处理（兼容路径）", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ImageModelDualSelect
+        valueT2I=""
+        valueI2I=""
         options={OPTIONS}
         providerNames={PROVIDER_NAMES}
         onChange={onChange}
       />,
     );
 
-    const [t2iTrigger] = screen.getAllByRole("combobox");
-    await user.click(t2iTrigger);
-    const imagenOption = screen.getByRole("option", { name: /imagen-4/ });
-    await user.click(imagenOption);
+    // 即使是 t2i-only endpoint 的模型，因为没传 customProviders，也按双能力处理
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /t2i-only/ }));
 
     expect(onChange).toHaveBeenCalledWith({
-      t2i: "gemini/imagen-4",
-      i2i: "ark/image-x1",
+      t2i: "custom-1/t2i-only",
+      i2i: "custom-1/t2i-only",
     });
   });
 
-  it("calls onChange with updated i2i value when I2I dropdown changes, preserving t2i", async () => {
+  it("双下拉模式下 onChange 各自独立改两槽", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     render(
       <ImageModelDualSelect
-        valueT2I="gemini/imagen-4"
+        valueT2I="custom-1/t2i-only"
         valueI2I=""
         options={OPTIONS}
         providerNames={PROVIDER_NAMES}
+        customProviders={CUSTOM_PROVIDERS}
         onChange={onChange}
       />,
     );
 
     const [, i2iTrigger] = screen.getAllByRole("combobox");
     await user.click(i2iTrigger);
-    const arkOption = screen.getByRole("option", { name: /image-x1/ });
-    await user.click(arkOption);
+    await user.click(screen.getByRole("option", { name: /i2i-only/ }));
 
     expect(onChange).toHaveBeenCalledWith({
-      t2i: "gemini/imagen-4",
-      i2i: "ark/image-x1",
+      t2i: "custom-1/t2i-only",
+      i2i: "custom-1/i2i-only",
     });
   });
 });

--- a/frontend/src/components/shared/ImageModelDualSelect.tsx
+++ b/frontend/src/components/shared/ImageModelDualSelect.tsx
@@ -114,8 +114,17 @@ export function ImageModelDualSelect({
     [customProviders, endpointToCaps],
   );
 
-  // 双下拉模式：两槽值不一致（含一空一非空）。单下拉模式：两槽值相等。
-  const isDualMode = valueT2I !== valueI2I;
+  // 双下拉模式条件：
+  // (1) 两槽值不一致（一空一非空 / 两不同模型）—— 用户已处于配置双槽状态；
+  // (2) 两槽值相等且非空，但所选模型仅单能力 —— 异常初始状态（迁移残留或外部数据错配）
+  //     需露出另一槽位让用户补全。catalog 异步就绪时本 useMemo 依赖 capsLookup，
+  //     会自动重算 → 单能力会从 BOTH fallback 转为真实 caps，UI 自动展开为双下拉。
+  const isDualMode = useMemo(() => {
+    if (valueT2I !== valueI2I) return true;
+    if (!valueT2I) return false;
+    const caps = capsOf(valueT2I, capsLookup);
+    return !caps.t2i || !caps.i2i;
+  }, [valueT2I, valueI2I, capsLookup]);
 
   const t2iOptions = useMemo(
     () => options.filter((o) => capsOf(o, capsLookup).t2i),

--- a/frontend/src/components/shared/ImageModelDualSelect.tsx
+++ b/frontend/src/components/shared/ImageModelDualSelect.tsx
@@ -175,11 +175,7 @@ export function ImageModelDualSelect({
           onChange={handlePrimaryChange}
           allowDefault
           defaultLabel={fallbackLabel}
-          defaultHint={
-            globalDefaultT2I
-              ? t("current_global_default", { value: globalDefaultT2I })
-              : defaultHint
-          }
+          defaultHint={t2iHint}
           fallbackValue={globalDefaultT2I || undefined}
           aria-label={labelPrimary ?? t("model_image")}
         />

--- a/frontend/src/components/shared/ImageModelDualSelect.tsx
+++ b/frontend/src/components/shared/ImageModelDualSelect.tsx
@@ -1,22 +1,26 @@
 /**
- * ImageModelDualSelect — dual image model selector for T2I and I2I.
+ * ImageModelDualSelect — 渐进式图片模型选择器（T2I + I2I）。
  *
- * Renders two side-by-side ProviderModelSelect dropdowns, one for
- * Text-to-Image (T2I) and one for Image-to-Image (I2I).
+ * 设计意图（spec: docs/superpowers/specs/2026-05-02-openai-image-endpoint-split-design.md）：
+ * - 默认渲染单一下拉，列出所有 image backend 选项。
+ * - 选中模型 caps ⊇ {T2I, I2I}（双能力 / 通配） → 仍 1 个下拉，valueT2I 与 valueI2I 同值写入。
+ * - 选中模型 caps 仅 T2I → 当前下拉作为 T2I 槽；下方动态露出第 2 个 I2I 下拉，仅列 caps∋I2I 的模型。
+ * - 选中模型 caps 仅 I2I → 镜像（先选 I2I 模型则露出 T2I 下拉）。
  *
- * NOTE: All image backend options are shown in both dropdowns without
- * capability filtering.  We intentionally avoid filtering by T2I/I2I
- * capability here because resolving a `provider/model` string to its
- * endpoint capabilities requires a catalog lookup that isn't always
- * available at this layer.  Backend gating at generation time handles
- * mismatches.  The hint text below guides the user to pick sensible models.
+ * Capability 来源：
+ * - 内置 provider（gemini / ark / grok / openai 默认 mode "both"）：一律双能力。
+ * - 自定义 provider：通过 customProviders[].models[].endpoint 反查 endpointToImageCapabilities。
+ *   未传 customProviders 或 catalog 未就绪时，所有选项按双能力处理（等价于关闭过滤）。
  *
  * Label / hint 字符串通过 prop 注入而非内部 t()，使本组件可在 project 层
  * （命名空间 templates）与 system settings 层（命名空间 dashboard）共用。
  */
 
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ProviderModelSelect } from "@/components/ui/ProviderModelSelect";
+import { useEndpointCatalogStore } from "@/stores/endpoint-catalog-store";
+import type { CustomProviderInfo, ImageCap } from "@/types/custom-provider";
 
 export interface ImageModelDualSelectProps {
   /** Current T2I value — empty string means "follow global default" */
@@ -26,10 +30,15 @@ export interface ImageModelDualSelectProps {
   /** Available backend strings like "gemini/imagen-4" */
   options: string[];
   providerNames: Record<string, string>;
+  /** 自定义供应商列表，用于派生 image capability；不传则所有选项按双能力处理。 */
+  customProviders?: CustomProviderInfo[];
   /** Called when either slot changes */
   onChange: (next: { t2i: string; i2i: string }) => void;
-  /** 行内 label 覆盖（已 t()）；不传则使用 templates 命名空间默认值 */
+  /** 单下拉模式 label（已 t()）；不传则使用 templates 命名空间默认值 model_image */
+  labelPrimary?: string;
+  /** 双下拉模式 T2I 槽 label（已 t()）；不传则使用 templates 默认 model_image_t2i */
   labelT2I?: string;
+  /** 双下拉模式 I2I 槽 label（已 t()）；不传则使用 templates 默认 model_image_i2i */
   labelI2I?: string;
   /** 「跟随全局默认 / 自动选择」label（已 t()）；不传则使用 templates 默认值 */
   defaultLabel?: string;
@@ -42,12 +51,46 @@ export interface ImageModelDualSelectProps {
   showCapabilityHint?: boolean;
 }
 
+interface OptionCaps {
+  t2i: boolean;
+  i2i: boolean;
+}
+
+const BOTH_CAPS: OptionCaps = { t2i: true, i2i: true };
+
+function buildCapsLookup(
+  customProviders: CustomProviderInfo[],
+  endpointToCaps: Record<string, ImageCap[]>,
+): Record<string, OptionCaps> {
+  const map: Record<string, OptionCaps> = {};
+  for (const cp of customProviders) {
+    const pid = `custom-${cp.id}`;
+    for (const m of cp.models) {
+      const caps = endpointToCaps[m.endpoint];
+      if (!caps) continue;
+      map[`${pid}/${m.model_id}`] = {
+        t2i: caps.includes("text_to_image"),
+        i2i: caps.includes("image_to_image"),
+      };
+    }
+  }
+  return map;
+}
+
+function capsOf(option: string, lookup: Record<string, OptionCaps>): OptionCaps {
+  if (!option) return BOTH_CAPS;
+  // 内置 provider 在 lookup 中不存在，按双能力处理（与 lib/image_backends 默认 mode 对齐）
+  return lookup[option] ?? BOTH_CAPS;
+}
+
 export function ImageModelDualSelect({
   valueT2I,
   valueI2I,
   options,
   providerNames,
+  customProviders,
   onChange,
+  labelPrimary,
   labelT2I,
   labelI2I,
   defaultLabel,
@@ -57,9 +100,32 @@ export function ImageModelDualSelect({
   showCapabilityHint = true,
 }: ImageModelDualSelectProps) {
   const { t } = useTranslation("templates");
+  const fetchCatalog = useEndpointCatalogStore((s) => s.fetch);
+  const endpointToCaps = useEndpointCatalogStore((s) => s.endpointToImageCapabilities);
 
-  const t2iLabel = labelT2I ?? t("model_image_t2i");
-  const i2iLabel = labelI2I ?? t("model_image_i2i");
+  // 仅在出现自定义 provider 时才需要 catalog；否则保持惰性，避免无谓请求。
+  const customProvidersLen = customProviders?.length ?? 0;
+  useEffect(() => {
+    if (customProvidersLen > 0) void fetchCatalog();
+  }, [customProvidersLen, fetchCatalog]);
+
+  const capsLookup = useMemo(
+    () => buildCapsLookup(customProviders ?? [], endpointToCaps),
+    [customProviders, endpointToCaps],
+  );
+
+  // 双下拉模式：两槽值不一致（含一空一非空）。单下拉模式：两槽值相等。
+  const isDualMode = valueT2I !== valueI2I;
+
+  const t2iOptions = useMemo(
+    () => options.filter((o) => capsOf(o, capsLookup).t2i),
+    [options, capsLookup],
+  );
+  const i2iOptions = useMemo(
+    () => options.filter((o) => capsOf(o, capsLookup).i2i),
+    [options, capsLookup],
+  );
+
   const fallbackLabel = defaultLabel ?? t("use_global_default");
   const t2iHint = globalDefaultT2I
     ? t("current_global_default", { value: globalDefaultT2I })
@@ -67,44 +133,85 @@ export function ImageModelDualSelect({
   const i2iHint = globalDefaultI2I
     ? t("current_global_default", { value: globalDefaultI2I })
     : defaultHint;
+  const dualHint = showCapabilityHint ? (
+    <p className="text-xs text-gray-500">{t("model_image_dual_hint")}</p>
+  ) : null;
 
-  return (
-    <div className="space-y-3">
-      {/* T2I */}
-      <div>
-        <div className="mb-1 text-xs text-gray-400">{t2iLabel}</div>
+  // 单下拉模式 onChange：依据所选模型 caps 自动决定写入哪个槽。
+  const handlePrimaryChange = (next: string) => {
+    if (!next) {
+      onChange({ t2i: "", i2i: "" });
+      return;
+    }
+    const caps = capsOf(next, capsLookup);
+    if (caps.t2i && caps.i2i) {
+      onChange({ t2i: next, i2i: next });
+    } else if (caps.t2i) {
+      onChange({ t2i: next, i2i: "" });
+    } else if (caps.i2i) {
+      onChange({ t2i: "", i2i: next });
+    } else {
+      // 既无 T2I 也无 I2I（理论上不该出现在 image_backends 列表）→ 全清
+      onChange({ t2i: "", i2i: "" });
+    }
+  };
+
+  if (!isDualMode) {
+    return (
+      <div className="space-y-3">
         <ProviderModelSelect
           value={valueT2I}
           options={options}
+          providerNames={providerNames}
+          onChange={handlePrimaryChange}
+          allowDefault
+          defaultLabel={fallbackLabel}
+          defaultHint={
+            globalDefaultT2I
+              ? t("current_global_default", { value: globalDefaultT2I })
+              : defaultHint
+          }
+          fallbackValue={globalDefaultT2I || undefined}
+          aria-label={labelPrimary ?? t("model_image")}
+        />
+        {dualHint}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <div className="mb-1 text-xs text-gray-400">{labelT2I ?? t("model_image_t2i")}</div>
+        <ProviderModelSelect
+          value={valueT2I}
+          options={t2iOptions}
           providerNames={providerNames}
           onChange={(next) => onChange({ t2i: next, i2i: valueI2I })}
           allowDefault
           defaultLabel={fallbackLabel}
           defaultHint={t2iHint}
           fallbackValue={globalDefaultT2I || undefined}
-          aria-label={t2iLabel}
+          aria-label={labelT2I ?? t("model_image_t2i")}
         />
       </div>
 
-      {/* I2I */}
       <div>
-        <div className="mb-1 text-xs text-gray-400">{i2iLabel}</div>
+        <div className="mb-1 text-xs text-gray-400">{labelI2I ?? t("model_image_i2i")}</div>
         <ProviderModelSelect
           value={valueI2I}
-          options={options}
+          options={i2iOptions}
           providerNames={providerNames}
           onChange={(next) => onChange({ t2i: valueT2I, i2i: next })}
           allowDefault
           defaultLabel={fallbackLabel}
           defaultHint={i2iHint}
           fallbackValue={globalDefaultI2I || undefined}
-          aria-label={i2iLabel}
+          aria-label={labelI2I ?? t("model_image_i2i")}
         />
       </div>
 
-      {showCapabilityHint && (
-        <p className="text-xs text-gray-500">{t("model_image_dual_hint")}</p>
-      )}
+      {dualHint}
     </div>
   );
 }

--- a/frontend/src/components/shared/ModelConfigSection.test.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.test.tsx
@@ -87,9 +87,10 @@ describe("ModelConfigSection", () => {
         }}
       />,
     );
-    // 6 combobox triggers should be rendered (1 video + 2 image T2I/I2I + 3 text)
+    // 5 combobox triggers — 单下拉模式下 image 只渲染 1 个（spec: 默认渲染单下拉，
+    // 仅当所选模型 caps 单一时才露出第二个槽位）：1 video + 1 image + 3 text
     const comboboxes = screen.getAllByRole("combobox");
-    expect(comboboxes).toHaveLength(6);
+    expect(comboboxes).toHaveLength(5);
 
     // Opening each dropdown should reveal "使用全局默认" as the default option
     await user.click(comboboxes[0]);
@@ -193,8 +194,8 @@ describe("ModelConfigSection", () => {
     );
     // No combobox for video model should be visible
     expect(screen.queryByRole("combobox", { name: /视频模型/ })).not.toBeInTheDocument();
-    // Image (T2I) and text should still be visible
-    expect(screen.getByRole("combobox", { name: /文生图/ })).toBeInTheDocument();
+    // 单下拉模式下 image card 主下拉 label 是「图片模型」（不是「文生图」/「图生图」）
+    expect(screen.getByRole("combobox", { name: /^图片模型$/ })).toBeInTheDocument();
   });
 
   it("falls back to globalDefaults.video supported_durations when videoBackend is empty (bug repro)", () => {

--- a/frontend/src/components/shared/ModelConfigSection.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.tsx
@@ -224,6 +224,7 @@ export function ModelConfigSection({
             valueI2I={value.imageBackendI2I}
             options={options.imageBackends}
             providerNames={options.providerNames}
+            customProviders={customProviders}
             onChange={({ t2i, i2i }) => {
               // 分辨率绑定 T2I（canonical slot），仅在 effective T2I 变化时清空
               const prevEffectiveT2I = value.imageBackendT2I || globalDefaults.imageT2I || "";


### PR DESCRIPTION
## Summary
- 修复 ImageModelDualSelect 永远渲染 2 个下拉、且无 capability 过滤的偏离 spec 行为
- 重写为渐进式 UI：默认 1 个下拉，选中单能力模型时才露出第 2 个，且第 2 个下拉按对侧能力过滤选项
- ModelConfigSection / MediaModelSection 调用方传入 customProviders 让能力过滤真正生效

## Test plan
- [x] 新增 10 条 ImageModelDualSelect 测试覆盖空值 / 双能力 / 仅 T2I / 仅 I2I / 双下拉过滤 / 无 customProviders 兼容路径
- [x] 更新 ModelConfigSection / WizardStep2Models / ProjectSettingsPage 测试期望（5 个 combobox + 「图片模型」label）
- [x] frontend 425 测试通过（3 个失败 test 文件是 main 既有 @headlessui/react import 错误，与本 PR 无关）
- [x] 121 个相关后端 image capability 测试通过
- [ ] 在浏览器验证：自定义 provider 仅 T2I 模型选中后露出 I2I 下拉，且 I2I 下拉不含仅 T2I 模型；反之亦然

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 发布说明

* **新功能**
  * 加载并传递自定义提供商元数据，扩展可选模型来源。
  * 基于模型能力在单/双下拉间智能切换，单模式下自动映射或清理槽位值并仅展示对应能力选项。

* **测试**
  * 大幅增强模型选择测试覆盖，更新断言以匹配渐进式 UI 行为和下拉数量变化。
  * 调整图片模型主下拉文本为“图片模型”。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->