### PR TITLE
fix(compose-video): 修复 ffmpeg 滤镜图与 fps fallback 多处问题

### DIFF
--- a/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
+++ b/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
@@ -86,6 +86,23 @@ def _resolve_fps(avg_frame_rate: object, r_frame_rate: object) -> str:
     return "30"
 
 
+def _coerce_numeric_duration(raw: object) -> float | None:
+    """把 ffprobe 的 duration 字段安全转成 float，无效值返回 None。
+
+    部分 webm/流式封装会让 `stream.duration="N/A"`（真值字符串，`or` 无法回退），
+    或返回空串 / 非数值；统一在这里过滤，让调用方走数值有效性而不是真值判断。
+    """
+    if raw is None:
+        return None
+    candidate = str(raw).strip()
+    if not candidate or candidate.upper() == "N/A":
+        return None
+    try:
+        return float(candidate)
+    except ValueError:
+        return None
+
+
 def get_video_duration(video_path: Path) -> float:
     """获取视频时长"""
     result = subprocess.run(
@@ -147,14 +164,14 @@ def probe_media(video_path: Path) -> dict[str, object]:
     fps = _resolve_fps(video_stream.get("avg_frame_rate"), video_stream.get("r_frame_rate"))
 
     # duration 优先 video stream（mkv/webm 等容器 format.duration 与 stream.duration
-    # 可能相差几毫秒；atrim 静音音轨长度与 xfade offset 需要精确，必须以 stream 为准）
-    duration_raw = video_stream.get("duration") or payload.get("format", {}).get("duration")
-    if not duration_raw:
+    # 可能相差几毫秒；atrim 静音音轨长度与 xfade offset 需要精确，必须以 stream 为准）。
+    # 但 ffprobe 对部分 webm/流式封装会让 stream.duration="N/A"（真值字符串，
+    # `or` 链不会回退），所以这里用数值有效性而不是真值判断逐级回退。
+    duration = _coerce_numeric_duration(video_stream.get("duration"))
+    if duration is None:
+        duration = _coerce_numeric_duration(payload.get("format", {}).get("duration"))
+    if duration is None:
         raise RuntimeError(f"无法从 ffprobe 输出中获取时长: {video_path}")
-    try:
-        duration = float(duration_raw)
-    except ValueError as exc:
-        raise RuntimeError(f"无法解析视频时长: {video_path}") from exc
 
     width = int(video_stream.get("width") or 0)
     height = int(video_stream.get("height") or 0)
@@ -502,6 +519,8 @@ def concatenate_with_transitions(
             "aac",
             "-b:a",
             "192k",
+            "-movflags",
+            "+faststart",
             str(output_path),
         ]
 

--- a/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
+++ b/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
@@ -12,6 +12,7 @@ Example:
 
 import argparse
 import json
+import math
 import subprocess
 import sys
 import tempfile
@@ -91,6 +92,10 @@ def _coerce_numeric_duration(raw: object) -> float | None:
 
     部分 webm/流式封装会让 `stream.duration="N/A"`（真值字符串，`or` 无法回退），
     或返回空串 / 非数值；统一在这里过滤，让调用方走数值有效性而不是真值判断。
+
+    同时拒绝 `nan` / `inf` 和非正数：`float("nan") <= 0.5` 是 `False`，
+    会绕过 `_build_xfade_filter_complex` 的短片段降级，把 `nan` 直接传进
+    xfade `offset` 参数，ffmpeg 会因此报错。
     """
     if raw is None:
         return None
@@ -98,9 +103,12 @@ def _coerce_numeric_duration(raw: object) -> float | None:
     if not candidate or candidate.upper() == "N/A":
         return None
     try:
-        return float(candidate)
+        value = float(candidate)
     except ValueError:
         return None
+    if not math.isfinite(value) or value <= 0:
+        return None
+    return value
 
 
 def get_video_duration(video_path: Path) -> float:

--- a/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
+++ b/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
@@ -69,6 +69,23 @@ def run_ffmpeg(cmd: list[str], error_prefix: str) -> None:
         raise RuntimeError(f"{error_prefix}: {result.stderr}")
 
 
+def _resolve_fps(avg_frame_rate: object, r_frame_rate: object) -> str:
+    """从 ffprobe 字段解析 fps。
+
+    `avg_frame_rate="0/0"` 是常见的伪真值（部分 GIF→MP4 转换 / 屏幕录制软件输出），
+    若用 `or` 链 fallback，下游 ffmpeg 滤镜会被喂入 `"0/0"` 直接失败。
+    这里显式黑名单 `{"0/0","0",""}`，优先 avg，再 r，最后回退 `"30"`。
+    """
+    for value in (avg_frame_rate, r_frame_rate):
+        if value is None:
+            continue
+        candidate = str(value).strip()
+        if candidate in {"0/0", "0", ""}:
+            continue
+        return candidate
+    return "30"
+
+
 def get_video_duration(video_path: Path) -> float:
     """获取视频时长"""
     result = subprocess.run(
@@ -127,11 +144,11 @@ def probe_media(video_path: Path) -> dict[str, object]:
     if not video_stream:
         raise RuntimeError(f"缺少视频流: {video_path}")
 
-    fps = str(video_stream.get("avg_frame_rate") or video_stream.get("r_frame_rate") or "30")
-    if fps in {"0/0", "0", ""}:
-        fps = "30"
+    fps = _resolve_fps(video_stream.get("avg_frame_rate"), video_stream.get("r_frame_rate"))
 
-    duration_raw = payload.get("format", {}).get("duration")
+    # duration 优先 video stream（mkv/webm 等容器 format.duration 与 stream.duration
+    # 可能相差几毫秒；atrim 静音音轨长度与 xfade offset 需要精确，必须以 stream 为准）
+    duration_raw = video_stream.get("duration") or payload.get("format", {}).get("duration")
     if not duration_raw:
         raise RuntimeError(f"无法从 ffprobe 输出中获取时长: {video_path}")
     try:
@@ -271,6 +288,25 @@ def concatenate_final(video_paths: list[Path], output_path: Path):
     if not video_paths:
         raise ValueError("没有可用的视频片段")
 
+    if len(video_paths) == 1:
+        # 单段直接 remux：concat filter 要求 n>=2，否则 ffmpeg 报参数错误；
+        # 中间片在 normalize_clip 内已统一编码 + setpts 归零，这里只需补 +faststart
+        run_ffmpeg(
+            [
+                "ffmpeg",
+                "-y",
+                "-i",
+                str(video_paths[0].resolve()),
+                "-c",
+                "copy",
+                "-movflags",
+                "+faststart",
+                str(output_path),
+            ],
+            "ffmpeg 单段最终输出失败",
+        )
+        return
+
     inputs: list[str] = []
     filter_inputs: list[str] = []
     for index, path in enumerate(video_paths):
@@ -325,13 +361,107 @@ def concatenate_simple(video_paths: list, output_path: Path):
         concatenate_final(normalized_paths, output_path)
 
 
+_XFADE_TYPE_MAP: dict[str, str] = {
+    "fade": "fade",
+    "dissolve": "dissolve",
+    "wipe": "wipeleft",
+}
+
+
+def _build_xfade_filter_complex(
+    durations: list[float],
+    transitions: list[str],
+    transition_duration: float,
+) -> str | None:
+    """按 cut 边界把片段切成 group，组内 xfade + acrossfade，组间 concat 串联。
+
+    - 单段或全 cut 序列：返回 None，由调用方走 concatenate_final 的纯 concat 路径
+    - 短片段（duration <= transition_duration）所触边界自动降级为 cut，避免 xfade
+      offset 为负
+    - video 走 xfade chain、audio 走 acrossfade chain，两者每个边界都消耗
+      transition_duration 秒，组内总时长一致 → 音画同步
+    - 组间用 concat=v=1:a=1 串联，避开"全局 xfade offset 在 cut 边界累加错位"
+    """
+    n = len(durations)
+    if n < 2:
+        return None
+
+    # 计算每个边界的有效转场类型（None 表示走 cut）
+    boundary_xfade: list[str | None] = []
+    for i in range(n - 1):
+        transition = transitions[i] if i < len(transitions) else "fade"
+        if transition == "cut":
+            boundary_xfade.append(None)
+            continue
+        xfade = _XFADE_TYPE_MAP.get(transition, "fade")
+        if durations[i] <= transition_duration or durations[i + 1] <= transition_duration:
+            boundary_xfade.append(None)
+            continue
+        boundary_xfade.append(xfade)
+
+    if all(b is None for b in boundary_xfade):
+        return None
+
+    # 按 cut 边界把片段索引切成 group（每个 group 内部边界都是 xfade）
+    groups: list[list[int]] = []
+    current: list[int] = [0]
+    for i, b in enumerate(boundary_xfade):
+        if b is None:
+            groups.append(current)
+            current = [i + 1]
+        else:
+            current.append(i + 1)
+    groups.append(current)
+
+    filter_parts: list[str] = []
+    group_outputs: list[tuple[str, str]] = []
+
+    for gi, group in enumerate(groups):
+        if len(group) == 1:
+            idx = group[0]
+            group_outputs.append((f"[{idx}:v]", f"[{idx}:a]"))
+            continue
+
+        group_durations = [durations[j] for j in group]
+
+        # video xfade chain：offset 在组内累加，索引从 group 起点起算
+        prev_v = f"[{group[0]}:v]"
+        for k in range(1, len(group)):
+            xfade_type = boundary_xfade[group[k] - 1]
+            assert xfade_type is not None
+            offset = sum(group_durations[:k]) - k * transition_duration
+            out_v = f"[g{gi}v]" if k == len(group) - 1 else f"[g{gi}v{k}]"
+            filter_parts.append(
+                f"{prev_v}[{group[k]}:v]xfade=transition={xfade_type}:"
+                f"duration={transition_duration}:offset={offset:.3f}{out_v}"
+            )
+            prev_v = out_v
+
+        # audio acrossfade chain：与 video xfade 一一对应，每个边界消耗 transition_duration
+        prev_a = f"[{group[0]}:a]"
+        for k in range(1, len(group)):
+            out_a = f"[g{gi}a]" if k == len(group) - 1 else f"[g{gi}a{k}]"
+            filter_parts.append(f"{prev_a}[{group[k]}:a]acrossfade=d={transition_duration}:c1=tri:c2=tri{out_a}")
+            prev_a = out_a
+
+        group_outputs.append((f"[g{gi}v]", f"[g{gi}a]"))
+
+    if len(group_outputs) == 1:
+        v_label, a_label = group_outputs[0]
+        filter_parts.append(f"{v_label}null[vout]")
+        filter_parts.append(f"{a_label}anull[aout]")
+    else:
+        concat_inputs = "".join(f"{v}{a}" for v, a in group_outputs)
+        filter_parts.append(f"{concat_inputs}concat=n={len(group_outputs)}:v=1:a=1[vout][aout]")
+
+    return ";".join(filter_parts)
+
+
 def concatenate_with_transitions(
     video_paths: list, transitions: list, output_path: Path, transition_duration: float = 0.5
 ):
     """
-    使用转场效果拼接视频
-
-    使用 xfade 滤镜实现转场
+    使用 xfade 滤镜实现场景间转场，cut 边界用 concat 串联以避免滤镜链断裂。
     """
     with tempfile.TemporaryDirectory(prefix="compose-video-") as temp_dir:
         normalized_paths = normalize_clips(video_paths, Path(temp_dir))
@@ -339,60 +469,16 @@ def concatenate_with_transitions(
             concatenate_final(normalized_paths, output_path)
             return
 
-        # 构建 filter_complex
-        inputs = []
-        for path in normalized_paths:
-            inputs.extend(["-i", str(path.resolve())])
-
-        # 获取每个视频的时长
         durations = [get_video_duration(p) for p in normalized_paths]
+        filter_complex = _build_xfade_filter_complex(durations, transitions, transition_duration)
 
-        # 构建 xfade 滤镜链
-        filter_parts = []
-
-        for i in range(len(normalized_paths) - 1):
-            transition = transitions[i] if i < len(transitions) else "fade"
-
-            # xfade 类型映射
-            xfade_type = {
-                "cut": None,  # 不使用转场
-                "fade": "fade",
-                "dissolve": "dissolve",
-                "wipe": "wipeleft",
-            }.get(transition, "fade")
-
-            if xfade_type is None:
-                # cut 转场，不需要 xfade
-                continue
-
-            if i == 0:
-                prev_label = "[0:v]"
-            else:
-                prev_label = f"[v{i}]"
-
-            next_label = f"[{i + 1}:v]"
-            out_label = f"[v{i + 1}]" if i < len(normalized_paths) - 2 else "[vout]"
-
-            # 计算偏移量
-            offset = sum(durations[: i + 1]) - transition_duration * (i + 1)
-
-            filter_parts.append(
-                f"{prev_label}{next_label}xfade=transition={xfade_type}:"
-                f"duration={transition_duration}:offset={offset:.3f}{out_label}"
-            )
-
-        if not filter_parts:
+        if filter_complex is None:
             concatenate_final(normalized_paths, output_path)
             return
 
-        # 下一个容易踩的坑：这里的视频转场已经平滑，但音频仍是硬拼接；
-        # 如果后面要做“听感也平滑”的转场，需要把 concat 改成 acrossfade / afade 链。
-        audio_filter = (
-            ";".join([f"[{i}:a]" for i in range(len(normalized_paths))])
-            + f"concat=n={len(normalized_paths)}:v=0:a=1[aout]"
-        )
-
-        filter_complex = ";".join(filter_parts) + ";" + audio_filter
+        inputs: list[str] = []
+        for path in normalized_paths:
+            inputs.extend(["-i", str(path.resolve())])
 
         cmd = [
             "ffmpeg",

--- a/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
+++ b/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
@@ -486,7 +486,11 @@ def concatenate_with_transitions(
             concatenate_final(normalized_paths, output_path)
             return
 
-        durations = [get_video_duration(p) for p in normalized_paths]
+        # xfade offset 必须取 video stream 时长：归一化后的 MP4 因 AAC priming /
+        # 容器取整，format.duration 可能比 stream.duration 长几毫秒，把它直接当
+        # offset 喂给 xfade 会让转场触发时机偏晚，看上去几乎"没淡出"。
+        # 复用 probe_media 的 stream-优先 + N/A 回退逻辑，而不是走 get_video_duration（仅 format.duration）。
+        durations = [float(probe_media(p)["duration"]) for p in normalized_paths]
         filter_complex = _build_xfade_filter_complex(durations, transitions, transition_duration)
 
         if filter_complex is None:

--- a/tests/test_compose_video_filter_graph.py
+++ b/tests/test_compose_video_filter_graph.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -80,6 +81,44 @@ class TestResolveFps:
 
     def test_strips_whitespace(self) -> None:
         assert compose_video._resolve_fps(" 24/1 ", None) == "24/1"
+
+
+# ---------------------------------------------------------------------------
+# _coerce_numeric_duration
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceNumericDuration:
+    """ffprobe duration 字段的容错解析。
+
+    ffprobe 对部分 webm / 流式封装会返回 `stream.duration="N/A"`，
+    这是真值字符串但不是数值；旧实现 `stream.duration or format.duration` 会
+    选中 "N/A" 然后 float() 抛错，导致正常视频被拒。这里覆盖该回归。
+    """
+
+    def test_numeric_string_parses(self) -> None:
+        assert compose_video._coerce_numeric_duration("12.34") == 12.34
+
+    def test_na_returns_none(self) -> None:
+        assert compose_video._coerce_numeric_duration("N/A") is None
+
+    def test_na_lowercase_returns_none(self) -> None:
+        assert compose_video._coerce_numeric_duration("n/a") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert compose_video._coerce_numeric_duration("") is None
+
+    def test_whitespace_only_returns_none(self) -> None:
+        assert compose_video._coerce_numeric_duration("   ") is None
+
+    def test_none_returns_none(self) -> None:
+        assert compose_video._coerce_numeric_duration(None) is None
+
+    def test_non_numeric_garbage_returns_none(self) -> None:
+        assert compose_video._coerce_numeric_duration("not-a-number") is None
+
+    def test_strips_whitespace(self) -> None:
+        assert compose_video._coerce_numeric_duration(" 5.5 ") == 5.5
 
 
 # ---------------------------------------------------------------------------
@@ -251,4 +290,4 @@ class TestConcatenateFinalSingleSegment:
 
     def test_empty_list_raises(self) -> None:
         with pytest.raises(ValueError, match="没有可用的视频片段"):
-            compose_video.concatenate_final([], Path("/tmp/unused.mp4"))
+            compose_video.concatenate_final([], Path(tempfile.gettempdir()) / "unused.mp4")

--- a/tests/test_compose_video_filter_graph.py
+++ b/tests/test_compose_video_filter_graph.py
@@ -120,6 +120,25 @@ class TestCoerceNumericDuration:
     def test_strips_whitespace(self) -> None:
         assert compose_video._coerce_numeric_duration(" 5.5 ") == 5.5
 
+    def test_nan_returns_none(self) -> None:
+        """nan 会让 `nan <= transition_duration` 是 False，绕过短片段降级，
+        把 nan 喂给 xfade offset。必须在 helper 层拒掉。"""
+        assert compose_video._coerce_numeric_duration("nan") is None
+        assert compose_video._coerce_numeric_duration("NaN") is None
+
+    def test_inf_returns_none(self) -> None:
+        assert compose_video._coerce_numeric_duration("inf") is None
+        assert compose_video._coerce_numeric_duration("Infinity") is None
+        assert compose_video._coerce_numeric_duration("-inf") is None
+
+    def test_zero_returns_none(self) -> None:
+        """duration=0 没意义，回退到 format.duration 试一次。"""
+        assert compose_video._coerce_numeric_duration("0") is None
+        assert compose_video._coerce_numeric_duration("0.0") is None
+
+    def test_negative_returns_none(self) -> None:
+        assert compose_video._coerce_numeric_duration("-1.5") is None
+
 
 # ---------------------------------------------------------------------------
 # _build_xfade_filter_complex

--- a/tests/test_compose_video_filter_graph.py
+++ b/tests/test_compose_video_filter_graph.py
@@ -1,0 +1,254 @@
+"""compose_video.py 滤镜图构造与 fps 解析的纯函数单测。
+
+不依赖 ffmpeg / ffprobe，覆盖以下回归断言：
+
+- `_resolve_fps`：avg_frame_rate `"0/0"`/`"0"`/`""` 显式回退到 r_frame_rate，
+  而不是被 `or` 链当作真值通过（issue #562、#564 第 5 条）
+- `_build_xfade_filter_complex`：
+  - 全 cut → 返回 None（调用方 fallback 到 concatenate_final）
+  - 多片段 xfade chain + acrossfade chain 音画对齐（#564 第 3 条）
+  - cut+xfade 混用按 cut 分组、组内 offset 不跨 cut 累加（#564 评论补充）
+  - 短片段边界自动降级为 cut（避免负 offset）
+  - audio 输入标签用空串连接而非 `;` 分隔（#564 第 1 条核心回归）
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = (
+    REPO_ROOT / "agent_runtime_profile" / ".claude" / "skills" / "compose-video" / "scripts" / "compose_video.py"
+)
+
+# compose_video.py 顶部会 `from lib.project_manager import ProjectManager`，
+# 需保证 REPO_ROOT 在 sys.path（pytest 默认会注入，这里二次防御）
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _load_module():
+    """以独立模块名加载脚本，避免和别处的 compose_video 冲突。"""
+    spec = importlib.util.spec_from_file_location("_compose_video_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+compose_video = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# _resolve_fps
+# ---------------------------------------------------------------------------
+
+
+class TestResolveFps:
+    def test_avg_0_over_0_falls_back_to_r(self) -> None:
+        """#562 核心场景：avg 为 '0/0' 时必须回退 r，不能直接被 `or` 当真值通过。"""
+        assert compose_video._resolve_fps("0/0", "24/1") == "24/1"
+
+    def test_avg_0_falls_back_to_r(self) -> None:
+        assert compose_video._resolve_fps("0", "24/1") == "24/1"
+
+    def test_avg_empty_string_falls_back_to_r(self) -> None:
+        assert compose_video._resolve_fps("", "30000/1001") == "30000/1001"
+
+    def test_both_invalid_returns_30(self) -> None:
+        assert compose_video._resolve_fps("0/0", "0/0") == "30"
+
+    def test_both_none_returns_30(self) -> None:
+        assert compose_video._resolve_fps(None, None) == "30"
+
+    def test_both_empty_returns_30(self) -> None:
+        assert compose_video._resolve_fps("", "") == "30"
+
+    def test_valid_avg_wins(self) -> None:
+        """合法 avg 直接返回，不读 r。"""
+        assert compose_video._resolve_fps("30/1", "24/1") == "30/1"
+
+    def test_avg_none_uses_r(self) -> None:
+        assert compose_video._resolve_fps(None, "24/1") == "24/1"
+
+    def test_fractional_passthrough(self) -> None:
+        assert compose_video._resolve_fps("30000/1001", None) == "30000/1001"
+
+    def test_strips_whitespace(self) -> None:
+        assert compose_video._resolve_fps(" 24/1 ", None) == "24/1"
+
+
+# ---------------------------------------------------------------------------
+# _build_xfade_filter_complex
+# ---------------------------------------------------------------------------
+
+
+class TestBuildXfadeFilterComplex:
+    def test_single_clip_returns_none(self) -> None:
+        """n<2 → None，调用方走 concatenate_final 单段路径。"""
+        assert compose_video._build_xfade_filter_complex([5.0], [], 0.5) is None
+
+    def test_all_cut_returns_none(self) -> None:
+        """全 cut → None，调用方 fallback 到纯 concat。"""
+        result = compose_video._build_xfade_filter_complex([5.0, 5.0, 5.0], ["cut", "cut"], 0.5)
+        assert result is None
+
+    def test_all_short_clips_returns_none(self) -> None:
+        """所有边界都因短片段降级为 cut → None。"""
+        result = compose_video._build_xfade_filter_complex([0.3, 0.3, 0.3], ["fade", "fade"], 0.5)
+        assert result is None
+
+    def test_two_clip_fade_single_group(self) -> None:
+        """两段全 fade：单 group，xfade + acrossfade 各一条，输出 null/anull 重命名为 vout/aout。"""
+        result = compose_video._build_xfade_filter_complex([5.0, 5.0], ["fade"], 0.5)
+        assert result is not None
+        # video xfade
+        assert "[0:v][1:v]xfade=transition=fade:duration=0.5:offset=4.500[g0v]" in result
+        # audio acrossfade（关键：使用 acrossfade 而非 concat 硬拼接）
+        assert "[0:a][1:a]acrossfade=d=0.5:c1=tri:c2=tri[g0a]" in result
+        # 单 group 收尾用 null/anull 改名
+        assert "[g0v]null[vout]" in result
+        assert "[g0a]anull[aout]" in result
+
+    def test_three_clip_fade_offset_chain(self) -> None:
+        """三段全 fade：单 group，第二个 xfade offset 应等于 D0+D1-2*dur。"""
+        result = compose_video._build_xfade_filter_complex([5.0, 5.0, 5.0], ["fade", "fade"], 0.5)
+        assert result is not None
+        # 第一 xfade offset = 5 - 0.5 = 4.500
+        assert "[0:v][1:v]xfade=transition=fade:duration=0.5:offset=4.500[g0v1]" in result
+        # 第二 xfade offset = 5+5 - 2*0.5 = 9.000，并改名为最终 [g0v]
+        assert "[g0v1][2:v]xfade=transition=fade:duration=0.5:offset=9.000[g0v]" in result
+
+    def test_no_semicolon_inside_audio_input_labels(self) -> None:
+        """#564 第 1 条核心回归：audio 输入标签之间不能出现 `;` 分隔。
+
+        旧实现用 `";".join([f"[{i}:a]"...])` 拼接成 `[0:a];[1:a];[2:a]concat=...`，
+        分号会被 ffmpeg 当作 filter chain 分隔符，导致 concat 输入参数不足报错。
+        新实现走 acrossfade 链，自然不会出现 `[N:a];[M:a]` 这种相邻片段。
+        """
+        result = compose_video._build_xfade_filter_complex([5.0, 5.0, 5.0], ["fade", "fade"], 0.5)
+        assert result is not None
+        # 任意两个相邻 audio 输入标签都不应该被 `;` 直接连起来
+        assert "[0:a];[1:a]" not in result
+        assert "[1:a];[2:a]" not in result
+
+    def test_cut_xfade_mix_groups_by_cut(self) -> None:
+        """#564 评论补充：cut+xfade 混用按 cut 分组。
+
+        durations=[5,5,5,5], transitions=["fade","cut","fade"]
+        → group A=[0,1], group B=[2,3]，组间 concat 串联
+        """
+        result = compose_video._build_xfade_filter_complex([5.0, 5.0, 5.0, 5.0], ["fade", "cut", "fade"], 0.5)
+        assert result is not None
+
+        # 组 0：[0:v][1:v] xfade，offset 应为 4.500（组内累加，不跨 cut）
+        assert "[0:v][1:v]xfade=transition=fade:duration=0.5:offset=4.500[g0v]" in result
+        # 组 1：[2:v][3:v] xfade，**关键**：offset 应该重新从 4.500 起算，
+        # 而不是按全局公式 sum(durs[:3]) - 3*0.5 = 13.500
+        assert "[2:v][3:v]xfade=transition=fade:duration=0.5:offset=4.500[g1v]" in result
+        assert "offset=13.500" not in result
+
+        # 组间 concat=v=1:a=1
+        assert "concat=n=2:v=1:a=1[vout][aout]" in result
+        assert "[g0v][g0a][g1v][g1a]" in result
+
+    def test_cut_xfade_mix_audio_groups_match_video(self) -> None:
+        """混用场景下 audio 也按相同 group 分链（不跨 cut 用 acrossfade）。"""
+        result = compose_video._build_xfade_filter_complex([5.0, 5.0, 5.0, 5.0], ["fade", "cut", "fade"], 0.5)
+        assert result is not None
+
+        # 组 0 audio
+        assert "[0:a][1:a]acrossfade=d=0.5:c1=tri:c2=tri[g0a]" in result
+        # 组 1 audio：不能出现跨 cut 的 acrossfade，例如 [1:a][2:a]acrossfade
+        assert "[1:a][2:a]acrossfade" not in result
+        # 应有 [2:a][3:a] 的 acrossfade
+        assert "[2:a][3:a]acrossfade=d=0.5:c1=tri:c2=tri[g1a]" in result
+
+    def test_single_clip_group_passes_through(self) -> None:
+        """单片段 group 直接透传 [i:v]/[i:a] 给 concat，无需 xfade。
+
+        durations=[5,5,5], transitions=["cut","fade"]
+        → group A=[0]（单片段透传），group B=[1,2]（xfade）
+        """
+        result = compose_video._build_xfade_filter_complex([5.0, 5.0, 5.0], ["cut", "fade"], 0.5)
+        assert result is not None
+
+        # 组 1 内 xfade，offset 必须从 0 起算（即 5-0.5=4.500）
+        assert "[1:v][2:v]xfade=transition=fade:duration=0.5:offset=4.500[g1v]" in result
+
+        # concat 串联，第一组直接用 [0:v][0:a]，第二组用 [g1v][g1a]
+        assert "[0:v][0:a][g1v][g1a]concat=n=2:v=1:a=1[vout][aout]" in result
+
+    def test_short_clip_downgrade_at_boundary(self) -> None:
+        """duration <= transition_duration 的片段所触边界自动降级 cut。
+
+        durations=[0.3, 5, 5], transitions=["fade","fade"], transition_duration=0.5
+        → 边界 0（涉及 d[0]=0.3）降级 cut，剩下边界 1 仍 fade
+        → group A=[0]（单段透传），group B=[1,2]（xfade）
+        """
+        result = compose_video._build_xfade_filter_complex([0.3, 5.0, 5.0], ["fade", "fade"], 0.5)
+        assert result is not None
+        # 不能出现 [0:v][1:v]xfade（边界 0 应已降级）
+        assert "[0:v][1:v]xfade" not in result
+        # 应有 [1:v][2:v]xfade
+        assert "[1:v][2:v]xfade=transition=fade:duration=0.5:offset=4.500[g1v]" in result
+
+    def test_wipe_maps_to_wipeleft(self) -> None:
+        result = compose_video._build_xfade_filter_complex([5.0, 5.0], ["wipe"], 0.5)
+        assert result is not None
+        assert "xfade=transition=wipeleft" in result
+
+    def test_unknown_transition_falls_back_to_fade(self) -> None:
+        """未知 transition 值按 fade 处理（保留原行为）。"""
+        result = compose_video._build_xfade_filter_complex([5.0, 5.0], ["nonexistent-transition"], 0.5)
+        assert result is not None
+        assert "xfade=transition=fade" in result
+
+    def test_transitions_shorter_than_boundaries_defaults_fade(self) -> None:
+        """transitions 比边界数少时，多出来的边界按 fade 处理。"""
+        result = compose_video._build_xfade_filter_complex([5.0, 5.0, 5.0], ["fade"], 0.5)
+        assert result is not None
+        # 边界 1 没在 transitions 里 → 默认 fade
+        assert "[g0v1][2:v]xfade=transition=fade" in result
+
+
+# ---------------------------------------------------------------------------
+# concatenate_final 单段路径
+# ---------------------------------------------------------------------------
+
+
+class TestConcatenateFinalSingleSegment:
+    def test_single_clip_skips_concat_filter(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """单段输入应走 `-c copy + faststart` 直接 remux，不走 concat filter。
+
+        #564 第 2 条：concat=n=1 会让 ffmpeg 报参数错误。
+        """
+        captured: list[list[str]] = []
+
+        def fake_run_ffmpeg(cmd: list[str], _error_prefix: str) -> None:
+            captured.append(cmd)
+
+        monkeypatch.setattr(compose_video, "run_ffmpeg", fake_run_ffmpeg)
+
+        clip = tmp_path / "normalized_000.mp4"
+        clip.write_bytes(b"\x00" * 16)
+        output = tmp_path / "final.mp4"
+
+        compose_video.concatenate_final([clip], output)
+
+        assert len(captured) == 1
+        cmd = captured[0]
+        # 关键不变量
+        assert "-c" in cmd and cmd[cmd.index("-c") + 1] == "copy"
+        assert "-movflags" in cmd and cmd[cmd.index("-movflags") + 1] == "+faststart"
+        # 不能出现 concat filter
+        assert not any("concat=" in arg for arg in cmd)
+        assert "-filter_complex" not in cmd
+
+    def test_empty_list_raises(self) -> None:
+        with pytest.raises(ValueError, match="没有可用的视频片段"):
+            compose_video.concatenate_final([], Path("/tmp/unused.mp4"))


### PR DESCRIPTION
## Summary

修复 `agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py` 中由上游 review (ArcReel-XingYao#22 gemini-code-assist) 命中的 6 处问题：

- **fps fallback 失效** — `avg_frame_rate="0/0"` 是真值，`or` 链不回退 `r_frame_rate`，导致下游 ffmpeg 滤镜直接拿到 `"0/0"` 失败
- **audio concat 输入分隔错误** — 旧实现用 `";".join([f"[{i}:a]"...])`，分号是 ffmpeg 滤镜链分隔符，concat 输入参数会被切碎
- **单段 concat 边界** — `concatenate_final` 在 `len==1` 时仍产出 `concat=n=1`，ffmpeg 报参数错误
- **xfade 音画不同步** — video 走 xfade 缩短 `(n-1)*duration` 秒，audio 仍硬 concat，每个转场累计错位
- **duration 来源** — 取自 `format.duration`，mkv/webm 等容器与 stream.duration 偏差几毫秒，影响 `atrim` 静音音轨长度与 `xfade` offset 精确度
- **cut+xfade 混用滤镜链断裂** — 旧代码 `if xfade_type is None: continue` 让标签序列断裂、offset 公式跨 cut 累加错位

## 修复策略

- 抽出 `_resolve_fps` / `_build_xfade_filter_complex` 两个纯函数，便于 unit test
- `_build_xfade_filter_complex` 按 cut 边界把片段切成 group：
  - 组内 video 走 xfade chain + audio 走 acrossfade chain，每个边界都消耗 `transition_duration` 秒 → 音画同步
  - 组间用 `concat=v=1:a=1` 串联，避开 cut 边界的 offset 累加问题
  - 短片段（`duration <= transition_duration`）所触边界自动降级为 cut，避免 xfade offset 负值
  - 单 group / 全 cut 序列返回 `None`，调用方走 `concatenate_final` 兜底
- `concatenate_final` 单段路径用 `-c copy +faststart`，跳过 concat filter
- `probe_media` duration 优先 `video_stream`，fps 用 `_resolve_fps`

## Test plan

- [x] 新增 `tests/test_compose_video_filter_graph.py`：25 个 unit test 覆盖：
  - `_resolve_fps` 各种 fallback 路径（#562 核心场景：avg=`"0/0"` + r=`"24/1"` → 返回 `"24/1"`）
  - `_build_xfade_filter_complex`：全 cut、全 fade 单组、cut+fade 混用、短片段降级、wipe/unknown 映射、audio 标签不含 `;` 分隔
  - `concatenate_final` 单段走 `-c copy` 不走 concat filter
- [x] 既有 `tests/test_skill_script_path_guards.py` (25 个 e2e) 不回归
- [x] `uv run ruff check` / `ruff format --check` / `basedpyright` 全绿

Closes #562
Closes #564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 更稳健地解析并回退帧率与时长，过滤无效/异常值以避免解析失败。
  * 优化时长来源优先级（优先视频流，再回退到容器），减少差异导致的拼接问题。

* **新特性**
  * 单段输出改为快速重封装（跳过滤镜、使用快速启动选项）以加速导出。
  * 转场拼接逻辑重构，改进视频/音频过渡并提供合理降级策略。

* **Tests**
  * 新增单元测试覆盖帧率/时长容错、转场滤镜构建与单段输出行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->