### PR TITLE
fix(env_init): 沙箱内 .env 不可读时降级，不阻断 import lib

### DIFF
--- a/lib/env_init.py
+++ b/lib/env_init.py
@@ -30,19 +30,17 @@ def init_environment():
         from dotenv import load_dotenv
 
         env_path = project_root / ".env"
+        # 沙箱里 stat 与 open 是两次独立 syscall：exists() 可能放行而
+        # load_dotenv() 仍被 denyRead 拦截。整段统一用 OSError 兜底，
+        # 任何文件访问失败都视为 ".env 不可用"，降级继续 import。
         try:
-            env_exists = env_path.exists()
-        except OSError:
-            # 沙箱里 .env 不可读 == 视为不存在
-            env_exists = False
-        if env_exists:
-            load_dotenv(env_path)
-        else:
-            # load_dotenv() 默认会向上回溯查找 .env；沙箱里同样可能撞权限墙
-            try:
+            if env_path.exists():
+                load_dotenv(env_path)
+            else:
+                # 默认会向上回溯查找 .env
                 load_dotenv()
-            except OSError:
-                pass
+        except OSError:
+            pass
     except ImportError:
         pass
 

--- a/lib/env_init.py
+++ b/lib/env_init.py
@@ -15,7 +15,14 @@ logger = logging.getLogger(__name__)
 
 
 def init_environment():
-    """初始化项目环境：定位项目根 + load .env。"""
+    """初始化项目环境：定位项目根 + load .env。
+
+    在 Agent Bash 沙箱子进程里，``.env`` 会被沙箱拒读（macOS sandbox-exec /
+    Linux bwrap deny list），``env_path.exists()`` 会抛 PermissionError。
+    沙箱子进程不需要 .env —— provider/Anthropic env 已由 SessionManager
+    通过 ``options.env`` 显式注入。这里吞掉 OSError 让 ``import lib`` 链
+    不被沙箱拦截。
+    """
     lib_dir = Path(__file__).parent
     project_root = lib_dir.parent
 
@@ -23,10 +30,19 @@ def init_environment():
         from dotenv import load_dotenv
 
         env_path = project_root / ".env"
-        if env_path.exists():
+        try:
+            env_exists = env_path.exists()
+        except OSError:
+            # 沙箱里 .env 不可读 == 视为不存在
+            env_exists = False
+        if env_exists:
             load_dotenv(env_path)
         else:
-            load_dotenv()
+            # load_dotenv() 默认会向上回溯查找 .env；沙箱里同样可能撞权限墙
+            try:
+                load_dotenv()
+            except OSError:
+                pass
     except ImportError:
         pass
 


### PR DESCRIPTION
## 问题

#521 启用 Bash 沙箱后，任意 skill 脚本（`agent_runtime_profile/.claude/skills/*/scripts/*.py`）启动时 `import lib` → `lib/env_init.py` 调 `env_path.exists()` 探测 `.env`，触发 sandbox `denyRead` 的内核级拒绝：

```
PermissionError: [Errno 1] Operation not permitted: '.../.env'
```

`.exists()` 本身也会触发 stat 调用，被 Seatbelt / bwrap 当作 read 操作直接拒掉，整个 import 链在脚本主代码运行前就崩。

## 修复

把 `env_path.exists()` + `load_dotenv()` 包在 `try/except OSError`，沙箱里命中 `denyRead` 视为 ".env 不存在"，降级继续 import。

沙箱子进程本来就**不应该**依赖 `.env` 的内容 — provider / Anthropic 凭据由 `SessionManager._build_provider_env_overrides()` 通过 `ClaudeAgentOptions.env` 显式注入。本修复只是把"读 .env 失败"从硬崩改为静默跳过，外部行为（沙箱外）零变化。

## 复现路径

WebUI 助手会话 → 触发任意 skill（如 generate-script）→ Bash 子进程 `python .claude/skills/.../*.py` → `import lib` → 上述 `PermissionError`。

## 测试

修复前后均跑 `uv run python -m pytest tests/`，无回归。沙箱场景需 macOS Seatbelt / Linux bwrap 实环境验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了环境变量加载的鲁棒性：在受限/沙盒环境中更宽容地处理 .env 文件访问错误，避免初始化因文件访问异常中断。

* **Documentation**
  * 完善了环境初始化功能的文档说明，明确了在沙盒场景下为何需要抑制相关文件访问错误。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/526)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->