### PR TITLE
fix(timeline): 分镜卡片状态独占首行 + ShotDetail 三栏修复溢出滚动

### DIFF
--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -419,7 +419,7 @@ export function ShotDetail({
   const dirtyHint = t("shot_detail_save_first");
 
   const leftColumn = (
-    <div className="flex min-h-0 flex-col gap-4 overflow-y-auto px-3.5 pb-5 pt-3.5">
+    <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto px-3.5 pb-5 pt-3.5">
       <div>
         <div
           className="mb-2 text-[10.5px] font-bold uppercase"
@@ -483,7 +483,7 @@ export function ShotDetail({
   );
 
   const midColumn = (
-    <div className="flex min-h-0 flex-col gap-3 overflow-y-auto px-5 pb-7 pt-3.5">
+    <div className="flex h-full min-h-0 flex-col gap-3 overflow-y-auto px-5 pb-7 pt-3.5">
       <div
         className="text-[10.5px] font-bold uppercase"
         style={{
@@ -572,7 +572,7 @@ export function ShotDetail({
   );
 
   const rightColumn = (
-    <div className="flex min-h-0 flex-col gap-4 overflow-y-auto px-[18px] pb-7 pt-3.5">
+    <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto px-[18px] pb-7 pt-3.5">
       <MediaCard
         kind="storyboard"
         projectName={projectName}

--- a/frontend/src/components/canvas/timeline/ShotList.tsx
+++ b/frontend/src/components/canvas/timeline/ShotList.tsx
@@ -80,7 +80,7 @@ export function ShotList({
   const virtualizer = useVirtualizer({
     count: filtered.length,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => 84,
+    estimateSize: () => 96,
     overscan: 6,
   });
 
@@ -295,7 +295,10 @@ export function ShotList({
                     {id.length > 4 ? id.slice(-3) : id}
                   </span>
                 </div>
-                <div className="min-w-0">
+                <div className="flex min-w-0 flex-col gap-1">
+                  <div className="flex">
+                    <StatusBadge status={status} />
+                  </div>
                   <div
                     className="text-[12px]"
                     style={{
@@ -310,8 +313,7 @@ export function ShotList({
                   >
                     {text || id}
                   </div>
-                  <div className="mt-1 flex items-center gap-1.5">
-                    <StatusBadge status={status} />
+                  <div className="flex items-center gap-1.5">
                     <span className="num text-[10px]" style={{ color: "var(--color-text-4)" }}>
                       {t("duration_seconds_value_text", { value: seg.duration_seconds ?? 0 })}
                     </span>


### PR DESCRIPTION
## Summary
- ShotList 卡片右栏改为三行：状态徽章独占首行 / 原文 line-clamp-2（超出省略号）/ 时长 + V1 第三行；virtualizer estimateSize 84 → 96 减少初始抖动
- ShotDetail 三栏容器加 h-full：父级 grid wrapper 是 block 元素，仅 `min-h-0` 不让子元素拿到确定高度，`overflow-y-auto` 无可滚区间。右栏（两个 9:16 媒体卡）最先溢出；左/中同结构同改

## Test plan
- [ ] /项目/制作/分镜：左侧卡片"分镜就绪"等状态徽章不再换行；原文超过 2 行显示 …
- [ ] /项目/制作/分镜：右侧分镜图 + 视频面板可正常向下滚动到视频卡
- [ ] 已本地验证 pnpm lint && pnpm check 全绿（68 files / 488 tests）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 样式改进

* 优化了时间线详情视图的网格布局，改进了垂直空间使用
* 改进了时间线列表视图的行高渲染和组件间距，优化了整体视觉呈现

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/491)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->