### PR TITLE
fix(docker): skip corepack download prompt in non-TTY builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ FROM node:22-slim AS frontend-builder
 WORKDIR /build/frontend
 
 # 启用 corepack；pnpm 版本由 frontend/package.json 的 packageManager 字段固定
+# 关闭交互式下载确认，否则 docker build 这种非 TTY 环境会卡在
+# "Corepack is about to download ..." 直到超时
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable
 
 # 先复制依赖文件，利用缓存（corepack 按 packageManager 字段自动下载对应 pnpm）


### PR DESCRIPTION
Corepack >= 0.27 prompts for confirmation before downloading the packageManager-pinned pnpm version. Inside 'docker build' there is no TTY, so the prompt waits forever and the build eventually times out.

Set COREPACK_ENABLE_DOWNLOAD_PROMPT=0 before 'corepack enable' so the download proceeds non-interactively. No behavior change on hosts that already have pnpm cached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 琐事

* **构建优化**
  * 改进了Docker构建流程配置，增强了构建过程在自动化环境中的稳定性和兼容性。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/513)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->