### PR TITLE
refactor(backend): video 后端 provider_job_id 持久化收口共享 mixin，gemini-aistudio 视频支持自定义 endpoint

### DIFF
--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -3,7 +3,7 @@
 镜像自定义侧 ENDPOINT_REGISTRY（lib/custom_provider/endpoints.py）：每条 spec 是 frozen
 dataclass，挂一个 build 闭包；闭包读 LoadedConfig 信封 + model_id 拼 backend，不查 DB、不 await。
 登记简单族（媒体侧只需 api_key + model + base_url 的内置 provider）的 image/video/audio，
-共享一个 _build_simple 闭包；外加 gemini（backend_type 双模式 + image/video base_url 非对称）与
+共享一个 _build_simple 闭包；外加 gemini（backend_type 双模式，image/video 对等透传 base_url）与
 kling（JWT 双 secret + api_model_name 解耦）两个特例族，各自挂专属 build 闭包。文本（media_type=text）
 四条 media_type 同经本表：简单文本（ark/ark-agent-plan/grok）、gemini 文本（aistudio/vertex）、
 OpenAI-compat 文本（openai/dashscope/minimax，dashscope/minimax 经 helper 派生 base_url + 透传
@@ -93,9 +93,9 @@ def _simple_spec(provider_id: str, media_type: str) -> ProviderSpec:
 # ── gemini 特例族 ──────────────────────────────────────────────────
 # gemini-aistudio / gemini-vertex 两个 provider_id 都映射到同一个 "gemini" media backend，
 # 差异只在 backend_type（aistudio | vertex）—— 由 spec 行声明（每个 provider_id 各一行），不在闭包内 if。
-# image 设 base_url，video 不设（保留迁移前的非对称：GeminiVideoBackend 虽接受 base_url 但 video 路径
-# 历来不传）。api_key 与 image 的 base_url 无条件透传（含 None）：迁移前命令式分支即无条件 db_config.get，
-# 由 backend 内 resolve_gemini_api_key / normalize_base_url 处理 None（vertex 读凭证文件、None base_url 省略）。
+# image/video 对等透传 base_url：aistudio 用用户配置的自定义 endpoint。api_key 与 base_url 无条件
+# 透传（含 None），由 backend 内 resolve_gemini_api_key / normalize_base_url 处理 None（None base_url 省略）；
+# vertex 分支走 vertexai=True + 服务账号凭证，结构性忽略 base_url（无注入点），透传的 None 被丢弃。
 
 _GEMINI_REGISTRY_BACKEND = "gemini"
 
@@ -116,6 +116,7 @@ def _build_gemini_video(config: LoadedConfig, model_id: str | None, *, backend_t
         _GEMINI_REGISTRY_BACKEND,
         backend_type=backend_type,
         api_key=config.credentials.get("api_key"),
+        base_url=config.credentials.get("base_url"),
         rate_limiter=config.rate_limiter,
         video_model=model_id,
     )
@@ -309,7 +310,7 @@ def _text_openai_compat_spec(
 # 共享 _build_simple 闭包。「简单族」按构造形态界定（不是 provider 名白名单），含 ark/ark-agent-plan/
 # grok/openai/vidu 与 dashscope/minimax（后两者媒体侧走原生简单构造；其文本侧 OpenAI-compat 形态见下方
 # 文本族）。ark-agent-plan 媒体侧复用 Ark image/video backend（registry 同名注册），与 ark 同为简单形态。
-# 特例族 = gemini（backend_type 双模式 + image/video base_url 非对称）与 kling（JWT 双 secret +
+# 特例族 = gemini（backend_type 双模式，image/video 对等透传 base_url）与 kling（JWT 双 secret +
 # api_model_name 解耦），各挂专属 build 闭包；gemini 的两个 provider_id 各按 backend_type 登记一行（裸
 # "gemini" 是死路径——resolver 只产出带后缀 id，按 fail-loud 不登记兜底行）。文本族（media_type=text）按
 # 构造形态分三类登记（简单文本 / gemini 文本 / OpenAI-compat 文本，见各闭包），其中 dashscope/minimax 文本

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -14,20 +14,20 @@ from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_ARK
 from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
 from lib.video_backends.base import (
+    ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
     VideoCapabilities,
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
-    persist_provider_job_id,
     poll_with_retry,
 )
 
 logger = logging.getLogger(__name__)
 
 
-class ArkVideoBackend:
+class ArkVideoBackend(ProviderJobIdPersistenceMixin):
     """Ark (火山方舟) 视频生成后端。"""
 
     DEFAULT_MODEL = "doubao-seedance-1-5-pro-251215"
@@ -101,8 +101,7 @@ class ArkVideoBackend:
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         """生成视频。任务创建和轮询阶段分离重试，避免瞬态错误导致重建任务。"""
         provider_task_id = await self._create_task(request)
-        if request.task_id is not None:
-            await persist_provider_job_id(request.task_id, provider_task_id, provider=PROVIDER_ARK)
+        await self._persist_provider_job_id(request, provider_task_id, provider=PROVIDER_ARK)
         return await self._poll_until_done(provider_task_id, request)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -66,6 +66,30 @@ async def persist_provider_job_id(task_id: str, job_id: str, *, provider: str) -
         raise
 
 
+class ProviderJobIdPersistenceMixin:
+    """提交-轮询型 video backend 的 provider_job_id 持久化收口点。
+
+    各 backend 在 ``generate()`` 内 submit 拿到 job_id 后调 ``self._persist_provider_job_id``
+    统一写回，不再各自手写「``if request.task_id is not None`` → 调模块级 ``persist_provider_job_id``」
+    那套形态；持久化时机（submit 后、poll 前）、None 跳过（非 worker 路径）、fail-fast 语义集中
+    于此单一调用点。新增提交-轮询型 backend 继承本 mixin 即得能力，无需自己记得调持久化。
+
+    ``provider`` 仍由 backend 显式传 PROVIDER_* 常量而非从 ``self.name`` 推：gemini 的
+    ``name`` 是 ``gemini-aistudio`` / ``gemini-vertex``，与计费/日志归因用的 ``PROVIDER_GEMINI``
+    （``gemini``）不同，自动取 name 会改写持久化日志的 provider 字段。
+    """
+
+    async def _persist_provider_job_id(self, request: VideoGenerationRequest, job_id: str, *, provider: str) -> None:
+        """submit 成功后立即调：worker 路径写回 job_id，非 worker 路径（task_id=None）跳过。
+
+        持久化失败抛出（DB 瞬态错误已在 ``persist_provider_job_id`` 内重试 3 次），由 worker
+        finally 兜底 mark_failed —— 保持现有 fail-fast 语义（ADR 0007）。
+        """
+        if request.task_id is None:
+            return
+        await persist_provider_job_id(request.task_id, job_id, provider=provider)
+
+
 @with_retry_async(
     max_attempts=3,
     backoff_seconds=_PERSIST_BACKOFF_SECONDS,
@@ -398,9 +422,9 @@ class VideoGenerationRequest:
     # 项目上下文（用于构建文件服务 URL 等）
     project_name: str | None = None
 
-    # Worker 路径下从 task["task_id"] 传入，让 backend submit 后能直接调
-    # `persist_provider_job_id(task_id, job_id)` 持久化。
-    # 非 worker 路径（grid / 直生 / 测试）保持 None，backend 跳过持久化。
+    # Worker 路径下从 task["task_id"] 传入，让 backend submit 后经
+    # `ProviderJobIdPersistenceMixin._persist_provider_job_id` 持久化 job_id。
+    # 非 worker 路径（grid / 直生 / 测试）保持 None，统一点据此跳过持久化。
     task_id: str | None = None
 
     # Seedance 特有

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -39,6 +39,7 @@ from lib.retry import (
     with_retry_async,
 )
 from lib.video_backends.base import (
+    ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
     VideoCapabilities,
     VideoCapability,
@@ -46,7 +47,6 @@ from lib.video_backends.base import (
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
-    persist_provider_job_id,
     poll_with_retry,
     should_retry_download,
     should_retry_poll,
@@ -130,7 +130,7 @@ def _profile_for_model(model: str | None) -> tuple[set[VideoCapability], VideoCa
     return _DEFAULT_PROFILE
 
 
-class DashScopeVideoBackend:
+class DashScopeVideoBackend(ProviderJobIdPersistenceMixin):
     """阿里百炼视频后端（异步 video-synthesis 端点）。"""
 
     def __init__(
@@ -183,8 +183,7 @@ class DashScopeVideoBackend:
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             task_id = await self._create_task(client, payload)
             logger.info("DashScope 视频任务已创建: task_id=%s model=%s", task_id, self._model)
-            if request.task_id is not None:
-                await persist_provider_job_id(request.task_id, task_id, provider=PROVIDER_DASHSCOPE)
+            await self._persist_provider_job_id(request, task_id, provider=PROVIDER_DASHSCOPE)
             return await self._poll_and_build(client, task_id, request, is_resume=False)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -17,19 +17,19 @@ from lib.providers import PROVIDER_GEMINI
 from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
 from lib.system_config import resolve_vertex_credentials_path
 from lib.video_backends.base import (
+    ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
     VideoCapabilities,
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
-    persist_provider_job_id,
     poll_with_retry,
 )
 
 logger = logging.getLogger(__name__)
 
 
-class GeminiVideoBackend:
+class GeminiVideoBackend(ProviderJobIdPersistenceMixin):
     """Gemini (Veo) 视频生成后端。"""
 
     def __init__(
@@ -121,8 +121,7 @@ class GeminiVideoBackend:
             # 一旦进程中断，孤儿处理会走 [restart_lost] 回退到重新提交路径——这正是要避免的
             # 重复扣费场景。直接抛错让 worker finally 标 failed，比静默继续 poll 安全。
             raise RuntimeError("Gemini 提交成功但未返回 operation.name，无法持久化 provider_job_id")
-        if request.task_id is not None:
-            await persist_provider_job_id(request.task_id, op_name, provider=PROVIDER_GEMINI)
+        await self._persist_provider_job_id(request, op_name, provider=PROVIDER_GEMINI)
         return await self._poll_until_done(operation, request)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -49,13 +49,13 @@ from lib.retry import (
     with_retry_async,
 )
 from lib.video_backends.base import (
+    ProviderJobIdPersistenceMixin,
     VideoCapabilities,
     VideoCapability,
     VideoCapabilityError,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
-    persist_provider_job_id,
     poll_with_retry,
     should_retry_download,
     should_retry_poll,
@@ -188,7 +188,7 @@ def _decode_job_id(job_id: str) -> tuple[str, str, bool | None]:
     return _TEXT2VIDEO, job_id, None
 
 
-class KlingVideoBackend:
+class KlingVideoBackend(ProviderJobIdPersistenceMixin):
     """可灵 Kling 视频后端（异步轮询，JWT / Bearer 双模式）。"""
 
     def __init__(
@@ -381,14 +381,13 @@ class KlingVideoBackend:
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             task_id = await self._create_task(client, subpath, payload)
             logger.info("Kling 视频任务已创建: task_id=%s model=%s", task_id, self._model)
-            if request.task_id is not None:
-                # 持久化「子路径:task_id:有声标志」而非裸 task_id：resume 据此复原查询端点
-                # 与 submit 时的有声决策（见 _encode_job_id）。
-                await persist_provider_job_id(
-                    request.task_id,
-                    _encode_job_id(subpath, task_id, generate_audio=generate_audio),
-                    provider=PROVIDER_KLING,
-                )
+            # 持久化「子路径:task_id:有声标志」而非裸 task_id：resume 据此复原查询端点
+            # 与 submit 时的有声决策（见 _encode_job_id）。
+            await self._persist_provider_job_id(
+                request,
+                _encode_job_id(subpath, task_id, generate_audio=generate_audio),
+                provider=PROVIDER_KLING,
+            )
             return await self._poll_and_build(client, subpath, task_id, request, generate_audio=generate_audio)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -40,13 +40,13 @@ from lib.retry import (
     with_retry_async,
 )
 from lib.video_backends.base import (
+    ProviderJobIdPersistenceMixin,
     VideoCapabilities,
     VideoCapability,
     VideoCapabilityError,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
-    persist_provider_job_id,
     poll_with_retry,
     should_retry_download,
     should_retry_poll,
@@ -109,7 +109,7 @@ def _safe_body_for_log(body: dict) -> dict:
     return safe
 
 
-class MiniMaxVideoBackend:
+class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
     """MiniMax 海螺视频后端（异步两步取 URL，轮询）。"""
 
     def __init__(
@@ -165,8 +165,7 @@ class MiniMaxVideoBackend:
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             task_id = await self._create_task(client, payload)
             logger.info("MiniMax 视频任务已创建: task_id=%s model=%s", task_id, self._model)
-            if request.task_id is not None:
-                await persist_provider_job_id(request.task_id, task_id, provider=PROVIDER_MINIMAX)
+            await self._persist_provider_job_id(request, task_id, provider=PROVIDER_MINIMAX)
             return await self._poll_and_build(client, task_id, request)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -22,13 +22,13 @@ from lib.retry import (
     with_retry_async,
 )
 from lib.video_backends.base import (
+    ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
     VideoCapabilities,
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
-    persist_provider_job_id,
     poll_with_retry,
     should_retry_poll,
     should_retry_submit,
@@ -58,7 +58,7 @@ def _resolve_size(resolution: str | None, aspect_ratio: str) -> tuple[int, int]:
     return aspect_size(aspect_ratio, short, round_to=_VIDEO_ROUND_TO)
 
 
-class NewAPIVideoBackend:
+class NewAPIVideoBackend(ProviderJobIdPersistenceMixin):
     """NewAPI 统一视频生成端点后端。"""
 
     def __init__(
@@ -137,8 +137,7 @@ class NewAPIVideoBackend:
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             provider_task_id = await self._create_task(client, payload)
             logger.info("NewAPI 任务创建: task_id=%s", provider_task_id)
-            if request.task_id is not None:
-                await persist_provider_job_id(request.task_id, provider_task_id, provider=PROVIDER_NEWAPI)
+            await self._persist_provider_job_id(request, provider_task_id, provider=PROVIDER_NEWAPI)
             return await self._poll_and_build(client, provider_task_id, request, is_resume=False)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -13,12 +13,12 @@ from lib.providers import PROVIDER_OPENAI
 from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
 from lib.video_backends.base import (
     IMAGE_MIME_TYPES,
+    ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
     VideoCapabilities,
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
-    persist_provider_job_id,
     poll_with_retry,
 )
 
@@ -88,7 +88,7 @@ def _resolve_size(model: str, resolution: str | None, aspect_ratio: str) -> str:
     return chosen
 
 
-class OpenAIVideoBackend:
+class OpenAIVideoBackend(ProviderJobIdPersistenceMixin):
     """OpenAI Sora 视频生成后端。"""
 
     def __init__(self, *, api_key: str | None = None, model: str | None = None, base_url: str | None = None):
@@ -146,9 +146,8 @@ class OpenAIVideoBackend:
 
         video = await self._create_video(**kwargs)
         # submit 成功立即持久化 job_id；持久化失败抛 → finally mark_failed。
-        # 非 worker 路径（grid / 直生 / 测试）request.task_id 为 None，跳过持久化。
-        if request.task_id is not None:
-            await persist_provider_job_id(request.task_id, video.id, provider=PROVIDER_OPENAI)
+        # 非 worker 路径（grid / 直生 / 测试）request.task_id 为 None，统一点内跳过持久化。
+        await self._persist_provider_job_id(request, video.id, provider=PROVIDER_OPENAI)
         final = await self._poll_until_complete(video.id, request.duration_seconds)
 
         # generate 路径下 expired 是「provider 异常 / 输入参数过期」类失败，

--- a/lib/video_backends/v2_video_generations.py
+++ b/lib/video_backends/v2_video_generations.py
@@ -31,13 +31,13 @@ from lib.retry import (
     with_retry_async,
 )
 from lib.video_backends.base import (
+    ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
     VideoCapabilities,
     VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
-    persist_provider_job_id,
     poll_with_retry,
     should_retry_poll,
     should_retry_submit,
@@ -257,7 +257,7 @@ def _extract_failure(state: dict) -> str | None:
     return f"V2 视频生成失败: {msg}"
 
 
-class V2VideoGenerationsBackend:
+class V2VideoGenerationsBackend(ProviderJobIdPersistenceMixin):
     """流派 C ``/v2/video/generations`` 通用视频后端。"""
 
     def __init__(self, *, api_key: str, base_url: str, model: str, http_timeout: float = 60.0) -> None:
@@ -314,8 +314,7 @@ class V2VideoGenerationsBackend:
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             generation_id = await self._create_task(client, body)
             logger.info("V2 任务创建: generation_id=%s", generation_id)
-            if request.task_id is not None:
-                await persist_provider_job_id(request.task_id, generation_id, provider=PROVIDER_V2_VIDEO)
+            await self._persist_provider_job_id(request, generation_id, provider=PROVIDER_V2_VIDEO)
             return await self._poll_and_build(client, generation_id, request, is_resume=False)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:

--- a/tests/test_backend_assembly_specs.py
+++ b/tests/test_backend_assembly_specs.py
@@ -110,10 +110,10 @@ class TestMediaRegistryRouting:
 
 
 class TestGeminiSpec:
-    """gemini 特例族：backend_type 按 provider_id 分叉（aistudio/vertex 各一行），image 设 base_url /
-    video 不设（非对称提升为两条表行），注入共享 rate_limiter，image_model/video_model 命名差异。
-    api_key 与 base_url 无条件透传（含 None）：与迁移前命令式分支一致，由 backend 内 resolve_gemini_api_key
-    / normalize_base_url 处理 None（读环境变量 / 省略）。"""
+    """gemini 特例族：backend_type 按 provider_id 分叉（aistudio/vertex 各一行），image/video 对等透传
+    base_url，注入共享 rate_limiter，image_model/video_model 命名差异。api_key 与 base_url 无条件透传
+    （含 None）：由 backend 内 resolve_gemini_api_key / normalize_base_url 处理 None（读环境变量 / 省略），
+    vertex 分支结构性忽略 base_url（vertexai=True + 服务账号凭证，无注入点）。"""
 
     @patch("lib.image_backends.registry.create_backend")
     def test_aistudio_image_sets_base_url_and_image_model(self, mock_create):
@@ -155,21 +155,22 @@ class TestGeminiSpec:
         )
 
     @patch("lib.video_backends.registry.create_backend")
-    def test_aistudio_video_omits_base_url_uses_video_model(self, mock_create):
+    def test_aistudio_video_sets_base_url_uses_video_model(self, mock_create):
         spec = get_provider_spec("gemini-aistudio", "video")
         assert spec.registry_backend == "gemini"
         limiter = object()
         config = LoadedConfig(
-            credentials={"api_key": "sk-aistudio", "base_url": "https://ignored.example.com"},
+            credentials={"api_key": "sk-aistudio", "base_url": "https://custom.example.com"},
             provider_meta=PROVIDER_REGISTRY.get("gemini-aistudio"),
             rate_limiter=limiter,
         )
         spec.build_backend(config, "veo-3.1-lite-generate-preview")
-        # video 非对称：不传 base_url（即使 credentials 含），命名参数是 video_model 不是 image_model
+        # video 与 image 对等：aistudio 透传用户 base_url，命名参数是 video_model 不是 image_model
         mock_create.assert_called_once_with(
             "gemini",
             backend_type="aistudio",
             api_key="sk-aistudio",
+            base_url="https://custom.example.com",
             rate_limiter=limiter,
             video_model="veo-3.1-lite-generate-preview",
         )
@@ -178,15 +179,17 @@ class TestGeminiSpec:
     def test_vertex_video_backend_type_vertex(self, mock_create):
         spec = get_provider_spec("gemini-vertex", "video")
         config = LoadedConfig(
-            credentials={"api_key": None},
+            credentials={"api_key": None, "base_url": None},
             provider_meta=PROVIDER_REGISTRY.get("gemini-vertex"),
             rate_limiter=None,
         )
         spec.build_backend(config, "veo-3.1-generate-preview")
+        # vertex 无 api_key/base_url：仍无条件透传 None（与 vertex image 对称，backend 内结构性忽略）
         mock_create.assert_called_once_with(
             "gemini",
             backend_type="vertex",
             api_key=None,
+            base_url=None,
             rate_limiter=None,
             video_model="veo-3.1-generate-preview",
         )

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -478,7 +478,7 @@ class TestPersist:
         client = _client(post=post, get=get)
         persist = AsyncMock()
         p1, p2, p3 = _patches(client, AsyncMock())
-        with p1, p2, p3, patch("lib.video_backends.dashscope.persist_provider_job_id", persist):
+        with p1, p2, p3, patch("lib.video_backends.base.persist_provider_job_id", persist):
             from lib.video_backends.dashscope import DashScopeVideoBackend
 
             b = DashScopeVideoBackend(api_key="sk", model="happyhorse-1.0-i2v")

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -452,7 +452,7 @@ class TestGenerateHappyPath:
             patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
             patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
             patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-            patch("lib.video_backends.kling.persist_provider_job_id", new=AsyncMock()) as persist,
+            patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist,
         ):
             await _jwt_backend().generate(_request(tmp_path, task_id="local-task-1"))
         persist.assert_awaited_once()
@@ -470,7 +470,7 @@ class TestGenerateHappyPath:
             patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
             patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
             patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-            patch("lib.video_backends.kling.persist_provider_job_id", new=AsyncMock()) as persist,
+            patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist,
         ):
             await _jwt_backend().generate(_request(tmp_path, task_id="local-task-2", start_image=img))
         # 有首帧 → image2video 前缀编入 job_id，resume 才能查对端点
@@ -584,7 +584,7 @@ class TestAudioGatingResult:
             patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
             patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
             patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-            patch("lib.video_backends.kling.persist_provider_job_id", new=AsyncMock()) as persist,
+            patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist,
         ):
             await _jwt_backend("kling-v2-6").generate(
                 _request(tmp_path, task_id="local-a", service_tier="pro", generate_audio=True)

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -257,7 +257,7 @@ class TestGenerateHappyPath:
             patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
             patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
             patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
-            patch("lib.video_backends.minimax.persist_provider_job_id", new=AsyncMock()) as persist,
+            patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist,
         ):
             await _backend().generate(_request(tmp_path, task_id="local-task-1"))
         persist.assert_awaited_once()

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -384,7 +384,7 @@ class TestV2BackendHttp:
                 "lib.video_backends.v2_video_generations.download_video",
                 AsyncMock(side_effect=_fake_download_factory()),
             ),
-            patch("lib.video_backends.v2_video_generations.persist_provider_job_id", persist),
+            patch("lib.video_backends.base.persist_provider_job_id", persist),
         ):
             req = VideoGenerationRequest(
                 prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5, task_id="task-77"

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import OperationalError
 
 from lib.video_backends.base import (
     AmbiguousSubmitError,
+    ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
     VideoCapability,
     VideoGenerationRequest,
@@ -564,6 +565,40 @@ class TestPersistJobIdRetry:
                 await persist_provider_job_id("task-T", "job-T", provider="gemini")
 
         assert attempts == 1, "expects no string-fallback retry for ValueError"
+
+
+class TestProviderJobIdPersistenceMixin:
+    """提交-轮询型 video backend 的持久化收口点：单一统一调用点承接 None 判断 + 写回 + fail-fast。"""
+
+    def _backend(self) -> ProviderJobIdPersistenceMixin:
+        # 裸 mixin 实例即可——_persist_provider_job_id 不依赖任何子类状态。
+        return ProviderJobIdPersistenceMixin()
+
+    def _request(self, *, task_id: str | None) -> VideoGenerationRequest:
+        return VideoGenerationRequest(prompt="p", output_path=Path("/tmp/out.mp4"), task_id=task_id)
+
+    async def test_worker_path_persists_via_module_helper(self):
+        """worker 路径（task_id 非空）经统一点转调模块级 persist_provider_job_id。"""
+        with patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist:
+            await self._backend()._persist_provider_job_id(
+                self._request(task_id="local-task-1"), "job-1", provider="ark"
+            )
+        persist.assert_awaited_once_with("local-task-1", "job-1", provider="ark")
+
+    async def test_non_worker_path_skips_persist(self):
+        """非 worker 路径（grid / 直生 / 测试，task_id=None）跳过持久化，不触碰 DB。"""
+        with patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist:
+            await self._backend()._persist_provider_job_id(self._request(task_id=None), "job-1", provider="ark")
+        persist.assert_not_awaited()
+
+    async def test_persist_failure_propagates_fail_fast(self):
+        """持久化失败抛出原异常，由 worker finally 兜底 mark_failed（fail-fast，不吞）。"""
+        boom = _make_operational_error("database is locked")
+        with patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock(side_effect=boom)):
+            with pytest.raises(OperationalError):
+                await self._backend()._persist_provider_job_id(
+                    self._request(task_id="local-task-1"), "job-1", provider="gemini"
+                )
 
 
 class TestPersistApiCallIdRetry:


### PR DESCRIPTION
## 概述

收口 PRD #856（内置 backend 声明式缝）在 Out of Scope 中标记为「独立议题」的两项延伸技术债。

### 1. provider_job_id 持久化收口到共享 mixin（承 ADR 0007）

8 处提交-轮询型 video backend（ark / dashscope / gemini / kling / minimax / newapi / openai / v2_video_generations）不再各自手写「`if request.task_id is not None` → 调模块级 `persist_provider_job_id`」那套形态，统一继承 `ProviderJobIdPersistenceMixin`，经单一调用点 `self._persist_provider_job_id(request, job_id, provider=PROVIDER_*)` 写回。

行为等价（逐处核对）：
- None 跳过（非 worker 路径：grid / 直生 / 测试）语义不变
- fail-fast：持久化失败照旧向上抛，由 worker finally 兜底 mark_failed（ADR 0007）
- submit → persist → poll 时序不变（gemini 的 `operation.name` 缺失校验仍在 persist 之前；openai 仍是 create → persist → poll）
- provider 归因仍由各 backend 显式传 `PROVIDER_*` 常量（gemini 的 `name` 是 `gemini-aistudio`/`gemini-vertex`，与计费/日志归因用的 `PROVIDER_GEMINI` 不同，不能从 `self.name` 推）
- kling 仍以 `_encode_job_id(子路径:task_id:有声标志)` 编码后再持久化，resume 端点复原不变
- DB 瞬态错误重试次数（3 次）不变——mixin 仅委托回同一个模块级 `persist_provider_job_id`

新增提交-轮询型 backend 继承本 mixin 即得能力，无需重复实现。

### 2. gemini-aistudio video 补 base_url 透传

声明式 spec 表中 gemini image build 闭包透传 `base_url` 而 video build 闭包不传，导致 aistudio video 无法用用户配置的自定义 endpoint（image 却可以）。本 PR 给 video build 闭包补 `base_url` 透传，与 image 对等。vertex 路径走 `vertexai=True` + 服务账号凭证，结构性忽略 `base_url`（无注入点），透传的 None 被丢弃——二者皆不用 base_url 的结构事实保持不变，未新增独立字段。

## 验证

- `uv run ruff check` / `ruff format --check`：通过
- `uv run basedpyright`：0 error
- `uv run python -m pytest`：5135 passed，覆盖率 89%（≥80%）；含 resume/orphan 回归（test_resume_executor / test_media_generator_resume）
- 新增 `TestProviderJobIdPersistenceMixin`：覆盖 worker 写回 / 非 worker 跳过 / 持久化失败 fail-fast 三态
- 独立 code-review（多角度 finder + 验证）：无 correctness/cleanup 发现

Closes #868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Gemini video backend to properly pass the base_url parameter during video creation, ensuring correct endpoint configuration.

* **Improvements**
  * Unified job ID persistence behavior across video backends (Ark, DashScope, Gemini, Kling, MiniMax, NewAPI, OpenAI, V2 Video Generations) for more consistent and reliable video generation tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->