### PR TITLE
fix(narration): 补齐宫格模式旁白配音入口与项目级配音设置

### DIFF
--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -703,6 +703,8 @@ export function StudioCanvasRouter() {
                     onUpdatePrompt={handleUpdatePrompt}
                     onGenerateStoryboard={voidPromise(handleGenerateStoryboard)}
                     onGenerateVideo={voidPromise(handleGenerateVideo)}
+                    onGenerateNarration={voidPromise(handleGenerateNarration)}
+                    onGenerateEpisodeNarration={voidPromise(handleGenerateEpisodeNarration)}
                     onGenerateGrid={handleGenerateGrid}
                     onRestoreStoryboard={handleRestoreAsset}
                     onRestoreVideo={handleRestoreAsset}

--- a/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
+++ b/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
@@ -8,6 +8,7 @@ import { GridPreviewView } from "./GridPreviewView";
 import { useAppStore } from "@/stores/app-store";
 import { useCostStore } from "@/stores/cost-store";
 import { useTasksStore } from "@/stores/tasks-store";
+import { getScriptItemId } from "@/utils/script-shape";
 import type {
   EpisodeScript,
   NarrationEpisodeScript,
@@ -37,6 +38,8 @@ interface GridImageToVideoCanvasProps {
   ) => void | Promise<void>;
   onGenerateStoryboard?: (segmentId: string, scriptFile?: string) => void;
   onGenerateVideo?: (segmentId: string, scriptFile?: string) => void;
+  onGenerateNarration?: (segmentId: string, scriptFile?: string) => void;
+  onGenerateEpisodeNarration?: (scriptFile?: string) => void;
   onGenerateGrid?: (
     episode: number,
     scriptFile: string,
@@ -60,6 +63,8 @@ export function GridImageToVideoCanvas({
   onUpdatePrompt,
   onGenerateStoryboard,
   onGenerateVideo,
+  onGenerateNarration,
+  onGenerateEpisodeNarration,
   onGenerateGrid,
   onRestoreStoryboard,
   onRestoreVideo,
@@ -116,7 +121,7 @@ export function GridImageToVideoCanvas({
 
   const tasks = useTasksStore((s) => s.tasks);
   const isGenerating = useCallback(
-    (taskType: "storyboard" | "video", segmentId: string): boolean =>
+    (taskType: "storyboard" | "video" | "tts", segmentId: string): boolean =>
       tasks.some(
         (tk) =>
           tk.task_type === taskType &&
@@ -133,6 +138,26 @@ export function GridImageToVideoCanvas({
   const generatingVideo = useCallback(
     (segId: string) => isGenerating("video", segId),
     [isGenerating],
+  );
+  const generatingNarration = useCallback(
+    (segId: string) => isGenerating("tts", segId),
+    [isGenerating],
+  );
+  // 批量旁白进行中：当前分集还有未完结的 tts 任务时禁用批量按钮，避免重复入队
+  const currentSegmentIds = useMemo(
+    () => new Set(segments.map((s) => getScriptItemId(s, editorContentMode ?? "drama"))),
+    [segments, editorContentMode],
+  );
+  const narrationBatchBusy = useMemo(
+    () =>
+      tasks.some(
+        (tk) =>
+          tk.task_type === "tts" &&
+          tk.project_name === projectName &&
+          currentSegmentIds.has(tk.resource_id) &&
+          (tk.status === "queued" || tk.status === "running"),
+      ),
+    [tasks, projectName, currentSegmentIds],
   );
 
   const invalidateGrids = useAppStore((s) => s.invalidateGrids);
@@ -187,6 +212,9 @@ export function GridImageToVideoCanvas({
   ) => onUpdatePrompt?.(segId, fieldOrPatch, value, scriptFile);
   const handleGenSb = (segId: string) => onGenerateStoryboard?.(segId, scriptFile);
   const handleGenVid = (segId: string) => onGenerateVideo?.(segId, scriptFile);
+  const handleGenNarration = onGenerateNarration
+    ? (segId: string) => onGenerateNarration(segId, scriptFile)
+    : undefined;
 
   const renderTabButton = (key: GridTab, label: string, disabled = false) => (
     <button
@@ -271,6 +299,18 @@ export function GridImageToVideoCanvas({
               <Sparkles className="h-3 w-3" />
               <span>{t("batch_generate_videos")}</span>
             </button>
+            {contentMode === "narration" && onGenerateEpisodeNarration && (
+              <button
+                type="button"
+                className="sv-navbtn inline-flex items-center gap-1.5"
+                disabled={narrationBatchBusy}
+                onClick={() => onGenerateEpisodeNarration(scriptFile)}
+                title={t("batch_generate_narration")}
+              >
+                <Sparkles className="h-3 w-3" />
+                <span>{t("batch_generate_narration")}</span>
+              </button>
+            )}
           </div>
         )}
       </div>
@@ -305,10 +345,12 @@ export function GridImageToVideoCanvas({
             onUpdatePrompt={handleUpdatePrompt}
             onGenerateStoryboard={handleGenSb}
             onGenerateVideo={handleGenVid}
+            onGenerateNarration={handleGenNarration}
             onRestoreStoryboard={onRestoreStoryboard}
             onRestoreVideo={onRestoreVideo}
             generatingStoryboard={generatingStoryboard}
             generatingVideo={generatingVideo}
+            generatingNarration={generatingNarration}
             durationOptions={durationOptions}
           />
         ) : null}

--- a/frontend/src/components/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.tsx
@@ -8,6 +8,7 @@ import { useAppStore } from "@/stores/app-store";
 import { PROVIDER_NAMES } from "@/components/ui/ProviderIcon";
 import { getProviderModels, getCustomProviderModels } from "@/utils/provider-models";
 import { ModelConfigSection } from "@/components/shared/ModelConfigSection";
+import { ProviderModelSelect } from "@/components/ui/ProviderModelSelect";
 import { StylePicker, type StylePickerValue } from "@/components/shared/StylePicker";
 import { DEFAULT_TEMPLATE_ID, STYLE_TEMPLATES } from "@/data/style-templates";
 import type { CustomProviderInfo, ProviderInfo } from "@/types";
@@ -95,6 +96,7 @@ export function ProjectSettingsPage() {
     video_backends: string[];
     image_backends: string[];
     text_backends: string[];
+    audio_backends: string[];
     provider_names?: Record<string, string>;
   } | null>(null);
   const [globalDefaults, setGlobalDefaults] = useState<{
@@ -104,7 +106,8 @@ export function ProjectSettingsPage() {
     textScript: string;
     textOverview: string;
     textStyle: string;
-  }>({ video: "", imageT2I: "", imageI2I: "", textScript: "", textOverview: "", textStyle: "" });
+    audio: string;
+  }>({ video: "", imageT2I: "", imageI2I: "", textScript: "", textOverview: "", textStyle: "", audio: "" });
 
   const allProviderNames = useMemo(
     () => ({ ...PROVIDER_NAMES, ...(options?.provider_names ?? {}) }),
@@ -117,6 +120,10 @@ export function ProjectSettingsPage() {
   const [imageBackendT2I, setImageBackendT2I] = useState<string>("");
   const [imageBackendI2I, setImageBackendI2I] = useState<string>("");
   const [audioOverride, setAudioOverride] = useState<boolean | null>(null);
+  // 旁白配音（TTS）项目级覆盖：空字符串/ null 表示跟随全局默认
+  const [audioBackend, setAudioBackend] = useState<string>("");
+  const [narrationVoice, setNarrationVoice] = useState<string>("");
+  const [narrationSpeed, setNarrationSpeed] = useState<number | null>(null);
   const [textScript, setTextScript] = useState<string>("");
   const [textOverview, setTextOverview] = useState<string>("");
   const [textStyle, setTextStyle] = useState<string>("");
@@ -137,6 +144,7 @@ export function ProjectSettingsPage() {
   const [savingStyle, setSavingStyle] = useState(false);
   const initialRef = useRef({
     videoBackend: "", imageBackendT2I: "", imageBackendI2I: "", audioOverride: null as boolean | null,
+    audioBackend: "", narrationVoice: "", narrationSpeed: null as number | null,
     textScript: "", textOverview: "", textStyle: "",
     aspectRatio: "", generationMode: "storyboard",
     defaultDuration: null as number | null,
@@ -161,6 +169,7 @@ export function ProjectSettingsPage() {
         video_backends: configRes.options?.video_backends ?? [],
         image_backends: configRes.options?.image_backends ?? [],
         text_backends: configRes.options?.text_backends ?? [],
+        audio_backends: configRes.options?.audio_backends ?? [],
         provider_names: configRes.options?.provider_names,
       });
       setGlobalDefaults({
@@ -176,6 +185,7 @@ export function ProjectSettingsPage() {
         textScript: configRes.settings?.text_backend_script ?? "",
         textOverview: configRes.settings?.text_backend_overview ?? "",
         textStyle: configRes.settings?.text_backend_style ?? "",
+        audio: configRes.settings?.default_audio_backend ?? "",
       });
       setProviders(providerList);
       setCustomProviders(customProviderList);
@@ -187,6 +197,10 @@ export function ProjectSettingsPage() {
       const ibi2i = (project.image_provider_i2i as string | undefined) ?? "";
       const rawAudio = project.video_generate_audio;
       const ao = typeof rawAudio === "boolean" ? rawAudio : null;
+      const ab = (project.audio_backend as string | undefined) ?? "";
+      const nv = (project.narration_voice as string | undefined) ?? "";
+      const rawSpeed = project.narration_speed;
+      const ns = typeof rawSpeed === "number" && Number.isFinite(rawSpeed) ? rawSpeed : null;
       const ts = (project.text_backend_script as string | undefined) ?? "";
       const to = (project.text_backend_overview as string | undefined) ?? "";
       const tst = (project.text_backend_style as string | undefined) ?? "";
@@ -202,6 +216,9 @@ export function ProjectSettingsPage() {
       setImageBackendT2I(ibt2i);
       setImageBackendI2I(ibi2i);
       setAudioOverride(ao);
+      setAudioBackend(ab);
+      setNarrationVoice(nv);
+      setNarrationSpeed(ns);
       setTextScript(ts);
       setTextOverview(to);
       setTextStyle(tst);
@@ -237,6 +254,7 @@ export function ProjectSettingsPage() {
       initialStyleRef.current = derivedStyle;
       initialRef.current = {
         videoBackend: vb, imageBackendT2I: ibt2i, imageBackendI2I: ibi2i, audioOverride: ao,
+        audioBackend: ab, narrationVoice: nv, narrationSpeed: ns,
         textScript: ts, textOverview: to, textStyle: tst,
         aspectRatio: ar, generationMode: gm, defaultDuration: dd,
         videoResolution: vRes, imageResolution: iRes,
@@ -282,6 +300,9 @@ export function ProjectSettingsPage() {
     imageBackendT2I !== initialRef.current.imageBackendT2I ||
     imageBackendI2I !== initialRef.current.imageBackendI2I ||
     audioOverride !== initialRef.current.audioOverride ||
+    audioBackend !== initialRef.current.audioBackend ||
+    narrationVoice !== initialRef.current.narrationVoice ||
+    narrationSpeed !== initialRef.current.narrationSpeed ||
     textScript !== initialRef.current.textScript ||
     textOverview !== initialRef.current.textOverview ||
     textStyle !== initialRef.current.textStyle ||
@@ -366,6 +387,8 @@ export function ProjectSettingsPage() {
     try {
       // resolution 的 key 用 effective backend（override ‖ global default），
       // 否则"跟随全局默认"路径下用户选的分辨率不会被写入。
+      // 音色与后端 .strip() 对齐：保存时去首尾空白，避免本地基线带空格而磁盘值不带导致 isDirty 误报
+      const trimmedVoice = narrationVoice.trim();
       const effectiveVideo = videoBackend || globalDefaults.video || "";
       const effectiveImageT2I = imageBackendT2I || globalDefaults.imageT2I || "";
       const newModelSettings: Record<string, { resolution: string | null }> = { ...modelSettings };
@@ -381,6 +404,9 @@ export function ProjectSettingsPage() {
         image_provider_t2i: imageBackendT2I || null,
         image_provider_i2i: imageBackendI2I || null,
         video_generate_audio: audioOverride,
+        audio_backend: audioBackend || null,
+        narration_voice: trimmedVoice || null,
+        narration_speed: narrationSpeed,
         text_backend_script: textScript || null,
         text_backend_overview: textOverview || null,
         text_backend_style: textStyle || null,
@@ -391,8 +417,10 @@ export function ProjectSettingsPage() {
         model_settings: newModelSettings,
       });
       setModelSettings(newModelSettings);
+      setNarrationVoice(trimmedVoice);
       initialRef.current = {
         videoBackend, imageBackendT2I, imageBackendI2I, audioOverride,
+        audioBackend, narrationVoice: trimmedVoice, narrationSpeed,
         textScript, textOverview, textStyle,
         aspectRatio, generationMode, defaultDuration,
         videoResolution, imageResolution,
@@ -403,7 +431,7 @@ export function ProjectSettingsPage() {
     } finally {
       setSaving(false);
     }
-  }, [modelSettings, videoBackend, imageBackendT2I, imageBackendI2I, audioOverride, textScript, textOverview, textStyle, aspectRatio, generationMode, defaultDuration, contentMode, videoResolution, imageResolution, projectName, t, globalDefaults.video, globalDefaults.imageT2I]);
+  }, [modelSettings, videoBackend, imageBackendT2I, imageBackendI2I, audioOverride, audioBackend, narrationVoice, narrationSpeed, textScript, textOverview, textStyle, aspectRatio, generationMode, defaultDuration, contentMode, videoResolution, imageResolution, projectName, t, globalDefaults.video, globalDefaults.imageT2I]);
 
   return (
     <div
@@ -557,6 +585,8 @@ export function ProjectSettingsPage() {
                     textOverview: globalDefaults.textOverview ?? "",
                     textStyle: globalDefaults.textStyle ?? "",
                   }}
+                  videoGenerateAudio={audioOverride}
+                  onVideoGenerateAudioChange={setAudioOverride}
                   enable={contentMode === "ad" ? { duration: false } : undefined}
                 />
               </SectionCard>
@@ -619,48 +649,73 @@ export function ProjectSettingsPage() {
                 </fieldset>
               </SectionCard>
 
-              {/* Audio override */}
-              <SectionCard kicker="Audio Channel">
-                <div className="mb-2.5 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-text-3">
-                  {t("generate_audio_label")}
+              {/* 旁白配音（TTS）：仅 narration 模式消费——TTS 绑定 segment.novel_text，drama/ad 无该字段，
+                  故与两个画布的批量旁白按钮（contentMode === "narration"）同口径门控，避免对无效模式展示配音卡 */}
+              {contentMode === "narration" && (
+              <SectionCard kicker="Audio Channel" title={t("media_narration_title")}>
+                <div className="space-y-4">
+                  <div>
+                    <div className="mb-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-text-4">
+                      {t("default_audio_model")}
+                    </div>
+                    <ProviderModelSelect
+                      value={audioBackend}
+                      options={options.audio_backends}
+                      providerNames={allProviderNames}
+                      onChange={setAudioBackend}
+                      allowDefault
+                      defaultLabel={t("follow_global_default")}
+                      fallbackValue={globalDefaults.audio || undefined}
+                      aria-label={t("default_audio_model")}
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="project-narration-voice"
+                      className="mb-1.5 block font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-text-4"
+                    >
+                      {t("narration_voice_label")}
+                    </label>
+                    <input
+                      id="project-narration-voice"
+                      type="text"
+                      value={narrationVoice}
+                      onChange={(e) => setNarrationVoice(e.target.value)}
+                      className="w-full rounded-[8px] border border-hairline bg-bg-grad-a/55 px-3 py-2 text-[12.5px] text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                    />
+                    <p className="mt-1 text-[11px] text-text-4">{t("narration_voice_hint")}</p>
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="project-narration-speed"
+                      className="mb-1.5 block font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-text-4"
+                    >
+                      {t("narration_speed_label")}
+                    </label>
+                    <input
+                      id="project-narration-speed"
+                      type="number"
+                      min={0.1}
+                      step={0.1}
+                      value={narrationSpeed ?? ""}
+                      onChange={(e) => {
+                        const raw = e.target.value;
+                        if (raw === "") {
+                          setNarrationSpeed(null);
+                          return;
+                        }
+                        const next = Number(raw);
+                        // 仅过滤非有限数：NaN/Infinity 会被序列化为 null 误触"清除"语义；
+                        // 正数约束交由保存时后端校验兜底
+                        if (Number.isFinite(next)) setNarrationSpeed(next);
+                      }}
+                      className="w-full rounded-[8px] border border-hairline bg-bg-grad-a/55 px-3 py-2 text-[12.5px] text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                    />
+                    <p className="mt-1 text-[11px] text-text-4">{t("narration_speed_hint")}</p>
+                  </div>
                 </div>
-                <fieldset className="flex flex-wrap gap-x-5 gap-y-2">
-                  <legend className="sr-only">{t("audio_settings_sr_label")}</legend>
-                  <label className="inline-flex items-center gap-2 text-[12.5px] text-text-2">
-                    <input
-                      type="radio"
-                      name="audio"
-                      value=""
-                      checked={audioOverride === null}
-                      onChange={() => setAudioOverride(null)}
-                      className="accent-[oklch(0.76_0.09_295)]"
-                    />
-                    {t("follow_global_default")}
-                  </label>
-                  <label className="inline-flex items-center gap-2 text-[12.5px] text-text-2">
-                    <input
-                      type="radio"
-                      name="audio"
-                      value="true"
-                      checked={audioOverride === true}
-                      onChange={() => setAudioOverride(true)}
-                      className="accent-[oklch(0.76_0.09_295)]"
-                    />
-                    {t("enabled_label")}
-                  </label>
-                  <label className="inline-flex items-center gap-2 text-[12.5px] text-text-2">
-                    <input
-                      type="radio"
-                      name="audio"
-                      value="false"
-                      checked={audioOverride === false}
-                      onChange={() => setAudioOverride(false)}
-                      className="accent-[oklch(0.76_0.09_295)]"
-                    />
-                    {t("disabled_label")}
-                  </label>
-                </fieldset>
               </SectionCard>
+              )}
             </>
           )}
 

--- a/frontend/src/components/pages/ProviderDetail.tsx
+++ b/frontend/src/components/pages/ProviderDetail.tsx
@@ -213,6 +213,15 @@ function FieldEditor({ field, draft, setDraft }: FieldEditorProps) {
 // Capability pill
 // ---------------------------------------------------------------------------
 
+// 能力徽标展示顺序：图片→视频→文本→音频，未列出的类型排到末尾。
+// media_types 由后端按注册顺序返回，前端统一排序避免 audio 等新类型插到队首。
+const CAPABILITY_PILL_ORDER = ["image", "video", "text", "audio"];
+
+function capabilityPillRank(kind: string): number {
+  const idx = CAPABILITY_PILL_ORDER.indexOf(kind);
+  return idx === -1 ? CAPABILITY_PILL_ORDER.length : idx;
+}
+
 function CapabilityPill({ kind }: { kind: string }) {
   const { t } = useTranslation("dashboard");
   const label =
@@ -222,7 +231,9 @@ function CapabilityPill({ kind }: { kind: string }) {
         ? t("media_type_image")
         : kind === "text"
           ? t("media_type_text")
-          : kind;
+          : kind === "audio"
+            ? t("media_type_audio")
+            : kind;
   return (
     <span className="rounded-full border border-hairline-soft bg-bg-grad-a/55 px-2.5 py-0.5 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-text-3">
       {label}
@@ -369,9 +380,11 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
       {/* Capabilities */}
       {detail.media_types && detail.media_types.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
-          {detail.media_types.map((mt) => (
-            <CapabilityPill key={mt} kind={mt} />
-          ))}
+          {[...detail.media_types]
+            .sort((a, b) => capabilityPillRank(a) - capabilityPillRank(b))
+            .map((mt) => (
+              <CapabilityPill key={mt} kind={mt} />
+            ))}
         </div>
       )}
 

--- a/frontend/src/components/shared/ModelConfigSection.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, type CSSProperties } from "react";
+import { useEffect, useId, useMemo, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import { ProviderModelSelect } from "@/components/ui/ProviderModelSelect";
 import { lookupSupportedDurations, lookupResolutions } from "@/utils/provider-models";
@@ -43,6 +43,13 @@ export interface ModelConfigSectionProps {
     textOverview: string;
     textStyle: string;
   };
+  /**
+   * 项目级「视频生成音频」覆盖（null=跟随全局，true/false=显式覆盖）。
+   * 仅在传入 onVideoGenerateAudioChange 时于视频通道内渲染该开关——此项是视频模型的能力开关，
+   * 与旁白配音（TTS）无关，故归在视频通道而非单列。创建项目向导不传则不渲染。
+   */
+  videoGenerateAudio?: boolean | null;
+  onVideoGenerateAudioChange?: (next: boolean | null) => void;
   enable?: {
     video?: boolean;
     image?: boolean;
@@ -78,9 +85,13 @@ export function ModelConfigSection({
   providers,
   customProviders = EMPTY_CUSTOM_PROVIDERS,
   globalDefaults,
+  videoGenerateAudio,
+  onVideoGenerateAudioChange,
   enable,
 }: ModelConfigSectionProps) {
-  const { t } = useTranslation("templates");
+  const { t } = useTranslation(["templates", "dashboard"]);
+  // 派生唯一 radio name，避免同页多个 ModelConfigSection 实例的音频开关被浏览器并入同一互斥组
+  const generateAudioName = useId();
 
   const endpointToMediaType = useEndpointCatalogStore((s) => s.endpointToMediaType);
   const fetchEndpointCatalog = useEndpointCatalogStore((s) => s.fetch);
@@ -195,6 +206,38 @@ export function ModelConfigSection({
                 />
               )}
             </>
+          )}
+
+          {onVideoGenerateAudioChange && (
+            <div className="mt-3">
+              <div className="mb-2 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-text-4">
+                {t("dashboard:generate_audio_label")}
+              </div>
+              <fieldset className="flex flex-wrap gap-x-5 gap-y-2">
+                <legend className="sr-only">{t("dashboard:audio_settings_sr_label")}</legend>
+                {(
+                  [
+                    [null, t("dashboard:follow_global_default")],
+                    [true, t("dashboard:enabled_label")],
+                    [false, t("dashboard:disabled_label")],
+                  ] as const
+                ).map(([val, label]) => (
+                  <label
+                    key={String(val)}
+                    className="inline-flex items-center gap-2 text-[12.5px] text-text-2"
+                  >
+                    <input
+                      type="radio"
+                      name={generateAudioName}
+                      checked={(videoGenerateAudio ?? null) === val}
+                      onChange={() => onVideoGenerateAudioChange(val)}
+                      className="accent-[oklch(0.76_0.09_295)]"
+                    />
+                    {label}
+                  </label>
+                ))}
+              </fieldset>
+            </div>
           )}
         </ChannelCard>
       )}

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -145,6 +145,10 @@ export interface ProjectData {
   /** Canonical values: storyboard | grid | reference_video. "single" is legacy-only. */
   generation_mode?: "storyboard" | "grid" | "reference_video" | "single";
   video_generate_audio?: boolean | null;
+  /** 旁白配音（TTS）项目级覆盖：音频后端 / 音色 / 语速，留空即跟随全局默认 */
+  audio_backend?: string | null;
+  narration_voice?: string | null;
+  narration_speed?: number | null;
   text_backend_script?: string | null;
   text_backend_overview?: string | null;
   text_backend_style?: string | null;

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 import shutil
 import tempfile
@@ -129,6 +130,10 @@ class UpdateProjectRequest(BaseModel):
     image_provider_t2i: str | None = None
     image_provider_i2i: str | None = None
     video_generate_audio: bool | None = None
+    # 旁白配音（TTS）项目级覆盖：音频后端 / 音色 / 语速；留空 = 跟随全局默认
+    audio_backend: str | None = None
+    narration_voice: str | None = None
+    narration_speed: float | None = None
     text_backend_script: str | None = None
     text_backend_overview: str | None = None
     text_backend_style: str | None = None
@@ -665,6 +670,7 @@ async def update_project(name: str, req: UpdateProjectRequest, _user: CurrentUse
                     "video_backend",
                     "image_provider_t2i",
                     "image_provider_i2i",
+                    "audio_backend",
                     "text_backend_script",
                     "text_backend_overview",
                     "text_backend_style",
@@ -682,6 +688,22 @@ async def update_project(name: str, req: UpdateProjectRequest, _user: CurrentUse
                         project.pop("video_generate_audio", None)
                     else:
                         project["video_generate_audio"] = req.video_generate_audio
+                # 旁白音色：照供应商文档填的字符串 id；空串 = 清除回落全局默认
+                if "narration_voice" in req.model_fields_set:
+                    voice = (req.narration_voice or "").strip()
+                    if voice:
+                        project["narration_voice"] = voice
+                    else:
+                        project.pop("narration_voice", None)
+                # 旁白语速：仅做正有限数卫生校验（拒绝 0/负数/inf/nan），取值范围由各供应商约束；null = 清除
+                if "narration_speed" in req.model_fields_set:
+                    if req.narration_speed is None:
+                        project.pop("narration_speed", None)
+                    else:
+                        speed = float(req.narration_speed)
+                        if not math.isfinite(speed) or speed <= 0:
+                            raise HTTPException(status_code=422, detail=_t("narration_speed_must_be_positive"))
+                        project["narration_speed"] = speed
                 if "aspect_ratio" in req.model_fields_set and req.aspect_ratio is not None:
                     project["aspect_ratio"] = req.aspect_ratio
                 if "generation_mode" in req.model_fields_set:

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1070,6 +1070,15 @@ class TestProjectsRouter:
             assert "narration_voice" not in data
             assert "narration_speed" not in data
 
+            # 纯空白音色值同样按清除处理（后端 .strip() 判空），防重构回退“空白即清除”语义
+            fake_pm.project_data["ready"]["narration_voice"] = "Cherry"
+            resp = client.patch(
+                "/api/v1/projects/ready",
+                json={"narration_voice": "   "},
+            )
+            assert resp.status_code == 200
+            assert "narration_voice" not in fake_pm.project_data["ready"]
+
     def test_update_project_rejects_non_positive_narration_speed(self, tmp_path, monkeypatch):
         """语速 0/负数应 422，且不写回 project.json。"""
         fake_pm = _FakePM(tmp_path)

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1032,6 +1032,61 @@ class TestProjectsRouter:
             assert "style_image" not in data
             assert "style_description" not in data
 
+    def test_update_project_persists_narration_overrides(self, tmp_path, monkeypatch):
+        """PATCH 旁白配音项目级覆盖：audio_backend / narration_voice / narration_speed 写入 project.json。"""
+        fake_pm = _FakePM(tmp_path)
+        client = _client(monkeypatch, fake_pm, _FakeCalc())
+        with client:
+            resp = client.patch(
+                "/api/v1/projects/ready",
+                json={
+                    "audio_backend": "dashscope/qwen3-tts-flash",
+                    "narration_voice": "Cherry",
+                    "narration_speed": 1.2,
+                },
+            )
+            assert resp.status_code == 200
+            data = fake_pm.project_data["ready"]
+            assert data["audio_backend"] == "dashscope/qwen3-tts-flash"
+            assert data["narration_voice"] == "Cherry"
+            assert data["narration_speed"] == 1.2
+
+    def test_update_project_clears_narration_overrides(self, tmp_path, monkeypatch):
+        """PATCH 空值/null：旁白配音覆盖回落全局默认（从 project.json 移除）。"""
+        fake_pm = _FakePM(tmp_path)
+        fake_pm.project_data["ready"]["audio_backend"] = "dashscope/qwen3-tts-flash"
+        fake_pm.project_data["ready"]["narration_voice"] = "Cherry"
+        fake_pm.project_data["ready"]["narration_speed"] = 1.2
+
+        client = _client(monkeypatch, fake_pm, _FakeCalc())
+        with client:
+            resp = client.patch(
+                "/api/v1/projects/ready",
+                json={"audio_backend": None, "narration_voice": "", "narration_speed": None},
+            )
+            assert resp.status_code == 200
+            data = fake_pm.project_data["ready"]
+            assert "audio_backend" not in data
+            assert "narration_voice" not in data
+            assert "narration_speed" not in data
+
+    def test_update_project_rejects_non_positive_narration_speed(self, tmp_path, monkeypatch):
+        """语速 0/负数应 422，且不写回 project.json。"""
+        fake_pm = _FakePM(tmp_path)
+        client = _client(monkeypatch, fake_pm, _FakeCalc())
+        with client:
+            resp = client.patch("/api/v1/projects/ready", json={"narration_speed": 0})
+            assert resp.status_code == 422
+            assert "narration_speed" not in fake_pm.project_data["ready"]
+
+    def test_update_project_rejects_invalid_audio_backend(self, tmp_path, monkeypatch):
+        """audio_backend 非法 provider 应 400（复用 backend 格式校验）。"""
+        fake_pm = _FakePM(tmp_path)
+        client = _client(monkeypatch, fake_pm, _FakeCalc())
+        with client:
+            resp = client.patch("/api/v1/projects/ready", json={"audio_backend": "garbage"})
+            assert resp.status_code == 400
+
     def test_list_projects_shares_script_preload_with_status(self, tmp_path, monkeypatch):
         """list_projects 一次性加载 episode scripts，传给 StatusCalculator，去除 cover + status 双重 I/O。"""
         fake_pm = _FakePM(tmp_path)


### PR DESCRIPTION
## 背景

PRD #704（TTS 旁白配音）QA 验收，修复 4 处问题并随附 code-review 改进。

## 改动

**QA 修复**
- **宫格模式旁白配音**：宫格生视频画布此前缺旁白配音接线，配音区域不可点击且无批量生成按钮（图生视频画布已有）；本次补齐逐段入口、生成中态与批量配音按钮。
- **项目级配音设置**：项目设置新增配音模型 / 音色 / 语速覆盖，留空即跟随全局默认（复用视频/图像/文本同款「跟随全局或项目覆盖」模式）。
- **音频开关归位**：「视频生成音频」开关移入视频通道——它是视频模型的原生音轨能力，原先单列容易与旁白配音混淆。
- **能力徽标**：供应商详情页能力徽标按 图片→视频→文本→音频 固定排序，音频徽标补齐中文 i18n。

**code-review 修复**
- 配音设置卡按 `contentMode === "narration"` 门控，与两个画布的批量旁白按钮同口径（TTS 仅消费 narration 段的 `novel_text`，drama/ad 无此字段）。
- 视频音频开关 radio 改用 `useId` 派生 name，避免同页多实例被并入同一互斥组。
- 音色保存时 `.trim()` 与后端 `.strip()` 对齐，消除尾随空白导致的脏状态误报。

## 测试

- 后端 `pytest tests/test_projects_router.py`：50 passed（含 4 个新增：配音覆盖持久化/清除、非正语速 422、非法后端 400）
- 前端 `eslint` + `tsc` + `vitest`：734 passed / 93 files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新功能
* 网格视图支持旁白（TTS）生成：提供单段与按集批量生成入口。
* 项目设置新增“旁白配音（TTS）”音频配置：可设置音频后端、旁白语音与语速（支持跟随全局/清空覆盖）。
* 项目级视频生成音频覆盖新增开关（跟随全局 / 启用 / 禁用）。

## 改进
* 提供商能力徽标排序与音频标签映射逻辑优化。

## 测试
* 补充项目旁白配音字段的接口校验与覆盖清理用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->