### PR TITLE
fix(ark): 显式注入 Seedream size 参数，修复项目 aspect_ratio 失效

### DIFF
--- a/lib/image_backends/ark.py
+++ b/lib/image_backends/ark.py
@@ -20,6 +20,45 @@ from lib.retry import with_retry_async
 
 logger = logging.getLogger(__name__)
 
+# Seedream `size` 参数：不传时 4.x/5.x 默认 2048x2048（1:1），3.0-t2i 默认 1024x1024（1:1）。
+# 不显式传 size 会让项目设置的 aspect_ratio 完全失效。
+#
+# Ark 官方推荐宽高像素值（方式 2）：
+#   - 4.x/5.x 系列 2K 档（总像素须 ≥ 3_686_400）
+#   - 3.0-t2i 系列 1K 档（单边 ∈ [512, 2048]）
+# 参考：https://www.volcengine.com/docs/82379/1666946
+_SEEDREAM_2K_SIZE_MAP: dict[str, str] = {
+    "1:1": "2048x2048",
+    "4:3": "2304x1728",
+    "3:4": "1728x2304",
+    "16:9": "2848x1600",
+    "9:16": "1600x2848",
+    "3:2": "2496x1664",
+    "2:3": "1664x2496",
+    "21:9": "3136x1344",
+}
+_SEEDREAM_1K_SIZE_MAP: dict[str, str] = {
+    "1:1": "1024x1024",
+    "4:3": "1152x864",
+    "3:4": "864x1152",
+    "16:9": "1280x720",
+    "9:16": "720x1280",
+    "3:2": "1248x832",
+    "2:3": "832x1248",
+    "21:9": "1512x648",
+}
+
+
+def _resolve_seedream_size(model_id: str, aspect_ratio: str) -> str:
+    """按模型族选尺寸表；未识别比例时回退到分辨率 keyword（方式 1，由模型按 prompt 自适应）。"""
+    mid = (model_id or "").lower()
+    if "seedream-3" in mid:
+        size = _SEEDREAM_1K_SIZE_MAP.get(aspect_ratio)
+        return size or "1K"
+    # 默认按 4.x/5.x 处理（含 lite 与未来兼容版本）
+    size = _SEEDREAM_2K_SIZE_MAP.get(aspect_ratio)
+    return size or "2K"
+
 
 class ArkImageBackend:
     """Ark (火山方舟) Seedream 图片生成后端。"""
@@ -59,6 +98,11 @@ class ArkImageBackend:
             "model": self._model,
             "prompt": request.prompt,
         }
+
+        # Seedream 不显式传 size 时默认输出 1:1（4.x/5.x: 2048x2048；3.0-t2i: 1024x1024），
+        # 项目设置的 aspect_ratio 会被静默忽略。优先使用 caller 显式传入的 image_size
+        # （如 grid 路径会传 "2K"/"4K"），否则按官方推荐表从 aspect_ratio 推导宽高。
+        kwargs["size"] = request.image_size or _resolve_seedream_size(self._model, request.aspect_ratio)
 
         # I2I: 读取参考图并转为 base64 data URI
         if request.reference_images:

--- a/tests/test_image_backends/test_ark.py
+++ b/tests/test_image_backends/test_ark.py
@@ -152,6 +152,53 @@ class TestArkImageBackendGenerate:
         call_kwargs = client.images.generate.call_args.kwargs
         assert call_kwargs["seed"] == 42
 
+    async def test_size_from_aspect_ratio(self, backend_and_client, tmp_path: Path):
+        """aspect_ratio 必须映射成显式 size 传给 SDK，否则 Seedream 默认 2048x2048（1:1），
+        导致项目设置失效。尺寸值按 Ark 官方推荐宽高像素表（2K 档，4.x/5.x 系列）。"""
+        backend, client = backend_and_client
+
+        cases = [
+            ("9:16", "1600x2848"),
+            ("16:9", "2848x1600"),
+            ("1:1", "2048x2048"),
+            ("4:3", "2304x1728"),
+            ("3:4", "1728x2304"),
+        ]
+        for i, (ar, expected) in enumerate(cases):
+            request = ImageGenerationRequest(prompt="x", output_path=tmp_path / f"{i}.png", aspect_ratio=ar)
+            await backend.generate(request)
+            assert client.images.generate.call_args.kwargs["size"] == expected, f"aspect_ratio={ar} 应映射到 {expected}"
+
+    async def test_size_fallback_unknown_aspect_ratio(self, backend_and_client, tmp_path: Path):
+        """未识别比例回退到 '2K' keyword（方式 1），由模型按 prompt 自适应，
+        避免传错宽高被 API 拒（4.x/5.x 方式 2 总像素须 ≥ 3_686_400）。"""
+        backend, client = backend_and_client
+        request = ImageGenerationRequest(prompt="x", output_path=tmp_path / "u.png", aspect_ratio="weird")
+        await backend.generate(request)
+        assert client.images.generate.call_args.kwargs["size"] == "2K"
+
+    async def test_size_for_seedream_3_uses_1k_table(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        """3.0-t2i 模型族单边像素 ∈ [512, 2048]，必须用 1K 表而非 2K 表。"""
+        monkeypatch.delenv("ARK_API_KEY", raising=False)
+        mock_client = _make_client_mock()
+        with patch("lib.image_backends.ark.create_ark_client", return_value=mock_client):
+            from lib.image_backends.ark import ArkImageBackend
+
+            backend = ArkImageBackend(api_key="test-key", model="doubao-seedream-3-0-t2i-250415")
+
+        request = ImageGenerationRequest(prompt="x", output_path=tmp_path / "v.png", aspect_ratio="9:16")
+        await backend.generate(request)
+        assert mock_client.images.generate.call_args.kwargs["size"] == "720x1280"
+
+    async def test_explicit_image_size_overrides_aspect_ratio(self, backend_and_client, tmp_path: Path):
+        """caller 显式传入 image_size（如 grid 路径的 '2K'）必须保留，不被 aspect_ratio 推导覆盖。"""
+        backend, client = backend_and_client
+        request = ImageGenerationRequest(
+            prompt="x", output_path=tmp_path / "g.png", aspect_ratio="9:16", image_size="2K"
+        )
+        await backend.generate(request)
+        assert client.images.generate.call_args.kwargs["size"] == "2K"
+
     async def test_i2i_single_ref(self, backend_and_client, tmp_path: Path):
         backend, client = backend_and_client
 

--- a/tests/test_image_backends/test_ark.py
+++ b/tests/test_image_backends/test_ark.py
@@ -190,6 +190,19 @@ class TestArkImageBackendGenerate:
         await backend.generate(request)
         assert mock_client.images.generate.call_args.kwargs["size"] == "720x1280"
 
+    async def test_size_fallback_unknown_aspect_ratio_seedream_3(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        """3.0-t2i 未识别比例必须回退到 '1K' 而非 '2K'（单边像素上限 2048）。"""
+        monkeypatch.delenv("ARK_API_KEY", raising=False)
+        mock_client = _make_client_mock()
+        with patch("lib.image_backends.ark.create_ark_client", return_value=mock_client):
+            from lib.image_backends.ark import ArkImageBackend
+
+            backend = ArkImageBackend(api_key="test-key", model="doubao-seedream-3-0-t2i-250415")
+
+        request = ImageGenerationRequest(prompt="x", output_path=tmp_path / "u3.png", aspect_ratio="weird")
+        await backend.generate(request)
+        assert mock_client.images.generate.call_args.kwargs["size"] == "1K"
+
     async def test_explicit_image_size_overrides_aspect_ratio(self, backend_and_client, tmp_path: Path):
         """caller 显式传入 image_size（如 grid 路径的 '2K'）必须保留，不被 aspect_ratio 推导覆盖。"""
         backend, client = backend_and_client


### PR DESCRIPTION
## 问题

实测多个 9:16 项目的分镜图实际产出是 **2048×2048 (1:1)**，下游跟首帧出视频的模型也成了1:1，**项目设置的 9:16 被静默忽略**。

## 根因

通过查 postgres `api_calls` 表 + PIL 读分镜图实际像素，得到对照：

| 项目 | aspect_ratio | image 调用 resolution | 分镜图像素 | 视频像素 |
|---|---|---|---|---|
| 1 | 9:16 | **None** | 2048×2048 ❌ | 1440×1440 |
| 2 | 9:16 | **None** | 2048×2048 ❌ | 960×960 |
| 3 | 9:16 | "2K"（宫格路径显式传） | 553×984 ✅ | 720×1280 ✅ |

**`lib/image_backends/ark.py::generate()` 历史上不构造 `size` 参数**——而 Ark Seedream 文档（[图片生成 API](https://www.volcengine.com/docs/82379/1666946)）明确：不传 `size` 时 4.x/5.x 默认 2048×2048，3.0-t2i 默认 1024×1024。所以**任何不显式传 `image_size` 的 caller（普通分镜、character/scene/prop 资产图）都会被 Seedream 静默回退到 1:1**。

prompt 末尾追加的"竖屏构图"提示属于 Seedream 文档里的"方式 1"，**对有些模型不可靠，比如Seedream-5-lite**。

## 修复

[lib/image_backends/ark.py](../lib/image_backends/ark.py) 的 `generate()` 显式注入 `size` 参数：

1. **caller 显式 `image_size` 优先**——保留 grid 路径"2K"/"4K"的现有约定，不被覆盖。
2. **否则按 Ark 官方推荐表从 aspect_ratio 推导宽高**：
   - **4.x/5.x 系列 2K 档**（总像素须 ≥ 3,686,400）：`9:16 → 1600x2848`、`16:9 → 2848x1600`、`1:1 → 2048x2048` 等
   - **3.0-t2i 系列 1K 档**（单边 ∈ [512, 2048]）：`9:16 → 720x1280`、`16:9 → 1280x720` 等
3. **未识别比例回退分辨率 keyword**（"2K"/"1K"，方式 1）由模型按 prompt 自适应，避免传错宽高被 API 拒。

## 影响面

| 调用路径 | 修复前 | 修复后 |
|---|---|---|
| 普通分镜（9:16 项目） | 2048×2048 ❌ | 1600×2848 ✅ |
| 普通分镜（16:9 项目） | 2048×2048 ❌ | 2848×1600 ✅ |
| 资产图 characters/scenes/props（硬编 16:9） | 2048×2048 ❌（本来也错） | 2848×1600 ✅（顺带修复） |
| 宫格 grid（显式传 `image_size="2K"`） | "2K" → 553×984 | **不变**，仍走显式分支 |
| Seedream-3.0-t2i 模型族 | 1024×1024 | 按 1K 表精确出图 |

下游不接受 aspect_ratio 的视频模型的输出比例跟首帧，首帧修对了视频自然就对。

## 验证

- [tests/test_image_backends/test_ark.py](../tests/test_image_backends/test_ark.py) 新增 4 个测试：
  - `test_size_from_aspect_ratio` —— 5 种比例映射 2K 表
  - `test_size_fallback_unknown_aspect_ratio` —— 未识别比例回退 "2K"
  - `test_size_for_seedream_3_uses_1k_table` —— 3.0-t2i 走 1K 表
  - `test_explicit_image_size_overrides_aspect_ratio` —— grid 路径显式 image_size 优先
- `uv run python -m pytest tests/test_image_backends/test_ark.py` → **18 passed**
- `uv run ruff check lib/image_backends/ark.py tests/test_image_backends/test_ark.py` → **clean**

## 边界 / 已知限制

- 宫格图的最终比例由 grid 子系统的 prompt 引导（方式 1），**接近**项目 aspect_ratio 但**不像素级精确**（如 553×984 接近 9:16）。此为既有行为，与本 PR 无关。
- `server/services/generation_tasks.py::get_aspect_ratio()` 仍把 characters/scenes/props 硬编为 `"16:9"`。本 PR 不修改该决策，仅保证"声明的 16:9 真的出 16:9"。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复图像生成中因纵横比未被采用导致的尺寸不一致问题，确保纵横比能正确映射为最终 SDK 尺寸
  * 支持按模型族选择不同的尺寸映射表，对未知比例按模型家族回退到对应的 1K/2K 关键字

* **Tests**
  * 新增单元测试，覆盖纵横比到尺寸的映射、模型族特定规则、未知比例回退及显式尺寸优先级验证

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/514)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->