### PR TITLE
docs(adr): 记录 partial migration 中间态为异常状态的已知限制

### DIFF
--- a/docs/adr/0003-agent-project-json-edits-via-tools.md
+++ b/docs/adr/0003-agent-project-json-edits-via-tools.md
@@ -41,3 +41,21 @@ PR #608 在 ADR-0002「不更坏」基础上落地了本 ADR 的工具收归,但
 - **工具职责边界**:`patch_episode_script` 的 `_set_nested` 在叶子(最后一段)不存在时**允许写入**(LLM 漏写的 optional 字段如 `video_prompt.note` agent 应能补,而非被迫走 remove+insert 重生整集),父节点(中间路径段)不存在仍 fail-loud(挡 typo);`split_segment` 保留 `parts[0]`(锚点)的 `generated_assets` 不动,与 `insert_segment` 锚点资产保留语义对齐,误用 split 当 insert 不再丢失已生成资产。
 
 横切原则:**fail-loud 改造时需先枚举二维矩阵**(读/写 × 键缺失/键脏 × validate/no-validate),逐格做决策;不能把「在结构校验层不引入新错误」的「不更坏」策略下沉到没有 before/after 概念的 helper(元数据重算、key lookup、异常处理)——那些场景的脏数据降级是 caller 的显式职责,不是 helper 的默认行为。
+
+## partial migration 中间态的已知限制(选项 C)
+
+上一条「路由按数据形状优先」只改了 `resolve_kind`(结构校验 / 编辑核心 / metadata 重算三处共用),三个**生成路径 caller** 仍按 `generation_mode` 优先判别,未随之迁移:
+
+| caller | 判别依据 | partial migration 下的表现 |
+|---|---|---|
+| `enqueue_videos.py::_is_reference_script` | `generation_mode == "reference_video"` | 走 reference 分支读空的 `video_units`,抛 `ValueError("video_units 为空")` |
+| `storyboard_sequence.py::get_storyboard_items` | `generation_mode == "reference_video"` 时早返回 `[]` | storyboard / grid / cost_estimation 看到空集,UI 报「无任务可生成」 |
+| `status_calculator.py::_select_content_mode_and_items` | `generation_mode == "reference_video"` 时取 `video_units` | progress / scene 数算成 0,前端显示「项目空了」 |
+
+于是 partial migration 中间态(项目配置已改为 `generation_mode=reference_video`,分镜数据仍留在 `segments`)下,两套判别给出不一致结果:MCP 编辑工具(按数据形状)看到 segments、可正常编辑;上述三个 caller(按 generation_mode)判空。
+
+**决策**:partial migration 中间态视为**异常状态**,不是受支持的合法形态。产品语义要求「改了 `generation_mode` 就要把分镜数据迁到对应顶层键」是一次完整、原子的迁移动作;停在半路属操作失误,系统不为该中间态提供功能可用性保证。本 issue 仅记录该取舍,**不改三个 caller 的运行时行为**。
+
+**理由**:caller 全迁到 `resolve_kind`(选项 A)会反向强制——partial migration 项目(配置 reference、数据在 segments)将永远走不到 reference 生成路径,等于用数据形状否决用户已表达的配置意图;中间态检测 + 诊断报错(选项 B)需在多个 caller 重复铺设状态检测,且只是把「判空」换成「报错」,治标。partial migration 是少数边角场景,以「文档化已知 trade-off」收口、把行为层修复留给后续重构,成本最低且不引入新运行时分支。
+
+**行为层修复的归宿**:reference_video 升格为顶层内容类型的重构(issue #618)。届时 `generation_mode=reference_video` 与 `video_units` 顶层键一一对应、配置与数据形状不再可能脱节,partial migration 中间态从根上消除,这三处判别的不一致随之消失。

--- a/docs/adr/0003-agent-project-json-edits-via-tools.md
+++ b/docs/adr/0003-agent-project-json-edits-via-tools.md
@@ -48,7 +48,7 @@ PR #608 在 ADR-0002「不更坏」基础上落地了本 ADR 的工具收归,但
 
 | caller | 判别依据 | partial migration 下的表现 |
 |---|---|---|
-| `enqueue_videos.py::_is_reference_script` | `generation_mode == "reference_video"` | 走 reference 分支读空的 `video_units`,抛 `ValueError("video_units 为空")` |
+| `enqueue_videos.py::_is_reference_script` | `generation_mode == "reference_video"` | 走 reference 分支读空的 `video_units`,抛 `ValueError(f"第 {episode} 集 video_units 为空：{script_filename}")` |
 | `storyboard_sequence.py::get_storyboard_items` | `generation_mode == "reference_video"` 时早返回 `[]` | storyboard / grid / cost_estimation 看到空集,UI 报「无任务可生成」 |
 | `status_calculator.py::_select_content_mode_and_items` | `generation_mode == "reference_video"` 时取 `video_units` | progress / scene 数算成 0,前端显示「项目空了」 |
 


### PR DESCRIPTION
## 背景

ADR-0003 上一条「路由按数据形状优先」只改了 `resolve_kind`（结构校验 / 编辑核心 / metadata 重算三处共用）。三个生成路径 caller（`enqueue_videos::_is_reference_script`、`storyboard_sequence::get_storyboard_items`、`status_calculator::_select_content_mode_and_items`）仍按 `generation_mode` 优先判别，未随之迁移。partial migration 中间态（配置改为 `reference_video`，数据仍在 `segments`）下两套判别结果不一致：MCP 编辑工具按数据形状可正常编辑，三个 caller 按 `generation_mode` 判空。

## 改动

maintainer 已拍板**选项 C**：文档化接受现状，不改 caller 运行时行为。本 PR 在 ADR-0003 增补「partial migration 中间态的已知限制」段：

- **决策**：中间态视为异常状态，非受支持的合法形态，系统不为其提供功能可用性保证
- **理由**：选项 A（caller 全迁 `resolve_kind`）会反向用数据形状否决用户的配置意图；选项 B（中间态检测 + 诊断报错）需多 caller 重复铺设状态检测且治标
- **行为层修复归宿**：reference_video 升格顶层内容类型的重构（issue #618）

## 验证

- 纯文档改动，零运行时行为变更（`git diff` 仅 1 文件 +18 行，未触碰任何 `.py`）
- 文档三处 caller 描述逐条核对 `main` 现行代码一致：`enqueue_videos.py:55/404-406`、`storyboard_sequence.py:43-44`、`status_calculator.py:56-57`
- `resolve_kind` 数据形状优先、「三处共用」表述均与现有代码注释（`script_editor.py:47`）吻合
- `_select_model` docstring 已先行同步「数据形状优先」表述，无需改动（验收标准 3 满足）

Closes #624

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 更新架构决策记录，新增对“部分迁移中间态（generation_mode 为 reference_video 而分镜数据仍为 segments）”的已知限制说明；将该中间态标记为不受支持的异常情形，说明不修改运行时行为，后续通过重构方案从源头修复。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->