### PR TITLE
fix(agent): normalize_drama_script 传入 project_name 让项目级文本后端生效

### DIFF
--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -240,7 +240,7 @@ def normalize_drama_script_tool(ctx: ToolContext):
                     ]
                 }
 
-            backend = await create_text_backend_for_task(TextTaskType.SCRIPT)
+            backend = await create_text_backend_for_task(TextTaskType.SCRIPT, project_name=ctx.project_name)
             result = await backend.generate(TextGenerationRequest(prompt=prompt, max_output_tokens=16000))
             response = result.text
 

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -519,6 +519,46 @@ async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext, monkeypatch
     assert "DRY RUN" in out["content"][0]["text"]
 
 
+async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: ToolContext, monkeypatch) -> None:
+    """工具必须把 ctx.project_name 传给 create_text_backend_for_task，
+    否则项目级 text_backend_script 覆盖被跳过，会回退到全局默认后端。"""
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    project_path = fake_ctx.project_path
+    src = project_path / "source"
+    src.mkdir(parents=True)
+    (src / "chapter1.txt").write_text("从前有座山", encoding="utf-8")
+
+    async def fake_caps(_p):
+        return 4, [4, 6, 8]
+
+    captured: dict[str, Any] = {}
+
+    class _FakeBackend:
+        async def generate(self, _request):
+            class _R:
+                text = "| 场景 ID | 描述 |\n|---|---|\n| E1S01 | 山中 |"
+
+            return _R()
+
+    async def fake_create(task_type, project_name=None):
+        captured["task_type"] = task_type
+        captured["project_name"] = project_name
+        return _FakeBackend()
+
+    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    monkeypatch.setattr(mod, "create_text_backend_for_task", fake_create)
+
+    tool_obj = normalize_drama_script_tool(fake_ctx)
+    out = await _call(tool_obj, {"episode": 1})
+
+    assert out.get("is_error") is not True, out
+    assert captured["project_name"] == "demo", (
+        f"normalize_drama_script 必须传入 project_name 以让项目级 text_backend_script 覆盖生效，"
+        f"实际传入: {captured.get('project_name')!r}"
+    )
+
+
 async def test_normalize_drama_script_no_source(fake_ctx: ToolContext) -> None:
     tool_obj = normalize_drama_script_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1})


### PR DESCRIPTION
## Summary
- `normalize_drama_script` MCP tool 调用 `create_text_backend_for_task(TextTaskType.SCRIPT)` 漏传 `project_name`，导致 `ConfigResolver._resolve_text_backend` 跳过项目级 `text_backend_script` 覆盖（解析优先级第 1 级），回退到全局默认后端；当全局默认 API key 失效就 401。
- 修复：把 `ctx.project_name` 传入；对照 `lib/text_generator.py:45` / `lib/script_generator.py:78,162` 同函数的正确调用模式。
- 新增 `test_normalize_drama_script_passes_project_name_to_backend` 锁定回归（先 fail：实际传入 None；改后 pass）。

## Test plan
- [x] `uv run python -m pytest tests/server/agent_runtime/test_sdk_tools.py tests/test_text_backends/test_factory.py` — 37/37
- [x] `uv run python -m pytest tests/ -k "normalize or script or text_backend or sdk_tools"` — 370/370
- [x] `uv run ruff check + format --check` 干净

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了剧本规范化工具的后端初始化方式，确保正确传递项目信息参数。

* **测试**
  * 新增测试用例，验证项目信息参数的正确传递。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/529)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->