### PR TITLE
fix: issue #589 follow-up（reference_videos i18n + 两处既有行为修正）

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -125,6 +125,13 @@ MESSAGES = {
     "ref_payload_too_large": "Reference image payload exceeded provider limits, retried with extra compression",
     "ref_sora_single_ref": "Sora reference mode does not currently support multiple images, downgraded to single image",
     "ref_shot_parse_fallback": "No Shot N (Xs) header detected, treated as a single shot",
+    "ref_episode_not_found": "Episode {episode} not found",
+    "ref_not_reference_video_mode": "Episode script is not in reference-video mode",
+    "ref_not_registered": "Referenced assets are not registered: {missing}",
+    "ref_unit_not_found": "Video unit '{unit_id}' not found",
+    "ref_unit_ids_length_mismatch": "unit_ids count does not match existing units",
+    "ref_duplicate_unit_ids": "unit_ids contains duplicates",
+    "ref_unit_ids_mismatch": "unit_ids do not match existing units",
     "about_update_check_failed": "Failed to check for updates, please try again later",
     "about_version_read_failed": "Failed to read app version",
     # Image Capability

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -125,6 +125,13 @@ MESSAGES = {
     "ref_payload_too_large": "Dữ liệu ảnh tham chiếu vượt giới hạn của nhà cung cấp, đã thử lại với mức nén bổ sung",
     "ref_sora_single_ref": "Chế độ tham chiếu Sora hiện không hỗ trợ nhiều ảnh, đã hạ về một ảnh",
     "ref_shot_parse_fallback": "Không phát hiện tiêu đề Shot N (Xs), được xử lý như một cảnh quay duy nhất",
+    "ref_episode_not_found": "Không tìm thấy tập {episode}",
+    "ref_not_reference_video_mode": "Kịch bản của tập này không ở chế độ video tham chiếu",
+    "ref_not_registered": "Các tài nguyên được tham chiếu chưa được đăng ký: {missing}",
+    "ref_unit_not_found": "Không tìm thấy đơn vị video '{unit_id}'",
+    "ref_unit_ids_length_mismatch": "Số lượng unit_ids không khớp với các đơn vị hiện có",
+    "ref_duplicate_unit_ids": "unit_ids bị trùng lặp",
+    "ref_unit_ids_mismatch": "unit_ids không khớp với các đơn vị hiện có",
     "about_update_check_failed": "Kiểm tra cập nhật thất bại, vui lòng thử lại sau",
     "about_version_read_failed": "Không đọc được phiên bản ứng dụng",
     # Image Capability

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -125,6 +125,13 @@ MESSAGES = {
     "ref_payload_too_large": "参考图请求体超出供应商限制，已二次压缩重试",
     "ref_sora_single_ref": "Sora 参考模式暂不支持多图，已降级为单图",
     "ref_shot_parse_fallback": "未识别到 Shot N (Xs): 标记，按单镜头处理",
+    "ref_episode_not_found": "第 {episode} 集不存在",
+    "ref_not_reference_video_mode": "该集剧本不是参考生视频模式",
+    "ref_not_registered": "引用的资产未注册：{missing}",
+    "ref_unit_not_found": "视频单元「{unit_id}」不存在",
+    "ref_unit_ids_length_mismatch": "unit_ids 数量与现有单元不一致",
+    "ref_duplicate_unit_ids": "unit_ids 存在重复",
+    "ref_unit_ids_mismatch": "unit_ids 与现有单元不匹配",
     "about_update_check_failed": "检查更新失败，请稍后重试",
     "about_version_read_failed": "读取应用版本失败",
     # Image Capability

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -859,8 +859,9 @@ async def update_segment(name: str, segment_id: str, req: UpdateSegmentRequest, 
             matched_segment: dict[str, Any] | None = None
             with project_change_source("webui"):
                 with manager.locked_script(name, req.script_file) as script:
-                    # 检查是否为说书模式
-                    if script.get("content_mode") != "narration" and "segments" not in script:
+                    # 检查是否为说书模式：仅 narration 且含 segments 键才放行；
+                    # drama 脚本即使残留 segments 键也拒绝，避免被当 narration 改写
+                    if script.get("content_mode") != "narration" or "segments" not in script:
                         raise HTTPException(status_code=400, detail=_t("narration_mode_required"))
 
                     for segment in script.get("segments", []):

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from lib.app_data_dir import app_data_dir
 from lib.asset_types import BUCKET_KEY
 from lib.generation_queue import get_generation_queue
+from lib.i18n import Translator
 from lib.project_manager import ProjectManager, effective_mode
 from lib.reference_video import parse_prompt
 from server.auth import CurrentUser
@@ -53,30 +54,27 @@ class AddUnitRequest(BaseModel):
 # ============ 辅助 ============
 
 
-def _load_episode_script(project_name: str, episode: int) -> tuple[dict, dict, str]:
+def _load_episode_script(project_name: str, episode: int, _t: Translator) -> tuple[dict, dict, str]:
     """加载 project.json + 指定集的剧本。返回 (project, script, script_file)。"""
     try:
         project = get_project_manager().load_project(project_name)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name)) from exc
     episodes = project.get("episodes") or []
     meta = next((e for e in episodes if e.get("episode") == episode), None)
     if meta is None or not meta.get("script_file"):
-        raise HTTPException(status_code=404, detail=f"episode {episode} not found")
+        raise HTTPException(status_code=404, detail=_t("ref_episode_not_found", episode=episode))
     script_file = meta["script_file"]
     try:
         script = get_project_manager().load_script(project_name, script_file)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=404, detail=_t("script_not_found", name=script_file)) from exc
     if effective_mode(project=project, episode=meta) != "reference_video":
-        raise HTTPException(
-            status_code=409,
-            detail="episode script is not in reference_video mode",
-        )
+        raise HTTPException(status_code=409, detail=_t("ref_not_reference_video_mode"))
     return project, script, script_file
 
 
-def _resolve_episode(project_name: str, episode: int) -> tuple[dict, str]:
+def _resolve_episode(project_name: str, episode: int, _t: Translator) -> tuple[dict, str]:
     """加载 project.json，解析并校验指定集的 script_file（不预读 script）。
 
     返回 (project, script_file)。写端点据此进入 `locked_script` 在锁内 fresh-load 剧本，
@@ -85,21 +83,18 @@ def _resolve_episode(project_name: str, episode: int) -> tuple[dict, str]:
     try:
         project = get_project_manager().load_project(project_name)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name)) from exc
     episodes = project.get("episodes") or []
     meta = next((e for e in episodes if e.get("episode") == episode), None)
     if meta is None or not meta.get("script_file"):
-        raise HTTPException(status_code=404, detail=f"episode {episode} not found")
+        raise HTTPException(status_code=404, detail=_t("ref_episode_not_found", episode=episode))
     if effective_mode(project=project, episode=meta) != "reference_video":
-        raise HTTPException(
-            status_code=409,
-            detail="episode script is not in reference_video mode",
-        )
+        raise HTTPException(status_code=409, detail=_t("ref_not_reference_video_mode"))
     return project, meta["script_file"]
 
 
 @contextmanager
-def _locked_episode_script(project_name: str, script_file: str) -> Iterator[dict]:
+def _locked_episode_script(project_name: str, script_file: str, _t: Translator) -> Iterator[dict]:
     """进入 locked_script，并把缺失脚本文件的 FileNotFoundError 归一为 404。
 
     project.json 可能残留指向已删除/移动文件的 script_file；此时 locked_script 内的
@@ -110,10 +105,10 @@ def _locked_episode_script(project_name: str, script_file: str) -> Iterator[dict
         with get_project_manager().locked_script(project_name, script_file) as script:
             yield script
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=404, detail=_t("script_not_found", name=script_file)) from exc
 
 
-def _validate_references_exist(project: dict, refs: list[dict]) -> None:
+def _validate_references_exist(project: dict, refs: list[dict], _t: Translator) -> None:
     """确保 references 都在 project.json 对应 bucket 中。"""
     missing: list[str] = []
     for r in refs:
@@ -121,10 +116,7 @@ def _validate_references_exist(project: dict, refs: list[dict]) -> None:
         if r["name"] not in bucket:
             missing.append(f"{r['type']}:{r['name']}")
     if missing:
-        raise HTTPException(
-            status_code=400,
-            detail=f"references not registered: {', '.join(missing)}",
-        )
+        raise HTTPException(status_code=400, detail=_t("ref_not_registered", missing=", ".join(missing)))
 
 
 def _next_unit_id(script: dict, episode: int) -> str:
@@ -172,8 +164,8 @@ def _build_unit_dict(
 
 
 @router.get("/episodes/{episode}/units")
-async def list_units(project_name: str, episode: int, _user: CurrentUser) -> dict[str, Any]:
-    _project, script, _sf = _load_episode_script(project_name, episode)
+async def list_units(project_name: str, episode: int, _user: CurrentUser, _t: Translator) -> dict[str, Any]:
+    _project, script, _sf = _load_episode_script(project_name, episode, _t)
     return {"units": script.get("video_units") or []}
 
 
@@ -183,13 +175,14 @@ async def add_unit(
     episode: int,
     req: AddUnitRequest,
     _user: CurrentUser,
+    _t: Translator,
 ) -> dict[str, Any]:
-    project, script_file = _resolve_episode(project_name, episode)
+    project, script_file = _resolve_episode(project_name, episode, _t)
 
     refs = [r.model_dump() for r in req.references]
-    _validate_references_exist(project, refs)
+    _validate_references_exist(project, refs, _t)
 
-    with _locked_episode_script(project_name, script_file) as script:
+    with _locked_episode_script(project_name, script_file, _t) as script:
         # unit_id 在锁内基于 fresh script 计算，避免并发新增撞 ID
         unit = _build_unit_dict(
             unit_id=_next_unit_id(script, episode),
@@ -214,11 +207,11 @@ class PatchUnitRequest(BaseModel):
     note: str | None = None
 
 
-def _find_unit(script: dict, unit_id: str) -> dict:
+def _find_unit(script: dict, unit_id: str, _t: Translator) -> dict:
     for u in script.get("video_units") or []:
         if u.get("unit_id") == unit_id:
             return u
-    raise HTTPException(status_code=404, detail=f"unit {unit_id} not found")
+    raise HTTPException(status_code=404, detail=_t("ref_unit_not_found", unit_id=unit_id))
 
 
 @router.patch("/episodes/{episode}/units/{unit_id}")
@@ -228,17 +221,18 @@ async def patch_unit(
     unit_id: str,
     req: PatchUnitRequest,
     _user: CurrentUser,
+    _t: Translator,
 ) -> dict[str, Any]:
-    project, script_file = _resolve_episode(project_name, episode)
+    project, script_file = _resolve_episode(project_name, episode, _t)
 
     # references 存在性校验对 project（只读）先做，失败 raise 400（在进锁前）
     refs: list[dict] | None = None
     if req.references is not None:
         refs = [r.model_dump() for r in req.references]
-        _validate_references_exist(project, refs)
+        _validate_references_exist(project, refs, _t)
 
-    with _locked_episode_script(project_name, script_file) as script:
-        unit = _find_unit(script, unit_id)  # 未找到 raise 404 → 跳过写回
+    with _locked_episode_script(project_name, script_file, _t) as script:
+        unit = _find_unit(script, unit_id, _t)  # 未找到 raise 404 → 跳过写回
 
         if refs is not None:
             unit["references"] = refs
@@ -269,14 +263,15 @@ async def delete_unit(
     episode: int,
     unit_id: str,
     _user: CurrentUser,
+    _t: Translator,
 ) -> Response:
-    _project, script_file = _resolve_episode(project_name, episode)
-    with _locked_episode_script(project_name, script_file) as script:
+    _project, script_file = _resolve_episode(project_name, episode, _t)
+    with _locked_episode_script(project_name, script_file, _t) as script:
         units = script.get("video_units") or []
         new_units = [u for u in units if u.get("unit_id") != unit_id]
         if len(new_units) == len(units):
             # 未找到 → 在锁内 raise，跳过写回
-            raise HTTPException(status_code=404, detail=f"unit {unit_id} not found")
+            raise HTTPException(status_code=404, detail=_t("ref_unit_not_found", unit_id=unit_id))
         script["video_units"] = new_units
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
@@ -291,19 +286,20 @@ async def reorder_units(
     episode: int,
     req: ReorderRequest,
     _user: CurrentUser,
+    _t: Translator,
 ) -> dict[str, Any]:
-    _project, script_file = _resolve_episode(project_name, episode)
-    with _locked_episode_script(project_name, script_file) as script:
+    _project, script_file = _resolve_episode(project_name, episode, _t)
+    with _locked_episode_script(project_name, script_file, _t) as script:
         units = script.get("video_units") or []
         existing_ids = [u.get("unit_id") for u in units]
 
         # 校验失败 → 在锁内 raise 400，跳过写回
         if len(req.unit_ids) != len(existing_ids):
-            raise HTTPException(status_code=400, detail="unit_ids length mismatch")
+            raise HTTPException(status_code=400, detail=_t("ref_unit_ids_length_mismatch"))
         if len(set(req.unit_ids)) != len(req.unit_ids):
-            raise HTTPException(status_code=400, detail="duplicate unit_ids")
+            raise HTTPException(status_code=400, detail=_t("ref_duplicate_unit_ids"))
         if set(req.unit_ids) != set(existing_ids):
-            raise HTTPException(status_code=400, detail="unit_ids do not match existing units")
+            raise HTTPException(status_code=400, detail=_t("ref_unit_ids_mismatch"))
 
         by_id = {u["unit_id"]: u for u in units}
         reordered = [by_id[uid] for uid in req.unit_ids]
@@ -320,9 +316,10 @@ async def generate_unit(
     episode: int,
     unit_id: str,
     _user: CurrentUser,
+    _t: Translator,
 ) -> dict[str, Any]:
-    _project, script, script_file = _load_episode_script(project_name, episode)
-    _find_unit(script, unit_id)  # raises 404 if missing
+    _project, script, script_file = _load_episode_script(project_name, episode, _t)
+    _find_unit(script, unit_id, _t)  # raises 404 if missing
 
     queue = get_generation_queue()
     result = await queue.enqueue_task(

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -326,10 +326,15 @@ async def execute_reference_video_task(
                 if u.get("unit_id") == resource_id:
                     ga = u.setdefault("generated_assets", {})
                     ga["video_clip"] = f"reference_videos/{resource_id}.mp4"
+                    # 重跑时若新结果不含 video_uri / 缩略图，清空旧值，避免指向过期 URI / 已删除文件
                     if video_uri:
                         ga["video_uri"] = video_uri
+                    else:
+                        ga.pop("video_uri", None)
                     if thumb_rel:
                         ga["video_thumbnail"] = thumb_rel
+                    else:
+                        ga.pop("video_thumbnail", None)
                     ga["status"] = "completed"
                     break
 

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -306,6 +307,80 @@ async def test_execute_reference_video_task_success(tmp_path: Path, monkeypatch:
     assert result["resource_type"] == "reference_videos"
     assert result["resource_id"] == "E1U1"
     assert result["file_path"].endswith("E1U1.mp4")
+
+
+@pytest.mark.asyncio
+async def test_execute_reference_video_task_clears_stale_video_uri_and_thumbnail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """重跑时新结果不含 video_uri 且缩略图提取失败 → 旧 video_uri / video_thumbnail 必须被清空，
+    不能保留指向过期 URI / 已删除文件的旧值。"""
+    proj_dir = _write_project(tmp_path)
+
+    # 预置上一次成功生成留下的旧产物
+    script_path = proj_dir / "scripts" / "episode_1.json"
+    script_data = json.loads(script_path.read_text(encoding="utf-8"))
+    ga = script_data["video_units"][0]["generated_assets"]
+    ga["video_uri"] = "https://old/expired.mp4"
+    ga["video_thumbnail"] = "reference_videos/thumbnails/E1U1.jpg"
+    script_path.write_text(json.dumps(script_data, ensure_ascii=False), encoding="utf-8")
+
+    from server.services import reference_video_tasks as rvt
+
+    # locked_script 用真实 contextmanager 回写到 live_script，供断言读取
+    live_script = json.loads(script_path.read_text(encoding="utf-8"))
+
+    @contextmanager
+    def _locked_script(_name, _file):
+        yield live_script
+
+    fake_pm = MagicMock()
+    fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
+    fake_pm.get_project_path.return_value = proj_dir
+    fake_pm.load_script.side_effect = lambda *_a: json.loads(script_path.read_text(encoding="utf-8"))
+    fake_pm.locked_script.side_effect = _locked_script
+    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
+
+    # 新后端不返回 video_uri（第 4 个元素为 None）
+    async def _fake_generate_video_async(**kwargs):
+        out = proj_dir / "reference_videos" / "E1U1.mp4"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\x00\x00\x00 ftypmp42")
+        return out, 1, None, None
+
+    fake_generator = MagicMock()
+    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
+    fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-17T10:00:00"}]}
+    fake_video_backend = MagicMock()
+    fake_video_backend.name = "ark"
+    fake_video_backend.model = "doubao-seedance-2-0-260128"
+    fake_generator._video_backend = fake_video_backend
+
+    async def _fake_get_media_generator(*_a, **_kw):
+        return fake_generator
+
+    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+
+    # 缩略图提取失败 → thumb_rel=None
+    async def _fake_extract(*_a, **_k):
+        return False
+
+    monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
+
+    await rvt.execute_reference_video_task(
+        "demo",
+        "E1U1",
+        {"script_file": "scripts/episode_1.json"},
+        user_id="u1",
+    )
+
+    ga_after = live_script["video_units"][0]["generated_assets"]
+    assert "video_uri" not in ga_after
+    assert "video_thumbnail" not in ga_after
+    # 正常产物仍正确写入
+    assert ga_after["video_clip"] == "reference_videos/E1U1.mp4"
+    assert ga_after["status"] == "completed"
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_reference_videos_router.py
+++ b/tests/server/test_reference_videos_router.py
@@ -304,7 +304,7 @@ def test_reorder_units_rejects_true_duplicate(client: TestClient):
         json={"unit_ids": [uid1, uid1]},
     )
     assert resp.status_code == 400
-    assert "duplicate" in resp.json()["detail"]
+    assert "重复" in resp.json()["detail"]
 
 
 def test_reorder_units_rejects_unknown_id_set_mismatch(client: TestClient):
@@ -316,4 +316,4 @@ def test_reorder_units_rejects_unknown_id_set_mismatch(client: TestClient):
         json={"unit_ids": [uid1, "E1U999"]},
     )
     assert resp.status_code == 400
-    assert "do not match" in resp.json()["detail"]
+    assert "不匹配" in resp.json()["detail"]

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -368,6 +368,24 @@ class TestProjectsRouter:
             assert seg2["scenes"] == ["Castle"]
             assert seg2["props"] == []
 
+    def test_update_segment_rejects_drama_script_with_residual_segments(self, tmp_path, monkeypatch):
+        # drama 脚本残留 segments 键不应被当 narration 改写：须返回 400 而非放行
+        fake_pm = _FakePM(tmp_path)
+        fake_pm.scripts[("ready", "drama.json")] = {
+            "content_mode": "drama",
+            "segments": [{"segment_id": "E1S01", "duration_seconds": 4}],
+            "scenes": [{"scene_id": "E1S01"}],
+        }
+
+        client = _client(monkeypatch, fake_pm, _FakeCalc())
+
+        with client:
+            resp = client.patch(
+                "/api/v1/projects/ready/segments/E1S01",
+                json={"script_file": "drama.json", "duration_seconds": 7},
+            )
+            assert resp.status_code == 400
+
     def test_update_scene_supports_character_and_clue_refs(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ready", "episode_1.json")] = {


### PR DESCRIPTION
## 背景

PR #585（统一 ProjectManager 读-改-写锁语义）的 AI review 中推回了若干 pre-existing / 独立改动，汇总到 tracking issue #589。本 PR 处理其中风险低、价值高的 3 项（第 1/3/4 项），分 3 个独立 commit。第 2 项（TOCTOU 跨锁竞态）和第 5 项（`update_project` 接口重构）体量大、优先级低，仍留在 issue 跟踪。

## 改动

### 第 1 项：`reference_videos.py` 全文件接入 i18n
- 全部 `HTTPException(detail=...)` 改走 `Translator`：7 个 handler 加 `_t` 依赖，5 个 helper 加 `_t` 形参
- 项目/脚本缺失复用既有 `project_not_found` / `script_not_found`
- 新增 7 个三语 key（zh/en/vi）：`ref_episode_not_found`、`ref_not_reference_video_mode`、`ref_not_registered`、`ref_unit_not_found`、`ref_unit_ids_length_mismatch`、`ref_duplicate_unit_ids`、`ref_unit_ids_mismatch`
- 默认 locale=zh，更新 router 测试两处英文断言为中文

### 第 3 项：`update_segment` 校验 `and` → `or`
- `content_mode != "narration"` 的脚本即使残留 `segments` 键也不再被当 narration 改写，仅 narration 且含 `segments` 键才放行
- **边缘行为变化**：narration 脚本若缺 `segments` 键，从「命中后 404」变为「前置 400」，属合理收紧
- 补 drama 带 `segments` 键 → 400 的回归测试

### 第 4 项：`_update_unit_assets` 重跑清空旧 video_uri / 缩略图
- 重跑时若新结果不含 `video_uri` 或缩略图提取失败，原仅跳过写入会保留旧值（指向过期 URI / 已删除文件），两处补 `else: pop`
- 补重跑清空回归测试

## 验证
- pytest：2848 passed（+2 新测试）
- ruff check / format：全量通过
- basedpyright：0 errors

Refs #589（本 PR 仅处理第 1/3/4 项；第 2、5 项继续在该 issue 跟踪）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修复参考视频任务重新执行时，过时的资源信息未被清除的问题
  * 改进剧本脚本验证逻辑，确保段落更新操作仅作用于指定脚本模式

* **新功能**
  * 新增参考视频操作的多语言错误提示，支持英文、越南文和中文
  * 完善参考视频相关的错误消息覆盖（如剧集未找到、单元校验失败等）

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->