### PR TITLE
fix(timeline): 修正费用币种展示与视频全屏宽高比

### DIFF
--- a/frontend/src/components/canvas/timeline/MediaCard.tsx
+++ b/frontend/src/components/canvas/timeline/MediaCard.tsx
@@ -5,6 +5,8 @@ import { useProjectsStore } from "@/stores/projects-store";
 import { AspectFrame } from "@/components/ui/AspectFrame";
 import { ImageFlipReveal } from "@/components/ui/ImageFlipReveal";
 import { PreviewableImageFrame } from "@/components/ui/PreviewableImageFrame";
+import { formatCost } from "@/utils/cost-format";
+import type { CostBreakdown } from "@/types";
 import { VersionTimeMachine } from "./VersionTimeMachine";
 
 type MediaKind = "storyboard" | "video";
@@ -27,8 +29,8 @@ interface MediaCardProps {
   generateDisabledHint?: string;
   /** 进行中状态 */
   generating?: boolean;
-  /** 估算费用（美元） */
-  estimatedCost?: number;
+  /** 估算费用（按币种 breakdown，例如 {USD: 0.12} 或 {CNY: 5.25}） */
+  estimatedCost?: CostBreakdown;
   /** 触发生成 */
   onGenerate?: () => void;
   /** 版本恢复回调 */
@@ -126,7 +128,9 @@ export function MediaCard({
                 poster={posterUrl ?? undefined}
                 controls
                 playsInline
-                className="h-full w-full object-cover"
+                // object-contain：卡片内容器比例一致时铺满，全屏到 16:9 屏幕时
+                // 9:16 视频会带左右黑边，避免被裁剪。
+                className="h-full w-full object-contain"
                 preload="metadata"
               />
             </AspectFrame>
@@ -169,11 +173,9 @@ export function MediaCard({
         >
           <Sparkles className="h-3.5 w-3.5" />
           <span>{generateLabel}</span>
-          {estimatedCost != null && estimatedCost > 0 && (
-            <span
-              className="num ml-1 text-[11px] opacity-70"
-            >
-              ~${estimatedCost.toFixed(estimatedCost < 0.01 ? 3 : 2)}
+          {estimatedCost && Object.values(estimatedCost).some((v) => v > 0) && (
+            <span className="num ml-1 text-[11px] opacity-70">
+              ~{formatCost(estimatedCost)}
             </span>
           )}
         </button>

--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -410,20 +410,8 @@ export function ShotDetail({
     setDraft({ image_prompt: ip, video_prompt: vp });
   };
 
-  const sbEstimate = useMemo(
-    () =>
-      segCost?.estimate?.image
-        ? Object.values(segCost.estimate.image).reduce((a, b) => a + b, 0)
-        : undefined,
-    [segCost?.estimate?.image],
-  );
-  const vidEstimate = useMemo(
-    () =>
-      segCost?.estimate?.video
-        ? Object.values(segCost.estimate.video).reduce((a, b) => a + b, 0)
-        : undefined,
-    [segCost?.estimate?.video],
-  );
+  const sbEstimate = segCost?.estimate?.image;
+  const vidEstimate = segCost?.estimate?.video;
 
   const assets = segment.generated_assets;
   const hasStoryboard = !!assets?.storyboard_image;


### PR DESCRIPTION
## 范围
frontend/src/components/canvas/timeline/ 下两个组件的展示修复。
不动后端。

## 变更
- `MediaCard` 估算费用 prop 从 `number` 改为 `CostBreakdown`，渲染走 `formatCost`，CNY 项目不再错显 `$`
- `ShotDetail` 的 `sbEstimate` / `vidEstimate` 直接透传 `CostBreakdown`，删除无意义的跨币种求和（之前 `Object.values().reduce()` 把不同币种当同币种相加）
- `MediaCard` `<video>` 由 `object-cover` 改为 `object-contain`，9:16 视频全屏到 16:9 屏幕不再被裁切，改为带左右黑边

## 验收清单
- [x] `pnpm lint` 通过
- [x] `pnpm exec tsc --noEmit` 通过
- [x] 手动验证 9:16 视频全屏不再裁切；CNY 估算费用渲染为 `¥...`
- [x] 无新增 ESLint disable
- [x] 不涉及面向用户文案，不需要 zh/en 翻译

## 已知 defer
无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 成本估算现已支持多货币的成本分解展示
  * 仅在至少有一项成本大于零时显示格式化的成本字符串

* **错误修复**
  * 优化视频资源的显示方式，纵向 9:16 内容不再被裁剪（保留边缘黑条以完整呈现）

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/480)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->