### PR TITLE
fix(assistant): 助手会话冷恢复时跟随用户实际语言，不再回落中文

### DIFF
--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -33,6 +33,7 @@ from fastapi.sse import ServerSentEvent
 
 from lib.agent_profile import agent_profile_dir
 from lib.app_data_dir import app_data_dir
+from lib.i18n import DEFAULT_LOCALE, get_locale
 from lib.profile_manifest import VALID_CONTENT_MODES
 from lib.project_manager import ProjectManager
 from server.agent_runtime.message_utils import extract_plain_user_content
@@ -242,7 +243,7 @@ class AssistantService:
         *,
         session_id: str | None = None,
         images: list["ImageAttachment"] | None = None,
-        locale: str = "zh",
+        locale: str = DEFAULT_LOCALE,
     ) -> dict[str, Any]:
         """Unified send: create new session or send to existing one."""
         self.pm.get_project_path(project_name)  # Validate project
@@ -367,8 +368,11 @@ class AssistantService:
                 yield event
             return
 
+        # 冷恢复经由 stream 路径复活会话时，按当前请求 locale 重建语言规范段，
+        # 与 send_message 路径一致；无 request（如非 SSE 消费者）回落默认 locale。
+        locale = get_locale(request) if request is not None else DEFAULT_LOCALE
         async with self.session_manager.stream_messages(
-            session_id, replay=True, idle_timeout=self.stream_heartbeat_seconds
+            session_id, replay=True, idle_timeout=self.stream_heartbeat_seconds, locale=locale
         ) as stream:
             replayed: list[dict[str, Any]] = []
             projector: AssistantStreamProjector | None = None

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -259,10 +259,10 @@ class AssistantService:
             text, sdk_prompt, echo_blocks = self._prepare_prompt(content, images)
             if sdk_prompt is not None:
                 await self.session_manager.send_message(
-                    session_id, sdk_prompt, echo_text=text, echo_content=echo_blocks, meta=meta
+                    session_id, sdk_prompt, echo_text=text, echo_content=echo_blocks, meta=meta, locale=locale
                 )
             else:
-                await self.session_manager.send_message(session_id, text, meta=meta)
+                await self.session_manager.send_message(session_id, text, meta=meta, locale=locale)
             return {"status": "accepted", "session_id": session_id}
         else:
             # New session

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -27,7 +27,7 @@ from lib.agent_session_store import session_store_flush_mode
 from lib.agent_session_store.store import DbSessionStore
 from lib.db.base import DEFAULT_USER_ID
 from lib.db.engine import async_session_factory as default_async_session_factory
-from lib.i18n import LOCALE_LANGUAGE_MAP
+from lib.i18n import DEFAULT_LOCALE, LOCALE_LANGUAGE_MAP
 from lib.logging_config import resolve_log_dir
 from server.agent_runtime.message_utils import extract_plain_user_content
 from server.agent_runtime.models import SessionMeta, SessionStatus
@@ -541,7 +541,7 @@ class SessionManager:
 - Write/Edit 不要写入代码文件（扩展名 .py/.js/.ts/.tsx/.sh/.yaml/.yml/.toml）；数据文件（.json/.md/.txt/.html/.csv 等）可以正常写入。代码逻辑应通过现有 skill 脚本完成
 - 你是用户的视频制作搭档，专业、友善、高效"""
 
-    def _build_append_prompt(self, project_name: str, locale: str = "zh") -> str:
+    def _build_append_prompt(self, project_name: str, locale: str = DEFAULT_LOCALE) -> str:
         """Build the append portion for SystemPromptPreset.
 
         Combines the ArcReel persona, the locale language regulation, and the
@@ -642,7 +642,7 @@ class SessionManager:
         project_name: str,
         resume_id: str | None = None,
         can_use_tool: Callable[[str, dict[str, Any], Any], Any] | None = None,
-        locale: str = "zh",
+        locale: str = DEFAULT_LOCALE,
         stderr: Callable[[str], None] | None = None,
     ) -> Any:
         """Build ClaudeAgentOptions for a session.
@@ -1238,7 +1238,7 @@ class SessionManager:
         *,
         echo_text: str | None = None,
         echo_content: list[dict[str, Any]] | None = None,
-        locale: str = "zh",
+        locale: str = DEFAULT_LOCALE,
     ) -> str:
         """Create a new session via send-first: start actor, send query, wait for sdk_session_id."""
         if not SDK_AVAILABLE or ClaudeSDKClient is None:
@@ -1441,7 +1441,7 @@ class SessionManager:
             raise
 
     async def get_or_connect(
-        self, session_id: str, *, meta: Optional["SessionMeta"] = None, locale: str = "zh"
+        self, session_id: str, *, meta: Optional["SessionMeta"] = None, locale: str = DEFAULT_LOCALE
     ) -> ManagedSession:
         """Get existing managed session or spin up an actor for resumed session.
 
@@ -1538,7 +1538,7 @@ class SessionManager:
         echo_text: str | None = None,
         echo_content: list[dict[str, Any]] | None = None,
         meta: Optional["SessionMeta"] = None,
-        locale: str = "zh",
+        locale: str = DEFAULT_LOCALE,
     ) -> None:
         """Send a message via the session actor.
 
@@ -2840,7 +2840,9 @@ class SessionManager:
         if not managed.resolve_pending_question(question_id, answers):
             raise ValueError("未找到待回答的问题")
 
-    async def _subscribe(self, session_id: str, *, replay: bool = True) -> tuple[asyncio.Queue, list[dict[str, Any]]]:
+    async def _subscribe(
+        self, session_id: str, *, replay: bool = True, locale: str = DEFAULT_LOCALE
+    ) -> tuple[asyncio.Queue, list[dict[str, Any]]]:
         """Register a live-message queue and capture the replay snapshot atomically.
 
         Returns the (live-only) queue plus a snapshot of the buffered messages.
@@ -2848,10 +2850,14 @@ class SessionManager:
         between, so no synchronous live broadcast can interleave between the two
         and be lost — the replay/live split has no race.
 
+        ``locale`` is forwarded to ``get_or_connect`` so reviving a cold session
+        through the stream path rebuilds its language regulation from the current
+        request's locale, matching the send-message path.
+
         Private: the only consumer is :meth:`stream_messages`, which owns the
         deterministic unsubscribe via its context-manager ``__aexit__``.
         """
-        managed = await self.get_or_connect(session_id)
+        managed = await self.get_or_connect(session_id, locale=locale)
         # Synchronous critical section — no ``await`` until registration completes.
         replay_snapshot = list(managed.message_buffer) if replay else []
         queue: asyncio.Queue = asyncio.Queue(maxsize=100)
@@ -2865,7 +2871,7 @@ class SessionManager:
 
     @contextlib.asynccontextmanager
     async def stream_messages(
-        self, session_id: str, *, replay: bool = True, idle_timeout: float = 20.0
+        self, session_id: str, *, replay: bool = True, idle_timeout: float = 20.0, locale: str = DEFAULT_LOCALE
     ) -> AsyncIterator[AsyncIterator[dict[str, Any]]]:
         """Subscribe to a session's messages as a self-cleaning async iterator.
 
@@ -2882,8 +2888,11 @@ class SessionManager:
         Subscription, replay, queue draining and unsubscribe all live behind this
         seam; cleanup is carried deterministically by ``__aexit__`` (see ADR-0005).
         Consume as ``async with stream_messages(...) as stream: async for msg in stream``.
+
+        ``locale`` only matters when this subscription revives a cold session; an
+        already-resident session ignores it (session-fixed system prompt).
         """
-        queue, replay_msgs = await self._subscribe(session_id, replay=replay)
+        queue, replay_msgs = await self._subscribe(session_id, replay=replay, locale=locale)
 
         async def _iter() -> AsyncIterator[dict[str, Any]]:
             # NOTE: intentionally NO ``finally: _unsubscribe`` here. Cleanup is owned

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -1440,8 +1440,17 @@ class SessionManager:
                 logger.debug("_mark_session_terminal cleanup failed", exc_info=True)
             raise
 
-    async def get_or_connect(self, session_id: str, *, meta: Optional["SessionMeta"] = None) -> ManagedSession:
-        """Get existing managed session or spin up an actor for resumed session."""
+    async def get_or_connect(
+        self, session_id: str, *, meta: Optional["SessionMeta"] = None, locale: str = "zh"
+    ) -> ManagedSession:
+        """Get existing managed session or spin up an actor for resumed session.
+
+        ``locale`` only matters when this call revives a cold session: the SDK's
+        ``resume`` rebuilds the whole system prompt from current options, so the
+        language regulation segment must reflect the caller's request locale. An
+        already-resident session returns from cache and ``locale`` is ignored —
+        the session-fixed system prompt stays unchanged.
+        """
         if session_id in self.sessions and session_id not in self._disconnecting:
             return self.sessions[session_id]
 
@@ -1477,6 +1486,7 @@ class SessionManager:
                 meta.project_name,
                 meta.id,  # SessionMeta.id 就是 sdk_session_id
                 can_use_tool=await self._build_can_use_tool_callback(session_id, managed_ref),
+                locale=locale,
                 stderr=_collect_stderr,
             )
             assistant_model = self._resolve_configured_assistant_model(getattr(options, "env", None))
@@ -1528,9 +1538,15 @@ class SessionManager:
         echo_text: str | None = None,
         echo_content: list[dict[str, Any]] | None = None,
         meta: Optional["SessionMeta"] = None,
+        locale: str = "zh",
     ) -> None:
-        """Send a message via the session actor."""
-        managed = await self.get_or_connect(session_id, meta=meta)
+        """Send a message via the session actor.
+
+        ``locale`` is forwarded to ``get_or_connect`` so a cold-recovered
+        session rebuilds its language regulation from the current request's
+        locale rather than the default.
+        """
+        managed = await self.get_or_connect(session_id, meta=meta, locale=locale)
         managed.last_activity = time.monotonic()
         # 取消待执行的 cleanup（会话恢复活跃）
         if managed._cleanup_task and not managed._cleanup_task.done():

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -41,6 +41,7 @@ class _FakeSessionManager:
         self.sessions = {}
         self.new_sessions = []
         self.sent = []
+        self.sent_kwargs = []
         self.answered = []
         self.interrupted = []
         self.closed = []
@@ -65,6 +66,7 @@ class _FakeSessionManager:
 
     async def send_message(self, session_id, content, **kwargs):
         self.sent.append((session_id, content))
+        self.sent_kwargs.append(kwargs)
 
     async def answer_user_question(self, session_id, question_id, answers):
         self.answered.append((session_id, question_id, answers))
@@ -209,6 +211,23 @@ class TestAssistantServiceMore:
             await service.interrupt_session("missing")
         interrupted = await service.interrupt_session("s1")
         assert interrupted["session_status"] == "interrupted"
+
+    @pytest.mark.asyncio
+    async def test_send_or_create_threads_locale_into_continuation(self, tmp_path):
+        """Continuation (existing session) must forward the request locale so a
+        cold-recovered session rebuilds its language regulation correctly."""
+        service = AssistantService(project_root=tmp_path)
+        meta = make_session_meta(id="s1", status="idle")
+
+        sm = _FakeSessionManager()
+        service.pm = _FakePM(valid_project="demo")
+        service.session_manager = sm
+        service.meta_store = _FakeMetaStore([meta])
+
+        await service.send_or_create("demo", "world", session_id="s1", locale="en")
+
+        assert sm.sent == [("s1", "world")]
+        assert sm.sent_kwargs[0]["locale"] == "en"
 
     @pytest.mark.asyncio
     async def test_delete_session_closes_active_session_before_delete(self, tmp_path):

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -230,6 +230,24 @@ class TestAssistantServiceMore:
         assert sm.sent_kwargs[0]["locale"] == "en"
 
     @pytest.mark.asyncio
+    async def test_send_or_create_threads_locale_into_multimodal_continuation(self, tmp_path):
+        """The image-bearing continuation branch (sdk_prompt is not None) must also
+        forward the request locale, not just the text branch."""
+        service = AssistantService(project_root=tmp_path)
+        meta = make_session_meta(id="s1", status="idle")
+
+        sm = _FakeSessionManager()
+        service.pm = _FakePM(valid_project="demo")
+        service.session_manager = sm
+        service.meta_store = _FakeMetaStore([meta])
+
+        image = SimpleNamespace(data="ZmFrZQ==", media_type="image/png")
+        await service.send_or_create("demo", "hello", session_id="s1", images=[image], locale="vi")
+
+        assert sm.sent_kwargs[0]["locale"] == "vi"
+        assert sm.sent_kwargs[0]["echo_content"] is not None
+
+    @pytest.mark.asyncio
     async def test_delete_session_closes_active_session_before_delete(self, tmp_path):
         service = AssistantService(project_root=tmp_path)
         meta = make_session_meta(id="s1")

--- a/tests/test_assistant_service_streaming.py
+++ b/tests/test_assistant_service_streaming.py
@@ -54,7 +54,9 @@ class _FakeSessionManager:
         return list(self.replay_messages)
 
     @contextlib.asynccontextmanager
-    async def stream_messages(self, session_id: str, *, replay: bool = True, idle_timeout: float = 20.0):
+    async def stream_messages(
+        self, session_id: str, *, replay: bool = True, idle_timeout: float = 20.0, locale: str = "zh"
+    ):
         """Mirror the real CM: replay snapshot → _replay_done → live queue → _idle."""
         self.call_log.append(("stream_messages", session_id, replay))
         queue: asyncio.Queue = asyncio.Queue()

--- a/tests/test_assistant_service_streaming.py
+++ b/tests/test_assistant_service_streaming.py
@@ -6,6 +6,7 @@ import contextlib
 import pytest
 from fastapi.sse import ServerSentEvent
 
+from lib.i18n import DEFAULT_LOCALE
 from server.agent_runtime.models import SessionMeta
 from server.agent_runtime.service import AssistantService
 from tests.factories import make_session_meta
@@ -55,7 +56,7 @@ class _FakeSessionManager:
 
     @contextlib.asynccontextmanager
     async def stream_messages(
-        self, session_id: str, *, replay: bool = True, idle_timeout: float = 20.0, locale: str = "zh"
+        self, session_id: str, *, replay: bool = True, idle_timeout: float = 20.0, locale: str = DEFAULT_LOCALE
     ):
         """Mirror the real CM: replay snapshot → _replay_done → live queue → _idle."""
         self.call_log.append(("stream_messages", session_id, replay))

--- a/tests/test_session_manager_more.py
+++ b/tests/test_session_manager_more.py
@@ -64,6 +64,33 @@ def _dummy_actor() -> SessionActor:
     return SessionActor(client_factory=_factory, on_message=lambda msg: None)
 
 
+@asynccontextmanager
+async def _cold_revival_clients(session_manager, monkeypatch):
+    """Patch the SDK symbols so a non-resident session revives against a fake
+    client, and yield the list capturing every constructed client. Each client's
+    ``options.kwargs["system_prompt"]["append"]`` carries the rebuilt prompt, so
+    tests can assert which locale the language regulation was rendered with."""
+
+    async def _fake_env(_self):
+        return {}
+
+    monkeypatch.setattr(sm_mod.SessionManager, "_build_provider_env_overrides", _fake_env)
+
+    created_clients: list[_FakeClaudeClient] = []
+
+    def _track_client(*, options):
+        c = _FakeClaudeClient(options=options)
+        created_clients.append(c)
+        return c
+
+    with monkeypatch.context() as m:
+        m.setattr(sm_mod, "SDK_AVAILABLE", True)
+        m.setattr(sm_mod, "ClaudeAgentOptions", _FakeOptions)
+        m.setattr(sm_mod, "ClaudeSDKClient", _track_client)
+        m.setattr(sm_mod, "HookMatcher", None)
+        yield created_clients
+
+
 class _FakeAllow:
     def __init__(self, updated_input):
         self.updated_input = updated_input
@@ -160,31 +187,34 @@ class TestSessionManagerMore:
         """Cold-recovery revival rebuilds the language regulation from the
         caller's locale instead of falling back to the default zh."""
 
-        async def _fake_env(_self):
-            return {}
-
-        monkeypatch.setattr(sm_mod.SessionManager, "_build_provider_env_overrides", _fake_env)
-
         (tmp_path / "projects" / "demo").mkdir(parents=True)
         meta = await meta_store.create("demo", "sdk-locale-vi")
 
-        created_clients: list[_FakeClaudeClient] = []
-
-        def _track_client(*, options):
-            c = _FakeClaudeClient(options=options)
-            created_clients.append(c)
-            return c
-
-        with monkeypatch.context() as m:
-            m.setattr(sm_mod, "SDK_AVAILABLE", True)
-            m.setattr(sm_mod, "ClaudeAgentOptions", _FakeOptions)
-            m.setattr(sm_mod, "ClaudeSDKClient", _track_client)
-            m.setattr(sm_mod, "HookMatcher", None)
+        async with _cold_revival_clients(session_manager, monkeypatch) as created_clients:
             await session_manager.get_or_connect(meta.id, locale="vi")
             await asyncio.sleep(0)
             assert created_clients
             append = created_clients[0].options.kwargs["system_prompt"]["append"]
             assert "Tiếng Việt" in append
+            assert "中文" not in append
+            await session_manager.close_session(meta.id)
+
+    @pytest.mark.asyncio
+    async def test_stream_messages_threads_locale_into_cold_revival(
+        self, session_manager, meta_store, tmp_path, monkeypatch
+    ):
+        """The SSE stream path is a second cold-revival entry: subscribing to a
+        non-resident session must rebuild the language regulation from the
+        caller's locale, matching the send-message path."""
+        (tmp_path / "projects" / "demo").mkdir(parents=True)
+        meta = await meta_store.create("demo", "sdk-locale-stream-en")
+
+        async with _cold_revival_clients(session_manager, monkeypatch) as created_clients:
+            async with session_manager.stream_messages(meta.id, replay=False, locale="en"):
+                await asyncio.sleep(0)
+            assert created_clients
+            append = created_clients[0].options.kwargs["system_prompt"]["append"]
+            assert "English" in append
             assert "中文" not in append
             await session_manager.close_session(meta.id)
 

--- a/tests/test_session_manager_more.py
+++ b/tests/test_session_manager_more.py
@@ -154,6 +154,41 @@ class TestSessionManagerMore:
         assert await session_manager._keep_stream_open_hook({}, None, None) == {"continue_": True}
 
     @pytest.mark.asyncio
+    async def test_get_or_connect_threads_locale_into_system_prompt(
+        self, session_manager, meta_store, tmp_path, monkeypatch
+    ):
+        """Cold-recovery revival rebuilds the language regulation from the
+        caller's locale instead of falling back to the default zh."""
+
+        async def _fake_env(_self):
+            return {}
+
+        monkeypatch.setattr(sm_mod.SessionManager, "_build_provider_env_overrides", _fake_env)
+
+        (tmp_path / "projects" / "demo").mkdir(parents=True)
+        meta = await meta_store.create("demo", "sdk-locale-vi")
+
+        created_clients: list[_FakeClaudeClient] = []
+
+        def _track_client(*, options):
+            c = _FakeClaudeClient(options=options)
+            created_clients.append(c)
+            return c
+
+        with monkeypatch.context() as m:
+            m.setattr(sm_mod, "SDK_AVAILABLE", True)
+            m.setattr(sm_mod, "ClaudeAgentOptions", _FakeOptions)
+            m.setattr(sm_mod, "ClaudeSDKClient", _track_client)
+            m.setattr(sm_mod, "HookMatcher", None)
+            await session_manager.get_or_connect(meta.id, locale="vi")
+            await asyncio.sleep(0)
+            assert created_clients
+            append = created_clients[0].options.kwargs["system_prompt"]["append"]
+            assert "Tiếng Việt" in append
+            assert "中文" not in append
+            await session_manager.close_session(meta.id)
+
+    @pytest.mark.asyncio
     async def test_resolve_project_scope_and_status_helpers(self, session_manager, tmp_path, meta_store):
         (tmp_path / "projects").mkdir(parents=True, exist_ok=True)
         with pytest.raises(ValueError):


### PR DESCRIPTION
Closes #891

## 问题

en/vi 用户的助手会话在**冷恢复**（会话被逐出内存或进程重启后续聊）时，助手回复与生成内容（对话/旁白/字幕/prompt）被强制切回中文，忽略用户实际 locale。内存内存活会话不受影响。

根因：Claude Agent SDK 的 `resume` 只恢复对话历史，system prompt 永远取自**当前** options；冷恢复重建整段 system prompt，而语言规范段由 locale 决定，续聊分支在调用链上把 locale 丢了，最终回落默认 `zh`。

## 改动

冷恢复有**两条独立入口**，二者都要透传当前请求 locale：

1. **send_message 路径**（commit 1）：`send_or_create` 续聊分支把 `get_locale(request)` 传入 `send_message → get_or_connect → _build_options → _build_append_prompt`。
2. **SSE 流路径**（commit 2，本地审查补全）：`stream_events → stream_messages → _subscribe → get_or_connect` 此前仍回落 `zh`——进程重启后以 `running` 状态持久化、非驻留的会话经 `GET /sessions/{id}/stream` 复活时同样被强制中文。沿该链补传 `get_locale(request)`。

同时把语言规范默认常量统一改用 `lib.i18n.DEFAULT_LOCALE`，避免字面量 `"zh"` 多处漂移。

行为对齐「跟随当前请求 locale」而非「冻结创建时 locale」，符合用户中途切 UI 语言的预期。**内存内存活会话不受影响**（`get_or_connect` 命中缓存即早返回、忽略 locale，符合「会话内 system prompt 不变」）。无 schema / 持久化改动。

## 验收对照

- [x] en/vi 用户冷恢复续聊时语言规范段为其实际 locale（send + stream 两条路径）
- [x] 内存内存活会话行为不变
- [x] 无 schema / 持久化改动
- [x] 覆盖冷恢复 locale 透传：send_message、SSE 流、图文续聊三个测试

## 验证

- `uv run ruff check` / `ruff format` 通过
- `uv run basedpyright` 改动文件 0 error
- `uv run python -m pytest` 全量 5159 passed

## 本地审查发现（已在 commit 2 修复）

工作流式 code-review（xhigh）确认：原修复只覆盖 send_message 路径，遗漏并行的 SSE 流冷恢复入口——同类 bug 经流路径仍可触发。已补全并加测试。其余为按设计取舍（locale 跟随当前请求而非持久化；warm 会话 system prompt 不变）与已采纳的测试去重/覆盖建议。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 会话发送与流式回复现在遵循当前语言设置，提升中英文内容一致性。
  * 冷恢复会话时，会根据请求语言重建语言提示段，保证回复语言匹配。
* **Bug 修复**
  * 修复续写场景下语言参数未正确透传的问题。
  * 修复多模态续写在流式/回放路径中可能回退到默认语言的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->