### PR TITLE
fix(compose-video): 守卫中段双侧 xfade 时间窗重叠

### DIFF
--- a/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
+++ b/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
@@ -424,6 +424,18 @@ def _build_xfade_filter_complex(
             continue
         boundary_xfade.append(xfade)
 
+    # 中段双侧 xfade 守卫：相邻 xfade 让中段同时承担入场 + 出场两个转场，合计需要
+    # 2*transition_duration 秒；单边界守卫只看单侧会漏判，导致 xfade 时段交叉。
+    # 对两侧都是 xfade 且 duration < 2*td 的中段，降左侧边界为 cut（保留右侧）。
+    # 从左向右遍历、原地修改，链式短中段逐个降级；恰好等于 2*td 视为足够不降级。
+    for i in range(1, n - 1):
+        if (
+            boundary_xfade[i - 1] is not None
+            and boundary_xfade[i] is not None
+            and durations[i] < 2 * transition_duration
+        ):
+            boundary_xfade[i - 1] = None
+
     if all(b is None for b in boundary_xfade):
         return None
 

--- a/tests/test_compose_video_filter_graph.py
+++ b/tests/test_compose_video_filter_graph.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 import tempfile
 from pathlib import Path
@@ -272,6 +273,86 @@ class TestBuildXfadeFilterComplex:
         assert result is not None
         # 边界 1 没在 transitions 里 → 默认 fade
         assert "[g0v1][2:v]xfade=transition=fade" in result
+
+    def test_middle_clip_both_sided_xfade_downgrades_left(self) -> None:
+        """中段两侧 xfade 且 td < dur < 2*td：左侧降 cut，保留右侧。
+
+        durations=[10, 3, 10], transitions=["fade","fade"], td=2.0
+        → 中段 3s 须承担 2+2=4s 转场但单边界守卫各自放行（3 > 2）
+        → 左侧边界 0 降 cut，等价 boundary_xfade=[None, "fade"]
+        → group A=[0]（单段透传），group B=[1,2]（xfade）
+        """
+        result = compose_video._build_xfade_filter_complex([10.0, 3.0, 10.0], ["fade", "fade"], 2.0)
+        assert result is not None
+        # 边界 0 降 cut：不应出现 [0:v][1:v]xfade
+        assert "[0:v][1:v]xfade" not in result
+        # 边界 1 保留 fade：offset = dur[1] - td = 3 - 2 = 1.000
+        assert "[1:v][2:v]xfade=transition=fade:duration=2.0:offset=1.000[g1v]" in result
+        # cut 分组 → 组间 concat
+        assert "concat=n=2:v=1:a=1[vout][aout]" in result
+
+    def test_chained_short_middle_clips_downgrade_left_to_right(self) -> None:
+        """链式短中段：从左向右逐个降左侧，最终只保留最右 xfade。
+
+        durations=[10, 3, 3, 10], transitions=["fade","fade","fade"], td=2.0
+        → 中段 1、2 均为 3s（< 4s）双侧 xfade
+        → i=1 降边界 0，i=2 降边界 1，等价 boundary_xfade=[None, None, "fade"]
+        → group A=[0]、B=[1]（均单段透传），C=[2,3]（xfade）
+        """
+        result = compose_video._build_xfade_filter_complex([10.0, 3.0, 3.0, 10.0], ["fade", "fade", "fade"], 2.0)
+        assert result is not None
+        # 边界 0、1 降 cut
+        assert "[0:v][1:v]xfade" not in result
+        assert "[1:v][2:v]xfade" not in result
+        # 只剩最右边界 2：offset = dur[2] - td = 3 - 2 = 1.000
+        assert "[2:v][3:v]xfade=transition=fade:duration=2.0:offset=1.000[g2v]" in result
+        # 三个 group 串联
+        assert "concat=n=3:v=1:a=1[vout][aout]" in result
+
+    def test_middle_clip_exactly_two_transition_durations_keeps_both(self) -> None:
+        """中段恰好等于 2*td：视为足够，双侧 xfade 都保留（严格 < 才降级）。
+
+        durations=[10, 4, 10], transitions=["fade","fade"], td=2.0
+        → 4 == 2*2，不降级；单 group=[0,1,2]，链式 xfade，无 concat
+        """
+        result = compose_video._build_xfade_filter_complex([10.0, 4.0, 10.0], ["fade", "fade"], 2.0)
+        assert result is not None
+        # 第一 xfade offset = 10 - 2 = 8.000
+        assert "[0:v][1:v]xfade=transition=fade:duration=2.0:offset=8.000[g0v1]" in result
+        # 第二 xfade offset = 10+4 - 2*2 = 10.000
+        assert "[g0v1][2:v]xfade=transition=fade:duration=2.0:offset=10.000[g0v]" in result
+        # 单 group 走 null/anull，不出现 concat
+        assert "concat" not in result
+
+    def test_short_end_clip_not_affected_by_middle_guard(self) -> None:
+        """端片短（td < dur < 2*td）但只有一个 xfade 边界，本守卫不触发。
+
+        durations=[3, 10, 10], transitions=["fade","fade"], td=2.0
+        → 端片 0 为 3s，只承担边界 0 单个转场（> td 足够）
+        → 中段 1 为 10s（>= 4s），不降级 → 双侧 xfade 全保留
+        """
+        result = compose_video._build_xfade_filter_complex([3.0, 10.0, 10.0], ["fade", "fade"], 2.0)
+        assert result is not None
+        # 端片短不触发降级，边界 0 仍 fade
+        assert "[0:v][1:v]xfade=transition=fade:duration=2.0:offset=1.000[g0v1]" in result
+        # 中段 10s 不降级，边界 1 仍 fade
+        assert "[g0v1][2:v]xfade=transition=fade" in result
+        assert "concat" not in result
+
+    def test_no_negative_xfade_offset_after_guard(self) -> None:
+        """守卫生效后，xfade chain 中不出现负 offset（解析 offset 字符串断言 >= 0）。"""
+        cases = [
+            ([10.0, 3.0, 10.0], ["fade", "fade"], 2.0),
+            ([10.0, 3.0, 3.0, 10.0], ["fade", "fade", "fade"], 2.0),
+            ([10.0, 4.0, 10.0], ["fade", "fade"], 2.0),
+            ([3.0, 10.0, 10.0], ["fade", "fade"], 2.0),
+        ]
+        for durations, transitions, td in cases:
+            result = compose_video._build_xfade_filter_complex(durations, transitions, td)
+            assert result is not None
+            offsets = [float(m) for m in re.findall(r"offset=(-?\d+\.\d+)", result)]
+            assert offsets, f"应至少有一个 xfade offset: {durations}"
+            assert all(o >= 0 for o in offsets), f"出现负 offset {offsets}: {durations}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

`_build_xfade_filter_complex` 拼接片段时，相邻片段间可选 xfade 转场。ffmpeg xfade 让相邻两段在时间上**重叠** `transition_duration` 秒。

原守卫仅按**单条边界**判断（`durations[i] <= td or durations[i+1] <= td`），漏判中间片段 `i` 两侧 boundary 都保留 xfade 的情形：此时它同时充当上一转场的入场端和下一转场的出场端，合计需 `2 * transition_duration` 秒。当 `td < duration[i] < 2*td` 时两个单边界守卫各自放行，但中段时间窗重叠 → xfade offset 交叉、画面错乱/闪烁或编码失败。

> 例：`[10, 3, 10] / fade,fade / td=2` → 第一 xfade 窗 `[8,10]`，第二 `[9,11]`，`[9,10]` 区间两个转场同时进行。

由 Gemini Code Assist review 发现，引入自 PR #578（commit `c4294a7`）。

## 改动

在 `boundary_xfade` 构建完毕后、`all None` 检查之前插入二次扫描：对每个中间片段 `i ∈ [1, n-2]`，若两侧 boundary 都是非-cut 的 xfade 且 `duration[i] < 2 * transition_duration`，则**降左侧边界（boundary i-1）为 cut**，保留右侧 xfade。从左向右原地遍历，链式短中段逐个降级；恰好等于 `2*td` 视为足够不降级（严格 `<`）。

- 不动 xfade offset 计算公式
- 不动既有单边界守卫
- audio acrossfade 由现有 cut 分组天然对齐，无需单独处理
- 入参/出参签名不变

## 测试

新增 5 个用例覆盖 issue 全部验收点：

- [x] `[10,3,10]/fade,fade/td=2` → 等价 `[None,"fade"]`（左 cut、右 fade），含 cut 分组 concat
- [x] `[10,3,3,10]/fade×3/td=2` → 左侧优先逐个降级，等价 `[None,None,"fade"]`
- [x] 边界相等 `[10,4,10]/fade,fade/td=2` → `4==2*td` 双侧 xfade 都保留
- [x] 端片短 `[3,10,10]` 不触发本守卫（已有单边界守卫覆盖）
- [x] 现有 `test_compose_video_filter_graph.py` 全部用例通过
- [x] 解析 offset 字符串断言全部 `>= 0`，无负 offset

验证：`pytest tests/test_compose_video_filter_graph.py` → 42 passed；全量 `pytest tests/` → 3377 passed；`ruff check` / `format` / `basedpyright` 均通过。

Closes #667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了视频合成中相邻过渡效果的处理，防止在短片段上出现转场时间冲突

* **Tests**
  * 扩展测试覆盖范围，验证短片段场景下过渡效果的正确降级与保留行为

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->