### PR TITLE
fix(workbench): 修复新版工作台 SSE 项目事件后的自动定位

### DIFF
--- a/frontend/src/components/canvas/lorebook/CharacterCard.tsx
+++ b/frontend/src/components/canvas/lorebook/CharacterCard.tsx
@@ -176,6 +176,7 @@ export function CharacterCard({
 
   return (
     <div
+      id={`character-${name}`}
       className="relative overflow-hidden rounded-xl p-5"
       data-workspace-editing={isEditing || isDirty ? "true" : undefined}
       onFocusCapture={() => setIsEditing(true)}

--- a/frontend/src/components/canvas/lorebook/CharactersPage.tsx
+++ b/frontend/src/components/canvas/lorebook/CharactersPage.tsx
@@ -7,6 +7,7 @@ import { AssetFormModal } from "@/components/assets/AssetFormModal";
 import { AssetPickerModal } from "@/components/assets/AssetPickerModal";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
+import { useScrollTarget } from "@/hooks/useScrollTarget";
 import { errMsg } from "@/utils/async";
 import type { Character } from "@/types";
 import { GalleryEmptyState } from "./GalleryEmptyState";
@@ -26,6 +27,8 @@ export function CharactersPage({ projectName, characters, onSaveCharacter, onGen
   const { t } = useTranslation(["dashboard", "assets"]);
   const [adding, setAdding] = useState(false);
   const [picking, setPicking] = useState(false);
+
+  useScrollTarget("character");
 
   const entries = Object.entries(characters);
 

--- a/frontend/src/components/canvas/lorebook/PropCard.tsx
+++ b/frontend/src/components/canvas/lorebook/PropCard.tsx
@@ -110,6 +110,7 @@ export function PropCard({
 
   return (
     <div
+      id={`prop-${name}`}
       className="relative overflow-hidden rounded-xl p-5"
       data-workspace-editing={isEditing || isDirty ? "true" : undefined}
       onFocusCapture={() => setIsEditing(true)}

--- a/frontend/src/components/canvas/lorebook/PropsPage.tsx
+++ b/frontend/src/components/canvas/lorebook/PropsPage.tsx
@@ -7,6 +7,7 @@ import { AssetFormModal } from "@/components/assets/AssetFormModal";
 import { AssetPickerModal } from "@/components/assets/AssetPickerModal";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
+import { useScrollTarget } from "@/hooks/useScrollTarget";
 import { errMsg } from "@/utils/async";
 import type { Prop } from "@/types";
 import { GalleryEmptyState } from "./GalleryEmptyState";
@@ -26,6 +27,8 @@ export function PropsPage({ projectName, props, onUpdateProp, onGenerateProp, on
   const { t } = useTranslation(["dashboard", "assets"]);
   const [adding, setAdding] = useState(false);
   const [picking, setPicking] = useState(false);
+
+  useScrollTarget("prop");
 
   const entries = Object.entries(props);
 

--- a/frontend/src/components/canvas/lorebook/SceneCard.tsx
+++ b/frontend/src/components/canvas/lorebook/SceneCard.tsx
@@ -110,6 +110,7 @@ export function SceneCard({
 
   return (
     <div
+      id={`scene-${name}`}
       className="relative overflow-hidden rounded-xl p-5"
       data-workspace-editing={isEditing || isDirty ? "true" : undefined}
       onFocusCapture={() => setIsEditing(true)}

--- a/frontend/src/components/canvas/lorebook/ScenesPage.tsx
+++ b/frontend/src/components/canvas/lorebook/ScenesPage.tsx
@@ -7,6 +7,7 @@ import { AssetFormModal } from "@/components/assets/AssetFormModal";
 import { AssetPickerModal } from "@/components/assets/AssetPickerModal";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
+import { useScrollTarget } from "@/hooks/useScrollTarget";
 import { errMsg } from "@/utils/async";
 import type { Scene } from "@/types";
 import { GalleryEmptyState } from "./GalleryEmptyState";
@@ -26,6 +27,8 @@ export function ScenesPage({ projectName, scenes, onUpdateScene, onGenerateScene
   const { t } = useTranslation(["dashboard", "assets"]);
   const [adding, setAdding] = useState(false);
   const [picking, setPicking] = useState(false);
+
+  useScrollTarget("scene");
 
   const entries = Object.entries(scenes);
 

--- a/frontend/src/components/canvas/timeline/ShotSplitView.tsx
+++ b/frontend/src/components/canvas/timeline/ShotSplitView.tsx
@@ -70,10 +70,14 @@ export function ShotSplitView({
   useEffect(() => {
     if (scrollTarget?.type !== "segment") return;
     const idx = segments.findIndex((s) => getSegmentId(s, contentMode) === scrollTarget.id);
-    if (idx === -1) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- 订阅 SSE 项目事件 store，触发后切换选中分镜
-    setSelectedIndex(idx);
-    clearScrollTarget(scrollTarget.request_id);
+    if (idx !== -1) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- 订阅 SSE 项目事件 store，触发后切换选中分镜
+      setSelectedIndex(idx);
+      clearScrollTarget(scrollTarget.request_id);
+    } else if (Date.now() >= scrollTarget.expires_at) {
+      // 当前 segments 不含该分镜（如事件指向其他剧集），过期后清理避免下次 segments 变更误触发
+      clearScrollTarget(scrollTarget.request_id);
+    }
   }, [scrollTarget, segments, contentMode, clearScrollTarget]);
 
   if (segments.length === 0) {

--- a/frontend/src/components/canvas/timeline/ShotSplitView.tsx
+++ b/frontend/src/components/canvas/timeline/ShotSplitView.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { NarrationSegment, DramaScene } from "@/types";
-import { useScrollTarget } from "@/hooks/useScrollTarget";
+import { useAppStore } from "@/stores/app-store";
 import { ShotList } from "./ShotList";
 import { ShotDetail } from "./ShotDetail";
 
@@ -64,16 +64,17 @@ export function ShotSplitView({
     }
   }, [segments.length, selectedIndex]);
 
-  const prepareScroll = useCallback(
-    (target: { id: string }) => {
-      const idx = segments.findIndex((s) => getSegmentId(s, contentMode) === target.id);
-      if (idx === -1) return false;
-      setSelectedIndex(idx);
-      return true;
-    },
-    [segments, contentMode],
-  );
-  useScrollTarget("segment", { prepareTarget: prepareScroll });
+  // SSE 自动定位：分屏布局只需切换 selectedIndex，不做 DOM 滚动
+  const scrollTarget = useAppStore((s) => s.scrollTarget);
+  const clearScrollTarget = useAppStore((s) => s.clearScrollTarget);
+  useEffect(() => {
+    if (scrollTarget?.type !== "segment") return;
+    const idx = segments.findIndex((s) => getSegmentId(s, contentMode) === scrollTarget.id);
+    if (idx === -1) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 订阅 SSE 项目事件 store，触发后切换选中分镜
+    setSelectedIndex(idx);
+    clearScrollTarget(scrollTarget.request_id);
+  }, [scrollTarget, segments, contentMode, clearScrollTarget]);
 
   if (segments.length === 0) {
     return null;


### PR DESCRIPTION
## Summary
- character / scene / prop 卡片根 div 补齐 \`id=\"${type}-${name}\"\` 锚点；CharactersPage / ScenesPage / PropsPage 挂载 \`useScrollTarget\`，恢复 SSE 触发后自动滚动 + 闪烁高亮
- ShotSplitView 替换 \`useScrollTarget(\"segment\")\` 为直接订阅 \`useAppStore.scrollTarget\` 的 effect，仅切 \`selectedIndex\` 不做 DOM 滚动（新分镜分屏布局无需滚动，且左侧 ShotList 是 virtualizer，原 prepareTarget→DOM 重试链会超时报 toast）

## Background
PR #471 (ff9ea3b) 新版工作台 UI 下，自动定位生效条件链路如下：
1. 后端 SSE 下发 \`focus.anchor_type\` + \`focus.anchor_id\`
2. \`useProjectEventsSSE\` → \`buildNotificationTarget\` → \`executeFocus\` → \`setLocation(route)\` + \`triggerScrollTo\`
3. 目标页面挂载 \`useScrollTarget(type)\` → \`document.getElementById(\\\`\${type}-\${id}\\\`)\` → \`scrollIntoView\`

老 UI 下 character / scene / prop 也未挂载锚点，但本次复盘后一并补齐；segment 在新分屏布局下无需滚动，改为只切 selectedIndex。

## Test plan
- [ ] 触发 character / scene / prop 生成完成的 SSE，路由自动跳转 + 卡片滚入视口 + 闪烁高亮
- [ ] 触发 segment 更新 SSE，右侧 ShotDetail 自动切换到对应分镜，无 toast 报错
- [ ] 编辑卡片输入框期间触发 SSE，不打断编辑（\`isWorkspaceEditing()\` 仍生效，焦点恢复后再定位）
- [ ] \`pnpm lint && pnpm check\` 本地 + CI 绿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进功能**
  * 为角色/场景/道具卡片添加稳定的 DOM 锚点，便于精确定位。
  * 在角色/场景/道具页面启用目标滚动支持，提升定位体验。
* **修复/优化**
  * 时间线视图的滚动目标同步改为应用级驱动，增强跨组件导航的稳定性与响应性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->