### PR TITLE
chore(ci): dependabot 新增 app-core 分组收编 wouter/zustand/@headlessui

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -128,6 +128,11 @@ updates:
           - "@eslint/*"
           - "typescript-eslint"
           - "globals"
+      app-core:
+        patterns:
+          - "wouter"
+          - "zustand"
+          - "@headlessui/react"
       dev-dependencies:
         dependency-type: "development"
         patterns:


### PR DESCRIPTION
## Summary

- 新建 dependabot frontend `app-core` 分组，覆盖 `wouter`（路由）、`zustand`（状态管理）、`@headlessui/react`（无样式组件）三个核心运行时依赖
- 此前这三者在 `.github/dependabot.yml` 中无匹配分组，全部被 `all-other` 兜底（参见 #636 wouter 升级 PR 的归类）
- 调整后 `all-other` 真正只作为未知新依赖的兜底，与既有「避免核心依赖落入 all-other」原则一致

## Test plan

- [x] `git diff` 仅修改 `.github/dependabot.yml`，新增 5 行 group 定义
- [ ] 合入后下一次 dependabot 周扫（周一）触发，验证后续 wouter / zustand / @headlessui 升级 PR 标题命中 `app-core` group
- [ ] #636 等已开 PR 由 dependabot 自动 rebase 后归入新分组（必要时手动 `@dependabot recreate`）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 优化依赖管理配置，调整了自动化依赖更新的分组策略。

**说明：** 此更改为内部开发工具配置，不影响用户功能体验。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->