### PR TITLE
fix(agent-sandbox): 放行 projects/ 写入以让 skill 脚本写 .arcreel.db

### DIFF
--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -1850,6 +1850,12 @@ class SessionManager:
           Bash 工具改走 ``_WINDOWS_BASH_PREFIX_WHITELIST`` 代码白名单。
         - ``filesystem.denyRead``：内核级文件读拒绝（macOS Seatbelt / Linux
           bwrap profile），对 sandbox 内所有子进程生效。
+        - ``filesystem.allowWrite``：放行 ``projects/`` 目录的写权限。SDK 沙箱
+          默认只允许写 cwd（``projects/<proj>/``），其子进程 — 包括 skill 脚本通过
+          ``lib.generation_queue_client`` / ``UsageTracker`` 直连 SQLite 写
+          ``projects/.arcreel.db`` — 会落到 cwd 的父级，触发 "attempt to write a
+          readonly database"。projects 根目录下除 ``.arcreel.db*`` 外都是项目子目录
+          （本就在 cwd 子树内），等价于只额外放行 db 三件套，对其他写路径无副作用。
         - ``allowUnsandboxedCommands=False``：禁止 agent 在 sandbox 失败时
           请求"重试 unsandboxed"，对红线场景不可接受。
         """
@@ -1861,7 +1867,10 @@ class SessionManager:
             "allowUnsandboxedCommands": False,
             "network": {"allowedDomains": list(self._build_sandbox_allowed_domains())},
             "enableWeakerNestedSandbox": bool(self._in_docker),
-            "filesystem": {"denyRead": self._build_sensitive_abs_paths()},
+            "filesystem": {
+                "denyRead": self._build_sensitive_abs_paths(),
+                "allowWrite": [str(self.projects_root)],
+            },
         }
 
     def _build_sensitive_abs_paths(self) -> list[str]:

--- a/tests/agent_runtime/test_session_manager_sandbox.py
+++ b/tests/agent_runtime/test_session_manager_sandbox.py
@@ -251,6 +251,27 @@ def test_build_sandbox_settings_enabled_returns_full_config(tmp_path: Path) -> N
     assert settings["allowUnsandboxedCommands"] is False
     assert "allowedDomains" in settings["network"]
     assert "denyRead" in settings["filesystem"]
+    # allowWrite 必含 projects_root：放行 .arcreel.db / .db-shm / .db-wal 三件套
+    # （sandbox cwd = projects/<proj>/，默认禁写父级，会导致 skill 脚本直连
+    # SQLite 写 db 时报 "attempt to write a readonly database"）
+    assert "allowWrite" in settings["filesystem"]
+    assert str(sm.projects_root) in settings["filesystem"]["allowWrite"]
+
+
+def test_build_sandbox_settings_allowwrite_covers_arcreel_db(tmp_path: Path) -> None:
+    """allowWrite 必须覆盖 projects/.arcreel.db 路径。
+
+    skill 脚本（generate-script / generate-grid / ...）通过 UsageTracker /
+    generation_queue_client 写 ApiCall / Task 行，db 位于 projects 根下、
+    sandbox cwd（projects/<proj>/）的父级。OS 级 sandbox 默认只允许写 cwd
+    子树，必须把 projects_root 加进 allowWrite 否则 SQLite 报 readonly。
+    """
+    sm = _make_session_manager(tmp_path, sandbox_enabled=True)
+    allow_write = sm._build_sandbox_settings()["filesystem"]["allowWrite"]
+    db_path = sm.projects_root / ".arcreel.db"
+    assert any(
+        Path(p) in (db_path.parent, db_path.parent.parent) or db_path.is_relative_to(Path(p)) for p in allow_write
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

#521 启用 SDK Bash 沙箱后，所有需要写 `.arcreel.db` 的 skill 脚本（`generate-script` / `generate-grid` / `generate-video` / `generate-storyboard` 等）都会崩：

```
sqlite3.OperationalError: attempt to write a readonly database
  at agent_runtime_profile/.claude/skills/generate-script/scripts/generate_script.py:116
  via ScriptGenerator.generate() → UsageTracker → INSERT INTO api_calls
```

## 根因

`claude-agent-sdk` 0.1.80 构造的 macOS Seatbelt / Linux bwrap profile 默认**只允许写当前 cwd 子树**，对应官方文档 [sandboxing.md § "Granting subprocess write access to specific paths"](https://docs.claude.com/en/docs/claude-code/sandboxing#granting-subprocess-write-access-to-specific-paths)。

ArcReel 里 sandbox cwd 是 `projects/<proj_name>/`，但 `.arcreel.db` 落在它的**父级** `projects/.arcreel.db`，所以 skill 子进程通过 `UsageTracker` / `lib.generation_queue_client` 写 `ApiCall` / `Task` 行时全部被内核级拒绝。

#521 注意到了 `.arcreel.db` 不能放进 `denyRead`（任务队列入队会瘫痪），并通过 issue #519 把"db 内 api_key 明文"标记为已知豁免 — 但**只从"读"的维度处理**，整个 PR commit message、spec、plan 验收清单都没触及"写 db"这条主路径。手工验收没跑会写 db 的 skill 流程，跑了就会立即暴露。

## 修复

`_build_sandbox_settings()` 的 `filesystem` 字典加 `allowWrite: [<projects_root>]`。

`projects/` 根目录下除 `.arcreel.db` / `.arcreel.db-shm` / `.arcreel.db-wal` 外都是项目子目录（本就在 sandbox cwd 子树内、本来就允许写），等价于**只额外放行 db 三件套**，对其它写路径无副作用。

## 测试

- `test_build_sandbox_settings_enabled_returns_full_config`：补 `allowWrite` 存在性断言
- `test_build_sandbox_settings_allowwrite_covers_arcreel_db`：显式覆盖 db 写场景

```
$ uv run python -m pytest tests/agent_runtime/test_session_manager_sandbox.py -q
20 passed in 0.21s
```

## 手工验收（macOS 14 / Seatbelt）

修复前：generate-script skill 在 sandbox 内调用 `ScriptGenerator.generate()` → SQLite readonly error → 退出码 1 → agent 报错  
修复后：脚本正常完成，`ApiCall` 行成功写入 `projects/.arcreel.db`，剧本 JSON 落盘

## 关联

- #521 sandbox 启用
- #519 db 明文密钥已知豁免（本 PR 不影响该豁免）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 改进了沙箱环境的文件系统权限配置，允许向项目目录进行写入操作
  * 修复了沙箱模式下数据库写入失败的问题，确保相关操作正常执行
  * 增强了权限验证测试覆盖范围

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/525)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->