### PR TITLE
refactor(project_manager): 剧本保存校验单一守卫点（「不更坏」语义）

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -15,6 +15,7 @@ MESSAGES = {
     "scene_not_found": "Scene '{id}' does not exist",
     "segment_not_found": "Segment '{id}' does not exist",
     "script_missing": "Script does not exist",
+    "script_validation_failed": "Script structure validation failed: {details}",
     "narration_mode_required": "This script is not in narration mode, please use the scene update interface",
     "content_or_file_required": "Please provide either content or file",
     "one_of_content_or_file": "Cannot provide both content and file, please choose one",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -15,6 +15,7 @@ MESSAGES = {
     "scene_not_found": "Cảnh '{id}' không tồn tại",
     "segment_not_found": "Đoạn '{id}' không tồn tại",
     "script_missing": "Kịch bản không tồn tại",
+    "script_validation_failed": "Xác thực cấu trúc kịch bản thất bại: {details}",
     "narration_mode_required": "Kịch bản này không ở chế độ thuyết minh, vui lòng dùng API cập nhật cảnh",
     "content_or_file_required": "Vui lòng cung cấp nội dung hoặc tệp",
     "one_of_content_or_file": "Không thể đồng thời cung cấp nội dung và tệp, vui lòng chọn một",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -15,6 +15,7 @@ MESSAGES = {
     "scene_not_found": "场景 '{id}' 不存在",
     "segment_not_found": "片段 '{id}' 不存在",
     "script_missing": "剧本不存在",
+    "script_validation_failed": "剧本结构校验失败：{details}",
     "narration_mode_required": "该剧本不是说书模式，请使用场景更新接口",
     "content_or_file_required": "需要提供 content（文本内容）或 file（文件上传）其中之一",
     "one_of_content_or_file": "content 和 file 不能同时提供，请选择其一",

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field
 
 from lib.agent_profile import agent_profile_dir
 from lib.asset_types import ASSET_SPECS
-from lib.json_io import atomic_write_json, load_json
+from lib.json_io import atomic_write_json, load_json, load_json_or_none
 from lib.profile_manifest import (
     VALID_CONTENT_MODES,
     ContentMode,
@@ -654,13 +654,7 @@ class ProjectManager:
     @staticmethod
     def _load_script_or_none(path: Path) -> dict | None:
         """裸读剧本 JSON 取「改前」快照；文件不存在或损坏时返回 None（→ 按严格校验处理）。"""
-        if not path.exists():
-            return None
-        try:
-            with open(path, encoding="utf-8") as f:  # noqa: PTH123
-                loaded = json.load(f)
-        except (OSError, json.JSONDecodeError):
-            return None
+        loaded = load_json_or_none(path)
         return loaded if isinstance(loaded, dict) else None
 
     @staticmethod

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -4,6 +4,7 @@
 管理视频项目的目录结构、分镜剧本读写、状态追踪。
 """
 
+import copy
 import json
 import logging
 import os
@@ -44,6 +45,13 @@ PROJECT_SLUG_SANITIZER = re.compile(r"[^a-zA-Z0-9]+")
 
 _VALID_GENERATION_MODES = {"storyboard", "grid", "reference_video"}
 _DEFAULT_GENERATION_MODE = "storyboard"
+
+
+class _Unset:
+    """哨兵：区分「未传 before」（写盘咽喉自行读盘取改前）与「显式传 None」（无改前）。"""
+
+
+_UNSET = _Unset()
 
 
 def effective_mode(*, project: dict, episode: dict) -> str:
@@ -440,7 +448,9 @@ class ProjectManager:
 
         return script
 
-    def save_script(self, project_name: str, script: dict, filename: str | None = None) -> Path:
+    def save_script(
+        self, project_name: str, script: dict, filename: str | None = None, *, validate: bool = True
+    ) -> Path:
         """
         保存分镜剧本
 
@@ -448,6 +458,8 @@ class ProjectManager:
             project_name: 项目名称
             script: 剧本字典
             filename: 可选的文件名，默认使用章节名
+            validate: 是否做「不更坏」结构校验（默认 True，fail-safe）。直连保存不持有
+                改前剧本，由写盘咽喉按需读盘取改前（已存在则不更坏，全新保存则严格校验）。
 
         Returns:
             保存的文件路径
@@ -460,9 +472,18 @@ class ProjectManager:
             filename = f"{chapter.replace(' ', '_')}_script.json"
 
         with self._script_lock(project_name, filename):
-            return self._write_script_unlocked(project_name, script, filename)
+            return self._write_script_unlocked(project_name, script, filename, validate=validate)
 
-    def _write_script_unlocked(self, project_name: str, script: dict, filename: str, sync_project: bool = True) -> Path:
+    def _write_script_unlocked(
+        self,
+        project_name: str,
+        script: dict,
+        filename: str,
+        sync_project: bool = True,
+        *,
+        validate: bool = True,
+        before: dict | None | _Unset = _UNSET,
+    ) -> Path:
         """剧本写盘主体：校验 + 更新元数据 + 原子写 + 同步 project.json。
 
         **不获取 `_script_lock`**——调用方必须已持有该锁（见 `save_script` / `locked_script`），
@@ -473,11 +494,24 @@ class ProjectManager:
         `sync_project=False` 时跳过 `sync_episode_from_script`：该同步会经 `update_project`
         再次获取 `_project_lock`，故已持有项目锁的调用方（见 `locked_episode_script`）须传 False
         以免同进程自死锁。仅写脚本内容、不改 episode 元数据的场景跳过同步无副作用。
+
+        `validate=True`（默认，fail-safe）时按「不更坏」语义做结构校验：仅当本次写入把一个
+        原本合法的剧本改成非法时才 `raise ScriptStructureValidationError`，改前就已非法的旧
+        剧本照常放行。读-改-写流程（`locked_script` 一族）已持有改前剧本，应作 `before` 传入
+        以零额外读盘；直连保存不传 `before`，由本函数按需读盘取改前（无改前则按严格校验）。
+        资产回写等只动 `generated_assets` 的热路径传 `validate=False` 整体豁免。
         """
         scripts_dir = self.get_project_path(project_name) / "scripts"
+        real = self._safe_subpath(scripts_dir, filename)
+        output_path = Path(real)
 
-        # 先做 filename/内部 episode 一致性校验，避免写盘后才在 sync 阶段抛错，
-        # 造成"脚本文件已落盘、project.json 未同步"的部分提交（codex 指出的原子性缺口）。
+        # 结构校验守卫（「不更坏」语义），置于落盘前，避免脏数据潜伏到 worker 执行层才暴露。
+        if validate:
+            before_script = self._load_script_or_none(output_path) if isinstance(before, _Unset) else before
+            self._guard_no_worse(before_script, script)
+
+        # 再做 filename/内部 episode 一致性校验，避免写盘后才在 sync 阶段抛错，
+        # 造成"脚本文件已落盘、project.json 未同步"的部分提交。
         self._require_filename_episode_consistency(script, filename)
 
         # 更新元数据（兼容旧脚本：可能缺少 metadata，或 narration 使用 segments）
@@ -515,10 +549,7 @@ class ProjectManager:
         total_duration = sum(item.get("duration_seconds", default_duration) for item in items)
         metadata["estimated_duration_seconds"] = total_duration
 
-        # 保存文件（含路径遍历防护）+ 原子写，避免并发 PATCH 导致 JSON 损坏
-        real = self._safe_subpath(scripts_dir, filename)
-        output_path = Path(real)
-
+        # 原子写（含路径遍历防护，output_path 已在守卫前解析），避免并发 PATCH 导致 JSON 损坏
         atomic_write_json(output_path, script)
 
         # 同步到 project.json，保证 script 写入与元数据同步是单一事务
@@ -534,18 +565,22 @@ class ProjectManager:
         return output_path
 
     @contextmanager
-    def locked_script(self, project_name: str, script_filename: str):
+    def locked_script(self, project_name: str, script_filename: str, *, validate: bool = True):
         """在单一 `_script_lock` 内完成剧本的 load → mutate → save 读-改-写。
 
         yield 出剧本字典供调用方就地修改；正常退出时写回，with 体内抛异常（如目标 scene/unit
         未找到）则跳过写回、照常释放锁。与 `update_project` 对称，消除"读改写之间被并发写覆盖"
         的 lost-update 竞态。
+
+        `validate=True`（默认）时在 yield 前快照「改前」剧本，写回走「不更坏」结构校验（零额外
+        读盘）。只动 `generated_assets` 的资产回写热路径传 `validate=False` 整体豁免。
         """
         norm = script_filename[len("scripts/") :] if script_filename.startswith("scripts/") else script_filename
         with self._script_lock(project_name, norm):
             script = self.load_script(project_name, norm)
+            before = copy.deepcopy(script) if validate else None
             yield script
-            self._write_script_unlocked(project_name, script, norm)
+            self._write_script_unlocked(project_name, script, norm, validate=validate, before=before)
 
     def _read_project_raw_unlocked(self, project_name: str) -> dict:
         """裸读 project.json（不取锁、不迁移）。仅供已持 `_project_lock` 的复核调用。"""
@@ -554,7 +589,9 @@ class ProjectManager:
             return json.load(f)
 
     @contextmanager
-    def locked_episode_script(self, project_name: str, resolve_script_file: Callable[[dict], str]):
+    def locked_episode_script(
+        self, project_name: str, resolve_script_file: Callable[[dict], str], *, validate: bool = True
+    ):
         """统一「脚本锁 → 项目锁」顺序下，解析 episode→script_file 并对剧本做读-改-写。
 
         `resolve_script_file(project) -> script_file`：调用方提供的解析器，从 project.json
@@ -580,8 +617,11 @@ class ProjectManager:
                 if cur_norm != norm:
                     raise EpisodeScriptReboundError(f"episode script binding changed: {norm} -> {cur_norm}")
                 script = self.load_script(project_name, norm)
+                before = copy.deepcopy(script) if validate else None
                 yield script
-                self._write_script_unlocked(project_name, script, norm, sync_project=False)
+                self._write_script_unlocked(
+                    project_name, script, norm, sync_project=False, validate=validate, before=before
+                )
                 # 在已持项目锁内联同步 project.json（等价 update_project 写路径，但不二次取锁）
                 if isinstance(script.get("episode"), int):
                     self._apply_episode_sync(project, script, norm)
@@ -610,6 +650,38 @@ class ProjectManager:
                 f"脚本 {base_name} 内部 episode={script_episode} 与文件名隐含的 "
                 f"episode={filename_episode} 不一致，拒绝操作以避免污染 project.json"
             )
+
+    @staticmethod
+    def _load_script_or_none(path: Path) -> dict | None:
+        """裸读剧本 JSON 取「改前」快照；文件不存在或损坏时返回 None（→ 按严格校验处理）。"""
+        if not path.exists():
+            return None
+        try:
+            with open(path, encoding="utf-8") as f:  # noqa: PTH123
+                loaded = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+        return loaded if isinstance(loaded, dict) else None
+
+    @staticmethod
+    def _guard_no_worse(before: dict | None, after: dict) -> None:
+        """「不更坏」守卫：仅当本次写入引入新结构错误时拒绝。
+
+        改后合法 → 放行；改后非法时：改前合法或无改前 → 拒绝（`raise`）；改前已非法 → 放行
+        （不为历史遗留背锅）。校验器经函数内延迟 import，打破 project_manager → 校验器 →
+        data_validator → project_manager 的导入环。
+        """
+        from lib.script_structure_validator import (
+            ScriptStructureValidationError,
+            validate_script_structure,
+        )
+
+        after_result = validate_script_structure(after)
+        if after_result.valid:
+            return
+        if before is not None and not validate_script_structure(before).valid:
+            return
+        raise ScriptStructureValidationError(after_result)
 
     @staticmethod
     def resolve_episode_from_script(script: dict, script_filename: str) -> int:
@@ -715,7 +787,8 @@ class ProjectManager:
 
     def update_character_sheet(self, project_name: str, script_filename: str, name: str, sheet_path: str) -> dict:
         """更新角色设计图路径"""
-        with self.locked_script(project_name, script_filename) as script:
+        # 资产回写热路径：只动运行时字段，结构不可能因此变坏，豁免结构校验。
+        with self.locked_script(project_name, script_filename, validate=False) as script:
             if name not in script["characters"]:
                 # 在锁内抛出，locked_script 跳过写回
                 raise KeyError(f"角色 '{name}' 不存在")
@@ -971,7 +1044,8 @@ class ProjectManager:
         Returns:
             更新后的剧本
         """
-        with self.locked_script(project_name, script_filename) as script:
+        # legacy helper：产出数字 scene_id 的旧结构 scene，与现行 Pydantic 模型不兼容，豁免结构校验。
+        with self.locked_script(project_name, script_filename, validate=False) as script:
             # 自动生成场景 ID
             existing_ids = [s["scene_id"] for s in script["scenes"]]
             next_id = f"{len(existing_ids) + 1:03d}"
@@ -1009,7 +1083,8 @@ class ProjectManager:
         Returns:
             更新后的剧本
         """
-        with self.locked_script(project_name, script_filename) as script:
+        # 资产回写热路径：只动 generated_assets，结构不可能因此变坏，豁免结构校验。
+        with self.locked_script(project_name, script_filename, validate=False) as script:
             # 根据内容模式选择正确的数据结构
             content_mode = script.get("content_mode", "narration")
             if content_mode == "narration" and "segments" in script:
@@ -1060,7 +1135,8 @@ class ProjectManager:
         if not updates:
             return {}
 
-        with self.locked_script(project_name, script_filename) as script:
+        # 资产回写热路径：只动 generated_assets，结构不可能因此变坏，豁免结构校验。
+        with self.locked_script(project_name, script_filename, validate=False) as script:
             content_mode = script.get("content_mode", "narration")
             if content_mode == "narration" and "segments" in script:
                 items = script["segments"]

--- a/lib/script_structure_validator.py
+++ b/lib/script_structure_validator.py
@@ -36,9 +36,9 @@ class ScriptStructureValidationError(ValueError):
 def _select_model(script: dict[str, Any]) -> type[BaseModel]:
     """按 generation_mode / content_mode / 顶层键判别该用哪个剧本模型。
 
-    判别顺序与 `ProjectManager._write_script_unlocked` 的模式分支保持一致，额外前置
-    reference 分支：generation_mode == "reference_video"（或存在 video_units）优先于
-    content_mode，即使 content_mode == "narration" 也走 ReferenceVideoScript。
+    reference 分支最优先：generation_mode == "reference_video"（或存在 video_units）压过
+    content_mode，即使 content_mode == "narration" 也走 ReferenceVideoScript。其余按
+    content_mode + 顶层键二分到 narration / drama。
     """
     if script.get("generation_mode") == "reference_video" or "video_units" in script:
         return ReferenceVideoScript

--- a/lib/script_structure_validator.py
+++ b/lib/script_structure_validator.py
@@ -1,0 +1,70 @@
+"""剧本结构校验器（纯函数）。
+
+把「一个剧本 dict 是否结构良构」这个判断收敛到唯一一处：喂入 dict、返回
+`ValidationResult`，不读磁盘、不依赖项目状态。写盘咽喉、测试、未来其它写入面都复用它。
+
+校验对象是结构层 Pydantic 模型（`lib.script_models`），而非 FS 感知的 `DataValidator`
+——后者会读磁盘并拒绝合法的半成品草稿（分镜图尚未生成）。模型已编码所有结构约束
+（必填、`duration_seconds` 范围、id 格式、prompt 形状、参考单元 shots↔duration 一致性），
+本校验器只负责「按模式选对模型」并把 Pydantic 的 `ValidationError` 转成 `ValidationResult`，
+不复制任何约束——模型变更即校验变更（单一真相源）。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+from pydantic_core import ErrorDetails
+
+from lib.data_validator import ValidationResult
+from lib.script_models import (
+    DramaEpisodeScript,
+    NarrationEpisodeScript,
+    ReferenceVideoScript,
+)
+
+
+class ScriptStructureValidationError(ValueError):
+    """剧本结构校验失败。携带 `ValidationResult`，供 router 转 i18n 4xx 响应。"""
+
+    def __init__(self, result: ValidationResult) -> None:
+        self.result = result
+        super().__init__("; ".join(result.errors) or "script structure invalid")
+
+
+def _select_model(script: dict[str, Any]) -> type[BaseModel]:
+    """按 generation_mode / content_mode / 顶层键判别该用哪个剧本模型。
+
+    判别顺序与 `ProjectManager._write_script_unlocked` 的模式分支保持一致，额外前置
+    reference 分支：generation_mode == "reference_video"（或存在 video_units）优先于
+    content_mode，即使 content_mode == "narration" 也走 ReferenceVideoScript。
+    """
+    if script.get("generation_mode") == "reference_video" or "video_units" in script:
+        return ReferenceVideoScript
+    content_mode = script.get("content_mode", "narration")
+    if content_mode == "narration" and script.get("segments"):
+        return NarrationEpisodeScript
+    if script.get("scenes"):
+        return DramaEpisodeScript
+    return NarrationEpisodeScript
+
+
+def _format_error(err: ErrorDetails) -> str:
+    loc = ".".join(str(part) for part in err.get("loc", ()))
+    msg = err.get("msg", "")
+    return f"{loc}: {msg}" if loc else str(msg)
+
+
+def validate_script_structure(script: dict[str, Any]) -> ValidationResult:
+    """校验剧本 dict 的结构是否良构，返回 `ValidationResult`。
+
+    纯函数：不读磁盘、不查文件引用、不查跨 project.json 的角色/场景名一致性
+    （那些是 `DataValidator.validate_project_tree` 的归档层职责）。
+    """
+    model = _select_model(script)
+    try:
+        model.model_validate(script)
+    except ValidationError as exc:
+        return ValidationResult(valid=False, errors=[_format_error(e) for e in exc.errors()])
+    return ValidationResult(valid=True)

--- a/lib/script_structure_validator.py
+++ b/lib/script_structure_validator.py
@@ -37,15 +37,19 @@ def _select_model(script: dict[str, Any]) -> type[BaseModel]:
     """按 generation_mode / content_mode / 顶层键判别该用哪个剧本模型。
 
     reference 分支最优先：generation_mode == "reference_video"（或存在 video_units）压过
-    content_mode，即使 content_mode == "narration" 也走 ReferenceVideoScript。其余按
-    content_mode + 顶层键二分到 narration / drama。
+    content_mode，即使 content_mode == "narration" 也走 ReferenceVideoScript。其余以
+    content_mode 为权威：drama → Drama、narration → Narration；content_mode 缺省时才按顶层键
+    存在性（而非列表真值）推断。用 "scenes" in script 而非 script.get("scenes") 真值，否则
+    空场景 drama（{"content_mode": "drama", "scenes": []}，结构合法）会被误判到 Narration 拒写。
     """
     if script.get("generation_mode") == "reference_video" or "video_units" in script:
         return ReferenceVideoScript
-    content_mode = script.get("content_mode", "narration")
-    if content_mode == "narration" and script.get("segments"):
+    content_mode = script.get("content_mode")
+    if content_mode == "drama":
+        return DramaEpisodeScript
+    if content_mode == "narration":
         return NarrationEpisodeScript
-    if script.get("scenes"):
+    if "scenes" in script and "segments" not in script:
         return DramaEpisodeScript
     return NarrationEpisodeScript
 

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -35,6 +35,7 @@ from lib.i18n import Translator
 from lib.profile_manifest import ContentMode
 from lib.project_change_hints import project_change_source
 from lib.project_manager import ProjectManager
+from lib.script_structure_validator import ScriptStructureValidationError
 from lib.status_calculator import StatusCalculator
 from lib.style_templates import is_known_template, resolve_template_prompt
 from server.auth import CurrentUser, create_download_token, verify_download_token
@@ -817,6 +818,11 @@ async def update_scene(name: str, scene_id: str, req: UpdateSceneRequest, _user:
         return await asyncio.to_thread(_sync)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=_t("script_not_found", name=req.script_file))
+    except ScriptStructureValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=_t("script_validation_failed", details="; ".join(exc.result.errors)),
+        )
     except HTTPException:
         raise
     except Exception as e:
@@ -888,6 +894,11 @@ async def update_segment(name: str, segment_id: str, req: UpdateSegmentRequest, 
         return await asyncio.to_thread(_sync)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=_t("script_not_found", name=req.script_file))
+    except ScriptStructureValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=_t("script_validation_failed", details="; ".join(exc.result.errors)),
+        )
     except HTTPException:
         raise
     except Exception as e:

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -821,7 +821,7 @@ async def update_scene(name: str, scene_id: str, req: UpdateSceneRequest, _user:
     except ScriptStructureValidationError as exc:
         raise HTTPException(
             status_code=422,
-            detail=_t("script_validation_failed", details="; ".join(exc.result.errors)),
+            detail=_t("script_validation_failed", details=str(exc)),
         )
     except HTTPException:
         raise
@@ -897,7 +897,7 @@ async def update_segment(name: str, segment_id: str, req: UpdateSegmentRequest, 
     except ScriptStructureValidationError as exc:
         raise HTTPException(
             status_code=422,
-            detail=_t("script_validation_failed", details="; ".join(exc.result.errors)),
+            detail=_t("script_validation_failed", details=str(exc)),
         )
     except HTTPException:
         raise

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -35,7 +35,6 @@ from lib.i18n import Translator
 from lib.profile_manifest import ContentMode
 from lib.project_change_hints import project_change_source
 from lib.project_manager import ProjectManager
-from lib.script_structure_validator import ScriptStructureValidationError
 from lib.status_calculator import StatusCalculator
 from lib.style_templates import is_known_template, resolve_template_prompt
 from server.auth import CurrentUser, create_download_token, verify_download_token
@@ -818,7 +817,9 @@ async def update_scene(name: str, scene_id: str, req: UpdateSceneRequest, _user:
         return await asyncio.to_thread(_sync)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=_t("script_not_found", name=req.script_file))
-    except ScriptStructureValidationError as exc:
+    except ValueError as exc:
+        # 结构校验失败、集号错配、非法文件名都抛 ValueError（ScriptStructureValidationError
+        # 即其子类）：统一转 422 客户端错误，避免落到下面的 500 兜底。
         raise HTTPException(
             status_code=422,
             detail=_t("script_validation_failed", details=str(exc)),
@@ -894,7 +895,9 @@ async def update_segment(name: str, segment_id: str, req: UpdateSegmentRequest, 
         return await asyncio.to_thread(_sync)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=_t("script_not_found", name=req.script_file))
-    except ScriptStructureValidationError as exc:
+    except ValueError as exc:
+        # 结构校验失败、集号错配、非法文件名都抛 ValueError（ScriptStructureValidationError
+        # 即其子类）：统一转 422 客户端错误，避免落到下面的 500 兜底。
         raise HTTPException(
             status_code=422,
             detail=_t("script_validation_failed", details=str(exc)),

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -19,6 +19,7 @@ from lib.generation_queue import get_generation_queue
 from lib.i18n import Translator
 from lib.project_manager import EpisodeScriptReboundError, ProjectManager, effective_mode
 from lib.reference_video import parse_prompt
+from lib.script_structure_validator import ScriptStructureValidationError
 from server.auth import CurrentUser
 
 logger = logging.getLogger(__name__)
@@ -115,6 +116,12 @@ def _locked_episode_script(project_name: str, resolver: Callable[[dict], str], _
     except EpisodeScriptReboundError as exc:
         logger.info("episode script rebound during write: %s", exc)
         raise HTTPException(status_code=409, detail=_t("ref_script_rebound")) from exc
+    except ScriptStructureValidationError as exc:
+        # 本次编辑把单元改成结构非法（如 shots↔duration 不一致）：当场转 422，而非生成时才炸
+        raise HTTPException(
+            status_code=422,
+            detail=_t("script_validation_failed", details="; ".join(exc.result.errors)),
+        ) from exc
 
 
 def _validate_references_exist(project: dict, refs: list[dict], _t: Translator) -> None:

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -120,7 +120,7 @@ def _locked_episode_script(project_name: str, resolver: Callable[[dict], str], _
         # 本次编辑把单元改成结构非法（如 shots↔duration 不一致）：当场转 422，而非生成时才炸
         raise HTTPException(
             status_code=422,
-            detail=_t("script_validation_failed", details="; ".join(exc.result.errors)),
+            detail=_t("script_validation_failed", details=str(exc)),
         ) from exc
 
 

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -19,7 +19,6 @@ from lib.generation_queue import get_generation_queue
 from lib.i18n import Translator
 from lib.project_manager import EpisodeScriptReboundError, ProjectManager, effective_mode
 from lib.reference_video import parse_prompt
-from lib.script_structure_validator import ScriptStructureValidationError
 from server.auth import CurrentUser
 
 logger = logging.getLogger(__name__)
@@ -116,8 +115,11 @@ def _locked_episode_script(project_name: str, resolver: Callable[[dict], str], _
     except EpisodeScriptReboundError as exc:
         logger.info("episode script rebound during write: %s", exc)
         raise HTTPException(status_code=409, detail=_t("ref_script_rebound")) from exc
-    except ScriptStructureValidationError as exc:
-        # 本次编辑把单元改成结构非法（如 shots↔duration 不一致）：当场转 422，而非生成时才炸
+    except ValueError as exc:
+        # 结构非法（如 shots↔duration 不一致）、集号错配、非法文件名都抛 ValueError
+        # （ScriptStructureValidationError 即其子类）：当场转 422，而非生成时才炸。
+        # EpisodeScriptReboundError(RuntimeError) 与 FileNotFoundError 不是 ValueError，
+        # 已被上面的 409 / 404 分支先行接住，不会落到这里。
         raise HTTPException(
             status_code=422,
             detail=_t("script_validation_failed", details=str(exc)),

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -321,7 +321,8 @@ async def execute_reference_video_task(
     #    避免与并发的 PATCH / 其他 unit 回写互相覆盖）
     def _update_unit_assets():
         pm = get_project_manager()
-        with pm.locked_script(project_name, script_file) as script:
+        # 资产回写热路径：只动 unit.generated_assets，结构不可能因此变坏，豁免结构校验。
+        with pm.locked_script(project_name, script_file, validate=False) as script:
             for u in script.get("video_units") or []:
                 if u.get("unit_id") == resource_id:
                     ga = u.setdefault("generated_assets", {})

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -332,7 +332,7 @@ async def test_execute_reference_video_task_clears_stale_video_uri_and_thumbnail
     live_script = json.loads(script_path.read_text(encoding="utf-8"))
 
     @contextmanager
-    def _locked_script(_name, _file):
+    def _locked_script(_name, _file, *, validate=True):
         yield live_script
 
     fake_pm = MagicMock()

--- a/tests/test_locked_episode_script_toctou.py
+++ b/tests/test_locked_episode_script_toctou.py
@@ -41,6 +41,7 @@ def _seed(pm: ProjectManager, name: str) -> None:
             "video_units": [],
         },
         "episode_1.json",
+        validate=False,  # 测锁/TOCTOU 用简化替身剧本，结构守卫不在本测试关注范围
     )
 
 
@@ -61,7 +62,7 @@ def test_locked_episode_script_no_relock_but_refreshes_project(tmp_path: Path, m
     calls: list[tuple] = []
     monkeypatch.setattr(pm, "sync_episode_from_script", lambda *a, **k: calls.append(a))
 
-    with pm.locked_episode_script(name, lambda _proj: "episode_1.json") as script:
+    with pm.locked_episode_script(name, lambda _proj: "episode_1.json", validate=False) as script:
         script["video_units"] = [{"unit_id": "E1U1", "generated_assets": {"status": "pending"}}]
 
     # 不调用会二次取项目锁的 sync_episode_from_script（否则自死锁）
@@ -88,7 +89,7 @@ def test_locked_episode_script_holds_project_lock_until_write_done(tmp_path: Pat
     t = threading.Thread(target=_other)
     t.start()
     try:
-        with pm.locked_episode_script(name, lambda _proj: "episode_1.json") as script:
+        with pm.locked_episode_script(name, lambda _proj: "episode_1.json", validate=False) as script:
             inside.set()  # 此刻已持脚本锁 + 项目锁
             time.sleep(0.3)
             assert not other_done.is_set(), "持项目锁期间 update_project 不应完成"
@@ -112,7 +113,7 @@ def test_locked_episode_script_detects_rebind(tmp_path: Path) -> None:
         return next(seq)
 
     with pytest.raises(EpisodeScriptReboundError):
-        with pm.locked_episode_script(name, _resolver) as script:
+        with pm.locked_episode_script(name, _resolver, validate=False) as script:
             script["video_units"] = [{"unit_id": "SHOULD_NOT_PERSIST"}]
 
     # 旧脚本未被写入（with 体未执行）
@@ -129,7 +130,7 @@ def test_locked_episode_script_no_self_deadlock(tmp_path: Path) -> None:
     done = threading.Event()
 
     def _run() -> None:
-        with pm.locked_episode_script(name, lambda _proj: "episode_1.json") as script:
+        with pm.locked_episode_script(name, lambda _proj: "episode_1.json", validate=False) as script:
             script.setdefault("video_units", []).append({"unit_id": "E1U1"})
         done.set()
 

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -41,6 +41,7 @@ class TestProjectEventService:
                     ],
                 },
                 "episode_1.json",
+                validate=False,  # 事件 diff 测试用简化替身剧本
             )
 
         service = ProjectEventService(tmp_path)
@@ -62,7 +63,7 @@ class TestProjectEventService:
         segment["generated_assets"]["storyboard_image"] = "storyboards/scene_E1S01.png"
         segment["generated_assets"]["status"] = "storyboard_ready"
         with project_change_source("filesystem"):
-            pm.save_script("demo", script, "episode_1.json")
+            pm.save_script("demo", script, "episode_1.json", validate=False)
 
         current = service._build_snapshot("demo")
         changes = service._diff_snapshots(previous, current)
@@ -103,6 +104,7 @@ class TestProjectEventService:
                     ],
                 },
                 "episode_1.json",
+                validate=False,  # 事件 diff 测试用简化替身剧本
             )
 
         service = ProjectEventService(tmp_path)
@@ -134,7 +136,7 @@ class TestProjectEventService:
             }
         )
         with project_change_source("filesystem"):
-            pm.save_script("demo", script, "episode_1.json")
+            pm.save_script("demo", script, "episode_1.json", validate=False)
 
         current = service._build_snapshot("demo")
         changes = service._diff_snapshots(previous, current)

--- a/tests/test_project_manager_compat.py
+++ b/tests/test_project_manager_compat.py
@@ -29,7 +29,7 @@ class TestProjectManagerCompatibility:
             ],
         }
 
-        pm.save_script(project_name, script, "episode_1.json")
+        pm.save_script(project_name, script, "episode_1.json", validate=False)  # 故意缺字段测元数据补全
         saved = pm.load_script(project_name, "episode_1.json")
 
         assert "metadata" in saved
@@ -46,7 +46,7 @@ class TestProjectManagerCompatibility:
             "segments": [{"segment_id": "E1S01"}],
         }
 
-        pm.save_script(project_name, script, "episode_1.json")
+        pm.save_script(project_name, script, "episode_1.json", validate=False)  # 故意缺字段测元数据补全
         saved = pm.load_script(project_name, "episode_1.json")
 
         assert saved["metadata"]["total_scenes"] == 1
@@ -59,7 +59,7 @@ class TestProjectManagerCompatibility:
             "scenes": [{"scene_id": "001"}],
         }
 
-        pm.save_script(project_name, script, "episode_1.json")
+        pm.save_script(project_name, script, "episode_1.json", validate=False)  # 故意缺字段测元数据补全
         saved = pm.load_script(project_name, "episode_1.json")
 
         assert saved["metadata"]["total_scenes"] == 1

--- a/tests/test_project_manager_concurrent_save.py
+++ b/tests/test_project_manager_concurrent_save.py
@@ -30,17 +30,29 @@ def _seed_project(pm: ProjectManager, name: str) -> None:
 
 
 def _make_script(episode: int, payload_size: int) -> dict:
-    """构造一个说书模式剧本，segment 数量决定 JSON 体积。"""
+    """构造一个结构合法的说书模式剧本，segment 数量决定 JSON 体积。"""
+    filler = "填充文本 " * (payload_size // 10 + 1)
     return {
         "episode": episode,
         "title": f"Episode {episode}",
         "content_mode": "narration",
+        "summary": "测试摘要",
+        "novel": {"title": "测试小说", "chapter": f"第{episode}章"},
         "segments": [
             {
                 "segment_id": f"E{episode}S{i}",
                 "duration_seconds": 4,
-                "image_prompt": "图像提示词 " * (payload_size // 10),
-                "video_prompt": "视频提示词 " * (payload_size // 10),
+                "novel_text": filler,
+                "characters_in_segment": ["角色A"],
+                "image_prompt": {
+                    "scene": filler,
+                    "composition": {"shot_type": "Medium Shot", "lighting": "暖光", "ambiance": "薄雾"},
+                },
+                "video_prompt": {
+                    "action": "转身",
+                    "camera_motion": "Static",
+                    "ambiance_audio": "风声",
+                },
             }
             for i in range(payload_size)
         ],

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -111,7 +111,7 @@ class TestProjectManagerMore:
             "content_mode": "narration",
             "segments": [{"segment_id": "E1S01", "duration_seconds": 4}],
         }
-        path = pm.save_script("demo", script, "episode_1.json")
+        path = pm.save_script("demo", script, "episode_1.json", validate=False)  # helper 测试用简化替身
         assert path.name == "episode_1.json"
 
         loaded = pm.load_script("demo", "episode_1.json")
@@ -129,7 +129,7 @@ class TestProjectManagerMore:
             "content_mode": "drama",
             "scenes": [],
         }
-        pm.save_script("demo", drama_script, "episode_2.json")
+        pm.save_script("demo", drama_script, "episode_2.json", validate=False)
         pm.add_scene("demo", "episode_2.json", {"duration_seconds": 8, "generated_assets": {}})
         loaded_drama = pm.load_script("demo", "episode_2.json")
         assert loaded_drama["scenes"][0]["scene_id"] == "001"
@@ -137,7 +137,7 @@ class TestProjectManagerMore:
         # update_scene_asset + pending helpers
         narration_script = pm.load_script("demo", "episode_1.json")
         narration_script["segments"][0]["generated_assets"] = {}
-        pm.save_script("demo", narration_script, "episode_1.json")
+        pm.save_script("demo", narration_script, "episode_1.json", validate=False)
 
         pm.update_scene_asset(
             "demo",
@@ -155,7 +155,7 @@ class TestProjectManagerMore:
         # get_scenes_needing_storyboard
         drama = pm.load_script("demo", "episode_2.json")
         drama["scenes"][0]["generated_assets"] = {"storyboard_image": None}
-        pm.save_script("demo", drama, "episode_2.json")
+        pm.save_script("demo", drama, "episode_2.json", validate=False)
         assert len(pm.get_scenes_needing_storyboard("demo", "episode_2.json")) == 1
 
         with pytest.raises(KeyError):
@@ -173,7 +173,7 @@ class TestProjectManagerMore:
             "content_mode": "drama",
             "scenes": [],
         }
-        pm.save_script("demo", drama_script, "episode_1.json")
+        pm.save_script("demo", drama_script, "episode_1.json", validate=False)
 
         # add_scene 未带 generated_assets：触发默认资产填充分支
         pm.add_scene("demo", "episode_1.json", {"duration_seconds": 6})
@@ -204,6 +204,7 @@ class TestProjectManagerMore:
                 ],
             },
             "episode_1.json",
+            validate=False,  # helper 测试用简化替身
         )
 
         # 空 updates 提前返回
@@ -233,6 +234,7 @@ class TestProjectManagerMore:
                 "segments": [{"segment_id": "E2S01", "duration_seconds": 4}],
             },
             "episode_2.json",
+            validate=False,
         )
         pm.batch_update_scene_assets("demo", "episode_2.json", [("E2S01", "storyboard_image", "sb/E2S01.png")])
         seg = pm.load_script("demo", "episode_2.json")["segments"][0]
@@ -253,6 +255,7 @@ class TestProjectManagerMore:
                 "scenes": [],
             },
             "episode_1.json",
+            validate=False,
         )
 
         pm.update_character_sheet("demo", "episode_1.json", "张三", "sheets/zhangsan.png")
@@ -276,8 +279,11 @@ class TestProjectManagerMore:
             "episode": 1,  # 与文件名 episode_10.json 错配
             "title": "第十集错误标题",
             "content_mode": "narration",
+            "summary": "摘要",
+            "novel": {"title": "小说", "chapter": "第一章"},
             "segments": [],
         }
+        # bad 结构合法（仅 episode 错配）：守卫放行后由一致性校验 fail-fast，验证守卫不误伤
         with pytest.raises(ValueError, match="不一致"):
             pm.save_script("demo", bad, "episode_10.json")
 
@@ -301,7 +307,7 @@ class TestProjectManagerMore:
             "content_mode": "narration",
             "segments": [{"segment_id": "E1S01", "duration_seconds": 4}],
         }
-        pm.save_script("demo", ep1, "episode_1.json")
+        pm.save_script("demo", ep1, "episode_1.json", validate=False)
 
         # 伪造错误脚本：文件名是 episode_10.json，但内部 episode=1（AI 幻觉场景）
         corrupted = {
@@ -335,7 +341,7 @@ class TestProjectManagerMore:
             "content_mode": "narration",
             "segments": [{"segment_id": "E1S01", "duration_seconds": 4, "generated_assets": {}}],
         }
-        pm.save_script("demo", script, "episode_1.json")
+        pm.save_script("demo", script, "episode_1.json", validate=False)
 
         # 纯文件名
         loaded1 = pm.load_script("demo", "episode_1.json")
@@ -347,7 +353,7 @@ class TestProjectManagerMore:
 
         # save_script 也应兼容带前缀的文件名
         script["title"] = "修改后"
-        pm.save_script("demo", script, "scripts/episode_1.json")
+        pm.save_script("demo", script, "scripts/episode_1.json", validate=False)
         loaded3 = pm.load_script("demo", "episode_1.json")
         assert loaded3["title"] == "修改后"
 

--- a/tests/test_project_manager_save_validation.py
+++ b/tests/test_project_manager_save_validation.py
@@ -1,0 +1,147 @@
+"""写盘咽喉「不更坏」结构校验守卫测试。
+
+只断言外部行为：构造 before/after 剧本，断言写盘是否 raise ScriptStructureValidationError，
+以及资产回写豁免、validate 默认值，不 patch 私有方法。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lib.project_manager import ProjectManager
+from lib.script_structure_validator import ScriptStructureValidationError
+
+
+def _segment(segment_id: str = "E1S01", duration: int = 4) -> dict:
+    return {
+        "segment_id": segment_id,
+        "duration_seconds": duration,
+        "novel_text": "原文",
+        "characters_in_segment": ["角色A"],
+        "image_prompt": {
+            "scene": "场景描述",
+            "composition": {"shot_type": "Medium Shot", "lighting": "暖光", "ambiance": "薄雾"},
+        },
+        "video_prompt": {"action": "转身", "camera_motion": "Static", "ambiance_audio": "风声"},
+    }
+
+
+def _valid_script(segments: list[dict] | None = None) -> dict:
+    return {
+        "episode": 1,
+        "title": "标题",
+        "content_mode": "narration",
+        "summary": "摘要",
+        "novel": {"title": "小说", "chapter": "第一章"},
+        "segments": segments if segments is not None else [_segment()],
+    }
+
+
+def _invalid_script() -> dict:
+    # 缺 summary/novel，image_prompt/video_prompt 形状错 —— 结构非法
+    return {
+        "episode": 1,
+        "title": "标题",
+        "content_mode": "narration",
+        "segments": [{"segment_id": "E1S01", "duration_seconds": 4, "image_prompt": "x", "video_prompt": "y"}],
+    }
+
+
+def _pm(tmp_path: Path) -> ProjectManager:
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+    return pm
+
+
+class TestNoWorseSemantics:
+    def test_valid_to_invalid_is_rejected(self, tmp_path: Path):
+        """前合法 ∧ 后非法 → 拒绝（本次编辑引入新结构错误）。"""
+        pm = _pm(tmp_path)
+        pm.save_script("demo", _valid_script(), "episode_1.json")
+
+        with pytest.raises(ScriptStructureValidationError):
+            with pm.locked_script("demo", "episode_1.json") as script:
+                # 把合法 segment 的 duration 改成越界值
+                script["segments"][0]["duration_seconds"] = 999
+
+    def test_invalid_to_invalid_is_allowed(self, tmp_path: Path):
+        """前非法 → 放行（不为历史遗留背锅），即使后仍非法。"""
+        pm = _pm(tmp_path)
+        pm.save_script("demo", _invalid_script(), "episode_1.json", validate=False)
+
+        # 在本就非法的旧剧本上做一次合法编辑（改 title），不应被拦
+        with pm.locked_script("demo", "episode_1.json") as script:
+            script["title"] = "新标题"
+
+        assert pm.load_script("demo", "episode_1.json")["title"] == "新标题"
+
+    def test_valid_to_valid_is_allowed(self, tmp_path: Path):
+        """前后都合法 → 放行。"""
+        pm = _pm(tmp_path)
+        pm.save_script("demo", _valid_script(), "episode_1.json")
+
+        with pm.locked_script("demo", "episode_1.json") as script:
+            script["segments"][0]["duration_seconds"] = 10
+
+        assert pm.load_script("demo", "episode_1.json")["segments"][0]["duration_seconds"] == 10
+
+    def test_fresh_save_invalid_is_rejected(self, tmp_path: Path):
+        """全新保存（无改前）+ 非法 → 严格拒绝。"""
+        pm = _pm(tmp_path)
+        with pytest.raises(ScriptStructureValidationError):
+            pm.save_script("demo", _invalid_script(), "episode_1.json")
+
+        # 拒绝后文件不应落盘
+        scripts_dir = pm.get_project_path("demo") / "scripts"
+        assert not (scripts_dir / "episode_1.json").exists()
+
+    def test_fresh_save_valid_is_allowed(self, tmp_path: Path):
+        """全新保存（无改前）+ 合法 → 放行。"""
+        pm = _pm(tmp_path)
+        pm.save_script("demo", _valid_script(), "episode_1.json")
+        assert pm.load_script("demo", "episode_1.json")["title"] == "标题"
+
+
+class TestValidateDefaultsOn:
+    def test_locked_script_validates_by_default(self, tmp_path: Path):
+        """不显式传 validate 时默认开启校验（fail-safe）。"""
+        pm = _pm(tmp_path)
+        pm.save_script("demo", _valid_script(), "episode_1.json")
+
+        with pytest.raises(ScriptStructureValidationError):
+            with pm.locked_script("demo", "episode_1.json") as script:  # 不传 validate
+                script["segments"][0]["video_prompt"] = "坏形状"
+
+    def test_validate_false_bypasses_guard(self, tmp_path: Path):
+        """显式 validate=False 时即便引入非法结构也放行。"""
+        pm = _pm(tmp_path)
+        pm.save_script("demo", _valid_script(), "episode_1.json")
+
+        with pm.locked_script("demo", "episode_1.json", validate=False) as script:
+            script["segments"][0]["video_prompt"] = "坏形状"
+
+        assert pm.load_script("demo", "episode_1.json")["segments"][0]["video_prompt"] == "坏形状"
+
+
+class TestAssetWritebackExemption:
+    def test_update_scene_asset_succeeds_on_invalid_script(self, tmp_path: Path):
+        """资产回写（validate=False）在剧本本就非法时仍能成功写入。"""
+        pm = _pm(tmp_path)
+        pm.save_script("demo", _invalid_script(), "episode_1.json", validate=False)
+
+        pm.update_scene_asset("demo", "episode_1.json", "E1S01", "storyboard_image", "storyboards/E1S01.png")
+
+        saved = pm.load_script("demo", "episode_1.json")
+        assert saved["segments"][0]["generated_assets"]["storyboard_image"] == "storyboards/E1S01.png"
+
+    def test_batch_update_scene_assets_succeeds_on_invalid_script(self, tmp_path: Path):
+        pm = _pm(tmp_path)
+        pm.save_script("demo", _invalid_script(), "episode_1.json", validate=False)
+
+        pm.batch_update_scene_assets("demo", "episode_1.json", [("E1S01", "video_clip", "videos/E1S01.mp4")])
+
+        saved = pm.load_script("demo", "episode_1.json")
+        assert saved["segments"][0]["generated_assets"]["video_clip"] == "videos/E1S01.mp4"

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -388,6 +388,32 @@ class TestProjectsRouter:
             )
             assert resp.status_code == 400
 
+    def test_update_segment_write_value_error_returns_422(self, tmp_path, monkeypatch):
+        # 写盘咽喉对客户端错误（结构非法 / 集号错配 / 非法文件名）抛 ValueError，
+        # router 须统一转 422 而非落到 500 兜底。
+        fake_pm = _FakePM(tmp_path)
+        fake_pm.scripts[("ready", "narration.json")] = {
+            "content_mode": "narration",
+            "segments": [{"segment_id": "E1S01", "duration_seconds": 4}],
+        }
+
+        @contextmanager
+        def _raising_locked_script(name, script_file):
+            script = fake_pm.load_script(name, script_file)
+            yield script
+            raise ValueError("脚本内 episode=1 与文件名 episode_10 不一致")
+
+        monkeypatch.setattr(fake_pm, "locked_script", _raising_locked_script)
+        client = _client(monkeypatch, fake_pm, _FakeCalc())
+
+        with client:
+            resp = client.patch(
+                "/api/v1/projects/ready/segments/E1S01",
+                json={"script_file": "narration.json", "duration_seconds": 7},
+            )
+            assert resp.status_code == 422
+            assert "不一致" in resp.json()["detail"]
+
     def test_update_scene_supports_character_and_clue_refs(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ready", "episode_1.json")] = {

--- a/tests/test_reference_video_concurrent_rmw.py
+++ b/tests/test_reference_video_concurrent_rmw.py
@@ -41,7 +41,7 @@ def _seed_reference_video_project(pm: ProjectManager, name: str, n_units: int) -
             for i in range(1, n_units + 1)
         ],
     }
-    pm.save_script(name, script, "episode_1.json")
+    pm.save_script(name, script, "episode_1.json", validate=False)  # 测并发 RMW 用简化替身 unit
 
 
 class TestReferenceVideoConcurrentRMW:
@@ -59,7 +59,7 @@ class TestReferenceVideoConcurrentRMW:
         def _append(idx: int) -> None:
             """模拟 add_unit：locked_script 内 fresh-load → append → save。"""
             barrier.wait()
-            with pm.locked_script(name, "episode_1.json") as script:
+            with pm.locked_script(name, "episode_1.json", validate=False) as script:
                 # 直接按 schema 访问，缺字段即报错（fail-loud），不用 setdefault 掩盖损坏
                 script["video_units"].append(
                     {
@@ -74,7 +74,7 @@ class TestReferenceVideoConcurrentRMW:
         def _writeback(unit_id: str) -> None:
             """模拟 executor 的 _update_unit_assets：定位 unit 写 generated_assets。"""
             barrier.wait()
-            with pm.locked_script(name, "episode_1.json") as script:
+            with pm.locked_script(name, "episode_1.json", validate=False) as script:
                 for u in script["video_units"]:
                     if u.get("unit_id") == unit_id:
                         ga = u.setdefault("generated_assets", {})

--- a/tests/test_script_structure_validator.py
+++ b/tests/test_script_structure_validator.py
@@ -105,6 +105,21 @@ class TestModeDetection:
     def test_drama_detected_by_scenes(self):
         assert validate_script_structure(_drama()).valid
 
+    def test_empty_scenes_drama_detected_by_content_mode(self):
+        """空场景 drama（scenes=[]，结构合法）应按 content_mode 判到 Drama，而非靠列表真值落回 Narration。
+
+        scenes 无 min_length 约束，空列表合法（对应「先建空 drama 再逐步填充场景」流程）。
+        若用 script.get("scenes") 真值判别，[] falsy 会误落 NarrationEpisodeScript 而被拒写。
+        """
+        script = _drama(scenes=[])
+        assert validate_script_structure(script).valid
+
+    def test_drama_detected_by_scenes_key_when_content_mode_absent(self):
+        # 无 content_mode、有 scenes 键（即便空）：按键存在推断 Drama
+        script = _drama(scenes=[])
+        del script["content_mode"]
+        assert validate_script_structure(script).valid
+
     def test_narration_is_default_fallback(self):
         # 无 content_mode、无 scenes/video_units：回退 NarrationEpisodeScript
         script = _narration()

--- a/tests/test_script_structure_validator.py
+++ b/tests/test_script_structure_validator.py
@@ -1,0 +1,174 @@
+"""剧本结构校验器（纯函数）测试。
+
+只断言外部行为：喂入纯 dict，断言返回的 ValidationResult。逐条覆盖三种模式的合法/非法
+判定与模式判别，不 patch 私有方法。
+"""
+
+from __future__ import annotations
+
+from lib.script_structure_validator import validate_script_structure
+
+
+def _segment(segment_id: str = "E1S01", duration: int = 4) -> dict:
+    return {
+        "segment_id": segment_id,
+        "duration_seconds": duration,
+        "novel_text": "原文",
+        "characters_in_segment": ["角色A"],
+        "image_prompt": {
+            "scene": "场景描述",
+            "composition": {"shot_type": "Medium Shot", "lighting": "暖光", "ambiance": "薄雾"},
+        },
+        "video_prompt": {"action": "转身", "camera_motion": "Static", "ambiance_audio": "风声"},
+    }
+
+
+def _narration(segments: list[dict] | None = None) -> dict:
+    return {
+        "title": "标题",
+        "content_mode": "narration",
+        "summary": "摘要",
+        "novel": {"title": "小说", "chapter": "第一章"},
+        "segments": segments if segments is not None else [_segment()],
+    }
+
+
+def _scene(scene_id: str = "E1S01", duration: int = 8) -> dict:
+    return {
+        "scene_id": scene_id,
+        "duration_seconds": duration,
+        "scene_type": "剧情",
+        "characters_in_scene": ["角色A"],
+        "image_prompt": {
+            "scene": "场景描述",
+            "composition": {"shot_type": "Medium Shot", "lighting": "暖光", "ambiance": "薄雾"},
+        },
+        "video_prompt": {"action": "转身", "camera_motion": "Static", "ambiance_audio": "风声"},
+    }
+
+
+def _drama(scenes: list[dict] | None = None) -> dict:
+    return {
+        "title": "标题",
+        "content_mode": "drama",
+        "summary": "摘要",
+        "novel": {"title": "小说", "chapter": "第一章"},
+        "scenes": scenes if scenes is not None else [_scene()],
+    }
+
+
+def _unit(unit_id: str = "E1U1", shots: list[dict] | None = None, duration: int | None = None, **extra) -> dict:
+    shots = shots if shots is not None else [{"duration": 3, "text": "镜头1"}, {"duration": 4, "text": "镜头2"}]
+    unit = {
+        "unit_id": unit_id,
+        "shots": shots,
+        "references": [],
+        "duration_seconds": duration if duration is not None else sum(s["duration"] for s in shots),
+    }
+    unit.update(extra)
+    return unit
+
+
+def _reference(units: list[dict] | None = None, content_mode: str = "narration") -> dict:
+    return {
+        "title": "标题",
+        "content_mode": content_mode,
+        "generation_mode": "reference_video",
+        "summary": "摘要",
+        "novel": {"title": "小说", "chapter": "第一章"},
+        "video_units": units if units is not None else [_unit()],
+    }
+
+
+class TestValidScripts:
+    def test_valid_narration(self):
+        assert validate_script_structure(_narration()).valid
+
+    def test_valid_drama(self):
+        assert validate_script_structure(_drama()).valid
+
+    def test_valid_reference_video(self):
+        assert validate_script_structure(_reference()).valid
+
+
+class TestModeDetection:
+    def test_reference_video_takes_priority_over_content_mode(self):
+        """generation_mode=reference_video 即使 content_mode=narration 也走 ReferenceVideoScript。
+
+        reference 剧本只有 video_units、无 segments；若误判为 NarrationEpisodeScript 会因缺
+        segments 而 invalid。结果 valid 证明判别走了 ReferenceVideoScript。
+        """
+        script = _reference(content_mode="narration")
+        assert script.get("content_mode") == "narration"
+        assert validate_script_structure(script).valid
+
+    def test_drama_detected_by_scenes(self):
+        assert validate_script_structure(_drama()).valid
+
+    def test_narration_is_default_fallback(self):
+        # 无 content_mode、无 scenes/video_units：回退 NarrationEpisodeScript
+        script = _narration()
+        del script["content_mode"]
+        assert validate_script_structure(script).valid
+
+
+class TestInvalidNarration:
+    def test_missing_required_top_field(self):
+        script = _narration()
+        del script["summary"]
+        result = validate_script_structure(script)
+        assert not result.valid
+        assert any("summary" in e for e in result.errors)
+
+    def test_missing_segment_required_field(self):
+        seg = _segment()
+        del seg["novel_text"]
+        result = validate_script_structure(_narration([seg]))
+        assert not result.valid
+        assert any("novel_text" in e for e in result.errors)
+
+    def test_duration_below_range(self):
+        result = validate_script_structure(_narration([_segment(duration=0)]))
+        assert not result.valid
+
+    def test_duration_above_range(self):
+        result = validate_script_structure(_narration([_segment(duration=61)]))
+        assert not result.valid
+
+    def test_video_prompt_wrong_shape(self):
+        seg = _segment()
+        seg["video_prompt"] = "纯字符串而非对象"
+        result = validate_script_structure(_narration([seg]))
+        assert not result.valid
+        assert any("video_prompt" in e for e in result.errors)
+
+    def test_image_prompt_missing_composition(self):
+        seg = _segment()
+        seg["image_prompt"] = {"scene": "只有 scene"}
+        result = validate_script_structure(_narration([seg]))
+        assert not result.valid
+        assert any("composition" in e for e in result.errors)
+
+
+class TestInvalidReferenceVideo:
+    def test_shots_duration_mismatch(self):
+        # shots 总和 7，duration_seconds 标 99，且未置 duration_override → 跨字段一致性失败
+        unit = _unit(duration=99)
+        result = validate_script_structure(_reference([unit]))
+        assert not result.valid
+        assert any("duration" in e.lower() for e in result.errors)
+
+    def test_shots_mismatch_allowed_with_override(self):
+        unit = _unit(duration=99, duration_override=True)
+        assert validate_script_structure(_reference([unit])).valid
+
+    def test_empty_shots_rejected(self):
+        unit = _unit(shots=[], duration=0)
+        result = validate_script_structure(_reference([unit]))
+        assert not result.valid
+
+    def test_too_many_shots_rejected(self):
+        shots = [{"duration": 1, "text": f"镜头{i}"} for i in range(5)]
+        unit = _unit(shots=shots, duration=5)
+        result = validate_script_structure(_reference([unit]))
+        assert not result.valid


### PR DESCRIPTION
## 背景

剧本结构校验早被抽成纯函数（Pydantic `script_models`），但只在归档导入/导出边界被调用。真正的写盘咽喉（`save_script` / `locked_script` / `locked_episode_script` 汇入的 `_write_script_unlocked`）不做结构校验，于是「加载→改 dict→保存」的任何调用方（WebUI 编辑、参考视频编辑）都能把结构损坏的剧本原样落盘，错误潜伏到 worker 执行层才暴露。

本 PR 把结构校验前移到唯一的 Python 写盘咽喉，采用**「不更坏」（no-worse）语义**：仅当「改前合法 ∧ 改后非法」（本次写入引入了新结构错误）才拒绝；改前就已非法的旧剧本照常放行（不为历史遗留背锅）。资产回写热路径（只动 `generated_assets`）整体豁免。

Closes #601

## 改动

- **M1 纯函数校验器** `lib/script_structure_validator.py`：喂 dict 返回 `ValidationResult`，不读盘、不依赖项目状态；按 `generation_mode`/`content_mode`/顶层键选 Pydantic 模型（`reference_video` 优先于 `content_mode`）；不复制约束，模型即单一真相源。
- **M2「不更坏」守卫 + 写盘咽喉集成** `lib/project_manager.py`：`_write_script_unlocked` 新增 `validate`（默认 True，fail-safe）与 `before` 参数；`locked_script`/`locked_episode_script` 在 yield 前快照改前剧本（零额外读盘）；资产回写四处（`update_character_sheet`/`update_scene_asset`/`batch_update_scene_assets` + `reference_video_tasks._update_unit_assets`）显式 `validate=False` 豁免。
- **Router 4xx** `projects.py`(`update_scene`/`update_segment`)、`reference_videos.py`(`patch/add/delete_unit`)：捕获 `ScriptStructureValidationError` → 422 + i18n。
- **i18n** zh/en/vi 各新增 `script_validation_failed`。
- **测试** 新增 `test_script_structure_validator.py`(16) + `test_project_manager_save_validation.py`(9)，修正受影响回归测试。

## 范围外（依赖说明）

- ADR \`docs/adr/0002-...\` 由 **PR #605** 负责创建，本 PR **不含 ADR 文件**。
- 历史剧本扫描脚本、入队侧校验、Agent 裸 Write/Edit 写入面收归、FS/引用一致性、`project.json` 校验均不在本 PR 范围。

## 验证

- ruff check + format 全绿
- basedpyright 0 error
- 受影响测试 105 passed；全量套件此前 2891 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 引入脚本结构校验与新错误类型，新增中/英/越三语错误提示（含详细原因占位符）。
  * 保存接口新增可选校验开关（默认开启）并加入“不得变坏”守卫；若必要，部分资产写回路径可显式跳过校验。
  * 当校验失败时，相关路由会返回 HTTP 422 并包含错误详情。

* **测试**
  * 增加并更新大量单元与集成测试，覆盖校验逻辑、模式识别、并发写入与资产写回豁免场景。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->