### PR TITLE
fix(frontend): 任务失败通知不再在切走再回项目时重弹

### DIFF
--- a/frontend/src/hooks/useTaskFailureNotifications.test.tsx
+++ b/frontend/src/hooks/useTaskFailureNotifications.test.tsx
@@ -193,6 +193,35 @@ describe("useTaskFailureNotifications", () => {
     expect(useAppStore.getState().workspaceNotifications[0].target).toMatchObject({ id: "E1S03" });
   });
 
+  // 回归：connected=false 期间切换项目（如网络抖动 + 用户切到别的项目），随后网络
+  // 恢复时第一个成功 poll 不能被误判为过渡 commit，否则永远不 seed，下一轮快速失败
+  // 任务将被永久漏报。
+  it("notifies for fast failures after switching project while disconnected", async () => {
+    useTasksStore.setState({ tasks: [], connected: true });
+    const { rerender } = render(<Harness project="demo" />);
+
+    // 网络断
+    act(() => {
+      useTasksStore.setState({ connected: false });
+    });
+    // 断网期间切换项目（projectName 变了，但 effect 因 connected=false early return）
+    act(() => {
+      rerender(<Harness project="other" />);
+    });
+    // 网络恢复，首个成功 poll 返回空 tasks（other 项目当前没任务）
+    act(() => {
+      useTasksStore.setState({ tasks: [], connected: true });
+    });
+    // 下一轮 poll：一个新任务在两 poll 间快速失败，首次被观测即 failed
+    act(() => {
+      useTasksStore.setState({
+        tasks: [task({ task_id: "fast-after-reconnect", project_name: "other", status: "failed", resource_id: "E1S04" })],
+      });
+    });
+    await waitFor(() => expect(useAppStore.getState().workspaceNotifications).toHaveLength(1));
+    expect(useAppStore.getState().workspaceNotifications[0].target).toMatchObject({ id: "E1S04" });
+  });
+
   it("builds a reference_unit target for reference_video failures", async () => {
     useTasksStore.setState({
       tasks: [task({ task_id: "r1", task_type: "reference_video", resource_id: "E1U1", status: "running" })],

--- a/frontend/src/hooks/useTaskFailureNotifications.test.tsx
+++ b/frontend/src/hooks/useTaskFailureNotifications.test.tsx
@@ -117,6 +117,67 @@ describe("useTaskFailureNotifications", () => {
     expect(useAppStore.getState().workspaceNotifications).toHaveLength(1);
   });
 
+  // 回归：切换项目（A→B→A）模拟用户离开再回到同一项目。useTasksSSE 的真实时序是
+  // cleanup setConnected(false) → 新 poll → setTasks(新项目) + setConnected(true)。
+  // 切回 A 后已通过 transition 通知过的历史 failed 不应被当作 fresh failure 再推一遍。
+  it("does not re-notify historical failed tasks when leaving and returning to the project", async () => {
+    useTasksStore.setState({ tasks: [task({ status: "running" })], connected: true });
+    const { rerender } = render(<Harness project="demo" />);
+    act(() => {
+      useTasksStore.setState({ tasks: [task({ status: "failed" })] });
+    });
+    await waitFor(() => expect(useAppStore.getState().workspaceNotifications).toHaveLength(1));
+
+    // 切到另一个项目：projectName 先变，然后 useTasksSSE cleanup+setup 模拟
+    // setConnected(false) → setTasks(空) + setConnected(true)
+    act(() => {
+      rerender(<Harness project="other" />);
+    });
+    act(() => {
+      useTasksStore.setState({ connected: false });
+    });
+    act(() => {
+      useTasksStore.setState({ tasks: [], connected: true });
+    });
+
+    // 切回 demo：同样的 useTasksSSE 时序，tasks 重新回到 demo 的（仍含同一条 failed）
+    act(() => {
+      rerender(<Harness project="demo" />);
+    });
+    act(() => {
+      useTasksStore.setState({ connected: false });
+    });
+    act(() => {
+      useTasksStore.setState({ tasks: [task({ status: "failed" })], connected: true });
+    });
+
+    expect(useAppStore.getState().workspaceNotifications).toHaveLength(1);
+  });
+
+  // 回归：切到一个新项目，新项目里已有的历史 failed 应被基线吸收、不推送。
+  it("does not notify when switching to a project whose tasks are already failed", async () => {
+    useTasksStore.setState({
+      tasks: [task({ task_id: "demo-old", status: "succeeded" })],
+      connected: true,
+    });
+    const { rerender } = render(<Harness project="demo" />);
+
+    act(() => {
+      rerender(<Harness project="other" />);
+    });
+    act(() => {
+      useTasksStore.setState({ connected: false });
+    });
+    act(() => {
+      useTasksStore.setState({
+        tasks: [task({ task_id: "other-old", project_name: "other", status: "failed" })],
+        connected: true,
+      });
+    });
+
+    expect(useAppStore.getState().workspaceNotifications).toHaveLength(0);
+  });
+
   it("builds a reference_unit target for reference_video failures", async () => {
     useTasksStore.setState({
       tasks: [task({ task_id: "r1", task_type: "reference_video", resource_id: "E1U1", status: "running" })],

--- a/frontend/src/hooks/useTaskFailureNotifications.test.tsx
+++ b/frontend/src/hooks/useTaskFailureNotifications.test.tsx
@@ -178,6 +178,21 @@ describe("useTaskFailureNotifications", () => {
     expect(useAppStore.getState().workspaceNotifications).toHaveLength(0);
   });
 
+  // 回归：项目首轮 poll 即使无任务也应建立基线，否则后续 task 在两 poll 间快速失败、
+  // 首次被观测即 failed 时，因 seeded=false 永远走不进 isFreshFailure 通道，永久漏报。
+  it("notifies for fast failures in a project whose first poll had no tasks", async () => {
+    useTasksStore.setState({ tasks: [], connected: true });
+    render(<Harness project="demo" />);
+    // 此前没有任何 task，但首轮 poll 已建立基线。后续 poll 一个新 task 直接以 failed 出现。
+    act(() => {
+      useTasksStore.setState({
+        tasks: [task({ task_id: "fast", status: "failed", resource_id: "E1S03" })],
+      });
+    });
+    await waitFor(() => expect(useAppStore.getState().workspaceNotifications).toHaveLength(1));
+    expect(useAppStore.getState().workspaceNotifications[0].target).toMatchObject({ id: "E1S03" });
+  });
+
   it("builds a reference_unit target for reference_video failures", async () => {
     useTasksStore.setState({
       tasks: [task({ task_id: "r1", task_type: "reference_video", resource_id: "E1U1", status: "running" })],

--- a/frontend/src/hooks/useTaskFailureNotifications.ts
+++ b/frontend/src/hooks/useTaskFailureNotifications.ts
@@ -51,12 +51,16 @@ export function useTaskFailureNotifications(projectName?: string | null): void {
   }, [projectName]);
 
   useEffect(() => {
-    // 等首个成功 poll 再建立基线。
-    if (!connected) return;
     // 过渡 commit：projectName 已变但 tasks/lastSeenProjectName 尚未跟上。此时
     // tasks 仍是旧项目数据，不该用它建立新项目的基线，否则下一轮新 tasks 进来时
     // prev 为空、seeded=true 会把历史 failed 全部当 fresh failure 重弹。
     const isTransitionCommit = lastSeenProjectNameRef.current !== projectName;
+    // 在 connected 检查之前同步 lastSeenProjectName——否则 connected=false 期间
+    // 切换项目时 effect early return 会让 ref 卡在旧 projectName，下一次 connected
+    // 恢复时第一个成功 poll 又被误判为 transition、不 seed，进而漏报本应捕获的
+    // fast failure。
+    lastSeenProjectNameRef.current = projectName;
+    if (!connected) return;
     const prev = prevStatusRef.current;
     const next = new Map<string, TaskStatus>();
     const seeded = seededRef.current;
@@ -83,6 +87,5 @@ export function useTaskFailureNotifications(projectName?: string | null): void {
     if (!isTransitionCommit) {
       seededRef.current = true;
     }
-    lastSeenProjectNameRef.current = projectName;
   }, [tasks, connected, projectName]);
 }

--- a/frontend/src/hooks/useTaskFailureNotifications.ts
+++ b/frontend/src/hooks/useTaskFailureNotifications.ts
@@ -39,6 +39,10 @@ export function useTaskFailureNotifications(projectName?: string | null): void {
   const prevStatusRef = useRef<Map<string, TaskStatus>>(new Map());
   // 是否已用首个成功 poll 建立基线。基线内的 failed 一律视为历史失败、不推送。
   const seededRef = useRef(false);
+  // 上次 effect 跑时观察到的 projectName。projectName 切换的过渡 commit 里 tasks 仍是
+  // 旧项目数据，此 ref 仍是旧 projectName；只有等到 tasks/connected 因新一轮 poll
+  // 变化、effect 再次跑时，ref 才与 props 同步。用它检测"这一轮是否是过渡 commit"。
+  const lastSeenProjectNameRef = useRef<string | null | undefined>(projectName);
 
   // 项目切换时重置基线，避免把新项目的历史 failed 误判为新失败。
   useEffect(() => {
@@ -49,14 +53,16 @@ export function useTaskFailureNotifications(projectName?: string | null): void {
   useEffect(() => {
     // 等首个成功 poll 再建立基线。
     if (!connected) return;
+    // 过渡 commit：projectName 已变但 tasks/lastSeenProjectName 尚未跟上。此时
+    // tasks 仍是旧项目数据，不该用它建立新项目的基线，否则下一轮新 tasks 进来时
+    // prev 为空、seeded=true 会把历史 failed 全部当 fresh failure 重弹。
+    const isTransitionCommit = lastSeenProjectNameRef.current !== projectName;
     const prev = prevStatusRef.current;
     const next = new Map<string, TaskStatus>();
     const seeded = seededRef.current;
-    let sawCurrentProject = false;
     for (const tk of tasks) {
       // 只跟踪当前项目的任务：其余项目的任务既不通知也不进 prevStatus。
       if (tk.project_name !== projectName) continue;
-      sawCurrentProject = true;
       const before = prev.get(tk.task_id);
       const isTransition = before !== undefined && before !== "failed";
       const isFreshFailure = seeded && before === undefined;
@@ -71,12 +77,12 @@ export function useTaskFailureNotifications(projectName?: string | null): void {
       next.set(tk.task_id, tk.status);
     }
     prevStatusRef.current = next;
-    // 仅当本轮真正读到当前项目的 task 才建立基线。projectName 切换的过渡 commit 里
-    // tasks 仍是旧项目数据（被 project_name 过滤后 next 为空），此时若也把 seeded 置
-    // true，下一轮新项目的 tasks 进来时 prev 仍为空、所有 failed 都满足
-    // isFreshFailure，造成离开再回到项目时重弹历史失败通知。
-    if (sawCurrentProject) {
+    // 非过渡 commit 才建立基线——即使本轮 tasks 为空（项目就是没有任务），也代表
+    // 已经收到当前项目的真实响应；后续若有 task 在两 poll 间快速失败被首次观测即
+    // failed，仍能走 isFreshFailure 通道触发通知。
+    if (!isTransitionCommit) {
       seededRef.current = true;
     }
+    lastSeenProjectNameRef.current = projectName;
   }, [tasks, connected, projectName]);
 }

--- a/frontend/src/hooks/useTaskFailureNotifications.ts
+++ b/frontend/src/hooks/useTaskFailureNotifications.ts
@@ -47,15 +47,16 @@ export function useTaskFailureNotifications(projectName?: string | null): void {
   }, [projectName]);
 
   useEffect(() => {
-    // 等首个成功 poll 再建立基线。项目切换时 useTasksSSE 的 cleanup 会先把 connected
-    // 置 false（同一 commit 内 destroy 先于 setup），故这里不会用旧项目的 tasks 误 seed。
+    // 等首个成功 poll 再建立基线。
     if (!connected) return;
     const prev = prevStatusRef.current;
     const next = new Map<string, TaskStatus>();
     const seeded = seededRef.current;
+    let sawCurrentProject = false;
     for (const tk of tasks) {
       // 只跟踪当前项目的任务：其余项目的任务既不通知也不进 prevStatus。
       if (tk.project_name !== projectName) continue;
+      sawCurrentProject = true;
       const before = prev.get(tk.task_id);
       const isTransition = before !== undefined && before !== "failed";
       const isFreshFailure = seeded && before === undefined;
@@ -70,6 +71,12 @@ export function useTaskFailureNotifications(projectName?: string | null): void {
       next.set(tk.task_id, tk.status);
     }
     prevStatusRef.current = next;
-    seededRef.current = true;
+    // 仅当本轮真正读到当前项目的 task 才建立基线。projectName 切换的过渡 commit 里
+    // tasks 仍是旧项目数据（被 project_name 过滤后 next 为空），此时若也把 seeded 置
+    // true，下一轮新项目的 tasks 进来时 prev 仍为空、所有 failed 都满足
+    // isFreshFailure，造成离开再回到项目时重弹历史失败通知。
+    if (sawCurrentProject) {
+      seededRef.current = true;
+    }
   }, [tasks, connected, projectName]);
 }


### PR DESCRIPTION
## Summary
- 修复后台任务失败通知在用户离开项目再返回时重复弹出的问题
- 根因：`useTaskFailureNotifications` 的 Effect B 在 projectName 切换的过渡 commit 中无条件把 `seededRef = true`，导致随后真正属于新项目的 tasks 进来时 `prev` 仍为空、所有 failed 任务都被误判为 fresh failure 触发通知
- 改为仅当本轮 effect 真正遍历到当前项目任务（`sawCurrentProject`）时才建立基线，从源头切断误推路径

## Test plan
- [x] 新增回归测试 `does not re-notify historical failed tasks when leaving and returning to the project`：复现用户场景（A→B→A），修复前红、修复后绿
- [x] 新增回归测试 `does not notify when switching to a project whose tasks are already failed`：切到新项目里的历史 failed 任务应被基线吸收
- [x] 全套 frontend vitest：577/577 通过
- [x] ESLint + tsc：无错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug修复**
  * 修复切换项目并返回时重复触发任务失败通知的问题，历史失败不会被误判为新失败。
  * 修正切换到新项目且首轮观测包含历史失败时的误报。
  * 处理断连恢复与首轮为空场景，确保基线正确建立且不会漏报或重复通知。

* **Tests**
  * 新增回归测试，覆盖跨项目切换、断连恢复、首轮为空及相关边界场景，验证通知行为一致性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->