### PR TITLE
chore(skills): pr-ai-review-loop 优化改版——纳入 CodeQL 告警闭环,循环无状态可断点恢复

### DIFF
--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -1,46 +1,50 @@
 ---
 name: pr-ai-review-loop
-description: 无人值守驱动 CodeRabbit、Gemini Code Assist、OpenAI Codex 的 review → 修复 → push → 再 review 循环,直到全部通过或触发收敛退出。主动调用:用户刚 push PR 或跑完 /commit-push-pr;提到 review / coderabbit / gemini / codex / 审查 / AI review / 等 bot 回复;CodeRabbit paused 需 resume;reviewer 有 actionable comments。即使用户只说"PR 怎么样了""review 回了吗"也应触发。
+description: 无人值守驱动 CodeRabbit、Gemini Code Assist、OpenAI Codex 与 GitHub Code Quality / Advanced Security(CodeQL)的 review → 修复 → push → 再 review 循环,直到全部通过或触发收敛退出。主动调用:用户刚 push PR 或跑完 /commit-push-pr;提到 review / coderabbit / gemini / codex / codeql / code quality / code security / 审查 / AI review 等 bot 回复;CodeRabbit paused 需 resume;reviewer 有 actionable comments。即使用户只说"PR 怎么样了""review 回了吗"也应触发。
 ---
 
 # AI Review 自动循环
 
-PR push 之后,CodeRabbit、Gemini、Codex 三家 AI reviewer 会反复进行 review → 修复 → push → 再 review 的循环。本 skill 负责调度该循环:监控状态、必要时触发 review、收集所有意见后转交 `receiving-code-review` 处理。
+PR push 之后,多家 reviewer bot 会产出评论。本 skill 调度 review → 修复 → push → 再 review 的循环:监控状态、必要时触发 review、收集评论转交 `receiving-code-review`,直到达成目标状态。首次进入循环时通读 [references/reviewers.md](references/reviewers.md)——每轮判定(已审 / actionable / 通过)全部依赖其中的 per-reviewer 规则。
 
-## 运行模式:无人值守与两类暂停场景
+## 目标状态
 
-自动执行整个循环,无需每轮征求授权。触发命令、push 修复、回应 inline、下一轮 poll 的延迟均按下文决策表自行决定。下列场景需要暂停并询问用户。
+循环的唯一正常出口。宣布通过前逐项核对:
 
-### A. 故障类暂停
+1. **本 PR 参审的每家 AI reviewer**(CodeRabbit / Gemini / Codex)对当前 HEAD 通过。CodeRabbit 始终参审,Gemini 由 cold-start fallback 保证参审,Codex 按其触发决策可不参审;fix-up 顺延时沿用上一已审 HEAD 的通过结论(口径见 reviewers.md「通用约定」)
+2. **CodeQL 退出门槛**:分析完成且成功、security 无 PR 引入的 open 告警、quality 全量评论逐条已处置——三条细则与"仓库未接入"的跳过口径见 reviewers.md「GitHub code scanning bots」节
+3. 循环期间的所有 actionable 评论均已实施修复或记录 pushback
 
-- bot 报错(如 "Internal error"、"Token limit exceeded")
-- 某家 reviewer 超过 15 分钟未响应
-- `gh` 401/403 认证失败
-- `poll.sh` 或 `classify_commits.sh` 重试一次后仍报错
-- review 意见语义模糊,`receiving-code-review` 无法判定是否 pushback
+门槛核对(alerts 差集、quality 逐条)成本高,设计上只在其余缺口全部消失后做一次**终核**,不必每轮执行。每轮决策 = 对照目标找缺口 → 执行最小动作集 → 安排下一次唤醒。达不成目标时由「收敛兜底」退出。
 
-### B. 调度类暂停
+## 运行模式:无人值守
 
-- **根本性分歧无定论**:同一主题指纹(reviewer + 关键词,例如 "Pydantic `extra=ignore` vs `forbid`")被同一家 reviewer 连续提出 ≥ 3 轮,且无 ADR / memory 兜底。暂停并请用户决定是否升级 ADR(与「收敛兜底」#3 同口径)
+自动执行整个循环,无需每轮征求授权:触发命令、push 修复、回应 inline、修复 CI、下一轮 poll 的延迟均自行决定。只有两类场景暂停询问用户——故障类见「故障处理」节,调度类如下:
+
+- **根本性分歧无定论**:同一主题(reviewer + 关键词,例如 "Pydantic `extra=ignore` vs `forbid`")被同一家 reviewer 在 ≥ 3 个 HEAD 上反复提出,且无 ADR / memory 兜底。暂停并请用户决定是否升级 ADR(与「收敛兜底」#3 同口径)
 - **reviewer 之间冲突**:同一议题,A 家主张 X、B 家反对 X。暂停并交用户裁决,不自行选边
 - **业务取舍**:修复方案在前向兼容、性能、用户体验上存在显著差异,可能影响业务意图。暂停并确认
 
-主题指纹由 Claude 在对话上下文中维护 `topic_history`,以语义相似度判定同主题。
+## 无状态原则
+
+本 skill 不在对话中维护状态账本。每轮判断所需的全部事实——谁审过当前 HEAD、本轮新评论、已进行的轮数、近几轮 commit 形状、主题是否重复——都从本轮 poll 输出与 git 数据现场推导。对话被压缩或会话中断后,重新跑一轮步骤 1 即可完全恢复循环。
+
+现场推导口径(按需推导,不必每轮全做):
+
+- **轮数**:读 poll 输出的 `round_estimate`(PR 创建后的 commits 按 >5 分钟间隔聚类;rebase 会刷新全部日期导致低估,仅作启发),每轮顺手对照收敛兜底阈值
+- **commit 形状**:仅在发触发命令前推导——对最近的 push 批次跑 `classify_commits.sh`,SINCE_SHA 取上一批次末 commit 的 `oid`(批次边界从 `commits[*].committedDate` 的间隔看)
+- **主题重复**:仅在新评论似曾相识或逼近兜底阈值时推导——通读全量评论历史(inline `body_head` + reviews body),按语义归并主题,看同一主题出现在几个不同 HEAD 上
+- **本轮已触发**:`own_trigger_comments` 中该命令最大 `createdAt` 晚于 `last_push_at`(详见 reviewers.md「触发去重」)
 
 ## 前置条件
 
-- 当前分支已有对应 PR(`gh pr view` 能读取到 PR 号)。若无,建议先运行 `/commit-commands:commit-push-pr`
-- `gh` 已登录且具备评论权限(`gh auth status` 通过)
-- 仓库已接入 CodeRabbit、Gemini Code Assist、OpenAI Codex 三家 reviewer
-- 已安装 `jq`(macOS:`brew install jq`;Debian/Ubuntu:`apt-get install jq`;Fedora:`dnf install jq`;Windows:WSL 内安装)
-
-## 三家 reviewer 速查
-
-参见 [references/reviewers.md](references/reviewers.md):bot 名(GraphQL 与 REST 命名差异)、状态表达方式、Codex 三种 ack 模式、bot 改名后的查询方法。
+- 当前分支已有对应 PR(`gh pr view` 能读取到 PR 号)且非 draft(draft 时 CodeRabbit 默认不审)。若无 PR,建议先运行 `/commit-commands:commit-push-pr`
+- `gh` 已登录且具备评论权限(`gh auth status` 通过);已安装 `jq`
+- 仓库已接入 CodeRabbit;Gemini Code Assist / OpenAI Codex / GitHub code scanning 按仓库实际接入情况启用
 
 ## 每轮 poll 流程
 
-每轮分三步:拉数据 → 决策 → 动作。**不要**用单条长 sleep 阻塞会话,由 ScheduleWakeup 控制节奏。
+每轮三步:拉数据 → 对照目标找缺口 → 动作。**不要**用单条长 sleep 阻塞会话,由 ScheduleWakeup 控制节奏。
 
 ### 步骤 1:拉取当前状态
 
@@ -50,132 +54,75 @@ bash .agents/skills/pr-ai-review-loop/scripts/poll.sh <PR_NUMBER>
 
 JSON 解析后仅保留在对话上下文中,不落盘。
 
-本 skill 维护的三个状态字段及其更新规则:
+### 步骤 2:对照目标找缺口
 
-| 字段 | 更新时机 | 跨 HEAD 行为 | 用途 |
-|---|---|---|---|
-| `round_count` | HEAD SHA 或 `last_push_at` 与上一轮记录不同时 +1 | 累加,不重置 | 收敛兜底 #1 |
-| `topic_history` | 每次拉到 reviewer 新意见时追加一条,记录 `comment id`、`head_sha` 与内容指纹 | 累积不清空,按 `(comment id, head_sha)` + 内容指纹去重(详见下) | 主题指纹比对 |
-| `last_commit_shapes` | HEAD SHA 或 `last_push_at` 变化时追加形状标签 | 长度 ≤ 3 的滑窗 | 收敛兜底 #2 |
+按「目标状态」逐项核对,对每个缺口执行对应动作(同一轮可并行处理多家):
 
-**`topic_history` 同记录判定**:
-
-- **内容指纹**:walkthrough 取 `updated_at`;其它评论取 `body_head` 的前 N 字符或哈希值
-- `(comment id, head_sha)` 命中且**内容指纹未变** → 视为已记录,跳过
-- `(comment id, head_sha)` 命中但**内容指纹变了** → 更新已记录条目(覆盖,不重复追加);覆盖 CodeRabbit walkthrough 在同 HEAD 内由 in-progress 改写为 final 的情况
-- 跨 HEAD 同 id → 一律视为新一轮
-
-### 步骤 2:对每家启用的 reviewer 决定动作
-
-进入决策表前,先运行 `classify_commits.sh` 判定 commit 性质:
-
-```bash
-bash .agents/skills/pr-ai-review-loop/scripts/classify_commits.sh <PR_NUMBER> <previous_round_head_sha>
-```
-
-若本轮 push 的所有 commit 均属 fix-up(nit、format、typo、单字段调整、小 bug 修复),本轮**跳过**手动触发 Gemini 与 Codex,等 CodeRabbit 自动跟即可。**例外**:下文 Gemini cold-start fallback 行不受此跳过限制 —— 该场景下 `gemini.reviews` 完全为空,整个 PR 还没经过任何 Gemini review,无论 commit 性质都需补发触发,否则 Gemini 将永远不会审本 PR。
-
-否则按下表执行,命中即执行,同一轮可并行处理多家 reviewer:
-
-| 条件 | 动作 |
+| 缺口 | 动作 |
 |---|---|
-| `coderabbit.walkthrough.is_paused == true`,且 `updated_at` 之后未发送过 `@coderabbitai resume`(从 `own_trigger_comments` 中筛,最新一条 `createdAt` 早于 walkthrough 的 `updated_at`,为空时视为未发送) | 发送 `@coderabbitai resume` |
-| Gemini 启用,`gemini.reviews` **完全为空**,且 `pr_created_at` 距今不足 5 分钟 | 等待 Gemini 自动 review(PR opened 触发,见 references/reviewers.md);不手动触发 |
-| Gemini 启用,`gemini.reviews` **完全为空**,`pr_created_at` 距今已超过 5 分钟,且 `own_trigger_comments` 中不存在 `/gemini review`(或存在但最大 `createdAt ≤ last_push_at`)| 发送 `/gemini review`(cold-start fallback:PR opened 自动 review 未在窗口内出现,可能失败或被跳过;**不受 fix-up 跳过限制**,见上文说明) |
-| Gemini 启用,`gemini.reviews` **非空**但最新一条 `submittedAt < last_push_at`,且 `own_trigger_comments` 中不存在 `/gemini review`(或存在但最大 `createdAt ≤ last_push_at`),且**前述跳过触发未命中** | 发送 `/gemini review`(synchronize 场景,Gemini 不自动跟新 commit) |
-| Codex 启用,按下方「Codex 触发决策」判断需要触发,且**前述跳过触发未命中** | 发送 `@codex review` |
+| `checks_failing` 非空(CI 红) | 就地修复并 push——CI 红会阻塞 reviewer 触发;修不动(重试仍红 / 根因在 main)才暂停询问 |
+| 某家参审 reviewer 未审当前 HEAD | 按 reviewers.md 该家「触发」规则决定等待或发触发命令 |
+| 至少一家有本轮新 actionable 评论(判定见 reviewers.md) | 进入步骤 3 |
+| `security_alerts.open_introduced` 非空但无对应新评论 | 上一轮没修干净(bot 不重复提醒)——把 alert 数据(rule / path / url)直接带入步骤 3,按数据修而非按评论修 |
+| CodeQL 分析未完成 | 等待(不阻塞其它缺口的处理) |
+| 以上缺口均消失 | 做目标状态**终核**(含 CodeQL 门槛逐条);全过则退出循环并简短汇报,发现遗留则按对应缺口处理 |
+| 未全部达成且无可执行动作(reviewer 响应中) | 按「轮询节奏」表等待下一轮 |
 
-执行完触发动作后,按下文「轮询节奏」表选择延迟,调用 `ScheduleWakeup`。
+**fix-up 跳过**:发触发命令前先跑 `classify_commits.sh`;若本轮 push 全为 fix-up(nit、format、typo、单字段调整、小 bug 修复)**且该家对上一已审 HEAD 已通过**,跳过手动触发 Gemini 与 Codex,沿用其通过结论(顺延口径见 reviewers.md),等 CodeRabbit 自动跟即可;该家还有未解决评论时不得跳过。例外:Gemini cold-start fallback 不受此限(该场景下整个 PR 还没经过任何 Gemini review)。
 
-**去重原则**:同一 HEAD 上 `/gemini review` 与 `@codex review` 各只能发送一次。每种命令在 `own_trigger_comments` 中取最大 `createdAt`,若晚于 `last_push_at`,视为本轮已触发,跳过。
+执行完触发动作后,按「轮询节奏」表选择延迟,调用 `ScheduleWakeup`。
 
-判定循环走向:
+### 步骤 3:收集评论并转交 receiving-code-review
 
-- 仍有 reviewer 未对最新 HEAD 出结果 → 等待下一轮
-- 至少一家 reviewer 提交了新的 actionable 意见 → 进入步骤 3
-- 所有启用的 reviewer 对当前 HEAD 均已通过 → 退出循环,简短汇报
+将所有 reviewer 的本轮新评论**合并为一次调用**,通过 Skill 工具调用 `receiving-code-review`。不要每家单独调用:`receiving-code-review` 以一次修复 push 收尾,分家调用意味着多次 push,而每次 push 都会让全部 reviewer 重审一轮——轮数膨胀、quota 加倍。
 
-### 步骤 3:收集意见并转交 receiving-code-review
+- Gemini 的 `gemini.reviews[*].body`(summary)整段贴入上下文——某些建议仅出现在 summary 中,inline 部分为空;只贴 inline 会丢失内容。`receiving-code-review` 与本 skill 共享 context,只有把 summary body 摆在对话中它才能读到
+- GitHub code scanning 两家(quality / security)的评论一并转交,全部视为 actionable;修复后**不回 inline**(bot 不读回复),pushback 落点为 PR 评论说明或 dismiss alert
+- `body_head` 只有 400 字符,语义被截断时按评论 id 用 `gh api` 拉全文再转交
 
-将所有 reviewer 的本轮新意见**合并为一次调用**,通过 Skill 工具调用 `receiving-code-review`,不要每家单独调用。
+`receiving-code-review` 调用完成后回到步骤 1。
 
-合并时必须将 `gemini.reviews[*].body`(summary)整段贴入上下文。Gemini 的某些建议仅出现在 summary 中,inline 部分为空;只贴 inline 会丢失意见。`receiving-code-review` 与本 skill 共享 context,只有把 summary body 摆在对话中它才能读到。
+## 轮询节奏
 
-`receiving-code-review` 调用完成后回到步骤 1。该 skill 负责实施修复、回复 reviewer inline、记录 pushback;本 skill 仅重新拉取数据,判断是否产生新 HEAD 或新一轮 review。
-
-## 关键判定
-
-### Reviewer 是否已审查当前 HEAD
-
-- **CodeRabbit**:`coderabbit.walkthrough.updated_at > last_push_at`
-- **Gemini**:`gemini.reviews[*].submittedAt > last_push_at` 至少一条
-- **Codex**:满足 references/reviewers.md 中 Codex 三种 ack 模式任一
-
-### 是否为 actionable
-
-- **CodeRabbit**:`walkthrough.is_ok == true` 或 `actionable_count == "0"` 时无 actionable;否则查看 `inline_comments_by_user["coderabbitai[bot]"]` 中 `created_at > last_push_at` 的条目,body 开头若含 `_⚠️ Potential issue_`、`_🟠 Major_`、`_🛠️ Refactor suggestion_`、`_💡 Verification agent_` 等标签,均视为 actionable;nit 级别不算
-- **Gemini**(两条路径,任一命中即算):
-  - **inline 路径**:`inline_comments_by_user["gemini-code-assist[bot]"]` 中 `created_at > last_push_at` 的条目,`severity_alt` 为 `high`、`medium`、`critical` 算 actionable;`low`、`nit`、`style` 不算
-  - **summary 路径**:`gemini.reviews` 中 `submittedAt > last_push_at` 的最新一条,body 非空且不含明确通过标记(`LGTM`、`No issues found`、`Approved`、仅有 `## Code Review` 标题而无后续内容),算 actionable
-- **Codex**:`inline_comments_by_user["chatgpt-codex-connector[bot]"]` 中 `severity_alt` 为 `Pn Badge` 形式(P0/P1 通常视为 actionable;P2/P3 视情况)
-
-**Acknowledgment 例外**:`inline_comments_by_user.*` 中 `is_ack == true` 的条目,是 reviewer 对上一次修复或 inline 回复的确认响应,**不算** actionable。review state 为 `APPROVED` 一律不算 actionable。
-
-### 是否已通过
-
-当前 HEAD 下,每家启用的 reviewer 满足以下之一:
-
-- **CodeRabbit**:`updated_at > last_push_at` **且** `is_in_progress == false` **且** `is_paused == false`(前置条件:CR 已审过当前 HEAD、不在 in-progress、未 paused;paused 时 `walkthrough` 中 `is_ok` 等字段可能是上一轮残留,需先经步骤 2 中的「CR resume」规则(`@coderabbitai resume`)恢复审查再判通过);在该前置之上,满足任一即通过 —— `walkthrough.is_ok == true` / `actionable_count == "0"` / 本轮 inline 均为 `is_ack == true` / 本轮 inline 均为 nit 级(body 含 `_🧹 Nitpick_` / `_🔵 Trivial_` / `_💤 Low value_` 标签,不含 `_⚠️ Potential issue_` / `_🟠 Major_` / `_🛠️ Refactor suggestion_` / `_💡 Verification agent_`)
-- **Gemini**:`gemini.reviews[*].submittedAt > last_push_at` 至少一条(前置条件:Gemini 已审过当前 HEAD,避免误用上一轮的通过标记);在该前置之上,需**同时**满足:(1) 本轮无新 inline 或本轮新 inline 全部为 `low/nit/style` 或全部为 `is_ack`;(2) summary 最新一条 `gemini.reviews` 的 body 含明确通过标记(非空不等于通过)
-- **Codex**:满足 references/reviewers.md 中三种 ack 模式之一,且本轮无 ack 以外的 inline
-- 或该 reviewer 已被用户临时停用
-
-### Codex 触发决策
-
-Codex 是否自动跟新 commit 取决于仓库配置(详见 references/reviewers.md)。仓库未开启自动 review 时,是否手动 `@codex review` 综合判断:
-
-- 用户明确意图(提到 codex 通常意味着需要触发)
-- CodeRabbit 与 Gemini 意见冲突,需要第三方仲裁
-- PR 改动面值得多看一遍(敏感模块、跨模块影响、新增依赖等)
-- 当前 HEAD 是否已触发过(去重)
-- 跳过触发是否命中(本轮全为 fix-up 则跳过)
-
-### 轮询节奏
-
-每轮 poll 与决策完成后,调用 `ScheduleWakeup` 安排下一次唤醒。延迟取值:
+每轮 poll 与决策完成后,调用 `ScheduleWakeup` 安排下一次唤醒。唤醒 prompt 写明 skill 名与 PR 号(例:"继续 pr-ai-review-loop:对 PR #N 重跑 poll.sh 走步骤 1"),即使唤醒发生在上下文压缩之后也能无损重入。延迟取值:
 
 | 场景 | 延迟 | 备注 |
 |---|---|---|
-| 新 HEAD 后首次 poll | 180s | reviewer cold-start;CR 通常 60-90s 跟新 HEAD;Gemini 仅 PR opened 自动 review,synchronize 不跟;Codex 取决于仓库配置 |
+| 新 HEAD 后首次 poll | 180s | reviewer cold-start;CR 通常 60-90s 跟新 HEAD;Gemini 仅 PR opened 自动 review;CodeQL 分析需数分钟 |
 | 发送 `/gemini review` 或 `@codex review` 之后 | 120s | Gemini 响应通常 90-120s,60s 容易错过 |
 | 常规等待(reviewer 响应中) | 60s | 处于 prompt cache 5 分钟窗口内 |
-| 超过 15 分钟无响应 | 暂停并询问用户,不再 ScheduleWakeup | 与故障类暂停一致 |
+| 仅剩 CodeQL 分析未完成 | 120s | 等 check 完成做终核 |
+| 超过 15 分钟无响应 | 暂停并询问用户,不再 ScheduleWakeup | 见「故障处理」 |
 
 ## 收敛兜底
 
 下列任一条件触发退出:
 
-1. `round_count >= 8` → 暂停询问"已 8 轮,merge / 继续 / 放弃?"
-2. 连续 2 轮 `last_commit_shapes` 全为 nit / format → 暂停询问"边际收益已降低,是否结束?"
-3. 同一主题指纹连续提出 ≥ 3 轮(与「运行模式」B 节联动)→ 暂停询问是否升级 ADR
-4. 所有 reviewer 对当前 HEAD 均通过 → 正常退出
+1. `round_estimate` ≥ 8 → 暂停询问"已 8 轮,merge / 继续 / 放弃?"
+2. 连续 2 轮 push 全为 nit / format 形状(跑 `classify_commits.sh` 看最近两批)→ 暂停询问"边际收益已降低,是否结束?"
+3. 同一主题在 ≥ 3 个 HEAD 上被反复提出(与「运行模式」调度类暂停联动)→ 暂停询问是否升级 ADR
+4. 目标状态全部达成 → 正常退出
 
 ## 故障处理
 
-- **某家 reviewer 长时间无响应**:bot 可能服务异常或配额已满。超过 15 分钟暂停并询问用户(与轮询节奏上限一致)
-- **bot 报错**(如 "Internal error"、"Token limit exceeded"):将错误内容贴给用户,询问是否强制重跑(`@coderabbitai full review` 或 `/gemini review`)
-- **`poll.quota_alerts` 非空**:bot 在 PR 中留下了 quota / rate limit 报错。将 `body_head` 贴给用户,询问是否暂时停用该 reviewer 继续其他家,或等 quota 恢复后再 push
+条件与处置一一对应,均暂停询问用户(无人值守的例外面):
+
+- **某家 reviewer(含 CodeQL 分析)超过 15 分钟未响应**:bot 可能服务异常或配额已满,暂停说明现状。fix-up 顺延导致的"未审"不算无响应——那是设计内跳过
+- **bot 报错**(如 "Internal error"、"Token limit exceeded"):贴出错误内容,询问是否强制重跑(`@coderabbitai full review` 或 `/gemini review`)
+- **`quota_alerts` 非空**:bot 留下了 quota / rate limit 报错,贴出 `body_head`,询问停用该家继续其他家,还是等 quota 恢复后再 push
+- **`codeql_checks` 有 conclusion 为 failure / cancelled / timed_out**:分析失败,alerts 数据停留在上次成功分析,不能做终核;询问是否重跑失败的 workflow
+- **`security_alerts.available == false`**(且不满足 reviewers.md 的"未接入"判定):贴出 `unavailable_hint`,security 门槛无法机器核对,请人工确认后再退出
 - **`gh` 401/403**:请用户运行 `gh auth refresh -s repo`
-- **脚本报 `POLL_ERROR:`**:重试一次(网络抖动常见),再失败则将 stderr 贴给用户
-- **CI 失败**:CodeRabbit 会等 GitHub Checks 完成后继续;CI 红时 review 可能不会触发,优先修复 CI
+- **脚本报 `POLL_ERROR:`**:重试一次(网络抖动常见),再失败贴出 stderr
+- **review 评论语义模糊**,`receiving-code-review` 无法判定是否 pushback:贴出原文请用户定夺
 
 ## 与其他 skill 的分工
 
 | 任务 | 对应 skill |
 |---|---|
 | 创建 PR | `commit-commands:commit-push-pr` |
-| 回应 / 实施 / 反驳 review 意见 | `receiving-code-review` |
+| 回应 / 实施 / 反驳 review 评论 | `receiving-code-review` |
 | 验证修复是否真的解决问题 | `verify` |
-| **监控多家 AI reviewer 的循环节奏** | **本 skill** |
+| **循环调度、CI 修复、终核与退出** | **本 skill** |
 
-本 skill 仅负责调度:何时 poll、何时 resume 或触发、何时转交 `receiving-code-review`、何时结束循环。**不**负责"回应意见"与"验证修复"。
+本 skill 不负责"回应评论"与"验证修复";CI 红的就地修复属于调度职责(不是 review 评论,不转交)。

--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -63,12 +63,12 @@ JSON 解析后仅保留在对话上下文中,不落盘。
 | `checks_failing` 非空(CI 红) | 就地修复并 push——CI 红会阻塞 reviewer 触发;修不动(重试仍红 / 根因在 main)才暂停询问 |
 | 某家参审 reviewer 未审当前 HEAD | 按 reviewers.md 该家「触发」规则决定等待或发触发命令 |
 | 至少一家有本轮新 actionable 评论(判定见 reviewers.md) | 进入步骤 3 |
-| `security_alerts.open_introduced` 非空但无对应新评论 | 上一轮没修干净(bot 不重复提醒)——把 alert 数据(rule / path / url)直接带入步骤 3,按数据修而非按评论修 |
-| CodeQL 分析未完成 | 等待(不阻塞其它缺口的处理) |
+| `security_alerts.open_introduced` 非空但无对应新评论 | 上一轮没修干净(bot 不重复提醒)——把 alert 数据(rule / path / url)直接带入步骤 3,按数据修而非按评论修。前提:CodeQL 分析完成且成功(门槛 1 口径)——分析未完成时差集基于过期数据,归入下行等待 |
+| CodeQL 分析未完成 | 等待(不阻塞其它缺口的处理,但阻塞终核——分析完成前不得宣布"缺口均消失") |
 | 以上缺口均消失 | 做目标状态**终核**(含 CodeQL 门槛逐条);全过则退出循环并简短汇报,发现遗留则按对应缺口处理 |
 | 未全部达成且无可执行动作(reviewer 响应中) | 按「轮询节奏」表等待下一轮 |
 
-**fix-up 跳过**:发触发命令前先跑 `classify_commits.sh`;若本轮 push 全为 fix-up(nit、format、typo、单字段调整、小 bug 修复)**且该家对上一已审 HEAD 已通过**,跳过手动触发 Gemini 与 Codex,沿用其通过结论(顺延口径见 reviewers.md),等 CodeRabbit 自动跟即可;该家还有未解决评论时不得跳过。例外:Gemini cold-start fallback 不受此限(该场景下整个 PR 还没经过任何 Gemini review)。
+**fix-up 跳过**:发触发命令前先跑 `classify_commits.sh`;若本轮 push 全为 fix-up(nit、format、typo、单字段调整、小 bug 修复)**且该家对上一已审 HEAD 已通过**,跳过手动触发 Gemini 与 Codex,沿用其通过结论(顺延口径见 reviewers.md);该家还有未解决评论时不得跳过。本跳过仅作用于需手动触发的 Gemini / Codex——CodeRabbit 自动跟审每次 push,不在跳过范围,最终 HEAD 始终有它过目。例外:Gemini cold-start fallback 不受此限(该场景下整个 PR 还没经过任何 Gemini review)。
 
 执行完触发动作后,按「轮询节奏」表选择延迟,调用 `ScheduleWakeup`。
 
@@ -84,7 +84,7 @@ JSON 解析后仅保留在对话上下文中,不落盘。
 
 ## 轮询节奏
 
-每轮 poll 与决策完成后,调用 `ScheduleWakeup` 安排下一次唤醒。唤醒 prompt 写明 skill 名与 PR 号(例:"继续 pr-ai-review-loop:对 PR #N 重跑 poll.sh 走步骤 1"),即使唤醒发生在上下文压缩之后也能无损重入。延迟取值:
+每轮 poll 与决策完成后,调用 `ScheduleWakeup` 安排下一次唤醒。唤醒 prompt 写明 skill 名与 PR 号,可附上一轮动作摘要(例:"继续 pr-ai-review-loop:对 PR #N 重跑 poll.sh 走步骤 1;上轮已发 /gemini review 等响应")。重入语义:判定所需的全部事实由唤醒后的现场 poll 重建(无状态原则),摘要只是省一次推导,不作判定依据——即使唤醒发生在上下文压缩之后,重跑步骤 1 即可继续。延迟取值:
 
 | 场景 | 延迟 | 备注 |
 |---|---|---|
@@ -111,7 +111,7 @@ JSON 解析后仅保留在对话上下文中,不落盘。
 - **bot 报错**(如 "Internal error"、"Token limit exceeded"):贴出错误内容,询问是否强制重跑(`@coderabbitai full review` 或 `/gemini review`)
 - **`quota_alerts` 非空**:bot 留下了 quota / rate limit 报错,贴出 `body_head`,询问停用该家继续其他家,还是等 quota 恢复后再 push
 - **`codeql_checks` 有 conclusion 为 failure / cancelled / timed_out**:分析失败,alerts 数据停留在上次成功分析,不能做终核;询问是否重跑失败的 workflow
-- **`security_alerts.available == false`**(且不满足 reviewers.md 的"未接入"判定):贴出 `unavailable_hint`,security 门槛无法机器核对,请人工确认后再退出
+- **`security_alerts.available == false`**:贴出 `unavailable_hint`,按 reviewers.md「仓库未接入」段判别权限问题与未接入——两种情形都需用户确认,不得自动跳过 security 门槛
 - **`gh` 401/403**:请用户运行 `gh auth refresh -s repo`
 - **脚本报 `POLL_ERROR:`**:重试一次(网络抖动常见),再失败贴出 stderr
 - **review 评论语义模糊**,`receiving-code-review` 无法判定是否 pushback:贴出原文请用户定夺

--- a/.agents/skills/pr-ai-review-loop/references/reviewers.md
+++ b/.agents/skills/pr-ai-review-loop/references/reviewers.md
@@ -6,8 +6,8 @@
 
 - **本轮新评论**:`created_at > last_push_at`。不要用 `commit_id == head` 判断——CodeRabbit 重审新 HEAD 时会改写旧 inline 的 `commit_id`,`created_at` 才是逐评论稳定的
 - **Acknowledgment 例外**:`inline_comments_by_user.*` 中 `is_ack == true` 的条目是 reviewer 对上一次修复或 inline 回复的确认,一律**不算** actionable;review state 为 `APPROVED` 也不算
-- **fix-up 顺延**:某家对上一已审 HEAD 已通过,且其后的 push 全为 fix-up(见 SKILL.md「fix-up 跳过」)时,沿用该通过结论参与目标判定,不触发重审——CodeRabbit 自动跟审每次 push,最终 HEAD 始终至少有它过目。前提是"已通过":该家还有未解决评论时不得跳过,必须正常触发重审
-- **触发去重**:同一 HEAD 上每种触发命令只发一次。在 `own_trigger_comments` 中取该命令最大 `createdAt`,晚于 `last_push_at` 即视为本轮已触发,跳过(`@coderabbitai resume` 例外:以 CodeRabbit 节的 `updated_at` 口径为准)。发触发命令时评论体只含命令本身——附加任何说明文字都会使 `own_trigger_comments` 的全行匹配落空,去重随之失效
+- **fix-up 顺延**:某家对上一已审 HEAD 已通过,且其后的 push 全为 fix-up(见 SKILL.md「fix-up 跳过」)时,沿用该通过结论参与目标判定,不触发重审——CodeRabbit 自动跟审每次 push,最终 HEAD 始终至少有它过目。**「上一已审 HEAD」指该家最近一次实际审过的 commit,不是最近一次通过的 commit**——若该家最近审的 HEAD 未通过(如 A 通过 → B 有 actionable → C fix-up,最近审的是 B),前提不满足,不得顺延;「其后」从该已审 HEAD 的下一个 commit 起算,到当前 HEAD 为止须全为 fix-up。该家还有未解决评论时同样不得跳过,必须正常触发重审
+- **触发去重**:同一 HEAD 上每种触发命令只发一次。在 `own_trigger_comments` 中取该命令最大 `createdAt`,晚于 `last_push_at` 即视为本轮已触发,跳过(`@coderabbitai resume` 例外:以 CodeRabbit 节的 `updated_at` 口径为准)。poll.sh 按**前缀**匹配:评论以命令开头即被收录(`/gemini review 补充说明` 算;`考虑过 /gemini review` 这类中段提及不算——故意不用包含匹配,否则引用过命令的 pushback 评论会被误判为已触发,导致漏触发)。发触发命令时仍应只写命令本身,且命令必须在评论首行——正则锚定整串开头,第二行的命令不会被识别
 
 ## 总表
 
@@ -45,7 +45,7 @@
 **触发**(按 `pr_created_at` 与 `gemini.reviews` 判别,均受触发去重约束):
 
 - `gemini.reviews` 完全为空,`pr_created_at` 距今**不足 5 分钟** → cold-start 窗口内,等待,不触发
-- `gemini.reviews` 完全为空,`pr_created_at` 距今**已超 5 分钟** → cold-start fallback:自动 review 未在窗口内出现(可能失败或被跳过),发送 `/gemini review`。**此行不受 fix-up 跳过限制**——此时整个 PR 还没经过任何 Gemini review,不补发则 Gemini 永远不会审本 PR
+- `gemini.reviews` 完全为空,`pr_created_at` 距今**已超 5 分钟** → cold-start fallback:自动 review 未在窗口内出现(可能失败或被跳过),发送 `/gemini review`。**此行不受 fix-up 跳过限制**——此时整个 PR 还没经过任何 Gemini review,不补发则 Gemini 永远不会审本 PR。5 分钟是含 webhook / 轮询延迟容差的宽松阈值,不必精确:若 Gemini 实际只是慢(窗口边缘误发),代价仅是一次额外触发,且受触发去重约束
 - `gemini.reviews` 非空但最新一条 `submittedAt < last_push_at` → synchronize 场景,发送 `/gemini review`(受 fix-up 跳过限制)
 
 **已审当前 HEAD**:`gemini.reviews[*].submittedAt > last_push_at` 至少一条。
@@ -91,9 +91,9 @@
 
 1. **分析完成且成功**:`codeql_checks` 非空,且各 check 对当前 HEAD 全部 `status == "completed"`、`conclusion` 无 failure / cancelled / timed_out(同名 check 取最新一条;check suite 重跑会产生同名多条)。两个陷阱:空数组对"全部 completed"恒真,但为空只说明分析未注册(继续等待)或仓库未接入(见下),不是通过;conclusion 失败时 alerts 数据停留在上次成功分析,直接核对门槛 2 会漏报新告警——归入故障类暂停。分析超过 15 分钟未完成同样归入故障类暂停
 2. **security 无遗留**:`security_alerts.open_introduced` 为空(poll.sh 已做 base 分支差集,排除存量告警)。`available == false` 时降级:把 `unavailable_hint` 贴给用户,说明无法核对 alerts API(权限或 merge ref 原因),请人工确认后再退出
-3. **quality 无遗留**:PR 上 `github-code-quality[bot]` 的**全量** inline 评论(不限本轮)逐条核对——对应代码已修改,或已有 pushback 记录(PR 评论说明)。quality 没有可查的告警列表 API(实测 404),全量评论 + 代码现状就是完整事实;不要依赖"本次循环收集过哪些"的对话记忆,压缩后无法重建
+3. **quality 无遗留**:PR 上 `github-code-quality[bot]` 的**全量** inline 评论(不限本轮)逐条核对——对应代码已修改,或已有 pushback 记录(PR 评论说明)。quality 没有可查的告警列表 API(实测 404),全量评论 + 代码现状就是完整事实;不要依赖"本次循环收集过哪些"的对话记忆,压缩后无法重建。常规 PR 该量级是个位数,逐条核对是终核的一次性成本;若全量达数十条,逐条核对不再现实,向用户说明数量并商定抽查口径,不要硬撑也不要静默放行
 
-**仓库未接入 code scanning 的判定**:`codeql_checks` 全程为空 + `security_alerts.available == false`(两端 alerts API 均不可用)+ PR 上从无两家 bot 评论 → 视为未接入,三条门槛整体跳过,但退出汇报中必须注明"未检测到 code scanning,该门槛未核对"。注意 GitHub 对无权限的资源同样返回 404,`unavailable_hint` 是佐证而非铁证,拿不准时问用户一次
+**仓库未接入 code scanning 的判定**:`codeql_checks` 全程为空 + `security_alerts.available == false`(两端 alerts API 均不可用)+ PR 上从无两家 bot 评论 → 疑似未接入。**不得据此自动跳过**——GitHub 对无权限的资源同样返回 404,权限不足(如 token 缺 `security_events` scope)会伪装成与未接入相同的三信号,静默跳过等于放行未核对的安全告警。先读 `unavailable_hint` 判别:含 403 / permission / "must be enabled"(Advanced Security 未开)字样 → 权限或配置问题,按故障类暂停处理,不可跳过;含 404 + "not enabled" / "no analysis found" → 未接入佐证。无论判别结果如何,跳过门槛前都必须向用户确认一次,确认后在退出汇报中注明"code scanning 未接入(经用户确认),该门槛未核对"
 
 ## REST vs GraphQL 命名陷阱
 

--- a/.agents/skills/pr-ai-review-loop/references/reviewers.md
+++ b/.agents/skills/pr-ai-review-loop/references/reviewers.md
@@ -1,47 +1,111 @@
-# AI Reviewer 速查
+# Reviewer 速查
 
-本 skill 的循环决策依赖三家 bot 的状态信号。每家表达"已审查 / 有意见 / 已通过"的方式不同,需按对应方式解读。
+循环决策依赖各家 bot 的状态信号,每家表达「已审 / 有 actionable 评论 / 已通过」的方式不同。本文件按 reviewer 聚合每家的全部规则(身份、触发、已审判定、actionable、通过信号);SKILL.md 只保留与 reviewer 无关的循环骨架。
 
-## 三家概览
+## 通用约定
 
-| Reviewer | GraphQL `author.login` | REST `user.login` | 自动 review 时机 | 状态表达方式 | 触发命令 |
-|---|---|---|---|---|---|
-| CodeRabbit | `coderabbitai` | `coderabbitai[bot]` | PR opened 及后续每次 push 均自动 | **反复改写首条评论(walkthrough)**:`updated_at` 会被推后,body 开头带 `<!-- ... summarize by coderabbit.ai -->` HTML 注释。通过时 body 首行为 `No actionable comments were generated in the recent review. 🎉`。其余 reply 为独立会话评论 | `@coderabbitai resume` / `review` / `full review` |
-| Gemini Code Assist | `gemini-code-assist` | `gemini-code-assist[bot]` | **仅 PR opened 时自动**(5 分钟内出结果);后续 push 不自动跟,需手动 `/gemini review` | **review summary** 每次发一条新评论(body 以 `## Code Review` 开头,涵盖整个 PR 的总结,**其中可能包含 actionable 建议** —— 不能只看 inline);**严重度标签位于 inline review comment 中**,body 开头形如 `![high](https://www.gstatic.com/codereviewagent/high-priority.svg)` 的 markdown 图片 | `/gemini review` |
-| OpenAI Codex | `chatgpt-codex-connector` | `chatgpt-codex-connector[bot]` | **取决于仓库配置**:默认需手动 `@codex review`;若仓库开启 PR 自动 review,Codex 会自动跟新 commit | **三种 ack 模式**,见下文 | `@codex review` |
+- **本轮新评论**:`created_at > last_push_at`。不要用 `commit_id == head` 判断——CodeRabbit 重审新 HEAD 时会改写旧 inline 的 `commit_id`,`created_at` 才是逐评论稳定的
+- **Acknowledgment 例外**:`inline_comments_by_user.*` 中 `is_ack == true` 的条目是 reviewer 对上一次修复或 inline 回复的确认,一律**不算** actionable;review state 为 `APPROVED` 也不算
+- **fix-up 顺延**:某家对上一已审 HEAD 已通过,且其后的 push 全为 fix-up(见 SKILL.md「fix-up 跳过」)时,沿用该通过结论参与目标判定,不触发重审——CodeRabbit 自动跟审每次 push,最终 HEAD 始终至少有它过目。前提是"已通过":该家还有未解决评论时不得跳过,必须正常触发重审
+- **触发去重**:同一 HEAD 上每种触发命令只发一次。在 `own_trigger_comments` 中取该命令最大 `createdAt`,晚于 `last_push_at` 即视为本轮已触发,跳过(`@coderabbitai resume` 例外:以 CodeRabbit 节的 `updated_at` 口径为准)。发触发命令时评论体只含命令本身——附加任何说明文字都会使 `own_trigger_comments` 的全行匹配落空,去重随之失效
 
-### Gemini 的 opened 与 synchronize 行为差异
+## 总表
 
-Gemini Code Assist 是事件驱动的 review bot,两种事件下行为不同,本 skill 的决策需要区分:
+| Reviewer | GraphQL `author.login` | REST `user.login` | 自动 review 时机 | 触发命令 |
+|---|---|---|---|---|
+| CodeRabbit | `coderabbitai` | `coderabbitai[bot]` | PR opened 及后续每次 push | `@coderabbitai resume` / `review` / `full review` |
+| Gemini Code Assist | `gemini-code-assist` | `gemini-code-assist[bot]` | **仅 PR opened**(5 分钟内出结果) | `/gemini review` |
+| OpenAI Codex | `chatgpt-codex-connector` | `chatgpt-codex-connector[bot]` | 取决于仓库配置 | `@codex review` |
+| GitHub Code Quality | —(只发 inline) | `github-code-quality[bot]` | 每次 push 后的 CodeQL 分析 | **不可触发** |
+| GitHub Advanced Security | —(只发 inline) | `github-advanced-security[bot]` | 同上 | **不可触发** |
 
-- **PR opened**:GitHub App 自动 review,通常 5 分钟内提交首条 review summary。本 skill 首轮 poll 应预留至少 180 秒 cold-start 等待,期间**不应**手动发送 `/gemini review`——重复触发会让 Gemini 再扫一遍,既消耗 quota,也容易引入第一次未提及的边缘建议。
-- **synchronize**(向已存在的 PR push 新 commit):Gemini 不会自动重新 review。当前 HEAD 上若需要 Gemini 重新审查,需要手动发送 `/gemini review`。
+## CodeRabbit
 
-判别方法(按 `poll.sh` 输出的 `pr_created_at` 与 `gemini.reviews`):
+**状态表达**:反复改写首条评论(walkthrough),`updated_at` 被推后,body 开头带 `<!-- ... summarize by coderabbit.ai -->` HTML 注释。通过时 body 首行为 `No actionable comments were generated in the recent review. 🎉`。其余 reply 为独立会话评论。
 
-- `gemini.reviews` 完全为空且 `pr_created_at` 距今不足 5 分钟 → cold-start 窗口内,等待即可
-- `gemini.reviews` 完全为空且 `pr_created_at` 距今已超过 5 分钟,且 `own_trigger_comments` 中不存在 `/gemini review`(或存在但最大 `createdAt ≤ last_push_at`)→ cold-start fallback:自动 review 未在窗口内出现(可能失败或被跳过),手动发送 `/gemini review`
-- `gemini.reviews` 非空但最新一条 `submittedAt < last_push_at`,且 `own_trigger_comments` 中不存在 `/gemini review`(或存在但最大 `createdAt ≤ last_push_at`)→ synchronize 场景,手动发送 `/gemini review`
+**触发**:`coderabbit.walkthrough.is_paused == true`,且 `updated_at` 之后未发送过 `@coderabbitai resume`(从 `own_trigger_comments` 筛,最新一条 `createdAt` 早于 walkthrough 的 `updated_at`;为空视为未发送)→ 发送 `@coderabbitai resume`。其余场景 CodeRabbit 自动跟新 push,无需手动触发。
 
-## Codex 三种 ack 模式
+**已审当前 HEAD**:`coderabbit.walkthrough.updated_at > last_push_at`。
 
-Codex 表达"对当前 HEAD 没意见"有三条路径,任一命中都算 ack:
+**actionable**:`walkthrough.is_ok == true` 或 `actionable_count == "0"` 时无 actionable;否则查看 `inline_comments_by_user["coderabbitai[bot]"]` 中本轮新条目,body 开头含 `_⚠️ Potential issue_`、`_🟠 Major_`、`_🛠️ Refactor suggestion_`、`_💡 Verification agent_` 等标签均算 actionable;nit 级不算。
 
-1. **inline review with body**:`codex.reviews` 最新一条,body 开头 `### 💡 Codex Review`,含 `**Reviewed commit:** <SHA>`。短 SHA 前 7-10 位与当前 HEAD 匹配即算
-2. **PR-level +1 reaction**:`codex.reactions` 里有 `content == "+1"` **且** `created_at > last_push_at`(必须是本轮 push 之后留的 👍,旧的不算)。Codex 用这条表示"看过了没话说"
-3. **empty-body review**:`codex.reviews` 最新一条 `submittedAt > last_push_at` **且** `state == "COMMENTED"` **且** `body == ""`,且本轮没有新 inline。Codex 自动跟新 HEAD 但无新意见时,可能用空 body review 代替 reaction
+**通过**:前置条件——已审当前 HEAD **且** `is_in_progress == false` **且** `is_paused == false`(paused 时 `is_ok` 等字段可能是上一轮残留,需先经触发规则 resume 后再判)。前置之上满足任一:
+
+- `walkthrough.is_ok == true`
+- `actionable_count == "0"`
+- 本轮 inline 均为 `is_ack == true`
+- 本轮 inline 均为 nit 级(body 含 `_🧹 Nitpick_` / `_🔵 Trivial_` / `_💤 Low value_`,不含上述 actionable 标签)
+
+## Gemini Code Assist
+
+**状态表达**:每次 review 发一条新 summary 评论(body 以 `## Code Review` 开头,涵盖整个 PR,**其中可能包含 inline 没有的 actionable 建议**——不能只看 inline);severity 标签在 inline 评论 body 开头,形如 `![high](https://www.gstatic.com/codereviewagent/high-priority.svg)` 的 markdown 图片。
+
+**opened 与 synchronize 行为差异**:PR opened 时 GitHub App 自动 review;向已存在的 PR push 新 commit(synchronize)**不会**自动重审,需手动 `/gemini review`。cold-start 窗口内不要手动触发——重复触发既耗 quota,也容易引入第一次未提及的边缘建议。
+
+**触发**(按 `pr_created_at` 与 `gemini.reviews` 判别,均受触发去重约束):
+
+- `gemini.reviews` 完全为空,`pr_created_at` 距今**不足 5 分钟** → cold-start 窗口内,等待,不触发
+- `gemini.reviews` 完全为空,`pr_created_at` 距今**已超 5 分钟** → cold-start fallback:自动 review 未在窗口内出现(可能失败或被跳过),发送 `/gemini review`。**此行不受 fix-up 跳过限制**——此时整个 PR 还没经过任何 Gemini review,不补发则 Gemini 永远不会审本 PR
+- `gemini.reviews` 非空但最新一条 `submittedAt < last_push_at` → synchronize 场景,发送 `/gemini review`(受 fix-up 跳过限制)
+
+**已审当前 HEAD**:`gemini.reviews[*].submittedAt > last_push_at` 至少一条。
+
+**actionable**(两条路径,任一命中即算):
+
+- **inline 路径**:本轮新 inline 中 `severity_alt` 为 `high` / `medium` / `critical`;`low` / `nit` / `style` 不算
+- **summary 路径**:本轮最新一条 `gemini.reviews` 的 body 非空且不含明确通过标记(`LGTM`、`No issues found`、`Approved`、仅有 `## Code Review` 标题而无后续内容)
+
+**通过**:前置条件——已审当前 HEAD(避免误用上一轮的通过标记)。前置之上需**同时**满足:
+
+1. 本轮无新 inline,或本轮新 inline 全部为 `low/nit/style` 或全部 `is_ack`
+2. summary 最新一条 body 含明确通过标记(非空不等于通过)
+
+## OpenAI Codex
+
+**触发决策**:仓库未开启自动 review 时,是否手动 `@codex review` 综合判断——用户明确意图(提到 codex 通常意味着要触发)、CodeRabbit 与 Gemini 意见冲突需第三方仲裁、改动面值得多看一遍(敏感模块、跨模块影响、新增依赖)、当前 HEAD 未触发过、fix-up 跳过未命中。
+
+**三种 ack 模式**(任一命中即算"对当前 HEAD 无 actionable"):
+
+1. **inline review with body**:`codex.reviews` 最新一条,body 开头 `### 💡 Codex Review`,含 `**Reviewed commit:** <SHA>`,短 SHA 前 7-10 位与当前 HEAD 匹配
+2. **PR-level +1 reaction**:`codex.reactions` 里有 `content == "+1"` **且** `created_at > last_push_at`(必须是本轮 push 之后留的 👍,旧的不算)
+3. **empty-body review**:`codex.reviews` 最新一条 `submittedAt > last_push_at` **且** `state == "COMMENTED"` **且** `body == ""`,且本轮无新 inline
+
+**已审当前 HEAD**:满足三种 ack 模式任一。
+
+**actionable**:本轮新 inline 中 `severity_alt` 为 `Pn Badge` 形式;P0/P1 通常算 actionable,P2/P3 视情况。
+
+**通过**:满足三种 ack 模式之一,且本轮无 ack 以外的 inline。
+
+## GitHub code scanning bots(Code Quality + Advanced Security)
+
+同一次 CodeQL 分析的两个投递面:`github-code-quality[bot]` 发质量告警(unused import、empty except 等,附修复建议),`github-advanced-security[bot]` 发安全告警(链接到 `/security/code-scanning/<n>` 的 alert)。与三家 AI reviewer 的本质差异:
+
+- **不可触发**,随 push 后的 CodeQL 分析自动产出,可能比 CodeRabbit 慢几分钟
+- **不读 inline 回复**,修复 push 后 alert 自动关闭——修了就不用回
+- **对未修复告警不重复提醒**:同一 alert 只在引入时评论一次,后续 push 不重贴。因此"无遗留告警"**不能**用"本轮无新评论"判定,漏修一条会静默通过
+- quality 告警通常**不会**让 check 变红,光看 CI 红绿会漏
+
+**actionable**:两家所有本轮新 inline 一律算 actionable(量少且都是 CodeQL 高置信度规则),与三家 AI reviewer 的评论合并转交 `receiving-code-review`。pushback(误报、不该提交的产物等)仍由 `receiving-code-review` 判断,但落点是 PR 评论说明或 dismiss alert,**不是**回 inline。
+
+**退出门槛**(代替"通过",在准备宣布循环结束时核对):
+
+1. **分析完成且成功**:`codeql_checks` 非空,且各 check 对当前 HEAD 全部 `status == "completed"`、`conclusion` 无 failure / cancelled / timed_out(同名 check 取最新一条;check suite 重跑会产生同名多条)。两个陷阱:空数组对"全部 completed"恒真,但为空只说明分析未注册(继续等待)或仓库未接入(见下),不是通过;conclusion 失败时 alerts 数据停留在上次成功分析,直接核对门槛 2 会漏报新告警——归入故障类暂停。分析超过 15 分钟未完成同样归入故障类暂停
+2. **security 无遗留**:`security_alerts.open_introduced` 为空(poll.sh 已做 base 分支差集,排除存量告警)。`available == false` 时降级:把 `unavailable_hint` 贴给用户,说明无法核对 alerts API(权限或 merge ref 原因),请人工确认后再退出
+3. **quality 无遗留**:PR 上 `github-code-quality[bot]` 的**全量** inline 评论(不限本轮)逐条核对——对应代码已修改,或已有 pushback 记录(PR 评论说明)。quality 没有可查的告警列表 API(实测 404),全量评论 + 代码现状就是完整事实;不要依赖"本次循环收集过哪些"的对话记忆,压缩后无法重建
+
+**仓库未接入 code scanning 的判定**:`codeql_checks` 全程为空 + `security_alerts.available == false`(两端 alerts API 均不可用)+ PR 上从无两家 bot 评论 → 视为未接入,三条门槛整体跳过,但退出汇报中必须注明"未检测到 code scanning,该门槛未核对"。注意 GitHub 对无权限的资源同样返回 404,`unavailable_hint` 是佐证而非铁证,拿不准时问用户一次
 
 ## REST vs GraphQL 命名陷阱
 
-`poll.sh` 的 JSON 输出已统一 key 命名 —— `inline_comments_by_user` 用 REST 的带 `[bot]` 名(因为 inline 数据本就来自 REST),其它顶层字段用 GraphQL 的不带 `[bot]` 名。**不过**直接写 SKILL.md 之外的 jq 时:
+`poll.sh` 的 JSON 输出已统一 key 命名——`inline_comments_by_user` 用 REST 的带 `[bot]` 名(inline 数据本就来自 REST),其它顶层字段用 GraphQL 的不带 `[bot]` 名。**不过**直接写 SKILL.md 之外的 jq 时:
 
 | 数据源 | 字段路径 | 带不带 `[bot]` |
 |---|---|---|
-| `gh pr view --json reviews,comments,...` (GraphQL) | `.author.login` | **不带** —— 比如 `coderabbitai` |
-| `gh api repos/.../pulls/.../comments` (REST inline) | `.user.login` | **带** —— 比如 `coderabbitai[bot]` |
-| `gh api repos/.../issues/.../reactions` (REST) | `.user.login` | **带** —— 比如 `chatgpt-codex-connector[bot]` |
+| `gh pr view --json reviews,comments,...`(GraphQL) | `.author.login` | **不带**——比如 `coderabbitai` |
+| `gh api repos/.../pulls/.../comments`(REST inline) | `.user.login` | **带**——比如 `coderabbitai[bot]` |
+| `gh api repos/.../issues/.../reactions`(REST) | `.user.login` | **带**——比如 `chatgpt-codex-connector[bot]` |
 
-两边的字符串不通用。
+两边的字符串不通用。GitHub code scanning 两家 bot 只出现在 REST inline 数据中(不发 GraphQL 可见的 review/comment)。
 
 ## 查询 bot 新名称
 
@@ -52,10 +116,8 @@ gh pr view <PR> --json reviews,comments \
   --jq '[.reviews[].author.login, .comments[].author.login] | unique'
 ```
 
-REST 名规则:GraphQL 名 + `[bot]` 后缀。同步修改 `references/reviewers.md` 和 `scripts/poll.sh` 的两处 select 语句。
+REST 名规则:GraphQL 名 + `[bot]` 后缀。同步修改本文件和 `scripts/poll.sh` 的 select 语句。
 
-## 其它 bot
+## reviewer 进出循环
 
-`github-code-quality[bot]`(GitHub 自带静态分析)、`codecov[bot]`(覆盖率)这类默认**不**纳入主循环 —— 它们输出大多是死板的 nit / 数字,没有"等待"或"重审"的概念。调 receiving-code-review 时会一并看到它们的 inline 意见。
-
-用户可以随时让某家 reviewer 进/出循环("这次别管 gemini"、"叫上 codex"、"也看看 code-quality"),按用户的意图执行。
+用户可以随时让某家 reviewer 进/出循环("这次别管 gemini"、"叫上 codex"),按用户意图执行。`codecov[bot]` 等纯指标类 bot 不纳入循环——它们没有意见可实施,也没有等待或重审的概念。

--- a/.agents/skills/pr-ai-review-loop/references/reviewers.md
+++ b/.agents/skills/pr-ai-review-loop/references/reviewers.md
@@ -7,7 +7,7 @@
 - **本轮新评论**:`created_at > last_push_at`。不要用 `commit_id == head` 判断——CodeRabbit 重审新 HEAD 时会改写旧 inline 的 `commit_id`,`created_at` 才是逐评论稳定的
 - **Acknowledgment 例外**:`inline_comments_by_user.*` 中 `is_ack == true` 的条目是 reviewer 对上一次修复或 inline 回复的确认,一律**不算** actionable;review state 为 `APPROVED` 也不算
 - **fix-up 顺延**:某家对上一已审 HEAD 已通过,且其后的 push 全为 fix-up(见 SKILL.md「fix-up 跳过」)时,沿用该通过结论参与目标判定,不触发重审——CodeRabbit 自动跟审每次 push,最终 HEAD 始终至少有它过目。**「上一已审 HEAD」指该家最近一次实际审过的 commit,不是最近一次通过的 commit**——若该家最近审的 HEAD 未通过(如 A 通过 → B 有 actionable → C fix-up,最近审的是 B),前提不满足,不得顺延;「其后」从该已审 HEAD 的下一个 commit 起算,到当前 HEAD 为止须全为 fix-up。该家还有未解决评论时同样不得跳过,必须正常触发重审
-- **触发去重**:同一 HEAD 上每种触发命令只发一次。在 `own_trigger_comments` 中取该命令最大 `createdAt`,晚于 `last_push_at` 即视为本轮已触发,跳过(`@coderabbitai resume` 例外:以 CodeRabbit 节的 `updated_at` 口径为准)。poll.sh 按**前缀**匹配:评论以命令开头即被收录(`/gemini review 补充说明` 算;`考虑过 /gemini review` 这类中段提及不算——故意不用包含匹配,否则引用过命令的 pushback 评论会被误判为已触发,导致漏触发)。发触发命令时仍应只写命令本身,且命令必须在评论首行——正则锚定整串开头,第二行的命令不会被识别
+- **触发去重**:同一 HEAD 上每种触发命令只发一次。在 `own_trigger_comments` 中取该命令最大 `createdAt`,晚于 `last_push_at` 即视为本轮已触发,跳过(`@coderabbitai resume` 例外:以 CodeRabbit 节的 `updated_at` 口径为准)。poll.sh 按**前缀**匹配:评论以命令开头即被收录(`/gemini review 补充说明` 算;`考虑过 /gemini review` 这类中段提及不算——故意不用包含匹配,否则引用过命令的 pushback 评论会被误判为已触发,导致漏触发)。发触发命令时仍应只写命令本身,且命令必须在评论最开头——前导只容空格/制表符(不容换行),空首行之后或第二行起的命令不会被识别
 
 ## 总表
 

--- a/.agents/skills/pr-ai-review-loop/scripts/poll.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/poll.sh
@@ -76,9 +76,13 @@
 #    (b) PR-level +1 reaction with NO comment (silent pass)
 #    (c) empty-body review (state=COMMENTED, body="") with no new inline
 #
-# 5. Trigger-command dedup MUST normalize whitespace + case.
-#    "@CodeRabbitAI Resume" / " @coderabbitai resume " / "@coderabbitai resume\n" all count as the same command.
-#    Use `test("...";"i")` with leading/trailing \s* — keep this regex consistent everywhere.
+# 5. Trigger-command dedup matches comments that START with the command (case-insensitive,
+#    leading whitespace tolerated, trailing text allowed). Prefix matching — not full-line —
+#    so a human-issued "/gemini review (re: security fix)" still registers for dedup, while
+#    a comment merely MENTIONING a command mid-text does not (substring matching would
+#    swallow pushback comments that quote a command, silently suppressing real triggers).
+#    Note: jq's regex anchors ^/$ bind to the whole string, not lines — a command on the
+#    second line of a comment is NOT matched; keep commands at the start of the comment.
 #
 # 6. Quota / rate-limit errors from Codex are PR-level ISSUE comments, NOT reviews/inline/reactions.
 #    Codex emits e.g. "You have reached your Codex usage limits..." as a plain PR comment — easy to miss.
@@ -133,8 +137,11 @@ gh pr view "$PR" --json number,createdAt,headRefOid,reviews,comments,commits > "
   exit 5
 }
 
-# REST endpoints — gh api wraps each page in []; --paginate yields concatenated arrays
-# (one big array, not a stream), which --slurpfile correctly reads as a single value.
+# REST endpoints. --paginate output shape differs by mode (verified empirically):
+#   - WITHOUT --jq/-q: gh merges all pages of an array endpoint into ONE JSON array,
+#     so --slurpfile sees a single value — unwrap with [0].
+#   - WITH -q: the projection runs per page, emitting one JSON value PER PAGE
+#     (concatenated stream) — unwrap with `add` (see sub-query D).
 # user.login here is WITH [bot] suffix.
 
 # Sub-query A — REST issue comments. Used to get CodeRabbit walkthrough's updated_at
@@ -187,9 +194,10 @@ if ! gh api "repos/${OWNER_REPO}/code-scanning/alerts?state=open&per_page=100" -
 fi
 
 # Combine everything in jq. Bot login normalization happens here so consumers see consistent keys.
-# --slurpfile wraps each file in [...]; unwrap with [0] at the top. Sub-query D/E files may
-# hold multiple page values (--paginate), so they are unwrapped with `add` instead (flattens
-# pages, tolerates a single page).
+# --slurpfile wraps each file in [...]. Unwrap rule: files written WITHOUT -q hold one
+# merged array (gh merges pages) — [0] suffices; sub-query D is written WITH -q, so it
+# holds one array PER PAGE — only `add` flattens that correctly ([0] would drop pages 2+).
+# `add` also equals [0] on single-value files, so D/E both use it.
 jq -n \
   --slurpfile main_w "$TMPDIR/main.json" \
   --slurpfile sub_a_w "$TMPDIR/sub_a.json" \
@@ -329,7 +337,7 @@ jq -n \
            (.author.login != "coderabbitai"
             and .author.login != "gemini-code-assist"
             and .author.login != "chatgpt-codex-connector")
-           and (.body | test("^\\s*(/gemini review|@codex review|@coderabbitai resume)\\s*$"; "i"))
+           and (.body | test("^\\s*(/gemini review|@codex review|@coderabbitai resume)(\\s|$)"; "i"))
          )
        | {author: .author.login, createdAt, body: (.body | gsub("^\\s+|\\s+$"; ""))}]
   }

--- a/.agents/skills/pr-ai-review-loop/scripts/poll.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/poll.sh
@@ -12,6 +12,9 @@
 #   "pr_created_at": "<ISO8601>",                       # PR createdAt (issue creation time) — distinct from last_push_at
 #   "head": "<sha>",                                    # current PR head commit SHA
 #   "last_push_at": "<ISO8601>",                        # head commit committedDate — see PITFALL 1
+#   "commits": [{oid, committedDate}],                  # full commit list (includes pre-PR development commits)
+#   "round_estimate": <int>,                            # fix-round count: commits with committedDate > pr_created_at, clustered
+#                                                       # by >5min gaps (rebase refreshes all dates => underestimates; heuristic only)
 #   "coderabbit": {
 #     "walkthrough": {                                  # CR's first comment (auto-edited each review)
 #       "id":                 <int>,                    # REST issue comment id — stable across walkthrough rewrites
@@ -33,8 +36,21 @@
 #     "comments":  [...],
 #     "reactions": [{content, created_at}]              # +1 reaction on PR = silent ack — see PITFALL 4
 #   },
-#   "inline_comments_by_user": {                        # PR-level inline review comments grouped by bot
-#     "<bot[bot]>": [{id, path, commit_id, created_at, severity_alt, is_ack, body_head}]  # id = REST PR review comment id
+#   "inline_comments_by_user": {                        # PR-level inline review comments grouped by bot — includes
+#     "<bot[bot]>": [{id, path, commit_id, created_at, severity_alt, is_ack, body_head}]  # github-code-quality[bot] and
+#   },                                                  # github-advanced-security[bot]; id = REST PR review comment id
+#   "codeql_checks": [{name, app, status, conclusion}], # CodeQL-related check runs on current HEAD (Analyze (*) /
+#                                                       # codeql-required / CodeQL, or runs owned by the code scanning apps)
+#   "checks_failing": [{name, conclusion}],             # ALL check runs on current HEAD with a failing-ish conclusion
+#                                                       # (failure/timed_out/cancelled/action_required/startup_failure);
+#                                                       # red CI can block reviewers, so fix it before waiting on them
+#   "security_alerts": {                                # code scanning alerts exit gate — see PITFALL 7
+#     "available": <bool>,                              # false = alerts API unreachable (missing scope / no merge-ref analysis); gate must degrade
+#     "unavailable_hint": "<str>" | null,               # first lines of the gh errors when available=false — helps distinguish
+#                                                       # 404 not-enabled vs 403 missing-scope vs no-analysis (note: GitHub returns
+#                                                       # 404 for missing permissions too, so treat as a hint, not proof)
+#     "pr_ref": "refs/pull/<n>/merge",
+#     "open_introduced": [{number, rule, severity, security_severity, tool, path, url}]  # open alerts introduced by this PR
 #   },
 #   "quota_alerts": [...],                              # PR-level issue comments matching quota keywords (bots emit quota errors as plain comments, not reviews)
 #   "own_trigger_comments": [...]                       # human-authored /gemini review / @codex review / @coderabbitai resume
@@ -67,6 +83,11 @@
 # 6. Quota / rate-limit errors from Codex are PR-level ISSUE comments, NOT reviews/inline/reactions.
 #    Codex emits e.g. "You have reached your Codex usage limits..." as a plain PR comment — easy to miss.
 #    Captured into quota_alerts so the skill catches it on the first poll.
+#
+# 7. security_alerts.open_introduced subtracts default-branch open alerts by alert number.
+#    The merge-ref analysis covers the whole codebase, so pre-existing alerts (e.g. scheduled
+#    Trivy scans on main) would otherwise block the exit gate forever. Alert numbers are
+#    repo-global and identical across refs, so a set difference on number is exact.
 
 set -euo pipefail
 
@@ -76,6 +97,11 @@ if [[ $# -lt 1 ]]; then
 fi
 
 PR="$1"
+
+if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+  echo "POLL_ERROR: PR_NUMBER must be a number, got: $PR" >&2
+  exit 2
+fi
 
 if ! command -v gh >/dev/null 2>&1; then
   echo "POLL_ERROR: gh CLI not found on PATH" >&2
@@ -133,13 +159,47 @@ gh api "repos/${OWNER_REPO}/pulls/${PR}/comments" --paginate > "$TMPDIR/sub_c.js
   exit 5
 }
 
+# Sub-query D — check runs on the PR head. Feeds two projections: codeql_checks (exit
+# gate: "analysis finished before declaring PASS") and checks_failing (red CI can block
+# reviewers). --paginate with -q runs the projection per page, emitting one array per
+# page; downstream slurpfile flattens with `add` (same as sub-query E).
+HEAD_SHA=$(jq -r '.headRefOid' "$TMPDIR/main.json")
+gh api "repos/${OWNER_REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" --paginate -q '[.check_runs[] | {name, app: .app.slug, status, conclusion}]' > "$TMPDIR/sub_d.json" 2>"$TMPDIR/gh_check_runs.err" || {
+  echo "POLL_ERROR: REST check-runs fetch failed" >&2
+  cat "$TMPDIR/gh_check_runs.err" >&2
+  exit 5
+}
+
+# Sub-query E — code scanning alerts (security exit gate). This API can fail for benign
+# reasons (token missing security-events scope, merge ref not analyzed yet, merge
+# conflict), so degrade to available=false instead of failing the whole poll.
+SECURITY_ALERTS_AVAILABLE=true
+SECURITY_ALERTS_HINT=""
+if ! gh api "repos/${OWNER_REPO}/code-scanning/alerts?ref=refs/pull/${PR}/merge&state=open&per_page=100" --paginate > "$TMPDIR/sub_e_pr.json" 2>"$TMPDIR/gh_alerts_pr.err"; then
+  SECURITY_ALERTS_AVAILABLE=false
+  SECURITY_ALERTS_HINT="pr-ref: $(head -n 2 "$TMPDIR/gh_alerts_pr.err" | tr '\n' ' ' | cut -c1-300)"
+  echo '[]' > "$TMPDIR/sub_e_pr.json"
+fi
+if ! gh api "repos/${OWNER_REPO}/code-scanning/alerts?state=open&per_page=100" --paginate > "$TMPDIR/sub_e_base.json" 2>"$TMPDIR/gh_alerts_base.err"; then
+  SECURITY_ALERTS_AVAILABLE=false
+  SECURITY_ALERTS_HINT="${SECURITY_ALERTS_HINT} base: $(head -n 2 "$TMPDIR/gh_alerts_base.err" | tr '\n' ' ' | cut -c1-300)"
+  echo '[]' > "$TMPDIR/sub_e_base.json"
+fi
+
 # Combine everything in jq. Bot login normalization happens here so consumers see consistent keys.
-# --slurpfile wraps each file in [...]; unwrap with [0] at the top.
+# --slurpfile wraps each file in [...]; unwrap with [0] at the top. Sub-query D/E files may
+# hold multiple page values (--paginate), so they are unwrapped with `add` instead (flattens
+# pages, tolerates a single page).
 jq -n \
   --slurpfile main_w "$TMPDIR/main.json" \
   --slurpfile sub_a_w "$TMPDIR/sub_a.json" \
   --slurpfile sub_b_w "$TMPDIR/sub_b.json" \
   --slurpfile sub_c_w "$TMPDIR/sub_c.json" \
+  --slurpfile sub_d_w "$TMPDIR/sub_d.json" \
+  --slurpfile sub_e_pr_w "$TMPDIR/sub_e_pr.json" \
+  --slurpfile sub_e_base_w "$TMPDIR/sub_e_base.json" \
+  --argjson security_available "$SECURITY_ALERTS_AVAILABLE" \
+  --arg security_hint "$SECURITY_ALERTS_HINT" \
   '
   ($main_w[0]) as $main
   | ($sub_a_w[0]) as $sub_a
@@ -169,7 +229,7 @@ jq -n \
     (test("<!--\\s*<review_comment_addressed>")) or (test("^### Summary"));
 
   def inline_by_bot:
-    [$sub_c[] | select(.user.login | test("(coderabbitai|gemini-code-assist|chatgpt-codex-connector)\\[bot\\]$"))]
+    [$sub_c[] | select(.user.login | test("(coderabbitai|gemini-code-assist|chatgpt-codex-connector|github-code-quality|github-advanced-security)\\[bot\\]$"))]
     | group_by(.user.login)
     | map({
         key:   .[0].user.login,
@@ -180,7 +240,7 @@ jq -n \
           created_at,
           severity_alt: ([.body | capture("!\\[(?<s>[^\\]]+)\\]")] | .[0].s // null),
           is_ack:       (.body | is_ack_body),
-          body_head:    (.body | .[0:200])
+          body_head:    (.body | .[0:400])
         })
       })
     | from_entries;
@@ -207,6 +267,13 @@ jq -n \
     pr_created_at: $main.createdAt,
     head:          $main.headRefOid,
     last_push_at:  ($main.commits | last.committedDate),
+    commits:       [$main.commits[] | {oid, committedDate}],
+    round_estimate:
+      ([$main.commits[] | select(.committedDate > $main.createdAt) | .committedDate]
+       | sort | map(fromdateiso8601)
+       | reduce .[] as $t ({prev: 0, n: 0};
+           if ($t - .prev) > 300 then {prev: $t, n: (.n + 1)} else {prev: $t, n: .n} end)
+       | .n),
 
     coderabbit: {
       walkthrough:    cr_walkthrough_rest,
@@ -226,6 +293,33 @@ jq -n \
     },
 
     inline_comments_by_user: inline_by_bot,
+
+    codeql_checks:
+      [($sub_d_w | add)[]
+       | select((.app == "github-advanced-security" or .app == "github-code-quality")
+                or (.name | test("^Analyze \\(|^codeql-required$|^CodeQL$")))],
+
+    checks_failing:
+      [($sub_d_w | add)[]
+       | select(.conclusion | IN("failure", "timed_out", "cancelled", "action_required", "startup_failure"))
+       | {name, conclusion}],
+
+    security_alerts: {
+      available: $security_available,
+      unavailable_hint: (if $security_available then null else $security_hint end),
+      pr_ref: ("refs/pull/" + ($main.number | tostring) + "/merge"),
+      open_introduced:
+        (($sub_e_base_w | add | map(.number)) as $base_numbers
+         | [($sub_e_pr_w | add)[]
+            | select(.number as $n | $base_numbers | index($n) | not)
+            | {number,
+               rule:              .rule.id,
+               severity:          .rule.severity,
+               security_severity: .rule.security_severity_level,
+               tool:              .tool.name,
+               path:              .most_recent_instance.location.path,
+               url:               .html_url}])
+    },
 
     quota_alerts: quota_alerts,
 

--- a/.agents/skills/pr-ai-review-loop/scripts/poll.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/poll.sh
@@ -77,12 +77,13 @@
 #    (c) empty-body review (state=COMMENTED, body="") with no new inline
 #
 # 5. Trigger-command dedup matches comments that START with the command (case-insensitive,
-#    leading whitespace tolerated, trailing text allowed). Prefix matching — not full-line —
+#    leading spaces/tabs tolerated, trailing text allowed). Prefix matching — not full-line —
 #    so a human-issued "/gemini review (re: security fix)" still registers for dedup, while
 #    a comment merely MENTIONING a command mid-text does not (substring matching would
 #    swallow pushback comments that quote a command, silently suppressing real triggers).
-#    Note: jq's regex anchors ^/$ bind to the whole string, not lines — a command on the
-#    second line of a comment is NOT matched; keep commands at the start of the comment.
+#    Leading whitespace is [ \t] only, NOT \s: \s matches \n, which would also register a
+#    command sitting on the second line after a blank first line — keep the matcher aligned
+#    with the documented contract (command at the very start of the comment).
 #
 # 6. Quota / rate-limit errors from Codex are PR-level ISSUE comments, NOT reviews/inline/reactions.
 #    Codex emits e.g. "You have reached your Codex usage limits..." as a plain PR comment — easy to miss.
@@ -337,7 +338,7 @@ jq -n \
            (.author.login != "coderabbitai"
             and .author.login != "gemini-code-assist"
             and .author.login != "chatgpt-codex-connector")
-           and (.body | test("^\\s*(/gemini review|@codex review|@coderabbitai resume)(\\s|$)"; "i"))
+           and (.body | test("^[ \\t]*(/gemini review|@codex review|@coderabbitai resume)(\\s|$)"; "i"))
          )
        | {author: .author.login, createdAt, body: (.body | gsub("^\\s+|\\s+$"; ""))}]
   }


### PR DESCRIPTION
## 背景

对 `/pr-ai-review-loop` 做一次优化改版;改版完成后又对结果跑了一轮完整审阅(22 条发现,经逼问式过堂达成 4 项拍板),调整全部落地。三文件:`SKILL.md`(重写为 128 行)、`references/reviewers.md`、`scripts/poll.sh`。

## 优化改版(主体)

- **纳入 GitHub code scanning**:Code Quality / Advanced Security(CodeQL)两家 bot 进入循环——poll.sh 新增 `codeql_checks` 与 `security_alerts`(对 base 分支做差集,排除存量告警)查询;reviewers.md 新增「GitHub code scanning bots」节与退出门槛;目标状态增加 CodeQL 门槛
- **循环无状态化**:删除对话内状态账本(round_count / topic_history / last_commit_shapes),每轮判定全部从 poll 输出与 git 数据现场推导——上下文压缩或会话中断后重跑一轮步骤 1 即可完全恢复
- **per-reviewer 规则聚合**:各家(CodeRabbit / Gemini / Codex / code scanning)的身份、触发、已审、actionable、通过判定全部收进 reviewers.md,SKILL.md 只留与 reviewer 无关的循环骨架(目标状态 → 找缺口 → 最小动作集)

## 第二轮审阅调整(五个真实缺口,场景留档)

1. **fix-up 顺延与目标判定冲突**:push 全为 fix-up 时跳过手动触发 Gemini/Codex,但目标要求"每家对当前 HEAD 通过"——两规则相遇时该家永远"未审",15 分钟后误报故障暂停。修复:引入「fix-up 顺延」条款,沿用上一已审 HEAD 的通过结论,前提是该家已通过(不洗白未通过);故障处理注明顺延导致的"未审"不算无响应。
2. **open alert 未修干净时死等**:GitHub code scanning bot 对同一 alert 只评论一次,后续 push 不重贴。上一轮没修干净时既无新评论也无决策表行可走,循环死等到超时。修复:决策表新增一行——`open_introduced` 非空但无对应新评论时,把 alert 数据(rule/path/url)直接带入修复,按数据修而非按评论修。
3. **CodeQL 门槛静默放行**:"全部 completed"存在两个漏洞——空数组对全称量词恒真(分析未注册时直接通过);conclusion=failure 时 status 仍是 completed,而 alerts 数据停留在上次成功分析,核对门槛会漏报新告警。修复:门槛改为"非空 + completed + conclusion 无 failure/cancelled/timed_out",失败归故障类暂停;另增"仓库未接入"组合判定(三信号同时成立才跳过,汇报必须注明)。
4. **轮数虚增误触发收敛兜底**:数 PR 全部 commits 会把开发期(PR 创建前)的 commits 也计入,长分支虚增到"已 8 轮"误暂停。修复:轮数推导下沉 poll.sh 为 `round_estimate`——只取 `committedDate > pr_created_at` 的 commits,按相邻间隔 >5 分钟聚类成批次数。
5. **quality 门槛依赖对话记忆**:"本次循环收集过的评论均已处置"是对话状态,上下文压缩后无法重建,违反自家无状态原则。修复:改为全量现场口径——PR 上 `github-code-quality[bot]` 的全部 inline 逐条核对代码现状或 pushback 记录。

## 其余调整

- poll.sh:`$PR` 数字校验;check-runs 查询加 `--paginate`(per-page 投影由 jq `add` 展平);新增 `checks_failing` 与 `security_alerts.unavailable_hint` 字段及 schema 注释
- SKILL.md:CI 红就地修复并 push(不转交不暂停);终核语义(高成本门槛只在其余缺口消失后做一次);ScheduleWakeup 唤醒 prompt 写明 skill 名与 PR 号,压缩后可无损重入;步骤 3 补"合并一次调用 receiving-code-review"的 why(分家调用 = 多次 push = 全员重审,轮数与 quota 膨胀)
- reviewers.md:触发评论体只含命令本身(附加说明文字会破坏 `own_trigger_comments` 全行匹配去重);`@coderabbitai resume` 去重口径归位;Codex 措辞统一为"无 actionable"

## 验证

- 两脚本 `bash -n` 通过
- 对既有 PR 实跑 poll.sh:`round_estimate: 2`(3 个同秒 commit 一批 + 18 分钟后一批,截断与聚类正确)、`checks_failing: []`、`codeql_checks` 6 条(分页改造无回归)、`available: true / hint: null / open_introduced: []`
- hint 失败路径用实测 404 端点验证,输出 `pr-ref: gh: Not Found (HTTP 404)` 形态符合预期

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Documentation**
  * 重构评审循环文档为“目标状态”驱动流程，明确三步循环、决策表、轮询节奏与收敛/故障处理，精简内部状态字段与判定细则。
  * 统一并细化评审者判定与触发规则（actionable、ack、fix-up 顺延、触发去重、各家 reviewer 行为）、支持评审者临时进出与 bot 排除。

* **Chores**
  * 扩展轮询输出与容错：新增提交/轮次估算、检查与安全告警信息、增强摘要截断与触发匹配规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->