### PR TITLE
fix(windows): 修复创建项目崩溃 + 清理 POSIX-only 假设

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,29 @@ ConfigService（`service.py`）→ Repository（持久化 + 密钥脱敏）→ R
 API Key、后端选择、模型配置等通过 WebUI 配置页（`/settings`）管理。
 外部工具依赖：`ffmpeg`（视频拼接与后期处理）。
 
+## Windows 兼容性
+
+主要开发部署平台是 macOS / Linux，但 server 必须在 Windows 上能完成项目创建与基础流程。
+新写代码涉及文件系统、子进程、tmp 路径或权限时遵循：
+
+- **POSIX-only `os` 常量必须 guard**：`os.O_NOFOLLOW` / `os.O_DIRECT` 等在 Windows 上 `AttributeError`。
+  取值用 `getattr(os, "O_NOFOLLOW", 0)`，symlink/路径校验另在 Python 层做 `is_symlink()` 预检兜底。
+  例：`lib/profile_manifest.py::_project_lock`。
+- **`os.chmod(..., 0o600)` 仅 POSIX**：Windows 上只能控制只读位，无法限制其他用户访问。
+  写敏感文件（凭证 JSON、系统配置）时用 `if os.name == "posix":` guard 跳过，
+  Windows 凭证保护交给文件系统 ACL（用户级 `%LOCALAPPDATA%`）。
+- **文件 I/O 显式 `encoding="utf-8"`**：`open()` / `Path.read_text()` / `Path.write_text()` 必须传 `encoding`。
+  Windows 默认 cp936（zh-CN）/cp1252（en-US）解码会破坏 unicode 文本（含中文注释的 `.env`、UTF-8 配置等）。
+- **tmp 路径用 `tempfile.gettempdir()`**：不要硬编码 `/tmp` 或 `/private/tmp`。
+  Windows `%TEMP%`、macOS 默认 `/var/folders/.../T`、Linux `/tmp`，差异由 `tempfile` 抽象。
+  对 Claude SDK tmp 输出做匹配时同时列 `Path(tempfile.gettempdir()) / "claude-"` + POSIX 别名兜底。
+- **subprocess 用 `create_subprocess_exec`（list 形式）**：避免 `shell=True` + `/bin/sh`。
+  ffmpeg/ffprobe 必须先 `shutil.which()` 探测，缺失时降级（不硬失败）。
+- **Sandbox 在 Windows 上自动关闭**：`server/app.py::check_sandbox_available` 显式 fallback，
+  Bash 工具回退到 `_WINDOWS_BASH_PREFIX_WHITELIST` 代码白名单。生产部署推荐 WSL2。
+- **长路径**：profile sync 会落到 `{project}/.claude/skills/<name>/scripts/<file>.py` 等深层路径，
+  Windows 10 1607+ 需注册表 `LongPathsEnabled=1` 解除 MAX_PATH (260) 限制。
+
 ### 代码质量
 
 - **ruff**：line-length 120，提交前对修改的 Python 文件执行 `uv run ruff check <files> && uv run ruff format <files>`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,29 @@ ConfigService（`service.py`）→ Repository（持久化 + 密钥脱敏）→ R
 API Key、后端选择、模型配置等通过 WebUI 配置页（`/settings`）管理。
 外部工具依赖：`ffmpeg`（视频拼接与后期处理）。
 
+## Windows 兼容性
+
+主要开发部署平台是 macOS / Linux，但 server 必须在 Windows 上能完成项目创建与基础流程。
+新写代码涉及文件系统、子进程、tmp 路径或权限时遵循：
+
+- **POSIX-only `os` 常量必须 guard**：`os.O_NOFOLLOW` / `os.O_DIRECT` 等在 Windows 上 `AttributeError`。
+  取值用 `getattr(os, "O_NOFOLLOW", 0)`，symlink/路径校验另在 Python 层做 `is_symlink()` 预检兜底。
+  例：`lib/profile_manifest.py::_project_lock`。
+- **`os.chmod(..., 0o600)` 仅 POSIX**：Windows 上只能控制只读位，无法限制其他用户访问。
+  写敏感文件（凭证 JSON、系统配置）时用 `if os.name == "posix":` guard 跳过，
+  Windows 凭证保护交给文件系统 ACL（用户级 `%LOCALAPPDATA%`）。
+- **文件 I/O 显式 `encoding="utf-8"`**：`open()` / `Path.read_text()` / `Path.write_text()` 必须传 `encoding`。
+  Windows 默认 cp936（zh-CN）/cp1252（en-US）解码会破坏 unicode 文本（含中文注释的 `.env`、UTF-8 配置等）。
+- **tmp 路径用 `tempfile.gettempdir()`**：不要硬编码 `/tmp` 或 `/private/tmp`。
+  Windows `%TEMP%`、macOS 默认 `/var/folders/.../T`、Linux `/tmp`，差异由 `tempfile` 抽象。
+  对 Claude SDK tmp 输出做匹配时同时列 `Path(tempfile.gettempdir()) / "claude-"` + POSIX 别名兜底。
+- **subprocess 用 `create_subprocess_exec`（list 形式）**：避免 `shell=True` + `/bin/sh`。
+  ffmpeg/ffprobe 必须先 `shutil.which()` 探测，缺失时降级（不硬失败）。
+- **Sandbox 在 Windows 上自动关闭**：`server/app.py::check_sandbox_available` 显式 fallback，
+  Bash 工具回退到 `_WINDOWS_BASH_PREFIX_WHITELIST` 代码白名单。生产部署推荐 WSL2。
+- **长路径**：profile sync 会落到 `{project}/.claude/skills/<name>/scripts/<file>.py` 等深层路径，
+  Windows 10 1607+ 需注册表 `LongPathsEnabled=1` 解除 MAX_PATH (260) 限制。
+
 ### 代码质量
 
 - **ruff**：line-length 120，提交前对修改的 Python 文件执行 `uv run ruff check <files> && uv run ruff format <files>`

--- a/lib/image_backends/gemini.py
+++ b/lib/image_backends/gemini.py
@@ -68,7 +68,7 @@ class GeminiImageBackend:
             if credentials_file is None:
                 raise ValueError("未找到 Vertex AI 凭证文件")
 
-            with open(credentials_file) as f:
+            with open(credentials_file, encoding="utf-8") as f:
                 creds_data = json_module.load(f)
             project_id = creds_data.get("project_id")
 

--- a/lib/profile_manifest.py
+++ b/lib/profile_manifest.py
@@ -178,10 +178,18 @@ def _project_lock(project_dir: Path):
     文件。这里改用 ``os.open(O_CREAT|O_WRONLY|O_NOFOLLOW)`` 自己开 fd，确保
     symlink 形态的锁文件直接 ELOOP 拒绝；拿到真实 fd 后用 portalocker 的 lower-level
     ``lock()`` / ``unlink()`` 加锁，timeout 自轮询。
+
+    Windows 上 ``os`` 没有 ``O_NOFOLLOW``（POSIX 专属），改用 lstat 预检 +
+    无 flag 的 ``os.open`` 降级。Windows 创建 symlink 需要 SeCreateSymbolicLinkPrivilege
+    或开发者模式，攻击模型本就低；预检与 open 之间的 TOCTOU 窗口与 ArcReel
+    本地用户、portalocker 持锁的部署模型一致。
     """
     lock_path = project_dir / LOCK_FILENAME
+    if lock_path.is_symlink():
+        raise ValueError(f"lock path is a symlink, refusing: {lock_path}")
+    o_nofollow = getattr(os, "O_NOFOLLOW", 0)
     try:
-        fd = os.open(lock_path, os.O_CREAT | os.O_WRONLY | os.O_NOFOLLOW, 0o600)
+        fd = os.open(lock_path, os.O_CREAT | os.O_WRONLY | o_nofollow, 0o600)
     except OSError as e:
         if e.errno == errno.ELOOP:
             raise ValueError(f"lock path is a symlink, refusing: {lock_path}") from e

--- a/lib/system_config.py
+++ b/lib/system_config.py
@@ -291,15 +291,18 @@ class SystemConfigManager:
             tmp_path = Path(tmp.name)
 
         os.replace(tmp_path, self.paths.config_path)
-        try:
-            os.chmod(self.paths.config_path, 0o600)
-        except OSError as exc:
-            logger.debug(
-                "Unable to chmod %s to 0600: %s",
-                self.paths.config_path,
-                exc,
-                exc_info=True,
-            )
+        # chmod 0o600 在 Windows 上只会清/设只读位，无法限制其他用户访问；
+        # Windows 凭证文件权限交给文件系统 ACL（用户级 %LOCALAPPDATA%）兜底。
+        if os.name == "posix":
+            try:
+                os.chmod(self.paths.config_path, 0o600)
+            except OSError as exc:
+                logger.debug(
+                    "Unable to chmod %s to 0600: %s",
+                    self.paths.config_path,
+                    exc,
+                    exc_info=True,
+                )
 
     # ------------------------------------------------------------------
     # Public API

--- a/lib/text_backends/gemini.py
+++ b/lib/text_backends/gemini.py
@@ -50,7 +50,7 @@ class GeminiTextBackend:
             if credentials_file is None:
                 raise ValueError("未找到 Vertex AI 凭证文件\n请将服务账号 JSON 文件放入 vertex_keys/ 目录")
 
-            with open(credentials_file) as f:
+            with open(credentials_file, encoding="utf-8") as f:
                 creds_data = json_module.load(f)
             project_id = creds_data.get("project_id")
 

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -61,7 +61,7 @@ class GeminiVideoBackend:
             if credentials_file is None:
                 raise ValueError("未找到 Vertex AI 凭证文件")
 
-            with open(credentials_file) as f:
+            with open(credentials_file, encoding="utf-8") as f:
                 creds_data = json_module.load(f)
             self._project_id = creds_data.get("project_id")
 

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -1956,10 +1956,14 @@ class SessionManager:
             if resolved.is_relative_to(sdk_project_dir) and "tool-results" in resolved.parts:
                 return True, None
             # SDK 后台任务输出例外。tempfile.gettempdir() 覆盖跨平台 tmp 根
-            # （Linux ``/tmp``、macOS 默认 ``/var/folders/.../T``、Windows ``%TEMP%``），
-            # 显式列 ``/tmp`` 和 ``/private/tmp`` 兜底 macOS 上两种别名形态。
+            # （Linux ``/tmp``、macOS 默认 ``/var/folders/.../T``、Windows ``%TEMP%``）。
+            # ``resolved`` 已 ``.resolve()`` 过：macOS 上 ``/var`` 是 ``/private/var``
+            # 的 symlink，``/tmp`` 是 ``/private/tmp``，两侧都要列出原始 + resolve 形态
+            # 避免 startswith 因别名失配。
+            _tempdir = Path(tempfile.gettempdir())
             _sdk_tmp_prefixes = (
-                str(Path(tempfile.gettempdir()) / "claude-"),
+                str(_tempdir / "claude-"),
+                str(_tempdir.resolve() / "claude-"),
                 "/tmp/claude-",
                 "/private/tmp/claude-",
             )

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import shlex
+import tempfile
 import time
 from collections.abc import AsyncIterable, Callable
 from dataclasses import dataclass, field
@@ -1954,9 +1955,15 @@ class SessionManager:
             sdk_project_dir = self._CLAUDE_PROJECTS_DIR / encoded
             if resolved.is_relative_to(sdk_project_dir) and "tool-results" in resolved.parts:
                 return True, None
-            # SDK 后台任务输出例外
-            _SDK_TMP_PREFIXES = ("/tmp/claude-", "/private/tmp/claude-")
-            if str(resolved).startswith(_SDK_TMP_PREFIXES) and "tasks" in resolved.parts:
+            # SDK 后台任务输出例外。tempfile.gettempdir() 覆盖跨平台 tmp 根
+            # （Linux ``/tmp``、macOS 默认 ``/var/folders/.../T``、Windows ``%TEMP%``），
+            # 显式列 ``/tmp`` 和 ``/private/tmp`` 兜底 macOS 上两种别名形态。
+            _sdk_tmp_prefixes = (
+                str(Path(tempfile.gettempdir()) / "claude-"),
+                "/tmp/claude-",
+                "/private/tmp/claude-",
+            )
+            if str(resolved).startswith(_sdk_tmp_prefixes) and "tasks" in resolved.parts:
                 return True, None
             # projects_root 下：当前项目以外的子目录拒，根直放文件放行
             projects_root = self.projects_root

--- a/server/auth.py
+++ b/server/auth.py
@@ -232,7 +232,7 @@ def ensure_auth_password(env_path: str | None = None) -> str:
     env_file = Path(env_path)
     try:
         if env_file.exists():
-            lines = env_file.read_text().splitlines()
+            lines = env_file.read_text(encoding="utf-8").splitlines()
             new_lines = []
             found = False
             for line in lines:
@@ -245,12 +245,12 @@ def ensure_auth_password(env_path: str | None = None) -> str:
                 new_lines.append(f"AUTH_PASSWORD={password}")
             new_content = "\n".join(new_lines) + "\n"
             # 使用原地写入（truncate + write）保留 inode，兼容 Docker bind mount
-            with open(env_file, "r+") as f:
+            with open(env_file, "r+", encoding="utf-8") as f:
                 f.seek(0)
                 f.write(new_content)
                 f.truncate()
         else:
-            env_file.write_text(f"AUTH_PASSWORD={password}\n")
+            env_file.write_text(f"AUTH_PASSWORD={password}\n", encoding="utf-8")
     except OSError:
         logger.warning("无法写入 .env 文件: %s", env_path)
 

--- a/server/auth.py
+++ b/server/auth.py
@@ -232,7 +232,18 @@ def ensure_auth_password(env_path: str | None = None) -> str:
     env_file = Path(env_path)
     try:
         if env_file.exists():
-            lines = env_file.read_text(encoding="utf-8").splitlines()
+            try:
+                lines = env_file.read_text(encoding="utf-8").splitlines()
+            except UnicodeDecodeError:
+                # 历史 .env 可能用 cp936 / ANSI 等本地编码（早期 Windows 用户写过中文注释/值）；
+                # 不强制覆写以免丢失用户内容，仅 log 并跳过自动回写。
+                # 进程内 password 已 set 到 os.environ，本次启动仍可用，只是不持久化。
+                logger.warning(
+                    "无法以 UTF-8 解码 %s，跳过 AUTH_PASSWORD 自动回写；"
+                    "请将该文件转存为 UTF-8 后重启以持久化生成的密码",
+                    env_path,
+                )
+                return password
             new_lines = []
             found = False
             for line in lines:

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -456,15 +456,19 @@ async def upload_vertex_credential(
     dest.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = dest.with_suffix(".tmp")
     tmp_path.write_bytes(contents)
-    try:
-        os.chmod(tmp_path, 0o600)
-    except OSError:
-        logger.warning("无法设置临时凭证文件权限: %s", tmp_path, exc_info=True)
+    # chmod 0o600 在 Windows 上只控制只读位，无法限制其他用户访问；
+    # Windows 上凭证保护交给文件系统 ACL（用户级 %LOCALAPPDATA%）。
+    if os.name == "posix":
+        try:
+            os.chmod(tmp_path, 0o600)
+        except OSError:
+            logger.warning("无法设置临时凭证文件权限: %s", tmp_path, exc_info=True)
     os.replace(tmp_path, dest)
-    try:
-        os.chmod(dest, 0o600)
-    except OSError:
-        logger.warning("无法设置凭证文件权限: %s", dest, exc_info=True)
+    if os.name == "posix":
+        try:
+            os.chmod(dest, 0o600)
+        except OSError:
+            logger.warning("无法设置凭证文件权限: %s", dest, exc_info=True)
 
     await repo.update(cred.id, credentials_path=str(dest))
     await session.commit()
@@ -512,7 +516,7 @@ def _test_gemini_vertex(config: dict[str, str], _t: Callable[..., str]) -> Conne
             message=_t("file_not_found", path=credentials_path),
         )
 
-    with open(credentials_path) as f:
+    with open(credentials_path, encoding="utf-8") as f:
         creds_data = json.load(f)
 
     project_id = creds_data.get("project_id")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -175,6 +175,23 @@ class TestEnsureAuthPassword:
             assert len(password) == 16
             assert password.isalnum()
 
+    def test_env_file_non_utf8_does_not_block_startup(self, tmp_path):
+        """历史 .env 用 cp936 / ANSI 等本地编码时，``read_text(encoding="utf-8")``
+        会抛 ``UnicodeDecodeError``。该函数被 server lifespan 启动期调用，必须捕获
+        并降级（不持久化、保留进程内密码），否则服务无法启动。
+        """
+        env_file = tmp_path / ".env"
+        # cp936 编码的中文注释 + 现有 AUTH_PASSWORD，UTF-8 解码必失败
+        env_file.write_bytes("# 注释\nAUTH_PASSWORD=old\n".encode("cp936"))
+        env = os.environ.copy()
+        env.pop("AUTH_PASSWORD", None)
+        with patch.dict(os.environ, env, clear=True):
+            password = auth_module.ensure_auth_password(env_path=str(env_file))
+            assert len(password) == 16
+            assert password.isalnum()
+            # .env 内容未被破坏（不强制覆写避免丢用户内容）
+            assert env_file.read_bytes() == "# 注释\nAUTH_PASSWORD=old\n".encode("cp936")
+
 
 class TestDownloadToken:
     def setup_method(self):

--- a/tests/test_project_manager_symlink.py
+++ b/tests/test_project_manager_symlink.py
@@ -499,6 +499,36 @@ class TestForceResync:
 
         assert outside.read_text() == "MUST NOT be truncated"
 
+    def test_sync_works_without_o_nofollow(self, env, monkeypatch: pytest.MonkeyPatch):
+        """Windows 上 ``os`` 模块没有 ``O_NOFOLLOW`` 常量。锁实现必须能降级到
+        Python 层 ``is_symlink`` 预检，否则进程在 ``_project_lock`` 入口就会因
+        ``AttributeError: module 'os' has no attribute 'O_NOFOLLOW'`` 直接崩，
+        Windows 用户无法创建项目。
+        """
+        pm, _, project_dir = env
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+
+        stats = pm.sync_agent_profile(project_dir)
+
+        assert stats["created"] >= 1
+        assert (project_dir / "CLAUDE.md").exists()
+
+    def test_sync_refuses_symlink_lock_without_o_nofollow(self, env, monkeypatch: pytest.MonkeyPatch):
+        """Windows 降级路径下仍须拒绝 symlink 形态的锁文件，不能因没有
+        ``O_NOFOLLOW`` 就放弃 symlink 防护。
+        """
+        pm, _, project_dir = env
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+        outside = project_dir.parent.parent / "outside_lock_target_win.txt"
+        outside.write_text("MUST NOT be truncated")
+        lock_link = project_dir / ".profile_sync.lock"
+        lock_link.symlink_to(outside)
+
+        with pytest.raises(ValueError, match="lock path is a symlink"):
+            pm.sync_agent_profile(project_dir)
+
+        assert outside.read_text() == "MUST NOT be truncated"
+
     def test_save_manifest_tmp_uses_unpredictable_name(self, tmp_path: Path):
         """``save_manifest`` 不能用 ``.arcreel_profile_manifest.json.tmp`` 这种
         predictable 名字，否则攻击者预置同名 symlink → ``/etc/x`` 时 tmp.write


### PR DESCRIPTION
## Summary

- **P0 修复**：`lib/profile_manifest.py::_project_lock` 直接引用 `os.O_NOFOLLOW`，POSIX 专属常量在 Windows 抛 `AttributeError`，阻塞所有项目创建。降级方案：`getattr(os, "O_NOFOLLOW", 0)` + Python 层 `is_symlink()` 预检（POSIX 保留内核原子防御，Windows 走预检）。
- **顺手盘点**：`os.chmod(0o600)` 三处加 `os.name == "posix"` guard；`_SDK_TMP_PREFIXES` 用 `tempfile.gettempdir()` 替换硬编码 `/tmp`；5 处 `open()` / `read_text` / `write_text` 补 `encoding="utf-8"`。
- **文档**：CLAUDE.md / AGENTS.md 新增 "Windows 兼容性" 章节，7 条规则覆盖 POSIX-only `os` 常量 / chmod / 文件编码 / tmp 路径 / subprocess / sandbox fallback / 长路径。

## 已知残余风险（功能不完全一致，对 ArcReel 攻击模型够用）

- Windows 上 `O_NOFOLLOW` 降级到 Python 预检存在微秒级 TOCTOU 窗口（POSIX 是内核原子）。Windows 创建 symlink 需特权，攻击模型本就低。
- `chmod` 跳过后凭证保护依赖 `%LOCALAPPDATA%` NTFS ACL，多用户/域环境下管理员可读。
- Claude Agent SDK 在 Windows 上实际 tmp 路径未验证（假设走 `tempfile.gettempdir()`）。

## Test plan

- [x] `tests/test_project_manager_symlink.py` 新增两条 case：`monkeypatch.delattr(os, "O_NOFOLLOW")` 模拟 Windows，验证 sync 不崩 + symlink 锁仍被拒
- [x] 50 个 symlink 测试全绿；575 个相关回归测试全绿
- [x] ruff check + format clean；basedpyright 0 errors（pre-existing warnings 无关）
- [ ] Windows 真机 / GitHub Actions Windows job 实测（建议作为后续 PR）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 新增并扩展面向 Windows 的兼容性指南，涵盖跨平台文件操作、编码、临时路径、子进程与降级策略等实践。

* **Bug 修复**
  * 加强锁文件安全与跨平台行为，避免符号链接误用。
  * 统一凭证与配置文件以 UTF-8 读取/写入，改进临时目录识别与权限处理；仅在 POSIX 上应用 chmod。

* **测试**
  * 新增针对锁文件符号链接与非 UTF-8 环境的回归测试。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->