### PR TITLE
fix(dashscope): 重试按 HTTP 状态码判定，避免 4xx 业务错误被误判重试到超时

### DIFF
--- a/lib/audio_backends/dashscope.py
+++ b/lib/audio_backends/dashscope.py
@@ -20,7 +20,6 @@ from lib.audio_backends.base import (
     AudioSynthesisResult,
 )
 from lib.dashscope_shared import (
-    DASHSCOPE_RETRYABLE_ERRORS,
     dashscope_headers,
     dashscope_native_base_url,
     extract_audio_url,
@@ -30,6 +29,7 @@ from lib.dashscope_shared import (
 from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_DASHSCOPE
 from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
+from lib.video_backends.base import should_retry_download, should_retry_submit, submit_post
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +89,7 @@ class DashScopeAudioBackend:
             output_path=request.output_path,
         )
 
-    @with_retry_async(retryable_errors=DASHSCOPE_RETRYABLE_ERRORS)
+    @with_retry_async(retry_if=should_retry_submit)
     async def _request_synthesis(self, request: AudioSynthesisRequest) -> str:
         """提交合成请求（计费段），返回 output.audio.url。"""
         payload = {
@@ -112,22 +112,26 @@ class DashScopeAudioBackend:
             format_kwargs_for_log(safe_body_for_log(payload)),
         )
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
-            resp = await client.post(
-                f"{self._base_url}{_TTS_ENDPOINT}",
-                json=payload,
-                headers=dashscope_headers(self._api_key),
+            # 合成是非幂等的「计费」POST：submit_post 把歧义传输错误（请求可能已送达但响应在途丢失）
+            # 转 AmbiguousSubmitError 终态失败避免重复计费；>=400 落 body 日志 + 抛 HTTPStatusError
+            # （保留 status_code），交 should_retry_submit 按状态码分流——4xx fail-fast、5xx/429 重试。
+            resp = await submit_post(
+                lambda: client.post(
+                    f"{self._base_url}{_TTS_ENDPOINT}",
+                    json=payload,
+                    headers=dashscope_headers(self._api_key),
+                ),
+                provider=PROVIDER_DASHSCOPE,
             )
-            if resp.status_code >= 400:
-                # raise_for_status 透出 httpx.HTTPStatusError，保留 .response.status_code；
-                # body 先落日志保留可诊断性，不嵌进异常消息以免重试的子串匹配误判 4xx 可重试。
-                logger.warning("DashScope 语音合成接口返回 %s: %s", resp.status_code, resp.text[:500])
-                resp.raise_for_status()
             return extract_audio_url(resp.json())
 
     @with_retry_async(
         max_attempts=DOWNLOAD_MAX_ATTEMPTS,
         backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
-        retryable_errors=(*DASHSCOPE_RETRYABLE_ERRORS, _EmptyDownloadError),
+        # 下载是幂等 GET：HTTPStatusError 按 status_code 闸门（should_retry_download，4xx 含 404 一律
+        # fail-fast——预签发 URL 的 4xx 是确定性错误），5xx/传输/网络错误重试，业务错误 fail-fast；
+        # 200-空体（_EmptyDownloadError）属瞬态另行重试。
+        retry_if=lambda e: isinstance(e, _EmptyDownloadError) or should_retry_download(e),
     )
     async def _download_audio(self, url: str, output_path: Path) -> None:
         """下载合成音频（非计费段，可独立多次重试）。"""

--- a/lib/dashscope_shared.py
+++ b/lib/dashscope_shared.py
@@ -3,7 +3,6 @@
 供 image_backends / video_backends / text_backends factory / custom_provider / config
 复用。包含：
 - DASHSCOPE_BASE_URL — 百炼 host 段（不含路径后缀），北京地域起点
-- DASHSCOPE_RETRYABLE_ERRORS — 瞬态错误集合（网络层 + 字符串兜底覆盖 5xx/429）
 - resolve_dashscope_api_key — API Key 解析（缺失即 raise，不走 env fallback）
 - dashscope_text_base_url / dashscope_native_base_url — 由 host 派生双 base
   （文本走 /compatible-mode/v1，原生图像/视频走 /api/v1），容忍带/不带后缀
@@ -20,28 +19,20 @@ import logging
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from pathlib import Path
 
-import httpx
-
 from lib.db.repositories.usage_repo import MAX_BILLED_DURATION_SECONDS
-from lib.retry import BASE_RETRYABLE_ERRORS
 
 logger = logging.getLogger(__name__)
 
 # host 段（scheme://host），不含 /api/v1 或 /compatible-mode/v1 后缀；两 base 由此派生。
 DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com"
 
-# 故意不含 httpx.HTTPStatusError —— 这是经核实的设计决策，勿据"它不是 RequestError 子类"加入。
-#
-# HTTPStatusError 与 RequestError 同为 HTTPXError 的兄弟类（互不继承），但重试无需把它列进
-# 类型元组：with_retry_async 与 poll_with_retry 都经 lib.retry._should_retry，该函数在类型
-# 不匹配时回退到字符串匹配——HTTPStatusError 的 str() 含状态码短语（如 "Server error '503 …'"），
-# 故 429/500/502/503/504 仍被重试；而 400/401/403/404 的 str 不命中 RETRYABLE_STATUS_PATTERNS，
-# 保持快速失败。若把 HTTPStatusError 直接加进本元组，isinstance 会对全部 4xx 也判 True →
-# 鉴权/参数等业务错误被重试到超时，反而破坏 fail-fast。此为全仓后端一致约定。
-DASHSCOPE_RETRYABLE_ERRORS: tuple[type[Exception], ...] = (
-    *BASE_RETRYABLE_ERRORS,
-    httpx.RequestError,
-)
+# 重试判定不再用「瞬态错误类型元组 + 字符串兜底」：HTTPStatusError 的 str() 携带 URL/task_id，
+# 其中的 "503"/"timeout" 子串会让 4xx 业务错误被误判为可重试。各 DashScope 后端改用
+# lib.video_backends.base 的状态码谓词——创建/提交（非幂等 POST）走 should_retry_submit（4xx
+# fail-fast、5xx/429 重试、歧义传输错误经 submit_post 转 AmbiguousSubmitError 不重试），轮询
+# （幂等 GET）走 should_retry_poll（404 视为未就绪重试），下载已签发结果 URL 走 should_retry_download
+# （4xx 含 404 一律 fail-fast）。HTTPStatusError 一律按 response.status_code 显式闸门判定，状态码
+# 语义也因此被保留，供咽喉层识别 413 做降档兜底。
 
 # 任务状态机（图像/视频异步两步式）
 DASHSCOPE_STATUS_PENDING = "PENDING"

--- a/lib/image_backends/dashscope.py
+++ b/lib/image_backends/dashscope.py
@@ -14,7 +14,6 @@ import httpx
 
 from lib.aspect_size import IMAGE_TIER_SHORT_EDGE, aspect_size, resolution_to_short_edge
 from lib.dashscope_shared import (
-    DASHSCOPE_RETRYABLE_ERRORS,
     dashscope_headers,
     dashscope_native_base_url,
     extract_image_url,
@@ -32,6 +31,7 @@ from lib.image_backends.base import (
 from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_DASHSCOPE
 from lib.retry import with_retry_async
+from lib.video_backends.base import should_retry_submit, submit_post
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +131,7 @@ class DashScopeImageBackend:
     def _ref_limit(self) -> int:
         return _WAN_REF_LIMIT if self._is_wan else _QWEN_REF_LIMIT
 
-    @with_retry_async(retryable_errors=DASHSCOPE_RETRYABLE_ERRORS)
+    @with_retry_async(retry_if=should_retry_submit)
     async def generate(self, request: ImageGenerationRequest) -> ImageGenerationResult:
         has_refs = bool(request.reference_images)
         if has_refs and ImageCapability.IMAGE_TO_IMAGE not in self._capabilities:
@@ -165,16 +165,18 @@ class DashScopeImageBackend:
             format_kwargs_for_log(safe_body_for_log(payload)),
         )
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
-            resp = await client.post(
-                f"{self._base_url}{_IMAGE_ENDPOINT}",
-                json=payload,
-                headers=dashscope_headers(self._api_key),
+            # 同步图像生成是非幂等的「建图 + 计费」POST：submit_post 把歧义传输错误（请求可能已送达
+            # 但响应在途丢失）转 AmbiguousSubmitError 终态失败，避免自动重试重复计费；>=400 落 body
+            # 日志 + 抛 HTTPStatusError（保留 status_code 供咽喉层识别 413 降档），交 should_retry_submit
+            # 按状态码分流——4xx fail-fast、5xx/429 重试。
+            resp = await submit_post(
+                lambda: client.post(
+                    f"{self._base_url}{_IMAGE_ENDPOINT}",
+                    json=payload,
+                    headers=dashscope_headers(self._api_key),
+                ),
+                provider=PROVIDER_DASHSCOPE,
             )
-            if resp.status_code >= 400:
-                # raise_for_status 透出 httpx.HTTPStatusError，保留 .response.status_code，
-                # 让咽喉层能识别 413 走降档重试；body 先落日志保留可诊断性。
-                logger.warning("DashScope 图像接口返回 %s: %s", resp.status_code, resp.text[:500])
-                resp.raise_for_status()
             data = resp.json()
 
         url = extract_image_url(data)

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -213,6 +213,22 @@ def should_retry_poll(exc: Exception) -> bool:
     return isinstance(exc, (httpx.RequestError, *BASE_RETRYABLE_ERRORS))
 
 
+def should_retry_download(exc: Exception) -> bool:
+    """下载阶段（幂等 GET 取 provider 任务成功后签发的结果 URL）重试谓词。
+
+    与 ``should_retry_poll`` 的唯一区别在 404：下载 URL 由 provider 直接签发，4xx（404 不存在 /
+    403 过期 / 413 等）是确定性错误，重试到 max 也不会变好，故 ``retry_not_found=False`` 让 404
+    随其余 4xx 一并 fail-fast（轮询的 404 才是"任务短暂未就绪"该重试）。5xx/408/425/429 与传输/
+    网络错误（幂等 GET 重试无副作用）重试。HTTPStatusError 按 status_code 显式闸门，绕开字符串
+    兜底对结果 URL 中 "503"/"timeout" 等子串的误判。
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        return is_retryable_http_status(exc.response.status_code, retry_not_found=False)
+    if isinstance(exc, _NON_RETRYABLE_LOCAL_ERRORS):
+        return False
+    return isinstance(exc, (httpx.RequestError, *BASE_RETRYABLE_ERRORS))
+
+
 async def submit_post(
     post_fn: Callable[[], Awaitable[httpx.Response]],
     *,

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -17,7 +17,6 @@ import httpx
 
 from lib.dashscope_shared import (
     DASHSCOPE_POLL_INTERVAL_SECONDS,
-    DASHSCOPE_RETRYABLE_ERRORS,
     dashscope_failure_reason,
     dashscope_headers,
     dashscope_native_base_url,
@@ -49,6 +48,10 @@ from lib.video_backends.base import (
     download_video,
     persist_provider_job_id,
     poll_with_retry,
+    should_retry_download,
+    should_retry_poll,
+    should_retry_submit,
+    submit_post,
 )
 
 logger = logging.getLogger(__name__)
@@ -266,19 +269,21 @@ class DashScopeVideoBackend:
     @with_retry_async(
         max_attempts=DEFAULT_MAX_ATTEMPTS,
         backoff_seconds=DEFAULT_BACKOFF_SECONDS,
-        retryable_errors=DASHSCOPE_RETRYABLE_ERRORS,
+        retry_if=should_retry_submit,
     )
     async def _create_task(self, client: httpx.AsyncClient, payload: dict) -> str:
-        resp = await client.post(
-            f"{self._base_url}{_VIDEO_ENDPOINT}",
-            json=payload,
-            headers=dashscope_headers(self._api_key, async_mode=True),
+        # 创建任务是非幂等的「建任务 + 计费」POST：submit_post 把歧义传输错误（请求可能已送达
+        # 服务端但响应在途丢失）转 AmbiguousSubmitError 终态失败，避免自动重试重复建任务 + 重复计费；
+        # >=400 由其落 body 日志 + raise_for_status 抛 HTTPStatusError（保留 status_code 供咽喉层识别
+        # 413 降档），交 should_retry_submit 按状态码分流——4xx fail-fast、5xx/429 重试。
+        resp = await submit_post(
+            lambda: client.post(
+                f"{self._base_url}{_VIDEO_ENDPOINT}",
+                json=payload,
+                headers=dashscope_headers(self._api_key, async_mode=True),
+            ),
+            provider=PROVIDER_DASHSCOPE,
         )
-        if resp.status_code >= 400:
-            # raise_for_status 透出 httpx.HTTPStatusError，保留 .response.status_code，
-            # 让咽喉层能识别 413 走降档重试；body 先落日志保留可诊断性。
-            logger.warning("DashScope 视频提交返回 %s: %s", resp.status_code, resp.text[:500])
-            resp.raise_for_status()
         return extract_task_id(resp.json())
 
     async def _poll_once(self, client: httpx.AsyncClient, task_id: str) -> dict:
@@ -314,7 +319,7 @@ class DashScopeVideoBackend:
             is_failed=dashscope_failure_reason,
             poll_interval=DASHSCOPE_POLL_INTERVAL_SECONDS,
             max_wait=self._max_wait(request.duration_seconds),
-            retryable_errors=DASHSCOPE_RETRYABLE_ERRORS,
+            retry_if=should_retry_poll,
             label="DashScope",
             on_progress=lambda v, elapsed: logger.info(
                 "DashScope 视频生成中... status=%s elapsed=%ds",
@@ -352,7 +357,7 @@ class DashScopeVideoBackend:
     @with_retry_async(
         max_attempts=DOWNLOAD_MAX_ATTEMPTS,
         backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
-        retryable_errors=DASHSCOPE_RETRYABLE_ERRORS,
+        retry_if=should_retry_download,
     )
     async def _download_with_retry(video_url: str, output_path: Path) -> None:
         await download_video(video_url, output_path)

--- a/tests/test_audio_backends.py
+++ b/tests/test_audio_backends.py
@@ -155,6 +155,26 @@ class TestDashScopeAudioBackend:
         assert client.post.call_count == 1
         client.get.assert_not_called()
 
+    async def test_submit_4xx_with_transient_substring_no_retry(self, tmp_path: Path, monkeypatch):
+        # 4xx 错误消息带 "503" 子串（请求 URL/task_id）：旧字符串兜底会据此误判重试到超时，
+        # 新状态码谓词只读 response.status_code，按 400 fail-fast——计费的合成 POST 只发一次、不连带下载。
+        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
+        err_resp = httpx.Response(
+            400, text="bad request", request=httpx.Request("POST", "https://x/api/v1/tasks/job-503")
+        )
+        client = _mock_client(err_resp, _download_response())
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.dashscope import DashScopeAudioBackend
+
+            b = DashScopeAudioBackend(api_key="sk")
+            with pytest.raises(httpx.HTTPStatusError) as ei:
+                await b.synthesize(AudioSynthesisRequest(text="x", output_path=tmp_path / "e.wav", voice="Cherry"))
+        # 异常字符串确实带瞬态子串（旧兜底据此误判重试的前提）；新谓词按状态码单次 fail-fast
+        assert "503" in str(ei.value)
+        assert ei.value.response.status_code == 400
+        assert client.post.call_count == 1
+        client.get.assert_not_called()
+
     async def test_download_failure_does_not_rebill_synthesis(self, tmp_path: Path, monkeypatch):
         # 下载瞬时失败只重试 GET，绝不回头重跑会再次计费的合成 POST。
         monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())

--- a/tests/test_audio_backends.py
+++ b/tests/test_audio_backends.py
@@ -142,7 +142,7 @@ class TestDashScopeAudioBackend:
         assert "speech_rate" not in body["input"]
 
     async def test_http_error_raises(self, tmp_path: Path):
-        # 4xx 透出 httpx.HTTPStatusError（与其余 backend 一致），不嵌响应体进异常消息
+        # 4xx 透出 httpx.HTTPStatusError（与其余 backend 一致），不嵌响应体进异常消息；提交按状态码不可重试
         err_resp = httpx.Response(400, text="bad request", request=httpx.Request("POST", "https://x"))
         client = _mock_client(err_resp, _download_response())
         with patch("httpx.AsyncClient", return_value=client):
@@ -151,6 +151,9 @@ class TestDashScopeAudioBackend:
             b = DashScopeAudioBackend(api_key="sk")
             with pytest.raises(httpx.HTTPStatusError):
                 await b.synthesize(AudioSynthesisRequest(text="x", output_path=tmp_path / "e.wav", voice="Cherry"))
+        # 4xx 按 status_code fail-fast：计费的合成 POST 只发一次、不连带触发下载
+        assert client.post.call_count == 1
+        client.get.assert_not_called()
 
     async def test_download_failure_does_not_rebill_synthesis(self, tmp_path: Path, monkeypatch):
         # 下载瞬时失败只重试 GET，绝不回头重跑会再次计费的合成 POST。

--- a/tests/test_dashscope_image_backend.py
+++ b/tests/test_dashscope_image_backend.py
@@ -443,8 +443,9 @@ class TestErrorResponse:
             b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0")
             with pytest.raises(httpx.HTTPStatusError) as ei:
                 await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
-        # raise_for_status 透出保留状态码（#701：4xx fail-fast，不再吞成无状态码的 RuntimeError）
+        # raise_for_status 透出保留状态码：4xx fail-fast，不再吞成无状态码的 RuntimeError
         assert ei.value.response.status_code == 400
+        assert client.post.call_count == 1
         download.assert_not_called()
 
     async def test_413_surfaces_httpstatuserror_no_retry(self, tmp_path: Path):

--- a/tests/test_dashscope_image_backend.py
+++ b/tests/test_dashscope_image_backend.py
@@ -52,6 +52,21 @@ def _error_response(status_code: int) -> MagicMock:
     return resp
 
 
+def _http_error_transient_substring(status_code: int) -> httpx.HTTPStatusError:
+    """状态码为 status_code 但 str() 含 "503" 子串（请求 URL/task_id）的真实 HTTPStatusError。
+
+    raise_for_status 的消息携带请求 URL，旧字符串兜底会据此误判重试；状态码谓词只读
+    response.status_code，不受 URL/消息里的瞬态子串影响。
+    """
+    request = httpx.Request("POST", "https://x/api/v1/tasks/job-503")
+    response = httpx.Response(status_code, request=request)
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        return exc
+    raise AssertionError("unreachable")
+
+
 def _patches(client: AsyncMock, download: AsyncMock):
     return (
         patch("httpx.AsyncClient", return_value=client),
@@ -444,6 +459,28 @@ class TestErrorResponse:
             with pytest.raises(httpx.HTTPStatusError) as ei:
                 await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
         # raise_for_status 透出保留状态码：4xx fail-fast，不再吞成无状态码的 RuntimeError
+        assert ei.value.response.status_code == 400
+        assert client.post.call_count == 1
+        download.assert_not_called()
+
+    async def test_submit_4xx_with_transient_substring_no_retry(self, tmp_path: Path, monkeypatch):
+        # 4xx 错误消息带 "503" 子串（请求 URL/task_id）：旧字符串兜底会据此误判重试到超时，
+        # 新状态码谓词只读 response.status_code，按 400 fail-fast——计费的建图 POST 只发一次、不连带下载。
+        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
+        resp = MagicMock()
+        resp.status_code = 400
+        resp.raise_for_status = MagicMock(side_effect=_http_error_transient_substring(400))
+        client = _mock_client(resp)
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.dashscope import DashScopeImageBackend
+
+            b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0")
+            with pytest.raises(httpx.HTTPStatusError) as ei:
+                await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
+        # 异常字符串确实带瞬态子串（旧兜底据此误判重试的前提）；新谓词按状态码单次 fail-fast
+        assert "503" in str(ei.value)
         assert ei.value.response.status_code == 400
         assert client.post.call_count == 1
         download.assert_not_called()

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -31,6 +31,21 @@ def _http_error(status_code: int, message: str) -> httpx.HTTPStatusError:
     return httpx.HTTPStatusError(f"error {status_code}", request=request, response=response)
 
 
+def _http_error_503_in_message(status_code: int) -> httpx.HTTPStatusError:
+    """生成 str() 含 "503" 子串、但状态码为 status_code 的真实 HTTPStatusError。
+
+    raise_for_status 的消息包含请求 URL（这里 task_id 带 "503"），旧字符串兜底会据此误判重试；
+    状态码谓词只读 response.status_code，不受 URL/消息中瞬态子串影响。
+    """
+    request = httpx.Request("POST", "https://x/api/v1/tasks/job-503-xyz")
+    response = httpx.Response(status_code, request=request)
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        return exc
+    raise AssertionError("expected HTTPStatusError")  # pragma: no cover
+
+
 def _submit(task_id: str = "t-1") -> dict:
     return {"output": {"task_id": task_id, "task_status": "PENDING"}}
 
@@ -506,3 +521,75 @@ class TestSubmit413:
         assert ei.value.response.status_code == 413
         assert post.call_count == 1
         download.assert_not_called()
+
+
+class TestRetryStatusGating:
+    """提交/轮询按 HTTP status_code 决定重试，消除字符串子串误判。"""
+
+    async def test_submit_4xx_with_503_substring_no_retry(self, tmp_path: Path):
+        # 4xx 错误消息里带 "503" 子串（URL/task_id）：旧字符串兜底会误判重试，新谓词按 400 fail-fast。
+        err = _http_error_503_in_message(400)
+        assert "503" in str(err)
+        bad = _resp({"code": "InvalidParameter"}, status_code=400)
+        bad.raise_for_status = MagicMock(side_effect=err)
+        post = AsyncMock(return_value=bad)
+        client = _client(post=post)
+        p1, p2, p3 = _patches(client, AsyncMock())
+        with p1, p2, p3, patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
+            from lib.video_backends.dashscope import DashScopeVideoBackend
+
+            b = DashScopeVideoBackend(api_key="sk", model="wan2.7-t2v")
+            with pytest.raises(httpx.HTTPStatusError) as ei:
+                await b.generate(VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="720p"))
+        assert ei.value.response.status_code == 400
+        assert post.call_count == 1
+
+    async def test_submit_real_503_retries_then_succeeds(self, tmp_path: Path):
+        # 真 5xx：按 status_code 重试，第三次成功。
+        err503 = _resp({"code": "ServiceUnavailable"}, status_code=503)
+        err503.raise_for_status = MagicMock(side_effect=_http_error_503_in_message(503))
+        post = AsyncMock(side_effect=[err503, err503, _resp(_submit("t-ok"))])
+        get = AsyncMock(return_value=_resp(_succeeded()))
+        client = _client(post=post, get=get)
+        p1, p2, p3 = _patches(client, AsyncMock())
+        with p1, p2, p3, patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
+            from lib.video_backends.dashscope import DashScopeVideoBackend
+
+            b = DashScopeVideoBackend(api_key="sk", model="happyhorse-1.0-t2v")
+            result = await b.generate(
+                VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="720p")
+            )
+        assert post.call_count == 3
+        assert result.task_id == "t-ok"
+
+    async def test_submit_connect_error_retries(self, tmp_path: Path):
+        # 网络层错误（连接确定未送达）维持重试。
+        post = AsyncMock(side_effect=[httpx.ConnectError("refused"), _resp(_submit("t-ok"))])
+        get = AsyncMock(return_value=_resp(_succeeded()))
+        client = _client(post=post, get=get)
+        p1, p2, p3 = _patches(client, AsyncMock())
+        with p1, p2, p3, patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
+            from lib.video_backends.dashscope import DashScopeVideoBackend
+
+            b = DashScopeVideoBackend(api_key="sk", model="happyhorse-1.0-t2v")
+            result = await b.generate(
+                VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="720p")
+            )
+        assert post.call_count == 2
+        assert result.task_id == "t-ok"
+
+    async def test_poll_timeout_retries(self, tmp_path: Path):
+        # 轮询（幂等 GET）网络层 Timeout 维持重试。
+        post = AsyncMock(return_value=_resp(_submit("t-poll")))
+        get = AsyncMock(side_effect=[httpx.TimeoutException("read timed out"), _resp(_succeeded())])
+        client = _client(post=post, get=get)
+        p1, p2, p3 = _patches(client, AsyncMock())
+        with p1, p2, p3:
+            from lib.video_backends.dashscope import DashScopeVideoBackend
+
+            b = DashScopeVideoBackend(api_key="sk", model="happyhorse-1.0-i2v")
+            result = await b.generate(
+                VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="720p")
+            )
+        assert get.call_count == 2
+        assert result.task_id == "t-poll"

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -16,6 +16,7 @@ from lib.video_backends.base import (
     persist_api_call_id,
     persist_provider_job_id,
     poll_with_retry,
+    should_retry_download,
     should_retry_poll,
     should_retry_submit,
     submit_post,
@@ -359,6 +360,36 @@ class TestRetryPredicates:
         # 普通异常即便消息含状态码子串也不重试（绕开字符串误判）。
         assert should_retry_poll(ValueError("503 in message")) is False
         assert should_retry_submit(RuntimeError("got 500 somewhere")) is False
+
+
+class TestShouldRetryDownload:
+    """should_retry_download 下载阶段谓词：4xx（含 404）fail-fast、5xx/传输错误重试。"""
+
+    def test_all_4xx_including_404_fail_fast(self):
+        # 预签发的结果 URL 4xx 是确定性错误：与 poll 不同，404 也 fail-fast。
+        for code in (400, 401, 403, 404, 413, 422):
+            assert should_retry_download(_http_status_error(code)) is False
+
+    def test_transient_http_retries(self):
+        for code in (408, 425, 429, 500, 502, 503, 504):
+            assert should_retry_download(_http_status_error(code)) is True
+
+    def test_retries_all_transport_errors(self):
+        # 幂等 GET 下载：连接建立失败与读阶段错误一律重试（与 poll 一致，无重复计费风险）。
+        for exc in (
+            httpx.ConnectError("refused"),
+            httpx.ReadTimeout("read timed out"),
+            httpx.RemoteProtocolError("server disconnected"),
+            ConnectionError(),
+            TimeoutError(),
+        ):
+            assert should_retry_download(exc) is True
+
+    def test_local_protocol_errors_and_business_exceptions_fail_fast(self):
+        assert should_retry_download(httpx.UnsupportedProtocol("scheme")) is False
+        assert should_retry_download(httpx.LocalProtocolError("bad")) is False
+        # 普通异常即便消息含状态码子串也不重试（绕开字符串误判）。
+        assert should_retry_download(ValueError("503 in message")) is False
 
 
 class TestSubmitPost:


### PR DESCRIPTION
## 问题

DashScope 各后端（视频/图像/语音）此前对 `httpx.HTTPStatusError` 走「可重试错误类型元组 + 字符串子串兜底」判定是否重试。子串匹配作用于整个 `str(exc)`，而异常消息携带请求 URL / task_id / 响应体，其中若含 `503`/`timeout` 等子串，会把鉴权/参数等确定性 4xx 业务错误误判为可重试，重试到超时白占额度；反向非常规 5xx 文案也可能漏重试。AI reviewer 在 PR #690 多轮提出该脆弱点。

## 修复

三个后端的重试判定改为复用已合入 main 的 `lib/video_backends/base.py` 状态码谓词，按 `HTTPStatusError.response.status_code` 显式闸门，绕开字符串子串误判：

- **创建/提交**（非幂等的「建任务 + 计费」POST）走 `submit_post` + `should_retry_submit`：歧义传输错误（请求可能已送达但响应在途丢失）转 `AmbiguousSubmitError` 终态失败避免重复计费；4xx fail-fast、5xx/429 重试。
- **轮询**（幂等 GET）走 `should_retry_poll`（404 视为任务短暂未就绪重试）。
- **下载**已签发结果 URL 走新增谓词 `should_retry_download`：与 `should_retry_poll` 唯一区别在 404——预签发 URL 的 4xx（含 404）是确定性错误，`retry_not_found=False` 让其随其余 4xx 一并 fail-fast；5xx/传输错误重试。

`HTTPStatusError` 状态码语义全程保留，供咽喉层识别 413 做参考图降档兜底（与 #743 的 413 降档天然无冲突）。移除 `dashscope_shared` 中已无引用的 `DASHSCOPE_RETRYABLE_ERRORS` 及其字符串兜底设计注释。

## 范围取舍

- **vidu / ark / newapi 等共享同一字符串兜底的其它后端**：本 PR 未动，避免扩大 blast radius；vidu 另与 #743 参考图压缩协调，单列跟进。
- **图像下载**仍内嵌在计费的 `generate()` 内（沿用既有结构，本 PR 未重构）：下载瞬态失败仍会连带重跑 POST，属预先存在行为，本次仅收敛其误判面而非扩大，可后续独立 PR 拆分（对齐音频/视频已有的提交↔下载分离）。

## 验证

- 新增 `should_retry_download` 谓词单测（`tests/test_video_backend_base.py`）：4xx 含 404 fail-fast、5xx/传输错误重试、本地协议/业务异常 fail-fast；并对照 `should_retry_poll` 的 404 重试差异。
- 视频提交/轮询状态码门控验收（`tests/test_dashscope_video_backend.py`）：「4xx 且消息含 `503` 子串 → 不重试」「真 503 → 重试后成功」「ConnectError → 重试」「轮询 Timeout → 重试」。
- 补强音频/图像提交路径回归断言：4xx 提交按状态码 fail-fast，计费 POST 仅发一次。
- 质量门全绿：`pytest` 全量 4685 passed；`ruff check/format`、`basedpyright` 0 error。

Closes #701


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化 DashScope 后端的重试判定，精准区分可重试与不可重试场景，避免因错误消息中包含瞬态子串（如“503”）导致误重试或重复提交/计费。
  * 强化 4xx 快速失败行为，减少不必要的网络重试。

* **Tests**
  * 扩展测试覆盖，验证提交/轮询/下载各阶段的重试门控与异常透出行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->