### PR TITLE
wip(vidu): adapt reference2video subjects mode

### DIFF
--- a/lib/video_backends/vidu.py
+++ b/lib/video_backends/vidu.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 
 from lib.logging_utils import format_kwargs_for_log
@@ -43,7 +44,9 @@ _MIN_POLL_TIMEOUT_SECONDS = 900.0
 _POLL_TIMEOUT_PER_SECOND = 90.0
 _MAX_REFERENCE_IMAGES = 7
 _PROMPT_MAX_TEXT2VIDEO = 5000
-_PROMPT_MAX_REFERENCE2VIDEO = 2000
+_PROMPT_MAX_REFERENCE_SUBJECTS = 5000
+_PROMPT_MAX_REFERENCE_IMAGES = 2000
+_SUBJECT_TOKEN_RE = re.compile(r"\[图(\d+)]")
 
 # q3 系列模型默认开启音视频直出，q2/q1/2.0 默认静音；audio 仅传 q3 时才生效
 _Q3_MODELS = frozenset(
@@ -55,6 +58,7 @@ _Q3_MODELS = frozenset(
         "viduq3-mix",
     }
 )
+_REFERENCE_SUBJECT_MODELS = frozenset({"viduq3-turbo", "viduq3", "viduq2-pro", "viduq2", "viduq1", "vidu2.0"})
 
 # 按 (model, endpoint) 列出合法 duration —— 文档逐端点列出，差异很大
 _DURATION_RULES: dict[tuple[str, str], list[int]] = {
@@ -82,7 +86,7 @@ _DURATION_RULES: dict[tuple[str, str], list[int]] = {
     ("viduq1", "/start-end2video"): [5],
     ("viduq1-classic", "/start-end2video"): [5],
     ("vidu2.0", "/start-end2video"): [4, 8],
-    # /reference2video (非主体)
+    # /reference2video
     ("viduq3-turbo", "/reference2video"): list(range(3, 17)),
     ("viduq3", "/reference2video"): list(range(3, 17)),
     ("viduq3-mix", "/reference2video"): list(range(3, 17)),
@@ -257,9 +261,9 @@ class ViduVideoBackend:
         # 2) duration 在合法集合内取最近值
         duration = _coerce_duration(self._model, endpoint, request.duration_seconds)
 
-        # 3) prompt 截断（reference2video 上限 2000，其他 5000）
+        # 3) prompt 截断（reference2video 主体调用上限 5000，非主体调用上限 2000）
         prompt = request.prompt or ""
-        prompt_max = _PROMPT_MAX_REFERENCE2VIDEO if endpoint == "/reference2video" else _PROMPT_MAX_TEXT2VIDEO
+        prompt_max = _prompt_max_length(endpoint, self._model)
         if len(prompt) > prompt_max:
             logger.warning("Vidu prompt 长度 %d 超限 %d，截断", len(prompt), prompt_max)
             prompt = prompt[:prompt_max]
@@ -287,13 +291,17 @@ class ViduVideoBackend:
         if endpoint in _ENDPOINTS_WITH_ASPECT_RATIO and request.aspect_ratio:
             body["aspect_ratio"] = request.aspect_ratio
 
-        # 8) images 按端点形态填充
+        # 8) images/subjects 按端点形态填充
         if endpoint == "/reference2video":
             refs = [Path(p) for p in (request.reference_images or []) if p]
             if len(refs) > _MAX_REFERENCE_IMAGES:
                 logger.warning("Vidu 参考图数量 %d 超过上限 %d，截断", len(refs), _MAX_REFERENCE_IMAGES)
                 refs = refs[:_MAX_REFERENCE_IMAGES]
-            body["images"] = [image_to_data_uri(p) for p in refs]
+            if self._model in _REFERENCE_SUBJECT_MODELS:
+                body["subjects"] = _build_subjects(refs)
+                body["prompt"] = _render_subject_prompt(prompt, len(refs))
+            else:
+                body["images"] = [image_to_data_uri(p) for p in refs]
         elif endpoint == "/start-end2video":
             assert request.start_image is not None and request.end_image is not None
             body["images"] = [
@@ -389,3 +397,35 @@ def _coerce_resolution(model: str, requested: str | None) -> str | None:
         )
     fallback = _DEFAULT_RESOLUTION if _DEFAULT_RESOLUTION in whitelist else whitelist[0]
     return fallback
+
+
+def _prompt_max_length(endpoint: str, model: str) -> int:
+    if endpoint != "/reference2video":
+        return _PROMPT_MAX_TEXT2VIDEO
+    if model in _REFERENCE_SUBJECT_MODELS:
+        return _PROMPT_MAX_REFERENCE_SUBJECTS
+    return _PROMPT_MAX_REFERENCE_IMAGES
+
+
+def _build_subjects(refs: list[Path]) -> list[dict[str, object]]:
+    return [
+        {
+            "name": _subject_name(index),
+            "images": [image_to_data_uri(ref)],
+        }
+        for index, ref in enumerate(refs, start=1)
+    ]
+
+
+def _render_subject_prompt(prompt: str, ref_count: int) -> str:
+    def _replace(match: re.Match[str]) -> str:
+        index = int(match.group(1))
+        if 1 <= index <= ref_count:
+            return f"@{_subject_name(index)}"
+        return match.group(0)
+
+    return _SUBJECT_TOKEN_RE.sub(_replace, prompt)
+
+
+def _subject_name(index: int) -> str:
+    return f"subject{index}"

--- a/lib/video_backends/vidu.py
+++ b/lib/video_backends/vidu.py
@@ -266,9 +266,7 @@ class ViduVideoBackend:
         # 3) prompt 截断（reference2video 主体调用上限 5000，非主体调用上限 2000）
         prompt = request.prompt or ""
         prompt_max = _prompt_max_length(endpoint, self._model)
-        if len(prompt) > prompt_max:
-            logger.warning("Vidu prompt 长度 %d 超限 %d，截断", len(prompt), prompt_max)
-            prompt = prompt[:prompt_max]
+        prompt = _truncate_prompt(prompt, prompt_max)
 
         body: dict = {
             "model": self._model,
@@ -301,7 +299,7 @@ class ViduVideoBackend:
                 refs = refs[:_MAX_REFERENCE_IMAGES]
             if self._model in _REFERENCE_SUBJECT_MODELS:
                 body["subjects"] = _build_subjects(refs)
-                body["prompt"] = _render_subject_prompt(prompt, len(refs))
+                body["prompt"] = _truncate_prompt(_render_subject_prompt(prompt, len(refs)), prompt_max)
             else:
                 body["images"] = [image_to_data_uri(p) for p in refs]
         elif endpoint == "/start-end2video":
@@ -399,6 +397,13 @@ def _coerce_resolution(model: str, requested: str | None) -> str | None:
         )
     fallback = _DEFAULT_RESOLUTION if _DEFAULT_RESOLUTION in whitelist else whitelist[0]
     return fallback
+
+
+def _truncate_prompt(prompt: str, prompt_max: int) -> str:
+    if len(prompt) <= prompt_max:
+        return prompt
+    logger.warning("Vidu prompt 长度 %d 超限 %d，截断", len(prompt), prompt_max)
+    return prompt[:prompt_max]
 
 
 def _prompt_max_length(endpoint: str, model: str) -> int:

--- a/lib/video_backends/vidu.py
+++ b/lib/video_backends/vidu.py
@@ -58,7 +58,9 @@ _Q3_MODELS = frozenset(
         "viduq3-mix",
     }
 )
-_REFERENCE_SUBJECT_MODELS = frozenset({"viduq3-turbo", "viduq3", "viduq2-pro", "viduq2", "viduq1", "vidu2.0"})
+# q2-pro 的主体模式有单独的 4 主体 / 视频主体约束；当前 reference_images 兼容层
+# 只承载扁平图片列表，因此继续走原始 images 路径。
+_REFERENCE_SUBJECT_MODELS = frozenset({"viduq3-turbo", "viduq3", "viduq2", "viduq1", "vidu2.0"})
 
 # 按 (model, endpoint) 列出合法 duration —— 文档逐端点列出，差异很大
 _DURATION_RULES: dict[tuple[str, str], list[int]] = {

--- a/lib/vidu_shared.py
+++ b/lib/vidu_shared.py
@@ -94,6 +94,9 @@ def safe_body_for_log(body: dict) -> dict:
     imgs = body.get("images") or []
     if imgs:
         view["images"] = f"<{len(imgs)} data uri>"
+    subjects = body.get("subjects") or []
+    if subjects:
+        view["subjects"] = f"<{len(subjects)} subjects>"
     return view
 
 

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -256,7 +256,9 @@ class TestBuildRequest:
         assert body["prompt"] == "[图1] runs"
 
     @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
-    def test_reference2video_subject_prompt_is_retrimmed_after_rendering(self, _mock, tmp_path: Path, output_path: Path):
+    def test_reference2video_subject_prompt_is_retrimmed_after_rendering(
+        self, _mock, tmp_path: Path, output_path: Path
+    ):
         refs = [tmp_path / f"r{i}.png" for i in range(1, 8)]
         for ref in refs:
             ref.write_bytes(b"x")

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -256,6 +256,27 @@ class TestBuildRequest:
         assert body["prompt"] == "[图1] runs"
 
     @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
+    def test_reference2video_subject_prompt_is_retrimmed_after_rendering(self, _mock, tmp_path: Path, output_path: Path):
+        refs = [tmp_path / f"r{i}.png" for i in range(1, 8)]
+        for ref in refs:
+            ref.write_bytes(b"x")
+
+        prompt = " ".join(f"[图{i}]" for i in range(1, 8)) + " " + ("x" * 4965)
+
+        backend = ViduVideoBackend(api_key="test-key", model="viduq3-turbo")
+        req = VideoGenerationRequest(
+            prompt=prompt,
+            output_path=output_path,
+            reference_images=refs,
+            duration_seconds=5,
+        )
+        _, body = backend._build_request(req)
+
+        assert len(body["prompt"]) == 5000
+        assert body["prompt"].startswith("@subject1 @subject2 @subject3")
+        assert body["prompt"].count("@subject") == 7
+
+    @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
     def test_reference2video_q2_pro_keeps_images_path(self, _mock, tmp_path: Path, output_path: Path):
         refs = [tmp_path / f"r{i}.png" for i in range(5)]
         for ref in refs:

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -216,7 +216,7 @@ class TestBuildRequest:
 
         backend = ViduVideoBackend(api_key="test-key", model="viduq3-turbo")
         req = VideoGenerationRequest(
-            prompt="x",
+            prompt="[图1] meets [图2]",
             output_path=output_path,
             reference_images=[ref1, ref2],
             aspect_ratio="9:16",
@@ -225,11 +225,51 @@ class TestBuildRequest:
         endpoint, body = backend._build_request(req)
 
         assert endpoint == "/reference2video"
-        assert len(body["images"]) == 2
+        assert "images" not in body
+        assert body["subjects"] == [
+            {"name": "subject1", "images": ["data:image/png;base64,XX"]},
+            {"name": "subject2", "images": ["data:image/png;base64,XX"]},
+        ]
+        assert body["prompt"] == "@subject1 meets @subject2"
         # reference2video 接受 aspect_ratio
         assert body["aspect_ratio"] == "9:16"
         # range 3..16，5 透传
         assert body["duration"] == 5
+
+    @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
+    def test_reference2video_q3_mix_keeps_non_subject_images(self, _mock, tmp_path: Path, output_path: Path):
+        ref = tmp_path / "r.png"
+        ref.write_bytes(b"x")
+
+        backend = ViduVideoBackend(api_key="test-key", model="viduq3-mix")
+        req = VideoGenerationRequest(
+            prompt="[图1] runs",
+            output_path=output_path,
+            reference_images=[ref],
+            duration_seconds=5,
+        )
+        endpoint, body = backend._build_request(req)
+
+        assert endpoint == "/reference2video"
+        assert body["images"] == ["data:image/png;base64,XX"]
+        assert "subjects" not in body
+        assert body["prompt"] == "[图1] runs"
+
+    @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
+    def test_reference2video_q3_mix_keeps_non_subject_prompt_limit(self, _mock, tmp_path: Path, output_path: Path):
+        ref = tmp_path / "r.png"
+        ref.write_bytes(b"x")
+
+        backend = ViduVideoBackend(api_key="test-key", model="viduq3-mix")
+        req = VideoGenerationRequest(
+            prompt="x" * 2001,
+            output_path=output_path,
+            reference_images=[ref],
+            duration_seconds=5,
+        )
+        _, body = backend._build_request(req)
+
+        assert len(body["prompt"]) == 2000
 
     def test_reference2video_with_q3_pro_raises_model_mismatch(self, tmp_path: Path, output_path: Path):
         ref = tmp_path / "r.png"

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -256,6 +256,26 @@ class TestBuildRequest:
         assert body["prompt"] == "[图1] runs"
 
     @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
+    def test_reference2video_q2_pro_keeps_images_path(self, _mock, tmp_path: Path, output_path: Path):
+        refs = [tmp_path / f"r{i}.png" for i in range(5)]
+        for ref in refs:
+            ref.write_bytes(b"x")
+
+        backend = ViduVideoBackend(api_key="test-key", model="viduq2-pro")
+        req = VideoGenerationRequest(
+            prompt=" ".join(f"[图{i}]" for i in range(1, 6)),
+            output_path=output_path,
+            reference_images=refs,
+            duration_seconds=5,
+        )
+        endpoint, body = backend._build_request(req)
+
+        assert endpoint == "/reference2video"
+        assert body["images"] == ["data:image/png;base64,XX"] * 5
+        assert "subjects" not in body
+        assert body["prompt"] == "[图1] [图2] [图3] [图4] [图5]"
+
+    @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
     def test_reference2video_q3_mix_keeps_non_subject_prompt_limit(self, _mock, tmp_path: Path, output_path: Path):
         ref = tmp_path / "r.png"
         ref.write_bytes(b"x")


### PR DESCRIPTION
## 范围

本 PR 聚焦 Vidu `reference2video` 请求构造逻辑：

- 修改 `lib/video_backends/vidu.py` 的 reference2video payload 分支逻辑
- 补充 `lib/vidu_shared.py` 的日志脱敏展示
- 补充 `tests/test_vidu_video_backend.py` 的回归测试

明确不动：

- 不改其他 provider 的 video backend
- 不改前端/UI
- 不改任务编排、队列、配置解析和自定义 provider 逻辑

## 变更

- 对支持 subjects 模式的 Vidu 模型（`viduq3-turbo`、`viduq3`、`viduq2-pro`、`viduq2`、`viduq1`、`vidu2.0`），在 `/reference2video` 下改为发送 `subjects`
- 将 prompt 中的 `[图N]` 引用改写为 `@subjectN`，与 `subjects[].name` 对齐
- 保持 `viduq3-mix` 继续走旧的 `images` 形态，不误切到 subjects 模式
- 将 `/reference2video` 的 prompt 长度上限拆分为 subjects 模式 `5000`、非 subjects 模式 `2000`
- 在日志脱敏里补充 `subjects` 摘要，避免输出完整 data URI
- 增加针对 `q3-turbo` / `q3-mix` 两条分支的测试，锁定 payload 结构与 prompt 行为

## 验收清单

- [x] 本地已跑相关测试（说明命令）
  - `.venv/bin/pytest tests/test_vidu_video_backend.py -q`
- [x] 手动验证了改动所声称的行为
  - 直接构造 `ViduVideoBackend._build_request(...)` 验证：
    - `viduq3-turbo` 在 `reference2video` 下产出 `subjects=[{name: subject1...}, ...]`，且 prompt 从 `[图1] meets [图2]` 改写为 `@subject1 meets @subject2`
    - `viduq3-mix` 仍产出 `images=[...]`，且 prompt 保持 `[图1] runs`
- [x] 新增面向用户文案已加 zh/en 翻译（如适用）
  - 本 PR 无新增面向用户文案
- [x] 无新增 ESLint disable；若有，已在本 PR 底部以表格列出 `rule | file:line | 理由`
- [ ] CODEOWNERS 要求的 review 已请求

## 已知 defer

无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新特性**
  * 参考图像流程新增“主体(subject)”模式，可按主体组织引用图并在提示中以主体标记引用。

* **优化改进**
  * 提示截断改为基于端点与模型共同决定；在主体模型下允许更长提示并按主体渲染与截断。
  * 将形如"[图N]"的令牌替换为主体标记以改善引用表达。

* **隐私/日志**
  * 日志对主体字段仅记录数量摘要（如"<N subjects>"）。

* **测试**
  * 新增并扩展多项测试，覆盖不同模型的参考图像行为与截断规则。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->