### PR TITLE
fix(settings): 项目设置时长选项与供应商配置实时一致，不再读到旧值

### DIFF
--- a/docs/adr/0035-frontend-provider-config-fetched-fresh-no-cache.md
+++ b/docs/adr/0035-frontend-provider-config-fetched-fresh-no-cache.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+---
+
+# 前端供应商配置按消费时点拉取，不持久缓存可变配置
+
+`provider-models.ts` 的模块级缓存（`_cache` 内置 / `_customCache` 自定义）从不失效——`invalidateProviderModelsCache` 零调用，是"供应商设置里给模型加了 10s、项目设置时长选择器仍只显示旧值"的根因：前端缓存成了会漂移的第二真相源，违背 ADR 0018（`supported_durations` per-model 单一真相源）与 ADR 0013（能力模型级真相源）。决定把两个 fetcher 改为完全无状态——每次调用直拉 `GET /custom-providers`、`GET /providers`，删除全部模块缓存、in-flight promise 与 invalidate 函数——以"消费即重拉"从结构上消灭陈旧这一类，而非依赖调用方记得失效。
+
+## Consequences
+
+- 进设置 / 创建向导 / 画布时各多拉一次供应商列表（小 JSON）。惊群不发生：消费者都在页面顶层各调一次再 props 下传，无兄弟组件并发拉同一 fetcher，故不引入 in-flight 去重。
+- 否决 zustand store 方案：其"响应式同屏一致"收益在本应用路由结构下用不上（设置页与项目页不同屏），属过度设计；将来真出现 N 个并发消费的热路径，才是引入 store 的时机。
+- `config-status-store` 走独立 fetch + 自带 `refresh()`（变更后已被调用），只产出配置红点与 `availableMediaTypes`、不向时长/能力选择器暴露模型列表，不在本约束范围内。
+- 已存 `default_duration` 因模型时长缩小而越界，由后端 resolver fail-loud（ADR 0018）兜底；前端 picker 的"存值失效"提示是单独议题，不在本次范围。

--- a/frontend/src/utils/provider-models.test.ts
+++ b/frontend/src/utils/provider-models.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { API } from "@/api";
+import { getCustomProviderModels, getProviderModels } from "./provider-models";
+
+describe("provider-models fetchers", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // 供应商配置可变（用户在设置页编辑模型 supported_durations），前端不得持久缓存它——
+  // 每次消费都必须重拉，否则项目设置/向导读到的时长集会陈旧（ADR 0035）。
+  it("getCustomProviderModels re-fetches on every call (no persistent cache)", async () => {
+    const spy = vi.spyOn(API, "listCustomProviders").mockResolvedValue({ providers: [] });
+
+    await getCustomProviderModels();
+    await getCustomProviderModels();
+
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  // 内置供应商缓存同理：status/enabled 等可变项陈旧会让模型选择器漏显刚配好的供应商。
+  it("getProviderModels re-fetches on every call (no persistent cache)", async () => {
+    const spy = vi.spyOn(API, "getProviders").mockResolvedValue({ providers: [] });
+
+    await getProviderModels();
+    await getProviderModels();
+
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/utils/provider-models.ts
+++ b/frontend/src/utils/provider-models.ts
@@ -4,65 +4,22 @@ import type { CustomProviderInfo, MediaType, ProviderInfo } from "@/types";
 const CUSTOM_PREFIX = "custom-";
 
 // ---------------------------------------------------------------------------
-// Built-in providers cache
+// Provider fetchers
+//
+// 供应商配置可变（用户在设置页改模型 supported_durations / 启用状态等），前端不持久缓存它：
+// 每次消费都直拉后端，避免长生命周期副本与后端单一真相源漂移（ADR 0035，ADR 0018/0013 的前端推论）。
 // ---------------------------------------------------------------------------
 
-let _cache: ProviderInfo[] | null = null;
-let _promise: Promise<ProviderInfo[]> | null = null;
-
-/** Fetch (or return cached) built-in provider list including models. */
+/** Fetch the built-in provider list (including models) fresh on every call. */
 export async function getProviderModels(): Promise<ProviderInfo[]> {
-  if (_cache) return _cache;
-  if (!_promise) {
-    _promise = API.getProviders()
-      .then((res) => {
-        _cache = res.providers;
-        _promise = null;
-        return _cache;
-      })
-      .catch((err) => {
-        _promise = null;
-        throw err;
-      });
-  }
-  return _promise;
+  const res = await API.getProviders();
+  return res.providers;
 }
 
-// ---------------------------------------------------------------------------
-// Custom providers cache
-// ---------------------------------------------------------------------------
-
-let _customCache: CustomProviderInfo[] | null = null;
-let _customPromise: Promise<CustomProviderInfo[]> | null = null;
-
-/** Fetch (or return cached) custom provider list. */
+/** Fetch the custom provider list fresh on every call. */
 export async function getCustomProviderModels(): Promise<CustomProviderInfo[]> {
-  if (_customCache) return _customCache;
-  if (!_customPromise) {
-    _customPromise = API.listCustomProviders()
-      .then((res) => {
-        _customCache = res.providers;
-        _customPromise = null;
-        return _customCache;
-      })
-      .catch((err) => {
-        _customPromise = null;
-        throw err;
-      });
-  }
-  return _customPromise;
-}
-
-// ---------------------------------------------------------------------------
-// Cache invalidation
-// ---------------------------------------------------------------------------
-
-/** Invalidate all provider caches (call after provider config changes). */
-export function invalidateProviderModelsCache(): void {
-  _cache = null;
-  _promise = null;
-  _customCache = null;
-  _customPromise = null;
+  const res = await API.listCustomProviders();
+  return res.providers;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

供应商设置里给视频模型增减「支持秒数」后，项目设置 / 创建向导 / 媒体模型页的时长选项仍停在编辑前的旧值，需硬刷新浏览器才一致。

## 根因

前端 `provider-models.ts` 用模块级缓存保存可变的供应商配置，且失效函数零调用——缓存成了与后端单一真相源漂移的第二副本。供应商详情页直拉新鲜值、项目设置读陈旧缓存，于是两处不一致。后端 list/detail 端点序列化同源，无问题。

## 修复

两个 fetcher 改为消费即重拉、完全无状态（删除全部模块缓存与失效函数）；内置 + 自定义两份缓存一并处理。决策记录见 docs/adr/0035-frontend-provider-config-fetched-fresh-no-cache.md（ADR 0018/0013 的前端推论）。

## 测试

新增 `frontend/src/utils/provider-models.test.ts`：两个 fetcher 各断言「调两次 → 底层 API 被调两次」，钉死无持久缓存不变量。`pnpm lint && pnpm check` 全绿（726 测试）。

## 跟进

「已存 default_duration 因模型时长缩小而越界、picker 无提示」是相邻独立问题，记为 #804。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 新增架构决策记录，阐述前端供应商配置的实时获取策略。

* **测试**
  * 新增供应商模型数据获取的测试用例，确保每次调用都获取最新数据。

* **Bug 修复**
  * 移除了前端缓存机制，现在每次调用都从后端获取最新的供应商列表，消除数据陈旧风险。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->