### PR TITLE
fix(skills): clarify compose-video content mode

### DIFF
--- a/agent_runtime_profile/.claude/skills/compose-video/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/compose-video/SKILL.md
@@ -61,7 +61,7 @@ python .claude/skills/compose-video/scripts/compose_video.py scripts/episode_1.j
 ## 前置检查
 
 - [ ] 当前 cwd 是项目根（含 `project.json`）
-- [ ] 剧本 generation_mode 为 drama（顶层有 `scenes[]`）
+- [ ] 剧本 content_mode 为 drama（顶层有 `scenes[]`）
 - [ ] 每个场景的 `generated_assets.video_clip` 都已生成
 - [ ] `ffmpeg` / `ffprobe` 都在 PATH（脚本会预检）
 - [ ] BGM 文件存在（如指定 `--music`）

--- a/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
+++ b/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
@@ -484,10 +484,12 @@ def compose_video(
 
     # 仅支持 drama 模式（顶层 scenes[]）；narration/reference_video 给友好错误
     if "scenes" not in script:
-        gen_mode = script.get("generation_mode") or "narration/reference_video"
+        content_mode = script.get("content_mode") or "unknown"
+        generation_mode = script.get("generation_mode") or "storyboard"
         raise RuntimeError(
             f"compose_video.py 目前仅支持 drama 模式（剧本顶层需有 scenes[]）；"
-            f"当前剧本 generation_mode={gen_mode}，请使用 Web 端剪映草稿导出"
+            f"当前剧本 content_mode={content_mode}, generation_mode={generation_mode}，"
+            "请使用 Web 端剪映草稿导出"
         )
 
     # 收集视频片段


### PR DESCRIPTION
## 概述

修正文档和脚本提示中对 `content_mode` / `generation_mode` 的混用。

`drama` 是剧本内容类型，应归属 `content_mode`；`reference_video` 是生成来源/路径，应归属 `generation_mode`。本 PR 只调整 `compose-video` skill 相关表述和错误提示，不修改生成逻辑。

## 变更

- 将 `compose-video` skill 前置检查中的“剧本 `generation_mode` 为 drama”修正为“剧本 `content_mode` 为 drama”
- 更新 `compose_video.py` 的错误提示，同时输出 `content_mode` 和 `generation_mode`，方便排查模式配置问题
- 保持 `generate-video` 的 `reference_video` 判断语义为 `generation_mode == "reference_video"`

## 验证

- `python -m py_compile agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了视频编排脚本的模式检查逻辑
  * 改进了缺失必要元素时的错误提示信息，包含更详细的调试信息

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->