### PR TITLE
fix: 透传 Claude SDK stderr，让 Windows agent 启动失败可诊断

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -73,6 +73,7 @@ MESSAGES = {
     "session_not_found": "Session '{session_id}' does not exist",
     "session_or_project_not_found": "Session or project does not exist",
     "sdk_session_timeout": "SDK session creation timed out",
+    "agent_startup_failed": "Failed to start agent:\n{details}",
     "interface_offline": "This interface is offline, please use the recommended interface",
     "answers_required": "answers cannot be empty",
     # Custom Providers

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -73,6 +73,7 @@ MESSAGES = {
     "session_not_found": "Phiên '{session_id}' không tồn tại",
     "session_or_project_not_found": "Phiên hoặc dự án không tồn tại",
     "sdk_session_timeout": "Tạo phiên SDK quá thời gian",
+    "agent_startup_failed": "Khởi động agent thất bại:\n{details}",
     "interface_offline": "Giao diện này đã ngừng hoạt động, vui lòng dùng giao diện được khuyến nghị",
     "answers_required": "answers không được để trống",
     # Custom Providers

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -73,6 +73,7 @@ MESSAGES = {
     "session_not_found": "会话 '{session_id}' 不存在",
     "session_or_project_not_found": "会话或项目不存在",
     "sdk_session_timeout": "SDK 会话创建超时",
+    "agent_startup_failed": "Agent 启动失败：\n{details}",
     "interface_offline": "该接口已下线，请使用推荐的接口",
     "answers_required": "answers 不能为空",
     # Custom Providers

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -12,6 +12,7 @@ import os
 import shlex
 import tempfile
 import time
+from collections import deque
 from collections.abc import AsyncIterable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -50,6 +51,11 @@ SDK_AVAILABLE = True
 # 持续高于此值说明 _process_inbox 被阻塞或下游 I/O 超慢。
 _INBOX_BACKLOG_WARN_THRESHOLD = 100
 _INBOX_BACKLOG_RESET_THRESHOLD = 50  # 降至此水位以下才重置告警状态，避免抖动刷屏
+
+# SDK stderr 缓冲上限（行）：actor.start() 失败时启动期 stderr 一般 <20 行；
+# 上限主要为应对启动成功后 SDK 在会话存活期间持续输出 stderr 的场景，cap
+# 在 200 行 × 平均行长，单会话最坏占用 <100KB，可控。
+_SDK_STDERR_BUFFER_MAX = 200
 
 
 class SessionCapacityError(Exception):
@@ -1240,7 +1246,11 @@ class SessionManager:
         temp_id = uuid4().hex
         managed_ref: list[ManagedSession | None] = [None]
 
-        stderr_lines: list[str] = []
+        # SDK stderr 回调在整个会话存活期间都被 ClaudeAgentOptions 持有，
+        # actor.start() 成功后仍会被调；用 deque(maxlen=) FIFO 自动裁剪老行，
+        # 避免长会话期间因 SDK 持续输出 stderr 造成内存无界增长。
+        # 启动失败场景下 stderr 通常远小于上限，关键提示不会被裁掉。
+        stderr_lines: deque[str] = deque(maxlen=_SDK_STDERR_BUFFER_MAX)
 
         def _collect_stderr(line: str) -> None:
             stderr_lines.append(line)
@@ -1451,7 +1461,8 @@ class SessionManager:
             await self._ensure_capacity()
             managed_ref: list[ManagedSession | None] = [None]
 
-            stderr_lines: list[str] = []
+            # 见 send_new_session 同名注释：deque(maxlen=) 防长会话内存累积。
+            stderr_lines: deque[str] = deque(maxlen=_SDK_STDERR_BUFFER_MAX)
 
             def _collect_stderr(line: str) -> None:
                 stderr_lines.append(line)

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -58,6 +58,31 @@ class SessionCapacityError(Exception):
     pass
 
 
+class AgentStartupError(RuntimeError):
+    """ClaudeSDKClient 启动失败时携带 SDK stderr 的异常。
+
+    SDK 内部用 ``ProcessError`` 抛子进程非 0 退出，但其 ``stderr`` 字段写死为
+    ``"Check stderr output for details"`` —— 真实 stderr 只能通过
+    ``ClaudeAgentOptions.stderr`` 回调拿到。本异常把回调收集的 stderr 行打包
+    透传给 router/前端，让用户能看到 SDK 给出的安装指引（例如 Windows 缺
+    bash.exe / pwsh.exe 时的下载链接）。
+
+    ``__str__`` 直接返回 message + stderr 的完整拼接，让 router 的通用
+    ``except Exception: str(exc)`` 分支也能自动透传，不需要每条路径都加专门
+    捕获。
+    """
+
+    def __init__(self, message: str, sdk_stderr: str = "") -> None:
+        self.message = message
+        self.sdk_stderr = sdk_stderr
+        super().__init__(self._compose())
+
+    def _compose(self) -> str:
+        if self.sdk_stderr:
+            return f"{self.message}\n\n{self.sdk_stderr}"
+        return self.message
+
+
 def _utc_now_iso() -> str:
     """Return current UTC timestamp in ISO-8601 format."""
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
@@ -620,8 +645,14 @@ class SessionManager:
         resume_id: str | None = None,
         can_use_tool: Callable[[str, dict[str, Any], Any], Any] | None = None,
         locale: str = "zh",
+        stderr: Callable[[str], None] | None = None,
     ) -> Any:
-        """Build ClaudeAgentOptions for a session."""
+        """Build ClaudeAgentOptions for a session.
+
+        ``stderr`` 在 SDK 子进程退出非 0 时是唯一拿到真实错误的途径
+        （``ProcessError.stderr`` 在 SDK 内部被写死为占位符）；上层应在
+        会话启动失败时把回调累积的行包装到 ``AgentStartupError`` 透传。
+        """
         if not SDK_AVAILABLE or ClaudeAgentOptions is None:
             raise RuntimeError("claude_agent_sdk is not installed")
 
@@ -708,6 +739,7 @@ class SessionManager:
             session_store_flush=session_store_flush_mode(),
             sandbox=sandbox_typed,  # type: ignore[arg-type]
             env=provider_env,
+            stderr=stderr,
         )
 
     @staticmethod
@@ -1208,11 +1240,18 @@ class SessionManager:
         temp_id = uuid4().hex
         managed_ref: list[ManagedSession | None] = [None]
 
+        stderr_lines: list[str] = []
+
+        def _collect_stderr(line: str) -> None:
+            stderr_lines.append(line)
+            logger.warning("claude_agent_sdk stderr: %s", line)
+
         options = await self._build_options(
             project_name,
             resume_id=None,
             can_use_tool=await self._build_can_use_tool_callback(temp_id, managed_ref),
             locale=locale,
+            stderr=_collect_stderr,
         )
 
         actor = SessionActor(
@@ -1232,10 +1271,10 @@ class SessionManager:
 
         try:
             await actor.start()
-        except Exception:
+        except Exception as exc:
             logger.exception("新会话 actor 启动失败 temp_id=%s", temp_id)
             self.sessions.pop(temp_id, None)
-            raise
+            raise AgentStartupError(str(exc), sdk_stderr="\n".join(stderr_lines)) from exc
 
         # Register done callback BEFORE spawning processor to avoid a race
         # where the actor task completes before add_done_callback is attached,
@@ -1411,10 +1450,18 @@ class SessionManager:
 
             await self._ensure_capacity()
             managed_ref: list[ManagedSession | None] = [None]
+
+            stderr_lines: list[str] = []
+
+            def _collect_stderr(line: str) -> None:
+                stderr_lines.append(line)
+                logger.warning("claude_agent_sdk stderr: %s", line)
+
             options = await self._build_options(
                 meta.project_name,
                 meta.id,  # SessionMeta.id 就是 sdk_session_id
                 can_use_tool=await self._build_can_use_tool_callback(session_id, managed_ref),
+                stderr=_collect_stderr,
             )
 
             actor = SessionActor(
@@ -1439,10 +1486,10 @@ class SessionManager:
 
             try:
                 await actor.start()
-            except Exception:
+            except Exception as exc:
                 logger.exception("恢复会话 actor 启动失败 session_id=%s", session_id)
                 self.sessions.pop(session_id, None)
-                raise
+                raise AgentStartupError(str(exc), sdk_stderr="\n".join(stderr_lines)) from exc
 
             # done_callback BEFORE processor spawn (avoids race where actor
             # completes before the callback attaches and the None sentinel

--- a/server/routers/assistant.py
+++ b/server/routers/assistant.py
@@ -16,7 +16,7 @@ from lib import PROJECT_ROOT
 from lib.i18n import Translator, get_locale
 from server.agent_runtime.models import SessionMeta
 from server.agent_runtime.service import AssistantService
-from server.agent_runtime.session_manager import SessionCapacityError
+from server.agent_runtime.session_manager import AgentStartupError, SessionCapacityError
 from server.auth import CurrentUser, CurrentUserFlexible
 
 router = APIRouter()
@@ -91,6 +91,11 @@ async def send_message(
         raise HTTPException(status_code=504, detail=_t("sdk_session_timeout"))
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    except AgentStartupError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=_t("agent_startup_failed", details=str(exc)),
+        )
     except Exception as exc:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=str(exc))

--- a/tests/agent_runtime/test_agent_startup_error.py
+++ b/tests/agent_runtime/test_agent_startup_error.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from server.agent_runtime.session_manager import (
+    _SDK_STDERR_BUFFER_MAX,
     AgentStartupError,
     SessionManager,
 )
@@ -171,3 +172,55 @@ async def test_send_new_session_no_stderr_still_wraps(
     assert "ENOENT" in str(exc_info.value)
     # 原因链保留，便于 logger.exception 看到底层异常
     assert isinstance(exc_info.value.__cause__, OSError)
+
+
+@pytest.mark.asyncio
+async def test_stderr_buffer_caps_to_maxlen(session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch) -> None:
+    """SDK 在长会话中持续吐 stderr 时，缓冲必须裁剪到 maxlen，避免无界增长。
+
+    回归 gemini-code-assist / chatgpt-codex review #573：``_collect_stderr`` 被
+    SDK 在整个会话期间持有，启动成功后没人消费的话 list 会无限增长。改用
+    ``deque(maxlen=_SDK_STDERR_BUFFER_MAX)`` 后旧行被 FIFO 裁掉，最坏占用
+    可控；这里直接打超过上限的行数，断言 sdk_stderr 行数受限。
+    """
+
+    async def fake_env(_self):
+        return {"ANTHROPIC_API_KEY": "sk"}
+
+    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", fake_env)
+
+    captured_stderr_cb: list = []
+    overflow_count = _SDK_STDERR_BUFFER_MAX + 50
+
+    class _FakeActor:
+        def __init__(self, *_, on_message=None, client_factory=None):
+            self.task = None
+
+        async def start(self):
+            cb = captured_stderr_cb[0]
+            for i in range(overflow_count):
+                cb(f"line-{i:04d}")
+            raise RuntimeError("Command failed with exit code 1")
+
+        def add_done_callback(self, _cb):
+            pass
+
+    real_build_options = SessionManager._build_options
+
+    async def wrapped_build_options(self, *args, **kwargs):
+        opts = await real_build_options(self, *args, **kwargs)
+        captured_stderr_cb.append(opts.stderr)
+        return opts
+
+    monkeypatch.setattr(SessionManager, "_build_options", wrapped_build_options)
+    monkeypatch.setattr("server.agent_runtime.session_manager.SessionActor", _FakeActor)
+    monkeypatch.setattr(SessionManager, "_ensure_capacity", AsyncMock(return_value=None))
+
+    with pytest.raises(AgentStartupError) as exc_info:
+        await session_manager.send_new_session("demo", "你好")
+
+    lines = exc_info.value.sdk_stderr.split("\n")
+    assert len(lines) == _SDK_STDERR_BUFFER_MAX
+    # FIFO：最早 50 行被裁，剩下的应是 line-0050 .. line-(MAX+49)
+    assert lines[0] == f"line-{overflow_count - _SDK_STDERR_BUFFER_MAX:04d}"
+    assert lines[-1] == f"line-{overflow_count - 1:04d}"

--- a/tests/agent_runtime/test_agent_startup_error.py
+++ b/tests/agent_runtime/test_agent_startup_error.py
@@ -1,0 +1,173 @@
+"""AgentStartupError 透传 SDK stderr 的回归覆盖。
+
+修这条路径的动机：SDK 子进程退出非 0 时 ProcessError.stderr 写死为占位符，
+之前 ArcReel 没传 stderr 回调，前端只看到 "Check stderr output for details"。
+此处覆盖：
+  1. AgentStartupError __str__ 自动拼 message + stderr，所有 except Exception:
+     str(exc) 路径都能透传；
+  2. _build_options 把 stderr 回调透传到 ClaudeAgentOptions；
+  3. send_new_session 在 actor.start 失败时收集 stderr 并包装为
+     AgentStartupError；
+  4. router 把 AgentStartupError 翻译成 502 + i18n 包装的 detail。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from server.agent_runtime.session_manager import (
+    AgentStartupError,
+    SessionManager,
+)
+from server.agent_runtime.session_store import SessionMetaStore
+
+
+def test_agent_startup_error_str_includes_stderr() -> None:
+    exc = AgentStartupError(
+        "Command failed with exit code 1",
+        sdk_stderr="Claude Code on Windows requires either Git for Windows (for bash) or PowerShell.",
+    )
+    rendered = str(exc)
+    assert "Command failed with exit code 1" in rendered
+    assert "Git for Windows" in rendered
+    # message 与 stderr 之间应留空行，方便前端展示
+    assert "\n\n" in rendered
+
+
+def test_agent_startup_error_without_stderr_keeps_message() -> None:
+    exc = AgentStartupError("启动失败")
+    assert str(exc) == "启动失败"
+    assert exc.sdk_stderr == ""
+
+
+@pytest.fixture
+def session_manager(tmp_path: Path) -> SessionManager:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    (project_root / "projects").mkdir()
+    proj_dir = project_root / "projects" / "demo"
+    proj_dir.mkdir()
+    (proj_dir / "project.json").write_text('{"title": "t"}', encoding="utf-8")
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    meta_store = SessionMetaStore()
+    sm = SessionManager(project_root, data_dir, meta_store)
+    sm._in_docker = False
+    return sm
+
+
+@pytest.mark.asyncio
+async def test_build_options_forwards_stderr_callback(
+    session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_build_options 必须把 stderr 回调透传给 ClaudeAgentOptions。"""
+
+    async def fake_env(_self):
+        return {"ANTHROPIC_API_KEY": "sk"}
+
+    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", fake_env)
+
+    captured: list[str] = []
+
+    def collector(line: str) -> None:
+        captured.append(line)
+
+    opts = await session_manager._build_options("demo", stderr=collector)
+    assert opts.stderr is collector
+
+    # 模拟 SDK 透传一行 stderr
+    opts.stderr("hello from claude.exe")
+    assert captured == ["hello from claude.exe"]
+
+
+@pytest.mark.asyncio
+async def test_send_new_session_wraps_actor_failure_with_stderr(
+    session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """actor.start() 抛错时应收集 stderr 并包装为 AgentStartupError 抛出。"""
+
+    async def fake_env(_self):
+        return {"ANTHROPIC_API_KEY": "sk"}
+
+    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", fake_env)
+
+    captured_stderr_cb: list = []
+
+    class _FakeActor:
+        def __init__(self, *_, on_message=None, client_factory=None):
+            self.task = None
+            self._on_message = on_message
+            # client_factory 是个 lambda，里面闭包了 options；从 client_factory
+            # 反推 options 比较麻烦，改由 monkeypatch 直接捕获 _build_options。
+
+        async def start(self):
+            # 模拟 SDK 在 connect 阶段先喷 stderr 再退出
+            cb = captured_stderr_cb[0]
+            cb("Claude Code on Windows requires either Git for Windows (for bash) or PowerShell.")
+            cb("Or set CLAUDE_CODE_GIT_BASH_PATH to your bash.exe location.")
+            raise RuntimeError("Command failed with exit code 1")
+
+        def add_done_callback(self, _cb):
+            pass
+
+    # 包装 _build_options，把 stderr 回调暴露给假 actor
+    real_build_options = SessionManager._build_options
+
+    async def wrapped_build_options(self, *args, **kwargs):
+        opts = await real_build_options(self, *args, **kwargs)
+        captured_stderr_cb.append(opts.stderr)
+        return opts
+
+    monkeypatch.setattr(SessionManager, "_build_options", wrapped_build_options)
+    monkeypatch.setattr("server.agent_runtime.session_manager.SessionActor", _FakeActor)
+
+    # _ensure_capacity 内部访问 DB，跳过
+    monkeypatch.setattr(SessionManager, "_ensure_capacity", AsyncMock(return_value=None))
+
+    with pytest.raises(AgentStartupError) as exc_info:
+        await session_manager.send_new_session("demo", "你好")
+
+    err = exc_info.value
+    assert "Git for Windows" in err.sdk_stderr
+    assert "CLAUDE_CODE_GIT_BASH_PATH" in err.sdk_stderr
+    # __str__ 必须把两段拼出来，给 router/前端直接看
+    text = str(err)
+    assert "Command failed with exit code 1" in text
+    assert "Git for Windows" in text
+
+
+@pytest.mark.asyncio
+async def test_send_new_session_no_stderr_still_wraps(
+    session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """即使 SDK 没产生 stderr，actor.start 失败也应包装为 AgentStartupError（保留原因链）。"""
+
+    async def fake_env(_self):
+        return {"ANTHROPIC_API_KEY": "sk"}
+
+    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", fake_env)
+
+    class _FakeActor:
+        def __init__(self, *_, on_message=None, client_factory=None):
+            self.task = None
+
+        async def start(self):
+            raise OSError("ENOENT")
+
+        def add_done_callback(self, _cb):
+            pass
+
+    monkeypatch.setattr("server.agent_runtime.session_manager.SessionActor", _FakeActor)
+    monkeypatch.setattr(SessionManager, "_ensure_capacity", AsyncMock(return_value=None))
+
+    with pytest.raises(AgentStartupError) as exc_info:
+        await session_manager.send_new_session("demo", "你好")
+
+    assert exc_info.value.sdk_stderr == ""
+    assert "ENOENT" in str(exc_info.value)
+    # 原因链保留，便于 logger.exception 看到底层异常
+    assert isinstance(exc_info.value.__cause__, OSError)

--- a/tests/agent_runtime/test_agent_startup_error.py
+++ b/tests/agent_runtime/test_agent_startup_error.py
@@ -175,6 +175,59 @@ async def test_send_new_session_no_stderr_still_wraps(
 
 
 @pytest.mark.asyncio
+async def test_get_or_connect_wraps_actor_failure_with_stderr(
+    session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """恢复历史会话路径同样要把 actor.start 失败包装为 AgentStartupError。
+
+    ``get_or_connect`` 与 ``send_new_session`` 是两条独立路径，单独覆盖避免
+    其中一条回归没人发现。
+    """
+    from tests.factories import make_session_meta
+
+    async def fake_env(_self):
+        return {"ANTHROPIC_API_KEY": "sk"}
+
+    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", fake_env)
+
+    captured_stderr_cb: list = []
+
+    class _FakeActor:
+        def __init__(self, *_, on_message=None, client_factory=None):
+            self.task = None
+
+        async def start(self):
+            cb = captured_stderr_cb[0]
+            cb("resume-failed: cannot rehydrate transcript")
+            raise RuntimeError("Command failed with exit code 1")
+
+        def add_done_callback(self, _cb):
+            pass
+
+    real_build_options = SessionManager._build_options
+
+    async def wrapped_build_options(self, *args, **kwargs):
+        opts = await real_build_options(self, *args, **kwargs)
+        captured_stderr_cb.append(opts.stderr)
+        return opts
+
+    monkeypatch.setattr(SessionManager, "_build_options", wrapped_build_options)
+    monkeypatch.setattr("server.agent_runtime.session_manager.SessionActor", _FakeActor)
+    monkeypatch.setattr(SessionManager, "_ensure_capacity", AsyncMock(return_value=None))
+
+    meta = make_session_meta(id="resumed-session", project_name="demo", status="idle")
+
+    with pytest.raises(AgentStartupError) as exc_info:
+        await session_manager.get_or_connect("resumed-session", meta=meta)
+
+    err = exc_info.value
+    assert "resume-failed" in err.sdk_stderr
+    assert "Command failed with exit code 1" in str(err)
+    # 失败后会话不应残留在内存里
+    assert "resumed-session" not in session_manager.sessions
+
+
+@pytest.mark.asyncio
 async def test_stderr_buffer_caps_to_maxlen(session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch) -> None:
     """SDK 在长会话中持续吐 stderr 时，缓冲必须裁剪到 maxlen，避免无界增长。
 

--- a/tests/test_assistant_routes.py
+++ b/tests/test_assistant_routes.py
@@ -93,3 +93,35 @@ class TestAssistantRoutes:
 
         assert response.status_code == 200
         assert response.json() == interrupt_payload
+
+    def test_send_endpoint_translates_agent_startup_error_to_502(self):
+        """``AgentStartupError`` 必须翻译成 502 + i18n 包装的 detail，
+        透传 SDK 自带的安装指引；500 + 占位符是回归（PR #573）。"""
+        from server.agent_runtime.session_manager import AgentStartupError
+
+        stderr_text = (
+            "Claude Code on Windows requires either Git for Windows (for bash) or PowerShell.\n"
+            "Or set CLAUDE_CODE_GIT_BASH_PATH to your bash.exe location."
+        )
+        startup_err = AgentStartupError(
+            "Command failed with exit code 1",
+            sdk_stderr=stderr_text,
+        )
+
+        with patch.object(
+            assistant.assistant_service,
+            "send_or_create",
+            new=AsyncMock(side_effect=startup_err),
+        ):
+            with _build_client() as client:
+                response = client.post(
+                    f"{PREFIX}/sessions/send",
+                    json={"content": "hi"},
+                )
+
+        assert response.status_code == 502
+        detail = response.json().get("detail", "")
+        # i18n 前缀 + SDK 原文必须都在 detail 里
+        assert "Agent" in detail or "agent" in detail
+        assert "Git for Windows" in detail
+        assert "CLAUDE_CODE_GIT_BASH_PATH" in detail


### PR DESCRIPTION
## Summary
- Windows 用户在缺 Git Bash / PowerShell 7 的机器上点 Agent 对话直接 500，看到的只有 \"Check stderr output for details\"——SDK 的 ProcessError 把真实 stderr 写死成了占位符
- 把 stderr 回调透传到 ClaudeAgentOptions，在 send_new_session / get_or_connect 路径采集 SDK 输出
- 启动失败包装为新的 AgentStartupError（__str__ 自动拼 message + stderr），router 翻译成 502 + 三语 i18n，前端能直接看到 SDK 给出的下载链接和 CLAUDE_CODE_GIT_BASH_PATH 提示

## Test plan
- [x] tests/agent_runtime/test_agent_startup_error.py 5 用例（stderr 拼接 / collector 透传 / actor 启动失败包装 / 无 stderr 也包装 / 原因链保留）
- [x] tests/test_i18n_consistency.py 全绿，zh/en/vi 新 key agent_startup_failed 一致
- [x] tests/agent_runtime/test_session_manager_sandbox.py 回归通过
- [x] ruff check + ruff format --check 通过
- [x] basedpyright 0 error（warning 全为本次改动前已有）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加代理启动失败的本地化错误提示（中/英/越），返回包含详情的多行提示信息。

* **Bug 修复**
  * 启动失败时改进错误响应：将启动异常映射为 HTTP 502，并在响应中包含收集到的子进程 stderr 以便诊断。

* **测试**
  * 新增回归测试，覆盖启动异常包装、stderr 收集与截断及接口返回行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->