### PR TITLE
fix(video-backends): 自定义供应商生成视频失败时立即报错,不再空等约 10 分钟

### DIFF
--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -124,6 +124,46 @@ IMAGE_MIME_TYPES: dict[str, str] = {
 }
 
 
+def is_retryable_http_status(status_code: int, *, retry_not_found: bool = False) -> bool:
+    """HTTP 状态码 → 是否可重试。
+
+    瞬态错误恒重试：408 Request Timeout / 425 Too Early / 429 Too Many Requests / 5xx。
+    404 默认快速失败（确定性"不存在"，如端点拼错）；轮询/下载场景传 retry_not_found=True，
+    按"任务提交后短暂未就绪 / 资源未传播"重试。其余 4xx（400/401/403/422 等）确定性客户端
+    错误一律快速失败——重试只会拖到 max_wait 超时，白占 worker 槽。
+    """
+    if status_code in (408, 425, 429):
+        return True
+    if 500 <= status_code <= 599:
+        return True
+    if status_code == 404:
+        return retry_not_found
+    return False
+
+
+def _retry_http_error(exc: Exception, *, retry_not_found: bool) -> bool:
+    """中转视频后端统一重试谓词。
+
+    HTTPStatusError 按 status_code 显式闸门判定，绕开 `_should_retry` 对异常字符串的子串
+    兜底——HTTPStatusError 消息含 URL/task_id，其中的 "500"/"503" 子串会被误判为可重试。
+    网络/传输错误（RequestError）与基础瞬态错误（Connection/Timeout）重试；其余（含
+    ResumeExpiredError 等业务异常）一律快速失败。
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        return is_retryable_http_status(exc.response.status_code, retry_not_found=retry_not_found)
+    return isinstance(exc, (httpx.RequestError, *BASE_RETRYABLE_ERRORS))
+
+
+def should_retry_submit(exc: Exception) -> bool:
+    """创建/提交阶段（POST）重试谓词：404 视为确定性端点错误，快速失败。"""
+    return _retry_http_error(exc, retry_not_found=False)
+
+
+def should_retry_poll(exc: Exception) -> bool:
+    """轮询/下载阶段（GET）重试谓词：404 视为"短暂未就绪"，重试。"""
+    return _retry_http_error(exc, retry_not_found=True)
+
+
 async def poll_with_retry[T](
     *,
     poll_fn: Callable[[], Awaitable[T]],
@@ -132,6 +172,7 @@ async def poll_with_retry[T](
     poll_interval: float,
     max_wait: float,
     retryable_errors: tuple[type[Exception], ...] = BASE_RETRYABLE_ERRORS,
+    retry_if: Callable[[Exception], bool] | None = None,
     label: str = "",
     on_progress: Callable[[T, float], None] | None = None,
 ) -> T:
@@ -143,19 +184,22 @@ async def poll_with_retry[T](
         is_failed: 判断轮询结果是否表示任务失败，返回错误信息或 None。
         poll_interval: 两次轮询之间的间隔（秒）。
         max_wait: 最大等待时间（秒），超时抛出 TimeoutError。
-        retryable_errors: 可重试的异常类型元组。
+        retryable_errors: 可重试的异常类型元组（未指定 retry_if 时生效）。
+        retry_if: 自定义重试谓词，指定时替代默认的 `_should_retry`，让调用方精确控制
+            哪些异常应当重试（如按 HTTP status_code 区分确定性 4xx 与瞬态 5xx）。
         label: 日志前缀（如 "Ark"、"Gemini"）。
         on_progress: 可选的进度回调，每次非终态轮询后调用。
     """
     start = time.monotonic()
     prefix = f"{label} " if label else ""
+    predicate = retry_if if retry_if is not None else (lambda e: _should_retry(e, retryable_errors))
 
     # 先查询再等待：已完成/缓存命中的任务立刻返回，不被 poll_interval 白等一轮。
     while True:
         try:
             result = await poll_fn()
         except Exception as e:
-            if not _should_retry(e, retryable_errors):
+            if not predicate(e):
                 raise
             logger.warning("%s轮询异常（将重试）: %s - %s", prefix, type(e).__name__, str(e)[:200])
         else:

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -14,7 +14,6 @@ import httpx
 from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_NEWAPI
 from lib.retry import (
-    BASE_RETRYABLE_ERRORS,
     DEFAULT_BACKOFF_SECONDS,
     DEFAULT_MAX_ATTEMPTS,
     DOWNLOAD_BACKOFF_SECONDS,
@@ -30,6 +29,8 @@ from lib.video_backends.base import (
     download_video,
     persist_provider_job_id,
     poll_with_retry,
+    should_retry_poll,
+    should_retry_submit,
 )
 
 logger = logging.getLogger(__name__)
@@ -39,9 +40,6 @@ DEFAULT_MODEL = "kling-v1"
 _POLL_INTERVAL_SECONDS = 5.0
 _MIN_POLL_TIMEOUT_SECONDS = 600
 _POLL_TIMEOUT_PER_SECOND = 30
-
-# HTTPStatusError 不继承 RequestError，必须显式列出以便 5xx 响应走类型匹配而非字符串匹配
-_NEWAPI_RETRYABLE_ERRORS = BASE_RETRYABLE_ERRORS + (httpx.RequestError, httpx.HTTPStatusError)
 
 # 超过此阈值的起始图会触发 warning，NewAPI 聚合后端常见 4MB 请求体上限
 _LARGE_IMAGE_WARN_BYTES = 4 * 1024 * 1024
@@ -168,10 +166,10 @@ class NewAPIVideoBackend:
     ) -> VideoGenerationResult:
         # _is_done 纯谓词：completed / failed / expired 均视为终态；caller 按 is_resume
         # flag 决定 expired 抛 RuntimeError（generate）还是 ResumeExpiredError（resume）。
-        # resume 路径下 4xx（特别 404）由 _gated_poll 直接抛 ResumeExpiredError 而不
-        # 走 poll_with_retry 的 HTTPStatusError 重试：原 retryable_errors 包含
-        # HTTPStatusError 会让 404 被无限重试到 max_wait 超时，过期任务永远不会落
-        # [resume_expired]，对应 pending ApiCall 也不走 failed/cost=0 路径。
+        # resume 路径下 404 由 _gated_poll 直接抛 ResumeExpiredError：should_retry_poll 把
+        # 轮询 404 当作"短暂未就绪"重试，对已过期的 resume 任务会一直重到 max_wait 超时、
+        # 永不落 [resume_expired]，对应 pending ApiCall 也不走 failed/cost=0 路径，故在此一击
+        # 转终态异常。非 resume 的 4xx 重新抛出，交 should_retry_poll 按 status_code 分流。
         async def _gated_poll() -> dict:
             try:
                 return await self._poll_once(client, task_id)
@@ -186,7 +184,7 @@ class NewAPIVideoBackend:
             is_failed=_extract_failure,
             poll_interval=_POLL_INTERVAL_SECONDS,
             max_wait=self._max_wait(request.duration_seconds),
-            retryable_errors=_NEWAPI_RETRYABLE_ERRORS,
+            retry_if=should_retry_poll,
             label="NewAPI",
         )
 
@@ -221,7 +219,7 @@ class NewAPIVideoBackend:
     @with_retry_async(
         max_attempts=DEFAULT_MAX_ATTEMPTS,
         backoff_seconds=DEFAULT_BACKOFF_SECONDS,
-        retryable_errors=_NEWAPI_RETRYABLE_ERRORS,
+        retry_if=should_retry_submit,
     )
     async def _create_task(self, client: httpx.AsyncClient, payload: dict) -> str:
         resp = await client.post(
@@ -248,7 +246,7 @@ class NewAPIVideoBackend:
     @with_retry_async(
         max_attempts=DOWNLOAD_MAX_ATTEMPTS,
         backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
-        retryable_errors=_NEWAPI_RETRYABLE_ERRORS,
+        retry_if=should_retry_poll,
     )
     async def _download_with_retry(video_url: str, output_path: Path) -> None:
         """对齐 OpenAI/Ark 的下载重试策略（5 次、5/10/20/40 秒），与生成阶段独立。"""

--- a/lib/video_backends/v2_video_generations.py
+++ b/lib/video_backends/v2_video_generations.py
@@ -24,7 +24,6 @@ from pathlib import Path
 import httpx
 
 from lib.retry import (
-    BASE_RETRYABLE_ERRORS,
     DEFAULT_BACKOFF_SECONDS,
     DEFAULT_MAX_ATTEMPTS,
     DOWNLOAD_BACKOFF_SECONDS,
@@ -40,6 +39,8 @@ from lib.video_backends.base import (
     download_video,
     persist_provider_job_id,
     poll_with_retry,
+    should_retry_poll,
+    should_retry_submit,
 )
 
 logger = logging.getLogger(__name__)
@@ -60,9 +61,6 @@ _LARGE_IMAGE_WARN_BYTES = 4 * 1024 * 1024
 
 # 日志摘要里 prompt 截断长度（避免长 prompt 撑爆日志）
 _PROMPT_LOG_MAX = 200
-
-# HTTPStatusError 不继承 RequestError，必须显式列出以便 5xx 响应走类型匹配而非字符串匹配
-_V2_RETRYABLE_ERRORS = BASE_RETRYABLE_ERRORS + (httpx.RequestError, httpx.HTTPStatusError)
 
 # 状态串 → canonical（lowercase 后查表）。覆盖 aimlapi 官方枚举 queued/generating/
 # completed/error，并并入跨厂商同义词（流派 C 路由到多家时底层状态串可能透传）。
@@ -316,7 +314,7 @@ class V2VideoGenerationsBackend:
     @with_retry_async(
         max_attempts=DEFAULT_MAX_ATTEMPTS,
         backoff_seconds=DEFAULT_BACKOFF_SECONDS,
-        retryable_errors=_V2_RETRYABLE_ERRORS,
+        retry_if=should_retry_submit,
     )
     async def _create_task(self, client: httpx.AsyncClient, body: dict) -> str:
         resp = await client.post(f"{self._root}{_SUBMIT_PATH}", json=body, headers=self._headers())
@@ -344,8 +342,10 @@ class V2VideoGenerationsBackend:
         *,
         is_resume: bool,
     ) -> VideoGenerationResult:
-        # resume 路径下 404 直接抛 ResumeExpiredError，不走 poll_with_retry 的
-        # HTTPStatusError 重试（否则 404 会被重试到超时，过期任务永不落 [resume_expired]）。
+        # resume 路径下 404 直接抛 ResumeExpiredError：should_retry_poll 把轮询 404 当作
+        # "短暂未就绪"重试，对已过期的 resume 任务会一直重到 max_wait 超时、永不落
+        # [resume_expired]，故在此一击转终态异常。非 resume 的 4xx 重新抛出，交 should_retry_poll
+        # 按 status_code 分流（确定性 4xx 快速失败，404/429/5xx 重试）。
         async def _gated_poll() -> dict:
             try:
                 return await self._poll_once(client, generation_id)
@@ -360,7 +360,7 @@ class V2VideoGenerationsBackend:
             is_failed=_extract_failure,
             poll_interval=_POLL_INTERVAL_SECONDS,
             max_wait=self._max_wait(request.duration_seconds),
-            retryable_errors=_V2_RETRYABLE_ERRORS,
+            retry_if=should_retry_poll,
             label="V2",
         )
 
@@ -383,7 +383,7 @@ class V2VideoGenerationsBackend:
     @with_retry_async(
         max_attempts=DOWNLOAD_MAX_ATTEMPTS,
         backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
-        retryable_errors=_V2_RETRYABLE_ERRORS,
+        retry_if=should_retry_poll,
     )
     async def _download_with_retry(video_url: str, output_path: Path) -> None:
         """对齐其它后端的下载重试策略（5 次、5/10/20/40 秒），与生成阶段独立。"""

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -368,7 +368,7 @@ class TestNewAPIVideoBackend:
         assert result.duration_seconds == 0
 
     async def test_create_retries_on_5xx(self, tmp_path: Path):
-        """5xx HTTPStatusError 应通过 _NEWAPI_RETRYABLE_ERRORS 类型匹配重试。"""
+        """5xx HTTPStatusError 应通过 should_retry_submit 的 status_code 闸门重试。"""
         failing_resp = MagicMock()
         failing_resp.status_code = 503
         failing_resp.raise_for_status = MagicMock(side_effect=_make_http_error(503, "upstream busy"))
@@ -411,6 +411,61 @@ class TestNewAPIVideoBackend:
 
         assert result.task_id == "t-retry"
         assert mock_client.post.call_count == 3
+
+    async def test_create_non_retryable_4xx_fails_fast(self, tmp_path: Path):
+        """创建任务遇确定性 4xx（400）应一次失败，不重试。"""
+        bad_resp = _make_response(400, {"error": "bad request"})
+        bad_resp.raise_for_status = MagicMock(side_effect=_make_http_error(400, "bad request"))
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=bad_resp)
+        mock_client.get = AsyncMock(side_effect=AssertionError("4xx 应在创建阶段失败，不该轮询"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            with pytest.raises(httpx.HTTPStatusError):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                    )
+                )
+
+        assert mock_client.post.call_count == 1, "确定性 4xx 不该被 retry"
+
+    async def test_poll_non_retryable_4xx_fails_fast(self, tmp_path: Path):
+        """轮询遇确定性 4xx（401，如 token 失效）应一次失败，不重试到 max_wait 超时。"""
+        create_resp = _make_response(200, {"task_id": "t-401", "status": "queued"})
+        unauthorized_resp = _make_response(401, {"error": "unauthorized"})
+        unauthorized_resp.raise_for_status = MagicMock(side_effect=_make_http_error(401, "unauthorized"))
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(return_value=unauthorized_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            with pytest.raises(httpx.HTTPStatusError):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                    )
+                )
+
+        assert mock_client.get.call_count == 1, "轮询确定性 4xx 应一击失败，不重试到超时"
 
     async def test_resume_video_polls_existing_job(self, tmp_path: Path):
         """resume_video 仅 poll + 下载,不 POST create (ADR 0007)。"""

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -457,3 +457,33 @@ class TestV2BackendHttp:
             req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
             with pytest.raises(ResumeExpiredError):
                 await self._backend().resume_video("gen-expired", req)
+
+    @pytest.mark.asyncio
+    async def test_create_non_retryable_4xx_fails_fast(self, tmp_path: Path):
+        """创建任务遇确定性 4xx（400）应一次失败，不重试。"""
+        resp400 = _make_response(400, {"error": "bad request"})
+        resp400.raise_for_status = MagicMock(side_effect=_make_http_error(400, "bad request"))
+        client = _mock_client(post=resp400)
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+        ):
+            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            with pytest.raises(httpx.HTTPStatusError):
+                await self._backend().generate(req)
+        assert client.post.call_count == 1, "确定性 4xx 不该被 retry"
+
+    @pytest.mark.asyncio
+    async def test_poll_non_retryable_4xx_fails_fast(self, tmp_path: Path):
+        """轮询遇确定性 4xx（401，如 token 轮换失效）应一次失败，不重试到 max_wait 超时。"""
+        resp401 = _make_response(401, {"error": "unauthorized"})
+        resp401.raise_for_status = MagicMock(side_effect=_make_http_error(401, "unauthorized"))
+        client = _mock_client(post=_make_response(200, {"id": "gen-401", "status": "queued"}), get=resp401)
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
+        ):
+            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            with pytest.raises(httpx.HTTPStatusError):
+                await self._backend().generate(req)
+        assert client.get.call_count == 1, "轮询确定性 4xx 应一击失败，不重试到超时"

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -2,17 +2,29 @@ import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from sqlalchemy.exc import OperationalError
 
 from lib.video_backends.base import (
+    ResumeExpiredError,
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
+    is_retryable_http_status,
     persist_api_call_id,
     persist_provider_job_id,
     poll_with_retry,
+    should_retry_poll,
+    should_retry_submit,
 )
+
+
+def _http_status_error(status_code: int, *, text: str = "boom") -> httpx.HTTPStatusError:
+    """构造真实 httpx.HTTPStatusError；URL 故意含 "503" 子串以验证不再走字符串误判。"""
+    request = httpx.Request("GET", "https://relay.example/v2/video/generations?generation_id=task-503")
+    response = httpx.Response(status_code, request=request, text=text)
+    return httpx.HTTPStatusError(f"error '{status_code}'", request=request, response=response)
 
 
 class TestVideoCapability:
@@ -202,6 +214,93 @@ class TestPollWithRetry:
             )
 
         assert progress_calls == ["pending"]
+
+    async def test_retry_if_overrides_default_and_fails_fast(self):
+        """retry_if 返回 False 时即便异常属"可重试类型"也立即抛，不重试。"""
+        poll_fn = AsyncMock(side_effect=ConnectionError("would normally retry"))
+
+        with pytest.raises(ConnectionError):
+            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+                await poll_with_retry(
+                    poll_fn=poll_fn,
+                    is_done=lambda r: True,
+                    is_failed=lambda r: None,
+                    poll_interval=1,
+                    max_wait=60,
+                    retry_if=lambda e: False,
+                )
+
+        assert poll_fn.await_count == 1
+
+    async def test_retry_if_overrides_default_and_retries(self):
+        """retry_if 返回 True 时重试，即便异常类型默认不可重试。"""
+        poll_fn = AsyncMock(side_effect=[ValueError("transient"), "done"])
+
+        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+            result = await poll_with_retry(
+                poll_fn=poll_fn,
+                is_done=lambda r: r == "done",
+                is_failed=lambda r: None,
+                poll_interval=1,
+                max_wait=60,
+                retry_if=lambda e: isinstance(e, ValueError),
+            )
+
+        assert result == "done"
+        assert poll_fn.await_count == 2
+
+
+class TestIsRetryableHttpStatus:
+    """is_retryable_http_status 状态码分类。"""
+
+    def test_transient_statuses_retry(self):
+        for code in (408, 425, 429, 500, 502, 503, 504):
+            assert is_retryable_http_status(code) is True
+            assert is_retryable_http_status(code, retry_not_found=True) is True
+
+    def test_deterministic_4xx_fail_fast(self):
+        for code in (400, 401, 403, 405, 409, 422):
+            assert is_retryable_http_status(code) is False
+            assert is_retryable_http_status(code, retry_not_found=True) is False
+
+    def test_404_depends_on_retry_not_found(self):
+        assert is_retryable_http_status(404) is False
+        assert is_retryable_http_status(404, retry_not_found=True) is True
+
+
+class TestRetryPredicates:
+    """should_retry_submit / should_retry_poll 中转视频后端统一重试谓词。"""
+
+    def test_deterministic_4xx_fail_fast(self):
+        for code in (400, 401, 403, 422):
+            err = _http_status_error(code)
+            assert should_retry_submit(err) is False
+            assert should_retry_poll(err) is False
+
+    def test_404_submit_fail_fast_poll_retries(self):
+        err = _http_status_error(404)
+        assert should_retry_submit(err) is False
+        assert should_retry_poll(err) is True
+
+    def test_transient_http_retries(self):
+        for code in (408, 429, 500, 503):
+            err = _http_status_error(code)
+            assert should_retry_submit(err) is True
+            assert should_retry_poll(err) is True
+
+    def test_network_and_base_errors_retry(self):
+        for exc in (httpx.ConnectError("refused"), ConnectionError(), TimeoutError()):
+            assert should_retry_submit(exc) is True
+            assert should_retry_poll(exc) is True
+
+    def test_business_exceptions_fail_fast(self):
+        # ResumeExpiredError 的 job_id 含 "503" 子串：旧字符串兜底会误判重试，新谓词不会。
+        resume_exc = ResumeExpiredError(job_id="job-503", provider="v2")
+        assert should_retry_poll(resume_exc) is False
+        assert should_retry_submit(resume_exc) is False
+        # 普通异常即便消息含状态码子串也不重试（绕开字符串误判）。
+        assert should_retry_poll(ValueError("503 in message")) is False
+        assert should_retry_submit(RuntimeError("got 500 somewhere")) is False
 
 
 def _make_operational_error(msg: str) -> OperationalError:


### PR DESCRIPTION
## 背景

Fixes #684。PR #683 引入 `V2VideoGenerationsBackend` 时,code review 发现中转视频后端轮询对**确定性 4xx** 会一直重试到 `max_wait` 超时。该模式与既有 `NewAPIVideoBackend` 同款,属跨后端潜在问题。

## 根因

`lib/retry.py::_should_retry` 对任何 `isinstance(exc, retryable_errors)` 直接返回 `True`。V2 / NewAPI 的 `_*_RETRYABLE_ERRORS` 把 `httpx.HTTPStatusError` 放进 tuple(本意让 5xx 走类型匹配),副作用是 **400/401/403 等确定性 4xx 也被判可重试**:

- 轮询路径每 `poll_interval`(5s)重试到 `max_wait`(≥600s)→ 约 10 分钟才 `TimeoutError`,期间白占一个 video worker 槽。
- submit 路径同样对 4xx 重试 ~3 次(~6s)。

不能简单去掉 tuple 里的 `HTTPStatusError` 靠字符串兜底:`HTTPStatusError` 消息含 URL/task_id,其中的 `500`/`503` 子串会被 `RETRYABLE_STATUS_PATTERNS` 误判。

## 改动(横切修复,统一覆盖 V2 与 NewAPI)

- **`lib/video_backends/base.py`**:新增按 `status_code` 显式闸门的共享谓词 `should_retry_submit` / `should_retry_poll`:
  - 确定性 4xx(400/401/403/422 等)→ 快速失败。
  - 408 / 425 / 429 / 5xx + 网络错误(`RequestError`)+ 基础瞬态(Connection/Timeout)→ 重试。
  - 404 → submit 视为端点错误 fail-fast;轮询/下载视为「短暂未就绪」重试。
  - 显式闸门绕开 `_should_retry` 对异常字符串的子串兜底。
- `poll_with_retry` 新增 `retry_if` 参数,镜像 `with_retry_async` 语义(其余调用方不传,行为不变)。
- **V2 / NewAPI**:删除 `_V2_RETRYABLE_ERRORS` / `_NEWAPI_RETRYABLE_ERRORS`,create/poll/download 三处统一走新谓词。
- 顺带根除字符串兜底对 `ResumeExpiredError`(job_id 含状态码子串)的潜在误判。

## 测试

- `test_video_backend_base.py`:`is_retryable_http_status` / 谓词矩阵 + `poll_with_retry` 的 `retry_if`。
- `test_newapi_video_backend.py` / `test_v2_video_generations_backend.py`:新增 4xx fail-fast 用例(submit + poll,断言 `call_count == 1`);既有 5xx 重试 / resume-404 用例仍通过。
- 全量 `pytest` 通过(改了 `poll_with_retry` 签名,跑全量);`ruff` / `basedpyright` 0 error。

## 范围说明:幂等性拆出

code review 另提出「创建阶段幂等性(`Idempotency-Key` 防重复建任务+计费)」。经逐家核实——aimlapi / xAI / getimg.ai / new-api 网关**均未文档化 `Idempotency-Key` 支持**,盲发无效。该维度拆为独立 issue #687 跟踪,不在本 PR。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增强 HTTP 重试判定逻辑，针对不同请求阶段（提交/轮询）实现差异化处理
  * 新增自定义重试条件的灵活配置选项

* **Bug 修复**
  * 优化非重试错误的处理，确定性错误（4xx）现可立即失败，避免不必要的重试等待

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->