### PR TITLE
feat: 分镜图与镜头视频支持手动上传，覆盖图生视频/宫格/参考生视频三种模式

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -432,6 +432,72 @@ describe("API", () => {
       await expect(API.uploadFile("demo", "source", file)).rejects.toThrow("上传失败");
     });
 
+    it("uploads shot media via multipart form and returns fingerprints", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({
+          jsonData: {
+            success: true,
+            path: "storyboards/scene_E1S01.png",
+            version: 2,
+            asset_fingerprints: { "storyboards/scene_E1S01.png": 2 },
+          },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const file = new File(["img"], "board.png", { type: "image/png" });
+      const result = await API.uploadShotMedia(
+        "my project",
+        "scripts/ep 1.json",
+        "E1S01",
+        "storyboard",
+        file,
+      );
+
+      expect(result.version).toBe(2);
+      expect(result.asset_fingerprints["storyboards/scene_E1S01.png"]).toBe(2);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        "/api/v1/projects/my%20project/shots/E1S01/upload/storyboard?script_file=scripts%2Fep%201.json",
+      );
+      expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe("POST");
+      expect((fetchMock.mock.calls[0][1] as RequestInit).body).toBeInstanceOf(FormData);
+    });
+
+    it("uploads reference unit video and throws detail on failure", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          mockResponse({
+            jsonData: {
+              success: true,
+              path: "reference_videos/unit-1.mp4",
+              version: 1,
+              asset_fingerprints: { "reference_videos/unit-1.mp4": 1 },
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            ok: false,
+            statusText: "Bad Request",
+            jsonData: { detail: "不支持的视频格式" },
+          }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+      const file = new File(["vid"], "clip.mp4", { type: "video/mp4" });
+
+      const result = await API.uploadReferenceUnitVideo("demo", 1, "unit-1", file);
+      expect(result.path).toBe("reference_videos/unit-1.mp4");
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        "/api/v1/projects/demo/reference-videos/episodes/1/units/unit-1/upload-video",
+      );
+      expect((fetchMock.mock.calls[0][1] as RequestInit).body).toBeInstanceOf(FormData);
+
+      await expect(API.uploadReferenceUnitVideo("demo", 1, "unit-1", file)).rejects.toThrow(
+        "不支持的视频格式",
+      );
+    });
+
     it("handles source and draft text APIs", async () => {
       const fetchMock = vi
         .fn()

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -107,6 +107,16 @@ export interface VersionInfo {
   file_url?: string;
   prompt?: string;
   restored_from?: number;
+  /** 版本来源标记；"manual_upload" 表示用户手动上传 */
+  source?: string;
+}
+
+/** 镜头/单元媒体上传的统一响应。 */
+export interface ShotUploadResult {
+  success: boolean;
+  path: string;
+  version: number;
+  asset_fingerprints: Record<string, number>;
 }
 
 /** Options for {@link API.openTaskStream}. */
@@ -763,6 +773,42 @@ class API {
       used_encoding?: string | null;
       chapter_count?: number;
     };
+  }
+
+  /** 单文件 multipart 上传 POST，返回 JSON 响应体。 */
+  private static async postFileUpload<T>(url: string, file: File): Promise<T> {
+    const formData = new FormData();
+    formData.append("file", file);
+    const response = await fetch(`${API_BASE}${url}`, withAuth({ method: "POST", body: formData }));
+    await throwIfNotOk(response, "上传失败");
+    return (await response.json()) as T;
+  }
+
+  /** 上传分镜图或镜头视频，替换该镜头的 AI 生成资产（storyboard/grid 模式）。 */
+  static async uploadShotMedia(
+    projectName: string,
+    scriptFile: string,
+    shotId: string,
+    kind: "storyboard" | "video",
+    file: File
+  ): Promise<ShotUploadResult> {
+    const url =
+      `/projects/${encodeURIComponent(projectName)}/shots/${encodeURIComponent(shotId)}` +
+      `/upload/${kind}?script_file=${encodeURIComponent(scriptFile)}`;
+    return API.postFileUpload<ShotUploadResult>(url, file);
+  }
+
+  /** 上传参考生视频单元的成片视频。 */
+  static async uploadReferenceUnitVideo(
+    projectName: string,
+    episode: number,
+    unitId: string,
+    file: File
+  ): Promise<ShotUploadResult> {
+    const url =
+      `/projects/${encodeURIComponent(projectName)}/reference-videos/episodes/${episode}` +
+      `/units/${encodeURIComponent(unitId)}/upload-video`;
+    return API.postFileUpload<ShotUploadResult>(url, file);
   }
 
   static async listFiles(

--- a/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
+++ b/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
@@ -287,6 +287,7 @@ export function GridImageToVideoCanvas({
             contentMode={contentMode}
             aspectRatio={aspectRatio}
             projectName={projectName}
+            scriptFile={scriptFile}
             isGridMode
             onUpdatePrompt={handleUpdatePrompt}
             onGenerateStoryboard={handleGenSb}

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -210,12 +210,20 @@ export function ReferenceVideoCanvas({
         return next;
       });
       try {
-        const result = await API.uploadReferenceUnitVideo(projectName, episode, unitId, file);
-        useProjectsStore.getState().updateAssetFingerprints(result.asset_fingerprints);
-        await loadUnits(projectName, episode);
-        useAppStore.getState().pushToast(t("media_upload_success", { id: unitId }), "success");
-      } catch (e) {
-        toastError(e, (msg) => t("media_upload_failed", { message: msg }));
+        try {
+          const result = await API.uploadReferenceUnitVideo(projectName, episode, unitId, file);
+          useProjectsStore.getState().updateAssetFingerprints(result.asset_fingerprints);
+          useAppStore.getState().pushToast(t("media_upload_success", { id: unitId }), "success");
+        } catch (e) {
+          toastError(e, (msg) => t("media_upload_failed", { message: msg }));
+          return;
+        }
+        // 上传已成功落盘：刷新失败单独提示，不误报为上传失败（SSE/重进页面兜底最终一致）
+        try {
+          await loadUnits(projectName, episode);
+        } catch (e) {
+          toastError(e, (msg) => t("media_refresh_failed", { message: msg }));
+        }
       } finally {
         setUploadingUnitIds((s) => {
           const next = new Set(s);

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -17,6 +17,7 @@ import { ReferenceVideoCard, unitPromptText } from "./ReferenceVideoCard";
 import { ReferencePanel } from "./ReferencePanel";
 import { EpisodeHeader } from "./EpisodeHeader";
 import { PreprocessingView } from "@/components/canvas/timeline/PreprocessingView";
+import { API } from "@/api";
 import {
   useReferenceVideoStore,
   referenceVideoCacheKey,
@@ -115,7 +116,10 @@ export function ReferenceVideoCanvas({
 
   const tasksByUnit = useMemo(() => {
     const map = new Map<string, (typeof relevantTasks)[number]>();
-    for (const tk of relevantTasks) map.set(tk.resource_id, tk);
+    // 任务列表按 updated_at 倒序：保留首个出现的（最新）任务行，重试时不被旧失败行盖住
+    for (const tk of relevantTasks) {
+      if (!map.has(tk.resource_id)) map.set(tk.resource_id, tk);
+    }
     return map;
   }, [relevantTasks]);
 
@@ -125,7 +129,9 @@ export function ReferenceVideoCanvas({
       let st: UnitStatus = u.generated_assets.video_clip ? "ready" : "pending";
       const queueRow = tasksByUnit.get(u.unit_id);
       if (queueRow?.status === "queued" || queueRow?.status === "running") st = "running";
-      else if (queueRow?.status === "failed") st = "failed";
+      // 失败任务行 DB 持久化、不会过期：手动上传成片后单元已有可播放资产，
+      // 不再让历史失败覆盖 ready（与 timeline/grid 画布用 toast 提示失败的语义对齐）
+      else if (queueRow?.status === "failed" && !u.generated_assets.video_clip) st = "failed";
       else if (optimisticUnitIds.has(u.unit_id) && !queueRow) st = "running";
       map[u.unit_id] = st;
     }
@@ -187,6 +193,38 @@ export function ReferenceVideoCanvas({
       }
     },
     [generate, projectName, episode, t],
+  );
+
+  const [uploadingUnitIds, setUploadingUnitIds] = useState<Set<string>>(() => new Set());
+
+  const handleUploadVideo = useCallback(
+    async (unitId: string, file: File) => {
+      setUploadingUnitIds((s) => {
+        const next = new Set(s);
+        next.add(unitId);
+        return next;
+      });
+      try {
+        const result = await API.uploadReferenceUnitVideo(projectName, episode, unitId, file);
+        useProjectsStore.getState().updateAssetFingerprints(result.asset_fingerprints);
+        await loadUnits(projectName, episode);
+        useAppStore.getState().pushToast(t("media_upload_success", { id: unitId }), "success");
+      } catch (e) {
+        toastError(e, (msg) => t("media_upload_failed", { message: msg }));
+      } finally {
+        setUploadingUnitIds((s) => {
+          const next = new Set(s);
+          next.delete(unitId);
+          return next;
+        });
+      }
+    },
+    [projectName, episode, loadUnits, t],
+  );
+
+  const handleUnitsRefresh = useCallback(
+    () => loadUnits(projectName, episode),
+    [loadUnits, projectName, episode],
   );
 
   const handleBatchGenerate = useCallback(async () => {
@@ -719,6 +757,9 @@ export function ReferenceVideoCanvas({
                           estimatedCost={estimatedCost}
                           actualCost={actualCost}
                           onGenerate={onGenerateVoid}
+                          onUploadVideo={handleUploadVideo}
+                          uploadingVideo={uploadingUnitIds.has(selected.unit_id)}
+                          onRestored={handleUnitsRefresh}
                         />
                       </div>
                     )}
@@ -742,6 +783,9 @@ export function ReferenceVideoCanvas({
                   estimatedCost={estimatedCost}
                   actualCost={actualCost}
                   onGenerate={onGenerateVoid}
+                  onUploadVideo={handleUploadVideo}
+                  uploadingVideo={selected ? uploadingUnitIds.has(selected.unit_id) : false}
+                  onRestored={handleUnitsRefresh}
                 />
               </div>
             )}

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -116,9 +116,11 @@ export function ReferenceVideoCanvas({
 
   const tasksByUnit = useMemo(() => {
     const map = new Map<string, (typeof relevantTasks)[number]>();
-    // 任务列表按 updated_at 倒序：保留首个出现的（最新）任务行，重试时不被旧失败行盖住
+    // store 不保证顺序（SSE upsert 原位更新、初始列表排序属后端实现细节）：
+    // 显式取 updated_at 最新的任务行，重试时不被旧失败行盖住
     for (const tk of relevantTasks) {
-      if (!map.has(tk.resource_id)) map.set(tk.resource_id, tk);
+      const prev = map.get(tk.resource_id);
+      if (!prev || tk.updated_at > prev.updated_at) map.set(tk.resource_id, tk);
     }
     return map;
   }, [relevantTasks]);

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -114,6 +114,8 @@ export function ReferenceVideoCanvas({
   // Optimistic UI: POST 前置位 → 队列接力 → 队列窗口换出后失效。
   const [optimisticUnitIds, setOptimisticUnitIds] = useState<Set<string>>(() => new Set());
 
+  const [uploadingUnitIds, setUploadingUnitIds] = useState<Set<string>>(() => new Set());
+
   const tasksByUnit = useMemo(() => {
     const map = new Map<string, (typeof relevantTasks)[number]>();
     // store 不保证顺序（SSE upsert 原位更新、初始列表排序属后端实现细节）：
@@ -130,7 +132,10 @@ export function ReferenceVideoCanvas({
     for (const u of units) {
       let st: UnitStatus = u.generated_assets.video_clip ? "ready" : "pending";
       const queueRow = tasksByUnit.get(u.unit_id);
-      if (queueRow?.status === "queued" || queueRow?.status === "running") st = "running";
+      // 上传中的 unit 视为 running：批量生成按 statusMap 选 pending，
+      // 否则上传期间会被再次入队，与生成回写同一个成片文件
+      if (uploadingUnitIds.has(u.unit_id)) st = "running";
+      else if (queueRow?.status === "queued" || queueRow?.status === "running") st = "running";
       // 失败任务行 DB 持久化、不会过期：手动上传成片后单元已有可播放资产，
       // 不再让历史失败覆盖 ready（与 timeline/grid 画布用 toast 提示失败的语义对齐）
       else if (queueRow?.status === "failed" && !u.generated_assets.video_clip) st = "failed";
@@ -138,7 +143,7 @@ export function ReferenceVideoCanvas({
       map[u.unit_id] = st;
     }
     return map;
-  }, [units, tasksByUnit, optimisticUnitIds]);
+  }, [units, tasksByUnit, optimisticUnitIds, uploadingUnitIds]);
 
   const generating = !!(selected && statusMap[selected.unit_id] === "running");
 
@@ -196,8 +201,6 @@ export function ReferenceVideoCanvas({
     },
     [generate, projectName, episode, t],
   );
-
-  const [uploadingUnitIds, setUploadingUnitIds] = useState<Set<string>>(() => new Set());
 
   const handleUploadVideo = useCallback(
     async (unitId: string, file: File) => {

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.test.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { UnitPreviewPanel } from "./UnitPreviewPanel";
 import type { ReferenceVideoUnit } from "@/types";
 
@@ -48,5 +48,36 @@ describe("UnitPreviewPanel", () => {
       <UnitPreviewPanel unit={unit} projectName="proj" />,
     );
     expect(container.querySelector("video")).toBeInTheDocument();
+  });
+
+  it("invokes onUploadVideo with unit id and selected file", () => {
+    const onUploadVideo = vi.fn();
+    const { container } = render(
+      <UnitPreviewPanel unit={mkUnit()} projectName="proj" onUploadVideo={onUploadVideo} />,
+    );
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).not.toBeNull();
+    const file = new File(["x"], "clip.mp4", { type: "video/mp4" });
+    fireEvent.change(input!, { target: { files: [file] } });
+    expect(onUploadVideo).toHaveBeenCalledWith("E1U1", file);
+  });
+
+  it("hides upload entry when onUploadVideo is not provided", () => {
+    const { container } = render(<UnitPreviewPanel unit={mkUnit()} projectName="proj" />);
+    expect(container.querySelector('input[type="file"]')).toBeNull();
+  });
+
+  it("disables upload button while the unit is generating", () => {
+    const { container } = render(
+      <UnitPreviewPanel
+        unit={mkUnit()}
+        projectName="proj"
+        status="running"
+        onUploadVideo={vi.fn()}
+      />,
+    );
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+    const button = input?.nextElementSibling as HTMLButtonElement;
+    expect(button).toBeDisabled();
   });
 });

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
@@ -1,6 +1,9 @@
 import { useTranslation } from "react-i18next";
 import { Film, Loader2, Sparkles, RotateCcw, AlertTriangle } from "lucide-react";
 import { API } from "@/api";
+import { useProjectsStore } from "@/stores/projects-store";
+import { VersionTimeMachine } from "@/components/canvas/timeline/VersionTimeMachine";
+import { UPLOAD_VIDEO_ACCEPT, UploadIconButton } from "@/components/ui/UploadIconButton";
 import { formatCost } from "@/utils/cost-format";
 import { StatusBadge, deriveUnitStatus } from "./unit-status";
 import type { CostBreakdown, ReferenceVideoUnit, UnitStatus } from "@/types";
@@ -18,6 +21,12 @@ export interface UnitPreviewPanelProps {
   /** Actual already-spent cost; rendered in the metadata block. */
   actualCost?: CostBreakdown;
   onGenerate?: (unitId: string) => void;
+  /** 上传成片视频（替换该单元的 AI 生成视频）；未提供时不显示上传入口 */
+  onUploadVideo?: (unitId: string, file: File) => void | Promise<void>;
+  /** 上传进行中 */
+  uploadingVideo?: boolean;
+  /** 版本恢复后的刷新回调（重新拉取 units） */
+  onRestored?: () => void | Promise<void>;
 }
 
 function hasCost(b: CostBreakdown | undefined): boolean {
@@ -34,8 +43,14 @@ export function UnitPreviewPanel({
   estimatedCost,
   actualCost,
   onGenerate,
+  onUploadVideo,
+  uploadingVideo,
+  onRestored,
 }: UnitPreviewPanelProps) {
   const { t } = useTranslation("dashboard");
+  const clip = unit?.generated_assets.video_clip ?? null;
+  // 上传/还原后路径不变，靠 fingerprint cache-bust 让 <video> 重新拉取
+  const clipFp = useProjectsStore((s) => (clip ? s.getAssetFingerprint(clip) : null));
 
   if (!unit) {
     return (
@@ -46,8 +61,7 @@ export function UnitPreviewPanel({
   }
 
   const effectiveStatus = status ?? deriveUnitStatus(unit);
-  const clip = unit.generated_assets.video_clip;
-  const videoUrl = clip && projectName ? API.getFileUrl(projectName, clip) : null;
+  const videoUrl = clip && projectName ? API.getFileUrl(projectName, clip, clipFp) : null;
 
   // 状态先于 video_clip 落库的窗口里，effectiveStatus==="ready" 但 videoUrl
   // 还为 null —— 这种情况下走 inFlight 占位避免空白面板。
@@ -70,6 +84,24 @@ export function UnitPreviewPanel({
           {t("reference_preview_label")}
         </span>
         <span className="flex-1" />
+        {onUploadVideo && (
+          <UploadIconButton
+            accept={UPLOAD_VIDEO_ACCEPT}
+            label={t("media_upload_video")}
+            busy={uploadingVideo}
+            disabled={inFlight}
+            onSelect={(f) => void onUploadVideo(unit.unit_id, f)}
+          />
+        )}
+        {projectName && (
+          <VersionTimeMachine
+            projectName={projectName}
+            resourceType="reference_videos"
+            resourceId={unit.unit_id}
+            onRestore={onRestored}
+            iconOnly
+          />
+        )}
         <StatusBadge status={effectiveStatus} size="md" />
       </div>
 

--- a/frontend/src/components/canvas/timeline/MediaCard.test.tsx
+++ b/frontend/src/components/canvas/timeline/MediaCard.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MediaCard } from "./MediaCard";
+
+function renderCard(props: Partial<Parameters<typeof MediaCard>[0]> = {}) {
+  return render(
+    <MediaCard
+      kind="storyboard"
+      projectName="demo"
+      segmentId="E1S01"
+      assetPath={null}
+      aspectRatio="9:16"
+      {...props}
+    />,
+  );
+}
+
+describe("MediaCard upload", () => {
+  it("invokes onUpload with the selected file", () => {
+    const onUpload = vi.fn();
+    const { container } = renderCard({ onUpload });
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).not.toBeNull();
+    const file = new File(["x"], "board.png", { type: "image/png" });
+    fireEvent.change(input!, { target: { files: [file] } });
+    expect(onUpload).toHaveBeenCalledWith(file);
+  });
+
+  it("hides upload entry when onUpload is not provided", () => {
+    const { container } = renderCard();
+    expect(container.querySelector('input[type="file"]')).toBeNull();
+  });
+
+  it("keeps upload entry visible in grid mode where the generate CTA is hidden", () => {
+    const { container } = renderCard({
+      onUpload: vi.fn(),
+      onGenerate: vi.fn(),
+      hideGenerateButton: true,
+    });
+    expect(container.querySelector('input[type="file"]')).not.toBeNull();
+  });
+
+  it("disables upload button while generating", () => {
+    const { container } = renderCard({ onUpload: vi.fn(), generating: true });
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+    const button = input?.nextElementSibling as HTMLButtonElement;
+    expect(button).toBeDisabled();
+  });
+
+  it("disables upload button when a sibling upload is in flight (uploadDisabled)", () => {
+    const { container } = renderCard({ onUpload: vi.fn(), uploadDisabled: true });
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+    const button = input?.nextElementSibling as HTMLButtonElement;
+    expect(button).toBeDisabled();
+  });
+
+  it("accepts video formats for the video card", () => {
+    const { container } = renderCard({ kind: "video", onUpload: vi.fn() });
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input?.accept).toContain(".mp4");
+  });
+});

--- a/frontend/src/components/canvas/timeline/MediaCard.tsx
+++ b/frontend/src/components/canvas/timeline/MediaCard.tsx
@@ -5,6 +5,11 @@ import { useProjectsStore } from "@/stores/projects-store";
 import { AspectFrame } from "@/components/ui/AspectFrame";
 import { ImageFlipReveal } from "@/components/ui/ImageFlipReveal";
 import { PreviewableImageFrame } from "@/components/ui/PreviewableImageFrame";
+import {
+  UPLOAD_IMAGE_ACCEPT,
+  UPLOAD_VIDEO_ACCEPT,
+  UploadIconButton,
+} from "@/components/ui/UploadIconButton";
 import { formatCost } from "@/utils/cost-format";
 import type { CostBreakdown } from "@/types";
 import { VersionTimeMachine } from "./VersionTimeMachine";
@@ -35,7 +40,18 @@ interface MediaCardProps {
   onGenerate?: () => void;
   /** 版本恢复回调 */
   onRestore?: () => Promise<void> | void;
+  /** 自主上传回调（替换该镜头的分镜图/视频）；未提供时不显示上传入口 */
+  onUpload?: (file: File) => Promise<void> | void;
+  /** 本卡片的上传请求进行中 */
+  uploading?: boolean;
+  /** 其他上传进行中等需要互斥的场景：禁用上传入口但不显示 spinner */
+  uploadDisabled?: boolean;
 }
+
+const UPLOAD_ACCEPT: Record<MediaKind, string> = {
+  storyboard: UPLOAD_IMAGE_ACCEPT,
+  video: UPLOAD_VIDEO_ACCEPT,
+};
 
 export function MediaCard({
   kind,
@@ -51,6 +67,9 @@ export function MediaCard({
   estimatedCost,
   onGenerate,
   onRestore,
+  onUpload,
+  uploading,
+  uploadDisabled,
 }: MediaCardProps) {
   const { t } = useTranslation("dashboard");
 
@@ -91,6 +110,19 @@ export function MediaCard({
           {title}
         </span>
         <span className="flex-1" />
+        {onUpload && (
+          <UploadIconButton
+            accept={UPLOAD_ACCEPT[kind]}
+            label={
+              kind === "storyboard"
+                ? t("media_upload_storyboard")
+                : t("media_upload_video")
+            }
+            busy={uploading}
+            disabled={generating || uploadDisabled}
+            onSelect={(f) => void onUpload(f)}
+          />
+        )}
         <VersionTimeMachine
           projectName={projectName}
           resourceType={resourceType}

--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -25,7 +25,11 @@ import { NotesDrawer } from "./NotesDrawer";
 import { ReferencesSection } from "./ReferencesSection";
 import { StatusBadge, statusFromAssets } from "./StatusBadge";
 import { Popover } from "@/components/ui/Popover";
+import { API } from "@/api";
+import { useAppStore } from "@/stores/app-store";
 import { useCostStore } from "@/stores/cost-store";
+import { useProjectsStore } from "@/stores/projects-store";
+import { errMsg } from "@/utils/async";
 import {
   isStructuredImagePrompt,
   isStructuredVideoPrompt,
@@ -42,6 +46,8 @@ interface ShotDetailProps {
   contentMode: "narration" | "drama";
   aspectRatio: "9:16" | "16:9";
   projectName: string;
+  /** 当前剧集剧本文件名，分镜图/视频自主上传需要它定位剧本条目 */
+  scriptFile?: string;
   isGridMode?: boolean;
   /** Total shot count for "1/N" indicator */
   selectedIndex: number;
@@ -271,6 +277,7 @@ export function ShotDetail({
   contentMode,
   aspectRatio,
   projectName,
+  scriptFile,
   isGridMode,
   selectedIndex,
   totalCount,
@@ -302,6 +309,32 @@ export function ShotDetail({
     video_prompt: vp,
   }));
   const [saving, setSaving] = useState(false);
+  const [uploadingKind, setUploadingKind] = useState<"storyboard" | "video" | null>(null);
+
+  const handleUpload = async (kind: "storyboard" | "video", file: File) => {
+    // 单镜头同时只允许一个上传：两张卡写同一后端资源族，避免并发覆写
+    if (!scriptFile || uploadingKind) return;
+    setUploadingKind(kind);
+    try {
+      const result = await API.uploadShotMedia(projectName, scriptFile, segmentId, kind, file);
+      useProjectsStore.getState().updateAssetFingerprints(result.asset_fingerprints);
+      // 复用版本恢复的刷新管线（refreshProject 等由父级回调承载）
+      if (kind === "storyboard") {
+        await onRestoreStoryboard?.();
+      } else {
+        await onRestoreVideo?.();
+      }
+      useAppStore
+        .getState()
+        .pushToast(t("media_upload_success", { id: segmentId }), "success");
+    } catch (err) {
+      useAppStore
+        .getState()
+        .pushToast(t("media_upload_failed", { message: errMsg(err) }), "error");
+    } finally {
+      setUploadingKind(null);
+    }
+  };
 
   const upstreamSig = useMemo(
     () => stableSig({ ip, vp }),
@@ -605,6 +638,9 @@ export function ShotDetail({
         estimatedCost={sbEstimate ?? undefined}
         onGenerate={() => onGenerateStoryboard?.(segmentId)}
         onRestore={onRestoreStoryboard}
+        onUpload={scriptFile ? (file) => handleUpload("storyboard", file) : undefined}
+        uploading={uploadingKind === "storyboard"}
+        uploadDisabled={uploadingKind !== null}
         generateDisabled={dirty || saving}
         generateDisabledHint={dirty ? dirtyHint : undefined}
       />
@@ -621,6 +657,9 @@ export function ShotDetail({
         estimatedCost={vidEstimate ?? undefined}
         onGenerate={() => onGenerateVideo?.(segmentId)}
         onRestore={onRestoreVideo}
+        onUpload={scriptFile ? (file) => handleUpload("video", file) : undefined}
+        uploading={uploadingKind === "video"}
+        uploadDisabled={uploadingKind !== null}
       />
     </div>
   );

--- a/frontend/src/components/canvas/timeline/ShotSplitView.tsx
+++ b/frontend/src/components/canvas/timeline/ShotSplitView.tsx
@@ -11,6 +11,8 @@ interface ShotSplitViewProps {
   contentMode: "narration" | "drama";
   aspectRatio: "9:16" | "16:9";
   projectName: string;
+  /** 当前剧集剧本文件名，分镜图/视频自主上传需要它定位剧本条目 */
+  scriptFile?: string;
   isGridMode?: boolean;
   onUpdatePrompt?: (
     segmentId: string,
@@ -40,6 +42,7 @@ export function ShotSplitView({
   contentMode,
   aspectRatio,
   projectName,
+  scriptFile,
   isGridMode,
   onUpdatePrompt,
   onGenerateStoryboard,
@@ -113,6 +116,7 @@ export function ShotSplitView({
         contentMode={contentMode}
         aspectRatio={aspectRatio}
         projectName={projectName}
+        scriptFile={scriptFile}
         isGridMode={isGridMode}
         selectedIndex={safeIndex}
         totalCount={segments.length}

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -258,6 +258,7 @@ export function TimelineCanvas({
             contentMode={contentMode}
             aspectRatio={aspectRatio}
             projectName={projectName}
+            scriptFile={scriptFile}
             isGridMode={false}
             onUpdatePrompt={handleUpdatePrompt}
             onGenerateStoryboard={handleGenSb}

--- a/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
+++ b/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
@@ -9,7 +9,7 @@ import { errMsg } from "@/utils/async";
 
 interface VersionTimeMachineProps {
   projectName: string;
-  resourceType: "storyboards" | "videos" | "characters" | "scenes" | "props";
+  resourceType: "storyboards" | "videos" | "characters" | "scenes" | "props" | "reference_videos";
   resourceId: string;
   onRestore?: (version: number) => void | Promise<void>;
   /** Icon-only trigger button: hides label and chevron for narrow card headers. */
@@ -47,6 +47,7 @@ export function VersionTimeMachine({
   const resourcePath =
     resourceType === "storyboards" ? `storyboards/scene_${resourceId}.png` :
     resourceType === "videos" ? `videos/scene_${resourceId}.mp4` :
+    resourceType === "reference_videos" ? `reference_videos/${resourceId}.mp4` :
     resourceType === "characters" ? `characters/${resourceId}.png` :
     resourceType === "scenes" ? `scenes/${resourceId}.png` :
     `props/${resourceId}.png`;
@@ -318,7 +319,7 @@ export function VersionTimeMachine({
 
                     {/* Media preview */}
                     {selectedInfo.file_url &&
-                      (resourceType === "videos" ? (
+                      (resourceType === "videos" || resourceType === "reference_videos" ? (
                         // eslint-disable-next-line jsx-a11y/media-has-caption -- 生成式预览视频暂无字幕源，将来如引入字幕生成则移除此 disable
                         <video
                           src={selectedInfo.file_url}
@@ -341,7 +342,10 @@ export function VersionTimeMachine({
 
                     {/* Prompt text */}
                     <p className="line-clamp-4 text-[11px] leading-5 text-gray-400">
-                      {selectedInfo.prompt || t("version_no_notes")}
+                      {selectedInfo.prompt ||
+                        (selectedInfo.source === "manual_upload"
+                          ? t("version_manual_upload")
+                          : t("version_no_notes"))}
                     </p>
 
 

--- a/frontend/src/components/ui/UploadIconButton.tsx
+++ b/frontend/src/components/ui/UploadIconButton.tsx
@@ -1,0 +1,53 @@
+import { useRef } from "react";
+import { Loader2, Upload } from "lucide-react";
+
+/** 与后端 upload_finalize.py 的扩展名白名单保持一致 */
+export const UPLOAD_IMAGE_ACCEPT = ".png,.jpg,.jpeg,.webp";
+export const UPLOAD_VIDEO_ACCEPT = ".mp4,.mov,.webm,.m4v";
+
+interface UploadIconButtonProps {
+  accept: string;
+  /** 同时作为 title 与 aria-label */
+  label: string;
+  /** 上传请求进行中：显示 spinner 并禁用 */
+  busy?: boolean;
+  disabled?: boolean;
+  onSelect: (file: File) => void;
+}
+
+/** 卡片头部的图标式上传入口：隐藏 file input + 7x7 图标按钮。 */
+export function UploadIconButton({ accept, label, busy, disabled, onSelect }: UploadIconButtonProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={accept}
+        className="hidden"
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          // 允许重复选择同一文件再次上传
+          e.target.value = "";
+          if (f) onSelect(f);
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={busy || disabled}
+        title={label}
+        aria-label={label}
+        className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:cursor-not-allowed disabled:opacity-50"
+        style={{ color: "var(--color-text-3)" }}
+      >
+        {busy ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+        ) : (
+          <Upload className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
+      </button>
+    </>
+  );
+}

--- a/frontend/src/components/ui/UploadIconButton.tsx
+++ b/frontend/src/components/ui/UploadIconButton.tsx
@@ -3,7 +3,7 @@ import { Loader2, Upload } from "lucide-react";
 
 /** 与后端 upload_finalize.py 的扩展名白名单保持一致 */
 export const UPLOAD_IMAGE_ACCEPT = ".png,.jpg,.jpeg,.webp";
-export const UPLOAD_VIDEO_ACCEPT = ".mp4,.mov,.webm,.m4v";
+export const UPLOAD_VIDEO_ACCEPT = ".mp4,.mov,.m4v";
 
 interface UploadIconButtonProps {
   accept: string;

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1152,6 +1152,7 @@ export default {
   'media_upload_video': 'Upload video',
   'media_upload_success': '"{{id}}" uploaded',
   'media_upload_failed': 'Upload failed: {{message}}',
+  'media_refresh_failed': 'Uploaded, but the list failed to refresh: {{message}}',
   'workspace_nav_overview': 'Overview',
   'workspace_nav_source': 'Source files',
   'workspace_nav_characters': 'Characters',

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -999,6 +999,7 @@ export default {
   'switch_to_version': 'Switch to this version',
   'version_preview_alt': 'Version v{{version}} preview',
   'version_no_notes': 'No additional notes recorded for this version.',
+  'version_manual_upload': 'Manually uploaded by the user.',
 
   // ProjectCard - more actions
   'more_actions': 'More Actions',
@@ -1147,6 +1148,10 @@ export default {
   'media_generate_video': 'Generate video',
   'media_regenerate_video': 'Regenerate video',
   'media_generate_video_disabled_hint': 'Generate the storyboard first',
+  'media_upload_storyboard': 'Upload storyboard image',
+  'media_upload_video': 'Upload video',
+  'media_upload_success': '"{{id}}" uploaded',
+  'media_upload_failed': 'Upload failed: {{message}}',
   'workspace_nav_overview': 'Overview',
   'workspace_nav_source': 'Source files',
   'workspace_nav_characters': 'Characters',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -965,6 +965,7 @@ export default {
   'switch_to_version': 'Chuyển sang phiên bản này',
   'version_preview_alt': 'Xem trước phiên bản v{{version}}',
   'version_no_notes': 'Phiên bản này không có ghi chú bổ sung.',
+  'version_manual_upload': 'Phiên bản do người dùng tải lên thủ công.',
 
   // ProjectCard - more actions
   'more_actions': 'Thao tác khác',
@@ -1103,6 +1104,10 @@ export default {
   'media_regenerate_video': 'Tạo lại video',
   'media_smart_generate_prompt': 'Tạo prompt thông minh',
   'media_storyboard_title': 'Phân cảnh',
+  'media_upload_storyboard': 'Tải lên ảnh phân cảnh',
+  'media_upload_video': 'Tải lên video',
+  'media_upload_success': 'Đã tải lên "{{id}}"',
+  'media_upload_failed': 'Tải lên thất bại: {{message}}',
   'media_versions_label': 'Phiên bản',
   'media_video_title': 'Video',
   'no_episode_search_results': 'Không có tập phù hợp',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1108,6 +1108,7 @@ export default {
   'media_upload_video': 'Tải lên video',
   'media_upload_success': 'Đã tải lên "{{id}}"',
   'media_upload_failed': 'Tải lên thất bại: {{message}}',
+  'media_refresh_failed': 'Đã tải lên, nhưng làm mới danh sách thất bại: {{message}}',
   'media_versions_label': 'Phiên bản',
   'media_video_title': 'Video',
   'no_episode_search_results': 'Không có tập phù hợp',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1000,6 +1000,7 @@ export default {
   'switch_to_version': '切换到此版本',
   'version_preview_alt': '版本 v{{version}} 预览',
   'version_no_notes': '该版本没有记录额外说明。',
+  'version_manual_upload': '用户手动上传的版本。',
 
   // ProjectCard - more actions
   'more_actions': '更多操作',
@@ -1148,6 +1149,10 @@ export default {
   'media_generate_video': '生成视频',
   'media_regenerate_video': '重新生成视频',
   'media_generate_video_disabled_hint': '先生成分镜图',
+  'media_upload_storyboard': '上传分镜图',
+  'media_upload_video': '上传视频',
+  'media_upload_success': '「{{id}}」上传完成',
+  'media_upload_failed': '上传失败: {{message}}',
   'workspace_nav_overview': '项目概览',
   'workspace_nav_source': '源文件',
   'workspace_nav_characters': '角色集',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1153,6 +1153,7 @@ export default {
   'media_upload_video': '上传视频',
   'media_upload_success': '「{{id}}」上传完成',
   'media_upload_failed': '上传失败: {{message}}',
+  'media_refresh_failed': '上传成功，但列表刷新失败: {{message}}',
   'workspace_nav_overview': '项目概览',
   'workspace_nav_source': '源文件',
   'workspace_nav_characters': '角色集',

--- a/lib/asset_fingerprints.py
+++ b/lib/asset_fingerprints.py
@@ -3,7 +3,16 @@
 from pathlib import Path
 
 # 扫描的媒体子目录
-_MEDIA_SUBDIRS = ("storyboards", "videos", "thumbnails", "characters", "scenes", "props", "grids")
+_MEDIA_SUBDIRS = (
+    "storyboards",
+    "videos",
+    "thumbnails",
+    "characters",
+    "scenes",
+    "props",
+    "grids",
+    "reference_videos",
+)
 
 # 根目录下的已知媒体文件（如风格参考图）
 _ROOT_MEDIA_SUFFIXES = frozenset((".png", ".jpg", ".jpeg", ".webp", ".mp4"))

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -48,6 +48,7 @@ MESSAGES = {
     "unsupported_video_type": "Unsupported video type {ext}. Allowed types: {allowed}",
     "upload_too_large": "Uploaded file exceeds the size limit ({max_mb} MB)",
     "invalid_image_file": "Invalid image file, could not be parsed",
+    "internal_server_error": "Internal server error, please try again later",
     "invalid_asset_type": "asset type must be character / scene / prop",
     "invalid_asset_filename": "filename must not contain path separators or ..",
     "invalid_step_num": "Invalid step number: {step_num}",

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -45,6 +45,8 @@ MESSAGES = {
     "invalid_upload_type": "Invalid upload type: {upload_type}",
     "missing_filename": "Uploaded file is missing a filename",
     "unsupported_image_type": "Unsupported file type {ext}. Allowed types: {allowed}",
+    "unsupported_video_type": "Unsupported video type {ext}. Allowed types: {allowed}",
+    "upload_too_large": "Uploaded file exceeds the size limit ({max_mb} MB)",
     "invalid_image_file": "Invalid image file, could not be parsed",
     "invalid_asset_type": "asset type must be character / scene / prop",
     "invalid_asset_filename": "filename must not contain path separators or ..",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -45,6 +45,8 @@ MESSAGES = {
     "invalid_upload_type": "Loại tải lên không hợp lệ: {upload_type}",
     "missing_filename": "Tệp tải lên thiếu tên tệp",
     "unsupported_image_type": "Định dạng tệp không hỗ trợ {ext}. Các loại cho phép: {allowed}",
+    "unsupported_video_type": "Định dạng video không hỗ trợ {ext}. Các loại cho phép: {allowed}",
+    "upload_too_large": "Tệp tải lên vượt quá giới hạn dung lượng ({max_mb} MB)",
     "invalid_image_file": "Tệp ảnh không hợp lệ, không thể phân tích",
     "invalid_asset_type": "Loại tài nguyên phải là character / scene / prop",
     "invalid_asset_filename": "Tên tệp không được chứa ký tự phân tách đường dẫn hoặc ..",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -48,6 +48,7 @@ MESSAGES = {
     "unsupported_video_type": "Định dạng video không hỗ trợ {ext}. Các loại cho phép: {allowed}",
     "upload_too_large": "Tệp tải lên vượt quá giới hạn dung lượng ({max_mb} MB)",
     "invalid_image_file": "Tệp ảnh không hợp lệ, không thể phân tích",
+    "internal_server_error": "Lỗi máy chủ nội bộ, vui lòng thử lại sau",
     "invalid_asset_type": "Loại tài nguyên phải là character / scene / prop",
     "invalid_asset_filename": "Tên tệp không được chứa ký tự phân tách đường dẫn hoặc ..",
     "invalid_step_num": "Số bước không hợp lệ: {step_num}",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -45,6 +45,8 @@ MESSAGES = {
     "invalid_upload_type": "无效的上传类型: {upload_type}",
     "missing_filename": "上传的文件缺少文件名",
     "unsupported_image_type": "不支持的文件类型 {ext}，允许的类型: {allowed}",
+    "unsupported_video_type": "不支持的视频类型 {ext}，允许的类型: {allowed}",
+    "upload_too_large": "上传文件超过大小上限（{max_mb} MB）",
     "invalid_image_file": "无效的图片文件，无法解析",
     "invalid_asset_type": "资产类型必须为 character / scene / prop",
     "invalid_asset_filename": "文件名不能包含路径分隔符或 ..",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -48,6 +48,7 @@ MESSAGES = {
     "unsupported_video_type": "不支持的视频类型 {ext}，允许的类型: {allowed}",
     "upload_too_large": "上传文件超过大小上限（{max_mb} MB）",
     "invalid_image_file": "无效的图片文件，无法解析",
+    "internal_server_error": "服务器内部错误，请稍后重试",
     "invalid_asset_type": "资产类型必须为 character / scene / prop",
     "invalid_asset_filename": "文件名不能包含路径分隔符或 ..",
     "invalid_step_num": "无效的步骤编号: {step_num}",

--- a/lib/image_utils.py
+++ b/lib/image_utils.py
@@ -10,6 +10,32 @@ from io import BytesIO
 
 from PIL import Image, ImageOps
 
+_COMPRESS_THRESHOLD = 2 * 1024 * 1024  # 2 MB
+_MAX_LONG_EDGE = 2048
+_JPEG_QUALITY = 85
+
+# EXIF Orientation tag（ImageOps.exif_transpose 读取的字段）
+_EXIF_ORIENTATION = 0x0112
+
+
+def _open_oriented(content: bytes, *, target_modes: tuple[str, ...], fallback_mode: str) -> Image.Image:
+    """解码 + EXIF 方向矫正 + 收敛到目标颜色模式。返回与源解码器解耦的图像对象。"""
+    with Image.open(BytesIO(content)) as src:
+        img = ImageOps.exif_transpose(src)
+        if img.mode not in target_modes:
+            img = img.convert(fallback_mode)
+        return img.copy() if img is src else img
+
+
+def _fit_long_edge(img: Image.Image, max_long_edge: int) -> Image.Image:
+    """长边超限时等比缩放；极端宽高比下短边钳到至少 1 像素，避免 resize(…, 0) 报错。"""
+    w, h = img.size
+    long_edge = max(w, h)
+    if long_edge <= max_long_edge:
+        return img
+    scale = max_long_edge / long_edge
+    return img.resize((max(1, int(w * scale)), max(1, int(h * scale))), Image.Resampling.LANCZOS)
+
 
 def convert_image_bytes_to_png(content: bytes) -> bytes:
     """
@@ -19,10 +45,37 @@ def convert_image_bytes_to_png(content: bytes) -> bytes:
         ValueError: if the input bytes are not a valid image.
     """
     try:
-        with Image.open(BytesIO(content)) as img:
-            img = ImageOps.exif_transpose(img)
-            if img.mode not in ("RGB", "RGBA"):
-                img = img.convert("RGBA")
+        with _open_oriented(content, target_modes=("RGB", "RGBA"), fallback_mode="RGBA") as img:
+            out = BytesIO()
+            img.save(out, format="PNG")
+            return out.getvalue()
+    except Exception as e:
+        raise ValueError("Invalid image") from e
+
+
+def normalize_storyboard_upload(content: bytes, *, max_long_edge: int = _MAX_LONG_EDGE) -> bytes:
+    """
+    将上传的分镜图归一化为 PNG 字节：exif 矫正方向、长边超限时等比缩放。
+
+    分镜图 canonical 路径固定为 .png（resource_paths / VersionManager / restore
+    均按此扩展名工作），因此无论输入格式一律转 PNG。
+    已合规的 PNG（模式/方向/尺寸均达标）原样返回，不做无谓的解码重编码。
+
+    Raises:
+        ValueError: if the input bytes are not a valid image.
+    """
+    try:
+        with Image.open(BytesIO(content)) as probe:
+            if (
+                probe.format == "PNG"
+                and probe.mode in ("RGB", "RGBA")
+                and max(probe.size) <= max_long_edge
+                and probe.getexif().get(_EXIF_ORIENTATION, 1) == 1
+            ):
+                return content
+
+        with _open_oriented(content, target_modes=("RGB", "RGBA"), fallback_mode="RGBA") as img:
+            img = _fit_long_edge(img, max_long_edge)
             out = BytesIO()
             img.save(out, format="PNG")
             return out.getvalue()
@@ -43,11 +96,6 @@ def validate_image_bytes(content: bytes) -> None:
         raise ValueError("Invalid image") from e
 
 
-_COMPRESS_THRESHOLD = 2 * 1024 * 1024  # 2 MB
-_MAX_LONG_EDGE = 2048
-_JPEG_QUALITY = 85
-
-
 def compress_image_bytes(
     content: bytes,
     *,
@@ -62,19 +110,8 @@ def compress_image_bytes(
         ValueError: if the input bytes are not a valid image.
     """
     try:
-        with Image.open(BytesIO(content)) as img:
-            img = ImageOps.exif_transpose(img)
-            if img.mode != "RGB":
-                img = img.convert("RGB")
-
-            w, h = img.size
-            long_edge = max(w, h)
-            if long_edge > max_long_edge:
-                scale = max_long_edge / long_edge
-                new_w = int(w * scale)
-                new_h = int(h * scale)
-                img = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
-
+        with _open_oriented(content, target_modes=("RGB",), fallback_mode="RGB") as img:
+            img = _fit_long_edge(img, max_long_edge)
             out = BytesIO()
             img.save(out, format="JPEG", quality=quality, optimize=True)
             return out.getvalue()

--- a/server/app.py
+++ b/server/app.py
@@ -57,6 +57,7 @@ from server.routers import (
     providers,
     reference_videos,
     scenes,
+    shot_uploads,
     system,
     system_config,
     tasks,
@@ -539,6 +540,7 @@ app.include_router(scenes.router, prefix="/api/v1", tags=["场景管理"])
 app.include_router(props.router, prefix="/api/v1", tags=["道具管理"])
 app.include_router(files.router, prefix="/api/v1", tags=["文件管理"])
 app.include_router(generate.router, prefix="/api/v1", tags=["生成"])
+app.include_router(shot_uploads.router, prefix="/api/v1", tags=["镜头上传"])
 app.include_router(versions.router, prefix="/api/v1", tags=["版本管理"])
 app.include_router(usage.router, prefix="/api/v1", tags=["费用统计"])
 app.include_router(assistant.router, prefix="/api/v1/projects/{project_name}/assistant", tags=["助手会话"])

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -57,7 +57,6 @@ ALLOWED_EXTENSIONS = {
     "character_ref": [".png", ".jpg", ".jpeg", ".webp"],
     "scene": [".png", ".jpg", ".jpeg", ".webp"],
     "prop": [".png", ".jpg", ".jpeg", ".webp"],
-    "storyboard": [".png", ".jpg", ".jpeg", ".webp"],
 }
 
 
@@ -131,9 +130,9 @@ async def upload_file(
 
     Args:
         project_name: 项目名称
-        upload_type: 上传类型 (source/character/prop/storyboard)
+        upload_type: 上传类型 (source/character/character_ref/scene/prop)
         file: 上传的文件
-        name: 可选，用于角色/道具名称，或分镜 ID（自动更新元数据）
+        name: 可选，用于角色/场景/道具名称（自动更新元数据）；分镜/视频上传走 shot_uploads 路由
         on_conflict: source 类型独有 — fail / replace / rename
     """
     if upload_type not in ALLOWED_EXTENSIONS:
@@ -193,13 +192,6 @@ async def upload_file(
                     filename = f"{name}.png"
                 else:
                     filename = f"{Path(original_filename).stem}.png"
-            elif upload_type == "storyboard":
-                # 注意：目录为 storyboards（复数），而不是 storyboard
-                target_dir = project_dir / "storyboards"
-                if name:
-                    filename = f"scene_{name}.png"
-                else:
-                    filename = f"{Path(original_filename).stem}.png"
             else:
                 target_dir = project_dir / upload_type
                 filename = original_filename
@@ -208,7 +200,7 @@ async def upload_file(
 
             # 保存文件（大于 2MB 时压缩为 JPEG，否则校验后原样保存）
             nonlocal content
-            if upload_type in ("character", "character_ref", "scene", "prop", "storyboard"):
+            if upload_type in ("character", "character_ref", "scene", "prop"):
                 try:
                     content, ext = normalize_uploaded_image(content, Path(original_filename).suffix.lower())
                 except ValueError:
@@ -230,8 +222,6 @@ async def upload_file(
                 relative_path = f"scenes/{filename}"
             elif upload_type == "prop":
                 relative_path = f"props/{filename}"
-            elif upload_type == "storyboard":
-                relative_path = f"storyboards/{filename}"
             else:
                 relative_path = f"{upload_type}/{filename}"
 

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -24,6 +24,7 @@ from lib.project_change_hints import project_change_source
 from lib.project_manager import EpisodeScriptReboundError, ProjectManager, effective_mode
 from lib.reference_video import assemble_shots_text, parse_prompt
 from lib.resource_paths import resource_relative_path
+from lib.script_editor import ScriptEditError
 from lib.version_manager import VersionManager
 from server.auth import CurrentUser
 from server.services.generation_tasks import emit_generation_success_batch
@@ -459,6 +460,8 @@ async def upload_unit_video(
     except KeyError as exc:
         # finalize 写回时 unit 已被并发删除（落盘后绑定重查到锁内写回之间的窄竞态）
         raise HTTPException(status_code=404, detail=_t("ref_unit_not_found", unit_id=unit_id)) from exc
+    except ScriptEditError as exc:
+        raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=str(exc))) from exc
     except HTTPException:
         raise
     except Exception as exc:

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -5,12 +5,14 @@ Mount prefix: /api/v1/projects/{project_name}/reference-videos
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Response, status
+from fastapi import APIRouter, File, HTTPException, Response, UploadFile, status
 from pydantic import BaseModel, Field
 
 from lib.app_data_dir import app_data_dir
@@ -18,9 +20,20 @@ from lib.asset_types import BUCKET_KEY
 from lib.generation_queue import get_generation_queue
 from lib.generation_queue_client import TaskSpec, TaskSpecValidationError
 from lib.i18n import Translator
+from lib.project_change_hints import project_change_source
 from lib.project_manager import EpisodeScriptReboundError, ProjectManager, effective_mode
 from lib.reference_video import assemble_shots_text, parse_prompt
+from lib.resource_paths import resource_relative_path
+from lib.version_manager import VersionManager
 from server.auth import CurrentUser
+from server.services.generation_tasks import emit_generation_success_batch
+from server.services.reference_video_tasks import _finalize_reference_video_unit
+from server.services.upload_finalize import (
+    UploadValidationError,
+    record_upload_version,
+    save_uploaded_video_stream,
+    validate_upload,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -355,3 +368,96 @@ async def generate_unit(
         user_id=_user.id,
     )
     return {"task_id": result["task_id"], "deduped": result.get("deduped", False)}
+
+
+@router.post("/episodes/{episode}/units/{unit_id}/upload-video")
+async def upload_unit_video(
+    project_name: str,
+    episode: int,
+    unit_id: str,
+    _user: CurrentUser,
+    _t: Translator,
+    file: UploadFile = File(...),
+) -> dict[str, Any]:
+    """上传单元成片视频，替换该 unit 的 AI 生成视频。
+
+    复用生成链路的 finalize（抽缩略图、清旧 video_uri、status=completed），
+    并纳入版本管理。参考图上传走既有的项目资产上传通路，不在此处。
+    """
+    try:
+        max_bytes = validate_upload(file.filename, file.size, kind="video")
+
+        relative_path = resource_relative_path("reference_videos", unit_id)
+
+        def _validate_unit() -> tuple[Path, VersionManager, str]:
+            _project, script, script_file = _load_episode_script(project_name, episode, _t)
+            _find_unit(script, unit_id, _t)  # raises 404 if missing
+            project_path = get_project_manager().get_project_path(project_name)
+            # 路径遍历防护：unit_id 拼出的绝对路径不得逃出项目目录（与 versions.py 对齐）
+            target = project_path / relative_path
+            try:
+                target.resolve().relative_to(project_path.resolve())
+            except ValueError:
+                raise HTTPException(status_code=400, detail=_t("invalid_resource_id", resource_id=unit_id))
+            return project_path, VersionManager(project_path), script_file
+
+        project_path, versions, script_file = await asyncio.to_thread(_validate_unit)
+        target = project_path / relative_path
+
+        with project_change_source("webui"):
+            await asyncio.to_thread(versions.ensure_current_tracked, "reference_videos", unit_id, target, "")
+            await save_uploaded_video_stream(file.file, target, max_bytes=max_bytes)
+
+            # 上传流可达数百 MB、耗时数秒，期间 episode→script 绑定可能被并发重绑
+            # （PATCH / agent 同步剧本）。落盘后重解析绑定，确保元数据写进当前生效的剧本。
+            def _recheck_binding() -> str:
+                _p, script2, script_file2 = _load_episode_script(project_name, episode, _t)
+                _find_unit(script2, unit_id, _t)
+                return script_file2
+
+            script_file = await asyncio.to_thread(_recheck_binding)
+
+            version = await asyncio.to_thread(
+                record_upload_version,
+                versions=versions,
+                resource_type="reference_videos",
+                resource_id=unit_id,
+                current_file=target,
+                original_filename=file.filename,
+            )
+            await _finalize_reference_video_unit(
+                project_name=project_name,
+                script_file=script_file,
+                project_path=project_path,
+                resource_id=unit_id,
+                output_path=target,
+                version=version,
+                video_uri=None,
+                versions=versions,
+            )
+            # emit 内部会读剧本解析 episode 并计算指纹，放线程池避免阻塞事件循环；
+            # 返回的指纹直接复用进响应体，免二次计算
+            fingerprints = await asyncio.to_thread(
+                emit_generation_success_batch,
+                task_type="reference_video",
+                project_name=project_name,
+                resource_id=unit_id,
+                payload={"script_file": script_file},
+            )
+
+        return {
+            "success": True,
+            "path": relative_path,
+            "version": version,
+            "asset_fingerprints": fingerprints,
+        }
+    except UploadValidationError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=_t(exc.key, **exc.params)) from exc
+    except FileNotFoundError as exc:
+        # 不回传 str(exc)：load_script 的异常信息含服务器绝对路径
+        raise HTTPException(status_code=404, detail=_t("ref_script_missing")) from exc
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("请求处理失败")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -456,8 +456,12 @@ async def upload_unit_video(
     except FileNotFoundError as exc:
         # 不回传 str(exc)：load_script 的异常信息含服务器绝对路径
         raise HTTPException(status_code=404, detail=_t("ref_script_missing")) from exc
+    except KeyError as exc:
+        # finalize 写回时 unit 已被并发删除（落盘后绑定重查到锁内写回之间的窄竞态）
+        raise HTTPException(status_code=404, detail=_t("ref_unit_not_found", unit_id=unit_id)) from exc
     except HTTPException:
         raise
     except Exception as exc:
+        # 不回传 str(exc)：未预期异常的消息可能含服务器路径等内部细节，堆栈进日志即可
         logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=str(exc))
+        raise HTTPException(status_code=500, detail=_t("internal_server_error")) from exc

--- a/server/routers/shot_uploads.py
+++ b/server/routers/shot_uploads.py
@@ -93,7 +93,8 @@ async def upload_shot_media(
             await asyncio.to_thread(versions.ensure_current_tracked, resource_type, shot_id, target, "")
 
             if kind == "storyboard":
-                content = await file.read()
+                # 限定读入内存的字节数：Content-Length 缺失/被绕过时不至于 OOM
+                content = await file.read(max_bytes + 1)
                 if len(content) > max_bytes:
                     raise UploadTooLargeError(max_bytes)
                 try:
@@ -155,5 +156,6 @@ async def upload_shot_media(
     except HTTPException:
         raise
     except Exception as e:
+        # 不回传 str(e)：未预期异常的消息可能含服务器路径等内部细节，堆栈进日志即可
         logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=_t("internal_server_error")) from e

--- a/server/routers/shot_uploads.py
+++ b/server/routers/shot_uploads.py
@@ -1,0 +1,159 @@
+"""镜头级分镜图/视频自主上传路由。
+
+与通用资产上传（files.py）分离：镜头上传需要 script_file + shot_id 定位剧本条目、
+纳入版本管理，并返回 asset_fingerprints 供上传方即时 cache-bust（SSE 兜底其他客户端）。
+
+宫格模式无独立端点：拆分后的单元格图 canonical 路径与图生视频模式相同
+（storyboards/scene_{id}.png），按镜头上传即覆盖该单元格，宫格记录不动。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Literal
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+
+from lib.app_data_dir import app_data_dir
+from lib.i18n import Translator
+from lib.image_utils import normalize_storyboard_upload
+from lib.project_change_hints import project_change_source
+from lib.project_manager import ProjectManager
+from lib.resource_paths import resource_relative_path
+from lib.script_editor import ScriptEditError
+from lib.storyboard_sequence import find_storyboard_item, get_storyboard_items
+from lib.version_manager import VersionManager
+from server.auth import CurrentUser
+from server.services.generation_tasks import emit_generation_success_batch
+from server.services.upload_finalize import (
+    UploadTooLargeError,
+    UploadValidationError,
+    finalize_shot_storyboard_upload,
+    finalize_shot_video_upload,
+    record_upload_version,
+    save_uploaded_bytes,
+    save_uploaded_video_stream,
+    validate_upload,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+pm = ProjectManager(app_data_dir())
+
+
+def get_project_manager() -> ProjectManager:
+    return pm
+
+
+@router.post("/projects/{project_name}/shots/{shot_id}/upload/{kind}")
+async def upload_shot_media(
+    project_name: str,
+    shot_id: str,
+    kind: Literal["storyboard", "video"],
+    script_file: str,
+    _user: CurrentUser,
+    _t: Translator,
+    file: UploadFile = File(...),
+):
+    """上传分镜图或镜头视频，替换该镜头的 AI 生成资产。
+
+    与生成链路保持一致：旧文件补登版本 → 写 canonical 路径 → 登记新版本 →
+    剧本元数据回写（status 自动推导）→ SSE batch 推送。
+    """
+    try:
+        max_bytes = validate_upload(file.filename, file.size, kind="image" if kind == "storyboard" else "video")
+
+        resource_type = "storyboards" if kind == "storyboard" else "videos"
+        relative_path = resource_relative_path(resource_type, shot_id)
+
+        def _validate_shot() -> tuple[Path, VersionManager]:
+            project_path = get_project_manager().get_project_path(project_name)
+            script = get_project_manager().load_script(project_name, script_file)
+            # reference_video 剧本返回空列表 → 404，该模式的视频上传走 reference-videos 路由
+            items, id_field, _, _, _ = get_storyboard_items(script)
+            if find_storyboard_item(items, id_field, shot_id) is None:
+                raise HTTPException(status_code=404, detail=_t("segment_not_found", id=shot_id))
+            # 路径遍历防护：shot_id 拼出的绝对路径不得逃出项目目录（与 versions.py 对齐）
+            target = project_path / relative_path
+            try:
+                target.resolve().relative_to(project_path.resolve())
+            except ValueError:
+                raise HTTPException(status_code=400, detail=_t("invalid_resource_id", resource_id=shot_id))
+            return project_path, VersionManager(project_path)
+
+        project_path, versions = await asyncio.to_thread(_validate_shot)
+        target = project_path / relative_path
+
+        with project_change_source("webui"):
+            # 旧文件若从未入版本库（如历史迁移），先补登，避免被覆盖后字节丢失
+            await asyncio.to_thread(versions.ensure_current_tracked, resource_type, shot_id, target, "")
+
+            if kind == "storyboard":
+                content = await file.read()
+                if len(content) > max_bytes:
+                    raise UploadTooLargeError(max_bytes)
+                try:
+                    png_bytes = await asyncio.to_thread(normalize_storyboard_upload, content)
+                except ValueError:
+                    raise HTTPException(status_code=400, detail=_t("invalid_image_file"))
+                await save_uploaded_bytes(png_bytes, target)
+            else:
+                await save_uploaded_video_stream(file.file, target, max_bytes=max_bytes)
+
+            version = await asyncio.to_thread(
+                record_upload_version,
+                versions=versions,
+                resource_type=resource_type,
+                resource_id=shot_id,
+                current_file=target,
+                original_filename=file.filename,
+            )
+
+            if kind == "storyboard":
+                await finalize_shot_storyboard_upload(
+                    project_name=project_name, script_file=script_file, shot_id=shot_id, asset_path=relative_path
+                )
+            else:
+                await finalize_shot_video_upload(
+                    project_name=project_name,
+                    script_file=script_file,
+                    shot_id=shot_id,
+                    project_path=project_path,
+                    video_rel=relative_path,
+                )
+
+            # emit 内部会读剧本解析 episode 并计算指纹，放线程池避免阻塞事件循环；
+            # 返回的指纹直接复用进响应体，免二次计算
+            fingerprints = await asyncio.to_thread(
+                emit_generation_success_batch,
+                task_type=kind,
+                project_name=project_name,
+                resource_id=shot_id,
+                payload={"script_file": script_file},
+            )
+
+        return {
+            "success": True,
+            "path": relative_path,
+            "version": version,
+            "asset_fingerprints": fingerprints,
+        }
+
+    except UploadValidationError as e:
+        raise HTTPException(status_code=e.status_code, detail=_t(e.key, **e.params))
+    except FileNotFoundError:
+        # 不回传 str(e)：load_script 的异常信息含服务器绝对路径
+        raise HTTPException(status_code=404, detail=_t("script_not_found", name=script_file))
+    except KeyError:
+        raise HTTPException(status_code=404, detail=_t("segment_not_found", id=shot_id))
+    except ScriptEditError as e:
+        raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=str(e)))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("请求处理失败")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/server/routers/versions.py
+++ b/server/routers/versions.py
@@ -21,6 +21,7 @@ from lib.resource_paths import resource_relative_path
 from lib.script_editor import ScriptEditError
 from lib.version_manager import VersionManager
 from server.auth import CurrentUser
+from server.services.reference_video_tasks import apply_unit_video_assets
 
 router = APIRouter()
 
@@ -28,8 +29,8 @@ router = APIRouter()
 pm = ProjectManager(app_data_dir())
 
 # 经此路由可还原的资源类型（API 面策略）。路径形状委托 lib.resource_paths，但本路由
-# 仅放行有还原后元数据同步分支的这五类；grids/reference_videos 的还原是独立议题。
-_RESTORABLE_RESOURCE_TYPES = frozenset({"storyboards", "videos", "characters", "scenes", "props"})
+# 仅放行有还原后元数据同步分支的这几类；grids 的还原是独立议题。
+_RESTORABLE_RESOURCE_TYPES = frozenset({"storyboards", "videos", "characters", "scenes", "props", "reference_videos"})
 
 
 def get_project_manager() -> ProjectManager:
@@ -61,39 +62,96 @@ def _resolve_resource_path(
     return current_file, relative
 
 
-def _sync_storyboard_metadata(
-    project_name: str,
-    resource_id: str,
-    file_path: str,
-    project_path: Path,
-) -> None:
+def _sync_scripts_best_effort(project_path: Path, apply: Callable[[str], None]) -> None:
+    """对项目内每集剧本执行 apply（入参为脚本文件名），逐集降级而非整体失败。
+
+    - KeyError：该集脚本不引用此资源，跳过同步是正常情况而非脏数据。
+    - ScriptEditError：脏脚本（结构键损坏）降级跳过，warning 标出集名 + 原因。
+    - OSError：transient IO 错误（单文件权限 / EBUSY / flock 超时 / 损坏 inode 等）。
+      跨集同步是 best-effort housekeeping，主集恢复在调用本函数前已成功，不应让
+      sibling 集的临时 IO 失败把整个 restore 操作 5xx。真正未预期的异常
+      （RuntimeError / ImportError / ...）仍让它冒到 router 5xx 暴露。
+    """
     scripts_dir = project_path / "scripts"
     if not scripts_dir.exists():
         return
     for script_file in scripts_dir.glob("*.json"):
         try:
             with project_change_source("webui"):
-                get_project_manager().update_scene_asset(
-                    project_name=project_name,
-                    script_filename=script_file.name,
-                    scene_id=resource_id,
-                    asset_type="storyboard_image",
-                    asset_path=file_path,
-                )
+                apply(script_file.name)
         except KeyError:
-            # 该集脚本里无此 scene_id（不引用该资产），跳过同步是正常情况而非脏数据。
             continue
         except ScriptEditError as exc:
-            # 脏脚本（分镜数组键损坏）：跨集同步降级跳过,但 warning 标出集名 + 原因。
             logger.warning("跨集同步元数据跳过脏脚本 %s: %s", script_file.name, exc)
             continue
         except OSError as exc:
-            # transient IO 错误(单文件权限 / EBUSY / flock 超时 / 损坏 inode 等):跨集同步是
-            # best-effort housekeeping,主集恢复在调用本函数前已成功,不应让 sibling 集的
-            # 临时 IO 失败把整个 restore 操作 5xx。降级跳过 + warning 含集名 + 异常信息。
-            # 真正未预期的异常(RuntimeError / ImportError / ...)仍让它冒到 router 5xx 暴露。
             logger.warning("跨集同步元数据 sibling 集 %s IO 失败: %s", script_file.name, exc)
             continue
+
+
+def _sync_storyboard_metadata(
+    project_name: str,
+    resource_id: str,
+    file_path: str,
+    project_path: Path,
+) -> None:
+    def _apply(script_name: str) -> None:
+        get_project_manager().update_scene_asset(
+            project_name=project_name,
+            script_filename=script_name,
+            scene_id=resource_id,
+            asset_type="storyboard_image",
+            asset_path=file_path,
+        )
+
+    _sync_scripts_best_effort(project_path, _apply)
+
+
+def _sync_video_metadata(
+    project_name: str,
+    resource_id: str,
+    file_path: str,
+    project_path: Path,
+) -> None:
+    """还原镜头视频后同步 generated_assets。
+
+    还原的是历史本地文件，旧 provider URI / 缩略图与之不再对应，一并清空
+    （缩略图文件本身由 restore 端点删除，同步路径无法内联 async ffmpeg 重新抽帧）。
+    """
+
+    def _apply(script_name: str) -> None:
+        get_project_manager().batch_update_scene_assets(
+            project_name=project_name,
+            script_filename=script_name,
+            updates=[
+                (resource_id, "video_clip", file_path),
+                (resource_id, "video_uri", None),
+                (resource_id, "video_thumbnail", None),
+            ],
+        )
+
+    _sync_scripts_best_effort(project_path, _apply)
+
+
+def _sync_reference_video_metadata(
+    project_name: str,
+    resource_id: str,
+    project_path: Path,
+) -> None:
+    """还原参考视频单元后同步 unit.generated_assets（写回口径与生成 finalize 共用）。
+
+    还原的是历史本地文件，旧 provider URI / 缩略图与之不再对应，一并清空；
+    缩略图文件本身由 restore 端点删除（同步路径无法内联 async ffmpeg 重新抽帧）。
+    """
+
+    def _apply(script_name: str) -> None:
+        # 资产回写热路径：只动 unit.generated_assets，豁免结构校验（与 update_scene_asset 对齐）
+        with get_project_manager().locked_script(project_name, script_name, validate=False) as script:
+            if not apply_unit_video_assets(script, resource_id, video_uri=None, thumb_rel=None):
+                # 该集脚本不含此 unit：锁内抛出让 locked_script 跳过写回
+                raise KeyError(resource_id)
+
+    _sync_scripts_best_effort(project_path, _apply)
 
 
 # resource_type（复数，URL 段）→ asset_type（单数，ASSET_SPECS 键）
@@ -121,6 +179,10 @@ def _sync_metadata(
             pass  # 资产条目可能已从 project.json 删除，跳过元数据同步
     elif resource_type == "storyboards":
         _sync_storyboard_metadata(project_name, resource_id, file_path, project_path)
+    elif resource_type == "videos":
+        _sync_video_metadata(project_name, resource_id, file_path, project_path)
+    elif resource_type == "reference_videos":
+        _sync_reference_video_metadata(project_name, resource_id, project_path)
 
 
 # ==================== 版本查询 ====================
@@ -208,6 +270,11 @@ async def restore_version(
                 thumbnail_key = f"thumbnails/scene_{resource_id}.jpg"
                 thumbnail_path.unlink(missing_ok=True)
                 # fingerprint=0 通知前端该文件已失效（poster 消失直到重新生成）
+                asset_fingerprints[thumbnail_key] = 0
+            elif resource_type == "reference_videos":
+                thumbnail_path = project_path / "reference_videos" / "thumbnails" / f"{resource_id}.jpg"
+                thumbnail_key = f"reference_videos/thumbnails/{resource_id}.jpg"
+                thumbnail_path.unlink(missing_ok=True)
                 asset_fingerprints[thumbnail_key] = 0
 
             return {

--- a/server/routers/versions.py
+++ b/server/routers/versions.py
@@ -145,11 +145,10 @@ def _sync_reference_video_metadata(
     """
 
     def _apply(script_name: str) -> None:
-        # 资产回写热路径：只动 unit.generated_assets，豁免结构校验（与 update_scene_asset 对齐）
+        # 资产回写热路径：只动 unit.generated_assets，豁免结构校验（与 update_scene_asset 对齐）。
+        # 该集脚本不含此 unit 时 apply_unit_video_assets 抛 KeyError，锁内冒出即跳过写回。
         with get_project_manager().locked_script(project_name, script_name, validate=False) as script:
-            if not apply_unit_video_assets(script, resource_id, video_uri=None, thumb_rel=None):
-                # 该集脚本不含此 unit：锁内抛出让 locked_script 跳过写回
-                raise KeyError(resource_id)
+            apply_unit_video_assets(script, resource_id, video_uri=None, thumb_rel=None)
 
     _sync_scripts_best_effort(project_path, _apply)
 

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -564,7 +564,7 @@ def _resolve_script_episode(project_name: str, script_file: str | None) -> int |
     return None
 
 
-def _compute_affected_fingerprints(project_name: str, task_type: str, resource_id: str) -> dict[str, int]:
+def compute_affected_fingerprints(project_name: str, task_type: str, resource_id: str) -> dict[str, int]:
     """计算受影响文件的 mtime 指纹"""
     try:
         project_path = get_project_manager().get_project_path(project_name)
@@ -660,13 +660,17 @@ def emit_generation_success_batch(
     project_name: str,
     resource_id: str,
     payload: dict[str, Any],
-) -> None:
+) -> dict[str, int]:
+    """发送生成/上传完成的项目变更事件，返回受影响文件的指纹（调用方可直接复用，免二次计算）。
+
+    事件 source 由 project_change_source contextvar 决定（worker / webui 调用方各自包裹）。
+    """
     spec = _TASK_CHANGE_SPECS.get(task_type)
     if spec is None:
-        return
+        return {}
 
     entity_type, action, label_tpl, include_script_episode = spec
-    asset_fingerprints = _compute_affected_fingerprints(project_name, task_type, resource_id)
+    asset_fingerprints = compute_affected_fingerprints(project_name, task_type, resource_id)
 
     change: dict[str, Any] = {
         "entity_type": entity_type,
@@ -683,7 +687,7 @@ def emit_generation_success_batch(
         change["episode"] = _resolve_script_episode(project_name, script_file)
 
     try:
-        emit_project_change_batch(project_name, [change], source="worker")
+        emit_project_change_batch(project_name, [change])
     except Exception:
         logger.exception(
             "发送生成完成项目事件失败 project=%s task_type=%s resource_id=%s",
@@ -691,6 +695,7 @@ def emit_generation_success_batch(
             task_type,
             resource_id,
         )
+    return asset_fingerprints
 
 
 async def execute_storyboard_task(
@@ -1320,7 +1325,19 @@ async def execute_grid_task(
 
                 cell_rel = f"storyboards/scene_{frame.next_scene_id}.png"
                 cell_path = storyboards_dir / f"scene_{frame.next_scene_id}.png"
+                # 与 MediaGenerator 版本顺序一致：旧文件先补登再覆写、覆写后登记新版本。
+                # 否则宫格重切的单元格不进版本史，版本面板的「当前版本」与磁盘内容脱节，
+                # 且下一次还原/上传会让未登记的格子字节永久丢失。
+                generator.versions.ensure_current_tracked("storyboards", str(frame.next_scene_id), cell_path, "")
                 cell.save(cell_path, format="PNG")
+                generator.versions.add_version(
+                    resource_type="storyboards",
+                    resource_id=str(frame.next_scene_id),
+                    prompt="",
+                    source_file=cell_path,
+                    source="grid_split",
+                    grid_id=resource_id,
+                )
                 frame.image_path = cell_rel
                 asset_updates.append((frame.next_scene_id, "storyboard_image", cell_rel))
                 asset_updates.append((frame.next_scene_id, "grid_id", resource_id))

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -639,11 +639,13 @@ def compute_affected_fingerprints(project_name: str, task_type: str, resource_id
                     continue
                 candidate = (project_path / frame.image_path).resolve()
                 try:
-                    candidate.relative_to(project_root)
+                    # 指纹 key 用归一化后的项目相对路径：原始字符串若是项目内的
+                    # 绝对路径，会把服务器路径泄漏给前端且匹配不上前端的资源 key
+                    rel = candidate.relative_to(project_root).as_posix()
                 except ValueError:
                     logger.warning("跳过越出项目目录的宫格 cell 路径: %s", frame.image_path)
                     continue
-                paths.append((frame.image_path, candidate))
+                paths.append((rel, candidate))
     elif task_type == "reference_video":
         paths.append(
             (

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -621,6 +621,19 @@ def compute_affected_fingerprints(project_name: str, task_type: str, resource_id
                 project_path / "grids" / f"{resource_id}.png",
             )
         )
+        # 宫格切割还会覆写多个 canonical 分镜图，实际写入的 cell 路径持久化在
+        # grid 记录的 frame_chain 中，一并纳入指纹让前端对这些文件 cache-bust；
+        # 记录缺失/损坏时降级为只报宫格主图。
+        try:
+            from lib.grid_manager import GridManager
+
+            grid = GridManager(project_path).get(resource_id)
+        except Exception:
+            grid = None
+        if grid is not None:
+            for frame in grid.frame_chain:
+                if frame.image_path:
+                    paths.append((frame.image_path, project_path / frame.image_path))
     elif task_type == "reference_video":
         paths.append(
             (

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -631,9 +631,19 @@ def compute_affected_fingerprints(project_name: str, task_type: str, resource_id
         except Exception:
             grid = None
         if grid is not None:
+            # 记录是磁盘上的 JSON，image_path 不可直接信任：绝对路径会覆盖左操作数、
+            # ../ 会越出项目目录，把任意服务器文件的存在性/mtime 暴露给前端
+            project_root = project_path.resolve()
             for frame in grid.frame_chain:
-                if frame.image_path:
-                    paths.append((frame.image_path, project_path / frame.image_path))
+                if not frame.image_path:
+                    continue
+                candidate = (project_path / frame.image_path).resolve()
+                try:
+                    candidate.relative_to(project_root)
+                except ValueError:
+                    logger.warning("跳过越出项目目录的宫格 cell 路径: %s", frame.image_path)
+                    continue
+                paths.append((frame.image_path, candidate))
     elif task_type == "reference_video":
         paths.append(
             (

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -22,6 +22,7 @@ from lib.image_utils import compress_image_bytes
 from lib.prompt_builders import append_video_negative_tail
 from lib.reference_video import assemble_shots_text, render_prompt_for_backend
 from lib.reference_video.errors import MissingReferenceError, RequestPayloadTooLargeError
+from lib.script_editor import ScriptEditError
 from lib.script_models import ReferenceResource
 from lib.thumbnail import extract_video_thumbnail
 from lib.version_manager import VersionManager
@@ -342,12 +343,13 @@ def apply_unit_video_assets(script: dict, resource_id: str, *, video_uri: str | 
 
     生成 finalize 与版本还原共用，保证两条路径写出的字段口径一致。
     新结果不含 video_uri / 缩略图时清空旧值，避免指向过期 URI / 已删除文件。
-    剧本不含 video_units 或 unit 不存在时抛 KeyError——写回失败必须让调用方可见，
-    finalize 不能在剧本未更新时静默成功；还原侧的跨集同步把 KeyError 当正常跳过。
+    写回失败必须让调用方可见、finalize 不能在剧本未更新时静默成功，且两种失败
+    要可区分：unit 不存在抛 KeyError（还原侧跨集同步把它当正常跳过），
+    video_units 结构损坏抛 ScriptEditError（还原侧按脏脚本 warning 降级）。
     """
     units = script.get("video_units")
     if not isinstance(units, list):
-        raise KeyError("video_units")
+        raise ScriptEditError("video_units 必须是 list")
     for u in units:
         if not isinstance(u, dict) or u.get("unit_id") != resource_id:
             continue

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -337,16 +337,17 @@ async def execute_reference_video_task(
     )
 
 
-def apply_unit_video_assets(script: dict, resource_id: str, *, video_uri: str | None, thumb_rel: str | None) -> bool:
+def apply_unit_video_assets(script: dict, resource_id: str, *, video_uri: str | None, thumb_rel: str | None) -> None:
     """在剧本 dict 上写回 unit.generated_assets（video_clip / video_uri / video_thumbnail / status）。
 
     生成 finalize 与版本还原共用，保证两条路径写出的字段口径一致。
     新结果不含 video_uri / 缩略图时清空旧值，避免指向过期 URI / 已删除文件。
-    返回是否找到该 unit。
+    剧本不含 video_units 或 unit 不存在时抛 KeyError——写回失败必须让调用方可见，
+    finalize 不能在剧本未更新时静默成功；还原侧的跨集同步把 KeyError 当正常跳过。
     """
     units = script.get("video_units")
     if not isinstance(units, list):
-        return False
+        raise KeyError("video_units")
     for u in units:
         if not isinstance(u, dict) or u.get("unit_id") != resource_id:
             continue
@@ -361,8 +362,8 @@ def apply_unit_video_assets(script: dict, resource_id: str, *, video_uri: str | 
         else:
             ga.pop("video_thumbnail", None)
         ga["status"] = "completed"
-        return True
-    return False
+        return
+    raise KeyError(resource_id)
 
 
 async def _finalize_reference_video_unit(

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -24,6 +24,7 @@ from lib.reference_video import assemble_shots_text, render_prompt_for_backend
 from lib.reference_video.errors import MissingReferenceError, RequestPayloadTooLargeError
 from lib.script_models import ReferenceResource
 from lib.thumbnail import extract_video_thumbnail
+from lib.version_manager import VersionManager
 from server.services.generation_tasks import assert_duration_supported, get_media_generator, get_project_manager
 
 logger = logging.getLogger(__name__)
@@ -331,9 +332,37 @@ async def execute_reference_video_task(
         output_path=output_path,
         version=version,
         video_uri=video_uri,
-        generator=generator,
+        versions=generator.versions,
         warnings=warnings,
     )
+
+
+def apply_unit_video_assets(script: dict, resource_id: str, *, video_uri: str | None, thumb_rel: str | None) -> bool:
+    """在剧本 dict 上写回 unit.generated_assets（video_clip / video_uri / video_thumbnail / status）。
+
+    生成 finalize 与版本还原共用，保证两条路径写出的字段口径一致。
+    新结果不含 video_uri / 缩略图时清空旧值，避免指向过期 URI / 已删除文件。
+    返回是否找到该 unit。
+    """
+    units = script.get("video_units")
+    if not isinstance(units, list):
+        return False
+    for u in units:
+        if not isinstance(u, dict) or u.get("unit_id") != resource_id:
+            continue
+        ga = u.setdefault("generated_assets", {})
+        ga["video_clip"] = f"reference_videos/{resource_id}.mp4"
+        if video_uri:
+            ga["video_uri"] = video_uri
+        else:
+            ga.pop("video_uri", None)
+        if thumb_rel:
+            ga["video_thumbnail"] = thumb_rel
+        else:
+            ga.pop("video_thumbnail", None)
+        ga["status"] = "completed"
+        return True
+    return False
 
 
 async def _finalize_reference_video_unit(
@@ -345,7 +374,7 @@ async def _finalize_reference_video_unit(
     output_path: Path,
     version: int,
     video_uri: str | None,
-    generator: Any,
+    versions: VersionManager,
     warnings: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Normal + resume 共用：抽缩略图、写 unit.generated_assets、返回 result dict。"""
@@ -364,30 +393,16 @@ async def _finalize_reference_video_unit(
         pm = get_project_manager()
         # 资产回写热路径：只动 unit.generated_assets，结构不可能因此变坏，豁免结构校验。
         with pm.locked_script(project_name, script_file, validate=False) as script:
-            for u in script.get("video_units") or []:
-                if u.get("unit_id") == resource_id:
-                    ga = u.setdefault("generated_assets", {})
-                    ga["video_clip"] = f"reference_videos/{resource_id}.mp4"
-                    # 重跑时若新结果不含 video_uri / 缩略图，清空旧值，避免指向过期 URI / 已删除文件
-                    if video_uri:
-                        ga["video_uri"] = video_uri
-                    else:
-                        ga.pop("video_uri", None)
-                    if thumb_rel:
-                        ga["video_thumbnail"] = thumb_rel
-                    else:
-                        ga.pop("video_thumbnail", None)
-                    ga["status"] = "completed"
-                    break
+            apply_unit_video_assets(script, resource_id, video_uri=video_uri, thumb_rel=thumb_rel)
 
     await asyncio.to_thread(_update_unit_assets)
 
     def _latest_created_at() -> str | None:
-        history = generator.versions.get_versions("reference_videos", resource_id) or {}
-        versions = history.get("versions") or []
-        if not versions:
+        history = versions.get_versions("reference_videos", resource_id) or {}
+        records = history.get("versions") or []
+        if not records:
             return None
-        return versions[-1].get("created_at")
+        return records[-1].get("created_at")
 
     created_at = await asyncio.to_thread(_latest_created_at)
 

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -354,6 +354,8 @@ def apply_unit_video_assets(script: dict, resource_id: str, *, video_uri: str | 
         if not isinstance(u, dict) or u.get("unit_id") != resource_id:
             continue
         ga = u.setdefault("generated_assets", {})
+        if not isinstance(ga, dict):
+            raise ScriptEditError("generated_assets 必须是 dict")
         ga["video_clip"] = f"reference_videos/{resource_id}.mp4"
         if video_uri:
             ga["video_uri"] = video_uri

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -126,7 +126,7 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
                 output_path=output_path,
                 version=version,
                 video_uri=video_uri,
-                generator=generator,
+                versions=generator.versions,
             )
         else:
             result = await _finalize_video_task(

--- a/server/services/upload_finalize.py
+++ b/server/services/upload_finalize.py
@@ -1,0 +1,184 @@
+"""用户自主上传分镜图/视频的 finalize 服务层。
+
+复用生成链路的元数据回写、缩略图与版本记录原语，让上传产出的资产
+在状态推导、SSE 刷新、版本回滚上与 AI 生成的资产行为一致。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from typing import BinaryIO, Literal
+
+from lib.thumbnail import extract_video_thumbnail
+from lib.version_manager import VersionManager
+from server.services.generation_tasks import get_project_manager
+
+# 版本记录里标记「用户手动上传」的 source 值；前端按此显示翻译文案
+UPLOAD_VERSION_SOURCE = "manual_upload"
+
+# 上传策略（shot_uploads 与 reference_videos 两个路由共用，避免口径漂移）。
+# 视频宽松校验：只看扩展名与大小上限，宽高比/时长不阻塞——用户自主上传即自己负责。
+UPLOAD_IMAGE_EXTENSIONS: tuple[str, ...] = (".png", ".jpg", ".jpeg", ".webp")
+UPLOAD_VIDEO_EXTENSIONS: tuple[str, ...] = (".mp4", ".mov", ".webm", ".m4v")
+UPLOAD_IMAGE_MAX_BYTES = 30 * 1024 * 1024
+UPLOAD_VIDEO_MAX_BYTES = 200 * 1024 * 1024
+
+_COPY_CHUNK_SIZE = 1024 * 1024
+
+
+class UploadValidationError(Exception):
+    """上传校验失败。路由层按 (status_code, key, params) 翻译为 HTTP 响应。"""
+
+    def __init__(self, key: str, *, status_code: int = 400, **params: object):
+        super().__init__(key)
+        self.key = key
+        self.status_code = status_code
+        self.params = params
+
+
+class UploadTooLargeError(UploadValidationError):
+    """上传字节数超过上限。"""
+
+    def __init__(self, max_bytes: int):
+        super().__init__("upload_too_large", status_code=413, max_mb=max_bytes // (1024 * 1024))
+        self.max_bytes = max_bytes
+
+
+def validate_upload(filename: str | None, declared_size: int | None, *, kind: Literal["image", "video"]) -> int:
+    """按上传策略校验文件名扩展名与申报大小，返回该类型的字节上限。
+
+    declared_size 只做 Content-Length 预拒；实际写入字节数由落盘函数兜底。
+    """
+    if kind == "image":
+        extensions, max_bytes = UPLOAD_IMAGE_EXTENSIONS, UPLOAD_IMAGE_MAX_BYTES
+        type_error_key = "unsupported_image_type"
+    else:
+        extensions, max_bytes = UPLOAD_VIDEO_EXTENSIONS, UPLOAD_VIDEO_MAX_BYTES
+        type_error_key = "unsupported_video_type"
+
+    if not filename:
+        raise UploadValidationError("missing_filename")
+    ext = Path(filename).suffix.lower()
+    if ext not in extensions:
+        raise UploadValidationError(type_error_key, ext=ext, allowed=", ".join(extensions))
+    if declared_size is not None and declared_size > max_bytes:
+        raise UploadTooLargeError(max_bytes)
+    return max_bytes
+
+
+def _upload_tmp_path(target: Path) -> Path:
+    """同目录 dot-tmp 路径，带每次调用唯一的后缀，避免并发上传交错写同一 tmp 文件。"""
+    return target.with_name(f".{target.stem}.{uuid.uuid4().hex[:8]}.tmp{target.suffix}")
+
+
+def _copy_limited(src: BinaryIO, dst_path: Path, max_bytes: int) -> None:
+    total = 0
+    with open(dst_path, "wb") as out:
+        while True:
+            chunk = src.read(_COPY_CHUNK_SIZE)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > max_bytes:
+                raise UploadTooLargeError(max_bytes)
+            out.write(chunk)
+
+
+async def save_uploaded_video_stream(src: BinaryIO, target: Path, *, max_bytes: int) -> None:
+    """把上传流分块写入 target（不整体读入内存）。
+
+    先写同目录 dot-tmp 再 ``Path.replace``：跨卷 rename 在 Windows 会失败，
+    且避免半截文件被 canonical 路径的读取方看到。超限抛 UploadTooLargeError。
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = _upload_tmp_path(target)
+    try:
+        await asyncio.to_thread(_copy_limited, src, tmp_path, max_bytes)
+        await asyncio.to_thread(tmp_path.replace, target)
+    except BaseException:
+        await asyncio.to_thread(tmp_path.unlink, True)
+        raise
+
+
+async def save_uploaded_bytes(content: bytes, target: Path) -> None:
+    """把内存中的上传内容原子写入 target（同 dot-tmp + replace + 失败清理）。"""
+
+    def _write() -> None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = _upload_tmp_path(target)
+        try:
+            tmp_path.write_bytes(content)
+            tmp_path.replace(target)
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)
+            raise
+
+    await asyncio.to_thread(_write)
+
+
+def record_upload_version(
+    *,
+    versions: VersionManager,
+    resource_type: str,
+    resource_id: str,
+    current_file: Path,
+    original_filename: str | None,
+) -> int:
+    """把刚写入 canonical 路径的上传文件登记为新版本，返回版本号。
+
+    调用方须在覆写 canonical 文件**之前**先调 ``ensure_current_tracked``
+    补登旧文件（镜像 MediaGenerator 的版本顺序），否则旧版本字节会丢失。
+    """
+    metadata: dict[str, str] = {"source": UPLOAD_VERSION_SOURCE}
+    if original_filename:
+        metadata["original_filename"] = original_filename
+    return versions.add_version(
+        resource_type=resource_type,
+        resource_id=resource_id,
+        prompt="",
+        source_file=current_file,
+        **metadata,
+    )
+
+
+async def finalize_shot_storyboard_upload(
+    *, project_name: str, script_file: str, shot_id: str, asset_path: str
+) -> None:
+    """分镜图上传后的剧本元数据回写（status 由 update_scene_status 自动推导）。"""
+    await asyncio.to_thread(
+        get_project_manager().update_scene_asset,
+        project_name=project_name,
+        script_filename=script_file,
+        scene_id=shot_id,
+        asset_type="storyboard_image",
+        asset_path=asset_path,
+    )
+
+
+async def finalize_shot_video_upload(
+    *, project_name: str, script_file: str, shot_id: str, project_path: Path, video_rel: str
+) -> None:
+    """镜头视频上传后的 finalize：抽缩略图 + 单次锁内回写 video_clip / video_uri / video_thumbnail。
+
+    旧 video_uri 指向上一次生成的 provider 端产物，与本地新文件不再对应，必须清空。
+    """
+    video_file = project_path / video_rel
+    thumbnail_file = project_path / "thumbnails" / f"scene_{shot_id}.jpg"
+    if await extract_video_thumbnail(video_file, thumbnail_file):
+        thumb_rel: str | None = f"thumbnails/scene_{shot_id}.jpg"
+    else:
+        thumbnail_file.unlink(missing_ok=True)
+        thumb_rel = None
+
+    await asyncio.to_thread(
+        get_project_manager().batch_update_scene_assets,
+        project_name=project_name,
+        script_filename=script_file,
+        updates=[
+            (shot_id, "video_clip", video_rel),
+            (shot_id, "video_uri", None),
+            (shot_id, "video_thumbnail", thumb_rel),
+        ],
+    )

--- a/server/services/upload_finalize.py
+++ b/server/services/upload_finalize.py
@@ -21,7 +21,9 @@ UPLOAD_VERSION_SOURCE = "manual_upload"
 # 上传策略（shot_uploads 与 reference_videos 两个路由共用，避免口径漂移）。
 # 视频宽松校验：只看扩展名与大小上限，宽高比/时长不阻塞——用户自主上传即自己负责。
 UPLOAD_IMAGE_EXTENSIONS: tuple[str, ...] = (".png", ".jpg", ".jpeg", ".webp")
-UPLOAD_VIDEO_EXTENSIONS: tuple[str, ...] = (".mp4", ".mov", ".webm", ".m4v")
+# 不收 webm：字节原样存为 canonical .mp4，VP8/VP9 在 Safari/剪映一侧解码不可用，
+# 错误扩展名还会误导排查；mp4/mov/m4v 同属 ISO BMFF 容器家族
+UPLOAD_VIDEO_EXTENSIONS: tuple[str, ...] = (".mp4", ".mov", ".m4v")
 UPLOAD_IMAGE_MAX_BYTES = 30 * 1024 * 1024
 UPLOAD_VIDEO_MAX_BYTES = 200 * 1024 * 1024
 

--- a/server/services/upload_finalize.py
+++ b/server/services/upload_finalize.py
@@ -98,7 +98,7 @@ async def save_uploaded_video_stream(src: BinaryIO, target: Path, *, max_bytes: 
         await asyncio.to_thread(_copy_limited, src, tmp_path, max_bytes)
         await asyncio.to_thread(tmp_path.replace, target)
     except BaseException:
-        await asyncio.to_thread(tmp_path.unlink, True)
+        await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
         raise
 
 

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -1147,6 +1147,13 @@ def test_apply_unit_video_assets_distinguishes_failures():
         apply_unit_video_assets({"video_units": "broken"}, "E1U1", video_uri=None, thumb_rel=None)
     with pytest.raises(ScriptEditError):
         apply_unit_video_assets({}, "E1U1", video_uri=None, thumb_rel=None)
+    with pytest.raises(ScriptEditError):
+        apply_unit_video_assets(
+            {"video_units": [{"unit_id": "E1U1", "generated_assets": "broken"}]},
+            "E1U1",
+            video_uri=None,
+            thumb_rel=None,
+        )
     with pytest.raises(KeyError):
         apply_unit_video_assets({"video_units": []}, "E1U1", video_uri=None, thumb_rel=None)
 

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -1136,3 +1136,24 @@ async def test_execute_reference_video_task_rejects_unsupported_duration(
         )
     # 守卫在调用 backend 前拦下：generate_video_async 不应被调用
     fake_generator.generate_video_async.assert_not_called()
+
+
+def test_apply_unit_video_assets_distinguishes_failures():
+    """结构损坏与 unit 不存在抛不同异常：还原侧据此区分「脏脚本告警」与「正常跳过」。"""
+    from lib.script_editor import ScriptEditError
+    from server.services.reference_video_tasks import apply_unit_video_assets
+
+    with pytest.raises(ScriptEditError):
+        apply_unit_video_assets({"video_units": "broken"}, "E1U1", video_uri=None, thumb_rel=None)
+    with pytest.raises(ScriptEditError):
+        apply_unit_video_assets({}, "E1U1", video_uri=None, thumb_rel=None)
+    with pytest.raises(KeyError):
+        apply_unit_video_assets({"video_units": []}, "E1U1", video_uri=None, thumb_rel=None)
+
+    script = {"video_units": [{"unit_id": "E1U1", "generated_assets": {"video_uri": "https://old"}}]}
+    apply_unit_video_assets(script, "E1U1", video_uri=None, thumb_rel="reference_videos/thumbnails/E1U1.jpg")
+    ga = script["video_units"][0]["generated_assets"]
+    assert ga["video_clip"] == "reference_videos/E1U1.mp4"
+    assert "video_uri" not in ga
+    assert ga["video_thumbnail"] == "reference_videos/thumbnails/E1U1.jpg"
+    assert ga["status"] == "completed"

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -83,6 +83,21 @@ def _write_project(tmp_path: Path) -> Path:
     return proj_dir
 
 
+def _wire_locked_script(fake_pm: MagicMock) -> None:
+    """让 fake_pm.locked_script 产出磁盘上的真实剧本 dict。
+
+    finalize 写回 unit 资产时会在剧本中查找 unit 并在缺失时抛 KeyError，
+    裸 MagicMock 的 script.get("video_units") 不是 list 会直接炸。
+    """
+    proj_dir = fake_pm.get_project_path.return_value
+
+    @contextmanager
+    def _locked(_name, script_file, *, validate=True):
+        yield json.loads((proj_dir / script_file).read_text(encoding="utf-8"))
+
+    fake_pm.locked_script.side_effect = _locked
+
+
 def test_resolve_unit_references_maps_sheets(tmp_path: Path):
     proj_dir = _write_project(tmp_path)
     project, unit = _load_project_and_unit(proj_dir, "E1U1")
@@ -271,6 +286,7 @@ async def test_execute_reference_video_task_success(tmp_path: Path, monkeypatch:
         return json.loads((proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8"))
 
     fake_pm.load_script.side_effect = fake_load_script
+    _wire_locked_script(fake_pm)
     monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
 
     # Mock generator.generate_video_async: 创建伪视频文件
@@ -404,6 +420,7 @@ async def test_execute_reference_video_task_grok_uses_provider_default_resolutio
     fake_pm.load_script.side_effect = lambda *_a: json.loads(
         (proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8")
     )
+    _wire_locked_script(fake_pm)
     monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
 
     captured: dict = {}
@@ -467,6 +484,7 @@ async def test_execute_reference_video_task_respects_project_model_settings_reso
     fake_pm.load_script.side_effect = lambda *_a: json.loads(
         (proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8")
     )
+    _wire_locked_script(fake_pm)
     monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
 
     captured: dict = {}
@@ -519,6 +537,7 @@ async def test_execute_reference_video_task_missing_reference_fails(tmp_path: Pa
     fake_pm.load_script.side_effect = lambda *_a: json.loads(
         (proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8")
     )
+    _wire_locked_script(fake_pm)
     monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
 
     with pytest.raises(MissingReferenceError):
@@ -550,6 +569,7 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
     fake_pm.load_script.side_effect = lambda *_a: json.loads(
         (proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8")
     )
+    _wire_locked_script(fake_pm)
     monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
 
     # 只 mock 最外层：VideoBackend（唯一的真外部依赖）+ UsageTracker/ConfigResolver
@@ -647,6 +667,7 @@ async def test_execute_reference_video_task_payload_too_large_retries(tmp_path: 
     fake_pm.load_script.side_effect = lambda *_a: json.loads(
         (proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8")
     )
+    _wire_locked_script(fake_pm)
     monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
 
     call_count = {"n": 0}
@@ -715,6 +736,7 @@ async def test_execute_reference_video_task_clamps_via_resolver(
     fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
     fake_pm.get_project_path.return_value = proj_dir
     fake_pm.load_script.side_effect = lambda *_a: json.loads(script_path.read_text(encoding="utf-8"))
+    _wire_locked_script(fake_pm)
     monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
 
     captured: dict = {}
@@ -816,6 +838,7 @@ async def test_execute_reference_video_task_prompt_matches_clipped_refs(
     fake_pm.load_project.return_value = json.loads(project_path.read_text(encoding="utf-8"))
     fake_pm.get_project_path.return_value = proj_dir
     fake_pm.load_script.side_effect = lambda *_a: json.loads(script_path.read_text(encoding="utf-8"))
+    _wire_locked_script(fake_pm)
     monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
 
     captured: dict = {}
@@ -914,6 +937,7 @@ async def test_gemini_model_settings_read_via_composite_key(
     fake_pm.load_script.side_effect = lambda *_a: json.loads(
         (proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8")
     )
+    _wire_locked_script(fake_pm)
     monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
 
     captured: dict = {}
@@ -979,6 +1003,7 @@ async def test_execute_reference_video_task_skips_clamp_when_backend_model_diver
     fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
     fake_pm.get_project_path.return_value = proj_dir
     fake_pm.load_script.side_effect = lambda *_a: json.loads(script_path.read_text(encoding="utf-8"))
+    _wire_locked_script(fake_pm)
     monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
 
     captured: dict = {}
@@ -1064,6 +1089,7 @@ async def test_execute_reference_video_task_rejects_unsupported_duration(
     fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
     fake_pm.get_project_path.return_value = proj_dir
     fake_pm.load_script.side_effect = lambda *_a: json.loads(script_path.read_text(encoding="utf-8"))
+    _wire_locked_script(fake_pm)
     monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
 
     async def _fake_generate_video_async(**kwargs):

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -119,12 +119,12 @@ class TestFilesRouter:
             assert clue.status_code == 200
             assert clue.json()["path"] == "props/玉佩.jpg"
 
-            storyboard = client.post(
+            # 分镜/视频上传走 shot_uploads 路由，通用上传不再支持 storyboard 类型
+            legacy_storyboard = client.post(
                 "/api/v1/projects/demo/upload/storyboard?name=E1S01",
                 files={"file": ("storyboard.jpg", _img_bytes("JPEG"), "image/jpeg")},
             )
-            assert storyboard.status_code == 200
-            assert storyboard.json()["path"] == "storyboards/scene_E1S01.jpg"
+            assert legacy_storyboard.status_code == 400
 
             invalid_ext = client.post(
                 "/api/v1/projects/demo/upload/source",
@@ -248,13 +248,6 @@ class TestFilesRouter:
             )
             assert character_missing_entity.status_code == 200
             assert character_missing_entity.json()["path"] == "characters/不存在角色.jpg"
-
-            storyboard_no_name = client.post(
-                "/api/v1/projects/demo/upload/storyboard",
-                files={"file": ("board.jpg", _img_bytes("JPEG"), "image/jpeg")},
-            )
-            assert storyboard_no_name.status_code == 200
-            assert storyboard_no_name.json()["path"] == "storyboards/board.jpg"
 
     def test_source_decode_and_draft_mode_helpers(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -617,7 +617,7 @@ class TestGenerationTasks:
         assert isinstance(change["asset_fingerprints"]["storyboards/scene_E1S01.png"], int)
 
     def test_grid_fingerprints_include_split_cells(self, monkeypatch, tmp_path):
-        """宫格指纹应包含切割覆写的 canonical 分镜图，前端才能对其 cache-bust"""
+        """宫格指纹应包含切割覆写的 canonical 分镜图（cache-bust），但拒绝越出项目目录的路径"""
         from lib.grid.models import FrameCell, GridGeneration
         from lib.grid_manager import GridManager
 
@@ -626,6 +626,8 @@ class TestGenerationTasks:
         (project_path / "grids").mkdir()
         (project_path / "grids" / "grid_1.png").write_bytes(b"grid")
         (project_path / "storyboards" / "scene_E1S01.png").write_bytes(b"img")
+        outside = tmp_path / "outside.png"
+        outside.write_bytes(b"secret")
 
         grid = GridGeneration(
             id="grid_1",
@@ -645,7 +647,9 @@ class TestGenerationTasks:
                     next_scene_id="E1S01",
                     image_path="storyboards/scene_E1S01.png",
                 ),
-                FrameCell(index=1, row=0, col=1, frame_type="placeholder"),
+                FrameCell(index=1, row=0, col=1, frame_type="transition", image_path="../outside.png"),
+                FrameCell(index=2, row=1, col=0, frame_type="transition", image_path=str(outside)),
+                FrameCell(index=3, row=1, col=1, frame_type="placeholder"),
             ],
             status="completed",
             prompt=None,
@@ -663,6 +667,7 @@ class TestGenerationTasks:
 
         assert "grids/grid_1.png" in fps
         assert "storyboards/scene_E1S01.png" in fps
+        assert all("outside" not in key for key in fps)
 
     async def test_execute_task_validation_errors(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -244,10 +244,9 @@ class TestGenerationTasks:
         monkeypatch.setattr(
             generation_tasks,
             "emit_project_change_batch",
-            lambda project_name, changes, source="worker": emitted_batches.append(
+            lambda project_name, changes: emitted_batches.append(
                 {
                     "project_name": project_name,
-                    "source": source,
                     "changes": list(changes),
                 }
             ),
@@ -592,7 +591,7 @@ class TestGenerationTasks:
         monkeypatch.setattr(
             generation_tasks,
             "emit_project_change_batch",
-            lambda project_name, changes, source: captured.append(changes),
+            lambda project_name, changes: captured.append(changes),
         )
 
         project_path = tmp_path / "demo"

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -626,6 +626,7 @@ class TestGenerationTasks:
         (project_path / "grids").mkdir()
         (project_path / "grids" / "grid_1.png").write_bytes(b"grid")
         (project_path / "storyboards" / "scene_E1S01.png").write_bytes(b"img")
+        (project_path / "storyboards" / "scene_E1S02.png").write_bytes(b"img2")
         outside = tmp_path / "outside.png"
         outside.write_bytes(b"secret")
 
@@ -647,9 +648,16 @@ class TestGenerationTasks:
                     next_scene_id="E1S01",
                     image_path="storyboards/scene_E1S01.png",
                 ),
-                FrameCell(index=1, row=0, col=1, frame_type="transition", image_path="../outside.png"),
-                FrameCell(index=2, row=1, col=0, frame_type="transition", image_path=str(outside)),
-                FrameCell(index=3, row=1, col=1, frame_type="placeholder"),
+                FrameCell(
+                    index=1,
+                    row=0,
+                    col=1,
+                    frame_type="transition",
+                    # 项目内的绝对路径：允许纳入，但指纹 key 必须归一为相对路径
+                    image_path=str(project_path / "storyboards" / "scene_E1S02.png"),
+                ),
+                FrameCell(index=2, row=1, col=0, frame_type="transition", image_path="../outside.png"),
+                FrameCell(index=3, row=1, col=1, frame_type="transition", image_path=str(outside)),
             ],
             status="completed",
             prompt=None,
@@ -667,7 +675,9 @@ class TestGenerationTasks:
 
         assert "grids/grid_1.png" in fps
         assert "storyboards/scene_E1S01.png" in fps
+        assert "storyboards/scene_E1S02.png" in fps
         assert all("outside" not in key for key in fps)
+        assert all(not key.startswith("/") for key in fps)
 
     async def test_execute_task_validation_errors(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -616,6 +616,54 @@ class TestGenerationTasks:
         assert "storyboards/scene_E1S01.png" in change["asset_fingerprints"]
         assert isinstance(change["asset_fingerprints"]["storyboards/scene_E1S01.png"], int)
 
+    def test_grid_fingerprints_include_split_cells(self, monkeypatch, tmp_path):
+        """宫格指纹应包含切割覆写的 canonical 分镜图，前端才能对其 cache-bust"""
+        from lib.grid.models import FrameCell, GridGeneration
+        from lib.grid_manager import GridManager
+
+        project_path = tmp_path / "demo"
+        (project_path / "storyboards").mkdir(parents=True)
+        (project_path / "grids").mkdir()
+        (project_path / "grids" / "grid_1.png").write_bytes(b"grid")
+        (project_path / "storyboards" / "scene_E1S01.png").write_bytes(b"img")
+
+        grid = GridGeneration(
+            id="grid_1",
+            episode=1,
+            script_file="ep01.json",
+            scene_ids=["E1S01"],
+            grid_image_path="grids/grid_1.png",
+            rows=2,
+            cols=2,
+            cell_count=4,
+            frame_chain=[
+                FrameCell(
+                    index=0,
+                    row=0,
+                    col=0,
+                    frame_type="first",
+                    next_scene_id="E1S01",
+                    image_path="storyboards/scene_E1S01.png",
+                ),
+                FrameCell(index=1, row=0, col=1, frame_type="placeholder"),
+            ],
+            status="completed",
+            prompt=None,
+            provider="p",
+            model="m",
+            grid_size="2K",
+            created_at="2026-01-01T00:00:00Z",
+        )
+        GridManager(project_path).save(grid)
+
+        fake_pm = _FakePM(project_path)
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+
+        fps = generation_tasks.compute_affected_fingerprints("demo", "grid", "grid_1")
+
+        assert "grids/grid_1.png" in fps
+        assert "storyboards/scene_E1S01.png" in fps
+
     async def test_execute_task_validation_errors(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)

--- a/tests/test_grid_executor.py
+++ b/tests/test_grid_executor.py
@@ -234,6 +234,13 @@ class TestExecuteGridTask:
         assert updated_grid_data["status"] == "completed"
         assert updated_grid_data["grid_image_path"] == f"grids/{grid.id}.png"
 
+        # 切割写入 canonical 分镜路径须登记版本（先补登旧文件，覆写后记新版本），
+        # 否则版本面板的「当前版本」与磁盘内容脱节
+        assert mock_generator.versions.ensure_current_tracked.called
+        add_calls = mock_generator.versions.add_version.call_args_list
+        assert add_calls
+        assert all(c.kwargs["resource_type"] == "storyboards" and c.kwargs["source"] == "grid_split" for c in add_calls)
+
     async def test_execute_grid_task_writes_clean_filenames(self, project_with_script, grid_json):
         """切割后 cell 文件名为 scene_{id}.png（无 _first/_last 后缀），且不再更新 storyboard_last_image。"""
         from PIL import Image

--- a/tests/test_shot_uploads_router.py
+++ b/tests/test_shot_uploads_router.py
@@ -271,6 +271,13 @@ class TestShotVideoUpload:
             resp = _upload(client, "video", "clip.avi", b"\x00" * 16)
             assert resp.status_code == 400
 
+    def test_webm_rejected(self, tmp_path, monkeypatch):
+        """webm 明确不收：字节按 canonical .mp4 存储，VP8/VP9 在 Safari/剪映侧不可解码"""
+        client, _ = _client(monkeypatch, tmp_path)
+        with client:
+            resp = _upload(client, "video", "clip.webm", b"\x00" * 16)
+            assert resp.status_code == 400
+
     def test_oversized_upload_413(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         monkeypatch.setattr(upload_finalize, "UPLOAD_VIDEO_MAX_BYTES", 32)

--- a/tests/test_shot_uploads_router.py
+++ b/tests/test_shot_uploads_router.py
@@ -1,0 +1,426 @@
+"""镜头级分镜图/视频上传路由 + 参考单元视频上传端点测试。"""
+
+import asyncio
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from lib.project_change_hints import get_project_change_source
+from lib.project_manager import ProjectManager
+from lib.version_manager import VersionManager
+from server.auth import CurrentUserInfo, get_current_user
+from server.routers import reference_videos, shot_uploads
+from server.services import generation_tasks, reference_video_tasks, upload_finalize
+
+
+def _img_bytes(fmt="JPEG", size=(8, 8)):
+    image = Image.new("RGB", size, (255, 0, 0))
+    buf = BytesIO()
+    image.save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def _seed_shot_project(tmp_path) -> ProjectManager:
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+    pm.save_script(
+        "demo",
+        {
+            "episode": 1,
+            "title": "E1",
+            "content_mode": "narration",
+            "segments": [
+                {
+                    "segment_id": "E1S01",
+                    "novel_text": "t",
+                    "duration_seconds": 5,
+                    "generated_assets": {
+                        "storyboard_image": None,
+                        "video_clip": None,
+                        "video_uri": None,
+                        "video_thumbnail": None,
+                        "grid_id": None,
+                        "grid_cell_index": None,
+                        "status": "pending",
+                    },
+                },
+            ],
+        },
+        "episode_1.json",
+        validate=False,
+    )
+    return pm
+
+
+def _client(monkeypatch, tmp_path):
+    pm = _seed_shot_project(tmp_path)
+    monkeypatch.setattr(shot_uploads, "get_project_manager", lambda: pm)
+    monkeypatch.setattr(upload_finalize, "get_project_manager", lambda: pm)
+    monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
+
+    app = FastAPI()
+    app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+    app.include_router(shot_uploads.router, prefix="/api/v1")
+    return TestClient(app), pm
+
+
+def _upload(client, kind: str, filename: str, content: bytes, shot_id="E1S01", script_file="episode_1.json"):
+    return client.post(
+        f"/api/v1/projects/demo/shots/{shot_id}/upload/{kind}?script_file={script_file}",
+        files={"file": (filename, BytesIO(content), "application/octet-stream")},
+    )
+
+
+class TestShotStoryboardUpload:
+    def test_upload_updates_metadata_versions_and_fingerprints(self, tmp_path, monkeypatch):
+        client, pm = _client(monkeypatch, tmp_path)
+        with client:
+            resp = _upload(client, "storyboard", "board.jpg", _img_bytes("JPEG"))
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["path"] == "storyboards/scene_E1S01.png"
+            assert body["version"] == 1
+            assert "storyboards/scene_E1S01.png" in body["asset_fingerprints"]
+
+        # 元数据回写 + status 自动推导
+        script = pm.load_script("demo", "episode_1.json")
+        ga = script["segments"][0]["generated_assets"]
+        assert ga["storyboard_image"] == "storyboards/scene_E1S01.png"
+        assert ga["status"] == "storyboard_ready"
+
+        # JPEG 入参也统一落盘为 PNG（canonical 扩展名）
+        target = pm.get_project_path("demo") / "storyboards" / "scene_E1S01.png"
+        with Image.open(target) as img:
+            assert img.format == "PNG"
+
+        # 版本记录带 manual_upload 来源标记
+        vm = VersionManager(pm.get_project_path("demo"))
+        info = vm.get_versions("storyboards", "E1S01")
+        assert info["current_version"] == 1
+        assert info["versions"][0]["source"] == "manual_upload"
+        assert info["versions"][0]["prompt"] == ""
+        assert info["versions"][0]["original_filename"] == "board.jpg"
+
+    def test_upload_backfills_untracked_existing_file(self, tmp_path, monkeypatch):
+        """磁盘已有旧分镜但无版本记录：上传前补登旧文件，旧字节不丢失。"""
+        client, pm = _client(monkeypatch, tmp_path)
+        project_path = pm.get_project_path("demo")
+        old = project_path / "storyboards" / "scene_E1S01.png"
+        old.parent.mkdir(parents=True, exist_ok=True)
+        old.write_bytes(_img_bytes("PNG"))
+
+        with client:
+            resp = _upload(client, "storyboard", "new.png", _img_bytes("PNG", size=(16, 16)))
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["version"] == 2
+
+        vm = VersionManager(project_path)
+        info = vm.get_versions("storyboards", "E1S01")
+        assert info["current_version"] == 2
+        assert len(info["versions"]) == 2
+        assert info["versions"][0].get("source") is None  # 补登的旧文件
+        assert info["versions"][1]["source"] == "manual_upload"
+
+    def test_upload_resizes_long_edge(self, tmp_path, monkeypatch):
+        client, pm = _client(monkeypatch, tmp_path)
+        with client:
+            resp = _upload(client, "storyboard", "big.jpg", _img_bytes("JPEG", size=(4096, 2048)))
+            assert resp.status_code == 200, resp.text
+
+        target = pm.get_project_path("demo") / "storyboards" / "scene_E1S01.png"
+        with Image.open(target) as img:
+            assert max(img.size) <= 2048
+
+    def test_grid_fields_untouched(self, tmp_path, monkeypatch):
+        """宫格模式按镜头上传单元格图：grid_id / grid_cell_index 保持不变。"""
+        client, pm = _client(monkeypatch, tmp_path)
+        pm.update_scene_asset("demo", "episode_1.json", "E1S01", "grid_id", "grid_abc")
+        pm.update_scene_asset("demo", "episode_1.json", "E1S01", "grid_cell_index", 2)
+
+        with client:
+            resp = _upload(client, "storyboard", "cell.png", _img_bytes("PNG"))
+            assert resp.status_code == 200, resp.text
+
+        ga = pm.load_script("demo", "episode_1.json")["segments"][0]["generated_assets"]
+        assert ga["grid_id"] == "grid_abc"
+        assert ga["grid_cell_index"] == 2
+        assert ga["storyboard_image"] == "storyboards/scene_E1S01.png"
+
+    def test_invalid_image_rejected(self, tmp_path, monkeypatch):
+        client, _ = _client(monkeypatch, tmp_path)
+        with client:
+            resp = _upload(client, "storyboard", "bad.png", b"not-an-image")
+            assert resp.status_code == 400
+
+    def test_bad_extension_rejected(self, tmp_path, monkeypatch):
+        client, _ = _client(monkeypatch, tmp_path)
+        with client:
+            resp = _upload(client, "storyboard", "anim.gif", b"gif")
+            assert resp.status_code == 400
+
+    def test_unknown_shot_404(self, tmp_path, monkeypatch):
+        client, _ = _client(monkeypatch, tmp_path)
+        with client:
+            resp = _upload(client, "storyboard", "x.png", _img_bytes("PNG"), shot_id="E9S99")
+            assert resp.status_code == 404
+
+    def test_reference_script_guarded_404(self, tmp_path, monkeypatch):
+        """reference_video 剧本无分镜概念，镜头上传一律 404。"""
+        client, pm = _client(monkeypatch, tmp_path)
+        pm.save_script(
+            "demo",
+            {
+                "episode": 2,
+                "title": "E2",
+                "content_mode": "narration",
+                "generation_mode": "reference_video",
+                "video_units": [{"unit_id": "E2U1", "generated_assets": {"status": "pending"}}],
+            },
+            "episode_2.json",
+            validate=False,
+        )
+        with client:
+            resp = _upload(
+                client, "storyboard", "x.png", _img_bytes("PNG"), shot_id="E2U1", script_file="episode_2.json"
+            )
+            assert resp.status_code == 404
+
+    def test_emit_uses_webui_source(self, tmp_path, monkeypatch):
+        """emit 在 project_change_source("webui") 上下文内被调用（SSE source 由 contextvar 决定）。"""
+        client, _ = _client(monkeypatch, tmp_path)
+        calls: list[dict] = []
+
+        def _fake_emit(**kw):
+            calls.append({**kw, "resolved_source": get_project_change_source()})
+            return {}
+
+        monkeypatch.setattr(shot_uploads, "emit_generation_success_batch", _fake_emit)
+        with client:
+            resp = _upload(client, "storyboard", "x.png", _img_bytes("PNG"))
+            assert resp.status_code == 200
+
+        assert len(calls) == 1
+        assert calls[0]["resolved_source"] == "webui"
+        assert calls[0]["task_type"] == "storyboard"
+        assert calls[0]["payload"]["script_file"] == "episode_1.json"
+
+    def test_missing_script_404_does_not_leak_server_path(self, tmp_path, monkeypatch):
+        client, _ = _client(monkeypatch, tmp_path)
+        with client:
+            resp = _upload(client, "storyboard", "x.png", _img_bytes("PNG"), script_file="nope.json")
+            assert resp.status_code == 404
+            assert str(tmp_path) not in resp.json()["detail"]
+
+
+class TestShotVideoUpload:
+    def test_upload_finalizes_and_clears_stale_video_uri(self, tmp_path, monkeypatch):
+        client, pm = _client(monkeypatch, tmp_path)
+        pm.update_scene_asset("demo", "episode_1.json", "E1S01", "video_uri", "https://stale-provider-uri")
+
+        async def _fake_thumbnail(video_path: Path, thumbnail_path: Path):
+            thumbnail_path.parent.mkdir(parents=True, exist_ok=True)
+            thumbnail_path.write_bytes(b"jpg")
+            return thumbnail_path
+
+        monkeypatch.setattr(upload_finalize, "extract_video_thumbnail", _fake_thumbnail)
+
+        with client:
+            resp = _upload(client, "video", "clip.mp4", b"\x00" * 1024)
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["path"] == "videos/scene_E1S01.mp4"
+            assert body["version"] == 1
+            assert "videos/scene_E1S01.mp4" in body["asset_fingerprints"]
+            assert "thumbnails/scene_E1S01.jpg" in body["asset_fingerprints"]
+
+        ga = pm.load_script("demo", "episode_1.json")["segments"][0]["generated_assets"]
+        assert ga["video_clip"] == "videos/scene_E1S01.mp4"
+        assert ga["video_uri"] is None
+        assert ga["video_thumbnail"] == "thumbnails/scene_E1S01.jpg"
+        assert ga["status"] == "completed"
+
+        vm = VersionManager(pm.get_project_path("demo"))
+        info = vm.get_versions("videos", "E1S01")
+        assert info["versions"][0]["source"] == "manual_upload"
+
+    def test_thumbnail_failure_degrades_gracefully(self, tmp_path, monkeypatch):
+        client, pm = _client(monkeypatch, tmp_path)
+
+        async def _fail_thumbnail(video_path: Path, thumbnail_path: Path):
+            return None
+
+        monkeypatch.setattr(upload_finalize, "extract_video_thumbnail", _fail_thumbnail)
+
+        with client:
+            resp = _upload(client, "video", "clip.mp4", b"\x00" * 64)
+            assert resp.status_code == 200, resp.text
+
+        ga = pm.load_script("demo", "episode_1.json")["segments"][0]["generated_assets"]
+        assert ga["video_clip"] == "videos/scene_E1S01.mp4"
+        assert ga["video_thumbnail"] is None
+        assert ga["status"] == "completed"
+
+    def test_bad_extension_rejected(self, tmp_path, monkeypatch):
+        client, _ = _client(monkeypatch, tmp_path)
+        with client:
+            resp = _upload(client, "video", "clip.avi", b"\x00" * 16)
+            assert resp.status_code == 400
+
+    def test_oversized_upload_413(self, tmp_path, monkeypatch):
+        client, _ = _client(monkeypatch, tmp_path)
+        monkeypatch.setattr(upload_finalize, "UPLOAD_VIDEO_MAX_BYTES", 32)
+        with client:
+            resp = _upload(client, "video", "clip.mp4", b"\x00" * 64)
+            assert resp.status_code == 413
+
+
+class TestSaveUploadedVideoStream:
+    def test_oversize_raises_and_cleans_tmp(self, tmp_path):
+        target = tmp_path / "videos" / "scene_X.mp4"
+        with pytest.raises(upload_finalize.UploadTooLargeError):
+            asyncio.run(upload_finalize.save_uploaded_video_stream(BytesIO(b"\x00" * 64), target, max_bytes=16))
+        assert not target.exists()
+        assert list(target.parent.iterdir()) == []  # dot-tmp 已清理
+
+    def test_writes_via_tmp_then_replace(self, tmp_path):
+        target = tmp_path / "videos" / "scene_X.mp4"
+        asyncio.run(upload_finalize.save_uploaded_video_stream(BytesIO(b"abc"), target, max_bytes=16))
+        assert target.read_bytes() == b"abc"
+        assert list(target.parent.iterdir()) == [target]
+
+    def test_tmp_paths_unique_per_call(self, tmp_path):
+        """tmp 文件名每次调用唯一：并发上传同一目标不会交错写同一个 tmp 文件。"""
+        target = tmp_path / "videos" / "scene_X.mp4"
+        assert upload_finalize._upload_tmp_path(target) != upload_finalize._upload_tmp_path(target)
+
+
+# ==================== 参考单元视频上传 ====================
+
+
+def _seed_reference_project(tmp_path) -> ProjectManager:
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+    project = pm.load_project("demo")
+    project["generation_mode"] = "reference_video"
+    project["episodes"] = [{"episode": 1, "title": "E1", "script_file": "scripts/episode_1.json"}]
+    pm.save_project("demo", project)
+    pm.save_script(
+        "demo",
+        {
+            "episode": 1,
+            "title": "E1",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "video_units": [
+                {
+                    "unit_id": "E1U1",
+                    "shots": [{"duration": 4, "text": "t"}],
+                    "references": [],
+                    "duration_seconds": 4,
+                    "generated_assets": {
+                        "video_clip": None,
+                        "video_uri": "https://stale",
+                        "status": "pending",
+                    },
+                }
+            ],
+        },
+        "episode_1.json",
+        validate=False,
+    )
+    return pm
+
+
+def _ref_client(monkeypatch, tmp_path):
+    pm = _seed_reference_project(tmp_path)
+    monkeypatch.setattr(reference_videos, "get_project_manager", lambda: pm)
+    monkeypatch.setattr(reference_video_tasks, "get_project_manager", lambda: pm)
+    monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
+
+    async def _fake_thumbnail(video_path: Path, thumbnail_path: Path):
+        thumbnail_path.parent.mkdir(parents=True, exist_ok=True)
+        thumbnail_path.write_bytes(b"jpg")
+        return thumbnail_path
+
+    monkeypatch.setattr(reference_video_tasks, "extract_video_thumbnail", _fake_thumbnail)
+
+    app = FastAPI()
+    app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+    app.include_router(reference_videos.router, prefix="/api/v1")
+    return TestClient(app), pm
+
+
+def _upload_unit(client, unit_id="E1U1", filename="clip.mp4", content=b"\x00" * 256, episode=1):
+    return client.post(
+        f"/api/v1/projects/demo/reference-videos/episodes/{episode}/units/{unit_id}/upload-video",
+        files={"file": (filename, BytesIO(content), "application/octet-stream")},
+    )
+
+
+class TestReferenceUnitVideoUpload:
+    def test_upload_finalizes_unit(self, tmp_path, monkeypatch):
+        client, pm = _ref_client(monkeypatch, tmp_path)
+        with client:
+            resp = _upload_unit(client)
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["path"] == "reference_videos/E1U1.mp4"
+            assert body["version"] == 1
+            assert "reference_videos/E1U1.mp4" in body["asset_fingerprints"]
+
+        ga = pm.load_script("demo", "episode_1.json")["video_units"][0]["generated_assets"]
+        assert ga["video_clip"] == "reference_videos/E1U1.mp4"
+        # 上传替换后旧 provider URI 不再对应本地文件，finalize 应清空
+        assert "video_uri" not in ga
+        assert ga["video_thumbnail"] == "reference_videos/thumbnails/E1U1.jpg"
+        assert ga["status"] == "completed"
+
+        vm = VersionManager(pm.get_project_path("demo"))
+        info = vm.get_versions("reference_videos", "E1U1")
+        assert info["current_version"] == 1
+        assert info["versions"][0]["source"] == "manual_upload"
+
+    def test_unit_not_found_404(self, tmp_path, monkeypatch):
+        client, _ = _ref_client(monkeypatch, tmp_path)
+        with client:
+            resp = _upload_unit(client, unit_id="E1U9")
+            assert resp.status_code == 404
+
+    def test_non_reference_mode_409(self, tmp_path, monkeypatch):
+        client, pm = _ref_client(monkeypatch, tmp_path)
+        project = pm.load_project("demo")
+        project["generation_mode"] = "storyboard"
+        pm.save_project("demo", project)
+        with client:
+            resp = _upload_unit(client)
+            assert resp.status_code == 409
+
+    def test_bad_extension_rejected(self, tmp_path, monkeypatch):
+        client, _ = _ref_client(monkeypatch, tmp_path)
+        with client:
+            resp = _upload_unit(client, filename="clip.avi")
+            assert resp.status_code == 400
+
+    def test_emit_uses_webui_source(self, tmp_path, monkeypatch):
+        """emit 在 project_change_source("webui") 上下文内被调用（SSE source 由 contextvar 决定）。"""
+        client, _ = _ref_client(monkeypatch, tmp_path)
+        calls: list[dict] = []
+
+        def _fake_emit(**kw):
+            calls.append({**kw, "resolved_source": get_project_change_source()})
+            return {}
+
+        monkeypatch.setattr(reference_videos, "emit_generation_success_batch", _fake_emit)
+        with client:
+            resp = _upload_unit(client)
+            assert resp.status_code == 200
+
+        assert len(calls) == 1
+        assert calls[0]["resolved_source"] == "webui"
+        assert calls[0]["task_type"] == "reference_video"

--- a/tests/test_versions_router.py
+++ b/tests/test_versions_router.py
@@ -129,11 +129,120 @@ class TestVersionsRouter:
             unsupported = client.post("/api/v1/projects/demo/versions/unknown/Alice/restore/1")
             assert unsupported.status_code == 400
 
-            # grids/reference_videos 是 VersionManager 合法类型，但本路由不放行其还原
+            # grids 是 VersionManager 合法类型，但本路由不放行其还原
             # （无还原后元数据同步分支），行为保持为 400——不因路径形状收敛而被静默放开。
-            for unrestorable in ("grids", "reference_videos"):
-                resp = client.post(f"/api/v1/projects/demo/versions/{unrestorable}/x/restore/1")
-                assert resp.status_code == 400
+            resp = client.post("/api/v1/projects/demo/versions/grids/x/restore/1")
+            assert resp.status_code == 400
+
+    def test_reference_video_restore_returns_thumbnail_fingerprint(self, tmp_path, monkeypatch):
+        """reference_videos 还原放行：清缩略图并以 fingerprint=0 通知前端失效。"""
+        from lib.project_manager import ProjectManager
+
+        real_pm = ProjectManager(tmp_path)
+        real_pm.create_project("demo")
+        real_pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+        real_pm.save_script(
+            "demo",
+            {
+                "episode": 1,
+                "title": "E1",
+                "content_mode": "narration",
+                "generation_mode": "reference_video",
+                "video_units": [
+                    {
+                        "unit_id": "E1U1",
+                        "generated_assets": {
+                            "video_clip": "reference_videos/E1U1.mp4",
+                            "video_uri": "https://stale",
+                            "video_thumbnail": "reference_videos/thumbnails/E1U1.jpg",
+                            "status": "completed",
+                        },
+                    }
+                ],
+            },
+            "episode_1.json",
+            validate=False,
+        )
+        project_path = real_pm.get_project_path("demo")
+        thumb = project_path / "reference_videos" / "thumbnails" / "E1U1.jpg"
+        thumb.parent.mkdir(parents=True, exist_ok=True)
+        thumb.write_bytes(b"jpg")
+
+        monkeypatch.setattr(versions, "get_project_manager", lambda: real_pm)
+        monkeypatch.setattr(versions, "get_version_manager", lambda project_name: _FakeVM())
+
+        app = FastAPI()
+        app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+        app.include_router(versions.router, prefix="/api/v1")
+        with TestClient(app) as client:
+            resp = client.post("/api/v1/projects/demo/versions/reference_videos/E1U1/restore/1")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["file_path"] == "reference_videos/E1U1.mp4"
+            assert body["asset_fingerprints"]["reference_videos/thumbnails/E1U1.jpg"] == 0
+
+        # 缩略图文件被删除；unit 元数据清掉过期 video_uri / video_thumbnail
+        assert not thumb.exists()
+        script = real_pm.load_script("demo", "episode_1.json")
+        ga = script["video_units"][0]["generated_assets"]
+        assert ga["video_clip"] == "reference_videos/E1U1.mp4"
+        assert "video_uri" not in ga
+        assert "video_thumbnail" not in ga
+        assert ga["status"] == "completed"
+
+    def test_video_restore_clears_stale_uri_and_thumbnail_metadata(self, tmp_path, monkeypatch):
+        """videos 还原同步剧本元数据：还原的是历史本地文件，过期 provider URI 与已删缩略图须清空。"""
+        from lib.project_manager import ProjectManager
+
+        real_pm = ProjectManager(tmp_path)
+        real_pm.create_project("demo")
+        real_pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+        real_pm.save_script(
+            "demo",
+            {
+                "episode": 1,
+                "title": "E1",
+                "content_mode": "narration",
+                "segments": [
+                    {
+                        "segment_id": "E1S01",
+                        "novel_text": "t",
+                        "duration_seconds": 5,
+                        "generated_assets": {
+                            "storyboard_image": "storyboards/scene_E1S01.png",
+                            "video_clip": "videos/scene_E1S01.mp4",
+                            "video_uri": "https://stale-provider-uri",
+                            "video_thumbnail": "thumbnails/scene_E1S01.jpg",
+                            "status": "completed",
+                        },
+                    }
+                ],
+            },
+            "episode_1.json",
+            validate=False,
+        )
+        project_path = real_pm.get_project_path("demo")
+        thumb = project_path / "thumbnails" / "scene_E1S01.jpg"
+        thumb.parent.mkdir(parents=True, exist_ok=True)
+        thumb.write_bytes(b"jpg")
+
+        monkeypatch.setattr(versions, "get_project_manager", lambda: real_pm)
+        monkeypatch.setattr(versions, "get_version_manager", lambda project_name: _FakeVM())
+
+        app = FastAPI()
+        app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+        app.include_router(versions.router, prefix="/api/v1")
+        with TestClient(app) as client:
+            resp = client.post("/api/v1/projects/demo/versions/videos/E1S01/restore/1")
+            assert resp.status_code == 200
+            assert resp.json()["asset_fingerprints"]["thumbnails/scene_E1S01.jpg"] == 0
+
+        assert not thumb.exists()
+        ga = real_pm.load_script("demo", "episode_1.json")["segments"][0]["generated_assets"]
+        assert ga["video_clip"] == "videos/scene_E1S01.mp4"
+        assert ga["video_uri"] is None
+        assert ga["video_thumbnail"] is None
+        assert ga["status"] == "completed"
 
     def test_resolve_resource_path_rejects_traversal(self):
         """resource_id 拼出的绝对路径若逃出项目目录，必须 400（路径遍历防护）。


### PR DESCRIPTION
## 概述

WebUI 支持手动上传媒体替换/补充 AI 生成结果，覆盖三种生成模式：

- **图生视频 / 宫格生视频**：按镜头上传分镜图（自动转 PNG、长边等比压缩）与镜头视频；宫格模式按镜头上传单元格图，`grid_id` / `grid_cell_index` 保持不变
- **参考生视频**：按单元上传成片视频，自动抽取缩略图、清空旧 provider URI

## 主要改动

- 新增 `POST /projects/{name}/shots/{shot_id}/upload/{kind}` 与参考单元 `upload-video` 端点；finalize 逻辑收敛到 `server/services/upload_finalize.py`
- 上传纳入版本管理（`source="manual_upload"`，版本面板显示来源并可回滚）；`reference_videos` 资源类型回滚链路打通，还原视频时同步清理过期 `video_uri` / `video_thumbnail`
- 上传后复用与生成完成一致的元数据更新、资产指纹 cache-bust 与 SSE 事件，多客户端即时刷新
- 校验与防护：扩展名白名单 + 大小上限（图 30MB / 视频 200MB）、路径越界守卫、唯一临时文件名原子写、404 响应不泄露服务器路径、上传期间双卡互斥禁用
- 顺带修复：宫格切割单元格补登版本记录；全量指纹扫描覆盖 `reference_videos` 目录；任务状态以最新行为准，持久化失败任务不再覆盖已有成片
- 前端抽取共享 `UploadIconButton` 组件与 `postFileUpload` helper；i18n 三语（zh/en/vi）同步补全

## 测试

- 后端：`uv run python -m pytest` 全量通过（3856 passed）；`basedpyright` 0 error；`ruff check` / `ruff format` 干净
- 前端：`pnpm lint` 干净；`pnpm check` 85 文件 638 测试全过
- 新增 `tests/test_shot_uploads_router.py`（元数据/版本/413/404/路径越界/tmp 唯一性）、`MediaCard.test.tsx` 上传交互用例，及 versions / grid executor / reference 路由回归用例

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 支持镜头/分镜与参考单元成片视频的主动上传，上传后生成版本并返回资产指纹以便刷新与 cache-bust。

* **UI**
  * 在媒体卡片、单元预览与镜头详情新增上传入口、上传中/禁用状态与成功/失败提示；版本面板新增“手动上传”来源文案。

* **Bug Fixes**
  * 防止旧任务覆盖重试后状态；上传后刷新与指纹计算更稳健。

* **Tests**
  * 扩展上传、恢复、版本、网格切割与错误场景的单元/集成测试覆盖。

* **Localization**
  * 新增多语言上传与错误提示文案。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->