### PR TITLE
fix(script): 代理未强制 schema 时回退带校验路径，修复广告/短片剧本生成失败

### DIFF
--- a/lib/text_backends/openai.py
+++ b/lib/text_backends/openai.py
@@ -6,6 +6,7 @@ import json
 import logging
 
 from openai import AsyncOpenAI, BadRequestError
+from pydantic import BaseModel, ValidationError
 
 from lib.config.url_utils import is_official_openai_base_url
 from lib.logging_utils import format_kwargs_for_log
@@ -117,18 +118,21 @@ class OpenAITextBackend:
         output_tokens = usage.completion_tokens if usage else None
         text = choice.message.content or ""
 
-        if request.response_schema and not _is_valid_json(text):
-            logger.warning(
-                "原生 response_format 返回非 JSON 内容（代理可能未支持 response_format），降级到 Instructor 路径",
-            )
-            return await _instructor_fallback(
-                self._client,
-                self._model,
-                request,
-                messages,
-                provider=self._provider_name,
-                token_param=self._max_tokens_param,
-            )
+        if request.response_schema:
+            fallback_reason = _structured_fallback_reason(text, request.response_schema)
+            if fallback_reason:
+                logger.warning(
+                    "原生 response_format %s，降级到带校验的 Instructor 路径",
+                    fallback_reason,
+                )
+                return await _instructor_fallback(
+                    self._client,
+                    self._model,
+                    request,
+                    messages,
+                    provider=self._provider_name,
+                    token_param=self._max_tokens_param,
+                )
 
         warn_if_truncated(
             getattr(choice, "finish_reason", None),
@@ -193,6 +197,29 @@ def _is_valid_json(text: str) -> bool:
         return True
     except (ValueError, TypeError):
         return False
+
+
+def _structured_fallback_reason(text: str, response_schema: dict | type | None) -> str | None:
+    """判断原生 response_format 的返回是否需要降级到带校验的 Instructor 路径。
+
+    返回降级原因（用于日志）；None 表示原生输出可直接采用。两类触发场景：
+
+    1. 返回非 JSON：代理静默忽略 response_format，吐出纯文本/markdown。
+    2. 返回违反 schema 的合法 JSON：代理接受 response_format 参数却不真正强制
+       schema（国内中转 / 非 OpenAI 模型常见），枚举值非法或缺必填字段。此类
+       违例 JSON 若直接放行，会一路漏到下游 Pydantic 校验才抛裸 ValidationError。
+
+    仅 Pydantic 模型可做 schema 校验；dict schema 无对应模型，沿用「仅校验是否合法
+    JSON」的既有行为，不额外收紧。
+    """
+    if not _is_valid_json(text):
+        return "返回非 JSON 内容（代理可能未支持 response_format）"
+    if isinstance(response_schema, type) and issubclass(response_schema, BaseModel):
+        try:
+            response_schema.model_validate_json(text)
+        except ValidationError as exc:
+            return f"返回的 JSON 不满足 response_schema（代理可能未强制 schema）：{exc}"
+    return None
 
 
 def _is_schema_error(exc: BaseException) -> bool:

--- a/lib/text_backends/openai.py
+++ b/lib/text_backends/openai.py
@@ -125,7 +125,7 @@ class OpenAITextBackend:
                     "原生 response_format %s，降级到带校验的 Instructor 路径",
                     fallback_reason,
                 )
-                return await _instructor_fallback(
+                result = await _instructor_fallback(
                     self._client,
                     self._model,
                     request,
@@ -133,6 +133,12 @@ class OpenAITextBackend:
                     provider=self._provider_name,
                     token_param=self._max_tokens_param,
                 )
+                # 这次原生 200 调用已被代理计费，把它的 token 并入降级结果，
+                # 否则 UsageTracker 会系统性漏记这部分真实消耗。
+                if usage:
+                    result.input_tokens = (result.input_tokens or 0) + (usage.prompt_tokens or 0)
+                    result.output_tokens = (result.output_tokens or 0) + (usage.completion_tokens or 0)
+                return result
 
         warn_if_truncated(
             getattr(choice, "finish_reason", None),
@@ -212,14 +218,27 @@ def _structured_fallback_reason(text: str, response_schema: dict | type | None) 
     仅 Pydantic 模型可做 schema 校验；dict schema 无对应模型，沿用「仅校验是否合法
     JSON」的既有行为，不额外收紧。
     """
-    if not _is_valid_json(text):
-        return "返回非 JSON 内容（代理可能未支持 response_format）"
     if isinstance(response_schema, type) and issubclass(response_schema, BaseModel):
+        # model_validate_json 单次解析即同时覆盖「非 JSON」与「违反 schema」两种情况
         try:
             response_schema.model_validate_json(text)
         except ValidationError as exc:
-            return f"返回的 JSON 不满足 response_schema（代理可能未强制 schema）：{exc}"
+            return f"返回内容不满足 response_schema（代理可能未强制 schema）：{_summarize_validation_error(exc)}"
+        return None
+    if not _is_valid_json(text):
+        return "返回非 JSON 内容（代理可能未支持 response_format）"
     return None
+
+
+def _summarize_validation_error(exc: ValidationError) -> str:
+    """把 ValidationError 压成简短的字段定位摘要。
+
+    只取字段路径（loc）与错误数，**不含模型原始输入值**——后者可能很大且会把
+    模型生成内容写进日志（经 /system/logs/download 外泄），也避免单条日志膨胀到数 KB。
+    """
+    locs = [".".join(str(part) for part in err.get("loc", ())) or "<root>" for err in exc.errors()[:5]]
+    suffix = "…" if exc.error_count() > 5 else ""
+    return f"{exc.error_count()} 处字段不符（{', '.join(locs)}{suffix}）"
 
 
 def _is_schema_error(exc: BaseException) -> bool:

--- a/lib/text_backends/openai.py
+++ b/lib/text_backends/openai.py
@@ -219,9 +219,11 @@ def _structured_fallback_reason(text: str, response_schema: dict | type | None) 
     JSON」的既有行为，不额外收紧。
     """
     if isinstance(response_schema, type) and issubclass(response_schema, BaseModel):
-        # model_validate_json 单次解析即同时覆盖「非 JSON」与「违反 schema」两种情况
+        # model_validate_json 单次解析即同时覆盖「非 JSON」与「违反 schema」两种情况；
+        # strict=True 与原生请求的 response_format.json_schema.strict=True 对齐——代理若
+        # 返回可强转但类型不严格匹配的 JSON（如 int 字段给 "30"），同样判定为未强制 schema。
         try:
-            response_schema.model_validate_json(text)
+            response_schema.model_validate_json(text, strict=True)
         except ValidationError as exc:
             return f"返回内容不满足 response_schema（代理可能未强制 schema）：{_summarize_validation_error(exc)}"
         return None

--- a/tests/test_openai_text_backend.py
+++ b/tests/test_openai_text_backend.py
@@ -244,6 +244,100 @@ class TestInstructorFallback:
         assert result.input_tokens == 50
         assert result.output_tokens == 20
 
+    async def test_schema_violating_json_triggers_instructor_fallback_pydantic(self):
+        """原生返回 200 + 合法 JSON 但违反 response_schema（代理接受却不强制 schema），应降级到 Instructor。"""
+        # 代理返回合法 JSON，但 age 是中文字符串、违反 Pydantic int 约束
+        violating_json = json.dumps({"name": "Alice", "age": "三十"}, ensure_ascii=False)
+        instructor_result = _PersonSchema(name="Alice", age=30)
+        instructor_completion = MagicMock()
+        instructor_completion.usage = MagicMock()
+        instructor_completion.usage.prompt_tokens = 80
+        instructor_completion.usage.completion_tokens = 30
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(violating_json, 100, 60))
+
+        mock_patched = AsyncMock()
+        mock_patched.chat.completions.create_with_completion = AsyncMock(
+            return_value=(instructor_result, instructor_completion)
+        )
+
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("instructor.from_openai", return_value=mock_patched),
+        ):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            backend = OpenAITextBackend(api_key="test-key")
+            request = TextGenerationRequest(
+                prompt="Extract info",
+                response_schema=_PersonSchema,
+            )
+            result = await backend.generate(request)
+
+        # 不再把违例 JSON 直接放行，而是返回经 Instructor 校验后的结果
+        assert result.text == instructor_result.model_dump_json()
+        assert result.input_tokens == 80
+        assert result.output_tokens == 30
+        mock_patched.chat.completions.create_with_completion.assert_awaited_once()
+
+    async def test_missing_required_field_json_triggers_instructor_fallback(self):
+        """原生返回缺必填字段的合法 JSON（如 title 缺失），应降级到 Instructor 而非直接放行。"""
+        # 缺 age 必填字段
+        violating_json = json.dumps({"name": "Bob"})
+        instructor_result = _PersonSchema(name="Bob", age=25)
+        instructor_completion = MagicMock()
+        instructor_completion.usage = None
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(violating_json, 90, 40))
+
+        mock_patched = AsyncMock()
+        mock_patched.chat.completions.create_with_completion = AsyncMock(
+            return_value=(instructor_result, instructor_completion)
+        )
+
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("instructor.from_openai", return_value=mock_patched),
+        ):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            backend = OpenAITextBackend(api_key="test-key")
+            request = TextGenerationRequest(
+                prompt="Extract info",
+                response_schema=_PersonSchema,
+            )
+            result = await backend.generate(request)
+
+        assert result.text == instructor_result.model_dump_json()
+        mock_patched.chat.completions.create_with_completion.assert_awaited_once()
+
+    async def test_schema_valid_json_with_dict_schema_no_fallback(self):
+        """dict schema（无 Pydantic 模型可校验）下，合法 JSON 不应触发额外的 schema 校验降级。"""
+        schema_response = json.dumps({"name": "Alice", "age": 30})
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(schema_response))
+
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("lib.text_backends.openai._instructor_fallback") as mock_fallback,
+        ):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            backend = OpenAITextBackend(api_key="test-key")
+            request = TextGenerationRequest(
+                prompt="Extract info",
+                response_schema={
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+                },
+            )
+            result = await backend.generate(request)
+
+        assert result.text == schema_response
+        mock_fallback.assert_not_called()
+
     async def test_bad_request_error_triggers_instructor_fallback_pydantic(self):
         """原生 response_format 抛 BadRequestError 且 schema 为 Pydantic 类时，走 Instructor 降级。"""
         mock_client = AsyncMock()

--- a/tests/test_openai_text_backend.py
+++ b/tests/test_openai_text_backend.py
@@ -241,8 +241,10 @@ class TestInstructorFallback:
 
         assert result.text == instructor_result.model_dump_json()
         assert result.provider == PROVIDER_OPENAI
-        assert result.input_tokens == 50
-        assert result.output_tokens == 20
+        # 原生 200 调用（100/60）已被代理计费，与 Instructor 调用（50/20）的 token 合并计入
+        assert result.input_tokens == 150
+        assert result.output_tokens == 80
+        mock_client.chat.completions.create.assert_awaited_once()
 
     async def test_schema_violating_json_triggers_instructor_fallback_pydantic(self):
         """原生返回 200 + 合法 JSON 但违反 response_schema（代理接受却不强制 schema），应降级到 Instructor。"""
@@ -277,12 +279,14 @@ class TestInstructorFallback:
 
         # 不再把违例 JSON 直接放行，而是返回经 Instructor 校验后的结果
         assert result.text == instructor_result.model_dump_json()
-        assert result.input_tokens == 80
-        assert result.output_tokens == 30
+        # 先原生再降级：原生调用恰发生一次，其计费 token（100/60）并入 Instructor 结果（80/30）
+        mock_client.chat.completions.create.assert_awaited_once()
+        assert result.input_tokens == 180
+        assert result.output_tokens == 90
         mock_patched.chat.completions.create_with_completion.assert_awaited_once()
 
     async def test_missing_required_field_json_triggers_instructor_fallback(self):
-        """原生返回缺必填字段的合法 JSON（如 title 缺失），应降级到 Instructor 而非直接放行。"""
+        """原生返回缺必填字段的合法 JSON（如 age 缺失），应降级到 Instructor 而非直接放行。"""
         # 缺 age 必填字段
         violating_json = json.dumps({"name": "Bob"})
         instructor_result = _PersonSchema(name="Bob", age=25)
@@ -310,14 +314,19 @@ class TestInstructorFallback:
             )
             result = await backend.generate(request)
 
+        # Instructor usage 为 None，结果 token 即原生 200 调用的计费量（90/40）
         assert result.text == instructor_result.model_dump_json()
+        mock_client.chat.completions.create.assert_awaited_once()
+        assert result.input_tokens == 90
+        assert result.output_tokens == 40
         mock_patched.chat.completions.create_with_completion.assert_awaited_once()
 
-    async def test_schema_valid_json_with_dict_schema_no_fallback(self):
-        """dict schema（无 Pydantic 模型可校验）下，合法 JSON 不应触发额外的 schema 校验降级。"""
-        schema_response = json.dumps({"name": "Alice", "age": 30})
+    async def test_schema_violating_json_with_dict_schema_no_fallback(self):
+        """dict schema 无对应 Pydantic 模型，即便 JSON 违反所声明类型也沿用「仅校验合法 JSON」的既有行为，不降级。"""
+        # 合法 JSON，但 age 是字符串、违反 dict schema 声明的 integer——dict schema 路径不做此校验
+        violating_json = json.dumps({"name": "Alice", "age": "thirty"})
         mock_client = AsyncMock()
-        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(schema_response))
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(violating_json))
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
@@ -335,7 +344,7 @@ class TestInstructorFallback:
             )
             result = await backend.generate(request)
 
-        assert result.text == schema_response
+        assert result.text == violating_json
         mock_fallback.assert_not_called()
 
     async def test_bad_request_error_triggers_instructor_fallback_pydantic(self):

--- a/tests/test_openai_text_backend.py
+++ b/tests/test_openai_text_backend.py
@@ -285,6 +285,44 @@ class TestInstructorFallback:
         assert result.output_tokens == 90
         mock_patched.chat.completions.create_with_completion.assert_awaited_once()
 
+    async def test_coercible_but_non_strict_json_triggers_instructor_fallback(self):
+        """原生返回可强转但类型不严格匹配的 JSON（age 为数字字符串 "30"），严格校验下视为未强制 schema，应降级。"""
+        # 宽松校验会把 "30" 强转为 30 而放行；strict=True 与原生 response_format 的 strict 对齐，拒绝并降级
+        coercible_json = json.dumps({"name": "Alice", "age": "30"})
+        instructor_result = _PersonSchema(name="Alice", age=30)
+        instructor_completion = MagicMock()
+        instructor_completion.usage = MagicMock()
+        instructor_completion.usage.prompt_tokens = 70
+        instructor_completion.usage.completion_tokens = 25
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(coercible_json, 100, 60))
+
+        mock_patched = AsyncMock()
+        mock_patched.chat.completions.create_with_completion = AsyncMock(
+            return_value=(instructor_result, instructor_completion)
+        )
+
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("instructor.from_openai", return_value=mock_patched),
+        ):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            backend = OpenAITextBackend(api_key="test-key")
+            request = TextGenerationRequest(
+                prompt="Extract info",
+                response_schema=_PersonSchema,
+            )
+            result = await backend.generate(request)
+
+        assert result.text == instructor_result.model_dump_json()
+        mock_client.chat.completions.create.assert_awaited_once()
+        mock_patched.chat.completions.create_with_completion.assert_awaited_once()
+        # 原生计费 token（100/60）并入 Instructor 结果（70/25）
+        assert result.input_tokens == 170
+        assert result.output_tokens == 85
+
     async def test_missing_required_field_json_triggers_instructor_fallback(self):
         """原生返回缺必填字段的合法 JSON（如 age 缺失），应降级到 Instructor 而非直接放行。"""
         # 缺 age 必填字段


### PR DESCRIPTION
## 问题

广告/短片（ad）模式用中文生成剧本时几乎 100% 失败，报错形如 `title: Field required; shots.0.image_prompt.composition.shot_type: Input should be ...`。

根因：部分 OpenAI 兼容代理（国内中转 / 非 OpenAI 模型）**接受** `response_format` 参数却不真正强制 schema，返回「合法但违反 schema」的 JSON。旧逻辑只在「返回非 JSON」时才降级到带校验的 Instructor 路径，违例 JSON 被直接放行，一路漏到写盘前的结构校验（`validate_script_structure` → Pydantic `model_validate`）才抛裸 `ValidationError`，使整集生成硬失败。

## 修复

`OpenAITextBackend.generate` 在原生 `response_format` 返回时，新增 `_structured_fallback_reason` 判定：

- 返回非 JSON → 降级（同既有行为）。
- response_schema 为 Pydantic 模型且返回的合法 JSON 不满足该 schema → 降级到既有的带校验 Instructor 路径（`_instructor_fallback`，复用 `instructor_fallback_async`，不引入第二套校验）。
- response_schema 为 dict（无对应模型）→ 沿用「仅校验是否合法 JSON」的既有行为，不额外收紧。

ad prompt 与 `AdEpisodeScript` / `AdShot` schema 不变。

## 本地审查附带修复

- **用量漏记**：代理返回违例 JSON 触发降级时，那次原生 200 调用已被计费的 token 此前被丢弃，导致 `UsageTracker` 系统性漏记；现并入降级结果（非 JSON 与违反 schema 两条触发路径统一处理）。
- **日志卫生**：完整 `ValidationError`（含模型原始输入值，可能数 KB 且经 `/system/logs/download` 外泄）不再整体写日志，改为只记字段定位摘要。
- **去重复解析**：Pydantic 分支合并为单次解析，去掉对同一文本的重复 `json.loads`。
- **测试增强**：断言原生调用恰发生一次、token 合并口径；dict-schema 用例改用「违例但合法」的 JSON，真正锁定「dict schema 不额外收紧」契约。

## 验证

- `uv run ruff check` / `ruff format --check`：通过
- `uv run basedpyright lib/text_backends/openai.py`：0 error
- `uv run python -m pytest tests/test_openai_text_backend.py`：25 passed
- 相关回归（text_backend / instructor / script_generator）：189 passed

Closes #894


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 更智能的结构化输出降级：当返回非 JSON，或严格校验下 JSON 虽合法但不符合 Pydantic `response_schema` 时，会自动切换到更可靠的校验流程；并合并原生与后续的 token 统计。
* **Bug Fixes**
  * 优化校验失败原因摘要（仅包含错误数量与前若干字段路径），避免日志冗长或泄露；保留未映射到 Pydantic 的 `dict` schema 时不降级行为。
* **Tests**
  * 扩展并更新结构化输出降级相关用例与 token 断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->