### PR TITLE
feat(audio): 导出剪映草稿自动附带逐段旁白音轨

### DIFF
--- a/lib/path_safety.py
+++ b/lib/path_safety.py
@@ -6,12 +6,12 @@ from pathlib import Path
 
 
 def safe_resolve(base: Path, rel_path: str | None) -> Path | None:
-    """解析 base 内的相对路径，返回绝对路径；越界/脏数据/文件不存在时返回 None（防路径穿越）。"""
+    """解析 base 内的相对路径，返回绝对路径；越界/脏数据/不是已存在的文件时返回 None（防路径穿越）。"""
     if not rel_path:
         return None
     try:
         full = (base / rel_path).resolve()
-        if full.is_relative_to(base.resolve()) and full.exists():
+        if full.is_relative_to(base.resolve()) and full.is_file():
             return full
     except (OSError, ValueError, TypeError):
         # TypeError：rel_path 来自 project.json 原始字段，脏数据（dict/int）按「不存在」处理

--- a/lib/path_safety.py
+++ b/lib/path_safety.py
@@ -5,13 +5,20 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def safe_exists(base: Path, rel_path: str) -> bool:
-    """rel_path 是否为 base 内的合法相对路径且文件存在（防路径穿越）。"""
+def safe_resolve(base: Path, rel_path: str | None) -> Path | None:
+    """解析 base 内的相对路径，返回绝对路径；越界/脏数据/文件不存在时返回 None（防路径穿越）。"""
     if not rel_path:
-        return False
+        return None
     try:
         full = (base / rel_path).resolve()
-        return full.is_relative_to(base.resolve()) and full.exists()
+        if full.is_relative_to(base.resolve()) and full.exists():
+            return full
     except (OSError, ValueError, TypeError):
         # TypeError：rel_path 来自 project.json 原始字段，脏数据（dict/int）按「不存在」处理
-        return False
+        return None
+    return None
+
+
+def safe_exists(base: Path, rel_path: str) -> bool:
+    """rel_path 是否为 base 内的合法相对路径且文件存在（防路径穿越）。"""
+    return safe_resolve(base, rel_path) is not None

--- a/server/services/jianying_draft_service.py
+++ b/server/services/jianying_draft_service.py
@@ -324,10 +324,15 @@ class JianyingDraftService:
 
             # 同一来源文件（safe_resolve 已规范化路径）只暂存一次，多段引用共享同一暂存副本
             staged_by_src: dict[Path, Path] = {}
+            project_root = project_dir.resolve()
 
             def stage_once(src: Path) -> str:
                 if src not in staged_by_src:
-                    staged_by_src[src] = self._stage_file(src, staging_dir)
+                    # 暂存前重校验：收集与暂存之间文件可能被替换（如换成越界 symlink）
+                    resolved = src.resolve()
+                    if not (resolved.is_relative_to(project_root) and resolved.is_file()):
+                        raise ValueError(f"路径越界，拒绝导出: {src}")
+                    staged_by_src[src] = self._stage_file(resolved, staging_dir)
                 return str(staged_by_src[src])
 
             local_clips = []

--- a/server/services/jianying_draft_service.py
+++ b/server/services/jianying_draft_service.py
@@ -16,6 +16,8 @@ from typing import Any
 
 import pyJianYingDraft as draft
 from pyJianYingDraft import (
+    AudioMaterial,
+    AudioSegment,
     ClipSettings,
     TextBorder,
     TextSegment,
@@ -34,6 +36,7 @@ _TRANSITION_MAP: dict[str, TransitionType] = {
     "dissolve": TransitionType.叠化,
 }
 
+from lib.path_safety import safe_resolve
 from lib.project_manager import ProjectManager
 
 logger = logging.getLogger(__name__)
@@ -74,11 +77,9 @@ class JianyingDraftService:
             if not video_clip:
                 continue
 
-            abs_path = (project_dir / video_clip).resolve()
-            if not abs_path.is_relative_to(project_dir.resolve()):
-                logger.warning("video_clip 路径越界，已跳过: %s", video_clip)
-                continue
-            if not abs_path.exists():
+            abs_path = safe_resolve(project_dir, video_clip)
+            if abs_path is None:
+                logger.warning("video_clip 不可用（越界或文件不存在），已跳过: %s", video_clip)
                 continue
 
             clips.append(
@@ -89,6 +90,7 @@ class JianyingDraftService:
                     "abs_path": abs_path,
                     "novel_text": item.get("novel_text", ""),
                     "transition_to_next": item.get("transition_to_next", "cut"),
+                    "narration_audio_abs": safe_resolve(project_dir, assets.get("narration_audio")),
                 }
             )
 
@@ -104,6 +106,25 @@ class JianyingDraftService:
         if aspect == "9:16":
             return 1080, 1920
         return 1920, 1080
+
+    @staticmethod
+    def _stage_file(src: Path, staging_dir: Path) -> Path:
+        """将素材文件硬链接（失败时复制）到暂存区，返回暂存路径
+
+        暂存区为扁平目录：来源文件同名时自动改名，避免覆盖已暂存的素材。
+        同一来源的去重由调用方按源路径判定（不依赖 inode 比较，FAT/exFAT 等
+        无稳定文件 ID 的文件系统上 samefile 会误判）。
+        """
+        dst = staging_dir / src.name
+        rename_index = 1
+        while dst.exists():
+            dst = staging_dir / f"{src.stem}_{rename_index}{src.suffix}"
+            rename_index += 1
+        try:
+            dst.hardlink_to(src)
+        except OSError:
+            shutil.copy2(src, dst)
+        return dst
 
     # ------------------------------------------------------------------
     # 内部方法：草稿生成
@@ -162,6 +183,7 @@ class JianyingDraftService:
         # 逐片段添加
         offset_us = 0
         last_index = len(clips) - 1
+        narration_placements: list[tuple[int, str]] = []
         for index, clip in enumerate(clips):
             # 预读实际视频时长
             material = VideoMaterial(clip["local_path"])
@@ -193,7 +215,35 @@ class JianyingDraftService:
                 )
                 script_file.add_segment(text_seg)
 
+            # 旁白音频：记录摆放位置（按视频片段 offset），统一在视频排布完成后添加
+            narration_audio_local = clip.get("narration_audio_local")
+            if narration_audio_local:
+                narration_placements.append((offset_us, narration_audio_local))
+
             offset_us += actual_duration_us
+
+        # 旁白素材：先解析全部音频文件，不可解析（截断/空文件等）的跳过不报错
+        narration_materials: list[tuple[int, AudioMaterial]] = []
+        for start_us, audio_path in narration_placements:
+            try:
+                narration_materials.append((start_us, AudioMaterial(audio_path)))
+            except (ValueError, TypeError, OSError, RuntimeError) as exc:
+                # RuntimeError：libmediainfo 打不开文件（占用/读错误）时由 pymediainfo 抛出
+                logger.warning("旁白音频无法解析，已跳过: %s (%s)", audio_path, exc)
+
+        # 旁白音频段：时长取音频文件真实时长，不与视频对齐；
+        # 仅当超长音频会与下一段旁白重叠时收口到其起点，保证草稿可导出（用户在剪映手动精调）
+        if narration_materials:
+            script_file.add_track(TrackType.audio, "旁白")
+        for material_index, (start_us, audio_material) in enumerate(narration_materials):
+            duration_us = audio_material.duration
+            if material_index + 1 < len(narration_materials):
+                window_us = narration_materials[material_index + 1][0] - start_us
+                if duration_us > window_us:
+                    logger.warning("旁白音频长过下一段起点，已收口: %s", audio_material.path)
+                    duration_us = window_us
+            audio_seg = AudioSegment(audio_material, trange(start_us, duration_us))
+            script_file.add_segment(audio_seg, "旁白")
 
         script_file.save()
 
@@ -266,15 +316,21 @@ class JianyingDraftService:
             staging_dir = tmp_dir / "staging"
             staging_dir.mkdir()
 
+            # 同一来源文件（safe_resolve 已规范化路径）只暂存一次，多段引用共享同一暂存副本
+            staged_by_src: dict[Path, Path] = {}
+
+            def stage_once(src: Path) -> str:
+                if src not in staged_by_src:
+                    staged_by_src[src] = self._stage_file(src, staging_dir)
+                return str(staged_by_src[src])
+
             local_clips = []
             for clip in clips:
-                src = clip["abs_path"]
-                dst = staging_dir / src.name
-                try:
-                    dst.hardlink_to(src)
-                except OSError:
-                    shutil.copy2(src, dst)
-                local_clips.append({**clip, "local_path": str(dst)})
+                local_clip = {**clip, "local_path": stage_once(clip["abs_path"])}
+                audio_src = clip.get("narration_audio_abs")
+                if audio_src:
+                    local_clip["narration_audio_local"] = stage_once(audio_src)
+                local_clips.append(local_clip)
 
             # 5. 生成草稿（create_draft 会重建 draft_dir）
             draft_dir = tmp_dir / draft_name
@@ -287,13 +343,11 @@ class JianyingDraftService:
                 content_mode=content_mode,
             )
 
-            # 6. 将素材移入草稿目录
+            # 6. 将素材移入草稿目录（暂存区内容即全部已暂存素材）
             assets_dir = draft_dir / "assets"
             assets_dir.mkdir(exist_ok=True)
-            for clip in local_clips:
-                src = Path(clip["local_path"])
-                dst = assets_dir / src.name
-                shutil.move(str(src), str(dst))
+            for staged in staging_dir.iterdir():
+                shutil.move(str(staged), str(assets_dir / staged.name))
 
             # 7. 路径后处理：staging 路径 → 用户本地路径
             draft_content_path = draft_dir / "draft_content.json"

--- a/server/services/jianying_draft_service.py
+++ b/server/services/jianying_draft_service.py
@@ -227,14 +227,13 @@ class JianyingDraftService:
         for start_us, audio_path in narration_placements:
             try:
                 narration_materials.append((start_us, AudioMaterial(audio_path)))
-            except (ValueError, TypeError, OSError, RuntimeError) as exc:
-                # RuntimeError：libmediainfo 打不开文件（占用/读错误）时由 pymediainfo 抛出
+            except Exception as exc:
+                # 解析失败不阻断导出：文件占用/损坏/底层库自定义异常均按跳过处理
                 logger.warning("旁白音频无法解析，已跳过: %s (%s)", audio_path, exc)
 
         # 旁白音频段：时长取音频文件真实时长，不与视频对齐；
         # 仅当超长音频会与下一段旁白重叠时收口到其起点，保证草稿可导出（用户在剪映手动精调）
-        if narration_materials:
-            script_file.add_track(TrackType.audio, "旁白")
+        narration_track_added = False
         for material_index, (start_us, audio_material) in enumerate(narration_materials):
             duration_us = audio_material.duration
             if material_index + 1 < len(narration_materials):
@@ -245,6 +244,10 @@ class JianyingDraftService:
             if duration_us <= 0:
                 logger.warning("旁白音频有效时长不足，已跳过: %s", audio_material.path)
                 continue
+            # 音轨仅在确有有效片段时创建，避免全部被过滤后留下空轨
+            if not narration_track_added:
+                script_file.add_track(TrackType.audio, "旁白")
+                narration_track_added = True
             audio_seg = AudioSegment(audio_material, trange(start_us, duration_us))
             script_file.add_segment(audio_seg, "旁白")
 
@@ -349,12 +352,14 @@ class JianyingDraftService:
             # 6. 将素材移入草稿目录（暂存区内容即全部已暂存素材）
             assets_dir = draft_dir / "assets"
             assets_dir.mkdir(exist_ok=True)
-            assets_root = assets_dir.resolve()
+            # normpath + startswith 做越界守卫：纯字符串规范化，不触发文件系统访问，
+            # 且是静态分析可识别的收敛模式（resolve/is_relative_to 不被识别）
+            assets_root = os.path.normpath(assets_dir)
             for staged in staging_dir.iterdir():
-                dest = (assets_root / staged.name).resolve()
-                if not dest.is_relative_to(assets_root):
+                dest = os.path.normpath(os.path.join(assets_root, staged.name))
+                if not dest.startswith(assets_root + os.sep):
                     raise ValueError(f"路径越界，拒绝写入: {dest}")
-                shutil.move(str(staged), str(dest))
+                shutil.move(str(staged), dest)
 
             # 7. 路径后处理：staging 路径 → 用户本地路径
             draft_content_path = draft_dir / "draft_content.json"

--- a/server/services/jianying_draft_service.py
+++ b/server/services/jianying_draft_service.py
@@ -242,6 +242,9 @@ class JianyingDraftService:
                 if duration_us > window_us:
                     logger.warning("旁白音频长过下一段起点，已收口: %s", audio_material.path)
                     duration_us = window_us
+            if duration_us <= 0:
+                logger.warning("旁白音频有效时长不足，已跳过: %s", audio_material.path)
+                continue
             audio_seg = AudioSegment(audio_material, trange(start_us, duration_us))
             script_file.add_segment(audio_seg, "旁白")
 
@@ -346,8 +349,12 @@ class JianyingDraftService:
             # 6. 将素材移入草稿目录（暂存区内容即全部已暂存素材）
             assets_dir = draft_dir / "assets"
             assets_dir.mkdir(exist_ok=True)
+            assets_root = assets_dir.resolve()
             for staged in staging_dir.iterdir():
-                shutil.move(str(staged), str(assets_dir / staged.name))
+                dest = (assets_root / staged.name).resolve()
+                if not dest.is_relative_to(assets_root):
+                    raise ValueError(f"路径越界，拒绝写入: {dest}")
+                shutil.move(str(staged), str(dest))
 
             # 7. 路径后处理：staging 路径 → 用户本地路径
             draft_content_path = draft_dir / "draft_content.json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,26 @@ def make_test_video(path: Path, *, duration_sec: float = 1.0, fps: int = 30) -> 
     )
 
 
+def make_test_audio(path: Path, *, duration_sec: float = 1.0) -> None:
+    """使用 ffmpeg 生成极短测试音频（正弦波 wav，pcm_s16le 为 ffmpeg 内置编码器）"""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"sine=frequency=440:duration={duration_sec}",
+            "-c:a",
+            "pcm_s16le",
+            str(path),
+        ],
+        capture_output=True,
+        check=True,
+    )
+
+
 @pytest.fixture(autouse=True)
 def _reset_app_data_dir_cache():
     """``app_data_dir()`` uses ``functools.cache`` for production; reset it between

--- a/tests/test_jianying_draft_service.py
+++ b/tests/test_jianying_draft_service.py
@@ -103,6 +103,85 @@ class TestCollectVideoClips:
         assert len(clips) == 0
 
 
+class TestCollectNarrationAudio:
+    """测试从剧本中收集旁白音频路径"""
+
+    def _make_script(self, narration_audio: str | None) -> dict:
+        assets: dict = {"video_clip": "videos/segment_S1.mp4", "status": "completed"}
+        if narration_audio is not None:
+            assets["narration_audio"] = narration_audio
+        return {
+            "content_mode": "narration",
+            "segments": [
+                {
+                    "segment_id": "S1",
+                    "duration_seconds": 8,
+                    "novel_text": "从前有座山",
+                    "generated_assets": assets,
+                },
+            ],
+        }
+
+    def test_collects_existing_narration_audio(self, tmp_path):
+        """段含 narration_audio 且文件存在时收集其绝对路径"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        project_dir = tmp_path / "projects" / "demo"
+        (project_dir / "videos").mkdir(parents=True)
+        (project_dir / "videos" / "segment_S1.mp4").write_bytes(b"fake")
+        (project_dir / "audio").mkdir()
+        (project_dir / "audio" / "segment_S1.wav").write_bytes(b"fake")
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        clips = svc._collect_video_clips(self._make_script("audio/segment_S1.wav"), project_dir)
+
+        assert len(clips) == 1
+        assert clips[0]["narration_audio_abs"] == (project_dir / "audio" / "segment_S1.wav").resolve()
+
+    def test_segment_without_narration_audio_yields_none(self, tmp_path):
+        """缺 narration_audio 的段不报错，音频路径为 None"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        project_dir = tmp_path / "projects" / "demo"
+        (project_dir / "videos").mkdir(parents=True)
+        (project_dir / "videos" / "segment_S1.mp4").write_bytes(b"fake")
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        clips = svc._collect_video_clips(self._make_script(None), project_dir)
+
+        assert len(clips) == 1
+        assert clips[0]["narration_audio_abs"] is None
+
+    def test_missing_audio_file_yields_none(self, tmp_path):
+        """narration_audio 有记录但文件不存在时视同缺失"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        project_dir = tmp_path / "projects" / "demo"
+        (project_dir / "videos").mkdir(parents=True)
+        (project_dir / "videos" / "segment_S1.mp4").write_bytes(b"fake")
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        clips = svc._collect_video_clips(self._make_script("audio/segment_S1.wav"), project_dir)
+
+        assert len(clips) == 1
+        assert clips[0]["narration_audio_abs"] is None
+
+    def test_path_traversal_audio_yields_none(self, tmp_path):
+        """narration_audio 路径越界时视同缺失，视频照常导出"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        project_dir = tmp_path / "projects" / "demo"
+        (project_dir / "videos").mkdir(parents=True)
+        (project_dir / "videos" / "segment_S1.mp4").write_bytes(b"fake")
+        (tmp_path / "secret.wav").write_bytes(b"fake")
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        clips = svc._collect_video_clips(self._make_script("../../secret.wav"), project_dir)
+
+        assert len(clips) == 1
+        assert clips[0]["narration_audio_abs"] is None
+
+
 class TestResolveCanvasSize:
     """测试画布尺寸解析"""
 
@@ -128,7 +207,7 @@ class TestResolveCanvasSize:
         assert (w, h) == (1920, 1080)
 
 
-from tests.conftest import make_test_video
+from tests.conftest import make_test_audio, make_test_video
 
 
 class TestGenerateDraft:
@@ -219,6 +298,227 @@ class TestGenerateDraft:
         content = json.loads((draft_dir / "draft_content.json").read_text(encoding="utf-8"))
         tracks = content.get("tracks", [])
         assert len(tracks) == 1
+
+
+class TestNarrationAudioTrack:
+    """测试逐段旁白音轨在剪映草稿中的接入"""
+
+    def test_clip_with_narration_audio_adds_audio_segment_at_video_offset(self, tmp_path):
+        """段含旁白音频时，草稿含音频轨，音频段按视频段 offset 摆放"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        videos_dir = tmp_path / "videos"
+        videos_dir.mkdir()
+        make_test_video(videos_dir / "seg_S1.mp4")
+        make_test_video(videos_dir / "seg_S2.mp4")
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        make_test_audio(audio_dir / "segment_S2.wav")
+
+        draft_dir = tmp_path / "drafts" / "旁白草稿"
+        clips = [
+            {"id": "S1", "local_path": str(videos_dir / "seg_S1.mp4"), "novel_text": ""},
+            {
+                "id": "S2",
+                "local_path": str(videos_dir / "seg_S2.mp4"),
+                "novel_text": "",
+                "narration_audio_local": str(audio_dir / "segment_S2.wav"),
+            },
+        ]
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        svc._generate_draft(
+            draft_dir=draft_dir,
+            draft_name="旁白草稿",
+            clips=clips,
+            width=1080,
+            height=1920,
+            content_mode="drama",
+        )
+
+        content = json.loads((draft_dir / "draft_content.json").read_text(encoding="utf-8"))
+        audios = content.get("materials", {}).get("audios", [])
+        assert len(audios) == 1
+        assert audios[0]["path"].endswith("segment_S2.wav")
+
+        audio_tracks = [t for t in content.get("tracks", []) if t.get("type") == "audio"]
+        assert len(audio_tracks) == 1
+        segments = audio_tracks[0]["segments"]
+        assert len(segments) == 1
+
+        # 音频段 offset 与第二个视频段一致（即第一个视频的实际时长）
+        video_track = next(t for t in content["tracks"] if t.get("type") == "video")
+        second_video_start = video_track["segments"][1]["target_timerange"]["start"]
+        assert segments[0]["target_timerange"]["start"] == second_video_start
+
+    def test_audio_duration_follows_audio_file_not_video(self, tmp_path):
+        """音频段时长取音频文件真实时长，不与视频段对齐"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        videos_dir = tmp_path / "videos"
+        videos_dir.mkdir()
+        make_test_video(videos_dir / "seg_S1.mp4", duration_sec=1.0)
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        make_test_audio(audio_dir / "segment_S1.wav", duration_sec=2.0)
+
+        draft_dir = tmp_path / "drafts" / "时长草稿"
+        clips = [
+            {
+                "id": "S1",
+                "local_path": str(videos_dir / "seg_S1.mp4"),
+                "novel_text": "",
+                "narration_audio_local": str(audio_dir / "segment_S1.wav"),
+            },
+        ]
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        svc._generate_draft(
+            draft_dir=draft_dir,
+            draft_name="时长草稿",
+            clips=clips,
+            width=1080,
+            height=1920,
+            content_mode="narration",
+        )
+
+        content = json.loads((draft_dir / "draft_content.json").read_text(encoding="utf-8"))
+        audio_track = next(t for t in content["tracks"] if t.get("type") == "audio")
+        audio_duration_us = audio_track["segments"][0]["target_timerange"]["duration"]
+        video_track = next(t for t in content["tracks"] if t.get("type") == "video")
+        video_duration_us = video_track["segments"][0]["target_timerange"]["duration"]
+
+        # 音频约 2s，明显长于 1s 视频
+        assert abs(audio_duration_us - 2_000_000) < 200_000
+        assert audio_duration_us > video_duration_us
+
+    def test_unparseable_audio_skipped_without_error(self, tmp_path):
+        """音频文件存在但无法解析（如截断/空文件）时跳过该段配音，导出不报错"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        videos_dir = tmp_path / "videos"
+        videos_dir.mkdir()
+        make_test_video(videos_dir / "seg_S1.mp4")
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        (audio_dir / "segment_S1.wav").write_bytes(b"not real audio")
+
+        draft_dir = tmp_path / "drafts" / "坏音频草稿"
+        clips = [
+            {
+                "id": "S1",
+                "local_path": str(videos_dir / "seg_S1.mp4"),
+                "novel_text": "",
+                "narration_audio_local": str(audio_dir / "segment_S1.wav"),
+            },
+        ]
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        svc._generate_draft(
+            draft_dir=draft_dir,
+            draft_name="坏音频草稿",
+            clips=clips,
+            width=1080,
+            height=1920,
+            content_mode="narration",
+        )
+
+        content = json.loads((draft_dir / "draft_content.json").read_text(encoding="utf-8"))
+        assert content.get("materials", {}).get("audios", []) == []
+        assert all(t.get("type") != "audio" for t in content.get("tracks", []))
+
+    def test_audio_open_failure_skipped_without_error(self, tmp_path, monkeypatch):
+        """音频文件解析阶段抛出运行时错误（如被占用）时跳过该段配音，导出不报错"""
+        import server.services.jianying_draft_service as svc_module
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        videos_dir = tmp_path / "videos"
+        videos_dir.mkdir()
+        make_test_video(videos_dir / "seg_S1.mp4")
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        make_test_audio(audio_dir / "segment_S1.wav")
+
+        def raise_runtime_error(*args, **kwargs):
+            raise RuntimeError("An error occured while opening the file")
+
+        monkeypatch.setattr(svc_module, "AudioMaterial", raise_runtime_error)
+
+        draft_dir = tmp_path / "drafts" / "占用草稿"
+        clips = [
+            {
+                "id": "S1",
+                "local_path": str(videos_dir / "seg_S1.mp4"),
+                "novel_text": "",
+                "narration_audio_local": str(audio_dir / "segment_S1.wav"),
+            },
+        ]
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        svc._generate_draft(
+            draft_dir=draft_dir,
+            draft_name="占用草稿",
+            clips=clips,
+            width=1080,
+            height=1920,
+            content_mode="narration",
+        )
+
+        content = json.loads((draft_dir / "draft_content.json").read_text(encoding="utf-8"))
+        assert content.get("materials", {}).get("audios", []) == []
+
+    def test_overlong_audio_clamped_to_next_narration_start(self, tmp_path):
+        """前段音频长过下一段音频的起点时收口到起点，导出不报错"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        videos_dir = tmp_path / "videos"
+        videos_dir.mkdir()
+        make_test_video(videos_dir / "seg_S1.mp4", duration_sec=1.0)
+        make_test_video(videos_dir / "seg_S2.mp4", duration_sec=1.0)
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        make_test_audio(audio_dir / "segment_S1.wav", duration_sec=3.0)
+        make_test_audio(audio_dir / "segment_S2.wav", duration_sec=1.0)
+
+        draft_dir = tmp_path / "drafts" / "超长草稿"
+        clips = [
+            {
+                "id": "S1",
+                "local_path": str(videos_dir / "seg_S1.mp4"),
+                "novel_text": "",
+                "narration_audio_local": str(audio_dir / "segment_S1.wav"),
+            },
+            {
+                "id": "S2",
+                "local_path": str(videos_dir / "seg_S2.mp4"),
+                "novel_text": "",
+                "narration_audio_local": str(audio_dir / "segment_S2.wav"),
+            },
+        ]
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        svc._generate_draft(
+            draft_dir=draft_dir,
+            draft_name="超长草稿",
+            clips=clips,
+            width=1080,
+            height=1920,
+            content_mode="narration",
+        )
+
+        content = json.loads((draft_dir / "draft_content.json").read_text(encoding="utf-8"))
+        audio_track = next(t for t in content["tracks"] if t.get("type") == "audio")
+        segments = audio_track["segments"]
+        assert len(segments) == 2
+
+        first, second = segments[0], segments[1]
+        # 第一段收口到第二段音频起点，互不重叠
+        assert (
+            first["target_timerange"]["start"] + first["target_timerange"]["duration"]
+            <= second["target_timerange"]["start"]
+        )
+        # 第二段保持真实时长（约 1s）
+        assert abs(second["target_timerange"]["duration"] - 1_000_000) < 200_000
 
 
 class TestTransitions:
@@ -374,6 +674,74 @@ class TestExportEpisodeDraft:
         (scripts_dir / "episode_1.json").write_text(json.dumps(script_data, ensure_ascii=False), encoding="utf-8")
 
         return pm, project_dir
+
+    def _add_narration_audio(self, project_dir, segment_id: str) -> None:
+        """为指定段补充旁白音频文件并写回剧本"""
+        audio_dir = project_dir / "audio"
+        audio_dir.mkdir(exist_ok=True)
+        make_test_audio(audio_dir / f"segment_{segment_id}.wav")
+
+        script_path = project_dir / "scripts" / "episode_1.json"
+        script_data = json.loads(script_path.read_text(encoding="utf-8"))
+        for segment in script_data["segments"]:
+            if segment["segment_id"] == segment_id:
+                segment["generated_assets"]["narration_audio"] = f"audio/segment_{segment_id}.wav"
+        script_path.write_text(json.dumps(script_data, ensure_ascii=False), encoding="utf-8")
+
+    def test_export_with_narration_audio_includes_audio_track(self, tmp_path):
+        """含 narration_audio 的项目导出后，ZIP 带音频素材，草稿含旁白音轨且路径已替换"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        pm, project_dir = self._setup_project(tmp_path)
+        self._add_narration_audio(project_dir, "S1")  # S2 缺 narration_audio，应跳过不报错
+        svc = JianyingDraftService(pm)
+        draft_path = "/Users/test/drafts"
+
+        zip_path = svc.export_episode_draft(project_name="demo", episode=1, draft_path=draft_path)
+
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+            assert any("segment_S1.wav" in n for n in names)
+
+            content_entry = [n for n in zf.namelist() if "draft_info.json" in n][0]
+            content = json.loads(zf.read(content_entry).decode("utf-8"))
+
+        audios = content["materials"]["audios"]
+        assert len(audios) == 1
+        assert audios[0]["path"].startswith(draft_path)
+        assert audios[0]["path"].endswith("segment_S1.wav")
+
+        audio_track = next(t for t in content["tracks"] if t.get("type") == "audio")
+        assert len(audio_track["segments"]) == 1
+        assert audio_track["segments"][0]["target_timerange"]["start"] == 0
+
+    def test_segments_sharing_one_audio_file_export_once(self, tmp_path):
+        """多段共享同一旁白音频文件时导出成功，素材只打包一份"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        pm, project_dir = self._setup_project(tmp_path)
+        audio_dir = project_dir / "audio"
+        audio_dir.mkdir()
+        make_test_audio(audio_dir / "shared.wav", duration_sec=0.5)
+
+        script_path = project_dir / "scripts" / "episode_1.json"
+        script_data = json.loads(script_path.read_text(encoding="utf-8"))
+        for segment in script_data["segments"]:
+            segment["generated_assets"]["narration_audio"] = "audio/shared.wav"
+        script_path.write_text(json.dumps(script_data, ensure_ascii=False), encoding="utf-8")
+
+        svc = JianyingDraftService(pm)
+        zip_path = svc.export_episode_draft(project_name="demo", episode=1, draft_path="/Users/test/drafts")
+
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+            assert sum(1 for n in names if "shared" in n and n.endswith(".wav")) == 1
+
+            content_entry = [n for n in names if "draft_info.json" in n][0]
+            content = json.loads(zf.read(content_entry).decode("utf-8"))
+
+        audio_track = next(t for t in content["tracks"] if t.get("type") == "audio")
+        assert len(audio_track["segments"]) == 2
 
     def test_exports_zip_with_correct_structure(self, tmp_path):
         """导出 ZIP 包含草稿 JSON + 视频素材"""

--- a/tests/test_jianying_draft_service.py
+++ b/tests/test_jianying_draft_service.py
@@ -756,6 +756,26 @@ class TestExportEpisodeDraft:
         assert len(audio_track["segments"]) == 1
         assert audio_track["segments"][0]["target_timerange"]["start"] == 0
 
+    def test_stage_rejects_source_replaced_outside_project(self, tmp_path, monkeypatch):
+        """收集后源路径被替换为项目外目标时，暂存前重校验拒绝导出"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        pm, _ = self._setup_project(tmp_path)
+        outside = tmp_path / "outside.mp4"
+        make_test_video(outside)
+        svc = JianyingDraftService(pm)
+        original = svc._collect_video_clips
+
+        def tampered(script_data, project_dir):
+            clips = original(script_data, project_dir)
+            clips[0]["abs_path"] = outside
+            return clips
+
+        monkeypatch.setattr(svc, "_collect_video_clips", tampered)
+
+        with pytest.raises(ValueError, match="路径越界"):
+            svc.export_episode_draft(project_name="demo", episode=1, draft_path="/mock/JianyingDrafts")
+
     def test_segments_sharing_one_audio_file_export_once(self, tmp_path):
         """多段共享同一旁白音频文件时导出成功，素材只打包一份"""
         from server.services.jianying_draft_service import JianyingDraftService

--- a/tests/test_jianying_draft_service.py
+++ b/tests/test_jianying_draft_service.py
@@ -429,7 +429,7 @@ class TestNarrationAudioTrack:
 
     def test_audio_open_failure_skipped_without_error(self, tmp_path, monkeypatch):
         """音频文件解析阶段抛出运行时错误（如被占用）时跳过该段配音，导出不报错"""
-        import server.services.jianying_draft_service as svc_module
+        from server.services.jianying_draft_service import JianyingDraftService
 
         videos_dir = tmp_path / "videos"
         videos_dir.mkdir()
@@ -441,7 +441,7 @@ class TestNarrationAudioTrack:
         def raise_runtime_error(*args, **kwargs):
             raise RuntimeError("An error occurred while opening the file")
 
-        monkeypatch.setattr(svc_module, "AudioMaterial", raise_runtime_error)
+        monkeypatch.setattr("server.services.jianying_draft_service.AudioMaterial", raise_runtime_error)
 
         draft_dir = tmp_path / "drafts" / "占用草稿"
         clips = [
@@ -453,7 +453,7 @@ class TestNarrationAudioTrack:
             },
         ]
 
-        svc = svc_module.JianyingDraftService.__new__(svc_module.JianyingDraftService)
+        svc = JianyingDraftService.__new__(JianyingDraftService)
         svc._generate_draft(
             draft_dir=draft_dir,
             draft_name="占用草稿",
@@ -468,7 +468,7 @@ class TestNarrationAudioTrack:
 
     def test_zero_duration_audio_skipped_without_error(self, tmp_path, monkeypatch):
         """音频有效时长为 0（解析异常或被收口到 0）时跳过该段配音，导出不报错"""
-        import server.services.jianying_draft_service as svc_module
+        from server.services.jianying_draft_service import JianyingDraftService
 
         videos_dir = tmp_path / "videos"
         videos_dir.mkdir()
@@ -482,7 +482,7 @@ class TestNarrationAudioTrack:
                 self.path = path
                 self.duration = 0
 
-        monkeypatch.setattr(svc_module, "AudioMaterial", ZeroDurationAudioMaterial)
+        monkeypatch.setattr("server.services.jianying_draft_service.AudioMaterial", ZeroDurationAudioMaterial)
 
         draft_dir = tmp_path / "drafts" / "零时长草稿"
         clips = [
@@ -494,7 +494,7 @@ class TestNarrationAudioTrack:
             },
         ]
 
-        svc = svc_module.JianyingDraftService.__new__(svc_module.JianyingDraftService)
+        svc = JianyingDraftService.__new__(JianyingDraftService)
         svc._generate_draft(
             draft_dir=draft_dir,
             draft_name="零时长草稿",
@@ -506,6 +506,7 @@ class TestNarrationAudioTrack:
 
         content = json.loads((draft_dir / "draft_content.json").read_text(encoding="utf-8"))
         assert content.get("materials", {}).get("audios", []) == []
+        assert all(t.get("type") != "audio" for t in content.get("tracks", []))
 
     def test_overlong_audio_clamped_to_next_narration_start(self, tmp_path):
         """前段音频长过下一段音频的起点时收口到起点，导出不报错"""
@@ -735,7 +736,7 @@ class TestExportEpisodeDraft:
         pm, project_dir = self._setup_project(tmp_path)
         self._add_narration_audio(project_dir, "S1")  # S2 缺 narration_audio，应跳过不报错
         svc = JianyingDraftService(pm)
-        draft_path = "/Users/test/drafts"
+        draft_path = "/mock/JianyingDrafts"
 
         zip_path = svc.export_episode_draft(project_name="demo", episode=1, draft_path=draft_path)
 
@@ -771,7 +772,7 @@ class TestExportEpisodeDraft:
         script_path.write_text(json.dumps(script_data, ensure_ascii=False), encoding="utf-8")
 
         svc = JianyingDraftService(pm)
-        zip_path = svc.export_episode_draft(project_name="demo", episode=1, draft_path="/Users/test/drafts")
+        zip_path = svc.export_episode_draft(project_name="demo", episode=1, draft_path="/mock/JianyingDrafts")
 
         with zipfile.ZipFile(zip_path) as zf:
             names = zf.namelist()

--- a/tests/test_jianying_draft_service.py
+++ b/tests/test_jianying_draft_service.py
@@ -430,7 +430,6 @@ class TestNarrationAudioTrack:
     def test_audio_open_failure_skipped_without_error(self, tmp_path, monkeypatch):
         """音频文件解析阶段抛出运行时错误（如被占用）时跳过该段配音，导出不报错"""
         import server.services.jianying_draft_service as svc_module
-        from server.services.jianying_draft_service import JianyingDraftService
 
         videos_dir = tmp_path / "videos"
         videos_dir.mkdir()
@@ -440,7 +439,7 @@ class TestNarrationAudioTrack:
         make_test_audio(audio_dir / "segment_S1.wav")
 
         def raise_runtime_error(*args, **kwargs):
-            raise RuntimeError("An error occured while opening the file")
+            raise RuntimeError("An error occurred while opening the file")
 
         monkeypatch.setattr(svc_module, "AudioMaterial", raise_runtime_error)
 
@@ -454,10 +453,51 @@ class TestNarrationAudioTrack:
             },
         ]
 
-        svc = JianyingDraftService.__new__(JianyingDraftService)
+        svc = svc_module.JianyingDraftService.__new__(svc_module.JianyingDraftService)
         svc._generate_draft(
             draft_dir=draft_dir,
             draft_name="占用草稿",
+            clips=clips,
+            width=1080,
+            height=1920,
+            content_mode="narration",
+        )
+
+        content = json.loads((draft_dir / "draft_content.json").read_text(encoding="utf-8"))
+        assert content.get("materials", {}).get("audios", []) == []
+
+    def test_zero_duration_audio_skipped_without_error(self, tmp_path, monkeypatch):
+        """音频有效时长为 0（解析异常或被收口到 0）时跳过该段配音，导出不报错"""
+        import server.services.jianying_draft_service as svc_module
+
+        videos_dir = tmp_path / "videos"
+        videos_dir.mkdir()
+        make_test_video(videos_dir / "seg_S1.mp4")
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        make_test_audio(audio_dir / "segment_S1.wav")
+
+        class ZeroDurationAudioMaterial:
+            def __init__(self, path):
+                self.path = path
+                self.duration = 0
+
+        monkeypatch.setattr(svc_module, "AudioMaterial", ZeroDurationAudioMaterial)
+
+        draft_dir = tmp_path / "drafts" / "零时长草稿"
+        clips = [
+            {
+                "id": "S1",
+                "local_path": str(videos_dir / "seg_S1.mp4"),
+                "novel_text": "",
+                "narration_audio_local": str(audio_dir / "segment_S1.wav"),
+            },
+        ]
+
+        svc = svc_module.JianyingDraftService.__new__(svc_module.JianyingDraftService)
+        svc._generate_draft(
+            draft_dir=draft_dir,
+            draft_name="零时长草稿",
             clips=clips,
             width=1080,
             height=1920,

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -15,6 +15,12 @@ def test_missing_file_returns_false(tmp_path: Path):
     assert safe_exists(tmp_path, "nope.txt") is False
 
 
+def test_directory_returns_false(tmp_path: Path):
+    # 素材路径只接受文件，目录视同不存在
+    (tmp_path / "subdir").mkdir()
+    assert safe_exists(tmp_path, "subdir") is False
+
+
 def test_traversal_rejected(tmp_path: Path):
     outside = tmp_path.parent / "outside.txt"
     outside.write_text("x", encoding="utf-8")


### PR DESCRIPTION
## 概述

说书项目导出剪映草稿时，已生成旁白配音的段自动带上独立的「旁白」音轨：每段音频按对应视频片段的起点摆放，时长取音频文件真实时长，用户在剪映里即可直接合成带配音的成片并手动精调。

Closes #711

## 行为

- 段的 `generated_assets.narration_audio` 存在且文件有效 → 草稿新增旁白音轨，AudioSegment 按该段视频片段的 offset 摆放，时长为音频文件真实时长（不做自动时长对齐）
- 缺 `narration_audio`、文件不存在、路径越界、文件损坏/无法解析的段 → 跳过该段配音，视频照常导出，不报错
- 超长音频会与下一段旁白重叠时收口到其起点，保证草稿可正常打开（pyJianYingDraft 同轨段不允许重叠）
- 音频素材随 ZIP 打包进草稿 assets，路径替换为用户本地剪映目录；多段共享同一音频文件只打包一份

## 实现要点

- 项目内相对路径解析收敛到 `lib/path_safety.safe_resolve`（新增），video_clip 与 narration_audio 守卫共用，含脏数据硬化；`safe_exists` 改为委托实现，行为不变
- 暂存区同名碰撞防护：来源文件同名时自动改名；同源去重按已解析路径判定（不依赖 inode 比较，FAT/exFAT 无稳定文件 ID 会误判）
- 测试音频 fixture 用 ffmpeg 内置 `pcm_s16le` 生成 wav，与生产端 `audio/segment_{id}.wav` 形状一致，无可选编码器依赖

## 测试

- `tests/test_jianying_draft_service.py` 新增 12 个用例：音轨按 offset 摆放、真实时长不对齐、超长收口、坏文件/解析失败/缺失/越界跳过、共享音频去重、e2e ZIP 结构与路径替换
- `uv run python -m pytest`：4175 passed（1 个已知本机环境耦合失败，CI 干净库通过）
- `uv run ruff check . && uv run ruff format .`：干净
- `uv run basedpyright`：0 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 草稿导出支持旁白音频：按视频偏移插入音轨，音频时长以文件为准，超长收口，只有存在有效片段时才创建音轨，重复引用的音频只打包一次。

* **改进**
  * 引入统一的安全路径解析与存在性判定，暂存阶段按源去重并优先硬链接或复制，移动资源前增加越界写入守卫以保障导出安全。

* **测试**
  * 增加旁白音频的单元与端到端测试、生成测试音频的辅助工具及路径安全性测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->