### PR TITLE
feat(kling): 可灵视频补齐 v3/v3-omni（4K+多图主体）、v2.6 人声、video-o1 参考生视频

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -1057,8 +1057,8 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
         # 存入 provider_credential 的 access_key / secret_key 定型列（见 ADR 0037）。
         required_keys=["access_key", "secret_key"],
         secret_keys=["access_key", "secret_key"],
-        # JWT 直连视频首发：默认视频模型 kling-v2-5-turbo（性价比走量）。其余视频模型
-        # （v3/v3-omni/v2-6/o1）与图像模型留后续片接入。
+        # JWT 直连视频：默认 kling-v2-5-turbo（性价比走量）+ v3/v3-omni（旗舰 4K + 多图主体）、
+        # v2-6（pro 人声）、video-o1（多图主体 R2V）。图像模型留后续片接入。
         models={
             "kling-v2-5-turbo": ModelInfo(
                 display_name="可灵 2.5 Turbo",
@@ -1087,6 +1087,45 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 resolutions=["1K", "2K", "4K"],
                 api_model_name="kling-v3-omni",
                 pricing=_kling_image_by_resolution_pricing("kling-v3-omni-image", {"1K": 0.2, "2K": 0.2, "4K": 0.4}),
+            ),
+            # --- video ---
+            "kling-v3": ModelInfo(
+                display_name="可灵 v3",
+                media_type="video",
+                capabilities=["text_to_video", "image_to_video"],
+                supported_durations=list(range(3, 16)),
+                resolutions=["720p", "1080p", "4k"],
+                pricing=_kling_video_pricing("kling-v3"),
+            ),
+            "kling-v3-omni": ModelInfo(
+                display_name="可灵 v3 Omni",
+                media_type="video",
+                capabilities=["text_to_video", "image_to_video"],
+                supported_durations=list(range(3, 16)),
+                resolutions=["720p", "1080p", "4k"],
+                # 多图主体（R2V）参考上限保守值；编排层裁剪读此处，与 backend caps 同值，
+                # 待 app.klingai.com 控制台核对，不硬编当既成事实。
+                max_reference_images=4,
+                pricing=_kling_video_pricing("kling-v3-omni"),
+            ),
+            "kling-v2-6": ModelInfo(
+                display_name="可灵 v2.6",
+                media_type="video",
+                capabilities=["text_to_video", "image_to_video", "generate_audio"],
+                supported_durations=[5, 10],
+                resolutions=["720p", "1080p"],
+                pricing=_kling_video_pricing("kling-v2-6"),
+            ),
+            "kling-video-o1": ModelInfo(
+                display_name="可灵 Video O1",
+                media_type="video",
+                capabilities=["image_to_video"],
+                supported_durations=[5, 10],
+                resolutions=["720p", "1080p"],
+                # 多图主体（R2V）参考上限保守值；编排层裁剪读此处，与 backend caps 同值，
+                # 待 app.klingai.com 控制台核对，不硬编当既成事实。
+                max_reference_images=4,
+                pricing=_kling_video_pricing("kling-video-o1"),
             ),
         },
         default_base_url="https://api.klingai.com/v1",

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -197,6 +197,8 @@ MESSAGES = {
     "video_resolution_duration_unsupported": "Model {model} does not support {duration}s at {resolution} resolution (only {supported}); adjust the resolution or duration",
     "video_reference_images_required": "Model {model} requires at least one reference image; please provide reference images",
     "video_reference_images_unreadable": "Model {model} has reference images that are missing or unreadable; generation aborted: {names}; check the reference image paths",
+    "video_reference_images_unsupported": "Model {model} does not support multi-subject reference images; remove the reference images or switch to a model that supports reference-to-video",
+    "video_reference_images_exceeded": "Model {model} supports at most {limit} reference images but received {count}; reduce the number of reference images",
     "video_start_image_unreadable": "The first-frame image for model {model} is unreadable; generation aborted: {name}; check the first-frame image path",
     # Agent credentials
     "agent_preset_unknown": "Unknown preset provider: {preset_id}",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -197,6 +197,8 @@ MESSAGES = {
     "video_resolution_duration_unsupported": "Mô hình {model} không hỗ trợ {duration}s ở độ phân giải {resolution} (chỉ {supported}); hãy điều chỉnh độ phân giải hoặc thời lượng",
     "video_reference_images_required": "Mô hình {model} cần ít nhất một ảnh tham chiếu; hãy cung cấp ảnh tham chiếu",
     "video_reference_images_unreadable": "Mô hình {model} có ảnh tham chiếu bị thiếu hoặc không đọc được; đã hủy tạo: {names}; hãy kiểm tra đường dẫn ảnh tham chiếu",
+    "video_reference_images_unsupported": "Mô hình {model} không hỗ trợ ảnh tham chiếu đa chủ thể; hãy bỏ ảnh tham chiếu hoặc chuyển sang mô hình có hỗ trợ tạo video từ ảnh tham chiếu",
+    "video_reference_images_exceeded": "Mô hình {model} hỗ trợ tối đa {limit} ảnh tham chiếu nhưng nhận được {count}; hãy giảm số lượng ảnh tham chiếu",
     "video_start_image_unreadable": "Ảnh khung hình đầu của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình đầu",
     # Agent credentials
     "agent_preset_unknown": "Nhà cung cấp đặt sẵn không xác định: {preset_id}",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -197,6 +197,8 @@ MESSAGES = {
     "video_resolution_duration_unsupported": "模型 {model} 在 {resolution} 分辨率下不支持 {duration}s（仅支持 {supported}）；请调整分辨率或时长",
     "video_reference_images_required": "模型 {model} 需要至少一张参考图；请提供参考图",
     "video_reference_images_unreadable": "模型 {model} 有参考图缺失或无法读取，已中止生成：{names}；请检查参考图路径",
+    "video_reference_images_unsupported": "模型 {model} 不支持多图主体参考；请移除参考图，或换一个支持参考生视频的模型",
+    "video_reference_images_exceeded": "模型 {model} 最多支持 {limit} 张参考图，收到 {count} 张；请减少参考图数量",
     "video_start_image_unreadable": "模型 {model} 的首帧图无法读取，已中止生成：{name}；请检查首帧图路径",
     # Agent credentials
     "agent_preset_unknown": "未知预设供应商: {preset_id}",

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -146,22 +146,33 @@ _POLL_TIMEOUT_PER_SECOND = 60.0
 _KLING_VIDEO_POLL_INTERVAL_SECONDS = 10.0
 
 
-def _encode_job_id(subpath: str, task_id: str) -> str:
-    """把生成类型子路径编进持久化 job_id（``subpath:task_id``）。
+def _encode_job_id(subpath: str, task_id: str, *, generate_audio: bool) -> str:
+    """把生成类型子路径 + 有声标志编进持久化 job_id（``subpath:task_id:audio``）。
 
     可灵查询端点按生成类型分路径（``GET /v1/videos/{text2video|image2video}/{id}``），
     且重启 resume 时请求已无 ``start_image`` 可推断子路径——必须把子路径随 task_id 一起
     持久化，否则 image2video 任务 resume 会误查 text2video 端点取不到任务。
+
+    有声标志（0/1）同理随 task_id 持久化：resume 直接复用 submit 时算定的有声决策，
+    不按 resume 时（config 默认/请求可能已漂移）重算，避免有声/无声计费漂移。
     """
-    return f"{subpath}:{task_id}"
+    return f"{subpath}:{task_id}:{1 if generate_audio else 0}"
 
 
-def _decode_job_id(job_id: str) -> tuple[str, str]:
-    """从持久化 job_id 复原 ``(子路径, task_id)``；无已知前缀（异常/旧数据）回落 text2video。"""
+def _decode_job_id(job_id: str) -> tuple[str, str, bool | None]:
+    """从持久化 job_id 复原 ``(子路径, task_id, 有声标志)``。
+
+    新格式 ``subpath:task_id:audio``（3 段，audio 为 0/1）；旧格式 ``subpath:task_id``
+    （2 段，有声标志未持久化，返回 None 由 caller 重算）；无已知前缀（异常/更旧数据）
+    回落 text2video、整串作 task_id。
+    """
+    parts = job_id.split(":")
+    if len(parts) == 3 and parts[0] in _RESUMABLE_SUBPATHS and parts[2] in ("0", "1"):
+        return parts[0], parts[1], parts[2] == "1"
     prefix, sep, rest = job_id.partition(":")
     if sep and prefix in _RESUMABLE_SUBPATHS:
-        return prefix, rest
-    return _TEXT2VIDEO, job_id
+        return prefix, rest, None
+    return _TEXT2VIDEO, job_id, None
 
 
 class KlingVideoBackend:
@@ -277,12 +288,26 @@ class KlingVideoBackend:
 
         reference_images = self._valid_frames(request.reference_images)
         if reference_images:
+            # 生成时防御（fail-loud）：未声明多图主体能力的 model 不得升级到 R2V 子路径，
+            # 超上限的参考图数同样拦截——否则会把必然报错的请求发出去且照常计费。
+            if not self._caps.reference_images:
+                raise VideoCapabilityError("video_reference_images_unsupported", model=self._model)
+            if len(reference_images) > self._caps.max_reference_images:
+                raise VideoCapabilityError(
+                    "video_reference_images_exceeded",
+                    model=self._model,
+                    count=len(reference_images),
+                    limit=self._caps.max_reference_images,
+                )
             # 多图主体：image_list 为 [{"image": <base64>}]（可灵原生 schema），无单首帧概念。
             payload["image_list"] = [{"image": self._encode_frame(p)} for p in reference_images]
             return _MULTI_IMAGE2VIDEO, payload
 
         start_image = request.start_image
         if not (isinstance(start_image, (str, Path)) and str(start_image)):
+            # 无首帧/无参考 = 文生视频意图；不支持 t2v 的 model（如 kling-video-o1）即拒绝。
+            if not self._caps.text_to_video:
+                raise VideoCapabilityError("video_capability_missing_t2v", provider=self.name, model=self._model)
             subpath = _TEXT2VIDEO
         else:
             payload["image"] = self._encode_frame(Path(start_image))
@@ -337,9 +362,12 @@ class KlingVideoBackend:
             task_id = await self._create_task(client, subpath, payload)
             logger.info("Kling 视频任务已创建: task_id=%s model=%s", task_id, self._model)
             if request.task_id is not None:
-                # 持久化「子路径:task_id」而非裸 task_id：resume 据此复原查询端点（见 _encode_job_id）。
+                # 持久化「子路径:task_id:有声标志」而非裸 task_id：resume 据此复原查询端点
+                # 与 submit 时的有声决策（见 _encode_job_id）。
                 await persist_provider_job_id(
-                    request.task_id, _encode_job_id(subpath, task_id), provider=PROVIDER_KLING
+                    request.task_id,
+                    _encode_job_id(subpath, task_id, generate_audio=generate_audio),
+                    provider=PROVIDER_KLING,
                 )
             return await self._poll_and_build(client, subpath, task_id, request, generate_audio=generate_audio)
 
@@ -348,9 +376,12 @@ class KlingVideoBackend:
 
         查询子路径从持久化 job_id 复原（submit 时编入）——可灵查询端点按生成类型分路径，
         而 resume 请求已无 ``start_image`` 可推断，故不能再从 request 取（见 _encode_job_id）。
+
+        有声标志同样优先取持久化值（submit 时算定）：直连有声/无声计费，避免按 resume 时
+        可能已漂移的 config 默认/请求重算。旧 job_id 未持久化时（None）回落重算。
         """
-        subpath, task_id = _decode_job_id(job_id)
-        generate_audio = self._effective_audio(request)
+        subpath, task_id, persisted_audio = _decode_job_id(job_id)
+        generate_audio = persisted_audio if persisted_audio is not None else self._effective_audio(request)
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             return await self._poll_and_build(client, subpath, task_id, request, generate_audio=generate_audio)
 

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -10,13 +10,18 @@
   每次 HTTP 调用前检查过期、距过期 <60s 按需重签——异步渲染可能超单 token 寿命。
 - ``auth_mode="bearer"``（自定义 endpoint）：接静态 api_key + base_url，旁路 JWT 管理器。
 
-本片只接默认视频模型 ``kling-v2-5-turbo``（std/pro，5s/10s，文生 + 图生视频含首尾帧）；
-其余模型（v3/v3-omni/v2-6/o1）与能力门控由后续片接入。
+各视频模型能力按 ``_KLING_VIDEO_CAPS`` 表驱动（官方一手核实）：
+- ``kling-v2-5-turbo``：文/图生视频含首尾帧，无音频/参考（默认 model）。
+- ``kling-v3`` / ``kling-v3-omni``：旗舰，首尾帧 + 4K（``mode="4k"``）；v3-omni 多图主体 R2V。
+- ``kling-v2-6``：pro 档支持视频内人声（``enable_audio``）。
+- ``kling-video-o1``：图生 + 多图主体 R2V。
+未登记 model（bearer 透传原生 model_name）回落保守默认能力。
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
@@ -64,7 +69,77 @@ DEFAULT_MODEL = "kling-v2-5-turbo"
 
 _TEXT2VIDEO = "text2video"
 _IMAGE2VIDEO = "image2video"
-_RESUMABLE_SUBPATHS = frozenset({_TEXT2VIDEO, _IMAGE2VIDEO})
+_MULTI_IMAGE2VIDEO = "multi-image2video"
+_RESUMABLE_SUBPATHS = frozenset({_TEXT2VIDEO, _IMAGE2VIDEO, _MULTI_IMAGE2VIDEO})
+
+# 多图主体（R2V）参考图上限保守值；同时声明于 registry ModelInfo（编排层裁剪读它）与
+# backend caps（生成时防御）。待 app.klingai.com 控制台核对，不硬编当既成事实。
+_R2V_MAX_REFERENCE_IMAGES = 4
+
+
+@dataclass(frozen=True)
+class _KlingVideoModelCaps:
+    """单个可灵视频模型的能力位（官方一手核实）。"""
+
+    text_to_video: bool
+    image_to_video: bool
+    last_frame: bool
+    reference_images: bool
+    max_reference_images: int
+    generate_audio: bool  # 能产出视频内人声；官方仅 v2-6（pro 档）标 ✅
+    audio_param: bool  # 请求体是否带 enable_audio：v3 代默认有声需显式压制，旧档无此字段
+
+
+# turbo / 未登记 model（bearer 透传原生 model_name）兜底：文/图生视频、首尾帧，无音频/参考。
+_DEFAULT_VIDEO_CAPS = _KlingVideoModelCaps(
+    text_to_video=True,
+    image_to_video=True,
+    last_frame=True,
+    reference_images=False,
+    max_reference_images=0,
+    generate_audio=False,
+    audio_param=False,
+)
+
+_KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
+    "kling-v2-5-turbo": _DEFAULT_VIDEO_CAPS,
+    "kling-v3": _KlingVideoModelCaps(
+        text_to_video=True,
+        image_to_video=True,
+        last_frame=True,
+        reference_images=False,
+        max_reference_images=0,
+        generate_audio=False,
+        audio_param=True,
+    ),
+    "kling-v3-omni": _KlingVideoModelCaps(
+        text_to_video=True,
+        image_to_video=True,
+        last_frame=True,
+        reference_images=True,
+        max_reference_images=_R2V_MAX_REFERENCE_IMAGES,
+        generate_audio=False,
+        audio_param=True,
+    ),
+    "kling-v2-6": _KlingVideoModelCaps(
+        text_to_video=True,
+        image_to_video=True,
+        last_frame=True,
+        reference_images=False,
+        max_reference_images=0,
+        generate_audio=True,
+        audio_param=True,
+    ),
+    "kling-video-o1": _KlingVideoModelCaps(
+        text_to_video=False,
+        image_to_video=True,
+        last_frame=True,
+        reference_images=True,
+        max_reference_images=_R2V_MAX_REFERENCE_IMAGES,
+        generate_audio=False,
+        audio_param=False,
+    ),
+}
 
 _MIN_POLL_TIMEOUT_SECONDS = 900.0
 _POLL_TIMEOUT_PER_SECOND = 60.0
@@ -118,11 +193,8 @@ class KlingVideoBackend:
         else:
             raise ValueError(f"未知 Kling auth_mode: {auth_mode}")
 
-        # turbo：文生 + 图生视频（首尾帧 pro），无参考图/音频。
-        self._capabilities: set[VideoCapability] = {
-            VideoCapability.TEXT_TO_VIDEO,
-            VideoCapability.IMAGE_TO_VIDEO,
-        }
+        # 按 model 取能力位；未登记 model（bearer 透传）回落保守默认。
+        self._caps = _KLING_VIDEO_CAPS.get(self._model, _DEFAULT_VIDEO_CAPS)
 
     @property
     def name(self) -> str:
@@ -134,12 +206,26 @@ class KlingVideoBackend:
 
     @property
     def capabilities(self) -> set[VideoCapability]:
-        return self._capabilities
+        caps: set[VideoCapability] = set()
+        if self._caps.text_to_video:
+            caps.add(VideoCapability.TEXT_TO_VIDEO)
+        if self._caps.image_to_video:
+            caps.add(VideoCapability.IMAGE_TO_VIDEO)
+        if self._caps.generate_audio:
+            caps.add(VideoCapability.GENERATE_AUDIO)
+        return caps
 
     @property
     def video_capabilities(self) -> VideoCapabilities:
-        # turbo 支持首尾帧（pro），不建模参考图（多图主体留 v3-omni/o1）。
-        return VideoCapabilities(first_frame=True, last_frame=True)
+        # first_frame 恒真（各档均支持 i2v 首帧）；last_frame / reference_images / 上限按 model。
+        # max_reference_images 同时声明于 registry ModelInfo（编排层裁剪读它）与此处（生成时防御），
+        # 取保守值、待 app.klingai.com 控制台核对。
+        return VideoCapabilities(
+            first_frame=True,
+            last_frame=self._caps.last_frame,
+            reference_images=self._caps.reference_images,
+            max_reference_images=self._caps.max_reference_images,
+        )
 
     # ── auth ────────────────────────────────────────────────────────────
 
@@ -152,26 +238,64 @@ class KlingVideoBackend:
 
     # ── request building ────────────────────────────────────────────────
 
+    def _resolve_mode(self, request: VideoGenerationRequest) -> str:
+        """质量档 → mode：resolution=4k 独立成 ``4k`` 档（仅 v3/v3-omni 可达），否则 service_tier→std/pro。
+
+        与 per_second_tiered 定价的档位派生一致（4k 优先于 std/pro），保证请求档与计费档同源。
+        """
+        if (request.resolution or "").lower() == "4k":
+            return "4k"
+        return "pro" if (request.service_tier or "").lower() == "pro" else "std"
+
+    def _effective_audio(self, request: VideoGenerationRequest) -> bool:
+        """实际是否产出视频内人声：请求要 + model 有 generate_audio 能力 + pro 档（官方仅 v2-6 pro ✅）。
+
+        无能力的 model 恒 False——不被错配有声价（下游 pricing 取 ``result.generate_audio``）。
+        """
+        return bool(request.generate_audio and self._caps.generate_audio and self._resolve_mode(request) == "pro")
+
+    @staticmethod
+    def _valid_frames(images: list[Path] | None) -> list[Path]:
+        """过滤出有效（非空）参考图路径；空 / None 归空列表。"""
+        if not images:
+            return []
+        return [Path(img) for img in images if str(img)]
+
     def _build_payload(self, request: VideoGenerationRequest) -> tuple[str, dict]:
-        """返回 (子路径, 请求体)。无首帧 → text2video；有首帧 → image2video（含可选尾帧）。"""
-        mode = "pro" if (request.service_tier or "").lower() == "pro" else "std"
+        """返回 (子路径, 请求体)。
+
+        子路径优先级：有 reference_images → multi-image2video（多图主体 R2V）；
+        有 start_image → image2video（含可选尾帧）；都无 → text2video。
+        """
         payload: dict = {
             "model_name": self._model,
             "prompt": request.prompt,
-            "mode": mode,
+            "mode": self._resolve_mode(request),
             "duration": str(request.duration_seconds),
             "aspect_ratio": request.aspect_ratio,
         }
 
+        reference_images = self._valid_frames(request.reference_images)
+        if reference_images:
+            # 多图主体：image_list 为 [{"image": <base64>}]（可灵原生 schema），无单首帧概念。
+            payload["image_list"] = [{"image": self._encode_frame(p)} for p in reference_images]
+            return _MULTI_IMAGE2VIDEO, payload
+
         start_image = request.start_image
         if not (isinstance(start_image, (str, Path)) and str(start_image)):
-            return _TEXT2VIDEO, payload
+            subpath = _TEXT2VIDEO
+        else:
+            payload["image"] = self._encode_frame(Path(start_image))
+            end_image = request.end_image
+            if isinstance(end_image, (str, Path)) and str(end_image):
+                payload["image_tail"] = self._encode_frame(Path(end_image))
+            subpath = _IMAGE2VIDEO
 
-        payload["image"] = self._encode_frame(Path(start_image))
-        end_image = request.end_image
-        if isinstance(end_image, (str, Path)) and str(end_image):
-            payload["image_tail"] = self._encode_frame(Path(end_image))
-        return _IMAGE2VIDEO, payload
+        # enable_audio 仅 text2video / image2video 子路径携带（multi-image2video 原生 schema 不含）；
+        # v3 代默认有声，无能力 model 在此显式压制为 False，有能力的 v2-6（pro）按需开启。
+        if self._caps.audio_param:
+            payload["enable_audio"] = self._effective_audio(request)
+        return subpath, payload
 
     def _encode_frame(self, path: Path) -> str:
         # fail-loud：声明了帧图却缺失/不可读即中止，不静默退化（会产出错误结果且照常计费）。
@@ -189,14 +313,17 @@ class KlingVideoBackend:
         base64 帧图 / prompt 一律不展开：仅记是否存在 + prompt 长度。
         """
         prompt = payload.get("prompt")
+        image_list = payload.get("image_list")
         return {
             "endpoint": subpath,
             "model_name": payload.get("model_name"),
             "mode": payload.get("mode"),
             "duration": payload.get("duration"),
             "aspect_ratio": payload.get("aspect_ratio"),
+            "enable_audio": bool(payload.get("enable_audio")),
             "has_image": "image" in payload,
             "has_image_tail": "image_tail" in payload,
+            "reference_count": len(image_list) if isinstance(image_list, list) else 0,
             "prompt_len": len(prompt) if isinstance(prompt, str) else 0,
         }
 
@@ -204,6 +331,7 @@ class KlingVideoBackend:
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         subpath, payload = self._build_payload(request)
+        generate_audio = self._effective_audio(request)
         logger.info("调用 Kling 视频 API payload=%s", self._safe_log_view(subpath, payload))
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             task_id = await self._create_task(client, subpath, payload)
@@ -213,7 +341,7 @@ class KlingVideoBackend:
                 await persist_provider_job_id(
                     request.task_id, _encode_job_id(subpath, task_id), provider=PROVIDER_KLING
                 )
-            return await self._poll_and_build(client, subpath, task_id, request)
+            return await self._poll_and_build(client, subpath, task_id, request, generate_audio=generate_audio)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
         """接续已 submit 的 Kling task：仅轮询 + 取 url + 下载，不重新提交（ADR 0007）。
@@ -222,8 +350,9 @@ class KlingVideoBackend:
         而 resume 请求已无 ``start_image`` 可推断，故不能再从 request 取（见 _encode_job_id）。
         """
         subpath, task_id = _decode_job_id(job_id)
+        generate_audio = self._effective_audio(request)
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
-            return await self._poll_and_build(client, subpath, task_id, request)
+            return await self._poll_and_build(client, subpath, task_id, request, generate_audio=generate_audio)
 
     # ── HTTP submit / poll / download ───────────────────────────────────
 
@@ -259,6 +388,8 @@ class KlingVideoBackend:
         subpath: str,
         task_id: str,
         request: VideoGenerationRequest,
+        *,
+        generate_audio: bool,
     ) -> VideoGenerationResult:
         final = await poll_with_retry(
             poll_fn=lambda: self._poll_query(client, subpath, task_id),
@@ -286,8 +417,8 @@ class KlingVideoBackend:
             duration_seconds=request.duration_seconds,
             video_uri=download_url,
             task_id=task_id,
-            # turbo 无音频能力：恒报无声，下游计费取无声价。
-            generate_audio=False,
+            # audio 门控后的实际有声标志（下游 finish_call 取它定有声/无声价）。
+            generate_audio=generate_audio,
         )
 
     @staticmethod

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -599,6 +599,42 @@ class TestVideoCapabilities:
             await engine.dispose()
         assert caps["max_reference_images"] == 9
 
+    async def test_max_reference_images_reads_model_info_for_kling_v3_omni(self):
+        """kling-v3-omni（多图主体 R2V）的 max_reference_images 来自 registry ModelInfo（=4，保守值）；
+
+        编排层据此裁剪参考图数量——内置 provider 经此值而非 backend caps 拿到上限。
+        """
+        factory, engine = await _make_session()
+        try:
+            resolver = ConfigResolver(factory)
+            with patch("lib.config.resolver.get_project_manager"):
+                caps = await resolver.video_capabilities_for_project({"video_backend": "kling/kling-v3-omni"})
+        finally:
+            await engine.dispose()
+        assert caps["max_reference_images"] == 4
+
+    async def test_max_reference_images_reads_model_info_for_kling_video_o1(self):
+        """kling-video-o1（多图主体 R2V）的 max_reference_images 来自 registry ModelInfo（=4，保守值）。"""
+        factory, engine = await _make_session()
+        try:
+            resolver = ConfigResolver(factory)
+            with patch("lib.config.resolver.get_project_manager"):
+                caps = await resolver.video_capabilities_for_project({"video_backend": "kling/kling-video-o1"})
+        finally:
+            await engine.dispose()
+        assert caps["max_reference_images"] == 4
+
+    async def test_kling_v3_non_reference_model_has_zero_max_refs(self):
+        """kling-v3（声明 4K + 首尾帧但非多图主体）max_reference_images=0，不误报参考能力。"""
+        factory, engine = await _make_session()
+        try:
+            resolver = ConfigResolver(factory)
+            with patch("lib.config.resolver.get_project_manager"):
+                caps = await resolver.video_capabilities_for_project({"video_backend": "kling/kling-v3"})
+        finally:
+            await engine.dispose()
+        assert caps["max_reference_images"] == 0
+
     async def test_custom_provider_reads_db_supported_durations(self):
         """custom-<id>/<model> 走 DB 分支，返回 source='custom'。"""
         from lib.db.models.custom_provider import CustomProvider, CustomProviderModel

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -234,6 +234,47 @@ class TestMultiImageSubpath:
         assert exc.value.code == "video_start_image_unreadable"
 
 
+class TestCapabilityValidation:
+    """生成时防御：能力不匹配的请求 fail-loud，不发出必然报错且照常计费的调用。"""
+
+    @staticmethod
+    def _refs(tmp_path: Path, n: int) -> list[Path]:
+        paths: list[Path] = []
+        for i in range(n):
+            p = tmp_path / f"ref{i}.png"
+            p.write_bytes(b"\x89PNG\r\n" + bytes([i]))
+            paths.append(p)
+        return paths
+
+    def test_reference_images_on_unsupported_model_raises(self, tmp_path):
+        # kling-v3 未声明多图主体能力：带参考图即拒绝，不误升级到 multi-image2video 子路径
+        with pytest.raises(VideoCapabilityError) as exc:
+            _jwt_backend("kling-v3")._build_payload(_request(tmp_path, reference_images=self._refs(tmp_path, 1)))
+        assert exc.value.code == "video_reference_images_unsupported"
+
+    def test_reference_images_over_limit_raises(self, tmp_path):
+        # v3-omni 上限 4：传 5 张即拒绝
+        with pytest.raises(VideoCapabilityError) as exc:
+            _jwt_backend("kling-v3-omni")._build_payload(_request(tmp_path, reference_images=self._refs(tmp_path, 5)))
+        assert exc.value.code == "video_reference_images_exceeded"
+        assert exc.value.params["limit"] == 4
+        assert exc.value.params["count"] == 5
+
+    def test_text2video_on_model_without_t2v_raises(self, tmp_path):
+        # kling-video-o1 不支持文生视频：无首帧/无参考即拒绝，不回落 text2video 子路径
+        with pytest.raises(VideoCapabilityError) as exc:
+            _jwt_backend("kling-video-o1")._build_payload(_request(tmp_path))
+        assert exc.value.code == "video_capability_missing_t2v"
+
+    def test_reference_at_limit_allowed(self, tmp_path):
+        # 恰好达上限（4 张）放行
+        subpath, payload = _jwt_backend("kling-v3-omni")._build_payload(
+            _request(tmp_path, reference_images=self._refs(tmp_path, 4))
+        )
+        assert subpath == "multi-image2video"
+        assert len(payload["image_list"]) == 4
+
+
 class TestAuthHeaders:
     def test_jwt_mode_signs_bearer_token(self):
         headers = _jwt_backend()._headers()
@@ -402,8 +443,8 @@ class TestGenerateHappyPath:
             await _jwt_backend().generate(_request(tmp_path, task_id="local-task-1"))
         persist.assert_awaited_once()
         assert persist.await_args is not None
-        # 持久化的是「子路径:task_id」，resume 据此复原查询端点（text2video 因无首帧）
-        assert persist.await_args.args[1] == "text2video:task-x"
+        # 持久化的是「子路径:task_id:有声标志」，resume 据此复原查询端点（text2video 因无首帧）+ 有声决策（turbo 恒 0）
+        assert persist.await_args.args[1] == "text2video:task-x:0"
 
     async def test_persists_image2video_subpath_in_job_id(self, tmp_path):
         img = tmp_path / "first.png"
@@ -420,7 +461,7 @@ class TestGenerateHappyPath:
             await _jwt_backend().generate(_request(tmp_path, task_id="local-task-2", start_image=img))
         # 有首帧 → image2video 前缀编入 job_id，resume 才能查对端点
         assert persist.await_args is not None
-        assert persist.await_args.args[1] == "image2video:task-i"
+        assert persist.await_args.args[1] == "image2video:task-i:0"
 
 
 class TestResume:
@@ -519,3 +560,52 @@ class TestAudioGatingResult:
                 _request(tmp_path, service_tier="pro", generate_audio=True)
             )
         assert result.generate_audio is False
+
+    async def test_v2_6_pro_persists_audio_bit_in_job_id(self, tmp_path):
+        # submit 时算定的有声决策编入 job_id（v2-6 pro 有声 → 末段 :1），resume 据此直连计费
+        post = AsyncMock(return_value=_resp(_submit("task-c")))
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+            patch("lib.video_backends.kling.persist_provider_job_id", new=AsyncMock()) as persist,
+        ):
+            await _jwt_backend("kling-v2-6").generate(
+                _request(tmp_path, task_id="local-a", service_tier="pro", generate_audio=True)
+            )
+        assert persist.await_args is not None
+        assert persist.await_args.args[1] == "text2video:task-c:1"
+
+    async def test_resume_reuses_persisted_audio_over_recompute(self, tmp_path):
+        # 持久化有声标志（:1）优先于 resume 时按请求重算：即使请求 generate_audio=False，
+        # 结果仍取 submit 时算定的有声（避免计费漂移）
+        post = AsyncMock()
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            result = await _jwt_backend("kling-v2-6").resume_video(
+                "text2video:task-c:1", _request(tmp_path, service_tier="pro", generate_audio=False)
+            )
+        post.assert_not_called()
+        assert result.generate_audio is True
+
+    async def test_resume_legacy_job_id_recomputes_audio(self, tmp_path):
+        # 旧 job_id（2 段，未持久化有声标志）回落按请求重算
+        post = AsyncMock()
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            result = await _jwt_backend("kling-v2-6").resume_video(
+                "text2video:task-c", _request(tmp_path, service_tier="pro", generate_audio=True)
+            )
+        assert result.generate_audio is True

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -95,8 +95,143 @@ class TestConstructionAndCapabilities:
         caps = _jwt_backend().video_capabilities
         assert caps.first_frame is True
         assert caps.last_frame is True
-        # turbo 不建模参考图（多图主体留后续片）
+        # turbo 不建模参考图（多图主体留 v3-omni/o1）
         assert caps.reference_images is False
+        assert caps.max_reference_images == 0
+
+
+class TestPerModelCapabilities:
+    def test_v3_t2v_i2v_no_audio_no_reference(self):
+        b = _jwt_backend("kling-v3")
+        assert b.capabilities == {VideoCapability.TEXT_TO_VIDEO, VideoCapability.IMAGE_TO_VIDEO}
+        vc = b.video_capabilities
+        assert vc.first_frame is True and vc.last_frame is True
+        assert vc.reference_images is False and vc.max_reference_images == 0
+
+    def test_v3_omni_declares_reference_images(self):
+        b = _jwt_backend("kling-v3-omni")
+        assert b.capabilities == {VideoCapability.TEXT_TO_VIDEO, VideoCapability.IMAGE_TO_VIDEO}
+        vc = b.video_capabilities
+        assert vc.reference_images is True
+        assert vc.max_reference_images == 4  # 保守值，待控制台核对
+
+    def test_v2_6_declares_generate_audio_no_reference(self):
+        b = _jwt_backend("kling-v2-6")
+        assert VideoCapability.GENERATE_AUDIO in b.capabilities
+        assert VideoCapability.TEXT_TO_VIDEO in b.capabilities
+        assert b.video_capabilities.reference_images is False
+
+    def test_video_o1_i2v_only_with_reference_images(self):
+        b = _jwt_backend("kling-video-o1")
+        # 仅图生（无 t2v），多图主体 R2V
+        assert b.capabilities == {VideoCapability.IMAGE_TO_VIDEO}
+        vc = b.video_capabilities
+        assert vc.last_frame is True
+        assert vc.reference_images is True and vc.max_reference_images == 4
+
+    def test_unknown_model_falls_back_to_default_caps(self):
+        # bearer 透传原生 model_name：未登记 → 保守默认（t2v+i2v、首尾帧、无音频/参考）
+        b = _bearer_backend("kling-some-passthrough")
+        assert b.capabilities == {VideoCapability.TEXT_TO_VIDEO, VideoCapability.IMAGE_TO_VIDEO}
+        vc = b.video_capabilities
+        assert vc.last_frame is True
+        assert vc.reference_images is False and vc.max_reference_images == 0
+
+
+class TestModeAndResolution:
+    def test_resolution_4k_maps_to_mode_4k(self, tmp_path):
+        _, payload = _jwt_backend("kling-v3")._build_payload(_request(tmp_path, resolution="4k"))
+        assert payload["mode"] == "4k"
+
+    def test_resolution_4k_case_insensitive(self, tmp_path):
+        _, payload = _jwt_backend("kling-v3-omni")._build_payload(_request(tmp_path, resolution="4K"))
+        assert payload["mode"] == "4k"
+
+    def test_4k_overrides_service_tier(self, tmp_path):
+        # 4k 档优先于 std/pro（与 per_second_tiered 档位派生一致）
+        _, payload = _jwt_backend("kling-v3")._build_payload(_request(tmp_path, resolution="4k", service_tier="pro"))
+        assert payload["mode"] == "4k"
+
+    def test_non_4k_resolution_keeps_service_tier_mode(self, tmp_path):
+        _, payload = _jwt_backend("kling-v3")._build_payload(_request(tmp_path, resolution="1080p", service_tier="pro"))
+        assert payload["mode"] == "pro"
+
+
+class TestAudioGating:
+    def test_v2_6_pro_audio_enabled(self, tmp_path):
+        _, payload = _jwt_backend("kling-v2-6")._build_payload(
+            _request(tmp_path, service_tier="pro", generate_audio=True)
+        )
+        assert payload["enable_audio"] is True
+
+    def test_v2_6_std_audio_forced_off(self, tmp_path):
+        # 人声仅 pro 档：std 即使请求有声也压制为无声
+        _, payload = _jwt_backend("kling-v2-6")._build_payload(
+            _request(tmp_path, service_tier="std", generate_audio=True)
+        )
+        assert payload["enable_audio"] is False
+
+    def test_v3_audio_capability_absent_forced_off(self, tmp_path):
+        # 无 generate_audio 能力的 model：即使请求有声，enable_audio 强制 False（压制 v3 默认有声）
+        _, payload = _jwt_backend("kling-v3")._build_payload(
+            _request(tmp_path, service_tier="pro", generate_audio=True)
+        )
+        assert payload["enable_audio"] is False
+
+    def test_turbo_omits_enable_audio_field(self, tmp_path):
+        # 旧档无 enable_audio 字段：不携带，避免向不支持的端点发未知参数
+        _, payload = _jwt_backend()._build_payload(_request(tmp_path, generate_audio=True))
+        assert "enable_audio" not in payload
+
+
+class TestMultiImageSubpath:
+    @staticmethod
+    def _refs(tmp_path: Path, n: int) -> list[Path]:
+        paths: list[Path] = []
+        for i in range(n):
+            p = tmp_path / f"ref{i}.png"
+            p.write_bytes(b"\x89PNG\r\n" + bytes([i]))
+            paths.append(p)
+        return paths
+
+    def test_reference_images_select_multi_image2video(self, tmp_path):
+        refs = self._refs(tmp_path, 2)
+        subpath, payload = _jwt_backend("kling-v3-omni")._build_payload(_request(tmp_path, reference_images=refs))
+        assert subpath == "multi-image2video"
+        # image_list 为 [{"image": <base64>}] 形态，无单首帧
+        assert isinstance(payload["image_list"], list) and len(payload["image_list"]) == 2
+        assert all(set(e) == {"image"} and isinstance(e["image"], str) and e["image"] for e in payload["image_list"])
+        assert not payload["image_list"][0]["image"].startswith("data:")
+        assert "image" not in payload and "image_tail" not in payload
+
+    def test_multi_image2video_omits_enable_audio(self, tmp_path):
+        refs = self._refs(tmp_path, 1)
+        _, payload = _jwt_backend("kling-v3-omni")._build_payload(
+            _request(tmp_path, reference_images=refs, service_tier="pro", generate_audio=True)
+        )
+        # multi-image2video 原生 schema 不含 enable_audio
+        assert "enable_audio" not in payload
+
+    def test_reference_images_take_precedence_over_start_image(self, tmp_path):
+        refs = self._refs(tmp_path, 1)
+        start = tmp_path / "start.png"
+        start.write_bytes(b"\x89PNG\r\n")
+        subpath, payload = _jwt_backend("kling-video-o1")._build_payload(
+            _request(tmp_path, reference_images=refs, start_image=start)
+        )
+        assert subpath == "multi-image2video"
+        assert "image_list" in payload
+
+    def test_empty_reference_images_falls_through(self, tmp_path):
+        subpath, _ = _jwt_backend("kling-v3-omni")._build_payload(_request(tmp_path, reference_images=[]))
+        assert subpath == "text2video"
+
+    def test_unreadable_reference_image_raises(self, tmp_path):
+        with pytest.raises(VideoCapabilityError) as exc:
+            _jwt_backend("kling-v3-omni")._build_payload(
+                _request(tmp_path, reference_images=[tmp_path / "missing.png"])
+            )
+        assert exc.value.code == "video_start_image_unreadable"
 
 
 class TestAuthHeaders:
@@ -336,3 +471,51 @@ class TestResume:
             result = await _jwt_backend().resume_video("legacy-bare-id", _request(tmp_path))
         assert result.task_id == "legacy-bare-id"
         assert get.await_args.args[0].endswith("/videos/text2video/legacy-bare-id")
+
+    async def test_resume_multi_image2video_subpath_from_encoded_job_id(self, tmp_path):
+        # 多图主体任务 resume：子路径从持久化 job_id 前缀复原，查 multi-image2video 端点。
+        post = AsyncMock()
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            result = await _jwt_backend("kling-v3-omni").resume_video("multi-image2video:task-m", _request(tmp_path))
+        post.assert_not_called()
+        assert result.task_id == "task-m"
+        assert get.await_args.args[0].endswith("/videos/multi-image2video/task-m")
+
+
+class TestAudioGatingResult:
+    async def test_v2_6_pro_audio_result_true(self, tmp_path):
+        # v2-6 pro + 请求有声 → result.generate_audio=True（下游计费取有声价 ¥1/s）
+        post = AsyncMock(return_value=_resp(_submit("task-a")))
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            result = await _jwt_backend("kling-v2-6").generate(
+                _request(tmp_path, service_tier="pro", generate_audio=True)
+            )
+        assert result.generate_audio is True
+        assert post.await_args.args[0].endswith("/videos/text2video")
+
+    async def test_v3_audio_gated_result_false(self, tmp_path):
+        # v3 无音频能力：即使请求有声，result.generate_audio=False（计费取无声价）
+        post = AsyncMock(return_value=_resp(_submit("task-b")))
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            result = await _jwt_backend("kling-v3").generate(
+                _request(tmp_path, service_tier="pro", generate_audio=True)
+            )
+        assert result.generate_audio is False

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -594,6 +594,9 @@ class TestAudioGatingResult:
             )
         post.assert_not_called()
         assert result.generate_audio is True
+        # 锁定解析契约：3 段 job_id 的有声末段不得漏进 task_id，子路径/任务号须正确复原
+        assert result.task_id == "task-c"
+        assert get.await_args.args[0].endswith("/videos/text2video/task-c")
 
     async def test_resume_legacy_job_id_recomputes_audio(self, tmp_path):
         # 旧 job_id（2 段，未持久化有声标志）回落按请求重算
@@ -608,4 +611,8 @@ class TestAudioGatingResult:
             result = await _jwt_backend("kling-v2-6").resume_video(
                 "text2video:task-c", _request(tmp_path, service_tier="pro", generate_audio=True)
             )
+        post.assert_not_called()
         assert result.generate_audio is True
+        # 2 段旧 job_id 同样须正确复原子路径/任务号（不误把整串当 task_id）
+        assert result.task_id == "task-c"
+        assert get.await_args.args[0].endswith("/videos/text2video/task-c")

--- a/tests/test_pricing_strategies.py
+++ b/tests/test_pricing_strategies.py
@@ -536,3 +536,42 @@ class TestPerSecondTiered:
             PricingParams(call_type="video", model="kling-v2-5-turbo", service_tier="std", generate_audio=False),
         )
         assert amount == pytest.approx(0.6 * 8)
+
+
+class TestKlingRegistryPricingReachability:
+    """各可灵视频模型经 registry 真实 pricing 触达 per_second_tiered 档位。
+
+    验证 4K 档（¥3/s，仅 v3/v3-omni 可达）与 (pro,有声) 档（¥1/s，仅 v2-6）实际命中——
+    全部 video 模型共享同一档位矩阵（_kling_video_pricing 复用 _KLING_VIDEO_TIERED_RATES）。
+    """
+
+    @staticmethod
+    def _amount(model: str, **params):
+        from lib.config.registry import PROVIDER_REGISTRY
+
+        pricing = PROVIDER_REGISTRY["kling"].models[model].pricing
+        assert pricing is not None
+        return calculate_pricing(pricing, PricingParams(call_type="video", model=model, **params))
+
+    def test_v3_omni_4k_tier_reached(self):
+        amount, currency = self._amount(
+            "kling-v3-omni", resolution="4k", duration_seconds=5, generate_audio=False, service_tier="std"
+        )
+        assert currency == "CNY"
+        assert amount == pytest.approx(3.0 * 5)
+
+    def test_v3_4k_tier_reached(self):
+        amount, _ = self._amount("kling-v3", resolution="4k", duration_seconds=5, generate_audio=True)
+        assert amount == pytest.approx(3.0 * 5)  # 4k 档忽略 audio
+
+    def test_v2_6_pro_audio_tier_reached(self):
+        amount, _ = self._amount("kling-v2-6", service_tier="pro", generate_audio=True, duration_seconds=5)
+        assert amount == pytest.approx(1.0 * 5)
+
+    def test_v2_6_pro_silent_tier(self):
+        amount, _ = self._amount("kling-v2-6", service_tier="pro", generate_audio=False, duration_seconds=5)
+        assert amount == pytest.approx(0.8 * 5)
+
+    def test_video_o1_std_silent_baseline(self):
+        amount, _ = self._amount("kling-video-o1", service_tier="std", generate_audio=False, duration_seconds=5)
+        assert amount == pytest.approx(0.6 * 5)


### PR DESCRIPTION
## 背景

可灵 Kling 内置 provider 接入第三片（视频侧）。在已接入的 JWT 直连视频后端与默认模型 2.5 Turbo 之上，补齐其余视频模型与能力：旗舰画质、视频内人声、参考生视频（R2V）。

## 改动

- **新增 4 个视频模型**（registry + 后端能力表同步声明）：
  - `kling-v3` / `kling-v3-omni`：文/图生视频、首尾帧、**4K** 画质；v3-omni 支持**多图主体**（R2V）
  - `kling-v2-6`：文/图生视频，**pro 档支持视频内人声**
  - `kling-video-o1`：图生视频 + 多图主体（R2V）
- **音频门控**：无人声能力的模型即使请求开启人声，实际请求强制无声、按无声价计费；人声仅 v2-6 pro 档实际产出。
- **画质档定价**：4K 档 ¥3/s、(pro, 有声) ¥1/s 等档位经各模型真实定价实际触达；请求档与计费档同源派生（4K 优先于 std/pro）。
- **子路径选择**：无图 → 文生视频；有首帧 → 图生视频（含可选尾帧）；有参考图 → 多图主体生视频。
- **参考图上限**：在后端能力与 registry 模型信息同步声明保守占位值（待官方控制台核对），编排层据此裁剪参考图数量；不引入已退役的止血条目。

## 验证

- 后端全量测试 `uv run pytest tests/`：4983 passed（唯一失败 `test_default_when_unresolvable` 为本机 dev DB 环境耦合，CI 干净库通过，非本片回归）
- `ruff check` + `ruff format` 净、`basedpyright` 0 error
- 新增覆盖：每模型能力位、4K/档位映射、音频门控（请求体与计费结果两端）、多图主体子路径、resume 复原子路径、各模型定价档位触达

Closes #835


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 扩展 Kling 视频模型能力与默认覆盖范围，新增 `kling-v3`、`kling-v3-omni`（4 张多主体参考图上限）、`kling-v2-6`（支持人声能力）、`kling-video-o1`（多主体参考图生成）。
- **改进**
  - 强化分辨率/服务档位到生成模式的映射；支持多主体参考图生成路径与数量上限校验。
  - 细化音频开关门控，并在生成与续传中保持一致；续传会复用先前的音频决策。
- **国际化**
  - 新增视频参考图能力相关的中英越错误提示。
- **测试**
  - 补充模型能力、请求构建、音频门控、续传与计费可达性的覆盖用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->