### PR TITLE
test(generation_worker): 补充参考生视频模型解析的测试

### DIFF
--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -131,6 +131,24 @@ class TestExtractProvider:
         task = {"payload": {}, "project_name": "demo", "task_type": "storyboard"}
         assert await _extract_provider(task) == "gemini-vertex"
 
+    async def test_reference_video_routes_to_video_lane(self, monkeypatch):
+        """reference_video task_type 必须按 video lane 解析 video_backend，而非 image 槽。
+
+        项目同时配置了不同 provider 的 video_backend（ark）与 image_provider_t2i
+        （gemini-vertex）。reference_video 属于 video lane，认领期 provider 投影须取 ark；
+        若误判为 image lane（历史上 task_type != "video" 即读 image 槽），会取到纯图片
+        供应商，导致 worker 在 video 通道以 video_max==0 直接把任务标记
+        「供应商不支持 video 生成」。"""
+        _patch_pm(
+            monkeypatch,
+            {
+                "video_backend": "ark/seedance-1-0-pro",
+                "image_provider_t2i": "gemini-vertex/imagen-3",
+            },
+        )
+        task = {"payload": {}, "project_name": "demo", "task_type": "reference_video"}
+        assert await _extract_provider(task) == "ark"
+
     async def test_payload_provider_takes_precedence_over_project(self, monkeypatch):
         """payload 历史 provider 优先于项目级。"""
         _patch_pm(monkeypatch, {"video_backend": "grok/grok-imagine-video"})


### PR DESCRIPTION
## 背景

来自部署服务的反馈：`reference_video` 模式下 6 个 video_unit 全部失败，报「供应商不支持视频生成」，请求落到纯图片供应商（gpt-image-2）。该 agent 把根因归为「MCP 工具内部供应商解析 bug」。

经诊断（diagnose 流程）：**根因在 worker 认领期，而非 MCP 工具，也非执行层**——执行层 `video_backend` 解析到 ark 本来是对的，任务在认领期能力门就被拒，根本没进 `execute_reference_video_task`。

链路：`_extract_provider` 用 `is_video` 决定读 video 槽还是 image 槽；历史实现以 `task_type == "video"` 判定，而 `reference_video` 不等于 `"video"` → 误读 image 槽 → 取到纯图片供应商 → 在 video 通道 `video_max==0` → `mark_task_failed("供应商 X 不支持 video 生成")`。

该缺陷**已在 provider 解析收敛重构（#599）中修复**（`is_video` 纳入 `"reference_video"`），但当时**没留专门用例**。

## 改动

补一个回归测试 `TestExtractProvider::test_reference_video_routes_to_video_lane`：项目同时配置不同 provider 的 `video_backend`（ark）与 `image_provider_t2i`（gemini-vertex），断言 `reference_video` 取 video lane 的 ark。

现有用例只覆盖 `task_type="video"`/`"storyboard"`，从 `is_video` 元组里删掉 `"reference_video"` 不会让任何测试变红——本用例补上这个缺口。

## 验证（变异检验）

| 步骤 | 结果 |
|------|------|
| 当前 main 跑新测试 | ✅ 通过（返回 `ark`） |
| 翻转修复（去掉 `"reference_video"`） | ❌ 返回 `gemini-vertex`（图片 provider），测试变红 |
| 还原修复 | ✅ 恢复绿 |

## 对部署的行动项（不在本 PR 范围）

故障的修复本身已在 main（#599，v0.15.0 之后）；报故障的部署需升级到含 #599 的版本即可恢复 `reference_video` 入队。本 PR 仅补回归测试，防止该路径再次回归。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **测试**
  * 新增测试用例，验证在同时配置视频后端和图像提供者的情况下，参考视频任务能正确路由到对应的视频后端提供者，确保不会错误地走向图像处理逻辑。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->