### PR TITLE
fix(frontend): 未登录访问项目工作区 URL 重定向到正确的登录页

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -143,13 +143,27 @@ describe("API", () => {
       );
       vi.stubGlobal("fetch", fetchMock);
       const clearTokenMock = vi.spyOn(await import("@/utils/auth"), "clearToken");
-      const location = { href: "/app" };
+      // /app（无尾斜杠）不属于 /app/ 受保护页面，重定向不应附带 from。
+      const location = { href: "", pathname: "/app", search: "" };
       vi.stubGlobal("location", location);
 
       await expect(API.request("/projects")).rejects.toThrow("认证已过期，请重新登录");
 
       expect(clearTokenMock).toHaveBeenCalledTimes(1);
       expect(location.href).toBe("/login");
+    });
+
+    it("appends the current /app path as ?from when redirecting on 401", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({ ok: false, status: 401, statusText: "Unauthorized" }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const location = { href: "", pathname: "/app/projects/demo", search: "" };
+      vi.stubGlobal("location", location);
+
+      await expect(API.request("/projects")).rejects.toThrow("认证已过期，请重新登录");
+
+      expect(location.href).toBe("/login?from=%2Fapp%2Fprojects%2Fdemo");
     });
   });
 
@@ -668,12 +682,12 @@ describe("API", () => {
         );
         vi.stubGlobal("fetch", fetchMock);
         const clearTokenMock = vi.spyOn(await import("@/utils/auth"), "clearToken");
-        const location = { href: "/app/settings" };
+        const location = { href: "", pathname: "/app/settings", search: "" };
         vi.stubGlobal("location", location);
 
         await expect(API.downloadDiagnostics()).rejects.toThrow("认证已过期，请重新登录");
         expect(clearTokenMock).toHaveBeenCalledTimes(1);
-        expect(location.href).toBe("/login");
+        expect(location.href).toBe("/login?from=%2Fapp%2Fsettings");
       });
 
       it("throws on other HTTP errors", async () => {

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -144,7 +144,7 @@ describe("API", () => {
       vi.stubGlobal("fetch", fetchMock);
       const clearTokenMock = vi.spyOn(await import("@/utils/auth"), "clearToken");
       // /app（无尾斜杠）不属于 /app/ 受保护页面，重定向不应附带 from。
-      const location = { href: "", pathname: "/app", search: "" };
+      const location = { href: "", pathname: "/app", search: "", hash: "" };
       vi.stubGlobal("location", location);
 
       await expect(API.request("/projects")).rejects.toThrow("认证已过期，请重新登录");
@@ -158,7 +158,7 @@ describe("API", () => {
         mockResponse({ ok: false, status: 401, statusText: "Unauthorized" }),
       );
       vi.stubGlobal("fetch", fetchMock);
-      const location = { href: "", pathname: "/app/projects/demo", search: "" };
+      const location = { href: "", pathname: "/app/projects/demo", search: "", hash: "" };
       vi.stubGlobal("location", location);
 
       await expect(API.request("/projects")).rejects.toThrow("认证已过期，请重新登录");
@@ -682,7 +682,7 @@ describe("API", () => {
         );
         vi.stubGlobal("fetch", fetchMock);
         const clearTokenMock = vi.spyOn(await import("@/utils/auth"), "clearToken");
-        const location = { href: "", pathname: "/app/settings", search: "" };
+        const location = { href: "", pathname: "/app/settings", search: "", hash: "" };
         vi.stubGlobal("location", location);
 
         await expect(API.downloadDiagnostics()).rejects.toThrow("认证已过期，请重新登录");

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -272,7 +272,7 @@ function handleUnauthorized(response: Response): void {
   clearToken();
   // 携带当前所在的站内地址，登录成功后回跳；仅对 /app/ 下的页面附加 from，
   // 避免把登录页自身等非应用路径写进回跳参数。
-  const current = `${globalThis.location.pathname}${globalThis.location.search}`;
+  const current = `${globalThis.location.pathname}${globalThis.location.search}${globalThis.location.hash}`;
   globalThis.location.href = current.startsWith("/app/")
     ? `/login?from=${encodeURIComponent(current)}`
     : "/login";

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -270,7 +270,12 @@ function handleUnauthorized(response: Response): void {
   if (response.status !== 401) return;
 
   clearToken();
-  globalThis.location.href = "/login";
+  // 携带当前所在的站内地址，登录成功后回跳；仅对 /app/ 下的页面附加 from，
+  // 避免把登录页自身等非应用路径写进回跳参数。
+  const current = `${globalThis.location.pathname}${globalThis.location.search}`;
+  globalThis.location.href = current.startsWith("/app/")
+    ? `/login?from=${encodeURIComponent(current)}`
+    : "/login";
   throw new Error("认证已过期，请重新登录");
 }
 

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Router, useLocation, useSearch } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
+import { LoginPage } from "@/pages/LoginPage";
+import { useAuthStore } from "@/stores/auth-store";
+
+// 探针组件：把当前 wouter location 渲染出来，响应式读取回跳目标。
+// useLocation 只返回 pathname，query 要从 useSearch 取，否则 ?tab=scene 这类
+// 回跳参数会被探针漏掉。
+function LocationProbe() {
+  const [location] = useLocation();
+  const search = useSearch();
+  return <div data-testid="location">{search ? `${location}?${search}` : location}</div>;
+}
+
+function renderLoginAt(path: string) {
+  const { hook } = memoryLocation({ path });
+  return render(
+    <Router hook={hook}>
+      <LoginPage />
+      <LocationProbe />
+    </Router>,
+  );
+}
+
+// 填表并提交。input id 来自 LoginPage（login-username / login-password），
+// 用 id 选择避免依赖 i18n 解析后的 label / 按钮文案。
+function submitLogin(container: HTMLElement) {
+  fireEvent.change(container.querySelector<HTMLInputElement>("#login-username")!, {
+    target: { value: "alice" },
+  });
+  fireEvent.change(container.querySelector<HTMLInputElement>("#login-password")!, {
+    target: { value: "pw" },
+  });
+  fireEvent.submit(container.querySelector("form")!);
+}
+
+describe("LoginPage returnTo consumption", () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      token: null,
+      username: null,
+      isAuthenticated: false,
+      isLoading: false,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ access_token: "tok-123" }),
+      } as unknown as Response),
+    );
+  });
+
+  // 锁住登录成功后对 ?from 的「消费」分支：读取 from → safeReturnPath 校验 → 回跳。
+  // 防止以后误改回固定跳转 /app/projects 而主流程回归漏过。
+  it("navigates to a valid internal ?from path after successful login", async () => {
+    const { container } = renderLoginAt("/login?from=%2Fapp%2Fprojects%2Fdemo%3Ftab%3Dscene");
+    submitLogin(container);
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/app/projects/demo?tab=scene");
+    });
+  });
+
+  it("falls back to /app/projects when ?from is an unsafe open-redirect target", async () => {
+    const { container } = renderLoginAt("/login?from=https%3A%2F%2Fevil.com%2Fapp%2Fx");
+    submitLogin(container);
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/app/projects");
+    });
+  });
+
+  it("falls back to /app/projects when no ?from is present", async () => {
+    const { container } = renderLoginAt("/login");
+    submitLogin(container);
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/app/projects");
+    });
+  });
+});

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,27 +1,22 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Router, useLocation, useSearch } from "wouter";
+import { Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
 import { LoginPage } from "@/pages/LoginPage";
 import { useAuthStore } from "@/stores/auth-store";
 
-// 探针组件：把当前 wouter location 渲染出来，响应式读取回跳目标。
-// useLocation 只返回 pathname，query 要从 useSearch 取，否则 ?tab=scene 这类
-// 回跳参数会被探针漏掉。
-function LocationProbe() {
-  const [location] = useLocation();
-  const search = useSearch();
-  return <div data-testid="location">{search ? `${location}?${search}` : location}</div>;
-}
-
+// wouter 的 useLocation/useSearch 钩子只暴露 pathname / search，不暴露 hash，
+// 无法用渲染探针断言 #fragment。改用 memoryLocation 的 record 历史：navigate
+// 入参被逐字 push 进 history，因此可直接断言登录成功后导航到的完整目标
+// （含 query 与 hash），从而锁住回跳链路对 hash 的保留。
 function renderLoginAt(path: string) {
-  const { hook } = memoryLocation({ path });
-  return render(
-    <Router hook={hook}>
+  const memory = memoryLocation({ path, record: true });
+  const view = render(
+    <Router hook={memory.hook}>
       <LoginPage />
-      <LocationProbe />
     </Router>,
   );
+  return { ...view, history: memory.history };
 }
 
 // 填表并提交。input id 来自 LoginPage（login-username / login-password），
@@ -56,26 +51,36 @@ describe("LoginPage returnTo consumption", () => {
   // 锁住登录成功后对 ?from 的「消费」分支：读取 from → safeReturnPath 校验 → 回跳。
   // 防止以后误改回固定跳转 /app/projects 而主流程回归漏过。
   it("navigates to a valid internal ?from path after successful login", async () => {
-    const { container } = renderLoginAt("/login?from=%2Fapp%2Fprojects%2Fdemo%3Ftab%3Dscene");
+    const { container, history } = renderLoginAt("/login?from=%2Fapp%2Fprojects%2Fdemo%3Ftab%3Dscene");
     submitLogin(container);
     await waitFor(() => {
-      expect(screen.getByTestId("location")).toHaveTextContent("/app/projects/demo?tab=scene");
+      expect(history.at(-1)).toBe("/app/projects/demo?tab=scene");
+    });
+  });
+
+  // 锁住 hash 在回跳链路中存活：from 携带 #shot-3，登录后导航目标须保留该锚点。
+  // 若源码（AuthGuard / 401 拦截 / safeReturnPath）丢掉 hash，此断言会失败。
+  it("preserves the URL hash in the return path", async () => {
+    const { container, history } = renderLoginAt("/login?from=%2Fapp%2Fprojects%2Fdemo%23shot-3");
+    submitLogin(container);
+    await waitFor(() => {
+      expect(history.at(-1)).toBe("/app/projects/demo#shot-3");
     });
   });
 
   it("falls back to /app/projects when ?from is an unsafe open-redirect target", async () => {
-    const { container } = renderLoginAt("/login?from=https%3A%2F%2Fevil.com%2Fapp%2Fx");
+    const { container, history } = renderLoginAt("/login?from=https%3A%2F%2Fevil.com%2Fapp%2Fx");
     submitLogin(container);
     await waitFor(() => {
-      expect(screen.getByTestId("location")).toHaveTextContent("/app/projects");
+      expect(history.at(-1)).toBe("/app/projects");
     });
   });
 
   it("falls back to /app/projects when no ?from is present", async () => {
-    const { container } = renderLoginAt("/login");
+    const { container, history } = renderLoginAt("/login");
     submitLogin(container);
     await waitFor(() => {
-      expect(screen.getByTestId("location")).toHaveTextContent("/app/projects");
+      expect(history.at(-1)).toBe("/app/projects");
     });
   });
 });

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -2,9 +2,10 @@ import { useState, type FormEvent } from "react";
 import { Loader2 } from "lucide-react";
 import { useAutoFocus } from "@/hooks/useAutoFocus";
 import { errMsg, voidPromise } from "@/utils/async";
-import { useLocation } from "wouter";
+import { useLocation, useSearch } from "wouter";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "@/stores/auth-store";
+import { safeReturnPath } from "@/utils/safe-url";
 import { BRAND } from "@/branding";
 import type { LoginResponse, ErrorResponse } from "@/api";
 import { FieldLabel } from "@/components/ui/FieldLabel";
@@ -27,6 +28,7 @@ export function LoginPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [, setLocation] = useLocation();
+  const search = useSearch();
   const login = useAuthStore((s) => s.login);
   const usernameRef = useAutoFocus<HTMLInputElement>();
 
@@ -57,7 +59,10 @@ export function LoginPage() {
 
       const data = await resp.json() as LoginResponse;
       login(data.access_token, username);
-      setLocation("/app/projects");
+      // 登录成功后回跳到进入登录页前的原始地址（由 AuthGuard / 401 拦截以 ?from 传入），
+      // 经 safeReturnPath 校验为站内安全路径；非法或缺失时回退到项目列表。
+      const returnTo = safeReturnPath(new URLSearchParams(search).get("from"));
+      setLocation(returnTo ?? "/app/projects");
     } catch (err) {
       setError(errMsg(err, t("auth:login_failed")));
     } finally {
@@ -66,7 +71,10 @@ export function LoginPage() {
   };
 
   return (
-    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-bg px-4 text-text">
+    <div
+      data-testid="login-page"
+      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-bg px-4 text-text"
+    >
       <div aria-hidden className="pointer-events-none absolute inset-0" style={AMBIENT_GLOW_STYLE} />
       <div aria-hidden className="pointer-events-none absolute inset-0" style={POSTER_GRID_STYLE} />
 

--- a/frontend/src/router.test.tsx
+++ b/frontend/src/router.test.tsx
@@ -132,4 +132,19 @@ describe("AppRoutes", () => {
       expect(projectState.projectDetailLoading).toBe(false);
     });
   });
+
+  it("redirects unauthenticated nested project URL to top-level /login", async () => {
+    useAuthStore.setState({ isAuthenticated: false, isLoading: false });
+    renderAt("/app/projects/demo");
+    // 回归：AuthGuard 渲染在 nest 路由内，相对的 /login 会被拼成
+    // /app/projects/demo/login（无匹配 → 404）；用 ~/login 绝对路径才落到 /login。
+    expect(await screen.findByTestId("login-page")).toBeInTheDocument();
+    expect(screen.queryByText("404")).not.toBeInTheDocument();
+  });
+
+  it("redirects unauthenticated non-nested protected route to /login", async () => {
+    useAuthStore.setState({ isAuthenticated: false, isLoading: false });
+    renderAt("/app/projects");
+    expect(await screen.findByTestId("login-page")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -40,7 +40,13 @@ function AuthGuard({ children }: { children: React.ReactNode }) {
   }
 
   if (!isAuthenticated) {
-    return <Redirect to="/login" />;
+    // 用 `~` 前缀跳到顶层 /login：AuthGuard 可能渲染在 nest 嵌套路由内
+    // （/app/projects/:projectName），此时相对路径会被拼到嵌套 base 之后，
+    // 必须用绝对路径才能落到真正的 /login。
+    // 带上完整原始 URL（取 window.location，nest 内 useLocation 只是相对路径），
+    // 登录成功后据此回跳。
+    const from = window.location.pathname + window.location.search;
+    return <Redirect to={`~/login?from=${encodeURIComponent(from)}`} />;
   }
 
   return <>{children}</>;

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -45,7 +45,7 @@ function AuthGuard({ children }: { children: React.ReactNode }) {
     // 必须用绝对路径才能落到真正的 /login。
     // 带上完整原始 URL（取 window.location，nest 内 useLocation 只是相对路径），
     // 登录成功后据此回跳。
-    const from = window.location.pathname + window.location.search;
+    const from = window.location.pathname + window.location.search + window.location.hash;
     return <Redirect to={`~/login?from=${encodeURIComponent(from)}`} />;
   }
 

--- a/frontend/src/utils/safe-url.test.ts
+++ b/frontend/src/utils/safe-url.test.ts
@@ -7,6 +7,13 @@ describe("safeReturnPath", () => {
     expect(safeReturnPath("/app/projects/demo?tab=scene")).toBe("/app/projects/demo?tab=scene");
   });
 
+  it("preserves the URL hash alongside path and query", () => {
+    expect(safeReturnPath("/app/projects/demo#shot-3")).toBe("/app/projects/demo#shot-3");
+    expect(safeReturnPath("/app/projects/demo?tab=scene#shot-3")).toBe(
+      "/app/projects/demo?tab=scene#shot-3",
+    );
+  });
+
   it("rejects internal paths outside /app/", () => {
     expect(safeReturnPath("/login")).toBeNull();
     expect(safeReturnPath("/")).toBeNull();

--- a/frontend/src/utils/safe-url.test.ts
+++ b/frontend/src/utils/safe-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { safeReturnPath } from "@/utils/safe-url";
+
+describe("safeReturnPath", () => {
+  it("allows internal /app/ paths and preserves the query string", () => {
+    expect(safeReturnPath("/app/projects/demo")).toBe("/app/projects/demo");
+    expect(safeReturnPath("/app/projects/demo?tab=scene")).toBe("/app/projects/demo?tab=scene");
+  });
+
+  it("rejects internal paths outside /app/", () => {
+    expect(safeReturnPath("/login")).toBeNull();
+    expect(safeReturnPath("/")).toBeNull();
+    expect(safeReturnPath("/app")).toBeNull();
+  });
+
+  it("rejects external and protocol-relative URLs (open redirect)", () => {
+    expect(safeReturnPath("//evil.com")).toBeNull();
+    expect(safeReturnPath("http://evil.com")).toBeNull();
+    expect(safeReturnPath("https://evil.com/app/x")).toBeNull();
+  });
+
+  it("rejects traversal that escapes /app/", () => {
+    expect(safeReturnPath("/app/../../evil")).toBeNull();
+  });
+
+  it("returns null for empty or missing input", () => {
+    expect(safeReturnPath(null)).toBeNull();
+    expect(safeReturnPath(undefined)).toBeNull();
+    expect(safeReturnPath("")).toBeNull();
+  });
+});

--- a/frontend/src/utils/safe-url.ts
+++ b/frontend/src/utils/safe-url.ts
@@ -31,5 +31,5 @@ export function safeReturnPath(raw: string | null | undefined): string | null {
   }
   if (url.origin !== window.location.origin) return null;
   if (!url.pathname.startsWith("/app/")) return null;
-  return url.pathname + url.search;
+  return url.pathname + url.search + url.hash;
 }

--- a/frontend/src/utils/safe-url.ts
+++ b/frontend/src/utils/safe-url.ts
@@ -15,3 +15,21 @@ export function sanitizeImageSrc(raw: string | null | undefined): string | undef
   // 通过 URL 对象重建输出，让静态分析器识别为已归一化的安全 URL
   return url.toString();
 }
+
+/**
+ * 校验登录后的回跳目标，杜绝 open redirect。
+ * 仅放行同源、且路径落在 /app/ 下的站内地址；外站、协议相对（//host）、
+ * 以及 /login 等非应用页面一律拒绝，返回 null（由调用方回退到默认页）。
+ */
+export function safeReturnPath(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  let url: URL;
+  try {
+    url = new URL(raw, window.location.origin);
+  } catch {
+    return null;
+  }
+  if (url.origin !== window.location.origin) return null;
+  if (!url.pathname.startsWith("/app/")) return null;
+  return url.pathname + url.search;
+}


### PR DESCRIPTION
## 问题

未登录状态下直接访问项目工作区 URL（如 `/app/projects/my-project`）时，本应跳到登录页 `/login`，实际却跳到 `/app/projects/my-project/login`（无路由匹配 → 404）。

## 根因

工作区路由用了 wouter 的 `nest` 嵌套路由，而 `AuthGuard` 渲染在它内部。wouter 在 `nest` 子树里会把**以 `/` 开头的相对路径拼到嵌套 base 之后**，于是 `<Redirect to="/login">` 被解析成 `/app/projects/my-project` + `/login`。

只有项目工作区 URL 复现，因为其余受保护路由（项目列表、设置、资产库）都不是 `nest`，base 为空，`/login` 仍正常。

## 改动

- **`router.tsx` `AuthGuard`**：`to="/login"` → `to="~/login"`（wouter `~` 前缀＝忽略 base 的绝对路径，嵌套/非嵌套都正确落到顶层 `/login`）。
- **登录后回跳**：`AuthGuard` 与 `api.ts` 的 401 拦截以 `?from=` 携带原始地址；`LoginPage` 登录成功后读取并经 `safeReturnPath` 校验后回跳。
- **`utils/safe-url.ts` 新增 `safeReturnPath()`**：仅放行同源、`/app/` 下的站内路径，挡掉 `//evil.com`、外站、`/login`、路径穿越（防 open redirect）。

## 测试

- 新增 `safe-url.test.ts`（`safeReturnPath` 6 类用例）。
- `router.test.tsx` 新增未登录访问嵌套/非嵌套路由跳转的回归用例（直接复现并锁定本 bug）。
- `api.test.ts` 新增 401 带 `from` 用例，并修正既有 3 处 401 测试 stub 缺失 `pathname`/`search` 导致的脆弱断言。
- 本地 `pnpm check`（typecheck + lint + vitest）全绿：81 文件 / 610 测试通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 登录成功后优先从 URL 的 from 参数返回原先页面，缺失或不安全时回退到项目列表。
  * 新增回跳路径校验，确保仅允许站内受保护路径作为返回目标。
  * 登录页增加测试标识以便定位。

* **修复**
  * 未授权重定向在受保护子路径情形下附带编码后的 from 参数，改善回跳准确性并确保跳转到顶层登录页。

* **测试**
  * 丰富了重定向、回跳与安全校验的单元与端到端测试覆盖。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->