### PR TITLE
fix(agent): 配置 no-op WorktreeCreate hook 避免派发 subagent 报错

### DIFF
--- a/agent_runtime_profile/.claude/settings.json
+++ b/agent_runtime_profile/.claude/settings.json
@@ -1,1 +1,11 @@
-{}
+{
+  "hooks": {
+    "WorktreeCreate": [
+      { "hooks": [{ "type": "command", "command": "pwd" }] }
+    ],
+    "WorktreeRemove": [
+      { "hooks": [{ "type": "command", "command": "true" }] }
+    ]
+  }
+}
+


### PR DESCRIPTION
## Summary
- CLI 2.1.x（claude-agent-sdk 0.1.80 自带）派发 subagent 时默认走 `isolation: "worktree"`，要求 cwd 在 git 仓库内或配置了 `WorktreeCreate` hook。Docker 镜像 `.dockerignore` 排除了 `.git`、Dockerfile 未装 `git`，触发 `Cannot create agent worktree` 错误。
- `agent_runtime_profile/.claude/settings.json` 之前是空 `{}`，按错误信息提示的官方路径补 no-op `WorktreeCreate`（返回 `pwd`）+ `WorktreeRemove`（`true`）hook。CLI 二进制 `wf_()` 检测到 hook 存在就走 hook-based 分支、跳过 git 检测，返回的"worktree 路径"作为 subagent cwd——这里返回 parent cwd 等价于不隔离，subagent 与主 agent 共享 `projects/{name}/`，符合"subagent 资产写到项目目录"的语义。
- 顺带消除本地 dev 模式下 subagent 被切到 `<repo>/.git/worktrees/agent-XXX` 读不到 `project.json` 的隐性 bug。

## Test plan
- [x] `uv run python -m pytest tests/agent_runtime/ -q` 全绿（97/97）
- [x] JSON schema 校验通过
- [ ] Docker 镜像重建后，派发 subagent 日志应出现 `Created hook-based agent worktree at: /app/projects/{name}` 而非 `Cannot create agent worktree`
- [ ] 主 agent 完成 manga-workflow 端到端跑一遍，确认 subagent 写入资产落到正确项目目录

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本更新说明

* **配置**
  * 更新了开发环境配置文件，为工作区事件处理机制添加了对应的处理器，以改进开发工作流程的可靠性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/533)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->