### PR TITLE
fix(assistant): 剧本生成耗时提示不再随重进项目重复弹出

### DIFF
--- a/frontend/src/hooks/useScriptGenerationNotice.test.tsx
+++ b/frontend/src/hooks/useScriptGenerationNotice.test.tsx
@@ -143,6 +143,28 @@ describe("useScriptGenerationNotice", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
+  it("treats a failed-but-completed call (only is_error, no result) as completed", () => {
+    // 注释与 ContentBlock 契约把 result/is_error 都列为完成信号。即便回放一个仅带
+    // is_error 而无 result 的失败完成块，也不应被误判为进行中而弹「耗时」提示。
+    useAssistantStore.setState({ sessionStatus: "running" });
+    const spy = vi.spyOn(useAppStore.getState(), "pushToast");
+    render(<Harness />);
+
+    act(() => {
+      useAssistantStore.setState({
+        draftTurn: assistantTurn({
+          type: "tool_use",
+          name: SCRIPT_TOOL,
+          id: "tu-err",
+          input: {},
+          is_error: true,
+        }),
+      });
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   it("does not fire when the session is not running (idle/interrupted reload)", () => {
     useAssistantStore.setState({ sessionStatus: "interrupted" });
     const spy = vi.spyOn(useAppStore.getState(), "pushToast");

--- a/frontend/src/hooks/useScriptGenerationNotice.test.tsx
+++ b/frontend/src/hooks/useScriptGenerationNotice.test.tsx
@@ -14,6 +14,12 @@ function toolUse(name: string, id: string): ContentBlock {
   return { type: "tool_use", name, id, input: {} };
 }
 
+// 后端 turn_grouper 把 tool_result 合并进发起调用的 tool_use 块的 result/is_error
+// 字段（同一 turn 内配对），完成的调用没有独立 tool_result 块。这是 UI 真实收到的形状。
+function completedToolUse(name: string, id: string): ContentBlock {
+  return { type: "tool_use", name, id, input: {}, result: "✅ done", is_error: false };
+}
+
 function toolResult(toolUseId: string): ContentBlock {
   return { type: "tool_result", tool_use_id: toolUseId, content: "✅ done" };
 }
@@ -108,6 +114,28 @@ describe("useScriptGenerationNotice", () => {
         turns: [
           assistantTurn(toolUse(SCRIPT_TOOL, "tu-done")),
           { type: "user", content: [toolResult("tu-done")] },
+        ],
+      });
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when a running session reloads a completed script call (result merged onto tool_use)", () => {
+    // 会话停在 AskUserQuestion 时后端 status 仍为 "running"。重新进入项目会重载快照，
+    // 其中已完成的剧本工具调用以「tool_use 带 result」形式回放（无独立 tool_result 块）。
+    // 该回放不应再弹「耗时」提示。
+    useAssistantStore.setState({ sessionStatus: "running" });
+    const spy = vi.spyOn(useAppStore.getState(), "pushToast");
+    render(<Harness />);
+
+    act(() => {
+      useAssistantStore.setState({
+        turns: [
+          assistantTurn(
+            completedToolUse(SCRIPT_TOOL, "tu-done"),
+            toolUse("AskUserQuestion", "tu-q"),
+          ),
         ],
       });
     });

--- a/frontend/src/hooks/useScriptGenerationNotice.ts
+++ b/frontend/src/hooks/useScriptGenerationNotice.ts
@@ -67,6 +67,7 @@ export function useScriptGenerationNotice(): void {
         block.name &&
         SCRIPT_GENERATION_TOOL_NAMES.has(block.name) &&
         block.result === undefined &&
+        block.is_error === undefined &&
         !completedToolUseIds.has(block.id) &&
         !notifiedRef.current.has(block.id)
       ) {

--- a/frontend/src/hooks/useScriptGenerationNotice.ts
+++ b/frontend/src/hooks/useScriptGenerationNotice.ts
@@ -49,6 +49,10 @@ export function useScriptGenerationNotice(): void {
 
     const blocks = collectBlocks(turns, draftTurn);
 
+    // 完成判定的主信号是 tool_use 块自身带 result/is_error：后端 turn_grouper 把同一 turn 内
+    // 配对的 tool_result 合并进发起调用的 tool_use 块（与 ToolCallWithResult 的渲染口径一致），
+    // 已完成调用不会再有独立 tool_result 块。仅扫描 tool_result 块会把回放的历史完成调用误判为
+    // 进行中，导致重载停在 AskUserQuestion（status 仍为 running）的会话时重复弹「耗时」提示。
     const completedToolUseIds = new Set<string>();
     for (const block of blocks) {
       if (block.type === "tool_result" && block.tool_use_id) {
@@ -62,6 +66,7 @@ export function useScriptGenerationNotice(): void {
         block.id &&
         block.name &&
         SCRIPT_GENERATION_TOOL_NAMES.has(block.name) &&
+        block.result === undefined &&
         !completedToolUseIds.has(block.id) &&
         !notifiedRef.current.has(block.id)
       ) {


### PR DESCRIPTION
## 问题

会话停在 AskUserQuestion 等待用户作答时，「正在生成剧本，这一步耗时较长，请耐心等待…」提示会弹出；每次重新进入项目都会再弹一次，即便此刻并没有任何剧本生成在进行。

## 根因

完成判定口径与后端实际数据契约不一致：

- 后端 `turn_grouper` 把同一 turn 内配对的 `tool_result` 合并进发起调用的 `tool_use` 块的 `result`/`is_error` 字段，已完成调用不再产生独立的 `tool_result` 块（前端 `ToolCallWithResult` 也以 `block.result` 作为完成信号）。
- 而 `useScriptGenerationNotice` 仅扫描独立 `tool_result` 块判定完成，于是一个早已完成的剧本工具调用永远找不到结果记录、被误判为进行中。
- 会话停在 AskUserQuestion 时后端 status 仍为 `running`，绕过了原本用于挡掉历史重载的运行态门槛；每次重进项目重载快照又把承载去重记忆的监听组件重新挂载、记忆清零，于是每次都重弹。

## 修复

让通知逻辑也认 `tool_use` 块自身的 `result` 作为完成信号（与前端其余组件同口径）：带 `result` 即视为已完成、不再弹。根因修掉后，状态算 running、去重记忆被清零都不再影响结果——完成的调用从源头被正确识别并跳过。

## 测试

- 新增反映后端真实数据形状的用例（result 合并在 tool_use 上 + 停在 AskUserQuestion + status=running）：修复前精确复现弹窗、修复后通过。
- 真正进行中的调用（tool_use 无 result）仍照常弹一次。
- 全量 `pnpm check`（typecheck + lint + 735 测试）全绿。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复脚本生成期间在会话仍为进行中时，因回放/历史工具结果判断不准确而错误弹出耗时提示的问题。
  * 扩展判断逻辑与测试覆盖：当工具调用已完成（包含成功结果或失败但已完成）时，不再触发耗时提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->