### PR TITLE
fix: agent_credential_repo delete 不存在 ID 时返回 404

### DIFF
--- a/lib/db/repositories/agent_credential_repo.py
+++ b/lib/db/repositories/agent_credential_repo.py
@@ -99,12 +99,20 @@ class AgentCredentialRepository(BaseRepository):
         cred.is_active = True
         await self.session.flush()
 
-    async def delete(self, cred_id: int) -> None:
-        """删除非 active 凭证。删 active 抛 ValueError。"""
+    async def delete(self, cred_id: int) -> bool:
+        """删除非 active 凭证。
+
+        Returns:
+            True: 删除成功；False: 凭证不存在。
+
+        Raises:
+            ValueError: 试图删除当前 active 凭证。
+        """
         cred = await self.get(cred_id)
         if cred is None:
-            return
+            return False
         if cred.is_active:
             raise ValueError("cannot delete active credential; activate another first")
         await self.session.execute(delete(AgentAnthropicCredential).where(AgentAnthropicCredential.id == cred_id))
         await self.session.flush()
+        return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ markers = [
 
 [tool.coverage.run]
 source = ["lib", "server"]
+concurrency = ["greenlet", "thread"]
 
 [tool.coverage.report]
 show_missing = true

--- a/server/routers/agent_config.py
+++ b/server/routers/agent_config.py
@@ -237,11 +237,11 @@ async def delete_credential(
 ) -> None:
     repo = AgentCredentialRepository(session)
     try:
-        await repo.delete(cred_id)
+        deleted = await repo.delete(cred_id)
     except ValueError as exc:
-        if "active" in str(exc):
-            raise HTTPException(status_code=409, detail=_t("agent_cannot_delete_active")) from exc
-        raise HTTPException(status_code=404, detail=_t("agent_credential_not_found")) from exc
+        raise HTTPException(status_code=409, detail=_t("agent_cannot_delete_active")) from exc
+    if not deleted:
+        raise HTTPException(status_code=404, detail=_t("agent_credential_not_found"))
     await session.commit()
 
 

--- a/tests/test_agent_config_router.py
+++ b/tests/test_agent_config_router.py
@@ -177,6 +177,24 @@ async def test_delete_nonexistent_returns_404(authed_client) -> None:
     assert resp.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_delete_inactive_returns_204(authed_client) -> None:
+    # 第一条自动 active
+    await authed_client.post(
+        "/api/v1/agent/credentials",
+        json={"preset_id": "deepseek", "api_key": "sk-A"},
+    )
+    # 第二条显式 activate=False，可删
+    second = (
+        await authed_client.post(
+            "/api/v1/agent/credentials",
+            json={"preset_id": "kimi", "api_key": "sk-B", "activate": False},
+        )
+    ).json()
+    resp = await authed_client.delete(f"/api/v1/agent/credentials/{second['id']}")
+    assert resp.status_code == 204
+
+
 # ── Task 11: POST /agent/credentials/{id}/activate ────────────────
 
 

--- a/tests/test_agent_config_router.py
+++ b/tests/test_agent_config_router.py
@@ -171,6 +171,12 @@ async def test_delete_active_blocked(authed_client) -> None:
     assert resp.status_code == 409
 
 
+@pytest.mark.asyncio
+async def test_delete_nonexistent_returns_404(authed_client) -> None:
+    resp = await authed_client.delete("/api/v1/agent/credentials/9999")
+    assert resp.status_code == 404
+
+
 # ── Task 11: POST /agent/credentials/{id}/activate ────────────────
 
 

--- a/tests/test_agent_credential_repo.py
+++ b/tests/test_agent_credential_repo.py
@@ -72,9 +72,15 @@ async def test_delete_inactive_works(async_session) -> None:
     repo = AgentCredentialRepository(async_session)
     a = await repo.create(preset_id="x", display_name="A", base_url="u", api_key="k")
     await async_session.flush()
-    await repo.delete(a.id)
+    assert await repo.delete(a.id) is True
     await async_session.flush()
     assert await repo.get(a.id) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_returns_false(async_session) -> None:
+    repo = AgentCredentialRepository(async_session)
+    assert await repo.delete(9999) is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `AgentCredentialRepository.delete` 在凭证不存在时返回 `False`（之前静默 `return None`），让路由层能区分"目标不存在"与"删除成功"
- `DELETE /api/v1/agent/credentials/{id}` 在目标缺失时正确返回 **404**（之前误判为 204），与 `api_keys` / `custom_providers` / `providers` 等 DELETE 行为一致
- 路由层 `except ValueError` 不再做 `"active" in str(exc)` 字符串匹配：`ValueError` 现在只承载"删 active"一种语义，直接映射 409

## Test plan

- [x] `tests/test_agent_credential_repo.py`：新增 `test_delete_nonexistent_returns_false`；`test_delete_inactive_works` 断言返回 `True`
- [x] `tests/test_agent_config_router.py`：新增 `test_delete_nonexistent_returns_404`
- [x] `uv run python -m pytest tests/test_agent_credential_repo.py tests/test_agent_config_router.py` → 23 passed
- [x] `uv run ruff check / format` → All checks passed
- [x] `uv run basedpyright` 改动文件 → 0 errors

Closes #563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 代理凭证删除行为调整：删除不存在的凭证返回 404，尝试删除活跃凭证返回 409；删除请求现在明确表明是否成功。
* **Tests**
  * 新增与更新删除相关测试，覆盖成功删除与凭证不存在的场景。
* **Chores**
  * 测试覆盖率并发配置已更新以改进覆盖采集。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->