### PR TITLE
feat(kling): 接入可灵 Kling JWT 直连视频与默认视频模型 2.5 Turbo

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -11,6 +11,7 @@ from lib.pricing.types import (
     PerImageFlat,
     PerImageOpenAIToken,
     PerSecondMatrix,
+    PerSecondTiered,
     PerToken,
     PerTokenVideo,
     PerVideoBucket,
@@ -215,6 +216,23 @@ def _minimax_image_pricing(model_id: str, per_image: float) -> PerImageFlat:
 # MiniMax 海螺视频按 (分辨率, 时长) 离散档计费（元/次，CNY）。
 def _minimax_video_pricing(model_id: str, buckets: dict[tuple[str, int], float]) -> PerVideoBucket:
     return PerVideoBucket(rates={model_id: buckets}, default_model=model_id, currency="CNY")
+
+
+# 可灵 Kling 视频「质量档 × 是否有声」¥/s 矩阵（官方一手核实，CNY，1 积分 = ¥1）。
+# 全部 video 模型共享同一档位矩阵（官方按维度组合定价、不分模型）：4K 档仅 v3/v3-omni 可达、
+# 有声仅 v2-6（pro）；turbo 仅触达 std/pro 无声/有声档。
+_KLING_VIDEO_TIERED_RATES: dict[tuple[str, bool], float] = {
+    ("std", False): 0.6,
+    ("std", True): 0.8,
+    ("pro", False): 0.8,
+    ("pro", True): 1.0,
+    ("4k", False): 3.0,
+    ("4k", True): 3.0,
+}
+
+
+def _kling_video_pricing(model_id: str) -> PerSecondTiered:
+    return PerSecondTiered(rates={model_id: _KLING_VIDEO_TIERED_RATES}, default_model=model_id, currency="CNY")
 
 
 PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
@@ -1019,8 +1037,19 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
         # 存入 provider_credential 的 access_key / secret_key 定型列（见 ADR 0037）。
         required_keys=["access_key", "secret_key"],
         secret_keys=["access_key", "secret_key"],
-        # 仅身份注册：models / backends / pricing 留给后续片接入。
-        models={},
+        # JWT 直连视频首发：默认视频模型 kling-v2-5-turbo（性价比走量）。其余视频模型
+        # （v3/v3-omni/v2-6/o1）与图像模型留后续片接入。
+        models={
+            "kling-v2-5-turbo": ModelInfo(
+                display_name="可灵 2.5 Turbo",
+                media_type="video",
+                capabilities=["text_to_video", "image_to_video"],
+                default=True,
+                supported_durations=[5, 10],
+                resolutions=["720p", "1080p"],
+                pricing=_kling_video_pricing("kling-v2-5-turbo"),
+            ),
+        },
         default_base_url="https://api.klingai.com/v1",
     ),
 }

--- a/lib/cost_calculator.py
+++ b/lib/cost_calculator.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from lib.custom_provider import is_custom_provider
 from lib.pricing.lookup import lookup_pricing
 from lib.pricing.strategies import PricingParams, calculate_pricing
-from lib.pricing.types import CHARACTERS_PER_PRICING_UNIT, PerSecondMatrix, PerTokenVideo
+from lib.pricing.types import CHARACTERS_PER_PRICING_UNIT, PerSecondMatrix, PerSecondTiered, PerTokenVideo
 from lib.providers import CallType
 
 
@@ -71,7 +71,7 @@ class CostCalculator:
         pricing = lookup_pricing(provider, model, call_type)
         # 按秒计费的视频：单次实时调用无/0 时长时按默认 8 秒计（历史行为）。参考模式聚合走
         # estimate_reference_video_cost，传真实累计时长（可为 0），不经此默认。
-        if isinstance(pricing, PerSecondMatrix):
+        if isinstance(pricing, (PerSecondMatrix, PerSecondTiered)):
             duration_seconds = duration_seconds or 8
         params = PricingParams(
             call_type=call_type,

--- a/lib/kling_shared.py
+++ b/lib/kling_shared.py
@@ -33,15 +33,6 @@ KLING_STATUS_SUCCEED = "succeed"
 KLING_STATUS_FAILED = "failed"
 _TERMINAL_STATES = frozenset({KLING_STATUS_SUCCEED, KLING_STATUS_FAILED})
 
-# 图片后缀 → MIME（image2video 首尾帧接受 base64）。
-_IMAGE_MIME_TYPES: dict[str, str] = {
-    ".png": "image/png",
-    ".jpg": "image/jpeg",
-    ".jpeg": "image/jpeg",
-    ".gif": "image/gif",
-    ".webp": "image/webp",
-}
-
 
 class KlingJWTManager:
     """可灵 JWT HS256 token 管理器（按需重签，时钟可注入）。

--- a/lib/kling_shared.py
+++ b/lib/kling_shared.py
@@ -130,9 +130,18 @@ def kling_response_error(payload: dict) -> str | None:
 
     可灵所有响应带顶层 ``code`` / ``message``，0 表成功。提交/查询接口本身失败（鉴权、参数
     非法等）即在此暴露（鉴权失败等也可能另走 4xx，由 submit_post / raise_for_status 兜住）。
+
+    ``code`` 归一化为 int 再比较：bearer / 中转 endpoint 可能把 code 序列化成字符串（``"0"``）
+    或浮点，直接 ``code != 0`` 会把字符串 ``"0"`` 误判为错误；无法解析的 code 一律视为错误暴露原值。
     """
     code = payload.get("code")
-    if code is not None and code != 0:
+    if code is None:
+        return None
+    try:
+        is_error = int(float(code)) != 0
+    except (TypeError, ValueError, OverflowError):
+        is_error = True
+    if is_error:
         return f"Kling API code={code}: {payload.get('message', '')}".strip()
     return None
 

--- a/lib/kling_shared.py
+++ b/lib/kling_shared.py
@@ -1,0 +1,193 @@
+"""可灵 Kling 共享工具：JWT HS256 鉴权管理器 + base URL + 异步任务响应解析。
+
+供 image_backends / video_backends / 连接测试复用。可灵官方走 JWT HS256 鉴权（access_key 作
+``iss``、secret_key 签名、约 30 分钟过期），图像/视频均为异步任务（提交→轮询 task_id→取 url）。
+
+- ``KLING_BASE_URL`` — 官方 base（含 ``/v1``）。
+- ``KlingJWTManager`` — HS256 token 管理器：缓存 token，**每次取用前检查过期、距过期 <60s 按需重签**
+  （异步渲染可能超单 token 寿命，不能实例级签一次）；时钟可注入（测试不依赖真实墙钟）。
+- ``kling_bearer_headers`` — bearer 模式旁路 JWT、用静态 api_key 的鉴权头。
+- 异步任务响应解析：``code`` 信封错误、``data.task_id``、``data.task_status``
+  （submitted/processing/succeed/failed）、``data.task_result.videos[].url``。
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import jwt
+
+# 官方 base（含 /v1），对齐 ark_shared.ARK_BASE_URL 约定。
+KLING_BASE_URL = "https://api.klingai.com/v1"
+
+# JWT token 寿命与刷新策略。
+_TOKEN_TTL_SECONDS = 1800  # 约 30 分钟过期（官方）。
+_TOKEN_NBF_SKEW_SECONDS = 5  # nbf 略提前，容忍 client/server 轻微时钟偏移。
+_TOKEN_REFRESH_MARGIN_SECONDS = 60  # 距过期 <60s 即重签，避免长任务途中 token 失效。
+
+# 异步视频任务终态：succeed / failed；中间态 submitted / processing 继续轮询。
+KLING_STATUS_SUCCEED = "succeed"
+KLING_STATUS_FAILED = "failed"
+_TERMINAL_STATES = frozenset({KLING_STATUS_SUCCEED, KLING_STATUS_FAILED})
+
+# 图片后缀 → MIME（image2video 首尾帧接受 base64）。
+_IMAGE_MIME_TYPES: dict[str, str] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
+
+
+class KlingJWTManager:
+    """可灵 JWT HS256 token 管理器（按需重签，时钟可注入）。
+
+    payload = ``{"iss": access_key, "exp": now+1800, "nbf": now-5}``，secret_key 签名。
+    缓存 token，``token()`` 每次取用前检查：距过期 >60s 复用缓存，否则重签。HS256 编码近乎
+    零成本，缓存只省重复编码——重点是长任务（>30 分钟异步渲染）跨越单 token 寿命时自动续签。
+    """
+
+    def __init__(
+        self,
+        access_key: str,
+        secret_key: str,
+        *,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._access_key = access_key
+        self._secret_key = secret_key
+        self._clock = clock
+        self._cached_token: str | None = None
+        self._expires_at: float = 0.0
+
+    def token(self) -> str:
+        """返回有效 token：距过期 >60s 复用缓存，否则按需重签。"""
+        now = self._clock()
+        if self._cached_token is not None and self._expires_at - now > _TOKEN_REFRESH_MARGIN_SECONDS:
+            return self._cached_token
+        return self._mint(now)
+
+    def _mint(self, now: float) -> str:
+        exp = int(now) + _TOKEN_TTL_SECONDS
+        payload = {
+            "iss": self._access_key,
+            "exp": exp,
+            "nbf": int(now) - _TOKEN_NBF_SKEW_SECONDS,
+        }
+        token = jwt.encode(
+            payload,
+            self._secret_key,
+            algorithm="HS256",
+            headers={"alg": "HS256", "typ": "JWT"},
+        )
+        self._cached_token = token
+        self._expires_at = exp
+        return token
+
+    def auth_headers(self) -> dict[str, str]:
+        """鉴权头（每次取用触发过期检查 + 按需重签）。"""
+        return {
+            "Authorization": f"Bearer {self.token()}",
+            "Content-Type": "application/json",
+        }
+
+
+def kling_bearer_headers(api_key: str) -> dict[str, str]:
+    """bearer 模式（自定义 endpoint）：旁路 JWT 管理器，用静态 api_key 的鉴权头。"""
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+
+def resolve_kling_jwt_credentials(access_key: str | None, secret_key: str | None) -> tuple[str, str]:
+    """校验并归一化可灵 JWT 双密钥；任一缺失即 raise（不走 env fallback）。"""
+    ak = (access_key or "").strip()
+    sk = (secret_key or "").strip()
+    if not ak or not sk:
+        raise ValueError("请到系统配置页填写可灵 Kling 的 Access Key 与 Secret Key")
+    return ak, sk
+
+
+def resolve_kling_api_key(api_key: str | None) -> str:
+    """校验并归一化 bearer 模式静态 api_key；缺失即 raise。"""
+    key = (api_key or "").strip()
+    if not key:
+        raise ValueError("请填写可灵 endpoint 的 API Key")
+    return key
+
+
+def image_to_base64(image_path: Path) -> str:
+    """本地图片 → 纯 base64 字符串（可灵 image / image_tail 接受 URL 或 base64，无 data URI 前缀）。"""
+    return base64.b64encode(image_path.read_bytes()).decode("ascii")
+
+
+# ── 异步任务响应解析（提交 / 轮询 / 取结果） ──────────────────────────────────────
+
+
+def _as_dict(value: object) -> dict:
+    """把任意值归一化为 dict：非 dict（None / list / str 等异常上游结构）一律回空 dict。"""
+    return value if isinstance(value, dict) else {}
+
+
+def kling_response_error(payload: dict) -> str | None:
+    """``code != 0`` → 错误描述；0 或缺失 → None。
+
+    可灵所有响应带顶层 ``code`` / ``message``，0 表成功。提交/查询接口本身失败（鉴权、参数
+    非法等）即在此暴露（鉴权失败等也可能另走 4xx，由 submit_post / raise_for_status 兜住）。
+    """
+    code = payload.get("code")
+    if code is not None and code != 0:
+        return f"Kling API code={code}: {payload.get('message', '')}".strip()
+    return None
+
+
+def extract_kling_task_id(submit_payload: dict) -> str:
+    """从提交响应提取 ``data.task_id``；缺失则按 code 错误或原样抛出。"""
+    task_id = _as_dict(submit_payload.get("data")).get("task_id")
+    if not task_id:
+        reason = kling_response_error(submit_payload)
+        raise RuntimeError(reason or f"Kling 视频提交响应缺少 task_id: {submit_payload}")
+    return str(task_id)
+
+
+def kling_task_status(payload: dict) -> str | None:
+    """查询响应的 ``data.task_status``（submitted/processing/succeed/failed）。"""
+    return _as_dict(payload.get("data")).get("task_status")
+
+
+def is_kling_task_terminal(payload: dict) -> bool:
+    """succeed / failed 为终态，停止轮询；其余（含未知/空）继续轮询。"""
+    return kling_task_status(payload) in _TERMINAL_STATES
+
+
+def kling_task_failure_reason(payload: dict) -> str | None:
+    """``task_status=failed`` 或顶层 ``code`` 硬错误 → 错误描述；否则 None。
+
+    succeed / 中间态返回 None（中间态由 is_terminal 判定为未完成继续轮询）。
+    """
+    # 顶层 code 硬错误（如 task_id 不存在 / 鉴权失败）优先暴露。
+    err = kling_response_error(payload)
+    if err is not None:
+        return err
+    if kling_task_status(payload) == KLING_STATUS_FAILED:
+        data = _as_dict(payload.get("data"))
+        return (f"Kling 视频任务失败 task_id={data.get('task_id')}: {data.get('task_status_msg', '')}").strip()
+    return None
+
+
+def extract_kling_video_url(payload: dict) -> str:
+    """从 succeed 的查询响应提取 ``data.task_result.videos[0].url``。"""
+    result = _as_dict(_as_dict(payload.get("data")).get("task_result"))
+    videos = result.get("videos")
+    if isinstance(videos, list):
+        for video in videos:
+            url = _as_dict(video).get("url")
+            if isinstance(url, str) and url:
+                return url
+    reason = kling_response_error(payload)
+    raise RuntimeError(reason or f"Kling 视频任务完成但缺少视频 URL: {payload}")

--- a/lib/kling_shared.py
+++ b/lib/kling_shared.py
@@ -125,6 +125,11 @@ def _as_dict(value: object) -> dict:
     return value if isinstance(value, dict) else {}
 
 
+def _as_str(value: object) -> str:
+    """把任意值归一化为 str：非 str（含显式 None）一律回空串，避免 null 被格式化成字面量 'None'。"""
+    return value if isinstance(value, str) else ""
+
+
 def kling_response_error(payload: dict) -> str | None:
     """``code != 0`` → 错误描述；0 或缺失 → None。
 
@@ -142,7 +147,7 @@ def kling_response_error(payload: dict) -> str | None:
     except (TypeError, ValueError, OverflowError):
         is_error = True
     if is_error:
-        return f"Kling API code={code}: {payload.get('message', '')}".strip()
+        return f"Kling API code={code}: {_as_str(payload.get('message'))}".strip()
     return None
 
 
@@ -176,7 +181,7 @@ def kling_task_failure_reason(payload: dict) -> str | None:
         return err
     if kling_task_status(payload) == KLING_STATUS_FAILED:
         data = _as_dict(payload.get("data"))
-        return (f"Kling 视频任务失败 task_id={data.get('task_id')}: {data.get('task_status_msg', '')}").strip()
+        return (f"Kling 视频任务失败 task_id={data.get('task_id')}: {_as_str(data.get('task_status_msg'))}").strip()
     return None
 
 

--- a/lib/pricing/lookup.py
+++ b/lib/pricing/lookup.py
@@ -14,6 +14,7 @@ from lib.providers import (
     PROVIDER_ARK,
     PROVIDER_DASHSCOPE,
     PROVIDER_GROK,
+    PROVIDER_KLING,
     PROVIDER_MINIMAX,
     PROVIDER_OPENAI,
     PROVIDER_VIDU,
@@ -24,7 +25,9 @@ logger = logging.getLogger(__name__)
 # 这些 provider 各有独立费率表：未知 model 回落到「该 provider 的默认模型」。其余 provider
 # （gemini-aistudio/vertex、裸 gemini、ark-agent-plan、未知）一律回落 Gemini 家族通用默认费率，
 # 复刻历史「仅 ark/grok/openai 走专属表、其余皆走全局 Gemini 表」的路由。
-_OWN_TABLE_PROVIDERS = frozenset({PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI, PROVIDER_DASHSCOPE, PROVIDER_MINIMAX})
+_OWN_TABLE_PROVIDERS = frozenset(
+    {PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI, PROVIDER_DASHSCOPE, PROVIDER_MINIMAX, PROVIDER_KLING}
+)
 
 # Anthropic 不在 PROVIDER_REGISTRY（无 ModelInfo 落点），文本定价作为 registry-external 例外。
 # 助手主链路优先使用 SDK 回报的实际费用；此表仅在只拿到 token 数时兜底。费率为美元/百万 token。

--- a/lib/pricing/strategies.py
+++ b/lib/pricing/strategies.py
@@ -15,6 +15,7 @@ from lib.pricing.types import (
     PerImageFlat,
     PerImageOpenAIToken,
     PerSecondMatrix,
+    PerSecondTiered,
     PerToken,
     PerTokenVideo,
     PerVideoBucket,
@@ -28,6 +29,10 @@ logger = logging.getLogger(__name__)
 # (resolution, duration) 离散档计费里 duration 缺省时的兜底秒数。海螺最短档为 6s，
 # 缺省按最短档计避免高估；真实请求恒带 duration，仅防御性兜底。
 _DEFAULT_BUCKET_DURATION = 6
+
+# per_second_tiered 档位派生常量：service_tier "default" 归一到 "std"，4K 分辨率独立成 "4k" 档。
+_TIERED_DEFAULT_TIER = "std"
+_TIERED_4K_RESOLUTION = "4k"
 
 
 @dataclass(frozen=True)
@@ -132,6 +137,37 @@ def _per_second_matrix(pricing: PerSecondMatrix, params: PricingParams) -> tuple
     return duration * per_second, pricing.currency
 
 
+def _per_second_tiered(pricing: PerSecondTiered, params: PricingParams) -> tuple[float, str]:
+    model = params.model or pricing.default_model
+    model_rates = pricing.rates.get(model, pricing.rates[pricing.default_model])
+    # 真实 0 秒保持 0；缺省（None）按 8 秒兜底（与 _per_second_matrix 对齐）。
+    duration = params.duration_seconds if params.duration_seconds is not None else 8
+
+    # 档位派生：4K 分辨率独立成档（忽略 std/pro），否则取 service_tier（"default"→"std"）。
+    resolution = (params.resolution or "").lower()
+    if resolution == _TIERED_4K_RESOLUTION:
+        tier = _TIERED_4K_RESOLUTION
+    else:
+        service_tier = (params.service_tier or "").lower()
+        tier = service_tier if service_tier and service_tier != "default" else _TIERED_DEFAULT_TIER
+
+    per_second = model_rates.get((tier, params.generate_audio))
+    if per_second is None:
+        # 未命中档：回落该 model 的 std 档（取相同 audio，其次无声），并 WARN——档表与请求漂移
+        # （如未知 service_tier）的可观测信号。
+        per_second = model_rates.get(
+            (_TIERED_DEFAULT_TIER, params.generate_audio),
+            model_rates.get((_TIERED_DEFAULT_TIER, False), 0.0),
+        )
+        logger.warning(
+            "per_second_tiered 未命中档 model=%s tier=%s audio=%s，回落 std 档",
+            model,
+            tier,
+            params.generate_audio,
+        )
+    return duration * per_second, pricing.currency
+
+
 def _per_video_bucket(pricing: PerVideoBucket, params: PricingParams) -> tuple[float, str]:
     model = params.model or pricing.default_model
     model_buckets = pricing.rates.get(model, pricing.rates[pricing.default_model])
@@ -198,6 +234,8 @@ def calculate_pricing(pricing: Pricing, params: PricingParams) -> tuple[float, s
         return _per_image_openai_token(pricing, params)
     if isinstance(pricing, PerSecondMatrix):
         return _per_second_matrix(pricing, params)
+    if isinstance(pricing, PerSecondTiered):
+        return _per_second_tiered(pricing, params)
     if isinstance(pricing, PerVideoBucket):
         return _per_video_bucket(pricing, params)
     if isinstance(pricing, PerTokenVideo):

--- a/lib/pricing/types.py
+++ b/lib/pricing/types.py
@@ -102,6 +102,27 @@ class PerVideoBucket:
 
 
 @dataclass(frozen=True)
+class PerSecondTiered:
+    """视频按「质量档 × 是否有声」定 ¥/s（再 × 时长），比 ``PerSecondMatrix`` 多一层质量档。
+
+    可灵 Kling 视频按维度组合计费：档位 ∈ ``{std, pro, 4k}``，再叠加是否有声。与 Veo 的
+    ``per_second_matrix``（仅 resolution × audio）不同，质量档（service_tier）是独立维度。
+
+    - ``rates`` 形如 ``{model: {(档位, 是否有声): 每秒价}}``。
+    - 档位派生：``resolution.lower()=="4k"`` → ``"4k"``，否则取 ``service_tier``
+      （``service_tier ∈ {std, pro}``，``"default"`` → ``"std"``）。4k 档忽略音频维度
+      （两个 audio 键同价）。
+    - 金额 = ``rate × duration_seconds``；未命中档回落该 model 的 ``std`` 档并 WARN
+      （档表与请求漂移的可观测信号）。
+    """
+
+    rates: dict[str, dict[tuple[str, bool], float]]
+    default_model: str
+    currency: str = "CNY"
+    kind: Literal["per_second_tiered"] = "per_second_tiered"
+
+
+@dataclass(frozen=True)
 class PerTokenVideo:
     """视频按 token 计费（按 ``(service_tier, 是否生成音频)`` 查每百万 token 价）。
 
@@ -149,6 +170,7 @@ Pricing = (
     | PerImageByResolution
     | PerImageOpenAIToken
     | PerSecondMatrix
+    | PerSecondTiered
     | PerVideoBucket
     | PerTokenVideo
     | PerCharacter

--- a/lib/providers.py
+++ b/lib/providers.py
@@ -11,6 +11,7 @@ PROVIDER_VIDU = "vidu"
 PROVIDER_NEWAPI = "newapi"
 PROVIDER_DASHSCOPE = "dashscope"
 PROVIDER_MINIMAX = "minimax"
+PROVIDER_KLING = "kling"
 PROVIDER_ANTHROPIC = "anthropic"
 
 CallType = Literal["image", "video", "text", "audio"]

--- a/lib/video_backends/__init__.py
+++ b/lib/video_backends/__init__.py
@@ -75,3 +75,9 @@ from lib.providers import PROVIDER_MINIMAX  # noqa: E402
 from lib.video_backends.minimax import MiniMaxVideoBackend  # noqa: E402
 
 register_backend(PROVIDER_MINIMAX, MiniMaxVideoBackend)
+
+# 可灵 Kling — JWT 直连视频（默认模型 kling-v2-5-turbo）
+from lib.providers import PROVIDER_KLING  # noqa: E402
+from lib.video_backends.kling import KlingVideoBackend  # noqa: E402
+
+register_backend(PROVIDER_KLING, KlingVideoBackend)

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -168,7 +168,7 @@ class KlingVideoBackend:
             return _TEXT2VIDEO, payload
 
         payload["image"] = self._encode_frame(Path(request.start_image))  # type: ignore[arg-type]
-        if request.end_image:
+        if isinstance(request.end_image, (str, Path)) and str(request.end_image):
             payload["image_tail"] = self._encode_frame(Path(request.end_image))
         return _IMAGE2VIDEO, payload
 

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -168,7 +168,7 @@ class KlingVideoBackend:
             return _TEXT2VIDEO, payload
 
         payload["image"] = self._encode_frame(Path(request.start_image))  # type: ignore[arg-type]
-        if request.end_image is not None:
+        if request.end_image:
             payload["image_tail"] = self._encode_frame(Path(request.end_image))
         return _IMAGE2VIDEO, payload
 

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -1,0 +1,281 @@
+"""KlingVideoBackend — 可灵 Kling 视频生成后端（JWT 直连 / Bearer 中转双模式，异步轮询）。
+
+走可灵原生视频端点：submit ``POST /v1/videos/{text2video|image2video}`` 取 ``data.task_id`` →
+轮询 ``GET /v1/videos/{subpath}/{task_id}`` 至 ``task_status=succeed`` 取
+``task_result.videos[0].url`` → 下载本地。复用 base.py 的 submit/poll/download helpers，
+自包含异步状态机、不依赖 DashScope async 机制。
+
+双模式（对齐 ``GeminiVideoBackend`` 的 ``backend_type`` 先例）：
+- ``auth_mode="jwt"``（内置 provider）：接 access_key + secret_key，走 ``KlingJWTManager``，
+  每次 HTTP 调用前检查过期、距过期 <60s 按需重签——异步渲染可能超单 token 寿命。
+- ``auth_mode="bearer"``（自定义 endpoint）：接静态 api_key + base_url，旁路 JWT 管理器。
+
+本片只接默认视频模型 ``kling-v2-5-turbo``（std/pro，5s/10s，文生 + 图生视频含首尾帧）；
+其余模型（v3/v3-omni/v2-6/o1）与能力门控由后续片接入。
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import httpx
+
+from lib.config.url_utils import normalize_base_url
+from lib.kling_shared import (
+    KLING_BASE_URL,
+    KlingJWTManager,
+    extract_kling_task_id,
+    extract_kling_video_url,
+    image_to_base64,
+    is_kling_task_terminal,
+    kling_bearer_headers,
+    kling_task_failure_reason,
+    resolve_kling_api_key,
+    resolve_kling_jwt_credentials,
+)
+from lib.providers import PROVIDER_KLING
+from lib.retry import (
+    DEFAULT_BACKOFF_SECONDS,
+    DEFAULT_MAX_ATTEMPTS,
+    DOWNLOAD_BACKOFF_SECONDS,
+    DOWNLOAD_MAX_ATTEMPTS,
+    with_retry_async,
+)
+from lib.video_backends.base import (
+    VideoCapabilities,
+    VideoCapability,
+    VideoCapabilityError,
+    VideoGenerationRequest,
+    VideoGenerationResult,
+    download_video,
+    persist_provider_job_id,
+    poll_with_retry,
+    should_retry_download,
+    should_retry_poll,
+    should_retry_submit,
+    submit_post,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "kling-v2-5-turbo"
+
+_TEXT2VIDEO = "text2video"
+_IMAGE2VIDEO = "image2video"
+
+_MIN_POLL_TIMEOUT_SECONDS = 900.0
+_POLL_TIMEOUT_PER_SECOND = 60.0
+_KLING_VIDEO_POLL_INTERVAL_SECONDS = 10.0
+
+
+class KlingVideoBackend:
+    """可灵 Kling 视频后端（异步轮询，JWT / Bearer 双模式）。"""
+
+    def __init__(
+        self,
+        *,
+        auth_mode: str = "jwt",
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        http_timeout: float = 60.0,
+    ) -> None:
+        self._auth_mode = auth_mode
+        self._model = model or DEFAULT_MODEL
+        self._base_url = (normalize_base_url(base_url) or KLING_BASE_URL).rstrip("/")
+        self._http_timeout = http_timeout
+
+        if auth_mode == "jwt":
+            ak, sk = resolve_kling_jwt_credentials(access_key, secret_key)
+            self._jwt: KlingJWTManager | None = KlingJWTManager(ak, sk)
+            self._static_api_key: str | None = None
+        elif auth_mode == "bearer":
+            self._jwt = None
+            self._static_api_key = resolve_kling_api_key(api_key)
+        else:
+            raise ValueError(f"未知 Kling auth_mode: {auth_mode}")
+
+        # turbo：文生 + 图生视频（首尾帧 pro），无参考图/音频。
+        self._capabilities: set[VideoCapability] = {
+            VideoCapability.TEXT_TO_VIDEO,
+            VideoCapability.IMAGE_TO_VIDEO,
+        }
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_KLING
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def capabilities(self) -> set[VideoCapability]:
+        return self._capabilities
+
+    @property
+    def video_capabilities(self) -> VideoCapabilities:
+        # turbo 支持首尾帧（pro），不建模参考图（多图主体留 v3-omni/o1）。
+        return VideoCapabilities(first_frame=True, last_frame=True)
+
+    # ── auth ────────────────────────────────────────────────────────────
+
+    def _headers(self) -> dict[str, str]:
+        """鉴权头：jwt 模式每次调用触发过期检查 + 按需重签；bearer 模式用静态 key。"""
+        if self._jwt is not None:
+            return self._jwt.auth_headers()
+        assert self._static_api_key is not None
+        return kling_bearer_headers(self._static_api_key)
+
+    # ── request building ────────────────────────────────────────────────
+
+    def _build_payload(self, request: VideoGenerationRequest) -> tuple[str, dict]:
+        """返回 (子路径, 请求体)。无首帧 → text2video；有首帧 → image2video（含可选尾帧）。"""
+        mode = "pro" if (request.service_tier or "").lower() == "pro" else "std"
+        payload: dict = {
+            "model_name": self._model,
+            "prompt": request.prompt,
+            "mode": mode,
+            "duration": str(request.duration_seconds),
+            "aspect_ratio": request.aspect_ratio,
+        }
+
+        has_start = isinstance(request.start_image, (str, Path)) and str(request.start_image)
+        if not has_start:
+            return _TEXT2VIDEO, payload
+
+        payload["image"] = self._encode_frame(Path(request.start_image))  # type: ignore[arg-type]
+        if request.end_image is not None:
+            payload["image_tail"] = self._encode_frame(Path(request.end_image))
+        return _IMAGE2VIDEO, payload
+
+    def _encode_frame(self, path: Path) -> str:
+        # fail-loud：声明了帧图却缺失/不可读即中止，不静默退化（会产出错误结果且照常计费）。
+        if not path.is_file():
+            raise VideoCapabilityError("video_start_image_unreadable", model=self._model, name=path.name)
+        try:
+            return image_to_base64(path)
+        except OSError as exc:
+            raise VideoCapabilityError("video_start_image_unreadable", model=self._model, name=path.name) from exc
+
+    @staticmethod
+    def _safe_log_view(subpath: str, payload: dict) -> dict:
+        """预脱敏标量视图，直接喂 logger（避开 format_kwargs_for_log sink）。
+
+        base64 帧图 / prompt 一律不展开：仅记是否存在 + prompt 长度。
+        """
+        prompt = payload.get("prompt")
+        return {
+            "endpoint": subpath,
+            "model_name": payload.get("model_name"),
+            "mode": payload.get("mode"),
+            "duration": payload.get("duration"),
+            "aspect_ratio": payload.get("aspect_ratio"),
+            "has_image": "image" in payload,
+            "has_image_tail": "image_tail" in payload,
+            "prompt_len": len(prompt) if isinstance(prompt, str) else 0,
+        }
+
+    # ── generate / resume ───────────────────────────────────────────────
+
+    async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
+        subpath, payload = self._build_payload(request)
+        logger.info("调用 Kling 视频 API payload=%s", self._safe_log_view(subpath, payload))
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            task_id = await self._create_task(client, subpath, payload)
+            logger.info("Kling 视频任务已创建: task_id=%s model=%s", task_id, self._model)
+            if request.task_id is not None:
+                await persist_provider_job_id(request.task_id, task_id, provider=PROVIDER_KLING)
+            return await self._poll_and_build(client, subpath, task_id, request)
+
+    async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
+        """接续已 submit 的 Kling task：仅轮询 + 取 url + 下载，不重新提交（ADR 0007）。
+
+        子路径由 request 复现（与 submit 同逻辑）——可灵查询端点按生成类型分路径。
+        """
+        subpath = (
+            _IMAGE2VIDEO if (isinstance(request.start_image, (str, Path)) and str(request.start_image)) else _TEXT2VIDEO
+        )
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            return await self._poll_and_build(client, subpath, job_id, request)
+
+    # ── HTTP submit / poll / download ───────────────────────────────────
+
+    @with_retry_async(
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+        retry_if=should_retry_submit,
+    )
+    async def _create_task(self, client: httpx.AsyncClient, subpath: str, payload: dict) -> str:
+        # 非幂等「建任务 + 计费」POST：submit_post 把歧义传输错误转 AmbiguousSubmitError 终态失败，
+        # 避免重试重复建任务 + 重复计费；>=400 抛 HTTPStatusError 交 should_retry_submit 按状态码分流。
+        resp = await submit_post(
+            lambda: client.post(
+                f"{self._base_url}/videos/{subpath}",
+                json=payload,
+                headers=self._headers(),
+            ),
+            provider=PROVIDER_KLING,
+        )
+        return extract_kling_task_id(resp.json())
+
+    async def _poll_query(self, client: httpx.AsyncClient, subpath: str, task_id: str) -> dict:
+        resp = await client.get(
+            f"{self._base_url}/videos/{subpath}/{task_id}",
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _poll_and_build(
+        self,
+        client: httpx.AsyncClient,
+        subpath: str,
+        task_id: str,
+        request: VideoGenerationRequest,
+    ) -> VideoGenerationResult:
+        final = await poll_with_retry(
+            poll_fn=lambda: self._poll_query(client, subpath, task_id),
+            is_done=is_kling_task_terminal,
+            is_failed=kling_task_failure_reason,
+            poll_interval=_KLING_VIDEO_POLL_INTERVAL_SECONDS,
+            max_wait=self._max_wait(request.duration_seconds),
+            retry_if=should_retry_poll,
+            label="Kling",
+            on_progress=lambda v, elapsed: logger.info(
+                "Kling 视频生成中... status=%s elapsed=%ds",
+                v.get("data", {}).get("task_status") if isinstance(v.get("data"), dict) else None,
+                int(elapsed),
+            ),
+        )
+
+        download_url = extract_kling_video_url(final)
+        await self._download_with_retry(download_url, request.output_path)
+        logger.info("Kling 视频下载完成: %s", request.output_path)
+
+        return VideoGenerationResult(
+            video_path=request.output_path,
+            provider=PROVIDER_KLING,
+            model=self._model,
+            duration_seconds=request.duration_seconds,
+            video_uri=download_url,
+            task_id=task_id,
+            # turbo 无音频能力：恒报无声，下游计费取无声价。
+            generate_audio=False,
+        )
+
+    @staticmethod
+    @with_retry_async(
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
+        retry_if=should_retry_download,
+    )
+    async def _download_with_retry(download_url: str, output_path: Path) -> None:
+        await download_video(download_url, output_path)
+
+    @staticmethod
+    def _max_wait(duration_seconds: int) -> float:
+        return max(_MIN_POLL_TIMEOUT_SECONDS, duration_seconds * _POLL_TIMEOUT_PER_SECOND)

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -63,10 +63,29 @@ DEFAULT_MODEL = "kling-v2-5-turbo"
 
 _TEXT2VIDEO = "text2video"
 _IMAGE2VIDEO = "image2video"
+_RESUMABLE_SUBPATHS = frozenset({_TEXT2VIDEO, _IMAGE2VIDEO})
 
 _MIN_POLL_TIMEOUT_SECONDS = 900.0
 _POLL_TIMEOUT_PER_SECOND = 60.0
 _KLING_VIDEO_POLL_INTERVAL_SECONDS = 10.0
+
+
+def _encode_job_id(subpath: str, task_id: str) -> str:
+    """把生成类型子路径编进持久化 job_id（``subpath:task_id``）。
+
+    可灵查询端点按生成类型分路径（``GET /v1/videos/{text2video|image2video}/{id}``），
+    且重启 resume 时请求已无 ``start_image`` 可推断子路径——必须把子路径随 task_id 一起
+    持久化，否则 image2video 任务 resume 会误查 text2video 端点取不到任务。
+    """
+    return f"{subpath}:{task_id}"
+
+
+def _decode_job_id(job_id: str) -> tuple[str, str]:
+    """从持久化 job_id 复原 ``(子路径, task_id)``；无已知前缀（异常/旧数据）回落 text2video。"""
+    prefix, sep, rest = job_id.partition(":")
+    if sep and prefix in _RESUMABLE_SUBPATHS:
+        return prefix, rest
+    return _TEXT2VIDEO, job_id
 
 
 class KlingVideoBackend:
@@ -188,19 +207,21 @@ class KlingVideoBackend:
             task_id = await self._create_task(client, subpath, payload)
             logger.info("Kling 视频任务已创建: task_id=%s model=%s", task_id, self._model)
             if request.task_id is not None:
-                await persist_provider_job_id(request.task_id, task_id, provider=PROVIDER_KLING)
+                # 持久化「子路径:task_id」而非裸 task_id：resume 据此复原查询端点（见 _encode_job_id）。
+                await persist_provider_job_id(
+                    request.task_id, _encode_job_id(subpath, task_id), provider=PROVIDER_KLING
+                )
             return await self._poll_and_build(client, subpath, task_id, request)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
         """接续已 submit 的 Kling task：仅轮询 + 取 url + 下载，不重新提交（ADR 0007）。
 
-        子路径由 request 复现（与 submit 同逻辑）——可灵查询端点按生成类型分路径。
+        查询子路径从持久化 job_id 复原（submit 时编入）——可灵查询端点按生成类型分路径，
+        而 resume 请求已无 ``start_image`` 可推断，故不能再从 request 取（见 _encode_job_id）。
         """
-        subpath = (
-            _IMAGE2VIDEO if (isinstance(request.start_image, (str, Path)) and str(request.start_image)) else _TEXT2VIDEO
-        )
+        subpath, task_id = _decode_job_id(job_id)
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
-            return await self._poll_and_build(client, subpath, job_id, request)
+            return await self._poll_and_build(client, subpath, task_id, request)
 
     # ── HTTP submit / poll / download ───────────────────────────────────
 

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -31,6 +31,7 @@ from lib.kling_shared import (
     is_kling_task_terminal,
     kling_bearer_headers,
     kling_task_failure_reason,
+    kling_task_status,
     resolve_kling_api_key,
     resolve_kling_jwt_credentials,
 )
@@ -268,7 +269,7 @@ class KlingVideoBackend:
             label="Kling",
             on_progress=lambda v, elapsed: logger.info(
                 "Kling 视频生成中... status=%s elapsed=%ds",
-                v.get("data", {}).get("task_status") if isinstance(v.get("data"), dict) else None,
+                kling_task_status(v),
                 int(elapsed),
             ),
         )

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -163,13 +163,14 @@ class KlingVideoBackend:
             "aspect_ratio": request.aspect_ratio,
         }
 
-        has_start = isinstance(request.start_image, (str, Path)) and str(request.start_image)
-        if not has_start:
+        start_image = request.start_image
+        if not (isinstance(start_image, (str, Path)) and str(start_image)):
             return _TEXT2VIDEO, payload
 
-        payload["image"] = self._encode_frame(Path(request.start_image))  # type: ignore[arg-type]
-        if isinstance(request.end_image, (str, Path)) and str(request.end_image):
-            payload["image_tail"] = self._encode_frame(Path(request.end_image))
+        payload["image"] = self._encode_frame(Path(start_image))
+        end_image = request.end_image
+        if isinstance(end_image, (str, Path)) and str(end_image):
+            payload["image_tail"] = self._encode_frame(Path(end_image))
         return _IMAGE2VIDEO, payload
 
     def _encode_frame(self, path: Path) -> str:

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -39,7 +39,7 @@ from lib.prompt_utils import (
     is_structured_video_prompt,
     video_prompt_to_yaml,
 )
-from lib.providers import PROVIDER_ARK, PROVIDER_GEMINI, PROVIDER_GROK, PROVIDER_OPENAI, PROVIDER_VIDU
+from lib.providers import PROVIDER_ARK, PROVIDER_GEMINI, PROVIDER_GROK, PROVIDER_KLING, PROVIDER_OPENAI, PROVIDER_VIDU
 from lib.reference_compression import ReferencePayloadFloorError
 from lib.resource_paths import resource_relative_path
 from lib.storyboard_sequence import (
@@ -199,6 +199,16 @@ async def _get_or_create_video_backend(
         kwargs["api_key"] = db_config.get("api_key")
         kwargs["rate_limiter"] = rate_limiter
         kwargs["video_model"] = effective_model
+    elif backend_name == PROVIDER_KLING:
+        # 可灵 JWT 直连：双 secret（access_key + secret_key）而非单 api_key（见 ADR 0037）。
+        db_config = await resolver.provider_config(PROVIDER_KLING)
+        kwargs["auth_mode"] = "jwt"
+        kwargs["access_key"] = db_config.get("access_key")
+        kwargs["secret_key"] = db_config.get("secret_key")
+        kwargs["model"] = effective_model
+        base_url = db_config.get("base_url") or (PROVIDER_REGISTRY[PROVIDER_KLING].default_base_url)
+        if base_url:
+            kwargs["base_url"] = base_url
     else:
         await _fill_simple_provider_kwargs(backend_name, resolver, kwargs, effective_model)
 

--- a/tests/test_cost_calculator.py
+++ b/tests/test_cost_calculator.py
@@ -106,6 +106,39 @@ class TestAnthropicTextCost:
         assert amount == pytest.approx(0.35)
 
 
+class TestKlingVideoCost:
+    """可灵 per_second_tiered 经统一入口 calculate_cost 的金额对拍（CNY）。"""
+
+    def test_turbo_std_silent(self):
+        amount, currency = cost_calculator.calculate_cost(
+            "kling", "video", model="kling-v2-5-turbo", service_tier="std", generate_audio=False, duration_seconds=5
+        )
+        assert currency == "CNY"
+        assert amount == pytest.approx(0.6 * 5)
+
+    def test_turbo_pro_with_audio(self):
+        amount, currency = cost_calculator.calculate_cost(
+            "kling", "video", model="kling-v2-5-turbo", service_tier="pro", generate_audio=True, duration_seconds=5
+        )
+        assert currency == "CNY"
+        assert amount == pytest.approx(1.0 * 5)
+
+    def test_turbo_default_tier_maps_to_std(self):
+        # service_tier 缺省 "default" → std 无声
+        amount, _ = cost_calculator.calculate_cost(
+            "kling", "video", model="kling-v2-5-turbo", generate_audio=False, duration_seconds=10
+        )
+        assert amount == pytest.approx(0.6 * 10)
+
+    def test_unknown_kling_model_falls_back_to_turbo(self):
+        # 未知 model 回落到 kling 默认视频模型（turbo）费率，不串到 Gemini 表
+        amount, currency = cost_calculator.calculate_cost(
+            "kling", "video", model="kling-mystery", service_tier="pro", generate_audio=False, duration_seconds=5
+        )
+        assert currency == "CNY"
+        assert amount == pytest.approx(0.8 * 5)
+
+
 class TestArkVideoCost:
     def test_online_with_audio(self):
         amount, currency = cost_calculator.calculate_cost(

--- a/tests/test_kling_shared.py
+++ b/tests/test_kling_shared.py
@@ -1,0 +1,152 @@
+"""可灵 Kling 共享层单测：JWT token 管理器（注入时钟）+ 异步任务响应解析。
+
+不打真实 HTTP、不调真实墙钟——token 续签语义用可控时间源验证。
+"""
+
+from __future__ import annotations
+
+import jwt
+import pytest
+
+from lib.kling_shared import (
+    KLING_BASE_URL,
+    KlingJWTManager,
+    extract_kling_task_id,
+    extract_kling_video_url,
+    is_kling_task_terminal,
+    kling_bearer_headers,
+    kling_response_error,
+    kling_task_failure_reason,
+    resolve_kling_api_key,
+    resolve_kling_jwt_credentials,
+)
+
+
+class _Clock:
+    """可推进的注入时钟。"""
+
+    def __init__(self, start: float = 1_000_000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _decode(token: str, secret: str) -> dict:
+    return jwt.decode(token, secret, algorithms=["HS256"], options={"verify_nbf": False, "verify_exp": False})
+
+
+class TestKlingJWTManager:
+    def test_token_structure(self):
+        clock = _Clock()
+        mgr = KlingJWTManager("ak-123", "s" * 40, clock=clock)
+        token = mgr.token()
+        claims = _decode(token, "s" * 40)
+        assert claims["iss"] == "ak-123"
+        assert claims["exp"] == int(clock.now) + 1800
+        assert claims["nbf"] == int(clock.now) - 5
+        # header 声明 HS256 / JWT
+        header = jwt.get_unverified_header(token)
+        assert header["alg"] == "HS256"
+        assert header["typ"] == "JWT"
+
+    def test_reuses_cached_token_when_far_from_expiry(self):
+        clock = _Clock()
+        mgr = KlingJWTManager("ak", "s" * 40, clock=clock)
+        first = mgr.token()
+        clock.advance(100)  # 距过期仍有约 1700s（>60s），复用缓存
+        assert mgr.token() == first  # 复用缓存
+
+    def test_resigns_when_within_refresh_margin(self):
+        clock = _Clock()
+        mgr = KlingJWTManager("ak", "s" * 40, clock=clock)
+        first = mgr.token()
+        # 推进到距过期 30s（<60s 刷新窗口）→ 重签返回新 token
+        clock.advance(1800 - 30)
+        second = mgr.token()
+        assert second != first
+        claims = _decode(second, "s" * 40)
+        assert claims["exp"] == int(clock.now) + 1800
+
+    def test_signed_with_secret_key(self):
+        mgr = KlingJWTManager("ak", "c" * 40, clock=_Clock())
+        token = mgr.token()
+        with pytest.raises(jwt.InvalidSignatureError):
+            jwt.decode(token, "w" * 40, algorithms=["HS256"], options={"verify_exp": False})
+
+    def test_auth_headers_carry_bearer_token(self):
+        mgr = KlingJWTManager("ak", "s" * 40, clock=_Clock())
+        headers = mgr.auth_headers()
+        assert headers["Authorization"].startswith("Bearer ")
+        assert headers["Content-Type"] == "application/json"
+
+
+class TestBearerMode:
+    def test_bearer_headers_use_static_key_no_jwt(self):
+        headers = kling_bearer_headers("static-api-key")
+        # bearer 模式旁路 JWT：Authorization 直接是静态 key，不是签名 token
+        assert headers["Authorization"] == "Bearer static-api-key"
+
+
+class TestCredentialResolution:
+    def test_jwt_credentials_strip_and_return(self):
+        assert resolve_kling_jwt_credentials(" ak ", " sk ") == ("ak", "sk")
+
+    @pytest.mark.parametrize("ak,sk", [(None, "sk"), ("ak", None), ("", "sk"), ("  ", "sk")])
+    def test_jwt_credentials_missing_raises(self, ak, sk):
+        with pytest.raises(ValueError):
+            resolve_kling_jwt_credentials(ak, sk)
+
+    def test_api_key_missing_raises(self):
+        with pytest.raises(ValueError):
+            resolve_kling_api_key("  ")
+
+
+class TestResponseParsing:
+    def test_base_url_constant(self):
+        assert KLING_BASE_URL == "https://api.klingai.com/v1"
+
+    def test_extract_task_id(self):
+        payload = {"code": 0, "message": "SUCCEED", "data": {"task_id": "t-1", "task_status": "submitted"}}
+        assert extract_kling_task_id(payload) == "t-1"
+
+    def test_extract_task_id_missing_uses_code_error(self):
+        payload = {"code": 1101, "message": "auth failed", "data": {}}
+        with pytest.raises(RuntimeError, match="1101"):
+            extract_kling_task_id(payload)
+
+    def test_code_error_nonzero(self):
+        assert kling_response_error({"code": 5, "message": "boom"}) == "Kling API code=5: boom"
+        assert kling_response_error({"code": 0, "message": "ok"}) is None
+
+    def test_terminal_states(self):
+        assert is_kling_task_terminal({"data": {"task_status": "succeed"}}) is True
+        assert is_kling_task_terminal({"data": {"task_status": "failed"}}) is True
+        assert is_kling_task_terminal({"data": {"task_status": "processing"}}) is False
+        assert is_kling_task_terminal({"data": {"task_status": "submitted"}}) is False
+
+    def test_failure_reason_on_failed(self):
+        payload = {"code": 0, "data": {"task_id": "t-1", "task_status": "failed", "task_status_msg": "nsfw"}}
+        reason = kling_task_failure_reason(payload)
+        assert reason is not None
+        assert "t-1" in reason and "nsfw" in reason
+
+    def test_failure_reason_none_on_success(self):
+        assert kling_task_failure_reason({"code": 0, "data": {"task_status": "succeed"}}) is None
+
+    def test_failure_reason_top_level_code_error(self):
+        assert kling_task_failure_reason({"code": 1200, "message": "bad task"}) == "Kling API code=1200: bad task"
+
+    def test_extract_video_url(self):
+        payload = {
+            "code": 0,
+            "data": {"task_status": "succeed", "task_result": {"videos": [{"id": "v1", "url": "https://x/v.mp4"}]}},
+        }
+        assert extract_kling_video_url(payload) == "https://x/v.mp4"
+
+    def test_extract_video_url_missing_raises(self):
+        with pytest.raises(RuntimeError):
+            extract_kling_video_url({"code": 0, "data": {"task_status": "succeed", "task_result": {"videos": []}}})

--- a/tests/test_kling_shared.py
+++ b/tests/test_kling_shared.py
@@ -122,6 +122,14 @@ class TestResponseParsing:
         assert kling_response_error({"code": 5, "message": "boom"}) == "Kling API code=5: boom"
         assert kling_response_error({"code": 0, "message": "ok"}) is None
 
+    def test_code_normalized_before_compare(self):
+        # bearer / 中转 endpoint 可能把 code 序列化成字符串或浮点，归一化为 int 再比较。
+        assert kling_response_error({"code": "0", "message": "ok"}) is None
+        assert kling_response_error({"code": 0.0, "message": "ok"}) is None
+        assert kling_response_error({"code": "5", "message": "boom"}) == "Kling API code=5: boom"
+        # 无法解析的 code 视为错误，暴露原值。
+        assert kling_response_error({"code": "oops", "message": "bad"}) == "Kling API code=oops: bad"
+
     def test_terminal_states(self):
         assert is_kling_task_terminal({"data": {"task_status": "succeed"}}) is True
         assert is_kling_task_terminal({"data": {"task_status": "failed"}}) is True

--- a/tests/test_kling_shared.py
+++ b/tests/test_kling_shared.py
@@ -148,6 +148,12 @@ class TestResponseParsing:
     def test_failure_reason_top_level_code_error(self):
         assert kling_task_failure_reason({"code": 1200, "message": "bad task"}) == "Kling API code=1200: bad task"
 
+    def test_null_message_not_stringified(self):
+        # message / task_status_msg 显式为 null 时归一化为空串，不把字面量 'None' 拼进错误描述。
+        assert kling_response_error({"code": 5, "message": None}) == "Kling API code=5:"
+        reason = kling_task_failure_reason({"code": 0, "data": {"task_id": "t-2", "task_status": "failed"}})
+        assert reason is not None and "None" not in reason
+
     def test_extract_video_url(self):
         payload = {
             "code": 0,

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -259,7 +259,25 @@ class TestGenerateHappyPath:
             await _jwt_backend().generate(_request(tmp_path, task_id="local-task-1"))
         persist.assert_awaited_once()
         assert persist.await_args is not None
-        assert persist.await_args.args[1] == "task-x"
+        # 持久化的是「子路径:task_id」，resume 据此复原查询端点（text2video 因无首帧）
+        assert persist.await_args.args[1] == "text2video:task-x"
+
+    async def test_persists_image2video_subpath_in_job_id(self, tmp_path):
+        img = tmp_path / "first.png"
+        img.write_bytes(b"\x89PNG\r\n")
+        post = AsyncMock(return_value=_resp(_submit("task-i")))
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+            patch("lib.video_backends.kling.persist_provider_job_id", new=AsyncMock()) as persist,
+        ):
+            await _jwt_backend().generate(_request(tmp_path, task_id="local-task-2", start_image=img))
+        # 有首帧 → image2video 前缀编入 job_id，resume 才能查对端点
+        assert persist.await_args is not None
+        assert persist.await_args.args[1] == "image2video:task-i"
 
 
 class TestResume:
@@ -272,18 +290,18 @@ class TestResume:
             patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
             patch("lib.video_backends.kling.download_video", new=AsyncMock()) as dl,
         ):
-            result = await _jwt_backend().resume_video("task-resume", _request(tmp_path))
+            # 持久化 job_id 带 text2video 前缀 → 复原查询端点 + 还原裸 task_id
+            result = await _jwt_backend().resume_video("text2video:task-resume", _request(tmp_path))
 
         post.assert_not_called()
         assert result.task_id == "task-resume"
         assert result.video_uri == "https://x/r.mp4"
-        # 无首帧 → text2video 查询端点
         assert get.await_args.args[0].endswith("/videos/text2video/task-resume")
         dl.assert_awaited_once()
 
-    async def test_resume_image2video_subpath_from_request(self, tmp_path):
-        img = tmp_path / "f.png"
-        img.write_bytes(b"\x89PNG\r\n")
+    async def test_resume_image2video_subpath_from_encoded_job_id(self, tmp_path):
+        # resume 请求不带 start_image（真实重启路径如此）：子路径必须来自持久化 job_id 前缀，
+        # 否则 image2video 任务会误查 text2video 端点取不到。
         post = AsyncMock()
         get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
         client = _client(post=post, get=get)
@@ -292,5 +310,21 @@ class TestResume:
             patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
             patch("lib.video_backends.kling.download_video", new=AsyncMock()),
         ):
-            await _jwt_backend().resume_video("task-r2", _request(tmp_path, start_image=img))
+            result = await _jwt_backend().resume_video("image2video:task-r2", _request(tmp_path))
+        post.assert_not_called()
+        assert result.task_id == "task-r2"
         assert get.await_args.args[0].endswith("/videos/image2video/task-r2")
+
+    async def test_resume_bare_job_id_falls_back_to_text2video(self, tmp_path):
+        # 无已知前缀（异常/旧数据）回落 text2video，整串作 task_id。
+        post = AsyncMock()
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            result = await _jwt_backend().resume_video("legacy-bare-id", _request(tmp_path))
+        assert result.task_id == "legacy-bare-id"
+        assert get.await_args.args[0].endswith("/videos/text2video/legacy-bare-id")

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -149,6 +149,14 @@ class TestPayloadBuilding:
         _, payload = _jwt_backend()._build_payload(_request(tmp_path, start_image=first, end_image=last))
         assert "image" in payload and "image_tail" in payload
 
+    def test_image2video_empty_end_frame_is_omitted(self, tmp_path):
+        # 空串 end_image 等价于"无尾帧"，按 truthy 判定跳过，不应误当路径去编码而崩溃。
+        first = tmp_path / "first.png"
+        first.write_bytes(b"\x89PNG\r\n1")
+        subpath, payload = _jwt_backend()._build_payload(_request(tmp_path, start_image=first, end_image=""))
+        assert subpath == "image2video"
+        assert "image" in payload and "image_tail" not in payload
+
     def test_unreadable_start_image_raises(self, tmp_path):
         with pytest.raises(VideoCapabilityError) as exc:
             _jwt_backend()._build_payload(_request(tmp_path, start_image=tmp_path / "nope.png"))

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -1,0 +1,296 @@
+"""KlingVideoBackend 单元测试（mock httpx，异步轮询，不打真实 HTTP）。
+
+覆盖：JWT / Bearer 双模式鉴权注入、子路径选择（text2video / image2video）、请求体构建、
+脱敏日志视图、submit→轮询→下载端到端、provider_job_id 持久化、失败终态、resume 不重提交。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jwt
+import pytest
+
+from lib.providers import PROVIDER_KLING
+from lib.video_backends.base import VideoCapability, VideoCapabilityError, VideoGenerationRequest
+from lib.video_backends.kling import KlingVideoBackend
+
+_SECRET = "s" * 40
+
+
+def _resp(json_body: dict, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _submit(task_id: str = "t-1") -> dict:
+    return {"code": 0, "message": "SUCCEED", "data": {"task_id": task_id, "task_status": "submitted"}}
+
+
+def _query(status: str, url: str = "", status_msg: str = "") -> dict:
+    data: dict = {"task_id": "t-1", "task_status": status, "task_status_msg": status_msg}
+    if url:
+        data["task_result"] = {"videos": [{"id": "v1", "url": url}]}
+    return {"code": 0, "message": "SUCCEED", "data": data}
+
+
+def _client(*, post=None, get=None) -> AsyncMock:
+    c = AsyncMock()
+    if post is not None:
+        c.post = post
+    if get is not None:
+        c.get = get
+    c.__aenter__ = AsyncMock(return_value=c)
+    c.__aexit__ = AsyncMock(return_value=None)
+    return c
+
+
+def _jwt_backend(model: str | None = None) -> KlingVideoBackend:
+    return KlingVideoBackend(auth_mode="jwt", access_key="ak-1", secret_key=_SECRET, model=model)
+
+
+def _bearer_backend(model: str | None = None) -> KlingVideoBackend:
+    return KlingVideoBackend(auth_mode="bearer", api_key="static-key", model=model)
+
+
+def _request(tmp_path: Path, **overrides) -> VideoGenerationRequest:
+    kwargs: dict = {
+        "prompt": "a cat walking",
+        "output_path": tmp_path / "out.mp4",
+        "duration_seconds": 5,
+        "aspect_ratio": "9:16",
+    }
+    kwargs.update(overrides)
+    return VideoGenerationRequest(**kwargs)
+
+
+class TestConstructionAndCapabilities:
+    def test_name_and_default_model(self):
+        b = _jwt_backend()
+        assert b.name == PROVIDER_KLING
+        assert b.model == "kling-v2-5-turbo"
+
+    def test_jwt_missing_credentials_raises(self):
+        with pytest.raises(ValueError):
+            KlingVideoBackend(auth_mode="jwt", access_key="ak", secret_key=None)
+
+    def test_bearer_missing_api_key_raises(self):
+        with pytest.raises(ValueError):
+            KlingVideoBackend(auth_mode="bearer", api_key=None)
+
+    def test_unknown_auth_mode_raises(self):
+        with pytest.raises(ValueError):
+            KlingVideoBackend(auth_mode="oauth", api_key="k")
+
+    def test_capabilities_t2v_and_i2v(self):
+        caps = _jwt_backend().capabilities
+        assert VideoCapability.TEXT_TO_VIDEO in caps
+        assert VideoCapability.IMAGE_TO_VIDEO in caps
+
+    def test_video_capabilities_first_and_last_frame(self):
+        caps = _jwt_backend().video_capabilities
+        assert caps.first_frame is True
+        assert caps.last_frame is True
+        # turbo 不建模参考图（多图主体留后续片）
+        assert caps.reference_images is False
+
+
+class TestAuthHeaders:
+    def test_jwt_mode_signs_bearer_token(self):
+        headers = _jwt_backend()._headers()
+        assert headers["Content-Type"] == "application/json"
+        token = headers["Authorization"].removeprefix("Bearer ")
+        claims = jwt.decode(token, _SECRET, algorithms=["HS256"], options={"verify_exp": False})
+        assert claims["iss"] == "ak-1"
+
+    def test_bearer_mode_uses_static_key(self):
+        # bearer 模式旁路 JWT 管理器：Authorization 是静态 key，非签名 token
+        headers = _bearer_backend()._headers()
+        assert headers["Authorization"] == "Bearer static-key"
+
+
+class TestPayloadBuilding:
+    def test_text2video_no_image(self, tmp_path):
+        subpath, payload = _jwt_backend()._build_payload(_request(tmp_path))
+        assert subpath == "text2video"
+        assert payload["model_name"] == "kling-v2-5-turbo"
+        assert payload["mode"] == "std"
+        assert payload["duration"] == "5"  # 字符串
+        assert payload["aspect_ratio"] == "9:16"
+        assert "image" not in payload
+
+    def test_service_tier_pro_maps_to_mode_pro(self, tmp_path):
+        _, payload = _jwt_backend()._build_payload(_request(tmp_path, service_tier="pro"))
+        assert payload["mode"] == "pro"
+
+    def test_service_tier_default_maps_to_std(self, tmp_path):
+        _, payload = _jwt_backend()._build_payload(_request(tmp_path, service_tier="default"))
+        assert payload["mode"] == "std"
+
+    def test_image2video_embeds_base64_frame(self, tmp_path):
+        img = tmp_path / "first.png"
+        img.write_bytes(b"\x89PNG\r\n")
+        subpath, payload = _jwt_backend()._build_payload(_request(tmp_path, start_image=img))
+        assert subpath == "image2video"
+        assert isinstance(payload["image"], str) and payload["image"]
+        # 纯 base64，无 data URI 前缀
+        assert not payload["image"].startswith("data:")
+        assert "image_tail" not in payload
+
+    def test_image2video_with_end_frame(self, tmp_path):
+        first = tmp_path / "first.png"
+        last = tmp_path / "last.png"
+        first.write_bytes(b"\x89PNG\r\n1")
+        last.write_bytes(b"\x89PNG\r\n2")
+        _, payload = _jwt_backend()._build_payload(_request(tmp_path, start_image=first, end_image=last))
+        assert "image" in payload and "image_tail" in payload
+
+    def test_unreadable_start_image_raises(self, tmp_path):
+        with pytest.raises(VideoCapabilityError) as exc:
+            _jwt_backend()._build_payload(_request(tmp_path, start_image=tmp_path / "nope.png"))
+        assert exc.value.code == "video_start_image_unreadable"
+
+
+class TestSafeLogView:
+    def test_no_base64_or_prompt_leaks(self, tmp_path):
+        img = tmp_path / "f.png"
+        img.write_bytes(b"\x89PNG\r\n")
+        b = _jwt_backend()
+        subpath, payload = b._build_payload(_request(tmp_path, start_image=img))
+        view = b._safe_log_view(subpath, payload)
+        # 仅标量；base64 与 prompt 不展开
+        assert view["has_image"] is True
+        assert view["prompt_len"] == len("a cat walking")
+        assert "image" not in view
+        assert "prompt" not in view
+        assert all(isinstance(v, (str, int, bool)) for v in view.values())
+
+
+class TestGenerateHappyPath:
+    async def test_submit_poll_download(self, tmp_path):
+        post = AsyncMock(return_value=_resp(_submit("task-9")))
+        get = AsyncMock(
+            side_effect=[
+                _resp(_query("processing")),
+                _resp(_query("succeed", url="https://x/final.mp4")),
+            ]
+        )
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()) as dl,
+        ):
+            result = await _jwt_backend().generate(_request(tmp_path))
+
+        assert result.provider == PROVIDER_KLING
+        assert result.task_id == "task-9"
+        assert result.video_uri == "https://x/final.mp4"
+        assert result.generate_audio is False  # turbo 无音频
+        dl.assert_awaited_once()
+        # text2video 提交端点
+        assert post.await_args.args[0].endswith("/videos/text2video")
+
+    async def test_jwt_injected_on_submit(self, tmp_path):
+        captured: dict = {}
+
+        async def _post(url, json, headers):
+            captured["headers"] = headers
+            return _resp(_submit())
+
+        post = AsyncMock(side_effect=_post)
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            await _jwt_backend().generate(_request(tmp_path))
+
+        token = captured["headers"]["Authorization"].removeprefix("Bearer ")
+        claims = jwt.decode(token, _SECRET, algorithms=["HS256"], options={"verify_exp": False})
+        assert claims["iss"] == "ak-1"
+
+    async def test_bearer_static_key_on_submit(self, tmp_path):
+        captured: dict = {}
+
+        async def _post(url, json, headers):
+            captured["headers"] = headers
+            return _resp(_submit())
+
+        post = AsyncMock(side_effect=_post)
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            await _bearer_backend().generate(_request(tmp_path))
+        assert captured["headers"]["Authorization"] == "Bearer static-key"
+
+    async def test_failed_status_raises(self, tmp_path):
+        post = AsyncMock(return_value=_resp(_submit()))
+        get = AsyncMock(return_value=_resp(_query("failed", status_msg="content rejected")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            with pytest.raises(RuntimeError, match="content rejected"):
+                await _jwt_backend().generate(_request(tmp_path))
+
+    async def test_persists_provider_job_id_when_task_id_present(self, tmp_path):
+        post = AsyncMock(return_value=_resp(_submit("task-x")))
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+            patch("lib.video_backends.kling.persist_provider_job_id", new=AsyncMock()) as persist,
+        ):
+            await _jwt_backend().generate(_request(tmp_path, task_id="local-task-1"))
+        persist.assert_awaited_once()
+        assert persist.await_args is not None
+        assert persist.await_args.args[1] == "task-x"
+
+
+class TestResume:
+    async def test_resume_polls_without_resubmit(self, tmp_path):
+        post = AsyncMock()  # must NOT be called
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()) as dl,
+        ):
+            result = await _jwt_backend().resume_video("task-resume", _request(tmp_path))
+
+        post.assert_not_called()
+        assert result.task_id == "task-resume"
+        assert result.video_uri == "https://x/r.mp4"
+        # 无首帧 → text2video 查询端点
+        assert get.await_args.args[0].endswith("/videos/text2video/task-resume")
+        dl.assert_awaited_once()
+
+    async def test_resume_image2video_subpath_from_request(self, tmp_path):
+        img = tmp_path / "f.png"
+        img.write_bytes(b"\x89PNG\r\n")
+        post = AsyncMock()
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            await _jwt_backend().resume_video("task-r2", _request(tmp_path, start_image=img))
+        assert get.await_args.args[0].endswith("/videos/image2video/task-r2")

--- a/tests/test_pricing_strategies.py
+++ b/tests/test_pricing_strategies.py
@@ -10,6 +10,7 @@ from lib.pricing.types import (
     PerImageFlat,
     PerImageOpenAIToken,
     PerSecondMatrix,
+    PerSecondTiered,
     PerToken,
     PerTokenVideo,
     PerVideoBucket,
@@ -447,3 +448,91 @@ class TestViduDelegate:
         )
         assert currency == "CNY"
         assert amount == pytest.approx(5 * 12 * 0.03125)
+
+
+class TestPerSecondTiered:
+    # 可灵 Kling 视频「质量档 × 是否有声」¥/s 矩阵（官方一手，CNY）。
+    pricing = PerSecondTiered(
+        rates={
+            "kling-v2-5-turbo": {
+                ("std", False): 0.6,
+                ("std", True): 0.8,
+                ("pro", False): 0.8,
+                ("pro", True): 1.0,
+                ("4k", False): 3.0,
+                ("4k", True): 3.0,
+            }
+        },
+        default_model="kling-v2-5-turbo",
+        currency="CNY",
+    )
+
+    def _amount(self, *, service_tier="default", generate_audio=True, resolution=None, duration_seconds=5):
+        return calculate_pricing(
+            self.pricing,
+            PricingParams(
+                call_type="video",
+                model="kling-v2-5-turbo",
+                resolution=resolution,
+                duration_seconds=duration_seconds,
+                generate_audio=generate_audio,
+                service_tier=service_tier,
+            ),
+        )
+
+    def test_std_silent(self):
+        amount, currency = self._amount(service_tier="std", generate_audio=False, duration_seconds=5)
+        assert currency == "CNY"
+        assert amount == pytest.approx(0.6 * 5)
+
+    def test_std_with_audio(self):
+        amount, _ = self._amount(service_tier="std", generate_audio=True, duration_seconds=5)
+        assert amount == pytest.approx(0.8 * 5)
+
+    def test_pro_silent(self):
+        amount, _ = self._amount(service_tier="pro", generate_audio=False, duration_seconds=5)
+        assert amount == pytest.approx(0.8 * 5)
+
+    def test_pro_with_audio(self):
+        amount, _ = self._amount(service_tier="pro", generate_audio=True, duration_seconds=5)
+        assert amount == pytest.approx(1.0 * 5)
+
+    def test_default_tier_maps_to_std(self):
+        # service_tier="default" → std 档
+        amount, _ = self._amount(service_tier="default", generate_audio=False, duration_seconds=10)
+        assert amount == pytest.approx(0.6 * 10)
+
+    def test_4k_resolution_overrides_tier_and_ignores_audio(self):
+        # resolution=4k → "4k" 档，忽略 std/pro 与 audio，均为 ¥3/s
+        silent, _ = self._amount(service_tier="std", generate_audio=False, resolution="4K", duration_seconds=5)
+        voiced, _ = self._amount(service_tier="pro", generate_audio=True, resolution="4k", duration_seconds=5)
+        assert silent == pytest.approx(3.0 * 5)
+        assert voiced == pytest.approx(3.0 * 5)
+
+    def test_unknown_tier_falls_back_to_std_with_warning(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            amount, _ = self._amount(service_tier="ultra", generate_audio=False, duration_seconds=5)
+        assert amount == pytest.approx(0.6 * 5)
+        assert any("per_second_tiered" in r.message for r in caplog.records)
+
+    def test_unknown_model_falls_back_to_default(self):
+        amount, _ = calculate_pricing(
+            self.pricing,
+            PricingParams(
+                call_type="video",
+                model="unknown-model",
+                service_tier="pro",
+                generate_audio=True,
+                duration_seconds=5,
+            ),
+        )
+        assert amount == pytest.approx(1.0 * 5)
+
+    def test_none_duration_defaults_to_eight_seconds(self):
+        amount, _ = calculate_pricing(
+            self.pricing,
+            PricingParams(call_type="video", model="kling-v2-5-turbo", service_tier="std", generate_audio=False),
+        )
+        assert amount == pytest.approx(0.6 * 8)

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -50,16 +50,35 @@ def test_ark_agent_plan_model_id_format_differs_from_ark() -> None:
     assert not (ark_ids & agent_plan_ids), "ark vs ark-agent-plan 模型 ID 命名不同，不应重叠"
 
 
-def test_kling_registered_identity_only() -> None:
-    """可灵仅身份注册：两个 secret required/secret key、默认 base_url、无 models。"""
+def test_kling_credentials_and_base_url() -> None:
+    """可灵双 secret required/secret key + 默认 base_url（JWT 直连，见 ADR 0037）。"""
     p = PROVIDER_REGISTRY["kling"]
     assert p.required_keys == ["access_key", "secret_key"]
     assert p.secret_keys == ["access_key", "secret_key"]
     assert p.default_base_url == "https://api.klingai.com/v1"
-    assert p.models == {}
-    # 无 models → 不暴露任何 media_type / capability，不会被 auto-resolve 选中
-    assert p.media_types == []
-    assert p.capabilities == []
+
+
+def test_kling_default_video_model_v2_5_turbo() -> None:
+    """JWT 直连视频首发：默认视频模型 kling-v2-5-turbo，能力声明齐备，无 text/image 模型。"""
+    p = PROVIDER_REGISTRY["kling"]
+    assert "kling-v2-5-turbo" in p.models
+    turbo = p.models["kling-v2-5-turbo"]
+    assert turbo.media_type == "video"
+    assert turbo.default is True
+    assert turbo.supported_durations == [5, 10]
+    assert turbo.resolutions, "默认视频模型须声明 resolutions"
+    assert turbo.pricing is not None
+    # 本片只接视频默认模型，尚无图像/文本模型
+    assert p.media_types == ["video"]
+
+
+def test_kling_video_backend_registered() -> None:
+    """可灵视频后端在 video registry 自注册（JWT 直连）。"""
+    import lib.video_backends  # noqa: F401  触发自注册
+    from lib.video_backends.kling import KlingVideoBackend
+    from lib.video_backends.registry import _BACKEND_FACTORIES as video_reg
+
+    assert video_reg["kling"] is KlingVideoBackend
 
 
 def test_ark_agent_plan_backend_registered() -> None:


### PR DESCRIPTION
## 做了什么

打通可灵 Kling **JWT 直连视频**的完整管线：配好可灵凭证的用户现在能用默认视频模型端到端生成一条视频（提交→轮询→下载），长任务自动续签鉴权、费用按人民币正确计算。这是后续可灵能力（图像、其余视频模型）复用的共享首发。

- **JWT 鉴权共享层**（`lib/kling_shared.py`）：HS256 token 管理器，access_key 作 `iss`、secret_key 签名、约 30 分钟过期；每次调用前检查过期、距过期 <60s 按需重签（长任务跨单 token 寿命自动续签），时钟可注入便于单测。bearer 模式旁路 JWT 用静态 key。
- **`KlingVideoBackend`**（jwt / bearer 双模式，对齐 Gemini 先例）：异步 submit→存 job_id→轮询→取 url→下载，复用 base 的 submit/poll/download helpers，自包含状态机；服务重启可按 provider_job_id 接续轮询、不重复提交/扣费。
- **默认视频模型 `kling-v2-5-turbo`**（std/pro 档，5s/10s，文生 + 图生视频含首尾帧）。
- **新定价 `per_second_tiered`**：按「质量档 × 是否有声」定 ¥/s 再 × 时长，档位 = `resolution==4k ? 4k : service_tier`（`default→std`），未命中回落 std 档 + WARN，币种 CNY。
- 新后端日志用预脱敏标量 dict 直接喂 logger，避开 `format_kwargs_for_log` 的 CodeQL sink，不展开 base64/媒体 URL/prompt。

## 审查修复（独立审查阶段发现）

- **resume 接续查询端点错配（image2video 重启自愈失效）**：可灵查询端点按生成类型分路径，而 resume 请求已无 `start_image` 可推断子路径，原实现固定回落 `text2video` → image2video 任务在服务重启后会查错端点、取不到任务而失败（不重复扣费/提交的红线仍守住，仅自愈失效）。改为 submit 时把子路径编入持久化 `provider_job_id`（`subpath:task_id`），resume 解码复原查询端点与裸 task_id，无前缀回落 text2video。与 Gemini 持久化结构化 `operation.name` 先例一致。补 3 条 resume 单测覆盖编码/解码/回落。

## 验证

- `uv run pytest`：全量 **4952 passed**（含 i18n 三语一致性、provider registry、pricing、Kling 共享层与 backend 共 46 例）
- `uv run ruff check` / `ruff format --check`：净
- `uv run basedpyright`：0 error
- 无前端改动

## 范围

本片仅 JWT 层 + 视频 backend + v2-5-turbo + per_second_tiered。图像 backend、其余视频模型（v3/v3-omni/v2-6/o1）与 audio 门控为后续片，turbo 恒报无声。

Closes #833


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

- **新功能**
  * 新增可灵 Kling 视频生成服务支持（异步提交/轮询/下载）与断点续传
  * 引入 Kling 共享鉴权与异步任务响应解析能力（支持 JWT 与静态密钥）
  * 自动注册 Kling 视频后端，并按配置完成生成任务接入

- **计费与价格**
  * 增强秒计费：新增按“质量档 × 是否有声”的分档计费（PerSecondTiered），支持分辨率档位与默认时长回退

- **测试**
  * 补充 Kling 后端端到端流程、共享鉴权解析、以及分档计费策略用例验证
<!-- end of auto-generated comment: release notes by coderabbit.ai -->