### PR TITLE
refactor(sse): 把会话/项目事件流深化到 async 上下文管理器背后 (#613)

### DIFF
--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+from fastapi import Request
 from fastapi.sse import ServerSentEvent
 
 from lib.agent_profile import agent_profile_dir
@@ -343,9 +344,17 @@ class AssistantService:
     # ==================== Streaming ====================
 
     async def stream_events(
-        self, session_id: str, *, meta: SessionMeta | None = None
+        self, session_id: str, *, meta: SessionMeta | None = None, request: Request | None = None
     ) -> AsyncIterator[ServerSentEvent]:
-        """Stream SSE events for a session."""
+        """Stream SSE events for a session.
+
+        Consumes the session's messages through ``SessionManager.stream_messages``
+        (an async context manager): replay messages are accumulated until the
+        ``_replay_done`` boundary, where the projector is built and the snapshot
+        emitted; live messages then drive patch/delta/question/status events. On
+        the ``_idle`` sentinel we poll ``request.is_disconnected()`` so a dropped
+        client triggers deterministic unsubscribe via ``__aexit__`` (see ADR-0005).
+        """
         if meta is None:
             meta = await self.meta_store.get(session_id)
             if meta is None:
@@ -357,47 +366,46 @@ class AssistantService:
                 yield event
             return
 
-        queue = await self.session_manager.subscribe(session_id, replay_buffer=True)
-        try:
-            async for event in self._stream_running_session(meta, session_id, initial_status, queue):
-                yield event
-        finally:
-            await self.session_manager.unsubscribe(session_id, queue)
+        async with self.session_manager.stream_messages(
+            session_id, replay=True, idle_timeout=self.stream_heartbeat_seconds
+        ) as stream:
+            replayed: list[dict[str, Any]] = []
+            projector: AssistantStreamProjector | None = None
+            status: SessionStatus = initial_status
+            async for message in stream:
+                msg_type = message.get("type", "")
 
-    async def _stream_running_session(
-        self,
-        meta: SessionMeta,
-        session_id: str,
-        initial_status: SessionStatus,
-        queue: asyncio.Queue,
-    ) -> AsyncIterator[ServerSentEvent]:
-        """Inner generator for a running session's SSE stream."""
-        replayed_messages, replay_overflowed = self._drain_replay(queue)
-        if replay_overflowed:
-            return
+                if projector is None:
+                    # Replay phase: accumulate buffer messages until the boundary.
+                    if msg_type == "_replay_done":
+                        status = await self.session_manager.get_status(session_id) or initial_status
+                        projector = await self._build_projector(meta, session_id, replayed)
+                        for event in await self._emit_running_snapshot(session_id, status, projector):
+                            yield event
+                        if status != "running":
+                            return
+                        continue
+                    replayed.append(message)
+                    continue
 
-        status = await self.session_manager.get_status(session_id) or initial_status
-        projector = await self._build_projector(meta, session_id, replayed_messages)
-        snapshot_events = await self._emit_running_snapshot(session_id, status, projector)
-        for event in snapshot_events:
-            yield event
-        if status != "running":
-            return
+                # Live phase.
+                if msg_type == "_idle":
+                    if request is not None and await request.is_disconnected():
+                        break
+                    event = await self._handle_heartbeat_timeout(session_id, status, projector)
+                    if event is not None:
+                        yield event
+                        break
+                    continue
 
-        while True:
-            try:
-                message = await asyncio.wait_for(queue.get(), timeout=self.stream_heartbeat_seconds)
+                if msg_type == "_queue_overflow":
+                    break
+
                 events, should_break = await self._dispatch_live_message(message, projector, session_id)
                 for event in events:
                     yield event
                 if should_break:
                     break
-            except TimeoutError:
-                event = await self._handle_heartbeat_timeout(session_id, status, projector)
-                if event is not None:
-                    yield event
-                    break
-                continue
 
     async def _emit_completed_snapshot(
         self, meta: SessionMeta, session_id: str, status: SessionStatus
@@ -457,23 +465,6 @@ class AssistantService:
                 )
             )
         return events
-
-    @staticmethod
-    def _drain_replay(
-        queue: asyncio.Queue,
-    ) -> tuple[list[dict[str, Any]], bool]:
-        """Drain replayed messages from *queue*, detecting overflow sentinel."""
-        replayed: list[dict[str, Any]] = []
-        while True:
-            try:
-                msg = queue.get_nowait()
-            except asyncio.QueueEmpty:
-                break
-            if isinstance(msg, dict):
-                if msg.get("type") == "_queue_overflow":
-                    return replayed, True
-                replayed.append(msg)
-        return replayed, False
 
     async def _dispatch_live_message(
         self,

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -373,6 +373,11 @@ class AssistantService:
             projector: AssistantStreamProjector | None = None
             status: SessionStatus = initial_status
             async for message in stream:
+                # 直播阶段每轮顶部检查断线;不依赖 _idle 作为唤醒条件,持续高频消息
+                # 流下断线一样能立刻发现。回放阶段尚未对客户端 yield 过,不查。
+                if projector is not None and request is not None and await request.is_disconnected():
+                    break
+
                 msg_type = message.get("type", "")
 
                 if projector is None:
@@ -390,8 +395,8 @@ class AssistantService:
 
                 # Live phase.
                 if msg_type == "_idle":
-                    if request is not None and await request.is_disconnected():
-                        break
+                    # 断线已在循环顶部判过;_idle 仅作为「无消息也要醒来」的 backstop,
+                    # 用来兜底「会话状态转换没带消息广播」这种异常路径。
                     event = await self._handle_heartbeat_timeout(session_id, status, projector)
                     if event is not None:
                         yield event

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -14,7 +14,7 @@ import shlex
 import tempfile
 import time
 from collections import deque
-from collections.abc import AsyncIterable, Callable
+from collections.abc import AsyncIterable, AsyncIterator, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -2631,26 +2631,73 @@ class SessionManager:
         if not managed.resolve_pending_question(question_id, answers):
             raise ValueError("未找到待回答的问题")
 
-    async def subscribe(self, session_id: str, replay_buffer: bool = True) -> asyncio.Queue:
-        """Subscribe to session messages. Returns queue for SSE."""
+    async def _subscribe(self, session_id: str, *, replay: bool = True) -> tuple[asyncio.Queue, list[dict[str, Any]]]:
+        """Register a live-message queue and capture the replay snapshot atomically.
+
+        Returns the (live-only) queue plus a snapshot of the buffered messages.
+        The buffer snapshot and queue registration happen with no ``await`` in
+        between, so no synchronous live broadcast can interleave between the two
+        and be lost — the replay/live split has no race.
+
+        Private: the only consumer is :meth:`stream_messages`, which owns the
+        deterministic unsubscribe via its context-manager ``__aexit__``.
+        """
         managed = await self.get_or_connect(session_id)
+        # Synchronous critical section — no ``await`` until registration completes.
+        replay_snapshot = list(managed.message_buffer) if replay else []
         queue: asyncio.Queue = asyncio.Queue(maxsize=100)
-
-        if replay_buffer:
-            # Replay buffered messages
-            for msg in managed.message_buffer:
-                try:
-                    queue.put_nowait(msg)
-                except asyncio.QueueFull:
-                    break
-
         managed.subscribers.add(queue)
-        return queue
+        return queue, replay_snapshot
 
-    async def unsubscribe(self, session_id: str, queue: asyncio.Queue) -> None:
-        """Unsubscribe from session messages."""
+    async def _unsubscribe(self, session_id: str, queue: asyncio.Queue) -> None:
+        """Remove a queue from a session's subscriber set."""
         if session_id in self.sessions:
             self.sessions[session_id].subscribers.discard(queue)
+
+    @contextlib.asynccontextmanager
+    async def stream_messages(
+        self, session_id: str, *, replay: bool = True, idle_timeout: float = 20.0
+    ) -> AsyncIterator[AsyncIterator[dict[str, Any]]]:
+        """Subscribe to a session's messages as a self-cleaning async iterator.
+
+        Yields an async iterator producing, in order:
+
+        - the replayed buffer messages (when *replay*),
+        - a ``{"type": "_replay_done"}`` sentinel marking the live boundary,
+        - live messages as they are broadcast,
+        - a ``{"type": "_idle"}`` sentinel whenever *idle_timeout* elapses with no
+          message (consumers poll liveness / disconnect on it),
+        - a ``{"type": "_queue_overflow"}`` sentinel if the subscriber queue is
+          dropped under backpressure, after which iteration ends.
+
+        Subscription, replay, queue draining and unsubscribe all live behind this
+        seam; cleanup is carried deterministically by ``__aexit__`` (see ADR-0005).
+        Consume as ``async with stream_messages(...) as stream: async for msg in stream``.
+        """
+        queue, replay_msgs = await self._subscribe(session_id, replay=replay)
+
+        async def _iter() -> AsyncIterator[dict[str, Any]]:
+            # NOTE: intentionally NO ``finally: _unsubscribe`` here. Cleanup is owned
+            # by the enclosing context manager's __aexit__ (ADR-0005): a bare async
+            # generator's finally only runs at GC on break/disconnect, which is the
+            # exact leak this design avoids. Do not add a finally to this inner gen.
+            for msg in replay_msgs:
+                yield msg
+            yield {"type": "_replay_done"}
+            while True:
+                try:
+                    msg = await asyncio.wait_for(queue.get(), timeout=idle_timeout)
+                except TimeoutError:
+                    yield {"type": "_idle"}
+                    continue
+                yield msg
+                if msg.get("type") == "_queue_overflow":
+                    return
+
+        try:
+            yield _iter()
+        finally:
+            await self._unsubscribe(session_id, queue)
 
     async def get_status(self, session_id: str) -> SessionStatus | None:
         """Get session status."""

--- a/server/routers/agent_chat.py
+++ b/server/routers/agent_chat.py
@@ -74,16 +74,19 @@ async def _collect_reply(
 
     async with service.session_manager.stream_messages(session_id, replay=True, idle_timeout=5.0) as stream:
         async for message in stream:
+            # deadline 必须每轮都查：持续 <idle_timeout 间隔的消息流会让 _idle 永不触发，
+            # 若只在 _idle 上判超时，跑飞/刷屏的会话会让本同步请求无界挂起。
+            if loop.time() >= deadline:
+                status = "timeout"
+                break
+
             msg_type = message.get("type", "")
 
             if msg_type == "_replay_done":
                 continue
 
             if msg_type == "_idle":
-                # 无 request 对象：在空闲哨兵上判 deadline 到期与会话状态。
-                if loop.time() >= deadline:
-                    status = "timeout"
-                    break
+                # 无 request 对象：在空闲哨兵上判会话状态（deadline 已在循环顶部统一判）。
                 live_status = await service.session_manager.get_status(session_id)
                 if live_status and live_status != "running":
                     status = "completed" if live_status in {"idle", "completed"} else live_status

--- a/server/routers/agent_chat.py
+++ b/server/routers/agent_chat.py
@@ -58,38 +58,37 @@ async def _collect_reply(
     session_id: str,
     timeout: float,
 ) -> tuple[str, str]:
-    """订阅会话队列，收集 assistant 回复直到完成或超时。
+    """消费会话消息流，收集 assistant 回复直到完成或超时。
+
+    通过 ``stream_messages`` 上下文管理器消费（非 SSE、无 ``request`` 对象）：
+    deadline 与会话状态判断挂在 ``_idle`` 哨兵上，超时检测粒度因此变为 idle_timeout
+    （≤5s）。退出注销由 ``__aexit__`` 确定性承载（见 ADR-0005）。
 
     Returns:
         (reply_text, status) — status 为 "completed" / "timeout" / "error"
     """
-    queue = await service.session_manager.subscribe(session_id, replay_buffer=True)
-    try:
-        reply_parts: list[str] = []
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + timeout
+    reply_parts: list[str] = []
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    status = "timeout"
 
-        while True:
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                status = "timeout"
-                break
+    async with service.session_manager.stream_messages(session_id, replay=True, idle_timeout=5.0) as stream:
+        async for message in stream:
+            msg_type = message.get("type", "")
 
-            try:
-                message = await asyncio.wait_for(queue.get(), timeout=min(remaining, 5.0))
-            except TimeoutError:
-                # 检查会话是否已完成
+            if msg_type == "_replay_done":
+                continue
+
+            if msg_type == "_idle":
+                # 无 request 对象：在空闲哨兵上判 deadline 到期与会话状态。
+                if loop.time() >= deadline:
+                    status = "timeout"
+                    break
                 live_status = await service.session_manager.get_status(session_id)
                 if live_status and live_status != "running":
                     status = "completed" if live_status in {"idle", "completed"} else live_status
                     break
-                # 检查是否超时
-                if loop.time() >= deadline:
-                    status = "timeout"
-                    break
                 continue
-
-            msg_type = message.get("type", "")
 
             if msg_type == "assistant":
                 text = _extract_text_from_assistant_message(message)
@@ -100,10 +99,7 @@ async def _collect_reply(
                 # 终结消息：提取最后一条 assistant 回复（如果还没有从队列里收到）
                 subtype = str(message.get("subtype") or "").lower()
                 is_error = bool(message.get("is_error"))
-                if is_error or subtype.startswith("error"):
-                    status = "error"
-                else:
-                    status = "completed"
+                status = "error" if is_error or subtype.startswith("error") else "completed"
                 break
 
             elif msg_type == "runtime_status":
@@ -113,14 +109,11 @@ async def _collect_reply(
                     break
 
             elif msg_type == "_queue_overflow":
-                # 队列溢出，中断
+                # 队列溢出：显式收尾（不再忽略后傻等到超时）。
                 status = "error"
                 break
 
-        return "".join(reply_parts), status
-
-    finally:
-        await service.session_manager.unsubscribe(session_id, queue)
+    return "".join(reply_parts), status
 
 
 @router.post("/agent/chat")

--- a/server/routers/assistant.py
+++ b/server/routers/assistant.py
@@ -228,12 +228,13 @@ async def answer_question(
 async def stream_events(
     project_name: str,
     session_id: str,
+    request: Request,
     _user: CurrentUserFlexible,
     deps: tuple[AssistantService, SessionMeta] = Depends(_assistant_service_for_stream),
 ) -> AsyncIterator[ServerSentEvent]:
     service, meta = deps
     try:
-        async for event in service.stream_events(session_id, meta=meta):
+        async for event in service.stream_events(session_id, meta=meta, request=request):
             yield event
     except HTTPException:
         raise

--- a/server/routers/project_events.py
+++ b/server/routers/project_events.py
@@ -58,10 +58,11 @@ async def stream_project_events(
     try:
         async with service.stream_events(project_name, idle_timeout=PROJECT_EVENTS_SSE_POLL_SECONDS) as stream:
             async for item in stream:
+                # 每轮迭代顶部都查断线;_idle 仅作为「队列空闲时也要醒一次」的唤醒兜底,
+                # 不再独占断线检测的时机——持续高频事件流下断线一样能立刻发现。
+                if await request.is_disconnected():
+                    break
                 if isinstance(item, dict) and item.get("type") == "_idle":
-                    # Idle tick: poll for disconnect so __aexit__ unsubscribes promptly.
-                    if await request.is_disconnected():
-                        break
                     continue
                 event_name, payload = item
                 yield ServerSentEvent(event=event_name, data=payload)

--- a/server/routers/project_events.py
+++ b/server/routers/project_events.py
@@ -5,14 +5,16 @@ SSE stream for project data changes inside the workspace.
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator
-from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.sse import EventSourceResponse, ServerSentEvent
 
 from server.auth import CurrentUserFlexible
 from server.services.project_events import ProjectEventService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -23,16 +25,21 @@ def get_project_event_service(request: Request) -> ProjectEventService:
     return request.app.state.project_event_service
 
 
-async def _project_events_subscription(
+async def _project_events_service(
     project_name: str,
     request: Request,
-) -> tuple[ProjectEventService, asyncio.Queue, dict[str, Any]]:
+) -> ProjectEventService:
+    """Resolve the service and validate the project exists before streaming starts.
+
+    The 404 must be raised here (before the EventSourceResponse begins) — once the
+    stream is open, no HTTP status can be returned.
+    """
     service = get_project_event_service(request)
     try:
-        queue, snapshot = await service.subscribe(project_name)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc))
-    return service, queue, snapshot
+        await asyncio.to_thread(service.pm.get_project_path, project_name)
+    except (FileNotFoundError, KeyError):
+        raise HTTPException(status_code=404, detail=f"project not found: {project_name}")
+    return service
 
 
 @router.get(
@@ -43,23 +50,21 @@ async def stream_project_events(
     project_name: str,
     request: Request,
     _user: CurrentUserFlexible,
-    subscription: tuple[ProjectEventService, asyncio.Queue, dict[str, Any]] = Depends(_project_events_subscription),
+    service: ProjectEventService = Depends(_project_events_service),
 ) -> AsyncIterator[ServerSentEvent]:
-    service, queue, snapshot = subscription
-
     try:
-        yield ServerSentEvent(event="snapshot", data=snapshot)
-
-        while True:
-            if await request.is_disconnected():
-                break
-            try:
-                event_name, payload = await asyncio.wait_for(
-                    queue.get(),
-                    timeout=PROJECT_EVENTS_SSE_POLL_SECONDS,
-                )
-            except TimeoutError:
-                continue
-            yield ServerSentEvent(event=event_name, data=payload)
-    finally:
-        await service.unsubscribe(project_name, queue)
+        async with service.stream_events(project_name, idle_timeout=PROJECT_EVENTS_SSE_POLL_SECONDS) as stream:
+            async for item in stream:
+                if isinstance(item, dict) and item.get("type") == "_idle":
+                    # Idle tick: poll for disconnect so __aexit__ unsubscribes promptly.
+                    if await request.is_disconnected():
+                        break
+                    continue
+                event_name, payload = item
+                yield ServerSentEvent(event=event_name, data=payload)
+    except FileNotFoundError:
+        # Race: project deleted between the Depends check and stream start. The
+        # EventSourceResponse has already begun, so we cannot raise HTTP — log and
+        # close the stream cleanly.
+        logger.info("项目在订阅前被删除，关闭事件流: %s", project_name)
+        return

--- a/server/routers/project_events.py
+++ b/server/routers/project_events.py
@@ -37,8 +37,11 @@ async def _project_events_service(
     service = get_project_event_service(request)
     try:
         await asyncio.to_thread(service.pm.get_project_path, project_name)
-    except (FileNotFoundError, KeyError):
-        raise HTTPException(status_code=404, detail=f"project not found: {project_name}")
+    except (FileNotFoundError, KeyError) as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except ValueError as exc:
+        # 非法项目名(路径穿越等)是坏请求,不是「不存在」。
+        raise HTTPException(status_code=400, detail=str(exc))
     return service
 
 

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -5,10 +5,12 @@ Project data change detection and SSE fanout for workspace realtime updates.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import json
 import logging
 import uuid
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -101,7 +103,12 @@ class ProjectEventService:
         self._channels.clear()
         self._loop = None
 
-    async def subscribe(self, project_name: str) -> tuple[asyncio.Queue, dict[str, Any]]:
+    async def _subscribe(self, project_name: str) -> tuple[asyncio.Queue, dict[str, Any]]:
+        """Register a queue for *project_name* and return it with the initial snapshot.
+
+        Private: the only consumer is :meth:`stream_events`, which owns the
+        deterministic unsubscribe via its context-manager ``__aexit__``.
+        """
         await asyncio.to_thread(self.pm.get_project_path, project_name)
         channel = self._channels.get(project_name)
         if channel is None:
@@ -123,7 +130,8 @@ class ProjectEventService:
         await channel.ready_event.wait()
         return queue, self._build_snapshot_payload(project_name, channel)
 
-    async def unsubscribe(self, project_name: str, queue: asyncio.Queue) -> None:
+    async def _unsubscribe(self, project_name: str, queue: asyncio.Queue) -> None:
+        """Remove a queue; stop the watch task once the last subscriber leaves."""
         channel = self._channels.get(project_name)
         if channel is None:
             return
@@ -135,6 +143,43 @@ class ProjectEventService:
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
         self._channels.pop(project_name, None)
+
+    @contextlib.asynccontextmanager
+    async def stream_events(
+        self, project_name: str, *, idle_timeout: float = 1.0
+    ) -> AsyncIterator[AsyncIterator[tuple[str, Any] | dict[str, Any]]]:
+        """Subscribe to a project's events as a self-cleaning async iterator.
+
+        Yields an async iterator producing, in order:
+
+        - a ``("snapshot", payload)`` tuple as the first event (initial state),
+        - live ``(event_name, payload)`` tuples as changes are broadcast,
+        - a ``{"type": "_idle"}`` sentinel whenever *idle_timeout* elapses with no
+          event (consumers poll disconnect on it).
+
+        The "queue full → silently drop subscriber" overflow semantics are
+        unchanged (no ``_queue_overflow`` sentinel). Subscription and unsubscribe
+        live behind this seam; cleanup is carried by ``__aexit__`` (see ADR-0005).
+        Consume as ``async with stream_events(...) as stream: async for item in stream``.
+        """
+        queue, snapshot = await self._subscribe(project_name)
+
+        async def _iter() -> AsyncIterator[tuple[str, Any] | dict[str, Any]]:
+            # NOTE: intentionally NO ``finally: _unsubscribe`` here — cleanup is owned
+            # by the enclosing context manager's __aexit__ (ADR-0005). Do not add one.
+            yield ("snapshot", snapshot)
+            while True:
+                try:
+                    item = await asyncio.wait_for(queue.get(), timeout=idle_timeout)
+                except TimeoutError:
+                    yield {"type": "_idle"}
+                    continue
+                yield item
+
+        try:
+            yield _iter()
+        finally:
+            await self._unsubscribe(project_name, queue)
 
     def _on_hint(
         self,

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -116,6 +116,7 @@ class ProjectEventService:
             self._channels[project_name] = channel
 
         queue: asyncio.Queue = asyncio.Queue(maxsize=100)
+        # 队列必须在首次扫描前注册,否则会漏掉扫描完成到注册之间广播的事件。
         channel.subscribers.add(queue)
 
         if channel.task is None or channel.task.done():
@@ -127,7 +128,17 @@ class ProjectEventService:
                 name=f"project-events-{project_name}",
             )
 
-        await channel.ready_event.wait()
+        try:
+            await channel.ready_event.wait()
+        except BaseException:
+            # 客户端在首次扫描期间断开会取消这里:此时 _subscribe 尚未返回 queue,
+            # stream_events 的 try/finally 进不去。同步清理掉刚注册的订阅者(空闲项目
+            # 下 watch task 不会自愈),不 await 以免取消重入。
+            channel.subscribers.discard(queue)
+            if not channel.subscribers and channel.task is not None:
+                channel.task.cancel()
+                self._channels.pop(project_name, None)
+            raise
         return queue, self._build_snapshot_payload(project_name, channel)
 
     async def _unsubscribe(self, project_name: str, queue: asyncio.Queue) -> None:

--- a/tests/test_agent_chat_router.py
+++ b/tests/test_agent_chat_router.py
@@ -4,6 +4,9 @@
 测试 POST /api/v1/agent/chat 端点的核心逻辑。
 """
 
+import asyncio
+import contextlib
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from fastapi import FastAPI
@@ -111,6 +114,75 @@ class TestAgentChatEndpoint:
         assert resp.status_code == 200
         assert resp.json()["status"] == "timeout"
         assert resp.json()["reply"] == "部分响应"
+
+
+class _StubSessionManager:
+    """A SessionManager whose stream_messages yields a scripted sequence."""
+
+    def __init__(self, live_messages, *, status="running", flood=False):
+        self._live = list(live_messages)
+        self.status = status
+        self._flood = flood
+
+    async def get_status(self, session_id):
+        return self.status
+
+    @contextlib.asynccontextmanager
+    async def stream_messages(self, session_id, *, replay=True, idle_timeout=5.0):
+        live = self._live
+        flood = self._flood
+
+        async def _iter():
+            yield {"type": "_replay_done"}
+            for msg in live:
+                yield msg
+            # flood: 持续以 <idle_timeout 间隔吐消息,_idle 永不触发。
+            while flood:
+                await asyncio.sleep(0.01)
+                yield {"type": "assistant", "content": [{"type": "text", "text": "x"}]}
+
+        yield _iter()
+
+
+class TestCollectReply:
+    async def test_enforces_deadline_under_continuous_traffic(self):
+        """持续 <idle_timeout 间隔的消息流下,deadline 仍被每轮检查 → timeout。
+
+        回归保护:若 deadline 只在 _idle 上判,这里会无限挂起(由外层 wait_for 兜底失败)。
+        """
+        service = SimpleNamespace(session_manager=_StubSessionManager([], flood=True))
+        reply, status = await asyncio.wait_for(
+            agent_chat._collect_reply(service, "sess-1", timeout=0.05),
+            timeout=5.0,
+        )
+        assert status == "timeout"
+
+    async def test_queue_overflow_yields_error(self):
+        """直播阶段 _queue_overflow → 显式收尾为 error,不傻等超时。"""
+        service = SimpleNamespace(
+            session_manager=_StubSessionManager([{"type": "_queue_overflow", "session_id": "sdk-1"}]),
+        )
+        reply, status = await asyncio.wait_for(
+            agent_chat._collect_reply(service, "sess-1", timeout=5.0),
+            timeout=5.0,
+        )
+        assert status == "error"
+
+    async def test_result_message_completes(self):
+        service = SimpleNamespace(
+            session_manager=_StubSessionManager(
+                [
+                    {"type": "assistant", "content": [{"type": "text", "text": "你好"}]},
+                    {"type": "result", "subtype": "success", "is_error": False},
+                ]
+            ),
+        )
+        reply, status = await asyncio.wait_for(
+            agent_chat._collect_reply(service, "sess-1", timeout=5.0),
+            timeout=5.0,
+        )
+        assert status == "completed"
+        assert reply == "你好"
 
 
 class TestExtractTextFromAssistantMessage:

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -261,15 +261,6 @@ class TestAssistantServiceMore:
         assert snapshot["status"] == "running"
         assert snapshot["pending_questions"][0]["question_id"] == "aq-1"
 
-        replayed, overflow = service._drain_replay(asyncio.Queue())
-        assert replayed == []
-        assert overflow is False
-        q = asyncio.Queue()
-        q.put_nowait({"type": "_queue_overflow"})
-        replayed2, overflow2 = service._drain_replay(q)
-        assert replayed2 == []
-        assert overflow2 is True
-
         projector = AssistantStreamProjector(initial_messages=[])
         events, should_break = await service._dispatch_live_message(
             {"type": "_queue_overflow"},

--- a/tests/test_assistant_service_streaming.py
+++ b/tests/test_assistant_service_streaming.py
@@ -1,6 +1,7 @@
 """Unit tests for AssistantService streaming snapshot/replay behavior."""
 
 import asyncio
+import contextlib
 
 import pytest
 from fastapi.sse import ServerSentEvent
@@ -52,16 +53,32 @@ class _FakeSessionManager:
         self.call_log.append(("get_buffered_messages", session_id))
         return list(self.replay_messages)
 
-    async def subscribe(self, session_id: str, replay_buffer: bool = True):
-        self.call_log.append(("subscribe", session_id, replay_buffer))
+    @contextlib.asynccontextmanager
+    async def stream_messages(self, session_id: str, *, replay: bool = True, idle_timeout: float = 20.0):
+        """Mirror the real CM: replay snapshot → _replay_done → live queue → _idle."""
+        self.call_log.append(("stream_messages", session_id, replay))
         queue: asyncio.Queue = asyncio.Queue()
-        for message in self.replay_messages:
-            queue.put_nowait(message)
         self.last_queue = queue
-        return queue
+        replay_msgs = list(self.replay_messages) if replay else []
 
-    async def unsubscribe(self, session_id: str, queue: asyncio.Queue):
-        self.call_log.append(("unsubscribe", session_id))
+        async def _iter():
+            for message in replay_msgs:
+                yield message
+            yield {"type": "_replay_done"}
+            while True:
+                try:
+                    message = await asyncio.wait_for(queue.get(), timeout=idle_timeout)
+                except TimeoutError:
+                    yield {"type": "_idle"}
+                    continue
+                yield message
+                if message.get("type") == "_queue_overflow":
+                    return
+
+        try:
+            yield _iter()
+        finally:
+            self.call_log.append(("unsubscribe", session_id))
 
     async def get_pending_questions_snapshot(self, session_id: str):
         self.call_log.append(("get_pending_questions_snapshot", session_id))
@@ -106,31 +123,35 @@ class TestAssistantServiceStreaming:
         assert payload["turns"][0]["type"] == "user"
         await stream.aclose()
 
-        subscribe_idx = call_log.index(("subscribe", "session-1", True))
+        subscribe_idx = call_log.index(("stream_messages", "session-1", True))
         read_raw_idx = call_log.index(("read_raw_messages", "session-1"))
         assert subscribe_idx < read_raw_idx
 
-    async def test_stream_replay_overflow_closes_stream_immediately(self, tmp_path):
+    async def test_stream_live_overflow_ends_stream_after_snapshot(self, tmp_path):
         service = AssistantService(project_root=tmp_path)
         meta = make_session_meta()
 
         call_log: list[tuple] = []
+        fake_manager = _FakeSessionManager(call_log, status="running", replay_messages=[])
         service.meta_store = _FakeMetaStore(meta)
         service.transcript_adapter = _FakeTranscriptAdapter(call_log, history_raw=[])
-        service.session_manager = _FakeSessionManager(
-            call_log,
-            status="running",
-            replay_messages=[{"type": "_queue_overflow", "session_id": "sdk-1"}],
-        )
+        service.session_manager = fake_manager
 
         stream = service.stream_events("session-1")
+        # 快照先发出(回放阶段干净,溢出只可能发生在直播阶段)。
+        snapshot_event = await anext(stream)
+        assert _parse_sse_event(snapshot_event)[0] == "snapshot"
+
+        # 直播阶段队列被挤爆 → _queue_overflow → 流结束。
+        queue = fake_manager.last_queue
+        assert queue is not None
+        queue.put_nowait({"type": "_queue_overflow", "session_id": "sdk-1"})
         with pytest.raises(StopAsyncIteration):
             await anext(stream)
         await stream.aclose()
 
-        assert ("subscribe", "session-1", True) in call_log
+        assert ("stream_messages", "session-1", True) in call_log
         assert ("unsubscribe", "session-1") in call_log
-        assert ("read_raw_messages", "session-1", "sdk-1", "demo") not in call_log
 
     async def test_stream_emits_delta_patch_question_and_status_events(self, tmp_path):
         service = AssistantService(project_root=tmp_path)

--- a/tests/test_project_events_router.py
+++ b/tests/test_project_events_router.py
@@ -1,4 +1,4 @@
-import asyncio
+import contextlib
 from types import SimpleNamespace
 
 import pytest
@@ -7,22 +7,36 @@ from server.routers import project_events as project_events_router
 
 
 class _FakeRequest:
-    def __init__(self, app):
+    def __init__(self, app, *, disconnected: bool = False):
         self.app = app
+        self._disconnected = disconnected
 
     async def is_disconnected(self):
-        return False
+        return self._disconnected
+
+
+class _FakePM:
+    def get_project_path(self, project_name: str):
+        return f"/projects/{project_name}"
 
 
 class _FakeService:
     def __init__(self):
         self.unsubscribed = False
-        self.queue = None
+        self.pm = _FakePM()
 
-    async def subscribe(self, project_name: str):
-        queue = asyncio.Queue()
-        await queue.put(
-            (
+    @contextlib.asynccontextmanager
+    async def stream_events(self, project_name: str, *, idle_timeout: float = 1.0):
+        async def _iter():
+            yield (
+                "snapshot",
+                {
+                    "project_name": project_name,
+                    "fingerprint": "fp-0",
+                    "generated_at": "2026-03-01T00:00:00Z",
+                },
+            )
+            yield (
                 "changes",
                 {
                     "project_name": project_name,
@@ -33,16 +47,14 @@ class _FakeService:
                     "changes": [],
                 },
             )
-        )
-        self.queue = queue
-        return queue, {
-            "project_name": project_name,
-            "fingerprint": "fp-0",
-            "generated_at": "2026-03-01T00:00:00Z",
-        }
+            # 之后进入空闲;消费方在 _idle 上轮询 is_disconnected。
+            while True:
+                yield {"type": "_idle"}
 
-    async def unsubscribe(self, project_name: str, queue):
-        self.unsubscribed = True
+        try:
+            yield _iter()
+        finally:
+            self.unsubscribed = True
 
 
 @pytest.mark.asyncio
@@ -51,10 +63,10 @@ async def test_stream_project_events_emits_snapshot_and_changes():
     app = SimpleNamespace(state=SimpleNamespace(project_event_service=service))
     request = _FakeRequest(app)
 
-    subscription = await project_events_router._project_events_subscription("demo", request)
-    stream = project_events_router.stream_project_events(
-        "demo", request, _user={"sub": "testuser"}, subscription=subscription
-    )
+    resolved = await project_events_router._project_events_service("demo", request)
+    assert resolved is service
+
+    stream = project_events_router.stream_project_events("demo", request, _user={"sub": "testuser"}, service=service)
 
     snapshot_event = await anext(stream)
     changes_event = await anext(stream)
@@ -65,4 +77,20 @@ async def test_stream_project_events_emits_snapshot_and_changes():
 
     assert changes_event.event == "changes"
     assert changes_event.data["batch_id"] == "batch-1"
+    assert service.unsubscribed is True
+
+
+@pytest.mark.asyncio
+async def test_stream_project_events_breaks_on_disconnect():
+    service = _FakeService()
+    app = SimpleNamespace(state=SimpleNamespace(project_event_service=service))
+    request = _FakeRequest(app, disconnected=True)
+
+    stream = project_events_router.stream_project_events("demo", request, _user={"sub": "testuser"}, service=service)
+
+    # snapshot + changes 后进入 _idle,断线被自检命中 → 流结束并注销。
+    assert (await anext(stream)).event == "snapshot"
+    assert (await anext(stream)).event == "changes"
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
     assert service.unsubscribed is True

--- a/tests/test_project_events_router.py
+++ b/tests/test_project_events_router.py
@@ -7,12 +7,21 @@ from server.routers import project_events as project_events_router
 
 
 class _FakeRequest:
-    def __init__(self, app, *, disconnected: bool = False):
+    def __init__(self, app, *, disconnect_after: int | None = None):
+        """断线检测在循环顶部进行,每次 anext 前都会调用一次 is_disconnected。
+
+        ``disconnect_after`` = None  → 永不断线
+        ``disconnect_after`` = N     → 前 N 次返回 False,第 N+1 次起返回 True
+        """
         self.app = app
-        self._disconnected = disconnected
+        self._disconnect_after = disconnect_after
+        self._calls = 0
 
     async def is_disconnected(self):
-        return self._disconnected
+        self._calls += 1
+        if self._disconnect_after is None:
+            return False
+        return self._calls > self._disconnect_after
 
 
 class _FakePM:
@@ -81,16 +90,61 @@ async def test_stream_project_events_emits_snapshot_and_changes():
 
 
 @pytest.mark.asyncio
-async def test_stream_project_events_breaks_on_disconnect():
+async def test_stream_project_events_breaks_on_disconnect_in_idle():
+    """空闲期间断线:_idle 哨兵被路由查到断线后 break,流结束并注销。"""
     service = _FakeService()
     app = SimpleNamespace(state=SimpleNamespace(project_event_service=service))
-    request = _FakeRequest(app, disconnected=True)
+    # 前 2 次 is_disconnected(snapshot 与 changes 的迭代顶部)返回 False,
+    # 之后第 3 次起(进入 _idle 阶段)返回 True。
+    request = _FakeRequest(app, disconnect_after=2)
 
     stream = project_events_router.stream_project_events("demo", request, _user={"sub": "testuser"}, service=service)
 
-    # snapshot + changes 后进入 _idle,断线被自检命中 → 流结束并注销。
     assert (await anext(stream)).event == "snapshot"
     assert (await anext(stream)).event == "changes"
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+    assert service.unsubscribed is True
+
+
+@pytest.mark.asyncio
+async def test_stream_project_events_breaks_on_disconnect_during_continuous_events():
+    """持续事件流(无 _idle)期间断线:循环顶部的检测也能立即触发 break。
+
+    回归保护:旧实现把断线检测放在 _idle 分支里,持续 <idle_timeout 间隔的事件流
+    会让 _idle 永不触发、断线发现被推迟到事件停歇。新实现每轮迭代顶部都查。
+    """
+
+    class _BusyService:
+        def __init__(self):
+            self.unsubscribed = False
+            self.pm = _FakePM()
+
+        @contextlib.asynccontextmanager
+        async def stream_events(self, project_name: str, *, idle_timeout: float = 1.0):
+            async def _iter():
+                yield ("snapshot", {"project_name": project_name, "fingerprint": "fp-0"})
+                # 持续吐真事件,不吐 _idle。
+                i = 0
+                while True:
+                    i += 1
+                    yield ("changes", {"batch_id": f"b{i}", "fingerprint": f"fp-{i}"})
+
+            try:
+                yield _iter()
+            finally:
+                self.unsubscribed = True
+
+    service = _BusyService()
+    app = SimpleNamespace(state=SimpleNamespace(project_event_service=service))
+    # 第 1 次(snapshot 顶部)False,第 2 次(第一条 changes 顶部)起 True。
+    request = _FakeRequest(app, disconnect_after=1)
+
+    stream = project_events_router.stream_project_events("demo", request, _user={"sub": "testuser"}, service=service)
+
+    # snapshot 通过(第 1 次 is_disconnected 返回 False)
+    assert (await anext(stream)).event == "snapshot"
+    # 下一轮迭代顶部的检测命中断线 → break,即使后面 _iter() 还在持续吐 changes。
     with pytest.raises(StopAsyncIteration):
         await anext(stream)
     assert service.unsubscribed is True

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -239,6 +239,38 @@ class TestProjectEventService:
 
         await service.shutdown()
 
+    @pytest.mark.asyncio
+    async def test_subscribe_cancellation_cleans_up_subscriber(self, tmp_path, monkeypatch):
+        """客户端在首次扫描期间断开 → _subscribe 被取消 → 订阅者与 watch task 不泄漏。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+
+        service = ProjectEventService(tmp_path, poll_interval=0.05)
+        await service.start()
+
+        # 模拟首次扫描卡住:watch task 永不 set ready_event,_subscribe 会 park 在 wait()。
+        async def _never_ready(project_name, channel):
+            await asyncio.sleep(3600)
+
+        monkeypatch.setattr(service, "_watch_project", _never_ready)
+
+        task = asyncio.create_task(service._subscribe("demo"))
+        await asyncio.sleep(0.05)  # 让 _subscribe 注册 queue 并 park
+        channel = service._channels["demo"]
+        assert channel.subscribers  # 已注册
+        watch_task = channel.task
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # 取消后:订阅者被清理、channel 被弹出、watch task 被取消(不泄漏)。
+        assert "demo" not in service._channels
+        await asyncio.sleep(0)  # 让 watch task 的取消落定
+        assert watch_task.cancelled() or watch_task.done()
+
+        await service.shutdown()
+
     def test_projects_root_kwarg_overrides_default_subdir(self, tmp_path):
         """显式传 projects_root 时，service.pm 走该目录而非 project_root/'projects'。
 

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -8,6 +8,21 @@ from lib.project_manager import ProjectManager
 from server.services.project_events import ProjectEventService
 
 
+async def _next_event(stream, *, timeout: float) -> tuple[str, dict]:
+    """Pull the next real (event_name, payload) tuple, skipping ``_idle`` sentinels."""
+
+    async def _pull() -> tuple[str, dict]:
+        async for item in stream:
+            if isinstance(item, dict):
+                if item.get("type") == "_idle":
+                    continue
+                raise AssertionError(f"unexpected dict sentinel: {item}")
+            return item
+        raise AssertionError("stream ended before a real event arrived")
+
+    return await asyncio.wait_for(_pull(), timeout=timeout)
+
+
 class TestProjectEventService:
     def test_diff_snapshots_reports_character_and_storyboard_changes(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
@@ -155,34 +170,36 @@ class TestProjectEventService:
 
         service = ProjectEventService(tmp_path, poll_interval=0.05)
         await service.start()
-        queue, snapshot = await service.subscribe("demo")
 
-        assert snapshot["project_name"] == "demo"
+        async with service.stream_events("demo", idle_timeout=0.1) as stream:
+            # 首个事件是 snapshot 元组。
+            first = await anext(stream)
+            assert first[0] == "snapshot"
+            assert first[1]["project_name"] == "demo"
 
-        script_path = pm.get_project_path("demo") / "scripts" / "episode_2.json"
-        script_path.write_text(
-            json.dumps(
-                {
-                    "episode": 2,
-                    "title": "第二集",
-                    "content_mode": "narration",
-                    "segments": [],
-                },
-                ensure_ascii=False,
-            ),
-            encoding="utf-8",
-        )
+            script_path = pm.get_project_path("demo") / "scripts" / "episode_2.json"
+            script_path.write_text(
+                json.dumps(
+                    {
+                        "episode": 2,
+                        "title": "第二集",
+                        "content_mode": "narration",
+                        "segments": [],
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
 
-        event_name, payload = await asyncio.wait_for(queue.get(), timeout=1.5)
-        assert event_name == "changes"
-        assert payload["source"] == "filesystem"
-        assert any(
-            change["entity_type"] == "episode" and change["action"] == "created" and change["episode"] == 2
-            for change in payload["changes"]
-        )
-        assert any(episode["episode"] == 2 for episode in pm.load_project("demo")["episodes"])
+            event_name, payload = await _next_event(stream, timeout=1.5)
+            assert event_name == "changes"
+            assert payload["source"] == "filesystem"
+            assert any(
+                change["entity_type"] == "episode" and change["action"] == "created" and change["episode"] == 2
+                for change in payload["changes"]
+            )
+            assert any(episode["episode"] == 2 for episode in pm.load_project("demo")["episodes"])
 
-        await service.unsubscribe("demo", queue)
         await service.shutdown()
 
     @pytest.mark.asyncio
@@ -193,32 +210,33 @@ class TestProjectEventService:
 
         service = ProjectEventService(tmp_path, poll_interval=1.0)
         await service.start()
-        queue, snapshot = await service.subscribe("demo")
 
-        assert snapshot["fingerprint"]
+        async with service.stream_events("demo", idle_timeout=0.1) as stream:
+            event_name, snapshot = await anext(stream)
+            assert event_name == "snapshot"
+            assert snapshot["fingerprint"]
 
-        emit_project_change_batch(
-            "demo",
-            [
-                {
-                    "entity_type": "segment",
-                    "action": "storyboard_ready",
-                    "entity_id": "E1S01",
-                    "label": "分镜「E1S01」",
-                    "focus": None,
-                    "important": True,
-                }
-            ],
-            source="worker",
-        )
+            emit_project_change_batch(
+                "demo",
+                [
+                    {
+                        "entity_type": "segment",
+                        "action": "storyboard_ready",
+                        "entity_id": "E1S01",
+                        "label": "分镜「E1S01」",
+                        "focus": None,
+                        "important": True,
+                    }
+                ],
+                source="worker",
+            )
 
-        event_name, payload = await asyncio.wait_for(queue.get(), timeout=1.0)
-        assert event_name == "changes"
-        assert payload["source"] == "worker"
-        assert payload["fingerprint"] == snapshot["fingerprint"]
-        assert payload["changes"][0]["action"] == "storyboard_ready"
+            event_name, payload = await _next_event(stream, timeout=1.0)
+            assert event_name == "changes"
+            assert payload["source"] == "worker"
+            assert payload["fingerprint"] == snapshot["fingerprint"]
+            assert payload["changes"][0]["action"] == "storyboard_ready"
 
-        await service.unsubscribe("demo", queue)
         await service.shutdown()
 
     def test_projects_root_kwarg_overrides_default_subdir(self, tmp_path):

--- a/tests/test_session_manager_more.py
+++ b/tests/test_session_manager_more.py
@@ -332,14 +332,95 @@ class TestSessionManagerMore:
         managed.message_buffer.append({"type": "assistant", "uuid": "a1"})
         session_manager.sessions[meta.id] = managed
 
-        queue = await session_manager.subscribe(meta.id, replay_buffer=True)
-        assert queue.get_nowait()["uuid"] == "a1"
-        await session_manager.unsubscribe(meta.id, queue)
+        queue, replay = await session_manager._subscribe(meta.id, replay=True)
+        # 回放作为快照单独返回，不再塞进直播队列。
+        assert replay[0]["uuid"] == "a1"
+        assert queue.empty()
+        await session_manager._unsubscribe(meta.id, queue)
         assert queue not in managed.subscribers
 
         await session_manager.shutdown_gracefully(timeout=0.01)
         assert client.disconnected is True
         assert session_manager.sessions == {}
+
+    @pytest.mark.asyncio
+    async def test_stream_messages_replay_boundary_live_and_idle(self, session_manager, meta_store):
+        from tests.fakes import build_managed_with_actor
+
+        meta = await meta_store.create("demo", "sdk-stream-seq")
+        managed, _actor, _client = await build_managed_with_actor(
+            session_id=meta.id,
+            project_name="demo",
+            status="running",
+        )
+        managed.message_buffer.append({"type": "assistant", "uuid": "replay-1"})
+        session_manager.sessions[meta.id] = managed
+
+        async with session_manager.stream_messages(meta.id, replay=True, idle_timeout=0.05) as stream:
+            assert (await anext(stream))["uuid"] == "replay-1"
+            assert (await anext(stream))["type"] == "_replay_done"
+            managed.add_message({"type": "assistant", "uuid": "live-1"})
+            assert (await anext(stream))["uuid"] == "live-1"
+            # idle_timeout 内无消息 → _idle 哨兵
+            assert (await anext(stream))["type"] == "_idle"
+        # 正常退出后订阅者被移除
+        assert managed.subscribers == set()
+
+    @pytest.mark.asyncio
+    async def test_stream_messages_overflow_ends_iteration(self, session_manager, meta_store):
+        from tests.fakes import build_managed_with_actor
+
+        meta = await meta_store.create("demo", "sdk-stream-overflow")
+        managed, _actor, _client = await build_managed_with_actor(
+            session_id=meta.id,
+            project_name="demo",
+            status="running",
+        )
+        session_manager.sessions[meta.id] = managed
+
+        async with session_manager.stream_messages(meta.id, replay=False, idle_timeout=5.0) as stream:
+            assert (await anext(stream))["type"] == "_replay_done"
+            # 挤爆订阅者队列：critical 消息填满 + 无可驱逐 → 注入 _queue_overflow。
+            for i in range(120):
+                managed.add_message({"type": "assistant", "uuid": f"m{i}"})
+            saw_overflow = False
+            async for msg in stream:
+                if msg.get("type") == "_queue_overflow":
+                    saw_overflow = True
+                    break
+            assert saw_overflow
+        assert managed.subscribers == set()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("exit_mode", ["break", "exception"])
+    async def test_stream_messages_unsubscribes_on_every_exit(self, session_manager, meta_store, exit_mode):
+        from tests.fakes import build_managed_with_actor
+
+        meta = await meta_store.create("demo", f"sdk-exit-{exit_mode}")
+        managed, _actor, _client = await build_managed_with_actor(
+            session_id=meta.id,
+            project_name="demo",
+            status="running",
+        )
+        session_manager.sessions[meta.id] = managed
+
+        async def consume():
+            async with session_manager.stream_messages(meta.id, replay=False, idle_timeout=0.02) as stream:
+                assert len(managed.subscribers) == 1
+                async for msg in stream:
+                    if msg.get("type") == "_replay_done":
+                        continue
+                    if exit_mode == "exception":
+                        raise RuntimeError("boom")
+                    break  # break 退出路径
+
+        if exit_mode == "exception":
+            with pytest.raises(RuntimeError):
+                await consume()
+        else:
+            await consume()
+        # break / 异常退出路径同样确定性移除订阅者
+        assert managed.subscribers == set()
 
     @pytest.mark.asyncio
     async def test_file_access_hook_allows_read_within_project_root(self, tmp_path):


### PR DESCRIPTION
## 背景

会话(`SessionManager`)与项目事件(`ProjectEventService`)两条实时推送过去把裸 `asyncio.Queue` 当接口暴露：消费方各自 `subscribe` → 手写取队列循环 → `finally: unsubscribe`，漏写即订阅者泄漏；且断线时注销落到 GC 兜底，不及时（见 ADR-0005）。

本 PR 把「订阅 + 回放 + 队列消费 + 溢出 + 退出注销」收敛到**两个独立的 async 上下文管理器**背后（两条流负载/回放语义不同，**不合并**），清理由 `__aexit__` 确定性承载，消费方在 `_idle` 哨兵上轮询 `is_disconnected` 主动 break。

Closes #613。设计依据 `docs/adr/0005-sse-stream-async-context-manager.md`。

## 改动（M1–M5）

- **M1** `SessionManager.stream_messages()`：`subscribe/unsubscribe` 收私有；回放快照与直播队列干净切分；吐 `replay → _replay_done → live`，空闲吐 `_idle`、溢出吐 `_queue_overflow`。
- **M2** `ProjectEventService.stream_events()`：同样收私有；snapshot 作首个事件，空闲吐 `_idle`，溢出语义不变。
- **M3** 会话 SSE(`AssistantService.stream_events` + assistant 路由)：改 `async with`，`_idle` 上查 `is_disconnected`；删除 `_stream_running_session`/`_drain_replay`。
- **M4** 同步对话收集(`_collect_reply`)：改 CM 消费，补 `_queue_overflow` 显式收尾。
- **M5** 项目事件 SSE 路由：加 logger；Depends 只校验存在(404 留在流前)；`except FileNotFoundError` 兜底删除竞态。

## 附带行为变化（已标注）

- 会话 SSE：修正了回放/直播切分的边界竞态（早到的直播消息不再被误并入回放）。
- 项目事件 SSE：断线检测从每轮改为在 `_idle` 间隔上进行（ADR-0005 接受的近似）。

## Code review 修复（第二个 commit）

- **超时失效（回归）**：`_collect_reply` 的 120s 超时原本只在 `_idle` 上判，持续 <idle_timeout 的消息流下 `_idle` 永不触发 → 同步请求无界挂起。改为每轮循环顶部检查 deadline。
- **订阅取消泄漏**：`_subscribe` 在 `ready_event.wait()` 期间被取消（客户端在首次扫描期断开）会泄漏订阅者与 watch task，加同步清理兜底。
- **错误语义**：还原 404 的本地化消息，非法项目名 `ValueError` 归 400。

## 验证

- 全量 `pytest`：2919 passed（新增 5 个测试覆盖回放/边界/溢出/三退出路径注销/超时回归/取消清理）。
- `ruff check` + `ruff format` 全过；`basedpyright` 0 error。
- 唯一失败 `test_default_when_unresolvable` 已确认在 clean `main` 上同样失败（本地 DB 全局配了 `grok`），与本 PR 无关。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 更及时检测并中止已断连的客户端，减少无效流式推送。

* **Improvements**
  * 优化实时流式交付：引入空闲检测与心跳，提升流稳定性和资源释放。
  * 溢出情况更早返回错误，用户能更快收到失败反馈。
  * 项目事件流在启动前做路径校验，错误映射为更明确的 HTTP 状态码（400/404）。

* **Refactor**
  * 订阅机制改为自清理的流式上下文，简化订阅生命周期管理。

* **Tests**
  * 增补并调整流式与断线相关单元测试，覆盖空闲、溢出与完成场景。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->