### PR TITLE
refactor(project_manager): update_project 返回完整的更新后元数据，减少冗余操作 (#589)

### DIFF
--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -621,10 +621,10 @@ class ProjectManager:
             episode_entry["script_file"] = script_file
             episodes.sort(key=lambda x: x["episode"])
 
-        self.update_project(project_name, _mutate)
+        result = self.update_project(project_name, _mutate)
 
         logger.info("已同步剧集信息: Episode %d - %s", episode_num, episode_title)
-        return self.load_project(project_name)
+        return result
 
     def load_script(self, project_name: str, filename: str) -> dict:
         """
@@ -1247,14 +1247,20 @@ class ProjectManager:
         self,
         project_name: str,
         mutate_fn: Callable[[dict], None],
-    ) -> Path:
+    ) -> dict:
         """原子性地更新 project.json：加文件锁 → 读 → 修改 → 原子写回。
 
         避免并发任务（如同时生成多张角色图片）之间的 lost-update 竞态。
+        在同一持锁窗口内统一应用读时迁移（_migrate_legacy_style），并在锁外应用
+        内存映射升级（_lazy_upgrade_image_provider），返回迁移后的项目元数据 dict，
+        调用方无需再 load_project 一次。
 
         Args:
             project_name: 项目名称
             mutate_fn: 接收 project dict 并就地修改的回调函数
+
+        Returns:
+            迁移后的项目元数据字典（与 load_project 返回结构一致）
         """
         project_file = self._get_project_file_path(project_name)
 
@@ -1263,6 +1269,7 @@ class ProjectManager:
                 project = json.load(f)
             mutate_fn(project)
             self._migrate_legacy_resolution_on_save(project)
+            self._migrate_legacy_style(project)
             self._touch_metadata(project)
             atomic_write_json(project_file, project)
 
@@ -1271,7 +1278,8 @@ class ProjectManager:
             changed_paths=[self.PROJECT_FILE],
         )
 
-        return project_file
+        self._lazy_upgrade_image_provider(project)
+        return project
 
     @staticmethod
     def _touch_metadata(project: dict) -> None:
@@ -1381,8 +1389,7 @@ class ProjectManager:
             project["episodes"].append({"episode": episode, "title": title, "script_file": script_file})
             project["episodes"].sort(key=lambda x: x["episode"])
 
-        self.update_project(project_name, _mutate)
-        return self.load_project(project_name)
+        return self.update_project(project_name, _mutate)
 
     def sync_project_status(self, project_name: str) -> dict:
         """
@@ -1477,8 +1484,7 @@ class ProjectManager:
                 raise KeyError(f"{spec.label_zh} '{name}' 不存在")
             bucket[name][spec.sheet_field] = sheet_path
 
-        self.update_project(project_name, _mutate)
-        return self.load_project(project_name)
+        return self.update_project(project_name, _mutate)
 
     def _get_asset(self, asset_type: str, project_name: str, name: str) -> dict:
         """获取资产定义。不存在抛 KeyError。"""
@@ -1537,8 +1543,7 @@ class ProjectManager:
                 "character_sheet": character_sheet or "",
             }
 
-        self.update_project(project_name, _mutate)
-        return self.load_project(project_name)
+        return self.update_project(project_name, _mutate)
 
     def update_project_character_sheet(self, project_name: str, name: str, sheet_path: str) -> dict:
         """更新项目级角色设计图路径"""
@@ -1562,8 +1567,7 @@ class ProjectManager:
                 raise KeyError(f"角色 '{char_name}' 不存在")
             project["characters"][char_name]["reference_image"] = ref_path
 
-        self.update_project(project_name, _mutate)
-        return self.load_project(project_name)
+        return self.update_project(project_name, _mutate)
 
     def get_project_character(self, project_name: str, name: str) -> dict:
         """获取项目级角色定义"""

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -720,11 +720,8 @@ async def update_project(name: str, req: UpdateProjectRequest, _user: CurrentUse
                     project["episodes"] = new_episodes
 
             with project_change_source("webui"):
-                manager.update_project(name, _mutate)
-            # 返回经 load_project 的 fresh 副本，恢复改用 update_project 前由 load_project
-            # 读取时执行的 _migrate_legacy_style（持久化）+ _lazy_upgrade_image_provider 语义，
-            # 确保回前端的 project 含升级后的字段（与其它已迁移 helper 一致：均 return load_project）
-            return {"success": True, "project": manager.load_project(name)}
+                # update_project 已在持锁窗口内统一应用迁移，返回升级后字段，无需二次 load_project
+                return {"success": True, "project": manager.update_project(name, _mutate)}
 
         return await asyncio.to_thread(_sync)
     except FileNotFoundError:

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -120,12 +120,14 @@ class _FakePM:
         self.scripts[(name, script_file)] = payload
 
     def update_project(self, name, mutate_fn):
-        # 复刻真实 ProjectManager.update_project：load → mutate → save 单一事务。
+        # 复刻真实 ProjectManager.update_project：load → mutate → save 单一事务，
+        # 并返回迁移后的 project dict（调用方据此回前端，无需二次 load_project）。
         # deepcopy 后再 mutate，使异常时（save 未执行）backing store 不被原地突变污染，
         # 忠实于真实 PM「读裸 JSON、出错不写回」的语义。
         project = deepcopy(self.load_project(name))
         mutate_fn(project)
         self.save_project(name, project)
+        return project
 
     @contextmanager
     def locked_script(self, name, script_file):

--- a/tests/test_update_project_atomicity.py
+++ b/tests/test_update_project_atomicity.py
@@ -117,3 +117,40 @@ class TestUpdateProjectAtomicity:
 
         result = pm.load_project(name)
         assert result["metadata"]["updated_at"] != "2025-01-01"
+
+    def test_update_project_returns_migrated_dict(self, tmp_path: Path):
+        """update_project 应在单次调用内应用读时迁移并返回最终 dict（无需二次 load_project）。
+
+        覆盖两条迁移：_migrate_legacy_style（持久化）+ _lazy_upgrade_image_provider（内存映射）。
+        """
+        project_name = "migrate-proj"
+        project_dir = tmp_path / project_name
+        project_dir.mkdir()
+        (project_dir / "project.json").write_text(
+            json.dumps(
+                {
+                    "characters": {"a": {"character_sheet": ""}},
+                    "style": "Anime",  # legacy 值，应迁移为 style_template_id
+                    "image_backend": "gemini/imagen",  # 旧单字段，应映射到 _t2i / _i2i
+                    "metadata": {"created_at": "2025-01-01", "updated_at": "2025-01-01"},
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        pm = ProjectManager(tmp_path)
+
+        returned = pm.update_project(
+            project_name, lambda p: p["characters"]["a"].__setitem__("character_sheet", "x.png")
+        )
+
+        # 返回值即迁移后的 dict
+        assert returned["style_template_id"] == "anim_kyoto"
+        assert returned["image_provider_t2i"] == "gemini/imagen"
+        assert returned["image_provider_i2i"] == "gemini/imagen"
+        assert returned["characters"]["a"]["character_sheet"] == "x.png"
+
+        # 与随后 load_project 的结果一致（持久化迁移已落盘）
+        reloaded = pm.load_project(project_name)
+        assert reloaded["style_template_id"] == returned["style_template_id"]
+        assert reloaded["image_provider_t2i"] == returned["image_provider_t2i"]


### PR DESCRIPTION
## 背景

PR #585 后，多个 project 级写操作以 `self.update_project(...); return self.load_project(name)` 收尾。`update_project` 返回 `Path`、持锁窗口内只跑 `_migrate_legacy_resolution_on_save`，**不跑** `load_project` 读时的 `_migrate_legacy_style`（持久化）和 `_lazy_upgrade_image_provider`（内存映射）。因此调用方必须再 `load_project` 一次才能把升级后的字段返回前端——每次写后多一次磁盘读 + 重新获取文件锁。

本 PR 落实 issue #589 第五项：让 `update_project` 在同一持锁窗口内统一应用全部迁移并返回最终 dict，消除写后二次读。

## 改动

- **`lib/project_manager.py`**
  - `update_project` 签名 `-> Path` 改为 `-> dict`；持锁窗口内补 `_migrate_legacy_style`（持久化），锁外补 `_lazy_upgrade_image_provider`（内存映射），返回与 `load_project` 结构一致的迁移后 dict。
  - 5 处写后二次读改为单次调用：同步剧集信息、`add_episode`、`_update_asset_sheet`（覆盖三个 `update_*_sheet`）、`add_project_character`、`update_character_reference_image`。
- **`server/routers/projects.py`** — PATCH `/projects/{name}` 直接返回 `update_project(...)` 结果，删除已不成立的解释性注释。
- **测试** — 新增 `test_update_project_returns_migrated_dict` 锁定「单次调用返回迁移后字段」契约；`_FakePM.update_project` 跟上新契约返回 mutate 后 project。

经核查无任何生产代码使用旧 `Path` 返回值，直接改签名安全。

## 验证

- ✅ `uv run python -m pytest` — 2847 passed
- ✅ `uv run basedpyright`（改动文件）— 0 errors
- ✅ `uv run ruff check` + `format` — 通过

Closes #589 (第五项)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 项目更新操作现在直接返回完整的更新后元数据，减少了冗余操作，提升了系统效率。

* **Tests**
  * 增强了项目更新原子性和元数据迁移处理的测试覆盖范围。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->