### PR TITLE
feat(thumbnail): add extract_video_last_frame helper

### DIFF
--- a/lib/thumbnail.py
+++ b/lib/thumbnail.py
@@ -120,6 +120,41 @@ async def _probe_frame_count(video_path: Path, *, count_frames: bool) -> int | N
         return None
 
 
+async def _extract_frame_at_index(
+    video_path: Path,
+    output_path: Path,
+    frame_index: int,
+) -> bool:
+    temp_path = output_path.with_name(f".{output_path.stem}.tmp{output_path.suffix}")
+    if temp_path.exists():
+        temp_path.unlink()
+
+    proc = await asyncio.create_subprocess_exec(
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(video_path),
+        "-vf",
+        f"select='eq(n\\,{frame_index})'",
+        "-fps_mode",
+        "vfr",
+        "-frames:v",
+        "1",
+        str(temp_path),
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    await proc.wait()
+
+    if proc.returncode != 0 or not temp_path.exists() or temp_path.stat().st_size < 1:
+        if temp_path.exists():
+            temp_path.unlink()
+        return False
+
+    temp_path.replace(output_path)
+    return True
+
+
 async def extract_video_last_frame(
     video_path: Path,
     output_path: Path,
@@ -151,32 +186,15 @@ async def extract_video_last_frame(
 
     # 1. 先走快路径（容器元数据），失败再回退到全量解码
     total_frames = await _probe_frame_count(video_path, count_frames=False)
-    if total_frames is None or total_frames < 1:
-        total_frames = await _probe_frame_count(video_path, count_frames=True)
-    if total_frames is None or total_frames < 1:
-        return None
-
-    # 2. 用 select 滤镜精确提取最后一帧
-    last_index = total_frames - 1
     try:
-        proc = await asyncio.create_subprocess_exec(
-            "ffmpeg",
-            "-y",
-            "-i",
-            str(video_path),
-            "-vf",
-            f"select='eq(n\\,{last_index})'",
-            "-fps_mode",
-            "vfr",
-            "-frames:v",
-            "1",
-            str(output_path),
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        await proc.wait()
+        if total_frames is not None and total_frames > 0:
+            if await _extract_frame_at_index(video_path, output_path, total_frames - 1):
+                return output_path
 
-        if proc.returncode != 0 or not output_path.exists():
+        total_frames = await _probe_frame_count(video_path, count_frames=True)
+        if total_frames is None or total_frames < 1:
+            return None
+        if not await _extract_frame_at_index(video_path, output_path, total_frames - 1):
             return None
 
         return output_path

--- a/lib/thumbnail.py
+++ b/lib/thumbnail.py
@@ -1,4 +1,4 @@
-"""视频首帧缩略图提取"""
+"""视频帧提取（首帧缩略图 / 尾帧）"""
 
 import asyncio
 import functools
@@ -15,9 +15,16 @@ def _ffmpeg_available() -> bool:
     return shutil.which("ffmpeg") is not None
 
 
+@functools.cache
+def _ffprobe_available() -> bool:
+    """ffprobe 可执行文件是否在 PATH 中（独立检查：精简容器可能只装了 ffmpeg）。"""
+    return shutil.which("ffprobe") is not None
+
+
 def _reset_for_tests() -> None:
     """test helper — 清缓存让 monkeypatch shutil.which 立刻生效。"""
     _ffmpeg_available.cache_clear()
+    _ffprobe_available.cache_clear()
 
 
 async def extract_video_thumbnail(
@@ -70,4 +77,109 @@ async def extract_video_thumbnail(
         return thumbnail_path
     except Exception:
         logger.warning("提取视频缩略图失败: %s", video_path, exc_info=True)
+        return None
+
+
+async def _probe_frame_count(video_path: Path, *, count_frames: bool) -> int | None:
+    """
+    用 ffprobe 读取视频帧数。
+
+    count_frames=False：从容器元数据读 ``nb_frames``，瞬时返回，但部分容器为 ``N/A``。
+    count_frames=True：``-count_frames`` 全量解码统计 ``nb_read_frames``，精确但慢。
+    """
+    entry = "stream=nb_read_frames" if count_frames else "stream=nb_frames"
+    args = ["ffprobe", "-v", "error"]
+    if count_frames:
+        args.append("-count_frames")
+    args += [
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        entry,
+        "-of",
+        "csv=p=0",
+        str(video_path),
+    ]
+
+    try:
+        probe = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await probe.communicate()
+    except (FileNotFoundError, OSError):
+        return None
+
+    if probe.returncode != 0:
+        return None
+
+    try:
+        return int(stdout.decode().strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+async def extract_video_last_frame(
+    video_path: Path,
+    output_path: Path,
+) -> Path | None:
+    """
+    提取视频最后一帧作为 PNG 图片。
+
+    通过 ffprobe 获取精确总帧数，再用 select 滤镜定位最后一帧，
+    避免 ``-sseof`` 的时间戳近似问题。
+
+    优化：优先读取容器元数据 ``nb_frames``（瞬时），失败时回退到
+    ``-count_frames`` 全量解码（精确但慢）。
+
+    Args:
+        video_path: 视频文件路径
+        output_path: 输出图片路径（建议 .png）
+
+    Returns:
+        输出路径（成功）或 None（失败 / ffmpeg 或 ffprobe 不可用）
+    """
+    if not video_path.exists():
+        return None
+
+    if not _ffmpeg_available() or not _ffprobe_available():
+        logger.info("ffmpeg/ffprobe 不可用，跳过尾帧提取")
+        return None
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # 1. 先走快路径（容器元数据），失败再回退到全量解码
+    total_frames = await _probe_frame_count(video_path, count_frames=False)
+    if total_frames is None or total_frames < 1:
+        total_frames = await _probe_frame_count(video_path, count_frames=True)
+    if total_frames is None or total_frames < 1:
+        return None
+
+    # 2. 用 select 滤镜精确提取最后一帧
+    last_index = total_frames - 1
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(video_path),
+            "-vf",
+            f"select='eq(n\\,{last_index})'",
+            "-fps_mode",
+            "vfr",
+            "-frames:v",
+            "1",
+            str(output_path),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await proc.wait()
+
+        if proc.returncode != 0 or not output_path.exists():
+            return None
+
+        return output_path
+    except Exception:
+        logger.warning("提取视频尾帧失败: %s", video_path, exc_info=True)
         return None

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -3,7 +3,7 @@ import shutil
 
 import pytest
 
-from lib.thumbnail import extract_video_thumbnail
+from lib.thumbnail import extract_video_last_frame, extract_video_thumbnail
 
 
 class TestExtractVideoThumbnail:
@@ -70,4 +70,59 @@ class TestExtractVideoThumbnail:
         bad_video = tmp_path / "bad.mp4"
         bad_video.write_text("not a video")
         result = await extract_video_thumbnail(bad_video, tmp_path / "thumb.jpg")
+        assert result is None
+
+
+class TestExtractVideoLastFrame:
+    @pytest.fixture(autouse=True)
+    def check_ffmpeg(self):
+        if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+            pytest.skip("ffmpeg/ffprobe not available")
+
+    async def _make_video(self, path, color: str = "green", duration: int = 1):
+        proc = await asyncio.create_subprocess_exec(
+            "ffmpeg",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c={color}:s=64x64:d={duration}",
+            "-c:v",
+            "libx264",
+            "-t",
+            str(duration),
+            "-y",
+            str(path),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await proc.wait()
+        assert path.exists()
+
+    async def test_extracts_last_frame(self, tmp_path):
+        video_path = tmp_path / "test.mp4"
+        await self._make_video(video_path)
+
+        out = tmp_path / "last.png"
+        result = await extract_video_last_frame(video_path, out)
+        assert result == out
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    async def test_creates_parent_directory(self, tmp_path):
+        video_path = tmp_path / "test.mp4"
+        await self._make_video(video_path)
+
+        out = tmp_path / "sub" / "dir" / "last.png"
+        result = await extract_video_last_frame(video_path, out)
+        assert result == out
+        assert out.exists()
+
+    async def test_returns_none_for_missing_video(self, tmp_path):
+        result = await extract_video_last_frame(tmp_path / "missing.mp4", tmp_path / "last.png")
+        assert result is None
+
+    async def test_returns_none_for_corrupt_video(self, tmp_path):
+        bad_video = tmp_path / "bad.mp4"
+        bad_video.write_text("not a video")
+        result = await extract_video_last_frame(bad_video, tmp_path / "last.png")
         assert result is None

--- a/tests/test_thumbnail_fallback.py
+++ b/tests/test_thumbnail_fallback.py
@@ -145,22 +145,26 @@ async def test_last_frame_falls_back_to_count_frames(tmp_path: Path):
             return self._payload, b""
 
     class _FfmpegProc:
+        def __init__(self, target: Path):
+            self._target = target
+
         returncode = 0
 
         async def wait(self):
             # 模拟 ffmpeg 写出文件
-            out.write_bytes(b"\x89PNG\r\n\x1a\n")
+            self._target.write_bytes(b"\x89PNG\r\n\x1a\n")
             return None
 
     call_log: list[list[str]] = []
     procs = [
         _ProbeProc(b"N/A\n"),  # nb_frames 快路径
         _ProbeProc(b"30\n"),  # -count_frames 回退
-        _FfmpegProc(),  # 提取
     ]
 
     async def _spawn(*args, **_kwargs):
         call_log.append(list(args))
+        if args[0] == "ffmpeg":
+            return _FfmpegProc(Path(args[-1]))
         return procs.pop(0)
 
     def _which(name: str):
@@ -175,6 +179,62 @@ async def test_last_frame_falls_back_to_count_frames(tmp_path: Path):
     assert call_log[0][0] == "ffprobe" and "-count_frames" not in call_log[0]
     assert call_log[1][0] == "ffprobe" and "-count_frames" in call_log[1]
     assert call_log[2][0] == "ffmpeg"
+
+
+@pytest.mark.asyncio
+async def test_last_frame_retries_precise_count_when_fast_extract_writes_nothing(
+    tmp_path: Path,
+):
+    """nb_frames 有值但 select 无输出时，用 -count_frames 结果重试并替换旧文件。"""
+    video = tmp_path / "fake.mp4"
+    video.write_bytes(b"\x00")
+    out = tmp_path / "out.png"
+    out.write_bytes(b"stale")
+
+    class _ProbeProc:
+        def __init__(self, payload: bytes):
+            self._payload = payload
+            self.returncode = 0
+
+        async def communicate(self):
+            return self._payload, b""
+
+    class _FfmpegProc:
+        returncode = 0
+
+        def __init__(self, target: Path, *, writes_output: bool):
+            self._target = target
+            self._writes_output = writes_output
+
+        async def wait(self):
+            if self._writes_output:
+                self._target.write_bytes(b"fresh")
+            return None
+
+    probe_procs = [_ProbeProc(b"999\n"), _ProbeProc(b"30\n")]
+    ffmpeg_writes = [False, True]
+    call_log: list[list[str]] = []
+
+    async def _spawn(*args, **_kwargs):
+        call_log.append(list(args))
+        if args[0] == "ffprobe":
+            return probe_procs.pop(0)
+        return _FfmpegProc(Path(args[-1]), writes_output=ffmpeg_writes.pop(0))
+
+    def _which(name: str):
+        return f"/usr/bin/{name}"
+
+    with patch("lib.thumbnail.shutil.which", side_effect=_which):
+        with patch("lib.thumbnail.asyncio.create_subprocess_exec", side_effect=_spawn):
+            result = await thumbnail_module.extract_video_last_frame(video, out)
+
+    assert result == out
+    assert out.read_bytes() == b"fresh"
+    assert len(call_log) == 4
+    assert call_log[0][0] == "ffprobe" and "-count_frames" not in call_log[0]
+    assert call_log[1][0] == "ffmpeg"
+    assert call_log[2][0] == "ffprobe" and "-count_frames" in call_log[2]
+    assert call_log[3][0] == "ffmpeg"
 
 
 def test_ffprobe_available_is_cached():

--- a/tests/test_thumbnail_fallback.py
+++ b/tests/test_thumbnail_fallback.py
@@ -78,3 +78,110 @@ def test_ffmpeg_available_is_cached():
         thumbnail_module._ffmpeg_available()
         thumbnail_module._ffmpeg_available()
     assert which.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_last_frame_returns_none_when_ffmpeg_missing(tmp_path: Path):
+    """ffmpeg 缺失时 extract_video_last_frame 直接返回 None，不 spawn 子进程。"""
+    video = tmp_path / "fake.mp4"
+    video.write_bytes(b"\x00")
+    out = tmp_path / "out.png"
+
+    with patch("lib.thumbnail.shutil.which", return_value=None):
+        with patch("lib.thumbnail.asyncio.create_subprocess_exec") as spawn:
+            result = await thumbnail_module.extract_video_last_frame(video, out)
+
+    assert result is None
+    assert not out.exists()
+    spawn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_last_frame_returns_none_when_only_ffprobe_missing(tmp_path: Path):
+    """ffmpeg 在 PATH 但 ffprobe 缺失（精简容器场景）时也应短路。"""
+    video = tmp_path / "fake.mp4"
+    video.write_bytes(b"\x00")
+    out = tmp_path / "out.png"
+
+    def _which(name: str):
+        return "/usr/bin/ffmpeg" if name == "ffmpeg" else None
+
+    with patch("lib.thumbnail.shutil.which", side_effect=_which):
+        with patch("lib.thumbnail.asyncio.create_subprocess_exec") as spawn:
+            result = await thumbnail_module.extract_video_last_frame(video, out)
+
+    assert result is None
+    spawn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_last_frame_returns_none_when_video_missing(tmp_path: Path):
+    """video 不存在时直接返回 None，不检查 ffmpeg/ffprobe。"""
+    nonexistent = tmp_path / "no-such-video.mp4"
+    out = tmp_path / "out.png"
+
+    with patch("lib.thumbnail.shutil.which") as which:
+        result = await thumbnail_module.extract_video_last_frame(nonexistent, out)
+
+    assert result is None
+    which.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_last_frame_falls_back_to_count_frames(tmp_path: Path):
+    """容器 nb_frames 为 N/A 时回退到 -count_frames 路径。"""
+    video = tmp_path / "fake.mp4"
+    video.write_bytes(b"\x00")
+    out = tmp_path / "out.png"
+
+    class _ProbeProc:
+        """第一次返回 N/A，第二次返回 30。"""
+
+        def __init__(self, payload: bytes, rc: int = 0):
+            self._payload = payload
+            self.returncode = rc
+
+        async def communicate(self):
+            return self._payload, b""
+
+    class _FfmpegProc:
+        returncode = 0
+
+        async def wait(self):
+            # 模拟 ffmpeg 写出文件
+            out.write_bytes(b"\x89PNG\r\n\x1a\n")
+            return None
+
+    call_log: list[list[str]] = []
+    procs = [
+        _ProbeProc(b"N/A\n"),  # nb_frames 快路径
+        _ProbeProc(b"30\n"),  # -count_frames 回退
+        _FfmpegProc(),  # 提取
+    ]
+
+    async def _spawn(*args, **_kwargs):
+        call_log.append(list(args))
+        return procs.pop(0)
+
+    def _which(name: str):
+        return f"/usr/bin/{name}"
+
+    with patch("lib.thumbnail.shutil.which", side_effect=_which):
+        with patch("lib.thumbnail.asyncio.create_subprocess_exec", side_effect=_spawn):
+            result = await thumbnail_module.extract_video_last_frame(video, out)
+
+    assert result == out
+    assert len(call_log) == 3
+    assert call_log[0][0] == "ffprobe" and "-count_frames" not in call_log[0]
+    assert call_log[1][0] == "ffprobe" and "-count_frames" in call_log[1]
+    assert call_log[2][0] == "ffmpeg"
+
+
+def test_ffprobe_available_is_cached():
+    """_ffprobe_available() 同样走 @functools.cache。"""
+    thumbnail_module._reset_for_tests()
+    with patch("lib.thumbnail.shutil.which", return_value=None) as which:
+        thumbnail_module._ffprobe_available()
+        thumbnail_module._ffprobe_available()
+        thumbnail_module._ffprobe_available()
+    assert which.call_count == 1


### PR DESCRIPTION
## 背景

参考视频→视频生成等场景需要提取视频尾帧作为下一段的首帧锚点，
现有 `lib/thumbnail.py` 仅提供 `extract_video_thumbnail`（首帧）。

## 变更

在 `lib/thumbnail.py` 紧跟 `extract_video_thumbnail` 之后新增
`extract_video_last_frame(video_path, output_path)`：

- 复用并扩展现有可用性检查：新增 `_ffprobe_available()`（`@functools.cache`），
  `_reset_for_tests()` 同步清理；
- 两步走定位末帧：
  1. **Fast path** — `ffprobe -select_streams v:0 -show_entries stream=nb_frames`
     直接读容器元数据；
  2. **Fallback** — 元数据缺失或 `N/A` 时降级 `-count_frames` 做一次完整解码计数；
- 用 `select='eq(n\,{last_index})'` 精确抓帧，写入 `-frames:v 1`；
- 使用 `-fps_mode vfr`（取代 deprecated `-vsync vfr`），避免 ffmpeg 7+ 警告；
- 所有子进程均通过 `asyncio.create_subprocess_exec` 异步执行。

## 测试

新增 9 个测试用例，`uv run python -m pytest tests/test_thumbnail.py tests/test_thumbnail_fallback.py` 共 17 用例通过 (2.18s)：

- `TestExtractVideoLastFrame`（集成）：happy path / 自动创建父目录 / 视频不存在 / 视频损坏；
- `test_thumbnail_fallback.py`（mock）：ffmpeg 缺失、仅 ffprobe 缺失、视频不存在、
  `nb_frames=N/A` 触发 `-count_frames` 回退、`_ffprobe_available` 缓存命中。

## 验收

- `uv run ruff check lib/thumbnail.py tests/test_thumbnail.py tests/test_thumbnail_fallback.py` 通过
- `uv run ruff format --check` 通过
- pytest 全部通过；外部依赖 `ffmpeg` / `ffprobe` 缺失时测试自动 skip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 支持提取视频末帧（保留原有首帧提取），在有条件下采用快速路径并在不可用时回退到精确路径
  * 缓存外部工具可用性检测以提升性能

* **修复与改进**
  * 提取流程增加重试与回退逻辑，增强对缺失/损坏视频和工具不可用场景的稳健性
  * 输出文件与父目录自动处理，失败时返回 None

* **测试**
  * 为末帧提取新增全面测试，覆盖成功、回退、重试及异常情况

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->