### PR TITLE
refactor(worker): 入队校验单一守卫点：结构入队 + 执行层 duration 能力

### DIFF
--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -276,6 +276,17 @@ class ConfigResolver:
         async with self._open_session() as (session, svc):
             return await self._resolve_video_capabilities_from_project(svc, session, project)
 
+    async def video_capabilities_for_model(self, provider_id: str, model_id: str, project: dict | None = None) -> dict:
+        """读取指定 provider/model 的视频能力，不再二次解析 provider。
+
+        供执行层使用：调用方已通过 `resolve_video_backend(project, payload)` 解析出实际
+        要调用的 ProviderModel（含历史任务 payload 覆盖），用此变体取能力可保证 duration
+        守卫所依据的 supported_durations 与实际调用的 model 一致，避免「按项目默认 model
+        的能力去校验 payload 解析出的 model」的错配。
+        """
+        async with self._open_session() as (session, svc):
+            return await self._resolve_video_caps_for_model(svc, session, provider_id, model_id, project)
+
     async def default_image_backend_t2i(self) -> tuple[str, str]:
         """返回 (provider_id, model_id)，T2I 默认。"""
         async with self._open_session() as (session, svc):
@@ -425,7 +436,16 @@ class ConfigResolver:
         project: dict | None,
     ) -> dict:
         provider_id, model_id = await self._resolve_video_backend_from_project(svc, session, project)
+        return await self._resolve_video_caps_for_model(svc, session, provider_id, model_id, project)
 
+    async def _resolve_video_caps_for_model(
+        self,
+        svc: ConfigService,
+        session: AsyncSession,
+        provider_id: str,
+        model_id: str,
+        project: dict | None,
+    ) -> dict:
         if is_custom_provider(provider_id):
             source = "custom"
             try:

--- a/lib/generation_queue_client.py
+++ b/lib/generation_queue_client.py
@@ -19,6 +19,7 @@ from lib.generation_queue import (
     get_generation_queue,
     read_queue_poll_interval,
 )
+from lib.prompt_utils import is_structured_image_prompt, is_structured_video_prompt
 
 
 class WorkerOfflineError(RuntimeError):
@@ -241,9 +242,74 @@ def enqueue_and_wait_sync(**kwargs) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+# Task types whose prompt is a *video* prompt (string or structured action object);
+# everything else carries an *image* prompt (string or structured scene object), and
+# plain-string-only asset prompts still flow through the image branch (no scene key).
+_VIDEO_TASK_TYPES = frozenset({"video"})
+_IMAGE_STRUCTURED_TASK_TYPES = frozenset({"storyboard"})
+
+
+def _validate_prompt(task_type: str, prompt: str | dict[str, Any] | None) -> None:
+    """Structural prompt validation, provider-agnostic and keyed by task type.
+
+    Mirrors (and now owns) the rules that previously lived inline in the WebUI
+    routes, so WebUI and SDK enqueue paths can't diverge. Raises
+    :class:`TaskSpecValidationError` with an i18n message code on failure.
+    """
+    if task_type in _VIDEO_TASK_TYPES:
+        if isinstance(prompt, dict):
+            if not is_structured_video_prompt(prompt):
+                raise TaskSpecValidationError("video_prompt_must_be_string_or_action_object")
+            if not str(prompt.get("action", "")).strip():
+                raise TaskSpecValidationError("video_prompt_action_empty")
+            dialogue = prompt.get("dialogue")
+            if dialogue is not None and not isinstance(dialogue, list):
+                raise TaskSpecValidationError("video_prompt_dialogue_array")
+        elif isinstance(prompt, str):
+            if not prompt.strip():
+                raise TaskSpecValidationError("prompt_text_empty")
+        else:
+            raise TaskSpecValidationError("prompt_must_be_string_or_object")
+        return
+
+    if task_type in _IMAGE_STRUCTURED_TASK_TYPES and isinstance(prompt, dict):
+        if not is_structured_image_prompt(prompt):
+            raise TaskSpecValidationError("prompt_must_be_string_or_scene_object")
+        if not str(prompt.get("scene", "")).strip():
+            raise TaskSpecValidationError("prompt_scene_empty")
+        return
+
+    # Asset (character/scene/prop) and string-form storyboard prompts: non-empty string.
+    if isinstance(prompt, str):
+        if not prompt.strip():
+            raise TaskSpecValidationError("prompt_text_empty")
+        return
+    raise TaskSpecValidationError("prompt_must_be_string_or_object")
+
+
+class TaskSpecValidationError(ValueError):
+    """Raised when a request fails the structural validation in ``TaskSpec.from_request``.
+
+    Carries an i18n message *code* (matching keys in the ``errors`` namespace) plus
+    optional format params, so routers can translate it to a 4xx without re-deriving
+    which rule failed. Agent-facing callers may just render ``str(self)``.
+    """
+
+    def __init__(self, code: str, **params: Any) -> None:
+        super().__init__(code)
+        self.code = code
+        self.params = params
+
+
 @dataclass
-class BatchTaskSpec:
-    """Specification for a single task in a batch submission."""
+class TaskSpec:
+    """Specification for a single enqueue request (single-task or batch member).
+
+    Construct via :meth:`from_request`, the single guard point that owns a request's
+    structural validity. Validation is provider-agnostic (no provider fields here):
+    capability checks such as ``duration ↔ supported_durations`` live at the execution
+    layer, after provider resolution (see ADR-0001).
+    """
 
     task_type: str
     media_type: str
@@ -255,6 +321,49 @@ class BatchTaskSpec:
     dependency_resource_id: str | None = None
     dependency_group: str | None = None
     dependency_index: int | None = None
+
+    @classmethod
+    def from_request(
+        cls,
+        *,
+        task_type: str,
+        media_type: str,
+        resource_id: str,
+        prompt: str | dict[str, Any] | None = None,
+        script_file: str | None = None,
+        source: str = "skill",
+        extra_payload: dict[str, Any] | None = None,
+        dependency_resource_id: str | None = None,
+        dependency_group: str | None = None,
+        dependency_index: int | None = None,
+    ) -> TaskSpec:
+        """Validate a request structurally and build a :class:`TaskSpec`.
+
+        Single source of truth for "is this enqueue request structurally legal" —
+        both the WebUI routes and the SDK spec builders construct through here so the
+        rules can't diverge. Raises :class:`TaskSpecValidationError` on invalid input.
+        """
+        if not resource_id:
+            raise ValueError("resource_id is required")
+        _validate_prompt(task_type, prompt)
+
+        payload: dict[str, Any] = {"prompt": prompt}
+        if script_file is not None:
+            payload["script_file"] = script_file
+        if extra_payload:
+            payload.update(extra_payload)
+
+        return cls(
+            task_type=task_type,
+            media_type=media_type,
+            resource_id=resource_id,
+            payload=payload,
+            script_file=script_file,
+            source=source,
+            dependency_resource_id=dependency_resource_id,
+            dependency_group=dependency_group,
+            dependency_index=dependency_index,
+        )
 
 
 @dataclass
@@ -295,7 +404,7 @@ def _task_result_from_finished(task: dict[str, Any], resource_id: str, task_id: 
 async def batch_enqueue_and_wait(
     *,
     project_name: str,
-    specs: list[BatchTaskSpec],
+    specs: list[TaskSpec],
     on_success: Callable[[BatchTaskResult], None] | None = None,
     on_failure: Callable[[BatchTaskResult], None] | None = None,
 ) -> tuple[list[BatchTaskResult], list[BatchTaskResult]]:
@@ -330,7 +439,7 @@ async def batch_enqueue_and_wait(
         task_ids[spec.resource_id] = enqueue_result["task_id"]
 
     # Phase 2 — Parallel wait via asyncio.gather (single event loop)
-    async def _wait_one(spec: BatchTaskSpec) -> BatchTaskResult:
+    async def _wait_one(spec: TaskSpec) -> BatchTaskResult:
         tid = task_ids[spec.resource_id]
         try:
             task = await wait_for_task(tid)
@@ -363,7 +472,7 @@ async def batch_enqueue_and_wait(
 def batch_enqueue_and_wait_sync(
     *,
     project_name: str,
-    specs: list[BatchTaskSpec],
+    specs: list[TaskSpec],
     on_success: Callable[[BatchTaskResult], None] | None = None,
     on_failure: Callable[[BatchTaskResult], None] | None = None,
 ) -> tuple[list[BatchTaskResult], list[BatchTaskResult]]:

--- a/lib/generation_queue_client.py
+++ b/lib/generation_queue_client.py
@@ -260,7 +260,9 @@ def _validate_prompt(task_type: str, prompt: str | dict[str, Any] | None) -> Non
         if isinstance(prompt, dict):
             if not is_structured_video_prompt(prompt):
                 raise TaskSpecValidationError("video_prompt_must_be_string_or_action_object")
-            if not str(prompt.get("action", "")).strip():
+            # ``or ""`` 而非默认参数：``{"action": null}`` 时 get 返回 None，
+            # ``str(None)`` 会得到 truthy 的 "None" 字符串绕过空值校验。
+            if not str(prompt.get("action") or "").strip():
                 raise TaskSpecValidationError("video_prompt_action_empty")
             dialogue = prompt.get("dialogue")
             if dialogue is not None and not isinstance(dialogue, list):
@@ -275,7 +277,7 @@ def _validate_prompt(task_type: str, prompt: str | dict[str, Any] | None) -> Non
     if task_type in _IMAGE_STRUCTURED_TASK_TYPES and isinstance(prompt, dict):
         if not is_structured_image_prompt(prompt):
             raise TaskSpecValidationError("prompt_must_be_string_or_scene_object")
-        if not str(prompt.get("scene", "")).strip():
+        if not str(prompt.get("scene") or "").strip():
             raise TaskSpecValidationError("prompt_scene_empty")
         return
 
@@ -347,11 +349,16 @@ class TaskSpec:
             raise ValueError("resource_id is required")
         _validate_prompt(task_type, prompt)
 
-        payload: dict[str, Any] = {"prompt": prompt}
+        # extra_payload 不得携带守卫点已校验的保留键，否则调用方能绕过单一守卫点
+        # 把未校验的 prompt / script_file 入队。
+        reserved = {"prompt", "script_file"}
+        if extra_payload and (conflict := reserved & extra_payload.keys()):
+            raise ValueError(f"extra_payload contains reserved keys: {', '.join(sorted(conflict))}")
+
+        payload: dict[str, Any] = dict(extra_payload) if extra_payload else {}
+        payload["prompt"] = prompt
         if script_file is not None:
             payload["script_file"] = script_file
-        if extra_payload:
-            payload.update(extra_payload)
 
         return cls(
             task_type=task_type,

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -143,6 +143,9 @@ MESSAGES = {
     "image_endpoint_mismatch_no_t2i": "Model {model} only supports image-to-image (reference images required); supply reference images or pick a model that supports text-to-image",
     "image_capability_missing_i2i": "{provider}/{model} does not support image-to-image; configure a default model that supports image edits",
     "image_capability_missing_t2i": "{provider}/{model} does not support text-to-image; configure a default model that supports text-to-image",
+    # Video Capability
+    "video_duration_invalid": "Video duration {duration} is not a valid integer number of seconds",
+    "video_duration_not_supported": "Video duration {duration}s is not within the durations supported by this model ({supported})",
     # Agent credentials
     "agent_preset_unknown": "Unknown preset provider: {preset_id}",
     "agent_base_url_required_custom": "base_url is required for custom configuration",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -143,6 +143,9 @@ MESSAGES = {
     "image_endpoint_mismatch_no_t2i": "Mô hình {model} chỉ hỗ trợ image-to-image (cần ảnh tham chiếu); hãy cung cấp ảnh tham chiếu hoặc chọn mô hình hỗ trợ text-to-image",
     "image_capability_missing_i2i": "{provider}/{model} không hỗ trợ image-to-image; hãy cấu hình mô hình mặc định có hỗ trợ chỉnh sửa ảnh",
     "image_capability_missing_t2i": "{provider}/{model} không hỗ trợ text-to-image; hãy cấu hình mô hình mặc định có hỗ trợ text-to-image",
+    # Video Capability
+    "video_duration_invalid": "Thời lượng video {duration} không phải là số giây nguyên hợp lệ",
+    "video_duration_not_supported": "Thời lượng video {duration}s không nằm trong các thời lượng mà mô hình này hỗ trợ ({supported})",
     # Agent credentials
     "agent_preset_unknown": "Nhà cung cấp đặt sẵn không xác định: {preset_id}",
     "agent_base_url_required_custom": "Cấu hình tuỳ chỉnh yêu cầu base_url",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -143,6 +143,9 @@ MESSAGES = {
     "image_endpoint_mismatch_no_t2i": "模型 {model} 仅支持图生图（必须传参考图）；请提供参考图或换一个支持文生图的模型",
     "image_capability_missing_i2i": "{provider}/{model} 不支持图生图；请配置一个支持图生图的默认模型",
     "image_capability_missing_t2i": "{provider}/{model} 不支持文生图；请配置一个支持文生图的默认模型",
+    # Video Capability
+    "video_duration_invalid": "视频时长 {duration} 不是合法的整数秒数",
+    "video_duration_not_supported": "视频时长 {duration}s 不在该模型支持的时长（{supported}）内",
     # Agent credentials
     "agent_preset_unknown": "未知预设供应商: {preset_id}",
     "agent_base_url_required_custom": "自定义配置需要填写 base_url",

--- a/lib/reference_video/__init__.py
+++ b/lib/reference_video/__init__.py
@@ -4,6 +4,7 @@ from lib.reference_video.errors import (
     RequestPayloadTooLargeError,
 )
 from lib.reference_video.shot_parser import (
+    assemble_shots_text,
     compute_duration_from_shots,
     parse_prompt,
     render_prompt_for_backend,
@@ -14,6 +15,7 @@ __all__ = [
     "MissingReferenceError",
     "ProviderUnsupportedFeatureError",
     "RequestPayloadTooLargeError",
+    "assemble_shots_text",
     "compute_duration_from_shots",
     "parse_prompt",
     "render_prompt_for_backend",

--- a/lib/reference_video/shot_parser.py
+++ b/lib/reference_video/shot_parser.py
@@ -91,6 +91,16 @@ def render_prompt_for_backend(text: str, references: list[ReferenceResource]) ->
     return _MENTION_RE.sub(_repl, text)
 
 
+def assemble_shots_text(shots: list[dict]) -> str:
+    """把 unit.shots[*].text 拼接为单一原始 prompt（渲染、@→[图N] 替换之前）。
+
+    供入队守卫点对参考生视频做空提示词结构校验：``render_prompt_for_backend`` 对未注册
+    的 @mention 保留原文、从不删字，故「拼接文本去空白后为空」等价于「渲染后为空」，
+    空检查可无损地在入队侧完成。
+    """
+    return "\n".join(str(s.get("text", "")) for s in shots)
+
+
 def compute_duration_from_shots(shots: list[Shot]) -> int:
     """把 shots 时长求和，返回整数秒。"""
     return sum(s.duration for s in shots)

--- a/lib/reference_video/shot_parser.py
+++ b/lib/reference_video/shot_parser.py
@@ -6,6 +6,7 @@ Spec: docs/superpowers/specs/2026-04-15-reference-to-video-mode-design.md §4.3
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from lib.asset_types import BUCKET_KEY
 from lib.script_models import ReferenceResource, Shot
@@ -91,14 +92,24 @@ def render_prompt_for_backend(text: str, references: list[ReferenceResource]) ->
     return _MENTION_RE.sub(_repl, text)
 
 
-def assemble_shots_text(shots: list[dict]) -> str:
+def assemble_shots_text(shots: list[Any]) -> str:
     """把 unit.shots[*].text 拼接为单一原始 prompt（渲染、@→[图N] 替换之前）。
 
     供入队守卫点对参考生视频做空提示词结构校验：``render_prompt_for_backend`` 对未注册
     的 @mention 保留原文、从不删字，故「拼接文本去空白后为空」等价于「渲染后为空」，
     空检查可无损地在入队侧完成。
+
+    对畸形数据做防御性归一化（Agent 可裸写 script JSON，绕过 ProjectManager 校验）：
+    非 dict 的 shot 元素跳过；``text`` 缺失或非字符串（含显式 ``null``）按空串处理——
+    否则 ``str(None)`` 会得到 truthy 的 "None" 既绕过空校验又把字面量注入 backend。
     """
-    return "\n".join(str(s.get("text", "")) for s in shots)
+    parts: list[str] = []
+    for s in shots:
+        if not isinstance(s, dict):
+            continue
+        text = s.get("text")
+        parts.append(text if isinstance(text, str) else "")
+    return "\n".join(parts)
 
 
 def compute_duration_from_shots(shots: list[Shot]) -> int:

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -99,6 +99,19 @@ async def download_video(url: str, output_path: Path, *, timeout: int = 120) -> 
             await asyncio.to_thread(_write_all)
 
 
+class VideoCapabilityError(RuntimeError):
+    """视频后端能力不匹配（如 duration ↔ supported_durations）。
+
+    与 ImageCapabilityError 对称：不携带本地化字符串，只带稳定 code + 上下文 params；
+    Worker 捕获后用 i18n_translate(code, **params) 渲染到 task.error_message。
+    """
+
+    def __init__(self, code: str, **params) -> None:
+        self.code = code
+        self.params = params
+        super().__init__(code)
+
+
 @dataclass
 class VideoCapabilities:
     """Declares what a video backend supports."""

--- a/server/agent_runtime/sdk_tools/enqueue_assets.py
+++ b/server/agent_runtime/sdk_tools/enqueue_assets.py
@@ -8,7 +8,7 @@ from claude_agent_sdk import tool
 
 from lib.asset_types import ASSET_SPECS, AssetSpec
 from lib.generation_queue_client import (
-    BatchTaskSpec,
+    TaskSpec,
     batch_enqueue_and_wait,
 )
 from lib.project_manager import ProjectManager
@@ -38,7 +38,7 @@ def _build_specs(
     asset_type: str,
     names: list[str] | None,
     warnings: list[str],
-) -> list[BatchTaskSpec]:
+) -> list[TaskSpec]:
     spec: AssetSpec = ASSET_SPECS[asset_type]
     project = pm.load_project(project_name)
     assets_dict = project.get(spec.bucket_key, {})
@@ -64,11 +64,11 @@ def _build_specs(
             resolved.append(name)
 
     return [
-        BatchTaskSpec(
+        TaskSpec.from_request(
             task_type=spec.asset_type,
             media_type="image",
             resource_id=name,
-            payload={"prompt": assets_dict[name]["description"]},
+            prompt=assets_dict[name]["description"],
         )
         for name in resolved
     ]

--- a/server/agent_runtime/sdk_tools/enqueue_assets.py
+++ b/server/agent_runtime/sdk_tools/enqueue_assets.py
@@ -49,8 +49,10 @@ def _build_specs(
             if name not in assets_dict:
                 warnings.append(f"⚠️  {spec.label_zh} '{name}' 不存在于 project.json 中，跳过")
                 continue
-            # strip 检查：空白描述也跳过并告警，避免漏到 from_request 抛错而中断整批。
-            if not (assets_dict[name].get("description") or "").strip():
+            # 仅当 description 是非空字符串才入队；空白 / 非字符串（dict、数字等）
+            # 都告警跳过，避免漏到 from_request 抛错或 .strip() 抛 AttributeError 而中断整批。
+            desc = assets_dict[name].get("description")
+            if not (isinstance(desc, str) and desc.strip()):
                 warnings.append(f"⚠️  {spec.label_zh} '{name}' 缺少描述，跳过")
                 continue
             resolved.append(name)
@@ -59,7 +61,8 @@ def _build_specs(
         resolved = []
         for item in pending:
             name = item["name"]
-            if not (assets_dict.get(name, {}).get("description") or "").strip():
+            desc = assets_dict.get(name, {}).get("description")
+            if not (isinstance(desc, str) and desc.strip()):
                 warnings.append(f"⚠️  {spec.label_zh} '{name}' 缺少描述，跳过")
                 continue
             resolved.append(name)

--- a/server/agent_runtime/sdk_tools/enqueue_assets.py
+++ b/server/agent_runtime/sdk_tools/enqueue_assets.py
@@ -49,7 +49,8 @@ def _build_specs(
             if name not in assets_dict:
                 warnings.append(f"⚠️  {spec.label_zh} '{name}' 不存在于 project.json 中，跳过")
                 continue
-            if not assets_dict[name].get("description"):
+            # strip 检查：空白描述也跳过并告警，避免漏到 from_request 抛错而中断整批。
+            if not (assets_dict[name].get("description") or "").strip():
                 warnings.append(f"⚠️  {spec.label_zh} '{name}' 缺少描述，跳过")
                 continue
             resolved.append(name)
@@ -58,7 +59,7 @@ def _build_specs(
         resolved = []
         for item in pending:
             name = item["name"]
-            if not assets_dict.get(name, {}).get("description"):
+            if not (assets_dict.get(name, {}).get("description") or "").strip():
                 warnings.append(f"⚠️  {spec.label_zh} '{name}' 缺少描述，跳过")
                 continue
             resolved.append(name)

--- a/server/agent_runtime/sdk_tools/enqueue_storyboards.py
+++ b/server/agent_runtime/sdk_tools/enqueue_storyboards.py
@@ -12,7 +12,7 @@ from claude_agent_sdk import tool
 
 from lib.generation_queue_client import (
     BatchTaskResult,
-    BatchTaskSpec,
+    TaskSpec,
     batch_enqueue_and_wait,
 )
 from lib.prompt_utils import image_prompt_to_yaml, is_structured_image_prompt
@@ -98,17 +98,17 @@ def _build_specs(
     style_description: str,
     id_field: str,
     script_filename: str,
-) -> list[BatchTaskSpec]:
-    specs: list[BatchTaskSpec] = []
+) -> list[TaskSpec]:
+    specs: list[TaskSpec] = []
     for plan in plans:
         item = items_by_id[plan.resource_id]
         prompt = _build_prompt(item, style, style_description, id_field)
         specs.append(
-            BatchTaskSpec(
+            TaskSpec.from_request(
                 task_type="storyboard",
                 media_type="image",
                 resource_id=plan.resource_id,
-                payload={"prompt": prompt, "script_file": script_filename},
+                prompt=prompt,
                 script_file=script_filename,
                 dependency_resource_id=plan.dependency_resource_id,
                 dependency_group=plan.dependency_group,

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -152,7 +152,9 @@ def _build_reference_specs(
     specs: list[TaskSpec] = []
     order_map: dict[str, int] = {}
     for idx, unit in enumerate(units):
-        unit_id = unit["unit_id"]
+        # 用 .get 归一化：缺失 unit_id 的坏数据（Agent 可裸写 script JSON）会被 from_request
+        # 当作空 resource_id 拒绝并走下面的跳过分支，而不是在此抛 KeyError 中断整批。
+        unit_id = str(unit.get("unit_id") or "")
         if unit_id in skip_set:
             continue
         if not unit.get("shots"):

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -14,11 +14,13 @@ from claude_agent_sdk import tool
 from lib.generation_queue_client import (
     BatchTaskResult,
     TaskSpec,
+    TaskSpecValidationError,
     batch_enqueue_and_wait,
     enqueue_and_wait,
 )
 from lib.project_manager import ProjectManager
 from lib.prompt_utils import is_structured_video_prompt, video_prompt_to_yaml
+from lib.reference_video import assemble_shots_text
 from lib.storyboard_sequence import get_storyboard_items
 from server.agent_runtime.sdk_tools._context import (
     ToolContext,
@@ -157,15 +159,20 @@ def _build_reference_specs(
         if not unit.get("shots"):
             log.append(f"⚠️  {unit_id} 没有 shots，跳过")
             continue
-        specs.append(
-            TaskSpec(
+        # prompt 由 shots[*].text 拼接，经统一守卫点做空提示词结构校验（见 ADR-0001）；
+        # 全空白的 unit 跳过并告警，与「没有 shots」一致，不让一个空 unit 中断整批。
+        try:
+            spec = TaskSpec.from_request(
                 task_type="reference_video",
                 media_type="video",
                 resource_id=unit_id,
-                payload={"script_file": script_filename},
+                prompt=assemble_shots_text(unit["shots"]),
                 script_file=script_filename,
             )
-        )
+        except TaskSpecValidationError:
+            log.append(f"⚠️  {unit_id} 提示词为空，跳过")
+            continue
+        specs.append(spec)
         order_map[unit_id] = idx
     return specs, order_map
 

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -14,7 +14,6 @@ from claude_agent_sdk import tool
 from lib.generation_queue_client import (
     BatchTaskResult,
     TaskSpec,
-    TaskSpecValidationError,
     batch_enqueue_and_wait,
     enqueue_and_wait,
 )
@@ -160,7 +159,9 @@ def _build_reference_specs(
             log.append(f"⚠️  {unit_id} 没有 shots，跳过")
             continue
         # prompt 由 shots[*].text 拼接，经统一守卫点做空提示词结构校验（见 ADR-0001）；
-        # 全空白的 unit 跳过并告警，与「没有 shots」一致，不让一个空 unit 中断整批。
+        # 任一 unit 不合法（空提示词、或 from_request 对空 resource_id 抛的裸 ValueError）
+        # 都跳过并告警，与「没有 shots」一致，不让一个坏 unit 中断整批。
+        # 注意 TaskSpecValidationError 是 ValueError 子类，捕 ValueError 同时覆盖两者。
         try:
             spec = TaskSpec.from_request(
                 task_type="reference_video",
@@ -169,8 +170,8 @@ def _build_reference_specs(
                 prompt=assemble_shots_text(unit["shots"]),
                 script_file=script_filename,
             )
-        except TaskSpecValidationError:
-            log.append(f"⚠️  {unit_id} 提示词为空，跳过")
+        except ValueError as exc:
+            log.append(f"⚠️  {unit_id} 入队校验未通过，跳过：{exc}")
             continue
         specs.append(spec)
         order_map[unit_id] = idx

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -13,7 +13,7 @@ from claude_agent_sdk import tool
 
 from lib.generation_queue_client import (
     BatchTaskResult,
-    BatchTaskSpec,
+    TaskSpec,
     batch_enqueue_and_wait,
     enqueue_and_wait,
 )
@@ -22,7 +22,6 @@ from lib.prompt_utils import is_structured_video_prompt, video_prompt_to_yaml
 from lib.storyboard_sequence import get_storyboard_items
 from server.agent_runtime.sdk_tools._context import (
     ToolContext,
-    fetch_video_caps,
     tool_error,
     validate_script_filename,
 )
@@ -46,16 +45,6 @@ def _get_video_prompt(item: dict[str, Any]) -> str:
 
 def _is_reference_script(script: dict[str, Any]) -> bool:
     return script.get("generation_mode") == "reference_video"
-
-
-async def _fetch_video_caps(project: dict[str, Any]) -> tuple[int | None, list[int]]:
-    """Video generation requires non-empty supported_durations — hard fail when
-    ``ConfigResolver`` returns nothing (script normalization uses a soft
-    fallback path, see ``_fetch_caps_with_fallback`` in ``text_generation``)."""
-    default_int, durations = await fetch_video_caps(project)
-    if not durations:
-        raise ValueError("supported_durations 无法解析：ConfigResolver 未返回任何时长")
-    return default_int, durations
 
 
 # Checkpoint helpers
@@ -101,15 +90,13 @@ def _build_video_specs(
     content_mode: str,
     script_filename: str,
     project_dir: Path,
-    default_duration: int,
-    supported_durations: list[int],
     skip_ids: list[str] | None,
     log: list[str],
-) -> tuple[list[BatchTaskSpec], dict[str, int]]:
+) -> tuple[list[TaskSpec], dict[str, int]]:
     item_type = "片段" if content_mode == "narration" else "场景"
     skip_set = set(skip_ids or [])
 
-    specs: list[BatchTaskSpec] = []
+    specs: list[TaskSpec] = []
     order_map: dict[str, int] = {}
     for idx, item in enumerate(items):
         item_id = item.get(id_field) or item.get("scene_id") or item.get("segment_id") or f"item_{idx}"
@@ -131,21 +118,21 @@ def _build_video_specs(
             log.append(f"⚠️  {item_type} {item_id} 的 video_prompt 无效，跳过: {exc}")
             continue
 
-        duration = item.get("duration_seconds", default_duration)
-        if duration not in supported_durations:
-            raise ValueError(f"duration={duration}s 不在模型 supported_durations={supported_durations} 内")
+        # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；
+        # 仅透传调用方显式指定的值，缺省由执行层按 caps 收口默认。
+        extra_payload: dict[str, Any] = {}
+        duration = item.get("duration_seconds")
+        if duration is not None:
+            extra_payload["duration_seconds"] = int(duration)
 
         specs.append(
-            BatchTaskSpec(
+            TaskSpec.from_request(
                 task_type="video",
                 media_type="video",
                 resource_id=item_id,
-                payload={
-                    "prompt": prompt,
-                    "script_file": script_filename,
-                    "duration_seconds": int(duration),
-                },
+                prompt=prompt,
                 script_file=script_filename,
+                extra_payload=extra_payload or None,
             )
         )
         order_map[item_id] = idx
@@ -158,9 +145,9 @@ def _build_reference_specs(
     script_filename: str,
     skip_ids: list[str] | None,
     log: list[str],
-) -> tuple[list[BatchTaskSpec], dict[str, int]]:
+) -> tuple[list[TaskSpec], dict[str, int]]:
     skip_set = set(skip_ids or [])
-    specs: list[BatchTaskSpec] = []
+    specs: list[TaskSpec] = []
     order_map: dict[str, int] = {}
     for idx, unit in enumerate(units):
         unit_id = unit["unit_id"]
@@ -170,7 +157,7 @@ def _build_reference_specs(
             log.append(f"⚠️  {unit_id} 没有 shots，跳过")
             continue
         specs.append(
-            BatchTaskSpec(
+            TaskSpec(
                 task_type="reference_video",
                 media_type="video",
                 resource_id=unit_id,
@@ -227,7 +214,7 @@ async def _submit_with_checkpoint(
     *,
     project_name: str,
     project_dir: Path,
-    specs: list[BatchTaskSpec],
+    specs: list[TaskSpec],
     order_map: dict[str, int],
     ordered_paths: list[Path | None],
     completed: list[str],
@@ -389,13 +376,8 @@ def generate_video_episode_tool(ctx: ToolContext):
                 )
 
             episode = ProjectManager.resolve_episode_from_script(script, script_filename)
-            project = ctx.pm.load_project(ctx.project_name)
             items, id_field, _chars, _scenes, _props = get_storyboard_items(script)
             content_mode = script.get("content_mode", "narration")
-            caps_default, supported_durations = await _fetch_video_caps(project)
-            default_duration = (
-                project.get("default_duration") or caps_default or (4 if content_mode == "narration" else 8)
-            )
             if not items:
                 raise ValueError(f"第 {episode} 集剧本为空：{script_filename}")
 
@@ -417,8 +399,6 @@ def generate_video_episode_tool(ctx: ToolContext):
                 content_mode=content_mode,
                 script_filename=script_filename,
                 project_dir=project_dir,
-                default_duration=default_duration,
-                supported_durations=supported_durations,
                 skip_ids=already_done,
                 log=log,
             )
@@ -483,9 +463,7 @@ def generate_video_scene_tool(ctx: ToolContext):
                     ctx=ctx, script=script, script_filename=script_filename, resume=False, log=log
                 )
 
-            project = ctx.pm.load_project(ctx.project_name)
             items, id_field, _chars, _scenes, _props = get_storyboard_items(script)
-            content_mode = script.get("content_mode", "narration")
             item = next((s for s in items if s.get(id_field) == scene_id or s.get("scene_id") == scene_id), None)
             if not item:
                 raise ValueError(f"场景/片段 '{scene_id}' 不存在")
@@ -501,25 +479,28 @@ def generate_video_scene_tool(ctx: ToolContext):
                 raise FileNotFoundError(f"分镜图不存在: {project_dir / storyboard_image}")
 
             prompt = _get_video_prompt(item)
-            caps_default, supported_durations = await _fetch_video_caps(project)
-            default_duration = (
-                project.get("default_duration") or caps_default or (4 if content_mode == "narration" else 8)
-            )
-            duration = item.get("duration_seconds", default_duration)
-            if duration not in supported_durations:
-                raise ValueError(f"duration={duration}s 不在模型 supported_durations={supported_durations} 内")
-
-            queued = await enqueue_and_wait(
-                project_name=ctx.project_name,
+            # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；
+            # 仅透传调用方显式指定的值，缺省由执行层按 caps 收口默认。
+            extra_payload: dict[str, Any] = {}
+            duration = item.get("duration_seconds")
+            if duration is not None:
+                extra_payload["duration_seconds"] = int(duration)
+            spec = TaskSpec.from_request(
                 task_type="video",
                 media_type="video",
                 resource_id=item_id,
-                payload={
-                    "prompt": prompt,
-                    "script_file": script_filename,
-                    "duration_seconds": int(duration),
-                },
+                prompt=prompt,
                 script_file=script_filename,
+                extra_payload=extra_payload or None,
+            )
+
+            queued = await enqueue_and_wait(
+                project_name=ctx.project_name,
+                task_type=spec.task_type,
+                media_type=spec.media_type,
+                resource_id=spec.resource_id,
+                payload=spec.payload,
+                script_file=spec.script_file,
                 source="skill",
             )
             result = queued.get("result") or {}
@@ -559,25 +540,18 @@ def generate_video_all_tool(ctx: ToolContext):
                     ctx=ctx, script=script, script_filename=script_filename, resume=False, log=log
                 )
 
-            project = ctx.pm.load_project(ctx.project_name)
             items, id_field, _chars, _scenes, _props = get_storyboard_items(script)
             content_mode = script.get("content_mode", "narration")
             pending = [it for it in items if not (it.get("generated_assets") or {}).get("video_clip")]
             if not pending:
                 return {"content": [{"type": "text", "text": "✨ 所有场景/片段的视频都已生成"}]}
 
-            caps_default, supported_durations = await _fetch_video_caps(project)
-            default_duration = (
-                project.get("default_duration") or caps_default or (4 if content_mode == "narration" else 8)
-            )
             specs, _order_map = _build_video_specs(
                 items=pending,
                 id_field=id_field,
                 content_mode=content_mode,
                 script_filename=script_filename,
                 project_dir=project_dir,
-                default_duration=default_duration,
-                supported_durations=supported_durations,
                 skip_ids=None,
                 log=log,
             )
@@ -643,7 +617,6 @@ def generate_video_selected_tool(ctx: ToolContext):
                     ctx=ctx, script=script, script_filename=script_filename, resume=resume, log=log
                 )
 
-            project = ctx.pm.load_project(ctx.project_name)
             items, id_field, _chars, _scenes, _props = get_storyboard_items(script)
             content_mode = script.get("content_mode", "narration")
 
@@ -688,10 +661,6 @@ def generate_video_selected_tool(ctx: ToolContext):
 
             videos_dir = project_dir / "videos"
             videos_dir.mkdir(parents=True, exist_ok=True)
-            caps_default, supported_durations = await _fetch_video_caps(project)
-            default_duration = (
-                project.get("default_duration") or caps_default or (4 if content_mode == "narration" else 8)
-            )
             ordered_paths, already_done, completed = _scan_completed_items(selected, id_field, completed, videos_dir)
             specs, order_map = _build_video_specs(
                 items=selected,
@@ -699,8 +668,6 @@ def generate_video_selected_tool(ctx: ToolContext):
                 content_mode=content_mode,
                 script_filename=script_filename,
                 project_dir=project_dir,
-                default_duration=default_duration,
-                supported_durations=supported_durations,
                 skip_ids=already_done,
                 log=log,
             )

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -119,11 +119,12 @@ def _build_video_specs(
             continue
 
         # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；
-        # 仅透传调用方显式指定的值，缺省由执行层按 caps 收口默认。
+        # 原样透传调用方显式指定的值，不在入队侧做 int() 截断式归一化（否则会把
+        # 本应被执行层拒绝的非法值静默修正）。缺省由执行层按 caps 收口默认。
         extra_payload: dict[str, Any] = {}
         duration = item.get("duration_seconds")
         if duration is not None:
-            extra_payload["duration_seconds"] = int(duration)
+            extra_payload["duration_seconds"] = duration
 
         specs.append(
             TaskSpec.from_request(
@@ -480,11 +481,12 @@ def generate_video_scene_tool(ctx: ToolContext):
 
             prompt = _get_video_prompt(item)
             # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；
-            # 仅透传调用方显式指定的值，缺省由执行层按 caps 收口默认。
+            # 原样透传调用方显式指定的值，不在入队侧做 int() 截断式归一化（否则会把
+            # 本应被执行层拒绝的非法值静默修正）。缺省由执行层按 caps 收口默认。
             extra_payload: dict[str, Any] = {}
             duration = item.get("duration_seconds")
             if duration is not None:
-                extra_payload["duration_seconds"] = int(duration)
+                extra_payload["duration_seconds"] = duration
             spec = TaskSpec.from_request(
                 task_type="video",
                 media_type="video",

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -16,12 +16,9 @@ from pydantic import BaseModel
 from lib.app_data_dir import app_data_dir
 from lib.asset_types import ASSET_SPECS
 from lib.generation_queue import get_generation_queue
+from lib.generation_queue_client import TaskSpec, TaskSpecValidationError
 from lib.i18n import Translator
 from lib.project_manager import ProjectManager
-from lib.prompt_utils import (
-    is_structured_image_prompt,
-    is_structured_video_prompt,
-)
 from lib.storyboard_sequence import (
     find_storyboard_item,
     get_storyboard_items,
@@ -93,34 +90,27 @@ async def generate_storyboard(
 
         await asyncio.to_thread(_sync)
 
-        # 验证 prompt 格式
-        if isinstance(req.prompt, dict):
-            if not is_structured_image_prompt(req.prompt):
-                raise HTTPException(
-                    status_code=400,
-                    detail=_t("prompt_must_be_string_or_scene_object"),
-                )
-            scene_text = str(req.prompt.get("scene", "")).strip()
-            if not scene_text:
-                raise HTTPException(status_code=400, detail=_t("prompt_scene_empty"))
-        elif isinstance(req.prompt, str):
-            if not req.prompt.strip():
-                raise HTTPException(status_code=400, detail=_t("prompt_text_empty"))
-        else:
-            raise HTTPException(status_code=400, detail=_t("prompt_must_be_string_or_object"))
+        # 结构校验 + 构造经单一守卫点（与 SDK 入队同源，规则不分叉）
+        try:
+            spec = TaskSpec.from_request(
+                task_type="storyboard",
+                media_type="image",
+                resource_id=segment_id,
+                prompt=req.prompt,
+                script_file=req.script_file,
+            )
+        except TaskSpecValidationError as e:
+            raise HTTPException(status_code=400, detail=_t(e.code, **e.params))
 
         # 入队
         queue = get_generation_queue()
         result = await queue.enqueue_task(
             project_name=project_name,
-            task_type="storyboard",
-            media_type="image",
-            resource_id=segment_id,
-            script_file=req.script_file,
-            payload={
-                "prompt": req.prompt,
-                "script_file": req.script_file,
-            },
+            task_type=spec.task_type,
+            media_type=spec.media_type,
+            resource_id=spec.resource_id,
+            script_file=spec.script_file,
+            payload=spec.payload,
             source="webui",
             user_id=_user.id,
         )
@@ -188,39 +178,29 @@ async def generate_video(
 
         await asyncio.to_thread(_sync)
 
-        # 验证 prompt 格式
-        if isinstance(req.prompt, dict):
-            if not is_structured_video_prompt(req.prompt):
-                raise HTTPException(
-                    status_code=400,
-                    detail=_t("video_prompt_must_be_string_or_action_object"),
-                )
-            action_text = str(req.prompt.get("action", "")).strip()
-            if not action_text:
-                raise HTTPException(status_code=400, detail=_t("video_prompt_action_empty"))
-            dialogue = req.prompt.get("dialogue", [])
-            if dialogue is not None and not isinstance(dialogue, list):
-                raise HTTPException(status_code=400, detail=_t("video_prompt_dialogue_array"))
-        elif isinstance(req.prompt, str):
-            if not req.prompt.strip():
-                raise HTTPException(status_code=400, detail=_t("prompt_text_empty"))
-        else:
-            raise HTTPException(status_code=400, detail=_t("prompt_must_be_string_or_object"))
+        # 结构校验 + 构造经单一守卫点（与 SDK 入队同源，规则不分叉）。
+        # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）。
+        try:
+            spec = TaskSpec.from_request(
+                task_type="video",
+                media_type="video",
+                resource_id=segment_id,
+                prompt=req.prompt,
+                script_file=req.script_file,
+                extra_payload={"duration_seconds": req.duration_seconds, "seed": req.seed},
+            )
+        except TaskSpecValidationError as e:
+            raise HTTPException(status_code=400, detail=_t(e.code, **e.params))
 
         # 入队（provider 由服务层根据配置自动解析，调用方无需传递）
         queue = get_generation_queue()
         result = await queue.enqueue_task(
             project_name=project_name,
-            task_type="video",
-            media_type="video",
-            resource_id=segment_id,
-            script_file=req.script_file,
-            payload={
-                "prompt": req.prompt,
-                "script_file": req.script_file,
-                "duration_seconds": req.duration_seconds,
-                "seed": req.seed,
-            },
+            task_type=spec.task_type,
+            media_type=spec.media_type,
+            resource_id=spec.resource_id,
+            script_file=spec.script_file,
+            payload=spec.payload,
             source="webui",
             user_id=_user.id,
         )
@@ -271,13 +251,23 @@ async def _enqueue_asset_generation(
 
     await asyncio.to_thread(_sync)
 
+    try:
+        task_spec = TaskSpec.from_request(
+            task_type=asset_type,
+            media_type="image",
+            resource_id=resource_name,
+            prompt=prompt,
+        )
+    except TaskSpecValidationError as e:
+        raise HTTPException(status_code=400, detail=_t(e.code, **e.params))
+
     queue = get_generation_queue()
     result = await queue.enqueue_task(
         project_name=project_name,
-        task_type=asset_type,
-        media_type="image",
-        resource_id=resource_name,
-        payload={"prompt": prompt},
+        task_type=task_spec.task_type,
+        media_type=task_spec.media_type,
+        resource_id=task_spec.resource_id,
+        payload=task_spec.payload,
         source="webui",
         user_id=user_id,
     )

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -16,9 +16,10 @@ from pydantic import BaseModel, Field
 from lib.app_data_dir import app_data_dir
 from lib.asset_types import BUCKET_KEY
 from lib.generation_queue import get_generation_queue
+from lib.generation_queue_client import TaskSpec, TaskSpecValidationError
 from lib.i18n import Translator
 from lib.project_manager import EpisodeScriptReboundError, ProjectManager, effective_mode
-from lib.reference_video import parse_prompt
+from lib.reference_video import assemble_shots_text, parse_prompt
 from server.auth import CurrentUser
 
 logger = logging.getLogger(__name__)
@@ -327,16 +328,29 @@ async def generate_unit(
     _t: Translator,
 ) -> dict[str, Any]:
     _project, script, script_file = _load_episode_script(project_name, episode, _t)
-    _find_unit(script, unit_id, _t)  # raises 404 if missing
+    unit = _find_unit(script, unit_id, _t)  # raises 404 if missing
+
+    # 经统一守卫点构造：空提示词的结构校验在此当场拒绝（400），与 SDK 入队路径一致，
+    # 不再漏到执行层失败（见 ADR-0001）。
+    try:
+        spec = TaskSpec.from_request(
+            task_type="reference_video",
+            media_type="video",
+            resource_id=unit_id,
+            prompt=assemble_shots_text(unit.get("shots") or []),
+            script_file=script_file,
+        )
+    except TaskSpecValidationError as exc:
+        raise HTTPException(status_code=400, detail=_t(exc.code, **exc.params)) from exc
 
     queue = get_generation_queue()
     result = await queue.enqueue_task(
         project_name=project_name,
-        task_type="reference_video",
-        media_type="video",
-        resource_id=unit_id,
-        payload={"script_file": script_file},
-        script_file=script_file,
+        task_type=spec.task_type,
+        media_type=spec.media_type,
+        resource_id=spec.resource_id,
+        payload=spec.payload,
+        script_file=spec.script_file,
         source="webui",
         user_id=_user.id,
     )

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -439,15 +439,28 @@ def _get_model_default_duration(provider_name: str, model_name: str | None) -> i
     return 4
 
 
-def assert_duration_supported(duration: int, supported_durations: list[int]) -> None:
+def assert_duration_supported(duration: int | float | str, supported_durations: list[int]) -> None:
     """执行层能力守卫：duration 必须落在已解析 model 的 supported_durations 内。
 
     这是 `duration ↔ supported_durations` 唯一的权威校验家——provider 在执行时才解析
     （见 ADR-0001），故能力校验只能坐在 provider 解析之后。``supported_durations`` 为空时
     放行（能力不可解析，不更坏：保持既有行为不被本次改动弄坏）。
+
+    duration 可能来自外部配置（payload / project.json），故安全解析字符串 / 浮点：
+    可解析为整数秒（如 ``"6"`` / ``6.0``）的归一化后比较；非整数秒（如 ``4.5``）一律
+    视为非法而**拒绝**，不做截断式归一化（截断会把本应拒绝的非法值静默修正）。
     """
-    if supported_durations and duration not in supported_durations:
-        raise ValueError(f"duration={duration}s 不在该模型支持范围 {supported_durations} 内")
+    if not supported_durations:
+        return
+    try:
+        numeric = float(duration)
+    except (TypeError, ValueError):
+        raise ValueError(f"duration={duration!r} 不是合法的秒数")
+    if not numeric.is_integer():
+        raise ValueError(f"duration={duration!r} 不是整数秒，不在该模型支持范围 {supported_durations} 内")
+    seconds = int(numeric)
+    if seconds not in supported_durations:
+        raise ValueError(f"duration={seconds}s 不在该模型支持范围 {supported_durations} 内")
 
 
 def _collect_sheet_paths(
@@ -834,8 +847,9 @@ async def execute_video_task(
             if supported_durations
             else _get_model_default_duration(registry_provider_id, model_name)
         )
-    # 能力守卫：provider 解析之后的唯一权威家（见 ADR-0001）。
-    assert_duration_supported(int(duration_seconds), supported_durations)
+    # 能力守卫：provider 解析之后的唯一权威家（见 ADR-0001）。安全解析交给守卫，
+    # 此处不预先 int() 截断，避免把非整数秒静默修正成「碰巧合法」的值。
+    assert_duration_supported(duration_seconds, supported_durations)
 
     end_image = None  # 宫格模式不再使用首尾帧，统一走普通图生视频
 

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -805,13 +805,14 @@ async def execute_video_task(
     except Exception:
         registry_provider_id, model_name = "gemini-aistudio", "veo-3.1-lite-generate-preview"
 
-    # supported_durations 单独解析：caps 失败不得丢弃已解析出的 provider/model，
-    # 否则 resolve_resolution 与默认 duration 会错配到 gemini。能力不可解析时留空，
-    # 守卫遇空列表放行（不更坏，见 ADR-0002）。caps 是 supported_durations 的单一
-    # 真相源，registry 与 custom provider 都准确。
+    # supported_durations 按上面已解析出的 provider/model 取（而非按 project 二次解析），
+    # 确保 duration 守卫所依据的能力与实际要调用的 model 一致——历史任务 payload 携带
+    # provider 覆盖时，二者不一致会用「项目默认 model 的能力」误判「payload 解析出的 model」。
+    # caps 失败不得丢弃已解析出的 provider/model，否则 resolve_resolution 与默认 duration
+    # 会错配。能力不可解析时留空，守卫遇空列表放行（不更坏，见 ADR-0002）。
     supported_durations: list[int] = []
     try:
-        caps = await _resolver.video_capabilities_for_project(project)
+        caps = await _resolver.video_capabilities_for_model(registry_provider_id, model_name or "", project)
         supported_durations = [int(d) for d in caps.get("supported_durations") or []]
     except Exception:
         supported_durations = []
@@ -823,7 +824,10 @@ async def execute_video_task(
     )
 
     # duration 解析收口于执行层：payload > project.default_duration > caps 默认。
-    duration_seconds = payload.get("duration_seconds") or project.get("default_duration")
+    # 用 ``is not None`` 而非 ``or`` 取 payload 值，避免显式 falsy 值被当作未设置。
+    duration_seconds = payload.get("duration_seconds")
+    if duration_seconds is None:
+        duration_seconds = project.get("default_duration")
     if not duration_seconds:
         duration_seconds = (
             supported_durations[0]

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -798,18 +798,23 @@ async def execute_video_task(
     from lib.db import async_session_factory
 
     _resolver = ConfigResolver(async_session_factory)
-    supported_durations: list[int] = []
     try:
         resolved_video = await _resolver.resolve_video_backend(project, payload)
         registry_provider_id = resolved_video.provider_id
         model_name = resolved_video.model_id or None
-        # caps 是 supported_durations 的单一真相源（registry 与 custom provider 都准确）。
+    except Exception:
+        registry_provider_id, model_name = "gemini-aistudio", "veo-3.1-lite-generate-preview"
+
+    # supported_durations 单独解析：caps 失败不得丢弃已解析出的 provider/model，
+    # 否则 resolve_resolution 与默认 duration 会错配到 gemini。能力不可解析时留空，
+    # 守卫遇空列表放行（不更坏，见 ADR-0002）。caps 是 supported_durations 的单一
+    # 真相源，registry 与 custom provider 都准确。
+    supported_durations: list[int] = []
+    try:
         caps = await _resolver.video_capabilities_for_project(project)
         supported_durations = [int(d) for d in caps.get("supported_durations") or []]
     except Exception:
-        # 能力不可解析时退回 gemini 默认且 supported_durations 留空——
-        # 不更坏：守卫遇空列表放行，保持既有行为不被本次改动弄坏。
-        registry_provider_id, model_name = "gemini-aistudio", "veo-3.1-lite-generate-preview"
+        supported_durations = []
 
     resolution = await resolve_resolution(
         project,

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -40,6 +40,7 @@ from lib.storyboard_sequence import (
     resolve_previous_storyboard_path,
 )
 from lib.thumbnail import extract_video_thumbnail
+from lib.video_backends.base import VideoCapabilityError
 from server.services.resolution_resolver import resolve_resolution
 
 pm = ProjectManager(app_data_dir())
@@ -449,18 +450,25 @@ def assert_duration_supported(duration: int | float | str, supported_durations: 
     duration 可能来自外部配置（payload / project.json），故安全解析字符串 / 浮点：
     可解析为整数秒（如 ``"6"`` / ``6.0``）的归一化后比较；非整数秒（如 ``4.5``）一律
     视为非法而**拒绝**，不做截断式归一化（截断会把本应拒绝的非法值静默修正）。
+
+    校验失败抛 :class:`VideoCapabilityError`（带稳定 code），与 ImageCapabilityError 对称——
+    Worker 捕获后渲染为本地化的 task.error_message。
     """
     if not supported_durations:
         return
     try:
         numeric = float(duration)
     except (TypeError, ValueError):
-        raise ValueError(f"duration={duration!r} 不是合法的秒数")
+        raise VideoCapabilityError("video_duration_invalid", duration=duration)
     if not numeric.is_integer():
-        raise ValueError(f"duration={duration!r} 不是整数秒，不在该模型支持范围 {supported_durations} 内")
+        raise VideoCapabilityError("video_duration_invalid", duration=duration)
     seconds = int(numeric)
     if seconds not in supported_durations:
-        raise ValueError(f"duration={seconds}s 不在该模型支持范围 {supported_durations} 内")
+        raise VideoCapabilityError(
+            "video_duration_not_supported",
+            duration=seconds,
+            supported=", ".join(str(d) for d in supported_durations),
+        )
 
 
 def _collect_sheet_paths(
@@ -1321,7 +1329,7 @@ async def execute_generation_task(task: dict[str, Any]) -> dict[str, Any]:
     with project_change_source("worker"):
         try:
             result = await executor(project_name, resource_id, payload, user_id=user_id)
-        except ImageCapabilityError as err:
+        except (ImageCapabilityError, VideoCapabilityError) as err:
             # Worker 后台无 request 上下文，按 DEFAULT_LOCALE 渲染稳定的 i18n 文案
             # 落到 task.error_message，前端轮询时即可看到本地化提示
             message = i18n_translate(err.code, locale=DEFAULT_LOCALE, **err.params)

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -439,6 +439,17 @@ def _get_model_default_duration(provider_name: str, model_name: str | None) -> i
     return 4
 
 
+def assert_duration_supported(duration: int, supported_durations: list[int]) -> None:
+    """执行层能力守卫：duration 必须落在已解析 model 的 supported_durations 内。
+
+    这是 `duration ↔ supported_durations` 唯一的权威校验家——provider 在执行时才解析
+    （见 ADR-0001），故能力校验只能坐在 provider 解析之后。``supported_durations`` 为空时
+    放行（能力不可解析，不更坏：保持既有行为不被本次改动弄坏）。
+    """
+    if supported_durations and duration not in supported_durations:
+        raise ValueError(f"duration={duration}s 不在该模型支持范围 {supported_durations} 内")
+
+
 def _collect_sheet_paths(
     project: dict,
     project_path: Path,
@@ -787,11 +798,17 @@ async def execute_video_task(
     from lib.db import async_session_factory
 
     _resolver = ConfigResolver(async_session_factory)
+    supported_durations: list[int] = []
     try:
         resolved_video = await _resolver.resolve_video_backend(project, payload)
         registry_provider_id = resolved_video.provider_id
         model_name = resolved_video.model_id or None
+        # caps 是 supported_durations 的单一真相源（registry 与 custom provider 都准确）。
+        caps = await _resolver.video_capabilities_for_project(project)
+        supported_durations = [int(d) for d in caps.get("supported_durations") or []]
     except Exception:
+        # 能力不可解析时退回 gemini 默认且 supported_durations 留空——
+        # 不更坏：守卫遇空列表放行，保持既有行为不被本次改动弄坏。
         registry_provider_id, model_name = "gemini-aistudio", "veo-3.1-lite-generate-preview"
 
     resolution = await resolve_resolution(
@@ -800,10 +817,16 @@ async def execute_video_task(
         model_name or "",
     )
 
-    # duration fallback: payload > project.default_duration > supported_durations[0] > 4
+    # duration 解析收口于执行层：payload > project.default_duration > caps 默认。
     duration_seconds = payload.get("duration_seconds") or project.get("default_duration")
     if not duration_seconds:
-        duration_seconds = _get_model_default_duration(registry_provider_id, model_name)
+        duration_seconds = (
+            supported_durations[0]
+            if supported_durations
+            else _get_model_default_duration(registry_provider_id, model_name)
+        )
+    # 能力守卫：provider 解析之后的唯一权威家（见 ADR-0001）。
+    assert_duration_supported(int(duration_seconds), supported_durations)
 
     end_image = None  # 宫格模式不再使用首尾帧，统一走普通图生视频
 

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -20,7 +20,7 @@ from lib.db import async_session_factory
 from lib.db.base import DEFAULT_USER_ID
 from lib.image_utils import compress_image_bytes
 from lib.prompt_builders import append_video_negative_tail
-from lib.reference_video import render_prompt_for_backend
+from lib.reference_video import assemble_shots_text, render_prompt_for_backend
 from lib.reference_video.errors import MissingReferenceError, RequestPayloadTooLargeError
 from lib.script_models import ReferenceResource
 from lib.thumbnail import extract_video_thumbnail
@@ -99,19 +99,14 @@ def _compress_references_to_tempfiles(
     return temp_paths
 
 
-def _render_unit_prompt(unit: dict) -> str:
-    """拼接 unit.shots[*].text 为单一 prompt，再用 shot_parser 把 @X 替成 [图N]，
-    并在末尾追加统一文本化的反向提示词。
+def _render_unit_prompt(raw: str, references: list[dict]) -> str:
+    """把原始 prompt 文本用 shot_parser 将 @X 替成 [图N]，并追加统一文本化的反向提示词。
 
-    空 prompt 会被显式拒绝：否则尾词追加后会变成只含「画面避免：…」的非空文本，
-    绕过 backend 端的空 prompt 保护，浪费配额且产出与分镜无关的内容。
+    空 prompt 的结构校验已上移到入队守卫点（``TaskSpec.from_request``），两条入队路径
+    （WebUI / SDK）都在入队时拒绝空提示词，故此处不再重复拦截。
     """
-    shots = unit.get("shots") or []
-    raw = "\n".join(str(s.get("text", "")) for s in shots)
-    references = [ReferenceResource(type=r["type"], name=r["name"]) for r in (unit.get("references") or [])]
-    rendered = render_prompt_for_backend(raw, references)
-    if not rendered.strip():
-        raise ValueError("reference video unit prompt is empty: all shots[*].text are blank")
+    refs = [ReferenceResource(type=r["type"], name=r["name"]) for r in references]
+    rendered = render_prompt_for_backend(raw, refs)
     return append_video_negative_tail(rendered)
 
 
@@ -258,11 +253,12 @@ async def execute_reference_video_task(
     # 6. 渲染 prompt（@→[图N]）。必须按 `constrained_refs` 的长度裁 `unit.references`
     #    再渲染，保证 [图N] 的 1-based 索引与 backend 实际收到的 reference_images
     #    长度严格对齐；否则裁剪后的 `@clipped_name` 会被替成 `[图N]` 指向不存在的图。
-    unit_for_prompt = unit
+    #    prompt 原文取自入队时守卫点校验过的 payload；缺省（如更早入队的在途任务）
+    #    时回退到从 unit.shots 重组。
     unit_refs = unit.get("references") or []
-    if len(constrained_refs) < len(unit_refs):
-        unit_for_prompt = {**unit, "references": unit_refs[: len(constrained_refs)]}
-    rendered_prompt = _render_unit_prompt(unit_for_prompt)
+    clipped_refs = unit_refs[: len(constrained_refs)] if len(constrained_refs) < len(unit_refs) else unit_refs
+    raw_prompt = payload.get("prompt") or assemble_shots_text(unit.get("shots") or [])
+    rendered_prompt = _render_unit_prompt(raw_prompt, clipped_refs)
 
     # 7. 压缩到临时文件（2048px/q=85）→ 首次调用
     tmp_refs: list[Path] = await asyncio.to_thread(_compress_references_to_tempfiles, constrained_refs)

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -99,14 +99,20 @@ def _compress_references_to_tempfiles(
     return temp_paths
 
 
-def _render_unit_prompt(raw: str, references: list[dict]) -> str:
-    """把原始 prompt 文本用 shot_parser 将 @X 替成 [图N]，并追加统一文本化的反向提示词。
+def _render_unit_prompt(unit: dict) -> str:
+    """从 unit.shots[*].text 拼接 prompt，用 shot_parser 把 @X 替成 [图N]，再追加反向尾词。
 
-    空 prompt 的结构校验已上移到入队守卫点（``TaskSpec.from_request``），两条入队路径
-    （WebUI / SDK）都在入队时拒绝空提示词，故此处不再重复拦截。
+    空提示词的*结构校验*已上移到入队守卫点（``TaskSpec.from_request``），两条入队路径
+    （WebUI / SDK）在入队时即拒绝空提示词。此处保留一道防御性空检查，因为参考生视频的
+    提示词源是*可变*的 script 文件且执行期从新读取（队列 dedup 不看 payload，无法靠入队
+    快照兜底）：若提示词在入队后被改空、或在途遗留任务漏过守卫，这道检查避免空提示词被
+    尾词追加成非空文本绕过 backend 的空值保护、白白消耗付费配额。
     """
-    refs = [ReferenceResource(type=r["type"], name=r["name"]) for r in references]
-    rendered = render_prompt_for_backend(raw, refs)
+    raw = assemble_shots_text(unit.get("shots") or [])
+    references = [ReferenceResource(type=r["type"], name=r["name"]) for r in (unit.get("references") or [])]
+    rendered = render_prompt_for_backend(raw, references)
+    if not rendered.strip():
+        raise ValueError("reference video unit prompt is empty: all shots[*].text are blank")
     return append_video_negative_tail(rendered)
 
 
@@ -253,12 +259,14 @@ async def execute_reference_video_task(
     # 6. 渲染 prompt（@→[图N]）。必须按 `constrained_refs` 的长度裁 `unit.references`
     #    再渲染，保证 [图N] 的 1-based 索引与 backend 实际收到的 reference_images
     #    长度严格对齐；否则裁剪后的 `@clipped_name` 会被替成 `[图N]` 指向不存在的图。
-    #    prompt 原文取自入队时守卫点校验过的 payload；缺省（如更早入队的在途任务）
-    #    时回退到从 unit.shots 重组。
+    #    prompt 始终从执行期新读取的 unit.shots 重组（脚本可变 + 队列 dedup 不看 payload，
+    #    用入队快照会丢失入队后对镜头文本的编辑）；入队 payload 里的 prompt 仅作守卫点的
+    #    校验记录，执行期不使用。
+    unit_for_prompt = unit
     unit_refs = unit.get("references") or []
-    clipped_refs = unit_refs[: len(constrained_refs)] if len(constrained_refs) < len(unit_refs) else unit_refs
-    raw_prompt = payload.get("prompt") or assemble_shots_text(unit.get("shots") or [])
-    rendered_prompt = _render_unit_prompt(raw_prompt, clipped_refs)
+    if len(constrained_refs) < len(unit_refs):
+        unit_for_prompt = {**unit, "references": unit_refs[: len(constrained_refs)]}
+    rendered_prompt = _render_unit_prompt(unit_for_prompt)
 
     # 7. 压缩到临时文件（2048px/q=85）→ 首次调用
     tmp_refs: list[Path] = await asyncio.to_thread(_compress_references_to_tempfiles, constrained_refs)

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -457,6 +457,41 @@ def test_build_video_specs_does_not_validate_duration_at_enqueue(tmp_path) -> No
     assert "duration_seconds" not in specs2[0].payload
 
 
+def test_build_reference_specs_routes_through_guard(tmp_path) -> None:
+    """参考生视频入队经统一守卫点：prompt 由 shots 拼接后随 payload 入队（见 ADR-0001）。"""
+    from server.agent_runtime.sdk_tools.enqueue_videos import _build_reference_specs
+
+    units = [
+        {
+            "unit_id": "E1U1",
+            "shots": [{"duration": 3, "text": "Shot 1 (3s): @张三 推门"}],
+            "references": [{"type": "character", "name": "张三"}],
+        }
+    ]
+    log: list[str] = []
+    specs, order_map = _build_reference_specs(units=units, script_filename="episode_1.json", skip_ids=None, log=log)
+    assert len(specs) == 1
+    assert specs[0].task_type == "reference_video"
+    assert specs[0].resource_id == "E1U1"
+    # 拼接出的 prompt 经守卫点校验后落入 payload。
+    assert specs[0].payload["prompt"] == "Shot 1 (3s): @张三 推门"
+    assert specs[0].payload["script_file"] == "episode_1.json"
+
+
+def test_build_reference_specs_skips_blank_prompt(tmp_path) -> None:
+    """shots 存在但文本全空白的 unit 被跳过并告警，不漏到执行层（结构校验上移到守卫点）。"""
+    from server.agent_runtime.sdk_tools.enqueue_videos import _build_reference_specs
+
+    units = [
+        {"unit_id": "E1U1", "shots": [{"duration": 3, "text": "   "}, {"duration": 2, "text": ""}]},
+        {"unit_id": "E1U2", "shots": [{"duration": 3, "text": "@李四 转身"}]},
+    ]
+    log: list[str] = []
+    specs, order_map = _build_reference_specs(units=units, script_filename="episode_1.json", skip_ids=None, log=log)
+    assert [s.resource_id for s in specs] == ["E1U2"]
+    assert any("E1U1" in w for w in log)
+
+
 # ---------------------------------------------------------------------------
 # text_generation
 # ---------------------------------------------------------------------------

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -461,10 +461,12 @@ def test_build_reference_specs_routes_through_guard(tmp_path) -> None:
     """参考生视频入队经统一守卫点：prompt 由 shots 拼接后随 payload 入队（见 ADR-0001）。"""
     from server.agent_runtime.sdk_tools.enqueue_videos import _build_reference_specs
 
+    # production 的 shots[*].text 由 parse_prompt 产出、已剥离 "Shot N (Xs):" header，
+    # fixture 用同样的 header-stripped 形态以贴近真实数据。
     units = [
         {
             "unit_id": "E1U1",
-            "shots": [{"duration": 3, "text": "Shot 1 (3s): @张三 推门"}],
+            "shots": [{"duration": 3, "text": "@张三 推门"}],
             "references": [{"type": "character", "name": "张三"}],
         }
     ]
@@ -474,7 +476,7 @@ def test_build_reference_specs_routes_through_guard(tmp_path) -> None:
     assert specs[0].task_type == "reference_video"
     assert specs[0].resource_id == "E1U1"
     # 拼接出的 prompt 经守卫点校验后落入 payload。
-    assert specs[0].payload["prompt"] == "Shot 1 (3s): @张三 推门"
+    assert specs[0].payload["prompt"] == "@张三 推门"
     assert specs[0].payload["script_file"] == "episode_1.json"
 
 
@@ -490,6 +492,34 @@ def test_build_reference_specs_skips_blank_prompt(tmp_path) -> None:
     specs, order_map = _build_reference_specs(units=units, script_filename="episode_1.json", skip_ids=None, log=log)
     assert [s.resource_id for s in specs] == ["E1U2"]
     assert any("E1U1" in w for w in log)
+
+
+def test_build_reference_specs_skips_empty_unit_id_without_aborting_batch(tmp_path) -> None:
+    """unit_id 为空时 from_request 抛裸 ValueError；该 unit 跳过而非中断整批（Agent 裸写 JSON 可致）。"""
+    from server.agent_runtime.sdk_tools.enqueue_videos import _build_reference_specs
+
+    units = [
+        {"unit_id": "", "shots": [{"duration": 3, "text": "@张三 推门"}]},
+        {"unit_id": "E1U2", "shots": [{"duration": 3, "text": "@李四 转身"}]},
+    ]
+    log: list[str] = []
+    specs, _ = _build_reference_specs(units=units, script_filename="episode_1.json", skip_ids=None, log=log)
+    assert [s.resource_id for s in specs] == ["E1U2"]
+
+
+def test_build_reference_specs_handles_malformed_shots(tmp_path) -> None:
+    """畸形 shots（显式 null text / 非 dict 元素）不应崩溃整批，且不得把 'None' 注入 prompt。"""
+    from server.agent_runtime.sdk_tools.enqueue_videos import _build_reference_specs
+
+    units = [
+        # text 显式 null + 一个非 dict 元素 → 拼接后为空 → 被守卫点判空跳过（不注入 'None'）。
+        {"unit_id": "E1U1", "shots": [{"duration": 3, "text": None}, "garbage"]},
+        {"unit_id": "E1U2", "shots": [{"duration": 3, "text": "@李四 转身"}]},
+    ]
+    log: list[str] = []
+    specs, _ = _build_reference_specs(units=units, script_filename="episode_1.json", skip_ids=None, log=log)
+    assert [s.resource_id for s in specs] == ["E1U2"]
+    assert all("None" not in (s.payload.get("prompt") or "") for s in specs)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -494,12 +494,14 @@ def test_build_reference_specs_skips_blank_prompt(tmp_path) -> None:
     assert any("E1U1" in w for w in log)
 
 
-def test_build_reference_specs_skips_empty_unit_id_without_aborting_batch(tmp_path) -> None:
-    """unit_id 为空时 from_request 抛裸 ValueError；该 unit 跳过而非中断整批（Agent 裸写 JSON 可致）。"""
+def test_build_reference_specs_skips_bad_unit_id_without_aborting_batch(tmp_path) -> None:
+    """unit_id 为空或键缺失（Agent 裸写 JSON 可致）都跳过该 unit 而非中断整批：
+    空串经 from_request 抛 ValueError 被捕获，缺键经 .get 归一化为空串后同样被拒。"""
     from server.agent_runtime.sdk_tools.enqueue_videos import _build_reference_specs
 
     units = [
-        {"unit_id": "", "shots": [{"duration": 3, "text": "@张三 推门"}]},
+        {"unit_id": "", "shots": [{"duration": 3, "text": "@张三 推门"}]},  # 空串
+        {"shots": [{"duration": 3, "text": "@王五 起身"}]},  # 缺 unit_id 键 → 不应抛 KeyError
         {"unit_id": "E1U2", "shots": [{"duration": 3, "text": "@李四 转身"}]},
     ]
     log: list[str] = []

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -392,8 +392,8 @@ async def test_generate_video_selected_no_match(fake_ctx: ToolContext) -> None:
     assert out.get("is_error") is True
 
 
-def test_build_asset_specs_skips_whitespace_description(monkeypatch) -> None:
-    """空白描述被跳过并告警，不应漏到 from_request 抛错而中断整批资产。"""
+def test_build_asset_specs_skips_invalid_description(monkeypatch) -> None:
+    """空白 / 非字符串描述都被跳过并告警，不应抛错（.strip()）或漏到 from_request 而中断整批。"""
     from lib.asset_types import ASSET_SPECS
     from server.agent_runtime.sdk_tools.enqueue_assets import _build_specs
 
@@ -401,12 +401,19 @@ def test_build_asset_specs_skips_whitespace_description(monkeypatch) -> None:
 
     class _PM:
         def load_project(self, _name):
-            return {bucket: {"Alice": {"description": "   "}, "Bob": {"description": "勇士"}}}
+            return {
+                bucket: {
+                    "Alice": {"description": "   "},  # 空白
+                    "Carol": {"description": {"x": 1}},  # 非字符串，.strip() 会抛 AttributeError
+                    "Bob": {"description": "勇士"},
+                }
+            }
 
     warnings: list[str] = []
-    specs = _build_specs(_PM(), "demo", "character", ["Alice", "Bob"], warnings)  # type: ignore[arg-type]
+    specs = _build_specs(_PM(), "demo", "character", ["Alice", "Carol", "Bob"], warnings)  # type: ignore[arg-type]
     assert [s.resource_id for s in specs] == ["Bob"]
     assert any("Alice" in w for w in warnings)
+    assert any("Carol" in w for w in warnings)
 
 
 def test_build_video_specs_does_not_validate_duration_at_enqueue(tmp_path) -> None:

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -392,6 +392,23 @@ async def test_generate_video_selected_no_match(fake_ctx: ToolContext) -> None:
     assert out.get("is_error") is True
 
 
+def test_build_asset_specs_skips_whitespace_description(monkeypatch) -> None:
+    """空白描述被跳过并告警，不应漏到 from_request 抛错而中断整批资产。"""
+    from lib.asset_types import ASSET_SPECS
+    from server.agent_runtime.sdk_tools.enqueue_assets import _build_specs
+
+    bucket = ASSET_SPECS["character"].bucket_key
+
+    class _PM:
+        def load_project(self, _name):
+            return {bucket: {"Alice": {"description": "   "}, "Bob": {"description": "勇士"}}}
+
+    warnings: list[str] = []
+    specs = _build_specs(_PM(), "demo", "character", ["Alice", "Bob"], warnings)  # type: ignore[arg-type]
+    assert [s.resource_id for s in specs] == ["Bob"]
+    assert any("Alice" in w for w in warnings)
+
+
 def test_build_video_specs_does_not_validate_duration_at_enqueue(tmp_path) -> None:
     """duration 是能力维度，入队侧不再校验——任意 duration 都透传给执行层（见 ADR-0001）。"""
     from server.agent_runtime.sdk_tools.enqueue_videos import _build_video_specs

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -287,11 +287,6 @@ async def test_generate_grid_wrong_mode(fake_ctx: ToolContext) -> None:
 async def test_generate_video_episode_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
 
-    async def fake_caps(_project):
-        return 4, [4, 6, 8]
-
-    monkeypatch.setattr(mod, "_fetch_video_caps", fake_caps)
-
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
         from lib.generation_queue_client import BatchTaskResult
 
@@ -322,11 +317,6 @@ async def test_generate_video_episode_error(fake_ctx: ToolContext) -> None:
 async def test_generate_video_scene_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
 
-    async def fake_caps(_project):
-        return 4, [4, 6, 8]
-
-    monkeypatch.setattr(mod, "_fetch_video_caps", fake_caps)
-
     async def fake_enqueue(**kwargs):
         return {"task": {}, "result": {"file_path": "videos/scene_E1S01.mp4"}}
 
@@ -344,11 +334,6 @@ async def test_generate_video_scene_missing(fake_ctx: ToolContext) -> None:
 
 async def test_generate_video_all_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
-
-    async def fake_caps(_project):
-        return 4, [4, 6, 8]
-
-    monkeypatch.setattr(mod, "_fetch_video_caps", fake_caps)
 
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
         from lib.generation_queue_client import BatchTaskResult
@@ -380,11 +365,6 @@ async def test_generate_video_all_error(fake_ctx: ToolContext) -> None:
 async def test_generate_video_selected_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
 
-    async def fake_caps(_project):
-        return 4, [4, 6, 8]
-
-    monkeypatch.setattr(mod, "_fetch_video_caps", fake_caps)
-
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
         from lib.generation_queue_client import BatchTaskResult
 
@@ -410,6 +390,47 @@ async def test_generate_video_selected_no_match(fake_ctx: ToolContext) -> None:
     tool_obj = generate_video_selected_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json", "scene_ids": ["NO_SUCH"]})
     assert out.get("is_error") is True
+
+
+def test_build_video_specs_does_not_validate_duration_at_enqueue(tmp_path) -> None:
+    """duration 是能力维度，入队侧不再校验——任意 duration 都透传给执行层（见 ADR-0001）。"""
+    from server.agent_runtime.sdk_tools.enqueue_videos import _build_video_specs
+
+    (tmp_path / "storyboards").mkdir()
+    (tmp_path / "storyboards" / "scene_S01.png").write_bytes(b"png")
+    items = [
+        {
+            "segment_id": "S01",
+            "video_prompt": "一个奔跑的镜头",
+            "duration_seconds": 7,  # 不属于任何典型 supported_durations
+            "generated_assets": {"storyboard_image": "storyboards/scene_S01.png"},
+        }
+    ]
+    log: list[str] = []
+    specs, order_map = _build_video_specs(
+        items=items,
+        id_field="segment_id",
+        content_mode="narration",
+        script_filename="episode_1.json",
+        project_dir=tmp_path,
+        skip_ids=None,
+        log=log,
+    )
+    assert len(specs) == 1
+    assert specs[0].payload["duration_seconds"] == 7
+
+    # 未显式指定 duration 时不携带该键，留给执行层按 caps 收口默认。
+    items[0].pop("duration_seconds")
+    specs2, _ = _build_video_specs(
+        items=items,
+        id_field="segment_id",
+        content_mode="narration",
+        script_filename="episode_1.json",
+        project_dir=tmp_path,
+        skip_ids=None,
+        log=[],
+    )
+    assert "duration_seconds" not in specs2[0].payload
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -138,21 +138,33 @@ def test_compress_references_empty_input(tmp_path: Path):
     assert _compress_references_to_tempfiles([]) == []
 
 
-def test_render_unit_prompt_no_longer_rejects_empty():
-    """空提示词的结构校验已上移到入队守卫点，渲染函数自身不再拦截（不重复守门）。"""
-    references = [{"type": "character", "name": "张三"}]
-    # 不抛错；返回的只是负向尾词部分（不含正文）。
-    rendered = _render_unit_prompt("   ", references)
-    assert isinstance(rendered, str)
+def test_render_unit_prompt_rejects_empty_shots():
+    """执行层保留一道防御性空检查：提示词源是可变 script、执行期重读，结构校验上移到
+    入队守卫点后仍需挡住「入队后被改空 / 在途遗留任务」漏过的空提示词，避免尾词追加后
+    被当成有效 prompt 提交给付费 backend。"""
+    unit = {
+        "shots": [
+            {"duration": 3, "text": ""},
+            {"duration": 2, "text": "   "},
+        ],
+        "references": [{"type": "character", "name": "张三"}],
+    }
+    with pytest.raises(ValueError, match="empty"):
+        _render_unit_prompt(unit)
 
 
 def test_render_unit_prompt_replaces_mentions_in_order():
-    raw = "Shot 1 (3s): @张三 推门\nShot 2 (5s): 对面的 @张三 抬眼，背景是 @酒馆"
-    references = [
-        {"type": "character", "name": "张三"},
-        {"type": "scene", "name": "酒馆"},
-    ]
-    rendered = _render_unit_prompt(raw, references)
+    unit = {
+        "shots": [
+            {"duration": 3, "text": "Shot 1 (3s): @张三 推门"},
+            {"duration": 5, "text": "Shot 2 (5s): 对面的 @张三 抬眼，背景是 @酒馆"},
+        ],
+        "references": [
+            {"type": "character", "name": "张三"},
+            {"type": "scene", "name": "酒馆"},
+        ],
+    }
+    rendered = _render_unit_prompt(unit)
     assert "[图1]" in rendered
     assert "[图2]" in rendered
     assert "@张三" not in rendered

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -138,31 +138,21 @@ def test_compress_references_empty_input(tmp_path: Path):
     assert _compress_references_to_tempfiles([]) == []
 
 
-def test_render_unit_prompt_rejects_empty_shots():
-    """所有 shots[].text 都为空时必须抛错，避免只追加负向尾词后被当成有效 prompt 提交给 backend。"""
-    unit = {
-        "shots": [
-            {"duration": 3, "text": ""},
-            {"duration": 2, "text": "   "},
-        ],
-        "references": [{"type": "character", "name": "张三"}],
-    }
-    with pytest.raises(ValueError, match="empty"):
-        _render_unit_prompt(unit)
+def test_render_unit_prompt_no_longer_rejects_empty():
+    """空提示词的结构校验已上移到入队守卫点，渲染函数自身不再拦截（不重复守门）。"""
+    references = [{"type": "character", "name": "张三"}]
+    # 不抛错；返回的只是负向尾词部分（不含正文）。
+    rendered = _render_unit_prompt("   ", references)
+    assert isinstance(rendered, str)
 
 
 def test_render_unit_prompt_replaces_mentions_in_order():
-    unit = {
-        "shots": [
-            {"duration": 3, "text": "Shot 1 (3s): @张三 推门"},
-            {"duration": 5, "text": "Shot 2 (5s): 对面的 @张三 抬眼，背景是 @酒馆"},
-        ],
-        "references": [
-            {"type": "character", "name": "张三"},
-            {"type": "scene", "name": "酒馆"},
-        ],
-    }
-    rendered = _render_unit_prompt(unit)
+    raw = "Shot 1 (3s): @张三 推门\nShot 2 (5s): 对面的 @张三 抬眼，背景是 @酒馆"
+    references = [
+        {"type": "character", "name": "张三"},
+        {"type": "scene", "name": "酒馆"},
+    ]
+    rendered = _render_unit_prompt(raw, references)
     assert "[图1]" in rendered
     assert "[图2]" in rendered
     assert "@张三" not in rendered

--- a/tests/server/test_reference_videos_router.py
+++ b/tests/server/test_reference_videos_router.py
@@ -214,6 +214,22 @@ def test_generate_unit_enqueues_task(client: TestClient, monkeypatch: pytest.Mon
     assert enqueued[0]["task_type"] == "reference_video"
     assert enqueued[0]["media_type"] == "video"
     assert enqueued[0]["resource_id"] == uid
+    # 经统一守卫点构造：shots[*].text 拼接出的 prompt 随 payload 入队（见 ADR-0001）。
+    # parse_prompt 已剥离 `Shot N (Xs):` header，存盘的 shot text 仅余正文。
+    assert enqueued[0]["payload"]["prompt"] == "@张三 推门"
+
+
+def test_generate_unit_rejects_blank_prompt(client: TestClient, tmp_path: Path):
+    """shots 文本全空白的 unit 在入队时被守卫点拒绝（400），不再漏到执行层失败。"""
+    script_path = tmp_path / "projects" / "demo" / "scripts" / "episode_1.json"
+    script = json.loads(script_path.read_text(encoding="utf-8"))
+    script["video_units"] = [
+        {"unit_id": "E1U1", "shots": [{"duration": 3, "text": "  "}], "references": [], "duration_seconds": 3}
+    ]
+    script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
+
+    resp = client.post("/api/v1/projects/demo/reference-videos/episodes/1/units/E1U1/generate")
+    assert resp.status_code == 400, resp.text
 
 
 def test_generate_unit_missing_returns_404(client: TestClient):

--- a/tests/test_generation_queue_client.py
+++ b/tests/test_generation_queue_client.py
@@ -6,8 +6,9 @@ import pytest
 
 from lib.generation_queue_client import (
     BatchTaskResult,
-    BatchTaskSpec,
     TaskCancelledError,
+    TaskSpec,
+    TaskSpecValidationError,
     TaskWaitTimeoutError,
     WorkerOfflineError,
     batch_enqueue_and_wait_sync,
@@ -15,6 +16,117 @@ from lib.generation_queue_client import (
     enqueue_task_only,
     wait_for_task,
 )
+
+
+class TestTaskSpecFromRequest:
+    def test_video_string_prompt_builds_spec(self):
+        spec = TaskSpec.from_request(
+            task_type="video",
+            media_type="video",
+            resource_id="S01",
+            prompt="一个奔跑的镜头",
+            script_file="episode_1.json",
+        )
+        assert spec.task_type == "video"
+        assert spec.media_type == "video"
+        assert spec.resource_id == "S01"
+        assert spec.script_file == "episode_1.json"
+        assert spec.payload == {"prompt": "一个奔跑的镜头", "script_file": "episode_1.json"}
+
+    def test_video_action_object_prompt_builds_spec(self):
+        prompt = {"action": "转身", "camera_motion": "Static", "dialogue": [{"speaker": "甲", "line": "走"}]}
+        spec = TaskSpec.from_request(
+            task_type="video",
+            media_type="video",
+            resource_id="S01",
+            prompt=prompt,
+        )
+        assert spec.payload == {"prompt": prompt}
+
+    def test_video_extra_payload_merged(self):
+        spec = TaskSpec.from_request(
+            task_type="video",
+            media_type="video",
+            resource_id="S01",
+            prompt="跑",
+            script_file="episode_1.json",
+            extra_payload={"duration_seconds": 8, "seed": 42},
+        )
+        assert spec.payload == {
+            "prompt": "跑",
+            "script_file": "episode_1.json",
+            "duration_seconds": 8,
+            "seed": 42,
+        }
+
+    def test_video_empty_string_prompt_rejected(self):
+        with pytest.raises(TaskSpecValidationError) as exc:
+            TaskSpec.from_request(task_type="video", media_type="video", resource_id="S01", prompt="   ")
+        assert exc.value.code == "prompt_text_empty"
+
+    def test_video_dict_without_action_rejected(self):
+        with pytest.raises(TaskSpecValidationError) as exc:
+            TaskSpec.from_request(task_type="video", media_type="video", resource_id="S01", prompt={"scene": "x"})
+        assert exc.value.code == "video_prompt_must_be_string_or_action_object"
+
+    def test_video_empty_action_rejected(self):
+        with pytest.raises(TaskSpecValidationError) as exc:
+            TaskSpec.from_request(task_type="video", media_type="video", resource_id="S01", prompt={"action": "  "})
+        assert exc.value.code == "video_prompt_action_empty"
+
+    def test_video_dialogue_not_array_rejected(self):
+        with pytest.raises(TaskSpecValidationError) as exc:
+            TaskSpec.from_request(
+                task_type="video",
+                media_type="video",
+                resource_id="S01",
+                prompt={"action": "转身", "dialogue": "走"},
+            )
+        assert exc.value.code == "video_prompt_dialogue_array"
+
+    def test_video_non_string_non_dict_prompt_rejected(self):
+        with pytest.raises(TaskSpecValidationError) as exc:
+            TaskSpec.from_request(task_type="video", media_type="video", resource_id="S01", prompt=123)
+        assert exc.value.code == "prompt_must_be_string_or_object"
+
+    def test_storyboard_scene_object_builds_spec(self):
+        prompt = {"scene": "黄昏的码头", "composition": {}}
+        spec = TaskSpec.from_request(
+            task_type="storyboard", media_type="image", resource_id="S01", prompt=prompt, script_file="e.json"
+        )
+        assert spec.payload == {"prompt": prompt, "script_file": "e.json"}
+
+    def test_storyboard_dict_without_scene_rejected(self):
+        with pytest.raises(TaskSpecValidationError) as exc:
+            TaskSpec.from_request(task_type="storyboard", media_type="image", resource_id="S01", prompt={"action": "x"})
+        assert exc.value.code == "prompt_must_be_string_or_scene_object"
+
+    def test_storyboard_empty_scene_rejected(self):
+        with pytest.raises(TaskSpecValidationError) as exc:
+            TaskSpec.from_request(task_type="storyboard", media_type="image", resource_id="S01", prompt={"scene": " "})
+        assert exc.value.code == "prompt_scene_empty"
+
+    def test_asset_empty_prompt_rejected(self):
+        with pytest.raises(TaskSpecValidationError) as exc:
+            TaskSpec.from_request(task_type="character", media_type="image", resource_id="张三", prompt="")
+        assert exc.value.code == "prompt_text_empty"
+
+    def test_asset_string_prompt_builds_spec(self):
+        spec = TaskSpec.from_request(task_type="character", media_type="image", resource_id="张三", prompt="一位老者")
+        assert spec.payload == {"prompt": "一位老者"}
+
+    def test_empty_resource_id_rejected(self):
+        with pytest.raises(ValueError):
+            TaskSpec.from_request(task_type="video", media_type="video", resource_id="", prompt="跑")
+
+    def test_webui_and_sdk_same_input_same_spec(self):
+        # 同一非法输入，两路（WebUI / SDK）都经 from_request，结果一致。
+        kwargs = dict(task_type="video", media_type="video", resource_id="S01", prompt={"action": ""})
+        with pytest.raises(TaskSpecValidationError) as web:
+            TaskSpec.from_request(**kwargs)
+        with pytest.raises(TaskSpecValidationError) as sdk:
+            TaskSpec.from_request(**kwargs)
+        assert web.value.code == sdk.value.code == "video_prompt_action_empty"
 
 
 class TestGenerationQueueClient:
@@ -159,8 +271,8 @@ class TestBatchEnqueueAndWaitSync:
         ]
 
         specs = [
-            BatchTaskSpec(task_type="character", media_type="image", resource_id="张三"),
-            BatchTaskSpec(task_type="character", media_type="image", resource_id="李四"),
+            TaskSpec(task_type="character", media_type="image", resource_id="张三"),
+            TaskSpec(task_type="character", media_type="image", resource_id="李四"),
         ]
         successes, failures = batch_enqueue_and_wait_sync(
             project_name="demo",
@@ -186,8 +298,8 @@ class TestBatchEnqueueAndWaitSync:
         ]
 
         specs = [
-            BatchTaskSpec(task_type="clue", media_type="image", resource_id="玉佩"),
-            BatchTaskSpec(task_type="clue", media_type="image", resource_id="老槐树"),
+            TaskSpec(task_type="clue", media_type="image", resource_id="玉佩"),
+            TaskSpec(task_type="clue", media_type="image", resource_id="老槐树"),
         ]
         successes, failures = batch_enqueue_and_wait_sync(
             project_name="demo",
@@ -206,7 +318,7 @@ class TestBatchEnqueueAndWaitSync:
         mock_wait.side_effect = RuntimeError("connection lost")
 
         specs = [
-            BatchTaskSpec(task_type="storyboard", media_type="image", resource_id="S01"),
+            TaskSpec(task_type="storyboard", media_type="image", resource_id="S01"),
         ]
         successes, failures = batch_enqueue_and_wait_sync(
             project_name="demo",
@@ -230,12 +342,12 @@ class TestBatchEnqueueAndWaitSync:
         ]
 
         specs = [
-            BatchTaskSpec(
+            TaskSpec(
                 task_type="storyboard",
                 media_type="image",
                 resource_id="S01",
             ),
-            BatchTaskSpec(
+            TaskSpec(
                 task_type="storyboard",
                 media_type="image",
                 resource_id="S02",
@@ -278,8 +390,8 @@ class TestBatchEnqueueAndWaitSync:
             failure_ids.append(br.resource_id)
 
         specs = [
-            BatchTaskSpec(task_type="character", media_type="image", resource_id="A"),
-            BatchTaskSpec(task_type="character", media_type="image", resource_id="B"),
+            TaskSpec(task_type="character", media_type="image", resource_id="A"),
+            TaskSpec(task_type="character", media_type="image", resource_id="B"),
         ]
         batch_enqueue_and_wait_sync(
             project_name="demo",

--- a/tests/test_generation_queue_client.py
+++ b/tests/test_generation_queue_client.py
@@ -126,6 +126,30 @@ class TestTaskSpecFromRequest:
         spec = TaskSpec.from_request(task_type="character", media_type="image", resource_id="张三", prompt="一位老者")
         assert spec.payload == {"prompt": "一位老者"}
 
+    def test_reference_video_prompt_builds_spec(self):
+        # 参考生视频的 prompt 由 shots[*].text 拼接而成，走默认（非空字符串）分支。
+        spec = TaskSpec.from_request(
+            task_type="reference_video",
+            media_type="video",
+            resource_id="E1U1",
+            prompt="Shot 1 (3s): @张三 推门",
+            script_file="episode_1.json",
+        )
+        assert spec.task_type == "reference_video"
+        assert spec.payload == {"prompt": "Shot 1 (3s): @张三 推门", "script_file": "episode_1.json"}
+
+    def test_reference_video_empty_prompt_rejected(self):
+        # 所有 shots[*].text 拼接后只剩空白 → 守卫点拒绝，不再漏到执行层。
+        with pytest.raises(TaskSpecValidationError) as exc:
+            TaskSpec.from_request(
+                task_type="reference_video",
+                media_type="video",
+                resource_id="E1U1",
+                prompt="\n   ",
+                script_file="episode_1.json",
+            )
+        assert exc.value.code == "prompt_text_empty"
+
     def test_empty_resource_id_rejected(self):
         with pytest.raises(ValueError):
             TaskSpec.from_request(task_type="video", media_type="video", resource_id="", prompt="跑")

--- a/tests/test_generation_queue_client.py
+++ b/tests/test_generation_queue_client.py
@@ -74,6 +74,12 @@ class TestTaskSpecFromRequest:
             TaskSpec.from_request(task_type="video", media_type="video", resource_id="S01", prompt={"action": "  "})
         assert exc.value.code == "video_prompt_action_empty"
 
+    def test_video_null_action_rejected(self):
+        # 显式 null：str(None) 会得到 truthy 的 "None"，必须当作空值拒绝而非放行。
+        with pytest.raises(TaskSpecValidationError) as exc:
+            TaskSpec.from_request(task_type="video", media_type="video", resource_id="S01", prompt={"action": None})
+        assert exc.value.code == "video_prompt_action_empty"
+
     def test_video_dialogue_not_array_rejected(self):
         with pytest.raises(TaskSpecValidationError) as exc:
             TaskSpec.from_request(
@@ -106,6 +112,11 @@ class TestTaskSpecFromRequest:
             TaskSpec.from_request(task_type="storyboard", media_type="image", resource_id="S01", prompt={"scene": " "})
         assert exc.value.code == "prompt_scene_empty"
 
+    def test_storyboard_null_scene_rejected(self):
+        with pytest.raises(TaskSpecValidationError) as exc:
+            TaskSpec.from_request(task_type="storyboard", media_type="image", resource_id="S01", prompt={"scene": None})
+        assert exc.value.code == "prompt_scene_empty"
+
     def test_asset_empty_prompt_rejected(self):
         with pytest.raises(TaskSpecValidationError) as exc:
             TaskSpec.from_request(task_type="character", media_type="image", resource_id="张三", prompt="")
@@ -118,6 +129,30 @@ class TestTaskSpecFromRequest:
     def test_empty_resource_id_rejected(self):
         with pytest.raises(ValueError):
             TaskSpec.from_request(task_type="video", media_type="video", resource_id="", prompt="跑")
+
+    def test_extra_payload_cannot_override_reserved_keys(self):
+        # extra_payload 携带保留键会绕过单一守卫点，必须拒绝。
+        with pytest.raises(ValueError) as exc:
+            TaskSpec.from_request(
+                task_type="video",
+                media_type="video",
+                resource_id="S01",
+                prompt="跑",
+                extra_payload={"prompt": "未校验的别的值"},
+            )
+        assert "reserved" in str(exc.value)
+
+    def test_extra_payload_cannot_override_script_file(self):
+        with pytest.raises(ValueError) as exc:
+            TaskSpec.from_request(
+                task_type="video",
+                media_type="video",
+                resource_id="S01",
+                prompt="跑",
+                script_file="e.json",
+                extra_payload={"script_file": "../越权.json"},
+            )
+        assert "reserved" in str(exc.value)
 
     def test_webui_and_sdk_same_input_same_spec(self):
         # 同一非法输入，两路（WebUI / SDK）都经 from_request，结果一致。

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -364,7 +364,7 @@ class TestGenerationTasks:
         )
         monkeypatch.setattr(
             resolver_mod.ConfigResolver,
-            "video_capabilities_for_project",
+            "video_capabilities_for_model",
             _async_return({"supported_durations": [4, 6, 8], "default_duration": None}),
         )
 
@@ -401,7 +401,7 @@ class TestGenerationTasks:
         )
         monkeypatch.setattr(
             resolver_mod.ConfigResolver,
-            "video_capabilities_for_project",
+            "video_capabilities_for_model",
             _async_return({"supported_durations": [4, 6, 8], "default_duration": None}),
         )
 
@@ -436,7 +436,7 @@ class TestGenerationTasks:
         )
         monkeypatch.setattr(
             resolver_mod.ConfigResolver,
-            "video_capabilities_for_project",
+            "video_capabilities_for_model",
             _async_return({"supported_durations": [6, 10], "default_duration": None}),
         )
         # 项目默认 duration 也置空，强制走 caps 默认。
@@ -464,7 +464,7 @@ class TestGenerationTasks:
         from lib.config import resolver as resolver_mod
         from lib.config.resolver import ProviderModel
 
-        async def boom_caps(self, project):
+        async def boom_caps(self, provider_id, model_id, project=None):
             raise ValueError("supported_durations is empty for ark/seedance")
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
@@ -475,7 +475,7 @@ class TestGenerationTasks:
         monkeypatch.setattr(
             resolver_mod.ConfigResolver, "resolve_video_backend", _async_return(ProviderModel("ark", "seedance"))
         )
-        monkeypatch.setattr(resolver_mod.ConfigResolver, "video_capabilities_for_project", boom_caps)
+        monkeypatch.setattr(resolver_mod.ConfigResolver, "video_capabilities_for_model", boom_caps)
 
         result = await generation_tasks.execute_video_task(
             "demo",
@@ -489,6 +489,43 @@ class TestGenerationTasks:
         assert result["resource_type"] == "videos"
         # caps 失败时 supported_durations 留空 → 守卫放行（不更坏），但 provider 不被改写。
         assert seen_resolution_args == [("ark", "seedance")]
+
+    async def test_caps_resolved_for_payload_provider_model(self, monkeypatch, tmp_path):
+        """caps 按已解析（含 payload 覆盖）的 provider/model 取，而非按 project 二次解析。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        seen_caps_args: list[tuple] = []
+
+        from lib.config import resolver as resolver_mod
+        from lib.config.resolver import ProviderModel
+
+        async def capture_caps(self, provider_id, model_id, project=None):
+            seen_caps_args.append((provider_id, model_id))
+            return {"supported_durations": [4, 6, 8], "default_duration": None}
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_resolution", _async_return("720p"))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+        # 模拟历史任务 payload 覆盖：resolve_video_backend 解析出 ark/seedance。
+        monkeypatch.setattr(
+            resolver_mod.ConfigResolver, "resolve_video_backend", _async_return(ProviderModel("ark", "seedance"))
+        )
+        monkeypatch.setattr(resolver_mod.ConfigResolver, "video_capabilities_for_model", capture_caps)
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {
+                "script_file": "episode_1.json",
+                "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                "duration_seconds": 8,
+            },
+        )
+        # caps 用解析后的 model 而非 project 默认取，二者一致。
+        assert seen_caps_args == [("ark", "seedance")]
 
     async def test_get_media_generator_skips_image_backend_for_video_tasks(self, monkeypatch, tmp_path):
         """视频任务只应初始化视频 backend，避免图片配置缺失导致提前失败。"""

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from lib.video_backends.base import VideoCapabilityError
 from server.services import generation_tasks
 from server.services.generation_tasks import assert_duration_supported
 
@@ -12,30 +13,33 @@ class TestAssertDurationSupported:
         assert_duration_supported(8, [4, 6, 8])  # no raise
 
     def test_unsupported_duration_rejected(self):
-        with pytest.raises(ValueError) as exc:
+        # 抛带稳定 code 的能力错误（与 ImageCapabilityError 对称），细节在 params。
+        with pytest.raises(VideoCapabilityError) as exc:
             assert_duration_supported(5, [4, 6, 8])
-        assert "5" in str(exc.value)
+        assert exc.value.code == "video_duration_not_supported"
+        assert exc.value.params["duration"] == 5
 
     def test_empty_supported_list_passes(self):
         # 能力不可解析时不更坏：空列表放行，保持既有行为不被本次改动弄坏。
         assert_duration_supported(99, [])  # no raise
 
     def test_integer_like_string_and_float_accepted(self):
-        # 外部配置可能给字符串 / 浮点，可解析为整数秒的归一化后通过，不抛裸 ValueError。
+        # 外部配置可能给字符串 / 浮点，可解析为整数秒的归一化后通过，不抛裸异常。
         assert_duration_supported("6", [4, 6, 8])  # no raise
         assert_duration_supported(6.0, [4, 6, 8])  # no raise
 
     def test_fractional_duration_rejected_not_truncated(self):
         # 非整数秒一律拒绝，绝不截断成「碰巧合法」的 4。
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(VideoCapabilityError) as exc:
             assert_duration_supported(4.5, [4, 6, 8])
-        assert "4.5" in str(exc.value)
-        with pytest.raises(ValueError):
+        assert exc.value.code == "video_duration_invalid"
+        with pytest.raises(VideoCapabilityError):
             assert_duration_supported("4.5", [4, 6, 8])
 
     def test_non_numeric_duration_rejected(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(VideoCapabilityError) as exc:
             assert_duration_supported("abc", [4, 6, 8])
+        assert exc.value.code == "video_duration_invalid"
 
 
 def _async_return(value):
@@ -385,7 +389,7 @@ class TestGenerationTasks:
             _async_return({"supported_durations": [4, 6, 8], "default_duration": None}),
         )
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(VideoCapabilityError) as exc:
             await generation_tasks.execute_video_task(
                 "demo",
                 "E1S01",
@@ -395,7 +399,7 @@ class TestGenerationTasks:
                     "duration_seconds": 5,
                 },
             )
-        assert "5" in str(exc.value)
+        assert exc.value.code == "video_duration_not_supported"
         # 越界 duration 在起跑时被拒，绝不应调用后端生成。
         assert fake_generator.video_calls == []
 

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -4,6 +4,21 @@ from pathlib import Path
 import pytest
 
 from server.services import generation_tasks
+from server.services.generation_tasks import assert_duration_supported
+
+
+class TestAssertDurationSupported:
+    def test_supported_duration_passes(self):
+        assert_duration_supported(8, [4, 6, 8])  # no raise
+
+    def test_unsupported_duration_rejected(self):
+        with pytest.raises(ValueError) as exc:
+            assert_duration_supported(5, [4, 6, 8])
+        assert "5" in str(exc.value)
+
+    def test_empty_supported_list_passes(self):
+        # 能力不可解析时不更坏：空列表放行，保持既有行为不被本次改动弄坏。
+        assert_duration_supported(99, [])  # no raise
 
 
 def _async_return(value):
@@ -331,6 +346,109 @@ class TestGenerationTasks:
         asset_types = [call["asset_type"] for call in fake_pm.updated_assets]
         assert "video_thumbnail" in asset_types
         assert thumbnail_path.exists()
+
+    async def test_execute_video_task_rejects_unsupported_duration(self, monkeypatch, tmp_path):
+        """执行层在解析出 ProviderModel 后，对越界 duration 以明确错误拒绝。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+
+        from lib.config import resolver as resolver_mod
+        from lib.config.resolver import ProviderModel
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_resolution", _async_return("720p"))
+        monkeypatch.setattr(
+            resolver_mod.ConfigResolver, "resolve_video_backend", _async_return(ProviderModel("ark", "seedance"))
+        )
+        monkeypatch.setattr(
+            resolver_mod.ConfigResolver,
+            "video_capabilities_for_project",
+            _async_return({"supported_durations": [4, 6, 8], "default_duration": None}),
+        )
+
+        with pytest.raises(ValueError) as exc:
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                    "duration_seconds": 5,
+                },
+            )
+        assert "5" in str(exc.value)
+        # 越界 duration 在起跑时被拒，绝不应调用后端生成。
+        assert fake_generator.video_calls == []
+
+    async def test_execute_video_task_supported_duration_passes(self, monkeypatch, tmp_path):
+        """合法 duration 通过守卫，正常进入后端生成。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+
+        from lib.config import resolver as resolver_mod
+        from lib.config.resolver import ProviderModel
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_resolution", _async_return("720p"))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            resolver_mod.ConfigResolver, "resolve_video_backend", _async_return(ProviderModel("ark", "seedance"))
+        )
+        monkeypatch.setattr(
+            resolver_mod.ConfigResolver,
+            "video_capabilities_for_project",
+            _async_return({"supported_durations": [4, 6, 8], "default_duration": None}),
+        )
+
+        result = await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {
+                "script_file": "episode_1.json",
+                "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                "duration_seconds": 8,
+            },
+        )
+        assert result["resource_type"] == "videos"
+        assert fake_generator.video_calls[0]["duration_seconds"] == 8
+
+    async def test_execute_video_task_default_duration_from_caps(self, monkeypatch, tmp_path):
+        """无显式 duration 时，默认值由 caps 收口（取 supported_durations[0]），且必然合法。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+
+        from lib.config import resolver as resolver_mod
+        from lib.config.resolver import ProviderModel
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_resolution", _async_return("720p"))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            resolver_mod.ConfigResolver, "resolve_video_backend", _async_return(ProviderModel("ark", "seedance"))
+        )
+        monkeypatch.setattr(
+            resolver_mod.ConfigResolver,
+            "video_capabilities_for_project",
+            _async_return({"supported_durations": [6, 10], "default_duration": None}),
+        )
+        # 项目默认 duration 也置空，强制走 caps 默认。
+        fake_pm.project.pop("default_duration", None)
+
+        result = await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {"script_file": "episode_1.json", "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []}},
+        )
+        assert result["resource_type"] == "videos"
+        assert fake_generator.video_calls[0]["duration_seconds"] == 6
 
     async def test_get_media_generator_skips_image_backend_for_video_tasks(self, monkeypatch, tmp_path):
         """视频任务只应初始化视频 backend，避免图片配置缺失导致提前失败。"""

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -20,6 +20,23 @@ class TestAssertDurationSupported:
         # 能力不可解析时不更坏：空列表放行，保持既有行为不被本次改动弄坏。
         assert_duration_supported(99, [])  # no raise
 
+    def test_integer_like_string_and_float_accepted(self):
+        # 外部配置可能给字符串 / 浮点，可解析为整数秒的归一化后通过，不抛裸 ValueError。
+        assert_duration_supported("6", [4, 6, 8])  # no raise
+        assert_duration_supported(6.0, [4, 6, 8])  # no raise
+
+    def test_fractional_duration_rejected_not_truncated(self):
+        # 非整数秒一律拒绝，绝不截断成「碰巧合法」的 4。
+        with pytest.raises(ValueError) as exc:
+            assert_duration_supported(4.5, [4, 6, 8])
+        assert "4.5" in str(exc.value)
+        with pytest.raises(ValueError):
+            assert_duration_supported("4.5", [4, 6, 8])
+
+    def test_non_numeric_duration_rejected(self):
+        with pytest.raises(ValueError):
+            assert_duration_supported("abc", [4, 6, 8])
+
 
 def _async_return(value):
     """Create an async function that always returns the given value (ignoring args)."""

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -450,6 +450,46 @@ class TestGenerationTasks:
         assert result["resource_type"] == "videos"
         assert fake_generator.video_calls[0]["duration_seconds"] == 6
 
+    async def test_caps_failure_preserves_resolved_provider(self, monkeypatch, tmp_path):
+        """caps 解析失败不得丢弃已解析的 provider/model：resolve_resolution 仍按真实 provider。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        seen_resolution_args: list[tuple] = []
+
+        async def fake_resolution(project, provider, model):
+            seen_resolution_args.append((provider, model))
+            return "720p"
+
+        from lib.config import resolver as resolver_mod
+        from lib.config.resolver import ProviderModel
+
+        async def boom_caps(self, project):
+            raise ValueError("supported_durations is empty for ark/seedance")
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_resolution", fake_resolution)
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            resolver_mod.ConfigResolver, "resolve_video_backend", _async_return(ProviderModel("ark", "seedance"))
+        )
+        monkeypatch.setattr(resolver_mod.ConfigResolver, "video_capabilities_for_project", boom_caps)
+
+        result = await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {
+                "script_file": "episode_1.json",
+                "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                "duration_seconds": 9,
+            },
+        )
+        assert result["resource_type"] == "videos"
+        # caps 失败时 supported_durations 留空 → 守卫放行（不更坏），但 provider 不被改写。
+        assert seen_resolution_args == [("ark", "seedance")]
+
     async def test_get_media_generator_skips_image_backend_for_video_tasks(self, monkeypatch, tmp_path):
         """视频任务只应初始化视频 backend，避免图片配置缺失导致提前失败。"""
         project_path = _prepare_files(tmp_path)


### PR DESCRIPTION
## 背景

「校验一个生成任务请求是否合法」原先在两个入队入口规则**分叉**：WebUI 路由 `generate.py` 校验 prompt 格式但不校验 duration；SDK 工具 `enqueue_videos.py` 在 `_build_video_specs` 里急切拉 caps 并校验 `duration ∈ supported_durations`。同一个非法 spec，从 SDK 进会被挡、从 WebUI 进却溜到执行层被 provider 静默改写。

前置依赖（收敛 provider 解析为深模块）已合并，provider 解析已收归执行层、入队 payload 不再携带 provider（见 `docs/adr/0001-image-capability-resolved-at-execution.md`）。本 PR 在其干净形态之上落地。

## 改动

按校验性质拆两轴：

**结构校验（provider 无关）收归入队单一守卫点**
- `BatchTaskSpec` 重命名为 `TaskSpec`，新增 `TaskSpec.from_request()` 做按 `task_type` 分派的 prompt 结构校验 + `TaskSpecValidationError`（复用现有 i18n key，零新增）。
- WebUI 三条路由（video/storyboard/asset）与 SDK 三个**带 prompt** 的 spec 构建器（assets/storyboards/videos）都经 `from_request` 构造，结构性杜绝分叉。reference_video 无 prompt、合法性维度不同（资产引用/容量约束），刻意经 `_build_reference_specs` 直接构造，不在本次 from_request 范围内。

**能力校验（duration ↔ supported_durations）下沉执行层**
- 新增纯函数 `assert_duration_supported`，在 `execute_video_task` 解析出 `ProviderModel` 后校验；默认 duration 由 caps 收口。
- caps 不可解析时空列表放行（不更坏，见 ADR-0002）；caps 解析与 provider 解析各自独立 try，caps 失败不丢弃已解析的 provider/model。
- SDK 删除入队侧急切 caps 拉取与 duration 校验，duration 透传执行层。

能力在执行时解析遵循 ADR-0001。

## 测试

- 新增 `TestTaskSpecFromRequest`（结构校验）、`TestAssertDurationSupported`（纯函数）、执行层 duration 守卫（越界/合法/默认/caps 失败保留 provider）、SDK 不再入队校验 duration、资产空白描述跳过。
- 全量回归 2933 passed（唯一失败 `test_default_when_unresolvable` 与本 PR 无关，在 main 基线同样失败，本地 DB 状态所致）。
- ruff / basedpyright 0 error。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 统一结构化提示词校验并返回可本地化错误码（TaskSpec 校验与 TaskSpecValidationError）
  * 新增将镜头文本合并为单一提示词的辅助函数（assemble_shots_text）

* **改进**
  * 规范化入队请求格式为 TaskSpec，禁止覆盖保留键并透传依赖信息
  * 视频时长处理重构：仅显式透传时长，缺省从模型能力取值并拒绝不被支持的时长（VideoCapabilityError）
  * 资产构建跳过空白描述并记录告警

* **测试**
  * 扩展单元测试覆盖提示词校验、批量入队、参考视频与时长行为

* **本地化**
  * 新增视频时长相关错误文案（多语言）

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->