### PR TITLE
feat(kling): 自定义供应商可直连可灵 Kling 原生图像与视频生成

### DIFF
--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -808,6 +808,8 @@ export default {
   'endpoint_dashscope_async_video_display': 'Alibaba Model Studio (Async Video)',
   'endpoint_minimax_image_display': 'MiniMax (Image)',
   'endpoint_minimax_video_display': 'MiniMax Hailuo (Video)',
+  'endpoint_kling_image_display': 'Kling (Image)',
+  'endpoint_kling_video_display': 'Kling (Video)',
   'endpoint_openai_tts_display': 'OpenAI Speech (TTS)',
   'endpoint_catalog_loading': 'Loading endpoint catalog…',
   // Image Capability

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -785,6 +785,8 @@ export default {
   'endpoint_dashscope_async_video_display': 'Alibaba Model Studio (Video bất đồng bộ)',
   'endpoint_minimax_image_display': 'MiniMax (Ảnh)',
   'endpoint_minimax_video_display': 'MiniMax Hailuo (Video)',
+  'endpoint_kling_image_display': 'Kling (Ảnh)',
+  'endpoint_kling_video_display': 'Kling (Video)',
   'endpoint_openai_tts_display': 'OpenAI Giọng nói (TTS)',
   'endpoint_catalog_loading': 'Đang tải danh mục endpoint…',
   // Image Capability

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -809,6 +809,8 @@ export default {
   'endpoint_dashscope_async_video_display': '阿里百炼（异步视频）',
   'endpoint_minimax_image_display': 'MiniMax（图片）',
   'endpoint_minimax_video_display': 'MiniMax 海螺（视频）',
+  'endpoint_kling_image_display': '可灵 Kling（图片）',
+  'endpoint_kling_video_display': '可灵 Kling（视频）',
   'endpoint_openai_tts_display': 'OpenAI 语音合成 (TTS)',
   'endpoint_catalog_loading': '加载端点目录…',
   // Image Capability

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -407,11 +407,12 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         family="kling",
         display_name_key="endpoint_kling_video_display",
         request_method="POST",
-        # 无首帧走 text2video、有首帧走 image2video（含可选尾帧），brace 表达两条路径
-        request_path_template="/v1/videos/{text2video,image2video}",
+        # 无首帧走 text2video、有首帧走 image2video（含可选尾帧）、有多图主体走 multi-image2video（R2V）
+        request_path_template="/v1/videos/{text2video,image2video,multi-image2video}",
         build_backend=_build_kling_video,
-        # 可灵视频走首尾帧、不接受参考图数组 → 显式 0（与 newapi-video 同构）。
-        video_max_reference_images=0,
+        # 参考图上限随 model 异质（v3-omni / video-o1 多图主体 R2V max=4，其余首尾帧无参考为 0）→ 不在
+        # endpoint 维度声明 int cap，按 model 读 backend 纯 caps 函数（与 minimax-video 同构）。
+        video_caps_for_model=KlingVideoBackend.video_capabilities_for_model,
     ),
 }
 

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -25,6 +25,7 @@ from lib.custom_provider.backends import (
 from lib.image_backends.base import ImageCapability
 from lib.image_backends.dashscope import DashScopeImageBackend
 from lib.image_backends.gemini import GeminiImageBackend
+from lib.image_backends.kling import KlingImageBackend
 from lib.image_backends.minimax import MiniMaxImageBackend
 from lib.image_backends.openai import OpenAIImageBackend
 from lib.text_backends.gemini import GeminiTextBackend
@@ -32,6 +33,7 @@ from lib.text_backends.openai import OpenAITextBackend
 from lib.video_backends.ark import ArkVideoBackend
 from lib.video_backends.base import VideoCapabilities
 from lib.video_backends.dashscope import DashScopeVideoBackend
+from lib.video_backends.kling import KlingVideoBackend
 from lib.video_backends.minimax import MiniMaxVideoBackend
 from lib.video_backends.newapi import NewAPIVideoBackend
 from lib.video_backends.openai import OpenAIVideoBackend
@@ -148,8 +150,8 @@ def _build_newapi_video(provider, model_id: str) -> CustomVideoBackend:
 
 
 def _ensure_url_path_suffix(base_url: str | None, suffix: str) -> str | None:
-    """用户只填到 host 时补全协议已知挂载路径（ark /api/v3、vidu /ent/v2）；
-    已带显式路径则原样信任，避免错误叠加。供 ark/vidu 闭包复用。
+    """用户只填到 host 时补全协议已知挂载路径（ark /api/v3、vidu /ent/v2、kling /v1）；
+    已带显式路径则原样信任，避免错误叠加。供 ark/vidu/kling 闭包复用。
 
     纯域名（无 scheme，如 ``relay.example.com``）会被 urlsplit 整体当作 path，
     先补 ``https://`` 再判定，否则 host-only 配置既补不上协议也挂不上路径。
@@ -203,6 +205,21 @@ def _build_minimax_image(provider, model_id: str) -> CustomImageBackend:
 def _build_minimax_video(provider, model_id: str) -> CustomVideoBackend:
     # 两步取 URL（submit→轮询 file_id→retrieve download_url）由 MiniMaxVideoBackend 内部处理
     delegate = MiniMaxVideoBackend(api_key=provider.api_key, base_url=provider.base_url, model=model_id)
+    return CustomVideoBackend(provider_id=provider.provider_id, delegate=delegate, model=model_id)
+
+
+def _build_kling_image(provider, model_id: str) -> CustomImageBackend:
+    # 中转站「原样代理可灵」：bearer 模式旁路 JWT 管理器，用静态 api_key 直发可灵原生异步图像端点。
+    # 仅 host 时补全可灵协议挂载路径 /v1（含显式路径则原样信任）；原生 model_name 透传不解耦别名。
+    base_url = _ensure_url_path_suffix(provider.base_url, "/v1")
+    delegate = KlingImageBackend(auth_mode="bearer", api_key=provider.api_key, base_url=base_url, model=model_id)
+    return CustomImageBackend(provider_id=provider.provider_id, delegate=delegate, model=model_id)
+
+
+def _build_kling_video(provider, model_id: str) -> CustomVideoBackend:
+    # 中转站「原样代理可灵」：bearer 模式旁路 JWT 管理器，用静态 api_key 直发可灵原生异步视频端点。
+    base_url = _ensure_url_path_suffix(provider.base_url, "/v1")
+    delegate = KlingVideoBackend(auth_mode="bearer", api_key=provider.api_key, base_url=base_url, model=model_id)
     return CustomVideoBackend(provider_id=provider.provider_id, delegate=delegate, model=model_id)
 
 
@@ -374,6 +391,28 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         # 声明 int cap，按 model 读 backend caps（不构造 client）。
         video_caps_for_model=MiniMaxVideoBackend.video_capabilities_for_model,
     ),
+    "kling-image": EndpointSpec(
+        key="kling-image",
+        media_type="image",
+        family="kling",
+        display_name_key="endpoint_kling_image_display",
+        request_method="POST",
+        request_path_template="/v1/images/generations",
+        image_capabilities=frozenset({ImageCapability.TEXT_TO_IMAGE, ImageCapability.IMAGE_TO_IMAGE}),
+        build_backend=_build_kling_image,
+    ),
+    "kling-video": EndpointSpec(
+        key="kling-video",
+        media_type="video",
+        family="kling",
+        display_name_key="endpoint_kling_video_display",
+        request_method="POST",
+        # 无首帧走 text2video、有首帧走 image2video（含可选尾帧），brace 表达两条路径
+        request_path_template="/v1/videos/{text2video,image2video}",
+        build_backend=_build_kling_video,
+        # 可灵视频走首尾帧、不接受参考图数组 → 显式 0（与 newapi-video 同构）。
+        video_max_reference_images=0,
+    ),
 }
 
 
@@ -487,6 +526,9 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
        dashscope（中转可能是 OpenAI 兼容），qwen-image / wan2.x-image 落到既有图像家族推断。
     2) MiniMax 原生 token → 海螺 / S2V 走 "minimax-video"，image-01 走 "minimax-image"。先于通用
        is_video/is_image 拦截：s2v 不在 _VIDEO_PATTERN、image-01 含 "image" 否则会被推到通用图像家族。
+    2.5) 可灵 kling token → 含 image 语义走 "kling-image"，否则走 "kling-video"。kling 同时命中
+       _VIDEO_PATTERN，须先于通用 is_video 拦截，否则视频会落到 openai-video；v3-omni 图像/视频同名
+       默认归视频、图像手动选。
     3) imagen → "gemini-image"（图像，不论 discovery_format）
     4) gemini 原生模型（非 video）→ image 形态走 "gemini-image"，否则文本走 "gemini-generate"
     5) 视频家族 → seedance→"ark-seedance"、viduq3→"vidu-video"、否则 "openai-video"
@@ -511,6 +553,13 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
         return "minimax-video"
     if "image-01" in lowered:
         return "minimax-image"
+
+    # 可灵原生中转二级路由：kling 同时命中 _VIDEO_PATTERN（含 kling）与（含 image 语义时）
+    # _IMAGE_PATTERN，须在通用 is_video/is_image 之前显式分流——含 image 语义 → kling-image，
+    # 否则 → kling-video。kling-v3-omni 图像/视频同名歧义无法纯靠 token 区分，默认归视频、图像手动选；
+    # 不分 discovery_format（可灵端点各自唯一）。
+    if "kling" in lowered:
+        return "kling-image" if is_image else "kling-video"
 
     # wan2.x-image 含 "wan" 会被 _VIDEO_PATTERN 误判为视频；显式排除让它落到图像家族推断
     is_video = bool(_VIDEO_PATTERN.search(model_id)) and not ("wan2." in lowered and is_image)

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -526,7 +526,8 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
        dashscope（中转可能是 OpenAI 兼容），qwen-image / wan2.x-image 落到既有图像家族推断。
     2) MiniMax 原生 token → 海螺 / S2V 走 "minimax-video"，image-01 走 "minimax-image"。先于通用
        is_video/is_image 拦截：s2v 不在 _VIDEO_PATTERN、image-01 含 "image" 否则会被推到通用图像家族。
-    2.5) 可灵 kling token → 含 image 语义走 "kling-image"，否则走 "kling-video"。kling 同时命中
+    2.5) 可灵 kling token → 含 video 语义优先归 "kling-video"（kling-image2video 等 i2v 含 image
+       语义但本质是视频）；其余含 image 语义走 "kling-image"，否则走 "kling-video"。kling 同时命中
        _VIDEO_PATTERN，须先于通用 is_video 拦截，否则视频会落到 openai-video；v3-omni 图像/视频同名
        默认归视频、图像手动选。
     3) imagen → "gemini-image"（图像，不论 discovery_format）
@@ -555,10 +556,14 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
         return "minimax-image"
 
     # 可灵原生中转二级路由：kling 同时命中 _VIDEO_PATTERN（含 kling）与（含 image 语义时）
-    # _IMAGE_PATTERN，须在通用 is_video/is_image 之前显式分流——含 image 语义 → kling-image，
-    # 否则 → kling-video。kling-v3-omni 图像/视频同名歧义无法纯靠 token 区分，默认归视频、图像手动选；
-    # 不分 discovery_format（可灵端点各自唯一）。
+    # _IMAGE_PATTERN，须在通用 is_video/is_image 之前显式分流。video 语义优先于 image——
+    # kling-image2video / kling-img2video 这类 image-to-video 含 image 语义但本质是视频模型，
+    # 若直接看 is_image 会被误推到 kling-image，故先拦 video 关键字归 kling-video；其余含 image
+    # 语义 → kling-image，否则 → kling-video。kling-v3-omni 图像/视频同名歧义无法纯靠 token 区分，
+    # 默认归视频、图像手动选；不分 discovery_format（可灵端点各自唯一）。
     if "kling" in lowered:
+        if "video" in lowered:
+            return "kling-video"
         return "kling-image" if is_image else "kling-video"
 
     # wan2.x-image 含 "wan" 会被 _VIDEO_PATTERN 误判为视频；显式排除让它落到图像家族推断

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -143,11 +143,14 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
 
 
 def _lookup_video_caps(model: str) -> _KlingVideoModelCaps:
-    """按 model 取能力位：剥厂商前缀（中转常见 ``vendor/kling-v3-omni``）取最后一段 + lower 归一化后做
-    【精确】命中 _KLING_VIDEO_CAPS。未登记 model（含未来版本 kling-v4、归一化后仍不精确匹配的中转自定义
-    id）回落保守默认（首尾帧、无参考/音频）——绝不按子串猜未知 model 的能力上限：未知 model 的限额可能
-    与已知档不同，误报参考图能力会在请求期触发 provider 400 或计费漂移，宁可保守。"""
-    key = model.rsplit("/", 1)[-1].lower()
+    """按 model 取能力位：剥厂商前缀后 + 去首尾空白 + lower 归一化，再做【精确】命中 _KLING_VIDEO_CAPS。
+    中转前缀分隔符仅认仓库既有约定 ``/``（``vendor/kling-v3-omni``）与 ``:``（``provider:kling-v3-omni``）
+    ——把 ``:`` 统一成 ``/`` 后取最后一段。刻意不把 ``_``/``.`` 当分隔符：它们是 model 名合法字符
+    （wan2. / image-01 / kling-v3-omni 都含），当分隔符会切坏真实 model 名。未登记 model（含未来版本
+    kling-v4、归一化后仍不精确匹配的中转自定义 id）回落保守默认（首尾帧、无参考/音频）——绝不按子串猜
+    未知 model 的能力上限：未知 model 的限额可能与已知档不同，误报参考图能力会在请求期触发 provider 400
+    或计费漂移，宁可保守。"""
+    key = model.replace(":", "/").rsplit("/", 1)[-1].strip().lower()
     return _KLING_VIDEO_CAPS.get(key, _DEFAULT_VIDEO_CAPS)
 
 

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -226,17 +226,23 @@ class KlingVideoBackend:
             caps.add(VideoCapability.GENERATE_AUDIO)
         return caps
 
-    @property
-    def video_capabilities(self) -> VideoCapabilities:
-        # first_frame 恒真（各档均支持 i2v 首帧）；last_frame / reference_images / 上限按 model。
-        # max_reference_images 同时声明于 registry ModelInfo（编排层裁剪读它）与此处（生成时防御），
-        # 取保守值、待 app.klingai.com 控制台核对。
+    @staticmethod
+    def video_capabilities_for_model(model: str) -> VideoCapabilities:
+        # first_frame 恒真（各档均支持 i2v 首帧）；last_frame / reference_images / 上限按 model 从
+        # _KLING_VIDEO_CAPS 读，未登记 model（bearer 透传）回落保守默认。max_reference_images 同时声明于
+        # registry ModelInfo（编排层裁剪读它）与此处（生成时防御），取保守值、待 app.klingai.com 控制台核对。
+        # 纯函数（不构造 client / 不需 api_key），供 custom endpoint resolver 按 model_id 读上限复用。
+        caps = _KLING_VIDEO_CAPS.get(model, _DEFAULT_VIDEO_CAPS)
         return VideoCapabilities(
             first_frame=True,
-            last_frame=self._caps.last_frame,
-            reference_images=self._caps.reference_images,
-            max_reference_images=self._caps.max_reference_images,
+            last_frame=caps.last_frame,
+            reference_images=caps.reference_images,
+            max_reference_images=caps.max_reference_images,
         )
+
+    @property
+    def video_capabilities(self) -> VideoCapabilities:
+        return self.video_capabilities_for_model(self._model)
 
     # ── auth ────────────────────────────────────────────────────────────
 

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -141,6 +141,16 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
     ),
 }
 
+
+def _lookup_video_caps(model: str) -> _KlingVideoModelCaps:
+    """按 model 取能力位：剥厂商前缀（中转常见 ``vendor/kling-v3-omni``）取最后一段 + lower 归一化后做
+    【精确】命中 _KLING_VIDEO_CAPS。未登记 model（含未来版本 kling-v4、归一化后仍不精确匹配的中转自定义
+    id）回落保守默认（首尾帧、无参考/音频）——绝不按子串猜未知 model 的能力上限：未知 model 的限额可能
+    与已知档不同，误报参考图能力会在请求期触发 provider 400 或计费漂移，宁可保守。"""
+    key = model.rsplit("/", 1)[-1].lower()
+    return _KLING_VIDEO_CAPS.get(key, _DEFAULT_VIDEO_CAPS)
+
+
 _MIN_POLL_TIMEOUT_SECONDS = 900.0
 _POLL_TIMEOUT_PER_SECOND = 60.0
 _KLING_VIDEO_POLL_INTERVAL_SECONDS = 10.0
@@ -204,8 +214,8 @@ class KlingVideoBackend:
         else:
             raise ValueError(f"未知 Kling auth_mode: {auth_mode}")
 
-        # 按 model 取能力位；未登记 model（bearer 透传）回落保守默认。
-        self._caps = _KLING_VIDEO_CAPS.get(self._model, _DEFAULT_VIDEO_CAPS)
+        # 按 model 取能力位（归一化前缀/大小写后精确命中）；未登记 model（bearer 透传）回落保守默认。
+        self._caps = _lookup_video_caps(self._model)
 
     @property
     def name(self) -> str:
@@ -229,10 +239,11 @@ class KlingVideoBackend:
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
         # first_frame 恒真（各档均支持 i2v 首帧）；last_frame / reference_images / 上限按 model 从
-        # _KLING_VIDEO_CAPS 读，未登记 model（bearer 透传）回落保守默认。max_reference_images 同时声明于
-        # registry ModelInfo（编排层裁剪读它）与此处（生成时防御），取保守值、待 app.klingai.com 控制台核对。
-        # 纯函数（不构造 client / 不需 api_key），供 custom endpoint resolver 按 model_id 读上限复用。
-        caps = _KLING_VIDEO_CAPS.get(model, _DEFAULT_VIDEO_CAPS)
+        # _KLING_VIDEO_CAPS 读（_lookup_video_caps 归一化前缀/大小写后精确命中，未登记回落保守默认）。
+        # max_reference_images 同时声明于 registry ModelInfo（编排层裁剪读它）与此处（生成时防御），取保守
+        # 值、待 app.klingai.com 控制台核对。纯函数（不构造 client / 不需 api_key），供 custom endpoint
+        # resolver 按 model_id 读上限复用。
+        caps = _lookup_video_caps(model)
         return VideoCapabilities(
             first_frame=True,
             last_frame=caps.last_frame,

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -134,10 +134,15 @@ class TestRegistry:
         assert turbo.first_frame is True
         assert turbo.reference_images is False
         assert turbo.max_reference_images == 0
-        # 未登记 model（bearer 原样透传）→ 保守默认：首尾帧、无参考
-        unknown = caps_fn("kling-some-future-proxy-model")
-        assert unknown.reference_images is False
-        assert unknown.max_reference_images == 0
+        # 中转 model_id 带厂商前缀 + 非规范大小写：归一化（剥前缀 + lower）后仍能精确命中已登记档
+        prefixed = caps_fn("vendor/Kling-V3-Omni")
+        assert prefixed.reference_images is True
+        assert prefixed.max_reference_images == 4
+        # 未登记 model（未来版本 kling-v4 / 归一化后仍不匹配的中转自定义 id）→ 保守默认，不按子串猜能力
+        for unknown_id in ("kling-v4", "vendor/some-unknown-model"):
+            unknown = caps_fn(unknown_id)
+            assert unknown.reference_images is False
+            assert unknown.max_reference_images == 0
 
     def test_negative_int_cap_rejected_at_validation(self, monkeypatch: pytest.MonkeyPatch):
         """import 期不变式拒绝负数 int cap：下游 references[:-1] 会误丢最后一张而非裁成 0 张。"""

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -64,14 +64,19 @@ class TestRegistry:
         }
 
     def test_new_video_endpoints_have_unset_cap(self):
-        """v2/ark/vidu/dashscope/minimax 不在 endpoint 维度声明上限，由 resolver 调 backend 纯 caps 函数读取。"""
-        for key in ("v2-video-generations", "ark-seedance", "vidu-video", "dashscope-async-video", "minimax-video"):
+        """v2/ark/vidu/dashscope/minimax/kling 不在 endpoint 维度声明上限，由 resolver 调 backend 纯 caps 函数读取。"""
+        for key in (
+            "v2-video-generations",
+            "ark-seedance",
+            "vidu-video",
+            "dashscope-async-video",
+            "minimax-video",
+            "kling-video",
+        ):
             assert ENDPOINT_REGISTRY[key].video_max_reference_images is None
         # 既有显式 int 保留，行为零变化
         assert ENDPOINT_REGISTRY["openai-video"].video_max_reference_images == 1
         assert ENDPOINT_REGISTRY["newapi-video"].video_max_reference_images == 0
-        # kling-video 走首尾帧、不接受参考图数组 → 显式 0（与 newapi-video 同构）
-        assert ENDPOINT_REGISTRY["kling-video"].video_max_reference_images == 0
 
     def test_video_caps_declaration_bindings(self):
         """每个 video endpoint 选对了上限来源：None-cap 的绑 caps_fn、显式 int 的不绑。
@@ -80,10 +85,17 @@ class TestRegistry:
         在 import 期保证（违反则本文件根本 import 不进来），故此处只断言「具体哪个 endpoint 选了哪条
         路径」——这是 XOR 校验抓不到的（换机制仍满足 XOR），是真正的回归护栏。"""
         # None-cap 的 video endpoint 必须绑定纯 caps 函数
-        for key in ("v2-video-generations", "ark-seedance", "vidu-video", "dashscope-async-video", "minimax-video"):
+        for key in (
+            "v2-video-generations",
+            "ark-seedance",
+            "vidu-video",
+            "dashscope-async-video",
+            "minimax-video",
+            "kling-video",
+        ):
             assert ENDPOINT_REGISTRY[key].video_caps_for_model is not None
         # 显式 int 的 video endpoint 不应再绑 caps 函数
-        for key in ("openai-video", "newapi-video", "kling-video"):
+        for key in ("openai-video", "newapi-video"):
             assert ENDPOINT_REGISTRY[key].video_caps_for_model is None
 
     def test_dashscope_caps_fn_reads_per_model_limit_without_client(self):
@@ -105,6 +117,27 @@ class TestRegistry:
         hailuo = caps_fn("MiniMax-Hailuo-2.3")
         assert hailuo.first_frame is True
         assert hailuo.max_reference_images == 0
+
+    def test_kling_caps_fn_reads_per_model_limit_without_client(self):
+        """kling-video 的 caps_fn 是纯函数：v3-omni / video-o1 多图主体 R2V max_ref=4，turbo 等其余档
+        走首尾帧无参考（max_ref=0），未登记 model（bearer 透传）回落保守默认，resolver 据此解析而无需
+        构造 backend / api_key。"""
+        caps_fn = ENDPOINT_REGISTRY["kling-video"].video_caps_for_model
+        assert caps_fn is not None
+        omni = caps_fn("kling-v3-omni")
+        assert omni.reference_images is True
+        assert omni.max_reference_images == 4
+        o1 = caps_fn("kling-video-o1")
+        assert o1.reference_images is True
+        assert o1.max_reference_images == 4
+        turbo = caps_fn("kling-v2-5-turbo")
+        assert turbo.first_frame is True
+        assert turbo.reference_images is False
+        assert turbo.max_reference_images == 0
+        # 未登记 model（bearer 原样透传）→ 保守默认：首尾帧、无参考
+        unknown = caps_fn("kling-some-future-proxy-model")
+        assert unknown.reference_images is False
+        assert unknown.max_reference_images == 0
 
     def test_negative_int_cap_rejected_at_validation(self, monkeypatch: pytest.MonkeyPatch):
         """import 期不变式拒绝负数 int cap：下游 references[:-1] 会误丢最后一张而非裁成 0 张。"""

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -32,6 +32,8 @@ class TestRegistry:
             "dashscope-async-video",
             "minimax-image",
             "minimax-video",
+            "kling-image",
+            "kling-video",
             "openai-tts",
         }
 
@@ -39,7 +41,7 @@ class TestRegistry:
         for key, spec in ENDPOINT_REGISTRY.items():
             assert spec.key == key
             assert spec.media_type in {"text", "image", "video", "audio"}
-            assert spec.family in {"openai", "google", "newapi", "v2", "ark", "vidu", "dashscope", "minimax"}
+            assert spec.family in {"openai", "google", "newapi", "v2", "ark", "vidu", "dashscope", "minimax", "kling"}
             assert spec.display_name_key.startswith("endpoint_")
             assert callable(spec.build_backend)
             assert spec.request_method == "POST"
@@ -68,6 +70,8 @@ class TestRegistry:
         # 既有显式 int 保留，行为零变化
         assert ENDPOINT_REGISTRY["openai-video"].video_max_reference_images == 1
         assert ENDPOINT_REGISTRY["newapi-video"].video_max_reference_images == 0
+        # kling-video 走首尾帧、不接受参考图数组 → 显式 0（与 newapi-video 同构）
+        assert ENDPOINT_REGISTRY["kling-video"].video_max_reference_images == 0
 
     def test_video_caps_declaration_bindings(self):
         """每个 video endpoint 选对了上限来源：None-cap 的绑 caps_fn、显式 int 的不绑。
@@ -79,7 +83,7 @@ class TestRegistry:
         for key in ("v2-video-generations", "ark-seedance", "vidu-video", "dashscope-async-video", "minimax-video"):
             assert ENDPOINT_REGISTRY[key].video_caps_for_model is not None
         # 显式 int 的 video endpoint 不应再绑 caps 函数
-        for key in ("openai-video", "newapi-video"):
+        for key in ("openai-video", "newapi-video", "kling-video"):
             assert ENDPOINT_REGISTRY[key].video_caps_for_model is None
 
     def test_dashscope_caps_fn_reads_per_model_limit_without_client(self):
@@ -156,6 +160,7 @@ class TestRegistry:
             "gemini-image",
             "dashscope-image",
             "minimax-image",
+            "kling-image",
         }
         assert video_keys == {
             "openai-video",
@@ -165,6 +170,7 @@ class TestRegistry:
             "vidu-video",
             "dashscope-async-video",
             "minimax-video",
+            "kling-video",
         }
 
 
@@ -222,7 +228,6 @@ class TestInferEndpoint:
             ("flux-pro", "openai", "openai-images"),
             ("sora-2", "openai", "openai-video"),
             ("SORA-2", "openai", "openai-video"),
-            ("kling-v2", "openai", "openai-video"),
             ("veo-3", "openai", "openai-video"),
             ("veo-3", "google", "openai-video"),  # 非 seedance/viduq3/minimax 视频 → openai-video
             # ── MiniMax 原生 token 二级路由 ──
@@ -239,6 +244,19 @@ class TestInferEndpoint:
             ("image-01", "openai", "minimax-image"),  # image-01 含 "image" 否则会被推到通用图像家族
             ("minimax/image-01", "openai", "minimax-image"),
             ("S2V-01", "google", "minimax-video"),  # minimax 路由不分 discovery_format
+            # ── Kling 原生中转二级路由（视频 family 含 kling，须收敛到 kling-video 而非 openai-video）──
+            ("kling-v2-5-turbo", "openai", "kling-video"),
+            ("kling-v2", "openai", "kling-video"),  # 前 kling endpoint 时代默认 openai-video
+            ("kling-v3", "openai", "kling-video"),
+            ("kling-v2-6", "openai", "kling-video"),
+            ("proxy/kling-v2-5-turbo", "openai", "kling-video"),
+            ("KLING-V3", "openai", "kling-video"),  # 大小写不敏感
+            ("kling-v3-omni", "openai", "kling-video"),  # 图像/视频同名歧义 → 默认归视频
+            # 含 image 语义的可灵图像 → kling-image（先于通用图像家族，不被推到 openai-images）
+            ("kling-image-o1", "openai", "kling-image"),
+            ("kling-v3-omni-image", "openai", "kling-image"),
+            ("proxy/kling-image-o1", "openai", "kling-image"),
+            ("kling-image-o1", "google", "kling-image"),  # kling 路由不分 discovery_format
             ("seedream-3.0", "openai", "openai-images"),
             ("jimeng-3.0", "openai", "openai-images"),
             ("jimeng-video-3.0", "openai", "openai-video"),
@@ -303,6 +321,7 @@ def test_image_endpoint_registry_entries():
         "gemini-image",
         "dashscope-image",
         "minimax-image",
+        "kling-image",
     }
 
 

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -257,6 +257,10 @@ class TestInferEndpoint:
             ("kling-v3-omni-image", "openai", "kling-image"),
             ("proxy/kling-image-o1", "openai", "kling-image"),
             ("kling-image-o1", "google", "kling-image"),  # kling 路由不分 discovery_format
+            # image-to-video 含 image 语义但本质是视频 → video 优先于 image，归 kling-video
+            ("kling-image2video", "openai", "kling-video"),
+            ("kling-img2video", "openai", "kling-video"),
+            ("proxy/kling-image2video", "openai", "kling-video"),
             ("seedream-3.0", "openai", "openai-images"),
             ("jimeng-3.0", "openai", "openai-images"),
             ("jimeng-video-3.0", "openai", "openai-video"),

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -134,10 +134,11 @@ class TestRegistry:
         assert turbo.first_frame is True
         assert turbo.reference_images is False
         assert turbo.max_reference_images == 0
-        # 中转 model_id 带厂商前缀 + 非规范大小写：归一化（剥前缀 + lower）后仍能精确命中已登记档
-        prefixed = caps_fn("vendor/Kling-V3-Omni")
-        assert prefixed.reference_images is True
-        assert prefixed.max_reference_images == 4
+        # 中转 model_id 带厂商前缀（仓库既有约定 / 与 :）+ 非规范大小写：归一化后仍能精确命中已登记档
+        for prefixed_id in ("vendor/Kling-V3-Omni", "provider:kling-v3-omni"):
+            prefixed = caps_fn(prefixed_id)
+            assert prefixed.reference_images is True
+            assert prefixed.max_reference_images == 4
         # 未登记 model（未来版本 kling-v4 / 归一化后仍不匹配的中转自定义 id）→ 保守默认，不按子串猜能力
         for unknown_id in ("kling-v4", "vendor/some-unknown-model"):
             unknown = caps_fn(unknown_id)

--- a/tests/test_custom_provider_factory.py
+++ b/tests/test_custom_provider_factory.py
@@ -149,6 +149,57 @@ class TestEndpointDispatch:
             api_key="sk-test", base_url="https://api.minimaxi.com/v1", model="MiniMax-Hailuo-2.3"
         )
 
+    @patch("lib.custom_provider.endpoints.KlingImageBackend")
+    def test_kling_image(self, mock_cls):
+        provider = _make_provider(base_url="https://relay.example.com/v1")
+        result = create_custom_backend(provider=provider, model_id="kling-image-o1", endpoint="kling-image")
+        assert isinstance(result, CustomImageBackend)
+        assert result.model == "kling-image-o1"
+        # bearer 模式：静态 api_key 旁路 JWT；显式 /v1 路径原样信任；原生 model_name 透传
+        mock_cls.assert_called_once_with(
+            auth_mode="bearer",
+            api_key="sk-test",
+            base_url="https://relay.example.com/v1",
+            model="kling-image-o1",
+        )
+
+    @patch("lib.custom_provider.endpoints.KlingImageBackend")
+    def test_kling_image_host_only_mounts_v1(self, mock_cls):
+        provider = _make_provider(base_url="https://relay.example.com")
+        create_custom_backend(provider=provider, model_id="kling-image-o1", endpoint="kling-image")
+        # 仅 host → 补全可灵协议挂载路径 /v1
+        mock_cls.assert_called_once_with(
+            auth_mode="bearer",
+            api_key="sk-test",
+            base_url="https://relay.example.com/v1",
+            model="kling-image-o1",
+        )
+
+    @patch("lib.custom_provider.endpoints.KlingVideoBackend")
+    def test_kling_video(self, mock_cls):
+        provider = _make_provider(base_url="https://relay.example.com/v1")
+        result = create_custom_backend(provider=provider, model_id="kling-v2-5-turbo", endpoint="kling-video")
+        assert isinstance(result, CustomVideoBackend)
+        assert result.model == "kling-v2-5-turbo"
+        mock_cls.assert_called_once_with(
+            auth_mode="bearer",
+            api_key="sk-test",
+            base_url="https://relay.example.com/v1",
+            model="kling-v2-5-turbo",
+        )
+
+    @patch("lib.custom_provider.endpoints.KlingVideoBackend")
+    def test_kling_video_host_only_mounts_v1(self, mock_cls):
+        provider = _make_provider(base_url="relay.example.com")
+        create_custom_backend(provider=provider, model_id="kling-v3", endpoint="kling-video")
+        # 纯域名（无 scheme）→ 补 https:// 再挂载 /v1
+        mock_cls.assert_called_once_with(
+            auth_mode="bearer",
+            api_key="sk-test",
+            base_url="https://relay.example.com/v1",
+            model="kling-v3",
+        )
+
     @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
     def test_openai_images_generations(self, mock_cls):
         provider = _make_provider()

--- a/tests/test_custom_providers_api.py
+++ b/tests/test_custom_providers_api.py
@@ -219,6 +219,8 @@ class TestEndpointCatalog:
             "dashscope-async-video",
             "minimax-image",
             "minimax-video",
+            "kling-image",
+            "kling-video",
             "openai-tts",
         }
 

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -137,6 +137,20 @@ class TestPerModelCapabilities:
         assert vc.last_frame is True
         assert vc.reference_images is False and vc.max_reference_images == 0
 
+    def test_prefixed_and_cased_model_normalizes_to_registered_caps(self):
+        # 中转 model_id 带厂商前缀 + 非规范大小写：归一化（剥前缀 + lower）后实例 caps 仍精确命中已登记档，
+        # 生成时防御与 resolver 裁剪同源——否则编排层放 4 张参考图、backend 却按默认 0 拒收。
+        b = _bearer_backend("vendor/Kling-V3-Omni")
+        vc = b.video_capabilities
+        assert vc.reference_images is True and vc.max_reference_images == 4
+
+    def test_future_version_does_not_inherit_caps_by_substring(self):
+        # kling-v4 含子串 "kling-v3"？不含——但即便形如 kling-v3-omni-pro 也不得被子串误判继承能力；
+        # 未登记一律保守默认，不猜未知 model 的参考图上限。
+        for model in ("kling-v4", "kling-v3-omni-pro"):
+            vc = _bearer_backend(model).video_capabilities
+            assert vc.reference_images is False and vc.max_reference_images == 0
+
 
 class TestModeAndResolution:
     def test_resolution_4k_maps_to_mode_4k(self, tmp_path):

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -138,11 +138,11 @@ class TestPerModelCapabilities:
         assert vc.reference_images is False and vc.max_reference_images == 0
 
     def test_prefixed_and_cased_model_normalizes_to_registered_caps(self):
-        # 中转 model_id 带厂商前缀 + 非规范大小写：归一化（剥前缀 + lower）后实例 caps 仍精确命中已登记档，
-        # 生成时防御与 resolver 裁剪同源——否则编排层放 4 张参考图、backend 却按默认 0 拒收。
-        b = _bearer_backend("vendor/Kling-V3-Omni")
-        vc = b.video_capabilities
-        assert vc.reference_images is True and vc.max_reference_images == 4
+        # 中转 model_id 带厂商前缀（仓库既有约定 / 与 :）+ 非规范大小写/空白：归一化后实例 caps 仍精确命中
+        # 已登记档，生成时防御与 resolver 裁剪同源——否则编排层放 4 张参考图、backend 却按默认 0 拒收。
+        for model in ("vendor/Kling-V3-Omni", "provider:kling-v3-omni", "  provider:kling-v3-omni  "):
+            vc = _bearer_backend(model).video_capabilities
+            assert vc.reference_images is True and vc.max_reference_images == 4
 
     def test_future_version_does_not_inherit_caps_by_substring(self):
         # kling-v4 含子串 "kling-v3"？不含——但即便形如 kling-v3-omni-pro 也不得被子串误判继承能力；

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -28,7 +28,9 @@ class TestInferEndpointSmoke:
     def test_video_model(self):
         from lib.custom_provider.endpoints import infer_endpoint
 
-        assert infer_endpoint("kling-v2", "openai") == "openai-video"
+        # 可灵视频收敛到原生 kling-video（视频 family 含 kling，不再默认落 openai-video）
+        assert infer_endpoint("kling-v2", "openai") == "kling-video"
+        assert infer_endpoint("sora-2", "openai") == "openai-video"
 
     def test_google_text(self):
         from lib.custom_provider.endpoints import infer_endpoint
@@ -481,8 +483,8 @@ def test_discover_openai_returns_endpoints(monkeypatch):
     )
     by_id = {m["model_id"]: m for m in result}
     assert by_id["gpt-4o"]["endpoint"] == "openai-chat"
-    assert by_id["kling-v2"]["endpoint"] == "openai-video"
+    assert by_id["kling-v2"]["endpoint"] == "kling-video"
     assert by_id["dall-e-3"]["endpoint"] == "openai-images"
     # 每种 media_type 仅一个 default
     defaults = [m for m in result if m["is_default"]]
-    assert {m["endpoint"] for m in defaults} == {"openai-chat", "openai-video", "openai-images"}
+    assert {m["endpoint"] for m in defaults} == {"openai-chat", "kling-video", "openai-images"}


### PR DESCRIPTION
## 做了什么

为**自定义供应商**新增两个可灵 Kling 端点，让接「可灵原样代理」中转站的用户能选到可灵原生协议、按 Bearer + 异步直接生成：

- **可灵 Kling（图片）** / **可灵 Kling（视频）** 两个端点，分别包装图像/视频后端的 Bearer 模式（静态 api_key + base_url，旁路 JWT 管理器，与内置 JWT 直连共享同一份异步请求 schema）。
- 添加自定义供应商时模型发现会自动把可灵视频 model id（如 `kling-v2-5-turbo`/`kling-v3`）收敛到可灵视频端点，可灵图像 model id 收敛到可灵图像端点；`kling-v3-omni` 图像/视频同名歧义默认归视频、图像手动选。向后兼容——不影响其它供应商既有推断。
- 端点显示名补齐前端三语（中/英/越）。

可灵内置直连仍走 JWT、中转代理走 Bearer，两条鉴权路径按既有约定分离；本片未触碰生成任务编排层。

## 验证

- 后端全量 `uv run pytest tests/`：5040 passed
- `uv run ruff check` 净、`uv run basedpyright` 0 error、i18n 三语一致
- 前端 `pnpm lint` + `pnpm check`（typecheck + vitest 736 passed）绿
- 已 rebase 到最新 main 并重新跑全部门禁

## 审查说明

独立审查（line-by-line + removed-behavior + wrapper/proxy + cross-file 多角度）确认：后端构造参数、`/v1` 挂载路径补全、`video_max_reference_images=0`、包装层方法转发、端点注册完整性、推断分支顺序均正确。顺带修正了共享 helper 文档串（新增可灵复用方）。

Closes #836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 Kling 图片生成与视频生成端点支持（自定义供应商端点可用）。
  * 增加 Kling 图片/视频端点的多语言显示文案（英文、越南文、中文）。
* **改进**
  * 模型发现与自动路由更准确地分配到 Kling 图片/视频端点，并提升能力推断的按模型精确匹配与保守回退表现。
  * 更一致的基础地址挂载处理（在仅提供主机或缺少挂载前缀时也能正确对齐）。
* **测试**
  * 扩展 Kling 端点注册、路由分发、能力推断与工厂实例化相关用例，覆盖多语言文案与边界场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->