### PR TITLE
fix(tasks): 任务恢复防双扣费 + 调度器加固（#647 + 代码审查 15 项收敛）

### DIFF
--- a/frontend/src/components/task-hud/__tests__/TaskHud.cascade.test.tsx
+++ b/frontend/src/components/task-hud/__tests__/TaskHud.cascade.test.tsx
@@ -22,14 +22,20 @@ function HostedTaskHud() {
 
 function resetStores() {
   useAppStore.setState({ taskHudOpen: true });
-  useTasksStore.setState({ tasks: [], stats: { total: 0 } });
+  useTasksStore.setState({
+    tasks: [],
+    stats: { queued: 0, running: 0, cancelling: 0, succeeded: 0, failed: 0, cancelled: 0, total: 0 },
+  });
 }
 
 describe("TaskHud cascade label", () => {
   afterEach(() => {
     cleanup();
     useAppStore.setState({ taskHudOpen: false });
-    useTasksStore.setState({ tasks: [], stats: { total: 0 } });
+    useTasksStore.setState({
+    tasks: [],
+    stats: { queued: 0, running: 0, cancelling: 0, succeeded: 0, failed: 0, cancelled: 0, total: 0 },
+  });
   });
 
   it("renders cascade label when cancelled_by === 'cascade'", async () => {

--- a/frontend/src/components/task-hud/__tests__/TaskHud.cascade.test.tsx
+++ b/frontend/src/components/task-hud/__tests__/TaskHud.cascade.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useRef } from "react";
+import { TaskHud } from "@/components/task-hud/TaskHud";
+import { useAppStore } from "@/stores/app-store";
+import { useTasksStore } from "@/stores/tasks-store";
+import { makeTask } from "@/test/factories";
+import i18n from "@/i18n";
+
+// 前端 finding #12 回归：cascade 取消的 task 在 HUD 渲染 cascade_label，
+// user 取消的不渲染。验证 SSE 携带的 cancelled_by 字段在前端被正确分流。
+
+function HostedTaskHud() {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  return (
+    <div>
+      <div ref={anchorRef} data-testid="anchor" />
+      <TaskHud anchorRef={anchorRef} />
+    </div>
+  );
+}
+
+function resetStores() {
+  useAppStore.setState({ taskHudOpen: true });
+  useTasksStore.setState({ tasks: [], stats: { total: 0 } });
+}
+
+describe("TaskHud cascade label", () => {
+  afterEach(() => {
+    cleanup();
+    useAppStore.setState({ taskHudOpen: false });
+    useTasksStore.setState({ tasks: [], stats: { total: 0 } });
+  });
+
+  it("renders cascade label when cancelled_by === 'cascade'", async () => {
+    await i18n.changeLanguage("zh");
+    resetStores();
+    useTasksStore.setState({
+      tasks: [
+        makeTask({
+          task_id: "cascade-1",
+          status: "cancelled",
+          cancelled_by: "cascade",
+          task_type: "video",
+          media_type: "video",
+        }),
+      ],
+    });
+
+    render(<HostedTaskHud />);
+    const labels = await screen.findAllByText("级联");
+    expect(labels.length).toBeGreaterThan(0);
+  });
+
+  it("does not render cascade label for user cancel", async () => {
+    await i18n.changeLanguage("zh");
+    resetStores();
+    useTasksStore.setState({
+      tasks: [
+        makeTask({
+          task_id: "user-1",
+          status: "cancelled",
+          cancelled_by: "user",
+          task_type: "video",
+          media_type: "video",
+        }),
+      ],
+    });
+
+    render(<HostedTaskHud />);
+    expect(screen.queryByText("级联")).toBeNull();
+  });
+
+  it("renders English cascade label after locale switch", async () => {
+    await i18n.changeLanguage("en");
+    resetStores();
+    useTasksStore.setState({
+      tasks: [
+        makeTask({
+          task_id: "cascade-en",
+          status: "cancelled",
+          cancelled_by: "cascade",
+          task_type: "video",
+          media_type: "video",
+        }),
+      ],
+    });
+
+    render(<HostedTaskHud />);
+    const labels = await screen.findAllByText("cascaded");
+    expect(labels.length).toBeGreaterThan(0);
+    await i18n.changeLanguage("zh");
+  });
+});

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -441,10 +441,13 @@ class TaskRepository(BaseRepository):
     async def cancel_task(self, task_id: str) -> dict[str, Any]:
         """按状态分发取消（ADR 0006）：
 
-        - ``queued`` → ``mark_cancelled('user')`` 直接终态
-        - ``running`` → ``mark_cancelling()`` 中间态，等待 worker finally 兜底
-        - ``cancelling`` → 幂等（视为已取消，不重复发信号）
-        - 终态（succeeded/failed/cancelled）→ skipped_terminal
+        - ``queued`` → ``mark_cancelled('user')`` 直接终态，``_mark_cancelled`` 内部
+          ``cascade=True`` 自动级联（含 grandchildren）；
+        - ``running`` → ``mark_cancelling()`` 中间态，等待 worker finally 兜底；
+          下游级联由该 task 的 ``finalize_cancelled`` 兜底触发，避免在 running 还未
+          实际终止时就把下游 queued 永久 cancelled。
+        - ``cancelling`` → 幂等（视为已取消，不重复发信号）；
+        - 终态（succeeded/failed/cancelled）→ skipped_terminal。
 
         Repository 只更新 DB，不持有 worker callback。``cancelling`` 列表交由
         上层（GenerationQueue）拿到后同步分发 in-process cancel 信号。
@@ -458,10 +461,13 @@ class TaskRepository(BaseRepository):
         cancelling: list[str] = []
         skipped_terminal: list[dict[str, Any]] = []
 
+        # 顶层 dispatch：若 task 是 queued，_dispatch_cancel → _mark_cancelled(cascade=True)
+        # 会自动递归级联下游（含 grandchildren）；若 task 是 running，仅落 cancelling，
+        # 下游 cascade 等 finalize_cancelled 时再触发——这样避免「running 父尚未终止，
+        # 下游 queued 已永久 cancelled」的语义错误。
         await self._dispatch_cancel(
             task, cancelled_by="user", cancelled=cancelled, cancelling=cancelling, skipped_terminal=skipped_terminal
         )
-        await self._cascade_cancel_dependents(task_id, cancelled, cancelling, skipped_terminal)
 
         await self.session.commit()
         return {
@@ -484,12 +490,22 @@ class TaskRepository(BaseRepository):
         cancelled_by 在 queued 和 running 两条路径都用同一个值，统一归因。
         running 路径写入 cancelling 中间态时即记录 cancelled_by，worker finally
         通过 COALESCE 保留这个值。
+
+        queued 路径调 ``_mark_cancelled(cascade=True, ...)``——同一组 list 引用向下传，
+        `_mark_cancelled` 内部递归触发后 grandchildren 自动累计到顶层响应体。
         """
         status = task.status
         if status == "queued":
-            data = await self._mark_cancelled(task.task_id, cancelled_by=cancelled_by)
-            if data:
-                cancelled.append(data)
+            # `_mark_cancelled` 内部会在 cascade 前把自身 task_data append 到 cancelled
+            # 列表（语义：先记录自己再级联下游），caller 拿返回值仅作 None 判定。
+            await self._mark_cancelled(
+                task.task_id,
+                cancelled_by=cancelled_by,
+                cancelled=cancelled,
+                cancelling=cancelling,
+                skipped_terminal=skipped_terminal,
+                cascade=True,
+            )
         elif status == "running":
             affected = await self._mark_cancelling(task.task_id, cancelled_by=cancelled_by)
             if affected > 0:
@@ -510,7 +526,16 @@ class TaskRepository(BaseRepository):
             # succeeded / failed / cancelled —— 终态
             skipped_terminal.append(_task_to_dict(task))
 
-    async def _mark_cancelled(self, task_id: str, *, cancelled_by: str) -> dict[str, Any] | None:
+    async def _mark_cancelled(
+        self,
+        task_id: str,
+        *,
+        cancelled_by: str,
+        cancelled: list[dict[str, Any]] | None = None,
+        cancelling: list[str] | None = None,
+        skipped_terminal: list[dict[str, Any]] | None = None,
+        cascade: bool = True,
+    ) -> dict[str, Any] | None:
         """将 queued / cancelling / running 任务标记为 cancelled（终态）。
 
         WHERE 守卫 ``status IN ('queued','cancelling','running')`` 承担三条路径：
@@ -523,6 +548,11 @@ class TaskRepository(BaseRepository):
 
         cancelled_by 用 COALESCE 写入：上游 _mark_cancelling 已写过的（cascade 等）保留，
         没写过的（直接 running→cancelled 兜底）用 caller 提供的值兜底，避免级联归因丢失。
+
+        cascade=True（默认）：UPDATE 成功后内部触发 _cascade_cancel_dependents 向下递归，
+        让 cancel_task 顶层响应体能收集到 grandchildren；递归通过 ``cancelled`` / ``cancelling``
+        / ``skipped_terminal`` 三个 list 引用一起向下传。caller 不传 list 时用空 list 兜底
+        （finalize_cancelled 等不需要响应体的 caller 走这条路径）。
         """
         now = utc_now()
         stmt = (
@@ -550,6 +580,19 @@ class TaskRepository(BaseRepository):
             status="cancelled",
             data=task_data,
         )
+
+        # 先把自身入 cancelled 列表，再级联——保证 cancel_task 响应体里父先于子。
+        # caller 不传 list（finalize_cancelled）时跳过。
+        if cancelled is not None:
+            cancelled.append(task_data)
+
+        if cascade:
+            await self._cascade_cancel_dependents(
+                task_id,
+                cancelled if cancelled is not None else [],
+                cancelling if cancelling is not None else [],
+                skipped_terminal if skipped_terminal is not None else [],
+            )
         return task_data
 
     async def _mark_cancelling(self, task_id: str, *, cancelled_by: str = "user") -> int:
@@ -589,13 +632,17 @@ class TaskRepository(BaseRepository):
         cancelling: list[str],
         skipped_terminal: list[dict[str, Any]],
     ) -> None:
-        """递归级联取消下游：queued → cancelled('cascade')；running → cancelling；其他幂等/跳过。"""
+        """级联取消下游 dependents（仅遍历直接下游 + 派发）。
+
+        递归由 ``_mark_cancelled`` 内部驱动：``_dispatch_cancel`` 调
+        ``_mark_cancelled(cascade=True, ...)`` 让其在 rows>0 后自动调本函数处理
+        grandchildren——即使下游 task 是 running（落 cancelling、不在本帧级联），
+        其 worker finally 走 ``finalize_cancelled`` 时仍会触发对它自己下游的级联。
+        """
         result = await self.session.execute(
             select(Task).where(Task.dependency_task_id == task_id).order_by(Task.queued_at.asc())
         )
         for dep_task in result.scalars().all():
-            before_cancelled = len(cancelled)
-            before_cancelling = len(cancelling)
             await self._dispatch_cancel(
                 dep_task,
                 cancelled_by="cascade",
@@ -603,10 +650,6 @@ class TaskRepository(BaseRepository):
                 cancelling=cancelling,
                 skipped_terminal=skipped_terminal,
             )
-            # 仅在 queued → cancelled 这条路径递归向下（cancelling 下游运行期不递归
-            # 以避免预先级联未确定的依赖；worker finally 落地 cancelled 后由依赖检查路径处理）
-            if len(cancelled) > before_cancelled and len(cancelling) == before_cancelling:
-                await self._cascade_cancel_dependents(dep_task.task_id, cancelled, cancelling, skipped_terminal)
 
     async def persist_provider_job_id(self, task_id: str, job_id: str) -> None:
         """单独事务持久化 provider_job_id；不带 WHERE 状态守卫（worker 内调用，确定是 running）。
@@ -635,9 +678,13 @@ class TaskRepository(BaseRepository):
         - mark_succeeded/mark_failed 返回 0 rows（外部已抢先翻 cancelling）后兜底；
         - SIGTERM / 进程外 cancel 直接打到 running，没有走过 cancel API 的也能落地。
 
+        ``cascade=True``：本 task 终态落地后，``_mark_cancelled`` 内部触发下游级联——
+        覆盖「父 running 还在 cancelling，下游 queued 暂未级联，等父 worker finally
+        落 cancelled 时再统一级联下游」这条主路径。caller 不消费 list，传 None 兜底。
+
         独立 commit，返回受影响行数。
         """
-        data = await self._mark_cancelled(task_id, cancelled_by=cancelled_by)
+        data = await self._mark_cancelled(task_id, cancelled_by=cancelled_by, cascade=True)
         await self.session.commit()
         return 1 if data is not None else 0
 

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -676,10 +676,14 @@ class TaskRepository(BaseRepository):
                 以为"已持久化"但 payload["api_call_id"] 实际未写入，resume 时只能退回兜底。
         """
         now = utc_now()
-        row = await self.session.execute(select(Task.payload_json).where(Task.task_id == task_id))
-        raw = row.scalar_one_or_none()
-        if raw is None:
+        # 用 .first() 而非 scalar_one_or_none()：Task.payload_json 允许 NULL（迁移历史/
+        # 旧任务存在 payload_json IS NULL 行），scalar_one_or_none 会把"行存在但
+        # payload_json=NULL"误判成"无行"。Row 解构 row[0] 后 None 由 _json_loads 兜底为 {}。
+        result = await self.session.execute(select(Task.payload_json).where(Task.task_id == task_id))
+        row = result.first()
+        if row is None:
             raise ValueError(f"task not found: {task_id}")
+        raw = row[0]
         data = _json_loads(raw, {})
         if not isinstance(data, dict):
             data = {}

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -698,7 +698,7 @@ class TaskRepository(BaseRepository):
         )
         return [_task_to_dict(t) for t in result.scalars().all()]
 
-    async def finalize_cancelled(self, task_id: str, *, cancelled_by: str = "user") -> int:
+    async def finalize_cancelled(self, task_id: str, *, cancelled_by: str = "user") -> dict[str, Any]:
         """Worker finally 0-rows-cancelled 协议入口：把 queued/cancelling/running task 落 cancelled。
 
         SQL 守卫 ``status IN ('queued','cancelling','running')`` 接住三条路径：
@@ -708,13 +708,22 @@ class TaskRepository(BaseRepository):
 
         ``cascade=True``：本 task 终态落地后，``_mark_cancelled`` 内部触发下游级联——
         覆盖「父 running 还在 cancelling，下游 queued 暂未级联，等父 worker finally
-        落 cancelled 时再统一级联下游」这条主路径。caller 不消费 list，传 None 兜底。
+        落 cancelled 时再统一级联下游」这条主路径。
 
-        独立 commit，返回受影响行数。
+        返回 ``{"rows": int, "cancelling": list[str]}``：cancelling 是级联出来的 running
+        下游 task_id 列表——Repository 只返回意图，由上层 GenerationQueue 同步分发
+        in-process cancel 信号（Repository 不持 Worker callback）；这样级联打到的
+        running 子任务能立刻收到 cancel 而不必等它跑完。
         """
-        data = await self._mark_cancelled(task_id, cancelled_by=cancelled_by, cascade=True)
+        cancelling: list[str] = []
+        data = await self._mark_cancelled(
+            task_id,
+            cancelled_by=cancelled_by,
+            cancelling=cancelling,
+            cascade=True,
+        )
         await self.session.commit()
-        return 1 if data is not None else 0
+        return {"rows": 1 if data is not None else 0, "cancelling": cancelling}
 
     async def get_cancel_all_preview(self, project_name: str) -> int:
         """返回项目中当前 queued 状态的任务数量。"""

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -670,17 +670,25 @@ class TaskRepository(BaseRepository):
         模式更新；并发安全前提：本方法**仅**由 media_generator 在 start_call 拿到 call_id
         后立即调一次（与 ``persist_provider_job_id`` 同一时序），不与其它路径竞争写 payload。
         如果未来引入并发写 payload 的路径，需要外层加 ``SELECT ... FOR UPDATE`` 或单事务串行化。
+
+        Raises:
+            ValueError: task_id 不存在或 UPDATE 命中 0 行——避免静默 commit 让上层
+                以为"已持久化"但 payload["api_call_id"] 实际未写入，resume 时只能退回兜底。
         """
         now = utc_now()
         row = await self.session.execute(select(Task.payload_json).where(Task.task_id == task_id))
         raw = row.scalar_one_or_none()
+        if raw is None:
+            raise ValueError(f"task not found: {task_id}")
         data = _json_loads(raw, {})
         if not isinstance(data, dict):
             data = {}
         data["api_call_id"] = call_id
-        await self.session.execute(
+        update_result = await self.session.execute(
             update(Task).where(Task.task_id == task_id).values(payload_json=_json_dumps(data), updated_at=now)
         )
+        if rowcount(update_result) == 0:
+            raise ValueError(f"task not found: {task_id}")
         await self.session.commit()
 
     async def list_orphan_tasks_on_start(self) -> list[dict[str, Any]]:

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -663,6 +663,26 @@ class TaskRepository(BaseRepository):
         )
         await self.session.commit()
 
+    async def persist_api_call_id(self, task_id: str, call_id: int) -> None:
+        """将 ApiCall.id 写入 task.payload["api_call_id"]，供 resume 路径精准翻 pending。
+
+        Task.payload_json 是 TEXT 列存 JSON 字符串（非 native JSONB），用 read-modify-write
+        模式更新；并发安全前提：本方法**仅**由 media_generator 在 start_call 拿到 call_id
+        后立即调一次（与 ``persist_provider_job_id`` 同一时序），不与其它路径竞争写 payload。
+        如果未来引入并发写 payload 的路径，需要外层加 ``SELECT ... FOR UPDATE`` 或单事务串行化。
+        """
+        now = utc_now()
+        row = await self.session.execute(select(Task.payload_json).where(Task.task_id == task_id))
+        raw = row.scalar_one_or_none()
+        data = _json_loads(raw, {})
+        if not isinstance(data, dict):
+            data = {}
+        data["api_call_id"] = call_id
+        await self.session.execute(
+            update(Task).where(Task.task_id == task_id).values(payload_json=_json_dumps(data), updated_at=now)
+        )
+        await self.session.commit()
+
     async def list_orphan_tasks_on_start(self) -> list[dict[str, Any]]:
         """返回 running + cancelling 状态任务用于重启自愈（ADR 0007）。"""
         result = await self.session.execute(

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -112,6 +112,7 @@ class UsageRepository(BaseRepository):
         cost_amount: float | None = None,
         currency: str | None = None,
         status: str = "success",
+        service_tier: str = "default",
     ) -> int:
         """Resume 路径专用：按 call_id 精准翻 pending → success/failed。
 
@@ -122,6 +123,8 @@ class UsageRepository(BaseRepository):
           算实际 cost（与 generate 路径等价记账，避免视频已生成但 cost=0 永久漏记）
         - cost_amount=None + status='failed' → 走 0.0/USD（失败不计费）
         - 显式传 cost_amount → 直接用
+        service_tier 由 caller 从原 generate 上下文透传（ApiCall 模型无此列，
+        与 finish_call 同 caller-passed 模式），非 default 档位才能按真实档计费。
         provider 端已扣费的事实通过 status='pending' WHERE 保护——绝不触发再次扣费。
         返回受影响行数（0=幂等无操作；1=正常翻一行）。
         """
@@ -159,6 +162,7 @@ class UsageRepository(BaseRepository):
                     aspect_ratio=row.aspect_ratio,
                     duration_seconds=row.duration_seconds,
                     generate_audio=bool(row.generate_audio),
+                    service_tier=service_tier,
                     custom_price_input=custom_price_input,
                     custom_price_output=custom_price_output,
                     custom_currency=custom_currency,

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -180,6 +180,7 @@ class UsageRepository(BaseRepository):
                 finished_at=finished_at,
                 cost_amount=final_cost_amount,
                 currency=final_currency,
+                usage_tokens=usage_tokens,
             )
         )
         affected = rowcount(result)

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -113,6 +113,7 @@ class UsageRepository(BaseRepository):
         currency: str | None = None,
         status: str = "success",
         service_tier: str = "default",
+        usage_tokens: int | None = None,
     ) -> int:
         """Resume 路径专用：按 call_id 精准翻 pending → success/failed。
 
@@ -125,6 +126,8 @@ class UsageRepository(BaseRepository):
         - 显式传 cost_amount → 直接用
         service_tier 由 caller 从原 generate 上下文透传（ApiCall 模型无此列，
         与 finish_call 同 caller-passed 模式），非 default 档位才能按真实档计费。
+        usage_tokens 同样由 caller 从 resume_video 返回的 VideoGenerationResult.usage_tokens
+        透传：Ark video 按 usage_tokens 计费，未传则 cost 永远为 0；其它 provider 不依赖该字段。
         provider 端已扣费的事实通过 status='pending' WHERE 保护——绝不触发再次扣费。
         返回受影响行数（0=幂等无操作；1=正常翻一行）。
         """
@@ -163,6 +166,7 @@ class UsageRepository(BaseRepository):
                     duration_seconds=row.duration_seconds,
                     generate_audio=bool(row.generate_audio),
                     service_tier=service_tier,
+                    usage_tokens=usage_tokens,
                     custom_price_input=custom_price_input,
                     custom_price_output=custom_price_output,
                     custom_currency=custom_currency,

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -11,7 +11,7 @@ from lib.cost_calculator import cost_calculator
 from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.db.base import DEFAULT_USER_ID, dt_to_iso, utc_now
 from lib.db.models.api_call import ApiCall
-from lib.db.repositories.base import BaseRepository
+from lib.db.repositories.base import BaseRepository, rowcount
 from lib.providers import PROVIDER_GEMINI, CallType
 
 
@@ -104,6 +104,38 @@ class UsageRepository(BaseRepository):
         await self.session.commit()
         await self.session.refresh(row)
         return row.id
+
+    async def finalize_pending_by_call_id(
+        self,
+        *,
+        call_id: int,
+        cost_amount: float = 0.0,
+        currency: str = "USD",
+        status: str = "success",
+    ) -> int:
+        """Resume 路径专用：按 call_id 精准翻 pending → success/failed。
+
+        Repo WHERE 子句包含 ``status='pending'`` —— 已 success 行不 touch
+        （防止 generate 已 finish_call 后崩、resume 反向把 success 行覆写）。
+        cost_amount=0 / currency=USD 默认：计费已在 submit 时由 provider 定型，
+        resume 仅接续，不应再触发计费。返回受影响行数（0=幂等无操作；1=正常翻一行）。
+        """
+        finished_at = utc_now()
+
+        result = await self.session.execute(
+            update(ApiCall)
+            .where(ApiCall.id == call_id, ApiCall.status == "pending")
+            .values(
+                status=status,
+                finished_at=finished_at,
+                cost_amount=cost_amount,
+                currency=currency,
+            )
+        )
+        affected = rowcount(result)
+        if affected > 0:
+            await self.session.commit()
+        return affected
 
     async def finish_call(
         self,

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -109,18 +109,60 @@ class UsageRepository(BaseRepository):
         self,
         *,
         call_id: int,
-        cost_amount: float = 0.0,
-        currency: str = "USD",
+        cost_amount: float | None = None,
+        currency: str | None = None,
         status: str = "success",
     ) -> int:
         """Resume 路径专用：按 call_id 精准翻 pending → success/failed。
 
         Repo WHERE 子句包含 ``status='pending'`` —— 已 success 行不 touch
         （防止 generate 已 finish_call 后崩、resume 反向把 success 行覆写）。
-        cost_amount=0 / currency=USD 默认：计费已在 submit 时由 provider 定型，
-        resume 仅接续，不应再触发计费。返回受影响行数（0=幂等无操作；1=正常翻一行）。
+        cost_amount/currency 行为对齐 finish_call：
+        - cost_amount=None + status='success' → 按 ApiCall 行字段调 cost_calculator
+          算实际 cost（与 generate 路径等价记账，避免视频已生成但 cost=0 永久漏记）
+        - cost_amount=None + status='failed' → 走 0.0/USD（失败不计费）
+        - 显式传 cost_amount → 直接用
+        provider 端已扣费的事实通过 status='pending' WHERE 保护——绝不触发再次扣费。
+        返回受影响行数（0=幂等无操作；1=正常翻一行）。
         """
         finished_at = utc_now()
+
+        final_cost_amount = 0.0
+        final_currency = currency or "USD"
+
+        if cost_amount is not None:
+            final_cost_amount = cost_amount
+            final_currency = currency or "USD"
+        elif status == "success":
+            select_result = await self.session.execute(select(ApiCall).where(ApiCall.id == call_id))
+            row = select_result.scalar_one_or_none()
+            if row is not None and row.status == "pending":
+                effective_provider = row.provider or PROVIDER_GEMINI
+                custom_price_input: float | None = None
+                custom_price_output: float | None = None
+                custom_currency: str | None = None
+                if is_custom_provider(effective_provider):
+                    from lib.db.repositories.custom_provider_repo import CustomProviderRepository
+
+                    repo = CustomProviderRepository(self.session)
+                    price_model = await repo.get_model_by_ids(parse_provider_id(effective_provider), row.model or "")
+                    if price_model:
+                        custom_price_input = price_model.price_input
+                        custom_price_output = price_model.price_output
+                        custom_currency = price_model.currency
+
+                final_cost_amount, final_currency = cost_calculator.calculate_cost(
+                    provider=effective_provider,
+                    call_type=row.call_type,  # type: ignore[arg-type]
+                    model=row.model,
+                    resolution=row.resolution,
+                    aspect_ratio=row.aspect_ratio,
+                    duration_seconds=row.duration_seconds,
+                    generate_audio=bool(row.generate_audio),
+                    custom_price_input=custom_price_input,
+                    custom_price_output=custom_price_output,
+                    custom_currency=custom_currency,
+                )
 
         result = await self.session.execute(
             update(ApiCall)
@@ -128,8 +170,8 @@ class UsageRepository(BaseRepository):
             .values(
                 status=status,
                 finished_at=finished_at,
-                cost_amount=cost_amount,
-                currency=currency,
+                cost_amount=final_cost_amount,
+                currency=final_currency,
             )
         )
         affected = rowcount(result)

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -114,6 +114,7 @@ class UsageRepository(BaseRepository):
         status: str = "success",
         service_tier: str = "default",
         usage_tokens: int | None = None,
+        generate_audio: bool | None = None,
     ) -> int:
         """Resume 路径专用：按 call_id 精准翻 pending → success/failed。
 
@@ -128,10 +129,32 @@ class UsageRepository(BaseRepository):
         与 finish_call 同 caller-passed 模式），非 default 档位才能按真实档计费。
         usage_tokens 同样由 caller 从 resume_video 返回的 VideoGenerationResult.usage_tokens
         透传：Ark video 按 usage_tokens 计费，未传则 cost 永远为 0；其它 provider 不依赖该字段。
+        generate_audio 由 caller 从 backend 返回值透传：provider 在 submit 后可能降级/关闭音频，
+        与 finish_call 的 ``generate_audio is not None`` 覆盖语义对齐，避免按请求值误计费。
+        duration_ms 按 (finished_at - started_at) 回写，让 get_stats_grouped_by_provider
+        的时长汇总不会因 resume 完成的调用 duration_ms=NULL 而系统性压低。
         provider 端已扣费的事实通过 status='pending' WHERE 保护——绝不触发再次扣费。
         返回受影响行数（0=幂等无操作；1=正常翻一行）。
         """
         finished_at = utc_now()
+
+        # 无条件 fetch row：既用于 auto-calc cost 路径，也用于 duration_ms 回写
+        # （即便 caller 显式传 cost_amount，duration_ms 计算仍需要 started_at）。
+        # row.status='pending' 守卫继续由下面的 UPDATE WHERE 子句保证幂等性。
+        select_result = await self.session.execute(select(ApiCall).where(ApiCall.id == call_id))
+        row = select_result.scalar_one_or_none()
+        if row is None:
+            return 0
+
+        duration_ms = 0
+        try:
+            duration_ms = int((finished_at - row.started_at).total_seconds() * 1000)
+        except (ValueError, TypeError):
+            duration_ms = 0
+
+        # backend 回写的实际 generate_audio 覆盖 start_call 时的请求值
+        # （与 finish_call 同语义；用于 cost_calculator 输入及 UPDATE 回写）
+        effective_generate_audio = generate_audio if generate_audio is not None else row.generate_audio
 
         final_cost_amount = 0.0
         final_currency = currency or "USD"
@@ -139,38 +162,35 @@ class UsageRepository(BaseRepository):
         if cost_amount is not None:
             final_cost_amount = cost_amount
             final_currency = currency or "USD"
-        elif status == "success":
-            select_result = await self.session.execute(select(ApiCall).where(ApiCall.id == call_id))
-            row = select_result.scalar_one_or_none()
-            if row is not None and row.status == "pending":
-                effective_provider = row.provider or PROVIDER_GEMINI
-                custom_price_input: float | None = None
-                custom_price_output: float | None = None
-                custom_currency: str | None = None
-                if is_custom_provider(effective_provider):
-                    from lib.db.repositories.custom_provider_repo import CustomProviderRepository
+        elif status == "success" and row.status == "pending":
+            effective_provider = row.provider or PROVIDER_GEMINI
+            custom_price_input: float | None = None
+            custom_price_output: float | None = None
+            custom_currency: str | None = None
+            if is_custom_provider(effective_provider):
+                from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 
-                    repo = CustomProviderRepository(self.session)
-                    price_model = await repo.get_model_by_ids(parse_provider_id(effective_provider), row.model or "")
-                    if price_model:
-                        custom_price_input = price_model.price_input
-                        custom_price_output = price_model.price_output
-                        custom_currency = price_model.currency
+                repo = CustomProviderRepository(self.session)
+                price_model = await repo.get_model_by_ids(parse_provider_id(effective_provider), row.model or "")
+                if price_model:
+                    custom_price_input = price_model.price_input
+                    custom_price_output = price_model.price_output
+                    custom_currency = price_model.currency
 
-                final_cost_amount, final_currency = cost_calculator.calculate_cost(
-                    provider=effective_provider,
-                    call_type=row.call_type,  # type: ignore[arg-type]
-                    model=row.model,
-                    resolution=row.resolution,
-                    aspect_ratio=row.aspect_ratio,
-                    duration_seconds=row.duration_seconds,
-                    generate_audio=bool(row.generate_audio),
-                    service_tier=service_tier,
-                    usage_tokens=usage_tokens,
-                    custom_price_input=custom_price_input,
-                    custom_price_output=custom_price_output,
-                    custom_currency=custom_currency,
-                )
+            final_cost_amount, final_currency = cost_calculator.calculate_cost(
+                provider=effective_provider,
+                call_type=row.call_type,  # type: ignore[arg-type]
+                model=row.model,
+                resolution=row.resolution,
+                aspect_ratio=row.aspect_ratio,
+                duration_seconds=row.duration_seconds,
+                generate_audio=bool(effective_generate_audio),
+                service_tier=service_tier,
+                usage_tokens=usage_tokens,
+                custom_price_input=custom_price_input,
+                custom_price_output=custom_price_output,
+                custom_currency=custom_currency,
+            )
 
         result = await self.session.execute(
             update(ApiCall)
@@ -178,9 +198,11 @@ class UsageRepository(BaseRepository):
             .values(
                 status=status,
                 finished_at=finished_at,
+                duration_ms=duration_ms,
                 cost_amount=final_cost_amount,
                 currency=final_currency,
                 usage_tokens=usage_tokens,
+                generate_audio=effective_generate_audio,
             )
         )
         affected = rowcount(result)

--- a/lib/generation_queue.py
+++ b/lib/generation_queue.py
@@ -162,6 +162,11 @@ class GenerationQueue:
             repo = TaskRepository(session)
             await repo.persist_provider_job_id(task_id, job_id)
 
+    async def persist_api_call_id(self, task_id: str, call_id: int) -> None:
+        async with self._session_factory() as session:
+            repo = TaskRepository(session)
+            await repo.persist_api_call_id(task_id, call_id)
+
     async def mark_task_succeeded(self, task_id: str, result: dict[str, Any] | None) -> int:
         """Returns rows_affected (0 = 已被外部翻成非 running 终/中间态，worker 走 0-rows-cancelled 协议)."""
         async with self._session_factory() as session:

--- a/lib/generation_queue.py
+++ b/lib/generation_queue.py
@@ -190,10 +190,26 @@ class GenerationQueue:
         return affected
 
     async def mark_task_cancelled(self, task_id: str, *, cancelled_by: str = "user") -> int:
-        """Worker finally 0-rows-cancelled 协议兜底入口（SQL 守卫 status IN queued|cancelling）。"""
+        """Worker finally 0-rows-cancelled 协议兜底入口（SQL 守卫 status IN queued|cancelling）。
+
+        Repository 返回 ``{"rows", "cancelling"}``：cancelling 是级联出来的 running 下游
+        task_id 列表——这里同步调 worker callback 分发 in-process cancel（与 cancel_task
+        模式一致），让父任务 finalize 时打到的 running 子任务也能立刻收到 cancel 信号，
+        而不必等它跑完整个 provider 调用。返回 rows 兼容现有 0-rows-cancelled 协议 caller。
+        """
         async with self._session_factory() as session:
             repo = TaskRepository(session)
-            return await repo.finalize_cancelled(task_id, cancelled_by=cancelled_by)
+            result = await repo.finalize_cancelled(task_id, cancelled_by=cancelled_by)
+
+        callback = self._worker_cancel_callback
+        if callback is not None:
+            for tid in result.get("cancelling", []):
+                try:
+                    callback(tid)
+                except Exception:
+                    logger.exception("worker cancel callback 派发失败 task_id=%s (finalize cascade)", tid)
+
+        return int(result.get("rows", 0))
 
     async def cancel_task(self, task_id: str) -> dict[str, Any]:
         async with self._session_factory() as session:

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Any
@@ -17,6 +18,11 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 from datetime import UTC
+
+# Lease 丢失超过 ``lease_ttl * _ORPHAN_RESCAN_LEASE_LOST_MULT`` 才认为是真切换 owner
+# （另一个 worker 进程曾持过 lease 且写入了新 orphan），需要重扫；短 flap（续约抖动）
+# 不触发。lease_ttl 默认 10s → 阈值 30s。常量化便于单测注入与未来调参。
+_ORPHAN_RESCAN_LEASE_LOST_MULT = 3
 
 from lib.generation_queue import (
     TASK_POLL_INTERVAL_SEC,
@@ -231,6 +237,10 @@ class GenerationWorker:
         # Orphan dispatcher 句柄持久化：shutdown 时 await 它跑完；lease 切换重夺时
         # 第二次进 _handle_orphan_tasks_on_start，旧句柄未 done 不能直接覆盖。
         self._orphan_dispatcher_task: asyncio.Task | None = None
+        # 一次性扫描开关：单 lease 互斥架构下，进程一旦扫过 orphan 就不再重扫；
+        # 配合 _lease_lost_monotonic 阈值在「真切换 owner」时清零、「短 flap」不清零。
+        self._orphan_handled_once: bool = False
+        self._lease_lost_monotonic: float | None = None
 
     # ------------------------------------------------------------------
     # Backward compatibility shims
@@ -383,12 +393,27 @@ class GenerationWorker:
 
                 await self._drain_finished_tasks()
 
-                # 仅在「真重启 / 长时间失去 lease 后重获」时扫一次孤儿做重启自愈：
-                # 同 ADR 0007——重启不重 submit；按 provider_job_id 接续轮询或标 failed。
-                # 保留 guard 否则 lease 续期会重复扫孤儿。
-                all_inflight = self._image_inflight or self._video_inflight
-                if self._owns_lease and not had_lease and not all_inflight:
+                # Lease 状态变化跟踪：首次失去 lease 时打点；重夺 lease 后判断
+                # 「真切换 owner」（>= 3× ttl）→ 重置开关；「续约 flap」（< 3× ttl）→ 保持。
+                if had_lease and not self._owns_lease and self._lease_lost_monotonic is None:
+                    self._lease_lost_monotonic = time.monotonic()
+                if self._owns_lease and self._lease_lost_monotonic is not None:
+                    lost_duration = time.monotonic() - self._lease_lost_monotonic
+                    if lost_duration > self.lease_ttl * _ORPHAN_RESCAN_LEASE_LOST_MULT:
+                        logger.info(
+                            "lease 丢失 %.1fs（> %d×ttl=%.1fs），认为另一进程曾持过 lease，重扫 orphan",
+                            lost_duration,
+                            _ORPHAN_RESCAN_LEASE_LOST_MULT,
+                            self.lease_ttl * _ORPHAN_RESCAN_LEASE_LOST_MULT,
+                        )
+                        self._orphan_handled_once = False
+                    self._lease_lost_monotonic = None
+
+                # 一次性扫描：进程持 lease 后只扫一次 orphan；后续主循环不再重扫。
+                # 单 lease 互斥保证不会与另一个 worker 同时扫；跨进程接管由上述阈值兜底。
+                if self._owns_lease and not self._orphan_handled_once:
                     await self._handle_orphan_tasks_on_start()
+                    self._orphan_handled_once = True
 
                 if not self._owns_lease:
                     await asyncio.sleep(self.heartbeat_interval)

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -924,14 +924,17 @@ class GenerationWorker:
                 logger.info("已派发 resume video orphan: task_id=%s provider=%s", task_id, provider_id)
                 await self._process_resume_task(t)
             except asyncio.CancelledError:
-                # sem 等待期被取消时 _process_resume_task 还没跑，DB 仍在 cancelling，
-                # 须显式落 cancelled 终态；acquire 之后的取消由 _process_resume_task 内部
-                # 自己处理（execute_resume_video_task → CancelledError → mark_task_cancelled）
-                if not acquired:
-                    try:
-                        await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
-                    except Exception:
-                        logger.exception("sem 排队期 cancel 落终态失败 task_id=%s", task_id)
+                # 三种 cancel 路径都在这里兜底 mark_task_cancelled——SQL WHERE
+                # status IN (queued, cancelling, running) 保证幂等：
+                # 1) sem.acquire 等待期 cancel → _process_resume_task 还没跑，必须由此落终态
+                # 2) acquired=True 后但 _process_resume_task 内 try 块外（如 _extract_provider
+                #    的 await）cancel → 内部 mark 路径不会触发，必须由此落终态（CR round 2 #6）
+                # 3) _process_resume_task 内部 cancel → 内部已 mark，此处再调 SQL 命中
+                #    cancelled 行返回 0 rows，无副作用
+                try:
+                    await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
+                except Exception:
+                    logger.exception("sem dispatch cancel 落终态失败 task_id=%s", task_id)
                 raise
             finally:
                 if acquired:

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -701,10 +701,13 @@ class GenerationWorker:
           → [resume_unsupported]（backend 不实现 resume_video，原 job 无接续手段）
         - video running，可 resume backend (ark/gemini/openai/newapi)：
           - 无 provider_job_id → [restart_lost]
-          - 有 job_id → 派发 _process_resume_task，由 backend.resume_video 决定后续走向
+          - 有 job_id → 收集到 `resumable_by_provider` 桶，后台 dispatcher 受
+            pool video_max 容量约束分批 dispatch（fix #647 第 1 项）
 
-        resume 阶段绕过 pool has_room 校验：把 resume task 一次性插入 pool inflight 字典，
-        期间 _claim_tasks 不接新 queued 任务（has_video_room() 返回 False）。
+        启动期 fast path（本函数）**只做终结类处理**，立刻返回；可 resume 的视频孤儿
+        派发给后台 dispatcher 处理，避免 N 个 Sora orphan × 每个 5min poll 把启动期
+        阻塞数十分钟。Dispatcher 不调 `_drain_finished_tasks`，完全依赖主循环每 cycle
+        清理 inflight 字典；`_stop_event` 触发时 dispatcher 自然退出。
         """
         orphans = await self.queue.list_orphan_tasks_on_start()
         if not orphans:
@@ -714,6 +717,8 @@ class GenerationWorker:
             len(orphans),
             self.lease_ttl,
         )
+
+        resumable_by_provider: dict[str, list[dict[str, Any]]] = {}
 
         for task in orphans:
             task_id = task["task_id"]
@@ -771,11 +776,77 @@ class GenerationWorker:
                     await self.queue.mark_task_cancelled(task_id, cancelled_by="user")
                 continue
 
-            # 把 resume task 插入对应 pool inflight，让 cancel running 也能命中
-            pool = self._get_or_create_pool(provider_id)
-            inflight = pool.video_inflight if media_type == "video" else pool.image_inflight
-            inflight[task_id] = asyncio.create_task(
-                self._process_resume_task(task),
-                name=f"resume-{media_type}-{task_id}",
+            # 收集到 provider 桶，交给后台 dispatcher 受 pool 容量约束分批处理。
+            # 顺便把 resolve 出的 provider_id 写回 task dict，dispatcher 路由用。
+            task["provider_id"] = provider_id
+            resumable_by_provider.setdefault(provider_id, []).append(task)
+
+        if resumable_by_provider:
+            total = sum(len(v) for v in resumable_by_provider.values())
+            logger.info(
+                "孤儿扫描 fast path 完成：%d 个可 resume video 任务交后台分批 dispatch",
+                total,
             )
-        logger.info("孤儿扫描完成，已派发 resume 任务")
+            asyncio.create_task(  # noqa: RUF006  # dispatcher 生命周期由 _stop_event 控制
+                self._dispatch_resume_orphans_background(resumable_by_provider),
+                name="orphan-dispatcher",
+            )
+        else:
+            logger.info("孤儿扫描完成，无可 resume 任务")
+
+    async def _dispatch_resume_orphans_background(
+        self,
+        resumable_by_provider: dict[str, list[dict[str, Any]]],
+    ) -> None:
+        """后台 dispatcher：按 provider 分桶并发，受 pool video_max 容量约束分批入 inflight。
+
+        - 不同 provider 之间无容量耦合 → 并发跑独立 sub-task；
+        - 同 provider 内顺序入队：满则 `asyncio.wait(inflight, FIRST_COMPLETED)` 等任一
+          完成（精确感知，不 sleep 轮询）；
+        - 主循环每 cycle 调 `_drain_finished_tasks` 自动 pop 已 done 的 task → dispatcher
+          下次 has_room 判定就有空位（解耦关键假设）；
+        - `_stop_event` 触发时 dispatcher 自然退出，不持有 lease 资源。
+        """
+        if self._stop_event.is_set():
+            return
+        sub_tasks = [
+            asyncio.create_task(
+                self._dispatch_provider_bucket(provider_id, tasks),
+                name=f"orphan-dispatch-{provider_id}",
+            )
+            for provider_id, tasks in resumable_by_provider.items()
+        ]
+        await asyncio.gather(*sub_tasks, return_exceptions=True)
+        logger.info("孤儿后台 dispatcher 完成")
+
+    async def _dispatch_provider_bucket(
+        self,
+        provider_id: str,
+        tasks: list[dict[str, Any]],
+    ) -> None:
+        """同 provider 桶内顺序入 inflight，pool 容量满则等任一 inflight 完成。"""
+        pool = self._get_or_create_pool(provider_id)
+        for task in tasks:
+            if self._stop_event.is_set():
+                logger.info(
+                    "stop_event 已触发，剩余 %d 个 %s 孤儿不再 dispatch",
+                    len(tasks) - tasks.index(task),
+                    provider_id,
+                )
+                return
+            while not pool.has_video_room():
+                if self._stop_event.is_set():
+                    return
+                # snapshot：race 防御。inflight 可能被主循环 _drain_finished_tasks
+                # 同步 pop 到空（罕见但可能）；空时让出一拍重新判断 has_room。
+                inflight_list = list(pool.video_inflight.values())
+                if not inflight_list:
+                    await asyncio.sleep(0)
+                    continue
+                await asyncio.wait(inflight_list, return_when=asyncio.FIRST_COMPLETED)
+            task_id = task["task_id"]
+            pool.video_inflight[task_id] = asyncio.create_task(
+                self._process_resume_task(task),
+                name=f"resume-video-{task_id}",
+            )
+            logger.info("已派发 resume video orphan: task_id=%s provider=%s", task_id, provider_id)

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -618,6 +618,11 @@ class GenerationWorker:
             # rowcount 决定——拿不到了，按"被外部取消"语义兜底。
             await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
             raise
+        except Exception:
+            # mark_succeeded 自身抛错（DB 超时 / OperationalError）：上层 _drain_finished_tasks
+            # 只吞掉异常 debug 日志，stack trace 会丢失，因此在这里显式 logger.exception 保留现场。
+            logger.exception("标记任务成功失败 %s", task_id)
+            raise
         if rows == 0:
             # 0-rows-cancelled 协议：execute 跑赢但 DB 已被外部翻 cancelling
             await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -59,19 +59,27 @@ def _read_int_env(name: str, default: int, minimum: int = 1) -> int:
 
 @dataclass
 class ProviderPool:
-    """Per-provider concurrency pool with independent image/video lanes."""
+    """Per-provider concurrency pool with independent image/video lanes.
+
+    Video lane 还有一个 ``video_pending`` 字典：dispatcher 父协程 ``create_task`` 后
+    sub-task 还在 sem 排队的瞬态。``has_video_room`` 计入 pending + inflight 严格
+    限制总并发；``request_cancel`` 也查 pending，让排队中的孤儿可被秒级取消。
+    Image lane 不引入 ``image_pending``——image 没有 sem-throttled dispatcher。
+    """
 
     provider_id: str
     image_max: int  # 0 = this provider doesn't support image
     video_max: int  # 0 = this provider doesn't support video
     image_inflight: dict[str, asyncio.Task] = field(default_factory=dict)
     video_inflight: dict[str, asyncio.Task] = field(default_factory=dict)
+    video_pending: dict[str, asyncio.Task] = field(default_factory=dict)
 
     def has_image_room(self) -> bool:
         return self.image_max > 0 and len(self.image_inflight) < self.image_max
 
     def has_video_room(self) -> bool:
-        return self.video_max > 0 and len(self.video_inflight) < self.video_max
+        # 计入 pending：sem 排队期 sub-task 同样占名额，避免主循环超额 claim
+        return self.video_max > 0 and len(self.video_inflight) + len(self.video_pending) < self.video_max
 
     def drain_finished(self) -> list[asyncio.Task]:
         """Remove finished tasks from inflight dicts. Return them for await."""
@@ -83,7 +91,12 @@ class ProviderPool:
         return finished
 
     def all_inflight(self) -> list[asyncio.Task]:
+        """实际在跑的 task（不含 sem 排队中的 pending）。用于 metrics/真实并发统计。"""
         return [*self.image_inflight.values(), *self.video_inflight.values()]
+
+    def all_active(self) -> list[asyncio.Task]:
+        """In-flight + 排队中的 pending：用于 reload keep-alive 判定 / shutdown wait。"""
+        return [*self.image_inflight.values(), *self.video_inflight.values(), *self.video_pending.values()]
 
 
 async def _extract_provider(task: dict[str, Any]) -> str:
@@ -215,6 +228,9 @@ class GenerationWorker:
         self._main_task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
         self._owns_lease = False
+        # Orphan dispatcher 句柄持久化：shutdown 时 await 它跑完；lease 切换重夺时
+        # 第二次进 _handle_orphan_tasks_on_start，旧句柄未 done 不能直接覆盖。
+        self._orphan_dispatcher_task: asyncio.Task | None = None
 
     # ------------------------------------------------------------------
     # Backward compatibility shims
@@ -288,17 +304,20 @@ class GenerationWorker:
             logger.warning("从 DB 加载供应商配置失败，保持当前配置", exc_info=True)
             return
 
-        # Migrate inflight tasks to new pool objects
+        # Migrate inflight + pending tasks to new pool objects；漏迁 video_pending
+        # 会让 sem 排队中的 sub-task 引用旧 pool 字典，新 pool 看不见，cancel 失配
+        # 且 keep-alive 判定漏掉这些 task。
         for pid, new_pool in new_pools.items():
             old_pool = self._pools.get(pid)
             if old_pool:
                 new_pool.image_inflight = old_pool.image_inflight
                 new_pool.video_inflight = old_pool.video_inflight
+                new_pool.video_pending = old_pool.video_pending
 
         # Pools that existed before but are no longer registered:
-        # keep them alive until their inflight tasks drain
+        # 仍有 pending / inflight 的旧 pool 保留到耗尽——用 all_active 判定（含 pending）。
         for pid, old_pool in self._pools.items():
-            if pid not in new_pools and old_pool.all_inflight():
+            if pid not in new_pools and old_pool.all_active():
                 new_pools[pid] = old_pool
                 new_pools[pid].image_max = 0
                 new_pools[pid].video_max = 0
@@ -520,15 +539,24 @@ class GenerationWorker:
                     logger.debug("已处理的任务异常已在 _process_task 中记录")
 
     async def _wait_inflight_completion(self) -> None:
-        pending_tasks = []
+        # shutdown：先等 dispatcher 派完最后一批 sub-task（否则 sub-task 可能在 dispatcher
+        # 退出后才创建），再等所有 active task。dispatcher 异常不能断 shutdown 链。
+        if self._orphan_dispatcher_task is not None and not self._orphan_dispatcher_task.done():
+            try:
+                await self._orphan_dispatcher_task
+            except Exception:
+                logger.exception("orphan dispatcher 在 shutdown 等待时异常")
+
+        active_tasks = []
         for pool in self._pools.values():
-            pending_tasks.extend(pool.all_inflight())
-        if not pending_tasks:
+            active_tasks.extend(pool.all_active())
+        if not active_tasks:
             return
-        await asyncio.gather(*pending_tasks, return_exceptions=True)
+        await asyncio.gather(*active_tasks, return_exceptions=True)
         for pool in self._pools.values():
             pool.image_inflight.clear()
             pool.video_inflight.clear()
+            pool.video_pending.clear()
 
     async def _process_task(self, task: dict[str, Any]) -> None:
         """Run a generation task with 0-rows-cancelled finally protocol (ADR 0006).
@@ -658,12 +686,13 @@ class GenerationWorker:
     def request_cancel(self, task_id: str) -> bool:
         """In-process cancel 信号：把 task 对应 asyncio.Task cancel()，返回是否找到。
 
-        由 GenerationQueue.cancel_task 同步调用（ADR 0006 秒级响应）。callback 不命中
-        （task 已 finally 阶段 pop）是 best-effort 失败——DB 已是 cancelling，
-        worker finally 走 mark_cancelled 兜底（SQL 守卫 IN queued|cancelling 接住）。
+        由 GenerationQueue.cancel_task 同步调用（ADR 0006 秒级响应）。也查 video_pending：
+        sem 排队中的 sub-task cancel 会让 sem.acquire 抛 CancelledError 让 sub-task
+        直接退出。callback 不命中是 best-effort 失败——worker finally 走 mark_cancelled
+        兜底（SQL 守卫 IN queued|cancelling|running 接住）。
         """
         for pool in self._pools.values():
-            for inflight in (pool.image_inflight, pool.video_inflight):
+            for inflight in (pool.image_inflight, pool.video_inflight, pool.video_pending):
                 t = inflight.get(task_id)
                 if t is not None and not t.done():
                     t.cancel()
@@ -771,7 +800,15 @@ class GenerationWorker:
                 "孤儿扫描 fast path 完成：%d 个可 resume video 任务交后台分批 dispatch",
                 total,
             )
-            asyncio.create_task(  # noqa: RUF006  # dispatcher 生命周期由 _stop_event 控制
+            # 覆盖前 done 检查：lease 切换重夺时第二次进 _handle_orphan_tasks_on_start，
+            # 旧 dispatcher 可能还在跑；不能直接覆盖句柄（旧 task 会泄露成 detached）。
+            if self._orphan_dispatcher_task is not None and not self._orphan_dispatcher_task.done():
+                logger.warning("旧 orphan dispatcher 仍在运行，等待完成后再启动新一轮")
+                try:
+                    await self._orphan_dispatcher_task
+                except Exception:
+                    logger.exception("旧 orphan dispatcher 异常")
+            self._orphan_dispatcher_task = asyncio.create_task(
                 self._dispatch_resume_orphans_background(resumable_by_provider),
                 name="orphan-dispatcher",
             )
@@ -808,32 +845,67 @@ class GenerationWorker:
         provider_id: str,
         tasks: list[dict[str, Any]],
     ) -> None:
-        """同 provider 桶并发跑 resume task，受 pool video_max 容量约束。
+        """同 provider 桶并发跑 resume task，pending/inflight 分集合精确容量与 cancel 跟踪。
 
-        Semaphore 直接表达"并发数 ≤ video_max"语义；每个子 task 自己管 inflight
-        字典生命周期，与 normal path `_process_task` 对称。
+        - ``pool.video_max <= 0``：fail-fast mark_failed[resume_unsupported]，不进
+          ``Semaphore(0)`` 死锁；reload 一次兜底，避免启动期 capability 抖动误判。
+        - sub-task 由父协程同步预先注册到 ``pool.video_pending``——避免 ``create_task``
+          异步调度还未触发时主循环 ``has_video_room`` 看 inflight={} 误判可有容量。
+        - sem acquire 成功后从 pending 移到 inflight；finally 两个 dict 都 pop。
+        - sem 闭包旧 pool 限制：本 sem = Semaphore(pool.video_max) 在 dispatch 顶部
+          捕获 pool 时定型；reload 期间替换的新 pool 不会影响 sem。这是本批 dispatch
+          内并发上限维持 reload 前值的已知设计选择，非 bug。
         """
         pool = self._get_or_create_pool(provider_id)
+        if pool.video_max <= 0:
+            # 启动期 reload 兜底：DB 加载可能晚于第一次 orphan 扫描。
+            try:
+                await self.reload_limits()
+            except Exception:
+                logger.warning("reload_limits 兜底失败", exc_info=True)
+            pool = self._get_or_create_pool(provider_id)
+        if pool.video_max <= 0:
+            for t in tasks:
+                rows = await self.queue.mark_task_failed(
+                    t["task_id"],
+                    f"[resume_unsupported] provider {provider_id} video_max=0",
+                )
+                if rows == 0:
+                    await self.queue.mark_task_cancelled(t["task_id"], cancelled_by="user")
+            return
+
         sem = asyncio.Semaphore(pool.video_max)
 
         async def _run_one(t: dict[str, Any]) -> None:
-            async with sem:
-                if self._stop_event.is_set():
-                    return
-                task_id = t["task_id"]
-                current = asyncio.current_task()
-                if current is not None:
-                    pool.video_inflight[task_id] = current
-                try:
+            task_id = t["task_id"]
+            try:
+                async with sem:
+                    if self._stop_event.is_set():
+                        return
+                    # acquire 后 pool 可能在 reload_limits 期间被换新引用；
+                    # 务必从 self._pools 重读，保证 inflight 字典写入新 pool
+                    pool_now = self._get_or_create_pool(provider_id)
+                    pool_now.video_pending.pop(task_id, None)
+                    current = asyncio.current_task()
+                    if current is not None:
+                        pool_now.video_inflight[task_id] = current
                     logger.info("已派发 resume video orphan: task_id=%s provider=%s", task_id, provider_id)
                     await self._process_resume_task(t)
-                finally:
-                    pool.video_inflight.pop(task_id, None)
+            finally:
+                # 同样重读以应对 reload race
+                pool_now = self._get_or_create_pool(provider_id)
+                pool_now.video_pending.pop(task_id, None)
+                pool_now.video_inflight.pop(task_id, None)
 
-        sub = [
-            asyncio.create_task(_run_one(t), name=f"resume-video-{t['task_id']}")
-            for t in tasks
-            if not self._stop_event.is_set()
-        ]
+        sub: list[asyncio.Task] = []
+        for t in tasks:
+            if self._stop_event.is_set():
+                break
+            # 父协程同步：先 create_task、再立即写入 pending dict——避免「create_task
+            # 是异步调度，has_video_room 在调度未发生前看 inflight={} 误判可有容量」
+            # 的瞬时 race。
+            sub_task = asyncio.create_task(_run_one(t), name=f"resume-video-{t['task_id']}")
+            pool.video_pending[t["task_id"]] = sub_task
+            sub.append(sub_task)
         if sub:
             await asyncio.gather(*sub, return_exceptions=True)

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -808,29 +808,32 @@ class GenerationWorker:
         provider_id: str,
         tasks: list[dict[str, Any]],
     ) -> None:
-        """同 provider 桶内顺序入 inflight，pool 容量满则等任一 inflight 完成。"""
+        """同 provider 桶并发跑 resume task，受 pool video_max 容量约束。
+
+        Semaphore 直接表达"并发数 ≤ video_max"语义；每个子 task 自己管 inflight
+        字典生命周期，与 normal path `_process_task` 对称。
+        """
         pool = self._get_or_create_pool(provider_id)
-        for task in tasks:
-            if self._stop_event.is_set():
-                logger.info(
-                    "stop_event 已触发，剩余 %d 个 %s 孤儿不再 dispatch",
-                    len(tasks) - tasks.index(task),
-                    provider_id,
-                )
-                return
-            while not pool.has_video_room():
+        sem = asyncio.Semaphore(pool.video_max)
+
+        async def _run_one(t: dict[str, Any]) -> None:
+            async with sem:
                 if self._stop_event.is_set():
                     return
-                # snapshot：race 防御。inflight 可能被主循环 _drain_finished_tasks
-                # 同步 pop 到空（罕见但可能）；空时让出一拍重新判断 has_room。
-                inflight_list = list(pool.video_inflight.values())
-                if not inflight_list:
-                    await asyncio.sleep(0)
-                    continue
-                await asyncio.wait(inflight_list, return_when=asyncio.FIRST_COMPLETED)
-            task_id = task["task_id"]
-            pool.video_inflight[task_id] = asyncio.create_task(
-                self._process_resume_task(task),
-                name=f"resume-video-{task_id}",
-            )
-            logger.info("已派发 resume video orphan: task_id=%s provider=%s", task_id, provider_id)
+                task_id = t["task_id"]
+                current = asyncio.current_task()
+                if current is not None:
+                    pool.video_inflight[task_id] = current
+                try:
+                    logger.info("已派发 resume video orphan: task_id=%s provider=%s", task_id, provider_id)
+                    await self._process_resume_task(t)
+                finally:
+                    pool.video_inflight.pop(task_id, None)
+
+        sub = [
+            asyncio.create_task(_run_one(t), name=f"resume-video-{t['task_id']}")
+            for t in tasks
+            if not self._stop_event.is_set()
+        ]
+        if sub:
+            await asyncio.gather(*sub, return_exceptions=True)

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -761,10 +761,26 @@ class GenerationWorker:
             self.lease_ttl,
         )
 
+        # self-active 防 self-preemption：lease flap > 3×TTL 后 _orphan_handled_once
+        # 重置，再扫 DB running 会包含本进程仍 inflight 的 task。若不排除：
+        # - image 任务 → 错误标 [restart_lost]（任务还在跑就被标失败）
+        # - video 任务 → 启动重复 resume 流，同一 provider job 被并发 poll/finalize，
+        #   崩溃窗口可能导致 provider 端双重扣费（违反 ADR 0007 红线）
+        # 收集本进程当前在跑的 task_id（image_inflight + video_inflight + video_pending），
+        # DB 扫到的同 id task 视为本进程的活，跳过孤儿处理。
+        self_active_task_ids: set[str] = set()
+        for pool in self._pools.values():
+            self_active_task_ids.update(pool.image_inflight.keys())
+            self_active_task_ids.update(pool.video_inflight.keys())
+            self_active_task_ids.update(pool.video_pending.keys())
+
         resumable_by_provider: dict[str, list[dict[str, Any]]] = {}
 
         for task in orphans:
             task_id = task["task_id"]
+            if task_id in self_active_task_ids:
+                logger.info("孤儿扫到本进程仍 active 的 task %s，跳过避免 self-preemption", task_id)
+                continue
             status = task.get("status")
             if status == "cancelling":
                 await self.queue.mark_task_cancelled(task_id, cancelled_by="user")

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -542,59 +542,57 @@ class GenerationWorker:
         provider_id = await _extract_provider(task)
         logger.info("开始处理任务 %s (type=%s, provider=%s)", task_id, task_type, provider_id)
 
-        from lib.video_backends.base import reset_current_task_id, set_current_task_id
+        from server.services.generation_tasks import execute_generation_task
 
-        token = set_current_task_id(task_id)
         try:
-            from server.services.generation_tasks import execute_generation_task
-
-            try:
-                result = await execute_generation_task(task)
-            except asyncio.CancelledError:
-                # 用户/级联取消：worker.request_cancel 触发 asyncio.Task.cancel()
-                await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
-                raise
-            except Exception as exc:
-                logger.exception("任务失败 %s (type=%s, provider=%s)", task_id, task_type, provider_id)
-                rows = await asyncio.shield(self.queue.mark_task_failed(task_id, str(exc)))
-                if rows == 0:
-                    # 外部已抢先翻 cancelling → 落地 cancelled 终态
-                    await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
-                return
-
-            try:
-                rows = await asyncio.shield(self.queue.mark_task_succeeded(task_id, result))
-            except asyncio.CancelledError:
-                # mark_succeeded 期间被取消：shield 让 inner 跑完了；inner 完成情况由
-                # rowcount 决定——拿不到了，按"被外部取消"语义兜底。
-                await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
-                raise
+            result = await execute_generation_task(task)
+        except asyncio.CancelledError:
+            # 用户/级联取消：worker.request_cancel 触发 asyncio.Task.cancel()
+            await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
+            raise
+        except Exception as exc:
+            logger.exception("任务失败 %s (type=%s, provider=%s)", task_id, task_type, provider_id)
+            rows = await asyncio.shield(self.queue.mark_task_failed(task_id, str(exc)))
             if rows == 0:
-                # 0-rows-cancelled 协议：execute 跑赢但 DB 已被外部翻 cancelling
+                # 外部已抢先翻 cancelling → 落地 cancelled 终态
                 await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
-            else:
-                logger.info("任务完成 %s (type=%s, provider=%s)", task_id, task_type, provider_id)
-        finally:
-            reset_current_task_id(token)
+            return
+
+        try:
+            rows = await asyncio.shield(self.queue.mark_task_succeeded(task_id, result))
+        except asyncio.CancelledError:
+            # mark_succeeded 期间被取消：shield 让 inner 跑完了；inner 完成情况由
+            # rowcount 决定——拿不到了，按"被外部取消"语义兜底。
+            await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
+            raise
+        if rows == 0:
+            # 0-rows-cancelled 协议：execute 跑赢但 DB 已被外部翻 cancelling
+            await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
+        else:
+            logger.info("任务完成 %s (type=%s, provider=%s)", task_id, task_type, provider_id)
 
     async def _process_resume_task(self, task: dict[str, Any]) -> None:
-        """重启自愈入口：set _RESUME_JOB_ID + _CURRENT_TASK_ID 后调 execute_generation_task。
-
-        与 ``_process_task`` 共用 finally 协议；backend.generate 内部检测 _RESUME_JOB_ID
-        会跳过 submit 直接走 resume_video 接续轮询（ADR 0007）。
+        """重启自愈入口：直接调 backend.resume_video，绕过 normal executor 流水线。
 
         provider 锁定：把持久化的 ``task["provider_id"]`` 注入 payload 的
-        ``video_provider`` / ``image_provider``，让 ``ConfigResolver`` 按持久化 provider
-        而非当前项目配置解析 backend。否则任务提交后到重启前若项目 provider 配置切换，
+        ``video_provider`` 字段，让 ``ConfigResolver`` 按持久化 provider 而非当前
+        项目配置解析 backend。否则任务提交后到重启前若项目 provider 配置切换，
         会拿旧 ``provider_job_id`` 去新 provider 轮询，导致可恢复任务被误判失败。
         """
         task_id = task["task_id"]
         task_type = task.get("task_type", "unknown")
 
+        job_id = task.get("provider_job_id") or ""
+        if not job_id:
+            # 防御：本不该被派发到这里（_handle_orphan_tasks_on_start 已 mark_failed [restart_lost]）
+            rows = await asyncio.shield(
+                self.queue.mark_task_failed(task_id, "[restart_lost] 无 provider_job_id 但被派发到 resume")
+            )
+            if rows == 0:
+                await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
+            return
+
         # 锁定持久化 provider 到 payload（resolver 优先级：payload > project > 默认）。
-        # _trusted_payload_provider 会拒绝不在 registry/custom 里的值，不可信时 resolver
-        # 回退默认，resume_video 大概率拿不到匹配的 job_id → 走 [resume_expired]，
-        # 比静默漂移好。
         persisted_provider_id = task.get("provider_id")
         if persisted_provider_id:
             payload = task.get("payload")
@@ -608,7 +606,6 @@ class GenerationWorker:
                 payload["image_provider"] = persisted_provider_id
 
         provider_id = await _extract_provider(task)
-        job_id = task.get("provider_job_id") or ""
         logger.info(
             "重启自愈处理任务 %s (type=%s, provider=%s, job=%s)",
             task_id,
@@ -617,55 +614,42 @@ class GenerationWorker:
             job_id,
         )
 
-        from lib.video_backends.base import (
-            ResumeExpiredError,
-            reset_current_task_id,
-            reset_resume_job_id,
-            set_current_task_id,
-            set_resume_job_id,
-        )
+        from lib.video_backends.base import ResumeExpiredError
+        from server.services.resume_executor import execute_resume_video_task
 
-        token_task = set_current_task_id(task_id)
-        token_resume = set_resume_job_id(job_id)
         try:
-            from server.services.generation_tasks import execute_generation_task
-
-            try:
-                result = await execute_generation_task(task)
-            except asyncio.CancelledError:
-                await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
-                raise
-            except NotImplementedError as exc:
-                logger.warning("resume 不支持 task %s: %s", task_id, exc)
-                rows = await asyncio.shield(self.queue.mark_task_failed(task_id, f"[resume_unsupported] {exc}"))
-                if rows == 0:
-                    await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
-                return
-            except ResumeExpiredError as exc:
-                logger.warning("resume 已过期 task %s: %s", task_id, exc)
-                rows = await asyncio.shield(self.queue.mark_task_failed(task_id, f"[resume_expired] {exc}"))
-                if rows == 0:
-                    await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
-                return
-            except Exception as exc:
-                logger.exception("resume 失败 %s (type=%s, provider=%s)", task_id, task_type, provider_id)
-                rows = await asyncio.shield(self.queue.mark_task_failed(task_id, str(exc)))
-                if rows == 0:
-                    await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
-                return
-
-            try:
-                rows = await asyncio.shield(self.queue.mark_task_succeeded(task_id, result))
-            except asyncio.CancelledError:
-                await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
-                raise
+            result = await execute_resume_video_task(task, job_id=job_id)
+        except asyncio.CancelledError:
+            await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
+            raise
+        except NotImplementedError as exc:
+            logger.warning("resume 不支持 task %s: %s", task_id, exc)
+            rows = await asyncio.shield(self.queue.mark_task_failed(task_id, f"[resume_unsupported] {exc}"))
             if rows == 0:
                 await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
-            else:
-                logger.info("重启自愈完成 %s", task_id)
-        finally:
-            reset_resume_job_id(token_resume)
-            reset_current_task_id(token_task)
+            return
+        except ResumeExpiredError as exc:
+            logger.warning("resume 已过期 task %s: %s", task_id, exc)
+            rows = await asyncio.shield(self.queue.mark_task_failed(task_id, f"[resume_expired] {exc}"))
+            if rows == 0:
+                await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
+            return
+        except Exception as exc:
+            logger.exception("resume 失败 %s (type=%s, provider=%s)", task_id, task_type, provider_id)
+            rows = await asyncio.shield(self.queue.mark_task_failed(task_id, str(exc)))
+            if rows == 0:
+                await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
+            return
+
+        try:
+            rows = await asyncio.shield(self.queue.mark_task_succeeded(task_id, result))
+        except asyncio.CancelledError:
+            await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
+            raise
+        if rows == 0:
+            await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
+        else:
+            logger.info("重启自愈完成 %s", task_id)
 
     # ------------------------------------------------------------------
     # Cancel & orphan recovery

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -908,20 +908,34 @@ class GenerationWorker:
 
         async def _run_one(t: dict[str, Any]) -> None:
             task_id = t["task_id"]
+            acquired = False
             try:
-                async with sem:
-                    if self._stop_event.is_set():
-                        return
-                    # acquire 后 pool 可能在 reload_limits 期间被换新引用；
-                    # 务必从 self._pools 重读，保证 inflight 字典写入新 pool
-                    pool_now = self._get_or_create_pool(provider_id)
-                    pool_now.video_pending.pop(task_id, None)
-                    current = asyncio.current_task()
-                    if current is not None:
-                        pool_now.video_inflight[task_id] = current
-                    logger.info("已派发 resume video orphan: task_id=%s provider=%s", task_id, provider_id)
-                    await self._process_resume_task(t)
+                await sem.acquire()
+                acquired = True
+                if self._stop_event.is_set():
+                    return
+                # acquire 后 pool 可能在 reload_limits 期间被换新引用；
+                # 务必从 self._pools 重读，保证 inflight 字典写入新 pool
+                pool_now = self._get_or_create_pool(provider_id)
+                pool_now.video_pending.pop(task_id, None)
+                current = asyncio.current_task()
+                if current is not None:
+                    pool_now.video_inflight[task_id] = current
+                logger.info("已派发 resume video orphan: task_id=%s provider=%s", task_id, provider_id)
+                await self._process_resume_task(t)
+            except asyncio.CancelledError:
+                # sem 等待期被取消时 _process_resume_task 还没跑，DB 仍在 cancelling，
+                # 须显式落 cancelled 终态；acquire 之后的取消由 _process_resume_task 内部
+                # 自己处理（execute_resume_video_task → CancelledError → mark_task_cancelled）
+                if not acquired:
+                    try:
+                        await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
+                    except Exception:
+                        logger.exception("sem 排队期 cancel 落终态失败 task_id=%s", task_id)
+                raise
             finally:
+                if acquired:
+                    sem.release()
                 # 同样重读以应对 reload race
                 pool_now = self._get_or_create_pool(provider_id)
                 pool_now.video_pending.pop(task_id, None)

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -830,14 +830,20 @@ class GenerationWorker:
                 "孤儿扫描 fast path 完成：%d 个可 resume video 任务交后台分批 dispatch",
                 total,
             )
-            # 覆盖前 done 检查：lease 切换重夺时第二次进 _handle_orphan_tasks_on_start，
-            # 旧 dispatcher 可能还在跑；不能直接覆盖句柄（旧 task 会泄露成 detached）。
+            # lease 重夺时旧 dispatcher 可能还在跑（典型场景：resume_video 内 poll provider
+            # 需要几分钟到 10+ 分钟）。本轮**不 await 不 cancel** 直接覆盖句柄：
+            # - 不 await：避免阻塞主循环 → liveness 问题（无法续 lease 心跳/无法响应 cancel API）
+            # - 不 cancel：cancel 会让旧 dispatcher 的 _run_one 抛 CancelledError，进入
+            #   兜底 mark_task_cancelled 路径，把用户**未主动取消**的 in-flight resume 错误
+            #   标为 cancelled，且让 provider 端已扣费 job 失去归属
+            # - 直接覆盖：旧 dispatcher_task 的 sub-task 仍由 pool.video_pending/video_inflight
+            #   持有引用 + asyncio.gather 内部 callback 链持有，旧 task 不会被 GC detached
+            # - shutdown 仍能感知：_wait_inflight_completion 经 pool.all_active() 等到旧 sub-task
             if self._orphan_dispatcher_task is not None and not self._orphan_dispatcher_task.done():
-                logger.warning("旧 orphan dispatcher 仍在运行，等待完成后再启动新一轮")
-                try:
-                    await self._orphan_dispatcher_task
-                except Exception:
-                    logger.exception("旧 orphan dispatcher 异常")
+                logger.warning(
+                    "旧 orphan dispatcher 仍在运行，本轮直接覆盖句柄不等待——"
+                    "旧 sub-task 由 pool 跟踪，shutdown 时经 pool.all_active 兜底"
+                )
             self._orphan_dispatcher_task = asyncio.create_task(
                 self._dispatch_resume_orphans_background(resumable_by_provider),
                 name="orphan-dispatcher",

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -339,6 +339,7 @@ class MediaGenerator:
         aspect_ratio: str = "9:16",
         duration_seconds: str | int = "8",
         resolution: str | None = None,
+        task_id: str | None = None,
         **version_metadata,
     ) -> tuple[Path, int, Any, str | None]:
         """
@@ -441,6 +442,7 @@ class MediaGenerator:
                 reference_images=actual_reference_images,
                 generate_audio=effective_generate_audio,
                 project_name=self.project_name,
+                task_id=task_id,
                 service_tier=version_metadata.get("service_tier", "default"),
                 seed=version_metadata.get("seed"),
             )

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -411,16 +411,17 @@ class MediaGenerator:
             segment_id=resource_id if resource_type in ("storyboards", "videos") else None,
         )
 
-        # start_call 拿到 call_id 后立即写入 task.payload["api_call_id"]，
-        # 让 worker 崩溃重启后 resume 路径能精准翻这条 pending ApiCall 行
-        # （而不是按 segment_id+LIMIT 1 模糊匹配）。失败仅 warning 不阻断主流程，
-        # generate 自身的 finish_call 仍按正常路径走。
-        if task_id is not None:
-            from lib.video_backends.base import persist_api_call_id
-
-            await persist_api_call_id(task_id, call_id)
-
         try:
+            # start_call 拿到 call_id 后立即写入 task.payload["api_call_id"]，让 worker
+            # 崩溃重启后 resume 路径能精准翻这条 pending ApiCall 行（而不是按
+            # segment_id+LIMIT 1 模糊匹配）。fail-fast 抛异常会被本块 except 捕获，
+            # 走 finish_call(status="failed") 翻 pending → failed 后再 raise，避免
+            # 留下永久 pending 账目（ADR 0007）；放在 try 块内是必须的。
+            if task_id is not None:
+                from lib.video_backends.base import persist_api_call_id
+
+                await persist_api_call_id(task_id, call_id)
+
             from lib.video_backends.base import VideoGenerationRequest
 
             # Three-level fallback based on backend video capabilities

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -516,8 +516,9 @@ class MediaGenerator:
         - 不调 usage_tracker.start_call/finish_call —— 首次 submit 已记账；ResumeExpired
           / crash window 都不应再写 ApiCall（防双重扣费）。caller 透传 ``api_call_id``
           时按 call_id 精准翻 pending → success/failed；不透传则 logger.warning 不阻断。
-        - 用 ensure_current_tracked 取代 add_version：已有版本则跳过补登记，
-          submit→poll 中崩的边界场景才补登记 v1 避免 finalize 处 IndexError。
+        - resume 成功后总是 add_version 记录新版本：无论 versions.json 是否已有历史版本，
+          backend.resume_video 都会下载新视频并覆盖 output_path，必须 bump 一个新版本号
+          让 versions.json 与磁盘文件一致；否则会漏记本次重新生成的视频，回滚记录失真。
         - prompt / start_image / reference_images 仅用于日志/版本元数据，不影响 provider 端结果。
 
         Returns: (output_path, version_number, video_ref, video_uri) 四元组。
@@ -527,24 +528,12 @@ class MediaGenerator:
 
         # 先把 duration 归一为 int：上游可能传 "8.0" 浮点字符串，直接 int("8.0") 会 ValueError
         # 走兜底分支静默掉真实值（"10.0" 会被吞成 8）。先 float() 再 int() 保留语义。
-        # 提前到所有 ensure_current_tracked / VideoGenerationRequest 之前，让版本元数据
+        # 提前到 VideoGenerationRequest / add_version 之前，让版本元数据
         # 与 provider 请求里的 duration_seconds 类型一致（都是 int，避免 versions.json 落字符串）。
         try:
             duration_int = int(float(duration_seconds)) if duration_seconds else 8
         except (ValueError, TypeError):
             duration_int = 8
-
-        # 开头的 ensure_current_tracked 覆盖「output_path 残留」场景（重试时旧文件还在）。
-        # 末尾还会再调一次 ensure —— 两次幂等（get_current_version > 0 时 short-circuit）。
-        if output_path.exists():
-            self.versions.ensure_current_tracked(
-                resource_type=resource_type,
-                resource_id=resource_id,
-                current_file=output_path,
-                prompt=prompt,
-                duration_seconds=duration_int,
-                **version_metadata,
-            )
 
         if self._video_backend is None:
             raise RuntimeError("video_backend not configured")
@@ -631,16 +620,17 @@ class MediaGenerator:
                 job_id,
             )
 
-        # versions.json 已有 v1 → ensure 跳过；submit→poll 中崩导致 versions.json 无记录
-        # 的边界场景，ensure 补登记 v1 以避开下游 _finalize_video_task 的 versions[-1] IndexError。
-        self.versions.ensure_current_tracked(
+        # backend.resume_video 已下载新视频并覆盖 output_path，必须 bump 一个新版本号：
+        # - versions.json 空时（submit→poll 中崩）add_version 直接登记 v1，避免下游 versions[-1] IndexError；
+        # - versions.json 已有 v_n（覆盖式重新生成）时 add_version 登记 v_(n+1)，避免 output_path
+        #   被新内容覆盖却仍报旧版本号导致 versions.json 与磁盘文件错位。
+        new_version = self.versions.add_version(
             resource_type=resource_type,
             resource_id=resource_id,
-            current_file=output_path,
             prompt=prompt,
+            source_file=output_path,
             duration_seconds=duration_int,
             **version_metadata,
         )
-        new_version = self.versions.get_current_version(resource_type, resource_id)
 
         return output_path, new_version, video_ref, video_uri

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -481,3 +481,118 @@ class MediaGenerator:
         )
 
         return output_path, new_version, video_ref, video_uri
+
+    async def resume_video_async(
+        self,
+        *,
+        job_id: str,
+        resource_type: str,
+        resource_id: str,
+        prompt: str = "",
+        aspect_ratio: str = "9:16",
+        duration_seconds: str | int = "8",
+        resolution: str | None = None,
+        task_id: str | None = None,
+        **version_metadata,
+    ) -> tuple[Path, int, Any, str | None]:
+        """接续 provider 上已发起的 video job：调 backend.resume_video 而非 generate。
+
+        与 generate_video_async 共享版本管理 + 用量统计骨架；区别在于：
+        - 不读 start_image / reference_images（resume 路径不需要重传输入资产）
+        - 调 backend.resume_video(job_id, request) 而非 backend.generate(request)
+        - prompt 仅用于日志/版本元数据，不影响 provider 端结果
+
+        Returns: (output_path, version_number, video_ref, video_uri) 四元组。
+        """
+        output_path = self._get_output_path(resource_type, resource_id)
+        self._ensure_parent_dir(output_path)
+
+        if output_path.exists():
+            self.versions.ensure_current_tracked(
+                resource_type=resource_type,
+                resource_id=resource_id,
+                current_file=output_path,
+                prompt=prompt,
+                duration_seconds=duration_seconds,
+                **version_metadata,
+            )
+
+        try:
+            duration_int = int(duration_seconds) if duration_seconds else 8
+        except (ValueError, TypeError):
+            duration_int = 8
+
+        if self._video_backend is None:
+            raise RuntimeError("video_backend not configured")
+
+        model_name = self._video_backend.model
+        provider_name = self._video_backend.name
+        if self._config is not None:
+            configured_generate_audio = await self._config.video_generate_audio(self.project_name)
+        else:
+            from lib.config.resolver import ConfigResolver
+
+            configured_generate_audio = ConfigResolver._DEFAULT_VIDEO_GENERATE_AUDIO
+        effective_generate_audio = version_metadata.get("generate_audio", configured_generate_audio)
+
+        call_id = await self.usage_tracker.start_call(
+            project_name=self.project_name,
+            call_type="video",
+            model=model_name,
+            prompt=prompt,
+            resolution=resolution,
+            duration_seconds=duration_int,
+            aspect_ratio=aspect_ratio,
+            generate_audio=effective_generate_audio,
+            provider=provider_name,
+            user_id=self._user_id,
+            segment_id=resource_id if resource_type in ("storyboards", "videos") else None,
+        )
+
+        try:
+            from lib.video_backends.base import VideoGenerationRequest
+
+            request = VideoGenerationRequest(
+                prompt=prompt,
+                output_path=output_path,
+                aspect_ratio=aspect_ratio,
+                duration_seconds=duration_int,
+                resolution=resolution,
+                generate_audio=effective_generate_audio,
+                project_name=self.project_name,
+                task_id=task_id,
+                service_tier=version_metadata.get("service_tier", "default"),
+                seed=version_metadata.get("seed"),
+            )
+
+            result = await self._video_backend.resume_video(job_id, request)
+            video_ref = None
+            video_uri = result.video_uri
+
+            await self.usage_tracker.finish_call(
+                call_id=call_id,
+                status="success",
+                output_path=str(output_path),
+                usage_tokens=result.usage_tokens,
+                service_tier=version_metadata.get("service_tier", "default"),
+                generate_audio=result.generate_audio,
+            )
+        except Exception as e:
+            logger.exception("resume 失败 (%s)", "video")
+            await self.usage_tracker.finish_call(
+                call_id=call_id,
+                status="failed",
+                error_message=str(e),
+            )
+            raise
+
+        new_version = self.versions.add_version(
+            resource_type=resource_type,
+            resource_id=resource_id,
+            prompt=prompt,
+            source_file=output_path,
+            duration_seconds=duration_seconds,
+            **version_metadata,
+        )
+
+        return output_path, new_version, video_ref, video_uri

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -589,12 +589,14 @@ class MediaGenerator:
         video_ref = None
         video_uri = result.video_uri
 
-        # Resume 成功：精准翻 pending → success，cost_amount=0 保持单次计费语义。
+        # Resume 成功：精准翻 pending → success。cost_amount=None 让 repo 按 ApiCall 行
+        # 字段（model/resolution/duration/generate_audio）调 cost_calculator 算实际 cost，
+        # 与 generate 路径 finish_call 自动算 cost 等价——避免视频已生成但账本永久漏记。
+        # WHERE status='pending' 仍保护幂等性，已 success 行不会被 touch。
         if api_call_id is not None:
             try:
                 affected = await self.usage_tracker.finalize_pending_by_call_id(
                     call_id=api_call_id,
-                    cost_amount=0.0,
                     status="success",
                 )
                 if affected == 0:

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -407,6 +407,15 @@ class MediaGenerator:
             segment_id=resource_id if resource_type in ("storyboards", "videos") else None,
         )
 
+        # start_call 拿到 call_id 后立即写入 task.payload["api_call_id"]，
+        # 让 worker 崩溃重启后 resume 路径能精准翻这条 pending ApiCall 行
+        # （而不是按 segment_id+LIMIT 1 模糊匹配）。失败仅 warning 不阻断主流程，
+        # generate 自身的 finish_call 仍按正常路径走。
+        if task_id is not None:
+            from lib.video_backends.base import persist_api_call_id
+
+            await persist_api_call_id(task_id, call_id)
+
         try:
             from lib.video_backends.base import VideoGenerationRequest
 
@@ -493,20 +502,26 @@ class MediaGenerator:
         duration_seconds: str | int = "8",
         resolution: str | None = None,
         task_id: str | None = None,
+        api_call_id: int | None = None,
         **version_metadata,
     ) -> tuple[Path, int, Any, str | None]:
         """接续 provider 上已发起的 video job：调 backend.resume_video 而非 generate。
 
-        与 generate_video_async 共享版本管理 + 用量统计骨架；区别在于：
-        - 不读 start_image / reference_images（resume 路径不需要重传输入资产）
-        - 调 backend.resume_video(job_id, request) 而非 backend.generate(request)
-        - prompt 仅用于日志/版本元数据，不影响 provider 端结果
+        与 generate_video_async 的差异：
+        - 不调 usage_tracker.start_call/finish_call —— 首次 submit 已记账；ResumeExpired
+          / crash window 都不应再写 ApiCall（防双重扣费）。caller 透传 ``api_call_id``
+          时按 call_id 精准翻 pending → success/failed；不透传则 logger.warning 不阻断。
+        - 用 ensure_current_tracked 取代 add_version：已有版本则跳过补登记，
+          submit→poll 中崩的边界场景才补登记 v1 避免 finalize 处 IndexError。
+        - prompt / start_image / reference_images 仅用于日志/版本元数据，不影响 provider 端结果。
 
         Returns: (output_path, version_number, video_ref, video_uri) 四元组。
         """
         output_path = self._get_output_path(resource_type, resource_id)
         self._ensure_parent_dir(output_path)
 
+        # 开头的 ensure_current_tracked 覆盖「output_path 残留」场景（重试时旧文件还在）。
+        # 末尾还会再调一次 ensure —— 两次幂等（get_current_version > 0 时 short-circuit）。
         if output_path.exists():
             self.versions.ensure_current_tracked(
                 resource_type=resource_type,
@@ -525,8 +540,6 @@ class MediaGenerator:
         if self._video_backend is None:
             raise RuntimeError("video_backend not configured")
 
-        model_name = self._video_backend.model
-        provider_name = self._video_backend.name
         if self._config is not None:
             configured_generate_audio = await self._config.video_generate_audio(self.project_name)
         else:
@@ -535,64 +548,84 @@ class MediaGenerator:
             configured_generate_audio = ConfigResolver._DEFAULT_VIDEO_GENERATE_AUDIO
         effective_generate_audio = version_metadata.get("generate_audio", configured_generate_audio)
 
-        call_id = await self.usage_tracker.start_call(
-            project_name=self.project_name,
-            call_type="video",
-            model=model_name,
+        from lib.video_backends.base import ResumeExpiredError, VideoGenerationRequest
+
+        request = VideoGenerationRequest(
             prompt=prompt,
-            resolution=resolution,
-            duration_seconds=duration_int,
+            output_path=output_path,
             aspect_ratio=aspect_ratio,
+            duration_seconds=duration_int,
+            resolution=resolution,
             generate_audio=effective_generate_audio,
-            provider=provider_name,
-            user_id=self._user_id,
-            segment_id=resource_id if resource_type in ("storyboards", "videos") else None,
+            project_name=self.project_name,
+            task_id=task_id,
+            service_tier=version_metadata.get("service_tier", "default"),
+            seed=version_metadata.get("seed"),
         )
 
         try:
-            from lib.video_backends.base import VideoGenerationRequest
-
-            request = VideoGenerationRequest(
-                prompt=prompt,
-                output_path=output_path,
-                aspect_ratio=aspect_ratio,
-                duration_seconds=duration_int,
-                resolution=resolution,
-                generate_audio=effective_generate_audio,
-                project_name=self.project_name,
-                task_id=task_id,
-                service_tier=version_metadata.get("service_tier", "default"),
-                seed=version_metadata.get("seed"),
-            )
-
             result = await self._video_backend.resume_video(job_id, request)
-            video_ref = None
-            video_uri = result.video_uri
-
-            await self.usage_tracker.finish_call(
-                call_id=call_id,
-                status="success",
-                output_path=str(output_path),
-                usage_tokens=result.usage_tokens,
-                service_tier=version_metadata.get("service_tier", "default"),
-                generate_audio=result.generate_audio,
-            )
-        except Exception as e:
-            logger.exception("resume 失败 (%s)", "video")
-            await self.usage_tracker.finish_call(
-                call_id=call_id,
-                status="failed",
-                error_message=str(e),
-            )
+        except ResumeExpiredError:
+            # Pending ApiCall 翻 failed 而不是留 pending：让 /api/v1/usage 报表不堆积无终态行；
+            # cost_amount=0 不增加计费（resume 不重扣，符合 "不主动扣费" 红线）。
+            if api_call_id is not None:
+                try:
+                    await self.usage_tracker.finalize_pending_by_call_id(
+                        call_id=api_call_id,
+                        cost_amount=0.0,
+                        status="failed",
+                    )
+                except Exception:
+                    logger.warning(
+                        "finalize_pending_by_call_id(failed) 失败 call_id=%d task_id=%s",
+                        api_call_id,
+                        task_id,
+                    )
+            raise
+        except Exception:
+            logger.exception("resume 失败 (video) task_id=%s job_id=%s", task_id, job_id)
             raise
 
-        new_version = self.versions.add_version(
+        video_ref = None
+        video_uri = result.video_uri
+
+        # Resume 成功：精准翻 pending → success，cost_amount=0 保持单次计费语义。
+        if api_call_id is not None:
+            try:
+                affected = await self.usage_tracker.finalize_pending_by_call_id(
+                    call_id=api_call_id,
+                    cost_amount=0.0,
+                    status="success",
+                )
+                if affected == 0:
+                    logger.info(
+                        "finalize_pending_by_call_id 0 rows call_id=%d task_id=%s （已 success 或不存在）",
+                        api_call_id,
+                        task_id,
+                    )
+            except Exception:
+                logger.warning(
+                    "finalize_pending_by_call_id(success) 失败 call_id=%d task_id=%s",
+                    api_call_id,
+                    task_id,
+                )
+        else:
+            logger.warning(
+                "resume 缺 api_call_id task_id=%s job_id=%s (旧任务未持久化 payload)",
+                task_id,
+                job_id,
+            )
+
+        # versions.json 已有 v1 → ensure 跳过；submit→poll 中崩导致 versions.json 无记录
+        # 的边界场景，ensure 补登记 v1 以避开下游 _finalize_video_task 的 versions[-1] IndexError。
+        self.versions.ensure_current_tracked(
             resource_type=resource_type,
             resource_id=resource_id,
+            current_file=output_path,
             prompt=prompt,
-            source_file=output_path,
             duration_seconds=duration_seconds,
             **version_metadata,
         )
+        new_version = self.versions.get_current_version(resource_type, resource_id)
 
         return output_path, new_version, video_ref, video_uri

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -363,6 +363,16 @@ class MediaGenerator:
         output_path = self._get_output_path(resource_type, resource_id)
         self._ensure_parent_dir(output_path)
 
+        # 先把 duration 归一为 int：上游可能传 "8.0" 浮点字符串，直接 int("8.0") 会 ValueError
+        # 走兜底分支静默掉真实值（"10.0" 会被吞成 8）。先 float() 再 int() 保留语义。
+        # 提前到所有 ensure_current_tracked / add_version / VideoGenerationRequest 之前，
+        # 让版本元数据与 provider 请求里的 duration_seconds 类型一致（都是 int），
+        # 避免 versions.json 落字符串而 ApiCall 落 int 的类型漂移。
+        try:
+            duration_int = int(float(duration_seconds)) if duration_seconds else 8
+        except (ValueError, TypeError):
+            duration_int = 8
+
         # 1. 若已存在，确保旧文件被记录
         if output_path.exists():
             self.versions.ensure_current_tracked(
@@ -370,15 +380,9 @@ class MediaGenerator:
                 resource_id=resource_id,
                 current_file=output_path,
                 prompt=prompt,
-                duration_seconds=duration_seconds,
+                duration_seconds=duration_int,
                 **version_metadata,
             )
-
-        # 2. 记录 API 调用开始
-        try:
-            duration_int = int(duration_seconds) if duration_seconds else 8
-        except (ValueError, TypeError):
-            duration_int = 8
 
         if self._video_backend is None:
             raise RuntimeError("video_backend not configured")
@@ -485,7 +489,7 @@ class MediaGenerator:
             resource_id=resource_id,
             prompt=prompt,
             source_file=output_path,
-            duration_seconds=duration_seconds,
+            duration_seconds=duration_int,
             **version_metadata,
         )
 
@@ -597,6 +601,7 @@ class MediaGenerator:
         # 字段（model/resolution/duration/generate_audio）调 cost_calculator 算实际 cost，
         # 与 generate 路径 finish_call 自动算 cost 等价——避免视频已生成但账本永久漏记。
         # service_tier 由 caller 透传（ApiCall 模型无该列），让非 default 档位按真实档计费。
+        # usage_tokens 同样透传：Ark video 按 token 计费，缺省 0 时 cost 永远为 0。
         # WHERE status='pending' 仍保护幂等性，已 success 行不会被 touch。
         if api_call_id is not None:
             try:
@@ -604,6 +609,7 @@ class MediaGenerator:
                     call_id=api_call_id,
                     status="success",
                     service_tier=version_metadata.get("service_tier", "default"),
+                    usage_tokens=result.usage_tokens,
                 )
                 if affected == 0:
                     logger.info(

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -520,6 +520,15 @@ class MediaGenerator:
         output_path = self._get_output_path(resource_type, resource_id)
         self._ensure_parent_dir(output_path)
 
+        # 先把 duration 归一为 int：上游可能传 "8.0" 浮点字符串，直接 int("8.0") 会 ValueError
+        # 走兜底分支静默掉真实值（"10.0" 会被吞成 8）。先 float() 再 int() 保留语义。
+        # 提前到所有 ensure_current_tracked / VideoGenerationRequest 之前，让版本元数据
+        # 与 provider 请求里的 duration_seconds 类型一致（都是 int，避免 versions.json 落字符串）。
+        try:
+            duration_int = int(float(duration_seconds)) if duration_seconds else 8
+        except (ValueError, TypeError):
+            duration_int = 8
+
         # 开头的 ensure_current_tracked 覆盖「output_path 残留」场景（重试时旧文件还在）。
         # 末尾还会再调一次 ensure —— 两次幂等（get_current_version > 0 时 short-circuit）。
         if output_path.exists():
@@ -528,14 +537,9 @@ class MediaGenerator:
                 resource_id=resource_id,
                 current_file=output_path,
                 prompt=prompt,
-                duration_seconds=duration_seconds,
+                duration_seconds=duration_int,
                 **version_metadata,
             )
-
-        try:
-            duration_int = int(duration_seconds) if duration_seconds else 8
-        except (ValueError, TypeError):
-            duration_int = 8
 
         if self._video_backend is None:
             raise RuntimeError("video_backend not configured")
@@ -627,7 +631,7 @@ class MediaGenerator:
             resource_id=resource_id,
             current_file=output_path,
             prompt=prompt,
-            duration_seconds=duration_seconds,
+            duration_seconds=duration_int,
             **version_metadata,
         )
         new_version = self.versions.get_current_version(resource_type, resource_id)

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -566,19 +566,14 @@ class MediaGenerator:
         except ResumeExpiredError:
             # Pending ApiCall 翻 failed 而不是留 pending：让 /api/v1/usage 报表不堆积无终态行；
             # cost_amount=0 不增加计费（resume 不重扣，符合 "不主动扣费" 红线）。
+            # finalize 失败时不吞异常，让 worker finally 走 mark_failed 兜底，避免 ApiCall
+            # 永久卡 pending 导致 usage 报表/补账缺口（与 persist_api_call_id 的 fail-fast 一致）。
             if api_call_id is not None:
-                try:
-                    await self.usage_tracker.finalize_pending_by_call_id(
-                        call_id=api_call_id,
-                        cost_amount=0.0,
-                        status="failed",
-                    )
-                except Exception:
-                    logger.warning(
-                        "finalize_pending_by_call_id(failed) 失败 call_id=%d task_id=%s",
-                        api_call_id,
-                        task_id,
-                    )
+                await self.usage_tracker.finalize_pending_by_call_id(
+                    call_id=api_call_id,
+                    cost_amount=0.0,
+                    status="failed",
+                )
             raise
         except Exception:
             logger.exception("resume 失败 (video) task_id=%s job_id=%s", task_id, job_id)
@@ -592,27 +587,19 @@ class MediaGenerator:
         # 与 generate 路径 finish_call 自动算 cost 等价——避免视频已生成但账本永久漏记。
         # service_tier 由 caller 透传（ApiCall 模型无该列），让非 default 档位按真实档计费。
         # usage_tokens 同样透传：Ark video 按 token 计费，缺省 0 时 cost 永远为 0。
+        # generate_audio 从 backend 返回值透传：provider 在 submit 后可能降级/关闭音频，
+        # 与 generate 路径 finish_call(generate_audio=result.generate_audio) 等价，
+        # 避免按请求值误计费。
+        # finalize 失败时不吞异常，让 worker finally 兜底处理（与 ResumeExpired 分支一致）。
         # WHERE status='pending' 仍保护幂等性，已 success 行不会被 touch。
         if api_call_id is not None:
-            try:
-                affected = await self.usage_tracker.finalize_pending_by_call_id(
-                    call_id=api_call_id,
-                    status="success",
-                    service_tier=version_metadata.get("service_tier", "default"),
-                    usage_tokens=result.usage_tokens,
-                )
-                if affected == 0:
-                    logger.info(
-                        "finalize_pending_by_call_id 0 rows call_id=%d task_id=%s （已 success 或不存在）",
-                        api_call_id,
-                        task_id,
-                    )
-            except Exception:
-                logger.warning(
-                    "finalize_pending_by_call_id(success) 失败 call_id=%d task_id=%s",
-                    api_call_id,
-                    task_id,
-                )
+            await self.usage_tracker.finalize_pending_by_call_id(
+                call_id=api_call_id,
+                status="success",
+                service_tier=version_metadata.get("service_tier", "default"),
+                usage_tokens=result.usage_tokens,
+                generate_audio=result.generate_audio,
+            )
         else:
             logger.warning(
                 "resume 缺 api_call_id task_id=%s job_id=%s (旧任务未持久化 payload)",

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -592,12 +592,14 @@ class MediaGenerator:
         # Resume 成功：精准翻 pending → success。cost_amount=None 让 repo 按 ApiCall 行
         # 字段（model/resolution/duration/generate_audio）调 cost_calculator 算实际 cost，
         # 与 generate 路径 finish_call 自动算 cost 等价——避免视频已生成但账本永久漏记。
+        # service_tier 由 caller 透传（ApiCall 模型无该列），让非 default 档位按真实档计费。
         # WHERE status='pending' 仍保护幂等性，已 success 行不会被 touch。
         if api_call_id is not None:
             try:
                 affected = await self.usage_tracker.finalize_pending_by_call_id(
                     call_id=api_call_id,
                     status="success",
+                    service_tier=version_metadata.get("service_tier", "default"),
                 )
                 if affected == 0:
                     logger.info(

--- a/lib/usage_tracker.py
+++ b/lib/usage_tracker.py
@@ -52,6 +52,23 @@ class UsageTracker:
                 segment_id=segment_id,
             )
 
+    async def finalize_pending_by_call_id(
+        self,
+        *,
+        call_id: int,
+        cost_amount: float = 0.0,
+        currency: str = "USD",
+        status: str = "success",
+    ) -> int:
+        async with self._session_factory() as session:
+            repo = UsageRepository(session)
+            return await repo.finalize_pending_by_call_id(
+                call_id=call_id,
+                cost_amount=cost_amount,
+                currency=currency,
+                status=status,
+            )
+
     async def finish_call(
         self,
         call_id: int,

--- a/lib/usage_tracker.py
+++ b/lib/usage_tracker.py
@@ -56,8 +56,8 @@ class UsageTracker:
         self,
         *,
         call_id: int,
-        cost_amount: float = 0.0,
-        currency: str = "USD",
+        cost_amount: float | None = None,
+        currency: str | None = None,
         status: str = "success",
     ) -> int:
         async with self._session_factory() as session:

--- a/lib/usage_tracker.py
+++ b/lib/usage_tracker.py
@@ -59,6 +59,7 @@ class UsageTracker:
         cost_amount: float | None = None,
         currency: str | None = None,
         status: str = "success",
+        service_tier: str = "default",
     ) -> int:
         async with self._session_factory() as session:
             repo = UsageRepository(session)
@@ -67,6 +68,7 @@ class UsageTracker:
                 cost_amount=cost_amount,
                 currency=currency,
                 status=status,
+                service_tier=service_tier,
             )
 
     async def finish_call(

--- a/lib/usage_tracker.py
+++ b/lib/usage_tracker.py
@@ -61,6 +61,7 @@ class UsageTracker:
         status: str = "success",
         service_tier: str = "default",
         usage_tokens: int | None = None,
+        generate_audio: bool | None = None,
     ) -> int:
         async with self._session_factory() as session:
             repo = UsageRepository(session)
@@ -71,6 +72,7 @@ class UsageTracker:
                 status=status,
                 service_tier=service_tier,
                 usage_tokens=usage_tokens,
+                generate_audio=generate_audio,
             )
 
     async def finish_call(

--- a/lib/usage_tracker.py
+++ b/lib/usage_tracker.py
@@ -60,6 +60,7 @@ class UsageTracker:
         currency: str | None = None,
         status: str = "success",
         service_tier: str = "default",
+        usage_tokens: int | None = None,
     ) -> int:
         async with self._session_factory() as session:
             repo = UsageRepository(session)
@@ -69,6 +70,7 @@ class UsageTracker:
                 currency=currency,
                 status=status,
                 service_tier=service_tier,
+                usage_tokens=usage_tokens,
             )
 
     async def finish_call(

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -21,7 +21,7 @@ from lib.video_backends.base import (
     VideoGenerationResult,
     download_video,
     get_resume_job_id,
-    persist_job_id_if_in_task_context,
+    persist_provider_job_id,
     poll_with_retry,
 )
 
@@ -90,14 +90,15 @@ class ArkVideoBackend:
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         """生成视频。任务创建和轮询阶段分离重试，避免瞬态错误导致重建任务。"""
-        # 重启自愈：worker _process_resume_task 入口 set _RESUME_JOB_ID 时跳 submit
+        # Resume 短路（共存阶段，commit 3 切 worker 后删除）
         resume_id = get_resume_job_id()
         if resume_id is not None:
             return await self.resume_video(resume_id, request)
 
-        task_id = await self._create_task(request)
-        await persist_job_id_if_in_task_context(task_id, provider=PROVIDER_ARK)
-        return await self._poll_until_done(task_id, request)
+        provider_task_id = await self._create_task(request)
+        if request.task_id is not None:
+            await persist_provider_job_id(request.task_id, provider_task_id, provider=PROVIDER_ARK)
+        return await self._poll_until_done(provider_task_id, request)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
         """接续已 submit 的 Ark task：仅 poll + 下载。

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -20,7 +20,6 @@ from lib.video_backends.base import (
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
-    get_resume_job_id,
     persist_provider_job_id,
     poll_with_retry,
 )
@@ -90,11 +89,6 @@ class ArkVideoBackend:
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         """生成视频。任务创建和轮询阶段分离重试，避免瞬态错误导致重建任务。"""
-        # Resume 短路（共存阶段，commit 3 切 worker 后删除）
-        resume_id = get_resume_job_id()
-        if resume_id is not None:
-            return await self.resume_video(resume_id, request)
-
         provider_task_id = await self._create_task(request)
         if request.task_id is not None:
             await persist_provider_job_id(request.task_id, provider_task_id, provider=PROVIDER_ARK)

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -96,7 +96,7 @@ class ArkVideoBackend:
             return await self.resume_video(resume_id, request)
 
         task_id = await self._create_task(request)
-        await persist_job_id_if_in_task_context(task_id)
+        await persist_job_id_if_in_task_context(task_id, provider=PROVIDER_ARK)
         return await self._poll_until_done(task_id, request)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
@@ -248,9 +248,15 @@ class ArkVideoBackend:
 
 
 def _is_ark_not_found(exc: BaseException) -> bool:
-    """识别 Ark 任务「不存在 / 已过期」响应。"""
+    """识别 Ark 任务「不存在 / 已过期」响应。
+
+    精确匹配官方稳定 ``task_not_found`` 错误码；移除宽泛的 ``"not found"`` 子串兜底，
+    避免业务侧错误（如 reference image not found）被误判为 provider 端任务过期。
+    ``expired`` 字串保留：Ark 自身 ``_poll_until_done`` 把 status in (failed, expired)
+    转成 ``RuntimeError("Ark 任务失败 ... status=expired")``，要靠该字串识别回 ResumeExpiredError。
+    """
     status_code = getattr(exc, "status_code", None) or getattr(getattr(exc, "response", None), "status_code", None)
     if status_code == 404:
         return True
     msg = str(exc).lower()
-    return "task_not_found" in msg or "tasknotfound" in msg or "expired" in msg or "not found" in msg
+    return "task_not_found" in msg or "tasknotfound" in msg or "expired" in msg

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -13,10 +13,22 @@ from pathlib import Path
 from typing import Protocol
 
 import httpx
+from sqlalchemy.exc import InterfaceError, OperationalError
 
 from lib.retry import BASE_RETRYABLE_ERRORS, _should_retry, with_retry_async
 
 logger = logging.getLogger(__name__)
+
+# DB 瞬态错误集合：sqlite "database is locked"、pg "could not connect" / 连接已关闭。
+# 故意不收 DBAPIError 父类——会兜住 IntegrityError/DataError/ProgrammingError 等非瞬态
+# 错误（SQL 语法 / 约束违反），重试无意义且拖延 fail-fast。
+_PERSIST_RETRYABLE_ERRORS: tuple[type[Exception], ...] = (
+    OperationalError,
+    InterfaceError,
+    ConnectionError,
+    TimeoutError,
+)
+_PERSIST_BACKOFF_SECONDS: tuple[int, ...] = (1, 2, 4)
 
 
 # Worker 在 _process_task / _process_resume_task 入口 set 当前 task_id；
@@ -52,22 +64,37 @@ def get_resume_job_id() -> str | None:
     return _RESUME_JOB_ID.get(None)
 
 
-async def persist_job_id_if_in_task_context(job_id: str) -> None:
+@with_retry_async(
+    max_attempts=3,
+    backoff_seconds=_PERSIST_BACKOFF_SECONDS,
+    retryable_errors=_PERSIST_RETRYABLE_ERRORS,
+)
+async def _persist_with_retry(tid: str, job_id: str) -> None:
+    from lib.generation_queue import get_generation_queue
+
+    await get_generation_queue().persist_provider_job_id(tid, job_id)
+
+
+async def persist_job_id_if_in_task_context(job_id: str, *, provider: str) -> None:
     """Submit 之后立即调：把 job_id 持久化到 DB 让重启可接续。
 
-    非 worker 路径 (contextvar 未 set) → no-op；worker 路径失败抛异常，
-    由 worker finally 兜底 mark_failed（ADR 0007 fail-fast）。
+    非 worker 路径 (contextvar 未 set) → no-op；DB 瞬态错误最多重试 3 次；
+    重试用尽抛异常，由 worker finally 兜底 mark_failed（ADR 0007 fail-fast）。
     """
     tid = _CURRENT_TASK_ID.get(None)
     if tid is None:
         return
     try:
-        from lib.generation_queue import get_generation_queue
-
-        await get_generation_queue().persist_provider_job_id(tid, job_id)
-        logger.info("provider_job_id 已持久化 task_id=%s job_id=%s", tid, job_id)
-    except Exception:
-        logger.exception("provider_job_id 持久化失败 task_id=%s job_id=%s", tid, job_id)
+        await _persist_with_retry(tid, job_id)
+        logger.info("provider_job_id 已持久化 task_id=%s provider=%s job_id=%s", tid, provider, job_id)
+    except Exception as exc:
+        logger.error(
+            "provider_job_id_persist_failed task_id=%s provider=%s job_id=%s error=%s",
+            tid,
+            provider,
+            job_id,
+            exc,
+        )
         raise
 
 

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -81,22 +81,24 @@ async def persist_api_call_id(task_id: str, call_id: int) -> None:
     """Start_call 拿到 call_id 后立即调：把 ApiCall.id 写入 task.payload。
 
     Resume 路径据此精准翻 pending ApiCall 行而不是按 segment_id+LIMIT 1 模糊匹配。
-    与 ``persist_provider_job_id`` 同样走 DB 瞬态错误重试；持久化失败不阻断 generate
-    主流程——日志 ``logger.warning`` 记录后吞掉。理由：api_call 行已在 DB 上（status=
-    pending），resume 时即便无 task.payload 锚定，generate 路径自身的 finish_call
-    仍会照常 success 化；只是 resume 路径无法精准翻这条 pending 行（其降级是 warning
-    日志而不是 crash，避免连带 task 失败）。
+    与 ``persist_provider_job_id`` 同样走 DB 瞬态错误重试；重试用尽抛异常，由
+    media_generator 的外层 try/except 走 finish_call(failed) 翻 pending ApiCall，
+    并把异常冒泡给 worker finally 兜底 mark_failed（ADR 0007 fail-fast：未持久化
+    的 submit 视为整笔失败——provider 端尚未提交，无需担心「幽灵任务」；若已提交
+    则 resume 拿不到 api_call_id 锚定将永远留 pending 账目，必须 fail-fast 让记账
+    在原地翻 failed 而不是延后到永远不会发生的 resume）。
     """
     try:
         await _persist_api_call_id_with_retry(task_id, call_id)
         logger.info("api_call_id 已持久化 task_id=%s call_id=%d", task_id, call_id)
     except Exception as exc:
-        logger.warning(
-            "api_call_id_persist_failed task_id=%s call_id=%d error=%s (resume 路径将走旧任务降级)",
+        logger.error(
+            "api_call_id_persist_failed task_id=%s call_id=%d error=%s",
             task_id,
             call_id,
             exc,
         )
+        raise
 
 
 class ResumeExpiredError(RuntimeError):

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -17,6 +17,11 @@ from sqlalchemy.exc import InterfaceError, OperationalError
 
 from lib.retry import BASE_RETRYABLE_ERRORS, _should_retry, with_retry_async
 
+# `_should_retry` 默认会做字符串模式兜底（"timeout"/"503" 等），
+# 而 persist 重试要严格"DB 瞬态错误"语义——业务异常（如
+# `ValueError("Connection timed out: rate")`）不该被字符串子串吞掉。
+# 显式传 `retry_if=lambda e: isinstance(e, _PERSIST_RETRYABLE_ERRORS)` 关掉兜底。
+
 logger = logging.getLogger(__name__)
 
 # DB 瞬态错误集合：sqlite "database is locked"、pg "could not connect" / 连接已关闭。
@@ -67,35 +72,40 @@ def get_resume_job_id() -> str | None:
 @with_retry_async(
     max_attempts=3,
     backoff_seconds=_PERSIST_BACKOFF_SECONDS,
-    retryable_errors=_PERSIST_RETRYABLE_ERRORS,
+    retry_if=lambda e: isinstance(e, _PERSIST_RETRYABLE_ERRORS),
 )
-async def _persist_with_retry(tid: str, job_id: str) -> None:
+async def _persist_with_retry(task_id: str, job_id: str) -> None:
     from lib.generation_queue import get_generation_queue
 
-    await get_generation_queue().persist_provider_job_id(tid, job_id)
+    await get_generation_queue().persist_provider_job_id(task_id, job_id)
 
 
-async def persist_job_id_if_in_task_context(job_id: str, *, provider: str) -> None:
+async def persist_provider_job_id(task_id: str, job_id: str, *, provider: str) -> None:
     """Submit 之后立即调：把 job_id 持久化到 DB 让重启可接续。
 
-    非 worker 路径 (contextvar 未 set) → no-op；DB 瞬态错误最多重试 3 次；
-    重试用尽抛异常，由 worker finally 兜底 mark_failed（ADR 0007 fail-fast）。
+    Caller 显式传 task_id；DB 瞬态错误最多重试 3 次，业务异常立即抛。
+    重试用尽抛异常，由 worker finally 兜底 mark_failed（fail-fast）。
     """
-    tid = _CURRENT_TASK_ID.get(None)
-    if tid is None:
-        return
     try:
-        await _persist_with_retry(tid, job_id)
-        logger.info("provider_job_id 已持久化 task_id=%s provider=%s job_id=%s", tid, provider, job_id)
+        await _persist_with_retry(task_id, job_id)
+        logger.info("provider_job_id 已持久化 task_id=%s provider=%s job_id=%s", task_id, provider, job_id)
     except Exception as exc:
         logger.error(
             "provider_job_id_persist_failed task_id=%s provider=%s job_id=%s error=%s",
-            tid,
+            task_id,
             provider,
             job_id,
             exc,
         )
         raise
+
+
+async def persist_job_id_if_in_task_context(job_id: str, *, provider: str) -> None:
+    """Deprecated: 旧 ContextVar 入口，保留作为兼容垫片直到 4 backend 都切到显式 caller。"""
+    task_id = _CURRENT_TASK_ID.get(None)
+    if task_id is None:
+        return
+    await persist_provider_job_id(task_id, job_id, provider=provider)
 
 
 class ResumeExpiredError(RuntimeError):
@@ -244,6 +254,11 @@ class VideoGenerationRequest:
 
     # 项目上下文（用于构建文件服务 URL 等）
     project_name: str | None = None
+
+    # Worker 路径下从 task["task_id"] 传入，让 backend submit 后能直接调
+    # `persist_provider_job_id(task_id, job_id)` 持久化。
+    # 非 worker 路径（grid / 直生 / 测试）保持 None，backend 跳过持久化。
+    task_id: str | None = None
 
     # Seedance 特有
     service_tier: str = "default"

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 import time
 from collections.abc import Awaitable, Callable
-from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -34,39 +33,6 @@ _PERSIST_RETRYABLE_ERRORS: tuple[type[Exception], ...] = (
     TimeoutError,
 )
 _PERSIST_BACKOFF_SECONDS: tuple[int, ...] = (1, 2, 4)
-
-
-# Worker 在 _process_task / _process_resume_task 入口 set 当前 task_id；
-# backend.generate 拿到 job_id 后调 persist_provider_job_id 让 ADR 0007
-# 「重启接续轮询不重 submit」可达。非 worker 路径（测试 / grid / 直生）
-# get(None) 默认返回 None，helper 自然 no-op。
-_CURRENT_TASK_ID: ContextVar[str | None] = ContextVar("arcreel_current_task_id", default=None)
-
-# 重启自愈：worker _process_resume_task 入口 set 上轮已持久化的 job_id；
-# backend.generate 检测到该 var 时跳过 submit、直接 resume_video（接续轮询）。
-# 走完后 worker 清空 var。
-_RESUME_JOB_ID: ContextVar[str | None] = ContextVar("arcreel_resume_job_id", default=None)
-
-
-def set_current_task_id(task_id: str | None) -> object:
-    """Worker 入口 set 当前 task_id；返回 token，由 caller reset。"""
-    return _CURRENT_TASK_ID.set(task_id)
-
-
-def reset_current_task_id(token: object) -> None:
-    _CURRENT_TASK_ID.reset(token)  # pyright: ignore[reportArgumentType]
-
-
-def set_resume_job_id(job_id: str | None) -> object:
-    return _RESUME_JOB_ID.set(job_id)
-
-
-def reset_resume_job_id(token: object) -> None:
-    _RESUME_JOB_ID.reset(token)  # pyright: ignore[reportArgumentType]
-
-
-def get_resume_job_id() -> str | None:
-    return _RESUME_JOB_ID.get(None)
 
 
 @with_retry_async(
@@ -98,14 +64,6 @@ async def persist_provider_job_id(task_id: str, job_id: str, *, provider: str) -
             exc,
         )
         raise
-
-
-async def persist_job_id_if_in_task_context(job_id: str, *, provider: str) -> None:
-    """Deprecated: 旧 ContextVar 入口，保留作为兼容垫片直到 4 backend 都切到显式 caller。"""
-    task_id = _CURRENT_TASK_ID.get(None)
-    if task_id is None:
-        return
-    await persist_provider_job_id(task_id, job_id, provider=provider)
 
 
 class ResumeExpiredError(RuntimeError):

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -66,6 +66,39 @@ async def persist_provider_job_id(task_id: str, job_id: str, *, provider: str) -
         raise
 
 
+@with_retry_async(
+    max_attempts=3,
+    backoff_seconds=_PERSIST_BACKOFF_SECONDS,
+    retry_if=lambda e: isinstance(e, _PERSIST_RETRYABLE_ERRORS),
+)
+async def _persist_api_call_id_with_retry(task_id: str, call_id: int) -> None:
+    from lib.generation_queue import get_generation_queue
+
+    await get_generation_queue().persist_api_call_id(task_id, call_id)
+
+
+async def persist_api_call_id(task_id: str, call_id: int) -> None:
+    """Start_call 拿到 call_id 后立即调：把 ApiCall.id 写入 task.payload。
+
+    Resume 路径据此精准翻 pending ApiCall 行而不是按 segment_id+LIMIT 1 模糊匹配。
+    与 ``persist_provider_job_id`` 同样走 DB 瞬态错误重试；持久化失败不阻断 generate
+    主流程——日志 ``logger.warning`` 记录后吞掉。理由：api_call 行已在 DB 上（status=
+    pending），resume 时即便无 task.payload 锚定，generate 路径自身的 finish_call
+    仍会照常 success 化；只是 resume 路径无法精准翻这条 pending 行（其降级是 warning
+    日志而不是 crash，避免连带 task 失败）。
+    """
+    try:
+        await _persist_api_call_id_with_retry(task_id, call_id)
+        logger.info("api_call_id 已持久化 task_id=%s call_id=%d", task_id, call_id)
+    except Exception as exc:
+        logger.warning(
+            "api_call_id_persist_failed task_id=%s call_id=%d error=%s (resume 路径将走旧任务降级)",
+            task_id,
+            call_id,
+            exc,
+        )
+
+
 class ResumeExpiredError(RuntimeError):
     """Provider 端 job 已过期或未找到——重启自愈无法接续，须走 mark_failed。
 

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -23,7 +23,7 @@ from lib.video_backends.base import (
     VideoGenerationRequest,
     VideoGenerationResult,
     get_resume_job_id,
-    persist_job_id_if_in_task_context,
+    persist_provider_job_id,
     poll_with_retry,
 )
 
@@ -112,7 +112,7 @@ class GeminiVideoBackend:
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         """生成视频。任务创建和轮询阶段分离重试，避免瞬态错误导致重建任务。"""
-        # 重启自愈：worker _process_resume_task 入口 set _RESUME_JOB_ID 时跳 submit
+        # Resume 短路（共存阶段，commit 3 切 worker 后删除）
         resume_id = get_resume_job_id()
         if resume_id is not None:
             return await self.resume_video(resume_id, request)
@@ -121,10 +121,11 @@ class GeminiVideoBackend:
         op_name = getattr(operation, "name", None)
         if not op_name:
             # fail-fast：缺 operation.name 意味着 submit 成功但无法持久化 provider_job_id，
-            # 一旦进程中断，孤儿处理会走 [restart_lost] 回退到重新提交路径——这正是 ADR 0007
-            # 要避免的重复扣费场景。直接抛错让 worker finally 标 failed，比静默继续 poll 安全。
+            # 一旦进程中断，孤儿处理会走 [restart_lost] 回退到重新提交路径——这正是要避免的
+            # 重复扣费场景。直接抛错让 worker finally 标 failed，比静默继续 poll 安全。
             raise RuntimeError("Gemini 提交成功但未返回 operation.name，无法持久化 provider_job_id")
-        await persist_job_id_if_in_task_context(op_name, provider=PROVIDER_GEMINI)
+        if request.task_id is not None:
+            await persist_provider_job_id(request.task_id, op_name, provider=PROVIDER_GEMINI)
         return await self._poll_until_done(operation, request)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -22,7 +22,6 @@ from lib.video_backends.base import (
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
-    get_resume_job_id,
     persist_provider_job_id,
     poll_with_retry,
 )
@@ -112,11 +111,6 @@ class GeminiVideoBackend:
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         """生成视频。任务创建和轮询阶段分离重试，避免瞬态错误导致重建任务。"""
-        # Resume 短路（共存阶段，commit 3 切 worker 后删除）
-        resume_id = get_resume_job_id()
-        if resume_id is not None:
-            return await self.resume_video(resume_id, request)
-
         operation = await self._create_task(request)
         op_name = getattr(operation, "name", None)
         if not op_name:

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -128,15 +128,21 @@ class GeminiVideoBackend:
         Operation 是 ABC，不可实例化；具体 LRO 子类 GenerateVideosOperation 通过
         Pydantic v2 ``model_validate`` 接收 dict 构造（pyright 对 Pydantic 多继承的
         字段推断不全，用 model_validate 绕开）。
+
+        NOT_FOUND 既可能在初次 ``operations.get`` 抛，也可能在 ``_poll_until_done`` 内
+        mid-poll 抛（远端 GC 了 LRO）。两处都需要归类为 ResumeExpiredError 让 worker
+        finally 走 ``[resume_expired]``——下面的 try/except 把整段包住。
         """
         op = self._types.GenerateVideosOperation.model_validate({"name": job_id, "done": False})
         try:
             refreshed = await self._client.aio.operations.get(op)
+            return await self._poll_until_done(refreshed, request)
+        except ResumeExpiredError:
+            raise
         except Exception as exc:
             if _is_gemini_not_found(exc):
                 raise ResumeExpiredError(job_id=job_id, provider=PROVIDER_GEMINI) from exc
             raise
-        return await self._poll_until_done(refreshed, request)
 
     @with_retry_async()
     async def _create_task(self, request: VideoGenerationRequest) -> Any:

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -124,7 +124,7 @@ class GeminiVideoBackend:
             # 一旦进程中断，孤儿处理会走 [restart_lost] 回退到重新提交路径——这正是 ADR 0007
             # 要避免的重复扣费场景。直接抛错让 worker finally 标 failed，比静默继续 poll 安全。
             raise RuntimeError("Gemini 提交成功但未返回 operation.name，无法持久化 provider_job_id")
-        await persist_job_id_if_in_task_context(op_name)
+        await persist_job_id_if_in_task_context(op_name, provider=PROVIDER_GEMINI)
         return await self._poll_until_done(operation, request)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
@@ -317,7 +317,11 @@ class GeminiVideoBackend:
 
 
 def _is_gemini_not_found(exc: BaseException) -> bool:
-    """识别 Gemini operations.get 「operation 不存在 / 已过期」响应。"""
+    """识别 Gemini operations.get 「operation 不存在 / 已过期」响应。
+
+    INVALID_ARGUMENT 不归过期：Gemini 用它表达入参不合法（如非法 operation 格式），
+    与 NOT_FOUND（资源不存在）语义不同；归过期会把客户端 bug 当成幽灵任务静默吞掉。
+    """
     try:
         from google.genai import errors as _genai_errors  # pyright: ignore[reportMissingImports]
     except ImportError:
@@ -327,7 +331,7 @@ def _is_gemini_not_found(exc: BaseException) -> bool:
         not_found_cls = getattr(_genai_errors, "ClientError", None) or getattr(_genai_errors, "APIError", None)
         if not_found_cls is not None and isinstance(exc, not_found_cls):
             code = getattr(exc, "code", None) or getattr(exc, "status_code", None)
-            if code in (404, "404", "NOT_FOUND", "INVALID_ARGUMENT"):
+            if code in (404, "404", "NOT_FOUND"):
                 return True
     msg = str(exc).lower()
-    return "not found" in msg or "invalid_argument" in msg or "expired" in msg
+    return "not found" in msg or "expired" in msg

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -155,7 +155,7 @@ class NewAPIVideoBackend:
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             task_id = await self._create_task(client, payload)
             logger.info("NewAPI 任务创建: task_id=%s", task_id)
-            await persist_job_id_if_in_task_context(task_id)
+            await persist_job_id_if_in_task_context(task_id, provider=PROVIDER_NEWAPI)
             return await self._poll_and_build(client, task_id, request)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
@@ -171,9 +171,20 @@ class NewAPIVideoBackend:
     async def _poll_and_build(
         self, client: httpx.AsyncClient, task_id: str, request: VideoGenerationRequest
     ) -> VideoGenerationResult:
+        def _is_done(state: dict) -> bool:
+            # 与 OpenAI 对称：在 is_done 内识别 expired 抛 ResumeExpiredError，
+            # 让 worker finally 走 [resume_expired] 路径，避免白等 max_wait。
+            if state.get("status") == "expired":
+                raise ResumeExpiredError(
+                    job_id=task_id,
+                    provider=PROVIDER_NEWAPI,
+                    message=f"NewAPI task expired: {task_id}",
+                )
+            return state.get("status") == "completed"
+
         final = await poll_with_retry(
             poll_fn=lambda: self._poll_once(client, task_id),
-            is_done=lambda s: s.get("status") == "completed",
+            is_done=_is_done,
             is_failed=_extract_failure,
             poll_interval=_POLL_INTERVAL_SECONDS,
             max_wait=self._max_wait(request.duration_seconds),

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -29,7 +29,7 @@ from lib.video_backends.base import (
     VideoGenerationResult,
     download_video,
     get_resume_job_id,
-    persist_job_id_if_in_task_context,
+    persist_provider_job_id,
     poll_with_retry,
 )
 
@@ -112,7 +112,7 @@ class NewAPIVideoBackend:
         return VideoCapabilities(reference_images=False, max_reference_images=0)
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
-        # 重启自愈：worker _process_resume_task 入口 set _RESUME_JOB_ID 时跳 submit
+        # Resume 短路（共存阶段，commit 3 切 worker 后删除）
         resume_id = get_resume_job_id()
         if resume_id is not None:
             return await self.resume_video(resume_id, request)
@@ -153,10 +153,11 @@ class NewAPIVideoBackend:
         logger.info("调用 %s 视频 SDK payload=%s", self.name, format_kwargs_for_log(payload))
 
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
-            task_id = await self._create_task(client, payload)
-            logger.info("NewAPI 任务创建: task_id=%s", task_id)
-            await persist_job_id_if_in_task_context(task_id, provider=PROVIDER_NEWAPI)
-            return await self._poll_and_build(client, task_id, request)
+            provider_task_id = await self._create_task(client, payload)
+            logger.info("NewAPI 任务创建: task_id=%s", provider_task_id)
+            if request.task_id is not None:
+                await persist_provider_job_id(request.task_id, provider_task_id, provider=PROVIDER_NEWAPI)
+            return await self._poll_and_build(client, provider_task_id, request)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
         """接续已 submit 的 NewAPI task：仅 poll + 下载。"""

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -151,41 +151,47 @@ class NewAPIVideoBackend:
             logger.info("NewAPI 任务创建: task_id=%s", provider_task_id)
             if request.task_id is not None:
                 await persist_provider_job_id(request.task_id, provider_task_id, provider=PROVIDER_NEWAPI)
-            return await self._poll_and_build(client, provider_task_id, request)
+            return await self._poll_and_build(client, provider_task_id, request, is_resume=False)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
         """接续已 submit 的 NewAPI task：仅 poll + 下载。"""
         try:
             async with httpx.AsyncClient(timeout=self._http_timeout) as client:
-                return await self._poll_and_build(client, job_id, request)
+                return await self._poll_and_build(client, job_id, request, is_resume=True)
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 404:
                 raise ResumeExpiredError(job_id=job_id, provider=PROVIDER_NEWAPI) from exc
             raise
 
     async def _poll_and_build(
-        self, client: httpx.AsyncClient, task_id: str, request: VideoGenerationRequest
+        self,
+        client: httpx.AsyncClient,
+        task_id: str,
+        request: VideoGenerationRequest,
+        *,
+        is_resume: bool,
     ) -> VideoGenerationResult:
-        def _is_done(state: dict) -> bool:
-            # 与 OpenAI 对称：在 is_done 内识别 expired 抛 ResumeExpiredError，
-            # 让 worker finally 走 [resume_expired] 路径，避免白等 max_wait。
-            if state.get("status") == "expired":
-                raise ResumeExpiredError(
-                    job_id=task_id,
-                    provider=PROVIDER_NEWAPI,
-                    message=f"NewAPI task expired: {task_id}",
-                )
-            return state.get("status") == "completed"
-
+        # _is_done 纯谓词：completed / failed / expired 均视为终态；caller 按 is_resume
+        # flag 决定 expired 抛 RuntimeError（generate）还是 ResumeExpiredError（resume）。
         final = await poll_with_retry(
             poll_fn=lambda: self._poll_once(client, task_id),
-            is_done=_is_done,
+            is_done=lambda state: state.get("status") in ("completed", "failed", "expired"),
             is_failed=_extract_failure,
             poll_interval=_POLL_INTERVAL_SECONDS,
             max_wait=self._max_wait(request.duration_seconds),
             retryable_errors=_NEWAPI_RETRYABLE_ERRORS,
             label="NewAPI",
         )
+
+        if final.get("status") == "expired":
+            if is_resume:
+                raise ResumeExpiredError(
+                    job_id=task_id,
+                    provider=PROVIDER_NEWAPI,
+                    message=f"NewAPI task expired: {task_id}",
+                )
+            raise RuntimeError(f"NewAPI task expired during generate: {task_id}")
+
         video_url = final.get("url")
         if not video_url:
             raise RuntimeError(f"NewAPI 任务完成但缺少 url 字段: {final}")

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -28,7 +28,6 @@ from lib.video_backends.base import (
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
-    get_resume_job_id,
     persist_provider_job_id,
     poll_with_retry,
 )
@@ -112,11 +111,6 @@ class NewAPIVideoBackend:
         return VideoCapabilities(reference_images=False, max_reference_images=0)
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
-        # Resume 短路（共存阶段，commit 3 切 worker 后删除）
-        resume_id = get_resume_job_id()
-        if resume_id is not None:
-            return await self.resume_video(resume_id, request)
-
         width, height = _resolve_size(request.resolution, request.aspect_ratio)
         payload: dict = {
             "model": self._model,

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -155,13 +155,8 @@ class NewAPIVideoBackend:
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
         """接续已 submit 的 NewAPI task：仅 poll + 下载。"""
-        try:
-            async with httpx.AsyncClient(timeout=self._http_timeout) as client:
-                return await self._poll_and_build(client, job_id, request, is_resume=True)
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code == 404:
-                raise ResumeExpiredError(job_id=job_id, provider=PROVIDER_NEWAPI) from exc
-            raise
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            return await self._poll_and_build(client, job_id, request, is_resume=True)
 
     async def _poll_and_build(
         self,
@@ -173,8 +168,20 @@ class NewAPIVideoBackend:
     ) -> VideoGenerationResult:
         # _is_done 纯谓词：completed / failed / expired 均视为终态；caller 按 is_resume
         # flag 决定 expired 抛 RuntimeError（generate）还是 ResumeExpiredError（resume）。
+        # resume 路径下 4xx（特别 404）由 _gated_poll 直接抛 ResumeExpiredError 而不
+        # 走 poll_with_retry 的 HTTPStatusError 重试：原 retryable_errors 包含
+        # HTTPStatusError 会让 404 被无限重试到 max_wait 超时，过期任务永远不会落
+        # [resume_expired]，对应 pending ApiCall 也不走 failed/cost=0 路径。
+        async def _gated_poll() -> dict:
+            try:
+                return await self._poll_once(client, task_id)
+            except httpx.HTTPStatusError as exc:
+                if is_resume and exc.response.status_code == 404:
+                    raise ResumeExpiredError(job_id=task_id, provider=PROVIDER_NEWAPI) from exc
+                raise
+
         final = await poll_with_retry(
-            poll_fn=lambda: self._poll_once(client, task_id),
+            poll_fn=_gated_poll,
             is_done=lambda state: state.get("status") in ("completed", "failed", "expired"),
             is_failed=_extract_failure,
             poll_interval=_POLL_INTERVAL_SECONDS,

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -131,7 +131,7 @@ class OpenAIVideoBackend:
 
         video = await self._create_video(**kwargs)
         # submit 成功立即持久化 job_id；持久化失败抛 → finally mark_failed（ADR 0007）
-        await persist_job_id_if_in_task_context(video.id)
+        await persist_job_id_if_in_task_context(video.id, provider=PROVIDER_OPENAI)
         final = await self._poll_until_complete(video.id, request.duration_seconds)
 
         return await self._download_and_build_result(final, request, kwargs)
@@ -182,9 +182,21 @@ class OpenAIVideoBackend:
         """
         max_wait = max(_MIN_POLL_TIMEOUT_SECONDS, float(duration_seconds) * _POLL_TIMEOUT_PER_SECOND)
 
+        def _is_done(v) -> bool:
+            # 在 is_done 内识别 expired——poll_with_retry 的 else 分支不在 except 块内，
+            # raise 自然冒泡；ResumeExpiredError 不在 OPENAI_RETRYABLE_ERRORS 内，
+            # 外层 except 不会重试。
+            if v.status == "expired":
+                raise ResumeExpiredError(
+                    job_id=v.id,
+                    provider=PROVIDER_OPENAI,
+                    message=f"OpenAI Sora job expired: {v.id}",
+                )
+            return v.status == "completed"
+
         return await poll_with_retry(
             poll_fn=lambda: self._client.videos.retrieve(video_id),
-            is_done=lambda v: v.status == "completed",
+            is_done=_is_done,
             is_failed=lambda v: f"Sora 视频生成失败: {getattr(v, 'error', None)}" if v.status == "failed" else None,
             poll_interval=_POLL_INTERVAL_SECONDS,
             max_wait=max_wait,
@@ -211,7 +223,12 @@ def _encode_start_image(image_path: Path) -> tuple[str, bytes, str]:
 
 
 def _is_openai_not_found(exc: BaseException) -> bool:
-    """识别 OpenAI/Sora 「job 不存在 / 已过期」响应（NotFoundError、HTTP 404、status=expired）。"""
+    """识别 OpenAI/Sora 「job 不存在」响应（NotFoundError / HTTP 404）。
+
+    不再做 ``"not found"`` / ``"expired"`` 子串兜底：``status='expired'`` 已在
+    ``_poll_until_complete`` 内直接抛 ``ResumeExpiredError`` 处理（fix #5），
+    宽泛字串会把诸如 ``"file not found in storage"`` 等业务错误误判为幽灵任务。
+    """
     try:
         from openai import NotFoundError  # pyright: ignore[reportMissingImports]
     except ImportError:
@@ -220,7 +237,4 @@ def _is_openai_not_found(exc: BaseException) -> bool:
     if NotFoundError is not None and isinstance(exc, NotFoundError):
         return True
     status_code = getattr(exc, "status_code", None) or getattr(getattr(exc, "response", None), "status_code", None)
-    if status_code == 404:
-        return True
-    msg = str(exc).lower()
-    return "not found" in msg or "expired" in msg
+    return status_code == 404

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -17,7 +17,6 @@ from lib.video_backends.base import (
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
-    get_resume_job_id,
     persist_provider_job_id,
     poll_with_retry,
 )
@@ -98,12 +97,6 @@ class OpenAIVideoBackend:
         return VideoCapabilities(reference_images=True, max_reference_images=3)
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
-        # Resume 短路（共存阶段）：worker _process_resume_task 入口仍 set _RESUME_JOB_ID；
-        # 后续 commit 将 worker 改为直接调 backend.resume_video 后，此分支删除。
-        resume_id = get_resume_job_id()
-        if resume_id is not None:
-            return await self.resume_video(resume_id, request)
-
         kwargs: dict = {
             "prompt": request.prompt,
             "model": self._model,

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -18,7 +18,7 @@ from lib.video_backends.base import (
     VideoGenerationRequest,
     VideoGenerationResult,
     get_resume_job_id,
-    persist_job_id_if_in_task_context,
+    persist_provider_job_id,
     poll_with_retry,
 )
 
@@ -98,8 +98,8 @@ class OpenAIVideoBackend:
         return VideoCapabilities(reference_images=True, max_reference_images=3)
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
-        # 重启自愈：worker _process_resume_task 入口 set _RESUME_JOB_ID 时跳 submit
-        # 直接 resume_video，避免重复扣费（ADR 0007）。
+        # Resume 短路（共存阶段）：worker _process_resume_task 入口仍 set _RESUME_JOB_ID；
+        # 后续 commit 将 worker 改为直接调 backend.resume_video 后，此分支删除。
         resume_id = get_resume_job_id()
         if resume_id is not None:
             return await self.resume_video(resume_id, request)
@@ -130,8 +130,10 @@ class OpenAIVideoBackend:
         logger.info("调用 %s 视频 SDK kwargs=%s", self.name, format_kwargs_for_log(kwargs))
 
         video = await self._create_video(**kwargs)
-        # submit 成功立即持久化 job_id；持久化失败抛 → finally mark_failed（ADR 0007）
-        await persist_job_id_if_in_task_context(video.id, provider=PROVIDER_OPENAI)
+        # submit 成功立即持久化 job_id；持久化失败抛 → finally mark_failed。
+        # 非 worker 路径（grid / 直生 / 测试）request.task_id 为 None，跳过持久化。
+        if request.task_id is not None:
+            await persist_provider_job_id(request.task_id, video.id, provider=PROVIDER_OPENAI)
         final = await self._poll_until_complete(video.id, request.duration_seconds)
 
         return await self._download_and_build_result(final, request, kwargs)

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -129,6 +129,11 @@ class OpenAIVideoBackend:
             await persist_provider_job_id(request.task_id, video.id, provider=PROVIDER_OPENAI)
         final = await self._poll_until_complete(video.id, request.duration_seconds)
 
+        # generate 路径下 expired 是「provider 异常 / 输入参数过期」类失败，
+        # 抛 RuntimeError 让 worker mark_failed（不带 [resume_expired] 前缀）。
+        if final.status == "expired":
+            raise RuntimeError(f"OpenAI Sora job expired during generate: {final.id}")
+
         return await self._download_and_build_result(final, request, kwargs)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
@@ -139,6 +144,16 @@ class OpenAIVideoBackend:
             if _is_openai_not_found(exc):
                 raise ResumeExpiredError(job_id=job_id, provider=PROVIDER_OPENAI) from exc
             raise
+
+        # resume 路径下 expired = provider 端已忘 / 输入资产过期，归类
+        # [resume_expired] 让 worker 错误前缀化、不再尝试重启自愈
+        if final.status == "expired":
+            raise ResumeExpiredError(
+                job_id=job_id,
+                provider=PROVIDER_OPENAI,
+                message=f"OpenAI Sora job expired: {final.id}",
+            )
+
         return await self._download_and_build_result(final, request, {"seconds": str(request.duration_seconds)})
 
     async def _download_and_build_result(
@@ -177,21 +192,15 @@ class OpenAIVideoBackend:
         """
         max_wait = max(_MIN_POLL_TIMEOUT_SECONDS, float(duration_seconds) * _POLL_TIMEOUT_PER_SECOND)
 
-        def _is_done(v) -> bool:
-            # 在 is_done 内识别 expired——poll_with_retry 的 else 分支不在 except 块内，
-            # raise 自然冒泡；ResumeExpiredError 不在 OPENAI_RETRYABLE_ERRORS 内，
-            # 外层 except 不会重试。
-            if v.status == "expired":
-                raise ResumeExpiredError(
-                    job_id=v.id,
-                    provider=PROVIDER_OPENAI,
-                    message=f"OpenAI Sora job expired: {v.id}",
-                )
-            return v.status == "completed"
-
+        # _is_done 是纯谓词：completed / failed / expired 三种状态都视为「已终态」让 poll 返回。
+        # caller (generate / resume_video) 拿到 result 后再分流：
+        #   - completed → 下载
+        #   - failed   → is_failed 已抛 RuntimeError
+        #   - expired  → 在 caller 处按 generate vs resume 上下文抛 RuntimeError / ResumeExpiredError
+        # 关键不变量：is_failed 不识别 expired，避免覆盖 caller 分流。
         return await poll_with_retry(
             poll_fn=lambda: self._client.videos.retrieve(video_id),
-            is_done=_is_done,
+            is_done=lambda v: v.status in ("completed", "failed", "expired"),
             is_failed=lambda v: f"Sora 视频生成失败: {getattr(v, 'error', None)}" if v.status == "failed" else None,
             poll_interval=_POLL_INTERVAL_SECONDS,
             max_wait=max_wait,

--- a/server/app.py
+++ b/server/app.py
@@ -425,8 +425,12 @@ async def lifespan(app: FastAPI):
         logger.info("正在停止 GenerationWorker...")
         from lib.generation_queue import get_generation_queue
 
-        get_generation_queue().set_worker_cancel_callback(None)
+        # 先 stop（内部 drain inflight + 退出主循环）：期间 cancel API 仍可发起，
+        # callback 仍可用，避免重新部署窗口期 cancel 信号被丢弃。
+        # 依赖 worker.stop() 内部已 await _wait_inflight_completion——若后续重构
+        # stop 拆掉 drain 步骤，需同时回访这里的顺序假设。
         await worker.stop()
+        get_generation_queue().set_worker_cancel_callback(None)
         logger.info("GenerationWorker 已停止")
     await shutdown_http_client()
     await close_db()

--- a/server/app.py
+++ b/server/app.py
@@ -429,8 +429,12 @@ async def lifespan(app: FastAPI):
         # callback 仍可用，避免重新部署窗口期 cancel 信号被丢弃。
         # 依赖 worker.stop() 内部已 await _wait_inflight_completion——若后续重构
         # stop 拆掉 drain 步骤，需同时回访这里的顺序假设。
-        await worker.stop()
-        get_generation_queue().set_worker_cancel_callback(None)
+        # try/finally 保证 callback 清理必达：worker.stop 抛错时 _worker_cancel_callback
+        # 仍能清空，避免污染后续生命周期/测试。
+        try:
+            await worker.stop()
+        finally:
+            get_generation_queue().set_worker_cancel_callback(None)
         logger.info("GenerationWorker 已停止")
     await shutdown_http_client()
     await close_db()

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -784,6 +784,15 @@ async def execute_video_task(
     if prompt is None:
         raise ValueError("prompt is required for video task")
 
+    # Resume 路径短路：worker _process_resume_task 入口 set 了 _RESUME_JOB_ID。
+    # 跳过 storyboard 文件存在性校验——provider 端 job 已在跑/已 ready，resume_video
+    # 只需 job_id 接续 poll + 下载，本地 storyboard 即使被用户删除也不该让 task fail
+    # 而把 provider 端 job 变成幽灵任务（issue #647 fix #2）。
+    from lib.video_backends.base import get_resume_job_id
+
+    if get_resume_job_id() is not None:
+        return await _execute_video_resume(project_name, resource_id, payload, user_id=user_id)
+
     def _load():
         _pm = get_project_manager()
         _project = _pm.load_project(project_name)
@@ -874,6 +883,29 @@ async def execute_video_task(
         service_tier=service_tier,
     )
 
+    return await _finalize_video_task(
+        project_name=project_name,
+        script_file=script_file,
+        project_path=project_path,
+        resource_id=resource_id,
+        version=version,
+        video_uri=video_uri,
+        generator=generator,
+    )
+
+
+async def _finalize_video_task(
+    *,
+    project_name: str,
+    script_file: str,
+    project_path: Path,
+    resource_id: str,
+    version: int,
+    video_uri: str | None,
+    generator: Any,
+) -> dict[str, Any]:
+    """Normal + resume 共用的 finalize 逻辑：写 scene asset + 抽缩略图 + 返回 result dict。"""
+
     def _update_video_metadata():
         get_project_manager().update_scene_asset(
             project_name=project_name,
@@ -893,7 +925,6 @@ async def execute_video_task(
 
     await asyncio.to_thread(_update_video_metadata)
 
-    # 提取视频首帧作为缩略图
     video_file = project_path / f"videos/scene_{resource_id}.mp4"
     thumbnail_file = project_path / f"thumbnails/scene_{resource_id}.jpg"
     if await extract_video_thumbnail(video_file, thumbnail_file):
@@ -920,6 +951,87 @@ async def execute_video_task(
         "resource_id": resource_id,
         "video_uri": video_uri,
     }
+
+
+async def _execute_video_resume(
+    project_name: str, resource_id: str, payload: dict[str, Any], *, user_id: str = DEFAULT_USER_ID
+) -> dict[str, Any]:
+    """Resume 短路：跳过 load_script + storyboard 文件存在性校验，仅复用 ConfigResolver 解析。
+
+    backend.generate 内部检测 ``_RESUME_JOB_ID`` 会跳过 submit 直接走 resume_video，
+    `start_image=None` 由 generate_video_async 的 isinstance 守卫透传到 VideoGenerationRequest，
+    不会先于 backend 抛错。issue #647 fix #2。
+    """
+    script_file = payload["script_file"]
+    prompt = payload["prompt"]
+
+    def _load_project_only():
+        _pm = get_project_manager()
+        _project = _pm.load_project(project_name)
+        _project_path = _pm.get_project_path(project_name)
+        return _project, _project_path
+
+    project, project_path = await asyncio.to_thread(_load_project_only)
+    generator = await get_media_generator(project_name, payload=payload, user_id=user_id)
+
+    prompt_text = _normalize_video_prompt(prompt)
+    aspect_ratio = get_aspect_ratio(project, "videos")
+    seed = payload.get("seed")
+    service_tier = payload.get("video_provider_settings", {}).get("service_tier", "default")
+
+    from lib.config.resolver import ConfigResolver
+    from lib.db import async_session_factory
+
+    _resolver = ConfigResolver(async_session_factory)
+    try:
+        resolved_video = await _resolver.resolve_video_backend(project, payload)
+        registry_provider_id = resolved_video.provider_id
+        model_name = resolved_video.model_id or None
+    except Exception:
+        registry_provider_id, model_name = "gemini-aistudio", "veo-3.1-lite-generate-preview"
+
+    supported_durations: list[int] = []
+    try:
+        caps = await _resolver.video_capabilities_for_model(registry_provider_id, model_name or "", project)
+        supported_durations = [int(d) for d in caps.get("supported_durations") or []]
+    except Exception:
+        supported_durations = []
+
+    resolution = await resolve_resolution(project, registry_provider_id, model_name or "")
+
+    duration_seconds = payload.get("duration_seconds")
+    if duration_seconds is None:
+        duration_seconds = project.get("default_duration")
+    if not duration_seconds:
+        duration_seconds = (
+            supported_durations[0]
+            if supported_durations
+            else _get_model_default_duration(registry_provider_id, model_name)
+        )
+    assert_duration_supported(duration_seconds, supported_durations)
+
+    _, version, _, video_uri = await generator.generate_video_async(
+        prompt=prompt_text,
+        resource_type="videos",
+        resource_id=resource_id,
+        start_image=None,
+        end_image=None,
+        aspect_ratio=aspect_ratio,
+        duration_seconds=duration_seconds,
+        resolution=resolution,
+        seed=seed,
+        service_tier=service_tier,
+    )
+
+    return await _finalize_video_task(
+        project_name=project_name,
+        script_file=script_file,
+        project_path=project_path,
+        resource_id=resource_id,
+        version=version,
+        video_uri=video_uri,
+        generator=generator,
+    )
 
 
 async def execute_character_task(

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -654,7 +654,7 @@ _TASK_CHANGE_SPECS: dict[str, tuple] = {
 }
 
 
-def _emit_generation_success_batch(
+def emit_generation_success_batch(
     *,
     task_type: str,
     project_name: str,
@@ -1393,7 +1393,7 @@ async def execute_generation_task(task: dict[str, Any]) -> dict[str, Any]:
             # 落到 task.error_message，前端轮询时即可看到本地化提示
             message = i18n_translate(err.code, locale=DEFAULT_LOCALE, **err.params)
             raise RuntimeError(message) from err
-        _emit_generation_success_batch(
+        emit_generation_success_batch(
             task_type=task_type,
             project_name=project_name,
             resource_id=resource_id,

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -694,7 +694,12 @@ def _emit_generation_success_batch(
 
 
 async def execute_storyboard_task(
-    project_name: str, resource_id: str, payload: dict[str, Any], *, user_id: str = DEFAULT_USER_ID
+    project_name: str,
+    resource_id: str,
+    payload: dict[str, Any],
+    *,
+    user_id: str = DEFAULT_USER_ID,
+    task_id: str | None = None,
 ) -> dict[str, Any]:
     script_file = payload.get("script_file")
     if not script_file:
@@ -774,7 +779,12 @@ async def execute_storyboard_task(
 
 
 async def execute_video_task(
-    project_name: str, resource_id: str, payload: dict[str, Any], *, user_id: str = DEFAULT_USER_ID
+    project_name: str,
+    resource_id: str,
+    payload: dict[str, Any],
+    *,
+    user_id: str = DEFAULT_USER_ID,
+    task_id: str | None = None,
 ) -> dict[str, Any]:
     script_file = payload.get("script_file")
     if not script_file:
@@ -879,6 +889,7 @@ async def execute_video_task(
         aspect_ratio=aspect_ratio,
         duration_seconds=duration_seconds,
         resolution=resolution,
+        task_id=task_id,
         seed=seed,
         service_tier=service_tier,
     )
@@ -954,7 +965,12 @@ async def _finalize_video_task(
 
 
 async def _execute_video_resume(
-    project_name: str, resource_id: str, payload: dict[str, Any], *, user_id: str = DEFAULT_USER_ID
+    project_name: str,
+    resource_id: str,
+    payload: dict[str, Any],
+    *,
+    user_id: str = DEFAULT_USER_ID,
+    task_id: str | None = None,
 ) -> dict[str, Any]:
     """Resume 短路：跳过 load_script + storyboard 文件存在性校验，仅复用 ConfigResolver 解析。
 
@@ -1035,7 +1051,12 @@ async def _execute_video_resume(
 
 
 async def execute_character_task(
-    project_name: str, resource_id: str, payload: dict[str, Any], *, user_id: str = DEFAULT_USER_ID
+    project_name: str,
+    resource_id: str,
+    payload: dict[str, Any],
+    *,
+    user_id: str = DEFAULT_USER_ID,
+    task_id: str | None = None,
 ) -> dict[str, Any]:
     prompt = str(payload.get("prompt", "") or "").strip()
     if not prompt:
@@ -1164,13 +1185,23 @@ async def execute_design_task(
 
 
 async def execute_scene_task(
-    project_name: str, resource_id: str, payload: dict[str, Any], *, user_id: str = DEFAULT_USER_ID
+    project_name: str,
+    resource_id: str,
+    payload: dict[str, Any],
+    *,
+    user_id: str = DEFAULT_USER_ID,
+    task_id: str | None = None,
 ) -> dict[str, Any]:
     return await execute_design_task("scene", project_name, resource_id, payload, user_id=user_id)
 
 
 async def execute_prop_task(
-    project_name: str, resource_id: str, payload: dict[str, Any], *, user_id: str = DEFAULT_USER_ID
+    project_name: str,
+    resource_id: str,
+    payload: dict[str, Any],
+    *,
+    user_id: str = DEFAULT_USER_ID,
+    task_id: str | None = None,
 ) -> dict[str, Any]:
     return await execute_design_task("prop", project_name, resource_id, payload, user_id=user_id)
 
@@ -1259,7 +1290,12 @@ def _collect_grid_reference_images(
 
 
 async def execute_grid_task(
-    project_name: str, resource_id: str, payload: dict[str, Any], *, user_id: str = DEFAULT_USER_ID
+    project_name: str,
+    resource_id: str,
+    payload: dict[str, Any],
+    *,
+    user_id: str = DEFAULT_USER_ID,
+    task_id: str | None = None,
 ) -> dict[str, Any]:
     """Execute a grid image generation task.
 
@@ -1403,12 +1439,17 @@ async def execute_grid_task(
 
 
 async def _execute_reference_video_task_proxy(
-    project_name: str, resource_id: str, payload: dict[str, Any], *, user_id: str
+    project_name: str,
+    resource_id: str,
+    payload: dict[str, Any],
+    *,
+    user_id: str,
+    task_id: str | None = None,
 ) -> dict[str, Any]:
     """Lazy proxy to avoid circular import: reference_video_tasks imports from this module."""
     from server.services.reference_video_tasks import execute_reference_video_task
 
-    return await execute_reference_video_task(project_name, resource_id, payload, user_id=user_id)
+    return await execute_reference_video_task(project_name, resource_id, payload, user_id=user_id, task_id=task_id)
 
 
 _TASK_EXECUTORS = {
@@ -1428,6 +1469,7 @@ async def execute_generation_task(task: dict[str, Any]) -> dict[str, Any]:
     resource_id = str(task.get("resource_id"))
     payload = task.get("payload") or {}
     user_id = task.get("user_id", DEFAULT_USER_ID)
+    queue_task_id = task.get("task_id")
 
     if not project_name:
         raise ValueError("task.project_name is required")
@@ -1440,7 +1482,7 @@ async def execute_generation_task(task: dict[str, Any]) -> dict[str, Any]:
 
     with project_change_source("worker"):
         try:
-            result = await executor(project_name, resource_id, payload, user_id=user_id)
+            result = await executor(project_name, resource_id, payload, user_id=user_id, task_id=queue_task_id)
         except (ImageCapabilityError, VideoCapabilityError) as err:
             # Worker 后台无 request 上下文，按 DEFAULT_LOCALE 渲染稳定的 i18n 文案
             # 落到 task.error_message，前端轮询时即可看到本地化提示

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -794,15 +794,6 @@ async def execute_video_task(
     if prompt is None:
         raise ValueError("prompt is required for video task")
 
-    # Resume 路径短路：worker _process_resume_task 入口 set 了 _RESUME_JOB_ID。
-    # 跳过 storyboard 文件存在性校验——provider 端 job 已在跑/已 ready，resume_video
-    # 只需 job_id 接续 poll + 下载，本地 storyboard 即使被用户删除也不该让 task fail
-    # 而把 provider 端 job 变成幽灵任务（issue #647 fix #2）。
-    from lib.video_backends.base import get_resume_job_id
-
-    if get_resume_job_id() is not None:
-        return await _execute_video_resume(project_name, resource_id, payload, user_id=user_id)
-
     def _load():
         _pm = get_project_manager()
         _project = _pm.load_project(project_name)
@@ -962,92 +953,6 @@ async def _finalize_video_task(
         "resource_id": resource_id,
         "video_uri": video_uri,
     }
-
-
-async def _execute_video_resume(
-    project_name: str,
-    resource_id: str,
-    payload: dict[str, Any],
-    *,
-    user_id: str = DEFAULT_USER_ID,
-    task_id: str | None = None,
-) -> dict[str, Any]:
-    """Resume 短路：跳过 load_script + storyboard 文件存在性校验，仅复用 ConfigResolver 解析。
-
-    backend.generate 内部检测 ``_RESUME_JOB_ID`` 会跳过 submit 直接走 resume_video，
-    `start_image=None` 由 generate_video_async 的 isinstance 守卫透传到 VideoGenerationRequest，
-    不会先于 backend 抛错。issue #647 fix #2。
-    """
-    script_file = payload["script_file"]
-    prompt = payload["prompt"]
-
-    def _load_project_only():
-        _pm = get_project_manager()
-        _project = _pm.load_project(project_name)
-        _project_path = _pm.get_project_path(project_name)
-        return _project, _project_path
-
-    project, project_path = await asyncio.to_thread(_load_project_only)
-    generator = await get_media_generator(project_name, payload=payload, user_id=user_id)
-
-    prompt_text = _normalize_video_prompt(prompt)
-    aspect_ratio = get_aspect_ratio(project, "videos")
-    seed = payload.get("seed")
-    service_tier = payload.get("video_provider_settings", {}).get("service_tier", "default")
-
-    from lib.config.resolver import ConfigResolver
-    from lib.db import async_session_factory
-
-    _resolver = ConfigResolver(async_session_factory)
-    try:
-        resolved_video = await _resolver.resolve_video_backend(project, payload)
-        registry_provider_id = resolved_video.provider_id
-        model_name = resolved_video.model_id or None
-    except Exception:
-        registry_provider_id, model_name = "gemini-aistudio", "veo-3.1-lite-generate-preview"
-
-    supported_durations: list[int] = []
-    try:
-        caps = await _resolver.video_capabilities_for_model(registry_provider_id, model_name or "", project)
-        supported_durations = [int(d) for d in caps.get("supported_durations") or []]
-    except Exception:
-        supported_durations = []
-
-    resolution = await resolve_resolution(project, registry_provider_id, model_name or "")
-
-    duration_seconds = payload.get("duration_seconds")
-    if duration_seconds is None:
-        duration_seconds = project.get("default_duration")
-    if not duration_seconds:
-        duration_seconds = (
-            supported_durations[0]
-            if supported_durations
-            else _get_model_default_duration(registry_provider_id, model_name)
-        )
-    assert_duration_supported(duration_seconds, supported_durations)
-
-    _, version, _, video_uri = await generator.generate_video_async(
-        prompt=prompt_text,
-        resource_type="videos",
-        resource_id=resource_id,
-        start_image=None,
-        end_image=None,
-        aspect_ratio=aspect_ratio,
-        duration_seconds=duration_seconds,
-        resolution=resolution,
-        seed=seed,
-        service_tier=service_tier,
-    )
-
-    return await _finalize_video_task(
-        project_name=project_name,
-        script_file=script_file,
-        project_path=project_path,
-        resource_id=resource_id,
-        version=version,
-        video_uri=video_uri,
-        generator=generator,
-    )
 
 
 async def execute_character_task(

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -173,6 +173,7 @@ async def execute_reference_video_task(
     payload: dict[str, Any],
     *,
     user_id: str = DEFAULT_USER_ID,
+    task_id: str | None = None,
 ) -> dict[str, Any]:
     """处理一个 reference_video unit 的生成。
 
@@ -292,6 +293,7 @@ async def execute_reference_video_task(
                 aspect_ratio=project.get("aspect_ratio", "9:16"),
                 duration_seconds=effective_duration,
                 resolution=resolution,
+                task_id=task_id,
             )
         except RequestPayloadTooLargeError:
             # 二次压缩重试（1024px/q=70）
@@ -312,6 +314,7 @@ async def execute_reference_video_task(
                 aspect_ratio=project.get("aspect_ratio", "9:16"),
                 duration_seconds=effective_duration,
                 resolution=resolution,
+                task_id=task_id,
             )
     finally:
         for p in tmp_refs:

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -182,6 +182,15 @@ async def execute_reference_video_task(
     if not script_file:
         raise ValueError("script_file is required for reference_video task")
 
+    # Resume 路径短路：worker _process_resume_task 入口 set 了 _RESUME_JOB_ID。
+    # 跳过 load_script + unit 查找 + 参考资产文件存在性校验三段——provider 端 job 已
+    # 在跑/已 ready，resume_video 只需 job_id 接续 poll + 下载；本地资产即使被删也不该
+    # 让 task fail 而把 provider 端 job 变成幽灵任务（issue #647 fix #2）。
+    from lib.video_backends.base import get_resume_job_id
+
+    if get_resume_job_id() is not None:
+        return await _execute_reference_video_resume(project_name, resource_id, payload, user_id=user_id)
+
     # 1. 加载上下文（阻塞 IO，线程池）
     def _load():
         pm = get_project_manager()
@@ -362,4 +371,106 @@ async def execute_reference_video_task(
         "resource_id": resource_id,
         "video_uri": video_uri,
         "warnings": warnings,
+    }
+
+
+async def _execute_reference_video_resume(
+    project_name: str,
+    resource_id: str,
+    payload: dict[str, Any],
+    *,
+    user_id: str,
+) -> dict[str, Any]:
+    """Resume 短路：跳过 load_script + unit 查找 + reference 资产存在性校验。
+
+    backend.generate 内部检测 ``_RESUME_JOB_ID`` 跳 submit 走 resume_video；
+    `reference_images=None` + 空提示词（执行期入参，对 resume 不重要）让 backend
+    用持久化 job_id 接续轮询。issue #647 fix #2。
+    """
+    script_file = payload["script_file"]
+
+    def _load_project_only():
+        pm = get_project_manager()
+        project = pm.load_project(project_name)
+        project_path = pm.get_project_path(project_name)
+        return project, project_path
+
+    project, project_path = await asyncio.to_thread(_load_project_only)
+    generator = await get_media_generator(project_name, payload=payload, user_id=user_id)
+    backend = getattr(generator, "_video_backend", None)
+    provider_name = getattr(backend, "name", "") if backend else ""
+    model_name = getattr(backend, "model", "") if backend else ""
+
+    from server.services.resolution_resolver import get_provider_fallback, resolve_resolution
+
+    video_backend_raw = project.get("video_backend") or ""
+    registry_provider_id = video_backend_raw.split("/", 1)[0] if "/" in video_backend_raw else provider_name
+    resolution = await resolve_resolution(project, registry_provider_id or provider_name, model_name or "")
+    if resolution is None:
+        resolution = get_provider_fallback(provider_name)
+
+    duration_seconds = int(payload.get("duration_seconds") or 8)
+
+    # resume 时 prompt 不影响结果（backend.resume_video 用 job_id 接续），但仍透传 payload 留底
+    rendered_prompt = append_video_negative_tail(str(payload.get("prompt") or ""))
+
+    output_path, version, _, video_uri = await generator.generate_video_async(
+        prompt=rendered_prompt,
+        resource_type="reference_videos",
+        resource_id=resource_id,
+        reference_images=None,
+        aspect_ratio=project.get("aspect_ratio", "9:16"),
+        duration_seconds=duration_seconds,
+        resolution=resolution,
+    )
+
+    if output_path is None:
+        raise RuntimeError("generate_video_async returned None output_path")
+
+    thumb_dir = project_path / "reference_videos" / "thumbnails"
+    thumb_dir.mkdir(parents=True, exist_ok=True)
+    thumb_path = thumb_dir / f"{resource_id}.jpg"
+    if await extract_video_thumbnail(output_path, thumb_path):
+        thumb_rel: str | None = f"reference_videos/thumbnails/{resource_id}.jpg"
+    else:
+        thumb_path.unlink(missing_ok=True)
+        thumb_rel = None
+
+    def _update_unit_assets():
+        pm = get_project_manager()
+        with pm.locked_script(project_name, script_file, validate=False) as script:
+            for u in script.get("video_units") or []:
+                if u.get("unit_id") == resource_id:
+                    ga = u.setdefault("generated_assets", {})
+                    ga["video_clip"] = f"reference_videos/{resource_id}.mp4"
+                    if video_uri:
+                        ga["video_uri"] = video_uri
+                    else:
+                        ga.pop("video_uri", None)
+                    if thumb_rel:
+                        ga["video_thumbnail"] = thumb_rel
+                    else:
+                        ga.pop("video_thumbnail", None)
+                    ga["status"] = "completed"
+                    break
+
+    await asyncio.to_thread(_update_unit_assets)
+
+    def _latest_created_at() -> str | None:
+        history = generator.versions.get_versions("reference_videos", resource_id) or {}
+        versions = history.get("versions") or []
+        if not versions:
+            return None
+        return versions[-1].get("created_at")
+
+    created_at = await asyncio.to_thread(_latest_created_at)
+
+    return {
+        "version": version,
+        "file_path": f"reference_videos/{resource_id}.mp4",
+        "created_at": created_at,
+        "resource_type": "reference_videos",
+        "resource_id": resource_id,
+        "video_uri": video_uri,
+        "warnings": [],
     }

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -183,15 +183,6 @@ async def execute_reference_video_task(
     if not script_file:
         raise ValueError("script_file is required for reference_video task")
 
-    # Resume 路径短路：worker _process_resume_task 入口 set 了 _RESUME_JOB_ID。
-    # 跳过 load_script + unit 查找 + 参考资产文件存在性校验三段——provider 端 job 已
-    # 在跑/已 ready，resume_video 只需 job_id 接续 poll + 下载；本地资产即使被删也不该
-    # 让 task fail 而把 provider 端 job 变成幽灵任务（issue #647 fix #2）。
-    from lib.video_backends.base import get_resume_job_id
-
-    if get_resume_job_id() is not None:
-        return await _execute_reference_video_resume(project_name, resource_id, payload, user_id=user_id)
-
     # 1. 加载上下文（阻塞 IO，线程池）
     def _load():
         pm = get_project_manager()
@@ -321,20 +312,46 @@ async def execute_reference_video_task(
             with contextlib.suppress(Exception):
                 p.unlink(missing_ok=True)
 
-    # 8. 首帧缩略图
     if output_path is None:
         raise RuntimeError("generate_video_async returned None output_path")
+
+    return await _finalize_reference_video_unit(
+        project_name=project_name,
+        script_file=script_file,
+        project_path=project_path,
+        resource_id=resource_id,
+        output_path=output_path,
+        version=version,
+        video_uri=video_uri,
+        generator=generator,
+        warnings=warnings,
+    )
+
+
+async def _finalize_reference_video_unit(
+    *,
+    project_name: str,
+    script_file: str,
+    project_path: Path,
+    resource_id: str,
+    output_path: Path,
+    version: int,
+    video_uri: str | None,
+    generator: Any,
+    warnings: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Normal + resume 共用：抽缩略图、写 unit.generated_assets、返回 result dict。"""
+    warnings = warnings if warnings is not None else []
+
     thumb_dir = project_path / "reference_videos" / "thumbnails"
     thumb_dir.mkdir(parents=True, exist_ok=True)
     thumb_path = thumb_dir / f"{resource_id}.jpg"
     if await extract_video_thumbnail(output_path, thumb_path):
-        thumb_rel = f"reference_videos/thumbnails/{resource_id}.jpg"
+        thumb_rel: str | None = f"reference_videos/thumbnails/{resource_id}.jpg"
     else:
         thumb_path.unlink(missing_ok=True)
         thumb_rel = None
 
-    # 9. 更新 unit.generated_assets（在 locked_script 内完成 read-modify-write，
-    #    避免与并发的 PATCH / 其他 unit 回写互相覆盖）
     def _update_unit_assets():
         pm = get_project_manager()
         # 资产回写热路径：只动 unit.generated_assets，结构不可能因此变坏，豁免结构校验。
@@ -374,106 +391,4 @@ async def execute_reference_video_task(
         "resource_id": resource_id,
         "video_uri": video_uri,
         "warnings": warnings,
-    }
-
-
-async def _execute_reference_video_resume(
-    project_name: str,
-    resource_id: str,
-    payload: dict[str, Any],
-    *,
-    user_id: str,
-) -> dict[str, Any]:
-    """Resume 短路：跳过 load_script + unit 查找 + reference 资产存在性校验。
-
-    backend.generate 内部检测 ``_RESUME_JOB_ID`` 跳 submit 走 resume_video；
-    `reference_images=None` + 空提示词（执行期入参，对 resume 不重要）让 backend
-    用持久化 job_id 接续轮询。issue #647 fix #2。
-    """
-    script_file = payload["script_file"]
-
-    def _load_project_only():
-        pm = get_project_manager()
-        project = pm.load_project(project_name)
-        project_path = pm.get_project_path(project_name)
-        return project, project_path
-
-    project, project_path = await asyncio.to_thread(_load_project_only)
-    generator = await get_media_generator(project_name, payload=payload, user_id=user_id)
-    backend = getattr(generator, "_video_backend", None)
-    provider_name = getattr(backend, "name", "") if backend else ""
-    model_name = getattr(backend, "model", "") if backend else ""
-
-    from server.services.resolution_resolver import get_provider_fallback, resolve_resolution
-
-    video_backend_raw = project.get("video_backend") or ""
-    registry_provider_id = video_backend_raw.split("/", 1)[0] if "/" in video_backend_raw else provider_name
-    resolution = await resolve_resolution(project, registry_provider_id or provider_name, model_name or "")
-    if resolution is None:
-        resolution = get_provider_fallback(provider_name)
-
-    duration_seconds = int(payload.get("duration_seconds") or 8)
-
-    # resume 时 prompt 不影响结果（backend.resume_video 用 job_id 接续），但仍透传 payload 留底
-    rendered_prompt = append_video_negative_tail(str(payload.get("prompt") or ""))
-
-    output_path, version, _, video_uri = await generator.generate_video_async(
-        prompt=rendered_prompt,
-        resource_type="reference_videos",
-        resource_id=resource_id,
-        reference_images=None,
-        aspect_ratio=project.get("aspect_ratio", "9:16"),
-        duration_seconds=duration_seconds,
-        resolution=resolution,
-    )
-
-    if output_path is None:
-        raise RuntimeError("generate_video_async returned None output_path")
-
-    thumb_dir = project_path / "reference_videos" / "thumbnails"
-    thumb_dir.mkdir(parents=True, exist_ok=True)
-    thumb_path = thumb_dir / f"{resource_id}.jpg"
-    if await extract_video_thumbnail(output_path, thumb_path):
-        thumb_rel: str | None = f"reference_videos/thumbnails/{resource_id}.jpg"
-    else:
-        thumb_path.unlink(missing_ok=True)
-        thumb_rel = None
-
-    def _update_unit_assets():
-        pm = get_project_manager()
-        with pm.locked_script(project_name, script_file, validate=False) as script:
-            for u in script.get("video_units") or []:
-                if u.get("unit_id") == resource_id:
-                    ga = u.setdefault("generated_assets", {})
-                    ga["video_clip"] = f"reference_videos/{resource_id}.mp4"
-                    if video_uri:
-                        ga["video_uri"] = video_uri
-                    else:
-                        ga.pop("video_uri", None)
-                    if thumb_rel:
-                        ga["video_thumbnail"] = thumb_rel
-                    else:
-                        ga.pop("video_thumbnail", None)
-                    ga["status"] = "completed"
-                    break
-
-    await asyncio.to_thread(_update_unit_assets)
-
-    def _latest_created_at() -> str | None:
-        history = generator.versions.get_versions("reference_videos", resource_id) or {}
-        versions = history.get("versions") or []
-        if not versions:
-            return None
-        return versions[-1].get("created_at")
-
-    created_at = await asyncio.to_thread(_latest_created_at)
-
-    return {
-        "version": version,
-        "file_path": f"reference_videos/{resource_id}.mp4",
-        "created_at": created_at,
-        "resource_type": "reference_videos",
-        "resource_id": resource_id,
-        "video_uri": video_uri,
-        "warnings": [],
     }

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -65,7 +65,10 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
     aspect_ratio = get_aspect_ratio(project, "videos") if task_type == "video" else project.get("aspect_ratio", "9:16")
     duration_seconds = int(payload.get("duration_seconds") or project.get("default_duration") or 8)
     seed = payload.get("seed")
-    service_tier = payload.get("video_provider_settings", {}).get("service_tier", "default")
+    # 旧任务 / 脏数据可能把 video_provider_settings 存成 None / str / list，全部归一化成 dict
+    raw_vp_settings = payload.get("video_provider_settings")
+    vp_settings = raw_vp_settings if isinstance(raw_vp_settings, dict) else {}
+    service_tier = vp_settings.get("service_tier", "default")
     raw_prompt = payload.get("prompt")
     prompt_text = raw_prompt if isinstance(raw_prompt, str) else ""
     raw_resolution = payload.get("resolution")

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -63,7 +63,11 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
     )
 
     aspect_ratio = get_aspect_ratio(project, "videos") if task_type == "video" else project.get("aspect_ratio", "9:16")
-    duration_seconds = int(payload.get("duration_seconds") or project.get("default_duration") or 8)
+    # 浮点数字符串（如 "8.0"）直接 int() 会抛 ValueError；先 float 再 int 兜底脏数据
+    try:
+        duration_seconds = int(float(payload.get("duration_seconds") or project.get("default_duration") or 8))
+    except (ValueError, TypeError):
+        duration_seconds = 8
     seed = payload.get("seed")
     # 旧任务 / 脏数据可能把 video_provider_settings 存成 None / str / list，全部归一化成 dict
     raw_vp_settings = payload.get("video_provider_settings")

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -66,7 +66,16 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
     duration_seconds = int(payload.get("duration_seconds") or project.get("default_duration") or 8)
     seed = payload.get("seed")
     service_tier = payload.get("video_provider_settings", {}).get("service_tier", "default")
-    prompt_text = str(payload.get("prompt") or "")
+    raw_prompt = payload.get("prompt")
+    prompt_text = raw_prompt if isinstance(raw_prompt, str) else ""
+    raw_resolution = payload.get("resolution")
+    resolution = raw_resolution if isinstance(raw_resolution, str) else None
+    raw_generate_audio = payload.get("generate_audio")
+    # generate_audio 仅在 payload 显式提供 bool 时透传；缺省让 resume_video_async 走 config 默认，
+    # 不传 None 是因为 version_metadata.get("generate_audio", default) 会把显式 None 当作"用户选择 None"
+    optional_kwargs: dict[str, Any] = {}
+    if isinstance(raw_generate_audio, bool):
+        optional_kwargs["generate_audio"] = raw_generate_audio
 
     if task_type == "reference_video":
         resource_type = "reference_videos"
@@ -93,10 +102,12 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
             prompt=prompt_text,
             aspect_ratio=aspect_ratio,
             duration_seconds=duration_seconds,
+            resolution=resolution,
             task_id=task_id,
             api_call_id=api_call_id,
             seed=seed,
             service_tier=service_tier,
+            **optional_kwargs,
         )
 
         if task_type == "reference_video":

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -1,0 +1,101 @@
+"""Resume executor：worker `_process_resume_task` 直接调用的入口。
+
+不走 `execute_video_task` / `execute_reference_video_task` 流水线——provider 端
+job 已经在跑，本地 storyboard / 参考资产是否存在不该影响接续轮询。仅复用 service
+层的 finalize helpers 写回 scene/unit 资产。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from lib.media_generator import MediaGenerator
+from server.services.generation_tasks import (
+    DEFAULT_USER_ID,
+    _finalize_video_task,
+    get_aspect_ratio,
+    get_media_generator,
+    get_project_manager,
+)
+from server.services.reference_video_tasks import _finalize_reference_video_unit
+
+logger = logging.getLogger(__name__)
+
+
+async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dict[str, Any]:
+    """重启自愈入口：worker `_process_resume_task` 直接调。
+
+    1. 解析项目 + 构造 MediaGenerator（受 task["provider_id"] 锁定 payload.video_provider）
+    2. 调 `generator.resume_video_async(job_id=..., ...)`——内部走 backend.resume_video
+    3. finalize：写 scene asset / unit assets、抽缩略图、返回 result dict
+
+    不读 storyboard / reference 本地图片，不调 assert_duration_supported——这些前置
+    校验若失败会让本地资产缺失"卡死"已经提交给 provider 的 job（变幽灵任务）。
+    """
+    task_type = task["task_type"]
+    project_name = task["project_name"]
+    resource_id = str(task["resource_id"])
+    task_id = task["task_id"]
+    payload = task.get("payload") or {}
+    user_id = task.get("user_id", DEFAULT_USER_ID)
+
+    if task_type not in ("video", "reference_video"):
+        raise NotImplementedError(f"resume not supported for task_type={task_type}")
+
+    project, project_path = await asyncio.to_thread(
+        lambda: (
+            get_project_manager().load_project(project_name),
+            get_project_manager().get_project_path(project_name),
+        )
+    )
+
+    generator: MediaGenerator = await get_media_generator(project_name, payload=payload, user_id=user_id)
+
+    aspect_ratio = get_aspect_ratio(project, "videos") if task_type == "video" else project.get("aspect_ratio", "9:16")
+    duration_seconds = int(payload.get("duration_seconds") or project.get("default_duration") or 8)
+    seed = payload.get("seed")
+    service_tier = payload.get("video_provider_settings", {}).get("service_tier", "default")
+    prompt_text = str(payload.get("prompt") or "")
+
+    if task_type == "reference_video":
+        resource_type = "reference_videos"
+        script_file = payload["script_file"]
+    else:
+        resource_type = "videos"
+        script_file = payload["script_file"]
+
+    output_path, version, _, video_uri = await generator.resume_video_async(
+        job_id=job_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        prompt=prompt_text,
+        aspect_ratio=aspect_ratio,
+        duration_seconds=duration_seconds,
+        task_id=task_id,
+        seed=seed,
+        service_tier=service_tier,
+    )
+
+    if task_type == "reference_video":
+        return await _finalize_reference_video_unit(
+            project_name=project_name,
+            script_file=script_file,
+            project_path=project_path,
+            resource_id=resource_id,
+            output_path=output_path,
+            version=version,
+            video_uri=video_uri,
+            generator=generator,
+        )
+
+    return await _finalize_video_task(
+        project_name=project_name,
+        script_file=script_file,
+        project_path=project_path,
+        resource_id=resource_id,
+        version=version,
+        video_uri=video_uri,
+        generator=generator,
+    )

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -66,6 +66,13 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
         resource_type = "videos"
         script_file = payload["script_file"]
 
+    api_call_id = payload.get("api_call_id")
+    if api_call_id is not None and not isinstance(api_call_id, int):
+        try:
+            api_call_id = int(api_call_id)
+        except (ValueError, TypeError):
+            api_call_id = None
+
     output_path, version, _, video_uri = await generator.resume_video_async(
         job_id=job_id,
         resource_type=resource_type,
@@ -74,6 +81,7 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
         aspect_ratio=aspect_ratio,
         duration_seconds=duration_seconds,
         task_id=task_id,
+        api_call_id=api_call_id,
         seed=seed,
         service_tier=service_tier,
     )

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -12,9 +12,11 @@ import logging
 from typing import Any
 
 from lib.media_generator import MediaGenerator
+from lib.project_change_hints import project_change_source
 from server.services.generation_tasks import (
     DEFAULT_USER_ID,
     _finalize_video_task,
+    emit_generation_success_batch,
     get_aspect_ratio,
     get_media_generator,
     get_project_manager,
@@ -51,7 +53,14 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
         )
     )
 
-    generator: MediaGenerator = await get_media_generator(project_name, payload=payload, user_id=user_id)
+    # require_image_backend=False：resume 路径用不到 image backend；若 image 配置在
+    # submit→重启之间被破坏，整段 resume 不该被无关检查弄失败（provider job 仍在跑）。
+    generator: MediaGenerator = await get_media_generator(
+        project_name,
+        payload=payload,
+        user_id=user_id,
+        require_image_backend=False,
+    )
 
     aspect_ratio = get_aspect_ratio(project, "videos") if task_type == "video" else project.get("aspect_ratio", "9:16")
     duration_seconds = int(payload.get("duration_seconds") or project.get("default_duration") or 8)
@@ -73,37 +82,50 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
         except (ValueError, TypeError):
             api_call_id = None
 
-    output_path, version, _, video_uri = await generator.resume_video_async(
-        job_id=job_id,
-        resource_type=resource_type,
-        resource_id=resource_id,
-        prompt=prompt_text,
-        aspect_ratio=aspect_ratio,
-        duration_seconds=duration_seconds,
-        task_id=task_id,
-        api_call_id=api_call_id,
-        seed=seed,
-        service_tier=service_tier,
-    )
-
-    if task_type == "reference_video":
-        return await _finalize_reference_video_unit(
-            project_name=project_name,
-            script_file=script_file,
-            project_path=project_path,
+    # 与 execute_generation_task 对齐：包 project_change_source('worker') 让下游
+    # asset 写入挂在 worker 来源；finalize 完成后同步触发 emit_generation_success_batch
+    # 推 SSE batch（带 asset_fingerprints），前端能即时刷缩略图缓存。
+    with project_change_source("worker"):
+        output_path, version, _, video_uri = await generator.resume_video_async(
+            job_id=job_id,
+            resource_type=resource_type,
             resource_id=resource_id,
-            output_path=output_path,
-            version=version,
-            video_uri=video_uri,
-            generator=generator,
+            prompt=prompt_text,
+            aspect_ratio=aspect_ratio,
+            duration_seconds=duration_seconds,
+            task_id=task_id,
+            api_call_id=api_call_id,
+            seed=seed,
+            service_tier=service_tier,
         )
 
-    return await _finalize_video_task(
-        project_name=project_name,
-        script_file=script_file,
-        project_path=project_path,
-        resource_id=resource_id,
-        version=version,
-        video_uri=video_uri,
-        generator=generator,
-    )
+        if task_type == "reference_video":
+            result = await _finalize_reference_video_unit(
+                project_name=project_name,
+                script_file=script_file,
+                project_path=project_path,
+                resource_id=resource_id,
+                output_path=output_path,
+                version=version,
+                video_uri=video_uri,
+                generator=generator,
+            )
+        else:
+            result = await _finalize_video_task(
+                project_name=project_name,
+                script_file=script_file,
+                project_path=project_path,
+                resource_id=resource_id,
+                version=version,
+                video_uri=video_uri,
+                generator=generator,
+            )
+
+        # emit_generation_success_batch 是同步函数，async caller 同步调用（不 await）
+        emit_generation_success_batch(
+            task_type=task_type,
+            project_name=project_name,
+            resource_id=resource_id,
+            payload=payload,
+        )
+        return result

--- a/tests/test_app_module.py
+++ b/tests/test_app_module.py
@@ -51,3 +51,51 @@ class TestAppModule:
             assert hasattr(app.state, "generation_worker")
 
         assert worker.stopped
+
+    @pytest.mark.asyncio
+    async def test_lifespan_clears_callback_after_worker_stop(self, monkeypatch):
+        """fix #647 #7：lifespan 应先 worker.stop()（drain inflight + callback 仍可用），
+        再清掉 set_worker_cancel_callback(None)。
+        """
+        from lib.generation_queue import get_generation_queue
+
+        # 用一个会在 stop() 时记录 callback 状态的 fake worker
+        callback_during_stop: list[bool] = []
+        queue = get_generation_queue()
+
+        class _OrderCheckingWorker:
+            def __init__(self):
+                self.started = False
+                self.stopped = False
+
+            async def start(self):
+                self.started = True
+
+            async def stop(self):
+                # 检查 stop() 调用期间 callback 还在
+                callback_during_stop.append(queue._worker_cancel_callback is not None)
+                self.stopped = True
+
+            def request_cancel(self, _task_id: str) -> bool:
+                return False
+
+        worker = _OrderCheckingWorker()
+        monkeypatch.setattr(app_module, "create_generation_worker", lambda: worker)
+        monkeypatch.setattr(app_module, "ensure_auth_password", lambda: "test")
+        monkeypatch.setattr(app_module, "init_db", _noop_async)
+        monkeypatch.setattr(lib.db, "init_db", _noop_async)
+        monkeypatch.setattr(assistant_router.assistant_service, "startup", _noop_async)
+        monkeypatch.setattr(assistant_router.assistant_service, "shutdown", _noop_async)
+
+        app = app_module.app
+        app.state = SimpleNamespace()
+
+        async with app_module.lifespan(app):
+            # lifespan 启动后 callback 应已 set
+            assert queue._worker_cancel_callback is not None
+
+        # 关键断言：worker.stop() 调用期间 callback 仍然存在
+        assert callback_during_stop == [True], f"stop() 时 callback 应仍可用，实际 {callback_during_stop}"
+        # 退出后 callback 已清
+        assert queue._worker_cancel_callback is None
+        assert worker.stopped

--- a/tests/test_generation_queue.py
+++ b/tests/test_generation_queue.py
@@ -361,6 +361,54 @@ class TestGenerationQueue:
         assert signaled == [enqueued["task_id"]]
         assert result["cancelling"] == [enqueued["task_id"]]
 
+    async def test_finalize_cancelled_dispatches_cascade_callback(self, queue):
+        """mark_task_cancelled(finalize 入口) 把级联出的 running 子任务派发给 callback。
+
+        A(running)→B(running)→C(queued)：worker finally 调 finalize_cancelled(A)，
+        cascade 把 B 标 cancelling，须同步调 callback(B) 让 worker request_cancel(B)
+        立刻发 in-process cancel，而非等 B 跑完 provider 调用。
+        """
+        from sqlalchemy import update as sql_update
+
+        from lib.db.models.task import Task
+
+        a_task = await queue.enqueue_task(
+            project_name="demo",
+            task_type="storyboard",
+            media_type="image",
+            resource_id="E1S01",
+            payload={},
+            script_file="ep1.json",
+        )
+        b_task = await queue.enqueue_task(
+            project_name="demo",
+            task_type="video",
+            media_type="video",
+            resource_id="E1S01",
+            payload={},
+            script_file="ep1.json",
+            dependency_task_id=a_task["task_id"],
+        )
+
+        # 把 A 拉到 running、B 也直接 set 成 running（跳过 dep 守卫）
+        await queue.claim_next_task("image")
+        async with queue._session_factory() as session:
+            await session.execute(sql_update(Task).where(Task.task_id == b_task["task_id"]).values(status="running"))
+            await session.commit()
+
+        signaled: list[str] = []
+
+        def _fake_cancel(task_id: str) -> bool:
+            signaled.append(task_id)
+            return True
+
+        queue.set_worker_cancel_callback(_fake_cancel)
+        # finalize_cancelled(A) 级联：A → cancelled、B(running) → cancelling
+        rows = await queue.mark_task_cancelled(a_task["task_id"], cancelled_by="user")
+        assert rows == 1
+        # B 必须被分发 callback —— Repository 返回意图、Queue 上层分发
+        assert b_task["task_id"] in signaled
+
     async def test_cancel_task_callback_exception_does_not_break(self, queue):
         """callback 抛异常不影响 cancel_task 返回(best-effort 信号)。"""
         enqueued = await queue.enqueue_task(

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -604,7 +604,7 @@ class TestGenerationTasks:
         fake_pm = _FakePM(project_path)
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
 
-        generation_tasks._emit_generation_success_batch(
+        generation_tasks.emit_generation_success_batch(
             task_type="storyboard",
             project_name="demo",
             resource_id="E1S01",

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -642,6 +642,40 @@ class TestGenerationTasks:
         with pytest.raises(ValueError):
             await generation_tasks.execute_prop_task("demo", "玉佩", {"prompt": ""})
 
+    async def test_execute_video_resume_skips_storyboard_check(self, tmp_path, monkeypatch):
+        """fix #647 #2：resume 路径（_RESUME_JOB_ID 已 set）跳过 storyboard 存在性校验，
+        即使 storyboard 文件被删依然能调到 backend.resume_video。"""
+        from lib.video_backends.base import reset_resume_job_id, set_resume_job_id
+
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_resolution", _async_return("720p"))
+
+        # 故意删除 storyboard——normal path 会 ValueError，resume path 不该看
+        (project_path / "storyboards" / "scene_E1S01.png").unlink()
+
+        token = set_resume_job_id("resume-job-123")
+        try:
+            result = await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {"script_file": "episode_1.json", "prompt": "p", "duration_seconds": 8},
+            )
+        finally:
+            reset_resume_job_id(token)
+
+        # backend.generate_video_async 被调 → start_image=None（resume 路径）
+        assert len(fake_generator.video_calls) == 1
+        assert fake_generator.video_calls[0]["start_image"] is None
+        # finalize 跑通：scene asset 被写、返回结果含 file_path
+        assert result["resource_type"] == "videos"
+        assert result["file_path"] == "videos/scene_E1S01.mp4"
+        # update_scene_asset 至少被调一次（video_clip）
+        assert any(a.get("asset_type") == "video_clip" for a in fake_pm.updated_assets)
+
 
 from server.services.generation_tasks import _resolve_effective_image_backend
 

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -642,40 +642,6 @@ class TestGenerationTasks:
         with pytest.raises(ValueError):
             await generation_tasks.execute_prop_task("demo", "玉佩", {"prompt": ""})
 
-    async def test_execute_video_resume_skips_storyboard_check(self, tmp_path, monkeypatch):
-        """fix #647 #2：resume 路径（_RESUME_JOB_ID 已 set）跳过 storyboard 存在性校验，
-        即使 storyboard 文件被删依然能调到 backend.resume_video。"""
-        from lib.video_backends.base import reset_resume_job_id, set_resume_job_id
-
-        project_path = _prepare_files(tmp_path)
-        fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
-        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
-        monkeypatch.setattr(generation_tasks, "resolve_resolution", _async_return("720p"))
-
-        # 故意删除 storyboard——normal path 会 ValueError，resume path 不该看
-        (project_path / "storyboards" / "scene_E1S01.png").unlink()
-
-        token = set_resume_job_id("resume-job-123")
-        try:
-            result = await generation_tasks.execute_video_task(
-                "demo",
-                "E1S01",
-                {"script_file": "episode_1.json", "prompt": "p", "duration_seconds": 8},
-            )
-        finally:
-            reset_resume_job_id(token)
-
-        # backend.generate_video_async 被调 → start_image=None（resume 路径）
-        assert len(fake_generator.video_calls) == 1
-        assert fake_generator.video_calls[0]["start_image"] is None
-        # finalize 跑通：scene asset 被写、返回结果含 file_path
-        assert result["resource_type"] == "videos"
-        assert result["file_path"] == "videos/scene_E1S01.mp4"
-        # update_scene_asset 至少被调一次（video_clip）
-        assert any(a.get("asset_type") == "video_clip" for a in fake_pm.updated_assets)
-
 
 from server.services.generation_tasks import _resolve_effective_image_backend
 

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -628,7 +628,11 @@ class TestGenerationWorker:
 
     @pytest.mark.asyncio
     async def test_handle_orphan_resumable_dispatches_process_resume_task(self, monkeypatch):
-        """video resumable provider + 有 job_id → 派发 _process_resume_task。"""
+        """video resumable provider + 有 job_id → 后台 dispatcher 派发 _process_resume_task。
+
+        fast path 只分桶 + 派 background dispatcher（fix #647 第 1 项），inflight 字典
+        由 dispatcher 异步填入；用 gather 等待 dispatcher 完成后再断言。
+        """
         queue = _FakeQueue()
         queue._orphans = [
             {
@@ -650,13 +654,175 @@ class TestGenerationWorker:
 
         monkeypatch.setattr(GenerationWorker, "_process_resume_task", _capture_resume)
         await worker._handle_orphan_tasks_on_start()
-        # 任务应进入 ark pool 的 video_inflight,等异步 task 调度
+        # 等所有 pending background task 完成（含 orphan-dispatcher + provider 桶 sub-task
+        # + 实际 inflight resume task）
         pool = worker._get_or_create_pool("ark")
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if "ark-orphan" in pool.video_inflight:
+                break
         assert "ark-orphan" in pool.video_inflight
-        # 等 inflight 任务执行（_capture_resume 被 asyncio.create_task 包了）
         await asyncio.gather(*pool.video_inflight.values(), return_exceptions=True)
         assert len(dispatched) == 1
         assert dispatched[0]["task_id"] == "ark-orphan"
+
+    @pytest.mark.asyncio
+    async def test_handle_orphan_fast_path_returns_immediately(self, monkeypatch):
+        """fix #647 #1：fast path 不阻塞——5 个可 resume orphan + video_max=2，
+        `_handle_orphan_tasks_on_start` 应几乎立刻返回（< 100ms），
+        实际 dispatch 由后台 dispatcher 处理。"""
+        import time
+
+        queue = _FakeQueue()
+        queue._orphans = [
+            {
+                "task_id": f"orphan-{i}",
+                "status": "running",
+                "provider_id": "ark",
+                "provider_job_id": f"job-{i}",
+                "media_type": "video",
+                "task_type": "video",
+                "payload": {},
+                "project_name": "demo",
+            }
+            for i in range(5)
+        ]
+        pool = ProviderPool(provider_id="ark", image_max=0, video_max=2)
+        worker = GenerationWorker(queue=queue, pools={"ark": pool})
+
+        # 让 _process_resume_task block 住——验证 fast path 不等它完成
+        async def _block_forever(self, task):
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _block_forever)
+
+        start = time.monotonic()
+        await worker._handle_orphan_tasks_on_start()
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.1, f"fast path 阻塞了 {elapsed:.3f}s（应 < 100ms）"
+
+        # 清理后台 dispatcher，避免 unawaited task 警告
+        for t in list(asyncio.all_tasks()):
+            if t.get_name() in ("orphan-dispatcher", "orphan-dispatch-ark"):
+                t.cancel()
+            if t.get_name().startswith("resume-video-"):
+                t.cancel()
+        await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_handle_orphan_dispatcher_respects_pool_capacity(self, monkeypatch):
+        """fix #647 #1：后台 dispatcher 受 pool video_max 容量约束分批入 inflight，
+        任一时刻 `len(pool.video_inflight) ≤ video_max`。"""
+        queue = _FakeQueue()
+        queue._orphans = [
+            {
+                "task_id": f"orphan-{i}",
+                "status": "running",
+                "provider_id": "ark",
+                "provider_job_id": f"job-{i}",
+                "media_type": "video",
+                "task_type": "video",
+                "payload": {},
+                "project_name": "demo",
+            }
+            for i in range(4)
+        ]
+        pool = ProviderPool(provider_id="ark", image_max=0, video_max=2)
+        worker = GenerationWorker(queue=queue, pools={"ark": pool})
+
+        # 用 controlled future 让 resume 任务可控完成；同时记录每次 dispatch 时的池占用
+        snapshots: list[int] = []
+        gates: dict[str, asyncio.Event] = {f"orphan-{i}": asyncio.Event() for i in range(4)}
+
+        async def _gated(self, task):
+            snapshots.append(len(pool.video_inflight))
+            await gates[task["task_id"]].wait()
+
+        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _gated)
+
+        await worker._handle_orphan_tasks_on_start()
+        # 让 dispatcher 把前 2 个 dispatch 进 inflight
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if len(pool.video_inflight) >= 2:
+                break
+        assert len(pool.video_inflight) == 2, f"应只有 2 个 inflight，实际 {len(pool.video_inflight)}"
+
+        # 释放第一个，让 dispatcher 继续派发——主循环在生产中负责 drain，这里手动模拟
+        first_done = next(iter(pool.video_inflight))
+        gates[first_done].set()
+        await asyncio.sleep(0)
+        # 模拟主循环 _drain_finished_tasks
+        for tid in list(pool.video_inflight):
+            if pool.video_inflight[tid].done():
+                pool.video_inflight.pop(tid)
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if len(pool.video_inflight) >= 2:
+                break
+        # 此时 dispatcher 应已把第 3 个推进 inflight
+        assert len(pool.video_inflight) <= 2
+
+        # 收尾：释放所有 gate，等 dispatcher 结束
+        for gate in gates.values():
+            gate.set()
+        for _ in range(50):
+            await asyncio.sleep(0)
+        # 清理可能的残余
+        for t in list(asyncio.all_tasks()):
+            name = t.get_name()
+            if name.startswith("orphan-") or name.startswith("resume-video-"):
+                if not t.done():
+                    t.cancel()
+        await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_handle_orphan_dispatcher_exits_on_stop_event(self, monkeypatch):
+        """fix #647 #1：`_stop_event` 触发时 dispatcher 干净退出，不再 dispatch 剩余 orphan。"""
+        queue = _FakeQueue()
+        queue._orphans = [
+            {
+                "task_id": f"orphan-{i}",
+                "status": "running",
+                "provider_id": "ark",
+                "provider_job_id": f"job-{i}",
+                "media_type": "video",
+                "task_type": "video",
+                "payload": {},
+                "project_name": "demo",
+            }
+            for i in range(3)
+        ]
+        pool = ProviderPool(provider_id="ark", image_max=0, video_max=1)
+        worker = GenerationWorker(queue=queue, pools={"ark": pool})
+
+        dispatched_count = 0
+        first_dispatched = asyncio.Event()
+        block_gate = asyncio.Event()
+
+        async def _maybe_block(self, task):
+            nonlocal dispatched_count
+            dispatched_count += 1
+            first_dispatched.set()
+            await block_gate.wait()
+
+        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _maybe_block)
+
+        await worker._handle_orphan_tasks_on_start()
+        # 等第一个 orphan 进 inflight
+        await asyncio.wait_for(first_dispatched.wait(), timeout=1.0)
+        assert dispatched_count == 1
+        # 触发停机
+        worker._stop_event.set()
+        block_gate.set()
+        # 让 dispatcher 看到 stop_event 退出（不再 dispatch 剩余 2 个）
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if dispatched_count == 1 and not any(
+                t.get_name() == "orphan-dispatcher" and not t.done() for t in asyncio.all_tasks()
+            ):
+                break
+        assert dispatched_count == 1, f"stop_event 后不应再 dispatch，实际 dispatched={dispatched_count}"
 
     # ------------------------------------------------------------------
     # _process_resume_task：分流 + provider 锁定

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any
 
 import pytest
 
@@ -1174,6 +1175,102 @@ class TestDispatcherFailFastAndPendingTracking:
 
         block.set()
         await worker._orphan_dispatcher_task
+
+
+class TestOrphanScanSelfPreemption:
+    """lease flap > 3×TTL 重夺时，本进程仍 inflight 的 task 不应被当孤儿处理。"""
+
+    @pytest.mark.asyncio
+    async def test_image_inflight_not_marked_restart_lost(self, monkeypatch):
+        """本进程 image_inflight 含 task → 孤儿扫描应跳过，不标 [restart_lost]。"""
+        queue = _FakeQueue()
+        queue._orphans = [
+            {
+                "task_id": "img-active",
+                "status": "running",
+                "media_type": "image",
+                "task_type": "storyboard",
+                "payload": {},
+                "project_name": "demo",
+            }
+        ]
+        pool = ProviderPool(provider_id="ark", image_max=1, video_max=0)
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        pool.image_inflight["img-active"] = fut  # type: ignore[assignment]
+        worker = GenerationWorker(queue=queue, pools={"ark": pool})
+
+        await worker._handle_orphan_tasks_on_start()
+
+        # 不应被标 [restart_lost] —— 本进程还在跑
+        assert "img-active" not in {tid for tid, _ in queue.failed}
+        # 清理
+        fut.set_result(None)
+
+    @pytest.mark.asyncio
+    async def test_video_inflight_not_dispatched_to_resume(self, monkeypatch):
+        """本进程 video_inflight 含 task → 孤儿扫描应跳过，不启动重复 resume 流。"""
+        queue = _FakeQueue()
+        queue._orphans = [
+            {
+                "task_id": "vid-active",
+                "status": "running",
+                "media_type": "video",
+                "task_type": "video",
+                "provider_id": "ark",
+                "provider_job_id": "ark-job-1",
+                "payload": {},
+                "project_name": "demo",
+            }
+        ]
+        pool = ProviderPool(provider_id="ark", image_max=0, video_max=1)
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        pool.video_inflight["vid-active"] = fut  # type: ignore[assignment]
+        worker = GenerationWorker(queue=queue, pools={"ark": pool})
+
+        captured: list[dict[str, Any]] = []
+
+        async def _spy_dispatch(self, mapping):
+            captured.append(dict(mapping))
+
+        monkeypatch.setattr(GenerationWorker, "_dispatch_resume_orphans_background", _spy_dispatch)
+
+        await worker._handle_orphan_tasks_on_start()
+
+        # 不应启动 dispatcher，因为本进程仍在跑该 task
+        assert captured == [], f"本进程 inflight 的 task 不应被重复 dispatch: {captured}"
+        assert "vid-active" not in {tid for tid, _ in queue.failed}
+        fut.set_result(None)
+
+    @pytest.mark.asyncio
+    async def test_video_pending_also_skipped(self):
+        """本进程 video_pending（sem 排队中）含 task → 孤儿扫描应跳过。"""
+        queue = _FakeQueue()
+        queue._orphans = [
+            {
+                "task_id": "vid-pending",
+                "status": "running",
+                "media_type": "video",
+                "task_type": "video",
+                "provider_id": "ark",
+                "provider_job_id": "ark-job-2",
+                "payload": {},
+                "project_name": "demo",
+            }
+        ]
+        pool = ProviderPool(provider_id="ark", image_max=0, video_max=1)
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        pool.video_pending["vid-pending"] = fut  # type: ignore[assignment]
+        worker = GenerationWorker(queue=queue, pools={"ark": pool})
+
+        await worker._handle_orphan_tasks_on_start()
+
+        assert "vid-pending" not in {tid for tid, _ in queue.failed}
+        # dispatcher 句柄不应被设置（无 resumable 任务进 dispatcher）
+        assert worker._orphan_dispatcher_task is None
+        fut.set_result(None)
 
 
 class TestOrphanDispatcherNonBlockingOverride:

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -833,13 +833,15 @@ class TestGenerationWorker:
         queue = _FakeQueue()
         worker = GenerationWorker(queue=queue)
         captured_task: dict | None = None
+        captured_job_id: str | None = None
 
-        async def _fake_execute(task):
-            nonlocal captured_task
+        async def _fake_resume(task, *, job_id):
+            nonlocal captured_task, captured_job_id
             captured_task = task
+            captured_job_id = job_id
             return {"ok": True}
 
-        monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _fake_execute)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _fake_resume)
 
         task = {
             "task_id": "resume-locked",
@@ -854,6 +856,7 @@ class TestGenerationWorker:
         assert captured_task is not None
         # _process_resume_task 应覆写为持久化 provider_id (openai)
         assert captured_task["payload"]["video_provider"] == "openai"
+        assert captured_job_id == "openai-job"
         assert queue.succeeded == [("resume-locked", {"ok": True})]
 
     @pytest.mark.asyncio
@@ -864,10 +867,10 @@ class TestGenerationWorker:
         queue = _FakeQueue()
         worker = GenerationWorker(queue=queue)
 
-        async def _expire(_task):
-            raise ResumeExpiredError(job_id="x", provider="ark")
+        async def _expire(_task, *, job_id):
+            raise ResumeExpiredError(job_id=job_id, provider="ark")
 
-        monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _expire)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _expire)
         task = {
             "task_id": "exp",
             "task_type": "video",
@@ -887,10 +890,10 @@ class TestGenerationWorker:
         queue = _FakeQueue()
         worker = GenerationWorker(queue=queue)
 
-        async def _unsup(_task):
+        async def _unsup(_task, *, job_id):
             raise NotImplementedError("no resume_video")
 
-        monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _unsup)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _unsup)
         task = {
             "task_id": "uns",
             "task_type": "video",
@@ -910,10 +913,10 @@ class TestGenerationWorker:
         queue = _FakeQueue()
         worker = GenerationWorker(queue=queue)
 
-        async def _boom(_task):
+        async def _boom(_task, *, job_id):
             raise RuntimeError("transient backend error")
 
-        monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _boom)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _boom)
         task = {
             "task_id": "boom",
             "task_type": "video",
@@ -934,10 +937,10 @@ class TestGenerationWorker:
         queue = _FakeQueue()
         worker = GenerationWorker(queue=queue)
 
-        async def _cancel(_task):
+        async def _cancel(_task, *, job_id):
             raise asyncio.CancelledError
 
-        monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _cancel)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _cancel)
         task = {
             "task_id": "rc",
             "task_type": "video",
@@ -950,3 +953,20 @@ class TestGenerationWorker:
         with pytest.raises(asyncio.CancelledError):
             await worker._process_resume_task(task)
         assert queue.cancelled and queue.cancelled[0][0] == "rc"
+
+    @pytest.mark.asyncio
+    async def test_process_resume_task_no_job_id_fails_fast(self):
+        """无 provider_job_id 的 task 被派发到 _process_resume_task 时直接 mark_failed。"""
+        queue = _FakeQueue()
+        worker = GenerationWorker(queue=queue)
+        task = {
+            "task_id": "no-job",
+            "task_type": "video",
+            "media_type": "video",
+            "provider_job_id": "",
+            "payload": {},
+            "project_name": "demo",
+        }
+        await worker._process_resume_task(task)
+        assert queue.failed and queue.failed[0][0] == "no-job"
+        assert "[restart_lost]" in queue.failed[0][1]

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -978,3 +978,124 @@ class TestGenerationWorker:
         await worker._process_resume_task(task)
         assert queue.failed and queue.failed[0][0] == "no-job"
         assert "[restart_lost]" in queue.failed[0][1]
+
+
+class TestDispatcherFailFastAndPendingTracking:
+    """dispatcher fail-fast + pending/inflight 分集合精确容量与 cancel 跟踪。"""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_provider_bucket_fail_fast_when_video_max_zero(self, monkeypatch):
+        """pool.video_max=0 → 直接 mark_failed[resume_unsupported]，不进 Semaphore(0) 死锁。"""
+        queue = _FakeQueue()
+        pool = ProviderPool(provider_id="ark", image_max=0, video_max=0)
+        worker = GenerationWorker(queue=queue, pools={"ark": pool})
+
+        async def _no_reload(self):
+            return None
+
+        monkeypatch.setattr(GenerationWorker, "reload_limits", _no_reload)
+
+        tasks = [{"task_id": f"orphan-{i}", "provider_id": "ark"} for i in range(3)]
+        await worker._dispatch_provider_bucket("ark", tasks)
+
+        assert {tid for tid, _ in queue.failed} == {"orphan-0", "orphan-1", "orphan-2"}
+        assert all("[resume_unsupported]" in msg for _, msg in queue.failed)
+
+    @pytest.mark.asyncio
+    async def test_sub_task_registered_in_pending_before_sem_acquire(self, monkeypatch):
+        """sem=1 + 2 task：第 2 个 sub-task sem 排队期间应在 pool.video_pending。"""
+        queue = _FakeQueue()
+        pool = ProviderPool(provider_id="ark", image_max=0, video_max=1)
+        worker = GenerationWorker(queue=queue, pools={"ark": pool})
+
+        gate = asyncio.Event()
+
+        async def _gated(self, task):
+            await gate.wait()
+
+        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _gated)
+
+        tasks = [{"task_id": f"orphan-{i}", "provider_id": "ark"} for i in range(2)]
+        dispatcher = asyncio.create_task(worker._dispatch_provider_bucket("ark", tasks))
+
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if len(pool.video_inflight) == 1:
+                break
+        assert len(pool.video_inflight) == 1
+        assert len(pool.video_pending) == 1
+        assert pool.has_video_room() is False
+
+        gate.set()
+        await dispatcher
+
+    @pytest.mark.asyncio
+    async def test_has_video_room_counts_pending_plus_inflight(self):
+        """pending=1, inflight=0, max=1 → has_video_room False，主循环不会超额 claim。"""
+        pool = ProviderPool(provider_id="ark", image_max=0, video_max=1)
+        loop = asyncio.get_running_loop()
+        dummy = loop.create_future()
+        dummy.set_result(None)
+        pool.video_pending["orphan-1"] = dummy
+        assert pool.has_video_room() is False
+
+    @pytest.mark.asyncio
+    async def test_request_cancel_finds_sem_queued_task_in_pending(self, monkeypatch):
+        """cancel sem 排队中的 task → request_cancel 命中并触发 cancel。"""
+        queue = _FakeQueue()
+        pool = ProviderPool(provider_id="ark", image_max=0, video_max=1)
+        worker = GenerationWorker(queue=queue, pools={"ark": pool})
+
+        gate = asyncio.Event()
+        process_started: asyncio.Event = asyncio.Event()
+
+        async def _gated(self, task):
+            process_started.set()
+            await gate.wait()
+
+        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _gated)
+
+        tasks = [{"task_id": f"orphan-{i}", "provider_id": "ark"} for i in range(2)]
+        dispatcher = asyncio.create_task(worker._dispatch_provider_bucket("ark", tasks))
+
+        await asyncio.wait_for(process_started.wait(), timeout=1.0)
+        assert "orphan-1" in pool.video_pending
+
+        ok = worker.request_cancel("orphan-1")
+        assert ok is True
+
+        gate.set()
+        await dispatcher
+
+    @pytest.mark.asyncio
+    async def test_dispatcher_handle_set_after_handle_orphan(self, monkeypatch):
+        """_handle_orphan_tasks_on_start 后 self._orphan_dispatcher_task 应被设置。"""
+        queue = _FakeQueue()
+        queue._orphans = [
+            {
+                "task_id": "orphan-x",
+                "status": "running",
+                "provider_id": "ark",
+                "provider_job_id": "job-x",
+                "media_type": "video",
+                "task_type": "video",
+                "payload": {},
+                "project_name": "demo",
+            }
+        ]
+        pool = ProviderPool(provider_id="ark", image_max=0, video_max=1)
+        worker = GenerationWorker(queue=queue, pools={"ark": pool})
+
+        block = asyncio.Event()
+
+        async def _gated(self, task):
+            await block.wait()
+
+        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _gated)
+
+        await worker._handle_orphan_tasks_on_start()
+        assert worker._orphan_dispatcher_task is not None
+        assert not worker._orphan_dispatcher_task.done()
+
+        block.set()
+        await worker._orphan_dispatcher_task

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -1069,6 +1069,41 @@ class TestDispatcherFailFastAndPendingTracking:
         await dispatcher
 
     @pytest.mark.asyncio
+    async def test_sem_queued_cancel_marks_task_cancelled(self, monkeypatch):
+        """sem 排队期被 cancel：_run_one 应显式 mark_task_cancelled，DB 不留 cancelling。"""
+        queue = _FakeQueue()
+        pool = ProviderPool(provider_id="ark", image_max=0, video_max=1)
+        worker = GenerationWorker(queue=queue, pools={"ark": pool})
+
+        gate = asyncio.Event()
+        first_started = asyncio.Event()
+
+        async def _gated(self, task):
+            first_started.set()
+            await gate.wait()
+
+        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _gated)
+
+        tasks = [{"task_id": f"orphan-{i}", "provider_id": "ark"} for i in range(2)]
+        dispatcher = asyncio.create_task(worker._dispatch_provider_bucket("ark", tasks))
+
+        # 等第 1 个 task 进入 _process_resume_task（占住 sem），第 2 个还在 sem 排队
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+        assert "orphan-1" in pool.video_pending
+
+        # 取消 sem 排队中的 orphan-1
+        queued_task = pool.video_pending["orphan-1"]
+        queued_task.cancel()
+
+        # 让 dispatcher 跑完
+        gate.set()
+        await dispatcher
+
+        # orphan-1 应被显式 mark_task_cancelled（sem 排队期 cancel 路径），不能停在 cancelling
+        cancelled_ids = {tid for tid, _ in queue.cancelled}
+        assert "orphan-1" in cancelled_ids
+
+    @pytest.mark.asyncio
     async def test_dispatcher_handle_set_after_handle_orphan(self, monkeypatch):
         """_handle_orphan_tasks_on_start 后 self._orphan_dispatcher_task 应被设置。"""
         queue = _FakeQueue()

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -630,8 +630,8 @@ class TestGenerationWorker:
     async def test_handle_orphan_resumable_dispatches_process_resume_task(self, monkeypatch):
         """video resumable provider + 有 job_id → 后台 dispatcher 派发 _process_resume_task。
 
-        fast path 只分桶 + 派 background dispatcher（fix #647 第 1 项），inflight 字典
-        由 dispatcher 异步填入；用 gather 等待 dispatcher 完成后再断言。
+        Semaphore-based dispatcher 在 sub-task 内填 inflight、finally pop；本测验证
+        dispatched 列表收到目标 task 即可（dispatcher 完成时 inflight 已被清理）。
         """
         queue = _FakeQueue()
         queue._orphans = [
@@ -654,15 +654,23 @@ class TestGenerationWorker:
 
         monkeypatch.setattr(GenerationWorker, "_process_resume_task", _capture_resume)
         await worker._handle_orphan_tasks_on_start()
-        # 等所有 pending background task 完成（含 orphan-dispatcher + provider 桶 sub-task
-        # + 实际 inflight resume task）
-        pool = worker._get_or_create_pool("ark")
-        for _ in range(20):
+        # 等后台 dispatcher（含 orphan-dispatcher + provider 桶 sub-task）完成
+        for _ in range(50):
             await asyncio.sleep(0)
-            if "ark-orphan" in pool.video_inflight:
+            if dispatched:
                 break
-        assert "ark-orphan" in pool.video_inflight
-        await asyncio.gather(*pool.video_inflight.values(), return_exceptions=True)
+        # 让 dispatcher 自身的 task 跑完（避免 unawaited task 警告）
+        for t in list(asyncio.all_tasks()):
+            name = t.get_name()
+            if (
+                name in ("orphan-dispatcher",)
+                or name.startswith("orphan-dispatch-")
+                or name.startswith("resume-video-")
+            ):
+                try:
+                    await t
+                except Exception:
+                    pass
         assert len(dispatched) == 1
         assert dispatched[0]["task_id"] == "ark-orphan"
 

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 
 from lib.generation_worker import (
+    _ORPHAN_RESCAN_LEASE_LOST_MULT,
     DEFAULT_PROVIDER,
     GenerationWorker,
     ProviderPool,
@@ -1099,3 +1100,123 @@ class TestDispatcherFailFastAndPendingTracking:
 
         block.set()
         await worker._orphan_dispatcher_task
+
+
+class TestOrphanOnceAndLeaseFlap:
+    """orphan 一次性扫描 + lease flap 阈值。"""
+
+    def _build_worker(self) -> tuple[GenerationWorker, _FakeQueue, list[int]]:
+        """构造 worker；返回 (worker, queue, scan_count)。scan_count 记录扫描次数。"""
+        queue = _FakeQueue()
+        worker = GenerationWorker(queue=queue)
+        scan_count: list[int] = []
+
+        async def _spy_scan():
+            scan_count.append(1)
+
+        # 替换 _handle_orphan_tasks_on_start 为 spy，便于精确断言扫描次数
+        worker._handle_orphan_tasks_on_start = _spy_scan  # type: ignore[assignment]
+        return worker, queue, scan_count
+
+    @pytest.mark.asyncio
+    async def test_orphan_scanned_once_on_first_lease_acquire(self):
+        worker, _, scan_count = self._build_worker()
+        worker._owns_lease = True
+        worker._orphan_handled_once = False
+
+        # 模拟主循环里那段守卫
+        if worker._owns_lease and not worker._orphan_handled_once:
+            await worker._handle_orphan_tasks_on_start()
+            worker._orphan_handled_once = True
+
+        assert len(scan_count) == 1
+        assert worker._orphan_handled_once is True
+
+    @pytest.mark.asyncio
+    async def test_orphan_not_rescanned_in_steady_state(self):
+        """稳定持 lease 多拍主循环：扫描仅 1 次。"""
+        worker, _, scan_count = self._build_worker()
+        worker._owns_lease = True
+
+        for _ in range(5):
+            if worker._owns_lease and not worker._orphan_handled_once:
+                await worker._handle_orphan_tasks_on_start()
+                worker._orphan_handled_once = True
+
+        assert len(scan_count) == 1
+
+    @pytest.mark.asyncio
+    async def test_orphan_does_not_rescan_on_short_lease_flap(self):
+        """lease flap < lease_ttl：不重扫。"""
+        worker, _, scan_count = self._build_worker()
+        worker.lease_ttl = 10.0
+
+        # 首次获得 lease 扫一次
+        worker._owns_lease = True
+        await worker._handle_orphan_tasks_on_start()
+        worker._orphan_handled_once = True
+
+        # 模拟丢 lease 1 秒后又夺回（短 flap）
+        import time as _time
+
+        worker._lease_lost_monotonic = _time.monotonic() - 1.0
+        # 应用 _run_loop 中的逻辑片段
+        lost_duration = _time.monotonic() - worker._lease_lost_monotonic
+        if lost_duration > worker.lease_ttl * _ORPHAN_RESCAN_LEASE_LOST_MULT:
+            worker._orphan_handled_once = False
+        worker._lease_lost_monotonic = None
+
+        # flap 时长远小于 30s，仍是 handled_once
+        assert worker._orphan_handled_once is True
+        if worker._owns_lease and not worker._orphan_handled_once:
+            await worker._handle_orphan_tasks_on_start()
+        assert len(scan_count) == 1, "短 flap 不应重扫"
+
+    @pytest.mark.asyncio
+    async def test_orphan_does_not_rescan_below_3x_ttl(self):
+        """lease_ttl < lost < 3×lease_ttl：仍不重扫（边界）。"""
+        worker, _, scan_count = self._build_worker()
+        worker.lease_ttl = 10.0
+
+        worker._owns_lease = True
+        await worker._handle_orphan_tasks_on_start()
+        worker._orphan_handled_once = True
+
+        import time as _time
+
+        # lost = 15s（介于 ttl=10s 与 3×ttl=30s 之间）
+        worker._lease_lost_monotonic = _time.monotonic() - 15.0
+        lost_duration = _time.monotonic() - worker._lease_lost_monotonic
+        if lost_duration > worker.lease_ttl * _ORPHAN_RESCAN_LEASE_LOST_MULT:
+            worker._orphan_handled_once = False
+        worker._lease_lost_monotonic = None
+
+        assert worker._orphan_handled_once is True
+        if worker._owns_lease and not worker._orphan_handled_once:
+            await worker._handle_orphan_tasks_on_start()
+        assert len(scan_count) == 1, "15s 仍 < 3×ttl=30s，不应重扫"
+
+    @pytest.mark.asyncio
+    async def test_orphan_rescans_after_real_lease_handoff(self):
+        """lost > 3×lease_ttl：清零开关，下次重扫。"""
+        worker, _, scan_count = self._build_worker()
+        worker.lease_ttl = 10.0
+
+        worker._owns_lease = True
+        await worker._handle_orphan_tasks_on_start()
+        worker._orphan_handled_once = True
+
+        import time as _time
+
+        # lost = 40s > 30s 阈值，认为另一进程曾持过 lease
+        worker._lease_lost_monotonic = _time.monotonic() - 40.0
+        lost_duration = _time.monotonic() - worker._lease_lost_monotonic
+        if lost_duration > worker.lease_ttl * _ORPHAN_RESCAN_LEASE_LOST_MULT:
+            worker._orphan_handled_once = False
+        worker._lease_lost_monotonic = None
+
+        assert worker._orphan_handled_once is False
+        if worker._owns_lease and not worker._orphan_handled_once:
+            await worker._handle_orphan_tasks_on_start()
+            worker._orphan_handled_once = True
+        assert len(scan_count) == 2, "lost 超过 3×ttl 应重扫一次"

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -1104,6 +1104,45 @@ class TestDispatcherFailFastAndPendingTracking:
         assert "orphan-1" in cancelled_ids
 
     @pytest.mark.asyncio
+    async def test_acquired_pre_process_cancel_marks_task_cancelled(self, monkeypatch):
+        """acquire 后、_process_resume_task 入 try 之前 cancel：_run_one 应兜底 mark cancelled。
+
+        模拟场景：_process_resume_task 内部 try 块之前还有 await（如 _extract_provider），
+        cancel 在那段 await 抛 CancelledError，内部不会调 mark，必须由 _run_one 兜底。
+        """
+        queue = _FakeQueue()
+        pool = ProviderPool(provider_id="ark", image_max=0, video_max=1)
+        worker = GenerationWorker(queue=queue, pools={"ark": pool})
+
+        acquired_event = asyncio.Event()
+        pre_try_gate = asyncio.Event()
+
+        async def _fake_resume_task(self, task):
+            # 模拟 acquired=True 后、try 块之前的 await（即漏窗）
+            acquired_event.set()
+            await pre_try_gate.wait()
+            # 一般不会走到这里——测试通过 cancel queued_task 中断
+
+        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _fake_resume_task)
+
+        tasks = [{"task_id": "orphan-pre-try", "provider_id": "ark"}]
+        dispatcher = asyncio.create_task(worker._dispatch_provider_bucket("ark", tasks))
+
+        # 等 _process_resume_task 进入空窗（await pre_try_gate.wait() 期间）
+        await asyncio.wait_for(acquired_event.wait(), timeout=1.0)
+
+        # 现在 task 在 acquired=True 状态，但 _process_resume_task 还没接管终态
+        sub_task = next(iter(pool.video_inflight.values()))
+        sub_task.cancel()
+
+        # gate 放开（CancelledError 已经在路上）
+        pre_try_gate.set()
+        await dispatcher
+
+        # 必须落 cancelled 终态，不能停在 cancelling
+        assert "orphan-pre-try" in {tid for tid, _ in queue.cancelled}
+
+    @pytest.mark.asyncio
     async def test_dispatcher_handle_set_after_handle_orphan(self, monkeypatch):
         """_handle_orphan_tasks_on_start 后 self._orphan_dispatcher_task 应被设置。"""
         queue = _FakeQueue()

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -1202,6 +1202,8 @@ class TestOrphanScanSelfPreemption:
 
         await worker._handle_orphan_tasks_on_start()
 
+        # dispatcher 句柄不应被设置（本进程仍在跑，无 resumable 任务进 dispatcher）
+        assert worker._orphan_dispatcher_task is None
         # 不应被标 [restart_lost] —— 本进程还在跑
         assert "img-active" not in {tid for tid, _ in queue.failed}
         # 清理
@@ -1238,7 +1240,9 @@ class TestOrphanScanSelfPreemption:
 
         await worker._handle_orphan_tasks_on_start()
 
-        # 不应启动 dispatcher，因为本进程仍在跑该 task
+        # 主断言：dispatcher 句柄从未被创建（同步检查，不受 spy 调度时机影响）
+        assert worker._orphan_dispatcher_task is None
+        # 兜底：spy 也确认未被调用（dispatcher 即便创建也会因 mapping 为空跳过）
         assert captured == [], f"本进程 inflight 的 task 不应被重复 dispatch: {captured}"
         assert "vid-active" not in {tid for tid, _ in queue.failed}
         fut.set_result(None)
@@ -1322,7 +1326,9 @@ class TestOrphanDispatcherNonBlockingOverride:
 
         # 清理：放开 gate 让 dispatcher 完成
         block.set()
-        await asyncio.gather(old_dispatcher, worker._orphan_dispatcher_task, return_exceptions=True)
+        new_dispatcher = worker._orphan_dispatcher_task
+        assert new_dispatcher is not None
+        await asyncio.gather(old_dispatcher, new_dispatcher, return_exceptions=True)
 
 
 class TestOrphanOnceAndLeaseFlap:

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -1176,6 +1176,58 @@ class TestDispatcherFailFastAndPendingTracking:
         await worker._orphan_dispatcher_task
 
 
+class TestOrphanDispatcherNonBlockingOverride:
+    """lease 重夺时旧 dispatcher 仍在跑：本轮直接覆盖句柄，不 await（liveness）也不 cancel
+    （避免错误中断 in-flight resume）。"""
+
+    @pytest.mark.asyncio
+    async def test_old_dispatcher_not_awaited_on_re_scan(self, monkeypatch):
+        """旧 dispatcher 跑 5s 时，再次进 _handle_orphan_tasks_on_start 应秒级返回（不阻塞）。"""
+        queue = _FakeQueue()
+        queue._orphans = [
+            {
+                "task_id": "orphan-x",
+                "status": "running",
+                "provider_id": "ark",
+                "provider_job_id": "job-x",
+                "media_type": "video",
+                "task_type": "video",
+                "payload": {},
+                "project_name": "demo",
+            }
+        ]
+        pool = ProviderPool(provider_id="ark", image_max=0, video_max=1)
+        worker = GenerationWorker(queue=queue, pools={"ark": pool})
+
+        block = asyncio.Event()
+
+        async def _gated(self, task):
+            await block.wait()
+
+        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _gated)
+
+        # 第 1 次扫描：启动旧 dispatcher
+        await worker._handle_orphan_tasks_on_start()
+        old_dispatcher = worker._orphan_dispatcher_task
+        assert old_dispatcher is not None
+        assert not old_dispatcher.done()
+
+        # 第 2 次扫描（模拟 lease flap 超阈值后重夺）：应直接覆盖句柄、不阻塞
+        start = asyncio.get_event_loop().time()
+        await worker._handle_orphan_tasks_on_start()
+        elapsed = asyncio.get_event_loop().time() - start
+        # 应在 1s 内完成；旧 dispatcher 仍未 done 但句柄已被新的覆盖
+        assert elapsed < 1.0, f"重夺时不应阻塞：elapsed={elapsed:.3f}s"
+        assert worker._orphan_dispatcher_task is not old_dispatcher
+        # 旧 dispatcher 未被 cancel——in-flight resume 不应被错误中断
+        assert not old_dispatcher.cancelled()
+        assert not old_dispatcher.done()
+
+        # 清理：放开 gate 让 dispatcher 完成
+        block.set()
+        await asyncio.gather(old_dispatcher, worker._orphan_dispatcher_task, return_exceptions=True)
+
+
 class TestOrphanOnceAndLeaseFlap:
     """orphan 一次性扫描 + lease flap 阈值。"""
 

--- a/tests/test_media_generator_resume.py
+++ b/tests/test_media_generator_resume.py
@@ -370,3 +370,103 @@ async def test_resume_missing_api_call_id_warns_does_not_crash(tmp_path, caplog)
     assert output_path.exists()
     assert version == 1
     assert gen.usage_tracker.finalized == [], "无 api_call_id 时不应 finalize"
+
+
+class _FailingFinalizeUsage(_FakeUsage):
+    """模拟 finalize_pending_by_call_id 自身失败的场景。"""
+
+    def __init__(self, *, exc: Exception) -> None:
+        super().__init__()
+        self._exc = exc
+
+    async def finalize_pending_by_call_id(self, **kwargs):
+        self.finalized.append(kwargs)
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_resume_success_propagates_finalize_exception(tmp_path):
+    """finalize_pending_by_call_id(success) 异常必须冒泡，不能被吞掉。
+
+    吞掉会让对应的 ApiCall 永远卡在 pending（success 分支无后续重试，
+    expired 分支又是终态），usage 报表和补账会出现永久缺口。fail-fast
+    交给 worker finally 的 mark_failed 兜底。"""
+    gen = _build_generator(tmp_path)
+    gen.usage_tracker = _FailingFinalizeUsage(exc=RuntimeError("db down"))
+
+    with pytest.raises(RuntimeError, match="db down"):
+        await gen.resume_video_async(
+            job_id="provider-job-1",
+            resource_type="videos",
+            resource_id="E1S01",
+            task_id="T-1",
+            api_call_id=42,
+        )
+
+    # finalize 被调过一次（看到异常上抛前的入参）
+    assert len(gen.usage_tracker.finalized) == 1
+
+
+@pytest.mark.asyncio
+async def test_resume_expired_propagates_finalize_exception(tmp_path):
+    """ResumeExpiredError 分支同样不能吞 finalize 异常：让 worker finally 兜底标记
+    失败，避免 ApiCall 永远卡 pending。"""
+    gen = _build_generator(tmp_path)
+    gen._video_backend = _FakeVideoBackend(raises=ResumeExpiredError(job_id="provider-job-1", provider="openai"))
+    gen.usage_tracker = _FailingFinalizeUsage(exc=RuntimeError("db down"))
+
+    # finalize 抛 RuntimeError 应该覆盖原本要抛的 ResumeExpiredError 上抛
+    with pytest.raises(RuntimeError, match="db down"):
+        await gen.resume_video_async(
+            job_id="provider-job-1",
+            resource_type="videos",
+            resource_id="E1S01",
+            task_id="T-1",
+            api_call_id=42,
+        )
+
+    assert len(gen.usage_tracker.finalized) == 1
+
+
+@pytest.mark.asyncio
+async def test_resume_passes_generate_audio_to_finalize(tmp_path):
+    """provider 在 submit 后可能降级/关闭音频；resume 必须把 backend 返回的
+    generate_audio 透传到 finalize_pending_by_call_id，避免 cost 沿用请求值误计费
+    （与 generate 路径 finish_call(generate_audio=result.generate_audio) 等价）。"""
+
+    class _AudioDowngradeResult:
+        def __init__(self) -> None:
+            self.video_uri = "video-uri-resume"
+            self.usage_tokens = 1234
+            self.generate_audio = False  # provider 实际降级到无音频
+
+    class _AudioDowngradeBackend:
+        name = "fake"
+        model = "video-model"
+
+        def __init__(self) -> None:
+            self.calls: list[Any] = []
+
+        async def generate(self, request):
+            raise AssertionError("generate 不应被 resume 路径调用")
+
+        async def resume_video(self, job_id, request):
+            self.calls.append((job_id, request))
+            request.output_path.parent.mkdir(parents=True, exist_ok=True)
+            request.output_path.write_bytes(b"fake-resume-video")
+            return _AudioDowngradeResult()
+
+    gen = _build_generator(tmp_path)
+    gen._video_backend = _AudioDowngradeBackend()
+
+    await gen.resume_video_async(
+        job_id="provider-job-1",
+        resource_type="videos",
+        resource_id="E1S01",
+        task_id="T-1",
+        api_call_id=42,
+    )
+
+    assert len(gen.usage_tracker.finalized) == 1
+    call = gen.usage_tracker.finalized[0]
+    assert call["generate_audio"] is False, "generate_audio 必须透传 backend 返回的实际值"

--- a/tests/test_media_generator_resume.py
+++ b/tests/test_media_generator_resume.py
@@ -257,6 +257,40 @@ async def test_resume_after_post_version_crash_does_not_bump(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_resume_handles_float_string_duration(tmp_path):
+    """duration_seconds 传浮点字符串（如 "10.0"）时应解析为 int(10)，
+    不能被 try/except 静默吞成兜底值 8（int("10.0") 会 ValueError）。
+    两次 ensure_current_tracked 与 VideoGenerationRequest 都应收到归一后的 int。"""
+    gen = _build_generator(tmp_path, initial_version=1)  # 已有 v1：开头 ensure 也会触发
+
+    # 预先放文件让开头 output_path.exists() 分支也走 ensure；用真实 _get_output_path
+    pre_path = gen._get_output_path("videos", "E1S01")
+    pre_path.parent.mkdir(parents=True, exist_ok=True)
+    pre_path.write_bytes(b"pre-existing")
+
+    await gen.resume_video_async(
+        job_id="provider-job-1",
+        resource_type="videos",
+        resource_id="E1S01",
+        duration_seconds="10.0",
+        task_id="T-1",
+        api_call_id=42,
+    )
+
+    # 两次 ensure_current_tracked 都应该收到 duration_seconds=10（int），不是 "10.0" 也不是 8
+    assert len(gen.versions.ensure_calls) == 2
+    for call in gen.versions.ensure_calls:
+        assert call["duration_seconds"] == 10
+        assert isinstance(call["duration_seconds"], int)
+
+    # provider 请求里的 duration_seconds 也应是 int(10)
+    backend = gen._video_backend
+    assert len(backend.calls) == 1
+    _, request = backend.calls[0]
+    assert request.duration_seconds == 10
+
+
+@pytest.mark.asyncio
 async def test_resume_missing_api_call_id_warns_does_not_crash(tmp_path, caplog):
     """旧任务 task.payload 无 api_call_id → resume 仍成功，仅 warning。"""
     gen = _build_generator(tmp_path)

--- a/tests/test_media_generator_resume.py
+++ b/tests/test_media_generator_resume.py
@@ -1,0 +1,272 @@
+"""MediaGenerator.resume_video_async 单元测试。
+
+关注点：
+- resume 路径不写 ApiCall（不调 start_call / finish_call）
+- finalize_pending_by_call_id 按 api_call_id 精准翻 pending → success/failed
+- 版本管理用 ensure_current_tracked（重启崩溃边界场景补登记 v1，已有版本时跳过）
+- ResumeExpiredError 沿调用链上抛，pending 翻 failed
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lib.media_generator import MediaGenerator
+from lib.video_backends.base import ResumeExpiredError
+
+
+class _FakeVideoResult:
+    def __init__(self) -> None:
+        self.video_uri = "video-uri-resume"
+        self.usage_tokens = 0
+        self.generate_audio = True
+
+
+class _FakeVideoBackend:
+    name = "fake-video"
+    model = "video-model"
+
+    def __init__(self, *, raises: Exception | None = None) -> None:
+        self.calls: list[Any] = []
+        self.raises = raises
+
+    async def generate(self, request):
+        raise AssertionError("generate 不应被 resume 路径调用")
+
+    async def resume_video(self, job_id, request):
+        self.calls.append((job_id, request))
+        if self.raises is not None:
+            raise self.raises
+        request.output_path.parent.mkdir(parents=True, exist_ok=True)
+        request.output_path.write_bytes(b"fake-resume-video")
+        return _FakeVideoResult()
+
+
+class _FakeVersions:
+    """模拟 VersionManager 的 ensure_current_tracked / add_version / get_current_version。"""
+
+    def __init__(self, *, initial_version: int = 0) -> None:
+        self._version = initial_version
+        self.ensure_calls: list[dict[str, Any]] = []
+        self.add_calls: list[dict[str, Any]] = []
+
+    def ensure_current_tracked(self, **kwargs):
+        self.ensure_calls.append(kwargs)
+        if self._version <= 0:
+            self._version = 1
+            self.add_calls.append(kwargs)
+            return self._version
+        return None
+
+    def add_version(self, **kwargs):
+        self.add_calls.append(kwargs)
+        self._version += 1
+        return self._version
+
+    def get_current_version(self, _resource_type, _resource_id):
+        return self._version
+
+
+class _FakeUsage:
+    def __init__(self) -> None:
+        self.started: list[dict[str, Any]] = []
+        self.finished: list[dict[str, Any]] = []
+        self.finalized: list[dict[str, Any]] = []
+        self._finalize_affected = 1
+
+    async def start_call(self, **kwargs):
+        self.started.append(kwargs)
+        return 999
+
+    async def finish_call(self, **kwargs):
+        self.finished.append(kwargs)
+
+    async def finalize_pending_by_call_id(self, **kwargs):
+        self.finalized.append(kwargs)
+        return self._finalize_affected
+
+
+class _FakeConfigResolver:
+    async def video_generate_audio(self, _project_name=None):
+        return True
+
+
+def _build_generator(tmp_path: Path, *, initial_version: int = 0) -> MediaGenerator:
+    gen = object.__new__(MediaGenerator)
+    gen.project_path = tmp_path / "projects" / "demo"
+    gen.project_path.mkdir(parents=True, exist_ok=True)
+    gen.project_name = "demo"
+    gen._rate_limiter = None
+    gen._image_backend = None
+    gen._video_backend = _FakeVideoBackend()
+    gen._user_id = "default"
+    gen._config = _FakeConfigResolver()
+    gen.versions = _FakeVersions(initial_version=initial_version)
+    gen.usage_tracker = _FakeUsage()
+    return gen
+
+
+@pytest.mark.asyncio
+async def test_resume_does_not_call_usage_tracker_start_or_finish(tmp_path):
+    gen = _build_generator(tmp_path)
+
+    await gen.resume_video_async(
+        job_id="provider-job-1",
+        resource_type="videos",
+        resource_id="E1S01",
+        task_id="T-1",
+        api_call_id=42,
+    )
+
+    assert gen.usage_tracker.started == [], "resume 不应调 start_call"
+    assert gen.usage_tracker.finished == [], "resume 不应调 finish_call"
+
+
+@pytest.mark.asyncio
+async def test_resume_success_flips_pending_apicall_by_call_id(tmp_path):
+    gen = _build_generator(tmp_path)
+
+    await gen.resume_video_async(
+        job_id="provider-job-1",
+        resource_type="videos",
+        resource_id="E1S01",
+        task_id="T-1",
+        api_call_id=42,
+    )
+
+    assert len(gen.usage_tracker.finalized) == 1
+    call = gen.usage_tracker.finalized[0]
+    assert call["call_id"] == 42
+    assert call["status"] == "success"
+    assert call["cost_amount"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_resume_idempotent_when_finalize_returns_zero(tmp_path, caplog):
+    gen = _build_generator(tmp_path)
+    gen.usage_tracker._finalize_affected = 0  # 模拟「已 success」幂等场景
+
+    output_path, version, _, _ = await gen.resume_video_async(
+        job_id="provider-job-1",
+        resource_type="videos",
+        resource_id="E1S01",
+        task_id="T-1",
+        api_call_id=42,
+    )
+
+    assert output_path.exists()
+    assert version == 1
+    # 0 rows 不应抛异常，应当 logger.info 记录
+    assert len(gen.usage_tracker.finalized) == 1
+
+
+@pytest.mark.asyncio
+async def test_resume_expired_flips_pending_to_failed(tmp_path):
+    gen = _build_generator(tmp_path)
+    gen._video_backend = _FakeVideoBackend(raises=ResumeExpiredError(job_id="provider-job-1", provider="openai"))
+
+    with pytest.raises(ResumeExpiredError):
+        await gen.resume_video_async(
+            job_id="provider-job-1",
+            resource_type="videos",
+            resource_id="E1S01",
+            task_id="T-1",
+            api_call_id=42,
+        )
+
+    assert len(gen.usage_tracker.finalized) == 1
+    call = gen.usage_tracker.finalized[0]
+    assert call["call_id"] == 42
+    assert call["status"] == "failed"
+    assert call["cost_amount"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_resume_other_exception_does_not_finalize(tmp_path):
+    """非 ResumeExpiredError（如下载超时）不翻 pending，留给 worker 重试机制处理。"""
+    gen = _build_generator(tmp_path)
+    gen._video_backend = _FakeVideoBackend(raises=RuntimeError("network timeout"))
+
+    with pytest.raises(RuntimeError):
+        await gen.resume_video_async(
+            job_id="provider-job-1",
+            resource_type="videos",
+            resource_id="E1S01",
+            task_id="T-1",
+            api_call_id=42,
+        )
+
+    assert gen.usage_tracker.finalized == [], "非 ResumeExpired 不应 finalize pending"
+
+
+@pytest.mark.asyncio
+async def test_resume_uses_ensure_current_tracked(tmp_path):
+    """resume 用 ensure_current_tracked，不调 add_version。"""
+    gen = _build_generator(tmp_path)
+
+    await gen.resume_video_async(
+        job_id="provider-job-1",
+        resource_type="videos",
+        resource_id="E1S01",
+        task_id="T-1",
+        api_call_id=42,
+    )
+
+    # ensure_current_tracked 至少被调一次（末尾必调；开头 output_path.exists() 时也会调）
+    assert len(gen.versions.ensure_calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_resume_after_pre_version_crash_creates_v1(tmp_path):
+    """submit→poll 中崩 → versions.json 空 → resume 后补登记 v1 避免 finalize IndexError。"""
+    gen = _build_generator(tmp_path, initial_version=0)
+
+    _, version, _, _ = await gen.resume_video_async(
+        job_id="provider-job-1",
+        resource_type="videos",
+        resource_id="E1S01",
+        task_id="T-1",
+        api_call_id=42,
+    )
+
+    assert version == 1
+    assert len(gen.versions.add_calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_resume_after_post_version_crash_does_not_bump(tmp_path):
+    """poll 成功→mark_succeeded 前崩 → versions 已有 v1 → resume 不重复 bump。"""
+    gen = _build_generator(tmp_path, initial_version=1)
+
+    _, version, _, _ = await gen.resume_video_async(
+        job_id="provider-job-1",
+        resource_type="videos",
+        resource_id="E1S01",
+        task_id="T-1",
+        api_call_id=42,
+    )
+
+    assert version == 1, "已有 v1 时 ensure 应跳过，不重复 bump"
+    # ensure_current_tracked 仍被调（但内部 short-circuit），add_calls 不增
+    assert len(gen.versions.add_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_resume_missing_api_call_id_warns_does_not_crash(tmp_path, caplog):
+    """旧任务 task.payload 无 api_call_id → resume 仍成功，仅 warning。"""
+    gen = _build_generator(tmp_path)
+
+    output_path, version, _, _ = await gen.resume_video_async(
+        job_id="provider-job-1",
+        resource_type="videos",
+        resource_id="E1S01",
+        task_id="T-1",
+        api_call_id=None,
+    )
+
+    assert output_path.exists()
+    assert version == 1
+    assert gen.usage_tracker.finalized == [], "无 api_call_id 时不应 finalize"

--- a/tests/test_media_generator_resume.py
+++ b/tests/test_media_generator_resume.py
@@ -288,6 +288,53 @@ async def test_resume_handles_float_string_duration(tmp_path):
     assert len(backend.calls) == 1
     _, request = backend.calls[0]
     assert request.duration_seconds == 10
+    assert isinstance(request.duration_seconds, int), "归一后类型必须是 int 而非 str/float"
+
+
+@pytest.mark.asyncio
+async def test_resume_passes_usage_tokens_to_finalize(tmp_path):
+    """Ark 视频按 usage_tokens 计费，缺省为 0 会导致 cost 永远为 0；
+    resume 路径必须把 backend.resume_video 返回的 usage_tokens 透传到 finalize_pending_by_call_id，
+    与 generate 路径 finish_call(..., usage_tokens=...) 等价记账。"""
+
+    class _ArkLikeResult:
+        def __init__(self) -> None:
+            self.video_uri = "video-uri-resume"
+            self.usage_tokens = 12345  # 模拟 Ark 返回的 completion_tokens
+            self.generate_audio = True
+
+    class _ArkLikeBackend:
+        name = "ark"
+        model = "doubao-seedance-1-0-pro"
+
+        def __init__(self) -> None:
+            self.calls: list[Any] = []
+
+        async def generate(self, request):
+            raise AssertionError("generate 不应被 resume 路径调用")
+
+        async def resume_video(self, job_id, request):
+            self.calls.append((job_id, request))
+            request.output_path.parent.mkdir(parents=True, exist_ok=True)
+            request.output_path.write_bytes(b"fake-resume-video")
+            return _ArkLikeResult()
+
+    gen = _build_generator(tmp_path)
+    gen._video_backend = _ArkLikeBackend()
+
+    await gen.resume_video_async(
+        job_id="provider-job-1",
+        resource_type="videos",
+        resource_id="E1S01",
+        task_id="T-1",
+        api_call_id=42,
+    )
+
+    assert len(gen.usage_tracker.finalized) == 1
+    call = gen.usage_tracker.finalized[0]
+    assert call["call_id"] == 42
+    assert call["status"] == "success"
+    assert call["usage_tokens"] == 12345, "usage_tokens 必须透传，否则 Ark cost 永远为 0"
 
 
 @pytest.mark.asyncio

--- a/tests/test_media_generator_resume.py
+++ b/tests/test_media_generator_resume.py
@@ -141,7 +141,9 @@ async def test_resume_success_flips_pending_apicall_by_call_id(tmp_path):
     call = gen.usage_tracker.finalized[0]
     assert call["call_id"] == 42
     assert call["status"] == "success"
-    assert call["cost_amount"] == 0.0
+    # success 路径不显式传 cost_amount，让 repo 按 ApiCall 行字段 auto-calc 算实际 cost
+    # （与 generate 路径 finish_call 等价记账），caller 端不再硬编码 0.0
+    assert "cost_amount" not in call or call["cost_amount"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_media_generator_resume.py
+++ b/tests/test_media_generator_resume.py
@@ -3,7 +3,8 @@
 关注点：
 - resume 路径不写 ApiCall（不调 start_call / finish_call）
 - finalize_pending_by_call_id 按 api_call_id 精准翻 pending → success/failed
-- 版本管理用 ensure_current_tracked（重启崩溃边界场景补登记 v1，已有版本时跳过）
+- 版本管理用 add_version：resume 成功后总是 bump 新版本，让 versions.json 与磁盘文件一致
+  （submit→poll 崩 → 登记 v1；已有 v_n 的覆盖式重新生成 → 登记 v_(n+1)）
 - ResumeExpiredError 沿调用链上抛，pending 翻 failed
 """
 
@@ -68,6 +69,19 @@ class _FakeVersions:
 
     def get_current_version(self, _resource_type, _resource_id):
         return self._version
+
+
+class _ProbeVideoBackend(_FakeVideoBackend):
+    """resume_video 触发时记录当时 add_calls 的快照，用来断言 add_version 在下载之后才发生。"""
+
+    def __init__(self, versions: _FakeVersions) -> None:
+        super().__init__()
+        self._versions = versions
+        self.add_calls_at_resume: int | None = None
+
+    async def resume_video(self, job_id, request):
+        self.add_calls_at_resume = len(self._versions.add_calls)
+        return await super().resume_video(job_id, request)
 
 
 class _FakeUsage:
@@ -205,9 +219,12 @@ async def test_resume_other_exception_does_not_finalize(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_resume_uses_ensure_current_tracked(tmp_path):
-    """resume 用 ensure_current_tracked，不调 add_version。"""
+async def test_resume_calls_add_version_after_download(tmp_path):
+    """resume 成功后必须 add_version 记录新版本，且 add_version 发生在 backend.resume_video 之后
+    （否则会把残留/旧文件错登记到 versions 表）。同时不应在开头预登记 ensure_current_tracked。"""
     gen = _build_generator(tmp_path)
+    probe = _ProbeVideoBackend(gen.versions)
+    gen._video_backend = probe
 
     await gen.resume_video_async(
         job_id="provider-job-1",
@@ -217,13 +234,17 @@ async def test_resume_uses_ensure_current_tracked(tmp_path):
         api_call_id=42,
     )
 
-    # ensure_current_tracked 至少被调一次（末尾必调；开头 output_path.exists() 时也会调）
-    assert len(gen.versions.ensure_calls) >= 1
+    # add_version 必须发生在下载之后：进入 resume_video 时 add_calls 还是 0
+    assert probe.add_calls_at_resume == 0
+    assert len(gen.versions.add_calls) == 1
+    # 不再在开头/末尾调 ensure_current_tracked（避免错位登记残留文件）
+    assert gen.versions.ensure_calls == []
 
 
 @pytest.mark.asyncio
 async def test_resume_after_pre_version_crash_creates_v1(tmp_path):
-    """submit→poll 中崩 → versions.json 空 → resume 后补登记 v1 避免 finalize IndexError。"""
+    """submit→poll 中崩 → versions.json 空 → resume 下载新视频后 add_version 登记 v1，
+    避免下游 _finalize_video_task 在 versions[-1] 上 IndexError。"""
     gen = _build_generator(tmp_path, initial_version=0)
 
     _, version, _, _ = await gen.resume_video_async(
@@ -235,12 +256,14 @@ async def test_resume_after_pre_version_crash_creates_v1(tmp_path):
     )
 
     assert version == 1
-    assert len(gen.versions.add_calls) >= 1
+    assert len(gen.versions.add_calls) == 1
 
 
 @pytest.mark.asyncio
-async def test_resume_after_post_version_crash_does_not_bump(tmp_path):
-    """poll 成功→mark_succeeded 前崩 → versions 已有 v1 → resume 不重复 bump。"""
+async def test_resume_after_version_v1_crash_bumps_to_v2(tmp_path):
+    """覆盖式重新生成：versions.json 已有 v1，generate 在 add_version 之前崩。
+    resume 下载新视频覆盖 output_path 后必须 bump 到 v2，让 versions.json 与磁盘内容一致；
+    否则 versions={v1} 仍指向旧记录而 output_path 已是 v2 内容，回滚/历史会失真。"""
     gen = _build_generator(tmp_path, initial_version=1)
 
     _, version, _, _ = await gen.resume_video_async(
@@ -251,22 +274,16 @@ async def test_resume_after_post_version_crash_does_not_bump(tmp_path):
         api_call_id=42,
     )
 
-    assert version == 1, "已有 v1 时 ensure 应跳过，不重复 bump"
-    # ensure_current_tracked 仍被调（但内部 short-circuit），add_calls 不增
-    assert len(gen.versions.add_calls) == 0
+    assert version == 2, "已有 v1 + 覆盖式重新生成 → 必须登记 v2"
+    assert len(gen.versions.add_calls) == 1
 
 
 @pytest.mark.asyncio
 async def test_resume_handles_float_string_duration(tmp_path):
     """duration_seconds 传浮点字符串（如 "10.0"）时应解析为 int(10)，
     不能被 try/except 静默吞成兜底值 8（int("10.0") 会 ValueError）。
-    两次 ensure_current_tracked 与 VideoGenerationRequest 都应收到归一后的 int。"""
-    gen = _build_generator(tmp_path, initial_version=1)  # 已有 v1：开头 ensure 也会触发
-
-    # 预先放文件让开头 output_path.exists() 分支也走 ensure；用真实 _get_output_path
-    pre_path = gen._get_output_path("videos", "E1S01")
-    pre_path.parent.mkdir(parents=True, exist_ok=True)
-    pre_path.write_bytes(b"pre-existing")
+    add_version 与 VideoGenerationRequest 都应收到归一后的 int。"""
+    gen = _build_generator(tmp_path, initial_version=1)
 
     await gen.resume_video_async(
         job_id="provider-job-1",
@@ -277,11 +294,11 @@ async def test_resume_handles_float_string_duration(tmp_path):
         api_call_id=42,
     )
 
-    # 两次 ensure_current_tracked 都应该收到 duration_seconds=10（int），不是 "10.0" 也不是 8
-    assert len(gen.versions.ensure_calls) == 2
-    for call in gen.versions.ensure_calls:
-        assert call["duration_seconds"] == 10
-        assert isinstance(call["duration_seconds"], int)
+    # add_version 应该收到 duration_seconds=10（int），不是 "10.0" 也不是 8
+    assert len(gen.versions.add_calls) == 1
+    add_call = gen.versions.add_calls[0]
+    assert add_call["duration_seconds"] == 10
+    assert isinstance(add_call["duration_seconds"], int)
 
     # provider 请求里的 duration_seconds 也应是 int(10)
     backend = gen._video_backend

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -450,3 +450,30 @@ class TestNewAPIVideoBackend:
         assert mock_client.get.call_args.args[0].endswith("/task-resume")
         assert result.task_id == "task-resume"
         assert (tmp_path / "out.mp4").read_bytes() == b"resumed"
+
+    async def test_poll_recognizes_expired_status(self, tmp_path: Path):
+        """fix #647 #5：poll 返回 status='expired' → 抛 ResumeExpiredError。"""
+        from lib.video_backends.base import ResumeExpiredError
+
+        expired_resp = _make_response(200, {"task_id": "task-x", "status": "expired"})
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=expired_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            with pytest.raises(ResumeExpiredError) as ei:
+                await backend.resume_video(
+                    "task-x",
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+                    ),
+                )
+            assert ei.value.job_id == "task-x"
+            assert ei.value.provider == PROVIDER_NEWAPI

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -478,6 +478,37 @@ class TestNewAPIVideoBackend:
             assert ei.value.job_id == "task-x"
             assert ei.value.provider == PROVIDER_NEWAPI
 
+    async def test_resume_404_raises_resume_expired_without_retry(self, tmp_path: Path):
+        """resume 路径下 GET 返 404 应立即转 ResumeExpiredError，不被 retryable 框架重试到超时。"""
+        from lib.video_backends.base import ResumeExpiredError
+
+        # 构造 404 response 让 raise_for_status 真抛 HTTPStatusError（_make_response 默认 mock 空，需手工设）
+        not_found_resp = _make_response(404, {"error": "task not found"})
+        not_found_resp.raise_for_status = MagicMock(side_effect=_make_http_error(404, "task not found"))
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=not_found_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            with pytest.raises(ResumeExpiredError) as ei:
+                await backend.resume_video(
+                    "task-404",
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+                    ),
+                )
+            assert ei.value.job_id == "task-404"
+            assert ei.value.provider == PROVIDER_NEWAPI
+            # 不应被 retry 框架重试多次（应仅 1 次 GET 调用立即抛错）
+            assert mock_client.get.call_count == 1, "404 应一击转 ResumeExpiredError，不该被 retry"
+
     async def test_generate_expired_status_raises_runtime_error_not_resume_expired(self, tmp_path: Path):
         """generate 路径下 status='expired' 抛 RuntimeError，不带 [resume_expired] 语义。"""
         from lib.video_backends.base import ResumeExpiredError

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -477,3 +477,34 @@ class TestNewAPIVideoBackend:
                 )
             assert ei.value.job_id == "task-x"
             assert ei.value.provider == PROVIDER_NEWAPI
+
+    async def test_generate_expired_status_raises_runtime_error_not_resume_expired(self, tmp_path: Path):
+        """generate 路径下 status='expired' 抛 RuntimeError，不带 [resume_expired] 语义。"""
+        from lib.video_backends.base import ResumeExpiredError
+
+        create_resp = _make_response(200, {"task_id": "task-new"})
+        expired_resp = _make_response(200, {"task_id": "task-new", "status": "expired"})
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(return_value=expired_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            with pytest.raises(RuntimeError) as ei:
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p",
+                        output_path=tmp_path / "out.mp4",
+                        aspect_ratio="9:16",
+                        duration_seconds=5,
+                    ),
+                )
+            assert "expired" in str(ei.value).lower()
+            assert not isinstance(ei.value, ResumeExpiredError), "generate 路径不应抛 ResumeExpiredError"

--- a/tests/test_openai_video_backend.py
+++ b/tests/test_openai_video_backend.py
@@ -500,6 +500,41 @@ class TestOpenAIVideoBackend:
         assert result.video_path == output_path
         assert output_path.read_bytes() == video_data
 
+    async def test_poll_recognizes_expired_status(self, tmp_path: Path):
+        """fix #647 #5：retrieve 返回 status='expired' → 抛 ResumeExpiredError，
+        而不是白等 max_wait。"""
+        from lib.video_backends.base import ResumeExpiredError
+
+        mock_client = AsyncMock()
+        expired_video = _make_mock_video(status="expired", video_id="vid_exp")
+        mock_client.videos.retrieve = AsyncMock(return_value=expired_video)
+
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            from lib.video_backends.openai import OpenAIVideoBackend
+
+            backend = OpenAIVideoBackend(api_key="test-key")
+            request = VideoGenerationRequest(
+                prompt="x", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=8
+            )
+            with pytest.raises(ResumeExpiredError) as ei:
+                await backend.resume_video("vid_exp", request)
+            assert ei.value.job_id == "vid_exp"
+            assert ei.value.provider == PROVIDER_OPENAI
+
+    async def test_is_openai_not_found_no_loose_string_match(self):
+        """fix #647 #6：移除 "not found" / "expired" 子串兜底，避免业务字符串误判。"""
+        from lib.video_backends.openai import _is_openai_not_found
+
+        assert _is_openai_not_found(RuntimeError("file not found in storage")) is False
+        assert _is_openai_not_found(RuntimeError("session expired but task is fine")) is False
+        # 仍能识别 status_code=404
+        exc = RuntimeError("any")
+        exc.status_code = 404  # type: ignore[attr-defined]
+        assert _is_openai_not_found(exc) is True
+
     async def test_resume_video_not_found_raises_resume_expired(self, tmp_path: Path):
         """job 不存在/已过期 → ResumeExpiredError(走 [resume_expired] 路径)。"""
         from openai import NotFoundError

--- a/tests/test_openai_video_backend.py
+++ b/tests/test_openai_video_backend.py
@@ -561,3 +561,29 @@ class TestOpenAIVideoBackend:
                 await backend.resume_video("vid_expired", request)
             assert ei.value.job_id == "vid_expired"
             assert ei.value.provider == PROVIDER_OPENAI
+
+    async def test_generate_expired_status_raises_runtime_error_not_resume_expired(self, tmp_path: Path):
+        """generate 路径下 status='expired' 抛 RuntimeError 而不是 ResumeExpiredError。
+
+        fresh submit 路径不该带 [resume_expired] 语义——后者只有 worker 重启接续场景才用。
+        """
+        from lib.video_backends.base import ResumeExpiredError
+
+        mock_client = AsyncMock()
+        mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued", video_id="vid_new"))
+        mock_client.videos.retrieve = AsyncMock(return_value=_make_mock_video(status="expired", video_id="vid_new"))
+
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            from lib.video_backends.openai import OpenAIVideoBackend
+
+            backend = OpenAIVideoBackend(api_key="test-key")
+            request = VideoGenerationRequest(
+                prompt="x", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=8
+            )
+            with pytest.raises(RuntimeError) as ei:
+                await backend.generate(request)
+            assert "expired" in str(ei.value).lower()
+            assert not isinstance(ei.value, ResumeExpiredError), "generate 路径不应抛 ResumeExpiredError"

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -164,6 +164,79 @@ async def test_execute_resume_expired_propagates(monkeypatch, fake_pm, video_tas
 
 
 @pytest.mark.asyncio
+async def test_execute_resume_passes_require_image_backend_false(monkeypatch, fake_pm, video_task):
+    """resume_executor 应显式 require_image_backend=False —— image 配置坏不影响接续。"""
+    from server.services import resume_executor
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator()
+    monkeypatch.setattr(resume_executor, "get_project_manager", lambda: fake_pm)
+    monkeypatch.setattr("server.services.generation_tasks.get_project_manager", lambda: fake_pm)
+    monkeypatch.setattr("server.services.reference_video_tasks.get_project_manager", lambda: fake_pm)
+
+    async def _fake_thumb(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr("server.services.generation_tasks.extract_video_thumbnail", _fake_thumb)
+    monkeypatch.setattr("server.services.reference_video_tasks.extract_video_thumbnail", _fake_thumb)
+
+    captured: dict[str, Any] = {}
+
+    async def _capturing_get_media_generator(*args: Any, **kwargs: Any) -> Any:
+        captured["kwargs"] = kwargs
+        return fake_gen
+
+    monkeypatch.setattr(resume_executor, "get_media_generator", _capturing_get_media_generator)
+
+    await execute_resume_video_task(video_task, job_id="openai-job-1")
+
+    assert captured["kwargs"].get("require_image_backend") is False
+
+
+@pytest.mark.asyncio
+async def test_execute_resume_emits_project_change_batch(monkeypatch, fake_pm, video_task):
+    """resume 成功后同步触发 emit_generation_success_batch（推 SSE 给前端）。"""
+    from server.services import resume_executor
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen)
+
+    calls: list[dict[str, Any]] = []
+
+    def _capture(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(resume_executor, "emit_generation_success_batch", _capture)
+
+    await execute_resume_video_task(video_task, job_id="openai-job-1")
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["task_type"] == "video"
+    assert call["project_name"] == "demo"
+    assert call["resource_id"] == "E1S01"
+
+
+@pytest.mark.asyncio
+async def test_execute_resume_failure_does_not_emit(monkeypatch, fake_pm, video_task):
+    """resume 抛错时不应 emit batch（finalize 未跑成功）。"""
+    from server.services import resume_executor
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator(raises=RuntimeError("backend boom"))
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen)
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(resume_executor, "emit_generation_success_batch", lambda **kwargs: calls.append(kwargs))
+
+    with pytest.raises(RuntimeError):
+        await execute_resume_video_task(video_task, job_id="openai-job-1")
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_execute_resume_rejects_image_task(monkeypatch, fake_pm):
     """非 video / reference_video 任务（如 storyboard）不应被派发到 resume—— image 类无 resume 路径。"""
     from server.services.resume_executor import execute_resume_video_task

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
@@ -46,7 +47,7 @@ class _FakeGenerator:
         self.resume_calls.append(kwargs)
         if self.raises is not None:
             raise self.raises
-        output_path = kwargs["output_path"] if "output_path" in kwargs else Path("/tmp/video.mp4")
+        output_path = kwargs["output_path"] if "output_path" in kwargs else Path(tempfile.gettempdir()) / "video.mp4"
         return output_path, 3, None, "video-uri-xyz"
 
     def get_versions(self, _resource_type: str, _resource_id: str) -> dict[str, Any]:

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -1,0 +1,185 @@
+"""Resume executor 单元测试。
+
+关注点：
+- resume_executor 直接调 generator.resume_video_async（→ backend.resume_video），
+  而不是 generate_video_async（→ backend.generate），避免重复扣费。
+- 跳过 storyboard / reference 本地文件存在性校验——provider 端 job 已经在跑。
+- ResumeExpiredError 沿调用链上抛由 worker mark_failed 时识别。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lib.video_backends.base import ResumeExpiredError
+
+
+class _FakeProjectManager:
+    def __init__(self, project_path: Path, project: dict[str, Any]) -> None:
+        self.project_path = project_path
+        self.project = project
+        self.scene_assets: list[dict[str, Any]] = []
+
+    def load_project(self, _project_name: str) -> dict[str, Any]:
+        return self.project
+
+    def get_project_path(self, _project_name: str) -> Path:
+        return self.project_path
+
+    def update_scene_asset(self, **kwargs: Any) -> None:
+        self.scene_assets.append(kwargs)
+
+
+class _FakeGenerator:
+    """模拟 MediaGenerator：resume_video_async 可控、versions 提供历史查询。"""
+
+    def __init__(self, *, raises: Exception | None = None) -> None:
+        self.resume_calls: list[dict[str, Any]] = []
+        self.raises = raises
+        self.versions = self  # 让 generator.versions.get_versions 走自身
+
+    async def resume_video_async(self, **kwargs: Any) -> tuple[Path, int, Any, str | None]:
+        self.resume_calls.append(kwargs)
+        if self.raises is not None:
+            raise self.raises
+        output_path = kwargs["output_path"] if "output_path" in kwargs else Path("/tmp/video.mp4")
+        return output_path, 3, None, "video-uri-xyz"
+
+    def get_versions(self, _resource_type: str, _resource_id: str) -> dict[str, Any]:
+        return {"versions": [{"created_at": "2026-05-26T00:00:00Z"}]}
+
+
+@pytest.fixture
+def fake_pm(tmp_path: Path) -> _FakeProjectManager:
+    project_path = tmp_path / "projects" / "demo"
+    (project_path / "videos").mkdir(parents=True, exist_ok=True)
+    (project_path / "thumbnails").mkdir(parents=True, exist_ok=True)
+    return _FakeProjectManager(
+        project_path=project_path,
+        project={"content_mode": "narration", "default_duration": 8, "aspect_ratio": "9:16"},
+    )
+
+
+@pytest.fixture
+def video_task() -> dict[str, Any]:
+    return {
+        "task_id": "T-1",
+        "task_type": "video",
+        "media_type": "video",
+        "project_name": "demo",
+        "resource_id": "E1S01",
+        "provider_id": "openai",
+        "provider_job_id": "openai-job-1",
+        "payload": {"script_file": "episode_1.json", "prompt": "p"},
+    }
+
+
+def _patch_resume_executor_deps(monkeypatch, fake_pm: _FakeProjectManager, fake_generator: _FakeGenerator) -> None:
+    """同时 patch resume_executor 的 pm/generator 来源——它从 generation_tasks 顶层 re-import。"""
+    from server.services import resume_executor
+
+    monkeypatch.setattr(resume_executor, "get_project_manager", lambda: fake_pm)
+    monkeypatch.setattr(resume_executor, "get_media_generator", AsyncMock(return_value=fake_generator))
+    # finalize helpers 内部也通过 generation_tasks/reference_video_tasks 的 get_project_manager
+    monkeypatch.setattr("server.services.generation_tasks.get_project_manager", lambda: fake_pm)
+    monkeypatch.setattr("server.services.reference_video_tasks.get_project_manager", lambda: fake_pm)
+
+    # extract_video_thumbnail 真实实现走 ffprobe；mock 成 no-op 让 finalize 不依赖外部工具
+    async def _fake_thumb(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr("server.services.generation_tasks.extract_video_thumbnail", _fake_thumb)
+    monkeypatch.setattr("server.services.reference_video_tasks.extract_video_thumbnail", _fake_thumb)
+
+
+@pytest.mark.asyncio
+async def test_execute_resume_video_calls_backend_resume_directly(monkeypatch, fake_pm, video_task):
+    """resume_executor 调 generator.resume_video_async（间接走 backend.resume_video），而非 generate。"""
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen)
+
+    result = await execute_resume_video_task(video_task, job_id="openai-job-1")
+
+    assert len(fake_gen.resume_calls) == 1
+    call = fake_gen.resume_calls[0]
+    assert call["job_id"] == "openai-job-1"
+    assert call["resource_type"] == "videos"
+    assert call["resource_id"] == "E1S01"
+    assert call["task_id"] == "T-1"
+    # 返回结果带 file_path / resource_type，供 worker mark_succeeded
+    assert result["resource_type"] == "videos"
+    assert result["file_path"] == "videos/scene_E1S01.mp4"
+
+
+@pytest.mark.asyncio
+async def test_execute_resume_skips_storyboard_check(monkeypatch, fake_pm, video_task):
+    """resume 路径不读 storyboard 本地文件——即使 storyboard 不存在也能成功。"""
+    from server.services.resume_executor import execute_resume_video_task
+
+    # 故意确保 storyboard 不存在
+    storyboard_dir = fake_pm.project_path / "storyboards"
+    if storyboard_dir.exists():
+        for f in storyboard_dir.glob("*.png"):
+            f.unlink()
+
+    fake_gen = _FakeGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen)
+
+    # 不应抛 "storyboard not found"
+    result = await execute_resume_video_task(video_task, job_id="openai-job-1")
+    assert result["file_path"] == "videos/scene_E1S01.mp4"
+
+
+@pytest.mark.asyncio
+async def test_execute_resume_writes_scene_asset(monkeypatch, fake_pm, video_task):
+    """resume 成功后写 scene asset（video_clip + video_uri）。"""
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen)
+
+    await execute_resume_video_task(video_task, job_id="openai-job-1")
+
+    asset_types = {a["asset_type"] for a in fake_pm.scene_assets}
+    assert "video_clip" in asset_types
+    assert "video_uri" in asset_types
+
+
+@pytest.mark.asyncio
+async def test_execute_resume_expired_propagates(monkeypatch, fake_pm, video_task):
+    """backend.resume_video raise ResumeExpiredError → resume_executor 不吞，往上抛。"""
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator(raises=ResumeExpiredError(job_id="openai-job-1", provider="openai"))
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen)
+
+    with pytest.raises(ResumeExpiredError):
+        await execute_resume_video_task(video_task, job_id="openai-job-1")
+
+
+@pytest.mark.asyncio
+async def test_execute_resume_rejects_image_task(monkeypatch, fake_pm):
+    """非 video / reference_video 任务（如 storyboard）不应被派发到 resume—— image 类无 resume 路径。"""
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen)
+
+    image_task = {
+        "task_id": "T-img",
+        "task_type": "storyboard",
+        "media_type": "image",
+        "project_name": "demo",
+        "resource_id": "E1S01",
+        "provider_id": "gemini-aistudio",
+        "provider_job_id": "x",
+        "payload": {"script_file": "episode_1.json"},
+    }
+    with pytest.raises(NotImplementedError):
+        await execute_resume_video_task(image_task, job_id="x")

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -238,6 +238,30 @@ async def test_execute_resume_failure_does_not_emit(monkeypatch, fake_pm, video_
 
 
 @pytest.mark.asyncio
+async def test_execute_resume_accepts_float_string_duration(monkeypatch, fake_pm):
+    """payload.duration_seconds = \"8.0\"（浮点字符串）应被 int(float()) 兜底转 8，不应 ValueError。"""
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen)
+
+    task = {
+        "task_id": "T-float",
+        "task_type": "video",
+        "media_type": "video",
+        "project_name": "demo",
+        "resource_id": "E1S01",
+        "provider_id": "openai",
+        "provider_job_id": "openai-job-1",
+        "payload": {"script_file": "episode_1.json", "prompt": "p", "duration_seconds": "8.0"},
+    }
+    # 不应抛 ValueError
+    result = await execute_resume_video_task(task, job_id="openai-job-1")
+    assert result["resource_type"] == "videos"
+    assert fake_gen.resume_calls[0]["duration_seconds"] == 8
+
+
+@pytest.mark.asyncio
 async def test_execute_resume_rejects_image_task(monkeypatch, fake_pm):
     """非 video / reference_video 任务（如 storyboard）不应被派发到 resume—— image 类无 resume 路径。"""
     from server.services.resume_executor import execute_resume_video_task

--- a/tests/test_task_repo.py
+++ b/tests/test_task_repo.py
@@ -516,6 +516,26 @@ class TestCancelCascadeAcrossCancelling:
         assert (await repo.get(c))["status"] == "cancelled"
         assert (await repo.get(c))["cancelled_by"] == "cascade"
 
+    async def test_cancel_cascade_event_data_carries_cancelled_by(self, db_session):
+        """前端通过 SSE 事件 data 中的 cancelled_by 字段区分级联取消。
+
+        本测试断言：finalize_cancelled(A) 触发的 B/C cancelled 事件 data 中
+        cancelled_by="cascade"；A 自己的事件 data cancelled_by="user"。
+        """
+        repo = TaskRepository(db_session)
+        a, b, c = await self._chain_3(repo)
+        await repo.claim_next("image")
+        await repo.cancel_task(a)
+        await repo.finalize_cancelled(a)
+
+        events = await repo.get_events_since(last_event_id=0)
+        cancelled_events = [e for e in events if e["event_type"] == "cancelled"]
+        by_task = {e["task_id"]: e for e in cancelled_events}
+
+        assert by_task[a]["data"]["cancelled_by"] == "user"
+        assert by_task[b]["data"]["cancelled_by"] == "cascade"
+        assert by_task[c]["data"]["cancelled_by"] == "cascade"
+
     async def test_cancel_emits_each_event_at_most_twice(self, db_session):
         """每个 task 的 cancelling/cancelled 事件不超过 1 次/各 1 次（不重复 emit）。"""
         repo = TaskRepository(db_session)

--- a/tests/test_task_repo.py
+++ b/tests/test_task_repo.py
@@ -373,6 +373,58 @@ class TestTaskRepository:
         assert stats["queued"] == 0
 
 
+class TestPersistApiCallId:
+    """persist_api_call_id：read-modify-write 写入 task.payload["api_call_id"]。"""
+
+    async def _enqueue(self, repo: TaskRepository, *, payload=None) -> str:
+        # 不用 `payload or {...}`——空 dict {} 会被 falsy 回退为默认值
+        if payload is None:
+            payload = {"prompt": "p"}
+        result = await repo.enqueue(
+            project_name="demo",
+            task_type="video",
+            media_type="video",
+            resource_id="E1S01",
+            payload=payload,
+            script_file="ep1.json",
+        )
+        return result["task_id"]
+
+    async def test_persist_writes_api_call_id_into_payload(self, db_session):
+        repo = TaskRepository(db_session)
+        task_id = await self._enqueue(repo, payload={"prompt": "p"})
+
+        await repo.persist_api_call_id(task_id, 42)
+
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["payload"]["api_call_id"] == 42
+        assert task["payload"]["prompt"] == "p", "其它 payload 字段不应被覆盖"
+
+    async def test_persist_overwrites_existing_api_call_id(self, db_session):
+        """重试场景：同一 task 第二次走 generate 写新 call_id 应覆盖。"""
+        repo = TaskRepository(db_session)
+        task_id = await self._enqueue(repo)
+
+        await repo.persist_api_call_id(task_id, 10)
+        await repo.persist_api_call_id(task_id, 20)
+
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["payload"]["api_call_id"] == 20
+
+    async def test_persist_handles_empty_payload(self, db_session):
+        """Payload 为空 JSON 也能正常写。"""
+        repo = TaskRepository(db_session)
+        task_id = await self._enqueue(repo, payload={})
+
+        await repo.persist_api_call_id(task_id, 7)
+
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["payload"] == {"api_call_id": 7}
+
+
 class TestCancelCascadeAcrossCancelling:
     """fix #647 #4：cancel 级联跨过 cancelling 节点，A(running)→B(queued)→C(queued)
     在 A 落 cancelled 时通过 finalize_cancelled 自动级联到 B/C。"""

--- a/tests/test_task_repo.py
+++ b/tests/test_task_repo.py
@@ -371,3 +371,113 @@ class TestTaskRepository:
         stats = await repo.get_stats()
         assert stats["cancelled"] == 1
         assert stats["queued"] == 0
+
+
+class TestCancelCascadeAcrossCancelling:
+    """fix #647 #4：cancel 级联跨过 cancelling 节点，A(running)→B(queued)→C(queued)
+    在 A 落 cancelled 时通过 finalize_cancelled 自动级联到 B/C。"""
+
+    async def _chain_3(self, repo: TaskRepository) -> tuple[str, str, str]:
+        a = await repo.enqueue(
+            project_name="demo",
+            task_type="storyboard",
+            media_type="image",
+            resource_id="E1S01",
+            payload={},
+            script_file="ep1.json",
+        )
+        b = await repo.enqueue(
+            project_name="demo",
+            task_type="video",
+            media_type="video",
+            resource_id="E1S01",
+            payload={},
+            script_file="ep1.json",
+            dependency_task_id=a["task_id"],
+        )
+        c = await repo.enqueue(
+            project_name="demo",
+            task_type="video",
+            media_type="video",
+            resource_id="E1S02",
+            payload={},
+            script_file="ep1.json",
+            dependency_task_id=b["task_id"],
+        )
+        return a["task_id"], b["task_id"], c["task_id"]
+
+    async def test_cancel_running_task_returns_only_cancelling(self, db_session):
+        """A running → cancel_task 响应体 cancelled=[]、cancelling=[A]、下游变动靠后续 SSE/finalize。"""
+        repo = TaskRepository(db_session)
+        a, b, c = await self._chain_3(repo)
+        await repo.claim_next("image")  # A 拉成 running
+
+        result = await repo.cancel_task(a)
+        assert result["cancelled"] == []
+        assert result["cancelling"] == [a]
+        assert result["skipped_terminal"] == []
+
+        # B/C 当前仍 queued，因为父 A 还没落 cancelled
+        assert (await repo.get(b))["status"] == "queued"
+        assert (await repo.get(c))["status"] == "queued"
+
+    async def test_cancel_link_running_to_queued(self, db_session):
+        """A(running)→B(queued)→C(queued)：finalize_cancelled(A) → A/B/C 全 cancelled，
+        B/C 的 cancelled_by="cascade"。"""
+        repo = TaskRepository(db_session)
+        a, b, c = await self._chain_3(repo)
+        await repo.claim_next("image")
+        await repo.cancel_task(a)  # A → cancelling
+
+        await repo.finalize_cancelled(a)
+
+        for tid, expected in [(a, "user"), (b, "cascade"), (c, "cascade")]:
+            t = await repo.get(tid)
+            assert t["status"] == "cancelled", f"{tid} expected cancelled, got {t['status']}"
+            assert t["cancelled_by"] == expected
+
+    async def test_cancel_link_running_running_queued(self, db_session):
+        """A(running)→B(running)→C(queued)：finalize(A) → A cancelled、B cancelling、C queued；
+        finalize(B) → B cancelled、C cancelled。"""
+        repo = TaskRepository(db_session)
+        a, b, c = await self._chain_3(repo)
+        # A、B 都拉到 running（B 实际还卡 dep，但模拟单元；用 mark 跳过 claim 守卫）
+        await repo.claim_next("image")
+        # 直接把 B set 成 running 绕开依赖守卫
+        from sqlalchemy import update
+
+        from lib.db.models.task import Task
+
+        await db_session.execute(update(Task).where(Task.task_id == b).values(status="running"))
+        await db_session.commit()
+
+        await repo.cancel_task(a)
+        await repo.cancel_task(b)
+        await repo.finalize_cancelled(a)
+
+        assert (await repo.get(a))["status"] == "cancelled"
+        assert (await repo.get(b))["status"] == "cancelling"
+        assert (await repo.get(c))["status"] == "queued"
+
+        await repo.finalize_cancelled(b)
+        assert (await repo.get(b))["status"] == "cancelled"
+        assert (await repo.get(c))["status"] == "cancelled"
+        assert (await repo.get(c))["cancelled_by"] == "cascade"
+
+    async def test_cancel_emits_each_event_at_most_twice(self, db_session):
+        """每个 task 的 cancelling/cancelled 事件不超过 1 次/各 1 次（不重复 emit）。"""
+        repo = TaskRepository(db_session)
+        a, b, c = await self._chain_3(repo)
+        await repo.claim_next("image")
+        await repo.cancel_task(a)
+        await repo.finalize_cancelled(a)
+
+        events = await repo.get_events_since(last_event_id=0)
+        cancel_events = [e for e in events if e["event_type"] in ("cancelling", "cancelled")]
+        # 计数每个 task 的 cancel-related events
+        by_task: dict[str, int] = {}
+        for e in cancel_events:
+            tid = e["task_id"]
+            by_task[tid] = by_task.get(tid, 0) + 1
+        for tid in (a, b, c):
+            assert by_task.get(tid, 0) <= 2, f"{tid} 有重复 cancel 事件: {by_task.get(tid)}"

--- a/tests/test_task_repo.py
+++ b/tests/test_task_repo.py
@@ -424,6 +424,12 @@ class TestPersistApiCallId:
         assert task is not None
         assert task["payload"] == {"api_call_id": 7}
 
+    async def test_persist_raises_when_task_not_found(self, db_session):
+        """task_id 不存在 → 显式 ValueError，避免静默 commit 让上层以为已持久化。"""
+        repo = TaskRepository(db_session)
+        with pytest.raises(ValueError, match="task not found"):
+            await repo.persist_api_call_id("nonexistent-task-id", 42)
+
 
 class TestCancelCascadeAcrossCancelling:
     """fix #647 #4：cancel 级联跨过 cancelling 节点，A(running)→B(queued)→C(queued)

--- a/tests/test_task_repo.py
+++ b/tests/test_task_repo.py
@@ -430,6 +430,25 @@ class TestPersistApiCallId:
         with pytest.raises(ValueError, match="task not found"):
             await repo.persist_api_call_id("nonexistent-task-id", 42)
 
+    async def test_persist_handles_null_payload_json_row(self, db_session):
+        """task 存在但 payload_json IS NULL（迁移历史/旧任务）→ 走 first() 判存在性，不应误判 task not found。"""
+        from sqlalchemy import update as sql_update
+
+        from lib.db.models.task import Task
+
+        repo = TaskRepository(db_session)
+        task_id = await self._enqueue(repo, payload={"prompt": "p"})
+        # 模拟历史/迁移数据 payload_json IS NULL（Task.payload_json 是 Mapped[str | None]）
+        await db_session.execute(sql_update(Task).where(Task.task_id == task_id).values(payload_json=None))
+        await db_session.commit()
+
+        # 不应抛 ValueError——行存在
+        await repo.persist_api_call_id(task_id, 99)
+
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["payload"] == {"api_call_id": 99}
+
 
 class TestCancelCascadeAcrossCancelling:
     """fix #647 #4：cancel 级联跨过 cancelling 节点，A(running)→B(queued)→C(queued)

--- a/tests/test_task_repo.py
+++ b/tests/test_task_repo.py
@@ -494,6 +494,30 @@ class TestCancelCascadeAcrossCancelling:
             assert t["status"] == "cancelled", f"{tid} expected cancelled, got {t['status']}"
             assert t["cancelled_by"] == expected
 
+    async def test_finalize_cancelled_returns_cascading_cancelling_ids(self, db_session):
+        """finalize_cancelled 应返回级联出来的 running 子任务 task_id 列表，
+        让上层 GenerationQueue 同步分发 in-process cancel 信号给 worker。
+        """
+        repo = TaskRepository(db_session)
+        a, b, c = await self._chain_3(repo)
+        await repo.claim_next("image")
+        # 直接把 B set 成 running 绕开依赖守卫
+        from sqlalchemy import update
+
+        from lib.db.models.task import Task
+
+        await db_session.execute(update(Task).where(Task.task_id == b).values(status="running"))
+        await db_session.commit()
+
+        # finalize_cancelled(a) 级联：A → cancelled、B(running) → cancelling、C(queued, dep on B) 留 queued
+        result = await repo.finalize_cancelled(a)
+
+        assert result["rows"] == 1
+        # B 是 running 下游，cascade 把它转 cancelling 应进入 cancelling 列表
+        assert b in result["cancelling"], "running 下游 task_id 必须返回，让上层分发 cancel"
+        # C 是 queued（依赖 B 还没结束），不进 cancelling 列表
+        assert c not in result["cancelling"]
+
     async def test_cancel_link_running_running_queued(self, db_session):
         """A(running)→B(running)→C(queued)：finalize(A) → A cancelled、B cancelling、C queued；
         finalize(B) → B cancelled、C cancelled。"""

--- a/tests/test_task_repo_state_machine.py
+++ b/tests/test_task_repo_state_machine.py
@@ -102,12 +102,13 @@ class TestRepoStateMachineGuards:
             script_file="ep1.json",
         )
         # queued → cancelled
-        rows = await repo.finalize_cancelled(t["task_id"], cancelled_by="user")
-        assert rows == 1
+        result = await repo.finalize_cancelled(t["task_id"], cancelled_by="user")
+        assert result["rows"] == 1
+        assert result["cancelling"] == []
         assert (await repo.get(t["task_id"]))["status"] == "cancelled"
         # 重复调 → 0 rows
-        rows = await repo.finalize_cancelled(t["task_id"], cancelled_by="user")
-        assert rows == 0
+        result = await repo.finalize_cancelled(t["task_id"], cancelled_by="user")
+        assert result["rows"] == 0
 
     async def test_finalize_cancelled_from_cancelling(self, db_session):
         repo = TaskRepository(db_session)
@@ -121,8 +122,8 @@ class TestRepoStateMachineGuards:
         )
         await repo.claim_next("image")
         await repo._mark_cancelling(t["task_id"])
-        rows = await repo.finalize_cancelled(t["task_id"], cancelled_by="user")
-        assert rows == 1
+        result = await repo.finalize_cancelled(t["task_id"], cancelled_by="user")
+        assert result["rows"] == 1
         assert (await repo.get(t["task_id"]))["status"] == "cancelled"
 
     async def test_finalize_cancelled_rejects_terminal(self, db_session):
@@ -138,8 +139,8 @@ class TestRepoStateMachineGuards:
         )
         await repo.claim_next("image")
         await repo.mark_succeeded(t["task_id"], {"x": 1})
-        rows = await repo.finalize_cancelled(t["task_id"], cancelled_by="user")
-        assert rows == 0
+        result = await repo.finalize_cancelled(t["task_id"], cancelled_by="user")
+        assert result["rows"] == 0
         assert (await repo.get(t["task_id"]))["status"] == "succeeded"
 
     async def test_cancel_task_running_returns_cancelling_intent(self, db_session):
@@ -304,8 +305,8 @@ class TestRepoStateMachineGuards:
         assert claimed["task_id"] == t["task_id"]
 
         # running → finalize_cancelled 直接落 cancelled，不需要走 cancelling
-        rows = await repo.finalize_cancelled(t["task_id"], cancelled_by="user")
-        assert rows == 1
+        result = await repo.finalize_cancelled(t["task_id"], cancelled_by="user")
+        assert result["rows"] == 1
         final = await repo.get(t["task_id"])
         assert final["status"] == "cancelled"
         assert final["cancelled_by"] == "user"

--- a/tests/test_usage_repo.py
+++ b/tests/test_usage_repo.py
@@ -154,6 +154,32 @@ class TestFinalizePendingByCallId:
         assert affected == 1
         assert captured["service_tier"] == "priority", "service_tier 必须从 caller 透传到 cost_calculator"
 
+    async def test_usage_tokens_passed_to_cost_calculator(self, db_session, monkeypatch):
+        """Ark video 按 usage_tokens 计费，repo 必须把 caller 传入的 usage_tokens 透传到 cost_calculator，
+        否则 calculate_ark_video_cost 走 usage_tokens or 0 路径 → cost 永远为 0 CNY。"""
+        from lib import cost_calculator as cc_module
+
+        captured: dict[str, object] = {}
+
+        def _spy_calculate_cost(**kwargs):
+            captured["usage_tokens"] = kwargs.get("usage_tokens", "MISSING")
+            return (3.2, "CNY")
+
+        monkeypatch.setattr(cc_module.cost_calculator, "calculate_cost", _spy_calculate_cost)
+
+        repo = UsageRepository(db_session)
+        call_id = await repo.start_call(
+            project_name="demo",
+            call_type="video",
+            model="doubao-seedance-1-0-pro",
+            duration_seconds=8,
+            provider="ark",
+        )
+
+        affected = await repo.finalize_pending_by_call_id(call_id=call_id, usage_tokens=12345)
+        assert affected == 1
+        assert captured["usage_tokens"] == 12345, "usage_tokens 必须从 caller 透传到 cost_calculator"
+
     async def test_does_not_touch_other_pending_call(self, db_session):
         repo = UsageRepository(db_session)
         cid_a = await repo.start_call(project_name="demo", call_type="video", model="m", segment_id="E1S01")

--- a/tests/test_usage_repo.py
+++ b/tests/test_usage_repo.py
@@ -180,6 +180,11 @@ class TestFinalizePendingByCallId:
         assert affected == 1
         assert captured["usage_tokens"] == 12345, "usage_tokens 必须从 caller 透传到 cost_calculator"
 
+        # 同时必须写回 ApiCall.usage_tokens 列，否则用量明细/抽屉里这条记录的
+        # tokens 字段永远为 null（resume 路径与正常 finish_call 路径行为不一致）。
+        calls = await repo.get_calls(project_name="demo")
+        assert calls["items"][0]["usage_tokens"] == 12345, "usage_tokens 必须 UPDATE 写回 ApiCall 行"
+
     async def test_does_not_touch_other_pending_call(self, db_session):
         repo = UsageRepository(db_session)
         cid_a = await repo.start_call(project_name="demo", call_type="video", model="m", segment_id="E1S01")

--- a/tests/test_usage_repo.py
+++ b/tests/test_usage_repo.py
@@ -99,19 +99,42 @@ class TestFinalizePendingByCallId:
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(project_name="demo", call_type="video", model="m")
 
-        affected = await repo.finalize_pending_by_call_id(call_id=call_id)
+        # 显式 cost_amount=0.0 维持单元测试的确定性，绕过 auto-calc 路径
+        affected = await repo.finalize_pending_by_call_id(call_id=call_id, cost_amount=0.0)
         assert affected == 1
 
         calls = await repo.get_calls(project_name="demo")
         assert calls["items"][0]["status"] == "success"
         assert calls["items"][0]["cost_amount"] == 0.0
 
+    async def test_auto_calculates_cost_when_amount_omitted(self, db_session):
+        """cost_amount=None + status='success' → 按 ApiCall 行字段调 cost_calculator 算实际 cost。"""
+        repo = UsageRepository(db_session)
+        call_id = await repo.start_call(
+            project_name="demo",
+            call_type="video",
+            model="veo-3.0-fast-generate-001",
+            duration_seconds=8,
+            resolution="1080p",
+            aspect_ratio="9:16",
+            generate_audio=True,
+            provider="gemini",
+        )
+
+        affected = await repo.finalize_pending_by_call_id(call_id=call_id)
+        assert affected == 1
+
+        calls = await repo.get_calls(project_name="demo")
+        # auto-calc 由 cost_calculator 按 model/duration/resolution/audio 算出，应为正数
+        assert calls["items"][0]["status"] == "success"
+        assert calls["items"][0]["cost_amount"] > 0.0, "auto-calc 应算出真实 cost，不应是 0"
+
     async def test_does_not_touch_other_pending_call(self, db_session):
         repo = UsageRepository(db_session)
         cid_a = await repo.start_call(project_name="demo", call_type="video", model="m", segment_id="E1S01")
         cid_b = await repo.start_call(project_name="demo", call_type="video", model="m", segment_id="E1S01")
 
-        affected = await repo.finalize_pending_by_call_id(call_id=cid_a)
+        affected = await repo.finalize_pending_by_call_id(call_id=cid_a, cost_amount=0.0)
         assert affected == 1
 
         # 全量查询

--- a/tests/test_usage_repo.py
+++ b/tests/test_usage_repo.py
@@ -92,6 +92,62 @@ class TestUsageRepository:
         assert len(page2["items"]) == 2
 
 
+class TestFinalizePendingByCallId:
+    """Resume 路径专用：按 call_id 精准翻 pending → success/failed。"""
+
+    async def test_flips_pending_to_success(self, db_session):
+        repo = UsageRepository(db_session)
+        call_id = await repo.start_call(project_name="demo", call_type="video", model="m")
+
+        affected = await repo.finalize_pending_by_call_id(call_id=call_id)
+        assert affected == 1
+
+        calls = await repo.get_calls(project_name="demo")
+        assert calls["items"][0]["status"] == "success"
+        assert calls["items"][0]["cost_amount"] == 0.0
+
+    async def test_does_not_touch_other_pending_call(self, db_session):
+        repo = UsageRepository(db_session)
+        cid_a = await repo.start_call(project_name="demo", call_type="video", model="m", segment_id="E1S01")
+        cid_b = await repo.start_call(project_name="demo", call_type="video", model="m", segment_id="E1S01")
+
+        affected = await repo.finalize_pending_by_call_id(call_id=cid_a)
+        assert affected == 1
+
+        # 全量查询
+        calls = await repo.get_calls(project_name="demo", page_size=100)
+        by_id = {c["id"]: c for c in calls["items"]}
+        assert by_id[cid_a]["status"] == "success"
+        assert by_id[cid_b]["status"] == "pending", "另一条 pending 不应被 touch"
+
+    async def test_idempotent_when_already_success(self, db_session):
+        repo = UsageRepository(db_session)
+        call_id = await repo.start_call(project_name="demo", call_type="video", model="m")
+        await repo.finish_call(call_id, status="success", cost_amount=5.0, currency="USD")
+
+        affected = await repo.finalize_pending_by_call_id(call_id=call_id, cost_amount=999.0)
+        assert affected == 0, "已 success 行应保持不变"
+
+        calls = await repo.get_calls(project_name="demo")
+        assert calls["items"][0]["cost_amount"] == 5.0, "cost 未被覆写"
+
+    async def test_finalize_failed_status(self, db_session):
+        repo = UsageRepository(db_session)
+        call_id = await repo.start_call(project_name="demo", call_type="video", model="m")
+
+        affected = await repo.finalize_pending_by_call_id(call_id=call_id, status="failed")
+        assert affected == 1
+
+        calls = await repo.get_calls(project_name="demo")
+        assert calls["items"][0]["status"] == "failed"
+        assert calls["items"][0]["cost_amount"] == 0.0
+
+    async def test_unknown_call_id_returns_zero(self, db_session):
+        repo = UsageRepository(db_session)
+        affected = await repo.finalize_pending_by_call_id(call_id=99999)
+        assert affected == 0
+
+
 class TestMultiProviderUsage:
     async def test_ark_call_records_provider_and_tokens(self, db_session):
         repo = UsageRepository(db_session)

--- a/tests/test_usage_repo.py
+++ b/tests/test_usage_repo.py
@@ -226,6 +226,55 @@ class TestFinalizePendingByCallId:
         affected = await repo.finalize_pending_by_call_id(call_id=99999)
         assert affected == 0
 
+    async def test_writes_duration_ms(self, db_session):
+        """resume 完成的调用必须回写 duration_ms，否则 get_stats_grouped_by_provider 的
+        provider 级时长统计会因 NULL 系统性压低。"""
+        repo = UsageRepository(db_session)
+        call_id = await repo.start_call(project_name="demo", call_type="video", model="m")
+
+        affected = await repo.finalize_pending_by_call_id(call_id=call_id, cost_amount=0.0)
+        assert affected == 1
+
+        calls = await repo.get_calls(project_name="demo")
+        item = calls["items"][0]
+        # started_at 与 finished_at 同瞬间内完成；duration_ms 必须是已写入的非 None 整数
+        assert item["duration_ms"] is not None
+        assert item["duration_ms"] >= 0
+
+    async def test_generate_audio_override_passed_to_cost_calculator(self, db_session, monkeypatch):
+        """provider 在 submit 后可能降级/关闭音频；finalize 接受 caller 透传的 generate_audio
+        覆盖 ApiCall 行上 start_call 时的请求值（与 finish_call 同语义），cost_calculator 也应收到
+        覆盖后的值，避免按请求值误计费。"""
+        from lib import cost_calculator as cc_module
+
+        captured: dict[str, object] = {}
+
+        def _spy_calculate_cost(**kwargs):
+            captured["generate_audio"] = kwargs.get("generate_audio", "MISSING")
+            return (1.5, "USD")
+
+        monkeypatch.setattr(cc_module.cost_calculator, "calculate_cost", _spy_calculate_cost)
+
+        repo = UsageRepository(db_session)
+        # start_call 时请求 generate_audio=True
+        call_id = await repo.start_call(
+            project_name="demo",
+            call_type="video",
+            model="veo-3.0-fast-generate-001",
+            duration_seconds=8,
+            generate_audio=True,
+            provider="gemini",
+        )
+
+        # provider 实际降级到关闭音频
+        affected = await repo.finalize_pending_by_call_id(call_id=call_id, generate_audio=False)
+        assert affected == 1
+        assert captured["generate_audio"] is False, "generate_audio 透传必须覆盖到 cost_calculator"
+
+        # 并且 ApiCall.generate_audio 也回写为降级后的实际值
+        calls = await repo.get_calls(project_name="demo")
+        assert calls["items"][0]["generate_audio"] is False
+
 
 class TestMultiProviderUsage:
     async def test_ark_call_records_provider_and_tokens(self, db_session):

--- a/tests/test_usage_repo.py
+++ b/tests/test_usage_repo.py
@@ -129,6 +129,31 @@ class TestFinalizePendingByCallId:
         assert calls["items"][0]["status"] == "success"
         assert calls["items"][0]["cost_amount"] > 0.0, "auto-calc 应算出真实 cost，不应是 0"
 
+    async def test_service_tier_passed_to_cost_calculator(self, db_session, monkeypatch):
+        """service_tier 应从 caller 透传到 cost_calculator.calculate_cost，非 default 档位才算对。"""
+        from lib import cost_calculator as cc_module
+
+        captured: dict[str, str] = {}
+
+        def _spy_calculate_cost(**kwargs):
+            captured["service_tier"] = kwargs.get("service_tier", "MISSING")
+            return (1.5, "USD")
+
+        monkeypatch.setattr(cc_module.cost_calculator, "calculate_cost", _spy_calculate_cost)
+
+        repo = UsageRepository(db_session)
+        call_id = await repo.start_call(
+            project_name="demo",
+            call_type="video",
+            model="sora-2",
+            duration_seconds=8,
+            provider="openai",
+        )
+
+        affected = await repo.finalize_pending_by_call_id(call_id=call_id, service_tier="priority")
+        assert affected == 1
+        assert captured["service_tier"] == "priority", "service_tier 必须从 caller 透传到 cost_calculator"
+
     async def test_does_not_touch_other_pending_call(self, db_session):
         repo = UsageRepository(db_session)
         cid_a = await repo.start_call(project_name="demo", call_type="video", model="m", segment_id="E1S01")

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -489,3 +489,31 @@ class TestArkVideoBackendBaseUrl:
         with patch("lib.video_backends.ark.create_ark_client") as mock_create:
             ArkVideoBackend(api_key="k")
             mock_create.assert_called_once_with(api_key="k", base_url=None)
+
+
+class TestIsArkNotFound:
+    """fix #647 #6：用 task_not_found / tasknotfound 精确匹配，剔除宽泛 "not found" 兜底；
+    保留 "expired" 字串识别（_poll_until_done 把 status=expired 转 RuntimeError）。"""
+
+    def test_excludes_business_not_found(self):
+        from lib.video_backends.ark import _is_ark_not_found
+
+        exc = RuntimeError("reference image not found in storage")
+        assert _is_ark_not_found(exc) is False
+
+    def test_recognizes_task_not_found(self):
+        from lib.video_backends.ark import _is_ark_not_found
+
+        assert _is_ark_not_found(RuntimeError("task_not_found: invalid id")) is True
+
+    def test_recognizes_expired_status(self):
+        from lib.video_backends.ark import _is_ark_not_found
+
+        assert _is_ark_not_found(RuntimeError("Ark 任务失败 ... status=expired")) is True
+
+    def test_recognizes_404(self):
+        from lib.video_backends.ark import _is_ark_not_found
+
+        exc = RuntimeError("any")
+        exc.status_code = 404  # type: ignore[attr-defined]
+        assert _is_ark_not_found(exc) is True

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -1,13 +1,18 @@
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from sqlalchemy.exc import OperationalError
 
 from lib.video_backends.base import (
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
+    persist_job_id_if_in_task_context,
     poll_with_retry,
+    reset_current_task_id,
+    set_current_task_id,
 )
 
 
@@ -198,3 +203,107 @@ class TestPollWithRetry:
             )
 
         assert progress_calls == ["pending"]
+
+
+def _make_operational_error(msg: str) -> OperationalError:
+    """构造 sqlalchemy OperationalError（params/orig/connection 仅签名形式占位）。"""
+    return OperationalError(msg, params=None, orig=Exception(msg))
+
+
+class TestPersistJobIdRetry:
+    """fix #647 #3：persist_provider_job_id 在 DB 瞬态错误下重试 + 结构化日志。"""
+
+    async def test_no_op_outside_worker_context(self):
+        """非 worker 路径（contextvar 未 set）→ no-op，不访问 queue。"""
+        with patch("lib.generation_queue.get_generation_queue") as fake_get:
+            await persist_job_id_if_in_task_context("job-1", provider="openai")
+            fake_get.assert_not_called()
+
+    async def test_retries_on_sqlite_locked(self, caplog):
+        """前 2 次 OperationalError → 第 3 次成功；retry 实际执行 3 次。"""
+        attempts = 0
+
+        async def _flaky_persist(_tid: str, _job: str) -> None:
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise _make_operational_error("database is locked")
+
+        class _FakeQueue:
+            async def persist_provider_job_id(self, tid: str, job_id: str) -> None:
+                await _flaky_persist(tid, job_id)
+
+        fake_queue = _FakeQueue()
+
+        token = set_current_task_id("task-1")
+        try:
+            with (
+                patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
+                patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+                caplog.at_level(logging.INFO, logger="lib.video_backends.base"),
+            ):
+                await persist_job_id_if_in_task_context("job-1", provider="openai")
+        finally:
+            reset_current_task_id(token)
+
+        assert attempts == 3
+        assert any("provider_job_id 已持久化" in r.message for r in caplog.records)
+
+    async def test_terminal_failure_logs_structured(self, caplog):
+        """全部重试失败 → logger.error 记录 task_id / provider / job_id 三键 + 重抛。"""
+
+        async def _always_fail(_tid: str, _job: str) -> None:
+            raise _make_operational_error("database is locked")
+
+        class _FailingQueue:
+            async def persist_provider_job_id(self, tid: str, job_id: str) -> None:
+                await _always_fail(tid, job_id)
+
+        fake_queue = _FailingQueue()
+
+        token = set_current_task_id("task-X")
+        try:
+            with (
+                patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
+                patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+                caplog.at_level(logging.ERROR, logger="lib.video_backends.base"),
+            ):
+                with pytest.raises(OperationalError):
+                    await persist_job_id_if_in_task_context("job-X", provider="ark")
+        finally:
+            reset_current_task_id(token)
+
+        terminal = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert terminal, "expected logger.error call"
+        msg = terminal[-1].message
+        assert "task_id=task-X" in msg
+        assert "provider=ark" in msg
+        assert "job_id=job-X" in msg
+
+    async def test_no_retry_for_value_error(self):
+        """ValueError 不在 retryable_errors 内 → 立即抛出，retry 仅尝试 1 次。"""
+        attempts = 0
+
+        async def _bad(_tid: str, _job: str) -> None:
+            nonlocal attempts
+            attempts += 1
+            raise ValueError("not retryable")
+
+        class _BadQueue:
+            async def persist_provider_job_id(self, tid: str, job_id: str) -> None:
+                await _bad(tid, job_id)
+
+        fake_queue = _BadQueue()
+
+        token = set_current_task_id("task-V")
+        try:
+            with (
+                patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
+                patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            ):
+                with pytest.raises(ValueError, match="not retryable"):
+                    await persist_job_id_if_in_task_context("job-V", provider="newapi")
+        finally:
+            reset_current_task_id(token)
+
+        assert attempts == 1

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -9,6 +9,7 @@ from lib.video_backends.base import (
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
+    persist_api_call_id,
     persist_provider_job_id,
     poll_with_retry,
 )
@@ -316,3 +317,89 @@ class TestPersistJobIdRetry:
                 await persist_provider_job_id("task-T", "job-T", provider="gemini")
 
         assert attempts == 1, "expects no string-fallback retry for ValueError"
+
+
+class TestPersistApiCallIdRetry:
+    """persist_api_call_id 与 persist_provider_job_id 对齐：DB 瞬态错误重试 + fail-fast 抛异常。
+
+    Fail-fast 理由：submit 已经把 provider 端任务排队（cost 已扣），caller media_generator
+    在 try 块内捕获到本异常会 finish_call(failed) 把 pending ApiCall 翻 failed 再 raise，
+    异常冒泡到 worker finally 兜底 mark_failed；若这里吞掉异常，crash window 内 resume
+    路径无 api_call_id 锚定将永远留 pending 账目。
+    """
+
+    async def test_retries_on_sqlite_locked(self, caplog):
+        """前 2 次 OperationalError → 第 3 次成功；retry 实际执行 3 次。"""
+        attempts = 0
+
+        async def _flaky_persist(_tid: str, _call_id: int) -> None:
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise _make_operational_error("database is locked")
+
+        class _FakeQueue:
+            async def persist_api_call_id(self, tid: str, call_id: int) -> None:
+                await _flaky_persist(tid, call_id)
+
+        fake_queue = _FakeQueue()
+
+        with (
+            patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
+            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            caplog.at_level(logging.INFO, logger="lib.video_backends.base"),
+        ):
+            await persist_api_call_id("task-1", 42)
+
+        assert attempts == 3
+        assert any("api_call_id 已持久化" in r.message for r in caplog.records)
+
+    async def test_terminal_failure_raises_and_logs(self, caplog):
+        """全部重试失败 → logger.error 记录 + 重抛（fail-fast，对齐 persist_provider_job_id）。"""
+
+        async def _always_fail(_tid: str, _call_id: int) -> None:
+            raise _make_operational_error("database is locked")
+
+        class _FailingQueue:
+            async def persist_api_call_id(self, tid: str, call_id: int) -> None:
+                await _always_fail(tid, call_id)
+
+        fake_queue = _FailingQueue()
+
+        with (
+            patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
+            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            caplog.at_level(logging.ERROR, logger="lib.video_backends.base"),
+        ):
+            with pytest.raises(OperationalError):
+                await persist_api_call_id("task-X", 99)
+
+        terminal = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert terminal, "expected logger.error call"
+        msg = terminal[-1].message
+        assert "task_id=task-X" in msg
+        assert "call_id=99" in msg
+
+    async def test_no_retry_for_value_error(self):
+        """ValueError 不在 retryable_errors 内 → 立即抛出，retry 仅尝试 1 次。"""
+        attempts = 0
+
+        async def _bad(_tid: str, _call_id: int) -> None:
+            nonlocal attempts
+            attempts += 1
+            raise ValueError("not retryable")
+
+        class _BadQueue:
+            async def persist_api_call_id(self, tid: str, call_id: int) -> None:
+                await _bad(tid, call_id)
+
+        fake_queue = _BadQueue()
+
+        with (
+            patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
+            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with pytest.raises(ValueError, match="not retryable"):
+                await persist_api_call_id("task-V", 7)
+
+        assert attempts == 1

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -307,3 +307,36 @@ class TestPersistJobIdRetry:
             reset_current_task_id(token)
 
         assert attempts == 1
+
+    async def test_no_retry_for_value_error_with_transient_string(self):
+        """业务异常即使消息含 ``timed out`` / ``503`` 等串，也不该被字符串兜底吞掉重试。
+
+        默认 `_should_retry` 在 isinstance 不匹配时做 RETRYABLE_STATUS_PATTERNS 字符串
+        子串兜底，会把 `ValueError("Connection timed out: rate")` 当瞬态错误重试；
+        改用 `retry_if=lambda e: isinstance(e, _PERSIST_RETRYABLE_ERRORS)` 后严格 isinstance。
+        """
+        attempts = 0
+
+        async def _bad(_tid: str, _job: str) -> None:
+            nonlocal attempts
+            attempts += 1
+            raise ValueError("Connection timed out: rate limited at upstream")
+
+        class _BadQueue:
+            async def persist_provider_job_id(self, tid: str, job_id: str) -> None:
+                await _bad(tid, job_id)
+
+        fake_queue = _BadQueue()
+
+        token = set_current_task_id("task-T")
+        try:
+            with (
+                patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
+                patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            ):
+                with pytest.raises(ValueError, match="timed out"):
+                    await persist_job_id_if_in_task_context("job-T", provider="gemini")
+        finally:
+            reset_current_task_id(token)
+
+        assert attempts == 1, "expects no string-fallback retry for ValueError"

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -9,10 +9,8 @@ from lib.video_backends.base import (
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
-    persist_job_id_if_in_task_context,
+    persist_provider_job_id,
     poll_with_retry,
-    reset_current_task_id,
-    set_current_task_id,
 )
 
 
@@ -211,13 +209,7 @@ def _make_operational_error(msg: str) -> OperationalError:
 
 
 class TestPersistJobIdRetry:
-    """fix #647 #3：persist_provider_job_id 在 DB 瞬态错误下重试 + 结构化日志。"""
-
-    async def test_no_op_outside_worker_context(self):
-        """非 worker 路径（contextvar 未 set）→ no-op，不访问 queue。"""
-        with patch("lib.generation_queue.get_generation_queue") as fake_get:
-            await persist_job_id_if_in_task_context("job-1", provider="openai")
-            fake_get.assert_not_called()
+    """persist_provider_job_id 在 DB 瞬态错误下重试 + 结构化日志。"""
 
     async def test_retries_on_sqlite_locked(self, caplog):
         """前 2 次 OperationalError → 第 3 次成功；retry 实际执行 3 次。"""
@@ -235,16 +227,12 @@ class TestPersistJobIdRetry:
 
         fake_queue = _FakeQueue()
 
-        token = set_current_task_id("task-1")
-        try:
-            with (
-                patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
-                patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
-                caplog.at_level(logging.INFO, logger="lib.video_backends.base"),
-            ):
-                await persist_job_id_if_in_task_context("job-1", provider="openai")
-        finally:
-            reset_current_task_id(token)
+        with (
+            patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
+            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            caplog.at_level(logging.INFO, logger="lib.video_backends.base"),
+        ):
+            await persist_provider_job_id("task-1", "job-1", provider="openai")
 
         assert attempts == 3
         assert any("provider_job_id 已持久化" in r.message for r in caplog.records)
@@ -261,17 +249,13 @@ class TestPersistJobIdRetry:
 
         fake_queue = _FailingQueue()
 
-        token = set_current_task_id("task-X")
-        try:
-            with (
-                patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
-                patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
-                caplog.at_level(logging.ERROR, logger="lib.video_backends.base"),
-            ):
-                with pytest.raises(OperationalError):
-                    await persist_job_id_if_in_task_context("job-X", provider="ark")
-        finally:
-            reset_current_task_id(token)
+        with (
+            patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
+            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            caplog.at_level(logging.ERROR, logger="lib.video_backends.base"),
+        ):
+            with pytest.raises(OperationalError):
+                await persist_provider_job_id("task-X", "job-X", provider="ark")
 
         terminal = [r for r in caplog.records if r.levelno == logging.ERROR]
         assert terminal, "expected logger.error call"
@@ -295,16 +279,12 @@ class TestPersistJobIdRetry:
 
         fake_queue = _BadQueue()
 
-        token = set_current_task_id("task-V")
-        try:
-            with (
-                patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
-                patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
-            ):
-                with pytest.raises(ValueError, match="not retryable"):
-                    await persist_job_id_if_in_task_context("job-V", provider="newapi")
-        finally:
-            reset_current_task_id(token)
+        with (
+            patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
+            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with pytest.raises(ValueError, match="not retryable"):
+                await persist_provider_job_id("task-V", "job-V", provider="newapi")
 
         assert attempts == 1
 
@@ -328,15 +308,11 @@ class TestPersistJobIdRetry:
 
         fake_queue = _BadQueue()
 
-        token = set_current_task_id("task-T")
-        try:
-            with (
-                patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
-                patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
-            ):
-                with pytest.raises(ValueError, match="timed out"):
-                    await persist_job_id_if_in_task_context("job-T", provider="gemini")
-        finally:
-            reset_current_task_id(token)
+        with (
+            patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
+            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with pytest.raises(ValueError, match="timed out"):
+                await persist_provider_job_id("task-T", "job-T", provider="gemini")
 
         assert attempts == 1, "expects no string-fallback retry for ValueError"

--- a/tests/test_video_backend_gemini.py
+++ b/tests/test_video_backend_gemini.py
@@ -357,6 +357,44 @@ class TestDownloadVideo:
             backend._download_video(mock_ref, output)
 
 
+class TestGeminiResumeVideo:
+    """resume_video 路径：初次 + mid-poll NOT_FOUND 都归类为 ResumeExpiredError。"""
+
+    async def test_mid_poll_not_found_classified_as_resume_expired(self, backend, tmp_path):
+        from lib.video_backends.base import ResumeExpiredError
+
+        # 初次 operations.get 返回 pending 让 poll 进入循环；poll_fn 中抛 NOT_FOUND
+        pending_op = MagicMock()
+        pending_op.done = False
+        get_calls = {"n": 0}
+
+        async def _fake_get(_op):
+            get_calls["n"] += 1
+            if get_calls["n"] == 1:
+                return pending_op
+            raise RuntimeError("operation not found mid poll")
+
+        backend._client.aio.operations.get = AsyncMock(side_effect=_fake_get)
+        # GenerateVideosOperation.model_validate 用 MagicMock，返回任意对象即可
+        backend._types.GenerateVideosOperation.model_validate = MagicMock(return_value=pending_op)
+
+        request = VideoGenerationRequest(prompt="x", output_path=tmp_path / "out.mp4")
+        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(ResumeExpiredError) as ei:
+                await backend.resume_video("op-xyz", request)
+        assert ei.value.job_id == "op-xyz"
+
+    async def test_initial_get_not_found_classified_as_resume_expired(self, backend, tmp_path):
+        from lib.video_backends.base import ResumeExpiredError
+
+        backend._client.aio.operations.get = AsyncMock(side_effect=RuntimeError("operation not found"))
+        backend._types.GenerateVideosOperation.model_validate = MagicMock(return_value=MagicMock())
+
+        request = VideoGenerationRequest(prompt="x", output_path=tmp_path / "out.mp4")
+        with pytest.raises(ResumeExpiredError):
+            await backend.resume_video("op-not-found", request)
+
+
 class TestIsGeminiNotFound:
     """fix #647 #6：INVALID_ARGUMENT 不归过期，只保留 404 / NOT_FOUND / "not found" / "expired"。"""
 

--- a/tests/test_video_backend_gemini.py
+++ b/tests/test_video_backend_gemini.py
@@ -355,3 +355,28 @@ class TestDownloadVideo:
 
         with pytest.raises(RuntimeError, match="无法获取视频数据"):
             backend._download_video(mock_ref, output)
+
+
+class TestIsGeminiNotFound:
+    """fix #647 #6：INVALID_ARGUMENT 不归过期，只保留 404 / NOT_FOUND / "not found" / "expired"。"""
+
+    def test_excludes_invalid_argument(self):
+        from lib.video_backends.gemini import _is_gemini_not_found
+
+        exc = RuntimeError("INVALID_ARGUMENT: malformed operation name")
+        assert _is_gemini_not_found(exc) is False
+
+    def test_not_found_string_matches(self):
+        from lib.video_backends.gemini import _is_gemini_not_found
+
+        assert _is_gemini_not_found(RuntimeError("operation not found"))
+
+    def test_expired_string_matches(self):
+        from lib.video_backends.gemini import _is_gemini_not_found
+
+        assert _is_gemini_not_found(RuntimeError("resource expired after 24h"))
+
+    def test_unrelated_runtime_error_returns_false(self):
+        from lib.video_backends.gemini import _is_gemini_not_found
+
+        assert _is_gemini_not_found(RuntimeError("rate limit exceeded")) is False


### PR DESCRIPTION
Fixes #647

## 为什么

#647 跟踪 PR #646 code review 遗留的 7 处 medium 缺陷；落地方案 A（撤销 ContextVar，回到 PRD #640 显式 `backend.resume_video(job_id, request)` 接口）4 个 commit 后做了 xhigh-effort code review，暴露 15 处 finding，按根因聚成 5 类：

1. resume 路径与 generate 共享计费/版本逻辑 → 重复扣费 / 账目漂移（#2/#3/#4/#5/#6）
2. 新 Semaphore dispatcher 与 inflight 管理双轨不一致 → 死锁/并发翻倍/取消失配/shutdown 残留（#7/#8/#9/#10）
3. Orphan handler 重扫 race（#1）
4. Backend 错误分类语义错位（#11/#15）
5. resume_executor 缺横切机制（#13/#14）
6. Cancel 级联前端可视化（#12 —— 已实现，仅补回归断言）

最严重的 4 条都指向核心原则：**不主动造成额外扣费**。本 PR 把 15 条全部修复并以新增/修改测试守住回归。

## 5 commit 概览

| Commit | 范围 | finding |
|---|---|---|
| `3e00cc2b` resume 解耦计费/版本 | resume 不再写 ApiCall / 不再 bump version；按 `api_call_id` 精准翻 pending | #2/#3/#4/#5/#6 |
| `71496b67` backend 错误语义统一 | `_is_done` 改纯谓词；resume_video 入口包 expired 识别；gemini mid-poll NOT_FOUND 归类 | #11/#15 |
| `04149837` resume_executor 流水线对齐 | `require_image_backend=False`；包 `project_change_source('worker')` + emit SSE batch | #13/#14 |
| `d12b8d33` dispatcher 重构 | sub-task 早注册 pending；`video_max<=0` 快速 mark_failed[resume_unsupported]；shutdown 等 dispatcher | #7/#8/#9/#10 |
| `0b783594` orphan 一次性扫描 + cascade 回归 | `_orphan_handled_once` + lease-lost duration 阈值；cascade SSE 字段断言 | #1/#12 |

附 `96e8657a` test fixup — TaskHud cascade 测试 TaskStats stub 字段补齐。

## 行为变更

- resume 路径不再写 ApiCall。pending ApiCall 通过新增 `task.payload["api_call_id"]` 由 generate 路径在 submit 时持久化，resume 完成后按 call_id 精准翻 success（cost=0）；ResumeExpired 翻 failed（cost=0）。usage 报表 resume 时不会出现新行。
- OpenAI / NewAPI 的 video backend 在 `status=='expired'` 状态下，按 caller 上下文分流：`generate` 抛 `RuntimeError`、`resume_video` 抛 `ResumeExpiredError`；`_is_done` 改为纯谓词不再短路抛错。
- Gemini `resume_video` 在 mid-poll 抛 NOT_FOUND 也归类为 `ResumeExpiredError`，不再只覆盖初次 `operations.get`。
- Orphan 扫描在进程内单 lease 生命周期内只触发一次；lease 抖动（< `lease_ttl * 3`）不重扫；持续超时再夺回 lease 时才重扫。
- Dispatcher 容量按 `inflight + pending` 严格 ≤ `video_max`；sem 排队中的 sub-task 也可被 `request_cancel` 命中。
- resume 成功后同步触发 `emit_generation_success_batch` 推 SSE，前端缩略图缓存与状态实时刷新；`emit_generation_success_batch` 私有前缀移除供跨模块复用。

## 验证

- ruff check / format：clean
- basedpyright：0 errors
- pytest：3147 passed（含新增 resume / backend / dispatcher / orphan 测试集；1 pre-existing 失败与本 PR 无关）
- 前端 pnpm check：79 文件 / 594 测试全过；新增 `TaskHud.cascade.test.tsx` 覆盖 cascade 标签三语渲染

## 不在范围

- `NON_RESUMABLE_VIDEO_PROVIDERS` 列表扩展：dispatcher fail-fast `video_max<=0` 已兜底
- ApiCall 加 `model_at_submit / generate_audio_at_submit` 列：resume 不再写 ApiCall，drift 问题从根上消失
- `generate_video_async` 路径修改
- `classify_resume_error` 协议统一：保留各 backend 私有谓词
- DB schema migration：单 lease 互斥架构，进程内开关即可
- 错误前缀 i18n 润色

## Test plan

- [x] 单测：`tests/test_media_generator_resume.py` / `tests/test_video_backends_resume_errors.py` / `tests/test_resume_executor.py` / `tests/test_generation_worker_module.py` / `tests/test_task_repo.py` / `tests/test_usage_repo.py`
- [x] 前端：`frontend/src/components/task-hud/__tests__/TaskHud.cascade.test.tsx`
- [x] 全量回归：`uv run pytest tests/` + `pnpm check` + `ruff` + `basedpyright`
- [ ] 端到端：起 OpenAI Sora video → submit 后 kill worker → 重启 → 直查 `api_calls` 表，仅 1 条 success 行，versions.json 版本号未 bump
- [ ] 端到端：mock provider 返 `status='expired'` → task.error_message 含 `[resume_expired]`、未新增 failed ApiCall
- [ ] 端到端：临时 patch `video_max=0` → orphan 快速 mark_failed[resume_unsupported]
- [ ] 端到端：3 个 video orphan + `video_max=1`，UI 取消第 3 个 → 秒级 mark cancelled
- [ ] 端到端：cancel 父任务 → HUD 子任务渲染 cascade 标签（zh/en/vi）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 视频恢复/续跑支持，生成调用与任务间可持久关联（记录调用 ID）

* **Improvements**
  * 取消级联与即时分发更可靠，提升一致性与响应性
  * 孤儿恢复、排队与并发控制增强（pending 计数、semaphore 与 lease 优化）
  * 后端轮询、过期/失败语义与计费回写逻辑更明确

* **Bug Fixes**
  * HUD 多语言下“级联取消”标签显示修复

* **Tests**
  * 大量新增/扩展测试覆盖恢复、取消、计费结算、轮询与多语言显示

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/663?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->