### PR TITLE
wip(ark): support 4k seedream image sizes

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -193,21 +193,25 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
                 default=True,
+                resolutions=["1K", "2K", "4K"],
             ),
             "doubao-seedream-5-0-260128": ModelInfo(
                 display_name="Seedream 5.0",
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
+                resolutions=["1K", "2K", "4K"],
             ),
             "doubao-seedream-4-5-251128": ModelInfo(
                 display_name="Seedream 4.5",
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
+                resolutions=["1K", "2K", "4K"],
             ),
             "doubao-seedream-4-0-250828": ModelInfo(
                 display_name="Seedream 4.0",
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
+                resolutions=["1K", "2K", "4K"],
             ),
             # --- video ---
             "doubao-seedance-1-5-pro-251215": ModelInfo(
@@ -295,6 +299,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
                 default=True,
+                resolutions=["1K", "2K", "4K"],
             ),
             # --- video ---
             "doubao-seedance-1.5-pro": ModelInfo(

--- a/lib/image_backends/ark.py
+++ b/lib/image_backends/ark.py
@@ -37,6 +37,16 @@ _SEEDREAM_2K_SIZE_MAP: dict[str, str] = {
     "2:3": "1664x2496",
     "21:9": "3136x1344",
 }
+_SEEDREAM_4K_SIZE_MAP: dict[str, str] = {
+    "1:1": "4096x4096",
+    "4:3": "4704x3520",
+    "3:4": "3520x4704",
+    "16:9": "5504x3040",
+    "9:16": "3040x5504",
+    "3:2": "4992x3328",
+    "2:3": "3328x4992",
+    "21:9": "6240x2656",
+}
 _SEEDREAM_1K_SIZE_MAP: dict[str, str] = {
     "1:1": "1024x1024",
     "4:3": "1152x864",
@@ -49,13 +59,16 @@ _SEEDREAM_1K_SIZE_MAP: dict[str, str] = {
 }
 
 
-def _resolve_seedream_size(model_id: str, aspect_ratio: str) -> str:
-    """按模型族选尺寸表；未识别比例时回退到分辨率 keyword（方式 1，由模型按 prompt 自适应）。"""
+def _resolve_seedream_size(model_id: str, aspect_ratio: str, image_size: str | None = None) -> str:
+    """按模型族和期望分辨率选尺寸表；未识别比例时回退到 resolution keyword。"""
     mid = (model_id or "").lower()
     if "seedream-3" in mid:
         size = _SEEDREAM_1K_SIZE_MAP.get(aspect_ratio)
         return size or "1K"
     # 默认按 4.x/5.x 处理（含 lite 与未来兼容版本）
+    if image_size == "4K":
+        size = _SEEDREAM_4K_SIZE_MAP.get(aspect_ratio)
+        return size or "4K"
     size = _SEEDREAM_2K_SIZE_MAP.get(aspect_ratio)
     return size or "2K"
 
@@ -101,9 +114,13 @@ class ArkImageBackend:
         }
 
         # Seedream 不显式传 size 时默认输出 1:1（4.x/5.x: 2048x2048；3.0-t2i: 1024x1024），
-        # 项目设置的 aspect_ratio 会被静默忽略。优先使用 caller 显式传入的 image_size
-        # （如 grid 路径会传 "2K"/"4K"），否则按官方推荐表从 aspect_ratio 推导宽高。
-        kwargs["size"] = request.image_size or _resolve_seedream_size(self._model, request.aspect_ratio)
+        # 项目设置的 aspect_ratio 会被静默忽略。对 4.x/5.x 的 4K 请求也需要映射成显式宽高，
+        # 否则上游把 "4K" 原样透传时，模型会更倾向生成超宽拼板；其余显式 image_size 维持透传。
+        kwargs["size"] = (
+            _resolve_seedream_size(self._model, request.aspect_ratio, request.image_size)
+            if request.image_size == "4K"
+            else request.image_size or _resolve_seedream_size(self._model, request.aspect_ratio)
+        )
 
         # I2I: 读取参考图并转为 base64 data URI
         if request.reference_images:

--- a/tests/test_image_backends/test_ark.py
+++ b/tests/test_image_backends/test_ark.py
@@ -239,7 +239,9 @@ class TestArkImageBackendGenerate:
                 image_size="4K",
             )
             await backend.generate(request)
-            assert client.images.generate.call_args.kwargs["size"] == expected, f"4K + aspect_ratio={ar} 应映射到 {expected}"
+            assert client.images.generate.call_args.kwargs["size"] == expected, (
+                f"4K + aspect_ratio={ar} 应映射到 {expected}"
+            )
 
     async def test_i2i_single_ref(self, backend_and_client, tmp_path: Path):
         backend, client = backend_and_client

--- a/tests/test_image_backends/test_ark.py
+++ b/tests/test_image_backends/test_ark.py
@@ -243,6 +243,21 @@ class TestArkImageBackendGenerate:
                 f"4K + aspect_ratio={ar} 应映射到 {expected}"
             )
 
+    async def test_explicit_4k_size_falls_back_to_4k_for_unknown_aspect_ratio(self, backend_and_client, tmp_path: Path):
+        """4.x/5.x 的 4K 请求遇到未识别比例时必须回退到 '4K'，不能错误降级到 '2K'。"""
+        backend, client = backend_and_client
+
+        request = ImageGenerationRequest(
+            prompt="x",
+            output_path=tmp_path / "4k-unknown.png",
+            aspect_ratio="weird",
+            image_size="4K",
+        )
+
+        await backend.generate(request)
+
+        assert client.images.generate.call_args.kwargs["size"] == "4K"
+
     async def test_i2i_single_ref(self, backend_and_client, tmp_path: Path):
         backend, client = backend_and_client
 

--- a/tests/test_image_backends/test_ark.py
+++ b/tests/test_image_backends/test_ark.py
@@ -222,6 +222,25 @@ class TestArkImageBackendGenerate:
         await backend.generate(request)
         assert client.images.generate.call_args.kwargs["size"] == "2K"
 
+    async def test_explicit_4k_size_maps_from_aspect_ratio(self, backend_and_client, tmp_path: Path):
+        """4.x/5.x 显式传 4K 时也必须按比例映射到明确像素宽高，避免直接透传 4K 丢掉构图约束。"""
+        backend, client = backend_and_client
+
+        cases = [
+            ("16:9", "5504x3040"),
+            ("9:16", "3040x5504"),
+            ("1:1", "4096x4096"),
+        ]
+        for i, (ar, expected) in enumerate(cases):
+            request = ImageGenerationRequest(
+                prompt="x",
+                output_path=tmp_path / f"4k-{i}.png",
+                aspect_ratio=ar,
+                image_size="4K",
+            )
+            await backend.generate(request)
+            assert client.images.generate.call_args.kwargs["size"] == expected, f"4K + aspect_ratio={ar} 应映射到 {expected}"
+
     async def test_i2i_single_ref(self, backend_and_client, tmp_path: Path):
         backend, client = backend_and_client
 

--- a/tests/test_registry_resolutions.py
+++ b/tests/test_registry_resolutions.py
@@ -10,11 +10,10 @@ def test_model_info_has_resolutions_default_empty_list():
 
 def test_all_image_video_models_have_resolutions_populated():
     missing: list[str] = []
-    ark_provider_ids = {"ark", "ark-agent-plan"}
     for pid, meta in PROVIDER_REGISTRY.items():
         for mid, minfo in meta.models.items():
             if minfo.media_type in ("image", "video"):
-                if not minfo.resolutions and not (pid in ark_provider_ids and mid.startswith("doubao-seedream")):
+                if not minfo.resolutions:
                     missing.append(f"{pid}/{mid}")
     assert missing == [], f"以下 image/video 模型缺少 resolutions: {missing}"
 
@@ -26,10 +25,10 @@ def test_text_models_have_empty_resolutions():
                 assert minfo.resolutions == [], f"{pid}/{mid}: text 模型不应声明 resolutions"
 
 
-def test_ark_seedream_image_resolutions_empty():
-    """Ark Seedream 当前不传分辨率，留空 → UI 不展示下拉。"""
+def test_ark_seedream_image_resolutions_include_4k():
+    """Ark Seedream 图片模型声明 4K，供 UI 保存到 model_settings 后显式透传。"""
     for pid in ("ark", "ark-agent-plan"):
         meta = PROVIDER_REGISTRY[pid]
         for mid, minfo in meta.models.items():
             if minfo.media_type == "image":
-                assert minfo.resolutions == [], f"{pid}/{mid}: Ark Seedream 应留空"
+                assert "4K" in minfo.resolutions, f"{pid}/{mid}: Ark Seedream 应支持 4K"


### PR DESCRIPTION
## 范围

本 PR 聚焦 Ark Seedream 图片分辨率支持：

- 扩展 Ark provider registry 的 Seedream 模型分辨率声明，补上 `4K`
- 为 Ark 图片后端补充 4K 场景下的显式 size 映射
- 补充 Ark backend 与 registry resolution 的回归测试

明确不动：

- 不改其他 provider 的 image backend
- 不改前端/UI
- 不改任务编排、配置页或模型选择流程

## 变更

- 为 Ark 的 Seedream 4.0 / 4.5 / 5.0 / 5.0 Lite 模型补充 `4K` resolution 声明
- 在 Ark 后端新增 4K 尺寸映射表，使 `4K` 请求按 aspect ratio 落到显式像素尺寸，而不是原样透传
- 保持 Seedream 3 系列继续走 1K 映射，4.x / 5.x 默认仍走 2K 映射；仅在显式请求 `4K` 时切到 4K size map
- 增加针对 Ark 4K resolution 暴露和 4K size 映射的测试覆盖

## 验收清单

- [x] 本地已跑相关测试（说明命令）：`.venv/bin/pytest tests/test_image_backends/test_ark.py tests/test_registry_resolutions.py -q`
- [x] 手动验证了改动所声称的行为：确认 Ark model resolutions 包含 `['1K', '2K', '4K']`，且 `4K` 在 `16:9 / 9:16 / 1:1` 下分别映射到 `5504x3040 / 3040x5504 / 4096x4096`
- [x] 新增面向用户文案已加 zh/en 翻译（如适用）：本 PR 无新增面向用户文案
- [x] 无新增 ESLint disable；若有，已在本 PR 底部以表格列出 `rule | file:line | 理由`
- [ ] CODEOWNERS 要求的 review 已请求

## 已知 defer

无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为火山方舟图片生成新增 4K 选项：在不同宽高比下映射为具体像素尺寸，提升 4K 输出的准确性与可控性。
* **文档/配置**
  * 补全若干图片模型的分辨率声明，公开并透传 1K/2K/4K 选项以供 UI 使用。
* **测试**
  * 新增/更新用例，验证 4K 映射逻辑与模型分辨率声明的行为与界面预期一致。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->