### PR TITLE
fix(compose-video): zero-align concatenated episode output

### DIFF
--- a/agent_runtime_profile/.claude/skills/compose-video/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/compose-video/SKILL.md
@@ -29,7 +29,7 @@ python .claude/skills/compose-video/scripts/compose_video.py --episode {N} --int
 
 ### 4. 后备拼接
 
-正常流程中视频由 Veo 3.1 逐场景独立生成，最终需要拼接成完整剧集。当标准的转场拼接（xfade 滤镜）因编码参数不一致而失败时，后备模式使用 ffmpeg concat demuxer 做无转场的快速拼接，确保至少能输出完整视频：
+正常流程中视频由视频大模型逐场景独立生成，最终需要拼接成完整剧集。当标准的转场拼接（xfade 滤镜）因编码参数不一致而失败时，后备模式会先把每个片段规范化为统一的 H.264/AAC 中间片（无音轨时自动补静音），再使用 ffmpeg concat demuxer 做无转场拼接，确保至少能输出完整视频且避免边界黑帧：
 
 ```bash
 python .claude/skills/compose-video/scripts/compose_video.py --episode {N} --fallback-mode

--- a/agent_runtime_profile/.claude/skills/compose-video/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/compose-video/SKILL.md
@@ -29,7 +29,7 @@ python .claude/skills/compose-video/scripts/compose_video.py --episode {N} --int
 
 ### 4. 后备拼接
 
-正常流程中视频由视频大模型逐场景独立生成，最终需要拼接成完整剧集。当标准的转场拼接（xfade 滤镜）因编码参数不一致而失败时，后备模式会先把每个片段规范化为统一的 H.264/AAC 中间片（无音轨时自动补静音），再使用 ffmpeg concat demuxer 做无转场拼接，确保至少能输出完整视频且避免边界黑帧：
+正常流程中视频由视频大模型逐场景独立生成，最终需要拼接成完整剧集。当标准的转场拼接（xfade 滤镜）因编码参数不一致而失败时，后备模式会先把每个片段规范化为统一的 H.264/AAC 中间片（无音轨时自动补静音），再使用 ffmpeg concat filter 做最终编码，确保成片从 0 开始并避免边界黑帧：
 
 ```bash
 python .claude/skills/compose-video/scripts/compose_video.py --episode {N} --fallback-mode
@@ -57,4 +57,4 @@ python .claude/skills/compose-video/scripts/compose_video.py --episode {N} --fal
 - [ ] 场景视频存在且可播放
 - [ ] 视频分辨率一致（由 content_mode 决定画面比例）
 - [ ] 背景音乐 / 片头片尾文件存在（如需要）
-- [ ] ffmpeg 已安装并在 PATH 中
+- [ ] ffmpeg / ffprobe 已安装并在 PATH 中

--- a/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
+++ b/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
@@ -86,7 +86,11 @@ def probe_media(video_path: Path) -> dict[str, object]:
             f"ffprobe 执行失败。{FFMPEG_TOOLS_HINT}；若环境已满足，再检查输入媒体。原始错误: {result.stderr}"
         )
 
-    payload = json.loads(result.stdout)
+    try:
+        payload = json.loads(result.stdout)
+    except ValueError as exc:
+        raise RuntimeError(f"无法解析 ffprobe 输出: {video_path}") from exc
+
     streams = payload.get("streams", [])
     video_stream = next((s for s in streams if s.get("codec_type") == "video"), None)
     audio_stream = next((s for s in streams if s.get("codec_type") == "audio"), None)
@@ -98,7 +102,12 @@ def probe_media(video_path: Path) -> dict[str, object]:
         fps = "30"
 
     duration_raw = payload.get("format", {}).get("duration")
-    duration = float(duration_raw) if duration_raw else get_video_duration(video_path)
+    if not duration_raw:
+        raise RuntimeError(f"无法从 ffprobe 输出中获取时长: {video_path}")
+    try:
+        duration = float(duration_raw)
+    except ValueError as exc:
+        raise RuntimeError(f"无法解析视频时长: {video_path}") from exc
 
     width = int(video_stream.get("width") or 0)
     height = int(video_stream.get("height") or 0)

--- a/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
+++ b/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
@@ -11,6 +11,7 @@ Example:
 """
 
 import argparse
+import json
 import subprocess
 import sys
 import tempfile
@@ -18,14 +19,24 @@ from pathlib import Path
 
 from lib.project_manager import ProjectManager
 
+FFMPEG_TOOLS_HINT = "需要 ffmpeg 和 ffprobe 同时可用，并且都在 PATH 中"
+
 
 def check_ffmpeg():
-    """检查 ffmpeg 是否可用"""
+    """检查 ffmpeg / ffprobe 是否可用"""
     try:
-        result = subprocess.run(["ffmpeg", "-version"], capture_output=True, text=True)
-        return result.returncode == 0
+        ffmpeg = subprocess.run(["ffmpeg", "-version"], capture_output=True, text=True)
+        ffprobe = subprocess.run(["ffprobe", "-version"], capture_output=True, text=True)
+        return ffmpeg.returncode == 0 and ffprobe.returncode == 0
     except FileNotFoundError:
         return False
+
+
+def run_ffmpeg(cmd: list[str], error_prefix: str) -> None:
+    """执行 ffmpeg / ffprobe 命令并在失败时抛出完整错误。"""
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"{error_prefix}: {result.stderr}")
 
 
 def get_video_duration(video_path: Path) -> float:
@@ -44,34 +55,235 @@ def get_video_duration(video_path: Path) -> float:
         capture_output=True,
         text=True,
     )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ffprobe 执行失败。{FFMPEG_TOOLS_HINT}；若环境已满足，再检查输入媒体。原始错误: {result.stderr}"
+        )
+    try:
+        return float(result.stdout.strip())
+    except ValueError as exc:
+        raise RuntimeError(f"无法解析视频时长: {video_path}") from exc
 
-    return float(result.stdout.strip())
+
+def probe_media(video_path: Path) -> dict[str, object]:
+    """读取片段的基础媒体信息，用于统一中间片规格。"""
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-print_format",
+            "json",
+            "-show_streams",
+            "-show_format",
+            str(video_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ffprobe 执行失败。{FFMPEG_TOOLS_HINT}；若环境已满足，再检查输入媒体。原始错误: {result.stderr}"
+        )
+
+    payload = json.loads(result.stdout)
+    streams = payload.get("streams", [])
+    video_stream = next((s for s in streams if s.get("codec_type") == "video"), None)
+    audio_stream = next((s for s in streams if s.get("codec_type") == "audio"), None)
+    if not video_stream:
+        raise RuntimeError(f"缺少视频流: {video_path}")
+
+    fps = str(video_stream.get("avg_frame_rate") or video_stream.get("r_frame_rate") or "30")
+    if fps in {"0/0", "0", ""}:
+        fps = "30"
+
+    duration_raw = payload.get("format", {}).get("duration")
+    duration = float(duration_raw) if duration_raw else get_video_duration(video_path)
+
+    width = int(video_stream.get("width") or 0)
+    height = int(video_stream.get("height") or 0)
+    if width <= 0 or height <= 0:
+        raise RuntimeError(f"无法解析视频分辨率: {video_path}")
+
+    return {
+        "width": width,
+        "height": height,
+        "fps": fps,
+        "duration": duration,
+        "has_audio": audio_stream is not None,
+    }
+
+
+def normalize_clip(
+    video_path: Path,
+    output_path: Path,
+    *,
+    target_width: int,
+    target_height: int,
+    target_fps: str,
+) -> None:
+    """先把单个片段重编码为统一中间片，再做最终拼接。"""
+    media = probe_media(video_path)
+    # 进入拼接链路的每个中间片都要把音视频轨归零，避免后续 concat / 转场继续放大时间戳偏移。
+    video_filter = (
+        f"scale={target_width}:{target_height}:force_original_aspect_ratio=decrease,"
+        f"pad={target_width}:{target_height}:(ow-iw)/2:(oh-ih)/2:black,"
+        f"setsar=1,fps={target_fps},format=yuv420p,setpts=PTS-STARTPTS"
+    )
+
+    if media["has_audio"]:
+        filter_complex = (
+            f"[0:v]{video_filter}[vout];[0:a]aresample=48000,aformat=channel_layouts=stereo,asetpts=PTS-STARTPTS[aout]"
+        )
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(video_path.resolve()),
+            "-filter_complex",
+            filter_complex,
+            "-map",
+            "[vout]",
+            "-map",
+            "[aout]",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "medium",
+            "-crf",
+            "18",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "192k",
+            "-ar",
+            "48000",
+            "-ac",
+            "2",
+            str(output_path),
+        ]
+    else:
+        filter_complex = (
+            f"[0:v]{video_filter}[vout];[1:a]atrim=duration={float(media['duration']):.6f},asetpts=PTS-STARTPTS[aout]"
+        )
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(video_path.resolve()),
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=r=48000:cl=stereo",
+            "-filter_complex",
+            filter_complex,
+            "-map",
+            "[vout]",
+            "-map",
+            "[aout]",
+            "-shortest",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "medium",
+            "-crf",
+            "18",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "192k",
+            "-ar",
+            "48000",
+            "-ac",
+            "2",
+            str(output_path),
+        ]
+
+    run_ffmpeg(cmd, "ffmpeg 规范化片段失败")
+
+
+def normalize_clips(video_paths: list[Path], temp_dir: Path) -> list[Path]:
+    """将全部片段统一成可安全拼接的中间片。"""
+    first = probe_media(video_paths[0])
+    target_width = int(first["width"])
+    target_height = int(first["height"])
+    target_fps = str(first["fps"])
+
+    normalized_paths: list[Path] = []
+    for index, path in enumerate(video_paths):
+        normalized_path = temp_dir / f"normalized_{index:03d}.mp4"
+        normalize_clip(
+            path,
+            normalized_path,
+            target_width=target_width,
+            target_height=target_height,
+            target_fps=target_fps,
+        )
+        normalized_paths.append(normalized_path)
+    return normalized_paths
+
+
+def concatenate_final(video_paths: list[Path], output_path: Path):
+    """对统一规格的中间片做最终拼接，并确保视频轨从 0 开始。"""
+    if not video_paths:
+        raise ValueError("没有可用的视频片段")
+
+    inputs: list[str] = []
+    filter_inputs: list[str] = []
+    for index, path in enumerate(video_paths):
+        inputs.extend(["-i", str(path.resolve())])
+        filter_inputs.append(f"[{index}:v][{index}:a]")
+
+    # 仅让中间片归零还不够；最终成片如果不是从 0 开始，QuickTime 停在 0.00s 仍会先黑一下。
+    # concat demuxer + stream copy 会让最终视频轨保留正的 start_time，
+    # QuickTime 停在 0.00s 时会先显示黑屏；这里对统一中间片做一次最终编码，
+    # 让音视频轨都从 0 开始。
+    filter_complex = "".join(filter_inputs) + f"concat=n={len(video_paths)}:v=1:a=1[vout][aout]"
+    run_ffmpeg(
+        [
+            "ffmpeg",
+            "-y",
+            *inputs,
+            "-filter_complex",
+            filter_complex,
+            "-map",
+            "[vout]",
+            "-map",
+            "[aout]",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "medium",
+            "-crf",
+            "18",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "192k",
+            "-movflags",
+            "+faststart",
+            str(output_path),
+        ],
+        "ffmpeg 拼接失败",
+    )
 
 
 def concatenate_simple(video_paths: list, output_path: Path):
     """
-    简单拼接（无转场效果）
+    无转场拼接
 
-    使用 concat demuxer 进行快速拼接
+    先把片段规范化为统一的 H.264/AAC 中间片，再做最终拼接，
+    避免直接 copy 原始码流时的关键帧 / 时间戳边界问题。
     """
-    # 创建临时文件列表
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-        for path in video_paths:
-            # 使用绝对路径，避免 ffmpeg 解析相对路径出错
-            abs_path = path.resolve()
-            f.write(f"file '{abs_path}'\n")
-        list_file = f.name
-
-    try:
-        cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", list_file, "-c", "copy", str(output_path)]
-
-        result = subprocess.run(cmd, capture_output=True, text=True)
-
-        if result.returncode != 0:
-            raise RuntimeError(f"ffmpeg 错误: {result.stderr}")
-
-    finally:
-        Path(list_file).unlink()
+    with tempfile.TemporaryDirectory(prefix="compose-video-") as temp_dir:
+        normalized_paths = normalize_clips(video_paths, Path(temp_dir))
+        concatenate_final(normalized_paths, output_path)
 
 
 def concatenate_with_transitions(
@@ -82,57 +294,63 @@ def concatenate_with_transitions(
 
     使用 xfade 滤镜实现转场
     """
-    if len(video_paths) < 2:
-        # 单个视频直接复制
-        subprocess.run(["ffmpeg", "-y", "-i", str(video_paths[0]), "-c", "copy", str(output_path)])
-        return
+    with tempfile.TemporaryDirectory(prefix="compose-video-") as temp_dir:
+        normalized_paths = normalize_clips(video_paths, Path(temp_dir))
+        if len(normalized_paths) < 2:
+            concatenate_final(normalized_paths, output_path)
+            return
 
-    # 构建 filter_complex
-    inputs = []
-    for i, path in enumerate(video_paths):
-        inputs.extend(["-i", str(path)])
+        # 构建 filter_complex
+        inputs = []
+        for path in normalized_paths:
+            inputs.extend(["-i", str(path.resolve())])
 
-    # 获取每个视频的时长
-    durations = [get_video_duration(p) for p in video_paths]
+        # 获取每个视频的时长
+        durations = [get_video_duration(p) for p in normalized_paths]
 
-    # 构建 xfade 滤镜链
-    filter_parts = []
+        # 构建 xfade 滤镜链
+        filter_parts = []
 
-    for i in range(len(video_paths) - 1):
-        transition = transitions[i] if i < len(transitions) else "fade"
+        for i in range(len(normalized_paths) - 1):
+            transition = transitions[i] if i < len(transitions) else "fade"
 
-        # xfade 类型映射
-        xfade_type = {
-            "cut": None,  # 不使用转场
-            "fade": "fade",
-            "dissolve": "dissolve",
-            "wipe": "wipeleft",
-        }.get(transition, "fade")
+            # xfade 类型映射
+            xfade_type = {
+                "cut": None,  # 不使用转场
+                "fade": "fade",
+                "dissolve": "dissolve",
+                "wipe": "wipeleft",
+            }.get(transition, "fade")
 
-        if xfade_type is None:
-            # cut 转场，不需要 xfade
-            continue
+            if xfade_type is None:
+                # cut 转场，不需要 xfade
+                continue
 
-        if i == 0:
-            prev_label = "[0:v]"
-        else:
-            prev_label = f"[v{i}]"
+            if i == 0:
+                prev_label = "[0:v]"
+            else:
+                prev_label = f"[v{i}]"
 
-        next_label = f"[{i + 1}:v]"
-        out_label = f"[v{i + 1}]" if i < len(video_paths) - 2 else "[vout]"
+            next_label = f"[{i + 1}:v]"
+            out_label = f"[v{i + 1}]" if i < len(normalized_paths) - 2 else "[vout]"
 
-        # 计算偏移量
-        offset = sum(durations[: i + 1]) - transition_duration * (i + 1)
+            # 计算偏移量
+            offset = sum(durations[: i + 1]) - transition_duration * (i + 1)
 
-        filter_parts.append(
-            f"{prev_label}{next_label}xfade=transition={xfade_type}:"
-            f"duration={transition_duration}:offset={offset:.3f}{out_label}"
-        )
+            filter_parts.append(
+                f"{prev_label}{next_label}xfade=transition={xfade_type}:"
+                f"duration={transition_duration}:offset={offset:.3f}{out_label}"
+            )
 
-    if filter_parts:
-        # 音频也需要处理
+        if not filter_parts:
+            concatenate_final(normalized_paths, output_path)
+            return
+
+        # 下一个容易踩的坑：这里的视频转场已经平滑，但音频仍是硬拼接；
+        # 如果后面要做“听感也平滑”的转场，需要把 concat 改成 acrossfade / afade 链。
         audio_filter = (
-            ";".join([f"[{i}:a]" for i in range(len(video_paths))]) + f"concat=n={len(video_paths)}:v=0:a=1[aout]"
+            ";".join([f"[{i}:a]" for i in range(len(normalized_paths))])
+            + f"concat=n={len(normalized_paths)}:v=0:a=1[aout]"
         )
 
         filter_complex = ";".join(filter_parts) + ";" + audio_filter
@@ -149,20 +367,24 @@ def concatenate_with_transitions(
             "[aout]",
             "-c:v",
             "libx264",
+            "-preset",
+            "medium",
+            "-crf",
+            "18",
+            "-pix_fmt",
+            "yuv420p",
             "-c:a",
             "aac",
+            "-b:a",
+            "192k",
             str(output_path),
         ]
-    else:
-        # 全是 cut 转场，使用简单拼接
-        concatenate_simple(video_paths, output_path)
-        return
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+        result = subprocess.run(cmd, capture_output=True, text=True)
 
-    if result.returncode != 0:
-        print(f"⚠️  转场效果失败，尝试简单拼接: {result.stderr[:200]}")
-        concatenate_simple(video_paths, output_path)
+        if result.returncode != 0:
+            print(f"⚠️  转场效果失败，尝试简单拼接: {result.stderr[:200]}")
+            concatenate_final(normalized_paths, output_path)
 
 
 def add_background_music(video_path: Path, music_path: Path, output_path: Path, music_volume: float = 0.3):
@@ -288,10 +510,11 @@ def main():
 
     args = parser.parse_args()
 
-    # 检查 ffmpeg
+    # 检查 ffmpeg / ffprobe
     if not check_ffmpeg():
-        print("❌ 错误: ffmpeg 未安装或不在 PATH 中")
-        print("   请安装 ffmpeg: brew install ffmpeg (macOS)")
+        print(f"❌ 错误: {FFMPEG_TOOLS_HINT}")
+        print("   macOS 可执行: brew install ffmpeg")
+        print("   安装后请确认 ffmpeg -version 和 ffprobe -version 都能执行")
         sys.exit(1)
 
     try:


### PR DESCRIPTION
## 范围

仅调整 compose-video skill 的后备拼接与最终输出时间戳处理，以及对应的 skill 文档说明；不涉及前后端接口、项目 schema、数据库迁移或 UI 逻辑。

## 变更

- 新增媒体探测与片段规范化流程，统一输出 H.264/AAC 中间片，并在缺音轨时自动补静音。
- 将最终无转场拼接改为基于 concat filter 的最终编码，确保成片视频轨和音轨从 0 开始，避免 QuickTime 在 0.00s 黑屏。
- 强化依赖检查与错误提示，明确要求 ffmpeg 和 ffprobe 同时可用。
- 在关键代码路径补充简短注释，说明“中间片归零 + 最终输出归零”的约束。
- 更新 SKILL.md 对后备拼接行为的描述，使文档说明与实现一致。

## 验收清单

- [x] 本地已跑相关测试（`uv run ruff check agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py`、`uv run ruff format --check agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py`、`uv run python -m py_compile agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py`）
- [x] 手动验证了改动所声称的行为（使用真实项目素材做 smoke test 合成；`ffprobe` 确认最终视频/音频 `start_time=0.000000`；QuickTime 在 `0.00s` 首帧显示正常）
- [x] 无新增 ESLint disable；

## 已知 defer

无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 自动规范化视频片段的编码规格、帧率和时间戳，并在最终合成时统一重编码以提升兼容性与稳定性。
  * 当转场合成失败时，自动回退到基于统一中间片的拼接流程。

* **Bug修复**
  * 修复拼接边界可能出现的黑帧问题。
  * 对无音轨视频自动补静音以保证音视频对齐和拼接一致性。

* **文档**
  * 更新拼接文档与预检列表：明确要求 ffmpeg 与 ffprobe 可用，并增强安装与诊断提示。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/537)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->