### PR TITLE
feat: env-driven runtime configuration and graceful fallbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,6 @@
 #
 # Copy this file to .env and fill in your values.
 # 将此文件复制为 .env 并填入你的配置值。
-#
-# Most settings (API keys, backend selection, rate limits, model choices, etc.)
-# have been moved to the WebUI settings page (/settings). Configure them there after first launch.
-# 大部分配置（API Key、后端选择、速率限制、模型选择等）
-# 已迁移至 WebUI 配置页（/settings），首次启动后通过页面配置即可。
-#
-# This file only contains startup-level / infrastructure settings.
-# 此文件仅保留启动级/基础设施配置。
 
 # ============================================================
 # Authentication / 认证配置
@@ -33,7 +25,13 @@ AUTH_TOKEN_SECRET=
 # Network Binding / 网络绑定
 # ============================================================
 # Defaults preserve current behavior. Override for tighter binding or non-default ports.
+# NOTE: LISTEN_HOST / LISTEN_PORT only apply when running via `python server/app.py`
+# (the __main__ entrypoint). For `uvicorn server.app:app` / Docker / systemd, pass
+# host/port as uvicorn CLI args — the ASGI module cannot rebind uvicorn at import.
 # 默认值与当前行为一致；按需收紧绑定地址或端口。
+# 注意：LISTEN_HOST / LISTEN_PORT 仅在 `python server/app.py` 入口生效；
+# 通过 `uvicorn server.app:app` / Docker / systemd 启动时，请把 host/port 作为
+# uvicorn CLI 参数传入（ASGI 模块层无法回头修改 uvicorn 进程的绑定）。
 # LISTEN_HOST=0.0.0.0
 # LISTEN_PORT=1241
 # Comma-separated CORS origins; "*" or unset → permissive (credentials disabled
@@ -78,18 +76,3 @@ AUTH_TOKEN_SECRET=
 # 日志级别（默认: INFO，可选: DEBUG, WARNING, ERROR）
 # LOG_LEVEL=INFO
 
-# ============================================================
-# Video Provider / 视频供应商
-# ============================================================
-# Global default video provider (gemini | seedance)
-# 全局默认视频供应商 (gemini | seedance)
-# DEFAULT_VIDEO_PROVIDER=gemini
-
-# ============================================================
-# Seedance (Volcengine Ark) / Seedance (火山方舟) 配置
-# ============================================================
-# Volcengine Ark API key / 火山方舟 API key
-# ARK_API_KEY=
-# Public URL of the project file service (Seedance image upload requires public access)
-# 项目文件服务公网地址（Seedance 图片上传需要公网访问）
-# FILE_SERVICE_BASE_URL=

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,33 @@ AUTH_PASSWORD=
 # JWT signing secret (leave empty to auto-generate; tokens will invalidate on restart)
 # JWT 签名密钥（留空则自动生成，但重启后 token 失效需重新登录）
 AUTH_TOKEN_SECRET=
+# Auth kill switch (default: true). Set to false to disable login / token checks
+# for single-user or trusted-network deployments.
+# 认证总开关（默认 true）。设为 false 时跳过登录与 token 校验，适合单机或可信网络部署。
+# AUTH_ENABLED=true
+
+# ============================================================
+# Network Binding / 网络绑定
+# ============================================================
+# Defaults preserve current behavior. Override for tighter binding or non-default ports.
+# 默认值与当前行为一致；按需收紧绑定地址或端口。
+# LISTEN_HOST=0.0.0.0
+# LISTEN_PORT=1241
+# Comma-separated CORS origins; "*" or unset → permissive (credentials disabled
+# by CORS spec). Set an explicit whitelist (e.g. "http://localhost:5173") to
+# enable credentialed cross-origin requests.
+# 逗号分隔的 CORS 允许 origin；"*" 或不设 → 通配（credentials 因 CORS spec 强制关闭）。
+# 设为白名单（如 "http://localhost:5173"）才会开启 credentials 跨域。
+# CORS_ORIGINS=*
+
+# ============================================================
+# Application Data Root / 应用数据根目录
+# ============================================================
+# Where projects, generated assets, SQLite DB live. Unset → PROJECT_ROOT/projects
+# (current behavior). Set to redirect data to an external location.
+# 项目数据/生成产物/SQLite DB 的根目录。不设则使用 PROJECT_ROOT/projects（现状）。
+# 设置后可将数据重定向到任意目录。
+# ARCREEL_DATA_DIR=
 
 # ============================================================
 # Database Configuration / 数据库配置

--- a/lib/app_data_dir.py
+++ b/lib/app_data_dir.py
@@ -1,0 +1,47 @@
+"""Application data root resolution.
+
+Centralizes where ArcReel stores per-deployment data (projects, SQLite DB,
+generated assets, system config). Decoupling this from the repository layout
+lets the same backend code run under varied deployment shapes that don't keep
+data alongside the source tree.
+
+Resolution order:
+    1. ``ARCREEL_DATA_DIR`` — explicit override
+    2. ``AI_ANIME_PROJECTS`` — legacy alias kept for backward compatibility
+    3. ``PROJECT_ROOT / "projects"`` — default
+
+Relative paths resolve against :data:`lib.env_init.PROJECT_ROOT`. The directory
+is created on first call.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+from pathlib import Path
+
+from lib.env_init import PROJECT_ROOT
+
+_ENV_KEYS: tuple[str, ...] = ("ARCREEL_DATA_DIR", "AI_ANIME_PROJECTS")
+
+
+@functools.cache
+def app_data_dir() -> Path:
+    """Return the configured application data root (cached)."""
+    for env_key in _ENV_KEYS:
+        raw = os.environ.get(env_key, "").strip()
+        if not raw:
+            continue
+        path = Path(raw)
+        if not path.is_absolute():
+            path = PROJECT_ROOT / path
+        path.mkdir(parents=True, exist_ok=True)
+        return path.resolve()
+    default = (PROJECT_ROOT / "projects").resolve()
+    default.mkdir(parents=True, exist_ok=True)
+    return default
+
+
+def _reset_for_tests() -> None:
+    """Clear the cached value so tests can monkeypatch env between cases."""
+    app_data_dir.cache_clear()

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lib.app_data_dir import app_data_dir
 from lib.config.registry import PROVIDER_REGISTRY
 from lib.config.service import (
     _DEFAULT_IMAGE_BACKEND,
@@ -28,7 +29,6 @@ from lib.config.service import (
 from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.db.repositories.credential_repository import CredentialRepository
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
-from lib.env_init import PROJECT_ROOT
 from lib.project_manager import ProjectManager
 from lib.reference_video.limits import DEFAULT_MAX_REFS, PROVIDER_MAX_REFS, normalize_provider_id
 from lib.text_backends.base import TextTaskType
@@ -40,7 +40,7 @@ def get_project_manager() -> ProjectManager:
     """返回共享的 ProjectManager 单例（使用标准项目根目录）。"""
     global _project_manager
     if _project_manager is None:
-        _project_manager = ProjectManager(PROJECT_ROOT / "projects")
+        _project_manager = ProjectManager(app_data_dir())
     return _project_manager
 
 

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -66,18 +66,20 @@ class DataValidator:
         "grids",
     }
 
-    def __init__(self, projects_root: str | None = None):
+    def __init__(self, projects_root: str | Path | None = None):
         """
         初始化验证器
 
         Args:
-            projects_root: 项目根目录，默认为 projects/
+            projects_root: 项目根目录；默认走 ``app_data_dir()``
+                （兼顾 ``ARCREEL_DATA_DIR`` / ``AI_ANIME_PROJECTS`` env）。
         """
-        import os
-
         if projects_root is None:
-            projects_root = os.environ.get("AI_ANIME_PROJECTS", "projects")
-        self.projects_root = Path(projects_root)
+            from lib.app_data_dir import app_data_dir
+
+            self.projects_root = app_data_dir()
+        else:
+            self.projects_root = Path(projects_root)
 
     @staticmethod
     def _is_hidden_path(path: Path) -> bool:

--- a/lib/db/engine.py
+++ b/lib/db/engine.py
@@ -7,7 +7,6 @@ import contextlib
 import logging
 import os
 from collections.abc import AsyncGenerator
-from pathlib import Path
 
 from sqlalchemy import event
 from sqlalchemy.exc import OperationalError
@@ -30,8 +29,9 @@ def get_database_url() -> str:
     url = os.environ.get("DATABASE_URL", "").strip()
     if url:
         return url
-    project_root = Path(__file__).parent.parent.parent
-    db_path = project_root / "projects" / ".arcreel.db"
+    from lib.app_data_dir import app_data_dir
+
+    db_path = app_data_dir() / ".arcreel.db"
     return f"sqlite+aiosqlite:///{db_path}"
 
 

--- a/lib/thumbnail.py
+++ b/lib/thumbnail.py
@@ -1,10 +1,23 @@
 """视频首帧缩略图提取"""
 
 import asyncio
+import functools
 import logging
+import shutil
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+@functools.cache
+def _ffmpeg_available() -> bool:
+    """ffmpeg 可执行文件是否在 PATH 中（结果缓存，避免每次调用重复 shutil.which）。"""
+    return shutil.which("ffmpeg") is not None
+
+
+def _reset_for_tests() -> None:
+    """test helper — 清缓存让 monkeypatch shutil.which 立刻生效。"""
+    _ffmpeg_available.cache_clear()
 
 
 async def extract_video_thumbnail(
@@ -19,9 +32,18 @@ async def extract_video_thumbnail(
         thumbnail_path: 输出缩略图路径
 
     Returns:
-        缩略图路径（成功）或 None（失败）
+        缩略图路径（成功）或 None（失败 / ffmpeg 不可用）
+
+    Note:
+        当 ffmpeg 不在 PATH 中时返回 None，让调用方走「不写 video_thumbnail
+        字段」的现有分支；前端 ``<video poster>`` 在 poster 为空时浏览器会
+        原生从视频流取首帧渲染，无需 server-side placeholder。
     """
     if not video_path.exists():
+        return None
+
+    if not _ffmpeg_available():
+        logger.info("ffmpeg 不可用，跳过缩略图提取（前端将原生取首帧）")
         return None
 
     thumbnail_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/migrate_claude_symlinks.py
+++ b/scripts/migrate_claude_symlinks.py
@@ -14,6 +14,13 @@ import argparse
 import sys
 from pathlib import Path
 
+# Put repo root on sys.path so `from lib.app_data_dir import app_data_dir` resolves
+# when this script is invoked directly (python scripts/migrate_claude_symlinks.py).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from lib.app_data_dir import app_data_dir  # noqa: E402
+
 SYMLINKS = {
     ".claude": "../../agent_runtime_profile/.claude",
     "CLAUDE.md": "../../agent_runtime_profile/CLAUDE.md",
@@ -25,8 +32,8 @@ def main():
     parser.add_argument("--dry-run", action="store_true", help="Preview without making changes")
     args = parser.parse_args()
 
-    project_root = Path(__file__).resolve().parent.parent
-    projects_dir = project_root / "projects"
+    project_root = _REPO_ROOT
+    projects_dir = app_data_dir()
     profile_dir = project_root / "agent_runtime_profile"
 
     if not profile_dir.exists():

--- a/scripts/migrate_sqlite_to_orm.py
+++ b/scripts/migrate_sqlite_to_orm.py
@@ -37,11 +37,12 @@ lib_stub.__path__ = [str(ROOT / "lib")]
 lib_stub.__package__ = "lib"
 sys.modules.setdefault("lib", lib_stub)
 
+from lib.app_data_dir import app_data_dir  # noqa: E402
 from lib.db import init_db  # noqa: E402
 from lib.db.engine import async_session_factory  # noqa: E402
 from lib.db.models import AgentSession, ApiCall, Task, TaskEvent, WorkerLease  # noqa: E402
 
-PROJECTS_DIR = ROOT / "projects"
+PROJECTS_DIR = app_data_dir()
 OLD_TASK_DB = PROJECTS_DIR / ".task_queue.db"
 OLD_USAGE_DB = PROJECTS_DIR / ".api_usage.db"
 OLD_SESSIONS_DB = PROJECTS_DIR / ".agent_data" / "sessions.db"

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 from fastapi.sse import ServerSentEvent
 
+from lib.app_data_dir import app_data_dir
 from lib.project_manager import ProjectManager
 from server.agent_runtime.message_utils import extract_plain_user_content
 from server.agent_runtime.models import SessionMeta, SessionStatus
@@ -55,7 +56,7 @@ class AssistantService:
     def __init__(self, project_root: Path):
         self.project_root = Path(project_root)
         self._load_project_env(self.project_root)
-        self.projects_root = self.project_root / "projects"
+        self.projects_root = app_data_dir()
         self.data_dir = self.projects_root / ".agent_data"
         self.data_dir.mkdir(parents=True, exist_ok=True)
 
@@ -65,6 +66,7 @@ class AssistantService:
             project_root=self.project_root,
             data_dir=self.data_dir,
             meta_store=self.meta_store,
+            projects_root=self.projects_root,
         )
         # Shared with SessionManager (lazy-cached there) so reads via the
         # adapter and writes via SDK options use the same per-user namespace.

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -350,8 +350,12 @@ class SessionManager:
         # Tests construct SessionManager directly without going through
         # AssistantService, so we fall back to the legacy ``project_root/projects``
         # convention. Production passes the configured app_data_dir() explicitly.
+        # 两路都 resolve，避免符号链接场景下 _resolve_project_cwd 的 relative_to
+        # 校验失败（project_cwd 已经 resolve 过）。strict=False 容忍目录不存在。
         self.projects_root = (
-            Path(projects_root) if projects_root is not None else (self.project_root / "projects").resolve()
+            Path(projects_root).resolve(strict=False)
+            if projects_root is not None
+            else (self.project_root / "projects").resolve()
         )
         self.meta_store = meta_store
         self.sessions: dict[str, ManagedSession] = {}

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -343,9 +343,16 @@ class SessionManager:
         project_root: Path,
         data_dir: Path,
         meta_store: SessionMetaStore,
+        projects_root: Path | None = None,
     ):
         self.project_root = Path(project_root)
         self.data_dir = Path(data_dir)
+        # Tests construct SessionManager directly without going through
+        # AssistantService, so we fall back to the legacy ``project_root/projects``
+        # convention. Production passes the configured app_data_dir() explicitly.
+        self.projects_root = (
+            Path(projects_root) if projects_root is not None else (self.project_root / "projects").resolve()
+        )
         self.meta_store = meta_store
         self.sessions: dict[str, ManagedSession] = {}
         self._disconnecting: set[str] = set()
@@ -907,7 +914,7 @@ class SessionManager:
 
     def _resolve_project_cwd(self, project_name: str) -> Path:
         """Resolve and validate per-session project working directory."""
-        projects_root = (self.project_root / "projects").resolve()
+        projects_root = self.projects_root
         project_cwd = (projects_root / project_name).resolve()
         try:
             project_cwd.relative_to(projects_root)

--- a/server/app.py
+++ b/server/app.py
@@ -26,6 +26,7 @@ from lib import PROJECT_ROOT
 from lib.agent_session_store import session_store_enabled
 from lib.agent_session_store.import_local import migrate_local_transcripts_to_store
 from lib.agent_session_store.store import DbSessionStore
+from lib.app_data_dir import app_data_dir
 from lib.db import async_session_factory, close_db, init_db
 from lib.generation_worker import GenerationWorker
 from lib.httpx_shared import shutdown_http_client, startup_http_client
@@ -122,7 +123,7 @@ async def lifespan(app: FastAPI):
     # Run any pending project.json schema migrations (file-based).
     # Both calls are synchronous filesystem walks — offload to a worker thread
     # so they don't block the event loop during uvicorn startup.
-    projects_root = PROJECT_ROOT / "projects"
+    projects_root = app_data_dir()
     migration_summary = await asyncio.to_thread(run_project_migrations, projects_root)
     if migration_summary.migrated or migration_summary.failed:
         logger.info(
@@ -162,7 +163,7 @@ async def lifespan(app: FastAPI):
     try:
         from lib.config.migration import migrate_json_to_db
 
-        json_path = PROJECT_ROOT / "projects" / ".system_config.json"
+        json_path = app_data_dir() / ".system_config.json"
         async with async_session_factory() as session:
             await migrate_json_to_db(session, json_path)
     except Exception as exc:
@@ -180,7 +181,7 @@ async def lifespan(app: FastAPI):
     # 修复存量项目的 agent_runtime 软连接（同步文件遍历 → 放到 worker 线程）
     from lib.project_manager import ProjectManager
 
-    _pm = ProjectManager(PROJECT_ROOT / "projects")
+    _pm = ProjectManager(app_data_dir())
     _symlink_stats = await asyncio.to_thread(_pm.repair_all_symlinks)
     if any(v > 0 for v in _symlink_stats.values()):
         logger.info("agent_runtime 软连接修复完成: %s", _symlink_stats)

--- a/server/app.py
+++ b/server/app.py
@@ -11,6 +11,7 @@ node_modules / .venv / .git / .worktrees 等十几万个文件，单核 CPU 50%+
 
 import asyncio
 import logging
+import os
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -230,11 +231,21 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# CORS 配置
+# CORS 配置（env 驱动）：
+#   - CORS_ORIGINS 未设置 / "*" → 通配 origins，credentials 强制关闭（CORS spec 不允许通配 + credentials 组合）
+#   - 否则按逗号分隔解析为白名单，credentials 打开供前端附带 cookie / Authorization 跨域
+_cors_raw = os.environ.get("CORS_ORIGINS", "*").strip()
+if _cors_raw in ("", "*"):
+    _allow_origins: list[str] = ["*"]
+    _allow_credentials = False
+else:
+    _allow_origins = [o.strip() for o in _cors_raw.split(",") if o.strip()]
+    _allow_credentials = True
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
+    allow_origins=_allow_origins,
+    allow_credentials=_allow_credentials,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -371,4 +382,6 @@ if frontend_dist_dir.exists():
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=1241, reload=True)
+    _host = os.environ.get("LISTEN_HOST", "0.0.0.0")
+    _port = int(os.environ.get("LISTEN_PORT", "1241"))
+    uvicorn.run(app, host=_host, port=_port, reload=True)

--- a/server/app.py
+++ b/server/app.py
@@ -201,7 +201,7 @@ async def lifespan(app: FastAPI):
     logger.info("GenerationWorker 已启动")
 
     logger.info("启动 ProjectEventService...")
-    project_event_service = ProjectEventService(PROJECT_ROOT)
+    project_event_service = ProjectEventService(PROJECT_ROOT, projects_root=app_data_dir())
     app.state.project_event_service = project_event_service
     await project_event_service.start()
     logger.info("ProjectEventService 已启动")

--- a/server/app.py
+++ b/server/app.py
@@ -232,14 +232,15 @@ app = FastAPI(
 )
 
 # CORS 配置（env 驱动）：
-#   - CORS_ORIGINS 未设置 / "*" → 通配 origins，credentials 强制关闭（CORS spec 不允许通配 + credentials 组合）
+#   - CORS_ORIGINS 未设置 / 空 / 包含 "*" → 通配 origins，credentials 强制关闭
+#     （CORS spec 不允许通配 + credentials 组合；Starlette 在初始化时会 RuntimeError）
 #   - 否则按逗号分隔解析为白名单，credentials 打开供前端附带 cookie / Authorization 跨域
 _cors_raw = os.environ.get("CORS_ORIGINS", "*").strip()
-if _cors_raw in ("", "*"):
-    _allow_origins: list[str] = ["*"]
+_allow_origins: list[str] = [o.strip() for o in _cors_raw.split(",") if o.strip()]
+if not _allow_origins or "*" in _allow_origins:
+    _allow_origins = ["*"]
     _allow_credentials = False
 else:
-    _allow_origins = [o.strip() for o in _cors_raw.split(",") if o.strip()]
     _allow_credentials = True
 
 app.add_middleware(
@@ -382,6 +383,7 @@ if frontend_dist_dir.exists():
 if __name__ == "__main__":
     import uvicorn
 
-    _host = os.environ.get("LISTEN_HOST", "0.0.0.0")
-    _port = int(os.environ.get("LISTEN_PORT", "1241"))
+    # 用 truthy 默认（`or`）兜底，避免 .env 误写 `LISTEN_PORT=` 空值时 int("") 崩溃。
+    _host = os.environ.get("LISTEN_HOST") or "0.0.0.0"
+    _port = int(os.environ.get("LISTEN_PORT") or "1241")
     uvicorn.run(app, host=_host, port=_port, reload=True)

--- a/server/app.py
+++ b/server/app.py
@@ -252,6 +252,16 @@ app.add_middleware(
 )
 
 
+def _resolve_listen_addr() -> tuple[str, int]:
+    """解析 ``LISTEN_HOST`` / ``LISTEN_PORT``，供 ``__main__`` 块与测试共用。
+
+    truthy 默认（``or``）兜底，覆盖 ``.env`` 误写空值（如 ``LISTEN_PORT=``）的场景。
+    """
+    host = os.environ.get("LISTEN_HOST") or "0.0.0.0"
+    port = int(os.environ.get("LISTEN_PORT") or "1241")
+    return host, port
+
+
 # 前端每 3s 轮询下述接口获取任务状态；稳态下成功响应会把真正的错误/慢请求淹没，
 # 所以对 2xx + 快速响应降级到 DEBUG，异常/慢响应仍走 INFO 保证可观测。
 _QUIET_POLL_ENDPOINTS: frozenset[tuple[str, str]] = frozenset(
@@ -383,7 +393,5 @@ if frontend_dist_dir.exists():
 if __name__ == "__main__":
     import uvicorn
 
-    # 用 truthy 默认（`or`）兜底，避免 .env 误写 `LISTEN_PORT=` 空值时 int("") 崩溃。
-    _host = os.environ.get("LISTEN_HOST") or "0.0.0.0"
-    _port = int(os.environ.get("LISTEN_PORT") or "1241")
+    _host, _port = _resolve_listen_addr()
     uvicorn.run(app, host=_host, port=_port, reload=True)

--- a/server/app.py
+++ b/server/app.py
@@ -255,6 +255,12 @@ app.add_middleware(
 def _resolve_listen_addr() -> tuple[str, int]:
     """解析 ``LISTEN_HOST`` / ``LISTEN_PORT``，供 ``__main__`` 块与测试共用。
 
+    **作用范围**：仅当通过 ``python server/app.py`` 直接执行（走下方 ``__main__``）
+    时生效。通过 ``uvicorn server.app:app`` 这种标准 ASGI CLI 启动时，listen 地址
+    由 uvicorn 进程自身的 ``--host`` / ``--port`` 参数决定，本函数不参与 —— 因为
+    ASGI app 模块在 import 时无法回头改 uvicorn 进程的绑定。Docker、systemd 等
+    部署需要把 host/port 作为 uvicorn CLI 参数显式传入。
+
     truthy 默认（``or``）兜底，覆盖 ``.env`` 误写空值（如 ``LISTEN_PORT=``）的场景。
     """
     host = os.environ.get("LISTEN_HOST") or "0.0.0.0"

--- a/server/auth.py
+++ b/server/auth.py
@@ -46,14 +46,15 @@ TOKEN_EXPIRY_SECONDS = 7 * 24 * 3600
 # 关闭认证时返回的匿名用户标识
 _ANONYMOUS_USER_SUB = "local"
 
-# 视为"关闭认证"的 env 取值（含空串，避免 .env 半空配置意外打开认证）
-_AUTH_DISABLED_VALUES = frozenset({"false", "0", "no", "off", ""})
+# 视为"关闭认证"的 env 取值。空串不在内 —— .env 误写 `AUTH_ENABLED=` 应回退到默认（开启），
+# 避免静默 fail-open。
+_AUTH_DISABLED_VALUES = frozenset({"false", "0", "no", "off"})
 
 
 def is_auth_enabled() -> bool:
-    """``AUTH_ENABLED`` env 解析。默认 ``true``，保持现有部署行为。
+    """``AUTH_ENABLED`` env 解析。默认 ``true``，保持现有部署行为；空值也按默认。
 
-    空串 / ``false`` / ``0`` / ``no`` / ``off`` 一律视为关闭（不区分大小写）。
+    ``false`` / ``0`` / ``no`` / ``off`` 一律视为关闭（不区分大小写）。
     """
     return os.environ.get("AUTH_ENABLED", "true").strip().lower() not in _AUTH_DISABLED_VALUES
 

--- a/server/auth.py
+++ b/server/auth.py
@@ -43,6 +43,28 @@ _cached_token_secret: str | None = None
 # Token 有效期：7 天
 TOKEN_EXPIRY_SECONDS = 7 * 24 * 3600
 
+# 关闭认证时返回的匿名用户标识
+_ANONYMOUS_USER_SUB = "local"
+
+# 视为"关闭认证"的 env 取值（含空串，避免 .env 半空配置意外打开认证）
+_AUTH_DISABLED_VALUES = frozenset({"false", "0", "no", "off", ""})
+
+
+def is_auth_enabled() -> bool:
+    """``AUTH_ENABLED`` env 解析。默认 ``true``，保持现有部署行为。
+
+    空串 / ``false`` / ``0`` / ``no`` / ``off`` 一律视为关闭（不区分大小写）。
+    """
+    return os.environ.get("AUTH_ENABLED", "true").strip().lower() not in _AUTH_DISABLED_VALUES
+
+
+def _anonymous_user() -> "CurrentUserInfo":
+    """关闭认证时返回的固定匿名用户。"""
+    from lib.db.base import DEFAULT_USER_ID
+
+    return CurrentUserInfo(id=DEFAULT_USER_ID, sub=_ANONYMOUS_USER_SUB, role="admin")
+
+
 # OAuth2 scheme
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/token")
 oauth2_scheme_optional = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/token", auto_error=False)
@@ -138,6 +160,12 @@ def verify_download_token(token: str, project_name: str) -> dict:
         jwt.InvalidTokenError: token 无效
         ValueError: purpose 或 project 不匹配
     """
+    if not is_auth_enabled():
+        return {
+            "sub": _ANONYMOUS_USER_SUB,
+            "project": project_name,
+            "purpose": "download",
+        }
     payload = jwt.decode(token, get_token_secret(), algorithms=["HS256"])
     if payload.get("purpose") != "download":
         raise ValueError("token purpose 不匹配")
@@ -160,7 +188,11 @@ def check_credentials(username: str, password: str) -> bool:
 
     从 AUTH_USERNAME（默认 admin）和 AUTH_PASSWORD 环境变量读取。
     即使用户名不匹配也执行哈希验证，防止时序攻击。
+
+    ``AUTH_ENABLED=false`` 时无条件返回 True。
     """
+    if not is_auth_enabled():
+        return True
     expected_username = os.environ.get("AUTH_USERNAME", "admin")
     pw_hash = _get_password_hash()
     username_ok = secrets.compare_digest(username, expected_username)
@@ -174,12 +206,16 @@ def ensure_auth_password(env_path: str | None = None) -> str:
     如果 AUTH_PASSWORD 环境变量为空，自动生成密码，写入环境变量，
     回写到 .env 文件，并用 logger.warning 输出到控制台。
 
+    ``AUTH_ENABLED=false`` 时整个步骤跳过（不生成、不回写）。
+
     Args:
         env_path: .env 文件路径，默认为项目根目录的 .env
 
     Returns:
-        当前的 AUTH_PASSWORD 值
+        当前的 AUTH_PASSWORD 值；关闭认证时返回空串。
     """
+    if not is_auth_enabled():
+        return ""
     password = os.environ.get("AUTH_PASSWORD")
     if password:
         return password
@@ -379,9 +415,21 @@ def _payload_to_user(payload: dict) -> CurrentUserInfo:
 
 
 async def get_current_user(
-    token: Annotated[str, Depends(oauth2_scheme)],
+    token: Annotated[str | None, Depends(oauth2_scheme_optional)] = None,
 ) -> CurrentUserInfo:
-    """标准认证依赖 — 支持 JWT 和 API Key Bearer token。"""
+    """标准认证依赖 — 支持 JWT 和 API Key Bearer token。
+
+    ``AUTH_ENABLED=false`` 时无视 token，直接返回匿名 admin。
+    启用时缺 token 抛 401（与旧 oauth2_scheme auto_error 行为等价）。
+    """
+    if not is_auth_enabled():
+        return _anonymous_user()
+    if not token:
+        raise HTTPException(
+            status_code=401,
+            detail="未认证",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     payload = await _verify_and_get_payload_async(token)
     return _payload_to_user(payload)
 
@@ -390,7 +438,12 @@ async def get_current_user_flexible(
     token: Annotated[str | None, Depends(oauth2_scheme_optional)] = None,
     query_token: str | None = Query(None, alias="token"),
 ) -> CurrentUserInfo:
-    """SSE 认证依赖 — 同时支持 Authorization header 和 ?token= query param。"""
+    """SSE 认证依赖 — 同时支持 Authorization header 和 ?token= query param。
+
+    ``AUTH_ENABLED=false`` 时无视 token，直接返回匿名 admin。
+    """
+    if not is_auth_enabled():
+        return _anonymous_user()
     raw = token or query_token
     if not raw:
         raise HTTPException(

--- a/server/routers/assets.py
+++ b/server/routers/assets.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 
-from lib import PROJECT_ROOT
+from lib.app_data_dir import app_data_dir
 from lib.asset_types import ASSET_TYPES, BUCKET_KEY, SHEET_KEY
 from lib.db import async_session_factory
 from lib.db.repositories.asset_repo import AssetRepository
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/assets", tags=["全局资产库"])
 
 # Module-level PM; overridable via monkeypatch in tests
-pm = ProjectManager(PROJECT_ROOT / "projects")
+pm = ProjectManager(app_data_dir())
 
 
 def get_project_manager() -> ProjectManager:

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -12,7 +12,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel
 
 from lib.i18n import Translator
-from server.auth import CurrentUser, check_credentials, create_token
+from server.auth import CurrentUser, check_credentials, create_token, is_auth_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +43,10 @@ async def login_for_access_token(
     """用户登录
 
     使用 OAuth2 标准表单格式验证凭据，成功返回 access_token。
+    ``AUTH_ENABLED=false`` 时跳过凭据校验，直接签发 token，让前端
+    LoginPage 即便被打开也能正常跳转主界面。
     """
-    if not check_credentials(form_data.username, form_data.password):
+    if is_auth_enabled() and not check_credentials(form_data.username, form_data.password):
         logger.warning("登录失败: 用户名或密码错误 (用户: %s)", form_data.username)
         raise HTTPException(
             status_code=401,

--- a/server/routers/characters.py
+++ b/server/routers/characters.py
@@ -1,10 +1,10 @@
 """角色管理路由（CRUD 由 _asset_router_factory 统一生成）。"""
 
-from lib import PROJECT_ROOT
+from lib.app_data_dir import app_data_dir
 from lib.project_manager import ProjectManager
 from server.routers._asset_router_factory import build_asset_router
 
-pm = ProjectManager(PROJECT_ROOT / "projects")
+pm = ProjectManager(app_data_dir())
 
 
 def get_project_manager() -> ProjectManager:

--- a/server/routers/cost_estimation.py
+++ b/server/routers/cost_estimation.py
@@ -7,7 +7,7 @@ import logging
 
 from fastapi import APIRouter, HTTPException
 
-from lib import PROJECT_ROOT
+from lib.app_data_dir import app_data_dir
 from lib.config.resolver import ConfigResolver
 from lib.db import async_session_factory
 from lib.i18n import Translator
@@ -18,7 +18,7 @@ from server.services.cost_estimation import CostEstimationService
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-pm = ProjectManager(PROJECT_ROOT / "projects")
+pm = ProjectManager(app_data_dir())
 
 
 @router.get("/projects/{project_name}/cost-estimate")

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 from fastapi import APIRouter, Body, File, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, PlainTextResponse
 
-from lib import PROJECT_ROOT
+from lib.app_data_dir import app_data_dir
 from lib.asset_types import ASSET_TYPES
 from lib.i18n import Translator
 from lib.image_utils import normalize_uploaded_image
@@ -36,7 +36,7 @@ from server.auth import CurrentUser
 router = APIRouter()
 
 # 初始化项目管理器
-pm = ProjectManager(PROJECT_ROOT / "projects")
+pm = ProjectManager(app_data_dir())
 
 
 def get_project_manager() -> ProjectManager:

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from lib import PROJECT_ROOT
+from lib.app_data_dir import app_data_dir
 from lib.asset_types import ASSET_SPECS
 from lib.generation_queue import get_generation_queue
 from lib.i18n import Translator
@@ -31,7 +31,7 @@ from server.auth import CurrentUser
 router = APIRouter()
 
 # 初始化管理器
-pm = ProjectManager(PROJECT_ROOT / "projects")
+pm = ProjectManager(app_data_dir())
 
 
 def get_project_manager() -> ProjectManager:

--- a/server/routers/grids.py
+++ b/server/routers/grids.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from lib import PROJECT_ROOT
+from lib.app_data_dir import app_data_dir
 from lib.generation_queue import get_generation_queue
 from lib.grid.layout import calculate_grid_layout
 from lib.grid.models import GridGeneration
@@ -27,7 +27,7 @@ from server.auth import CurrentUser
 router = APIRouter(prefix="/projects/{project_name}", tags=["grids"])
 
 # 初始化管理器
-pm = ProjectManager(PROJECT_ROOT / "projects")
+pm = ProjectManager(app_data_dir())
 
 
 def get_project_manager() -> ProjectManager:

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -27,7 +27,7 @@ from starlette.background import BackgroundTask
 
 logger = logging.getLogger(__name__)
 
-from lib import PROJECT_ROOT
+from lib.app_data_dir import app_data_dir
 from lib.asset_fingerprints import compute_asset_fingerprints
 from lib.config.resolver import ConfigResolver
 from lib.db import async_session_factory
@@ -47,7 +47,7 @@ from server.services.project_cover import resolve_project_cover
 router = APIRouter()
 
 # 初始化项目管理器和状态计算器
-pm = ProjectManager(PROJECT_ROOT / "projects")
+pm = ProjectManager(app_data_dir())
 calc = StatusCalculator(pm)
 
 # episode 字段白名单：只允许持久化合法的 on-disk 字段。

--- a/server/routers/props.py
+++ b/server/routers/props.py
@@ -1,10 +1,10 @@
 """道具管理路由（CRUD 由 _asset_router_factory 统一生成）。"""
 
-from lib import PROJECT_ROOT
+from lib.app_data_dir import app_data_dir
 from lib.project_manager import ProjectManager
 from server.routers._asset_router_factory import build_asset_router
 
-pm = ProjectManager(PROJECT_ROOT / "projects")
+pm = ProjectManager(app_data_dir())
 
 
 def get_project_manager() -> ProjectManager:

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -12,7 +12,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Response, status
 from pydantic import BaseModel, Field
 
-from lib import PROJECT_ROOT
+from lib.app_data_dir import app_data_dir
 from lib.asset_types import BUCKET_KEY
 from lib.generation_queue import get_generation_queue
 from lib.project_manager import ProjectManager
@@ -26,7 +26,7 @@ router = APIRouter(
     tags=["reference-videos"],
 )
 
-pm = ProjectManager(PROJECT_ROOT / "projects")
+pm = ProjectManager(app_data_dir())
 
 
 def get_project_manager() -> ProjectManager:

--- a/server/routers/scenes.py
+++ b/server/routers/scenes.py
@@ -1,10 +1,10 @@
 """场景管理路由（CRUD 由 _asset_router_factory 统一生成）。"""
 
-from lib import PROJECT_ROOT
+from lib.app_data_dir import app_data_dir
 from lib.project_manager import ProjectManager
 from server.routers._asset_router_factory import build_asset_router
 
-pm = ProjectManager(PROJECT_ROOT / "projects")
+pm = ProjectManager(app_data_dir())
 
 
 def get_project_manager() -> ProjectManager:

--- a/server/routers/versions.py
+++ b/server/routers/versions.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, HTTPException
 
 logger = logging.getLogger(__name__)
 
-from lib import PROJECT_ROOT
+from lib.app_data_dir import app_data_dir
 from lib.i18n import Translator
 from lib.project_change_hints import project_change_source
 from lib.project_manager import ProjectManager
@@ -23,7 +23,7 @@ from server.auth import CurrentUser
 router = APIRouter()
 
 # 初始化项目管理器
-pm = ProjectManager(PROJECT_ROOT / "projects")
+pm = ProjectManager(app_data_dir())
 
 _RESOURCE_FILE_PATTERNS: dict[str, tuple[str, str]] = {
     "storyboards": ("storyboards", "scene_{id}.png"),

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from lib.config.resolver import ConfigResolver
 
-from lib import PROJECT_ROOT
+from lib.app_data_dir import app_data_dir
 from lib.asset_types import ASSET_SPECS
 from lib.config.registry import PROVIDER_REGISTRY
 from lib.custom_provider import is_custom_provider
@@ -42,7 +42,7 @@ from lib.storyboard_sequence import (
 from lib.thumbnail import extract_video_thumbnail
 from server.services.resolution_resolver import resolve_resolution
 
-pm = ProjectManager(PROJECT_ROOT / "projects")
+pm = ProjectManager(app_data_dir())
 rate_limiter = get_shared_rate_limiter()
 logger = logging.getLogger(__name__)
 

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -57,10 +57,16 @@ class ProjectEventService:
         self,
         project_root: Path | None = None,
         *,
+        projects_root: Path | None = None,
         poll_interval: float = PROJECT_EVENTS_POLL_SECONDS,
     ):
         self.project_root = Path(project_root or PROJECT_ROOT)
-        self.pm = ProjectManager(self.project_root / "projects")
+        # 显式传入 ``projects_root`` 时优先使用（生产入口走 ``app_data_dir()``），
+        # 否则保留旧契约（仓库根下的 ``projects/``）兼容测试 fixture。
+        projects_dir = (
+            Path(projects_root).resolve(strict=False) if projects_root is not None else self.project_root / "projects"
+        )
+        self.pm = ProjectManager(projects_dir)
         self.poll_interval = max(0.1, float(poll_interval))
         self._channels: dict[str, _ProjectChannel] = {}
         self._listener_unregister = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,18 @@ def make_test_video(path: Path, *, duration_sec: float = 1.0, fps: int = 30) -> 
     )
 
 
+@pytest.fixture(autouse=True)
+def _reset_app_data_dir_cache():
+    """``app_data_dir()`` uses ``functools.cache`` for production; reset it between
+    tests so per-test monkeypatching of ARCREEL_DATA_DIR / AI_ANIME_PROJECTS takes
+    effect immediately."""
+    from lib.app_data_dir import _reset_for_tests
+
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
 @pytest.fixture()
 def fd_count():
     """Return a callable that reports the current process file-descriptor count.

--- a/tests/test_app_data_dir.py
+++ b/tests/test_app_data_dir.py
@@ -1,0 +1,142 @@
+"""Tests for lib.app_data_dir env resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _import_fresh():
+    """Re-import the module fresh — `@functools.cache` traps env values."""
+    from lib.app_data_dir import _reset_for_tests, app_data_dir
+
+    _reset_for_tests()
+    return app_data_dir
+
+
+@pytest.fixture()
+def app_data_dir_fn(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("ARCREEL_DATA_DIR", raising=False)
+    monkeypatch.delenv("AI_ANIME_PROJECTS", raising=False)
+    return _import_fresh()
+
+
+def test_default_returns_project_root_projects(app_data_dir_fn):
+    from lib.env_init import PROJECT_ROOT
+
+    result = app_data_dir_fn()
+    assert result == (PROJECT_ROOT / "projects").resolve()
+    assert result.exists()
+
+
+def test_absolute_arcreel_data_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    target = tmp_path / "custom-data"
+    monkeypatch.setenv("ARCREEL_DATA_DIR", str(target))
+    monkeypatch.delenv("AI_ANIME_PROJECTS", raising=False)
+    app_data_dir_fn = _import_fresh()
+
+    result = app_data_dir_fn()
+    assert result == target.resolve()
+    assert result.exists()
+
+
+def test_relative_arcreel_data_dir_resolved_against_project_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from lib.env_init import PROJECT_ROOT
+
+    # Use a relative path; should be joined to PROJECT_ROOT.
+    rel_name = "test_relative_data_dir_xyz"
+    monkeypatch.setenv("ARCREEL_DATA_DIR", rel_name)
+    monkeypatch.delenv("AI_ANIME_PROJECTS", raising=False)
+    app_data_dir_fn = _import_fresh()
+
+    try:
+        result = app_data_dir_fn()
+        expected = (PROJECT_ROOT / rel_name).resolve()
+        assert result == expected
+        assert result.exists()
+    finally:
+        # Cleanup: remove the dir we accidentally created in repo root.
+        created = PROJECT_ROOT / rel_name
+        if created.exists():
+            created.rmdir()
+
+
+def test_ai_anime_projects_legacy_alias_works(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    target = tmp_path / "legacy-data"
+    monkeypatch.delenv("ARCREEL_DATA_DIR", raising=False)
+    monkeypatch.setenv("AI_ANIME_PROJECTS", str(target))
+    app_data_dir_fn = _import_fresh()
+
+    result = app_data_dir_fn()
+    assert result == target.resolve()
+
+
+def test_arcreel_data_dir_takes_precedence_over_legacy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    primary = tmp_path / "primary"
+    secondary = tmp_path / "secondary"
+    monkeypatch.setenv("ARCREEL_DATA_DIR", str(primary))
+    monkeypatch.setenv("AI_ANIME_PROJECTS", str(secondary))
+    app_data_dir_fn = _import_fresh()
+
+    result = app_data_dir_fn()
+    assert result == primary.resolve()
+
+
+def test_empty_env_value_falls_through_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`ARCREEL_DATA_DIR=` (empty) should not be treated as a path."""
+    from lib.env_init import PROJECT_ROOT
+
+    monkeypatch.setenv("ARCREEL_DATA_DIR", "")
+    monkeypatch.setenv("AI_ANIME_PROJECTS", "   ")  # whitespace-only
+    app_data_dir_fn = _import_fresh()
+
+    result = app_data_dir_fn()
+    assert result == (PROJECT_ROOT / "projects").resolve()
+
+
+def test_directory_is_created_on_first_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    target = tmp_path / "not-yet-created" / "nested" / "dir"
+    monkeypatch.setenv("ARCREEL_DATA_DIR", str(target))
+    monkeypatch.delenv("AI_ANIME_PROJECTS", raising=False)
+    app_data_dir_fn = _import_fresh()
+
+    assert not target.exists()
+    result = app_data_dir_fn()
+    assert result.exists()
+    assert result.is_dir()
+
+
+def test_result_is_cached_within_single_call_sequence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Confirm the @functools.cache wrapper; changing env after first call has no effect."""
+    target_a = tmp_path / "a"
+    target_b = tmp_path / "b"
+    monkeypatch.setenv("ARCREEL_DATA_DIR", str(target_a))
+    monkeypatch.delenv("AI_ANIME_PROJECTS", raising=False)
+    app_data_dir_fn = _import_fresh()
+
+    first = app_data_dir_fn()
+    # mutate env, but don't reset cache — same result expected.
+    monkeypatch.setenv("ARCREEL_DATA_DIR", str(target_b))
+    second = app_data_dir_fn()
+    assert first == second == target_a.resolve()

--- a/tests/test_auth_kill_switch.py
+++ b/tests/test_auth_kill_switch.py
@@ -1,0 +1,177 @@
+"""AUTH_ENABLED kill-switch behavior tests."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+import server.auth as auth_module
+
+
+@pytest.fixture(autouse=True)
+def _isolated_auth_env():
+    """Clear cached secret/password hash per-test so env tweaks take effect."""
+    auth_module._cached_token_secret = None
+    auth_module._cached_password_hash = None
+    yield
+    auth_module._cached_token_secret = None
+    auth_module._cached_password_hash = None
+
+
+class TestIsAuthEnabled:
+    """``is_auth_enabled()`` 解析 AUTH_ENABLED env 值。"""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (None, True),  # 未设置 → 默认开启（向后兼容）
+            ("true", True),
+            ("True", True),
+            ("TRUE", True),
+            ("1", True),
+            ("yes", True),
+            ("anything-else", True),
+            ("false", False),
+            ("False", False),
+            ("FALSE", False),
+            ("0", False),
+            ("no", False),
+            ("off", False),
+            ("", False),  # 空串视为关闭，防 .env 半空配置
+            ("  false  ", False),
+        ],
+    )
+    def test_env_value_resolution(self, raw, expected):
+        env = os.environ.copy()
+        env.pop("AUTH_ENABLED", None)
+        if raw is not None:
+            env["AUTH_ENABLED"] = raw
+        with patch.dict(os.environ, env, clear=True):
+            assert auth_module.is_auth_enabled() is expected
+
+
+class TestEnsureAuthPasswordKillSwitch:
+    def test_disabled_returns_empty_and_does_not_touch_env(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env = os.environ.copy()
+        env["AUTH_ENABLED"] = "false"
+        env.pop("AUTH_PASSWORD", None)
+        with patch.dict(os.environ, env, clear=True):
+            result = auth_module.ensure_auth_password(env_path=str(env_file))
+            assert result == ""
+            assert not env_file.exists()
+            assert "AUTH_PASSWORD" not in os.environ
+
+    def test_enabled_still_generates(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env = os.environ.copy()
+        env.pop("AUTH_ENABLED", None)
+        env.pop("AUTH_PASSWORD", None)
+        with patch.dict(os.environ, env, clear=True):
+            result = auth_module.ensure_auth_password(env_path=str(env_file))
+        assert result != ""
+        assert len(result) == 16
+
+
+class TestCheckCredentialsKillSwitch:
+    def test_disabled_returns_true_for_any_input(self):
+        with patch.dict(os.environ, {"AUTH_ENABLED": "false"}):
+            assert auth_module.check_credentials("anyone", "anything") is True
+            assert auth_module.check_credentials("", "") is True
+
+    def test_enabled_still_validates(self):
+        env = {
+            "AUTH_ENABLED": "true",
+            "AUTH_USERNAME": "admin",
+            "AUTH_PASSWORD": "pass123",
+        }
+        with patch.dict(os.environ, env):
+            assert auth_module.check_credentials("admin", "pass123") is True
+            assert auth_module.check_credentials("admin", "wrong") is False
+
+
+class TestVerifyDownloadTokenKillSwitch:
+    def test_disabled_returns_fake_payload_without_verifying(self):
+        with patch.dict(os.environ, {"AUTH_ENABLED": "false"}):
+            payload = auth_module.verify_download_token("invalid-garbage", "myproject")
+        assert payload["project"] == "myproject"
+        assert payload["purpose"] == "download"
+        assert payload["sub"] == "local"
+
+    def test_enabled_rejects_invalid_token(self):
+        env = {
+            "AUTH_ENABLED": "true",
+            "AUTH_TOKEN_SECRET": "test-secret-key-that-is-at-least-32-bytes",
+        }
+        with patch.dict(os.environ, env):
+            import jwt
+
+            with pytest.raises(jwt.InvalidTokenError):
+                auth_module.verify_download_token("not-a-jwt", "myproject")
+
+
+class TestGetCurrentUserKillSwitch:
+    """这些 dep 函数是 async；用 asyncio.run 直接调用。"""
+
+    @pytest.mark.asyncio
+    async def test_disabled_returns_anonymous_admin_without_token(self):
+        with patch.dict(os.environ, {"AUTH_ENABLED": "false"}):
+            user = await auth_module.get_current_user(token=None)
+        assert user.role == "admin"
+        assert user.sub == "local"
+
+    @pytest.mark.asyncio
+    async def test_disabled_returns_anonymous_admin_even_with_invalid_token(self):
+        with patch.dict(os.environ, {"AUTH_ENABLED": "false"}):
+            user = await auth_module.get_current_user(token="anything-goes")
+        assert user.sub == "local"
+
+    @pytest.mark.asyncio
+    async def test_enabled_without_token_raises_401(self):
+        env = os.environ.copy()
+        env.pop("AUTH_ENABLED", None)
+        env["AUTH_TOKEN_SECRET"] = "test-secret-key-that-is-at-least-32-bytes"
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(HTTPException) as exc_info:
+                await auth_module.get_current_user(token=None)
+            assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_flexible_disabled_returns_anonymous_without_token(self):
+        with patch.dict(os.environ, {"AUTH_ENABLED": "false"}):
+            user = await auth_module.get_current_user_flexible(token=None, query_token=None)
+        assert user.sub == "local"
+
+    @pytest.mark.asyncio
+    async def test_flexible_enabled_without_token_raises_401(self):
+        env = os.environ.copy()
+        env.pop("AUTH_ENABLED", None)
+        env["AUTH_TOKEN_SECRET"] = "test-secret-key-that-is-at-least-32-bytes"
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(HTTPException) as exc_info:
+                await auth_module.get_current_user_flexible(token=None, query_token=None)
+            assert exc_info.value.status_code == 401
+
+
+class TestLoginRouteKillSwitch:
+    @pytest.mark.asyncio
+    async def test_disabled_login_succeeds_with_any_password(self):
+        """端到端：AUTH_ENABLED=false 时 /auth/token 接受任意凭据。"""
+        from fastapi.testclient import TestClient
+
+        from server.app import app
+
+        env = {"AUTH_ENABLED": "false"}
+        with patch.dict(os.environ, env):
+            with TestClient(app) as client:
+                response = client.post(
+                    "/api/v1/auth/token",
+                    data={"username": "anyone", "password": "wrong"},
+                )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["token_type"] == "bearer"
+        assert body["access_token"]

--- a/tests/test_auth_kill_switch.py
+++ b/tests/test_auth_kill_switch.py
@@ -40,7 +40,8 @@ class TestIsAuthEnabled:
             ("0", False),
             ("no", False),
             ("off", False),
-            ("", False),  # 空串视为关闭，防 .env 半空配置
+            ("", True),  # 空串视为未配置 → 回退默认（开启），fail-closed
+            ("  ", True),  # 仅空白同上
             ("  false  ", False),
         ],
     )

--- a/tests/test_cors_config.py
+++ b/tests/test_cors_config.py
@@ -76,14 +76,15 @@ class TestCorsOriginsParsing:
 
 
 class TestListenEnvVars:
-    """LISTEN_HOST / LISTEN_PORT are only consumed by the ``__main__`` block.
-    Verify the values are read from env without actually starting uvicorn."""
+    """``LISTEN_HOST`` / ``LISTEN_PORT`` 的解析仅在 ``__main__`` 块被 uvicorn 消费，
+    导入 ``server.app`` 不会触发；通过共用的模块级 ``_resolve_listen_addr()`` 函数
+    测试同一份生产解析逻辑，避免测试 / 生产代码漂移。"""
 
     @staticmethod
     def _resolve() -> tuple[str, int]:
-        host = os.environ.get("LISTEN_HOST") or "0.0.0.0"
-        port = int(os.environ.get("LISTEN_PORT") or "1241")
-        return host, port
+        from server.app import _resolve_listen_addr
+
+        return _resolve_listen_addr()
 
     def test_defaults_match_existing_behavior(self):
         env = os.environ.copy()

--- a/tests/test_cors_config.py
+++ b/tests/test_cors_config.py
@@ -1,0 +1,90 @@
+"""Tests for env-driven CORS / network binding configuration."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def reload_app_with_env(monkeypatch: pytest.MonkeyPatch):
+    """Reload server.app under controlled env so module-level CORS config rebuilds."""
+
+    def _reload(env_overrides: dict[str, str | None]):
+        env = os.environ.copy()
+        for k, v in env_overrides.items():
+            if v is None:
+                env.pop(k, None)
+            else:
+                env[k] = v
+        with patch.dict(os.environ, env, clear=True):
+            import server.app as module
+
+            return importlib.reload(module)
+
+    return _reload
+
+
+class TestCorsOriginsParsing:
+    """The CORS middleware values come from CORS_ORIGINS at module import time."""
+
+    def test_unset_defaults_to_wildcard_no_credentials(self, reload_app_with_env):
+        mod = reload_app_with_env({"CORS_ORIGINS": None})
+        assert mod._allow_origins == ["*"]
+        assert mod._allow_credentials is False
+
+    def test_explicit_wildcard_keeps_credentials_off(self, reload_app_with_env):
+        mod = reload_app_with_env({"CORS_ORIGINS": "*"})
+        assert mod._allow_origins == ["*"]
+        assert mod._allow_credentials is False
+
+    def test_empty_string_falls_back_to_wildcard(self, reload_app_with_env):
+        mod = reload_app_with_env({"CORS_ORIGINS": "   "})
+        assert mod._allow_origins == ["*"]
+        assert mod._allow_credentials is False
+
+    def test_single_origin_enables_credentials(self, reload_app_with_env):
+        mod = reload_app_with_env({"CORS_ORIGINS": "http://localhost:5173"})
+        assert mod._allow_origins == ["http://localhost:5173"]
+        assert mod._allow_credentials is True
+
+    def test_multiple_origins_parsed_and_stripped(self, reload_app_with_env):
+        mod = reload_app_with_env(
+            {"CORS_ORIGINS": " http://a.example.com , http://b.example.com,http://c.example.com "}
+        )
+        assert mod._allow_origins == [
+            "http://a.example.com",
+            "http://b.example.com",
+            "http://c.example.com",
+        ]
+        assert mod._allow_credentials is True
+
+    def test_empty_segments_dropped(self, reload_app_with_env):
+        mod = reload_app_with_env({"CORS_ORIGINS": "http://a,,http://b,"})
+        assert mod._allow_origins == ["http://a", "http://b"]
+        assert mod._allow_credentials is True
+
+
+class TestListenEnvVars:
+    """LISTEN_HOST / LISTEN_PORT are only consumed by the ``__main__`` block.
+    Verify the values are read from env without actually starting uvicorn."""
+
+    def test_defaults_match_existing_behavior(self):
+        env = os.environ.copy()
+        env.pop("LISTEN_HOST", None)
+        env.pop("LISTEN_PORT", None)
+        with patch.dict(os.environ, env, clear=True):
+            host = os.environ.get("LISTEN_HOST", "0.0.0.0")
+            port = int(os.environ.get("LISTEN_PORT", "1241"))
+        assert host == "0.0.0.0"
+        assert port == 1241
+
+    def test_env_overrides_take_effect(self):
+        with patch.dict(os.environ, {"LISTEN_HOST": "127.0.0.1", "LISTEN_PORT": "18080"}):
+            host = os.environ.get("LISTEN_HOST", "0.0.0.0")
+            port = int(os.environ.get("LISTEN_PORT", "1241"))
+        assert host == "127.0.0.1"
+        assert port == 18080

--- a/tests/test_cors_config.py
+++ b/tests/test_cors_config.py
@@ -82,9 +82,9 @@ class TestListenEnvVars:
 
     @staticmethod
     def _resolve() -> tuple[str, int]:
-        from server.app import _resolve_listen_addr
+        import server.app as module
 
-        return _resolve_listen_addr()
+        return module._resolve_listen_addr()
 
     def test_defaults_match_existing_behavior(self):
         env = os.environ.copy()

--- a/tests/test_cors_config.py
+++ b/tests/test_cors_config.py
@@ -67,24 +67,42 @@ class TestCorsOriginsParsing:
         assert mod._allow_origins == ["http://a", "http://b"]
         assert mod._allow_credentials is True
 
+    def test_mixed_wildcard_with_specific_origin_collapses_to_wildcard(self, reload_app_with_env):
+        """`*` 出现在白名单里时，整体降级为通配 + credentials=False，
+        避免 Starlette `RuntimeError` (CORS spec 禁止通配 + credentials 共存)。"""
+        mod = reload_app_with_env({"CORS_ORIGINS": "http://localhost:5173, *"})
+        assert mod._allow_origins == ["*"]
+        assert mod._allow_credentials is False
+
 
 class TestListenEnvVars:
     """LISTEN_HOST / LISTEN_PORT are only consumed by the ``__main__`` block.
     Verify the values are read from env without actually starting uvicorn."""
+
+    @staticmethod
+    def _resolve() -> tuple[str, int]:
+        host = os.environ.get("LISTEN_HOST") or "0.0.0.0"
+        port = int(os.environ.get("LISTEN_PORT") or "1241")
+        return host, port
 
     def test_defaults_match_existing_behavior(self):
         env = os.environ.copy()
         env.pop("LISTEN_HOST", None)
         env.pop("LISTEN_PORT", None)
         with patch.dict(os.environ, env, clear=True):
-            host = os.environ.get("LISTEN_HOST", "0.0.0.0")
-            port = int(os.environ.get("LISTEN_PORT", "1241"))
+            host, port = self._resolve()
         assert host == "0.0.0.0"
         assert port == 1241
 
     def test_env_overrides_take_effect(self):
         with patch.dict(os.environ, {"LISTEN_HOST": "127.0.0.1", "LISTEN_PORT": "18080"}):
-            host = os.environ.get("LISTEN_HOST", "0.0.0.0")
-            port = int(os.environ.get("LISTEN_PORT", "1241"))
+            host, port = self._resolve()
         assert host == "127.0.0.1"
         assert port == 18080
+
+    def test_empty_listen_port_falls_back_to_default(self):
+        """`.env` 误写 `LISTEN_PORT=`（空值）不应让 `int("")` 抛 ValueError。"""
+        with patch.dict(os.environ, {"LISTEN_HOST": "", "LISTEN_PORT": ""}):
+            host, port = self._resolve()
+        assert host == "0.0.0.0"
+        assert port == 1241

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -218,3 +218,18 @@ class TestProjectEventService:
 
         await service.unsubscribe("demo", queue)
         await service.shutdown()
+
+    def test_projects_root_kwarg_overrides_default_subdir(self, tmp_path):
+        """显式传 projects_root 时，service.pm 走该目录而非 project_root/'projects'。
+
+        覆盖 ARCREEL_DATA_DIR 场景：app.py 启动时传 ``app_data_dir()`` 进来，
+        事件监听应跟着切换，不能继续指向旧的 ``project_root/projects``。
+        """
+        custom_projects = tmp_path / "external-data"
+        pm = ProjectManager(custom_projects)
+        pm.create_project("demo")
+
+        service = ProjectEventService(tmp_path, projects_root=custom_projects)
+
+        assert service.pm.projects_root == custom_projects.resolve()
+        assert service.pm.get_project_path("demo") == (custom_projects / "demo").resolve()

--- a/tests/test_thumbnail_fallback.py
+++ b/tests/test_thumbnail_fallback.py
@@ -1,0 +1,80 @@
+"""Thumbnail extraction graceful-skip when ffmpeg is unavailable."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import lib.thumbnail as thumbnail_module
+
+
+@pytest.fixture(autouse=True)
+def _reset_ffmpeg_cache():
+    thumbnail_module._reset_for_tests()
+    yield
+    thumbnail_module._reset_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_ffmpeg_missing(tmp_path: Path):
+    """ffmpeg 不在 PATH 中时不应 spawn 子进程，直接返回 None。"""
+    video = tmp_path / "fake.mp4"
+    video.write_bytes(b"\x00")  # nominal file; we never actually decode
+    out = tmp_path / "out.jpg"
+
+    with patch("lib.thumbnail.shutil.which", return_value=None):
+        with patch("lib.thumbnail.asyncio.create_subprocess_exec") as spawn:
+            result = await thumbnail_module.extract_video_thumbnail(video, out)
+
+    assert result is None
+    assert not out.exists()
+    spawn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_video_missing(tmp_path: Path):
+    """video 文件不存在时直接返回 None，不检查 ffmpeg。"""
+    nonexistent = tmp_path / "no-such-video.mp4"
+    out = tmp_path / "out.jpg"
+
+    with patch("lib.thumbnail.shutil.which") as which:
+        result = await thumbnail_module.extract_video_thumbnail(nonexistent, out)
+
+    assert result is None
+    which.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ffmpeg_available_attempts_extraction(tmp_path: Path):
+    """ffmpeg 在 PATH 时走原有 spawn 路径（spawn 被调用，returncode 非零仍返回 None）。"""
+    video = tmp_path / "fake.mp4"
+    video.write_bytes(b"\x00")
+    out = tmp_path / "out.jpg"
+
+    class _FakeProc:
+        returncode = 1  # ffmpeg failure
+
+        async def wait(self):
+            return None
+
+    with patch("lib.thumbnail.shutil.which", return_value="/usr/bin/ffmpeg"):
+        with patch(
+            "lib.thumbnail.asyncio.create_subprocess_exec",
+            return_value=_FakeProc(),
+        ) as spawn:
+            result = await thumbnail_module.extract_video_thumbnail(video, out)
+
+    assert result is None
+    spawn.assert_called_once()
+
+
+def test_ffmpeg_available_is_cached():
+    """_ffmpeg_available() 用 @functools.cache，多次调用 shutil.which 只一次。"""
+    thumbnail_module._reset_for_tests()
+    with patch("lib.thumbnail.shutil.which", return_value=None) as which:
+        thumbnail_module._ffmpeg_available()
+        thumbnail_module._ffmpeg_available()
+        thumbnail_module._ffmpeg_available()
+    assert which.call_count == 1


### PR DESCRIPTION
## Summary

将后端运行时的几处硬编码收敛为 env 驱动，所有改动默认值与现状等价，Docker / Web 部署无需任何运维动作即可继续工作。

- **AppDataDir 抽象**：新增 `lib/app_data_dir.py` 单点解析数据根目录，按 `ARCREEL_DATA_DIR` / `AI_ANIME_PROJECTS`（legacy）/ `PROJECT_ROOT/projects`（默认）三级优先级解析。\~25 处硬编码 `PROJECT_ROOT / "projects"` 统一切换。
- **AUTH_ENABLED kill switch**（默认 true）：四处短路点（\`ensure_auth_password\` / \`check_credentials\` / \`verify_download_token\` / \`get_current_user(_flexible)\`）+ login 路由。关闭时无视 token 返回匿名 admin。
- **网络绑定 env 化**：\`LISTEN_HOST\` / \`LISTEN_PORT\` / \`CORS_ORIGINS\` 全部可覆盖。CORS 顺手修正 \`["*"] + credentials=True\` 的 spec 违例（通配符模式下 credentials 强制关闭，白名单模式下打开）。
- **缩略图 graceful skip**：\`extract_video_thumbnail()\` 在 ffmpeg 不在 PATH 时直接返回 None，让前端 \`<video poster>\` 走浏览器原生取首帧的免费 fallback（不写后端 placeholder，避免顶掉 HTML 标准行为）。

## Compatibility

| Env | 默认 | 说明 |
|---|---|---|
| \`ARCREEL_DATA_DIR\` | unset | 不设 → \`PROJECT_ROOT/projects\` 完全等价于现状 |
| \`AUTH_ENABLED\` | \`true\` | 不设 / true → 所有认证逻辑与现状一致；false 仅适合单机或可信网络 |
| \`LISTEN_HOST\` / \`LISTEN_PORT\` | \`0.0.0.0\` / \`1241\` | 与现状等价；CLI \`uvicorn --port X\` 启动不经 \`__main__\` 块，不受影响 |
| \`CORS_ORIGINS\` | \`*\` | 通配（credentials 关闭）；白名单时启用 credentials |

无 DB schema 变更，无 Alembic revision，无前端改动。

## Commits

四个分主题 commit，便于按主题阅读 / 单独 revert：

\`\`\`
2d11381 feat(thumbnail): gracefully skip extraction when ffmpeg is unavailable
1a316ac feat(infra): make LISTEN_HOST / LISTEN_PORT / CORS_ORIGINS env-driven
bd4cd7e feat(auth):  add AUTH_ENABLED kill switch (default true)
3c6407d feat(infra): introduce AppDataDir for configurable application data root
\`\`\`

## Test plan

- [x] 新增 47 个单测（app_data_dir 8 + auth_kill_switch 27 + cors_config 8 + thumbnail_fallback 4）
- [x] 全量 \`uv run python -m pytest\` → **2434 passed**, 0 failed, 0 回归
- [x] \`uv run ruff check . && uv run ruff format .\` → 全绿
- [ ] 手动 smoke：默认 env 启动 → \`.env\` 仍自动生成 \`AUTH_PASSWORD\`，DB 仍落 \`projects/.arcreel.db\`，CORS 仍为通配
- [ ] 手动 smoke：\`AUTH_ENABLED=false ARCREEL_DATA_DIR=/tmp/x LISTEN_HOST=127.0.0.1 CORS_ORIGINS=http://localhost:5173\` → 数据落 \`/tmp/x/\`，curl 不带 token 返回 200
- [ ] 手动 smoke：移除 ffmpeg 后视频生成完成，前端 \`<video>\` 标签浏览器原生取首帧渲染
- [ ] Docker：\`docker build && docker run\` 现有 compose 配置不改也能起，行为不变

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增环境变量：AUTH_ENABLED、ARCREEL_DATA_DIR、CORS_ORIGINS、LISTEN_HOST、LISTEN_PORT，用于控制认证、数据目录与网络/CORS 行为；AUTH_ENABLED=false 时支持匿名访问并跳过凭据校验

* **行为变更**
  * 默认项目/数据目录改为可配置的“应用数据目录”，各服务与迁移工具改为使用该位置；启动绑定与 CORS 策略由环境变量控制

* **性能**
  * 缓存媒体工具（如 ffmpeg）可用性检测以减少重复探测

* **文档**
  * 更新示例环境配置，移除旧视频提供商示例并补充新变量说明

* **测试**
  * 新增/扩展测试覆盖认证开关、数据目录解析、CORS 解析与缩略图回退行为

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/515)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->