### PR TITLE
fix(script): 剧本生成时将分镜时长约束到视频模型支持范围，避免不支持时长导致视频生成失败

### DIFF
--- a/lib/prompt_builders_reference.py
+++ b/lib/prompt_builders_reference.py
@@ -115,7 +115,7 @@ def build_reference_video_prompt(
 a. **unit_id**：保留 step1 中的 `E{episode}U{{序号}}`（当前为第 {episode} 集），不要改格式。
 
 b. **shots**：1-4 个 Shot。
-    - `duration`：整数秒，取值必须在当前模型支持列表中：{durations_desc}。{max_duration_line}
+    - `duration`：整数秒（1-15），用于在同一段视频内编排时间段。{max_duration_line}
     - `text`：镜头描述，聚焦此刻可见画面（语言遵循上方"输出语言"约束）。仅用 `@[名称]` 引用角色 / 场景 / 道具——**不要**写外貌、服装、场景细节（这些由参考图提供视觉一致性）。
         - 好例：「@[角色A] 立于 @[场景A] 前，左手紧握 @[道具A]，目光投向远处」。
         - 反例：「身穿某色服装的角色A 站在某色场景A 前，手里紧握着某色道具A」（外貌 / 服装 / 颜色应由参考图承担）。
@@ -129,7 +129,7 @@ c. **references**：`{{type, name}}` 列表，顺序决定 `[图N]` 编号。
         - prop: {", ".join(prop_names) or "（无）"}
     - 每个 shot `text` 中出现的 `@[名称]` 都要在 references 注册一次。{max_refs_line}
 
-d. **duration_seconds**：所有 shot `duration` 之和；不要手动覆盖。
+d. **duration_seconds**：所有 shot `duration` 之和，且**必须**等于当前模型支持列表中的某个值：{durations_desc}。请据此编排各 shot 时长，使其相加正好落在该集合内。
 
 # 顶层字段
 

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -28,6 +28,8 @@ from lib.script_models import (
     DramaEpisodeScript,
     NarrationEpisodeScript,
     ReferenceVideoScript,
+    build_episode_script_model,
+    build_reference_video_script_model,
 )
 from lib.text_backends.base import TextGenerationRequest, TextTaskType
 from lib.text_generator import TextGenerator
@@ -140,6 +142,9 @@ class ScriptGenerator:
         scenes = self.project_json.get("scenes", {})
         props = self.project_json.get("props", {})
 
+        # 三分支同口径解析一次：作为 prompt 的时长约束文本，并据此构造 duration 枚举硬约束的 schema。
+        supported_durations = self._resolve_supported_durations(caps)
+
         if gen_mode == "reference_video":
             prompt = build_reference_video_prompt(
                 project_overview=self.project_json.get("overview", {}),
@@ -149,13 +154,15 @@ class ScriptGenerator:
                 scenes=scenes,
                 props=props,
                 units_md=step1_md,
-                supported_durations=self._resolve_supported_durations(caps),
+                supported_durations=supported_durations,
                 max_refs=self._resolve_max_refs(caps),
                 max_duration=self._resolve_max_duration(caps),
                 aspect_ratio=self._resolve_aspect_ratio(),
                 episode=episode,
             )
-            schema = ReferenceVideoScript
+            # unit 总时长（duration_seconds = 各 shot 之和）枚举约束到 supported_durations：
+            # 发给 API 的就是这个总和，源头杜绝非成员值漏到供应商报错。
+            schema = build_reference_video_script_model(supported_durations)
         elif self.content_mode == "narration":
             prompt = build_narration_prompt(
                 project_overview=self.project_json.get("overview", {}),
@@ -165,12 +172,14 @@ class ScriptGenerator:
                 scenes=scenes,
                 props=props,
                 segments_md=step1_md,
-                supported_durations=self._resolve_supported_durations(caps),
+                supported_durations=supported_durations,
                 default_duration=self.project_json.get("default_duration"),
                 aspect_ratio=self._resolve_aspect_ratio(),
                 episode=episode,
             )
-            schema = NarrationEpisodeScript
+            # duration_seconds 收紧为 supported_durations 的 enum：LLM 结构化输出层即被卡死，
+            # 避免生成出执行层 assert_duration_supported 会拒、或漏到供应商 API 报错的非成员时长。
+            schema = build_episode_script_model("narration", supported_durations)
         else:
             prompt = build_drama_prompt(
                 project_overview=self.project_json.get("overview", {}),
@@ -180,12 +189,12 @@ class ScriptGenerator:
                 scenes=scenes,
                 props=props,
                 scenes_md=step1_md,
-                supported_durations=self._resolve_supported_durations(caps),
+                supported_durations=supported_durations,
                 default_duration=self.project_json.get("default_duration"),
                 aspect_ratio=self._resolve_aspect_ratio(),
                 episode=episode,
             )
-            schema = DramaEpisodeScript
+            schema = build_episode_script_model("drama", supported_durations)
 
         # 4. 调用 TextBackend
         logger.info("正在生成第 %d 集剧本...", episode)

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -9,7 +9,7 @@ script_models.py - 剧本数据模型
 from dataclasses import dataclass
 from typing import ClassVar, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, create_model, model_validator
 from pydantic.json_schema import SkipJsonSchema
 
 # 所有剧本模型默认禁止额外字段:agent 的 `patch_episode_script` 通过 `_set_nested` 允许在
@@ -362,3 +362,80 @@ def script_shape(content_mode: str) -> ScriptShape:
     if content_mode == "narration":
         return SCRIPT_SHAPES["narration"]
     return SCRIPT_SHAPES["drama"]
+
+
+# ============ duration 枚举硬约束（按视频模型能力动态构造剧本 schema） ============
+
+
+def _duration_literal(supported_durations: list[int]) -> object:
+    """把 supported_durations 去重排序后构造成 ``Literal[...]``。
+
+    多值在 ``model_json_schema()`` 里渲染为 JSON-schema ``enum``、单值渲染为 ``const``，两者都是硬约束。
+    与 ``ConfigResolver`` 同口径用 ``int(d)`` 归一（见 ``lib/config/resolver.py`` custom 分支）。空集抛 ValueError。
+    """
+    values = tuple(sorted({int(d) for d in supported_durations}))
+    if not values:
+        raise ValueError("supported_durations 为空，无法构造 duration 枚举约束")
+    return Literal[values]
+
+
+def _constrained_duration_item(item_base: type[BaseModel], duration_type: object, description: str) -> type[BaseModel]:
+    """在 ``item_base`` 上把 ``duration_seconds`` 收紧为 ``duration_type``（三工厂共用的字段约束骨架）。"""
+    return create_model(
+        item_base.__name__,
+        __base__=item_base,
+        duration_seconds=(duration_type, Field(description=description)),
+    )
+
+
+def build_episode_script_model(content_mode: str, supported_durations: list[int]) -> type[BaseModel]:
+    """构造 ``duration_seconds`` 被 ``supported_durations`` 枚举硬约束的剧集脚本模型。
+
+    NarrationSegment / DramaScene 静态定义里 ``duration_seconds`` 是 ``Field(ge=1, le=60)`` 的开区间，
+    LLM 在此区间内挑个非成员值（如模型支持 [4,6,8] 却写 5/7）能过 Pydantic、却会在执行层
+    ``assert_duration_supported`` 处晚失败、甚至漏到供应商 API 报错。这里按当前视频模型的
+    ``supported_durations`` 把该字段收紧为 ``Literal[*supported_durations]``：
+    - 在 response_schema（结构化输出）里渲染为 JSON-schema ``enum``（单值时为 ``const``）→ LLM 生成层即被卡死；
+    - ``model_validate`` 时强制成员校验。
+
+    仅服务 narration / drama 两种内容模式（忠实 ``script_shape`` 的二分：仅 ``"narration"`` 走
+    narration，其余落 drama）。reference_video 不经此路：其 API 消费的是 ``unit.duration_seconds``
+    （各 shot 之和），与单 shot 枚举不对应，沿用静态 ``ReferenceVideoScript``。
+    """
+    duration_type = _duration_literal(supported_durations)
+    if content_mode == "narration":
+        segment = _constrained_duration_item(
+            NarrationSegment, duration_type, "片段时长（秒），必须取 supported_durations 中的值"
+        )
+        return create_model(
+            "NarrationEpisodeScript",
+            __base__=NarrationEpisodeScript,
+            segments=(list[segment], Field(description="片段列表")),
+        )
+    scene = _constrained_duration_item(DramaScene, duration_type, "场景时长（秒），必须取 supported_durations 中的值")
+    return create_model(
+        "DramaEpisodeScript",
+        __base__=DramaEpisodeScript,
+        scenes=(list[scene], Field(description="场景列表")),
+    )
+
+
+def build_reference_video_script_model(supported_durations: list[int]) -> type[BaseModel]:
+    """构造 unit 总时长被 ``supported_durations`` 枚举硬约束的参考视频剧集模型。
+
+    参考视频模式发给供应商 API 的是 ``unit.duration_seconds``（各 shot 时长之和），而非单个 shot——
+    单 shot 只是同一段 clip 内的时间编排。故约束加在 ``ReferenceVideoUnit.duration_seconds`` 这个
+    派生字段上：``Literal[*supported_durations]`` 在 response_schema 里渲染为 ``enum``（单值时为 ``const``，LLM 可见），
+    叠加 ``ReferenceVideoUnit`` 既有的 ``duration_seconds == sum(shots)`` 一致性校验器，等价于强制
+    「各 shot 之和 ∈ supported_durations」。``Shot.duration`` 仍保留 1-15 的合理性上限、不要求单 shot 成员。
+    """
+    unit = _constrained_duration_item(
+        ReferenceVideoUnit,
+        _duration_literal(supported_durations),
+        "所有 shot 时长之和，必须取 supported_durations 中的值",
+    )
+    return create_model(
+        "ReferenceVideoScript",
+        __base__=ReferenceVideoScript,
+        video_units=(list[unit], Field(description="视频单元列表")),
+    )

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -24,7 +24,7 @@ from lib.reference_video import assemble_shots_text, render_prompt_for_backend
 from lib.reference_video.errors import MissingReferenceError, RequestPayloadTooLargeError
 from lib.script_models import ReferenceResource
 from lib.thumbnail import extract_video_thumbnail
-from server.services.generation_tasks import get_media_generator, get_project_manager
+from server.services.generation_tasks import assert_duration_supported, get_media_generator, get_project_manager
 
 logger = logging.getLogger(__name__)
 
@@ -218,6 +218,7 @@ async def execute_reference_video_task(
     #    本 PR 范围内先缓解。
     max_refs: int | None = None
     max_duration: int | None = None
+    supported_durations: list[int] = []
     try:
         resolver = ConfigResolver(async_session_factory)
         caps = await resolver.video_capabilities_for_project(project)
@@ -232,6 +233,9 @@ async def execute_reference_video_task(
         else:
             max_refs = caps.get("max_reference_images")
             max_duration = caps.get("max_duration")
+            # caps 与实际 backend model 一致时才取 supported_durations 做 duration 能力守卫；
+            # 不一致（caps 不可信）时留空，守卫遇空集放行，把决策推给 backend（与 clamp 同口径）。
+            supported_durations = [int(d) for d in caps.get("supported_durations") or []]
     except (ValueError, SQLAlchemyError) as exc:
         logger.info("无法解析 video_capabilities，跳过 executor clamp：%s", exc)
 
@@ -245,6 +249,10 @@ async def execute_reference_video_task(
         references=source_refs,
         duration_seconds=base_duration,
     )
+
+    # duration 能力守卫：clamp 只裁"超上限"，区间内的非成员总时长（如模型支持 [4,8,12] 而总和=5）
+    # 它不修正、会漏给 backend 报 400；这里与普通视频路径对称地本地拦下（VideoCapabilityError）。
+    assert_duration_supported(effective_duration, supported_durations)
 
     # resolver key 必须是 registry provider_id（project.video_backend 的 "/" 前半段），
     # 而非 backend.name（如 "gemini"）——与 generation_tasks.execute_video_task 保持一致。

--- a/tests/lib/test_prompt_builders_reference.py
+++ b/tests/lib/test_prompt_builders_reference.py
@@ -122,6 +122,30 @@ def test_build_reference_video_prompt_max_duration_none_skips_segment():
     assert "当前模型上限" not in prompt
 
 
+def test_build_reference_video_prompt_constrains_unit_total_to_supported():
+    """约束的是 unit 总时长（各 shot 之和）∈ supported，而非单个 shot 成员。
+
+    参考视频发给 API 的是 unit.duration_seconds（各 shot 之和），故 prompt 必须把"必须取支持值"
+    挂到总和上；per-shot duration 只保留 1-15 合理性，不再要求每个 shot 都是 supported 成员。
+    """
+    prompt = build_reference_video_prompt(
+        project_overview={"synopsis": "s", "genre": "g", "theme": "t", "world_setting": "w"},
+        style="s",
+        style_description="d",
+        characters={"甲": {"description": "d"}},
+        scenes={},
+        props={},
+        units_md="stub",
+        supported_durations=[4, 8, 12],
+        max_refs=9,
+        max_duration=12,
+        episode=1,
+    )
+    # 支持集合出现，且与"之和 / 必须"绑定（约束挂在总和上）
+    assert "4/8/12s" in prompt
+    assert "之和" in prompt and "必须" in prompt
+
+
 def test_build_reference_video_prompt_injects_episode_constraints():
     """reference_video prompt 必须告知 LLM 当前 episode，避免 unit_id 跨集污染（#574）。"""
     prompt = build_reference_video_prompt(

--- a/tests/lib/test_script_generator_reference_branch.py
+++ b/tests/lib/test_script_generator_reference_branch.py
@@ -93,9 +93,13 @@ async def test_script_generator_uses_reference_schema_on_generate(reference_proj
     assert data["generation_mode"] == "reference_video"
     assert len(data["video_units"]) == 1
 
-    # 确认生成时用了 ReferenceVideoScript schema
-    call_kwargs = fake_generator.generate.await_args.args[0]
-    assert call_kwargs.response_schema is ReferenceVideoScript
+    # 确认生成时用了 duration 枚举硬约束的 ReferenceVideoScript 子类（unit 总时长被收紧为 enum）
+    schema = fake_generator.generate.await_args.args[0].response_schema
+    assert isinstance(schema, type) and issubclass(schema, ReferenceVideoScript)
+    unit_def = next(
+        d for d in schema.model_json_schema().get("$defs", {}).values() if "shots" in d.get("properties", {})
+    )
+    assert "enum" in unit_def["properties"]["duration_seconds"]
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -800,7 +800,9 @@ async def test_execute_reference_video_task_prompt_matches_clipped_refs(
 
     script_path = proj_dir / "scripts" / "episode_1.json"
     script = json.loads(script_path.read_text(encoding="utf-8"))
-    script["video_units"][0]["shots"] = [{"duration": 3, "text": "Shot 1 (3s): @张三 在 @酒馆 拿起 @瓶子"}]
+    # 时长取 sora supported_durations 成员（4），避免触发执行层 duration 能力守卫；本测试聚焦 refs 裁剪。
+    script["video_units"][0]["shots"] = [{"duration": 4, "text": "Shot 1 (4s): @张三 在 @酒馆 拿起 @瓶子"}]
+    script["video_units"][0]["duration_seconds"] = 4
     script["video_units"][0]["references"] = [
         {"type": "character", "name": "张三"},
         {"type": "scene", "name": "酒馆"},
@@ -896,6 +898,13 @@ async def test_gemini_model_settings_read_via_composite_key(
     project["video_backend"] = "gemini-aistudio/veo-3.1-generate-preview"
     project["model_settings"] = {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}}
     project_path.write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
+
+    # video_backend 显式指向 veo（caps 命中 → duration 守卫生效）：unit 时长取 veo 支持成员，
+    # 避免触发能力守卫（本测试聚焦 resolution composite key）。
+    script_path = proj_dir / "scripts" / "episode_1.json"
+    script = json.loads(script_path.read_text(encoding="utf-8"))
+    script["video_units"][0]["duration_seconds"] = 8
+    script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
     from server.services import reference_video_tasks as rvt
 
@@ -1029,3 +1038,75 @@ async def test_execute_reference_video_task_skips_clamp_when_backend_model_diver
     assert captured["duration_seconds"] == 20
     # refs 也保留原数（2 张，未被 caps.max_reference_images=1 裁到 1）
     assert len(captured["reference_images"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_execute_reference_video_task_rejects_unsupported_duration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """执行层能力守卫：unit 总时长不在 supported_durations 内（且 ≤max 不会被 clamp 修正）时，
+    必须抛 VideoCapabilityError 本地失败，而非把非成员时长漏给供应商 API 报 400。
+    """
+    from lib.video_backends.base import VideoCapabilityError
+
+    proj_dir = _write_project(tmp_path)
+    script_path = proj_dir / "scripts" / "episode_1.json"
+    script = json.loads(script_path.read_text(encoding="utf-8"))
+    # 5 ≤ max(12) 不会被 clamp，但不是 [4,8,12] 成员 → 守卫必须拒
+    script["video_units"][0]["shots"] = [{"duration": 5, "text": "Shot 1 (5s): @张三 推门"}]
+    script["video_units"][0]["duration_seconds"] = 5
+    script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
+
+    from server.services import reference_video_tasks as rvt
+
+    fake_pm = MagicMock()
+    fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
+    fake_pm.get_project_path.return_value = proj_dir
+    fake_pm.load_script.side_effect = lambda *_a: json.loads(script_path.read_text(encoding="utf-8"))
+    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
+
+    async def _fake_generate_video_async(**kwargs):
+        out = proj_dir / "reference_videos" / "E1U1.mp4"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\x00")
+        return out, 1, None, None
+
+    fake_generator = MagicMock()
+    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
+    fake_video_backend = MagicMock()
+    fake_video_backend.name = "openai"
+    fake_video_backend.model = "sora-2"
+    fake_generator._video_backend = fake_video_backend
+
+    async def _fake_get_media_generator(*_a, **_kw):
+        return fake_generator
+
+    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+
+    from lib.config.resolver import ConfigResolver
+
+    async def _fake_caps(self, project):
+        return {
+            "provider_id": "openai",
+            "model": "sora-2",
+            "supported_durations": [4, 8, 12],
+            "max_duration": 12,
+            "max_reference_images": 9,
+            "source": "registry",
+            "default_duration": None,
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+        }
+
+    monkeypatch.setattr(ConfigResolver, "video_capabilities_for_project", _fake_caps)
+
+    with pytest.raises(VideoCapabilityError):
+        await rvt.execute_reference_video_task(
+            "demo",
+            "E1U1",
+            {"script_file": "scripts/episode_1.json"},
+            user_id="u1",
+        )
+    # 守卫在调用 backend 前拦下：generate_video_async 不应被调用
+    fake_generator.generate_video_async.assert_not_called()

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -207,8 +207,12 @@ class TestScriptGenerator:
         assert output == project_path / "scripts" / "episode_10.json"
         assert payload["episode"] == 10
 
-    async def test_generate_passes_pydantic_class_as_schema(self, tmp_path):
-        """generate 应传入 Pydantic 类而非 model_json_schema() dict。"""
+    async def test_generate_passes_duration_constrained_schema(self, tmp_path):
+        """generate 应传入 duration_seconds 被 supported_durations 枚举硬约束的 Pydantic 类。
+
+        schema 是 DramaEpisodeScript 的动态约束子类（非静态类本身），其 scenes 时长字段在
+        JSON schema 里渲染为 enum——LLM 结构化输出层即被卡死。
+        """
         project_path = tmp_path / "demo"
         _write_json(
             project_path / "project.json",
@@ -229,11 +233,27 @@ class TestScriptGenerator:
 
         fake = _FakeTextGenerator(json.dumps({"foo": "bar"}))
         generator = ScriptGenerator(project_path, generator=fake)
+
+        # caps 解析耦合本机 DB（已配置的视频供应商会盖过 project.json 兜底），此处固定能力
+        # 让断言 hermetic：验证的是「按解析出的 supported_durations 构造枚举约束」这条机制。
+        async def _fixed_caps():
+            return {"supported_durations": [4, 6, 8]}
+
+        generator._fetch_video_capabilities = _fixed_caps
+
         # 结构非法的响应在写盘统一入口被严格校验拒绝；但模型调用已发生，
-        # 仍可断言传入的 schema 是 Pydantic 类。
+        # 仍可断言传入的 schema 形态。
         with pytest.raises(ScriptStructureValidationError):
             await generator.generate(1)
-        assert fake.backend.last_request.response_schema is DramaEpisodeScript
+
+        schema = fake.backend.last_request.response_schema
+        assert isinstance(schema, type) and issubclass(schema, DramaEpisodeScript)
+        duration_enums = [
+            props["duration_seconds"].get("enum")
+            for props in (d.get("properties", {}) for d in schema.model_json_schema().get("$defs", {}).values())
+            if "duration_seconds" in props
+        ]
+        assert [4, 6, 8] in duration_enums
 
     async def test_generate_sets_script_max_output_tokens(self, tmp_path):
         """generate 应在 TextGenerationRequest 上设置 SCRIPT_MAX_OUTPUT_TOKENS。"""

--- a/tests/test_script_models_duration_enum.py
+++ b/tests/test_script_models_duration_enum.py
@@ -1,0 +1,165 @@
+"""duration_seconds 枚举硬约束：剧本生成时把每个分镜时长卡在视频模型 supported_durations 内。
+
+剧本生成器把 supported_durations 作为 response_schema 的 enum 下发，LLM 结构化输出层即被
+卡死，且 model_validate 时强制成员校验——而非仅靠 prompt 文字软约束 + 执行层晚失败。
+"""
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from lib.script_models import build_episode_script_model, build_reference_video_script_model
+
+
+def _duration_enum(model: type[BaseModel]) -> list[int] | None:
+    """从模型 JSON schema 的 $defs 里取出 duration_seconds 的 enum（无则 None）。"""
+    schema = model.model_json_schema()
+    for definition in schema.get("$defs", {}).values():
+        props = definition.get("properties", {})
+        if "duration_seconds" in props:
+            return props["duration_seconds"].get("enum")
+    return None
+
+
+def _duration_field_schema(model: type[BaseModel]) -> dict:
+    schema = model.model_json_schema()
+    for definition in schema.get("$defs", {}).values():
+        props = definition.get("properties", {})
+        if "duration_seconds" in props:
+            return props["duration_seconds"]
+    raise AssertionError("未在 $defs 中找到 duration_seconds 字段")
+
+
+class TestBuildEpisodeScriptModel:
+    def test_narration_duration_rendered_as_enum(self):
+        model = build_episode_script_model("narration", [4, 6, 8])
+        assert _duration_enum(model) == [4, 6, 8]
+
+    def test_drama_duration_rendered_as_enum(self):
+        model = build_episode_script_model("drama", [4, 6, 8])
+        assert _duration_enum(model) == [4, 6, 8]
+
+    def test_enum_replaces_open_range(self):
+        """约束后的 schema 不应再带原 ge/le 区间（minimum/maximum）。"""
+        field_schema = _duration_field_schema(build_episode_script_model("narration", [4, 6, 8]))
+        assert "minimum" not in field_schema
+        assert "maximum" not in field_schema
+
+    def test_durations_deduped_and_sorted(self):
+        model = build_episode_script_model("narration", [8, 4, 6, 4])
+        assert _duration_enum(model) == [4, 6, 8]
+
+    def test_single_value_uses_const(self):
+        field_schema = _duration_field_schema(build_episode_script_model("narration", [8]))
+        # 单值集 Pydantic 渲染为 const（仍是硬约束）
+        assert field_schema.get("const") == 8 or field_schema.get("enum") == [8]
+
+    def test_empty_supported_durations_raises(self):
+        with pytest.raises(ValueError):
+            build_episode_script_model("narration", [])
+
+
+class TestConstrainedValidation:
+    def _narration_payload(self, duration: int) -> dict:
+        return {
+            "title": "第一集",
+            "segments": [
+                {
+                    "segment_id": "E1S01",
+                    "duration_seconds": duration,
+                    "segment_break": False,
+                    "novel_text": "原文",
+                    "characters_in_segment": ["甲"],
+                    "image_prompt": {
+                        "scene": "场景",
+                        "composition": {"shot_type": "Medium Shot", "lighting": "暖光", "ambiance": "薄雾"},
+                    },
+                    "video_prompt": {
+                        "action": "转身",
+                        "camera_motion": "Static",
+                        "ambiance_audio": "风声",
+                        "dialogue": [],
+                    },
+                }
+            ],
+        }
+
+    def test_in_set_duration_accepted(self):
+        model = build_episode_script_model("narration", [4, 6, 8])
+        validated = model.model_validate(self._narration_payload(6))
+        assert validated.segments[0].duration_seconds == 6
+
+    def test_out_of_set_duration_rejected(self):
+        """5 在 [1,60] 区间内但不是 supported_durations 成员——旧 ge/le 约束会放过，枚举约束必须拒。"""
+        model = build_episode_script_model("narration", [4, 6, 8])
+        with pytest.raises(ValidationError):
+            model.model_validate(self._narration_payload(5))
+
+    def test_drama_out_of_set_duration_rejected(self):
+        model = build_episode_script_model("drama", [4, 6, 8])
+        payload = {
+            "title": "第一集",
+            "scenes": [
+                {
+                    "scene_id": "E1S01",
+                    "duration_seconds": 7,
+                    "segment_break": False,
+                    "characters_in_scene": ["甲"],
+                    "image_prompt": {
+                        "scene": "场景",
+                        "composition": {"shot_type": "Medium Shot", "lighting": "暖光", "ambiance": "薄雾"},
+                    },
+                    "video_prompt": {
+                        "action": "转身",
+                        "camera_motion": "Static",
+                        "ambiance_audio": "风声",
+                        "dialogue": [],
+                    },
+                }
+            ],
+        }
+        with pytest.raises(ValidationError):
+            model.model_validate(payload)
+
+
+class TestReferenceVideoModel:
+    """参考视频模式：约束的是 unit 总时长（各 shot 之和），不是单个 shot。"""
+
+    def _unit_payload(self, *, shots: list[int], total: int) -> dict:
+        return {
+            "title": "第一集",
+            "video_units": [
+                {
+                    "unit_id": "E1U01",
+                    "shots": [{"duration": d, "text": f"@甲 动作 {i}"} for i, d in enumerate(shots)],
+                    "references": [{"type": "character", "name": "甲"}],
+                    "duration_seconds": total,
+                }
+            ],
+        }
+
+    def test_unit_total_rendered_as_enum(self):
+        model = build_reference_video_script_model([4, 6, 8])
+        schema = model.model_json_schema()
+        unit_def = next(d for d in schema["$defs"].values() if "shots" in d.get("properties", {}))
+        assert unit_def["properties"]["duration_seconds"].get("enum") == [4, 6, 8]
+
+    def test_sum_in_set_accepted(self):
+        model = build_reference_video_script_model([4, 6, 8])
+        validated = model.model_validate(self._unit_payload(shots=[4, 4], total=8))
+        assert validated.video_units[0].duration_seconds == 8
+
+    def test_sum_out_of_set_rejected(self):
+        """各 shot（3+4=7）合法（1-15），但和 7 不是 supported 成员——必须拒。"""
+        model = build_reference_video_script_model([4, 6, 8])
+        with pytest.raises(ValidationError):
+            model.model_validate(self._unit_payload(shots=[3, 4], total=7))
+
+    def test_total_must_equal_shot_sum_preserved(self):
+        """既有一致性校验保留：total=8 但 shots 之和=6 仍拒（即便 8 是 supported 成员）。"""
+        model = build_reference_video_script_model([4, 6, 8])
+        with pytest.raises(ValidationError):
+            model.model_validate(self._unit_payload(shots=[6], total=8))
+
+    def test_empty_supported_durations_raises(self):
+        with pytest.raises(ValueError):
+            build_reference_video_script_model([])


### PR DESCRIPTION
## 问题

剧本生成时给每个分镜赋的时长，此前只在 prompt 里软提示，落盘仅靠 Pydantic 的 `1-60` 开区间校验。LLM 可能产出当前视频模型**不支持**的秒数（例如模型仅支持 `[4,6,8]` 却写 5/7）——这类值能过校验落盘，直到视频生成执行层才被能力守卫拒绝（晚失败），少数情况下还会漏到供应商 API 报 400。

## 改动

- **生成层硬约束**：按当前视频模型 `supported_durations` 动态构造剧本 schema，把 `duration_seconds` 收紧为枚举（`Literal`）。结构化输出层即卡死，LLM 无法产出非成员时长，`model_validate` 也强制成员校验。
  - narration / drama：约束每个 segment / scene 的 `duration_seconds`。
  - 参考生视频：约束 unit 总时长（= 各 shot 之和，发给 API 的就是它）；`Shot.duration` 仍保留 1-15 合理性，不要求单 shot 成员。
- **prompt 文案同步**：参考生视频从“每个 shot 时长须是支持值”改为“各 shot 之和须是支持值”。
- **执行层兜底**：参考生视频路径补上与普通视频对称的时长能力守卫，拦截换模型 / 手动改时长 / 旧脚本等生成层管不到的来源——本地失败（带本地化提示）而非漏给供应商。

## 测试

- 新增 duration 枚举约束单测（narration / drama / 参考视频）与参考视频执行层拒绝测试；并更新了因 schema 由静态类改为动态约束子类而失效的旧断言。
- 全量 `pytest` 通过（唯一失败为既有的本机环境耦合用例，CI 干净库可过，与本改动无关）；`ruff`、`basedpyright` 均 0 error。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复及改进**
  * 强化视频时长约束验证逻辑，确保生成的视频时长严格符合模型支持的时长列表。
  * 优化时长验证的一致性，在生成阶段即进行硬约束校验，更早地拦截不支持的时长设置。
  * 完善能力守卫机制，提高系统可靠性。

* **测试**
  * 新增综合测试覆盖时长约束的校验与渲染行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->