### PR TITLE
ci: doc-only 改动跳过重型 job + 聚合 gate 不再卡 required check

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,8 +9,28 @@ on:
     - cron: "22 9 * * 3"
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!LICENSE'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/pull_request_template.md'
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -42,3 +62,16 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
+
+  codeql-required:
+    if: always()
+    needs: [changes, analyze]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify CodeQL jobs
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "CodeQL job failed"
+            exit 1
+          fi
+          echo "CodeQL passed or skipped (docs-only / changes job ok)"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,12 @@ name: Docker
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
     tags: ["v*"]
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,30 +3,34 @@ name: Tests
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "README*.md"
-      - "CHANGELOG.md"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/pull_request_template.md"
-      - "LICENSE"
   pull_request:
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "README*.md"
-      - "CHANGELOG.md"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/pull_request_template.md"
-      - "LICENSE"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!LICENSE'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/pull_request_template.md'
+
   backend-tests:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -66,6 +70,8 @@ jobs:
   postgres-compat:
     # SQLite/PostgreSQL 方言兼容性闸门：alembic 三步闭环（upgrade/downgrade/idempotent）
     # + 所有 DB-touching 测试（marker 驱动）跑在 PG16 上。
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     services:
@@ -121,6 +127,8 @@ jobs:
           fail_ci_if_error: false
 
   frontend-tests:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -159,3 +167,16 @@ jobs:
           files: frontend/coverage/lcov.info
           flags: frontend
           fail_ci_if_error: false
+
+  ci-required:
+    if: always()
+    needs: [changes, backend-tests, postgres-compat, frontend-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped (docs-only change)"


### PR DESCRIPTION
## Summary

两类长期问题一并修复:

1. **资源浪费**:`docker.yml` 与 `codeql.yml` 此前无 path 过滤,doc-only 改动也会跑多架构镜像构建 + Trivy / CodeQL matrix 分析。
2. **required check 卡 pending**:`test.yml` 顶层用 `paths-ignore`,docs PR 完全不触发 workflow → `backend-tests` / `postgres-compat` / `frontend-tests` status check 永不出现 → branch protection 显示 `Expected — Waiting for status to be reported`,无法合并。

引入 **changes-detect + aggregator-gate** 模式:

```
PR/push ─► workflow 触发(无 paths-ignore)
            │
            ▼
       changes (dorny/paths-filter@v3) ── outputs.code = true|false
            │
            ├─ true  → heavy job 全跑
            └─ false → heavy job skip
            ▼
       *-required (if: always(), needs: 所有 heavy job + changes)
            │
            ├─ 任一 failure/cancelled → exit 1
            └─ 全 success 或 skipped  → exit 0  ← required check 始终 report
```

## 改动

- `.github/workflows/test.yml` — 删顶层 `paths-ignore`;新增 `changes` job + `ci-required` 聚合 job;`backend-tests` / `postgres-compat` / `frontend-tests` 加 `needs: changes` + `if: needs.changes.outputs.code == 'true'`。
- `.github/workflows/codeql.yml` — 新增 `changes` job + `codeql-required` 聚合 job;`analyze` matrix 加 `needs: changes` + `if: needs.changes.outputs.code == 'true' || github.event_name == 'schedule'`(保留每周 cron 全量扫描)。
- `.github/workflows/docker.yml` — 仅 push 到 main 时跑、不是 PR required check,直接加 `paths-ignore` 即可;`tags: ["v*"]` 触发不受 `paths-ignore` 影响,发布流程不变。
- `release-please.yml` 不动。

`dorny/paths-filter` 的 filter 用 `'**'` + 负向排除而不是纯负向集合,picomatch 语义更稳。

## ⚠️ 合并后必须手动操作

代码改完后还需在 **Settings → Branches → Branch protection rule for `main`** 修改 required status checks:

- **移除**:`backend-tests`、`postgres-compat`、`frontend-tests`、`Analyze (python)`、`Analyze (javascript-typescript)`
- **新增**:`ci-required`、`codeql-required`

首个 PR(本 PR)自身仍会跑旧 required check 名,因为代码改动让这些 job 真实跑出 success,所以可以合并;后续 PR 才依赖新的 `*-required`。

## Test plan

- [ ] CI 在本 PR 上正常跑:三个 heavy job 全跑(本 PR 改了 `.github/workflows/*`,触发 `code=true`),`ci-required` / `codeql-required` 显示 Success
- [ ] 合并后开一个纯 docs PR(改 README typo),观察:
  - workflow 被触发(不再 "skipped")
  - heavy job 显示为 **Skipped**
  - `ci-required` / `codeql-required` 显示 **Success**
- [ ] 手动更新 branch protection required check 列表
- [ ] 合到 main 后 push 一个纯 docs commit,观察 `docker.yml` 不触发
- [ ] 下次周三 09:22 UTC cron 触发,确认 CodeQL 仍跑全量


---
_Generated by [Claude Code](https://claude.ai/code/session_019u5znCkTAq3gbY4f3Pt7uV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Chores**
  * 优化持续集成工作流效率：现在工作流能更智能地检测代码变更，当仅修改文档、许可证或其他非代码文件时，会自动跳过代码质量检查和测试任务，加快反馈速度并节省资源。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->