### PR TITLE
feat(custom-provider): 扩充视频 endpoint 生态并重构 endpoint 自动推断

### DIFF
--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -746,6 +746,9 @@ export default {
   'endpoint_gemini_image_display': 'Google Gemini Image',
   'endpoint_openai_video_display': 'OpenAI Video (Sora)',
   'endpoint_newapi_video_display': 'NewAPI Unified Video',
+  'endpoint_v2_video_generations_display': 'V2 Video Generations',
+  'endpoint_ark_seedance_display': 'Volcengine Ark (Seedance)',
+  'endpoint_vidu_video_display': 'Vidu Video',
   'endpoint_catalog_loading': 'Loading endpoint catalog…',
   // Image Capability
   'image_capability_t2i': 'T2I',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -723,6 +723,9 @@ export default {
   'endpoint_gemini_image_display': 'Google Gemini Image',
   'endpoint_openai_video_display': 'OpenAI Video (Sora)',
   'endpoint_newapi_video_display': 'NewAPI Unified Video',
+  'endpoint_v2_video_generations_display': 'V2 Video Generations',
+  'endpoint_ark_seedance_display': 'Volcengine Ark (Seedance)',
+  'endpoint_vidu_video_display': 'Vidu Video',
   'endpoint_catalog_loading': 'Đang tải danh mục endpoint…',
   // Image Capability
   'image_capability_t2i': 'T2I',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -747,6 +747,9 @@ export default {
   'endpoint_gemini_image_display': 'Google Gemini Image',
   'endpoint_openai_video_display': 'OpenAI Video (Sora)',
   'endpoint_newapi_video_display': 'NewAPI Unified Video',
+  'endpoint_v2_video_generations_display': 'V2 Video Generations',
+  'endpoint_ark_seedance_display': 'Volcengine Ark (Seedance)',
+  'endpoint_vidu_video_display': 'Vidu Video',
   'endpoint_catalog_loading': '加载端点目录…',
   // Image Capability
   'image_capability_t2i': '文生图',

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -28,7 +28,9 @@ from lib.config.service import (
     ConfigService,
 )
 from lib.custom_provider import is_custom_provider, parse_provider_id
+from lib.custom_provider.backends import CustomVideoBackend
 from lib.custom_provider.endpoints import get_endpoint_spec
+from lib.custom_provider.factory import create_custom_backend
 from lib.db.repositories.credential_repository import CredentialRepository
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.project_manager import ProjectManager
@@ -463,7 +465,27 @@ class ConfigResolver:
                     f"endpoint media_type mismatch: {provider_id}/{model_id} endpoint={model.endpoint!r} "
                     f"is {endpoint_spec.media_type}, not video"
                 )
-            max_reference_images = endpoint_spec.video_max_reference_images
+            endpoint_cap = endpoint_spec.video_max_reference_images
+            if endpoint_cap is not None:
+                max_reference_images = endpoint_cap
+            else:
+                # endpoint cap 未声明（多 model 共享端点、容量不同）→ fallthrough 到 backend caps。
+                # CustomProviderModel 无 provider relationship，须显式取 provider 行（多一次 DB 查询）。
+                provider = await repo.get_provider(db_pid)
+                if provider is None:
+                    raise ValueError(f"custom provider not found: {provider_id}")
+                try:
+                    backend = create_custom_backend(provider=provider, model_id=model_id, endpoint=model.endpoint)
+                except Exception as exc:
+                    raise ValueError(
+                        f"failed to construct backend for max_reference_images fallthrough: "
+                        f"{provider_id}/{model_id} endpoint={model.endpoint!r}"
+                    ) from exc
+                if not isinstance(backend, CustomVideoBackend):
+                    raise ValueError(
+                        f"video endpoint built non-video backend: {provider_id}/{model_id} endpoint={model.endpoint!r}"
+                    )
+                max_reference_images = backend.video_capabilities.max_reference_images
             raw_durations = model.supported_durations
             supported_durations: list[int] = []
             if raw_durations:

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -486,6 +486,13 @@ class ConfigResolver:
                         f"video endpoint built non-video backend: {provider_id}/{model_id} endpoint={model.endpoint!r}"
                     )
                 max_reference_images = backend.video_capabilities.max_reference_images
+                if max_reference_images < 0:
+                    # backend caps 是这条链路的真相源，负数直接抛错，不静默下传——
+                    # 否则 reference_video_tasks 会按坏值跳过裁剪。
+                    raise ValueError(
+                        f"invalid backend max_reference_images: {provider_id}/{model_id} "
+                        f"endpoint={model.endpoint!r} value={max_reference_images!r}"
+                    )
             raw_durations = model.supported_durations
             supported_durations: list[int] = []
             if raw_durations:

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -324,7 +324,8 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     openai-chat/openai-images，每次都要手动改回。
 
     1) imagen → "gemini-image"（图像，不论 discovery_format）
-    2) gemini 且非 video/image 形态 → "gemini-generate"（文本，不论 discovery_format）
+    2) gemini 原生模型（非 video）→ image 形态走 "gemini-image"，否则文本走 "gemini-generate"
+       （均不论 discovery_format：gemini-* 一律按 Google 端点路由，gemini-*-image 也不例外）
     3) 视频家族 → seedance→"ark-seedance"、viduq3→"vidu-video"、否则 "openai-video"
        （v2-video-generations 命名碎片化无法可靠识别，不自动推断，留用户手选）
     4) 图像家族 → discovery_format=google 走 "gemini-image" 否则 "openai-images"
@@ -336,8 +337,8 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
 
     if "imagen" in lowered:
         return "gemini-image"
-    if "gemini" in lowered and not is_video and not is_image:
-        return "gemini-generate"
+    if "gemini" in lowered and not is_video:
+        return "gemini-image" if is_image else "gemini-generate"
     if is_video:
         if "seedance" in lowered:
             return "ark-seedance"

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -118,13 +118,18 @@ def _build_newapi_video(provider, model_id: str) -> CustomVideoBackend:
 
 def _ensure_url_path_suffix(base_url: str | None, suffix: str) -> str | None:
     """用户只填到 host 时补全协议已知挂载路径（ark /api/v3、vidu /ent/v2）；
-    已带显式路径则原样信任，避免错误叠加。供 ark/vidu 闭包复用。"""
+    已带显式路径则原样信任，避免错误叠加。供 ark/vidu 闭包复用。
+
+    纯域名（无 scheme，如 ``relay.example.com``）会被 urlsplit 整体当作 path，
+    先补 ``https://`` 再判定，否则 host-only 配置既补不上协议也挂不上路径。
+    """
     s = (base_url or "").strip().rstrip("/")
     if not s:
         return None
-    if urlsplit(s).path in ("", "/"):
-        return s + suffix
-    return s
+    normalized = s if "://" in s else f"https://{s}"
+    if urlsplit(normalized).path in ("", "/"):
+        return normalized + suffix
+    return normalized
 
 
 def _build_v2_video_generations(provider, model_id: str) -> CustomVideoBackend:

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -12,6 +12,7 @@ import re
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 from lib.config.url_utils import ensure_google_base_url, ensure_openai_base_url
 from lib.custom_provider.backends import CustomImageBackend, CustomTextBackend, CustomVideoBackend
@@ -20,8 +21,11 @@ from lib.image_backends.gemini import GeminiImageBackend
 from lib.image_backends.openai import OpenAIImageBackend
 from lib.text_backends.gemini import GeminiTextBackend
 from lib.text_backends.openai import OpenAITextBackend
+from lib.video_backends.ark import ArkVideoBackend
 from lib.video_backends.newapi import NewAPIVideoBackend
 from lib.video_backends.openai import OpenAIVideoBackend
+from lib.video_backends.v2_video_generations import V2VideoGenerationsBackend
+from lib.video_backends.vidu import ViduVideoBackend
 
 if TYPE_CHECKING:
     from lib.db.models.custom_provider import CustomProvider
@@ -42,9 +46,11 @@ class EndpointSpec:
     request_path_template: str  # "/v1/chat/completions"，可含 {model} 等占位
     build_backend: Callable[[CustomProvider, str], CustomTextBackend | CustomImageBackend | CustomVideoBackend]
     image_capabilities: frozenset[ImageCapability] | None = None  # image 类才填，非 image 类省略
-    # 参考生视频单镜头参考图上限；仅 video 类有意义。这是显式上限，0 会原样下传作为硬约束
-    # （表示不接受参考图，executor 据此将 references 裁剪为 0 张），不代表「未声明」。
-    video_max_reference_images: int = 0
+    # 参考生视频单镜头参考图上限；仅 video 类有意义。
+    # 显式 int：原样下传作为硬约束（0 表示不接受参考图，executor 据此将 references 裁剪为 0 张）。
+    # None：未声明 —— 一个 endpoint 多 model、容量不同时 endpoint 维度给不出准数，由 resolver
+    # fallthrough 到 backend video_capabilities 读取该 model 的真实上限。
+    video_max_reference_images: int | None = None
 
 
 # ── 各 endpoint 的 build_backend 闭包 ──────────────────────────────
@@ -107,6 +113,37 @@ def _build_newapi_video(provider, model_id: str) -> CustomVideoBackend:
     if not base_url:
         raise ValueError("NewAPI 视频后端需要 base_url")
     delegate = NewAPIVideoBackend(api_key=provider.api_key, base_url=base_url, model=model_id)
+    return CustomVideoBackend(provider_id=provider.provider_id, delegate=delegate, model=model_id)
+
+
+def _ensure_url_path_suffix(base_url: str | None, suffix: str) -> str | None:
+    """用户只填到 host 时补全协议已知挂载路径（ark /api/v3、vidu /ent/v2）；
+    已带显式路径则原样信任，避免错误叠加。供 ark/vidu 闭包复用。"""
+    s = (base_url or "").strip().rstrip("/")
+    if not s:
+        return None
+    if urlsplit(s).path in ("", "/"):
+        return s + suffix
+    return s
+
+
+def _build_v2_video_generations(provider, model_id: str) -> CustomVideoBackend:
+    if not provider.base_url:
+        raise ValueError("v2-video-generations 端点需要 base_url")
+    # base_url 归一化（去版本段 + 拼 /v2/video/generations）由 V2VideoGenerationsBackend 内部处理
+    delegate = V2VideoGenerationsBackend(api_key=provider.api_key, base_url=provider.base_url, model=model_id)
+    return CustomVideoBackend(provider_id=provider.provider_id, delegate=delegate, model=model_id)
+
+
+def _build_ark_seedance(provider, model_id: str) -> CustomVideoBackend:
+    base_url = _ensure_url_path_suffix(provider.base_url, "/api/v3")
+    delegate = ArkVideoBackend(api_key=provider.api_key, base_url=base_url, model=model_id)
+    return CustomVideoBackend(provider_id=provider.provider_id, delegate=delegate, model=model_id)
+
+
+def _build_vidu_video(provider, model_id: str) -> CustomVideoBackend:
+    base_url = _ensure_url_path_suffix(provider.base_url, "/ent/v2")
+    delegate = ViduVideoBackend(api_key=provider.api_key, base_url=base_url, model=model_id)
     return CustomVideoBackend(provider_id=provider.provider_id, delegate=delegate, model=model_id)
 
 
@@ -194,6 +231,34 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         build_backend=_build_newapi_video,
         video_max_reference_images=0,
     ),
+    "v2-video-generations": EndpointSpec(
+        key="v2-video-generations",
+        media_type="video",
+        family="v2",
+        display_name_key="endpoint_v2_video_generations_display",
+        request_method="POST",
+        request_path_template="/v2/video/generations",
+        build_backend=_build_v2_video_generations,
+        # 多 model 共享端点、容量不同 → 未声明，fallthrough 到 backend caps
+    ),
+    "ark-seedance": EndpointSpec(
+        key="ark-seedance",
+        media_type="video",
+        family="ark",
+        display_name_key="endpoint_ark_seedance_display",
+        request_method="POST",
+        request_path_template="/api/v3/contents/generations/tasks",
+        build_backend=_build_ark_seedance,
+    ),
+    "vidu-video": EndpointSpec(
+        key="vidu-video",
+        media_type="video",
+        family="vidu",
+        display_name_key="endpoint_vidu_video_display",
+        request_method="POST",
+        request_path_template="/ent/v2/img2video",
+        build_backend=_build_vidu_video,
+    ),
 }
 
 
@@ -252,19 +317,33 @@ _VIDEO_PATTERN = re.compile(
 
 
 def infer_endpoint(model_id: str, discovery_format: str) -> str:
-    """根据模型 id 与 discovery_format 推默认 endpoint。
+    """根据模型 id 与 discovery_format 推默认 endpoint（content-first）。
 
-    1) 视频家族 → 一律 "openai-video"（OpenAI /v1/videos 协议为首选默认，
-       newapi-video 仅在用户手动选择时使用）
-    2) 图像家族 → discovery_format=google 走 "gemini-image" 否则 "openai-images"
-    3) 文本（默认）→ discovery_format=google 走 "gemini-generate" 否则 "openai-chat"
+    model id 内容优先于 discovery_format：中转站普遍 discovery_format="openai"，但模型
+    列表常夹带 gemini-*/imagen-* 原生 id，必须按内容纠偏到 Google 端点，否则被错推到
+    openai-chat/openai-images，每次都要手动改回。
+
+    1) imagen → "gemini-image"（图像，不论 discovery_format）
+    2) gemini 且非 video/image 形态 → "gemini-generate"（文本，不论 discovery_format）
+    3) 视频家族 → seedance→"ark-seedance"、viduq3→"vidu-video"、否则 "openai-video"
+       （v2-video-generations 命名碎片化无法可靠识别，不自动推断，留用户手选）
+    4) 图像家族 → discovery_format=google 走 "gemini-image" 否则 "openai-images"
+    5) 默认（文本）→ discovery_format=google 走 "gemini-generate" 否则 "openai-chat"
     """
-    if _VIDEO_PATTERN.search(model_id):
-        return "openai-video"
-    if _IMAGE_PATTERN.search(model_id):
-        if discovery_format == "google":
-            return "gemini-image"
-        return "openai-images"
-    if discovery_format == "google":
+    lowered = model_id.lower()
+    is_video = bool(_VIDEO_PATTERN.search(model_id))
+    is_image = bool(_IMAGE_PATTERN.search(model_id))
+
+    if "imagen" in lowered:
+        return "gemini-image"
+    if "gemini" in lowered and not is_video and not is_image:
         return "gemini-generate"
-    return "openai-chat"
+    if is_video:
+        if "seedance" in lowered:
+            return "ark-seedance"
+        if "viduq3" in lowered:
+            return "vidu-video"
+        return "openai-video"
+    if is_image:
+        return "gemini-image" if discovery_format == "google" else "openai-images"
+    return "gemini-generate" if discovery_format == "google" else "openai-chat"

--- a/lib/video_backends/v2_video_generations.py
+++ b/lib/video_backends/v2_video_generations.py
@@ -207,14 +207,19 @@ def build_request_body(model: str, request: VideoGenerationRequest) -> dict:
     return body
 
 
-# 请求体里这些键可能内嵌整张图片的 base64 data URI，落日志前脱敏：
-# 避免明文记录用户图像，也防止日志体积被撑爆。
-_REDACTED_BODY_KEYS = frozenset({"image_url", "last_image_url", "image_urls"})
+# 仅以下键允许进入日志（白名单，键集静态可判定，CodeQL 不再把整份 dict 保守标记为污点）。
+_SAFE_LOG_KEYS = frozenset({"model", "prompt", "duration", "aspect_ratio", "resolution", "seed"})
+# 这些键可能内嵌整张图片的 base64 data URI，固定替换为占位符（白名单外的未知键一律丢弃）。
+_IMAGE_BODY_KEYS = ("image_url", "last_image_url", "image_urls")
 
 
 def _redacted_body(body: dict) -> dict:
-    """日志用副本：内嵌图片字段替换为占位符，其余原样保留。"""
-    return {key: ("<redacted-image-data>" if key in _REDACTED_BODY_KEYS else value) for key, value in body.items()}
+    """日志用副本：仅保留白名单字段，图片字段替换为占位符；不就地修改入参。"""
+    view: dict = {key: body[key] for key in _SAFE_LOG_KEYS if key in body}
+    for key in _IMAGE_BODY_KEYS:
+        if key in body:
+            view[key] = "<redacted-image-data>"
+    return view
 
 
 def _normalize_root(base_url: str) -> str:

--- a/lib/video_backends/v2_video_generations.py
+++ b/lib/video_backends/v2_video_generations.py
@@ -1,0 +1,366 @@
+"""V2VideoGenerationsBackend —— 通用「流派 C」/v2/video/generations 视频后端。
+
+对接「单端点 + model 字段切换」的中转协议（aimlapi / xAI / getimg.ai / APIMart /
+CometAPI 等事实标准）：``POST /v2/video/generations`` 提交拿 generation_id，
+``GET /v2/video/generations?generation_id={id}`` 轮询，终态后取视频 URL 下载。
+
+单端点承载多模型（discriminated union by model），各模型可选字段集合不同。本后端
+只编码一份通用 canonical I/O 契约 + 多路径容错解析（不背 per-model schema）：
+
+- 请求体取各家公共子集（model / prompt / duration / image_url / last_image_url /
+  image_urls / seed / resolution）；尾帧键随模型差异（Veo ``last_image_url`` /
+  Kling ``tail_image_url``），generic 取最常见的 ``last_image_url``。
+- 状态串归一化：覆盖 aimlapi 官方枚举（queued/generating/completed/error）并并入
+  跨厂商同义词，未知串当 running 继续轮询。
+- 视频 URL / task_id / status 各用一张多路径优先级表逐个试取，容忍各家回包结构差异。
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+import httpx
+
+from lib.logging_utils import format_kwargs_for_log
+from lib.retry import (
+    BASE_RETRYABLE_ERRORS,
+    DEFAULT_BACKOFF_SECONDS,
+    DEFAULT_MAX_ATTEMPTS,
+    DOWNLOAD_BACKOFF_SECONDS,
+    DOWNLOAD_MAX_ATTEMPTS,
+    with_retry_async,
+)
+from lib.video_backends.base import (
+    ResumeExpiredError,
+    VideoCapabilities,
+    VideoCapability,
+    VideoGenerationRequest,
+    VideoGenerationResult,
+    download_video,
+    persist_provider_job_id,
+    poll_with_retry,
+)
+
+logger = logging.getLogger(__name__)
+
+PROVIDER_V2_VIDEO = "v2-video-generations"
+
+_SUBMIT_PATH = "/v2/video/generations"
+_POLL_INTERVAL_SECONDS = 5.0
+_MIN_POLL_TIMEOUT_SECONDS = 600
+_POLL_TIMEOUT_PER_SECOND = 30
+
+# generic 端点跨多模型，参考图上限无单一供应商真相；取保守默认，由 resolver 在 endpoint
+# cap 未声明（None）时 fallthrough 读取。非供应商核实值，用户按所选模型对齐。
+_DEFAULT_MAX_REFERENCE_IMAGES = 4
+
+# 超过此阈值的图触发 warning（base64 编码后易触发中转站请求体上限）
+_LARGE_IMAGE_WARN_BYTES = 4 * 1024 * 1024
+
+# HTTPStatusError 不继承 RequestError，必须显式列出以便 5xx 响应走类型匹配而非字符串匹配
+_V2_RETRYABLE_ERRORS = BASE_RETRYABLE_ERRORS + (httpx.RequestError, httpx.HTTPStatusError)
+
+# 状态串 → canonical（lowercase 后查表）。覆盖 aimlapi 官方枚举 queued/generating/
+# completed/error，并并入跨厂商同义词（流派 C 路由到多家时底层状态串可能透传）。
+_STATUS_SYNONYMS: dict[str, str] = {
+    "completed": "succeeded",
+    "succeeded": "succeeded",
+    "succeed": "succeeded",
+    "success": "succeeded",
+    "failed": "failed",
+    "fail": "failed",
+    "error": "failed",
+    "expired": "failed",
+    "canceled": "failed",
+    "cancelled": "failed",
+    "generating": "running",
+    "in_progress": "running",
+    "running": "running",
+    "processing": "running",
+    "queued": "queued",
+    "queueing": "queued",
+    "preparing": "queued",
+    "submitted": "queued",
+    "pending": "queued",
+    "created": "queued",
+}
+
+# 多路径优先级表，配 _dig 逐层走 dict key / list 下标（int 段表 list 下标）。
+# 取自参数对齐表「视频 URL 路径 / task_id 路径」的流派 C 并集。
+_VIDEO_URL_PATHS: tuple[tuple[str | int, ...], ...] = (
+    ("video", "url"),
+    ("assets", "video"),
+    ("output", "video_url"),
+    ("content", "video_url"),
+    ("data", "task_result", "videos", 0, "url"),
+    ("url",),
+)
+_TASK_ID_PATHS: tuple[tuple[str | int, ...], ...] = (
+    ("id",),
+    ("task_id",),
+    ("data", "task_id"),
+    ("request_id",),
+    ("data", "taskId"),
+)
+_STATUS_PATHS: tuple[tuple[str | int, ...], ...] = (
+    ("status",),
+    ("state",),
+    ("data", "status"),
+    ("data", "state"),
+    ("output", "status"),
+)
+
+
+def _dig(payload: object, path: tuple[str | int, ...]) -> object | None:
+    """按 path 逐层走 dict key / list 下标，任一层缺失返回 None。"""
+    cur: object = payload
+    for seg in path:
+        if isinstance(seg, int):
+            if not isinstance(cur, list) or seg >= len(cur):
+                return None
+            cur = cur[seg]
+        else:
+            if not isinstance(cur, dict) or seg not in cur:
+                return None
+            cur = cur[seg]
+    return cur
+
+
+def _first_str_by_paths(payload: object, paths: tuple[tuple[str | int, ...], ...]) -> str | None:
+    """按优先级逐个试取第一个非空字符串值（int 容忍并 str 化）。"""
+    for path in paths:
+        val = _dig(payload, path)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+        if isinstance(val, int) and not isinstance(val, bool):
+            return str(val)
+    return None
+
+
+def normalize_status(raw: object) -> str:
+    """raw 状态值 → canonical：queued | running | succeeded | failed。未知串当 running。"""
+    if not isinstance(raw, str):
+        return "running"
+    return _STATUS_SYNONYMS.get(raw.strip().lower(), "running")
+
+
+def _warn_if_large(path: Path) -> None:
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return
+    if size > _LARGE_IMAGE_WARN_BYTES:
+        logger.warning(
+            "图片较大 (%.1fMB)，base64 编码后可能触发中转站请求体上限: %s",
+            size / 1024 / 1024,
+            path,
+        )
+
+
+def build_request_body(model: str, request: VideoGenerationRequest) -> dict:
+    """按流派 C canonical 拼请求体；缺省字段一律省略。
+
+    图像走 base64 data URI 内嵌（与 newapi 一致）：首帧 ``image_url``、尾帧
+    ``last_image_url``、参考数组 ``image_urls``。已知风险：部分中转站要求公网 URL
+    而非 base64（见研究报告 §8.2），真实接受形态留手动集成测试。
+    """
+    # 延迟导入避免 image_backends ↔ video_backends 循环依赖
+    from lib.image_backends.base import image_to_base64_data_uri
+
+    body: dict = {"model": model, "prompt": request.prompt, "duration": request.duration_seconds}
+    if request.resolution:
+        body["resolution"] = request.resolution
+    if request.seed is not None:
+        body["seed"] = request.seed
+
+    if request.start_image:
+        start = Path(request.start_image)
+        if start.exists():
+            _warn_if_large(start)
+            body["image_url"] = image_to_base64_data_uri(start)
+        else:
+            logger.warning("start_image 文件不存在，已忽略: %s", start)
+    if request.end_image:
+        end = Path(request.end_image)
+        if end.exists():
+            _warn_if_large(end)
+            body["last_image_url"] = image_to_base64_data_uri(end)
+        else:
+            logger.warning("end_image 文件不存在，已忽略: %s", end)
+    if request.reference_images:
+        refs: list[str] = []
+        for ref in request.reference_images:
+            p = Path(ref)
+            if p.exists():
+                _warn_if_large(p)
+                refs.append(image_to_base64_data_uri(p))
+            else:
+                logger.warning("reference_image 文件不存在，已忽略: %s", p)
+        if refs:
+            body["image_urls"] = refs
+    return body
+
+
+def _normalize_root(base_url: str) -> str:
+    """归一化为 root 形态：去尾斜杠 + 去末尾版本段（/v1、/v2beta 等）。
+
+    后续显式拼 ``/v2/video/generations``。不能用 ensure_openai_base_url —— 它会在
+    缺版本段时追加 ``/v1``，与本端点的 ``/v2`` 路径冲突。
+    """
+    s = base_url.strip().rstrip("/")
+    return re.sub(r"/v\d+[a-zA-Z]*$", "", s)
+
+
+def _extract_failure(state: dict) -> str | None:
+    if normalize_status(_first_str_by_paths(state, _STATUS_PATHS)) != "failed":
+        return None
+    err = _dig(state, ("error",))
+    if isinstance(err, dict):
+        msg = err.get("message") or err.get("name") or "unknown"
+    elif isinstance(err, str) and err.strip():
+        msg = err
+    else:
+        msg = "unknown"
+    return f"V2 视频生成失败: {msg}"
+
+
+class V2VideoGenerationsBackend:
+    """流派 C ``/v2/video/generations`` 通用视频后端。"""
+
+    def __init__(self, *, api_key: str, base_url: str, model: str, http_timeout: float = 60.0) -> None:
+        if not api_key:
+            raise ValueError("V2VideoGenerationsBackend 需要 api_key")
+        if not base_url:
+            raise ValueError("V2VideoGenerationsBackend 需要 base_url")
+        self._api_key = api_key
+        self._root = _normalize_root(base_url)
+        self._model = model
+        self._http_timeout = http_timeout
+        self._capabilities: set[VideoCapability] = {
+            VideoCapability.TEXT_TO_VIDEO,
+            VideoCapability.IMAGE_TO_VIDEO,
+            VideoCapability.SEED_CONTROL,
+        }
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_V2_VIDEO
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def capabilities(self) -> set[VideoCapability]:
+        return self._capabilities
+
+    @property
+    def video_capabilities(self) -> VideoCapabilities:
+        return VideoCapabilities(
+            first_frame=True,
+            last_frame=True,
+            reference_images=True,
+            max_reference_images=_DEFAULT_MAX_REFERENCE_IMAGES,
+        )
+
+    async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
+        body = build_request_body(self._model, request)
+        logger.info("V2 视频生成开始: model=%s duration=%s", self._model, request.duration_seconds)
+        logger.info("调用 %s 视频接口 payload=%s", self.name, format_kwargs_for_log(body))
+
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            generation_id = await self._create_task(client, body)
+            logger.info("V2 任务创建: generation_id=%s", generation_id)
+            if request.task_id is not None:
+                await persist_provider_job_id(request.task_id, generation_id, provider=PROVIDER_V2_VIDEO)
+            return await self._poll_and_build(client, generation_id, request, is_resume=False)
+
+    async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
+        """接续已 submit 的 V2 task：仅 poll + 下载（generation_id 已持久化）。"""
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            return await self._poll_and_build(client, job_id, request, is_resume=True)
+
+    @with_retry_async(
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+        retryable_errors=_V2_RETRYABLE_ERRORS,
+    )
+    async def _create_task(self, client: httpx.AsyncClient, body: dict) -> str:
+        resp = await client.post(f"{self._root}{_SUBMIT_PATH}", json=body, headers=self._headers())
+        resp.raise_for_status()
+        payload = resp.json()
+        generation_id = _first_str_by_paths(payload, _TASK_ID_PATHS)
+        if not generation_id:
+            raise RuntimeError(f"V2 创建任务返回体未能从已知路径提取 task_id: {payload}")
+        return generation_id
+
+    async def _poll_once(self, client: httpx.AsyncClient, generation_id: str) -> dict:
+        resp = await client.get(
+            f"{self._root}{_SUBMIT_PATH}",
+            params={"generation_id": generation_id},
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _poll_and_build(
+        self,
+        client: httpx.AsyncClient,
+        generation_id: str,
+        request: VideoGenerationRequest,
+        *,
+        is_resume: bool,
+    ) -> VideoGenerationResult:
+        # resume 路径下 404 直接抛 ResumeExpiredError，不走 poll_with_retry 的
+        # HTTPStatusError 重试（否则 404 会被重试到超时，过期任务永不落 [resume_expired]）。
+        async def _gated_poll() -> dict:
+            try:
+                return await self._poll_once(client, generation_id)
+            except httpx.HTTPStatusError as exc:
+                if is_resume and exc.response.status_code == 404:
+                    raise ResumeExpiredError(job_id=generation_id, provider=PROVIDER_V2_VIDEO) from exc
+                raise
+
+        final = await poll_with_retry(
+            poll_fn=_gated_poll,
+            is_done=lambda s: normalize_status(_first_str_by_paths(s, _STATUS_PATHS)) == "succeeded",
+            is_failed=_extract_failure,
+            poll_interval=_POLL_INTERVAL_SECONDS,
+            max_wait=self._max_wait(request.duration_seconds),
+            retryable_errors=_V2_RETRYABLE_ERRORS,
+            label="V2",
+        )
+
+        video_url = _first_str_by_paths(final, _VIDEO_URL_PATHS)
+        if not video_url:
+            raise RuntimeError(f"V2 任务完成但未能从已知路径提取视频 URL: {final}")
+        await self._download_with_retry(video_url, request.output_path)
+
+        return VideoGenerationResult(
+            video_path=request.output_path,
+            provider=PROVIDER_V2_VIDEO,
+            model=self._model,
+            duration_seconds=request.duration_seconds,
+            video_uri=video_url,
+            seed=request.seed,
+            task_id=generation_id,
+        )
+
+    @staticmethod
+    @with_retry_async(
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
+        retryable_errors=_V2_RETRYABLE_ERRORS,
+    )
+    async def _download_with_retry(video_url: str, output_path: Path) -> None:
+        """对齐其它后端的下载重试策略（5 次、5/10/20/40 秒），与生成阶段独立。"""
+        await download_video(video_url, output_path)
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"}
+
+    @staticmethod
+    def _max_wait(duration_seconds: int) -> float:
+        return max(_MIN_POLL_TIMEOUT_SECONDS, duration_seconds * _POLL_TIMEOUT_PER_SECOND)

--- a/lib/video_backends/v2_video_generations.py
+++ b/lib/video_backends/v2_video_generations.py
@@ -218,12 +218,15 @@ def _redacted_body(body: dict) -> dict:
 
 
 def _normalize_root(base_url: str) -> str:
-    """归一化为 root 形态：去尾斜杠 + 去末尾版本段（/v1、/v2beta 等）。
+    """归一化为 root 形态：补协议 + 去尾斜杠 + 去末尾版本段（/v1、/v2beta 等）。
 
     后续显式拼 ``/v2/video/generations``。不能用 ensure_openai_base_url —— 它会在
-    缺版本段时追加 ``/v1``，与本端点的 ``/v2`` 路径冲突。
+    缺版本段时追加 ``/v1``，与本端点的 ``/v2`` 路径冲突。无 scheme 的纯域名（如
+    ``api.aimlapi.com``）先补 ``https://``，否则 httpx 拒收缺协议的相对 URL。
     """
     s = base_url.strip().rstrip("/")
+    if s and "://" not in s:
+        s = f"https://{s}"
     return re.sub(r"/v\d+(?:\.\d+)?[a-zA-Z]*$", "", s)
 
 

--- a/lib/video_backends/v2_video_generations.py
+++ b/lib/video_backends/v2_video_generations.py
@@ -207,19 +207,24 @@ def build_request_body(model: str, request: VideoGenerationRequest) -> dict:
     return body
 
 
-# 仅以下键允许进入日志（白名单，键集静态可判定，CodeQL 不再把整份 dict 保守标记为污点）。
-_SAFE_LOG_KEYS = frozenset({"model", "prompt", "duration", "aspect_ratio", "resolution", "seed"})
-# 这些键可能内嵌整张图片的 base64 data URI，固定替换为占位符（白名单外的未知键一律丢弃）。
-_IMAGE_BODY_KEYS = ("image_url", "last_image_url", "image_urls")
+def _log_fields(model: str, request: VideoGenerationRequest) -> dict:
+    """日志摘要：只从 request 的标量字段 + 图片「有无/数量」构造，绝不读取请求体里
+    由图片编码得到的 base64 data URI。
 
-
-def _redacted_body(body: dict) -> dict:
-    """日志用副本：仅保留白名单字段，图片字段替换为占位符；不就地修改入参。"""
-    view: dict = {key: body[key] for key in _SAFE_LOG_KEYS if key in body}
-    for key in _IMAGE_BODY_KEYS:
-        if key in body:
-            view[key] = "<redacted-image-data>"
-    return view
+    必须从 request 而非 build_request_body 的产物（body）派生——后者内嵌的图片 base64
+    是污点源，任何从该 dict 取值都会被静态分析判定为带污点并触发明文记录告警；图片只记数量。
+    """
+    return {
+        "model": model,
+        "prompt": request.prompt,
+        "duration": request.duration_seconds,
+        "aspect_ratio": request.aspect_ratio,
+        "resolution": request.resolution,
+        "seed": request.seed,
+        "start_image": bool(request.start_image),
+        "end_image": bool(request.end_image),
+        "reference_images": len(request.reference_images or []),
+    }
 
 
 def _normalize_root(base_url: str) -> str:
@@ -290,7 +295,7 @@ class V2VideoGenerationsBackend:
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         body = build_request_body(self._model, request)
         logger.info("V2 视频生成开始: model=%s duration=%s", self._model, request.duration_seconds)
-        logger.info("调用 %s 视频接口 payload=%s", self.name, format_kwargs_for_log(_redacted_body(body)))
+        logger.info("调用 %s 视频接口 payload=%s", self.name, format_kwargs_for_log(_log_fields(self._model, request)))
 
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             generation_id = await self._create_task(client, body)

--- a/lib/video_backends/v2_video_generations.py
+++ b/lib/video_backends/v2_video_generations.py
@@ -164,12 +164,16 @@ def build_request_body(model: str, request: VideoGenerationRequest) -> dict:
 
     图像走 base64 data URI 内嵌（与 newapi 一致）：首帧 ``image_url``、尾帧
     ``last_image_url``、参考数组 ``image_urls``。已知风险：部分中转站要求公网 URL
-    而非 base64（见研究报告 §8.2），真实接受形态留手动集成测试。
+    而非 base64，真实接受形态留手动集成测试。
     """
     # 延迟导入避免 image_backends ↔ video_backends 循环依赖
     from lib.image_backends.base import image_to_base64_data_uri
 
     body: dict = {"model": model, "prompt": request.prompt, "duration": request.duration_seconds}
+    # 画幅恒有值（默认 9:16），表达项目朝向意图；与 resolution 同属公共子集的尽力透传，
+    # 不识别该字段的中转站会忽略。漏发会让竖屏项目在按 aspect_ratio 出片的供应商上变横屏。
+    if request.aspect_ratio:
+        body["aspect_ratio"] = request.aspect_ratio
     if request.resolution:
         body["resolution"] = request.resolution
     if request.seed is not None:
@@ -203,6 +207,16 @@ def build_request_body(model: str, request: VideoGenerationRequest) -> dict:
     return body
 
 
+# 请求体里这些键可能内嵌整张图片的 base64 data URI，落日志前脱敏：
+# 避免明文记录用户图像，也防止日志体积被撑爆。
+_REDACTED_BODY_KEYS = frozenset({"image_url", "last_image_url", "image_urls"})
+
+
+def _redacted_body(body: dict) -> dict:
+    """日志用副本：内嵌图片字段替换为占位符，其余原样保留。"""
+    return {key: ("<redacted-image-data>" if key in _REDACTED_BODY_KEYS else value) for key, value in body.items()}
+
+
 def _normalize_root(base_url: str) -> str:
     """归一化为 root 形态：去尾斜杠 + 去末尾版本段（/v1、/v2beta 等）。
 
@@ -210,7 +224,7 @@ def _normalize_root(base_url: str) -> str:
     缺版本段时追加 ``/v1``，与本端点的 ``/v2`` 路径冲突。
     """
     s = base_url.strip().rstrip("/")
-    return re.sub(r"/v\d+[a-zA-Z]*$", "", s)
+    return re.sub(r"/v\d+(?:\.\d+)?[a-zA-Z]*$", "", s)
 
 
 def _extract_failure(state: dict) -> str | None:
@@ -268,7 +282,7 @@ class V2VideoGenerationsBackend:
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         body = build_request_body(self._model, request)
         logger.info("V2 视频生成开始: model=%s duration=%s", self._model, request.duration_seconds)
-        logger.info("调用 %s 视频接口 payload=%s", self.name, format_kwargs_for_log(body))
+        logger.info("调用 %s 视频接口 payload=%s", self.name, format_kwargs_for_log(_redacted_body(body)))
 
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             generation_id = await self._create_task(client, body)

--- a/lib/video_backends/v2_video_generations.py
+++ b/lib/video_backends/v2_video_generations.py
@@ -23,7 +23,6 @@ from pathlib import Path
 
 import httpx
 
-from lib.logging_utils import format_kwargs_for_log
 from lib.retry import (
     BASE_RETRYABLE_ERRORS,
     DEFAULT_BACKOFF_SECONDS,
@@ -58,6 +57,9 @@ _DEFAULT_MAX_REFERENCE_IMAGES = 4
 
 # 超过此阈值的图触发 warning（base64 编码后易触发中转站请求体上限）
 _LARGE_IMAGE_WARN_BYTES = 4 * 1024 * 1024
+
+# 日志摘要里 prompt 截断长度（避免长 prompt 撑爆日志）
+_PROMPT_LOG_MAX = 200
 
 # HTTPStatusError 不继承 RequestError，必须显式列出以便 5xx 响应走类型匹配而非字符串匹配
 _V2_RETRYABLE_ERRORS = BASE_RETRYABLE_ERRORS + (httpx.RequestError, httpx.HTTPStatusError)
@@ -208,15 +210,17 @@ def build_request_body(model: str, request: VideoGenerationRequest) -> dict:
 
 
 def _log_fields(model: str, request: VideoGenerationRequest) -> dict:
-    """日志摘要：只从 request 的标量字段 + 图片「有无/数量」构造，绝不读取请求体里
-    由图片编码得到的 base64 data URI。
+    """日志摘要：只从 request 的标量字段 + 图片「有无/数量」构造，自带 prompt 截断。
 
-    必须从 request 而非 build_request_body 的产物（body）派生——后者内嵌的图片 base64
-    是污点源，任何从该 dict 取值都会被静态分析判定为带污点并触发明文记录告警；图片只记数量。
+    两点刻意为之：① 从 request 而非 build_request_body 的产物 body 派生——body 内嵌的图片
+    base64 是污点源，从该 dict 取值会被静态分析判为带污点；图片只记有无/数量。② 直接喂
+    logger、不过 format_kwargs_for_log——后者内部含密钥脱敏分支，静态分析把其返回值整体判为
+    带 secret 污点；本摘要已自带去敏与截断，无需再过那层。
     """
+    prompt = request.prompt
     return {
         "model": model,
-        "prompt": request.prompt,
+        "prompt": prompt if len(prompt) <= _PROMPT_LOG_MAX else f"{prompt[:_PROMPT_LOG_MAX]}…<{len(prompt)} chars>",
         "duration": request.duration_seconds,
         "aspect_ratio": request.aspect_ratio,
         "resolution": request.resolution,
@@ -295,7 +299,7 @@ class V2VideoGenerationsBackend:
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         body = build_request_body(self._model, request)
         logger.info("V2 视频生成开始: model=%s duration=%s", self._model, request.duration_seconds)
-        logger.info("调用 %s 视频接口 payload=%s", self.name, format_kwargs_for_log(_log_fields(self._model, request)))
+        logger.info("调用 %s 视频接口 payload=%s", self.name, _log_fields(self._model, request))
 
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             generation_id = await self._create_task(client, body)

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -105,6 +105,11 @@ class TestInferEndpoint:
             ("imagen-4", "openai", "gemini-image"),  # imagen 一律 gemini-image
             ("imagen-4", "google", "gemini-image"),
             ("gemini-imagen-3", "openai", "gemini-image"),  # imagen 优先于 gemini 文本
+            # gemini 原生图像模型也按内容纠偏到 gemini-image（不被错推到 openai-images）
+            ("gemini-2.5-flash-image", "openai", "gemini-image"),
+            ("gemini-2.5-flash-image", "google", "gemini-image"),
+            ("gemini-2.0-flash-exp-image-generation", "openai", "gemini-image"),
+            ("gemini-3-pro-image-preview", "openai", "gemini-image"),
             # ── 新视频分支路由 ──
             ("seedance-1.0", "openai", "ark-seedance"),
             ("doubao-seedance-2-0", "openai", "ark-seedance"),

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -15,7 +15,7 @@ from lib.custom_provider.endpoints import (
 
 
 class TestRegistry:
-    def test_six_endpoints(self):
+    def test_endpoint_count(self):
         assert set(ENDPOINT_REGISTRY.keys()) == {
             "openai-chat",
             "gemini-generate",
@@ -25,13 +25,16 @@ class TestRegistry:
             "gemini-image",
             "openai-video",
             "newapi-video",
+            "v2-video-generations",
+            "ark-seedance",
+            "vidu-video",
         }
 
     def test_each_spec_has_required_fields(self):
         for key, spec in ENDPOINT_REGISTRY.items():
             assert spec.key == key
             assert spec.media_type in {"text", "image", "video"}
-            assert spec.family in {"openai", "google", "newapi"}
+            assert spec.family in {"openai", "google", "newapi", "v2", "ark", "vidu"}
             assert spec.display_name_key.startswith("endpoint_")
             assert callable(spec.build_backend)
             assert spec.request_method == "POST"
@@ -49,8 +52,17 @@ class TestRegistry:
             "request_method": "POST",
             "request_path_template": "/v1/chat/completions",
             "image_capabilities": None,
-            "video_max_reference_images": 0,
+            # 未声明的 endpoint cap 序列化为 None（resolver fallthrough 到 backend caps）
+            "video_max_reference_images": None,
         }
+
+    def test_new_video_endpoints_have_unset_cap(self):
+        """v2/ark/vidu 不在 endpoint 维度声明上限，由 resolver fallthrough 到 backend caps。"""
+        for key in ("v2-video-generations", "ark-seedance", "vidu-video"):
+            assert ENDPOINT_REGISTRY[key].video_max_reference_images is None
+        # 既有显式 int 保留，行为零变化
+        assert ENDPOINT_REGISTRY["openai-video"].video_max_reference_images == 1
+        assert ENDPOINT_REGISTRY["newapi-video"].video_max_reference_images == 0
 
     def test_media_type_groups(self):
         text_keys = {s.key for s in ENDPOINT_REGISTRY.values() if s.media_type == "text"}
@@ -58,7 +70,7 @@ class TestRegistry:
         video_keys = {s.key for s in ENDPOINT_REGISTRY.values() if s.media_type == "video"}
         assert text_keys == {"openai-chat", "gemini-generate"}
         assert image_keys == {"openai-images", "openai-images-generations", "openai-images-edits", "gemini-image"}
-        assert video_keys == {"openai-video", "newapi-video"}
+        assert video_keys == {"openai-video", "newapi-video", "v2-video-generations", "ark-seedance", "vidu-video"}
 
 
 class TestHelpers:
@@ -87,26 +99,38 @@ class TestInferEndpoint:
     @pytest.mark.parametrize(
         "model_id,discovery_format,expected",
         [
-            ("gpt-4o", "openai", "openai-chat"),
+            # ── content-first 纠偏（中转站普遍 discovery_format="openai" 却夹带原生 id）──
+            ("gemini-2.5-flash", "openai", "gemini-generate"),  # 不再被错推到 openai-chat
             ("gemini-2.5-flash", "google", "gemini-generate"),
-            ("gemini-2.5-flash", "openai", "openai-chat"),  # 中转站常见
+            ("imagen-4", "openai", "gemini-image"),  # imagen 一律 gemini-image
+            ("imagen-4", "google", "gemini-image"),
+            ("gemini-imagen-3", "openai", "gemini-image"),  # imagen 优先于 gemini 文本
+            # ── 新视频分支路由 ──
+            ("seedance-1.0", "openai", "ark-seedance"),
+            ("doubao-seedance-2-0", "openai", "ark-seedance"),
+            ("viduq3", "openai", "vidu-video"),
+            ("viduq3-mix", "openai", "vidu-video"),
+            ("viduq3-pro", "openai", "vidu-video"),
+            ("viduq3-turbo", "openai", "vidu-video"),
+            ("viduq3-i2v", "openai", "vidu-video"),
+            ("proxy/viduq3-turbo", "openai", "vidu-video"),
+            # ── 向后兼容（行为不变）──
+            ("gpt-4o", "openai", "openai-chat"),
             ("claude-sonnet-4.5", "openai", "openai-chat"),
             ("dall-e-3", "openai", "openai-images"),
             ("gpt-image-1", "openai", "openai-images"),
-            ("imagen-4", "google", "gemini-image"),
-            ("imagen-4", "openai", "openai-images"),
             ("flux-pro", "openai", "openai-images"),
             ("sora-2", "openai", "openai-video"),
+            ("SORA-2", "openai", "openai-video"),
             ("kling-v2", "openai", "openai-video"),
             ("veo-3", "openai", "openai-video"),
-            ("veo-3", "google", "openai-video"),  # 视频家族一律默认 openai-video
-            ("seedance-1.0", "openai", "openai-video"),
+            ("veo-3", "google", "openai-video"),  # 非 seedance/viduq3 视频 → openai-video
             ("hailuo-02", "openai", "openai-video"),
             ("seedream-3.0", "openai", "openai-images"),
             ("jimeng-3.0", "openai", "openai-images"),
             ("jimeng-video-3.0", "openai", "openai-video"),
             ("jimengvideo-3.0", "openai", "openai-video"),
-            ("SORA-2", "openai", "openai-video"),
+            # viduq1/viduq2 是 vidu 早期图像版本 → 维持 image 推断不变
             ("viduq1", "openai", "openai-images"),
             ("viduq1-classic", "openai", "openai-images"),
             ("my-proxy/viduq1", "openai", "openai-images"),
@@ -117,16 +141,25 @@ class TestInferEndpoint:
             ("vidu2", "openai", "openai-video"),
             ("vidu2.0", "openai", "openai-video"),
             ("provider:vidu2.0", "openai", "openai-video"),
-            ("viduq3", "openai", "openai-video"),
-            ("viduq3-mix", "openai", "openai-video"),
-            ("viduq3-pro", "openai", "openai-video"),
-            ("viduq3-turbo", "openai", "openai-video"),
-            ("proxy/viduq3-turbo", "openai", "openai-video"),
             ("vidu-tts", "openai", "openai-chat"),
         ],
     )
     def test_infer(self, model_id, discovery_format, expected):
         assert infer_endpoint(model_id, discovery_format) == expected
+
+    @pytest.mark.parametrize(
+        "model_id,discovery_format",
+        [
+            ("seedance-1.0", "openai"),
+            ("viduq3-turbo", "openai"),
+            ("kling-v2", "openai"),
+            ("some-v2-model", "openai"),
+            ("gpt-4o", "openai"),
+        ],
+    )
+    def test_v2_never_auto_inferred(self, model_id, discovery_format):
+        """v2-video-generations 命名碎片化无法可靠识别，永不自动推断，留用户手选。"""
+        assert infer_endpoint(model_id, discovery_format) != "v2-video-generations"
 
 
 def test_image_endpoint_registry_has_four_entries():

--- a/tests/test_custom_provider_factory.py
+++ b/tests/test_custom_provider_factory.py
@@ -67,6 +67,38 @@ class TestEndpointDispatch:
         create_custom_backend(provider=provider, model_id="kling-v2", endpoint="newapi-video")
         mock_cls.assert_called_once_with(api_key="sk-test", base_url="https://api.example.com/v1", model="kling-v2")
 
+    @patch("lib.custom_provider.endpoints.V2VideoGenerationsBackend")
+    def test_v2_video_generations(self, mock_cls):
+        provider = _make_provider(base_url="https://api.aimlapi.com")
+        result = create_custom_backend(
+            provider=provider, model_id="bytedance/seedance-1-0-lite-i2v", endpoint="v2-video-generations"
+        )
+        assert isinstance(result, CustomVideoBackend)
+        # base_url 原样下传，归一化由 V2VideoGenerationsBackend 内部处理
+        mock_cls.assert_called_once_with(
+            api_key="sk-test", base_url="https://api.aimlapi.com", model="bytedance/seedance-1-0-lite-i2v"
+        )
+
+    @patch("lib.custom_provider.endpoints.ArkVideoBackend")
+    def test_ark_seedance(self, mock_cls):
+        provider = _make_provider(base_url="https://relay.example.com")
+        result = create_custom_backend(provider=provider, model_id="doubao-seedance-2-0", endpoint="ark-seedance")
+        assert isinstance(result, CustomVideoBackend)
+        # 仅 host → 补全 ark 协议挂载路径 /api/v3
+        mock_cls.assert_called_once_with(
+            api_key="sk-test", base_url="https://relay.example.com/api/v3", model="doubao-seedance-2-0"
+        )
+
+    @patch("lib.custom_provider.endpoints.ViduVideoBackend")
+    def test_vidu_video(self, mock_cls):
+        provider = _make_provider(base_url="https://relay.example.com")
+        result = create_custom_backend(provider=provider, model_id="viduq3-turbo", endpoint="vidu-video")
+        assert isinstance(result, CustomVideoBackend)
+        # 仅 host → 补全 vidu 协议挂载路径 /ent/v2
+        mock_cls.assert_called_once_with(
+            api_key="sk-test", base_url="https://relay.example.com/ent/v2", model="viduq3-turbo"
+        )
+
     @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
     def test_openai_images_generations(self, mock_cls):
         provider = _make_provider()
@@ -114,6 +146,21 @@ class TestUrlNormalization:
         provider = _make_provider(base_url="")
         create_custom_backend(provider=provider, model_id="gemini-2.5", endpoint="gemini-generate")
         mock_cls.assert_called_once_with(api_key="sk-test", base_url=None, model="gemini-2.5")
+
+    @patch("lib.custom_provider.endpoints.ArkVideoBackend")
+    def test_ark_explicit_path_passthrough(self, mock_cls):
+        """已带显式路径（/api/v3）→ 原样信任，不重复叠加。"""
+        provider = _make_provider(base_url="https://relay.example.com/api/v3")
+        create_custom_backend(provider=provider, model_id="doubao-seedance-2-0", endpoint="ark-seedance")
+        mock_cls.assert_called_once_with(
+            api_key="sk-test", base_url="https://relay.example.com/api/v3", model="doubao-seedance-2-0"
+        )
+
+    @patch("lib.custom_provider.endpoints.ViduVideoBackend")
+    def test_vidu_explicit_path_passthrough(self, mock_cls):
+        provider = _make_provider(base_url="https://api.vidu.cn/ent/v2")
+        create_custom_backend(provider=provider, model_id="viduq3-turbo", endpoint="vidu-video")
+        mock_cls.assert_called_once_with(api_key="sk-test", base_url="https://api.vidu.cn/ent/v2", model="viduq3-turbo")
 
 
 class TestErrors:

--- a/tests/test_custom_provider_factory.py
+++ b/tests/test_custom_provider_factory.py
@@ -162,9 +162,45 @@ class TestUrlNormalization:
         create_custom_backend(provider=provider, model_id="viduq3-turbo", endpoint="vidu-video")
         mock_cls.assert_called_once_with(api_key="sk-test", base_url="https://api.vidu.cn/ent/v2", model="viduq3-turbo")
 
+    @patch("lib.custom_provider.endpoints.ArkVideoBackend")
+    def test_ark_host_only_no_scheme(self, mock_cls):
+        """纯域名（无 scheme）→ 补 https:// 再挂载 /api/v3。"""
+        provider = _make_provider(base_url="relay.example.com")
+        create_custom_backend(provider=provider, model_id="doubao-seedance-2-0", endpoint="ark-seedance")
+        mock_cls.assert_called_once_with(
+            api_key="sk-test", base_url="https://relay.example.com/api/v3", model="doubao-seedance-2-0"
+        )
+
+    @patch("lib.custom_provider.endpoints.ViduVideoBackend")
+    def test_vidu_host_only_no_scheme(self, mock_cls):
+        provider = _make_provider(base_url="relay.example.com")
+        create_custom_backend(provider=provider, model_id="viduq3-turbo", endpoint="vidu-video")
+        mock_cls.assert_called_once_with(
+            api_key="sk-test", base_url="https://relay.example.com/ent/v2", model="viduq3-turbo"
+        )
+
+    @patch("lib.custom_provider.endpoints.ArkVideoBackend")
+    def test_ark_empty_base_url_normalizes_to_none(self, mock_cls):
+        """空 base_url → _ensure_url_path_suffix 归一化为 None 下传（不强行补挂载路径）。"""
+        provider = _make_provider(base_url="")
+        create_custom_backend(provider=provider, model_id="doubao-seedance-2-0", endpoint="ark-seedance")
+        mock_cls.assert_called_once_with(api_key="sk-test", base_url=None, model="doubao-seedance-2-0")
+
+    @patch("lib.custom_provider.endpoints.ViduVideoBackend")
+    def test_vidu_empty_base_url_normalizes_to_none(self, mock_cls):
+        provider = _make_provider(base_url="")
+        create_custom_backend(provider=provider, model_id="viduq3-turbo", endpoint="vidu-video")
+        mock_cls.assert_called_once_with(api_key="sk-test", base_url=None, model="viduq3-turbo")
+
 
 class TestErrors:
     def test_unknown_endpoint(self):
         provider = _make_provider()
         with pytest.raises(ValueError, match="unknown endpoint"):
             create_custom_backend(provider=provider, model_id="claude-4", endpoint="anthropic-messages")
+
+    def test_v2_empty_base_url_raises(self):
+        """v2-video-generations 强制要求 base_url（无默认 host），空值 fail-loud。"""
+        provider = _make_provider(base_url="")
+        with pytest.raises(ValueError, match="需要 base_url"):
+            create_custom_backend(provider=provider, model_id="some-model", endpoint="v2-video-generations")

--- a/tests/test_custom_provider_resolution.py
+++ b/tests/test_custom_provider_resolution.py
@@ -245,3 +245,47 @@ async def test_custom_video_max_refs_fallthrough_failure_raises(db_session: Asyn
     with patch("lib.config.resolver.create_custom_backend", side_effect=RuntimeError("boom")):
         with pytest.raises(ValueError, match="failed to construct backend"):
             await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
+
+
+async def test_custom_video_max_refs_negative_caps_raises(db_session: AsyncSession):
+    """endpoint cap=None，fallthrough 读到 backend 负数 caps → raise ValueError（不静默下传坏值）。"""
+    from unittest.mock import MagicMock, patch
+
+    from lib.config.resolver import ConfigResolver
+    from lib.config.service import ConfigService
+    from lib.custom_provider import make_provider_id
+    from lib.custom_provider.backends import CustomVideoBackend
+
+    provider = CustomProvider(
+        display_name="VideoProv",
+        discovery_format="openai",
+        base_url="https://api.example.com",
+        api_key="k",
+    )
+    db_session.add(provider)
+    await db_session.flush()
+
+    model = CustomProviderModel(
+        provider_id=provider.id,
+        model_id="doubao-seedance-2-0",
+        display_name="Vid Model",
+        endpoint="ark-seedance",
+        is_default=True,
+        is_enabled=True,
+        supported_durations="[5, 10]",
+    )
+    db_session.add(model)
+    await db_session.flush()
+
+    provider_id_str = make_provider_id(provider.id)
+    project = {"video_backend": f"{provider_id_str}/doubao-seedance-2-0"}
+
+    factory = async_sessionmaker(bind=db_session.get_bind(), class_=AsyncSession, expire_on_commit=False)  # type: ignore[call-overload]
+    svc = ConfigService(db_session)
+    resolver = ConfigResolver(factory, _bound_session=db_session)
+
+    bad_backend = MagicMock(spec=CustomVideoBackend)
+    bad_backend.video_capabilities.max_reference_images = -1
+    with patch("lib.config.resolver.create_custom_backend", return_value=bad_backend):
+        with pytest.raises(ValueError, match="invalid backend max_reference_images"):
+            await resolver._resolve_video_capabilities_from_project(svc, db_session, project)

--- a/tests/test_custom_provider_resolution.py
+++ b/tests/test_custom_provider_resolution.py
@@ -247,6 +247,7 @@ async def test_custom_video_max_refs_fallthrough_failure_raises(db_session: Asyn
             await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
 
 
+@pytest.mark.asyncio
 async def test_custom_video_max_refs_negative_caps_raises(db_session: AsyncSession):
     """endpoint cap=None，fallthrough 读到 backend 负数 caps → raise ValueError（不静默下传坏值）。"""
     from unittest.mock import MagicMock, patch

--- a/tests/test_custom_provider_resolution.py
+++ b/tests/test_custom_provider_resolution.py
@@ -153,16 +153,21 @@ async def test_video_capabilities_endpoint_mismatch_raises(db_session: AsyncSess
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "endpoint, expected_max_refs",
+    "endpoint, model_id, expected_max_refs",
     [
-        ("openai-video", 1),
-        ("newapi-video", 0),
+        # 显式 int：直接用 endpoint cap（行为零变化）
+        ("openai-video", "vid-model", 1),
+        ("newapi-video", "vid-model", 0),
+        # 未声明（None）：fallthrough 到 backend video_capabilities 读该 model 真实上限
+        ("ark-seedance", "doubao-seedance-2-0", 9),
+        ("vidu-video", "viduq3-turbo", 7),
     ],
 )
 async def test_custom_video_max_reference_images_from_endpoint(
-    db_session: AsyncSession, endpoint: str, expected_max_refs: int
+    db_session: AsyncSession, endpoint: str, model_id: str, expected_max_refs: int
 ):
-    """custom 视频 model 的 max_reference_images 经 ENDPOINT_REGISTRY 派生，不再静默落默认值。"""
+    """custom 视频 model 的 max_reference_images 经 ENDPOINT_REGISTRY 派生：endpoint cap
+    为显式 int 时直接用；为 None 时 fallthrough 到 backend caps，均不静默落默认值。"""
     from lib.config.resolver import ConfigResolver
     from lib.config.service import ConfigService
     from lib.custom_provider import make_provider_id
@@ -178,7 +183,7 @@ async def test_custom_video_max_reference_images_from_endpoint(
 
     model = CustomProviderModel(
         provider_id=provider.id,
-        model_id="vid-model",
+        model_id=model_id,
         display_name="Vid Model",
         endpoint=endpoint,
         is_default=True,
@@ -189,7 +194,7 @@ async def test_custom_video_max_reference_images_from_endpoint(
     await db_session.flush()
 
     provider_id_str = make_provider_id(provider.id)
-    project = {"video_backend": f"{provider_id_str}/vid-model"}
+    project = {"video_backend": f"{provider_id_str}/{model_id}"}
 
     factory = async_sessionmaker(bind=db_session.get_bind(), class_=AsyncSession, expire_on_commit=False)  # type: ignore[call-overload]
     svc = ConfigService(db_session)
@@ -198,3 +203,45 @@ async def test_custom_video_max_reference_images_from_endpoint(
     caps = await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
     assert caps["source"] == "custom"
     assert caps["max_reference_images"] == expected_max_refs
+
+
+@pytest.mark.asyncio
+async def test_custom_video_max_refs_fallthrough_failure_raises(db_session: AsyncSession):
+    """endpoint cap=None 且 backend 构造失败 → raise ValueError（不静默裁剪为 0）。"""
+    from unittest.mock import patch
+
+    from lib.config.resolver import ConfigResolver
+    from lib.config.service import ConfigService
+    from lib.custom_provider import make_provider_id
+
+    provider = CustomProvider(
+        display_name="VideoProv",
+        discovery_format="openai",
+        base_url="https://api.example.com",
+        api_key="k",
+    )
+    db_session.add(provider)
+    await db_session.flush()
+
+    model = CustomProviderModel(
+        provider_id=provider.id,
+        model_id="doubao-seedance-2-0",
+        display_name="Vid Model",
+        endpoint="ark-seedance",
+        is_default=True,
+        is_enabled=True,
+        supported_durations="[5, 10]",
+    )
+    db_session.add(model)
+    await db_session.flush()
+
+    provider_id_str = make_provider_id(provider.id)
+    project = {"video_backend": f"{provider_id_str}/doubao-seedance-2-0"}
+
+    factory = async_sessionmaker(bind=db_session.get_bind(), class_=AsyncSession, expire_on_commit=False)  # type: ignore[call-overload]
+    svc = ConfigService(db_session)
+    resolver = ConfigResolver(factory, _bound_session=db_session)
+
+    with patch("lib.config.resolver.create_custom_backend", side_effect=RuntimeError("boom")):
+        with pytest.raises(ValueError, match="failed to construct backend"):
+            await resolver._resolve_video_capabilities_from_project(svc, db_session, project)

--- a/tests/test_custom_providers_api.py
+++ b/tests/test_custom_providers_api.py
@@ -212,6 +212,9 @@ class TestEndpointCatalog:
             "gemini-image",
             "openai-video",
             "newapi-video",
+            "v2-video-generations",
+            "ark-seedance",
+            "vidu-video",
         }
 
     def test_descriptor_shape(self, client: TestClient):

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -17,6 +17,7 @@ from lib.video_backends.v2_video_generations import (
     _extract_failure,
     _first_str_by_paths,
     _normalize_root,
+    _redacted_body,
     build_request_body,
     normalize_status,
 )
@@ -128,8 +129,13 @@ class TestTaskIdExtraction:
 
 class TestBuildRequestBody:
     def test_text_to_video_minimal(self, tmp_path):
+        # aspect_ratio 恒透传（默认 9:16），表达项目朝向
         body = build_request_body("kling-v2", _req(tmp_path, duration_seconds=8))
-        assert body == {"model": "kling-v2", "prompt": "a cat", "duration": 8}
+        assert body == {"model": "kling-v2", "prompt": "a cat", "duration": 8, "aspect_ratio": "9:16"}
+
+    def test_aspect_ratio_passed_through(self, tmp_path):
+        body = build_request_body("m", _req(tmp_path, aspect_ratio="16:9"))
+        assert body["aspect_ratio"] == "16:9"
 
     def test_includes_seed_and_resolution(self, tmp_path):
         body = build_request_body("m", _req(tmp_path, seed=42, resolution="720p"))
@@ -188,7 +194,29 @@ class TestNormalizeRoot:
             ("https://api.aimlapi.com/v1", "https://api.aimlapi.com"),
             ("https://api.aimlapi.com/v2", "https://api.aimlapi.com"),
             ("https://api.aimlapi.com/v1beta", "https://api.aimlapi.com"),
+            # 带小版本号的版本段（/v1.1、/v1.0）也归一化
+            ("https://api.aimlapi.com/v1.1", "https://api.aimlapi.com"),
+            ("https://api.aimlapi.com/v1.0", "https://api.aimlapi.com"),
         ],
     )
     def test_strips_version_suffix(self, base_url, expected):
         assert _normalize_root(base_url) == expected
+
+
+class TestRedactedBody:
+    def test_image_fields_redacted(self):
+        body = {
+            "model": "m",
+            "prompt": "p",
+            "image_url": "data:image/png;base64,AAAA",
+            "last_image_url": "data:image/png;base64,BBBB",
+            "image_urls": ["data:image/png;base64,CCCC"],
+        }
+        safe = _redacted_body(body)
+        assert safe["model"] == "m"
+        assert safe["prompt"] == "p"
+        assert safe["image_url"] == "<redacted-image-data>"
+        assert safe["last_image_url"] == "<redacted-image-data>"
+        assert safe["image_urls"] == "<redacted-image-data>"
+        # 原 body 不被就地修改
+        assert body["image_url"].startswith("data:image/png;base64,")

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -23,8 +23,8 @@ from lib.video_backends.v2_video_generations import (
     _dig,
     _extract_failure,
     _first_str_by_paths,
+    _log_fields,
     _normalize_root,
-    _redacted_body,
     build_request_body,
     normalize_status,
 )
@@ -249,28 +249,30 @@ class TestNormalizeRoot:
         assert _normalize_root(base_url) == expected
 
 
-class TestRedactedBody:
-    def test_image_fields_redacted(self):
-        body = {
-            "model": "m",
-            "prompt": "p",
-            "image_url": "data:image/png;base64,AAAA",
-            "last_image_url": "data:image/png;base64,BBBB",
-            "image_urls": ["data:image/png;base64,CCCC"],
-        }
-        safe = _redacted_body(body)
-        assert safe["model"] == "m"
-        assert safe["prompt"] == "p"
-        assert safe["image_url"] == "<redacted-image-data>"
-        assert safe["last_image_url"] == "<redacted-image-data>"
-        assert safe["image_urls"] == "<redacted-image-data>"
-        # 原 body 不被就地修改
-        assert body["image_url"].startswith("data:image/png;base64,")
+class TestLogFields:
+    def test_summary_built_from_request_never_base64(self, tmp_path):
+        start = _write_img(tmp_path, "s.png")
+        refs = [_write_img(tmp_path, "r1.png"), _write_img(tmp_path, "r2.png")]
+        fields = _log_fields(
+            "seedance-1.0",
+            _req(tmp_path, start_image=start, reference_images=refs, resolution="720p", seed=7, aspect_ratio="16:9"),
+        )
+        assert fields["model"] == "seedance-1.0"
+        assert fields["prompt"] == "a cat"
+        assert fields["resolution"] == "720p"
+        assert fields["aspect_ratio"] == "16:9"
+        assert fields["seed"] == 7
+        # 图片只记有无/数量，绝不出现 base64 data URI
+        assert fields["start_image"] is True
+        assert fields["end_image"] is False
+        assert fields["reference_images"] == 2
+        assert not any("base64" in str(v) for v in fields.values())
 
-    def test_unknown_keys_dropped(self):
-        # 白名单外的键一律不进日志（CodeQL 不再保守标记整份 dict）
-        safe = _redacted_body({"model": "m", "duration": 5, "negative_prompt": "x", "secret": "y"})
-        assert safe == {"model": "m", "duration": 5}
+    def test_no_images(self, tmp_path):
+        fields = _log_fields("m", _req(tmp_path))
+        assert fields["start_image"] is False
+        assert fields["end_image"] is False
+        assert fields["reference_images"] == 0
 
 
 class TestBuildRequestBodyBranches:

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -6,13 +6,20 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
-from lib.video_backends.base import VideoGenerationRequest
+from lib.video_backends.base import (
+    ResumeExpiredError,
+    VideoCapability,
+    VideoGenerationRequest,
+)
 from lib.video_backends.v2_video_generations import (
     _TASK_ID_PATHS,
     _VIDEO_URL_PATHS,
+    PROVIDER_V2_VIDEO,
     _dig,
     _extract_failure,
     _first_str_by_paths,
@@ -21,6 +28,42 @@ from lib.video_backends.v2_video_generations import (
     build_request_body,
     normalize_status,
 )
+from lib.video_backends.v2_video_generations import (
+    V2VideoGenerationsBackend as _V2Backend,
+)
+
+
+def _make_response(status_code: int, json_body: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _make_http_error(status_code: int, message: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://x/v2/video/generations")
+    response = httpx.Response(status_code, request=request, text=message)
+    return httpx.HTTPStatusError(f"error '{status_code}'", request=request, response=response)
+
+
+def _fake_download_factory(payload: bytes = b"mp4-bytes"):
+    async def _fake(url: str, output_path: Path, *, timeout: int = 120) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(payload)
+
+    return _fake
+
+
+def _mock_client(*, post=None, get=None) -> AsyncMock:
+    client = AsyncMock()
+    if post is not None:
+        client.post = AsyncMock(return_value=post) if not isinstance(post, list) else AsyncMock(side_effect=post)
+    if get is not None:
+        client.get = AsyncMock(return_value=get) if not isinstance(get, list) else AsyncMock(side_effect=get)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
 
 
 def _req(tmp_path: Path, **kwargs) -> VideoGenerationRequest:
@@ -223,3 +266,186 @@ class TestRedactedBody:
         assert safe["image_urls"] == "<redacted-image-data>"
         # 原 body 不被就地修改
         assert body["image_url"].startswith("data:image/png;base64,")
+
+    def test_unknown_keys_dropped(self):
+        # 白名单外的键一律不进日志（CodeQL 不再保守标记整份 dict）
+        safe = _redacted_body({"model": "m", "duration": 5, "negative_prompt": "x", "secret": "y"})
+        assert safe == {"model": "m", "duration": 5}
+
+
+class TestBuildRequestBodyBranches:
+    def test_large_image_warns(self, tmp_path, caplog):
+        import logging
+
+        img = _write_img(tmp_path, "big.png")
+        with patch("lib.video_backends.v2_video_generations._LARGE_IMAGE_WARN_BYTES", 0):
+            with caplog.at_level(logging.WARNING, logger="lib.video_backends.v2_video_generations"):
+                body = build_request_body("m", _req(tmp_path, start_image=img))
+        assert body["image_url"].startswith("data:image/png;base64,")
+        assert any("图片较大" in r.message for r in caplog.records)
+
+    def test_missing_reference_image_skipped(self, tmp_path):
+        present = _write_img(tmp_path, "r1.png")
+        body = build_request_body("m", _req(tmp_path, reference_images=[present, tmp_path / "missing.png"]))
+        assert len(body["image_urls"]) == 1
+
+    def test_missing_end_image_omitted(self, tmp_path):
+        start = _write_img(tmp_path, "start.png")
+        body = build_request_body("m", _req(tmp_path, start_image=start, end_image=tmp_path / "no_end.png"))
+        assert "image_url" in body
+        assert "last_image_url" not in body
+
+    def test_all_reference_images_missing_omits_key(self, tmp_path):
+        body = build_request_body("m", _req(tmp_path, reference_images=[tmp_path / "nope.png"]))
+        assert "image_urls" not in body
+
+
+class TestV2BackendHttp:
+    """V2 backend HTTP 流程（submit → poll → 提取 → 下载 / resume），全程 mock httpx，不跑真实网络。"""
+
+    @staticmethod
+    def _backend() -> _V2Backend:
+        return _V2Backend(api_key="sk-test", base_url="https://api.aimlapi.com", model="seedance-1.0")
+
+    def test_name_model_capabilities(self):
+        b = self._backend()
+        assert b.name == PROVIDER_V2_VIDEO
+        assert b.model == "seedance-1.0"
+        assert VideoCapability.TEXT_TO_VIDEO in b.capabilities
+        assert VideoCapability.IMAGE_TO_VIDEO in b.capabilities
+        caps = b.video_capabilities
+        assert caps.first_frame and caps.last_frame and caps.reference_images
+        assert caps.max_reference_images == 4
+
+    def test_constructor_requires_api_key(self):
+        with pytest.raises(ValueError, match="api_key"):
+            _V2Backend(api_key="", base_url="https://x", model="m")
+
+    def test_constructor_requires_base_url(self):
+        with pytest.raises(ValueError, match="base_url"):
+            _V2Backend(api_key="k", base_url="", model="m")
+
+    @pytest.mark.asyncio
+    async def test_generate_happy_path(self, tmp_path: Path):
+        client = _mock_client(
+            post=_make_response(200, {"id": "gen-1", "status": "queued"}),
+            get=[
+                _make_response(200, {"id": "gen-1", "status": "generating"}),
+                _make_response(200, {"id": "gen-1", "status": "completed", "video": {"url": "https://cdn/v.mp4"}}),
+            ],
+        )
+        fake_dl = AsyncMock(side_effect=_fake_download_factory(b"mp4"))
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.v2_video_generations.download_video", fake_dl),
+        ):
+            req = VideoGenerationRequest(prompt="a cat", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            result = await self._backend().generate(req)
+        assert result.video_path.read_bytes() == b"mp4"
+        assert result.provider == PROVIDER_V2_VIDEO
+        assert result.model == "seedance-1.0"
+        assert result.task_id == "gen-1"
+        assert result.video_uri == "https://cdn/v.mp4"
+        post_call = client.post.call_args
+        assert post_call.args[0] == "https://api.aimlapi.com/v2/video/generations"
+        assert post_call.kwargs["json"]["model"] == "seedance-1.0"
+        assert post_call.kwargs["headers"]["Authorization"] == "Bearer sk-test"
+        assert client.get.call_args.kwargs["params"] == {"generation_id": "gen-1"}
+        fake_dl.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_generate_persists_job_id_when_task_id_set(self, tmp_path: Path):
+        client = _mock_client(
+            post=_make_response(200, {"id": "gen-9"}),
+            get=_make_response(200, {"status": "completed", "video": {"url": "https://cdn/v.mp4"}}),
+        )
+        persist = AsyncMock()
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
+            patch(
+                "lib.video_backends.v2_video_generations.download_video",
+                AsyncMock(side_effect=_fake_download_factory()),
+            ),
+            patch("lib.video_backends.v2_video_generations.persist_provider_job_id", persist),
+        ):
+            req = VideoGenerationRequest(
+                prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5, task_id="task-77"
+            )
+            await self._backend().generate(req)
+        persist.assert_awaited_once()
+        call = persist.await_args
+        assert call is not None
+        assert call.args[0] == "task-77"
+        assert call.args[1] == "gen-9"
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_task_id_raises(self, tmp_path: Path):
+        client = _mock_client(post=_make_response(200, {"status": "queued"}))
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.v2_video_generations.download_video", AsyncMock()),
+        ):
+            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            with pytest.raises(RuntimeError, match="task_id"):
+                await self._backend().generate(req)
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_video_url_raises(self, tmp_path: Path):
+        client = _mock_client(
+            post=_make_response(200, {"id": "g"}),
+            get=_make_response(200, {"status": "completed"}),
+        )
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.v2_video_generations.download_video", AsyncMock()),
+        ):
+            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            with pytest.raises(RuntimeError, match="视频 URL"):
+                await self._backend().generate(req)
+
+    @pytest.mark.asyncio
+    async def test_generate_failed_status_raises(self, tmp_path: Path):
+        client = _mock_client(
+            post=_make_response(200, {"id": "g"}),
+            get=_make_response(200, {"status": "error", "error": {"message": "boom"}}),
+        )
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.v2_video_generations.download_video", AsyncMock()),
+        ):
+            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            with pytest.raises(RuntimeError, match="boom"):
+                await self._backend().generate(req)
+
+    @pytest.mark.asyncio
+    async def test_resume_video_poll_and_download(self, tmp_path: Path):
+        client = _mock_client(get=_make_response(200, {"status": "completed", "video": {"url": "https://cdn/r.mp4"}}))
+        fake_dl = AsyncMock(side_effect=_fake_download_factory(b"r"))
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.v2_video_generations.download_video", fake_dl),
+        ):
+            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            result = await self._backend().resume_video("gen-resume", req)
+        assert result.task_id == "gen-resume"
+        assert result.video_path.read_bytes() == b"r"
+        # resume 只 poll，不再 submit
+        client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resume_404_raises_resume_expired(self, tmp_path: Path):
+        resp404 = _make_response(404, {})
+        resp404.raise_for_status = MagicMock(side_effect=_make_http_error(404, "not found"))
+        client = _mock_client(get=resp404)
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
+        ):
+            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            with pytest.raises(ResumeExpiredError):
+                await self._backend().resume_video("gen-expired", req)

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -274,6 +274,12 @@ class TestLogFields:
         assert fields["end_image"] is False
         assert fields["reference_images"] == 0
 
+    def test_long_prompt_truncated(self, tmp_path):
+        long_prompt = "x" * 1000
+        fields = _log_fields("m", _req(tmp_path, prompt=long_prompt))
+        assert len(fields["prompt"]) < len(long_prompt)
+        assert "1000 chars" in fields["prompt"]
+
 
 class TestBuildRequestBodyBranches:
     def test_large_image_warns(self, tmp_path, caplog):

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -197,6 +197,9 @@ class TestNormalizeRoot:
             # 带小版本号的版本段（/v1.1、/v1.0）也归一化
             ("https://api.aimlapi.com/v1.1", "https://api.aimlapi.com"),
             ("https://api.aimlapi.com/v1.0", "https://api.aimlapi.com"),
+            # 无 scheme 的纯域名补 https://（否则 httpx 拒收相对 URL）
+            ("api.aimlapi.com", "https://api.aimlapi.com"),
+            ("api.aimlapi.com/v1", "https://api.aimlapi.com"),
         ],
     )
     def test_strips_version_suffix(self, base_url, expected):

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -1,0 +1,194 @@
+"""V2VideoGenerationsBackend 纯函数单测（请求体映射 / 状态归一 / 多路径提取）。
+
+只测外部可观察行为与纯函数，不跑真实 HTTP。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lib.video_backends.base import VideoGenerationRequest
+from lib.video_backends.v2_video_generations import (
+    _TASK_ID_PATHS,
+    _VIDEO_URL_PATHS,
+    _dig,
+    _extract_failure,
+    _first_str_by_paths,
+    _normalize_root,
+    build_request_body,
+    normalize_status,
+)
+
+
+def _req(tmp_path: Path, **kwargs) -> VideoGenerationRequest:
+    base = {"prompt": "a cat", "output_path": tmp_path / "out.mp4"}
+    base.update(kwargs)
+    return VideoGenerationRequest(**base)
+
+
+def _write_img(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.write_bytes(b"\x89PNG\r\n\x1a\n fake bytes")
+    return p
+
+
+class TestNormalizeStatus:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # aimlapi 官方枚举
+            ("queued", "queued"),
+            ("generating", "running"),
+            ("completed", "succeeded"),
+            ("error", "failed"),
+            # 跨厂商同义词（流派 C 路由到多家时底层串可能透传）
+            ("succeed", "succeeded"),  # Kling
+            ("Success", "succeeded"),  # MiniMax 首字母大写
+            ("Fail", "failed"),
+            ("expired", "failed"),
+            ("canceled", "failed"),
+            ("in_progress", "running"),  # Sora
+            ("Processing", "running"),  # Kling
+            ("PENDING", "queued"),  # DashScope 全大写
+            ("Queueing", "queued"),  # MiniMax
+            ("submitted", "queued"),  # Kling
+            ("  COMPLETED  ", "succeeded"),  # 大小写 + 空白
+            # 未知 / 非字符串 → 当 running 继续轮询
+            ("weird-status", "running"),
+            (None, "running"),
+            (99, "running"),
+        ],
+    )
+    def test_normalize(self, raw, expected):
+        assert normalize_status(raw) == expected
+
+
+class TestDig:
+    def test_walks_dict_and_list_index(self):
+        payload = {"data": {"task_result": {"videos": [{"url": "u0"}, {"url": "u1"}]}}}
+        assert _dig(payload, ("data", "task_result", "videos", 0, "url")) == "u0"
+
+    def test_missing_key_returns_none(self):
+        assert _dig({"a": 1}, ("a", "b")) is None
+
+    def test_list_index_out_of_range_returns_none(self):
+        assert _dig({"v": []}, ("v", 0)) is None
+
+    def test_type_mismatch_returns_none(self):
+        assert _dig({"v": "str"}, ("v", 0)) is None  # 期望 list 实为 str
+
+
+class TestVideoUrlExtraction:
+    @pytest.mark.parametrize(
+        "payload,expected",
+        [
+            ({"id": "g", "status": "completed", "video": {"url": "https://cdn/v.mp4"}}, "https://cdn/v.mp4"),
+            ({"assets": {"video": "https://a/v.mp4"}}, "https://a/v.mp4"),
+            ({"output": {"video_url": "https://w/v.mp4"}}, "https://w/v.mp4"),
+            ({"content": {"video_url": "https://s/v.mp4"}}, "https://s/v.mp4"),
+            ({"data": {"task_result": {"videos": [{"url": "https://k/v.mp4"}]}}}, "https://k/v.mp4"),
+            ({"url": "https://n/v.mp4"}, "https://n/v.mp4"),
+        ],
+    )
+    def test_extracts_first_match(self, payload, expected):
+        assert _first_str_by_paths(payload, _VIDEO_URL_PATHS) == expected
+
+    def test_priority_video_url_wins_over_bare_url(self):
+        payload = {"video": {"url": "https://primary/v.mp4"}, "url": "https://fallback/v.mp4"}
+        assert _first_str_by_paths(payload, _VIDEO_URL_PATHS) == "https://primary/v.mp4"
+
+    def test_all_miss_returns_none(self):
+        assert _first_str_by_paths({"foo": "bar"}, _VIDEO_URL_PATHS) is None
+
+    def test_empty_string_skipped(self):
+        payload = {"video": {"url": "   "}, "url": "https://fallback/v.mp4"}
+        assert _first_str_by_paths(payload, _VIDEO_URL_PATHS) == "https://fallback/v.mp4"
+
+
+class TestTaskIdExtraction:
+    @pytest.mark.parametrize(
+        "payload,expected",
+        [
+            ({"id": "gen_1"}, "gen_1"),
+            ({"task_id": "t1"}, "t1"),
+            ({"data": {"task_id": "d1"}}, "d1"),
+            ({"request_id": "r1"}, "r1"),
+            ({"data": {"taskId": "dt1"}}, "dt1"),
+            ({"id": 123}, "123"),  # int 容忍并 str 化
+        ],
+    )
+    def test_extracts(self, payload, expected):
+        assert _first_str_by_paths(payload, _TASK_ID_PATHS) == expected
+
+    def test_priority_id_wins(self):
+        assert _first_str_by_paths({"id": "primary", "task_id": "secondary"}, _TASK_ID_PATHS) == "primary"
+
+
+class TestBuildRequestBody:
+    def test_text_to_video_minimal(self, tmp_path):
+        body = build_request_body("kling-v2", _req(tmp_path, duration_seconds=8))
+        assert body == {"model": "kling-v2", "prompt": "a cat", "duration": 8}
+
+    def test_includes_seed_and_resolution(self, tmp_path):
+        body = build_request_body("m", _req(tmp_path, seed=42, resolution="720p"))
+        assert body["seed"] == 42
+        assert body["resolution"] == "720p"
+
+    def test_start_image_to_image_url(self, tmp_path):
+        img = _write_img(tmp_path, "start.png")
+        body = build_request_body("m", _req(tmp_path, start_image=img))
+        assert body["image_url"].startswith("data:image/png;base64,")
+
+    def test_end_image_to_last_image_url(self, tmp_path):
+        start = _write_img(tmp_path, "start.png")
+        end = _write_img(tmp_path, "end.png")
+        body = build_request_body("m", _req(tmp_path, start_image=start, end_image=end))
+        assert body["last_image_url"].startswith("data:image/png;base64,")
+
+    def test_reference_images_to_image_urls(self, tmp_path):
+        refs = [_write_img(tmp_path, "r1.png"), _write_img(tmp_path, "r2.png")]
+        body = build_request_body("m", _req(tmp_path, reference_images=refs))
+        assert isinstance(body["image_urls"], list)
+        assert len(body["image_urls"]) == 2
+        assert all(u.startswith("data:image/png;base64,") for u in body["image_urls"])
+
+    def test_missing_image_file_omitted(self, tmp_path):
+        body = build_request_body("m", _req(tmp_path, start_image=tmp_path / "nope.png"))
+        assert "image_url" not in body
+
+
+class TestExtractFailure:
+    def test_succeeded_returns_none(self):
+        assert _extract_failure({"status": "completed", "video": {"url": "u"}}) is None
+
+    def test_running_returns_none(self):
+        assert _extract_failure({"status": "generating"}) is None
+
+    def test_error_dict_message(self):
+        msg = _extract_failure({"status": "error", "error": {"message": "boom", "name": "E"}})
+        assert msg is not None and "boom" in msg
+
+    def test_error_string(self):
+        msg = _extract_failure({"status": "failed", "error": "explicit reason"})
+        assert msg is not None and "explicit reason" in msg
+
+    def test_error_without_detail(self):
+        msg = _extract_failure({"status": "error"})
+        assert msg is not None and "unknown" in msg
+
+
+class TestNormalizeRoot:
+    @pytest.mark.parametrize(
+        "base_url,expected",
+        [
+            ("https://api.aimlapi.com", "https://api.aimlapi.com"),
+            ("https://api.aimlapi.com/", "https://api.aimlapi.com"),
+            ("https://api.aimlapi.com/v1", "https://api.aimlapi.com"),
+            ("https://api.aimlapi.com/v2", "https://api.aimlapi.com"),
+            ("https://api.aimlapi.com/v1beta", "https://api.aimlapi.com"),
+        ],
+    )
+    def test_strips_version_suffix(self, base_url, expected):
+        assert _normalize_root(base_url) == expected


### PR DESCRIPTION
## 背景

接 AI 中转站的自定义供应商，当前视频 endpoint 下拉只有 `openai-video`（Sora `/v1/videos`）和 `newapi-video`（`/v1/video/generations`）两个。中转生态还有三种主流形态没覆盖：流派 C `/v2/video/generations`（单端点 + model 字段切换）、ark-seedance 原样代理、vidu-video 原样代理。同时点「获取模型列表」后 `infer_endpoint()` 在中转站普遍 `discovery_format="openai"` 下常把 `gemini-*` / `imagen-*` 原生 id 错推到 OpenAI 端点。

Closes #669

## 改动

- **新增 `V2VideoGenerationsBackend`**：通用流派 C `/v2/video/generations` 适配器。submit 拿 `generation_id`、`GET ?generation_id=` 轮询、终态取视频 URL 下载；视频 URL / task_id / status 各用一张多路径优先级表逐个试取，状态串归一化覆盖 aimlapi 官方枚举（queued/generating/completed/error）+ 跨厂商同义词。复用 `base.py` 的 `poll_with_retry` / `download_video` / `persist_provider_job_id`，submit/poll 拆分支持 resume。
- **视频 endpoint 2→5**：新增 `v2-video-generations` / `ark-seedance` / `vidu-video`。ark/vidu 直接复用现有 `ArkVideoBackend` / `ViduVideoBackend`（不改其本体），闭包仅在用户只填 host 时补全协议挂载路径（`/api/v3`、`/ent/v2`）。
- **`infer_endpoint` content-first 重写**：model id 内容优先于 discovery_format。修复 gemini→gemini-generate、imagen→gemini-image 的错配；seedance→ark-seedance、viduq3→vidu-video 自动路由；viduq1/viduq2（vidu 早期图像版本）维持图像推断不变；v2 命名碎片化不自动推断，留用户手选。
- **`EndpointSpec.video_max_reference_images` 改 `int | None`**：`None` 表「未声明」，resolver 在 endpoint cap 为 None 时 fallthrough 到 backend `video_capabilities` 读取该 model 真实上限（ark seedance-2→9、vidu→7、v2→保守默认），避免一个 endpoint 多 model、容量不同时被错压为 0。构造/读取失败 raise ValueError（与同函数 media_type 校验对称，fail-fast）。前端零影响：`EndpointDescriptor` 不声明该字段，pydantic 构造时丢弃 None。
- **前端 i18n**：三语补 3 个 `endpoint_*_display` key。

## 对 PRD 的偏离（已与需求方确认）

1. **V2 backend = 通用适配器，放弃 PRD 模块 1/2 的 per-model `ModelSchemaSpec` 派发表**。`/v2/video/generations` 本身就是「通用端口格式」，流派 C 的 I/O 契约即该端点的 canonical 契约。实现一份通用契约 + 容错解析，比按 N 个模型分支更稳、且只编码 1 个有文档出处的契约，不背 per-model schema 知识。
2. **endpoint display name 只加前端 `dashboard.ts`，不动后端 `lib/i18n/`**。现有 `endpoint_*_display` key 本就只在前端，后端 `lib/i18n` 只有 error 类 endpoint key；display name 是 UI 文案（前端 user-facing）。
3. **独立交付，不依赖声明式定价重构**。自定义供应商走用户配置价，新 endpoint 无需定价重构即可跑通。

## 数据核实修正（外部数据以 live doc 为准，不臆造）

按 aimlapi（流派 C canonical 代表）官方文档核实并修正了几处：`duration` 是 integer（非字符串）、轮询是 query-param 形态 `?generation_id=`（非 REST 子资源）、状态枚举含 `generating`/`error`、首帧 `image_url` / 尾帧 `last_image_url`。v2 backend 的 `max_reference_images` 为 generic 端点的保守默认（非供应商核实值，注释已标明）。

## 验证

- 后端：`uv run pytest tests/` → **3462 passed**；`uv run ruff check/format`、`uv run basedpyright` → **0 error**
- 前端：`pnpm lint` + `pnpm check`（typecheck + 624 vitest）→ 全绿
- 新增 `tests/test_v2_video_generations_backend.py`，扩展 endpoints/factory/resolution/api 测试（endpoint 数 8→11、video 组 2→5、infer_endpoint 新分支与回归、Option A fallthrough 含失败路径）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持三种新视频生成服务：V2 Video Generations、Volcengine Ark (Seedance)、Vidu Video。

* **文案**
  * 仪表盘新增对应多语言展示文案（中文/英文/越南语）。

* **错误处理**
  * 强化自定义视频后端解析与 base_url 归一化校验；未声明上限时回退至后端能力并对缺失或异常配置返回明确错误提示。

* **测试**
  * 扩展端点注册、推断、后端分发与视频后端工作流的单元测试覆盖，包含回退与异常场景验证。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->