### PR TITLE
feat(drama): 剧本源分集规划尊重作者自带分集，无分集按剧情弧语义切分

### DIFF
--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -30,7 +30,7 @@ from lib.episode_ledger import (
     normalize_source_text,
     parse_episode_num,
 )
-from lib.project_manager import ProjectManager
+from lib.project_manager import DEFAULT_SOURCE_KIND, VALID_SOURCE_KINDS, ProjectManager
 from lib.text_backends.base import TextGenerationRequest, TextTaskType
 from lib.text_generator import TextGenerator
 from lib.text_metrics import count_reading_units
@@ -260,6 +260,42 @@ def _ledger_entry_from_draft(
 def _language_of(project: Mapping[str, Any]) -> str | None:
     language = project.get("source_language")
     return language if isinstance(language, str) else None
+
+
+def _source_kind_of(project: Mapping[str, Any]) -> str:
+    """项目源文件性质（novel / screenplay），缺失或非法值回退 novel。"""
+    value = project.get("source_kind")
+    return value if value in VALID_SOURCE_KINDS else DEFAULT_SOURCE_KIND
+
+
+# plan_episodes 开篇定位：novel 走「切分 / 创作」，screenplay 翻为「尊重作者分集 / 提取」。
+# screenplay 二分支——剧本自带分集（任意形态）照用作者边界，无分集才按剧情弧语义切，
+# 绝不按字数机械切；不依赖任何固定分集标记，靠模型语义识别作者写下的分集形态。
+_PLAN_INTRO_NOVEL: tuple[str, ...] = (
+    "你是短视频分集规划师。请把下面的小说原文片段切分为若干集，每一集都必须是一个完整的剧情弧，",
+    "并在集尾留下让观众想看下一集的钩子。",
+)
+_PLAN_INTRO_SCREENPLAY: tuple[str, ...] = (
+    "你是短视频分集规划师。下面是作者已写好的成品剧本片段，请尊重作者自带的分集、提取而非重切：",
+    "- 若剧本自带分集（任意形态——分集标记、结构表、标题体系、分隔等，不要依赖任何固定标记或正则识别），",
+    "  照用作者划定的每一集边界，title、hook 与分集大纲都取自剧本原文。",
+    "- 若剧本没有任何分集线索，再按完整剧情弧语义切分，每一集都是一个完整的故事段落，绝不按字数机械切碎。",
+)
+# screenplay 在「切分规则」段补一条把上述意图落到 end_anchor 层的具体指令。
+_PLAN_RULE_SCREENPLAY = (
+    "- 优先照用作者的分集：剧本已划定每集边界时，end_anchor 取作者每集结尾处的原文片段，"
+    "title / hook 也取自剧本（作者写明的集标题、集尾钩子）；剧本未分集时才按剧情弧自行切，绝不按字数硬凑集数。"
+)
+# drama 大纲条目说明：screenplay 优先照搬作者写下的故事节点 / 下集预告。
+_PLAN_DRAMA_OUTLINE_NOVEL = (
+    "- 每一集另给出 story_beats（本集故事节点列表，按顺序）"
+    "与 next_episode_teaser（下集预告语；最后一集若后续未知可为 null）。"
+)
+_PLAN_DRAMA_OUTLINE_SCREENPLAY = (
+    "- 每一集另给出 story_beats（本集故事节点列表，按顺序）"
+    "与 next_episode_teaser（下集预告语；最后一集若后续未知可为 null）；"
+    "剧本已写明本集节点 / 下集预告时照搬其原文，未写明再自行提炼。"
+)
 
 
 class EpisodePlanner:
@@ -869,10 +905,10 @@ def _build_planning_prompt(
     language = str(project.get("source_language") or "zh")
     unit_name = "词" if language in ("en", "vi") else "字"
     target_units = project.get("episode_target_units")
+    is_screenplay = _source_kind_of(project) == "screenplay"
 
     lines: list[str] = [
-        "你是短视频分集规划师。请把下面的小说原文片段切分为若干集，每一集都必须是一个完整的剧情弧，",
-        "并在集尾留下让观众想看下一集的钩子。",
+        *(_PLAN_INTRO_SCREENPLAY if is_screenplay else _PLAN_INTRO_NOVEL),
         "",
         "# 项目信息",
         f"- 内容模式：{'剧集动画（drama）' if content_mode == 'drama' else '说书旁白（narration）'}",
@@ -916,10 +952,10 @@ def _build_planning_prompt(
         "  end_anchor（本集结尾处的原文片段，10~30 个字符，必须从下方原文中逐字摘抄、含标点，且在整段原文中唯一出现；",
         "  本集内容 = 上一集结尾之后到该片段末尾为止的全部原文）。",
     ]
+    if is_screenplay:
+        lines.append(_PLAN_RULE_SCREENPLAY)
     if content_mode == "drama":
-        lines += [
-            "- 每一集另给出 story_beats（本集故事节点列表，按顺序）与 next_episode_teaser（下集预告语；最后一集若后续未知可为 null）。",
-        ]
+        lines.append(_PLAN_DRAMA_OUTLINE_SCREENPLAY if is_screenplay else _PLAN_DRAMA_OUTLINE_NOVEL)
     lines += [
         "- 各集按顺序排列，end_anchor 位置必须严格递增（范围连续、不重叠、不留空洞）。",
     ]
@@ -935,5 +971,5 @@ def _build_planning_prompt(
         lines += ["", "# 上一轮输出未通过校验，请针对性修正后重新输出"]
         lines += [f"- {reason}" for reason in failure]
 
-    lines += ["", "# 小说原文片段", "---", window, "---"]
+    lines += ["", "# 剧本原文片段" if is_screenplay else "# 小说原文片段", "---", window, "---"]
     return "\n".join(lines)

--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -30,7 +30,7 @@ from lib.episode_ledger import (
     normalize_source_text,
     parse_episode_num,
 )
-from lib.project_manager import DEFAULT_SOURCE_KIND, VALID_SOURCE_KINDS, ProjectManager
+from lib.project_manager import ProjectManager, resolve_source_kind
 from lib.text_backends.base import TextGenerationRequest, TextTaskType
 from lib.text_generator import TextGenerator
 from lib.text_metrics import count_reading_units
@@ -260,12 +260,6 @@ def _ledger_entry_from_draft(
 def _language_of(project: Mapping[str, Any]) -> str | None:
     language = project.get("source_language")
     return language if isinstance(language, str) else None
-
-
-def _source_kind_of(project: Mapping[str, Any]) -> str:
-    """项目源文件性质（novel / screenplay），缺失或非法值回退 novel。"""
-    value = project.get("source_kind")
-    return value if value in VALID_SOURCE_KINDS else DEFAULT_SOURCE_KIND
 
 
 # plan_episodes 开篇定位：novel 走「切分 / 创作」，screenplay 翻为「尊重作者分集 / 提取」。
@@ -905,7 +899,7 @@ def _build_planning_prompt(
     language = str(project.get("source_language") or "zh")
     unit_name = "词" if language in ("en", "vi") else "字"
     target_units = project.get("episode_target_units")
-    is_screenplay = _source_kind_of(project) == "screenplay"
+    is_screenplay = resolve_source_kind(project) == "screenplay"
 
     lines: list[str] = [
         *(_PLAN_INTRO_SCREENPLAY if is_screenplay else _PLAN_INTRO_NOVEL),

--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -276,16 +276,16 @@ _PLAN_INTRO_SCREENPLAY: tuple[str, ...] = (
     "- 若剧本没有任何分集线索，再按完整剧情弧语义切分，每一集都是一个完整的故事段落，绝不按字数机械切碎。",
 )
 # screenplay 在「切分规则」段补一条把上述意图落到 end_anchor 层的具体指令。
-_PLAN_RULE_SCREENPLAY = (
+_PLAN_RULE_SCREENPLAY: str = (
     "- 优先照用作者的分集：剧本已划定每集边界时，end_anchor 取作者每集结尾处的原文片段，"
     "title / hook 也取自剧本（作者写明的集标题、集尾钩子）；剧本未分集时才按剧情弧自行切，绝不按字数硬凑集数。"
 )
 # drama 大纲条目说明：screenplay 优先照搬作者写下的故事节点 / 下集预告。
-_PLAN_DRAMA_OUTLINE_NOVEL = (
+_PLAN_DRAMA_OUTLINE_NOVEL: str = (
     "- 每一集另给出 story_beats（本集故事节点列表，按顺序）"
     "与 next_episode_teaser（下集预告语；最后一集若后续未知可为 null）。"
 )
-_PLAN_DRAMA_OUTLINE_SCREENPLAY = (
+_PLAN_DRAMA_OUTLINE_SCREENPLAY: str = (
     "- 每一集另给出 story_beats（本集故事节点列表，按顺序）"
     "与 next_episode_teaser（下集预告语；最后一集若后续未知可为 null）；"
     "剧本已写明本集节点 / 下集预告时照搬其原文，未写明再自行提炼。"

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -80,7 +80,7 @@ def effective_mode(*, project: dict, episode: dict) -> str:
 def resolve_source_kind(project: Mapping[str, Any]) -> SourceKind:
     """项目源文件性质（novel / screenplay），缺失或非法值回退默认 novel，兼容脏数据。"""
     value = project.get("source_kind")
-    if value in VALID_SOURCE_KINDS:
+    if isinstance(value, str) and value in VALID_SOURCE_KINDS:
         return cast(SourceKind, value)
     return DEFAULT_SOURCE_KIND
 
@@ -2231,7 +2231,7 @@ class ProjectManager:
 
         # 调用 TextGenerator（Structured Outputs）。source_kind=screenplay 时翻为「提取优先」：
         # 作者写下的创作方案前言优先照用，缺失才退回从正文归纳（novel 行为不变）。
-        source_kind = self.load_project(project_name).get("source_kind") or DEFAULT_SOURCE_KIND
+        source_kind = resolve_source_kind(self.load_project(project_name))
         prompt = build_overview_prompt(source_content, source_kind=source_kind)
 
         result = await generator.generate(

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -12,7 +12,7 @@ import re
 import secrets
 import shutil
 import unicodedata
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
@@ -75,6 +75,12 @@ def effective_mode(*, project: dict, episode: dict) -> str:
     if proj_mode in _VALID_GENERATION_MODES:
         return proj_mode
     return _DEFAULT_GENERATION_MODE
+
+
+def resolve_source_kind(project: Mapping[str, Any]) -> str:
+    """项目源文件性质（novel / screenplay），缺失或非法值回退默认 novel，兼容脏数据。"""
+    value = project.get("source_kind")
+    return value if value in VALID_SOURCE_KINDS else DEFAULT_SOURCE_KIND
 
 
 def _resolve_items_or_warn(script: dict, *, script_filename: str | None = None) -> list[dict]:

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -77,10 +77,12 @@ def effective_mode(*, project: dict, episode: dict) -> str:
     return _DEFAULT_GENERATION_MODE
 
 
-def resolve_source_kind(project: Mapping[str, Any]) -> str:
+def resolve_source_kind(project: Mapping[str, Any]) -> SourceKind:
     """项目源文件性质（novel / screenplay），缺失或非法值回退默认 novel，兼容脏数据。"""
     value = project.get("source_kind")
-    return value if value in VALID_SOURCE_KINDS else DEFAULT_SOURCE_KIND
+    if value in VALID_SOURCE_KINDS:
+        return cast(SourceKind, value)
+    return DEFAULT_SOURCE_KIND
 
 
 def _resolve_items_or_warn(script: dict, *, script_filename: str | None = None) -> list[dict]:

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -18,7 +18,7 @@ from lib.config.registry import PROVIDER_REGISTRY
 from lib.config.resolver import ConfigResolver
 from lib.db import async_session_factory
 from lib.episode_ledger import normalize_source_text
-from lib.project_manager import DEFAULT_SOURCE_KIND, VALID_SOURCE_KINDS, ProjectManager, effective_mode
+from lib.project_manager import ProjectManager, effective_mode, resolve_source_kind
 from lib.prompt_builders_ad import build_ad_prompt
 from lib.prompt_builders_reference import build_reference_video_prompt
 from lib.prompt_builders_script import (
@@ -457,8 +457,7 @@ class ScriptGenerator:
 
     def _source_kind(self) -> str:
         """解析项目源文件性质（novel / screenplay），缺失或非法值回退 novel（drama 提取优先分支用）。"""
-        value = self.project_json.get("source_kind")
-        return value if value in VALID_SOURCE_KINDS else DEFAULT_SOURCE_KIND
+        return resolve_source_kind(self.project_json)
 
     def _resolve_max_refs(self, caps: dict | None = None) -> int | None:
         """解析当前视频模型的最大参考图数；caps → project.json.video_backend → registry 两级回退。

--- a/tests/test_episode_planner.py
+++ b/tests/test_episode_planner.py
@@ -334,6 +334,85 @@ class TestPlan:
         assert len(fake.requests) == 2
         assert "schema" in fake.requests[1].prompt
 
+    async def test_plan_screenplay_respects_author_divisions(self, tmp_path: Path):
+        """screenplay：mock 返回尊重作者分集的规划 → 账本落作者的边界 / 标题 / 钩子 / 大纲。"""
+        project_dir = _write_project(tmp_path, content_mode="drama", extra={"source_kind": "screenplay"})
+        fake = _FakeTextGenerator(
+            [
+                _plan_response(
+                    [
+                        {
+                            "title": "山村少年",  # 作者写明的集标题，照搬
+                            "hook": "古玉剑诀来历成谜",
+                            "end_anchor": ANCHOR_EP1,
+                            "story_beats": ["山村习武", "后山得玉"],
+                            "next_episode_teaser": "下集李恒下山",
+                        },
+                        {
+                            "title": "下山",
+                            "hook": "少女为何被追杀",
+                            "end_anchor": ANCHOR_EP2,
+                            "story_beats": ["辞别师父", "城门遇袭"],
+                            "next_episode_teaser": "下集风波将起",
+                        },
+                    ]
+                )
+            ]
+        )
+
+        await EpisodePlanner(project_dir, generator=fake).plan()
+
+        eps = _load_project(project_dir)["episodes"]
+        assert [e["title"] for e in eps] == ["山村少年", "下山"]
+        assert eps[0]["hook"] == "古玉剑诀来历成谜"
+        assert eps[0]["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": _end_of(ANCHOR_EP1)}
+        assert eps[1]["source_range"] == {
+            "source_file": "source/novel.txt",
+            "start": _end_of(ANCHOR_EP1),
+            "end": _end_of(ANCHOR_EP2),
+        }
+        assert eps[0]["outline"] == {"story_beats": ["山村习武", "后山得玉"], "next_episode_teaser": "下集李恒下山"}
+
+    async def test_plan_prompt_branches_on_source_kind(self, tmp_path: Path):
+        """screenplay 规划 prompt 携带「尊重作者分集 / 无则按剧情弧语义切 / 不依赖固定标记」；novel 不翻面。"""
+
+        def _one_episode_generator() -> _FakeTextGenerator:
+            return _FakeTextGenerator(
+                [
+                    _plan_response(
+                        [
+                            {
+                                "title": "甲",
+                                "hook": "甲",
+                                "end_anchor": ANCHOR_EP1,
+                                "story_beats": ["节点"],
+                                "next_episode_teaser": None,
+                            }
+                        ]
+                    )
+                ]
+            )
+
+        screenplay_dir = _write_project(tmp_path / "scr", content_mode="drama", extra={"source_kind": "screenplay"})
+        scr_fake = _one_episode_generator()
+        await EpisodePlanner(screenplay_dir, generator=scr_fake).plan()
+        scr_prompt = scr_fake.requests[0].prompt
+
+        novel_dir = _write_project(tmp_path / "nov", content_mode="drama")
+        nov_fake = _one_episode_generator()
+        await EpisodePlanner(novel_dir, generator=nov_fake).plan()
+        nov_prompt = nov_fake.requests[0].prompt
+
+        # screenplay：尊重作者分集、无则按剧情弧语义切、不依赖固定标记
+        assert "尊重作者" in scr_prompt
+        assert "固定标记" in scr_prompt
+        assert "剧情弧" in scr_prompt
+        assert "剧本原文片段" in scr_prompt
+        # novel：仍是「切分为若干集」的创作口径，不含 screenplay 专属指令（回归）
+        assert "尊重作者" not in nov_prompt
+        assert "固定标记" not in nov_prompt
+        assert "小说原文片段" in nov_prompt
+
     async def test_plan_window_setting_limits_prompt_window(self, tmp_path: Path):
         """planning_window_chars 项目设置覆盖内部默认：窗口外内容不进 prompt。"""
         window_chars = _end_of(ANCHOR_EP1) + 4

--- a/tests/test_project_manager_source_kind.py
+++ b/tests/test_project_manager_source_kind.py
@@ -9,11 +9,32 @@ from pathlib import Path
 
 import pytest
 
-from lib.project_manager import ProjectManager
+from lib.project_manager import ProjectManager, resolve_source_kind
 
 
 def _pm(tmp_path: Path) -> ProjectManager:
     return ProjectManager(tmp_path / "projects")
+
+
+class TestResolveSourceKind:
+    """统一回退入口：合法值原样返回，缺失 / 非法 / 脏数据一律回退 novel 不抛异常。"""
+
+    def test_valid_values_pass_through(self):
+        assert resolve_source_kind({"source_kind": "novel"}) == "novel"
+        assert resolve_source_kind({"source_kind": "screenplay"}) == "screenplay"
+
+    def test_missing_key_falls_back_to_novel(self):
+        assert resolve_source_kind({}) == "novel"
+
+    def test_invalid_string_falls_back_to_novel(self):
+        assert resolve_source_kind({"source_kind": "screen_play"}) == "novel"
+        assert resolve_source_kind({"source_kind": ""}) == "novel"
+
+    def test_unhashable_dirty_value_falls_back_without_raising(self):
+        # list / dict 等不可哈希脏值不得在成员判断时抛 TypeError，须回退 novel
+        assert resolve_source_kind({"source_kind": ["novel"]}) == "novel"
+        assert resolve_source_kind({"source_kind": {"k": "v"}}) == "novel"
+        assert resolve_source_kind({"source_kind": 123}) == "novel"
 
 
 class TestCreateSourceKind:


### PR DESCRIPTION
Closes #827

## 背景

承接 #826 引入的 `source_kind` 轴。本 PR 让 `plan_episodes` 在 `source_kind=screenplay` 下从「语义规划」收紧为「**尊重作者分集**」，`novel` 路径行为完全不变。

## 改动

- `lib/episode_planner.py::_build_planning_prompt` 按 `source_kind` 分支：
  - **screenplay** — 开篇定位翻为「提取而非重切」，二分支：① 剧本自带分集（任意形态——分集标记/结构表/标题体系/分隔等，**不依赖任何固定标记或正则**）→ 照用作者边界，title/hook/分集大纲取自剧本原文，落到 `end_anchor` 层与 drama 大纲条目；② 无分集线索 → 按完整剧情弧语义切，**绝不按字数机械切**。
  - **novel** — prompt 逐字不变（intro / drama 大纲 / 原文片段标题均抽取为常量保证 byte 级一致）。
- 边界判定仍走现有 `end_anchor` 校验 + 批级审阅 / replan 闸，零新增审核机制。
- 审查附带的去重清理：`source_kind` 回退解析在 `episode_planner` 与 `script_generator` 各有一份完全相同的逻辑，收敛为 `project_manager.resolve_source_kind` 单一入口（与既有 `effective_mode` 并列），消除三处枚举回退漂移风险，行为不变。

## 验收对照

- [x] screenplay + 自带分集 → 账本落作者边界/标题/钩子/大纲（`test_plan_screenplay_respects_author_divisions`）
- [x] screenplay + 无分集标记 → 按剧情弧语义切、不按字数机械切（prompt 二分支显式禁止）
- [x] plan prompt 在 screenplay 下携带「尊重作者分集 / 无则语义切 / 不依赖固定标记」、novel 不变（`test_plan_prompt_branches_on_source_kind`）
- [x] 复用现有批级审阅 / replan 闸，无新增机制
- [x] novel 分集规划行为不变（回归）

## 验证

- `ruff check` / `ruff format` 干净；`basedpyright` 0 error。
- novel 路径 prompt 与父提交逐字比对：384 组 flag 组合 0 差异（byte 级一致），并验证空串/非法/缺失 `source_kind` 均回退至与 novel 完全一致的 prompt。
- `uv run pytest` 全量：4866 passed，唯一失败 `test_generation_worker_module.py::TestExtractProvider::test_default_when_unresolvable` 系本机 dev DB 配 grok 的环境耦合（已在干净 main 复现，CI 干净库通过），非本 PR 回归。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 支持按内容源类型（剧本/小说）进行更精细的分集规划：分割锚点落地要求与原文片段标注随源类型自动调整。

* **Tests**
  * 新增分集规划测试：覆盖剧本在“剧情大纲”模式下的分割锚点边界连续性与落账结果校验。
  * 新增提示分支校验：剧本包含对应语义要点，小说使用“小说原文片段”标注；同时新增源类型解析的回退行为测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->