### PR TITLE
fix(auth): 前端根据 AUTH_ENABLED 状态判断是否跳过登录

### DIFF
--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -22,9 +22,25 @@ export const useAuthStore = create<AuthState>((set) => ({
     const token = getToken();
     if (token) {
       set({ token, isAuthenticated: true, isLoading: false });
-    } else {
-      set({ isLoading: false });
+      return;
     }
+    // 无 token 时先问后端是否启用了鉴权。`AUTH_ENABLED=false`（桌面壳 / 单
+    // 用户场景）下后端全链路 bypass，前端也应该跳过登录页直接进主界面。
+    // 网络异常时退回到原有行为（显示登录页），保守优先。
+    fetch("/api/v1/auth/status")
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`status ${res.status}`);
+        const data: { enabled: boolean } = await res.json();
+        if (!data.enabled) {
+          set({ isAuthenticated: true, isLoading: false });
+        } else {
+          set({ isLoading: false });
+        }
+      })
+      .catch((err) => {
+        console.warn("[auth] /auth/status fetch failed; defaulting to login", err);
+        set({ isLoading: false });
+      });
   },
 
   login: (token, username) => {

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -30,7 +30,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     fetch("/api/v1/auth/status")
       .then(async (res) => {
         if (!res.ok) throw new Error(`status ${res.status}`);
-        const data: { enabled: boolean } = await res.json();
+        const data = (await res.json()) as { enabled: boolean };
         if (!data.enabled) {
           set({ isAuthenticated: true, isLoading: false });
         } else {

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -24,10 +24,9 @@ export const useAuthStore = create<AuthState>((set) => ({
       set({ token, isAuthenticated: true, isLoading: false });
       return;
     }
-    // 无 token 时先问后端是否启用了鉴权。`AUTH_ENABLED=false`（桌面壳 / 单
-    // 用户场景）下后端全链路 bypass，前端也应该跳过登录页直接进主界面。
-    // 超时 / 网络异常 / 响应 shape 异常时 fail-closed 退回到登录页，避免误
-    // 把损坏响应当成"无需鉴权"放行。
+    // 无 token 时先问后端是否启用了鉴权。`AUTH_ENABLED=false` 时后端全链路
+    // bypass，前端也应该跳过登录页直接进主界面。超时 / 网络异常 / 响应 shape
+    // 异常时 fail-closed 退回到登录页，避免误把损坏响应当成"无需鉴权"放行。
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000);
     fetch("/api/v1/auth/status", { signal: controller.signal })

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -26,19 +26,31 @@ export const useAuthStore = create<AuthState>((set) => ({
     }
     // 无 token 时先问后端是否启用了鉴权。`AUTH_ENABLED=false`（桌面壳 / 单
     // 用户场景）下后端全链路 bypass，前端也应该跳过登录页直接进主界面。
-    // 网络异常时退回到原有行为（显示登录页），保守优先。
-    fetch("/api/v1/auth/status")
+    // 超时 / 网络异常 / 响应 shape 异常时 fail-closed 退回到登录页，避免误
+    // 把损坏响应当成"无需鉴权"放行。
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    fetch("/api/v1/auth/status", { signal: controller.signal })
       .then(async (res) => {
         if (!res.ok) throw new Error(`status ${res.status}`);
-        const data = (await res.json()) as { enabled: boolean };
-        if (!data.enabled) {
-          set({ isAuthenticated: true, isLoading: false });
-        } else {
-          set({ isLoading: false });
+        const payload: unknown = await res.json();
+        if (
+          typeof payload !== "object" ||
+          payload === null ||
+          typeof (payload as { enabled?: unknown }).enabled !== "boolean"
+        ) {
+          throw new Error("invalid /auth/status payload");
+        }
+        const { enabled } = payload as { enabled: boolean };
+        if (!enabled) {
+          set({ isAuthenticated: true });
         }
       })
       .catch((err) => {
         console.warn("[auth] /auth/status fetch failed; defaulting to login", err);
+      })
+      .finally(() => {
+        clearTimeout(timeoutId);
         set({ isLoading: false });
       });
   },

--- a/frontend/src/utils/runtime.ts
+++ b/frontend/src/utils/runtime.ts
@@ -1,0 +1,35 @@
+/**
+ * 检测当前 SPA 是否运行在 ArcReel 桌面客户端（Electron + preload）里。
+ *
+ * 桌面壳 `src/preload/index.ts` 在 `window.arcreel` 暴露一个标识对象，Web /
+ * Docker 部署不加载该 preload，window.arcreel 始终是 undefined，因此存在性
+ * 检查即可区分两种运行环境。
+ *
+ * 用法：
+ *   if (isDesktop()) { ... }                  // 隐藏 / 显示 / 布局差异化
+ *   <button hidden={isDesktop()}>下载</button>  // Web 显示、桌面隐藏
+ *   const cmd = isMac() ? "⌘" : "Ctrl";        // 快捷键标签
+ */
+
+interface ArcreelClientApi {
+  readonly platform: "desktop";
+  readonly os: string;
+}
+
+declare global {
+  interface Window {
+    arcreel?: ArcreelClientApi & Record<string, unknown>;
+  }
+}
+
+export function isDesktop(): boolean {
+  return typeof window !== "undefined" && window.arcreel?.platform === "desktop";
+}
+
+export function isMac(): boolean {
+  return window.arcreel?.os === "darwin";
+}
+
+export function isWindows(): boolean {
+  return window.arcreel?.os === "win32";
+}

--- a/frontend/src/utils/runtime.ts
+++ b/frontend/src/utils/runtime.ts
@@ -26,9 +26,9 @@ export function isDesktop(): boolean {
 }
 
 export function isMac(): boolean {
-  return window.arcreel?.os === "darwin";
+  return typeof window !== "undefined" && window.arcreel?.os === "darwin";
 }
 
 export function isWindows(): boolean {
-  return window.arcreel?.os === "win32";
+  return typeof window !== "undefined" && window.arcreel?.os === "win32";
 }

--- a/frontend/src/utils/runtime.ts
+++ b/frontend/src/utils/runtime.ts
@@ -1,14 +1,13 @@
 /**
- * 检测当前 SPA 是否运行在 ArcReel 桌面客户端（Electron + preload）里。
+ * 检测当前 SPA 是否运行在原生宿主（通过 preload 注入 `window.arcreel`）里。
  *
- * 桌面壳 `src/preload/index.ts` 在 `window.arcreel` 暴露一个标识对象，Web /
- * Docker 部署不加载该 preload，window.arcreel 始终是 undefined，因此存在性
- * 检查即可区分两种运行环境。
+ * 宿主端 preload 在 `window.arcreel` 暴露一个标识对象（含
+ * `platform === "desktop"` 与 `os`）；浏览器直接访问的部署不加载该 preload，
+ * `window.arcreel` 始终是 undefined，因此存在性检查即可区分两种运行环境。
  *
  * 用法：
- *   if (isDesktop()) { ... }                  // 隐藏 / 显示 / 布局差异化
- *   <button hidden={isDesktop()}>下载</button>  // Web 显示、桌面隐藏
- *   const cmd = isMac() ? "⌘" : "Ctrl";        // 快捷键标签
+ *   if (isDesktop()) { ... }                       // 显隐 / 布局差异化
+ *   const cmd = isMac() ? "⌘" : "Ctrl";             // 快捷键标签
  */
 
 interface ArcreelClientApi {

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -12,7 +12,12 @@ from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel
 
 from lib.i18n import Translator
-from server.auth import CurrentUser, check_credentials, create_token, is_auth_enabled
+from server.auth import (
+    CurrentUser,
+    check_credentials,
+    create_token,
+    is_auth_enabled,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +37,23 @@ class VerifyResponse(BaseModel):
     username: str
 
 
+class AuthStatusResponse(BaseModel):
+    enabled: bool
+
+
 # ==================== 路由 ====================
+
+
+@router.get("/auth/status", response_model=AuthStatusResponse)
+async def auth_status():
+    """暴露 ``AUTH_ENABLED`` 状态供前端 bootstrap 判断是否需要登录拦截。
+
+    前端 ``auth-store.initialize()`` 在 localStorage 无 token 时调用本接口：
+    ``enabled=false`` 时跳过登录页直接进主界面；``enabled=true`` 时保留原
+    登录链路。本接口本身**不要求认证**——一个 boolean 比 401 探针更直观，
+    且实际"是否需要登录"通过 401/200 也能从外部观察到，因此不增量泄露。
+    """
+    return AuthStatusResponse(enabled=is_auth_enabled())
 
 
 @router.post("/auth/token", response_model=TokenResponse)


### PR DESCRIPTION
## Summary

- 新增 `GET /api/v1/auth/status` 端点（无需认证），返回 `{"enabled": bool}`
- 前端 `auth-store.initialize()` 在没 token 时先 fetch `/auth/status`；`enabled=false` 自动 `isAuthenticated=true` 跳过登录页
- 默认 `AUTH_ENABLED=true`，旧 Docker / Web 部署行为完全不变
- 完成 Phase 0 前置改造里漏掉的前端 AuthGuard 这条链路（桌面客户端 `AUTH_ENABLED=false` 启动后不再被前端拦截到登录页）

## Test plan

- [ ] 默认 `AUTH_ENABLED=true` 启动后端，`curl /api/v1/auth/status` 返回 `{"enabled": true}`
- [ ] 默认状态下未登录用户仍被 AuthGuard redirect 到 `/login`（行为不变）
- [ ] `AUTH_ENABLED=false` 启动后端，`curl /api/v1/auth/status` 返回 `{"enabled": false}`
- [ ] `AUTH_ENABLED=false` 时未登录前端 bootstrap 后直接进主界面，不再 redirect 到 `/login`
- [ ] `/auth/status` 端点无 Authorization header 时返回 200（不要求认证）
- [ ] 网络异常 `/auth/status` fetch 失败时前端落到登录页，不卡 spinner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 后端新增认证状态查询接口，前端可在启动时探测是否启用认证。
  * 新增运行环境检测工具，可区分桌面（Electron）与浏览器及操作系统。

* **修复与改进**
  * 客户端认证初始化优化：若存在本地令牌则立即完成；无令牌时发起带超时的探测并校验返回，出错时优雅降级并确保加载状态清理。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/522)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->