### PR TITLE
ci: 完善覆盖率上传、并发控制与镜像安全扫描

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -74,19 +74,13 @@ component_management:
         - server/**
       flag_regexes:
         - backend
+        - postgres
     - component_id: frontend
       name: Frontend
       paths:
         - frontend/src/**
       flag_regexes:
         - frontend
-    - component_id: postgres
-      name: Postgres compat
-      paths:
-        - lib/**
-        - server/**
-      flag_regexes:
-        - postgres
 
 comment:
   layout: "header, diff, flags, components, files"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,85 @@
+coverage:
+  status:
+    project:
+      backend:
+        flags:
+          - backend
+        target: 80%
+        threshold: 1%
+        if_ci_failed: error
+      frontend:
+        flags:
+          - frontend
+        target: 60%
+        threshold: 1%
+        if_ci_failed: error
+      postgres:
+        flags:
+          - postgres
+        target: 40%
+        threshold: 5%
+        if_ci_failed: error
+        informational: true
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        if_ci_failed: error
+
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: backend
+      paths:
+        - lib/
+        - server/
+      carryforward: true
+    - name: frontend
+      paths:
+        - frontend/src/
+      carryforward: true
+    - name: postgres
+      paths:
+        - lib/
+        - server/
+      carryforward: true
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+  individual_components:
+    - component_id: backend
+      name: Backend
+      paths:
+        - lib/**
+        - server/**
+      flag_regexes:
+        - backend
+    - component_id: frontend
+      name: Frontend
+      paths:
+        - frontend/src/**
+      flag_regexes:
+        - frontend
+    - component_id: postgres
+      name: Postgres compat
+      paths:
+        - lib/**
+        - server/**
+      flag_regexes:
+        - postgres
+
+comment:
+  layout: "header, diff, flags, components, files"
+  behavior: default
+  require_changes: true
+
+ignore:
+  - "alembic/versions/**"
+  - "**/__mocks__/**"
+  - "tests/**"
+  - "scripts/**"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -32,17 +32,17 @@ flag_management:
   individual_flags:
     - name: backend
       paths:
-        - lib/
-        - server/
+        - lib/**
+        - server/**
       carryforward: true
     - name: frontend
       paths:
-        - frontend/src/
+        - frontend/src/**
       carryforward: true
     - name: postgres
       paths:
-        - lib/
-        - server/
+        - lib/**
+        - server/**
       carryforward: true
 
 component_management:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,10 +21,25 @@ coverage:
         if_ci_failed: error
         informational: true
     patch:
-      default:
-        target: 70%
+      backend:
+        flags:
+          - backend
+        target: 80%
+        threshold: 1%
+        if_ci_failed: error
+      frontend:
+        flags:
+          - frontend
+        target: 60%
+        threshold: 1%
+        if_ci_failed: error
+      postgres:
+        flags:
+          - postgres
+        target: 40%
         threshold: 5%
         if_ci_failed: error
+        informational: true
 
 flag_management:
   default_rules:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  workflow_dispatch:
 
 permissions:
   contents: write
   packages: write
+  security-events: write
 
 env:
   REGISTRY: ghcr.io
@@ -41,7 +43,37 @@ jobs:
 
       - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/build-push-action@v7
+      - name: Build amd64 image for security scan
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan-${{ github.sha }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "0"
+
+      - name: Upload Trivy SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-image
+
+      - name: Build & push multi-arch image
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,7 +54,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db
         with:
@@ -66,7 +66,7 @@ jobs:
           exit-code: "0"
 
       - name: Upload Trivy SARIF
-        if: always()
+        if: always() && hashFiles('trivy-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ on:
       - "LICENSE"
 
 concurrency:
-  group: ci-tests-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,32 @@ name: Tests
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "README*.md"
+      - "CHANGELOG.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
+      - "LICENSE"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "README*.md"
+      - "CHANGELOG.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
+      - "LICENSE"
+
+concurrency:
+  group: ci-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   backend-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
 
@@ -45,7 +66,7 @@ jobs:
     # SQLite/PostgreSQL 方言兼容性闸门：alembic 三步闭环（upgrade/downgrade/idempotent）
     # + 所有 DB-touching 测试（marker 驱动）跑在 PG16 上。
     runs-on: ubuntu-latest
-    needs: backend-tests
+    timeout-minutes: 25
     services:
       postgres:
         image: postgres:16
@@ -99,6 +120,7 @@ jobs:
 
   frontend-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -116,10 +138,6 @@ jobs:
         working-directory: frontend
         run: pnpm install --frozen-lockfile
 
-      - name: Type check
-        working-directory: frontend
-        run: pnpm typecheck
-
       - name: Lint
         working-directory: frontend
         run: pnpm lint
@@ -128,6 +146,13 @@ jobs:
         working-directory: frontend
         run: pnpm build
 
-      - name: Run tests
+      - name: Run tests with coverage
         working-directory: frontend
         run: pnpm test:coverage
+
+      - name: Upload frontend coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: frontend/coverage/lcov.info
+          flags: frontend
+          fail_ci_if_error: false

--- a/README.en.md
+++ b/README.en.md
@@ -23,6 +23,9 @@
   <a href="https://github.com/ArcReel/ArcReel"><img src="https://img.shields.io/github/stars/ArcReel/ArcReel?style=for-the-badge" alt="Stars"></a>
   <a href="https://github.com/ArcReel/ArcReel/pkgs/container/arcreel"><img src="https://img.shields.io/badge/Docker-ghcr.io-blue?style=for-the-badge&logo=docker" alt="Docker"></a>
   <a href="https://github.com/ArcReel/ArcReel/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/ArcReel/ArcReel/test.yml?style=for-the-badge&label=Tests" alt="Tests"></a>
+  <a href="https://codecov.io/gh/ArcReel/ArcReel"><img src="https://img.shields.io/codecov/c/github/ArcReel/ArcReel?style=for-the-badge&label=Coverage" alt="Coverage"></a>
+  <a href="https://github.com/ArcReel/ArcReel/security/code-scanning"><img src="https://img.shields.io/github/actions/workflow/status/ArcReel/ArcReel/codeql.yml?style=for-the-badge&label=CodeQL" alt="CodeQL"></a>
+  <a href="https://github.com/ArcReel/ArcReel/releases/latest"><img src="https://img.shields.io/github/v/release/ArcReel/ArcReel?style=for-the-badge&label=Release" alt="Release"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@
   <a href="https://github.com/ArcReel/ArcReel"><img src="https://img.shields.io/github/stars/ArcReel/ArcReel?style=for-the-badge" alt="Stars"></a>
   <a href="https://github.com/ArcReel/ArcReel/pkgs/container/arcreel"><img src="https://img.shields.io/badge/Docker-ghcr.io-blue?style=for-the-badge&logo=docker" alt="Docker"></a>
   <a href="https://github.com/ArcReel/ArcReel/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/ArcReel/ArcReel/test.yml?style=for-the-badge&label=Tests" alt="Tests"></a>
+  <a href="https://codecov.io/gh/ArcReel/ArcReel"><img src="https://img.shields.io/codecov/c/github/ArcReel/ArcReel?style=for-the-badge&label=Coverage" alt="Coverage"></a>
+  <a href="https://github.com/ArcReel/ArcReel/security/code-scanning"><img src="https://img.shields.io/github/actions/workflow/status/ArcReel/ArcReel/codeql.yml?style=for-the-badge&label=CodeQL" alt="CodeQL"></a>
+  <a href="https://github.com/ArcReel/ArcReel/releases/latest"><img src="https://img.shields.io/github/v/release/ArcReel/ArcReel?style=for-the-badge&label=Release" alt="Release"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- **覆盖率全链路接入 Codecov**：frontend-tests 新增 `codecov-action@v5` 上传（`frontend/coverage/lcov.info`，flag=frontend）；新建 `.codecov.yml` 锁定三个 flag 的 project target（backend 80% / frontend 60% / postgres 40% informational）与 **per-flag patch target**（backend 80% / frontend 60% / postgres 40% informational，threshold 1%，与 project 对齐——AI 协作下新代码不应低于历史均线），按 `paths` 做 component 分组（Backend / Frontend 两个组件，Backend 同时挂 `[backend, postgres]` 两个 flag_regexes），`comment.require_changes: true` 避免无 delta 时刷 PR 评论。
- **CI 流程优化**：所有 workflow 加 `concurrency` group（PR 上取消旧 run，main push 不取消以免污染基线）；`paths-ignore` 跳过纯文档改动；`postgres-compat` 去掉 `needs: backend-tests` 改为与 backend-tests 并行（两者跑不同测试集合，串行无意义）；frontend 删掉单独的 `Type check`（已被 `pnpm build` 内含）；三个 job 加 `timeout-minutes`。
- **Docker 镜像安全扫描**：`docker.yml` 新增 Trivy 扫 CRITICAL/HIGH → 上传 SARIF 到 GitHub Security (`category: trivy-image`)。流程拆为「单 arch `load=true` 本地构建 → Trivy 扫 → multi-arch push 到 ghcr」，BuildKit 缓存复用，墙钟开销小；`exit-code: "0"` 不阻断发布，结果送到 Security tab 由 oncall 跟进。`TRIVY_DB_REPOSITORY` 走 `ghcr.io/aquasecurity/trivy-db` 避开 docker.io 限速；Trivy action 钉 `v0.36.0`（旧的非 `v` 前缀 tag 在 2026-03 供应链事件后已删除）。SARIF 上传步骤加 `hashFiles('trivy-results.sarif') != ''` 守卫，避免 Trivy 异常未生成报告时步骤误报错。`permissions` 增加 `security-events: write`；新增 `workflow_dispatch:` 触发入口便于手动验证（不污染 Releases 页）。
- **README badges**：在 Tests badge 后追加 Coverage / CodeQL / Release 三个 shields.io badge，自动从 GitHub API + Codecov API 拉数据，无需 PR-bot 写回 README；中英双 README 同步。

## Test plan

- [ ] 合并到 main 前在该 PR 上观察 backend-tests / postgres-compat / frontend-tests 三个 job **并行**起跑（之前 postgres-compat 串行等 backend）
- [ ] Codecov PR 评论里同时出现 backend、frontend、postgres 三个 flag 的 delta
- [ ] 在同一 PR 上快速连推两个 commit，确认第一次 run 被 cancel（PR 才取消，main push 不取消）
- [ ] 合并后从 GitHub Actions UI 用 `workflow_dispatch` 手动跑一次 Docker，确认：
  - Trivy 步骤成功，SARIF 上传完成
  - GitHub Security → Code scanning alerts → category `trivy-image` 出现条目
  - 镜像被推送到 ghcr 且 multi-arch manifest 完整（`docker manifest inspect ghcr.io/arcreel/arcreel:sha-<sha>`）
- [ ] README 的 Coverage badge 在首次 Codecov 上传后 5–10 分钟内变绿（非 "unknown"）
