### PR TITLE
feat(usage): track assistant usage costs

### DIFF
--- a/frontend/src/components/layout/UsageDrawer.tsx
+++ b/frontend/src/components/layout/UsageDrawer.tsx
@@ -265,17 +265,23 @@ export function UsageDrawer({ open, onClose, projectName, anchorRef }: UsageDraw
                     <span className="num truncate">{call.model}</span>
                     {call.call_type === "text" ? (
                       <>
-                        {call.input_tokens != null && (
+                        {call.usage_tokens != null ? (
                           <span className="num">
-                            {t("input_token_label")}{" "}
-                            {call.input_tokens.toLocaleString()}
+                            {call.usage_tokens.toLocaleString()} {t("tokens_suffix")}
                           </span>
-                        )}
-                        {call.output_tokens != null && (
-                          <span className="num">
-                            {t("output_token_label")}{" "}
-                            {call.output_tokens.toLocaleString()} tokens
-                          </span>
+                        ) : (
+                          <>
+                            {call.input_tokens != null && (
+                              <span className="num">
+                                {t("input_token_label")} {call.input_tokens.toLocaleString()} {t("tokens_suffix")}
+                              </span>
+                            )}
+                            {call.output_tokens != null && (
+                              <span className="num">
+                                {t("output_token_label")} {call.output_tokens.toLocaleString()} {t("tokens_suffix")}
+                              </span>
+                            )}
+                          </>
                         )}
                       </>
                     ) : (

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -764,6 +764,7 @@ export default {
   'no_call_records': 'No call records yet',
   'input_token_label': 'Input',
   'output_token_label': 'Output',
+  'tokens_suffix': 'tokens',
   'records_count': '{{count}} records',
 
   // WorkspaceNotificationsDrawer

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -741,6 +741,7 @@ export default {
   'no_call_records': 'Chưa có bản ghi cuộc gọi',
   'input_token_label': 'Đầu vào',
   'output_token_label': 'Đầu ra',
+  'tokens_suffix': 'token',
   'records_count': '{{count}} bản ghi',
 
   // WorkspaceNotificationsDrawer

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -765,6 +765,7 @@ export default {
   'no_call_records': '暂无调用记录',
   'input_token_label': '输入',
   'output_token_label': '输出',
+  'tokens_suffix': 'tokens',
   'records_count': '{{count}} 条记录',
 
   // WorkspaceNotificationsDrawer

--- a/frontend/src/stores/stores.test.ts
+++ b/frontend/src/stores/stores.test.ts
@@ -292,6 +292,7 @@ describe("stores", () => {
           error_message: null,
           started_at: "2026-02-01T00:00:00Z",
           created_at: "2026-02-01T00:00:00Z",
+          usage_tokens: null,
           input_tokens: null,
           output_tokens: null,
         },

--- a/frontend/src/stores/usage-store.ts
+++ b/frontend/src/stores/usage-store.ts
@@ -33,6 +33,7 @@ export interface UsageCall {
   error_message: string | null;
   started_at: string;
   created_at: string;
+  usage_tokens: number | null;
   input_tokens: number | null;
   output_tokens: number | null;
 }

--- a/lib/cost_calculator.py
+++ b/lib/cost_calculator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from lib.custom_provider import is_custom_provider
 from lib.openai_shared import OPENAI_IMAGE_SIZE_MAP
-from lib.providers import PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI, CallType
+from lib.providers import PROVIDER_ANTHROPIC, PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI, CallType
 
 # fork: Vidu provider — 单独 import 块以避免与上游聚合 import 冲突
 # isort: off
@@ -168,6 +168,22 @@ class CostCalculator:
         "gpt-5.4": {"input": 2.50, "output": 15.00},
         "gpt-5.4-mini": {"input": 0.75, "output": 4.50},
         "gpt-5.4-nano": {"input": 0.20, "output": 1.25},
+    }
+
+    # Claude Agent SDK / Anthropic 文本 token 费率（美元/百万 token）。
+    # 助手主链路优先使用 SDK result.total_cost_usd；这里作为只拿到 token 时的兜底。
+    ANTHROPIC_TEXT_COST = {
+        "claude-sonnet-4": {"input": 3.00, "output": 15.00},
+        "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
+        "claude-sonnet-4.5": {"input": 3.00, "output": 15.00},
+        "claude-sonnet-4-5": {"input": 3.00, "output": 15.00},
+        "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
+        "claude-haiku-4-5": {"input": 1.00, "output": 5.00},
+        "claude-haiku-4-5-20251001": {"input": 1.00, "output": 5.00},
+        "claude-haiku-4-20250514": {"input": 1.00, "output": 5.00},
+        "claude-opus-4": {"input": 15.00, "output": 75.00},
+        "claude-opus-4-6": {"input": 15.00, "output": 75.00},
+        "claude-opus-4-7": {"input": 15.00, "output": 75.00},
     }
     # OpenAI 图片 token 费率（美元/百万 token）— GPT Image 实际计费形式
     # 来源：https://platform.openai.com/docs/pricing — GPT Image (April 2026)
@@ -431,6 +447,7 @@ class CostCalculator:
         PROVIDER_ARK: ("ARK_TEXT_COST", "doubao-seed-2-0-lite-260215", "CNY"),
         PROVIDER_GROK: ("GROK_TEXT_COST", "grok-4-1-fast-reasoning", "USD"),
         PROVIDER_OPENAI: ("OPENAI_TEXT_COST", "gpt-5.4-mini", "USD"),
+        PROVIDER_ANTHROPIC: ("ANTHROPIC_TEXT_COST", "claude-sonnet-4", "USD"),
     }
     _TEXT_COST_DEFAULT = ("GEMINI_TEXT_COST", "gemini-3-flash-preview", "USD")
 

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -123,6 +123,8 @@ class UsageRepository(BaseRepository):
         image_output_tokens: int | None = None,
         text_input_tokens: int | None = None,
         text_output_tokens: int | None = None,
+        cost_amount: float | None = None,
+        currency: str | None = None,
     ) -> None:
         finished_at = utc_now()
 
@@ -141,9 +143,9 @@ class UsageRepository(BaseRepository):
         except (ValueError, TypeError):
             duration_ms = 0
 
-        # Calculate cost (failed = 0)
-        cost_amount = 0.0
-        currency = row.currency or "USD"
+        # Calculate cost. Explicit cost input is treated as provider-reported billing data.
+        final_cost_amount = 0.0
+        final_currency = row.currency or "USD"
         effective_provider = row.provider or PROVIDER_GEMINI
 
         # Pre-query custom provider pricing (avoids sync-over-async in CostCalculator)
@@ -169,8 +171,11 @@ class UsageRepository(BaseRepository):
             input_tokens = (image_input_tokens or 0) + (text_input_tokens or 0)
             output_tokens = (image_output_tokens or 0) + (text_output_tokens or 0)
 
-        if status == "success":
-            cost_amount, currency = cost_calculator.calculate_cost(
+        if cost_amount is not None:
+            final_cost_amount = cost_amount
+            final_currency = currency or row.currency or "USD"
+        elif status == "success":
+            final_cost_amount, final_currency = cost_calculator.calculate_cost(
                 provider=effective_provider,
                 call_type=row.call_type,  # type: ignore[arg-type]
                 model=row.model,
@@ -202,8 +207,8 @@ class UsageRepository(BaseRepository):
                 finished_at=finished_at,
                 duration_ms=duration_ms,
                 retry_count=retry_count,
-                cost_amount=cost_amount,
-                currency=currency,
+                cost_amount=final_cost_amount,
+                currency=final_currency,
                 usage_tokens=usage_tokens,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,

--- a/lib/providers.py
+++ b/lib/providers.py
@@ -9,6 +9,7 @@ PROVIDER_GROK = "grok"
 PROVIDER_OPENAI = "openai"
 PROVIDER_VIDU = "vidu"
 PROVIDER_NEWAPI = "newapi"
+PROVIDER_ANTHROPIC = "anthropic"
 
 CallType = Literal["image", "video", "text"]
 CALL_TYPE_IMAGE: CallType = "image"

--- a/lib/usage_tracker.py
+++ b/lib/usage_tracker.py
@@ -69,6 +69,8 @@ class UsageTracker:
         image_output_tokens: int | None = None,
         text_input_tokens: int | None = None,
         text_output_tokens: int | None = None,
+        cost_amount: float | None = None,
+        currency: str | None = None,
     ) -> None:
 
         async with self._session_factory() as session:
@@ -89,6 +91,8 @@ class UsageTracker:
                 image_output_tokens=image_output_tokens,
                 text_input_tokens=text_input_tokens,
                 text_output_tokens=text_output_tokens,
+                cost_amount=cost_amount,
+                currency=currency,
             )
 
     async def get_stats(

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -20,7 +20,7 @@ from lib.project_manager import effective_mode
 from lib.prompt_builders_script import build_normalize_prompt
 from lib.script_generator import ScriptGenerator
 from lib.text_backends.base import TextGenerationRequest, TextTaskType
-from lib.text_backends.factory import create_text_backend_for_task
+from lib.text_generator import TextGenerator
 from server.agent_runtime.sdk_tools._context import ToolContext, fetch_video_caps, tool_error
 
 logger = logging.getLogger(__name__)
@@ -241,8 +241,11 @@ def normalize_drama_script_tool(ctx: ToolContext):
                     ]
                 }
 
-            backend = await create_text_backend_for_task(TextTaskType.SCRIPT, project_name=ctx.project_name)
-            result = await backend.generate(TextGenerationRequest(prompt=prompt, max_output_tokens=16000))
+            generator = await TextGenerator.create(TextTaskType.SCRIPT, project_name=ctx.project_name)
+            result = await generator.generate(
+                TextGenerationRequest(prompt=prompt, max_output_tokens=16000),
+                project_name=ctx.project_name,
+            )
             response = result.text
 
             drafts_dir = project_path / "drafts" / f"episode_{episode}"

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -8,6 +8,7 @@ import fnmatch
 import functools
 import json
 import logging
+import math
 import os
 import shlex
 import tempfile
@@ -43,6 +44,8 @@ from claude_agent_sdk.types import (
 
 from lib.config.service import ConfigService
 from lib.db import async_session_factory
+from lib.providers import PROVIDER_ANTHROPIC
+from lib.usage_tracker import UsageTracker
 
 SDK_AVAILABLE = True
 
@@ -118,6 +121,8 @@ class ManagedSession:
     buffer_max_size: int = 100
     pending_questions: dict[str, PendingQuestion] = field(default_factory=dict)
     pending_user_echoes: list[str] = field(default_factory=list)
+    last_user_prompt: str = ""
+    assistant_model: str = ""
     interrupt_requested: bool = False
     last_activity: float | None = None  # updated on every send/receive
     _cleanup_task: asyncio.Task | None = None  # current cleanup timer (idle TTL or terminal delay)
@@ -442,6 +447,7 @@ class SessionManager:
         self._sensitive_prefixes: tuple[Path, ...] = prefixes
         self._sensitive_globs: tuple[tuple[Path, str], ...] = globs
         self._load_config()
+        self.usage_tracker = UsageTracker(session_factory=getattr(meta_store, "_session_factory", None))
 
     def _compute_sensitive_paths(
         self,
@@ -1263,6 +1269,7 @@ class SessionManager:
             locale=locale,
             stderr=_collect_stderr,
         )
+        assistant_model = self._resolve_configured_assistant_model(getattr(options, "env", None))
 
         actor = SessionActor(
             client_factory=lambda: ClaudeSDKClient(options=options),
@@ -1274,6 +1281,7 @@ class SessionManager:
             actor=actor,
             status="running",
             project_name=project_name,
+            assistant_model=assistant_model,
         )
         managed_ref[0] = managed
         managed.last_activity = time.monotonic()
@@ -1322,6 +1330,7 @@ class SessionManager:
         dedup_key = display_text or (self._IMAGE_ONLY_SENTINEL if echo_content else "")
         if dedup_key:
             managed.pending_user_echoes.append(dedup_key)
+        managed.last_user_prompt = display_text
         managed.add_message(self._build_user_echo_message(display_text, echo_content))
 
         try:
@@ -1474,6 +1483,7 @@ class SessionManager:
                 can_use_tool=await self._build_can_use_tool_callback(session_id, managed_ref),
                 stderr=_collect_stderr,
             )
+            assistant_model = self._resolve_configured_assistant_model(getattr(options, "env", None))
 
             actor = SessionActor(
                 client_factory=lambda: ClaudeSDKClient(options=options),
@@ -1488,6 +1498,7 @@ class SessionManager:
                 actor=actor,
                 status=resumed_status,
                 project_name=meta.project_name,
+                assistant_model=assistant_model,
                 resolved_sdk_id=meta.id,  # 标记为已注册，防止重复创建 DB 记录
             )
             managed.sdk_id_event.set()  # 已有会话不需要等待 sdk_id
@@ -1548,6 +1559,7 @@ class SessionManager:
             managed.pending_user_echoes.append(dedup_key)
             if len(managed.pending_user_echoes) > 20:
                 managed.pending_user_echoes.pop(0)
+        managed.last_user_prompt = display_text
         managed.add_message(self._build_user_echo_message(display_text, echo_content))
 
         # Persist status asynchronously — don't block the echo broadcast
@@ -1623,11 +1635,191 @@ class SessionManager:
         )
         managed.status = final_status
         managed.last_activity = time.monotonic()
+        try:
+            await self._record_assistant_usage(managed, result_msg, final_status)
+        except Exception:
+            logger.exception("记录 assistant usage 失败 session_id=%s", managed.session_id)
         await self.meta_store.update_status(managed.session_id, final_status)
         managed.interrupt_requested = False
         self._prune_transient_buffer(managed)
         if final_status != "running":
             self._schedule_cleanup(managed.session_id)
+
+    async def _record_assistant_usage(
+        self,
+        managed: ManagedSession,
+        result_msg: dict[str, Any],
+        final_status: SessionStatus,
+    ) -> None:
+        input_tokens, output_tokens, usage_tokens = self._extract_text_token_usage(result_msg)
+        total_cost_usd = self._extract_assistant_cost(result_msg)
+        if input_tokens is None and output_tokens is None and total_cost_usd is None:
+            return
+
+        call_id = await self.usage_tracker.start_call(
+            project_name=managed.project_name,
+            call_type="text",
+            model=self._resolve_assistant_model(result_msg, managed.assistant_model),
+            prompt=managed.last_user_prompt[:500] if managed.last_user_prompt else None,
+            provider=PROVIDER_ANTHROPIC,
+            user_id=getattr(self, "_user_id", DEFAULT_USER_ID),
+        )
+        await self.usage_tracker.finish_call(
+            call_id,
+            status="success" if final_status == "completed" else "failed",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            usage_tokens=usage_tokens,
+            cost_amount=total_cost_usd,
+            currency="USD" if total_cost_usd is not None else None,
+        )
+
+    @classmethod
+    def _extract_text_token_usage(cls, result_msg: dict[str, Any]) -> tuple[int | None, int | None, int | None]:
+        usage = result_msg.get("usage")
+        usage_dict = usage if isinstance(usage, dict) else {}
+        raw_input_tokens = cls._first_int(usage_dict, "input_tokens", "prompt_tokens")
+        output_tokens = cls._first_int(usage_dict, "output_tokens", "completion_tokens")
+        cache_creation_tokens = cls._first_int(usage_dict, "cache_creation_input_tokens")
+        cache_read_tokens = cls._first_int(usage_dict, "cache_read_input_tokens")
+        if (
+            raw_input_tokens is None
+            and output_tokens is None
+            and cache_creation_tokens is None
+            and cache_read_tokens is None
+        ):
+            return cls._extract_model_usage_tokens(result_msg)
+
+        # Claude Agent SDK reports prompt cache tokens separately. Store them in
+        # input_tokens as well so aggregate usage includes the full prompt-side token volume.
+        input_parts = (raw_input_tokens, cache_creation_tokens, cache_read_tokens)
+        input_tokens = sum(part or 0 for part in input_parts) if any(part is not None for part in input_parts) else None
+        token_parts = (raw_input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens)
+        usage_tokens = sum(part or 0 for part in token_parts) if any(part is not None for part in token_parts) else None
+        return input_tokens, output_tokens, usage_tokens
+
+    @classmethod
+    def _extract_model_usage_tokens(cls, result_msg: dict[str, Any]) -> tuple[int | None, int | None, int | None]:
+        model_usage = result_msg.get("model_usage")
+        if not isinstance(model_usage, dict):
+            return None, None, None
+
+        raw_input_total = 0
+        output_total = 0
+        cache_creation_total = 0
+        cache_read_total = 0
+        has_tokens = False
+        has_input_tokens = False
+        has_output_tokens = False
+        for usage in model_usage.values():
+            if not isinstance(usage, dict):
+                continue
+            raw_input = cls._first_int(usage, "inputTokens")
+            output = cls._first_int(usage, "outputTokens")
+            cache_creation = cls._first_int(usage, "cacheCreationInputTokens")
+            cache_read = cls._first_int(usage, "cacheReadInputTokens")
+            if any(part is not None for part in (raw_input, output, cache_creation, cache_read)):
+                has_tokens = True
+            if any(part is not None for part in (raw_input, cache_creation, cache_read)):
+                has_input_tokens = True
+            if output is not None:
+                has_output_tokens = True
+            raw_input_total += raw_input or 0
+            output_total += output or 0
+            cache_creation_total += cache_creation or 0
+            cache_read_total += cache_read or 0
+
+        if not has_tokens:
+            return None, None, None
+        input_tokens = raw_input_total + cache_creation_total + cache_read_total if has_input_tokens else None
+        output_tokens = output_total if has_output_tokens else None
+        usage_tokens = raw_input_total + output_total + cache_creation_total + cache_read_total
+        return input_tokens, output_tokens, usage_tokens
+
+    @classmethod
+    def _extract_assistant_cost(cls, result_msg: dict[str, Any]) -> float | None:
+        total_cost = cls._extract_float(result_msg.get("total_cost_usd"))
+        if total_cost is not None:
+            return total_cost
+
+        model_usage = result_msg.get("model_usage")
+        if not isinstance(model_usage, dict):
+            return None
+
+        model_cost_total = 0.0
+        has_model_cost = False
+        for usage in model_usage.values():
+            if not isinstance(usage, dict):
+                continue
+            cost = cls._extract_float(usage.get("costUSD"))
+            if cost is None:
+                continue
+            model_cost_total += cost
+            has_model_cost = True
+        return model_cost_total if has_model_cost else None
+
+    @classmethod
+    def _first_int(cls, source: dict[str, Any], *keys: str) -> int | None:
+        for key in keys:
+            value = cls._extract_int(source.get(key))
+            if value is not None:
+                return value
+        return None
+
+    @staticmethod
+    def _extract_int(value: Any) -> int | None:
+        if isinstance(value, bool) or value is None:
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value) if math.isfinite(value) and value >= 0 and value.is_integer() else None
+        if isinstance(value, str):
+            value_str = value.strip()
+            if not value_str:
+                return None
+            try:
+                numeric_value = float(value_str)
+            except ValueError:
+                return None
+            if not math.isfinite(numeric_value) or numeric_value < 0 or not numeric_value.is_integer():
+                return None
+            return int(numeric_value)
+        return None
+
+    @staticmethod
+    def _extract_float(value: Any) -> float | None:
+        if isinstance(value, bool) or value is None:
+            return None
+        try:
+            numeric_value = float(value)
+        except (TypeError, ValueError):
+            return None
+        return numeric_value if math.isfinite(numeric_value) and numeric_value >= 0 else None
+
+    @staticmethod
+    def _resolve_assistant_model(result_msg: dict[str, Any], configured_model: str = "") -> str:
+        model = result_msg.get("model") or result_msg.get("model_name")
+        if isinstance(model, str) and model.strip():
+            return model.strip()
+        if configured_model.strip():
+            return configured_model.strip()
+        model_usage = result_msg.get("model_usage")
+        if isinstance(model_usage, dict) and len(model_usage) == 1:
+            model_name = next(iter(model_usage))
+            if isinstance(model_name, str) and model_name.strip():
+                return model_name.strip()
+        return os.environ.get("ANTHROPIC_MODEL", "").strip() or "claude-sonnet-4"
+
+    @staticmethod
+    def _resolve_configured_assistant_model(env: Any) -> str:
+        if not isinstance(env, dict):
+            return ""
+        for key in ("ANTHROPIC_MODEL", "ANTHROPIC_DEFAULT_OPUS_MODEL", "ANTHROPIC_DEFAULT_SONNET_MODEL"):
+            value = env.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
 
     async def _mark_session_terminal(self, managed: ManagedSession, status: SessionStatus, reason: str) -> None:
         """Set terminal status on abnormal consumer exit."""

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -542,8 +542,8 @@ async def test_normalize_drama_script_injects_episode_into_prompt(fake_ctx: Tool
 
 
 async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: ToolContext, monkeypatch) -> None:
-    """工具必须把 ctx.project_name 传给 create_text_backend_for_task，
-    否则项目级 text_backend_script 覆盖被跳过，会回退到全局默认后端。"""
+    """工具必须把 ctx.project_name 传给 TextGenerator.create/generate，
+    否则项目级 text_backend_script 覆盖被跳过，且 usage tracking 会丢 project_name。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
 
     project_path = fake_ctx.project_path
@@ -556,8 +556,10 @@ async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: T
 
     captured: dict[str, Any] = {}
 
-    class _FakeBackend:
-        async def generate(self, _request):
+    class _FakeGenerator:
+        async def generate(self, _request, project_name=None):
+            captured["generate_project_name"] = project_name
+
             class _R:
                 text = "| 场景 ID | 描述 |\n|---|---|\n| E1S01 | 山中 |"
 
@@ -565,19 +567,24 @@ async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: T
 
     async def fake_create(task_type, project_name=None):
         captured["task_type"] = task_type
-        captured["project_name"] = project_name
-        return _FakeBackend()
+        captured["create_project_name"] = project_name
+        return _FakeGenerator()
 
     monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
-    monkeypatch.setattr(mod, "create_text_backend_for_task", fake_create)
+    monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
     tool_obj = normalize_drama_script_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1})
 
     assert out.get("is_error") is not True, out
-    assert captured["project_name"] == "demo", (
-        f"normalize_drama_script 必须传入 project_name 以让项目级 text_backend_script 覆盖生效，"
-        f"实际传入: {captured.get('project_name')!r}"
+    assert captured["task_type"] is mod.TextTaskType.SCRIPT
+    assert captured["create_project_name"] == "demo", (
+        f"normalize_drama_script 必须向 TextGenerator.create 传入 project_name，"
+        f"实际传入: {captured.get('create_project_name')!r}"
+    )
+    assert captured["generate_project_name"] == "demo", (
+        f"normalize_drama_script 必须向 TextGenerator.generate 传入 project_name，"
+        f"实际传入: {captured.get('generate_project_name')!r}"
     )
 
 

--- a/tests/test_cost_calculator.py
+++ b/tests/test_cost_calculator.py
@@ -1,6 +1,7 @@
 import pytest
 
 from lib.cost_calculator import CostCalculator, cost_calculator
+from lib.providers import PROVIDER_ANTHROPIC
 
 
 class TestCostCalculator:
@@ -41,6 +42,41 @@ class TestCostCalculator:
 
     def test_singleton_instance(self):
         assert isinstance(cost_calculator, CostCalculator)
+
+
+class TestAnthropicTextCost:
+    def test_calculate_anthropic_text_cost(self):
+        amount, currency = cost_calculator.calculate_text_cost(
+            input_tokens=100_000,
+            output_tokens=50_000,
+            provider=PROVIDER_ANTHROPIC,
+            model="claude-sonnet-4",
+        )
+
+        assert currency == "USD"
+        assert amount == pytest.approx(1.05)
+
+    def test_unknown_anthropic_model_uses_default(self):
+        amount, currency = cost_calculator.calculate_text_cost(
+            input_tokens=100_000,
+            output_tokens=50_000,
+            provider=PROVIDER_ANTHROPIC,
+            model="unknown-claude",
+        )
+
+        assert currency == "USD"
+        assert amount == pytest.approx(1.05)
+
+    def test_calculate_anthropic_haiku_text_cost(self):
+        amount, currency = cost_calculator.calculate_text_cost(
+            input_tokens=100_000,
+            output_tokens=50_000,
+            provider=PROVIDER_ANTHROPIC,
+            model="claude-haiku-4-5",
+        )
+
+        assert currency == "USD"
+        assert amount == pytest.approx(0.35)
 
 
 class TestArkCost:

--- a/tests/test_session_manager_sdk_session_id.py
+++ b/tests/test_session_manager_sdk_session_id.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 
+import pytest
+from sqlalchemy import select
+
+from lib.db.models.api_call import ApiCall
 from server.agent_runtime.session_actor import SessionActor
 from server.agent_runtime.session_manager import ManagedSession
 from tests.fakes import FakeSDKClient
@@ -68,6 +72,220 @@ class TestSessionManagerSdkSessionId:
         assert meta is not None
         assert meta.project_name == "demo"
         assert meta.status == "running"
+
+    async def test_finalize_turn_records_assistant_usage(self, session_manager, meta_store):
+        meta = await meta_store.create("demo", "sdk-usage-789")
+        managed = _make_managed(session_id=meta.id, project_name="demo", assistant_model="claude-sonnet-4")
+        managed.last_user_prompt = "hello assistant"
+        session_manager._user_id = "assistant-user"  # type: ignore[attr-defined]
+
+        await session_manager._finalize_turn(
+            managed,
+            {
+                "type": "result",
+                "session_status": "completed",
+                "model": "claude-sonnet-4",
+                "total_cost_usd": 0.1234,
+                "usage": {
+                    "input_tokens": 1000,
+                    "output_tokens": 200,
+                    "cache_creation_input_tokens": 50,
+                },
+            },
+        )
+
+        async with meta_store._session_factory() as session:  # noqa: SLF001 - test fixture exposes shared DB factory
+            row = (
+                await session.execute(
+                    select(ApiCall).where(
+                        ApiCall.project_name == "demo",
+                        ApiCall.model == "claude-sonnet-4",
+                        ApiCall.prompt == "hello assistant",
+                    )
+                )
+            ).scalar_one()
+
+        assert row.project_name == "demo"
+        assert row.user_id == "assistant-user"
+        assert row.provider == "anthropic"
+        assert row.call_type == "text"
+        assert row.model == "claude-sonnet-4"
+        assert row.prompt == "hello assistant"
+        assert row.input_tokens == 1050
+        assert row.output_tokens == 200
+        assert row.usage_tokens == 1250
+        assert row.cost_amount == pytest.approx(0.1234)
+        assert row.currency == "USD"
+        refreshed = await meta_store.get(meta.id)
+        assert refreshed is not None
+        assert refreshed.status == "completed"
+
+    async def test_finalize_turn_preserves_sdk_cost_for_failed_status(self, session_manager, meta_store):
+        meta = await meta_store.create("demo", "sdk-usage-failed-789")
+        managed = _make_managed(session_id=meta.id, project_name="demo", assistant_model="claude-sonnet-4")
+        managed.last_user_prompt = "failed but billed"
+
+        await session_manager._finalize_turn(
+            managed,
+            {
+                "type": "result",
+                "session_status": "error",
+                "model": "claude-sonnet-4",
+                "total_cost_usd": 0.0456,
+                "usage": {"input_tokens": 100, "output_tokens": 20},
+            },
+        )
+
+        async with meta_store._session_factory() as session:  # noqa: SLF001 - test fixture exposes shared DB factory
+            row = (
+                await session.execute(
+                    select(ApiCall).where(
+                        ApiCall.project_name == "demo",
+                        ApiCall.model == "claude-sonnet-4",
+                        ApiCall.prompt == "failed but billed",
+                    )
+                )
+            ).scalar_one()
+
+        assert row.status == "failed"
+        assert row.cost_amount == pytest.approx(0.0456)
+        assert row.currency == "USD"
+        refreshed = await meta_store.get(meta.id)
+        assert refreshed is not None
+        assert refreshed.status == "error"
+
+    async def test_finalize_turn_uses_model_usage_cost_when_total_cost_missing(self, session_manager, meta_store):
+        meta = await meta_store.create("demo", "sdk-model-usage-cost-789")
+        managed = _make_managed(session_id=meta.id, project_name="demo", assistant_model="claude-sonnet-4")
+        managed.last_user_prompt = "model usage cost"
+
+        await session_manager._finalize_turn(
+            managed,
+            {
+                "type": "result",
+                "session_status": "completed",
+                "model": "claude-sonnet-4",
+                "usage": {"input_tokens": 100, "output_tokens": 20},
+                "model_usage": {
+                    "claude-sonnet-4": {"costUSD": "0.0123"},
+                    "claude-haiku-4-5": {"costUSD": 0.0045},
+                },
+            },
+        )
+
+        async with meta_store._session_factory() as session:  # noqa: SLF001 - test fixture exposes shared DB factory
+            row = (
+                await session.execute(
+                    select(ApiCall).where(
+                        ApiCall.project_name == "demo",
+                        ApiCall.model == "claude-sonnet-4",
+                        ApiCall.prompt == "model usage cost",
+                    )
+                )
+            ).scalar_one()
+
+        assert row.cost_amount == pytest.approx(0.0168)
+        assert row.currency == "USD"
+
+    async def test_finalize_turn_uses_model_usage_tokens_when_usage_missing(self, session_manager, meta_store):
+        meta = await meta_store.create("demo", "sdk-model-usage-tokens-789")
+        managed = _make_managed(session_id=meta.id, project_name="demo")
+        managed.last_user_prompt = "model usage tokens"
+
+        await session_manager._finalize_turn(
+            managed,
+            {
+                "type": "result",
+                "session_status": "completed",
+                "model_usage": {
+                    "claude-sonnet-4": {
+                        "inputTokens": 100,
+                        "outputTokens": 20,
+                        "cacheCreationInputTokens": 30,
+                        "cacheReadInputTokens": 40,
+                        "costUSD": 0.0123,
+                    }
+                },
+            },
+        )
+
+        async with meta_store._session_factory() as session:  # noqa: SLF001 - test fixture exposes shared DB factory
+            row = (
+                await session.execute(
+                    select(ApiCall).where(
+                        ApiCall.project_name == "demo",
+                        ApiCall.model == "claude-sonnet-4",
+                        ApiCall.prompt == "model usage tokens",
+                    )
+                )
+            ).scalar_one()
+
+        assert row.input_tokens == 170
+        assert row.output_tokens == 20
+        assert row.usage_tokens == 190
+        assert row.cost_amount == pytest.approx(0.0123)
+
+    async def test_finalize_turn_usage_failure_does_not_override_status(self, session_manager, meta_store, monkeypatch):
+        meta = await meta_store.create("demo", "sdk-usage-error-789")
+        managed = _make_managed(session_id=meta.id, project_name="demo")
+        called = False
+
+        async def _raise_usage_error(*_args, **_kwargs):
+            nonlocal called
+            called = True
+            raise RuntimeError("usage db unavailable")
+
+        monkeypatch.setattr(session_manager, "_record_assistant_usage", _raise_usage_error)
+
+        await session_manager._finalize_turn(
+            managed,
+            {"type": "result", "session_status": "completed", "model": "claude-sonnet-4", "usage": {"input_tokens": 1}},
+        )
+
+        assert called is True
+        refreshed = await meta_store.get(meta.id)
+        assert refreshed is not None
+        assert refreshed.status == "completed"
+
+    async def test_extract_text_token_usage_accepts_numeric_strings(self, session_manager):
+        input_tokens, output_tokens, usage_tokens = session_manager._extract_text_token_usage(
+            {
+                "usage": {
+                    "input_tokens": "1000.0",
+                    "output_tokens": "200",
+                    "cache_read_input_tokens": 50.0,
+                }
+            }
+        )
+
+        # input_tokens includes prompt cache read/creation tokens for aggregate reporting.
+        assert input_tokens == 1050
+        assert output_tokens == 200
+        assert usage_tokens == 1250
+
+    async def test_extract_text_token_usage_preserves_missing_as_none(self, session_manager):
+        input_tokens, output_tokens, usage_tokens = session_manager._extract_text_token_usage(
+            {"usage": {"input_tokens": None, "output_tokens": "not-a-number"}}
+        )
+
+        assert input_tokens is None
+        assert output_tokens is None
+        assert usage_tokens is None
+
+    async def test_extract_assistant_cost_rejects_invalid_values(self, session_manager):
+        assert session_manager._extract_assistant_cost({"total_cost_usd": -1}) is None
+        assert session_manager._extract_assistant_cost({"total_cost_usd": "nan"}) is None
+        assert session_manager._extract_assistant_cost({"model_usage": {"m": {"costUSD": -0.1}}}) is None
+
+    async def test_extract_text_token_usage_rejects_invalid_values(self, session_manager):
+        assert session_manager._extract_text_token_usage({"usage": {"input_tokens": "inf"}}) == (None, None, None)
+        assert session_manager._extract_text_token_usage({"usage": {"input_tokens": "1.9"}}) == (None, None, None)
+        assert session_manager._extract_text_token_usage({"usage": {"input_tokens": 1.9}}) == (None, None, None)
+        assert session_manager._extract_text_token_usage({"model_usage": {"m": {"inputTokens": float("nan")}}}) == (
+            None,
+            None,
+            None,
+        )
 
     async def test_on_sdk_session_id_received_noop_when_already_registered(self, session_manager, meta_store):
         """For sessions with resolved_sdk_id already set, it's a no-op."""


### PR DESCRIPTION
## 范围

- 记录 Claude Agent SDK assistant 会话的文本 usage 与成本。
- 更新 UsageDrawer 的文本 token 展示，让 assistant 文本调用能显示明细总 token，能显示费用成本。

## 变更

- 在 assistant turn finalize 时记录 Anthropic text usage，包含 input/output/total tokens、prompt 摘要、模型名和 SDK 上报成本。
- 优先使用 SDK `total_cost_usd`，缺失时从 `model_usage[*].costUSD` 汇总；`usage` 缺失时从 `model_usage` 聚合 token。
- 将 cache creation/read tokens 计入 prompt-side input tokens，保持 aggregate token 统计完整。
- 为 Anthropic text 调用增加本地 token 费率兜底；provider 上报成本存在时优先使用上报值。
- 允许 usage repository 接收 provider-reported cost/currency，并保持统计聚合只计算 success 调用。
- 补充 assistant usage、Anthropic 成本计算、SDK tool project usage context 和前端 store 的测试覆盖。

## 验收清单

- [x] 本地已跑相关测试：`conda run -n arcreel python -m pytest tests/test_session_manager_sdk_session_id.py tests/test_cost_calculator.py tests/test_usage_repo.py tests/server/agent_runtime/test_sdk_tools.py`
- [x] 本地已跑 Python lint/format：`conda run -n arcreel python -m ruff check server/agent_runtime/session_manager.py tests/test_session_manager_sdk_session_id.py && conda run -n arcreel python -m ruff format --check server/agent_runtime/session_manager.py tests/test_session_manager_sdk_session_id.py`
- [x] 本地已跑类型检查：`conda run -n arcreel python -m basedpyright`
- [x] 本地已跑前端检查：`cd frontend && pnpm lint && pnpm check`
- [x] 手动验证了改动所声称的行为：复核 SDK 文档字段、最终 diff、compare 页面可自动合并
- [x] 新增面向用户文案已加 zh/en/vi 翻译
- [x] 无新增 ESLint disable
- [ ] CODEOWNERS 要求的 review 已请求

## 已知 defer

无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支持 Anthropic（Claude）文本 token 计费与记录
  * 在调用记录中可显式写入成本金额与货币

* **改进**
  * 优化使用量抽屉中 token 展示逻辑与本地化后缀（新增 tokens_suffix）
  * 会话结束流程增加助理侧使用量与费用记录，改进归因与容错

* **测试**
  * 增加针对 Anthropic 计费与会话记录/解析的单元测试覆盖

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->