### PR TITLE
feat(sdk): claude-agent-sdk 升级到 0.1.76 并适配新字段

### DIFF
--- a/docs/superpowers/plans/2026-05-07-sdk-0.1.76-upgrade.md
+++ b/docs/superpowers/plans/2026-05-07-sdk-0.1.76-upgrade.md
@@ -1,0 +1,627 @@
+# claude-agent-sdk 0.1.76 升级与新特性适配 — 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 `claude-agent-sdk` 依赖下限提升到 0.1.76，并消费两个低风险新字段（`ResultMessage.api_error_status` 透传 SSE + 错误日志；`ToolPermissionContext.decision_reason` 拼到 `_can_use_tool` default-deny 提示）。
+
+**Architecture:** 后端单进程改动。pyproject 改下限，`uv sync` 重锁。`server/agent_runtime/service.py` 在 `_build_status_event_payload` 和 result 错误日志路径消费 `api_error_status`；`server/agent_runtime/session_manager.py` 在 `_can_use_tool` default-deny 分支用 `getattr` 读 `decision_reason`。所有新字段读取都做 None 兜底，向后兼容。
+
+**Tech Stack:** Python 3.x, claude-agent-sdk 0.1.76, FastAPI/SSE, pytest (asyncio_mode=auto), uv 包管理, ruff lint/format。
+
+**参考 spec:** `docs/superpowers/specs/2026-05-07-sdk-0.1.76-upgrade-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 类型 | 责任 |
+|---|---|---|
+| `pyproject.toml` | 修改 | 依赖下限 `>=0.1.73` → `>=0.1.76` |
+| `uv.lock` | 修改 | `uv sync` 产物，0.1.74 → 0.1.76 |
+| `server/agent_runtime/service.py` | 修改 | `_build_status_event_payload` 注入 `api_error_status` 字段；`result` 消息错误路径新增结构化 `logger.warning` |
+| `server/agent_runtime/session_manager.py` | 修改 | `_can_use_tool` default-deny 分支读 `getattr(_context, "decision_reason", None)` 拼到 hint |
+| `tests/agent_runtime/test_sdk_0_1_76_features.py` | 创建 | 4 个单测覆盖新字段消费 |
+
+---
+
+## Task 1: 升级 SDK 依赖到 0.1.76
+
+**Files:**
+- Modify: `pyproject.toml`（搜索字符串 `claude-agent-sdk>=0.1.73`）
+- Modify: `uv.lock`（自动产物）
+
+- [ ] **Step 1: 修改 pyproject.toml**
+
+定位文件中 `"claude-agent-sdk>=0.1.73",` 一行，替换为 `"claude-agent-sdk>=0.1.76",`。
+
+可用以下命令验证当前内容：
+
+```bash
+grep -n "claude-agent-sdk" pyproject.toml
+```
+
+预期：输出 `"claude-agent-sdk>=0.1.73",`（升级前）。
+
+用 Edit 工具改成：
+
+```
+"claude-agent-sdk>=0.1.76",
+```
+
+- [ ] **Step 2: 重锁依赖**
+
+```bash
+uv sync
+```
+
+预期：`Resolved N packages` 输出，`claude-agent-sdk` 版本变为 `0.1.76`。
+
+- [ ] **Step 3: 验证 lock 已升级**
+
+```bash
+grep -A1 'name = "claude-agent-sdk"' uv.lock | head -10
+```
+
+预期：能看到 `claude_agent_sdk-0.1.76` 字符串（sdist URL 或版本号）。
+
+- [ ] **Step 4: 跑现有 agent_runtime 测试套件回归**
+
+```bash
+uv run python -m pytest tests/agent_runtime/ -v
+```
+
+预期：全部通过，无 ImportError，无 AttributeError。如出现失败，**停下来定位**，不要绕过——很可能是 0.1.74 atexit / `MemoryObjectReceiveStream` / `created_at` 修复导致的行为差异。
+
+- [ ] **Step 5: 跑 agent_session_store 测试回归**
+
+```bash
+uv run python -m pytest tests/agent_session_store/ -v
+```
+
+预期：全部通过。该模块用 `fold_session_summary`、`project_key_for_directory`，需确认 0.1.76 这两个 API 未变。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "chore(deps): bump claude-agent-sdk >=0.1.73 → >=0.1.76"
+```
+
+---
+
+## Task 2: 新增测试文件骨架 + api_error_status 透传单测（红）
+
+**Files:**
+- Create: `tests/agent_runtime/test_sdk_0_1_76_features.py`
+
+- [ ] **Step 1: 创建测试文件**
+
+用 Write 工具创建 `tests/agent_runtime/test_sdk_0_1_76_features.py`，写入以下内容：
+
+```python
+"""SDK 0.1.76 新字段消费的单元测试。
+
+覆盖：
+- ResultMessage.api_error_status 透传到 SSE 状态 payload
+- ToolPermissionContext.decision_reason 拼到 _can_use_tool default-deny hint
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from server.agent_runtime.service import AssistantService
+
+
+class TestApiErrorStatusInStatusPayload:
+    """0.1.76 新字段 api_error_status 透传到 SSE payload。"""
+
+    def test_api_error_status_present_when_set(self):
+        result_message: dict[str, Any] = {
+            "type": "result",
+            "subtype": "error_during_execution",
+            "is_error": True,
+            "api_error_status": 429,
+            "stop_reason": "api_error",
+        }
+        payload = AssistantService._build_status_event_payload(
+            status="error",
+            session_id="sess-1",
+            result_message=result_message,
+        )
+        assert payload["api_error_status"] == 429
+
+    def test_api_error_status_absent_when_none(self):
+        result_message: dict[str, Any] = {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "api_error_status": None,
+        }
+        payload = AssistantService._build_status_event_payload(
+            status="completed",
+            session_id="sess-2",
+            result_message=result_message,
+        )
+        assert "api_error_status" not in payload
+
+    def test_api_error_status_absent_when_field_missing(self):
+        # 老 SDK / 老消息没有 api_error_status 字段
+        result_message: dict[str, Any] = {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+        }
+        payload = AssistantService._build_status_event_payload(
+            status="completed",
+            session_id="sess-3",
+            result_message=result_message,
+        )
+        assert "api_error_status" not in payload
+```
+
+- [ ] **Step 2: 跑测试，确认前两个 fail**
+
+```bash
+uv run python -m pytest tests/agent_runtime/test_sdk_0_1_76_features.py -v
+```
+
+预期：
+- `test_api_error_status_present_when_set` **FAIL**：`KeyError: 'api_error_status'` 或 `assert ... in payload`
+- `test_api_error_status_absent_when_none` **PASS**（payload 本来就不含该键）
+- `test_api_error_status_absent_when_field_missing` **PASS**（同上）
+
+记录第一个测试 FAIL 的具体错误信息，证明红→绿循环开始。
+
+---
+
+## Task 3: 实现 api_error_status 透传（绿）
+
+**Files:**
+- Modify: `server/agent_runtime/service.py`（`_build_status_event_payload`，约 line 725-748）
+
+- [ ] **Step 1: 改造 `_build_status_event_payload`**
+
+定位 `service.py` 中以下原始片段：
+
+```python
+        return {
+            "status": status,
+            "subtype": subtype,
+            "stop_reason": stop_reason,
+            "is_error": is_error,
+            "session_id": session_id,
+        }
+```
+
+替换为：
+
+```python
+        payload: dict[str, Any] = {
+            "status": status,
+            "subtype": subtype,
+            "stop_reason": stop_reason,
+            "is_error": is_error,
+            "session_id": session_id,
+        }
+        api_error_status = message.get("api_error_status")  # SDK 0.1.76+
+        if api_error_status is not None:
+            payload["api_error_status"] = api_error_status
+        return payload
+```
+
+注意：`message` 变量已在函数顶部定义为 `result_message if isinstance(result_message, dict) else {}`，可直接用。
+
+- [ ] **Step 2: 跑测试，确认全部 pass**
+
+```bash
+uv run python -m pytest tests/agent_runtime/test_sdk_0_1_76_features.py::TestApiErrorStatusInStatusPayload -v
+```
+
+预期：3 个测试全部 PASS。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/agent_runtime/service.py tests/agent_runtime/test_sdk_0_1_76_features.py
+git commit -m "feat(sdk): 透传 ResultMessage.api_error_status 到 SSE 状态 payload"
+```
+
+---
+
+## Task 4: 错误路径结构化日志单测（红）
+
+**Files:**
+- Modify: `tests/agent_runtime/test_sdk_0_1_76_features.py`（追加测试类）
+
+- [ ] **Step 1: 追加日志测试类**
+
+在测试文件末尾追加：
+
+```python
+
+
+class TestResultErrorLogging:
+    """result 消息错误路径写结构化 logger.warning，含 api_error_status。"""
+
+    @pytest.mark.asyncio
+    async def test_logger_warning_emitted_on_error_with_api_status(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path,
+    ):
+        from unittest.mock import MagicMock
+
+        service = AssistantService(project_root=tmp_path)
+        projector = MagicMock()
+        projector.apply_message.return_value = {}  # 无 patch/delta/question
+
+        result_message: dict[str, Any] = {
+            "type": "result",
+            "subtype": "error_during_execution",
+            "is_error": True,
+            "api_error_status": 429,
+            "stop_reason": "api_error",
+        }
+        with caplog.at_level(logging.WARNING, logger="server.agent_runtime.service"):
+            events, terminal = await service._dispatch_live_message(
+                message=result_message,
+                projector=projector,
+                session_id="sess-err",
+            )
+        assert terminal is True
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            getattr(r, "api_error_status", None) == 429 for r in warnings
+        ), f"expected a warning with api_error_status=429, got {[r.__dict__ for r in warnings]}"
+
+    @pytest.mark.asyncio
+    async def test_no_warning_on_completed_result(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path,
+    ):
+        from unittest.mock import MagicMock
+
+        service = AssistantService(project_root=tmp_path)
+        projector = MagicMock()
+        projector.apply_message.return_value = {}
+
+        result_message: dict[str, Any] = {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+        }
+        with caplog.at_level(logging.WARNING, logger="server.agent_runtime.service"):
+            await service._dispatch_live_message(
+                message=result_message,
+                projector=projector,
+                session_id="sess-ok",
+            )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert not warnings, f"unexpected warnings on completed result: {warnings}"
+```
+
+> ℹ️ 已核实：`_dispatch_live_message` 是 `service.py:477` 中 result 消息的 async 处理入口；`AssistantStreamProjector.apply_message`（`stream_projector.py:455`）是同步方法，可直接 MagicMock。`asyncio_mode = "auto"` 已在项目 pytest 配置生效，所以 `@pytest.mark.asyncio` 也可省略；保留写法确保意图明确。
+
+- [ ] **Step 2: 跑测试，确认 1 个 fail**
+
+```bash
+uv run python -m pytest tests/agent_runtime/test_sdk_0_1_76_features.py::TestResultErrorLogging -v
+```
+
+预期：
+- `test_logger_warning_emitted_on_error_with_api_status` **FAIL**：当前 result 路径没有 `logger.warning` 调用
+- `test_no_warning_on_completed_result` **PASS**：当前没有日志，所以不会有 warning
+
+---
+
+## Task 5: 实现错误路径结构化日志（绿）
+
+**Files:**
+- Modify: `server/agent_runtime/service.py`（result 消息分支，参考 spec 3.2 段落）
+
+- [ ] **Step 1: 定位 result 消息分支**
+
+```bash
+grep -n 'msg_type == "result"' server/agent_runtime/service.py
+```
+
+预期输出指向 `service.py:540` 附近。原始片段（约 line 540-551）：
+
+```python
+        if msg_type == "result":
+            events.append(
+                self._sse_event(
+                    "status",
+                    self._build_status_event_payload(
+                        status=self._resolve_result_status(message),
+                        session_id=session_id,
+                        result_message=message,
+                    ),
+                )
+            )
+            return events, True
+```
+
+- [ ] **Step 2: 替换为含日志版本**
+
+```python
+        if msg_type == "result":
+            status = self._resolve_result_status(message)
+            if status == "error":
+                logger.warning(
+                    "assistant session result error",
+                    extra={
+                        "session_id": session_id,
+                        "subtype": message.get("subtype"),
+                        "is_error": message.get("is_error"),
+                        "api_error_status": message.get("api_error_status"),  # SDK 0.1.76+
+                        "stop_reason": message.get("stop_reason"),
+                    },
+                )
+            events.append(
+                self._sse_event(
+                    "status",
+                    self._build_status_event_payload(
+                        status=status,
+                        session_id=session_id,
+                        result_message=message,
+                    ),
+                )
+            )
+            return events, True
+```
+
+注意：`logger` 已在文件顶部 `logger = logging.getLogger(__name__)` 定义，无需新 import。
+
+- [ ] **Step 3: 跑测试，确认全部 pass**
+
+```bash
+uv run python -m pytest tests/agent_runtime/test_sdk_0_1_76_features.py -v
+```
+
+预期：5 个测试全部 PASS（前 3 个 + 新加 2 个）。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/agent_runtime/service.py tests/agent_runtime/test_sdk_0_1_76_features.py
+git commit -m "feat(sdk): result 错误路径写结构化日志，附 api_error_status"
+```
+
+---
+
+## Task 6: decision_reason 拼到 default-deny 单测（红）
+
+**Files:**
+- Modify: `tests/agent_runtime/test_sdk_0_1_76_features.py`
+
+- [ ] **Step 1: 追加 can_use_tool 测试类**
+
+在测试文件末尾追加：
+
+```python
+
+
+class TestCanUseToolDecisionReason:
+    """0.1.74 新字段 ToolPermissionContext.decision_reason 拼到 default-deny hint。"""
+
+    @pytest.mark.asyncio
+    async def test_default_deny_includes_decision_reason(self, tmp_path):
+        from server.agent_runtime.session_manager import SessionManager
+        from server.agent_runtime.session_store import SessionMetaStore
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        sm = SessionManager(
+            project_root=tmp_path,
+            data_dir=data_dir,
+            meta_store=SessionMetaStore(),
+        )
+        callback = await sm._build_can_use_tool_callback(session_id="sess-x")
+        ctx = SimpleNamespace(decision_reason="No matching allow rule")
+        result = await callback("Bash", {"command": "rm -rf /"}, ctx)
+        assert hasattr(result, "message"), f"expected PermissionResultDeny, got {type(result)}"
+        assert "No matching allow rule" in result.message
+        assert "上游决策原因" in result.message
+
+    @pytest.mark.asyncio
+    async def test_default_deny_without_decision_reason_does_not_raise(self, tmp_path):
+        from server.agent_runtime.session_manager import SessionManager
+        from server.agent_runtime.session_store import SessionMetaStore
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        sm = SessionManager(
+            project_root=tmp_path,
+            data_dir=data_dir,
+            meta_store=SessionMetaStore(),
+        )
+        callback = await sm._build_can_use_tool_callback(session_id="sess-y")
+        ctx = SimpleNamespace()  # no decision_reason
+        result = await callback("Bash", {"command": "echo hi"}, ctx)
+        assert hasattr(result, "message")
+        assert "未授权的工具调用" in result.message
+        assert "上游决策原因" not in result.message
+```
+
+> ℹ️ 已核实：`SessionManager.__init__(project_root, data_dir, meta_store)`（`session_manager.py:341`），`data_dir` 不会自动 mkdir（service 层负责），所以测试里要先 `mkdir(parents=True, exist_ok=True)`。`SessionMetaStore()` 默认构造无参可直接调。
+
+- [ ] **Step 2: 跑测试，确认 1 个 fail**
+
+```bash
+uv run python -m pytest tests/agent_runtime/test_sdk_0_1_76_features.py::TestCanUseToolDecisionReason -v
+```
+
+预期：
+- `test_default_deny_includes_decision_reason` **FAIL**：当前 hint 不含 "上游决策原因" 字符串
+- `test_default_deny_without_decision_reason_does_not_raise` **PASS**：当前 hint 本来就不含这串
+
+---
+
+## Task 7: 实现 decision_reason 拼接（绿）
+
+**Files:**
+- Modify: `server/agent_runtime/session_manager.py`（`_can_use_tool` default-deny 分支，约 line 1772-1782）
+
+- [ ] **Step 1: 定位 default-deny 分支**
+
+```bash
+grep -n "未授权的工具调用" server/agent_runtime/session_manager.py
+```
+
+预期输出指向 `session_manager.py:1774` 附近。
+
+原始片段（约 line 1772-1782）：
+
+```python
+            if PermissionResultDeny is not None:
+                hint = (
+                    f"未授权的工具调用: {tool_name}"
+                    f"({json.dumps(input_data, ensure_ascii=False)[:200]})\n"
+                    "当前 Bash 白名单仅允许以下命令:\n"
+                    "  - python .claude/skills/<skill>/scripts/<script>.py <args>（必须用相对路径）\n"
+                    "  - ffmpeg / ffprobe\n"
+                    "其他 Bash 命令均不可用。"
+                    "请检查命令格式是否匹配白名单规则。"
+                )
+                return PermissionResultDeny(message=hint)
+```
+
+- [ ] **Step 2: 替换为含 decision_reason 拼接版本**
+
+```python
+            if PermissionResultDeny is not None:
+                reason = getattr(_context, "decision_reason", None)  # SDK 0.1.74+
+                reason_line = f"上游决策原因: {reason}\n" if reason else ""
+                hint = (
+                    f"未授权的工具调用: {tool_name}"
+                    f"({json.dumps(input_data, ensure_ascii=False)[:200]})\n"
+                    f"{reason_line}"
+                    "当前 Bash 白名单仅允许以下命令:\n"
+                    "  - python .claude/skills/<skill>/scripts/<script>.py <args>（必须用相对路径）\n"
+                    "  - ffmpeg / ffprobe\n"
+                    "其他 Bash 命令均不可用。"
+                    "请检查命令格式是否匹配白名单规则。"
+                )
+                return PermissionResultDeny(message=hint)
+```
+
+- [ ] **Step 3: 跑测试，确认全部 pass**
+
+```bash
+uv run python -m pytest tests/agent_runtime/test_sdk_0_1_76_features.py -v
+```
+
+预期：7 个测试全部 PASS。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/agent_runtime/session_manager.py tests/agent_runtime/test_sdk_0_1_76_features.py
+git commit -m "feat(sdk): _can_use_tool default-deny 拼接 ToolPermissionContext.decision_reason"
+```
+
+---
+
+## Task 8: 全套 lint + 覆盖率 + 端到端验收
+
+**Files:**
+- 无代码改动（除非 lint 自动修复）
+
+- [ ] **Step 1: 跑 ruff check 修过的文件**
+
+```bash
+uv run ruff check server/agent_runtime/service.py server/agent_runtime/session_manager.py tests/agent_runtime/test_sdk_0_1_76_features.py
+```
+
+预期：`All checks passed!`。如有错误，按提示修复。
+
+- [ ] **Step 2: 跑 ruff format**
+
+```bash
+uv run ruff format server/agent_runtime/service.py server/agent_runtime/session_manager.py tests/agent_runtime/test_sdk_0_1_76_features.py
+```
+
+预期：`X file(s) left unchanged` 或显示 reformatted。如 reformat，把改动也加进下一个 commit。
+
+- [ ] **Step 3: 跑全套 agent_runtime 测试 + 覆盖率**
+
+```bash
+uv run python -m pytest tests/agent_runtime/ --cov=server/agent_runtime --cov-report=term -v
+```
+
+预期：
+- 全部测试 PASS（包括新加的 7 个）
+- agent_runtime 模块覆盖率 ≥ 升级前水平（不要求上升，只求不下降）
+
+记录覆盖率数字到 commit message 或 PR 描述。
+
+- [ ] **Step 4: 端到端手动验收（可选，但推荐）**
+
+启动开发服务器：
+
+```bash
+uv run uvicorn server.app:app --reload --reload-dir server --reload-dir lib --port 1241
+```
+
+打开前端（如已 `pnpm dev`），跑一次完整 assistant 对话：
+- 选一个项目，发一条消息
+- 等回复完成（看到 result 事件）
+- 在浏览器 devtools Network 面板找到 `/api/v1/assistant/sessions/{id}/stream` SSE，
+  确认正常事件流没有破坏
+- 如果想验 `api_error_status` 透传，可临时把 API key 设错触发 401/429，
+  确认 SSE status 事件 payload 含 `api_error_status` 字段
+
+如果端到端有异常，**不要 force ahead**——回到失败位置定位根因。
+
+- [ ] **Step 5: 提交 lint/format 改动（如有）**
+
+```bash
+git status
+# 如有 ruff format 改动：
+git add -u
+git commit -m "style: ruff format 0.1.76 升级相关文件"
+```
+
+如无改动，跳过此步。
+
+- [ ] **Step 6: 检查 git log 概览**
+
+```bash
+git log --oneline main..HEAD
+```
+
+预期能看到（顺序无所谓）：
+1. `chore(deps): bump claude-agent-sdk >=0.1.73 → >=0.1.76`
+2. `feat(sdk): 透传 ResultMessage.api_error_status 到 SSE 状态 payload`
+3. `feat(sdk): result 错误路径写结构化日志，附 api_error_status`
+4. `feat(sdk): _can_use_tool default-deny 拼接 ToolPermissionContext.decision_reason`
+5.（可选）`style: ruff format 0.1.76 升级相关文件`
+6.（可选 docs commit 已在 brainstorming 阶段做完）
+
+实施完成。
+
+---
+
+## 验收清单（与 spec 对齐）
+
+- [ ] `pyproject.toml` 下限到 `>=0.1.76`
+- [ ] `uv.lock` `claude-agent-sdk` 版本块为 0.1.76
+- [ ] `_build_status_event_payload` 透传 `api_error_status`（None 时不写键）
+- [ ] result 错误路径写结构化 `logger.warning`，含 `api_error_status` 字段
+- [ ] `_can_use_tool` default-deny 拼 `decision_reason`（无字段时不抛异常）
+- [ ] 新增 7 个单测全部通过
+- [ ] `tests/agent_runtime/` 现有测试无回归
+- [ ] `tests/agent_session_store/` 现有测试无回归
+- [ ] ruff check / format 全绿
+- [ ] agent_runtime 覆盖率不下降
+- [ ] 端到端 SSE 流式回复跑通（手动）
+
+不在范围：前端对 `api_error_status` 的展示、`include_hook_events` 集成等
+（详见 spec "不在本范围内" 段）。

--- a/docs/superpowers/specs/2026-05-07-sdk-0.1.76-upgrade-design.md
+++ b/docs/superpowers/specs/2026-05-07-sdk-0.1.76-upgrade-design.md
@@ -1,0 +1,273 @@
+# claude-agent-sdk 0.1.76 升级与新特性适配设计
+
+- **日期**：2026-05-07
+- **分支**：`feature/sdk-0.1.76`
+- **范围**：依赖升级 + 低风险新特性采纳；不引入 breaking change，无前端 schema 强制变更
+
+## 背景
+
+项目当前 `pyproject.toml` 写 `claude-agent-sdk>=0.1.73`，`uv.lock` 锁定 0.1.74。
+PyPI 已发布 0.1.74 / 0.1.75 / 0.1.76 三个新版本。本设计将依赖下限提升到 0.1.76，
+并主动消费两个对项目有直接价值的新字段。
+
+## 0.1.74 → 0.1.76 关键变更
+
+### 0.1.74（重大版本）
+
+新特性：
+
+- `include_hook_events` 选项：CLI 把 PreToolUse / PostToolUse / Stop 等 hook 事件
+  作为 `HookEventMessage` yield 给消费者
+- `"defer"` hook decision + `DeferredToolUse` 数据类
+- `strict_mcp_config` 选项：仅使用 `mcp_servers` 显式传入的 MCP 服务器
+- `ToolPermissionContext` 新字段：`decision_reason`、`blocked_path`、`title`、
+  `display_name`、`description`
+- `updatedToolOutput`：PostToolUse hook 可改写任何工具的输出
+- `xhigh` effort level（Opus 4.7 专属）
+- atexit 子进程清理，防 orphan `claude` 进程
+
+Bug fix：
+
+- `ResourceWarning: Unclosed <MemoryObjectReceiveStream>` on disconnect
+- `list_sessions()` 中 `created_at=None` 修复（扫整个 head buffer）
+
+### 0.1.75
+
+仅 bundled CLI 升级到 2.1.131。
+
+### 0.1.76
+
+新特性：
+
+- `ResultMessage.api_error_status: int | None`：当 `is_error=True` 时携带
+  HTTP 状态码（如 429、500、529），用于错误分类
+
+Bug fix：
+
+- `ToolPermissionContext.suggestions` 反序列化为 `PermissionUpdate` 实例
+  （之前是 raw dict，会让 callback 调用 `from_dict()` / `updated_permissions`
+  抛 AttributeError）
+
+Bundled CLI 升级到 2.1.132。
+
+## 项目当前 SDK 用法盘点
+
+### 已使用
+
+- `ClaudeSDKClient`、`ClaudeAgentOptions`（`session_manager.py`）
+- 4 个 `HookMatcher`：file_access、json_validation、json_post_validation、
+  keep_stream_open（`session_manager.py:_build_options`）
+- `can_use_tool` 回调：处理 AskUserQuestion + default-deny 兜底
+  （`session_manager.py:_build_can_use_tool_callback`）
+- `PermissionResultAllow` / `PermissionResultDeny`
+- `setting_sources=["project"]` + `SystemPromptPreset(claude_code)`
+- `session_store` 自定义包装（`agent_session_store/`）+ `session_store_flush`
+- `tag_session`（0.1.73 引入）
+- `list_sessions` / `delete_session` / `delete_session_via_store` /
+  `list_sessions_from_store`（`service.py`）
+- `fold_session_summary`、`project_key_for_directory`（`agent_session_store/`）
+- `ResultMessage` 处理：读取 `subtype` + `is_error`（`service.py` /
+  `session_manager.py` 多处）
+
+### 未使用
+
+- `mcp_servers`（→ `strict_mcp_config` 不直接相关）
+- `effort` level（→ `xhigh` 暂无场景）
+- `include_hook_events`
+- `"defer"` decision、`DeferredToolUse`
+- `updatedToolOutput`
+- `ToolPermissionContext.suggestions`（→ 0.1.76 修复对项目无即时影响，
+  但仍是正确性增益）
+
+## 升级目标
+
+### 被动收益（仅版本号 bump 即得）
+
+- 0.1.74 `MemoryObjectReceiveStream` 关闭修复 — 项目频繁开关
+  `ClaudeSDKClient`，命中
+- 0.1.74 atexit 子进程清理 — 防 dev 环境 reload 时遗留 `claude` 进程
+- 0.1.74 `list_sessions` `created_at=None` 修复 — 项目用 `list_sessions`
+- 0.1.76 `suggestions` 反序列化修复 — 即使当前不读 `suggestions`，
+  类型正确性提升
+
+### 主动采纳（低风险新特性）
+
+1. `ResultMessage.api_error_status` 透传到 SSE 状态事件 + 后端日志
+2. `ToolPermissionContext.decision_reason` 拼接到 `_can_use_tool` 的
+   default-deny 提示
+
+### 显式不采纳（本轮）
+
+- `include_hook_events`：需要前端新事件渲染组件 + transcript schema 适配，
+  工作量大，单独立项
+- `"defer"` / `DeferredToolUse`：当前无异步 hook 决策需求
+- `updatedToolOutput`：当前无改写工具输出需求
+- `strict_mcp_config`：项目未使用 MCP
+- `xhigh` effort：模型选择器在前端，未在 SDK 层面使用 effort
+
+## 改动清单
+
+### 1. `pyproject.toml`
+
+```diff
+- "claude-agent-sdk>=0.1.73",
++ "claude-agent-sdk>=0.1.76",
+```
+
+保留无上限风格，与 0.1.73 → 0.1.74 历史一致。
+
+### 2. `uv.lock`
+
+执行 `uv sync` 重锁。预期：
+
+- `claude-agent-sdk` 版本块 0.1.74 → 0.1.76
+- 隐式引入 bundled CLI 2.1.132
+- 不主动调整其他依赖
+
+### 3. `server/agent_runtime/service.py`
+
+#### 3.1 `_build_status_event_payload` (≈ line 725)
+
+读取 `result_message.get("api_error_status")`，仅当非 None 时加入 payload。
+为 None 时不写键，避免给前端塞噪声字段。
+
+```python
+api_error_status = message.get("api_error_status")  # SDK 0.1.76+
+payload = {
+    "status": status,
+    "subtype": subtype,
+    "stop_reason": stop_reason,
+    "is_error": is_error,
+    "session_id": session_id,
+}
+if api_error_status is not None:
+    payload["api_error_status"] = api_error_status
+return payload
+```
+
+#### 3.2 错误路径结构化日志（新增）
+
+`service.py:540-551` 当前在收到 `result` 消息时仅构造 SSE 事件，无日志。
+`session_manager.py:_handle_special_message` / `_finalize_turn` 同样无日志。
+
+在 `service.py:540` 处理 `msg_type == "result"` 的分支里，新增一行
+**仅在错误时触发**的结构化 `logger.warning`：
+
+```python
+if msg_type == "result":
+    status = self._resolve_result_status(message)
+    if status == "error":
+        logger.warning(
+            "assistant session result error",
+            extra={
+                "session_id": session_id,
+                "subtype": message.get("subtype"),
+                "is_error": message.get("is_error"),
+                "api_error_status": message.get("api_error_status"),  # 0.1.76+
+                "stop_reason": message.get("stop_reason"),
+            },
+        )
+    events.append(
+        self._sse_event(
+            "status",
+            self._build_status_event_payload(
+                status=status,
+                session_id=session_id,
+                result_message=message,
+            ),
+        )
+    )
+    return events, True
+```
+
+`session_manager.py` 侧不新增日志（避免重复打印；service.py 是更靠近用户的
+出口边界）。
+
+### 4. `server/agent_runtime/session_manager.py`
+
+#### 4.1 `_can_use_tool` default-deny 分支 (≈ line 1772)
+
+`_context` 在 SDK 0.1.74+ 上有 `decision_reason` 属性，老版本/老消息无该字段。
+用 `getattr` 兜底，仅当 reason 非空时拼到 hint。
+
+```python
+if PermissionResultDeny is not None:
+    reason = getattr(_context, "decision_reason", None)  # SDK 0.1.74+
+    reason_line = f"上游决策原因: {reason}\n" if reason else ""
+    hint = (
+        f"未授权的工具调用: {tool_name}"
+        f"({json.dumps(input_data, ensure_ascii=False)[:200]})\n"
+        f"{reason_line}"
+        "当前 Bash 白名单仅允许以下命令:\n"
+        "  - python .claude/skills/<skill>/scripts/<script>.py <args>"
+        "（必须用相对路径）\n"
+        "  - ffmpeg / ffprobe\n"
+        "其他 Bash 命令均不可用。"
+        "请检查命令格式是否匹配白名单规则。"
+    )
+    return PermissionResultDeny(message=hint)
+```
+
+#### 4.2 `_message_to_dict` 验证（无代码改动）
+
+`ResultMessage` 序列化走 `_serialize_value`（dataclass → dict 风格）。
+0.1.76 新增 `api_error_status` 字段会自动序列化。**无需代码改动**，
+仅需在测试中验证字段确实出现在序列化结果里。
+
+### 5. 测试
+
+新增 `tests/agent_runtime/test_sdk_0_1_76_features.py`，含：
+
+- `test_api_error_status_in_status_payload`：构造
+  `result_message = {"is_error": True, "subtype": "error_during_execution",
+  "api_error_status": 429}` 调 `AssistantService._build_status_event_payload`，
+  断言 payload 含 `api_error_status: 429`
+- `test_api_error_status_absent_when_none`：`api_error_status=None` 时
+  payload 不含该键
+- `test_can_use_tool_includes_decision_reason`：Mock `_context` 带
+  `decision_reason="No matching allow rule"`，调 default-deny 分支，
+  断言返回的 `PermissionResultDeny.message` 包含 reason 文本
+- `test_can_use_tool_no_reason_when_missing`：`_context` 无
+  `decision_reason` 属性时仍返回正常 hint，不抛异常
+
+可选：复用现有 `tests/agent_runtime/conftest.py` 的 fixtures，避免重复构造
+`AssistantService` / `SessionManager`。
+
+## 设计原则
+
+- **向后兼容**：所有新字段读取走 `getattr` 或 `.get(..., None)` + 显式判空。
+  即使运行时拿到了 SDK 老版本 / 没有该字段的旧消息，也不会 AttributeError
+- **无 schema 破坏**：SSE payload 只"增加可选字段"。前端不读照常工作；
+  前端有需求时可平滑接入
+- **不引入新 import**：不导入 `DeferredToolUse`、`HookEventMessage`、
+  `PermissionUpdate.from_dict` 等本轮不采纳的 API
+- **保留 `try: from claude_agent_sdk import ... except ImportError` 风格**：
+  与 `session_manager.py` 现有写法一致
+- **测试覆盖率不下降**：新增字段读取路径全部加单测
+
+## 风险与缓解
+
+| 风险 | 概率 | 缓解 |
+|---|---|---|
+| 0.1.74 atexit handler 与 FastAPI shutdown 冲突 | 低 | atexit 仅终止 SDK 自有子进程，与应用 lifespan 正交 |
+| `MemoryObjectReceiveStream` 修复改变断流时序 | 极低 | 现有 SSE 闭合测试回归验证 |
+| `created_at` 修复改变 `list_sessions` 返回顺序 | 低 | 项目对 `created_at=None` 已有容错，保留 |
+| `ResultMessage` dataclass 新字段破坏 `_serialize_value` | 低 | 单测验证 dataclass → dict 行为 |
+| 0.1.76 bundled CLI 2.1.132 与项目交互回归 | 低 | 端到端跑一次 `/api/v1/assistant` 流式回复 |
+
+## 验收标准
+
+- `uv run python -m pytest tests/agent_runtime/` 全绿
+- `uv run python -m pytest --cov`，agent_runtime 模块覆盖率不下降
+- `uv run ruff check . && uv run ruff format --check .` 全绿
+- 手动跑一次 `uvicorn` 启动 + `/api/v1/assistant/sessions/{id}/stream`
+  完成一轮对话，验证 SSE 状态事件未破坏
+- 错误注入测试：mock 一次 429 错误，确认前端能在 SSE 收到
+  `api_error_status: 429`
+
+## 不在本范围内
+
+- 前端对 `api_error_status` 的展示（提示文本、icon 差异化）
+  — 后端字段先就位，前端按需在新 PR 接入
+- `include_hook_events` 集成
+- 任何 `lib/` 下非 `agent_session_store` 模块的改动

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "AI video generation workspace"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "claude-agent-sdk>=0.1.73",
+    "claude-agent-sdk>=0.1.76",
     "ffmpeg-python>=0.2.0",
     "fastapi>=0.135.1",
     "google-genai>=1.65.0",

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -538,11 +538,23 @@ class AssistantService:
                 return events, True
 
         if msg_type == "result":
+            status = self._resolve_result_status(message)
+            if status == "error":
+                logger.warning(
+                    "assistant session result error",
+                    extra={
+                        "session_id": session_id,
+                        "subtype": message.get("subtype"),
+                        "is_error": message.get("is_error"),
+                        "api_error_status": message.get("api_error_status"),  # SDK 0.1.76+
+                        "stop_reason": message.get("stop_reason"),
+                    },
+                )
             events.append(
                 self._sse_event(
                     "status",
                     self._build_status_event_payload(
-                        status=self._resolve_result_status(message),
+                        status=status,
                         session_id=session_id,
                         result_message=message,
                     ),

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -739,13 +739,17 @@ class AssistantService:
         if status == "error":
             is_error = True
 
-        return {
+        payload: dict[str, Any] = {
             "status": status,
             "subtype": subtype,
             "stop_reason": stop_reason,
             "is_error": is_error,
             "session_id": session_id,
         }
+        api_error_status = message.get("api_error_status")  # SDK 0.1.76+
+        if api_error_status is not None:
+            payload["api_error_status"] = api_error_status
+        return payload
 
     async def _with_session_metadata(
         self,

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -1770,9 +1770,12 @@ class SessionManager:
             # Whitelist fallback: deny any tool that was not pre-approved
             # by allowed_tools or settings.json allow rules.
             if PermissionResultDeny is not None:
+                reason = getattr(_context, "decision_reason", None)  # SDK 0.1.74+
+                reason_line = f"上游决策原因: {reason}\n" if reason else ""
                 hint = (
                     f"未授权的工具调用: {tool_name}"
                     f"({json.dumps(input_data, ensure_ascii=False)[:200]})\n"
+                    f"{reason_line}"
                     "当前 Bash 白名单仅允许以下命令:\n"
                     "  - python .claude/skills/<skill>/scripts/<script>.py <args>（必须用相对路径）\n"
                     "  - ffmpeg / ffprobe\n"

--- a/tests/agent_runtime/test_sdk_0_1_76_features.py
+++ b/tests/agent_runtime/test_sdk_0_1_76_features.py
@@ -122,3 +122,45 @@ class TestResultErrorLogging:
             )
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert not warnings, f"unexpected warnings on completed result: {warnings}"
+
+
+class TestCanUseToolDecisionReason:
+    """0.1.74 新字段 ToolPermissionContext.decision_reason 拼到 default-deny hint。"""
+
+    @pytest.mark.asyncio
+    async def test_default_deny_includes_decision_reason(self, tmp_path):
+        from server.agent_runtime.session_manager import SessionManager
+        from server.agent_runtime.session_store import SessionMetaStore
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        sm = SessionManager(
+            project_root=tmp_path,
+            data_dir=data_dir,
+            meta_store=SessionMetaStore(),
+        )
+        callback = await sm._build_can_use_tool_callback(session_id="sess-x")
+        ctx = SimpleNamespace(decision_reason="No matching allow rule")
+        result = await callback("Bash", {"command": "rm -rf /"}, ctx)
+        assert hasattr(result, "message"), f"expected PermissionResultDeny, got {type(result)}"
+        assert "No matching allow rule" in result.message
+        assert "上游决策原因" in result.message
+
+    @pytest.mark.asyncio
+    async def test_default_deny_without_decision_reason_does_not_raise(self, tmp_path):
+        from server.agent_runtime.session_manager import SessionManager
+        from server.agent_runtime.session_store import SessionMetaStore
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        sm = SessionManager(
+            project_root=tmp_path,
+            data_dir=data_dir,
+            meta_store=SessionMetaStore(),
+        )
+        callback = await sm._build_can_use_tool_callback(session_id="sess-y")
+        ctx = SimpleNamespace()  # no decision_reason
+        result = await callback("Bash", {"command": "echo hi"}, ctx)
+        assert hasattr(result, "message")
+        assert "未授权的工具调用" in result.message
+        assert "上游决策原因" not in result.message

--- a/tests/agent_runtime/test_sdk_0_1_76_features.py
+++ b/tests/agent_runtime/test_sdk_0_1_76_features.py
@@ -1,0 +1,63 @@
+"""SDK 0.1.76 新字段消费的单元测试。
+
+覆盖：
+- ResultMessage.api_error_status 透传到 SSE 状态 payload
+- ToolPermissionContext.decision_reason 拼到 _can_use_tool default-deny hint
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from server.agent_runtime.service import AssistantService
+
+
+class TestApiErrorStatusInStatusPayload:
+    """0.1.76 新字段 api_error_status 透传到 SSE payload。"""
+
+    def test_api_error_status_present_when_set(self):
+        result_message: dict[str, Any] = {
+            "type": "result",
+            "subtype": "error_during_execution",
+            "is_error": True,
+            "api_error_status": 429,
+            "stop_reason": "api_error",
+        }
+        payload = AssistantService._build_status_event_payload(
+            status="error",
+            session_id="sess-1",
+            result_message=result_message,
+        )
+        assert payload["api_error_status"] == 429
+
+    def test_api_error_status_absent_when_none(self):
+        result_message: dict[str, Any] = {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "api_error_status": None,
+        }
+        payload = AssistantService._build_status_event_payload(
+            status="completed",
+            session_id="sess-2",
+            result_message=result_message,
+        )
+        assert "api_error_status" not in payload
+
+    def test_api_error_status_absent_when_field_missing(self):
+        # 老 SDK / 老消息没有 api_error_status 字段
+        result_message: dict[str, Any] = {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+        }
+        payload = AssistantService._build_status_event_payload(
+            status="completed",
+            session_id="sess-3",
+            result_message=result_message,
+        )
+        assert "api_error_status" not in payload

--- a/tests/agent_runtime/test_sdk_0_1_76_features.py
+++ b/tests/agent_runtime/test_sdk_0_1_76_features.py
@@ -61,3 +61,64 @@ class TestApiErrorStatusInStatusPayload:
             result_message=result_message,
         )
         assert "api_error_status" not in payload
+
+
+class TestResultErrorLogging:
+    """result 消息错误路径写结构化 logger.warning，含 api_error_status。"""
+
+    @pytest.mark.asyncio
+    async def test_logger_warning_emitted_on_error_with_api_status(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path,
+    ):
+        from unittest.mock import MagicMock
+
+        service = AssistantService(project_root=tmp_path)
+        projector = MagicMock()
+        projector.apply_message.return_value = {}  # 无 patch/delta/question
+
+        result_message: dict[str, Any] = {
+            "type": "result",
+            "subtype": "error_during_execution",
+            "is_error": True,
+            "api_error_status": 429,
+            "stop_reason": "api_error",
+        }
+        with caplog.at_level(logging.WARNING, logger="server.agent_runtime.service"):
+            events, terminal = await service._dispatch_live_message(
+                message=result_message,
+                projector=projector,
+                session_id="sess-err",
+            )
+        assert terminal is True
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(getattr(r, "api_error_status", None) == 429 for r in warnings), (
+            f"expected a warning with api_error_status=429, got {[r.__dict__ for r in warnings]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_warning_on_completed_result(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path,
+    ):
+        from unittest.mock import MagicMock
+
+        service = AssistantService(project_root=tmp_path)
+        projector = MagicMock()
+        projector.apply_message.return_value = {}
+
+        result_message: dict[str, Any] = {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+        }
+        with caplog.at_level(logging.WARNING, logger="server.agent_runtime.service"):
+            await service._dispatch_live_message(
+                message=result_message,
+                projector=projector,
+                session_id="sess-ok",
+            )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert not warnings, f"unexpected warnings on completed result: {warnings}"

--- a/uv.lock
+++ b/uv.lock
@@ -221,7 +221,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "charset-normalizer", specifier = ">=3.4.6" },
-    { name = "claude-agent-sdk", specifier = ">=0.1.73" },
+    { name = "claude-agent-sdk", specifier = ">=0.1.76" },
     { name = "docx2txt", specifier = ">=0.9" },
     { name = "ebooklib", specifier = ">=0.20" },
     { name = "fastapi", specifier = ">=0.135.1" },
@@ -513,20 +513,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.74"
+version = "0.1.76"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/8e/51749a75a0908e0bb71b77ae289b0f2357381903ba43fe6d17bd13b9f8c8/claude_agent_sdk-0.1.74.tar.gz", hash = "sha256:412308bab715133894126e882fcc8778e281a7a76e74264e3a428a233eeaf768", size = 246973, upload-time = "2026-05-06T01:51:52.115Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/df/1ec1b9489c90342eb00078ab482871440baefae0707006d6cf4bf3e67e02/claude_agent_sdk-0.1.76.tar.gz", hash = "sha256:9a36f7629cc00dc1c5959b68d3bef8f8810b3616f9012df92a60144d6b0f0a84", size = 248264, upload-time = "2026-05-06T22:22:00.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/79/b0c858d9d6af1ce118bf4d1d0c92f0e46f37c4dc89a132321a745959a961/claude_agent_sdk-0.1.74-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6b850008b9241c76c4b645159685ba8382075d3e7253e3de969dd3a1a438e296", size = 64039705, upload-time = "2026-05-06T01:51:55.562Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/02/c885e736ae24cd6c8243312637ac32ca8a46f9aa482386b6b4cbe8185879/claude_agent_sdk-0.1.74-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:aec9ec939dc9da3c93186b3a66507e3b4507d2be36a31d96562d6af1ca0427e5", size = 65881226, upload-time = "2026-05-06T01:51:59.016Z" },
-    { url = "https://files.pythonhosted.org/packages/44/f7/ae42174c4db6bcc2e8e821d1deec395a29353fc9f2691bc754a2f3392d0f/claude_agent_sdk-0.1.74-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:56889dc56556f515561ffe8cecce37c319a0d3d608258fb7af9ad7e52cce355b", size = 77211570, upload-time = "2026-05-06T01:52:02.9Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a8/e5ae47a9b4a351de46728cf23f407ff9e823acc8fe1918a894065830f02b/claude_agent_sdk-0.1.74-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:c45fd2b6abb534865d79d058a375a825e1aef9d12d22b1419ec45ea432ed1f5d", size = 77357370, upload-time = "2026-05-06T01:52:06.524Z" },
-    { url = "https://files.pythonhosted.org/packages/df/ca/5c2e501e51a978c203e7441e8b643a2c196e3a63d8cb33d7f043d4621793/claude_agent_sdk-0.1.74-py3-none-win_amd64.whl", hash = "sha256:65becad62edf1e5d39cb9014b70942c8657504b0840e2359ffd7479ef73eb09f", size = 78765668, upload-time = "2026-05-06T01:52:10.257Z" },
+    { url = "https://files.pythonhosted.org/packages/48/fa/f87ed968ddfdd1f99c9d5b6c690f4589c0e3f91bc50d964c331d40c9c0b5/claude_agent_sdk-0.1.76-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4c06607b60fd0704a55d61675da179aa16107f6c656c70cc296c3a845b898bc3", size = 64186601, upload-time = "2026-05-06T22:22:04.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/92/be2a0c3b397aa1056fa39e5457d55c3b37699adab90a855d2b5252f03171/claude_agent_sdk-0.1.76-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:bbaeb4bccfabe71b0a9041352fae06f0ea9ac1192537d845ac89bd67f9c7fa08", size = 66026957, upload-time = "2026-05-06T22:22:07.749Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d0/091d31cb46d0a7d3e4dc61b33fe831169d99aac06485eac5bfb3e4035115/claude_agent_sdk-0.1.76-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:90134c8b1e48c84fb544683b004d8acbe1ee6e91e39dd03f3937bea2f101b5dc", size = 77350162, upload-time = "2026-05-06T22:22:11.687Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/cb/680c52c9235e16f50cbb5b0427b695663d480bbefe90e5ad237835c4e27e/claude_agent_sdk-0.1.76-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:0b323ee8c5fad84f1fa1acdaa4578a0ea027d158ee5bc3f4df7fd792d269a0e0", size = 77495303, upload-time = "2026-05-06T22:22:16.147Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/4e/1e5cdb5c5c8cd330c53aabbf99e4ea23bbda4700c0d27d00200eff119d75/claude_agent_sdk-0.1.76-py3-none-win_amd64.whl", hash = "sha256:68a879d642982c4d451b4bed0d323f8c3897103393a2b8c936123f868afba6a7", size = 78913643, upload-time = "2026-05-06T22:22:20.779Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- 依赖下限从 `>=0.1.73` 提升到 `>=0.1.76`，被动收益：`MemoryObjectReceiveStream` 关闭修复、atexit 子进程清理、`list_sessions().created_at=None` 修复、`suggestions` 反序列化修复
- `ResultMessage.api_error_status`（HTTP 状态码 429/500/529）透传到 SSE `status` event payload + 在 `_dispatch_live_message` 错误路径写结构化 `logger.warning`（含 `api_error_status` extra 字段）；前端 schema 仅"增加可选字段"，未读取则不受影响
- `ToolPermissionContext.decision_reason`（SDK 0.1.74+）拼接到 `_can_use_tool` default-deny 的 hint，让上游决策原因可见；`getattr` 兜底，老 SDK 不会 AttributeError
- 显式不采纳：`include_hook_events` / `defer` / `updatedToolOutput` / `strict_mcp_config` / `xhigh`（详见 spec）
- 新增 7 个单测覆盖以上行为及反例（None / 字段缺失 / completed 不告警 / 无 reason 不抛异常）

参考：
- spec `docs/superpowers/specs/2026-05-07-sdk-0.1.76-upgrade-design.md`
- plan `docs/superpowers/plans/2026-05-07-sdk-0.1.76-upgrade.md`

## Test plan

- [x] `uv run python -m pytest tests/agent_runtime/ tests/agent_session_store/ -v` → 61/61 pass
- [x] `uv run python -m pytest tests/agent_runtime/test_sdk_0_1_76_features.py -v` → 7/7 pass
- [x] `uv run ruff check server/agent_runtime/service.py server/agent_runtime/session_manager.py tests/agent_runtime/test_sdk_0_1_76_features.py` → All checks passed
- [x] `uv run ruff format` → 3 files left unchanged
- [ ] 端到端：本地 `uvicorn` 启动 + 跑一轮 assistant SSE 对话，确认 `status` 事件未破坏（待人工验证）
- [ ] 错误注入：mock 一次 429（错误的 API key）触发 `ResultMessage(is_error=True)`，确认前端收到的 SSE payload 含 `api_error_status: 429`（待人工验证）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增强错误信息显示，SSE 状态消息现包含 API 错误状态详情
  * 改进工具权限拒绝提示，加入上游决策原因说明（如可用）

* **文档**
  * 添加 SDK 升级计划与设计规范文档

<!-- end of auto-generated comment: release notes by coderabbit.ai -->