### PR TITLE
feat(provider): MiniMax image-01 图像生成（单步取 URL，含单脸 subject_reference）

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -206,6 +206,11 @@ def _minimax_text_pricing(model_id: str, input_rate: float, output_rate: float) 
     )
 
 
+# MiniMax 图片费率（元/张），T2I 与 I2I 同价。
+def _minimax_image_pricing(model_id: str, per_image: float) -> PerImageFlat:
+    return PerImageFlat(rates={model_id: per_image}, default_model=model_id, currency="CNY")
+
+
 PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
     "gemini-aistudio": ProviderMeta(
         display_name="AI Studio",
@@ -942,6 +947,18 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 capabilities=["text_generation", "structured_output"],
                 default=True,
                 pricing=_minimax_text_pricing("MiniMax-M2.7", 2.1, 8.4),
+            ),
+            # --- image ---
+            # image-01：单步同步取 URL，T2I + I2I（subject_reference 单脸参考）；
+            # 尺寸用 width/height ∈ [512, 2048]（8 倍数），档位短边经精确比例算出。
+            "image-01": ModelInfo(
+                display_name="MiniMax Image 01",
+                media_type="image",
+                capabilities=["text_to_image", "image_to_image"],
+                default=True,
+                resolutions=["1K", "2K"],
+                max_reference_images=1,
+                pricing=_minimax_image_pricing("image-01", 0.025),
             ),
         },
         default_base_url=MINIMAX_BASE_URL,

--- a/lib/image_backends/__init__.py
+++ b/lib/image_backends/__init__.py
@@ -51,3 +51,8 @@ from lib.image_backends.dashscope import DashScopeImageBackend
 from lib.providers import PROVIDER_DASHSCOPE
 
 register_backend(PROVIDER_DASHSCOPE, DashScopeImageBackend)
+
+from lib.image_backends.minimax import MiniMaxImageBackend
+from lib.providers import PROVIDER_MINIMAX
+
+register_backend(PROVIDER_MINIMAX, MiniMaxImageBackend)

--- a/lib/image_backends/minimax.py
+++ b/lib/image_backends/minimax.py
@@ -1,0 +1,222 @@
+"""MiniMaxImageBackend — MiniMax（海螺）image-01 图像生成后端（单步同步）。
+
+走 OpenAI 兼容 base 上的原生 /image_generation 同步端点：单次 POST 直接返回图片 URL
+（24h 有效）或 base64，立即落地为本地资产。T2I 与 I2I 共用同一请求体，I2I 经
+subject_reference 单脸参考驱动多场景角色一致性立绘。尺寸用 width/height（512–2048、8 倍数），
+按「比例优先、清晰度其次」从项目 aspect_ratio + image_size 精确算出。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from pathlib import Path
+
+import httpx
+
+from lib.aspect_size import IMAGE_TIER_SHORT_EDGE, aspect_size, resolution_to_short_edge
+from lib.image_backends.base import (
+    ImageCapability,
+    ImageCapabilityError,
+    ImageGenerationRequest,
+    ImageGenerationResult,
+    download_image_to_path,
+    image_to_base64_data_uri,
+)
+from lib.logging_utils import format_kwargs_for_log
+from lib.minimax_shared import (
+    extract_image_base64,
+    extract_image_url,
+    minimax_failure_reason,
+    minimax_headers,
+    minimax_text_base_url,
+    resolve_minimax_api_key,
+    safe_body_for_log,
+)
+from lib.providers import PROVIDER_MINIMAX
+from lib.retry import with_retry_async
+from lib.video_backends.base import should_retry_submit, submit_post
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "image-01"
+
+_IMAGE_ENDPOINT = "/image_generation"
+
+# image-01 宽高均 ∈ [512, 2048] 且须被 8 整除；可表达的最极端比例为 2048/512 = 4:1。
+_MIN_EDGE = 512
+_MAX_EDGE = 2048
+_ROUND_TO = 8
+_MAX_RATIO = 4.0
+
+# 缺 image_size 时的默认短边（2K 档），经 max_long_edge=2048 收口后竖屏得 1152*2048。
+_DEFAULT_SHORT = 1440
+
+# image-01 单脸参考：subject_reference 仅取首张参考图驱动角色一致性。
+_SUBJECT_REF_LIMIT = 1
+
+
+def _clamp_edge(value: int) -> int:
+    """把单边像素夹进 [512, 2048]。两端点均为 8 的倍数，夹取后仍满足 8 整除约束。"""
+    return max(_MIN_EDGE, min(_MAX_EDGE, value))
+
+
+class MiniMaxImageBackend:
+    """MiniMax 图像后端（单步同步 image_generation 端点）。"""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        http_timeout: float = 120.0,
+    ) -> None:
+        self._api_key = resolve_minimax_api_key(api_key)
+        self._base_url = minimax_text_base_url(base_url)
+        self._model = model or DEFAULT_MODEL
+        self._http_timeout = http_timeout
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_MINIMAX
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def capabilities(self) -> set[ImageCapability]:
+        # image-01 文生图 + 图生图（subject_reference）同模型。
+        return {ImageCapability.TEXT_TO_IMAGE, ImageCapability.IMAGE_TO_IMAGE}
+
+    @with_retry_async(retry_if=should_retry_submit)
+    async def generate(self, request: ImageGenerationRequest) -> ImageGenerationResult:
+        width, height = self._resolve_dimensions(request)
+
+        payload: dict = {
+            "model": self._model,
+            "prompt": request.prompt,
+            "width": width,
+            "height": height,
+            "response_format": "url",
+            "n": 1,
+            # ArcReel 剧本 prompt 已是 LLM 精炼描述，关闭智能改写保留原意。
+            "prompt_optimizer": False,
+        }
+        if request.seed is not None:
+            payload["seed"] = request.seed
+        if request.reference_images:
+            payload["subject_reference"] = self._build_subject_reference(request)
+
+        logger.info(
+            "调用 %s 图片 API model=%s body=%s",
+            self.name,
+            self._model,
+            format_kwargs_for_log(safe_body_for_log(payload)),
+        )
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            # 单步图像生成是非幂等的「建图 + 计费」POST：submit_post 把歧义传输错误转
+            # AmbiguousSubmitError 终态失败避免重复计费；>=400 落 body 日志 + 抛 HTTPStatusError
+            # （保留 status_code 供咽喉层识别 413 降档），交 should_retry_submit 按状态码分流。
+            resp = await submit_post(
+                lambda: client.post(
+                    f"{self._base_url}{_IMAGE_ENDPOINT}",
+                    json=payload,
+                    headers=minimax_headers(self._api_key),
+                ),
+                provider=PROVIDER_MINIMAX,
+            )
+            data = resp.json()
+
+        image_uri = await self._persist_image(data, request.output_path)
+        logger.info("MiniMax 图片生成完成: %s", request.output_path)
+
+        return ImageGenerationResult(
+            image_path=request.output_path,
+            provider=PROVIDER_MINIMAX,
+            model=self._model,
+            image_uri=image_uri,
+        )
+
+    def _resolve_dimensions(self, request: ImageGenerationRequest) -> tuple[int, int]:
+        """按「比例优先、清晰度其次」算出 (宽, 高)。
+
+        比例永远来自 aspect_ratio；image_size（档位词 / 自定义 宽*高 / None）只决定清晰度短边，
+        自定义值剥离其自带比例（取 min）。结果被 8 整除、长边受 2048 收口，再把每边夹进
+        [512, 2048] 满足 image-01 的单边范围约束。
+        """
+        short = resolution_to_short_edge(
+            request.image_size or None, tier_map=IMAGE_TIER_SHORT_EDGE, default_short=_DEFAULT_SHORT
+        )
+        w, h = aspect_size(
+            request.aspect_ratio, short, round_to=_ROUND_TO, max_long_edge=_MAX_EDGE, max_ratio=_MAX_RATIO
+        )
+        return _clamp_edge(w), _clamp_edge(h)
+
+    def _build_subject_reference(self, request: ImageGenerationRequest) -> list[dict]:
+        """构建 subject_reference（单脸参考）。
+
+        image-01 仅取一张人脸参考；多张时截断为首张并告警。首张缺失 / 读取失败即 fail-loud，
+        报 image_reference_images_unreadable，让用户感知有图未被使用而非静默丢弃后照常计费。
+        """
+        refs = request.reference_images
+        if len(refs) > _SUBJECT_REF_LIMIT:
+            logger.warning(
+                "MiniMax subject_reference 仅支持 %d 张参考图，截断 %d 张取首张",
+                _SUBJECT_REF_LIMIT,
+                len(refs),
+            )
+        ref = refs[0]
+        # 空路径无文件名可显示，用序号 #1 标识，避免中文占位漏进非中文报错模板。
+        path = Path(ref.path) if ref.path else None
+        if path is None or not path.is_file():
+            raise ImageCapabilityError(
+                "image_reference_images_unreadable", model=self._model, names=path.name if path else "#1"
+            )
+        try:
+            image_file = image_to_base64_data_uri(path)
+        except OSError as exc:
+            logger.warning("MiniMax 参考图读取失败: %s (%s)", path, exc)
+            raise ImageCapabilityError("image_reference_images_unreadable", model=self._model, names=path.name) from exc
+        return [{"type": "character", "image_file": image_file}]
+
+    async def _persist_image(self, data: dict, output_path: Path) -> str | None:
+        """把 image_generation 响应落地为本地文件，返回远端 URL（base64 路径返回 None）。
+
+        先查 base_resp 业务错误（200 + 非零 status_code），再优先 URL（立即下载，24h 失效前落地），
+        URL 缺失降级 base64 解码写盘；两者皆空即报错。
+        """
+        reason = minimax_failure_reason(data)
+        if reason:
+            raise RuntimeError(reason)
+
+        url = extract_image_url(data)
+        if url:
+            await download_image_to_path(url, output_path)
+            return url
+
+        b64 = extract_image_base64(data)
+        if b64:
+            await _write_base64_image(b64, output_path)
+            return None
+
+        raise RuntimeError(f"MiniMax 图像响应缺少 image_urls/image_base64: {data}")
+
+
+async def _write_base64_image(b64: str, output_path: Path) -> None:
+    """解码 base64 图片并写盘（解码 + 写盘 offload 到线程，避免事件循环内做 CPU 密集解码）。
+
+    容忍少数中转返回 data URI（``data:image/...;base64,<payload>``）：剥前缀后再解码。
+    """
+    payload = b64
+    if payload.startswith("data:") and "," in payload:
+        payload = payload.split(",", 1)[1]
+
+    def _decode_and_save() -> None:
+        image_bytes = base64.b64decode(payload)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(image_bytes)
+
+    await asyncio.to_thread(_decode_and_save)

--- a/lib/image_backends/minimax.py
+++ b/lib/image_backends/minimax.py
@@ -216,7 +216,10 @@ class MiniMaxImageBackend:
             await _write_base64_image(b64, output_path)
             return None
 
-        raise RuntimeError(f"MiniMax 图像响应缺少 image_urls/image_base64: {data}")
+        # 完整响应体记日志便于诊断，但不嵌进异常消息——避免 body 里的 "503"/"timeout" 等子串
+        # 被默认 _should_retry 误判为可重试（仓库已确立按状态码而非字符串判重试）。
+        logger.error("MiniMax 图像响应缺少 image_urls/image_base64: %s", data)
+        raise RuntimeError("MiniMax 图像响应缺少 image_urls/image_base64")
 
     @with_retry_async(
         max_attempts=DOWNLOAD_MAX_ATTEMPTS,

--- a/lib/image_backends/minimax.py
+++ b/lib/image_backends/minimax.py
@@ -109,7 +109,9 @@ class MiniMaxImageBackend:
         if request.seed is not None:
             payload["seed"] = request.seed
         if request.reference_images:
-            payload["subject_reference"] = self._build_subject_reference(request)
+            # 参考图读盘 + base64 编码（可能数 MB）offload 到线程，避免阻塞事件循环；
+            # 单次 to_thread 整体执行同步 helper，最小化线程调度开销。
+            payload["subject_reference"] = await asyncio.to_thread(self._build_subject_reference, request)
 
         data = await self._submit(payload)
         image_uri = await self._persist_image(data, request.output_path)

--- a/lib/image_backends/minimax.py
+++ b/lib/image_backends/minimax.py
@@ -152,11 +152,15 @@ class MiniMaxImageBackend:
         """按「比例优先、清晰度其次」算出 (宽, 高)。
 
         比例永远来自 aspect_ratio；image_size（档位词 / 自定义 宽*高 / None）只决定清晰度短边，
-        自定义值剥离其自带比例（取 min）。结果被 8 整除、长边受 2048 收口，再把每边夹进
-        [512, 2048] 满足 image-01 的单边范围约束。
+        自定义值剥离其自带比例（取 min）。短边先夹到 ≥ _MIN_EDGE 再算尺寸——否则过小的短边会让
+        aspect_size 产出 <512 的边，随后 _clamp_edge 对宽高独立夹取会破坏比例（如 16:9 退化成
+        512x512 的 1:1）。结果被 8 整除、长边受 2048 收口，每边仍经 _clamp_edge 夹进 [512, 2048] 兜底。
         """
-        short = resolution_to_short_edge(
-            request.image_size or None, tier_map=IMAGE_TIER_SHORT_EDGE, default_short=_DEFAULT_SHORT
+        short = max(
+            _MIN_EDGE,
+            resolution_to_short_edge(
+                request.image_size or None, tier_map=IMAGE_TIER_SHORT_EDGE, default_short=_DEFAULT_SHORT
+            ),
         )
         w, h = aspect_size(
             request.aspect_ratio, short, round_to=_ROUND_TO, max_long_edge=_MAX_EDGE, max_ratio=_MAX_RATIO

--- a/lib/image_backends/minimax.py
+++ b/lib/image_backends/minimax.py
@@ -35,8 +35,8 @@ from lib.minimax_shared import (
     safe_body_for_log,
 )
 from lib.providers import PROVIDER_MINIMAX
-from lib.retry import with_retry_async
-from lib.video_backends.base import should_retry_submit, submit_post
+from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
+from lib.video_backends.base import should_retry_download, should_retry_submit, submit_post
 
 logger = logging.getLogger(__name__)
 
@@ -91,8 +91,9 @@ class MiniMaxImageBackend:
         # image-01 文生图 + 图生图（subject_reference）同模型。
         return {ImageCapability.TEXT_TO_IMAGE, ImageCapability.IMAGE_TO_IMAGE}
 
-    @with_retry_async(retry_if=should_retry_submit)
     async def generate(self, request: ImageGenerationRequest) -> ImageGenerationResult:
+        # 编排层不带重试：把非幂等的「建图 + 计费」submit 与幂等的结果下载隔离到各自的
+        # 重试范围（_submit / _download_result），避免下载失败回退到重跑生成 POST 造成重复计费。
         width, height = self._resolve_dimensions(request)
 
         payload: dict = {
@@ -110,26 +111,7 @@ class MiniMaxImageBackend:
         if request.reference_images:
             payload["subject_reference"] = self._build_subject_reference(request)
 
-        logger.info(
-            "调用 %s 图片 API model=%s body=%s",
-            self.name,
-            self._model,
-            format_kwargs_for_log(safe_body_for_log(payload)),
-        )
-        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
-            # 单步图像生成是非幂等的「建图 + 计费」POST：submit_post 把歧义传输错误转
-            # AmbiguousSubmitError 终态失败避免重复计费；>=400 落 body 日志 + 抛 HTTPStatusError
-            # （保留 status_code 供咽喉层识别 413 降档），交 should_retry_submit 按状态码分流。
-            resp = await submit_post(
-                lambda: client.post(
-                    f"{self._base_url}{_IMAGE_ENDPOINT}",
-                    json=payload,
-                    headers=minimax_headers(self._api_key),
-                ),
-                provider=PROVIDER_MINIMAX,
-            )
-            data = resp.json()
-
+        data = await self._submit(payload)
         image_uri = await self._persist_image(data, request.output_path)
         logger.info("MiniMax 图片生成完成: %s", request.output_path)
 
@@ -139,6 +121,32 @@ class MiniMaxImageBackend:
             model=self._model,
             image_uri=image_uri,
         )
+
+    @with_retry_async(retry_if=should_retry_submit)
+    async def _submit(self, payload: dict) -> dict:
+        """单步图像生成 POST（非幂等「建图 + 计费」），返回解析后的响应体。
+
+        重试范围严格限定在本方法内、不含下载——下载失败不会触发整流程重试导致重复建图与
+        重复计费。submit_post 把歧义传输错误转 AmbiguousSubmitError 终态失败避免重复计费；
+        >=400 落 body 日志 + 抛 HTTPStatusError（保留 status_code 供咽喉层识别 413 降档），
+        交 should_retry_submit 按状态码分流。
+        """
+        logger.info(
+            "调用 %s 图片 API model=%s body=%s",
+            self.name,
+            self._model,
+            format_kwargs_for_log(safe_body_for_log(payload)),
+        )
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            resp = await submit_post(
+                lambda: client.post(
+                    f"{self._base_url}{_IMAGE_ENDPOINT}",
+                    json=payload,
+                    headers=minimax_headers(self._api_key),
+                ),
+                provider=PROVIDER_MINIMAX,
+            )
+            return resp.json()
 
     def _resolve_dimensions(self, request: ImageGenerationRequest) -> tuple[int, int]:
         """按「比例优先、清晰度其次」算出 (宽, 高)。
@@ -194,7 +202,7 @@ class MiniMaxImageBackend:
 
         url = extract_image_url(data)
         if url:
-            await download_image_to_path(url, output_path)
+            await self._download_result(url, output_path)
             return url
 
         b64 = extract_image_base64(data)
@@ -203,6 +211,19 @@ class MiniMaxImageBackend:
             return None
 
         raise RuntimeError(f"MiniMax 图像响应缺少 image_urls/image_base64: {data}")
+
+    @with_retry_async(
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
+        retry_if=should_retry_download,
+    )
+    async def _download_result(self, url: str, output_path: Path) -> None:
+        """下载已签发的结果图 URL（幂等 GET），独立的下载重试范围。
+
+        瞬态失败在本层重试，绝不回退到重跑非幂等的生成 POST；4xx（URL 失效等确定性错误）
+        快速失败。下载比生成更宽容（失败不浪费生成额度），故用 DOWNLOAD_* 重试配置。
+        """
+        await download_image_to_path(url, output_path)
 
 
 async def _write_base64_image(b64: str, output_path: Path) -> None:

--- a/lib/minimax_shared.py
+++ b/lib/minimax_shared.py
@@ -66,12 +66,12 @@ def _as_dict(value: object) -> dict:
 # ── 单步 image_generation 响应工具 ────────────────────────────────────────────
 
 
-def extract_image_url(payload: dict) -> str | None:
+def extract_image_url(payload: object) -> str | None:
     """从 image_generation 响应 data.image_urls 取首个 URL（response_format=url，24h 有效）。
 
-    无可用 URL（字段缺失 / 非 list / 全为空）返回 None，由 caller 回落 base64 或报错。
+    无可用 URL（顶层 / data 非 dict、字段缺失、非 list、全为空）返回 None，由 caller 回落 base64 或报错。
     """
-    urls = _as_dict(payload.get("data")).get("image_urls")
+    urls = _as_dict(_as_dict(payload).get("data")).get("image_urls")
     if isinstance(urls, list):
         for url in urls:
             if isinstance(url, str) and url:
@@ -79,12 +79,12 @@ def extract_image_url(payload: dict) -> str | None:
     return None
 
 
-def extract_image_base64(payload: dict) -> str | None:
+def extract_image_base64(payload: object) -> str | None:
     """从 image_generation 响应 data.image_base64 取首个 base64（response_format=base64）。
 
-    无可用 base64 返回 None，由 caller 报错。
+    无可用 base64（顶层 / data 非 dict、字段缺失等）返回 None，由 caller 报错。
     """
-    items = _as_dict(payload.get("data")).get("image_base64")
+    items = _as_dict(_as_dict(payload).get("data")).get("image_base64")
     if isinstance(items, list):
         for item in items:
             if isinstance(item, str) and item:
@@ -92,13 +92,13 @@ def extract_image_base64(payload: dict) -> str | None:
     return None
 
 
-def minimax_failure_reason(payload: dict) -> str | None:
+def minimax_failure_reason(payload: object) -> str | None:
     """base_resp.status_code 非零时返回错误描述；成功（0）或缺失 base_resp 返回 None。
 
     MiniMax 业务错误以 HTTP 200 + base_resp.status_code 非零承载（鉴权失败等可能另走 4xx，
     由 submit_post/raise_for_status 兜住），故同步图像响应须先查 base_resp 再取图。
     """
-    base = _as_dict(payload.get("base_resp"))
+    base = _as_dict(_as_dict(payload).get("base_resp"))
     status = base.get("status_code")
     if status is not None and status != 0:
         msg = base.get("status_msg") or ""

--- a/lib/minimax_shared.py
+++ b/lib/minimax_shared.py
@@ -1,15 +1,22 @@
 """MiniMax（海螺）共享工具模块。
 
-供 text_backends factory / config / 连接测试复用。MiniMax 本身 OpenAI 兼容，
+供 text_backends / image_backends / config / 连接测试复用。MiniMax 本身 OpenAI 兼容，
 单 `/v1` base（无 DashScope 那种文本/原生双 base 派生），故只需：
 - MINIMAX_BASE_URL — 国内站默认 base（含 `/v1`）
 - MINIMAX_INTL_BASE_URL — 国际站 base，供配置覆盖参考
 - resolve_minimax_api_key — Bearer API Key 解析（缺失即 raise，不走 env fallback）
 - minimax_text_base_url — 归一化为 {host}/v1，容忍用户填 host 或带 `/v1` 后缀
 - minimax_headers — Bearer 鉴权头
+- extract_image_url / extract_image_base64 — 单步 image_generation 响应取首图
+- minimax_failure_reason — base_resp.status_code 非零时的错误描述
+- safe_body_for_log — 日志白名单视图（剥 base64/URL/prompt）
 """
 
 from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 # 国内站默认 base（含 /v1）；国际站经配置覆盖 base_url 指向 MINIMAX_INTL_BASE_URL。
 MINIMAX_BASE_URL = "https://api.minimaxi.com/v1"
@@ -46,3 +53,78 @@ def minimax_headers(api_key: str) -> dict[str, str]:
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
+
+
+def _as_dict(value: object) -> dict:
+    """把任意值归一化为 dict：非 dict（None / list / str 等异常上游结构）一律回空 dict。
+
+    避免对中转代理 / 错误响应给出的非 dict 真值调用 .get 抛 AttributeError。
+    """
+    return value if isinstance(value, dict) else {}
+
+
+# ── 单步 image_generation 响应工具 ────────────────────────────────────────────
+
+
+def extract_image_url(payload: dict) -> str | None:
+    """从 image_generation 响应 data.image_urls 取首个 URL（response_format=url，24h 有效）。
+
+    无可用 URL（字段缺失 / 非 list / 全为空）返回 None，由 caller 回落 base64 或报错。
+    """
+    urls = _as_dict(payload.get("data")).get("image_urls")
+    if isinstance(urls, list):
+        for url in urls:
+            if isinstance(url, str) and url:
+                return url
+    return None
+
+
+def extract_image_base64(payload: dict) -> str | None:
+    """从 image_generation 响应 data.image_base64 取首个 base64（response_format=base64）。
+
+    无可用 base64 返回 None，由 caller 报错。
+    """
+    items = _as_dict(payload.get("data")).get("image_base64")
+    if isinstance(items, list):
+        for item in items:
+            if isinstance(item, str) and item:
+                return item
+    return None
+
+
+def minimax_failure_reason(payload: dict) -> str | None:
+    """base_resp.status_code 非零时返回错误描述；成功（0）或缺失 base_resp 返回 None。
+
+    MiniMax 业务错误以 HTTP 200 + base_resp.status_code 非零承载（鉴权失败等可能另走 4xx，
+    由 submit_post/raise_for_status 兜住），故同步图像响应须先查 base_resp 再取图。
+    """
+    base = _as_dict(payload.get("base_resp"))
+    status = base.get("status_code")
+    if status is not None and status != 0:
+        msg = base.get("status_msg") or ""
+        return f"MiniMax 图像生成失败 status_code={status}: {msg}".strip()
+    return None
+
+
+# ── 日志脱敏 ──────────────────────────────────────────────────────────────────
+
+# 仅允许进日志的标量字段白名单；prompt 仅记长度、subject_reference 仅计数，
+# base64/URL 一律不入日志（对齐 CodeQL clear-text-logging 约束）。
+_SAFE_LOG_KEYS: frozenset[str] = frozenset(
+    {"model", "aspect_ratio", "width", "height", "response_format", "n", "prompt_optimizer", "seed"}
+)
+
+
+def safe_body_for_log(body: dict) -> dict:
+    """生成安全日志视图：白名单标量 + prompt 仅长度 + subject_reference 仅计数。
+
+    subject_reference 内嵌参考图 base64/URL，prompt 为长文本，一律不展开。
+    """
+    view: dict = {key: body[key] for key in _SAFE_LOG_KEYS if key in body}
+    prompt = body.get("prompt")
+    if isinstance(prompt, str):
+        view["prompt_len"] = len(prompt)
+    refs = body.get("subject_reference")
+    if isinstance(refs, list) and refs:
+        view["subject_reference"] = f"<{len(refs)} ref>"
+    return view

--- a/tests/test_minimax_image_backend.py
+++ b/tests/test_minimax_image_backend.py
@@ -377,6 +377,27 @@ class TestHttpErrors:
         download.assert_not_called()
 
 
+class TestRetryScope:
+    async def test_download_failure_does_not_retrigger_generation(self, tmp_path: Path, monkeypatch):
+        # 下载阶段瞬态失败只在下载层重试，绝不回退到重跑非幂等的生成 POST（防重复建图 + 重复计费）。
+        # 退避 sleep 打桩跳过，避免下载层重试真的等 DOWNLOAD_BACKOFF 秒级时间。
+        from lib.retry import DOWNLOAD_MAX_ATTEMPTS
+
+        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
+        client = _mock_client(_img_response())
+        download = AsyncMock(side_effect=httpx.ConnectError("conn reset"))
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk")
+            with pytest.raises(httpx.ConnectError):
+                await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
+        # 生成 POST 恰好一次（计费一次）；重试全部发生在下载层
+        assert client.post.call_count == 1
+        assert download.call_count == DOWNLOAD_MAX_ATTEMPTS
+
+
 class TestPricing:
     def test_image_01_per_image_flat_cny(self):
         from lib.pricing.lookup import lookup_pricing

--- a/tests/test_minimax_image_backend.py
+++ b/tests/test_minimax_image_backend.py
@@ -1,0 +1,390 @@
+"""MiniMaxImageBackend 单元测试（mock httpx，单步同步端点，不打真实 HTTP）。"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from lib.image_backends.base import (
+    ImageCapability,
+    ImageCapabilityError,
+    ImageGenerationRequest,
+    ReferenceImage,
+)
+from lib.providers import PROVIDER_MINIMAX
+
+
+def _img_response(url: str = "https://x/out.png") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "id": "trace-1",
+        "data": {"image_urls": [url]},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    return resp
+
+
+def _b64_response(b64: str) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "id": "trace-1",
+        "data": {"image_base64": [b64]},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    return resp
+
+
+def _biz_error_response(status_code: int = 1004, msg: str = "invalid api key") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"base_resp": {"status_code": status_code, "status_msg": msg}}
+    return resp
+
+
+def _mock_client(resp: MagicMock) -> AsyncMock:
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+def _make_ref(tmp_path: Path, name: str) -> ReferenceImage:
+    p = tmp_path / name
+    p.write_bytes(b"\x89PNG\r\nfake")
+    return ReferenceImage(path=str(p))
+
+
+def _http_error(status_code: int, message: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://x/v1/image_generation")
+    response = httpx.Response(status_code, request=request, text=message)
+    return httpx.HTTPStatusError(f"error {status_code}", request=request, response=response)
+
+
+def _error_response(status_code: int) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = "Request Entity Too Large"
+    resp.raise_for_status = MagicMock(side_effect=_http_error(status_code, "Request Entity Too Large"))
+    return resp
+
+
+def _patches(client: AsyncMock, download: AsyncMock):
+    return (
+        patch("httpx.AsyncClient", return_value=client),
+        patch("lib.image_backends.minimax.download_image_to_path", download),
+    )
+
+
+class TestCapabilities:
+    def test_image_01_t2i_and_i2i(self):
+        from lib.image_backends.minimax import MiniMaxImageBackend
+
+        b = MiniMaxImageBackend(api_key="sk", model="image-01")
+        assert b.name == PROVIDER_MINIMAX
+        assert b.model == "image-01"
+        assert b.capabilities == {ImageCapability.TEXT_TO_IMAGE, ImageCapability.IMAGE_TO_IMAGE}
+
+    def test_default_model_when_unset(self):
+        from lib.image_backends.minimax import MiniMaxImageBackend
+
+        assert MiniMaxImageBackend(api_key="sk").model == "image-01"
+
+    def test_registered_in_factory(self):
+        from lib.image_backends import create_backend, get_registered_backends
+        from lib.image_backends.minimax import MiniMaxImageBackend
+
+        assert PROVIDER_MINIMAX in get_registered_backends()
+        assert isinstance(create_backend(PROVIDER_MINIMAX, api_key="sk"), MiniMaxImageBackend)
+
+
+class TestTextToImage:
+    async def test_t2i_request_build(self, tmp_path: Path):
+        client = _mock_client(_img_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk", model="image-01", base_url="https://api.minimax.io")
+            result = await b.generate(ImageGenerationRequest(prompt="a fox", output_path=tmp_path / "o.png"))
+
+        body = client.post.call_args.kwargs["json"]
+        assert body["model"] == "image-01"
+        assert body["prompt"] == "a fox"
+        assert body["response_format"] == "url"
+        assert body["n"] == 1
+        assert body["prompt_optimizer"] is False
+        assert "subject_reference" not in body
+        # 默认 aspect_ratio=9:16 精确算、受单边 2048 收口
+        assert (body["width"], body["height"]) == (1152, 2048)
+        # 端点：base host 派生 /v1 + /image_generation
+        assert client.post.call_args.args[0] == "https://api.minimax.io/v1/image_generation"
+        assert client.post.call_args.kwargs["headers"]["Authorization"] == "Bearer sk"
+        assert result.provider == PROVIDER_MINIMAX
+        assert result.model == "image-01"
+        assert result.image_uri == "https://x/out.png"
+        download.assert_called_once()
+
+    async def test_default_endpoint_is_domestic(self, tmp_path: Path):
+        client = _mock_client(_img_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk")
+            await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
+
+        assert client.post.call_args.args[0] == "https://api.minimaxi.com/v1/image_generation"
+
+    async def test_seed_passthrough(self, tmp_path: Path):
+        client = _mock_client(_img_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk")
+            await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png", seed=42))
+
+        assert client.post.call_args.kwargs["json"]["seed"] == 42
+
+    async def test_no_seed_field_when_unset(self, tmp_path: Path):
+        client = _mock_client(_img_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk")
+            await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
+
+        assert "seed" not in client.post.call_args.kwargs["json"]
+
+
+class TestDimensions:
+    async def _dims(self, tmp_path: Path, **req_kwargs) -> tuple[int, int]:
+        client = _mock_client(_img_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk")
+            await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png", **req_kwargs))
+        body = client.post.call_args.kwargs["json"]
+        return body["width"], body["height"]
+
+    async def test_landscape_picks_wide(self, tmp_path: Path):
+        assert await self._dims(tmp_path, aspect_ratio="16:9") == (2048, 1152)
+
+    async def test_square(self, tmp_path: Path):
+        assert await self._dims(tmp_path, aspect_ratio="1:1") == (1440, 1440)
+
+    async def test_explicit_1k_tier(self, tmp_path: Path):
+        assert await self._dims(tmp_path, aspect_ratio="9:16", image_size="1K") == (1008, 1792)
+
+    async def test_custom_pixel_strips_embedded_ratio(self, tmp_path: Path):
+        # 自定义像素 16:9 的 1920*1080 只贡献 min=1080 当短边，比例仍由项目 aspect_ratio=9:16 决定
+        w, h = await self._dims(tmp_path, aspect_ratio="9:16", image_size="1920*1080")
+        assert w * 16 == h * 9 and w < h
+
+    @pytest.mark.parametrize("aspect", ["9:16", "16:9", "1:1", "3:4", "4:3", "2:3", "3:2", "21:9", "5:1"])
+    async def test_dims_within_range_and_multiple_of_8(self, tmp_path: Path, aspect: str):
+        w, h = await self._dims(tmp_path, aspect_ratio=aspect)
+        assert 512 <= w <= 2048 and 512 <= h <= 2048
+        assert w % 8 == 0 and h % 8 == 0
+
+    async def test_extreme_ratio_short_edge_clamped_to_512(self, tmp_path: Path):
+        # 5:1 超出 4:1 可表达上限，短边自然算出 <512 → 夹到 512（仍 8 整除）
+        w, h = await self._dims(tmp_path, aspect_ratio="5:1")
+        assert h == 512 and w == 2040
+
+
+class TestSubjectReference:
+    async def test_i2i_single_subject_reference(self, tmp_path: Path):
+        client = _mock_client(_img_response())
+        download = AsyncMock()
+        ref = _make_ref(tmp_path, "face.png")
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk")
+            await b.generate(
+                ImageGenerationRequest(prompt="hero portrait", output_path=tmp_path / "o.png", reference_images=[ref])
+            )
+
+        subject = client.post.call_args.kwargs["json"]["subject_reference"]
+        assert len(subject) == 1
+        assert subject[0]["type"] == "character"
+        assert subject[0]["image_file"].startswith("data:image/png;base64,")
+
+    async def test_multiple_refs_truncated_to_first(self, tmp_path: Path):
+        client = _mock_client(_img_response())
+        download = AsyncMock()
+        refs = [_make_ref(tmp_path, f"r{i}.png") for i in range(3)]
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk")
+            await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png", reference_images=refs))
+
+        # image-01 单脸参考：仅取首张
+        subject = client.post.call_args.kwargs["json"]["subject_reference"]
+        assert len(subject) == 1
+
+    async def test_missing_ref_raises_unreadable(self, tmp_path: Path):
+        from lib.image_backends.minimax import MiniMaxImageBackend
+
+        b = MiniMaxImageBackend(api_key="sk")
+        with pytest.raises(ImageCapabilityError) as ei:
+            await b.generate(
+                ImageGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.png",
+                    reference_images=[ReferenceImage(path=str(tmp_path / "nope.png"))],
+                )
+            )
+        assert ei.value.code == "image_reference_images_unreadable"
+        assert ei.value.params["names"] == "nope.png"
+
+    async def test_empty_ref_path_treated_as_missing(self, tmp_path: Path):
+        from lib.image_backends.minimax import MiniMaxImageBackend
+
+        b = MiniMaxImageBackend(api_key="sk")
+        with pytest.raises(ImageCapabilityError) as ei:
+            await b.generate(
+                ImageGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.png", reference_images=[ReferenceImage(path="")]
+                )
+            )
+        assert ei.value.code == "image_reference_images_unreadable"
+        # 空路径用 locale 中性序号 #1，不漏中文占位
+        assert ei.value.params["names"] == "#1"
+
+    async def test_ref_read_oserror_raises_unreadable(self, tmp_path: Path):
+        from lib.image_backends.minimax import MiniMaxImageBackend
+
+        ref = _make_ref(tmp_path, "face.png")
+        b = MiniMaxImageBackend(api_key="sk")
+        with patch("lib.image_backends.minimax.image_to_base64_data_uri", side_effect=OSError("permission denied")):
+            with pytest.raises(ImageCapabilityError) as ei:
+                await b.generate(
+                    ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png", reference_images=[ref])
+                )
+        assert ei.value.code == "image_reference_images_unreadable"
+
+
+class TestResponseHandling:
+    async def test_base64_response_decoded_and_saved(self, tmp_path: Path):
+        raw = b"\x89PNG\r\nhello-bytes"
+        b64 = base64.b64encode(raw).decode("ascii")
+        client = _mock_client(_b64_response(b64))
+        download = AsyncMock()
+        out = tmp_path / "o.png"
+        # 不 patch download：base64 路径独立落盘
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk")
+            result = await b.generate(ImageGenerationRequest(prompt="x", output_path=out))
+
+        assert out.read_bytes() == raw
+        # base64 路径无远端 URL
+        assert result.image_uri is None
+        download.assert_not_called()
+
+    async def test_base64_data_uri_prefix_stripped(self, tmp_path: Path):
+        raw = b"PNGDATA"
+        b64 = "data:image/png;base64," + base64.b64encode(raw).decode("ascii")
+        client = _mock_client(_b64_response(b64))
+        out = tmp_path / "o.png"
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk")
+            await b.generate(ImageGenerationRequest(prompt="x", output_path=out))
+
+        assert out.read_bytes() == raw
+
+    async def test_business_error_raises_runtime(self, tmp_path: Path):
+        client = _mock_client(_biz_error_response(1004, "invalid api key"))
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk")
+            with pytest.raises(RuntimeError) as ei:
+                await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
+        assert "1004" in str(ei.value)
+        # 业务错误不重试、不下载
+        assert client.post.call_count == 1
+        download.assert_not_called()
+
+    async def test_empty_data_raises_runtime(self, tmp_path: Path):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"data": {}, "base_resp": {"status_code": 0}}
+        client = _mock_client(resp)
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk")
+            with pytest.raises(RuntimeError):
+                await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
+
+
+class TestHttpErrors:
+    async def test_400_surfaces_httpstatuserror_single_call(self, tmp_path: Path):
+        client = _mock_client(_error_response(400))
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk")
+            with pytest.raises(httpx.HTTPStatusError) as ei:
+                await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
+        assert ei.value.response.status_code == 400
+        assert client.post.call_count == 1
+        download.assert_not_called()
+
+    async def test_413_surfaces_httpstatuserror_no_retry(self, tmp_path: Path):
+        client = _mock_client(_error_response(413))
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.minimax import MiniMaxImageBackend
+
+            b = MiniMaxImageBackend(api_key="sk")
+            with pytest.raises(httpx.HTTPStatusError) as ei:
+                await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
+        # 保留 status_code 让咽喉层识别 413 走降档；单次 fail-fast
+        assert ei.value.response.status_code == 413
+        assert client.post.call_count == 1
+        download.assert_not_called()
+
+
+class TestPricing:
+    def test_image_01_per_image_flat_cny(self):
+        from lib.pricing.lookup import lookup_pricing
+        from lib.pricing.strategies import PricingParams, calculate_pricing
+        from lib.pricing.types import PerImageFlat
+
+        pricing = lookup_pricing(PROVIDER_MINIMAX, "image-01", "image")
+        assert isinstance(pricing, PerImageFlat)
+        amount, currency = calculate_pricing(pricing, PricingParams(call_type="image", model="image-01"))
+        assert amount == pytest.approx(0.025)
+        assert currency == "CNY"

--- a/tests/test_minimax_image_backend.py
+++ b/tests/test_minimax_image_backend.py
@@ -207,6 +207,14 @@ class TestDimensions:
         w, h = await self._dims(tmp_path, aspect_ratio="5:1")
         assert h == 512 and w == 2040
 
+    async def test_small_custom_size_preserves_ratio(self, tmp_path: Path):
+        # 自定义小尺寸（短边 <512）：短边先夹到 _MIN_EDGE，避免 aspect_size 出 <512 边后
+        # 被 _clamp_edge 独立夹取破坏比例（16:9 横屏退化成 512x512 的 1:1）
+        w, h = await self._dims(tmp_path, aspect_ratio="16:9", image_size="320*180")
+        assert w >= 512 and h >= 512
+        assert w > h  # 横屏未退化成 1:1
+        assert abs(w / h - 16 / 9) < 0.1
+
 
 class TestSubjectReference:
     async def test_i2i_single_subject_reference(self, tmp_path: Path):

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -27,17 +27,23 @@ def _text_response(content: str = "ok", in_tok: int = 10, out_tok: int = 5) -> M
 
 
 class TestRegistry:
-    def test_minimax_registered_as_text_provider(self):
+    def test_minimax_registered_with_text_and_image(self):
         from lib.config.registry import PROVIDER_REGISTRY
 
         meta = PROVIDER_REGISTRY[PROVIDER_MINIMAX]
-        assert meta.media_types == ["text"]
+        assert meta.media_types == ["image", "text"]
         assert "api_key" in meta.required_keys
         assert "api_key" in meta.secret_keys
         assert "base_url" in meta.optional_keys
         assert meta.default_base_url == "https://api.minimaxi.com/v1"
         assert "MiniMax-M2.7" in meta.models
         assert meta.models["MiniMax-M2.7"].default is True
+        # image-01：默认图像模型，T2I + I2I，单脸参考
+        image = meta.models["image-01"]
+        assert image.media_type == "image"
+        assert image.default is True
+        assert image.capabilities == ["text_to_image", "image_to_image"]
+        assert image.max_reference_images == 1
 
     def test_env_keys_registered(self):
         from lib.config.env_keys import OTHER_PROVIDER_ENV_KEYS, PROVIDER_SECRET_KEYS

--- a/tests/test_minimax_shared.py
+++ b/tests/test_minimax_shared.py
@@ -136,3 +136,9 @@ class TestSafeBodyForLog:
     def test_omits_absent_scalars(self):
         view = safe_body_for_log({"model": "image-01", "prompt": "x"})
         assert view == {"model": "image-01", "prompt_len": 1}
+
+    def test_empty_subject_reference_omitted(self):
+        # 空列表显式跳过：不漏 subject_reference 字段（日志脱敏是安全关键路径，边界须显式覆盖）
+        view = safe_body_for_log({"model": "image-01", "subject_reference": []})
+        assert "subject_reference" not in view
+        assert view == {"model": "image-01"}

--- a/tests/test_minimax_shared.py
+++ b/tests/test_minimax_shared.py
@@ -80,6 +80,12 @@ class TestExtractImageUrl:
         assert extract_image_url({"data": None}) is None
         assert extract_image_url({"data": ["x"]}) is None
 
+    def test_non_dict_payload_tolerated(self):
+        # 中转代理 / 错误响应可能返回非 dict 顶层（list / str）：不得抛 AttributeError
+        assert extract_image_url(["not", "a", "dict"]) is None
+        assert extract_image_url("error") is None
+        assert extract_image_url(None) is None
+
 
 class TestExtractImageBase64:
     def test_first_base64(self):
@@ -90,6 +96,11 @@ class TestExtractImageBase64:
         assert extract_image_base64({"data": {}}) is None
         assert extract_image_base64({}) is None
 
+    def test_non_dict_payload_tolerated(self):
+        # 顶层非 dict（代理 / 错误响应）一律回 None，不抛 AttributeError
+        assert extract_image_base64(["x"]) is None
+        assert extract_image_base64(None) is None
+
 
 class TestFailureReason:
     def test_success_status_zero_returns_none(self):
@@ -97,6 +108,11 @@ class TestFailureReason:
 
     def test_missing_base_resp_returns_none(self):
         assert minimax_failure_reason({}) is None
+
+    def test_non_dict_payload_returns_none(self):
+        # 顶层非 dict（代理 / 错误响应）不抛 AttributeError，按"无业务错误"回 None
+        assert minimax_failure_reason(["x"]) is None
+        assert minimax_failure_reason("boom") is None
 
     def test_nonzero_status_returns_reason(self):
         reason = minimax_failure_reason({"base_resp": {"status_code": 1004, "status_msg": "invalid api key"}})

--- a/tests/test_minimax_shared.py
+++ b/tests/test_minimax_shared.py
@@ -7,9 +7,13 @@ import pytest
 from lib.minimax_shared import (
     MINIMAX_BASE_URL,
     MINIMAX_INTL_BASE_URL,
+    extract_image_base64,
+    extract_image_url,
+    minimax_failure_reason,
     minimax_headers,
     minimax_text_base_url,
     resolve_minimax_api_key,
+    safe_body_for_log,
 )
 
 
@@ -57,3 +61,78 @@ class TestHeaders:
         h = minimax_headers("sk-abc")
         assert h["Authorization"] == "Bearer sk-abc"
         assert h["Content-Type"] == "application/json"
+
+
+class TestExtractImageUrl:
+    def test_first_url(self):
+        payload = {"data": {"image_urls": ["https://a/1.png", "https://a/2.png"]}}
+        assert extract_image_url(payload) == "https://a/1.png"
+
+    def test_missing_returns_none(self):
+        assert extract_image_url({"data": {}}) is None
+        assert extract_image_url({}) is None
+
+    def test_non_list_or_empty_returns_none(self):
+        assert extract_image_url({"data": {"image_urls": "not-a-list"}}) is None
+        assert extract_image_url({"data": {"image_urls": [""]}}) is None
+
+    def test_non_dict_data_tolerated(self):
+        assert extract_image_url({"data": None}) is None
+        assert extract_image_url({"data": ["x"]}) is None
+
+
+class TestExtractImageBase64:
+    def test_first_base64(self):
+        payload = {"data": {"image_base64": ["AAAA", "BBBB"]}}
+        assert extract_image_base64(payload) == "AAAA"
+
+    def test_missing_returns_none(self):
+        assert extract_image_base64({"data": {}}) is None
+        assert extract_image_base64({}) is None
+
+
+class TestFailureReason:
+    def test_success_status_zero_returns_none(self):
+        assert minimax_failure_reason({"base_resp": {"status_code": 0, "status_msg": "success"}}) is None
+
+    def test_missing_base_resp_returns_none(self):
+        assert minimax_failure_reason({}) is None
+
+    def test_nonzero_status_returns_reason(self):
+        reason = minimax_failure_reason({"base_resp": {"status_code": 1004, "status_msg": "invalid api key"}})
+        assert reason is not None
+        assert "1004" in reason
+        assert "invalid api key" in reason
+
+
+class TestSafeBodyForLog:
+    def test_strips_prompt_base64_url(self):
+        body = {
+            "model": "image-01",
+            "prompt": "a very long prompt describing the scene",
+            "width": 1152,
+            "height": 2048,
+            "response_format": "url",
+            "n": 1,
+            "prompt_optimizer": False,
+            "seed": 7,
+            "subject_reference": [{"type": "character", "image_file": "data:image/png;base64,AAAA"}],
+        }
+        view = safe_body_for_log(body)
+        # 白名单标量保留
+        assert view["model"] == "image-01"
+        assert view["width"] == 1152
+        assert view["height"] == 2048
+        assert view["response_format"] == "url"
+        assert view["n"] == 1
+        assert view["prompt_optimizer"] is False
+        assert view["seed"] == 7
+        # prompt 仅长度、subject_reference 仅计数；base64/URL 不出现
+        assert view["prompt_len"] == len(body["prompt"])
+        assert "prompt" not in view
+        assert view["subject_reference"] == "<1 ref>"
+        assert "data:image" not in repr(view)
+
+    def test_omits_absent_scalars(self):
+        view = safe_body_for_log({"model": "image-01", "prompt": "x"})
+        assert view == {"model": "image-01", "prompt_len": 1}


### PR DESCRIPTION
## 摘要

让 MiniMax `image-01` 图像生成端到端可用——参照已合并的 DashScope 图像 backend 同构先例（单步同步取 URL）。用户选 `image-01` 即可生成角色一致性最稳的电影级人像/立绘，支持单张人脸驱动多场景立绘。

## 改动

- **新增 `MiniMaxImageBackend`**（`lib/image_backends/minimax.py`）：单步 `POST /image_generation`，直接返回 URL（24h 有效）或 base64，立即落地为本地资产；T2I 与 I2I 共用同一请求体。
- **`subject_reference` 单脸参考**：仅取首张人脸驱动角色一致性，多张时截断告警；首张缺失/读取失败 fail-loud（`image_reference_images_unreadable`），不静默丢弃后照常计费。
- **尺寸解析**：按「比例优先、清晰度其次」从 `aspect_ratio` + `image_size` 精确算出 `width`/`height`，被 8 整除、长边 2048 收口、每边夹进 `[512, 2048]`。
- **`minimax_shared` 扩展**：图像 URL/base64 提取工具、`base_resp` 业务错误识别、日志脱敏白名单（剥 base64/URL/prompt）。
- **registry**：注册 `image-01`（默认图像模型，T2I + I2I，`max_reference_images=1`），挂 `per_image_flat`（¥0.025/张，CNY）。
- **自动注册**：`register_backend("minimax", MiniMaxImageBackend)` 于 image `__init__`。

## 验证

- `uv run ruff check` / `ruff format --check`：clean
- `uv run basedpyright`（改动文件）：0 errors / 0 warnings
- `uv run pytest tests/test_minimax_image_backend.py tests/test_minimax_shared.py tests/test_minimax_integration.py`：62 passed（全 mock httpx，不打真实 HTTP）
- 全量 `uv run pytest tests/`：4751 passed（唯一 `test_default_when_unresolvable` 失败为本机 dev DB 环境耦合、非本次回归、CI 干净库会过）

## 审查

以未参与实现的独立视角跑 `/code-review --fix`（5 正确性 + 3 清理 + 1 高度 + 查漏角度）：

- 正确性：无新增 bug。维度数学/夹取保持 8 倍数与范围不变式（5:1 → 2040×512 已核），错误参数键对齐三语模板，per-media-type 默认无冲突。
- 验收标准：六项全由代码（非仅测试）满足。`n=1`/`prompt_optimizer=False` 硬编码与 DashScope 先例一致——架构每请求生成单图，属正确设计而非缺陷。
- 日志安全：白名单仅放安全标量，prompt 仅记长度、subject_reference 仅计数，Bearer 头独立构建不入日志。CodeQL clear-text-logging 约束满足。
- 唯一低置信度发现（`_write_base64_image` 与 base.py 内嵌解码逻辑弱重复）：无干净可复用 helper、修复需改动 diff 外的 base.py，按 `--fix` 契约跳过。

Closes #799


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **新功能**
  * 新增 MiniMax 图片后端，默认模型 `image-01`；支持 Text-to-Image 与 Image-to-Image（最多 1 张参考图），并支持 1K/2K 分辨率与种子参数。
  * 图片结果支持优先按 URL 下载落地，或在可用时解析 Base64/`data URI` 写盘。
  * 新增图片按量计费：CNY `PerImageFlat`，单张 0.025。
* **改进**
  * 增强失败原因识别与日志脱敏，避免敏感内容泄露；下载/生成重试策略更精细。
  * 集成注册校验更新：媒体类型现包含图/文/视频，并覆盖 `image-01` 配置。
* **测试**
  * 完整补齐图片后端、共享工具与集成注册相关用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->