### PR TITLE
fix(video): OpenAI 后端 resolution=None 时按 aspect_ratio 兜底 size

### DIFF
--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -36,11 +36,26 @@ _SIZE_MAP: dict[tuple[str, str], str] = {
     ("1024p", "16:9"): "1792x1024",
 }
 
+# resolution=None 时按 aspect_ratio 兜底的最小 size。OpenAI 官方协议下 size 是唯一
+# 传比例的通道，不传则中转聚合（NewAPI / huitongkeji 等）会让各家上游用自己的默认
+# 比例，导致同一项目里输出比例横/方/竖随模型而变。720p 与 NewAPIVideoBackend 的
+# _DEFAULT_SIZE 一致，被所有上游模型接受。
+_FALLBACK_SIZE_BY_ASPECT: dict[str, str] = {
+    "9:16": "720x1280",
+    "16:9": "1280x720",
+}
+
 
 def _resolve_size(resolution: str | None, aspect_ratio: str) -> str | None:
-    """解析 size：None 不传；已知复合 key 映射；未知 → warning 后透传作为 size。"""
+    """解析 size：None → 按 aspect 兜底；已知复合 key 映射；未知 → warning 后透传。"""
     if resolution is None:
-        return None
+        fallback = _FALLBACK_SIZE_BY_ASPECT.get(aspect_ratio)
+        if fallback is None:
+            logger.warning(
+                "OpenAI video: resolution 未配置且 aspect=%r 无兜底，size 字段不传，比例由上游默认决定",
+                aspect_ratio,
+            )
+        return fallback
     mapped = _SIZE_MAP.get((resolution, aspect_ratio))
     if mapped is not None:
         return mapped

--- a/tests/test_openai_video_resolution.py
+++ b/tests/test_openai_video_resolution.py
@@ -1,4 +1,4 @@
-"""测试 OpenAIVideoBackend resolution=None 时不传 size。"""
+"""测试 OpenAIVideoBackend 的 resolution → size 解析。"""
 
 from unittest.mock import MagicMock
 
@@ -17,7 +17,12 @@ def _make_backend():
 
 
 @pytest.mark.asyncio
-async def test_resolution_none_omits_size(tmp_path):
+@pytest.mark.parametrize(
+    "aspect,expected_size",
+    [("9:16", "720x1280"), ("16:9", "1280x720")],
+)
+async def test_resolution_none_falls_back_by_aspect(tmp_path, aspect, expected_size):
+    """resolution 未配置时按 aspect_ratio 兜底 720p size，保证比例不丢。"""
     backend = _make_backend()
     captured: dict = {}
 
@@ -30,7 +35,32 @@ async def test_resolution_none_omits_size(tmp_path):
     req = VideoGenerationRequest(
         prompt="x",
         output_path=tmp_path / "o.mp4",
-        aspect_ratio="9:16",
+        aspect_ratio=aspect,
+        duration_seconds=4,
+        resolution=None,
+    )
+    with pytest.raises(RuntimeError):
+        await backend.generate(req)
+
+    assert captured["size"] == expected_size
+
+
+@pytest.mark.asyncio
+async def test_resolution_none_unknown_aspect_omits_size(tmp_path):
+    """非 9:16 / 16:9 的 aspect_ratio 无兜底时仍不传 size（保留旧行为）。"""
+    backend = _make_backend()
+    captured: dict = {}
+
+    async def fake_create(**kwargs):
+        captured.update(kwargs)
+        raise RuntimeError("stop")
+
+    backend._client.videos.create = fake_create
+
+    req = VideoGenerationRequest(
+        prompt="x",
+        output_path=tmp_path / "o.mp4",
+        aspect_ratio="1:1",
         duration_seconds=4,
         resolution=None,
     )


### PR DESCRIPTION
## Summary
- OpenAI 视频后端在 `resolution=None` 时按 `aspect_ratio` 兜底一个 720p size，避免比例信息被丢弃
- 与 `NewAPIVideoBackend` 现有的 `_DEFAULT_SIZE` 兜底方式对齐；非 9:16/16:9 的 aspect 仍走"不传"路径，并加 warning
- 测试：`test_resolution_none_omits_size` → 参数化 `test_resolution_none_falls_back_by_aspect`，新增 `test_resolution_none_unknown_aspect_omits_size` 保留旧行为

## Background
诊断用户线上日志（684 MB / 1563 次 OpenAI 视频调用）发现只有 1 次带 `size` 字段，其余 1562 次都没传。用户走 OpenAI 兼容中转聚合，把 `grok-video-3-10s` / `viduq2-pro` / `veo_3_1-fast-4K` 等不同厂商模型都委托给 `OpenAIVideoBackend`，自定义供应商里又没设 `resolution`，导致 `_resolve_size(None, aspect) → None → size 不传 → 中转无法翻译比例 → 各上游用自己的默认比例`，最终同一项目的视频"一会横屏、一会方形、一会竖屏"。

PR #402 当年的设计是"不配 resolution 就让 OpenAI 用官方默认 720x1280"，对直连 Sora 是稳定的，但对中转 + 多家上游场景不成立。本 PR 把"丢弃比例"改成"按项目 aspect_ratio 兜底"，更贴近 `NewAPIVideoBackend` 的成熟处理。

## Test plan
- [x] \`uv run python -m pytest tests/test_openai_video_resolution.py tests/test_openai_video_backend.py -v\`（21 passed）
- [x] \`uv run ruff check lib/video_backends/openai.py tests/test_openai_video_resolution.py\`
- [x] \`uv run basedpyright lib/video_backends/openai.py tests/test_openai_video_resolution.py\`（无新增 error）
- [ ] 用户重启部署后用未设 resolution 的 `grok-video-3-10s` 跑一组视频，确认 9:16 项目输出 9:16、16:9 项目输出 16:9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了视频分辨率处理逻辑：当未指定分辨率时，现在会根据视频宽高比自动应用标准尺寸——竖屏（9:16）生成720x1280，横屏（16:9）生成1280x720。未识别的宽高比保持向后兼容。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->