### PR TITLE
fix(ci): GHCR 镜像名小写 + Codecov 显式 token

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Compute lowercase image name
+        run: echo "IMAGE_NAME_LC=${REPO,,}" >> "$GITHUB_ENV"
+        env:
+          REPO: ${{ github.repository }}
+
       - uses: docker/setup-buildx-action@v4
 
       - uses: docker/login-action@v4
@@ -49,7 +54,7 @@ jobs:
           context: .
           platforms: linux/amd64
           load: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan-${{ github.sha }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:scan-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -58,7 +63,7 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan-${{ github.sha }}
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:scan-${{ github.sha }}
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Upload backend coverage
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: backend
           fail_ci_if_error: false
@@ -114,6 +115,7 @@ jobs:
       - name: Upload PG coverage
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage-pg.xml
           flags: postgres
           fail_ci_if_error: false
@@ -153,6 +155,7 @@ jobs:
       - name: Upload frontend coverage
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: frontend/coverage/lcov.info
           flags: frontend
           fail_ci_if_error: false


### PR DESCRIPTION
## 范围

- 仅改 CI 配置：[.github/workflows/docker.yml](.github/workflows/docker.yml) 与 [.github/workflows/test.yml](.github/workflows/test.yml)
- **不动**应用代码、测试代码、产物镜像构建逻辑（multi-arch push 仍走 `metadata-action`，本身已 lowercase）

## 变更

- **docker.yml**：新增 `Compute lowercase image name` 一步，用 bash 大小写转换把 `github.repository` 写入 `IMAGE_NAME_LC`；scan 镜像 tag 与 Trivy `image-ref` 改用 `IMAGE_NAME_LC`。修复 [main 上 Docker job](https://github.com/ArcReel/ArcReel/actions/runs/26014523542/job/76461733668) 的 `repository name must be lowercase` 失败
- **test.yml**：backend / postgres / frontend 三处 `codecov/codecov-action@v5` 均补 `token: ${{ secrets.CODECOV_TOKEN }}`。Codecov 已不再接受 tokenless upload，旧配置在 CI 日志中静默报 `{"message":"Token required - not valid tokenless upload"}`，因 `fail_ci_if_error: false` 没让 CI 红，但 Codecov 收不到数据 → README badge 长期 unknown

## 验收清单

- [x] 本地无可跑测试（纯 workflow YAML 改动，靠 CI 验证）
- [x] CI 全绿（backend-tests / postgres-compat / frontend-tests / CodeQL 均 ✅）
- [ ] **合并前/后** repo 管理员手工添加 GitHub secret `CODECOV_TOKEN`：
  1. 登录 https://app.codecov.io/gh/ArcReel/ArcReel → Settings → 复制 Repository Upload Token
  2. https://github.com/ArcReel/ArcReel/settings/secrets/actions → New repository secret → Name `CODECOV_TOKEN`，Value 粘贴上一步 token
- [ ] 添加 secret 后下一次 push/PR 验证：`Upload backend coverage` 步骤日志不再出现 `Token required`，Codecov dashboard 出现新 commit 覆盖率，README badge 显示具体百分比
- [ ] 下一次 push to main 的 Docker workflow 顺利通过 `Build amd64 image for security scan`
- [ ] 无新增 ESLint disable（不适用 YAML）
- [ ] 无新增面向用户文案（不适用）

## 已知 defer

- 当前三处 `fail_ci_if_error: false` 暂不改动，避免 token 未配置完成时 PR 直接红。等 `CODECOV_TOKEN` 落地、上传稳定后单独提 PR 将 main 上的上传步骤切到 `true`，防止下次再有静默失败