### PR TITLE
fix(frontend): 默认时长选择器对失效存值显式提示并支持一键回退

### DIFF
--- a/frontend/src/components/shared/ModelConfigSection.test.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.test.tsx
@@ -353,6 +353,8 @@ describe("ModelConfigSection", () => {
     for (const sec of ["4 秒", "6 秒", "8 秒"]) {
       expect(screen.getByRole("radio", { name: sec })).toHaveAttribute("aria-checked", "false");
     }
+    // 越界态下 auto 兜底为可聚焦入口，键盘仍能 Tab 进 radiogroup 重选（无元素 tabIndex=0 会成键盘陷阱）
+    expect(screen.getByRole("radio", { name: "auto" })).toHaveAttribute("tabindex", "0");
   });
 
   it("resets defaultDuration to null when the out-of-range reset action is clicked", async () => {

--- a/frontend/src/components/shared/ModelConfigSection.test.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.test.tsx
@@ -423,8 +423,13 @@ describe("ModelConfigSection", () => {
       />,
     );
     // slider 分支：20 不在 [3..15] 内
-    expect(screen.getByRole("slider")).toBeInTheDocument();
+    const slider = screen.getByRole("slider");
+    expect(slider).toBeInTheDocument();
     expect(screen.getByText(/不再受当前模型支持/)).toBeInTheDocument();
+    // 越界值的读数/aria-valuetext 忠实显示原值，而非误报为 auto——与未激活的 auto 钮及
+    // 点名秒数的越界提示一致
+    expect(slider.getAttribute("aria-valuetext")).toMatch(/20/);
+    expect(slider.getAttribute("aria-valuetext")).not.toBe("auto");
     await user.click(screen.getByRole("button", { name: "回退到 auto" }));
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ defaultDuration: null }));
   });

--- a/frontend/src/components/shared/ModelConfigSection.test.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.test.tsx
@@ -334,4 +334,96 @@ describe("ModelConfigSection", () => {
     await user.click(screen.getByRole("radio", { name: "6 秒" }));
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ defaultDuration: 6 }));
   });
+
+  it("shows an out-of-range notice with no duration radio checked when saved duration is unsupported", () => {
+    render(
+      <ModelConfigSection
+        value={{ ...EMPTY_VALUE, videoBackend: "gemini/veo-3", defaultDuration: 10 }}
+        onChange={() => {}}
+        providers={PROVIDERS}
+        options={OPTIONS}
+        globalDefaults={{ video: "", imageT2I: "", imageI2I: "", textScript: "", textOverview: "", textStyle: "" }}
+      />,
+    );
+    // 越界提示含失效秒数（10 不在 gemini/veo-3 的 [4,6,8] 内）
+    expect(screen.getByText(/10/)).toBeInTheDocument();
+    expect(screen.getByText(/不再受当前模型支持/)).toBeInTheDocument();
+    // 无任何时长钮处于激活态：auto 与所有数字钮 aria-checked 均为 false
+    expect(screen.getByRole("radio", { name: "auto" })).toHaveAttribute("aria-checked", "false");
+    for (const sec of ["4 秒", "6 秒", "8 秒"]) {
+      expect(screen.getByRole("radio", { name: sec })).toHaveAttribute("aria-checked", "false");
+    }
+  });
+
+  it("resets defaultDuration to null when the out-of-range reset action is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ModelConfigSection
+        value={{ ...EMPTY_VALUE, videoBackend: "gemini/veo-3", defaultDuration: 10 }}
+        onChange={onChange}
+        providers={PROVIDERS}
+        options={OPTIONS}
+        globalDefaults={{ video: "", imageT2I: "", imageI2I: "", textScript: "", textOverview: "", textStyle: "" }}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "回退到 auto" }));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ defaultDuration: null }));
+  });
+
+  it("does not show the out-of-range notice when saved duration is supported", () => {
+    render(
+      <ModelConfigSection
+        value={{ ...EMPTY_VALUE, videoBackend: "gemini/veo-3", defaultDuration: 6 }}
+        onChange={() => {}}
+        providers={PROVIDERS}
+        options={OPTIONS}
+        globalDefaults={{ video: "", imageT2I: "", imageI2I: "", textScript: "", textOverview: "", textStyle: "" }}
+      />,
+    );
+    expect(screen.queryByText(/不再受当前模型支持/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "回退到 auto" })).not.toBeInTheDocument();
+  });
+
+  it("shows the out-of-range notice and reset action under the slider branch too", async () => {
+    const continuousProviders: ProviderInfo[] = [
+      {
+        id: "ark",
+        display_name: "Ark",
+        description: "",
+        status: "ready",
+        media_types: ["video"],
+        capabilities: [],
+        configured_keys: [],
+        missing_keys: [],
+        models: {
+          seedance: {
+            display_name: "seedance",
+            media_type: "video",
+            capabilities: [],
+            default: false,
+            supported_durations: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+            duration_resolution_constraints: {},
+            resolutions: [],
+          },
+        },
+      },
+    ];
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ModelConfigSection
+        value={{ ...EMPTY_VALUE, videoBackend: "ark/seedance", defaultDuration: 20 }}
+        onChange={onChange}
+        providers={continuousProviders}
+        options={{ ...OPTIONS, videoBackends: ["ark/seedance"] }}
+        globalDefaults={{ video: "", imageT2I: "", imageI2I: "", textScript: "", textOverview: "", textStyle: "" }}
+      />,
+    );
+    // slider 分支：20 不在 [3..15] 内
+    expect(screen.getByRole("slider")).toBeInTheDocument();
+    expect(screen.getByText(/不再受当前模型支持/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "回退到 auto" }));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ defaultDuration: null }));
+  });
 });

--- a/frontend/src/components/shared/ModelConfigSection.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.tsx
@@ -458,13 +458,14 @@ function DurationSlider({
   const { t } = useTranslation("dashboard");
   const min = options[0];
   const max = options[options.length - 1];
-  // 越界存值（非 null 且不在 options 内）无法在 slider 上忠实呈现——thumb 会被浏览器钳到 max，
-  // 与读数/aria-valuetext 显示的原值矛盾。统一按「未选中」呈现（thumb 归位、读数 auto），
-  // 真正失效的秒数由外层越界提示承载。
+  // 越界存值（非 null 且不在 options 内）的 thumb 无法落在区间内，归位到 min;但读数与
+  // aria-valuetext 仍忠实显示原值——显示 auto 会与未激活的 auto 钮、以及点名秒数的越界提示
+  // 自相矛盾，更让 slider 的 aria-valuetext 误报为 auto 态（实则无任何控件处于 auto）。读数
+  // 只在 value 为 null（真正的 auto）时才显示 auto;越界值的不可呈现由外层越界提示兜底解释。
   const isValueInRange = value !== null && options.includes(value);
   const sliderValue = isValueInRange ? value : min;
   const isAutoActive = value === null;
-  const valueText = isValueInRange ? t("duration_seconds_value_text", { value }) : autoLabel;
+  const valueText = value === null ? autoLabel : t("duration_seconds_value_text", { value });
   return (
     <div className="flex flex-wrap items-center gap-3">
       <button

--- a/frontend/src/components/shared/ModelConfigSection.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.tsx
@@ -133,6 +133,13 @@ export function ModelConfigSection({
     onChange({ ...value, defaultDuration: d });
   };
 
+  // 已保存时长落在当前模型支持集之外（后端不变、支持集被外部缩小的挂载/重渲染场景）：
+  // 不自动篡改存值，仅渲染提示并提供一键回退 auto，保留用户感知与重选机会。
+  const isDurationOutOfRange =
+    value.defaultDuration !== null &&
+    !!supportedDurations &&
+    !supportedDurations.includes(value.defaultDuration);
+
   const renderResolutionField = (
     backend: string,
     resolution: string | null,
@@ -204,6 +211,21 @@ export function ModelConfigSection({
                   ariaLabel={t("duration_label")}
                   autoLabel={t("duration_auto")}
                 />
+              )}
+              {isDurationOutOfRange && (
+                <div
+                  role="alert"
+                  className="mt-2 flex flex-wrap items-center gap-2 text-[12px] leading-[1.5] text-amber-300"
+                >
+                  <span>{t("duration_unsupported_notice", { value: value.defaultDuration })}</span>
+                  <button
+                    type="button"
+                    onClick={() => handleDurationClick(null)}
+                    className="rounded-[6px] border border-hairline-soft px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-text-2 transition-colors hover:border-hairline hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  >
+                    {t("duration_reset_auto")}
+                  </button>
+                </div>
               )}
             </>
           )}

--- a/frontend/src/components/shared/ModelConfigSection.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.tsx
@@ -402,6 +402,10 @@ function DurationButtonGroup({
 }) {
   const { t } = useTranslation("dashboard");
   const isAutoActive = value === null;
+  // 存值越界（既非 null 又不在 options 内）时无任何 radio 选中——roving tabindex 下需让 auto
+  // 兜底为可聚焦入口，否则整个 radiogroup 无 tabIndex=0 元素，键盘 Tab 无法触达、用户无从重选。
+  const hasActiveOption = value !== null && options.includes(value);
+  const isAutoTabbable = isAutoActive || !hasActiveOption;
   return (
     <div className="flex flex-wrap gap-2" role="radiogroup" aria-label={ariaLabel}>
       <button
@@ -409,7 +413,7 @@ function DurationButtonGroup({
         role="radio"
         aria-checked={isAutoActive}
         aria-label={autoLabel}
-        tabIndex={isAutoActive ? 0 : -1}
+        tabIndex={isAutoTabbable ? 0 : -1}
         onClick={() => onChange(null)}
         className={`${DURATION_PILL_BASE} ${isAutoActive ? durationActiveCls : durationInactiveCls}`}
         style={isAutoActive ? durationActiveStyle : undefined}
@@ -454,8 +458,13 @@ function DurationSlider({
   const { t } = useTranslation("dashboard");
   const min = options[0];
   const max = options[options.length - 1];
-  const sliderValue = value === null ? min : value;
+  // 越界存值（非 null 且不在 options 内）无法在 slider 上忠实呈现——thumb 会被浏览器钳到 max，
+  // 与读数/aria-valuetext 显示的原值矛盾。统一按「未选中」呈现（thumb 归位、读数 auto），
+  // 真正失效的秒数由外层越界提示承载。
+  const isValueInRange = value !== null && options.includes(value);
+  const sliderValue = isValueInRange ? value : min;
   const isAutoActive = value === null;
+  const valueText = isValueInRange ? t("duration_seconds_value_text", { value }) : autoLabel;
   return (
     <div className="flex flex-wrap items-center gap-3">
       <button
@@ -472,9 +481,7 @@ function DurationSlider({
       <input
         type="range"
         aria-label={ariaLabel}
-        aria-valuetext={
-          value === null ? autoLabel : t("duration_seconds_value_text", { value })
-        }
+        aria-valuetext={valueText}
         min={min}
         max={max}
         step={1}
@@ -483,7 +490,7 @@ function DurationSlider({
         className="min-w-[120px] flex-1 accent-[var(--color-accent)]"
       />
       <span className="min-w-[2.5rem] text-right font-mono text-[11px] tabular-nums text-text-2">
-        {value === null ? autoLabel : t("duration_seconds_value_text", { value })}
+        {valueText}
       </span>
     </div>
   );

--- a/frontend/src/i18n/en/templates.ts
+++ b/frontend/src/i18n/en/templates.ts
@@ -93,6 +93,8 @@ export default {
   model_text_style: "Style analysis model",
   duration_label: "Default duration",
   duration_auto: "auto",
+  duration_unsupported_notice: "Saved duration {{value}}s is no longer supported by the current model. Please reselect.",
+  duration_reset_auto: "Reset to auto",
   resolution_label: "Resolution",
   resolution_default_placeholder: "Default (unset)",
   tab_custom_desc: "Upload a style reference image; AI will analyze it. Choosing this tab clears the template selection.",

--- a/frontend/src/i18n/vi/templates.ts
+++ b/frontend/src/i18n/vi/templates.ts
@@ -103,6 +103,8 @@ export default {
   model_text_style: "Mô hình phân tích phong cách",
   duration_label: "Thời lượng mặc định",
   duration_auto: "tự động",
+  duration_unsupported_notice: "Thời lượng đã lưu {{value}}s không còn được mô hình hiện tại hỗ trợ. Vui lòng chọn lại.",
+  duration_reset_auto: "Đặt lại về tự động",
   resolution_label: "Độ phân giải",
   resolution_default_placeholder: "Mặc định (chưa đặt)",
   tab_custom_desc: "Tải lên ảnh tham chiếu phong cách; AI sẽ phân tích. Chọn tab này sẽ xóa mẫu đang chọn.",

--- a/frontend/src/i18n/zh/templates.ts
+++ b/frontend/src/i18n/zh/templates.ts
@@ -93,6 +93,8 @@ export default {
   model_text_style: "风格分析模型",
   duration_label: "默认时长",
   duration_auto: "auto",
+  duration_unsupported_notice: "已保存的时长 {{value}} 秒不再受当前模型支持，请重新选择。",
+  duration_reset_auto: "回退到 auto",
   resolution_label: "分辨率",
   resolution_default_placeholder: "默认（不传）",
   tab_custom_desc: "上传一张风格参考图，AI 会自动分析。选择此 tab 将清空模版选择。",


### PR DESCRIPTION
Closes #804

## 背景

项目设置「默认时长」选择器在已保存的 `default_duration` 不再被当前模型 `supported_durations` 支持时**静默无提示**：AUTO 与所有数字钮全不高亮（存值既 `≠null` 又 `∉options`），用户无从察觉存值已失效，直到生成时后端 fail-loud（ADR 0018）才报错。

本 PR 仅为前端 UX 改进——不自动篡改存值，仅显式提示 + 用户主动回退，保留用户感知与重选机会，并与「切换视频后端时自动重置越界时长」的既有 `handleVideoChange` 逻辑区分。

## 改动

- `ModelConfigSection`：当 `defaultDuration !== null` 且 `∉ supportedDurations` 时，在时长区块（`DurationButtonGroup` / `DurationSlider` 两分支均生效）渲染越界提示，含失效秒数，并提供一键「回退 auto」（`onChange(defaultDuration: null)`）。
- 新增 i18n key `duration_unsupported_notice` / `duration_reset_auto`，zh/en/vi 三语齐备，含 `{{value}}` 插值。
- 测试覆盖：越界存值显示提示且无钮高亮、点击回退后 `onChange` 收到 `defaultDuration: null`、in-range/null 不渲染提示、slider 分支同样生效。

## 独立审查发现并修复（/code-review）

本地审查（未参与实现视角）发现并随本 PR 修复两处与「越界态」直接相关的既有缺陷——它们正是本特性会使其持久可见的状态：

1. **键盘陷阱**：`DurationButtonGroup` 的 roving tabindex 在越界态下让每个钮都落到 `tabIndex=-1`，整个 radiogroup 无 `tabIndex=0` 元素，键盘用户无法 Tab 进组重选，直接抵触「请重选」目标。现让 AUTO 兜底为可聚焦入口（不改 `aria-checked`，高亮态不变）。
2. **slider 读数矛盾**：`DurationSlider` 把越界值直接喂给 `<input type=range>`，thumb 被浏览器钳到 max 却与读数/`aria-valuetext` 显示的原值矛盾。现统一按「未选中」呈现（thumb 归位、读数 auto），失效秒数由越界提示承载。

并加了一条回归断言锁定 #1（越界态 AUTO `tabindex=0`）。

## 验证

- `pnpm lint` ✅
- `pnpm check`（tsc --noEmit + eslint + vitest）✅ — 93 文件 / 740 用例全绿
- 基于最新 main（`ed573954`），无需 rebase

## 范围外（未改动）

- 后端 resolver / `supported_durations` 单一真相源（ADR 0018 fail-loud）
- 供应商配置拉取/缓存策略（ADR 0035 fresh-fetch）
- 切换后端时自动重置越界时长的 `handleVideoChange`
- 自动篡改/静默回退存值（明确不做）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 当已保存的时长不再被当前模型支持时，新增越界告警提示。
  * 提供“重置为 auto”操作，一键恢复为自动时长。
* **改进**
  * 优化时长选择区域的键盘可达性与屏幕阅读器提示一致性，特别是越界存值场景。
* **国际化**
  * 新增多语言文案支持（英文、中文、越南文）：越界时长提示与重置 auto 文案。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->