### PR TITLE
chore(deps): basedpyright 归入 dev-dependencies 分组

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,7 @@ updates:
         patterns:
           - "pytest*"
           - "ruff"
+          - "basedpyright"
           - "pre-commit"
           - "python-docx"
         update-types:


### PR DESCRIPTION
## Summary
- `basedpyright` 之前没被 `dev-dependencies` 组的 patterns 命中，落到 `all-other` 兜底组（见 #559），与运行时依赖混在一起
- 把 `basedpyright` 加入 dev-dependencies 的 patterns，下一轮 dependabot 调度时会自动归位

## Test plan
- [ ] 合并后下一轮 dependabot 运行时观察 basedpyright 版本升级 PR 落入 `dev-dependencies` 组
- [ ] PR #559 可在合并后评论 `@dependabot recreate` 让现存 PR 走新规则（或直接 close 让下轮重出）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 更新开发工具的自动更新配置，以确保开发依赖保持最新状态。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->