### PR TITLE
perf(i18n): 按需加载 i18n namespace，首屏 bundle -56KB gzip (#489)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "framer-motion": "^12.38.0",
     "i18next": "^26.0.8",
     "i18next-browser-languagedetector": "^8.2.1",
+    "i18next-resources-to-backend": "^1.2.1",
     "lucide-react": "^1.11.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       i18next-browser-languagedetector:
         specifier: ^8.2.1
         version: 8.2.1
+      i18next-resources-to-backend:
+        specifier: ^1.2.1
+        version: 1.2.1
       lucide-react:
         specifier: ^1.11.0
         version: 1.11.0(react@19.2.6)
@@ -2895,6 +2898,9 @@ packages:
 
   i18next-browser-languagedetector@8.2.1:
     resolution: {integrity: sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==}
+
+  i18next-resources-to-backend@1.2.1:
+    resolution: {integrity: sha512-okHbVA+HZ7n1/76MsfhPqDou0fptl2dAlhRDu2ideXloRRduzHsqDOznJBef+R3DFZnbvWoBW+KxJ7fnFjd6Yw==}
 
   i18next@26.0.8:
     resolution: {integrity: sha512-BRzLom0mhDhV9v0QhgUUHWQJuwFmnr1194xEcNLYD6ym8y8s542n4jXUvRLnhNTbh9PmpU6kGZamyuGHQMsGjw==}
@@ -8044,6 +8050,10 @@ snapshots:
   html-void-elements@3.0.0: {}
 
   i18next-browser-languagedetector@8.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+
+  i18next-resources-to-backend@1.2.1:
     dependencies:
       '@babel/runtime': 7.29.2
 

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,29 +1,18 @@
-
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
-import { voidCall } from '@/utils/async';
+import resourcesToBackend from 'i18next-resources-to-backend';
 
-import enCommon from './en/common';
-import enAuth from './en/auth';
-import enDashboard from './en/dashboard';
-import enErrors from './en/errors';
-import enTemplates from './en/templates';
-import enAssets from './en/assets';
+// 按需加载 i18n namespace（issue #489）：
+// Vite import.meta.glob 在编译期为每个 (lang, ns) 文件生成独立 chunk；运行时由
+// i18next 异步 load。资源仍是 .ts（保留 satisfies Record schema 锁），不是 JSON。
+const loaders = import.meta.glob<{ default: Record<string, string> }>(
+  './{en,zh,vi}/*.ts',
+);
 
-import zhCommon from './zh/common';
-import zhAuth from './zh/auth';
-import zhDashboard from './zh/dashboard';
-import zhErrors from './zh/errors';
-import zhTemplates from './zh/templates';
-import zhAssets from './zh/assets';
-
-import viCommon from './vi/common';
-import viAuth from './vi/auth';
-import viDashboard from './vi/dashboard';
-import viErrors from './vi/errors';
-import viTemplates from './vi/templates';
-import viAssets from './vi/assets';
+function pathFor(lang: string, ns: string): string {
+  return `./${lang}/${ns}.ts`;
+}
 
 export const SUPPORTED_LANGUAGES = ['zh', 'en', 'vi'] as const;
 export type SupportedLanguage = typeof SUPPORTED_LANGUAGES[number];
@@ -34,47 +23,38 @@ export const LANGUAGE_DISPLAY_LABELS: Record<SupportedLanguage, string> = {
   vi: 'Tiếng Việt',
 };
 
-const resources = {
-  en: {
-    common: enCommon,
-    auth: enAuth,
-    dashboard: enDashboard,
-    errors: enErrors,
-    templates: enTemplates,
-    assets: enAssets,
-  },
-  zh: {
-    common: zhCommon,
-    auth: zhAuth,
-    dashboard: zhDashboard,
-    errors: zhErrors,
-    templates: zhTemplates,
-    assets: zhAssets,
-  },
-  vi: {
-    common: viCommon,
-    auth: viAuth,
-    dashboard: viDashboard,
-    errors: viErrors,
-    templates: viTemplates,
-    assets: viAssets,
-  },
-};
+export const I18N_NAMESPACES = [
+  'common',
+  'auth',
+  'dashboard',
+  'errors',
+  'templates',
+  'assets',
+] as const;
 
-voidCall(i18n
+// 返回 init Promise，调用方（main.tsx / test setup）await 后再 render，避免首屏闪 key。
+export const i18nReady = i18n
+  .use(
+    resourcesToBackend(async (lang: string, ns: string) => {
+      const loader = loaders[pathFor(lang, ns)];
+      if (!loader) {
+        throw new Error(`i18n: missing locale file ${pathFor(lang, ns)}`);
+      }
+      const mod = await loader();
+      return mod.default;
+    }),
+  )
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    resources,
     fallbackLng: 'zh',
     supportedLngs: SUPPORTED_LANGUAGES as unknown as string[],
     debug: false,
-    interpolation: {
-      escapeValue: false,
-    },
-    // Use 'common' as the default namespace
+    interpolation: { escapeValue: false },
     defaultNS: 'common',
-    ns: ['common', 'auth', 'dashboard', 'errors', 'templates', 'assets'],
-  }));
+    ns: I18N_NAMESPACES as unknown as string[],
+    partialBundledLanguages: true,
+    react: { useSuspense: false },
+  });
 
 export default i18n;

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -38,7 +38,11 @@ export const i18nReady = i18n
     resourcesToBackend(async (lang: string, ns: string) => {
       const loader = loaders[pathFor(lang, ns)];
       if (!loader) {
-        throw new Error(`i18n: missing locale file ${pathFor(lang, ns)}`);
+        // LanguageDetector 可能解析出 zh-CN / en-GB 等带区域的 BCP47 代码，
+        // i18next 会先按完整代码请求一次再 fallback 到 zh/en。这是预期路径，
+        // 不应该升级成异常。返回空对象让 i18next 走 fallback 链。
+        console.warn(`i18n: no resource for ${pathFor(lang, ns)}, falling back`);
+        return {};
       }
       const mod = await loader();
       return mod.default;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,7 +5,7 @@
 import { createRoot } from "react-dom/client";
 import { AppRoutes } from "./router";
 import { useAuthStore } from "@/stores/auth-store";
-import "./i18n/index";
+import { i18nReady } from "./i18n/index";
 
 import "./index.css";
 import "./css/styles.css";
@@ -49,5 +49,9 @@ useAuthStore.getState().initialize();
 
 const root = document.getElementById("app-root");
 if (root) {
-  createRoot(root).render(<AppRoutes />);
+  // 等 i18n 当前语言 + fallback 的 namespace 全部加载完再渲染，避免首屏闪 key。
+  // chunk 都是本地 lazy import，弱网下也只是几十 ms 延迟（cold start）。
+  void i18nReady.finally(() => {
+    createRoot(root).render(<AppRoutes />);
+  });
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,7 +5,7 @@
 import { createRoot } from "react-dom/client";
 import { AppRoutes } from "./router";
 import { useAuthStore } from "@/stores/auth-store";
-import { i18nReady } from "./i18n/index";
+import { i18nReady } from "@/i18n";
 
 import "./index.css";
 import "./css/styles.css";
@@ -51,7 +51,11 @@ const root = document.getElementById("app-root");
 if (root) {
   // 等 i18n 当前语言 + fallback 的 namespace 全部加载完再渲染，避免首屏闪 key。
   // chunk 都是本地 lazy import，弱网下也只是几十 ms 延迟（cold start）。
-  void i18nReady.finally(() => {
-    createRoot(root).render(<AppRoutes />);
+  // i18n 加载失败时不能阻塞应用启动（仍 render，让 t() 退回 key 字符串），
+  // 但失败必须可观测——所以显式记 error 而不是用 finally 把成功/失败合流静默。
+  const render = () => createRoot(root).render(<AppRoutes />);
+  i18nReady.then(render, (err) => {
+    console.error("i18n initialization failed", err);
+    render();
   });
 }

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,10 +1,12 @@
 import "@testing-library/jest-dom/vitest";
 import { afterEach, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
-import i18n from "@/i18n";
-import { voidCall } from "@/utils/async";
+import i18n, { i18nReady } from "@/i18n";
 
-voidCall(i18n.changeLanguage("zh"));
+// i18n 改为 lazy backend (issue #489) 后，测试运行前必须 await 资源加载完，
+// 否则首次 t() 返回 key 字符串而不是中文，断言会失败。
+await i18nReady;
+await i18n.changeLanguage("zh");
 
 // jsdom 默认不实现 ResizeObserver；@floating-ui/react 的 autoUpdate 会调它来
 // 跟踪 reference / floating 元素尺寸变化。用空 stub 即可，测试只断言可见性、


### PR DESCRIPTION
## Summary

把 \`frontend/src/i18n/index.ts\` 的 18 个静态 import（3 语言 × 6 namespace）改成 Vite \`import.meta.glob\` lazy import + \`i18next-resources-to-backend\` 异步 backend。资源仍是 \`.ts\`（保留 PR #486 的 \`satisfies Record\` schema 锁），不是 JSON；每个 (lang, ns) 在编译期单独成 chunk，按需加载。

- 新增依赖 \`i18next-resources-to-backend@^1.2.1\`（~1 KB）
- \`i18n/index.ts\` 导出 \`i18nReady\` Promise（init + 当前 lang 所有 ns 就绪）
- \`main.tsx\` 在 \`createRoot.render\` 前 \`await i18nReady\`，避免首屏闪 key（无需 Suspense 边界）
- \`test/setup.ts\` 同样 top-level \`await i18nReady\`，保证测试中 \`t()\` 拿到中文

## Bundle 验证

| | before | after | diff |
|--|--|--|--|
| main chunk raw | 1.39 MB | **1.21 MB** | **-180 KB** |
| main chunk gzip | 385 KB | **329 KB** | **-56 KB** |

三语 \`dashboard\` / \`common\` / \`errors\` / \`assets\` / \`templates\` / \`auth\` 全部按 (lang, ns) 拆为独立 chunk。\`grep "跨项目复用的人物" dist/assets/*.js\` 仅命中独立 \`assets-HwFoJqaw.js\` chunk，main 不含。

## Test plan

- [x] \`pnpm check\` 全绿（72 文件 / 519 测试），i18n setup 改用 \`await i18nReady\` 后所有测试稳定
- [x] \`pnpm build\` 验证 chunk 拆分（见上表）
- [ ] 浏览器 Network 走查：首次进入只下载当前语言 6 个 ns chunk；切到第二语言时按需加载、不重复加载已缓存的
- [ ] 弱网冷启动走查：首屏 spinner 闪烁是否可接受

Closes #489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进国际化加载为按需异步获取命名空间，减少首屏未翻译的情况。
  * 启动流程调整为在翻译准备好后再渲染，若初始化失败仍安全挂载应用以避免阻断启动。
  * 测试环境同步等待翻译初始化，确保断言读取到已加载的文案。

* **Chores**
  * 添加了用于按需加载翻译资源的运行时依赖（i18next 后端适配器）。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/502)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->