### PR TITLE
fix(assistant): "/" 唤起 skills 列表识别 content_mode 变体文件

### DIFF
--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -946,8 +946,8 @@ class AssistantService:
             for skill_dir in directories:
                 if not skill_dir.is_dir():
                     continue
-                skill_file = skill_dir / "SKILL.md"
-                if not skill_file.exists():
+                skill_file = self._resolve_skill_entry_file(skill_dir)
+                if skill_file is None:
                     continue
 
                 try:
@@ -974,6 +974,20 @@ class AssistantService:
                 skills.append(skill_entry)
 
         return skills
+
+    @staticmethod
+    def _resolve_skill_entry_file(skill_dir: Path) -> Path | None:
+        # profile 端的 content_mode 变体（SKILL.narration.md / SKILL.drama.md）只在 sync
+        # 进项目目录时才会被物化为 SKILL.md；列表接口直接扫 profile 时必须自己识别变体，
+        # 否则 manga-workflow 这类 variant-only skill 永远拿不到。约定：variant 之间
+        # frontmatter 的 user-facing 字段（name / description）保持一致。
+        skill_file = skill_dir / "SKILL.md"
+        if skill_file.exists():
+            return skill_file
+        for variant in sorted(skill_dir.glob("SKILL.*.md")):
+            if variant.is_file():
+                return variant
+        return None
 
     @staticmethod
     def _load_skill_metadata(skill_file: Path, fallback_name: str) -> dict[str, Any]:

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -33,6 +33,7 @@ from fastapi.sse import ServerSentEvent
 
 from lib.agent_profile import agent_profile_dir
 from lib.app_data_dir import app_data_dir
+from lib.profile_manifest import VALID_CONTENT_MODES
 from lib.project_manager import ProjectManager
 from server.agent_runtime.message_utils import extract_plain_user_content
 from server.agent_runtime.models import SessionMeta, SessionStatus
@@ -979,15 +980,31 @@ class AssistantService:
     def _resolve_skill_entry_file(skill_dir: Path) -> Path | None:
         # profile 端的 content_mode 变体（SKILL.narration.md / SKILL.drama.md）只在 sync
         # 进项目目录时才会被物化为 SKILL.md；列表接口直接扫 profile 时必须自己识别变体，
-        # 否则 manga-workflow 这类 variant-only skill 永远拿不到。约定：variant 之间
-        # frontmatter 的 user-facing 字段（name / description）保持一致。
-        skill_file = skill_dir / "SKILL.md"
-        if skill_file.exists():
-            return skill_file
-        for variant in sorted(skill_dir.glob("SKILL.*.md")):
-            if variant.is_file():
-                return variant
-        return None
+        # 否则 manga-workflow 这类 variant-only skill 永远拿不到。
+        #
+        # 查找契约与 tests/test_frontend_skill_i18n.py:_find_skill_md 保持一致：
+        # 用 is_file 严格筛文件、按 sorted(VALID_CONTENT_MODES) 显式枚举有效模式、
+        # 校验所有变体的 user-invocable 状态一致。不一致时 warning 后返回 None
+        # 跳过该 skill——避免列表里随机选到某个 mode 的 frontmatter 导致行为漂移。
+        common = skill_dir / "SKILL.md"
+        if common.is_file():
+            return common
+        variants = [skill_dir / f"SKILL.{mode}.md" for mode in sorted(VALID_CONTENT_MODES)]
+        existing = [v for v in variants if v.is_file()]
+        if not existing:
+            return None
+        try:
+            states = {AssistantService._load_skill_metadata(v, skill_dir.name)["user_invocable"] for v in existing}
+        except OSError:
+            return None
+        if len(states) > 1:
+            logger.warning(
+                "skill %s 各 content_mode 变体的 user-invocable 不一致，跳过；"
+                "请保证所有 SKILL.<mode>.md frontmatter 的 user-invocable 字段相同",
+                skill_dir.name,
+            )
+            return None
+        return existing[0]
 
     @staticmethod
     def _load_skill_metadata(skill_file: Path, fallback_name: str) -> dict[str, Any]:

--- a/tests/test_assistant_service_skills.py
+++ b/tests/test_assistant_service_skills.py
@@ -40,3 +40,25 @@ class TestListAvailableSkills:
 
         skills = service.list_available_skills()
         assert skills == []
+
+    def test_lists_skill_with_only_content_mode_variants(self, tmp_path, monkeypatch):
+        """Variant-only skills (SKILL.<mode>.md without a plain SKILL.md) must appear."""
+        profile_root = tmp_path / "agent_runtime_profile"
+        skill_dir = profile_root / ".claude" / "skills" / "manga-workflow"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.narration.md").write_text(
+            "---\nname: manga-workflow\ndescription: Narration variant\n---\n"
+        )
+        (skill_dir / "SKILL.drama.md").write_text("---\nname: manga-workflow\ndescription: Drama variant\n---\n")
+        monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_root))
+
+        with patch.object(AssistantService, "__init__", lambda self, *a, **kw: None):
+            service = AssistantService.__new__(AssistantService)
+            service.project_root = tmp_path
+            from lib.project_manager import ProjectManager
+
+            service.pm = ProjectManager(tmp_path / "projects")
+
+        skills = service.list_available_skills()
+        names = [s["name"] for s in skills]
+        assert "manga-workflow" in names

--- a/tests/test_assistant_service_skills.py
+++ b/tests/test_assistant_service_skills.py
@@ -10,12 +10,18 @@ class TestListAvailableSkills:
         """Should scan agent_runtime_profile/.claude/skills/ instead of .claude/skills/."""
         skill_dir = tmp_path / "agent_runtime_profile" / ".claude" / "skills" / "test-skill"
         skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text("---\nname: test-skill\ndescription: A test skill\n---\n")
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test-skill\ndescription: A test skill\n---\n",
+            encoding="utf-8",
+        )
 
         # Create a dev-only skill in .claude/skills/ (should NOT appear)
         dev_skill = tmp_path / ".claude" / "skills" / "dev-tool"
         dev_skill.mkdir(parents=True)
-        (dev_skill / "SKILL.md").write_text("---\nname: dev-tool\ndescription: Dev only\n---\n")
+        (dev_skill / "SKILL.md").write_text(
+            "---\nname: dev-tool\ndescription: Dev only\n---\n",
+            encoding="utf-8",
+        )
 
         with patch.object(AssistantService, "__init__", lambda self, *a, **kw: None):
             service = AssistantService.__new__(AssistantService)

--- a/tests/test_assistant_service_skills.py
+++ b/tests/test_assistant_service_skills.py
@@ -47,9 +47,13 @@ class TestListAvailableSkills:
         skill_dir = profile_root / ".claude" / "skills" / "manga-workflow"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.narration.md").write_text(
-            "---\nname: manga-workflow\ndescription: Narration variant\n---\n"
+            "---\nname: manga-workflow\ndescription: Narration variant\n---\n",
+            encoding="utf-8",
         )
-        (skill_dir / "SKILL.drama.md").write_text("---\nname: manga-workflow\ndescription: Drama variant\n---\n")
+        (skill_dir / "SKILL.drama.md").write_text(
+            "---\nname: manga-workflow\ndescription: Drama variant\n---\n",
+            encoding="utf-8",
+        )
         monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_root))
 
         with patch.object(AssistantService, "__init__", lambda self, *a, **kw: None):
@@ -62,3 +66,33 @@ class TestListAvailableSkills:
         skills = service.list_available_skills()
         names = [s["name"] for s in skills]
         assert "manga-workflow" in names
+
+    def test_skips_variant_skill_when_user_invocable_disagrees(self, tmp_path, monkeypatch, caplog):
+        """Variants with conflicting user-invocable frontmatter should be skipped with a warning."""
+        import logging
+
+        profile_root = tmp_path / "agent_runtime_profile"
+        skill_dir = profile_root / ".claude" / "skills" / "drifted-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.narration.md").write_text(
+            "---\nname: drifted-skill\ndescription: Narration\nuser-invocable: true\n---\n",
+            encoding="utf-8",
+        )
+        (skill_dir / "SKILL.drama.md").write_text(
+            "---\nname: drifted-skill\ndescription: Drama\nuser-invocable: false\n---\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_root))
+
+        with patch.object(AssistantService, "__init__", lambda self, *a, **kw: None):
+            service = AssistantService.__new__(AssistantService)
+            service.project_root = tmp_path
+            from lib.project_manager import ProjectManager
+
+            service.pm = ProjectManager(tmp_path / "projects")
+
+        with caplog.at_level(logging.WARNING, logger="server.agent_runtime.service"):
+            skills = service.list_available_skills()
+
+        assert all(s["name"] != "drifted-skill" for s in skills)
+        assert any("user-invocable" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

- `AssistantService.list_available_skills` 直接扫 `agent_runtime_profile/.claude/skills/` 并硬匹配 `SKILL.md`，导致只有 `SKILL.<mode>.md` 变体的 skill（如 manga-workflow）被跳过，前端 `/` 唤起的 skill 列表里看不到。
- 新增 `_resolve_skill_entry_file` helper：`SKILL.md` 不存在时按字母序回退到第一个 `SKILL.*.md` 变体。约定 variant 之间 frontmatter 的 user-facing 字段（name/description）保持一致。
- 加回归测试 `test_lists_skill_with_only_content_mode_variants` 覆盖 variant-only 场景。

## Test plan

- [x] `uv run python -m pytest tests/test_assistant_service_skills.py -v` — 3 passed
- [x] `uv run python -m pytest tests/test_assistant_service_more.py tests/test_assistant_router_full.py tests/test_profile_manifest.py -q` — 88 passed
- [x] 本地手动调用 `list_available_skills()`：返回 6 个 user-invocable skill，包含 manga-workflow；`generate-script` / `manage-project` 仍按 `user-invocable: false` 被过滤（预期）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 改进技能识别：支持识别仅存在变体的技能条目；若变体间 `user-invocable` 元数据不一致，则跳过该技能并记录包含 `"user-invocable"` 的警告，避免前端列表不一致。

* **测试**
  * 新增两项测试：验证仅有变体时仍被枚举；验证变体间 `user-invocable` 冲突时会跳过并记录告警。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->