### PR TITLE
fix(vidu): 连接测试用数字 task id 避免 400 CODEC parse error

### DIFF
--- a/lib/vidu_shared.py
+++ b/lib/vidu_shared.py
@@ -216,14 +216,18 @@ def test_vidu_connection(config: dict[str, str]) -> None:
     """通过查询不存在的 task id 验证 Vidu API Key。
 
     Vidu 无 list-models 端点，借助 ``GET /tasks/<bogus>/creations`` 校验认证。
-    采用白名单：仅在凭证有效时服务端会返回 404（task 不存在）；任何其他状态码
-    （包括 5xx 网关错误）都视为不可判定，统一抛错避免误判成功。
+    Vidu 服务端把 task id 当作整数解析，必须传数字字符串；非数字会在 auth 检查
+    之前返回 400 CODEC parse error，让连接测试始终失败。
+
+    采用白名单：凭证有效时返回 404（task 不存在）；401/403 视为凭证无效；
+    其他状态码（含 5xx）一律视为不可判定，抛错避免误判成功。
     """
     api_key = resolve_vidu_api_key(config.get("api_key"), allow_env_fallback=False)
     base_url = (config.get("base_url") or VIDU_BASE_URL).rstrip("/")
     headers = {"Authorization": f"Token {api_key}"}
+    # 用一个语法上合法但极不可能存在的数字 id（避开整数解析失败的 400 CODEC）
     with httpx.Client(timeout=10.0) as client:
-        resp = client.get(f"{base_url}/tasks/__connection_test__/creations", headers=headers)
+        resp = client.get(f"{base_url}/tasks/0/creations", headers=headers)
     if resp.status_code == 404:
         return
     if resp.status_code in (401, 403):

--- a/tests/test_vidu_shared.py
+++ b/tests/test_vidu_shared.py
@@ -41,3 +41,52 @@ class TestViduConnectionTestKeyResolution:
 
         with pytest.raises(ValueError, match="Vidu API Key 未提供"):
             vidu_shared.test_vidu_connection({})
+
+
+class TestViduConnectionTestUrl:
+    """验证连接测试用数字 task id（Vidu 服务端把 id 当 int 解析，非数字会 400 CODEC）。"""
+
+    @staticmethod
+    def _patched_client(monkeypatch: pytest.MonkeyPatch, *, status_code: int, body: str = ""):
+        captured: dict[str, str] = {}
+
+        class _FakeResp:
+            def __init__(self):
+                self.status_code = status_code
+                self.text = body
+
+        class _FakeClient:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def get(self, url, **_kwargs):
+                captured["url"] = url
+                return _FakeResp()
+
+        monkeypatch.setattr(vidu_shared.httpx, "Client", _FakeClient)
+        return captured
+
+    def test_url_uses_numeric_bogus_id(self, monkeypatch: pytest.MonkeyPatch):
+        captured = self._patched_client(monkeypatch, status_code=404)
+        vidu_shared.test_vidu_connection({"api_key": "vda_test"})
+        assert captured["url"].endswith("/tasks/0/creations")
+
+    def test_404_is_success(self, monkeypatch: pytest.MonkeyPatch):
+        self._patched_client(monkeypatch, status_code=404)
+        vidu_shared.test_vidu_connection({"api_key": "vda_test"})  # 不抛错即成功
+
+    def test_401_is_invalid_credential(self, monkeypatch: pytest.MonkeyPatch):
+        self._patched_client(monkeypatch, status_code=401)
+        with pytest.raises(RuntimeError, match="凭证无效"):
+            vidu_shared.test_vidu_connection({"api_key": "vda_test"})
+
+    def test_400_is_undecidable(self, monkeypatch: pytest.MonkeyPatch):
+        self._patched_client(monkeypatch, status_code=400, body="CODEC parse error")
+        with pytest.raises(RuntimeError, match="无法判定"):
+            vidu_shared.test_vidu_connection({"api_key": "vda_test"})


### PR DESCRIPTION
Vidu 服务端把 `/tasks/<id>/creations` 路径中的 id 当作整数解析，
`__connection_test__` 这种非数字字符串会在 auth 检查之前直接返回
400 CODEC parse field "id" invalid syntax。配合 PR #481 之后采用的 404-only 白名单，所有用户的连接测试都会失败（哪怕 API Key 完全有效）。

改用 `/tasks/0/creations` —— 0 是合法 int 字面量、且不可能存在的 task， 凭证有效时正常返回 404，连接测试恢复正常。

仅影响设置页"测试连接"按钮，不影响实际生成调用（poll_task 用真实
任务 id，不会触发解析失败路径）。

新增测试覆盖：
- 验证请求 URL 以 /tasks/0/creations 结尾
- 404 视为成功
- 401 视为凭证无效
- 400 视为不可判定（防回归）

## 范围

<!-- 本 PR 动了哪些模块 / 明确不动什么。让 reviewer 一眼知道聚焦点。 -->

## 变更

<!-- 主要改动点，每条一行。对 config/schema 变化尤其要点出。 -->

-
-

## 验收清单

<!-- Merge 前必须勾完。CI 绿不等于可合。 -->

- [ ] 本地已跑相关测试（说明命令）
- [ ] 手动验证了改动所声称的行为
- [ ] 新增面向用户文案已加 zh/en 翻译（如适用）
- [ ] 无新增 ESLint disable；若有，已在本 PR 底部以表格列出 `rule | file:line | 理由`
- [ ] CODEOWNERS 要求的 review 已请求

## 已知 defer

<!--
列出因作用域控制而推后的改进点。Merge 前必须把每一条开成 follow-up issue 并贴链接；
不允许以「之后再说」形式合入。若无 defer 项，写「无」。
-->

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 改进了连接测试函数以使用有效的数字任务 ID 格式
  * 增强了服务端任务 ID 验证的文档说明
  * 新增测试套件，全面验证连接测试的 URL 行为
  * 新增 HTTP 状态码处理测试，覆盖成功、无效凭证及错误场景

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/490)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->