### PR TITLE
feat(provider): 接入 MiniMax 海螺 Hailuo 2.3 / 2.3-Fast 视频生成

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -13,6 +13,7 @@ from lib.pricing.types import (
     PerSecondMatrix,
     PerToken,
     PerTokenVideo,
+    PerVideoBucket,
     Pricing,
     ViduDelegate,
 )
@@ -204,6 +205,11 @@ def _minimax_text_pricing(model_id: str, input_rate: float, output_rate: float) 
         default_model=model_id,
         currency="CNY",
     )
+
+
+# MiniMax 海螺视频按 (分辨率, 时长) 离散档计费（元/次，CNY）。
+def _minimax_video_pricing(model_id: str, buckets: dict[tuple[str, int], float]) -> PerVideoBucket:
+    return PerVideoBucket(rates={model_id: buckets}, default_model=model_id, currency="CNY")
 
 
 PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
@@ -930,7 +936,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
     ),
     "minimax": ProviderMeta(
         display_name="MiniMax",
-        description="MiniMax（海螺）OpenAI 兼容平台，MiniMax-M2.7 文本擅长中文文学与人设创作；缺省国内站，可改 base_url 指向国际站。",
+        description="MiniMax（海螺）OpenAI 兼容平台，M2.7 文本擅长中文文学与人设创作，Hailuo 2.3 视频擅长动漫/插画风；缺省国内站，可改 base_url 指向国际站。",
         required_keys=["api_key"],
         optional_keys=["base_url", "image_max_workers", "video_max_workers"],
         secret_keys=["api_key"],
@@ -942,6 +948,34 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 capabilities=["text_generation", "structured_output"],
                 default=True,
                 pricing=_minimax_text_pricing("MiniMax-M2.7", 2.1, 8.4),
+            ),
+            # --- video ---
+            # 1080P 仅 6s（10s 仅 768P）；细粒度越界由 MiniMaxVideoBackend 抛 VideoCapabilityError，
+            # duration_resolution_constraints 同步给前端做下拉门控。
+            "MiniMax-Hailuo-2.3": ModelInfo(
+                display_name="MiniMax Hailuo 2.3",
+                media_type="video",
+                capabilities=["text_to_video", "image_to_video"],
+                default=True,
+                supported_durations=[6, 10],
+                resolutions=["768p", "1080p"],
+                duration_resolution_constraints={"1080p": [6]},
+                pricing=_minimax_video_pricing(
+                    "MiniMax-Hailuo-2.3",
+                    {("768p", 6): 2.0, ("768p", 10): 4.0, ("1080p", 6): 3.5},
+                ),
+            ),
+            "MiniMax-Hailuo-2.3-Fast": ModelInfo(
+                display_name="MiniMax Hailuo 2.3 Fast",
+                media_type="video",
+                capabilities=["image_to_video"],
+                supported_durations=[6, 10],
+                resolutions=["768p", "1080p"],
+                duration_resolution_constraints={"1080p": [6]},
+                pricing=_minimax_video_pricing(
+                    "MiniMax-Hailuo-2.3-Fast",
+                    {("768p", 6): 1.35, ("768p", 10): 2.25, ("1080p", 6): 2.31},
+                ),
             ),
         },
         default_base_url=MINIMAX_BASE_URL,

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -192,6 +192,8 @@ MESSAGES = {
     # Video Capability
     "video_duration_invalid": "Video duration {duration} is not a valid integer number of seconds",
     "video_duration_not_supported": "Video duration {duration}s is not within the durations supported by this model ({supported})",
+    "video_capability_missing_t2v": "{provider}/{model} does not support text-to-video; provide a first-frame image or switch to a model that supports text-to-video",
+    "video_resolution_duration_unsupported": "Model {model} does not support {duration}s at {resolution} resolution (only {supported}); adjust the resolution or duration",
     "video_reference_images_required": "Model {model} requires at least one reference image; please provide reference images",
     "video_reference_images_unreadable": "Model {model} has reference images that are missing or unreadable; generation aborted: {names}; check the reference image paths",
     "video_start_image_unreadable": "The first-frame image for model {model} is unreadable; generation aborted: {name}; check the first-frame image path",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -192,6 +192,8 @@ MESSAGES = {
     # Video Capability
     "video_duration_invalid": "Thời lượng video {duration} không phải là số giây nguyên hợp lệ",
     "video_duration_not_supported": "Thời lượng video {duration}s không nằm trong các thời lượng mà mô hình này hỗ trợ ({supported})",
+    "video_capability_missing_t2v": "{provider}/{model} không hỗ trợ text-to-video; hãy cung cấp ảnh khung hình đầu hoặc chuyển sang mô hình có hỗ trợ text-to-video",
+    "video_resolution_duration_unsupported": "Mô hình {model} không hỗ trợ {duration}s ở độ phân giải {resolution} (chỉ {supported}); hãy điều chỉnh độ phân giải hoặc thời lượng",
     "video_reference_images_required": "Mô hình {model} cần ít nhất một ảnh tham chiếu; hãy cung cấp ảnh tham chiếu",
     "video_reference_images_unreadable": "Mô hình {model} có ảnh tham chiếu bị thiếu hoặc không đọc được; đã hủy tạo: {names}; hãy kiểm tra đường dẫn ảnh tham chiếu",
     "video_start_image_unreadable": "Ảnh khung hình đầu của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình đầu",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -192,6 +192,8 @@ MESSAGES = {
     # Video Capability
     "video_duration_invalid": "视频时长 {duration} 不是合法的整数秒数",
     "video_duration_not_supported": "视频时长 {duration}s 不在该模型支持的时长（{supported}）内",
+    "video_capability_missing_t2v": "{provider}/{model} 不支持文生视频；请提供首帧图，或换一个支持文生视频的模型",
+    "video_resolution_duration_unsupported": "模型 {model} 在 {resolution} 分辨率下不支持 {duration}s（仅支持 {supported}）；请调整分辨率或时长",
     "video_reference_images_required": "模型 {model} 需要至少一张参考图；请提供参考图",
     "video_reference_images_unreadable": "模型 {model} 有参考图缺失或无法读取，已中止生成：{names}；请检查参考图路径",
     "video_start_image_unreadable": "模型 {model} 的首帧图无法读取，已中止生成：{name}；请检查首帧图路径",

--- a/lib/minimax_shared.py
+++ b/lib/minimax_shared.py
@@ -1,15 +1,19 @@
 """MiniMax（海螺）共享工具模块。
 
-供 text_backends factory / config / 连接测试复用。MiniMax 本身 OpenAI 兼容，
-单 `/v1` base（无 DashScope 那种文本/原生双 base 派生），故只需：
+供 text_backends / video_backends / config / 连接测试复用。MiniMax 本身 OpenAI 兼容，
+单 `/v1` base（无 DashScope 那种文本/原生双 base 派生），文本与原生视频端点共用同一 base：
 - MINIMAX_BASE_URL — 国内站默认 base（含 `/v1`）
 - MINIMAX_INTL_BASE_URL — 国际站 base，供配置覆盖参考
 - resolve_minimax_api_key — Bearer API Key 解析（缺失即 raise，不走 env fallback）
-- minimax_text_base_url — 归一化为 {host}/v1，容忍用户填 host 或带 `/v1` 后缀
+- minimax_text_base_url / minimax_video_base_url — 归一化为 {host}/v1，容忍用户填 host 或带 `/v1` 后缀
 - minimax_headers — Bearer 鉴权头
+- 视频两步取 URL 状态机：submit→轮询 query 至 status=Success 取 file_id→files/retrieve 取 download_url
 """
 
 from __future__ import annotations
+
+import base64
+from pathlib import Path
 
 # 国内站默认 base（含 /v1）；国际站经配置覆盖 base_url 指向 MINIMAX_INTL_BASE_URL。
 MINIMAX_BASE_URL = "https://api.minimaxi.com/v1"
@@ -17,6 +21,23 @@ MINIMAX_INTL_BASE_URL = "https://api.minimax.io/v1"
 
 # 单一已知路径后缀，归一化 host 时剥除以容忍用户填入完整 base。
 _V1_SUFFIX = "/v1"
+
+# 视频异步任务终态：Success/Fail；中间态 Preparing/Queueing/Processing 继续轮询。
+MINIMAX_STATUS_SUCCESS = "Success"
+MINIMAX_STATUS_FAIL = "Fail"
+_TERMINAL_VIDEO_STATES = frozenset({MINIMAX_STATUS_SUCCESS, MINIMAX_STATUS_FAIL})
+
+# 轮询间隔（秒）：海螺视频生成通常数十秒至数分钟，10s 一次平衡时延与请求量。
+MINIMAX_VIDEO_POLL_INTERVAL_SECONDS = 10.0
+
+# 图片后缀 → MIME（first_frame_image 接受 data URI）。
+_IMAGE_MIME_TYPES: dict[str, str] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
 
 
 def resolve_minimax_api_key(api_key: str | None = None) -> str:
@@ -40,9 +61,93 @@ def minimax_text_base_url(configured: str | None = None) -> str:
     return f"{_minimax_host(configured)}{_V1_SUFFIX}"
 
 
+def minimax_video_base_url(configured: str | None = None) -> str:
+    """原生视频端点 base：{host}/v1。与文本共用单一 /v1 base，仅命名区分用途。"""
+    return f"{_minimax_host(configured)}{_V1_SUFFIX}"
+
+
 def minimax_headers(api_key: str) -> dict[str, str]:
     """Bearer 鉴权头。"""
     return {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
+
+
+def image_to_data_uri(image_path: Path) -> str:
+    """本地图片 → base64 data URI（first_frame_image 接受 URL 或 data URI）。"""
+    mime = _IMAGE_MIME_TYPES.get(image_path.suffix.lower(), "image/png")
+    b64 = base64.b64encode(image_path.read_bytes()).decode("ascii")
+    return f"data:{mime};base64,{b64}"
+
+
+# ── 视频两步取 URL 状态机工具 ──────────────────────────────────────────────────
+
+
+def _as_dict(value: object) -> dict:
+    """把任意值归一化为 dict：非 dict（含 None / list / str 等异常上游结构）一律回空 dict。"""
+    return value if isinstance(value, dict) else {}
+
+
+def _base_resp_error(payload: dict) -> str | None:
+    """``base_resp.status_code != 0`` → 错误描述；0 或缺失 → None。
+
+    MiniMax 所有响应带 ``base_resp``（``{status_code, status_msg}``），0 表成功。
+    提交/查询/取回接口本身失败（鉴权、task_id 非法等）即在此暴露。
+    """
+    base = _as_dict(payload.get("base_resp"))
+    code = base.get("status_code")
+    if code is not None and code != 0:
+        return f"MiniMax base_resp status_code={code}: {base.get('status_msg', '')}".strip()
+    return None
+
+
+def extract_minimax_video_task_id(submit_payload: dict) -> str:
+    """从提交响应提取顶层 task_id；缺失则按 base_resp 错误或原样抛出。"""
+    task_id = submit_payload.get("task_id")
+    if not task_id:
+        reason = _base_resp_error(submit_payload)
+        raise RuntimeError(reason or f"MiniMax 视频提交响应缺少 task_id: {submit_payload}")
+    return str(task_id)
+
+
+def minimax_video_status(payload: dict) -> str | None:
+    """查询响应的 status 字段（Preparing/Queueing/Processing/Success/Fail）。"""
+    return payload.get("status")
+
+
+def is_minimax_video_terminal(payload: dict) -> bool:
+    """Success / Fail 为终态，停止轮询；其余（含未知/空）继续轮询。"""
+    return minimax_video_status(payload) in _TERMINAL_VIDEO_STATES
+
+
+def minimax_video_failure_reason(payload: dict) -> str | None:
+    """status=Fail 或查询接口顶层 base_resp 硬错误 → 错误描述；否则 None。
+
+    status=Success / 中间态返回 None（中间态由 is_terminal 判定为未完成继续轮询）。
+    """
+    if minimax_video_status(payload) == MINIMAX_STATUS_FAIL:
+        base = _as_dict(payload.get("base_resp"))
+        return (
+            f"MiniMax 视频任务失败 task_id={payload.get('task_id')} "
+            f"status_code={base.get('status_code')}: {base.get('status_msg', '')}"
+        ).strip()
+    # 顶层 base_resp 硬错误（如 task_id 不存在 / 鉴权失败），非 0 即失败。
+    return _base_resp_error(payload)
+
+
+def extract_minimax_file_id(query_payload: dict) -> str:
+    """从 status=Success 的查询响应提取 file_id。"""
+    file_id = query_payload.get("file_id")
+    if not file_id:
+        raise RuntimeError(f"MiniMax 视频任务完成但缺少 file_id: {query_payload}")
+    return str(file_id)
+
+
+def extract_minimax_download_url(retrieve_payload: dict) -> str:
+    """从 files/retrieve 响应提取 file.download_url。"""
+    url = _as_dict(retrieve_payload.get("file")).get("download_url")
+    if not url:
+        reason = _base_resp_error(retrieve_payload)
+        raise RuntimeError(reason or f"MiniMax files/retrieve 响应缺少 download_url: {retrieve_payload}")
+    return url

--- a/lib/pricing/strategies.py
+++ b/lib/pricing/strategies.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from lib.pricing.types import (
@@ -16,10 +17,17 @@ from lib.pricing.types import (
     PerSecondMatrix,
     PerToken,
     PerTokenVideo,
+    PerVideoBucket,
     Pricing,
     ViduDelegate,
 )
 from lib.vidu_shared import calculate_vidu_cost
+
+logger = logging.getLogger(__name__)
+
+# (resolution, duration) 离散档计费里 duration 缺省时的兜底秒数。海螺最短档为 6s，
+# 缺省按最短档计避免高估；真实请求恒带 duration，仅防御性兜底。
+_DEFAULT_BUCKET_DURATION = 6
 
 
 @dataclass(frozen=True)
@@ -124,6 +132,32 @@ def _per_second_matrix(pricing: PerSecondMatrix, params: PricingParams) -> tuple
     return duration * per_second, pricing.currency
 
 
+def _per_video_bucket(pricing: PerVideoBucket, params: PricingParams) -> tuple[float, str]:
+    model = params.model or pricing.default_model
+    model_buckets = pricing.rates.get(model, pricing.rates[pricing.default_model])
+    resolution = (params.resolution or "768p").lower()
+    duration = params.duration_seconds if params.duration_seconds is not None else _DEFAULT_BUCKET_DURATION
+
+    key = (resolution, duration)
+    exact = model_buckets.get(key)
+    if exact is not None:
+        return exact, pricing.currency
+
+    # 未命中档：先在同分辨率档内取 |时长差| 最小者；无同分辨率档再在全部档内取最近。
+    # 同距离按更小时长 tie-break，保证确定性（不依赖 dict 插入序）。
+    same_resolution = [(res, dur) for (res, dur) in model_buckets if res == resolution]
+    candidates = same_resolution or list(model_buckets.keys())
+    nearest = min(candidates, key=lambda k: (abs(k[1] - duration), k[1]))
+    logger.warning(
+        "per_video_bucket 未命中档 model=%s resolution=%s duration=%ss，回落最近档 %s",
+        model,
+        resolution,
+        duration,
+        nearest,
+    )
+    return model_buckets[nearest], pricing.currency
+
+
 def _per_token_video(pricing: PerTokenVideo, params: PricingParams) -> tuple[float, str]:
     model = params.model or pricing.default_model
     model_costs = pricing.rates.get(model, pricing.rates[pricing.default_model])
@@ -163,6 +197,8 @@ def calculate_pricing(pricing: Pricing, params: PricingParams) -> tuple[float, s
         return _per_image_openai_token(pricing, params)
     if isinstance(pricing, PerSecondMatrix):
         return _per_second_matrix(pricing, params)
+    if isinstance(pricing, PerVideoBucket):
+        return _per_video_bucket(pricing, params)
     if isinstance(pricing, PerTokenVideo):
         return _per_token_video(pricing, params)
     if isinstance(pricing, PerCharacter):

--- a/lib/pricing/strategies.py
+++ b/lib/pricing/strategies.py
@@ -144,10 +144,11 @@ def _per_video_bucket(pricing: PerVideoBucket, params: PricingParams) -> tuple[f
         return exact, pricing.currency
 
     # 未命中档：先在同分辨率档内取 |时长差| 最小者；无同分辨率档再在全部档内取最近。
-    # 同距离按更小时长 tie-break，保证确定性（不依赖 dict 插入序）。
+    # tie-break 链保证完全确定性（不依赖 dict 插入序）：|时长差| → 更小时长 → 更低价
+    # （跨分辨率回落时同距离取便宜档，避免高估）→ 档 key（同价时兜底，保证全序）。
     same_resolution = [(res, dur) for (res, dur) in model_buckets if res == resolution]
     candidates = same_resolution or list(model_buckets.keys())
-    nearest = min(candidates, key=lambda k: (abs(k[1] - duration), k[1]))
+    nearest = min(candidates, key=lambda k: (abs(k[1] - duration), k[1], model_buckets[k], k))
     logger.warning(
         "per_video_bucket 未命中档 model=%s resolution=%s duration=%ss，回落最近档 %s",
         model,

--- a/lib/pricing/types.py
+++ b/lib/pricing/types.py
@@ -84,6 +84,24 @@ class PerSecondMatrix:
 
 
 @dataclass(frozen=True)
+class PerVideoBucket:
+    """视频按 (分辨率, 时长秒) 离散档计费：金额=查表 flat_price，与秒数不成比例。
+
+    适用 MiniMax 海螺等「按 (分辨率, 时长) 定价点」而非线性每秒的视频模型。
+
+    - ``rates`` 形如 ``{model: {(分辨率小写, 时长秒): flat_price}}``，分辨率键以小写存储，
+      查表前对入参 ``.lower()``。
+    - 未命中 (resolution, duration) 档时回落该 model「最接近的档」：先在同分辨率档内取
+      |时长差| 最小者，无同分辨率档再在全部档内取最近，并 WARN（档表与请求漂移的可观测信号）。
+    """
+
+    rates: dict[str, dict[tuple[str, int], float]]
+    default_model: str
+    currency: str
+    kind: Literal["per_video_bucket"] = "per_video_bucket"
+
+
+@dataclass(frozen=True)
 class PerTokenVideo:
     """视频按 token 计费（按 ``(service_tier, 是否生成音频)`` 查每百万 token 价）。
 
@@ -131,6 +149,7 @@ Pricing = (
     | PerImageByResolution
     | PerImageOpenAIToken
     | PerSecondMatrix
+    | PerVideoBucket
     | PerTokenVideo
     | PerCharacter
     | ViduDelegate

--- a/lib/video_backends/__init__.py
+++ b/lib/video_backends/__init__.py
@@ -69,3 +69,9 @@ from lib.providers import PROVIDER_DASHSCOPE  # noqa: E402
 from lib.video_backends.dashscope import DashScopeVideoBackend  # noqa: E402
 
 register_backend(PROVIDER_DASHSCOPE, DashScopeVideoBackend)
+
+# MiniMax 海螺 — Hailuo 2.3 / 2.3-Fast 视频
+from lib.providers import PROVIDER_MINIMAX  # noqa: E402
+from lib.video_backends.minimax import MiniMaxVideoBackend  # noqa: E402
+
+register_backend(PROVIDER_MINIMAX, MiniMaxVideoBackend)

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -1,0 +1,290 @@
+"""MiniMaxVideoBackend — MiniMax（海螺）Hailuo 视频生成后端（异步两步取 URL）。
+
+走原生视频端点，轮询而非 callback：submit POST /video_generation 取 task_id →
+轮询 GET /query/video_generation?task_id= 至 status=Success 取 file_id →
+GET /files/retrieve?file_id= 取 download_url → 下载本地。覆盖 MiniMax-Hailuo-2.3
+（t2v+i2v）与 MiniMax-Hailuo-2.3-Fast（仅 i2v，约半价）。
+
+能力约束：resolution ∈ {768P, 1080P}，1080P 仅 6s（10s 仅 768P）；越界抛
+VideoCapabilityError。Fast 仅图生视频，无首帧的文生视频请求被能力拒绝。
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import httpx
+
+from lib.logging_utils import format_kwargs_for_log
+from lib.minimax_shared import (
+    MINIMAX_VIDEO_POLL_INTERVAL_SECONDS,
+    extract_minimax_download_url,
+    extract_minimax_file_id,
+    extract_minimax_video_task_id,
+    image_to_data_uri,
+    is_minimax_video_terminal,
+    minimax_headers,
+    minimax_video_base_url,
+    minimax_video_failure_reason,
+    resolve_minimax_api_key,
+)
+from lib.providers import PROVIDER_MINIMAX
+from lib.retry import (
+    DEFAULT_BACKOFF_SECONDS,
+    DEFAULT_MAX_ATTEMPTS,
+    DOWNLOAD_BACKOFF_SECONDS,
+    DOWNLOAD_MAX_ATTEMPTS,
+    with_retry_async,
+)
+from lib.video_backends.base import (
+    VideoCapabilities,
+    VideoCapability,
+    VideoCapabilityError,
+    VideoGenerationRequest,
+    VideoGenerationResult,
+    download_video,
+    persist_provider_job_id,
+    poll_with_retry,
+    should_retry_download,
+    should_retry_poll,
+    should_retry_submit,
+    submit_post,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "MiniMax-Hailuo-2.3"
+
+_HAILUO = "MiniMax-Hailuo-2.3"
+_HAILUO_FAST = "MiniMax-Hailuo-2.3-Fast"
+
+_SUBMIT_ENDPOINT = "/video_generation"
+_QUERY_ENDPOINT = "/query/video_generation"
+_RETRIEVE_ENDPOINT = "/files/retrieve"
+
+_MIN_POLL_TIMEOUT_SECONDS = 900.0
+_POLL_TIMEOUT_PER_SECOND = 60.0
+
+_TV = VideoCapability.TEXT_TO_VIDEO
+_IV = VideoCapability.IMAGE_TO_VIDEO
+
+# 按 model id 派发能力：Hailuo 2.3 文+图生视频；2.3-Fast 仅图生视频。
+_MODEL_CAPABILITIES: dict[str, set[VideoCapability]] = {
+    _HAILUO: {_TV, _IV},
+    _HAILUO_FAST: {_IV},
+}
+# 未知 model（代理中转自定义命名）按通用文+图生视频处理。
+_DEFAULT_CAPABILITIES: set[VideoCapability] = {_TV, _IV}
+
+# (分辨率小写 → 允许的时长集合)：1080P 仅 6s，768P 支持 6s/10s（两代 Hailuo 同此矩阵）。
+_RESOLUTION_DURATIONS: dict[str, set[int]] = {"768p": {6, 10}, "1080p": {6}}
+
+# 进日志的安全标量白名单；first_frame_image（base64）一律不入日志。
+_SAFE_LOG_KEYS: frozenset[str] = frozenset({"model", "resolution", "duration"})
+
+
+def _capabilities_for_model(model: str | None) -> set[VideoCapability]:
+    normalized = (model or "").strip()
+    return _MODEL_CAPABILITIES.get(normalized, _DEFAULT_CAPABILITIES)
+
+
+def _safe_body_for_log(body: dict) -> dict:
+    """安全日志视图：白名单标量 + prompt 截断；first_frame_image 仅标记是否存在。"""
+    safe = {k: v for k, v in body.items() if k in _SAFE_LOG_KEYS}
+    if "prompt" in body:
+        prompt = body["prompt"] or ""
+        safe["prompt"] = prompt[:120] + ("…" if len(prompt) > 120 else "")
+    if body.get("first_frame_image"):
+        safe["first_frame_image"] = "<data_uri>"
+    return safe
+
+
+class MiniMaxVideoBackend:
+    """MiniMax 海螺视频后端（异步两步取 URL，轮询）。"""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        http_timeout: float = 60.0,
+    ) -> None:
+        self._api_key = resolve_minimax_api_key(api_key)
+        self._base_url = minimax_video_base_url(base_url)
+        self._model = model or DEFAULT_MODEL
+        self._http_timeout = http_timeout
+        self._capabilities = _capabilities_for_model(self._model)
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_MINIMAX
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def capabilities(self) -> set[VideoCapability]:
+        return self._capabilities
+
+    @staticmethod
+    def video_capabilities_for_model(model: str) -> VideoCapabilities:
+        """海螺图生视频走 first_frame_image 首帧；首批不建模尾帧/参考图。"""
+        return VideoCapabilities(first_frame=True)
+
+    @property
+    def video_capabilities(self) -> VideoCapabilities:
+        return self.video_capabilities_for_model(self._model)
+
+    async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
+        payload = self._build_payload(request)
+        logger.info(
+            "调用 %s 视频 API model=%s body=%s",
+            self.name,
+            self._model,
+            format_kwargs_for_log(_safe_body_for_log(payload)),
+        )
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            task_id = await self._create_task(client, payload)
+            logger.info("MiniMax 视频任务已创建: task_id=%s model=%s", task_id, self._model)
+            if request.task_id is not None:
+                await persist_provider_job_id(request.task_id, task_id, provider=PROVIDER_MINIMAX)
+            return await self._poll_and_build(client, task_id, request)
+
+    async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
+        """接续已 submit 的 MiniMax task：仅轮询 + 取回 + 下载，不重新提交（ADR 0007）。"""
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            return await self._poll_and_build(client, job_id, request)
+
+    # ── request building ────────────────────────────────────────────────
+
+    def _build_payload(self, request: VideoGenerationRequest) -> dict:
+        resolution = (request.resolution or "768p").lower()
+        duration = request.duration_seconds
+        has_start_image = isinstance(request.start_image, (str, Path)) and str(request.start_image)
+
+        # 无首帧 = 文生视频意图；模型不支持 t2v（如 Fast）即拒绝。
+        if not has_start_image and _TV not in self._capabilities:
+            raise VideoCapabilityError("video_capability_missing_t2v", provider=self.name, model=self._model)
+
+        allowed_durations = _RESOLUTION_DURATIONS.get(resolution, set())
+        if duration not in allowed_durations:
+            supported = ", ".join(f"{d}s" for d in sorted(allowed_durations)) or "无"
+            raise VideoCapabilityError(
+                "video_resolution_duration_unsupported",
+                model=self._model,
+                resolution=resolution.upper(),
+                duration=duration,
+                supported=supported,
+            )
+
+        payload: dict = {
+            "model": self._model,
+            "prompt": request.prompt,
+            "duration": duration,
+            "resolution": resolution.upper(),
+        }
+        if has_start_image:
+            p = Path(request.start_image)  # type: ignore[arg-type]
+            # fail-loud：声明了首帧图却缺失/不可读即中止，不静默退化为文生视频。
+            if not p.is_file():
+                raise VideoCapabilityError("video_start_image_unreadable", model=self._model, name=p.name)
+            try:
+                payload["first_frame_image"] = image_to_data_uri(p)
+            except OSError as exc:
+                raise VideoCapabilityError("video_start_image_unreadable", model=self._model, name=p.name) from exc
+        return payload
+
+    # ── HTTP submit / poll / retrieve / download ────────────────────────
+
+    @with_retry_async(
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+        retry_if=should_retry_submit,
+    )
+    async def _create_task(self, client: httpx.AsyncClient, payload: dict) -> str:
+        # 非幂等的「建任务 + 计费」POST：submit_post 把歧义传输错误转 AmbiguousSubmitError
+        # 终态失败，避免重试重复建任务 + 重复计费；>=400 抛 HTTPStatusError 交 should_retry_submit
+        # 按状态码分流（4xx fail-fast、5xx/429 重试）。
+        resp = await submit_post(
+            lambda: client.post(
+                f"{self._base_url}{_SUBMIT_ENDPOINT}",
+                json=payload,
+                headers=minimax_headers(self._api_key),
+            ),
+            provider=PROVIDER_MINIMAX,
+        )
+        return extract_minimax_video_task_id(resp.json())
+
+    async def _poll_query(self, client: httpx.AsyncClient, task_id: str) -> dict:
+        resp = await client.get(
+            f"{self._base_url}{_QUERY_ENDPOINT}",
+            params={"task_id": task_id},
+            headers=minimax_headers(self._api_key),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    @with_retry_async(
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+        retry_if=should_retry_poll,
+    )
+    async def _retrieve_download_url(self, client: httpx.AsyncClient, file_id: str) -> str:
+        # 取回是幂等 GET（不计费），瞬态错误重试无副作用。
+        resp = await client.get(
+            f"{self._base_url}{_RETRIEVE_ENDPOINT}",
+            params={"file_id": file_id},
+            headers=minimax_headers(self._api_key),
+        )
+        resp.raise_for_status()
+        return extract_minimax_download_url(resp.json())
+
+    async def _poll_and_build(
+        self,
+        client: httpx.AsyncClient,
+        task_id: str,
+        request: VideoGenerationRequest,
+    ) -> VideoGenerationResult:
+        final = await poll_with_retry(
+            poll_fn=lambda: self._poll_query(client, task_id),
+            is_done=is_minimax_video_terminal,
+            is_failed=minimax_video_failure_reason,
+            poll_interval=MINIMAX_VIDEO_POLL_INTERVAL_SECONDS,
+            max_wait=self._max_wait(request.duration_seconds),
+            retry_if=should_retry_poll,
+            label="MiniMax",
+            on_progress=lambda v, elapsed: logger.info(
+                "MiniMax 视频生成中... status=%s elapsed=%ds", v.get("status"), int(elapsed)
+            ),
+        )
+
+        file_id = extract_minimax_file_id(final)
+        download_url = await self._retrieve_download_url(client, file_id)
+        await self._download_with_retry(download_url, request.output_path)
+        logger.info("MiniMax 视频下载完成: %s", request.output_path)
+
+        return VideoGenerationResult(
+            video_path=request.output_path,
+            provider=PROVIDER_MINIMAX,
+            model=self._model,
+            duration_seconds=request.duration_seconds,
+            video_uri=download_url,
+            task_id=task_id,
+            generate_audio=request.generate_audio,
+        )
+
+    @staticmethod
+    @with_retry_async(
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
+        retry_if=should_retry_download,
+    )
+    async def _download_with_retry(download_url: str, output_path: Path) -> None:
+        await download_video(download_url, output_path)
+
+    @staticmethod
+    def _max_wait(duration_seconds: int) -> float:
+        return max(_MIN_POLL_TIMEOUT_SECONDS, duration_seconds * _POLL_TIMEOUT_PER_SECOND)

--- a/server/services/resolution_resolver.py
+++ b/server/services/resolution_resolver.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-# 当 resolve_resolution 返回 None 时下游的保底分辨率。#387 Grok 即便 registry
-# 声明 1080p 也可能被 xai_sdk 拒收，故按 provider 区分。
+# 当 resolve_resolution 返回 None 时下游的保底分辨率。Grok 即便 registry 声明 1080p
+# 也可能被 xai_sdk 拒收，故按 provider 区分。
 PROVIDER_FALLBACK_RESOLUTION: dict[str, str] = {
     "gemini": "1080p",
     "ark": "720p",
     "grok": "720p",
     "openai": "720p",
+    # MiniMax 海螺缺省 768P：1080P 仅 6s，默认落 768P 避免与 10s 档冲突。
+    "minimax": "768p",
 }
 
 

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -27,11 +27,11 @@ def _text_response(content: str = "ok", in_tok: int = 10, out_tok: int = 5) -> M
 
 
 class TestRegistry:
-    def test_minimax_registered_as_text_provider(self):
+    def test_minimax_registered_as_text_and_video_provider(self):
         from lib.config.registry import PROVIDER_REGISTRY
 
         meta = PROVIDER_REGISTRY[PROVIDER_MINIMAX]
-        assert meta.media_types == ["text"]
+        assert meta.media_types == ["text", "video"]
         assert "api_key" in meta.required_keys
         assert "api_key" in meta.secret_keys
         assert "base_url" in meta.optional_keys
@@ -121,6 +121,55 @@ class TestLookupPricing:
             p, PricingParams(call_type="text", model="minimax-unknown-xyz", input_tokens=1000, output_tokens=0)
         )
         assert cur == "CNY"
+
+    @pytest.mark.parametrize(
+        ("model", "resolution", "duration", "expected"),
+        [
+            ("MiniMax-Hailuo-2.3", "768p", 6, 2.0),
+            ("MiniMax-Hailuo-2.3", "768p", 10, 4.0),
+            ("MiniMax-Hailuo-2.3", "1080p", 6, 3.5),
+            ("MiniMax-Hailuo-2.3-Fast", "768p", 6, 1.35),
+            ("MiniMax-Hailuo-2.3-Fast", "768p", 10, 2.25),
+            ("MiniMax-Hailuo-2.3-Fast", "1080p", 6, 2.31),
+        ],
+    )
+    def test_video_per_video_bucket(self, model, resolution, duration, expected):
+        p = lookup_pricing(PROVIDER_MINIMAX, model, "video")
+        amount, cur = calculate_pricing(
+            p, PricingParams(call_type="video", model=model, resolution=resolution, duration_seconds=duration)
+        )
+        assert cur == "CNY"
+        assert amount == pytest.approx(expected)
+
+    def test_video_unmet_bucket_falls_back_nearest_cny(self):
+        # 1080p 仅 6s 档；请求 1080p 10s 未命中 → 同分辨率最近档 (1080p,6)=3.5
+        p = lookup_pricing(PROVIDER_MINIMAX, "MiniMax-Hailuo-2.3", "video")
+        amount, cur = calculate_pricing(
+            p, PricingParams(call_type="video", model="MiniMax-Hailuo-2.3", resolution="1080p", duration_seconds=10)
+        )
+        assert cur == "CNY"
+        assert amount == pytest.approx(3.5)
+
+
+class TestVideoRegistry:
+    def test_video_models_registered(self):
+        from lib.config.registry import PROVIDER_REGISTRY
+
+        models = PROVIDER_REGISTRY[PROVIDER_MINIMAX].models
+        hailuo = models["MiniMax-Hailuo-2.3"]
+        assert hailuo.media_type == "video"
+        assert "text_to_video" in hailuo.capabilities
+        assert "image_to_video" in hailuo.capabilities
+        assert hailuo.supported_durations == [6, 10]
+        assert hailuo.duration_resolution_constraints == {"1080p": [6]}
+
+        fast = models["MiniMax-Hailuo-2.3-Fast"]
+        assert fast.capabilities == ["image_to_video"]
+
+    def test_video_backend_registered(self):
+        from lib.video_backends import get_registered_backends
+
+        assert PROVIDER_MINIMAX in get_registered_backends()
 
 
 class TestProviderConstantsDistinct:

--- a/tests/test_minimax_shared.py
+++ b/tests/test_minimax_shared.py
@@ -2,13 +2,24 @@
 
 from __future__ import annotations
 
+import base64
+
 import pytest
 
 from lib.minimax_shared import (
     MINIMAX_BASE_URL,
     MINIMAX_INTL_BASE_URL,
+    MINIMAX_STATUS_FAIL,
+    MINIMAX_STATUS_SUCCESS,
+    extract_minimax_download_url,
+    extract_minimax_file_id,
+    extract_minimax_video_task_id,
+    image_to_data_uri,
+    is_minimax_video_terminal,
     minimax_headers,
     minimax_text_base_url,
+    minimax_video_base_url,
+    minimax_video_failure_reason,
     resolve_minimax_api_key,
 )
 
@@ -57,3 +68,88 @@ class TestHeaders:
         h = minimax_headers("sk-abc")
         assert h["Authorization"] == "Bearer sk-abc"
         assert h["Content-Type"] == "application/json"
+
+
+class TestVideoBaseUrl:
+    def test_shares_v1_base_with_text(self):
+        # 视频原生端点与文本同走单 /v1 base
+        assert minimax_video_base_url(None) == MINIMAX_BASE_URL
+        assert minimax_video_base_url(MINIMAX_INTL_BASE_URL) == "https://api.minimax.io/v1"
+        assert minimax_video_base_url("https://api.minimax.io") == "https://api.minimax.io/v1"
+
+
+class TestExtractVideoTaskId:
+    def test_extracts_top_level_task_id(self):
+        payload = {"task_id": "12345", "base_resp": {"status_code": 0, "status_msg": "success"}}
+        assert extract_minimax_video_task_id(payload) == "12345"
+
+    def test_missing_task_id_raises_with_base_resp_reason(self):
+        payload = {"base_resp": {"status_code": 1004, "status_msg": "auth failed"}}
+        with pytest.raises(RuntimeError, match="1004"):
+            extract_minimax_video_task_id(payload)
+
+    def test_missing_task_id_no_base_resp_raises(self):
+        with pytest.raises(RuntimeError):
+            extract_minimax_video_task_id({})
+
+
+class TestVideoStateMachine:
+    def test_processing_not_terminal(self):
+        for status in ("Preparing", "Queueing", "Processing"):
+            assert is_minimax_video_terminal({"status": status}) is False
+            assert minimax_video_failure_reason({"status": status}) is None
+
+    def test_success_is_terminal(self):
+        payload = {"status": MINIMAX_STATUS_SUCCESS, "file_id": "f-1"}
+        assert is_minimax_video_terminal(payload) is True
+        assert minimax_video_failure_reason(payload) is None
+
+    def test_fail_is_terminal_and_reports_reason(self):
+        payload = {"status": MINIMAX_STATUS_FAIL, "base_resp": {"status_code": 2013, "status_msg": "invalid params"}}
+        assert is_minimax_video_terminal(payload) is True
+        reason = minimax_video_failure_reason(payload)
+        assert reason is not None
+        assert "2013" in reason
+
+    def test_query_base_resp_hard_error_is_failure(self):
+        # 查询接口本身失败（如 task_id 不存在）：base_resp 非 0 即终态失败
+        payload = {"status": "", "base_resp": {"status_code": 1004, "status_msg": "invalid task_id"}}
+        assert minimax_video_failure_reason(payload) is not None
+
+    def test_non_dict_payload_tolerated(self):
+        assert is_minimax_video_terminal({"status": None}) is False
+
+
+class TestExtractFileIdAndDownloadUrl:
+    def test_extract_file_id(self):
+        assert extract_minimax_file_id({"status": "Success", "file_id": "f-99"}) == "f-99"
+
+    def test_extract_file_id_missing_raises(self):
+        with pytest.raises(RuntimeError):
+            extract_minimax_file_id({"status": "Success"})
+
+    def test_extract_download_url(self):
+        payload = {"file": {"file_id": "f-1", "download_url": "https://x/o.mp4"}}
+        assert extract_minimax_download_url(payload) == "https://x/o.mp4"
+
+    def test_extract_download_url_missing_raises(self):
+        with pytest.raises(RuntimeError):
+            extract_minimax_download_url({"file": {"file_id": "f-1"}})
+
+    def test_extract_download_url_non_dict_file_tolerated(self):
+        with pytest.raises(RuntimeError):
+            extract_minimax_download_url({"file": None})
+
+
+class TestImageToDataUri:
+    def test_png_data_uri(self, tmp_path):
+        img = tmp_path / "x.png"
+        img.write_bytes(b"\x89PNG\r\n")
+        uri = image_to_data_uri(img)
+        assert uri.startswith("data:image/png;base64,")
+        assert base64.b64decode(uri.split(",", 1)[1]) == b"\x89PNG\r\n"
+
+    def test_jpg_mime(self, tmp_path):
+        img = tmp_path / "x.jpg"
+        img.write_bytes(b"\xff\xd8\xff")
+        assert image_to_data_uri(img).startswith("data:image/jpeg;base64,")

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -1,0 +1,207 @@
+"""MiniMaxVideoBackend 单元测试（mock httpx，异步两步取 URL，不打真实 HTTP）。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lib.providers import PROVIDER_MINIMAX
+from lib.video_backends.base import VideoCapability, VideoCapabilityError, VideoGenerationRequest
+from lib.video_backends.minimax import MiniMaxVideoBackend
+
+
+def _resp(json_body: dict, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _submit(task_id: str = "t-1") -> dict:
+    return {"task_id": task_id, "base_resp": {"status_code": 0, "status_msg": "success"}}
+
+
+def _query(status: str, file_id: str = "", base_resp: dict | None = None) -> dict:
+    body: dict = {
+        "task_id": "t-1",
+        "status": status,
+        "base_resp": base_resp or {"status_code": 0, "status_msg": "success"},
+    }
+    if file_id:
+        body["file_id"] = file_id
+    return body
+
+
+def _retrieve(url: str = "https://x/o.mp4") -> dict:
+    return {"file": {"file_id": "f-1", "download_url": url}, "base_resp": {"status_code": 0}}
+
+
+def _client(*, post=None, get=None) -> AsyncMock:
+    c = AsyncMock()
+    if post is not None:
+        c.post = post
+    if get is not None:
+        c.get = get
+    c.__aenter__ = AsyncMock(return_value=c)
+    c.__aexit__ = AsyncMock(return_value=None)
+    return c
+
+
+def _backend(model: str = "MiniMax-Hailuo-2.3") -> MiniMaxVideoBackend:
+    return MiniMaxVideoBackend(api_key="sk-test", model=model)
+
+
+def _request(tmp_path: Path, **overrides) -> VideoGenerationRequest:
+    kwargs: dict = {
+        "prompt": "a cat",
+        "output_path": tmp_path / "out.mp4",
+        "duration_seconds": 6,
+        "resolution": "768p",
+    }
+    kwargs.update(overrides)
+    return VideoGenerationRequest(**kwargs)
+
+
+class TestConstructionAndCapabilities:
+    def test_name_and_default_model(self):
+        b = MiniMaxVideoBackend(api_key="k")
+        assert b.name == PROVIDER_MINIMAX
+        assert b.model == "MiniMax-Hailuo-2.3"
+
+    def test_hailuo_supports_t2v_and_i2v(self):
+        caps = _backend("MiniMax-Hailuo-2.3").capabilities
+        assert VideoCapability.TEXT_TO_VIDEO in caps
+        assert VideoCapability.IMAGE_TO_VIDEO in caps
+
+    def test_fast_supports_only_i2v(self):
+        caps = _backend("MiniMax-Hailuo-2.3-Fast").capabilities
+        assert VideoCapability.TEXT_TO_VIDEO not in caps
+        assert VideoCapability.IMAGE_TO_VIDEO in caps
+
+    def test_video_capabilities_first_frame(self):
+        assert _backend().video_capabilities.first_frame is True
+
+    def test_missing_api_key_raises(self):
+        with pytest.raises(ValueError):
+            MiniMaxVideoBackend(api_key=None)
+
+
+class TestPayloadAndCapabilityGating:
+    def test_fast_t2v_rejected(self, tmp_path):
+        # 2.3-Fast 无首帧（文生视频意图）→ 能力拒绝
+        b = _backend("MiniMax-Hailuo-2.3-Fast")
+        with pytest.raises(VideoCapabilityError) as exc:
+            b._build_payload(_request(tmp_path, start_image=None))
+        assert exc.value.code == "video_capability_missing_t2v"
+
+    def test_hailuo_t2v_allowed(self, tmp_path):
+        payload = _backend("MiniMax-Hailuo-2.3")._build_payload(_request(tmp_path, start_image=None))
+        assert payload["model"] == "MiniMax-Hailuo-2.3"
+        assert payload["resolution"] == "768P"
+        assert payload["duration"] == 6
+        assert "first_frame_image" not in payload
+
+    def test_1080p_6s_allowed(self, tmp_path):
+        payload = _backend()._build_payload(_request(tmp_path, resolution="1080p", duration_seconds=6))
+        assert payload["resolution"] == "1080P"
+
+    def test_1080p_10s_rejected(self, tmp_path):
+        with pytest.raises(VideoCapabilityError) as exc:
+            _backend()._build_payload(_request(tmp_path, resolution="1080p", duration_seconds=10))
+        assert exc.value.code == "video_resolution_duration_unsupported"
+
+    def test_768p_10s_allowed(self, tmp_path):
+        payload = _backend()._build_payload(_request(tmp_path, resolution="768p", duration_seconds=10))
+        assert payload["resolution"] == "768P"
+        assert payload["duration"] == 10
+
+    def test_unknown_resolution_rejected(self, tmp_path):
+        with pytest.raises(VideoCapabilityError) as exc:
+            _backend()._build_payload(_request(tmp_path, resolution="540p", duration_seconds=6))
+        assert exc.value.code == "video_resolution_duration_unsupported"
+
+    def test_i2v_embeds_first_frame_data_uri(self, tmp_path):
+        img = tmp_path / "first.png"
+        img.write_bytes(b"\x89PNG\r\n")
+        payload = _backend()._build_payload(_request(tmp_path, start_image=img))
+        assert payload["first_frame_image"].startswith("data:image/png;base64,")
+
+    def test_i2v_missing_first_frame_file_raises(self, tmp_path):
+        with pytest.raises(VideoCapabilityError) as exc:
+            _backend()._build_payload(_request(tmp_path, start_image=tmp_path / "nope.png"))
+        assert exc.value.code == "video_start_image_unreadable"
+
+
+class TestGenerateHappyPath:
+    async def test_two_step_url_extraction(self, tmp_path):
+        post = AsyncMock(return_value=_resp(_submit("task-9")))
+        get = AsyncMock(
+            side_effect=[
+                _resp(_query("Processing")),
+                _resp(_query("Success", file_id="file-9")),
+                _resp(_retrieve("https://x/final.mp4")),
+            ]
+        )
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.minimax.download_video", new=AsyncMock()) as dl,
+        ):
+            result = await _backend().generate(_request(tmp_path, duration_seconds=10))
+
+        assert result.provider == PROVIDER_MINIMAX
+        assert result.task_id == "task-9"
+        assert result.video_uri == "https://x/final.mp4"
+        assert result.duration_seconds == 10
+        dl.assert_awaited_once()
+        # submit + 2 query + 1 retrieve
+        assert get.await_count == 3
+
+    async def test_fail_status_raises(self, tmp_path):
+        post = AsyncMock(return_value=_resp(_submit()))
+        get = AsyncMock(return_value=_resp(_query("Fail", base_resp={"status_code": 2013, "status_msg": "invalid"})))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
+        ):
+            with pytest.raises(RuntimeError, match="2013"):
+                await _backend().generate(_request(tmp_path))
+
+    async def test_persists_provider_job_id_when_task_id_present(self, tmp_path):
+        post = AsyncMock(return_value=_resp(_submit("task-x")))
+        get = AsyncMock(side_effect=[_resp(_query("Success", file_id="f")), _resp(_retrieve())])
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
+            patch("lib.video_backends.minimax.persist_provider_job_id", new=AsyncMock()) as persist,
+        ):
+            await _backend().generate(_request(tmp_path, task_id="local-task-1"))
+        persist.assert_awaited_once()
+        assert persist.await_args is not None
+        assert persist.await_args.args[1] == "task-x"
+
+
+class TestResume:
+    async def test_resume_polls_without_resubmit(self, tmp_path):
+        post = AsyncMock()  # must NOT be called
+        get = AsyncMock(side_effect=[_resp(_query("Success", file_id="f-r")), _resp(_retrieve("https://x/r.mp4"))])
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.minimax.download_video", new=AsyncMock()) as dl,
+        ):
+            result = await _backend().resume_video("task-resume", _request(tmp_path))
+
+        post.assert_not_called()
+        assert result.task_id == "task-resume"
+        assert result.video_uri == "https://x/r.mp4"
+        dl.assert_awaited_once()

--- a/tests/test_pricing_strategies.py
+++ b/tests/test_pricing_strategies.py
@@ -355,6 +355,25 @@ class TestPerVideoBucket:
         )
         assert amount == pytest.approx(4.0)
 
+    def test_cross_resolution_tie_break_prefers_cheaper_deterministically(self):
+        # 未知分辨率 540p + duration=6 → 无同分辨率档，("768p",6)=2.0 与 ("1080p",6)=3.5
+        # 时长差同为 0 而完全打平。tie-break 须取更低价档（2.0），且与 dict 插入序无关——
+        # 反向插入同一档表仍得 2.0，证明结果确定。
+        amount, _ = calculate_pricing(
+            self.pricing, PricingParams(call_type="video", model="hailuo", resolution="540p", duration_seconds=6)
+        )
+        assert amount == pytest.approx(2.0)
+
+        reversed_pricing = PerVideoBucket(
+            rates={"hailuo": {("1080p", 6): 3.5, ("768p", 10): 4.0, ("768p", 6): 2.0}},
+            default_model="hailuo",
+            currency="CNY",
+        )
+        reversed_amount, _ = calculate_pricing(
+            reversed_pricing, PricingParams(call_type="video", model="hailuo", resolution="540p", duration_seconds=6)
+        )
+        assert reversed_amount == pytest.approx(2.0)
+
     def test_none_resolution_defaults_to_768p(self):
         amount, _ = calculate_pricing(
             self.pricing, PricingParams(call_type="video", model="hailuo", duration_seconds=6)

--- a/tests/test_pricing_strategies.py
+++ b/tests/test_pricing_strategies.py
@@ -12,6 +12,7 @@ from lib.pricing.types import (
     PerSecondMatrix,
     PerToken,
     PerTokenVideo,
+    PerVideoBucket,
     ViduDelegate,
 )
 
@@ -291,6 +292,78 @@ class TestPerSecondMatrix:
             ),
         )
         assert amount == pytest.approx(0.0)
+
+
+class TestPerVideoBucket:
+    pricing = PerVideoBucket(
+        rates={
+            "hailuo": {("768p", 6): 2.0, ("768p", 10): 4.0, ("1080p", 6): 3.5},
+            "hailuo-fast": {("768p", 6): 1.35, ("768p", 10): 2.25, ("1080p", 6): 2.31},
+        },
+        default_model="hailuo",
+        currency="CNY",
+    )
+
+    def test_exact_bucket_768p_6s(self):
+        amount, currency = calculate_pricing(
+            self.pricing, PricingParams(call_type="video", model="hailuo", resolution="768p", duration_seconds=6)
+        )
+        assert amount == pytest.approx(2.0)
+        assert currency == "CNY"
+
+    def test_exact_bucket_768p_10s(self):
+        amount, _ = calculate_pricing(
+            self.pricing, PricingParams(call_type="video", model="hailuo", resolution="768p", duration_seconds=10)
+        )
+        assert amount == pytest.approx(4.0)
+
+    def test_exact_bucket_1080p_6s(self):
+        amount, _ = calculate_pricing(
+            self.pricing, PricingParams(call_type="video", model="hailuo", resolution="1080p", duration_seconds=6)
+        )
+        assert amount == pytest.approx(3.5)
+
+    def test_fast_model_buckets(self):
+        amount, _ = calculate_pricing(
+            self.pricing, PricingParams(call_type="video", model="hailuo-fast", resolution="1080p", duration_seconds=6)
+        )
+        assert amount == pytest.approx(2.31)
+
+    def test_resolution_uppercased_normalized(self):
+        amount, _ = calculate_pricing(
+            self.pricing, PricingParams(call_type="video", model="hailuo", resolution="768P", duration_seconds=10)
+        )
+        assert amount == pytest.approx(4.0)
+
+    def test_unknown_model_falls_back_to_default(self):
+        amount, _ = calculate_pricing(
+            self.pricing, PricingParams(call_type="video", model="unknown", resolution="768p", duration_seconds=6)
+        )
+        assert amount == pytest.approx(2.0)
+
+    def test_missing_duration_falls_back_to_nearest_same_resolution(self):
+        # 1080p 仅声明 6s 档；请求 1080p 10s 未命中 → 同分辨率档内取最近（6s 档 3.5）。
+        amount, _ = calculate_pricing(
+            self.pricing, PricingParams(call_type="video", model="hailuo", resolution="1080p", duration_seconds=10)
+        )
+        assert amount == pytest.approx(3.5)
+
+    def test_missing_resolution_falls_back_to_nearest_bucket(self):
+        # 未知分辨率无同分辨率档 → 全档取时长最近（duration=10 命中 ("768p",10)=4.0）。
+        amount, _ = calculate_pricing(
+            self.pricing, PricingParams(call_type="video", model="hailuo", resolution="540p", duration_seconds=10)
+        )
+        assert amount == pytest.approx(4.0)
+
+    def test_none_resolution_defaults_to_768p(self):
+        amount, _ = calculate_pricing(
+            self.pricing, PricingParams(call_type="video", model="hailuo", duration_seconds=6)
+        )
+        assert amount == pytest.approx(2.0)
+
+    def test_none_duration_defaults_to_min_bucket(self):
+        amount, _ = calculate_pricing(self.pricing, PricingParams(call_type="video", model="hailuo", resolution="768p"))
+        assert amount == pytest.approx(2.0)
 
 
 class TestPerTokenVideo:


### PR DESCRIPTION
## 做了什么

接入 MiniMax（海螺）`MiniMax-Hailuo-2.3` / `MiniMax-Hailuo-2.3-Fast` 视频生成，端到端可用：

- 用户选 Hailuo 2.3（文生+图生、768P/1080P）或 2.3-Fast（仅图生、约半价）即可出视频。
- 海螺视频走异步轮询：提交任务 → 轮询拿 file_id → 取回 download_url → 在链接失效前转存本地。
- 服务重启后按已提交任务接续轮询，不重复提交、不重复扣费。
- 费用按 (分辨率, 时长) 离散档正确计算（CNY），未命中档回落最近档并告警。
- 能力约束生效：1080P 仅 6s，2.3-Fast 拒绝无首帧的文生视频请求，越界报错并提示可调整项。

## 验收对照（issue #800）

- ✅ Hailuo 2.3 文生+图生出视频；2.3-Fast 仅图生（文生被能力拒绝）
- ✅ duration/resolution 约束：1080p 仅 6s，越界抛 `VideoCapabilityError`
- ✅ 两步取 URL 状态机单测（Processing/Success/Fail），不打真实 HTTP
- ✅ 生成完成即在链接失效前转存本地
- ✅ 重启后按已提交任务接续轮询，不重复提交/扣费
- ✅ 新离散档计费：各档金额、未命中回落最近档 + 告警、币种 CNY，定价测试覆盖

## 验证

- `uv run pytest tests/`：4759 passed（唯一失败 `test_default_when_unresolvable` 为本机 dev DB 环境耦合，非本次改动，CI 干净库通过）
- 新增/覆盖测试：`tests/test_minimax_video_backend.py`、`tests/test_minimax_shared.py`、`tests/test_pricing_strategies.py`、`tests/test_minimax_integration.py`
- `uv run ruff check` / `ruff format --check`：clean
- `uv run basedpyright`：0 error

## 取舍

海螺视频两步取 URL 的任务过期接续未建模专用过期类型——MiniMax task 过期的 wire 语义官方未文档化，不臆造；接续失败走常规失败标记，不重复提交。

Closes #800


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 新增 MiniMax 视频模型支持（MiniMax-Hailuo-2.3、MiniMax-Hailuo-2.3-Fast），支持文生视频/图生视频能力校验与首帧可选提交。
  * 引入“按分辨率 + 时长桶”计费（bucketed video pricing），并在未命中档位时按规则回退到同分辨率的最近档。
  * 扩展视频能力校验提示文案（中英文），覆盖能力缺失与不支持的分辨率/时长组合。

* **Tests**
  * 补充 MiniMax 后端生成/恢复流程、视频计费桶策略及计费金额预期的集成与单元测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->