### PR TITLE
fix(agent): 收紧智能体沙箱在 Windows 回退下的 Bash 防护与跨平台路径围栏

### DIFF
--- a/docs/adr/0027-provider-secrets-banned-from-process-env.md
+++ b/docs/adr/0027-provider-secrets-banned-from-process-env.md
@@ -9,5 +9,5 @@ provider 密钥若进 `os.environ`，会被 agent 子进程整体继承，泄漏
 ## Consequences
 
 - 新增供应商时须把它的 env 变量名登记进 `lib/config/env_keys.py`（启动断言/env 覆盖/Bash 清洗共用此清单；模式扫描只能覆盖命名规整的变量）。
-- ③ 是 POSIX 机制（依赖 `env`/`sh`），仅在沙箱可用（macOS/Linux）时执行包装；hook 只改写命令、不下权限决策，放行由权限链后续步骤（allowed_tools）完成。Windows 原生回退下 hook 跳过包装，原始命令交由 `can_use_tool` 的 Bash 白名单裁决，拒绝规则三道：token 边界匹配（挡 `ffmpegX` 这类前缀碰撞）、shell metachar 拦截（`; & | < > ` $ 换行`，挡链式/管道/重定向/命令替换）、`..` 路径穿越拦截（含 `".."` 引号与 `.\.` 反斜杠转义的混淆形式，挡逃出 skills 目录跑任意脚本）；其中 `python` 入口进一步限定为 `.claude/skills/<skill>/scripts/<script>.py`。运维排障时拒绝文案会标明命中哪条规则。①② 两层不受平台影响。
+- ③ 是 POSIX 机制（依赖 `env`/`sh`），仅在沙箱可用（macOS/Linux）时执行包装；hook 只改写命令、不下权限决策，放行由权限链后续步骤（allowed_tools）完成。Windows 原生回退下 hook 跳过包装，原始命令交由 `can_use_tool` 的 Bash 白名单裁决，拒绝规则三道：token 边界匹配（挡 `ffmpegX` 这类前缀碰撞）、shell metachar 拦截（分号、`&`、管道符、尖括号、反引号、`$`、换行——挡链式/管道/重定向/命令替换）、`..` 路径穿越拦截（含 `".."` 引号与 `.\.` 反斜杠转义的混淆形式，挡逃出 skills 目录跑任意脚本）；其中 `python` 入口进一步限定为 `.claude/skills/<skill>/scripts/<script>.py`。运维排障时拒绝文案会标明命中哪条规则。①② 两层不受平台影响。
 - 与 `docs/adr/0017` 互补：0017 讲 Anthropic 凭证「如何注入」，本条讲所有 provider 密钥「如何不泄漏」。

--- a/docs/adr/0027-provider-secrets-banned-from-process-env.md
+++ b/docs/adr/0027-provider-secrets-banned-from-process-env.md
@@ -9,5 +9,5 @@ provider 密钥若进 `os.environ`，会被 agent 子进程整体继承，泄漏
 ## Consequences
 
 - 新增供应商时须把它的 env 变量名登记进 `lib/config/env_keys.py`（启动断言/env 覆盖/Bash 清洗共用此清单；模式扫描只能覆盖命名规整的变量）。
-- ③ 是 POSIX 机制（依赖 `env`/`sh`），仅在沙箱可用（macOS/Linux）时执行包装；hook 只改写命令、不下权限决策，放行由权限链后续步骤（allowed_tools）完成。Windows 原生回退下 hook 跳过包装，原始命令交由 `can_use_tool` 的 Bash 白名单（token 边界匹配 + shell metachar 拦截）裁决——①② 两层不受平台影响。
+- ③ 是 POSIX 机制（依赖 `env`/`sh`），仅在沙箱可用（macOS/Linux）时执行包装；hook 只改写命令、不下权限决策，放行由权限链后续步骤（allowed_tools）完成。Windows 原生回退下 hook 跳过包装，原始命令交由 `can_use_tool` 的 Bash 白名单裁决，拒绝规则三道：token 边界匹配（挡 `ffmpegX` 这类前缀碰撞）、shell metachar 拦截（`; & | < > ` $ 换行`，挡链式/管道/重定向/命令替换）、`..` 路径穿越拦截（含 `".."` 引号与 `.\.` 反斜杠转义的混淆形式，挡逃出 skills 目录跑任意脚本）；其中 `python` 入口进一步限定为 `.claude/skills/<skill>/scripts/<script>.py`。运维排障时拒绝文案会标明命中哪条规则。①② 两层不受平台影响。
 - 与 `docs/adr/0017` 互补：0017 讲 Anthropic 凭证「如何注入」，本条讲所有 provider 密钥「如何不泄漏」。

--- a/docs/adr/0027-provider-secrets-banned-from-process-env.md
+++ b/docs/adr/0027-provider-secrets-banned-from-process-env.md
@@ -9,5 +9,5 @@ provider 密钥若进 `os.environ`，会被 agent 子进程整体继承，泄漏
 ## Consequences
 
 - 新增供应商时须把它的 env 变量名登记进 `lib/config/env_keys.py`（启动断言/env 覆盖/Bash 清洗共用此清单；模式扫描只能覆盖命名规整的变量）。
-- ③ 是 POSIX 机制（依赖 `env`/`sh`），只为 macOS/Linux 沙箱路径设计；Windows 原生回退下不适用，且该 hook 与 Bash 前缀白名单的权限链交互存在已知缺陷，修复在 issue #622 跟踪——①② 两层不受平台影响。
+- ③ 是 POSIX 机制（依赖 `env`/`sh`），仅在沙箱可用（macOS/Linux）时执行包装；hook 只改写命令、不下权限决策，放行由权限链后续步骤（allowed_tools）完成。Windows 原生回退下 hook 跳过包装，原始命令交由 `can_use_tool` 的 Bash 白名单（token 边界匹配 + shell metachar 拦截）裁决——①② 两层不受平台影响。
 - 与 `docs/adr/0017` 互补：0017 讲 Anthropic 凭证「如何注入」，本条讲所有 provider 密钥「如何不泄漏」。

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -335,11 +335,18 @@ class SessionManager:
 
     _BASH_TOOLS: tuple[str, ...] = ("Bash", "BashOutput", "KillBash")
 
+    # python skills 入口前缀。约定形态 ``python .claude/skills/<skill>/scripts/
+    # <script>.py <args>``：脚本路径须落在某 skill 的 scripts/ 下（_SKILL_SCRIPT_RE
+    # 校验），挡住 skills 目录里任意现有/未来文件被当作可执行入口——Windows 回退
+    # 无 sandbox denyExec 兜底，仅靠前缀放行会把整棵 skills 树暴露为可执行面。
+    _PYTHON_SKILLS_PREFIX = "python .claude/skills/"
+    _SKILL_SCRIPT_RE: "re.Pattern[str]" = re.compile(r"^\.claude/skills/[^/]+/scripts/[^/]+\.py$")
+
     # Windows 回退（_sandbox_enabled=False）的 Bash 命令白名单：等价于 PR 沙箱化前
     # main 分支 settings.json permissions.allow 段。也是 _can_use_tool deny hint
     # 文案的单一真相源（_format_bash_whitelist_deny_message 从此派生）。
     _WINDOWS_BASH_PREFIX_WHITELIST: tuple[str, ...] = (
-        "python .claude/skills/",
+        _PYTHON_SKILLS_PREFIX,
         "ffmpeg",
         "ffprobe",
     )
@@ -2563,28 +2570,50 @@ class SessionManager:
     def _is_bash_command_whitelisted(cls, command: str) -> bool:
         """Windows 回退（sandbox 不可用）的 Bash 命令白名单判定。
 
-        纯 startswith 前缀匹配有两类绕过：metachar 链（``ffmpeg ...; evil`` 整串
-        满足前缀，尾部命令照常执行，且 Windows 上无 sandbox denyWrite 兜底）与
-        命令名前缀碰撞（``ffmpegX`` 也以 ``ffmpeg`` 开头）。判定分两步：
+        纯 startswith 前缀匹配有三类绕过：metachar 链（``ffmpeg ...; evil`` 整串
+        满足前缀，尾部命令照常执行，且 Windows 上无 sandbox denyWrite 兜底）、
+        命令名前缀碰撞（``ffmpegX`` 也以 ``ffmpeg`` 开头）、路径穿越（``..`` 逃出
+        skills 目录）。判定分四步：
 
         1. 整串拒 shell metachar（``_BASH_METACHARS_RE``），挡链式/管道/重定向/
            命令替换；
-        2. 整串拒 ``..`` 路径段（``_BASH_PATH_TRAVERSAL_RE``），挡
-           ``python .claude/skills/../../evil.py`` 逃出 skills 目录跑任意脚本；
+        2. 拒 ``..`` 路径段（``_BASH_PATH_TRAVERSAL_RE``）：原串之外，再剥引号、
+           按 Windows 分隔符（``\\``→``/``）与 POSIX 转义（去 ``\\``）两解后各查一遍
+           ——shell 会把 ``".."`` / ``.\\.`` 还原成 ``..``，只查原串会被这类混淆
+           绕过逃出 skills 目录；
         3. 按 token 边界匹配 ``_WINDOWS_BASH_PREFIX_WHITELIST``：不含空格的前缀
-           （ffmpeg/ffprobe）要求命令名完全相等或后跟空格；含空格的前缀
-           （``python .claude/skills/``）空格已锚定命令名，路径段按前缀匹配。
+           （ffmpeg/ffprobe）要求命令名完全相等或后跟空格；
+        4. python skills 入口额外要求首个参数是 ``<skill>/scripts/<script>.py``
+           （``_is_allowed_python_skill_command``），不放行 skills 目录下任意文件。
         """
         cmd = command.strip()
-        if not cmd or cls._BASH_METACHARS_RE.search(cmd) or cls._BASH_PATH_TRAVERSAL_RE.search(cmd):
+        if not cmd or cls._BASH_METACHARS_RE.search(cmd):
             return False
+        unquoted = cmd.replace('"', "").replace("'", "")
+        for variant in (cmd, unquoted.replace("\\", "/"), unquoted.replace("\\", "")):
+            if cls._BASH_PATH_TRAVERSAL_RE.search(variant):
+                return False
         for prefix in cls._WINDOWS_BASH_PREFIX_WHITELIST:
-            if " " in prefix:
+            if prefix == cls._PYTHON_SKILLS_PREFIX:
+                if cmd.startswith(prefix) and cls._is_allowed_python_skill_command(cmd):
+                    return True
+            elif " " in prefix:
                 if cmd.startswith(prefix):
                     return True
             elif cmd == prefix or cmd.startswith(prefix + " "):
                 return True
         return False
+
+    @classmethod
+    def _is_allowed_python_skill_command(cls, cmd: str) -> bool:
+        """``python .claude/skills/...`` 的脚本入口校验：取首个参数（脚本路径），
+        要求匹配 ``.claude/skills/<skill>/scripts/<script>.py``。约束到显式 scripts
+        入口，避免 skills 目录下任意文件在 Windows 回退（无 sandbox 兜底）下可执行。
+        """
+        parts = cmd.split(maxsplit=2)
+        if len(parts) < 2:
+            return False
+        return cls._SKILL_SCRIPT_RE.match(parts[1]) is not None
 
     @classmethod
     def _format_bash_whitelist_deny_message(cls, command: str) -> str:
@@ -2597,6 +2626,7 @@ class SessionManager:
             f"{allowed_lines}\n"
             "且命令不得包含 shell 元字符（; & | < > ` $ 或换行）或 .. 路径穿越——"
             "复合命令请拆成多次独立调用，脚本路径不要用 .. 逃出目录。\n"
+            "python 仅允许跑 .claude/skills/<skill>/scripts/<script>.py 入口脚本。\n"
             "其他 Bash 命令在 Windows 回退模式下不可用。"
         )
 

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -10,9 +10,11 @@ import json
 import logging
 import math
 import os
+import re
 import shlex
 import tempfile
 import time
+import unicodedata
 from collections import deque
 from collections.abc import AsyncIterable, AsyncIterator, Callable
 from dataclasses import dataclass, field
@@ -341,6 +343,18 @@ class SessionManager:
         "ffmpeg",
         "ffprobe",
     )
+
+    # Windows 回退白名单的 shell metachar 黑名单：``;`` ``&`` ``|`` ``<`` ``>``
+    # `` ` `` ``$`` 与换行都可能在白名单前缀后挂任意命令（链式/管道/重定向/
+    # 命令替换）。不解析引号语境，引号内出现也整串拒——宁可误拒（fail-closed），
+    # deny 文案会引导 agent 改写命令。
+    _BASH_METACHARS_RE: "re.Pattern[str]" = re.compile(r"[;&|<>`$\r\n]")
+
+    # ``..`` 路径段：``python .claude/skills/../../evil.py`` 不含 metachar 且满足
+    # ``python .claude/skills/`` 前缀，但 ``..`` 逃出 skills 目录执行任意脚本——
+    # Windows 回退无 sandbox denyWrite/denyExec 兜底，整串拒。仅匹配被分隔符/
+    # 空白/串首尾界定的 ``..`` 段，``my..name`` 这类文件名不误伤。
+    _BASH_PATH_TRAVERSAL_RE: "re.Pattern[str]" = re.compile(r"(?:^|[\s/\\])\.\.(?:[\s/\\]|$)")
 
     # Sandbox 启用后 Bash 进入 allowed_tools；具体命令由 SDK Sandbox 自动放行
     # (autoAllowBashIfSandboxed=True)。文件访问控制走 settings.json deny rules
@@ -811,9 +825,8 @@ class SessionManager:
         unset_flags = " ".join(f"-u {key}" for key in cls._collect_env_keys_to_scrub())
         return f"env {unset_flags} sh -c "
 
-    @classmethod
     async def _bash_env_scrub_hook(
-        cls,
+        self,
         input_data: dict[str, Any],
         _tool_use_id: str | None,
         _context: Any,
@@ -825,19 +838,30 @@ class SessionManager:
         继承全部 env，agent 跑 ``env | grep`` 能看到变量名。通过
         ``env -u VAR ... sh -c '<cmd>'`` 把所有命中的变量名从 Bash subshell 中
         unset，原 command 经 ``shlex.quote`` 整体作为 sh 子壳的 -c 参数。
+
+        只返回 ``updatedInput``、不返回 ``permissionDecision``：PreToolUse hook
+        是权限链第 1 步，``allow`` 会短路后续所有步骤（包括 ``_can_use_tool``）。
+        sandbox 启用时 Bash 在 allowed_tools 内，包装后的命令由 allow 规则放行；
+        权限决策始终留给链上后续步骤。
+
+        sandbox 不可用（Windows 回退）时跳过包装：``env -u``/``sh -c`` 是 POSIX
+        机制，原生 Windows 不可执行；Bash 已从 allowed_tools 剥离，原始命令落到
+        ``_can_use_tool`` 做白名单匹配——若仍包装，命令以 ``env -u`` 开头会让
+        白名单永远匹配不上。
         """
         tool_input = input_data.get("tool_input") or {}
         command = tool_input.get("command")
         if not isinstance(command, str) or not command.strip():
             return {"continue_": True}
+        if not self._sandbox_enabled:
+            return {"continue_": True}
 
-        wrapped = f"{cls._env_scrub_wrap_prefix()}{shlex.quote(command)}"
+        wrapped = f"{self._env_scrub_wrap_prefix()}{shlex.quote(command)}"
         updated_input = {**tool_input, "command": wrapped}
         return {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
                 "updatedInput": updated_input,
-                "permissionDecision": "allow",
             },
         }
 
@@ -2132,18 +2156,26 @@ class SessionManager:
             },
         }
 
-    @staticmethod
-    def _build_protected_json_abs_paths(project_cwd: Path) -> list[str]:
+    @classmethod
+    def _build_protected_json_abs_paths(cls, project_cwd: Path) -> list[str]:
         """项目 JSON 写禁清单（绝对路径）：``scripts/`` 目录子树 + ``project.json``。
 
         与 ``_check_write_access`` 的内置 Write/Edit 拒绝同源（同两类路径），二者构成双层：
         sandbox denyWrite 管 Bash 子进程（内核级），``_check_write_access`` hook 管内置
         Write/Edit（权限系统，全平台）。
+
+        base 经 ``_enumerate_cwd_bases`` 同时枚举 raw + resolved 两种形式（与
+        ``_check_write_access`` 同口径）：sandbox 实现若按字符串路径比对而非 inode，
+        仅注册 raw 形式会在 Bash 子进程经 symlink 解析（macOS ``/var↔/private/var``、
+        Linux symlinked 项目根）后写 resolved 路径时失配。
         """
-        return [
-            str(project_cwd / "scripts"),
-            str(project_cwd / "project.json"),
-        ]
+        paths: list[str] = []
+        for base in cls._enumerate_cwd_bases(project_cwd):
+            for target in (base / "scripts", base / "project.json"):
+                target_s = str(target)
+                if target_s not in paths:
+                    paths.append(target_s)
+        return paths
 
     def _build_sensitive_abs_paths(self) -> list[str]:
         """构造敏感文件绝对路径列表，传给 sandbox profile 的 denyRead 字段。
@@ -2310,20 +2342,10 @@ class SessionManager:
         是 symlink 入口（macOS ``/var↔/private/var``、Linux symlinked 项目根）。仅用 raw base 拼
         protected 路径与 resolved target 字符串比对会失配 → bypass；同时枚举两种 base 保证同口径。
         """
-        # 一次性 resolve project_cwd 同时枚举 raw 与 resolved 形式的 base，避免 symlinked
+        # raw + resolved 两种形式的 base 由 _enumerate_cwd_bases 一次性枚举，避免 symlinked
         # project_cwd 下 is_relative_to / 受保护谓词因 base↔target 形式不一致漏判。bases 复用
         # 给下游 `_is_protected_project_json`,后者直接消费列表不再做第二次 resolve（消除冗余 lstat）。
-        bases: list[Path] = [project_cwd]
-        try:
-            resolved_cwd = project_cwd.resolve(strict=False)
-            if resolved_cwd != project_cwd:
-                bases.append(resolved_cwd)
-        except (OSError, RuntimeError) as exc:
-            # 静默 pass 会让"权限不足 / symlink 环路解析失败" 类 fs 异常吃掉,后续
-            # is_relative_to 用 raw base 与 caller 传入的 resolved target 比对可能漏判;
-            # 失败时 fail-closed（bases 仅含 raw,target 不在 raw 下时拒绝写入）仍是安全的,
-            # 但加 warning 让运维知道 base 解析失败,而非把诊断信号全部吞掉。
-            logger.warning("project_cwd 解析失败,write_access 检查降级为仅 raw base: %s (%s)", project_cwd, exc)
+        bases = self._enumerate_cwd_bases(project_cwd)
 
         if not any(resolved.is_relative_to(base) for base in bases):
             return False, (f"访问被拒绝：不允许写入当前项目目录之外的路径 ({resolved})")
@@ -2347,7 +2369,53 @@ class SessionManager:
         return True, None
 
     @staticmethod
-    def _is_protected_project_json(target: Path, bases: list[Path]) -> bool:
+    def _enumerate_cwd_bases(project_cwd: Path) -> list[Path]:
+        """raw + resolved 两种形式的 project_cwd base 列表。
+
+        ``project_cwd`` 可能是 symlink 入口（macOS ``/var↔/private/var``、Linux
+        symlinked 项目根），仅用 raw 形式拼路径与已 resolve 的 target 比对会失配。
+        ``_check_write_access``（hook 层）与 ``_build_protected_json_abs_paths``
+        （sandbox denyWrite）共用此枚举，保证两层路径基同口径。
+
+        resolve 失败时 fail-closed：bases 仅含 raw（hook 层 target 不在 raw 下时
+        拒绝写入仍安全），加 warning 保留诊断信号而非静默吞掉。
+        """
+        bases: list[Path] = [project_cwd]
+        try:
+            resolved_cwd = project_cwd.resolve(strict=False)
+            if resolved_cwd != project_cwd:
+                bases.append(resolved_cwd)
+        except (OSError, RuntimeError) as exc:
+            logger.warning("project_cwd 解析失败,路径围栏降级为仅 raw base: %s (%s)", project_cwd, exc)
+        return bases
+
+    @classmethod
+    def _normalize_path_for_protected_compare(cls, path: Path | str) -> str:
+        """把路径字符串归一化为受保护区比对用的统一键。
+
+        三步处理，覆盖三类形态漂移：
+
+        - Windows ``\\\\?\\`` 扩展长度前缀：``Path.resolve`` 在路径接近 MAX_PATH 或
+          UNC 共享时返回 ``\\\\?\\C:\\...`` / ``\\\\?\\UNC\\server\\...`` 形式，与常规
+          形式混入 bases 时 startswith 失配——剥成常规形式再比；
+        - ``unicodedata.normalize("NFC", ...)``：macOS HFS+ 按 NFD 存储文件名，
+          resolve 返回的 NFD 形式与 NFC 输入即使 casefold 后仍是不同字符串；
+        - ``os.path.normcase`` + ``casefold``：normcase 统一 Windows 分隔符
+          （``/``→``\\``，POSIX 上恒等）；casefold 承担大小写不敏感比较——
+          Windows NTFS / macOS APFS 默认卷大小写不敏感，``PROJECT.JSON`` 与
+          ``project.json`` 指向同一物理文件。Linux case-sensitive 卷上 agent
+          实际不会用大小写变体，偶尔 over-match 不破坏 fail-loud 语义。
+        """
+        s = str(path)
+        if s.startswith("\\\\?\\"):
+            rest = s[4:]
+            # \\?\UNC\server\share → \\server\share；\\?\C:\... → C:\...
+            s = "\\\\" + rest[4:] if rest[:4].casefold() == "unc\\" else rest
+        s = unicodedata.normalize("NFC", s)
+        return os.path.normcase(s).casefold()
+
+    @classmethod
+    def _is_protected_project_json(cls, target: Path, bases: list[Path]) -> bool:
         """命中受保护的项目 JSON（``scripts/`` 下任意 .json，或根 ``project.json``）。
 
         caller 应分别对「逻辑目标」（normpath 收敛 `.`/`..` 但不展开 symlink）和「resolve
@@ -2359,20 +2427,19 @@ class SessionManager:
         project_cwd 列表（同口径 raw/resolved 与 target 比对，避免 macOS ``/var↔/private/var``、
         Linux symlinked 项目根下漏判），本谓词消费现成 list 不再自行 resolve（消除冗余 lstat）。
 
-        路径用 ``casefold`` 后比较：Windows NTFS / macOS APFS 默认卷是大小写不敏感文件系统，
-        ``PROJECT.JSON`` 与 ``project.json`` 指向同一物理文件，但 ``Path`` 字符串比较 case-sensitive
-        会漏判这一类大小写变体绕过。Linux case-sensitive 卷上 agent 实际不会用大小写变体，
-        casefold 的偶尔 over-match 不会破坏 fail-loud 语义。
+        比对两侧都经 ``_normalize_path_for_protected_compare`` 归一化（NFC + normcase +
+        casefold + 剥 ``\\\\?\\`` 前缀），处理大小写、Unicode 归一化形式与 Windows
+        扩展长度前缀三类形态漂移。
 
         与 sandbox ``denyWrite`` 同源；此谓词覆盖内置 Write/Edit（权限系统，全平台），
         与 denyWrite（Bash 子进程，内核级）构成双层。
         """
-        target_s = str(target).casefold()
+        target_s = cls._normalize_path_for_protected_compare(target)
 
         for base in bases:
-            if target_s == str(base / "project.json").casefold():
+            if target_s == cls._normalize_path_for_protected_compare(base / "project.json"):
                 return True
-            scripts_dir = str(base / "scripts").casefold()
+            scripts_dir = cls._normalize_path_for_protected_compare(base / "scripts")
             # 拒绝 scripts/ 子树（含目录本身）：sandbox denyWrite 把整个 scripts/ 列入内核级 deny，
             # hook 层须保持一致——否则 agent 用 Write 写 scripts/foo.bak / .tmp / .md 会污染剧本
             # 目录，破坏项目结构约定（scripts/ 是剧本 .json 专属，drafts/ 才放草稿）。
@@ -2465,7 +2532,7 @@ class SessionManager:
             # 落到这里走 _WINDOWS_BASH_PREFIX_WHITELIST 代码白名单。
             if not self._sandbox_enabled and tool_name == "Bash":
                 cmd = str((input_data or {}).get("command") or "").strip()
-                if cmd.startswith(self._WINDOWS_BASH_PREFIX_WHITELIST):
+                if self._is_bash_command_whitelisted(cmd):
                     return PermissionResultAllow(updated_input=input_data)
                 if PermissionResultDeny is not None:
                     return PermissionResultDeny(
@@ -2493,6 +2560,33 @@ class SessionManager:
         return _can_use_tool
 
     @classmethod
+    def _is_bash_command_whitelisted(cls, command: str) -> bool:
+        """Windows 回退（sandbox 不可用）的 Bash 命令白名单判定。
+
+        纯 startswith 前缀匹配有两类绕过：metachar 链（``ffmpeg ...; evil`` 整串
+        满足前缀，尾部命令照常执行，且 Windows 上无 sandbox denyWrite 兜底）与
+        命令名前缀碰撞（``ffmpegX`` 也以 ``ffmpeg`` 开头）。判定分两步：
+
+        1. 整串拒 shell metachar（``_BASH_METACHARS_RE``），挡链式/管道/重定向/
+           命令替换；
+        2. 整串拒 ``..`` 路径段（``_BASH_PATH_TRAVERSAL_RE``），挡
+           ``python .claude/skills/../../evil.py`` 逃出 skills 目录跑任意脚本；
+        3. 按 token 边界匹配 ``_WINDOWS_BASH_PREFIX_WHITELIST``：不含空格的前缀
+           （ffmpeg/ffprobe）要求命令名完全相等或后跟空格；含空格的前缀
+           （``python .claude/skills/``）空格已锚定命令名，路径段按前缀匹配。
+        """
+        cmd = command.strip()
+        if not cmd or cls._BASH_METACHARS_RE.search(cmd) or cls._BASH_PATH_TRAVERSAL_RE.search(cmd):
+            return False
+        for prefix in cls._WINDOWS_BASH_PREFIX_WHITELIST:
+            if " " in prefix:
+                if cmd.startswith(prefix):
+                    return True
+            elif cmd == prefix or cmd.startswith(prefix + " "):
+                return True
+        return False
+
+    @classmethod
     def _format_bash_whitelist_deny_message(cls, command: str) -> str:
         """Windows 回退 Bash 白名单拒绝文案。从 _WINDOWS_BASH_PREFIX_WHITELIST
         派生 allowed 列表，避免常量与文案双份漂移。"""
@@ -2501,6 +2595,8 @@ class SessionManager:
             f"未授权的 Bash 命令: {command[:200]}\n"
             "当前 Bash 白名单仅允许以下前缀:\n"
             f"{allowed_lines}\n"
+            "且命令不得包含 shell 元字符（; & | < > ` $ 或换行）或 .. 路径穿越——"
+            "复合命令请拆成多次独立调用，脚本路径不要用 .. 逃出目录。\n"
             "其他 Bash 命令在 Windows 回退模式下不可用。"
         )
 

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -2585,6 +2585,11 @@ class SessionManager:
            （ffmpeg/ffprobe）要求命令名完全相等或后跟空格；
         4. python skills 入口额外要求首个参数是 ``<skill>/scripts/<script>.py``
            （``_is_allowed_python_skill_command``），不放行 skills 目录下任意文件。
+
+        白名单匹配在剥引号 + 反斜杠转正斜杠的归一化串上做：容忍 Windows agent 发出
+        的 ``\\`` 分隔符路径与带引号的脚本路径，避免合法命令被误拒（matching 不改写
+        实际执行的命令，放行时仍透传原始 input）。metachar 与 ``..`` 已先对原串及
+        各归一化变体拒过，归一化只用于「是否命中白名单」的判定，不会放宽安全边界。
         """
         cmd = command.strip()
         if not cmd or cls._BASH_METACHARS_RE.search(cmd):
@@ -2593,24 +2598,28 @@ class SessionManager:
         for variant in (cmd, unquoted.replace("\\", "/"), unquoted.replace("\\", "")):
             if cls._BASH_PATH_TRAVERSAL_RE.search(variant):
                 return False
+        normalized = unquoted.replace("\\", "/")
         for prefix in cls._WINDOWS_BASH_PREFIX_WHITELIST:
             if prefix == cls._PYTHON_SKILLS_PREFIX:
-                if cmd.startswith(prefix) and cls._is_allowed_python_skill_command(cmd):
+                if normalized.startswith(prefix) and cls._is_allowed_python_skill_command(normalized):
                     return True
             elif " " in prefix:
-                if cmd.startswith(prefix):
+                if normalized.startswith(prefix):
                     return True
-            elif cmd == prefix or cmd.startswith(prefix + " "):
+            elif normalized == prefix or normalized.startswith(prefix + " "):
                 return True
         return False
 
     @classmethod
-    def _is_allowed_python_skill_command(cls, cmd: str) -> bool:
+    def _is_allowed_python_skill_command(cls, normalized_cmd: str) -> bool:
         """``python .claude/skills/...`` 的脚本入口校验：取首个参数（脚本路径），
         要求匹配 ``.claude/skills/<skill>/scripts/<script>.py``。约束到显式 scripts
         入口，避免 skills 目录下任意文件在 Windows 回退（无 sandbox 兜底）下可执行。
+
+        入参须为 ``_is_bash_command_whitelisted`` 归一化后的串（已剥引号、反斜杠转
+        正斜杠），故按空白切分取首参即可，无需 shell 级 tokenize。
         """
-        parts = cmd.split(maxsplit=2)
+        parts = normalized_cmd.split(maxsplit=2)
         if len(parts) < 2:
             return False
         return cls._SKILL_SCRIPT_RE.match(parts[1]) is not None

--- a/tests/agent_runtime/test_path_isolation_hook.py
+++ b/tests/agent_runtime/test_path_isolation_hook.py
@@ -163,6 +163,39 @@ def test_write_protected_with_symlinked_project_cwd_denied(sm: SessionManager, t
     assert reason and ("patch_episode_script" in reason or "patch_project" in reason)
 
 
+def test_protected_json_predicate_normalizes_nfd_and_case() -> None:
+    """NFC/NFD 与大小写混合形式都须命中：macOS HFS+ 按 NFD 存储文件名，resolve
+    返回的 target 与 NFC 形式的 base 即使 casefold 后仍是不同字符串——受保护
+    比对须先做 NFC 归一化，再做大小写不敏感比较。"""
+    base_nfc = Path("/data/projects/caf\u00e9")  # café（NFC 单码位）
+    target_nfd = Path("/data/projects/cafe\u0301/project.json")  # café（NFD 组合字符）
+    assert SessionManager._is_protected_project_json(target_nfd, [base_nfc])
+
+    # 大小写变体 + NFD 叠加
+    target_mixed = Path("/data/projects/CAFE\u0301/SCRIPTS/EPISODE_1.JSON")
+    assert SessionManager._is_protected_project_json(target_mixed, [base_nfc])
+
+    # 反向：base 是 NFD（HFS+ 磁盘形式）、target 是 NFC（用户输入形式）
+    base_nfd = Path("/data/projects/cafe\u0301")
+    target_nfc = Path("/data/projects/caf\u00e9/scripts/episode_1.json")
+    assert SessionManager._is_protected_project_json(target_nfc, [base_nfd])
+
+    # 归一化不引入 over-match：其他项目路径不受影响
+    other = Path("/data/projects/cafe_other/project.json")
+    assert not SessionManager._is_protected_project_json(other, [base_nfc])
+
+
+def test_normalize_path_for_protected_compare_strips_windows_extended_prefix() -> None:
+    """Windows ``\\\\?\\`` 扩展长度前缀（resolve 在长路径/UNC 下返回）与常规形态
+    须归一化为同一比较键，否则 bases 混入两种形式时 startswith 失配。
+    helper 级单测；实机 Windows 端到端验证另行跟踪。"""
+    norm = SessionManager._normalize_path_for_protected_compare
+    assert norm("\\\\?\\C:\\data\\projects\\demo") == norm("C:\\data\\projects\\demo")
+    assert norm("\\\\?\\UNC\\server\\share\\proj") == norm("\\\\server\\share\\proj")
+    # 常规路径不受影响
+    assert norm("/data/projects/demo") == norm("/data/projects/demo")
+
+
 def test_write_drafts_and_source_still_allowed(sm: SessionManager) -> None:
     """合法的草稿/源文件写入不受影响（drafts/*.md、source/*.txt、scripts 外的 .json）。"""
     cwd = sm.project_root / "projects" / "selfproj"
@@ -179,6 +212,30 @@ def test_build_sandbox_settings_denies_write_to_project_json(sm: SessionManager)
     deny_write = settings["filesystem"]["denyWrite"]
     assert str(cwd / "scripts") in deny_write
     assert str(cwd / "project.json") in deny_write
+
+
+def test_build_sandbox_settings_deny_write_includes_resolved_paths(sm: SessionManager, tmp_path: Path) -> None:
+    """project_cwd 是 symlink 入口时（macOS /var↔/private/var、Linux symlinked
+    项目根），denyWrite 须同时枚举 raw 与 resolved 两种形式——sandbox 实现若按
+    字符串路径比对，仅注册 raw 形式会在 Bash 子进程经 symlink 解析后写 resolved
+    路径时失配。与 _check_write_access 的 bases 同口径。"""
+    real_root = tmp_path / "real_data"
+    (real_root / "projects" / "selfproj").mkdir(parents=True)
+    link_cwd = sm.project_root / "projects" / "selfproj_link"
+    link_cwd.symlink_to(real_root / "projects" / "selfproj")
+
+    sm._sandbox_enabled = True
+    settings = sm._build_sandbox_settings(link_cwd)
+    deny_write = settings["filesystem"]["denyWrite"]
+    resolved_cwd = link_cwd.resolve()
+    assert resolved_cwd != link_cwd
+    # raw 与 resolved 两种形式都注册
+    assert str(link_cwd / "scripts") in deny_write
+    assert str(link_cwd / "project.json") in deny_write
+    assert str(resolved_cwd / "scripts") in deny_write
+    assert str(resolved_cwd / "project.json") in deny_write
+    # raw == resolved 的常规路径不重复注册
+    assert len(deny_write) == len(set(deny_write))
 
 
 @pytest.mark.parametrize(

--- a/tests/agent_runtime/test_session_manager_sandbox.py
+++ b/tests/agent_runtime/test_session_manager_sandbox.py
@@ -448,6 +448,17 @@ async def test_windows_bash_whitelist_matches_main_behavior(tmp_path: Path, comm
         "python .claude/skills/../../../tmp/evil.py",
         "python .claude/skills/../../arcreel_secrets_dumper.py",
         "ffmpeg -i ../../other_project/secret.mp4 out.mp4",
+        # 路径穿越混淆绕过：shell 会把 ".." / .\. 还原成 ..，归一化后必须拒
+        'python .claude/skills/dir/".."/".."/evil.py',
+        "python .claude/skills/dir/'..'/'..'/evil.py",
+        "python .claude/skills/dir/.\\./.\\./evil.py",
+        'ffmpeg -i ".."/".."/secret.mp4 out.mp4',
+        # python 入口必须是 <skill>/scripts/<script>.py：skills 目录下任意其它
+        # 文件（无 scripts/ 段、非 .py、或直接挂在 skill 根）一律不放行
+        "python .claude/skills/evil.py",
+        "python .claude/skills/compose-video/compose_video.py scripts/ep.json",
+        "python .claude/skills/compose-video/scripts/data.json",
+        "python .claude/skills/compose-video/scripts/sub/run.py",
     ],
 )
 async def test_windows_bash_whitelist_blocks_metachar_chains(tmp_path: Path, command: str) -> None:

--- a/tests/agent_runtime/test_session_manager_sandbox.py
+++ b/tests/agent_runtime/test_session_manager_sandbox.py
@@ -409,6 +409,15 @@ async def test_build_options_bash_in_allowed_tools_by_sandbox(
         ("ffprobe in.mp4", "PermissionResultAllow"),
         # `..` 在文件名内部（非路径段）不触发穿越拦截，合法命令照常放行
         ("ffmpeg -i my..clip.mp4 out.mp4", "PermissionResultAllow"),
+        # 归一化容错：带引号的脚本路径、Windows 反斜杠分隔符的合法命令不误拒
+        (
+            'python ".claude/skills/compose-video/scripts/compose_video.py" scripts/ep.json',
+            "PermissionResultAllow",
+        ),
+        (
+            "python .claude\\skills\\compose-video\\scripts\\compose_video.py scripts/ep.json",
+            "PermissionResultAllow",
+        ),
         ("cat /etc/passwd", "PermissionResultDeny"),
         ("ls -la", "PermissionResultDeny"),
     ],
@@ -453,6 +462,8 @@ async def test_windows_bash_whitelist_matches_main_behavior(tmp_path: Path, comm
         "python .claude/skills/dir/'..'/'..'/evil.py",
         "python .claude/skills/dir/.\\./.\\./evil.py",
         'ffmpeg -i ".."/".."/secret.mp4 out.mp4',
+        # Windows 反斜杠分隔符下的 .. 穿越同样要拒（归一化后 ../ 命中）
+        "python .claude\\skills\\..\\..\\evil.py",
         # python 入口必须是 <skill>/scripts/<script>.py：skills 目录下任意其它
         # 文件（无 scripts/ 段、非 .py、或直接挂在 skill 根）一律不放行
         "python .claude/skills/evil.py",

--- a/tests/agent_runtime/test_session_manager_sandbox.py
+++ b/tests/agent_runtime/test_session_manager_sandbox.py
@@ -269,11 +269,13 @@ def test_build_sensitive_abs_paths_honors_env_overrides(tmp_path: Path, monkeypa
 
 
 @pytest.mark.asyncio
-async def test_bash_env_scrub_hook_wraps_command_with_env_unset() -> None:
-    """Bash PreToolUse hook 把 command 包装成 ``env -u ANTHROPIC_* sh -c '<orig>'``。"""
+async def test_bash_env_scrub_hook_wraps_command_with_env_unset(session_manager: SessionManager) -> None:
+    """POSIX（sandbox 启用）：command 包装成 ``env -u ANTHROPIC_* sh -c '<orig>'``，
+    且不返回 permissionDecision——PreToolUse hook 是权限链第 1 步，allow 会短路
+    后续所有步骤；包装后的命令应由 allowed_tools 的 Bash allow 规则放行。"""
     from lib.config.env_keys import ANTHROPIC_ENV_KEYS
 
-    result = await SessionManager._bash_env_scrub_hook(
+    result = await session_manager._bash_env_scrub_hook(
         {"tool_name": "Bash", "tool_input": {"command": "env | grep ANTHROPIC"}},
         None,
         None,
@@ -282,8 +284,8 @@ async def test_bash_env_scrub_hook_wraps_command_with_env_unset() -> None:
     out = result.get("hookSpecificOutput")
     assert out is not None
     assert out["hookEventName"] == "PreToolUse"
-    # updatedInput 必须配 permissionDecision=allow，否则修改后命令仍会触发权限询问（SDK hooks.md）
-    assert out["permissionDecision"] == "allow"
+    # 不携带权限决策，让权限链继续走到 allow 规则 / can_use_tool
+    assert "permissionDecision" not in out
     new_cmd = out["updatedInput"]["command"]
     # 每个 ANTHROPIC_* key 都被 unset
     for key in ANTHROPIC_ENV_KEYS:
@@ -294,9 +296,23 @@ async def test_bash_env_scrub_hook_wraps_command_with_env_unset() -> None:
 
 
 @pytest.mark.asyncio
-async def test_bash_env_scrub_hook_handles_single_quotes() -> None:
+async def test_bash_env_scrub_hook_skips_wrap_when_sandbox_disabled(tmp_path: Path) -> None:
+    """Windows 回退：``env -u``/``sh -c`` 是 POSIX 机制，原生 Windows 不可执行；
+    hook 不包装也不给权限决策，原始命令落到 _can_use_tool 做白名单匹配
+    （包装后命令以 ``env -u`` 开头，会让白名单永远匹配不上）。"""
+    sm = _make_session_manager(tmp_path, sandbox_enabled=False)
+    result = await sm._bash_env_scrub_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "ffmpeg -i in.mp4 out.mp4"}},
+        None,
+        None,
+    )
+    assert result == {"continue_": True}
+
+
+@pytest.mark.asyncio
+async def test_bash_env_scrub_hook_handles_single_quotes(session_manager: SessionManager) -> None:
     """命令含单引号时不能破坏 shell 引号闭合。"""
-    result = await SessionManager._bash_env_scrub_hook(
+    result = await session_manager._bash_env_scrub_hook(
         {"tool_name": "Bash", "tool_input": {"command": "echo 'hello world'"}},
         None,
         None,
@@ -307,9 +323,9 @@ async def test_bash_env_scrub_hook_handles_single_quotes() -> None:
 
 
 @pytest.mark.asyncio
-async def test_bash_env_scrub_hook_passthrough_when_no_command() -> None:
+async def test_bash_env_scrub_hook_passthrough_when_no_command(session_manager: SessionManager) -> None:
     """空 command 时直接放行，不做包装。"""
-    result = await SessionManager._bash_env_scrub_hook(
+    result = await session_manager._bash_env_scrub_hook(
         {"tool_name": "Bash", "tool_input": {}},
         None,
         None,
@@ -391,6 +407,8 @@ async def test_build_options_bash_in_allowed_tools_by_sandbox(
         ),
         ("ffmpeg -i in.mp4 out.mp4", "PermissionResultAllow"),
         ("ffprobe in.mp4", "PermissionResultAllow"),
+        # `..` 在文件名内部（非路径段）不触发穿越拦截，合法命令照常放行
+        ("ffmpeg -i my..clip.mp4 out.mp4", "PermissionResultAllow"),
         ("cat /etc/passwd", "PermissionResultDeny"),
         ("ls -la", "PermissionResultDeny"),
     ],
@@ -406,6 +424,40 @@ async def test_windows_bash_whitelist_matches_main_behavior(tmp_path: Path, comm
         # deny 文案必须包含所有白名单 prefix（单一真相源）
         for prefix in SessionManager._WINDOWS_BASH_PREFIX_WHITELIST:
             assert prefix in result.message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command",
+    [
+        # 白名单前缀 + metachar 链：尾部命令在 Windows 上无 sandbox denyWrite
+        # 兜底，可直写 protected JSON，必须整串拒
+        'python .claude/skills/manage-project/scripts/peek_split_point.py; python -c "evil"',
+        "ffmpeg -i in.mp4 out.mp4 && python -c \"open('project.json','w')\"",
+        "ffprobe in.mp4 | tee scripts/episode_1.json",
+        "ffmpeg -i in.mp4 $(evil) out.mp4",
+        "ffmpeg -i in.mp4 `evil` out.mp4",
+        "ffmpeg -i in.mp4 -f json > scripts/episode_1.json",
+        "ffprobe < secret.txt",
+        "ffmpeg -i in.mp4 out.mp4\npython -c evil",
+        # 命令名前缀碰撞：ffmpegX 以 ffmpeg 开头但不是 ffmpeg
+        "ffmpegX --evil",
+        "ffprobe2 in.mp4",
+        # 路径穿越：满足 python .claude/skills/ 前缀且不含 metachar，但 .. 逃出
+        # skills 目录跑任意脚本——Windows 回退无 sandbox 兜底，必须拒
+        "python .claude/skills/../../../tmp/evil.py",
+        "python .claude/skills/../../arcreel_secrets_dumper.py",
+        "ffmpeg -i ../../other_project/secret.mp4 out.mp4",
+    ],
+)
+async def test_windows_bash_whitelist_blocks_metachar_chains(tmp_path: Path, command: str) -> None:
+    """白名单前缀 + shell metachar（; && | $() ` 重定向 换行）的复合命令必须拒；
+    命令名按 token 边界匹配，挡 ffmpegX 这类前缀碰撞；.. 路径穿越整串拒。"""
+    sm = _make_session_manager(tmp_path, sandbox_enabled=False)
+    callback = await sm._build_can_use_tool_callback("test_sid", [None])
+    result = await callback("Bash", {"command": command}, None)
+    assert type(result).__name__ == "PermissionResultDeny"
+    assert "Bash 白名单" in result.message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

智能体在原生 Windows（无 bwrap/Seatbelt 沙箱）下回退到代码白名单放行 Bash。本次收紧这条回退防线，并对齐跨平台路径围栏的一致性。

## 改动

- **Windows 回退白名单真正参与决策**：此前 `PreToolUse` scrub hook 无条件下 `allow`，短路了整条权限链——白名单形同虚设，任意 Bash 命令被放行。现 hook 只改写命令、不下权限决策，放行交回权限链；沙箱不可用时跳过 POSIX `env -u … sh -c` 包装（原生 Windows 不可执行），原始命令落到白名单裁决。
- **白名单从纯前缀升级为 token 边界匹配 + metachar 拦截**：拒绝 `;` `&` `|` `<` `>` `` ` `` `$` 与换行的复合命令（挡链式/管道/重定向/命令替换），命令名按 token 边界匹配（挡 `ffmpegX` 这类前缀碰撞），并拒绝 `..` 路径穿越（挡 `python .claude/skills/../../evil.py` 逃出 skills 目录跑任意脚本）。
- **denyWrite 路径基与 hook 层对齐**：sandbox `denyWrite` 与 `_check_write_access` 共用 `_enumerate_cwd_bases`，同时枚举 raw + resolved 形式，消除 symlink 入口（macOS `/var↔/private/var`、Linux symlinked 项目根）下的路径失配旁路。
- **受保护路径比对归一化**：NFC + `normcase` + `casefold` + 剥 `\\?\` 扩展长度前缀，覆盖大小写、Unicode 归一化形式与 Windows 长路径/UNC 三类形态漂移。
- ADR 0027 同步现状（hook 只改写不决策、Windows 回退由白名单裁决）。

## 验证

- 全量后端测试 4470 passed；ruff / basedpyright（0 error）通过。
- 新增单测：sandbox 不可用时白名单外命令被拒、metachar 复合命令被拒、`..` 路径穿越被拒、`..` 在文件名内部不误伤、POSIX 路径包装不回归且不再下 `permissionDecision`、denyWrite 含 resolved 路径、NFC/NFD 与大小写混合受保护路径命中。
- 实机 Windows 端到端验证以单测模拟为准，另行跟踪（见 issue Out of scope）。

Closes #622


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 强化 Windows 回退的 Bash 白名单与沙箱写入保护：严格匹配命令边界、拦截 shell 元字符、链式/重定向/替换/换行和路径穿越，限制 Python 脚本入口并统一路径归一化与比较以避免绕过。

* **Documentation**
  * 更新架构决策文档，明确跨平台执行规则、责任划分与拒绝/排障说明。

* **Tests**
  * 新增并扩展多项沙箱与路径隔离测试覆盖上述行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->