### PR TITLE
fix(security): 资产与助手路由兜底 500 不再回传内部异常文本

### DIFF
--- a/server/routers/_asset_router_factory.py
+++ b/server/routers/_asset_router_factory.py
@@ -127,9 +127,9 @@ def build_asset_router(
             raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
         except HTTPException:
             raise
-        except Exception as exc:
+        except Exception:
             logger.exception("请求处理失败")
-            raise HTTPException(status_code=500, detail=str(exc))
+            raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
     @router.patch(f"/projects/{{project_name}}/{spec.subdir}/{{entry_name}}")
     async def update_entry(
@@ -178,9 +178,9 @@ def build_asset_router(
             raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
         except HTTPException:
             raise
-        except Exception as exc:
+        except Exception:
             logger.exception("请求处理失败")
-            raise HTTPException(status_code=500, detail=str(exc))
+            raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
     @router.delete(f"/projects/{{project_name}}/{spec.subdir}/{{entry_name}}")
     async def delete_entry(project_name: str, entry_name: str, _user: CurrentUser, _t: Translator):
@@ -206,8 +206,8 @@ def build_asset_router(
             raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
         except HTTPException:
             raise
-        except Exception as exc:
+        except Exception:
             logger.exception("请求处理失败")
-            raise HTTPException(status_code=500, detail=str(exc))
+            raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
     return router

--- a/server/routers/assistant.py
+++ b/server/routers/assistant.py
@@ -96,15 +96,16 @@ async def send_message(
             status_code=502,
             detail=_t("agent_startup_failed", details=str(exc)),
         )
-    except Exception as exc:
+    except Exception:
         logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=str(exc))
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
 
 @router.get("/sessions")
 async def list_sessions(
     project_name: str,
     _user: CurrentUser,
+    _t: Translator,
     status: Literal["idle", "running", "completed", "error", "interrupted"] | None = None,
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
@@ -116,9 +117,9 @@ async def list_sessions(
         return {"sessions": [s.model_dump() for s in sessions]}
     except HTTPException:
         raise
-    except Exception as exc:
+    except Exception:
         logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=str(exc))
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
 
 @router.get("/sessions/{session_id}")
@@ -129,9 +130,9 @@ async def get_session(project_name: str, session_id: str, _user: CurrentUser, _t
         return session.model_dump()
     except HTTPException:
         raise
-    except Exception as exc:
+    except Exception:
         logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=str(exc))
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
 
 @router.delete("/sessions/{session_id}")
@@ -145,9 +146,9 @@ async def delete_session(project_name: str, session_id: str, _user: CurrentUser,
         return {"success": True}
     except HTTPException:
         raise
-    except Exception as exc:
+    except Exception:
         logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=str(exc))
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
 
 @router.get("/sessions/{session_id}/messages")
@@ -169,9 +170,9 @@ async def get_snapshot(project_name: str, session_id: str, _user: CurrentUser, _
         raise
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=_t("session_not_found", session_id=session_id))
-    except Exception as exc:
+    except Exception:
         logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=str(exc))
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
 
 @router.post("/sessions/{session_id}/interrupt")
@@ -187,9 +188,9 @@ async def interrupt_session(project_name: str, session_id: str, _user: CurrentUs
         raise HTTPException(status_code=404, detail=_t("session_not_found", session_id=session_id))
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
-    except Exception as exc:
+    except Exception:
         logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=str(exc))
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
 
 @router.post("/sessions/{session_id}/questions/{question_id}/answer")
@@ -219,9 +220,9 @@ async def answer_question(
         raise HTTPException(status_code=404, detail=_t("session_not_found", session_id=session_id))
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
-    except Exception as exc:
+    except Exception:
         logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=str(exc))
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
 
 @router.get("/sessions/{session_id}/stream", response_class=EventSourceResponse)
@@ -230,6 +231,7 @@ async def stream_events(
     session_id: str,
     request: Request,
     _user: CurrentUserFlexible,
+    _t: Translator,
     deps: tuple[AssistantService, SessionMeta] = Depends(_assistant_service_for_stream),
 ) -> AsyncIterator[ServerSentEvent]:
     service, meta = deps
@@ -238,9 +240,9 @@ async def stream_events(
             yield event
     except HTTPException:
         raise
-    except Exception as exc:
+    except Exception:
         logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=str(exc))
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
 
 @router.get("/skills")
@@ -252,6 +254,6 @@ async def list_skills(project_name: str, _user: CurrentUser, _t: Translator):
         raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
     except HTTPException:
         raise
-    except Exception as exc:
+    except Exception:
         logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=str(exc))
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))

--- a/tests/test_asset_router_factory.py
+++ b/tests/test_asset_router_factory.py
@@ -9,6 +9,11 @@ from fastapi.testclient import TestClient
 
 from server.auth import CurrentUserInfo, get_current_user
 from server.routers import characters
+from tests.conftest import make_translator
+
+# 兜底 500 的默认 locale 文案：测试未覆盖 get_translator，端点回落到 DEFAULT_LOCALE("zh")，
+# 与 make_translator() 默认 locale 一致。
+_INTERNAL_ERROR_DETAIL = make_translator()("internal_server_error")
 
 
 class _FakePM:
@@ -146,7 +151,7 @@ class TestAssetRouterNoLeak:
 
     把 add/update/delete 各自 try 块里最早调用的 pm_getter（get_project_manager）
     monkeypatch 成抛带哨兵串的 RuntimeError，绕过前置的 FileNotFoundError/HTTPException
-    分支落到末端 except Exception，断言 500 且哨兵串不出现在响应体。
+    分支落到末端 except Exception，断言 500、detail 为通用 i18n 文案且哨兵串不出现在响应体。
     """
 
     def test_add_unexpected_error_no_leak(self, monkeypatch):
@@ -161,6 +166,7 @@ class TestAssetRouterNoLeak:
         with TestClient(app) as client:
             resp = client.post("/api/v1/projects/demo/characters", json={"name": "Bob", "description": "x"})
             assert resp.status_code == 500
+            assert resp.json()["detail"] == _INTERNAL_ERROR_DETAIL
             assert "LEAK_add" not in resp.text
 
     def test_update_unexpected_error_no_leak(self, monkeypatch):
@@ -175,6 +181,7 @@ class TestAssetRouterNoLeak:
         with TestClient(app) as client:
             resp = client.patch("/api/v1/projects/demo/characters/Alice", json={"description": "new"})
             assert resp.status_code == 500
+            assert resp.json()["detail"] == _INTERNAL_ERROR_DETAIL
             assert "LEAK_update" not in resp.text
 
     def test_delete_unexpected_error_no_leak(self, monkeypatch):
@@ -189,4 +196,5 @@ class TestAssetRouterNoLeak:
         with TestClient(app) as client:
             resp = client.delete("/api/v1/projects/demo/characters/Alice")
             assert resp.status_code == 500
+            assert resp.json()["detail"] == _INTERNAL_ERROR_DETAIL
             assert "LEAK_delete" not in resp.text

--- a/tests/test_asset_router_factory.py
+++ b/tests/test_asset_router_factory.py
@@ -139,3 +139,54 @@ class TestAssetRouterFactory:
             assert "unknown" in str(e)
         else:
             raise AssertionError("should have raised ValueError")
+
+
+class TestAssetRouterNoLeak:
+    """末端 catch-all：未预期异常返回通用 500，内部异常细节不泄露给客户端。
+
+    把 add/update/delete 各自 try 块里最早调用的 pm_getter（get_project_manager）
+    monkeypatch 成抛带哨兵串的 RuntimeError，绕过前置的 FileNotFoundError/HTTPException
+    分支落到末端 except Exception，断言 500 且哨兵串不出现在响应体。
+    """
+
+    def test_add_unexpected_error_no_leak(self, monkeypatch):
+        monkeypatch.setattr(
+            characters,
+            "get_project_manager",
+            lambda: (_ for _ in ()).throw(RuntimeError("LEAK_add")),
+        )
+        app = FastAPI()
+        app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+        app.include_router(characters.router, prefix="/api/v1")
+        with TestClient(app) as client:
+            resp = client.post("/api/v1/projects/demo/characters", json={"name": "Bob", "description": "x"})
+            assert resp.status_code == 500
+            assert "LEAK_add" not in resp.text
+
+    def test_update_unexpected_error_no_leak(self, monkeypatch):
+        monkeypatch.setattr(
+            characters,
+            "get_project_manager",
+            lambda: (_ for _ in ()).throw(RuntimeError("LEAK_update")),
+        )
+        app = FastAPI()
+        app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+        app.include_router(characters.router, prefix="/api/v1")
+        with TestClient(app) as client:
+            resp = client.patch("/api/v1/projects/demo/characters/Alice", json={"description": "new"})
+            assert resp.status_code == 500
+            assert "LEAK_update" not in resp.text
+
+    def test_delete_unexpected_error_no_leak(self, monkeypatch):
+        monkeypatch.setattr(
+            characters,
+            "get_project_manager",
+            lambda: (_ for _ in ()).throw(RuntimeError("LEAK_delete")),
+        )
+        app = FastAPI()
+        app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+        app.include_router(characters.router, prefix="/api/v1")
+        with TestClient(app) as client:
+            resp = client.delete("/api/v1/projects/demo/characters/Alice")
+            assert resp.status_code == 500
+            assert "LEAK_delete" not in resp.text

--- a/tests/test_assistant_routes.py
+++ b/tests/test_assistant_routes.py
@@ -18,11 +18,21 @@ PREFIX = f"/api/v1/projects/{PROJECT}/assistant"
 _FAKE_USER = CurrentUserInfo(id="default", sub="testuser", role="admin")
 
 
+def _override_translator():
+    """Parameterless override returning a fixed-locale translator.
+
+    A bare ``make_translator`` reference would surface its ``locale`` default as
+    an optional query parameter under FastAPI dependency resolution; wrapping it
+    in a zero-arg callable keeps the override contract parameterless.
+    """
+    return make_translator()
+
+
 def _build_client() -> TestClient:
     app = FastAPI()
     app.dependency_overrides[get_current_user] = lambda: _FAKE_USER
     app.dependency_overrides[get_current_user_flexible] = lambda: _FAKE_USER
-    app.dependency_overrides[get_translator] = lambda: make_translator()
+    app.dependency_overrides[get_translator] = _override_translator
     app.include_router(assistant.router, prefix="/api/v1/projects/{project_name}/assistant")
     return TestClient(app)
 
@@ -223,7 +233,7 @@ class TestAssistantRoutes:
         app = FastAPI()
         app.dependency_overrides[get_current_user] = lambda: _FAKE_USER
         app.dependency_overrides[get_current_user_flexible] = lambda: _FAKE_USER
-        app.dependency_overrides[get_translator] = lambda: make_translator()
+        app.dependency_overrides[get_translator] = _override_translator
         app.include_router(assistant.router, prefix="/api/v1/projects/{project_name}/assistant")
 
         with (

--- a/tests/test_assistant_routes.py
+++ b/tests/test_assistant_routes.py
@@ -94,6 +94,147 @@ class TestAssistantRoutes:
         assert response.status_code == 200
         assert response.json() == interrupt_payload
 
+    def test_send_unexpected_error_no_leak(self):
+        """send 末端 catch-all：未预期异常返回通用 500，不泄露内部细节。"""
+        with patch.object(
+            assistant.assistant_service,
+            "send_or_create",
+            new=AsyncMock(side_effect=RuntimeError("LEAK_send")),
+        ):
+            with _build_client() as client:
+                response = client.post(f"{PREFIX}/sessions/send", json={"content": "hi"})
+
+        assert response.status_code == 500
+        assert "LEAK_send" not in response.text
+
+    def test_list_sessions_unexpected_error_no_leak(self):
+        with patch.object(
+            assistant.assistant_service,
+            "list_sessions",
+            new=AsyncMock(side_effect=RuntimeError("LEAK_list")),
+        ):
+            with _build_client() as client:
+                response = client.get(f"{PREFIX}/sessions")
+
+        assert response.status_code == 500
+        assert "LEAK_list" not in response.text
+
+    def test_get_session_unexpected_error_no_leak(self):
+        with patch.object(
+            assistant.assistant_service,
+            "get_session",
+            new=AsyncMock(side_effect=RuntimeError("LEAK_get")),
+        ):
+            with _build_client() as client:
+                response = client.get(f"{PREFIX}/sessions/session-1")
+
+        assert response.status_code == 500
+        assert "LEAK_get" not in response.text
+
+    def test_delete_session_unexpected_error_no_leak(self):
+        session_meta = make_session_meta(id="session-1", project_name=PROJECT)
+        with (
+            patch.object(assistant.assistant_service, "get_session", return_value=session_meta),
+            patch.object(
+                assistant.assistant_service,
+                "delete_session",
+                new=AsyncMock(side_effect=RuntimeError("LEAK_delete")),
+            ),
+        ):
+            with _build_client() as client:
+                response = client.delete(f"{PREFIX}/sessions/session-1")
+
+        assert response.status_code == 500
+        assert "LEAK_delete" not in response.text
+
+    def test_snapshot_unexpected_error_no_leak(self):
+        session_meta = make_session_meta(id="session-1", project_name=PROJECT)
+        with (
+            patch.object(assistant.assistant_service, "get_session", return_value=session_meta),
+            patch.object(
+                assistant.assistant_service,
+                "get_snapshot",
+                new=AsyncMock(side_effect=RuntimeError("LEAK_snapshot")),
+            ),
+        ):
+            with _build_client() as client:
+                response = client.get(f"{PREFIX}/sessions/session-1/snapshot")
+
+        assert response.status_code == 500
+        assert "LEAK_snapshot" not in response.text
+
+    def test_interrupt_unexpected_error_no_leak(self):
+        session_meta = make_session_meta(id="session-1", project_name=PROJECT)
+        with (
+            patch.object(assistant.assistant_service, "get_session", return_value=session_meta),
+            patch.object(
+                assistant.assistant_service,
+                "interrupt_session",
+                new=AsyncMock(side_effect=RuntimeError("LEAK_interrupt")),
+            ),
+        ):
+            with _build_client() as client:
+                response = client.post(f"{PREFIX}/sessions/session-1/interrupt")
+
+        assert response.status_code == 500
+        assert "LEAK_interrupt" not in response.text
+
+    def test_answer_question_unexpected_error_no_leak(self):
+        session_meta = make_session_meta(id="session-1", project_name=PROJECT)
+        with (
+            patch.object(assistant.assistant_service, "get_session", return_value=session_meta),
+            patch.object(
+                assistant.assistant_service,
+                "answer_user_question",
+                new=AsyncMock(side_effect=RuntimeError("LEAK_answer")),
+            ),
+        ):
+            with _build_client() as client:
+                response = client.post(
+                    f"{PREFIX}/sessions/session-1/questions/q-1/answer",
+                    json={"answers": {"q-1": "yes"}},
+                )
+
+        assert response.status_code == 500
+        assert "LEAK_answer" not in response.text
+
+    def test_stream_unexpected_error_no_leak(self):
+        # SSE 端点在开始流式后已提交 200，未预期异常无法把 detail 写回响应体，但末端
+        # catch-all 仍统一走 i18n（不构造 str(exc)）。用 raise_server_exceptions=False
+        # 观察传播异常下的响应体，断言哨兵串不泄露，并确认 _t 依赖已正确注入（缺注入会 500）。
+        session_meta = make_session_meta(id="session-1", project_name=PROJECT)
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("LEAK_stream")
+            yield  # pragma: no cover - 标记为异步生成器
+
+        app = FastAPI()
+        app.dependency_overrides[get_current_user] = lambda: _FAKE_USER
+        app.dependency_overrides[get_current_user_flexible] = lambda: _FAKE_USER
+        app.dependency_overrides[get_translator] = lambda: make_translator()
+        app.include_router(assistant.router, prefix="/api/v1/projects/{project_name}/assistant")
+
+        with (
+            patch.object(assistant.assistant_service, "get_session", return_value=session_meta),
+            patch.object(assistant.assistant_service, "stream_events", new=_boom),
+        ):
+            with TestClient(app, raise_server_exceptions=False) as client:
+                response = client.get(f"{PREFIX}/sessions/session-1/stream")
+
+        assert "LEAK_stream" not in response.text
+
+    def test_list_skills_unexpected_error_no_leak(self):
+        with patch.object(
+            assistant.assistant_service,
+            "list_available_skills",
+            side_effect=RuntimeError("LEAK_skills"),
+        ):
+            with _build_client() as client:
+                response = client.get(f"{PREFIX}/skills")
+
+        assert response.status_code == 500
+        assert "LEAK_skills" not in response.text
+
     def test_send_endpoint_translates_agent_startup_error_to_502(self):
         """``AgentStartupError`` 必须翻译成 502 + i18n 包装的 detail，
         透传 SDK 自带的安装指引；500 + 占位符是回归（PR #573）。"""

--- a/tests/test_assistant_routes.py
+++ b/tests/test_assistant_routes.py
@@ -1,11 +1,12 @@
 """Unit tests for assistant router contract changes."""
 
+import inspect
 from unittest.mock import AsyncMock, patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from lib.i18n import get_translator
+from lib.i18n import Translator, get_translator
 from server.auth import CurrentUserInfo, get_current_user, get_current_user_flexible
 from server.routers import assistant
 from tests.conftest import make_translator
@@ -24,6 +25,20 @@ def _build_client() -> TestClient:
     app.dependency_overrides[get_translator] = lambda: make_translator()
     app.include_router(assistant.router, prefix="/api/v1/projects/{project_name}/assistant")
     return TestClient(app)
+
+
+_INTERNAL_ERROR_DETAIL = make_translator()("internal_server_error")
+
+
+def _assert_generic_500(response, sentinel: str) -> None:
+    """兜底 500 契约：响应体 detail 必须是通用 i18n 文案、且不泄露内部哨兵串。
+
+    仅断言 ``sentinel not in text`` 不够——detail 被清空或 i18n key 打错时也不含哨兵串，
+    回归会静默通过；故同时正向锁定 detail 等于翻译后的 internal_server_error 文案。
+    """
+    assert response.status_code == 500
+    assert response.json()["detail"] == _INTERNAL_ERROR_DETAIL
+    assert sentinel not in response.text
 
 
 class TestAssistantRoutes:
@@ -104,8 +119,7 @@ class TestAssistantRoutes:
             with _build_client() as client:
                 response = client.post(f"{PREFIX}/sessions/send", json={"content": "hi"})
 
-        assert response.status_code == 500
-        assert "LEAK_send" not in response.text
+        _assert_generic_500(response, "LEAK_send")
 
     def test_list_sessions_unexpected_error_no_leak(self):
         with patch.object(
@@ -116,8 +130,7 @@ class TestAssistantRoutes:
             with _build_client() as client:
                 response = client.get(f"{PREFIX}/sessions")
 
-        assert response.status_code == 500
-        assert "LEAK_list" not in response.text
+        _assert_generic_500(response, "LEAK_list")
 
     def test_get_session_unexpected_error_no_leak(self):
         with patch.object(
@@ -128,8 +141,7 @@ class TestAssistantRoutes:
             with _build_client() as client:
                 response = client.get(f"{PREFIX}/sessions/session-1")
 
-        assert response.status_code == 500
-        assert "LEAK_get" not in response.text
+        _assert_generic_500(response, "LEAK_get")
 
     def test_delete_session_unexpected_error_no_leak(self):
         session_meta = make_session_meta(id="session-1", project_name=PROJECT)
@@ -144,8 +156,7 @@ class TestAssistantRoutes:
             with _build_client() as client:
                 response = client.delete(f"{PREFIX}/sessions/session-1")
 
-        assert response.status_code == 500
-        assert "LEAK_delete" not in response.text
+        _assert_generic_500(response, "LEAK_delete")
 
     def test_snapshot_unexpected_error_no_leak(self):
         session_meta = make_session_meta(id="session-1", project_name=PROJECT)
@@ -160,8 +171,7 @@ class TestAssistantRoutes:
             with _build_client() as client:
                 response = client.get(f"{PREFIX}/sessions/session-1/snapshot")
 
-        assert response.status_code == 500
-        assert "LEAK_snapshot" not in response.text
+        _assert_generic_500(response, "LEAK_snapshot")
 
     def test_interrupt_unexpected_error_no_leak(self):
         session_meta = make_session_meta(id="session-1", project_name=PROJECT)
@@ -176,8 +186,7 @@ class TestAssistantRoutes:
             with _build_client() as client:
                 response = client.post(f"{PREFIX}/sessions/session-1/interrupt")
 
-        assert response.status_code == 500
-        assert "LEAK_interrupt" not in response.text
+        _assert_generic_500(response, "LEAK_interrupt")
 
     def test_answer_question_unexpected_error_no_leak(self):
         session_meta = make_session_meta(id="session-1", project_name=PROJECT)
@@ -195,13 +204,16 @@ class TestAssistantRoutes:
                     json={"answers": {"q-1": "yes"}},
                 )
 
-        assert response.status_code == 500
-        assert "LEAK_answer" not in response.text
+        _assert_generic_500(response, "LEAK_answer")
 
-    def test_stream_unexpected_error_no_leak(self):
-        # SSE 端点在开始流式后已提交 200，未预期异常无法把 detail 写回响应体，但末端
-        # catch-all 仍统一走 i18n（不构造 str(exc)）。用 raise_server_exceptions=False
-        # 观察传播异常下的响应体，断言哨兵串不泄露，并确认 _t 依赖已正确注入（缺注入会 500）。
+    def test_stream_injects_translator_and_no_leak(self):
+        # SSE 端点在开始流式后已提交 200，末端 catch-all 的 HTTPException 无法把 detail 写回
+        # 已提交的响应体（body 恒为空）——故响应体断言对该端点天然 vacuous，无法区分修复与回归。
+        # 真正可锁定的契约是 catch-all 走 i18n 而非 str(exc)，这依赖 `_t: Translator` 被注入签名；
+        # 用 inspect 正向核验注入，再以 raise_server_exceptions=False 跑一遍确认哨兵串不泄露。
+        params = inspect.signature(assistant.stream_events).parameters
+        assert params["_t"].annotation is Translator
+
         session_meta = make_session_meta(id="session-1", project_name=PROJECT)
 
         async def _boom(*args, **kwargs):
@@ -232,8 +244,7 @@ class TestAssistantRoutes:
             with _build_client() as client:
                 response = client.get(f"{PREFIX}/skills")
 
-        assert response.status_code == 500
-        assert "LEAK_skills" not in response.text
+        _assert_generic_500(response, "LEAK_skills")
 
     def test_send_endpoint_translates_agent_startup_error_to_502(self):
         """``AgentStartupError`` 必须翻译成 502 + i18n 包装的 detail，


### PR DESCRIPTION
## 背景

#849 已堵住 `files / generate / grids / projects / versions` 五个 router 的兜底 `except Exception` 信息泄露，但同形态漏洞在另外两处仍未覆盖。本 PR 一并补齐。

## 改动

把这 12 处 generic `except Exception` 的 `detail=str(exc)` 改为 `detail=_t("internal_server_error")`，内部异常细节只进 `logger.exception(...)`、不进响应体：

- `server/routers/_asset_router_factory.py`（3 处：add/update/delete）——经 `build_asset_router()` 驱动 character / scene / prop / product 四类资产路由，故 4 类资产的 add/update/delete 端点全部受益
- `server/routers/assistant.py`（9 处）——`list_sessions` 与 `stream_events` 此前未注入 `_t`，按需补 `_t: Translator` 依赖

`internal_server_error` key 由 #849 引入，zh/en/vi 三语已齐备，未新增 key。

## 范围（保持不变）

- 4xx/502/504 域校验分支语义不动：`except ValueError → 400 detail=str(exc)`、`agent_startup_failed` 的 502 i18n 包装、`session_not_found` 404、`sdk_session_timeout` 504 等均保留
- `agent_startup_failed(details=str(exc))` 是有意把 SDK 安装指引嵌入 i18n 模板，属域错误，不在本次范围

## 测试

- `tests/test_asset_router_factory.py`：新增 add/update/delete 三个 no-leak 测试（哨兵 RuntimeError → 断言 500 且哨兵串不泄露）
- `tests/test_assistant_routes.py`：覆盖 9 个端点的 no-leak，并保留 502 域错误回归测试
- 经独立审查（xhigh 多智能体）加固两处测试质量缺口：非 stream no-leak 测试正向锁定响应体 detail 等于翻译后的 `internal_server_error`（detail 被清空/写错 key 不再静默通过）；stream 端点因 SSE 响应体已提交恒空、响应体断言天然 vacuous，改用 `inspect` 正向核验 `_t` 注入签名
- 质量门全绿：`ruff check`/`format`、`basedpyright`（0 error）、`pytest`（含 i18n 一致性）

Closes #878

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 统一资产与会话/技能相关接口的兜底错误响应：意外异常时仅返回通用的本地化 500 提示，不再回传内部异常细节。
  * 流式与列表类接口的错误处理保持一致，错误信息更安全。

* **Tests**
  * 新增并扩展异常场景用例，断言返回 `detail` 为通用 i18n 文案，且响应文本不包含内部哨兵信息，覆盖多条资产路由与会话路由端点。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->