### PR TITLE
refactor: 收敛资源路径与剧本字段名形状常量到单一真相源 (#611)

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -120,6 +120,7 @@ MESSAGES = {
     "deprecated_image_backend": "The image_backend field is deprecated; use image_provider_t2i and image_provider_i2i instead",
     # Versions
     "unsupported_resource_type": "Unsupported resource type: {resource_type}",
+    "invalid_resource_id": "Invalid resource ID: {resource_id}",
     # Reference Video
     "ref_missing_asset": "Reference to {type} '{name}' is not in the project asset library, please generate it first",
     "ref_duration_exceeded": "Reference video unit duration {duration}s exceeds {model} limit of {max_duration}s, clamped",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -120,6 +120,7 @@ MESSAGES = {
     "deprecated_image_backend": "Trường image_backend đã ngừng dùng; hãy dùng image_provider_t2i và image_provider_i2i",
     # Versions
     "unsupported_resource_type": "Loại tài nguyên không hỗ trợ: {resource_type}",
+    "invalid_resource_id": "ID tài nguyên không hợp lệ: {resource_id}",
     # Reference Video
     "ref_missing_asset": "Tham chiếu đến {type} '{name}' không có trong thư viện tài nguyên dự án, vui lòng tạo trước",
     "ref_duration_exceeded": "Thời lượng đơn vị video tham chiếu {duration}s vượt giới hạn {max_duration}s của {model}, đã cắt bớt",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -120,6 +120,7 @@ MESSAGES = {
     "deprecated_image_backend": "image_backend 字段已废弃，请改用 image_provider_t2i 与 image_provider_i2i",
     # Versions
     "unsupported_resource_type": "不支持的资源类型: {resource_type}",
+    "invalid_resource_id": "非法的资源 ID: {resource_id}",
     # Reference Video
     "ref_missing_asset": "参考图引用的{type}「{name}」不在项目资产库中，请先生成",
     "ref_duration_exceeded": "参考视频单元时长 {duration}s 超出 {model} 上限 {max_duration}s，已裁剪",

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 from lib.db.base import DEFAULT_USER_ID
 from lib.gemini_shared import RateLimiter
+from lib.resource_paths import resource_relative_path
 from lib.usage_tracker import UsageTracker
 from lib.version_manager import VersionManager
 
@@ -38,17 +39,6 @@ class MediaGenerator:
 
     封装 GeminiClient + VersionManager，提供自动版本管理。
     """
-
-    # 资源类型到输出路径模式的映射
-    OUTPUT_PATTERNS = {
-        "storyboards": "storyboards/scene_{resource_id}.png",
-        "videos": "videos/scene_{resource_id}.mp4",
-        "characters": "characters/{resource_id}.png",
-        "scenes": "scenes/{resource_id}.png",
-        "props": "props/{resource_id}.png",
-        "grids": "grids/{resource_id}.png",
-        "reference_videos": "reference_videos/{resource_id}.mp4",
-    }
 
     def __init__(
         self,
@@ -109,11 +99,7 @@ class MediaGenerator:
         Returns:
             输出文件的绝对路径
         """
-        if resource_type not in self.OUTPUT_PATTERNS:
-            raise ValueError(f"不支持的资源类型: {resource_type}")
-
-        pattern = self.OUTPUT_PATTERNS[resource_type]
-        relative_path = pattern.format(resource_id=resource_id)
+        relative_path = resource_relative_path(resource_type, resource_id)
         output_path = (self.project_path / relative_path).resolve()
         try:
             output_path.relative_to(self.project_path.resolve())

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -36,6 +36,7 @@ from lib.profile_manifest import (
     force_resync_profile as _force_resync_profile,
 )
 from lib.project_change_hints import emit_project_change_hint
+from lib.script_models import SCRIPT_SHAPES, ScriptShape
 from lib.style_templates import LEGACY_STYLE_MAP, resolve_template_prompt
 
 logger = logging.getLogger(__name__)
@@ -66,6 +67,19 @@ def effective_mode(*, project: dict, episode: dict) -> str:
     if proj_mode in _VALID_GENERATION_MODES:
         return proj_mode
     return _DEFAULT_GENERATION_MODE
+
+
+def _script_items_shape(script: dict, content_mode: str) -> ScriptShape:
+    """选剧本列表所在的形状（字段名取自 lib.script_models.SCRIPT_SHAPES）。
+
+    仅当 content_mode=narration **且**脚本确有 narration 列表键时走 narration 形状；
+    否则落 drama 形状——这覆盖了 narration 但数据畸形落在 `scenes` 键下的回退，保持
+    与历史 `if content_mode == "narration" and "segments" in script` 守卫一致。
+    """
+    narration = SCRIPT_SHAPES["narration"]
+    if content_mode == "narration" and narration.items_key in script:
+        return narration
+    return SCRIPT_SHAPES["drama"]
 
 
 class EpisodeScriptReboundError(RuntimeError):
@@ -1081,12 +1095,9 @@ class ProjectManager:
         with self.locked_script(project_name, script_filename, validate=False) as script:
             # 根据内容模式选择正确的数据结构
             content_mode = script.get("content_mode", "narration")
-            if content_mode == "narration" and "segments" in script:
-                items = script["segments"]
-                id_field = "segment_id"
-            else:
-                items = script.get("scenes", [])
-                id_field = "scene_id"
+            shape = _script_items_shape(script, content_mode)
+            items = script.get(shape.items_key, [])
+            id_field = shape.id_field
 
             for item in items:
                 if str(item.get(id_field)) == str(scene_id):
@@ -1132,12 +1143,9 @@ class ProjectManager:
         # 资产回写热路径：只动 generated_assets，结构不可能因此变坏，豁免结构校验。
         with self.locked_script(project_name, script_filename, validate=False) as script:
             content_mode = script.get("content_mode", "narration")
-            if content_mode == "narration" and "segments" in script:
-                items = script["segments"]
-                id_field = "segment_id"
-            else:
-                items = script.get("scenes", [])
-                id_field = "scene_id"
+            shape = _script_items_shape(script, content_mode)
+            items = script.get(shape.items_key, [])
+            id_field = shape.id_field
 
             # 建立 scene_id → item 索引，避免 O(N*M) 查找
             item_by_id: dict[str, dict] = {str(item.get(id_field)): item for item in items}
@@ -1177,10 +1185,7 @@ class ProjectManager:
 
         # 根据内容模式选择正确的数据结构
         content_mode = script.get("content_mode", "narration")
-        if content_mode == "narration" and "segments" in script:
-            items = script["segments"]
-        else:
-            items = script.get("scenes", [])
+        items = script.get(_script_items_shape(script, content_mode).items_key, [])
 
         return [item for item in items if not item["generated_assets"].get(asset_type)]
 
@@ -1220,10 +1225,7 @@ class ProjectManager:
         script = self.load_script(project_name, script_filename)
 
         content_mode = script.get("content_mode", "narration")
-        if content_mode == "narration" and "segments" in script:
-            items = script["segments"]
-        else:
-            items = script.get("scenes", [])
+        items = script.get(_script_items_shape(script, content_mode).items_key, [])
 
         return [item for item in items if not item.get("generated_assets", {}).get("storyboard_image")]
 

--- a/lib/resource_paths.py
+++ b/lib/resource_paths.py
@@ -1,0 +1,58 @@
+"""资源路径解析器 — 「资源类型 → 项目内相对路径」的唯一真相源。
+
+纯函数，不读盘、不持有项目状态。独家拥有各资源类型的子目录、文件名模板、
+扩展名，以及 storyboards/videos 的 ``scene_`` 前缀特例。
+
+写侧（MediaGenerator）、版本回溯（versions 路由）、导入修复（project_archive）、
+版本管理（VersionManager）都从这里取形状，避免副本各自漂移。越界校验不在此处，
+由调用方拼绝对路径时自行负责。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ResourcePattern:
+    """单一资源类型的路径形状。"""
+
+    subdir: str
+    extension: str
+    scene_prefix: bool  # storyboards/videos 的文件名带 scene_ 前缀
+
+
+_PATTERNS: dict[str, ResourcePattern] = {
+    "storyboards": ResourcePattern("storyboards", ".png", scene_prefix=True),
+    "videos": ResourcePattern("videos", ".mp4", scene_prefix=True),
+    "characters": ResourcePattern("characters", ".png", scene_prefix=False),
+    "scenes": ResourcePattern("scenes", ".png", scene_prefix=False),
+    "props": ResourcePattern("props", ".png", scene_prefix=False),
+    "grids": ResourcePattern("grids", ".png", scene_prefix=False),
+    "reference_videos": ResourcePattern("reference_videos", ".mp4", scene_prefix=False),
+}
+
+RESOURCE_TYPES: tuple[str, ...] = tuple(_PATTERNS)
+
+
+def _pattern(resource_type: str) -> ResourcePattern:
+    pattern = _PATTERNS.get(resource_type)
+    if pattern is None:
+        raise ValueError(f"不支持的资源类型: {resource_type}")
+    return pattern
+
+
+def resource_relative_path(resource_type: str, resource_id: str) -> str:
+    """返回资源在项目内的相对路径（posix，正斜杠）。
+
+    storyboards/videos 形如 ``storyboards/scene_{id}.png``；其余 ``{subdir}/{id}{ext}``。
+    未知类型抛 ``ValueError``。
+    """
+    pattern = _pattern(resource_type)
+    filename = f"scene_{resource_id}" if pattern.scene_prefix else resource_id
+    return f"{pattern.subdir}/{filename}{pattern.extension}"
+
+
+def resource_extension(resource_type: str) -> str:
+    """返回资源类型的文件扩展名（含点，如 ``.png``）。未知类型抛 ``ValueError``。"""
+    return _pattern(resource_type).extension

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -6,6 +6,7 @@ script_models.py - 剧本数据模型
 2. 输出验证
 """
 
+from dataclasses import dataclass
 from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
@@ -249,3 +250,35 @@ class ReferenceVideoScript(BaseModel):
     summary: str = Field(description="剧集摘要")
     novel: NovelInfo = Field(description="小说来源信息")
     video_units: list[ReferenceVideoUnit] = Field(description="视频单元列表")
+
+
+# ============ content_mode → 剧本字段名分派 ============
+
+
+@dataclass(frozen=True)
+class ScriptShape:
+    """某个 content_mode 下剧本的结构形状：列表字段名 / 每项 id 字段名 / 角色字段名。"""
+
+    items_key: str
+    id_field: str
+    chars_field: str
+
+
+SCRIPT_SHAPES: dict[str, ScriptShape] = {
+    "narration": ScriptShape("segments", "segment_id", "characters_in_segment"),
+    "drama": ScriptShape("scenes", "scene_id", "characters_in_scene"),
+}
+
+
+def script_shape(content_mode: str) -> ScriptShape:
+    """返回该 content_mode 的剧本形状。
+
+    忠实于既有二分语义（``"segments" if content_mode == "narration" else "scenes"``）：
+    只有 ``"narration"`` 返回 narration 形状，其余一切（含未知值）落 drama。
+
+    reference_video 模式用 video_units/unit_id/references 组织，结构不同，不经此分派
+    （由 project_archive 的专用分支处理）。
+    """
+    if content_mode == "narration":
+        return SCRIPT_SHAPES["narration"]
+    return SCRIPT_SHAPES["drama"]

--- a/lib/version_manager.py
+++ b/lib/version_manager.py
@@ -11,6 +11,9 @@ import threading
 from datetime import UTC, datetime
 from pathlib import Path
 
+from lib.resource_paths import RESOURCE_TYPES as _RESOURCE_TYPES
+from lib.resource_paths import resource_extension
+
 _LOCKS_GUARD = threading.Lock()
 _LOCKS_BY_VERSIONS_FILE: dict[str, threading.RLock] = {}
 
@@ -28,19 +31,9 @@ def _get_versions_file_lock(versions_file: Path) -> threading.RLock:
 class VersionManager:
     """版本管理器"""
 
-    # 支持的资源类型
-    RESOURCE_TYPES = ("storyboards", "videos", "characters", "scenes", "props", "grids", "reference_videos")
-
-    # 资源类型对应的文件扩展名
-    EXTENSIONS = {
-        "storyboards": ".png",
-        "videos": ".mp4",
-        "characters": ".png",
-        "scenes": ".png",
-        "props": ".png",
-        "grids": ".png",
-        "reference_videos": ".mp4",
-    }
+    # 支持的资源类型与扩展名均派生自单一真相源 lib.resource_paths，避免副本漂移。
+    RESOURCE_TYPES = _RESOURCE_TYPES
+    EXTENSIONS = {rt: resource_extension(rt) for rt in _RESOURCE_TYPES}
 
     def __init__(self, project_path: Path):
         """

--- a/server/routers/versions.py
+++ b/server/routers/versions.py
@@ -47,11 +47,17 @@ def _resolve_resource_path(
     project_path: Path,
     _t: Callable[..., str],
 ) -> tuple[Path, str]:
-    """返回 (current_file_absolute, relative_file_path)，资源类型不可还原时抛出 HTTPException。"""
+    """返回 (current_file_absolute, relative_file_path)；资源类型不可还原或 ID 越界时抛出 HTTPException。"""
     if resource_type not in _RESTORABLE_RESOURCE_TYPES:
         raise HTTPException(status_code=400, detail=_t("unsupported_resource_type", resource_type=resource_type))
     relative = resource_relative_path(resource_type, resource_id)
-    return project_path / relative, relative
+    current_file = project_path / relative
+    # 路径遍历防护：resource_id 拼出的绝对路径不得逃出项目目录（与 MediaGenerator._get_output_path 对齐）。
+    try:
+        current_file.resolve().relative_to(project_path.resolve())
+    except ValueError:
+        raise HTTPException(status_code=400, detail=_t("invalid_resource_id", resource_id=resource_id))
+    return current_file, relative
 
 
 def _sync_storyboard_metadata(

--- a/server/routers/versions.py
+++ b/server/routers/versions.py
@@ -17,6 +17,7 @@ from lib.app_data_dir import app_data_dir
 from lib.i18n import Translator
 from lib.project_change_hints import project_change_source
 from lib.project_manager import ProjectManager
+from lib.resource_paths import resource_relative_path
 from lib.version_manager import VersionManager
 from server.auth import CurrentUser
 
@@ -25,13 +26,9 @@ router = APIRouter()
 # 初始化项目管理器
 pm = ProjectManager(app_data_dir())
 
-_RESOURCE_FILE_PATTERNS: dict[str, tuple[str, str]] = {
-    "storyboards": ("storyboards", "scene_{id}.png"),
-    "videos": ("videos", "scene_{id}.mp4"),
-    "characters": ("characters", "{id}.png"),
-    "scenes": ("scenes", "{id}.png"),
-    "props": ("props", "{id}.png"),
-}
+# 经此路由可还原的资源类型（API 面策略）。路径形状委托 lib.resource_paths，但本路由
+# 仅放行有还原后元数据同步分支的这五类；grids/reference_videos 的还原是独立议题。
+_RESTORABLE_RESOURCE_TYPES = frozenset({"storyboards", "videos", "characters", "scenes", "props"})
 
 
 def get_project_manager() -> ProjectManager:
@@ -50,13 +47,11 @@ def _resolve_resource_path(
     project_path: Path,
     _t: Callable[..., str],
 ) -> tuple[Path, str]:
-    """返回 (current_file_absolute, relative_file_path)，资源类型无效时抛出 HTTPException。"""
-    pattern = _RESOURCE_FILE_PATTERNS.get(resource_type)
-    if pattern is None:
+    """返回 (current_file_absolute, relative_file_path)，资源类型不可还原时抛出 HTTPException。"""
+    if resource_type not in _RESTORABLE_RESOURCE_TYPES:
         raise HTTPException(status_code=400, detail=_t("unsupported_resource_type", resource_type=resource_type))
-    subdir, name_tpl = pattern
-    name = name_tpl.format(id=resource_id)
-    return project_path / subdir / name, f"{subdir}/{name}"
+    relative = resource_relative_path(resource_type, resource_id)
+    return project_path / relative, relative
 
 
 def _sync_storyboard_metadata(

--- a/server/services/project_archive.py
+++ b/server/services/project_archive.py
@@ -18,6 +18,8 @@ from lib.json_io import load_json
 from lib.project_change_hints import emit_project_change_hint
 from lib.project_manager import ProjectManager, effective_mode
 from lib.project_migrations.runner import migrate_project_dir
+from lib.resource_paths import resource_extension, resource_relative_path
+from lib.script_models import script_shape
 
 logger = logging.getLogger(__name__)
 
@@ -156,14 +158,6 @@ class ProjectArchiveService:
             "reference_videos",
         }
     )
-    _RESOURCE_EXTENSIONS = {
-        "storyboards": ".png",
-        "videos": ".mp4",
-        "characters": ".png",
-        "scenes": ".png",
-        "props": ".png",
-        "reference_videos": ".mp4",
-    }
     _ROOT_VISIBLE_ENTRIES = frozenset(DataValidator.ALLOWED_ROOT_ENTRIES)
     _AGENT_RUNTIME_EXCLUDES = frozenset({".claude", "CLAUDE.md"})
     _PLACEHOLDER_CHARACTER_DESCRIPTION = "Imported placeholder character"
@@ -719,9 +713,10 @@ class ProjectArchiveService:
             )
             return script_changed or units_changed, project_changed or units_project_changed
 
-        items_key = "segments" if content_mode == "narration" else "scenes"
-        id_field = "segment_id" if content_mode == "narration" else "scene_id"
-        chars_field = "characters_in_segment" if content_mode == "narration" else "characters_in_scene"
+        shape = script_shape(content_mode)
+        items_key = shape.items_key
+        id_field = shape.id_field
+        chars_field = shape.chars_field
 
         raw_items = script_payload.get(items_key)
         if not isinstance(raw_items, list):
@@ -808,10 +803,7 @@ class ProjectArchiveService:
                         project_dir,
                         assets,
                         field_name=field_name,
-                        canonical_rel=self._canonical_resource_path(
-                            resource_type,
-                            resource_id,
-                        ),
+                        canonical_rel=resource_relative_path(resource_type, resource_id),
                         location=f"{location_prefix}.generated_assets.{field_name}",
                         diagnostics=diagnostics,
                         resource_type=resource_type,
@@ -954,7 +946,7 @@ class ProjectArchiveService:
                 project_dir,
                 assets,
                 field_name="video_clip",
-                canonical_rel=self._canonical_resource_path("reference_videos", resource_id),
+                canonical_rel=resource_relative_path("reference_videos", resource_id),
                 location=f"{location_prefix}.generated_assets.video_clip",
                 diagnostics=diagnostics,
                 resource_type="reference_videos",
@@ -1136,7 +1128,7 @@ class ProjectArchiveService:
             return None
 
         prefix = f"{resource_id}_v"
-        extension = self._RESOURCE_EXTENSIONS[resource_type]
+        extension = resource_extension(resource_type)
         candidates: list[str] = []
         for candidate in sorted(version_dir.iterdir(), key=lambda path: path.name):
             if candidate.is_file() and candidate.name.startswith(prefix) and candidate.suffix == extension:
@@ -1278,13 +1270,6 @@ class ProjectArchiveService:
                 return candidate.as_posix()
 
         return None
-
-    @classmethod
-    def _canonical_resource_path(cls, resource_type: str, resource_id: str) -> str:
-        extension = cls._RESOURCE_EXTENSIONS[resource_type]
-        if resource_type in {"storyboards", "videos"}:
-            return f"{resource_type}/scene_{resource_id}{extension}"
-        return f"{resource_type}/{resource_id}{extension}"
 
     def _load_json_file(self, path: Path) -> dict[str, Any] | None:
         real = os.path.realpath(path)

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -530,11 +530,10 @@ async def test_execute_reference_video_task_missing_reference_fails(tmp_path: Pa
 
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """回归守门：executor 必须走真实 MediaGenerator._get_output_path 白名单。
+    """回归守门：executor 必须走真实 MediaGenerator._get_output_path。
 
     只 mock 最外层的 VideoBackend.generate — 若未来哪次又漏注册新 resource_type
-    到 OUTPUT_PATTERNS，这条测试会立刻爆 ValueError。
-    参见 issue #364。
+    到 lib.resource_paths，这条测试会立刻爆 ValueError。
     """
     from lib.media_generator import MediaGenerator
     from lib.version_manager import VersionManager
@@ -620,7 +619,7 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
         user_id="u1",
     )
 
-    # Backend 被真实调用一次，且 output_path 走 OUTPUT_PATTERNS["reference_videos"] 模板
+    # Backend 被真实调用一次，且 output_path 走 resource_relative_path("reference_videos", ...) 模板
     assert len(captured_requests) == 1
     req = captured_requests[0]
     assert req.output_path == (proj_dir / "reference_videos" / "E1U1.mp4")

--- a/tests/test_project_archive_reference_video.py
+++ b/tests/test_project_archive_reference_video.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from lib.project_manager import ProjectManager
+from lib.resource_paths import resource_relative_path
 from server.services.project_archive import ProjectArchiveService, ProjectArchiveValidationError
 
 REMOTE_VIDEO_URI = "https://cdn.example.com/v/E1U1.mp4"
@@ -122,8 +123,8 @@ def _create_reference_video_project(
 
 class TestProjectArchiveReferenceVideo:
     def test_canonical_resource_path_reference_videos(self):
-        # 验收项：reference_videos 走 unit_id 无前缀分支
-        assert ProjectArchiveService._canonical_resource_path("reference_videos", "E1U1") == "reference_videos/E1U1.mp4"
+        # 验收项：reference_videos 走 unit_id 无前缀分支（路径形状由 lib.resource_paths 独家拥有）
+        assert resource_relative_path("reference_videos", "E1U1") == "reference_videos/E1U1.mp4"
 
     def test_round_trip_preserves_video_units(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")

--- a/tests/test_project_manager_content_mode_dispatch.py
+++ b/tests/test_project_manager_content_mode_dispatch.py
@@ -1,0 +1,82 @@
+"""PM 按 content_mode 选数据结构的守卫回归测试。
+
+锁定一个边缘行为：content_mode=narration 但数据落在 `scenes` 键下（无 `segments` 键）
+的畸形脚本，PM 必须沿键存在性守卫回退去读 `scenes`，而非因 content_mode 字面映射到
+`segments` 就读到空列表。
+
+收敛字段名分派（→ lib.script_models.script_shape）时若天真改为
+`items = script.get(<content_mode 对应 items_key>, [])`、丢掉 `"segments" in script`
+守卫，这些断言会变红——这正是它们要守的回归。只断言外部行为，不 patch 私有方法。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lib.project_manager import ProjectManager
+
+
+def _pm(tmp_path: Path) -> ProjectManager:
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+    return pm
+
+
+def _narration_script_with_data_under_scenes() -> dict:
+    """content_mode=narration，但内容存在 `scenes` 键下、无 `segments` 键的畸形脚本。"""
+    return {
+        "episode": 1,
+        "title": "标题",
+        "content_mode": "narration",
+        "summary": "摘要",
+        "novel": {"title": "小说", "chapter": "第一章"},
+        "scenes": [
+            {
+                "scene_id": "E1S01",
+                "duration_seconds": 8,
+                "characters_in_scene": ["角色A"],
+                "generated_assets": {},
+            }
+        ],
+    }
+
+
+@pytest.mark.unit
+class TestNarrationDataUnderScenesFallback:
+    def test_update_scene_asset_falls_back_to_scenes(self, tmp_path: Path):
+        pm = _pm(tmp_path)
+        pm.save_script("demo", _narration_script_with_data_under_scenes(), "episode_1.json", validate=False)
+
+        # 不应抛 KeyError；应命中 scenes 下的 E1S01 并回写
+        pm.update_scene_asset("demo", "episode_1.json", "E1S01", "storyboard_image", "storyboards/scene_E1S01.png")
+
+        saved = pm.load_script("demo", "episode_1.json")
+        assert saved["scenes"][0]["generated_assets"]["storyboard_image"] == "storyboards/scene_E1S01.png"
+
+    def test_batch_update_scene_assets_falls_back_to_scenes(self, tmp_path: Path):
+        pm = _pm(tmp_path)
+        pm.save_script("demo", _narration_script_with_data_under_scenes(), "episode_1.json", validate=False)
+
+        pm.batch_update_scene_assets("demo", "episode_1.json", [("E1S01", "video_clip", "videos/scene_E1S01.mp4")])
+
+        saved = pm.load_script("demo", "episode_1.json")
+        assert saved["scenes"][0]["generated_assets"]["video_clip"] == "videos/scene_E1S01.mp4"
+
+    def test_get_pending_scenes_reads_scenes(self, tmp_path: Path):
+        pm = _pm(tmp_path)
+        pm.save_script("demo", _narration_script_with_data_under_scenes(), "episode_1.json", validate=False)
+
+        pending = pm.get_pending_scenes("demo", "episode_1.json", "storyboard_image")
+
+        assert [item["scene_id"] for item in pending] == ["E1S01"]
+
+    def test_get_scenes_needing_storyboard_reads_scenes(self, tmp_path: Path):
+        pm = _pm(tmp_path)
+        pm.save_script("demo", _narration_script_with_data_under_scenes(), "episode_1.json", validate=False)
+
+        needing = pm.get_scenes_needing_storyboard("demo", "episode_1.json")
+
+        assert [item["scene_id"] for item in needing] == ["E1S01"]

--- a/tests/test_registry_consistency.py
+++ b/tests/test_registry_consistency.py
@@ -1,30 +1,19 @@
-"""Registry consistency — 三张资源注册表的 keys 必须互相一致。
+"""Registry consistency — 资源注册表派生自单一真相源。
 
-断言 MediaGenerator.OUTPUT_PATTERNS / VersionManager.RESOURCE_TYPES /
-VersionManager.EXTENSIONS 三者的 keys 集合相等。
-
-不预置 canonical 白名单：任何未来新增的资源类型只要三处都登记，测试自动通过；
-只登记到 1~2 处（漏登记）会立刻红。这样新增资源类型不需要修改本测试。
+`lib.resource_paths` 是「资源类型 → 路径/扩展名」的唯一真相源；VersionManager 的
+`RESOURCE_TYPES` / `EXTENSIONS` 均从它派生。本测试断言派生未脱钩——若有人把
+VersionManager 改回手写副本、与真相源漂移，立刻红。
 """
 
 from __future__ import annotations
 
 import pytest
 
-from lib.media_generator import MediaGenerator
+from lib.resource_paths import RESOURCE_TYPES, resource_extension
 from lib.version_manager import VersionManager
 
 
 @pytest.mark.unit
-def test_resource_registries_have_consistent_keys() -> None:
-    patterns_keys = set(MediaGenerator.OUTPUT_PATTERNS.keys())
-    types_keys = set(VersionManager.RESOURCE_TYPES)
-    ext_keys = set(VersionManager.EXTENSIONS.keys())
-
-    assert patterns_keys == types_keys == ext_keys, (
-        "资源注册表 keys 漂移：\n"
-        f"  MediaGenerator.OUTPUT_PATTERNS keys = {sorted(patterns_keys)}\n"
-        f"  VersionManager.RESOURCE_TYPES     = {sorted(types_keys)}\n"
-        f"  VersionManager.EXTENSIONS keys    = {sorted(ext_keys)}\n"
-        "新增资源类型时三处都要同步登记。"
-    )
+def test_version_manager_derives_from_resource_paths() -> None:
+    assert set(VersionManager.RESOURCE_TYPES) == set(RESOURCE_TYPES)
+    assert VersionManager.EXTENSIONS == {rt: resource_extension(rt) for rt in RESOURCE_TYPES}

--- a/tests/test_resource_paths.py
+++ b/tests/test_resource_paths.py
@@ -1,0 +1,84 @@
+"""资源路径解析器（模块 A）单元测试。
+
+只断言外部行为：喂 resource_type + resource_id，断言项目内相对路径、扩展名、
+未知类型的处理。纯函数，无 fixture、不读盘。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lib.resource_paths import (
+    RESOURCE_TYPES,
+    resource_extension,
+    resource_relative_path,
+)
+
+
+@pytest.mark.unit
+class TestResourceRelativePath:
+    @pytest.mark.parametrize(
+        ("resource_type", "resource_id", "expected"),
+        [
+            # storyboards / videos 带 scene_ 前缀特例
+            ("storyboards", "E1S01", "storyboards/scene_E1S01.png"),
+            ("videos", "E1S01", "videos/scene_E1S01.mp4"),
+            # 其余无前缀
+            ("characters", "姜月茴", "characters/姜月茴.png"),
+            ("scenes", "庙宇", "scenes/庙宇.png"),
+            ("props", "玉佩", "props/玉佩.png"),
+            ("grids", "grid_abc", "grids/grid_abc.png"),
+            ("reference_videos", "E1U1", "reference_videos/E1U1.mp4"),
+        ],
+    )
+    def test_canonical_paths(self, resource_type: str, resource_id: str, expected: str) -> None:
+        assert resource_relative_path(resource_type, resource_id) == expected
+
+    def test_only_storyboards_and_videos_get_scene_prefix(self) -> None:
+        # 反向断言：非 storyboards/videos 不得带 scene_ 前缀
+        for rt in ("characters", "scenes", "props", "grids", "reference_videos"):
+            assert "scene_" not in resource_relative_path(rt, "X")
+
+    def test_returns_posix_forward_slashes(self) -> None:
+        # 跨平台：始终用 / 分隔，不受运行平台影响
+        assert "\\" not in resource_relative_path("storyboards", "E1S01")
+
+    def test_unknown_resource_type_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            resource_relative_path("unknown_type", "x")
+
+
+@pytest.mark.unit
+class TestResourceExtension:
+    @pytest.mark.parametrize(
+        ("resource_type", "expected"),
+        [
+            ("storyboards", ".png"),
+            ("videos", ".mp4"),
+            ("characters", ".png"),
+            ("scenes", ".png"),
+            ("props", ".png"),
+            ("grids", ".png"),
+            ("reference_videos", ".mp4"),
+        ],
+    )
+    def test_extensions(self, resource_type: str, expected: str) -> None:
+        assert resource_extension(resource_type) == expected
+
+    def test_unknown_resource_type_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            resource_extension("unknown_type")
+
+
+@pytest.mark.unit
+class TestResourceTypes:
+    def test_covers_seven_canonical_types(self) -> None:
+        assert set(RESOURCE_TYPES) == {
+            "storyboards",
+            "videos",
+            "characters",
+            "scenes",
+            "props",
+            "grids",
+            "reference_videos",
+        }

--- a/tests/test_script_shape.py
+++ b/tests/test_script_shape.py
@@ -1,0 +1,39 @@
+"""剧本形状分派（模块 B）单元测试。
+
+只断言外部行为：喂 content_mode，断言返回的字段名三元组
+（列表字段 / 每项 id 字段 / 角色字段）正确。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lib.script_models import SCRIPT_SHAPES, script_shape
+
+
+@pytest.mark.unit
+class TestScriptShape:
+    def test_narration(self) -> None:
+        shape = script_shape("narration")
+        assert (shape.items_key, shape.id_field, shape.chars_field) == (
+            "segments",
+            "segment_id",
+            "characters_in_segment",
+        )
+
+    def test_drama(self) -> None:
+        shape = script_shape("drama")
+        assert (shape.items_key, shape.id_field, shape.chars_field) == (
+            "scenes",
+            "scene_id",
+            "characters_in_scene",
+        )
+
+    def test_non_narration_maps_to_drama(self) -> None:
+        # 忠实于现状二分 `"segments" if content_mode == "narration" else "scenes"`：
+        # 只有 "narration" 走 narration 形状，其余一切（含未知值）落 drama。
+        assert script_shape("???") == SCRIPT_SHAPES["drama"]
+        assert script_shape("drama") == SCRIPT_SHAPES["drama"]
+
+    def test_registry_covers_narration_and_drama(self) -> None:
+        assert set(SCRIPT_SHAPES) == {"narration", "drama"}

--- a/tests/test_versions_router.py
+++ b/tests/test_versions_router.py
@@ -122,6 +122,12 @@ class TestVersionsRouter:
             unsupported = client.post("/api/v1/projects/demo/versions/unknown/Alice/restore/1")
             assert unsupported.status_code == 400
 
+            # grids/reference_videos 是 VersionManager 合法类型，但本路由不放行其还原
+            # （无还原后元数据同步分支），行为保持为 400——不因路径形状收敛而被静默放开。
+            for unrestorable in ("grids", "reference_videos"):
+                resp = client.post(f"/api/v1/projects/demo/versions/{unrestorable}/x/restore/1")
+                assert resp.status_code == 400
+
     def test_storyboard_restore_syncs_scripts_with_error_tolerance(self, tmp_path, monkeypatch):
         project_path = tmp_path / "demo"
         scripts_dir = project_path / "scripts"

--- a/tests/test_versions_router.py
+++ b/tests/test_versions_router.py
@@ -1,5 +1,8 @@
+import tempfile
+from pathlib import Path
+
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from server.auth import CurrentUserInfo, get_current_user
@@ -134,30 +137,29 @@ class TestVersionsRouter:
 
         正常路由的 path 参数不会含 `/`，故直接对 helper 断言这道收口防护。
         """
-        from pathlib import Path
-
-        from fastapi import HTTPException
+        project_path = Path(tempfile.gettempdir()) / "demo"
 
         with pytest.raises(HTTPException) as exc:
             versions._resolve_resource_path(
                 "characters",
                 "../../../../etc/passwd",
-                Path("/tmp/demo"),
+                project_path,
                 lambda key, **kw: key,
             )
         assert exc.value.status_code == 400
 
     def test_resolve_resource_path_accepts_normal_id(self):
-        from pathlib import Path
+        project_path = Path(tempfile.gettempdir()) / "demo"
 
         current_file, relative = versions._resolve_resource_path(
             "characters",
             "Alice",
-            Path("/tmp/demo"),
+            project_path,
             lambda key, **kw: key,
         )
         assert relative == "characters/Alice.png"
-        assert current_file == Path("/tmp/demo/characters/Alice.png")
+        # helper 返回未 resolve 的 project_path/relative，故用同一入参 base 拼接断言。
+        assert current_file == project_path / "characters" / "Alice.png"
 
     def test_storyboard_restore_syncs_scripts_with_error_tolerance(self, tmp_path, monkeypatch):
         project_path = tmp_path / "demo"

--- a/tests/test_versions_router.py
+++ b/tests/test_versions_router.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -127,6 +128,36 @@ class TestVersionsRouter:
             for unrestorable in ("grids", "reference_videos"):
                 resp = client.post(f"/api/v1/projects/demo/versions/{unrestorable}/x/restore/1")
                 assert resp.status_code == 400
+
+    def test_resolve_resource_path_rejects_traversal(self):
+        """resource_id 拼出的绝对路径若逃出项目目录，必须 400（路径遍历防护）。
+
+        正常路由的 path 参数不会含 `/`，故直接对 helper 断言这道收口防护。
+        """
+        from pathlib import Path
+
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            versions._resolve_resource_path(
+                "characters",
+                "../../../../etc/passwd",
+                Path("/tmp/demo"),
+                lambda key, **kw: key,
+            )
+        assert exc.value.status_code == 400
+
+    def test_resolve_resource_path_accepts_normal_id(self):
+        from pathlib import Path
+
+        current_file, relative = versions._resolve_resource_path(
+            "characters",
+            "Alice",
+            Path("/tmp/demo"),
+            lambda key, **kw: key,
+        )
+        assert relative == "characters/Alice.png"
+        assert current_file == Path("/tmp/demo/characters/Alice.png")
 
     def test_storyboard_restore_syncs_scripts_with_error_tolerance(self, tmp_path, monkeypatch):
         project_path = tmp_path / "demo"


### PR DESCRIPTION
## 背景

closes #611（决策见 ADR-0004）。`project_archive` 的导入修复逻辑里藏着两类「本该有唯一真相源、却被各处手抄」的形状常量，一改就要满仓库找副本、漏一个就静默漂移：

1. **资源类型 → 项目内相对路径** 被抄了 **4 份**：`MediaGenerator.OUTPUT_PATTERNS`（写侧）、`versions.py::_RESOURCE_FILE_PATTERNS`、`project_archive._canonical_resource_path`+`_RESOURCE_EXTENSIONS`、`VersionManager.RESOURCE_TYPES`+`EXTENSIONS`。
2. **content_mode → 剧本字段名** 被抄了多份：archive `_repair_script_payload` 手写 `if narration/drama`，`ProjectManager` 也在 4 处重抄。

## 改动

把这两类形状各收敛到一个深模块，调用点统一消费、删除手抄副本，**对外行为不变**。不动 ProjectManager 方法集、不新增 restore 接缝、不把导入修复搬入 PM（ADR-0004 边界）。

- **模块 A `lib/resource_paths.py`（新建，纯函数）**：资源类型 → 相对路径/扩展名的唯一真相源，独家拥有子目录、文件名模板、`scene_` 前缀特例、扩展名。以写侧为权威统一 7 类。
  - `MediaGenerator._get_output_path` 走模块 A（保留越界校验）；`VersionManager.RESOURCE_TYPES`/`EXTENSIONS` 改为派生；`versions` 路由路径委托模块 A，**仅放行原 5 类还原**（API 面策略不放开）；`project_archive` 删 `_canonical_resource_path`/`_RESOURCE_EXTENSIONS`。
- **模块 B `lib/script_models.py` 的 `ScriptShape`/`script_shape`**：content_mode → 列表/id/角色字段名分派，放模型旁。archive 与 PM 多处同形推导改调统一来源。
  - PM 的 `"segments" in script` 键存在性守卫**逐字保留**（收敛进 `_script_items_shape`），不破坏 narration 数据落 `scenes` 键的回退；archive 用无守卫的纯 `script_shape`（与其旧二分一致）。
- **顺手加固**：`versions._resolve_resource_path` 补路径遍历防护（与 `MediaGenerator` 对齐），越界返回 400（新增 `invalid_resource_id` 三语 key）。此为收口加固，重构前即缺。

## 测试

- 新增模块 A/B 单元测试；PM 边缘行为护栏（**先验证天真实现会红**，再写守卫版本转绿）。
- `versions` 补 grids/reference_videos 仍返回 400 的行为锁定 + helper 级遍历拒绝/正常放行。
- `registry consistency` 改为断言派生未脱钩。
- 全量套件通过；ruff、basedpyright 0 error；i18n 三语一致。

## Out of scope（继承 ADR-0004）

不新增 `ProjectManager.restore_from_staging()`、不把 archive 导入修复搬入 PM、不让导入走保存统一入口、不拆分 PM 上帝模块、不改导入对外行为。archive 局部三条路径（refs/thumbnails/style）保持局部。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 发布说明

* **Bug 修复**
  * 改进了无效资源 ID 的多语言提示（新增中文/英文/越南文文案）

* **系统改进**
  * 统一并严格化资源相对路径与扩展名解析，增强路径越界校验
  * 统一脚本内容结构的派发与回写逻辑，提升对异常脚本形态的兼容性
  * 版本管理同步资源类型来源，提升一致性

* **测试**
  * 增补多项单元与路由测试，覆盖资源路径、脚本形状和回写场景验证

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->