### PR TITLE
refactor(backend): 统一内置/自定义供应商的 backend 构造入口

### DIFF
--- a/lib/backend_assembly/__init__.py
+++ b/lib/backend_assembly/__init__.py
@@ -1,0 +1,12 @@
+"""backend_assembly — 「provider config + model → backend」的统一构造缝。
+
+暴露唯一入口 assemble_backend，内部按 is_custom_provider 分流到内置 / 自定义两族。
+两族共享入口、不共享表结构（见 docs/adr/0039）：内置侧用 ProviderSpec 闭包表（specs.py），
+自定义侧委托现成 ENDPOINT_REGISTRY（lib/custom_provider/endpoints.py）。
+"""
+
+from __future__ import annotations
+
+from lib.backend_assembly.assembler import assemble_backend
+
+__all__ = ["assemble_backend"]

--- a/lib/backend_assembly/assembler.py
+++ b/lib/backend_assembly/assembler.py
@@ -1,0 +1,56 @@
+"""assemble_backend — 「provider config + model → backend」统一构造入口。
+
+按 is_custom_provider 单分支分流到内置 / 自定义两族（一道门、门后两个对称房间，见 ADR 0039）。
+构造拆两段：async 装载（查 DB/config，产出 LoadedConfig 信封）/ sync 纯闭包构造。缝无状态、纯构造，
+backend 实例缓存留在调用方编排层、不进缝。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from lib.backend_assembly.loaded_config import LoadedConfig
+from lib.backend_assembly.specs import get_provider_spec
+from lib.config.registry import PROVIDER_REGISTRY
+from lib.custom_provider import is_custom_provider
+
+if TYPE_CHECKING:
+    from lib.config.resolver import ConfigResolver
+
+
+async def _load_builtin_config(resolver: ConfigResolver, provider_id: str, rate_limiter: Any | None) -> LoadedConfig:
+    """内置侧 async 装载段：查 DB/config 产出 LoadedConfig 信封。
+
+    凭证 overlay 来自 db_config（resolver.provider_config）；registry meta 提供 default_base_url /
+    api_model_name 来源；rate_limiter 由调用方注入（共享实例）。这一段是唯一的 await/DB 触点，
+    之后 sync 构造闭包只读信封。
+    """
+    db_config = await resolver.provider_config(provider_id)
+    return LoadedConfig(
+        credentials=dict(db_config),
+        provider_meta=PROVIDER_REGISTRY.get(provider_id),
+        rate_limiter=rate_limiter,
+    )
+
+
+async def assemble_backend(
+    *,
+    provider_id: str,
+    media_type: str,
+    model_id: str | None,
+    resolver: ConfigResolver,
+    rate_limiter: Any | None = None,
+) -> Any:
+    """统一构造入口。按 provider_id 是否自定义分流；未登记的内置 provider × media fail-loud。"""
+    if is_custom_provider(provider_id):
+        from lib.custom_provider.loader import load_custom_backend
+
+        # 借 resolver 的 session（bound 时复用其事务上下文）：自定义装载与简单族装载共用同一
+        # session_factory，调用方在 resolver.session() 内构造时复用同一连接，避免另开 factory。
+        async with resolver._open_session() as (session, _):
+            return await load_custom_backend(
+                session=session, provider_id=provider_id, model_id=model_id, media_type=media_type
+            )
+    spec = get_provider_spec(provider_id, media_type)  # 未登记 → ValueError（fail-loud）
+    config = await _load_builtin_config(resolver, provider_id, rate_limiter)
+    return spec.build_backend(config, model_id)

--- a/lib/backend_assembly/loaded_config.py
+++ b/lib/backend_assembly/loaded_config.py
@@ -1,0 +1,26 @@
+"""LoadedConfig — 内置 backend 构造缝的 async 装载段产物、sync 构造段唯一输入。
+
+承载三样东西：① 凭证 overlay（db_config 解析出的 api_key / access_key / secret_key /
+base_url 等，键名即列名，承 ADR 0037「registry key 名 = 列名 = 构造参数名 = config key」）；
+② provider registry meta（default_base_url / api_model_name 来源）；③ 共享 rate_limiter。
+
+构造闭包只读这个信封拼 backend，不查 DB、不 await —— 这条中线是「构造可脱离 DB 直接单测」的
+结构保证（手搓一个 LoadedConfig + model_id 即可断言造出的构造参数）。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lib.config.registry import ProviderMeta
+
+
+@dataclass(frozen=True)
+class LoadedConfig:
+    """内置侧 build 闭包的唯一输入信封。"""
+
+    credentials: dict[str, str | None]
+    provider_meta: ProviderMeta | None
+    rate_limiter: Any | None

--- a/lib/backend_assembly/loaded_config.py
+++ b/lib/backend_assembly/loaded_config.py
@@ -23,4 +23,6 @@ class LoadedConfig:
 
     credentials: dict[str, str | None]
     provider_meta: ProviderMeta | None
+    # 简单族 _build_simple 不消费 rate_limiter（与迁移前 _fill_simple_provider_kwargs 一致：限流由
+    # 简单后端各自的 httpx 客户端内建）；信封预留此槽供后续迁入的特例族 build 闭包（如 gemini 媒体）读取。
     rate_limiter: Any | None

--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -72,14 +72,16 @@ def _simple_spec(provider_id: str, media_type: str) -> ProviderSpec:
 
 # ── PROVIDER_SPEC_REGISTRY 注册表 ──────────────────────────────────
 # 键 = (provider_id, media_type)。简单族 = 媒体侧只需 api_key + model + base_url 的内置 provider，
-# 共享 _build_simple 闭包。「简单族」按构造形态界定（不是 provider 名白名单），含 ark/grok/openai/vidu
-# 与 dashscope/minimax（后两者媒体侧走原生简单构造；其文本侧 OpenAI-compat 特例由文本工厂另行处理）。
-# 每对显式登记一行，fail-loud（未登记的 provider × media 抛 ValueError，不「缺席即默认」造静默
-# 错误 backend）。只登记今天确有注册 backend 的对：image/video 简单族六家齐全，audio 仅 dashscope。
+# 共享 _build_simple 闭包。「简单族」按构造形态界定（不是 provider 名白名单），含 ark/ark-agent-plan/
+# grok/openai/vidu 与 dashscope/minimax（后两者媒体侧走原生简单构造；其文本侧 OpenAI-compat 特例由
+# 文本工厂另行处理）。ark-agent-plan 媒体侧复用 Ark image/video backend（registry 同名注册），与 ark
+# 同为简单形态。每对显式登记一行，fail-loud（未登记的 provider × media 抛 ValueError，不「缺席即默认」
+# 造静默错误 backend）。只登记今天确有注册 backend 的对：image/video 简单族七家齐全，audio 仅 dashscope。
 
+_SIMPLE_IMAGE_VIDEO_PROVIDERS = ("ark", "ark-agent-plan", "grok", "openai", "vidu", "dashscope", "minimax")
 _SIMPLE_MEDIA_PAIRS: list[tuple[str, str]] = [
-    *((p, "image") for p in ("ark", "grok", "openai", "vidu", "dashscope", "minimax")),
-    *((p, "video") for p in ("ark", "grok", "openai", "vidu", "dashscope", "minimax")),
+    *((p, "image") for p in _SIMPLE_IMAGE_VIDEO_PROVIDERS),
+    *((p, "video") for p in _SIMPLE_IMAGE_VIDEO_PROVIDERS),
     ("dashscope", "audio"),
 ]
 

--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -1,0 +1,120 @@
+"""内置 provider 的 (provider_id, media_type) → ProviderSpec 声明式表。
+
+镜像自定义侧 ENDPOINT_REGISTRY（lib/custom_provider/endpoints.py）：每条 spec 是 frozen
+dataclass，挂一个 build 闭包；闭包读 LoadedConfig 信封 + model_id 拼 backend，不查 DB、不 await。
+本切片登记简单族（媒体侧只需 api_key + model + base_url 的内置 provider）的 image/video/audio，
+共享一个 _build_simple 闭包。表在 import 期校验不变式（registry 名已注册除外，见模块末尾说明），
+misconfig fail-fast。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import partial
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lib.backend_assembly.loaded_config import LoadedConfig
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """单条内置 (provider, media) 的 backend 构造规格。"""
+
+    provider_id: str  # registry / config provider id，如 "ark"
+    media_type: str  # "image" | "video" | "audio"
+    registry_backend: str  # 映射到哪个 media backend registry 名（合并两份 PROVIDER_ID_TO_BACKEND）
+    # model_id 可为 None：缺省时由 backend 内部回落各自 DEFAULT_MODEL（与 effective_model 上游一致）
+    build_backend: Callable[[LoadedConfig, str | None], Any]
+
+
+def _media_create_backend(media_type: str) -> Callable[..., Any]:
+    """按 media_type 取对应 registry 的 create_backend（运行时取，便于测试 patch 模块属性）。"""
+    if media_type == "image":
+        from lib.image_backends.registry import create_backend
+    elif media_type == "video":
+        from lib.video_backends.registry import create_backend
+    elif media_type == "audio":
+        from lib.audio_backends.registry import create_backend
+    else:
+        raise ValueError(f"unknown media_type: {media_type!r}")
+    return create_backend
+
+
+def _build_simple(config: LoadedConfig, model_id: str | None, *, media_type: str, registry_backend: str) -> Any:
+    """简单族通用构造：api_key + model + base_url。
+
+    base_url 优先级：用户在 db_config 显式填写 > ProviderMeta.default_base_url > 不传。只在结果
+    非空时传入 kwargs —— grok 等无 default 且用户未配的 provider 不接受 base_url 参数，传 None
+    会触发 TypeError。
+    """
+    kwargs: dict[str, Any] = {
+        "api_key": config.credentials.get("api_key"),
+        "model": model_id,
+    }
+    default_base_url = config.provider_meta.default_base_url if config.provider_meta else None
+    base_url = config.credentials.get("base_url") or default_base_url
+    if base_url:
+        kwargs["base_url"] = base_url
+    return _media_create_backend(media_type)(registry_backend, **kwargs)
+
+
+def _simple_spec(provider_id: str, media_type: str) -> ProviderSpec:
+    """登记一条简单族 spec：registry_backend 即 provider_id 自身（媒体侧无别名映射）。"""
+    return ProviderSpec(
+        provider_id=provider_id,
+        media_type=media_type,
+        registry_backend=provider_id,
+        build_backend=partial(_build_simple, media_type=media_type, registry_backend=provider_id),
+    )
+
+
+# ── PROVIDER_SPEC_REGISTRY 注册表 ──────────────────────────────────
+# 键 = (provider_id, media_type)。简单族 = 媒体侧只需 api_key + model + base_url 的内置 provider，
+# 共享 _build_simple 闭包。「简单族」按构造形态界定（不是 provider 名白名单），含 ark/grok/openai/vidu
+# 与 dashscope/minimax（后两者媒体侧走原生简单构造；其文本侧 OpenAI-compat 特例由文本工厂另行处理）。
+# 每对显式登记一行，fail-loud（未登记的 provider × media 抛 ValueError，不「缺席即默认」造静默
+# 错误 backend）。只登记今天确有注册 backend 的对：image/video 简单族六家齐全，audio 仅 dashscope。
+
+_SIMPLE_MEDIA_PAIRS: list[tuple[str, str]] = [
+    *((p, "image") for p in ("ark", "grok", "openai", "vidu", "dashscope", "minimax")),
+    *((p, "video") for p in ("ark", "grok", "openai", "vidu", "dashscope", "minimax")),
+    ("dashscope", "audio"),
+]
+
+PROVIDER_SPEC_REGISTRY: dict[tuple[str, str], ProviderSpec] = {
+    (provider_id, media_type): _simple_spec(provider_id, media_type) for provider_id, media_type in _SIMPLE_MEDIA_PAIRS
+}
+
+
+_VALID_MEDIA_TYPES = frozenset({"image", "video", "audio"})
+
+
+def _validate_provider_specs() -> None:
+    """import 期校验内置表自身不变式，misconfig fail-fast（镜像 endpoints._validate_video_caps_declarations）。
+
+    只做不需 import 媒体后端的内表自洽检查：build 可调用、字典键与 spec 字段一致、media_type 合法。
+    「registry 名都在媒体后端 registry 里」需 import 全部 lib.{image,video,audio}_backends 才能断言，
+    为免轻量场景（CLI / 迁移）因 import 本缝而被动拉起全部后端，归入单测，不进 import 期（见 ADR 0039）。
+    """
+    for key, spec in PROVIDER_SPEC_REGISTRY.items():
+        if not callable(spec.build_backend):
+            raise ValueError(f"ProviderSpec {key!r} declares non-callable build_backend: {spec.build_backend!r}")
+        if (spec.provider_id, spec.media_type) != key:
+            raise ValueError(
+                f"PROVIDER_SPEC_REGISTRY key {key!r} does not match spec fields "
+                f"(provider_id={spec.provider_id!r}, media_type={spec.media_type!r})"
+            )
+        if spec.media_type not in _VALID_MEDIA_TYPES:
+            raise ValueError(f"ProviderSpec {key!r} declares unknown media_type: {spec.media_type!r}")
+
+
+_validate_provider_specs()
+
+
+def get_provider_spec(provider_id: str, media_type: str) -> ProviderSpec:
+    spec = PROVIDER_SPEC_REGISTRY.get((provider_id, media_type))
+    if spec is None:
+        raise ValueError(f"no builtin ProviderSpec for provider={provider_id!r} media={media_type!r}")
+    return spec

--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -45,14 +45,15 @@ def _media_create_backend(media_type: str) -> Callable[..., Any]:
 def _build_simple(config: LoadedConfig, model_id: str | None, *, media_type: str, registry_backend: str) -> Any:
     """简单族通用构造：api_key + model + base_url。
 
-    base_url 优先级：用户在 db_config 显式填写 > ProviderMeta.default_base_url > 不传。只在结果
-    非空时传入 kwargs —— grok 等无 default 且用户未配的 provider 不接受 base_url 参数，传 None
-    会触发 TypeError。
+    api_key 与 base_url 同遵「仅非空才写入 kwargs」：显式传 None 可能覆盖底层 SDK 的环境变量兜底
+    （如 OpenAI SDK 读 OPENAI_API_KEY），缺省由 backend 各自处理（要么读环境变量、要么 fail-loud）。
+    base_url 优先级：用户在 db_config 显式填写 > ProviderMeta.default_base_url > 不传 —— grok 等无
+    default 且用户未配的 provider 不接受 base_url 参数，传 None 会触发 TypeError。
     """
-    kwargs: dict[str, Any] = {
-        "api_key": config.credentials.get("api_key"),
-        "model": model_id,
-    }
+    kwargs: dict[str, Any] = {"model": model_id}
+    api_key = config.credentials.get("api_key")
+    if api_key:
+        kwargs["api_key"] = api_key
     default_base_url = config.provider_meta.default_base_url if config.provider_meta else None
     base_url = config.credentials.get("base_url") or default_base_url
     if base_url:

--- a/lib/custom_provider/loader.py
+++ b/lib/custom_provider/loader.py
@@ -56,7 +56,7 @@ async def load_custom_backend(
         stmt = select(CustomProviderModel).where(
             CustomProviderModel.provider_id == db_id,
             CustomProviderModel.model_id == model_id,
-            CustomProviderModel.is_enabled == True,  # noqa: E712
+            CustomProviderModel.is_enabled,
         )
         result = await session.execute(stmt)
         candidate = result.scalar_one_or_none()

--- a/lib/custom_provider/loader.py
+++ b/lib/custom_provider/loader.py
@@ -1,0 +1,82 @@
+"""自定义供应商 backend 的 DB 装载。
+
+查 provider、校验请求的 model（存在 / 启用 / endpoint 推算 media_type 相符），失效则回退该
+media_type 的默认启用 model，最后委托现成 create_custom_backend（ENDPOINT_REGISTRY 不改）。
+装载落在 lib 让媒体路径与文本工厂共用一份自定义解析，且 lib 不反向依赖 server。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from lib.custom_provider import parse_provider_id
+from lib.custom_provider.backends import (
+    CustomAudioBackend,
+    CustomImageBackend,
+    CustomTextBackend,
+    CustomVideoBackend,
+)
+from lib.custom_provider.endpoints import endpoint_to_media_type
+from lib.custom_provider.factory import create_custom_backend
+from lib.db.models.custom_provider import CustomProviderModel
+from lib.db.repositories.custom_provider_repo import CustomProviderRepository
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+
+async def load_custom_backend(
+    *,
+    session: AsyncSession,
+    provider_id: str,
+    model_id: str | None,
+    media_type: str,
+) -> CustomTextBackend | CustomImageBackend | CustomVideoBackend | CustomAudioBackend:
+    """装载并构造自定义供应商 backend。
+
+    media_type 用于校验请求 model 的 endpoint 是否相符、以及回退默认时分组；实际派发以 model.endpoint
+    为准。请求 model 不存在 / 已禁用 / 媒体类型不符 → 视为失效并回退该 media_type 的默认启用 model。
+
+    Raises:
+        ValueError: provider 不存在，或该 media_type 无默认启用 model。
+    """
+    repo = CustomProviderRepository(session)
+    db_id = parse_provider_id(provider_id)
+    provider = await repo.get_provider(db_id)
+    if provider is None:
+        raise ValueError(f"自定义供应商 {provider_id} 不存在")
+
+    model = None
+    if model_id:
+        stmt = select(CustomProviderModel).where(
+            CustomProviderModel.provider_id == db_id,
+            CustomProviderModel.model_id == model_id,
+            CustomProviderModel.is_enabled == True,  # noqa: E712
+        )
+        result = await session.execute(stmt)
+        candidate = result.scalar_one_or_none()
+        if candidate and endpoint_to_media_type(candidate.endpoint) == media_type:
+            model = candidate
+        else:
+            logger.warning(
+                "自定义模型 %s/%s 已不存在 / 已禁用 / 媒体类型不符（期望 %s），回退到默认模型",
+                provider_id,
+                model_id,
+                media_type,
+            )
+            model_id = None
+
+    if model is None:
+        default_model = await repo.get_default_model(db_id, media_type)
+        if default_model is None:
+            raise ValueError(f"自定义供应商 {provider_id} 没有默认 {media_type} 模型")
+        model = default_model
+        model_id = default_model.model_id
+
+    assert model_id is not None
+    return create_custom_backend(provider=provider, model_id=model_id, endpoint=model.endpoint)

--- a/lib/custom_provider/loader.py
+++ b/lib/custom_provider/loader.py
@@ -78,5 +78,6 @@ async def load_custom_backend(
         model = default_model
         model_id = default_model.model_id
 
-    assert model_id is not None
+    if model_id is None:
+        raise ValueError(f"自定义供应商 {provider_id} 解析后仍缺少 model_id")
     return create_custom_backend(provider=provider, model_id=model_id, endpoint=model.endpoint)

--- a/lib/text_backends/factory.py
+++ b/lib/text_backends/factory.py
@@ -105,7 +105,7 @@ async def create_text_backend_for_task(
             kwargs["provider_name"] = PROVIDER_MINIMAX
         else:
             # ark / ark-agent-plan 等：用户优先，缺省回落 ProviderMeta.default_base_url
-            # （与 server.services.generation_tasks._fill_simple_provider_kwargs 对称）。
+            # （与简单族媒体 backend 构造的 base_url 优先级对称）。
             meta = PROVIDER_REGISTRY.get(provider_id)
             base_url = user_base_url or (meta.default_base_url if meta else None)
             if base_url:

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -777,7 +777,7 @@ async def test_provider_connection(
     config = await svc.get_provider_config(provider_id)
     cred.overlay_config(config)
 
-    # 与 generation_tasks._fill_simple_provider_kwargs 对称：用户未显式配 base_url
+    # 与简单族 backend 构造的 base_url 优先级对称：用户未显式配 base_url
     # 时，注入 ProviderMeta.default_base_url，使连接测试命中正确 endpoint。
     if not config.get("base_url"):
         meta = PROVIDER_REGISTRY.get(provider_id)

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 from lib.app_data_dir import app_data_dir
 from lib.asset_types import ASSET_SPECS
+from lib.backend_assembly import assemble_backend
 from lib.config.registry import PROVIDER_REGISTRY
 from lib.custom_provider import is_custom_provider
 from lib.db.base import DEFAULT_USER_ID
@@ -101,60 +102,6 @@ async def _resolve_effective_image_backend(
     return await resolver.resolve_image_backend(project, payload, capability=capability)
 
 
-async def _create_custom_backend(provider_name: str, model_id: str | None, media_type: str):
-    """自定义供应商的 backend 创建路径。
-
-    media_type 仅用于回退到默认模型时分组（仍接收以兼容调用方调用语义）。
-    实际派发以 model.endpoint 为准；若 endpoint 推算 media_type 与 caller 传入不符 → 视为模型不存在并 fallback。
-    """
-    from lib.custom_provider import parse_provider_id
-    from lib.custom_provider.endpoints import endpoint_to_media_type
-    from lib.custom_provider.factory import create_custom_backend
-    from lib.db import async_session_factory
-    from lib.db.repositories.custom_provider_repo import CustomProviderRepository
-
-    async with async_session_factory() as session:
-        repo = CustomProviderRepository(session)
-        db_id = parse_provider_id(provider_name)
-        provider = await repo.get_provider(db_id)
-        if provider is None:
-            raise ValueError(f"自定义供应商 {provider_name} 不存在")
-
-        model = None
-        if model_id:
-            from sqlalchemy import select
-
-            from lib.db.models.custom_provider import CustomProviderModel
-
-            stmt = select(CustomProviderModel).where(
-                CustomProviderModel.provider_id == db_id,
-                CustomProviderModel.model_id == model_id,
-                CustomProviderModel.is_enabled == True,  # noqa: E712
-            )
-            result = await session.execute(stmt)
-            candidate = result.scalar_one_or_none()
-            if candidate and endpoint_to_media_type(candidate.endpoint) == media_type:
-                model = candidate
-            else:
-                logger.warning(
-                    "自定义模型 %s/%s 已不存在 / 已禁用 / 媒体类型不符（期望 %s），回退到默认模型",
-                    provider_name,
-                    model_id,
-                    media_type,
-                )
-                model_id = None
-
-        if model is None:
-            default_model = await repo.get_default_model(db_id, media_type)
-            if default_model is None:
-                raise ValueError(f"自定义供应商 {provider_name} 没有默认 {media_type} 模型")
-            model = default_model
-            model_id = default_model.model_id
-
-        assert model_id is not None
-        return create_custom_backend(provider=provider, model_id=model_id, endpoint=model.endpoint)
-
-
 async def _get_or_create_video_backend(
     provider_name: str,
     provider_settings: dict,
@@ -175,14 +122,18 @@ async def _get_or_create_video_backend(
     if cache_key in _backend_cache:
         return _backend_cache[cache_key]
 
-    # 自定义供应商走独立工厂路径
-    if is_custom_provider(provider_name):
-        backend = await _create_custom_backend(provider_name, effective_model, "video")
+    # 自定义供应商 + 简单族经统一构造缝；gemini/kling 媒体特例暂留下方命令式分支
+    backend_name = _PROVIDER_ID_TO_BACKEND.get(provider_name, provider_name)
+    if is_custom_provider(provider_name) or backend_name not in (PROVIDER_GEMINI, PROVIDER_KLING):
+        backend = await assemble_backend(
+            provider_id=provider_name,
+            media_type="video",
+            model_id=effective_model,
+            resolver=resolver,
+            rate_limiter=rate_limiter,
+        )
         _backend_cache[cache_key] = backend
         return backend
-
-    # 解析 provider_id → backend registry name
-    backend_name = _PROVIDER_ID_TO_BACKEND.get(provider_name, provider_name)
 
     kwargs: dict = {}
     if backend_name == PROVIDER_GEMINI:
@@ -199,7 +150,7 @@ async def _get_or_create_video_backend(
         kwargs["api_key"] = db_config.get("api_key")
         kwargs["rate_limiter"] = rate_limiter
         kwargs["video_model"] = effective_model
-    elif backend_name == PROVIDER_KLING:
+    else:  # PROVIDER_KLING
         # 可灵 JWT 直连：双 secret（access_key + secret_key）而非单 api_key（见 ADR 0037）。
         db_config = await resolver.provider_config(PROVIDER_KLING)
         kwargs["auth_mode"] = "jwt"
@@ -209,33 +160,10 @@ async def _get_or_create_video_backend(
         base_url = db_config.get("base_url") or (PROVIDER_REGISTRY[PROVIDER_KLING].default_base_url)
         if base_url:
             kwargs["base_url"] = base_url
-    else:
-        await _fill_simple_provider_kwargs(backend_name, resolver, kwargs, effective_model)
 
     backend = create_backend(backend_name, **kwargs)
     _backend_cache[cache_key] = backend
     return backend
-
-
-async def _fill_simple_provider_kwargs(
-    backend_name: str,
-    resolver: ConfigResolver,
-    kwargs: dict,
-    effective_model: str | None,
-) -> None:
-    """Ark/Grok/OpenAI 等简单供应商的通用配置填充。
-
-    base_url 优先级：用户在 DB 配置中显式填写 > ProviderMeta.default_base_url > 不传。
-    """
-    from lib.config.registry import PROVIDER_REGISTRY
-
-    db_config = await resolver.provider_config(backend_name)
-    kwargs["api_key"] = db_config.get("api_key")
-    kwargs["model"] = effective_model
-    meta = PROVIDER_REGISTRY.get(backend_name)
-    base_url = db_config.get("base_url") or (meta.default_base_url if meta else None)
-    if base_url:
-        kwargs["base_url"] = base_url
 
 
 async def _get_or_create_image_backend(
@@ -253,13 +181,18 @@ async def _get_or_create_image_backend(
     if cache_key in _backend_cache:
         return _backend_cache[cache_key]
 
-    # 自定义供应商走独立工厂路径
-    if is_custom_provider(provider_name):
-        backend = await _create_custom_backend(provider_name, effective_model, "image")
+    # 自定义供应商 + 简单族经统一构造缝；gemini/kling 媒体特例暂留下方命令式分支
+    backend_name = _PROVIDER_ID_TO_BACKEND.get(provider_name, provider_name)
+    if is_custom_provider(provider_name) or backend_name not in (PROVIDER_GEMINI, PROVIDER_KLING):
+        backend = await assemble_backend(
+            provider_id=provider_name,
+            media_type="image",
+            model_id=effective_model,
+            resolver=resolver,
+            rate_limiter=rate_limiter,
+        )
         _backend_cache[cache_key] = backend
         return backend
-
-    backend_name = _PROVIDER_ID_TO_BACKEND.get(provider_name, provider_name)
 
     kwargs: dict = {}
     if backend_name == PROVIDER_GEMINI:
@@ -273,7 +206,7 @@ async def _get_or_create_image_backend(
         kwargs["base_url"] = db_config.get("base_url")
         kwargs["rate_limiter"] = rate_limiter
         kwargs["image_model"] = effective_model
-    elif backend_name == PROVIDER_KLING:
+    else:  # PROVIDER_KLING
         # 可灵 JWT 直连：双 secret（access_key + secret_key）而非单 api_key（见 ADR 0037）。
         meta = PROVIDER_REGISTRY[PROVIDER_KLING]
         db_config = await resolver.provider_config(PROVIDER_KLING)
@@ -288,8 +221,6 @@ async def _get_or_create_image_backend(
         base_url = db_config.get("base_url") or meta.default_base_url
         if base_url:
             kwargs["base_url"] = base_url
-    else:
-        await _fill_simple_provider_kwargs(backend_name, resolver, kwargs, effective_model)
 
     backend = create_backend(backend_name, **kwargs)
     _backend_cache[cache_key] = backend
@@ -304,23 +235,19 @@ async def _get_or_create_audio_backend(
     default_audio_model: str | None = None,
 ):
     """获取或创建 AudioBackend 实例（带缓存）。"""
-    from lib.audio_backends import create_backend
-
     effective_model = provider_settings.get("model") or default_audio_model or None
     cache_key = ("audio", provider_name, effective_model)
     if cache_key in _backend_cache:
         return _backend_cache[cache_key]
 
-    # 自定义供应商走独立工厂路径
-    if is_custom_provider(provider_name):
-        backend = await _create_custom_backend(provider_name, effective_model, "audio")
-        _backend_cache[cache_key] = backend
-        return backend
-
-    backend_name = _PROVIDER_ID_TO_BACKEND.get(provider_name, provider_name)
-    kwargs: dict = {}
-    await _fill_simple_provider_kwargs(backend_name, resolver, kwargs, effective_model)
-    backend = create_backend(backend_name, **kwargs)
+    # audio 无 gemini/kling 媒体特例：自定义 + 简单族统一经构造缝
+    backend = await assemble_backend(
+        provider_id=provider_name,
+        media_type="audio",
+        model_id=effective_model,
+        resolver=resolver,
+        rate_limiter=rate_limiter,
+    )
     _backend_cache[cache_key] = backend
     return backend
 
@@ -420,9 +347,9 @@ async def get_media_generator(
     return MediaGenerator(
         project_path,
         rate_limiter=rate_limiter,
-        image_backend=image_backend,  # type: ignore[arg-type]
-        video_backend=video_backend,  # type: ignore[arg-type]
-        audio_backend=audio_backend,  # type: ignore[arg-type]
+        image_backend=image_backend,
+        video_backend=video_backend,
+        audio_backend=audio_backend,
         config_resolver=resolver,
         user_id=user_id,
         image_provider_id=image_provider_id,

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -318,8 +318,8 @@ async def execute_reference_video_task(
     #    ScriptGenerator._fetch_video_capabilities 的口径保持一致。
     #
     #    注意：caps 基于 `project.json.video_backend` 解析；但自定义 provider 的 model
-    #    被禁用时，`_create_custom_backend` 会静默回退到默认启用 model（见
-    #    server/services/generation_tasks.py:99-122）。为避免"按旧模型 clamp、按新模型生成"
+    #    被禁用时，`lib.custom_provider.loader.load_custom_backend` 会静默回退到默认启用
+    #    model。为避免"按旧模型 clamp、按新模型生成"
     #    的错位，下面校验 caps.model 与 backend.model 是否一致；不一致就 skip clamp，
     #    把决策推给 backend 自报错。根治需要 `VideoCapabilities` 协议暴露 `max_duration`，
     #    本 PR 范围内先缓解。

--- a/tests/test_backend_assembly_loader.py
+++ b/tests/test_backend_assembly_loader.py
@@ -1,0 +1,103 @@
+"""assemble_backend 内置（简单族）async 装载段单测：内存 SQLite + 真 ConfigResolver。
+
+镜像 test_config_resolver.py 的内存 DB 范式：不 mock resolver，断言凭证 overlay 真进 LoadedConfig
+信封、端到端经 assemble_backend 造出简单族 backend、未登记 provider × media fail-loud。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from lib.backend_assembly import assemble_backend
+from lib.backend_assembly.assembler import _load_builtin_config
+from lib.config.resolver import ConfigResolver
+from lib.config.service import ConfigService
+from lib.db.base import Base
+
+
+@pytest.fixture()
+async def session_factory():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+async def _seed_provider_config(factory, provider: str, **kv: str) -> None:
+    async with factory() as session:
+        svc = ConfigService(session)
+        for key, value in kv.items():
+            await svc.set_provider_config(provider, key, value)
+        await session.commit()
+
+
+class TestLoadBuiltinConfig:
+    async def test_credential_overlay_enters_envelope(self, session_factory):
+        await _seed_provider_config(session_factory, "ark", api_key="ark-secret", base_url="https://relay.test/api/v3")
+        resolver = ConfigResolver(session_factory)
+        config = await _load_builtin_config(resolver, "ark", rate_limiter=None)
+        assert config.credentials.get("api_key") == "ark-secret"
+        assert config.credentials.get("base_url") == "https://relay.test/api/v3"
+        # registry meta 进信封：用于 default_base_url 回退
+        assert config.provider_meta is not None
+        assert config.provider_meta.default_base_url == "https://ark.cn-beijing.volces.com/api/v3"
+
+    async def test_rate_limiter_carried_into_envelope(self, session_factory):
+        sentinel = object()
+        resolver = ConfigResolver(session_factory)
+        config = await _load_builtin_config(resolver, "grok", rate_limiter=sentinel)
+        assert config.rate_limiter is sentinel
+
+
+class TestAssembleBuiltinEndToEnd:
+    @patch("lib.image_backends.registry.create_backend")
+    async def test_simple_image_end_to_end(self, mock_create, session_factory):
+        await _seed_provider_config(session_factory, "ark", api_key="ark-secret")
+        resolver = ConfigResolver(session_factory)
+        await assemble_backend(provider_id="ark", media_type="image", model_id="doubao-x", resolver=resolver)
+        # 用户未配 base_url → 回落 registry default；凭证 overlay 经装载真进构造参数
+        mock_create.assert_called_once_with(
+            "ark", api_key="ark-secret", model="doubao-x", base_url="https://ark.cn-beijing.volces.com/api/v3"
+        )
+
+    async def test_unknown_provider_media_fails_loud(self, session_factory):
+        resolver = ConfigResolver(session_factory)
+        with pytest.raises(ValueError, match="no builtin ProviderSpec"):
+            await assemble_backend(provider_id="ark", media_type="audio", model_id="x", resolver=resolver)
+
+
+class TestAssembleCustomEndToEnd:
+    @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
+    async def test_custom_provider_delegates_to_loader(self, mock_cls, session_factory):
+        from lib.custom_provider import make_provider_id
+        from lib.custom_provider.backends import CustomImageBackend
+        from lib.db.repositories.custom_provider_repo import CustomProviderRepository
+
+        async with session_factory() as s:
+            repo = CustomProviderRepository(s)
+            provider = await repo.create_provider(
+                display_name="Relay",
+                discovery_format="openai",
+                base_url="https://relay.test/v1",
+                api_key="sk-relay",
+                models=[
+                    {
+                        "model_id": "dall-e-3",
+                        "display_name": "dall-e-3",
+                        "endpoint": "openai-images",
+                        "is_enabled": True,
+                    }
+                ],
+            )
+            await s.commit()
+            pid = make_provider_id(provider.id)
+
+        resolver = ConfigResolver(session_factory)
+        result = await assemble_backend(provider_id=pid, media_type="image", model_id="dall-e-3", resolver=resolver)
+        assert isinstance(result, CustomImageBackend)
+        mock_cls.assert_called_once_with(api_key="sk-relay", base_url="https://relay.test/v1", model="dall-e-3")

--- a/tests/test_backend_assembly_specs.py
+++ b/tests/test_backend_assembly_specs.py
@@ -77,6 +77,15 @@ class TestBuildSimpleBaseUrlPriority:
         spec.build_backend(config, "grok-2-image")
         mock_create.assert_called_once_with("grok", api_key="sk-test", model="grok-2-image")
 
+    @patch("lib.image_backends.registry.create_backend")
+    def test_missing_api_key_omitted_so_sdk_env_fallback_survives(self, mock_create):
+        # 用户未配 api_key → 不传 api_key（而非传 None）：让 backend 各自决定环境变量兜底
+        # （OpenAI SDK 读 OPENAI_API_KEY）或 fail-loud；显式 None 会覆盖兜底。
+        spec = get_provider_spec("openai", "image")
+        config = _loaded(credentials={}, provider_id="openai")
+        spec.build_backend(config, "gpt-image-1")
+        mock_create.assert_called_once_with("openai", model="gpt-image-1")
+
 
 class TestMediaRegistryRouting:
     """_build_simple 按 media_type 选对应 registry 的 create_backend（唯一分支逻辑）。"""

--- a/tests/test_backend_assembly_specs.py
+++ b/tests/test_backend_assembly_specs.py
@@ -55,6 +55,20 @@ class TestBuildSimpleBaseUrlPriority:
             "ark", api_key="sk-test", model="model-x", base_url="https://custom.example.com/v3"
         )
 
+    @patch("lib.video_backends.registry.create_backend")
+    def test_ark_agent_plan_uses_own_plan_base_url(self, mock_create):
+        # ark-agent-plan 媒体侧复用 Ark backend，但 registry default 是独立的 /api/plan/v3
+        # （非 ark 的 /api/v3）——回归保护：迁移前经简单族构造即取此值，新缝须一致。
+        spec = get_provider_spec("ark-agent-plan", "video")
+        config = _loaded(credentials={"api_key": "sk-test"}, provider_id="ark-agent-plan")
+        spec.build_backend(config, "doubao-seedance-2.0")
+        mock_create.assert_called_once_with(
+            "ark-agent-plan",
+            api_key="sk-test",
+            model="doubao-seedance-2.0",
+            base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
+        )
+
     @patch("lib.image_backends.registry.create_backend")
     def test_grok_image_no_default_no_user_omits_base_url(self, mock_create):
         # grok 无 registry default 且用户未配 → 不传 base_url（grok backend 不接受该参数）
@@ -96,7 +110,7 @@ class TestRegistryShape:
         assert audio_keys == {("dashscope", "audio")}
 
     def test_simple_family_image_video_complete(self):
-        for provider in ("ark", "grok", "openai", "vidu", "dashscope", "minimax"):
+        for provider in ("ark", "ark-agent-plan", "grok", "openai", "vidu", "dashscope", "minimax"):
             assert (provider, "image") in PROVIDER_SPEC_REGISTRY
             assert (provider, "video") in PROVIDER_SPEC_REGISTRY
 

--- a/tests/test_backend_assembly_specs.py
+++ b/tests/test_backend_assembly_specs.py
@@ -1,0 +1,133 @@
+"""内置 ProviderSpec 表 + _build_simple 闭包的 sync 构造单测。
+
+镜像 test_custom_provider_factory.py：patch 各 backend 类、手搓 LoadedConfig 信封、
+断言 backend 类被以正确构造参数调用。逐 (provider, media) 覆盖简单族 base_url 优先级特例。
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from unittest.mock import patch
+
+import pytest
+
+from lib.backend_assembly.loaded_config import LoadedConfig
+from lib.backend_assembly.specs import (
+    PROVIDER_SPEC_REGISTRY,
+    _validate_provider_specs,
+    get_provider_spec,
+)
+from lib.config.registry import PROVIDER_REGISTRY
+
+
+def _loaded(*, credentials: dict, provider_id: str) -> LoadedConfig:
+    return LoadedConfig(
+        credentials=credentials,
+        provider_meta=PROVIDER_REGISTRY.get(provider_id),
+        rate_limiter=None,
+    )
+
+
+class TestBuildSimpleBaseUrlPriority:
+    """简单族 base_url 优先级：用户显式 > registry default > 不传。"""
+
+    @patch("lib.image_backends.registry.create_backend")
+    def test_ark_image_falls_back_to_registry_default(self, mock_create):
+        spec = get_provider_spec("ark", "image")
+        config = _loaded(credentials={"api_key": "sk-test"}, provider_id="ark")
+        spec.build_backend(config, "doubao-seed-2-0-pro-260215")
+        mock_create.assert_called_once_with(
+            "ark",
+            api_key="sk-test",
+            model="doubao-seed-2-0-pro-260215",
+            base_url="https://ark.cn-beijing.volces.com/api/v3",
+        )
+
+    @patch("lib.image_backends.registry.create_backend")
+    def test_user_base_url_wins_over_registry_default(self, mock_create):
+        spec = get_provider_spec("ark", "image")
+        config = _loaded(
+            credentials={"api_key": "sk-test", "base_url": "https://custom.example.com/v3"},
+            provider_id="ark",
+        )
+        spec.build_backend(config, "model-x")
+        mock_create.assert_called_once_with(
+            "ark", api_key="sk-test", model="model-x", base_url="https://custom.example.com/v3"
+        )
+
+    @patch("lib.image_backends.registry.create_backend")
+    def test_grok_image_no_default_no_user_omits_base_url(self, mock_create):
+        # grok 无 registry default 且用户未配 → 不传 base_url（grok backend 不接受该参数）
+        spec = get_provider_spec("grok", "image")
+        config = _loaded(credentials={"api_key": "sk-test"}, provider_id="grok")
+        spec.build_backend(config, "grok-2-image")
+        mock_create.assert_called_once_with("grok", api_key="sk-test", model="grok-2-image")
+
+
+class TestMediaRegistryRouting:
+    """_build_simple 按 media_type 选对应 registry 的 create_backend（唯一分支逻辑）。"""
+
+    @patch("lib.video_backends.registry.create_backend")
+    def test_dashscope_video_uses_video_registry_and_default(self, mock_create):
+        spec = get_provider_spec("dashscope", "video")
+        config = _loaded(credentials={"api_key": "sk-test"}, provider_id="dashscope")
+        spec.build_backend(config, "wan2.7-r2v")
+        mock_create.assert_called_once_with(
+            "dashscope", api_key="sk-test", model="wan2.7-r2v", base_url="https://dashscope.aliyuncs.com"
+        )
+
+    @patch("lib.audio_backends.registry.create_backend")
+    def test_dashscope_audio_uses_audio_registry(self, mock_create):
+        spec = get_provider_spec("dashscope", "audio")
+        config = _loaded(credentials={"api_key": "sk-test"}, provider_id="dashscope")
+        spec.build_backend(config, "qwen3-tts-flash")
+        mock_create.assert_called_once_with(
+            "dashscope", api_key="sk-test", model="qwen3-tts-flash", base_url="https://dashscope.aliyuncs.com"
+        )
+
+
+class TestRegistryShape:
+    def test_unknown_provider_media_fails_loud(self):
+        with pytest.raises(ValueError, match="no builtin ProviderSpec"):
+            get_provider_spec("ark", "audio")  # ark 无 audio backend，未登记
+
+    def test_audio_only_dashscope_registered(self):
+        audio_keys = {k for k in PROVIDER_SPEC_REGISTRY if k[1] == "audio"}
+        assert audio_keys == {("dashscope", "audio")}
+
+    def test_simple_family_image_video_complete(self):
+        for provider in ("ark", "grok", "openai", "vidu", "dashscope", "minimax"):
+            assert (provider, "image") in PROVIDER_SPEC_REGISTRY
+            assert (provider, "video") in PROVIDER_SPEC_REGISTRY
+
+
+class TestValidateProviderSpecs:
+    """import 期不变式：build 可调用、键与 spec 字段一致、media_type 合法。misconfig fail-fast。"""
+
+    def test_passes_on_real_registry(self):
+        _validate_provider_specs()  # 真表不抛
+
+    def test_non_callable_build_rejected(self, monkeypatch: pytest.MonkeyPatch):
+        bad = dataclasses.replace(PROVIDER_SPEC_REGISTRY[("ark", "image")], build_backend="not-callable")
+        monkeypatch.setitem(PROVIDER_SPEC_REGISTRY, ("ark", "image"), bad)
+        with pytest.raises(ValueError, match="non-callable build_backend"):
+            _validate_provider_specs()
+
+    def test_key_field_mismatch_rejected(self, monkeypatch: pytest.MonkeyPatch):
+        # spec 内 provider_id/media_type 与字典键漂移 → fail-fast
+        bad = dataclasses.replace(PROVIDER_SPEC_REGISTRY[("ark", "image")], provider_id="drifted")
+        monkeypatch.setitem(PROVIDER_SPEC_REGISTRY, ("ark", "image"), bad)
+        with pytest.raises(ValueError, match="key .* does not match spec"):
+            _validate_provider_specs()
+
+    def test_registry_backend_names_are_registered(self):
+        """ADR 0039：registry 名都在媒体后端 registry 里 —— 归单测（import 全部后端无碍），不进 import 期。"""
+        from lib.audio_backends import get_registered_backends as audio_names
+        from lib.image_backends import get_registered_backends as image_names
+        from lib.video_backends import get_registered_backends as video_names
+
+        registered = {"image": set(image_names()), "video": set(video_names()), "audio": set(audio_names())}
+        for (_provider, media), spec in PROVIDER_SPEC_REGISTRY.items():
+            assert spec.registry_backend in registered[media], (
+                f"{spec.registry_backend!r} 未注册到 {media} backend registry"
+            )

--- a/tests/test_custom_provider_loader.py
+++ b/tests/test_custom_provider_loader.py
@@ -1,0 +1,86 @@
+"""自定义 backend DB 装载（lib.custom_provider.loader）单测：内存 SQLite + 真 CustomProviderRepository。
+
+查 provider、校验 model（存在 / 启用 / endpoint 推算 media_type 相符）、失效回退默认、委托现成
+create_custom_backend（ENDPOINT_REGISTRY 不改）。镜像 test_custom_provider_repo.py 的内存 DB 范式，不 mock repo。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from lib.custom_provider import make_provider_id
+from lib.custom_provider.backends import CustomImageBackend
+from lib.custom_provider.loader import load_custom_backend
+from lib.db.base import Base
+from lib.db.repositories.custom_provider_repo import CustomProviderRepository
+
+
+@pytest.fixture()
+async def session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+async def _seed(session, *, models: list[dict]) -> str:
+    repo = CustomProviderRepository(session)
+    # display_name 列 NOT NULL：缺省补 model_id 作显示名
+    for m in models:
+        m.setdefault("display_name", m["model_id"])
+    provider = await repo.create_provider(
+        display_name="Relay",
+        discovery_format="openai",
+        base_url="https://relay.test/v1",
+        api_key="sk-relay",
+        models=models,
+    )
+    await session.commit()
+    return make_provider_id(provider.id)
+
+
+class TestLoadCustomBackend:
+    @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
+    async def test_resolves_named_model_and_delegates(self, mock_cls, session):
+        pid = await _seed(
+            session,
+            models=[{"model_id": "dall-e-3", "endpoint": "openai-images", "is_enabled": True}],
+        )
+        result = await load_custom_backend(session=session, provider_id=pid, model_id="dall-e-3", media_type="image")
+        assert isinstance(result, CustomImageBackend)
+        assert result.model == "dall-e-3"
+        mock_cls.assert_called_once_with(api_key="sk-relay", base_url="https://relay.test/v1", model="dall-e-3")
+
+    @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
+    async def test_falls_back_to_default_when_model_disabled(self, mock_cls, session):
+        # 请求的 model 已禁用 → 回退到该 media_type 的默认启用 model
+        pid = await _seed(
+            session,
+            models=[
+                {"model_id": "disabled-m", "endpoint": "openai-images", "is_enabled": False},
+                {"model_id": "active-m", "endpoint": "openai-images", "is_enabled": True, "is_default": True},
+            ],
+        )
+        result = await load_custom_backend(session=session, provider_id=pid, model_id="disabled-m", media_type="image")
+        assert result.model == "active-m"
+
+    async def test_provider_not_found_fails_loud(self, session):
+        with pytest.raises(ValueError, match="不存在"):
+            await load_custom_backend(
+                session=session, provider_id=make_provider_id(999), model_id="x", media_type="image"
+            )
+
+    async def test_no_default_model_for_media_fails_loud(self, session):
+        # 只有 image model，请求 video → 无默认 video model
+        pid = await _seed(
+            session,
+            models=[{"model_id": "dall-e-3", "endpoint": "openai-images", "is_enabled": True}],
+        )
+        with pytest.raises(ValueError, match="没有默认"):
+            await load_custom_backend(session=session, provider_id=pid, model_id=None, media_type="video")

--- a/tests/test_execute_tts_task.py
+++ b/tests/test_execute_tts_task.py
@@ -130,37 +130,38 @@ class TestExecuteTtsTask:
 
 
 class TestGetOrCreateAudioBackend:
-    async def test_custom_provider_routes_to_custom_factory(self, monkeypatch):
+    """audio backend 构造统一委托 assemble_backend；缓存留在调用方编排层。"""
+
+    async def test_custom_provider_routes_through_assemble(self, monkeypatch):
         sentinel = object()
         calls = []
 
-        async def _fake_create_custom(provider_name, model_id, media_type):
-            calls.append((provider_name, model_id, media_type))
+        async def _fake_assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
+            calls.append((provider_id, media_type, model_id))
             return sentinel
 
-        monkeypatch.setattr(generation_tasks, "_create_custom_backend", _fake_create_custom)
+        monkeypatch.setattr(generation_tasks, "assemble_backend", _fake_assemble)
         monkeypatch.setattr(generation_tasks, "_backend_cache", {})
 
-        resolver = cast(ConfigResolver, None)  # 自定义供应商分支不会触达 resolver
+        resolver = cast(ConfigResolver, None)
         b1 = await generation_tasks._get_or_create_audio_backend("custom-3", {"model": "tts-1"}, resolver)
         b2 = await generation_tasks._get_or_create_audio_backend("custom-3", {"model": "tts-1"}, resolver)
 
         assert b1 is sentinel and b2 is sentinel
-        assert calls == [("custom-3", "tts-1", "audio")], "第二次调用须命中缓存，不再重建 backend"
+        assert calls == [("custom-3", "audio", "tts-1")], "第二次调用须命中缓存，不再重建 backend"
 
     async def test_builtin_created_and_cached(self, monkeypatch):
         created = []
         sentinel = object()
 
-        def _fake_create(name, **kwargs):
-            created.append((name, kwargs))
+        async def _fake_assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
+            created.append((provider_id, media_type, model_id))
             return sentinel
 
-        monkeypatch.setattr("lib.audio_backends.create_backend", _fake_create)
-        monkeypatch.setattr(generation_tasks, "_fill_simple_provider_kwargs", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "assemble_backend", _fake_assemble)
         monkeypatch.setattr(generation_tasks, "_backend_cache", {})
 
-        resolver = cast(ConfigResolver, None)  # _fill_simple_provider_kwargs 已 mock，不触达 resolver
+        resolver = cast(ConfigResolver, None)
         b1 = await generation_tasks._get_or_create_audio_backend(
             "dashscope", {}, resolver, default_audio_model="qwen3-tts-flash"
         )
@@ -168,32 +169,25 @@ class TestGetOrCreateAudioBackend:
             "dashscope", {}, resolver, default_audio_model="qwen3-tts-flash"
         )
         assert b1 is sentinel and b2 is sentinel
-        assert len(created) == 1, "第二次调用须命中缓存，不再重建 backend"
+        assert created == [("dashscope", "audio", "qwen3-tts-flash")], "第二次调用须命中缓存，不再重建 backend"
 
     async def test_payload_model_overrides_default(self, monkeypatch):
-        created = []
+        calls = []
 
-        def _fake_create(name, **kwargs):
-            created.append(name)
+        async def _fake_assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
+            calls.append(model_id)
             return object()
 
-        monkeypatch.setattr("lib.audio_backends.create_backend", _fake_create)
-
-        filled = []
-
-        async def _fake_fill(backend_name, resolver, kwargs, effective_model):
-            filled.append(effective_model)
-
-        monkeypatch.setattr(generation_tasks, "_fill_simple_provider_kwargs", _fake_fill)
+        monkeypatch.setattr(generation_tasks, "assemble_backend", _fake_assemble)
         monkeypatch.setattr(generation_tasks, "_backend_cache", {})
 
         await generation_tasks._get_or_create_audio_backend(
             "dashscope",
             {"model": "explicit-model"},
-            cast(ConfigResolver, None),  # _fill_simple_provider_kwargs 已 mock，不触达 resolver
+            cast(ConfigResolver, None),
             default_audio_model="fallback-model",
         )
-        assert filled == ["explicit-model"]
+        assert calls == ["explicit-model"]
 
 
 class TestGetMediaGeneratorNeedsAudio:

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -868,35 +868,6 @@ class TestGetAspectRatio:
         assert generation_tasks.get_aspect_ratio(project, "props") == "16:9"
 
 
-class TestFillSimpleProviderKwargs:
-    """_fill_simple_provider_kwargs 应优先用户 base_url，缺省回落 ProviderMeta.default_base_url。"""
-
-    class _FakeResolver:
-        def __init__(self, config: dict):
-            self._config = config
-
-        async def provider_config(self, name: str) -> dict:
-            return self._config
-
-    async def test_uses_default_base_url_when_user_unset(self):
-        resolver = self._FakeResolver({"api_key": "sk-test"})
-        kwargs: dict = {}
-        await generation_tasks._fill_simple_provider_kwargs("ark", resolver, kwargs, "doubao-seed-2-0-pro-260215")
-        assert kwargs["base_url"] == "https://ark.cn-beijing.volces.com/api/v3"
-
-    async def test_user_base_url_wins(self):
-        resolver = self._FakeResolver({"api_key": "sk-test", "base_url": "https://custom.example.com/v3"})
-        kwargs: dict = {}
-        await generation_tasks._fill_simple_provider_kwargs("ark", resolver, kwargs, "model-x")
-        assert kwargs["base_url"] == "https://custom.example.com/v3"
-
-    async def test_no_default_no_user_no_kwarg(self):
-        resolver = self._FakeResolver({"api_key": "sk-test"})
-        kwargs: dict = {}
-        await generation_tasks._fill_simple_provider_kwargs("grok", resolver, kwargs, "m")
-        assert "base_url" not in kwargs
-
-
 def _ad_pm(project_path: Path, *, with_sheet: bool) -> _FakePM:
     """ad 项目 fixture：产品镜头 E1S02（引用保温杯）+ 氛围镜头 E1S01/E1S03。"""
     pm = _FakePM(project_path)


### PR DESCRIPTION
## 背景

内置供应商的 backend 构造此前散落在 generation_tasks 的三个 `_get_or_create_*` 与 text factory 四处命令式 `if/elif` 分支，per-provider 知识全泄漏到调用方，且 `PROVIDER_ID_TO_BACKEND` 映射存在两份已漂移。自定义供应商侧早已用声明式 `ENDPOINT_REGISTRY` 表。本切片把内置侧抬到同一水位，立起统一构造缝（tracer-bullet 第一弹，决策依据 ADR 0039）。

Closes #857
Parent: PRD 856

## 改动

- 新建 `lib/backend_assembly/`：统一入口 `assemble_backend(provider_id, media_type, model_id, ...)`，按 `is_custom_provider` 单分支分流到内置/自定义两族（一道门、门后两个对称房间）。
- 构造拆两段：async 装载（查 DB/config → `LoadedConfig` 信封：凭证 overlay + registry meta + 共享 rate_limiter）/ sync 纯闭包构造。
- 内置侧 `(provider_id, media_type) → ProviderSpec` 声明式表，简单族（ark/ark-agent-plan/grok/openai/vidu/dashscope/minimax）共享 `_build_simple` 闭包；import 期校验不变式 fail-fast，未登记的 `provider × media` fail-loud 抛 `ValueError`。
- 自定义 backend 的 DB 装载从 server 下移到 `lib/custom_provider/loader.py`，委托现成 `EndpointSpec.build_backend`，`ENDPOINT_REGISTRY` 一行未改。
- 三条媒体路径（分镜/视频/音频）对简单族 + 自定义改调 `assemble_backend`；删除 `_fill_simple_provider_kwargs` 与内联的 `_create_custom_backend`。gemini/kling 媒体特例本切片暂留命令式分支（下一切片迁）。backend 实例缓存仍留在调用方编排层。

## 验证

- 全量 `uv run pytest tests/`：5099 passed。
- 新增三个测试文件镜像 `test_custom_provider_factory.py`：手搓 `LoadedConfig` 断言简单族构造参数（含 base_url 优先级、grok 无 default、ark-agent-plan 专属接入地址）+ 自定义委托 + import 校验 + 内存 DB 端到端装载。
- `uv run ruff check` / `ruff format` 全绿；`uv run basedpyright` 0 error（5 个 warning 均为未触及旧代码的预存 `reportUnnecessaryIsInstance`）。

## 审查发现与修复

独立审查发现一处真实回归：统一入口迁移时漏登记 `ark-agent-plan` 媒体侧——它在 image/video registry 同名注册、有专属接入地址，迁移前经简单族路径正常构造，迁移后会因无 spec 而 fail-loud 报错。已补回简单族表并加端到端回归测试。

https://claude.ai/code/session_0126iwRjKSMx8XBWEs2Ne1ZT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Refactor**
  * 新增统一后端组装入口：内置 ProviderSpec 与自定义供应商走同一路径，并按媒体类型构造对应后端。
  * “简单族”后端创建逻辑统一处理默认 `base_url` 回退与参数传递。
  * 音频/视频/图片后端创建流程改用新组装入口，并移除旧的自定义工厂分支。
* **Bug Fixes**
  * 自定义供应商在模型被禁用或不匹配时，自动回退到同媒体类型下默认启用模型。
* **Tests**
  * 新增后端组装、规格校验与自定义加载的单元测试；更新音频组装与缓存断言，并移除不再适用的测试用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->