### PR TITLE
fix(archive): 归档导入遍历 reference_video 的 video_units (#333)

### DIFF
--- a/server/services/project_archive.py
+++ b/server/services/project_archive.py
@@ -16,7 +16,7 @@ from typing import Any
 from lib.data_validator import DataValidator, ValidationResult
 from lib.json_io import load_json
 from lib.project_change_hints import emit_project_change_hint
-from lib.project_manager import ProjectManager
+from lib.project_manager import ProjectManager, effective_mode
 
 logger = logging.getLogger(__name__)
 
@@ -693,6 +693,20 @@ class ProjectArchiveService:
                 )
 
         content_mode = str(script_payload.get("content_mode") or project_payload.get("content_mode") or "narration")
+
+        # reference_video 模式的剧本用 video_units 组织，结构与 narration/drama 的
+        # segments/scenes 不同，单独走专用修复分支。
+        if effective_mode(project=project_payload, episode=script_payload) == "reference_video":
+            units_changed = self._repair_video_units_payload(
+                project_dir,
+                script_path_rel=script_path_rel,
+                script_payload=script_payload,
+                content_mode=content_mode,
+                versions_payload=versions_payload,
+                diagnostics=diagnostics,
+            )
+            return script_changed or units_changed, project_changed
+
         items_key = "segments" if content_mode == "narration" else "scenes"
         id_field = "segment_id" if content_mode == "narration" else "scene_id"
         chars_field = "characters_in_segment" if content_mode == "narration" else "characters_in_scene"
@@ -730,33 +744,16 @@ class ProjectArchiveService:
                         location=f"{location_prefix}.{asset_field}",
                     )
 
-            assets = item.get("generated_assets")
-            if assets is None:
-                item["generated_assets"] = self.project_manager.create_generated_assets(content_mode)
+            assets, assets_changed = self._backfill_generated_assets(
+                item,
+                content_mode=content_mode,
+                label=items_key,
+                index=index,
+                location_prefix=location_prefix,
+                diagnostics=diagnostics,
+            )
+            if assets_changed:
                 script_changed = True
-                diagnostics.add(
-                    "auto_fixed",
-                    "missing_generated_assets",
-                    f"{items_key}[{index}]: 补全缺失字段 generated_assets",
-                    location=f"{location_prefix}.generated_assets",
-                )
-                assets = item["generated_assets"]
-            elif isinstance(assets, dict):
-                template = self.project_manager.create_generated_assets(content_mode)
-                missing_keys = [key for key in template if key not in assets]
-                if missing_keys:
-                    for key in missing_keys:
-                        assets[key] = template[key]
-                    script_changed = True
-                    # 补全值非 None 的才报诊断，避免 no-op 补全产生噪音
-                    non_null_keys = sorted(k for k in missing_keys if template[k] is not None)
-                    if non_null_keys:
-                        diagnostics.add(
-                            "auto_fixed",
-                            "generated_assets_defaults",
-                            (f"{items_key}[{index}].generated_assets: 补全默认字段 {', '.join(non_null_keys)}"),
-                            location=f"{location_prefix}.generated_assets",
-                        )
 
             characters = item.get(chars_field)
             if isinstance(characters, list):
@@ -821,6 +818,116 @@ class ProjectArchiveService:
                         script_changed = True
 
         return script_changed, project_changed
+
+    def _backfill_generated_assets(
+        self,
+        item: dict[str, Any],
+        *,
+        content_mode: str,
+        label: str,
+        index: int,
+        location_prefix: str,
+        diagnostics: ArchiveDiagnostics,
+    ) -> tuple[Any, bool]:
+        """补全 item.generated_assets 的缺失字段，返回 (assets, changed)。"""
+        assets = item.get("generated_assets")
+        changed = False
+        if assets is None:
+            item["generated_assets"] = self.project_manager.create_generated_assets(content_mode)
+            changed = True
+            diagnostics.add(
+                "auto_fixed",
+                "missing_generated_assets",
+                f"{label}[{index}]: 补全缺失字段 generated_assets",
+                location=f"{location_prefix}.generated_assets",
+            )
+            assets = item["generated_assets"]
+        elif isinstance(assets, dict):
+            template = self.project_manager.create_generated_assets(content_mode)
+            missing_keys = [key for key in template if key not in assets]
+            if missing_keys:
+                for key in missing_keys:
+                    assets[key] = template[key]
+                changed = True
+                # 补全值非 None 的才报诊断，避免 no-op 补全产生噪音
+                non_null_keys = sorted(k for k in missing_keys if template[k] is not None)
+                if non_null_keys:
+                    diagnostics.add(
+                        "auto_fixed",
+                        "generated_assets_defaults",
+                        (f"{label}[{index}].generated_assets: 补全默认字段 {', '.join(non_null_keys)}"),
+                        location=f"{location_prefix}.generated_assets",
+                    )
+        return assets, changed
+
+    def _repair_video_units_payload(
+        self,
+        project_dir: Path,
+        *,
+        script_path_rel: str,
+        script_payload: dict[str, Any],
+        content_mode: str,
+        versions_payload: dict[str, Any],
+        diagnostics: ArchiveDiagnostics,
+    ) -> bool:
+        """修复 reference_video 模式剧本 video_units[*].generated_assets 的本地资源路径。
+
+        video_units 没有 narration/drama 的 characters/scenes/props 字段，因此只做
+        generated_assets 补全 + video_clip / video_thumbnail 路径规范化与版本回溯。
+        video_uri 是远端 URL，不当作本地路径处理（否则会被同名 canonical 本地文件覆盖）。
+        """
+        raw_units = script_payload.get("video_units")
+        if not isinstance(raw_units, list):
+            return False
+
+        changed = False
+        for index, unit in enumerate(raw_units):
+            if not isinstance(unit, dict):
+                continue
+
+            location_prefix = f"{script_path_rel}:video_units[{index}]"
+            resource_id = str(unit.get("unit_id") or "").strip()
+
+            assets, assets_changed = self._backfill_generated_assets(
+                unit,
+                content_mode=content_mode,
+                label="video_units",
+                index=index,
+                location_prefix=location_prefix,
+                diagnostics=diagnostics,
+            )
+            if assets_changed:
+                changed = True
+
+            if not (isinstance(assets, dict) and resource_id):
+                continue
+
+            # video_clip 有版本历史，可从 versions/ 回溯物化当前文件
+            if self._repair_path_to_canonical(
+                project_dir,
+                assets,
+                field_name="video_clip",
+                canonical_rel=self._canonical_resource_path("reference_videos", resource_id),
+                location=f"{location_prefix}.generated_assets.video_clip",
+                diagnostics=diagnostics,
+                resource_type="reference_videos",
+                resource_id=resource_id,
+                versions_payload=versions_payload,
+            ):
+                changed = True
+
+            # 缩略图无版本历史，仅在 canonical 文件存在时规范化路径
+            if self._repair_path_to_canonical(
+                project_dir,
+                assets,
+                field_name="video_thumbnail",
+                canonical_rel=f"reference_videos/thumbnails/{resource_id}.jpg",
+                location=f"{location_prefix}.generated_assets.video_thumbnail",
+                diagnostics=diagnostics,
+            ):
+                changed = True
+
+        return changed
 
     def _repair_path_to_canonical(
         self,

--- a/tests/test_project_archive_reference_video.py
+++ b/tests/test_project_archive_reference_video.py
@@ -1,0 +1,209 @@
+"""归档导入针对 reference_video 模式（video_units）的修复测试。
+
+覆盖 issue：_repair_script_payload 此前只按 content_mode 走 segments/scenes，
+未处理 generation_mode=reference_video 项目剧本里的 video_units，导致导出-导入往返时
+video_units[*].generated_assets 的路径规范化与版本回溯不触发。
+"""
+
+import json
+import shutil
+import zipfile
+from pathlib import Path
+
+from lib.project_manager import ProjectManager
+from server.services.project_archive import ProjectArchiveService
+
+REMOTE_VIDEO_URI = "https://cdn.example.com/v/E1U1.mp4"
+
+# 区分"未传 generated_assets（用默认）"与"显式传 None（不写该字段）"
+_DEFAULT_ASSETS = object()
+
+
+def _write_bytes(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _make_manual_zip(project_dir: Path, zip_path: Path) -> None:
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for item in sorted(project_dir.rglob("*")):
+            relative = item.relative_to(project_dir)
+            if item.is_dir():
+                info = zipfile.ZipInfo(relative.as_posix().rstrip("/") + "/")
+                archive.writestr(info, b"")
+            else:
+                archive.write(item, arcname=relative.as_posix())
+
+
+def _build_unit(*, video_clip: str | None, generated_assets: dict | None | object = _DEFAULT_ASSETS) -> dict:
+    if generated_assets is _DEFAULT_ASSETS:
+        generated_assets = {
+            "storyboard_image": None,
+            "storyboard_last_image": None,
+            "video_clip": video_clip,
+            "video_thumbnail": "reference_videos/thumbnails/E1U1.jpg",
+            "video_uri": REMOTE_VIDEO_URI,
+            "grid_id": None,
+            "grid_cell_index": None,
+            "status": "completed",
+        }
+    unit: dict = {
+        "unit_id": "E1U1",
+        "shots": [{"duration": 4, "text": "镜头一"}],
+        "references": [],
+        "duration_seconds": 4,
+        "transition_to_next": "cut",
+    }
+    if generated_assets is not None:
+        unit["generated_assets"] = generated_assets
+    return unit
+
+
+def _build_reference_episode(unit: dict) -> dict:
+    return {
+        "episode": 1,
+        "title": "第一集",
+        "content_mode": "narration",
+        "generation_mode": "reference_video",
+        "duration_seconds": 4,
+        "summary": "demo",
+        "novel": {"title": "RefDemo", "chapter": "第一章"},
+        "video_units": [unit],
+    }
+
+
+def _create_reference_video_project(
+    pm: ProjectManager,
+    *,
+    name: str = "refdemo",
+    unit: dict | None = None,
+    write_clip: bool = True,
+    write_thumbnail: bool = True,
+) -> Path:
+    pm.create_project(name)
+    pm.create_project_metadata(name, "RefDemo", "Anime", "narration")
+
+    project_dir = pm.get_project_path(name)
+    project = pm.load_project(name)
+    project["generation_mode"] = "reference_video"
+    project["style_image"] = "style_reference.png"
+    project["episodes"] = [
+        {
+            "episode": 1,
+            "title": "第一集",
+            "script_file": "scripts/episode_1.json",
+        }
+    ]
+    pm.save_project(name, project)
+
+    _write_bytes(project_dir / "style_reference.png", b"png")
+    if write_clip:
+        _write_bytes(project_dir / "reference_videos" / "E1U1.mp4", b"mp4")
+    if write_thumbnail:
+        _write_bytes(project_dir / "reference_videos" / "thumbnails" / "E1U1.jpg", b"jpg")
+
+    if unit is None:
+        unit = _build_unit(video_clip="reference_videos/E1U1.mp4")
+    _write_json(project_dir / "scripts" / "episode_1.json", _build_reference_episode(unit))
+    return project_dir
+
+
+class TestProjectArchiveReferenceVideo:
+    def test_canonical_resource_path_reference_videos(self):
+        # 验收项：reference_videos 走 unit_id 无前缀分支
+        assert ProjectArchiveService._canonical_resource_path("reference_videos", "E1U1") == "reference_videos/E1U1.mp4"
+
+    def test_round_trip_preserves_video_units(self, tmp_path):
+        pm = ProjectManager(tmp_path / "projects")
+        _create_reference_video_project(pm)
+        service = ProjectArchiveService(pm)
+
+        archive_path, _ = service.export_project("refdemo")
+        shutil.rmtree(pm.get_project_path("refdemo"))
+
+        result = service.import_project_archive(archive_path, uploaded_filename="refdemo.zip")
+
+        assert result.project_name == "refdemo"
+        project_dir = pm.get_project_path("refdemo")
+        imported = json.loads((project_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8"))
+        assets = imported["video_units"][0]["generated_assets"]
+        assert assets["video_clip"] == "reference_videos/E1U1.mp4"
+        assert assets["video_thumbnail"] == "reference_videos/thumbnails/E1U1.jpg"
+        # video_uri 是远端 URL，绝不能被当成本地路径覆盖
+        assert assets["video_uri"] == REMOTE_VIDEO_URI
+        assert (project_dir / "reference_videos" / "E1U1.mp4").exists()
+        assert (project_dir / "reference_videos" / "thumbnails" / "E1U1.jpg").exists()
+
+    def test_import_restores_video_clip_from_version(self, tmp_path):
+        pm = ProjectManager(tmp_path / "projects")
+        # video_clip 指向失效的版本路径，靠 versions.json 回溯物化当前文件
+        unit = _build_unit(
+            video_clip="versions/reference_videos/E1U1_v9.mp4",
+            generated_assets={
+                "storyboard_image": None,
+                "video_clip": "versions/reference_videos/E1U1_v9.mp4",
+                "video_thumbnail": None,
+                "video_uri": None,
+                "status": "completed",
+            },
+        )
+        project_dir = _create_reference_video_project(pm, unit=unit, write_clip=False, write_thumbnail=False)
+        service = ProjectArchiveService(pm)
+
+        _write_json(
+            project_dir / "versions" / "versions.json",
+            {
+                "reference_videos": {
+                    "E1U1": {
+                        "current_version": 1,
+                        "versions": [
+                            {
+                                "version": 1,
+                                "file": "versions/reference_videos/E1U1_v1.mp4",
+                                "prompt": "vp1",
+                                "created_at": "2024-01-01",
+                            }
+                        ],
+                    }
+                }
+            },
+        )
+        _write_bytes(project_dir / "versions" / "reference_videos" / "E1U1_v1.mp4", b"mp4-v1")
+
+        archive_path = tmp_path / "legacy.zip"
+        _make_manual_zip(project_dir, archive_path)
+        shutil.rmtree(project_dir)
+
+        result = service.import_project_archive(archive_path, uploaded_filename="legacy.zip")
+
+        imported = json.loads(
+            (pm.get_project_path(result.project_name) / "scripts" / "episode_1.json").read_text(encoding="utf-8")
+        )
+        assert imported["video_units"][0]["generated_assets"]["video_clip"] == "reference_videos/E1U1.mp4"
+        assert (pm.get_project_path(result.project_name) / "reference_videos" / "E1U1.mp4").exists()
+        assert result.diagnostics["auto_fixed"]
+
+    def test_import_backfills_missing_generated_assets(self, tmp_path):
+        pm = ProjectManager(tmp_path / "projects")
+        unit = _build_unit(video_clip=None, generated_assets=None)
+        project_dir = _create_reference_video_project(pm, unit=unit, write_clip=False, write_thumbnail=False)
+        service = ProjectArchiveService(pm)
+
+        archive_path = tmp_path / "legacy.zip"
+        _make_manual_zip(project_dir, archive_path)
+        shutil.rmtree(project_dir)
+
+        result = service.import_project_archive(archive_path, uploaded_filename="legacy.zip")
+
+        imported = json.loads(
+            (pm.get_project_path(result.project_name) / "scripts" / "episode_1.json").read_text(encoding="utf-8")
+        )
+        assets = imported["video_units"][0]["generated_assets"]
+        assert isinstance(assets, dict)
+        assert "video_thumbnail" in assets
+        assert assets["status"] == "pending"


### PR DESCRIPTION
## 背景

Closes #333

PR #332 给 `ProjectArchiveService` 的 `_VERSION_HISTORY_DIRS` / `_RESOURCE_EXTENSIONS` 补了 `reference_videos` 条目，但归档导入时真正修复脚本内资源路径的 `_repair_script_payload` 仍只按 `content_mode`（narration→`segments` / drama→`scenes`）分支，**没有处理 `generation_mode=reference_video` 项目剧本里的 `video_units`**。

因为 `script_payload.get("scenes")` 不是 list，方法提前 return，导致导出含参考视频生成状态的项目再导入时，`video_units[*].generated_assets.video_clip` 的路径规范化与版本历史回溯不触发，可能丢失生成状态或资源索引错位。仅影响 reference_video 模式的「导出→导入」全链路。

## 改动

`server/services/project_archive.py`
- 在 `_repair_script_payload` 增加 `effective_mode == "reference_video"` 分支，走专用修复路径。
- 抽出 `_backfill_generated_assets` helper（generated_assets 缺失字段补全），narration/drama 原循环复用，行为不变。
- 新增 `_repair_video_units_payload`：遍历 `video_units[*]` 补全 `generated_assets`，并修复本地路径：
  - `video_clip` → canonical `reference_videos/{unit_id}.mp4`，含版本历史回溯；
  - `video_thumbnail` → `reference_videos/thumbnails/{unit_id}.jpg`，仅路径规范化（缩略图无版本历史）；
  - `video_uri` 为远端 URL，**不当作本地路径处理**（否则会被同名 canonical 本地文件覆盖；narration/drama 同样不碰它）。
- `_canonical_resource_path` 未改——fallback 已返回 `reference_videos/E1U1.mp4`，仅加单测锁定。

`tests/test_project_archive_reference_video.py`（新增）
- canonical 路径单测（验收项 `_canonical_resource_path("reference_videos", "E1U1") == "reference_videos/E1U1.mp4"`）
- 导出-导入往返：video_units 与远端 video_uri 完整保留
- 版本回溯：失效 `versions/reference_videos/E1U1_v9.mp4` → 从 versions.json 物化为 canonical
- 缺失 generated_assets 自动补全

## 验证

- 新测试 4 个 + 既有归档测试 42 个 = 46 passed
- `ruff check` / `ruff format` 通过
- `basedpyright` 0 errors, 0 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了对参考视频项目的专项支持，包括视频单元的归档导出和导入
  * 增强了视频资源路径的规范化和修复能力
  * 支持自动从版本历史中恢复过期视频版本
  * 改进了归档导入时缺失资源信息的自动回填机制

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->