### PR TITLE
fix: 编辑自定义供应商未改 apikey 时测试连接复用已存储凭证

### DIFF
--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -248,10 +248,10 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
 
   // base_url 相对存储值是否变更：变更后必须用 UI 上的新地址 + 新 key 走明文路径，
   // 否则 by-id 端点会用 DB 中的旧 base_url，与保存的新地址错位。
-  const baseUrlChanged = isEdit && !!existing && baseUrl.trim() !== existing.base_url;
+  const baseUrlChanged = !!existing && baseUrl.trim() !== existing.base_url;
   // 编辑模式下若用户未输入新 key 且 base_url 未变更，则用已存储凭证（by-id 端点）；
   // 创建模式或 base_url 变更时必须明文 api_key。发现模型与测试连接共用此判断。
-  const useStoredCredential = isEdit && !!existing && !apiKey && !baseUrlChanged;
+  const useStoredCredential = !!existing && !apiKey && !baseUrlChanged;
 
   // --- Discover models ---
   const handleDiscover = useCallback(async () => {
@@ -297,6 +297,8 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
 
   // --- Test connection ---
   const handleTest = useCallback(async () => {
+    // 清空上一次结果放在所有校验之前：校验失败直接 return 时也不残留旧的成功/失败提示。
+    setTestResult(null);
     if (!baseUrl) {
       showError(t("fill_base_url_first"));
       return;
@@ -306,7 +308,6 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
       return;
     }
     setTesting(true);
-    setTestResult(null);
     try {
       const res = useStoredCredential
         ? await API.testCustomConnectionById(existing.id)

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -246,18 +246,19 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
     [filteredModels],
   );
 
+  // base_url 相对存储值是否变更：变更后必须用 UI 上的新地址 + 新 key 走明文路径，
+  // 否则 by-id 端点会用 DB 中的旧 base_url，与保存的新地址错位。
+  const baseUrlChanged = isEdit && !!existing && baseUrl.trim() !== existing.base_url;
+  // 编辑模式下若用户未输入新 key 且 base_url 未变更，则用已存储凭证（by-id 端点）；
+  // 创建模式或 base_url 变更时必须明文 api_key。发现模型与测试连接共用此判断。
+  const useStoredCredential = isEdit && !!existing && !apiKey && !baseUrlChanged;
+
   // --- Discover models ---
   const handleDiscover = useCallback(async () => {
     if (!baseUrl) {
       showError(t("fill_base_url_first"));
       return;
     }
-    // base_url 相对存储值是否变更：变更后必须用 UI 上的新地址 + 新 key 走明文路径，
-    // 否则 by-id 端点会用 DB 中的旧 base_url 发现模型，与保存的新地址错位。
-    const baseUrlChanged = isEdit && !!existing && baseUrl.trim() !== existing.base_url;
-    // 编辑模式下若用户未输入新 key 且 base_url 未变更，则用已存储凭证（by-id 端点）发现模型；
-    // 创建模式或 base_url 变更时必须明文 api_key。
-    const useStoredCredential = isEdit && !!existing && !apiKey && !baseUrlChanged;
     if (!useStoredCredential && !apiKey) {
       showError(t(baseUrlChanged ? "base_url_changed_reenter_key" : "fill_api_key_first"));
       return;
@@ -292,7 +293,7 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
     } finally {
       setDiscovering(false);
     }
-  }, [discoveryFormat, baseUrl, apiKey, isEdit, existing, showError, t]);
+  }, [discoveryFormat, baseUrl, apiKey, useStoredCredential, baseUrlChanged, existing, showError, t]);
 
   // --- Test connection ---
   const handleTest = useCallback(async () => {
@@ -300,17 +301,23 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
       showError(t("fill_base_url_first"));
       return;
     }
+    if (!useStoredCredential && !apiKey) {
+      showError(t(baseUrlChanged ? "base_url_changed_reenter_key" : "fill_api_key_first"));
+      return;
+    }
     setTesting(true);
     setTestResult(null);
     try {
-      const res = await API.testCustomConnection({ discovery_format: discoveryFormat, base_url: baseUrl, api_key: apiKey });
+      const res = useStoredCredential
+        ? await API.testCustomConnectionById(existing.id)
+        : await API.testCustomConnection({ discovery_format: discoveryFormat, base_url: baseUrl, api_key: apiKey });
       setTestResult(res);
     } catch (e) {
       setTestResult({ success: false, message: errMsg(e, t("connection_test_failed")) });
     } finally {
       setTesting(false);
     }
-  }, [discoveryFormat, baseUrl, apiKey, showError, t]);
+  }, [discoveryFormat, baseUrl, apiKey, useStoredCredential, baseUrlChanged, existing, showError, t]);
 
   // --- Save ---
   const handleSave = useCallback(async () => {

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -248,7 +248,7 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
 
   // base_url 相对存储值是否变更：变更后必须用 UI 上的新地址 + 新 key 走明文路径，
   // 否则 by-id 端点会用 DB 中的旧 base_url，与保存的新地址错位。
-  const baseUrlChanged = !!existing && baseUrl.trim() !== existing.base_url;
+  const baseUrlChanged = !!existing && baseUrl.trim() !== existing.base_url.trim();
   // 编辑模式下若用户未输入新 key 且 base_url 未变更，则用已存储凭证（by-id 端点）；
   // 创建模式或 base_url 变更时必须明文 api_key。发现模型与测试连接共用此判断。
   const useStoredCredential = !!existing && !apiKey && !baseUrlChanged;


### PR DESCRIPTION
## 问题

编辑一个已有的自定义供应商，apikey 保持原值（不改动）直接点「测试连接」，提示「未配置 apikey」。

## 根因

出于安全，编辑模式下 apikey 输入框**故意不回填**后端返回的脱敏值，本地 state 始终从空串开始，输入框只用 `existing.api_key_masked` 作 placeholder。而 `handleTest` 直接把空串 `api_key` 发给明文测试端点 `/custom-providers/test` → 后端用空 key 认证失败 → 报「未配置 apikey」。

同文件的 `handleDiscover` **已经**正确处理了这个场景（通过 `baseUrlChanged` / `useStoredCredential` 判断改走 by-id 端点用已存储凭证），`handleTest` 缺少这套判断，是唯一的缺口。

## 改动

仅前端单文件 `frontend/src/components/pages/settings/CustomProviderForm.tsx`：

1. 把 `handleDiscover` 内已有的 `baseUrlChanged` / `useStoredCredential` 判断**抽到组件 body 作为共享派生值**，两个 handler 复用同一份，避免逻辑漂移。
2. `handleTest` 对齐 `handleDiscover`：编辑模式 + 未输入新 key + base_url 未变 → 改走 by-id 端点 `testCustomConnectionById(existing.id)`，用 DB 已存储凭证测试；并补齐缺 key 时的错误提示。

后端 / DB / i18n 均无需改动（`testCustomConnectionById`、by-id 测试端点、相关 i18n key 都已存在）。

### 行为对照（修复后）

| 场景 | 测试连接走的路径 |
|---|---|
| 创建模式 | 明文端点 `testCustomConnection`（缺 key 提示 `fill_api_key_first`） |
| 编辑 + 未改 key + base_url 未变 | by-id 端点 `testCustomConnectionById`（用已存储凭证）✅ 修复点 |
| 编辑 + 输入了新 key | 明文端点，用新 key |
| 编辑 + 改了 base_url 但未填 key | 提示 `base_url_changed_reenter_key` |

## 验证

- `pnpm lint` ✅
- `pnpm check`（typecheck + 602 个 vitest）全绿 ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进自定义提供商表单中连接测试的验证逻辑，准确区分编辑/创建场景与 base_url 是否变更
  * 在编辑模式下：当 base_url 未变更且未输入新密钥时，优先使用已存储凭证进行测试与发现
  * 在创建或 base_url 变更或输入新密钥时，使用明文 API 密钥路径进行测试与发现
  * 清除旧测试结果以避免测试/发现操作中残留数据导致的混淆
  * 优化测试与发现的触发条件，减少误判与重复请求

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->