### PR TITLE
feat(ark): 火山方舟支持 Agent Plan 和 Coding Plan 端点

### DIFF
--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1217,8 +1217,4 @@ export default {
   'diagnosis_rate_limited': 'Rate limited. Try again later.',
   'diagnosis_network': 'Network unreachable. Check URL and firewall.',
   'diagnosis_unknown': 'Unknown error. See raw response.',
-  'preset_notes_deepseek': 'DeepSeek official Anthropic-compat endpoint; needs sk- prefixed key.',
-  'preset_notes_xiaomi_mimo': 'Xiaomi MiMo only accepts known model names; no public model list.',
-  'preset_notes_ark_coding_plan': 'Volcengine Ark Coding Plan',
-  'preset_notes_ark_agent_plan': 'Volcengine Ark Agent Plan',
 };

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1219,4 +1219,6 @@ export default {
   'diagnosis_unknown': 'Unknown error. See raw response.',
   'preset_notes_deepseek': 'DeepSeek official Anthropic-compat endpoint; needs sk- prefixed key.',
   'preset_notes_xiaomi_mimo': 'Xiaomi MiMo only accepts known model names; no public model list.',
+  'preset_notes_ark_coding_plan': 'Volcengine Ark Coding Plan',
+  'preset_notes_ark_agent_plan': 'Volcengine Ark Agent Plan',
 };

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1216,4 +1216,6 @@ export default {
   'diagnosis_unknown': 'Lỗi không xác định. Xem chi tiết bên dưới.',
   'preset_notes_deepseek': 'Endpoint Anthropic-compat chính thức của DeepSeek; cần API key sk-.',
   'preset_notes_xiaomi_mimo': 'Xiaomi MiMo chỉ chấp nhận tên model đã biết; không có danh sách model công khai.',
+  'preset_notes_ark_coding_plan': 'Gói Volcengine Ark Coding Plan',
+  'preset_notes_ark_agent_plan': 'Gói Volcengine Ark Agent Plan',
 } satisfies Record<keyof typeof enDashboard, string>;

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1214,8 +1214,4 @@ export default {
   'diagnosis_rate_limited': 'Đã vượt giới hạn tốc độ. Thử lại sau.',
   'diagnosis_network': 'Không thể truy cập mạng. Kiểm tra URL và tường lửa.',
   'diagnosis_unknown': 'Lỗi không xác định. Xem chi tiết bên dưới.',
-  'preset_notes_deepseek': 'Endpoint Anthropic-compat chính thức của DeepSeek; cần API key sk-.',
-  'preset_notes_xiaomi_mimo': 'Xiaomi MiMo chỉ chấp nhận tên model đã biết; không có danh sách model công khai.',
-  'preset_notes_ark_coding_plan': 'Gói Volcengine Ark Coding Plan',
-  'preset_notes_ark_agent_plan': 'Gói Volcengine Ark Agent Plan',
 } satisfies Record<keyof typeof enDashboard, string>;

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1218,8 +1218,4 @@ export default {
   'diagnosis_rate_limited': '触发限流，稍后重试',
   'diagnosis_network': '网络无法访问，检查 URL 与防火墙',
   'diagnosis_unknown': '未知错误，请查看原始错误信息',
-  'preset_notes_deepseek': 'DeepSeek 官方 anthropic 兼容端点，需 sk- 开头的 API Key',
-  'preset_notes_xiaomi_mimo': '小米 MiMo 仅支持已知模型名，未公开模型列表',
-  'preset_notes_ark_coding_plan': '火山方舟 Coding Plan 套餐',
-  'preset_notes_ark_agent_plan': '火山方舟 Agent Plan 套餐',
 } satisfies Record<keyof typeof enDashboard, string>;

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1220,4 +1220,6 @@ export default {
   'diagnosis_unknown': '未知错误，请查看原始错误信息',
   'preset_notes_deepseek': 'DeepSeek 官方 anthropic 兼容端点，需 sk- 开头的 API Key',
   'preset_notes_xiaomi_mimo': '小米 MiMo 仅支持已知模型名，未公开模型列表',
+  'preset_notes_ark_coding_plan': '火山方舟 Coding Plan 套餐',
+  'preset_notes_ark_agent_plan': '火山方舟 Agent Plan 套餐',
 } satisfies Record<keyof typeof enDashboard, string>;

--- a/lib/agent_provider_catalog.py
+++ b/lib/agent_provider_catalog.py
@@ -157,6 +157,34 @@ PRESET_PROVIDERS: dict[str, PresetProvider] = {
         api_key_pattern=r"^sk-[A-Za-z0-9]+$",
         is_recommended=False,
     ),
+    "ark-coding-plan": PresetProvider(
+        id="ark-coding-plan",
+        display_name="Volcengine Ark Coding Plan",
+        icon_key="Volcengine",
+        messages_url="https://ark.cn-beijing.volces.com/api/coding",
+        discovery_url="https://ark.cn-beijing.volces.com",
+        default_model="",
+        suggested_models=(),
+        docs_url="https://www.volcengine.com/docs/82379/1928262",
+        api_key_url="https://console.volcengine.com/ark",
+        notes_i18n_key="preset_notes_ark_coding_plan",
+        api_key_pattern=None,
+        is_recommended=False,
+    ),
+    "ark-agent-plan": PresetProvider(
+        id="ark-agent-plan",
+        display_name="Volcengine Ark Agent Plan",
+        icon_key="Volcengine",
+        messages_url="https://ark.cn-beijing.volces.com/api/plan",
+        discovery_url="https://ark.cn-beijing.volces.com",
+        default_model="",
+        suggested_models=(),
+        docs_url="https://www.volcengine.com/docs/82379/2375486",
+        api_key_url="https://console.volcengine.com/ark",
+        notes_i18n_key="preset_notes_ark_agent_plan",
+        api_key_pattern=None,
+        is_recommended=False,
+    ),
 }
 
 
@@ -171,6 +199,8 @@ PRESET_ORDER: tuple[str, ...] = (
     "glm-intl",
     "minimax-cn",
     "minimax-intl",
+    "ark-coding-plan",
+    "ark-agent-plan",
 )
 
 

--- a/lib/ark_shared.py
+++ b/lib/ark_shared.py
@@ -20,8 +20,9 @@ def resolve_ark_api_key(api_key: str | None = None) -> str:
     return api_key.strip()
 
 
-def create_ark_client(*, api_key: str | None = None):
-    """创建 Ark 客户端，统一校验 api_key 并构造。"""
+def create_ark_client(*, api_key: str | None = None, base_url: str | None = None):
+    """创建 Ark 客户端；base_url 缺省走 ARK_BASE_URL（即 /api/v3）。"""
     from volcenginesdkarkruntime import Ark
 
-    return Ark(base_url=ARK_BASE_URL, api_key=resolve_ark_api_key(api_key))
+    effective_base_url = base_url or ARK_BASE_URL
+    return Ark(base_url=effective_base_url, api_key=resolve_ark_api_key(api_key))

--- a/lib/config/anthropic_url.py
+++ b/lib/config/anthropic_url.py
@@ -7,6 +7,7 @@
 - /plan/anthropic         腾讯 LKEAP Token Plan
 - /coding/anthropic       腾讯 LKEAP Coding Plan
 - /api/coding             火山方舟 Coding Plan
+- /api/plan               火山方舟 Agent Plan
 
 而模型发现 /v1/models 总是在「子路径之前的根」下。
 本模块负责一次性派生这两个 root，下游 SDK / 模型发现各取所需。
@@ -32,7 +33,7 @@ _SUFFIX_PATTERNS: list[tuple[re.Pattern[str], int]] = [
     # /api/anthropic — discovery_root 保留 "/api"（4 字符）
     (re.compile(r"/api/anthropic/?$"), 4),
     # 其余已知子路径 — 整体剥掉（保留 0 字符）
-    (re.compile(r"/(?:apps/anthropic|plan/anthropic|coding/anthropic|api/coding|anthropic)/?$"), 0),
+    (re.compile(r"/(?:apps/anthropic|plan/anthropic|coding/anthropic|api/coding|api/plan|anthropic)/?$"), 0),
 ]
 
 

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from lib.ark_shared import ARK_BASE_URL
+
 
 @dataclass(frozen=True)
 class ModelInfo:
@@ -231,7 +233,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 resolutions=["480p", "720p", "1080p"],
             ),
         },
-        default_base_url="https://ark.cn-beijing.volces.com/api/v3",
+        default_base_url=ARK_BASE_URL,
     ),
     "ark-agent-plan": ProviderMeta(
         display_name="火山方舟 Agent Plan",

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -22,6 +22,7 @@ class ProviderMeta:
     optional_keys: list[str] = field(default_factory=list)
     secret_keys: list[str] = field(default_factory=list)
     models: dict[str, ModelInfo] = field(default_factory=dict)
+    default_base_url: str | None = None
 
     @property
     def media_types(self) -> list[str]:
@@ -230,6 +231,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 resolutions=["480p", "720p", "1080p"],
             ),
         },
+        default_base_url="https://ark.cn-beijing.volces.com/api/v3",
     ),
     "grok": ProviderMeta(
         display_name="Grok",

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -233,6 +233,93 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
         },
         default_base_url="https://ark.cn-beijing.volces.com/api/v3",
     ),
+    "ark-agent-plan": ProviderMeta(
+        display_name="火山方舟 Agent Plan",
+        description="火山方舟 Agent Plan 套餐，聚合豆包及多家主流大模型，覆盖文本、图片与视频生成。",
+        required_keys=["api_key"],
+        optional_keys=["video_max_workers", "image_max_workers"],
+        secret_keys=["api_key"],
+        models={
+            # --- text ---
+            "doubao-seed-2.0-mini": ModelInfo(
+                display_name="豆包 Seed 2.0 Mini",
+                media_type="text",
+                capabilities=["text_generation", "vision"],
+            ),
+            "doubao-seed-2.0-lite": ModelInfo(
+                display_name="豆包 Seed 2.0 Lite",
+                media_type="text",
+                capabilities=["text_generation", "vision"],
+                default=True,
+            ),
+            "doubao-seed-2.0-pro": ModelInfo(
+                display_name="豆包 Seed 2.0 Pro",
+                media_type="text",
+                capabilities=["text_generation", "vision"],
+            ),
+            "doubao-seed-2.0-code": ModelInfo(
+                display_name="豆包 Seed 2.0 Code",
+                media_type="text",
+                capabilities=["text_generation"],
+            ),
+            "deepseek-v4-flash": ModelInfo(
+                display_name="DeepSeek V4 Flash",
+                media_type="text",
+                capabilities=["text_generation"],
+            ),
+            "deepseek-v4-pro": ModelInfo(
+                display_name="DeepSeek V4 Pro",
+                media_type="text",
+                capabilities=["text_generation"],
+            ),
+            "glm-5.1": ModelInfo(
+                display_name="GLM 5.1",
+                media_type="text",
+                capabilities=["text_generation"],
+            ),
+            "kimi-k2.6": ModelInfo(
+                display_name="Kimi K2.6",
+                media_type="text",
+                capabilities=["text_generation"],
+            ),
+            "minimax-m2.7": ModelInfo(
+                display_name="MiniMax M2.7",
+                media_type="text",
+                capabilities=["text_generation"],
+            ),
+            # --- image ---
+            "doubao-seedream-5.0-lite": ModelInfo(
+                display_name="Seedream 5.0 Lite",
+                media_type="image",
+                capabilities=["text_to_image", "image_to_image"],
+                default=True,
+            ),
+            # --- video ---
+            "doubao-seedance-1.5-pro": ModelInfo(
+                display_name="Seedance 1.5 Pro",
+                media_type="video",
+                capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control", "flex_tier"],
+                supported_durations=list(range(4, 13)),
+                resolutions=["480p", "720p", "1080p"],
+            ),
+            "doubao-seedance-2.0": ModelInfo(
+                display_name="Seedance 2.0",
+                media_type="video",
+                capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control", "video_extend"],
+                supported_durations=list(range(4, 16)),
+                resolutions=["480p", "720p", "1080p"],
+            ),
+            "doubao-seedance-2.0-fast": ModelInfo(
+                display_name="Seedance 2.0 Fast",
+                media_type="video",
+                capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control", "video_extend"],
+                default=True,
+                supported_durations=list(range(4, 16)),
+                resolutions=["480p", "720p", "1080p"],
+            ),
+        },
+        default_base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
+    ),
     "grok": ProviderMeta(
         display_name="Grok",
         description="xAI Grok 模型，支持视频和图片生成。",

--- a/lib/i18n/en/providers.py
+++ b/lib/i18n/en/providers.py
@@ -5,6 +5,7 @@ MESSAGES: dict[str, str] = {
     "provider_name_gemini-aistudio": "AI Studio",
     "provider_name_gemini-vertex": "Vertex AI",
     "provider_name_ark": "Volcengine Ark",
+    "provider_name_ark-agent-plan": "Volcengine Ark Agent Plan",
     "provider_name_grok": "Grok",
     "provider_name_openai": "OpenAI",
     "provider_name_vidu": "Vidu",
@@ -12,10 +13,13 @@ MESSAGES: dict[str, str] = {
     "provider_desc_gemini-aistudio": "Google AI Studio provides Gemini models with image and video generation, ideal for rapid prototyping and personal projects.",
     "provider_desc_gemini-vertex": "Google Cloud Vertex AI enterprise platform supporting Gemini and Imagen models with higher quotas and audio generation.",
     "provider_desc_ark": "ByteDance Volcengine Ark AI platform supporting Seedance video generation and Seedream image generation, with audio and seed control.",
+    "provider_desc_ark-agent-plan": "Volcengine Ark Agent Plan aggregates Doubao and other major models for text, image and video generation.",
     "provider_desc_grok": "xAI Grok models supporting video and image generation.",
     "provider_desc_openai": "OpenAI platform supporting GPT-5.4 text, GPT Image and Sora video generation.",
     "provider_desc_vidu": "Shengshu Vidu video platform supporting text-to-video, image-to-video, first-last frame, reference-to-video and reference-to-image. Image and video only.",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "DeepSeek official Anthropic-compat endpoint; needs sk- prefixed key.",
     "preset_notes_xiaomi_mimo": "Xiaomi MiMo only accepts known model names; no public model list.",
+    "preset_notes_ark_coding_plan": "Volcengine Ark Coding Plan",
+    "preset_notes_ark_agent_plan": "Volcengine Ark Agent Plan",
 }

--- a/lib/i18n/vi/providers.py
+++ b/lib/i18n/vi/providers.py
@@ -5,6 +5,7 @@ MESSAGES: dict[str, str] = {
     "provider_name_gemini-aistudio": "AI Studio",
     "provider_name_gemini-vertex": "Vertex AI",
     "provider_name_ark": "Volcengine Ark",
+    "provider_name_ark-agent-plan": "Volcengine Ark Agent Plan",
     "provider_name_grok": "Grok",
     "provider_name_openai": "OpenAI",
     "provider_name_vidu": "Vidu",
@@ -12,10 +13,13 @@ MESSAGES: dict[str, str] = {
     "provider_desc_gemini-aistudio": "Google AI Studio cung cấp các mô hình Gemini hỗ trợ tạo ảnh và video, phù hợp cho việc dựng prototype nhanh và dự án cá nhân.",
     "provider_desc_gemini-vertex": "Nền tảng doanh nghiệp Vertex AI của Google Cloud hỗ trợ các mô hình Gemini và Imagen với hạn mức cao hơn cùng khả năng tạo âm thanh.",
     "provider_desc_ark": "Nền tảng AI Volcengine Ark của ByteDance hỗ trợ tạo video Seedance và tạo ảnh Seedream, kèm âm thanh và điều khiển seed.",
+    "provider_desc_ark-agent-plan": "Gói Volcengine Ark Agent Plan tổng hợp Doubao và nhiều mô hình lớn chủ lưu, bao gồm văn bản, ảnh và video.",
     "provider_desc_grok": "Các mô hình Grok của xAI hỗ trợ tạo video và tạo ảnh.",
     "provider_desc_openai": "Nền tảng OpenAI hỗ trợ văn bản GPT-5.4, GPT Image và tạo video Sora.",
     "provider_desc_vidu": "Nền tảng Vidu của Shengshu hỗ trợ tạo video từ văn bản, từ ảnh, khung đầu–cuối, video tham chiếu và ảnh tham chiếu. Chỉ hỗ trợ ảnh và video.",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "Endpoint Anthropic-compat chính thức của DeepSeek; cần API key sk-.",
     "preset_notes_xiaomi_mimo": "Xiaomi MiMo chỉ chấp nhận tên model đã biết; không có danh sách model công khai.",
+    "preset_notes_ark_coding_plan": "Gói Volcengine Ark Coding Plan",
+    "preset_notes_ark_agent_plan": "Gói Volcengine Ark Agent Plan",
 }

--- a/lib/i18n/zh/providers.py
+++ b/lib/i18n/zh/providers.py
@@ -5,6 +5,7 @@ MESSAGES: dict[str, str] = {
     "provider_name_gemini-aistudio": "AI Studio",
     "provider_name_gemini-vertex": "Vertex AI",
     "provider_name_ark": "火山方舟",
+    "provider_name_ark-agent-plan": "火山方舟 Agent Plan",
     "provider_name_grok": "Grok",
     "provider_name_openai": "OpenAI",
     "provider_name_vidu": "Vidu",
@@ -12,10 +13,13 @@ MESSAGES: dict[str, str] = {
     "provider_desc_gemini-aistudio": "Google AI Studio 提供 Gemini 系列模型，支持图片和视频生成，适合快速原型和个人项目。",
     "provider_desc_gemini-vertex": "Google Cloud Vertex AI 企业级平台，支持 Gemini 和 Imagen 模型，提供更高配额和音频生成能力。",
     "provider_desc_ark": "字节跳动火山方舟 AI 平台，支持 Seedance 视频生成和 Seedream 图片生成，具备音频生成和种子控制能力。",
+    "provider_desc_ark-agent-plan": "火山方舟 Agent Plan 套餐，聚合豆包及多家主流大模型，覆盖文本、图片与视频生成。",
     "provider_desc_grok": "xAI Grok 模型，支持视频和图片生成。",
     "provider_desc_openai": "OpenAI 官方平台，支持 GPT-5.4 文本、GPT Image 图片和 Sora 视频生成。",
     "provider_desc_vidu": "生数科技 Vidu 视频生成平台，支持文生视频、图生视频、首尾帧、参考生视频与参考生图，仅图片与视频能力。",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "DeepSeek 官方 Anthropic 兼容端点，需 sk- 开头的 API Key",
     "preset_notes_xiaomi_mimo": "小米 MiMo 仅支持已知模型名，未公开模型列表",
+    "preset_notes_ark_coding_plan": "火山方舟 Coding Plan 套餐",
+    "preset_notes_ark_agent_plan": "火山方舟 Agent Plan 套餐",
 }

--- a/lib/image_backends/__init__.py
+++ b/lib/image_backends/__init__.py
@@ -23,14 +23,14 @@ __all__ = [
 ]
 # Backend auto-registration
 from lib.image_backends.gemini import GeminiImageBackend
-from lib.providers import PROVIDER_ARK, PROVIDER_GEMINI
+from lib.providers import PROVIDER_ARK, PROVIDER_ARK_AGENT_PLAN, PROVIDER_GEMINI
 
 register_backend(PROVIDER_GEMINI, GeminiImageBackend)
 
 from lib.image_backends.ark import ArkImageBackend
 
 register_backend(PROVIDER_ARK, ArkImageBackend)
-register_backend("ark-agent-plan", ArkImageBackend)
+register_backend(PROVIDER_ARK_AGENT_PLAN, ArkImageBackend)
 
 from lib.image_backends.grok import GrokImageBackend
 from lib.providers import PROVIDER_GROK

--- a/lib/image_backends/__init__.py
+++ b/lib/image_backends/__init__.py
@@ -30,6 +30,7 @@ register_backend(PROVIDER_GEMINI, GeminiImageBackend)
 from lib.image_backends.ark import ArkImageBackend
 
 register_backend(PROVIDER_ARK, ArkImageBackend)
+register_backend("ark-agent-plan", ArkImageBackend)
 
 from lib.image_backends.grok import GrokImageBackend
 from lib.providers import PROVIDER_GROK

--- a/lib/image_backends/ark.py
+++ b/lib/image_backends/ark.py
@@ -70,8 +70,9 @@ class ArkImageBackend:
         *,
         api_key: str | None = None,
         model: str | None = None,
+        base_url: str | None = None,
     ):
-        self._client = create_ark_client(api_key=api_key)
+        self._client = create_ark_client(api_key=api_key, base_url=base_url)
         self._model = model or self.DEFAULT_MODEL
         self._capabilities: set[ImageCapability] = {
             ImageCapability.TEXT_TO_IMAGE,

--- a/lib/providers.py
+++ b/lib/providers.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 PROVIDER_GEMINI = "gemini"
 PROVIDER_ARK = "ark"
+PROVIDER_ARK_AGENT_PLAN = "ark-agent-plan"
 PROVIDER_GROK = "grok"
 PROVIDER_OPENAI = "openai"
 PROVIDER_VIDU = "vidu"

--- a/lib/text_backends/__init__.py
+++ b/lib/text_backends/__init__.py
@@ -32,6 +32,7 @@ from lib.providers import PROVIDER_ARK
 from lib.text_backends.ark import ArkTextBackend
 
 register_backend(PROVIDER_ARK, ArkTextBackend)
+register_backend("ark-agent-plan", ArkTextBackend)
 
 from lib.providers import PROVIDER_GROK
 from lib.text_backends.grok import GrokTextBackend

--- a/lib/text_backends/__init__.py
+++ b/lib/text_backends/__init__.py
@@ -28,11 +28,11 @@ from lib.text_backends.gemini import GeminiTextBackend
 
 register_backend(PROVIDER_GEMINI, GeminiTextBackend)
 
-from lib.providers import PROVIDER_ARK
+from lib.providers import PROVIDER_ARK, PROVIDER_ARK_AGENT_PLAN
 from lib.text_backends.ark import ArkTextBackend
 
 register_backend(PROVIDER_ARK, ArkTextBackend)
-register_backend("ark-agent-plan", ArkTextBackend)
+register_backend(PROVIDER_ARK_AGENT_PLAN, ArkTextBackend)
 
 from lib.providers import PROVIDER_GROK
 from lib.text_backends.grok import GrokTextBackend

--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -32,11 +32,12 @@ class ArkTextBackend:
         model: str | None = None,
         base_url: str | None = None,
     ):
-        self._client = create_ark_client(api_key=api_key, base_url=base_url)
         # Instructor 要求 openai.OpenAI 实例；Ark SDK client 类型不兼容，
         # 但 Ark API 是 OpenAI 兼容的，因此额外创建原生 OpenAI 客户端供降级使用。
+        resolved_key = resolve_ark_api_key(api_key)
         effective_base_url = base_url or ARK_BASE_URL
-        self._openai_client = OpenAI(base_url=effective_base_url, api_key=resolve_ark_api_key(api_key))
+        self._client = create_ark_client(api_key=resolved_key, base_url=effective_base_url)
+        self._openai_client = OpenAI(base_url=effective_base_url, api_key=resolved_key)
         self._model = model or DEFAULT_MODEL
         self._capabilities: set[TextCapability] = self._resolve_capabilities()
 
@@ -45,11 +46,16 @@ class ArkTextBackend:
         from lib.config.registry import PROVIDER_REGISTRY
 
         base = {TextCapability.TEXT_GENERATION, TextCapability.VISION}
-        provider_meta = PROVIDER_REGISTRY.get("ark")
-        if provider_meta:
+        # 同一 backend 类同时服务 ark 与 ark-agent-plan，模型 ID 命名格式不同，
+        # 任一 provider 命中即可解析 STRUCTURED_OUTPUT。
+        for provider_id in ("ark", "ark-agent-plan"):
+            provider_meta = PROVIDER_REGISTRY.get(provider_id)
+            if provider_meta is None:
+                continue
             model_info = provider_meta.models.get(self._model)
             if model_info and TextCapability.STRUCTURED_OUTPUT in model_info.capabilities:
                 base.add(TextCapability.STRUCTURED_OUTPUT)
+                break
         # 未注册模型不加 STRUCTURED_OUTPUT：宁可走 Instructor 降级也不调用会报错的原生 API
         return base
 

--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from openai import OpenAI
+
 from lib.ark_shared import ARK_BASE_URL, create_ark_client, resolve_ark_api_key
 from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_ARK
@@ -23,13 +25,18 @@ DEFAULT_MODEL = "doubao-seed-2-0-lite-260215"
 class ArkTextBackend:
     """Ark (火山方舟) 文本生成后端。"""
 
-    def __init__(self, *, api_key: str | None = None, model: str | None = None):
-        self._client = create_ark_client(api_key=api_key)
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+    ):
+        self._client = create_ark_client(api_key=api_key, base_url=base_url)
         # Instructor 要求 openai.OpenAI 实例；Ark SDK client 类型不兼容，
         # 但 Ark API 是 OpenAI 兼容的，因此额外创建原生 OpenAI 客户端供降级使用。
-        from openai import OpenAI
-
-        self._openai_client = OpenAI(base_url=ARK_BASE_URL, api_key=resolve_ark_api_key(api_key))
+        effective_base_url = base_url or ARK_BASE_URL
+        self._openai_client = OpenAI(base_url=effective_base_url, api_key=resolve_ark_api_key(api_key))
         self._model = model or DEFAULT_MODEL
         self._capabilities: set[TextCapability] = self._resolve_capabilities()
 

--- a/lib/text_backends/factory.py
+++ b/lib/text_backends/factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from lib.config.registry import PROVIDER_REGISTRY
 from lib.config.resolver import ConfigResolver
 from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.db import async_session_factory
@@ -13,6 +14,7 @@ PROVIDER_ID_TO_BACKEND: dict[str, str] = {
     "gemini-aistudio": "gemini",
     "gemini-vertex": "gemini",
     "ark": "ark",
+    "ark-agent-plan": "ark-agent-plan",
     "grok": "grok",
     "openai": "openai",
 }
@@ -79,7 +81,16 @@ async def create_text_backend_for_task(
         kwargs["gcs_bucket"] = provider_config.get("gcs_bucket")
     else:
         kwargs["api_key"] = provider_config.get("api_key")
+        user_base_url = provider_config.get("base_url")
         if provider_id in ("gemini-aistudio", PROVIDER_OPENAI):
-            kwargs["base_url"] = provider_config.get("base_url")
+            # 这两个允许用户填自定义 endpoint，没有 registry default。
+            kwargs["base_url"] = user_base_url
+        else:
+            # ark / ark-agent-plan 等：用户优先，缺省回落 ProviderMeta.default_base_url
+            # （与 server.services.generation_tasks._fill_simple_provider_kwargs 对称）。
+            meta = PROVIDER_REGISTRY.get(provider_id)
+            base_url = user_base_url or (meta.default_base_url if meta else None)
+            if base_url:
+                kwargs["base_url"] = base_url
 
     return create_backend(backend_name, **kwargs)

--- a/lib/video_backends/__init__.py
+++ b/lib/video_backends/__init__.py
@@ -1,6 +1,13 @@
 """视频生成服务层公共 API。"""
 
-from lib.providers import PROVIDER_ARK, PROVIDER_GEMINI, PROVIDER_GROK, PROVIDER_NEWAPI, PROVIDER_OPENAI
+from lib.providers import (
+    PROVIDER_ARK,
+    PROVIDER_ARK_AGENT_PLAN,
+    PROVIDER_GEMINI,
+    PROVIDER_GROK,
+    PROVIDER_NEWAPI,
+    PROVIDER_OPENAI,
+)
 from lib.video_backends.base import (
     VideoBackend,
     VideoCapability,
@@ -34,7 +41,7 @@ register_backend(PROVIDER_GEMINI, GeminiVideoBackend)
 from lib.video_backends.ark import ArkVideoBackend
 
 register_backend(PROVIDER_ARK, ArkVideoBackend)
-register_backend("ark-agent-plan", ArkVideoBackend)
+register_backend(PROVIDER_ARK_AGENT_PLAN, ArkVideoBackend)
 
 # Grok: xai-sdk
 from lib.video_backends.grok import GrokVideoBackend

--- a/lib/video_backends/__init__.py
+++ b/lib/video_backends/__init__.py
@@ -34,6 +34,7 @@ register_backend(PROVIDER_GEMINI, GeminiVideoBackend)
 from lib.video_backends.ark import ArkVideoBackend
 
 register_backend(PROVIDER_ARK, ArkVideoBackend)
+register_backend("ark-agent-plan", ArkVideoBackend)
 
 # Grok: xai-sdk
 from lib.video_backends.grok import GrokVideoBackend

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -30,19 +30,21 @@ class ArkVideoBackend:
 
     DEFAULT_MODEL = "doubao-seedance-1-5-pro-251215"
 
+    # Seedance 2.0 系列不接受 service_tier 参数；FLEX_TIER 必须从能力集中剔除，
+    # 否则 _create_task 会触发上游 400。ark 与 ark-agent-plan 各用不同的模型 ID
+    # 命名（dash + 日期戳 vs. dot 简洁版），两套都要纳入。
+    _SEEDANCE_2_BASE_CAPABILITIES: set[VideoCapability] = {
+        VideoCapability.TEXT_TO_VIDEO,
+        VideoCapability.IMAGE_TO_VIDEO,
+        VideoCapability.GENERATE_AUDIO,
+        VideoCapability.SEED_CONTROL,
+    }
+
     _MODEL_CAPABILITIES: dict[str, set[VideoCapability]] = {
-        "doubao-seedance-2-0-260128": {
-            VideoCapability.TEXT_TO_VIDEO,
-            VideoCapability.IMAGE_TO_VIDEO,
-            VideoCapability.GENERATE_AUDIO,
-            VideoCapability.SEED_CONTROL,
-        },
-        "doubao-seedance-2-0-fast-260128": {
-            VideoCapability.TEXT_TO_VIDEO,
-            VideoCapability.IMAGE_TO_VIDEO,
-            VideoCapability.GENERATE_AUDIO,
-            VideoCapability.SEED_CONTROL,
-        },
+        "doubao-seedance-2-0-260128": _SEEDANCE_2_BASE_CAPABILITIES,
+        "doubao-seedance-2-0-fast-260128": _SEEDANCE_2_BASE_CAPABILITIES,
+        "doubao-seedance-2.0": _SEEDANCE_2_BASE_CAPABILITIES,
+        "doubao-seedance-2.0-fast": _SEEDANCE_2_BASE_CAPABILITIES,
     }
 
     _DEFAULT_CAPABILITIES: set[VideoCapability] = {

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -58,8 +58,9 @@ class ArkVideoBackend:
         *,
         api_key: str | None = None,
         model: str | None = None,
+        base_url: str | None = None,
     ):
-        self._client = create_ark_client(api_key=api_key)
+        self._client = create_ark_client(api_key=api_key, base_url=base_url)
         self._model = model or self.DEFAULT_MODEL
         self._capabilities = self._MODEL_CAPABILITIES.get(self._model, self._DEFAULT_CAPABILITIES)
 

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -565,7 +565,7 @@ def _test_ark(config: dict[str, str], _t: Callable[..., str]) -> ConnectionTestR
     """通过 tasks.list 验证 Ark API Key。"""
     from lib.ark_shared import create_ark_client
 
-    client = create_ark_client(api_key=config["api_key"])
+    client = create_ark_client(api_key=config["api_key"], base_url=config.get("base_url"))
     # 轻量级调用验证连通性，不创建任何资源
     client.content_generation.tasks.list(page_size=1)
     return ConnectionTestResponse(
@@ -626,6 +626,7 @@ _TEST_DISPATCH: dict[str, Callable[[dict[str, str], Any], ConnectionTestResponse
     "gemini-aistudio": _test_gemini_aistudio,
     "gemini-vertex": _test_gemini_vertex,
     "ark": _test_ark,
+    "ark-agent-plan": _test_ark,
     "grok": _test_grok,
     "openai": _test_openai,
     "vidu": _test_vidu,
@@ -658,6 +659,13 @@ async def test_provider_connection(
     svc = ConfigService(session)
     config = await svc.get_provider_config(provider_id)
     cred.overlay_config(config)
+
+    # 与 generation_tasks._fill_simple_provider_kwargs 对称：用户未显式配 base_url
+    # 时，注入 ProviderMeta.default_base_url，使连接测试命中正确 endpoint。
+    if not config.get("base_url"):
+        meta = PROVIDER_REGISTRY.get(provider_id)
+        if meta and meta.default_base_url:
+            config["base_url"] = meta.default_base_url
 
     test_fn = _TEST_DISPATCH.get(provider_id)
     if test_fn is None:

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -261,9 +261,8 @@ async def _fill_simple_provider_kwargs(
     db_config = await resolver.provider_config(backend_name)
     kwargs["api_key"] = db_config.get("api_key")
     kwargs["model"] = effective_model
-    base_url = db_config.get("base_url") or (
-        PROVIDER_REGISTRY[backend_name].default_base_url if backend_name in PROVIDER_REGISTRY else None
-    )
+    meta = PROVIDER_REGISTRY.get(backend_name)
+    base_url = db_config.get("base_url") or (meta.default_base_url if meta else None)
     if base_url:
         kwargs["base_url"] = base_url
 

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -252,11 +252,19 @@ async def _fill_simple_provider_kwargs(
     kwargs: dict,
     effective_model: str | None,
 ) -> None:
-    """Ark/Grok/OpenAI 等简单供应商的通用配置填充。"""
+    """Ark/Grok/OpenAI 等简单供应商的通用配置填充。
+
+    base_url 优先级：用户在 DB 配置中显式填写 > ProviderMeta.default_base_url > 不传。
+    """
+    from lib.config.registry import PROVIDER_REGISTRY
+
     db_config = await resolver.provider_config(backend_name)
     kwargs["api_key"] = db_config.get("api_key")
     kwargs["model"] = effective_model
-    if base_url := db_config.get("base_url"):
+    base_url = db_config.get("base_url") or (
+        PROVIDER_REGISTRY[backend_name].default_base_url if backend_name in PROVIDER_REGISTRY else None
+    )
+    if base_url:
         kwargs["base_url"] = base_url
 
 

--- a/tests/test_agent_provider_catalog.py
+++ b/tests/test_agent_provider_catalog.py
@@ -52,7 +52,7 @@ def test_messages_url_https_only() -> None:
 
 
 def test_curated_preset_set() -> None:
-    """目录与用户提供的表格保持一致;9 条预设."""
+    """目录与用户提供的表格保持一致;11 条预设."""
     expected = {
         "anthropic-official",
         "arcreel",
@@ -63,6 +63,8 @@ def test_curated_preset_set() -> None:
         "minimax-cn",
         "minimax-intl",
         "kimi",
+        "ark-coding-plan",
+        "ark-agent-plan",
     }
     actual = {p.id for p in list_presets()}
     assert actual == expected
@@ -80,6 +82,8 @@ def test_default_models_match_table() -> None:
         "minimax-cn": "MiniMax-M2.7",
         "minimax-intl": "MiniMax-M2.7",
         "kimi": "",
+        "ark-coding-plan": "",
+        "ark-agent-plan": "",
     }
     actual = {p.id: p.default_model for p in list_presets()}
     assert actual == expected

--- a/tests/test_anthropic_url.py
+++ b/tests/test_anthropic_url.py
@@ -59,6 +59,15 @@ from lib.config.anthropic_url import AnthropicEndpoints, derive_anthropic_endpoi
                 True,
             ),
         ),
+        # /api/plan (火山方舟 Agent Plan)
+        (
+            "https://ark.cn-beijing.volces.com/api/plan",
+            AnthropicEndpoints(
+                "https://ark.cn-beijing.volces.com/api/plan",
+                "https://ark.cn-beijing.volces.com",
+                True,
+            ),
+        ),
         # 用户误带 /v1
         (
             "https://api.deepseek.com/anthropic/v1",

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -2,7 +2,15 @@ from lib.config.registry import PROVIDER_REGISTRY, ModelInfo, ProviderMeta
 
 
 def test_all_providers_registered():
-    assert set(PROVIDER_REGISTRY.keys()) == {"gemini-aistudio", "gemini-vertex", "ark", "grok", "openai", "vidu"}
+    assert set(PROVIDER_REGISTRY.keys()) == {
+        "gemini-aistudio",
+        "gemini-vertex",
+        "ark",
+        "ark-agent-plan",
+        "grok",
+        "openai",
+        "vidu",
+    }
 
 
 def test_provider_meta_fields():

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -505,3 +505,32 @@ class TestGetAspectRatio:
         project = {"aspect_ratio": "9:16"}
         assert generation_tasks.get_aspect_ratio(project, "scenes") == "16:9"
         assert generation_tasks.get_aspect_ratio(project, "props") == "16:9"
+
+
+class TestFillSimpleProviderKwargs:
+    """_fill_simple_provider_kwargs 应优先用户 base_url，缺省回落 ProviderMeta.default_base_url。"""
+
+    class _FakeResolver:
+        def __init__(self, config: dict):
+            self._config = config
+
+        async def provider_config(self, name: str) -> dict:
+            return self._config
+
+    async def test_uses_default_base_url_when_user_unset(self):
+        resolver = self._FakeResolver({"api_key": "sk-test"})
+        kwargs: dict = {}
+        await generation_tasks._fill_simple_provider_kwargs("ark", resolver, kwargs, "doubao-seed-2-0-pro-260215")
+        assert kwargs["base_url"] == "https://ark.cn-beijing.volces.com/api/v3"
+
+    async def test_user_base_url_wins(self):
+        resolver = self._FakeResolver({"api_key": "sk-test", "base_url": "https://custom.example.com/v3"})
+        kwargs: dict = {}
+        await generation_tasks._fill_simple_provider_kwargs("ark", resolver, kwargs, "model-x")
+        assert kwargs["base_url"] == "https://custom.example.com/v3"
+
+    async def test_no_default_no_user_no_kwarg(self):
+        resolver = self._FakeResolver({"api_key": "sk-test"})
+        kwargs: dict = {}
+        await generation_tasks._fill_simple_provider_kwargs("grok", resolver, kwargs, "m")
+        assert "base_url" not in kwargs

--- a/tests/test_image_backends/test_ark.py
+++ b/tests/test_image_backends/test_ark.py
@@ -71,7 +71,18 @@ class TestArkImageBackendInit:
             from lib.image_backends.ark import ArkImageBackend
 
             ArkImageBackend(api_key="my-key")
-            mock_create.assert_called_once_with(api_key="my-key")
+            mock_create.assert_called_once_with(api_key="my-key", base_url=None)
+
+    def test_custom_base_url_passed_through(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ARK_API_KEY", raising=False)
+        with patch("lib.image_backends.ark.create_ark_client") as mock_create:
+            from lib.image_backends.ark import ArkImageBackend
+
+            ArkImageBackend(api_key="k", base_url="https://ark.cn-beijing.volces.com/api/plan/v3")
+            mock_create.assert_called_once_with(
+                api_key="k",
+                base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
+            )
 
 
 class TestArkImageBackendProperties:

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,0 +1,13 @@
+"""PROVIDER_REGISTRY 字段与注册完整性单元测试。"""
+
+from lib.config.registry import PROVIDER_REGISTRY
+
+
+def test_ark_has_default_base_url() -> None:
+    ark = PROVIDER_REGISTRY["ark"]
+    assert ark.default_base_url == "https://ark.cn-beijing.volces.com/api/v3"
+
+
+def test_provider_meta_default_base_url_optional() -> None:
+    gemini = PROVIDER_REGISTRY["gemini-aistudio"]
+    assert gemini.default_base_url is None

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -48,3 +48,20 @@ def test_ark_agent_plan_model_id_format_differs_from_ark() -> None:
     ark_ids = set(PROVIDER_REGISTRY["ark"].models.keys())
     agent_plan_ids = set(PROVIDER_REGISTRY["ark-agent-plan"].models.keys())
     assert not (ark_ids & agent_plan_ids), "ark vs ark-agent-plan 模型 ID 命名不同，不应重叠"
+
+
+def test_ark_agent_plan_backend_registered() -> None:
+    """复用现有 ark backend 类支持 ark-agent-plan provider。"""
+    import lib.image_backends  # noqa: F401  触发自注册
+    import lib.text_backends  # noqa: F401
+    import lib.video_backends  # noqa: F401
+    from lib.image_backends.ark import ArkImageBackend
+    from lib.image_backends.registry import _BACKEND_FACTORIES as image_reg
+    from lib.text_backends.ark import ArkTextBackend
+    from lib.text_backends.registry import _BACKEND_FACTORIES as text_reg
+    from lib.video_backends.ark import ArkVideoBackend
+    from lib.video_backends.registry import _BACKEND_FACTORIES as video_reg
+
+    assert image_reg["ark-agent-plan"] is ArkImageBackend
+    assert video_reg["ark-agent-plan"] is ArkVideoBackend
+    assert text_reg["ark-agent-plan"] is ArkTextBackend

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -11,3 +11,40 @@ def test_ark_has_default_base_url() -> None:
 def test_provider_meta_default_base_url_optional() -> None:
     gemini = PROVIDER_REGISTRY["gemini-aistudio"]
     assert gemini.default_base_url is None
+
+
+def test_ark_agent_plan_registered() -> None:
+    p = PROVIDER_REGISTRY["ark-agent-plan"]
+    assert p.default_base_url == "https://ark.cn-beijing.volces.com/api/plan/v3"
+    assert "api_key" in p.required_keys
+    defaults_by_media = {m.media_type: mid for mid, m in p.models.items() if m.default}
+    assert defaults_by_media == {
+        "text": "doubao-seed-2.0-lite",
+        "image": "doubao-seedream-5.0-lite",
+        "video": "doubao-seedance-2.0-fast",
+    }
+    for mid, m in p.models.items():
+        if m.media_type == "video":
+            assert m.supported_durations, f"{mid} missing supported_durations"
+            assert m.resolutions, f"{mid} missing resolutions"
+
+
+def test_ark_agent_plan_baseline_models_present() -> None:
+    p = PROVIDER_REGISTRY["ark-agent-plan"]
+    baseline = {
+        "doubao-seed-2.0-mini",
+        "doubao-seed-2.0-lite",
+        "doubao-seed-2.0-pro",
+        "doubao-seed-2.0-code",
+        "doubao-seedream-5.0-lite",
+        "doubao-seedance-1.5-pro",
+        "doubao-seedance-2.0",
+        "doubao-seedance-2.0-fast",
+    }
+    assert baseline.issubset(set(p.models.keys()))
+
+
+def test_ark_agent_plan_model_id_format_differs_from_ark() -> None:
+    ark_ids = set(PROVIDER_REGISTRY["ark"].models.keys())
+    agent_plan_ids = set(PROVIDER_REGISTRY["ark-agent-plan"].models.keys())
+    assert not (ark_ids & agent_plan_ids), "ark vs ark-agent-plan 模型 ID 命名不同，不应重叠"

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -543,3 +543,70 @@ class TestTestProviderConnection:
                 resp = client.post("/api/v1/providers/gemini-aistudio/test?credential_id=1")
         assert resp.status_code == 200
         assert resp.json()["success"] is True
+
+
+class TestArkAgentPlanConnectionTest:
+    """ark-agent-plan 必须复用 _test_ark 并自动注入 default_base_url。"""
+
+    def _fake_cred(self):
+        cred = MagicMock()
+        cred.provider = "ark-agent-plan"
+        cred.api_key = "ark-fake"
+        cred.credentials_path = None
+        cred.base_url = None
+        return cred
+
+    def _mock_cred_repo(self):
+        repo = MagicMock(spec=CredentialRepository)
+        repo.get_active = AsyncMock(return_value=self._fake_cred())
+        return repo
+
+    def _mock_svc(self) -> ConfigService:
+        svc = MagicMock(spec=ConfigService)
+        svc.get_provider_config = AsyncMock(return_value={"api_key": "ark-fake"})
+        return svc
+
+    def test_ark_agent_plan_is_dispatched(self):
+        assert "ark-agent-plan" in providers._TEST_DISPATCH
+        assert providers._TEST_DISPATCH["ark-agent-plan"] is providers._test_ark
+
+    def test_default_base_url_injected_when_user_did_not_set(self):
+        captured: dict = {}
+
+        def _capture(config: dict, _t=None) -> providers.ConnectionTestResponse:
+            captured["base_url"] = config.get("base_url")
+            return providers.ConnectionTestResponse(success=True, available_models=[], message="ok")
+
+        app, _ = _make_session_app()
+        with (
+            patch("server.routers.providers.CredentialRepository", return_value=self._mock_cred_repo()),
+            patch("server.routers.providers.ConfigService", return_value=self._mock_svc()),
+            patch.dict(providers._TEST_DISPATCH, {"ark-agent-plan": _capture}),
+        ):
+            with TestClient(app) as client:
+                resp = client.post("/api/v1/providers/ark-agent-plan/test")
+        assert resp.status_code == 200
+        assert captured["base_url"] == "https://ark.cn-beijing.volces.com/api/plan/v3"
+
+    def test_user_base_url_overrides_default(self):
+        captured: dict = {}
+
+        def _capture(config: dict, _t=None) -> providers.ConnectionTestResponse:
+            captured["base_url"] = config.get("base_url")
+            return providers.ConnectionTestResponse(success=True, available_models=[], message="ok")
+
+        svc = MagicMock(spec=ConfigService)
+        svc.get_provider_config = AsyncMock(
+            return_value={"api_key": "ark-fake", "base_url": "https://custom.example.com/v9"}
+        )
+
+        app, _ = _make_session_app()
+        with (
+            patch("server.routers.providers.CredentialRepository", return_value=self._mock_cred_repo()),
+            patch("server.routers.providers.ConfigService", return_value=svc),
+            patch.dict(providers._TEST_DISPATCH, {"ark-agent-plan": _capture}),
+        ):
+            with TestClient(app) as client:
+                resp = client.post("/api/v1/providers/ark-agent-plan/test")
+        assert resp.status_code == 200
+        assert captured["base_url"] == "https://custom.example.com/v9"

--- a/tests/test_registry_resolutions.py
+++ b/tests/test_registry_resolutions.py
@@ -10,10 +10,11 @@ def test_model_info_has_resolutions_default_empty_list():
 
 def test_all_image_video_models_have_resolutions_populated():
     missing: list[str] = []
+    ark_provider_ids = {"ark", "ark-agent-plan"}
     for pid, meta in PROVIDER_REGISTRY.items():
         for mid, minfo in meta.models.items():
             if minfo.media_type in ("image", "video"):
-                if not minfo.resolutions and not (pid == "ark" and mid.startswith("doubao-seedream")):
+                if not minfo.resolutions and not (pid in ark_provider_ids and mid.startswith("doubao-seedream")):
                     missing.append(f"{pid}/{mid}")
     assert missing == [], f"以下 image/video 模型缺少 resolutions: {missing}"
 
@@ -27,7 +28,8 @@ def test_text_models_have_empty_resolutions():
 
 def test_ark_seedream_image_resolutions_empty():
     """Ark Seedream 当前不传分辨率，留空 → UI 不展示下拉。"""
-    ark = PROVIDER_REGISTRY["ark"]
-    for mid, minfo in ark.models.items():
-        if minfo.media_type == "image":
-            assert minfo.resolutions == [], f"{mid}: Ark Seedream 应留空"
+    for pid in ("ark", "ark-agent-plan"):
+        meta = PROVIDER_REGISTRY[pid]
+        for mid, minfo in meta.models.items():
+            if minfo.media_type == "image":
+                assert minfo.resolutions == [], f"{pid}/{mid}: Ark Seedream 应留空"

--- a/tests/test_text_backends/test_ark.py
+++ b/tests/test_text_backends/test_ark.py
@@ -304,5 +304,5 @@ class TestBaseUrl:
         with patch("lib.text_backends.ark.create_ark_client") as mock_ark_create:
             with patch("lib.text_backends.ark.OpenAI") as mock_openai_ctor:
                 ArkTextBackend(api_key="k")
-                mock_ark_create.assert_called_once_with(api_key="k", base_url=None)
+                mock_ark_create.assert_called_once_with(api_key="k", base_url=ARK_BASE_URL)
                 mock_openai_ctor.assert_called_once_with(base_url=ARK_BASE_URL, api_key="k")

--- a/tests/test_text_backends/test_ark.py
+++ b/tests/test_text_backends/test_ark.py
@@ -282,3 +282,27 @@ class TestCapabilityAwareStructured:
         backend_with_structured._test_client.chat.completions.create.assert_called_once()
         # 降级路径应该被使用
         backend_with_structured._openai_client.chat.completions.create.assert_called_once()
+
+
+class TestBaseUrl:
+    def test_custom_base_url_passes_to_both_clients(self):
+        with patch("lib.text_backends.ark.create_ark_client") as mock_ark_create:
+            with patch("lib.text_backends.ark.OpenAI") as mock_openai_ctor:
+                ArkTextBackend(api_key="k", base_url="https://ark.cn-beijing.volces.com/api/plan/v3")
+                mock_ark_create.assert_called_once_with(
+                    api_key="k",
+                    base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
+                )
+                mock_openai_ctor.assert_called_once_with(
+                    base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
+                    api_key="k",
+                )
+
+    def test_default_base_url_keeps_ark_v3(self):
+        from lib.ark_shared import ARK_BASE_URL
+
+        with patch("lib.text_backends.ark.create_ark_client") as mock_ark_create:
+            with patch("lib.text_backends.ark.OpenAI") as mock_openai_ctor:
+                ArkTextBackend(api_key="k")
+                mock_ark_create.assert_called_once_with(api_key="k", base_url=None)
+                mock_openai_ctor.assert_called_once_with(base_url=ARK_BASE_URL, api_key="k")

--- a/tests/test_text_backends/test_factory.py
+++ b/tests/test_text_backends/test_factory.py
@@ -64,8 +64,48 @@ async def test_creates_ark_backend():
             "ark",
             api_key="ark-key",
             model="doubao-seed-2-0-lite-260215",
+            base_url="https://ark.cn-beijing.volces.com/api/v3",
         )
         assert result is mock_backend
+
+
+async def test_creates_ark_agent_plan_backend_uses_plan_endpoint():
+    """ark-agent-plan 必须把 default_base_url=/api/plan/v3 透传到 backend，
+    否则文本生成会被 ArkTextBackend 默认的 /api/v3 拉到错误的套餐网关。"""
+    mock_resolver = _make_mock_resolver(
+        text_backend_for_task=("ark-agent-plan", "doubao-seed-2.0-lite"),
+        provider_config={"api_key": "ark-plan-key"},
+    )
+
+    with (
+        patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
+        patch("lib.text_backends.factory.create_backend") as mock_create,
+    ):
+        mock_backend = MagicMock()
+        mock_create.return_value = mock_backend
+
+        await create_text_backend_for_task(TextTaskType.OVERVIEW, "my-project")
+
+        mock_create.assert_called_once_with(
+            "ark-agent-plan",
+            api_key="ark-plan-key",
+            model="doubao-seed-2.0-lite",
+            base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
+        )
+
+
+async def test_user_base_url_overrides_default_for_ark_agent_plan():
+    mock_resolver = _make_mock_resolver(
+        text_backend_for_task=("ark-agent-plan", "doubao-seed-2.0-lite"),
+        provider_config={"api_key": "k", "base_url": "https://custom.example.com/v9"},
+    )
+
+    with (
+        patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
+        patch("lib.text_backends.factory.create_backend") as mock_create,
+    ):
+        await create_text_backend_for_task(TextTaskType.OVERVIEW, "my-project")
+        assert mock_create.call_args.kwargs["base_url"] == "https://custom.example.com/v9"
 
 
 async def test_creates_vertex_backend():

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -401,6 +401,17 @@ class TestArkModelCapabilities:
         caps = b.capabilities
         assert VideoCapability.FLEX_TIER in caps
 
+    def test_seedance_2_dot_format_no_flex_tier(self):
+        """ark-agent-plan 用 dot 命名（doubao-seedance-2.0），同样不该带 FLEX_TIER。"""
+        with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
+            b = ArkVideoBackend(api_key="test", model="doubao-seedance-2.0")
+        assert VideoCapability.FLEX_TIER not in b.capabilities
+
+    def test_seedance_2_fast_dot_format_no_flex_tier(self):
+        with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
+            b = ArkVideoBackend(api_key="test", model="doubao-seedance-2.0-fast")
+        assert VideoCapability.FLEX_TIER not in b.capabilities
+
 
 class TestArkServiceTierParam:
     """service_tier 只对声明了 FLEX_TIER 能力的模型传入，否则 API 会报错。"""

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -463,3 +463,18 @@ class TestArkServiceTierParam:
 
         create_kwargs = backend._client.content_generation.tasks.create.call_args.kwargs
         assert create_kwargs.get("service_tier") == "default"
+
+
+class TestArkVideoBackendBaseUrl:
+    def test_custom_base_url_passed_through(self):
+        with patch("lib.video_backends.ark.create_ark_client") as mock_create:
+            ArkVideoBackend(api_key="k", base_url="https://ark.cn-beijing.volces.com/api/plan/v3")
+            mock_create.assert_called_once_with(
+                api_key="k",
+                base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
+            )
+
+    def test_default_base_url_is_none(self):
+        with patch("lib.video_backends.ark.create_ark_client") as mock_create:
+            ArkVideoBackend(api_key="k")
+            mock_create.assert_called_once_with(api_key="k", base_url=None)


### PR DESCRIPTION
closes #517 

## Summary
- 智能体目录新增两条 Anthropic 兼容预置：`ark-coding-plan`（`/api/coding`）、`ark-agent-plan`（`/api/plan`）
- `_SUFFIX_PATTERNS` 补齐 `/api/plan`，让 `derive_anthropic_endpoints` 正确剥到根域作为 discovery_root
- 基础设施升级：`ProviderMeta.default_base_url` 字段；`create_ark_client(base_url=...)`；ark image/video/text backends 全部透传 base_url；`_fill_simple_provider_kwargs` 增加 `default_base_url` fallback
- `PROVIDER_REGISTRY` 新增 `ark-agent-plan` 预设供应商条目（13 个模型，覆盖文本/图片/视频），同时 backend 注册表把 `ark-agent-plan` 映射到既有 ark backend 类
- 后端 + 前端 i18n（zh/en/vi）补齐 `provider_name_ark-agent-plan` / `provider_desc_ark-agent-plan` / `preset_notes_ark_coding_plan` / `preset_notes_ark_agent_plan`

## Test plan
- [x] \`uv run python -m pytest tests\` — 2738 passed
- [x] \`uv run ruff check lib server tests && uv run ruff format --check lib server tests\`
- [x] \`uv run basedpyright lib server tests\` — 0 errors
- [x] \`pnpm lint && pnpm check\` — 74 test files / 546 tests passed
- [ ] 手测：智能体配置 chip 列表显示两条 Volcengine 预置，选中后 messages_url / discovery_url 正确预填
- [ ] 手测：预设供应商列表显示 \`火山方舟 Agent Plan\` 条目，填入真实 API Key 后能跑图片生成 + 视频生成
- [ ] 手测：Coding Plan 智能体场景下 connection test → \`messages_probe.success=True\`、\`status_code=200\`、响应 \`type=message\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 新增两项 Volcengine Ark 预设：Coding Plan 与 Agent Plan，前端展示与后端注册同步支持。
  * 文本/图片/视频后端与任务调度支持透传自定义 base_url，并支持提供方级默认 base_url 回退。

* **本地化**
  * 在中/英/越语文案中补充并调整与 Ark 两项计划相关的展示说明。

* **Tests**
  * 增补并调整单元测试以覆盖新增提供方、base_url 传递与端点解析逻辑。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->