### PR TITLE
fix(video-backends): 自定义供应商 BytePlus seedance-2 参考生视频不再因 service_tier 报 400

### DIFF
--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -32,29 +32,11 @@ class ArkVideoBackend:
 
     DEFAULT_MODEL = "doubao-seedance-1-5-pro-251215"
 
-    # Seedance 2.0 系列不接受 service_tier 参数；FLEX_TIER 必须从能力集中剔除，
-    # 否则 _create_task 会触发上游 400。ark 与 ark-agent-plan 各用不同的模型 ID
-    # 命名（dash + 日期戳 vs. dot 简洁版），两套都要纳入。
-    _SEEDANCE_2_BASE_CAPABILITIES: set[VideoCapability] = {
+    _BASE_CAPABILITIES: set[VideoCapability] = {
         VideoCapability.TEXT_TO_VIDEO,
         VideoCapability.IMAGE_TO_VIDEO,
         VideoCapability.GENERATE_AUDIO,
         VideoCapability.SEED_CONTROL,
-    }
-
-    _MODEL_CAPABILITIES: dict[str, set[VideoCapability]] = {
-        "doubao-seedance-2-0-260128": _SEEDANCE_2_BASE_CAPABILITIES,
-        "doubao-seedance-2-0-fast-260128": _SEEDANCE_2_BASE_CAPABILITIES,
-        "doubao-seedance-2.0": _SEEDANCE_2_BASE_CAPABILITIES,
-        "doubao-seedance-2.0-fast": _SEEDANCE_2_BASE_CAPABILITIES,
-    }
-
-    _DEFAULT_CAPABILITIES: set[VideoCapability] = {
-        VideoCapability.TEXT_TO_VIDEO,
-        VideoCapability.IMAGE_TO_VIDEO,
-        VideoCapability.GENERATE_AUDIO,
-        VideoCapability.SEED_CONTROL,
-        VideoCapability.FLEX_TIER,
     }
 
     def __init__(
@@ -66,7 +48,13 @@ class ArkVideoBackend:
     ):
         self._client = create_ark_client(api_key=api_key, base_url=base_url)
         self._model = model or self.DEFAULT_MODEL
-        self._capabilities = self._MODEL_CAPABILITIES.get(self._model, self._DEFAULT_CAPABILITIES)
+        # FLEX_TIER（service_tier 参数）仅 seedance-1.x 等老模型支持；seedance-2 系列上游
+        # 在 r2v 下会 400 拒绝该参数，必须从能力集中剔除。族系用子串识别而非枚举具体 model id：
+        # 同族有多套命名（doubao-/dreamina- 前缀、dash+日期戳 / dot 简洁版），枚举必漏（见
+        # video_capabilities_for_model 已采用同一识别口径）。
+        self._capabilities = set(self._BASE_CAPABILITIES)
+        if not self._is_seedance_2(self._model):
+            self._capabilities.add(VideoCapability.FLEX_TIER)
 
     @property
     def name(self) -> str:
@@ -81,14 +69,24 @@ class ArkVideoBackend:
         return self._capabilities
 
     @staticmethod
+    def _is_seedance_2(model: str) -> bool:
+        """按 model_id 子串识别 seedance-2 族系（含 fast 变体）。
+
+        同一族系上游有多套命名：doubao-/dreamina- 前缀（火山国内站 / BytePlus 国际站）、
+        dash+日期戳（doubao-seedance-2-0-260128）与 dot 简洁版（doubao-seedance-2.0）。
+        FLEX_TIER 剔除与参考图能力共用本判定，避免两条路径口径漂移。
+        """
+        model_lower = model.lower()
+        return "seedance-2" in model_lower or "seedance2" in model_lower
+
+    @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
         """按 model_id 纯计算参考图等 caps —— 不构造 SDK client（无需 api_key）。
 
         resolver 解析参考图上限时调本方法即可，不必构造整个 backend；instance property 委托至此，
         保持 backend 为单一真相源。
         """
-        model_lower = model.lower()
-        if "seedance-2" in model_lower or "seedance2" in model_lower:
+        if ArkVideoBackend._is_seedance_2(model):
             return VideoCapabilities(last_frame=True, reference_images=True, max_reference_images=9)
         return VideoCapabilities()
 

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -48,10 +48,10 @@ class ArkVideoBackend:
     ):
         self._client = create_ark_client(api_key=api_key, base_url=base_url)
         self._model = model or self.DEFAULT_MODEL
-        # FLEX_TIER（service_tier 参数）仅 seedance-1.x 等老模型支持；seedance-2 系列上游
-        # 在 r2v 下会 400 拒绝该参数，必须从能力集中剔除。族系用子串识别而非枚举具体 model id：
-        # 同族有多套命名（doubao-/dreamina- 前缀、dash+日期戳 / dot 简洁版），枚举必漏（见
-        # video_capabilities_for_model 已采用同一识别口径）。
+        # FLEX_TIER（service_tier 参数）仅 seedance-1.x 等老模型支持；seedance-2-0/2.0 系列
+        # 上游在 r2v 下会 400 拒绝该参数，必须从能力集中剔除。判定见 _is_seedance_2：用 `in`
+        # 子串兼容多套前缀命名（doubao-/dreamina-），但版本号收窄到已验证的 2-0/2.0，
+        # 不对未发布版本（如 seedance-2.5）过早假设。
         self._capabilities = set(self._BASE_CAPABILITIES)
         if not self._is_seedance_2(self._model):
             self._capabilities.add(VideoCapability.FLEX_TIER)
@@ -70,14 +70,15 @@ class ArkVideoBackend:
 
     @staticmethod
     def _is_seedance_2(model: str) -> bool:
-        """按 model_id 子串识别 seedance-2 族系（含 fast 变体）。
+        """按 model_id 子串识别已验证的 seedance-2-0 / seedance-2.0 系列（含 fast 变体）。
 
-        同一族系上游有多套命名：doubao-/dreamina- 前缀（火山国内站 / BytePlus 国际站）、
-        dash+日期戳（doubao-seedance-2-0-260128）与 dot 简洁版（doubao-seedance-2.0）。
-        FLEX_TIER 剔除与参考图能力共用本判定，避免两条路径口径漂移。
+        只匹配已验证不支持 service_tier 的版本号（2-0 与 2.0 两种写法），不对未发布的未来版本
+        （如 seedance-2.5）过早假设。用 `in` 子串而非前缀匹配，以兼容上游多套前缀命名
+        （doubao- 火山国内站 / dreamina- BytePlus 国际站）。FLEX_TIER 剔除与参考图能力共用
+        本判定，避免两条路径口径漂移。
         """
         model_lower = model.lower()
-        return "seedance-2" in model_lower or "seedance2" in model_lower
+        return "seedance-2-0" in model_lower or "seedance-2.0" in model_lower
 
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -427,52 +427,23 @@ class TestArkModelCapabilities:
 class TestArkServiceTierParam:
     """service_tier 只对声明了 FLEX_TIER 能力的模型传入，否则 API 会报错。"""
 
-    async def test_seedance_2_does_not_send_service_tier(self, tmp_path):
+    @pytest.mark.parametrize(
+        "model",
+        ["doubao-seedance-2-0-260128", "dreamina-seedance-2-0-260128"],
+    )
+    async def test_seedance_2_does_not_send_service_tier(self, tmp_path, model):
+        """seedance-2 系列（含 dreamina- 前缀的自定义供应商命名）不得发 service_tier，否则 r2v 上游 400。"""
         output = tmp_path / "out.mp4"
         mock_client = MagicMock()
         mock_client.content_generation = MagicMock()
         mock_client.content_generation.tasks = MagicMock()
 
         with patch("lib.video_backends.ark.create_ark_client", return_value=mock_client):
-            backend = ArkVideoBackend(api_key="test", model="doubao-seedance-2-0-260128")
+            backend = ArkVideoBackend(api_key="test", model=model)
         backend._client = mock_client
 
         create_result = MagicMock()
         create_result.id = "cgt-seedance2"
-        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
-
-        get_result = MagicMock()
-        get_result.status = "succeeded"
-        get_result.content = MagicMock()
-        get_result.content.video_url = "https://cdn.example.com/v.mp4"
-        get_result.seed = None
-        get_result.usage = None
-        backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
-
-        patcher = _mock_httpx_stream()
-        try:
-            request = VideoGenerationRequest(prompt="test", output_path=output)
-            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-                await backend.generate(request)
-        finally:
-            patcher.stop()
-
-        create_kwargs = backend._client.content_generation.tasks.create.call_args.kwargs
-        assert "service_tier" not in create_kwargs
-
-    async def test_seedance_2_dreamina_prefix_does_not_send_service_tier(self, tmp_path):
-        """dreamina- 前缀的 seedance-2（自定义供应商常见）同样不得发 service_tier，否则 r2v 上游 400。"""
-        output = tmp_path / "out.mp4"
-        mock_client = MagicMock()
-        mock_client.content_generation = MagicMock()
-        mock_client.content_generation.tasks = MagicMock()
-
-        with patch("lib.video_backends.ark.create_ark_client", return_value=mock_client):
-            backend = ArkVideoBackend(api_key="test", model="dreamina-seedance-2-0-260128")
-        backend._client = mock_client
-
-        create_result = MagicMock()
-        create_result.id = "cgt-dreamina2"
         backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
 
         get_result = MagicMock()

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -412,6 +412,17 @@ class TestArkModelCapabilities:
             b = ArkVideoBackend(api_key="test", model="doubao-seedance-2.0-fast")
         assert VideoCapability.FLEX_TIER not in b.capabilities
 
+    def test_seedance_2_dreamina_prefix_no_flex_tier(self):
+        """BytePlus 国际站用 dreamina- 前缀（dreamina-seedance-2-0-260128），同族不该带 FLEX_TIER。"""
+        with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
+            b = ArkVideoBackend(api_key="test", model="dreamina-seedance-2-0-260128")
+        assert VideoCapability.FLEX_TIER not in b.capabilities
+
+    def test_seedance_2_dreamina_fast_prefix_no_flex_tier(self):
+        with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
+            b = ArkVideoBackend(api_key="test", model="dreamina-seedance-2-0-fast-260128")
+        assert VideoCapability.FLEX_TIER not in b.capabilities
+
 
 class TestArkServiceTierParam:
     """service_tier 只对声明了 FLEX_TIER 能力的模型传入，否则 API 会报错。"""
@@ -428,6 +439,40 @@ class TestArkServiceTierParam:
 
         create_result = MagicMock()
         create_result.id = "cgt-seedance2"
+        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+
+        get_result = MagicMock()
+        get_result.status = "succeeded"
+        get_result.content = MagicMock()
+        get_result.content.video_url = "https://cdn.example.com/v.mp4"
+        get_result.seed = None
+        get_result.usage = None
+        backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
+
+        patcher = _mock_httpx_stream()
+        try:
+            request = VideoGenerationRequest(prompt="test", output_path=output)
+            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+                await backend.generate(request)
+        finally:
+            patcher.stop()
+
+        create_kwargs = backend._client.content_generation.tasks.create.call_args.kwargs
+        assert "service_tier" not in create_kwargs
+
+    async def test_seedance_2_dreamina_prefix_does_not_send_service_tier(self, tmp_path):
+        """dreamina- 前缀的 seedance-2（自定义供应商常见）同样不得发 service_tier，否则 r2v 上游 400。"""
+        output = tmp_path / "out.mp4"
+        mock_client = MagicMock()
+        mock_client.content_generation = MagicMock()
+        mock_client.content_generation.tasks = MagicMock()
+
+        with patch("lib.video_backends.ark.create_ark_client", return_value=mock_client):
+            backend = ArkVideoBackend(api_key="test", model="dreamina-seedance-2-0-260128")
+        backend._client = mock_client
+
+        create_result = MagicMock()
+        create_result.id = "cgt-dreamina2"
         backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
 
         get_result = MagicMock()


### PR DESCRIPTION
## 问题

自定义供应商接入 BytePlus 国际站（`ark.ap-southeast.bytepluses.com`）的 seedance-2 模型做参考生视频时，上游返回 400：

```
InvalidParameter: the specified parameter service_tier is not supported for model dreamina-seedance-2-0 in r2v, must be empty
```

## 根因

`ArkVideoBackend.__init__` 用**精确字典匹配**决定能力集，注册表只枚举了 `doubao-` 前缀的 seedance-2 model id。BytePlus 国际站用 `dreamina-` 前缀（`dreamina-seedance-2-0-260128`），未命中后 fallback 到含 `FLEX_TIER` 的默认集 → 发出 `service_tier="default"` → r2v 模式拒绝。

同一文件里参考图能力 `video_capabilities_for_model` 早已用子串识别同族系（能正确命中 dreamina），缺陷本质是**两条检测路径口径不一致**。

## 修复

- 删除脆弱的精确匹配字典，新增 `_is_seedance_2` 子串判定识别族系
- FLEX_TIER 剔除与参考图能力共用同一口径，覆盖 `doubao-`/`dreamina-` 前缀及 dash+日期戳 / dot 简洁版两套命名，避免再因新增命名变体漏网

## 测试

新增 3 个回归用例（dreamina 前缀能力判定 + 端到端不发 `service_tier`）。`test_video_backend_ark.py` / `test_video_backend_base.py` 共 59 项通过；ruff / basedpyright 干净。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **重构**
  * 改进了视频后端对模型能力的识别逻辑，使 seedance-2 系列模型按规则归类，统一处理能力集合。

* **测试**
  * 扩展并参数化了视频后端相关单元测试，覆盖更多模型变体并验证不应包含的能力/请求参数。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->