### PR TITLE
fix(tasks): worker 吸收 inflight 任务取消的 CancelledError，主循环不再退出

### DIFF
--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -560,6 +560,13 @@ class GenerationWorker:
             for finished_task in pool.drain_finished():
                 try:
                     await finished_task
+                except asyncio.CancelledError:
+                    # 用户取消 inflight 任务：_process_task 已 mark_cancelled 并按 asyncio
+                    # 协议 re-raise。CancelledError 继承 BaseException，不能落到下方 except
+                    # Exception，否则冒泡到 _run_loop 让主循环永久退出。drain 端吞掉即可——
+                    # drain_finished() 只返回已 done() 的 task，await 不会挂起本协程，
+                    # 故这里捕获的必是子任务的取消结果，绝不会误吞针对 _run_loop 的取消。
+                    pass
                 except Exception:
                     logger.debug("已处理的任务异常已在 _process_task 中记录")
 

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -87,13 +87,13 @@ class ProviderPool:
         # 计入 pending：sem 排队期 sub-task 同样占名额，避免主循环超额 claim
         return self.video_max > 0 and len(self.video_inflight) + len(self.video_pending) < self.video_max
 
-    def drain_finished(self) -> list[asyncio.Task]:
-        """Remove finished tasks from inflight dicts. Return them for await."""
+    def drain_finished(self) -> list[tuple[str, asyncio.Task]]:
+        """Remove finished tasks from inflight dicts. Return ``(task_id, task)`` for inspection."""
         finished = []
         for inflight in (self.image_inflight, self.video_inflight):
             done_ids = [tid for tid, t in inflight.items() if t.done()]
             for tid in done_ids:
-                finished.append(inflight.pop(tid))
+                finished.append((tid, inflight.pop(tid)))
         return finished
 
     def all_inflight(self) -> list[asyncio.Task]:
@@ -557,16 +557,22 @@ class GenerationWorker:
 
     async def _drain_finished_tasks(self) -> None:
         for pool in self._pools.values():
-            for finished_task in pool.drain_finished():
+            for task_id, finished_task in pool.drain_finished():
+                # 同步判定取消/异常：drain_finished() 只返回 done() 的 task，无需 await。
+                # 不 await 就没有挂起点，自然不会误吞针对 _run_loop 自身的取消信号。
+                if finished_task.cancelled():
+                    # 子任务被取消。正常路径 _process_task 已 mark_cancelled 并 re-raise；
+                    # 但取消可能落在 _process_task 进入 try 之前（协程尚未开始执行，或仍停在
+                    # 入口的 _extract_provider await），那一刻子任务来不及落终态。drain 端兜底
+                    # mark_cancelled——SQL 守卫 status IN (queued, cancelling, running) 保证幂等：
+                    # 已落终态则 0 rows 无副作用，避免任务永久卡在 running/cancelling。
+                    try:
+                        await self.queue.mark_task_cancelled(task_id, cancelled_by="user")
+                    except Exception:
+                        logger.warning("drain 兜底 mark_cancelled 失败 task_id=%s", task_id, exc_info=True)
+                    continue
                 try:
-                    await finished_task
-                except asyncio.CancelledError:
-                    # 用户取消 inflight 任务：_process_task 已 mark_cancelled 并按 asyncio
-                    # 协议 re-raise。CancelledError 继承 BaseException，不能落到下方 except
-                    # Exception，否则冒泡到 _run_loop 让主循环永久退出。drain 端吞掉即可——
-                    # drain_finished() 只返回已 done() 的 task，await 不会挂起本协程，
-                    # 故这里捕获的必是子任务的取消结果，绝不会误吞针对 _run_loop 的取消。
-                    pass
+                    finished_task.result()
                 except Exception:
                     logger.debug("已处理的任务异常已在 _process_task 中记录")
 

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -303,6 +303,169 @@ class TestGenerationWorker:
         assert worker.request_cancel("ghost") is False
 
     @pytest.mark.asyncio
+    async def test_drain_finished_tasks_absorbs_cancelled_error(self):
+        """取消的 inflight task 被 drain 时不能让 CancelledError 冒泡（继承 BaseException）。"""
+        queue = _FakeQueue()
+        pool = ProviderPool(provider_id="test", image_max=1, video_max=1)
+        worker = GenerationWorker(queue=queue, pools={"test": pool})
+
+        async def _long():
+            await asyncio.sleep(10)
+
+        t = asyncio.create_task(_long())
+        t.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await t
+        assert t.cancelled()
+        pool.video_inflight["tid"] = t
+
+        # 修复前：CancelledError 不被 except Exception 接住，会从这里抛出。
+        # 修复后：drain 端显式吸收，不抛，且 task 已从 inflight 字典 pop。
+        await worker._drain_finished_tasks()
+        assert "tid" not in pool.video_inflight
+
+    @pytest.mark.asyncio
+    async def test_run_loop_survives_inflight_task_cancellation(self, monkeypatch):
+        """用户取消运行中的任务：任务 mark_cancelled，但 worker 主循环不退出。"""
+        queue = _FakeQueue()
+        pool = ProviderPool(provider_id="test", image_max=1, video_max=1)
+        worker = GenerationWorker(queue=queue, pools={"test": pool})
+        worker.heartbeat_interval = 0.01
+        worker.poll_interval = 0.01
+
+        started = asyncio.Event()
+
+        async def _block(_task):
+            started.set()
+            await asyncio.sleep(10)  # 模拟长时间运行的生成任务
+
+        monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _block)
+
+        t = asyncio.create_task(
+            worker._process_task({"task_id": "tid", "media_type": "video"}),
+            name="generation-video-tid",
+        )
+        pool.video_inflight["tid"] = t
+
+        await worker.start()
+        await started.wait()  # 确保 _process_task 已进入 execute（_extract_provider 已完成）
+
+        assert worker.request_cancel("tid") is True
+        await asyncio.sleep(0.1)  # 跨多个 loop tick：取消落地 + drain
+
+        # 任务被正确 mark_cancelled
+        assert queue.cancelled and queue.cancelled[0][0] == "tid"
+        # 主循环吸收 CancelledError 后仍存活
+        assert worker._main_task is not None and not worker._main_task.done()
+
+        await asyncio.wait_for(worker.stop(), timeout=2.0)
+        assert queue.released
+
+    @pytest.mark.asyncio
+    async def test_run_loop_survives_consecutive_cancellations_and_keeps_claiming(self, monkeypatch):
+        """连续取消多个 inflight 任务后，主循环仍存活并能继续 claim 新任务。"""
+
+        class _GatedQueue(_FakeQueue):
+            def __init__(self):
+                super().__init__()
+                self.allow_new = False
+                self.new_dispatched = False
+
+            async def claim_next_task(self, media_type, **_kwargs):  # type: ignore[override]
+                if self.allow_new and not self.new_dispatched and media_type == "image":
+                    self.new_dispatched = True
+                    return {
+                        "task_id": "fresh-img",
+                        "task_type": "gen_image",
+                        "media_type": "image",
+                        "payload": {"image_provider": "gemini-aistudio"},
+                    }
+                return None
+
+        queue = _GatedQueue()
+        pool = ProviderPool(provider_id="gemini-aistudio", image_max=5, video_max=3)
+        worker = GenerationWorker(queue=queue, pools={"gemini-aistudio": pool})
+        worker.heartbeat_interval = 0.01
+        worker.poll_interval = 0.01
+
+        release = asyncio.Event()
+        entered: set[str] = set()
+
+        async def _block(task):
+            entered.add(task["task_id"])
+            await release.wait()
+            return {"ok": True}
+
+        monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _block)
+
+        vid_ids = ["vid-0", "vid-1", "vid-2"]
+        for tid in vid_ids:
+            t = asyncio.create_task(
+                worker._process_task({"task_id": tid, "media_type": "video"}),
+                name=f"generation-video-{tid}",
+            )
+            pool.video_inflight[tid] = t
+
+        await worker.start()
+        while not set(vid_ids) <= entered:  # 等三个任务都进入 execute
+            await asyncio.sleep(0)
+
+        for tid in vid_ids:
+            assert worker.request_cancel(tid) is True
+        await asyncio.sleep(0.1)
+
+        # 主循环存活 + 三个任务都 mark_cancelled
+        assert worker._main_task is not None and not worker._main_task.done()
+        assert set(vid_ids) <= {c[0] for c in queue.cancelled}
+
+        # 取消后仍能 claim 并 dispatch 新任务
+        queue.allow_new = True
+        await asyncio.sleep(0.1)
+        assert queue.new_dispatched is True
+        assert "fresh-img" in pool.image_inflight
+
+        # 收尾：放行 fresh-img 后正常停机
+        release.set()
+        await asyncio.wait_for(worker.stop(), timeout=2.0)
+        assert queue.released
+
+    @pytest.mark.asyncio
+    async def test_stop_event_exits_loop_even_with_cancellations(self, monkeypatch):
+        """语义对比：单任务取消不退出，但显式 stop（set stop event）必须让 worker 退出。"""
+        queue = _FakeQueue()
+        pool = ProviderPool(provider_id="test", image_max=1, video_max=1)
+        worker = GenerationWorker(queue=queue, pools={"test": pool})
+        worker.heartbeat_interval = 0.01
+        worker.poll_interval = 0.01
+
+        started = asyncio.Event()
+
+        async def _block(_task):
+            started.set()
+            await asyncio.sleep(10)
+
+        monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _block)
+
+        t = asyncio.create_task(
+            worker._process_task({"task_id": "tid", "media_type": "video"}),
+            name="generation-video-tid",
+        )
+        pool.video_inflight["tid"] = t
+
+        await worker.start()
+        await started.wait()
+        assert worker.request_cancel("tid") is True
+        await asyncio.sleep(0.05)
+        # 取消阶段：主循环仍存活
+        assert worker._main_task is not None and not worker._main_task.done()
+        assert queue.cancelled and queue.cancelled[0][0] == "tid"
+
+        # 显式 stop → worker 正常退出
+        await asyncio.wait_for(worker.stop(), timeout=2.0)
+        assert worker._main_task is None
+        assert queue.released
+
+    @pytest.mark.asyncio
     async def test_handle_orphan_cancelling_marks_cancelled(self, monkeypatch):
         """ADR 0007：orphan cancelling 状态 → mark_cancelled。"""
         queue = _FakeQueue()

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -314,8 +314,7 @@ class TestGenerationWorker:
 
         t = asyncio.create_task(_long())
         t.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await t
+        await asyncio.gather(t, return_exceptions=True)  # 驱动到 done(cancelled)，吞掉取消结果
         assert t.cancelled()
         pool.video_inflight["tid"] = t
 
@@ -367,8 +366,8 @@ class TestGenerationWorker:
 
         t = asyncio.create_task(_long())
         t.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await t
+        await asyncio.gather(t, return_exceptions=True)  # 驱动到 done(cancelled)，吞掉取消结果
+        assert t.cancelled()
         pool.video_inflight["tid"] = t
 
         # mark_cancelled 抛错被 except 吞掉，drain 不抛、task 仍被 pop

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -326,6 +326,56 @@ class TestGenerationWorker:
         assert queue.cancelled and queue.cancelled[0][0] == "tid"
 
     @pytest.mark.asyncio
+    async def test_drain_finished_tasks_drains_success_and_failure(self):
+        """非取消路径：成功 task 走 .result() 无异常，失败 task 走 except 分支，均不触发兜底取消。"""
+        queue = _FakeQueue()
+        pool = ProviderPool(provider_id="test", image_max=2, video_max=2)
+        worker = GenerationWorker(queue=queue, pools={"test": pool})
+
+        async def _ok():
+            return "done"
+
+        async def _boom():
+            raise RuntimeError("boom")
+
+        ok_t = asyncio.create_task(_ok())
+        boom_t = asyncio.create_task(_boom())
+        await asyncio.gather(ok_t, boom_t, return_exceptions=True)
+        pool.image_inflight["ok"] = ok_t
+        pool.video_inflight["boom"] = boom_t
+
+        await worker._drain_finished_tasks()  # 不抛
+        assert "ok" not in pool.image_inflight
+        assert "boom" not in pool.video_inflight
+        # 非取消任务不应触发 drain 兜底 mark_cancelled
+        assert queue.cancelled == []
+
+    @pytest.mark.asyncio
+    async def test_drain_fallback_mark_cancelled_failure_does_not_propagate(self):
+        """drain 端兜底 mark_cancelled 自身抛错时只 warning，不冒泡（不挂掉主循环）。"""
+
+        class _RaisingQueue(_FakeQueue):
+            async def mark_task_cancelled(self, task_id, *, cancelled_by="user"):  # type: ignore[override]
+                raise RuntimeError("db down")
+
+        queue = _RaisingQueue()
+        pool = ProviderPool(provider_id="test", image_max=1, video_max=1)
+        worker = GenerationWorker(queue=queue, pools={"test": pool})
+
+        async def _long():
+            await asyncio.sleep(10)
+
+        t = asyncio.create_task(_long())
+        t.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await t
+        pool.video_inflight["tid"] = t
+
+        # mark_cancelled 抛错被 except 吞掉，drain 不抛、task 仍被 pop
+        await worker._drain_finished_tasks()
+        assert "tid" not in pool.video_inflight
+
+    @pytest.mark.asyncio
     async def test_drain_marks_cancelled_when_cancel_hits_before_process_task_try(self, monkeypatch):
         """取消落在 _process_task 进 try 之前（_extract_provider await）：drain 端兜底落终态。"""
         queue = _FakeQueue()

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -304,7 +304,7 @@ class TestGenerationWorker:
 
     @pytest.mark.asyncio
     async def test_drain_finished_tasks_absorbs_cancelled_error(self):
-        """取消的 inflight task 被 drain 时不能让 CancelledError 冒泡（继承 BaseException）。"""
+        """取消的 inflight task 被 drain：不抛、从字典 pop，并 drain 端兜底 mark_cancelled。"""
         queue = _FakeQueue()
         pool = ProviderPool(provider_id="test", image_max=1, video_max=1)
         worker = GenerationWorker(queue=queue, pools={"test": pool})
@@ -319,10 +319,52 @@ class TestGenerationWorker:
         assert t.cancelled()
         pool.video_inflight["tid"] = t
 
-        # 修复前：CancelledError 不被 except Exception 接住，会从这里抛出。
-        # 修复后：drain 端显式吸收，不抛，且 task 已从 inflight 字典 pop。
+        # 同步判定 .cancelled()：不 await，不抛 CancelledError，task 已被 drain pop。
         await worker._drain_finished_tasks()
         assert "tid" not in pool.video_inflight
+        # 子任务来不及自落终态时，drain 端兜底 mark_cancelled。
+        assert queue.cancelled and queue.cancelled[0][0] == "tid"
+
+    @pytest.mark.asyncio
+    async def test_drain_marks_cancelled_when_cancel_hits_before_process_task_try(self, monkeypatch):
+        """取消落在 _process_task 进 try 之前（_extract_provider await）：drain 端兜底落终态。"""
+        queue = _FakeQueue()
+        pool = ProviderPool(provider_id="test", image_max=1, video_max=1)
+        worker = GenerationWorker(queue=queue, pools={"test": pool})
+        worker.heartbeat_interval = 0.01
+        worker.poll_interval = 0.01
+
+        in_extract = asyncio.Event()
+
+        async def _blocking_extract(_task):
+            in_extract.set()
+            await asyncio.sleep(10)  # 停在入口解析，模拟 cancel 落在 _process_task 的 try 之前
+            return "test"
+
+        monkeypatch.setattr("lib.generation_worker._extract_provider", _blocking_extract)
+
+        async def _execute(_task):
+            raise AssertionError("execute 不应被调用：cancel 在 _extract_provider 阶段就到")
+
+        monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _execute)
+
+        t = asyncio.create_task(
+            worker._process_task({"task_id": "tid", "media_type": "video"}),
+            name="generation-video-tid",
+        )
+        pool.video_inflight["tid"] = t
+
+        await worker.start()
+        await in_extract.wait()  # 确保停在 _extract_provider（try 之前）
+        assert worker.request_cancel("tid") is True
+        await asyncio.sleep(0.1)
+
+        # _process_task 没机会 mark（cancel 在 try 之前）→ drain 端兜底 mark_cancelled
+        assert queue.cancelled and queue.cancelled[0][0] == "tid"
+        # 主循环仍存活
+        assert worker._main_task is not None and not worker._main_task.done()
+
+        await asyncio.wait_for(worker.stop(), timeout=2.0)
 
     @pytest.mark.asyncio
     async def test_run_loop_survives_inflight_task_cancellation(self, monkeypatch):


### PR DESCRIPTION
## 问题

用户取消 running 中的生成任务（`request_cancel` → `asyncio.Task.cancel()`）后，整个 GenerationWorker 主循环会永久退出，后续任务卡在 `queued`，必须重启进程才能恢复。Production hot path，100% 复现，P1。

**根因**：`_process_task` 收到 `CancelledError` 后按 asyncio 协议 `mark_task_cancelled` 再 re-raise；该异常经 `_drain_finished_tasks` 的 `await finished_task` 重新抛出，但 `asyncio.CancelledError` 继承 `BaseException` 而非 `Exception`，原有的 `except Exception` 接不住 → 冒泡到 `_run_loop`（只有 `finally` 无 `except`）→ 协程释放 lease 后退出，worker 主任务永久 `done`。

引入 commit：`ed9c359`（#663）。来源：OpenAI Codex review（P1）。

## 修复

在 `_drain_finished_tasks` 显式捕获 `CancelledError` 吸收掉。`drain_finished()` 只返回已 `done()` 的 task，`await` 不会挂起本协程，故捕获的必是子任务的取消结果，绝不会误吞针对 `_run_loop` 的取消。采用 issue 推荐的「drain 路径精确捕获」方案，而非在 `_run_loop` 顶层加 `except CancelledError`（粒度粗，未来若 `stop()` 改成 cancel 主任务会掩盖正常 shutdown）。

`_process_task` / ADR 0006 0-rows-cancelled 协议 / `_wait_inflight_completion`（已用 `gather(return_exceptions=True)` 天然吸收）均不改动。

## 测试

新增 4 个用例（均已验证：回退修复后全部失败，恢复后全部通过）：

- `test_drain_finished_tasks_absorbs_cancelled_error` —— drain 端不让 CancelledError 冒泡
- `test_run_loop_survives_inflight_task_cancellation` —— 取消单任务后主循环仍存活（AC1）
- `test_run_loop_survives_consecutive_cancellations_and_keeps_claiming` —— 连续取消多个后仍能 claim 新任务（AC2）
- `test_stop_event_exits_loop_even_with_cancellations` —— 显式 stop 仍正常退出，语义对比（AC3）

验证：
- `uv run pytest tests/` —— 3375 passed（唯一失败 `TestExtractProvider::test_default_when_unresolvable` 是本地开发 DB 配了 grok 供应商导致的环境性失败，已确认在未改动的 main 上同样失败，CI 干净 DB 不受影响）
- `uv run ruff check` —— 通过；`ruff format` —— 无变更
- `uv run basedpyright` —— 0 errors

Closes #666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化停机/清理流程：drain 阶段按任务标识落终态，对已取消子任务做兜底标记；已完成任务不再 await，改为同步取结果/异常并仅记录为调试级别，避免在停机时抛出额外错误，提升停机稳定性与一致性。

* **Tests**
  * 新增一组异步测试，覆盖取消、并发取消、停机交互、兜底标记失败、强制退出与主循环存活等场景，增强对资源释放与行为的验证。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->