### PR TITLE
fix(project-manager): 损坏剧本（数组含非对象元素）不再导致 500，按 script_editor 既有模式干净降级

### DIFF
--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -587,6 +587,10 @@ class ProjectManager:
             default_duration = 4 if kind == "segments" else 8
 
             def _duration(item: dict) -> int:
+                # 损坏脚本可能混入非 dict 元素（如 ["foo", {...}]）——与 script_editor 的
+                # _find_index / _existing_ids 一致地跳过，退化为 default 而非抛 AttributeError。
+                if not isinstance(item, dict):
+                    return default_duration
                 value = item.get("duration_seconds")
                 # bool 是 int 子类,排除避免 duration_seconds=True 被算成 1 秒、=False 算成 0 秒
                 if isinstance(value, bool):
@@ -1125,6 +1129,10 @@ class ProjectManager:
             items, id_field, _kind = resolve_items(script)
 
             for item in items:
+                # 损坏脚本的非 dict 元素跳过（镜像 script_editor._find_index 的 isinstance 守卫），
+                # 避免 item.get(id_field) 抛 AttributeError；未命中仍走下方 else 的 KeyError fail-loud。
+                if not isinstance(item, dict):
+                    continue
                 if str(item.get(id_field)) == str(scene_id):
                     assets = item.get("generated_assets")
                     if not isinstance(assets, dict):
@@ -1175,8 +1183,9 @@ class ProjectManager:
             content_mode = script.get("content_mode", "narration")
             items, id_field, _kind = resolve_items(script)
 
-            # 建立 scene_id → item 索引，避免 O(N*M) 查找
-            item_by_id: dict[str, dict] = {str(item.get(id_field)): item for item in items}
+            # 建立 scene_id → item 索引，避免 O(N*M) 查找。损坏脚本的非 dict 元素过滤掉
+            # （镜像 script_editor._existing_ids），命中这类 id 的 update 会落 missing → KeyError fail-loud。
+            item_by_id: dict[str, dict] = {str(item.get(id_field)): item for item in items if isinstance(item, dict)}
             missing: list[str] = []
 
             for scene_id, asset_type, asset_path in updates:
@@ -1230,7 +1239,8 @@ class ProjectManager:
             assets = item.get("generated_assets")
             return not isinstance(assets, dict) or not assets.get(asset_type)
 
-        return [item for item in items if _missing(item)]
+        # 损坏脚本的非 dict 元素直接剔除（镜像 script_editor._existing_ids 的过滤），UI 不渲染垃圾项。
+        return [item for item in items if isinstance(item, dict) and _missing(item)]
 
     # ==================== 文件路径工具 ====================
 
@@ -1275,7 +1285,8 @@ class ProjectManager:
             assets = item.get("generated_assets")
             return not isinstance(assets, dict) or not assets.get("storyboard_image")
 
-        return [item for item in items if _missing_storyboard(item)]
+        # 同 get_pending_scenes：非 dict 元素剔除，镜像 script_editor._existing_ids。
+        return [item for item in items if isinstance(item, dict) and _missing_storyboard(item)]
 
     # ==================== 项目级元数据管理 ====================
 

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -578,7 +578,12 @@ class ProjectManager:
                 e,
             )
         else:
-            metadata["total_scenes"] = len(items)
+            # 损坏脚本可能混入非 dict 元素（如 ["foo", {...}]）——它们在读取路径
+            # （get_pending_scenes 等）与写入路径（batch_update 索引 / update_scene_asset 循环）
+            # 都被当作不存在过滤掉，metadata 重算一并排除：否则 total_scenes 会多计、
+            # estimated_duration_seconds 会被垃圾元素按 default 时长撑大，与各路径不一致。
+            scene_items = [item for item in items if isinstance(item, dict)]
+            metadata["total_scenes"] = len(scene_items)
             # 计算总时长：按当前选中的数据结构决定回退值，避免 content_mode 缺失时误判。
             # ``.get(k, default)`` 仅在键缺失时返回 default，键存在但值为 None（脏数据）会
             # 返回 None 让 sum() 抛 TypeError——显式判 None 视为缺失，与同函数前面对 metadata
@@ -587,10 +592,6 @@ class ProjectManager:
             default_duration = 4 if kind == "segments" else 8
 
             def _duration(item: dict) -> int:
-                # 损坏脚本可能混入非 dict 元素（如 ["foo", {...}]）——与 script_editor 的
-                # _find_index / _existing_ids 一致地跳过，退化为 default 而非抛 AttributeError。
-                if not isinstance(item, dict):
-                    return default_duration
                 value = item.get("duration_seconds")
                 # bool 是 int 子类,排除避免 duration_seconds=True 被算成 1 秒、=False 算成 0 秒
                 if isinstance(value, bool):
@@ -599,7 +600,7 @@ class ProjectManager:
                     return int(value)
                 return default_duration
 
-            metadata["estimated_duration_seconds"] = sum(_duration(item) for item in items)
+            metadata["estimated_duration_seconds"] = sum(_duration(item) for item in scene_items)
 
         # 原子写（含路径遍历防护，output_path 已在守卫前解析），避免并发 PATCH 导致 JSON 损坏
         atomic_write_json(output_path, script)

--- a/tests/test_project_manager_save_validation.py
+++ b/tests/test_project_manager_save_validation.py
@@ -338,3 +338,51 @@ class TestAssetWritebackExemption:
         # 同样 get_scenes_needing_storyboard 也容错
         result2 = pm.get_scenes_needing_storyboard("demo", "episode_1.json")
         assert len(result2) == 1
+
+    def _seed_non_dict_element(self, tmp_path: Path) -> None:
+        """落盘构造合法 list 但混入非 dict 元素（"foo"）的脏剧本——模拟手改/损坏数据。"""
+        script_dir = tmp_path / "projects" / "demo" / "scripts"
+        script_dir.mkdir(parents=True, exist_ok=True)
+        (script_dir / "episode_1.json").write_text(
+            '{"episode": 1, "title": "x", "content_mode": "narration", '
+            '"segments": ["foo", {"segment_id": "E1S01", "duration_seconds": 4}], '
+            '"novel": {"title": "n", "chapter": "c"}, "summary": ""}',
+            encoding="utf-8",
+        )
+
+    def test_read_helpers_skip_non_dict_items(self, tmp_path: Path):
+        """读取侧：数组混入非 dict 元素（"foo"）时跳过它、只返回合法 dict 项，不抛 AttributeError。
+        与 script_editor._existing_ids 的 isinstance 过滤一致。"""
+        pm = _pm(tmp_path)
+        self._seed_non_dict_element(tmp_path)
+        pending = pm.get_pending_scenes("demo", "episode_1.json", "storyboard_image")
+        assert [item["segment_id"] for item in pending] == ["E1S01"]
+        needing = pm.get_scenes_needing_storyboard("demo", "episode_1.json")
+        assert [item["segment_id"] for item in needing] == ["E1S01"]
+
+    def test_update_scene_asset_writes_with_non_dict_sibling(self, tmp_path: Path):
+        """写入侧 update_scene_asset：非 dict 兄弟元素被跳过，合法 id 正常回写，不抛 AttributeError。
+        写回触发的 metadata 重算（_duration）遍历含非 dict 元素的数组也不崩。"""
+        pm = _pm(tmp_path)
+        self._seed_non_dict_element(tmp_path)
+        pm.update_scene_asset("demo", "episode_1.json", "E1S01", "storyboard_image", "storyboards/E1S01.png")
+        saved = pm.load_script("demo", "episode_1.json")
+        target = next(s for s in saved["segments"] if isinstance(s, dict) and s.get("segment_id") == "E1S01")
+        assert target["generated_assets"]["storyboard_image"] == "storyboards/E1S01.png"
+
+    def test_batch_update_scene_assets_writes_with_non_dict_sibling(self, tmp_path: Path):
+        """批量写入：非 dict 兄弟元素被过滤；合法 id 成功；写回触发的 metadata 重算（_duration）
+        遍历含非 dict 元素的数组也不抛 AttributeError。"""
+        pm = _pm(tmp_path)
+        self._seed_non_dict_element(tmp_path)
+        pm.batch_update_scene_assets("demo", "episode_1.json", [("E1S01", "video_clip", "videos/E1S01.mp4")])
+        saved = pm.load_script("demo", "episode_1.json")
+        target = next(s for s in saved["segments"] if isinstance(s, dict) and s.get("segment_id") == "E1S01")
+        assert target["generated_assets"]["video_clip"] == "videos/E1S01.mp4"
+
+    def test_batch_update_scene_assets_missing_id_fails_loud_with_non_dict_sibling(self, tmp_path: Path):
+        """命中不存在 id 仍 fail-loud（KeyError）——非 dict 元素被过滤后不会被误当作 id 命中。"""
+        pm = _pm(tmp_path)
+        self._seed_non_dict_element(tmp_path)
+        with pytest.raises(KeyError):
+            pm.batch_update_scene_assets("demo", "episode_1.json", [("E1S99", "video_clip", "videos/x.mp4")])

--- a/tests/test_project_manager_save_validation.py
+++ b/tests/test_project_manager_save_validation.py
@@ -379,6 +379,9 @@ class TestAssetWritebackExemption:
         saved = pm.load_script("demo", "episode_1.json")
         target = next(s for s in saved["segments"] if isinstance(s, dict) and s.get("segment_id") == "E1S01")
         assert target["generated_assets"]["video_clip"] == "videos/E1S01.mp4"
+        # 非 dict 元素（"foo"）不计入 metadata：只有 1 个合法片段、4 秒，不被垃圾元素撑大
+        assert saved["metadata"]["total_scenes"] == 1
+        assert saved["metadata"]["estimated_duration_seconds"] == 4
 
     def test_batch_update_scene_assets_missing_id_fails_loud_with_non_dict_sibling(self, tmp_path: Path):
         """命中不存在 id 仍 fail-loud（KeyError）——非 dict 元素被过滤后不会被误当作 id 命中。"""


### PR DESCRIPTION
## 问题

`lib/project_manager.py` 中消费 `resolve_items()` 返回数组的若干方法，未护住「数组元素本身不是 dict」的损坏脚本（如手改/损坏的 `{"segments": ["foo", {...}]}`），对非 dict 元素调 `item.get(...)` 抛 `AttributeError`（未捕获 → 500），而非干净报错。

这与**同库** `lib/script_editor.py` 的既有模式不一致——`_find_index` / `_existing_ids` 已用 `isinstance(item, dict)` 干净跳过非 dict 元素。

## 修复

在 5 个消费方补 `isinstance(item, dict)` 护栏，与 `script_editor.py` 既有模式对齐：

| 方法 | 行为 |
|---|---|
| `_write_script_unlocked` → `_duration` | 非 dict 退化为 default 时长 |
| `update_scene_asset` | 循环跳过非 dict（未命中 id 仍走 `KeyError` fail-loud） |
| `batch_update_scene_assets` | 索引过滤非 dict（命中这类 id → `missing` → `KeyError` fail-loud） |
| `get_pending_scenes` → `_missing` | 读取侧剔除非 dict |
| `get_scenes_needing_storyboard` → `_missing_storyboard` | 读取侧剔除非 dict |

> 注：`update_scene_asset`（写入侧循环）原先只护了内层 `generated_assets`、未护外层 `item`，与 `batch_update_scene_assets` 是完全相同的未护栏模式，一并修复以免留下同类不一致。

**不在 `resolve_items` 源头 filter**——其 docstring 明确返回「script 内实际引用（就地编辑生效）」，filter 会产生新 list 破坏就地编辑契约；这些均为只读消费，在消费侧 guard 安全且一致。仅影响畸形数据，正常输入无影响。

## 测试

`tests/test_project_manager_save_validation.py` 新增一组用例，种入 `"segments": ["foo", {合法 segment}]`：
- 读取 helper 跳过 `"foo"`、只返回合法 dict 项
- `update_scene_asset` / `batch_update_scene_assets` 对合法 id 正常回写（同时覆盖写回触发的 `_duration` 重算）
- 命中不存在 id → `KeyError` fail-loud

`pytest`（161 项 project_manager 用例）/ `ruff` / `basedpyright`（0 error）全绿。新增 `isinstance` 守卫产生的 `reportUnnecessaryIsInstance` warning 与既有 `script_editor.py` 同类（warning 级、不阻塞 CI）。

Closes #717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 提升对异常/非结构化条目的容错：读写流程会跳过非字典结构项，避免因脏数据导致时长计算异常或调用时发生属性错误，仍对缺失项保持显式失败行为。

* **Tests**
  * 新增覆盖脏数据场景的测试，验证读写一致性、元数据重算与预期失败路径。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->