### PR TITLE
fix(ad-mode): 广告引导页未填产品描述时也能勾选生成标准产品图

### DIFF
--- a/frontend/src/components/canvas/AdInitCanvas.test.tsx
+++ b/frontend/src/components/canvas/AdInitCanvas.test.tsx
@@ -92,6 +92,27 @@ describe("AdInitCanvas", () => {
     expect(submit).toBeEnabled();
   });
 
+  it("keeps the sheet checkbox enabled and guides users to complete product info", () => {
+    render(<AdInitCanvas projectName="ad-demo" onDone={onDone} />);
+    const checkbox = screen.getByLabelText("生成标准产品参考图");
+    const submit = screen.getByRole("button", { name: "开始创作" });
+
+    // 产品信息为空时复选框仍可勾选，不再置灰形成无反馈死路
+    expect(checkbox).toBeEnabled();
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    // 勾选即视为要建产品：信息不完整时提示出现且不可提交，避免静默丢弃生图意图
+    expect(screen.getByRole("alert")).toHaveTextContent("产品信息不完整");
+    expect(submit).toBeDisabled();
+
+    // 补全产品名称与描述后恢复可提交、提示消失
+    fireEvent.change(screen.getByLabelText("产品名称"), { target: { value: "保温杯" } });
+    fireEvent.change(screen.getByLabelText("产品描述"), { target: { value: "不锈钢" } });
+    expect(submit).toBeEnabled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
   it("blocks brief-only submit while the product section is partially filled", () => {
     render(<AdInitCanvas projectName="ad-demo" onDone={onDone} />);
     const submit = screen.getByRole("button", { name: "开始创作" });

--- a/frontend/src/components/canvas/AdInitCanvas.tsx
+++ b/frontend/src/components/canvas/AdInitCanvas.tsx
@@ -43,9 +43,10 @@ export function AdInitCanvas({ projectName, onDone }: AdInitCanvasProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const hasProduct = productName.trim() !== "" && description.trim() !== "";
-  // 产品区有任意输入（名称/描述/图片）即视为用户想建产品：此时必须信息完整才能提交，
-  // 避免 brief-only 提交静默丢弃已填的产品信息与已选图片
-  const productDirty = productName.trim() !== "" || description.trim() !== "" || files.length > 0;
+  // 产品区有任意输入（名称/描述/图片）或勾选了「生成标准产品参考图」即视为用户想建产品：
+  // 此时必须信息完整才能提交，避免 brief-only 提交静默丢弃已填的产品信息、已选图片或生图意图
+  const productDirty =
+    productName.trim() !== "" || description.trim() !== "" || files.length > 0 || generateSheet;
   const productIncomplete = productDirty && !hasProduct;
   const canSubmit = !submitting && (hasProduct || (brief.trim() !== "" && !productDirty));
 
@@ -233,12 +234,14 @@ export function AdInitCanvas({ projectName, onDone }: AdInitCanvasProps) {
         )}
 
         <div className="mt-2 flex items-start gap-2">
+          {/* 始终可勾选以表达「要生标准图」的意图；产品信息是否完整由 productIncomplete
+              提示与 canSubmit 把关引导补全，而非置灰复选框形成无反馈死路 */}
           <input
             id={sheetId}
             type="checkbox"
             checked={generateSheet}
             onChange={(e) => setGenerateSheet(e.target.checked)}
-            disabled={submitting || !hasProduct}
+            disabled={submitting}
             className="focus-ring mt-0.5 h-3.5 w-3.5 accent-[var(--color-accent)]"
           />
           <div>


### PR DESCRIPTION
## 问题

广告/短片模式引导页「准备你的素材」中，「生成标准产品参考图」复选框仅在产品名称与产品描述都填写后才可勾选。用户填了名称、选了图但描述为空时，复选框被置灰且旁边无任何说明，想勾却勾不动、也不知原因，形成无反馈的「死路」体验。

## 改动

把「禁用死路」改为「始终可勾选 + 明确引导」：

- 复选框始终可勾选（仅提交中禁用），让用户先表达「要生标准图」的意图
- 勾选即视为要建产品，复用已有的「产品信息不完整」提示引导补全产品名称与描述，提交按钮仍受把关阻止不完整提交，不会静默丢弃生图意图

## 测试

- 新增用例覆盖：空信息下复选框可勾、勾选后出现提示并禁用提交、补全后恢复可提交且提示消失
- `AdInitCanvas` 测试全过；`pnpm lint` 与 `tsc --noEmit` 均通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug 修复
* 改进产品信息校验逻辑：生成标准产品参考图复选框现始终可用，通过告警提示与禁用提交按钮约束用户补全产品信息，避免数据丢失。

## 测试
* 新增测试用例验证产品信息不完整时的完整流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->