### PR TITLE
ci(postgres-compat): PostgreSQL 兼容性测试隔离与验证

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,16 @@ jobs:
       - name: Run tests with coverage
         run: uv run python -m pytest -m "not e2e" --cov=lib --cov=server --cov-report=term-missing --cov-report=xml --cov-fail-under=80
 
-  session-store-postgres:
+      - name: Upload backend coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          flags: backend
+          fail_ci_if_error: false
+
+  postgres-compat:
+    # SQLite/PostgreSQL 方言兼容性闸门：alembic 三步闭环（upgrade/downgrade/idempotent）
+    # + 所有 DB-touching 测试（marker 驱动）跑在 PG16 上。
     runs-on: ubuntu-latest
     needs: backend-tests
     services:
@@ -48,6 +57,8 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+    env:
+      DATABASE_URL: postgresql+asyncpg://arcreel:arcreel@localhost:5432/arcreel_test
     steps:
       - uses: actions/checkout@v6
 
@@ -62,19 +73,26 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Run alembic migrations
-        env:
-          DATABASE_URL: postgresql+asyncpg://arcreel:arcreel@localhost:5432/arcreel_test
-        run: uv run alembic upgrade head
+      - name: Validate alembic migrations (upgrade / idempotent / downgrade / re-upgrade)
+        run: |
+          set -e
+          uv run alembic upgrade head           # 1. 正向迁移
+          uv run alembic upgrade head           # 2. 幂等性：第二次应该 no-op
+          uv run alembic downgrade base         # 3. 反向回到空 schema
+          uv run alembic upgrade head           # 4. 再次正向，验证 downgrade 真清掉了
 
       - name: Run dialect-sensitive tests against Postgres
-        env:
-          DATABASE_URL: postgresql+asyncpg://arcreel:arcreel@localhost:5432/arcreel_test
         run: |
-          uv run python -m pytest \
-            tests/agent_session_store/ \
-            tests/test_agent_credential_repo.py \
-            -v -m "not sqlite_only"
+          uv run python -m pytest -v \
+            -m "uses_db and not sqlite_only" \
+            --cov=lib --cov=server --cov-report=xml:coverage-pg.xml
+
+      - name: Upload PG coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage-pg.xml
+          flags: postgres
+          fail_ci_if_error: false
 
   frontend-tests:
     runs-on: ubuntu-latest

--- a/alembic/versions/2c57c41eca74_add_provider_credential_table.py
+++ b/alembic/versions/2c57c41eca74_add_provider_credential_table.py
@@ -99,7 +99,7 @@ def downgrade() -> None:
     # 反向迁移：将活跃凭证写回 provider_config
     conn = op.get_bind()
     rows = conn.execute(
-        sa.text("SELECT provider, api_key, credentials_path, base_url FROM provider_credential WHERE is_active = 1")
+        sa.text("SELECT provider, api_key, credentials_path, base_url FROM provider_credential WHERE is_active")
     ).fetchall()
 
     config_table = sa.table(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ markers = [
     "integration: 跨模块真实协作测试；禁止 mock 被测 module 的公共入口（否则是在测 mock 本身）",
     "e2e: 端到端、依赖真实外部资源（远程 API、大模型调用、重型 ffmpeg 等）的测试；CI 默认跳过",
     "sqlite_only: 仅适用于 SQLite 的测试（依赖 SQLite 特定 fixture / 行为，PG CI job 会跳过）",
+    "uses_db: 触达真实数据库的测试（repo/DAO/ORM/迁移）；PG job 用 `-m uses_db` 选集合。由 conftest 根据 fixture 使用自动注入",
 ]
 
 [tool.coverage.run]

--- a/tests/agent_session_store/conftest.py
+++ b/tests/agent_session_store/conftest.py
@@ -24,7 +24,7 @@ def _pg_url_from_env() -> str | None:
 # Test fixtures attribute writes to a small set of fixed user_ids; seed them
 # on PG so FK constraints (which SQLite tests bypass via PRAGMA foreign_keys=OFF)
 # don't reject inserts.
-_PG_TEST_USER_IDS = ("default", "u1", "conformance")
+_PG_TEST_USER_IDS = ("default", "u1", "conformance", "e2e", "crash-recover", "long-turn")
 
 
 async def _seed_pg_users(engine) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,17 +156,33 @@ async def session_manager(tmp_path: Path, meta_store: SessionMetaStore) -> Sessi
 
 
 def pytest_collection_modifyitems(config, items):
-    """Auto-mark DB-touching tests with `uses_db`.
+    """Auto-mark dialect-sensitive tests with `uses_db`.
 
-    Any test that requests one of the canonical DB fixtures (async_session,
-    session_factory, file_session_factory) gets `uses_db`, so the PG CI job
-    can select via `-m uses_db` without per-file `pytestmark` annotations.
+    Mark a test only when it consumes a fixture defined in a canonical
+    dialect-sensitive conftest — the main `tests/conftest.py` (`async_session`,
+    reads DATABASE_URL) or `tests/agent_session_store/conftest.py`
+    (`session_factory` / `file_session_factory`, also reads DATABASE_URL).
+    Tests that locally override the same fixture name with a hard-coded
+    SQLite engine (e.g. `tests/test_custom_providers_api.py`) are excluded so
+    the postgres-compat job stays a true dialect signal rather than running
+    SQLite-only code under a `postgres` coverage flag.
     """
-    db_fixtures = {"async_session", "session_factory", "file_session_factory"}
+    target_fixtures = {"async_session", "session_factory", "file_session_factory"}
+    canonical_modules = {"tests.conftest", "tests.agent_session_store.conftest"}
     uses_db = pytest.mark.uses_db
     for item in items:
-        if db_fixtures.intersection(getattr(item, "fixturenames", ())):
-            item.add_marker(uses_db)
+        info = getattr(item, "_fixtureinfo", None)
+        if info is None:
+            continue
+        fixturenames = set(getattr(item, "fixturenames", ()) or ())
+        for fname in target_fixtures & fixturenames:
+            for fdef in info.name2fixturedefs.get(fname, ()) or ():
+                if getattr(fdef.func, "__module__", "") in canonical_modules:
+                    item.add_marker(uses_db)
+                    break
+            else:
+                continue
+            break
 
 
 @pytest.fixture()
@@ -192,14 +208,16 @@ async def async_session():
         try:
             async with engine.connect() as conn:
                 outer = await conn.begin()
-                factory = async_sessionmaker(
-                    bind=conn,
-                    expire_on_commit=False,
-                    join_transaction_mode="create_savepoint",
-                )
-                async with factory() as session:
-                    yield session
-                await outer.rollback()
+                try:
+                    factory = async_sessionmaker(
+                        bind=conn,
+                        expire_on_commit=False,
+                        join_transaction_mode="create_savepoint",
+                    )
+                    async with factory() as session:
+                        yield session
+                finally:
+                    await outer.rollback()
         finally:
             await engine.dispose()
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,18 +155,58 @@ async def session_manager(tmp_path: Path, meta_store: SessionMetaStore) -> Sessi
 # ---------------------------------------------------------------------------
 
 
+def pytest_collection_modifyitems(config, items):
+    """Auto-mark DB-touching tests with `uses_db`.
+
+    Any test that requests one of the canonical DB fixtures (async_session,
+    session_factory, file_session_factory) gets `uses_db`, so the PG CI job
+    can select via `-m uses_db` without per-file `pytestmark` annotations.
+    """
+    db_fixtures = {"async_session", "session_factory", "file_session_factory"}
+    uses_db = pytest.mark.uses_db
+    for item in items:
+        if db_fixtures.intersection(getattr(item, "fixturenames", ())):
+            item.add_marker(uses_db)
+
+
 @pytest.fixture()
 async def async_session():
     """Generic AsyncSession for repository tests.
 
-    Reads DATABASE_URL env var (used by CI postgres job to exercise dialect
-    compat); otherwise falls back to in-memory SQLite.
+    PG (DATABASE_URL=postgresql+...): trusts that ``alembic upgrade head`` has
+    already created the schema (CI job does this before pytest). Each test
+    opens a fresh NullPool engine, an outer transaction, and uses SAVEPOINT
+    semantics so any `session.commit()` is contained — teardown ROLLBACKs the
+    outer transaction, so data writes never persist.
+
+    SQLite (default): each test gets a fresh in-memory engine + ORM
+    ``create_all`` — engine is throwaway, no isolation primitive needed.
     """
-    url = os.environ.get("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
-    engine = create_async_engine(url)
+    url = os.environ.get("DATABASE_URL", "")
+    if url.startswith("postgresql"):
+        # Per-test engine with NullPool: avoids cross-event-loop reuse of
+        # asyncpg connections (each pytest-asyncio test runs on a fresh loop).
+        from sqlalchemy.pool import NullPool
+
+        engine = create_async_engine(url, poolclass=NullPool)
+        try:
+            async with engine.connect() as conn:
+                outer = await conn.begin()
+                factory = async_sessionmaker(
+                    bind=conn,
+                    expire_on_commit=False,
+                    join_transaction_mode="create_savepoint",
+                )
+                async with factory() as session:
+                    yield session
+                await outer.rollback()
+        finally:
+            await engine.dispose()
+        return
+
+    # SQLite in-memory — engine is throwaway, ORM-driven schema.
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
-        # 同一 DB 跨 fixture 复用时必须先清表（PG 容器跨用例持久）
-        await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
     factory = async_sessionmaker(engine, expire_on_commit=False)
     async with factory() as session:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,13 +176,17 @@ def pytest_collection_modifyitems(config, items):
             continue
         fixturenames = set(getattr(item, "fixturenames", ()) or ())
         for fname in target_fixtures & fixturenames:
-            for fdef in info.name2fixturedefs.get(fname, ()) or ():
-                if getattr(fdef.func, "__module__", "") in canonical_modules:
-                    item.add_marker(uses_db)
-                    break
-            else:
+            # `name2fixturedefs[fname]` is pytest's fixture override chain
+            # (general → specific). The last element is the definition that
+            # actually wins for this test; only it determines whether the
+            # test really hits a dialect-sensitive engine.
+            defs = info.name2fixturedefs.get(fname) or ()
+            if not defs:
                 continue
-            break
+            active = defs[-1]
+            if getattr(active.func, "__module__", "") in canonical_modules:
+                item.add_marker(uses_db)
+                break
 
 
 @pytest.fixture()


### PR DESCRIPTION
Closes #510

## Summary
- 将 `session-store-postgres` 重命名为 `postgres-compat`，正名为方言兼容性闸门
- Alembic 四步闭环（upgrade × 2 含幂等性 + downgrade base + upgrade head）
- 新增 `uses_db` marker + conftest 钩子按 fixture 自动注入；PG job 改用 marker 选集合（从 2 文件 → 9 文件 96 测试）
- `async_session` fixture 重构：PG 路径 NullPool + 外层事务 + SAVEPOINT，免每用例 DDL；强制信任 alembic schema
- PG / backend 双 codecov 上传（flags=`postgres` / `backend`），打开方言分支覆盖率黑盒

## 闭环立刻揪出的真 bug（同 PR 修复）
- `alembic/versions/2c57c41eca74` downgrade 中 `WHERE is_active = 1` 在 SQLite 接受、PG 报 `boolean = integer` 错——同类 PR #507 那种问题。改为 `WHERE is_active` 两方言通吃。
- `tests/agent_session_store/conftest.py` 的 PG `_PG_TEST_USER_IDS` 补全 `e2e` / `crash-recover` / `long-turn`，配合 marker hook 新拉进来的 e2e 测试。

## Test plan
- [x] 本地 ruff check + format check
- [x] SQLite 全套件 2649/2649 通过，coverage 83.65% ≥ 80%
- [x] 本地 docker PG16 跑 alembic 四步闭环全过
- [x] 本地 docker PG16 跑 `-m "uses_db and not sqlite_only"` 96/96 通过
- [ ] CI `backend-tests` 绿
- [ ] CI `postgres-compat` 绿（含 codecov 上报）
- [ ] CI `frontend-tests` 绿

## 后续
当前 branch protection 未把 `session-store-postgres` 设为 required check（已与作者确认），改名零协调成本。合并后建议把 `postgres-compat` 加为 required check。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 强化数据库相关测试：按需区分 PostgreSQL/SQLite 流程、每测隔离与回滚策略、自动标记需真实 DB 的用例。
  * 扩充预置测试用户 ID 集合以覆盖更多场景。

* **Chores**
  * 增强迁移与 CI 校验：加入 Alembic 幂等性与回归验证，改进覆盖率收集与单独上报（后端与 Postgres）。
* **Bug Fixes**
  * 调整迁移回退时的活跃凭证筛选表达以修正行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/544?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->