### PR TITLE
fix(video): 视频生成提交超时不再重复建任务与重复计费

### DIFF
--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -141,27 +141,91 @@ def is_retryable_http_status(status_code: int, *, retry_not_found: bool = False)
     return False
 
 
-def _retry_http_error(exc: Exception, *, retry_not_found: bool) -> bool:
-    """中转视频后端统一重试谓词。
+# httpx 传输错误中「请求确定未送达」的子集：连接建立阶段失败或从未取得连接。
+# 重试安全——服务端不可能已建任务 / 已计费。读/写阶段及之后的传输错误（ReadTimeout、
+# WriteError、连接中途断开、RemoteProtocolError 等）请求可能已抵达服务端，归歧义态，不在此列。
+_NOT_SENT_TRANSPORT_ERRORS: tuple[type[Exception], ...] = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.PoolTimeout,
+)
 
-    HTTPStatusError 按 status_code 显式闸门判定，绕开 `_should_retry` 对异常字符串的子串
-    兜底——HTTPStatusError 消息含 URL/task_id，其中的 "500"/"503" 子串会被误判为可重试。
-    网络/传输错误（RequestError）与基础瞬态错误（Connection/Timeout）重试；其余（含
-    ResumeExpiredError 等业务异常）一律快速失败。
+
+class AmbiguousSubmitError(RuntimeError):
+    """create/submit（非幂等的「创建 + 计费」）阶段的歧义态失败。
+
+    请求可能已抵达服务端并已落库 + 已计费，但响应在途丢失（ReadTimeout、写超时、
+    连接中途断开、RemoteProtocolError 等）。此时自动重试会重复建任务 + 重复计费，故
+    不重试、直接终态失败；error_message 带 ``[create_ambiguous]`` 前缀提示运维到供应商侧
+    确认任务状态后再手动重试（与 ``[restart_lost]`` / ``[resume_unsupported]``
+    「宁可手动重试、不可重复计费」先例一致，agent-facing 豁免 i18n）。
     """
-    if isinstance(exc, httpx.HTTPStatusError):
-        return is_retryable_http_status(exc.response.status_code, retry_not_found=retry_not_found)
-    return isinstance(exc, (httpx.RequestError, *BASE_RETRYABLE_ERRORS))
+
+    def __init__(self, *, provider: str, message: str = "") -> None:
+        self.provider = provider
+        super().__init__(
+            message
+            or f"[create_ambiguous] {provider} 创建请求可能已送达服务端但响应在途丢失"
+            "（读超时/连接中途断开），为避免重复建任务与重复计费不自动重试；"
+            "请到供应商侧确认任务状态后再手动重试"
+        )
 
 
 def should_retry_submit(exc: Exception) -> bool:
-    """创建/提交阶段（POST）重试谓词：404 视为确定性端点错误，快速失败。"""
-    return _retry_http_error(exc, retry_not_found=False)
+    """创建/提交阶段（非幂等「创建 + 计费」POST）重试谓词。
+
+    与 ``should_retry_poll`` 的关键区别：传输错误只重试「请求确定未送达」的子集
+    （``_NOT_SENT_TRANSPORT_ERRORS``：连接建立失败 / 从未取得连接），重试不会重复建
+    任务、不会重复计费。歧义态（ReadTimeout 等「请求可能已被服务端处理」）由
+    ``submit_post`` 包成 ``AmbiguousSubmitError`` 终态失败，本谓词对其（及一切业务异常）
+    返回 False。HTTPStatusError 按 status_code 显式闸门：5xx/408/425/429 重试（服务端
+    明示创建失败），404 与确定性 4xx 快速失败。
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        return is_retryable_http_status(exc.response.status_code, retry_not_found=False)
+    return isinstance(exc, _NOT_SENT_TRANSPORT_ERRORS)
 
 
 def should_retry_poll(exc: Exception) -> bool:
-    """轮询/下载阶段（GET）重试谓词：404 视为"短暂未就绪"，重试。"""
-    return _retry_http_error(exc, retry_not_found=True)
+    """轮询/下载阶段（幂等 GET）重试谓词。
+
+    幂等查询重试无副作用，故传输/网络错误（RequestError）与基础瞬态错误一律重试；
+    HTTPStatusError 按 status_code 闸门，404 视为"任务提交后短暂未就绪 / 资源未传播"重试。
+    HTTPStatusError 消息含 URL/task_id，其中 "500"/"503" 子串会被字符串兜底误判，故走
+    显式 status_code 判定绕开；ResumeExpiredError 等业务异常一律快速失败。
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        return is_retryable_http_status(exc.response.status_code, retry_not_found=True)
+    return isinstance(exc, (httpx.RequestError, *BASE_RETRYABLE_ERRORS))
+
+
+async def submit_post(
+    post_fn: Callable[[], Awaitable[httpx.Response]],
+    *,
+    provider: str,
+) -> httpx.Response:
+    """create/提交阶段（非幂等 POST）统一包装：按「请求是否确定送达」给失败分流。
+
+    - 连接建立失败（ConnectError/ConnectTimeout/PoolTimeout）：请求确定未送达 → 原样抛出，
+      交 ``should_retry_submit`` 重试。
+    - 其余传输错误（ReadTimeout/WriteError/RemoteProtocolError 等）：请求可能已被服务端
+      处理 → 抛 ``AmbiguousSubmitError`` 终态失败，不重试，避免重复建任务 + 重复计费。
+    - 收到 >=400 响应：先落 body 日志（诊断 413 等），再 ``raise_for_status`` 抛
+      HTTPStatusError，交 ``should_retry_submit`` 按 status_code 分流。
+
+    与 ``with_retry_async(retry_if=should_retry_submit)`` 配套使用：装饰器负责重试，
+    本包装负责把歧义态在重试前转成不可重试的终态异常。
+    """
+    try:
+        resp = await post_fn()
+    except httpx.RequestError as exc:
+        if isinstance(exc, _NOT_SENT_TRANSPORT_ERRORS):
+            raise
+        raise AmbiguousSubmitError(provider=provider) from exc
+    if resp.status_code >= 400:
+        logger.warning("%s create 返回 %s: %s", provider, resp.status_code, resp.text[:500])
+        resp.raise_for_status()
+    return resp
 
 
 async def poll_with_retry[T](

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -141,13 +141,14 @@ def is_retryable_http_status(status_code: int, *, retry_not_found: bool = False)
     return False
 
 
-# httpx 传输错误中「请求确定未送达」的子集：连接建立阶段失败或从未取得连接。
+# httpx 传输错误中「请求确定未送达」的子集：连接建立阶段失败 / 从未取得连接 / 代理握手失败。
 # 重试安全——服务端不可能已建任务 / 已计费。读/写阶段及之后的传输错误（ReadTimeout、
 # WriteError、连接中途断开、RemoteProtocolError 等）请求可能已抵达服务端，归歧义态，不在此列。
 _NOT_SENT_TRANSPORT_ERRORS: tuple[type[Exception], ...] = (
     httpx.ConnectError,
     httpx.ConnectTimeout,
     httpx.PoolTimeout,
+    httpx.ProxyError,  # 代理连接/握手失败：请求从未离开客户端→代理段，未抵达目标供应商
 )
 
 # 请求字节发出前就确定失败的本地/协议错误：URL scheme 不受支持（UnsupportedProtocol）
@@ -184,7 +185,7 @@ def should_retry_submit(exc: Exception) -> bool:
     """创建/提交阶段（非幂等「创建 + 计费」POST）重试谓词。
 
     与 ``should_retry_poll`` 的关键区别：传输错误只重试「请求确定未送达」的子集
-    （``_NOT_SENT_TRANSPORT_ERRORS``：连接建立失败 / 从未取得连接），重试不会重复建
+    （``_NOT_SENT_TRANSPORT_ERRORS``：连接建立失败 / 从未取得连接 / 代理握手失败），重试不会重复建
     任务、不会重复计费。歧义态（ReadTimeout 等「请求可能已被服务端处理」）由
     ``submit_post`` 包成 ``AmbiguousSubmitError`` 终态失败，本谓词对其（及一切业务异常）
     返回 False。HTTPStatusError 按 status_code 显式闸门：5xx/408/425/429 重试（服务端
@@ -219,8 +220,8 @@ async def submit_post(
 ) -> httpx.Response:
     """create/提交阶段（非幂等 POST）统一包装：按「请求是否确定送达」给失败分流。
 
-    - 连接建立失败（ConnectError/ConnectTimeout/PoolTimeout）：请求确定未送达 → 原样抛出，
-      交 ``should_retry_submit`` 重试。
+    - 连接/代理建立失败（ConnectError/ConnectTimeout/PoolTimeout/ProxyError）：请求确定未送达
+      → 原样抛出，交 ``should_retry_submit`` 重试。
     - 本地/协议错误（UnsupportedProtocol/LocalProtocolError）：请求发出前就确定失败、无计费
       风险 → 原样抛出，由 ``should_retry_submit`` 快速失败（非歧义态，不套「请求可能已送达」）。
     - 其余传输错误（ReadTimeout/WriteError/RemoteProtocolError 等）：请求可能已被服务端

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -150,6 +150,15 @@ _NOT_SENT_TRANSPORT_ERRORS: tuple[type[Exception], ...] = (
     httpx.PoolTimeout,
 )
 
+# 请求字节发出前就确定失败的本地/协议错误：URL scheme 不受支持（UnsupportedProtocol）
+# 或本地请求构造违反协议（LocalProtocolError）。二者既无重复计费风险，重试到 max_wait
+# 也不会变好——poll 路径快速失败、submit 路径原样抛出（非歧义态，不套「请求可能已送达」）。
+# 注意 RemoteProtocolError 是其同级 ProtocolError 子类，但属「服务端中途断开」，不在此列。
+_NON_RETRYABLE_LOCAL_ERRORS: tuple[type[Exception], ...] = (
+    httpx.LocalProtocolError,
+    httpx.UnsupportedProtocol,
+)
+
 
 class AmbiguousSubmitError(RuntimeError):
     """create/submit（非幂等的「创建 + 计费」）阶段的歧义态失败。
@@ -189,13 +198,17 @@ def should_retry_submit(exc: Exception) -> bool:
 def should_retry_poll(exc: Exception) -> bool:
     """轮询/下载阶段（幂等 GET）重试谓词。
 
-    幂等查询重试无副作用，故传输/网络错误（RequestError）与基础瞬态错误一律重试；
-    HTTPStatusError 按 status_code 闸门，404 视为"任务提交后短暂未就绪 / 资源未传播"重试。
-    HTTPStatusError 消息含 URL/task_id，其中 "500"/"503" 子串会被字符串兜底误判，故走
-    显式 status_code 判定绕开；ResumeExpiredError 等业务异常一律快速失败。
+    幂等查询重试无副作用，故传输/网络错误（RequestError）与基础瞬态错误一律重试；唯本地/
+    协议错误（``_NON_RETRYABLE_LOCAL_ERRORS``：UnsupportedProtocol / LocalProtocolError）在
+    请求发出前就确定失败，重试到 max_wait 也不会变好，快速失败。HTTPStatusError 按
+    status_code 闸门，404 视为"任务提交后短暂未就绪 / 资源未传播"重试。HTTPStatusError 消息
+    含 URL/task_id，其中 "500"/"503" 子串会被字符串兜底误判，故走显式 status_code 判定绕开；
+    ResumeExpiredError 等业务异常一律快速失败。
     """
     if isinstance(exc, httpx.HTTPStatusError):
         return is_retryable_http_status(exc.response.status_code, retry_not_found=True)
+    if isinstance(exc, _NON_RETRYABLE_LOCAL_ERRORS):
+        return False
     return isinstance(exc, (httpx.RequestError, *BASE_RETRYABLE_ERRORS))
 
 
@@ -208,6 +221,8 @@ async def submit_post(
 
     - 连接建立失败（ConnectError/ConnectTimeout/PoolTimeout）：请求确定未送达 → 原样抛出，
       交 ``should_retry_submit`` 重试。
+    - 本地/协议错误（UnsupportedProtocol/LocalProtocolError）：请求发出前就确定失败、无计费
+      风险 → 原样抛出，由 ``should_retry_submit`` 快速失败（非歧义态，不套「请求可能已送达」）。
     - 其余传输错误（ReadTimeout/WriteError/RemoteProtocolError 等）：请求可能已被服务端
       处理 → 抛 ``AmbiguousSubmitError`` 终态失败，不重试，避免重复建任务 + 重复计费。
     - 收到 >=400 响应：先落 body 日志（诊断 413 等），再 ``raise_for_status`` 抛
@@ -219,7 +234,9 @@ async def submit_post(
     try:
         resp = await post_fn()
     except httpx.RequestError as exc:
-        if isinstance(exc, _NOT_SENT_TRANSPORT_ERRORS):
+        # 请求确定未送达——连接建立失败（瞬态、可重试）或本地/协议错误（确定性、快速失败）——
+        # 均无重复建任务 / 重复计费风险，原样抛出交 should_retry_submit 分流；不套歧义态。
+        if isinstance(exc, (*_NOT_SENT_TRANSPORT_ERRORS, *_NON_RETRYABLE_LOCAL_ERRORS)):
             raise
         raise AmbiguousSubmitError(provider=provider) from exc
     if resp.status_code >= 400:

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -32,6 +32,7 @@ from lib.video_backends.base import (
     poll_with_retry,
     should_retry_poll,
     should_retry_submit,
+    submit_post,
 )
 
 logger = logging.getLogger(__name__)
@@ -211,12 +212,14 @@ class NewAPIVideoBackend:
         retry_if=should_retry_submit,
     )
     async def _create_task(self, client: httpx.AsyncClient, payload: dict) -> str:
-        resp = await client.post(
-            f"{self._base_url}/video/generations",
-            json=payload,
-            headers=self._headers(),
+        resp = await submit_post(
+            lambda: client.post(
+                f"{self._base_url}/video/generations",
+                json=payload,
+                headers=self._headers(),
+            ),
+            provider=PROVIDER_NEWAPI,
         )
-        resp.raise_for_status()
         body = resp.json()
         task_id = body.get("task_id")
         if not task_id:

--- a/lib/video_backends/v2_video_generations.py
+++ b/lib/video_backends/v2_video_generations.py
@@ -41,6 +41,7 @@ from lib.video_backends.base import (
     poll_with_retry,
     should_retry_poll,
     should_retry_submit,
+    submit_post,
 )
 
 logger = logging.getLogger(__name__)
@@ -328,8 +329,10 @@ class V2VideoGenerationsBackend:
         retry_if=should_retry_submit,
     )
     async def _create_task(self, client: httpx.AsyncClient, body: dict) -> str:
-        resp = await client.post(f"{self._root}{_SUBMIT_PATH}", json=body, headers=self._headers())
-        resp.raise_for_status()
+        resp = await submit_post(
+            lambda: client.post(f"{self._root}{_SUBMIT_PATH}", json=body, headers=self._headers()),
+            provider=PROVIDER_V2_VIDEO,
+        )
         payload = resp.json()
         generation_id = _first_str_by_paths(payload, _TASK_ID_PATHS)
         if not generation_id:

--- a/lib/video_backends/vidu.py
+++ b/lib/video_backends/vidu.py
@@ -22,6 +22,8 @@ from lib.video_backends.base import (
     VideoGenerationResult,
     download_video,
     poll_with_retry,
+    should_retry_submit,
+    submit_post,
 )
 from lib.vidu_shared import (
     VIDU_RETRYABLE_ERRORS,
@@ -336,7 +338,7 @@ class ViduVideoBackend:
 
     # ── HTTP wrappers ───────────────────────────────────────────────────
 
-    @with_retry_async(retryable_errors=VIDU_RETRYABLE_ERRORS)
+    @with_retry_async(retry_if=should_retry_submit)
     async def _create_task(self, client, endpoint: str, body: dict) -> dict:
         assert_vidu_body_size(body)
         logger.info(
@@ -344,12 +346,12 @@ class ViduVideoBackend:
             endpoint,
             format_kwargs_for_log(safe_body_for_log(body)),
         )
-        resp = await client.post(endpoint, json=body)
-        if resp.status_code >= 400:
-            # raise_for_status 透出 httpx.HTTPStatusError，保留 .response.status_code，
-            # 让咽喉层能识别 413 走降档重试；body 先落日志保留可诊断性。
-            logger.warning("Vidu 视频接口 %s 返回 %s: %s", endpoint, resp.status_code, resp.text[:500])
-            resp.raise_for_status()
+        # create 是非幂等的「创建 + 计费」调用：submit_post 把歧义态（ReadTimeout 等
+        # 「请求可能已送达服务端」）转 AmbiguousSubmitError 终态失败、不重试，仅「请求确定
+        # 未送达」的连接建立失败交 should_retry_submit 重试，避免重复建任务 + 重复计费。
+        # 413 等 4xx 经 raise_for_status 透出 httpx.HTTPStatusError（保留 status_code），
+        # 让咽喉层识别 413 走降档重试；body 由 submit_post 落日志保留可诊断性。
+        resp = await submit_post(lambda: client.post(endpoint, json=body), provider=PROVIDER_VIDU)
         data = resp.json()
         if not data.get("task_id"):
             raise RuntimeError(f"Vidu 视频任务创建响应缺少 task_id: {data}")

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -439,6 +439,96 @@ class TestNewAPIVideoBackend:
 
         assert mock_client.post.call_count == 1, "确定性 4xx 不该被 retry"
 
+    async def test_create_read_timeout_fails_fast_with_manual_retry_hint(self, tmp_path: Path):
+        """create 阶段 ReadTimeout（请求可能已送达）→ 不重试、单次失败、错误信息含手动重试提示。"""
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=httpx.ReadTimeout("read timed out"))
+        mock_client.get = AsyncMock(side_effect=AssertionError("歧义态应在创建阶段失败，不该轮询"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+        ):
+            from lib.video_backends.base import AmbiguousSubmitError
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            with pytest.raises(AmbiguousSubmitError, match="手动重试"):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                    )
+                )
+
+        assert mock_client.post.call_count == 1, "歧义态不该被 retry"
+
+    async def test_create_connect_error_retries(self, tmp_path: Path):
+        """create 阶段 ConnectError（请求确定未送达）→ 重试，第三次成功。"""
+        create_resp = _make_response(200, {"task_id": "t-conn", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {"task_id": "t-conn", "status": "completed", "url": "https://cdn/v.mp4", "metadata": {"duration": 5}},
+        )
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=[httpx.ConnectError("refused"), httpx.ConnectError("refused"), create_resp]
+        )
+        mock_client.get = AsyncMock(return_value=poll_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            patch("lib.video_backends.newapi.download_video", fake_download),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert result.task_id == "t-conn"
+        assert mock_client.post.call_count == 3, "ConnectError 请求确定未送达，应重试"
+
+    async def test_poll_read_timeout_retries(self, tmp_path: Path):
+        """poll 阶段 ReadTimeout（幂等 GET）→ 重试，不回归。"""
+        create_resp = _make_response(200, {"task_id": "t-pr", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {"task_id": "t-pr", "status": "completed", "url": "https://cdn/v.mp4", "metadata": {"duration": 5}},
+        )
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=create_resp)
+        mock_client.get = AsyncMock(side_effect=[httpx.ReadTimeout("read timed out"), poll_resp])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.newapi.download_video", fake_download),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert result.task_id == "t-pr"
+        assert mock_client.get.call_count == 2, "poll 网络超时应重试"
+
     async def test_poll_non_retryable_4xx_fails_fast(self, tmp_path: Path):
         """轮询遇确定性 4xx（401，如 token 失效）应一次失败，不重试到 max_wait 超时。"""
         create_resp = _make_response(200, {"task_id": "t-401", "status": "queued"})

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -38,6 +38,8 @@ def _make_response(status_code: int, json_body: dict) -> MagicMock:
     resp = MagicMock()
     resp.status_code = status_code
     resp.json.return_value = json_body
+    # 真字符串而非 MagicMock：submit_post 在 >=400 时记 resp.text[:500]，让该日志切片走真实 str 路径。
+    resp.text = str(json_body)
     resp.raise_for_status = MagicMock()
     return resp
 

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -12,6 +12,7 @@ import httpx
 import pytest
 
 from lib.video_backends.base import (
+    AmbiguousSubmitError,
     ResumeExpiredError,
     VideoCapability,
     VideoGenerationRequest,
@@ -492,3 +493,83 @@ class TestV2BackendHttp:
             with pytest.raises(httpx.HTTPStatusError):
                 await self._backend().generate(req)
         assert client.get.call_count == 1, "轮询确定性 4xx 应一击失败，不重试到超时"
+
+    @pytest.mark.asyncio
+    async def test_create_read_timeout_fails_fast_with_manual_retry_hint(self, tmp_path: Path):
+        """create 阶段 ReadTimeout（请求可能已送达）→ 不重试、单次失败、错误信息含手动重试提示。"""
+        # list 形式 → side_effect，AsyncMock 会抛出该异常（单值形式会被当 return_value 返回）。
+        client = _mock_client(post=[httpx.ReadTimeout("read timed out")])
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+        ):
+            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            with pytest.raises(AmbiguousSubmitError, match="手动重试"):
+                await self._backend().generate(req)
+        assert client.post.call_count == 1, "歧义态不该被 retry"
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_connect_error_retries(self, tmp_path: Path):
+        """create 阶段 ConnectError（请求确定未送达）→ 重试，第三次成功。"""
+        client = _mock_client(
+            post=[
+                httpx.ConnectError("refused"),
+                httpx.ConnectError("refused"),
+                _make_response(200, {"id": "gen-ok", "status": "queued"}),
+            ],
+            get=_make_response(200, {"status": "completed", "video": {"url": "https://cdn/v.mp4"}}),
+        )
+        fake_dl = AsyncMock(side_effect=_fake_download_factory(b"mp4"))
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.v2_video_generations.download_video", fake_dl),
+            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+        ):
+            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            result = await self._backend().generate(req)
+        assert result.task_id == "gen-ok"
+        assert client.post.call_count == 3, "ConnectError 请求确定未送达，应重试"
+
+    @pytest.mark.asyncio
+    async def test_create_retries_on_5xx(self, tmp_path: Path):
+        """create 阶段收到 503 响应（服务端明示创建失败）→ 维持重试（现状保持）。"""
+        resp503 = _make_response(503, {"error": "upstream busy"})
+        resp503.raise_for_status = MagicMock(side_effect=_make_http_error(503, "upstream busy"))
+        client = _mock_client(
+            post=[resp503, resp503, _make_response(200, {"id": "gen-503", "status": "queued"})],
+            get=_make_response(200, {"status": "completed", "video": {"url": "https://cdn/v.mp4"}}),
+        )
+        fake_dl = AsyncMock(side_effect=_fake_download_factory(b"mp4"))
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.v2_video_generations.download_video", fake_dl),
+            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+        ):
+            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            result = await self._backend().generate(req)
+        assert result.task_id == "gen-503"
+        assert client.post.call_count == 3, "5xx 应维持重试"
+
+    @pytest.mark.asyncio
+    async def test_poll_read_timeout_retries(self, tmp_path: Path):
+        """poll 阶段 ReadTimeout（幂等 GET）→ 重试，不回归。"""
+        client = _mock_client(
+            post=_make_response(200, {"id": "gen-p", "status": "queued"}),
+            get=[
+                httpx.ReadTimeout("read timed out"),
+                _make_response(200, {"status": "completed", "video": {"url": "https://cdn/v.mp4"}}),
+            ],
+        )
+        fake_dl = AsyncMock(side_effect=_fake_download_factory(b"mp4"))
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.v2_video_generations.download_video", fake_dl),
+        ):
+            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            result = await self._backend().generate(req)
+        assert result.task_id == "gen-p"
+        assert client.get.call_count == 2, "poll 网络超时应重试"

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -7,6 +7,7 @@ import pytest
 from sqlalchemy.exc import OperationalError
 
 from lib.video_backends.base import (
+    AmbiguousSubmitError,
     ResumeExpiredError,
     VideoCapability,
     VideoGenerationRequest,
@@ -17,6 +18,7 @@ from lib.video_backends.base import (
     poll_with_retry,
     should_retry_poll,
     should_retry_submit,
+    submit_post,
 )
 
 
@@ -269,7 +271,11 @@ class TestIsRetryableHttpStatus:
 
 
 class TestRetryPredicates:
-    """should_retry_submit / should_retry_poll 中转视频后端统一重试谓词。"""
+    """should_retry_submit / should_retry_poll 中转视频后端重试谓词。
+
+    submit 是非幂等的「创建 + 计费」：传输错误只重试「请求确定未送达」的子集；
+    poll 是幂等 GET：传输错误一律重试。
+    """
 
     def test_deterministic_4xx_fail_fast(self):
         for code in (400, 401, 403, 422):
@@ -283,15 +289,49 @@ class TestRetryPredicates:
         assert should_retry_poll(err) is True
 
     def test_transient_http_retries(self):
-        for code in (408, 429, 500, 503):
+        for code in (408, 425, 429, 500, 503):
             err = _http_status_error(code)
             assert should_retry_submit(err) is True
             assert should_retry_poll(err) is True
 
-    def test_network_and_base_errors_retry(self):
-        for exc in (httpx.ConnectError("refused"), ConnectionError(), TimeoutError()):
+    def test_submit_retries_only_not_sent_transport_errors(self):
+        # 连接建立失败 / 从未取得连接 → 请求确定未送达 → submit 重试安全。
+        for exc in (
+            httpx.ConnectError("refused"),
+            httpx.ConnectTimeout("connect timed out"),
+            httpx.PoolTimeout("pool exhausted"),
+        ):
             assert should_retry_submit(exc) is True
+
+    def test_submit_does_not_retry_ambiguous_transport_errors(self):
+        # 请求可能已送达服务端（已建任务 / 已计费）→ submit 不重试，避免重复计费。
+        # 这些错误在 create 路径由 submit_post 转成 AmbiguousSubmitError 终态失败。
+        for exc in (
+            httpx.ReadTimeout("read timed out"),
+            httpx.WriteTimeout("write timed out"),
+            httpx.ReadError("conn reset mid-read"),
+            httpx.WriteError("conn reset mid-write"),
+            httpx.RemoteProtocolError("server disconnected"),
+            ConnectionError(),  # 内建：歧义，不重试
+            TimeoutError(),  # 内建：歧义，不重试
+        ):
+            assert should_retry_submit(exc) is False
+
+    def test_poll_retries_all_transport_errors(self):
+        # 幂等 GET：连接建立失败与读/写阶段错误一律重试。
+        for exc in (
+            httpx.ConnectError("refused"),
+            httpx.ReadTimeout("read timed out"),
+            httpx.RemoteProtocolError("server disconnected"),
+            ConnectionError(),
+            TimeoutError(),
+        ):
             assert should_retry_poll(exc) is True
+
+    def test_ambiguous_submit_error_never_retries(self):
+        # AmbiguousSubmitError 是终态：被装饰器捕获后谓词须返回 False，不再重试。
+        assert should_retry_submit(AmbiguousSubmitError(provider="v2")) is False
+        assert should_retry_poll(AmbiguousSubmitError(provider="v2")) is False
 
     def test_business_exceptions_fail_fast(self):
         # ResumeExpiredError 的 job_id 含 "503" 子串：旧字符串兜底会误判重试，新谓词不会。
@@ -301,6 +341,49 @@ class TestRetryPredicates:
         # 普通异常即便消息含状态码子串也不重试（绕开字符串误判）。
         assert should_retry_poll(ValueError("503 in message")) is False
         assert should_retry_submit(RuntimeError("got 500 somewhere")) is False
+
+
+class TestSubmitPost:
+    """submit_post：create/提交阶段按「请求是否确定送达」给失败分流。"""
+
+    async def test_returns_response_on_success(self):
+        resp = httpx.Response(200, request=httpx.Request("POST", "https://x/v2"), json={"id": "ok"})
+
+        async def _post() -> httpx.Response:
+            return resp
+
+        assert await submit_post(_post, provider="v2") is resp
+
+    async def test_not_sent_error_propagates_for_retry(self):
+        # 连接建立失败原样抛出，交 should_retry_submit 重试（不包成终态）。
+        async def _post() -> httpx.Response:
+            raise httpx.ConnectError("refused")
+
+        with pytest.raises(httpx.ConnectError):
+            await submit_post(_post, provider="v2")
+
+    async def test_ambiguous_error_wrapped_with_manual_retry_hint(self):
+        # ReadTimeout（请求可能已送达）包成 AmbiguousSubmitError，消息含手动重试提示。
+        async def _post() -> httpx.Response:
+            raise httpx.ReadTimeout("read timed out")
+
+        with pytest.raises(AmbiguousSubmitError) as excinfo:
+            await submit_post(_post, provider="newapi")
+        msg = str(excinfo.value)
+        assert "[create_ambiguous]" in msg
+        assert "手动重试" in msg
+        assert isinstance(excinfo.value.__cause__, httpx.ReadTimeout)
+
+    async def test_http_status_error_propagates_for_status_gate(self):
+        # >=400 响应经 raise_for_status 抛 HTTPStatusError，交 should_retry_submit 按 status_code 分流。
+        request = httpx.Request("POST", "https://x/v2")
+        resp = httpx.Response(503, request=request, text="upstream busy")
+
+        async def _post() -> httpx.Response:
+            return resp
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await submit_post(_post, provider="v2")
 
 
 def _make_operational_error(msg: str) -> OperationalError:

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -295,11 +295,12 @@ class TestRetryPredicates:
             assert should_retry_poll(err) is True
 
     def test_submit_retries_only_not_sent_transport_errors(self):
-        # 连接建立失败 / 从未取得连接 → 请求确定未送达 → submit 重试安全。
+        # 连接建立失败 / 从未取得连接 / 代理握手失败 → 请求确定未送达 → submit 重试安全。
         for exc in (
             httpx.ConnectError("refused"),
             httpx.ConnectTimeout("connect timed out"),
             httpx.PoolTimeout("pool exhausted"),
+            httpx.ProxyError("proxy handshake failed"),
         ):
             assert should_retry_submit(exc) is True
 
@@ -372,12 +373,14 @@ class TestSubmitPost:
         assert await submit_post(_post, provider="v2") is resp
 
     async def test_not_sent_error_propagates_for_retry(self):
-        # 连接建立失败原样抛出，交 should_retry_submit 重试（不包成终态）。
-        async def _post() -> httpx.Response:
-            raise httpx.ConnectError("refused")
+        # 连接建立失败 / 代理握手失败原样抛出，交 should_retry_submit 重试（不包成终态）。
+        for exc in (httpx.ConnectError("refused"), httpx.ProxyError("proxy handshake failed")):
 
-        with pytest.raises(httpx.ConnectError):
-            await submit_post(_post, provider="v2")
+            async def _post(_exc: httpx.RequestError = exc) -> httpx.Response:
+                raise _exc
+
+            with pytest.raises(type(exc)):
+                await submit_post(_post, provider="v2")
 
     async def test_local_protocol_error_propagates_raw_not_ambiguous(self):
         # 本地/协议错误请求发出前就失败、无计费风险 → 原样抛出，不包成 AmbiguousSubmitError

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -305,7 +305,9 @@ class TestRetryPredicates:
 
     def test_submit_does_not_retry_ambiguous_transport_errors(self):
         # 请求可能已送达服务端（已建任务 / 已计费）→ submit 不重试，避免重复计费。
-        # 这些错误在 create 路径由 submit_post 转成 AmbiguousSubmitError 终态失败。
+        # 注意：实际 create 路径中这些原始异常会先被 submit_post 包成 AmbiguousSubmitError 再
+        # 进重试谓词，should_retry_submit 运行时并不会直接收到它们；此处单独断言谓词对原始异常
+        # 的防御性行为（文档化兜底），与 submit_post 的包装互为双保险。
         for exc in (
             httpx.ReadTimeout("read timed out"),
             httpx.WriteTimeout("write timed out"),
@@ -332,6 +334,21 @@ class TestRetryPredicates:
         # AmbiguousSubmitError 是终态：被装饰器捕获后谓词须返回 False，不再重试。
         assert should_retry_submit(AmbiguousSubmitError(provider="v2")) is False
         assert should_retry_poll(AmbiguousSubmitError(provider="v2")) is False
+
+    def test_local_protocol_errors_fail_fast_both_paths(self):
+        # UnsupportedProtocol / LocalProtocolError 在请求发出前就确定失败（均为 RequestError
+        # 子类），两条路径都快速失败——poll 不该重试到 max_wait，submit 也无重复计费风险。
+        for exc in (
+            httpx.UnsupportedProtocol("scheme not http(s)"),
+            httpx.LocalProtocolError("bad local request"),
+        ):
+            assert should_retry_poll(exc) is False
+            assert should_retry_submit(exc) is False
+
+    def test_poll_still_retries_remote_protocol_error(self):
+        # RemoteProtocolError 与 LocalProtocolError 同为 ProtocolError 子类，但属「服务端中途
+        # 断开」，幂等 GET 重试安全——确认本地错误的排除没有误伤它。
+        assert should_retry_poll(httpx.RemoteProtocolError("server disconnected")) is True
 
     def test_business_exceptions_fail_fast(self):
         # ResumeExpiredError 的 job_id 含 "503" 子串：旧字符串兜底会误判重试，新谓词不会。
@@ -361,6 +378,20 @@ class TestSubmitPost:
 
         with pytest.raises(httpx.ConnectError):
             await submit_post(_post, provider="v2")
+
+    async def test_local_protocol_error_propagates_raw_not_ambiguous(self):
+        # 本地/协议错误请求发出前就失败、无计费风险 → 原样抛出，不包成 AmbiguousSubmitError
+        # （否则会误导运维去供应商侧确认一个从未创建的任务）。
+        for exc in (
+            httpx.UnsupportedProtocol("scheme not http(s)"),
+            httpx.LocalProtocolError("bad local request"),
+        ):
+
+            async def _post(_exc: httpx.RequestError = exc) -> httpx.Response:
+                raise _exc
+
+            with pytest.raises(type(exc)):
+                await submit_post(_post, provider="v2")
 
     async def test_ambiguous_error_wrapped_with_manual_retry_hint(self):
         # ReadTimeout（请求可能已送达）包成 AmbiguousSubmitError，消息含手动重试提示。

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -298,3 +298,46 @@ class TestCreateTask413:
         assert ei.value.response.status_code == 413
         # 413 非 retryable → fail-fast 单次
         assert client.post.call_count == 1
+
+
+class TestCreateTaskAmbiguity:
+    """create 阶段按「请求是否确定送达」收窄重试，避免重复建任务 + 重复计费。"""
+
+    async def test_read_timeout_fails_fast_with_manual_retry_hint(self):
+        from unittest.mock import AsyncMock
+
+        import httpx
+
+        from lib.video_backends.base import AmbiguousSubmitError
+
+        client = AsyncMock()
+        client.post = AsyncMock(side_effect=httpx.ReadTimeout("read timed out"))
+
+        backend = ViduVideoBackend(api_key="k", model="viduq3-turbo")
+        with (
+            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            pytest.raises(AmbiguousSubmitError, match="手动重试"),
+        ):
+            await backend._create_task(client, "/text2video", {"model": "viduq3-turbo", "prompt": "x", "duration": 8})
+        # 歧义态：请求可能已送达，不重试
+        assert client.post.call_count == 1
+
+    async def test_connect_error_retries(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        import httpx
+
+        ok = MagicMock()
+        ok.status_code = 200
+        ok.json.return_value = {"task_id": "vidu-conn"}
+        client = AsyncMock()
+        client.post = AsyncMock(side_effect=[httpx.ConnectError("refused"), httpx.ConnectError("refused"), ok])
+
+        backend = ViduVideoBackend(api_key="k", model="viduq3-turbo")
+        with patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0):
+            data = await backend._create_task(
+                client, "/text2video", {"model": "viduq3-turbo", "prompt": "x", "duration": 8}
+            )
+        assert data["task_id"] == "vidu-conn"
+        # ConnectError 请求确定未送达，应重试
+        assert client.post.call_count == 3


### PR DESCRIPTION
## 问题

视频创建调用（`POST /v2/video/generations` 等）是**非幂等的「创建 + 计费」**操作。此前对所有网络/传输错误一律重试，当「服务端已落库 + 已计费、但响应在途丢失」时，重试会**重复建任务 + 重复计费**：

```
客户端 ──POST创建──▶ 服务端：任务已落库 + 已计费
客户端 ◀──响应丢失──  （网络抖动 / 读超时）
客户端 ──POST重试──▶ 服务端：又建一个任务 + 又扣一次钱
```

目标中转站/供应商均未文档化幂等去重（Idempotency-Key），盲发幂等头无效。

## 方案

按「请求是否确定送达」对创建阶段的失败二分，新增统一包装 `submit_post`（复用既有状态码门控基础设施，不另造）：

- **请求确定未送达**（连接建立失败：`ConnectError` / `ConnectTimeout` / `PoolTimeout`）→ 重试安全，保留重试。
- **歧义态**（`ReadTimeout` / 写超时 / 连接中途断开等「请求可能已被服务端处理」）→ 包成终态失败、**不重试**；错误信息带 `[create_ambiguous]` 前缀，提示「为避免重复建任务与重复计费，请到供应商侧确认任务状态后再手动重试」——与既有 `[restart_lost]` / `[resume_unsupported]`「宁可手动重试、不可重复计费」先例一致。
- **收到明确 5xx 响应**（服务端明示创建失败）→ 维持重试（与现状一致）。
- **轮询（poll）阶段为幂等查询**，重试行为完全不变。

终态失败的错误信息经 worker 既有 `mark_task_failed(str(exc))` 路径原样落到 `task.error_message`，无需改动 worker。

## 覆盖范围与各后端结论

| 后端 | 类型 | 处理 |
|---|---|---|
| **V2 视频后端** | httpx 中转 | ✅ create 走 `submit_post` 收窄重试（本 issue 核心） |
| **NewAPI 视频后端** | httpx 中转 | ✅ create 走 `submit_post` 收窄重试（本 issue 核心） |
| **Vidu** | httpx 直连 | ✅ create 一并收窄；**413 降档链路保留**——`submit_post` 对 ≥400 响应仍 `raise_for_status` 透出携带 `status_code` 的 `HTTPStatusError`，媒体层 `_is_413` 据此走参考图降档，未受本次改动影响 |
| **Ark** | volcengine SDK | ⏸️ 未动。create 经 SDK 提交，其异常类目与「请求是否送达」语义未文档化；按「不猜测外部供应商数据」红线**有意 scoping**，不强行套用 httpx 传输错误分类。后续若核实 SDK 异常映射可同法收窄 |
| **Grok** | xAI SDK | ⏸️ 未动，同 Ark（SDK 路径，异常类目未核实） |
| **DashScope** | httpx 直连 | ⏸️ 本 issue 范围外；其重试谓词改造已由 issue #701 单独跟踪，可在彼处一并纳入同一收窄 |

## 验收

- [x] create 阶段 `ReadTimeout` → 不重试、单次失败、错误信息含手动重试提示（newapi / v2 / vidu 三处单测）
- [x] create 阶段 `ConnectError` → 重试（newapi / v2 / vidu）
- [x] create 阶段收到 503 响应 → 重试（v2，现状保持）
- [x] poll 阶段网络错误/超时重试行为不回归（newapi / v2）
- [x] ark / vidu（及 grok / dashscope）幂等性处理结论见上表
- [x] 全量后端测试通过

## 验证

- `uv run pytest`：4654 passed
- 受影响 4 个测试文件：177 passed
- `uv run ruff check` / `uv run basedpyright`：clean，0 error

## 本地审查发现

独立审查（未参与实现）对歧义态判定、413 降档链路、worker 错误透传逐一核实，结论：实现完整、无重复计费回归。补一处测试增强——`_make_response` 设真实 `text` 字符串，使 5xx create 测试真正覆盖 `submit_post` 的日志切片路径。`AmbiguousSubmitError` 的 `message` 形参在自定义消息时不前置 `[create_ambiguous]`，但唯一调用方不传 message、且签名与同文件 `ResumeExpiredError` 一致，为潜在 wart 非现网缺陷，不改。

Closes #687


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化视频任务创建与轮询的重试与失败判定，避免在提交歧义场景造成重复创建与重复计费，并在需人工判断时提供“手动重试”提示。
  * 更精确区分“请求未送达可重试”与“本地/协议确定失败快速失败”，提升稳定性与成本安全性。

* **Tests**
  * 补充并强化超时、连接错误与 5xx 场景下的单元测试，覆盖提交/轮询的新重试语义并验证行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->