### PR TITLE
fix(openai-text): API 返回非 JSON 时降级到 Instructor

### DIFF
--- a/lib/text_backends/openai.py
+++ b/lib/text_backends/openai.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 
 from openai import AsyncOpenAI, BadRequestError
@@ -96,6 +97,14 @@ class OpenAITextBackend:
         usage = response.usage
         choice = response.choices[0]
         output_tokens = usage.completion_tokens if usage else None
+        text = choice.message.content or ""
+
+        if request.response_schema and not _is_valid_json(text):
+            logger.warning(
+                "原生 response_format 返回非 JSON 内容（代理可能未支持 response_format），降级到 Instructor 路径",
+            )
+            return await _instructor_fallback(self._client, self._model, request, messages)
+
         warn_if_truncated(
             getattr(choice, "finish_reason", None),
             provider=PROVIDER_OPENAI,
@@ -103,7 +112,7 @@ class OpenAITextBackend:
             output_tokens=output_tokens,
         )
         return TextGenerationResult(
-            text=choice.message.content or "",
+            text=text,
             provider=PROVIDER_OPENAI,
             model=self._model,
             input_tokens=usage.prompt_tokens if usage else None,
@@ -144,6 +153,21 @@ _SCHEMA_ERROR_KEYWORDS = (
     "Cannot find field",
     "Invalid JSON payload",
 )
+
+
+def _is_valid_json(text: str) -> bool:
+    """判断字符串是否为合法 JSON。
+
+    一些 OpenAI 兼容代理（自定义供应商常见情况）会静默忽略 response_format
+    参数并返回纯文本/markdown，需要据此触发 Instructor 降级。
+    """
+    if not text or not text.strip():
+        return False
+    try:
+        json.loads(text)
+        return True
+    except (ValueError, TypeError):
+        return False
 
 
 def _is_schema_error(exc: BaseException) -> bool:

--- a/tests/test_openai_text_backend.py
+++ b/tests/test_openai_text_backend.py
@@ -208,6 +208,42 @@ class TestInstructorFallback:
         assert result.text == schema_response
         mock_fallback.assert_not_called()
 
+    async def test_non_json_response_triggers_instructor_fallback_pydantic(self):
+        """原生返回 200 但内容非 JSON（OpenAI 兼容代理静默忽略 response_format），应降级到 Instructor。"""
+        markdown_text = "## 小说关键信息提取\n\n- 主角: 张三\n- 题材: 都市悬疑\n开放式续集铺垫"
+        instructor_result = _PersonSchema(name="Bob", age=25)
+        instructor_completion = MagicMock()
+        instructor_completion.usage = MagicMock()
+        instructor_completion.usage.prompt_tokens = 50
+        instructor_completion.usage.completion_tokens = 20
+
+        mock_client = AsyncMock()
+        # 原生调用返回 200 + markdown 文本（无异常）
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(markdown_text, 100, 60))
+
+        mock_patched = AsyncMock()
+        mock_patched.chat.completions.create_with_completion = AsyncMock(
+            return_value=(instructor_result, instructor_completion)
+        )
+
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("instructor.from_openai", return_value=mock_patched),
+        ):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            backend = OpenAITextBackend(api_key="test-key")
+            request = TextGenerationRequest(
+                prompt="Extract info",
+                response_schema=_PersonSchema,
+            )
+            result = await backend.generate(request)
+
+        assert result.text == instructor_result.model_dump_json()
+        assert result.provider == PROVIDER_OPENAI
+        assert result.input_tokens == 50
+        assert result.output_tokens == 20
+
     async def test_bad_request_error_triggers_instructor_fallback_pydantic(self):
         """原生 response_format 抛 BadRequestError 且 schema 为 Pydantic 类时，走 Instructor 降级。"""
         mock_client = AsyncMock()


### PR DESCRIPTION
## Summary

- **问题**：使用自定义 OpenAI 兼容供应商生成项目概述时报错 `1 validation error for ProjectOverview Invalid JSON: expected value at line 1 column 1`，输入是 `## 小说关键信息提取...开放式续集铺垫` 的 markdown 文本。
- **根因**：`OpenAITextBackend` 给所有 OpenAI 兼容端点都设置 `response_format={"type":"json_schema","strict":true,...}`，但很多自定义代理（尤其是国内"OpenAI 兼容"网关）会**静默忽略** `response_format` 参数，返回 HTTP 200 + 纯 markdown。原生路径不报错 → `_is_schema_error` 不触发 → Instructor 降级不走 → markdown 直接传给 `ProjectOverview.model_validate_json()` 引爆。
- **修复**：在 `OpenAITextBackend.generate()` 拿到原生响应后，若 `request.response_schema` 已设但响应非合法 JSON，触发现有的 `_instructor_fallback()`（MD_JSON 模式：注入 JSON 指令 + Pydantic 解析 + 自动重试）。

## 影响范围

- 真·OpenAI 端点：`response_format` 一定返回合法 JSON → `_is_valid_json` 通过 → 不触发降级，行为不变
- 自定义代理：返回 markdown → 走 Instructor，问题解决
- 不影响无 `response_schema` 的纯文本路径
- 不影响已有的 `BadRequestError` 异常分支（仍然先抛错走原降级）

## Test plan

- [x] 新增 `test_non_json_response_triggers_instructor_fallback_pydantic` 覆盖代理静默忽略 `response_format` 场景
- [x] `tests/test_openai_text_backend.py` 17 个测试全绿
- [x] `tests/test_text_backends/` + `tests/test_script_generator.py` 共 96 个相关测试全绿
- [x] `ruff check` + `ruff format --check` 通过
- [ ] 手动复跑：用自定义 OpenAI-format 供应商生成项目概述，确认成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了结构化响应的处理机制，当返回内容不是有效JSON时，系统将自动触发降级处理，确保能获得有效的结构化数据。

* **Tests**
  * 新增测试覆盖非JSON响应场景下的降级处理流程，确保系统可靠性。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/493)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->