### PR TITLE
chore(custom-provider): 清理 infer 路由与时长预设中的冗余 minimax/hailuo/jimeng-video token

### DIFF
--- a/lib/custom_provider/duration_presets.py
+++ b/lib/custom_provider/duration_presets.py
@@ -40,7 +40,7 @@ PRESETS: list[tuple[re.Pattern[str], list[int]]] = [
     # PixVerse V5/V5.5/V5.6/V6（1-15 任意）
     (re.compile(r"pixverse|^v[56](\.\d+)?$", re.I), list(range(1, 16))),
     # MiniMax Hailuo（固定 6）
-    (re.compile(r"hailuo|minimax", re.I), [6]),
+    (re.compile(r"hailuo", re.I), [6]),
     # Wan
     (re.compile(r"wan-?\d", re.I), [4, 5]),
     # Pika

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -464,7 +464,7 @@ def endpoint_spec_to_dict(spec: EndpointSpec) -> dict:
 
 _IMAGE_PATTERN = re.compile(r"image|dall|img|imagen|flux|seedream|jimeng|viduq[12](?:[-_].*)?", re.IGNORECASE)
 _VIDEO_PATTERN = re.compile(
-    r"video|sora|kling|wan|seedance|cog|mochi|veo|pika|hailuo|jimeng-?video|runway|"
+    r"video|sora|kling|wan|seedance|cog|mochi|veo|pika|runway|"
     r"vidu2(?:\.0)?(?:[-_].*)?|viduq3(?:[-_].*)?",
     re.IGNORECASE,
 )

--- a/tests/test_duration_presets.py
+++ b/tests/test_duration_presets.py
@@ -47,9 +47,12 @@ from lib.custom_provider.duration_presets import (
         # PixVerse
         ("pixverse-v6", list(range(1, 16))),
         ("v5.6", list(range(1, 16))),
-        # Hailuo / MiniMax
+        # Hailuo / MiniMax（真实视频 model id 都带 hailuo 品牌名）
         ("hailuo-02", [6]),
-        ("minimax-video", [6]),
+        ("MiniMax-Hailuo-2.3", [6]),
+        ("MiniMax-Hailuo-2.3-Fast", [6]),
+        # 不带 hailuo 的 minimax id 不再命中固定 6，落回默认（裸 minimax token 已移除）
+        ("minimax-abab-6.5", DEFAULT_FALLBACK),
         # Wan
         ("wan-2.1", [4, 5]),
         # Pika


### PR DESCRIPTION
## 背景

PRD #674（MiniMax 全模态接入）已全部合并；follow-up #819/#820 修掉 `_VIDEO_PATTERN` 里把纯文本 model 误判为视频的裸 `minimax` token 后，留下两处**同源但无害**的冗余 token——今天不致错，但属于 #415 时代的遗留。本 PR 单独收口，纯清理、行为零变化。

## 改动

1. **`endpoints.py` `_VIDEO_PATTERN`** 移除两个冗余 token：
   - `hailuo`：含 `hailuo` 的 model 已被上游 MiniMax 二级路由（`if "hailuo" in lowered → minimax-video`）先于通用 `is_video` 拦截，`_VIDEO_PATTERN` 这一步走不到。
   - `jimeng-?video`：pattern 开头已有 `video` token，`jimeng-video` / `jimengvideo` 自带 "video" 已被命中。
2. **`duration_presets.py`** 移除 `(re.compile(r"hailuo|minimax"), [6])` 里的裸 `minimax`，保留 `hailuo`：真实 MiniMax 视频 model id 都带 `hailuo`（`S2V-01` 本就不带且固定输出、忽略 duration），纯文本 minimax model 在 #819/#820 后走文本端点、不查时长预设。

均不改变任何**真实** model 的端点推断结果与时长预设结果。

## 验证

- `_VIDEO_PATTERN` / `infer_endpoint` 全链路：`infer_supported_durations` 仅在 `to_db_dict` 中 `is_video` 为真时调用；`_VIDEO_PATTERN` 仅用于 `infer_endpoint`——确认两处无其它调用点受影响。
- 回归断言：
  - `test_custom_provider_endpoints.py` 已覆盖 `jimeng-video-3.0` / `jimengvideo-3.0` 仍判视频、`MiniMax-Hailuo-*` / `hailuo-02` / `S2V-01` → `minimax-video`、纯文本 `MiniMax-M2.7` → 文本端点。
  - `test_duration_presets.py` 新增 `MiniMax-Hailuo-2.3` / `MiniMax-Hailuo-2.3-Fast` → `[6]`，并锁定 `minimax-abab-6.5` → `DEFAULT_FALLBACK`（裸 minimax token 移除后落回默认）。
- 质量门全绿：`uv run pytest tests/`（4844 passed）、`ruff check` + `ruff format --check`、`basedpyright`（0 errors）。

Closes #821


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修正了模型持续时间预设的识别规则，使 Hailuo 系列模型正确应用固定持续时间 [6]；不包含 "hailuo" 标识的 MiniMax 模型将回退至默认持续时间配置，提高了多模型支持的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->