### PR TITLE
feat(provider): 新增 MiniMax 内置供应商，MiniMax-M2.7 文本开箱即用

### DIFF
--- a/frontend/src/components/ui/ProviderIcon.tsx
+++ b/frontend/src/components/ui/ProviderIcon.tsx
@@ -1,6 +1,7 @@
 import BailianColor from "@lobehub/icons/es/Bailian/components/Color";
 import GeminiColor from "@lobehub/icons/es/Gemini/components/Color";
 import GrokMono from "@lobehub/icons/es/Grok/components/Mono";
+import MinimaxColor from "@lobehub/icons/es/Minimax/components/Color";
 import OpenAIMono from "@lobehub/icons/es/OpenAI/components/Mono";
 import VertexAIColor from "@lobehub/icons/es/VertexAI/components/Color";
 import ViduColor from "@lobehub/icons/es/Vidu/components/Color";
@@ -17,7 +18,7 @@ export const PROVIDER_NAMES: Record<string, string> = {
 
 /**
  * 根据 providerId 渲染对应的供应商图标。
- * 支持 gemini-aistudio、gemini-vertex、grok、ark、dashscope、openai、vidu，其余显示首字母。
+ * 支持 gemini-aistudio、gemini-vertex、grok、ark、dashscope、minimax、openai、vidu，其余显示首字母。
  */
 export function ProviderIcon({ providerId, className }: { providerId: string; className?: string }) {
   const cls = className ?? "h-6 w-6";
@@ -26,6 +27,7 @@ export function ProviderIcon({ providerId, className }: { providerId: string; cl
   if (providerId.startsWith("grok")) return <GrokMono className={cls} />;
   if (providerId === "ark") return <VolcengineColor className={cls} />;
   if (providerId === "dashscope") return <BailianColor className={cls} />;
+  if (providerId === "minimax") return <MinimaxColor className={cls} />;
   if (providerId === "openai") return <OpenAIMono className={cls} />;
   if (providerId === "vidu") return <ViduColor className={cls} />;
   // Fallback: first letter badge

--- a/lib/config/env_keys.py
+++ b/lib/config/env_keys.py
@@ -23,6 +23,7 @@ OTHER_PROVIDER_ENV_KEYS: tuple[str, ...] = (
     "GEMINI_API_KEY",
     "VIDU_API_KEY",
     "DASHSCOPE_API_KEY",
+    "MINIMAX_API_KEY",
     "GOOGLE_APPLICATION_CREDENTIALS",
     "GEMINI_BASE_URL",
     "GEMINI_IMAGE_MODEL",
@@ -43,6 +44,7 @@ PROVIDER_SECRET_KEYS: frozenset[str] = frozenset(
         "GEMINI_API_KEY",
         "VIDU_API_KEY",
         "DASHSCOPE_API_KEY",
+        "MINIMAX_API_KEY",
         "GOOGLE_APPLICATION_CREDENTIALS",
     }
 )

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 
 from lib.ark_shared import ARK_BASE_URL
 from lib.dashscope_shared import DASHSCOPE_BASE_URL
+from lib.minimax_shared import MINIMAX_BASE_URL
 from lib.pricing.types import (
     PerCharacter,
     PerImageByResolution,
@@ -194,6 +195,15 @@ def _dashscope_video_pricing(model_id: str, rates: dict[str, float]) -> PerSecon
 # DashScope 语音合成费率（元/万字符）。
 def _dashscope_audio_pricing(model_id: str, per_10k_chars: float) -> PerCharacter:
     return PerCharacter(rates={model_id: per_10k_chars}, default_model=model_id, currency="CNY")
+
+
+# MiniMax（海螺）文本费率（元/百万 token），标准在线推理价；缓存折扣首批不建模。
+def _minimax_text_pricing(model_id: str, input_rate: float, output_rate: float) -> PerToken:
+    return PerToken(
+        rates={model_id: {"input": input_rate, "output": output_rate}},
+        default_model=model_id,
+        currency="CNY",
+    )
 
 
 PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
@@ -917,6 +927,24 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             ),
         },
         default_base_url=DASHSCOPE_BASE_URL,
+    ),
+    "minimax": ProviderMeta(
+        display_name="MiniMax",
+        description="MiniMax（海螺）OpenAI 兼容平台，MiniMax-M2.7 文本擅长中文文学与人设创作；缺省国内站，可改 base_url 指向国际站。",
+        required_keys=["api_key"],
+        optional_keys=["base_url", "image_max_workers", "video_max_workers"],
+        secret_keys=["api_key"],
+        models={
+            # --- text ---
+            "MiniMax-M2.7": ModelInfo(
+                display_name="MiniMax M2.7",
+                media_type="text",
+                capabilities=["text_generation", "structured_output"],
+                default=True,
+                pricing=_minimax_text_pricing("MiniMax-M2.7", 2.1, 8.4),
+            ),
+        },
+        default_base_url=MINIMAX_BASE_URL,
     ),
 }
 

--- a/lib/i18n/en/providers.py
+++ b/lib/i18n/en/providers.py
@@ -10,6 +10,7 @@ MESSAGES: dict[str, str] = {
     "provider_name_openai": "OpenAI",
     "provider_name_vidu": "Vidu",
     "provider_name_dashscope": "Alibaba Model Studio",
+    "provider_name_minimax": "MiniMax",
     # Provider descriptions
     "provider_desc_gemini-aistudio": "Google AI Studio provides Gemini models with image and video generation, ideal for rapid prototyping and personal projects.",
     "provider_desc_gemini-vertex": "Google Cloud Vertex AI enterprise platform supporting Gemini and Imagen models with higher quotas and audio generation.",
@@ -19,6 +20,7 @@ MESSAGES: dict[str, str] = {
     "provider_desc_openai": "OpenAI platform supporting GPT-5.4 text, GPT Image and Sora video generation.",
     "provider_desc_vidu": "Shengshu Vidu video platform supporting text-to-video, image-to-video, first-last frame, reference-to-video and reference-to-image. Image and video only.",
     "provider_desc_dashscope": "Alibaba Cloud Model Studio (DashScope) full-modality platform supporting Qwen text, Qwen-Image / Wan images, and HappyHorse / Wan video (including reference-to-video).",
+    "provider_desc_minimax": "MiniMax (Hailuo) OpenAI-compatible platform; MiniMax-M2.7 text excels at Chinese literary and character writing. Defaults to the domestic site; set base_url to the international site.",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "DeepSeek official Anthropic-compat endpoint; needs sk- prefixed key.",
     "preset_notes_xiaomi_mimo": "Xiaomi MiMo only accepts known model names; no public model list.",

--- a/lib/i18n/vi/providers.py
+++ b/lib/i18n/vi/providers.py
@@ -10,6 +10,7 @@ MESSAGES: dict[str, str] = {
     "provider_name_openai": "OpenAI",
     "provider_name_vidu": "Vidu",
     "provider_name_dashscope": "Alibaba Model Studio",
+    "provider_name_minimax": "MiniMax",
     # Provider descriptions
     "provider_desc_gemini-aistudio": "Google AI Studio cung cấp các mô hình Gemini hỗ trợ tạo ảnh và video, phù hợp cho việc dựng prototype nhanh và dự án cá nhân.",
     "provider_desc_gemini-vertex": "Nền tảng doanh nghiệp Vertex AI của Google Cloud hỗ trợ các mô hình Gemini và Imagen với hạn mức cao hơn cùng khả năng tạo âm thanh.",
@@ -19,6 +20,7 @@ MESSAGES: dict[str, str] = {
     "provider_desc_openai": "Nền tảng OpenAI hỗ trợ văn bản GPT-5.4, GPT Image và tạo video Sora.",
     "provider_desc_vidu": "Nền tảng Vidu của Shengshu hỗ trợ tạo video từ văn bản, từ ảnh, khung đầu–cuối, video tham chiếu và ảnh tham chiếu. Chỉ hỗ trợ ảnh và video.",
     "provider_desc_dashscope": "Nền tảng đa phương thức Alibaba Cloud Model Studio (DashScope) hỗ trợ văn bản Qwen, ảnh Qwen-Image / Wan và video HappyHorse / Wan (bao gồm video tham chiếu).",
+    "provider_desc_minimax": "Nền tảng tương thích OpenAI của MiniMax (Hailuo); văn bản MiniMax-M2.7 mạnh về sáng tác văn học và nhân vật tiếng Trung. Mặc định dùng site nội địa; đặt base_url để trỏ sang site quốc tế.",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "Endpoint Anthropic-compat chính thức của DeepSeek; cần API key sk-.",
     "preset_notes_xiaomi_mimo": "Xiaomi MiMo chỉ chấp nhận tên model đã biết; không có danh sách model công khai.",

--- a/lib/i18n/zh/providers.py
+++ b/lib/i18n/zh/providers.py
@@ -10,6 +10,7 @@ MESSAGES: dict[str, str] = {
     "provider_name_openai": "OpenAI",
     "provider_name_vidu": "Vidu",
     "provider_name_dashscope": "阿里百炼",
+    "provider_name_minimax": "MiniMax",
     # Provider descriptions
     "provider_desc_gemini-aistudio": "Google AI Studio 提供 Gemini 系列模型，支持图片和视频生成，适合快速原型和个人项目。",
     "provider_desc_gemini-vertex": "Google Cloud Vertex AI 企业级平台，支持 Gemini 和 Imagen 模型，提供更高配额和音频生成能力。",
@@ -19,6 +20,7 @@ MESSAGES: dict[str, str] = {
     "provider_desc_openai": "OpenAI 官方平台，支持 GPT-5.4 文本、GPT Image 图片和 Sora 视频生成。",
     "provider_desc_vidu": "生数科技 Vidu 视频生成平台，支持文生视频、图生视频、首尾帧、参考生视频与参考生图，仅图片与视频能力。",
     "provider_desc_dashscope": "阿里云百炼（Model Studio）全模态平台，支持 Qwen 文本、Qwen-Image / 万相图像与 HappyHorse / 万相视频（含参考生视频）。",
+    "provider_desc_minimax": "MiniMax（海螺）OpenAI 兼容平台，MiniMax-M2.7 文本擅长中文文学与人设创作；缺省国内站，可改 base_url 指向国际站。",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "DeepSeek 官方 Anthropic 兼容端点，需 sk- 开头的 API Key",
     "preset_notes_xiaomi_mimo": "小米 MiMo 仅支持已知模型名，未公开模型列表",

--- a/lib/minimax_shared.py
+++ b/lib/minimax_shared.py
@@ -1,0 +1,48 @@
+"""MiniMax（海螺）共享工具模块。
+
+供 text_backends factory / config / 连接测试复用。MiniMax 本身 OpenAI 兼容，
+单 `/v1` base（无 DashScope 那种文本/原生双 base 派生），故只需：
+- MINIMAX_BASE_URL — 国内站默认 base（含 `/v1`）
+- MINIMAX_INTL_BASE_URL — 国际站 base，供配置覆盖参考
+- resolve_minimax_api_key — Bearer API Key 解析（缺失即 raise，不走 env fallback）
+- minimax_text_base_url — 归一化为 {host}/v1，容忍用户填 host 或带 `/v1` 后缀
+- minimax_headers — Bearer 鉴权头
+"""
+
+from __future__ import annotations
+
+# 国内站默认 base（含 /v1）；国际站经配置覆盖 base_url 指向 MINIMAX_INTL_BASE_URL。
+MINIMAX_BASE_URL = "https://api.minimaxi.com/v1"
+MINIMAX_INTL_BASE_URL = "https://api.minimax.io/v1"
+
+# 单一已知路径后缀，归一化 host 时剥除以容忍用户填入完整 base。
+_V1_SUFFIX = "/v1"
+
+
+def resolve_minimax_api_key(api_key: str | None = None) -> str:
+    if api_key is None or not api_key.strip():
+        raise ValueError("请到系统配置页填写 MiniMax API Key")
+    return api_key.strip()
+
+
+def _minimax_host(configured: str | None) -> str:
+    """从配置的 base_url 提取 host 段（剥除 `/v1` 后缀），缺省回落国内站 host。"""
+    # 先 strip 再判空：纯空白串（"   "）是真值会绕过 or，回落必须在 strip 之后，
+    # 否则 base 变空串、派生出 "/v1" 这类非法相对 URL。
+    base = ((configured or "").strip() or MINIMAX_BASE_URL).rstrip("/")
+    if base.endswith(_V1_SUFFIX):
+        return base[: -len(_V1_SUFFIX)]
+    return base
+
+
+def minimax_text_base_url(configured: str | None = None) -> str:
+    """文本（OpenAI 兼容）base：{host}/v1。"""
+    return f"{_minimax_host(configured)}{_V1_SUFFIX}"
+
+
+def minimax_headers(api_key: str) -> dict[str, str]:
+    """Bearer 鉴权头。"""
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }

--- a/lib/pricing/lookup.py
+++ b/lib/pricing/lookup.py
@@ -14,6 +14,7 @@ from lib.providers import (
     PROVIDER_ARK,
     PROVIDER_DASHSCOPE,
     PROVIDER_GROK,
+    PROVIDER_MINIMAX,
     PROVIDER_OPENAI,
     PROVIDER_VIDU,
 )
@@ -23,7 +24,7 @@ logger = logging.getLogger(__name__)
 # 这些 provider 各有独立费率表：未知 model 回落到「该 provider 的默认模型」。其余 provider
 # （gemini-aistudio/vertex、裸 gemini、ark-agent-plan、未知）一律回落 Gemini 家族通用默认费率，
 # 复刻历史「仅 ark/grok/openai 走专属表、其余皆走全局 Gemini 表」的路由。
-_OWN_TABLE_PROVIDERS = frozenset({PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI, PROVIDER_DASHSCOPE})
+_OWN_TABLE_PROVIDERS = frozenset({PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI, PROVIDER_DASHSCOPE, PROVIDER_MINIMAX})
 
 # Anthropic 不在 PROVIDER_REGISTRY（无 ModelInfo 落点），文本定价作为 registry-external 例外。
 # 助手主链路优先使用 SDK 回报的实际费用；此表仅在只拿到 token 数时兜底。费率为美元/百万 token。

--- a/lib/providers.py
+++ b/lib/providers.py
@@ -10,6 +10,7 @@ PROVIDER_OPENAI = "openai"
 PROVIDER_VIDU = "vidu"
 PROVIDER_NEWAPI = "newapi"
 PROVIDER_DASHSCOPE = "dashscope"
+PROVIDER_MINIMAX = "minimax"
 PROVIDER_ANTHROPIC = "anthropic"
 
 CallType = Literal["image", "video", "text", "audio"]

--- a/lib/text_backends/factory.py
+++ b/lib/text_backends/factory.py
@@ -6,7 +6,7 @@ from lib.config.registry import PROVIDER_REGISTRY
 from lib.config.resolver import ConfigResolver
 from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.db import async_session_factory
-from lib.providers import PROVIDER_DASHSCOPE, PROVIDER_OPENAI
+from lib.providers import PROVIDER_DASHSCOPE, PROVIDER_MINIMAX, PROVIDER_OPENAI
 from lib.text_backends.base import TextBackend, TextTaskType
 from lib.text_backends.registry import create_backend
 
@@ -19,6 +19,8 @@ PROVIDER_ID_TO_BACKEND: dict[str, str] = {
     "openai": "openai",
     # 阿里百炼文本走 OpenAI 兼容协议，复用 OpenAI 后端（base_url 与 provider_name 在下方特例处理）
     "dashscope": "openai",
+    # MiniMax 文本同样走 OpenAI 兼容协议，复用 OpenAI 后端（单 /v1 base，处理见下方特例）
+    "minimax": "openai",
 }
 
 
@@ -94,6 +96,13 @@ async def create_text_backend_for_task(
 
             kwargs["base_url"] = dashscope_text_base_url(user_base_url)
             kwargs["provider_name"] = PROVIDER_DASHSCOPE
+        elif provider_id == PROVIDER_MINIMAX:
+            # MiniMax 文本走 OpenAI 兼容模式：单 /v1 base（缺省国内站，可改 base_url 指向国际站）；
+            # 透传真实 provider 名给 OpenAI 后端，确保 usage 记账与计费查表命中 MiniMax 自身的 CNY 费率。
+            from lib.minimax_shared import minimax_text_base_url
+
+            kwargs["base_url"] = minimax_text_base_url(user_base_url)
+            kwargs["provider_name"] = PROVIDER_MINIMAX
         else:
             # ark / ark-agent-plan 等：用户优先，缺省回落 ProviderMeta.default_base_url
             # （与 server.services.generation_tasks._fill_simple_provider_kwargs 对称）。

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -658,6 +658,29 @@ def _test_dashscope(config: dict[str, str], _t: Callable[..., str]) -> Connectio
     )
 
 
+def _test_minimax(config: dict[str, str], _t: Callable[..., str]) -> ConnectionTestResponse:
+    """通过 models.list() 验证 MiniMax API Key（OpenAI 兼容协议）。
+
+    与 DashScope 同构：复用 OpenAI 客户端打 models.list()；base_url 经 minimax_text_base_url
+    归一化为 {host}/v1，容忍用户填 host 或带 /v1 后缀（缺省国内站，可改指向国际站）。
+    """
+    from openai import OpenAI
+
+    from lib.minimax_shared import minimax_text_base_url
+
+    client = OpenAI(
+        api_key=config["api_key"],
+        base_url=minimax_text_base_url(config.get("base_url")),
+    )
+    models = client.models.list()
+    available = sorted(m.id for m in models.data if "minimax" in m.id.lower() or "abab" in m.id.lower())
+    return ConnectionTestResponse(
+        success=True,
+        available_models=available,
+        message=_t("connection_success"),
+    )
+
+
 _TEST_DISPATCH: dict[str, Callable[[dict[str, str], Any], ConnectionTestResponse]] = {
     "gemini-aistudio": _test_gemini_aistudio,
     "gemini-vertex": _test_gemini_vertex,
@@ -667,6 +690,7 @@ _TEST_DISPATCH: dict[str, Callable[[dict[str, str], Any], ConnectionTestResponse
     "openai": _test_openai,
     "vidu": _test_vidu,
     "dashscope": _test_dashscope,
+    "minimax": _test_minimax,
 }
 
 

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -11,6 +11,7 @@ def test_all_providers_registered():
         "openai",
         "vidu",
         "dashscope",
+        "minimax",
     }
 
 

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -67,6 +67,9 @@ class TestTextProviderBilling:
             result = await b.generate(TextGenerationRequest(prompt="x"))
         assert result.provider == "minimax"
         assert result.model == "MiniMax-M2.7"
+        # token 数须透传，否则「实际」费用汇总按 0 token 算不出 MiniMax CNY 费率
+        assert result.input_tokens == 10
+        assert result.output_tokens == 5
 
 
 class TestFactoryWiring:

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,126 @@
+"""MiniMax 跨层集成测试：内置 provider 注册、文本记账 provider、定价查表、env keys。"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lib.pricing.lookup import lookup_pricing
+from lib.pricing.strategies import PricingParams, calculate_pricing
+from lib.providers import PROVIDER_MINIMAX, PROVIDER_OPENAI
+
+
+def _text_response(content: str = "ok", in_tok: int = 10, out_tok: int = 5) -> MagicMock:
+    usage = MagicMock()
+    usage.prompt_tokens = in_tok
+    usage.completion_tokens = out_tok
+    message = MagicMock()
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = "stop"
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = usage
+    return response
+
+
+class TestRegistry:
+    def test_minimax_registered_as_text_provider(self):
+        from lib.config.registry import PROVIDER_REGISTRY
+
+        meta = PROVIDER_REGISTRY[PROVIDER_MINIMAX]
+        assert meta.media_types == ["text"]
+        assert "api_key" in meta.required_keys
+        assert "api_key" in meta.secret_keys
+        assert "base_url" in meta.optional_keys
+        assert meta.default_base_url == "https://api.minimaxi.com/v1"
+        assert "MiniMax-M2.7" in meta.models
+        assert meta.models["MiniMax-M2.7"].default is True
+
+    def test_env_keys_registered(self):
+        from lib.config.env_keys import OTHER_PROVIDER_ENV_KEYS, PROVIDER_SECRET_KEYS
+
+        assert "MINIMAX_API_KEY" in OTHER_PROVIDER_ENV_KEYS
+        assert "MINIMAX_API_KEY" in PROVIDER_SECRET_KEYS
+
+
+class TestTextProviderBilling:
+    """文本复用 OpenAI 后端必须以 'minimax' 记账，否则计费命中 USD。"""
+
+    def test_provider_name_override(self):
+        with patch("lib.openai_shared.AsyncOpenAI"):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            b = OpenAITextBackend(api_key="k", model="MiniMax-M2.7", provider_name=PROVIDER_MINIMAX)
+            assert b.name == "minimax"
+
+    async def test_result_provider_is_minimax(self):
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_text_response("hi"))
+        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.text_backends.base import TextGenerationRequest
+            from lib.text_backends.openai import OpenAITextBackend
+
+            b = OpenAITextBackend(api_key="k", model="MiniMax-M2.7", provider_name=PROVIDER_MINIMAX)
+            result = await b.generate(TextGenerationRequest(prompt="x"))
+        assert result.provider == "minimax"
+        assert result.model == "MiniMax-M2.7"
+
+
+class TestFactoryWiring:
+    async def test_text_factory_uses_openai_backend_with_minimax_provider(self):
+        """provider=minimax 经 text 工厂 → OpenAI 后端，base_url 派生 /v1，provider_name 透传。"""
+        from lib.text_backends import factory
+
+        resolver = MagicMock()
+        session_cm = MagicMock()
+        session_cm.text_backend_for_task = AsyncMock(return_value=(PROVIDER_MINIMAX, "MiniMax-M2.7"))
+        session_cm.provider_config = AsyncMock(return_value={"api_key": "sk-mm", "base_url": None})
+        resolver.session.return_value.__aenter__ = AsyncMock(return_value=session_cm)
+        resolver.session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        captured: dict = {}
+
+        def _fake_create_backend(backend_name: str, **kwargs):
+            captured["backend_name"] = backend_name
+            captured.update(kwargs)
+            return MagicMock()
+
+        with (
+            patch.object(factory, "ConfigResolver", return_value=resolver),
+            patch.object(factory, "create_backend", side_effect=_fake_create_backend),
+        ):
+            await factory.create_text_backend_for_task("script")
+
+        assert captured["backend_name"] == "openai"
+        assert captured["provider_name"] == PROVIDER_MINIMAX
+        assert captured["base_url"] == "https://api.minimaxi.com/v1"
+        assert captured["model"] == "MiniMax-M2.7"
+
+
+class TestLookupPricing:
+    def test_text_cny_per_token(self):
+        p = lookup_pricing(PROVIDER_MINIMAX, "MiniMax-M2.7", "text")
+        amount, cur = calculate_pricing(
+            p,
+            PricingParams(call_type="text", model="MiniMax-M2.7", input_tokens=1_000_000, output_tokens=1_000_000),
+        )
+        assert cur == "CNY"
+        # ¥2.1 入 + ¥8.4 出
+        assert amount == pytest.approx(10.5)
+
+    def test_unknown_model_falls_back_to_minimax_cny(self):
+        # 未知 minimax model 回落自身默认 CNY，而非 Gemini USD
+        p = lookup_pricing(PROVIDER_MINIMAX, "minimax-unknown-xyz", "text")
+        _, cur = calculate_pricing(
+            p, PricingParams(call_type="text", model="minimax-unknown-xyz", input_tokens=1000, output_tokens=0)
+        )
+        assert cur == "CNY"
+
+
+class TestProviderConstantsDistinct:
+    def test_minimax_not_openai(self):
+        assert PROVIDER_MINIMAX == "minimax"
+        assert PROVIDER_MINIMAX != PROVIDER_OPENAI

--- a/tests/test_minimax_shared.py
+++ b/tests/test_minimax_shared.py
@@ -1,0 +1,59 @@
+"""lib.minimax_shared 纯函数单元测试（不打真实 HTTP）。"""
+
+from __future__ import annotations
+
+import pytest
+
+from lib.minimax_shared import (
+    MINIMAX_BASE_URL,
+    MINIMAX_INTL_BASE_URL,
+    minimax_headers,
+    minimax_text_base_url,
+    resolve_minimax_api_key,
+)
+
+
+class TestBaseUrlDerivation:
+    def test_default_is_domestic(self):
+        assert minimax_text_base_url(None) == MINIMAX_BASE_URL
+        assert MINIMAX_BASE_URL == "https://api.minimaxi.com/v1"
+
+    def test_override_to_intl(self):
+        assert minimax_text_base_url(MINIMAX_INTL_BASE_URL) == "https://api.minimax.io/v1"
+
+    def test_host_only_gets_v1_suffix(self):
+        # 用户只填 host，派生时补 /v1
+        assert minimax_text_base_url("https://api.minimax.io") == "https://api.minimax.io/v1"
+
+    def test_full_v1_base_is_idempotent(self):
+        assert minimax_text_base_url("https://api.minimaxi.com/v1") == "https://api.minimaxi.com/v1"
+
+    def test_trailing_slash_stripped(self):
+        assert minimax_text_base_url("https://api.minimax.io/v1/") == "https://api.minimax.io/v1"
+        assert minimax_text_base_url("https://api.minimax.io/") == "https://api.minimax.io/v1"
+
+    def test_whitespace_falls_back_to_default(self):
+        # 纯空白 base_url 是真值会绕过 or，须 strip 后回落默认 host，
+        # 不能 strip 成空串派生出 "/v1" 这类非法相对 URL
+        assert minimax_text_base_url("   ") == MINIMAX_BASE_URL
+
+
+class TestApiKeyResolution:
+    def test_strips_and_returns(self):
+        assert resolve_minimax_api_key("  sk-abc  ") == "sk-abc"
+
+    def test_missing_raises(self):
+        with pytest.raises(ValueError):
+            resolve_minimax_api_key(None)
+
+    def test_blank_raises(self):
+        # 不走 env fallback：缺失即明确报错
+        with pytest.raises(ValueError):
+            resolve_minimax_api_key("   ")
+
+
+class TestHeaders:
+    def test_bearer_and_content_type(self):
+        h = minimax_headers("sk-abc")
+        assert h["Authorization"] == "Bearer sk-abc"
+        assert h["Content-Type"] == "application/json"

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -654,6 +654,40 @@ class TestTestProviderConnection:
         assert resp.available_models == ["qwen-plus", "wan2.7-image"]
         assert resp.success is True
 
+    def test_minimax_registered_in_dispatch(self):
+        # minimax 作为内置 provider 暴露在设置页，连接测试必须有 dispatcher，
+        # 否则点"测试连接"会落到 unsupported_test 分支（即便 API Key 有效）
+        assert "minimax" in providers._TEST_DISPATCH
+
+    def test_minimax_test_fn_uses_v1_base_and_filters_models(self):
+        from types import SimpleNamespace
+
+        captured: dict = {}
+
+        class _FakeModels:
+            def list(self):
+                return SimpleNamespace(
+                    data=[
+                        SimpleNamespace(id="MiniMax-M2.7"),
+                        SimpleNamespace(id="abab6.5s-chat"),
+                        SimpleNamespace(id="text-embedding-v1"),
+                    ]
+                )
+
+        class _FakeOpenAI:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.models = _FakeModels()
+
+        with patch("openai.OpenAI", _FakeOpenAI):
+            resp = providers._test_minimax({"api_key": "sk", "base_url": "https://api.minimax.io"}, lambda k, **kw: k)
+        # host → {host}/v1（OpenAI 协议），api_key 透传
+        assert captured["base_url"] == "https://api.minimax.io/v1"
+        assert captured["api_key"] == "sk"
+        # 仅暴露 minimax/abab 模型，过滤掉 embedding 等
+        assert resp.available_models == ["MiniMax-M2.7", "abab6.5s-chat"]
+        assert resp.success is True
+
     def test_specific_credential_id(self):
         """使用 credential_id 参数测试特定凭证。"""
         repo = MagicMock(spec=CredentialRepository)


### PR DESCRIPTION
Closes #798
父 PRD: #674

## 做了什么

把 MiniMax（海螺）注册为 ArcReel 内置供应商，`MiniMax-M2.7` 文本开箱即用——后续图像/视频切片的地基。参照已合并的 DashScope 内置 provider 同构先例（文本复用 OpenAI backend），但 MiniMax 更简单：单 `/v1` base，本身 OpenAI 兼容，无需双 base 派生。

实现要点：
- `lib/minimax_shared.py`：base_url 归一化（单 `/v1`、国内/国际 host，容忍 host 或带 `/v1` 后缀）、Bearer api_key 解析（缺失即 raise，不走 env fallback）、鉴权头。
- `PROVIDER_MINIMAX = "minimax"` 常量；`MINIMAX_API_KEY` 进 `OTHER_PROVIDER_ENV_KEYS` + `PROVIDER_SECRET_KEYS`。
- 文本复用 OpenAI backend：provider→backend 映射加 `minimax → openai`，base_url 派生 `{host}/v1`，`provider_name="minimax"` 透传以命中 CNY 计费查表。
- `PROVIDER_REGISTRY["minimax"]`：默认国内站 `https://api.minimaxi.com/v1`，可改 base_url 指向国际站；text catalog 含 `MiniMax-M2.7`，定价 `per_token`（¥2.1 入 / ¥8.4 出 CNY）。
- i18n 三语：`provider_name_minimax` / `provider_desc_minimax`。

## 本地审查补充（review 阶段）

独立审查发现并修复了实现遗漏的 DashScope 同构缺口：
- **连接测试**：`_TEST_DISPATCH` 此前缺 minimax handler，设置页点「测试连接」对有效 Key 也返回 `unsupported_test`。补 `_test_minimax`（OpenAI 兼容 `models.list()`），与 `_test_dashscope` 同构。
- **品牌图标**：`ProviderIcon` 此前回落首字母徽标，补 MiniMax 品牌图标（`@lobehub/icons`），与其它内置供应商一致。
- **测试**：补连接测试 dispatch 守护用例 + 文本记账 token 透传断言（保护实际费用汇总命中 MiniMax 费率）。

审查认定为有意保留、未改动：`resolve_minimax_api_key` / `minimax_headers` / `MINIMAX_INTL_BASE_URL` 系后续图像/视频切片地基（与 DashScope 同构）；`optional_keys` 含 image/video workers 为 PRD 显式要求的前向兼容。tool_calls 为共享 OpenAI backend 的协议级能力，文本层对所有 OpenAI 兼容供应商均不单独 surface，非本切片范围。

## 验证

- `uv run pytest tests/`：4708 passed
- `uv run basedpyright`：0 errors
- `uv run ruff check` / `format`：clean
- 前端 `pnpm lint && pnpm check`：724 tests passed（含 typecheck）
- 验收标准逐条覆盖：内置供应商可见可选、base_url 国内/国际可切、缺 Key 明确报错、CNY `per_token` 计费正确（1M+1M = ¥10.5）、三语 key 齐备（`test_i18n_consistency` 绿）、不改其它供应商行为

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 MiniMax（海螺）AI 模型提供商支持，包括 MiniMax-M2.7 默认模型
  * 支持 MiniMax 文本生成与结构化输出能力
  * 新增 MiniMax 提供商连接测试功能
  * 新增中文、英文、越南文多语言支持

* **配置更新**
  * 配置 MiniMax API 密钥环境变量支持
  * 设置 MiniMax 文本模型定价（CNY 货币单位）
  * 支持自定义 base_url 配置

<!-- end of auto-generated comment: release notes by coderabbit.ai -->