### PR TITLE
fix(status): 按产物倒序判定阶段，overview 降级为软信号

### DIFF
--- a/lib/status_calculator.py
+++ b/lib/status_calculator.py
@@ -143,20 +143,47 @@ class StatusCalculator:
             )
             return "generated", None
 
-    def calculate_current_phase(self, project: dict, episodes_stats: list[dict]) -> str:
-        """根据项目和集状态推断当前阶段"""
-        if not project.get("overview"):
-            return "setup"
-        if not episodes_stats:
-            return "worldbuilding"
-        any_generated = any(s["script_status"] == "generated" for s in episodes_stats)
-        all_generated = all(s["script_status"] == "generated" for s in episodes_stats)
-        if not any_generated:
-            return "worldbuilding"
-        if not all_generated:
+    def calculate_current_phase(
+        self,
+        project: dict,
+        episodes_stats: list[dict],
+        *,
+        assets_completed: int = 0,
+    ) -> str:
+        """根据项目和集状态推断当前阶段（按实际产物倒序判定）。
+
+        判定顺序（高优先级在前）：
+        1. 已有任意一集脚本生成 → ``scripting`` / ``production`` / ``completed``
+        2. 已有任意分段草稿、资产设计图（character/scene/prop sheet）或 overview
+           → ``worldbuilding``
+        3. 其它（全新项目）→ ``setup``
+
+        这避免了「用户跳过 overview 直接做剧本/分镜/视频，阶段却卡在 setup」
+        的体验问题——overview 只是 worldbuilding 的一种入口信号，而不是
+        离开 setup 的必经门票。
+        """
+        any_generated = False
+        all_generated = bool(episodes_stats)
+        any_segmented = False
+        all_completed = bool(episodes_stats)
+        for s in episodes_stats:
+            script_status = s["script_status"]
+            if script_status == "generated":
+                any_generated = True
+            else:
+                all_generated = False
+                if script_status == "segmented":
+                    any_segmented = True
+            if s.get("status") != "completed":
+                all_completed = False
+
+        if all_generated:
+            return "completed" if all_completed else "production"
+        if any_generated:
             return "scripting"
-        all_completed = all(s["status"] == "completed" for s in episodes_stats)
-        return "completed" if all_completed else "production"
+        if any_segmented or assets_completed > 0 or project.get("overview"):
+            return "worldbuilding"
+        return "setup"
 
     def _calculate_phase_progress(self, project: dict, phase: str, episodes_stats: list[dict]) -> float:
         """计算当前阶段完成率 0.0–1.0"""
@@ -270,7 +297,11 @@ class StatusCalculator:
         else:
             episodes_stats = self._build_episodes_stats(project_name, project, preloaded_scripts=preloaded_scripts)
 
-        phase = self.calculate_current_phase(project, episodes_stats)
+        phase = self.calculate_current_phase(
+            project,
+            episodes_stats,
+            assets_completed=chars_done + scenes_done + props_done,
+        )
         phase_progress = self._calculate_phase_progress(project, phase, episodes_stats)
         if phase == "worldbuilding":
             total_assets = chars_total + scenes_total + props_total

--- a/tests/test_status_calculator.py
+++ b/tests/test_status_calculator.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from lib.status_calculator import StatusCalculator
 
 
@@ -124,6 +126,8 @@ class TestStatusCalculator:
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
         project_no_overview = {}
         assert calc.calculate_current_phase(project_no_overview, []) == "setup"
+        # 即使有空集列表，但无 overview 且无资产 → 仍是 setup
+        assert calc.calculate_current_phase(project_no_overview, [], assets_completed=0) == "setup"
 
     def test_calculate_current_phase_worldbuilding(self, tmp_path):
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
@@ -133,6 +137,10 @@ class TestStatusCalculator:
         assert calc.calculate_current_phase(project, episodes_stats) == "worldbuilding"
         # 无集 → worldbuilding
         assert calc.calculate_current_phase(project, []) == "worldbuilding"
+        # 没有 overview，但已有资产产出 → 仍判定为 worldbuilding（不卡在 setup）
+        assert calc.calculate_current_phase({}, [], assets_completed=1) == "worldbuilding"
+        # 没有 overview / 资产，但已有分段草稿 → 仍判定为 worldbuilding
+        assert calc.calculate_current_phase({}, [{"script_status": "segmented"}], assets_completed=0) == "worldbuilding"
 
     def test_calculate_current_phase_scripting(self, tmp_path):
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
@@ -143,6 +151,8 @@ class TestStatusCalculator:
             {"script_status": "none"},
         ]
         assert calc.calculate_current_phase(project, episodes_stats) == "scripting"
+        # 没有 overview 也一样：脚本产物本身就是更强信号
+        assert calc.calculate_current_phase({}, episodes_stats) == "scripting"
 
     def test_calculate_current_phase_production_and_completed(self, tmp_path):
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
@@ -158,6 +168,35 @@ class TestStatusCalculator:
             {"script_status": "generated", "status": "completed"},
         ]
         assert calc.calculate_current_phase(project, episodes_stats_done) == "completed"
+        # 没有 overview 也一样：production / completed 由脚本与视频状态决定
+        assert calc.calculate_current_phase({}, episodes_stats) == "production"
+        assert calc.calculate_current_phase({}, episodes_stats_done) == "completed"
+
+    @pytest.mark.unit
+    def test_calculate_current_phase_regression_no_overview_with_artifacts(self, tmp_path):
+        """回归：项目缺 overview 但已生成资产+脚本+部分视频，阶段必须前进。
+
+        历史 bug：``calculate_current_phase`` 早退判定 ``if not overview: return "setup"``
+        导致用户跳过 overview 直接做后续步骤时，阶段进度条永远卡在「筹备」。
+        """
+        calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
+        project = {"title": "无 overview 的项目"}
+
+        # 仅有资产 → worldbuilding（之前会被错判为 setup）
+        assert calc.calculate_current_phase(project, [], assets_completed=2) == "worldbuilding"
+
+        # 资产 + 部分脚本 → scripting
+        partial_scripts = [
+            {"script_status": "generated", "status": "draft"},
+            {"script_status": "none"},
+        ]
+        assert calc.calculate_current_phase(project, partial_scripts, assets_completed=3) == "scripting"
+
+        # 资产 + 全部脚本 + 部分视频 → production
+        all_scripts_in_prod = [
+            {"script_status": "generated", "status": "in_production"},
+        ]
+        assert calc.calculate_current_phase(project, all_scripts_in_prod, assets_completed=3) == "production"
 
     def test_calculate_project_status(self, tmp_path):
         project_root = tmp_path / "projects"


### PR DESCRIPTION
## 动机

线上观察到：用户直接通过AI助手对话，已生成角色/场景/道具设计图、剧本、分镜、视频，前端阶段进度条仍卡在「筹备」。根因是 `calculate_current_phase` 第一句 `if not project.get("overview"): return "setup"` 早退，跳过项目概述生成步骤的用户永远走不出阶段 1。可见产物应胜过这个可选元数据字段。

## 范围

`lib/status_calculator.py` + `tests/test_status_calculator.py`，不动其他模块（router / front-end / DB schema 均无变化）。

## 变更

- `calculate_current_phase()` 改为按产物倒序判定：
  1. 任意一集脚本已生成 → `scripting` / `production` / `completed`
  2. 否则有任意资产 sheet 或 `project.overview` → `worldbuilding`
  3. 否则 → `setup`
- 新增 keyword-only 参数 `assets_completed`（默认 0，保持调用方向后兼容）。`calculate_project_status` 本来就在统计 `chars_done + scenes_done + props_done`，原地透传，无新增 I/O。
- `overview` 从「离开 setup 的硬门票」降级为「worldbuilding 入口信号之一」。
- 新增回归测试 `test_calculate_current_phase_regression_no_overview_with_artifacts`（覆盖三段式产物推进）；为现有 4 个 phase 测试补充「无 overview」断言。

## 验收清单

- [x] 本地已跑相关测试：`uv run pytest tests/test_status_calculator.py -v` → 14/14 通过；`uv run pytest -q -k "status or phase or project_status"` → 43/43 通过
- [x] 手动验证：生产环境一个无 overview 但已生成分镜+视频的项目，补丁前停在 `setup`；补丁后 `current_phase` 推进到 `production`
- [x] 新增面向用户文案：无（纯后端状态机改动）
- [x] 无新增 ESLint disable
- [x] CODEOWNERS review 已请求（自动触发）

## 已知 defer

无。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了项目阶段判定逻辑：在缺少概览时也会基于已完成的脚本/视频/资产判断阶段，不再过早返回“setup”，能更准确反映已完成的设计资产。

* **Tests**
  * 新增回归单元测试，验证在缺少概览但存在脚本/媒体/资产时阶段会继续推进，防止早退回归。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/505)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->