### PR TITLE
refactor(backend): 文本后端工厂收口统一构造缝，根除映射漂移

### DIFF
--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -37,7 +37,7 @@ class ProviderSpec:
 def _media_create_backend(media_type: str) -> Callable[..., Any]:
     """按 media_type 取对应 registry 的 create_backend（运行时取，便于测试 patch 模块属性）。
 
-    text 与 image/video/audio 四条 media_type 共用同一缝（见 ADR 0039），文本 backend 注册在
+    text 与 image/video/audio 四条 media_type 共用同一构造缝，文本 backend 注册在
     独立的 lib.text_backends.registry，故在此分流。
     """
     if media_type == "image":
@@ -132,7 +132,7 @@ def _gemini_spec(provider_id: str, media_type: str, *, backend_type: str) -> Pro
 
 
 # ── kling 特例族 ──────────────────────────────────────────────────
-# JWT 直连：双 secret（access_key + secret_key，按 ADR 0037 列名直取，无条件透传含 None，由 backend 内
+# JWT 直连：双 secret（access_key + secret_key 按列名直取，无条件透传含 None，由 backend 内
 # resolve_kling_jwt_credentials 处理）+ auth_mode=jwt。base_url 兜底：db_config 显式填写 > registry
 # default_base_url > 不传（KlingBackend 自带 KLING_BASE_URL 兜底）。image 侧额外做 api_model_name 解耦
 # （两栖别名键如 kling-v3-omni-image 读 registry api_model_name 发真实 API 名）；video backend 不接受
@@ -368,9 +368,9 @@ _VALID_MEDIA_TYPES = frozenset({"image", "video", "audio", "text"})
 def _validate_provider_specs() -> None:
     """import 期校验内置表自身不变式，misconfig fail-fast（镜像 endpoints._validate_video_caps_declarations）。
 
-    只做不需 import 媒体后端的内表自洽检查：build 可调用、字典键与 spec 字段一致、media_type 合法。
-    「registry 名都在媒体后端 registry 里」需 import 全部 lib.{image,video,audio}_backends 才能断言，
-    为免轻量场景（CLI / 迁移）因 import 本缝而被动拉起全部后端，归入单测，不进 import 期（见 ADR 0039）。
+    只做不需 import 后端的内表自洽检查：build 可调用、字典键与 spec 字段一致、media_type 合法。
+    「registry 名都在对应后端 registry 里」需 import 全部 lib.{image,video,audio,text}_backends 才能断言，
+    为免轻量场景（CLI / 迁移）因 import 本缝而被动拉起全部后端，归入单测，不进 import 期。
     """
     for key, spec in PROVIDER_SPEC_REGISTRY.items():
         if not callable(spec.build_backend):

--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -4,7 +4,11 @@
 dataclass，挂一个 build 闭包；闭包读 LoadedConfig 信封 + model_id 拼 backend，不查 DB、不 await。
 登记简单族（媒体侧只需 api_key + model + base_url 的内置 provider）的 image/video/audio，
 共享一个 _build_simple 闭包；外加 gemini（backend_type 双模式 + image/video base_url 非对称）与
-kling（JWT 双 secret + api_model_name 解耦）两个特例族，各自挂专属 build 闭包。表在 import 期校验
+kling（JWT 双 secret + api_model_name 解耦）两个特例族，各自挂专属 build 闭包。文本（media_type=text）
+四条 media_type 同经本表：简单文本（ark/ark-agent-plan/grok）、gemini 文本（aistudio/vertex）、
+OpenAI-compat 文本（openai/dashscope/minimax，dashscope/minimax 经 helper 派生 base_url + 透传
+provider_name 计费归因）各挂专属闭包；文本侧别名映射（dashscope/minimax → openai registry backend）
+并入 spec 的 registry_backend 字段，根除原文本工厂第二份 PROVIDER_ID_TO_BACKEND。表在 import 期校验
 不变式（registry 名已注册除外，见模块末尾说明），misconfig fail-fast。
 """
 
@@ -24,20 +28,26 @@ class ProviderSpec:
     """单条内置 (provider, media) 的 backend 构造规格。"""
 
     provider_id: str  # registry / config provider id，如 "ark"
-    media_type: str  # "image" | "video" | "audio"
+    media_type: str  # "image" | "video" | "audio" | "text"
     registry_backend: str  # 映射到哪个 media backend registry 名（合并两份 PROVIDER_ID_TO_BACKEND）
     # model_id 可为 None：缺省时由 backend 内部回落各自 DEFAULT_MODEL（与 effective_model 上游一致）
     build_backend: Callable[[LoadedConfig, str | None], Any]
 
 
 def _media_create_backend(media_type: str) -> Callable[..., Any]:
-    """按 media_type 取对应 registry 的 create_backend（运行时取，便于测试 patch 模块属性）。"""
+    """按 media_type 取对应 registry 的 create_backend（运行时取，便于测试 patch 模块属性）。
+
+    text 与 image/video/audio 四条 media_type 共用同一缝（见 ADR 0039），文本 backend 注册在
+    独立的 lib.text_backends.registry，故在此分流。
+    """
     if media_type == "image":
         from lib.image_backends.registry import create_backend
     elif media_type == "video":
         from lib.video_backends.registry import create_backend
     elif media_type == "audio":
         from lib.audio_backends.registry import create_backend
+    elif media_type == "text":
+        from lib.text_backends.registry import create_backend
     else:
         raise ValueError(f"unknown media_type: {media_type!r}")
     return create_backend
@@ -170,16 +180,142 @@ def _kling_spec(media_type: str) -> ProviderSpec:
     )
 
 
+# ── 文本族 ────────────────────────────────────────────────────────
+# 文本 backend 注册在独立的 lib.text_backends.registry（非 media registry），构造形态与媒体有别：
+# api_key/base_url 透传规则、OpenAI-compat 别名映射、provider_name 计费归因透传各不相同，故文本侧
+# 不复用 _build_simple，各类形态挂专属闭包。三类：
+#   ① 简单文本（ark / ark-agent-plan / grok）—— model + api_key（无条件透传）+ base_url（user >
+#      registry default，仅非空才传，对称媒体简单族 base_url 优先级）。
+#   ② gemini 文本 —— aistudio（model + api_key + base_url 无条件透传，含 None/空串）/ vertex
+#      （model + backend=vertex + gcs_bucket）按 provider_id 分两行，不在闭包内 if。
+#   ③ OpenAI-compat（openai / dashscope / minimax）—— 都映射到 "openai" registry backend；openai 直传
+#      用户 base_url（无条件，含 None），dashscope/minimax 由各自 helper 从 host 派生 base_url 并透传
+#      真实 provider_name，确保 usage 记账与计费查表命中自身（百炼/MiniMax）的 CNY 费率而非 OpenAI USD。
+
+
+def _build_text_simple(config: LoadedConfig, model_id: str | None, *, registry_backend: str) -> Any:
+    """简单文本族：model + api_key（无条件透传）+ base_url（user > registry default，仅非空才传）。
+
+    api_key 无条件透传（含 None）保留迁移前命令式分支语义（db_config.get("api_key") 直写 kwargs）；
+    base_url 仅非空才写入，对称媒体简单族 —— ark/ark-agent-plan 有 registry default 回落，grok 无 default
+    且用户未配时省略该参数。
+    """
+    kwargs: dict[str, Any] = {"model": model_id, "api_key": config.credentials.get("api_key")}
+    base_url = _resolve_base_url(config)
+    if base_url:
+        kwargs["base_url"] = base_url
+    return _media_create_backend("text")(registry_backend, **kwargs)
+
+
+def _text_simple_spec(provider_id: str) -> ProviderSpec:
+    """登记一条简单文本 spec：registry_backend 即 provider_id 自身（文本侧无别名映射）。"""
+    return ProviderSpec(
+        provider_id=provider_id,
+        media_type="text",
+        registry_backend=provider_id,
+        build_backend=partial(_build_text_simple, registry_backend=provider_id),
+    )
+
+
+_TEXT_GEMINI_REGISTRY_BACKEND = "gemini"
+
+
+def _build_text_gemini_aistudio(config: LoadedConfig, model_id: str | None) -> Any:
+    # aistudio 允许用户填自定义 endpoint，无 registry default：base_url 无条件透传用户值（含 None/空串），
+    # 由 GeminiTextBackend 内部处理。文本 gemini 不接受 rate_limiter（保留迁移前非对称）。
+    return _media_create_backend("text")(
+        _TEXT_GEMINI_REGISTRY_BACKEND,
+        model=model_id,
+        api_key=config.credentials.get("api_key"),
+        base_url=config.credentials.get("base_url"),
+    )
+
+
+def _build_text_gemini_vertex(config: LoadedConfig, model_id: str | None) -> Any:
+    # vertex 走服务账号凭证文件 + gcs_bucket，不传 api_key/base_url（保留迁移前命令式分支）。
+    return _media_create_backend("text")(
+        _TEXT_GEMINI_REGISTRY_BACKEND,
+        model=model_id,
+        backend="vertex",
+        gcs_bucket=config.credentials.get("gcs_bucket"),
+    )
+
+
+def _text_gemini_spec(provider_id: str, *, build: Callable[[LoadedConfig, str | None], Any]) -> ProviderSpec:
+    return ProviderSpec(
+        provider_id=provider_id,
+        media_type="text",
+        registry_backend=_TEXT_GEMINI_REGISTRY_BACKEND,
+        build_backend=build,
+    )
+
+
+_TEXT_OPENAI_COMPAT_REGISTRY_BACKEND = "openai"
+
+
+def _dashscope_text_base_url(configured: str | None) -> str:
+    # 运行时 import：免轻量场景（CLI / 迁移）因 import 本表被动拉起 dashscope_shared。
+    from lib.dashscope_shared import dashscope_text_base_url
+
+    return dashscope_text_base_url(configured)
+
+
+def _minimax_text_base_url(configured: str | None) -> str:
+    from lib.minimax_shared import minimax_text_base_url
+
+    return minimax_text_base_url(configured)
+
+
+def _build_text_openai_compat(
+    config: LoadedConfig,
+    model_id: str | None,
+    *,
+    derive_base_url: Callable[[str | None], str] | None,
+    provider_name: str | None,
+) -> Any:
+    """OpenAI-compat 文本构造：openai / dashscope / minimax 都用 OpenAITextBackend。
+
+    derive_base_url=None（openai）：直传用户 base_url（无条件，含 None，由 backend 决定 endpoint）。
+    derive_base_url 非空（dashscope/minimax）：由 helper 从用户 host 派生 OpenAI 兼容 base，并透传
+    provider_name 给 backend，确保 usage 记账与计费查表命中自身 CNY 费率而非 OpenAI USD。
+    """
+    user_base_url = config.credentials.get("base_url")
+    kwargs: dict[str, Any] = {
+        "model": model_id,
+        "api_key": config.credentials.get("api_key"),
+        "base_url": derive_base_url(user_base_url) if derive_base_url else user_base_url,
+    }
+    if provider_name:
+        kwargs["provider_name"] = provider_name
+    return _media_create_backend("text")(_TEXT_OPENAI_COMPAT_REGISTRY_BACKEND, **kwargs)
+
+
+def _text_openai_compat_spec(
+    provider_id: str,
+    *,
+    derive_base_url: Callable[[str | None], str] | None,
+    provider_name: str | None,
+) -> ProviderSpec:
+    return ProviderSpec(
+        provider_id=provider_id,
+        media_type="text",
+        registry_backend=_TEXT_OPENAI_COMPAT_REGISTRY_BACKEND,
+        build_backend=partial(_build_text_openai_compat, derive_base_url=derive_base_url, provider_name=provider_name),
+    )
+
+
 # ── PROVIDER_SPEC_REGISTRY 注册表 ──────────────────────────────────
 # 键 = (provider_id, media_type)。简单族 = 媒体侧只需 api_key + model + base_url 的内置 provider，
 # 共享 _build_simple 闭包。「简单族」按构造形态界定（不是 provider 名白名单），含 ark/ark-agent-plan/
-# grok/openai/vidu 与 dashscope/minimax（后两者媒体侧走原生简单构造；其文本侧 OpenAI-compat 特例由
-# 文本工厂另行处理）。ark-agent-plan 媒体侧复用 Ark image/video backend（registry 同名注册），与 ark
-# 同为简单形态。特例族 = gemini（backend_type 双模式 + image/video base_url 非对称）与 kling（JWT 双
-# secret + api_model_name 解耦），各挂专属 build 闭包；gemini 的两个 provider_id 各按 backend_type 登记
-# 一行（裸 "gemini" 是死路径——resolver 只产出带后缀 id，按 fail-loud 不登记兜底行）。每对显式登记一行，
-# fail-loud（未登记的 provider × media 抛 ValueError，不「缺席即默认」造静默错误 backend）。只登记今天
-# 确有注册 backend 的对：image/video 简单族七家齐全，audio 仅 dashscope。
+# grok/openai/vidu 与 dashscope/minimax（后两者媒体侧走原生简单构造；其文本侧 OpenAI-compat 形态见下方
+# 文本族）。ark-agent-plan 媒体侧复用 Ark image/video backend（registry 同名注册），与 ark 同为简单形态。
+# 特例族 = gemini（backend_type 双模式 + image/video base_url 非对称）与 kling（JWT 双 secret +
+# api_model_name 解耦），各挂专属 build 闭包；gemini 的两个 provider_id 各按 backend_type 登记一行（裸
+# "gemini" 是死路径——resolver 只产出带后缀 id，按 fail-loud 不登记兜底行）。文本族（media_type=text）按
+# 构造形态分三类登记（简单文本 / gemini 文本 / OpenAI-compat 文本，见各闭包），其中 dashscope/minimax 文本
+# 映射到 "openai" registry backend，别名映射并入 spec.registry_backend 字段。每对显式登记一行，fail-loud
+# （未登记的 provider × media 抛 ValueError，不「缺席即默认」造静默错误 backend）。只登记今天确有注册 backend
+# 的对：image/video 简单族七家齐全，audio 仅 dashscope，text 八家（六 provider，gemini 两 id）。
 
 _SIMPLE_IMAGE_VIDEO_PROVIDERS = ("ark", "ark-agent-plan", "grok", "openai", "vidu", "dashscope", "minimax")
 _SIMPLE_MEDIA_PAIRS: list[tuple[str, str]] = [
@@ -205,8 +341,28 @@ PROVIDER_SPEC_REGISTRY.update(
     {(_KLING_REGISTRY_BACKEND, media_type): _kling_spec(media_type) for media_type in ("image", "video")}
 )
 
+# ── 文本族注册 ────────────────────────────────────────────────────
+# 简单文本三家（registry_backend = provider_id 自身）；gemini 两个 provider_id 按 backend 分两行
+# （aistudio/vertex 各自闭包，registry_backend 同为 "gemini"）；OpenAI-compat 三家都映射到 "openai"
+# registry backend，openai 直传用户 base_url，dashscope/minimax 经 helper 派生 + 透传 provider_name 计费归因。
+_TEXT_SIMPLE_PROVIDERS = ("ark", "ark-agent-plan", "grok")
+PROVIDER_SPEC_REGISTRY.update({(p, "text"): _text_simple_spec(p) for p in _TEXT_SIMPLE_PROVIDERS})
+PROVIDER_SPEC_REGISTRY.update(
+    {
+        ("gemini-aistudio", "text"): _text_gemini_spec("gemini-aistudio", build=_build_text_gemini_aistudio),
+        ("gemini-vertex", "text"): _text_gemini_spec("gemini-vertex", build=_build_text_gemini_vertex),
+        ("openai", "text"): _text_openai_compat_spec("openai", derive_base_url=None, provider_name=None),
+        ("dashscope", "text"): _text_openai_compat_spec(
+            "dashscope", derive_base_url=_dashscope_text_base_url, provider_name="dashscope"
+        ),
+        ("minimax", "text"): _text_openai_compat_spec(
+            "minimax", derive_base_url=_minimax_text_base_url, provider_name="minimax"
+        ),
+    }
+)
 
-_VALID_MEDIA_TYPES = frozenset({"image", "video", "audio"})
+
+_VALID_MEDIA_TYPES = frozenset({"image", "video", "audio", "text"})
 
 
 def _validate_provider_specs() -> None:

--- a/lib/text_backends/factory.py
+++ b/lib/text_backends/factory.py
@@ -1,27 +1,16 @@
-"""文本 backend 工厂。"""
+"""文本 backend 工厂。
+
+provider/model 解析仍在此（resolver.text_backend_for_task），backend 构造收口到统一缝
+assemble_backend（media_type=text，见 docs/adr/0039）：内置文本 provider 全部经 ProviderSpec 表，
+自定义 provider 经下移到 lib 的 load_custom_backend，文本侧不再各写一份命令式构造与自定义解析。
+"""
 
 from __future__ import annotations
 
-from lib.config.registry import PROVIDER_REGISTRY
+from lib.backend_assembly import assemble_backend
 from lib.config.resolver import ConfigResolver
-from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.db import async_session_factory
-from lib.providers import PROVIDER_DASHSCOPE, PROVIDER_MINIMAX, PROVIDER_OPENAI
 from lib.text_backends.base import TextBackend, TextTaskType
-from lib.text_backends.registry import create_backend
-
-PROVIDER_ID_TO_BACKEND: dict[str, str] = {
-    "gemini-aistudio": "gemini",
-    "gemini-vertex": "gemini",
-    "ark": "ark",
-    "ark-agent-plan": "ark-agent-plan",
-    "grok": "grok",
-    "openai": "openai",
-    # 阿里百炼文本走 OpenAI 兼容协议，复用 OpenAI 后端（base_url 与 provider_name 在下方特例处理）
-    "dashscope": "openai",
-    # MiniMax 文本同样走 OpenAI 兼容协议，复用 OpenAI 后端（单 /v1 base，处理见下方特例）
-    "minimax": "openai",
-}
 
 
 async def create_text_backend_for_task(
@@ -33,82 +22,10 @@ async def create_text_backend_for_task(
 
     async with resolver.session() as r:
         provider_id, model_id = await r.text_backend_for_task(task_type, project_name)
-
-        # Custom providers use a separate factory path
-        if is_custom_provider(provider_id):
-            from sqlalchemy import select
-
-            from lib.custom_provider.endpoints import endpoint_to_media_type
-            from lib.custom_provider.factory import create_custom_backend
-            from lib.db.models.custom_provider import CustomProviderModel
-            from lib.db.repositories.custom_provider_repo import CustomProviderRepository
-
-            async with r._open_session() as (session, _):
-                repo = CustomProviderRepository(session)
-                db_id = parse_provider_id(provider_id)
-                provider = await repo.get_provider(db_id)
-                if provider is None:
-                    raise ValueError("配置的自定义供应商已被删除，请到项目设置中重新选择文本模型")
-                name = provider.display_name
-                model = None
-                # 校验 model_id 仍存在、已启用、endpoint 推算 media_type=text
-                if model_id:
-                    stmt = select(CustomProviderModel).where(
-                        CustomProviderModel.provider_id == db_id,
-                        CustomProviderModel.model_id == model_id,
-                        CustomProviderModel.is_enabled == True,  # noqa: E712
-                    )
-                    result = await session.execute(stmt)
-                    candidate = result.scalar_one_or_none()
-                    if candidate and endpoint_to_media_type(candidate.endpoint) == "text":
-                        model = candidate
-                    else:
-                        model_id = None
-                if model is None:
-                    default_model = await repo.get_default_model(db_id, "text")
-                    if default_model is None:
-                        raise ValueError(f"供应商「{name}」没有可用的文本模型，请到项目设置中重新选择")
-                    model = default_model
-                    model_id = default_model.model_id
-                assert model_id is not None
-                return create_custom_backend(  # type: ignore[return-value]
-                    provider=provider, model_id=model_id, endpoint=model.endpoint
-                )
-
-        provider_config = await r.provider_config(provider_id)
-
-    backend_name = PROVIDER_ID_TO_BACKEND.get(provider_id, provider_id)
-    kwargs: dict = {"model": model_id}
-
-    if provider_id == "gemini-vertex":
-        kwargs["backend"] = "vertex"
-        kwargs["gcs_bucket"] = provider_config.get("gcs_bucket")
-    else:
-        kwargs["api_key"] = provider_config.get("api_key")
-        user_base_url = provider_config.get("base_url")
-        if provider_id in ("gemini-aistudio", PROVIDER_OPENAI):
-            # 这两个允许用户填自定义 endpoint，没有 registry default。
-            kwargs["base_url"] = user_base_url
-        elif provider_id == PROVIDER_DASHSCOPE:
-            # 文本走 OpenAI 兼容模式：从 host 派生 /compatible-mode/v1；并透传真实 provider
-            # 名给 OpenAI 后端，确保 usage 记账与计费查表命中百炼自身的 CNY 费率。
-            from lib.dashscope_shared import dashscope_text_base_url
-
-            kwargs["base_url"] = dashscope_text_base_url(user_base_url)
-            kwargs["provider_name"] = PROVIDER_DASHSCOPE
-        elif provider_id == PROVIDER_MINIMAX:
-            # MiniMax 文本走 OpenAI 兼容模式：单 /v1 base（缺省国内站，可改 base_url 指向国际站）；
-            # 透传真实 provider 名给 OpenAI 后端，确保 usage 记账与计费查表命中 MiniMax 自身的 CNY 费率。
-            from lib.minimax_shared import minimax_text_base_url
-
-            kwargs["base_url"] = minimax_text_base_url(user_base_url)
-            kwargs["provider_name"] = PROVIDER_MINIMAX
-        else:
-            # ark / ark-agent-plan 等：用户优先，缺省回落 ProviderMeta.default_base_url
-            # （与简单族媒体 backend 构造的 base_url 优先级对称）。
-            meta = PROVIDER_REGISTRY.get(provider_id)
-            base_url = user_base_url or (meta.default_base_url if meta else None)
-            if base_url:
-                kwargs["base_url"] = base_url
-
-    return create_backend(backend_name, **kwargs)
+        backend = await assemble_backend(
+            provider_id=provider_id,
+            media_type="text",
+            model_id=model_id,
+            resolver=r,
+        )
+    return backend

--- a/lib/text_backends/factory.py
+++ b/lib/text_backends/factory.py
@@ -1,7 +1,7 @@
 """文本 backend 工厂。
 
 provider/model 解析仍在此（resolver.text_backend_for_task），backend 构造收口到统一缝
-assemble_backend（media_type=text，见 docs/adr/0039）：内置文本 provider 全部经 ProviderSpec 表，
+assemble_backend（media_type=text）：内置文本 provider 全部经 ProviderSpec 表，
 自定义 provider 经下移到 lib 的 load_custom_backend，文本侧不再各写一份命令式构造与自定义解析。
 """
 

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -39,7 +39,6 @@ from lib.prompt_utils import (
     is_structured_video_prompt,
     video_prompt_to_yaml,
 )
-from lib.providers import PROVIDER_ARK, PROVIDER_GEMINI, PROVIDER_GROK, PROVIDER_OPENAI, PROVIDER_VIDU
 from lib.reference_compression import ReferencePayloadFloorError
 from lib.resource_paths import resource_relative_path
 from lib.storyboard_sequence import (
@@ -59,17 +58,6 @@ logger = logging.getLogger(__name__)
 
 # 按 (channel, provider_name, model) 缓存 Backend 实例，避免每次任务重建 API 客户端
 _backend_cache: dict[tuple[str, str, str | None], Any] = {}
-
-# 新 provider_id → 旧 backend registry name 的映射
-_PROVIDER_ID_TO_BACKEND: dict[str, str] = {
-    "gemini-aistudio": PROVIDER_GEMINI,
-    "gemini-vertex": PROVIDER_GEMINI,
-    PROVIDER_GEMINI: PROVIDER_GEMINI,
-    PROVIDER_ARK: PROVIDER_ARK,
-    PROVIDER_GROK: PROVIDER_GROK,
-    PROVIDER_OPENAI: PROVIDER_OPENAI,
-    PROVIDER_VIDU: PROVIDER_VIDU,
-}
 
 
 def get_project_manager() -> ProjectManager:
@@ -183,23 +171,17 @@ async def _resolve_video_backend(
     project_name: str,
     resolver: ConfigResolver,
     payload: dict | None,
-) -> tuple[Any | None, str, str, str]:
-    """解析并构造视频后端，返回 (video_backend, video_backend_type, video_model, provider_id)。
+) -> tuple[Any | None, str]:
+    """解析并构造视频后端，返回 (video_backend, provider_id)。
 
     provider/model 的**解析**是 ``resolver.resolve_video_backend`` 的薄投影；backend **构造**
     （``_get_or_create_video_backend``）留在原地。仅在 payload 存在时创建 VideoBackend，避免
-    图片任务因视频配置缺失而报错。注意：video_backend_type 仅在 video_backend 为 None
-    （回退到 GeminiClient）时生效。provider_id 是 registry id（参考图压缩按它查 per-provider 上限）。
+    图片任务因视频配置缺失而报错。provider_id 是 registry id（参考图压缩按它查 per-provider 上限）。
     """
     project = await asyncio.to_thread(get_project_manager().load_project, project_name) if payload else None
     resolved = await resolver.resolve_video_backend(project, payload)
 
     video_backend = None
-    video_backend_type = "aistudio"
-    mapped = _PROVIDER_ID_TO_BACKEND.get(resolved.provider_id, resolved.provider_id)
-    if mapped == PROVIDER_GEMINI:
-        video_backend_type = "vertex" if resolved.provider_id == "gemini-vertex" else "aistudio"
-
     if payload:
         provider_settings: dict = {"model": resolved.model_id} if resolved.model_id else {}
         video_backend = await _get_or_create_video_backend(
@@ -209,7 +191,7 @@ async def _resolve_video_backend(
             default_video_model=resolved.model_id or None,
         )
 
-    return video_backend, video_backend_type, resolved.model_id, resolved.provider_id
+    return video_backend, resolved.provider_id
 
 
 async def get_media_generator(
@@ -265,7 +247,7 @@ async def get_media_generator(
                 )
 
             # 解析 video backend（保持现有逻辑）
-            video_backend, _, _, video_provider_id = await _resolve_video_backend(
+            video_backend, video_provider_id = await _resolve_video_backend(
                 project_name,
                 r,
                 payload,

--- a/tests/test_backend_assembly_loader.py
+++ b/tests/test_backend_assembly_loader.py
@@ -94,6 +94,30 @@ class TestAssembleBuiltinEndToEnd:
             image_model="gemini-3.1-flash-image-preview",
         )
 
+    @patch("lib.text_backends.registry.create_backend")
+    async def test_text_simple_end_to_end(self, mock_create, session_factory):
+        # 文本简单族：凭证 overlay 经装载真进构造参数，base_url 回落 registry default
+        await _seed_provider_config(session_factory, "ark", api_key="ark-secret")
+        resolver = ConfigResolver(session_factory)
+        await assemble_backend(provider_id="ark", media_type="text", model_id="doubao-x", resolver=resolver)
+        mock_create.assert_called_once_with(
+            "ark", model="doubao-x", api_key="ark-secret", base_url="https://ark.cn-beijing.volces.com/api/v3"
+        )
+
+    @patch("lib.text_backends.registry.create_backend")
+    async def test_text_dashscope_compat_end_to_end(self, mock_create, session_factory):
+        # dashscope 文本 OpenAI-compat：base_url 经 helper 派生、透传 provider_name 计费归因，端到端经缝
+        await _seed_provider_config(session_factory, "dashscope", api_key="ds-secret")
+        resolver = ConfigResolver(session_factory)
+        await assemble_backend(provider_id="dashscope", media_type="text", model_id="qwen-max", resolver=resolver)
+        mock_create.assert_called_once_with(
+            "openai",
+            model="qwen-max",
+            api_key="ds-secret",
+            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            provider_name="dashscope",
+        )
+
     @patch("lib.image_backends.registry.create_backend")
     async def test_kling_image_api_model_name_decoupled_end_to_end(self, mock_create, session_factory):
         # kling 特例族：双 secret overlay 真进闭包；api_model_name 解耦从 registry models 读到（别名键）
@@ -143,3 +167,33 @@ class TestAssembleCustomEndToEnd:
         result = await assemble_backend(provider_id=pid, media_type="image", model_id="dall-e-3", resolver=resolver)
         assert isinstance(result, CustomImageBackend)
         mock_cls.assert_called_once_with(api_key="sk-relay", base_url="https://relay.test/v1", model="dall-e-3")
+
+    @patch("lib.custom_provider.endpoints.OpenAITextBackend")
+    async def test_custom_text_provider_delegates_to_loader(self, mock_cls, session_factory):
+        # 文本自定义路径与媒体共用 load_custom_backend：text media_type 同经统一缝
+        from lib.custom_provider import make_provider_id
+        from lib.custom_provider.backends import CustomTextBackend
+        from lib.db.repositories.custom_provider_repo import CustomProviderRepository
+
+        async with session_factory() as s:
+            repo = CustomProviderRepository(s)
+            provider = await repo.create_provider(
+                display_name="Relay",
+                discovery_format="openai",
+                base_url="https://relay.test/v1",
+                api_key="sk-relay",
+                models=[
+                    {
+                        "model_id": "gpt-5",
+                        "display_name": "gpt-5",
+                        "endpoint": "openai-chat",
+                        "is_enabled": True,
+                    }
+                ],
+            )
+            await s.commit()
+            pid = make_provider_id(provider.id)
+
+        resolver = ConfigResolver(session_factory)
+        result = await assemble_backend(provider_id=pid, media_type="text", model_id="gpt-5", resolver=resolver)
+        assert isinstance(result, CustomTextBackend)

--- a/tests/test_backend_assembly_specs.py
+++ b/tests/test_backend_assembly_specs.py
@@ -281,6 +281,151 @@ class TestKlingSpec:
         )
 
 
+class TestTextSimpleSpec:
+    """简单文本族（ark / ark-agent-plan / grok）：model + api_key（无条件透传）+ base_url
+    （user > registry default，仅非空才传）。映射到文本 registry 的 create_backend，registry_backend
+    即 provider_id 自身。"""
+
+    @patch("lib.text_backends.registry.create_backend")
+    def test_ark_falls_back_to_registry_default(self, mock_create):
+        spec = get_provider_spec("ark", "text")
+        assert spec.registry_backend == "ark"
+        config = _loaded(credentials={"api_key": "ark-key"}, provider_id="ark")
+        spec.build_backend(config, "doubao-seed-2-0-lite-260215")
+        mock_create.assert_called_once_with(
+            "ark",
+            model="doubao-seed-2-0-lite-260215",
+            api_key="ark-key",
+            base_url="https://ark.cn-beijing.volces.com/api/v3",
+        )
+
+    @patch("lib.text_backends.registry.create_backend")
+    def test_ark_agent_plan_uses_plan_base_url(self, mock_create):
+        spec = get_provider_spec("ark-agent-plan", "text")
+        assert spec.registry_backend == "ark-agent-plan"
+        config = _loaded(credentials={"api_key": "k"}, provider_id="ark-agent-plan")
+        spec.build_backend(config, "doubao-seed-2.0-lite")
+        mock_create.assert_called_once_with(
+            "ark-agent-plan",
+            model="doubao-seed-2.0-lite",
+            api_key="k",
+            base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
+        )
+
+    @patch("lib.text_backends.registry.create_backend")
+    def test_user_base_url_wins(self, mock_create):
+        spec = get_provider_spec("ark", "text")
+        config = _loaded(credentials={"api_key": "k", "base_url": "https://relay.test/v3"}, provider_id="ark")
+        spec.build_backend(config, "m")
+        assert mock_create.call_args.kwargs["base_url"] == "https://relay.test/v3"
+
+    @patch("lib.text_backends.registry.create_backend")
+    def test_grok_no_default_no_user_omits_base_url(self, mock_create):
+        spec = get_provider_spec("grok", "text")
+        config = _loaded(credentials={"api_key": "grok-key"}, provider_id="grok")
+        spec.build_backend(config, "grok-4")
+        mock_create.assert_called_once_with("grok", model="grok-4", api_key="grok-key")
+
+    @patch("lib.text_backends.registry.create_backend")
+    def test_api_key_passed_unconditionally_even_when_missing(self, mock_create):
+        # 文本简单族 api_key 无条件透传（含 None）：保留迁移前命令式分支语义，
+        # 与媒体简单族「缺省省略」非对称。
+        spec = get_provider_spec("grok", "text")
+        config = _loaded(credentials={}, provider_id="grok")
+        spec.build_backend(config, "grok-4")
+        mock_create.assert_called_once_with("grok", model="grok-4", api_key=None)
+
+
+class TestTextGeminiSpec:
+    """gemini 文本：aistudio（base_url 无条件透传用户值）/ vertex（backend=vertex + gcs_bucket）
+    按 provider_id 分两行，registry_backend 同为 "gemini"。文本 gemini 不接受 rate_limiter。"""
+
+    @patch("lib.text_backends.registry.create_backend")
+    def test_aistudio_passes_user_base_url_unconditionally(self, mock_create):
+        spec = get_provider_spec("gemini-aistudio", "text")
+        assert spec.registry_backend == "gemini"
+        config = _loaded(credentials={"api_key": "g-key", "base_url": ""}, provider_id="gemini-aistudio")
+        spec.build_backend(config, "gemini-3-flash-preview")
+        # base_url 无条件透传（含空串），不回落 registry default
+        mock_create.assert_called_once_with(
+            "gemini",
+            model="gemini-3-flash-preview",
+            api_key="g-key",
+            base_url="",
+        )
+
+    @patch("lib.text_backends.registry.create_backend")
+    def test_vertex_uses_gcs_bucket_no_api_key(self, mock_create):
+        spec = get_provider_spec("gemini-vertex", "text")
+        assert spec.registry_backend == "gemini"
+        config = _loaded(credentials={"gcs_bucket": "my-bucket"}, provider_id="gemini-vertex")
+        spec.build_backend(config, "gemini-3-flash-preview")
+        mock_create.assert_called_once_with(
+            "gemini",
+            model="gemini-3-flash-preview",
+            backend="vertex",
+            gcs_bucket="my-bucket",
+        )
+
+
+class TestTextOpenAICompatSpec:
+    """OpenAI-compat 文本（openai / dashscope / minimax）都映射到 "openai" registry backend。
+    openai 直传用户 base_url；dashscope/minimax 经 helper 从 host 派生 base_url 并透传 provider_name
+    计费归因（保证 usage 记账命中自身 CNY 费率，非 OpenAI USD）。"""
+
+    @patch("lib.text_backends.registry.create_backend")
+    def test_openai_passes_user_base_url_no_provider_name(self, mock_create):
+        spec = get_provider_spec("openai", "text")
+        assert spec.registry_backend == "openai"
+        config = _loaded(credentials={"api_key": "oa", "base_url": "https://relay.test/v1"}, provider_id="openai")
+        spec.build_backend(config, "gpt-5")
+        mock_create.assert_called_once_with(
+            "openai",
+            model="gpt-5",
+            api_key="oa",
+            base_url="https://relay.test/v1",
+        )
+
+    @patch("lib.text_backends.registry.create_backend")
+    def test_dashscope_derives_base_url_and_passes_provider_name(self, mock_create):
+        spec = get_provider_spec("dashscope", "text")
+        assert spec.registry_backend == "openai"
+        config = _loaded(credentials={"api_key": "ds"}, provider_id="dashscope")
+        spec.build_backend(config, "qwen-max")
+        mock_create.assert_called_once_with(
+            "openai",
+            model="qwen-max",
+            api_key="ds",
+            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            provider_name="dashscope",
+        )
+
+    @patch("lib.text_backends.registry.create_backend")
+    def test_dashscope_user_host_derives_compatible_mode_path(self, mock_create):
+        # 用户填自定义 host → helper 仍派生 /compatible-mode/v1 后缀
+        spec = get_provider_spec("dashscope", "text")
+        config = _loaded(
+            credentials={"api_key": "ds", "base_url": "https://dashscope-intl.aliyuncs.com"},
+            provider_id="dashscope",
+        )
+        spec.build_backend(config, "qwen-max")
+        assert mock_create.call_args.kwargs["base_url"] == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+
+    @patch("lib.text_backends.registry.create_backend")
+    def test_minimax_derives_base_url_and_passes_provider_name(self, mock_create):
+        spec = get_provider_spec("minimax", "text")
+        assert spec.registry_backend == "openai"
+        config = _loaded(credentials={"api_key": "mm"}, provider_id="minimax")
+        spec.build_backend(config, "minimax-text-01")
+        mock_create.assert_called_once_with(
+            "openai",
+            model="minimax-text-01",
+            api_key="mm",
+            base_url="https://api.minimaxi.com/v1",
+            provider_name="minimax",
+        )
+
+
 class TestRegistryShape:
     def test_unknown_provider_media_fails_loud(self):
         with pytest.raises(ValueError, match="no builtin ProviderSpec"):
@@ -294,6 +439,24 @@ class TestRegistryShape:
         for provider in ("ark", "ark-agent-plan", "grok", "openai", "vidu", "dashscope", "minimax"):
             assert (provider, "image") in PROVIDER_SPEC_REGISTRY
             assert (provider, "video") in PROVIDER_SPEC_REGISTRY
+
+    def test_text_family_complete(self):
+        # 文本八对：六 provider + gemini 两 id（aistudio/vertex）
+        text_keys = {k for k in PROVIDER_SPEC_REGISTRY if k[1] == "text"}
+        assert text_keys == {
+            ("ark", "text"),
+            ("ark-agent-plan", "text"),
+            ("grok", "text"),
+            ("gemini-aistudio", "text"),
+            ("gemini-vertex", "text"),
+            ("openai", "text"),
+            ("dashscope", "text"),
+            ("minimax", "text"),
+        }
+
+    def test_bare_gemini_text_not_registered(self):
+        # 与媒体侧一致：裸 "gemini" 是死路径，resolver 只产出带后缀 id，fail-loud 不登记兜底行
+        assert ("gemini", "text") not in PROVIDER_SPEC_REGISTRY
 
 
 class TestValidateProviderSpecs:
@@ -316,12 +479,18 @@ class TestValidateProviderSpecs:
             _validate_provider_specs()
 
     def test_registry_backend_names_are_registered(self):
-        """ADR 0039：registry 名都在媒体后端 registry 里 —— 归单测（import 全部后端无碍），不进 import 期。"""
+        """ADR 0039：registry 名都在对应后端 registry 里 —— 归单测（import 全部后端无碍），不进 import 期。"""
         from lib.audio_backends import get_registered_backends as audio_names
         from lib.image_backends import get_registered_backends as image_names
+        from lib.text_backends import get_registered_backends as text_names
         from lib.video_backends import get_registered_backends as video_names
 
-        registered = {"image": set(image_names()), "video": set(video_names()), "audio": set(audio_names())}
+        registered = {
+            "image": set(image_names()),
+            "video": set(video_names()),
+            "audio": set(audio_names()),
+            "text": set(text_names()),
+        }
         for (_provider, media), spec in PROVIDER_SPEC_REGISTRY.items():
             assert spec.registry_backend in registered[media], (
                 f"{spec.registry_backend!r} 未注册到 {media} backend registry"

--- a/tests/test_backend_assembly_specs.py
+++ b/tests/test_backend_assembly_specs.py
@@ -193,13 +193,13 @@ class TestGeminiSpec:
 
     def test_bare_gemini_not_registered(self):
         # 裸 "gemini"（无 aistudio/vertex 后缀）是死路径：resolver 只产出带后缀 id。
-        # 按 ADR 0039 fail-loud，不为死路径登记兜底行。
+        # fail-loud，不为死路径登记兜底行。
         assert ("gemini", "image") not in PROVIDER_SPEC_REGISTRY
         assert ("gemini", "video") not in PROVIDER_SPEC_REGISTRY
 
 
 class TestKlingSpec:
-    """kling 特例族：JWT 双 secret（access_key + secret_key 按 ADR 0037 列名直取）、auth_mode=jwt、
+    """kling 特例族：JWT 双 secret（access_key + secret_key 按列名直取）、auth_mode=jwt、
     image 侧 api_model_name 解耦（两栖别名键读 registry api_model_name）、base_url 兜底（db > registry default）。
     video backend 不接受 api_model_name —— 非对称，video 闭包不传。"""
 
@@ -479,7 +479,7 @@ class TestValidateProviderSpecs:
             _validate_provider_specs()
 
     def test_registry_backend_names_are_registered(self):
-        """ADR 0039：registry 名都在对应后端 registry 里 —— 归单测（import 全部后端无碍），不进 import 期。"""
+        """registry 名都在对应后端 registry 里 —— 归单测（import 全部后端无碍），不进 import 期。"""
         from lib.audio_backends import get_registered_backends as audio_names
         from lib.image_backends import get_registered_backends as image_names
         from lib.text_backends import get_registered_backends as text_names

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -655,8 +655,8 @@ class TestGenerationTasks:
 
         async def _fake_resolve_video_backend(project_name, resolver, payload):
             assert project_name == "demo"
-            # 4 元组：(video_backend, video_backend_type, video_model, provider_id)
-            return fake_video_backend, "unused", "video-model", "gemini-aistudio"
+            # 2 元组：(video_backend, provider_id)
+            return fake_video_backend, "gemini-aistudio"
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr("lib.config.resolver.ConfigResolver", _FakeResolver)

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -82,7 +82,8 @@ class TestTextProviderBilling:
 
 class TestFactoryWiring:
     async def test_text_factory_uses_openai_backend_with_minimax_provider(self):
-        """provider=minimax 经 text 工厂 → OpenAI 后端，base_url 派生 /v1，provider_name 透传。"""
+        """provider=minimax 经 text 工厂 → assemble_backend → OpenAI 后端，base_url 派生 /v1，provider_name 透传。"""
+        import lib.text_backends.registry as text_registry
         from lib.text_backends import factory
 
         resolver = MagicMock()
@@ -101,7 +102,7 @@ class TestFactoryWiring:
 
         with (
             patch.object(factory, "ConfigResolver", return_value=resolver),
-            patch.object(factory, "create_backend", side_effect=_fake_create_backend),
+            patch.object(text_registry, "create_backend", side_effect=_fake_create_backend),
         ):
             await factory.create_text_backend_for_task("script")
 

--- a/tests/test_text_backends/test_factory.py
+++ b/tests/test_text_backends/test_factory.py
@@ -1,4 +1,9 @@
-"""Text backend factory tests."""
+"""Text backend factory tests.
+
+工厂构造已收口到 assemble_backend（media_type=text，见 docs/adr/0039）：文本工厂只解析
+provider/model，构造经统一缝下沉到 ProviderSpec 表。这些测试 mock 文本 registry 的 create_backend
+（spec 闭包最终调它），断言各内置文本 provider 的构造参数与 provider_name 计费归因透传零变化。
+"""
 
 import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -29,17 +34,18 @@ async def test_creates_gemini_aistudio_backend():
 
     with (
         patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.factory.create_backend") as mock_create,
+        patch("lib.text_backends.registry.create_backend") as mock_create,
     ):
         mock_backend = MagicMock()
         mock_create.return_value = mock_backend
 
         result = await create_text_backend_for_task(TextTaskType.SCRIPT)
 
+        # aistudio：base_url 无条件透传用户值（含空串），由 backend 内部处理
         mock_create.assert_called_once_with(
             "gemini",
-            api_key="test-key",
             model="gemini-3-flash-preview",
+            api_key="test-key",
             base_url="",
         )
         assert result is mock_backend
@@ -53,17 +59,18 @@ async def test_creates_ark_backend():
 
     with (
         patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.factory.create_backend") as mock_create,
+        patch("lib.text_backends.registry.create_backend") as mock_create,
     ):
         mock_backend = MagicMock()
         mock_create.return_value = mock_backend
 
         result = await create_text_backend_for_task(TextTaskType.OVERVIEW, "my-project")
 
+        # ark：用户未配 base_url → 回落 registry default
         mock_create.assert_called_once_with(
             "ark",
-            api_key="ark-key",
             model="doubao-seed-2-0-lite-260215",
+            api_key="ark-key",
             base_url="https://ark.cn-beijing.volces.com/api/v3",
         )
         assert result is mock_backend
@@ -79,7 +86,7 @@ async def test_creates_ark_agent_plan_backend_uses_plan_endpoint():
 
     with (
         patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.factory.create_backend") as mock_create,
+        patch("lib.text_backends.registry.create_backend") as mock_create,
     ):
         mock_backend = MagicMock()
         mock_create.return_value = mock_backend
@@ -88,8 +95,8 @@ async def test_creates_ark_agent_plan_backend_uses_plan_endpoint():
 
         mock_create.assert_called_once_with(
             "ark-agent-plan",
-            api_key="ark-plan-key",
             model="doubao-seed-2.0-lite",
+            api_key="ark-plan-key",
             base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
         )
 
@@ -102,7 +109,7 @@ async def test_user_base_url_overrides_default_for_ark_agent_plan():
 
     with (
         patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.factory.create_backend") as mock_create,
+        patch("lib.text_backends.registry.create_backend") as mock_create,
     ):
         await create_text_backend_for_task(TextTaskType.OVERVIEW, "my-project")
         assert mock_create.call_args.kwargs["base_url"] == "https://custom.example.com/v9"
@@ -116,7 +123,7 @@ async def test_creates_vertex_backend():
 
     with (
         patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.factory.create_backend") as mock_create,
+        patch("lib.text_backends.registry.create_backend") as mock_create,
     ):
         mock_backend = MagicMock()
         mock_create.return_value = mock_backend
@@ -130,3 +137,80 @@ async def test_creates_vertex_backend():
             gcs_bucket="my-bucket",
         )
         assert result is mock_backend
+
+
+async def test_creates_grok_backend_omits_base_url_when_unset():
+    """grok 无 registry default 且用户未配 → 不传 base_url（GrokTextBackend 不接受该参数）。"""
+    mock_resolver = _make_mock_resolver(
+        text_backend_for_task=("grok", "grok-4"),
+        provider_config={"api_key": "grok-key"},
+    )
+
+    with (
+        patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
+        patch("lib.text_backends.registry.create_backend") as mock_create,
+    ):
+        await create_text_backend_for_task(TextTaskType.SCRIPT)
+        mock_create.assert_called_once_with("grok", model="grok-4", api_key="grok-key")
+
+
+async def test_creates_openai_backend_passes_user_base_url():
+    """openai：base_url 无条件透传用户值（无 registry default，允许自定义 endpoint）。"""
+    mock_resolver = _make_mock_resolver(
+        text_backend_for_task=("openai", "gpt-5"),
+        provider_config={"api_key": "oa-key", "base_url": "https://relay.example.com/v1"},
+    )
+
+    with (
+        patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
+        patch("lib.text_backends.registry.create_backend") as mock_create,
+    ):
+        await create_text_backend_for_task(TextTaskType.SCRIPT)
+        mock_create.assert_called_once_with(
+            "openai",
+            model="gpt-5",
+            api_key="oa-key",
+            base_url="https://relay.example.com/v1",
+        )
+
+
+async def test_creates_dashscope_backend_derives_base_url_and_passes_provider_name():
+    """dashscope 文本走 OpenAI 兼容：从 host 派生 /compatible-mode/v1，并透传 provider_name 计费归因。"""
+    mock_resolver = _make_mock_resolver(
+        text_backend_for_task=("dashscope", "qwen-max"),
+        provider_config={"api_key": "ds-key"},
+    )
+
+    with (
+        patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
+        patch("lib.text_backends.registry.create_backend") as mock_create,
+    ):
+        await create_text_backend_for_task(TextTaskType.SCRIPT)
+        mock_create.assert_called_once_with(
+            "openai",
+            model="qwen-max",
+            api_key="ds-key",
+            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            provider_name="dashscope",
+        )
+
+
+async def test_creates_minimax_backend_derives_base_url_and_passes_provider_name():
+    """minimax 文本走 OpenAI 兼容：单 /v1 base，并透传 provider_name 计费归因。"""
+    mock_resolver = _make_mock_resolver(
+        text_backend_for_task=("minimax", "minimax-text-01"),
+        provider_config={"api_key": "mm-key"},
+    )
+
+    with (
+        patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
+        patch("lib.text_backends.registry.create_backend") as mock_create,
+    ):
+        await create_text_backend_for_task(TextTaskType.SCRIPT)
+        mock_create.assert_called_once_with(
+            "openai",
+            model="minimax-text-01",
+            api_key="mm-key",
+            base_url="https://api.minimaxi.com/v1",
+            provider_name="minimax",
+        )

--- a/tests/test_text_backends/test_factory.py
+++ b/tests/test_text_backends/test_factory.py
@@ -1,6 +1,6 @@
 """Text backend factory tests.
 
-工厂构造已收口到 assemble_backend（media_type=text，见 docs/adr/0039）：文本工厂只解析
+工厂构造已收口到 assemble_backend（media_type=text）：文本工厂只解析
 provider/model，构造经统一缝下沉到 ProviderSpec 表。这些测试 mock 文本 registry 的 create_backend
 （spec 闭包最终调它），断言各内置文本 provider 的构造参数与 provider_name 计费归因透传零变化。
 """


### PR DESCRIPTION
## 做了什么

收尾切片：把文本 backend 构造收口到统一构造缝，四条 media_type（image/video/audio/text）× 内置/自定义两族全部经同一条缝。

- 文本工厂改调 `assemble_backend`（media_type=text），所有内置文本 provider 进 `ProviderSpec` 表：简单文本（ark/ark-agent-plan/grok）、gemini 文本（aistudio/vertex）、OpenAI-compat 文本（openai/dashscope/minimax，后两者经 helper 派生 base_url 并透传 provider_name 保住计费归因）。
- 删除两份 `PROVIDER_ID_TO_BACKEND`：文本侧别名映射（dashscope/minimax→openai）并入各 `ProviderSpec` 的 registry_backend 字段；媒体侧那份仅服务于被丢弃的死返回值，连同 `_resolve_video_backend` 的 video_backend_type/video_model 一并清理（返回值 4-tuple 收窄到 2-tuple）。两侧映射合一，漂移在数据结构层面不再可能。
- 文本工厂内联的自定义解析与下移到 lib 的 `load_custom_backend` 合一。

设计依据见 docs/adr/0039。

## 验证

- 全量 `uv run pytest tests/` 绿：5132 passed
- `uv run ruff check .` + `ruff format --check` 全绿
- `uv run basedpyright` 0 errors
- 新增/迁移单测覆盖文本各 provider 构造参数与 provider_name 计费归因透传（test_backend_assembly_specs.py / test_backend_assembly_loader.py / test_text_backends/test_factory.py），四 media × 两族行为对拍零变化

## 审查

独立审查（10 角度 finder + 验证 + 查漏）：实现忠于声明式缝设计，迁移行为零变化（删除的 _fill_simple_provider_kwargs / 命令式分支逻辑在新闭包逐一重建、调用点已同步收窄、helper 签名匹配、自定义文本路径与媒体共用 loader）。修复一项：代码/测试注释里新引入的规划层编号引用已清除，注释改为描述当下机制。其余疑点（base_url 空串 or 语义、媒体/文本 api_key 透传非对称、backend 缓存键）经核实均与迁移前一致或为既有设计取舍，非本切片回归。

Closes #859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 后端系统改进

* **新特性**
  * 文本后端现已集成至统一的后端装配系统，支持简单文本、Gemini 和 OpenAI 兼容等多种提供商。
  * 自定义文本提供商配置流程已简化并统一到主后端装配通道。

* **改进**
  * 后端初始化流程更加一致，提升了配置透传的可靠性。
  * 完善了视频后端参数处理的稳健性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->