### PR TITLE
fix: propagate image usage tokens

### DIFF
--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -267,6 +267,7 @@ class MediaGenerator:
                 call_id=call_id,
                 status="success",
                 output_path=str(output_path),
+                usage_tokens=getattr(result, "usage_tokens", None),
                 quality=getattr(result, "quality", None),
                 image_input_tokens=getattr(result, "image_input_tokens", None),
                 image_output_tokens=getattr(result, "image_output_tokens", None),

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from lib.image_backends.base import ImageCapability
+from lib.image_backends.base import ImageCapability, ImageGenerationResult
 from lib.media_generator import MediaGenerator
 
 
@@ -21,6 +21,12 @@ class _FakeImageBackend:
         # Touch the output file so version tracking works
         request.output_path.parent.mkdir(parents=True, exist_ok=True)
         request.output_path.write_bytes(b"fake-image-data")
+        return ImageGenerationResult(
+            image_path=request.output_path,
+            provider=self.name,
+            model=self.model,
+            usage_tokens=8,
+        )
 
 
 class _FakeVideoResult:
@@ -126,6 +132,7 @@ class TestMediaGenerator:
         assert version == 1
         assert gen.usage_tracker.started[0]["call_type"] == "image"
         assert gen.usage_tracker.finished[0]["status"] == "success"
+        assert gen.usage_tracker.finished[0]["usage_tokens"] == 8
 
         async def _raise(request):
             raise RuntimeError("boom")


### PR DESCRIPTION
## Summary

- Propagate `ImageGenerationResult.usage_tokens` from image backends into `UsageTracker.finish_call`.
- Add a regression test that verifies image generation usage tokens are forwarded to the usage tracker.

## Why

Some image backends can return actual usage information. For example, Vidu image generation returns consumed `credits`, which are exposed as `usage_tokens` on `ImageGenerationResult`.

Video generation already forwards usage tokens into usage tracking, but image generation dropped `usage_tokens` before calling `UsageTracker.finish_call`. As a result, downstream cost calculation could fall back to estimated pricing even when actual backend usage was available.

## Testing

- `conda run -n arcreel python -m pytest tests/test_media_generator_module.py::TestMediaGenerator::test_generate_image_success_and_failure -q`
- `conda run -n arcreel python -m pytest tests/test_usage_repo.py tests/test_media_generator_module.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 图片生成服务现在记录并跟踪每次生成所使用的 token 数量

* **测试**
  * 测试已更新以验证 token 使用情况的准确记录

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->