### PR TITLE
fix(scenes): drama PATCH 改用 script-scenes 路径，防止路由冲突

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -230,7 +230,7 @@ describe("API", () => {
       expect(requestSpy).toHaveBeenCalledWith(
         "/projects/demo/scripts/episode%201.json",
       );
-      expect(requestSpy).toHaveBeenCalledWith("/projects/demo/scenes/scene-1", {
+      expect(requestSpy).toHaveBeenCalledWith("/projects/demo/script-scenes/scene-1", {
         method: "PATCH",
         body: JSON.stringify({ script_file: "episode_1.json", updates: { x: 1 } }),
       });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -638,7 +638,7 @@ class API {
     updates: Record<string, unknown>
   ): Promise<SuccessResponse> {
     return this.request(
-      `/projects/${encodeURIComponent(projectName)}/scenes/${encodeURIComponent(sceneId)}`,
+      `/projects/${encodeURIComponent(projectName)}/script-scenes/${encodeURIComponent(sceneId)}`,
       {
         method: "PATCH",
         body: JSON.stringify({ script_file: scriptFile, updates }),

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -772,9 +772,14 @@ class UpdateSceneRequest(BaseModel):
     updates: dict
 
 
-@router.patch("/projects/{name}/scenes/{scene_id}")
+@router.patch("/projects/{name}/script-scenes/{scene_id}")
 async def update_scene(name: str, scene_id: str, req: UpdateSceneRequest, _user: CurrentUser, _t: Translator):
-    """更新场景"""
+    """更新 drama 模式剧本中的单个场景镜头（按 scene_id 定位）。
+
+    路径与项目场景资产 CRUD（``/projects/{name}/scenes/{entry_name}``）做明确区分，
+    避免 FastAPI 按注册顺序优先匹配本端点导致 SceneCard 保存请求被截获、Pydantic
+    必填字段校验返回双 "Field required"。
+    """
     try:
 
         def _sync():

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -269,14 +269,14 @@ class TestProjectsRouter:
 
         with client:
             patch_scene = client.patch(
-                "/api/v1/projects/ready/scenes/001",
+                "/api/v1/projects/ready/script-scenes/001",
                 json={"script_file": "episode_1.json", "updates": {"duration_seconds": 6, "segment_break": True}},
             )
             assert patch_scene.status_code == 200
             assert patch_scene.json()["scene"]["duration_seconds"] == 6
 
             patch_scene_missing = client.patch(
-                "/api/v1/projects/ready/scenes/404",
+                "/api/v1/projects/ready/script-scenes/404",
                 json={"script_file": "episode_1.json", "updates": {}},
             )
             assert patch_scene_missing.status_code == 404
@@ -367,7 +367,7 @@ class TestProjectsRouter:
 
         with client:
             patched = client.patch(
-                "/api/v1/projects/ready/scenes/001",
+                "/api/v1/projects/ready/script-scenes/001",
                 json={
                     "script_file": "episode_1.json",
                     "updates": {

--- a/tests/test_scenes_router.py
+++ b/tests/test_scenes_router.py
@@ -86,3 +86,34 @@ class TestScenesRouter:
 
             missing_del = client.delete("/api/v1/projects/demo/scenes/不存在")
             assert missing_del.status_code == 404
+
+
+class TestScenesRouterDoesNotCollideWithProjects:
+    """Path 模板冲突回归保护。
+
+    projects.router 与 scenes.router 都在同一 ``/api/v1`` 前缀下注册，且历史上
+    都使用过 ``PATCH /projects/{name}/scenes/{*}`` 路径。FastAPI 按注册顺序匹配
+    path 模板，drama 端点（必填字段 ``script_file`` / ``updates``）若优先匹配
+    会让 SceneCard "保存" 请求收到 422 "Field required; Field required"。
+    """
+
+    def test_patch_scene_with_description_only_body_hits_asset_router(self, monkeypatch):
+        from server.routers import projects as projects_router
+
+        fake_pm = _FakePM()
+        monkeypatch.setattr(scenes, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(projects_router, "get_project_manager", lambda: fake_pm)
+
+        app = FastAPI()
+        app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+        # 与 server/app.py 同序：projects 先 include
+        app.include_router(projects_router.router, prefix="/api/v1")
+        app.include_router(scenes.router, prefix="/api/v1")
+
+        with TestClient(app) as client:
+            resp = client.patch(
+                "/api/v1/projects/demo/scenes/祠堂",
+                json={"description": "傍晚至清晨室外海景"},
+            )
+            assert resp.status_code == 200, resp.json()
+            assert resp.json()["scene"]["description"] == "傍晚至清晨室外海景"


### PR DESCRIPTION
## Summary
- `projects.router` 的 `PATCH /projects/{name}/scenes/{scene_id}`（drama 剧本镜头更新，必填 `script_file`/`updates`）与 `scenes.router` 由 `_asset_router_factory` 生成的 `PATCH /projects/{name}/scenes/{entry_name}`（项目场景资产更新，body 为 `dict[str, Any]`）路径模板完全相同。`server/app.py` 中前者先注册，FastAPI 按注册顺序匹配 → SceneCard 保存描述请求被 drama 端点截获，Pydantic 返回双 "Field required"，前端 toast 显示「更新场景失败: Field required; Field required」
- 把 drama 端点重命名为 `PATCH /projects/{name}/script-scenes/{scene_id}`，并同步更新前端 `API.updateScene`、相关单元测试 URL
- 新增回归测试 `TestScenesRouterDoesNotCollideWithProjects`：模拟与 `server/app.py` 同序注册两个 router，验证带 `{description: ...}` 的 PATCH 必须命中资产路由

## Test plan
- [x] `uv run python -m pytest`（2556 passed）
- [x] `pnpm lint && pnpm check`（typecheck + 550 tests passed）
- [x] `uv run ruff check` + `format`
- [x] 复现脚本：完整 app 调 `PATCH /api/v1/projects/demo/scenes/seaside` body `{description: "..."}` 修复前 422 双 Field required → 修复后正确 404（项目不存在）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复了脚本场景更新端点的路由冲突问题，确保脚本场景的更新请求能被正确识别和处理，提升系统的可靠性。

* **Tests**
  * 添加并更新了测试用例，新增了回归测试以验证脚本场景功能与其他功能之间不存在路由冲突。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/530)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->