### PR TITLE
feat(custom-provider): 开放 minimax-image / minimax-video 自定义 endpoint 与 infer 推断

### DIFF
--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -801,6 +801,8 @@ export default {
   'endpoint_vidu_video_display': 'Vidu Video',
   'endpoint_dashscope_image_display': 'Alibaba Model Studio (Image)',
   'endpoint_dashscope_async_video_display': 'Alibaba Model Studio (Async Video)',
+  'endpoint_minimax_image_display': 'MiniMax (Image)',
+  'endpoint_minimax_video_display': 'MiniMax Hailuo (Video)',
   'endpoint_openai_tts_display': 'OpenAI Speech (TTS)',
   'endpoint_catalog_loading': 'Loading endpoint catalog…',
   // Image Capability

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -778,6 +778,8 @@ export default {
   'endpoint_vidu_video_display': 'Vidu Video',
   'endpoint_dashscope_image_display': 'Alibaba Model Studio (Ảnh)',
   'endpoint_dashscope_async_video_display': 'Alibaba Model Studio (Video bất đồng bộ)',
+  'endpoint_minimax_image_display': 'MiniMax (Ảnh)',
+  'endpoint_minimax_video_display': 'MiniMax Hailuo (Video)',
   'endpoint_openai_tts_display': 'OpenAI Giọng nói (TTS)',
   'endpoint_catalog_loading': 'Đang tải danh mục endpoint…',
   // Image Capability

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -802,6 +802,8 @@ export default {
   'endpoint_vidu_video_display': 'Vidu 视频',
   'endpoint_dashscope_image_display': '阿里百炼（图片）',
   'endpoint_dashscope_async_video_display': '阿里百炼（异步视频）',
+  'endpoint_minimax_image_display': 'MiniMax（图片）',
+  'endpoint_minimax_video_display': 'MiniMax 海螺（视频）',
   'endpoint_openai_tts_display': 'OpenAI 语音合成 (TTS)',
   'endpoint_catalog_loading': '加载端点目录…',
   // Image Capability

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -25,12 +25,14 @@ from lib.custom_provider.backends import (
 from lib.image_backends.base import ImageCapability
 from lib.image_backends.dashscope import DashScopeImageBackend
 from lib.image_backends.gemini import GeminiImageBackend
+from lib.image_backends.minimax import MiniMaxImageBackend
 from lib.image_backends.openai import OpenAIImageBackend
 from lib.text_backends.gemini import GeminiTextBackend
 from lib.text_backends.openai import OpenAITextBackend
 from lib.video_backends.ark import ArkVideoBackend
 from lib.video_backends.base import VideoCapabilities
 from lib.video_backends.dashscope import DashScopeVideoBackend
+from lib.video_backends.minimax import MiniMaxVideoBackend
 from lib.video_backends.newapi import NewAPIVideoBackend
 from lib.video_backends.openai import OpenAIVideoBackend
 from lib.video_backends.v2_video_generations import V2VideoGenerationsBackend
@@ -192,6 +194,18 @@ def _build_dashscope_async_video(provider, model_id: str) -> CustomVideoBackend:
     return CustomVideoBackend(provider_id=provider.provider_id, delegate=delegate, model=model_id)
 
 
+def _build_minimax_image(provider, model_id: str) -> CustomImageBackend:
+    # backend 内部把 base_url 归一化为 {host}/v1（容忍 host 或带 /v1 后缀），此处传原始 base_url 即可
+    delegate = MiniMaxImageBackend(api_key=provider.api_key, base_url=provider.base_url, model=model_id)
+    return CustomImageBackend(provider_id=provider.provider_id, delegate=delegate, model=model_id)
+
+
+def _build_minimax_video(provider, model_id: str) -> CustomVideoBackend:
+    # 两步取 URL（submit→轮询 file_id→retrieve download_url）由 MiniMaxVideoBackend 内部处理
+    delegate = MiniMaxVideoBackend(api_key=provider.api_key, base_url=provider.base_url, model=model_id)
+    return CustomVideoBackend(provider_id=provider.provider_id, delegate=delegate, model=model_id)
+
+
 # ── ENDPOINT_REGISTRY 注册表 ───────────────────────────────────────
 
 
@@ -338,6 +352,28 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         # 按 model 读 backend caps（不构造 client）。
         video_caps_for_model=DashScopeVideoBackend.video_capabilities_for_model,
     ),
+    "minimax-image": EndpointSpec(
+        key="minimax-image",
+        media_type="image",
+        family="minimax",
+        display_name_key="endpoint_minimax_image_display",
+        request_method="POST",
+        request_path_template="/image_generation",
+        image_capabilities=frozenset({ImageCapability.TEXT_TO_IMAGE, ImageCapability.IMAGE_TO_IMAGE}),
+        build_backend=_build_minimax_image,
+    ),
+    "minimax-video": EndpointSpec(
+        key="minimax-video",
+        media_type="video",
+        family="minimax",
+        display_name_key="endpoint_minimax_video_display",
+        request_method="POST",
+        request_path_template="/video_generation",
+        build_backend=_build_minimax_video,
+        # 多 model 容量异质（S2V-01 单脸参考 max_ref=1 / 海螺系列走首帧 no-ref）→ endpoint 维度不
+        # 声明 int cap，按 model 读 backend caps（不构造 client）。
+        video_caps_for_model=MiniMaxVideoBackend.video_capabilities_for_model,
+    ),
 }
 
 
@@ -449,13 +485,15 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     1) 阿里百炼视频 → happyhorse / wan2.x（非 image）走 "dashscope-async-video"（原生异步端点）。
        happyhorse 不在 _VIDEO_PATTERN 须显式；wan2.x 视频抢在通用 is_video 前拦截。图像不自动推
        dashscope（中转可能是 OpenAI 兼容），qwen-image / wan2.x-image 落到既有图像家族推断。
-    2) imagen → "gemini-image"（图像，不论 discovery_format）
-    3) gemini 原生模型（非 video）→ image 形态走 "gemini-image"，否则文本走 "gemini-generate"
-    4) 视频家族 → seedance→"ark-seedance"、viduq3→"vidu-video"、否则 "openai-video"
-    5) 图像家族 → discovery_format=google 走 "gemini-image" 否则 "openai-images"
-    6) TTS 家族（tts/speech/cosyvoice）→ "openai-tts"（audio 仅 OpenAI 兼容一条端点，
+    2) MiniMax 原生 token → 海螺 / S2V 走 "minimax-video"，image-01 走 "minimax-image"。先于通用
+       is_video/is_image 拦截：s2v 不在 _VIDEO_PATTERN、image-01 含 "image" 否则会被推到通用图像家族。
+    3) imagen → "gemini-image"（图像，不论 discovery_format）
+    4) gemini 原生模型（非 video）→ image 形态走 "gemini-image"，否则文本走 "gemini-generate"
+    5) 视频家族 → seedance→"ark-seedance"、viduq3→"vidu-video"、否则 "openai-video"
+    6) 图像家族 → discovery_format=google 走 "gemini-image" 否则 "openai-images"
+    7) TTS 家族（tts/speech/cosyvoice）→ "openai-tts"（audio 仅 OpenAI 兼容一条端点，
        不分 discovery_format；precedence 在 text 默认之前）
-    7) 默认（文本）→ discovery_format=google 走 "gemini-generate" 否则 "openai-chat"
+    8) 默认（文本）→ discovery_format=google 走 "gemini-generate" 否则 "openai-chat"
     """
     lowered = model_id.lower()
     is_image = bool(_IMAGE_PATTERN.search(model_id))
@@ -465,6 +503,14 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
         return "dashscope-async-video"
     if "wan2." in lowered and not is_image:
         return "dashscope-async-video"
+
+    # MiniMax 原生 token 二级路由：海螺（含 minimax-hailuo）/ S2V → 两步 file_id 视频端点；
+    # image-01 → 单步图像端点。先于通用 is_video/is_image：s2v 不被 _VIDEO_PATTERN 覆盖，
+    # image-01 含 "image" 否则会被通用图像家族抢走。
+    if "hailuo" in lowered or "s2v" in lowered:
+        return "minimax-video"
+    if "image-01" in lowered:
+        return "minimax-image"
 
     # wan2.x-image 含 "wan" 会被 _VIDEO_PATTERN 误判为视频；显式排除让它落到图像家族推断
     is_video = bool(_VIDEO_PATTERN.search(model_id)) and not ("wan2." in lowered and is_image)

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -30,6 +30,8 @@ class TestRegistry:
             "vidu-video",
             "dashscope-image",
             "dashscope-async-video",
+            "minimax-image",
+            "minimax-video",
             "openai-tts",
         }
 
@@ -37,7 +39,7 @@ class TestRegistry:
         for key, spec in ENDPOINT_REGISTRY.items():
             assert spec.key == key
             assert spec.media_type in {"text", "image", "video", "audio"}
-            assert spec.family in {"openai", "google", "newapi", "v2", "ark", "vidu", "dashscope"}
+            assert spec.family in {"openai", "google", "newapi", "v2", "ark", "vidu", "dashscope", "minimax"}
             assert spec.display_name_key.startswith("endpoint_")
             assert callable(spec.build_backend)
             assert spec.request_method == "POST"
@@ -60,8 +62,8 @@ class TestRegistry:
         }
 
     def test_new_video_endpoints_have_unset_cap(self):
-        """v2/ark/vidu/dashscope 不在 endpoint 维度声明上限，由 resolver 调 backend 纯 caps 函数读取。"""
-        for key in ("v2-video-generations", "ark-seedance", "vidu-video", "dashscope-async-video"):
+        """v2/ark/vidu/dashscope/minimax 不在 endpoint 维度声明上限，由 resolver 调 backend 纯 caps 函数读取。"""
+        for key in ("v2-video-generations", "ark-seedance", "vidu-video", "dashscope-async-video", "minimax-video"):
             assert ENDPOINT_REGISTRY[key].video_max_reference_images is None
         # 既有显式 int 保留，行为零变化
         assert ENDPOINT_REGISTRY["openai-video"].video_max_reference_images == 1
@@ -74,7 +76,7 @@ class TestRegistry:
         在 import 期保证（违反则本文件根本 import 不进来），故此处只断言「具体哪个 endpoint 选了哪条
         路径」——这是 XOR 校验抓不到的（换机制仍满足 XOR），是真正的回归护栏。"""
         # None-cap 的 video endpoint 必须绑定纯 caps 函数
-        for key in ("v2-video-generations", "ark-seedance", "vidu-video", "dashscope-async-video"):
+        for key in ("v2-video-generations", "ark-seedance", "vidu-video", "dashscope-async-video", "minimax-video"):
             assert ENDPOINT_REGISTRY[key].video_caps_for_model is not None
         # 显式 int 的 video endpoint 不应再绑 caps 函数
         for key in ("openai-video", "newapi-video"):
@@ -87,6 +89,18 @@ class TestRegistry:
         assert caps_fn is not None
         assert caps_fn("happyhorse-1.0-r2v").max_reference_images == 9
         assert caps_fn("wan2.7-r2v").max_reference_images == 5
+
+    def test_minimax_caps_fn_reads_per_model_limit_without_client(self):
+        """minimax-video 的 caps_fn 是纯函数：S2V-01 单脸参考 max_ref=1，海螺系列走首帧无参考
+        （max_ref=0），resolver 据此解析而无需构造 backend / api_key。"""
+        caps_fn = ENDPOINT_REGISTRY["minimax-video"].video_caps_for_model
+        assert caps_fn is not None
+        s2v = caps_fn("S2V-01")
+        assert s2v.reference_images is True
+        assert s2v.max_reference_images == 1
+        hailuo = caps_fn("MiniMax-Hailuo-2.3")
+        assert hailuo.first_frame is True
+        assert hailuo.max_reference_images == 0
 
     def test_negative_int_cap_rejected_at_validation(self, monkeypatch: pytest.MonkeyPatch):
         """import 期不变式拒绝负数 int cap：下游 references[:-1] 会误丢最后一张而非裁成 0 张。"""
@@ -141,6 +155,7 @@ class TestRegistry:
             "openai-images-edits",
             "gemini-image",
             "dashscope-image",
+            "minimax-image",
         }
         assert video_keys == {
             "openai-video",
@@ -149,6 +164,7 @@ class TestRegistry:
             "ark-seedance",
             "vidu-video",
             "dashscope-async-video",
+            "minimax-video",
         }
 
 
@@ -208,8 +224,21 @@ class TestInferEndpoint:
             ("SORA-2", "openai", "openai-video"),
             ("kling-v2", "openai", "openai-video"),
             ("veo-3", "openai", "openai-video"),
-            ("veo-3", "google", "openai-video"),  # 非 seedance/viduq3 视频 → openai-video
-            ("hailuo-02", "openai", "openai-video"),
+            ("veo-3", "google", "openai-video"),  # 非 seedance/viduq3/minimax 视频 → openai-video
+            # ── MiniMax 原生 token 二级路由 ──
+            ("MiniMax-Hailuo-2.3", "openai", "minimax-video"),
+            ("MiniMax-Hailuo-2.3-Fast", "openai", "minimax-video"),
+            ("minimax-hailuo-2.3", "openai", "minimax-video"),
+            (
+                "hailuo-02",
+                "openai",
+                "minimax-video",
+            ),  # 海螺 token → minimax-video（前 minimax endpoint 时代默认 openai-video）
+            ("S2V-01", "openai", "minimax-video"),  # s2v 不在通用视频 pattern，须显式路由
+            ("minimax-s2v-01", "openai", "minimax-video"),
+            ("image-01", "openai", "minimax-image"),  # image-01 含 "image" 否则会被推到通用图像家族
+            ("minimax/image-01", "openai", "minimax-image"),
+            ("S2V-01", "google", "minimax-video"),  # minimax 路由不分 discovery_format
             ("seedream-3.0", "openai", "openai-images"),
             ("jimeng-3.0", "openai", "openai-images"),
             ("jimeng-video-3.0", "openai", "openai-video"),
@@ -269,6 +298,7 @@ def test_image_endpoint_registry_entries():
         "openai-images-edits",
         "gemini-image",
         "dashscope-image",
+        "minimax-image",
     }
 
 

--- a/tests/test_custom_provider_factory.py
+++ b/tests/test_custom_provider_factory.py
@@ -130,6 +130,25 @@ class TestEndpointDispatch:
             provider_name="custom-42",
         )
 
+    @patch("lib.custom_provider.endpoints.MiniMaxImageBackend")
+    def test_minimax_image(self, mock_cls):
+        provider = _make_provider(base_url="https://api.minimaxi.com/v1")
+        result = create_custom_backend(provider=provider, model_id="image-01", endpoint="minimax-image")
+        assert isinstance(result, CustomImageBackend)
+        assert result.model == "image-01"
+        # base_url 原样下传，归一化（host→{host}/v1）由 MiniMaxImageBackend 内部处理
+        mock_cls.assert_called_once_with(api_key="sk-test", base_url="https://api.minimaxi.com/v1", model="image-01")
+
+    @patch("lib.custom_provider.endpoints.MiniMaxVideoBackend")
+    def test_minimax_video(self, mock_cls):
+        provider = _make_provider(base_url="https://api.minimaxi.com/v1")
+        result = create_custom_backend(provider=provider, model_id="MiniMax-Hailuo-2.3", endpoint="minimax-video")
+        assert isinstance(result, CustomVideoBackend)
+        assert result.model == "MiniMax-Hailuo-2.3"
+        mock_cls.assert_called_once_with(
+            api_key="sk-test", base_url="https://api.minimaxi.com/v1", model="MiniMax-Hailuo-2.3"
+        )
+
     @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
     def test_openai_images_generations(self, mock_cls):
         provider = _make_provider()

--- a/tests/test_custom_provider_resolution.py
+++ b/tests/test_custom_provider_resolution.py
@@ -162,6 +162,9 @@ async def test_video_capabilities_endpoint_mismatch_raises(db_session: AsyncSess
         ("ark-seedance", "doubao-seedance-2-0", 9),
         ("ark-seedance", "doubao-seedance-1-0", 0),  # 非 seedance-2 → 0，证明纯函数仍按 model 分支
         ("vidu-video", "viduq3-turbo", 7),
+        # minimax-video：S2V-01 单脸参考 → 1；海螺系列走首帧无参考 → 0
+        ("minimax-video", "S2V-01", 1),
+        ("minimax-video", "MiniMax-Hailuo-2.3", 0),
     ],
 )
 async def test_custom_video_max_reference_images_from_endpoint(

--- a/tests/test_custom_providers_api.py
+++ b/tests/test_custom_providers_api.py
@@ -217,6 +217,8 @@ class TestEndpointCatalog:
             "vidu-video",
             "dashscope-image",
             "dashscope-async-video",
+            "minimax-image",
+            "minimax-video",
             "openai-tts",
         }
 


### PR DESCRIPTION
## 背景

接 PRD #674（接入 MiniMax 内置 provider 全模态）。本切片为「原样代理 MiniMax 协议」的中转站用户开放两个自定义供应商 endpoint，并让含 MiniMax 原生 token 的 model id 自动推断到对应 endpoint，少手动改。参照已合并的 DashScope endpoint 同构扩展。

## 改动

- 新增 2 条 `EndpointSpec`（family 新值 `minimax`）：
  - `minimax-image`（media_type=image）— `_build_minimax_image` 把 `MiniMaxImageBackend` 包进 `CustomImageBackend`，单步 `image_generation` 取 URL。
  - `minimax-video`（media_type=video）— `_build_minimax_video` 把 `MiniMaxVideoBackend` 包进 `CustomVideoBackend`，两步 file_id（submit→轮询→retrieve download_url）。
- `minimax-video` 多 model 容量异质（S2V-01 单脸参考 max_ref=1 / 海螺系列走首帧无参考），按先例用 `video_caps_for_model` 纯函数按 model 读 backend caps，不在 endpoint 维度写死 int；满足 import 期 XOR 不变式。
- `infer_endpoint` 二级路由：model id 含 `hailuo` / `minimax-hailuo` / `s2v` → `minimax-video`，含 `image-01` → `minimax-image`；置于 dashscope 之后、通用 `is_video`/`is_image` 之前（`s2v` 不在通用视频 pattern、`image-01` 否则会被通用图像家族抢走）。
- endpoint display name 三语补全（en/zh/vi dashboard）：`endpoint_minimax_image_display` / `endpoint_minimax_video_display`。

### 行为变更（PRD 预期）

含 `hailuo` token 的 model（如 `hailuo-02`）由原默认 `openai-video` 改为 `minimax-video`——minimax endpoint 上线后海螺 token 正确归位。其余既有推断向后兼容不变（`veo-3` 等仍 → `openai-video`）。

## 验证

- `uv run ruff check` / `ruff format --check`：通过
- `uv run basedpyright`（全量）：0 errors
- `uv run pytest`（endpoints / factory / resolution / API + minimax 后端套件）：314 passed
- `uv run pytest tests/test_i18n_consistency.py`：12 passed
- 前端 `pnpm lint` + `pnpm check`（typecheck + 726 vitest）：全绿

## 验收对照

- [x] 添加自定义供应商时可选到 `minimax-image` / `minimax-video`
- [x] factory 正确构造：image→`CustomImageBackend`、video→`CustomVideoBackend`（两步 file_id）
- [x] `infer_endpoint`：`MiniMax-Hailuo-2.3` / `S2V-01` → `minimax-video`；`image-01` → `minimax-image`；向后兼容不破
- [x] 三语 display name 齐备，i18n 一致性测试通过
- [x] registry/factory/infer/resolution 测试覆盖；全量绿、basedpyright 0 error

Closes #802


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增对 MiniMax 图像生成端点的支持
  * 新增对 MiniMax Hailuo 视频生成端点的支持

* **文档**
  * 为新增端点添加了多语言界面文本翻译（英文、越南文、中文）

* **测试**
  * 新增端点功能与路由推断的测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->