### PR TITLE
test: 隔离供应商默认回退用例的 DB，根除本机全量测试恒失败

### DIFF
--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -2,7 +2,9 @@ import asyncio
 from typing import Any
 
 import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
+from lib.db import Base
 from lib.generation_worker import (
     _ORPHAN_RESCAN_LEASE_LOST_MULT,
     DEFAULT_PROVIDER,
@@ -93,6 +95,21 @@ def _patch_pm(monkeypatch, project: dict | None):
     )
 
 
+@pytest.fixture()
+async def _patch_empty_db(monkeypatch):
+    """把全局 async_session_factory 换成空内存库，隔离掉真实数据库。
+
+    无 project_name 的 _extract_provider 会用 lib.db.async_session_factory 经 ConfigResolver
+    解析全局默认供应商；不隔离时它读真实 dev 库，本机一旦配了其它 ready 供应商，回退断言就被污染。
+    """
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    monkeypatch.setattr("lib.db.async_session_factory", async_sessionmaker(engine, expire_on_commit=False))
+    yield
+    await engine.dispose()
+
+
 class TestExtractProvider:
     """_extract_provider 是解析链的薄投影：按 task_type 派发，取 .provider_id。"""
 
@@ -106,8 +123,12 @@ class TestExtractProvider:
         task = {"payload": {"image_provider": "gemini-vertex"}, "task_type": "storyboard"}
         assert await _extract_provider(task) == "gemini-vertex"
 
-    async def test_default_when_unresolvable(self):
-        """无 project、无 payload、全局未配供应商 → 回退 DEFAULT_PROVIDER（仅供限流）。"""
+    async def test_default_when_unresolvable(self, _patch_empty_db):
+        """无 project、无 payload、全局未配供应商 → 回退 DEFAULT_PROVIDER（仅供限流）。
+
+        必须隔离全局 DB（_patch_empty_db）——否则会读真实 dev 库，本机配了其它 ready 供应商时
+        auto-resolve 会返回该供应商而非 DEFAULT_PROVIDER，断言被本机环境污染。
+        """
         task = {"payload": {}}
         assert await _extract_provider(task) == DEFAULT_PROVIDER
 


### PR DESCRIPTION
## 问题
`tests/test_generation_worker_module.py::TestExtractProvider::test_default_when_unresolvable` 未隔离数据库。无 `project_name` 时 `_extract_provider` 直接用真实 `lib.db.async_session_factory` 经 `ConfigResolver` 读本机 dev 库 `projects/.arcreel.db`；当本机配了其它 ready 的 image 供应商（如 grok）时，auto-resolve 返回该供应商而非 `DEFAULT_PROVIDER`，断言 `'grok' == 'gemini-aistudio'` 失败。CI 干净库下能过，故为本机环境耦合、非回归。

## 修复
新增 `_patch_empty_db` fixture：用空内存 SQLite（`create_all` 建表）替换 `async_session_factory`，与同组 `_patch_pm` 隔离 project 的做法对齐。该用例消费此 fixture 后，断言只依赖「未配任何供应商」前提，不再受本机 dev 库状态影响。

## 测试
- `uv run python -m pytest tests/test_generation_worker_module.py` 全绿（67 passed，对真实 dev 库跑，此前恒失败的用例现通过）
- `uv run ruff check` / `uv run ruff format` 通过
- `uv run basedpyright` 0 errors

Closes #864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 改进测试数据库隔离机制，提升测试的可靠性和稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->