### PR TITLE
fix: 资产名称不再允许包含 / 等路径字符，修复此类资产生成失败与 Web 端无法加载的问题

### DIFF
--- a/lib/asset_types.py
+++ b/lib/asset_types.py
@@ -73,3 +73,20 @@ ASSET_TYPES: frozenset[str] = frozenset(ASSET_SPECS.keys())
 BUCKET_KEY: dict[str, str] = {t: s.bucket_key for t, s in ASSET_SPECS.items()}
 
 SHEET_KEY: dict[str, str] = {t: s.sheet_field for t, s in ASSET_SPECS.items()}
+
+ILLEGAL_ASSET_NAME_CHARS: tuple[str, ...] = ("/", "\\", "\0")
+
+
+def validate_asset_name(name: object) -> str:
+    """校验并规范化（strip）资产名，非法时抛 ValueError，合法时返回 strip 后的名字。
+
+    资产名全链路被当作单段路径组件使用：文件名（``characters/{name}.png``、
+    ``versions/{type}/{name}_v{n}_{ts}.png``）与 REST 路由的单段路径参数。含路径
+    分隔符、空字节或 ``..`` 的名字会产生嵌套路径与无法匹配的 URL，须在创建入口拒绝。
+    """
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("资产名称不能为空或仅含空白字符")
+    cleaned = name.strip()
+    if ".." in cleaned or any(c in cleaned for c in ILLEGAL_ASSET_NAME_CHARS):
+        raise ValueError(f"资产名称 {cleaned!r} 含非法字符：不允许路径分隔符（/ \\）、空字节或 ..")
+    return cleaned

--- a/lib/asset_types.py
+++ b/lib/asset_types.py
@@ -74,7 +74,11 @@ BUCKET_KEY: dict[str, str] = {t: s.bucket_key for t, s in ASSET_SPECS.items()}
 
 SHEET_KEY: dict[str, str] = {t: s.sheet_field for t, s in ASSET_SPECS.items()}
 
-ILLEGAL_ASSET_NAME_CHARS: tuple[str, ...] = ("/", "\\", "\0")
+ILLEGAL_ASSET_NAME_CHARS: tuple[str, ...] = ("/", "\\", "\0", ":", "*", "?", '"', "<", ">", "|")
+
+WINDOWS_RESERVED_BASENAMES: frozenset[str] = frozenset(
+    {"CON", "PRN", "AUX", "NUL", *(f"COM{i}" for i in range(1, 10)), *(f"LPT{i}" for i in range(1, 10))}
+)
 
 
 def validate_asset_name(name: object) -> str:
@@ -82,11 +86,26 @@ def validate_asset_name(name: object) -> str:
 
     资产名全链路被当作单段路径组件使用：文件名（``characters/{name}.png``、
     ``versions/{type}/{name}_v{n}_{ts}.png``）与 REST 路由的单段路径参数。含路径
-    分隔符、空字节或 ``..`` 的名字会产生嵌套路径与无法匹配的 URL，须在创建入口拒绝。
+    分隔符、控制字符或 ``..`` 的名字会产生嵌套路径与无法匹配的 URL；Windows 还会
+    拒绝 ``: * ? " < > |``、尾随点与保留设备名（CON / COM1 等，按首个点段判定，
+    ``CON.backup`` 同样保留）。项目目录须可跨平台迁移，这些约束在所有平台统一执行，
+    并在创建入口拒绝。
     """
-    if not isinstance(name, str) or not name.strip():
-        raise ValueError("资产名称不能为空或仅含空白字符")
+    if not isinstance(name, str):
+        raise ValueError(f"资产名称必须是字符串，当前为 {type(name).__name__}")
     cleaned = name.strip()
-    if ".." in cleaned or any(c in cleaned for c in ILLEGAL_ASSET_NAME_CHARS):
-        raise ValueError(f"资产名称 {cleaned!r} 含非法字符：不允许路径分隔符（/ \\）、空字节或 ..")
+    if not cleaned:
+        raise ValueError("资产名称不能为空或仅含空白字符")
+    if (
+        ".." in cleaned
+        or any(c in cleaned for c in ILLEGAL_ASSET_NAME_CHARS)
+        or any(ord(c) < 32 or ord(c) == 127 for c in cleaned)
+    ):
+        raise ValueError(
+            f'资产名称 {cleaned!r} 含非法字符：不允许路径分隔符（/ \\）、Windows 保留字符（: * ? " < > |）、控制字符或 ..'
+        )
+    if cleaned.endswith("."):
+        raise ValueError(f"资产名称 {cleaned!r} 不能以点结尾（Windows 文件名约束）")
+    if cleaned.split(".", 1)[0].upper() in WINDOWS_RESERVED_BASENAMES:
+        raise ValueError(f"资产名称 {cleaned!r} 是 Windows 保留设备名（CON/PRN/AUX/NUL/COM1-9/LPT1-9）")
     return cleaned

--- a/lib/i18n/en/assets.py
+++ b/lib/i18n/en/assets.py
@@ -8,5 +8,5 @@ MESSAGES = {
     "asset_target_project_not_found": "Target project '{project}' does not exist",
     "asset_load_project_failed": "failed to load target project",
     "asset_invalid_conflict_policy": "conflict_policy must be skip / overwrite / rename",
-    "asset_invalid_name": "Asset name '{name}' contains illegal characters (path separators or ..)",
+    "asset_invalid_name": "Asset name '{name}' is invalid: characters like / \\ : * ? \" < > |, control characters, .., a trailing dot, or Windows reserved names (e.g. CON) are not allowed",
 }

--- a/lib/i18n/vi/assets.py
+++ b/lib/i18n/vi/assets.py
@@ -8,5 +8,5 @@ MESSAGES = {
     "asset_target_project_not_found": "Dự án đích '{project}' không tồn tại",
     "asset_load_project_failed": "Không tải được dự án đích",
     "asset_invalid_conflict_policy": "conflict_policy phải là skip / overwrite / rename",
-    "asset_invalid_name": "Tên tài nguyên '{name}' chứa ký tự không hợp lệ (ký tự phân tách đường dẫn hoặc ..)",
+    "asset_invalid_name": "Tên tài nguyên '{name}' không hợp lệ: không cho phép các ký tự như / \\ : * ? \" < > |, ký tự điều khiển, .., dấu chấm ở cuối hoặc tên dành riêng của Windows (ví dụ CON)",
 }

--- a/lib/i18n/zh/assets.py
+++ b/lib/i18n/zh/assets.py
@@ -8,5 +8,5 @@ MESSAGES = {
     "asset_target_project_not_found": "目标项目「{project}」不存在",
     "asset_load_project_failed": "加载目标项目失败",
     "asset_invalid_conflict_policy": "冲突策略必须为 skip / overwrite / rename",
-    "asset_invalid_name": "资产名「{name}」包含非法字符，不允许路径分隔符或 ..",
+    "asset_invalid_name": '资产名「{name}」无效：不允许 / \\ : * ? " < > | 等字符、控制字符、..、以点结尾或 Windows 保留名（如 CON）',
 }

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -22,7 +22,7 @@ import portalocker
 from pydantic import BaseModel, Field
 
 from lib.agent_profile import agent_profile_dir
-from lib.asset_types import ASSET_SPECS
+from lib.asset_types import ASSET_SPECS, validate_asset_name
 from lib.json_io import atomic_write_json, load_json, load_json_or_none
 from lib.profile_manifest import (
     VALID_CONTENT_MODES,
@@ -1607,6 +1607,7 @@ class ProjectManager:
         通过 update_project 在单一文件锁内完成 read-modify-write，避免并发新增时的
         lost-update 竞态。
         """
+        name = validate_asset_name(name)
         spec = ASSET_SPECS[asset_type]
         added = False
 
@@ -1630,6 +1631,7 @@ class ProjectManager:
         通过 update_project 在单一文件锁内完成 read-modify-write，避免并发批量新增时
         的 lost-update 竞态。
         """
+        entries = {validate_asset_name(name): entry for name, entry in entries.items()}
         spec = ASSET_SPECS[asset_type]
         added = 0
 
@@ -1676,16 +1678,18 @@ class ProjectManager:
             raise ValueError(f"entries 必须是对象（dict），当前为 {type(entries).__name__}")
         if not entries:
             raise ValueError("entries 不能为空（至少需要一个 name → attrs 条目）")
-        # 规范化 name：strip 空白后非空。agent 误传 "  李白  " 这种带空格的 name 会让后续按
-        # name 索引查找（角色生成等）因空格差异 mismatch。空白 name 全空 fail-loud。
+        # 规范化 name：strip 空白后非空，且须是路径安全的单段组件（validate_asset_name，
+        # 名称会被拼进文件路径与单段路由参数）。agent 误传 "  李白  " 这种带空格的 name 会让
+        # 后续按 name 索引查找（角色生成等）因空格差异 mismatch。非法 name fail-loud。
         # 同时检测 strip 后冲突：{"李白": {...}, "  李白  ": {...}} 规范化后 key 相同 →
         # 后者会 silent overwrite 前者；fail-loud 让 agent 明确感知 collision 并去重。
         normalized_entries: dict[str, dict] = {}
         raw_keys_by_normalized: dict[str, str] = {}
         for raw_name, attrs in entries.items():
-            name = raw_name.strip() if isinstance(raw_name, str) else raw_name
-            if not isinstance(name, str) or not name:
-                raise ValueError(f"{table} 的名称不能为空或仅含空白字符")
+            try:
+                name = validate_asset_name(raw_name)
+            except ValueError as exc:
+                raise ValueError(f"{table}: {exc}") from None
             if not isinstance(attrs, dict):
                 raise ValueError(f"{table} '{name}' 的内容必须是对象")
             if name in normalized_entries:
@@ -1855,6 +1859,7 @@ class ProjectManager:
         Returns:
             更新后的项目元数据
         """
+        name = validate_asset_name(name)
 
         def _mutate(project: dict) -> None:
             project["characters"][name] = {

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -1631,8 +1631,21 @@ class ProjectManager:
         通过 update_project 在单一文件锁内完成 read-modify-write，避免并发批量新增时
         的 lost-update 竞态。
         """
-        entries = {validate_asset_name(name): entry for name, entry in entries.items()}
         spec = ASSET_SPECS[asset_type]
+        # 与 upsert_assets 同口径：strip 后等价的 key（{"李白", "  李白  "}）不允许静默
+        # 互相覆盖，整批 fail-loud 不落盘，让调用方感知 collision 并去重。
+        normalized_entries: dict[str, dict] = {}
+        raw_keys_by_normalized: dict[str, str] = {}
+        for raw_name, entry in entries.items():
+            name = validate_asset_name(raw_name)
+            if name in normalized_entries:
+                raise ValueError(
+                    f"{spec.bucket_key} 的 entries 含规范化后冲突的 name {name!r}："
+                    f"原始键 {raw_keys_by_normalized[name]!r} 与 {raw_name!r} 在 strip 后等价"
+                )
+            normalized_entries[name] = entry
+            raw_keys_by_normalized[name] = raw_name
+        entries = normalized_entries
         added = 0
 
         def _mutate(project):

--- a/server/routers/_asset_router_factory.py
+++ b/server/routers/_asset_router_factory.py
@@ -20,7 +20,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict
 
-from lib.asset_types import ASSET_SPECS
+from lib.asset_types import ASSET_SPECS, validate_asset_name
 from lib.i18n import Translator
 from lib.project_change_hints import project_change_source
 from lib.project_manager import ProjectManager
@@ -83,6 +83,12 @@ def build_asset_router(
         _user: CurrentUser,
         _t: Translator,
     ):
+        # 名称会被拼进文件路径与单段路由参数，路径不安全的名字在边界即拒绝，
+        # 否则后续生成与按名访问（PATCH/DELETE/{name}）全部失效。
+        try:
+            name = validate_asset_name(req.name)
+        except ValueError:
+            raise HTTPException(status_code=400, detail=_t("asset_invalid_name", name=req.name))
         try:
             extras = req.model_extra or {}
 
@@ -92,11 +98,11 @@ def build_asset_router(
                 for field in spec.extra_string_fields:
                     entry[field] = extras.get(field, "")
                 with project_change_source("webui"):
-                    ok = manager._add_asset(asset_type, project_name, req.name, entry)
+                    ok = manager._add_asset(asset_type, project_name, name, entry)
                 if not ok:
-                    raise HTTPException(status_code=409, detail=_t(keys["exists"], name=req.name))
+                    raise HTTPException(status_code=409, detail=_t(keys["exists"], name=name))
                 data = manager.load_project(project_name)
-                return {"success": True, result_key: data[spec.bucket_key][req.name]}
+                return {"success": True, result_key: data[spec.bucket_key][name]}
 
             return await asyncio.to_thread(_sync)
         except FileNotFoundError:

--- a/server/routers/assets.py
+++ b/server/routers/assets.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 
 from lib.app_data_dir import app_data_dir
-from lib.asset_types import ASSET_TYPES, BUCKET_KEY, SHEET_KEY
+from lib.asset_types import ASSET_TYPES, BUCKET_KEY, SHEET_KEY, validate_asset_name
 from lib.db import async_session_factory
 from lib.db.repositories.asset_repo import AssetRepository
 from lib.i18n import Translator
@@ -35,15 +35,13 @@ def get_project_manager() -> ProjectManager:
 MAX_UPLOAD_BYTES = 5 * 1024 * 1024
 ALLOWED_EXTS = {".png", ".jpg", ".jpeg", ".webp"}
 
-_ILLEGAL_NAME_CHARS = ("/", "\\", "\0")
-
 
 def _validate_asset_name(name: str, _t: Translator) -> str:
-    """拒绝包含路径分隔符 / 空字节 / .. 的名字；防止路径穿越。"""
-    cleaned = (name or "").strip()
-    if not cleaned or ".." in cleaned or any(c in cleaned for c in _ILLEGAL_NAME_CHARS):
+    """HTTP 边界包装：路径不安全的名字（分隔符 / 空字节 / ..）返回 400。"""
+    try:
+        return validate_asset_name(name)
+    except ValueError:
         raise HTTPException(status_code=400, detail=_t("asset_invalid_name", name=name))
-    return cleaned
 
 
 def _serialize(asset) -> dict:

--- a/tests/test_asset_name_validation.py
+++ b/tests/test_asset_name_validation.py
@@ -1,0 +1,79 @@
+"""资产名路径安全校验。
+
+资产名全链路被当作单段路径组件使用：文件名（characters/{name}.png、
+versions/{type}/{name}_v{n}_{ts}.png）与 REST 路由的单段路径参数
+（PATCH/DELETE /projects/{p}/characters/{name}、POST .../generate/character/{name}）。
+含路径分隔符的名字会产生嵌套目录（版本登记 shutil.copy2 因父目录缺失而失败）和
+无法匹配的 URL（uvicorn 把 %2F 解码回 / 后单段参数 404），因此须在所有创建入口拒绝。
+"""
+
+import pytest
+
+from lib.asset_types import validate_asset_name
+from lib.project_manager import ProjectManager
+
+
+class TestValidateAssetName:
+    def test_valid_names_pass_and_are_stripped(self):
+        assert validate_asset_name("李白") == "李白"
+        assert validate_asset_name("  李白  ") == "李白"
+        assert validate_asset_name("Mr. Smith-2") == "Mr. Smith-2"
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "李白/诗人",
+            "a\\b",
+            "..",
+            "a/../b",
+            "x\0y",
+            "",
+            "   ",
+            None,
+            123,
+        ],
+    )
+    def test_illegal_names_rejected(self, bad):
+        with pytest.raises(ValueError):
+            validate_asset_name(bad)
+
+
+@pytest.fixture
+def pm(tmp_path):
+    manager = ProjectManager(tmp_path / "projects")
+    manager.create_project("demo")
+    manager.create_project_metadata("demo", "Demo")
+    return manager
+
+
+class TestProjectManagerCreationEntryPoints:
+    def test_add_character_rejects_slash(self, pm):
+        with pytest.raises(ValueError):
+            pm.add_character("demo", "李白/诗人", "desc")
+        assert "李白/诗人" not in pm.load_project("demo")["characters"]
+
+    def test_add_project_character_rejects_slash(self, pm):
+        with pytest.raises(ValueError):
+            pm.add_project_character("demo", "李白/诗人", "desc")
+
+    def test_add_batch_rejects_slash(self, pm):
+        with pytest.raises(ValueError):
+            pm.add_scenes_batch("demo", {"庙/宇": {"description": "d"}})
+        assert "庙/宇" not in pm.load_project("demo").get("scenes", {})
+
+    def test_upsert_assets_rejects_slash(self, pm):
+        with pytest.raises(ValueError):
+            pm.upsert_assets("demo", "props", {"玉/佩": {"description": "d"}})
+        assert "玉/佩" not in pm.load_project("demo").get("props", {})
+
+    def test_add_asset_strips_name(self, pm):
+        assert pm.add_character("demo", "  李白  ", "desc") is True
+        chars = pm.load_project("demo")["characters"]
+        assert "李白" in chars
+        assert "  李白  " not in chars
+
+    def test_legal_names_still_work(self, pm):
+        assert pm.add_character("demo", "李白", "desc") is True
+        result = pm.upsert_assets("demo", "scenes", {"庙宇": {"description": "d"}})
+        assert "庙宇" in result["added"]
+        assert pm.add_props_batch("demo", {"玉佩": {"description": "d"}}) == 1

--- a/tests/test_asset_name_validation.py
+++ b/tests/test_asset_name_validation.py
@@ -37,6 +37,48 @@ class TestValidateAssetName:
         with pytest.raises(ValueError):
             validate_asset_name(bad)
 
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "a:b",
+            "a*b",
+            "a?b",
+            'a"b',
+            "a<b",
+            "a>b",
+            "a|b",
+            "a\nb",
+            "a\rb",
+            "a\tb",
+            "a\x1fb",
+            "a\x7fb",
+            "尾随点.",
+            "CON",
+            "con",
+            "Nul",
+            "COM1",
+            "lpt9",
+            "CON.backup",
+        ],
+    )
+    def test_windows_unsafe_names_rejected(self, bad):
+        """名称会拼进文件名，Windows 上保留字符 / 控制字符 / 尾随点 / 保留设备名
+        会"校验通过但写盘失败"；项目须可跨平台迁移，所有平台统一拒绝。"""
+        with pytest.raises(ValueError):
+            validate_asset_name(bad)
+
+    def test_non_string_reports_type_error(self):
+        with pytest.raises(ValueError, match="必须是字符串"):
+            validate_asset_name(None)
+        with pytest.raises(ValueError, match="必须是字符串"):
+            validate_asset_name(123)
+
+    def test_reserved_device_names_not_overmatched(self):
+        # 仅精确（首个点段）匹配保留设备名，CON1 / CONAN / COM10 这类合法名不误杀
+        assert validate_asset_name("CON1") == "CON1"
+        assert validate_asset_name("CONAN") == "CONAN"
+        assert validate_asset_name("COM10") == "COM10"
+
 
 @pytest.fixture
 def pm(tmp_path):
@@ -60,6 +102,12 @@ class TestProjectManagerCreationEntryPoints:
         with pytest.raises(ValueError):
             pm.add_scenes_batch("demo", {"庙/宇": {"description": "d"}})
         assert "庙/宇" not in pm.load_project("demo").get("scenes", {})
+
+    def test_add_batch_rejects_normalized_collision(self, pm):
+        """strip 后等价的两个 key 不允许静默覆盖，整批 fail-loud 不落盘（与 upsert_assets 一致）。"""
+        with pytest.raises(ValueError, match="冲突"):
+            pm.add_scenes_batch("demo", {"庙宇": {"description": "a"}, "  庙宇  ": {"description": "b"}})
+        assert "庙宇" not in pm.load_project("demo").get("scenes", {})
 
     def test_upsert_assets_rejects_slash(self, pm):
         with pytest.raises(ValueError):

--- a/tests/test_asset_router_factory.py
+++ b/tests/test_asset_router_factory.py
@@ -62,6 +62,19 @@ class TestAssetRouterFactory:
             # reference_image 是 character 的 extra 字段，create 时未传则默认 ""
             assert entry["reference_image"] == ""
 
+    def test_character_post_400_on_path_unsafe_name(self, monkeypatch):
+        """名字含路径分隔符须在 HTTP 边界拒绝：这类名字会让生成（嵌套文件路径）
+        与后续单段路由（PATCH/DELETE/{name}）全部失效。"""
+        client, fake_pm = _client(monkeypatch)
+        with client:
+            for bad_name in ("李白/诗人", "a\\b", ".."):
+                resp = client.post(
+                    "/api/v1/projects/demo/characters",
+                    json={"name": bad_name, "description": "x"},
+                )
+                assert resp.status_code == 400, bad_name
+                assert bad_name not in fake_pm.projects["demo"]["characters"]
+
     def test_character_post_409_on_duplicate(self, monkeypatch):
         client, fake_pm = _client(monkeypatch)
         fake_pm.projects["demo"]["characters"]["Alice"] = {


### PR DESCRIPTION
## 问题

资产（角色/场景/道具）名称含 `/` 时，生成与 Web 端加载/操作全面失效。

## 根因

资产名全链路被当作单段路径组件使用，但创建入口没有任何路径安全校验：

1. **生成失败**：版本登记 `VersionManager.add_version` 用 `shutil.copy2` 写 `versions/characters/{名字}_v1_*.png`，名字含 `/` 产生嵌套路径且父目录不存在，直接 `FileNotFoundError`（agent 队列路径同样命中）
2. **Web 端 404**：生成触发、改名、删除、版本历史的路由都是单段 `{param}`；前端虽做了 `encodeURIComponent`，但 uvicorn 在 ASGI 层把 `%2F` 解码回 `/`，Starlette 按多段匹配必然 404

对照：全局资产库 `assets.py` 已有正确的名称校验（拒绝 `/`、`\`、空字节、`..`），项目级资产入口漏了这一层。

## 修复

在源头拒绝路径不安全的名称，校验逻辑收敛为单一真相源：

- `lib/asset_types.py`：新增 `validate_asset_name()`（strip 规范化 + 拒绝路径分隔符/空字节/`..`）
- `lib/project_manager.py`：接入全部创建入口 `_add_asset` / `_add_assets_batch` / `upsert_assets`（agent 路径，整批 fail-loud 不落盘）/ `add_project_character`
- `server/routers/_asset_router_factory.py`：HTTP 边界校验，非法名返回 400 + 既有三语 i18n key `asset_invalid_name`
- `server/routers/assets.py`：全局资产库校验改为委托共享实现，消除重复

## 测试

- 新增 `tests/test_asset_name_validation.py`：校验函数 + 四个创建入口的拒绝/放行/strip 规范化
- `tests/test_asset_router_factory.py`：HTTP 边界 400 测试
- 全量 pytest 3976 passed（唯一失败为已知本机环境耦合测试，与本改动无关）；ruff / basedpyright 干净

## 遗留

存量项目中已存在的含 `/` 资产无法通过 UI 删除（DELETE 路由同样 404），需手动清理 project.json；如需要可另开 issue 做校验警告或清理工具。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 强化资产/角色名称校验：禁止路径分隔符、控制字符、尾随点、相对路径片段及 Windows 保留设备名；会自动去除首尾空白并在多入口统一生效，非法名称将被拒绝并返回 400 错误提示。

* **测试**
  * 新增全面测试覆盖，包含单条与批量写入、边界情况与冲突检测，确保拒绝不安全名称且不落盘。

* **文档/本地化**
  * 更新多语言错误提示，明确列出不被允许的字符与命名规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->