### PR TITLE
fix(concurrency): 统一 ProjectManager 读-改-写锁语义（跨 script / project）

### DIFF
--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -448,15 +448,25 @@ class ProjectManager:
         Returns:
             保存的文件路径
         """
-        project_dir = self.get_project_path(project_name)
-        scripts_dir = project_dir / "scripts"
-
         if filename is not None and filename.startswith("scripts/"):
             filename = filename[len("scripts/") :]
 
         if filename is None:
             chapter = script["novel"].get("chapter", "chapter_01")
             filename = f"{chapter.replace(' ', '_')}_script.json"
+
+        with self._script_lock(project_name, filename):
+            return self._write_script_unlocked(project_name, script, filename)
+
+    def _write_script_unlocked(self, project_name: str, script: dict, filename: str) -> Path:
+        """剧本写盘主体：校验 + 更新元数据 + 原子写 + 同步 project.json。
+
+        **不获取 `_script_lock`**——调用方必须已持有该锁（见 `save_script` / `locked_script`），
+        否则会丧失并发保护。独立抽出是为了避免 `locked_script` 复用 `save_script` 时二次获取
+        同一把 flock 造成同进程自死锁（与 `update_project` 内联 `atomic_write_json` 而不复用
+        `save_project` 同理）。filename 须已去除 `scripts/` 前缀且非 None。
+        """
+        scripts_dir = self.get_project_path(project_name) / "scripts"
 
         # 先做 filename/内部 episode 一致性校验，避免写盘后才在 sync 阶段抛错，
         # 造成"脚本文件已落盘、project.json 未同步"的部分提交（codex 指出的原子性缺口）。
@@ -497,16 +507,16 @@ class ProjectManager:
         total_duration = sum(item.get("duration_seconds", default_duration) for item in items)
         metadata["estimated_duration_seconds"] = total_duration
 
-        # 保存文件（含路径遍历防护）+ 文件锁 + 原子写，避免并发 PATCH 导致 JSON 损坏
+        # 保存文件（含路径遍历防护）+ 原子写，避免并发 PATCH 导致 JSON 损坏
         real = self._safe_subpath(scripts_dir, filename)
         output_path = Path(real)
 
-        with self._script_lock(project_name, filename):
-            atomic_write_json(output_path, script)
+        atomic_write_json(output_path, script)
 
-            # 在同一把锁内同步到 project.json，保证 script 写入与元数据同步是单一事务
-            if self.project_exists(project_name) and isinstance(script.get("episode"), int):
-                self.sync_episode_from_script(project_name, filename)
+        # 同步到 project.json，保证 script 写入与元数据同步是单一事务
+        # （sync 走的是 `_project_lock`，与外层 `_script_lock` 不同锁，不会冲突）。
+        if self.project_exists(project_name) and isinstance(script.get("episode"), int):
+            self.sync_episode_from_script(project_name, filename)
 
         emit_project_change_hint(
             project_name,
@@ -514,6 +524,20 @@ class ProjectManager:
         )
 
         return output_path
+
+    @contextmanager
+    def locked_script(self, project_name: str, script_filename: str):
+        """在单一 `_script_lock` 内完成剧本的 load → mutate → save 读-改-写。
+
+        yield 出剧本字典供调用方就地修改；正常退出时写回，with 体内抛异常（如目标 scene/unit
+        未找到）则跳过写回、照常释放锁。与 `update_project` 对称，消除"读改写之间被并发写覆盖"
+        的 lost-update 竞态。
+        """
+        norm = script_filename[len("scripts/") :] if script_filename.startswith("scripts/") else script_filename
+        with self._script_lock(project_name, norm):
+            script = self.load_script(project_name, norm)
+            yield script
+            self._write_script_unlocked(project_name, script, norm)
 
     @staticmethod
     def _require_filename_episode_consistency(script: dict, script_filename: str) -> None:
@@ -571,7 +595,6 @@ class ProjectManager:
                 错写为 episode=1，会覆盖第 1 集）。
         """
         script = self.load_script(project_name, script_filename)
-        project = self.load_project(project_name)
 
         base_name = script_filename[len("scripts/") :] if script_filename.startswith("scripts/") else script_filename
         # 防御纵深：SSE 扫描路径直接调用此函数（不经 save_script），同样需要校验
@@ -586,24 +609,22 @@ class ProjectManager:
         episode_title = script.get("title", "")
         script_file = f"scripts/{base_name}"
 
-        # 查找或创建 episode 条目
-        episodes = project.setdefault("episodes", [])
-        episode_entry: dict[str, Any] | None = next((ep for ep in episodes if ep["episode"] == episode_num), None)
+        def _mutate(project: dict) -> None:
+            # 查找或创建 episode 条目（整段 RMW 在单一 _project_lock 内完成，避免并发同步丢失）
+            episodes = project.setdefault("episodes", [])
+            episode_entry: dict[str, Any] | None = next((ep for ep in episodes if ep["episode"] == episode_num), None)
+            if episode_entry is None:
+                episode_entry = {"episode": episode_num}
+                episodes.append(episode_entry)
+            # 同步核心元数据（不包含统计字段，统计字段由 StatusCalculator 读时计算）
+            episode_entry["title"] = episode_title
+            episode_entry["script_file"] = script_file
+            episodes.sort(key=lambda x: x["episode"])
 
-        if episode_entry is None:
-            episode_entry = {"episode": episode_num}
-            episodes.append(episode_entry)
-
-        # 同步核心元数据（不包含统计字段，统计字段由 StatusCalculator 读时计算）
-        episode_entry["title"] = episode_title
-        episode_entry["script_file"] = script_file
-
-        # 排序并保存
-        episodes.sort(key=lambda x: x["episode"])
-        self.save_project(project_name, project)
+        self.update_project(project_name, _mutate)
 
         logger.info("已同步剧集信息: Episode %d - %s", episode_num, episode_title)
-        return project
+        return self.load_project(project_name)
 
     def load_script(self, project_name: str, filename: str) -> dict:
         """
@@ -637,13 +658,11 @@ class ProjectManager:
 
     def update_character_sheet(self, project_name: str, script_filename: str, name: str, sheet_path: str) -> dict:
         """更新角色设计图路径"""
-        script = self.load_script(project_name, script_filename)
-
-        if name not in script["characters"]:
-            raise KeyError(f"角色 '{name}' 不存在")
-
-        script["characters"][name]["character_sheet"] = sheet_path
-        self.save_script(project_name, script, script_filename)
+        with self.locked_script(project_name, script_filename) as script:
+            if name not in script["characters"]:
+                # 在锁内抛出，locked_script 跳过写回
+                raise KeyError(f"角色 '{name}' 不存在")
+            script["characters"][name]["character_sheet"] = sheet_path
         return script
 
     # ==================== 数据结构标准化 ====================
@@ -895,23 +914,21 @@ class ProjectManager:
         Returns:
             更新后的剧本
         """
-        script = self.load_script(project_name, script_filename)
+        with self.locked_script(project_name, script_filename) as script:
+            # 自动生成场景 ID
+            existing_ids = [s["scene_id"] for s in script["scenes"]]
+            next_id = f"{len(existing_ids) + 1:03d}"
+            scene["scene_id"] = next_id
 
-        # 自动生成场景 ID
-        existing_ids = [s["scene_id"] for s in script["scenes"]]
-        next_id = f"{len(existing_ids) + 1:03d}"
-        scene["scene_id"] = next_id
+            # 确保有 generated_assets 字段
+            if "generated_assets" not in scene:
+                scene["generated_assets"] = {
+                    "storyboard_image": None,
+                    "video_clip": None,
+                    "status": "pending",
+                }
 
-        # 确保有 generated_assets 字段
-        if "generated_assets" not in scene:
-            scene["generated_assets"] = {
-                "storyboard_image": None,
-                "video_clip": None,
-                "status": "pending",
-            }
-
-        script["scenes"].append(scene)
-        self.save_script(project_name, script, script_filename)
+            script["scenes"].append(scene)
         return script
 
     def update_scene_asset(
@@ -935,38 +952,37 @@ class ProjectManager:
         Returns:
             更新后的剧本
         """
-        script = self.load_script(project_name, script_filename)
+        with self.locked_script(project_name, script_filename) as script:
+            # 根据内容模式选择正确的数据结构
+            content_mode = script.get("content_mode", "narration")
+            if content_mode == "narration" and "segments" in script:
+                items = script["segments"]
+                id_field = "segment_id"
+            else:
+                items = script.get("scenes", [])
+                id_field = "scene_id"
 
-        # 根据内容模式选择正确的数据结构
-        content_mode = script.get("content_mode", "narration")
-        if content_mode == "narration" and "segments" in script:
-            items = script["segments"]
-            id_field = "segment_id"
-        else:
-            items = script.get("scenes", [])
-            id_field = "scene_id"
+            for item in items:
+                if str(item.get(id_field)) == str(scene_id):
+                    assets = item.get("generated_assets")
+                    if not isinstance(assets, dict):
+                        assets = {}
+                        item["generated_assets"] = assets
 
-        for item in items:
-            if str(item.get(id_field)) == str(scene_id):
-                assets = item.get("generated_assets")
-                if not isinstance(assets, dict):
-                    assets = {}
-                    item["generated_assets"] = assets
+                    assets_template = self.create_generated_assets(content_mode)
+                    for key, default_value in assets_template.items():
+                        if key not in assets:
+                            assets[key] = default_value
 
-                assets_template = self.create_generated_assets(content_mode)
-                for key, default_value in assets_template.items():
-                    if key not in assets:
-                        assets[key] = default_value
+                    assets[asset_type] = asset_path
 
-                assets[asset_type] = asset_path
-
-                # 使用 update_scene_status 更新状态
-                self.update_scene_status(item)
-
-                self.save_script(project_name, script, script_filename)
-                return script
-
-        raise KeyError(f"场景 '{scene_id}' 不存在")
+                    # 使用 update_scene_status 更新状态
+                    self.update_scene_status(item)
+                    break
+            else:
+                # 未命中：在锁内抛出，locked_script 跳过写回
+                raise KeyError(f"场景 '{scene_id}' 不存在")
+        return script
 
     def batch_update_scene_assets(
         self,
@@ -987,38 +1003,35 @@ class ProjectManager:
         if not updates:
             return {}
 
-        script = self.load_script(project_name, script_filename)
+        with self.locked_script(project_name, script_filename) as script:
+            content_mode = script.get("content_mode", "narration")
+            if content_mode == "narration" and "segments" in script:
+                items = script["segments"]
+                id_field = "segment_id"
+            else:
+                items = script.get("scenes", [])
+                id_field = "scene_id"
 
-        content_mode = script.get("content_mode", "narration")
-        if content_mode == "narration" and "segments" in script:
-            items = script["segments"]
-            id_field = "segment_id"
-        else:
-            items = script.get("scenes", [])
-            id_field = "scene_id"
+            # 建立 scene_id → item 索引，避免 O(N*M) 查找
+            item_by_id: dict[str, dict] = {str(item.get(id_field)): item for item in items}
 
-        # 建立 scene_id → item 索引，避免 O(N*M) 查找
-        item_by_id: dict[str, dict] = {str(item.get(id_field)): item for item in items}
+            for scene_id, asset_type, asset_path in updates:
+                item = item_by_id.get(str(scene_id))
+                if item is None:
+                    continue
 
-        for scene_id, asset_type, asset_path in updates:
-            item = item_by_id.get(str(scene_id))
-            if item is None:
-                continue
+                assets = item.get("generated_assets")
+                if not isinstance(assets, dict):
+                    assets = {}
+                    item["generated_assets"] = assets
 
-            assets = item.get("generated_assets")
-            if not isinstance(assets, dict):
-                assets = {}
-                item["generated_assets"] = assets
+                assets_template = self.create_generated_assets(content_mode)
+                for key, default_value in assets_template.items():
+                    if key not in assets:
+                        assets[key] = default_value
 
-            assets_template = self.create_generated_assets(content_mode)
-            for key, default_value in assets_template.items():
-                if key not in assets:
-                    assets[key] = default_value
-
-            assets[asset_type] = asset_path
-            self.update_scene_status(item)
-
-        self.save_script(project_name, script, script_filename)
+                assets[asset_type] = asset_path
+                self.update_scene_status(item)
         return script
 
     def get_pending_scenes(self, project_name: str, script_filename: str, asset_type: str) -> list[dict]:
@@ -1356,24 +1369,20 @@ class ProjectManager:
         Returns:
             更新后的项目元数据
         """
-        project = self.load_project(project_name)
 
-        # 检查是否已存在
-        for ep in project["episodes"]:
-            if ep["episode"] == episode:
-                ep["title"] = title
-                ep["script_file"] = script_file
-                self.save_project(project_name, project)
-                return project
+        def _mutate(project: dict) -> None:
+            # 已存在则更新，否则追加（整段 RMW 在单一 _project_lock 内完成）
+            for ep in project["episodes"]:
+                if ep["episode"] == episode:
+                    ep["title"] = title
+                    ep["script_file"] = script_file
+                    return
+            # 添加新剧集（不包含统计字段，由 StatusCalculator 读时计算）
+            project["episodes"].append({"episode": episode, "title": title, "script_file": script_file})
+            project["episodes"].sort(key=lambda x: x["episode"])
 
-        # 添加新剧集（不包含统计字段，由 StatusCalculator 读时计算）
-        project["episodes"].append({"episode": episode, "title": title, "script_file": script_file})
-
-        # 按集数排序
-        project["episodes"].sort(key=lambda x: x["episode"])
-
-        self.save_project(project_name, project)
-        return project
+        self.update_project(project_name, _mutate)
+        return self.load_project(project_name)
 
     def sync_project_status(self, project_name: str) -> dict:
         """
@@ -1520,16 +1529,16 @@ class ProjectManager:
         Returns:
             更新后的项目元数据
         """
-        project = self.load_project(project_name)
 
-        project["characters"][name] = {
-            "description": description,
-            "voice_style": voice_style or "",
-            "character_sheet": character_sheet or "",
-        }
+        def _mutate(project: dict) -> None:
+            project["characters"][name] = {
+                "description": description,
+                "voice_style": voice_style or "",
+                "character_sheet": character_sheet or "",
+            }
 
-        self.save_project(project_name, project)
-        return project
+        self.update_project(project_name, _mutate)
+        return self.load_project(project_name)
 
     def update_project_character_sheet(self, project_name: str, name: str, sheet_path: str) -> dict:
         """更新项目级角色设计图路径"""
@@ -1547,14 +1556,14 @@ class ProjectManager:
         Returns:
             更新后的项目数据
         """
-        project = self.load_project(project_name)
 
-        if "characters" not in project or char_name not in project["characters"]:
-            raise KeyError(f"角色 '{char_name}' 不存在")
+        def _mutate(project: dict) -> None:
+            if "characters" not in project or char_name not in project["characters"]:
+                raise KeyError(f"角色 '{char_name}' 不存在")
+            project["characters"][char_name]["reference_image"] = ref_path
 
-        project["characters"][char_name]["reference_image"] = ref_path
-        self.save_project(project_name, project)
-        return project
+        self.update_project(project_name, _mutate)
+        return self.load_project(project_name)
 
     def get_project_character(self, project_name: str, name: str) -> dict:
         """获取项目级角色定义"""
@@ -1771,10 +1780,11 @@ class ProjectManager:
         overview_dict = overview.model_dump()
         overview_dict["generated_at"] = datetime.now(UTC).isoformat()
 
-        # 保存到 project.json
-        project = self.load_project(project_name)
-        project["overview"] = overview_dict
-        self.save_project(project_name, project)
+        # 保存到 project.json（RMW 在单一 _project_lock 内完成，避免并发覆盖其它字段）
+        def _mutate(project: dict) -> None:
+            project["overview"] = overview_dict
+
+        self.update_project(project_name, _mutate)
 
         logger.info("项目概述已生成并保存")
         return overview_dict

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -831,17 +831,18 @@ async def upload_style_image(project_name: str, _user: CurrentUser, _t: Translat
         style_description = result.text
 
         def _sync_save():
-            # 更新 project.json
-            project_data = get_project_manager().load_project(project_name)
-            project_data["style_image"] = style_filename
-            project_data["style_description"] = style_description
-            # 强互斥：自定义参考图与模版二选一。除了清 template_id，
-            # 还需清掉之前由模板展开写入的 `style` prompt，否则生成链路会把
-            # 模板 prompt 与 style_description 同时喂给 LLM，破坏二选一语义。
-            project_data.pop("style_template_id", None)
-            project_data["style"] = ""
+            # 更新 project.json：整段 RMW 在单一 _project_lock 内完成，避免覆盖并发写入的其它字段
+            def _mutate(project_data: dict) -> None:
+                project_data["style_image"] = style_filename
+                project_data["style_description"] = style_description
+                # 强互斥：自定义参考图与模版二选一。除了清 template_id，
+                # 还需清掉之前由模板展开写入的 `style` prompt，否则生成链路会把
+                # 模板 prompt 与 style_description 同时喂给 LLM，破坏二选一语义。
+                project_data.pop("style_template_id", None)
+                project_data["style"] = ""
+
             with project_change_source("webui"):
-                get_project_manager().save_project(project_name, project_data)
+                get_project_manager().update_project(project_name, _mutate)
 
         await asyncio.to_thread(_sync_save)
 

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -607,8 +607,6 @@ async def update_project(name: str, req: UpdateProjectRequest, _user: CurrentUse
                     detail=_t("project_id_not_editable"),
                 )
 
-            captured: dict[str, Any] = {}
-
             def _mutate(project: dict) -> None:
                 # 整段 read-modify-write 在单一 _project_lock 内完成，避免并发 PATCH / 任务回写丢更新
                 if req.title is not None:
@@ -721,11 +719,12 @@ async def update_project(name: str, req: UpdateProjectRequest, _user: CurrentUse
 
                     project["episodes"] = new_episodes
 
-                captured["project"] = project
-
             with project_change_source("webui"):
                 manager.update_project(name, _mutate)
-            return {"success": True, "project": captured["project"]}
+            # 返回经 load_project 的 fresh 副本，恢复改用 update_project 前由 load_project
+            # 读取时执行的 _migrate_legacy_style（持久化）+ _lazy_upgrade_image_provider 语义，
+            # 确保回前端的 project 含升级后的字段（与其它已迁移 helper 一致：均 return load_project）
+            return {"success": True, "project": manager.load_project(name)}
 
         return await asyncio.to_thread(_sync)
     except FileNotFoundError:

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -487,6 +487,9 @@ async def create_project(
             }
             if req.model_settings is not None:
                 extras["model_settings"] = req.model_settings
+            # generation_mode 并入 extras 一次性写入，避免 create 后再 load-save 的额外 RMW
+            if req.generation_mode is not None:
+                extras["generation_mode"] = req.generation_mode
             with project_change_source("webui"):
                 project = manager.create_project_metadata(
                     project_name,
@@ -498,9 +501,6 @@ async def create_project(
                     style_template_id=req.style_template_id,
                     extras=extras or None,
                 )
-                if req.generation_mode is not None:
-                    project["generation_mode"] = req.generation_mode
-                    manager.save_project(project_name, project)
             return {"success": True, "name": project_name, "project": project}
 
         return await asyncio.to_thread(_sync)
@@ -601,127 +601,131 @@ async def update_project(name: str, req: UpdateProjectRequest, _user: CurrentUse
 
         def _sync():
             manager = get_project_manager()
-            project = manager.load_project(name)
-
             if req.content_mode is not None:
                 raise HTTPException(
                     status_code=400,
                     detail=_t("project_id_not_editable"),
                 )
 
-            if req.title is not None:
-                project["title"] = req.title
-            if req.style is not None:
-                project["style"] = req.style
-            for field in (
-                "video_backend",
-                "image_backend",
-                "image_provider_t2i",
-                "image_provider_i2i",
-                "text_backend_script",
-                "text_backend_overview",
-                "text_backend_style",
-            ):
-                if field in req.model_fields_set:
-                    value = getattr(req, field)
-                    if value:
-                        validate_backend_value(value, field, _t)
-                        project[field] = value
+            captured: dict[str, Any] = {}
+
+            def _mutate(project: dict) -> None:
+                # 整段 read-modify-write 在单一 _project_lock 内完成，避免并发 PATCH / 任务回写丢更新
+                if req.title is not None:
+                    project["title"] = req.title
+                if req.style is not None:
+                    project["style"] = req.style
+                for field in (
+                    "video_backend",
+                    "image_backend",
+                    "image_provider_t2i",
+                    "image_provider_i2i",
+                    "text_backend_script",
+                    "text_backend_overview",
+                    "text_backend_style",
+                ):
+                    if field in req.model_fields_set:
+                        value = getattr(req, field)
+                        if value:
+                            validate_backend_value(value, field, _t)
+                            project[field] = value
+                        else:
+                            project.pop(field, None)
+
+                # 用户显式清空 t2i/i2i 任一时，同步清掉 legacy `image_backend`：否则 ProjectManager
+                # 的 lazy upgrade 会在下次 load_project 时用 legacy 值回填新字段，让"清空 → 跟随
+                # 全局默认"的语义失效。仅当客户端没在同一请求里写入 image_backend 才执行（避免
+                # 撤掉用户刚写入的值）。
+                if "image_backend" not in req.model_fields_set:
+                    cleared_t2i = "image_provider_t2i" in req.model_fields_set and not req.image_provider_t2i
+                    cleared_i2i = "image_provider_i2i" in req.model_fields_set and not req.image_provider_i2i
+                    if cleared_t2i or cleared_i2i:
+                        project.pop("image_backend", None)
+                if "video_generate_audio" in req.model_fields_set:
+                    if req.video_generate_audio is None:
+                        project.pop("video_generate_audio", None)
                     else:
-                        project.pop(field, None)
+                        project["video_generate_audio"] = req.video_generate_audio
+                if "aspect_ratio" in req.model_fields_set and req.aspect_ratio is not None:
+                    project["aspect_ratio"] = req.aspect_ratio
+                if "generation_mode" in req.model_fields_set:
+                    if req.generation_mode is None:
+                        project.pop("generation_mode", None)
+                    else:
+                        project["generation_mode"] = req.generation_mode
+                if "default_duration" in req.model_fields_set:
+                    if req.default_duration is None:
+                        project.pop("default_duration", None)
+                    else:
+                        project["default_duration"] = req.default_duration
 
-            # 用户显式清空 t2i/i2i 任一时，同步清掉 legacy `image_backend`：否则 ProjectManager
-            # 的 lazy upgrade 会在下次 load_project 时用 legacy 值回填新字段，让"清空 → 跟随
-            # 全局默认"的语义失效。仅当客户端没在同一请求里写入 image_backend 才执行（避免
-            # 撤掉用户刚写入的值）。
-            if "image_backend" not in req.model_fields_set:
-                cleared_t2i = "image_provider_t2i" in req.model_fields_set and not req.image_provider_t2i
-                cleared_i2i = "image_provider_i2i" in req.model_fields_set and not req.image_provider_i2i
-                if cleared_t2i or cleared_i2i:
-                    project.pop("image_backend", None)
-            if "video_generate_audio" in req.model_fields_set:
-                if req.video_generate_audio is None:
-                    project.pop("video_generate_audio", None)
-                else:
-                    project["video_generate_audio"] = req.video_generate_audio
-            if "aspect_ratio" in req.model_fields_set and req.aspect_ratio is not None:
-                project["aspect_ratio"] = req.aspect_ratio
-            if "generation_mode" in req.model_fields_set:
-                if req.generation_mode is None:
-                    project.pop("generation_mode", None)
-                else:
-                    project["generation_mode"] = req.generation_mode
-            if "default_duration" in req.model_fields_set:
-                if req.default_duration is None:
-                    project.pop("default_duration", None)
-                else:
-                    project["default_duration"] = req.default_duration
+                if "style_template_id" in req.model_fields_set:
+                    if req.style_template_id is None:
+                        # 取消模版选择：同时清掉展开的 style prompt，避免遗留孤儿文本
+                        project.pop("style_template_id", None)
+                        project["style"] = ""
+                    else:
+                        if not is_known_template(req.style_template_id):
+                            raise HTTPException(
+                                status_code=400,
+                                detail=_t("unknown_style_template", template_id=req.style_template_id),
+                            )
+                        project["style_template_id"] = req.style_template_id
+                        project["style"] = resolve_template_prompt(req.style_template_id)
+                        # 强互斥:模版与参考图二选一
+                        project.pop("style_image", None)
+                        project.pop("style_description", None)
 
-            if "style_template_id" in req.model_fields_set:
-                if req.style_template_id is None:
-                    # 取消模版选择：同时清掉展开的 style prompt，避免遗留孤儿文本
-                    project.pop("style_template_id", None)
-                    project["style"] = ""
-                else:
-                    if not is_known_template(req.style_template_id):
-                        raise HTTPException(
-                            status_code=400,
-                            detail=_t("unknown_style_template", template_id=req.style_template_id),
-                        )
-                    project["style_template_id"] = req.style_template_id
-                    project["style"] = resolve_template_prompt(req.style_template_id)
-                    # 强互斥:模版与参考图二选一
+                if req.clear_style_image:
+                    # 显式清除自定义参考图，用于"取消风格"流程
                     project.pop("style_image", None)
                     project.pop("style_description", None)
 
-            if req.clear_style_image:
-                # 显式清除自定义参考图，用于"取消风格"流程
-                project.pop("style_image", None)
-                project.pop("style_description", None)
+                if "model_settings" in req.model_fields_set:
+                    if req.model_settings is None:
+                        project.pop("model_settings", None)
+                    else:
+                        project["model_settings"] = req.model_settings
 
-            if "model_settings" in req.model_fields_set:
-                if req.model_settings is None:
-                    project.pop("model_settings", None)
-                else:
-                    project["model_settings"] = req.model_settings
+                if "episodes" in req.model_fields_set and req.episodes is not None:
+                    # 合并 episodes：保留现有 episode 的完整数据，仅更新请求中显式提供的字段。
+                    # 使用 model_fields_set（而非 exclude_none）判断字段是否显式出现，使得
+                    # `generation_mode: null` 可用于清空集级覆盖、回退到项目级模式继承。
+                    # 白名单同时拦截 StatusCalculator 注入的计算字段（scenes_count / status
+                    # / storyboards / videos 等），防止写回 project.json。
+                    existing_list = project.get("episodes", [])
+                    patch_map: dict[int, EpisodePatch] = {}
+                    for ep in req.episodes:
+                        patch_map[ep.episode] = ep  # 重复编号：后者覆盖前者
 
-            if "episodes" in req.model_fields_set and req.episodes is not None:
-                # 合并 episodes：保留现有 episode 的完整数据，仅更新请求中显式提供的字段。
-                # 使用 model_fields_set（而非 exclude_none）判断字段是否显式出现，使得
-                # `generation_mode: null` 可用于清空集级覆盖、回退到项目级模式继承。
-                # 白名单同时拦截 StatusCalculator 注入的计算字段（scenes_count / status
-                # / storyboards / videos 等），防止写回 project.json。
-                existing_list = project.get("episodes", [])
-                patch_map: dict[int, EpisodePatch] = {}
-                for ep in req.episodes:
-                    patch_map[ep.episode] = ep  # 重复编号：后者覆盖前者
-
-                new_episodes: list[dict] = []
-                for existing_ep in existing_list:
-                    ep_num = existing_ep.get("episode")
-                    patch = patch_map.pop(ep_num, None)
-                    if patch is None:
-                        new_episodes.append(existing_ep)
-                        continue
-                    updated = dict(existing_ep)
-                    for field_name in EPISODE_PERSIST_FIELDS:
-                        if field_name not in patch.model_fields_set:
+                    new_episodes: list[dict] = []
+                    for existing_ep in existing_list:
+                        ep_num = existing_ep.get("episode")
+                        patch = patch_map.pop(ep_num, None)
+                        if patch is None:
+                            new_episodes.append(existing_ep)
                             continue
-                        value = getattr(patch, field_name)
-                        if value is None:
-                            updated.pop(field_name, None)
-                        else:
-                            updated[field_name] = value
-                    new_episodes.append(updated)
+                        updated = dict(existing_ep)
+                        for field_name in EPISODE_PERSIST_FIELDS:
+                            if field_name not in patch.model_fields_set:
+                                continue
+                            value = getattr(patch, field_name)
+                            if value is None:
+                                updated.pop(field_name, None)
+                            else:
+                                updated[field_name] = value
+                        new_episodes.append(updated)
 
-                for unknown_ep in patch_map:
-                    logger.warning("Skipping patch for unknown episode %s", unknown_ep)
+                    for unknown_ep in patch_map:
+                        logger.warning("Skipping patch for unknown episode %s", unknown_ep)
 
-                project["episodes"] = new_episodes
+                    project["episodes"] = new_episodes
+
+                captured["project"] = project
 
             with project_change_source("webui"):
-                manager.save_project(name, project)
-            return {"success": True, "project": project}
+                manager.update_project(name, _mutate)
+            return {"success": True, "project": captured["project"]}
 
         return await asyncio.to_thread(_sync)
     except FileNotFoundError:
@@ -785,35 +789,33 @@ async def update_scene(name: str, scene_id: str, req: UpdateSceneRequest, _user:
 
         def _sync():
             manager = get_project_manager()
-            script = manager.load_script(name, req.script_file)
 
-            # 找到并更新场景
+            # 整段 RMW 在单一 _script_lock 内完成；未命中时在锁内 raise，跳过写回
             matched_scene: dict[str, Any] | None = None
-            for scene in script.get("scenes", []):
-                if scene.get("scene_id") == scene_id:
-                    matched_scene = scene
-                    # 更新允许的字段
-                    for key, value in req.updates.items():
-                        if key in [
-                            "duration_seconds",
-                            "image_prompt",
-                            "video_prompt",
-                            "characters_in_scene",
-                            "scenes",
-                            "props",
-                            "segment_break",
-                            "note",
-                        ]:
-                            if value is None and key != "note":
-                                continue
-                            scene[key] = value
-                    break
-
-            if matched_scene is None:
-                raise HTTPException(status_code=404, detail=_t("scene_not_found", id=scene_id))
-
             with project_change_source("webui"):
-                manager.save_script(name, script, req.script_file)
+                with manager.locked_script(name, req.script_file) as script:
+                    for scene in script.get("scenes", []):
+                        if scene.get("scene_id") == scene_id:
+                            matched_scene = scene
+                            # 更新允许的字段
+                            for key, value in req.updates.items():
+                                if key in [
+                                    "duration_seconds",
+                                    "image_prompt",
+                                    "video_prompt",
+                                    "characters_in_scene",
+                                    "scenes",
+                                    "props",
+                                    "segment_break",
+                                    "note",
+                                ]:
+                                    if value is None and key != "note":
+                                        continue
+                                    scene[key] = value
+                            break
+
+                    if matched_scene is None:
+                        raise HTTPException(status_code=404, detail=_t("scene_not_found", id=scene_id))
             return {"success": True, "scene": matched_scene}
 
         return await asyncio.to_thread(_sync)
@@ -853,39 +855,37 @@ async def update_segment(name: str, segment_id: str, req: UpdateSegmentRequest, 
 
         def _sync():
             manager = get_project_manager()
-            script = manager.load_script(name, req.script_file)
 
-            # 检查是否为说书模式
-            if script.get("content_mode") != "narration" and "segments" not in script:
-                raise HTTPException(status_code=400, detail=_t("narration_mode_required"))
-
-            # 找到并更新片段
+            # 整段 RMW 在单一 _script_lock 内完成；模式不符 / 未命中时在锁内 raise，跳过写回
             matched_segment: dict[str, Any] | None = None
-            for segment in script.get("segments", []):
-                if segment.get("segment_id") == segment_id:
-                    matched_segment = segment
-                    if req.duration_seconds is not None:
-                        segment["duration_seconds"] = req.duration_seconds
-                    if req.segment_break is not None:
-                        segment["segment_break"] = req.segment_break
-                    if req.image_prompt is not None:
-                        segment["image_prompt"] = req.image_prompt
-                    if req.video_prompt is not None:
-                        segment["video_prompt"] = req.video_prompt
-                    if req.transition_to_next is not None:
-                        segment["transition_to_next"] = req.transition_to_next
-                    if "note" in req.model_fields_set:
-                        segment["note"] = req.note
-                    for field in ("characters_in_segment", "scenes", "props"):
-                        if field in req.model_fields_set:
-                            segment[field] = getattr(req, field) or []
-                    break
-
-            if matched_segment is None:
-                raise HTTPException(status_code=404, detail=_t("segment_not_found", id=segment_id))
-
             with project_change_source("webui"):
-                manager.save_script(name, script, req.script_file)
+                with manager.locked_script(name, req.script_file) as script:
+                    # 检查是否为说书模式
+                    if script.get("content_mode") != "narration" and "segments" not in script:
+                        raise HTTPException(status_code=400, detail=_t("narration_mode_required"))
+
+                    for segment in script.get("segments", []):
+                        if segment.get("segment_id") == segment_id:
+                            matched_segment = segment
+                            if req.duration_seconds is not None:
+                                segment["duration_seconds"] = req.duration_seconds
+                            if req.segment_break is not None:
+                                segment["segment_break"] = req.segment_break
+                            if req.image_prompt is not None:
+                                segment["image_prompt"] = req.image_prompt
+                            if req.video_prompt is not None:
+                                segment["video_prompt"] = req.video_prompt
+                            if req.transition_to_next is not None:
+                                segment["transition_to_next"] = req.transition_to_next
+                            if "note" in req.model_fields_set:
+                                segment["note"] = req.note
+                            for field in ("characters_in_segment", "scenes", "props"):
+                                if field in req.model_fields_set:
+                                    segment[field] = getattr(req, field) or []
+                            break
+
+                    if matched_segment is None:
+                        raise HTTPException(status_code=404, detail=_t("segment_not_found", id=segment_id))
             return {"success": True, "segment": matched_segment}
 
         return await asyncio.to_thread(_sync)
@@ -1019,23 +1019,25 @@ async def update_overview(name: str, req: UpdateOverviewRequest, _user: CurrentU
 
         def _sync():
             manager = get_project_manager()
-            project = manager.load_project(name)
+            captured: dict[str, Any] = {}
 
-            if "overview" not in project:
-                project["overview"] = {}
-
-            if req.synopsis is not None:
-                project["overview"]["synopsis"] = req.synopsis
-            if req.genre is not None:
-                project["overview"]["genre"] = req.genre
-            if req.theme is not None:
-                project["overview"]["theme"] = req.theme
-            if req.world_setting is not None:
-                project["overview"]["world_setting"] = req.world_setting
+            def _mutate(project: dict) -> None:
+                # 整段 RMW 在单一 _project_lock 内完成，避免与并发生成的 overview 回写互相覆盖
+                if "overview" not in project:
+                    project["overview"] = {}
+                if req.synopsis is not None:
+                    project["overview"]["synopsis"] = req.synopsis
+                if req.genre is not None:
+                    project["overview"]["genre"] = req.genre
+                if req.theme is not None:
+                    project["overview"]["theme"] = req.theme
+                if req.world_setting is not None:
+                    project["overview"]["world_setting"] = req.world_setting
+                captured["overview"] = project["overview"]
 
             with project_change_source("webui"):
-                manager.save_project(name, project)
-            return {"success": True, "overview": project["overview"]}
+                manager.update_project(name, _mutate)
+            return {"success": True, "overview": captured["overview"]}
 
         return await asyncio.to_thread(_sync)
     except FileNotFoundError:

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -74,6 +74,28 @@ def _load_episode_script(project_name: str, episode: int) -> tuple[dict, dict, s
     return project, script, script_file
 
 
+def _resolve_episode(project_name: str, episode: int) -> tuple[dict, str]:
+    """加载 project.json，解析并校验指定集的 script_file（不预读 script）。
+
+    返回 (project, script_file)。写端点据此进入 `locked_script` 在锁内 fresh-load 剧本，
+    避免在锁外读取的快照与并发写者互相覆盖。
+    """
+    try:
+        project = get_project_manager().load_project(project_name)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    episodes = project.get("episodes") or []
+    meta = next((e for e in episodes if e.get("episode") == episode), None)
+    if meta is None or not meta.get("script_file"):
+        raise HTTPException(status_code=404, detail=f"episode {episode} not found")
+    if effective_mode(project=project, episode=meta) != "reference_video":
+        raise HTTPException(
+            status_code=409,
+            detail="episode script is not in reference_video mode",
+        )
+    return project, meta["script_file"]
+
+
 def _validate_references_exist(project: dict, refs: list[dict]) -> None:
     """确保 references 都在 project.json 对应 bucket 中。"""
     missing: list[str] = []
@@ -145,21 +167,22 @@ async def add_unit(
     req: AddUnitRequest,
     _user: CurrentUser,
 ) -> dict[str, Any]:
-    project, script, script_file = _load_episode_script(project_name, episode)
+    project, script_file = _resolve_episode(project_name, episode)
 
     refs = [r.model_dump() for r in req.references]
     _validate_references_exist(project, refs)
 
-    unit = _build_unit_dict(
-        unit_id=_next_unit_id(script, episode),
-        prompt=req.prompt,
-        references=refs,
-        duration_override=req.duration_seconds,
-        transition=req.transition_to_next,
-        note=req.note,
-    )
-    script.setdefault("video_units", []).append(unit)
-    get_project_manager().save_script(project_name, script, script_file)
+    with get_project_manager().locked_script(project_name, script_file) as script:
+        # unit_id 在锁内基于 fresh script 计算，避免并发新增撞 ID
+        unit = _build_unit_dict(
+            unit_id=_next_unit_id(script, episode),
+            prompt=req.prompt,
+            references=refs,
+            duration_override=req.duration_seconds,
+            transition=req.transition_to_next,
+            note=req.note,
+        )
+        script.setdefault("video_units", []).append(unit)
     return {"unit": unit}
 
 
@@ -189,32 +212,37 @@ async def patch_unit(
     req: PatchUnitRequest,
     _user: CurrentUser,
 ) -> dict[str, Any]:
-    project, script, script_file = _load_episode_script(project_name, episode)
-    unit = _find_unit(script, unit_id)
+    project, script_file = _resolve_episode(project_name, episode)
 
+    # references 存在性校验对 project（只读）先做，失败 raise 400（在进锁前）
+    refs: list[dict] | None = None
     if req.references is not None:
         refs = [r.model_dump() for r in req.references]
         _validate_references_exist(project, refs)
-        unit["references"] = refs
 
-    if req.prompt is not None:
-        shots, _mentions, override = parse_prompt(req.prompt)
-        if override and req.duration_seconds is not None:
-            shots[0].duration = max(1, int(req.duration_seconds))
-        unit["shots"] = [s.model_dump() for s in shots]
-        unit["duration_seconds"] = sum(s.duration for s in shots)
-        unit["duration_override"] = override
-    elif req.duration_seconds is not None and unit.get("duration_override"):
-        unit["duration_seconds"] = max(1, int(req.duration_seconds))
-        if unit.get("shots"):
-            unit["shots"][0]["duration"] = unit["duration_seconds"]
+    with get_project_manager().locked_script(project_name, script_file) as script:
+        unit = _find_unit(script, unit_id)  # 未找到 raise 404 → 跳过写回
 
-    if req.transition_to_next is not None:
-        unit["transition_to_next"] = req.transition_to_next
-    if req.note is not None:
-        unit["note"] = req.note
+        if refs is not None:
+            unit["references"] = refs
 
-    get_project_manager().save_script(project_name, script, script_file)
+        if req.prompt is not None:
+            shots, _mentions, override = parse_prompt(req.prompt)
+            if override and req.duration_seconds is not None:
+                shots[0].duration = max(1, int(req.duration_seconds))
+            unit["shots"] = [s.model_dump() for s in shots]
+            unit["duration_seconds"] = sum(s.duration for s in shots)
+            unit["duration_override"] = override
+        elif req.duration_seconds is not None and unit.get("duration_override"):
+            unit["duration_seconds"] = max(1, int(req.duration_seconds))
+            if unit.get("shots"):
+                unit["shots"][0]["duration"] = unit["duration_seconds"]
+
+        if req.transition_to_next is not None:
+            unit["transition_to_next"] = req.transition_to_next
+        if req.note is not None:
+            unit["note"] = req.note
+
     return {"unit": unit}
 
 
@@ -225,13 +253,14 @@ async def delete_unit(
     unit_id: str,
     _user: CurrentUser,
 ) -> Response:
-    _project, script, script_file = _load_episode_script(project_name, episode)
-    units = script.get("video_units") or []
-    new_units = [u for u in units if u.get("unit_id") != unit_id]
-    if len(new_units) == len(units):
-        raise HTTPException(status_code=404, detail=f"unit {unit_id} not found")
-    script["video_units"] = new_units
-    get_project_manager().save_script(project_name, script, script_file)
+    _project, script_file = _resolve_episode(project_name, episode)
+    with get_project_manager().locked_script(project_name, script_file) as script:
+        units = script.get("video_units") or []
+        new_units = [u for u in units if u.get("unit_id") != unit_id]
+        if len(new_units) == len(units):
+            # 未找到 → 在锁内 raise，跳过写回
+            raise HTTPException(status_code=404, detail=f"unit {unit_id} not found")
+        script["video_units"] = new_units
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -246,21 +275,23 @@ async def reorder_units(
     req: ReorderRequest,
     _user: CurrentUser,
 ) -> dict[str, Any]:
-    _project, script, script_file = _load_episode_script(project_name, episode)
-    units = script.get("video_units") or []
-    existing_ids = [u.get("unit_id") for u in units]
+    _project, script_file = _resolve_episode(project_name, episode)
+    with get_project_manager().locked_script(project_name, script_file) as script:
+        units = script.get("video_units") or []
+        existing_ids = [u.get("unit_id") for u in units]
 
-    if len(req.unit_ids) != len(existing_ids):
-        raise HTTPException(status_code=400, detail="unit_ids length mismatch")
-    if len(set(req.unit_ids)) != len(req.unit_ids):
-        raise HTTPException(status_code=400, detail="duplicate unit_ids")
-    if set(req.unit_ids) != set(existing_ids):
-        raise HTTPException(status_code=400, detail="unit_ids do not match existing units")
+        # 校验失败 → 在锁内 raise 400，跳过写回
+        if len(req.unit_ids) != len(existing_ids):
+            raise HTTPException(status_code=400, detail="unit_ids length mismatch")
+        if len(set(req.unit_ids)) != len(req.unit_ids):
+            raise HTTPException(status_code=400, detail="duplicate unit_ids")
+        if set(req.unit_ids) != set(existing_ids):
+            raise HTTPException(status_code=400, detail="unit_ids do not match existing units")
 
-    by_id = {u["unit_id"]: u for u in units}
-    script["video_units"] = [by_id[uid] for uid in req.unit_ids]
-    get_project_manager().save_script(project_name, script, script_file)
-    return {"units": script["video_units"]}
+        by_id = {u["unit_id"]: u for u in units}
+        reordered = [by_id[uid] for uid in req.unit_ids]
+        script["video_units"] = reordered
+    return {"units": reordered}
 
 
 @router.post(

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -6,6 +6,8 @@ Mount prefix: /api/v1/projects/{project_name}/reference-videos
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Response, status
@@ -96,6 +98,21 @@ def _resolve_episode(project_name: str, episode: int) -> tuple[dict, str]:
     return project, meta["script_file"]
 
 
+@contextmanager
+def _locked_episode_script(project_name: str, script_file: str) -> Iterator[dict]:
+    """进入 locked_script，并把缺失脚本文件的 FileNotFoundError 归一为 404。
+
+    project.json 可能残留指向已删除/移动文件的 script_file；此时 locked_script 内的
+    load_script 会抛 FileNotFoundError，需转成 404 而非 500（对齐旧 _load_episode_script
+    的行为，后者会先 load_script 把缺失文件转成 404）。
+    """
+    try:
+        with get_project_manager().locked_script(project_name, script_file) as script:
+            yield script
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 def _validate_references_exist(project: dict, refs: list[dict]) -> None:
     """确保 references 都在 project.json 对应 bucket 中。"""
     missing: list[str] = []
@@ -172,7 +189,7 @@ async def add_unit(
     refs = [r.model_dump() for r in req.references]
     _validate_references_exist(project, refs)
 
-    with get_project_manager().locked_script(project_name, script_file) as script:
+    with _locked_episode_script(project_name, script_file) as script:
         # unit_id 在锁内基于 fresh script 计算，避免并发新增撞 ID
         unit = _build_unit_dict(
             unit_id=_next_unit_id(script, episode),
@@ -220,7 +237,7 @@ async def patch_unit(
         refs = [r.model_dump() for r in req.references]
         _validate_references_exist(project, refs)
 
-    with get_project_manager().locked_script(project_name, script_file) as script:
+    with _locked_episode_script(project_name, script_file) as script:
         unit = _find_unit(script, unit_id)  # 未找到 raise 404 → 跳过写回
 
         if refs is not None:
@@ -254,7 +271,7 @@ async def delete_unit(
     _user: CurrentUser,
 ) -> Response:
     _project, script_file = _resolve_episode(project_name, episode)
-    with get_project_manager().locked_script(project_name, script_file) as script:
+    with _locked_episode_script(project_name, script_file) as script:
         units = script.get("video_units") or []
         new_units = [u for u in units if u.get("unit_id") != unit_id]
         if len(new_units) == len(units):
@@ -276,7 +293,7 @@ async def reorder_units(
     _user: CurrentUser,
 ) -> dict[str, Any]:
     _project, script_file = _resolve_episode(project_name, episode)
-    with get_project_manager().locked_script(project_name, script_file) as script:
+    with _locked_episode_script(project_name, script_file) as script:
         units = script.get("video_units") or []
         existing_ids = [u.get("unit_id") for u in units]
 

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -317,22 +317,21 @@ async def execute_reference_video_task(
         thumb_path.unlink(missing_ok=True)
         thumb_rel = None
 
-    # 9. 更新 unit.generated_assets（简单读改写 episode script）
+    # 9. 更新 unit.generated_assets（在 locked_script 内完成 read-modify-write，
+    #    避免与并发的 PATCH / 其他 unit 回写互相覆盖）
     def _update_unit_assets():
         pm = get_project_manager()
-        script = pm.load_script(project_name, script_file)
-        for u in script.get("video_units") or []:
-            if u.get("unit_id") == resource_id:
-                ga = u.setdefault("generated_assets", {})
-                ga["video_clip"] = f"reference_videos/{resource_id}.mp4"
-                if video_uri:
-                    ga["video_uri"] = video_uri
-                if thumb_rel:
-                    ga["video_thumbnail"] = thumb_rel
-                ga["status"] = "completed"
-                break
-        pm.save_script(project_name, script, script_file)
-        return script
+        with pm.locked_script(project_name, script_file) as script:
+            for u in script.get("video_units") or []:
+                if u.get("unit_id") == resource_id:
+                    ga = u.setdefault("generated_assets", {})
+                    ga["video_clip"] = f"reference_videos/{resource_id}.mp4"
+                    if video_uri:
+                        ga["video_uri"] = video_uri
+                    if thumb_rel:
+                        ga["video_thumbnail"] = thumb_rel
+                    ga["status"] = "completed"
+                    break
 
     await asyncio.to_thread(_update_unit_assets)
 

--- a/tests/server/test_reference_videos_router.py
+++ b/tests/server/test_reference_videos_router.py
@@ -229,3 +229,91 @@ def test_add_unit_stale_script_file_returns_404(client: TestClient, tmp_path: Pa
         json={"prompt": "Shot 1 (2s): @张三 出现", "references": [{"type": "character", "name": "张三"}]},
     )
     assert resp.status_code == 404, resp.text
+
+
+def test_add_unit_unknown_project_returns_404(client: TestClient):
+    resp = client.post(
+        "/api/v1/projects/missing/reference-videos/episodes/1/units",
+        json={"prompt": "Shot 1 (2s): @张三 出现", "references": []},
+    )
+    assert resp.status_code == 404
+
+
+def test_add_unit_unknown_episode_returns_404(client: TestClient):
+    resp = client.post(
+        "/api/v1/projects/demo/reference-videos/episodes/99/units",
+        json={"prompt": "Shot 1 (2s): 空镜", "references": []},
+    )
+    assert resp.status_code == 404
+
+
+def test_write_endpoint_rejects_non_reference_video_mode(client: TestClient, tmp_path: Path):
+    """episode 非 reference_video 模式时，写端点应返回 409。"""
+    script_path = tmp_path / "projects" / "demo" / "scripts" / "episode_1.json"
+    script = json.loads(script_path.read_text(encoding="utf-8"))
+    script["generation_mode"] = "image"
+    script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
+    proj_path = tmp_path / "projects" / "demo" / "project.json"
+    proj = json.loads(proj_path.read_text(encoding="utf-8"))
+    proj["generation_mode"] = "image"
+    proj_path.write_text(json.dumps(proj, ensure_ascii=False), encoding="utf-8")
+
+    resp = client.post(
+        "/api/v1/projects/demo/reference-videos/episodes/1/units",
+        json={"prompt": "Shot 1 (2s): 空镜", "references": []},
+    )
+    assert resp.status_code == 409
+
+
+def test_patch_unit_duration_override_without_header(client: TestClient):
+    """无 header 的 prompt → override=True，duration_seconds 直接生效。"""
+    resp = client.post(
+        "/api/v1/projects/demo/reference-videos/episodes/1/units",
+        json={"prompt": "@张三 推门", "references": [{"type": "character", "name": "张三"}], "duration_seconds": 5},
+    )
+    assert resp.status_code == 201, resp.text
+    uid = resp.json()["unit"]["unit_id"]
+    assert resp.json()["unit"]["duration_seconds"] == 5
+
+    # 仅改 duration_seconds（无 prompt）：走 elif 分支按已有 override 直接覆盖时长
+    resp = client.patch(
+        f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}",
+        json={"duration_seconds": 8, "transition_to_next": "fade", "note": "hi"},
+    )
+    assert resp.status_code == 200, resp.text
+    unit = resp.json()["unit"]
+    assert unit["duration_seconds"] == 8
+    assert unit["transition_to_next"] == "fade"
+    assert unit["note"] == "hi"
+
+    # 带无 header 的新 prompt + duration_seconds：走 prompt 分支并对单镜头 override 时长
+    resp = client.patch(
+        f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}",
+        json={"prompt": "@张三 转身离开", "duration_seconds": 7},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["unit"]["duration_seconds"] == 7
+
+
+def test_reorder_units_rejects_true_duplicate(client: TestClient):
+    """长度匹配但含重复 ID → 命中 duplicate 校验分支。"""
+    uid1 = _seed_unit(client)
+    _uid2 = _seed_unit(client)
+    resp = client.post(
+        "/api/v1/projects/demo/reference-videos/episodes/1/units/reorder",
+        json={"unit_ids": [uid1, uid1]},
+    )
+    assert resp.status_code == 400
+    assert "duplicate" in resp.json()["detail"]
+
+
+def test_reorder_units_rejects_unknown_id_set_mismatch(client: TestClient):
+    """长度匹配、无重复，但 ID 集合与现有不一致 → set mismatch 分支。"""
+    uid1 = _seed_unit(client)
+    _uid2 = _seed_unit(client)
+    resp = client.post(
+        "/api/v1/projects/demo/reference-videos/episodes/1/units/reorder",
+        json={"unit_ids": [uid1, "E1U999"]},
+    )
+    assert resp.status_code == 400
+    assert "do not match" in resp.json()["detail"]

--- a/tests/server/test_reference_videos_router.py
+++ b/tests/server/test_reference_videos_router.py
@@ -219,3 +219,13 @@ def test_generate_unit_enqueues_task(client: TestClient, monkeypatch: pytest.Mon
 def test_generate_unit_missing_returns_404(client: TestClient):
     resp = client.post("/api/v1/projects/demo/reference-videos/episodes/1/units/E9U9/generate")
     assert resp.status_code == 404
+
+
+def test_add_unit_stale_script_file_returns_404(client: TestClient, tmp_path: Path):
+    """project.json 残留指向已删除文件的 script_file 时，写端点应返回 404 而非 500。"""
+    (tmp_path / "projects" / "demo" / "scripts" / "episode_1.json").unlink()
+    resp = client.post(
+        "/api/v1/projects/demo/reference-videos/episodes/1/units",
+        json={"prompt": "Shot 1 (2s): @张三 出现", "references": [{"type": "character", "name": "张三"}]},
+    )
+    assert resp.status_code == 404, resp.text

--- a/tests/test_project_manager_concurrent_save.py
+++ b/tests/test_project_manager_concurrent_save.py
@@ -208,6 +208,69 @@ class TestSyncAfterConcurrentWrite:
         assert loaded["title"] == episodes[0]["title"]
 
 
+class TestConcurrentReadModifyWrite:
+    """并发 read-modify-write 不应丢更新（issue #334）。"""
+
+    def test_concurrent_update_scene_asset_preserves_all(self, tmp_path: Path) -> None:
+        """并发对不同 segment 调用 update_scene_asset，所有写入都必须持久化。
+
+        修复前 load_script 在锁外、save_script 仅锁住写入，多个线程读到同一份快照后
+        互相覆盖，只有最后一个写者的更新存活。locked_script 把整段 RMW 收进单锁后应全部保留。
+        """
+        pm = ProjectManager(tmp_path)
+        name = "proj-rmw"
+        _seed_project(pm, name)
+
+        n = 24
+        pm.save_script(name, _make_script(1, payload_size=n), "episode_1.json")
+
+        # 用 barrier 让所有线程尽量同时进入，最大化竞争窗口
+        barrier = threading.Barrier(n)
+
+        def _writer(i: int) -> None:
+            barrier.wait()
+            pm.update_scene_asset(
+                project_name=name,
+                script_filename="episode_1.json",
+                scene_id=f"E1S{i}",
+                asset_type="video_clip",
+                asset_path=f"videos/scene_{i}.mp4",
+            )
+
+        with ThreadPoolExecutor(max_workers=n) as pool:
+            futures = [pool.submit(_writer, i) for i in range(n)]
+            for fut in as_completed(futures):
+                fut.result()
+
+        loaded = pm.load_script(name, "episode_1.json")
+        by_id = {s["segment_id"]: s for s in loaded["segments"]}
+        for i in range(n):
+            ga = by_id[f"E1S{i}"].get("generated_assets") or {}
+            assert ga.get("video_clip") == f"videos/scene_{i}.mp4", f"E1S{i} 的更新丢失：{ga}"
+
+    def test_update_scene_asset_missing_scene_does_not_write(self, tmp_path: Path) -> None:
+        """目标 scene 不存在时抛 KeyError 且不改动文件（locked_script 跳过写回）。"""
+        pm = ProjectManager(tmp_path)
+        name = "proj-rmw-missing"
+        _seed_project(pm, name)
+        pm.save_script(name, _make_script(1, payload_size=4), "episode_1.json")
+
+        before = (pm.get_project_path(name) / "scripts" / "episode_1.json").read_bytes()
+        try:
+            pm.update_scene_asset(
+                project_name=name,
+                script_filename="episode_1.json",
+                scene_id="NOPE",
+                asset_type="video_clip",
+                asset_path="videos/nope.mp4",
+            )
+            raise AssertionError("应抛 KeyError")
+        except KeyError:
+            pass
+        after = (pm.get_project_path(name) / "scripts" / "episode_1.json").read_bytes()
+        assert before == after, "未命中时不应改写脚本文件"
+
+
 def test_loaded_json_not_extra_data_after_save_script(tmp_path: Path) -> None:
     """回归：save_script 后磁盘内容必须是单个 JSON 对象，不能有 Extra data。"""
     pm = ProjectManager(tmp_path)

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -161,6 +161,107 @@ class TestProjectManagerMore:
         with pytest.raises(KeyError):
             pm.update_scene_asset("demo", "episode_1.json", "NOT_FOUND", "video_clip", "x.mp4")
 
+    def test_locked_script_helpers_drama_paths(self, tmp_path):
+        """覆盖经 locked_script 迁移的 helper 在 drama/scenes 分支与默认资产填充。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "drama")
+
+        drama_script = {
+            "episode": 1,
+            "title": "第一集",
+            "content_mode": "drama",
+            "scenes": [],
+        }
+        pm.save_script("demo", drama_script, "episode_1.json")
+
+        # add_scene 未带 generated_assets：触发默认资产填充分支
+        pm.add_scene("demo", "episode_1.json", {"duration_seconds": 6})
+        pm.add_scene("demo", "episode_1.json", {"duration_seconds": 4})
+        loaded = pm.load_script("demo", "episode_1.json")
+        assert [s["scene_id"] for s in loaded["scenes"]] == ["001", "002"]
+        assert loaded["scenes"][0]["generated_assets"]["status"] == "pending"
+
+        # update_scene_asset 走 drama/scenes 分支（else: scene_id）
+        pm.update_scene_asset("demo", "episode_1.json", "001", "storyboard_image", "sb/001.png")
+        loaded = pm.load_script("demo", "episode_1.json")
+        assert loaded["scenes"][0]["generated_assets"]["storyboard_image"] == "sb/001.png"
+
+    def test_batch_update_scene_assets_persists_all(self, tmp_path):
+        """batch_update_scene_assets 单次锁内写多个场景，缺失 scene_id 静默跳过。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "drama")
+        pm.save_script(
+            "demo",
+            {
+                "episode": 1,
+                "title": "第一集",
+                "content_mode": "drama",
+                "scenes": [
+                    {"scene_id": "001", "duration_seconds": 4, "generated_assets": {}},
+                    {"scene_id": "002", "duration_seconds": 4},
+                ],
+            },
+            "episode_1.json",
+        )
+
+        # 空 updates 提前返回
+        assert pm.batch_update_scene_assets("demo", "episode_1.json", []) == {}
+
+        pm.batch_update_scene_assets(
+            "demo",
+            "episode_1.json",
+            [
+                ("001", "storyboard_image", "sb/001.png"),
+                ("002", "video_clip", "v/002.mp4"),
+                ("999", "video_clip", "ignored.mp4"),  # 不存在 → 静默跳过
+            ],
+        )
+        loaded = pm.load_script("demo", "episode_1.json")
+        by_id = {s["scene_id"]: s for s in loaded["scenes"]}
+        assert by_id["001"]["generated_assets"]["storyboard_image"] == "sb/001.png"
+        assert by_id["002"]["generated_assets"]["video_clip"] == "v/002.mp4"
+
+        # narration/segments 分支：同 helper 走 segment_id 索引
+        pm.save_script(
+            "demo",
+            {
+                "episode": 2,
+                "title": "第二集",
+                "content_mode": "narration",
+                "segments": [{"segment_id": "E2S01", "duration_seconds": 4}],
+            },
+            "episode_2.json",
+        )
+        pm.batch_update_scene_assets("demo", "episode_2.json", [("E2S01", "storyboard_image", "sb/E2S01.png")])
+        seg = pm.load_script("demo", "episode_2.json")["segments"][0]
+        assert seg["generated_assets"]["storyboard_image"] == "sb/E2S01.png"
+
+    def test_update_character_sheet_success_and_missing(self, tmp_path):
+        """update_character_sheet 写入 sheet 路径；角色缺失时锁内 raise 且跳过写回。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "drama")
+        pm.save_script(
+            "demo",
+            {
+                "episode": 1,
+                "title": "第一集",
+                "content_mode": "drama",
+                "characters": {"张三": {"description": "x"}},
+                "scenes": [],
+            },
+            "episode_1.json",
+        )
+
+        pm.update_character_sheet("demo", "episode_1.json", "张三", "sheets/zhangsan.png")
+        loaded = pm.load_script("demo", "episode_1.json")
+        assert loaded["characters"]["张三"]["character_sheet"] == "sheets/zhangsan.png"
+
+        with pytest.raises(KeyError):
+            pm.update_character_sheet("demo", "episode_1.json", "李四", "sheets/lisi.png")
+
     def test_save_script_rejects_mismatch_before_write(self, tmp_path):
         """save_script 在 filename/内部 episode 不一致时必须写盘前 fail-fast。
 

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1,5 +1,6 @@
 import re
 from contextlib import contextmanager
+from copy import deepcopy
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -119,15 +120,18 @@ class _FakePM:
         self.scripts[(name, script_file)] = payload
 
     def update_project(self, name, mutate_fn):
-        # 复刻真实 ProjectManager.update_project：load → mutate → save 单一事务
-        project = self.load_project(name)
+        # 复刻真实 ProjectManager.update_project：load → mutate → save 单一事务。
+        # deepcopy 后再 mutate，使异常时（save 未执行）backing store 不被原地突变污染，
+        # 忠实于真实 PM「读裸 JSON、出错不写回」的语义。
+        project = deepcopy(self.load_project(name))
         mutate_fn(project)
         self.save_project(name, project)
 
     @contextmanager
     def locked_script(self, name, script_file):
-        # 复刻真实 ProjectManager.locked_script：load → yield → save，异常时跳过写回
-        script = self.load_script(name, script_file)
+        # 复刻真实 ProjectManager.locked_script：load → yield → save，异常时跳过写回。
+        # deepcopy 同上，确保 with 体内抛异常时原始存储对象保持不变。
+        script = deepcopy(self.load_script(name, script_file))
         yield script
         self.save_script(name, script, script_file)
 

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1,4 +1,5 @@
 import re
+from contextlib import contextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -113,7 +114,22 @@ class _FakePM:
         return self.scripts[key]
 
     def save_script(self, name, payload, script_file):
+        if script_file.startswith("scripts/"):
+            script_file = script_file[len("scripts/") :]
         self.scripts[(name, script_file)] = payload
+
+    def update_project(self, name, mutate_fn):
+        # 复刻真实 ProjectManager.update_project：load → mutate → save 单一事务
+        project = self.load_project(name)
+        mutate_fn(project)
+        self.save_project(name, project)
+
+    @contextmanager
+    def locked_script(self, name, script_file):
+        # 复刻真实 ProjectManager.locked_script：load → yield → save，异常时跳过写回
+        script = self.load_script(name, script_file)
+        yield script
+        self.save_script(name, script, script_file)
 
     async def generate_overview(self, name):
         if name == "ready":

--- a/tests/test_reference_video_concurrent_rmw.py
+++ b/tests/test_reference_video_concurrent_rmw.py
@@ -1,0 +1,102 @@
+"""参考视频 episode script 的并发读-改-写竞态防护测试（issue #334）。
+
+覆盖 `ProjectManager.locked_script` 在两类并发写者同时操作 `video_units` 时不丢更新：
+  1. 追加新 unit（对应 router 的 add_unit）
+  2. 回写已有 unit 的 generated_assets（对应 executor 的 _update_unit_assets）
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from lib.project_manager import ProjectManager
+
+
+def _seed_reference_video_project(pm: ProjectManager, name: str, n_units: int) -> None:
+    """创建项目 + 一个 reference_video 模式的 episode_1 剧本，预置 n_units 个 unit。"""
+    pm.create_project(name)
+    pm.save_project(
+        name,
+        {
+            "name": name,
+            "episodes": [],
+            "metadata": {"created_at": "2025-01-01", "updated_at": "2025-01-01"},
+        },
+    )
+    script = {
+        "episode": 1,
+        "title": "Episode 1",
+        "content_mode": "drama",
+        "generation_mode": "reference_video",
+        "video_units": [
+            {
+                "unit_id": f"E1U{i}",
+                "shots": [],
+                "references": [],
+                "duration_seconds": 4,
+                "generated_assets": {"video_clip": None, "status": "pending"},
+            }
+            for i in range(1, n_units + 1)
+        ],
+    }
+    pm.save_script(name, script, "episode_1.json")
+
+
+class TestReferenceVideoConcurrentRMW:
+    def test_concurrent_append_and_asset_writeback_preserve_all(self, tmp_path: Path) -> None:
+        """并发追加新 unit 与回写已有 unit 资产，二者都不丢。"""
+        pm = ProjectManager(tmp_path)
+        name = "proj-refvid-rmw"
+        n_existing = 12
+        _seed_reference_video_project(pm, name, n_existing)
+
+        appenders = 12  # 追加 E1U13..E1U24
+        total = n_existing + appenders
+        barrier = threading.Barrier(total)
+
+        def _append(idx: int) -> None:
+            """模拟 add_unit：locked_script 内 fresh-load → append → save。"""
+            barrier.wait()
+            with pm.locked_script(name, "episode_1.json") as script:
+                script.setdefault("video_units", []).append(
+                    {
+                        "unit_id": f"E1U{idx}",
+                        "shots": [],
+                        "references": [],
+                        "duration_seconds": 4,
+                        "generated_assets": {"video_clip": None, "status": "pending"},
+                    }
+                )
+
+        def _writeback(unit_id: str) -> None:
+            """模拟 executor 的 _update_unit_assets：定位 unit 写 generated_assets。"""
+            barrier.wait()
+            with pm.locked_script(name, "episode_1.json") as script:
+                for u in script.get("video_units") or []:
+                    if u.get("unit_id") == unit_id:
+                        ga = u.setdefault("generated_assets", {})
+                        ga["video_clip"] = f"reference_videos/{unit_id}.mp4"
+                        ga["status"] = "completed"
+                        break
+
+        with ThreadPoolExecutor(max_workers=total) as pool:
+            futures = [pool.submit(_append, i) for i in range(n_existing + 1, total + 1)]
+            futures += [pool.submit(_writeback, f"E1U{i}") for i in range(1, n_existing + 1)]
+            for fut in as_completed(futures):
+                fut.result()
+
+        loaded = pm.load_script(name, "episode_1.json")
+        units = {u["unit_id"]: u for u in loaded["video_units"]}
+
+        # 所有追加的 unit 都在
+        assert len(units) == total, f"期望 {total} 个 unit，实际 {sorted(units)}"
+        for i in range(n_existing + 1, total + 1):
+            assert f"E1U{i}" in units, f"追加的 E1U{i} 丢失"
+
+        # 所有已有 unit 的资产回写都生效
+        for i in range(1, n_existing + 1):
+            ga = units[f"E1U{i}"].get("generated_assets") or {}
+            assert ga.get("video_clip") == f"reference_videos/E1U{i}.mp4", f"E1U{i} 资产回写丢失：{ga}"
+            assert ga.get("status") == "completed"

--- a/tests/test_reference_video_concurrent_rmw.py
+++ b/tests/test_reference_video_concurrent_rmw.py
@@ -60,7 +60,8 @@ class TestReferenceVideoConcurrentRMW:
             """模拟 add_unit：locked_script 内 fresh-load → append → save。"""
             barrier.wait()
             with pm.locked_script(name, "episode_1.json") as script:
-                script.setdefault("video_units", []).append(
+                # 直接按 schema 访问，缺字段即报错（fail-loud），不用 setdefault 掩盖损坏
+                script["video_units"].append(
                     {
                         "unit_id": f"E1U{idx}",
                         "shots": [],
@@ -74,7 +75,7 @@ class TestReferenceVideoConcurrentRMW:
             """模拟 executor 的 _update_unit_assets：定位 unit 写 generated_assets。"""
             barrier.wait()
             with pm.locked_script(name, "episode_1.json") as script:
-                for u in script.get("video_units") or []:
+                for u in script["video_units"]:
                     if u.get("unit_id") == unit_id:
                         ga = u.setdefault("generated_assets", {})
                         ga["video_clip"] = f"reference_videos/{unit_id}.mp4"


### PR DESCRIPTION
## 背景

所有经 `ProjectManager` 回写 `project.json` / `scripts/*.json` 的路径此前只在最终 `atomic_write_json` 那一段持锁，没有包住整段 load→mutate→save，存在 read-modify-write 竞态：

- 用户 PATCH 某 unit 的同时 Worker 完成另一 unit 生成回写 `generated_assets`，两者读到同一份 script 快照，后写覆盖前写 → 丢更新
- 两个 Worker 并发完成同一集不同 scene/unit → 后完成的覆盖 `generated_assets`

## 方案

新增与既有 `update_project(mutate_fn)` 对称的 **`locked_script` context**，把 script 的 load→mutate→save 收进单一 `_script_lock`。

**关键约束**：`save_script` 自身已持 `_script_lock`，若 `locked_script` 内部再调 `save_script` 会在同进程对同一 flock 二次加锁自死锁。故抽出**不加锁的写主体** `_write_script_unlocked`，由 `save_script` / `locked_script` 各自在锁内调用一次（与 `update_project` 内联 `atomic_write_json` 而不复用 `save_project` 同理）。

校验失败 / 未命中的 `HTTPException` / `KeyError` 在锁内抛出 → 经 context 自然跳过写回、照常释放锁，HTTP / 异常语义不变。

## 迁移的全部 RMW 调用点

issue 点名的 + 排查中发现的同类，一并统一：

**`lib/project_manager.py`**
- script 级 → `locked_script`：`update_scene_asset`、`batch_update_scene_assets`、`update_character_sheet`、`add_scene`
- project 级 → `update_project`：`add_project_character`、`update_character_reference_image`、`sync_episode_from_script`、`add_episode`、`generate_overview`
- 经核实非 RMW、未动：`sync_project_status`（已废弃不写）、`create_project_metadata`（纯创建无前置 load）

**`server/routers/reference_videos.py`** — 新增轻量 `_resolve_episode`（只解析 script_file 不预读），`add_unit` / `patch_unit` / `delete_unit` / `reorder_units` 在 `locked_script` 内修改 fresh script（`_next_unit_id` 也在锁内算，避免并发撞 ID）

**`server/services/reference_video_tasks.py`** — executor 回写 `_update_unit_assets` → `locked_script`

**`server/routers/projects.py`** — `PATCH project` / `update_scene` / `update_segment` / `update_overview` → `update_project` / `locked_script`；创建端点把 `generation_mode` 并入 `create_project_metadata` 的 `extras`，消除 create 后二次写

**`server/routers/files.py`** — 风格图分析回写 → `update_project`

> `generation_tasks.py` 各 executor 无需改动——经 `update_scene_asset` / `batch_update_scene_assets` / `update_project` / `_update_asset_sheet` 回写，helper 内部修好即自动安全。

## 测试

- 扩展 `tests/test_project_manager_concurrent_save.py`：24 线程 barrier 并发对不同 scene 写 asset，断言全部持久化（修复前必丢）+ 未命中不写盘
- 新增 `tests/test_reference_video_concurrent_rmw.py`：并发追加 unit + 回写已有 unit 资产，断言两类都不丢
- `_FakePM` 桩补 `update_project` / `locked_script`，复刻真实 load→mutate→save 语义

## 验证

- 全量套件：**2827 passed, 0 failed**
- `ruff check` / `ruff format`：clean
- `basedpyright`：**0 errors**

## 约束遵守

- 锁粒度保持 per-script-file / per-project，无全局锁
- 锁 key 继续经 `_safe_subpath` 用 real path 派生（`./episode_1.json` 别名共享同一锁）
- 不改外部 API 签名，兼容所有现有调用方

Closes #334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 提升项目/剧本/分集的并发读-改-写原子性，避免高并发下的数据丢失或覆盖；缺失脚本情形返回 404 而非 500。
  * 多处更新（场景、分段、角色表、集列表、概览、风格图/描述等）改为单次原子变更，增强字段写入校验并禁止编辑不可变字段（如 content_mode）。
  * 创建项目时一次性保存生成模式等元数据；风格参考图上传为原子更新并清理互斥字段。

* **测试**
  * 新增多项并发读写测试，覆盖原子性、写回跳过及接口错误返回场景。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->