### PR TITLE
fix(custom-provider): 修复返回 generation_id 的 V2 视频供应商提交即报错无法生成

### DIFF
--- a/lib/video_backends/v2_video_generations.py
+++ b/lib/video_backends/v2_video_generations.py
@@ -98,6 +98,7 @@ _VIDEO_URL_PATHS: tuple[tuple[str | int, ...], ...] = (
     ("url",),
 )
 _TASK_ID_PATHS: tuple[tuple[str | int, ...], ...] = (
+    ("generation_id",),
     ("id",),
     ("task_id",),
     ("data", "task_id"),

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -155,6 +155,7 @@ class TestTaskIdExtraction:
     @pytest.mark.parametrize(
         "payload,expected",
         [
+            ({"generation_id": "vg_xxx"}, "vg_xxx"),  # 流派 C 文档约定字段（CometAPI 等）
             ({"id": "gen_1"}, "gen_1"),
             ({"task_id": "t1"}, "t1"),
             ({"data": {"task_id": "d1"}}, "d1"),
@@ -168,6 +169,10 @@ class TestTaskIdExtraction:
 
     def test_priority_id_wins(self):
         assert _first_str_by_paths({"id": "primary", "task_id": "secondary"}, _TASK_ID_PATHS) == "primary"
+
+    def test_priority_generation_id_wins(self):
+        # generation_id 是端点文档约定字段，优先级压过 id（表首）
+        assert _first_str_by_paths({"generation_id": "gen", "id": "fallback"}, _TASK_ID_PATHS) == "gen"
 
 
 class TestBuildRequestBody:


### PR DESCRIPTION
## 问题

`V2VideoGenerationsBackend`（`/v2/video/generations` 通用后端）在**创建任务**阶段无法解析 `generation_id`：遵循该端点事实标准、create 返回 `{"generation_id": "vg_xxx"}` 的自定义视频 provider（CometAPI 等）一提交就 `RuntimeError`，根本走不到轮询，完全不可用。

## 自相矛盾点

模块 docstring 与 `_poll_once()` 都把 task id 字段定为 `generation_id`，但 create 响应的提取表 `_TASK_ID_PATHS` 偏偏漏了 `("generation_id",)`。

## 修复

把 `("generation_id",)` 加到 `_TASK_ID_PATHS` **表首**（按文档约定该字段优先级最高）。提取逻辑 `_first_str_by_paths` 无需改。

## 测试

- `TestTaskIdExtraction::test_extracts` 新增 `{"generation_id": "vg_xxx"}` 参数化用例
- 新增 `test_priority_generation_id_wins`，证明 `generation_id` 压过 `id`

`pytest` / `ruff` / `basedpyright` 全绿。

Closes #716