### PR TITLE
feat(scripts): 剧本按分集大纲改编：集尾落地钩子与下集预告，重排失效的集自动回退待预处理

### DIFF
--- a/lib/prompt_builders_script.py
+++ b/lib/prompt_builders_script.py
@@ -77,9 +77,11 @@ def _format_episode_outline_block(episode_outline: dict | None, next_episode_out
     """渲染本集大纲 + 下集大纲两个上下文块；无规划数据时返回空串（prompt 不渲染该段）。"""
     parts: list[str] = []
     if episode_outline:
+        title = episode_outline.get("title")
+        title_line = f"本集标题：{title}\n" if title else ""
         parts.append(f"""<episode_outline>
 本集大纲（分集规划设计，剧本改编应覆盖全部故事节点）：
-{_format_outline_lines(episode_outline)}
+{title_line}{_format_outline_lines(episode_outline)}
 </episode_outline>""")
         if episode_outline.get("hook") or episode_outline.get("next_episode_teaser"):
             parts.append(_HOOK_LANDING_GUIDE)

--- a/lib/prompt_builders_script.py
+++ b/lib/prompt_builders_script.py
@@ -50,6 +50,51 @@ def _format_aspect_ratio_desc(aspect_ratio: str) -> str:
     return f"{aspect_ratio} 构图"
 
 
+def _format_outline_lines(outline: dict) -> str:
+    """渲染分集大纲条目：故事节点 / 集尾钩子 / 下集预告语，缺失的行省略。"""
+    lines: list[str] = []
+    beats = outline.get("story_beats") or []
+    if beats:
+        lines.append("故事节点：")
+        lines.extend(f"- {beat}" for beat in beats)
+    if outline.get("hook"):
+        lines.append(f"集尾钩子：{outline['hook']}")
+    if outline.get("next_episode_teaser"):
+        lines.append(f"下集预告语：{outline['next_episode_teaser']}")
+    return "\n".join(lines)
+
+
+# 钩子落地要求：集尾钩子与下集预告是分集规划的核心设计，必须体现在成片末场，
+# 而不是只停留在规划文档里。仅在账本提供了钩子/预告时渲染。
+_HOOK_LANDING_GUIDE = (
+    "集尾钩子与下集预告不能只停留在大纲：末场（最后一个或几个分镜）的画面与对白"
+    "必须实际呈现集尾钩子的戏剧内容，让悬念定格在画面上；有下集预告语时，"
+    "用结尾画面或对白自然引出它，不要生硬插入「下集预告」字样的旁白。"
+)
+
+
+def _format_episode_outline_block(episode_outline: dict | None, next_episode_outline: dict | None) -> str:
+    """渲染本集大纲 + 下集大纲两个上下文块；无规划数据时返回空串（prompt 不渲染该段）。"""
+    parts: list[str] = []
+    if episode_outline:
+        parts.append(f"""<episode_outline>
+本集大纲（分集规划设计，剧本改编应覆盖全部故事节点）：
+{_format_outline_lines(episode_outline)}
+</episode_outline>""")
+        if episode_outline.get("hook") or episode_outline.get("next_episode_teaser"):
+            parts.append(_HOOK_LANDING_GUIDE)
+    if next_episode_outline:
+        title = next_episode_outline.get("title")
+        title_line = f"下集标题：{title}\n" if title else ""
+        parts.append(f"""<next_episode_outline>
+下集大纲（仅用于设计本集结尾的衔接，不要把下集情节提前写进本集）：
+{title_line}{_format_outline_lines(next_episode_outline)}
+</next_episode_outline>""")
+    if not parts:
+        return ""
+    return "\n\n".join(parts) + "\n\n"
+
+
 # ---------------------------------------------------------------------------
 # 字段写作指导（drama / narration 共用）
 # ---------------------------------------------------------------------------
@@ -199,12 +244,19 @@ def build_drama_prompt(
     default_duration: int | None = None,
     aspect_ratio: str = "16:9",
     target_language: str = "中文",
+    episode_outline: dict | None = None,
+    next_episode_outline: dict | None = None,
 ) -> str:
-    """构建剧集动画模式的剧本生成 prompt。"""
+    """构建剧集动画模式的剧本生成 prompt。
+
+    ``episode_outline`` / ``next_episode_outline`` 来自分集账本（title / hook /
+    story_beats / next_episode_teaser），None 表示账本无规划数据，prompt 不渲染大纲段。
+    """
     character_names = list(characters.keys())
     scene_names = list(scenes.keys())
     prop_names = list(props.keys())
     pacing_block = (render_pacing_section("drama") + "\n\n") if is_v2_enabled() else ""
+    outline_block = _format_episode_outline_block(episode_outline, next_episode_outline)
 
     return f"""# 角色与任务
 
@@ -248,7 +300,7 @@ def build_drama_prompt(
 
 shots 表每行是一个分镜，包含：分镜 ID（E{episode}S{{序号}}，当前为第 {episode} 集）、分镜描述、{_format_duration_constraint(supported_durations, default_duration)}、是否为 segment_break。
 
-<episode_constraints>
+{outline_block}<episode_constraints>
 当前正在生成第 {episode} 集。本集所有 scene_id 必须严格使用 `E{episode}S{{两位序号}}` 格式（如 E{episode}S01、E{episode}S02），不得使用其他集号前缀。
 若 shots 表里出现非 `E{episode}` 前缀（如 E1S..），视为脏数据，请按当前集号 `E{episode}` 重写。
 </episode_constraints>

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -87,13 +87,50 @@ class ScriptGenerator:
         self.project_json = self._load_project_json()
         self.content_mode = self.project_json.get("content_mode", "narration")
 
-    def _effective_generation_mode(self, episode: int) -> str:
-        """按 episode → project → 默认 storyboard 回退解析 generation_mode。"""
-        episode_dict = next(
-            (ep for ep in (self.project_json.get("episodes") or []) if ep.get("episode") == episode),
+    def _episode_entry(self, episode: int) -> dict:
+        """按集号取 project.json episodes 条目；缺失返回空 dict。"""
+        return next(
+            (
+                ep
+                for ep in (self.project_json.get("episodes") or [])
+                if isinstance(ep, dict) and ep.get("episode") == episode
+            ),
             {},
         )
-        return effective_mode(project=self.project_json, episode=episode_dict)
+
+    def _effective_generation_mode(self, episode: int) -> str:
+        """按 episode → project → 默认 storyboard 回退解析 generation_mode。"""
+        return effective_mode(project=self.project_json, episode=self._episode_entry(episode))
+
+    @staticmethod
+    def _entry_outline(entry: dict) -> dict:
+        """账本条目的 outline 字段归一化为 dict（缺失/形状异常返回空 dict）。"""
+        raw_outline = entry.get("outline")
+        return raw_outline if isinstance(raw_outline, dict) else {}
+
+    def _ledger_outline_context(self, episode: int) -> tuple[dict | None, dict | None]:
+        """从分集账本条目提取 drama 剧本生成的规划输入：(本集大纲, 下集大纲)。
+
+        大纲 dict 含 title / hook / story_beats / next_episode_teaser。条目无任何
+        规划数据（旧式条目，规划工具尚未写入）时对应项为 None，prompt 退回纯中间
+        文件输入；末集无下集，第二项为 None。
+        """
+
+        def _context(entry: dict) -> dict | None:
+            outline = self._entry_outline(entry)
+            raw_beats = outline.get("story_beats")
+            ctx = {
+                "title": entry.get("title"),
+                "hook": entry.get("hook"),
+                # 非 list 形状（手编损坏）按缺失处理，避免字符串被逐字符渲染进 prompt
+                "story_beats": raw_beats if isinstance(raw_beats, list) else [],
+                "next_episode_teaser": outline.get("next_episode_teaser"),
+            }
+            if not ctx["hook"] and not ctx["story_beats"] and not ctx["next_episode_teaser"]:
+                return None
+            return ctx
+
+        return _context(self._episode_entry(episode)), _context(self._episode_entry(episode + 1))
 
     @classmethod
     async def create(cls, project_path: str | Path) -> "ScriptGenerator":
@@ -181,6 +218,7 @@ class ScriptGenerator:
             # 避免生成出执行层 assert_duration_supported 会拒、或漏到供应商 API 报错的非成员时长。
             schema = build_episode_script_model("narration", supported_durations)
         else:
+            episode_outline, next_episode_outline = self._ledger_outline_context(episode)
             prompt = build_drama_prompt(
                 project_overview=self.project_json.get("overview", {}),
                 style=self.project_json.get("style", ""),
@@ -193,6 +231,8 @@ class ScriptGenerator:
                 default_duration=self.project_json.get("default_duration"),
                 aspect_ratio=self._resolve_aspect_ratio(),
                 episode=episode,
+                episode_outline=episode_outline,
+                next_episode_outline=next_episode_outline,
             )
             schema = build_episode_script_model("drama", supported_durations)
 
@@ -272,6 +312,7 @@ class ScriptGenerator:
                 episode=episode,
             )
         else:
+            episode_outline, next_episode_outline = self._ledger_outline_context(episode)
             return build_drama_prompt(
                 project_overview=self.project_json.get("overview", {}),
                 style=self.project_json.get("style", ""),
@@ -284,6 +325,8 @@ class ScriptGenerator:
                 default_duration=self.project_json.get("default_duration"),
                 aspect_ratio=self._resolve_aspect_ratio(),
                 episode=episode,
+                episode_outline=episode_outline,
+                next_episode_outline=next_episode_outline,
             )
 
     async def _fetch_video_capabilities(self) -> dict | None:
@@ -371,27 +414,28 @@ class ScriptGenerator:
             return json.load(f)
 
     def _load_step1(self, episode: int) -> str:
-        """加载 Step 1 的 Markdown 文件，支持两种文件命名"""
+        """加载 Step 1 的 Markdown 中间文件。
+
+        每种模式只对应一个期望文件，缺失时显式报错并指明期望路径——不降级改读
+        其他模式的中间文件（静默 fallback 会让剧本基于错误模式的中间产物生成）。
+        """
         drafts_path = self.project_path / "drafts" / f"episode_{episode}"
         gen_mode = self._effective_generation_mode(episode)
         if gen_mode == "reference_video":
-            primary_path = drafts_path / "step1_reference_units.md"
-            fallback_path = None
+            step1_path = drafts_path / "step1_reference_units.md"
         elif self.content_mode == "narration":
-            primary_path = drafts_path / "step1_segments.md"
-            fallback_path = drafts_path / "step1_normalized_script.md"
+            step1_path = drafts_path / "step1_segments.md"
         else:
-            primary_path = drafts_path / "step1_normalized_script.md"
-            fallback_path = drafts_path / "step1_segments.md"
+            step1_path = drafts_path / "step1_normalized_script.md"
 
-        if not primary_path.exists():
-            if fallback_path is not None and fallback_path.exists():
-                logger.warning("未找到 Step 1 文件: %s，改用 %s", primary_path, fallback_path)
-                primary_path = fallback_path
-            else:
-                raise FileNotFoundError(f"未找到 Step 1 文件: {primary_path}")
+        if not step1_path.exists():
+            raise FileNotFoundError(
+                f"未找到 Step 1 中间文件: {step1_path}；"
+                f"content_mode={self.content_mode}, generation_mode={gen_mode} 期望该文件，"
+                "请先完成本集预处理"
+            )
 
-        with open(primary_path, encoding="utf-8") as f:
+        with open(step1_path, encoding="utf-8") as f:
             return f.read()
 
     def _parse_response(self, response_text: str, episode: int) -> dict:
@@ -476,6 +520,12 @@ class ScriptGenerator:
             script_data["generation_mode"] = "reference_video"
         else:
             script_data.setdefault("content_mode", self.content_mode)
+
+        # 集级钩子/下集预告：分集账本是钩子设计的单一真相源，强制以账本值覆盖
+        # （LLM 不参与填写，model_dump 只会留下 None 默认值）。账本无规划数据时为 None。
+        entry = self._episode_entry(ep)
+        script_data["hook"] = entry.get("hook")
+        script_data["next_episode_teaser"] = self._entry_outline(entry).get("next_episode_teaser")
 
         # 添加小说信息
         # 注意守卫语义：novel 字段已 SkipJsonSchema 隐藏，但 default_factory=NovelInfo

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -435,8 +435,7 @@ class ScriptGenerator:
                 "请先完成本集预处理"
             )
 
-        with open(step1_path, encoding="utf-8") as f:
-            return f.read()
+        return step1_path.read_text(encoding="utf-8")
 
     def _parse_response(self, response_text: str, episode: int) -> dict:
         """

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -196,6 +196,10 @@ class NarrationEpisodeScript(BaseModel):
     duration_seconds: SkipJsonSchema[int] = Field(default=0, description="总时长（秒）")
     # novel 由 _add_metadata 注入 {项目 title, f"第N集"};compose-video 用 chapter 作输出文件名,LLM 自由发挥反而不可预测
     novel: SkipJsonSchema[NovelInfo] = Field(default_factory=NovelInfo, description="小说来源信息")
+    # hook / next_episode_teaser 由 _add_metadata 从分集账本注入（账本是钩子设计的
+    # 单一真相源，LLM 不参与填写）；账本无规划数据时为 null。
+    hook: SkipJsonSchema[str | None] = Field(default=None, description="集尾钩子（来自分集账本）")
+    next_episode_teaser: SkipJsonSchema[str | None] = Field(default=None, description="下集预告语（来自分集账本）")
     segments: list[NarrationSegment] = Field(description="片段列表")
 
 
@@ -253,6 +257,9 @@ class DramaEpisodeScript(BaseModel):
     duration_seconds: SkipJsonSchema[int] = Field(default=0, description="总时长（秒）")
     # 见 NarrationEpisodeScript.novel 说明
     novel: SkipJsonSchema[NovelInfo] = Field(default_factory=NovelInfo, description="小说来源信息")
+    # 见 NarrationEpisodeScript 同名字段说明。
+    hook: SkipJsonSchema[str | None] = Field(default=None, description="集尾钩子（来自分集账本）")
+    next_episode_teaser: SkipJsonSchema[str | None] = Field(default=None, description="下集预告语（来自分集账本）")
     scenes: list[DramaScene] = Field(description="场景列表")
 
 
@@ -332,6 +339,9 @@ class ReferenceVideoScript(BaseModel):
     duration_seconds: SkipJsonSchema[int] = Field(default=0, description="总时长（秒）")
     # 见 NarrationEpisodeScript.novel 说明
     novel: SkipJsonSchema[NovelInfo] = Field(default_factory=NovelInfo, description="小说来源信息")
+    # 见 NarrationEpisodeScript 同名字段说明。
+    hook: SkipJsonSchema[str | None] = Field(default=None, description="集尾钩子（来自分集账本）")
+    next_episode_teaser: SkipJsonSchema[str | None] = Field(default=None, description="下集预告语（来自分集账本）")
     video_units: list[ReferenceVideoUnit] = Field(description="视频单元列表")
 
 

--- a/lib/status_calculator.py
+++ b/lib/status_calculator.py
@@ -227,6 +227,12 @@ class StatusCalculator:
         content_mode = project.get("content_mode", "narration")
         episodes_stats = []
         for ep in project.get("episodes", []):
+            # 账本标 stale 的集（重排后原文范围已失效）：读时状态回退为待预处理，
+            # 驱动重做流程；剧本/媒体产物不删除，重做沿现有覆盖/版本机制替换。
+            if ep.get("ledger_status") == "stale":
+                episodes_stats.append(self._make_fallback_ep_stats("none"))
+                continue
+
             script_file = ep.get("script_file", "")
             episode_num = ep.get("episode", 0)
 

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -229,13 +229,14 @@ class TestScriptGenerator:
         generator = ScriptGenerator(project_path)
         prompt = await generator.build_prompt(1)
 
-        # 本集大纲：故事节点 / 集尾钩子 / 下集预告语
+        # 本集大纲：本集标题 / 故事节点 / 集尾钩子 / 下集预告语
+        assert "本集标题：初入江湖" in prompt
         assert "少年下山" in prompt
         assert "初遇黑衣人" in prompt
         assert "少年坠崖生死未卜" in prompt
         assert "崖底神秘人出手相救" in prompt
         # 下集大纲：用于衔接的下一集内容
-        assert "绝处逢生" in prompt
+        assert "下集标题：绝处逢生" in prompt
         assert "崖底醒来" in prompt
 
     async def test_drama_prompt_last_episode_without_next_outline(self, tmp_path):

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -50,6 +50,51 @@ def _valid_narration_response() -> dict:
     }
 
 
+def _write_drama_ledger_project(project_path: Path, episodes: list[dict], characters: dict | None = None) -> None:
+    """写一个带分集账本条目的最小 drama 项目 project.json。"""
+    _write_json(
+        project_path / "project.json",
+        {
+            "title": "项目",
+            "content_mode": "drama",
+            "overview": {},
+            "characters": characters or {},
+            "style": "古风",
+            "style_description": "cinematic",
+            "_supported_durations": [4, 6, 8],
+            "episodes": episodes,
+        },
+    )
+
+
+def _valid_drama_response() -> dict:
+    return {
+        "title": "第一集",
+        "scenes": [
+            {
+                "scene_id": "E1S01",
+                "duration_seconds": 8,
+                "segment_break": False,
+                "characters_in_scene": ["姜月茴"],
+                "image_prompt": {
+                    "scene": "场景",
+                    "composition": {
+                        "shot_type": "Medium Shot",
+                        "lighting": "暖光",
+                        "ambiance": "薄雾",
+                    },
+                },
+                "video_prompt": {
+                    "action": "转身",
+                    "camera_motion": "Static",
+                    "ambiance_audio": "风声",
+                    "dialogue": [],
+                },
+            }
+        ],
+    }
+
+
 class _FakeTextBackend:
     def __init__(self, response_text: str = "{}"):
         self._response_text = response_text
@@ -110,7 +155,9 @@ class TestScriptGenerator:
         assert "E1S01 | 片段" in prompt
         assert "姜月茴" in prompt
 
-    async def test_load_step1_falls_back_when_primary_missing(self, tmp_path):
+    async def test_load_step1_narration_missing_raises_without_fallback(self, tmp_path):
+        """narration 集缺 step1_segments.md 时显式报错并指明期望文件；
+        即使 drama 模式的中间文件存在也不得降级改读。"""
         project_path = tmp_path / "demo"
         _write_json(
             project_path / "project.json",
@@ -122,11 +169,144 @@ class TestScriptGenerator:
                 "clues": {},
             },
         )
-        _write(project_path / "drafts" / "episode_1" / "step1_normalized_script.md", "fallback")
+        _write(project_path / "drafts" / "episode_1" / "step1_normalized_script.md", "其他模式中间文件")
 
         generator = ScriptGenerator(project_path)
-        content = generator._load_step1(1)
-        assert content == "fallback"
+        with pytest.raises(FileNotFoundError, match="step1_segments.md"):
+            generator._load_step1(1)
+
+    async def test_load_step1_drama_missing_raises_without_fallback(self, tmp_path):
+        """drama 集缺 step1_normalized_script.md 时显式报错；不得降级改读 narration 的拆分表。"""
+        project_path = tmp_path / "demo"
+        _write_json(
+            project_path / "project.json",
+            {
+                "title": "项目",
+                "content_mode": "drama",
+                "overview": {},
+                "characters": {},
+                "clues": {},
+            },
+        )
+        _write(project_path / "drafts" / "episode_1" / "step1_segments.md", "其他模式中间文件")
+
+        generator = ScriptGenerator(project_path)
+        with pytest.raises(FileNotFoundError, match="step1_normalized_script.md"):
+            generator._load_step1(1)
+
+    async def test_drama_prompt_includes_current_and_next_episode_outlines(self, tmp_path):
+        """drama 剧本生成输入须包含账本里本集大纲（故事节点/钩子/下集预告）与下集大纲。"""
+        project_path = tmp_path / "demo"
+        _write_drama_ledger_project(
+            project_path,
+            [
+                {
+                    "episode": 1,
+                    "title": "初入江湖",
+                    "script_file": "scripts/episode_1.json",
+                    "hook": "少年坠崖生死未卜",
+                    "outline": {
+                        "story_beats": ["少年下山", "初遇黑衣人"],
+                        "next_episode_teaser": "崖底神秘人出手相救",
+                    },
+                    "ledger_status": "planned",
+                },
+                {
+                    "episode": 2,
+                    "title": "绝处逢生",
+                    "script_file": "scripts/episode_2.json",
+                    "hook": "神秘人身份揭晓",
+                    "outline": {
+                        "story_beats": ["崖底醒来", "拜师学艺"],
+                        "next_episode_teaser": None,
+                    },
+                    "ledger_status": "planned",
+                },
+            ],
+        )
+        _write(project_path / "drafts" / "episode_1" / "step1_normalized_script.md", "E1S01 | 场景")
+
+        generator = ScriptGenerator(project_path)
+        prompt = await generator.build_prompt(1)
+
+        # 本集大纲：故事节点 / 集尾钩子 / 下集预告语
+        assert "少年下山" in prompt
+        assert "初遇黑衣人" in prompt
+        assert "少年坠崖生死未卜" in prompt
+        assert "崖底神秘人出手相救" in prompt
+        # 下集大纲：用于衔接的下一集内容
+        assert "绝处逢生" in prompt
+        assert "崖底醒来" in prompt
+
+    async def test_drama_prompt_last_episode_without_next_outline(self, tmp_path):
+        """末集（账本无下一集条目）正常生成 prompt：含本集大纲，不渲染下集大纲段。"""
+        project_path = tmp_path / "demo"
+        _write_drama_ledger_project(
+            project_path,
+            [
+                {
+                    "episode": 1,
+                    "title": "大结局",
+                    "script_file": "scripts/episode_1.json",
+                    "hook": "尘埃落定",
+                    "outline": {"story_beats": ["决战", "告别"], "next_episode_teaser": None},
+                    "ledger_status": "planned",
+                },
+            ],
+        )
+        _write(project_path / "drafts" / "episode_1" / "step1_normalized_script.md", "E1S01 | 场景")
+
+        generator = ScriptGenerator(project_path)
+        prompt = await generator.build_prompt(1)
+
+        assert "决战" in prompt
+        assert "尘埃落定" in prompt
+        assert "<next_episode_outline>" not in prompt
+
+    async def test_drama_prompt_without_ledger_outline_omits_outline_section(self, tmp_path):
+        """旧式条目（账本无规划数据）：prompt 不渲染大纲段，生成不受影响。"""
+        project_path = tmp_path / "demo"
+        _write_drama_ledger_project(
+            project_path,
+            [{"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"}],
+        )
+        _write(project_path / "drafts" / "episode_1" / "step1_normalized_script.md", "E1S01 | 场景")
+
+        generator = ScriptGenerator(project_path)
+        prompt = await generator.build_prompt(1)
+
+        assert "E1S01 | 场景" in prompt
+        assert "<episode_outline>" not in prompt
+        assert "<next_episode_outline>" not in prompt
+        assert "末场" not in prompt
+
+    async def test_drama_prompt_requires_hook_to_land_in_final_scene(self, tmp_path):
+        """账本有钩子/预告时，prompt 须要求其落地到末场内容（而非只停留在规划文档）。"""
+        project_path = tmp_path / "demo"
+        _write_drama_ledger_project(
+            project_path,
+            [
+                {
+                    "episode": 1,
+                    "title": "初入江湖",
+                    "script_file": "scripts/episode_1.json",
+                    "hook": "少年坠崖生死未卜",
+                    "outline": {
+                        "story_beats": ["少年下山"],
+                        "next_episode_teaser": "崖底神秘人出手相救",
+                    },
+                    "ledger_status": "planned",
+                },
+            ],
+        )
+        _write(project_path / "drafts" / "episode_1" / "step1_normalized_script.md", "E1S01 | 场景")
+
+        generator = ScriptGenerator(project_path)
+        prompt = await generator.build_prompt(1)
+
+        # 落地要求与钩子内容须同时在场：仅有指引而无钩子（或反之）都不构成可执行要求
+        assert "末场" in prompt
+        assert "少年坠崖生死未卜" in prompt
 
     async def test_parse_response_invalid_json_raises(self, tmp_path):
         project_path = tmp_path / "demo"
@@ -171,6 +351,69 @@ class TestScriptGenerator:
         assert payload["duration_seconds"] == 4
         assert payload["metadata"]["generator"] == "fake-model"
         assert "created_at" in payload["metadata"]
+
+    async def test_generate_injects_hook_and_teaser_from_ledger(self, tmp_path):
+        """剧本 JSON 的集级 hook / next_episode_teaser 元数据来自分集账本（经写盘严格校验）。"""
+        project_path = tmp_path / "demo"
+        _write_drama_ledger_project(
+            project_path,
+            [
+                {
+                    "episode": 1,
+                    "title": "初入江湖",
+                    "script_file": "scripts/episode_1.json",
+                    "hook": "少年坠崖生死未卜",
+                    "outline": {
+                        "story_beats": ["少年下山"],
+                        "next_episode_teaser": "崖底神秘人出手相救",
+                    },
+                    "ledger_status": "planned",
+                },
+            ],
+            characters={"姜月茴": {}},
+        )
+        _write(project_path / "drafts" / "episode_1" / "step1_normalized_script.md", "E1S01 | 场景")
+
+        fake = _FakeTextGenerator(json.dumps(_valid_drama_response(), ensure_ascii=False))
+        generator = ScriptGenerator(project_path, generator=fake)
+
+        async def _fixed_caps():
+            return {"supported_durations": [4, 6, 8]}
+
+        generator._fetch_video_capabilities = _fixed_caps
+        output = await generator.generate(1)
+
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        assert payload["hook"] == "少年坠崖生死未卜"
+        assert payload["next_episode_teaser"] == "崖底神秘人出手相救"
+
+    async def test_generate_without_ledger_hook_leaves_fields_null(self, tmp_path):
+        """旧式条目（账本无钩子/预告）：字段为 null，写盘校验仍通过。"""
+        project_path = tmp_path / "demo"
+        _write_json(
+            project_path / "project.json",
+            {
+                "title": "项目",
+                "content_mode": "narration",
+                "overview": {},
+                "characters": {"姜月茴": {}},
+                "style": "古风",
+                "style_description": "cinematic",
+                "_supported_durations": [4, 6, 8],
+                "episodes": [
+                    {"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"},
+                ],
+            },
+        )
+        _write(project_path / "drafts" / "episode_1" / "step1_segments.md", "E1S01 | 片段")
+
+        fake = _FakeTextGenerator(json.dumps(_valid_narration_response(), ensure_ascii=False))
+        generator = ScriptGenerator(project_path, generator=fake)
+        output = await generator.generate(1)
+
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        assert payload["hook"] is None
+        assert payload["next_episode_teaser"] is None
 
     async def test_generate_overrides_hallucinated_episode_field(self, tmp_path):
         """AI 返回带错误 episode 字段时，CLI 参数 episode 必须胜出。

--- a/tests/test_script_models.py
+++ b/tests/test_script_models.py
@@ -237,6 +237,30 @@ class TestLLMSchemaExclusion:
             assert "scene_type" not in keys, f"{model.__name__} 不应有 scene_type"
             assert "transition_to_next" not in keys, f"{model.__name__} 不应有 transition_to_next"
 
+    def test_schema_excludes_hook_and_teaser_including_derived_models(self):
+        """hook / next_episode_teaser 由分集账本注入，LLM 不该看到——
+        含 build_*_script_model 动态约束子类（response_schema 实际取自它们）。"""
+        from lib.script_models import (
+            DramaEpisodeScript,
+            NarrationEpisodeScript,
+            ReferenceVideoScript,
+            build_episode_script_model,
+            build_reference_video_script_model,
+        )
+
+        models = (
+            NarrationEpisodeScript,
+            DramaEpisodeScript,
+            ReferenceVideoScript,
+            build_episode_script_model("narration", [4, 6, 8]),
+            build_episode_script_model("drama", [4, 6, 8]),
+            build_reference_video_script_model([4, 8]),
+        )
+        for model in models:
+            top_props = set(model.model_json_schema()["properties"].keys())
+            assert "hook" not in top_props, f"{model.__name__} 顶层不应有 hook"
+            assert "next_episode_teaser" not in top_props, f"{model.__name__} 顶层不应有 next_episode_teaser"
+
 
 class TestRuntimeBackwardCompat:
     """LLM schema 隐藏的字段在 Python 端 model_validate 时仍能接受旧数据,并由 default 兜底。"""

--- a/tests/test_status_calculator.py
+++ b/tests/test_status_calculator.py
@@ -290,6 +290,52 @@ class TestStatusCalculator:
         assert ep2["script_status"] == "none"
         assert ep2["status"] == "draft"
 
+    def test_stale_ledger_episode_regresses_to_pending_preprocess(self, tmp_path):
+        """账本标 stale 的集：读时状态回退为待预处理（script_status=none），已有产物不删除。
+
+        重排使该集原文范围失效，剧本/媒体虽存在但已过期；读时回退驱动前端
+        与 agent 走重做流程，旧产物沿覆盖/版本机制保留可回滚。
+        """
+        project_root = tmp_path / "projects"
+        (project_root / "demo" / "drafts" / "episode_1").mkdir(parents=True)
+        (project_root / "demo" / "drafts" / "episode_1" / "step1_segments.md").write_text("ok", encoding="utf-8")
+        project = {
+            "overview": {"synopsis": "test"},
+            "characters": {},
+            "scenes": {},
+            "props": {},
+            "episodes": [
+                {"episode": 1, "script_file": "scripts/episode_1.json", "ledger_status": "stale"},
+                {"episode": 2, "script_file": "scripts/episode_2.json", "ledger_status": "consumed"},
+            ],
+        }
+        scripts = {
+            "episode_1.json": {
+                "content_mode": "narration",
+                "segments": [
+                    {"duration_seconds": 4, "generated_assets": {"storyboard_image": "a.png", "video_clip": "b.mp4"}}
+                ],
+            },
+            "episode_2.json": {"content_mode": "narration", "segments": [{"duration_seconds": 4}]},
+        }
+        calc = StatusCalculator(_FakePM(project_root, project, scripts))
+
+        enriched = calc.enrich_project("demo", project)
+
+        ep1 = enriched["episodes"][0]
+        # stale 集即使剧本与分段草稿都在，也回退为待预处理
+        assert ep1["script_status"] == "none"
+        assert ep1["status"] == "draft"
+        assert ep1["videos"] == {"total": 0, "completed": 0}
+        # 不删除任何产物：条目仍保留剧本引用与账本状态
+        assert ep1["script_file"] == "scripts/episode_1.json"
+        assert ep1["ledger_status"] == "stale"
+        # 非 stale 集不受影响
+        ep2 = enriched["episodes"][1]
+        assert ep2["script_status"] == "generated"
+        # 项目级汇总同步回退：仅 1 集计为已生成剧本
+        assert enriched["status"]["episodes_summary"]["scripted"] == 1
+
     def test_enrich_script(self, tmp_path):
         script = {
             "content_mode": "narration",


### PR DESCRIPTION
Closes #754

## 问题

分集账本（PRD 751，#752 已落地数据基座）规划出的大纲与钩子此前不被剧本生成消费：

- drama 剧本只看中间文件，看不到本集大纲与下集内容，集尾钩子停留在规划文档里，无法落地到成片末场
- Step1 中间文件缺失时静默降级改读其他模式的中间文件，剧本可能基于错误模式的中间产物生成（客户曾反馈"不同的集剧本内容相同"一类事故）
- 重排后账本标 stale 的集，状态计算不感知，前端与 agent 看不出该集需要重做

## 方案

- **中间文件加载禁用 fallback**：每种模式只对应一个期望文件，缺失显式报错并指明期望路径与模式组合
- **drama 大纲输入**：剧本生成 prompt 注入账本里的本集大纲（故事节点/集尾钩子/下集预告语）与下集大纲（仅用于结尾衔接）；末集无下集、旧项目无账本规划数据时自动省略对应段落
- **钩子落地末场**：账本有钩子/预告时，prompt 显式要求末场画面与对白实际呈现钩子内容
- **剧本 JSON 集级元数据**：新增 `hook` / `next_episode_teaser` 字段，对 LLM 隐藏（SkipJsonSchema），由生成器从账本注入——账本是钩子设计的单一真相源
- **stale 读时回退**：账本标 stale 的集读时状态回退为待预处理，驱动重做流程；不删除任何已有产物，旧版本沿现有覆盖/版本机制可回滚

## 测试

- 剧本生成缝：narration/drama 缺中间文件显式报错且不降级；prompt 含本集+下集大纲；末集与无账本数据的边界；hook/teaser 注入与空值兜底（先例 test_script_generator）
- schema 排除回归：hook/teaser 不出现在发给 LLM 的 response_schema（含 build_*_script_model 动态约束子类）
- 状态计算缝：stale 集回退 script_status=none，非 stale 集与项目级汇总不受影响（先例 test_status_calculator）
- 全量 `uv run pytest tests/`：4151 通过（唯一失败为 test_default_when_unresolvable，本机 dev DB 环境耦合的已知问题，与本改动无关）；ruff / basedpyright（0 error）通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 将分集规划大纲（故事节点、集尾钩子、下集预告）纳入生成提示并在适当场景渲染当前/下集大纲块。
* **改进**
  * 生成流程输入严格化：中间文件不再降级回退，提示构建顺序调整以优先包含分集上下文；生成结果注入并持久化账本的钩子与预告（缺失时为 null）。
* **测试**
  * 扩充单元测试，覆盖分集渲染、写盘注入、缺失回退与 stale 状态行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->