### PR TITLE
fix(agent): normalize_drama_script 透传 project_name 让项目级模型覆盖生效

### DIFF
--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -240,7 +240,7 @@ def normalize_drama_script_tool(ctx: ToolContext):
                     ]
                 }
 
-            backend = await create_text_backend_for_task(TextTaskType.SCRIPT)
+            backend = await create_text_backend_for_task(TextTaskType.SCRIPT, ctx.project_name)
             result = await backend.generate(TextGenerationRequest(prompt=prompt, max_output_tokens=16000))
             response = result.text
 

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -523,3 +523,41 @@ async def test_normalize_drama_script_no_source(fake_ctx: ToolContext) -> None:
     tool_obj = normalize_drama_script_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1})
     assert out.get("is_error") is True
+
+
+async def test_normalize_drama_script_passes_project_name(fake_ctx: ToolContext, monkeypatch) -> None:
+    """normalize_drama_script 必须把 ctx.project_name 透传给 create_text_backend_for_task，
+    否则项目级 text_backend_script 覆盖会被 resolver 跳过（_resolve_text_backend 第 1 步要求 project_name）。"""
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    project_path = fake_ctx.project_path
+    src = project_path / "source"
+    src.mkdir(parents=True)
+    (src / "chapter1.txt").write_text("从前有座山", encoding="utf-8")
+
+    async def fake_caps(_p):
+        return 4, [4, 6, 8]
+
+    captured: dict[str, Any] = {}
+
+    class _FakeBackend:
+        async def generate(self, _req):
+            class _R:
+                text = "| 场景 ID | x |\n|---|---|\n| E1S01 | y |"
+                input_tokens = 0
+                output_tokens = 0
+
+            return _R()
+
+    async def fake_factory(task_type, project_name=None):
+        captured["task_type"] = task_type
+        captured["project_name"] = project_name
+        return _FakeBackend()
+
+    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    monkeypatch.setattr(mod, "create_text_backend_for_task", fake_factory)
+
+    tool_obj = normalize_drama_script_tool(fake_ctx)
+    out = await _call(tool_obj, {"episode": 1})
+    assert out.get("is_error") is not True, out
+    assert captured["project_name"] == "demo"


### PR DESCRIPTION
## Summary
- `normalize_drama_script` SDK 工具调用 `create_text_backend_for_task(TextTaskType.SCRIPT)` 时未传 `project_name`
- 导致 `ConfigResolver._resolve_text_backend` 第 1 步项目级 `text_backend_script` 覆盖检查被跳过，与 `ScriptGenerator` / OVERVIEW / STYLE_ANALYSIS 三条已正确传 `project_name` 的路径不一致
- 透传 `ctx.project_name` 即修复；新增 regression 测试 `test_normalize_drama_script_passes_project_name` 用 monkeypatch spy 断言参数

## Test plan
- [x] `uv run python -m pytest tests/server/agent_runtime/test_sdk_tools.py` 34 passed
- [x] `uv run ruff check + format` 通过
- [x] 故意回退 fix 后 regression test 立即失败（`assert None == 'demo'`），恢复后通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复脚本规范化工具中文本后端的配置逻辑，现在能正确识别和应用当前项目的设置。

* **Tests**
  * 新增测试用例，验证脚本规范化工具正确传递项目配置信息。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/532)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->