### PR TITLE
fix(project): 中文标题不再塌成 slug 作为项目显示名

### DIFF
--- a/frontend/src/components/canvas/WelcomeCanvas.tsx
+++ b/frontend/src/components/canvas/WelcomeCanvas.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
+import { getProjectDisplayName } from "@/utils/project-display";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -51,7 +52,7 @@ export function WelcomeCanvas({
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const sourceFilesVersion = useAppStore((s) => s.sourceFilesVersion);
-  const displayProjectTitle = projectTitle?.trim() || t("untitled_project");
+  const displayProjectTitle = getProjectDisplayName(projectTitle, t("untitled_project"));
 
   // 拉取已有源文件，决定初始 phase
   useEffect(() => {

--- a/frontend/src/components/canvas/WelcomeCanvas.tsx
+++ b/frontend/src/components/canvas/WelcomeCanvas.tsx
@@ -51,7 +51,7 @@ export function WelcomeCanvas({
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const sourceFilesVersion = useAppStore((s) => s.sourceFilesVersion);
-  const displayProjectTitle = projectTitle?.trim() || projectName;
+  const displayProjectTitle = projectTitle?.trim() || t("untitled_project");
 
   // 拉取已有源文件，决定初始 phase
   useEffect(() => {

--- a/frontend/src/components/layout/ProjectMenu.tsx
+++ b/frontend/src/components/layout/ProjectMenu.tsx
@@ -28,7 +28,8 @@ export function ProjectMenu() {
   }, [open]);
 
   const projectTitle =
-    currentProjectData?.title?.trim() || currentProjectName || t("no_project_selected");
+    currentProjectData?.title?.trim() ||
+    (currentProjectName ? t("dashboard:untitled_project") : t("no_project_selected"));
   const initial = (projectTitle || "?").slice(0, 1).toUpperCase();
   const contentMode = currentProjectData?.content_mode;
   const aspectRatio =

--- a/frontend/src/components/layout/ProjectMenu.tsx
+++ b/frontend/src/components/layout/ProjectMenu.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "wouter";
 import { ChevronDown, Plus, SlidersHorizontal } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useProjectsStore } from "@/stores/projects-store";
+import { getProjectDisplayName } from "@/utils/project-display";
 
 /**
  * 顶栏左上的项目切换菜单。
@@ -27,9 +28,10 @@ export function ProjectMenu() {
     return () => document.removeEventListener("mousedown", onDoc);
   }, [open]);
 
-  const projectTitle =
-    currentProjectData?.title?.trim() ||
-    (currentProjectName ? t("dashboard:untitled_project") : t("no_project_selected"));
+  const fallbackLabel = currentProjectName
+    ? t("dashboard:untitled_project")
+    : t("no_project_selected");
+  const projectTitle = getProjectDisplayName(currentProjectData?.title, fallbackLabel);
   const initial = (projectTitle || "?").slice(0, 1).toUpperCase();
   const contentMode = currentProjectData?.content_mode;
   const aspectRatio =

--- a/frontend/src/components/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.tsx
@@ -447,11 +447,11 @@ export function ProjectSettingsPage() {
                 letterSpacing: "-0.012em",
                 color: "var(--color-text)",
               }}
-              title={projectTitle || projectName}
+              title={projectTitle?.trim() || t("untitled_project")}
             >
               {t("project_settings")}
               <span className="ml-2 align-middle font-mono text-[11.5px] font-medium uppercase tracking-[0.08em] text-text-3">
-                {projectTitle || projectName}
+                {projectTitle?.trim() || t("untitled_project")}
               </span>
             </h1>
           </div>

--- a/frontend/src/components/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.tsx
@@ -16,6 +16,7 @@ import { ACCENT_BTN_CLS, ACCENT_BUTTON_STYLE, GHOST_BTN_LG_CLS, radioCardClass }
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { useWarnUnsaved } from "@/hooks/useWarnUnsaved";
 import { normalizeMode, type GenerationMode } from "@/utils/generation-mode";
+import { getProjectDisplayName } from "@/utils/project-display";
 
 function deriveStyleValue(project: Record<string, unknown>, projectName: string): StylePickerValue {
   const styleImage = project.style_image as string | undefined;
@@ -447,11 +448,11 @@ export function ProjectSettingsPage() {
                 letterSpacing: "-0.012em",
                 color: "var(--color-text)",
               }}
-              title={projectTitle?.trim() || t("untitled_project")}
+              title={getProjectDisplayName(projectTitle, t("untitled_project"))}
             >
               {t("project_settings")}
               <span className="ml-2 align-middle font-mono text-[11.5px] font-medium uppercase tracking-[0.08em] text-text-3">
-                {projectTitle?.trim() || t("untitled_project")}
+                {getProjectDisplayName(projectTitle, t("untitled_project"))}
               </span>
             </h1>
           </div>

--- a/frontend/src/components/pages/ProjectsPage.tsx
+++ b/frontend/src/components/pages/ProjectsPage.tsx
@@ -34,6 +34,7 @@ import { ProgressBar } from "@/components/ui/ProgressBar";
 import { SecondaryButton } from "@/components/ui/SecondaryButton";
 import { Typewriter, type TypewriterSegment } from "@/components/ui/Typewriter";
 import { WARM_TONE } from "@/utils/severity-tone";
+import { getProjectDisplayName } from "@/utils/project-display";
 import { CreateProjectModal } from "./CreateProjectModal";
 import { OpenClawModal } from "./OpenClawModal";
 import { rememberAssetLibraryReturnTo } from "./AssetLibraryPage";
@@ -231,7 +232,7 @@ function Poster({ project, styleLabel, large = false }: PosterProps) {
             overflowWrap: "anywhere",
           }}
         >
-          {project.title?.trim() || t("untitled_project")}
+          {getProjectDisplayName(project.title, t("untitled_project"))}
         </div>
       </div>
     </div>
@@ -366,7 +367,7 @@ function ProjectCard({ project, styleLabel, phaseLabels, t, onDelete }: ProjectC
   const propsStat = status?.props ?? { completed: 0, total: 0 };
   const episodes =
     status?.episodes_summary ?? { total: 0, scripted: 0, in_production: 0, completed: 0 };
-  const projectDisplayName = project.title?.trim() || t("dashboard:untitled_project");
+  const projectDisplayName = getProjectDisplayName(project.title, t("dashboard:untitled_project"));
 
   const { trackStyle, barStyle } = gradientProgressStyles(
     phase === "completed" ? "good" : "accent",
@@ -579,7 +580,7 @@ function NowEditingCard({ project, styleLabel, phaseLabels, t }: NowEditingCardP
             color: "var(--color-text)",
           }}
         >
-          {project.title?.trim() || t("dashboard:untitled_project")}
+          {getProjectDisplayName(project.title, t("dashboard:untitled_project"))}
         </h3>
         <div className="font-editorial relative italic text-text-3" style={{ fontSize: 15 }}>
           {styleLabel}
@@ -1213,11 +1214,17 @@ export function ProjectsPage() {
           .pushToast(
             autoFixedCount > 0
               ? t("dashboard:import_auto_fixed", {
-                  title: result.project.title?.trim() || t("dashboard:untitled_project"),
+                  title: getProjectDisplayName(
+                    result.project.title,
+                    t("dashboard:untitled_project"),
+                  ),
                   count: autoFixedCount,
                 })
               : t("dashboard:import_success", {
-                  title: result.project.title?.trim() || t("dashboard:untitled_project"),
+                  title: getProjectDisplayName(
+                    result.project.title,
+                    t("dashboard:untitled_project"),
+                  ),
                 }),
             "success",
           );

--- a/frontend/src/components/pages/ProjectsPage.tsx
+++ b/frontend/src/components/pages/ProjectsPage.tsx
@@ -171,6 +171,7 @@ interface PosterProps {
 }
 
 function Poster({ project, styleLabel, large = false }: PosterProps) {
+  const { t } = useTranslation("dashboard");
   const hue1 = useMemo(() => hashHue(project.name, 17), [project.name]);
   const aspect = large ? "2.39 / 1" : "2 / 1";
   const radius = large ? 8 : 6;
@@ -230,7 +231,7 @@ function Poster({ project, styleLabel, large = false }: PosterProps) {
             overflowWrap: "anywhere",
           }}
         >
-          {project.title || project.name}
+          {project.title?.trim() || t("untitled_project")}
         </div>
       </div>
     </div>
@@ -365,7 +366,7 @@ function ProjectCard({ project, styleLabel, phaseLabels, t, onDelete }: ProjectC
   const propsStat = status?.props ?? { completed: 0, total: 0 };
   const episodes =
     status?.episodes_summary ?? { total: 0, scripted: 0, in_production: 0, completed: 0 };
-  const projectDisplayName = project.title || project.name;
+  const projectDisplayName = project.title?.trim() || t("dashboard:untitled_project");
 
   const { trackStyle, barStyle } = gradientProgressStyles(
     phase === "completed" ? "good" : "accent",
@@ -376,7 +377,7 @@ function ProjectCard({ project, styleLabel, phaseLabels, t, onDelete }: ProjectC
       <Link
         href={`/app/projects/${project.name}`}
         className="block w-full text-left text-text no-underline outline-none"
-        aria-label={`${project.title || project.name} · ${styleLabel}${phaseLabel ? ` · ${phaseLabel}` : ""}`}
+        aria-label={`${projectDisplayName} · ${styleLabel}${phaseLabel ? ` · ${phaseLabel}` : ""}`}
       >
         <div className="p-2.5">
           <Poster project={project} styleLabel={styleLabel} />
@@ -385,7 +386,7 @@ function ProjectCard({ project, styleLabel, phaseLabels, t, onDelete }: ProjectC
         <div className="px-4 pt-1 pb-3.5">
           <div className="mb-1.5 flex items-baseline justify-between gap-2">
             <h3 className="truncate text-[17px] font-semibold tracking-tight text-text">
-              {project.title || project.name}
+              {projectDisplayName}
             </h3>
             <span
               className="shrink-0 font-mono text-[9.5px] uppercase tracking-[0.08em] text-text-3"
@@ -578,7 +579,7 @@ function NowEditingCard({ project, styleLabel, phaseLabels, t }: NowEditingCardP
             color: "var(--color-text)",
           }}
         >
-          {project.title || project.name}
+          {project.title?.trim() || t("dashboard:untitled_project")}
         </h3>
         <div className="font-editorial relative italic text-text-3" style={{ fontSize: 15 }}>
           {styleLabel}
@@ -1212,11 +1213,11 @@ export function ProjectsPage() {
           .pushToast(
             autoFixedCount > 0
               ? t("dashboard:import_auto_fixed", {
-                  title: result.project.title || result.project_name,
+                  title: result.project.title?.trim() || t("dashboard:untitled_project"),
                   count: autoFixedCount,
                 })
               : t("dashboard:import_success", {
-                  title: result.project.title || result.project_name,
+                  title: result.project.title?.trim() || t("dashboard:untitled_project"),
                 }),
             "success",
           );

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -6,6 +6,7 @@ export default {
   'new_project': 'New Project',
   'project_name': 'Project Name',
   'project_title': 'Project Title',
+  'untitled_project': 'Untitled Project',
   'content_mode': 'Content Mode',
   'narration': 'Narration',
   'standard': 'Standard',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -7,6 +7,7 @@ export default {
   'new_project': 'Dự án mới',
   'project_name': 'Tên dự án',
   'project_title': 'Tiêu đề dự án',
+  'untitled_project': 'Dự án chưa đặt tên',
   'content_mode': 'Chế độ nội dung',
   'narration': 'Thuyết minh',
   'standard': 'Tiêu chuẩn',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -7,6 +7,7 @@ export default {
   'new_project': '新建项目',
   'project_name': '项目名称',
   'project_title': '项目标题',
+  'untitled_project': '未命名项目',
   'content_mode': '内容模式',
   'narration': '说书',
   'standard': '标准',

--- a/frontend/src/utils/project-display.test.ts
+++ b/frontend/src/utils/project-display.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getProjectDisplayName } from "./project-display";
+
+describe("getProjectDisplayName", () => {
+  const UNTITLED = "未命名项目";
+
+  it("falls back when title is null / undefined / empty / whitespace", () => {
+    expect(getProjectDisplayName(undefined, UNTITLED)).toBe(UNTITLED);
+    expect(getProjectDisplayName(null, UNTITLED)).toBe(UNTITLED);
+    expect(getProjectDisplayName("", UNTITLED)).toBe(UNTITLED);
+    expect(getProjectDisplayName("   ", UNTITLED)).toBe(UNTITLED);
+    expect(getProjectDisplayName("\t\n", UNTITLED)).toBe(UNTITLED);
+  });
+
+  it("returns trimmed title when non-empty", () => {
+    expect(getProjectDisplayName("第一集", UNTITLED)).toBe("第一集");
+    expect(getProjectDisplayName("  第一集  ", UNTITLED)).toBe("第一集");
+    expect(getProjectDisplayName("My Novel", UNTITLED)).toBe("My Novel");
+  });
+
+  it("respects caller-provided untitled label across locales", () => {
+    expect(getProjectDisplayName(undefined, "Untitled Project")).toBe("Untitled Project");
+    expect(getProjectDisplayName("", "Dự án chưa đặt tên")).toBe("Dự án chưa đặt tên");
+  });
+});

--- a/frontend/src/utils/project-display.ts
+++ b/frontend/src/utils/project-display.ts
@@ -1,0 +1,10 @@
+// 项目显示名解析:trim 后非空用原值,否则塌成调用方传入的 i18n 兜底文案。
+// 抽出 helper 是因为 fallback 模式在多处显示位置重复,且早期把内部 slug-style
+// project_name 当显示名暴露给用户引发过报障(中文标题被 NFKD 后剩纯 hex)。
+export function getProjectDisplayName(
+  rawTitle: string | null | undefined,
+  untitledLabel: string,
+): string {
+  const trimmed = rawTitle?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : untitledLabel;
+}

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -163,8 +163,10 @@ class DataValidator:
         errors: list[str],
         warnings: list[str],
     ) -> None:
-        if "title" not in project or not isinstance(project["title"], str):
+        if "title" not in project:
             errors.append("缺少必填字段: title")
+        elif not isinstance(project["title"], str):
+            errors.append("字段类型错误: title 应为字符串")
 
         content_mode = project.get("content_mode")
         if not content_mode:

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -163,7 +163,7 @@ class DataValidator:
         errors: list[str],
         warnings: list[str],
     ) -> None:
-        if not project.get("title"):
+        if "title" not in project or not isinstance(project["title"], str):
             errors.append("缺少必填字段: title")
 
         content_mode = project.get("content_mode")

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -131,10 +131,17 @@ class ProjectManager:
 
     @staticmethod
     def _slugify_project_title(title: str) -> str:
-        """Build a filesystem-safe slug prefix from the project title."""
+        """Build a filesystem-safe slug prefix from the project title.
+
+        CJK 标题经 NFKD + ascii ignore 后会丢光汉字;若结果不包含任何字母
+        （纯空 / 仅夹在标题里的孤立数字,如「第1集」→ "1"),退化为中性
+        前缀 ``proj``,避免产生 ``1-<hex>`` 这种看似有意义实则误导的 slug。
+        """
         ascii_text = unicodedata.normalize("NFKD", str(title).strip()).encode("ascii", "ignore").decode("ascii")
         slug = PROJECT_SLUG_SANITIZER.sub("-", ascii_text).strip("-_").lower()
-        return slug[:24] or "project"
+        if not slug or not any(c.isalpha() for c in slug):
+            return "proj"
+        return slug[:24]
 
     def generate_project_name(self, title: str | None = None) -> str:
         """Generate a unique internal project identifier."""
@@ -1453,7 +1460,9 @@ class ProjectManager:
 
         project = {
             "schema_version": CURRENT_SCHEMA_VERSION,
-            "title": project_title or project_name,
+            # 允许空字符串:前端会以 i18n「未命名项目」兜底显示,避免把 slug
+            # 风格的 project_name 固化为用户可见的标题。
+            "title": project_title,
             "content_mode": content_mode or "narration",
             "aspect_ratio": aspect_ratio or "9:16",
             "style": style or "",

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -136,12 +136,15 @@ class ProjectManager:
         CJK 标题经 NFKD + ascii ignore 后会丢光汉字;若结果不包含任何字母
         （纯空 / 仅夹在标题里的孤立数字,如「第1集」→ "1"),退化为中性
         前缀 ``proj``,避免产生 ``1-<hex>`` 这种看似有意义实则误导的 slug。
+
+        注意 truncate 必须在 letter 校验之前:像 ``"1-2345...23abc"``(>24 字符,
+        字母在尾部) 截前 24 后会只剩数字,这种结果同样应塌成 ``proj``。
         """
         ascii_text = unicodedata.normalize("NFKD", str(title).strip()).encode("ascii", "ignore").decode("ascii")
-        slug = PROJECT_SLUG_SANITIZER.sub("-", ascii_text).strip("-_").lower()
+        slug = PROJECT_SLUG_SANITIZER.sub("-", ascii_text).strip("-_").lower()[:24]
         if not slug or not any(c.isalpha() for c in slug):
             return "proj"
-        return slug[:24]
+        return slug
 
     def generate_project_name(self, title: str | None = None) -> str:
         """Generate a unique internal project identifier."""

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -394,12 +394,13 @@ async def list_projects(_user: CurrentUser):
                     # 使用 StatusCalculator 计算进度（读时计算）
                     status = calculator.calculate_project_status(name, project, preloaded_scripts=preloaded_scripts)
 
+                    raw_title = project.get("title")
                     projects.append(
                         {
                             "name": name,
-                            # title 缺失/空时返回空串,由前端 i18n 兜底显示「未命名项目」,
-                            # 避免把 slug 风格的 name 当成显示名暴露给用户。
-                            "title": project.get("title", ""),
+                            # title 缺失/为 None/类型异常时统一归一为空串,前端 i18n
+                            # 兜底显示「未命名项目」,确保接口契约始终返回 str。
+                            "title": raw_title if isinstance(raw_title, str) else "",
                             "style": project.get("style", ""),
                             "style_template_id": project.get("style_template_id"),
                             "style_image": project.get("style_image"),

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -397,7 +397,9 @@ async def list_projects(_user: CurrentUser):
                     projects.append(
                         {
                             "name": name,
-                            "title": project.get("title", name),
+                            # title 缺失/空时返回空串,由前端 i18n 兜底显示「未命名项目」,
+                            # 避免把 slug 风格的 name 当成显示名暴露给用户。
+                            "title": project.get("title", ""),
                             "style": project.get("style", ""),
                             "style_template_id": project.get("style_template_id"),
                             "style_image": project.get("style_image"),
@@ -410,7 +412,7 @@ async def list_projects(_user: CurrentUser):
                     projects.append(
                         {
                             "name": name,
-                            "title": name,
+                            "title": "",
                             "style": "",
                             "thumbnail": None,
                             "status": {},
@@ -420,7 +422,7 @@ async def list_projects(_user: CurrentUser):
                 # 出错时返回基本信息
                 logger.warning("加载项目 '%s' 元数据失败: %s", name, e)
                 projects.append(
-                    {"name": name, "title": name, "style": "", "thumbnail": None, "status": {}, "error": str(e)}
+                    {"name": name, "title": "", "style": "", "thumbnail": None, "status": {}, "error": str(e)}
                 )
 
         return {"projects": projects}

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -42,10 +42,10 @@ class TestDataValidator:
 
     def test_validate_project_reports_missing_and_invalid_fields(self, tmp_path):
         project_dir = tmp_path / "projects" / "demo"
+        # title 字段完全缺失才报错;空字符串在新策略下属于合法状态(前端 i18n 兜底)
         _write_json(
             project_dir / "project.json",
             {
-                "title": "",
                 "content_mode": "invalid",
                 "style": "",
                 "characters": {"A": []},
@@ -67,6 +67,19 @@ class TestDataValidator:
         # scenes/props 缺少 description 也应报错
         assert any("场景 'X'" in error for error in result.errors)
         assert any("道具 'Y'" in error for error in result.errors)
+
+    def test_validate_project_allows_empty_title(self, tmp_path):
+        # title 为空字符串属于合法状态:前端会以「未命名项目」i18n 兜底,
+        # lib 层不再要求 title 非空,避免 ProjectManager 写路径被迫存 slug 作 fallback。
+        project_dir = tmp_path / "projects" / "demo"
+        payload = _project_payload()
+        payload["title"] = ""
+        _write_json(project_dir / "project.json", payload)
+
+        result = DataValidator(projects_root=str(tmp_path / "projects")).validate_project("demo")
+
+        assert result.valid
+        assert not any("title" in error for error in result.errors)
 
     def test_validate_episode_narration_success_with_warnings(self, tmp_path):
         project_dir = tmp_path / "projects" / "demo"

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -61,12 +61,27 @@ class TestDataValidator:
         result = DataValidator(projects_root=str(tmp_path / "projects")).validate_project("demo")
 
         assert not result.valid
-        assert any("title" in error for error in result.errors)
+        # title 完全缺失 → "缺少必填字段",区别于"字段类型错误"
+        assert any("缺少必填字段: title" in error for error in result.errors)
         assert any("content_mode" in error for error in result.errors)
         assert any("角色 'A' 数据格式错误" in error for error in result.errors)
         # scenes/props 缺少 description 也应报错
         assert any("场景 'X'" in error for error in result.errors)
         assert any("道具 'Y'" in error for error in result.errors)
+
+    def test_validate_project_rejects_non_string_title(self, tmp_path):
+        # title 字段存在但类型不是 string(如 int / null / list)应给出区分于"缺失"的明确文案,
+        # 避免调用方误以为字段没写。
+        project_dir = tmp_path / "projects" / "demo"
+        payload = _project_payload()
+        payload["title"] = 123
+        _write_json(project_dir / "project.json", payload)
+
+        result = DataValidator(projects_root=str(tmp_path / "projects")).validate_project("demo")
+
+        assert not result.valid
+        assert any("字段类型错误: title 应为字符串" in error for error in result.errors)
+        assert not any("缺少必填字段: title" in error for error in result.errors)
 
     def test_validate_project_allows_empty_title(self, tmp_path):
         # title 为空字符串属于合法状态:前端会以「未命名项目」i18n 兜底,

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -93,7 +93,7 @@ class TestProjectManagerMore:
         )
         assert project["image_provider_t2i"] == "openai/gpt-image-1"
 
-    def test_project_identifier_validation_and_title_fallback(self, tmp_path):
+    def test_project_identifier_validation_and_empty_title(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
 
         with pytest.raises(ValueError):
@@ -104,19 +104,31 @@ class TestProjectManagerMore:
         pm.create_project("demo")
         project = pm.create_project_metadata("demo", "")
 
-        assert project["title"] == "demo"
+        # 空 title 直接保留为空字符串,由前端 i18n 兜底,不再 fallback 为 project_name(slug)
+        assert project["title"] == ""
+
+    def test_create_project_metadata_preserves_cjk_title(self, tmp_path):
+        pm = ProjectManager(tmp_path / "projects")
+        project_name = pm.generate_project_name("第1集")
+        pm.create_project(project_name)
+        project = pm.create_project_metadata(project_name, "第1集")
+        assert project["title"] == "第1集"
 
     def test_generate_project_name_is_unique_and_safe(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
 
         first = pm.generate_project_name("My Demo Project")
         second = pm.generate_project_name("我的项目")
+        third = pm.generate_project_name("第1集")
 
         assert first.startswith("my-demo-project-")
-        assert second.startswith("project-")
-        assert first != second
+        # CJK 标题 / 只剩孤立数字的标题统一塌成中性前缀 proj-,避免误导性 slug
+        assert second.startswith("proj-")
+        assert third.startswith("proj-")
+        assert first != second != third
         assert pm.normalize_project_name(first) == first
         assert pm.normalize_project_name(second) == second
+        assert pm.normalize_project_name(third) == third
 
     def test_script_operations_and_scene_updates(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -130,6 +130,13 @@ class TestProjectManagerMore:
         assert pm.normalize_project_name(second) == second
         assert pm.normalize_project_name(third) == third
 
+    def test_generate_project_name_truncates_before_letter_check(self, tmp_path):
+        # 长 ASCII 标题前 24 字符全是数字/连字符、字母被截掉时,应塌成 proj-,
+        # 而不是返回 "1234567890-1234567890-12" 这种纯数字 slug。
+        pm = ProjectManager(tmp_path / "projects")
+        candidate = pm.generate_project_name("1234567890-1234567890-1234-letters")
+        assert candidate.startswith("proj-")
+
     def test_script_operations_and_scene_updates(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")


### PR DESCRIPTION
## Summary
- slug 算法在无 ASCII 字母前缀时统一塌为中性 `proj-<hex>`,避免「第1集」→ `1-55898f35`、「我的小说」→ `project-352ec63c` 等误导性 slug
- `create_project_metadata` 在 title 空时保留空字符串,不再把 slug 写进 title 字段;前端用 i18n `dashboard:untitled_project` 兜底显示「未命名项目」
- 放宽 `data_validator` title 校验(string 即可,允许空);`list_projects` 路由三处 fallback 同步改回空串
- 存量已被污染的 `title=slug` 项目不做自动迁移,用户在项目设置页手改

## Test plan
- [x] `uv run python -m pytest tests/test_project_manager_more.py tests/test_data_validator.py tests/test_projects_router.py tests/test_i18n_consistency.py`
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run basedpyright`(本次改动 0 errors)
- [x] `cd frontend && pnpm check`(typecheck + lint + 579 vitest 全绿)
- [x] 端到端:`generate_project_name("第1集")` → `proj-xxxxxxxx`、`create_project_metadata(name, "第1集")["title"] == "第1集"`、空 title 持久化为 `""`
- [ ] 手动 UI:创建中文标题项目,确认 URL `proj-xxx`、header 显示中文 title;切 EN/VI 看「未命名项目」三语

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 统一前端项目标题展示：当标题为空或仅空白时一致显示“未命名项目”、更新相关提示与 aria 文案。
  * 后端列表接口与校验调整：项目元数据中缺失或非法标题不再回退为名称，空标题以空串返回/允许。

* **多语言支持**
  * 新增英文、越南文、中文的“未命名项目”翻译条目。

* **Tests**
  * 增加与更新测试，覆盖空标题允许、显示回退和元数据生成行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->