### PR TITLE
fix(copilot): guard IME Enter in agent input

### DIFF
--- a/frontend/src/components/copilot/AgentCopilot.test.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.test.tsx
@@ -122,4 +122,32 @@ describe("AgentCopilot", () => {
     fireEvent.click(screen.getByTitle("切换会话"));
     expect(document.querySelector(`.${UI_LAYERS.assistantLocalPopover}`)).toBeTruthy();
   });
+
+  it("does not send when Enter is used to confirm an IME composition", () => {
+    render(<AgentCopilot />);
+
+    const textarea = screen.getByLabelText("助手输入");
+    fireEvent.change(textarea, { target: { value: "你好" } });
+
+    fireEvent.compositionStart(textarea);
+    fireEvent.keyDown(textarea, {
+      key: "Enter",
+      code: "Enter",
+      keyCode: 229,
+      which: 229,
+      isComposing: true,
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    fireEvent.compositionEnd(textarea);
+    fireEvent.keyDown(textarea, {
+      key: "Enter",
+      code: "Enter",
+      keyCode: 13,
+      which: 13,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith("你好", undefined);
+  });
 });

--- a/frontend/src/components/copilot/AgentCopilot.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.tsx
@@ -187,6 +187,7 @@ export function AgentCopilot() {
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isComposingRef = useRef(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const imageGenRef = useRef(0);
   const slashMenuRef = useRef<SlashCommandMenuHandle>(null);
@@ -280,7 +281,7 @@ export function AgentCopilot() {
     }
   }, [inputDisabled, localInput, attachedImages, sendMessage]);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // Delegate to slash menu when open
     if (showSlashMenu && slashMenuRef.current) {
       const consumed = slashMenuRef.current.handleKeyDown(e.key);
@@ -291,6 +292,10 @@ export function AgentCopilot() {
       }
     }
     if (e.key === "Enter" && !e.shiftKey) {
+      const nativeEvent = e.nativeEvent;
+      if (nativeEvent.isComposing || nativeEvent.keyCode === 229 || isComposingRef.current) {
+        return;
+      }
       e.preventDefault();
       handleSend();
     }
@@ -590,6 +595,12 @@ export function AgentCopilot() {
             value={localInput}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
+            onCompositionStart={() => {
+              isComposingRef.current = true;
+            }}
+            onCompositionEnd={() => {
+              isComposingRef.current = false;
+            }}
             onPaste={handlePaste}
             placeholder={inputPlaceholder}
             rows={1}


### PR DESCRIPTION
## 变更

- 在 [frontend/src/components/copilot/AgentCopilot.tsx](frontend/src/components/copilot/AgentCopilot.tsx) 为助手输入框补上 IME 组合输入保护
- 当输入法还处于候选确认阶段时，按 Enter 不再触发消息发送
- 在 [frontend/src/components/copilot/AgentCopilot.test.tsx](frontend/src/components/copilot/AgentCopilot.test.tsx) 增加回归测试，覆盖 “IME 确认 Enter 不发送，普通 Enter 正常发送”

## 背景

AI 助手输入框之前直接把 Enter 视为发送。
在中文输入法确认候选词时，Enter 会同时用于结束 composition，这会导致“确认候选词”和“发送消息”一起发生，体验错误。

## 方案

- 增加 composition 状态跟踪
- 在 keydown 发送分支里识别 `nativeEvent.isComposing`、`keyCode === 229` 以及本地 composition 状态
- 只有真正结束组合输入后，普通 Enter 才会走发送逻辑

## 验证

- 运行：`pnpm exec vitest run src/components/copilot/AgentCopilot.test.tsx`
- 结果：4/4 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 改进了输入法（IME）的处理和文本编辑体验：系统现在能够正确识别用户是否正在使用输入法进行文本组合，在组合过程中按下回车键将不再发送消息，仅在输入法组合完成后的回车才会触发发送功能。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/516)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->