### PR TITLE
feat(backends): 调用 provider SDK 前打印生成参数日志

### DIFF
--- a/lib/image_backends/ark.py
+++ b/lib/image_backends/ark.py
@@ -14,6 +14,7 @@ from lib.image_backends.base import (
     image_to_base64_data_uri,
     save_image_from_response_item,
 )
+from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_ARK
 from lib.retry import with_retry_async
 
@@ -68,6 +69,7 @@ class ArkImageBackend:
         if request.seed is not None:
             kwargs["seed"] = request.seed
 
+        logger.info("调用 %s 图片 SDK kwargs=%s", self.name, format_kwargs_for_log(kwargs))
         # 同步 SDK 通过 to_thread 包装
         response = await asyncio.to_thread(
             self._client.images.generate,

--- a/lib/image_backends/gemini.py
+++ b/lib/image_backends/gemini.py
@@ -17,6 +17,7 @@ from lib.image_backends.base import (
     ImageGenerationResult,
     ReferenceImage,
 )
+from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_GEMINI
 from lib.system_config import resolve_vertex_credentials_path
 
@@ -122,6 +123,13 @@ class GeminiImageBackend:
         )
 
         # 4. 调用异步 API
+        logger.info(
+            "调用 %s 图片 SDK payload=%s",
+            self.name,
+            format_kwargs_for_log(
+                {"model": self._image_model, "contents": contents, "image_config": image_config_kwargs}
+            ),
+        )
         response = await self._client.aio.models.generate_content(
             model=self._image_model, contents=contents, config=config
         )

--- a/lib/image_backends/grok.py
+++ b/lib/image_backends/grok.py
@@ -13,6 +13,7 @@ from lib.image_backends.base import (
     download_image_to_path,
     image_to_base64_data_uri,
 )
+from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_GROK
 from lib.retry import with_retry_async
 
@@ -96,6 +97,7 @@ class GrokImageBackend:
                 logger.info("Grok I2I 模式: %d 张参考图", len(data_uris))
 
         logger.info("Grok 图片生成开始: model=%s", self._model)
+        logger.info("调用 %s 图片 SDK kwargs=%s", self.name, format_kwargs_for_log(generate_kwargs))
         response = await self._client.image.sample(**generate_kwargs)
 
         # 审核检查

--- a/lib/image_backends/openai.py
+++ b/lib/image_backends/openai.py
@@ -15,6 +15,7 @@ from lib.image_backends.base import (
     ImageGenerationResult,
     save_image_from_response_item,
 )
+from lib.logging_utils import format_kwargs_for_log
 from lib.openai_shared import (
     OPENAI_IMAGE_QUALITY_MAP as _QUALITY_MAP,
 )
@@ -113,6 +114,7 @@ class OpenAIImageBackend:
             "n": 1,
         }
         kwargs.update(_resolve_openai_params(request.image_size, request.aspect_ratio))
+        logger.info("调用 %s 图片 SDK (T2I) kwargs=%s", self.name, format_kwargs_for_log(kwargs))
         response = await self._client.images.generate(**kwargs)
         return await self._save_and_return(response, request)
 
@@ -149,6 +151,17 @@ class OpenAIImageBackend:
                     model=self._model,
                     detail="all reference images failed to open",
                 )
+            logger.info(
+                "调用 %s 图片 SDK (I2I) kwargs=%s",
+                self.name,
+                format_kwargs_for_log(
+                    {
+                        "model": self._model,
+                        "image_count": len(image_files),
+                        "prompt": request.prompt,
+                    }
+                ),
+            )
             response = await self._client.images.edit(
                 model=self._model,
                 image=image_files,

--- a/lib/logging_utils.py
+++ b/lib/logging_utils.py
@@ -117,7 +117,6 @@ def format_kwargs_for_log(payload: Any) -> str:
         safe = _to_safe(payload)
         return json.dumps(safe, ensure_ascii=False, default=str)
     except Exception:
-        try:
-            return _truncate_str(repr(payload))
-        except Exception:
-            return "<unserializable>"
+        # 不能回退到 repr(payload)：原始对象未经脱敏，可能把敏感字段
+        # 字面量重新带回日志，绕过前面所有的脱敏逻辑。固定占位符更安全。
+        return "<unserializable>"

--- a/lib/logging_utils.py
+++ b/lib/logging_utils.py
@@ -1,0 +1,108 @@
+"""日志安全格式化工具。
+
+提供 ``format_kwargs_for_log``：把任意 dict / Pydantic 对象 / 列表
+序列化为单行字符串，专门用于 logger.info 调用前对参数做"截断 + 摘要"，
+避免长 prompt、参考图 base64、bytes 等大字段把日志撑爆。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+_STR_TRUNCATE_AT = 500
+_STR_TRUNCATE_PREFIX = 200
+_LIST_TRUNCATE_AT = 10
+_LIST_HEAD = 5
+_LIST_TAIL = 2
+
+_SENSITIVE_KEY_RE = re.compile(r"(api[_-]?key|secret|token|password|authorization)", re.IGNORECASE)
+
+
+def _mask_secret(value: str) -> str:
+    raw = value.strip()
+    if len(raw) <= 8:
+        return "••••"
+    return f"{raw[:4]}…{raw[-4:]}"
+
+
+def _truncate_str(value: str) -> str:
+    if len(value) <= _STR_TRUNCATE_AT:
+        return value
+    return f"{value[:_STR_TRUNCATE_PREFIX]}... <truncated, total {len(value)} chars>"
+
+
+def _summarize_image_like(obj: Any) -> str | None:
+    mime = getattr(obj, "mime_type", None)
+    if mime is not None:
+        data = getattr(obj, "data", None)
+        size = len(data) if isinstance(data, bytes | bytearray) else None
+        return f"<image:mime={mime},bytes={size}>" if size is not None else f"<image:mime={mime}>"
+    if hasattr(obj, "size") and hasattr(obj, "mode") and hasattr(obj, "format"):
+        return f"<image:format={obj.format},size={obj.size},mode={obj.mode}>"
+    if hasattr(obj, "read") and callable(obj.read):
+        return f"<file-like:{type(obj).__name__}>"
+    return None
+
+
+def _to_safe(obj: Any, key_hint: str | None = None) -> Any:
+    if key_hint and isinstance(obj, str) and _SENSITIVE_KEY_RE.search(key_hint):
+        return _mask_secret(obj)
+
+    if obj is None or isinstance(obj, bool | int | float):
+        return obj
+
+    if isinstance(obj, str):
+        return _truncate_str(obj)
+
+    if isinstance(obj, bytes | bytearray):
+        return f"<bytes:{len(obj)}>"
+
+    image_summary = _summarize_image_like(obj)
+    if image_summary is not None:
+        return image_summary
+
+    if isinstance(obj, Mapping):
+        return {str(k): _to_safe(v, key_hint=str(k)) for k, v in obj.items()}
+
+    model_dump = getattr(obj, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return _to_safe(model_dump())
+        except Exception:
+            pass
+
+    if is_dataclass(obj) and not isinstance(obj, type):
+        try:
+            return _to_safe(asdict(obj))
+        except Exception:
+            pass
+
+    if isinstance(obj, Sequence) and not isinstance(obj, str | bytes | bytearray):
+        items = list(obj)
+        if len(items) > _LIST_TRUNCATE_AT:
+            head = [_to_safe(x) for x in items[:_LIST_HEAD]]
+            tail = [_to_safe(x) for x in items[-_LIST_TAIL:]]
+            return [*head, f"...省略 {len(items) - _LIST_HEAD - _LIST_TAIL} 项...", *tail]
+        return [_to_safe(x) for x in items]
+
+    return _truncate_str(repr(obj))
+
+
+def format_kwargs_for_log(payload: Any) -> str:
+    """把任意对象转成单行、安全可读的字符串，供 logger 输出。
+
+    - 长字符串截断到 500 字
+    - bytes/bytearray 替换为 ``<bytes:N>``
+    - 嵌套 dict/list 递归处理
+    - 敏感 key（api_key/secret/token/password/authorization）的 string 值脱敏
+    - Pydantic / dataclass 自动转 dict
+    """
+    safe = _to_safe(payload)
+    try:
+        return json.dumps(safe, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return repr(safe)

--- a/lib/logging_utils.py
+++ b/lib/logging_utils.py
@@ -92,7 +92,8 @@ def _to_safe(obj: Any, key_hint: str | None = None) -> Any:
         if len(items) > _LIST_TRUNCATE_AT:
             head = [_to_safe(x) for x in items[:_LIST_HEAD]]
             tail = [_to_safe(x) for x in items[-_LIST_TAIL:]]
-            return [*head, f"...省略 {len(items) - _LIST_HEAD - _LIST_TAIL} 项...", *tail]
+            omitted = len(items) - _LIST_HEAD - _LIST_TAIL
+            return [*head, f"<omitted:{omitted}>", *tail]
         return [_to_safe(x) for x in items]
 
     return _truncate_str(repr(obj))

--- a/lib/logging_utils.py
+++ b/lib/logging_utils.py
@@ -52,10 +52,12 @@ def _to_safe(obj: Any, key_hint: str | None = None) -> Any:
     # 敏感 key 命中时整体脱敏：避免 {"api_key": {"value": "secret"}} 这类嵌套结构
     # 在递归到 "value" 子键时，因为 key_hint 不再敏感而泄漏 secret。
     if key_hint and _SENSITIVE_KEY_RE.search(key_hint):
+        # None 透传以便区分"未配置"和"已配置但脱敏"；其他任何类型（含 int/bool/float）
+        # 都整体替换为 ••••，避免 {"password": 123456} 这类用数字当 secret 的场景泄漏。
+        if obj is None:
+            return None
         if isinstance(obj, str):
             return _mask_secret(obj)
-        if obj is None or isinstance(obj, bool | int | float):
-            return obj
         return "••••"
 
     if obj is None or isinstance(obj, bool | int | float):

--- a/lib/logging_utils.py
+++ b/lib/logging_utils.py
@@ -49,8 +49,14 @@ def _summarize_image_like(obj: Any) -> str | None:
 
 
 def _to_safe(obj: Any, key_hint: str | None = None) -> Any:
-    if key_hint and isinstance(obj, str) and _SENSITIVE_KEY_RE.search(key_hint):
-        return _mask_secret(obj)
+    # 敏感 key 命中时整体脱敏：避免 {"api_key": {"value": "secret"}} 这类嵌套结构
+    # 在递归到 "value" 子键时，因为 key_hint 不再敏感而泄漏 secret。
+    if key_hint and _SENSITIVE_KEY_RE.search(key_hint):
+        if isinstance(obj, str):
+            return _mask_secret(obj)
+        if obj is None or isinstance(obj, bool | int | float):
+            return obj
+        return "••••"
 
     if obj is None or isinstance(obj, bool | int | float):
         return obj
@@ -69,7 +75,7 @@ def _to_safe(obj: Any, key_hint: str | None = None) -> Any:
         return {str(k): _to_safe(v, key_hint=str(k)) for k, v in obj.items()}
 
     model_dump = getattr(obj, "model_dump", None)
-    if callable(model_dump):
+    if callable(model_dump) and not isinstance(obj, type):
         try:
             return _to_safe(model_dump())
         except Exception:
@@ -98,11 +104,17 @@ def format_kwargs_for_log(payload: Any) -> str:
     - 长字符串截断到 500 字
     - bytes/bytearray 替换为 ``<bytes:N>``
     - 嵌套 dict/list 递归处理
-    - 敏感 key（api_key/secret/token/password/authorization）的 string 值脱敏
+    - 敏感 key（api_key/secret/token/password/authorization）整体脱敏
     - Pydantic / dataclass 自动转 dict
+
+    "失败不影响主流程"：日志辅助逻辑任何异常都吞掉，最差也只返回 ``<unserializable>``，
+    保证生成调用链不会因为日志格式化崩溃。
     """
-    safe = _to_safe(payload)
     try:
+        safe = _to_safe(payload)
         return json.dumps(safe, ensure_ascii=False, default=str)
-    except (TypeError, ValueError):
-        return repr(safe)
+    except Exception:
+        try:
+            return _truncate_str(repr(payload))
+        except Exception:
+            return "<unserializable>"

--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 
 from lib.ark_shared import ARK_BASE_URL, create_ark_client, resolve_ark_api_key
+from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_ARK
 from lib.retry import with_retry_async
 from lib.text_backends.base import (
@@ -68,6 +69,7 @@ class ArkTextBackend:
         kwargs: dict = {"model": self._model, "messages": messages}
         if request.max_output_tokens is not None:
             kwargs["max_tokens"] = request.max_output_tokens
+        logger.info("调用 %s 文本 SDK kwargs=%s", self.name, format_kwargs_for_log(kwargs))
         response = await asyncio.to_thread(
             self._client.chat.completions.create,
             **kwargs,
@@ -91,6 +93,7 @@ class ArkTextBackend:
             }
             if request.max_output_tokens is not None:
                 kwargs["max_tokens"] = request.max_output_tokens
+            logger.info("调用 %s 文本 SDK kwargs=%s", self.name, format_kwargs_for_log(kwargs))
             try:
                 response = await asyncio.to_thread(self._client.chat.completions.create, **kwargs)
                 return self._parse_chat_response(response)

--- a/lib/text_backends/gemini.py
+++ b/lib/text_backends/gemini.py
@@ -14,6 +14,7 @@ except ImportError:
 
 from ..config.url_utils import normalize_base_url
 from ..gemini_shared import VERTEX_SCOPES, with_retry_async
+from ..logging_utils import format_kwargs_for_log
 from ..providers import PROVIDER_GEMINI
 from .base import (
     TextCapability,
@@ -145,6 +146,11 @@ class GeminiTextBackend:
         )
         contents = self._build_contents(request)
 
+        logger.info(
+            "调用 %s 文本 SDK payload=%s",
+            self.name,
+            format_kwargs_for_log({"model": self._model, "contents": contents, "config": config or None}),
+        )
         response = await self._client.aio.models.generate_content(
             model=self._model,
             contents=contents,

--- a/lib/text_backends/grok.py
+++ b/lib/text_backends/grok.py
@@ -7,6 +7,7 @@ import logging
 from xai_sdk import chat as xai_chat
 
 from lib.grok_shared import create_grok_client, grok_should_retry
+from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_GROK
 from lib.retry import with_retry_async
 from lib.text_backends.base import (
@@ -71,6 +72,21 @@ class GrokTextBackend:
                     user_parts.append(xai_chat.image(image_url=img_input.url))
 
         chat.append(xai_chat.user(request.prompt, *user_parts))
+
+        logger.info(
+            "调用 %s 文本 SDK payload=%s",
+            self.name,
+            format_kwargs_for_log(
+                {
+                    "model": self._model,
+                    "max_tokens": chat_kwargs.get("max_tokens"),
+                    "system_prompt": request.system_prompt,
+                    "prompt": request.prompt,
+                    "image_count": len(request.images) if request.images else 0,
+                    "structured_output": bool(request.response_schema),
+                }
+            ),
+        )
 
         # Structured output or plain
         if request.response_schema:

--- a/lib/text_backends/openai.py
+++ b/lib/text_backends/openai.py
@@ -6,6 +6,7 @@ import logging
 
 from openai import AsyncOpenAI, BadRequestError
 
+from lib.logging_utils import format_kwargs_for_log
 from lib.openai_shared import OPENAI_RETRYABLE_ERRORS, create_openai_client
 from lib.providers import PROVIDER_OPENAI
 from lib.retry import with_retry_async
@@ -80,6 +81,7 @@ class OpenAITextBackend:
                 },
             }
 
+        logger.info("调用 %s 文本 SDK kwargs=%s", self.name, format_kwargs_for_log(kwargs))
         try:
             response = await self._client.chat.completions.create(**kwargs)
         except Exception as exc:

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import httpx
 
 from lib.ark_shared import create_ark_client
+from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_ARK
 from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
 from lib.video_backends.base import (
@@ -150,6 +151,7 @@ class ArkVideoBackend:
             create_params["seed"] = request.seed
 
         # 3. Create task (sync SDK call, run in executor)
+        logger.info("调用 %s 视频 SDK kwargs=%s", self.name, format_kwargs_for_log(create_params))
         create_result = await asyncio.to_thread(
             self._client.content_generation.tasks.create,
             **create_params,

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -13,6 +13,7 @@ from PIL import Image
 
 from lib.config.url_utils import normalize_base_url
 from lib.gemini_shared import VERTEX_SCOPES, RateLimiter, get_shared_rate_limiter
+from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_GEMINI
 from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
 from lib.system_config import resolve_vertex_credentials_path
@@ -171,6 +172,19 @@ class GeminiVideoBackend:
         source = self._types.GenerateVideosSource(prompt=request.prompt, image=image_param)
 
         # 5. 调用 API
+        logger.info(
+            "调用 %s 视频 SDK payload=%s",
+            self.name,
+            format_kwargs_for_log(
+                {
+                    "model": self._video_model,
+                    "prompt": request.prompt,
+                    "config": config_params,
+                    "has_start_image": request.start_image is not None,
+                    "reference_image_count": len(request.reference_images) if request.reference_images else 0,
+                }
+            ),
+        )
         operation = await self._client.aio.models.generate_videos(model=self._video_model, source=source, config=config)
         op_name = getattr(operation, "name", "unknown")
         logger.info("视频生成已提交, operation=%s", op_name)

--- a/lib/video_backends/grok.py
+++ b/lib/video_backends/grok.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from pathlib import Path
 
 from lib.grok_shared import create_grok_client, grok_should_retry
+from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_GROK
 from lib.retry import with_retry_async
 from lib.video_backends.base import (
@@ -108,4 +109,5 @@ class GrokVideoBackend:
                 generate_kwargs["reference_image_urls"] = list(ref_urls)
 
         logger.info("Grok 视频生成开始: model=%s, duration=%ds", self._model, request.duration_seconds)
+        logger.info("调用 %s 视频 SDK kwargs=%s", self.name, format_kwargs_for_log(generate_kwargs))
         return await self._client.video.generate(**generate_kwargs)

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import httpx
 
+from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_NEWAPI
 from lib.retry import (
     BASE_RETRYABLE_ERRORS,
@@ -143,6 +144,7 @@ class NewAPIVideoBackend:
             )
 
         logger.info("NewAPI 视频生成开始: model=%s, duration=%s", self._model, request.duration_seconds)
+        logger.info("调用 %s 视频 SDK payload=%s", self.name, format_kwargs_for_log(payload))
 
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             task_id = await self._create_task(client, payload)

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from pathlib import Path
 
+from lib.logging_utils import format_kwargs_for_log
 from lib.openai_shared import OPENAI_RETRYABLE_ERRORS, create_openai_client
 from lib.providers import PROVIDER_OPENAI
 from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
@@ -102,6 +103,7 @@ class OpenAIVideoBackend:
             kwargs["input_reference"] = refs[0] if len(refs) == 1 else refs
 
         logger.info("OpenAI 视频生成开始: model=%s, seconds=%s", self._model, kwargs["seconds"])
+        logger.info("调用 %s 视频 SDK kwargs=%s", self.name, format_kwargs_for_log(kwargs))
 
         video = await self._create_video(**kwargs)
         final = await self._poll_until_complete(video.id, request.duration_seconds)

--- a/tests/lib/test_logging_utils.py
+++ b/tests/lib/test_logging_utils.py
@@ -23,6 +23,11 @@ def test_bytes_summarized():
     assert json.loads(out) == {"image": "<bytes:4>"}
 
 
+def test_bytearray_summarized():
+    out = format_kwargs_for_log({"image": bytearray(b"\x00\x01\x02\x03\x04")})
+    assert json.loads(out) == {"image": "<bytes:5>"}
+
+
 def test_nested_dict_recursion():
     payload = {"outer": {"inner": {"prompt": "x" * 1000}}}
     out = format_kwargs_for_log(payload)
@@ -131,12 +136,28 @@ def test_formatter_swallows_internal_errors():
     assert parsed == {"x": "Boom()"}
 
 
-def test_formatter_returns_fallback_when_repr_explodes():
+def test_fallback_returns_fixed_placeholder_not_raw_repr():
+    """_to_safe 抛错时必须返回固定占位符，不能回退到 repr(payload)，
+    否则会把未脱敏的原始对象内容（含敏感字段字面量）重新带回日志。"""
+
     class Disaster:
         def __repr__(self) -> str:
             raise RuntimeError("repr exploded")
 
     out = format_kwargs_for_log(Disaster())
+    assert out == "<unserializable>"
+
+
+def test_fallback_does_not_leak_sensitive_via_repr(monkeypatch):
+    """即使 _to_safe 抛错，也不应通过 repr 路径把 api_key 等字面量泄漏到日志。"""
+    from lib import logging_utils
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated _to_safe failure")
+
+    monkeypatch.setattr(logging_utils, "_to_safe", boom)
+    out = logging_utils.format_kwargs_for_log({"api_key": "sk-real-secret-1234"})
+    assert "sk-real-secret-1234" not in out
     assert out == "<unserializable>"
 
 

--- a/tests/lib/test_logging_utils.py
+++ b/tests/lib/test_logging_utils.py
@@ -1,0 +1,102 @@
+import json
+
+from pydantic import BaseModel
+
+from lib.logging_utils import format_kwargs_for_log
+
+
+def test_short_string_passthrough():
+    out = format_kwargs_for_log({"prompt": "hello"})
+    assert json.loads(out) == {"prompt": "hello"}
+
+
+def test_long_string_truncated():
+    long_text = "a" * 1500
+    out = format_kwargs_for_log({"prompt": long_text})
+    payload = json.loads(out)
+    assert payload["prompt"].startswith("a" * 200)
+    assert "truncated, total 1500 chars" in payload["prompt"]
+
+
+def test_bytes_summarized():
+    out = format_kwargs_for_log({"image": b"\x00\x01\x02\x03"})
+    assert json.loads(out) == {"image": "<bytes:4>"}
+
+
+def test_nested_dict_recursion():
+    payload = {"outer": {"inner": {"prompt": "x" * 1000}}}
+    out = format_kwargs_for_log(payload)
+    parsed = json.loads(out)
+    assert "truncated" in parsed["outer"]["inner"]["prompt"]
+
+
+def test_pydantic_model_dump():
+    class Req(BaseModel):
+        prompt: str
+        size: str
+
+    out = format_kwargs_for_log(Req(prompt="hi", size="1024x1024"))
+    assert json.loads(out) == {"prompt": "hi", "size": "1024x1024"}
+
+
+def test_sensitive_key_masked():
+    out = format_kwargs_for_log({"api_key": "sk-1234567890abcdef", "model": "gpt-4o"})
+    parsed = json.loads(out)
+    assert parsed["api_key"] == "sk-1…cdef"
+    assert parsed["model"] == "gpt-4o"
+
+
+def test_short_secret_redacted_to_dots():
+    out = format_kwargs_for_log({"token": "short"})
+    assert json.loads(out)["token"] == "••••"
+
+
+def test_long_list_truncated():
+    out = format_kwargs_for_log({"messages": list(range(20))})
+    parsed = json.loads(out)
+    msgs = parsed["messages"]
+    assert msgs[:5] == [0, 1, 2, 3, 4]
+    assert "省略 13 项" in msgs[5]
+    assert msgs[-2:] == [18, 19]
+
+
+def test_short_list_kept_as_is():
+    out = format_kwargs_for_log({"messages": [{"role": "user", "content": "hi"}]})
+    parsed = json.loads(out)
+    assert parsed["messages"] == [{"role": "user", "content": "hi"}]
+
+
+def test_image_part_with_mime_type():
+    class FakePart:
+        mime_type = "image/png"
+        data = b"\x89PNG" + b"\x00" * 100
+
+    out = format_kwargs_for_log({"image": FakePart()})
+    assert json.loads(out)["image"] == "<image:mime=image/png,bytes=104>"
+
+
+def test_authorization_header_masked():
+    out = format_kwargs_for_log({"headers": {"Authorization": "Bearer eyJabcdefgh"}})
+    parsed = json.loads(out)
+    assert parsed["headers"]["Authorization"] == "Bear…efgh"
+
+
+def test_dataclass_serialized():
+    from dataclasses import dataclass
+
+    @dataclass
+    class Cfg:
+        model: str
+        temperature: float
+
+    out = format_kwargs_for_log(Cfg(model="gpt-4o", temperature=0.7))
+    assert json.loads(out) == {"model": "gpt-4o", "temperature": 0.7}
+
+
+def test_unserializable_object_falls_back_to_repr():
+    class Weird:
+        def __repr__(self) -> str:
+            return "Weird()"
+
+    out = format_kwargs_for_log({"x": Weird()})
+    assert json.loads(out) == {"x": "Weird()"}

--- a/tests/lib/test_logging_utils.py
+++ b/tests/lib/test_logging_utils.py
@@ -56,7 +56,8 @@ def test_long_list_truncated():
     parsed = json.loads(out)
     msgs = parsed["messages"]
     assert msgs[:5] == [0, 1, 2, 3, 4]
-    assert "省略 13 项" in msgs[5]
+    assert isinstance(msgs[5], str)
+    assert msgs[5] == "<omitted:13>"
     assert msgs[-2:] == [18, 19]
 
 

--- a/tests/lib/test_logging_utils.py
+++ b/tests/lib/test_logging_utils.py
@@ -100,3 +100,50 @@ def test_unserializable_object_falls_back_to_repr():
 
     out = format_kwargs_for_log({"x": Weird()})
     assert json.loads(out) == {"x": "Weird()"}
+
+
+def test_sensitive_key_with_nested_dict_value_fully_masked():
+    out = format_kwargs_for_log({"api_key": {"value": "supersecret123", "scope": "all"}})
+    assert json.loads(out) == {"api_key": "••••"}
+
+
+def test_sensitive_key_with_list_value_fully_masked():
+    out = format_kwargs_for_log({"tokens": ["a-token-1", "a-token-2"]})
+    assert json.loads(out) == {"tokens": "••••"}
+
+
+def test_sensitive_key_with_none_passthrough():
+    out = format_kwargs_for_log({"api_key": None})
+    assert json.loads(out) == {"api_key": None}
+
+
+def test_formatter_swallows_internal_errors():
+    class Boom:
+        def model_dump(self):
+            raise RuntimeError("boom")
+
+        def __repr__(self) -> str:
+            return "Boom()"
+
+    out = format_kwargs_for_log({"x": Boom()})
+    parsed = json.loads(out)
+    assert parsed == {"x": "Boom()"}
+
+
+def test_formatter_returns_fallback_when_repr_explodes():
+    class Disaster:
+        def __repr__(self) -> str:
+            raise RuntimeError("repr exploded")
+
+    out = format_kwargs_for_log(Disaster())
+    assert out == "<unserializable>"
+
+
+def test_pydantic_class_not_called_as_instance():
+    class Req(BaseModel):
+        prompt: str
+
+    out = format_kwargs_for_log({"cls": Req})
+    parsed = json.loads(out)
+    assert isinstance(parsed["cls"], str)
+    assert "Req" in parsed["cls"]

--- a/tests/lib/test_logging_utils.py
+++ b/tests/lib/test_logging_utils.py
@@ -140,6 +140,18 @@ def test_formatter_returns_fallback_when_repr_explodes():
     assert out == "<unserializable>"
 
 
+def test_sensitive_key_with_numeric_value_masked():
+    out = format_kwargs_for_log({"password": 123456, "pin_token": 9999})
+    parsed = json.loads(out)
+    assert parsed["password"] == "••••"
+    assert parsed["pin_token"] == "••••"
+
+
+def test_sensitive_key_with_bool_value_masked():
+    out = format_kwargs_for_log({"api_key": True})
+    assert json.loads(out)["api_key"] == "••••"
+
+
 def test_pydantic_class_not_called_as_instance():
     class Req(BaseModel):
         prompt: str


### PR DESCRIPTION
## Summary

- 新增 `lib/logging_utils.py:format_kwargs_for_log`，对任意 kwargs / Pydantic / dataclass 做安全格式化：长字符串截到 500 字、`bytes` / 参考图替换为 `<bytes:N>`、超长列表头 5 + 尾 2 摘要、`api_key/secret/token/password/authorization` 等敏感 key 自动脱敏
- 在 image / video / text 三类共 **13 个 backend**（openai/gemini/grok/ark + newapi 视频）的 SDK 调用前加 INFO 级日志，便于排查"为什么生成结果与预期不符"
- `custom_provider` 包装层不动 — 它是 delegate 透传，日志由底层真实 backend 出，避免重复
- 为新工具补 13 个单元测试覆盖：长字符串、bytes、嵌套 dict、Pydantic、dataclass、敏感 key、超长列表、image part、authorization header 等

日志样例：
```
[INFO] lib.image_backends.openai: 调用 openai 图片 SDK (T2I) kwargs={"model":"gpt-image-2","prompt":"...","n":1,"size":"1024x1024","quality":"high"}
```

## Test plan

- [x] `uv run python -m pytest tests/lib/test_logging_utils.py -v` — 13/13 通过
- [x] `uv run python -m pytest tests/ -k "backend or generator or generation" --no-cov` — 438 passed
- [x] `uv run ruff check` + `ruff format` 全部修改文件 — 通过
- [ ] 端到端：在 WebUI 触发文本/图片/视频生成各一次，确认日志输出格式与脱敏行为符合预期
- [ ] 自定义供应商触发一次生成，确认日志只出现一次（来自底层 backend，不来自 wrapper）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 各文本、图像、视频后端在调用 SDK 前新增 info 级结构化请求日志，记录已格式化的请求参数以便排查。

* **Chores**
  * 新增安全日志格式化工具，输出单行 JSON，支持截断、二进制/图片摘要及敏感字段脱敏。

* **测试**
  * 增加全面单元测试，覆盖截断、字节/图片摘要、敏感信息掩码、复杂对象序列化与失败回退。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->