### PR TITLE
a11y(assets): AssetLibraryPage tabs 升级到 WAI-ARIA tablist (#488)

### DIFF
--- a/frontend/src/components/pages/AssetLibraryPage.test.tsx
+++ b/frontend/src/components/pages/AssetLibraryPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
@@ -57,38 +57,47 @@ describe("AssetLibraryPage tablist (issue #488)", () => {
     expect(prop).toHaveAttribute("tabindex", "-1");
   });
 
-  it("ArrowRight moves focus + selection to next tab and cycles at end", () => {
+  it("ArrowRight moves focus + selection to next tab and cycles at end", async () => {
     renderPage();
     const tabs = screen.getAllByRole("tab");
     tabs[0].focus();
     fireEvent.keyDown(tabs[0], { key: "ArrowRight" });
     expect(tabs[1]).toHaveAttribute("aria-selected", "true");
     expect(tabs[0]).toHaveAttribute("aria-selected", "false");
+    // roving focus 是 WAI-ARIA Tabs 规范的核心：方向键后激活 tab 必须获得焦点。
+    // moveTabFocus 用 requestAnimationFrame 异步搬，所以要 waitFor。
+    await waitFor(() => expect(tabs[1]).toHaveFocus());
 
     fireEvent.keyDown(tabs[1], { key: "ArrowRight" });
     expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+    await waitFor(() => expect(tabs[2]).toHaveFocus());
 
     // cycle back to first
     fireEvent.keyDown(tabs[2], { key: "ArrowRight" });
     expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+    await waitFor(() => expect(tabs[0]).toHaveFocus());
   });
 
-  it("ArrowLeft moves focus + selection to previous tab and cycles at start", () => {
+  it("ArrowLeft moves focus + selection to previous tab and cycles at start", async () => {
     renderPage();
     const tabs = screen.getAllByRole("tab");
     tabs[0].focus();
     fireEvent.keyDown(tabs[0], { key: "ArrowLeft" });
     // wraps to last
     expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+    await waitFor(() => expect(tabs[2]).toHaveFocus());
   });
 
-  it("Home jumps to first tab; End jumps to last tab", () => {
+  it("Home jumps to first tab; End jumps to last tab", async () => {
     renderPage();
     const tabs = screen.getAllByRole("tab");
     fireEvent.keyDown(tabs[0], { key: "End" });
     expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+    await waitFor(() => expect(tabs[2]).toHaveFocus());
+
     fireEvent.keyDown(tabs[2], { key: "Home" });
     expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+    await waitFor(() => expect(tabs[0]).toHaveFocus());
   });
 
   it("renders tabpanel labelled by the active tab id with stable shared id", () => {

--- a/frontend/src/components/pages/AssetLibraryPage.test.tsx
+++ b/frontend/src/components/pages/AssetLibraryPage.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Router } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
+import { API } from "@/api";
+import { useAssetsStore } from "@/stores/assets-store";
+import { AssetLibraryPage } from "./AssetLibraryPage";
+
+vi.mock("@/components/assets/AssetFormModal", () => ({
+  AssetFormModal: () => <div data-testid="asset-form-modal" />,
+}));
+
+function renderPage(initialPath = "/app/assets") {
+  const location = memoryLocation({ path: initialPath, record: true });
+  return {
+    ...render(
+      <Router hook={location.hook} searchHook={location.searchHook}>
+        <AssetLibraryPage />
+      </Router>,
+    ),
+    location,
+  };
+}
+
+describe("AssetLibraryPage tablist (issue #488)", () => {
+  beforeEach(() => {
+    useAssetsStore.setState(useAssetsStore.getInitialState(), true);
+    vi.spyOn(API, "listAssets").mockResolvedValue({ items: [] });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders nav with role=tablist + aria-orientation + aria-label", () => {
+    renderPage();
+    const tablist = screen.getByRole("tablist");
+    expect(tablist).toHaveAttribute("aria-orientation", "horizontal");
+    expect(tablist).toHaveAttribute("aria-label", "资产类型");
+  });
+
+  it("renders three tab buttons with role=tab + aria-selected reflecting active tab", () => {
+    renderPage();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(3);
+    // character active by default
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[1]).toHaveAttribute("aria-selected", "false");
+    expect(tabs[2]).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("applies roving tabindex (active=0, others=-1)", () => {
+    renderPage();
+    const [character, scene, prop] = screen.getAllByRole("tab");
+    expect(character).toHaveAttribute("tabindex", "0");
+    expect(scene).toHaveAttribute("tabindex", "-1");
+    expect(prop).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("ArrowRight moves focus + selection to next tab and cycles at end", () => {
+    renderPage();
+    const tabs = screen.getAllByRole("tab");
+    tabs[0].focus();
+    fireEvent.keyDown(tabs[0], { key: "ArrowRight" });
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[0]).toHaveAttribute("aria-selected", "false");
+
+    fireEvent.keyDown(tabs[1], { key: "ArrowRight" });
+    expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+
+    // cycle back to first
+    fireEvent.keyDown(tabs[2], { key: "ArrowRight" });
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("ArrowLeft moves focus + selection to previous tab and cycles at start", () => {
+    renderPage();
+    const tabs = screen.getAllByRole("tab");
+    tabs[0].focus();
+    fireEvent.keyDown(tabs[0], { key: "ArrowLeft" });
+    // wraps to last
+    expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("Home jumps to first tab; End jumps to last tab", () => {
+    renderPage();
+    const tabs = screen.getAllByRole("tab");
+    fireEvent.keyDown(tabs[0], { key: "End" });
+    expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+    fireEvent.keyDown(tabs[2], { key: "Home" });
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("renders tabpanel labelled by the active tab id", () => {
+    renderPage();
+    const panel = screen.getByRole("tabpanel");
+    expect(panel).toHaveAttribute("id", "asset-panel-character");
+    expect(panel).toHaveAttribute("aria-labelledby", "asset-tab-character");
+  });
+
+  it("respects URL ?tab=scene as initial active tab", () => {
+    renderPage("/app/assets?tab=scene");
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toHaveAttribute("aria-selected", "false");
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[2]).toHaveAttribute("aria-selected", "false");
+  });
+});

--- a/frontend/src/components/pages/AssetLibraryPage.test.tsx
+++ b/frontend/src/components/pages/AssetLibraryPage.test.tsx
@@ -64,17 +64,24 @@ describe("AssetLibraryPage tablist (issue #488)", () => {
     fireEvent.keyDown(tabs[0], { key: "ArrowRight" });
     expect(tabs[1]).toHaveAttribute("aria-selected", "true");
     expect(tabs[0]).toHaveAttribute("aria-selected", "false");
-    // roving focus 是 WAI-ARIA Tabs 规范的核心：方向键后激活 tab 必须获得焦点。
-    // moveTabFocus 用 requestAnimationFrame 异步搬，所以要 waitFor。
+    // roving tabindex + focus 都是 WAI-ARIA Tabs 规范要求：激活 tab tabindex=0
+    // 进 Tab 序列、其他=-1 跳过；激活 tab 必须真的拿到焦点。moveTabFocus 用
+    // requestAnimationFrame 异步搬焦点，所以 focus 断言要 waitFor。
+    expect(tabs[1]).toHaveAttribute("tabindex", "0");
+    expect(tabs[0]).toHaveAttribute("tabindex", "-1");
     await waitFor(() => expect(tabs[1]).toHaveFocus());
 
     fireEvent.keyDown(tabs[1], { key: "ArrowRight" });
     expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[2]).toHaveAttribute("tabindex", "0");
+    expect(tabs[1]).toHaveAttribute("tabindex", "-1");
     await waitFor(() => expect(tabs[2]).toHaveFocus());
 
     // cycle back to first
     fireEvent.keyDown(tabs[2], { key: "ArrowRight" });
     expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[0]).toHaveAttribute("tabindex", "0");
+    expect(tabs[2]).toHaveAttribute("tabindex", "-1");
     await waitFor(() => expect(tabs[0]).toHaveFocus());
   });
 
@@ -85,6 +92,8 @@ describe("AssetLibraryPage tablist (issue #488)", () => {
     fireEvent.keyDown(tabs[0], { key: "ArrowLeft" });
     // wraps to last
     expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[2]).toHaveAttribute("tabindex", "0");
+    expect(tabs[0]).toHaveAttribute("tabindex", "-1");
     await waitFor(() => expect(tabs[2]).toHaveFocus());
   });
 
@@ -93,10 +102,14 @@ describe("AssetLibraryPage tablist (issue #488)", () => {
     const tabs = screen.getAllByRole("tab");
     fireEvent.keyDown(tabs[0], { key: "End" });
     expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[2]).toHaveAttribute("tabindex", "0");
+    expect(tabs[0]).toHaveAttribute("tabindex", "-1");
     await waitFor(() => expect(tabs[2]).toHaveFocus());
 
     fireEvent.keyDown(tabs[2], { key: "Home" });
     expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[0]).toHaveAttribute("tabindex", "0");
+    expect(tabs[2]).toHaveAttribute("tabindex", "-1");
     await waitFor(() => expect(tabs[0]).toHaveFocus());
   });
 

--- a/frontend/src/components/pages/AssetLibraryPage.test.tsx
+++ b/frontend/src/components/pages/AssetLibraryPage.test.tsx
@@ -91,11 +91,21 @@ describe("AssetLibraryPage tablist (issue #488)", () => {
     expect(tabs[0]).toHaveAttribute("aria-selected", "true");
   });
 
-  it("renders tabpanel labelled by the active tab id", () => {
+  it("renders tabpanel labelled by the active tab id with stable shared id", () => {
     renderPage();
     const panel = screen.getByRole("tabpanel");
-    expect(panel).toHaveAttribute("id", "asset-panel-character");
+    // 所有 tab 共用同一个 panel id，避免未激活 tab 的 aria-controls
+    // 指向不存在的 DOM 元素（WAI-ARIA 1.2 要求引用必须可解析）。
+    expect(panel).toHaveAttribute("id", "asset-panel");
     expect(panel).toHaveAttribute("aria-labelledby", "asset-tab-character");
+
+    // 每个 tab 的 aria-controls 都必须能在 DOM 中找到目标
+    const tabs = screen.getAllByRole("tab");
+    for (const tab of tabs) {
+      const controls = tab.getAttribute("aria-controls");
+      expect(controls).toBeTruthy();
+      expect(document.getElementById(controls!)).not.toBeNull();
+    }
   });
 
   it("respects URL ?tab=scene as initial active tab", () => {

--- a/frontend/src/components/pages/AssetLibraryPage.tsx
+++ b/frontend/src/components/pages/AssetLibraryPage.tsx
@@ -261,7 +261,7 @@ export function AssetLibraryPage() {
                 role="tab"
                 id={`asset-tab-${type}`}
                 aria-selected={active}
-                aria-controls={`asset-panel-${type}`}
+                aria-controls="asset-panel"
                 tabIndex={active ? 0 : -1}
                 onClick={() => setActiveTab(type)}
                 onKeyDown={(e) => handleTabKeyDown(e, type)}
@@ -285,10 +285,10 @@ export function AssetLibraryPage() {
       <main className="relative mx-auto w-full max-w-6xl flex-1 px-6 py-8">
         <div
           role="tabpanel"
-          id={`asset-panel-${activeTab}`}
+          id="asset-panel"
           aria-labelledby={`asset-tab-${activeTab}`}
           tabIndex={0}
-          className="focus:outline-none"
+          className="rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
         {assets.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-hairline bg-bg-grad-a/30 py-24 text-center">

--- a/frontend/src/components/pages/AssetLibraryPage.tsx
+++ b/frontend/src/components/pages/AssetLibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { useLocation, useSearch } from "wouter";
 import { useTranslation } from "react-i18next";
 import { ChevronLeft, Landmark, Package as PackageIcon, Plus, Search, User } from "lucide-react";
@@ -73,6 +73,39 @@ export function AssetLibraryPage() {
   }, [navigate]);
 
   const setActiveTab = useCallback((next: AssetType) => writeQuery({ tab: next }), [writeQuery]);
+
+  // WAI-ARIA tablist 键盘导航（issue #488）：roving tabindex + 方向键 + Home/End。
+  // 切换后用 requestAnimationFrame 把焦点搬到新激活 tab，避免与 React commit 抢时序。
+  const tabRefs = useRef<Map<AssetType, HTMLButtonElement>>(new Map());
+  const moveTabFocus = useCallback(
+    (next: AssetType) => {
+      setActiveTab(next);
+      requestAnimationFrame(() => {
+        tabRefs.current.get(next)?.focus();
+      });
+    },
+    [setActiveTab],
+  );
+  const handleTabKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, current: AssetType) => {
+      const idx = TABS.findIndex((tab) => tab.type === current);
+      if (idx < 0) return;
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        moveTabFocus(TABS[(idx + 1) % TABS.length].type);
+      } else if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        moveTabFocus(TABS[(idx - 1 + TABS.length) % TABS.length].type);
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        moveTabFocus(TABS[0].type);
+      } else if (event.key === "End") {
+        event.preventDefault();
+        moveTabFocus(TABS[TABS.length - 1].type);
+      }
+    },
+    [moveTabFocus],
+  );
 
   const urlQ = useMemo(() => new URLSearchParams(search).get("q") ?? "", [search]);
   const [q, setQ] = useState(urlQ);
@@ -205,7 +238,12 @@ export function AssetLibraryPage() {
           </div>
         </div>
 
-        <nav className="mx-auto flex max-w-6xl items-center gap-2 px-6 pb-3">
+        <div
+          role="tablist"
+          aria-orientation="horizontal"
+          aria-label={t("library_tabs_label")}
+          className="mx-auto flex max-w-6xl items-center gap-2 px-6 pb-3"
+        >
           {TABS.map(({ type, icon: Icon }) => {
             const active = activeTab === type;
             const count = byType[type].length;
@@ -215,9 +253,18 @@ export function AssetLibraryPage() {
             return (
               <button
                 key={type}
+                ref={(el) => {
+                  if (el) tabRefs.current.set(type, el);
+                  else tabRefs.current.delete(type);
+                }}
                 type="button"
+                role="tab"
+                id={`asset-tab-${type}`}
+                aria-selected={active}
+                aria-controls={`asset-panel-${type}`}
+                tabIndex={active ? 0 : -1}
                 onClick={() => setActiveTab(type)}
-                aria-pressed={active}
+                onKeyDown={(e) => handleTabKeyDown(e, type)}
                 className={`inline-flex items-center gap-2 rounded-[8px] border px-3.5 py-2 text-[12.5px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${cls}`}
               >
                 <Icon className={`h-4 w-4 ${active ? "text-accent-2" : "text-text-4"}`} />
@@ -232,10 +279,17 @@ export function AssetLibraryPage() {
               </button>
             );
           })}
-        </nav>
+        </div>
       </header>
 
       <main className="relative mx-auto w-full max-w-6xl flex-1 px-6 py-8">
+        <div
+          role="tabpanel"
+          id={`asset-panel-${activeTab}`}
+          aria-labelledby={`asset-tab-${activeTab}`}
+          tabIndex={0}
+          className="focus:outline-none"
+        >
         {assets.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-hairline bg-bg-grad-a/30 py-24 text-center">
             <div className="flex h-12 w-12 items-center justify-center rounded-full bg-accent-dim text-accent-2">
@@ -260,6 +314,7 @@ export function AssetLibraryPage() {
             onDelete={handleDeleteAsset}
           />
         )}
+        </div>
       </main>
 
       {formModal && (

--- a/frontend/src/i18n/en/assets.ts
+++ b/frontend/src/i18n/en/assets.ts
@@ -21,6 +21,7 @@ export default {
   "close": "Close",
   "library_title": "Asset Library",
   "library_subtitle": "Characters, scenes and props reusable across projects",
+  "library_tabs_label": "Asset type",
   "back_to_projects": "Back to projects",
   "add_asset": "New asset",
   "search_placeholder": "Search assets...",

--- a/frontend/src/i18n/vi/assets.ts
+++ b/frontend/src/i18n/vi/assets.ts
@@ -23,6 +23,7 @@ export default {
   "close": "Đóng",
   "library_title": "Thư viện tài nguyên",
   "library_subtitle": "Nhân vật, cảnh và đạo cụ có thể tái sử dụng giữa các dự án",
+  "library_tabs_label": "Loại tài nguyên",
   "back_to_projects": "Quay lại danh sách dự án",
   "add_asset": "Thêm tài nguyên",
   "search_placeholder": "Tìm kiếm tài nguyên...",

--- a/frontend/src/i18n/zh/assets.ts
+++ b/frontend/src/i18n/zh/assets.ts
@@ -23,6 +23,7 @@ export default {
   "close": "关闭",
   "library_title": "资产库",
   "library_subtitle": "跨项目复用的人物、场景与道具",
+  "library_tabs_label": "资产类型",
   "back_to_projects": "返回项目",
   "add_asset": "新增资产",
   "search_placeholder": "搜索资产...",


### PR DESCRIPTION
## Summary

\`AssetLibraryPage\` 的 character / scene / prop 三 tab 从 \`<button aria-pressed>\` 升级到完整 WAI-ARIA tabs pattern，屏幕阅读器读到"标签 1 / 3"语义、键盘方向键单键切换。

- \`<nav>\` → \`<div role="tablist" aria-orientation="horizontal" aria-label>\`
- 每个 tab \`role="tab" aria-selected aria-controls id\`
- roving tabindex（active=0、其他=-1，tablist 在 Tab 序列只占一格）
- 方向键：ArrowLeft / ArrowRight 循环、Home / End 跳首尾
- 切换后 \`requestAnimationFrame\` 把焦点搬到新激活 tab，避开 React commit 时序
- 内容区包 \`<div role="tabpanel" id aria-labelledby>\`，保留 \`<main>\` 作 landmark
- 保留 \`useSearch\` URL \`?tab=scene\` 同步逻辑

i18n 新增 \`library_tabs_label\`（zh/en/vi 三语齐全），后端 \`tests/test_i18n_consistency.py\` 校验不受影响。

## Test plan

- [x] \`pnpm check\` 全绿，新增 \`AssetLibraryPage.test.tsx\` 8 个单测覆盖 tablist 属性 / ArrowRight 循环 / ArrowLeft 反向循环 / Home / End / tabpanel 关联 / URL \`?tab=scene\` 初始激活
- [ ] 浏览器键盘走查：搜索框 Tab 进 tablist → ArrowRight/Left 三 tab 循环 → Home/End 跳首尾
- [ ] VoiceOver / NVDA 走查：读出"标签 character, 选中, 1 / 3"

Closes #488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 资源库页面选项卡现在支持完整键盘导航（左右箭头、Home、End）并采用漫游焦点管理，提升无障碍体验与键盘可用性，选中状态与焦点行为更一致。
* **测试**
  * 新增针对选项卡可访问性的测试覆盖：键盘交互、焦点移动、选中状态、标签与面板的关联性及 URL 初始化行为。
* **本地化**
  * 为选项卡标签新增英文、越南语与中文翻译以支持多语言显示。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/501)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->