### PR TITLE
fix(script): 按 episode 注入 prompt 并兜底重写 ID 前缀

### DIFF
--- a/agent_runtime_profile/.claude/agents/normalize-drama-script.md
+++ b/agent_runtime_profile/.claude/agents/normalize-drama-script.md
@@ -123,15 +123,16 @@ mcp__arcreel__normalize_drama_script({"episode": N, "source": "source/episode_N.
 ```markdown
 | 场景 ID | 场景描述 | 时长 | 场景类型 | segment_break |
 |---------|---------|------|---------|---------------|
-| E1S01 | 竹林深处，晨雾弥漫。青年剑客李明手持长剑，缓缓踏入林间，目光坚定。 | <duration> | 剧情 | 是 |
-| E1S02 | 李明凝视着竹林深处，若有所思。"师父，我回来了。" | <duration> | 对话 | 否 |
+| E<集号>S01 | 竹林深处，晨雾弥漫。青年剑客李明手持长剑，缓缓踏入林间，目光坚定。 | <duration> | 剧情 | 是 |
+| E<集号>S02 | 李明凝视着竹林深处，若有所思。"师父，我回来了。" | <duration> | 对话 | 否 |
 ```
 
 > 填值规则：`<duration>` 必须取自 Step 0 查得的 `supported_durations`。
+> `<集号>` 由 `mcp__arcreel__normalize_drama_script` 工具在调用时按当前 episode 注入到 prompt；本示例使用占位符是为了避免误把 `E1` 当作硬编码值。
 
 ## 注意事项
 
-- 场景 ID 格式：E{集数}S{两位序号}（如 E1S01）
+- 场景 ID 格式：E{集数}S{两位序号}（集数 = 当前 episode，由调用工具时的 `episode` 参数决定）
 - 每个场景宜为一个独立的视觉画面，可在指定时长内完成
 - 时长取自 Step 0 查得的 `supported_durations`；优先贴近 `default_duration`，复杂画面（打斗 / 大场面 / 情绪铺陈）可取更长值，不超过 `max_duration`
 - segment_break 标记真正的镜头切换点（场景、时间、地点的重大变化）

--- a/lib/prompt_builders_reference.py
+++ b/lib/prompt_builders_reference.py
@@ -29,6 +29,7 @@ def build_reference_video_prompt(
     units_md: str,
     supported_durations: list[int],
     max_refs: int,
+    episode: int,
     max_duration: int | None = None,
     aspect_ratio: str = "9:16",
     target_language: str = "中文",
@@ -97,11 +98,16 @@ def build_reference_video_prompt(
 {units_md}
 </step1_units>
 
+<episode_constraints>
+当前正在生成第 {episode} 集。本集所有 unit_id 必须严格使用 `E{episode}U{{两位序号}}` 格式（如 E{episode}U01、E{episode}U02），不得使用其他集号前缀。
+若 step1_units 表里出现非 `E{episode}` 前缀（如 E1U..），视为脏数据，请按当前集号 `E{episode}` 重写。
+</episode_constraints>
+
 # 字段写作指引
 
 对每个 video_unit，按下列要求填写字段：
 
-a. **unit_id**：保留 step1 中的 `E{{集}}U{{序号}}`，不要改格式。
+a. **unit_id**：保留 step1 中的 `E{episode}U{{序号}}`（当前为第 {episode} 集），不要改格式。
 
 b. **shots**：1-4 个 Shot。
    - `duration`：整数秒，取值必须在当前模型支持列表中：{durations_desc}。{max_duration_line}

--- a/lib/prompt_builders_script.py
+++ b/lib/prompt_builders_script.py
@@ -85,6 +85,7 @@ def build_narration_prompt(
     props: dict,
     segments_md: str,
     supported_durations: list[int],
+    episode: int,
     default_duration: int | None = None,
     aspect_ratio: str = "9:16",
     target_language: str = "中文",
@@ -135,7 +136,12 @@ def build_narration_prompt(
 {segments_md}
 </segments>
 
-segments 表每行是一个待生成的片段，包含：片段 ID（E{{集}}S{{序号}}）、小说原文、{_format_duration_constraint(supported_durations, default_duration)}、是否含对话、是否为 segment_break。
+segments 表每行是一个待生成的片段，包含：片段 ID（E{episode}S{{序号}}，当前为第 {episode} 集）、小说原文、{_format_duration_constraint(supported_durations, default_duration)}、是否含对话、是否为 segment_break。
+
+<episode_constraints>
+当前正在生成第 {episode} 集。本集所有 segment_id 必须严格使用 `E{episode}S{{两位序号}}` 格式（如 E{episode}S01、E{episode}S02），不得使用其他集号前缀。
+若 segments 表里出现非 `E{episode}` 前缀（如 E1S..），视为脏数据，请按当前集号 `E{episode}` 重写。
+</episode_constraints>
 
 # 字段写作指引
 
@@ -180,6 +186,7 @@ def build_drama_prompt(
     props: dict,
     scenes_md: str,
     supported_durations: list[int],
+    episode: int,
     default_duration: int | None = None,
     aspect_ratio: str = "16:9",
     target_language: str = "中文",
@@ -230,7 +237,12 @@ def build_drama_prompt(
 {scenes_md}
 </shots>
 
-shots 表每行是一个分镜，包含：分镜 ID（E{{集}}S{{序号}}）、分镜描述、{_format_duration_constraint(supported_durations, default_duration)}、场景类型、是否为 segment_break。
+shots 表每行是一个分镜，包含：分镜 ID（E{episode}S{{序号}}，当前为第 {episode} 集）、分镜描述、{_format_duration_constraint(supported_durations, default_duration)}、场景类型、是否为 segment_break。
+
+<episode_constraints>
+当前正在生成第 {episode} 集。本集所有 scene_id 必须严格使用 `E{episode}S{{两位序号}}` 格式（如 E{episode}S01、E{episode}S02），不得使用其他集号前缀。
+若 shots 表里出现非 `E{episode}` 前缀（如 E1S..），视为脏数据，请按当前集号 `E{episode}` 重写。
+</episode_constraints>
 
 # 字段写作指引
 
@@ -273,6 +285,7 @@ def build_normalize_prompt(
     props: dict,
     default_duration: int | None,
     supported_durations: list[int],
+    episode: int,
 ) -> str:
     """Step-1 normalization prompt: novel text → markdown scene table.
 
@@ -346,11 +359,11 @@ def build_normalize_prompt(
 
 | 场景 ID | 场景描述 | 时长 | 场景类型 | segment_break |
 |---------|---------|------|---------|---------------|
-| E{{N}}S01 | 详细的场景描述... | <duration> | 剧情 | 是 |
-| E{{N}}S02 | 详细的场景描述... | <duration> | 对话 | 否 |
+| E{episode}S01 | 详细的场景描述... | <duration> | 剧情 | 是 |
+| E{episode}S02 | 详细的场景描述... | <duration> | 对话 | 否 |
 
 规则：
-- 场景 ID 格式：E{{集数}}S{{两位序号}}（如 E1S01, E1S02）
+- 当前正在生成第 {episode} 集；所有场景 ID 必须使用 `E{episode}S{{两位序号}}` 格式，不得使用其他集号前缀
 - 场景描述：改编后的剧本化描述，包含角色动作、对话、环境，适合视觉化呈现
 {duration_rules}
 - 场景类型：剧情、动作、对话、过渡、空镜

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -6,6 +6,7 @@ script_generator.py - 剧本生成器
 
 import json
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -40,6 +41,23 @@ logger = logging.getLogger(__name__)
 # 大型 JSON 剧本输出上限：22+ 场景典型约 14K token，留 2× 安全边际。
 # 注意：受各模型硬上限约束（如 doubao-seed-1-8 ~8192），需选择支持 ≥16K 输出的模型。
 SCRIPT_MAX_OUTPUT_TOKENS = 32000
+
+# 集号前缀正则：仅匹配 `E{数字}` + 紧随 S/U（segment/scene 用 S，video_unit 用 U），
+# 保留后缀（如 `E1S03_2` → `E2S03_2`）。设计契约见 lib/script_models.py。
+_EID_PREFIX_RE = re.compile(r"^E\d+(?=[SU])")
+
+
+def _rewrite_episode_prefix(rid: object, ep: int) -> object:
+    """把 ID 中的 `E\\d+` 前缀强制改写为 `E{ep}`；非字符串或无 E 前缀的原样返回。
+
+    兜底 LLM 在 prompt 已注入集号的情况下仍写错前缀的场景。
+    """
+    if not isinstance(rid, str):
+        return rid
+    new_rid, n = _EID_PREFIX_RE.subn(f"E{ep}", rid)
+    if n and new_rid != rid:
+        logger.warning("episode prefix rewritten: %s → %s", rid, new_rid)
+    return new_rid
 
 
 class ScriptGenerator:
@@ -119,6 +137,7 @@ class ScriptGenerator:
                 max_refs=self._resolve_max_refs(caps),
                 max_duration=self._resolve_max_duration(caps),
                 aspect_ratio=self._resolve_aspect_ratio(),
+                episode=episode,
             )
             schema = ReferenceVideoScript
         elif self.content_mode == "narration":
@@ -133,6 +152,7 @@ class ScriptGenerator:
                 supported_durations=self._resolve_supported_durations(caps),
                 default_duration=self.project_json.get("default_duration"),
                 aspect_ratio=self._resolve_aspect_ratio(),
+                episode=episode,
             )
             schema = NarrationEpisodeScript
         else:
@@ -147,6 +167,7 @@ class ScriptGenerator:
                 supported_durations=self._resolve_supported_durations(caps),
                 default_duration=self.project_json.get("default_duration"),
                 aspect_ratio=self._resolve_aspect_ratio(),
+                episode=episode,
             )
             schema = DramaEpisodeScript
 
@@ -208,6 +229,7 @@ class ScriptGenerator:
                 max_refs=self._resolve_max_refs(caps),
                 max_duration=self._resolve_max_duration(caps),
                 aspect_ratio=self._resolve_aspect_ratio(),
+                episode=episode,
             )
         elif self.content_mode == "narration":
             return build_narration_prompt(
@@ -221,6 +243,7 @@ class ScriptGenerator:
                 supported_durations=self._resolve_supported_durations(caps),
                 default_duration=self.project_json.get("default_duration"),
                 aspect_ratio=self._resolve_aspect_ratio(),
+                episode=episode,
             )
         else:
             return build_drama_prompt(
@@ -234,6 +257,7 @@ class ScriptGenerator:
                 supported_durations=self._resolve_supported_durations(caps),
                 default_duration=self.project_json.get("default_duration"),
                 aspect_ratio=self._resolve_aspect_ratio(),
+                episode=episode,
             )
 
     async def _fetch_video_capabilities(self) -> dict | None:
@@ -388,6 +412,22 @@ class ScriptGenerator:
         # CLI 参数 --episode 是集号唯一真相源。schema 已从 AI 输出中移除 episode 字段，
         # 这里负责落盘前补上。
         script_data["episode"] = int(episode)
+
+        # 兜底改写 segment/scene/unit ID 中的 E\d+ 前缀，避免 LLM 写错集号导致文件
+        # 名跨集冲突（如 storyboards/scene_E1S01.png 被 E2 重新覆盖）。
+        ep = int(episode)
+        if gen_mode == "reference_video":
+            for u in script_data.get("video_units") or []:
+                if isinstance(u, dict) and "unit_id" in u:
+                    u["unit_id"] = _rewrite_episode_prefix(u.get("unit_id"), ep)
+        elif self.content_mode == "narration":
+            for s in script_data.get("segments") or []:
+                if isinstance(s, dict) and "segment_id" in s:
+                    s["segment_id"] = _rewrite_episode_prefix(s.get("segment_id"), ep)
+        else:
+            for s in script_data.get("scenes") or []:
+                if isinstance(s, dict) and "scene_id" in s:
+                    s["scene_id"] = _rewrite_episode_prefix(s.get("scene_id"), ep)
         # content_mode 严格只是"内容类型"（narration/drama）；reference_video 属于
         # "视频来源"维度，由 generation_mode 表达。
         # 参考视频集必须强制覆盖：ReferenceVideoScript.content_mode 有 Pydantic 默认值

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -228,6 +228,7 @@ def normalize_drama_script_tool(ctx: ToolContext):
                 props=project.get("props", {}),
                 default_duration=default_duration,
                 supported_durations=supported_durations,
+                episode=episode,
             )
 
             if dry_run:

--- a/tests/lib/test_prompt_builders_reference.py
+++ b/tests/lib/test_prompt_builders_reference.py
@@ -29,6 +29,7 @@ def test_build_reference_video_prompt_contains_required_sections():
         supported_durations=[5, 8, 10],
         max_refs=9,
         aspect_ratio="9:16",
+        episode=1,
     )
 
     # 必备上下文
@@ -63,6 +64,7 @@ def test_build_reference_video_prompt_emphasizes_no_appearance_description():
         units_md="stub",
         supported_durations=[8],
         max_refs=9,
+        episode=1,
     )
     assert "外貌" in prompt  # 有反向说明
 
@@ -79,6 +81,7 @@ def test_build_reference_video_prompt_lists_shot_max_count():
         units_md="stub",
         supported_durations=[8],
         max_refs=9,
+        episode=1,
     )
     assert "4" in prompt  # shot 数量上限
 
@@ -96,6 +99,7 @@ def test_build_reference_video_prompt_injects_max_duration():
         supported_durations=list(range(1, 16)),
         max_refs=7,
         max_duration=15,
+        episode=1,
     )
     assert "15 秒" in prompt
     assert "当前模型上限" in prompt
@@ -113,5 +117,25 @@ def test_build_reference_video_prompt_max_duration_none_skips_segment():
         units_md="stub",
         supported_durations=[4, 8],
         max_refs=9,
+        episode=1,
     )
     assert "当前模型上限" not in prompt
+
+
+def test_build_reference_video_prompt_injects_episode_constraints():
+    """reference_video prompt 必须告知 LLM 当前 episode，避免 unit_id 跨集污染（#574）。"""
+    prompt = build_reference_video_prompt(
+        project_overview={"synopsis": "s", "genre": "g", "theme": "t", "world_setting": "w"},
+        style="s",
+        style_description="d",
+        characters={},
+        scenes={},
+        props={},
+        units_md="stub",
+        supported_durations=[8],
+        max_refs=9,
+        episode=3,
+    )
+    assert "第 3 集" in prompt
+    assert "E3U" in prompt
+    assert "<episode_constraints>" in prompt

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -519,6 +519,28 @@ async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext, monkeypatch
     assert "DRY RUN" in out["content"][0]["text"]
 
 
+async def test_normalize_drama_script_injects_episode_into_prompt(fake_ctx: ToolContext, monkeypatch) -> None:
+    """工具必须把 episode 注入 build_normalize_prompt，避免 LLM 写错 E\\d+ 前缀（#574）。"""
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    project_path = fake_ctx.project_path
+    src = project_path / "source"
+    src.mkdir(parents=True)
+    (src / "chapter2.txt").write_text("第二集开场", encoding="utf-8")
+
+    async def fake_caps(_p):
+        return 4, [4, 6, 8]
+
+    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    tool_obj = normalize_drama_script_tool(fake_ctx)
+    out = await _call(tool_obj, {"episode": 2, "dry_run": True, "source": "source/chapter2.txt"})
+    assert out.get("is_error") is not True, out
+    prompt_text = out["content"][0]["text"]
+    assert "E2S01" in prompt_text
+    assert "第 2 集" in prompt_text or "E2S{两位序号}" in prompt_text
+    assert "E1S01" not in prompt_text
+
+
 async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: ToolContext, monkeypatch) -> None:
     """工具必须把 ctx.project_name 传给 create_text_backend_for_task，
     否则项目级 text_backend_script 覆盖被跳过，会回退到全局默认后端。"""

--- a/tests/test_prompt_builders_script.py
+++ b/tests/test_prompt_builders_script.py
@@ -23,6 +23,7 @@ class TestPromptBuildersScript:
             supported_durations=[4, 6, 8],
             default_duration=4,
             aspect_ratio="9:16",
+            episode=1,
         )
         assert "4, 6, 8" in prompt
         assert "默认 4 秒" in prompt
@@ -41,6 +42,7 @@ class TestPromptBuildersScript:
             supported_durations=[5, 10],
             default_duration=None,
             aspect_ratio="9:16",
+            episode=1,
         )
         assert "5, 10" in prompt
         assert "按内容节奏自行决定" in prompt
@@ -57,6 +59,7 @@ class TestPromptBuildersScript:
             supported_durations=[4, 8, 12],
             default_duration=8,
             aspect_ratio="9:16",
+            episode=1,
         )
         assert "竖屏构图" in prompt
 
@@ -72,6 +75,7 @@ class TestPromptBuildersScript:
             supported_durations=[4, 6, 8],
             default_duration=8,
             aspect_ratio="16:9",
+            episode=1,
         )
         assert "横屏构图" in prompt
 
@@ -88,6 +92,7 @@ class TestPromptBuildersScript:
             supported_durations=[4, 6, 8],
             default_duration=8,
             aspect_ratio="16:9",
+            episode=1,
         )
         assert "Tracking Shot" not in prompt
         assert "Pan Left, Pan Right" not in prompt

--- a/tests/test_prompt_builders_script_v2.py
+++ b/tests/test_prompt_builders_script_v2.py
@@ -28,6 +28,7 @@ def _kwargs() -> dict:
         props={"玉佩": {"description": "Z"}},
         supported_durations=[4, 5, 6, 7, 8],
         default_duration=4,
+        episode=2,
     )
 
 
@@ -70,3 +71,19 @@ def test_drama_no_hard_char_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     text = build_drama_prompt(scenes_md="| E1S01 | xxx | 4 | 剧情 | 是 |", **_kwargs())
     assert "200 字以内" not in text
     assert "150 字以内" not in text
+
+
+def test_drama_injects_episode_constraints() -> None:
+    """drama prompt 必须明确告知 LLM 当前 episode，避免 ID 跨集污染（#574）。"""
+    text = build_drama_prompt(scenes_md="| E1S01 | xxx | 4 | 剧情 | 是 |", **_kwargs())
+    assert "第 2 集" in text
+    assert "E2S" in text
+    assert "<episode_constraints>" in text
+
+
+def test_narration_injects_episode_constraints() -> None:
+    """narration prompt 同样需告知 episode；step1 用 G01 编号，episode 必须靠 prompt 传递（#574）。"""
+    text = build_narration_prompt(segments_md="| G01 | xxx | 25 | 4s | 否 | - |", **_kwargs())
+    assert "第 2 集" in text
+    assert "E2S" in text
+    assert "<episode_constraints>" in text

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -271,6 +271,86 @@ class TestScriptGenerator:
             await generator.generate(1)
 
 
+class TestAddMetadataRewritesEpisodePrefix:
+    """_add_metadata 兜底改写 segment/scene/unit ID 的 E\\d+ 前缀（#574）。"""
+
+    @staticmethod
+    def _make_generator(tmp_path: Path, content_mode: str = "narration") -> ScriptGenerator:
+        project_path = tmp_path / "demo"
+        _write_json(
+            project_path / "project.json",
+            {
+                "title": "项目",
+                "content_mode": content_mode,
+                "_supported_durations": [4, 6, 8],
+            },
+        )
+        return ScriptGenerator(project_path)
+
+    def test_drama_rewrites_scene_ids(self, tmp_path: Path) -> None:
+        sg = self._make_generator(tmp_path, content_mode="drama")
+        data = {
+            "scenes": [
+                {"scene_id": "E1S01", "other": "keep"},
+                {"scene_id": "E1S04_2"},
+            ],
+        }
+        out = sg._add_metadata(data, episode=2)
+        assert out["scenes"][0]["scene_id"] == "E2S01"
+        assert out["scenes"][1]["scene_id"] == "E2S04_2"
+        assert out["scenes"][0]["other"] == "keep"
+
+    def test_narration_rewrites_segment_ids(self, tmp_path: Path) -> None:
+        sg = self._make_generator(tmp_path, content_mode="narration")
+        data = {
+            "segments": [
+                {"segment_id": "E1S01"},
+                {"segment_id": "E1S02_1"},
+            ],
+        }
+        out = sg._add_metadata(data, episode=3)
+        assert out["segments"][0]["segment_id"] == "E3S01"
+        assert out["segments"][1]["segment_id"] == "E3S02_1"
+
+    def test_reference_video_rewrites_unit_ids(self, tmp_path: Path) -> None:
+        project_path = tmp_path / "demo"
+        _write_json(
+            project_path / "project.json",
+            {
+                "title": "项目",
+                "content_mode": "narration",
+                "generation_mode": "reference_video",
+                "_supported_durations": [8],
+            },
+        )
+        sg = ScriptGenerator(project_path)
+        data = {
+            "video_units": [
+                {"unit_id": "E1U01"},
+                {"unit_id": "E1U02_1"},
+            ],
+        }
+        out = sg._add_metadata(data, episode=2)
+        assert out["video_units"][0]["unit_id"] == "E2U01"
+        assert out["video_units"][1]["unit_id"] == "E2U02_1"
+
+    def test_idempotent_when_prefix_already_correct(self, tmp_path: Path) -> None:
+        """ID 前缀已经匹配 episode 时，rewrite 不应改动（不破坏正确数据）。"""
+        sg = self._make_generator(tmp_path, content_mode="narration")
+        data = {"segments": [{"segment_id": "E2S01"}, {"segment_id": "E2S02_3"}]}
+        out = sg._add_metadata(data, episode=2)
+        assert out["segments"][0]["segment_id"] == "E2S01"
+        assert out["segments"][1]["segment_id"] == "E2S02_3"
+
+    def test_unknown_id_format_unchanged(self, tmp_path: Path) -> None:
+        """ID 不带 `E\\d+[SU]` 前缀时不应被改写（避免误伤）。"""
+        sg = self._make_generator(tmp_path, content_mode="narration")
+        data = {"segments": [{"segment_id": "G01"}, {"segment_id": "scene_1"}]}
+        out = sg._add_metadata(data, episode=2)
+        assert out["segments"][0]["segment_id"] == "G01"
+        assert out["segments"][1]["segment_id"] == "scene_1"
+
+
 def test_resolve_supported_durations_raises_when_unset(tmp_path):
     """caps、project.json、registry 三处都查不到时应抛 ValueError，不再 silent fallback。"""
     project_dir = tmp_path / "p"


### PR DESCRIPTION
## Summary
fixes #574
分次上传源文件生成第 N 集剧本时，LLM 由于看不到当前 episode 编号，会照抄 prompt 示例中的 `E1` 前缀，导致 `segment_id` / `scene_id` / `unit_id` 跨集冲突，进而把 `storyboards/scene_E1S*.png` 被第 2 集重新覆盖原第 1 集已生成的分镜。

- prompt builders（narration / drama / normalize / reference_video）增加 `episode` 参数；prompt 显式告知当前集号 + `<episode_constraints>` 块约束 ID 前缀；示例由 `E1S01` 改为 `E{episode}S01`
- `ScriptGenerator._add_metadata` 兜底扫描 `segments` / `scenes` / `video_units` 内 ID，强制重写 `E\d+` 前缀为 `E{episode}`，保留 `S/U` 序号与 `_` 后缀
- `normalize_drama_script_tool` 把已接收的 `episode` 透传给 `build_normalize_prompt`
- subagent 示例 `E1S01` 改为 `E<集号>S01` 占位，避免误把 `E1` 当事实值

## Test plan
- [x] `uv run python -m pytest tests/test_prompt_builders_script.py tests/test_prompt_builders_script_v2.py tests/lib/test_prompt_builders_reference.py tests/test_script_generator.py tests/server/agent_runtime/test_sdk_tools.py` — 70 passed（含 5 个 `_add_metadata` 兜底改写测试）
- [x] `uv run python -m pytest tests/test_prompt_builders.py tests/test_prompt_builders_script_duration.py tests/test_skill_script_path_guards.py` — 40 passed（回归）
- [x] `uv run ruff check` & `uv run ruff format` — 全部通过
- [x] `uv run basedpyright`（修改源文件）— 0 errors 0 warnings
- [ ] 端到端复现：上传 E1 + 全分镜 → 上传 E2 + 生成脚本 → 检查 `scripts/episode_2.json` 中所有 ID 以 `E2` 开头，分镜产物为 `scene_E2S*.png`，E1 文件不被覆盖

## 存量受污染数据
受影响的项目（E2 分镜物理覆盖到 `scene_E1S*.png`）需手动恢复：备份 → 删除被污染的 `scene_E1S*.png` → 重新生成 E2 脚本与分镜。本 PR 不提供自动迁移脚本（无法可靠从文件名区分真 E1 与污染 E2）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改进

* 增强了脚本生成框架的集号管理能力：所有生成的场景、段落及视频单元ID现都能精确对应其所属集数；系统还能自动识别和修正输入中的集号错误，确保整体数据的一致性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->