### PR TITLE
refactor(backend): gemini/kling 媒体后端构造迁入声明式 ProviderSpec 表 [PRD #856]

### DIFF
--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -2,9 +2,10 @@
 
 镜像自定义侧 ENDPOINT_REGISTRY（lib/custom_provider/endpoints.py）：每条 spec 是 frozen
 dataclass，挂一个 build 闭包；闭包读 LoadedConfig 信封 + model_id 拼 backend，不查 DB、不 await。
-本切片登记简单族（媒体侧只需 api_key + model + base_url 的内置 provider）的 image/video/audio，
-共享一个 _build_simple 闭包。表在 import 期校验不变式（registry 名已注册除外，见模块末尾说明），
-misconfig fail-fast。
+登记简单族（媒体侧只需 api_key + model + base_url 的内置 provider）的 image/video/audio，
+共享一个 _build_simple 闭包；外加 gemini（backend_type 双模式 + image/video base_url 非对称）与
+kling（JWT 双 secret + api_model_name 解耦）两个特例族，各自挂专属 build 闭包。表在 import 期校验
+不变式（registry 名已注册除外，见模块末尾说明），misconfig fail-fast。
 """
 
 from __future__ import annotations
@@ -71,13 +72,111 @@ def _simple_spec(provider_id: str, media_type: str) -> ProviderSpec:
     )
 
 
+# ── gemini 特例族 ──────────────────────────────────────────────────
+# gemini-aistudio / gemini-vertex 两个 provider_id 都映射到同一个 "gemini" media backend，
+# 差异只在 backend_type（aistudio | vertex）—— 由 spec 行声明（每个 provider_id 各一行），不在闭包内 if。
+# image 设 base_url，video 不设（保留迁移前的非对称：GeminiVideoBackend 虽接受 base_url 但 video 路径
+# 历来不传）。api_key 与 image 的 base_url 无条件透传（含 None）：迁移前命令式分支即无条件 db_config.get，
+# 由 backend 内 resolve_gemini_api_key / normalize_base_url 处理 None（vertex 读凭证文件、None base_url 省略）。
+
+_GEMINI_REGISTRY_BACKEND = "gemini"
+
+
+def _build_gemini_image(config: LoadedConfig, model_id: str | None, *, backend_type: str) -> Any:
+    return _media_create_backend("image")(
+        _GEMINI_REGISTRY_BACKEND,
+        backend_type=backend_type,
+        api_key=config.credentials.get("api_key"),
+        base_url=config.credentials.get("base_url"),
+        rate_limiter=config.rate_limiter,
+        image_model=model_id,
+    )
+
+
+def _build_gemini_video(config: LoadedConfig, model_id: str | None, *, backend_type: str) -> Any:
+    return _media_create_backend("video")(
+        _GEMINI_REGISTRY_BACKEND,
+        backend_type=backend_type,
+        api_key=config.credentials.get("api_key"),
+        rate_limiter=config.rate_limiter,
+        video_model=model_id,
+    )
+
+
+def _gemini_spec(provider_id: str, media_type: str, *, backend_type: str) -> ProviderSpec:
+    build = _build_gemini_image if media_type == "image" else _build_gemini_video
+    return ProviderSpec(
+        provider_id=provider_id,
+        media_type=media_type,
+        registry_backend=_GEMINI_REGISTRY_BACKEND,
+        build_backend=partial(build, backend_type=backend_type),
+    )
+
+
+# ── kling 特例族 ──────────────────────────────────────────────────
+# JWT 直连：双 secret（access_key + secret_key，按 ADR 0037 列名直取，无条件透传含 None，由 backend 内
+# resolve_kling_jwt_credentials 处理）+ auth_mode=jwt。base_url 兜底：db_config 显式填写 > registry
+# default_base_url > 不传（KlingBackend 自带 KLING_BASE_URL 兜底）。image 侧额外做 api_model_name 解耦
+# （两栖别名键如 kling-v3-omni-image 读 registry api_model_name 发真实 API 名）；video backend 不接受
+# api_model_name 参数，video 闭包不传（保留迁移前非对称）。
+
+_KLING_REGISTRY_BACKEND = "kling"
+
+
+def _kling_base_url(config: LoadedConfig) -> str | None:
+    default = config.provider_meta.default_base_url if config.provider_meta else None
+    return config.credentials.get("base_url") or default
+
+
+def _build_kling_image(config: LoadedConfig, model_id: str | None) -> Any:
+    kwargs: dict[str, Any] = {
+        "auth_mode": "jwt",
+        "access_key": config.credentials.get("access_key"),
+        "secret_key": config.credentials.get("secret_key"),
+        "model": model_id,
+    }
+    model_info = config.provider_meta.models.get(model_id) if (config.provider_meta and model_id) else None
+    if model_info is not None and model_info.api_model_name:
+        kwargs["api_model_name"] = model_info.api_model_name
+    base_url = _kling_base_url(config)
+    if base_url:
+        kwargs["base_url"] = base_url
+    return _media_create_backend("image")(_KLING_REGISTRY_BACKEND, **kwargs)
+
+
+def _build_kling_video(config: LoadedConfig, model_id: str | None) -> Any:
+    kwargs: dict[str, Any] = {
+        "auth_mode": "jwt",
+        "access_key": config.credentials.get("access_key"),
+        "secret_key": config.credentials.get("secret_key"),
+        "model": model_id,
+    }
+    base_url = _kling_base_url(config)
+    if base_url:
+        kwargs["base_url"] = base_url
+    return _media_create_backend("video")(_KLING_REGISTRY_BACKEND, **kwargs)
+
+
+def _kling_spec(media_type: str) -> ProviderSpec:
+    build = _build_kling_image if media_type == "image" else _build_kling_video
+    return ProviderSpec(
+        provider_id=_KLING_REGISTRY_BACKEND,
+        media_type=media_type,
+        registry_backend=_KLING_REGISTRY_BACKEND,
+        build_backend=build,
+    )
+
+
 # ── PROVIDER_SPEC_REGISTRY 注册表 ──────────────────────────────────
 # 键 = (provider_id, media_type)。简单族 = 媒体侧只需 api_key + model + base_url 的内置 provider，
 # 共享 _build_simple 闭包。「简单族」按构造形态界定（不是 provider 名白名单），含 ark/ark-agent-plan/
 # grok/openai/vidu 与 dashscope/minimax（后两者媒体侧走原生简单构造；其文本侧 OpenAI-compat 特例由
 # 文本工厂另行处理）。ark-agent-plan 媒体侧复用 Ark image/video backend（registry 同名注册），与 ark
-# 同为简单形态。每对显式登记一行，fail-loud（未登记的 provider × media 抛 ValueError，不「缺席即默认」
-# 造静默错误 backend）。只登记今天确有注册 backend 的对：image/video 简单族七家齐全，audio 仅 dashscope。
+# 同为简单形态。特例族 = gemini（backend_type 双模式 + image/video base_url 非对称）与 kling（JWT 双
+# secret + api_model_name 解耦），各挂专属 build 闭包；gemini 的两个 provider_id 各按 backend_type 登记
+# 一行（裸 "gemini" 是死路径——resolver 只产出带后缀 id，按 fail-loud 不登记兜底行）。每对显式登记一行，
+# fail-loud（未登记的 provider × media 抛 ValueError，不「缺席即默认」造静默错误 backend）。只登记今天
+# 确有注册 backend 的对：image/video 简单族七家齐全，audio 仅 dashscope。
 
 _SIMPLE_IMAGE_VIDEO_PROVIDERS = ("ark", "ark-agent-plan", "grok", "openai", "vidu", "dashscope", "minimax")
 _SIMPLE_MEDIA_PAIRS: list[tuple[str, str]] = [
@@ -86,9 +185,22 @@ _SIMPLE_MEDIA_PAIRS: list[tuple[str, str]] = [
     ("dashscope", "audio"),
 ]
 
+# gemini 两个 provider_id → backend_type，每个 × image/video 登记一行。
+_GEMINI_BACKEND_TYPES: dict[str, str] = {"gemini-aistudio": "aistudio", "gemini-vertex": "vertex"}
+
 PROVIDER_SPEC_REGISTRY: dict[tuple[str, str], ProviderSpec] = {
     (provider_id, media_type): _simple_spec(provider_id, media_type) for provider_id, media_type in _SIMPLE_MEDIA_PAIRS
 }
+PROVIDER_SPEC_REGISTRY.update(
+    {
+        (provider_id, media_type): _gemini_spec(provider_id, media_type, backend_type=backend_type)
+        for provider_id, backend_type in _GEMINI_BACKEND_TYPES.items()
+        for media_type in ("image", "video")
+    }
+)
+PROVIDER_SPEC_REGISTRY.update(
+    {(_KLING_REGISTRY_BACKEND, media_type): _kling_spec(media_type) for media_type in ("image", "video")}
+)
 
 
 _VALID_MEDIA_TYPES = frozenset({"image", "video", "audio"})

--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -43,20 +43,28 @@ def _media_create_backend(media_type: str) -> Callable[..., Any]:
     return create_backend
 
 
+def _resolve_base_url(config: LoadedConfig) -> str | None:
+    """base_url 优先级：用户在 db_config 显式填写 > ProviderMeta.default_base_url > None。
+
+    简单族与 kling 共用此兜底语义；调用方各自决定 None 时是否省略 base_url 参数。
+    """
+    default = config.provider_meta.default_base_url if config.provider_meta else None
+    return config.credentials.get("base_url") or default
+
+
 def _build_simple(config: LoadedConfig, model_id: str | None, *, media_type: str, registry_backend: str) -> Any:
     """简单族通用构造：api_key + model + base_url。
 
     api_key 与 base_url 同遵「仅非空才写入 kwargs」：显式传 None 可能覆盖底层 SDK 的环境变量兜底
     （如 OpenAI SDK 读 OPENAI_API_KEY），缺省由 backend 各自处理（要么读环境变量、要么 fail-loud）。
-    base_url 优先级：用户在 db_config 显式填写 > ProviderMeta.default_base_url > 不传 —— grok 等无
-    default 且用户未配的 provider 不接受 base_url 参数，传 None 会触发 TypeError。
+    base_url 优先级见 _resolve_base_url —— grok 等无 default 且用户未配的 provider 不接受 base_url
+    参数，传 None 会触发 TypeError，故仅非空才写入。
     """
     kwargs: dict[str, Any] = {"model": model_id}
     api_key = config.credentials.get("api_key")
     if api_key:
         kwargs["api_key"] = api_key
-    default_base_url = config.provider_meta.default_base_url if config.provider_meta else None
-    base_url = config.credentials.get("base_url") or default_base_url
+    base_url = _resolve_base_url(config)
     if base_url:
         kwargs["base_url"] = base_url
     return _media_create_backend(media_type)(registry_backend, **kwargs)
@@ -123,11 +131,6 @@ def _gemini_spec(provider_id: str, media_type: str, *, backend_type: str) -> Pro
 _KLING_REGISTRY_BACKEND = "kling"
 
 
-def _kling_base_url(config: LoadedConfig) -> str | None:
-    default = config.provider_meta.default_base_url if config.provider_meta else None
-    return config.credentials.get("base_url") or default
-
-
 def _build_kling_image(config: LoadedConfig, model_id: str | None) -> Any:
     kwargs: dict[str, Any] = {
         "auth_mode": "jwt",
@@ -138,7 +141,7 @@ def _build_kling_image(config: LoadedConfig, model_id: str | None) -> Any:
     model_info = config.provider_meta.models.get(model_id) if (config.provider_meta and model_id) else None
     if model_info is not None and model_info.api_model_name:
         kwargs["api_model_name"] = model_info.api_model_name
-    base_url = _kling_base_url(config)
+    base_url = _resolve_base_url(config)
     if base_url:
         kwargs["base_url"] = base_url
     return _media_create_backend("image")(_KLING_REGISTRY_BACKEND, **kwargs)
@@ -151,7 +154,7 @@ def _build_kling_video(config: LoadedConfig, model_id: str | None) -> Any:
         "secret_key": config.credentials.get("secret_key"),
         "model": model_id,
     }
-    base_url = _kling_base_url(config)
+    base_url = _resolve_base_url(config)
     if base_url:
         kwargs["base_url"] = base_url
     return _media_create_backend("video")(_KLING_REGISTRY_BACKEND, **kwargs)

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -17,7 +17,6 @@ from lib.app_data_dir import app_data_dir
 from lib.asset_types import ASSET_SPECS
 from lib.backend_assembly import assemble_backend
 from lib.config.registry import PROVIDER_REGISTRY
-from lib.custom_provider import is_custom_provider
 from lib.db.base import DEFAULT_USER_ID
 from lib.gemini_shared import get_shared_rate_limiter
 from lib.i18n import DEFAULT_LOCALE
@@ -40,7 +39,7 @@ from lib.prompt_utils import (
     is_structured_video_prompt,
     video_prompt_to_yaml,
 )
-from lib.providers import PROVIDER_ARK, PROVIDER_GEMINI, PROVIDER_GROK, PROVIDER_KLING, PROVIDER_OPENAI, PROVIDER_VIDU
+from lib.providers import PROVIDER_ARK, PROVIDER_GEMINI, PROVIDER_GROK, PROVIDER_OPENAI, PROVIDER_VIDU
 from lib.reference_compression import ReferencePayloadFloorError
 from lib.resource_paths import resource_relative_path
 from lib.storyboard_sequence import (
@@ -115,53 +114,18 @@ async def _get_or_create_video_backend(
     通过 resolver 按需加载供应商配置。
     default_video_model: 全局默认视频模型，当 provider_settings 中无 model 时作为 fallback。
     """
-    from lib.video_backends import create_backend
-
     effective_model = provider_settings.get("model") or default_video_model or None
     cache_key = ("video", provider_name, effective_model)
     if cache_key in _backend_cache:
         return _backend_cache[cache_key]
 
-    # 自定义供应商 + 简单族经统一构造缝；gemini/kling 媒体特例暂留下方命令式分支
-    backend_name = _PROVIDER_ID_TO_BACKEND.get(provider_name, provider_name)
-    if is_custom_provider(provider_name) or backend_name not in (PROVIDER_GEMINI, PROVIDER_KLING):
-        backend = await assemble_backend(
-            provider_id=provider_name,
-            media_type="video",
-            model_id=effective_model,
-            resolver=resolver,
-            rate_limiter=rate_limiter,
-        )
-        _backend_cache[cache_key] = backend
-        return backend
-
-    kwargs: dict = {}
-    if backend_name == PROVIDER_GEMINI:
-        # 确定 backend_type（aistudio 或 vertex）
-        if provider_name == "gemini-vertex":
-            kwargs["backend_type"] = "vertex"
-        elif provider_name == "gemini-aistudio":
-            kwargs["backend_type"] = "aistudio"
-        else:
-            kwargs["backend_type"] = "aistudio"
-
-        config_provider_id = "gemini-vertex" if kwargs["backend_type"] == "vertex" else "gemini-aistudio"
-        db_config = await resolver.provider_config(config_provider_id)
-        kwargs["api_key"] = db_config.get("api_key")
-        kwargs["rate_limiter"] = rate_limiter
-        kwargs["video_model"] = effective_model
-    else:  # PROVIDER_KLING
-        # 可灵 JWT 直连：双 secret（access_key + secret_key）而非单 api_key（见 ADR 0037）。
-        db_config = await resolver.provider_config(PROVIDER_KLING)
-        kwargs["auth_mode"] = "jwt"
-        kwargs["access_key"] = db_config.get("access_key")
-        kwargs["secret_key"] = db_config.get("secret_key")
-        kwargs["model"] = effective_model
-        base_url = db_config.get("base_url") or (PROVIDER_REGISTRY[PROVIDER_KLING].default_base_url)
-        if base_url:
-            kwargs["base_url"] = base_url
-
-    backend = create_backend(backend_name, **kwargs)
+    backend = await assemble_backend(
+        provider_id=provider_name,
+        media_type="video",
+        model_id=effective_model,
+        resolver=resolver,
+        rate_limiter=rate_limiter,
+    )
     _backend_cache[cache_key] = backend
     return backend
 
@@ -174,55 +138,18 @@ async def _get_or_create_image_backend(
     default_image_model: str | None = None,
 ):
     """获取或创建 ImageBackend 实例（带缓存）。"""
-    from lib.image_backends import create_backend
-
     effective_model = provider_settings.get("model") or default_image_model or None
     cache_key = ("image", provider_name, effective_model)
     if cache_key in _backend_cache:
         return _backend_cache[cache_key]
 
-    # 自定义供应商 + 简单族经统一构造缝；gemini/kling 媒体特例暂留下方命令式分支
-    backend_name = _PROVIDER_ID_TO_BACKEND.get(provider_name, provider_name)
-    if is_custom_provider(provider_name) or backend_name not in (PROVIDER_GEMINI, PROVIDER_KLING):
-        backend = await assemble_backend(
-            provider_id=provider_name,
-            media_type="image",
-            model_id=effective_model,
-            resolver=resolver,
-            rate_limiter=rate_limiter,
-        )
-        _backend_cache[cache_key] = backend
-        return backend
-
-    kwargs: dict = {}
-    if backend_name == PROVIDER_GEMINI:
-        if provider_name == "gemini-vertex":
-            kwargs["backend_type"] = "vertex"
-        else:
-            kwargs["backend_type"] = "aistudio"
-        config_id = "gemini-vertex" if kwargs["backend_type"] == "vertex" else "gemini-aistudio"
-        db_config = await resolver.provider_config(config_id)
-        kwargs["api_key"] = db_config.get("api_key")
-        kwargs["base_url"] = db_config.get("base_url")
-        kwargs["rate_limiter"] = rate_limiter
-        kwargs["image_model"] = effective_model
-    else:  # PROVIDER_KLING
-        # 可灵 JWT 直连：双 secret（access_key + secret_key）而非单 api_key（见 ADR 0037）。
-        meta = PROVIDER_REGISTRY[PROVIDER_KLING]
-        db_config = await resolver.provider_config(PROVIDER_KLING)
-        kwargs["auth_mode"] = "jwt"
-        kwargs["access_key"] = db_config.get("access_key")
-        kwargs["secret_key"] = db_config.get("secret_key")
-        kwargs["model"] = effective_model
-        # 两栖模型 registry 键名与 API 模型名解耦：别名键（如 kling-v3-omni-image）发真实 API 名。
-        model_info = meta.models.get(effective_model) if effective_model else None
-        if model_info is not None and model_info.api_model_name:
-            kwargs["api_model_name"] = model_info.api_model_name
-        base_url = db_config.get("base_url") or meta.default_base_url
-        if base_url:
-            kwargs["base_url"] = base_url
-
-    backend = create_backend(backend_name, **kwargs)
+    backend = await assemble_backend(
+        provider_id=provider_name,
+        media_type="image",
+        model_id=effective_model,
+        resolver=resolver,
+        rate_limiter=rate_limiter,
+    )
     _backend_cache[cache_key] = backend
     return backend
 

--- a/tests/test_backend_assembly_loader.py
+++ b/tests/test_backend_assembly_loader.py
@@ -70,6 +70,48 @@ class TestAssembleBuiltinEndToEnd:
         with pytest.raises(ValueError, match="no builtin ProviderSpec"):
             await assemble_backend(provider_id="ark", media_type="audio", model_id="x", resolver=resolver)
 
+    @patch("lib.image_backends.registry.create_backend")
+    async def test_gemini_aistudio_image_end_to_end(self, mock_create, session_factory):
+        # gemini 特例族：provider_id 直接决定 backend_type，凭证 overlay + 共享 rate_limiter 经装载进闭包
+        await _seed_provider_config(
+            session_factory, "gemini-aistudio", api_key="g-secret", base_url="https://g.relay.test"
+        )
+        sentinel = object()
+        resolver = ConfigResolver(session_factory)
+        await assemble_backend(
+            provider_id="gemini-aistudio",
+            media_type="image",
+            model_id="gemini-3.1-flash-image-preview",
+            resolver=resolver,
+            rate_limiter=sentinel,
+        )
+        mock_create.assert_called_once_with(
+            "gemini",
+            backend_type="aistudio",
+            api_key="g-secret",
+            base_url="https://g.relay.test",
+            rate_limiter=sentinel,
+            image_model="gemini-3.1-flash-image-preview",
+        )
+
+    @patch("lib.image_backends.registry.create_backend")
+    async def test_kling_image_api_model_name_decoupled_end_to_end(self, mock_create, session_factory):
+        # kling 特例族：双 secret overlay 真进闭包；api_model_name 解耦从 registry models 读到（别名键）
+        await _seed_provider_config(session_factory, "kling", access_key="ak-1", secret_key="sk-1")
+        resolver = ConfigResolver(session_factory)
+        await assemble_backend(
+            provider_id="kling", media_type="image", model_id="kling-v3-omni-image", resolver=resolver
+        )
+        mock_create.assert_called_once_with(
+            "kling",
+            auth_mode="jwt",
+            access_key="ak-1",
+            secret_key="sk-1",
+            model="kling-v3-omni-image",
+            api_model_name="kling-v3-omni",
+            base_url="https://api.klingai.com/v1",
+        )
+
 
 class TestAssembleCustomEndToEnd:
     @patch("lib.custom_provider.endpoints.OpenAIImageBackend")

--- a/tests/test_backend_assembly_specs.py
+++ b/tests/test_backend_assembly_specs.py
@@ -109,6 +109,178 @@ class TestMediaRegistryRouting:
         )
 
 
+class TestGeminiSpec:
+    """gemini 特例族：backend_type 按 provider_id 分叉（aistudio/vertex 各一行），image 设 base_url /
+    video 不设（非对称提升为两条表行），注入共享 rate_limiter，image_model/video_model 命名差异。
+    api_key 与 base_url 无条件透传（含 None）：与迁移前命令式分支一致，由 backend 内 resolve_gemini_api_key
+    / normalize_base_url 处理 None（读环境变量 / 省略）。"""
+
+    @patch("lib.image_backends.registry.create_backend")
+    def test_aistudio_image_sets_base_url_and_image_model(self, mock_create):
+        spec = get_provider_spec("gemini-aistudio", "image")
+        assert spec.registry_backend == "gemini"
+        limiter = object()
+        config = LoadedConfig(
+            credentials={"api_key": "sk-aistudio", "base_url": "https://custom.example.com"},
+            provider_meta=PROVIDER_REGISTRY.get("gemini-aistudio"),
+            rate_limiter=limiter,
+        )
+        spec.build_backend(config, "gemini-3.1-flash-image-preview")
+        mock_create.assert_called_once_with(
+            "gemini",
+            backend_type="aistudio",
+            api_key="sk-aistudio",
+            base_url="https://custom.example.com",
+            rate_limiter=limiter,
+            image_model="gemini-3.1-flash-image-preview",
+        )
+
+    @patch("lib.image_backends.registry.create_backend")
+    def test_vertex_image_backend_type_vertex(self, mock_create):
+        spec = get_provider_spec("gemini-vertex", "image")
+        config = LoadedConfig(
+            credentials={"api_key": None, "base_url": None},
+            provider_meta=PROVIDER_REGISTRY.get("gemini-vertex"),
+            rate_limiter=None,
+        )
+        spec.build_backend(config, None)
+        # vertex 无 api_key/base_url：仍无条件透传 None（backend 内回落凭证文件 / 省略 base_url）
+        mock_create.assert_called_once_with(
+            "gemini",
+            backend_type="vertex",
+            api_key=None,
+            base_url=None,
+            rate_limiter=None,
+            image_model=None,
+        )
+
+    @patch("lib.video_backends.registry.create_backend")
+    def test_aistudio_video_omits_base_url_uses_video_model(self, mock_create):
+        spec = get_provider_spec("gemini-aistudio", "video")
+        assert spec.registry_backend == "gemini"
+        limiter = object()
+        config = LoadedConfig(
+            credentials={"api_key": "sk-aistudio", "base_url": "https://ignored.example.com"},
+            provider_meta=PROVIDER_REGISTRY.get("gemini-aistudio"),
+            rate_limiter=limiter,
+        )
+        spec.build_backend(config, "veo-3.1-lite-generate-preview")
+        # video 非对称：不传 base_url（即使 credentials 含），命名参数是 video_model 不是 image_model
+        mock_create.assert_called_once_with(
+            "gemini",
+            backend_type="aistudio",
+            api_key="sk-aistudio",
+            rate_limiter=limiter,
+            video_model="veo-3.1-lite-generate-preview",
+        )
+
+    @patch("lib.video_backends.registry.create_backend")
+    def test_vertex_video_backend_type_vertex(self, mock_create):
+        spec = get_provider_spec("gemini-vertex", "video")
+        config = LoadedConfig(
+            credentials={"api_key": None},
+            provider_meta=PROVIDER_REGISTRY.get("gemini-vertex"),
+            rate_limiter=None,
+        )
+        spec.build_backend(config, "veo-3.1-generate-preview")
+        mock_create.assert_called_once_with(
+            "gemini",
+            backend_type="vertex",
+            api_key=None,
+            rate_limiter=None,
+            video_model="veo-3.1-generate-preview",
+        )
+
+    def test_bare_gemini_not_registered(self):
+        # 裸 "gemini"（无 aistudio/vertex 后缀）是死路径：resolver 只产出带后缀 id。
+        # 按 ADR 0039 fail-loud，不为死路径登记兜底行。
+        assert ("gemini", "image") not in PROVIDER_SPEC_REGISTRY
+        assert ("gemini", "video") not in PROVIDER_SPEC_REGISTRY
+
+
+class TestKlingSpec:
+    """kling 特例族：JWT 双 secret（access_key + secret_key 按 ADR 0037 列名直取）、auth_mode=jwt、
+    image 侧 api_model_name 解耦（两栖别名键读 registry api_model_name）、base_url 兜底（db > registry default）。
+    video backend 不接受 api_model_name —— 非对称，video 闭包不传。"""
+
+    @patch("lib.image_backends.registry.create_backend")
+    def test_image_dual_secret_and_jwt(self, mock_create):
+        spec = get_provider_spec("kling", "image")
+        assert spec.registry_backend == "kling"
+        config = LoadedConfig(
+            credentials={"access_key": "ak-1", "secret_key": "sk-1"},
+            provider_meta=PROVIDER_REGISTRY.get("kling"),
+            rate_limiter=None,
+        )
+        spec.build_backend(config, "kling-image-o1")
+        mock_create.assert_called_once_with(
+            "kling",
+            auth_mode="jwt",
+            access_key="ak-1",
+            secret_key="sk-1",
+            model="kling-image-o1",
+            base_url="https://api.klingai.com/v1",
+        )
+
+    @patch("lib.image_backends.registry.create_backend")
+    def test_image_api_model_name_decoupled_for_amphibious_alias(self, mock_create):
+        # 两栖别名键 kling-v3-omni-image 的 registry api_model_name 是 kling-v3-omni（发真实 API 名）。
+        spec = get_provider_spec("kling", "image")
+        config = LoadedConfig(
+            credentials={"access_key": "ak-1", "secret_key": "sk-1"},
+            provider_meta=PROVIDER_REGISTRY.get("kling"),
+            rate_limiter=None,
+        )
+        spec.build_backend(config, "kling-v3-omni-image")
+        mock_create.assert_called_once_with(
+            "kling",
+            auth_mode="jwt",
+            access_key="ak-1",
+            secret_key="sk-1",
+            model="kling-v3-omni-image",
+            api_model_name="kling-v3-omni",
+            base_url="https://api.klingai.com/v1",
+        )
+
+    @patch("lib.image_backends.registry.create_backend")
+    def test_image_user_base_url_wins_over_registry_default(self, mock_create):
+        spec = get_provider_spec("kling", "image")
+        config = LoadedConfig(
+            credentials={"access_key": "ak-1", "secret_key": "sk-1", "base_url": "https://relay.example.com"},
+            provider_meta=PROVIDER_REGISTRY.get("kling"),
+            rate_limiter=None,
+        )
+        spec.build_backend(config, "kling-image-o1")
+        mock_create.assert_called_once_with(
+            "kling",
+            auth_mode="jwt",
+            access_key="ak-1",
+            secret_key="sk-1",
+            model="kling-image-o1",
+            base_url="https://relay.example.com",
+        )
+
+    @patch("lib.video_backends.registry.create_backend")
+    def test_video_dual_secret_no_api_model_name(self, mock_create):
+        spec = get_provider_spec("kling", "video")
+        assert spec.registry_backend == "kling"
+        config = LoadedConfig(
+            credentials={"access_key": "ak-1", "secret_key": "sk-1"},
+            provider_meta=PROVIDER_REGISTRY.get("kling"),
+            rate_limiter=None,
+        )
+        spec.build_backend(config, "kling-v3")
+        # video backend 不接受 api_model_name：即使 model 是别名也不传该参数（迁移前 video 分支即不设）
+        mock_create.assert_called_once_with(
+            "kling",
+            auth_mode="jwt",
+            access_key="ak-1",
+            secret_key="sk-1",
+            model="kling-v3",
+            base_url="https://api.klingai.com/v1",
+        )
+
+
 class TestRegistryShape:
     def test_unknown_provider_media_fails_loud(self):
         with pytest.raises(ValueError, match="no builtin ProviderSpec"):


### PR DESCRIPTION
## 背景

把 gemini 与 kling 两家有构造特例的内置 provider 的**媒体侧（image + video）**构造，从命令式 `if/elif` 分支迁进声明式 `ProviderSpec` 闭包表（ADR 0039）。迁完媒体侧 `_get_or_create_*` 仅余「查缓存 → `assemble_backend` → 存缓存」的薄壳。行为零变化，活路径与迁移前对拍一致。

基线为 #857（统一内置/自定义供应商 backend 构造入口）的成果。

## 改动

- **gemini 特例族**（`lib/backend_assembly/specs.py`）：`gemini-aistudio` / `gemini-vertex` 各按 `backend_type` 登记一行（不在闭包内 `if` 分叉）；image 设 `base_url` / video 不设（保留迁移前非对称，提升为两条显式表行）；`api_key`/`base_url` 含 None 无条件透传，由 backend 内 `resolve_gemini_api_key` / `normalize_base_url` 处理；注入共享 `rate_limiter`；`image_model` / `video_model` 命名差异封进各自闭包。
- **kling 特例族**：`auth_mode=jwt` + 双 secret（`access_key` + `secret_key`，按 ADR 0037 列名直取）；image 侧 `api_model_name` 解耦（两栖别名键读 registry `api_model_name`）；`base_url` 兜底（db_config > registry default）；video 闭包不传 `api_model_name`（保留迁移前非对称）。
- **裸 `gemini`**（无后缀）按 ADR 0039 fail-loud 不登记兜底行——resolver 只产出带后缀的规范 id（`PROVIDER_REGISTRY` 不含裸 `gemini` 键），该路径迁移前即为死路径。
- **`server/services/generation_tasks.py`**：删 gemini `if` / kling `elif` 命令式分支与失效 import（`is_custom_provider`、`PROVIDER_KLING`），媒体侧 `_get_or_create_*` 变薄壳。
- **审查 cleanup**：抽模块级 `_resolve_base_url` helper，消除简单族与 kling 各一份的 base_url 兜底重复表达式。

## 验证

- 新增单测：specs 加 `TestGeminiSpec` / `TestKlingSpec`（各 4 用例）+ 死路径断言；loader 端到端加 gemini-aistudio image + kling api_model_name 解耦两段内存 DB 用例。
- 全量 `uv run pytest tests/`：5112 passed。
- `uv run ruff check . && uv run ruff format --check .`：通过。
- `uv run basedpyright`：0 errors。
- 本地审查逐项对照迁移前命令式分支，确认 gemini/kling 的 `base_url` / `api_key` / `api_model_name` / 双 secret 透传与迁移前 1:1 一致；裸 gemini 死路径 fail-loud 经 resolver 规范 id 约束证实不可达。

Closes #858

https://claude.ai/code/session_0126iwRjKSMx8XBWEs2Ne1ZT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 统一了提供商后端的装配机制，简化了 Gemini 和 Kling 等多个提供商的配置处理流程。
  * 优化了视频和图像后端的获取逻辑，提升了系统的可维护性和稳定性。

* **测试**
  * 新增端到端集成测试，验证提供商规格配置和后端装配的正确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->