### PR TITLE
fix(settings): 修复配置提醒没有即时显示的问题

### DIFF
--- a/frontend/src/components/pages/ProviderSection.tsx
+++ b/frontend/src/components/pages/ProviderSection.tsx
@@ -4,6 +4,7 @@ import { useLocation, useSearch } from "wouter";
 import { Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { API } from "@/api";
+import { useConfigStatusStore } from "@/stores/config-status-store";
 import { ProviderIcon } from "@/components/ui/ProviderIcon";
 import type { ProviderInfo, CustomProviderInfo } from "@/types";
 import { ProviderDetail } from "./ProviderDetail";
@@ -97,11 +98,13 @@ export function ProviderSection() {
   const refreshPreset = useCallback(async () => {
     const res = await API.getProviders();
     setProviders(res.providers);
+    void useConfigStatusStore.getState().refresh();
   }, []);
 
   const refreshCustom = useCallback(async () => {
     const res = await API.listCustomProviders();
     setCustomProviders(res.providers);
+    void useConfigStatusStore.getState().refresh();
   }, []);
 
   useEffect(() => {
@@ -250,6 +253,7 @@ export function ProviderSection() {
               void API.listCustomProviders()
                 .then((res) => {
                   setCustomProviders(res.providers);
+                  void useConfigStatusStore.getState().refresh();
                   if (res.providers.length > 0) {
                     const newest = res.providers[res.providers.length - 1];
                     setSelection({ kind: "custom", id: newest.id });

--- a/frontend/src/router.test.tsx
+++ b/frontend/src/router.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
 import { API } from "@/api";
@@ -45,6 +45,11 @@ describe("AppRoutes", () => {
     // 路由测试无需关心配置状态，也避免触发未 mock 的供应商接口与退避重试。
     useConfigStatusStore.setState({ initialized: true });
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    // 个别用例切到 fake timers,统一还原,避免污染其它用例。
+    vi.useRealTimers();
   });
 
   it("redirects root path to /app/projects", async () => {
@@ -150,5 +155,29 @@ describe("AppRoutes", () => {
     useAuthStore.setState({ isAuthenticated: false, isLoading: false });
     renderAt("/app/projects");
     expect(await screen.findByTestId("login-page")).toBeInTheDocument();
+  });
+
+  it("ConfigStatusLoader 挂载后拉取配置状态,未初始化时按退避重试", async () => {
+    vi.useFakeTimers();
+    // 从未初始化起步,让根级 ConfigStatusLoader 真正执行 fetch/重试逻辑
+    useConfigStatusStore.setState(useConfigStatusStore.getInitialState(), true);
+    // 让配置拉取失败 → store 保持未初始化 → loader 按退避重试
+    vi.spyOn(API, "getProviders").mockRejectedValue(new Error("backend not ready"));
+    vi.spyOn(API, "listCustomProviders").mockRejectedValue(new Error("backend not ready"));
+    vi.spyOn(API, "getSystemConfig").mockRejectedValue(new Error("backend not ready"));
+
+    renderAt("/app/projects");
+
+    // 挂载即首次拉取
+    await vi.advanceTimersByTimeAsync(0);
+    expect(API.getProviders).toHaveBeenCalledTimes(1);
+
+    // 第一次退避重试(800ms)
+    await vi.advanceTimersByTimeAsync(800);
+    expect(API.getProviders).toHaveBeenCalledTimes(2);
+
+    // 第二次退避重试(再 1600ms)
+    await vi.advanceTimersByTimeAsync(1600);
+    expect(API.getProviders).toHaveBeenCalledTimes(3);
   });
 });

--- a/frontend/src/router.test.tsx
+++ b/frontend/src/router.test.tsx
@@ -5,6 +5,7 @@ import { memoryLocation } from "wouter/memory-location";
 import { API } from "@/api";
 import { useAssistantStore } from "@/stores/assistant-store";
 import { useAuthStore } from "@/stores/auth-store";
+import { useConfigStatusStore } from "@/stores/config-status-store";
 import { useProjectsStore } from "@/stores/projects-store";
 import { AppRoutes } from "@/router";
 
@@ -40,6 +41,9 @@ describe("AppRoutes", () => {
   beforeEach(() => {
     resetStores();
     useAuthStore.setState({ isAuthenticated: true, isLoading: false });
+    // ConfigStatusLoader 在 AppRoutes 中始终挂载；预置 initialized 让其 fetch() 短路，
+    // 路由测试无需关心配置状态，也避免触发未 mock 的供应商接口与退避重试。
+    useConfigStatusStore.setState({ initialized: true });
     vi.restoreAllMocks();
   });
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -17,6 +17,42 @@ import { API } from "@/api";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useAssistantStore } from "@/stores/assistant-store";
 import { useAuthStore } from "@/stores/auth-store";
+import { useConfigStatusStore } from "@/stores/config-status-store";
+
+// ---------------------------------------------------------------------------
+// ConfigStatusLoader — 登录后集中拉取一次配置完整性状态
+// ---------------------------------------------------------------------------
+
+/**
+ * 配置完整性（红点 / 必需设置提醒）的单点加载器，始终挂载在路由根，跨页面导航存活。
+ * 单例 store 一次初始化即覆盖所有落地页（首页 / 设置 / 项目），不再依赖某个具体页面
+ * 是否在 mount 时拉取。首次失败（如后端尚未就绪）时带界次数退避重试，无需手动刷新页面。
+ */
+function ConfigStatusLoader() {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+    let attempts = 0;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const tick = async () => {
+      await useConfigStatusStore.getState().fetch();
+      if (cancelled) return;
+      if (!useConfigStatusStore.getState().initialized && attempts < 5) {
+        attempts += 1;
+        timer = setTimeout(() => void tick(), 800 * attempts);
+      }
+    };
+    void tick();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [isAuthenticated]);
+
+  return null;
+}
 
 // ---------------------------------------------------------------------------
 // AuthGuard — redirects to /login when not authenticated
@@ -111,6 +147,7 @@ function StudioWorkspace() {
 export function AppRoutes() {
   return (
     <>
+      <ConfigStatusLoader />
       <Switch>
         {/* Login page */}
         <Route path="/login" component={LoginPage} />

--- a/frontend/src/stores/config-status-store.test.ts
+++ b/frontend/src/stores/config-status-store.test.ts
@@ -107,4 +107,50 @@ describe("config-status-store", () => {
     expect(useConfigStatusStore.getState().initialized).toBe(true);
     expect(useConfigStatusStore.getState().issues.length).toBeGreaterThan(0);
   });
+
+  it("coalesces a refresh requested while one is in flight instead of dropping it", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let providersCall = 0;
+    vi.spyOn(API, "getProviders").mockImplementation(async () => {
+      providersCall += 1;
+      if (providersCall === 1) {
+        await gate; // 让首次刷新停在 in-flight,模拟"保存后刷新"撞上进行中的加载
+        return makeProviders(); // 旧数据:未就绪 → 有 issues
+      }
+      return makeProviders([
+        {
+          id: "gemini",
+          display_name: "Google Gemini",
+          status: "ready",
+          media_types: ["image", "video", "text"],
+          capabilities: [],
+          configured_keys: ["api_key"],
+          missing_keys: [],
+          models: {},
+        },
+      ]); // 新数据:全就绪 → 无 issues
+    });
+    vi.spyOn(API, "listCustomProviders").mockResolvedValue({ providers: [] });
+    vi.spyOn(API, "getSystemConfig").mockResolvedValue(
+      makeConfigResponse({ anthropic_api_key: { is_set: true, masked: "sk-ant-***" } }),
+    );
+
+    const store = useConfigStatusStore.getState();
+    const first = store.refresh();
+    const second = store.refresh(); // 命中 loading 守卫 → 应被合并而非丢弃
+    expect(useConfigStatusStore.getState().pendingRefresh).toBe(true);
+
+    release();
+    await first; // 首次刷新 + 合并补跑的尾部刷新都在此完成
+    await second;
+
+    // 补跑确实执行(getProviders 被调两次),且最终落地的是最新数据
+    expect(API.getProviders).toHaveBeenCalledTimes(2);
+    expect(useConfigStatusStore.getState().issues).toHaveLength(0);
+    expect(useConfigStatusStore.getState().isComplete).toBe(true);
+    expect(useConfigStatusStore.getState().pendingRefresh).toBe(false);
+  });
 });

--- a/frontend/src/stores/config-status-store.ts
+++ b/frontend/src/stores/config-status-store.ts
@@ -87,42 +87,58 @@ interface ConfigStatusState {
   isComplete: boolean;
   loading: boolean;
   initialized: boolean;
-  /** 进行中刷新期间又收到 refresh() 时置位,完成后补跑一次,避免丢掉最后一次请求的数据。 */
+  /** 进行中刷新期间又收到 refresh() 时置位,本轮完成后补跑一次,避免丢掉最后一次请求的数据。 */
   pendingRefresh: boolean;
   fetch: () => Promise<void>;
   refresh: () => Promise<void>;
 }
 
-export const useConfigStatusStore = create<ConfigStatusState>((set, get) => ({
-  issues: [],
-  isComplete: true,
-  loading: false,
-  initialized: false,
-  pendingRefresh: false,
+export const useConfigStatusStore = create<ConfigStatusState>((set, get) => {
+  // 单条在途刷新链:并发 refresh()/fetch() 都复用它,
+  // 返回的 Promise 只在数据(含补跑)真正落地后才 resolve——await 完即代表状态最新。
+  let inflight: Promise<void> | null = null;
 
-  fetch: async () => {
-    if (get().initialized || get().loading) return;
-    await get().refresh();
-  },
+  const run = async (): Promise<void> => {
+    // 循环直到没有新的 pending:补跑在同一条链上完成,而非提前 resolve。
+    for (;;) {
+      set({ loading: true, pendingRefresh: false });
+      try {
+        const issues = await getConfigIssues();
+        set({ issues, isComplete: issues.length === 0, initialized: true });
+      } catch {
+        // 失败保持 initialized=false,下次仍可重试。
+      } finally {
+        set({ loading: false });
+      }
+      if (!get().pendingRefresh) break;
+    }
+  };
 
-  refresh: async () => {
-    // 已有刷新在途:不丢弃这次请求,而是标记 pending,在途刷新完成后补跑一次。
-    // 否则"保存供应商后的 refresh()"会被初始加载/前一次刷新的 loading 守卫静默吞掉,
-    // 红点/警示停留在保存前的旧值。
-    if (get().loading) {
-      set({ pendingRefresh: true });
-      return;
-    }
-    set({ loading: true, pendingRefresh: false });
-    try {
-      const issues = await getConfigIssues();
-      set({ issues, isComplete: issues.length === 0, loading: false, initialized: true });
-    } catch {
-      set({ loading: false });
-    }
-    if (get().pendingRefresh) {
-      set({ pendingRefresh: false });
-      await get().refresh();
-    }
-  },
-}));
+  return {
+    issues: [],
+    isComplete: true,
+    loading: false,
+    initialized: false,
+    pendingRefresh: false,
+
+    fetch: async () => {
+      if (get().initialized) return;
+      // 已有刷新在途:等它,而不是另起一轮;无在途则发起一次。
+      await (inflight ?? get().refresh());
+    },
+
+    refresh: () => {
+      // 已有刷新在途:标记补跑并复用同一条完成链,所有并发调用方都 await 到最终落地。
+      // 否则"保存供应商后的 refresh()"会被进行中的初始加载/前一次刷新静默吞掉,
+      // 红点/警示停留在保存前的旧值。
+      if (inflight) {
+        set({ pendingRefresh: true });
+        return inflight;
+      }
+      inflight = run().finally(() => {
+        inflight = null;
+      });
+      return inflight;
+    },
+  };
+});

--- a/frontend/src/stores/config-status-store.ts
+++ b/frontend/src/stores/config-status-store.ts
@@ -87,6 +87,8 @@ interface ConfigStatusState {
   isComplete: boolean;
   loading: boolean;
   initialized: boolean;
+  /** 进行中刷新期间又收到 refresh() 时置位,完成后补跑一次,避免丢掉最后一次请求的数据。 */
+  pendingRefresh: boolean;
   fetch: () => Promise<void>;
   refresh: () => Promise<void>;
 }
@@ -96,6 +98,7 @@ export const useConfigStatusStore = create<ConfigStatusState>((set, get) => ({
   isComplete: true,
   loading: false,
   initialized: false,
+  pendingRefresh: false,
 
   fetch: async () => {
     if (get().initialized || get().loading) return;
@@ -103,13 +106,23 @@ export const useConfigStatusStore = create<ConfigStatusState>((set, get) => ({
   },
 
   refresh: async () => {
-    if (get().loading) return;
-    set({ loading: true });
+    // 已有刷新在途:不丢弃这次请求,而是标记 pending,在途刷新完成后补跑一次。
+    // 否则"保存供应商后的 refresh()"会被初始加载/前一次刷新的 loading 守卫静默吞掉,
+    // 红点/警示停留在保存前的旧值。
+    if (get().loading) {
+      set({ pendingRefresh: true });
+      return;
+    }
+    set({ loading: true, pendingRefresh: false });
     try {
       const issues = await getConfigIssues();
       set({ issues, isComplete: issues.length === 0, loading: false, initialized: true });
     } catch {
       set({ loading: false });
+    }
+    if (get().pendingRefresh) {
+      set({ pendingRefresh: false });
+      await get().refresh();
     }
   },
 }));

--- a/frontend/src/stores/config-status-store.ts
+++ b/frontend/src/stores/config-status-store.ts
@@ -107,10 +107,12 @@ export const useConfigStatusStore = create<ConfigStatusState>((set, get) => {
         set({ issues, isComplete: issues.length === 0, initialized: true });
       } catch {
         // 失败保持 initialized=false,下次仍可重试。
-      } finally {
-        set({ loading: false });
       }
-      if (!get().pendingRefresh) break;
+      // loading 仅在整条链终止时才置 false:补跑间隙保持 true,避免 true→false→true 闪烁。
+      if (!get().pendingRefresh) {
+        set({ loading: false });
+        break;
+      }
     }
   };
 


### PR DESCRIPTION
## 背景

设置按钮红点与设置页"必需设置"提醒存在两个显示问题:

1. **首次进入不显示,需手动刷新** —— 红点/提醒在首屏与设置页首次进入时不出现,刷新后才显示。
2. **配置后不消失** —— 例如配置自定义供应商后,供应商/模型设置 tab 与顶部提醒仍残留。

## 根因

- 首页 `ProjectsPage` 只读取配置完整性状态、从不触发拉取;触发拉取的 `GlobalHeader` 仅在项目内挂载。冷启动落在首页时,单例 store 停在乐观默认值,红点不出现。
- 配置状态拉取是"每次挂载一次性 + 静默吞错",首次失败(如后端尚未就绪)后无重试,只能手动刷新页面恢复。
- 供应商保存/删除/新建路径(`ProviderSection`)从不调用配置状态 `refresh()`,导致提醒不重算。
- `refresh()` 的 `loading` 守卫会静默丢弃在途期间收到的刷新请求,造成"保存后刷新撞上初始加载"的丢更新。

## 改动

- 路由根新增 `ConfigStatusLoader`:登录后集中拉取一次配置完整性状态,跨页面导航存活,覆盖所有落地页;首次失败时带界次数退避重试,无需手动刷新。
- `ProviderSection` 在保存/删除/新建供应商后刷新配置状态,使红点、tab 警示 icon、顶部提醒即时清除或恢复。
- `config-status` store 的 `refresh()` 改为合并在途请求(trailing-coalesce):在途期间收到的刷新标记为 pending,完成后补跑一次,保证最后一次请求的数据必然落地,消除丢更新。

## 验证

`pnpm lint` 与 `pnpm check`(tsc + eslint + vitest)全绿 —— 84 个测试文件 / 628 项通过,含新增的 trailing-coalesce 回归测试。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复添加/更新 provider 后配置状态不同步的问题，确保列表变更后即时刷新并同步。
  * 改进并发刷新行为：合并重复刷新请求并保证补跑后最终结果不丢失，避免竞态导致的不一致。

* **New Features**
  * 登录后在路由根部自动触发配置完整性加载，首次失败时按退避策略重试并在卸载时清理定时器。

* **Tests**
  * 新增并发刷新合并、重试逻辑与定时器恢复的测试用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->