### PR TITLE
fix(deps): 添加 socksio 以兼容系统 SOCKS 代理

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "packaging>=24.0",
     "portalocker>=2.10.1",
     "pdf-oxide>=0.3.46",
+    "socksio>=1.0.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -198,6 +198,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "pyyaml" },
+    { name = "socksio" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn" },
     { name = "volcengine-python-sdk", extra = ["ark"] },
@@ -242,6 +243,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "socksio", specifier = ">=1.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.48" },
     { name = "uvicorn", specifier = ">=0.41.0" },
     { name = "volcengine-python-sdk", extras = ["ark"], specifier = ">=5.0.17" },
@@ -2463,6 +2465,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 问题

#521 sandbox 启用后，SDK 会把宿主机的 `ALL_PROXY` / `HTTPS_PROXY` 环境变量注入沙箱子进程。当宿主机开启了 SOCKS 代理（macOS 上 Clash 等工具常通过 `scutil --proxy` 注册，启动 shell 时也常 export `ALL_PROXY=socks5://...`），httpx 客户端在 `trust_env=True`（默认）下读取后会立即抛：

```
RuntimeError: Using SOCKS proxy, but the socksio package is not installed.
Make sure to install httpx using `pip install httpx[socks]`.
```

#521 之前这个路径不会暴露：
- 主进程的 httpx 客户端虽然也 `trust_env=True`，但宿主机用户态 macOS SOCKS 代理是 `scutil` 系统注册的，**不在** `os.environ`，httpx 看不到
- 沙箱子进程则不一样：SDK 显式把代理环境变量**注入**到子进程 env，httpx 这次能看到，于是要求 socksio

## 修复

把 `socksio` 加为运行期依赖。

- 无代理 / 无沙箱场景：零影响（依赖不被加载）
- 沙箱 + 系统 SOCKS 代理：httpx 能正常解析 `socks://` URL，不再启动期硬崩

## 影响范围

依赖大小：socksio 1.0.0（pure-python，零传递依赖），增加 < 50KB。

## 验证

```bash
$ ALL_PROXY=socks5://127.0.0.1:7890 uv run python -c "import httpx; httpx.get('https://example.com', timeout=3)"
# 修复前：RuntimeError: ... socksio package is not installed
# 修复后：HTTP/1.1 200 OK
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本说明

* **Chores**
  * 添加了新的依赖包以支持应用功能。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/527)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->