### PR TITLE
fix(frontend): 自定义供应商 Base URL 占位符去掉 /v1 后缀

### DIFF
--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -451,7 +451,7 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
             type="url"
             value={baseUrl}
             onChange={(e) => setBaseUrl(e.target.value)}
-            placeholder="https://api.example.com/v1"
+            placeholder="https://api.example.com"
             className={INPUT_CLS}
           />
           {urlPreview && (


### PR DESCRIPTION
## Summary

- 自定义供应商表单的 Base URL 输入框占位符从 `https://api.example.com/v1` 改为 `https://api.example.com`,避免误导用户把 `/v1` 当作必填部分
- 后端 `urlPreviewFor` 已经自动补全:OpenAI 兼容格式补 `/v1`,Google 兼容统一规范成 `/v1beta`,所以占位符不需要带版本号
- 全局排查后只此一处问题;`AddCredentialModal` 的 `/anthropic` 是 Anthropic-relay 必需路径前缀,不在本次范围

## Test plan

- [x] `pnpm lint` 通过
- [x] `pnpm check`(typecheck + vitest 624 个测试)通过
- [ ] 启动前端,设置 → 自定义供应商 → 新建,确认:
  - Base URL 占位符显示 `https://api.example.com`(无 `/v1`)
  - 输入 `https://api.foo.com`(不带 `/v1`)时,预览显示 `https://api.foo.com/v1/models`(OpenAI)或 `https://api.foo.com/v1beta/models`(Google)
  - 输入 `https://api.foo.com/v2` 时,预览显示 `https://api.foo.com/v2/models`,保留用户指定的版本

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 更新了自定义提供商 Base URL 输入框的示例占位符文本。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->