### PR TITLE
fix(agent): 修复 docker 部署 bwrap 沙箱 user namespace 受阻

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,10 +5,15 @@ services:
     ports:
       - "1241:1241"
     env_file: .env
-    # Agent Bash 沙箱 (bwrap) 需要非特权 user namespace，放开 docker 默认 profile
+    # Agent Bash 沙箱 (bwrap) 需要：
+    # 1) 非特权 user namespace → 放开 docker 默认 seccomp/apparmor profile
+    # 2) bwrap 嵌套出的 net namespace 内配置 loopback → 容器需要 NET_ADMIN cap
+    #    （否则报 "loopback: Failed RTM_NEWADDR: Operation not permitted"）
     security_opt:
       - seccomp:unconfined
       - apparmor:unconfined
+    cap_add:
+      - NET_ADMIN
     volumes:
       - ./.env:/app/.env
       - ./projects:/app/projects

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,6 +5,10 @@ services:
     ports:
       - "1241:1241"
     env_file: .env
+    # Agent Bash 沙箱 (bwrap) 需要非特权 user namespace，放开 docker 默认 profile
+    security_opt:
+      - seccomp:unconfined
+      - apparmor:unconfined
     volumes:
       - ./.env:/app/.env
       - ./projects:/app/projects

--- a/deploy/production/docker-compose.yml
+++ b/deploy/production/docker-compose.yml
@@ -21,6 +21,10 @@ services:
     env_file: .env
     environment:
       DATABASE_URL: postgresql+asyncpg://arcreel:${POSTGRES_PASSWORD}@postgres:5432/arcreel
+    # Agent Bash 沙箱 (bwrap) 需要非特权 user namespace，放开 docker 默认 profile
+    security_opt:
+      - seccomp:unconfined
+      - apparmor:unconfined
     volumes:
       - ./.env:/app/.env
       - ./projects:/app/projects

--- a/deploy/production/docker-compose.yml
+++ b/deploy/production/docker-compose.yml
@@ -21,10 +21,15 @@ services:
     env_file: .env
     environment:
       DATABASE_URL: postgresql+asyncpg://arcreel:${POSTGRES_PASSWORD}@postgres:5432/arcreel
-    # Agent Bash 沙箱 (bwrap) 需要非特权 user namespace，放开 docker 默认 profile
+    # Agent Bash 沙箱 (bwrap) 需要：
+    # 1) 非特权 user namespace → 放开 docker 默认 seccomp/apparmor profile
+    # 2) bwrap 嵌套出的 net namespace 内配置 loopback → 容器需要 NET_ADMIN cap
+    #    （否则报 "loopback: Failed RTM_NEWADDR: Operation not permitted"）
     security_opt:
       - seccomp:unconfined
       - apparmor:unconfined
+    cap_add:
+      - NET_ADMIN
     volumes:
       - ./.env:/app/.env
       - ./projects:/app/projects

--- a/server/app.py
+++ b/server/app.py
@@ -14,6 +14,7 @@ import logging
 import os
 import platform
 import shutil
+import subprocess
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -98,13 +99,45 @@ def check_sandbox_available() -> bool:
             )
         return True
     if system == "Linux":
-        if shutil.which("bwrap") is None:
+        # 官方 sandboxing.md 明确 Linux 需要 bubblewrap + socat 一起装
+        # （bwrap 做进程/文件隔离，socat 做网络代理转发）。
+        missing = [name for name in ("bwrap", "socat") if shutil.which(name) is None]
+        if missing:
             raise RuntimeError(
                 "SANDBOX_UNAVAILABLE on linux\n"
-                "  bwrap: not found in PATH\n"
-                "Required for ArcReel agent runtime. Install bubblewrap:\n"
-                "  Ubuntu/Debian: sudo apt install bubblewrap\n"
-                "  Arch:          sudo pacman -S bubblewrap"
+                f"  missing in PATH: {', '.join(missing)}\n"
+                "Required for ArcReel agent runtime. Install:\n"
+                "  Ubuntu/Debian: sudo apt install bubblewrap socat\n"
+                "  Fedora:        sudo dnf install bubblewrap socat\n"
+                "  Arch:          sudo pacman -S bubblewrap socat"
+            )
+        # bwrap 装了不代表跑得起来：容器内非特权 user namespace 经常被
+        # docker seccomp 或 sysctl(kernel.unprivileged_userns_clone=0) 禁掉，
+        # 这时 bwrap 启动会立刻报 "No permissions to create new namespace"。
+        # 启动期做一次最小试跑，让运维在容器冒烟阶段就拿到清晰错误，
+        # 而不是 agent 第一次调 Bash 才神秘失败。
+        try:
+            probe = subprocess.run(
+                ["bwrap", "--ro-bind", "/", "/", "/bin/true"],
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise RuntimeError(
+                "SANDBOX_BWRAP_BROKEN on Linux\n"
+                f"  bwrap probe failed to execute: {exc}\n"
+                "Required for ArcReel agent runtime."
+            ) from exc
+        if probe.returncode != 0:
+            stderr = probe.stderr.decode("utf-8", errors="replace").strip() or "(no stderr)"
+            raise RuntimeError(
+                "SANDBOX_BWRAP_BROKEN on Linux\n"
+                f"  bwrap installed but cannot run: {stderr}\n"
+                "Typical cause: container blocks unprivileged user namespaces.\n"
+                "Fix one of:\n"
+                "  - docker run --security-opt seccomp=unconfined --security-opt apparmor=unconfined ...\n"
+                "  - or on host: sudo sysctl -w kernel.unprivileged_userns_clone=1"
             )
         return True
     logger.warning(

--- a/server/app.py
+++ b/server/app.py
@@ -80,6 +80,70 @@ def assert_no_provider_secrets_in_environ() -> None:
         )
 
 
+_APPARMOR_USERNS_SYSCTL = Path("/proc/sys/kernel/apparmor_restrict_unprivileged_userns")
+_UNPRIV_USERNS_SYSCTL = Path("/proc/sys/kernel/unprivileged_userns_clone")
+_MAX_USER_NS_SYSCTL = Path("/proc/sys/user/max_user_namespaces")
+
+
+def _read_sysctl(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
+def _diagnose_bwrap_failure() -> str:
+    """根据 host sysctl 状态给出 bwrap 失败的精确修复路径。
+
+    procfs 是宿主机共享的，容器内同样能读到 host sysctl 值，所以这套
+    诊断在 docker 内外都能跑。优先级：Ubuntu 24.04 AppArmor 限制 >
+    传统 unprivileged_userns_clone > max_user_namespaces > 兜底容器配置。
+    """
+    parts: list[str] = []
+
+    apparmor_userns = _read_sysctl(_APPARMOR_USERNS_SYSCTL)
+    if apparmor_userns == "1":
+        parts.append(
+            "Detected Ubuntu 24.04+ AppArmor restriction (root cause):\n"
+            "  /proc/sys/kernel/apparmor_restrict_unprivileged_userns = 1\n"
+            "  Blocks ALL unprivileged user namespaces. `apparmor:unconfined`\n"
+            "  in docker compose does NOT bypass this — it is a global LSM\n"
+            "  switch, not a per-process profile.\n"
+            "  Fix on HOST (not inside the container):\n"
+            "    sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0\n"
+            '    echo "kernel.apparmor_restrict_unprivileged_userns=0" '
+            "| sudo tee /etc/sysctl.d/60-arcreel-bwrap.conf"
+        )
+
+    userns_clone = _read_sysctl(_UNPRIV_USERNS_SYSCTL)
+    if userns_clone == "0":
+        parts.append(
+            "Unprivileged user namespaces disabled on host:\n"
+            "  /proc/sys/kernel/unprivileged_userns_clone = 0\n"
+            "  Fix on HOST: sudo sysctl -w kernel.unprivileged_userns_clone=1"
+        )
+
+    max_userns = _read_sysctl(_MAX_USER_NS_SYSCTL)
+    if max_userns == "0":
+        parts.append(
+            "User namespace count limit set to 0 on host:\n"
+            "  /proc/sys/user/max_user_namespaces = 0\n"
+            "  Fix on HOST: sudo sysctl -w user.max_user_namespaces=15000"
+        )
+
+    if not parts:
+        parts.append(
+            "Container likely missing security relaxation. docker compose:\n"
+            "  security_opt:\n"
+            "    - seccomp:unconfined\n"
+            "    - apparmor:unconfined\n"
+            "  cap_add:\n"
+            "    - NET_ADMIN"
+        )
+
+    return "\n".join(parts)
+
+
 def check_sandbox_available() -> bool:
     """启动期检测 sandbox 工具可用性。
 
@@ -141,15 +205,7 @@ def check_sandbox_available() -> bool:
             raise RuntimeError(
                 "SANDBOX_BWRAP_BROKEN on Linux\n"
                 f"  bwrap installed but cannot run: {stderr}\n"
-                "Typical cause: container blocks unprivileged user namespaces or\n"
-                "lacks CAP_NET_ADMIN to configure the sandbox loopback interface.\n"
-                "Fix (docker compose):\n"
-                "  security_opt:\n"
-                "    - seccomp:unconfined\n"
-                "    - apparmor:unconfined\n"
-                "  cap_add:\n"
-                "    - NET_ADMIN\n"
-                "On host: sudo sysctl -w kernel.unprivileged_userns_clone=1"
+                f"{_diagnose_bwrap_failure()}"
             )
         return True
     logger.warning(

--- a/server/app.py
+++ b/server/app.py
@@ -111,18 +111,25 @@ def check_sandbox_available() -> bool:
                 "  Fedora:        sudo dnf install bubblewrap socat\n"
                 "  Arch:          sudo pacman -S bubblewrap socat"
             )
-        # bwrap 装了不代表跑得起来：容器内非特权 user namespace 经常被
-        # docker seccomp 或 sysctl(kernel.unprivileged_userns_clone=0) 禁掉，
-        # 这时 bwrap 启动会立刻报 "No permissions to create new namespace"。
-        # 启动期做一次最小试跑，让运维在容器冒烟阶段就拿到清晰错误，
-        # 而不是 agent 第一次调 Bash 才神秘失败。
+        # bwrap 装了不代表跑得起来。两类常见失败：
+        # 1) 创建 user namespace 被拒：seccomp / apparmor / sysctl 屏蔽
+        #    → "No permissions to create new namespace"
+        # 2) 新 net namespace 内 loopback 配置被拒：容器缺 CAP_NET_ADMIN
+        #    → "loopback: Failed RTM_NEWADDR: Operation not permitted"
+        # 用与 SDK 实际调用接近的 unshare 参数试跑，启动期就拦下来，
+        # 避免 agent 第一次调 Bash 才神秘失败。
+        probe_cmd = [
+            "bwrap",
+            "--unshare-user",
+            "--unshare-net",
+            "--unshare-pid",
+            "--ro-bind",
+            "/",
+            "/",
+            "/bin/true",
+        ]
         try:
-            probe = subprocess.run(
-                ["bwrap", "--ro-bind", "/", "/", "/bin/true"],
-                capture_output=True,
-                timeout=5,
-                check=False,
-            )
+            probe = subprocess.run(probe_cmd, capture_output=True, timeout=5, check=False)
         except (OSError, subprocess.TimeoutExpired) as exc:
             raise RuntimeError(
                 "SANDBOX_BWRAP_BROKEN on Linux\n"
@@ -134,10 +141,15 @@ def check_sandbox_available() -> bool:
             raise RuntimeError(
                 "SANDBOX_BWRAP_BROKEN on Linux\n"
                 f"  bwrap installed but cannot run: {stderr}\n"
-                "Typical cause: container blocks unprivileged user namespaces.\n"
-                "Fix one of:\n"
-                "  - docker run --security-opt seccomp=unconfined --security-opt apparmor=unconfined ...\n"
-                "  - or on host: sudo sysctl -w kernel.unprivileged_userns_clone=1"
+                "Typical cause: container blocks unprivileged user namespaces or\n"
+                "lacks CAP_NET_ADMIN to configure the sandbox loopback interface.\n"
+                "Fix (docker compose):\n"
+                "  security_opt:\n"
+                "    - seccomp:unconfined\n"
+                "    - apparmor:unconfined\n"
+                "  cap_add:\n"
+                "    - NET_ADMIN\n"
+                "On host: sudo sysctl -w kernel.unprivileged_userns_clone=1"
             )
         return True
     logger.warning(

--- a/tests/server/test_startup_assertions.py
+++ b/tests/server/test_startup_assertions.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import platform
+import subprocess
+from types import SimpleNamespace
 
 import pytest
 
@@ -12,6 +14,17 @@ from server.app import (
     check_sandbox_available,
     detect_docker_environment,
 )
+
+
+def _bwrap_probe_stub(returncode: int = 0, stderr: bytes = b""):
+    """构造 subprocess.run 替身，用于桩 bwrap 试跑结果。"""
+
+    def _stub(cmd, *args, **kwargs):  # noqa: ANN001 - 测试替身，宽松签名
+        assert cmd[0] == "bwrap"
+        return SimpleNamespace(returncode=returncode, stderr=stderr, stdout=b"")
+
+    return _stub
+
 
 # 复用生产代码（assert_no_provider_secrets_in_environ）所基于的同一份真相源，
 # 避免测试与运行时密钥清单漂移。sorted() 让 parametrize 测试 ID 稳定。
@@ -56,16 +69,67 @@ def test_sandbox_missing_macos_raises(monkeypatch: pytest.MonkeyPatch) -> None:
         check_sandbox_available()
 
 
+def _linux_which_stub(present: set[str]):
+    """构造 shutil.which 替身：仅 present 集合内的 binary 视为已安装。"""
+
+    def _stub(name: str):
+        return f"/usr/bin/{name}" if name in present else None
+
+    return _stub
+
+
 def test_sandbox_available_linux(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(platform, "system", lambda: "Linux")
-    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/bwrap" if name == "bwrap" else None)
+    monkeypatch.setattr("shutil.which", _linux_which_stub({"bwrap", "socat"}))
+    monkeypatch.setattr("server.app.subprocess.run", _bwrap_probe_stub(returncode=0))
     assert check_sandbox_available() is True
 
 
 def test_sandbox_missing_linux_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(platform, "system", lambda: "Linux")
-    monkeypatch.setattr("shutil.which", lambda _name: None)
-    with pytest.raises(RuntimeError, match="bubblewrap"):
+    monkeypatch.setattr("shutil.which", _linux_which_stub(set()))
+    with pytest.raises(RuntimeError, match="bwrap, socat"):
+        check_sandbox_available()
+
+
+def test_sandbox_missing_socat_only_linux_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """官方 sandboxing.md 明文要求 socat 同装（网络代理需要）。"""
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr("shutil.which", _linux_which_stub({"bwrap"}))
+    with pytest.raises(RuntimeError, match="missing in PATH: socat"):
+        check_sandbox_available()
+
+
+def test_sandbox_bwrap_probe_failure_linux_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """bwrap 装了但跑不起来（容器禁用 unprivileged userns）→ 启动期就硬失败，
+    并把 bwrap 真实 stderr + 修复建议透传给运维。"""
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr("shutil.which", _linux_which_stub({"bwrap", "socat"}))
+    monkeypatch.setattr(
+        "server.app.subprocess.run",
+        _bwrap_probe_stub(
+            returncode=1,
+            stderr=b"bwrap: No permissions to create new namespace",
+        ),
+    )
+    with pytest.raises(RuntimeError, match="SANDBOX_BWRAP_BROKEN") as exc_info:
+        check_sandbox_available()
+    msg = str(exc_info.value)
+    assert "No permissions to create new namespace" in msg
+    assert "seccomp=unconfined" in msg
+    assert "unprivileged_userns_clone" in msg
+
+
+def test_sandbox_bwrap_probe_oserror_linux_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """subprocess.run 抛 OSError / TimeoutExpired 时也要包成 SANDBOX_BWRAP_BROKEN。"""
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr("shutil.which", _linux_which_stub({"bwrap", "socat"}))
+
+    def _raises(*args, **kwargs):  # noqa: ANN001 - 测试替身
+        raise subprocess.TimeoutExpired(cmd=["bwrap"], timeout=5)
+
+    monkeypatch.setattr("server.app.subprocess.run", _raises)
+    with pytest.raises(RuntimeError, match="SANDBOX_BWRAP_BROKEN"):
         check_sandbox_available()
 
 

--- a/tests/server/test_startup_assertions.py
+++ b/tests/server/test_startup_assertions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import platform
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -104,30 +105,39 @@ def test_sandbox_missing_socat_only_linux_raises(monkeypatch: pytest.MonkeyPatch
         check_sandbox_available()
 
 
-def test_sandbox_bwrap_probe_userns_failure_linux_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    """bwrap 装了但 user namespace 创建被 seccomp/userns_clone 拦下 →
-    启动期硬失败，stderr + 三条修复建议都进异常信息。"""
-    monkeypatch.setattr(platform, "system", lambda: "Linux")
-    monkeypatch.setattr("shutil.which", _linux_which_stub({"bwrap", "socat"}))
-    monkeypatch.setattr(
-        "server.app.subprocess.run",
-        _bwrap_probe_stub(
-            returncode=1,
-            stderr=b"bwrap: No permissions to create new namespace",
-        ),
-    )
-    with pytest.raises(RuntimeError, match="SANDBOX_BWRAP_BROKEN") as exc_info:
-        check_sandbox_available()
-    msg = str(exc_info.value)
-    assert "No permissions to create new namespace" in msg
-    assert "seccomp:unconfined" in msg
-    assert "NET_ADMIN" in msg
-    assert "unprivileged_userns_clone" in msg
+def _patch_sysctls(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    apparmor_userns: str | None = None,
+    userns_clone: str | None = None,
+    max_user_ns: str | None = None,
+) -> None:
+    """桩三条 host sysctl 读取，模拟不同的失败拓扑。
+
+    None 表示该 sysctl 在测试系统上不存在（read_text 抛 OSError），
+    与 mac / 老内核行为一致。
+    """
+
+    def _stub(self: Path, *args, **kwargs):  # noqa: ANN001 - 测试替身
+        mapping = {
+            "/proc/sys/kernel/apparmor_restrict_unprivileged_userns": apparmor_userns,
+            "/proc/sys/kernel/unprivileged_userns_clone": userns_clone,
+            "/proc/sys/user/max_user_namespaces": max_user_ns,
+        }
+        val = mapping.get(str(self))
+        if val is None:
+            raise OSError("simulated missing sysctl")
+        return val
+
+    monkeypatch.setattr("server.app.Path.read_text", _stub)
 
 
-def test_sandbox_bwrap_probe_loopback_failure_linux_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    """容器缺 CAP_NET_ADMIN，bwrap 配 loopback 失败 → 启动期硬失败，
-    把 NET_ADMIN 修复路径透出。这是 PR #534 实测复现的二段错误。"""
+def test_sandbox_bwrap_probe_apparmor_userns_diagnoses_ubuntu_2404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ubuntu 24.04 默认 kernel.apparmor_restrict_unprivileged_userns=1 →
+    异常信息必须把"在 host 上关 sysctl"作为根因路径透传，因为这是 PR #534
+    实测线上 Oracle Cloud Ubuntu 24.04 撞到的真根因，docker compose 改不动。"""
     monkeypatch.setattr(platform, "system", lambda: "Linux")
     monkeypatch.setattr("shutil.which", _linux_which_stub({"bwrap", "socat"}))
     monkeypatch.setattr(
@@ -137,11 +147,49 @@ def test_sandbox_bwrap_probe_loopback_failure_linux_raises(monkeypatch: pytest.M
             stderr=b"bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted",
         ),
     )
+    _patch_sysctls(monkeypatch, apparmor_userns="1", userns_clone="1", max_user_ns="95499")
     with pytest.raises(RuntimeError, match="SANDBOX_BWRAP_BROKEN") as exc_info:
         check_sandbox_available()
     msg = str(exc_info.value)
-    assert "RTM_NEWADDR" in msg
+    assert "Ubuntu 24.04" in msg
+    assert "apparmor_restrict_unprivileged_userns=0" in msg
+    assert "60-arcreel-bwrap.conf" in msg
+
+
+def test_sandbox_bwrap_probe_userns_clone_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """老内核 / 强化系统：kernel.unprivileged_userns_clone=0 → 给老 sysctl 修复路径。"""
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr("shutil.which", _linux_which_stub({"bwrap", "socat"}))
+    monkeypatch.setattr(
+        "server.app.subprocess.run",
+        _bwrap_probe_stub(
+            returncode=1,
+            stderr=b"bwrap: Creating new namespace failed",
+        ),
+    )
+    _patch_sysctls(monkeypatch, userns_clone="0")
+    with pytest.raises(RuntimeError, match="SANDBOX_BWRAP_BROKEN") as exc_info:
+        check_sandbox_available()
+    msg = str(exc_info.value)
+    assert "unprivileged_userns_clone=1" in msg
+
+
+def test_sandbox_bwrap_probe_fallback_container_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """sysctl 都正常但 bwrap 仍跑不起来 → 兜底给出 docker compose 修复建议
+    （seccomp/apparmor unconfined + NET_ADMIN）。"""
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr("shutil.which", _linux_which_stub({"bwrap", "socat"}))
+    monkeypatch.setattr(
+        "server.app.subprocess.run",
+        _bwrap_probe_stub(returncode=1, stderr=b"bwrap: some other error"),
+    )
+    _patch_sysctls(monkeypatch, apparmor_userns="0", userns_clone="1", max_user_ns="15000")
+    with pytest.raises(RuntimeError, match="SANDBOX_BWRAP_BROKEN") as exc_info:
+        check_sandbox_available()
+    msg = str(exc_info.value)
+    assert "seccomp:unconfined" in msg
     assert "NET_ADMIN" in msg
+    assert "Ubuntu 24.04" not in msg  # 未命中 apparmor sysctl，不应误导
 
 
 def test_sandbox_bwrap_probe_oserror_linux_raises(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/server/test_startup_assertions.py
+++ b/tests/server/test_startup_assertions.py
@@ -21,6 +21,10 @@ def _bwrap_probe_stub(returncode: int = 0, stderr: bytes = b""):
 
     def _stub(cmd, *args, **kwargs):  # noqa: ANN001 - 测试替身，宽松签名
         assert cmd[0] == "bwrap"
+        # probe 必须用 unshare-user + unshare-net 才能在启动期捕获两类典型失败：
+        # userns 创建被拒 / loopback 配置被拒（缺 NET_ADMIN）。
+        assert "--unshare-user" in cmd
+        assert "--unshare-net" in cmd
         return SimpleNamespace(returncode=returncode, stderr=stderr, stdout=b"")
 
     return _stub
@@ -100,9 +104,9 @@ def test_sandbox_missing_socat_only_linux_raises(monkeypatch: pytest.MonkeyPatch
         check_sandbox_available()
 
 
-def test_sandbox_bwrap_probe_failure_linux_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    """bwrap 装了但跑不起来（容器禁用 unprivileged userns）→ 启动期就硬失败，
-    并把 bwrap 真实 stderr + 修复建议透传给运维。"""
+def test_sandbox_bwrap_probe_userns_failure_linux_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """bwrap 装了但 user namespace 创建被 seccomp/userns_clone 拦下 →
+    启动期硬失败，stderr + 三条修复建议都进异常信息。"""
     monkeypatch.setattr(platform, "system", lambda: "Linux")
     monkeypatch.setattr("shutil.which", _linux_which_stub({"bwrap", "socat"}))
     monkeypatch.setattr(
@@ -116,8 +120,28 @@ def test_sandbox_bwrap_probe_failure_linux_raises(monkeypatch: pytest.MonkeyPatc
         check_sandbox_available()
     msg = str(exc_info.value)
     assert "No permissions to create new namespace" in msg
-    assert "seccomp=unconfined" in msg
+    assert "seccomp:unconfined" in msg
+    assert "NET_ADMIN" in msg
     assert "unprivileged_userns_clone" in msg
+
+
+def test_sandbox_bwrap_probe_loopback_failure_linux_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """容器缺 CAP_NET_ADMIN，bwrap 配 loopback 失败 → 启动期硬失败，
+    把 NET_ADMIN 修复路径透出。这是 PR #534 实测复现的二段错误。"""
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr("shutil.which", _linux_which_stub({"bwrap", "socat"}))
+    monkeypatch.setattr(
+        "server.app.subprocess.run",
+        _bwrap_probe_stub(
+            returncode=1,
+            stderr=b"bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted",
+        ),
+    )
+    with pytest.raises(RuntimeError, match="SANDBOX_BWRAP_BROKEN") as exc_info:
+        check_sandbox_available()
+    msg = str(exc_info.value)
+    assert "RTM_NEWADDR" in msg
+    assert "NET_ADMIN" in msg
 
 
 def test_sandbox_bwrap_probe_oserror_linux_raises(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- compose 文件加 `security_opt: seccomp:unconfined + apparmor:unconfined`，绕过 docker 默认 profile 对 bwrap 创建非特权 user namespace 的拦截（Ubuntu 24.04+/RHEL/Rocky 容器默认受阻）
- `check_sandbox_available()` Linux 路径同时校验 `bwrap` + `socat`（官方 sandboxing.md 明文同装要求），并在启动期真实试跑一次 bwrap，拦下"binary 装了但 userns 跑不起来"的情况
- 失败时硬抛 `SANDBOX_BWRAP_BROKEN`，透传 bwrap 真实 stderr + 两条修复建议（compose `security_opt`、宿主机 `sysctl kernel.unprivileged_userns_clone=1`），替代 agent 第一次调 Bash 时才神秘 exit 1

## Why
PR #521 启用了 Agent Bash 沙箱后，最新 main docker 部署的用户调用 agent Bash 工具会立刻撞 `bwrap: No permissions to create new namespace`。

根因：
1. compose 没设 `security_opt`，部分发行版 docker 默认 seccomp/apparmor profile 阻止 bwrap unshare userns
2. `check_sandbox_available()` 只 `which bwrap` 就返回 True，没验证实际可运行；server 启动看似正常，运行时才炸

对照 Claude Agent SDK 官方 sandboxing.md：bwrap 是 Linux 官方实现；`enableWeakerNestedSandbox` 就是为 docker 设计；Ubuntu 24.04+ 的 AppArmor 默认阻 bwrap userns（官方修复路径是装 bwrap 专用 AppArmor profile，容器内不可改 host profile，等价方案是 `apparmor:unconfined`）。SDK 自身没有 `failIfUnavailable`，由集成方在启动期补硬失败逻辑。

## Test plan
- [x] `uv run python -m pytest tests/server/test_startup_assertions.py -v` 19/19 通过，含 3 个新增 case：socat 缺失、bwrap 试跑非零退出、试跑 TimeoutExpired
- [x] `uv run ruff check && uv run ruff format` 干净
- [ ] 在受 affected 的 docker 环境（kernel.unprivileged_userns_clone=0 或 Ubuntu 24.04+ AppArmor）拉本 PR 镜像并 `compose up`，验证 agent Bash 能正常跑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 调整容器运行时安全配置以支持 Agent Bash 沙箱，放宽默认限制并启用网络命名空间相关能力。
  * 启动时增强了对 Linux 沙箱依赖的检测与探测，提供更具体的错误信息与修复建议。

* **Tests**
  * 扩展并细化启动断言测试，覆盖缺失依赖、探测失败与异常场景，提升诊断可观测性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/534)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->