### PR TITLE
fix(grid): 分组超过 9 个分镜时宫格预览不显示

### DIFF
--- a/frontend/src/components/canvas/grid/GridPreviewView.tsx
+++ b/frontend/src/components/canvas/grid/GridPreviewView.tsx
@@ -3,7 +3,7 @@ import { Loader2, Sparkles } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
-import { groupBySegmentBreak, computeGridSize } from "@/utils/grid-layout";
+import { groupBySegmentBreak, computeGridSize, matchGridsForGroup } from "@/utils/grid-layout";
 import { GridPreviewPanel } from "@/components/canvas/timeline/GridPreviewPanel";
 import type { GridGeneration } from "@/types/grid";
 import type { NarrationSegment, DramaScene } from "@/types";
@@ -62,26 +62,12 @@ export function GridPreviewView({
   }, [refreshGrids, gridsRevision]);
 
   const getGridIdsForGroup = useCallback(
-    (groupSegs: Segment[]): string[] => {
-      const idSet = new Set(groupSegs.map((s) => getSegmentId(s, contentMode)));
-      const matched = grids.filter(
-        (g) =>
-          g.episode === episode &&
-          g.scene_ids.length === idSet.size &&
-          g.scene_ids.every((id) => idSet.has(id)),
-      );
-      const byKey = new Map<string, (typeof matched)[number]>();
-      for (const g of matched) {
-        const key = [...g.scene_ids].sort().join(",");
-        const existing = byKey.get(key);
-        if (!existing || g.created_at > existing.created_at) {
-          byKey.set(key, g);
-        }
-      }
-      return Array.from(byKey.values())
-        .sort((a, b) => a.created_at.localeCompare(b.created_at))
-        .map((g) => g.id);
-    },
+    (groupSegs: Segment[]): string[] =>
+      matchGridsForGroup(
+        grids,
+        groupSegs.map((s) => getSegmentId(s, contentMode)),
+        episode,
+      ).map((g) => g.id),
     [grids, episode, contentMode],
   );
 
@@ -109,14 +95,16 @@ export function GridPreviewView({
     const batches = groups.length;
     const cells = segments.length;
     const readyBatches = groups.filter((group) => {
-      const ids = new Set(group.map((s) => getSegmentId(s, contentMode)));
-      return grids.some(
-        (g) =>
-          g.episode === episode &&
-          g.status === "completed" &&
-          g.scene_ids.length === ids.size &&
-          g.scene_ids.every((id) => ids.has(id)),
-      );
+      const sceneIds = group.map((s) => getSegmentId(s, contentMode));
+      // chunk 拆分后,group 内可能有多条 grid;全部 completed 且并集覆盖整组才算就绪。
+      const groupGrids = matchGridsForGroup(grids, sceneIds, episode);
+      if (groupGrids.length === 0) return false;
+      const covered = new Set<string>();
+      for (const g of groupGrids) {
+        if (g.status !== "completed") return false;
+        for (const id of g.scene_ids) covered.add(id);
+      }
+      return covered.size === sceneIds.length;
     }).length;
     const percent = batches > 0 ? Math.round((readyBatches / batches) * 100) : 0;
     return { batches, cells, percent };

--- a/frontend/src/components/canvas/grid/GridPreviewView.tsx
+++ b/frontend/src/components/canvas/grid/GridPreviewView.tsx
@@ -104,7 +104,7 @@ export function GridPreviewView({
         if (g.status !== "completed") return false;
         for (const id of g.scene_ids) covered.add(id);
       }
-      return covered.size === sceneIds.length;
+      return sceneIds.every((id) => covered.has(id));
     }).length;
     const percent = batches > 0 ? Math.round((readyBatches / batches) * 100) : 0;
     return { batches, cells, percent };

--- a/frontend/src/utils/grid-layout.test.ts
+++ b/frontend/src/utils/grid-layout.test.ts
@@ -76,4 +76,17 @@ describe("matchGridsForGroup", () => {
     const result = matchGridsForGroup(grids, ["s1", "s2"], 1);
     expect(result).toEqual([]);
   });
+
+  it("filters out obsolete overlapping grids covered by newer generations", () => {
+    // 用户调整 segment_break 后,旧 chunk 仍在表里但不再属于当前布局。
+    // 贪心覆盖按 created_at 降序,只保留贡献新 scene_id 的 grid。
+    const grids = [
+      grid("obsolete_subset", ["s1", "s2"], "2026-05-01T00:00:00Z"),
+      grid("obsolete_superset", ["s1", "s2", "s3", "s4", "s5"], "2026-05-01T00:00:01Z"),
+      grid("new_chunk_1", ["s1", "s2", "s3"], "2026-05-02T00:00:00Z"),
+      grid("new_chunk_2", ["s4", "s5"], "2026-05-02T00:00:01Z"),
+    ];
+    const result = matchGridsForGroup(grids, ["s1", "s2", "s3", "s4", "s5"], 1);
+    expect(result.map((g) => g.id)).toEqual(["new_chunk_1", "new_chunk_2"]);
+  });
 });

--- a/frontend/src/utils/grid-layout.test.ts
+++ b/frontend/src/utils/grid-layout.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { matchGridsForGroup } from "./grid-layout";
+
+interface FakeGrid {
+  id: string;
+  episode: number;
+  scene_ids: string[];
+  created_at: string;
+}
+
+function grid(
+  id: string,
+  scene_ids: string[],
+  created_at: string,
+  episode = 1,
+): FakeGrid {
+  return { id, episode, scene_ids, created_at };
+}
+
+describe("matchGridsForGroup", () => {
+  it("matches a single grid covering the whole group exactly", () => {
+    const grids = [grid("g1", ["s1", "s2", "s3"], "2026-05-01T00:00:00Z")];
+    const result = matchGridsForGroup(grids, ["s1", "s2", "s3"], 1);
+    expect(result.map((g) => g.id)).toEqual(["g1"]);
+  });
+
+  it("matches multiple chunk grids when group exceeds cell_count (regression: 14-scene group → grid_9 + grid_4)", () => {
+    const big = Array.from({ length: 14 }, (_, i) => `s${i + 1}`);
+    const grids = [
+      grid("g9", big.slice(0, 9), "2026-05-01T00:00:00Z"),
+      grid("g4", big.slice(9), "2026-05-01T00:00:01Z"),
+    ];
+    const result = matchGridsForGroup(grids, big, 1);
+    expect(result.map((g) => g.id)).toEqual(["g9", "g4"]);
+  });
+
+  it("ignores grids belonging to a different episode", () => {
+    const grids = [
+      grid("g1", ["s1", "s2"], "2026-05-01T00:00:00Z", 1),
+      grid("g2", ["s1", "s2"], "2026-05-01T00:00:00Z", 2),
+    ];
+    const result = matchGridsForGroup(grids, ["s1", "s2"], 1);
+    expect(result.map((g) => g.id)).toEqual(["g1"]);
+  });
+
+  it("ignores grids whose scene_ids contain ids outside the group", () => {
+    const grids = [
+      grid("g1", ["s1", "s2"], "2026-05-01T00:00:00Z"),
+      grid("g_other", ["s1", "s99"], "2026-05-01T00:00:01Z"),
+    ];
+    const result = matchGridsForGroup(grids, ["s1", "s2"], 1);
+    expect(result.map((g) => g.id)).toEqual(["g1"]);
+  });
+
+  it("dedupes regenerations by scene_ids set, keeping latest created_at", () => {
+    const grids = [
+      grid("old", ["s1", "s2"], "2026-05-01T00:00:00Z"),
+      grid("new", ["s1", "s2"], "2026-05-02T00:00:00Z"),
+    ];
+    const result = matchGridsForGroup(grids, ["s1", "s2"], 1);
+    expect(result.map((g) => g.id)).toEqual(["new"]);
+  });
+
+  it("returns chunks ordered by created_at ascending", () => {
+    const big = Array.from({ length: 14 }, (_, i) => `s${i + 1}`);
+    const grids = [
+      grid("late", big.slice(9), "2026-05-01T00:00:05Z"),
+      grid("early", big.slice(0, 9), "2026-05-01T00:00:00Z"),
+    ];
+    const result = matchGridsForGroup(grids, big, 1);
+    expect(result.map((g) => g.id)).toEqual(["early", "late"]);
+  });
+
+  it("returns empty for unrelated grids", () => {
+    const grids = [grid("g1", ["x1"], "2026-05-01T00:00:00Z")];
+    const result = matchGridsForGroup(grids, ["s1", "s2"], 1);
+    expect(result).toEqual([]);
+  });
+});

--- a/frontend/src/utils/grid-layout.ts
+++ b/frontend/src/utils/grid-layout.ts
@@ -16,7 +16,10 @@ interface GridMatchRecord {
 /**
  * 后端会把超过 layout.cell_count(最多 9)的 group 拆成多个 chunk,
  * 每条 grid 记录的 scene_ids 是 group 的子集。匹配时按子集判断,
- * 同一组 scene_ids 取 created_at 最新的一条,再按 created_at 升序返回。
+ * 再按 created_at 降序贪心覆盖:只保留贡献新 scene_id 的 grid,
+ * 过滤掉被新生成覆盖的旧 chunk(用户调整 segment_break 后未重新生成时,
+ * 旧 chunk 仍在 grids 表里但已不属于当前布局)。
+ * 返回时按 created_at 升序,保证 batch pills 显示顺序稳定。
  */
 export function matchGridsForGroup<G extends GridMatchRecord>(
   grids: G[],
@@ -30,17 +33,22 @@ export function matchGridsForGroup<G extends GridMatchRecord>(
       g.scene_ids.length > 0 &&
       g.scene_ids.every((id) => idSet.has(id)),
   );
-  const byKey = new Map<string, G>();
-  for (const g of matched) {
-    const key = [...g.scene_ids].sort().join(",");
-    const existing = byKey.get(key);
-    if (!existing || g.created_at > existing.created_at) {
-      byKey.set(key, g);
+
+  const sorted = [...matched].sort((a, b) =>
+    b.created_at.localeCompare(a.created_at),
+  );
+
+  const selected: G[] = [];
+  const covered = new Set<string>();
+  for (const g of sorted) {
+    const hasUncovered = g.scene_ids.some((id) => !covered.has(id));
+    if (hasUncovered) {
+      selected.push(g);
+      for (const id of g.scene_ids) covered.add(id);
     }
   }
-  return Array.from(byKey.values()).sort((a, b) =>
-    a.created_at.localeCompare(b.created_at),
-  );
+
+  return selected.sort((a, b) => a.created_at.localeCompare(b.created_at));
 }
 
 export function groupBySegmentBreak<S extends { segment_break?: boolean }>(

--- a/frontend/src/utils/grid-layout.ts
+++ b/frontend/src/utils/grid-layout.ts
@@ -6,6 +6,43 @@ export interface GridLayout {
   batchCount: number;
 }
 
+interface GridMatchRecord {
+  id: string;
+  episode: number;
+  scene_ids: string[];
+  created_at: string;
+}
+
+/**
+ * 后端会把超过 layout.cell_count(最多 9)的 group 拆成多个 chunk,
+ * 每条 grid 记录的 scene_ids 是 group 的子集。匹配时按子集判断,
+ * 同一组 scene_ids 取 created_at 最新的一条,再按 created_at 升序返回。
+ */
+export function matchGridsForGroup<G extends GridMatchRecord>(
+  grids: G[],
+  groupSceneIds: Iterable<string>,
+  episode: number,
+): G[] {
+  const idSet = new Set(groupSceneIds);
+  const matched = grids.filter(
+    (g) =>
+      g.episode === episode &&
+      g.scene_ids.length > 0 &&
+      g.scene_ids.every((id) => idSet.has(id)),
+  );
+  const byKey = new Map<string, G>();
+  for (const g of matched) {
+    const key = [...g.scene_ids].sort().join(",");
+    const existing = byKey.get(key);
+    if (!existing || g.created_at > existing.created_at) {
+      byKey.set(key, g);
+    }
+  }
+  return Array.from(byKey.values()).sort((a, b) =>
+    a.created_at.localeCompare(b.created_at),
+  );
+}
+
 export function groupBySegmentBreak<S extends { segment_break?: boolean }>(
   segments: S[],
 ): S[][] {


### PR DESCRIPTION
## Summary
- 前端 `GridPreviewView` 改为子集匹配,修复 group >9 scene 时宫格 Tab 显示"尚未生成"的 bug(后端把组拆成多条 chunk grid,前端等长精确匹配撞不上)
- 抽出纯函数 `matchGridsForGroup` 到 `frontend/src/utils/grid-layout.ts`,`stats.readyBatches` 改为"所有 chunk 都 completed 且并集覆盖整组"
- 新增 7 个回归 case(`grid-layout.test.ts`),含 14-scene 组 → grid_9 + grid_4 两条 chunk 都被返回的关键场景

## Test plan
- [x] `pnpm vitest run src/utils/grid-layout.test.ts` 7/7 通过
- [x] `pnpm check`(typecheck + lint + 全量 598 tests)绿
- [ ] 手动:启动 dev server,打开出问题的 EP·02(14 片段)宫格 Tab,确认:
  - 顶部不再"0% 就绪"
  - batch 卡片内 `GridPreviewPanel` 顶部出现 2 个 batch pill,可切换两张合成图

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进网格就绪判定：不再仅依赖单条网格精确匹配，支持多条网格联合覆盖判断，提升就绪判断的准确性与鲁棒性。

* **New Features**
  * 引入基于覆盖与时间优先的网格匹配策略，允许将组内场景拆分为多个网格片段并按时间顺序组合展示。

* **Tests**
  * 新增网格匹配单元测试，覆盖分片、去重、时间优先、跨话集过滤和边界场景验证。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->