### PR TITLE
feat(assistant): 智能体生成剧本时前端弹出耗时提示，避免误以为卡死

### DIFF
--- a/frontend/src/components/layout/ScriptGenerationNoticeListener.tsx
+++ b/frontend/src/components/layout/ScriptGenerationNoticeListener.tsx
@@ -1,0 +1,11 @@
+import { useScriptGenerationNotice } from "@/hooks/useScriptGenerationNotice";
+
+/**
+ * 无 UI 监听组件：把 useScriptGenerationNotice 对 assistant store 的订阅隔离在叶子节点，
+ * 避免直接挂在 StudioLayout 时助手流每次更新都触发整个布局重渲染。常驻挂载使其去重
+ * 记录跨会话/项目切换持久。
+ */
+export function ScriptGenerationNoticeListener() {
+  useScriptGenerationNotice();
+  return null;
+}

--- a/frontend/src/components/layout/StudioLayout.tsx
+++ b/frontend/src/components/layout/StudioLayout.tsx
@@ -9,6 +9,7 @@ import { AgentCopilot } from "@/components/copilot/AgentCopilot";
 import { useTasksSSE } from "@/hooks/useTasksSSE";
 import { useProjectEventsSSE } from "@/hooks/useProjectEventsSSE";
 import { TaskFailureListener } from "./TaskFailureListener";
+import { ScriptGenerationNoticeListener } from "./ScriptGenerationNoticeListener";
 import { useProjectsStore } from "@/stores/projects-store";
 import {
   ASSISTANT_PANEL_DEFAULT_WIDTH,
@@ -147,6 +148,7 @@ export function StudioLayout({ children }: StudioLayoutProps) {
       style={{ color: "var(--color-text)" }}
     >
       <TaskFailureListener projectName={currentProjectName} />
+      <ScriptGenerationNoticeListener />
       <GlobalHeader onNavigateBack={() => setLocation("~/app/projects")} />
       <div className="flex flex-1 overflow-hidden">
         <AssetSidebar />

--- a/frontend/src/hooks/useScriptGenerationNotice.test.tsx
+++ b/frontend/src/hooks/useScriptGenerationNotice.test.tsx
@@ -1,0 +1,156 @@
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useScriptGenerationNotice } from "@/hooks/useScriptGenerationNotice";
+import { useAssistantStore } from "@/stores/assistant-store";
+import { useAppStore } from "@/stores/app-store";
+import type { ContentBlock, Turn } from "@/types";
+
+function Harness() {
+  useScriptGenerationNotice();
+  return null;
+}
+
+function toolUse(name: string, id: string): ContentBlock {
+  return { type: "tool_use", name, id, input: {} };
+}
+
+function toolResult(toolUseId: string): ContentBlock {
+  return { type: "tool_result", tool_use_id: toolUseId, content: "✅ done" };
+}
+
+function assistantTurn(...content: ContentBlock[]): Turn {
+  return { type: "assistant", content };
+}
+
+const SCRIPT_TOOL = "mcp__arcreel__generate_episode_script";
+const NORMALIZE_TOOL = "mcp__arcreel__normalize_drama_script";
+
+describe("useScriptGenerationNotice", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState(), true);
+    useAssistantStore.setState(useAssistantStore.getInitialState(), true);
+  });
+
+  it("pushes one info toast when a running session starts a script generation tool", () => {
+    useAssistantStore.setState({ sessionStatus: "running" });
+    const spy = vi.spyOn(useAppStore.getState(), "pushToast");
+    render(<Harness />);
+
+    act(() => {
+      useAssistantStore.setState({
+        draftTurn: assistantTurn(toolUse(SCRIPT_TOOL, "tu-1")),
+      });
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][1]).toBe("info");
+  });
+
+  it("also fires for the drama-script normalization tool", () => {
+    useAssistantStore.setState({ sessionStatus: "running" });
+    const spy = vi.spyOn(useAppStore.getState(), "pushToast");
+    render(<Harness />);
+
+    act(() => {
+      useAssistantStore.setState({
+        draftTurn: assistantTurn(toolUse(NORMALIZE_TOOL, "tu-n")),
+      });
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire for non-script tool calls", () => {
+    useAssistantStore.setState({ sessionStatus: "running" });
+    const spy = vi.spyOn(useAppStore.getState(), "pushToast");
+    render(<Harness />);
+
+    act(() => {
+      useAssistantStore.setState({
+        draftTurn: assistantTurn(
+          toolUse("mcp__arcreel__generate_storyboards", "tu-sb"),
+          toolUse("Bash", "tu-bash"),
+        ),
+      });
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does not fire twice for the same tool_use id across re-renders/reconnect", () => {
+    useAssistantStore.setState({ sessionStatus: "running" });
+    const spy = vi.spyOn(useAppStore.getState(), "pushToast");
+    render(<Harness />);
+
+    act(() => {
+      useAssistantStore.setState({
+        draftTurn: assistantTurn(toolUse(SCRIPT_TOOL, "tu-1")),
+      });
+    });
+    // Simulate an SSE reconnect re-delivering the same in-flight draft turn.
+    act(() => {
+      useAssistantStore.setState({ draftTurn: null });
+      useAssistantStore.setState({
+        draftTurn: assistantTurn(toolUse(SCRIPT_TOOL, "tu-1")),
+      });
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when the tool call already has a result (historical/completed)", () => {
+    useAssistantStore.setState({ sessionStatus: "running" });
+    const spy = vi.spyOn(useAppStore.getState(), "pushToast");
+    render(<Harness />);
+
+    act(() => {
+      useAssistantStore.setState({
+        turns: [
+          assistantTurn(toolUse(SCRIPT_TOOL, "tu-done")),
+          { type: "user", content: [toolResult("tu-done")] },
+        ],
+      });
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when the session is not running (idle/interrupted reload)", () => {
+    useAssistantStore.setState({ sessionStatus: "interrupted" });
+    const spy = vi.spyOn(useAppStore.getState(), "pushToast");
+    render(<Harness />);
+
+    act(() => {
+      useAssistantStore.setState({
+        draftTurn: assistantTurn(toolUse(SCRIPT_TOOL, "tu-int")),
+      });
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does not re-fire after switching away and back to the same running call", () => {
+    useAssistantStore.setState({ sessionStatus: "running" });
+    const spy = vi.spyOn(useAppStore.getState(), "pushToast");
+    render(<Harness />);
+
+    act(() => {
+      useAssistantStore.setState({
+        draftTurn: assistantTurn(toolUse(SCRIPT_TOOL, "tu-keep")),
+      });
+    });
+    // Switch away: turns/draft reset, status drops to idle.
+    act(() => {
+      useAssistantStore.setState({ draftTurn: null, turns: [], sessionStatus: "idle" });
+    });
+    // Switch back: snapshot reloads the still-running call (same id).
+    act(() => {
+      useAssistantStore.setState({
+        sessionStatus: "running",
+        draftTurn: assistantTurn(toolUse(SCRIPT_TOOL, "tu-keep")),
+      });
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useScriptGenerationNotice.ts
+++ b/frontend/src/hooks/useScriptGenerationNotice.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useAssistantStore } from "@/stores/assistant-store";
+import { useAppStore } from "@/stores/app-store";
+import type { ContentBlock, Turn } from "@/types";
+
+/**
+ * 剧本生成是分钟级的 LLM 文本生成，agent 调用期间前端原本毫无反馈，用户容易误以为
+ * 卡死。本 hook 监听助手会话流，识别到剧本生成类工具调用开始时弹一条瞬时 toast
+ * （过程性提示，无需持久回看），告知该步骤耗时较长。
+ *
+ * 工具名是 SDK 注册后的全限定名 mcp__arcreel__<id>，与 ToolCallWithResult 的解析口径
+ * 一致。仅覆盖剧本/规范化两类文本生成工具；分镜/视频等长耗时工具已有任务队列 HUD。
+ */
+const SCRIPT_GENERATION_TOOL_NAMES = new Set([
+  "mcp__arcreel__generate_episode_script",
+  "mcp__arcreel__normalize_drama_script",
+]);
+
+function collectBlocks(turns: Turn[], draftTurn: Turn | null): ContentBlock[] {
+  const blocks: ContentBlock[] = [];
+  for (const turn of turns) {
+    if (turn.content) blocks.push(...turn.content);
+  }
+  if (draftTurn?.content) blocks.push(...draftTurn.content);
+  return blocks;
+}
+
+export function useScriptGenerationNotice(): void {
+  const { t } = useTranslation("dashboard");
+  // 经 ref 暴露最新 t，避免切语言重建 effect、丢失已弹记录。
+  const tRef = useRef(t);
+  useEffect(() => {
+    tRef.current = t;
+  }, [t]);
+
+  const turns = useAssistantStore((s) => s.turns);
+  const draftTurn = useAssistantStore((s) => s.draftTurn);
+  const sessionStatus = useAssistantStore((s) => s.sessionStatus);
+
+  // 已弹过提示的 tool_use id。跨会话/项目切换持久（StudioLayout 常驻），
+  // 切走再回同一进行中调用不重弹；SSE 重连重投同一 draft 也不重弹。
+  const notifiedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    // 仅在会话运行中弹"耗时"提示：已完成/已中断会话重新载入时，其历史 tool_use 或
+    // 残留 draft 可能仍缺 result，运行态门槛把这类陈旧状态挡在外面。
+    if (sessionStatus !== "running") return;
+
+    const blocks = collectBlocks(turns, draftTurn);
+
+    const completedToolUseIds = new Set<string>();
+    for (const block of blocks) {
+      if (block.type === "tool_result" && block.tool_use_id) {
+        completedToolUseIds.add(block.tool_use_id);
+      }
+    }
+
+    for (const block of blocks) {
+      if (
+        block.type === "tool_use" &&
+        block.id &&
+        block.name &&
+        SCRIPT_GENERATION_TOOL_NAMES.has(block.name) &&
+        !completedToolUseIds.has(block.id) &&
+        !notifiedRef.current.has(block.id)
+      ) {
+        notifiedRef.current.add(block.id);
+        useAppStore.getState().pushToast(tRef.current("script_generation_notice_toast"), "info");
+      }
+    }
+  }, [turns, draftTurn, sessionStatus]);
+}

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -390,6 +390,7 @@ export default {
   'video_task_submitted_toast': 'Video generation task for "{{id}}" submitted',
   'generate_video_failed': 'Failed to generate video: {{message}}',
   'narration_task_submitted_toast': 'Narration audio task for "{{id}}" submitted',
+  'script_generation_notice_toast': 'Generating the script — this step takes a while, please wait…',
   'narration_batch_submitted_toast': 'Submitted {{count}} narration audio tasks',
   'narration_batch_none_missing_toast': 'All shots already have narration audio',
   'generate_narration_failed': 'Failed to generate narration: {{message}}',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -380,6 +380,7 @@ export default {
   'video_task_submitted_toast': 'Đã gửi tác vụ tạo video cho "{{id}}"',
   'generate_video_failed': 'Tạo video thất bại: {{message}}',
   'narration_task_submitted_toast': 'Đã gửi tác vụ tạo thuyết minh cho "{{id}}"',
+  'script_generation_notice_toast': 'Đang tạo kịch bản — bước này mất khá lâu, vui lòng đợi…',
   'narration_batch_submitted_toast': 'Đã gửi {{count}} tác vụ tạo thuyết minh',
   'narration_batch_none_missing_toast': 'Tất cả phân cảnh đã có thuyết minh',
   'generate_narration_failed': 'Tạo thuyết minh thất bại: {{message}}',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -391,6 +391,7 @@ export default {
   'video_task_submitted_toast': '已提交视频 "{{id}}" 生成任务',
   'generate_video_failed': '生成视频失败: {{message}}',
   'narration_task_submitted_toast': '已提交旁白 "{{id}}" 生成任务',
+  'script_generation_notice_toast': '正在生成剧本，这一步耗时较长，请耐心等待…',
   'narration_batch_submitted_toast': '已提交 {{count}} 个旁白生成任务',
   'narration_batch_none_missing_toast': '所有分镜均已生成旁白',
   'generate_narration_failed': '生成旁白失败: {{message}}',


### PR DESCRIPTION
## 背景

智能体调用剧本生成工具（`generate_episode_script` / `normalize_drama_script`）是分钟级的 LLM 文本生成，期间前端原本毫无反馈，用户容易误以为系统卡死。

## 改动

新增常驻监听 hook `useScriptGenerationNotice`，识别这两类剧本生成工具调用开始时弹一条**瞬时 info toast**，告知该步骤耗时较长、请耐心等待。

- 订阅逻辑隔离在无 UI 叶子组件 `ScriptGenerationNoticeListener`（常驻挂 `StudioLayout`），避免助手流每次更新触发整个布局重渲染
- 按 `tool_use` id 去重：SSE 重连重投同一 draft、切走再回同一进行中调用均不重弹
- 双门槛防误弹：已带 `tool_result` 的历史调用不弹；仅会话 `running` 时弹（已完成/中断会话重载不误弹）
- 仅覆盖剧本/规范化两类文本生成；分镜/视频等长耗时工具已有任务队列 HUD
- 工具全限定名 `mcp__arcreel__<id>` 与 `ToolCallWithResult` 解析口径一致，名称对齐后端 `ARCREEL_MCP_TOOL_IDS`
- 通知样式选用瞬时 `pushToast`（过程性提示，无需持久回看），符合通知系统分工规则
- 提示文案 `script_generation_notice_toast` 补全 zh/en/vi 三语

## 验收标准对照

- [x] agent 调用剧本生成工具时，前端展示一条通知，告知用户该步骤耗时较长，请耐心等待
- [x] 通知样式（瞬时/持久）按通知系统分工规则选择 → 过程性提示走瞬时 toast

## 验证

- 前端 `pnpm check`（typecheck + eslint + vitest 724 通过，含新增 7 条 hook 测试覆盖去重/防误弹/三语场景）
- 后端 `ruff check` 全绿、`basedpyright` 0 error（本 PR 为纯前端改动，未触碰 Python）

Closes #354


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 添加脚本生成过程中的实时提示，在脚本生成步骤运行时通知用户该步骤耗时较长
  * 支持多语言提示信息（中文、英文、越南文）
  * 添加完整的自动化测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->