### PR TITLE
fix(logging): 日志目录搬出 projects 根 + 加固迁移与 agent 沙箱

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,10 +85,13 @@ AUTH_TOKEN_SECRET=
 
 # Log file directory (default: $PROJECT_ROOT/logs)
 # Relative paths resolve against PROJECT_ROOT. Logs intentionally live OUTSIDE
-# the projects root: that root is enumerated as a list of video projects, so any
-# stray sibling directory would surface as a fake project in the UI.
+# the projects root (projects/ — the directory enumerated as the list of video
+# projects in the UI), so any stray sibling directory would surface as a fake
+# project. Note: PROJECT_ROOT is the repo root, projects root = $PROJECT_ROOT/projects.
 # 日志文件目录（默认 $PROJECT_ROOT/logs），相对路径基于 PROJECT_ROOT。
-# 刻意不放在项目根下：项目根会被枚举为视频项目列表，旁系目录会被错认为项目。
+# 刻意不放在 projects 目录（视频项目数据根目录）下：该目录会被枚举为视频项目
+# 列表，旁系目录会被错认为项目。注意：PROJECT_ROOT 指仓库根，projects 数据
+# 根目录则是 $PROJECT_ROOT/projects。
 # ARCREEL_LOG_DIR=
 
 # Disable file logging (default: false). When set to 1/true/yes, logs go only to stdout.

--- a/.env.example
+++ b/.env.example
@@ -83,9 +83,12 @@ AUTH_TOKEN_SECRET=
 # 日志级别（默认: INFO，可选: DEBUG, WARNING, ERROR）
 # LOG_LEVEL=INFO
 
-# Log file directory (default: $ARCREEL_DATA_DIR/logs)
-# Relative paths resolve against PROJECT_ROOT.
-# 日志文件目录（默认 $ARCREEL_DATA_DIR/logs），相对路径基于 PROJECT_ROOT。
+# Log file directory (default: $PROJECT_ROOT/logs)
+# Relative paths resolve against PROJECT_ROOT. Logs intentionally live OUTSIDE
+# the projects root: that root is enumerated as a list of video projects, so any
+# stray sibling directory would surface as a fake project in the UI.
+# 日志文件目录（默认 $PROJECT_ROOT/logs），相对路径基于 PROJECT_ROOT。
+# 刻意不放在项目根下：项目根会被枚举为视频项目列表，旁系目录会被错认为项目。
 # ARCREEL_LOG_DIR=
 
 # Disable file logging (default: false). When set to 1/true/yes, logs go only to stdout.

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ projects/*
 vertex_keys/*
 !vertex_keys/.gitkeep
 
+# Runtime log directory (PROJECT_ROOT/logs from lib/logging_config.py)
+logs/
+
 # Keep project structure but ignore generated content
 !projects/.gitkeep
 !projects/.agent_data/

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     volumes:
       - ./.env:/app/.env
       - ./projects:/app/projects
+      - ./logs:/app/logs
       - ./vertex_keys:/app/vertex_keys
       - ./claude_data:/root/.claude
     restart: unless-stopped

--- a/deploy/production/docker-compose.yml
+++ b/deploy/production/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     volumes:
       - ./.env:/app/.env
       - ./projects:/app/projects
+      - ./logs:/app/logs
       - ./vertex_keys:/app/vertex_keys
       - ./claude_data:/root/.claude
     depends_on:

--- a/docs/superpowers/specs/2026-05-18-log-persistence-design.md
+++ b/docs/superpowers/specs/2026-05-18-log-persistence-design.md
@@ -191,7 +191,7 @@ async function downloadDiagnostics() {
 ## 平台兼容
 
 - **Windows**：`TimedRotatingFileHandler` 单进程写无锁问题（uvicorn 默认 worker=1）；路径用 pathlib，IO 显式 `encoding="utf-8"`；zip 用标准 `ZipFile`（自带 UTF-8 文件名支持）
-- **Sandbox**：日志写在 `app_data_dir()` 下，已是 bwrap 白名单的写路径，无需额外声明
+- **Sandbox**：日志写在 `PROJECT_ROOT/logs` 下，作为 server 进程写路径需在 bwrap 白名单中（默认 PROJECT_ROOT 整树可写已涵盖）；同时该路径在 `SessionManager._compute_sensitive_paths` 里登记为 sensitive prefix，agent 工具无法 Read/Grep 全局日志
 - **Docker / journald**：stdout 不变，外部收集器零感知
 
 ## 测试

--- a/docs/superpowers/specs/2026-05-18-log-persistence-design.md
+++ b/docs/superpowers/specs/2026-05-18-log-persistence-design.md
@@ -37,7 +37,7 @@
 应用代码 logger.info(...)
    │
    ├─ StreamHandler → stdout（既有，不变）
-   └─ TimedRotatingFileHandler → app_data_dir()/logs/arcreel.log
+   └─ TimedRotatingFileHandler → PROJECT_ROOT/logs/arcreel.log
             │
             └─ 每日 midnight 切到 arcreel.log.YYYY-MM-DD，最多 7 份
 
@@ -75,7 +75,9 @@
 - 标记 `_HANDLER_ATTR = True` 保证幂等
 - 日志目录由新增函数 `resolve_log_dir()` 决定：
   1. `ARCREEL_LOG_DIR` env（绝对路径或相对 `PROJECT_ROOT`）
-  2. 默认 `app_data_dir() / "logs"`
+  2. 默认 `PROJECT_ROOT / "logs"`
+- 不放在 `app_data_dir()` 下：那一层同时是 `projects_root`，目录被枚举为视频项目列表，无前缀的兄弟目录会被错认为项目（容器部署用 `./logs:/app/logs` 单独挂出来）
+- 升级路径：`lib.logging_config.migrate_legacy_log_dir()` 在 `setup_logging()` 之前调用，把旧 `app_data_dir()/logs` 平移到新位置；新旧并存时告警保留
 - 首次启动 `mkdir(parents=True, exist_ok=True)`
 - 逃生口：`ARCREEL_LOG_FILE_DISABLED` 取值 `1` / `true` / `yes`（大小写不敏感）时跳过 file handler 注册
 - **容错**：mkdir 或 FileHandler 构造异常时 catch + `logging.getLogger(__name__).warning("file logging disabled: %s", exc)`，stdout 继续工作 — 日志辅助逻辑不阻塞主流程
@@ -162,9 +164,12 @@ async function downloadDiagnostics() {
 在现有 `# Logging` 区块下追加注释化变量：
 
 ```bash
-# Log file directory (default: $ARCREEL_DATA_DIR/logs)
-# Relative paths resolve against PROJECT_ROOT.
-# 日志文件目录（默认 $ARCREEL_DATA_DIR/logs），相对路径基于 PROJECT_ROOT。
+# Log file directory (default: $PROJECT_ROOT/logs)
+# Relative paths resolve against PROJECT_ROOT. Logs intentionally live OUTSIDE
+# the projects root: that root is enumerated as a list of video projects, so any
+# stray sibling directory would surface as a fake project in the UI.
+# 日志文件目录（默认 $PROJECT_ROOT/logs），相对路径基于 PROJECT_ROOT。
+# 刻意不放在项目根下：项目根会被枚举为视频项目列表，旁系目录会被错认为项目。
 # ARCREEL_LOG_DIR=
 
 # Disable file logging (default: false). When set to 1/true/yes, logs go only to stdout.

--- a/lib/logging_config.py
+++ b/lib/logging_config.py
@@ -20,9 +20,13 @@ def _file_logging_disabled() -> bool:
 
 
 def resolve_log_dir() -> Path:
-    """日志目录解析：ARCREEL_LOG_DIR > app_data_dir()/logs。
+    """日志目录解析：ARCREEL_LOG_DIR > PROJECT_ROOT/logs。
 
-    相对路径基于 PROJECT_ROOT，与 app_data_dir 的策略保持一致。
+    相对路径基于 PROJECT_ROOT。
+
+    日志目录刻意不放在 app_data_dir() 里：app_data_dir() 同时承担 projects_root
+    的身份，project 枚举走的是 `.`/`_` 前缀负向过滤，任何无前缀的兄弟目录都会被
+    当作项目暴露给前端。logs 走独立的 PROJECT_ROOT/logs，从源头消除这条歧义。
     """
     raw = os.environ.get("ARCREEL_LOG_DIR", "").strip()
     if raw:
@@ -30,7 +34,50 @@ def resolve_log_dir() -> Path:
         if not path.is_absolute():
             path = PROJECT_ROOT / path
         return path
+    return PROJECT_ROOT / "logs"
+
+
+def legacy_log_dir() -> Path:
+    """旧默认路径（app_data_dir()/logs），用于一次性启动迁移。"""
     return app_data_dir() / "logs"
+
+
+def migrate_legacy_log_dir() -> None:
+    """将旧默认位置的日志迁到新位置；只在 ARCREEL_LOG_DIR 未显式覆盖时进行。
+
+    策略：
+    - 用户显式设了 ARCREEL_LOG_DIR → 不动（用户已自主决定路径）
+    - 新旧路径解析到同一处 → no-op（例如 ARCREEL_DATA_DIR == PROJECT_ROOT）
+    - 旧目录不存在 → no-op
+    - 新目录不存在 → 整体 rename 旧→新
+    - 新旧都存在 → 警告，不动（避免静默覆盖；让用户自己处置）
+    - 任意异常 → warning，不抛（迁移辅助逻辑不阻塞启动）
+    """
+    if os.environ.get("ARCREEL_LOG_DIR", "").strip():
+        return
+
+    logger = logging.getLogger(__name__)
+    try:
+        old_dir = legacy_log_dir()
+        new_dir = resolve_log_dir()
+
+        if old_dir.resolve() == new_dir.resolve():
+            return
+        if not old_dir.exists():
+            return
+        if new_dir.exists():
+            logger.warning(
+                "legacy log dir %s and new log dir %s both exist; leaving both in place — please move/delete manually",
+                old_dir,
+                new_dir,
+            )
+            return
+
+        new_dir.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(old_dir, new_dir)
+        logger.info("migrated legacy log dir %s → %s", old_dir, new_dir)
+    except Exception as exc:
+        logger.warning("legacy log dir migration skipped: %s", exc)
 
 
 def setup_logging(level: str | None = None) -> None:

--- a/lib/logging_config.py
+++ b/lib/logging_config.py
@@ -85,13 +85,13 @@ def migrate_legacy_log_dir() -> None:
             # 的内容到 new_dir，最后再删已清空的 old_dir。每项独立 shutil.move
             # 在跨设备时仍会 fallback 到 copy+unlink。
             for entry in old_dir.iterdir():
-                shutil.move(str(entry), str(new_dir / entry.name))
+                shutil.move(entry, new_dir / entry.name)
             old_dir.rmdir()
         else:
             new_dir.parent.mkdir(parents=True, exist_ok=True)
             # shutil.move 在 src/dst 同设备时走 os.rename，跨设备时降级到 copytree + rmtree。
             # 这正是 docker bind-mount 升级路径下 os.replace 报 EXDEV 的解药。
-            shutil.move(str(old_dir), str(new_dir))
+            shutil.move(old_dir, new_dir)
         logger.info("migrated legacy log dir %s -> %s", old_dir, new_dir)
     except OSError as exc:
         logger.error(

--- a/lib/logging_config.py
+++ b/lib/logging_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
@@ -49,18 +50,19 @@ def migrate_legacy_log_dir() -> None:
     - 用户显式设了 ARCREEL_LOG_DIR → 不动（用户已自主决定路径）
     - 新旧路径解析到同一处 → no-op（例如 ARCREEL_DATA_DIR == PROJECT_ROOT）
     - 旧目录不存在 → no-op
-    - 新目录不存在 → 整体 rename 旧→新
+    - 新目录不存在 → 用 shutil.move 平移旧→新（跨设备自动 fallback 到
+      copy+unlink，专门覆盖 docker bind-mount 等典型升级路径）
     - 新旧都存在 → 警告，不动（避免静默覆盖；让用户自己处置）
-    - 任意异常 → warning，不抛（迁移辅助逻辑不阻塞启动）
+    - OSError 升级为 ERROR：迁移失败常意味着 logs 仍卡在旧路径下，会以
+      伪项目形式出现在 UI，operator 必须看到这条
     """
     if os.environ.get("ARCREEL_LOG_DIR", "").strip():
         return
 
     logger = logging.getLogger(__name__)
+    old_dir = legacy_log_dir()
+    new_dir = resolve_log_dir()
     try:
-        old_dir = legacy_log_dir()
-        new_dir = resolve_log_dir()
-
         if old_dir.resolve() == new_dir.resolve():
             return
         if not old_dir.exists():
@@ -74,18 +76,30 @@ def migrate_legacy_log_dir() -> None:
             return
 
         new_dir.parent.mkdir(parents=True, exist_ok=True)
-        os.replace(old_dir, new_dir)
-        logger.info("migrated legacy log dir %s → %s", old_dir, new_dir)
-    except Exception as exc:
-        logger.warning("legacy log dir migration skipped: %s", exc)
+        # shutil.move 在 src/dst 同设备时走 os.rename，跨设备时降级到 copytree + rmtree。
+        # 这正是 docker bind-mount 升级路径下 os.replace 报 EXDEV 的解药。
+        shutil.move(str(old_dir), str(new_dir))
+        logger.info("migrated legacy log dir %s -> %s", old_dir, new_dir)
+    except OSError as exc:
+        logger.error(
+            "legacy log dir migration FAILED (logs may still appear at %s as a pseudo-project; "
+            "please move %s -> %s manually): %s",
+            old_dir,
+            old_dir,
+            new_dir,
+            exc,
+        )
 
 
-def setup_logging(level: str | None = None) -> None:
+def setup_logging(level: str | None = None, *, file: bool = True) -> None:
     """配置根 logger。
 
     Args:
         level: 日志级别字符串（DEBUG/INFO/WARNING/ERROR）。
                如未提供，从环境变量 LOG_LEVEL 读取，默认 INFO。
+        file: 是否挂 TimedRotatingFileHandler。模块导入期传 False 推迟到
+              lifespan 之后挂——避免 import 期 mkdir 新 logs/ 污染开发树，
+              也让 migrate_legacy_log_dir() 能在新目录还不存在时 rename。
     """
     if level is None:
         level = os.environ.get("LOG_LEVEL", "INFO")
@@ -107,24 +121,8 @@ def setup_logging(level: str | None = None) -> None:
         setattr(handler, _HANDLER_ATTR, True)
         root.addHandler(handler)
 
-    # 文件 handler：默认开启，按天切，保留 7 份。失败不阻塞 stdout。
-    file_handler_exists = any(getattr(h, _FILE_HANDLER_ATTR, False) for h in root.handlers)
-    if not _file_logging_disabled() and not file_handler_exists:
-        try:
-            log_dir = resolve_log_dir()
-            log_dir.mkdir(parents=True, exist_ok=True)
-            file_handler = TimedRotatingFileHandler(
-                filename=str(log_dir / "arcreel.log"),
-                when="midnight",
-                backupCount=7,
-                encoding="utf-8",
-                utc=False,
-            )
-            file_handler.setFormatter(formatter)
-            setattr(file_handler, _FILE_HANDLER_ATTR, True)
-            root.addHandler(file_handler)
-        except Exception as exc:
-            logging.getLogger(__name__).warning("file logging disabled: %s", exc)
+    if file:
+        attach_file_handler(formatter)
 
     # 统一 uvicorn 的日志格式，避免两种格式并存
     for name in ("uvicorn", "uvicorn.error"):
@@ -139,3 +137,40 @@ def setup_logging(level: str | None = None) -> None:
 
     # 抑制 aiosqlite 的 DEBUG 噪音（每次 SQL 操作都会输出两行日志）
     logging.getLogger("aiosqlite").setLevel(max(numeric_level, logging.INFO))
+
+
+def attach_file_handler(formatter: logging.Formatter | None = None) -> None:
+    """为 root logger 挂 TimedRotatingFileHandler（默认开启，按天切，保留 7 份）。
+
+    幂等：已挂则直接返回。被 setup_logging 调用，也可在 lifespan 内
+    单独触发——后者用于先跑 migrate_legacy_log_dir() 平移旧目录，再挂
+    file handler 以避免新目录被提前创建堵掉 rename。
+    """
+    if _file_logging_disabled():
+        return
+
+    root = logging.getLogger()
+    if any(getattr(h, _FILE_HANDLER_ATTR, False) for h in root.handlers):
+        return
+
+    if formatter is None:
+        formatter = logging.Formatter(
+            fmt="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+
+    try:
+        log_dir = resolve_log_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        file_handler = TimedRotatingFileHandler(
+            filename=str(log_dir / "arcreel.log"),
+            when="midnight",
+            backupCount=7,
+            encoding="utf-8",
+            utc=False,
+        )
+        file_handler.setFormatter(formatter)
+        setattr(file_handler, _FILE_HANDLER_ATTR, True)
+        root.addHandler(file_handler)
+    except Exception as exc:
+        logging.getLogger(__name__).warning("file logging disabled: %s", exc)

--- a/lib/logging_config.py
+++ b/lib/logging_config.py
@@ -50,9 +50,12 @@ def migrate_legacy_log_dir() -> None:
     - 用户显式设了 ARCREEL_LOG_DIR → 不动（用户已自主决定路径）
     - 新旧路径解析到同一处 → no-op（例如 ARCREEL_DATA_DIR == PROJECT_ROOT）
     - 旧目录不存在 → no-op
-    - 新目录不存在 → 用 shutil.move 平移旧→新（跨设备自动 fallback 到
-      copy+unlink，专门覆盖 docker bind-mount 等典型升级路径）
-    - 新旧都存在 → 警告，不动（避免静默覆盖；让用户自己处置）
+    - 新目录不存在，或存在但为空 → 用 shutil.move 平移旧→新（跨设备自动
+      fallback 到 copy+unlink，专门覆盖 docker bind-mount 等典型升级路径）。
+      "存在但为空" 分支专门照顾 docker-compose 的 ``./logs:/app/logs`` 挂载——
+      容器启动时宿主机 ``./logs`` 会被预创建为空目录，否则升级路径下旧 logs
+      会一直留在 projects/logs 下被当成伪项目枚举
+    - 新目录存在且非空 → 警告，不动（避免静默覆盖；让用户自己处置）
     - OSError 升级为 ERROR：迁移失败常意味着 logs 仍卡在旧路径下，会以
       伪项目形式出现在 UI，operator 必须看到这条
     """
@@ -68,12 +71,16 @@ def migrate_legacy_log_dir() -> None:
         if not old_dir.exists():
             return
         if new_dir.exists():
-            logger.warning(
-                "legacy log dir %s and new log dir %s both exist; leaving both in place — please move/delete manually",
-                old_dir,
-                new_dir,
-            )
-            return
+            if any(new_dir.iterdir()):
+                logger.warning(
+                    "legacy log dir %s and new log dir %s both have content; leaving both in place — please move/delete manually",
+                    old_dir,
+                    new_dir,
+                )
+                return
+            # 空目录（典型来自 docker bind-mount 预创建）—— rmdir 让 shutil.move
+            # 能把整个旧目录搬过来，而不是嵌套成 new_dir/old_dir_basename
+            new_dir.rmdir()
 
         new_dir.parent.mkdir(parents=True, exist_ok=True)
         # shutil.move 在 src/dst 同设备时走 os.rename，跨设备时降级到 copytree + rmtree。

--- a/lib/logging_config.py
+++ b/lib/logging_config.py
@@ -78,14 +78,20 @@ def migrate_legacy_log_dir() -> None:
                     new_dir,
                 )
                 return
-            # 空目录（典型来自 docker bind-mount 预创建）—— rmdir 让 shutil.move
-            # 能把整个旧目录搬过来，而不是嵌套成 new_dir/old_dir_basename
-            new_dir.rmdir()
-
-        new_dir.parent.mkdir(parents=True, exist_ok=True)
-        # shutil.move 在 src/dst 同设备时走 os.rename，跨设备时降级到 copytree + rmtree。
-        # 这正是 docker bind-mount 升级路径下 os.replace 报 EXDEV 的解药。
-        shutil.move(str(old_dir), str(new_dir))
+            # new_dir 存在但为空 —— 这是 docker bind-mount 的典型形态：
+            # ``./logs:/app/logs`` 让 docker 启动时把宿主机 ./logs 创建为空
+            # 目录，容器内 /app/logs 是挂载点。不能对挂载点本身 rmdir
+            # （会报 EBUSY/Device or resource busy），所以逐项搬运 old_dir
+            # 的内容到 new_dir，最后再删已清空的 old_dir。每项独立 shutil.move
+            # 在跨设备时仍会 fallback 到 copy+unlink。
+            for entry in old_dir.iterdir():
+                shutil.move(str(entry), str(new_dir / entry.name))
+            old_dir.rmdir()
+        else:
+            new_dir.parent.mkdir(parents=True, exist_ok=True)
+            # shutil.move 在 src/dst 同设备时走 os.rename，跨设备时降级到 copytree + rmtree。
+            # 这正是 docker bind-mount 升级路径下 os.replace 报 EXDEV 的解药。
+            shutil.move(str(old_dir), str(new_dir))
         logger.info("migrated legacy log dir %s -> %s", old_dir, new_dir)
     except OSError as exc:
         logger.error(

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -468,7 +468,10 @@ class SessionManager:
             data / ".system_config.json.bak",
             profile / ".claude" / "settings.json",
         )
-        prefixes: tuple[Path, ...] = (data.parent / "vertex_keys",)
+        # ``repo / "logs"`` —— 服务器日志含 HTTP 请求路径、provider 探测、异常栈，
+        # 默认 read 规则会把 PROJECT_ROOT 当成参考资料根（lib/docs/...）放行，
+        # 不显式 deny 会让任意项目 session 里的 agent 通过 Read/Grep 读到全局日志。
+        prefixes: tuple[Path, ...] = (data.parent / "vertex_keys", repo / "logs")
         # ``.arcreel.db-wal`` / ``.arcreel.db-shm`` 与主 db 同目录
         globs: tuple[tuple[Path, str], ...] = (
             (repo, ".env.*"),

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -26,6 +26,7 @@ from lib.agent_session_store.store import DbSessionStore
 from lib.db.base import DEFAULT_USER_ID
 from lib.db.engine import async_session_factory as default_async_session_factory
 from lib.i18n import LOCALE_LANGUAGE_MAP
+from lib.logging_config import resolve_log_dir
 from server.agent_runtime.message_utils import extract_plain_user_content
 from server.agent_runtime.models import SessionMeta, SessionStatus
 from server.agent_runtime.sdk_tools import build_arcreel_mcp_server
@@ -468,10 +469,14 @@ class SessionManager:
             data / ".system_config.json.bak",
             profile / ".claude" / "settings.json",
         )
-        # ``repo / "logs"`` —— 服务器日志含 HTTP 请求路径、provider 探测、异常栈，
-        # 默认 read 规则会把 PROJECT_ROOT 当成参考资料根（lib/docs/...）放行，
-        # 不显式 deny 会让任意项目 session 里的 agent 通过 Read/Grep 读到全局日志。
-        prefixes: tuple[Path, ...] = (data.parent / "vertex_keys", repo / "logs")
+        # 日志目录 —— 服务器日志含 HTTP 请求路径、provider 探测、异常栈，默认
+        # read 规则会把 PROJECT_ROOT 当成参考资料根（lib/docs/...）放行，不显式
+        # deny 会让任意项目 session 里的 agent 通过 Read/Grep 读到全局日志。
+        # 用 resolve_log_dir() 拿真实路径，覆盖 ARCREEL_LOG_DIR 自定义场景；
+        # 无论 LOG_DIR 落在 repo 内还是外（如 /var/log/arcreel）都必须 deny——
+        # 把约束反过来用 is_relative_to(repo) 限制只会让 repo 外的 LOG_DIR 漏过。
+        log_dir = resolve_log_dir().resolve()
+        prefixes: tuple[Path, ...] = (data.parent / "vertex_keys", log_dir)
         # ``.arcreel.db-wal`` / ``.arcreel.db-shm`` 与主 db 同目录
         globs: tuple[tuple[Path, str], ...] = (
             (repo, ".env.*"),

--- a/server/app.py
+++ b/server/app.py
@@ -35,7 +35,7 @@ from lib.config.env_keys import PROVIDER_SECRET_KEYS
 from lib.db import async_session_factory, close_db, init_db
 from lib.generation_worker import GenerationWorker
 from lib.httpx_shared import shutdown_http_client, startup_http_client
-from lib.logging_config import migrate_legacy_log_dir, setup_logging
+from lib.logging_config import attach_file_handler, migrate_legacy_log_dir, setup_logging
 from lib.project_migrations import cleanup_stale_backups, run_project_migrations
 from lib.source_loader.migration import migrate_project_source_encoding
 from server.auth import ensure_auth_password
@@ -236,11 +236,12 @@ def detect_docker_environment() -> bool:
     return "docker" in content or "podman" in content
 
 
-# 初始化日志
-# 迁移必须先于 setup_logging：后者会创建新 logs/ 目录并打开 file handler，
-# 之后再迁移会撞到 "新旧都存在" 而放弃。
-migrate_legacy_log_dir()
-setup_logging()
+# 初始化日志：模块导入期只挂 stream handler。
+# file handler 推迟到 lifespan，前面要先跑 migrate_legacy_log_dir()
+# 把旧 app_data_dir()/logs 平移到 PROJECT_ROOT/logs，否则新目录在 import
+# 期被创建会堵掉 rename；同时也避免 pytest 收集阶段 import server.app 时
+# 对真实文件系统产生副作用。
+setup_logging(file=False)
 logger = logging.getLogger(__name__)
 
 
@@ -319,6 +320,12 @@ async def lifespan(app: FastAPI):
 
     app.state.in_docker = is_docker
     app.state.sandbox_enabled = sandbox_enabled
+
+    # 日志文件持久化：先一次性平移旧 app_data_dir()/logs，再挂 file handler。
+    # 顺序很重要——file handler 会 mkdir 新目录，提前挂会让 migrate 的 rename
+    # 撞到 "新旧都存在" 分支放弃迁移。
+    await asyncio.to_thread(migrate_legacy_log_dir)
+    attach_file_handler()
 
     ensure_auth_password()
 

--- a/server/app.py
+++ b/server/app.py
@@ -35,7 +35,7 @@ from lib.config.env_keys import PROVIDER_SECRET_KEYS
 from lib.db import async_session_factory, close_db, init_db
 from lib.generation_worker import GenerationWorker
 from lib.httpx_shared import shutdown_http_client, startup_http_client
-from lib.logging_config import setup_logging
+from lib.logging_config import migrate_legacy_log_dir, setup_logging
 from lib.project_migrations import cleanup_stale_backups, run_project_migrations
 from lib.source_loader.migration import migrate_project_source_encoding
 from server.auth import ensure_auth_password
@@ -237,6 +237,9 @@ def detect_docker_environment() -> bool:
 
 
 # 初始化日志
+# 迁移必须先于 setup_logging：后者会创建新 logs/ 目录并打开 file handler，
+# 之后再迁移会撞到 "新旧都存在" 而放弃。
+migrate_legacy_log_dir()
 setup_logging()
 logger = logging.getLogger(__name__)
 

--- a/tests/agent_runtime/test_session_manager_sandbox.py
+++ b/tests/agent_runtime/test_session_manager_sandbox.py
@@ -156,14 +156,16 @@ def test_build_sensitive_abs_paths_includes_existing_files(tmp_path: Path) -> No
     assert str(root.resolve() / "projects" / ".arcreel.db-shm") in paths
 
 
-def test_logs_dir_is_sensitive_prefix(tmp_path: Path) -> None:
+def test_logs_dir_is_sensitive_prefix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """PROJECT_ROOT/logs 必须落在 sensitive prefixes 里，agent 不能 Read/Grep 全局日志。
 
     背景：lib/logging_config.py 把日志目录默认改为 PROJECT_ROOT/logs 后，
-    _check_read_access 走到 line ~2264 的 'is_relative_to(_project_root_resolved)
-    -> 放行' 分支，会把全局服务器日志当成参考资料放给 agent。规则 0 的
-    sensitive-path 拒绝必须在前面截住，所以 logs/ 要进 _sensitive_prefixes。
+    _check_read_access 的 "仓库根内参考资料放行" 分支
+    （is_relative_to(_project_root_resolved)）会把全局服务器日志当成参考资料
+    放给 agent。规则 0 的 sensitive-path 拒绝必须在前面截住，所以 logs/ 要进
+    _sensitive_prefixes。
     """
+    from lib import logging_config
     from server.agent_runtime.session_manager import SessionManager
     from server.agent_runtime.session_store import SessionMetaStore
 
@@ -173,6 +175,11 @@ def test_logs_dir_is_sensitive_prefix(tmp_path: Path) -> None:
     logs_dir.mkdir()
     (logs_dir / "arcreel.log").write_text("payload\n", encoding="utf-8")
     (logs_dir / "arcreel.log.2026-05-20").write_text("rotated\n", encoding="utf-8")
+
+    # SessionManager 通过 lib.logging_config.resolve_log_dir() 解析 sensitive
+    # log 目录；钉到测试 root 才能让 deny 命中 tmp_path/repo/logs
+    monkeypatch.setattr(logging_config, "PROJECT_ROOT", root)
+    monkeypatch.delenv("ARCREEL_LOG_DIR", raising=False)
 
     sm = SessionManager(root, tmp_path / "data", SessionMetaStore())
 
@@ -185,6 +192,35 @@ def test_logs_dir_is_sensitive_prefix(tmp_path: Path) -> None:
     # _build_sensitive_abs_paths 也必须把 logs 目录交给 SDK denyRead 清单
     paths = sm._build_sensitive_abs_paths()
     assert str(logs_dir.resolve()) in paths
+
+
+def test_logs_dir_honors_arcreel_log_dir_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """用户用 ARCREEL_LOG_DIR 把日志搬到任意目录（含 repo 外）时，sandbox
+    sensitive prefixes 必须跟着指过去——硬编码 repo/logs 会让 agent 仍能
+    Read/Grep 真实 LOG_DIR 下的日志，PR 上 gemini 给的 security-high 反馈。
+    """
+    from server.agent_runtime.session_manager import SessionManager
+    from server.agent_runtime.session_store import SessionMetaStore
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # 把 LOG_DIR 设到 repo 之外，模拟用户自定义日志位置
+    external_logs = tmp_path / "external" / "arcreel_logs"
+    external_logs.mkdir(parents=True)
+    (external_logs / "arcreel.log").write_text("secret\n", encoding="utf-8")
+    monkeypatch.setenv("ARCREEL_LOG_DIR", str(external_logs))
+
+    sm = SessionManager(repo, tmp_path / "data", SessionMetaStore())
+
+    # repo 外的自定义 LOG_DIR 也要被 deny
+    assert sm._is_sensitive_path((external_logs / "arcreel.log").resolve())
+    assert sm._is_sensitive_path(external_logs.resolve())
+    # repo/logs 在此场景下不应被默认 deny（避免误覆盖）
+    assert not sm._is_sensitive_path((repo / "logs" / "anything.txt").resolve())
+
+    paths = sm._build_sensitive_abs_paths()
+    assert str(external_logs.resolve()) in paths
+    assert str((repo / "logs").resolve()) not in paths
 
 
 def test_build_sensitive_abs_paths_honors_env_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/agent_runtime/test_session_manager_sandbox.py
+++ b/tests/agent_runtime/test_session_manager_sandbox.py
@@ -156,6 +156,37 @@ def test_build_sensitive_abs_paths_includes_existing_files(tmp_path: Path) -> No
     assert str(root.resolve() / "projects" / ".arcreel.db-shm") in paths
 
 
+def test_logs_dir_is_sensitive_prefix(tmp_path: Path) -> None:
+    """PROJECT_ROOT/logs 必须落在 sensitive prefixes 里，agent 不能 Read/Grep 全局日志。
+
+    背景：lib/logging_config.py 把日志目录默认改为 PROJECT_ROOT/logs 后，
+    _check_read_access 走到 line ~2264 的 'is_relative_to(_project_root_resolved)
+    -> 放行' 分支，会把全局服务器日志当成参考资料放给 agent。规则 0 的
+    sensitive-path 拒绝必须在前面截住，所以 logs/ 要进 _sensitive_prefixes。
+    """
+    from server.agent_runtime.session_manager import SessionManager
+    from server.agent_runtime.session_store import SessionMetaStore
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    logs_dir = root / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "arcreel.log").write_text("payload\n", encoding="utf-8")
+    (logs_dir / "arcreel.log.2026-05-20").write_text("rotated\n", encoding="utf-8")
+
+    sm = SessionManager(root, tmp_path / "data", SessionMetaStore())
+
+    # 当前 + 历史 log 文件都被认定为敏感
+    assert sm._is_sensitive_path((logs_dir / "arcreel.log").resolve())
+    assert sm._is_sensitive_path((logs_dir / "arcreel.log.2026-05-20").resolve())
+    # 整目录本身也是敏感（Glob/listdir 拒）
+    assert sm._is_sensitive_path(logs_dir.resolve())
+
+    # _build_sensitive_abs_paths 也必须把 logs 目录交给 SDK denyRead 清单
+    paths = sm._build_sensitive_abs_paths()
+    assert str(logs_dir.resolve()) in paths
+
+
 def test_build_sensitive_abs_paths_honors_env_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """``ARCREEL_DATA_DIR`` / ``ARCREEL_PROFILE_DIR`` 把数据/profile 目录搬到
     项目外时，sandbox denyRead 必须跟着指到新位置——否则源码根下的硬编码

--- a/tests/test_logging_persistence.py
+++ b/tests/test_logging_persistence.py
@@ -144,7 +144,8 @@ def test_migrate_moves_legacy_dir_when_new_absent(isolated_data_dir: Path) -> No
     assert (new_dir / "arcreel.log.2026-05-20").exists()
 
 
-def test_migrate_skips_when_both_exist(isolated_data_dir: Path) -> None:
+def test_migrate_skips_when_both_have_content(isolated_data_dir: Path) -> None:
+    """新旧都有内容时不动，避免静默覆盖。"""
     old_dir = isolated_data_dir / "data" / "logs"
     new_dir = isolated_data_dir / "root" / "logs"
     old_dir.mkdir()
@@ -157,6 +158,27 @@ def test_migrate_skips_when_both_exist(isolated_data_dir: Path) -> None:
     # 两边都原样保留，不静默覆盖
     assert (old_dir / "arcreel.log").read_text(encoding="utf-8") == "old\n"
     assert (new_dir / "arcreel.log").read_text(encoding="utf-8") == "new\n"
+
+
+def test_migrate_proceeds_when_new_dir_empty(isolated_data_dir: Path) -> None:
+    """docker bind-mount 预创建场景：new_dir 是空目录时仍要搬旧目录过来。
+
+    docker-compose 的 ``./logs:/app/logs`` 会让 docker 启动时把宿主机 ``./logs``
+    创建为空目录。若 ``new_dir.exists()`` 直接放弃迁移，旧 logs 会一直留在
+    projects/logs 下被当作伪项目枚举——这是升级路径的核心回归用例。
+    """
+    old_dir = isolated_data_dir / "data" / "logs"
+    new_dir = isolated_data_dir / "root" / "logs"
+    old_dir.mkdir()
+    new_dir.mkdir()  # 模拟 docker 预创建的空 mount point
+    (old_dir / "arcreel.log").write_text("payload\n", encoding="utf-8")
+    (old_dir / "arcreel.log.2026-05-20").write_text("rotated\n", encoding="utf-8")
+
+    logging_config.migrate_legacy_log_dir()
+
+    assert not old_dir.exists(), "旧目录应已被搬走"
+    assert (new_dir / "arcreel.log").read_text(encoding="utf-8") == "payload\n"
+    assert (new_dir / "arcreel.log.2026-05-20").read_text(encoding="utf-8") == "rotated\n"
 
 
 def test_migrate_noop_when_legacy_absent(isolated_data_dir: Path) -> None:

--- a/tests/test_logging_persistence.py
+++ b/tests/test_logging_persistence.py
@@ -177,6 +177,43 @@ def test_migrate_proceeds_when_new_dir_empty(isolated_data_dir: Path) -> None:
     logging_config.migrate_legacy_log_dir()
 
     assert not old_dir.exists(), "旧目录应已被搬走"
+    # new_dir 本身（挂载点）不能被 rmdir，但内容已被填入
+    assert new_dir.exists(), "new_dir 必须保留（bind-mount 挂载点不能 rmdir）"
+    assert (new_dir / "arcreel.log").read_text(encoding="utf-8") == "payload\n"
+    assert (new_dir / "arcreel.log.2026-05-20").read_text(encoding="utf-8") == "rotated\n"
+
+
+def test_migrate_preserves_new_dir_when_it_is_mountpoint(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """new_dir 是 docker bind-mount 挂载点时，rmdir(new_dir) 会抛 EBUSY。
+    迁移必须不依赖 rmdir(new_dir) 成功——通过 mock 让任何对 new_dir 自身
+    的 rmdir 都抛 OSError(EBUSY)，确认搬运仍能完成。
+    """
+    import errno
+
+    old_dir = isolated_data_dir / "data" / "logs"
+    new_dir = isolated_data_dir / "root" / "logs"
+    old_dir.mkdir()
+    new_dir.mkdir()
+    (old_dir / "arcreel.log").write_text("payload\n", encoding="utf-8")
+    (old_dir / "arcreel.log.2026-05-20").write_text("rotated\n", encoding="utf-8")
+
+    real_rmdir = Path.rmdir
+
+    def fake_rmdir(self: Path) -> None:
+        # 任何对 new_dir 路径的 rmdir 都模拟成挂载点失败
+        if self.resolve() == new_dir.resolve():
+            raise OSError(errno.EBUSY, "Device or resource busy")
+        real_rmdir(self)
+
+    monkeypatch.setattr(Path, "rmdir", fake_rmdir)
+
+    logging_config.migrate_legacy_log_dir()
+
+    # 即使 new_dir.rmdir 全程会失败，迁移仍要完成
+    assert not old_dir.exists()
+    assert new_dir.exists()
     assert (new_dir / "arcreel.log").read_text(encoding="utf-8") == "payload\n"
     assert (new_dir / "arcreel.log.2026-05-20").read_text(encoding="utf-8") == "rotated\n"
 

--- a/tests/test_logging_persistence.py
+++ b/tests/test_logging_persistence.py
@@ -15,13 +15,37 @@ from lib import logging_config
 
 @pytest.fixture(autouse=True)
 def _reset_root_logger():
-    """每个用例前后清空 root logger handlers，避免污染。"""
+    """每个用例前后清空 root logger handlers，避免污染。
+
+    setup_logging() / attach_file_handler() 不止改 root.handlers——还动
+    root.level 以及 uvicorn*/aiosqlite 等命名 logger 的 handlers/disabled/
+    propagate。teardown 必须把这些都恢复，并 close() 临时挂的 file handler
+    以释放 fd（Windows 上 file locking 尤其敏感）。
+    """
     root = logging.getLogger()
-    saved = list(root.handlers)
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    named_loggers = {
+        name: logging.getLogger(name) for name in ("uvicorn", "uvicorn.error", "uvicorn.access", "aiosqlite")
+    }
+    saved_named = {
+        name: (list(logger.handlers), logger.level, logger.disabled, logger.propagate)
+        for name, logger in named_loggers.items()
+    }
     root.handlers.clear()
     yield
-    root.handlers.clear()
-    root.handlers.extend(saved)
+    # 关闭测试中临时挂的 handler 释放 fd
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+        handler.close()
+    root.setLevel(saved_level)
+    root.handlers[:] = saved_handlers
+    for name, logger in named_loggers.items():
+        handlers, level, disabled, propagate = saved_named[name]
+        logger.handlers[:] = handlers
+        logger.setLevel(level)
+        logger.disabled = disabled
+        logger.propagate = propagate
 
 
 @pytest.fixture
@@ -123,6 +147,18 @@ def test_resolve_log_dir_env_override(tmp_path: Path, monkeypatch: pytest.Monkey
     target = tmp_path / "custom-logs"
     monkeypatch.setenv("ARCREEL_LOG_DIR", str(target))
     assert logging_config.resolve_log_dir() == target
+
+
+def test_resolve_log_dir_relative_path_resolves_against_project_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """相对路径 ARCREEL_LOG_DIR 必须基于 PROJECT_ROOT 解析。"""
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    monkeypatch.setattr(logging_config, "PROJECT_ROOT", project_root)
+    monkeypatch.setenv("ARCREEL_LOG_DIR", "var/log/arcreel")
+
+    assert logging_config.resolve_log_dir() == project_root / "var" / "log" / "arcreel"
 
 
 def test_legacy_log_dir_points_to_app_data(isolated_data_dir: Path) -> None:

--- a/tests/test_logging_persistence.py
+++ b/tests/test_logging_persistence.py
@@ -192,3 +192,82 @@ def test_migrate_noop_when_paths_equal(tmp_path: Path, monkeypatch: pytest.Monke
         assert (logs / "arcreel.log").read_text(encoding="utf-8") == "hi\n"
     finally:
         app_data_dir_mod._reset_for_tests()
+
+
+def test_migrate_falls_back_to_copy_on_exdev(isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """跨 mount 场景（docker bind-mount）下 os.rename 抛 EXDEV，shutil.move 自动降级 copy+unlink。"""
+    import errno
+    import os
+
+    old_dir = isolated_data_dir / "data" / "logs"
+    old_dir.mkdir()
+    (old_dir / "arcreel.log").write_text("payload\n", encoding="utf-8")
+    (old_dir / "arcreel.log.2026-05-20").write_text("rotated\n", encoding="utf-8")
+
+    real_rename = os.rename
+
+    def fake_rename(src: str, dst: str, *args: object, **kwargs: object) -> None:
+        # 只对老 logs dir 的根 rename 制造 EXDEV，其他路径（如 shutil 内部的临时操作）
+        # 不受影响
+        if str(src) == str(old_dir):
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        real_rename(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(os, "rename", fake_rename)
+
+    logging_config.migrate_legacy_log_dir()
+
+    new_dir = isolated_data_dir / "root" / "logs"
+    assert not old_dir.exists(), "shutil.move 应在跨设备时自动 copy+unlink"
+    assert (new_dir / "arcreel.log").read_text(encoding="utf-8") == "payload\n"
+    assert (new_dir / "arcreel.log.2026-05-20").read_text(encoding="utf-8") == "rotated\n"
+
+
+def test_migrate_failure_logs_error(
+    isolated_data_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """迁移失败必须 ERROR 级（不是 WARNING）以让 operator 看到 logs 卡在旧位置。"""
+    import shutil
+
+    old_dir = isolated_data_dir / "data" / "logs"
+    old_dir.mkdir()
+    (old_dir / "arcreel.log").write_text("stuck\n", encoding="utf-8")
+
+    def fake_move(src: str, dst: str, *args: object, **kwargs: object) -> None:
+        raise PermissionError("simulated permission denied")
+
+    monkeypatch.setattr(shutil, "move", fake_move)
+
+    with caplog.at_level(logging.ERROR, logger="lib.logging_config"):
+        logging_config.migrate_legacy_log_dir()
+
+    assert any("FAILED" in rec.message and rec.levelno == logging.ERROR for rec in caplog.records)
+    # 旧 dir 仍在
+    assert (old_dir / "arcreel.log").exists()
+
+
+def test_setup_logging_file_false_skips_file_handler(isolated_log_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """模块导入期用 file=False 时不应挂 file handler、不应 mkdir 新目录。"""
+    # 注意：isolated_log_dir 把 ARCREEL_LOG_DIR 设到 tmp_path/logs 但还没创建
+    log_dir = isolated_log_dir
+    assert not log_dir.exists()
+
+    logging_config.setup_logging(file=False)
+
+    root = logging.getLogger()
+    assert not any(isinstance(h, TimedRotatingFileHandler) for h in root.handlers)
+    assert not log_dir.exists(), "file=False 不应触发 mkdir"
+
+
+def test_attach_file_handler_is_idempotent(isolated_log_dir: Path) -> None:
+    """attach_file_handler() 多次调用只挂一个 file handler。"""
+    logging_config.setup_logging(file=False)
+    logging_config.attach_file_handler()
+    logging_config.attach_file_handler()
+    logging_config.attach_file_handler()
+
+    root = logging.getLogger()
+    file_handlers = [h for h in root.handlers if isinstance(h, TimedRotatingFileHandler)]
+    assert len(file_handlers) == 1

--- a/tests/test_logging_persistence.py
+++ b/tests/test_logging_persistence.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
 import pytest
 
+from lib import app_data_dir as app_data_dir_mod
 from lib import logging_config
 
 
@@ -89,3 +91,104 @@ def test_disabled_env_accepts_aliases(isolated_log_dir: Path, monkeypatch: pytes
     logging_config.setup_logging()
     root = logging.getLogger()
     assert not any(isinstance(h, TimedRotatingFileHandler) for h in root.handlers)
+
+
+# --- resolve_log_dir 默认路径 + 一次性迁移 -------------------------------------
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """把 app_data_dir() 与 PROJECT_ROOT 都钉到 tmp_path 下的独立子目录。
+
+    使新旧默认路径分别落在 tmp_path/data/logs（旧）与 tmp_path/root/logs（新），
+    便于断言迁移是否搬动了文件。
+    """
+    data_root = tmp_path / "data"
+    project_root = tmp_path / "root"
+    data_root.mkdir()
+    project_root.mkdir()
+    monkeypatch.setenv("ARCREEL_DATA_DIR", str(data_root))
+    monkeypatch.delenv("ARCREEL_LOG_DIR", raising=False)
+    monkeypatch.setattr(logging_config, "PROJECT_ROOT", project_root)
+    app_data_dir_mod._reset_for_tests()
+    yield tmp_path
+    app_data_dir_mod._reset_for_tests()
+
+
+def test_resolve_log_dir_default_is_project_root(isolated_data_dir: Path) -> None:
+    assert logging_config.resolve_log_dir() == isolated_data_dir / "root" / "logs"
+
+
+def test_resolve_log_dir_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "custom-logs"
+    monkeypatch.setenv("ARCREEL_LOG_DIR", str(target))
+    assert logging_config.resolve_log_dir() == target
+
+
+def test_legacy_log_dir_points_to_app_data(isolated_data_dir: Path) -> None:
+    assert logging_config.legacy_log_dir() == (isolated_data_dir / "data" / "logs").resolve()
+
+
+def test_migrate_moves_legacy_dir_when_new_absent(isolated_data_dir: Path) -> None:
+    old_dir = isolated_data_dir / "data" / "logs"
+    old_dir.mkdir()
+    (old_dir / "arcreel.log").write_text("old content\n", encoding="utf-8")
+    (old_dir / "arcreel.log.2026-05-20").write_text("rotated\n", encoding="utf-8")
+
+    logging_config.migrate_legacy_log_dir()
+
+    new_dir = isolated_data_dir / "root" / "logs"
+    assert not old_dir.exists()
+    assert new_dir.exists()
+    assert (new_dir / "arcreel.log").read_text(encoding="utf-8") == "old content\n"
+    assert (new_dir / "arcreel.log.2026-05-20").exists()
+
+
+def test_migrate_skips_when_both_exist(isolated_data_dir: Path) -> None:
+    old_dir = isolated_data_dir / "data" / "logs"
+    new_dir = isolated_data_dir / "root" / "logs"
+    old_dir.mkdir()
+    new_dir.mkdir()
+    (old_dir / "arcreel.log").write_text("old\n", encoding="utf-8")
+    (new_dir / "arcreel.log").write_text("new\n", encoding="utf-8")
+
+    logging_config.migrate_legacy_log_dir()
+
+    # 两边都原样保留，不静默覆盖
+    assert (old_dir / "arcreel.log").read_text(encoding="utf-8") == "old\n"
+    assert (new_dir / "arcreel.log").read_text(encoding="utf-8") == "new\n"
+
+
+def test_migrate_noop_when_legacy_absent(isolated_data_dir: Path) -> None:
+    logging_config.migrate_legacy_log_dir()  # 不抛
+    assert not (isolated_data_dir / "root" / "logs").exists()
+
+
+def test_migrate_skips_when_log_dir_env_set(isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    old_dir = isolated_data_dir / "data" / "logs"
+    old_dir.mkdir()
+    (old_dir / "arcreel.log").write_text("keep me\n", encoding="utf-8")
+    monkeypatch.setenv("ARCREEL_LOG_DIR", str(isolated_data_dir / "custom"))
+
+    logging_config.migrate_legacy_log_dir()
+
+    # 用户显式设了 LOG_DIR，旧目录原地保留
+    assert (old_dir / "arcreel.log").read_text(encoding="utf-8") == "keep me\n"
+
+
+def test_migrate_noop_when_paths_equal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """ARCREEL_DATA_DIR == PROJECT_ROOT 时旧新路径解析到同一处，不要把目录自己 rename 到自己。"""
+    monkeypatch.setenv("ARCREEL_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("ARCREEL_LOG_DIR", raising=False)
+    monkeypatch.setattr(logging_config, "PROJECT_ROOT", tmp_path)
+    app_data_dir_mod._reset_for_tests()
+    try:
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        (logs / "arcreel.log").write_text("hi\n", encoding="utf-8")
+
+        logging_config.migrate_legacy_log_dir()  # 不抛
+
+        assert (logs / "arcreel.log").read_text(encoding="utf-8") == "hi\n"
+    finally:
+        app_data_dir_mod._reset_for_tests()


### PR DESCRIPTION
## Summary

- **根因**：`resolve_log_dir()` 默认 `app_data_dir()/logs` 物理重合于 `projects_root`，`list_projects()` 走 `.`/`_` 前缀负向过滤，`logs/` 因为无前缀被前端识别为视频项目
- **主修**：日志目录默认改为 `PROJECT_ROOT/logs`，加 `migrate_legacy_log_dir()` 一次性平移旧位置；docker-compose.yml + production/docker-compose.yml 同步 `./logs:/app/logs` 挂载
- **code-review 整改**：
  - migration 从模块导入期挪进 lifespan startup（pytest 收集不再有文件系统副作用），`setup_logging` 拆 `file=False` kwarg 推迟 file handler 挂载，INFO 级成功日志现可见
  - `os.replace` → `shutil.move`：docker bind-mount 跨设备 EXDEV 自动 fallback copy+unlink；失败升级到 ERROR 级
  - `PROJECT_ROOT/logs` 加进 `SessionManager._sensitive_prefixes`，阻 agent 通过 Read/Grep 读全局服务器日志（含 HTTP 路径/provider 探测/异常栈）
  - `.gitignore` 加 `/logs/`，spec 平台兼容段同步

## Test plan

- [x] `pytest tests/test_logging_persistence.py tests/test_system_logs_router.py tests/agent_runtime/test_session_manager_sandbox.py` 全过（49 用例，新增 9 个：EXDEV fallback、ERROR 升级、`file=False` 不副作用、attach 幂等、logs 敏感前缀等）
- [x] `pytest tests/test_app_module.py tests/server/test_startup_assertions.py tests/test_request_logging_middleware.py` 30 用例全过，确认 import 链未坏
- [x] `ruff check` + `basedpyright` 0 errors
- [x] Smoke：`import server.app` 不创建任何目录；lifespan 触发后看到 `[INFO] migrated legacy log dir ... -> ...`，旧 `projects/logs/` 实测被搬到 `logs/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 应用日志默认持久化到项目根的 logs 目录，按天轮转并保留最多 7 天；文件日志在启动期安全挂载以避免导入期副作用。
* **部署**
  * 容器已映射宿主机 ./logs 为持久化日志卷；.gitignore 已忽略 logs 内容。
* **安全/运行时**
  * 将日志目录纳入沙箱敏感路径，防止子进程无权限读取/枚举。
* **文档**
  * 更新环境示例与设计文档，明确日志位置、解析与迁移规则及 sandbox 要求。
* **测试**
  * 新增多项测试覆盖日志解析、迁移、文件处理与沙箱判定。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/620?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->