### PR TITLE
feat(kling): 新增可灵图像生成，支持 image-o1（默认）与 v3-omni 多分辨率

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -35,6 +35,10 @@ class ModelInfo:
     pricing: Pricing | None = None
     # 从 UI 下拉剔除但保留条目（供"入队后、finish 前被下线"的边角仍能算价）。
     hidden: bool = False
+    # 发给供应商 API 的模型名；None 时回退到 registry 键名。两栖模型（同一 API 模型名同时有
+    # 图像 / 视频两个 registry 条目）用此字段让两条目共用一个 API 模型名，而 registry 键名各自
+    # 唯一——键名兼作 UI 标识与计费查表键，不能重复，故 API 模型名需与键名解耦。
+    api_model_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -233,6 +237,16 @@ _KLING_VIDEO_TIERED_RATES: dict[tuple[str, bool], float] = {
 
 def _kling_video_pricing(model_id: str) -> PerSecondTiered:
     return PerSecondTiered(rates={model_id: _KLING_VIDEO_TIERED_RATES}, default_model=model_id, currency="CNY")
+
+
+# 可灵 Kling 图像费率（元/张，CNY，图像 1 积分 = ¥0.025，官方一手核实）。
+# image-o1 各长宽比同价（flat）；v3-omni 按分辨率分档（1K/2K 同价、4K 翻倍）。
+def _kling_image_flat_pricing(model_id: str, per_image: float) -> PerImageFlat:
+    return PerImageFlat(rates={model_id: per_image}, default_model=model_id, currency="CNY")
+
+
+def _kling_image_by_resolution_pricing(model_id: str, rates: dict[str, float]) -> PerImageByResolution:
+    return PerImageByResolution(rates={model_id: rates}, default_model=model_id, currency="CNY")
 
 
 PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
@@ -1048,6 +1062,25 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 supported_durations=[5, 10],
                 resolutions=["720p", "1080p"],
                 pricing=_kling_video_pricing("kling-v2-5-turbo"),
+            ),
+            # --- image ---
+            "kling-image-o1": ModelInfo(
+                display_name="可灵图像 O1",
+                media_type="image",
+                capabilities=["text_to_image", "image_to_image"],
+                default=True,
+                resolutions=["1K", "2K"],
+                pricing=_kling_image_flat_pricing("kling-image-o1", 0.2),
+            ),
+            # 两栖模型：API 模型名 kling-v3-omni 同时承载图像/视频；图像条目用别名键避开与视频
+            # 条目（归视频片）撞 model_id 主键，api_model_name 回指真实 API 名。
+            "kling-v3-omni-image": ModelInfo(
+                display_name="可灵 V3-Omni（图像）",
+                media_type="image",
+                capabilities=["text_to_image", "image_to_image"],
+                resolutions=["1K", "2K", "4K"],
+                api_model_name="kling-v3-omni",
+                pricing=_kling_image_by_resolution_pricing("kling-v3-omni-image", {"1K": 0.2, "2K": 0.2, "4K": 0.4}),
             ),
         },
         default_base_url="https://api.klingai.com/v1",

--- a/lib/image_backends/__init__.py
+++ b/lib/image_backends/__init__.py
@@ -56,3 +56,8 @@ from lib.image_backends.minimax import MiniMaxImageBackend
 from lib.providers import PROVIDER_MINIMAX
 
 register_backend(PROVIDER_MINIMAX, MiniMaxImageBackend)
+
+from lib.image_backends.kling import KlingImageBackend
+from lib.providers import PROVIDER_KLING
+
+register_backend(PROVIDER_KLING, KlingImageBackend)

--- a/lib/image_backends/kling.py
+++ b/lib/image_backends/kling.py
@@ -168,7 +168,8 @@ class KlingImageBackend:
         for idx, ref in enumerate(reference_images, start=1):
             path = Path(ref.path) if ref.path else None
             if path is None or not path.is_file():
-                unreadable.append(path.name if path else f"#{idx}")
+                # path.name 可能为空（如 "." / "/" 解析出空文件名）：回退序号 #N，避免空 token 漏进报错。
+                unreadable.append(path.name if (path and path.name) else f"#{idx}")
                 continue
             try:
                 encoded.append(image_to_base64(path))

--- a/lib/image_backends/kling.py
+++ b/lib/image_backends/kling.py
@@ -35,6 +35,7 @@ from lib.image_backends.base import (
     ImageCapabilityError,
     ImageGenerationRequest,
     ImageGenerationResult,
+    ReferenceImage,
     download_image_to_path,
 )
 from lib.kling_shared import (
@@ -157,7 +158,7 @@ class KlingImageBackend:
             payload["image"] = images
         return payload
 
-    def _encode_references(self, reference_images) -> list[str]:
+    def _encode_references(self, reference_images: list[ReferenceImage]) -> list[str]:
         """参考图 → 纯 base64 列表（无 data URI 前缀）；超上限截断，缺失/不可读 fail-loud。"""
         if not reference_images:
             return []

--- a/lib/image_backends/kling.py
+++ b/lib/image_backends/kling.py
@@ -1,0 +1,272 @@
+"""KlingImageBackend — 可灵 Kling 图像生成后端（JWT 直连 / Bearer 中转双模式，异步轮询）。
+
+走可灵原生图像端点：submit ``POST /v1/images/generations`` 取 ``data.task_id`` →
+轮询 ``GET /v1/images/generations/{task_id}`` 至 ``task_status=succeed`` 取
+``task_result.images[0].url``（24h 有效）→ 失效前立即下载本地。复用 video_backends/base
+的 submit/poll helpers + image_backends/base 的图片下载，与 KlingVideoBackend 同构。
+
+双模式（对齐 ``KlingVideoBackend`` 的 ``auth_mode`` 先例）：
+- ``auth_mode="jwt"``（内置 provider）：接 access_key + secret_key，走 ``KlingJWTManager``，
+  每次 HTTP 调用前检查过期、距过期 <60s 按需重签——异步渲染可能超单 token 寿命。
+- ``auth_mode="bearer"``（自定义 endpoint）：接静态 api_key + base_url，旁路 JWT 管理器。
+
+注册图像模型：
+- ``kling-image-o1``（默认）：文生图 / 图生图 / 1-10 图参考（跨图角色一致性），按 ``image`` 数组下传。
+- ``kling-v3-omni-image``：文生图 / 图生图 / 组图生成（registry 别名键，API 模型名 ``kling-v3-omni``）。
+
+发给 API 的模型名取 ``api_model_name``（registry 解耦键名与 API 名，供两栖模型共用 API 名），缺省回退
+到 registry 键名——不硬发键名，否则别名键会把 ``kling-v3-omni-image`` 误当 API 模型名。
+
+resolution（1K/2K/4K）由 registry 声明驱动 UI 下拉与计费，不下传请求体：可灵图像官方关键参数
+（model_name/prompt/image/aspect_ratio/n 等）未含 resolution 字段，与 KlingVideoBackend 一致只发
+已核实参数，避免猜测外部 API 结构。
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import httpx
+
+from lib.config.url_utils import normalize_base_url
+from lib.image_backends.base import (
+    ImageCapability,
+    ImageCapabilityError,
+    ImageGenerationRequest,
+    ImageGenerationResult,
+    download_image_to_path,
+)
+from lib.kling_shared import (
+    KLING_BASE_URL,
+    KlingJWTManager,
+    extract_kling_image_urls,
+    extract_kling_task_id,
+    image_to_base64,
+    is_kling_task_terminal,
+    kling_bearer_headers,
+    kling_task_failure_reason,
+    kling_task_status,
+    resolve_kling_api_key,
+    resolve_kling_jwt_credentials,
+)
+from lib.providers import PROVIDER_KLING
+from lib.retry import (
+    DEFAULT_BACKOFF_SECONDS,
+    DEFAULT_MAX_ATTEMPTS,
+    with_retry_async,
+)
+from lib.video_backends.base import (
+    poll_with_retry,
+    should_retry_poll,
+    should_retry_submit,
+    submit_post,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "kling-image-o1"
+
+_IMAGE_ENDPOINT = "images/generations"
+_POLL_INTERVAL_SECONDS = 5.0
+_POLL_MAX_WAIT_SECONDS = 600.0
+
+# 各图像模型参考图上限（多图主体，按 registry 键名）：o1 / v3-omni 均支持多图主体，官方 o1 上限 10 张。
+_DEFAULT_REF_LIMIT = 10
+_MODEL_REF_LIMITS: dict[str, int] = {
+    "kling-image-o1": 10,
+    "kling-v3-omni-image": 10,
+}
+
+
+class KlingImageBackend:
+    """可灵 Kling 图像后端（异步轮询，JWT / Bearer 双模式）。"""
+
+    def __init__(
+        self,
+        *,
+        auth_mode: str = "jwt",
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        api_key: str | None = None,
+        model: str | None = None,
+        api_model_name: str | None = None,
+        base_url: str | None = None,
+        http_timeout: float = 60.0,
+    ) -> None:
+        self._auth_mode = auth_mode
+        self._model = model or DEFAULT_MODEL
+        # 发给可灵 API 的模型名：调用方按 registry 解耦后传入；缺省回退 registry 键名（普通模型键名即 API 名）。
+        self._api_model_name = api_model_name or self._model
+        self._base_url = (normalize_base_url(base_url) or KLING_BASE_URL).rstrip("/")
+        self._http_timeout = http_timeout
+
+        if auth_mode == "jwt":
+            ak, sk = resolve_kling_jwt_credentials(access_key, secret_key)
+            self._jwt: KlingJWTManager | None = KlingJWTManager(ak, sk)
+            self._static_api_key: str | None = None
+        elif auth_mode == "bearer":
+            self._jwt = None
+            self._static_api_key = resolve_kling_api_key(api_key)
+        else:
+            raise ValueError(f"未知 Kling auth_mode: {auth_mode}")
+
+        # o1 / v3-omni 均支持文生图 + 图生图（多图主体）。
+        self._capabilities: set[ImageCapability] = {
+            ImageCapability.TEXT_TO_IMAGE,
+            ImageCapability.IMAGE_TO_IMAGE,
+        }
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_KLING
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def capabilities(self) -> set[ImageCapability]:
+        return self._capabilities
+
+    @property
+    def _ref_limit(self) -> int:
+        return _MODEL_REF_LIMITS.get(self._model, _DEFAULT_REF_LIMIT)
+
+    # ── auth ────────────────────────────────────────────────────────────
+
+    def _headers(self) -> dict[str, str]:
+        """鉴权头：jwt 模式每次调用触发过期检查 + 按需重签；bearer 模式用静态 key。"""
+        if self._jwt is not None:
+            return self._jwt.auth_headers()
+        assert self._static_api_key is not None
+        return kling_bearer_headers(self._static_api_key)
+
+    # ── request building ────────────────────────────────────────────────
+
+    def _build_payload(self, request: ImageGenerationRequest) -> dict:
+        """构建图像请求体。无参考图 → 文生图；有参考图 → 图生图（image 数组）。"""
+        payload: dict = {
+            "model_name": self._api_model_name,
+            "prompt": request.prompt,
+            "aspect_ratio": request.aspect_ratio,
+            "n": 1,
+        }
+        images = self._encode_references(request.reference_images)
+        if images:
+            payload["image"] = images
+        return payload
+
+    def _encode_references(self, reference_images) -> list[str]:
+        """参考图 → 纯 base64 列表（无 data URI 前缀）；超上限截断，缺失/不可读 fail-loud。"""
+        if not reference_images:
+            return []
+        encoded: list[str] = []
+        unreadable: list[str] = []
+        # names 进多语言错误模板：空路径无文件名时用序号 #N 标识第几张，避免占位漏进非中文报错。
+        for idx, ref in enumerate(reference_images, start=1):
+            path = Path(ref.path) if ref.path else None
+            if path is None or not path.is_file():
+                unreadable.append(path.name if path else f"#{idx}")
+                continue
+            try:
+                encoded.append(image_to_base64(path))
+            except OSError as exc:
+                logger.warning("Kling 参考图读取失败: %s (%s)", path, exc)
+                unreadable.append(path.name)
+        if unreadable:
+            # fail-loud：声明的参考图缺失即中止，不静默用子集生成出错误结果还照常计费。
+            raise ImageCapabilityError(
+                "image_reference_images_unreadable", model=self._model, names=", ".join(unreadable)
+            )
+        if len(encoded) > self._ref_limit:
+            logger.warning(
+                "Kling 参考图数量 %d 超过 model=%s 上限 %d，截断",
+                len(encoded),
+                self._model,
+                self._ref_limit,
+            )
+            encoded = encoded[: self._ref_limit]
+        return encoded
+
+    @staticmethod
+    def _safe_log_view(payload: dict) -> dict:
+        """预脱敏标量视图，直接喂 logger（避开 format_kwargs_for_log sink）。
+
+        base64 参考图 / prompt 一律不展开：仅记是否存在 + 数量 + prompt 长度。
+        """
+        prompt = payload.get("prompt")
+        images = payload.get("image")
+        return {
+            "endpoint": _IMAGE_ENDPOINT,
+            "model_name": payload.get("model_name"),
+            "aspect_ratio": payload.get("aspect_ratio"),
+            "n": payload.get("n"),
+            "reference_count": len(images) if isinstance(images, list) else 0,
+            "prompt_len": len(prompt) if isinstance(prompt, str) else 0,
+        }
+
+    # ── generate ────────────────────────────────────────────────────────
+
+    async def generate(self, request: ImageGenerationRequest) -> ImageGenerationResult:
+        payload = self._build_payload(request)
+        logger.info("调用 Kling 图像 API payload=%s", self._safe_log_view(payload))
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            task_id = await self._create_task(client, payload)
+            logger.info("Kling 图像任务已创建: task_id=%s model=%s", task_id, self._model)
+
+            final = await poll_with_retry(
+                poll_fn=lambda: self._poll_query(client, task_id),
+                is_done=is_kling_task_terminal,
+                is_failed=kling_task_failure_reason,
+                poll_interval=_POLL_INTERVAL_SECONDS,
+                max_wait=_POLL_MAX_WAIT_SECONDS,
+                retry_if=should_retry_poll,
+                label="Kling",
+                on_progress=lambda v, elapsed: logger.info(
+                    "Kling 图像生成中... status=%s elapsed=%ds",
+                    kling_task_status(v),
+                    int(elapsed),
+                ),
+            )
+            # 24h 有效的 image_url 必须在失效前落地：取首张转存本地（组图按张产出，单输出取 [0]）。
+            download_url = extract_kling_image_urls(final)[0]
+
+        await download_image_to_path(download_url, request.output_path)
+        logger.info("Kling 图像下载完成: %s", request.output_path)
+
+        return ImageGenerationResult(
+            image_path=request.output_path,
+            provider=PROVIDER_KLING,
+            model=self._model,
+            image_uri=download_url,
+            seed=request.seed,
+        )
+
+    # ── HTTP submit / poll ──────────────────────────────────────────────
+
+    @with_retry_async(
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+        retry_if=should_retry_submit,
+    )
+    async def _create_task(self, client: httpx.AsyncClient, payload: dict) -> str:
+        # 非幂等「建任务 + 计费」POST：submit_post 把歧义传输错误转 AmbiguousSubmitError 终态失败，
+        # 避免重试重复建任务 + 重复计费；>=400 抛 HTTPStatusError 交 should_retry_submit 按状态码分流。
+        resp = await submit_post(
+            lambda: client.post(
+                f"{self._base_url}/{_IMAGE_ENDPOINT}",
+                json=payload,
+                headers=self._headers(),
+            ),
+            provider=PROVIDER_KLING,
+        )
+        return extract_kling_task_id(resp.json())
+
+    async def _poll_query(self, client: httpx.AsyncClient, task_id: str) -> dict:
+        resp = await client.get(
+            f"{self._base_url}/{_IMAGE_ENDPOINT}/{task_id}",
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/lib/kling_shared.py
+++ b/lib/kling_shared.py
@@ -8,7 +8,7 @@
   （异步渲染可能超单 token 寿命，不能实例级签一次）；时钟可注入（测试不依赖真实墙钟）。
 - ``kling_bearer_headers`` — bearer 模式旁路 JWT、用静态 api_key 的鉴权头。
 - 异步任务响应解析：``code`` 信封错误、``data.task_id``、``data.task_status``
-  （submitted/processing/succeed/failed）、``data.task_result.videos[].url``。
+  （submitted/processing/succeed/failed）、``data.task_result.{videos,images}[].url``。
 """
 
 from __future__ import annotations
@@ -181,18 +181,39 @@ def kling_task_failure_reason(payload: dict) -> str | None:
         return err
     if kling_task_status(payload) == KLING_STATUS_FAILED:
         data = _as_dict(payload.get("data"))
-        return (f"Kling 视频任务失败 task_id={data.get('task_id')}: {_as_str(data.get('task_status_msg'))}").strip()
+        return (f"Kling 任务失败 task_id={data.get('task_id')}: {_as_str(data.get('task_status_msg'))}").strip()
     return None
+
+
+def _extract_task_result_urls(payload: dict, collection_key: str) -> list[str]:
+    """从 succeed 查询响应提取 ``data.task_result.{collection_key}[].url`` 列表（非法结构回空）。"""
+    result = _as_dict(_as_dict(payload.get("data")).get("task_result"))
+    items = result.get(collection_key)
+    urls: list[str] = []
+    if isinstance(items, list):
+        for item in items:
+            url = _as_dict(item).get("url")
+            if isinstance(url, str) and url:
+                urls.append(url)
+    return urls
 
 
 def extract_kling_video_url(payload: dict) -> str:
     """从 succeed 的查询响应提取 ``data.task_result.videos[0].url``。"""
-    result = _as_dict(_as_dict(payload.get("data")).get("task_result"))
-    videos = result.get("videos")
-    if isinstance(videos, list):
-        for video in videos:
-            url = _as_dict(video).get("url")
-            if isinstance(url, str) and url:
-                return url
+    for url in _extract_task_result_urls(payload, "videos"):
+        return url
     reason = kling_response_error(payload)
     raise RuntimeError(reason or f"Kling 视频任务完成但缺少视频 URL: {payload}")
+
+
+def extract_kling_image_urls(payload: dict) -> list[str]:
+    """从 succeed 的查询响应提取 ``data.task_result.images[].url`` 列表（按张顺序）。
+
+    可灵图像异步任务可一次产出多张（``n`` / 组图）；返回全部有效 URL，由后端按需取首张转存。
+    缺少任何有效 URL 即按 code 错误或原样抛出（与视频取 url 对称的 fail-loud）。
+    """
+    urls = _extract_task_result_urls(payload, "images")
+    if urls:
+        return urls
+    reason = kling_response_error(payload)
+    raise RuntimeError(reason or f"Kling 图像任务完成但缺少图片 URL: {payload}")

--- a/lib/kling_shared.py
+++ b/lib/kling_shared.py
@@ -156,7 +156,7 @@ def extract_kling_task_id(submit_payload: dict) -> str:
     task_id = _as_dict(submit_payload.get("data")).get("task_id")
     if not task_id:
         reason = kling_response_error(submit_payload)
-        raise RuntimeError(reason or f"Kling 视频提交响应缺少 task_id: {submit_payload}")
+        raise RuntimeError(reason or f"Kling 提交响应缺少 task_id: {submit_payload}")
     return str(task_id)
 
 

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -273,6 +273,21 @@ async def _get_or_create_image_backend(
         kwargs["base_url"] = db_config.get("base_url")
         kwargs["rate_limiter"] = rate_limiter
         kwargs["image_model"] = effective_model
+    elif backend_name == PROVIDER_KLING:
+        # 可灵 JWT 直连：双 secret（access_key + secret_key）而非单 api_key（见 ADR 0037）。
+        meta = PROVIDER_REGISTRY[PROVIDER_KLING]
+        db_config = await resolver.provider_config(PROVIDER_KLING)
+        kwargs["auth_mode"] = "jwt"
+        kwargs["access_key"] = db_config.get("access_key")
+        kwargs["secret_key"] = db_config.get("secret_key")
+        kwargs["model"] = effective_model
+        # 两栖模型 registry 键名与 API 模型名解耦：别名键（如 kling-v3-omni-image）发真实 API 名。
+        model_info = meta.models.get(effective_model) if effective_model else None
+        if model_info is not None and model_info.api_model_name:
+            kwargs["api_model_name"] = model_info.api_model_name
+        base_url = db_config.get("base_url") or meta.default_base_url
+        if base_url:
+            kwargs["base_url"] = base_url
     else:
         await _fill_simple_provider_kwargs(backend_name, resolver, kwargs, effective_model)
 

--- a/tests/test_config_registry_models.py
+++ b/tests/test_config_registry_models.py
@@ -15,6 +15,20 @@ class TestModelInfo:
         assert m.media_type == "text"
         assert m.default is True
 
+    def test_api_model_name_defaults_none(self):
+        m = ModelInfo(display_name="X", media_type="image", capabilities=["text_to_image"])
+        assert m.api_model_name is None
+
+    def test_api_model_name_only_declared_for_amphibious_aliases(self):
+        # 解耦字段对存量模型零影响：仅两栖别名键显式声明 api_model_name，其余一律回退键名。
+        declared = {
+            f"{pid}/{mid}": minfo.api_model_name
+            for pid, meta in PROVIDER_REGISTRY.items()
+            for mid, minfo in meta.models.items()
+            if minfo.api_model_name is not None
+        }
+        assert declared == {"kling/kling-v3-omni-image": "kling-v3-omni"}
+
 
 class TestProviderMeta:
     def test_media_types_derived_from_models(self):

--- a/tests/test_kling_image_backend.py
+++ b/tests/test_kling_image_backend.py
@@ -1,0 +1,279 @@
+"""KlingImageBackend 单元测试（mock httpx，异步轮询，不打真实 HTTP）。
+
+覆盖：JWT / Bearer 双模式鉴权注入、请求体构建（文生图 / 图生图 image 数组）、参考图上限截断、
+缺失参考图 fail-loud、脱敏日志视图、submit→轮询→取 image_url→下载端到端、失败终态、多图取首张。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jwt
+import pytest
+
+from lib.image_backends.base import (
+    ImageCapability,
+    ImageCapabilityError,
+    ImageGenerationRequest,
+    ReferenceImage,
+)
+from lib.image_backends.kling import KlingImageBackend
+from lib.providers import PROVIDER_KLING
+
+_SECRET = "s" * 40
+
+
+def _resp(json_body: dict, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _submit(task_id: str = "t-1") -> dict:
+    return {"code": 0, "message": "SUCCEED", "data": {"task_id": task_id, "task_status": "submitted"}}
+
+
+def _query(status: str, urls: list[str] | None = None, status_msg: str = "") -> dict:
+    data: dict = {"task_id": "t-1", "task_status": status, "task_status_msg": status_msg}
+    if urls:
+        data["task_result"] = {"images": [{"index": i, "url": u} for i, u in enumerate(urls)]}
+    return {"code": 0, "message": "SUCCEED", "data": data}
+
+
+def _client(*, post=None, get=None) -> AsyncMock:
+    c = AsyncMock()
+    if post is not None:
+        c.post = post
+    if get is not None:
+        c.get = get
+    c.__aenter__ = AsyncMock(return_value=c)
+    c.__aexit__ = AsyncMock(return_value=None)
+    return c
+
+
+def _jwt_backend(model: str | None = None, api_model_name: str | None = None) -> KlingImageBackend:
+    return KlingImageBackend(
+        auth_mode="jwt", access_key="ak-1", secret_key=_SECRET, model=model, api_model_name=api_model_name
+    )
+
+
+def _bearer_backend(model: str | None = None) -> KlingImageBackend:
+    return KlingImageBackend(auth_mode="bearer", api_key="static-key", model=model)
+
+
+def _request(tmp_path: Path, **overrides) -> ImageGenerationRequest:
+    kwargs: dict = {
+        "prompt": "a hero portrait",
+        "output_path": tmp_path / "out.png",
+        "aspect_ratio": "9:16",
+    }
+    kwargs.update(overrides)
+    return ImageGenerationRequest(**kwargs)
+
+
+def _ref(tmp_path: Path, name: str) -> ReferenceImage:
+    p = tmp_path / name
+    p.write_bytes(b"\x89PNG\r\n" + name.encode())
+    return ReferenceImage(path=str(p))
+
+
+class TestConstructionAndCapabilities:
+    def test_name_and_default_model(self):
+        b = _jwt_backend()
+        assert b.name == PROVIDER_KLING
+        assert b.model == "kling-image-o1"
+
+    def test_explicit_model_keeps_registry_key(self):
+        # model 属性 = registry 键名（result.model / 计费查表键），即使带 API 名别名。
+        b = _jwt_backend("kling-v3-omni-image", api_model_name="kling-v3-omni")
+        assert b.model == "kling-v3-omni-image"
+
+    def test_jwt_missing_credentials_raises(self):
+        with pytest.raises(ValueError):
+            KlingImageBackend(auth_mode="jwt", access_key="ak", secret_key=None)
+
+    def test_bearer_missing_api_key_raises(self):
+        with pytest.raises(ValueError):
+            KlingImageBackend(auth_mode="bearer", api_key=None)
+
+    def test_unknown_auth_mode_raises(self):
+        with pytest.raises(ValueError):
+            KlingImageBackend(auth_mode="oauth", api_key="k")
+
+    def test_capabilities_t2i_and_i2i(self):
+        caps = _jwt_backend().capabilities
+        assert ImageCapability.TEXT_TO_IMAGE in caps
+        assert ImageCapability.IMAGE_TO_IMAGE in caps
+
+
+class TestAuthHeaders:
+    def test_jwt_mode_signs_bearer_token(self):
+        headers = _jwt_backend()._headers()
+        assert headers["Content-Type"] == "application/json"
+        token = headers["Authorization"].removeprefix("Bearer ")
+        claims = jwt.decode(token, _SECRET, algorithms=["HS256"], options={"verify_exp": False})
+        assert claims["iss"] == "ak-1"
+
+    def test_bearer_mode_uses_static_key(self):
+        headers = _bearer_backend()._headers()
+        assert headers["Authorization"] == "Bearer static-key"
+
+
+class TestApiModelNameResolution:
+    def test_alias_key_sends_api_model_name(self, tmp_path):
+        # 别名键（registry 键 ≠ API 名）：请求体 model_name 发真实 API 名。
+        b = _jwt_backend("kling-v3-omni-image", api_model_name="kling-v3-omni")
+        payload = b._build_payload(_request(tmp_path))
+        assert payload["model_name"] == "kling-v3-omni"
+
+    def test_plain_key_sends_itself(self, tmp_path):
+        # 普通键（无别名）：请求体 model_name 回退到键名自身。
+        b = _jwt_backend("kling-image-o1")
+        payload = b._build_payload(_request(tmp_path))
+        assert payload["model_name"] == "kling-image-o1"
+
+    def test_default_model_sends_itself(self, tmp_path):
+        payload = _jwt_backend()._build_payload(_request(tmp_path))
+        assert payload["model_name"] == "kling-image-o1"
+
+
+class TestPayloadBuilding:
+    def test_text2image_no_reference(self, tmp_path):
+        payload = _jwt_backend()._build_payload(_request(tmp_path))
+        assert payload["model_name"] == "kling-image-o1"
+        assert payload["aspect_ratio"] == "9:16"
+        assert payload["n"] == 1
+        assert "image" not in payload
+
+    def test_image2image_embeds_base64_array(self, tmp_path):
+        refs = [_ref(tmp_path, "a.png"), _ref(tmp_path, "b.png")]
+        payload = _jwt_backend()._build_payload(_request(tmp_path, reference_images=refs))
+        assert isinstance(payload["image"], list)
+        assert len(payload["image"]) == 2
+        # 纯 base64，无 data URI 前缀
+        assert all(isinstance(u, str) and u and not u.startswith("data:") for u in payload["image"])
+
+    def test_reference_over_limit_truncated(self, tmp_path):
+        refs = [_ref(tmp_path, f"r{i}.png") for i in range(12)]
+        payload = _jwt_backend()._build_payload(_request(tmp_path, reference_images=refs))
+        # o1 上限 10 张，超出截断
+        assert len(payload["image"]) == 10
+
+    def test_missing_reference_raises(self, tmp_path):
+        bad = ReferenceImage(path=str(tmp_path / "nope.png"))
+        with pytest.raises(ImageCapabilityError) as exc:
+            _jwt_backend()._build_payload(_request(tmp_path, reference_images=[bad]))
+        assert exc.value.code == "image_reference_images_unreadable"
+
+
+class TestSafeLogView:
+    def test_no_base64_or_prompt_leaks(self, tmp_path):
+        refs = [_ref(tmp_path, "a.png")]
+        b = _jwt_backend()
+        payload = b._build_payload(_request(tmp_path, reference_images=refs))
+        view = b._safe_log_view(payload)
+        assert view["reference_count"] == 1
+        assert view["prompt_len"] == len("a hero portrait")
+        assert "image" not in view
+        assert "prompt" not in view
+        assert all(isinstance(v, (str, int, bool)) for v in view.values())
+
+
+class TestGenerateHappyPath:
+    async def test_submit_poll_download(self, tmp_path):
+        post = AsyncMock(return_value=_resp(_submit("task-9")))
+        get = AsyncMock(
+            side_effect=[
+                _resp(_query("processing")),
+                _resp(_query("succeed", urls=["https://x/final.png"])),
+            ]
+        )
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.image_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.image_backends.kling._POLL_INTERVAL_SECONDS", 0),
+            patch("lib.image_backends.kling.download_image_to_path", new=AsyncMock()) as dl,
+        ):
+            result = await _jwt_backend().generate(_request(tmp_path))
+
+        assert result.provider == PROVIDER_KLING
+        assert result.image_uri == "https://x/final.png"
+        dl.assert_awaited_once()
+        # images/generations 提交端点
+        assert post.await_args.args[0].endswith("/images/generations")
+
+    async def test_multiple_images_takes_first(self, tmp_path):
+        post = AsyncMock(return_value=_resp(_submit()))
+        get = AsyncMock(return_value=_resp(_query("succeed", urls=["https://x/1.png", "https://x/2.png"])))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.image_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.image_backends.kling._POLL_INTERVAL_SECONDS", 0),
+            patch("lib.image_backends.kling.download_image_to_path", new=AsyncMock()),
+        ):
+            result = await _jwt_backend().generate(_request(tmp_path))
+        assert result.image_uri == "https://x/1.png"
+
+    async def test_jwt_injected_on_submit(self, tmp_path):
+        captured: dict = {}
+
+        async def _post(url, json, headers):
+            captured["headers"] = headers
+            return _resp(_submit())
+
+        post = AsyncMock(side_effect=_post)
+        get = AsyncMock(return_value=_resp(_query("succeed", urls=["https://x/v.png"])))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.image_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.image_backends.kling._POLL_INTERVAL_SECONDS", 0),
+            patch("lib.image_backends.kling.download_image_to_path", new=AsyncMock()),
+        ):
+            await _jwt_backend().generate(_request(tmp_path))
+
+        token = captured["headers"]["Authorization"].removeprefix("Bearer ")
+        claims = jwt.decode(token, _SECRET, algorithms=["HS256"], options={"verify_exp": False})
+        assert claims["iss"] == "ak-1"
+
+    async def test_bearer_static_key_on_submit(self, tmp_path):
+        captured: dict = {}
+
+        async def _post(url, json, headers):
+            captured["headers"] = headers
+            return _resp(_submit())
+
+        post = AsyncMock(side_effect=_post)
+        get = AsyncMock(return_value=_resp(_query("succeed", urls=["https://x/v.png"])))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.image_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.image_backends.kling._POLL_INTERVAL_SECONDS", 0),
+            patch("lib.image_backends.kling.download_image_to_path", new=AsyncMock()),
+        ):
+            await _bearer_backend().generate(_request(tmp_path))
+        assert captured["headers"]["Authorization"] == "Bearer static-key"
+
+    async def test_failed_status_raises(self, tmp_path):
+        post = AsyncMock(return_value=_resp(_submit()))
+        get = AsyncMock(return_value=_resp(_query("failed", status_msg="content rejected")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.image_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.image_backends.kling._POLL_INTERVAL_SECONDS", 0),
+            patch("lib.image_backends.kling.download_image_to_path", new=AsyncMock()),
+        ):
+            with pytest.raises(RuntimeError, match="content rejected"):
+                await _jwt_backend().generate(_request(tmp_path))
+
+
+class TestRegistration:
+    def test_kling_image_backend_registered(self):
+        # 触发 image_backends 包级自动注册
+        from lib.image_backends import create_backend, get_registered_backends
+
+        assert PROVIDER_KLING in get_registered_backends()
+        backend = create_backend(PROVIDER_KLING, auth_mode="jwt", access_key="ak", secret_key=_SECRET)
+        assert isinstance(backend, KlingImageBackend)

--- a/tests/test_kling_image_backend.py
+++ b/tests/test_kling_image_backend.py
@@ -169,6 +169,13 @@ class TestPayloadBuilding:
             _jwt_backend()._build_payload(_request(tmp_path, reference_images=[bad]))
         assert exc.value.code == "image_reference_images_unreadable"
 
+    def test_empty_filename_path_uses_index_placeholder(self, tmp_path):
+        # "." 解析出空文件名（非文件）：报错按序号 #N 标识，不漏空 token。
+        bad = ReferenceImage(path=".")
+        with pytest.raises(ImageCapabilityError) as exc:
+            _jwt_backend()._build_payload(_request(tmp_path, reference_images=[bad]))
+        assert exc.value.params["names"] == "#1"
+
 
 class TestSafeLogView:
     def test_no_base64_or_prompt_leaks(self, tmp_path):

--- a/tests/test_kling_image_backend.py
+++ b/tests/test_kling_image_backend.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import jwt
 import pytest
 
@@ -267,6 +268,21 @@ class TestGenerateHappyPath:
         ):
             with pytest.raises(RuntimeError, match="content rejected"):
                 await _jwt_backend().generate(_request(tmp_path))
+
+    async def test_http_error_raises_and_no_retry_on_4xx(self, tmp_path):
+        # 真实 httpx.Response：submit 阶段 4xx 经 raise_for_status 抛 HTTPStatusError；
+        # 确定性 4xx 不重试（非幂等建任务 POST），post 仅调用一次，不重复建任务 + 重复计费。
+        req = httpx.Request("POST", "https://api.klingai.com/v1/images/generations")
+        resp = httpx.Response(400, request=req, text="Bad Request")
+        post = AsyncMock(return_value=resp)
+        client = _client(post=post)
+        with (
+            patch("lib.image_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.image_backends.kling._POLL_INTERVAL_SECONDS", 0),
+        ):
+            with pytest.raises(httpx.HTTPStatusError):
+                await _jwt_backend().generate(_request(tmp_path))
+        assert post.call_count == 1
 
 
 class TestRegistration:

--- a/tests/test_kling_shared.py
+++ b/tests/test_kling_shared.py
@@ -11,6 +11,7 @@ import pytest
 from lib.kling_shared import (
     KLING_BASE_URL,
     KlingJWTManager,
+    extract_kling_image_urls,
     extract_kling_task_id,
     extract_kling_video_url,
     is_kling_task_terminal,
@@ -164,3 +165,35 @@ class TestResponseParsing:
     def test_extract_video_url_missing_raises(self):
         with pytest.raises(RuntimeError):
             extract_kling_video_url({"code": 0, "data": {"task_status": "succeed", "task_result": {"videos": []}}})
+
+    def test_extract_image_urls_in_order(self):
+        payload = {
+            "code": 0,
+            "data": {
+                "task_status": "succeed",
+                "task_result": {
+                    "images": [{"index": 0, "url": "https://x/0.png"}, {"index": 1, "url": "https://x/1.png"}]
+                },
+            },
+        }
+        assert extract_kling_image_urls(payload) == ["https://x/0.png", "https://x/1.png"]
+
+    def test_extract_image_urls_skips_blank(self):
+        payload = {
+            "code": 0,
+            "data": {"task_status": "succeed", "task_result": {"images": [{"url": ""}, {"url": "https://x/ok.png"}]}},
+        }
+        assert extract_kling_image_urls(payload) == ["https://x/ok.png"]
+
+    def test_extract_image_urls_missing_raises(self):
+        with pytest.raises(RuntimeError):
+            extract_kling_image_urls({"code": 0, "data": {"task_status": "succeed", "task_result": {"images": []}}})
+
+    def test_failure_reason_message_modality_neutral(self):
+        # image / video 共用 failure_reason：消息不应写死「视频」，便于图像任务复用。
+        reason = kling_task_failure_reason(
+            {"code": 0, "data": {"task_id": "t-9", "task_status": "failed", "task_status_msg": "boom"}}
+        )
+        assert reason is not None
+        assert "视频" not in reason
+        assert "t-9" in reason and "boom" in reason

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -59,7 +59,7 @@ def test_kling_credentials_and_base_url() -> None:
 
 
 def test_kling_default_video_model_v2_5_turbo() -> None:
-    """JWT 直连视频首发：默认视频模型 kling-v2-5-turbo，能力声明齐备，无 text/image 模型。"""
+    """JWT 直连视频默认模型 kling-v2-5-turbo，能力声明齐备。"""
     p = PROVIDER_REGISTRY["kling"]
     assert "kling-v2-5-turbo" in p.models
     turbo = p.models["kling-v2-5-turbo"]
@@ -68,8 +68,37 @@ def test_kling_default_video_model_v2_5_turbo() -> None:
     assert turbo.supported_durations == [5, 10]
     assert turbo.resolutions, "默认视频模型须声明 resolutions"
     assert turbo.pricing is not None
-    # 本片只接视频默认模型，尚无图像/文本模型
-    assert p.media_types == ["video"]
+
+
+def test_kling_image_models() -> None:
+    """图像模型：默认 kling-image-o1（按张 flat ¥0.2），v3-omni 别名键按分辨率（4K ¥0.4）。"""
+    from lib.pricing.types import PerImageByResolution, PerImageFlat
+
+    p = PROVIDER_REGISTRY["kling"]
+    assert "image" in p.media_types
+
+    o1 = p.models["kling-image-o1"]
+    assert o1.media_type == "image"
+    assert o1.default is True
+    assert o1.capabilities == ["text_to_image", "image_to_image"]
+    assert o1.resolutions == ["1K", "2K"]
+    # 普通模型：无别名，键名即 API 名。
+    assert o1.api_model_name is None
+    assert isinstance(o1.pricing, PerImageFlat)
+    assert o1.pricing.currency == "CNY"
+    assert o1.pricing.rates["kling-image-o1"] == 0.2
+
+    # 两栖模型：图像条目用别名键避开与视频条目撞主键，api_model_name 回指真实 API 名。
+    omni = p.models["kling-v3-omni-image"]
+    assert omni.media_type == "image"
+    assert omni.api_model_name == "kling-v3-omni"
+    assert omni.resolutions == ["1K", "2K", "4K"]
+    assert isinstance(omni.pricing, PerImageByResolution)
+    # 计费查表键 = registry 键名（result.model），非 API 名。
+    assert omni.pricing.rates["kling-v3-omni-image"] == {"1K": 0.2, "2K": 0.2, "4K": 0.4}
+    # 视频主键 kling-v3-omni 不归本片（图像片不注册视频条目）。
+    video_omni = p.models.get("kling-v3-omni")
+    assert video_omni is None or video_omni.media_type == "video"
 
 
 def test_kling_video_backend_registered() -> None:


### PR DESCRIPTION
## 概述

接入可灵图像生成，用户可用可灵图像模型端到端出图（提交 → 轮询 → 取图 → 在 24h 有效期前立即转存本地，资产不丢），费用按张正确以人民币计。

## 新增模型

- **可灵图像 O1（`kling-image-o1`，默认图像模型）** — 文生图 / 图生图 / 1-10 张参考图（跨图主体一致性）；按张计费 ¥0.2。
- **可灵 V3-Omni（图像）** — 文生图 / 图生图；分辨率 1K / 2K / 4K，按分辨率分档计费（1K/2K ¥0.2、4K ¥0.4）。

JWT 直连与 Bearer 中转双鉴权模式，与可灵视频共享同一套 JWT 凭证管理。

## 实现要点

- `ModelInfo` 新增 `api_model_name`（默认 `None`，对存量模型零影响）：用于「同一 API 模型名、两个 registry 条目」的两栖模型——V3-Omni 图像条目用别名键 `kling-v3-omni-image`，API 模型名回指 `kling-v3-omni`，主键留给视频条目。registry 键名兼作 UI 标识与计费查表键，发给 API 的是 `api_model_name`，二者解耦。
- 新后端日志走预脱敏标量视图，不展开 base64 / prompt，规避 CodeQL 日志 sink。

## 验证

- `uv run pytest tests/`：4983 passed（唯一失败 `test_default_when_unresolvable` 为本机 dev 库环境耦合，CI 干净库通过，非回归）
- `ruff` 净、`basedpyright` 0 error、i18n 三语一致
- 未改动前端文件，前端门不受影响

## 审查

本地以独立视角完成 `/code-review`（多角度，高召回）：未发现正确性缺陷。计费链路与既有按分辨率计费的图像模型同构、实际计费正确（分辨率经 `image_size` 入 usage → 计费）；提交重试用 `AmbiguousSubmitError` 防重复建任务 + 重复计费。

非阻塞后续观察（不在本片范围）：图像后端与视频后端在构造/鉴权/提交轮询上有结构性重复，后续可抽共享基类收敛。

Closes #834


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 Kling 图像生成能力：支持 `kling-image-o1`，以及两栖别名模型 `kling-v3-omni-image`（图像计费按分辨率档位）。
* **计费与鉴权**
  * 图像支持两种计费：按张固定费率、按分辨率档位计费。
  * 支持 JWT 与 Bearer 鉴权模式。
* **改进**
  * 任务轮询与图片结果解析更稳健，成功后自动保存生成图片；失败原因更清晰。
* **测试**
  * 新增并扩展 Kling 图像用例，覆盖构造、鉴权、计费、请求体与结果解析。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->