### PR TITLE
fix(ui): 模型选择下拉 portal 到 body 避免被 overflow 祖先裁剪

### DIFF
--- a/frontend/src/components/ui/ProviderModelSelect.tsx
+++ b/frontend/src/components/ui/ProviderModelSelect.tsx
@@ -1,8 +1,18 @@
-import { useState, useRef, useEffect, useCallback, useMemo, useId } from "react";
+import { useState, useRef, useEffect, useCallback, useLayoutEffect, useMemo, useId } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, Check, Search } from "lucide-react";
+import {
+  FloatingPortal,
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  size,
+  useFloating,
+} from "@floating-ui/react";
 import { ProviderIcon } from "@/components/ui/ProviderIcon";
 import { DROPDOWN_PANEL_STYLE } from "@/components/ui/darkroom-tokens";
+import { UI_LAYERS } from "@/utils/ui-layers";
 
 interface ProviderModelSelectProps {
   value: string; // "gemini-aistudio/veo-3.1-generate-001"
@@ -75,6 +85,37 @@ export function ProviderModelSelect({
   const inputRef = useRef<HTMLInputElement>(null);
   const itemRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
 
+  // 用 FloatingPortal + useFloating 把面板渲染到 document.body，使其脱离任何
+  // overflow: hidden / overflow: auto 祖先（如 ProjectSettingsPage 的 SectionCard
+  // 或 SystemConfigPage 的 main 滚动容器）的视觉裁剪。fixed 策略 + autoUpdate
+  // 保证窗口滚动/缩放时面板跟随触发按钮。
+  const { refs, floatingStyles } = useFloating({
+    open,
+    onOpenChange: setOpen,
+    strategy: "fixed",
+    placement: "bottom-start",
+    whileElementsMounted: autoUpdate,
+    middleware: [
+      offset(4),
+      flip({ padding: 12 }),
+      shift({ padding: 12 }),
+      size({
+        padding: 8,
+        apply({ rects, elements }) {
+          // 同步面板宽度到触发按钮，保持视觉等宽（替代原本依赖父级 `w-full`）。
+          elements.floating.style.width = `${rects.reference.width}px`;
+        },
+      }),
+    ],
+  });
+
+  // 在 layout 阶段绑定 reference，避免首帧把面板钉在视窗左上。open 进入依赖
+  // 是为了 close→open 切换时让 floating-ui 重新计算位置（autoUpdate 仅在
+  // 元素同时存在时才生效）。
+  useLayoutEffect(() => {
+    refs.setReference(triggerRef.current);
+  }, [open, refs]);
+
   const showSearch = searchable && options.length >= searchThreshold;
 
   // Memoize grouped so flatOptions below has a stable reference when options
@@ -124,17 +165,22 @@ export function ProviderModelSelect({
     return list;
   }, [showDefault, filteredGrouped]);
 
-  // Close on outside click
+  // Close on outside click. 面板 portal 到 body 后已不在 containerRef 子树内，
+  // 必须同时检查 floating element，否则点击搜索框 / 选项会被判定为 outside 并立即关闭。
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      const insideTrigger = containerRef.current?.contains(target);
+      const floatingEl = refs.floating.current;
+      const insidePanel = floatingEl?.contains(target);
+      if (!insideTrigger && !insidePanel) {
         setOpen(false);
         setQuery("");
       }
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
-  }, []);
+  }, [refs]);
 
   // Reset active index when opened — point to current value or 0
   useEffect(() => {
@@ -294,13 +340,20 @@ export function ProviderModelSelect({
         />
       </button>
 
-      {/* Dropdown panel */}
+      {/* Dropdown panel — portal 到 body 后由 floating-ui 用 fixed 策略定位，
+          脱离所有 overflow 祖先的视觉裁剪。z-layer 取 `modal` 与上层全屏容器同级，
+          portal 默认 append 到 body 末尾，DOM order 保证下拉盖在 modal/page 之上。 */}
       {open && (
-        <div
-          className="absolute z-50 mt-1 w-full rounded-[8px] border border-hairline shadow-xl"
-          style={DROPDOWN_PANEL_STYLE}
-        >
-          {showSearch && (
+        <FloatingPortal>
+          <div
+            // floating-ui 的 setFloating 是 stable callback ref；hooks/refs
+            // 规则误认为是读取 ref.current，这里安全。
+            // eslint-disable-next-line react-hooks/refs
+            ref={refs.setFloating}
+            className={`isolate overflow-hidden rounded-[8px] border border-hairline shadow-xl ${UI_LAYERS.modal}`}
+            style={{ ...floatingStyles, ...DROPDOWN_PANEL_STYLE }}
+          >
+            {showSearch && (
             <div className="relative border-b border-hairline-soft p-2">
               <Search className="pointer-events-none absolute left-4 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-4" />
               <input
@@ -405,7 +458,8 @@ export function ProviderModelSelect({
               </div>
             )}
           </div>
-        </div>
+          </div>
+        </FloatingPortal>
       )}
     </div>
   );

--- a/frontend/src/components/ui/ProviderModelSelect.tsx
+++ b/frontend/src/components/ui/ProviderModelSelect.tsx
@@ -167,7 +167,9 @@ export function ProviderModelSelect({
 
   // Close on outside click. 面板 portal 到 body 后已不在 containerRef 子树内，
   // 必须同时检查 floating element，否则点击搜索框 / 选项会被判定为 outside 并立即关闭。
+  // 仅在 open=true 时挂载全局监听，避免大量关闭态实例长期占用 mousedown listener。
   useEffect(() => {
+    if (!open) return;
     const handler = (e: MouseEvent) => {
       const target = e.target as Node;
       const insideTrigger = containerRef.current?.contains(target);
@@ -180,7 +182,7 @@ export function ProviderModelSelect({
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
-  }, [refs]);
+  }, [open, refs]);
 
   // Reset active index when opened — point to current value or 0
   useEffect(() => {


### PR DESCRIPTION
## Summary

- `ProviderModelSelect` 下拉面板原本 `position: absolute` 相对父级 relative 定位，会被任何 `overflow-hidden` / `overflow-auto` 祖先视觉裁剪——在项目设置 `SectionCard`、全局设置 `main` 滚动容器、`CreateProjectModal` 内均触发
- 改用 `FloatingPortal` + `useFloating(strategy: "fixed")` 渲染到 `document.body`，配合 `offset` / `flip` / `shift` / `size` middleware 完成偏移、视口翻转、贴边、宽度同步
- 一处修复全部受益：`ModelConfigSection` / `ImageModelDualSelect` / `MediaModelSection` / Create Project 向导 等所有复用点

## Test plan

- [x] `pnpm lint` 通过
- [x] `pnpm typecheck` 通过
- [x] `pnpm vitest` 75 文件 / 550 测试全部通过（含 `ProviderModelSelect.test.tsx` 全部 19 个断言：search、IME、aria id、关闭重开等）
- [ ] 项目设置 → 模型配置：展开「风格分析模型」下拉，搜索框 + 选项列表完整显示，不被 SectionCard 圆角裁剪
- [ ] 全局设置 → 模型配置：滚动到页面底部展开下拉，确认不被 main 滚动容器裁剪
- [ ] CreateProjectModal 第 2 步：modal 内展开下拉，下拉盖在 modal 之上
- [ ] 关闭/重开、搜索过滤、键盘导航（↑↓ Enter Esc）、IME 输入法仍正常

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了模型选择下拉菜单的定位与对齐，面板在滚动或受容器约束时更稳定并与触发器宽度保持一致。
  * 优化了点击外部关闭逻辑，只有在同时点击触发器与面板之外时才关闭菜单并清除搜索。
  * 更新了面板渲染层级与样式，确保遮罩/模态层级显示正确。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/531)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->