### PR TITLE
fix(skill): pr-ai-review-loop round_count 只在 HEAD 切换时计数

### DIFF
--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -57,9 +57,9 @@ bash .agents/skills/pr-ai-review-loop/scripts/poll.sh <PR_NUMBER>
 脚本输出一个 JSON。字段 schema、设计意图、关键踩坑(比如为什么用 `created_at > last_push_at` 而不是 `commit_id == head`)都写在 `scripts/poll.sh` 头部注释里 —— 第一次进循环时 Read 一遍脚本注释,之后只看 JSON 输出。
 
 JSON 解析后**只放在对话上下文里**,不要落盘。同时更新:
-- `round_count`(+1)
-- `topic_history`(把本轮 reviewer 的意见提炼成一句话主题加进去)
-- `last_commit_shapes`(见下文「收敛兜底」)
+- `round_count` —— **只在本轮 `last_push_at` / HEAD SHA 与上一轮记录的不同时 +1**(初次进入算第 1 轮);HEAD 没变、仅仅是 wakeup 回来继续等 reviewer 出意见的 poll **不计**(一轮 = 一次"修复 → push → reviewer 回意见"周期,不是"poll 了多少次")
+- `topic_history`(把本轮 reviewer 的新意见提炼成一句话主题加进去;同 HEAD 重复 poll 拉到的同一条意见不重复加)
+- `last_commit_shapes`(同样 HEAD 切换时才追加,见下文「收敛兜底」)
 
 ### 2. 对每家启用的 reviewer 决定动作
 

--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -58,7 +58,7 @@ bash .agents/skills/pr-ai-review-loop/scripts/poll.sh <PR_NUMBER>
 
 JSON 解析后**只放在对话上下文里**,不要落盘。下面三个状态字段的更新触发条件**各不相同**,分别描述:
 - `round_count` —— **只在本轮 `last_push_at` / HEAD SHA 与上一轮记录的不同时 +1**(初次进入算第 1 轮);HEAD 没变、仅仅是 wakeup 回来继续等 reviewer 出意见的 poll **不计**(一轮 = 一次"修复 → push → reviewer 回意见"周期,不是"poll 了多少次")
-- `topic_history` —— **每次 poll 拉到 reviewer 新意见时都追加**(不绑定 HEAD 切换);把新意见提炼成一句话主题加进去。**跨 HEAD 累积、不清空**:收敛兜底 #3 的"同一主题指纹连提 ≥ 3 轮"靠它跨 HEAD 比对(line 32 的语义相似度判同主题),清空就破坏了这个判定。同 HEAD 内多次 poll 拉到的同一条 reviewer comment 只入一次,避免噪声
+- `topic_history` —— **每次 poll 拉到 reviewer 新意见时都追加**(不绑定 HEAD 切换);entry 形式建议 `{reviewer, round_count, 主题摘要}` —— reviewer 用于 line 26 的"同一家连提"判定,round_count 用于 line 152 收敛兜底 #3 的"≥ 3 轮"计数。**跨 HEAD 累积、不清空**:收敛兜底 #3 的"同一主题指纹连提 ≥ 3 轮"靠它跨 HEAD 比对(line 32 的语义相似度判同主题),清空就破坏了这个判定。同 HEAD 内多次 poll 拉到的同一条 reviewer comment 只入一次,避免噪声;初次进入或主题未出现过时直接追加,不用做相似度比对
 - `last_commit_shapes` —— **只在本轮 `last_push_at` / HEAD SHA 与上一轮记录的不同时追加**一条 Claude 看 `classify_commits.sh` 输出后概括的简短标签(如 `all_nit/format` / `contains_functional`),供收敛兜底 #2 判定;长度 ≤ 3 的滑窗
 
 ### 2. 对每家启用的 reviewer 决定动作

--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -56,10 +56,10 @@ bash .agents/skills/pr-ai-review-loop/scripts/poll.sh <PR_NUMBER>
 
 脚本输出一个 JSON。字段 schema、设计意图、关键踩坑(比如为什么用 `created_at > last_push_at` 而不是 `commit_id == head`)都写在 `scripts/poll.sh` 头部注释里 —— 第一次进循环时 Read 一遍脚本注释,之后只看 JSON 输出。
 
-JSON 解析后**只放在对话上下文里**,不要落盘。同时更新:
-- `round_count` —— **只在本轮 `last_push_at` / HEAD SHA 与上一轮记录的不同时 +1**(初次进入算第 1 轮);HEAD 没变、仅仅是 wakeup 回来继续等 reviewer 出意见的 poll **不计**(一轮 = 一次"修复 → push → reviewer 回意见"周期,不是"poll 了多少次")
-- `topic_history`(把本轮 reviewer 的新意见提炼成一句话主题加进去;同 HEAD 重复 poll 拉到的同一条意见不重复加)
-- `last_commit_shapes`(同样 HEAD 切换时才追加,见下文「收敛兜底」)
+JSON 解析后**只放在对话上下文里**,不要落盘。同时更新(下面三个状态字段都用同一组「触发条件」:本轮 `last_push_at` / HEAD SHA 与上一轮记录的不同):
+- `round_count` —— **只在触发条件命中时 +1**(初次进入算第 1 轮);HEAD 没变、仅仅是 wakeup 回来继续等 reviewer 出意见的 poll **不计**(一轮 = 一次"修复 → push → reviewer 回意见"周期,不是"poll 了多少次")
+- `topic_history` —— 把本轮 reviewer 的新意见提炼成一句话主题加进去。**跨 HEAD 累积、不清空**:收敛兜底 #3 的"同一主题指纹连提 ≥ 3 轮"靠它跨 HEAD 比对(line 32 的语义相似度判同主题),清空就破坏了这个判定。同 HEAD 内多次 poll 拉到的同一条 reviewer comment 只入一次,避免噪声
+- `last_commit_shapes` —— 触发条件命中时追加一条 Claude 看 `classify_commits.sh` 输出后概括的简短标签(如 `all_nit/format` / `contains_functional`),供收敛兜底 #2 判定;长度 ≤ 3 的滑窗
 
 ### 2. 对每家启用的 reviewer 决定动作
 

--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -56,10 +56,10 @@ bash .agents/skills/pr-ai-review-loop/scripts/poll.sh <PR_NUMBER>
 
 脚本输出一个 JSON。字段 schema、设计意图、关键踩坑(比如为什么用 `created_at > last_push_at` 而不是 `commit_id == head`)都写在 `scripts/poll.sh` 头部注释里 —— 第一次进循环时 Read 一遍脚本注释,之后只看 JSON 输出。
 
-JSON 解析后**只放在对话上下文里**,不要落盘。同时更新(下面三个状态字段都用同一组「触发条件」:本轮 `last_push_at` / HEAD SHA 与上一轮记录的不同):
-- `round_count` —— **只在触发条件命中时 +1**(初次进入算第 1 轮);HEAD 没变、仅仅是 wakeup 回来继续等 reviewer 出意见的 poll **不计**(一轮 = 一次"修复 → push → reviewer 回意见"周期,不是"poll 了多少次")
-- `topic_history` —— 把本轮 reviewer 的新意见提炼成一句话主题加进去。**跨 HEAD 累积、不清空**:收敛兜底 #3 的"同一主题指纹连提 ≥ 3 轮"靠它跨 HEAD 比对(line 32 的语义相似度判同主题),清空就破坏了这个判定。同 HEAD 内多次 poll 拉到的同一条 reviewer comment 只入一次,避免噪声
-- `last_commit_shapes` —— 触发条件命中时追加一条 Claude 看 `classify_commits.sh` 输出后概括的简短标签(如 `all_nit/format` / `contains_functional`),供收敛兜底 #2 判定;长度 ≤ 3 的滑窗
+JSON 解析后**只放在对话上下文里**,不要落盘。下面三个状态字段的更新触发条件**各不相同**,分别描述:
+- `round_count` —— **只在本轮 `last_push_at` / HEAD SHA 与上一轮记录的不同时 +1**(初次进入算第 1 轮);HEAD 没变、仅仅是 wakeup 回来继续等 reviewer 出意见的 poll **不计**(一轮 = 一次"修复 → push → reviewer 回意见"周期,不是"poll 了多少次")
+- `topic_history` —— **每次 poll 拉到 reviewer 新意见时都追加**(不绑定 HEAD 切换);把新意见提炼成一句话主题加进去。**跨 HEAD 累积、不清空**:收敛兜底 #3 的"同一主题指纹连提 ≥ 3 轮"靠它跨 HEAD 比对(line 32 的语义相似度判同主题),清空就破坏了这个判定。同 HEAD 内多次 poll 拉到的同一条 reviewer comment 只入一次,避免噪声
+- `last_commit_shapes` —— **只在本轮 `last_push_at` / HEAD SHA 与上一轮记录的不同时追加**一条 Claude 看 `classify_commits.sh` 输出后概括的简短标签(如 `all_nit/format` / `contains_functional`),供收敛兜底 #2 判定;长度 ≤ 3 的滑窗
 
 ### 2. 对每家启用的 reviewer 决定动作
 


### PR DESCRIPTION
## Summary
- `round_count` 之前每次 poll 都 +1，等 reviewer cold-start 的几次 wakeup 也被算进去，容易在还没真正发生修复时就触发 8 轮收敛上限
- 改成只在本轮 HEAD SHA / `last_push_at` 与上一轮记录的不同时 +1（初次进入算第 1 轮），对齐"一轮 = 一次修复→push→reviewer 回意见周期"的语义
- 三个状态字段的触发条件分别独立描述：`round_count` / `last_commit_shapes` 仅在 HEAD SHA / `last_push_at` 切换时更新；`topic_history` 触发条件不同 —— 每次 poll 拉到 reviewer 新意见就追加（同 HEAD 内对同一条 comment 去重，跨 HEAD 累积），供收敛兜底 #3 "连提 ≥ 3 轮" 判定
- `last_commit_shapes` 补充每条追加内容的具体形态（Claude 看 `classify_commits.sh` 输出后概括的简短标签，如 `all_nit/format` / `contains_functional`），明示长度 ≤ 3 的滑窗
- `topic_history` entry 形式建议 `{reviewer, round_count, 主题摘要}`，跟 line 26 的"同一家 reviewer 连提"和 line 152 收敛兜底 #3 的"≥ 3 轮"计数对齐

## Test plan
- [ ] 下次跑 /pr-ai-review-loop 时观察 round_count 不再随等待型 wakeup 漂移，只在新 HEAD 出现后 +1
- [ ] 验证收敛兜底 `round_count >= 8` 真正反映"修复了 8 次"而不是"poll 了 8 次"
- [ ] 验证 topic_history 在同 HEAD 多次 poll 时也能正确追加新到达的 reviewer 意见

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 优化与改进
* 改进了AI审查循环的对话上下文管理机制，优化了审查状态的跟踪规则，增强了重复审查意见的去重能力和历史记录的准确性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->