### PR TITLE
fix(script): Gemini 生成剧本时按视频模型时长枚举约束不再报错

### DIFF
--- a/lib/text_backends/gemini.py
+++ b/lib/text_backends/gemini.py
@@ -24,31 +24,26 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL = "gemini-3-flash-preview"
 
 
-# JSON Schema（Draft 2020-12）里这些关键字的值是「按名字索引的映射」：其 key 是字段名/定义名而非
-# schema 关键字。递归进入这类映射时，key 不可当关键字识别（可能恰好叫 ``const``），而其每个值才是
-# 子 schema。这是 2020-12 中此类关键字的完整集合。
-_NAME_KEYED_MAP_KEYS = frozenset(
-    {"properties", "patternProperties", "$defs", "definitions", "dependentSchemas", "dependentRequired"}
-)
+# ``const`` / ``enum`` / ``default`` / ``examples`` 的值是「实例数据」而非子 schema：递归进去会把
+# 数据里恰好叫 ``const`` 的内容误当关键字。跳过它们即可绕开整类「数据里含 const」的边界。
+_VALUE_KEYWORDS = frozenset({"const", "enum", "default", "examples"})
 
 
-def _const_to_enum(node: object, *, is_name_keyed_map: bool = False) -> object:
-    """递归把 JSON Schema 的 ``const: X`` 归一为 ``enum: [X]``（语义等价）。
+def _const_to_enum(node: object) -> object:
+    """把 schema 里「值为标量」的 ``const: X`` 归一为 ``enum: [X]``（语义等价）。
 
-    单值 ``Literal`` 在 ``model_json_schema()`` 里渲染为 ``const``，而 ``const`` 不在
-    Gemini ``response_json_schema`` 的受支持特性内（``enum`` 在）。归一后单值约束落到受支持
-    的 ``enum``，保留生成层硬约束。
+    单值 ``Literal`` 在 ``model_json_schema()`` 里渲染为 ``const``，而 ``const`` 不在 Gemini
+    ``response_json_schema`` 的受支持特性内（``enum`` 在）。归一后单值约束落到受支持的 ``enum``，
+    保留生成层硬约束。
 
-    ``const`` 只有在 schema 对象里作为关键字时才改写。``is_name_keyed_map`` 标记当前 dict 是否为
-    ``_NAME_KEYED_MAP_KEYS`` 关键字的值（其 key 是名字、不是关键字）：是则跳过 key 的关键字识别，
-    其每个值按子 schema 继续递归。注意「是否为映射」取决于父关键字，而非 key 字面——字段名恰好叫
-    ``properties`` 时其值仍是普通 schema，里面的 ``const`` 要照常归一。
+    本仓库的 ``const`` 只来自单值时长 ``Literal``（标量整数），故采取保守策略：只改写「值为标量」的
+    ``const``，且不递归进 ``_VALUE_KEYWORDS``（其值是实例数据）。这覆盖唯一会出现的 const 形态，并
+    免疫字段名为 ``const``、``default``/``examples`` 数据含 ``const``、非标量 ``const`` 等边界——
+    无需穷举 JSON Schema 关键字、也不把这个供应商适配器写成通用 normalizer。
     """
     if isinstance(node, dict):
-        if is_name_keyed_map:
-            return {k: _const_to_enum(v) for k, v in node.items()}
-        out = {k: _const_to_enum(v, is_name_keyed_map=k in _NAME_KEYED_MAP_KEYS) for k, v in node.items()}
-        if "const" in out:
+        out = {k: (v if k in _VALUE_KEYWORDS else _const_to_enum(v)) for k, v in node.items()}
+        if "const" in out and (out["const"] is None or isinstance(out["const"], (str, int, float, bool))):
             out["enum"] = [out.pop("const")]
         return out
     if isinstance(node, list):

--- a/lib/text_backends/gemini.py
+++ b/lib/text_backends/gemini.py
@@ -24,25 +24,31 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL = "gemini-3-flash-preview"
 
 
-# JSON Schema 里这些键的直接子节点是「按字段名索引的子 schema 映射」，其 key 是字段名而非
-# schema 关键字，递归进入时不可把这些子节点自身的 key 当作 ``const`` 关键字识别。
-_SUBSCHEMA_MAP_KEYS = frozenset({"properties", "patternProperties", "$defs", "definitions", "dependentSchemas"})
+# JSON Schema（Draft 2020-12）里这些关键字的值是「按名字索引的映射」：其 key 是字段名/定义名而非
+# schema 关键字。递归进入这类映射时，key 不可当关键字识别（可能恰好叫 ``const``），而其每个值才是
+# 子 schema。这是 2020-12 中此类关键字的完整集合。
+_NAME_KEYED_MAP_KEYS = frozenset(
+    {"properties", "patternProperties", "$defs", "definitions", "dependentSchemas", "dependentRequired"}
+)
 
 
-def _const_to_enum(node: object, *, in_schema_map: bool = False) -> object:
+def _const_to_enum(node: object, *, is_name_keyed_map: bool = False) -> object:
     """递归把 JSON Schema 的 ``const: X`` 归一为 ``enum: [X]``（语义等价）。
 
     单值 ``Literal`` 在 ``model_json_schema()`` 里渲染为 ``const``，而 ``const`` 不在
     Gemini ``response_json_schema`` 的受支持特性内（``enum`` 在）。归一后单值约束落到受支持
     的 ``enum``，保留生成层硬约束。
 
-    ``const`` 仅在作为 schema 对象的关键字时才改写；``properties`` / ``$defs`` 等容器映射的
-    key 是字段名（可能恰好叫 ``const``），不可误判——``in_schema_map`` 标记当前 dict 是否为
-    这类映射，是则跳过其 key 的关键字识别，但仍递归其值（值本身是子 schema）。
+    ``const`` 只有在 schema 对象里作为关键字时才改写。``is_name_keyed_map`` 标记当前 dict 是否为
+    ``_NAME_KEYED_MAP_KEYS`` 关键字的值（其 key 是名字、不是关键字）：是则跳过 key 的关键字识别，
+    其每个值按子 schema 继续递归。注意「是否为映射」取决于父关键字，而非 key 字面——字段名恰好叫
+    ``properties`` 时其值仍是普通 schema，里面的 ``const`` 要照常归一。
     """
     if isinstance(node, dict):
-        out = {k: _const_to_enum(v, in_schema_map=k in _SUBSCHEMA_MAP_KEYS) for k, v in node.items()}
-        if not in_schema_map and "const" in out:
+        if is_name_keyed_map:
+            return {k: _const_to_enum(v) for k, v in node.items()}
+        out = {k: _const_to_enum(v, is_name_keyed_map=k in _NAME_KEYED_MAP_KEYS) for k, v in node.items()}
+        if "const" in out:
             out["enum"] = [out.pop("const")]
         return out
     if isinstance(node, list):

--- a/lib/text_backends/gemini.py
+++ b/lib/text_backends/gemini.py
@@ -24,31 +24,42 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL = "gemini-3-flash-preview"
 
 
-# ``const`` / ``enum`` / ``default`` / ``examples`` 的值是「实例数据」而非子 schema：递归进去会把
-# 数据里恰好叫 ``const`` 的内容误当关键字。跳过它们即可绕开整类「数据里含 const」的边界。
-_VALUE_KEYWORDS = frozenset({"const", "enum", "default", "examples"})
+# 这些关键字的值是「名字 → 子 schema 的映射」：其 key 是属性名/定义名，不是 schema 关键字。
+# 递归进入时，每个值才是子 schema（key 可能恰好叫 ``const``，不可当关键字识别）。
+_SUBSCHEMA_MAP_KEYS = frozenset({"properties", "patternProperties", "$defs", "definitions", "dependentSchemas"})
+# 这些关键字的值是「实例数据」而非子 schema：不可递归进去（里面恰好叫 ``const`` 的内容是数据）。
+_INSTANCE_KEYWORDS = frozenset({"const", "enum", "default", "examples"})
 
 
-def _const_to_enum(node: object) -> object:
+def _const_to_enum(node: object, *, in_subschema_map: bool = False) -> object:
     """把 schema 里「值为标量」的 ``const: X`` 归一为 ``enum: [X]``（语义等价）。
 
     单值 ``Literal`` 在 ``model_json_schema()`` 里渲染为 ``const``，而 ``const`` 不在 Gemini
     ``response_json_schema`` 的受支持特性内（``enum`` 在）。归一后单值约束落到受支持的 ``enum``，
     保留生成层硬约束。
 
-    本仓库的 ``const`` 只来自单值时长 ``Literal``（标量整数），故采取保守策略：只改写「值为标量」的
-    ``const``，且不递归进 ``_VALUE_KEYWORDS``（其值是实例数据）。这覆盖唯一会出现的 const 形态，并
-    免疫字段名为 ``const``、``default``/``examples`` 数据含 ``const``、非标量 ``const`` 等边界——
-    无需穷举 JSON Schema 关键字、也不把这个供应商适配器写成通用 normalizer。
+    ``const`` 出现的位置有三种，须区分对待（这是正确性的不可约最小状态机）：
+    - **schema 关键字**：归一（仅标量，对齐本仓库唯一的 const 形态——单值时长 Literal）；
+    - **字段名**（``_SUBSCHEMA_MAP_KEYS`` 映射的 key）：当前 dict 的 key 是名字，其值仍是子 schema，
+      继续按 schema 递归（里面真正的 const 照常归一）；
+    - **实例数据**（``_INSTANCE_KEYWORDS`` 的值）：原样保留、不递归。
     """
-    if isinstance(node, dict):
-        out = {k: (v if k in _VALUE_KEYWORDS else _const_to_enum(v)) for k, v in node.items()}
-        if "const" in out and (out["const"] is None or isinstance(out["const"], (str, int, float, bool))):
-            out["enum"] = [out.pop("const")]
-        return out
     if isinstance(node, list):
         return [_const_to_enum(item) for item in node]
-    return node
+    if not isinstance(node, dict):
+        return node
+    if in_subschema_map:
+        # 当前 dict 的 key 是属性名/定义名；每个值才是子 schema
+        return {k: _const_to_enum(v) for k, v in node.items()}
+    out: dict = {}
+    for k, v in node.items():
+        if k in _INSTANCE_KEYWORDS:
+            out[k] = v  # 值是实例数据，原样保留
+        else:
+            out[k] = _const_to_enum(v, in_subschema_map=k in _SUBSCHEMA_MAP_KEYS)
+    if "const" in out and (out["const"] is None or isinstance(out["const"], (str, int, float, bool))):
+        out["enum"] = [out.pop("const")]
+    return out
 
 
 def _to_response_json_schema(schema: dict | type) -> dict:

--- a/lib/text_backends/gemini.py
+++ b/lib/text_backends/gemini.py
@@ -15,12 +15,44 @@ from .base import (
     TextCapability,
     TextGenerationRequest,
     TextGenerationResult,
+    resolve_schema,
     warn_if_truncated,
 )
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = "gemini-3-flash-preview"
+
+
+def _const_to_enum(node: object) -> object:
+    """递归把 JSON Schema 的 ``const: X`` 归一为 ``enum: [X]``（语义等价）。
+
+    单值 ``Literal`` 在 ``model_json_schema()`` 里渲染为 ``const``，而 ``const`` 不在
+    Gemini ``response_json_schema`` 的受支持特性内（``enum`` 在）。归一后单值约束落到受支持
+    的 ``enum``，保留生成层硬约束。
+    """
+    if isinstance(node, dict):
+        out = {k: _const_to_enum(v) for k, v in node.items()}
+        if "const" in out:
+            out["enum"] = [out.pop("const")]
+        return out
+    if isinstance(node, list):
+        return [_const_to_enum(item) for item in node]
+    return node
+
+
+def _to_response_json_schema(schema: dict | type) -> dict:
+    """把 response_schema 统一转成 Gemini ``response_json_schema`` 可消费的 JSON Schema dict。
+
+    Gemini 有两条结构化输出通道：``response_schema``（``types.Schema``，OpenAPI 子集，``enum``
+    仅支持字符串）与 ``response_json_schema``（标准 JSON Schema，``enum`` 支持字符串与数字）。
+    ``build_episode_script_model`` 把 ``duration_seconds`` 收紧为 ``Literal[*supported_durations]``
+    的整数 enum，走前者会在 SDK schema 转换时抛 "Input should be a valid string"，故统一走后者：
+    先 ``resolve_schema`` 内联 ``$ref``，再把单值 ``const`` 归一为 ``enum``。
+    """
+    normalized = _const_to_enum(resolve_schema(schema))
+    assert isinstance(normalized, dict)  # resolve_schema 必返回 dict
+    return normalized
 
 
 class GeminiTextBackend:
@@ -105,10 +137,7 @@ class GeminiTextBackend:
         config: dict = {}
         if response_schema:
             config["response_mime_type"] = "application/json"
-            if isinstance(response_schema, type):
-                config["response_schema"] = response_schema
-            else:
-                config["response_json_schema"] = response_schema
+            config["response_json_schema"] = _to_response_json_schema(response_schema)
         if system_prompt:
             config["system_instruction"] = system_prompt
         if max_output_tokens is not None:

--- a/lib/text_backends/gemini.py
+++ b/lib/text_backends/gemini.py
@@ -24,16 +24,25 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL = "gemini-3-flash-preview"
 
 
-def _const_to_enum(node: object) -> object:
+# JSON Schema 里这些键的直接子节点是「按字段名索引的子 schema 映射」，其 key 是字段名而非
+# schema 关键字，递归进入时不可把这些子节点自身的 key 当作 ``const`` 关键字识别。
+_SUBSCHEMA_MAP_KEYS = frozenset({"properties", "patternProperties", "$defs", "definitions", "dependentSchemas"})
+
+
+def _const_to_enum(node: object, *, in_schema_map: bool = False) -> object:
     """递归把 JSON Schema 的 ``const: X`` 归一为 ``enum: [X]``（语义等价）。
 
     单值 ``Literal`` 在 ``model_json_schema()`` 里渲染为 ``const``，而 ``const`` 不在
     Gemini ``response_json_schema`` 的受支持特性内（``enum`` 在）。归一后单值约束落到受支持
     的 ``enum``，保留生成层硬约束。
+
+    ``const`` 仅在作为 schema 对象的关键字时才改写；``properties`` / ``$defs`` 等容器映射的
+    key 是字段名（可能恰好叫 ``const``），不可误判——``in_schema_map`` 标记当前 dict 是否为
+    这类映射，是则跳过其 key 的关键字识别，但仍递归其值（值本身是子 schema）。
     """
     if isinstance(node, dict):
-        out = {k: _const_to_enum(v) for k, v in node.items()}
-        if "const" in out:
+        out = {k: _const_to_enum(v, in_schema_map=k in _SUBSCHEMA_MAP_KEYS) for k, v in node.items()}
+        if not in_schema_map and "const" in out:
             out["enum"] = [out.pop("const")]
         return out
     if isinstance(node, list):

--- a/tests/test_text_backends/test_gemini.py
+++ b/tests/test_text_backends/test_gemini.py
@@ -144,6 +144,25 @@ class TestGenerate:
         assert "const" not in ds
         assert ds["enum"] == [8]
 
+    def test_property_named_const_is_preserved(self, backend):
+        """字段名恰为 const（properties 容器的 key）不应被误判为 const 关键字而改写成 enum。
+
+        const 仅在作为 schema 关键字时才归一；出现在 properties/$defs 等容器映射的 key 是字段名。
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "const": {"type": "string"},  # 字段名恰为 const
+                "duration_seconds": {"const": 8, "type": "integer"},  # 真正的 const 关键字
+            },
+        }
+        config = backend._build_config(schema, None)
+        props = config["response_json_schema"]["properties"]
+        # 字段名 const 原样保留，未被改写成 enum
+        assert props["const"] == {"type": "string"}
+        # 真正的 const 关键字仍归一为单元素 enum
+        assert props["duration_seconds"] == {"type": "integer", "enum": [8]}
+
     def test_episode_script_schema_accepted_by_google_genai_jsonschema(self, backend):
         """集成回归：剧本 schema 经 _build_config 产出后必须被 google-genai 真实 JSONSchema 接受。
 

--- a/tests/test_text_backends/test_gemini.py
+++ b/tests/test_text_backends/test_gemini.py
@@ -144,24 +144,26 @@ class TestGenerate:
         assert "const" not in ds
         assert ds["enum"] == [8]
 
-    def test_const_to_enum_is_conservative_scalar_only(self, backend):
-        """只把「schema 关键字位置的标量 const」归一为 enum；不碰数据值与非标量 const。
+    def test_const_to_enum_distinguishes_keyword_field_name_and_data(self, backend):
+        """区分 const 出现的三种位置：schema 关键字（归一）、字段名（值仍是子 schema）、实例数据（不动）。
 
-        本仓库的 const 只来自单值时长 Literal（标量整数）。保守策略让该适配器免疫各类「数据里恰好
-        含 const 键」的边界——字段名为 const、default/examples 数据含 const、非标量 const 等。
+        本仓库 const 只来自单值时长 Literal（标量）。位置感知确保：properties 等映射的 key 是字段名，
+        其值仍是子 schema（里面真正的 const 照常归一）；const/default 等关键字的值是数据，不递归。
         """
         schema = {
             "type": "object",
             "properties": {
-                "duration_seconds": {"const": 8, "type": "integer"},  # 标量 const 关键字 → 归一
-                "const": {"type": "string"},  # 字段名恰为 const → 不动
-                "with_default": {"type": "object", "default": {"const": 42}},  # default 是数据 → 不动
-                "obj_const": {"const": {"const": 5}},  # 非标量 const（值是对象）→ 不动
+                "duration_seconds": {"const": 8, "type": "integer"},  # const 作关键字 → 归一
+                "const": {"type": "string"},  # 字段名为 const → 不动（值无 const）
+                "default": {"const": 6, "type": "integer"},  # 字段名为 default → 其值是子 schema，const 照常归一
+                "with_default": {"type": "object", "default": {"const": 42}},  # default 作关键字（数据）→ 不动
+                "obj_const": {"const": {"const": 5}},  # 非标量 const → 不动
             },
         }
         props = backend._build_config(schema, None)["response_json_schema"]["properties"]
         assert props["duration_seconds"] == {"type": "integer", "enum": [8]}
         assert props["const"] == {"type": "string"}
+        assert props["default"] == {"type": "integer", "enum": [6]}
         assert props["with_default"]["default"] == {"const": 42}
         assert props["obj_const"] == {"const": {"const": 5}}
 

--- a/tests/test_text_backends/test_gemini.py
+++ b/tests/test_text_backends/test_gemini.py
@@ -85,8 +85,13 @@ class TestGenerate:
         assert config["response_mime_type"] == "application/json"
         assert config["response_json_schema"] == schema
 
-    async def test_structured_output_pydantic_class_uses_response_schema(self, backend):
-        """传入 Pydantic 类时应使用 response_schema 而非 response_json_schema。"""
+    async def test_structured_output_pydantic_class_resolved_to_json_schema(self, backend):
+        """传入 Pydantic 类时解析为 JSON Schema dict 走 response_json_schema。
+
+        google-genai 的 response_schema(types.Schema) 是 OpenAPI 子集，enum 仅支持字符串，
+        整数/数字 enum 会在 SDK schema 转换时抛 "Input should be a valid string"。统一走
+        response_json_schema（标准 JSON Schema，官方支持数字 enum），与 dict 入参同口径。
+        """
         from pydantic import BaseModel
 
         class MyModel(BaseModel):
@@ -103,8 +108,57 @@ class TestGenerate:
         call_kwargs = backend._test_client.aio.models.generate_content.call_args
         config = call_kwargs.kwargs.get("config")
         assert config["response_mime_type"] == "application/json"
-        assert config["response_schema"] is MyModel
-        assert "response_json_schema" not in config
+        assert "response_schema" not in config
+        js = config["response_json_schema"]
+        assert js["type"] == "object"
+        assert js["properties"]["name"]["type"] == "string"
+        assert js["required"] == ["name"]
+
+    async def test_episode_script_integer_enum_routes_to_json_schema(self, backend):
+        """回归：duration_seconds 整数 enum 的剧本 schema 必须走 response_json_schema。
+
+        build_episode_script_model 把 duration_seconds 收紧为 Literal[*supported_durations]
+        （整数 enum）。若退回 response_schema(types.Schema, enum: list[str]) 会在真实 SDK
+        转换时抛 "Input should be a valid string"，整集生成直接失败。
+        """
+        from lib.script_models import build_episode_script_model
+
+        schema = build_episode_script_model("narration", [4, 6, 8])
+        mock_resp = SimpleNamespace(text="{}", usage_metadata=None)
+        backend._test_client.aio.models.generate_content = AsyncMock(return_value=mock_resp)
+
+        await backend.generate(TextGenerationRequest(prompt="x", response_schema=schema))
+
+        config = backend._test_client.aio.models.generate_content.call_args.kwargs["config"]
+        assert "response_schema" not in config
+        seg_props = config["response_json_schema"]["properties"]["segments"]["items"]["properties"]
+        assert seg_props["duration_seconds"]["enum"] == [4, 6, 8]
+
+    def test_single_value_duration_const_normalized_to_enum(self, backend):
+        """单值 supported_durations 渲染为 const（不在 response_json_schema 支持特性内），
+        归一为单元素 enum 以保留生成层硬约束。"""
+        from lib.script_models import build_episode_script_model
+
+        config = backend._build_config(build_episode_script_model("narration", [8]), None)
+        ds = config["response_json_schema"]["properties"]["segments"]["items"]["properties"]["duration_seconds"]
+        assert "const" not in ds
+        assert ds["enum"] == [8]
+
+    def test_episode_script_schema_accepted_by_google_genai_jsonschema(self, backend):
+        """集成回归：剧本 schema 经 _build_config 产出后必须被 google-genai 真实 JSONSchema 接受。
+
+        mock 掉 generate_content 会让 SDK 的 schema 转换不执行，掩盖整数 enum 与 Gemini
+        response_schema 的不兼容。这里直接过真实 SDK 类型校验，堵住该盲区。
+        """
+        from google.genai import types as gtypes
+
+        from lib.script_models import build_episode_script_model
+
+        for content_mode in ("narration", "drama", "ad"):
+            for durations in ([4, 6, 8], [8]):
+                config = backend._build_config(build_episode_script_model(content_mode, durations), None)
+                # 不抛 = 整数 enum / 归一后单值被 google-genai 的 JSONSchema(enum: list[Any]) 接受
+                gtypes.JSONSchema.model_validate(config["response_json_schema"])
 
     async def test_system_prompt(self, backend):
         mock_resp = SimpleNamespace(

--- a/tests/test_text_backends/test_gemini.py
+++ b/tests/test_text_backends/test_gemini.py
@@ -144,24 +144,29 @@ class TestGenerate:
         assert "const" not in ds
         assert ds["enum"] == [8]
 
-    def test_property_named_const_is_preserved(self, backend):
-        """字段名恰为 const（properties 容器的 key）不应被误判为 const 关键字而改写成 enum。
+    def test_const_normalization_distinguishes_field_names_from_keywords(self, backend):
+        """正确区分「字段名」与「schema 关键字」：const 只在 schema 对象里作关键字才归一。
 
-        const 仅在作为 schema 关键字时才归一；出现在 properties/$defs 等容器映射的 key 是字段名。
+        出现在 properties/$defs/dependentRequired 等映射的 key 是字段名，不归一；反过来，字段名
+        恰为容器关键字（如 properties）时其值仍是普通 schema，里面的 const 要照常归一。
         """
         schema = {
             "type": "object",
             "properties": {
-                "const": {"type": "string"},  # 字段名恰为 const
-                "duration_seconds": {"const": 8, "type": "integer"},  # 真正的 const 关键字
+                "const": {"type": "string"},  # 字段名恰为 const → 当字段名，不动
+                "duration_seconds": {"const": 8, "type": "integer"},  # 真正的 const 关键字 → 归一
+                "properties": {"const": 42},  # 字段名恰为容器关键字 → 其值仍是 schema，const 照常归一
             },
         }
-        config = backend._build_config(schema, None)
-        props = config["response_json_schema"]["properties"]
-        # 字段名 const 原样保留，未被改写成 enum
+        props = backend._build_config(schema, None)["response_json_schema"]["properties"]
         assert props["const"] == {"type": "string"}
-        # 真正的 const 关键字仍归一为单元素 enum
         assert props["duration_seconds"] == {"type": "integer", "enum": [8]}
+        assert props["properties"] == {"enum": [42]}
+
+        # dependentRequired 的 key 同样是字段名：名为 const 的依赖约束不被误判
+        dep_schema = {"type": "object", "dependentRequired": {"const": ["other"]}}
+        dep_config = backend._build_config(dep_schema, None)
+        assert dep_config["response_json_schema"]["dependentRequired"] == {"const": ["other"]}
 
     def test_episode_script_schema_accepted_by_google_genai_jsonschema(self, backend):
         """集成回归：剧本 schema 经 _build_config 产出后必须被 google-genai 真实 JSONSchema 接受。

--- a/tests/test_text_backends/test_gemini.py
+++ b/tests/test_text_backends/test_gemini.py
@@ -144,29 +144,26 @@ class TestGenerate:
         assert "const" not in ds
         assert ds["enum"] == [8]
 
-    def test_const_normalization_distinguishes_field_names_from_keywords(self, backend):
-        """正确区分「字段名」与「schema 关键字」：const 只在 schema 对象里作关键字才归一。
+    def test_const_to_enum_is_conservative_scalar_only(self, backend):
+        """只把「schema 关键字位置的标量 const」归一为 enum；不碰数据值与非标量 const。
 
-        出现在 properties/$defs/dependentRequired 等映射的 key 是字段名，不归一；反过来，字段名
-        恰为容器关键字（如 properties）时其值仍是普通 schema，里面的 const 要照常归一。
+        本仓库的 const 只来自单值时长 Literal（标量整数）。保守策略让该适配器免疫各类「数据里恰好
+        含 const 键」的边界——字段名为 const、default/examples 数据含 const、非标量 const 等。
         """
         schema = {
             "type": "object",
             "properties": {
-                "const": {"type": "string"},  # 字段名恰为 const → 当字段名，不动
-                "duration_seconds": {"const": 8, "type": "integer"},  # 真正的 const 关键字 → 归一
-                "properties": {"const": 42},  # 字段名恰为容器关键字 → 其值仍是 schema，const 照常归一
+                "duration_seconds": {"const": 8, "type": "integer"},  # 标量 const 关键字 → 归一
+                "const": {"type": "string"},  # 字段名恰为 const → 不动
+                "with_default": {"type": "object", "default": {"const": 42}},  # default 是数据 → 不动
+                "obj_const": {"const": {"const": 5}},  # 非标量 const（值是对象）→ 不动
             },
         }
         props = backend._build_config(schema, None)["response_json_schema"]["properties"]
-        assert props["const"] == {"type": "string"}
         assert props["duration_seconds"] == {"type": "integer", "enum": [8]}
-        assert props["properties"] == {"enum": [42]}
-
-        # dependentRequired 的 key 同样是字段名：名为 const 的依赖约束不被误判
-        dep_schema = {"type": "object", "dependentRequired": {"const": ["other"]}}
-        dep_config = backend._build_config(dep_schema, None)
-        assert dep_config["response_json_schema"]["dependentRequired"] == {"const": ["other"]}
+        assert props["const"] == {"type": "string"}
+        assert props["with_default"]["default"] == {"const": 42}
+        assert props["obj_const"] == {"const": {"const": 5}}
 
     def test_episode_script_schema_accepted_by_google_genai_jsonschema(self, backend):
         """集成回归：剧本 schema 经 _build_config 产出后必须被 google-genai 真实 JSONSchema 接受。


### PR DESCRIPTION
剧本片段/镜头时长被收紧到视频模型支持的离散值（如 4/6/8 秒）后，用 Gemini 文本模型生成剧集剧本会在请求发出前直接报 schema 校验错误，导致整集生成失败。

根因：该时长约束渲染为整数枚举，而 Gemini 的 response_schema 通道只接受字符串枚举，SDK 转换时即抛 "Input should be a valid string"；Vertex 与 Developer API 两路均受影响。

修复：统一改走 response_json_schema 通道（官方支持数字枚举），与 OpenAI/Ark/Grok 文本后端口径一致；单值约束渲染出的 const 一并归一为单元素枚举，保留生成层硬约束。

测试：新增过真实 google-genai schema 类型校验的回归用例（narration/drama/ad × 多值/单值），堵住此前 mock 掩盖 SDK 转换的盲区；并改写了将旧路由钉死的单测。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化 Gemini 结构化输出：当提供 `response_schema` 时，统一展开并改用 `response_json_schema`，固定使用 JSON 响应配置，移除原先的 `response_schema` 写入逻辑。
  * 改进 `const` 归一化：仅在 schema 关键字层面的标量 `const` 场景将其转换为单元素 `enum`，避免误改实例数据或非标量 `const`。

* **Tests**
  * 更新并细化结构化输出回归：精确断言 `response_json_schema`（含顶层 `name` 结构）、新增整数 enum 路由、单值 `const` 归一、边界与真实环境校验用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->