### PR TITLE
feat(ui): Agent 面板支持拖拽调宽 + 大厅 pill 栏透明度对齐标题栏

### DIFF
--- a/frontend/src/components/layout/AssistantResizeHandle.tsx
+++ b/frontend/src/components/layout/AssistantResizeHandle.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from "react-i18next";
+import {
+  ASSISTANT_PANEL_MAX_WIDTH,
+  ASSISTANT_PANEL_MIN_WIDTH,
+} from "@/stores/app-store";
+
+interface Props {
+  width: number;
+  isResizing: boolean;
+  onMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onDoubleClick: () => void;
+}
+
+/**
+ * 右侧助手面板的左边缘 resize 手柄。
+ * 4px 宽热区跨在边线上（-translate-x-1/2），内部 1px 高亮线在 hover / 拖动时显现。
+ */
+export function AssistantResizeHandle({
+  width,
+  isResizing,
+  onMouseDown,
+  onDoubleClick,
+}: Props) {
+  const { t } = useTranslation("dashboard");
+  const label = t("resize_assistant_panel");
+
+  return (
+    // role="separator" + aria-valuenow/min/max 是 WAI-ARIA Authoring Practices
+    // 中的 window splitter 模式（交互式控件），但 jsx-a11y 默认未把 separator
+    // 列入 interactive 角色，故就地抑制 noninteractive-element 规则。
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-valuemin={ASSISTANT_PANEL_MIN_WIDTH}
+      aria-valuemax={ASSISTANT_PANEL_MAX_WIDTH}
+      aria-valuenow={width}
+      aria-label={label}
+      title={label}
+      onMouseDown={onMouseDown}
+      onDoubleClick={onDoubleClick}
+      className="group absolute inset-y-0 left-0 z-10 w-1 -translate-x-1/2 cursor-col-resize select-none"
+    >
+      <div
+        className={`absolute inset-y-0 left-1/2 w-px -translate-x-1/2 transition-colors duration-150 ${
+          isResizing
+            ? "bg-[var(--color-accent)]"
+            : "bg-transparent group-hover:bg-[var(--color-accent)]"
+        }`}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/layout/StudioLayout.tsx
+++ b/frontend/src/components/layout/StudioLayout.tsx
@@ -37,8 +37,10 @@ export function StudioLayout({ children }: StudioLayoutProps) {
 
   // 拖动期间的"草稿宽度"。非 null 表示正在拖动，UI 用 draftWidth 即时反馈；
   // mouseup / blur 时才把 draftWidth 提交到 store + localStorage，避免每帧
-  // 触发 zustand 订阅链路。
+  // 触发 zustand 订阅链路。draftWidthRef 与 state 同步更新，让 finishResize
+  // 能在 setState updater 之外读取最终值（updater 必须保持纯净）。
   const [draftWidth, setDraftWidth] = useState<number | null>(null);
+  const draftWidthRef = useRef<number | null>(null);
   const isResizing = draftWidth !== null;
   const dragStateRef = useRef<{ startX: number; startWidth: number } | null>(
     null,
@@ -46,6 +48,11 @@ export function StudioLayout({ children }: StudioLayoutProps) {
   const restoreBodyStyleRef = useRef<{ cursor: string; userSelect: string } | null>(
     null,
   );
+
+  const updateDraftWidth = useCallback((next: number | null) => {
+    draftWidthRef.current = next;
+    setDraftWidth(next);
+  }, []);
 
   useTasksSSE(currentProjectName);
   useProjectEventsSSE(currentProjectName);
@@ -72,9 +79,9 @@ export function StudioLayout({ children }: StudioLayoutProps) {
       };
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
-      setDraftWidth(startWidth);
+      updateDraftWidth(startWidth);
     },
-    [],
+    [updateDraftWidth],
   );
 
   const handleResizeDoubleClick = useCallback(() => {
@@ -88,14 +95,13 @@ export function StudioLayout({ children }: StudioLayoutProps) {
     const finishResize = () => {
       dragStateRef.current = null;
       restoreBodyStyle();
-      setDraftWidth((current) => {
-        if (current != null) {
-          // 把 draft 提交到 store；setter 内部会再 clamp，persist 读 store 最新值
-          setAssistantPanelWidth(current);
-          persistAssistantPanelWidth();
-        }
-        return null;
-      });
+      const final = draftWidthRef.current;
+      updateDraftWidth(null);
+      if (final != null) {
+        // 把 draft 提交到 store；setter 内部会再 clamp，persist 读 store 最新值
+        setAssistantPanelWidth(final);
+        persistAssistantPanelWidth();
+      }
     };
 
     const onMouseMove = (e: MouseEvent) => {
@@ -110,7 +116,7 @@ export function StudioLayout({ children }: StudioLayoutProps) {
       const next = clampAssistantPanelWidth(
         drag.startWidth + (drag.startX - e.clientX),
       );
-      setDraftWidth(next);
+      updateDraftWidth(next);
     };
 
     window.addEventListener("mousemove", onMouseMove);
@@ -129,6 +135,7 @@ export function StudioLayout({ children }: StudioLayoutProps) {
     setAssistantPanelWidth,
     persistAssistantPanelWidth,
     restoreBodyStyle,
+    updateDraftWidth,
   ]);
 
   const displayedPanelWidth = draftWidth ?? assistantPanelWidth;

--- a/frontend/src/components/layout/StudioLayout.tsx
+++ b/frontend/src/components/layout/StudioLayout.tsx
@@ -11,6 +11,7 @@ import { useProjectEventsSSE } from "@/hooks/useProjectEventsSSE";
 import { useProjectsStore } from "@/stores/projects-store";
 import {
   ASSISTANT_PANEL_DEFAULT_WIDTH,
+  clampAssistantPanelWidth,
   useAppStore,
 } from "@/stores/app-store";
 import { UI_LAYERS } from "@/utils/ui-layers";
@@ -34,7 +35,11 @@ export function StudioLayout({ children }: StudioLayoutProps) {
     (s) => s.persistAssistantPanelWidth,
   );
 
-  const [isResizing, setIsResizing] = useState(false);
+  // 拖动期间的"草稿宽度"。非 null 表示正在拖动，UI 用 draftWidth 即时反馈；
+  // mouseup / blur 时才把 draftWidth 提交到 store + localStorage，避免每帧
+  // 触发 zustand 订阅链路。
+  const [draftWidth, setDraftWidth] = useState<number | null>(null);
+  const isResizing = draftWidth !== null;
   const dragStateRef = useRef<{ startX: number; startWidth: number } | null>(
     null,
   );
@@ -56,20 +61,20 @@ export function StudioLayout({ children }: StudioLayoutProps) {
 
   const handleResizeMouseDown = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
+      // 仅响应主键，避免右键/中键意外进入拖拽态
+      if (e.button !== 0) return;
       e.preventDefault();
-      dragStateRef.current = {
-        startX: e.clientX,
-        startWidth: assistantPanelWidth,
-      };
+      const startWidth = useAppStore.getState().assistantPanelWidth;
+      dragStateRef.current = { startX: e.clientX, startWidth };
       restoreBodyStyleRef.current = {
         cursor: document.body.style.cursor,
         userSelect: document.body.style.userSelect,
       };
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
-      setIsResizing(true);
+      setDraftWidth(startWidth);
     },
-    [assistantPanelWidth],
+    [],
   );
 
   const handleResizeDoubleClick = useCallback(() => {
@@ -80,26 +85,42 @@ export function StudioLayout({ children }: StudioLayoutProps) {
   useEffect(() => {
     if (!isResizing) return;
 
+    const finishResize = () => {
+      dragStateRef.current = null;
+      restoreBodyStyle();
+      setDraftWidth((current) => {
+        if (current != null) {
+          // 把 draft 提交到 store；setter 内部会再 clamp，persist 读 store 最新值
+          setAssistantPanelWidth(current);
+          persistAssistantPanelWidth();
+        }
+        return null;
+      });
+    };
+
     const onMouseMove = (e: MouseEvent) => {
       const drag = dragStateRef.current;
       if (!drag) return;
+      // 主键已在中途松开（如焦点切走时）→ 主动收尾
+      if ((e.buttons & 1) === 0) {
+        finishResize();
+        return;
+      }
       // 手柄在右侧栏左缘，鼠标向左 (clientX 减小) → 宽度增大
-      const next = drag.startWidth + (drag.startX - e.clientX);
-      setAssistantPanelWidth(next);
-    };
-
-    const onMouseUp = () => {
-      dragStateRef.current = null;
-      restoreBodyStyle();
-      setIsResizing(false);
-      persistAssistantPanelWidth();
+      const next = clampAssistantPanelWidth(
+        drag.startWidth + (drag.startX - e.clientX),
+      );
+      setDraftWidth(next);
     };
 
     window.addEventListener("mousemove", onMouseMove);
-    window.addEventListener("mouseup", onMouseUp);
+    window.addEventListener("mouseup", finishResize);
+    // 鼠标在窗外松开时 mouseup 可能不触发，blur 兜底防止卡死
+    window.addEventListener("blur", finishResize);
     return () => {
       window.removeEventListener("mousemove", onMouseMove);
-      window.removeEventListener("mouseup", onMouseUp);
+      window.removeEventListener("mouseup", finishResize);
+      window.removeEventListener("blur", finishResize);
       // 组件意外卸载时兜底清理 body 样式
       restoreBodyStyle();
     };
@@ -109,6 +130,8 @@ export function StudioLayout({ children }: StudioLayoutProps) {
     persistAssistantPanelWidth,
     restoreBodyStyle,
   ]);
+
+  const displayedPanelWidth = draftWidth ?? assistantPanelWidth;
 
   return (
     <div
@@ -128,7 +151,7 @@ export function StudioLayout({ children }: StudioLayoutProps) {
               : "transition-[width,min-width,border-color] duration-300 ease-in-out"
           }`}
           style={{
-            width: assistantPanelOpen ? assistantPanelWidth : 0,
+            width: assistantPanelOpen ? displayedPanelWidth : 0,
             background: "oklch(0.19 0.011 250 / 0.5)",
             borderLeft: assistantPanelOpen
               ? "1px solid var(--color-hairline)"
@@ -137,7 +160,7 @@ export function StudioLayout({ children }: StudioLayoutProps) {
         >
           {assistantPanelOpen ? (
             <AssistantResizeHandle
-              width={assistantPanelWidth}
+              width={displayedPanelWidth}
               isResizing={isResizing}
               onMouseDown={handleResizeMouseDown}
               onDoubleClick={handleResizeDoubleClick}

--- a/frontend/src/components/layout/StudioLayout.tsx
+++ b/frontend/src/components/layout/StudioLayout.tsx
@@ -1,13 +1,18 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation } from "wouter";
 import { Bot } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { GlobalHeader } from "./GlobalHeader";
 import { AssetSidebar } from "./AssetSidebar";
+import { AssistantResizeHandle } from "./AssistantResizeHandle";
 import { AgentCopilot } from "@/components/copilot/AgentCopilot";
 import { useTasksSSE } from "@/hooks/useTasksSSE";
 import { useProjectEventsSSE } from "@/hooks/useProjectEventsSSE";
 import { useProjectsStore } from "@/stores/projects-store";
-import { useAppStore } from "@/stores/app-store";
+import {
+  ASSISTANT_PANEL_DEFAULT_WIDTH,
+  useAppStore,
+} from "@/stores/app-store";
 import { UI_LAYERS } from "@/utils/ui-layers";
 
 interface StudioLayoutProps {
@@ -23,9 +28,87 @@ export function StudioLayout({ children }: StudioLayoutProps) {
   const currentProjectName = useProjectsStore((s) => s.currentProjectName);
   const assistantPanelOpen = useAppStore((s) => s.assistantPanelOpen);
   const toggleAssistantPanel = useAppStore((s) => s.toggleAssistantPanel);
+  const assistantPanelWidth = useAppStore((s) => s.assistantPanelWidth);
+  const setAssistantPanelWidth = useAppStore((s) => s.setAssistantPanelWidth);
+  const persistAssistantPanelWidth = useAppStore(
+    (s) => s.persistAssistantPanelWidth,
+  );
+
+  const [isResizing, setIsResizing] = useState(false);
+  const dragStateRef = useRef<{ startX: number; startWidth: number } | null>(
+    null,
+  );
+  const restoreBodyStyleRef = useRef<{ cursor: string; userSelect: string } | null>(
+    null,
+  );
 
   useTasksSSE(currentProjectName);
   useProjectEventsSSE(currentProjectName);
+
+  const restoreBodyStyle = useCallback(() => {
+    const saved = restoreBodyStyleRef.current;
+    if (saved) {
+      document.body.style.cursor = saved.cursor;
+      document.body.style.userSelect = saved.userSelect;
+      restoreBodyStyleRef.current = null;
+    }
+  }, []);
+
+  const handleResizeMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      dragStateRef.current = {
+        startX: e.clientX,
+        startWidth: assistantPanelWidth,
+      };
+      restoreBodyStyleRef.current = {
+        cursor: document.body.style.cursor,
+        userSelect: document.body.style.userSelect,
+      };
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      setIsResizing(true);
+    },
+    [assistantPanelWidth],
+  );
+
+  const handleResizeDoubleClick = useCallback(() => {
+    setAssistantPanelWidth(ASSISTANT_PANEL_DEFAULT_WIDTH);
+    persistAssistantPanelWidth();
+  }, [setAssistantPanelWidth, persistAssistantPanelWidth]);
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const onMouseMove = (e: MouseEvent) => {
+      const drag = dragStateRef.current;
+      if (!drag) return;
+      // 手柄在右侧栏左缘，鼠标向左 (clientX 减小) → 宽度增大
+      const next = drag.startWidth + (drag.startX - e.clientX);
+      setAssistantPanelWidth(next);
+    };
+
+    const onMouseUp = () => {
+      dragStateRef.current = null;
+      restoreBodyStyle();
+      setIsResizing(false);
+      persistAssistantPanelWidth();
+    };
+
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+    return () => {
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+      // 组件意外卸载时兜底清理 body 样式
+      restoreBodyStyle();
+    };
+  }, [
+    isResizing,
+    setAssistantPanelWidth,
+    persistAssistantPanelWidth,
+    restoreBodyStyle,
+  ]);
 
   return (
     <div
@@ -39,15 +122,27 @@ export function StudioLayout({ children }: StudioLayoutProps) {
           {children}
         </main>
         <div
-          className="shrink-0 overflow-hidden transition-[width,min-width,border-color] duration-300 ease-in-out"
+          className={`relative shrink-0 overflow-hidden ${
+            isResizing
+              ? "transition-[min-width,border-color]"
+              : "transition-[width,min-width,border-color] duration-300 ease-in-out"
+          }`}
           style={{
-            width: assistantPanelOpen ? 505 : 0,
+            width: assistantPanelOpen ? assistantPanelWidth : 0,
             background: "oklch(0.19 0.011 250 / 0.5)",
             borderLeft: assistantPanelOpen
               ? "1px solid var(--color-hairline)"
               : "1px solid transparent",
           }}
         >
+          {assistantPanelOpen ? (
+            <AssistantResizeHandle
+              width={assistantPanelWidth}
+              isResizing={isResizing}
+              onMouseDown={handleResizeMouseDown}
+              onDoubleClick={handleResizeDoubleClick}
+            />
+          ) : null}
           {/* 始终渲染但收起时透明 + 不可达，保持内部状态；invisible + aria-hidden 防止 Tab 仍可聚焦内部控件 */}
           <div
             aria-hidden={!assistantPanelOpen}

--- a/frontend/src/components/pages/ProjectsPage.tsx
+++ b/frontend/src/components/pages/ProjectsPage.tsx
@@ -1074,7 +1074,7 @@ function FilterPills({ active, onChange, counts, phaseLabels, t }: FilterPillsPr
       style={{
         top: "var(--lobby-topbar-h, 57px)",
         background:
-          "linear-gradient(180deg, oklch(0.18 0.010 265 / 0.94), oklch(0.17 0.010 265 / 0.90))",
+          "linear-gradient(180deg, oklch(0.20 0.011 265 / 0.55), oklch(0.15 0.010 265 / 0.45))",
         backdropFilter: "blur(16px) saturate(1.1)",
         borderTopWidth: 1,
         borderTopColor: "var(--color-hairline-soft)",
@@ -1090,10 +1090,10 @@ function FilterPills({ active, onChange, counts, phaseLabels, t }: FilterPillsPr
               onClick={() => onChange(c.key)}
               aria-pressed={isActive}
               className={
-                "inline-flex items-center rounded-full px-3 py-1 text-[11.5px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent " +
+                "inline-flex items-center rounded-full px-3 py-1 text-[11.5px] font-medium backdrop-blur-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent " +
                 (isActive
-                  ? "border border-accent/35 bg-accent/30 text-text"
-                  : "border border-hairline-soft bg-transparent text-text-3 hover:border-hairline hover:text-text-2")
+                  ? "border border-accent/40 bg-accent/45 text-text"
+                  : "border border-hairline-soft bg-[oklch(0.22_0.012_265_/_0.7)] text-text-3 hover:border-hairline hover:bg-[oklch(0.24_0.012_265_/_0.78)] hover:text-text-2")
               }
             >
               {c.label}

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1072,6 +1072,7 @@ export default {
   'pending_question_wizard_submitting': 'Submitting…',
   'pending_question_wizard_submit': 'Submit →',
   'open_assistant_panel': 'Open assistant panel',
+  'resize_assistant_panel': 'Resize assistant panel (double-click to reset)',
   'progress_aria_label': '{{label}} progress',
   'shot_detail_save': 'Save',
   'shot_detail_saving': 'Saving…',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1097,6 +1097,7 @@ export default {
   'media_video_title': 'Video',
   'no_episode_search_results': 'Không có tập phù hợp',
   'open_assistant_panel': 'Mở bảng trợ lý',
+  'resize_assistant_panel': 'Điều chỉnh chiều rộng bảng trợ lý (nhấp đúp để đặt lại)',
   'open_source_file_aria_label': 'Mở tệp gốc {{filename}}',
   'openclaw': 'OpenClaw',
   'pending_question_wizard_label': 'Cần bạn nhập thông tin',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1073,6 +1073,7 @@ export default {
   'pending_question_wizard_submitting': '提交中…',
   'pending_question_wizard_submit': '完成并提交 →',
   'open_assistant_panel': '展开助手面板',
+  'resize_assistant_panel': '调整助手面板宽度（双击恢复默认）',
   'progress_aria_label': '{{label}} 进度',
   'shot_detail_save': '保存',
   'shot_detail_saving': '保存中…',

--- a/frontend/src/stores/app-store.ts
+++ b/frontend/src/stores/app-store.ts
@@ -25,7 +25,7 @@ export const ASSISTANT_PANEL_MIN_WIDTH = 360;
 export const ASSISTANT_PANEL_MAX_WIDTH = 720;
 export const ASSISTANT_PANEL_WIDTH_STORAGE_KEY = "arcreel_assistant_panel_width";
 
-function clampAssistantPanelWidth(value: number): number {
+export function clampAssistantPanelWidth(value: number): number {
   if (!Number.isFinite(value)) return ASSISTANT_PANEL_DEFAULT_WIDTH;
   return Math.min(
     ASSISTANT_PANEL_MAX_WIDTH,

--- a/frontend/src/stores/app-store.ts
+++ b/frontend/src/stores/app-store.ts
@@ -20,6 +20,32 @@ interface FocusedContext {
 
 const ALL_ENTITIES_REVISION_KEY = "__all__";
 
+export const ASSISTANT_PANEL_DEFAULT_WIDTH = 505;
+export const ASSISTANT_PANEL_MIN_WIDTH = 360;
+export const ASSISTANT_PANEL_MAX_WIDTH = 720;
+export const ASSISTANT_PANEL_WIDTH_STORAGE_KEY = "arcreel_assistant_panel_width";
+
+function clampAssistantPanelWidth(value: number): number {
+  if (!Number.isFinite(value)) return ASSISTANT_PANEL_DEFAULT_WIDTH;
+  return Math.min(
+    ASSISTANT_PANEL_MAX_WIDTH,
+    Math.max(ASSISTANT_PANEL_MIN_WIDTH, Math.round(value)),
+  );
+}
+
+function readPersistedAssistantPanelWidth(): number {
+  if (typeof window === "undefined") return ASSISTANT_PANEL_DEFAULT_WIDTH;
+  try {
+    const raw = window.localStorage.getItem(ASSISTANT_PANEL_WIDTH_STORAGE_KEY);
+    if (!raw) return ASSISTANT_PANEL_DEFAULT_WIDTH;
+    const parsed = parseInt(raw, 10);
+    if (Number.isNaN(parsed)) return ASSISTANT_PANEL_DEFAULT_WIDTH;
+    return clampAssistantPanelWidth(parsed);
+  } catch {
+    return ASSISTANT_PANEL_DEFAULT_WIDTH;
+  }
+}
+
 interface AppState {
   // Context focus (design doc "Context-Aware" feature)
   focusedContext: FocusedContext | null;
@@ -52,6 +78,9 @@ interface AppState {
   assistantPanelOpen: boolean;
   toggleAssistantPanel: () => void;
   setAssistantPanelOpen: (open: boolean) => void;
+  assistantPanelWidth: number;
+  setAssistantPanelWidth: (width: number) => void;
+  persistAssistantPanelWidth: () => void;
   taskHudOpen: boolean;
   setTaskHudOpen: (open: boolean) => void;
 
@@ -182,6 +211,21 @@ export const useAppStore = create<AppState>((set, get) => ({
   toggleAssistantPanel: () =>
     set((s) => ({ assistantPanelOpen: !s.assistantPanelOpen })),
   setAssistantPanelOpen: (open) => set({ assistantPanelOpen: open }),
+  assistantPanelWidth: readPersistedAssistantPanelWidth(),
+  setAssistantPanelWidth: (width) =>
+    set({ assistantPanelWidth: clampAssistantPanelWidth(width) }),
+  persistAssistantPanelWidth: () => {
+    if (typeof window === "undefined") return;
+    const width = clampAssistantPanelWidth(get().assistantPanelWidth);
+    try {
+      window.localStorage.setItem(
+        ASSISTANT_PANEL_WIDTH_STORAGE_KEY,
+        String(width),
+      );
+    } catch {
+      // localStorage 不可用（隐私模式 / quota exceeded）静默失败，内存值仍生效
+    }
+  },
   taskHudOpen: false,
   setTaskHudOpen: (open) => set({ taskHudOpen: open }),
 


### PR DESCRIPTION
## Summary
- StudioLayout 右侧 Agent 面板加 resize 手柄（左缘 4px hot zone + 1px hover 高亮线），宽度区间 [360, 720]，双击恢复默认 505，localStorage 持久化（key: arcreel_assistant_panel_width）
- 拖动期间禁 width transition 与 body user-select，window 级 mousemove/mouseup 监听 + 组件卸载兜底
- 大厅页 FilterPills 栏背景 alpha 改成 0.55/0.45 与 TopBar 一致；非激活 pill 加 oklch 实底色避免背景透明后与海报糊在一起

## Test plan
- [ ] 拖动右侧栏左边缘可改变 Agent 面板宽度，撞到 360/720 上下限不再变化
- [ ] 双击手柄宽度立即回到 505
- [ ] 关闭面板再打开宽度保留；刷新页面宽度仍保留（DevTools 能看到 arcreel_assistant_panel_width）
- [ ] 大厅页向下滚动时 pill 栏的玻璃感与顶部标题栏一致；pill 按钮自身仍清晰可读
- [ ] cd frontend && pnpm lint && pnpm check 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 助手面板支持拖拽调整宽度，双击手柄可重置为默认宽度，宽度设置会被记住并恢复。

* **改进**
  * 调整时面板展开/收缩与动画更平滑；过滤器标签视觉样式优化以提升可读性与交互反馈。

* **国际化**
  * 为助手面板调整添加了英文、越南文和中文本地化文案。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/492)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/492)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->