### PR TITLE
feat(provider): MiniMax S2V-01 单脸参考生视频

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -977,6 +977,21 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                     {("768p", 6): 1.35, ("768p", 10): 2.25, ("1080p", 6): 2.31},
                 ),
             ),
+            # S2V-01：单张人脸驱动整段视频角色一致性（subject_reference 单脸 R2V）。固定输出
+            # 720P/6s，请求不接受 resolution/duration（MiniMaxVideoBackend 走专门的 subject_reference
+            # 路径，忽略这两项）；supported_durations=[6] 仅供编排层时长守卫与档价口径。
+            # max_reference_images=1：编排层解析器读 registry ModelInfo.max_reference_images，据此只取 1 张参考图。
+            # 定价单档约 ¥3（资源包 1.5 积分近似，半核实）；键到 minimax 缺省档 768P/6s 求精确命中，
+            # 任意分辨率漂移由 per_video_bucket 最近档回落到唯一档。
+            "S2V-01": ModelInfo(
+                display_name="MiniMax S2V-01",
+                media_type="video",
+                capabilities=["image_to_video"],
+                supported_durations=[6],
+                resolutions=["768p"],
+                max_reference_images=1,
+                pricing=_minimax_video_pricing("S2V-01", {("768p", 6): 3.0}),
+            ),
         },
         default_base_url=MINIMAX_BASE_URL,
     ),

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -3,10 +3,12 @@
 走原生视频端点，轮询而非 callback：submit POST /video_generation 取 task_id →
 轮询 GET /query/video_generation?task_id= 至 status=Success 取 file_id →
 GET /files/retrieve?file_id= 取 download_url → 下载本地。覆盖 MiniMax-Hailuo-2.3
-（t2v+i2v）与 MiniMax-Hailuo-2.3-Fast（仅 i2v，约半价）。
+（t2v+i2v）、MiniMax-Hailuo-2.3-Fast（仅 i2v，约半价）与 S2V-01（单脸参考生视频 R2V）。
 
-能力约束：resolution ∈ {768P, 1080P}，1080P 仅 6s（10s 仅 768P）；越界抛
-VideoCapabilityError。Fast 仅图生视频，无首帧的文生视频请求被能力拒绝。
+能力约束：Hailuo resolution ∈ {768P, 1080P}，1080P 仅 6s（10s 仅 768P）；越界抛
+VideoCapabilityError，Fast 仅图生视频、无首帧的文生视频请求被能力拒绝。S2V-01 走单脸
+subject_reference（reference_images[0]→{"type":"character","image":[...]}），固定输出、
+不传 resolution/duration，无参考图即 fail-loud。
 """
 
 from __future__ import annotations
@@ -58,6 +60,9 @@ DEFAULT_MODEL = "MiniMax-Hailuo-2.3"
 
 _HAILUO = "MiniMax-Hailuo-2.3"
 _HAILUO_FAST = "MiniMax-Hailuo-2.3-Fast"
+# S2V-01：单张人脸驱动的角色一致性参考生视频（R2V），走 subject_reference 单脸字段，
+# 不接受 first_frame_image / resolution / duration（固定输出）。
+_S2V = "S2V-01"
 
 _SUBMIT_ENDPOINT = "/video_generation"
 _QUERY_ENDPOINT = "/query/video_generation"
@@ -69,10 +74,12 @@ _POLL_TIMEOUT_PER_SECOND = 60.0
 _TV = VideoCapability.TEXT_TO_VIDEO
 _IV = VideoCapability.IMAGE_TO_VIDEO
 
-# 按 model id 派发能力：Hailuo 2.3 文+图生视频；2.3-Fast 仅图生视频。
+# 按 model id 派发能力：Hailuo 2.3 文+图生视频；2.3-Fast 仅图生视频；S2V-01 既非 t2v 也非
+# i2v（subject_reference 驱动，能力经 VideoCapabilities.reference_images 表达），故为空集。
 _MODEL_CAPABILITIES: dict[str, set[VideoCapability]] = {
     _HAILUO: {_TV, _IV},
     _HAILUO_FAST: {_IV},
+    _S2V: set(),
 }
 # 未知 model（代理中转自定义命名）按通用文+图生视频处理。
 _DEFAULT_CAPABILITIES: set[VideoCapability] = {_TV, _IV}
@@ -80,7 +87,7 @@ _DEFAULT_CAPABILITIES: set[VideoCapability] = {_TV, _IV}
 # (分辨率小写 → 允许的时长集合)：1080P 仅 6s，768P 支持 6s/10s（两代 Hailuo 同此矩阵）。
 _RESOLUTION_DURATIONS: dict[str, set[int]] = {"768p": {6, 10}, "1080p": {6}}
 
-# 进日志的安全标量白名单；first_frame_image（base64）一律不入日志。
+# 进日志的安全标量白名单；first_frame_image / subject_reference（base64）一律不入日志。
 _SAFE_LOG_KEYS: frozenset[str] = frozenset({"model", "resolution", "duration"})
 
 
@@ -97,6 +104,8 @@ def _safe_body_for_log(body: dict) -> dict:
         safe["prompt"] = prompt[:120] + ("…" if len(prompt) > 120 else "")
     if body.get("first_frame_image"):
         safe["first_frame_image"] = "<data_uri>"
+    if body.get("subject_reference"):
+        safe["subject_reference"] = "<character_ref>"
     return safe
 
 
@@ -131,7 +140,14 @@ class MiniMaxVideoBackend:
 
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
-        """海螺图生视频走 first_frame_image 首帧；首批不建模尾帧/参考图。"""
+        """海螺图生视频走 first_frame_image 首帧；S2V-01 走 subject_reference 单脸参考生视频。
+
+        S2V-01 仅接受单张人脸参考、不接受首帧图，故 first_frame=False + reference_images=True
+        + max_reference_images=1；reference_images_with_start_frame 维持 False（参考与首帧不叠加）。
+        Hailuo 系列首批不建模尾帧/参考图。
+        """
+        if model == _S2V:
+            return VideoCapabilities(first_frame=False, reference_images=True, max_reference_images=1)
         return VideoCapabilities(first_frame=True)
 
     @property
@@ -161,6 +177,10 @@ class MiniMaxVideoBackend:
     # ── request building ────────────────────────────────────────────────
 
     def _build_payload(self, request: VideoGenerationRequest) -> dict:
+        # S2V-01 走单脸 subject_reference 路径：不取首帧、不传 resolution/duration（固定输出）。
+        if self._model == _S2V:
+            return self._build_s2v_payload(request)
+
         resolution = (request.resolution or "768p").lower()
         duration = request.duration_seconds
         has_start_image = isinstance(request.start_image, (str, Path)) and str(request.start_image)
@@ -196,6 +216,29 @@ class MiniMaxVideoBackend:
             except OSError as exc:
                 raise VideoCapabilityError("video_start_image_unreadable", model=self._model, name=p.name) from exc
         return payload
+
+    def _build_s2v_payload(self, request: VideoGenerationRequest) -> dict:
+        """S2V-01：把 reference_images[0] 映射成单脸 subject_reference。
+
+        编排层已按 registry max_reference_images=1 裁剪，此处防御性仅取首张人脸图。
+        fail-loud：未提供参考图 → required；声明的参考图缺失/不可读 → unreadable，
+        不静默退化为无参考生成（会产出错误结果且照常计费）。
+        """
+        provided = [r for r in (request.reference_images or []) if r]
+        if not provided:
+            raise VideoCapabilityError("video_reference_images_required", model=self._model)
+        face = Path(provided[0])
+        if not face.is_file():
+            raise VideoCapabilityError("video_reference_images_unreadable", model=self._model, names=face.name)
+        try:
+            data_uri = image_to_data_uri(face)
+        except OSError as exc:
+            raise VideoCapabilityError("video_reference_images_unreadable", model=self._model, names=face.name) from exc
+        return {
+            "model": self._model,
+            "prompt": request.prompt,
+            "subject_reference": [{"type": "character", "image": [data_uri]}],
+        }
 
     # ── HTTP submit / poll / retrieve / download ────────────────────────
 

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -572,6 +572,20 @@ class TestVideoCapabilities:
             await engine.dispose()
         assert caps["max_reference_images"] == 1
 
+    async def test_max_reference_images_reads_model_info_for_minimax_s2v(self):
+        """minimax S2V-01 的 max_reference_images 来自 registry ModelInfo（=1）；
+
+        编排层据此只取 1 张参考图，不会向只吃单脸的 S2V-01 拼多张。
+        """
+        factory, engine = await _make_session()
+        try:
+            resolver = ConfigResolver(factory)
+            with patch("lib.config.resolver.get_project_manager"):
+                caps = await resolver.video_capabilities_for_project({"video_backend": "minimax/S2V-01"})
+        finally:
+            await engine.dispose()
+        assert caps["max_reference_images"] == 1
+
     async def test_max_reference_images_reads_model_info_for_ark_seedance(self):
         """ark seedance 的 max_reference_images 来自 registry ModelInfo（=9）。"""
         factory, engine = await _make_session()

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -131,6 +131,8 @@ class TestLookupPricing:
             ("MiniMax-Hailuo-2.3-Fast", "768p", 6, 1.35),
             ("MiniMax-Hailuo-2.3-Fast", "768p", 10, 2.25),
             ("MiniMax-Hailuo-2.3-Fast", "1080p", 6, 2.31),
+            # S2V-01 单档定价（约 ¥3，半核实）：固定 768P/6s 档命中。
+            ("S2V-01", "768p", 6, 3.0),
         ],
     )
     def test_video_per_video_bucket(self, model, resolution, duration, expected):
@@ -150,6 +152,15 @@ class TestLookupPricing:
         assert cur == "CNY"
         assert amount == pytest.approx(3.5)
 
+    def test_s2v01_single_bucket_resolves_for_any_resolution(self):
+        # S2V-01 仅单档，固定输出；任意分辨率经最近档回落到唯一档，价格恒为 ¥3。
+        p = lookup_pricing(PROVIDER_MINIMAX, "S2V-01", "video")
+        amount, cur = calculate_pricing(
+            p, PricingParams(call_type="video", model="S2V-01", resolution="1080p", duration_seconds=6)
+        )
+        assert cur == "CNY"
+        assert amount == pytest.approx(3.0)
+
 
 class TestVideoRegistry:
     def test_video_models_registered(self):
@@ -165,6 +176,16 @@ class TestVideoRegistry:
 
         fast = models["MiniMax-Hailuo-2.3-Fast"]
         assert fast.capabilities == ["image_to_video"]
+
+    def test_s2v01_registered_with_single_reference_cap(self):
+        from lib.config.registry import PROVIDER_REGISTRY
+
+        s2v = PROVIDER_REGISTRY[PROVIDER_MINIMAX].models["S2V-01"]
+        assert s2v.media_type == "video"
+        # 单脸参考生视频：编排层据 registry max_reference_images 只取 1 张。
+        assert s2v.max_reference_images == 1
+        # 固定 6s 输出。
+        assert s2v.supported_durations == [6]
 
     def test_video_backend_registered(self):
         from lib.video_backends import get_registered_backends

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -135,6 +135,82 @@ class TestPayloadAndCapabilityGating:
         assert exc.value.code == "video_start_image_unreadable"
 
 
+class TestS2V01SubjectReference:
+    """S2V-01 单脸参考生视频（R2V）：reference_images[0] → subject_reference 单脸结构。"""
+
+    def test_caps_reference_single_no_first_frame(self):
+        caps = _backend("S2V-01").video_capabilities
+        assert caps.reference_images is True
+        assert caps.max_reference_images == 1
+        # S2V-01 仅 subject_reference 驱动，不接受首帧图。
+        assert caps.first_frame is False
+
+    def test_capability_set_excludes_t2v_and_i2v(self):
+        caps = _backend("S2V-01").capabilities
+        assert VideoCapability.TEXT_TO_VIDEO not in caps
+        assert VideoCapability.IMAGE_TO_VIDEO not in caps
+
+    def test_payload_maps_reference_to_subject_reference(self, tmp_path):
+        face = tmp_path / "face.png"
+        face.write_bytes(b"\x89PNG\r\n")
+        payload = _backend("S2V-01")._build_payload(_request(tmp_path, reference_images=[face]))
+        assert payload["model"] == "S2V-01"
+        assert payload["prompt"] == "a cat"
+        subject = payload["subject_reference"]
+        assert isinstance(subject, list) and len(subject) == 1
+        assert subject[0]["type"] == "character"
+        assert isinstance(subject[0]["image"], list) and len(subject[0]["image"]) == 1
+        assert subject[0]["image"][0].startswith("data:image/png;base64,")
+        # S2V-01 不接受 resolution/duration/first_frame_image。
+        assert "resolution" not in payload
+        assert "duration" not in payload
+        assert "first_frame_image" not in payload
+
+    def test_takes_only_first_reference(self, tmp_path):
+        # 编排层已按 max_reference_images=1 裁剪；backend 防御性仅取首张。
+        face1 = tmp_path / "face1.png"
+        face2 = tmp_path / "face2.png"
+        face1.write_bytes(b"\x89PNG\r\n1")
+        face2.write_bytes(b"\x89PNG\r\n2")
+        payload = _backend("S2V-01")._build_payload(_request(tmp_path, reference_images=[face1, face2]))
+        assert len(payload["subject_reference"][0]["image"]) == 1
+
+    def test_missing_reference_raises(self, tmp_path):
+        b = _backend("S2V-01")
+        with pytest.raises(VideoCapabilityError) as exc:
+            b._build_payload(_request(tmp_path, reference_images=None))
+        assert exc.value.code == "video_reference_images_required"
+
+    def test_unreadable_reference_raises(self, tmp_path):
+        b = _backend("S2V-01")
+        with pytest.raises(VideoCapabilityError) as exc:
+            b._build_payload(_request(tmp_path, reference_images=[tmp_path / "nope.png"]))
+        assert exc.value.code == "video_reference_images_unreadable"
+
+    async def test_generate_two_step_via_subject_reference(self, tmp_path):
+        face = tmp_path / "face.png"
+        face.write_bytes(b"\x89PNG\r\n")
+        captured: dict = {}
+
+        async def _post(url, json, headers):
+            captured["json"] = json
+            return _resp(_submit("s2v-task"))
+
+        post = AsyncMock(side_effect=_post)
+        get = AsyncMock(side_effect=[_resp(_query("Success", file_id="f")), _resp(_retrieve("https://x/s2v.mp4"))])
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
+        ):
+            result = await _backend("S2V-01").generate(_request(tmp_path, reference_images=[face]))
+
+        assert result.video_uri == "https://x/s2v.mp4"
+        assert captured["json"]["model"] == "S2V-01"
+        assert captured["json"]["subject_reference"][0]["type"] == "character"
+
+
 class TestGenerateHappyPath:
     async def test_two_step_url_extraction(self, tmp_path):
         post = AsyncMock(return_value=_resp(_submit("task-9")))


### PR DESCRIPTION
## 这个 PR 做了什么

新增内置 MiniMax **S2V-01** 模型：用户用一张主角人脸图，经参考生视频（reference_video）模式生成整段角色一致的视频，复用已落的 `MiniMaxVideoBackend` 两步取 URL 流程。

## 落点

- **registry**：注册 `S2V-01`（video，`max_reference_images=1`，固定 6s，`per_video_bucket` 单档约 ¥3，半核实价已标注）。
- **backend**：`MiniMaxVideoBackend` 把 `reference_images[0]` 映射成单脸 `subject_reference=[{"type":"character","image":[...]}]`；走专门路径，不传 resolution/duration（S2V-01 固定 720P/6s 输出）。
- **能力声明**：`VideoCapabilities(first_frame=False, reference_images=True, max_reference_images=1)`。编排层解析器（`#677` 已落）对内置 provider 读 registry 的 `ModelInfo.max_reference_images`，据此只取 1 张参考图，不落 `DEFAULT_MAX_REFS=9`。
- **fail-loud**：无参考图 → `video_reference_images_required`；参考图缺失/不可读 → `video_reference_images_unreadable`，不静默退化为无参考生成（避免产出错误结果且照常计费）。

## 验收对照（issue #801）

- ✅ 选 `S2V-01` 走 reference_video：单张人脸图 → 整段角色一致视频（backend 已注册 + 编排层裁剪到 1 张 + 映射 subject_reference）
- ✅ 声明 `reference_images=True, max_reference_images=1`，resolver 对 `minimax/S2V-01` 返回 `max=1`（新增 resolver 单测验证）
- ✅ `reference_images[0]` → 单脸 `subject_reference` 结构
- ✅ 费用按 `per_video_bucket` 单档计算（任意分辨率经最近档回落到唯一档，恒 ¥3）
- ✅ backend 单测覆盖 caps + subject_reference 映射 + 缺图/坏图守卫 + 两步生成

## 已知取舍 / 边界

- S2V-01 请求体不传 resolution/duration（据 MiniMax 官方 OpenAPI 核实，固定 720P/6s）；定价档键到缺省 768P/6s 精确命中（¥3 单档，半核实）。
- `supported_durations=[6]`：非 6s 的 unit 会被既有编排层 `assert_duration_supported` 守卫拦下（既有机制，非本切片范围）。

## 验证

- `uv run pytest tests/`：**4776 passed**
- `uv run basedpyright`：**0 errors**
- `uv run ruff check` / `format --check`：clean
- 本地审查（独立上下文 /code-review，多角度 finder + 验证 + sweep）：无需修复项。

Closes #801


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
* 新增 S2V-01 视频生成模型，支持通过参考图像驱动视频生成。该模型支持 768p 分辨率、6 秒视频时长，单次生成价格为 3.0 元，最多支持 1 张参考图像。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->