### PR TITLE
docs(script-skills): 解耦 Gemini 硬编码并打印实际使用的文本后端

### DIFF
--- a/agent_runtime_profile/.claude/agents/create-episode-script.md
+++ b/agent_runtime_profile/.claude/agents/create-episode-script.md
@@ -42,7 +42,7 @@ skills:
 python .claude/skills/generate-script/scripts/generate_script.py --episode {N}
 ```
 
-等待执行完成。如果失败，查看错误信息并尝试修复或报告问题。
+等待执行完成。脚本会先打印实际使用的文本后端（`provider/model`）。如果失败，查看错误信息并尝试修复或报告问题。
 
 ### Step 3: 验证生成结果
 
@@ -65,7 +65,7 @@ python .claude/skills/generate-script/scripts/generate_script.py --episode {N}
 | 内容模式 | narration/drama |
 | 总片段/场景数 | XX 个 |
 | 总时长 | X 分 X 秒 |
-| 生成模型 | gemini-3-flash-preview |
+| 生成模型 | {从脚本输出读取的 provider/model；若未读取到则写“按当前文本后端配置”} |
 
 **文件已保存**: `scripts/episode_{N}.json`
 

--- a/agent_runtime_profile/.claude/skills/generate-script/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/generate-script/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: generate-script
-description: 使用 Gemini API 生成 JSON 剧本。由 create-episode-script subagent 调用。读取 step1 中间文件和 project.json，调用 Gemini 生成符合 Pydantic 模型的 JSON 剧本。
+description: 使用当前配置的文本后端生成 JSON 剧本。由 create-episode-script subagent 调用。读取 step1 中间文件和 project.json，调用当前文本模型生成符合 Pydantic 模型的 JSON 剧本。
 user-invocable: false
 ---
 
 # generate-script
 
-使用 Gemini API 生成 JSON 剧本。此 skill 由 `create-episode-script` subagent 调用，不直接面向用户。
+使用当前配置的文本后端生成 JSON 剧本。此 skill 由 `create-episode-script` subagent 调用，不直接面向用户。
 
 ## 前置条件
 
@@ -36,7 +36,7 @@ python .claude/skills/generate-script/scripts/generate_script.py --episode {N} -
 1. **加载 project.json** — 读取 content_mode、characters、scenes、props、overview、style
 2. **加载 Step 1 中间文件** — 根据 content_mode 选择 `step1_segments.md`（narration）或 `step1_normalized_script.md`（drama）
 3. **构建 Prompt** — 将项目概述、风格、角色、场景、道具和中间文件内容组合成完整 prompt
-4. **调用 Gemini API** — 使用 `gemini-3-flash-preview` 模型，传入 Pydantic schema 作为 `response_schema` 约束输出格式
+4. **调用当前文本后端** — 文本模型按以下优先级解析：项目级 `text_backend_script` → 系统级 `text_backend_script` → `default_text_backend` → 第一个 ready 的文本供应商。脚本启动时会打印实际使用的 `provider/model`。
 5. **Pydantic 验证** — 按 effective_mode 选 schema：
    - reference_video → `ReferenceVideoScript`（含 `video_units[]`）
    - narration → `NarrationEpisodeScript`
@@ -56,6 +56,6 @@ python .claude/skills/generate-script/scripts/generate_script.py --episode {N} -
 
 ## `--dry-run` 输出
 
-打印将发送给 Gemini 的完整 prompt 文本，不调用 API、不写文件。用于检查 prompt 质量和长度。
+打印将发送给当前文本后端的完整 prompt 文本，不调用 API、不写文件。用于检查 prompt 质量和长度。
 
 > 三种生成模式的数据路径、预处理 subagent、schema 选择详见 `.claude/references/generation-modes.md`。

--- a/agent_runtime_profile/.claude/skills/generate-script/scripts/generate_script.py
+++ b/agent_runtime_profile/.claude/skills/generate-script/scripts/generate_script.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-generate_script.py - 使用 Gemini 生成 JSON 剧本
+generate_script.py - 使用当前配置的文本后端生成 JSON 剧本
 
 用法:
     python generate_script.py --episode <N>
@@ -27,7 +27,7 @@ from lib.script_generator import ScriptGenerator
 
 def main():
     parser = argparse.ArgumentParser(
-        description="使用 Gemini 生成 JSON 剧本",
+        description="使用当前配置的文本后端生成 JSON 剧本",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 示例:
@@ -93,7 +93,7 @@ def main():
             # dry-run 不需要 client
             generator = ScriptGenerator(project_path)
             print("=" * 60)
-            print("DRY RUN - 以下是将发送给 Gemini 的 Prompt:")
+            print("DRY RUN - 以下是将发送给当前文本后端的 Prompt:")
             print("=" * 60)
             prompt = generator.build_prompt(args.episode)
             print(prompt)
@@ -105,6 +105,10 @@ def main():
 
         async def _run():
             generator = await ScriptGenerator.create(project_path)
+            text_generator = generator.generator
+            if text_generator is None:
+                raise RuntimeError("TextGenerator 未初始化")
+            print(f"ℹ️ 使用文本后端: {text_generator.backend.name}/{text_generator.model}")
             output_path = Path(args.output) if args.output else None
             return await generator.generate(
                 episode=args.episode,

--- a/agent_runtime_profile/.claude/skills/generate-script/scripts/normalize_drama_script.py
+++ b/agent_runtime_profile/.claude/skills/generate-script/scripts/normalize_drama_script.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-normalize_drama_script.py - 使用 Gemini Pro 生成规范化剧本
+normalize_drama_script.py - 使用当前配置的文本后端生成规范化剧本
 
 将 source/ 小说原文转化为 Markdown 格式的规范化剧本（step1_normalized_script.md），
 供 generate_script.py 消费。
@@ -153,7 +153,7 @@ async def _fetch_video_caps(project_name: str) -> tuple[int | None, list[int]]:
 
 async def amain() -> None:
     parser = argparse.ArgumentParser(
-        description="使用 Gemini Pro 生成规范化剧本",
+        description="使用当前配置的文本后端生成规范化剧本",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 示例:
@@ -218,7 +218,7 @@ async def amain() -> None:
 
     if args.dry_run:
         print("=" * 60)
-        print("DRY RUN - 以下是将发送给 Gemini 的 Prompt:")
+        print("DRY RUN - 以下是将发送给当前文本后端的 Prompt:")
         print("=" * 60)
         print(prompt)
         print("=" * 60)
@@ -226,7 +226,7 @@ async def amain() -> None:
         return
 
     backend = await create_text_backend_for_task(TextTaskType.SCRIPT)
-    print(f"正在使用 {backend.model} 生成规范化剧本...")
+    print(f"正在使用文本后端 {backend.name}/{backend.model} 生成规范化剧本...")
     result = await backend.generate(TextGenerationRequest(prompt=prompt, max_output_tokens=16000))
     response = result.text
 

--- a/agent_runtime_profile/CLAUDE.md
+++ b/agent_runtime_profile/CLAUDE.md
@@ -99,7 +99,7 @@
 |-------|---------|------|
 | manga-workflow | `/manga-workflow` | 编排 skill：状态检测 + subagent dispatch + 用户确认 |
 | manage-project | — | 项目管理工具集：分集切分（peek+split）、角色/场景/道具批量写入 |
-| generate-script | — | 使用 Gemini 生成 JSON 剧本（由 subagent 调用） |
+| generate-script | — | 使用当前文本后端生成 JSON 剧本（由 subagent 调用） |
 | generate-assets | `/generate-assets` | 统一资产生成：`--type=character\|scene\|prop` 三类并行 |
 | generate-storyboard | `/generate-storyboard` | 生成分镜图片 |
 | generate-video | `/generate-video` | 生成视频 |


### PR DESCRIPTION
## 范围
agent_runtime_profile 下 generate-script / normalize-drama-script 的 skill 文档与脚本。
不动 lib/、server/、frontend/。

## 变更
- 文档去除 "Gemini" 硬编码措辞，改述为"当前配置的文本后端"
- `generate_script.py` 启动时打印实际 `provider/model`，便于多供应商环境下定位
- `normalize_drama_script.py` 进度提示补上 `provider/` 前缀

## 验收清单
- [x] `uv run ruff check . && uv run ruff format --check .` 通过
- [x] 改动仅文案 + 一行 print，无新逻辑分支
- [x] 不涉及面向用户文案，不需要 zh/en 翻译
- [x] 无新 ESLint disable

## 已知 defer
无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档更新**
  * 更新剧本生成相关文档，现支持通过配置灵活切换文本后端
  * 改进脚本执行日志，显示实际使用的后端和模型信息
  * 完善错误处理和故障排查说明

<!-- end of auto-generated comment: release notes by coderabbit.ai -->