### PR TITLE
fix(project): materialize .claude/CLAUDE.md on Linux for bwrap sandbox

### DIFF
--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -10,6 +10,7 @@ import os
 import re
 import secrets
 import shutil
+import sys
 import unicodedata
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -190,9 +191,29 @@ class ProjectManager:
             "CLAUDE.md": profile_dir / "CLAUDE.md",
         }
 
+        # Linux 上 Claude Agent SDK 的 bwrap 沙箱按 lstat 判断 .claude 类型，
+        # symlink 会被当文件 bind，与目录冲突报 "Is a directory"。改为物化拷贝。
+        # 每次同步前移除旧目标，确保删除和文件/目录类型变化也能跟随 profile。
+        materialize = sys.platform.startswith("linux")
+
+        def _remove_materialized_target(path: Path) -> None:
+            if path.is_symlink() or path.is_file():
+                path.unlink()
+            elif path.is_dir():
+                shutil.rmtree(path)
+
         def _link_or_copy(name: str, target_source: Path, link_path: Path) -> None:
-            """Create symlink to target_source. On Windows, fall back to copy
-            when symlink creation fails (Developer Mode off / non-admin)."""
+            """Link target_source into project. macOS/Windows symlink; Linux materialize.
+
+            Windows fall back to copy when symlink creation fails (Developer Mode off / non-admin).
+            """
+            if materialize:
+                _remove_materialized_target(link_path)
+                if target_source.is_dir():
+                    shutil.copytree(target_source, link_path, symlinks=False)
+                else:
+                    shutil.copyfile(target_source, link_path)
+                return
             try:
                 rel_target: str = os.path.relpath(target_source, link_path.parent)
             except ValueError:
@@ -259,6 +280,16 @@ class ProjectManager:
                     stats["created"] += 1
                 except OSError as e:
                     logger.warning("无法为项目 %s 创建 %s 符号链接: %s", project_dir.name, name, e)
+                    stats["errors"] += 1
+            elif materialize:
+                # Linux: 已存在 → 升级旧 symlink / 镜像同步物化拷贝
+                # （projects/ 是 docker volume，镜像更新后旧项目目录必须跟随刷新）
+                try:
+                    was_symlink = symlink_path.is_symlink()
+                    _link_or_copy(name, target_source, symlink_path)
+                    stats["repaired" if was_symlink else "skipped"] += 1
+                except OSError as e:
+                    logger.warning("无法同步项目 %s 的 %s: %s", project_dir.name, name, e)
                     stats["errors"] += 1
             else:
                 stats["skipped"] += 1

--- a/tests/test_project_archive_service.py
+++ b/tests/test_project_archive_service.py
@@ -427,8 +427,10 @@ class TestProjectArchiveService:
         assert pm.load_project("demo")["style"] == "Fresh"
         assert (pm.get_project_path("demo") / "source" / "chapter.txt").read_text(encoding="utf-8") == "source"
 
-    def test_import_creates_claude_symlink(self, tmp_path):
+    def test_import_creates_claude_symlink_on_symlink_platform(self, tmp_path, monkeypatch):
         """Imported project should get .claude symlink for agent runtime isolation."""
+        monkeypatch.setattr("lib.project_manager.sys.platform", "darwin")
+
         # Create agent_runtime_profile in project root (parent of projects/)
         profile_claude = tmp_path / "agent_runtime_profile" / ".claude"
         profile_claude.mkdir(parents=True)
@@ -449,6 +451,30 @@ class TestProjectArchiveService:
         symlink = imported_dir / ".claude"
         assert symlink.is_symlink()
         assert symlink.resolve() == profile_claude.resolve()
+
+    def test_import_materializes_claude_dir_on_linux(self, tmp_path, monkeypatch):
+        """Imported project should materialize .claude on Linux for bwrap sandbox compatibility."""
+        monkeypatch.setattr("lib.project_manager.sys.platform", "linux")
+
+        profile_claude = tmp_path / "agent_runtime_profile" / ".claude"
+        profile_claude.mkdir(parents=True)
+        (profile_claude / "settings.json").write_text("{}", encoding="utf-8")
+
+        pm = ProjectManager(tmp_path / "projects")
+        _create_project(pm)
+        service = ProjectArchiveService(pm)
+        archive_path, _ = service.export_project("demo")
+
+        result = service.import_project_archive(
+            archive_path,
+            uploaded_filename="demo.zip",
+            conflict_policy="rename",
+        )
+
+        imported_claude = pm.get_project_path(result.project_name) / ".claude"
+        assert imported_claude.is_dir()
+        assert not imported_claude.is_symlink()
+        assert (imported_claude / "settings.json").read_text(encoding="utf-8") == "{}"
 
     def test_import_overwrite_rolls_back_on_install_failure(self, tmp_path, monkeypatch):
         pm = ProjectManager(tmp_path / "projects")

--- a/tests/test_project_manager_symlink.py
+++ b/tests/test_project_manager_symlink.py
@@ -2,7 +2,22 @@
 
 from pathlib import Path
 
+import pytest
+
 from lib.project_manager import ProjectManager
+
+
+@pytest.fixture(autouse=True)
+def _force_symlink_platform(monkeypatch):
+    """Pin sys.platform=darwin so the upstream symlink-shaped suites always
+    exercise the symlink branch.
+
+    ``ProjectManager.repair_claude_symlink`` materializes the profile into a
+    real directory/file on Linux because the Claude Agent SDK bwrap sandbox
+    refuses to bind a symlink at ``<cwd>/.claude``. ``TestLinuxMaterialize``
+    overrides this fixture to cover the Linux branch.
+    """
+    monkeypatch.setattr("lib.project_manager.sys.platform", "darwin")
 
 
 class TestProjectSymlink:
@@ -185,3 +200,102 @@ class TestRepairAllSymlinks:
         stats = pm.repair_all_symlinks()
 
         assert stats["created"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Linux branch: ``repair_claude_symlink`` materializes ``.claude`` / ``CLAUDE.md``
+# into real directories/files so the Claude Agent SDK bwrap sandbox can bind
+# the path (it lstats ``<cwd>/.claude`` and refuses to bind a symlink that
+# resolves to a directory, raising ``Can't create file ... Is a directory``).
+# ---------------------------------------------------------------------------
+
+
+class TestLinuxMaterialize:
+    @pytest.fixture(autouse=True)
+    def _force_linux(self, monkeypatch):
+        # Overrides the module-level fixture (pinned to darwin) for this class.
+        monkeypatch.setattr("lib.project_manager.sys.platform", "linux")
+
+    def _make_env(self, tmp_path: Path):
+        projects_root = tmp_path / "projects"
+        projects_root.mkdir()
+        profile_dir = tmp_path / "agent_runtime_profile"
+        (profile_dir / ".claude").mkdir(parents=True)
+        (profile_dir / "CLAUDE.md").write_text("prompt")
+        pm = ProjectManager(projects_root)
+        project_dir = projects_root / "test-proj"
+        project_dir.mkdir()
+        return pm, project_dir, profile_dir
+
+    def test_creates_real_directory_and_file(self, tmp_path):
+        pm, project_dir, _ = self._make_env(tmp_path)
+
+        pm.repair_claude_symlink(project_dir)
+
+        claude = project_dir / ".claude"
+        assert claude.is_dir() and not claude.is_symlink()
+        md = project_dir / "CLAUDE.md"
+        assert md.is_file() and not md.is_symlink()
+
+    def test_upgrades_existing_symlink_to_real_dir(self, tmp_path):
+        """A symlink left over from a previous release should be upgraded
+        to a materialized copy on startup."""
+        pm, project_dir, _ = self._make_env(tmp_path)
+        (project_dir / ".claude").symlink_to(Path("../../agent_runtime_profile/.claude"))
+
+        stats = pm.repair_claude_symlink(project_dir)
+
+        claude = project_dir / ".claude"
+        assert claude.is_dir() and not claude.is_symlink()
+        assert stats["repaired"] >= 1
+
+    def test_sync_propagates_profile_updates(self, tmp_path):
+        """A second ``repair`` after profile updates must propagate new files,
+        preserving the upstream symlink-mode semantics where editing the
+        profile is reflected immediately in every project."""
+        pm, project_dir, profile_dir = self._make_env(tmp_path)
+
+        pm.repair_claude_symlink(project_dir)
+        assert (project_dir / ".claude").is_dir()
+
+        (profile_dir / ".claude" / "skills").mkdir()
+        (profile_dir / ".claude" / "skills" / "new.md").write_text("v2")
+        (profile_dir / "CLAUDE.md").write_text("v2 prompt")
+
+        pm.repair_claude_symlink(project_dir)
+
+        assert (project_dir / ".claude" / "skills" / "new.md").read_text() == "v2"
+        assert (project_dir / "CLAUDE.md").read_text() == "v2 prompt"
+
+    def test_sync_removes_deleted_profile_files(self, tmp_path):
+        pm, project_dir, profile_dir = self._make_env(tmp_path)
+        stale_source = profile_dir / ".claude" / "stale.md"
+        stale_source.write_text("remove me")
+
+        pm.repair_claude_symlink(project_dir)
+        assert (project_dir / ".claude" / "stale.md").exists()
+
+        stale_source.unlink()
+        pm.repair_claude_symlink(project_dir)
+
+        assert not (project_dir / ".claude" / "stale.md").exists()
+
+    def test_sync_replaces_mismatched_destination_types(self, tmp_path):
+        pm, project_dir, _ = self._make_env(tmp_path)
+        (project_dir / ".claude").write_text("wrong type")
+        (project_dir / "CLAUDE.md").mkdir()
+
+        pm.repair_claude_symlink(project_dir)
+
+        assert (project_dir / ".claude").is_dir()
+        assert (project_dir / "CLAUDE.md").is_file()
+        assert (project_dir / "CLAUDE.md").read_text() == "prompt"
+
+    def test_repair_idempotent(self, tmp_path):
+        pm, project_dir, _ = self._make_env(tmp_path)
+
+        pm.repair_claude_symlink(project_dir)
+        stats = pm.repair_claude_symlink(project_dir)
+
+        assert stats["errors"] == 0
+        assert (project_dir / ".claude").is_dir()


### PR DESCRIPTION
## 范围

修复 Linux 环境下项目目录中的 `.claude` symlink 与 Claude Agent SDK bwrap sandbox 冲突的问题。

本 PR 只修改项目 profile 链接/同步逻辑与对应测试：
- `lib/project_manager.py`
- `tests/test_project_manager_symlink.py`

不改 API、数据库 schema、前端 UI 或配置格式。不修改 Docker / AppArmor / seccomp 配置。若部署环境禁止容器内创建 unprivileged user namespace，仍可能需要部署侧单独配置；这与本 PR 修复的 `.claude` symlink bind 失败是两个独立问题。

## 变更

- Linux 上不再为项目目录创建 `.claude` / `CLAUDE.md` symlink，改为物化拷贝真实目录/文件，避免 bwrap 对 `<cwd>/.claude` 做 bind 时因 symlink 类型判断失败。
- macOS / Windows 继续保持原有 symlink 行为；Windows symlink 失败时仍沿用 copy fallback。
- `repair_claude_symlink()` 在 Linux 上会把历史遗留 symlink 升级为真实目录/文件，并通过镜像同步 profile 更新，确保新增、修改、删除以及文件/目录类型变化都会反映到项目目录。
- 新增 Linux 分支测试，覆盖创建真实目录、升级旧 symlink、镜像同步和幂等修复；现有 symlink 测试固定到 darwin 分支，避免在 Linux CI 上语义漂移。

## 验收清单

- [x] 本地已跑相关测试：`uv run python -m pytest tests/test_project_manager_symlink.py -q`
- [x] 本地已跑 lint：`uv run ruff check lib/project_manager.py tests/test_project_manager_symlink.py`
- [ ] 手动验证了改动所声称的行为
- [x] 新增面向用户文案已加 zh/en 翻译（如适用，本 PR 不涉及用户可见文案）
- [x] 无新增 ESLint disable；若有，已在本 PR 底部以表格列出 `rule | file:line | 理由`

## 已知 defer

无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 在 Linux 平台上将特定配置从符号链接改为物化为真实目录/文件，自动将已有符号链接升级为真实项并在修复流程中正确记录状态，保持与配置源的同步和类型一致性。
* **测试**
  * 新增/调整测试以通过平台钉绑覆盖不同平台行为，并增加 Linux 特定用例验证物化、同步、类型替换与幂等性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/536)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->