### PR TITLE
fix(usage): support multi-currency cost totals

### DIFF
--- a/frontend/src/components/layout/GlobalHeader.tsx
+++ b/frontend/src/components/layout/GlobalHeader.tsx
@@ -18,6 +18,7 @@ import { PhaseStepper } from "./PhaseStepper";
 import { API } from "@/api";
 import { ArchiveDiagnosticsDialog } from "@/components/shared/ArchiveDiagnosticsDialog";
 import { rememberAssetLibraryReturnTo } from "@/components/pages/AssetLibraryPage";
+import { costEntries, formatCostOrZero, formatCurrencyAmount } from "@/utils/cost-format";
 import type { ExportDiagnostics, WorkspaceNotification } from "@/types";
 
 /** 通过隐藏 <a> 触发浏览器下载，避免 window.open 产生空白标签页 */
@@ -81,16 +82,11 @@ export function GlobalHeader({ onNavigateBack }: GlobalHeaderProps) {
 
   // Format cost display – show multi-currency summary
   const costByCurrency = usageStats?.cost_by_currency ?? {};
-  const costEntries = Object.entries(costByCurrency).filter(([, v]) => v > 0);
-  const cnyCost = costEntries.find(([c]) => c === "CNY")?.[1] ?? 0;
-  const usdCost = costEntries.find(([c]) => c === "USD")?.[1] ?? 0;
-  const otherCosts = costEntries.filter(([c]) => c !== "CNY" && c !== "USD");
-  const costTooltip =
-    costEntries.length > 0
-      ? costEntries
-          .map(([currency, amount]) => `${currency === "CNY" ? "¥" : "$"}${amount.toFixed(2)}`)
-          .join(" + ")
-      : "$0.00";
+  const nonZeroCostEntries = costEntries(costByCurrency);
+  const primaryCost = nonZeroCostEntries[0];
+  const secondaryCost = nonZeroCostEntries[1];
+  const extraCostCount = Math.max(0, nonZeroCostEntries.length - 2);
+  const costTooltip = formatCostOrZero(costByCurrency);
 
   const handleNotificationNavigate = (notification: WorkspaceNotification) => {
     if (!notification.target) return;
@@ -279,12 +275,19 @@ export function GlobalHeader({ onNavigateBack }: GlobalHeaderProps) {
               }}
               title={t("dashboard:cost_tooltip", { cost: costTooltip })}
             >
-              {cnyCost > 0 && (
+              {primaryCost ? (
                 <span className="num" style={{ color: "var(--color-text-4)" }}>
-                  ¥{cnyCost.toFixed(2)}
+                  {formatCurrencyAmount(primaryCost[0], primaryCost[1])}
+                </span>
+              ) : (
+                <span
+                  className="num font-medium"
+                  style={{ color: "var(--color-text-2)" }}
+                >
+                  {formatCostOrZero(undefined)}
                 </span>
               )}
-              {cnyCost > 0 && usdCost > 0 && (
+              {primaryCost && secondaryCost && (
                 <span
                   aria-hidden="true"
                   style={{
@@ -295,17 +298,17 @@ export function GlobalHeader({ onNavigateBack }: GlobalHeaderProps) {
                   }}
                 />
               )}
-              {(usdCost > 0 || cnyCost === 0) && (
+              {secondaryCost && (
                 <span
                   className="num font-medium"
                   style={{ color: "var(--color-text-2)" }}
                 >
-                  ${usdCost.toFixed(2)}
+                  {formatCurrencyAmount(secondaryCost[0], secondaryCost[1])}
                 </span>
               )}
-              {otherCosts.length > 0 && (
+              {extraCostCount > 0 && (
                 <span className="num" style={{ color: "var(--color-text-4)" }}>
-                  +{otherCosts.length}
+                  +{extraCostCount}
                 </span>
               )}
             </button>

--- a/frontend/src/components/layout/UsageDrawer.tsx
+++ b/frontend/src/components/layout/UsageDrawer.tsx
@@ -14,6 +14,7 @@ import { API } from "@/api";
 import { GlassPopover } from "@/components/ui/GlassPopover";
 import { ModalCloseButton } from "@/components/ui/ModalCloseButton";
 import { formatShortDateTime } from "@/utils/date-format";
+import { costEntries, formatCostOrZero, formatCurrencyAmount } from "@/utils/cost-format";
 import type { CallType } from "@/types/provider";
 
 // ---------------------------------------------------------------------------
@@ -86,14 +87,10 @@ export function UsageDrawer({ open, onClose, projectName, anchorRef }: UsageDraw
   }, [open, loadCalls]);
 
   const totalPages = Math.ceil(total / pageSize);
-  const costByCurrency = stats?.cost_by_currency ?? {};
-  const costParts = Object.entries(costByCurrency)
-    .filter(([, v]) => v > 0)
-    .map(
-      ([currency, amount]) =>
-        `${currency === "CNY" ? "¥" : "$"}${amount.toFixed(2)}`,
-    );
-  const costSummary = costParts.length > 0 ? costParts : ["$0.00"];
+  const costParts = costEntries(stats?.cost_by_currency).map(([currency, amount]) =>
+    formatCurrencyAmount(currency, amount),
+  );
+  const costSummary = costParts.length > 0 ? costParts : [formatCostOrZero(undefined)];
 
   return (
     <GlassPopover
@@ -256,8 +253,9 @@ export function UsageDrawer({ open, onClose, projectName, anchorRef }: UsageDraw
                         fontWeight: call.cost_amount > 0 ? 600 : 400,
                       }}
                     >
-                      {call.currency === "CNY" ? "¥" : "$"}
-                      {call.cost_amount.toFixed(4)}
+                      {formatCurrencyAmount(call.currency, call.cost_amount, {
+                        maximumFractionDigits: 6,
+                      })}
                     </span>
                   </div>
                   <div

--- a/frontend/src/components/pages/settings/UsageStatsSection.tsx
+++ b/frontend/src/components/pages/settings/UsageStatsSection.tsx
@@ -4,9 +4,8 @@ import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
 import { API } from "@/api";
 import { CARD_STYLE } from "@/components/ui/darkroom-tokens";
+import { formatCostOrZero } from "@/utils/cost-format";
 import type { UsageStat } from "@/types";
-
-const currencyFmt = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
 
 const EDITORIAL_KPI_STYLE: CSSProperties = {
   fontSize: 22,
@@ -87,17 +86,25 @@ export function UsageStatsSection() {
     [stats],
   );
 
-  // Aggregate totals — used for the editorial header summary card
+  // Aggregate totals — used for the editorial header summary card.
+  // 这里只是求和：用 Object.entries 直接遍历，避免 costEntries 的排序/过滤开销
+  // （那是 UI 展示语义，不是聚合语义）。累加后统一 4 位小数四舍五入，与
+  // totalBreakdown 的精度处理保持一致，避免浮点累加产生 1.76000000000002。
   const totals = useMemo(() => {
-    let cost = 0;
+    const costByCurrency: Record<string, number> = {};
     let calls = 0;
     let success = 0;
     for (const s of stats) {
-      cost += s.total_cost_usd;
+      for (const [currency, amount] of Object.entries(s.cost_by_currency ?? {})) {
+        costByCurrency[currency] = (costByCurrency[currency] ?? 0) + amount;
+      }
       calls += s.total_calls;
       success += s.success_calls;
     }
-    return { cost, calls, success };
+    for (const currency of Object.keys(costByCurrency)) {
+      costByCurrency[currency] = Math.round(costByCurrency[currency] * 10000) / 10000;
+    }
+    return { costByCurrency, calls, success };
   }, [stats]);
 
   return (
@@ -105,7 +112,7 @@ export function UsageStatsSection() {
       {/* Heading */}
       <div>
         <div className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-accent-2">
-          Spend Ledger
+          {t("spend_ledger")}
         </div>
         <h3 className="font-editorial mt-1" style={EDITORIAL_HEADING_STYLE}>
           {t("usage_stats")}
@@ -121,10 +128,10 @@ export function UsageStatsSection() {
         style={CARD_STYLE}
       >
         {[
-          { label: "Total Cost", value: currencyFmt.format(totals.cost) },
-          { label: "Total Calls", value: totals.calls.toLocaleString() },
+          { label: t("total_cost"), value: formatCostOrZero(totals.costByCurrency) },
+          { label: t("total_calls"), value: totals.calls.toLocaleString() },
           {
-            label: "Success Rate",
+            label: t("success_rate"),
             value:
               totals.calls > 0 ? percentFmt.format(totals.success / totals.calls) : "—",
           },
@@ -218,7 +225,7 @@ export function UsageStatsSection() {
                     className="font-editorial shrink-0 tabular-nums"
                     style={EDITORIAL_STAT_VALUE_STYLE}
                   >
-                    {currencyFmt.format(s.total_cost_usd)}
+                    {formatCostOrZero(s.cost_by_currency)}
                   </div>
                 </div>
                 <div className="mt-3 flex flex-wrap gap-x-5 gap-y-1.5 font-mono text-[11px] tabular-nums text-text-3">

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -464,6 +464,7 @@ export default {
   'save_failed': 'Failed to save: {{message}}',
 
   // UsageStatsSection
+  'spend_ledger': 'Spend Ledger',
   'last_7_days': 'Last 7 days',
   'last_30_days': 'Last 30 days',
   'all': 'All',
@@ -471,6 +472,7 @@ export default {
   'filter_by_provider': 'Filter by provider',
   'all_providers': 'All providers',
   'no_data': 'No data yet',
+  'total_calls': 'Total Calls',
   'calls': 'Calls',
   'success_count': 'Success',
   'success_rate': 'Success Rate',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -444,6 +444,7 @@ export default {
   'save_failed': 'Lưu thất bại: {{message}}',
 
   // UsageStatsSection
+  'spend_ledger': 'Sổ chi phí',
   'last_7_days': '7 ngày qua',
   'last_30_days': '30 ngày qua',
   'all': 'Tất cả',
@@ -451,6 +452,7 @@ export default {
   'filter_by_provider': 'Lọc theo nhà cung cấp',
   'all_providers': 'Tất cả nhà cung cấp',
   'no_data': 'Chưa có dữ liệu',
+  'total_calls': 'Tổng lượt gọi',
   'calls': 'Lượt gọi',
   'success_count': 'Thành công',
   'success_rate': 'Tỉ lệ thành công',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -465,6 +465,7 @@ export default {
   'save_failed': '保存失败: {{message}}',
 
   // UsageStatsSection
+  'spend_ledger': '费用账本',
   'last_7_days': '最近 7 天',
   'last_30_days': '最近 30 天',
   'all': '全部',
@@ -472,6 +473,7 @@ export default {
   'filter_by_provider': '按供应商筛选',
   'all_providers': '全部供应商',
   'no_data': '暂无数据',
+  'total_calls': '总调用',
   'calls': '调用',
   'success_count': '成功',
   'success_rate': '成功率',

--- a/frontend/src/types/provider.ts
+++ b/frontend/src/types/provider.ts
@@ -66,6 +66,7 @@ export interface UsageStat {
   total_calls: number;
   success_calls: number;
   total_cost_usd: number;
+  cost_by_currency: Record<string, number>;
   total_duration_seconds?: number;
 }
 

--- a/frontend/src/utils/cost-format.test.ts
+++ b/frontend/src/utils/cost-format.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  costEntries,
+  formatCost,
+  formatCostOrZero,
+  formatCurrencyAmount,
+  totalBreakdown,
+} from "./cost-format";
+
+describe("cost-format", () => {
+  it("formats multi-currency breakdowns in a stable order", () => {
+    expect(costEntries({ USD: 1.2, CNY: 3.4, EUR: 5.6 })).toEqual([
+      ["CNY", 3.4],
+      ["USD", 1.2],
+      ["EUR", 5.6],
+    ]);
+    expect(formatCost({ USD: 1.2, CNY: 3.4 })).toBe("CN¥3.40 + $1.20");
+    expect(formatCurrencyAmount("CNY", 1.234)).toBe("CN¥1.23");
+  });
+
+  it("filters zero costs and falls back to em-dash", () => {
+    expect(formatCost({ USD: 0, CNY: 0 })).toBe("—");
+    expect(formatCostOrZero({ USD: 0 })).toBe("—");
+    expect(formatCostOrZero(undefined)).toBe("—");
+  });
+
+  it("falls back for unknown currency codes", () => {
+    expect(formatCurrencyAmount("POINTS", 12.345)).toBe("POINTS 12.35");
+  });
+
+  it("supports higher precision for line-item costs", () => {
+    expect(formatCurrencyAmount("USD", 0.0006)).toBe("$0.00");
+    expect(formatCurrencyAmount("USD", 0.0006, { maximumFractionDigits: 6 })).toBe("$0.0006");
+    expect(formatCurrencyAmount("POINTS", 0.0006, { maximumFractionDigits: 6 })).toBe("POINTS 0.0006");
+  });
+
+  it("normalizes invalid fraction digit ranges", () => {
+    expect(formatCurrencyAmount("USD", 1.2345, { minimumFractionDigits: 4, maximumFractionDigits: 2 })).toBe(
+      "$1.2345",
+    );
+    expect(formatCurrencyAmount("POINTS", 1.2345, { minimumFractionDigits: 4, maximumFractionDigits: 2 })).toBe(
+      "POINTS 1.2345",
+    );
+  });
+
+  it("totals cost breakdowns by type", () => {
+    expect(
+      totalBreakdown({
+        image: { CNY: 1.11115, USD: 2 },
+        video: { CNY: 3 },
+      }),
+    ).toEqual({ CNY: 4.1112, USD: 2 });
+  });
+});

--- a/frontend/src/utils/cost-format.ts
+++ b/frontend/src/utils/cost-format.ts
@@ -1,32 +1,84 @@
 import type { CostBreakdown, CostByType } from "@/types";
 
 const formatterCache = new Map<string, Intl.NumberFormat>();
+// Display order for known currencies. Currencies not listed here fall back to
+// alphabetical order. Adjust this list to match the deployment's primary audience.
+const CURRENCY_ORDER = ["CNY", "USD"];
+const EMPTY_COST_PLACEHOLDER = "\u2014";
+const DEFAULT_FRACTION_DIGITS = 2;
 
-function getFormatter(currency: string): Intl.NumberFormat {
-  let fmt = formatterCache.get(currency);
+interface CurrencyFormatOptions {
+  minimumFractionDigits?: number;
+  maximumFractionDigits?: number;
+}
+
+function getFormatter(
+  currency: string,
+  minimumFractionDigits: number,
+  maximumFractionDigits: number,
+): Intl.NumberFormat {
+  const cacheKey = `${currency}:${minimumFractionDigits}:${maximumFractionDigits}`;
+  let fmt = formatterCache.get(cacheKey);
   if (!fmt) {
     fmt = new Intl.NumberFormat("en", {
       style: "currency",
       currency,
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 4,
+      currencyDisplay: "symbol",
+      minimumFractionDigits,
+      maximumFractionDigits,
     });
-    formatterCache.set(currency, fmt);
+    formatterCache.set(cacheKey, fmt);
   }
   return fmt;
 }
 
-export function formatCost(breakdown: CostBreakdown | undefined): string {
-  if (!breakdown || Object.keys(breakdown).length === 0) return "\u2014";
-  return Object.entries(breakdown)
-    .map(([cur, amt]) => {
-      try {
-        return getFormatter(cur).format(amt);
-      } catch {
-        return `${cur} ${amt.toFixed(2)}`;
+export function costEntries(breakdown: CostBreakdown | undefined): [string, number][] {
+  return Object.entries(breakdown ?? {})
+    .filter(([, amount]) => amount > 0)
+    .sort(([left], [right]) => {
+      const leftIndex = CURRENCY_ORDER.indexOf(left);
+      const rightIndex = CURRENCY_ORDER.indexOf(right);
+      if (leftIndex !== -1 || rightIndex !== -1) {
+        return (leftIndex === -1 ? CURRENCY_ORDER.length : leftIndex) -
+          (rightIndex === -1 ? CURRENCY_ORDER.length : rightIndex);
       }
-    })
-    .join(" + ");
+      return left.localeCompare(right);
+    });
+}
+
+export function formatCurrencyAmount(
+  currency: string,
+  amount: number,
+  options: CurrencyFormatOptions = {},
+): string {
+  const minimumFractionDigits = options.minimumFractionDigits ?? DEFAULT_FRACTION_DIGITS;
+  const maximumFractionDigits = options.maximumFractionDigits ?? DEFAULT_FRACTION_DIGITS;
+  const normalizedMinimumFractionDigits = Math.min(minimumFractionDigits, maximumFractionDigits);
+  const normalizedMaximumFractionDigits = Math.max(minimumFractionDigits, maximumFractionDigits);
+
+  try {
+    return getFormatter(currency, normalizedMinimumFractionDigits, normalizedMaximumFractionDigits).format(amount);
+  } catch {
+    return `${currency} ${amount.toLocaleString("en", {
+      minimumFractionDigits: normalizedMinimumFractionDigits,
+      maximumFractionDigits: normalizedMaximumFractionDigits,
+    })}`;
+  }
+}
+
+export function formatCost(breakdown: CostBreakdown | undefined): string {
+  const entries = costEntries(breakdown);
+  if (entries.length === 0) return EMPTY_COST_PLACEHOLDER;
+  return entries.map(([cur, amt]) => formatCurrencyAmount(cur, amt)).join(" + ");
+}
+
+/**
+ * Same as {@link formatCost}, kept for callers that explicitly want a non-empty
+ * placeholder when no cost has been recorded yet. Now also returns the em-dash
+ * placeholder so multi-currency deployments don't see a stray `$0.00`.
+ */
+export function formatCostOrZero(breakdown: CostBreakdown | undefined): string {
+  return formatCost(breakdown);
 }
 
 export function totalBreakdown(byType: CostByType): CostBreakdown {

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -262,9 +262,18 @@ class UsageRepository(BaseRepository):
         # Main aggregation query
         main_stmt = (
             select(
-                func.coalesce(func.sum(case((ApiCall.currency == "USD", ApiCall.cost_amount), else_=0)), 0).label(
-                    "total_cost_usd"
-                ),
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (
+                                (ApiCall.status == "success") & (ApiCall.currency == "USD") & (ApiCall.cost_amount > 0),
+                                ApiCall.cost_amount,
+                            ),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ).label("total_cost_usd"),
                 func.count(case((ApiCall.call_type == "image", 1))).label("image_count"),
                 func.count(case((ApiCall.call_type == "video", 1))).label("video_count"),
                 func.count(case((ApiCall.call_type == "text", 1))).label("text_count"),
@@ -277,14 +286,19 @@ class UsageRepository(BaseRepository):
         main_stmt = self._scope_query(main_stmt, ApiCall)
         row = (await self.session.execute(main_stmt)).one()
 
-        # Cost by currency
+        # Cost by currency mirrors project cost estimates: only successful billed calls count.
         currency_stmt = (
             select(
                 ApiCall.currency,
                 func.coalesce(func.sum(ApiCall.cost_amount), 0).label("total"),
             )
             .select_from(ApiCall)
-            .where(*filters)
+            .where(
+                *filters,
+                ApiCall.status == "success",
+                ApiCall.cost_amount > 0,
+                ApiCall.currency.isnot(None),
+            )
             .group_by(ApiCall.currency)
         )
         currency_stmt = self._scope_query(currency_stmt, ApiCall)
@@ -323,9 +337,18 @@ class UsageRepository(BaseRepository):
                 ApiCall.call_type,
                 func.count().label("total_calls"),
                 func.count(case((ApiCall.status == "success", 1))).label("success_calls"),
-                func.coalesce(func.sum(case((ApiCall.currency == "USD", ApiCall.cost_amount), else_=0)), 0).label(
-                    "total_cost_usd"
-                ),
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (
+                                (ApiCall.status == "success") & (ApiCall.currency == "USD") & (ApiCall.cost_amount > 0),
+                                ApiCall.cost_amount,
+                            ),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ).label("total_cost_usd"),
                 func.coalesce(func.sum(ApiCall.duration_ms), 0).label("total_duration_ms"),
             )
             .select_from(ApiCall)
@@ -336,6 +359,28 @@ class UsageRepository(BaseRepository):
         stmt = self._scope_query(stmt, ApiCall)
         rows = (await self.session.execute(stmt)).all()
 
+        currency_stmt = (
+            select(
+                ApiCall.provider,
+                ApiCall.call_type,
+                ApiCall.currency,
+                func.coalesce(func.sum(ApiCall.cost_amount), 0).label("total"),
+            )
+            .select_from(ApiCall)
+            .where(
+                *filters,
+                ApiCall.status == "success",
+                ApiCall.cost_amount > 0,
+                ApiCall.currency.isnot(None),
+            )
+            .group_by(ApiCall.provider, ApiCall.call_type, ApiCall.currency)
+        )
+        currency_stmt = self._scope_query(currency_stmt, ApiCall)
+        currency_rows = (await self.session.execute(currency_stmt)).all()
+        cost_by_group: dict[tuple[str | None, str | None], dict[str, float]] = {}
+        for provider_value, call_type_value, currency, total in currency_rows:
+            cost_by_group.setdefault((provider_value, call_type_value), {})[currency] = round(total, 4)
+
         stats = [
             {
                 "provider": row.provider,
@@ -343,6 +388,7 @@ class UsageRepository(BaseRepository):
                 "total_calls": row.total_calls,
                 "success_calls": row.success_calls,
                 "total_cost_usd": round(row.total_cost_usd, 4),
+                "cost_by_currency": cost_by_group.get((row.provider, row.call_type), {}),
                 "total_duration_seconds": round(row.total_duration_ms / 1000, 1) if row.total_duration_ms else 0,
             }
             for row in rows

--- a/tests/test_usage_repo.py
+++ b/tests/test_usage_repo.py
@@ -1,9 +1,11 @@
 """Tests for UsageRepository."""
 
 import pytest
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.db.base import Base
+from lib.db.models.api_call import ApiCall
 from lib.db.repositories.usage_repo import UsageRepository
 
 
@@ -168,6 +170,123 @@ class TestMultiProviderUsage:
         assert stats["cost_by_currency"]["USD"] == pytest.approx(3.2)
         assert stats["cost_by_currency"]["CNY"] == pytest.approx(3.9494, rel=1e-3)
         assert stats["total_cost"] == pytest.approx(3.2)
+
+    async def test_get_stats_cost_by_currency_excludes_failed_billed_calls(self, db_session):
+        """金额维度与项目成本口径一致：只统计 success 且已扣费调用。"""
+        repo = UsageRepository(db_session)
+
+        ok = await repo.start_call(
+            project_name="demo",
+            call_type="image",
+            model="viduq2",
+            resolution="1080p",
+            provider="vidu",
+        )
+        await repo.finish_call(ok, status="success", usage_tokens=8)
+
+        failed = await repo.start_call(
+            project_name="demo",
+            call_type="text",
+            model="claude-sonnet-4",
+            provider="anthropic",
+        )
+        await repo.finish_call(failed, status="failed", error_message="boom")
+        await db_session.execute(
+            update(ApiCall)
+            .where(ApiCall.id == failed)
+            .values(cost_amount=0.0456, currency="USD", input_tokens=100, output_tokens=20)
+        )
+        await db_session.commit()
+
+        failed_unbilled = await repo.start_call(
+            project_name="demo",
+            call_type="image",
+            model="viduq2",
+            resolution="1080p",
+            provider="vidu",
+        )
+        await repo.finish_call(failed_unbilled, status="failed", error_message="boom")
+
+        zero_cost = await repo.start_call(
+            project_name="demo",
+            call_type="text",
+            model="gemini-3-flash-preview",
+            provider="gemini",
+        )
+        await repo.finish_call(zero_cost, status="success", input_tokens=0, output_tokens=0)
+
+        stats = await repo.get_stats(project_name="demo")
+        # failed 即使有实付记录也不计入金额；零费用/未扣费记录也不计入金额。
+        assert stats["total_count"] == 4
+        assert stats["failed_count"] == 2
+        assert stats["total_cost"] == pytest.approx(0)
+        assert stats["cost_by_currency"] == {
+            "CNY": pytest.approx(0.25),
+        }
+
+    async def test_get_stats_grouped_by_provider_includes_cost_by_currency(self, db_session):
+        repo = UsageRepository(db_session)
+
+        gemini_id = await repo.start_call(
+            project_name="demo",
+            call_type="image",
+            model="gemini-3.1-flash-image-preview",
+            resolution="1K",
+            provider="gemini",
+        )
+        await repo.finish_call(gemini_id, status="success")
+
+        vidu_id = await repo.start_call(
+            project_name="demo",
+            call_type="image",
+            model="viduq2",
+            resolution="1080p",
+            provider="vidu",
+        )
+        await repo.finish_call(vidu_id, status="success", usage_tokens=8)
+
+        failed_vidu_id = await repo.start_call(
+            project_name="demo",
+            call_type="image",
+            model="viduq2",
+            resolution="1080p",
+            provider="vidu",
+        )
+        await repo.finish_call(failed_vidu_id, status="failed", error_message="boom")
+
+        failed_anthropic_id = await repo.start_call(
+            project_name="demo",
+            call_type="text",
+            model="claude-sonnet-4",
+            provider="anthropic",
+        )
+        await repo.finish_call(failed_anthropic_id, status="failed", error_message="boom")
+        await db_session.execute(
+            update(ApiCall)
+            .where(ApiCall.id == failed_anthropic_id)
+            .values(cost_amount=0.0456, currency="USD", input_tokens=100, output_tokens=20)
+        )
+        await db_session.commit()
+
+        stats = await repo.get_stats_grouped_by_provider(project_name="demo")
+        by_group = {(item["provider"], item["call_type"]): item for item in stats["stats"]}
+
+        assert set(by_group) == {
+            ("anthropic", "text"),
+            ("gemini", "image"),
+            ("vidu", "image"),
+        }
+
+        assert by_group[("anthropic", "text")]["total_cost_usd"] == pytest.approx(0)
+        assert by_group[("anthropic", "text")]["cost_by_currency"] == {}
+        assert by_group[("anthropic", "text")]["total_calls"] == 1
+        assert by_group[("anthropic", "text")]["success_calls"] == 0
+        assert by_group[("gemini", "image")]["total_cost_usd"] == pytest.approx(0.067)
+        assert by_group[("gemini", "image")]["cost_by_currency"] == {"USD": pytest.approx(0.067)}
+        assert by_group[("vidu", "image")]["total_cost_usd"] == 0
+        assert by_group[("vidu", "image")]["cost_by_currency"] == {"CNY": pytest.approx(0.25)}
+        assert by_group[("vidu", "image")]["total_calls"] == 2
+        assert by_group[("vidu", "image")]["success_calls"] == 1
 
     async def test_text_call_gemini_cost(self, db_session):
         repo = UsageRepository(db_session)


### PR DESCRIPTION
## 范围

本 PR 聚焦 usage stats 的多币种费用统计与展示：

- 更新 usage repository 的费用聚合口径
- 更新顶部费用 badge、UsageDrawer、设置页 usage stats 的多币种展示
- 增加共享费用格式化工具与测试
- 不调整现有费用文案语义，相关表达精修作为 defer 处理

## 变更

- 为 usage stats 增加 `cost_by_currency` 的多币种展示路径
- 将聚合费用口径统一为只统计 `success` 调用，和项目实际成本口径保持一致
- 保留调用明细的单条费用精度，避免小额 API 调用显示为 `$0.00`
- 增加 `cost-format` 工具测试和 usage repository 回归测试
- 保留上游主线的时间格式化/timezone 处理方式

## 验收清单

- [x] 本地已跑相关测试（`uv run ruff check ...`、`uv run python -m pytest tests/test_usage_repo.py`、`cd frontend && pnpm exec vitest run src/utils/cost-format.test.ts`）
- [x] 手动验证了改动所声称的行为
- [x] 新增面向用户文案已加 zh/en/vi 翻译（如适用）
- [x] 无新增 ESLint disable；
- [ ] CODEOWNERS 要求的 review 已请求

## 已知 defer

- 费用相关文案仍可能不够精确地区分“成功产出成本”和“供应商账单/调用明细”。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 顶栏和使用详情中改进了多币种费用展示，优先显示主要币种并对超出项以“+N” 汇总。
  * 费用数字支持更高精度与更一致的格式化回退显示。

* **缺陷修复**
  * 费用聚合口径调整，确保仅将成功且正费用调用计入统计，避免将失败或零费用计入。

* **文档**
  * 补充中文/英文/越南文的界面文案键。

* **测试**
  * 新增覆盖多币种与费用口径边界的单元测试。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->