### PR TITLE
fix(timezone): 容器/后端/前端时间统一为 TZ-aware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,3 +92,12 @@ AUTH_TOKEN_SECRET=
 # 关闭文件日志（默认 false）。设为 1/true/yes 时日志仅输出到 stdout。
 # ARCREEL_LOG_FILE_DISABLED=
 
+# ============================================================
+# Timezone / 时区
+# ============================================================
+# IANA timezone for the container's system clock (used by Docker compose).
+# Default: Asia/Shanghai. Common values: Asia/Tokyo, America/Los_Angeles, UTC.
+# 容器系统时区（被 docker-compose 注入），默认 Asia/Shanghai。
+# 常用值：Asia/Tokyo、America/Los_Angeles、UTC。
+# TZ=Asia/Shanghai
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     bubblewrap \
     socat \
+    tzdata \
     && rm -rf /var/lib/apt/lists/*
 
 # 安装 uv
@@ -39,6 +40,9 @@ WORKDIR /app
 
 # 禁用 Python 输出缓冲，确保日志实时输出到 Docker logs
 ENV PYTHONUNBUFFERED=1
+
+# 默认时区，可由 docker-compose / 运行时 -e TZ=... 覆盖
+ENV TZ=Asia/Shanghai
 
 # 先复制依赖和包元数据文件，利用缓存
 COPY pyproject.toml uv.lock README.md ./

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     ports:
       - "1241:1241"
     env_file: .env
+    environment:
+      TZ: ${TZ:-Asia/Shanghai}
     # Agent Bash 沙箱 (bwrap) 需要：
     # 1) 非特权 user namespace → 放开 docker 默认 seccomp/apparmor profile
     # 2) bwrap 嵌套出的 net namespace 内配置 loopback → 容器需要 NET_ADMIN cap

--- a/deploy/production/docker-compose.yml
+++ b/deploy/production/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       POSTGRES_USER: arcreel
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?请在 .env 中设置 POSTGRES_PASSWORD}
       POSTGRES_DB: arcreel
+      TZ: ${TZ:-Asia/Shanghai}
     volumes:
       - ./pgdata:/var/lib/postgresql
     restart: unless-stopped
@@ -21,6 +22,7 @@ services:
     env_file: .env
     environment:
       DATABASE_URL: postgresql+asyncpg://arcreel:${POSTGRES_PASSWORD}@postgres:5432/arcreel
+      TZ: ${TZ:-Asia/Shanghai}
     # Agent Bash 沙箱 (bwrap) 需要：
     # 1) 非特权 user namespace → 放开 docker 默认 seccomp/apparmor profile
     # 2) bwrap 嵌套出的 net namespace 内配置 loopback → 容器需要 NET_ADMIN cap

--- a/frontend/src/components/copilot/AgentCopilot.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.tsx
@@ -18,6 +18,7 @@ import { TodoListPanel } from "./TodoListPanel";
 import { ChatMessage } from "./chat/ChatMessage";
 import { composeAllTurns } from "./chat/utils";
 import { uid } from "@/utils/id";
+import { parseIso } from "@/utils/date-format";
 
 const MAX_IMAGES = 5;
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5MB
@@ -162,7 +163,8 @@ function StatusDot({ status }: { status: string }) {
 function formatTime(isoStr: string | undefined, t: TFunction): string {
   if (!isoStr) return t("new_session");
   try {
-    const d = new Date(isoStr);
+    const d = parseIso(isoStr);
+    if (Number.isNaN(d.getTime())) return t("new_session");
     return `${(d.getMonth() + 1).toString().padStart(2, "0")}/${d.getDate().toString().padStart(2, "0")} ${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`;
   } catch {
     return t("new_session");

--- a/frontend/src/components/copilot/AgentCopilot.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.tsx
@@ -18,7 +18,7 @@ import { TodoListPanel } from "./TodoListPanel";
 import { ChatMessage } from "./chat/ChatMessage";
 import { composeAllTurns } from "./chat/utils";
 import { uid } from "@/utils/id";
-import { parseIso } from "@/utils/date-format";
+import { formatShortDateTime } from "@/utils/date-format";
 
 const MAX_IMAGES = 5;
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5MB
@@ -161,14 +161,7 @@ function StatusDot({ status }: { status: string }) {
 }
 
 function formatTime(isoStr: string | undefined, t: TFunction): string {
-  if (!isoStr) return t("new_session");
-  try {
-    const d = parseIso(isoStr);
-    if (Number.isNaN(d.getTime())) return t("new_session");
-    return `${(d.getMonth() + 1).toString().padStart(2, "0")}/${d.getDate().toString().padStart(2, "0")} ${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`;
-  } catch {
-    return t("new_session");
-  }
+  return formatShortDateTime(isoStr) ?? t("new_session");
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/layout/UsageDrawer.tsx
+++ b/frontend/src/components/layout/UsageDrawer.tsx
@@ -13,6 +13,7 @@ import { useUsageStore, type UsageStats, type UsageCall } from "@/stores/usage-s
 import { API } from "@/api";
 import { GlassPopover } from "@/components/ui/GlassPopover";
 import { ModalCloseButton } from "@/components/ui/ModalCloseButton";
+import { parseIso } from "@/utils/date-format";
 import type { CallType } from "@/types/provider";
 
 // ---------------------------------------------------------------------------
@@ -451,7 +452,8 @@ function StatusBadge({ status }: { status: string }) {
 
 function formatDateTime(isoStr: string): string {
   try {
-    const d = new Date(isoStr);
+    const d = parseIso(isoStr);
+    if (Number.isNaN(d.getTime())) return isoStr;
     return `${(d.getMonth() + 1).toString().padStart(2, "0")}/${d.getDate().toString().padStart(2, "0")} ${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`;
   } catch {
     return isoStr;

--- a/frontend/src/components/layout/UsageDrawer.tsx
+++ b/frontend/src/components/layout/UsageDrawer.tsx
@@ -13,7 +13,7 @@ import { useUsageStore, type UsageStats, type UsageCall } from "@/stores/usage-s
 import { API } from "@/api";
 import { GlassPopover } from "@/components/ui/GlassPopover";
 import { ModalCloseButton } from "@/components/ui/ModalCloseButton";
-import { parseIso } from "@/utils/date-format";
+import { formatShortDateTime } from "@/utils/date-format";
 import type { CallType } from "@/types/provider";
 
 // ---------------------------------------------------------------------------
@@ -289,7 +289,7 @@ export function UsageDrawer({ open, onClose, projectName, anchorRef }: UsageDraw
                       </>
                     )}
                     <span className="num ml-auto shrink-0">
-                      {formatDateTime(call.started_at || call.created_at)}
+                      {formatShortDateTime(call.started_at || call.created_at) ?? (call.started_at || call.created_at)}
                     </span>
                   </div>
                   {call.status === "failed" && call.error_message && (
@@ -448,16 +448,6 @@ function StatusBadge({ status }: { status: string }) {
       {status}
     </span>
   );
-}
-
-function formatDateTime(isoStr: string): string {
-  try {
-    const d = parseIso(isoStr);
-    if (Number.isNaN(d.getTime())) return isoStr;
-    return `${(d.getMonth() + 1).toString().padStart(2, "0")}/${d.getDate().toString().padStart(2, "0")} ${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`;
-  } catch {
-    return isoStr;
-  }
 }
 
 function extractFilename(outputPath: string | null | undefined): string {

--- a/frontend/src/components/pages/settings/CustomProviderDetail.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderDetail.tsx
@@ -7,6 +7,7 @@ import { errMsg } from "@/utils/async";
 import type { CustomProviderInfo } from "@/types";
 import { useEndpointCatalogStore } from "@/stores/endpoint-catalog-store";
 import { formatDurationsLabel } from "@/utils/duration_format";
+import { formatDate } from "@/utils/date-format";
 import { ACCENT_BTN_CLS, ACCENT_BUTTON_STYLE, CARD_STYLE, GHOST_BTN_CLS } from "@/components/ui/darkroom-tokens";
 import { CustomProviderForm } from "./CustomProviderForm";
 
@@ -194,7 +195,7 @@ export function CustomProviderDetail({ providerId, onDeleted, onSaved }: CustomP
               <div className="flex justify-between gap-4">
                 <span className="text-text-3">{t("created_at")}</span>
                 <span className="text-text">
-                  {new Date(provider.created_at).toLocaleDateString(i18n.language)}
+                  {formatDate(provider.created_at, i18n.language, { year: "numeric", month: "2-digit", day: "2-digit" })}
                 </span>
               </div>
             </div>

--- a/frontend/src/utils/date-format.ts
+++ b/frontend/src/utils/date-format.ts
@@ -14,9 +14,9 @@ function getFormatter(lang: string | undefined, options: Intl.DateTimeFormatOpti
   return fmt;
 }
 
-// ISO 字符串若没有显式时区后缀（Z / ±HH:MM），按 UTC 处理避免浏览器歧义
+// ISO 字符串若没有显式时区后缀（Z / ±HH(:MM)），按 UTC 处理避免浏览器歧义
 export function parseIso(value: string): Date {
-  const hasTz = /(?:Z|[+-]\d{2}:?\d{2})$/.test(value);
+  const hasTz = /(?:Z|[+-]\d{2}(?::?\d{2})?)$/.test(value);
   return new Date(hasTz ? value : `${value}Z`);
 }
 
@@ -46,4 +46,13 @@ export function formatDateTime(
   fallback = "—",
 ): string {
   return formatDate(value, lang, DATE_TIME_OPTIONS, fallback);
+}
+
+// 紧凑本地时间 MM/DD HH:mm，用于信息密集的列表/标题；解析失败返回 null 由调用方兜底
+export function formatShortDateTime(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const d = parseIso(value);
+  if (Number.isNaN(d.getTime())) return null;
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }

--- a/frontend/src/utils/date-format.ts
+++ b/frontend/src/utils/date-format.ts
@@ -14,6 +14,12 @@ function getFormatter(lang: string | undefined, options: Intl.DateTimeFormatOpti
   return fmt;
 }
 
+// ISO 字符串若没有显式时区后缀（Z / ±HH:MM），按 UTC 处理避免浏览器歧义
+export function parseIso(value: string): Date {
+  const hasTz = /(?:Z|[+-]\d{2}:?\d{2})$/.test(value);
+  return new Date(hasTz ? value : `${value}Z`);
+}
+
 export function formatDate(
   value: string | Date | null | undefined,
   lang: string,
@@ -21,7 +27,23 @@ export function formatDate(
   fallback = "—",
 ): string {
   if (value === null || value === undefined || value === "") return fallback;
-  const date = typeof value === "string" ? new Date(value) : value;
+  const date = typeof value === "string" ? parseIso(value) : value;
   if (Number.isNaN(date.getTime())) return fallback;
   return getFormatter(lang, options).format(date);
+}
+
+const DATE_TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+export function formatDateTime(
+  value: string | Date | null | undefined,
+  lang: string,
+  fallback = "—",
+): string {
+  return formatDate(value, lang, DATE_TIME_OPTIONS, fallback);
 }

--- a/lib/grid/models.py
+++ b/lib/grid/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Literal
 
 
@@ -211,6 +211,6 @@ class GridGeneration:
             provider=provider,
             model=model,
             grid_size=grid_size,
-            created_at=datetime.now().isoformat(),
+            created_at=datetime.now(UTC).isoformat(),
             error_message=None,
         )

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -13,7 +13,7 @@ import shutil
 import unicodedata
 from collections.abc import Callable
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
@@ -426,8 +426,8 @@ class ProjectManager:
             "novel": {"title": title, "chapter": chapter},
             "scenes": [],
             "metadata": {
-                "created_at": datetime.now().isoformat(),
-                "updated_at": datetime.now().isoformat(),
+                "created_at": datetime.now(UTC).isoformat(),
+                "updated_at": datetime.now(UTC).isoformat(),
                 "total_scenes": 0,
                 "estimated_duration_seconds": 0,
                 "status": "draft",
@@ -463,7 +463,7 @@ class ProjectManager:
         self._require_filename_episode_consistency(script, filename)
 
         # 更新元数据（兼容旧脚本：可能缺少 metadata，或 narration 使用 segments）
-        now = datetime.now().isoformat()
+        now = datetime.now(UTC).isoformat()
         metadata = script.get("metadata")
         if not isinstance(metadata, dict):
             metadata = {}
@@ -859,8 +859,8 @@ class ProjectManager:
 
         if "metadata" not in script:
             script["metadata"] = {
-                "created_at": datetime.now().isoformat(),
-                "updated_at": datetime.now().isoformat(),
+                "created_at": datetime.now(UTC).isoformat(),
+                "updated_at": datetime.now(UTC).isoformat(),
                 "total_scenes": 0,
                 "estimated_duration_seconds": 0,
                 "status": "draft",
@@ -1262,7 +1262,7 @@ class ProjectManager:
 
     @staticmethod
     def _touch_metadata(project: dict) -> None:
-        now = datetime.now().isoformat()
+        now = datetime.now(UTC).isoformat()
         if "metadata" not in project:
             project["metadata"] = {"created_at": now, "updated_at": now}
         else:
@@ -1329,8 +1329,8 @@ class ProjectManager:
             "scenes": {},
             "props": {},
             "metadata": {
-                "created_at": datetime.now().isoformat(),
-                "updated_at": datetime.now().isoformat(),
+                "created_at": datetime.now(UTC).isoformat(),
+                "updated_at": datetime.now(UTC).isoformat(),
             },
         }
         if default_duration is not None:
@@ -1769,7 +1769,7 @@ class ProjectManager:
         # 解析并验证响应
         overview = ProjectOverview.model_validate_json(response_text)
         overview_dict = overview.model_dump()
-        overview_dict["generated_at"] = datetime.now().isoformat()
+        overview_dict["generated_at"] = datetime.now(UTC).isoformat()
 
         # 保存到 project.json
         project = self.load_project(project_name)

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -7,7 +7,7 @@ script_generator.py - 剧本生成器
 import json
 import logging
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Optional
 
@@ -451,7 +451,7 @@ class ScriptGenerator:
             novel.pop("source_file", None)
 
         # 添加时间戳
-        now = datetime.now().isoformat()
+        now = datetime.now(UTC).isoformat()
         script_data.setdefault("metadata", {})
         script_data["metadata"]["created_at"] = now
         script_data["metadata"]["updated_at"] = now

--- a/lib/system_config.py
+++ b/lib/system_config.py
@@ -87,7 +87,7 @@ def init_and_apply_system_config(project_root: Path) -> SystemConfigManager:
 
 
 def _iso_now_millis() -> str:
-    return datetime.now(UTC).astimezone().isoformat(timespec="milliseconds")
+    return datetime.now(UTC).isoformat(timespec="milliseconds")
 
 
 def _safe_str(value: Any) -> str | None:

--- a/scripts/migrate_to_project_json.py
+++ b/scripts/migrate_to_project_json.py
@@ -10,7 +10,7 @@
 import argparse
 import json
 import sys
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 # 添加 lib 目录到 Python 路径
@@ -126,8 +126,8 @@ def migrate_project(pm: ProjectManager, project_name: str, dry_run: bool = False
         "characters": all_characters,
         "clues": {},
         "metadata": {
-            "created_at": datetime.now().isoformat(),
-            "updated_at": datetime.now().isoformat(),
+            "created_at": datetime.now(UTC).isoformat(),
+            "updated_at": datetime.now(UTC).isoformat(),
             "migrated_from": "script_based_characters",
         },
     }

--- a/server/agent_runtime/sdk_tools/enqueue_storyboards.py
+++ b/server/agent_runtime/sdk_tools/enqueue_storyboards.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import threading
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -42,7 +42,7 @@ class _FailureRecorder:
                     "type": resource_type,
                     "error": error,
                     "attempts": attempts,
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": datetime.now(UTC).isoformat(),
                 }
             )
 
@@ -51,7 +51,7 @@ class _FailureRecorder:
             return
         with self._lock:
             data = {
-                "generated_at": datetime.now().isoformat(),
+                "generated_at": datetime.now(UTC).isoformat(),
                 "total_failures": len(self.failures),
                 "failures": self.failures,
             }

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Callable
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -80,7 +80,7 @@ def _save_checkpoint_at(path: Path, completed: list[str], started_at: str, **ext
     payload: dict[str, Any] = {
         "completed_scenes": completed,
         "started_at": started_at,
-        "updated_at": datetime.now().isoformat(),
+        "updated_at": datetime.now(UTC).isoformat(),
         **extra,
     }
     path.write_text(
@@ -279,7 +279,7 @@ async def _generate_reference_episode(
 
     ckpt_path = _episode_checkpoint_path(project_dir, episode)
     completed: list[str] = []
-    started_at = datetime.now().isoformat()
+    started_at = datetime.now(UTC).isoformat()
     if resume:
         ckpt = _load_checkpoint_at(ckpt_path)
         if ckpt:
@@ -401,7 +401,7 @@ def generate_video_episode_tool(ctx: ToolContext):
 
             ckpt_path = _episode_checkpoint_path(project_dir, episode)
             completed: list[str] = []
-            started_at = datetime.now().isoformat()
+            started_at = datetime.now(UTC).isoformat()
             if resume:
                 ckpt = _load_checkpoint_at(ckpt_path)
                 if ckpt:
@@ -679,7 +679,7 @@ def generate_video_selected_tool(ctx: ToolContext):
             scenes_hash = hashlib.md5(",".join(canonical_scene_ids).encode("utf-8")).hexdigest()[:8]
             ckpt_path = _selected_checkpoint_path(project_dir, scenes_hash)
             completed: list[str] = []
-            started_at = datetime.now().isoformat()
+            started_at = datetime.now(UTC).isoformat()
             if resume:
                 ckpt = _load_checkpoint_at(ckpt_path)
                 if ckpt:

--- a/server/services/project_archive.py
+++ b/server/services/project_archive.py
@@ -9,7 +9,7 @@ import stat
 import tempfile
 import zipfile
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -363,7 +363,7 @@ class ProjectArchiveService:
             "project_title": project_payload.get("title", project_name),
             "content_mode": project_payload.get("content_mode", ""),
             "scope": scope,
-            "exported_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+            "exported_at": datetime.now(UTC).isoformat(timespec="seconds"),
             "export_diagnostics": diagnostics,
             "pass_through_entries": pass_through_entries,
         }


### PR DESCRIPTION
- Dockerfile 安装 tzdata，默认 ENV TZ=Asia/Shanghai
- docker-compose（dev+prod）注入 TZ=${TZ:-Asia/Shanghai}，prod postgres 一并对齐
- .env.example 暴露 TZ 给用户配置
- 后端持久化写入的 datetime.now() 改为 datetime.now(UTC)，
  ISO 序列化自动带 +00:00；版本目录/下载文件名等本地展示场景保留 naive
- 前端 date-format 增加 parseIso 防御性解析（无时区后缀按 UTC 处理）
  与 formatDateTime 便捷函数；UsageDrawer/AgentCopilot/CustomProviderDetail
  调用方改为复用统一解析路径

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 新增更健壮的日期解析与格式化工具，提供短/长日期时间输出选项。

* **Bug Fixes**
  * 统一使用 UTC 生成时间戳，减少时区偏差导致的问题。
  * 改进前端时间显示回退逻辑，增强无效/缺省时间处理。

* **Chores**
  * 添加容器时区配置与运行时默认值（Asia/Shanghai），并在镜像中包含时区数据包。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->