### PR TITLE
fix(agent): 助手会话内更改风格等项目设置后即时生效

### DIFF
--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -544,10 +544,11 @@ class SessionManager:
     def _build_append_prompt(self, project_name: str, locale: str = "zh") -> str:
         """Build the append portion for SystemPromptPreset.
 
-        Combines the ArcReel persona with project-specific context from
-        project.json.  The base CLAUDE.md is auto-loaded by the SDK via
-        setting_sources=["project"] and the CLAUDE.md symlink in the
-        project cwd.
+        Combines the ArcReel persona, the locale language regulation, and the
+        session-invariant project context (identity, cwd, operating rules).
+        Mutable project metadata is not included here — it lives in project.json
+        and is read on demand. The project's CLAUDE.md (mode variant projected
+        into the cwd) is auto-loaded by the SDK via setting_sources=["project"].
         """
         parts = [self._PERSONA_PROMPT]
 
@@ -567,71 +568,28 @@ class SessionManager:
         return "\n".join(parts)
 
     def _build_project_context(self, project_name: str) -> str:
-        """Build project-specific context from project.json metadata."""
+        """Build session-invariant project context for the system prompt.
+
+        Holds only facts that cannot change within a session: project identity,
+        cwd, and static operating rules. Mutable metadata (title, style,
+        overview, ...) lives in project.json and is read on demand by the agent
+        and tools — never baked into the session-fixed system prompt.
+        """
         try:
             project_cwd = self._resolve_project_cwd(project_name)
         except (ValueError, FileNotFoundError):
             return ""
 
-        project_json = project_cwd / "project.json"
-        if not project_json.exists():
-            return ""
-
-        try:
-            config = json.loads(project_json.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning("Failed to read project.json for %s: %s", project_name, exc)
-            return ""
-
-        if not isinstance(config, dict):
-            logger.warning("project.json for %s is not a JSON object", project_name)
-            return ""
-
         parts = [
             "## 当前项目上下文",
             "",
+            f"- 项目标识：{project_name}",
+            f"- 项目目录（即当前工作目录 cwd）：{project_cwd}",
+            "- 项目元数据存于 project.json，可能在会话期间被修改；需要某项元数据时按需读取 project.json "
+            "获取当前值，不要沿用此前对话中出现过的旧值。",
+            "- Bash 命令必须写在单行，禁止使用 `\\` 换行，JSON 参数使用紧凑格式。",
         ]
-
-        # TODO: 当前定位是自部署服务，这里直接拼接项目元数据以保持实现简单。
-        # TODO: 若后续演进为 SaaS / 多租户服务，需要把 title/style/overview 等用户输入
-        # TODO: 按“非指令上下文”做边界化或转义，降低 prompt injection 风险。
-        parts.append(f"- 项目标识：{project_name}")
-        if title := config.get("title"):
-            parts.append(f"- 项目标题：{title}")
-        if mode := config.get("content_mode"):
-            parts.append(f"- 内容模式：{mode}")
-        if style := config.get("style"):
-            parts.append(f"- 视觉风格：{style}")
-        if style_desc := config.get("style_description"):
-            parts.append(f"- 风格描述：{style_desc}")
-        parts.append(f"- 项目目录（即当前工作目录 cwd）：{project_cwd}")
-        parts.append(
-            "- Read/Edit/Write 等工具的 file_path 参数必须使用绝对路径，不要使用相对路径，也不要把项目标题当成目录名。"
-        )
-        parts.append(
-            "- Bash 调用 skill 脚本时必须使用相对路径（如 `python .claude/skills/.../script.py`），不要转换为绝对路径。"
-        )
-        parts.append("- Bash 命令必须写在单行，禁止使用 `\\` 换行，JSON 参数使用紧凑格式。")
-
-        self._append_overview_section(parts, config.get("overview", {}))
-
         return "\n".join(parts)
-
-    @staticmethod
-    def _append_overview_section(parts: list[str], overview: Any) -> None:
-        """Append project overview fields to prompt parts."""
-        if not isinstance(overview, dict) or not overview:
-            return
-        parts.append("")
-        parts.append("### 项目概述")
-        if synopsis := overview.get("synopsis"):
-            parts.append(synopsis)
-        if genre := overview.get("genre"):
-            parts.append(f"- 题材：{genre}")
-        if theme := overview.get("theme"):
-            parts.append(f"- 主题：{theme}")
-        if world := overview.get("world_setting"):
-            parts.append(f"- 世界观：{world}")
 
     def _build_session_store(self) -> DbSessionStore | None:
         """Return a cached per-user DbSessionStore, or None when env disables it.

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -584,9 +584,8 @@ class SessionManager:
             "## 当前项目上下文",
             "",
             f"- 项目标识：{project_name}",
-            f"- 项目目录（即当前工作目录 cwd）：{project_cwd}",
-            "- 项目元数据存于 project.json，可能在会话期间被修改；需要某项元数据时按需读取 project.json "
-            "获取当前值，不要沿用此前对话中出现过的旧值。",
+            f"- 项目目录（即当前工作目录 cwd）：{project_cwd.as_posix()}",
+            "- 项目元数据（标题、风格、概述等）存于 project.json，需要时读取。",
             "- Bash 命令必须写在单行，禁止使用 `\\` 换行，JSON 参数使用紧凑格式。",
         ]
         return "\n".join(parts)

--- a/tests/test_session_manager_project_scope.py
+++ b/tests/test_session_manager_project_scope.py
@@ -155,8 +155,8 @@ class TestSessionManagerProjectScope:
         await engine.dispose()
 
     @pytest.mark.asyncio
-    async def test_build_project_context_injects_project_context(self, tmp_path):
-        """Verify full project.json fields are injected into the system prompt."""
+    async def test_build_project_context_excludes_mutable_metadata(self, tmp_path):
+        """Mutable metadata must NOT leak into the session-fixed system prompt."""
         project_dir = tmp_path / "projects" / "demo"
         project_dir.mkdir(parents=True)
         project_json = project_dir / "project.json"
@@ -188,28 +188,43 @@ class TestSessionManagerProjectScope:
 
         prompt = manager._build_project_context("demo")
 
-        # Project metadata fields
+        # Session-invariant facts are present
         assert "项目标识：demo" in prompt
-        assert "项目标题：重生之皇后威武" in prompt
-        assert "重生之皇后威武" in prompt
-        assert "narration" in prompt
-        assert "Photographic" in prompt
-        assert "Soft diffused lighting" in prompt
         assert f"项目目录（即当前工作目录 cwd）：{project_dir.resolve()}" in prompt
-        assert "必须使用绝对路径" in prompt
-        assert "必须使用相对路径" in prompt
+        assert "按需读取 project.json" in prompt
+        assert "Bash 命令必须写在单行" in prompt
 
-        # Overview fields
-        assert "姜月茴重生后逆袭的故事" in prompt
-        assert "古装宫斗" in prompt
-        assert "复仇与救赎" in prompt
-        assert "架空古代皇朝" in prompt
+        # The cwd line embeds an arbitrary temp path; exclude it so ASCII tokens
+        # that may appear in the test's tmp_path can't cause false substring matches.
+        body = "\n".join(line for line in prompt.splitlines() if "项目目录" not in line)
+
+        # Mutable metadata (every label and value) must be absent — read on demand instead
+        for token in (
+            "项目标题",
+            "重生之皇后威武",
+            "内容模式",
+            "narration",
+            "视觉风格",
+            "Photographic",
+            "风格描述",
+            "Soft diffused lighting",
+            "项目概述",
+            "姜月茴重生后逆袭的故事",
+            "古装宫斗",
+            "复仇与救赎",
+            "架空古代皇朝",
+        ):
+            assert token not in body
+
+        # Redundant path rules now live only in CLAUDE.{mode}.md — guard against re-adding them here
+        assert "必须使用绝对路径" not in body
+        assert "必须使用相对路径" not in body
 
         await engine.dispose()
 
     @pytest.mark.asyncio
-    async def test_build_project_context_graceful_fallback_no_project_json(self, tmp_path):
-        """Verify graceful degradation when project.json does not exist."""
+    async def test_build_project_context_emits_block_without_project_json(self, tmp_path):
+        """Output is independent of project.json: the stable block is emitted even when it is absent."""
         project_dir = tmp_path / "projects" / "empty"
         project_dir.mkdir(parents=True)
         # No project.json created
@@ -223,48 +238,9 @@ class TestSessionManagerProjectScope:
 
         prompt = manager._build_project_context("empty")
 
-        # Should return empty string — base prompt is auto-loaded by SDK
-        assert prompt == ""
-
-        await engine.dispose()
-
-    @pytest.mark.asyncio
-    async def test_build_project_context_partial_fields(self, tmp_path):
-        """Verify partial project.json (some fields missing) works correctly."""
-        project_dir = tmp_path / "projects" / "partial"
-        project_dir.mkdir(parents=True)
-        project_json = project_dir / "project.json"
-        project_json.write_text(
-            json.dumps(
-                {
-                    "title": "测试项目",
-                    "content_mode": "drama",
-                    # No style, style_description, or overview
-                },
-                ensure_ascii=False,
-            ),
-            encoding="utf-8",
-        )
-
-        store, engine = await _make_store()
-        manager = SessionManager(
-            project_root=tmp_path,
-            data_dir=tmp_path,
-            meta_store=store,
-        )
-
-        prompt = manager._build_project_context("partial")
-
-        # Present fields should be injected
-        assert "项目标识：partial" in prompt
-        assert "项目标题：测试项目" in prompt
+        assert "项目标识：empty" in prompt
         assert f"项目目录（即当前工作目录 cwd）：{project_dir.resolve()}" in prompt
-        assert "测试项目" in prompt
-        assert "drama" in prompt
-
-        # Missing fields should NOT cause errors or appear
-        assert "Photographic" not in prompt
-        assert "项目概述" not in prompt  # No overview section header
+        assert "按需读取 project.json" in prompt
 
         await engine.dispose()
 
@@ -309,10 +285,9 @@ class TestAllowedToolsAndConstants:
 
 class TestSystemPromptProjectContext:
     @pytest.mark.asyncio
-    async def test_build_project_context_returns_empty_without_project_json(self, tmp_path):
-        """Without project.json, system_prompt should be empty (SDK auto-loads CLAUDE.md)."""
-        project_dir = tmp_path / "projects" / "demo"
-        project_dir.mkdir(parents=True)
+    async def test_build_project_context_returns_empty_when_project_dir_missing(self, tmp_path):
+        """The only empty case left: no project directory at all (cwd cannot resolve)."""
+        (tmp_path / "projects").mkdir(parents=True, exist_ok=True)
 
         store, engine = await _make_store()
         manager = SessionManager(
@@ -321,28 +296,6 @@ class TestSystemPromptProjectContext:
             meta_store=store,
         )
 
-        prompt = manager._build_project_context("demo")
+        prompt = manager._build_project_context("does-not-exist")
         assert prompt == ""
-        await engine.dispose()
-
-    @pytest.mark.asyncio
-    async def test_build_project_context_returns_project_context_only(self, tmp_path):
-        """system_prompt should only contain project.json context, not base prompt."""
-        project_dir = tmp_path / "projects" / "demo"
-        project_dir.mkdir(parents=True)
-        (project_dir / "project.json").write_text(
-            json.dumps({"title": "测试项目"}, ensure_ascii=False),
-            encoding="utf-8",
-        )
-
-        store, engine = await _make_store()
-        manager = SessionManager(
-            project_root=tmp_path,
-            data_dir=tmp_path,
-            meta_store=store,
-        )
-
-        prompt = manager._build_project_context("demo")
-        assert "项目标题：测试项目" in prompt
-        assert "当前项目上下文" in prompt
         await engine.dispose()

--- a/tests/test_session_manager_project_scope.py
+++ b/tests/test_session_manager_project_scope.py
@@ -190,8 +190,8 @@ class TestSessionManagerProjectScope:
 
         # Session-invariant facts are present
         assert "项目标识：demo" in prompt
-        assert f"项目目录（即当前工作目录 cwd）：{project_dir.resolve()}" in prompt
-        assert "按需读取 project.json" in prompt
+        assert f"项目目录（即当前工作目录 cwd）：{project_dir.resolve().as_posix()}" in prompt
+        assert "项目元数据（标题、风格、概述等）存于 project.json，需要时读取。" in prompt
         assert "Bash 命令必须写在单行" in prompt
 
         # The cwd line embeds an arbitrary temp path; exclude it so ASCII tokens
@@ -239,8 +239,8 @@ class TestSessionManagerProjectScope:
         prompt = manager._build_project_context("empty")
 
         assert "项目标识：empty" in prompt
-        assert f"项目目录（即当前工作目录 cwd）：{project_dir.resolve()}" in prompt
-        assert "按需读取 project.json" in prompt
+        assert f"项目目录（即当前工作目录 cwd）：{project_dir.resolve().as_posix()}" in prompt
+        assert "项目元数据（标题、风格、概述等）存于 project.json，需要时读取。" in prompt
 
         await engine.dispose()
 


### PR DESCRIPTION
## 问题
终端用户反馈：选中风格模块后再更改，助手仍按最初选定的风格生成提示词。

## 根因
会话级 system prompt 注入了项目可变元数据（风格 / 标题 / 内容模式 / 概述）的快照。活跃的内存会话在续聊时直接复用缓存的 options、不重建 system prompt，因此创建时烤进去的风格快照在会话内终生冻结；用户中途改风格不生效。各生成工具其实都从 project.json 读最新值，唯独助手的会话感知停留在旧快照。

## 改动
- `_build_project_context` 不再读取 project.json、不再注入任何可变元数据；只保留会话内不可变且未在别处提供的事实：项目标识、cwd、单行 Bash 规则，并新增一行指引 agent 按需读取 project.json。
- 移除与 CLAUDE.{mode}.md 路径规范重复的两条路径行、`_append_overview_section` 及相关死代码。
- 测试整合为 3 个聚焦用例：可变元数据排除、无 project.json 仍输出稳定块、缺目录返回空。

## 验证
- `uv run python -m pytest tests/test_session_manager_project_scope.py`：9 passed
- ruff 通过；basedpyright 0 error
- session / agent_runtime 相关 523 passed

## 范围与后续
- 仅修复 system prompt 陈旧（成因 1）。已生成剧本的 image_prompt 文本冻结（改风格需重生剧本）是符合预期的行为，不在本次范围。
- 代码审查另发现一处独立的预存缺陷：会话冷恢复时语言规范回落中文、忽略用户实际 locale，已记录为 #891 待后续处理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化会话固定系统提示的生成方式：不再把可变的项目元数据写入固定提示内容。
  * 让项目配置说明（如 CLAUDE.md）由 SDK 在当前目录按需自动加载。
  * 项目上下文构建更聚焦于稳定的项目标识与静态约束说明；定位失败时采用兜底返回。

* **测试**
  * 调整/新增项目上下文相关用例：验证元数据隔离、稳定片段输出，以及缺失项目目录时的空返回场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->