### PR TITLE
perf(reference-video): 优化参考视频生成性能

### DIFF
--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -28,9 +28,7 @@ from lib.config.service import (
     ConfigService,
 )
 from lib.custom_provider import is_custom_provider, parse_provider_id
-from lib.custom_provider.backends import CustomVideoBackend
 from lib.custom_provider.endpoints import get_endpoint_spec
-from lib.custom_provider.factory import create_custom_backend
 from lib.db.repositories.credential_repository import CredentialRepository
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.project_manager import ProjectManager
@@ -458,23 +456,16 @@ class ConfigResolver:
             if endpoint_cap is not None:
                 max_reference_images = endpoint_cap
             else:
-                # endpoint cap 未声明（多 model 共享端点、容量不同）→ fallthrough 到 backend caps。
-                # CustomProviderModel 无 provider relationship，须显式取 provider 行（多一次 DB 查询）。
-                provider = await repo.get_provider(db_pid)
-                if provider is None:
-                    raise ValueError(f"custom provider not found: {provider_id}")
-                try:
-                    backend = create_custom_backend(provider=provider, model_id=model_id, endpoint=model.endpoint)
-                except Exception as exc:
+                # endpoint cap 未声明（多 model 共享端点、容量随 model 变）→ 用 endpoint 绑定的纯
+                # caps 函数按 model_id 读 backend 声明的上限。纯函数不查 provider 行、不构造 SDK
+                # client，故每镜头解析无 DB/网络/client 构造副作用（也不因 api_key 缺失而抛）。
+                caps_fn = endpoint_spec.video_caps_for_model
+                if caps_fn is None:
                     raise ValueError(
-                        f"failed to construct backend for max_reference_images fallthrough: "
-                        f"{provider_id}/{model_id} endpoint={model.endpoint!r}"
-                    ) from exc
-                if not isinstance(backend, CustomVideoBackend):
-                    raise ValueError(
-                        f"video endpoint built non-video backend: {provider_id}/{model_id} endpoint={model.endpoint!r}"
+                        f"video endpoint {model.endpoint!r} declares neither video_max_reference_images "
+                        f"nor video_caps_for_model: {provider_id}/{model_id}"
                     )
-                max_reference_images = backend.video_capabilities.max_reference_images
+                max_reference_images = caps_fn(model_id).max_reference_images
                 if max_reference_images < 0:
                     # backend caps 是这条链路的真相源，负数直接抛错，不静默下传——
                     # 否则 reference_video_tasks 会按坏值跳过裁剪。

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -29,6 +29,7 @@ from lib.video_backends.vidu import ViduVideoBackend
 
 if TYPE_CHECKING:
     from lib.db.models.custom_provider import CustomProvider
+    from lib.video_backends.base import VideoCapabilities
 
 
 # ── EndpointSpec 数据类型 ───────────────────────────────────────────
@@ -49,8 +50,12 @@ class EndpointSpec:
     # 参考生视频单镜头参考图上限；仅 video 类有意义。
     # 显式 int：原样下传作为硬约束（0 表示不接受参考图，executor 据此将 references 裁剪为 0 张）。
     # None：未声明 —— 一个 endpoint 多 model、容量不同时 endpoint 维度给不出准数，由 resolver
-    # fallthrough 到 backend video_capabilities 读取该 model 的真实上限。
+    # 调 video_caps_for_model 按 model_id 读取该 model 的真实上限。
     video_max_reference_images: int | None = None
+    # 当 video_max_reference_images 为 None 时，resolver 用此纯函数按 model_id 读 backend 声明的
+    # caps —— 不构造 SDK client、不查 provider 行。video_max_reference_images 为 int 时此字段应为
+    # None（endpoint 维度已能给出硬上限）。二者对每个 video endpoint 恰填其一（见注册表末尾不变式）。
+    video_caps_for_model: Callable[[str], VideoCapabilities] | None = None
 
 
 # ── 各 endpoint 的 build_backend 闭包 ──────────────────────────────
@@ -244,7 +249,8 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         request_method="POST",
         request_path_template="/v2/video/generations",
         build_backend=_build_v2_video_generations,
-        # 多 model 共享端点、容量不同 → 未声明，fallthrough 到 backend caps
+        # 多 model 共享端点、容量不同 → endpoint 维度不声明，按 model 读 backend caps（不构造 client）
+        video_caps_for_model=V2VideoGenerationsBackend.video_capabilities_for_model,
     ),
     "ark-seedance": EndpointSpec(
         key="ark-seedance",
@@ -254,6 +260,7 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         request_method="POST",
         request_path_template="/api/v3/contents/generations/tasks",
         build_backend=_build_ark_seedance,
+        video_caps_for_model=ArkVideoBackend.video_capabilities_for_model,
     ),
     "vidu-video": EndpointSpec(
         key="vidu-video",
@@ -263,6 +270,7 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         request_method="POST",
         request_path_template="/ent/v2/img2video",
         build_backend=_build_vidu_video,
+        video_caps_for_model=ViduVideoBackend.video_capabilities_for_model,
     ),
 }
 
@@ -271,6 +279,38 @@ ENDPOINT_KEYS_BY_MEDIA_TYPE: dict[str, tuple[str, ...]] = {
     media_type: tuple(k for k, s in ENDPOINT_REGISTRY.items() if s.media_type == media_type)
     for media_type in {s.media_type for s in ENDPOINT_REGISTRY.values()}
 }
+
+
+def _validate_video_caps_declarations() -> None:
+    """import 期校验参考图上限来源：每个 video endpoint 必须「int cap」XOR「caps_fn 非 None」恰一、
+    且 int cap 非负；非 video endpoint 两者皆 None。misconfig（多 model 共享端点漏配 caps_fn、同时
+    声明二者、或声明负数 cap）在 import 期 fail-fast，而非等到 request 期 resolver 才抛。
+    """
+    for key, spec in ENDPOINT_REGISTRY.items():
+        cap = spec.video_max_reference_images
+        has_int = cap is not None
+        has_fn = spec.video_caps_for_model is not None
+        if spec.media_type == "video":
+            if has_int == has_fn:
+                raise ValueError(
+                    f"video endpoint {key!r} must declare exactly one of video_max_reference_images "
+                    f"(int) or video_caps_for_model (callable), got "
+                    f"video_max_reference_images={cap!r}, "
+                    f"video_caps_for_model={'<callable>' if has_fn else None}"
+                )
+            if cap is not None and cap < 0:
+                # int cap 是参考图张数硬上限；负数到了下游会被当负切片 references[:-1] 误丢最后一张
+                # 而非裁成 0 张 → import 期挡掉，保证 resolver int 分支取到的恒为合法非负数。
+                raise ValueError(f"video endpoint {key!r} declares negative video_max_reference_images: {cap}")
+        elif has_int or has_fn:
+            raise ValueError(
+                f"non-video endpoint {key!r} must not declare video caps, got "
+                f"video_max_reference_images={cap!r}, "
+                f"video_caps_for_model={'<callable>' if has_fn else None}"
+            )
+
+
+_validate_video_caps_declarations()
 
 
 # ── 工具函数 ───────────────────────────────────────────────────────
@@ -303,6 +343,7 @@ def endpoint_spec_to_dict(spec: EndpointSpec) -> dict:
     """把 EndpointSpec 转成可序列化的纯数据 dict（剥掉不可 JSON 化的 build_backend 闭包）。"""
     data = asdict(spec)
     data.pop("build_backend", None)
+    data.pop("video_caps_for_model", None)  # 同 build_backend：callable 不可 JSON 化，剥掉
     if spec.image_capabilities is not None:
         data["image_capabilities"] = sorted(c.value for c in spec.image_capabilities)
     else:

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -282,21 +282,27 @@ ENDPOINT_KEYS_BY_MEDIA_TYPE: dict[str, tuple[str, ...]] = {
 
 
 def _validate_video_caps_declarations() -> None:
-    """import 期校验参考图上限来源：每个 video endpoint 必须「int cap」XOR「caps_fn 非 None」恰一、
-    且 int cap 非负；非 video endpoint 两者皆 None。misconfig（多 model 共享端点漏配 caps_fn、同时
-    声明二者、或声明负数 cap）在 import 期 fail-fast，而非等到 request 期 resolver 才抛。
+    """import 期校验参考图上限来源：caps_fn 若声明必须可调用；每个 video endpoint 必须「int cap」
+    XOR「caps_fn 非 None」恰一、且 int cap 非负；非 video endpoint 两者皆 None。misconfig（caps_fn
+    填成非 callable、多 model 共享端点漏配 caps_fn、同时声明二者、或声明负数 cap）在 import 期
+    fail-fast，而非等到 request 期 resolver 才抛。
     """
     for key, spec in ENDPOINT_REGISTRY.items():
         cap = spec.video_max_reference_images
+        caps_fn = spec.video_caps_for_model
         has_int = cap is not None
-        has_fn = spec.video_caps_for_model is not None
+        # resolver 会以 caps_fn(model_id) 执行它，故必须是 callable。误填字符串/整数等非空非 callable
+        # 值要在 import 期就挡掉，而非放行到请求期才在 resolver 里炸——与本函数的 fail-fast 初衷一致。
+        if caps_fn is not None and not callable(caps_fn):
+            raise ValueError(f"endpoint {key!r} declares non-callable video_caps_for_model: {caps_fn!r}")
+        has_fn = callable(caps_fn)
         if spec.media_type == "video":
             if has_int == has_fn:
                 raise ValueError(
                     f"video endpoint {key!r} must declare exactly one of video_max_reference_images "
                     f"(int) or video_caps_for_model (callable), got "
                     f"video_max_reference_images={cap!r}, "
-                    f"video_caps_for_model={'<callable>' if has_fn else None}"
+                    f"video_caps_for_model={caps_fn!r}"
                 )
             if cap is not None and cap < 0:
                 # int cap 是参考图张数硬上限；负数到了下游会被当负切片 references[:-1] 误丢最后一张
@@ -306,7 +312,7 @@ def _validate_video_caps_declarations() -> None:
             raise ValueError(
                 f"non-video endpoint {key!r} must not declare video caps, got "
                 f"video_max_reference_images={cap!r}, "
-                f"video_caps_for_model={'<callable>' if has_fn else None}"
+                f"video_caps_for_model={caps_fn!r}"
             )
 
 

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -22,6 +22,7 @@ from lib.image_backends.openai import OpenAIImageBackend
 from lib.text_backends.gemini import GeminiTextBackend
 from lib.text_backends.openai import OpenAITextBackend
 from lib.video_backends.ark import ArkVideoBackend
+from lib.video_backends.base import VideoCapabilities
 from lib.video_backends.newapi import NewAPIVideoBackend
 from lib.video_backends.openai import OpenAIVideoBackend
 from lib.video_backends.v2_video_generations import V2VideoGenerationsBackend
@@ -29,7 +30,6 @@ from lib.video_backends.vidu import ViduVideoBackend
 
 if TYPE_CHECKING:
     from lib.db.models.custom_provider import CustomProvider
-    from lib.video_backends.base import VideoCapabilities
 
 
 # ── EndpointSpec 数据类型 ───────────────────────────────────────────

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -80,12 +80,21 @@ class ArkVideoBackend:
     def capabilities(self) -> set[VideoCapability]:
         return self._capabilities
 
-    @property
-    def video_capabilities(self) -> VideoCapabilities:
-        model_lower = self._model.lower()
+    @staticmethod
+    def video_capabilities_for_model(model: str) -> VideoCapabilities:
+        """按 model_id 纯计算参考图等 caps —— 不构造 SDK client（无需 api_key）。
+
+        resolver 解析参考图上限时调本方法即可，不必构造整个 backend；instance property 委托至此，
+        保持 backend 为单一真相源。
+        """
+        model_lower = model.lower()
         if "seedance-2" in model_lower or "seedance2" in model_lower:
             return VideoCapabilities(last_frame=True, reference_images=True, max_reference_images=9)
         return VideoCapabilities()
+
+    @property
+    def video_capabilities(self) -> VideoCapabilities:
+        return self.video_capabilities_for_model(self._model)
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         """生成视频。任务创建和轮询阶段分离重试，避免瞬态错误导致重建任务。"""

--- a/lib/video_backends/v2_video_generations.py
+++ b/lib/video_backends/v2_video_generations.py
@@ -287,14 +287,21 @@ class V2VideoGenerationsBackend:
     def capabilities(self) -> set[VideoCapability]:
         return self._capabilities
 
-    @property
-    def video_capabilities(self) -> VideoCapabilities:
+    @staticmethod
+    def video_capabilities_for_model(model: str) -> VideoCapabilities:
+        """按 model_id 纯计算 caps —— 不构造 client。保留 `model` 形参仅为跨 backend 接口统一，
+        generic 端点跨多模型无单一供应商真相，当前取保守默认 `_DEFAULT_MAX_REFERENCE_IMAGES`。
+        """
         return VideoCapabilities(
             first_frame=True,
             last_frame=True,
             reference_images=True,
             max_reference_images=_DEFAULT_MAX_REFERENCE_IMAGES,
         )
+
+    @property
+    def video_capabilities(self) -> VideoCapabilities:
+        return self.video_capabilities_for_model(self._model)
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         body = build_request_body(self._model, request)

--- a/lib/video_backends/vidu.py
+++ b/lib/video_backends/vidu.py
@@ -181,14 +181,21 @@ class ViduVideoBackend:
     def capabilities(self) -> set[VideoCapability]:
         return self._capabilities
 
-    @property
-    def video_capabilities(self) -> VideoCapabilities:
+    @staticmethod
+    def video_capabilities_for_model(model: str) -> VideoCapabilities:
+        """按 model_id 纯计算 caps —— 不构造 client。保留 `model` 形参仅为跨 backend 接口统一，
+        Vidu 容量当前不随 model 变（恒为 `_MAX_REFERENCE_IMAGES`）。
+        """
         return VideoCapabilities(
             first_frame=True,
             last_frame=True,
             reference_images=True,
             max_reference_images=_MAX_REFERENCE_IMAGES,
         )
+
+    @property
+    def video_capabilities(self) -> VideoCapabilities:
+        return self.video_capabilities_for_model(self._model)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
         # 本 PR 暂不实现 Vidu resume（poll 完全内联在 generate，需要先抽 _poll_until_done）；

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -90,6 +90,23 @@ class TestRegistry:
         with pytest.raises(ValueError, match="negative video_max_reference_images"):
             _validate_video_caps_declarations()
 
+    def test_non_callable_caps_fn_rejected_at_validation(self, monkeypatch: pytest.MonkeyPatch):
+        """import 期不变式拒绝非 callable 的 video_caps_for_model：否则误填字符串/整数会放行到
+        request 期才在 resolver `caps_fn(model_id)` 处炸，违背 fail-fast 初衷。"""
+        import dataclasses
+
+        from lib.custom_provider.endpoints import _validate_video_caps_declarations
+
+        # 非 callable 真值（字符串）冒充 caps_fn；同时清掉 int cap 避免先撞 XOR 校验
+        bad = dataclasses.replace(
+            ENDPOINT_REGISTRY["ark-seedance"],
+            video_max_reference_images=None,
+            video_caps_for_model="not-callable",
+        )
+        monkeypatch.setitem(ENDPOINT_REGISTRY, "ark-seedance", bad)
+        with pytest.raises(ValueError, match="non-callable video_caps_for_model"):
+            _validate_video_caps_declarations()
+
     def test_media_type_groups(self):
         text_keys = {s.key for s in ENDPOINT_REGISTRY.values() if s.media_type == "text"}
         image_keys = {s.key for s in ENDPOINT_REGISTRY.values() if s.media_type == "image"}

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -57,12 +57,38 @@ class TestRegistry:
         }
 
     def test_new_video_endpoints_have_unset_cap(self):
-        """v2/ark/vidu 不在 endpoint 维度声明上限，由 resolver fallthrough 到 backend caps。"""
+        """v2/ark/vidu 不在 endpoint 维度声明上限，由 resolver 调 backend 纯 caps 函数读取。"""
         for key in ("v2-video-generations", "ark-seedance", "vidu-video"):
             assert ENDPOINT_REGISTRY[key].video_max_reference_images is None
         # 既有显式 int 保留，行为零变化
         assert ENDPOINT_REGISTRY["openai-video"].video_max_reference_images == 1
         assert ENDPOINT_REGISTRY["newapi-video"].video_max_reference_images == 0
+
+    def test_video_caps_declaration_bindings(self):
+        """每个 video endpoint 选对了上限来源：None-cap 的绑 caps_fn、显式 int 的不绑。
+
+        全注册表 XOR/非负不变式由 endpoints.py 的 module-load `_validate_video_caps_declarations()`
+        在 import 期保证（违反则本文件根本 import 不进来），故此处只断言「具体哪个 endpoint 选了哪条
+        路径」——这是 XOR 校验抓不到的（换机制仍满足 XOR），是真正的回归护栏。"""
+        # None-cap 的三个 video endpoint 必须绑定纯 caps 函数
+        for key in ("v2-video-generations", "ark-seedance", "vidu-video"):
+            assert ENDPOINT_REGISTRY[key].video_caps_for_model is not None
+        # 显式 int 的 video endpoint 不应再绑 caps 函数
+        for key in ("openai-video", "newapi-video"):
+            assert ENDPOINT_REGISTRY[key].video_caps_for_model is None
+
+    def test_negative_int_cap_rejected_at_validation(self, monkeypatch: pytest.MonkeyPatch):
+        """import 期不变式拒绝负数 int cap：下游 references[:-1] 会误丢最后一张而非裁成 0 张。"""
+        import dataclasses
+
+        from lib.custom_provider.endpoints import _validate_video_caps_declarations
+
+        bad = dataclasses.replace(
+            ENDPOINT_REGISTRY["openai-video"], video_max_reference_images=-1, video_caps_for_model=None
+        )
+        monkeypatch.setitem(ENDPOINT_REGISTRY, "openai-video", bad)
+        with pytest.raises(ValueError, match="negative video_max_reference_images"):
+            _validate_video_caps_declarations()
 
     def test_media_type_groups(self):
         text_keys = {s.key for s in ENDPOINT_REGISTRY.values() if s.media_type == "text"}

--- a/tests/test_custom_provider_resolution.py
+++ b/tests/test_custom_provider_resolution.py
@@ -158,8 +158,9 @@ async def test_video_capabilities_endpoint_mismatch_raises(db_session: AsyncSess
         # 显式 int：直接用 endpoint cap（行为零变化）
         ("openai-video", "vid-model", 1),
         ("newapi-video", "vid-model", 0),
-        # 未声明（None）：fallthrough 到 backend video_capabilities 读该 model 真实上限
+        # 未声明（None）：按 model_id 调 backend 纯 caps 函数读上限，不构造 backend
         ("ark-seedance", "doubao-seedance-2-0", 9),
+        ("ark-seedance", "doubao-seedance-1-0", 0),  # 非 seedance-2 → 0，证明纯函数仍按 model 分支
         ("vidu-video", "viduq3-turbo", 7),
     ],
 )
@@ -167,10 +168,16 @@ async def test_custom_video_max_reference_images_from_endpoint(
     db_session: AsyncSession, endpoint: str, model_id: str, expected_max_refs: int
 ):
     """custom 视频 model 的 max_reference_images 经 ENDPOINT_REGISTRY 派生：endpoint cap
-    为显式 int 时直接用；为 None 时 fallthrough 到 backend caps，均不静默落默认值。"""
+    为显式 int 时直接用；为 None 时按 model_id 调 backend 纯 caps 函数读上限，均不静默落默认值。
+
+    perf 回归护栏：无论哪条路径都断言 `CustomProviderRepository.get_provider` 未被调用——
+    旧 fallthrough 会多查一次 provider 行 + 构造 backend，新路径纯函数解析不应触发。"""
+    from unittest.mock import patch
+
     from lib.config.resolver import ConfigResolver
     from lib.config.service import ConfigService
     from lib.custom_provider import make_provider_id
+    from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 
     provider = CustomProvider(
         display_name="VideoProv",
@@ -200,16 +207,19 @@ async def test_custom_video_max_reference_images_from_endpoint(
     svc = ConfigService(db_session)
     resolver = ConfigResolver(factory, _bound_session=db_session)
 
-    caps = await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
+    with patch.object(CustomProviderRepository, "get_provider") as mock_get_provider:
+        caps = await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
+    mock_get_provider.assert_not_called()
     assert caps["source"] == "custom"
     assert caps["max_reference_images"] == expected_max_refs
 
 
 @pytest.mark.asyncio
-async def test_custom_video_max_refs_fallthrough_failure_raises(db_session: AsyncSession):
-    """endpoint cap=None 且 backend 构造失败 → raise ValueError（不静默裁剪为 0）。"""
-    from unittest.mock import patch
+async def test_custom_video_caps_resolved_without_api_key(db_session: AsyncSession):
+    """endpoint cap=None 的 ark-seedance 在 api_key 为空时仍解析出上限（=9）且**不抛**。
 
+    旧路径构造 ArkVideoBackend 会因空 key 抛 ValueError（与延迟解析的 vidu 行为不对称）；
+    纯 caps 函数不依赖 client，故对称放行。"""
     from lib.config.resolver import ConfigResolver
     from lib.config.service import ConfigService
     from lib.custom_provider import make_provider_id
@@ -218,7 +228,7 @@ async def test_custom_video_max_refs_fallthrough_failure_raises(db_session: Asyn
         display_name="VideoProv",
         discovery_format="openai",
         base_url="https://api.example.com",
-        api_key="k",
+        api_key="",
     )
     db_session.add(provider)
     await db_session.flush()
@@ -242,20 +252,27 @@ async def test_custom_video_max_refs_fallthrough_failure_raises(db_session: Asyn
     svc = ConfigService(db_session)
     resolver = ConfigResolver(factory, _bound_session=db_session)
 
-    with patch("lib.config.resolver.create_custom_backend", side_effect=RuntimeError("boom")):
-        with pytest.raises(ValueError, match="failed to construct backend"):
-            await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
+    caps = await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
+    assert caps["max_reference_images"] == 9
 
 
 @pytest.mark.asyncio
-async def test_custom_video_max_refs_negative_caps_raises(db_session: AsyncSession):
-    """endpoint cap=None，fallthrough 读到 backend 负数 caps → raise ValueError（不静默下传坏值）。"""
-    from unittest.mock import MagicMock, patch
+async def test_custom_video_max_refs_missing_caps_fn_raises(db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch):
+    """endpoint cap=None 且 video_caps_for_model 也缺失（misconfig）→ resolver raise ValueError。
+
+    EndpointSpec 是 frozen dataclass，用 dataclasses.replace 造 misconfig spec 再 setitem 临时替换
+    （module-load 不变式仅 import 期生效，不拦运行时 monkeypatch）。"""
+    import dataclasses
 
     from lib.config.resolver import ConfigResolver
     from lib.config.service import ConfigService
     from lib.custom_provider import make_provider_id
-    from lib.custom_provider.backends import CustomVideoBackend
+    from lib.custom_provider.endpoints import ENDPOINT_REGISTRY
+
+    bad_spec = dataclasses.replace(
+        ENDPOINT_REGISTRY["ark-seedance"], video_max_reference_images=None, video_caps_for_model=None
+    )
+    monkeypatch.setitem(ENDPOINT_REGISTRY, "ark-seedance", bad_spec)
 
     provider = CustomProvider(
         display_name="VideoProv",
@@ -285,8 +302,54 @@ async def test_custom_video_max_refs_negative_caps_raises(db_session: AsyncSessi
     svc = ConfigService(db_session)
     resolver = ConfigResolver(factory, _bound_session=db_session)
 
-    bad_backend = MagicMock(spec=CustomVideoBackend)
-    bad_backend.video_capabilities.max_reference_images = -1
-    with patch("lib.config.resolver.create_custom_backend", return_value=bad_backend):
-        with pytest.raises(ValueError, match="invalid backend max_reference_images"):
-            await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
+    with pytest.raises(ValueError, match="declares neither video_max_reference_images"):
+        await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
+
+
+@pytest.mark.asyncio
+async def test_custom_video_max_refs_negative_caps_raises(db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch):
+    """endpoint cap=None，caps 函数返回负数 → raise ValueError（不静默下传坏值）。"""
+    import dataclasses
+
+    from lib.config.resolver import ConfigResolver
+    from lib.config.service import ConfigService
+    from lib.custom_provider import make_provider_id
+    from lib.custom_provider.endpoints import ENDPOINT_REGISTRY
+    from lib.video_backends.base import VideoCapabilities
+
+    def _negative_caps(model: str) -> VideoCapabilities:
+        return VideoCapabilities(max_reference_images=-1)
+
+    bad_spec = dataclasses.replace(ENDPOINT_REGISTRY["ark-seedance"], video_caps_for_model=_negative_caps)
+    monkeypatch.setitem(ENDPOINT_REGISTRY, "ark-seedance", bad_spec)
+
+    provider = CustomProvider(
+        display_name="VideoProv",
+        discovery_format="openai",
+        base_url="https://api.example.com",
+        api_key="k",
+    )
+    db_session.add(provider)
+    await db_session.flush()
+
+    model = CustomProviderModel(
+        provider_id=provider.id,
+        model_id="doubao-seedance-2-0",
+        display_name="Vid Model",
+        endpoint="ark-seedance",
+        is_default=True,
+        is_enabled=True,
+        supported_durations="[5, 10]",
+    )
+    db_session.add(model)
+    await db_session.flush()
+
+    provider_id_str = make_provider_id(provider.id)
+    project = {"video_backend": f"{provider_id_str}/doubao-seedance-2-0"}
+
+    factory = async_sessionmaker(bind=db_session.get_bind(), class_=AsyncSession, expire_on_commit=False)  # type: ignore[call-overload]
+    svc = ConfigService(db_session)
+    resolver = ConfigResolver(factory, _bound_session=db_session)
+
+    with pytest.raises(ValueError, match="invalid backend max_reference_images"):
+        await resolver._resolve_video_capabilities_from_project(svc, db_session, project)

--- a/tests/test_video_backend_capabilities.py
+++ b/tests/test_video_backend_capabilities.py
@@ -63,3 +63,39 @@ class TestVideoGenerationRequestNewFields:
         assert req.start_image == Path("/tmp/start.png")
         assert req.generate_audio is False
         assert req.seed == 42
+
+
+class TestVideoCapabilitiesForModel:
+    """各 backend 的 client-free 静态 caps 方法：按 model_id 纯计算，不构造实例 / 不需 api_key。
+
+    resolver 解析参考图上限走这条纯函数路径，故不应触发 SDK client 构造或 api_key 校验。"""
+
+    def test_ark_seedance_2_returns_nine(self):
+        from lib.video_backends.ark import ArkVideoBackend
+
+        # 不构造实例（即不构造 Ark SDK client、不需 api_key）即可取得 caps
+        caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-2-0")
+        assert caps.max_reference_images == 9
+        assert caps.reference_images is True
+
+    def test_ark_non_seedance_2_returns_zero(self):
+        from lib.video_backends.ark import ArkVideoBackend
+
+        assert ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-0").max_reference_images == 0
+
+    def test_vidu_returns_seven(self):
+        from lib.video_backends.vidu import ViduVideoBackend
+
+        assert ViduVideoBackend.video_capabilities_for_model("viduq3-turbo").max_reference_images == 7
+
+    def test_v2_returns_four(self):
+        from lib.video_backends.v2_video_generations import V2VideoGenerationsBackend
+
+        assert V2VideoGenerationsBackend.video_capabilities_for_model("whatever").max_reference_images == 4
+
+    def test_instance_property_delegates_to_static(self):
+        """instance video_capabilities 委托至静态方法，保持 backend 为单一真相源。"""
+        from lib.video_backends.ark import ArkVideoBackend
+
+        backend = ArkVideoBackend(api_key="k", model="doubao-seedance-2-0")
+        assert backend.video_capabilities == ArkVideoBackend.video_capabilities_for_model("doubao-seedance-2-0")

--- a/tests/test_video_backend_capabilities.py
+++ b/tests/test_video_backend_capabilities.py
@@ -94,8 +94,14 @@ class TestVideoCapabilitiesForModel:
         assert V2VideoGenerationsBackend.video_capabilities_for_model("whatever").max_reference_images == 4
 
     def test_instance_property_delegates_to_static(self):
-        """instance video_capabilities 委托至静态方法，保持 backend 为单一真相源。"""
+        """instance video_capabilities 委托至静态方法，保持 backend 为单一真相源。
+
+        patch 掉 create_ark_client：本测试只验证 property→静态方法的委托，不应在 __init__ 里真实
+        构造 Ark SDK client（那正是本 PR 要移出 caps 路径的依赖）。"""
+        from unittest.mock import patch
+
         from lib.video_backends.ark import ArkVideoBackend
 
-        backend = ArkVideoBackend(api_key="k", model="doubao-seedance-2-0")
+        with patch("lib.video_backends.ark.create_ark_client"):
+            backend = ArkVideoBackend(api_key="k", model="doubao-seedance-2-0")
         assert backend.video_capabilities == ArkVideoBackend.video_capabilities_for_model("doubao-seedance-2-0")


### PR DESCRIPTION
## 背景

承接 PR #683：`EndpointSpec.video_max_reference_images: int | None` 声明式上限。`None`（`ark-seedance` / `vidu-video` / `v2-video-generations` 这类单端点多 model、容量随 model 变的共享端点）时，resolver `_resolve_video_caps_for_model` 的 fallthrough 为读一个**静态整数**（ark `seedance-2`→9/否则 0、vidu→7、v2→4）而：

1. `repo.get_provider(db_pid)` —— 多一次 DB 查询；
2. `create_custom_backend(...)` —— 构造完整 backend，其中 `ArkVideoBackend` 经 `create_ark_client` 构造 volcengine Ark SDK client。

`video_capabilities_for_project` 在参考生视频路径**每镜头调一次**（`reference_video_tasks.py`，每任务一 unit），N 镜头 = N 次 backend 构造 + N 次额外 DB 查询；还把 SDK client 构造副作用放进了纯读路径，且 `ark`/`v2` 在 api_key 为空时读 caps 即抛 `ValueError`（与 `vidu` 延迟解析不抛 → 行为不对称）。

Closes #685

## 方案（issue 的 Option 1：backend 暴露 client-free caps）

- 三个 None-cap 视频 backend 各加 `@staticmethod video_capabilities_for_model(model) -> VideoCapabilities`，按 `model_id` **纯计算**（不碰 SDK client、不需 api_key）；instance `video_capabilities` property 改薄委托至此，保持「backend = 单一真相源」。
- `EndpointSpec` 新增 `video_caps_for_model: Callable[[str], VideoCapabilities] | None`，三个 endpoint 绑定对应 backend 静态方法；resolver fallthrough 删掉 `repo.get_provider` + `create_custom_backend` + `isinstance` 三件套，改直接调 `caps_fn(model_id)`。
- 注册表加 **import 期不变式** `_validate_video_caps_declarations()`：每个 video endpoint「int cap」XOR「caps_fn」恰一、且 int cap 非负，misconfig 在 import 期 fail-fast。

净效果：每镜头解析不再有额外 DB 查询 / backend / Ark-SDK-client 构造；并消除空 api_key 读 caps 抛错的非对称（与 vidu 对齐）。

## 设计取舍

保留 `video_max_reference_images: int | None` 的**语义区分**——`int` = endpoint 维度硬上限保证（`openai-video`=1 Sora 单图、`newapi-video`=0 不接受参考图），`None`+`caps_fn` = 容量随 model 变、委托 backend。**不**把 int 路径也函数化：二者是有意的语义区分（XOR 不变式正把它编码进数据），非冗余。

## 验证

- `ruff check` + `format` 干净；`basedpyright` 改动文件 **0 error / 0 warning**。
- 受影响测试全绿；新增：ark 非 seedance-2→0、空 api_key 仍解析出 9 不抛、缺 caps_fn / 负数 caps fail-loud、负数 int cap 被 import 期不变式拒绝、backend 静态方法 client-free 单测、perf 护栏（断言 `get_provider` 未被调用）。
- 全量 `pytest` 3555 passed。

> 含 `/code-review --fix`（xhigh）一轮修复：补 int-cap 分支缺失的非负守卫（移到 import 期校验，正确高度）、校验错误信息措辞、精简测试中与 import 期校验重复的断言。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进与优化**
  * 自定义视频端点改为按模型计算视频能力（支持可调用声明），统一各后端能力入口并在缺失时明确报错
  * 序列化时排除不可序列化的能力声明，避免输出异常

* **错误修复 / 验证**
  * 导入时进行 fail-fast 校验：拒绝不合规或负值的视频能力配置

* **测试**
  * 扩展并新增测试，覆盖模型级能力解析、无 API Key 路径及校验失败场景

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->