### PR TITLE
fix(custom-provider): 纯文本 MiniMax 模型经自定义供应商不再被误推到视频端点

### DIFF
--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -464,7 +464,7 @@ def endpoint_spec_to_dict(spec: EndpointSpec) -> dict:
 
 _IMAGE_PATTERN = re.compile(r"image|dall|img|imagen|flux|seedream|jimeng|viduq[12](?:[-_].*)?", re.IGNORECASE)
 _VIDEO_PATTERN = re.compile(
-    r"video|sora|kling|wan|seedance|cog|mochi|veo|pika|minimax|hailuo|jimeng-?video|runway|"
+    r"video|sora|kling|wan|seedance|cog|mochi|veo|pika|hailuo|jimeng-?video|runway|"
     r"vidu2(?:\.0)?(?:[-_].*)?|viduq3(?:[-_].*)?",
     re.IGNORECASE,
 )

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -243,6 +243,10 @@ class TestInferEndpoint:
             ("jimeng-3.0", "openai", "openai-images"),
             ("jimeng-video-3.0", "openai", "openai-video"),
             ("jimengvideo-3.0", "openai", "openai-video"),
+            # ── 纯文本 MiniMax model 落到文本端点（不被裸 minimax 误推到视频）──
+            ("MiniMax-M2.7", "openai", "openai-chat"),
+            ("minimax-abab-6.5-chat", "openai", "openai-chat"),
+            ("MiniMax-M2.7", "google", "gemini-generate"),  # discovery_format=google → gemini-generate
             # viduq1/viduq2 是 vidu 早期图像版本 → 维持 image 推断不变
             ("viduq1", "openai", "openai-images"),
             ("viduq1-classic", "openai", "openai-images"),


### PR DESCRIPTION
Closes #819

## 问题

`lib/custom_provider/endpoints.py` 的 `_VIDEO_PATTERN` 含裸 `minimax` token。一个纯文本 MiniMax model id（如 `MiniMax-M2.7`、`minimax-abab-6.5-chat`）经自定义（OpenAI 兼容中转）供应商添加时，不匹配 MiniMax 二级路由的 `hailuo`/`s2v`/`image-01` token，落到通用 `is_video` 分支后被裸 `minimax` 误判为视频，推到 openai-video 端点（文本 model 当视频端点），用户须每次手动改回——正是 infer 本该消灭的负担。

## 修复

从 `_VIDEO_PATTERN` 移除裸 `minimax` token，纯文本 MiniMax model 正确落到文本默认端点（按 discovery_format 走 openai-chat / gemini-generate）。

**安全性**：所有真实 MiniMax 视频/图像 model id 都在通用 `is_video`/`is_image` 之前被二级路由拦截——`MiniMax-Hailuo-2.3` / `MiniMax-Hailuo-2.3-Fast` 含 `hailuo`、`S2V-01` 含 `s2v`（均命中第 510-511 行，先于第 516 行的 `is_video` 计算）、`image-01` 命中第 512 行。带 `video` token 的 model 仍被 `_VIDEO_PATTERN` 其它 token 覆盖。裸 `minimax` 对视频路由完全冗余，移除只改变纯文本 model 的归位，不影响任何 MiniMax 视频/图像路由；`minimax` 是 MiniMax 专属 token，对非 MiniMax 供应商零影响。

## 验证

- 新增纯文本 MiniMax 回归用例，覆盖 openai / google 两种 discovery_format：
  - `MiniMax-M2.7` (openai) → openai-chat
  - `minimax-abab-6.5-chat` (openai) → openai-chat
  - `MiniMax-M2.7` (google) → gemini-generate
- 既有 MiniMax 视频/图像断言全部保持不变（`MiniMax-Hailuo-2.3` / `S2V-01` → minimax-video、`image-01` → minimax-image），独立确认无旧 `minimax→openai-video` 断言需更新（不存在）。
- 全量 `pytest`（隔离 SQLite test DB）：**4842 passed, 0 failed**
- custom_provider 测试：239 passed
- `ruff check` / `ruff format --check`：clean
- `basedpyright`（改动文件）：0 errors

## 审查

本地以独立视角复核：逐角度核对（line-by-line / removed-behavior / cross-file tracer / 语言陷阱 / 簇）后无 correctness 或 cleanup 发现。`infer_endpoint` 的两个调用方（discovery.py 的 openai/google 路径）均被新用例覆盖；`_VIDEO_PATTERN` 仅在本文件内部使用，无外部消费者。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug修复**
  * 修复了MiniMax文本模型的路由识别，确保这些模型能被正确分类和处理

* **测试**
  * 增加了MiniMax文本模型在不同格式下的路由测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->