### PR TITLE
fix(grid): 修复宫格图重新生成后 UI 仍显示旧图

### DIFF
--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -175,9 +175,9 @@ export function GridPreviewPanel({
   const safeIdx = Math.min(selectedIdx, Math.max(0, gridIds.length - 1));
   const selectedGridId = gridIds[safeIdx] ?? null;
 
-  // 直接订阅全局 grid 变更信号；不再依赖 parent 透传的 refreshKey，
-  // 避免链路中任一环节（list 抛错被吞、remount、初始 refreshKey 与 prop 相等）
-  // 导致 SSE grid_ready 到达后面板状态永远停在 pending。
+  // 直接订阅全局 grid 变更信号作为唯一 refetch 触发源；
+  // parent 透传的 refreshKey 是同一事件流（gridsRevision → listGrids → setRefreshKey）
+  // 的下游产物，加入 deps 会导致每次事件多发一次冗余 GET /grids/{id}。
   const gridsRevision = useAppStore((s) => s.gridsRevision);
 
   // safeIdx already clamps selectedIdx to valid range; no effect needed
@@ -213,8 +213,8 @@ export function GridPreviewPanel({
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- grid 用于判断是否切换批次，加入 deps 会在每次拉取完成后触发重新拉取，导致无限循环；t 稳定可忽略
-  }, [expanded, selectedGridId, projectName, refreshKey, gridsRevision]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- grid 仅用于切换批次判断；refreshKey 与 gridsRevision 同源，仅保留后者避免双触发；t 稳定
+  }, [expanded, selectedGridId, projectName, gridsRevision]);
 
   const isInProgress =
     grid?.status === "pending" || grid?.status === "generating" || grid?.status === "splitting";

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -16,6 +16,8 @@ import { motion, AnimatePresence } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { API } from "@/api";
 import { errMsg } from "@/utils/async";
+import { useProjectsStore } from "@/stores/projects-store";
+import { useAppStore } from "@/stores/app-store";
 import type { GridGeneration, ReferenceImage } from "@/types/grid";
 
 // ---------------------------------------------------------------------------
@@ -100,10 +102,12 @@ function ReferenceImageStrip({
   projectName: string;
   refreshKey: number;
 }) {
+  const fingerprints = useProjectsStore((s) => s.assetFingerprints);
   return (
     <div className="flex gap-2.5 overflow-x-auto pb-1 scrollbar-thin">
       {references.map((ref, idx) => {
         const isChar = ref.ref_type === "character";
+        const cacheBust = fingerprints[ref.path] ?? refreshKey;
         return (
           <motion.div
             key={ref.path}
@@ -120,7 +124,7 @@ function ReferenceImageStrip({
               }`}
             >
               <img
-                src={API.getFileUrl(projectName, ref.path, refreshKey)}
+                src={API.getFileUrl(projectName, ref.path, cacheBust)}
                 alt={ref.name}
                 className="block aspect-square w-full object-cover transition-transform duration-200 group-hover:scale-105"
               />
@@ -171,6 +175,11 @@ export function GridPreviewPanel({
   const safeIdx = Math.min(selectedIdx, Math.max(0, gridIds.length - 1));
   const selectedGridId = gridIds[safeIdx] ?? null;
 
+  // 直接订阅全局 grid 变更信号；不再依赖 parent 透传的 refreshKey，
+  // 避免链路中任一环节（list 抛错被吞、remount、初始 refreshKey 与 prop 相等）
+  // 导致 SSE grid_ready 到达后面板状态永远停在 pending。
+  const gridsRevision = useAppStore((s) => s.gridsRevision);
+
   // safeIdx already clamps selectedIdx to valid range; no effect needed
 
   // Fetch grid data when expanded and selectedGridId is available
@@ -205,14 +214,19 @@ export function GridPreviewPanel({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- grid 用于判断是否切换批次，加入 deps 会在每次拉取完成后触发重新拉取，导致无限循环；t 稳定可忽略
-  }, [expanded, selectedGridId, projectName, refreshKey]);
+  }, [expanded, selectedGridId, projectName, refreshKey, gridsRevision]);
 
   const isInProgress =
     grid?.status === "pending" || grid?.status === "generating" || grid?.status === "splitting";
 
+  // 优先使用持久化的 mtime 指纹做 cache-bust，跨页面刷新仍然有效；
+  // 回退到 refreshKey 仅用于指纹尚未送达前的当次会话。
+  const gridFp = useProjectsStore((s) =>
+    grid?.grid_image_path ? (s.assetFingerprints[grid.grid_image_path] ?? null) : null,
+  );
   const imageUrl =
     grid?.grid_image_path
-      ? API.getFileUrl(projectName, grid.grid_image_path, refreshKey)
+      ? API.getFileUrl(projectName, grid.grid_image_path, gridFp ?? refreshKey)
       : null;
 
   const refs = grid?.reference_images ?? [];

--- a/lib/asset_fingerprints.py
+++ b/lib/asset_fingerprints.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 # 扫描的媒体子目录
-_MEDIA_SUBDIRS = ("storyboards", "videos", "thumbnails", "characters", "scenes", "props")
+_MEDIA_SUBDIRS = ("storyboards", "videos", "thumbnails", "characters", "scenes", "props", "grids")
 
 # 根目录下的已知媒体文件（如风格参考图）
 _ROOT_MEDIA_SUFFIXES = frozenset((".png", ".jpg", ".jpeg", ".webp", ".mp4"))


### PR DESCRIPTION
## 范围

- `lib/asset_fingerprints.py`：mtime 指纹扫描目录补齐 `grids/`
- `frontend/src/components/canvas/timeline/GridPreviewPanel.tsx`：refetch 触发器 + cache-bust 参数来源
- **不动**：server 路由、worker、`files.py` 的 cache-control 策略、其它资产的指纹/UI 路径

## 变更

- `_MEDIA_SUBDIRS` 新增 `"grids"`，让初次加载项目时 `assetFingerprints` 包含宫格图的 `mtime_ns`
- `GridPreviewPanel` 直接订阅 `useAppStore.gridsRevision`，作为 parent `refreshKey` prop 透传链路的兜底触发器
- `GridPreviewPanel` 的 `imageUrl` 与参考图缩略图的 `?v=` 参数改为优先取 `useProjectsStore.assetFingerprints[path]`（即文件 mtime），指纹缺失时回退到 `refreshKey`

## 背景与根因

点击「重新生成」后，文件确实被覆盖写入新图、worker task 状态 `succeeded`、`grid.json` 状态 `completed`，但 UI：
- 仍展示老图
- 状态徽标停留在「待处理」、按钮停留在「生成中...」
- F5 刷新页面无法恢复

两处独立缺陷叠加：

**① mtime 指纹漏扫 `grids/`**

`lib/asset_fingerprints.py` 的 `_MEDIA_SUBDIRS` 不包含 `grids/`。结果：

1. 项目初次加载时 `asset_fingerprints` map 没有 `grids/*.png` 的 key
2. 前端只能退回到组件本地的 `refreshKey` 计数器（初值 `0`）作为 cache-bust
3. 第一次拉图 URL 是 `?v=0`，`server/routers/files.py` 对所有带 `?v=` 的请求返回 `Cache-Control: public, max-age=31536000, immutable`
4. 浏览器永久缓存 `?v=0`，刷新页面后 `refreshKey` 又从 `0` 计数 → 命中老缓存

worker 在 `grid_ready` SSE 时确实下发新指纹（`_compute_affected_fingerprints` 已处理 grid 路径），但 store 里这个 key 从未初始化，前端用不上。

**② `GridPreviewPanel` refetch 链路脆弱**

原链路：
SSE grid_ready
→ useAppStore.invalidateGrids() (useProjectEventsSSE.ts)
→ gridsRevision++
→ GridPreviewView useEffect [gridsRevision]
→ API.listGrids() + setRefreshKey(v+1)
→ GridPreviewPanel useEffect [refreshKey] ← 依赖 parent prop 透传
→ API.getGrid(id)

中间任一环失败（`API.listGrids().catch(()=>{})` 静默吞错、parent remount、prop 同值跳过 effect）panel 都不会重新拉 `GET /grids/{id}`，状态停留在 `pending`。

## 修复策略

- 改动 ①：把 `grids` 纳入扫描，让 `?v=<mtime_ns>` 成为真正的内容寻址 token，与 server `immutable` 头语义一致
- 改动 ②：panel 末端直接订阅 `gridsRevision`，与 parent 链路并联兜底；同时把图片 URL 的 cache-bust 来源切到持久化的 mtime 指纹

## 风险

- 改动 ② 是末端冗余订阅，**未定位 parent 透传链具体在哪步失败**。同样的链路脆弱模式可能存在于其它消费 `refreshKey`/`gridsRevision` 透传的组件（如 `ReferencePanel`、视频预览面板）。本 PR 不处理这部分。
- 多触发器（parent `refreshKey++` 与 panel 监听 `gridsRevision`）会被 React 批处理合并为单次 effect 执行，不会触发额外的 `GET /grids/{id}` 请求。
- 用 mtime 作 immutable cache-bust 的副作用：未来若新增媒体子目录而忘记加入 `_MEDIA_SUBDIRS`，那个目录的资源会退化到 `?v=0` 被永久缓存。

## 验收清单

- [x] 本地已跑相关测试：`uv run ruff check lib/asset_fingerprints.py && uv run ruff format --check lib/asset_fingerprints.py`、`cd frontend && pnpm lint`
- [x] 手动验证了改动所声称的行为：硬刷新清掉 `?v=0` 旧缓存后，点击「重新生成」→ 状态徽标 `pending → generating → splitting → completed`，新图自动替换；F5 后仍显示新图
- [x] 新增面向用户文案已加 zh/en 翻译（不适用，本 PR 无新 UI 文案）
- [x] 无新增 ESLint disable
- [x] CODEOWNERS 要求的 review 已请求

## 已知 defer

- parent → child refresh 链路在哪一环失败的根因未定位，仅做末端兜底。Follow-up issue：(待开)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化网格预览与参考图的缓存与刷新机制，减少无谓刷新、提升显示稳定性
  * 优先使用资源指纹作为缓存触发器，保证资源 URL 在指纹就位后保持稳定
* **改动**
  * 资源指纹扫描范围扩展，纳入网格相关媒体文件以改善缓存管理

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/524)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->