### PR TITLE
refactor(pricing): 声明式定价重构——定价并进 ModelInfo、按 kind 派发

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -3,6 +3,16 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from lib.ark_shared import ARK_BASE_URL
+from lib.pricing.types import (
+    PerImageByResolution,
+    PerImageFlat,
+    PerImageOpenAIToken,
+    PerSecondMatrix,
+    PerToken,
+    PerTokenVideo,
+    Pricing,
+    ViduDelegate,
+)
 
 
 @dataclass(frozen=True)
@@ -16,6 +26,10 @@ class ModelInfo:
     resolutions: list[str] = field(default_factory=list)
     # 参考生视频单镜头参考图上限；0 = 不适用（图像/文本模型，或视频模型未声明）。
     max_reference_images: int = 0
+    # 计费定价声明（单一真相源）；None = 该模型按 provider 默认模型 / Gemini 默认费率兜底计费。
+    pricing: Pricing | None = None
+    # 从 UI 下拉剔除但保留条目（供"入队后、finish 前被下线"的边角仍能算价）。
+    hidden: bool = False
 
 
 @dataclass(frozen=True)
@@ -37,6 +51,120 @@ class ProviderMeta:
         return sorted(set(c for m in self.models.values() for c in m.capabilities))
 
 
+# Gemini 文本费率（美元/百万 token），Standard paid tier、prompt ≤200K 区间。
+def _gemini_text_pricing(model_id: str, input_rate: float, output_rate: float) -> PerToken:
+    return PerToken(
+        rates={model_id: {"input": input_rate, "output": output_rate}},
+        default_model=model_id,
+        currency="USD",
+    )
+
+
+# Gemini 图片费率（美元/张），按分辨率档位。
+def _gemini_image_pricing(model_id: str, rates: dict[str, float]) -> PerImageByResolution:
+    return PerImageByResolution(rates={model_id: rates}, default_model=model_id, currency="USD")
+
+
+# Veo 视频费率（美元/秒），按 (分辨率, 是否生成音频)。
+def _veo_video_pricing(model_id: str, rates: dict[tuple[str, bool | None], float]) -> PerSecondMatrix:
+    return PerSecondMatrix(
+        rates={model_id: rates},
+        default_model=model_id,
+        dimensions="resolution_audio",
+        currency="USD",
+    )
+
+
+_VEO_STANDARD_RATES: dict[tuple[str, bool | None], float] = {
+    ("720p", True): 0.40,
+    ("720p", False): 0.20,
+    ("1080p", True): 0.40,
+    ("1080p", False): 0.20,
+    ("4k", True): 0.60,
+    ("4k", False): 0.40,
+}
+_VEO_FAST_RATES: dict[tuple[str, bool | None], float] = {
+    ("720p", True): 0.15,
+    ("720p", False): 0.10,
+    ("1080p", True): 0.15,
+    ("1080p", False): 0.10,
+    ("4k", True): 0.35,
+    ("4k", False): 0.30,
+}
+_VEO_LITE_RATES: dict[tuple[str, bool | None], float] = {
+    ("720p", True): 0.05,
+    ("720p", False): 0.05,
+    ("1080p", True): 0.08,
+    ("1080p", False): 0.08,
+}
+
+
+# Ark 文本费率（元/百万 token），在线推理、输入 [0, 32k] 区间。
+def _ark_text_pricing(model_id: str, input_rate: float, output_rate: float) -> PerToken:
+    return PerToken(
+        rates={model_id: {"input": input_rate, "output": output_rate}},
+        default_model=model_id,
+        currency="CNY",
+    )
+
+
+# Ark 图片费率（元/张）。
+def _ark_image_pricing(model_id: str, per_image: float) -> PerImageFlat:
+    return PerImageFlat(rates={model_id: per_image}, default_model=model_id, currency="CNY")
+
+
+# Ark 视频费率（元/百万 token），按 (service_tier, 是否生成音频)。
+def _ark_video_pricing(model_id: str, rates: dict[tuple[str, bool], float]) -> PerTokenVideo:
+    return PerTokenVideo(rates={model_id: rates}, default_model=model_id)
+
+
+# Grok 文本费率（美元/百万 token）。
+def _grok_text_pricing(model_id: str, input_rate: float, output_rate: float) -> PerToken:
+    return PerToken(
+        rates={model_id: {"input": input_rate, "output": output_rate}},
+        default_model=model_id,
+        currency="USD",
+    )
+
+
+# Grok 图片费率（美元/张）。
+def _grok_image_pricing(model_id: str, per_image: float) -> PerImageFlat:
+    return PerImageFlat(rates={model_id: per_image}, default_model=model_id, currency="USD")
+
+
+# OpenAI 文本费率（美元/百万 token）。
+def _openai_text_pricing(model_id: str, input_rate: float, output_rate: float) -> PerToken:
+    return PerToken(
+        rates={model_id: {"input": input_rate, "output": output_rate}},
+        default_model=model_id,
+        currency="USD",
+    )
+
+
+# OpenAI 图片费率：token 主路径 + (quality, size) 兜底表。
+def _openai_image_pricing(
+    model_id: str,
+    token_rates: dict[str, float],
+    fallback_rates: dict[tuple[str, str], float],
+) -> PerImageOpenAIToken:
+    return PerImageOpenAIToken(
+        token_rates={model_id: token_rates},
+        fallback_rates={model_id: fallback_rates},
+        default_model=model_id,
+        currency="USD",
+    )
+
+
+# Sora 视频费率（美元/秒），按分辨率。
+def _sora_video_pricing(model_id: str, rates: dict[str, float]) -> PerSecondMatrix:
+    return PerSecondMatrix(
+        rates={model_id: {(res, None): rate for res, rate in rates.items()}},
+        default_model=model_id,
+        dimensions="resolution_only",
+        currency="USD",
+    )
+
+
 PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
     "gemini-aistudio": ProviderMeta(
         display_name="AI Studio",
@@ -50,17 +178,20 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="Gemini 3.1 Pro",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                pricing=_gemini_text_pricing("gemini-3.1-pro-preview", 2.00, 12.00),
             ),
             "gemini-3-flash-preview": ModelInfo(
                 display_name="Gemini 3 Flash",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
                 default=True,
+                pricing=_gemini_text_pricing("gemini-3-flash-preview", 0.50, 3.00),
             ),
             "gemini-3.1-flash-lite-preview": ModelInfo(
                 display_name="Gemini 3.1 Flash Lite",
                 media_type="text",
                 capabilities=["text_generation", "structured_output"],
+                pricing=_gemini_text_pricing("gemini-3.1-flash-lite-preview", 0.25, 1.50),
             ),
             # --- image ---
             "gemini-3-pro-image-preview": ModelInfo(
@@ -68,6 +199,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
                 resolutions=["1K", "2K", "4K"],
+                pricing=_gemini_image_pricing("gemini-3-pro-image-preview", {"1K": 0.134, "2K": 0.134, "4K": 0.24}),
             ),
             "gemini-3.1-flash-image-preview": ModelInfo(
                 display_name="Gemini 3.1 Flash Image",
@@ -75,6 +207,10 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 capabilities=["text_to_image", "image_to_image"],
                 default=True,
                 resolutions=["1K", "2K", "4K"],
+                pricing=_gemini_image_pricing(
+                    "gemini-3.1-flash-image-preview",
+                    {"512PX": 0.045, "1K": 0.067, "2K": 0.101, "4K": 0.151},
+                ),
             ),
             # --- video ---
             "veo-3.1-generate-preview": ModelInfo(
@@ -85,6 +221,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 duration_resolution_constraints={"1080p": [8]},
                 resolutions=["720p", "1080p"],
                 max_reference_images=3,
+                pricing=_veo_video_pricing("veo-3.1-generate-preview", _VEO_STANDARD_RATES),
             ),
             "veo-3.1-fast-generate-preview": ModelInfo(
                 display_name="Veo 3.1 Fast",
@@ -94,6 +231,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 duration_resolution_constraints={"1080p": [8]},
                 resolutions=["720p", "1080p"],
                 max_reference_images=3,
+                pricing=_veo_video_pricing("veo-3.1-fast-generate-preview", _VEO_FAST_RATES),
             ),
             "veo-3.1-lite-generate-preview": ModelInfo(
                 display_name="Veo 3.1 Lite",
@@ -104,6 +242,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 duration_resolution_constraints={"1080p": [8]},
                 resolutions=["720p", "1080p"],
                 max_reference_images=3,
+                pricing=_veo_video_pricing("veo-3.1-lite-generate-preview", _VEO_LITE_RATES),
             ),
         },
     ),
@@ -119,17 +258,20 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="Gemini 3.1 Pro",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                pricing=_gemini_text_pricing("gemini-3.1-pro-preview", 2.00, 12.00),
             ),
             "gemini-3-flash-preview": ModelInfo(
                 display_name="Gemini 3 Flash",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
                 default=True,
+                pricing=_gemini_text_pricing("gemini-3-flash-preview", 0.50, 3.00),
             ),
             "gemini-3.1-flash-lite-preview": ModelInfo(
                 display_name="Gemini 3.1 Flash Lite",
                 media_type="text",
                 capabilities=["text_generation", "structured_output"],
+                pricing=_gemini_text_pricing("gemini-3.1-flash-lite-preview", 0.25, 1.50),
             ),
             # --- image ---
             "gemini-3-pro-image-preview": ModelInfo(
@@ -137,6 +279,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
                 resolutions=["1K", "2K", "4K"],
+                pricing=_gemini_image_pricing("gemini-3-pro-image-preview", {"1K": 0.134, "2K": 0.134, "4K": 0.24}),
             ),
             "gemini-3.1-flash-image-preview": ModelInfo(
                 display_name="Gemini 3.1 Flash Image",
@@ -144,6 +287,10 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 capabilities=["text_to_image", "image_to_image"],
                 default=True,
                 resolutions=["1K", "2K", "4K"],
+                pricing=_gemini_image_pricing(
+                    "gemini-3.1-flash-image-preview",
+                    {"512PX": 0.045, "1K": 0.067, "2K": 0.101, "4K": 0.151},
+                ),
             ),
             # --- video ---
             "veo-3.1-generate-001": ModelInfo(
@@ -153,6 +300,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 supported_durations=[4, 6, 8],
                 resolutions=["720p", "1080p"],
                 max_reference_images=3,
+                pricing=_veo_video_pricing("veo-3.1-generate-001", _VEO_STANDARD_RATES),
             ),
             "veo-3.1-fast-generate-001": ModelInfo(
                 display_name="Veo 3.1 Fast",
@@ -162,6 +310,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 supported_durations=[4, 6, 8],
                 resolutions=["720p", "1080p"],
                 max_reference_images=3,
+                pricing=_veo_video_pricing("veo-3.1-fast-generate-001", _VEO_FAST_RATES),
             ),
         },
     ),
@@ -177,22 +326,26 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="豆包 Seed 2.0 Pro",
                 media_type="text",
                 capabilities=["text_generation", "vision"],
+                pricing=_ark_text_pricing("doubao-seed-2-0-pro-260215", 3.20, 16.00),
             ),
             "doubao-seed-2-0-lite-260215": ModelInfo(
                 display_name="豆包 Seed 2.0 Lite",
                 media_type="text",
                 capabilities=["text_generation", "vision"],
                 default=True,
+                pricing=_ark_text_pricing("doubao-seed-2-0-lite-260215", 0.60, 3.60),
             ),
             "doubao-seed-2-0-mini-260215": ModelInfo(
                 display_name="豆包 Seed 2.0 Mini",
                 media_type="text",
                 capabilities=["text_generation", "vision"],
+                pricing=_ark_text_pricing("doubao-seed-2-0-mini-260215", 0.20, 2.00),
             ),
             "doubao-seed-1-8-251228": ModelInfo(
                 display_name="豆包 Seed 1.8",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                pricing=_ark_text_pricing("doubao-seed-1-8-251228", 0.80, 2.00),
             ),
             # --- image ---
             "doubao-seedream-5-0-lite-260128": ModelInfo(
@@ -200,21 +353,25 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
                 default=True,
+                pricing=_ark_image_pricing("doubao-seedream-5-0-lite-260128", 0.22),
             ),
             "doubao-seedream-5-0-260128": ModelInfo(
                 display_name="Seedream 5.0",
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
+                pricing=_ark_image_pricing("doubao-seedream-5-0-260128", 0.22),
             ),
             "doubao-seedream-4-5-251128": ModelInfo(
                 display_name="Seedream 4.5",
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
+                pricing=_ark_image_pricing("doubao-seedream-4-5-251128", 0.25),
             ),
             "doubao-seedream-4-0-250828": ModelInfo(
                 display_name="Seedream 4.0",
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
+                pricing=_ark_image_pricing("doubao-seedream-4-0-250828", 0.20),
             ),
             # --- video ---
             "doubao-seedance-1-5-pro-251215": ModelInfo(
@@ -225,6 +382,15 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 supported_durations=list(range(4, 13)),
                 resolutions=["480p", "720p", "1080p"],
                 max_reference_images=9,
+                pricing=_ark_video_pricing(
+                    "doubao-seedance-1-5-pro-251215",
+                    {
+                        ("default", True): 16.00,
+                        ("default", False): 8.00,
+                        ("flex", True): 8.00,
+                        ("flex", False): 4.00,
+                    },
+                ),
             ),
             "doubao-seedance-2-0-260128": ModelInfo(
                 display_name="Seedance 2.0",
@@ -233,6 +399,10 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p", "1080p"],
                 max_reference_images=9,
+                pricing=_ark_video_pricing(
+                    "doubao-seedance-2-0-260128",
+                    {("default", True): 46.00, ("default", False): 46.00},
+                ),
             ),
             "doubao-seedance-2-0-fast-260128": ModelInfo(
                 display_name="Seedance 2.0 Fast",
@@ -241,6 +411,10 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p", "1080p"],
                 max_reference_images=9,
+                pricing=_ark_video_pricing(
+                    "doubao-seedance-2-0-fast-260128",
+                    {("default", True): 37.00, ("default", False): 37.00},
+                ),
             ),
         },
         default_base_url=ARK_BASE_URL,
@@ -253,6 +427,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
         secret_keys=["api_key"],
         models={
             # --- text ---
+            # Agent Plan 套餐价当前无独立费率表，沿用历史行为：按 Gemini 默认费率兜底（pricing=None）。
             "doubao-seed-2.0-mini": ModelInfo(
                 display_name="豆包 Seed 2.0 Mini",
                 media_type="text",
@@ -347,22 +522,26 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="Grok 4.20 Reasoning",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                pricing=_grok_text_pricing("grok-4.20-0309-reasoning", 2.00, 6.00),
             ),
             "grok-4.20-0309-non-reasoning": ModelInfo(
                 display_name="Grok 4.20 Non-Reasoning",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                pricing=_grok_text_pricing("grok-4.20-0309-non-reasoning", 2.00, 6.00),
             ),
             "grok-4-1-fast-reasoning": ModelInfo(
                 display_name="Grok 4.1 Fast Reasoning",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
                 default=True,
+                pricing=_grok_text_pricing("grok-4-1-fast-reasoning", 0.20, 0.50),
             ),
             "grok-4-1-fast-non-reasoning": ModelInfo(
                 display_name="Grok 4.1 Fast (Non-Reasoning)",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                pricing=_grok_text_pricing("grok-4-1-fast-non-reasoning", 0.20, 0.50),
             ),
             # --- image ---
             "grok-imagine-image-pro": ModelInfo(
@@ -370,6 +549,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
                 resolutions=["1K", "2K"],
+                pricing=_grok_image_pricing("grok-imagine-image-pro", 0.07),
             ),
             "grok-imagine-image": ModelInfo(
                 display_name="Grok Imagine Image",
@@ -377,6 +557,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 capabilities=["text_to_image", "image_to_image"],
                 default=True,
                 resolutions=["1K", "2K"],
+                pricing=_grok_image_pricing("grok-imagine-image", 0.02),
             ),
             # --- video ---
             "grok-imagine-video": ModelInfo(
@@ -388,6 +569,13 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 resolutions=["480p", "720p"],
                 # 参考图上限值来自第三方来源，官方文档未明确列出。
                 max_reference_images=7,
+                # 不区分分辨率/音频的单一秒费率。
+                pricing=PerSecondMatrix(
+                    rates={"grok-imagine-video": {("", None): 0.050}},
+                    default_model="grok-imagine-video",
+                    dimensions="flat",
+                    currency="USD",
+                ),
             ),
         },
     ),
@@ -403,22 +591,26 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="GPT-5.5",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                pricing=_openai_text_pricing("gpt-5.5", 5.00, 30.00),
             ),
             "gpt-5.4": ModelInfo(
                 display_name="GPT-5.4",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                pricing=_openai_text_pricing("gpt-5.4", 2.50, 15.00),
             ),
             "gpt-5.4-mini": ModelInfo(
                 display_name="GPT-5.4 Mini",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
                 default=True,
+                pricing=_openai_text_pricing("gpt-5.4-mini", 0.75, 4.50),
             ),
             "gpt-5.4-nano": ModelInfo(
                 display_name="GPT-5.4 Nano",
                 media_type="text",
                 capabilities=["text_generation", "structured_output", "vision"],
+                pricing=_openai_text_pricing("gpt-5.4-nano", 0.20, 1.25),
             ),
             # --- image ---
             "gpt-image-2": ModelInfo(
@@ -427,18 +619,84 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 capabilities=["text_to_image", "image_to_image"],
                 default=True,
                 resolutions=["512px", "1K", "2K"],
+                pricing=_openai_image_pricing(
+                    "gpt-image-2",
+                    {
+                        "image_in": 8.0,
+                        "image_cached_in": 2.0,
+                        "image_out": 30.0,
+                        "text_in": 5.0,
+                        "text_cached_in": 1.25,
+                        "text_out": 0.0,
+                    },
+                    {
+                        ("low", "1024x1024"): 0.006,
+                        ("low", "1024x1792"): 0.012,
+                        ("low", "1792x1024"): 0.012,
+                        ("medium", "1024x1024"): 0.053,
+                        ("medium", "1024x1792"): 0.106,
+                        ("medium", "1792x1024"): 0.106,
+                        ("high", "1024x1024"): 0.211,
+                        ("high", "1024x1792"): 0.317,
+                        ("high", "1792x1024"): 0.317,
+                    },
+                ),
             ),
             "gpt-image-1.5": ModelInfo(
                 display_name="GPT Image 1.5",
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
                 resolutions=["512px", "1K", "2K"],
+                pricing=_openai_image_pricing(
+                    "gpt-image-1.5",
+                    {
+                        "image_in": 8.0,
+                        "image_cached_in": 2.0,
+                        "image_out": 32.0,
+                        "text_in": 5.0,
+                        "text_cached_in": 1.25,
+                        "text_out": 10.0,
+                    },
+                    {
+                        ("low", "1024x1024"): 0.009,
+                        ("low", "1024x1792"): 0.013,
+                        ("low", "1792x1024"): 0.013,
+                        ("medium", "1024x1024"): 0.034,
+                        ("medium", "1024x1792"): 0.051,
+                        ("medium", "1792x1024"): 0.051,
+                        ("high", "1024x1024"): 0.133,
+                        ("high", "1024x1792"): 0.200,
+                        ("high", "1792x1024"): 0.200,
+                    },
+                ),
             ),
             "gpt-image-1-mini": ModelInfo(
                 display_name="GPT Image 1 Mini",
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
                 resolutions=["512px", "1K", "2K"],
+                pricing=_openai_image_pricing(
+                    "gpt-image-1-mini",
+                    {
+                        "image_in": 2.5,
+                        "image_cached_in": 0.25,
+                        "image_out": 8.0,
+                        "text_in": 2.0,
+                        "text_cached_in": 0.20,
+                        "text_out": 0.0,
+                    },
+                    {
+                        ("low", "1024x1024"): 0.005,
+                        ("low", "1024x1792"): 0.008,
+                        ("low", "1792x1024"): 0.008,
+                        ("medium", "1024x1024"): 0.011,
+                        ("medium", "1024x1792"): 0.017,
+                        ("medium", "1792x1024"): 0.017,
+                        ("high", "1024x1024"): 0.036,
+                        ("high", "1024x1792"): 0.054,
+                        ("high", "1792x1024"): 0.054,
+                    },
+                ),
             ),
             # --- video ---
             "sora-2": ModelInfo(
@@ -449,6 +707,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 supported_durations=[4, 8, 12],
                 resolutions=["720p", "1080p"],
                 max_reference_images=1,
+                pricing=_sora_video_pricing("sora-2", {"720p": 0.10}),
             ),
             "sora-2-pro": ModelInfo(
                 display_name="Sora 2 Pro",
@@ -457,6 +716,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 supported_durations=[4, 8, 12],
                 resolutions=["720p", "1080p"],
                 max_reference_images=1,
+                pricing=_sora_video_pricing("sora-2-pro", {"720p": 0.30, "1024p": 0.50, "1080p": 0.70}),
             ),
         },
     ),
@@ -468,18 +728,21 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
         secret_keys=["api_key"],
         models={
             # --- image ---
+            # Vidu 计费以响应 credits 为准，费率逻辑在 lib.vidu_shared；此处统一委托标记。
             "viduq2": ModelInfo(
                 display_name="Vidu Q2 Image",
                 media_type="image",
                 capabilities=["text_to_image", "image_to_image"],
                 default=True,
                 resolutions=["1080p", "2K", "4K"],
+                pricing=ViduDelegate(),
             ),
             "viduq1": ModelInfo(
                 display_name="Vidu Q1 Image",
                 media_type="image",
                 capabilities=["image_to_image"],
                 resolutions=["1080p"],
+                pricing=ViduDelegate(),
             ),
             # --- video ---
             "viduq3-turbo": ModelInfo(
@@ -490,6 +753,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 supported_durations=list(range(1, 17)),
                 resolutions=["540p", "720p", "1080p"],
                 max_reference_images=7,
+                pricing=ViduDelegate(),
             ),
             "viduq3-pro": ModelInfo(
                 display_name="Vidu Q3 Pro",
@@ -498,6 +762,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 supported_durations=list(range(1, 17)),
                 resolutions=["540p", "720p", "1080p"],
                 max_reference_images=7,
+                pricing=ViduDelegate(),
             ),
             "viduq3": ModelInfo(
                 display_name="Vidu Q3 (Reference)",
@@ -506,6 +771,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 supported_durations=list(range(3, 17)),
                 resolutions=["540p", "720p", "1080p"],
                 max_reference_images=7,
+                pricing=ViduDelegate(),
             ),
             "vidu2.0": ModelInfo(
                 display_name="Vidu 2.0",
@@ -514,7 +780,19 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 supported_durations=[4, 8],
                 resolutions=["360p", "720p", "1080p"],
                 max_reference_images=7,
+                pricing=ViduDelegate(),
             ),
         },
     ),
 }
+
+
+def default_model_for_provider(provider_id: str, media_type: str) -> str | None:
+    """返回该 provider 在 ``PROVIDER_REGISTRY`` 中指定 media_type 的默认 model_id；无则 None。"""
+    meta = PROVIDER_REGISTRY.get(provider_id)
+    if meta is None:
+        return None
+    for model_id, model_info in meta.models.items():
+        if model_info.media_type == media_type and model_info.default:
+            return model_id
+    return None

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lib.app_data_dir import app_data_dir
-from lib.config.registry import PROVIDER_REGISTRY
+from lib.config.registry import PROVIDER_REGISTRY, default_model_for_provider
 from lib.config.service import (
     _DEFAULT_IMAGE_BACKEND,
     _DEFAULT_TEXT_BACKEND,
@@ -83,17 +83,6 @@ def _split_pair(raw: object) -> tuple[str, str] | None:
     return provider, model
 
 
-def _default_model_for_provider(provider_id: str, media_type: str) -> str | None:
-    """返回该 provider 在 ``PROVIDER_REGISTRY`` 中指定 media_type 的默认 model_id；无则 None。"""
-    meta = PROVIDER_REGISTRY.get(provider_id)
-    if meta is None:
-        return None
-    for model_id, model_info in meta.models.items():
-        if model_info.media_type == media_type and model_info.default:
-            return model_id
-    return None
-
-
 def _parse_project_provider(raw: object, media_type: str) -> tuple[str, str] | None:
     """解析 project.json 的 provider 字段，兼容裸 provider 覆盖。
 
@@ -110,7 +99,7 @@ def _parse_project_provider(raw: object, media_type: str) -> tuple[str, str] | N
         # 裸 provider，或带尾斜杠缺 model 的脏值（如 "openai/"）→ 取该 provider 默认 model
         provider = raw.strip().rstrip("/").strip()
         if provider:
-            model = _default_model_for_provider(provider, media_type)
+            model = default_model_for_provider(provider, media_type)
             if model is not None:
                 return provider, model
     return None
@@ -139,7 +128,7 @@ def _payload_model_or_default(raw_model: object, provider_id: str, media_type: s
     返回 None，由调用方回退 project/global。"""
     if isinstance(raw_model, str) and raw_model.strip():
         return raw_model.strip()
-    return _default_model_for_provider(provider_id, media_type)
+    return default_model_for_provider(provider_id, media_type)
 
 
 _TEXT_TASK_SETTING_KEYS: dict[TextTaskType, str] = {

--- a/lib/config/service.py
+++ b/lib/config/service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import Literal
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -123,10 +123,11 @@ class ConfigService:
             else:
                 status = "unconfigured"
                 missing = list(meta.required_keys)
-            # 排除 pricing：其费率含 tuple 键（如 (resolution, audio)），asdict 后非 JSON 可序列化，
-            # 且供应商状态/前端响应不消费定价。保留其余字段供 ModelInfoResponse 构造。
+            # 用 __dict__ 浅拷贝并排除 pricing：pricing 费率含 tuple 键（如 (resolution, audio)），
+            # 非 JSON 可序列化且响应不消费；asdict 会递归转换 pricing 后又被丢弃，纯属浪费。其余字段
+            # 均为标量或标量容器，浅拷贝后交 ModelInfoResponse（Pydantic 构造时复制）即可。
             models_dict = {
-                mid: {k: v for k, v in asdict(mi).items() if k != "pricing"} for mid, mi in meta.models.items()
+                mid: {k: v for k, v in mi.__dict__.items() if k != "pricing"} for mid, mi in meta.models.items()
             }
             statuses.append(
                 ProviderStatus(

--- a/lib/config/service.py
+++ b/lib/config/service.py
@@ -123,7 +123,11 @@ class ConfigService:
             else:
                 status = "unconfigured"
                 missing = list(meta.required_keys)
-            models_dict = {mid: asdict(mi) for mid, mi in meta.models.items()}
+            # 排除 pricing：其费率含 tuple 键（如 (resolution, audio)），asdict 后非 JSON 可序列化，
+            # 且供应商状态/前端响应不消费定价。保留其余字段供 ModelInfoResponse 构造。
+            models_dict = {
+                mid: {k: v for k, v in asdict(mi).items() if k != "pricing"} for mid, mi in meta.models.items()
+            }
             statuses.append(
                 ProviderStatus(
                     name=name,

--- a/lib/config/service.py
+++ b/lib/config/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Literal
 
@@ -123,11 +124,12 @@ class ConfigService:
             else:
                 status = "unconfigured"
                 missing = list(meta.required_keys)
-            # 用 __dict__ 浅拷贝并排除 pricing：pricing 费率含 tuple 键（如 (resolution, audio)），
-            # 非 JSON 可序列化且响应不消费；asdict 会递归转换 pricing 后又被丢弃，纯属浪费。其余字段
-            # 均为标量或标量容器，浅拷贝后交 ModelInfoResponse（Pydantic 构造时复制）即可。
+            # 先按 __dict__ 排除 pricing（其费率含 tuple 键，非 JSON 可序列化且响应不消费；
+            # 用 __dict__ 而非 asdict 以免递归转换 pricing 后又被丢弃），再 deepcopy 其余可变容器
+            # 字段（list/dict），避免返回值与全局 PROVIDER_REGISTRY 共享引用被调用方意外改写。
             models_dict = {
-                mid: {k: v for k, v in mi.__dict__.items() if k != "pricing"} for mid, mi in meta.models.items()
+                mid: deepcopy({k: v for k, v in mi.__dict__.items() if k != "pricing"})
+                for mid, mi in meta.models.items()
             }
             statuses.append(
                 ProviderStatus(

--- a/lib/cost_calculator.py
+++ b/lib/cost_calculator.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from lib.custom_provider import is_custom_provider
 from lib.pricing.lookup import lookup_pricing
 from lib.pricing.strategies import PricingParams, calculate_pricing
-from lib.pricing.types import PerTokenVideo
+from lib.pricing.types import PerSecondMatrix, PerTokenVideo
 from lib.providers import CallType
 
 
@@ -68,6 +68,10 @@ class CostCalculator:
             return 0.0, "USD"
 
         pricing = lookup_pricing(provider, model, call_type)
+        # 按秒计费的视频：单次实时调用无/0 时长时按默认 8 秒计（历史行为）。参考模式聚合走
+        # estimate_reference_video_cost，传真实累计时长（可为 0），不经此默认。
+        if isinstance(pricing, PerSecondMatrix):
+            duration_seconds = duration_seconds or 8
         params = PricingParams(
             call_type=call_type,
             model=model,

--- a/lib/cost_calculator.py
+++ b/lib/cost_calculator.py
@@ -1,470 +1,28 @@
-"""
-费用计算器
+"""费用计算器。
 
-基于 docs/视频&图片生成费用表.md 中的费用规则，计算图片和视频生成的费用。
-支持按模型区分费用，以便不同模型的历史数据能正确计费。
+统一入口 ``calculate_cost`` 按 ``lookup_pricing`` 查出模型定价声明（``ModelInfo.pricing``，
+单一真相源），再交 ``lib.pricing.strategies`` 按定价形状 ``kind`` 派发计算。新增内置模型只需在
+其 ``ModelInfo.pricing`` 写一条声明并复用已有 kind，无需改动本文件。
 """
 
 from __future__ import annotations
 
 from lib.custom_provider import is_custom_provider
-from lib.openai_shared import OPENAI_IMAGE_SIZE_MAP
-from lib.providers import PROVIDER_ANTHROPIC, PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI, CallType
-
-# fork: Vidu provider — 单独 import 块以避免与上游聚合 import 冲突
-# isort: off
-from lib.providers import PROVIDER_VIDU
-from lib.vidu_shared import calculate_vidu_cost as _vidu_cost
-
-# isort: on
+from lib.pricing.lookup import lookup_pricing
+from lib.pricing.strategies import PricingParams, calculate_pricing
+from lib.pricing.types import PerTokenVideo
+from lib.providers import CallType
 
 
 class CostCalculator:
-    """费用计算器"""
+    """费用计算器：按定价声明的 ``kind`` 派发，不含 provider 分支。"""
 
-    # 图片费用（美元/张），按模型和分辨率区分
-    IMAGE_COST = {
-        "gemini-3-pro-image-preview": {
-            "1K": 0.134,
-            "2K": 0.134,
-            "4K": 0.24,
-        },
-        "gemini-3.1-flash-image-preview": {
-            "512PX": 0.045,
-            "1K": 0.067,
-            "2K": 0.101,
-            "4K": 0.151,
-        },
-    }
-
+    # 外部依赖常量（lib.gemini_shared / lib.video_backends.gemini 直接读取）。
     DEFAULT_IMAGE_MODEL = "gemini-3.1-flash-image-preview"
-
-    # 视频费用（美元/秒），按模型区分
-    # 格式：model -> {(resolution, generate_audio): cost_per_second}
-    VIDEO_COST = {
-        "veo-3.1-generate-001": {
-            ("720p", True): 0.40,
-            ("720p", False): 0.20,
-            ("1080p", True): 0.40,
-            ("1080p", False): 0.20,
-            ("4k", True): 0.60,
-            ("4k", False): 0.40,
-        },
-        "veo-3.1-fast-generate-001": {
-            ("720p", True): 0.15,
-            ("720p", False): 0.10,
-            ("1080p", True): 0.15,
-            ("1080p", False): 0.10,
-            ("4k", True): 0.35,
-            ("4k", False): 0.30,
-        },
-        # 历史兼容：preview 模型已下线，保留费率供历史计费使用
-        "veo-3.1-generate-preview": {
-            ("720p", True): 0.40,
-            ("720p", False): 0.20,
-            ("1080p", True): 0.40,
-            ("1080p", False): 0.20,
-            ("4k", True): 0.60,
-            ("4k", False): 0.40,
-        },
-        "veo-3.1-fast-generate-preview": {
-            ("720p", True): 0.15,
-            ("720p", False): 0.10,
-            ("1080p", True): 0.15,
-            ("1080p", False): 0.10,
-            ("4k", True): 0.35,
-            ("4k", False): 0.30,
-        },
-        "veo-3.1-lite-generate-preview": {
-            ("720p", True): 0.05,
-            ("720p", False): 0.05,
-            ("1080p", True): 0.08,
-            ("1080p", False): 0.08,
-        },
-    }
-
-    SELECTABLE_VIDEO_MODELS = [
-        "veo-3.1-generate-preview",
-        "veo-3.1-fast-generate-preview",
-        "veo-3.1-lite-generate-preview",
-    ]
-
     DEFAULT_VIDEO_MODEL = "veo-3.1-lite-generate-preview"
 
-    # Ark 视频费用（元/百万 token），按 (service_tier, generate_audio) 查表
-    ARK_VIDEO_COST = {
-        "doubao-seedance-1-5-pro-251215": {
-            ("default", True): 16.00,
-            ("default", False): 8.00,
-            ("flex", True): 8.00,
-            ("flex", False): 4.00,
-        },
-        "doubao-seedance-2-0-260128": {
-            ("default", True): 46.00,
-            ("default", False): 46.00,
-        },
-        "doubao-seedance-2-0-fast-260128": {
-            ("default", True): 37.00,
-            ("default", False): 37.00,
-        },
-    }
-
-    DEFAULT_ARK_VIDEO_MODEL = "doubao-seedance-1-5-pro-251215"
-
-    # Grok 视频费用（美元/秒），不区分分辨率
-    # 来源：docs/grok-docs/models.md — $0.050/sec
-    GROK_VIDEO_COST = {
-        "grok-imagine-video": 0.050,
-    }
-
-    DEFAULT_GROK_MODEL = "grok-imagine-video"
-
-    # Ark 图片费用（元/张）
-    ARK_IMAGE_COST = {
-        "doubao-seedream-5-0-260128": 0.22,
-        "doubao-seedream-5-0-lite-260128": 0.22,
-        "doubao-seedream-4-5-251128": 0.25,
-        "doubao-seedream-4-0-250828": 0.20,
-    }
-    DEFAULT_ARK_IMAGE_MODEL = "doubao-seedream-5-0-lite-260128"
-
-    # Grok 图片费用（美元/张）
-    GROK_IMAGE_COST = {
-        "grok-imagine-image": 0.02,
-        "grok-imagine-image-pro": 0.07,
-    }
-    DEFAULT_GROK_IMAGE_MODEL = "grok-imagine-image"
-
-    # Gemini 文本 token 费率（美元/百万 token），Standard paid tier、prompt ≤200K 区间
-    # 来源：docs/google-genai-docs/pricing.md
-    GEMINI_TEXT_COST = {
-        "gemini-3.1-pro-preview": {"input": 2.00, "output": 12.00},
-        "gemini-3-flash-preview": {"input": 0.50, "output": 3.00},
-        "gemini-3.1-flash-lite-preview": {"input": 0.25, "output": 1.50},
-    }
-
-    # Ark 文本 token 费率（元/百万 token），在线推理、输入 [0, 32k] 区间
-    # 来源：docs/ark-docs/火山方舟费用参考.md
-    # 注：doubao-seed-1-8 输出价格分段（[0,0.2]k: 2.00；超出: 8.00），此处按基础价 2.00 计
-    ARK_TEXT_COST = {
-        "doubao-seed-2-0-pro-260215": {"input": 3.20, "output": 16.00},
-        "doubao-seed-2-0-lite-260215": {"input": 0.60, "output": 3.60},
-        "doubao-seed-2-0-mini-260215": {"input": 0.20, "output": 2.00},
-        "doubao-seed-1-8-251228": {"input": 0.80, "output": 2.00},
-    }
-
-    # Grok 文本 token 费率（美元/百万 token）
-    # 来源：docs/grok-docs/models.md
-    GROK_TEXT_COST = {
-        "grok-4-1-fast-reasoning": {"input": 0.20, "output": 0.50},
-        "grok-4-1-fast-non-reasoning": {"input": 0.20, "output": 0.50},
-        "grok-4.20-0309-reasoning": {"input": 2.00, "output": 6.00},
-        "grok-4.20-0309-non-reasoning": {"input": 2.00, "output": 6.00},
-    }
-
-    # OpenAI 文本 token 费率（美元/百万 token）
-    OPENAI_TEXT_COST = {
-        "gpt-5.5": {"input": 5.00, "output": 30.00},
-        "gpt-5.4": {"input": 2.50, "output": 15.00},
-        "gpt-5.4-mini": {"input": 0.75, "output": 4.50},
-        "gpt-5.4-nano": {"input": 0.20, "output": 1.25},
-    }
-
-    # Claude Agent SDK / Anthropic 文本 token 费率（美元/百万 token）。
-    # 助手主链路优先使用 SDK result.total_cost_usd；这里作为只拿到 token 时的兜底。
-    ANTHROPIC_TEXT_COST = {
-        "claude-sonnet-4": {"input": 3.00, "output": 15.00},
-        "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
-        "claude-sonnet-4.5": {"input": 3.00, "output": 15.00},
-        "claude-sonnet-4-5": {"input": 3.00, "output": 15.00},
-        "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
-        "claude-haiku-4-5": {"input": 1.00, "output": 5.00},
-        "claude-haiku-4-5-20251001": {"input": 1.00, "output": 5.00},
-        "claude-haiku-4-20250514": {"input": 1.00, "output": 5.00},
-        "claude-opus-4": {"input": 15.00, "output": 75.00},
-        "claude-opus-4-6": {"input": 15.00, "output": 75.00},
-        "claude-opus-4-7": {"input": 15.00, "output": 75.00},
-    }
-    # OpenAI 图片 token 费率（美元/百万 token）— GPT Image 实际计费形式
-    # 来源：https://platform.openai.com/docs/pricing — GPT Image (April 2026)
-    # cached_in 字段当前版本不消费（SDK 不返回 cached token 拆分），保留以备后续切换
-    OPENAI_IMAGE_TOKEN_COST: dict[str, dict[str, float]] = {
-        "gpt-image-2": {
-            "image_in": 8.0,
-            "image_cached_in": 2.0,
-            "image_out": 30.0,
-            "text_in": 5.0,
-            "text_cached_in": 1.25,
-            "text_out": 0.0,
-        },
-        "gpt-image-1.5": {
-            "image_in": 8.0,
-            "image_cached_in": 2.0,
-            "image_out": 32.0,
-            "text_in": 5.0,
-            "text_cached_in": 1.25,
-            "text_out": 10.0,
-        },
-        "gpt-image-1-mini": {
-            "image_in": 2.5,
-            "image_cached_in": 0.25,
-            "image_out": 8.0,
-            "text_in": 2.0,
-            "text_cached_in": 0.20,
-            "text_out": 0.0,
-        },
-    }
-    # OpenAI 图片费用（美元/张），fallback 表：当 SDK 不返回 usage 时按 (quality, size) 二维查表估算
-    # 注：主路径已切换为 OPENAI_IMAGE_TOKEN_COST 的 token-based 计费
-    OPENAI_IMAGE_COST: dict[str, dict[tuple[str, str], float]] = {
-        "gpt-image-2": {
-            ("low", "1024x1024"): 0.006,
-            ("low", "1024x1792"): 0.012,
-            ("low", "1792x1024"): 0.012,
-            ("medium", "1024x1024"): 0.053,
-            ("medium", "1024x1792"): 0.106,
-            ("medium", "1792x1024"): 0.106,
-            ("high", "1024x1024"): 0.211,
-            ("high", "1024x1792"): 0.317,
-            ("high", "1792x1024"): 0.317,
-        },
-        "gpt-image-1.5": {
-            ("low", "1024x1024"): 0.009,
-            ("low", "1024x1792"): 0.013,
-            ("low", "1792x1024"): 0.013,
-            ("medium", "1024x1024"): 0.034,
-            ("medium", "1024x1792"): 0.051,
-            ("medium", "1792x1024"): 0.051,
-            ("high", "1024x1024"): 0.133,
-            ("high", "1024x1792"): 0.200,
-            ("high", "1792x1024"): 0.200,
-        },
-        "gpt-image-1-mini": {
-            ("low", "1024x1024"): 0.005,
-            ("low", "1024x1792"): 0.008,
-            ("low", "1792x1024"): 0.008,
-            ("medium", "1024x1024"): 0.011,
-            ("medium", "1024x1792"): 0.017,
-            ("medium", "1792x1024"): 0.017,
-            ("high", "1024x1024"): 0.036,
-            ("high", "1024x1792"): 0.054,
-            ("high", "1792x1024"): 0.054,
-        },
-    }
-    DEFAULT_OPENAI_IMAGE_MODEL = "gpt-image-2"
-    OPENAI_VIDEO_COST = {
-        "sora-2": {"720p": 0.10},
-        "sora-2-pro": {"720p": 0.30, "1024p": 0.50, "1080p": 0.70},
-    }
-    DEFAULT_OPENAI_VIDEO_MODEL = "sora-2"
-
-    def calculate_ark_video_cost(
-        self,
-        usage_tokens: int,
-        service_tier: str = "default",
-        generate_audio: bool = True,
-        model: str | None = None,
-    ) -> tuple[float, str]:
-        """
-        计算 Ark 视频生成费用。
-
-        Returns:
-            (amount, currency) — 金额和币种 (CNY)
-        """
-        model = model or self.DEFAULT_ARK_VIDEO_MODEL
-        model_costs = self.ARK_VIDEO_COST.get(model, self.ARK_VIDEO_COST[self.DEFAULT_ARK_VIDEO_MODEL])
-        key = (service_tier, generate_audio)
-        price_per_million = model_costs.get(
-            key,
-            model_costs.get(("default", True), 16.00),
-        )
-        amount = usage_tokens / 1_000_000 * price_per_million
-        return amount, "CNY"
-
-    def calculate_image_cost(self, resolution: str = "1K", model: str | None = None) -> float:
-        """
-        计算图片生成费用
-
-        Args:
-            resolution: 图片分辨率 ('512PX', '1K', '2K', '4K')
-            model: 模型名称，默认使用当前默认模型
-
-        Returns:
-            费用（美元）
-        """
-        model = model or self.DEFAULT_IMAGE_MODEL
-        model_costs = self.IMAGE_COST.get(model, self.IMAGE_COST[self.DEFAULT_IMAGE_MODEL])
-        default_cost = model_costs.get("1K") or self.IMAGE_COST[self.DEFAULT_IMAGE_MODEL]["1K"]
-        return model_costs.get(resolution.upper(), default_cost)
-
-    def calculate_video_cost(
-        self,
-        duration_seconds: int,
-        resolution: str = "1080p",
-        generate_audio: bool = True,
-        model: str | None = None,
-    ) -> float:
-        """
-        计算视频生成费用
-
-        Args:
-            duration_seconds: 视频时长（秒）
-            resolution: 分辨率 ('720p', '1080p', '4k')
-            generate_audio: 是否生成音频
-            model: 模型名称，默认使用当前默认模型
-
-        Returns:
-            费用（美元）
-        """
-        model = model or self.DEFAULT_VIDEO_MODEL
-        model_costs = self.VIDEO_COST.get(model, self.VIDEO_COST[self.DEFAULT_VIDEO_MODEL])
-        resolution = resolution.lower()
-        cost_per_second = model_costs.get(
-            (resolution, generate_audio),
-            model_costs.get(("1080p", True)) or self.VIDEO_COST[self.DEFAULT_VIDEO_MODEL][("1080p", True)],
-        )
-        return duration_seconds * cost_per_second
-
-    def calculate_ark_image_cost(
-        self,
-        model: str | None = None,
-        n: int = 1,
-    ) -> tuple[float, str]:
-        """
-        Ark 图片按张计费。
-
-        Returns:
-            (amount, currency) — 金额和币种 (CNY)
-        """
-        model = model or self.DEFAULT_ARK_IMAGE_MODEL
-        per_image = self.ARK_IMAGE_COST.get(model, self.ARK_IMAGE_COST[self.DEFAULT_ARK_IMAGE_MODEL])
-        return per_image * n, "CNY"
-
-    def calculate_grok_image_cost(
-        self,
-        model: str | None = None,
-        n: int = 1,
-    ) -> tuple[float, str]:
-        """
-        Grok 图片按张计费。
-
-        Returns:
-            (amount, currency) — 金额和币种 (USD)
-        """
-        model = model or self.DEFAULT_GROK_IMAGE_MODEL
-        per_image = self.GROK_IMAGE_COST.get(model, self.GROK_IMAGE_COST[self.DEFAULT_GROK_IMAGE_MODEL])
-        return per_image * n, "USD"
-
-    def calculate_grok_video_cost(
-        self,
-        duration_seconds: int,
-        model: str | None = None,
-    ) -> tuple[float, str]:
-        """
-        计算 Grok 视频生成费用。
-
-        Args:
-            duration_seconds: 视频时长（秒）
-            model: 模型名称
-
-        Returns:
-            (amount, currency) — 金额和币种 (USD)
-        """
-        model = model or self.DEFAULT_GROK_MODEL
-        per_second = self.GROK_VIDEO_COST.get(model, self.GROK_VIDEO_COST[self.DEFAULT_GROK_MODEL])
-        return duration_seconds * per_second, "USD"
-
-    def calculate_openai_image_cost(
-        self,
-        *,
-        model: str | None = None,
-        image_input_tokens: int | None = None,
-        image_output_tokens: int | None = None,
-        text_input_tokens: int | None = None,
-        text_output_tokens: int | None = None,
-        quality: str | None = None,
-        resolution: str | None = None,
-        aspect_ratio: str | None = None,
-        size: str | None = None,
-    ) -> tuple[float, str]:
-        """
-        OpenAI 图片费用计算。
-
-        主路径（SDK 返回 usage）：按 image_in/image_out/text_in/text_out token × 对应费率/1M。
-        兜底路径（usage 全 None）：按 (quality, size) 静态表估算；
-            ``size`` 缺失时用 ``OPENAI_IMAGE_SIZE_MAP[(resolution, aspect_ratio)]`` 反查（解决 #401）。
-
-        Returns:
-            (amount, currency) — 金额和币种 (USD)
-        """
-        model = model or self.DEFAULT_OPENAI_IMAGE_MODEL
-        has_usage = any(
-            t is not None for t in (image_input_tokens, image_output_tokens, text_input_tokens, text_output_tokens)
-        )
-        if has_usage:
-            rates = self.OPENAI_IMAGE_TOKEN_COST.get(
-                model, self.OPENAI_IMAGE_TOKEN_COST[self.DEFAULT_OPENAI_IMAGE_MODEL]
-            )
-            amount = (
-                (image_input_tokens or 0) * rates["image_in"]
-                + (image_output_tokens or 0) * rates["image_out"]
-                + (text_input_tokens or 0) * rates["text_in"]
-                + (text_output_tokens or 0) * rates["text_out"]
-            ) / 1_000_000
-            return amount, "USD"
-
-        # fallback：(resolution, aspect_ratio) → "WxH"
-        if size is None and resolution is not None and aspect_ratio is not None:
-            size = OPENAI_IMAGE_SIZE_MAP.get((resolution, aspect_ratio))
-        quality = quality or "medium"
-        size = size or "1024x1024"
-        model_costs = self.OPENAI_IMAGE_COST.get(model, self.OPENAI_IMAGE_COST[self.DEFAULT_OPENAI_IMAGE_MODEL])
-        per_image = model_costs.get(
-            (quality, size), model_costs.get((quality, "1024x1024"), model_costs.get(("medium", "1024x1024"), 0.034))
-        )
-        return per_image, "USD"
-
-    def calculate_openai_video_cost(
-        self,
-        duration_seconds: int,
-        model: str | None = None,
-        resolution: str | None = None,
-    ) -> tuple[float, str]:
-        """
-        计算 OpenAI 视频生成费用（按秒计费）。
-
-        Returns:
-            (amount, currency) — 金额和币种 (USD)
-        """
-        model = model or self.DEFAULT_OPENAI_VIDEO_MODEL
-        resolution = resolution or "720p"
-        model_costs = self.OPENAI_VIDEO_COST.get(model, self.OPENAI_VIDEO_COST[self.DEFAULT_OPENAI_VIDEO_MODEL])
-        per_second = model_costs.get(resolution, model_costs.get("720p", 0.0))
-        return duration_seconds * per_second, "USD"
-
-    _TEXT_COST_TABLES: dict[str, tuple[str, str, str]] = {
-        # provider -> (cost_table_attr, default_model, currency)
-        PROVIDER_ARK: ("ARK_TEXT_COST", "doubao-seed-2-0-lite-260215", "CNY"),
-        PROVIDER_GROK: ("GROK_TEXT_COST", "grok-4-1-fast-reasoning", "USD"),
-        PROVIDER_OPENAI: ("OPENAI_TEXT_COST", "gpt-5.4-mini", "USD"),
-        PROVIDER_ANTHROPIC: ("ANTHROPIC_TEXT_COST", "claude-sonnet-4", "USD"),
-    }
-    _TEXT_COST_DEFAULT = ("GEMINI_TEXT_COST", "gemini-3-flash-preview", "USD")
-
-    def calculate_text_cost(
-        self,
-        input_tokens: int,
-        output_tokens: int,
-        provider: str,
-        model: str | None = None,
-    ) -> tuple[float, str]:
-        """计算文本生成费用。返回 (amount, currency)。"""
-        table_attr, default_model, currency = self._TEXT_COST_TABLES.get(provider, self._TEXT_COST_DEFAULT)
-        cost_table = getattr(self, table_attr)
-        model = model or default_model
-        rates = cost_table.get(model, cost_table.get(default_model, {"input": 0.0, "output": 0.0}))
-        amount = (input_tokens * rates["input"] + output_tokens * rates["output"]) / 1_000_000
-        return amount, currency
+    # Ark 生成视频的 token/s 近似常量（用于参考模式成本估算，实际 token 由生成回调覆盖）。
+    _ARK_TOKENS_PER_SECOND_ESTIMATE = 60_000
 
     def calculate_cost(
         self,
@@ -490,9 +48,9 @@ class CostCalculator:
         custom_price_output: float | None = None,
         custom_currency: str | None = None,
     ) -> tuple[float, str]:
-        """统一费用计算入口。按 (call_type, provider) 显式路由。返回 (amount, currency)。
+        """统一费用计算入口。返回 ``(amount, currency)``。
 
-        自定义供应商的价格信息通过 custom_price_* 参数传入（调用方需预先查询 DB）。
+        自定义供应商的价格信息通过 ``custom_price_*`` 参数传入（调用方需预先查询 DB）。
         """
         if is_custom_provider(provider):
             return self._calculate_custom_cost(
@@ -505,80 +63,30 @@ class CostCalculator:
                 duration_seconds=duration_seconds,
             )
 
-        if call_type == "text":
-            if input_tokens is None:
-                return 0.0, "USD"
-            return self.calculate_text_cost(
-                input_tokens=input_tokens,
-                output_tokens=output_tokens or 0,
-                provider=provider,
-                model=model,
-            )
+        # 文本无 token 数据时无从计费，保留早返回。
+        if call_type == "text" and input_tokens is None:
+            return 0.0, "USD"
 
-        if call_type == "image":
-            if provider == PROVIDER_ARK:
-                return self.calculate_ark_image_cost(model=model)
-            if provider == PROVIDER_GROK:
-                return self.calculate_grok_image_cost(model=model)
-            if provider == PROVIDER_OPENAI:
-                return self.calculate_openai_image_cost(
-                    model=model,
-                    image_input_tokens=image_input_tokens,
-                    image_output_tokens=image_output_tokens,
-                    text_input_tokens=text_input_tokens,
-                    text_output_tokens=text_output_tokens,
-                    quality=quality,
-                    resolution=resolution,
-                    aspect_ratio=aspect_ratio,
-                    size=size,
-                )
-            if provider == PROVIDER_VIDU:
-                return _vidu_cost(
-                    call_type="image",
-                    usage_tokens=usage_tokens,
-                    model=model,
-                    resolution=resolution,
-                )
-            return self.calculate_image_cost(resolution or "1K", model=model), "USD"
-
-        if call_type == "video":
-            if provider == PROVIDER_ARK:
-                return self.calculate_ark_video_cost(
-                    usage_tokens=usage_tokens or 0,
-                    service_tier=service_tier,
-                    generate_audio=generate_audio,
-                    model=model,
-                )
-            if provider == PROVIDER_GROK:
-                return self.calculate_grok_video_cost(
-                    duration_seconds=duration_seconds or 8,
-                    model=model,
-                )
-            if provider == PROVIDER_OPENAI:
-                return self.calculate_openai_video_cost(
-                    duration_seconds=duration_seconds or 8,
-                    model=model,
-                    resolution=resolution or "720p",
-                )
-            if provider == PROVIDER_VIDU:
-                return _vidu_cost(
-                    call_type="video",
-                    usage_tokens=usage_tokens,
-                    model=model,
-                    resolution=resolution,
-                    duration_seconds=duration_seconds,
-                )
-            return self.calculate_video_cost(
-                duration_seconds=duration_seconds or 8,
-                resolution=resolution or "1080p",
-                generate_audio=generate_audio,
-                model=model,
-            ), "USD"
-
-        return 0.0, "USD"
-
-    # Ark 生成视频的 token/s 近似常量（用于参考模式成本估算，实际 token 由生成回调覆盖）
-    _ARK_TOKENS_PER_SECOND_ESTIMATE = 60_000
+        pricing = lookup_pricing(provider, model, call_type)
+        params = PricingParams(
+            call_type=call_type,
+            model=model,
+            resolution=resolution,
+            aspect_ratio=aspect_ratio,
+            duration_seconds=duration_seconds,
+            generate_audio=generate_audio,
+            usage_tokens=usage_tokens,
+            service_tier=service_tier,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            quality=quality,
+            size=size,
+            image_input_tokens=image_input_tokens,
+            image_output_tokens=image_output_tokens,
+            text_input_tokens=text_input_tokens,
+            text_output_tokens=text_output_tokens,
+        )
+        return calculate_pricing(pricing, params)
 
     def estimate_reference_video_cost(
         self,
@@ -592,53 +100,27 @@ class CostCalculator:
     ) -> tuple[float, str]:
         """聚合参考模式一集的视频费用：sum over units of (duration × 单价)。
 
-        - Grok/OpenAI/Gemini：按 duration_seconds 累加后一次性计费
-        - Ark：token-based 计费，按 duration × _ARK_TOKENS_PER_SECOND_ESTIMATE 近似
+        token 计费的视频（Ark）按 duration × ``_ARK_TOKENS_PER_SECOND_ESTIMATE`` 近似换算 token；
+        其余按秒计费的模型直接用累计时长。空列表返回该定价声明自带的币种。
         """
+        pricing = lookup_pricing(provider, model, "video")
         if not unit_durations_seconds:
-            if provider == PROVIDER_ARK:
-                return 0.0, "CNY"
-            if provider == PROVIDER_VIDU:
-                return 0.0, "CNY"
-            return 0.0, "USD"
+            return 0.0, pricing.currency
 
         total_duration = sum(max(0, int(d)) for d in unit_durations_seconds)
-        if provider == PROVIDER_ARK:
-            usage_tokens = total_duration * self._ARK_TOKENS_PER_SECOND_ESTIMATE
-            return self.calculate_ark_video_cost(
-                usage_tokens=usage_tokens,
-                service_tier=service_tier,
-                generate_audio=generate_audio,
-                model=model,
-            )
-        if provider == PROVIDER_GROK:
-            return self.calculate_grok_video_cost(
-                duration_seconds=total_duration,
-                model=model,
-            )
-        if provider == PROVIDER_OPENAI:
-            return self.calculate_openai_video_cost(
-                duration_seconds=total_duration,
-                model=model,
-                resolution=resolution,
-            )
-        if provider == PROVIDER_VIDU:
-            return _vidu_cost(
-                call_type="video",
-                model=model,
-                resolution=resolution,
-                duration_seconds=total_duration,
-            )
-        # Gemini/Veo 默认
-        return (
-            self.calculate_video_cost(
-                duration_seconds=total_duration,
-                resolution=resolution or "1080p",
-                generate_audio=generate_audio,
-                model=model,
-            ),
-            "USD",
+        usage_tokens = (
+            total_duration * self._ARK_TOKENS_PER_SECOND_ESTIMATE if isinstance(pricing, PerTokenVideo) else None
         )
+        params = PricingParams(
+            call_type="video",
+            model=model,
+            resolution=resolution,
+            duration_seconds=total_duration,
+            generate_audio=generate_audio,
+            usage_tokens=usage_tokens,
+            service_tier=service_tier,
+        )
+        return calculate_pricing(pricing, params)
 
     @staticmethod
     def _calculate_custom_cost(

--- a/lib/pricing/__init__.py
+++ b/lib/pricing/__init__.py
@@ -1,0 +1,6 @@
+"""声明式定价：类型（``types``）、按 kind 计算策略（``strategies``）、按 provider/model 查表（``lookup``）。
+
+各模块独立可导入；消费方按需 ``from lib.pricing.lookup import lookup_pricing`` 等显式引用子模块。
+"""
+
+from __future__ import annotations

--- a/lib/pricing/lookup.py
+++ b/lib/pricing/lookup.py
@@ -9,9 +9,14 @@ from __future__ import annotations
 import logging
 
 from lib.pricing.types import PerToken, Pricing, ViduDelegate
-from lib.providers import PROVIDER_ANTHROPIC, PROVIDER_VIDU
+from lib.providers import PROVIDER_ANTHROPIC, PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI, PROVIDER_VIDU
 
 logger = logging.getLogger(__name__)
+
+# 这些 provider 各有独立费率表：未知 model 回落到「该 provider 的默认模型」。其余 provider
+# （gemini-aistudio/vertex、裸 gemini、ark-agent-plan、未知）一律回落 Gemini 家族通用默认费率，
+# 复刻历史「仅 ark/grok/openai 走专属表、其余皆走全局 Gemini 表」的路由。
+_OWN_TABLE_PROVIDERS = frozenset({PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI})
 
 # Anthropic 不在 PROVIDER_REGISTRY（无 ModelInfo 落点），文本定价作为 registry-external 例外。
 # 助手主链路优先使用 SDK 回报的实际费用；此表仅在只拿到 token 数时兜底。费率为美元/百万 token。
@@ -33,22 +38,17 @@ _ANTHROPIC_PRICING = PerToken(
     currency="USD",
 )
 
-# 未知 provider（``gemini`` / ``unknown`` / 缺省）回落到的 Gemini 默认模型，按媒体类型。
-_GEMINI_DEFAULT_MODELS: dict[str, str] = {
-    "text": "gemini-3-flash-preview",
-    "image": "gemini-3.1-flash-image-preview",
-    "video": "veo-3.1-lite-generate-preview",
-}
-
 
 def _gemini_default_pricing_for(media_type: str, model: str | None = None) -> Pricing:
     """非 ark/grok/openai/vidu/anthropic 的 provider（含裸 ``gemini`` / 未知 provider /
-    Agent Plan）统一走 Gemini 家族费率：先按 model 在 aistudio + vertex 命中（复刻历史「全局
-    Gemini 费率表按 model 命中」，覆盖如裸 ``gemini`` + ``veo-3.1-generate-001`` 这类历史调用），
-    未命中再回落该媒体类型的默认模型。"""
+    Agent Plan / gemini-aistudio / gemini-vertex）统一走 Gemini 家族费率：先按 model 在
+    aistudio + vertex 命中（复刻历史「全局 Gemini 费率表按 model 命中」，覆盖如裸 ``gemini`` +
+    ``veo-3.1-generate-001`` 这类历史调用），未命中再回落 aistudio 该媒体类型的默认模型——
+    历史上所有 Gemini 家族 provider 共用同一通用默认（如视频 veo-3.1-lite），故按 aistudio
+    的 ``default=True`` 取，避免按各 provider 自身默认（如 vertex 视频默认是 fast-001）算错价。"""
     # registry 导入放函数内：lib.config 包初始化会拉起 resolver→usage_repo→cost_calculator，
     # 与本模块（被 cost_calculator 导入）构成导入环；延迟到调用时导入即可避开。
-    from lib.config.registry import PROVIDER_REGISTRY
+    from lib.config.registry import PROVIDER_REGISTRY, default_model_for_provider
 
     if model is not None:
         for provider_id in ("gemini-aistudio", "gemini-vertex"):
@@ -57,13 +57,14 @@ def _gemini_default_pricing_for(media_type: str, model: str | None = None) -> Pr
                 return info.pricing
 
     meta = PROVIDER_REGISTRY["gemini-aistudio"]
-    model_id = _GEMINI_DEFAULT_MODELS.get(media_type, "gemini-3-flash-preview")
-    info = meta.models.get(model_id)
-    if info is not None and info.pricing is not None:
-        return info.pricing
-    text_info = meta.models["gemini-3-flash-preview"]
-    assert text_info.pricing is not None
-    return text_info.pricing
+    # 默认模型取 registry 的 default=True 单一真相源，避免与硬编码模型名漂移。
+    for fallback_media in (media_type, "text"):
+        model_id = default_model_for_provider("gemini-aistudio", fallback_media)
+        if model_id is not None:
+            info = meta.models.get(model_id)
+            if info is not None and info.pricing is not None:
+                return info.pricing
+    raise RuntimeError("gemini-aistudio 缺少可用于兜底的默认模型定价声明")
 
 
 def lookup_pricing(provider: str, model: str | None, media_type: str) -> Pricing:
@@ -91,9 +92,12 @@ def lookup_pricing(provider: str, model: str | None, media_type: str) -> Pricing
     elif info is not None and info.pricing is None:
         logger.debug("pricing lookup: provider=%s model=%s 未声明定价，回落到默认模型费率", provider, model)
 
-    default_model = default_model_for_provider(provider, media_type)
-    if default_model is not None:
-        default_info = meta.models.get(default_model)
-        if default_info is not None and default_info.pricing is not None:
-            return default_info.pricing
+    # ark/grok/openai 各有专属费率表 → 未知 model 回落到该 provider 的默认模型；
+    # 其余（gemini 家族等）回落 Gemini 通用默认费率，与历史路由一致。
+    if provider in _OWN_TABLE_PROVIDERS:
+        default_model = default_model_for_provider(provider, media_type)
+        if default_model is not None:
+            default_info = meta.models.get(default_model)
+            if default_info is not None and default_info.pricing is not None:
+                return default_info.pricing
     return _gemini_default_pricing_for(media_type, model)

--- a/lib/pricing/lookup.py
+++ b/lib/pricing/lookup.py
@@ -82,13 +82,24 @@ def lookup_pricing(provider: str, model: str | None, media_type: str) -> Pricing
         return _gemini_default_pricing_for(media_type, model)
 
     info = meta.models.get(model) if model is not None else None
-    if info is not None and info.pricing is not None:
+    # 必须媒体类型匹配才命中：历史按 call_type 分表，模型名只在本模态费率表内查。跨模态的
+    # (model, call_type) 组合（如 video 调用带着图像模型名）应回落到当前媒体类型的默认模型，
+    # 而非按该模型自身的异模态费率计价。
+    if info is not None and info.media_type == media_type and info.pricing is not None:
         return info.pricing
 
-    # 未知 model 名很可能是配置/调用错误，告警；已知 model 但定价为 None（如 Agent Plan 套餐）
-    # 是预期的 Gemini 兜底，降级到 debug 避免噪声。
+    # 未知 model 名很可能是配置/调用错误，告警；媒体类型与调用不符同样告警（将按默认模型计价）；
+    # 已知 model 但定价为 None（如 Agent Plan 套餐）是预期的 Gemini 兜底，降级到 debug 避免噪声。
     if model is not None and info is None:
         logger.warning("pricing lookup: provider=%s model=%s 未在 registry，回落到默认模型费率", provider, model)
+    elif info is not None and info.media_type != media_type:
+        logger.warning(
+            "pricing lookup: provider=%s model=%s 媒体类型(%s)与调用(%s)不符，回落到默认模型费率",
+            provider,
+            model,
+            info.media_type,
+            media_type,
+        )
     elif info is not None and info.pricing is None:
         logger.debug("pricing lookup: provider=%s model=%s 未声明定价，回落到默认模型费率", provider, model)
 

--- a/lib/pricing/lookup.py
+++ b/lib/pricing/lookup.py
@@ -1,0 +1,99 @@
+"""按 ``(provider, model, media_type)`` 查出该调用应使用的 ``Pricing`` 声明。
+
+回落次序复刻历史计费行为：未知 provider / 未知 model / 无声明定价均回落到「该 provider 该
+媒体类型默认模型」的定价，再回落到 Gemini 默认费率——保证迁移前后金额一致。
+"""
+
+from __future__ import annotations
+
+import logging
+
+from lib.pricing.types import PerToken, Pricing, ViduDelegate
+from lib.providers import PROVIDER_ANTHROPIC, PROVIDER_VIDU
+
+logger = logging.getLogger(__name__)
+
+# Anthropic 不在 PROVIDER_REGISTRY（无 ModelInfo 落点），文本定价作为 registry-external 例外。
+# 助手主链路优先使用 SDK 回报的实际费用；此表仅在只拿到 token 数时兜底。费率为美元/百万 token。
+_ANTHROPIC_PRICING = PerToken(
+    rates={
+        "claude-sonnet-4": {"input": 3.00, "output": 15.00},
+        "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
+        "claude-sonnet-4.5": {"input": 3.00, "output": 15.00},
+        "claude-sonnet-4-5": {"input": 3.00, "output": 15.00},
+        "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
+        "claude-haiku-4-5": {"input": 1.00, "output": 5.00},
+        "claude-haiku-4-5-20251001": {"input": 1.00, "output": 5.00},
+        "claude-haiku-4-20250514": {"input": 1.00, "output": 5.00},
+        "claude-opus-4": {"input": 15.00, "output": 75.00},
+        "claude-opus-4-6": {"input": 15.00, "output": 75.00},
+        "claude-opus-4-7": {"input": 15.00, "output": 75.00},
+    },
+    default_model="claude-sonnet-4",
+    currency="USD",
+)
+
+# 未知 provider（``gemini`` / ``unknown`` / 缺省）回落到的 Gemini 默认模型，按媒体类型。
+_GEMINI_DEFAULT_MODELS: dict[str, str] = {
+    "text": "gemini-3-flash-preview",
+    "image": "gemini-3.1-flash-image-preview",
+    "video": "veo-3.1-lite-generate-preview",
+}
+
+
+def _gemini_default_pricing_for(media_type: str, model: str | None = None) -> Pricing:
+    """非 ark/grok/openai/vidu/anthropic 的 provider（含裸 ``gemini`` / 未知 provider /
+    Agent Plan）统一走 Gemini 家族费率：先按 model 在 aistudio + vertex 命中（复刻历史「全局
+    Gemini 费率表按 model 命中」，覆盖如裸 ``gemini`` + ``veo-3.1-generate-001`` 这类历史调用），
+    未命中再回落该媒体类型的默认模型。"""
+    # registry 导入放函数内：lib.config 包初始化会拉起 resolver→usage_repo→cost_calculator，
+    # 与本模块（被 cost_calculator 导入）构成导入环；延迟到调用时导入即可避开。
+    from lib.config.registry import PROVIDER_REGISTRY
+
+    if model is not None:
+        for provider_id in ("gemini-aistudio", "gemini-vertex"):
+            info = PROVIDER_REGISTRY[provider_id].models.get(model)
+            if info is not None and info.pricing is not None and info.media_type == media_type:
+                return info.pricing
+
+    meta = PROVIDER_REGISTRY["gemini-aistudio"]
+    model_id = _GEMINI_DEFAULT_MODELS.get(media_type, "gemini-3-flash-preview")
+    info = meta.models.get(model_id)
+    if info is not None and info.pricing is not None:
+        return info.pricing
+    text_info = meta.models["gemini-3-flash-preview"]
+    assert text_info.pricing is not None
+    return text_info.pricing
+
+
+def lookup_pricing(provider: str, model: str | None, media_type: str) -> Pricing:
+    """返回该调用的定价声明。``media_type`` 即 call_type（``text`` / ``image`` / ``video``）。"""
+    if provider == PROVIDER_ANTHROPIC:
+        return _ANTHROPIC_PRICING
+    if provider == PROVIDER_VIDU:
+        # provider 级判定：不经 model→pricing 回落，确保策略拿到原始 model 透传给 vidu 计费。
+        return ViduDelegate()
+
+    from lib.config.registry import PROVIDER_REGISTRY, default_model_for_provider
+
+    meta = PROVIDER_REGISTRY.get(provider)
+    if meta is None:
+        return _gemini_default_pricing_for(media_type, model)
+
+    info = meta.models.get(model) if model is not None else None
+    if info is not None and info.pricing is not None:
+        return info.pricing
+
+    # 未知 model 名很可能是配置/调用错误，告警；已知 model 但定价为 None（如 Agent Plan 套餐）
+    # 是预期的 Gemini 兜底，降级到 debug 避免噪声。
+    if model is not None and info is None:
+        logger.warning("pricing lookup: provider=%s model=%s 未在 registry，回落到默认模型费率", provider, model)
+    elif info is not None and info.pricing is None:
+        logger.debug("pricing lookup: provider=%s model=%s 未声明定价，回落到默认模型费率", provider, model)
+
+    default_model = default_model_for_provider(provider, media_type)
+    if default_model is not None:
+        default_info = meta.models.get(default_model)
+        if default_info is not None and default_info.pricing is not None:
+            return default_info.pricing
+    return _gemini_default_pricing_for(media_type, model)

--- a/lib/pricing/strategies.py
+++ b/lib/pricing/strategies.py
@@ -60,7 +60,9 @@ def _per_image_flat(pricing: PerImageFlat, params: PricingParams) -> tuple[float
 def _per_image_by_resolution(pricing: PerImageByResolution, params: PricingParams) -> tuple[float, str]:
     model = params.model or pricing.default_model
     model_costs = pricing.rates.get(model, pricing.rates[pricing.default_model])
-    default_cost = model_costs.get("1K") or pricing.rates[pricing.default_model].get("1K", 0.0)
+    # 用 is None 而非 or：模型可显式声明 0.0 免费档，falsy 的 0.0 不应被当作缺失而回落默认费率。
+    own_1k = model_costs.get("1K")
+    default_cost = own_1k if own_1k is not None else pricing.rates[pricing.default_model].get("1K", 0.0)
     resolution = params.resolution or "1K"
     return model_costs.get(resolution.upper(), default_cost) * params.n, pricing.currency
 
@@ -107,7 +109,11 @@ def _per_second_matrix(pricing: PerSecondMatrix, params: PricingParams) -> tuple
     duration = params.duration_seconds if params.duration_seconds is not None else 8
     if pricing.dimensions == "resolution_audio":
         resolution = (params.resolution or "1080p").lower()
-        fallback = model_costs.get(("1080p", True)) or pricing.rates[pricing.default_model].get(("1080p", True), 0.0)
+        # 同上：0.0 免费档不应被 or 当作缺失而回落默认模型费率。
+        own_1080p = model_costs.get(("1080p", True))
+        fallback = (
+            own_1080p if own_1080p is not None else pricing.rates[pricing.default_model].get(("1080p", True), 0.0)
+        )
         per_second = model_costs.get((resolution, params.generate_audio), fallback)
     elif pricing.dimensions == "resolution_only":
         resolution = (params.resolution or "720p").lower()

--- a/lib/pricing/strategies.py
+++ b/lib/pricing/strategies.py
@@ -102,7 +102,9 @@ def _per_image_openai_token(pricing: PerImageOpenAIToken, params: PricingParams)
 def _per_second_matrix(pricing: PerSecondMatrix, params: PricingParams) -> tuple[float, str]:
     model = params.model or pricing.default_model
     model_costs = pricing.rates.get(model, pricing.rates[pricing.default_model])
-    duration = params.duration_seconds or 8
+    # 真实 0 秒（如参考模式全零时长聚合）保持 0；缺省（None）才按 8 秒兜底。
+    # 「无时长视为 8 秒」的默认由 calculate_cost 对单次实时调用施加，不在此处。
+    duration = params.duration_seconds if params.duration_seconds is not None else 8
     if pricing.dimensions == "resolution_audio":
         resolution = (params.resolution or "1080p").lower()
         fallback = model_costs.get(("1080p", True)) or pricing.rates[pricing.default_model][("1080p", True)]

--- a/lib/pricing/strategies.py
+++ b/lib/pricing/strategies.py
@@ -1,0 +1,153 @@
+"""按 ``kind`` 派发的计费策略：每种定价形状一个纯函数，``calculate_pricing`` 统一入口。
+
+策略只读 ``Pricing`` 声明 + ``PricingParams`` 维度，无 HTTP/DB 依赖，可独立单测。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lib.openai_shared import OPENAI_IMAGE_SIZE_MAP
+from lib.pricing.types import (
+    PerImageByResolution,
+    PerImageFlat,
+    PerImageOpenAIToken,
+    PerSecondMatrix,
+    PerToken,
+    PerTokenVideo,
+    Pricing,
+    ViduDelegate,
+)
+from lib.vidu_shared import calculate_vidu_cost
+
+
+@dataclass(frozen=True)
+class PricingParams:
+    """承载一次计费所需的全部维度；各 kind 策略按需取用。"""
+
+    call_type: str
+    model: str | None = None
+    resolution: str | None = None
+    aspect_ratio: str | None = None
+    duration_seconds: int | None = None
+    generate_audio: bool = True
+    usage_tokens: int | None = None
+    service_tier: str = "default"
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    quality: str | None = None
+    size: str | None = None
+    image_input_tokens: int | None = None
+    image_output_tokens: int | None = None
+    text_input_tokens: int | None = None
+    text_output_tokens: int | None = None
+    n: int = 1
+
+
+def _per_token(pricing: PerToken, params: PricingParams) -> tuple[float, str]:
+    model = params.model or pricing.default_model
+    rates = pricing.rates.get(model, pricing.rates.get(pricing.default_model, {"input": 0.0, "output": 0.0}))
+    amount = ((params.input_tokens or 0) * rates["input"] + (params.output_tokens or 0) * rates["output"]) / 1_000_000
+    return amount, pricing.currency
+
+
+def _per_image_flat(pricing: PerImageFlat, params: PricingParams) -> tuple[float, str]:
+    model = params.model or pricing.default_model
+    per_image = pricing.rates.get(model, pricing.rates[pricing.default_model])
+    return per_image * params.n, pricing.currency
+
+
+def _per_image_by_resolution(pricing: PerImageByResolution, params: PricingParams) -> tuple[float, str]:
+    model = params.model or pricing.default_model
+    model_costs = pricing.rates.get(model, pricing.rates[pricing.default_model])
+    default_cost = model_costs.get("1K") or pricing.rates[pricing.default_model]["1K"]
+    resolution = params.resolution or "1K"
+    return model_costs.get(resolution.upper(), default_cost), pricing.currency
+
+
+def _per_image_openai_token(pricing: PerImageOpenAIToken, params: PricingParams) -> tuple[float, str]:
+    model = params.model or pricing.default_model
+    has_usage = any(
+        t is not None
+        for t in (
+            params.image_input_tokens,
+            params.image_output_tokens,
+            params.text_input_tokens,
+            params.text_output_tokens,
+        )
+    )
+    if has_usage:
+        rates = pricing.token_rates.get(model, pricing.token_rates[pricing.default_model])
+        amount = (
+            (params.image_input_tokens or 0) * rates["image_in"]
+            + (params.image_output_tokens or 0) * rates["image_out"]
+            + (params.text_input_tokens or 0) * rates["text_in"]
+            + (params.text_output_tokens or 0) * rates["text_out"]
+        ) / 1_000_000
+        return amount, pricing.currency
+
+    size = params.size
+    if size is None and params.resolution is not None and params.aspect_ratio is not None:
+        size = OPENAI_IMAGE_SIZE_MAP.get((params.resolution, params.aspect_ratio))
+    quality = params.quality or "medium"
+    size = size or "1024x1024"
+    model_costs = pricing.fallback_rates.get(model, pricing.fallback_rates[pricing.default_model])
+    per_image = model_costs.get(
+        (quality, size),
+        model_costs.get((quality, "1024x1024"), model_costs.get(("medium", "1024x1024"), 0.034)),
+    )
+    return per_image, pricing.currency
+
+
+def _per_second_matrix(pricing: PerSecondMatrix, params: PricingParams) -> tuple[float, str]:
+    model = params.model or pricing.default_model
+    model_costs = pricing.rates.get(model, pricing.rates[pricing.default_model])
+    duration = params.duration_seconds or 8
+    if pricing.dimensions == "resolution_audio":
+        resolution = (params.resolution or "1080p").lower()
+        fallback = model_costs.get(("1080p", True)) or pricing.rates[pricing.default_model][("1080p", True)]
+        per_second = model_costs.get((resolution, params.generate_audio), fallback)
+    elif pricing.dimensions == "resolution_only":
+        resolution = params.resolution or "720p"
+        per_second = model_costs.get((resolution, None), model_costs.get(("720p", None), 0.0))
+    else:  # flat
+        per_second = model_costs[("", None)]
+    return duration * per_second, pricing.currency
+
+
+def _per_token_video(pricing: PerTokenVideo, params: PricingParams) -> tuple[float, str]:
+    model = params.model or pricing.default_model
+    model_costs = pricing.rates.get(model, pricing.rates[pricing.default_model])
+    key = (params.service_tier, params.generate_audio)
+    price_per_million = model_costs.get(key, model_costs.get(("default", True), 16.00))
+    amount = (params.usage_tokens or 0) / 1_000_000 * price_per_million
+    return amount, pricing.currency
+
+
+def _vidu(pricing: ViduDelegate, params: PricingParams) -> tuple[float, str]:
+    return calculate_vidu_cost(
+        call_type=params.call_type,
+        usage_tokens=params.usage_tokens,
+        model=params.model,
+        resolution=params.resolution,
+        duration_seconds=params.duration_seconds,
+    )
+
+
+def calculate_pricing(pricing: Pricing, params: PricingParams) -> tuple[float, str]:
+    """按 ``pricing`` 的运行时类型派发到对应策略，返回 ``(金额, 币种)``。"""
+    if isinstance(pricing, PerToken):
+        return _per_token(pricing, params)
+    if isinstance(pricing, PerImageFlat):
+        return _per_image_flat(pricing, params)
+    if isinstance(pricing, PerImageByResolution):
+        return _per_image_by_resolution(pricing, params)
+    if isinstance(pricing, PerImageOpenAIToken):
+        return _per_image_openai_token(pricing, params)
+    if isinstance(pricing, PerSecondMatrix):
+        return _per_second_matrix(pricing, params)
+    if isinstance(pricing, PerTokenVideo):
+        return _per_token_video(pricing, params)
+    # 仅剩 ViduDelegate；若日后新增 kind 未在上方分派，此处类型收窄会让 _vidu 入参报错，
+    # 起到穷尽性检查的作用。
+    return _vidu(pricing, params)

--- a/lib/pricing/strategies.py
+++ b/lib/pricing/strategies.py
@@ -60,9 +60,9 @@ def _per_image_flat(pricing: PerImageFlat, params: PricingParams) -> tuple[float
 def _per_image_by_resolution(pricing: PerImageByResolution, params: PricingParams) -> tuple[float, str]:
     model = params.model or pricing.default_model
     model_costs = pricing.rates.get(model, pricing.rates[pricing.default_model])
-    default_cost = model_costs.get("1K") or pricing.rates[pricing.default_model]["1K"]
+    default_cost = model_costs.get("1K") or pricing.rates[pricing.default_model].get("1K", 0.0)
     resolution = params.resolution or "1K"
-    return model_costs.get(resolution.upper(), default_cost), pricing.currency
+    return model_costs.get(resolution.upper(), default_cost) * params.n, pricing.currency
 
 
 def _per_image_openai_token(pricing: PerImageOpenAIToken, params: PricingParams) -> tuple[float, str]:
@@ -96,7 +96,7 @@ def _per_image_openai_token(pricing: PerImageOpenAIToken, params: PricingParams)
         (quality, size),
         model_costs.get((quality, "1024x1024"), model_costs.get(("medium", "1024x1024"), 0.034)),
     )
-    return per_image, pricing.currency
+    return per_image * params.n, pricing.currency
 
 
 def _per_second_matrix(pricing: PerSecondMatrix, params: PricingParams) -> tuple[float, str]:
@@ -107,13 +107,13 @@ def _per_second_matrix(pricing: PerSecondMatrix, params: PricingParams) -> tuple
     duration = params.duration_seconds if params.duration_seconds is not None else 8
     if pricing.dimensions == "resolution_audio":
         resolution = (params.resolution or "1080p").lower()
-        fallback = model_costs.get(("1080p", True)) or pricing.rates[pricing.default_model][("1080p", True)]
+        fallback = model_costs.get(("1080p", True)) or pricing.rates[pricing.default_model].get(("1080p", True), 0.0)
         per_second = model_costs.get((resolution, params.generate_audio), fallback)
     elif pricing.dimensions == "resolution_only":
-        resolution = params.resolution or "720p"
+        resolution = (params.resolution or "720p").lower()
         per_second = model_costs.get((resolution, None), model_costs.get(("720p", None), 0.0))
     else:  # flat
-        per_second = model_costs[("", None)]
+        per_second = model_costs.get(("", None), 0.0)
     return duration * per_second, pricing.currency
 
 

--- a/lib/pricing/types.py
+++ b/lib/pricing/types.py
@@ -1,0 +1,116 @@
+"""定价数据类型：每种计费形状一个 frozen dataclass，``kind`` 字段为判别标签。
+
+定价数据声明在 ``PROVIDER_REGISTRY`` 每个模型的 ``ModelInfo.pricing`` 上（单一真相源），
+计算策略在 ``lib.pricing.strategies`` 按 ``kind`` 派发。两者职责分层：数据声明式、逻辑可单测。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class PerToken:
+    """按 token 计费（文本，或任何 input/output token 双费率形态）。
+
+    ``rates`` 形如 ``{model: {"input": 每百万输入价, "output": 每百万输出价}}``；
+    未知 model 回落到 ``default_model``，再回落到零费率。
+    """
+
+    rates: dict[str, dict[str, float]]
+    default_model: str
+    currency: str
+    kind: Literal["per_token"] = "per_token"
+
+
+@dataclass(frozen=True)
+class PerImageFlat:
+    """按张计费，单价与分辨率无关。``rates`` 形如 ``{model: 每张价}``。"""
+
+    rates: dict[str, float]
+    default_model: str
+    currency: str
+    kind: Literal["per_image_flat"] = "per_image_flat"
+
+
+@dataclass(frozen=True)
+class PerImageByResolution:
+    """按张计费，单价随分辨率档位变化。``rates`` 形如 ``{model: {分辨率: 每张价}}``。
+
+    分辨率键以大写形态存储（``1K`` / ``2K`` / ``4K`` / ``512PX``），查表前对入参 ``.upper()``。
+    """
+
+    rates: dict[str, dict[str, float]]
+    default_model: str
+    currency: str
+    kind: Literal["per_image_by_resolution"] = "per_image_by_resolution"
+
+
+@dataclass(frozen=True)
+class PerImageOpenAIToken:
+    """OpenAI 图片计费：SDK 返回 usage 时按 token 计，否则按 (quality, size) 静态表兜底。
+
+    - ``token_rates`` 形如 ``{model: {"image_in","image_out","text_in","text_out", ...}}``（每百万）。
+    - ``fallback_rates`` 形如 ``{model: {(quality, size): 每张价}}``，size 缺失时按宽高比反查。
+    """
+
+    token_rates: dict[str, dict[str, float]]
+    fallback_rates: dict[str, dict[tuple[str, str], float]]
+    default_model: str
+    currency: str
+    kind: Literal["per_image_openai_token"] = "per_image_openai_token"
+
+
+@dataclass(frozen=True)
+class PerSecondMatrix:
+    """视频按秒计费，单价由 ``dimensions`` 控制的维度组合查表得出。
+
+    ``dimensions``：
+    - ``resolution_audio`` — 键 ``(分辨率小写, 是否生成音频)``，缺失回落 ``("1080p", True)``。
+    - ``resolution_only`` — 键 ``(分辨率, None)``，缺失回落 ``("720p", None)`` 再回落 0.0。
+    - ``flat`` — 单一费率，键 ``("", None)``，与分辨率/音频无关。
+    """
+
+    rates: dict[str, dict[tuple[str, bool | None], float]]
+    default_model: str
+    dimensions: Literal["resolution_audio", "resolution_only", "flat"]
+    currency: str
+    kind: Literal["per_second_matrix"] = "per_second_matrix"
+
+
+@dataclass(frozen=True)
+class PerTokenVideo:
+    """视频按 token 计费（按 ``(service_tier, 是否生成音频)`` 查每百万 token 价）。
+
+    ``rates`` 形如 ``{model: {(service_tier, generate_audio): 每百万 token 价}}``；
+    缺失键回落 ``("default", True)``，再回落 16.00。
+    """
+
+    rates: dict[str, dict[tuple[str, bool], float]]
+    default_model: str
+    currency: str = "CNY"
+    kind: Literal["per_token_video"] = "per_token_video"
+
+
+@dataclass(frozen=True)
+class ViduDelegate:
+    """委托标记：实际费率在 ``lib.vidu_shared.calculate_vidu_cost``（依赖响应 credits）。
+
+    本类型不携带费率，仅作为 union 成员承载币种，使空列表等分支可统一读 ``currency``，
+    无需对 provider 名做硬编码判断。
+    """
+
+    currency: str = "CNY"
+    kind: Literal["vidu_delegate"] = "vidu_delegate"
+
+
+Pricing = (
+    PerToken
+    | PerImageFlat
+    | PerImageByResolution
+    | PerImageOpenAIToken
+    | PerSecondMatrix
+    | PerTokenVideo
+    | ViduDelegate
+)

--- a/tests/lib/test_cost_calculator_reference_video.py
+++ b/tests/lib/test_cost_calculator_reference_video.py
@@ -54,3 +54,14 @@ def test_estimate_empty_units_returns_zero(calc: CostCalculator):
     )
     assert amount == 0.0
     assert currency == "USD"
+
+
+def test_estimate_all_zero_durations_returns_zero(calc: CostCalculator):
+    # 累计时长为 0（非空全零列表）按秒计费应得 0，不应被默认 8 秒兜底成非零。
+    amount, currency = calc.estimate_reference_video_cost(
+        unit_durations_seconds=[0, 0],
+        provider=PROVIDER_GROK,
+        model="grok-imagine-video",
+    )
+    assert amount == pytest.approx(0.0)
+    assert currency == "USD"

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -32,6 +32,18 @@ async def test_get_all_providers_status_empty(config_service: ConfigService):
         assert s.status == "unconfigured"
 
 
+async def test_provider_status_models_isolated_from_registry(config_service: ConfigService):
+    # models 返回值须与全局 PROVIDER_REGISTRY 隔离：改写其可变容器不应污染注册表。
+    from lib.config.registry import PROVIDER_REGISTRY
+
+    statuses = await config_service.get_all_providers_status()
+    target = next(s for s in statuses if s.models)
+    mid, model_dict = next(iter(target.models.items()))
+    before = list(PROVIDER_REGISTRY[target.name].models[mid].capabilities)
+    model_dict["capabilities"].append("__mutation_probe__")
+    assert PROVIDER_REGISTRY[target.name].models[mid].capabilities == before
+
+
 async def test_provider_becomes_ready(config_service: ConfigService, session: AsyncSession):
     # 新逻辑：status 由凭证表中的活跃凭证决定，而不是 ProviderConfig 表
     cred_repo = CredentialRepository(session)

--- a/tests/test_cost_calculator.py
+++ b/tests/test_cost_calculator.py
@@ -1,44 +1,71 @@
+"""统一入口 ``calculate_cost`` 的费用对拍：金额数值与币种逐项保持迁移前不变。
+
+底层 per-shape 方法已删除，断言改指向公共入口 ``calculate_cost(provider, call_type, ...)``，
+用各模型所属的规范 provider id（veo ``-001`` 在 gemini-vertex、``-preview`` / ``-lite`` 在
+gemini-aistudio）。仅在底层暴露的形态（如按张 n、纯策略 fallback）见 ``test_pricing_strategies``。
+"""
+
 import pytest
 
 from lib.cost_calculator import CostCalculator, cost_calculator
 from lib.providers import PROVIDER_ANTHROPIC
 
 
-class TestCostCalculator:
+class TestImageCost:
     def test_calculate_image_cost_known_and_default(self):
-        calculator = CostCalculator()
+        calc = CostCalculator()
         # 默认模型 (gemini-3.1-flash-image-preview)
-        assert calculator.calculate_image_cost("1k") == 0.067
-        assert calculator.calculate_image_cost("2K") == 0.101
-        assert calculator.calculate_image_cost("4K") == 0.151
-        assert calculator.calculate_image_cost("unknown") == 0.067
+        assert calc.calculate_cost("gemini-aistudio", "image", resolution="1k") == (0.067, "USD")
+        assert calc.calculate_cost("gemini-aistudio", "image", resolution="2K") == (0.101, "USD")
+        assert calc.calculate_cost("gemini-aistudio", "image", resolution="4K") == (0.151, "USD")
+        assert calc.calculate_cost("gemini-aistudio", "image", resolution="unknown") == (0.067, "USD")
         # 指定旧模型 (gemini-3-pro-image-preview)
-        assert calculator.calculate_image_cost("1k", model="gemini-3-pro-image-preview") == 0.134
-        assert calculator.calculate_image_cost("2K", model="gemini-3-pro-image-preview") == 0.134
+        assert calc.calculate_cost("gemini-aistudio", "image", resolution="1k", model="gemini-3-pro-image-preview") == (
+            0.134,
+            "USD",
+        )
+        assert calc.calculate_cost("gemini-aistudio", "image", resolution="2K", model="gemini-3-pro-image-preview") == (
+            0.134,
+            "USD",
+        )
 
+
+class TestVideoCost:
     def test_calculate_video_cost_known_and_default(self):
-        calculator = CostCalculator()
+        calc = CostCalculator()
+
+        def video(duration, resolution, audio, provider="gemini-aistudio", model=None):
+            amount, _ = calc.calculate_cost(
+                provider,
+                "video",
+                duration_seconds=duration,
+                resolution=resolution,
+                generate_audio=audio,
+                model=model,
+            )
+            return amount
+
         # 默认模型 (veo-3.1-lite-generate-preview)
-        assert calculator.calculate_video_cost(8, "1080p", True) == pytest.approx(0.64)
-        assert calculator.calculate_video_cost(8, "1080p", False) == pytest.approx(0.64)
-        assert calculator.calculate_video_cost(8, "720p", True) == pytest.approx(0.40)
-        assert calculator.calculate_video_cost(8, "720p", False) == pytest.approx(0.40)
+        assert video(8, "1080p", True) == pytest.approx(0.64)
+        assert video(8, "1080p", False) == pytest.approx(0.64)
+        assert video(8, "720p", True) == pytest.approx(0.40)
+        assert video(8, "720p", False) == pytest.approx(0.40)
         # Lite 不支持 4K，未知分辨率回退到 1080p+audio 费率 (0.08)
-        assert calculator.calculate_video_cost(5, "unknown", True) == pytest.approx(0.40)
-        # Fast 模型 (veo-3.1-fast-generate-001)
+        assert video(5, "unknown", True) == pytest.approx(0.40)
+        # Fast 模型 (veo-3.1-fast-generate-001，在 gemini-vertex)
         fast = "veo-3.1-fast-generate-001"
-        assert calculator.calculate_video_cost(8, "1080p", True, model=fast) == pytest.approx(1.2)
-        assert calculator.calculate_video_cost(8, "1080p", False, model=fast) == pytest.approx(0.8)
-        assert calculator.calculate_video_cost(6, "4k", True, model=fast) == pytest.approx(2.1)
-        assert calculator.calculate_video_cost(6, "4k", False, model=fast) == pytest.approx(1.8)
+        assert video(8, "1080p", True, provider="gemini-vertex", model=fast) == pytest.approx(1.2)
+        assert video(8, "1080p", False, provider="gemini-vertex", model=fast) == pytest.approx(0.8)
+        assert video(6, "4k", True, provider="gemini-vertex", model=fast) == pytest.approx(2.1)
+        assert video(6, "4k", False, provider="gemini-vertex", model=fast) == pytest.approx(1.8)
         # Fast 模型未知分辨率应回退到自身的 1080p+audio 费率 (0.15)，而非标准模型的 0.40
-        assert calculator.calculate_video_cost(5, "unknown", True, model=fast) == pytest.approx(0.75)
-        # 历史兼容：preview 模型费率与 001 相同
+        assert video(5, "unknown", True, provider="gemini-vertex", model=fast) == pytest.approx(0.75)
+        # 历史兼容：preview 模型费率与 001 相同（preview 在 gemini-aistudio）
         preview = "veo-3.1-generate-preview"
-        assert calculator.calculate_video_cost(8, "1080p", True, model=preview) == pytest.approx(3.2)
-        assert calculator.calculate_video_cost(8, "1080p", False, model=preview) == pytest.approx(1.6)
+        assert video(8, "1080p", True, model=preview) == pytest.approx(3.2)
+        assert video(8, "1080p", False, model=preview) == pytest.approx(1.6)
         fast_preview = "veo-3.1-fast-generate-preview"
-        assert calculator.calculate_video_cost(8, "1080p", True, model=fast_preview) == pytest.approx(1.2)
+        assert video(8, "1080p", True, model=fast_preview) == pytest.approx(1.2)
 
     def test_singleton_instance(self):
         assert isinstance(cost_calculator, CostCalculator)
@@ -46,43 +73,44 @@ class TestCostCalculator:
 
 class TestAnthropicTextCost:
     def test_calculate_anthropic_text_cost(self):
-        amount, currency = cost_calculator.calculate_text_cost(
+        amount, currency = cost_calculator.calculate_cost(
+            PROVIDER_ANTHROPIC,
+            "text",
             input_tokens=100_000,
             output_tokens=50_000,
-            provider=PROVIDER_ANTHROPIC,
             model="claude-sonnet-4",
         )
-
         assert currency == "USD"
         assert amount == pytest.approx(1.05)
 
     def test_unknown_anthropic_model_uses_default(self):
-        amount, currency = cost_calculator.calculate_text_cost(
+        amount, currency = cost_calculator.calculate_cost(
+            PROVIDER_ANTHROPIC,
+            "text",
             input_tokens=100_000,
             output_tokens=50_000,
-            provider=PROVIDER_ANTHROPIC,
             model="unknown-claude",
         )
-
         assert currency == "USD"
         assert amount == pytest.approx(1.05)
 
     def test_calculate_anthropic_haiku_text_cost(self):
-        amount, currency = cost_calculator.calculate_text_cost(
+        amount, currency = cost_calculator.calculate_cost(
+            PROVIDER_ANTHROPIC,
+            "text",
             input_tokens=100_000,
             output_tokens=50_000,
-            provider=PROVIDER_ANTHROPIC,
             model="claude-haiku-4-5",
         )
-
         assert currency == "USD"
         assert amount == pytest.approx(0.35)
 
 
-class TestArkCost:
+class TestArkVideoCost:
     def test_online_with_audio(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_ark_video_cost(
+        amount, currency = cost_calculator.calculate_cost(
+            "ark",
+            "video",
             usage_tokens=246840,
             service_tier="default",
             generate_audio=True,
@@ -92,59 +120,44 @@ class TestArkCost:
         assert amount == pytest.approx(3.9494, rel=1e-3)
 
     def test_online_no_audio(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_ark_video_cost(
-            usage_tokens=246840,
-            service_tier="default",
-            generate_audio=False,
+        amount, currency = cost_calculator.calculate_cost(
+            "ark", "video", usage_tokens=246840, service_tier="default", generate_audio=False
         )
         assert currency == "CNY"
         assert amount == pytest.approx(1.9747, rel=1e-3)
 
     def test_flex_with_audio(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_ark_video_cost(
-            usage_tokens=246840,
-            service_tier="flex",
-            generate_audio=True,
+        amount, currency = cost_calculator.calculate_cost(
+            "ark", "video", usage_tokens=246840, service_tier="flex", generate_audio=True
         )
         assert currency == "CNY"
         assert amount == pytest.approx(1.9747, rel=1e-3)
 
     def test_flex_no_audio(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_ark_video_cost(
-            usage_tokens=246840,
-            service_tier="flex",
-            generate_audio=False,
+        amount, currency = cost_calculator.calculate_cost(
+            "ark", "video", usage_tokens=246840, service_tier="flex", generate_audio=False
         )
         assert currency == "CNY"
         assert amount == pytest.approx(0.9874, rel=1e-3)
 
     def test_zero_tokens(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_ark_video_cost(
-            usage_tokens=0,
-            service_tier="default",
-            generate_audio=True,
+        amount, currency = cost_calculator.calculate_cost(
+            "ark", "video", usage_tokens=0, service_tier="default", generate_audio=True
         )
         assert amount == pytest.approx(0.0)
         assert currency == "CNY"
 
     def test_unknown_model_uses_default(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_ark_video_cost(
-            usage_tokens=1_000_000,
-            service_tier="default",
-            generate_audio=True,
-            model="unknown-model",
+        amount, currency = cost_calculator.calculate_cost(
+            "ark", "video", usage_tokens=1_000_000, service_tier="default", generate_audio=True, model="unknown-model"
         )
         assert currency == "CNY"
         assert amount == pytest.approx(16.0)
 
     def test_seedance_2_cost(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_ark_video_cost(
+        amount, currency = cost_calculator.calculate_cost(
+            "ark",
+            "video",
             usage_tokens=1_000_000,
             service_tier="default",
             generate_audio=True,
@@ -154,8 +167,9 @@ class TestArkCost:
         assert amount == pytest.approx(46.00)
 
     def test_seedance_2_cost_no_audio_same_price(self):
-        calculator = CostCalculator()
-        amount, _ = calculator.calculate_ark_video_cost(
+        amount, _ = cost_calculator.calculate_cost(
+            "ark",
+            "video",
             usage_tokens=1_000_000,
             service_tier="default",
             generate_audio=False,
@@ -164,8 +178,9 @@ class TestArkCost:
         assert amount == pytest.approx(46.00)
 
     def test_seedance_2_fast_cost(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_ark_video_cost(
+        amount, currency = cost_calculator.calculate_cost(
+            "ark",
+            "video",
             usage_tokens=1_000_000,
             service_tier="default",
             generate_audio=True,
@@ -175,224 +190,168 @@ class TestArkCost:
         assert amount == pytest.approx(37.00)
 
 
-class TestGrokCost:
+class TestGrokVideoCost:
     def test_default_model_per_second(self):
-        calculator = CostCalculator()
-        cost, currency = calculator.calculate_grok_video_cost(
-            duration_seconds=10,
-            model="grok-imagine-video",
+        cost, currency = cost_calculator.calculate_cost(
+            "grok", "video", duration_seconds=10, model="grok-imagine-video"
         )
         assert cost == pytest.approx(0.50)
         assert currency == "USD"
 
     def test_short_video(self):
-        calculator = CostCalculator()
-        cost, currency = calculator.calculate_grok_video_cost(
-            duration_seconds=1,
-            model="grok-imagine-video",
-        )
+        cost, currency = cost_calculator.calculate_cost("grok", "video", duration_seconds=1, model="grok-imagine-video")
         assert cost == pytest.approx(0.050)
         assert currency == "USD"
 
     def test_max_duration(self):
-        calculator = CostCalculator()
-        cost, _ = calculator.calculate_grok_video_cost(
-            duration_seconds=15,
-            model="grok-imagine-video",
-        )
+        cost, _ = cost_calculator.calculate_cost("grok", "video", duration_seconds=15, model="grok-imagine-video")
         assert cost == pytest.approx(0.75)
 
-    def test_zero_duration(self):
-        calculator = CostCalculator()
-        cost, _ = calculator.calculate_grok_video_cost(
-            duration_seconds=0,
-            model="grok-imagine-video",
-        )
-        assert cost == pytest.approx(0.0)
+    def test_zero_duration_defaults_to_8s(self):
+        # 统一入口把 0/缺省时长视为默认 8 秒（与历史 calculate_cost 行为一致）：8 × 0.050 = 0.40
+        cost, _ = cost_calculator.calculate_cost("grok", "video", duration_seconds=0, model="grok-imagine-video")
+        assert cost == pytest.approx(0.40)
 
     def test_unknown_model_uses_default(self):
-        calculator = CostCalculator()
-        cost, _ = calculator.calculate_grok_video_cost(
-            duration_seconds=10,
-            model="unknown-grok-model",
-        )
+        cost, _ = cost_calculator.calculate_cost("grok", "video", duration_seconds=10, model="unknown-grok-model")
         assert cost == pytest.approx(0.50)
 
 
 class TestArkImageCost:
     def test_ark_image_cost_default(self):
-        cost, currency = cost_calculator.calculate_ark_image_cost()
+        cost, currency = cost_calculator.calculate_cost("ark", "image")
         assert currency == "CNY"
         assert cost == pytest.approx(0.22)
 
     def test_ark_image_cost_by_model(self):
-        cost, _ = cost_calculator.calculate_ark_image_cost(model="doubao-seedream-4-5-251128")
+        cost, _ = cost_calculator.calculate_cost("ark", "image", model="doubao-seedream-4-5-251128")
         assert cost == pytest.approx(0.25)
 
-    def test_ark_image_cost_n_images(self):
-        cost, _ = cost_calculator.calculate_ark_image_cost(n=3)
-        assert cost == pytest.approx(0.22 * 3)
-
     def test_ark_image_cost_unknown_model(self):
-        cost, currency = cost_calculator.calculate_ark_image_cost(model="unknown-model")
+        cost, currency = cost_calculator.calculate_cost("ark", "image", model="unknown-model")
         assert currency == "CNY"
         assert cost == pytest.approx(0.22)
 
 
 class TestGrokImageCost:
     def test_grok_image_cost_default(self):
-        cost, currency = cost_calculator.calculate_grok_image_cost()
+        cost, currency = cost_calculator.calculate_cost("grok", "image")
         assert cost == pytest.approx(0.02)
         assert currency == "USD"
 
     def test_grok_image_cost_pro(self):
-        cost, currency = cost_calculator.calculate_grok_image_cost(model="grok-imagine-image-pro")
+        cost, currency = cost_calculator.calculate_cost("grok", "image", model="grok-imagine-image-pro")
         assert cost == pytest.approx(0.07)
         assert currency == "USD"
 
-    def test_grok_image_cost_n_images(self):
-        cost, _ = cost_calculator.calculate_grok_image_cost(n=4)
-        assert cost == pytest.approx(0.02 * 4)
-
     def test_grok_image_cost_unknown_model(self):
-        cost, currency = cost_calculator.calculate_grok_image_cost(model="unknown-model")
+        cost, currency = cost_calculator.calculate_cost("grok", "image", model="unknown-model")
         assert cost == pytest.approx(0.02)
         assert currency == "USD"
 
 
 class TestOpenAICost:
     def test_openai_text_cost(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_text_cost(
-            input_tokens=1_000_000,
-            output_tokens=1_000_000,
-            provider="openai",
-            model="gpt-5.4-mini",
+        amount, currency = cost_calculator.calculate_cost(
+            "openai", "text", input_tokens=1_000_000, output_tokens=1_000_000, model="gpt-5.4-mini"
         )
         assert currency == "USD"
         assert amount == pytest.approx(0.75 + 4.50)
 
     def test_openai_text_cost_default_model(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_text_cost(
-            input_tokens=1_000_000,
-            output_tokens=0,
-            provider="openai",
-        )
+        amount, currency = cost_calculator.calculate_cost("openai", "text", input_tokens=1_000_000, output_tokens=0)
         assert currency == "USD"
         assert amount == pytest.approx(0.75)
 
     def test_openai_image_cost_square(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_openai_image_cost(model="gpt-image-1.5", quality="medium")
+        amount, currency = cost_calculator.calculate_cost("openai", "image", model="gpt-image-1.5", quality="medium")
         assert currency == "USD"
         assert amount == pytest.approx(0.034)  # 默认 1024x1024
 
     def test_openai_image_cost_portrait(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_openai_image_cost(
-            model="gpt-image-1.5",
-            quality="medium",
-            size="1024x1792",
+        amount, currency = cost_calculator.calculate_cost(
+            "openai", "image", model="gpt-image-1.5", quality="medium", size="1024x1792"
         )
         assert currency == "USD"
         assert amount == pytest.approx(0.051)
 
     def test_openai_image_cost_landscape(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_openai_image_cost(
-            model="gpt-image-1.5",
-            quality="high",
-            size="1792x1024",
+        amount, currency = cost_calculator.calculate_cost(
+            "openai", "image", model="gpt-image-1.5", quality="high", size="1792x1024"
         )
         assert currency == "USD"
         assert amount == pytest.approx(0.200)
 
     def test_openai_image_cost_low(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_openai_image_cost(model="gpt-image-1-mini", quality="low")
+        amount, currency = cost_calculator.calculate_cost("openai", "image", model="gpt-image-1-mini", quality="low")
         assert currency == "USD"
         assert amount == pytest.approx(0.005)
 
     def test_openai_image_cost_mini_portrait(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_openai_image_cost(
-            model="gpt-image-1-mini",
-            quality="medium",
-            size="1024x1792",
+        amount, currency = cost_calculator.calculate_cost(
+            "openai", "image", model="gpt-image-1-mini", quality="medium", size="1024x1792"
         )
         assert currency == "USD"
         assert amount == pytest.approx(0.017)
 
     def test_openai_video_cost(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_openai_video_cost(duration_seconds=8, model="sora-2")
+        amount, currency = cost_calculator.calculate_cost("openai", "video", duration_seconds=8, model="sora-2")
         assert currency == "USD"
         assert amount == pytest.approx(0.80)
 
     def test_openai_video_cost_pro(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_openai_video_cost(
-            duration_seconds=4, model="sora-2-pro", resolution="1080p"
+        amount, currency = cost_calculator.calculate_cost(
+            "openai", "video", duration_seconds=4, model="sora-2-pro", resolution="1080p"
         )
         assert currency == "USD"
         assert amount == pytest.approx(2.80)
 
     def test_openai_text_cost_5_5(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_text_cost(
-            input_tokens=1_000_000,
-            output_tokens=1_000_000,
-            provider="openai",
-            model="gpt-5.5",
+        amount, currency = cost_calculator.calculate_cost(
+            "openai", "text", input_tokens=1_000_000, output_tokens=1_000_000, model="gpt-5.5"
         )
         assert currency == "USD"
         assert amount == pytest.approx(5.00 + 30.00)
 
     def test_openai_image_cost_gpt_image_2_high_square(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_openai_image_cost(model="gpt-image-2", quality="high")
+        amount, currency = cost_calculator.calculate_cost("openai", "image", model="gpt-image-2", quality="high")
         assert currency == "USD"
         assert amount == pytest.approx(0.211)
 
     def test_openai_image_cost_gpt_image_2_high_portrait(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_openai_image_cost(
-            model="gpt-image-2",
-            quality="high",
-            size="1024x1792",
+        amount, currency = cost_calculator.calculate_cost(
+            "openai", "image", model="gpt-image-2", quality="high", size="1024x1792"
         )
         assert currency == "USD"
         assert amount == pytest.approx(0.317)
 
     def test_openai_image_cost_default_uses_gpt_image_2(self):
-        calculator = CostCalculator()
-        assert calculator.DEFAULT_OPENAI_IMAGE_MODEL == "gpt-image-2"
-        amount, currency = calculator.calculate_openai_image_cost(quality="medium")
+        # 不传 model → 回落 OpenAI 图片默认模型 gpt-image-2，medium 1024x1024 = 0.053
+        amount, currency = cost_calculator.calculate_cost("openai", "image", quality="medium")
         assert currency == "USD"
         assert amount == pytest.approx(0.053)
 
     def test_unified_entry_openai(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_cost("openai", "text", input_tokens=500_000, output_tokens=100_000)
+        amount, _ = cost_calculator.calculate_cost("openai", "text", input_tokens=500_000, output_tokens=100_000)
         assert amount == pytest.approx(0.375 + 0.45)
-        amount, currency = calculator.calculate_cost("openai", "image", model="gpt-image-1.5", quality="high")
+        amount, _ = cost_calculator.calculate_cost("openai", "image", model="gpt-image-1.5", quality="high")
         assert amount == pytest.approx(0.133)  # 默认 1024x1024
-        amount, currency = calculator.calculate_cost(
+        amount, _ = cost_calculator.calculate_cost(
             "openai", "image", model="gpt-image-1.5", quality="high", size="1024x1792"
         )
         assert amount == pytest.approx(0.200)
-        amount, currency = calculator.calculate_cost("openai", "video", duration_seconds=12, model="sora-2")
+        amount, _ = cost_calculator.calculate_cost("openai", "video", duration_seconds=12, model="sora-2")
         assert amount == pytest.approx(1.20)
 
 
 class TestOpenAIImageTokenCost:
-    """token-based 主路径与 fallback 兜底（#401 回归）。"""
+    """token-based 主路径与 (quality, size) 兜底（aspect_ratio 反查 size 的回归）。"""
 
     def test_token_cost_gpt_image_2(self):
-        calculator = CostCalculator()
         # image_in × 8 + image_out × 30 + text_in × 5 + text_out × 0
-        amount, currency = calculator.calculate_openai_image_cost(
+        amount, currency = cost_calculator.calculate_cost(
+            "openai",
+            "image",
             model="gpt-image-2",
             image_input_tokens=10_000,
             image_output_tokens=2_000,
@@ -403,18 +362,17 @@ class TestOpenAIImageTokenCost:
         assert amount == pytest.approx((10_000 * 8 + 2_000 * 30 + 500 * 5 + 100 * 0) / 1_000_000)
 
     def test_token_cost_gpt_image_1_5_text_output(self):
-        """gpt-image-1.5 text output 费率 $10/M，与 gpt-image-2 不同。"""
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_openai_image_cost(
-            model="gpt-image-1.5",
-            text_output_tokens=200,
+        # gpt-image-1.5 text output 费率 $10/M，与 gpt-image-2 不同。
+        amount, currency = cost_calculator.calculate_cost(
+            "openai", "image", model="gpt-image-1.5", text_output_tokens=200
         )
         assert currency == "USD"
         assert amount == pytest.approx(200 * 10 / 1_000_000)
 
     def test_token_cost_gpt_image_1_mini(self):
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_openai_image_cost(
+        amount, currency = cost_calculator.calculate_cost(
+            "openai",
+            "image",
             model="gpt-image-1-mini",
             image_input_tokens=5_000,
             image_output_tokens=1_000,
@@ -424,9 +382,10 @@ class TestOpenAIImageTokenCost:
         assert amount == pytest.approx((5_000 * 2.5 + 1_000 * 8 + 300 * 2) / 1_000_000)
 
     def test_zero_tokens_still_uses_token_path(self):
-        """所有 token 至少有一个非 None 时走 token 主路径，即使全为 0。"""
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_openai_image_cost(
+        # 所有 token 至少有一个非 None 时走 token 主路径，即使全为 0。
+        amount, _ = cost_calculator.calculate_cost(
+            "openai",
+            "image",
             model="gpt-image-2",
             image_input_tokens=0,
             image_output_tokens=0,
@@ -436,33 +395,29 @@ class TestOpenAIImageTokenCost:
         assert amount == pytest.approx(0.0)
 
     def test_fallback_resolves_size_from_resolution_aspect(self):
-        """所有 token 入参 None 时走 fallback；resolution+aspect_ratio 反查 _SIZE_MAP。"""
-        calculator = CostCalculator()
-        amount, _ = calculator.calculate_openai_image_cost(
-            model="gpt-image-2",
-            quality="high",
-            resolution="1K",
-            aspect_ratio="9:16",
+        # 所有 token 入参 None 时走 fallback；resolution+aspect_ratio 反查 size map。
+        amount, _ = cost_calculator.calculate_cost(
+            "openai", "image", model="gpt-image-2", quality="high", resolution="1K", aspect_ratio="9:16"
         )
         # 1K + 9:16 → 1024x1792 → high 0.317
         assert amount == pytest.approx(0.317)
 
-    def test_fallback_401_regression_aspect_dependent(self):
-        """#401 回归：相同 quality 不同 aspect_ratio 应得到不同金额（修复前一律按 1024x1024 0.211）。"""
-        calculator = CostCalculator()
+    def test_fallback_aspect_dependent(self):
+        # 相同 quality 不同 aspect_ratio 应得到不同金额（修复前一律按 1024x1024 0.211）。
         common = {"model": "gpt-image-2", "quality": "high", "resolution": "1K"}
-        amount_1_1, _ = calculator.calculate_openai_image_cost(aspect_ratio="1:1", **common)
-        amount_9_16, _ = calculator.calculate_openai_image_cost(aspect_ratio="9:16", **common)
-        amount_16_9, _ = calculator.calculate_openai_image_cost(aspect_ratio="16:9", **common)
+        amount_1_1, _ = cost_calculator.calculate_cost("openai", "image", aspect_ratio="1:1", **common)
+        amount_9_16, _ = cost_calculator.calculate_cost("openai", "image", aspect_ratio="9:16", **common)
+        amount_16_9, _ = cost_calculator.calculate_cost("openai", "image", aspect_ratio="16:9", **common)
         assert amount_1_1 == pytest.approx(0.211)  # 1024x1024
         assert amount_9_16 == pytest.approx(0.317)  # 1024x1792
         assert amount_16_9 == pytest.approx(0.317)  # 1792x1024
         assert amount_1_1 != amount_9_16, "aspect 1:1 和 9:16 必须算出不同金额"
 
     def test_fallback_explicit_size_overrides_resolution_aspect(self):
-        """size kwarg 优先于 resolution+aspect_ratio。"""
-        calculator = CostCalculator()
-        amount, _ = calculator.calculate_openai_image_cost(
+        # size kwarg 优先于 resolution+aspect_ratio。
+        amount, _ = cost_calculator.calculate_cost(
+            "openai",
+            "image",
             model="gpt-image-2",
             quality="medium",
             resolution="1K",
@@ -472,9 +427,7 @@ class TestOpenAIImageTokenCost:
         assert amount == pytest.approx(0.106)  # gpt-image-2 medium 1024x1792
 
     def test_unified_entry_token_path(self):
-        """calculate_cost 入口透传 token 字段到 token 主路径。"""
-        calculator = CostCalculator()
-        amount, currency = calculator.calculate_cost(
+        amount, currency = cost_calculator.calculate_cost(
             "openai",
             "image",
             model="gpt-image-2",
@@ -485,12 +438,10 @@ class TestOpenAIImageTokenCost:
         assert amount == pytest.approx((2_200 * 30 + 350 * 5) / 1_000_000)
 
     def test_unified_entry_fallback_with_aspect_ratio(self):
-        """calculate_cost 不带 token 时透传 resolution + aspect_ratio 走 fallback；#401 在 unified 入口也修了。"""
-        calculator = CostCalculator()
-        amount_1_1, _ = calculator.calculate_cost(
+        amount_1_1, _ = cost_calculator.calculate_cost(
             "openai", "image", model="gpt-image-2", quality="high", resolution="1K", aspect_ratio="1:1"
         )
-        amount_9_16, _ = calculator.calculate_cost(
+        amount_9_16, _ = cost_calculator.calculate_cost(
             "openai", "image", model="gpt-image-2", quality="high", resolution="1K", aspect_ratio="9:16"
         )
         assert amount_1_1 == pytest.approx(0.211)

--- a/tests/test_cost_calculator_text.py
+++ b/tests/test_cost_calculator_text.py
@@ -24,5 +24,8 @@ class TestTextCost:
         assert amount == (1000 * 0.20 + 500 * 0.50) / 1_000_000
 
     def test_unknown_provider_defaults_to_gemini(self):
+        # unknown / 裸 gemini 同走 _gemini_default_pricing_for("text") → gemini-3-flash-preview，
+        # 金额须与 test_gemini_cost 一致，才证明确实回落到了 Gemini 费率而非任意 USD provider。
         amount, currency = self._text("unknown")
         assert currency == "USD"
+        assert amount == (1000 * 0.50 + 500 * 3.00) / 1_000_000

--- a/tests/test_cost_calculator_text.py
+++ b/tests/test_cost_calculator_text.py
@@ -5,21 +5,24 @@ class TestTextCost:
     def setup_method(self):
         self.calc = CostCalculator()
 
+    def _text(self, provider: str):
+        return self.calc.calculate_cost(provider, "text", input_tokens=1000, output_tokens=500)
+
     def test_gemini_cost(self):
-        amount, currency = self.calc.calculate_text_cost(1000, 500, "gemini")
+        amount, currency = self._text("gemini")
         assert currency == "USD"
         assert amount == (1000 * 0.50 + 500 * 3.00) / 1_000_000
 
     def test_ark_cost(self):
-        amount, currency = self.calc.calculate_text_cost(1000, 500, "ark")
+        amount, currency = self._text("ark")
         assert currency == "CNY"
         assert amount == (1000 * 0.60 + 500 * 3.60) / 1_000_000
 
     def test_grok_cost(self):
-        amount, currency = self.calc.calculate_text_cost(1000, 500, "grok")
+        amount, currency = self._text("grok")
         assert currency == "USD"
         assert amount == (1000 * 0.20 + 500 * 0.50) / 1_000_000
 
     def test_unknown_provider_defaults_to_gemini(self):
-        amount, currency = self.calc.calculate_text_cost(1000, 500, "unknown")
+        amount, currency = self._text("unknown")
         assert currency == "USD"

--- a/tests/test_pricing_lookup.py
+++ b/tests/test_pricing_lookup.py
@@ -121,6 +121,22 @@ class TestGeminiFamilyVideoFallback:
         assert pricing.rates["veo-3.1-generate-001"][("1080p", True)] == 0.40
 
 
+class TestCrossModalModelMismatch:
+    """模型名与 call_type 媒体类型不符时，应按当前媒体类型默认模型计价，而非该模型自身的异模态费率
+    （复刻历史「按 call_type 分表」：模型名只在本模态费率表内查）。"""
+
+    def test_openai_image_model_on_video_call_falls_back_to_video_default(self):
+        # video 调用带图像模型名 → 不返回图片定价，回落 openai 视频默认（Sora，PerSecondMatrix）。
+        pricing = lookup_pricing("openai", "gpt-image-2", "video")
+        assert isinstance(pricing, PerSecondMatrix)
+
+    def test_gemini_image_model_on_video_call_falls_back_to_video_default(self):
+        # 非 OWN_TABLE 的 gemini 家族同理 → 回落 Gemini 视频通用默认（lite）。
+        pricing = lookup_pricing("gemini-aistudio", "gemini-3.1-flash-image-preview", "video")
+        assert isinstance(pricing, PerSecondMatrix)
+        assert "veo-3.1-lite-generate-preview" in pricing.rates
+
+
 class TestHiddenModelStillResolves:
     def test_hidden_does_not_block_lookup(self, monkeypatch):
         # 成本快照边角：模型被下线（hidden=True）后，入队遗留任务仍需算价。

--- a/tests/test_pricing_lookup.py
+++ b/tests/test_pricing_lookup.py
@@ -1,0 +1,109 @@
+"""``lookup_pricing`` 的回落路径：registry 命中 / 未知 provider / Anthropic 例外 / vidu 委托 /
+未知 model 回落默认 + 告警 / Agent Plan 无定价回落 Gemini / hidden 模型仍可命中。"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+
+import pytest
+
+from lib.config.registry import PROVIDER_REGISTRY
+from lib.pricing.lookup import lookup_pricing
+from lib.pricing.types import (
+    PerImageByResolution,
+    PerImageOpenAIToken,
+    PerSecondMatrix,
+    PerToken,
+    PerTokenVideo,
+    ViduDelegate,
+)
+
+
+class TestRegistryHit:
+    def test_gemini_image_flash(self):
+        pricing = lookup_pricing("gemini-aistudio", "gemini-3.1-flash-image-preview", "image")
+        assert isinstance(pricing, PerImageByResolution)
+        assert pricing.rates["gemini-3.1-flash-image-preview"]["1K"] == 0.067
+
+    def test_vertex_video_001(self):
+        pricing = lookup_pricing("gemini-vertex", "veo-3.1-fast-generate-001", "video")
+        assert isinstance(pricing, PerSecondMatrix)
+        assert pricing.dimensions == "resolution_audio"
+
+    def test_openai_image_token(self):
+        pricing = lookup_pricing("openai", "gpt-image-2", "image")
+        assert isinstance(pricing, PerImageOpenAIToken)
+
+    def test_ark_video_per_token(self):
+        pricing = lookup_pricing("ark", "doubao-seedance-1-5-pro-251215", "video")
+        assert isinstance(pricing, PerTokenVideo)
+        assert pricing.currency == "CNY"
+
+
+class TestUnknownProviderFallsBackToGemini:
+    @pytest.mark.parametrize("provider", ["gemini", "unknown", "seedance"])
+    def test_text(self, provider: str):
+        pricing = lookup_pricing(provider, None, "text")
+        assert isinstance(pricing, PerToken)
+        assert pricing.rates["gemini-3-flash-preview"] == {"input": 0.50, "output": 3.00}
+
+    def test_image(self):
+        pricing = lookup_pricing("unknown", None, "image")
+        assert isinstance(pricing, PerImageByResolution)
+        assert "gemini-3.1-flash-image-preview" in pricing.rates
+
+    def test_video(self):
+        pricing = lookup_pricing("unknown", None, "video")
+        assert isinstance(pricing, PerSecondMatrix)
+        assert "veo-3.1-lite-generate-preview" in pricing.rates
+
+
+class TestAnthropicException:
+    def test_anthropic_returns_per_token(self):
+        pricing = lookup_pricing("anthropic", "claude-sonnet-4", "text")
+        assert isinstance(pricing, PerToken)
+        assert pricing.currency == "USD"
+        assert pricing.rates["claude-sonnet-4"] == {"input": 3.00, "output": 15.00}
+
+    def test_anthropic_unknown_model_still_anthropic_table(self):
+        # Anthropic 走 provider 级例外，未知 model 不回落 Gemini，仍用 Anthropic 默认。
+        pricing = lookup_pricing("anthropic", "unknown-claude", "text")
+        assert isinstance(pricing, PerToken)
+        assert pricing.default_model == "claude-sonnet-4"
+
+
+class TestViduDelegate:
+    def test_vidu_returns_delegate_provider_level(self):
+        # 任意 model（含未知）都返回委托标记，不经 model→pricing 回落。
+        assert isinstance(lookup_pricing("vidu", "viduq3-turbo", "video"), ViduDelegate)
+        assert isinstance(lookup_pricing("vidu", "totally-unknown", "image"), ViduDelegate)
+
+
+class TestUnknownModelFallback:
+    def test_unknown_model_falls_back_and_warns(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="lib.pricing.lookup"):
+            pricing = lookup_pricing("ark", "no-such-model", "video")
+        assert isinstance(pricing, PerTokenVideo)
+        # 回落到 ark 默认视频模型
+        assert "doubao-seedance-1-5-pro-251215" in pricing.rates
+        assert any("no-such-model" in r.message for r in caplog.records)
+
+    def test_agent_plan_no_pricing_falls_back_to_gemini_quietly(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="lib.pricing.lookup"):
+            pricing = lookup_pricing("ark-agent-plan", "doubao-seedance-2.0", "video")
+        # Agent Plan 模型 pricing=None → 回落 Gemini 默认视频费率，不发 WARNING
+        assert isinstance(pricing, PerSecondMatrix)
+        assert "veo-3.1-lite-generate-preview" in pricing.rates
+        assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+class TestHiddenModelStillResolves:
+    def test_hidden_does_not_block_lookup(self, monkeypatch):
+        # 成本快照边角：模型被下线（hidden=True）后，入队遗留任务仍需算价。
+        meta = PROVIDER_REGISTRY["gemini-aistudio"]
+        base = meta.models["gemini-3-flash-preview"]
+        hidden_model = replace(base, hidden=True)
+        monkeypatch.setitem(meta.models, "gemini-3-flash-retired", hidden_model)
+        pricing = lookup_pricing("gemini-aistudio", "gemini-3-flash-retired", "text")
+        assert pricing is hidden_model.pricing

--- a/tests/test_pricing_lookup.py
+++ b/tests/test_pricing_lookup.py
@@ -87,7 +87,7 @@ class TestUnknownModelFallback:
         assert isinstance(pricing, PerTokenVideo)
         # 回落到 ark 默认视频模型
         assert "doubao-seedance-1-5-pro-251215" in pricing.rates
-        assert any("no-such-model" in r.message for r in caplog.records)
+        assert any("no-such-model" in r.getMessage() for r in caplog.records)
 
     def test_agent_plan_no_pricing_falls_back_to_gemini_quietly(self, caplog):
         with caplog.at_level(logging.WARNING, logger="lib.pricing.lookup"):

--- a/tests/test_pricing_lookup.py
+++ b/tests/test_pricing_lookup.py
@@ -98,6 +98,29 @@ class TestUnknownModelFallback:
         assert not any(r.levelno >= logging.WARNING for r in caplog.records)
 
 
+class TestGeminiFamilyVideoFallback:
+    """gemini-aistudio/vertex 的未知/None 视频模型应回落到 Gemini 通用默认（lite），
+    而非各 provider 自身默认（vertex 视频默认是 fast-001），保持历史费率一致。"""
+
+    def test_vertex_none_model_uses_universal_lite_not_vertex_fast_default(self):
+        pricing = lookup_pricing("gemini-vertex", None, "video")
+        assert isinstance(pricing, PerSecondMatrix)
+        # 通用默认 = veo-3.1-lite-generate-preview（1080p+audio=0.08），不是 vertex 默认 fast-001（0.15）
+        assert "veo-3.1-lite-generate-preview" in pricing.rates
+        assert pricing.rates["veo-3.1-lite-generate-preview"][("1080p", True)] == 0.08
+
+    def test_vertex_unknown_model_uses_universal_lite(self):
+        pricing = lookup_pricing("gemini-vertex", "veo-removed-from-registry", "video")
+        assert isinstance(pricing, PerSecondMatrix)
+        assert "veo-3.1-lite-generate-preview" in pricing.rates
+
+    def test_vertex_known_model_still_resolves_own_pricing(self):
+        # 正常配对（vertex + 其自有模型）仍命中该模型自身费率。
+        pricing = lookup_pricing("gemini-vertex", "veo-3.1-generate-001", "video")
+        assert isinstance(pricing, PerSecondMatrix)
+        assert pricing.rates["veo-3.1-generate-001"][("1080p", True)] == 0.40
+
+
 class TestHiddenModelStillResolves:
     def test_hidden_does_not_block_lookup(self, monkeypatch):
         # 成本快照边角：模型被下线（hidden=True）后，入队遗留任务仍需算价。

--- a/tests/test_pricing_strategies.py
+++ b/tests/test_pricing_strategies.py
@@ -1,0 +1,310 @@
+"""按 kind 的计费策略纯函数测试：canonical 输入 + 各 fallback 分支。"""
+
+from __future__ import annotations
+
+import pytest
+
+from lib.pricing.strategies import PricingParams, calculate_pricing
+from lib.pricing.types import (
+    PerImageByResolution,
+    PerImageFlat,
+    PerImageOpenAIToken,
+    PerSecondMatrix,
+    PerToken,
+    PerTokenVideo,
+    ViduDelegate,
+)
+
+
+class TestPerToken:
+    pricing = PerToken(
+        rates={"m1": {"input": 0.50, "output": 3.00}},
+        default_model="m1",
+        currency="USD",
+    )
+
+    def test_known_model(self):
+        amount, currency = calculate_pricing(
+            self.pricing, PricingParams(call_type="text", model="m1", input_tokens=1000, output_tokens=500)
+        )
+        assert currency == "USD"
+        assert amount == pytest.approx((1000 * 0.50 + 500 * 3.00) / 1_000_000)
+
+    def test_unknown_model_falls_back_to_default(self):
+        amount, _ = calculate_pricing(
+            self.pricing, PricingParams(call_type="text", model="unknown", input_tokens=1000, output_tokens=500)
+        )
+        assert amount == pytest.approx((1000 * 0.50 + 500 * 3.00) / 1_000_000)
+
+    def test_none_model_uses_default(self):
+        amount, _ = calculate_pricing(self.pricing, PricingParams(call_type="text", input_tokens=1000, output_tokens=0))
+        assert amount == pytest.approx(1000 * 0.50 / 1_000_000)
+
+
+class TestPerImageFlat:
+    pricing = PerImageFlat(rates={"m1": 0.22}, default_model="m1", currency="CNY")
+
+    def test_single_image(self):
+        amount, currency = calculate_pricing(self.pricing, PricingParams(call_type="image", model="m1"))
+        assert currency == "CNY"
+        assert amount == pytest.approx(0.22)
+
+    def test_n_images(self):
+        amount, _ = calculate_pricing(self.pricing, PricingParams(call_type="image", model="m1", n=3))
+        assert amount == pytest.approx(0.22 * 3)
+
+    def test_unknown_model_falls_back(self):
+        amount, _ = calculate_pricing(self.pricing, PricingParams(call_type="image", model="unknown", n=4))
+        assert amount == pytest.approx(0.22 * 4)
+
+
+class TestPerImageByResolution:
+    pricing = PerImageByResolution(
+        rates={"m1": {"512PX": 0.045, "1K": 0.067, "2K": 0.101, "4K": 0.151}},
+        default_model="m1",
+        currency="USD",
+    )
+
+    def test_known_resolution_uppercased(self):
+        amount, currency = calculate_pricing(
+            self.pricing, PricingParams(call_type="image", model="m1", resolution="1k")
+        )
+        assert currency == "USD"
+        assert amount == pytest.approx(0.067)
+
+    def test_high_resolution(self):
+        amount, _ = calculate_pricing(self.pricing, PricingParams(call_type="image", model="m1", resolution="4K"))
+        assert amount == pytest.approx(0.151)
+
+    def test_unknown_resolution_falls_back_to_1k(self):
+        amount, _ = calculate_pricing(self.pricing, PricingParams(call_type="image", model="m1", resolution="unknown"))
+        assert amount == pytest.approx(0.067)
+
+    def test_none_resolution_defaults_to_1k(self):
+        amount, _ = calculate_pricing(self.pricing, PricingParams(call_type="image", model="m1"))
+        assert amount == pytest.approx(0.067)
+
+
+class TestPerImageOpenAIToken:
+    pricing = PerImageOpenAIToken(
+        token_rates={
+            "gpt-image-2": {
+                "image_in": 8.0,
+                "image_cached_in": 2.0,
+                "image_out": 30.0,
+                "text_in": 5.0,
+                "text_cached_in": 1.25,
+                "text_out": 0.0,
+            }
+        },
+        fallback_rates={
+            "gpt-image-2": {
+                ("low", "1024x1024"): 0.006,
+                ("medium", "1024x1024"): 0.053,
+                ("medium", "1024x1792"): 0.106,
+                ("high", "1024x1024"): 0.211,
+                ("high", "1024x1792"): 0.317,
+                ("high", "1792x1024"): 0.317,
+            }
+        },
+        default_model="gpt-image-2",
+        currency="USD",
+    )
+
+    def test_token_path(self):
+        amount, currency = calculate_pricing(
+            self.pricing,
+            PricingParams(
+                call_type="image",
+                model="gpt-image-2",
+                image_input_tokens=10_000,
+                image_output_tokens=2_000,
+                text_input_tokens=500,
+                text_output_tokens=100,
+            ),
+        )
+        assert currency == "USD"
+        assert amount == pytest.approx((10_000 * 8 + 2_000 * 30 + 500 * 5 + 100 * 0) / 1_000_000)
+
+    def test_zero_tokens_still_token_path(self):
+        amount, _ = calculate_pricing(
+            self.pricing,
+            PricingParams(
+                call_type="image",
+                model="gpt-image-2",
+                image_input_tokens=0,
+                image_output_tokens=0,
+                text_input_tokens=0,
+                text_output_tokens=0,
+            ),
+        )
+        assert amount == pytest.approx(0.0)
+
+    def test_fallback_no_size_defaults_to_1024_square(self):
+        # size=None, resolution=None, aspect_ratio=None → 不反查 → 1024x1024
+        amount, _ = calculate_pricing(
+            self.pricing, PricingParams(call_type="image", model="gpt-image-2", quality="medium")
+        )
+        assert amount == pytest.approx(0.053)
+
+    def test_fallback_resolves_size_from_resolution_aspect(self):
+        # size=None, resolution + aspect_ratio → 反查 SIZE_MAP → 1024x1792
+        amount, _ = calculate_pricing(
+            self.pricing,
+            PricingParams(call_type="image", model="gpt-image-2", quality="high", resolution="1K", aspect_ratio="9:16"),
+        )
+        assert amount == pytest.approx(0.317)
+
+    def test_fallback_explicit_size_overrides(self):
+        amount, _ = calculate_pricing(
+            self.pricing,
+            PricingParams(
+                call_type="image",
+                model="gpt-image-2",
+                quality="medium",
+                resolution="1K",
+                aspect_ratio="1:1",
+                size="1024x1792",
+            ),
+        )
+        assert amount == pytest.approx(0.106)
+
+    def test_fallback_unknown_quality_size_three_level(self):
+        # (quality, size) 与 (quality, 1024x1024) 都缺 → ("medium","1024x1024") 0.053
+        amount, _ = calculate_pricing(
+            self.pricing,
+            PricingParams(call_type="image", model="gpt-image-2", quality="ultra", size="9999x9999"),
+        )
+        assert amount == pytest.approx(0.053)
+
+
+class TestPerSecondMatrix:
+    audio = PerSecondMatrix(
+        rates={
+            "veo": {
+                ("720p", True): 0.05,
+                ("720p", False): 0.05,
+                ("1080p", True): 0.08,
+                ("1080p", False): 0.08,
+            }
+        },
+        default_model="veo",
+        dimensions="resolution_audio",
+        currency="USD",
+    )
+    res_only = PerSecondMatrix(
+        rates={"sora": {("720p", None): 0.30, ("1024p", None): 0.50, ("1080p", None): 0.70}},
+        default_model="sora",
+        dimensions="resolution_only",
+        currency="USD",
+    )
+    flat = PerSecondMatrix(
+        rates={"grok": {("", None): 0.050}},
+        default_model="grok",
+        dimensions="flat",
+        currency="USD",
+    )
+
+    def test_resolution_audio_known(self):
+        amount, currency = calculate_pricing(
+            self.audio,
+            PricingParams(call_type="video", model="veo", duration_seconds=8, resolution="1080p", generate_audio=True),
+        )
+        assert currency == "USD"
+        assert amount == pytest.approx(0.64)
+
+    def test_resolution_audio_lowercased_and_unknown_falls_back_to_1080p_true(self):
+        # resolution="UNKNOWN" → .lower() 后查不到 → fallback ("1080p", True) = 0.08
+        amount, _ = calculate_pricing(
+            self.audio,
+            PricingParams(
+                call_type="video", model="veo", duration_seconds=5, resolution="UNKNOWN", generate_audio=True
+            ),
+        )
+        assert amount == pytest.approx(0.40)
+
+    def test_resolution_only_known(self):
+        amount, _ = calculate_pricing(
+            self.res_only,
+            PricingParams(call_type="video", model="sora", duration_seconds=4, resolution="1080p"),
+        )
+        assert amount == pytest.approx(2.80)
+
+    def test_resolution_only_defaults_to_720p(self):
+        amount, _ = calculate_pricing(self.res_only, PricingParams(call_type="video", model="sora", duration_seconds=8))
+        assert amount == pytest.approx(2.40)
+
+    def test_flat_ignores_resolution(self):
+        amount, _ = calculate_pricing(
+            self.flat,
+            PricingParams(call_type="video", model="grok", duration_seconds=10, resolution="480p"),
+        )
+        assert amount == pytest.approx(0.50)
+
+    def test_duration_defaults_to_8(self):
+        amount, _ = calculate_pricing(self.flat, PricingParams(call_type="video", model="grok"))
+        assert amount == pytest.approx(0.40)
+
+
+class TestPerTokenVideo:
+    pricing = PerTokenVideo(
+        rates={
+            "seedance": {
+                ("default", True): 16.00,
+                ("default", False): 8.00,
+                ("flex", True): 8.00,
+                ("flex", False): 4.00,
+            }
+        },
+        default_model="seedance",
+    )
+
+    def test_default_currency_is_cny(self):
+        _, currency = calculate_pricing(
+            self.pricing, PricingParams(call_type="video", model="seedance", usage_tokens=0)
+        )
+        assert currency == "CNY"
+
+    def test_tier_audio_matrix(self):
+        amount, _ = calculate_pricing(
+            self.pricing,
+            PricingParams(
+                call_type="video", model="seedance", usage_tokens=1_000_000, service_tier="flex", generate_audio=False
+            ),
+        )
+        assert amount == pytest.approx(4.00)
+
+    def test_unknown_key_falls_back_to_default_true(self):
+        # service_tier 未在表中 → fallback ("default", True) = 16.00
+        amount, _ = calculate_pricing(
+            self.pricing,
+            PricingParams(call_type="video", model="seedance", usage_tokens=1_000_000, service_tier="ultra"),
+        )
+        assert amount == pytest.approx(16.00)
+
+    def test_unknown_model_falls_back_to_default(self):
+        amount, _ = calculate_pricing(
+            self.pricing,
+            PricingParams(call_type="video", model="unknown", usage_tokens=1_000_000, generate_audio=True),
+        )
+        assert amount == pytest.approx(16.00)
+
+
+class TestViduDelegate:
+    def test_credits_path(self):
+        # usage_tokens (credits) 给定 → credits × 0.03125 CNY
+        amount, currency = calculate_pricing(
+            ViduDelegate(),
+            PricingParams(call_type="video", model="viduq3-turbo", usage_tokens=100),
+        )
+        assert currency == "CNY"
+        assert amount == pytest.approx(100 * 0.03125)
+
+    def test_fallback_passes_original_model(self):
+        # 无 credits → 按表估算，model 透传（viduq3-turbo 720p = 12 credits/s）
+        amount, currency = calculate_pricing(
+            ViduDelegate(),
+            PricingParams(call_type="video", model="viduq3-turbo", resolution="720p", duration_seconds=5),
+        )
+        assert currency == "CNY"
+        assert amount == pytest.approx(5 * 12 * 0.03125)

--- a/tests/test_pricing_strategies.py
+++ b/tests/test_pricing_strategies.py
@@ -88,6 +88,16 @@ class TestPerImageByResolution:
         amount, _ = calculate_pricing(self.pricing, PricingParams(call_type="image", model="m1", resolution="1K", n=3))
         assert amount == pytest.approx(0.067 * 3)
 
+    def test_zero_1k_rate_not_treated_as_missing(self):
+        # free 模型 1K 显式 0.0，未知分辨率回落 default_cost 时应保留自身 0.0，不误用 paid 费率。
+        pricing = PerImageByResolution(
+            rates={"free": {"1K": 0.0}, "paid": {"1K": 0.067}},
+            default_model="paid",
+            currency="USD",
+        )
+        amount, _ = calculate_pricing(pricing, PricingParams(call_type="image", model="free", resolution="4K"))
+        assert amount == pytest.approx(0.0)
+
 
 class TestPerImageOpenAIToken:
     pricing = PerImageOpenAIToken(
@@ -264,6 +274,22 @@ class TestPerSecondMatrix:
     def test_duration_defaults_to_8(self):
         amount, _ = calculate_pricing(self.flat, PricingParams(call_type="video", model="grok"))
         assert amount == pytest.approx(0.40)
+
+    def test_resolution_audio_zero_fallback_rate_not_treated_as_missing(self):
+        # free 模型 (1080p,True) 显式 0.0，未知分辨率回落 fallback 时应保留自身 0.0，不误用 paid 费率。
+        pricing = PerSecondMatrix(
+            rates={"free": {("1080p", True): 0.0}, "paid": {("1080p", True): 0.08}},
+            default_model="paid",
+            dimensions="resolution_audio",
+            currency="USD",
+        )
+        amount, _ = calculate_pricing(
+            pricing,
+            PricingParams(
+                call_type="video", model="free", duration_seconds=10, resolution="UNKNOWN", generate_audio=True
+            ),
+        )
+        assert amount == pytest.approx(0.0)
 
 
 class TestPerTokenVideo:

--- a/tests/test_pricing_strategies.py
+++ b/tests/test_pricing_strategies.py
@@ -84,6 +84,10 @@ class TestPerImageByResolution:
         amount, _ = calculate_pricing(self.pricing, PricingParams(call_type="image", model="m1"))
         assert amount == pytest.approx(0.067)
 
+    def test_n_images(self):
+        amount, _ = calculate_pricing(self.pricing, PricingParams(call_type="image", model="m1", resolution="1K", n=3))
+        assert amount == pytest.approx(0.067 * 3)
+
 
 class TestPerImageOpenAIToken:
     pricing = PerImageOpenAIToken(
@@ -177,6 +181,14 @@ class TestPerImageOpenAIToken:
         )
         assert amount == pytest.approx(0.053)
 
+    def test_fallback_n_images(self):
+        # 兜底路径同样按 n 缩放（与 token 路径无关）
+        amount, _ = calculate_pricing(
+            self.pricing,
+            PricingParams(call_type="image", model="gpt-image-2", quality="medium", n=2),
+        )
+        assert amount == pytest.approx(0.053 * 2)
+
 
 class TestPerSecondMatrix:
     audio = PerSecondMatrix(
@@ -233,6 +245,14 @@ class TestPerSecondMatrix:
     def test_resolution_only_defaults_to_720p(self):
         amount, _ = calculate_pricing(self.res_only, PricingParams(call_type="video", model="sora", duration_seconds=8))
         assert amount == pytest.approx(2.40)
+
+    def test_resolution_only_uppercased(self):
+        # 大写分辨率经 .lower() 归一后命中小写费率键，不再回落 720p
+        amount, _ = calculate_pricing(
+            self.res_only,
+            PricingParams(call_type="video", model="sora", duration_seconds=4, resolution="1080P"),
+        )
+        assert amount == pytest.approx(2.80)
 
     def test_flat_ignores_resolution(self):
         amount, _ = calculate_pricing(

--- a/tests/test_usage_repo.py
+++ b/tests/test_usage_repo.py
@@ -156,7 +156,7 @@ class TestFinalizePendingByCallId:
 
     async def test_usage_tokens_passed_to_cost_calculator(self, db_session, monkeypatch):
         """Ark video 按 usage_tokens 计费，repo 必须把 caller 传入的 usage_tokens 透传到 cost_calculator，
-        否则 calculate_ark_video_cost 走 usage_tokens or 0 路径 → cost 永远为 0 CNY。"""
+        否则按 token 计费的视频走 usage_tokens or 0 路径 → cost 永远为 0 CNY。"""
         from lib import cost_calculator as cc_module
 
         captured: dict[str, object] = {}


### PR DESCRIPTION
## 背景

`lib/cost_calculator.py` 此前把每家供应商各模态的费率写成 ~15 张散落的类属性 dict，`calculate_cost` 用一长串 `if provider == X` 路由到 per-shape 计算函数。痛点：新增内置视频供应商若忘加分支会**静默回落到 Veo 费率**按错价计费；促销价散落难维护。

本 PR 落地 `docs/adr/0009-declarative-model-pricing.md`：每个内置模型的定价挂在它自己的 `ModelInfo.pricing`（单一真相源），计算按"定价形状 `kind`"派发而非按 provider 分支。**纯重构、行为零变化**，是后续内置供应商接入的前置基础设施。

## 改动

- **`lib/pricing/`**（新）：
  - `types.py` — 每种计费形状一个 frozen dataclass（`kind` 判别标签）：`PerToken` / `PerImageFlat` / `PerImageByResolution` / `PerImageOpenAIToken` / `PerSecondMatrix` / `PerTokenVideo` / `ViduDelegate`。
  - `strategies.py` — 按 `kind` 派发的纯函数，逐字复刻现有 fallback 公式。
  - `lookup.py` — 按 `(provider, model, media_type)` 查定价，复刻历史回落次序。
- **`lib/config/registry.py`**：`ModelInfo` 增量加 `pricing` / `hidden` 两字段；全部内置模型把费率原值搬进自身 `ModelInfo.pricing`；`default_model_for_provider` 提升为公共函数。
- **`lib/cost_calculator.py`**：`calculate_cost` / `estimate_reference_video_cost` 改 `lookup_pricing` + `calculate_pricing`，删除 `if provider==X` 路由链与 9 个底层 per-shape 方法及散落 dict。对外签名与 `(amount, currency)` 返回不变。

## 关键决策

- **零行为变化**：Gemini/Ark/Grok/OpenAI/Vidu + Anthropic 文本全量迁移，以现有 cost 测试金额逐项对拍兜底。未知 provider/model 走 Gemini 家族 model-keyed 回落（复刻历史「全局 Gemini 费率表按 model 命中」，含裸 `gemini` + 历史 veo 模型这类调用）；Anthropic 作 registry-external 例外；Vidu provider 级委托给 `lib.vidu_shared`。
- **`hidden` 字段本 PR 只加不消费**：不触碰 `system_config.py`、不给任何 model 打开 hidden（UI 隐藏拆到独立 issue），避免纯重构 PR 引入死代码或改变 UI 枚举。
- **`ark-agent-plan` 一律 `pricing=None`**：今天无费率表、沿用 Gemini 默认兜底，不臆造外部价格。

## 验证

- 全量 `uv run python -m pytest tests/` → **3432 passed**；现有 cost 测试改指向公共入口后金额逐项不变、新增 currency 维度断言全绿。
- 新增 `tests/test_pricing_strategies.py`（各 kind + fallback）、`tests/test_pricing_lookup.py`（registry 命中 / 未知 provider / Anthropic 例外 / vidu 委托 / 未知 model 回落 + 告警 / Agent Plan 回落 / hidden 仍可命中）。
- `uv run ruff check` 通过；`uv run basedpyright` **0 errors**。

Closes #670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  - 为模型配置新增显式定价声明与 hidden 下线标记
  - 新增按媒体类型查询 Provider 默认模型的公共接口

* **改进**
  - 统一成本计算入口，按声明化定价类型策略计算并多层回退
  - 增强定价查找与特殊 Provider 委托处理
  - 配置 API 输出屏蔽 pricing 字段以避免序列化/可变性问题
  - 视频估算：默认时长与全零时长处理及币种回退

* **测试**
  - 大量新增与迁移单元测试，覆盖定价解析、计费策略与回退场景

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->