### PR TITLE
fix(providers): 并发上限配置填错保存时即时报错，单个坏值不再静默冻结全部供应商容量更新

### DIFF
--- a/frontend/src/components/pages/ProviderDetail.tsx
+++ b/frontend/src/components/pages/ProviderDetail.tsx
@@ -258,6 +258,12 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
     onSaved?.();
   }, [providerId, onSaved]);
 
+  // 用户编辑草稿时同步清掉上一次保存失败的错误，避免旧文案滞留误导
+  const handleDraftEdit = useCallback<React.Dispatch<React.SetStateAction<Record<string, string>>>>((action) => {
+    setSaveError(null);
+    setDraft(action);
+  }, []);
+
   useEffect(() => {
     let disposed = false;
     // providerId 变化时重置草稿/详情/错误后再异步拉取，属于动作驱动重置
@@ -393,7 +399,7 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
           {showAdvanced && (
             <div className="mt-3 space-y-4">
               {detail.fields.map((field) => (
-                <FieldEditor key={field.key} field={field} draft={draft} setDraft={setDraft} />
+                <FieldEditor key={field.key} field={field} draft={draft} setDraft={handleDraftEdit} />
               ))}
               {hasDraft && (
                 <div className="pt-1">

--- a/frontend/src/components/pages/ProviderDetail.tsx
+++ b/frontend/src/components/pages/ProviderDetail.tsx
@@ -246,6 +246,7 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
   const [saving, setSaving] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
 
   const hasDraft = Object.keys(draft).length > 0;
@@ -264,6 +265,7 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
     setDraft({});
     setDetail(null);
     setLoadError(null);
+    setSaveError(null);
     voidCall(
       API.getProviderConfig(providerId)
         .then((res) => {
@@ -281,6 +283,7 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
   const handleSave = useCallback(async () => {
     if (Object.keys(draft).length === 0) return;
     setSaving(true);
+    setSaveError(null);
     try {
       const patch: Record<string, string | null> = {};
       for (const [key, value] of Object.entries(draft)) {
@@ -291,6 +294,9 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
       setDetail(updated);
       setDraft({});
       onSaved?.();
+    } catch (err) {
+      // 后端校验失败（如 Max Workers 非法值）返回已本地化的 detail，直接展示
+      setSaveError(errMsg(err));
     } finally {
       setSaving(false);
     }
@@ -391,6 +397,19 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
               ))}
               {hasDraft && (
                 <div className="pt-1">
+                  {saveError && (
+                    <p
+                      aria-live="polite"
+                      className="mb-2 rounded-[6px] px-2.5 py-1.5 text-[11.5px]"
+                      style={{
+                        background: "var(--color-warm-tint)",
+                        color: "var(--color-warm-bright)",
+                        border: "1px solid var(--color-warm-ring)",
+                      }}
+                    >
+                      {saveError}
+                    </p>
+                  )}
                   <button
                     type="button"
                     onClick={() => void handleSave()}

--- a/lib/config/service.py
+++ b/lib/config/service.py
@@ -29,16 +29,23 @@ _DEFAULT_REFERENCE_SINGLE_MAX_BYTES = 4 * 1024 * 1024
 # 写入层校验为非负整数的容量键（与 CapacityTable 的三条 lane 一一对应）。
 # 其余 number 字段（image_rpm / video_rpm / request_gap）语义不同（允许小数），不在此列。
 _MAX_WORKERS_KEYS = frozenset({"image_max_workers", "video_max_workers", "audio_max_workers"})
+_MAX_WORKERS_CODE = "max_workers_must_be_nonnegative_integer"
 
 
 class ProviderConfigValueError(ValueError):
-    """provider 配置值校验失败；携带 key/value，由 router 层渲染 user-facing 文案。"""
+    """provider 配置值校验失败。
 
-    def __init__(self, provider: str, key: str, value: str) -> None:
-        super().__init__(f"invalid value for {provider}.{key}: {value!r} (expected a non-negative integer)")
+    携带 i18n message code + 渲染参数（key 而非译文），router 层 ``_t(exc.code, **exc.params)``
+    泛化翻译为 user-facing 文案，无需感知具体校验规则。
+    """
+
+    def __init__(self, provider: str, key: str, value: str, *, code: str) -> None:
+        super().__init__(f"invalid value for {provider}.{key}: {value!r} ({code})")
         self.provider = provider
         self.key = key
         self.value = value
+        self.code = code
+        self.params: dict[str, str] = {"field": key, "value": value}
 
 
 # DB setting key → environment variable name
@@ -123,6 +130,10 @@ class ConfigService:
     ) -> None:
         self._validate_provider(provider)
         self._validate_value(provider, key, value)
+        if key in _MAX_WORKERS_KEYS:
+            # 入库统一规范化为 ASCII 数字串（int() 接受 " 5 " / "+5" / "1_0" / 全角数字等
+            # 非规范形态），保证任何读取方拿到的都是可直接解析、可在 number 输入框回显的值
+            value = str(int(value))
         meta = PROVIDER_REGISTRY[provider]
         is_secret = key in meta.secret_keys
         await self._provider_repo.set(provider, key, value, is_secret=is_secret, flush=flush)
@@ -260,9 +271,9 @@ class ConfigService:
         try:
             parsed = int(value)
         except ValueError:
-            raise ProviderConfigValueError(provider, key, value) from None
+            raise ProviderConfigValueError(provider, key, value, code=_MAX_WORKERS_CODE) from None
         if parsed < 0:
-            raise ProviderConfigValueError(provider, key, value)
+            raise ProviderConfigValueError(provider, key, value, code=_MAX_WORKERS_CODE)
 
     @staticmethod
     def _parse_backend(raw: str, fallback: str) -> tuple[str, str]:

--- a/lib/config/service.py
+++ b/lib/config/service.py
@@ -26,6 +26,21 @@ _DEFAULT_NARRATION_VOICE = "Cherry"
 _DEFAULT_REFERENCE_TOTAL_MAX_BYTES = 8 * 1024 * 1024
 _DEFAULT_REFERENCE_SINGLE_MAX_BYTES = 4 * 1024 * 1024
 
+# 写入层校验为非负整数的容量键（与 CapacityTable 的三条 lane 一一对应）。
+# 其余 number 字段（image_rpm / video_rpm / request_gap）语义不同（允许小数），不在此列。
+_MAX_WORKERS_KEYS = frozenset({"image_max_workers", "video_max_workers", "audio_max_workers"})
+
+
+class ProviderConfigValueError(ValueError):
+    """provider 配置值校验失败；携带 key/value，由 router 层渲染 user-facing 文案。"""
+
+    def __init__(self, provider: str, key: str, value: str) -> None:
+        super().__init__(f"invalid value for {provider}.{key}: {value!r} (expected a non-negative integer)")
+        self.provider = provider
+        self.key = key
+        self.value = value
+
+
 # DB setting key → environment variable name
 _ANTHROPIC_ENV_MAP: dict[str, str] = {
     "anthropic_api_key": "ANTHROPIC_API_KEY",
@@ -107,6 +122,7 @@ class ConfigService:
         flush: bool = True,
     ) -> None:
         self._validate_provider(provider)
+        self._validate_value(provider, key, value)
         meta = PROVIDER_REGISTRY[provider]
         is_secret = key in meta.secret_keys
         await self._provider_repo.set(provider, key, value, is_secret=is_secret, flush=flush)
@@ -231,6 +247,22 @@ class ConfigService:
     def _validate_provider(provider: str) -> None:
         if provider not in PROVIDER_REGISTRY:
             raise ValueError(f"Unknown provider: {provider}")
+
+    @staticmethod
+    def _validate_value(provider: str, key: str, value: str) -> None:
+        """容量键写入校验：非负整数（0 合法，语义=该 lane 容量为 0 即 fail-fast）。
+
+        坏值一旦入库，容量 reload 只能逐 key 回退默认值，配置变更静默失效，
+        因此在写入口拦下。
+        """
+        if key not in _MAX_WORKERS_KEYS:
+            return
+        try:
+            parsed = int(value)
+        except ValueError:
+            raise ProviderConfigValueError(provider, key, value) from None
+        if parsed < 0:
+            raise ProviderConfigValueError(provider, key, value)
 
     @staticmethod
     def _parse_backend(raw: str, fallback: str) -> tuple[str, str]:

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -67,16 +67,19 @@ def _parse_lane_max(config: dict[str, str], key: str, default: int, provider_id:
     """逐 key 容错解析单条 lane 的并发上限。
 
     解析失败回退默认值并告警，不让单个坏值（写入校验上线前的存量脏数据）拖垮
-    整表加载；可解析的负数沿用 clamp 语义（→0，即该 lane fail-fast）。
+    整表加载；可解析的负数沿用 clamp 语义（→0，即该 lane fail-fast）并告警。
     """
     raw = config.get(key)
     if raw is None:
         return default
     try:
-        return max(0, int(raw))
+        parsed = int(raw)
     except ValueError:
         logger.warning("供应商 %s 的 %s 配置值非法（%r），回退默认值 %d", provider_id, key, raw, default)
         return default
+    if parsed < 0:
+        logger.warning("供应商 %s 的 %s 配置值为负（%r），按 0 处理（该 lane 关闭）", provider_id, key, raw)
+    return max(0, parsed)
 
 
 @dataclass

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -63,6 +63,22 @@ def _read_int_env(name: str, default: int, minimum: int = 1) -> int:
     return max(minimum, value)
 
 
+def _parse_lane_max(config: dict[str, str], key: str, default: int, provider_id: str) -> int:
+    """逐 key 容错解析单条 lane 的并发上限。
+
+    解析失败回退默认值并告警，不让单个坏值（写入校验上线前的存量脏数据）拖垮
+    整表加载；可解析的负数沿用 clamp 语义（→0，即该 lane fail-fast）。
+    """
+    raw = config.get(key)
+    if raw is None:
+        return default
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning("供应商 %s 的 %s 配置值非法（%r），回退默认值 %d", provider_id, key, raw, default)
+        return default
+
+
 @dataclass
 class CapacityTable:
     """Per-provider concurrency limits keyed by ``provider_id × media_type``.
@@ -135,9 +151,9 @@ class CapacityTable:
             all_configs = await svc.get_all_provider_configs()
             for provider_id, meta in PROVIDER_REGISTRY.items():
                 config = all_configs.get(provider_id, {})
-                image_max = max(0, int(config.get("image_max_workers", str(default_image))))
-                video_max = max(0, int(config.get("video_max_workers", str(default_video))))
-                audio_max = max(0, int(config.get("audio_max_workers", str(default_audio))))
+                image_max = _parse_lane_max(config, "image_max_workers", default_image, provider_id)
+                video_max = _parse_lane_max(config, "video_max_workers", default_video, provider_id)
+                audio_max = _parse_lane_max(config, "audio_max_workers", default_audio, provider_id)
                 # _lane_limits 统一负责"不支持的 lane → 0"，三个装载路径共用同一投影点
                 limits[provider_id] = cls._lane_limits(meta.media_types, image_max, video_max, audio_max)
 

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -77,6 +77,7 @@ MESSAGES = {
     "source_conflict": "Source file '{existing}' already exists; suggested rename: '{suggested}'",
     # Providers
     "unknown_provider": "Unknown provider: {provider_id}",
+    "max_workers_must_be_nonnegative_integer": "{field} must be a non-negative integer, got: {value}",
     "credentials_not_found": "Credentials not found",
     "vertex_json_read_failed": "Failed to read the uploaded file",
     "vertex_json_too_large": "Credentials file is too large",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -77,6 +77,7 @@ MESSAGES = {
     "source_conflict": "Tệp nguồn '{existing}' đã tồn tại; gợi ý đổi tên: '{suggested}'",
     # Providers
     "unknown_provider": "Nhà cung cấp không xác định: {provider_id}",
+    "max_workers_must_be_nonnegative_integer": "{field} phải là số nguyên không âm, đã nhận: {value}",
     "credentials_not_found": "Không tìm thấy thông tin xác thực",
     "vertex_json_read_failed": "Không đọc được tệp đã tải lên",
     "vertex_json_too_large": "Tệp thông tin xác thực quá lớn",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -77,6 +77,7 @@ MESSAGES = {
     "source_conflict": "源文件「{existing}」已存在，建议改名为「{suggested}」",
     # Providers
     "unknown_provider": "未知供应商: {provider_id}",
+    "max_workers_must_be_nonnegative_integer": "{field} 必须是非负整数，收到：{value}",
     "credentials_not_found": "凭证不存在",
     "vertex_json_read_failed": "读取上传文件失败",
     "vertex_json_too_large": "凭证文件过大",

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -313,10 +313,7 @@ async def patch_provider_config(
             try:
                 await svc.set_provider_config(provider_id, key, value, flush=False)
             except ProviderConfigValueError as exc:
-                raise HTTPException(
-                    status_code=422,
-                    detail=_t("max_workers_must_be_nonnegative_integer", field=exc.key, value=exc.value),
-                ) from exc
+                raise HTTPException(status_code=422, detail=_t(exc.code, **exc.params)) from exc
 
     await session.commit()
 

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -22,7 +22,7 @@ from starlette.responses import Response
 from lib.app_data_dir import app_data_dir
 from lib.config.registry import PROVIDER_REGISTRY
 from lib.config.repository import mask_secret
-from lib.config.service import ConfigService
+from lib.config.service import ConfigService, ProviderConfigValueError
 from lib.config.url_utils import normalize_base_url
 from lib.db import get_async_session
 from lib.db.base import dt_to_iso
@@ -56,6 +56,7 @@ _FIELD_META: dict[str, dict[str, str]] = {
     "request_gap": {"label": "Request Gap (sec)", "type": "number"},
     "image_max_workers": {"label": "Image Max Workers", "type": "number"},
     "video_max_workers": {"label": "Video Max Workers", "type": "number"},
+    "audio_max_workers": {"label": "Audio Max Workers", "type": "number"},
 }
 
 
@@ -309,7 +310,13 @@ async def patch_provider_config(
         if value is None:
             await svc.delete_provider_config(provider_id, key, flush=False)
         else:
-            await svc.set_provider_config(provider_id, key, value, flush=False)
+            try:
+                await svc.set_provider_config(provider_id, key, value, flush=False)
+            except ProviderConfigValueError as exc:
+                raise HTTPException(
+                    status_code=422,
+                    detail=_t("max_workers_must_be_nonnegative_integer", field=exc.key, value=exc.value),
+                ) from exc
 
     await session.commit()
 

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -313,7 +313,12 @@ async def patch_provider_config(
             try:
                 await svc.set_provider_config(provider_id, key, value, flush=False)
             except ProviderConfigValueError as exc:
-                raise HTTPException(status_code=422, detail=_t(exc.code, **exc.params)) from exc
+                # 错误文案中的字段名换成 UI 同款 label（如 Image Max Workers），与表单展示一致
+                params = dict(exc.params)
+                meta = _FIELD_META.get(exc.key)
+                if meta is not None:
+                    params["field"] = meta["label"]
+                raise HTTPException(status_code=422, detail=_t(exc.code, **params)) from exc
 
     await session.commit()
 

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -100,6 +100,9 @@ async def test_set_max_workers_rejects_invalid_values(config_service: ConfigServ
         await config_service.set_provider_config("dashscope", key, value)
     assert exc_info.value.key == key
     assert exc_info.value.value == value
+    # router 依赖 code/params 泛化渲染 i18n 文案，契约在此 pin 住
+    assert exc_info.value.code == "max_workers_must_be_nonnegative_integer"
+    assert exc_info.value.params == {"field": key, "value": value}
 
 
 @pytest.mark.parametrize("value", ["0", "5"])
@@ -107,6 +110,14 @@ async def test_set_max_workers_accepts_nonnegative_integers(config_service: Conf
     await config_service.set_provider_config("ark", "image_max_workers", value)
     config = await config_service.get_provider_config("ark")
     assert config["image_max_workers"] == value
+
+
+@pytest.mark.parametrize(("raw", "canonical"), [(" 5 ", "5"), ("+5", "5"), ("1_0", "10")])
+async def test_set_max_workers_canonicalizes_on_write(config_service: ConfigService, raw: str, canonical: str):
+    # int() 接受的非规范形态统一规范化入库，读取方与 number 输入框拿到的都是纯数字串
+    await config_service.set_provider_config("ark", "video_max_workers", raw)
+    config = await config_service.get_provider_config("ark")
+    assert config["video_max_workers"] == canonical
 
 
 async def test_set_other_number_keys_not_restricted_to_integers(config_service: ConfigService):

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -89,3 +89,28 @@ async def test_get_default_backend_fallback(config_service: ConfigService):
 async def test_unknown_provider_raises(config_service: ConfigService):
     with pytest.raises(ValueError, match="Unknown provider"):
         await config_service.set_provider_config("unknown-provider", "key", "val")
+
+
+@pytest.mark.parametrize("key", ["image_max_workers", "video_max_workers", "audio_max_workers"])
+@pytest.mark.parametrize("value", ["", "3.7", "abc", "-1"])
+async def test_set_max_workers_rejects_invalid_values(config_service: ConfigService, key: str, value: str):
+    from lib.config.service import ProviderConfigValueError
+
+    with pytest.raises(ProviderConfigValueError) as exc_info:
+        await config_service.set_provider_config("dashscope", key, value)
+    assert exc_info.value.key == key
+    assert exc_info.value.value == value
+
+
+@pytest.mark.parametrize("value", ["0", "5"])
+async def test_set_max_workers_accepts_nonnegative_integers(config_service: ConfigService, value: str):
+    await config_service.set_provider_config("ark", "image_max_workers", value)
+    config = await config_service.get_provider_config("ark")
+    assert config["image_max_workers"] == value
+
+
+async def test_set_other_number_keys_not_restricted_to_integers(config_service: ConfigService):
+    # request_gap / *_rpm 语义允许小数，不受容量键的非负整数校验约束
+    await config_service.set_provider_config("gemini-aistudio", "request_gap", "0.5")
+    config = await config_service.get_provider_config("gemini-aistudio")
+    assert config["request_gap"] == "0.5"

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -299,12 +299,17 @@ class TestCapacityTable:
         assert table.get("ark", "video") == 2
         assert table.get("gemini-aistudio", "image") == 7
 
-    async def test_from_db_negative_value_clamps_to_zero(self, monkeypatch):
-        """可解析的负数沿用 clamp 语义（→0），不视为脏值回退默认。"""
+    async def test_from_db_negative_value_clamps_to_zero(self, monkeypatch, caplog):
+        """可解析的负数沿用 clamp 语义（→0），不视为脏值回退默认，但留告警可观测。"""
+        import logging
+
         self._stub_from_db_sources(monkeypatch, {"ark": {"video_max_workers": "-1"}})
 
-        table = await CapacityTable.from_db()
+        with caplog.at_level(logging.WARNING, logger="lib.generation_worker"):
+            table = await CapacityTable.from_db()
+
         assert table.get("ark", "video") == 0
+        assert "video_max_workers" in caplog.text
 
 
 class TestGenerationWorker:

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -251,6 +251,61 @@ class TestCapacityTable:
             if "video" not in meta.media_types:
                 assert table.get(pid, "video") == 0
 
+    @staticmethod
+    def _stub_from_db_sources(monkeypatch, configs: dict[str, dict[str, str]]) -> None:
+        """把 from_db 的两个数据源（provider config / 自定义供应商）替换为内存数据。"""
+        from unittest.mock import AsyncMock, MagicMock
+
+        for env in ("IMAGE_MAX_WORKERS", "VIDEO_MAX_WORKERS", "AUDIO_MAX_WORKERS"):
+            monkeypatch.delenv(env, raising=False)
+
+        class _FakeSessionCtx:
+            async def __aenter__(self):
+                return MagicMock()
+
+            async def __aexit__(self, *exc_info):
+                return False
+
+        monkeypatch.setattr("lib.db.safe_session_factory", lambda: _FakeSessionCtx())
+        monkeypatch.setattr(
+            "lib.config.service.ConfigService.get_all_provider_configs",
+            AsyncMock(return_value=configs),
+        )
+        monkeypatch.setattr(
+            "lib.db.repositories.custom_provider_repo.CustomProviderRepository.list_providers_with_models",
+            AsyncMock(return_value=[]),
+        )
+
+    @pytest.mark.parametrize("dirty", ["", "3.7", "abc"])
+    async def test_from_db_dirty_value_falls_back_per_key(self, monkeypatch, caplog, dirty):
+        """单个 key 的存量脏值只回退该 key 默认值并告警，不拖垮整表加载。"""
+        import logging
+
+        self._stub_from_db_sources(
+            monkeypatch,
+            {
+                "ark": {"image_max_workers": dirty, "video_max_workers": "2"},
+                "gemini-aistudio": {"image_max_workers": "7"},
+            },
+        )
+
+        with caplog.at_level(logging.WARNING, logger="lib.generation_worker"):
+            table = await CapacityTable.from_db()
+
+        # 脏 key 回退 env 默认值（image=5）并告警
+        assert table.get("ark", "image") == 5
+        assert "image_max_workers" in caplog.text
+        # 同 provider 其余合法 key、其他 provider 的配置正常生效
+        assert table.get("ark", "video") == 2
+        assert table.get("gemini-aistudio", "image") == 7
+
+    async def test_from_db_negative_value_clamps_to_zero(self, monkeypatch):
+        """可解析的负数沿用 clamp 语义（→0），不视为脏值回退默认。"""
+        self._stub_from_db_sources(monkeypatch, {"ark": {"video_max_workers": "-1"}})
+
+        table = await CapacityTable.from_db()
+        assert table.get("ark", "video") == 0
+
 
 class TestGenerationWorker:
     @pytest.mark.asyncio

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -444,20 +444,31 @@ class TestPatchProviderConfigMaxWorkersValidation:
 
     @staticmethod
     def _make_db_app(locale: str = "zh") -> FastAPI:
+        from contextlib import asynccontextmanager
+
         from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
         from lib.db.base import Base
 
-        app = FastAPI()
+        # engine 由 lifespan 持有：TestClient 上下文退出时必然 dispose——若放在
+        # session 依赖的 yield 之后，路由抛 HTTPException 时会被跳过而泄漏 engine
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        sm = async_sessionmaker(engine, expire_on_commit=False)
 
-        async def _override_session():
-            engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        @asynccontextmanager
+        async def _lifespan(_app: FastAPI):
             async with engine.begin() as conn:
                 await conn.run_sync(Base.metadata.create_all)
-            sm = async_sessionmaker(engine, expire_on_commit=False)
+            try:
+                yield
+            finally:
+                await engine.dispose()
+
+        app = FastAPI(lifespan=_lifespan)
+
+        async def _override_session():
             async with sm() as s:
                 yield s
-            await engine.dispose()
 
         app.dependency_overrides[get_async_session] = _override_session
         app.dependency_overrides[get_translator] = lambda: make_translator(locale)

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -482,9 +482,9 @@ class TestPatchProviderConfigMaxWorkersValidation:
             resp = client.patch("/api/v1/providers/dashscope/config", json={key: bad_value})
         assert resp.status_code == 422
         detail = resp.json()["detail"]
-        # 消息已经过 Translator 渲染（非裸 key id），且包含字段名便于定位
+        # 消息已经过 Translator 渲染（非裸 key id），且包含 UI 同款字段 Label 便于定位
         assert detail != "max_workers_must_be_nonnegative_integer"
-        assert key in detail
+        assert providers._FIELD_META[key]["label"] in detail
 
     @pytest.mark.parametrize("locale", ["zh", "en", "vi"])
     def test_error_message_renders_in_all_locales(self, locale: str):
@@ -493,7 +493,7 @@ class TestPatchProviderConfigMaxWorkersValidation:
         assert resp.status_code == 422
         detail = resp.json()["detail"]
         assert detail != "max_workers_must_be_nonnegative_integer"
-        assert "video_max_workers" in detail
+        assert providers._FIELD_META["video_max_workers"]["label"] in detail
         assert "abc" in detail
 
     @pytest.mark.parametrize("good_value", ["0", "5"])

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -436,6 +436,62 @@ class TestPatchProviderConfig:
         mock_svc.set_provider_config.assert_awaited_once_with("gemini-aistudio", "api_key", "AIza-test", flush=False)
 
 
+class TestPatchProviderConfigMaxWorkersValidation:
+    """容量键（*_max_workers）写入校验：非法值 422 + 可读消息，合法值正常保存。
+
+    走真实 ConfigService + 内存 DB，覆盖 router → service → repository 全链路。
+    """
+
+    @staticmethod
+    def _make_db_app(locale: str = "zh") -> FastAPI:
+        from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+        from lib.db.base import Base
+
+        app = FastAPI()
+
+        async def _override_session():
+            engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+            async with engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all)
+            sm = async_sessionmaker(engine, expire_on_commit=False)
+            async with sm() as s:
+                yield s
+            await engine.dispose()
+
+        app.dependency_overrides[get_async_session] = _override_session
+        app.dependency_overrides[get_translator] = lambda: make_translator(locale)
+        app.include_router(providers.router, prefix="/api/v1")
+        return app
+
+    @pytest.mark.parametrize("bad_value", ["", "3.7", "abc", "-1"])
+    @pytest.mark.parametrize("key", ["image_max_workers", "video_max_workers", "audio_max_workers"])
+    def test_invalid_value_returns_422(self, key: str, bad_value: str):
+        with TestClient(self._make_db_app()) as client:
+            resp = client.patch("/api/v1/providers/dashscope/config", json={key: bad_value})
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        # 消息已经过 Translator 渲染（非裸 key id），且包含字段名便于定位
+        assert detail != "max_workers_must_be_nonnegative_integer"
+        assert key in detail
+
+    @pytest.mark.parametrize("locale", ["zh", "en", "vi"])
+    def test_error_message_renders_in_all_locales(self, locale: str):
+        with TestClient(self._make_db_app(locale)) as client:
+            resp = client.patch("/api/v1/providers/dashscope/config", json={"video_max_workers": "abc"})
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert detail != "max_workers_must_be_nonnegative_integer"
+        assert "video_max_workers" in detail
+        assert "abc" in detail
+
+    @pytest.mark.parametrize("good_value", ["0", "5"])
+    def test_valid_value_returns_204(self, good_value: str):
+        with TestClient(self._make_db_app()) as client:
+            resp = client.patch("/api/v1/providers/dashscope/config", json={"audio_max_workers": good_value})
+        assert resp.status_code == 204
+
+
 # ---------------------------------------------------------------------------
 # POST /providers/{id}/test — 连接测试
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #728

## 问题

供应商配置的并发上限（Image/Video/Audio Max Workers）保存时无任何校验，空串、小数、负数等非法值可直接入库。容量表加载（`CapacityTable.from_db`）遇到任一非法值即整体放弃本次加载并保留旧表——任何一个供应商的一个坏值会让**所有**供应商的容量配置变更静默失效，仅留一条日志。

## 修复

**写入层（咽喉点）**：`ConfigService.set_provider_config` 对三个容量键校验非负整数（`0` 合法，语义为该通道容量为 0 即快速失败）；非法值返回 422，错误消息经 Translator 渲染（zh/en/vi）。校验异常携带 i18n message code + 渲染参数，路由层泛化翻译，后续新增校验规则不会误用本条文案。合法值统一规范化为纯数字串入库（`int()` 接受 `" 5 "` / `"+5"` / `"1_0"` / 全角数字等形态，原样入库会导致设置页数字输入框回显空白）。

**读取层（存量脏数据兜底）**：`from_db` 改为逐 key 容错——单个 key 解析失败时回退该键默认值并告警，不再拖垮整表加载；可解析的负值沿用钳 0 语义并补告警（通道关闭不再零观测）。

**前端**：设置页保存失败补错误展示（沿用同页凭证列表的 inline error 模式），后端本地化的校验消息可达用户；此前保存失败界面无任何提示。

**附带**：`_FIELD_META` 补 `audio_max_workers` 的 number 类型标注；新增测试 app 工厂由 lifespan 持有 engine，错误响应路径不再泄漏 engine。

已知边界（不在本 PR 范围）：遗留 JSON 迁移路径（`lib/config/migration.py`）直写 repository 不经过写入校验，其产物即「存量脏数据」，由读取层兜底覆盖。

## 验证

- 新增测试：service 层 12 种非法值组合（3 键 × 4 形态）+ 规范化入库 + `request_gap` 小数不受影响；router → service → repository 全链路 422（含 zh/en/vi 三语渲染断言）与合法值 204；`from_db` 脏值逐 key 回退（其余键与其他供应商不受影响）、负值钳 0 且告警
- 全量后端测试 4491 passed；basedpyright 0 errors；ruff 干净；前端 `pnpm lint` + `pnpm check`（typecheck + 705 vitest）全绿
- 已 rebase 至最新 main 后重验全部质量门

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  - 编辑 Provider 时，保存失败会在高级配置处显示可访问的错误提示
  - 新增 audio_max_workers 为可配置的容量字段

* **改进**
  - 对 max_workers 类字段增加非负整数校验与规范化，非法或脏值将回退或归一化，避免加载失败

* **本地化**
  - 增加错误提示的中/英/越三语支持
<!-- end of auto-generated comment: release notes by coderabbit.ai -->