### PR TITLE
refactor(backend): 抽取共享 JSON 代码栅栏剥离工具，统一大小写不敏感口径

### DIFF
--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -34,6 +34,7 @@ from lib.project_manager import ProjectManager, resolve_source_kind
 from lib.text_backends.base import TextGenerationRequest, TextTaskType
 from lib.text_generator import TextGenerator
 from lib.text_metrics import count_reading_units
+from lib.text_utils import strip_json_code_fences
 
 logger = logging.getLogger(__name__)
 
@@ -160,17 +161,6 @@ class _DraftRejected(Exception):
     def __init__(self, reasons: list[str]):
         super().__init__("; ".join(reasons))
         self.reasons = reasons
-
-
-def _strip_md_fences(text: str) -> str:
-    text = text.strip()
-    if text[:7].lower() == "```json":  # 部分模型输出 ```JSON / ```Json，标记匹配不区分大小写
-        text = text[7:]
-    if text.startswith("```"):
-        text = text[3:]
-    if text.endswith("```"):
-        text = text[:-3]
-    return text.strip()
 
 
 def _resolve_boundaries(
@@ -684,7 +674,7 @@ class EpisodePlanner:
 
     @staticmethod
     def _parse_draft(response_text: str, draft_model: type[BaseModel]) -> BaseModel:
-        text = _strip_md_fences(response_text)
+        text = strip_json_code_fences(response_text)
         try:
             data = json.loads(text)
         except json.JSONDecodeError as exc:

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -40,6 +40,7 @@ from lib.script_models import (
 from lib.text_backends.base import TextGenerationRequest, TextTaskType
 from lib.text_generator import TextGenerator
 from lib.text_metrics import count_reading_units
+from lib.text_utils import strip_json_code_fences
 
 logger = logging.getLogger(__name__)
 
@@ -527,14 +528,7 @@ class ScriptGenerator:
             验证后的剧本数据字典
         """
         # 清理可能的 markdown 包装
-        text = response_text.strip()
-        if text.startswith("```json"):
-            text = text[7:]
-        if text.startswith("```"):
-            text = text[3:]
-        if text.endswith("```"):
-            text = text[:-3]
-        text = text.strip()
+        text = strip_json_code_fences(response_text)
 
         # 解析 JSON
         try:

--- a/lib/text_utils.py
+++ b/lib/text_utils.py
@@ -2,19 +2,23 @@
 
 from __future__ import annotations
 
+import re
+
+# 开栏：``` 后可跟空白、可选的语言标注 json（大小写不敏感）、可选空白与换行。
+# 兼容 ```json / ```JSON / ``` json / ```  JSON 等带空格变体。
+_OPENING_FENCE = re.compile(r"^```[ \t]*(?:json)?[ \t]*\n?", re.IGNORECASE)
+# 闭栏：结尾的 ``` 及其前导换行。
+_CLOSING_FENCE = re.compile(r"\n?```$")
+
 
 def strip_json_code_fences(text: str) -> str:
     """剥离 LLM 输出最外层的 markdown 代码栅栏，返回可交给 json.loads 的纯文本。
 
-    两端去空白后：开头若为 ```json（大小写不敏感，兼容 ```JSON / ```Json 等变体）
-    去掉该 7 字前缀，否则若以 ``` 开头去掉 3 字；结尾若以 ``` 收束去掉尾 3 字；再去空白返回。
+    两端去空白后：剥离开头的 ``` 栅栏（可带空白与可选的 json 语言标注，大小写不敏感，
+    兼容 ```JSON / ```Json / ``` json / ```  JSON 等变体），再剥离结尾的 ``` 闭栏；最后去空白返回。
     无栅栏的裸 JSON 仅做两端 strip。
     """
     text = text.strip()
-    if text[:7].lower() == "```json":
-        text = text[7:]
-    if text.startswith("```"):
-        text = text[3:]
-    if text.endswith("```"):
-        text = text[:-3]
+    text = _OPENING_FENCE.sub("", text)
+    text = _CLOSING_FENCE.sub("", text)
     return text.strip()

--- a/lib/text_utils.py
+++ b/lib/text_utils.py
@@ -1,0 +1,20 @@
+"""面向字符串的文本预处理工具。"""
+
+from __future__ import annotations
+
+
+def strip_json_code_fences(text: str) -> str:
+    """剥离 LLM 输出最外层的 markdown 代码栅栏，返回可交给 json.loads 的纯文本。
+
+    两端去空白后：开头若为 ```json（大小写不敏感，兼容 ```JSON / ```Json 等变体）
+    去掉该 7 字前缀，否则若以 ``` 开头去掉 3 字；结尾若以 ``` 收束去掉尾 3 字；再去空白返回。
+    无栅栏的裸 JSON 仅做两端 strip。
+    """
+    text = text.strip()
+    if text[:7].lower() == "```json":
+        text = text[7:]
+    if text.startswith("```"):
+        text = text[3:]
+    if text.endswith("```"):
+        text = text[:-3]
+    return text.strip()

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -14,6 +14,8 @@ from lib.text_utils import strip_json_code_fences
         '```JSON\n{"a": 1}\n```',
         '```Json\n{"a": 1}\n```',
         '```jSoN\n{"a": 1}\n```',
+        '``` json\n{"a": 1}\n```',
+        '```  JSON\n{"a": 1}\n```',
         '```\n{"a": 1}\n```',
         '{"a": 1}',
         '  ```json\n{"a": 1}\n```  ',

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,0 +1,50 @@
+"""strip_json_code_fences 单元测试：覆盖大小写变体、裸 JSON、仅开/闭栏、空白等输入。"""
+
+import json
+
+import pytest
+
+from lib.text_utils import strip_json_code_fences
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '```json\n{"a": 1}\n```',
+        '```JSON\n{"a": 1}\n```',
+        '```Json\n{"a": 1}\n```',
+        '```jSoN\n{"a": 1}\n```',
+        '```\n{"a": 1}\n```',
+        '{"a": 1}',
+        '  ```json\n{"a": 1}\n```  ',
+        '\n\n```json\n{"a": 1}\n```\n\n',
+    ],
+)
+def test_stripped_output_parses_as_json(raw: str) -> None:
+    """剥离后必须能被 json.loads 正确解析为等价对象。"""
+    assert json.loads(strip_json_code_fences(raw)) == {"a": 1}
+
+
+def test_only_opening_fence() -> None:
+    """仅含开栏标记：去掉开栏前缀后可解析。"""
+    assert json.loads(strip_json_code_fences('```json\n{"a": 1}')) == {"a": 1}
+
+
+def test_only_opening_fence_no_language() -> None:
+    """仅含无语言标注的开栏标记。"""
+    assert json.loads(strip_json_code_fences('```\n{"a": 1}')) == {"a": 1}
+
+
+def test_only_closing_fence() -> None:
+    """仅含闭栏标记：去掉尾部 ``` 后可解析。"""
+    assert json.loads(strip_json_code_fences('{"a": 1}\n```')) == {"a": 1}
+
+
+def test_bare_json_untouched() -> None:
+    """无栅栏的裸 JSON 仅做两端 strip，内容不变。"""
+    assert strip_json_code_fences('  {"a": 1}  ') == '{"a": 1}'
+
+
+def test_case_insensitive_opening_marker() -> None:
+    """大小写变体开栏标记均剥离 7 字前缀，不把语言标注残留进正文。"""
+    assert strip_json_code_fences('```JSON\n{"a": 1}\n```').startswith("{")


### PR DESCRIPTION
## 问题
LLM 返回 JSON 时常包裹 markdown 代码栅栏（```json … ```），需剥离后再 `json.loads`。此前存在两份近乎逐字重复的剥离逻辑：

- `lib/episode_planner.py` 的 `_strip_md_fences()`（大小写不敏感匹配 ```JSON / ```Json）
- `lib/script_generator.py` JSON 解析前的内联清理（`startswith("```json")` 大小写敏感，不兼容上述变体）

## 改动
- 新增 `lib/text_utils.py::strip_json_code_fences()`，统一采用大小写不敏感的更健壮实现
- `episode_planner` 与 `script_generator` 两处改为调用共享工具，消除重复并统一行为差异（`script_generator` 现也兼容 ```JSON / ```Json）
- 新增 `tests/test_text_utils.py`，参数化覆盖大小写变体、裸 JSON、仅开/闭栏、首尾空白等输入

## 验证
- `ruff check` + `ruff format --check`：通过
- `basedpyright`：0 errors / 0 warnings
- `pytest tests/test_text_utils.py`：13 passed
- 相关回归 `pytest -k "episode_planner or script_generator or text_utils"`：130 passed

Closes #862


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 新增并复用统一的 JSON 代码块清理工具，自动识别 ` ```json/JSON/... ``` ` 等不同大小写与换行变体，提升 LLM 输出解析的稳定性与一致性。
* **测试**
  * 补充覆盖多种栅栏组合与边界场景的单元测试，验证剥离后内容可被 `json` 正确解析，并确保语言标记不残留。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->