### PR TITLE
docs(adr): 校验守卫点决策记录 (ADR-0002 不更坏语义 + ADR-0003 Agent JSON 工具)

### DIFF
--- a/docs/adr/0002-save-validation-no-worse-semantics.md
+++ b/docs/adr/0002-save-validation-no-worse-semantics.md
@@ -1,0 +1,16 @@
+---
+status: proposed
+---
+
+# 剧本保存校验采用「不更坏」语义，资产回写热路径豁免
+
+剧本结构校验（`segment`/`scene`/`unit` 形状、`duration` 范围、必填字段）此前被抽成纯函数后只在归档边界被调用，写盘路径完全不校验——脏数据写时不报、`load_script` 只 `json.load` 也不报，要到 worker 深处解析时才炸。我们决定把这个结构校验器（一处纯函数定义）前移到 Python 写盘咽喉 `_write_script_unlocked`，但**不**采用「永远严格 raise」：写入仅在「改前合法 ∧ 改后非法」时才拒绝（本次写入引入了新的结构错误），改前就已非法的遗留旧剧本照常放行；同时只动 `generated_assets` 的资产回写热路径（`update_scene_asset` / `batch_update_scene_assets` / `update_character_sheet` / 参考视频任务回写）**完全跳过**校验。校验对象是结构层 Pydantic 模型（按 `generation_mode`/顶层键选 `Narration`/`Drama`/`ReferenceVideoScript`），**不是** FS 感知的 `DataValidator`——后者会读磁盘、并拒绝合法的半成品草稿（分镜图尚未生成）。
+
+## Consequences
+
+- 保存有时会接受一个已非法的剧本（改前就坏）。这是刻意的：守卫的职责是「不让本次编辑把脏数据带进系统」，而非为 schema 演进产生的历史遗留背锅；否则用户编辑一个「写入时合法、不满足现行 schema」的旧剧本会突然吃 400，且非因本次编辑非法。`load_script` 不前置 `before` 时（如直连 `save_script` 的 normalize）产出的是完整重算脚本，严格校验即可。
+- 资产回写路径跳过校验，意味着 worker 给一个遗留非法剧本贴 `generated_assets` 不会被连带拖死。理由是性能 + 语义：这些是高频热路径、只写 `SkipJsonSchema` 运行时字段，结构不可能因此变坏，没必要每次校验整脚本。
+- 校验失败在**写时**当场暴露（人工路径返回错误），而非排队后在执行层才炸。
+- 剧本/`project.json` 共有三个写入面：Python API（`save_script` 等，本 ADR 覆盖）、Agent 生成工具（`text_generation`→`ScriptGenerator`，生成时已 Pydantic 校验）、**Agent 裸 `Write`/`Edit`**。最后一面今天只过 PreToolUse 的 JSON 语法 hook（`json.loads` + 弯引号），结构错误照样落盘、绕开本 ADR 的咽喉。已决定将其**收归 ProjectManager**：deny Agent 对 `scripts/*.json` + `project.json` 的裸 `Write`/`Edit`，改由走 `_write_script_unlocked` 的工具承接，使结构校验真正只有一个强制点。该替代 affordance（粒度/协议/profile 调整/精确 deny 范围/工具侧 raw write 的处理）作为独立功能另行设计，本 ADR 暂不展开。
+- **不要把它"收紧成永远严格 raise"**：那会让编辑旧剧本回归 400、并给热路径回写加上每次全量校验的开销——这两点正是本决策刻意规避的。
+- 与入队侧的校验是两条独立轴：本 ADR 管「写盘」，入队侧的结构校验（provider-agnostic）与能力校验（duration↔supported_durations，执行时解析，见 `docs/adr/0001` 原则）另行落地，依赖 provider 解析收敛（#599）先行。

--- a/docs/adr/0003-agent-project-json-edits-via-tools.md
+++ b/docs/adr/0003-agent-project-json-edits-via-tools.md
@@ -9,7 +9,7 @@ Agent 今天能用裸 `Write`/`Edit`（甚至 Bash 的 `echo>`/`sed`/`python -c`
 工具集（均为 in-process MCP `arcreel`，跑在 server 进程、不在 agent sandbox 内）：
 
 - `patch_episode_script` — 通用字段编辑，**按 `segment_id`/`scene_id`/`unit_id` 定位**（与 `update_scene_asset` 一致；序号仅生成时约定，运行时排序靠数组位，compose/`resolve_episode_from_script` 都不解析序号），三种内容/生成模式通用。纯 setter。
-- `insert_segment` / `remove_segment` / `split_segment` — 结构性增删拆，三模式全覆盖（reference 模式作用于 `video_units`/`shots`）。**id 稳定不重排**，插入/拆分用 `E{集}S{序号}_{子序号}` 形态发新 id。
+- `insert_segment` / `remove_segment` / `split_segment` — 结构性增删拆，三模式全覆盖（reference 模式作用于 `video_units`/`shots`）。**id 稳定不重排**，插入/拆分**按模式**发新 id 并加 `_{子序号}` 后缀：narration/drama 的 segments/scenes 用 `E{集}S{序号}`、reference 的 units 用 `E{集}U{序号}`（见 `script_models.py` 的 `segment_id`/`scene_id`/`unit_id` 定义；前缀不能统一成 `S`，否则 reference 走 Pydantic 校验会失败）。
 - `patch_project` — `project.json` 加+改（按 table+name），**取代** `add_assets.py`（删除该脚本，`analyze-assets` subagent 改调本工具，顺带消灭其脆弱的单行 CLI-JSON 调用）。
 - `generate_episode_script` — 整集生成，改为**经 `_write_script_unlocked` 写盘**（替代 `ScriptGenerator` 原先的裸 `json.dump`）。
 
@@ -23,7 +23,7 @@ Agent 今天能用裸 `Write`/`Edit`（甚至 Bash 的 `echo>`/`sed`/`python -c`
 - in-process MCP 工具跑在 server 进程、**不在 agent sandbox 内**，故 FS write-deny profile 不约束它们，工具照常写盘；删掉 `add_assets.py` 后，sandbox 内已**无任何合法的 Bash 写 `scripts/*.json`/`project.json`**（`split_episode` 写 `source/`、compose 写视频输出，均不碰），内核级 write-deny 不会误伤。
 - **Windows 无 sandbox**：内核级堵法不可用，回退到 `_check_write_access` deny（Write/Edit）+ 现有 `_WINDOWS_BASH_PREFIX_WHITELIST`（只放行 `python .claude/skills/`、ffmpeg、ffprobe，任意 `echo>`/`sed` 本就不在白名单）。Bash 旁路在 Windows 天然关闭。
 - **实现首要验证项**：ArcReel 现在的 sandbox `denyRead` 走的是未文档化 passthrough；write-deny 须按文档用声明式 Edit-deny 规则，**需实测确认 SDK 把该规则下推到 sandbox 的 Bash FS profile**。若实测不下推，Bash 旁路在 Linux/macOS 仍开，需另寻 Bash 层封堵或显式记为残留风险。
-- **`patch` 不作废 `generated_assets`**（纯字段 setter）。系统无新鲜度/陈旧检测（`status` 仅由路径有无算出），故改了 `image_prompt` 又不重生时，会出现「新 prompt + 旧图 + status=completed」的静默陈旧。这是刻意取舍：场景本就是「改 prompt **并**重新生成」，regen 会覆盖资产；自动作废需在 patch 里硬编码字段→资产依赖链，且可能误删用户想留的图。代价由 agent profile 的「改 prompt 必重生」纪律 + 本 ADR 承接。
+- **`patch` 不作废 `generated_assets`**（纯字段 setter）。系统无新鲜度/陈旧检测（`status` 仅由路径有无算出），故改了 `image_prompt` 又不重生时，会出现「新 prompt + 旧图 + status=completed」的静默陈旧。这是刻意取舍：场景本就是「改 prompt **并**重新生成」，regen 会覆盖资产；自动作废需在 patch 里硬编码字段→资产依赖链，且可能误删用户想留的图。代价由 agent profile 的「改 prompt 必重生」纪律 + 本 ADR 承接。一个更轻的备选是改关键字段时把 `generated_assets.status` 重置为 `pending`（不删路径）——**不采纳**：剧本 JSON 编辑与资产生命周期**解耦**，patch 不对资产状态作任何声明，资产的生成/重生是独立的显式动作。
 - **结构工具（split/remove）清受影响分镜的 `generated_assets`**：与字段编辑相反，结构改动改变了分镜身份（`E1S3` 拆成两个，旧资产无合理归属），故必须清空使其退回 pending。
 - 工具**返回文本**是 agent-facing（免 i18n）；工具**显示名**是 user-facing，须在 `ARCREEL_MCP_TOOL_IDS` 注册并补 `tool_name_<id>` 三语（zh/en/vi）。
-- 与 ADR-0002 同源：本 ADR 是其「Agent 裸写入面收归」承诺的兑现。reference_video 切分的精确语义（切 unit 还是切 shots）留作实现细节，约束是结果必须满足 `ReferenceVideoUnit` 的 `duration==sum(shots)` 校验（由 funnel 自动兜住）。
+- 与 ADR-0002 同源：本 ADR 是其「Agent 裸写入面收归」承诺的兑现。reference_video 切分的精确语义（切 unit 还是切 shots）留作实现细节，约束是结果必须满足 `ReferenceVideoUnit` 的 `duration==sum(shots)` 校验。**注意**：`_write_script_unlocked` 今天只对 `segments`/`scenes` 做校验 dispatch 与统计（`video_units` 会落入 segments 兜底分支、`total_scenes` 错算），所以「由 funnel 兜住」reference **不是现状自动成立的**——需先把该函数扩展到识别 `video_units`（校验 dispatch + 统计），属 #604 的实现任务。

--- a/docs/adr/0003-agent-project-json-edits-via-tools.md
+++ b/docs/adr/0003-agent-project-json-edits-via-tools.md
@@ -1,0 +1,29 @@
+---
+status: proposed
+---
+
+# Agent 改项目 JSON 数据收归 in-process MCP 工具，裸 Write/Edit/Bash 一律 deny
+
+Agent 今天能用裸 `Write`/`Edit`（甚至 Bash 的 `echo>`/`sed`/`python -c`）直改 `scripts/*.json` 与 `project.json`，只过一个 PreToolUse 的 **JSON 语法** hook——结构错误（`duration_seconds` 越界、缺 `image_prompt`、`ReferenceVideoUnit` 的 shots↔duration 不一致）照样落盘，绕开 `_write_script_unlocked` 咽喉（ADR-0002）。这条旁路让「单一守卫点」是假的。我们决定把 Agent 对项目 JSON 数据的一切写入收归一组 in-process MCP 工具，并在工具外**禁止**裸字节写入这两类文件，使 ADR-0002 的结构校验真正只有一个强制点。
+
+工具集（均为 in-process MCP `arcreel`，跑在 server 进程、不在 agent sandbox 内）：
+
+- `patch_episode_script` — 通用字段编辑，**按 `segment_id`/`scene_id`/`unit_id` 定位**（与 `update_scene_asset` 一致；序号仅生成时约定，运行时排序靠数组位，compose/`resolve_episode_from_script` 都不解析序号），三种内容/生成模式通用。纯 setter。
+- `insert_segment` / `remove_segment` / `split_segment` — 结构性增删拆，三模式全覆盖（reference 模式作用于 `video_units`/`shots`）。**id 稳定不重排**，插入/拆分用 `E{集}S{序号}_{子序号}` 形态发新 id。
+- `patch_project` — `project.json` 加+改（按 table+name），**取代** `add_assets.py`（删除该脚本，`analyze-assets` subagent 改调本工具，顺带消灭其脆弱的单行 CLI-JSON 调用）。
+- `generate_episode_script` — 整集生成，改为**经 `_write_script_unlocked` 写盘**（替代 `ScriptGenerator` 原先的裸 `json.dump`）。
+
+强制（双层）：
+
+- 声明式 **Edit-deny 规则**（`scripts/*.json` + `project.json`）。SDK 文档：sandbox 的文件**写**限制由 Edit allow/deny 规则派生为内核级 FS profile，对 sandbox 内**所有子进程（含 Bash）生效**——一个机制同时堵住裸 Write/Edit 与 Bash 写入。
+- 剧本写入全 funnel 进 `_write_script_unlocked`：继承 ADR-0002 的「不更坏」语义 + metadata 重算（`total_scenes`/`estimated_duration_seconds`）+ 加锁 + filename↔episode 一致性。`project.json` 走 `update_project(_mutate)` + `validate_project`。
+
+## Consequences
+
+- in-process MCP 工具跑在 server 进程、**不在 agent sandbox 内**，故 FS write-deny profile 不约束它们，工具照常写盘；删掉 `add_assets.py` 后，sandbox 内已**无任何合法的 Bash 写 `scripts/*.json`/`project.json`**（`split_episode` 写 `source/`、compose 写视频输出，均不碰），内核级 write-deny 不会误伤。
+- **Windows 无 sandbox**：内核级堵法不可用，回退到 `_check_write_access` deny（Write/Edit）+ 现有 `_WINDOWS_BASH_PREFIX_WHITELIST`（只放行 `python .claude/skills/`、ffmpeg、ffprobe，任意 `echo>`/`sed` 本就不在白名单）。Bash 旁路在 Windows 天然关闭。
+- **实现首要验证项**：ArcReel 现在的 sandbox `denyRead` 走的是未文档化 passthrough；write-deny 须按文档用声明式 Edit-deny 规则，**需实测确认 SDK 把该规则下推到 sandbox 的 Bash FS profile**。若实测不下推，Bash 旁路在 Linux/macOS 仍开，需另寻 Bash 层封堵或显式记为残留风险。
+- **`patch` 不作废 `generated_assets`**（纯字段 setter）。系统无新鲜度/陈旧检测（`status` 仅由路径有无算出），故改了 `image_prompt` 又不重生时，会出现「新 prompt + 旧图 + status=completed」的静默陈旧。这是刻意取舍：场景本就是「改 prompt **并**重新生成」，regen 会覆盖资产；自动作废需在 patch 里硬编码字段→资产依赖链，且可能误删用户想留的图。代价由 agent profile 的「改 prompt 必重生」纪律 + 本 ADR 承接。
+- **结构工具（split/remove）清受影响分镜的 `generated_assets`**：与字段编辑相反，结构改动改变了分镜身份（`E1S3` 拆成两个，旧资产无合理归属），故必须清空使其退回 pending。
+- 工具**返回文本**是 agent-facing（免 i18n）；工具**显示名**是 user-facing，须在 `ARCREEL_MCP_TOOL_IDS` 注册并补 `tool_name_<id>` 三语（zh/en/vi）。
+- 与 ADR-0002 同源：本 ADR 是其「Agent 裸写入面收归」承诺的兑现。reference_video 切分的精确语义（切 unit 还是切 shots）留作实现细节，约束是结果必须满足 `ReferenceVideoUnit` 的 `duration==sum(shots)` 校验（由 funnel 自动兜住）。


### PR DESCRIPTION
## 内容

本分支携带两条决策记录（ADR），记录「校验单一守卫点」走查的定案，独立于实现先合 main。

- **ADR-0002** — 剧本保存校验「不更坏」语义，资产回写热路径豁免。对应保存线 PRD #601。
- **ADR-0003** — Agent 改项目 JSON 数据收归 in-process MCP 工具，裸 `Write`/`Edit`/Bash 一律 deny；通用 patch（按 id）+ 结构工具（insert/remove/split）+ `patch_project`（取代 `add_assets.py`）+ `generate_episode_script` 收编咽喉。对应 PRD #604。

两者均为 `status: proposed`：决策已定、待实现验证后翻 accepted（ADR-0003 的 M4 声明式 Edit-deny → sandbox 内核级 Bash 封堵需实测确认 SDK 下推）。

## 排序

- 保存线 **#601** 独立可先做。
- **#604**（Agent 工具）实现排在 #601 之后——其剧本工具 funnel 进 #601 的 `_write_script_unlocked`「不更坏」咽喉。
- 入队线 **#602** 阻塞于 #599。

仅文档，无代码。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 新增两份架构决策文档：明确脚本保存阶段的结构校验语义与放行条件，避免因 schema 演进误拒旧数据；同时规定 Agent 对项目脚本与项目元数据的写入需通过受控的进程内工具链执行，禁止裸写入/外部子进程直接修改，以统一校验入口并强化数据一致性与回退策略。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->