### PR TITLE
fix(usage): track assistant anthropic text usage

### DIFF
--- a/frontend/src/components/layout/UsageDrawer.tsx
+++ b/frontend/src/components/layout/UsageDrawer.tsx
@@ -266,17 +266,23 @@ export function UsageDrawer({ open, onClose, projectName, anchorRef }: UsageDraw
                     <span className="num truncate">{call.model}</span>
                     {call.call_type === "text" ? (
                       <>
-                        {call.input_tokens != null && (
+                        {call.usage_tokens != null ? (
                           <span className="num">
-                            {t("input_token_label")}{" "}
-                            {call.input_tokens.toLocaleString()}
+                            {call.usage_tokens.toLocaleString()} {t("tokens_suffix")}
                           </span>
-                        )}
-                        {call.output_tokens != null && (
-                          <span className="num">
-                            {t("output_token_label")}{" "}
-                            {call.output_tokens.toLocaleString()} tokens
-                          </span>
+                        ) : (
+                          <>
+                            {call.input_tokens != null && (
+                              <span className="num">
+                                {t("input_token_label")} {call.input_tokens.toLocaleString()}
+                              </span>
+                            )}
+                            {call.output_tokens != null && (
+                              <span className="num">
+                                {t("output_token_label")} {call.output_tokens.toLocaleString()} {t("tokens_suffix")}
+                              </span>
+                            )}
+                          </>
                         )}
                       </>
                     ) : (

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -751,6 +751,7 @@ export default {
   'no_call_records': 'No call records yet',
   'input_token_label': 'Input',
   'output_token_label': 'Output',
+  'tokens_suffix': 'tokens',
   'records_count': '{{count}} records',
 
   // WorkspaceNotificationsDrawer

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -728,6 +728,7 @@ export default {
   'no_call_records': 'Chưa có bản ghi cuộc gọi',
   'input_token_label': 'Đầu vào',
   'output_token_label': 'Đầu ra',
+  'tokens_suffix': 'token',
   'records_count': '{{count}} bản ghi',
 
   // WorkspaceNotificationsDrawer

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -752,6 +752,7 @@ export default {
   'no_call_records': '暂无调用记录',
   'input_token_label': '输入',
   'output_token_label': '输出',
+  'tokens_suffix': 'tokens',
   'records_count': '{{count}} 条记录',
 
   // WorkspaceNotificationsDrawer

--- a/frontend/src/stores/stores.test.ts
+++ b/frontend/src/stores/stores.test.ts
@@ -292,6 +292,7 @@ describe("stores", () => {
           error_message: null,
           started_at: "2026-02-01T00:00:00Z",
           created_at: "2026-02-01T00:00:00Z",
+          usage_tokens: null,
           input_tokens: null,
           output_tokens: null,
         },

--- a/frontend/src/stores/usage-store.ts
+++ b/frontend/src/stores/usage-store.ts
@@ -33,6 +33,7 @@ export interface UsageCall {
   error_message: string | null;
   started_at: string;
   created_at: string;
+  usage_tokens: number | null;
   input_tokens: number | null;
   output_tokens: number | null;
 }

--- a/lib/cost_calculator.py
+++ b/lib/cost_calculator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from lib.custom_provider import is_custom_provider
 from lib.openai_shared import OPENAI_IMAGE_SIZE_MAP
-from lib.providers import PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI, CallType
+from lib.providers import PROVIDER_ANTHROPIC, PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI, CallType
 
 # fork: Vidu provider — 单独 import 块以避免与上游聚合 import 冲突
 # isort: off
@@ -168,6 +168,22 @@ class CostCalculator:
         "gpt-5.4": {"input": 2.50, "output": 15.00},
         "gpt-5.4-mini": {"input": 0.75, "output": 4.50},
         "gpt-5.4-nano": {"input": 0.20, "output": 1.25},
+    }
+
+    # Claude Agent SDK / Anthropic 文本 token 费率（美元/百万 token）。
+    # 助手主链路优先使用 SDK result.total_cost_usd；这里作为只拿到 token 时的兜底。
+    ANTHROPIC_TEXT_COST = {
+        "claude-sonnet-4": {"input": 3.00, "output": 15.00},
+        "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
+        "claude-sonnet-4.5": {"input": 3.00, "output": 15.00},
+        "claude-sonnet-4-5": {"input": 3.00, "output": 15.00},
+        "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
+        "claude-haiku-4-5": {"input": 1.00, "output": 5.00},
+        "claude-haiku-4-5-20251001": {"input": 1.00, "output": 5.00},
+        "claude-haiku-4-20250514": {"input": 1.00, "output": 5.00},
+        "claude-opus-4": {"input": 15.00, "output": 75.00},
+        "claude-opus-4-6": {"input": 15.00, "output": 75.00},
+        "claude-opus-4-7": {"input": 15.00, "output": 75.00},
     }
     # OpenAI 图片 token 费率（美元/百万 token）— GPT Image 实际计费形式
     # 来源：https://platform.openai.com/docs/pricing — GPT Image (April 2026)
@@ -431,6 +447,7 @@ class CostCalculator:
         PROVIDER_ARK: ("ARK_TEXT_COST", "doubao-seed-2-0-lite-260215", "CNY"),
         PROVIDER_GROK: ("GROK_TEXT_COST", "grok-4-1-fast-reasoning", "USD"),
         PROVIDER_OPENAI: ("OPENAI_TEXT_COST", "gpt-5.4-mini", "USD"),
+        PROVIDER_ANTHROPIC: ("ANTHROPIC_TEXT_COST", "claude-sonnet-4", "USD"),
     }
     _TEXT_COST_DEFAULT = ("GEMINI_TEXT_COST", "gemini-3-flash-preview", "USD")
 

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -123,6 +123,8 @@ class UsageRepository(BaseRepository):
         image_output_tokens: int | None = None,
         text_input_tokens: int | None = None,
         text_output_tokens: int | None = None,
+        cost_amount: float | None = None,
+        currency: str | None = None,
     ) -> None:
         finished_at = utc_now()
 
@@ -141,9 +143,9 @@ class UsageRepository(BaseRepository):
         except (ValueError, TypeError):
             duration_ms = 0
 
-        # Calculate cost (failed = 0)
-        cost_amount = 0.0
-        currency = row.currency or "USD"
+        # Calculate cost (failed = 0 unless the caller provides actual billed cost)
+        final_cost_amount = 0.0
+        final_currency = row.currency or "USD"
         effective_provider = row.provider or PROVIDER_GEMINI
 
         # Pre-query custom provider pricing (avoids sync-over-async in CostCalculator)
@@ -169,8 +171,11 @@ class UsageRepository(BaseRepository):
             input_tokens = (image_input_tokens or 0) + (text_input_tokens or 0)
             output_tokens = (image_output_tokens or 0) + (text_output_tokens or 0)
 
-        if status == "success":
-            cost_amount, currency = cost_calculator.calculate_cost(
+        if cost_amount is not None:
+            final_cost_amount = cost_amount
+            final_currency = currency or row.currency or "USD"
+        elif status == "success":
+            final_cost_amount, final_currency = cost_calculator.calculate_cost(
                 provider=effective_provider,
                 call_type=row.call_type,  # type: ignore[arg-type]
                 model=row.model,
@@ -202,8 +207,8 @@ class UsageRepository(BaseRepository):
                 finished_at=finished_at,
                 duration_ms=duration_ms,
                 retry_count=retry_count,
-                cost_amount=cost_amount,
-                currency=currency,
+                cost_amount=final_cost_amount,
+                currency=final_currency,
                 usage_tokens=usage_tokens,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,

--- a/lib/providers.py
+++ b/lib/providers.py
@@ -9,6 +9,7 @@ PROVIDER_GROK = "grok"
 PROVIDER_OPENAI = "openai"
 PROVIDER_VIDU = "vidu"
 PROVIDER_NEWAPI = "newapi"
+PROVIDER_ANTHROPIC = "anthropic"
 
 CallType = Literal["image", "video", "text"]
 CALL_TYPE_IMAGE: CallType = "image"

--- a/lib/usage_tracker.py
+++ b/lib/usage_tracker.py
@@ -69,6 +69,8 @@ class UsageTracker:
         image_output_tokens: int | None = None,
         text_input_tokens: int | None = None,
         text_output_tokens: int | None = None,
+        cost_amount: float | None = None,
+        currency: str | None = None,
     ) -> None:
 
         async with self._session_factory() as session:
@@ -89,6 +91,8 @@ class UsageTracker:
                 image_output_tokens=image_output_tokens,
                 text_input_tokens=text_input_tokens,
                 text_output_tokens=text_output_tokens,
+                cost_amount=cost_amount,
+                currency=currency,
             )
 
     async def get_stats(

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -20,7 +20,7 @@ from lib.project_manager import effective_mode
 from lib.prompt_builders_script import build_normalize_prompt
 from lib.script_generator import ScriptGenerator
 from lib.text_backends.base import TextGenerationRequest, TextTaskType
-from lib.text_backends.factory import create_text_backend_for_task
+from lib.text_generator import TextGenerator
 from server.agent_runtime.sdk_tools._context import ToolContext, fetch_video_caps, tool_error
 
 logger = logging.getLogger(__name__)
@@ -240,8 +240,11 @@ def normalize_drama_script_tool(ctx: ToolContext):
                     ]
                 }
 
-            backend = await create_text_backend_for_task(TextTaskType.SCRIPT, project_name=ctx.project_name)
-            result = await backend.generate(TextGenerationRequest(prompt=prompt, max_output_tokens=16000))
+            generator = await TextGenerator.create(TextTaskType.SCRIPT, project_name=ctx.project_name)
+            result = await generator.generate(
+                TextGenerationRequest(prompt=prompt, max_output_tokens=16000),
+                project_name=ctx.project_name,
+            )
             response = result.text
 
             drafts_dir = project_path / "drafts" / f"episode_{episode}"

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -1676,11 +1676,16 @@ class SessionManager:
     def _extract_text_token_usage(cls, result_msg: dict[str, Any]) -> tuple[int | None, int | None, int | None]:
         usage = result_msg.get("usage")
         usage_dict = usage if isinstance(usage, dict) else {}
-        input_tokens = cls._first_int(usage_dict, "input_tokens", "prompt_tokens")
+        raw_input_tokens = cls._first_int(usage_dict, "input_tokens", "prompt_tokens")
         output_tokens = cls._first_int(usage_dict, "output_tokens", "completion_tokens")
         cache_creation_tokens = cls._first_int(usage_dict, "cache_creation_input_tokens")
         cache_read_tokens = cls._first_int(usage_dict, "cache_read_input_tokens")
-        token_parts = (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens)
+        # Anthropic prompt caching：把 cache_creation/cache_read 一并合入 input_tokens，
+        # 以便价目按 input_per_million 一档"模糊覆盖"全部 prompt 成本，
+        # 避免 cache 部分被遗漏（真实 cache_read 单价更低，因此该口径偏保守、永不低估）。
+        input_parts = (raw_input_tokens, cache_creation_tokens, cache_read_tokens)
+        input_tokens = sum(part or 0 for part in input_parts) if any(part is not None for part in input_parts) else None
+        token_parts = (raw_input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens)
         usage_tokens = sum(part or 0 for part in token_parts) if any(part is not None for part in token_parts) else None
         return input_tokens, output_tokens, usage_tokens
 

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -43,6 +43,8 @@ from claude_agent_sdk.types import (
 
 from lib.config.service import ConfigService
 from lib.db import async_session_factory
+from lib.providers import PROVIDER_ANTHROPIC
+from lib.usage_tracker import UsageTracker
 
 SDK_AVAILABLE = True
 
@@ -118,6 +120,8 @@ class ManagedSession:
     buffer_max_size: int = 100
     pending_questions: dict[str, PendingQuestion] = field(default_factory=dict)
     pending_user_echoes: list[str] = field(default_factory=list)
+    last_user_prompt: str = ""
+    assistant_model: str = ""
     interrupt_requested: bool = False
     last_activity: float | None = None  # updated on every send/receive
     _cleanup_task: asyncio.Task | None = None  # current cleanup timer (idle TTL or terminal delay)
@@ -442,6 +446,7 @@ class SessionManager:
         self._sensitive_prefixes: tuple[Path, ...] = prefixes
         self._sensitive_globs: tuple[tuple[Path, str], ...] = globs
         self._load_config()
+        self.usage_tracker = UsageTracker(session_factory=getattr(meta_store, "_session_factory", None))
 
     def _compute_sensitive_paths(
         self,
@@ -1263,6 +1268,7 @@ class SessionManager:
             locale=locale,
             stderr=_collect_stderr,
         )
+        assistant_model = self._resolve_configured_assistant_model(getattr(options, "env", None))
 
         actor = SessionActor(
             client_factory=lambda: ClaudeSDKClient(options=options),
@@ -1274,6 +1280,7 @@ class SessionManager:
             actor=actor,
             status="running",
             project_name=project_name,
+            assistant_model=assistant_model,
         )
         managed_ref[0] = managed
         managed.last_activity = time.monotonic()
@@ -1322,6 +1329,7 @@ class SessionManager:
         dedup_key = display_text or (self._IMAGE_ONLY_SENTINEL if echo_content else "")
         if dedup_key:
             managed.pending_user_echoes.append(dedup_key)
+        managed.last_user_prompt = display_text
         managed.add_message(self._build_user_echo_message(display_text, echo_content))
 
         try:
@@ -1474,6 +1482,7 @@ class SessionManager:
                 can_use_tool=await self._build_can_use_tool_callback(session_id, managed_ref),
                 stderr=_collect_stderr,
             )
+            assistant_model = self._resolve_configured_assistant_model(getattr(options, "env", None))
 
             actor = SessionActor(
                 client_factory=lambda: ClaudeSDKClient(options=options),
@@ -1488,6 +1497,7 @@ class SessionManager:
                 actor=actor,
                 status=resumed_status,
                 project_name=meta.project_name,
+                assistant_model=assistant_model,
                 resolved_sdk_id=meta.id,  # 标记为已注册，防止重复创建 DB 记录
             )
             managed.sdk_id_event.set()  # 已有会话不需要等待 sdk_id
@@ -1548,6 +1558,7 @@ class SessionManager:
             managed.pending_user_echoes.append(dedup_key)
             if len(managed.pending_user_echoes) > 20:
                 managed.pending_user_echoes.pop(0)
+        managed.last_user_prompt = display_text
         managed.add_message(self._build_user_echo_message(display_text, echo_content))
 
         # Persist status asynchronously — don't block the echo broadcast
@@ -1623,11 +1634,110 @@ class SessionManager:
         )
         managed.status = final_status
         managed.last_activity = time.monotonic()
+        try:
+            await self._record_assistant_usage(managed, result_msg, final_status)
+        except Exception:
+            logger.exception("记录 assistant usage 失败 session_id=%s", managed.session_id)
         await self.meta_store.update_status(managed.session_id, final_status)
         managed.interrupt_requested = False
         self._prune_transient_buffer(managed)
         if final_status != "running":
             self._schedule_cleanup(managed.session_id)
+
+    async def _record_assistant_usage(
+        self,
+        managed: ManagedSession,
+        result_msg: dict[str, Any],
+        final_status: SessionStatus,
+    ) -> None:
+        input_tokens, output_tokens, usage_tokens = self._extract_text_token_usage(result_msg)
+        total_cost_usd = self._extract_float(result_msg.get("total_cost_usd"))
+        if input_tokens is None and output_tokens is None and total_cost_usd is None:
+            return
+
+        call_id = await self.usage_tracker.start_call(
+            project_name=managed.project_name,
+            call_type="text",
+            model=self._resolve_assistant_model(result_msg, managed.assistant_model),
+            prompt=managed.last_user_prompt[:500] if managed.last_user_prompt else None,
+            provider=PROVIDER_ANTHROPIC,
+        )
+        await self.usage_tracker.finish_call(
+            call_id,
+            status="success" if final_status == "completed" else "failed",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            usage_tokens=usage_tokens,
+            cost_amount=total_cost_usd,
+            currency="USD" if total_cost_usd is not None else None,
+        )
+
+    @classmethod
+    def _extract_text_token_usage(cls, result_msg: dict[str, Any]) -> tuple[int | None, int | None, int | None]:
+        usage = result_msg.get("usage")
+        usage_dict = usage if isinstance(usage, dict) else {}
+        input_tokens = cls._first_int(usage_dict, "input_tokens", "prompt_tokens")
+        output_tokens = cls._first_int(usage_dict, "output_tokens", "completion_tokens")
+        cache_creation_tokens = cls._first_int(usage_dict, "cache_creation_input_tokens")
+        cache_read_tokens = cls._first_int(usage_dict, "cache_read_input_tokens")
+        token_parts = (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens)
+        usage_tokens = sum(part or 0 for part in token_parts) if any(part is not None for part in token_parts) else None
+        return input_tokens, output_tokens, usage_tokens
+
+    @classmethod
+    def _first_int(cls, source: dict[str, Any], *keys: str) -> int | None:
+        for key in keys:
+            value = cls._extract_int(source.get(key))
+            if value is not None:
+                return value
+        return None
+
+    @staticmethod
+    def _extract_int(value: Any) -> int | None:
+        if isinstance(value, bool) or value is None:
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value) if value >= 0 else None
+        if isinstance(value, str):
+            value_str = value.strip()
+            if not value_str:
+                return None
+            try:
+                numeric_value = float(value_str)
+            except ValueError:
+                return None
+            return int(numeric_value) if numeric_value >= 0 else None
+        return None
+
+    @staticmethod
+    def _extract_float(value: Any) -> float | None:
+        if isinstance(value, bool) or value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _resolve_assistant_model(result_msg: dict[str, Any], configured_model: str = "") -> str:
+        model = result_msg.get("model") or result_msg.get("model_name")
+        if isinstance(model, str) and model.strip():
+            return model.strip()
+        if configured_model.strip():
+            return configured_model.strip()
+        return os.environ.get("ANTHROPIC_MODEL", "").strip() or "claude-sonnet-4"
+
+    @staticmethod
+    def _resolve_configured_assistant_model(env: Any) -> str:
+        if not isinstance(env, dict):
+            return ""
+        for key in ("ANTHROPIC_MODEL", "ANTHROPIC_DEFAULT_OPUS_MODEL", "ANTHROPIC_DEFAULT_SONNET_MODEL"):
+            value = env.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
 
     async def _mark_session_terminal(self, managed: ManagedSession, status: SessionStatus, reason: str) -> None:
         """Set terminal status on abnormal consumer exit."""

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -520,8 +520,8 @@ async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext, monkeypatch
 
 
 async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: ToolContext, monkeypatch) -> None:
-    """工具必须把 ctx.project_name 传给 create_text_backend_for_task，
-    否则项目级 text_backend_script 覆盖被跳过，会回退到全局默认后端。"""
+    """工具必须把 ctx.project_name 传给 TextGenerator.create/generate，
+    否则项目级 text_backend_script 覆盖被跳过，且 usage tracking 会丢 project_name。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
 
     project_path = fake_ctx.project_path
@@ -534,8 +534,10 @@ async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: T
 
     captured: dict[str, Any] = {}
 
-    class _FakeBackend:
-        async def generate(self, _request):
+    class _FakeGenerator:
+        async def generate(self, _request, project_name=None):
+            captured["generate_project_name"] = project_name
+
             class _R:
                 text = "| 场景 ID | 描述 |\n|---|---|\n| E1S01 | 山中 |"
 
@@ -543,19 +545,24 @@ async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: T
 
     async def fake_create(task_type, project_name=None):
         captured["task_type"] = task_type
-        captured["project_name"] = project_name
-        return _FakeBackend()
+        captured["create_project_name"] = project_name
+        return _FakeGenerator()
 
     monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
-    monkeypatch.setattr(mod, "create_text_backend_for_task", fake_create)
+    monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
     tool_obj = normalize_drama_script_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1})
 
     assert out.get("is_error") is not True, out
-    assert captured["project_name"] == "demo", (
-        f"normalize_drama_script 必须传入 project_name 以让项目级 text_backend_script 覆盖生效，"
-        f"实际传入: {captured.get('project_name')!r}"
+    assert captured["task_type"] is mod.TextTaskType.SCRIPT
+    assert captured["create_project_name"] == "demo", (
+        f"normalize_drama_script 必须向 TextGenerator.create 传入 project_name，"
+        f"实际传入: {captured.get('create_project_name')!r}"
+    )
+    assert captured["generate_project_name"] == "demo", (
+        f"normalize_drama_script 必须向 TextGenerator.generate 传入 project_name，"
+        f"实际传入: {captured.get('generate_project_name')!r}"
     )
 
 

--- a/tests/test_cost_calculator.py
+++ b/tests/test_cost_calculator.py
@@ -1,6 +1,7 @@
 import pytest
 
 from lib.cost_calculator import CostCalculator, cost_calculator
+from lib.providers import PROVIDER_ANTHROPIC
 
 
 class TestCostCalculator:
@@ -41,6 +42,41 @@ class TestCostCalculator:
 
     def test_singleton_instance(self):
         assert isinstance(cost_calculator, CostCalculator)
+
+
+class TestAnthropicTextCost:
+    def test_calculate_anthropic_text_cost(self):
+        amount, currency = cost_calculator.calculate_text_cost(
+            input_tokens=100_000,
+            output_tokens=50_000,
+            provider=PROVIDER_ANTHROPIC,
+            model="claude-sonnet-4",
+        )
+
+        assert currency == "USD"
+        assert amount == pytest.approx(1.05)
+
+    def test_unknown_anthropic_model_uses_default(self):
+        amount, currency = cost_calculator.calculate_text_cost(
+            input_tokens=100_000,
+            output_tokens=50_000,
+            provider=PROVIDER_ANTHROPIC,
+            model="unknown-claude",
+        )
+
+        assert currency == "USD"
+        assert amount == pytest.approx(1.05)
+
+    def test_calculate_anthropic_haiku_text_cost(self):
+        amount, currency = cost_calculator.calculate_text_cost(
+            input_tokens=100_000,
+            output_tokens=50_000,
+            provider=PROVIDER_ANTHROPIC,
+            model="claude-haiku-4-5",
+        )
+
+        assert currency == "USD"
+        assert amount == pytest.approx(0.35)
 
 
 class TestArkCost:

--- a/tests/test_session_manager_sdk_session_id.py
+++ b/tests/test_session_manager_sdk_session_id.py
@@ -109,7 +109,7 @@ class TestSessionManagerSdkSessionId:
         assert row.call_type == "text"
         assert row.model == "claude-sonnet-4"
         assert row.prompt == "hello assistant"
-        assert row.input_tokens == 1000
+        assert row.input_tokens == 1050
         assert row.output_tokens == 200
         assert row.usage_tokens == 1250
         assert row.cost_amount == pytest.approx(0.1234)
@@ -181,7 +181,8 @@ class TestSessionManagerSdkSessionId:
             }
         )
 
-        assert input_tokens == 1000
+        # input_tokens 现在合并了 cache_read/cache_creation（按输入价"模糊覆盖" prompt cache 成本）
+        assert input_tokens == 1050
         assert output_tokens == 200
         assert usage_tokens == 1250
 

--- a/tests/test_session_manager_sdk_session_id.py
+++ b/tests/test_session_manager_sdk_session_id.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 
+import pytest
+from sqlalchemy import select
+
+from lib.db.models.api_call import ApiCall
 from server.agent_runtime.session_actor import SessionActor
 from server.agent_runtime.session_manager import ManagedSession
 from tests.fakes import FakeSDKClient
@@ -68,6 +72,127 @@ class TestSessionManagerSdkSessionId:
         assert meta is not None
         assert meta.project_name == "demo"
         assert meta.status == "running"
+
+    async def test_finalize_turn_records_assistant_usage(self, session_manager, meta_store):
+        meta = await meta_store.create("demo", "sdk-usage-789")
+        managed = _make_managed(session_id=meta.id, project_name="demo", assistant_model="claude-sonnet-4")
+        managed.last_user_prompt = "hello assistant"
+
+        await session_manager._finalize_turn(
+            managed,
+            {
+                "type": "result",
+                "session_status": "completed",
+                "model": "claude-sonnet-4",
+                "total_cost_usd": 0.1234,
+                "usage": {
+                    "input_tokens": 1000,
+                    "output_tokens": 200,
+                    "cache_creation_input_tokens": 50,
+                },
+            },
+        )
+
+        async with meta_store._session_factory() as session:  # noqa: SLF001 - test fixture exposes shared DB factory
+            row = (
+                await session.execute(
+                    select(ApiCall).where(
+                        ApiCall.project_name == "demo",
+                        ApiCall.model == "claude-sonnet-4",
+                        ApiCall.prompt == "hello assistant",
+                    )
+                )
+            ).scalar_one()
+
+        assert row.project_name == "demo"
+        assert row.provider == "anthropic"
+        assert row.call_type == "text"
+        assert row.model == "claude-sonnet-4"
+        assert row.prompt == "hello assistant"
+        assert row.input_tokens == 1000
+        assert row.output_tokens == 200
+        assert row.usage_tokens == 1250
+        assert row.cost_amount == pytest.approx(0.1234)
+        assert row.currency == "USD"
+        refreshed = await meta_store.get(meta.id)
+        assert refreshed is not None
+        assert refreshed.status == "completed"
+
+    async def test_finalize_turn_preserves_sdk_cost_for_failed_status(self, session_manager, meta_store):
+        meta = await meta_store.create("demo", "sdk-usage-failed-789")
+        managed = _make_managed(session_id=meta.id, project_name="demo", assistant_model="claude-sonnet-4")
+        managed.last_user_prompt = "failed but billed"
+
+        await session_manager._finalize_turn(
+            managed,
+            {
+                "type": "result",
+                "session_status": "error",
+                "model": "claude-sonnet-4",
+                "total_cost_usd": 0.0456,
+                "usage": {"input_tokens": 100, "output_tokens": 20},
+            },
+        )
+
+        async with meta_store._session_factory() as session:  # noqa: SLF001 - test fixture exposes shared DB factory
+            row = (
+                await session.execute(
+                    select(ApiCall).where(
+                        ApiCall.project_name == "demo",
+                        ApiCall.model == "claude-sonnet-4",
+                        ApiCall.prompt == "failed but billed",
+                    )
+                )
+            ).scalar_one()
+
+        assert row.status == "failed"
+        assert row.cost_amount == pytest.approx(0.0456)
+        assert row.currency == "USD"
+        refreshed = await meta_store.get(meta.id)
+        assert refreshed is not None
+        assert refreshed.status == "error"
+
+    async def test_finalize_turn_usage_failure_does_not_override_status(self, session_manager, meta_store, monkeypatch):
+        meta = await meta_store.create("demo", "sdk-usage-error-789")
+        managed = _make_managed(session_id=meta.id, project_name="demo")
+
+        async def _raise_usage_error(*_args, **_kwargs):
+            raise RuntimeError("usage db unavailable")
+
+        monkeypatch.setattr(session_manager, "_record_assistant_usage", _raise_usage_error)
+
+        await session_manager._finalize_turn(
+            managed,
+            {"type": "result", "session_status": "completed", "usage": {"input_tokens": 1}},
+        )
+
+        refreshed = await meta_store.get(meta.id)
+        assert refreshed is not None
+        assert refreshed.status == "completed"
+
+    async def test_extract_text_token_usage_accepts_numeric_strings(self, session_manager):
+        input_tokens, output_tokens, usage_tokens = session_manager._extract_text_token_usage(
+            {
+                "usage": {
+                    "input_tokens": "1000.0",
+                    "output_tokens": "200",
+                    "cache_read_input_tokens": 50.0,
+                }
+            }
+        )
+
+        assert input_tokens == 1000
+        assert output_tokens == 200
+        assert usage_tokens == 1250
+
+    async def test_extract_text_token_usage_preserves_missing_as_none(self, session_manager):
+        input_tokens, output_tokens, usage_tokens = session_manager._extract_text_token_usage(
+            {"usage": {"input_tokens": None, "output_tokens": "not-a-number"}}
+        )
+
+        assert input_tokens is None
+        assert output_tokens is None
+        assert usage_tokens is None
 
     async def test_on_sdk_session_id_received_noop_when_already_registered(self, session_manager, meta_store):
         """For sessions with resolved_sdk_id already set, it's a no-op."""


### PR DESCRIPTION
## 范围

本 PR 聚焦 AI 助手 Claude Agent SDK 文本调用的 usage / cost 记录问题。

包含：
- 助手会话 result 完成时记录 Anthropic text usage
- 支持优先落库 SDK 返回的 `total_cost_usd`
- 为 Anthropic text token 增加内置 fallback 计价
- 让 SDK text generation tool 复用现有 `TextGenerator` usage tracking

## 变更

- 新增 `anthropic` provider 常量，并接入 `CostCalculator` text 计价表
- `UsageTracker` / `UsageRepository` 支持调用方传入已计算成本与币种，避免覆盖 SDK 返回成本
- `SessionManager` 在 assistant turn finalized 时从 SDK result 提取 token / model / cost 并写入 usage 记录
- `normalize_drama_script_tool` 改为通过 `TextGenerator` 调用文本后端，复用现有 usage tracking
- 前端用量抽屉补充 `usage_tokens` 类型与展示，便于查看 assistant SDK 返回的总 token 用量
- 增加 Anthropic text fallback 计价测试和 assistant session usage 落库测试

## 验收清单

- [x] 本地已跑相关测试（说明命令）
  - `conda run -n arcreel ruff check .`
  - `conda run -n arcreel python -m pytest tests/test_cost_calculator.py tests/test_session_manager_sdk_session_id.py tests/test_assistant_routes.py tests/agent_runtime/test_agent_startup_error.py -q`
  - `uv run --no-dev python -c "import server.app; print('server-app-import-ok')"`
  - `conda run -n arcreel basedpyright lib/cost_calculator.py lib/usage_tracker.py lib/db/repositories/usage_repo.py server/agent_runtime/session_manager.py server/agent_runtime/sdk_tools/text_generation.py tests/test_cost_calculator.py tests/test_session_manager_sdk_session_id.py`
- [x] 手动验证了改动所声称的行为
  - 确认 PR 分支仅包含 assistant usage/cost tracking 相关 diff，未包含 fork-only pricing / user-roles 内容
  - 确认新增 session manager 测试覆盖 SDK result finalized 后写入 `ApiCall`
- [x] 新增面向用户文案已加 zh/en 翻译（如适用）
  - 不适用，本 PR 无新增面向用户文案
- [x] 无新增 ESLint disable

## 已知 defer

无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 支持 Anthropic (Claude) 文本计费，按模型返回币种与金额（默认 USD）
  * 会话自动记录并上报助手模型、用户最新 prompt、token 使用与费用；允许外部传入并覆盖成本金额与货币
  * 前端优先展示汇总 usage_tokens，新增 usage_tokens 字段并补充 tokens 后缀文案

* **测试**
  * 新增与完善 Anthropic 计费及会话/用量上报相关测试覆盖

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->