### PR TITLE
ci: release-please 的 Release PR 在 changes 阶段短路，跳过完整测试

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      code: ${{ steps.gate.outputs.code }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -27,6 +27,19 @@ jobs:
               - '!LICENSE'
               - '!.github/ISSUE_TEMPLATE/**'
               - '!.github/pull_request_template.md'
+      - id: gate
+        # Release PR(release-please-- 前缀)只 bump 版本与 CHANGELOG，重 job 必然与 base 一致，
+        # 强制 code=false 让 backend/postgres/frontend 直接 skip；其余分支沿用 paths-filter 结果。
+        # head_ref 经 env 传入，避免分支名作为表达式注入到 run 脚本。
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          FILTER_CODE: ${{ steps.filter.outputs.code }}
+        run: |
+          if [[ "$HEAD_REF" == release-please--* ]]; then
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=$FILTER_CODE" >> "$GITHUB_OUTPUT"
+          fi
 
   backend-tests:
     needs: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,11 @@ jobs:
               - '!.github/ISSUE_TEMPLATE/**'
               - '!.github/pull_request_template.md'
       - id: gate
-        # Release PR(release-please-- 前缀)只 bump 版本与 CHANGELOG，重 job 必然与 base 一致，
-        # 强制 code=false 让 backend/postgres/frontend 直接 skip；其余分支沿用 paths-filter 结果。
-        # head_ref 经 env 传入，避免分支名作为表达式注入到 run 脚本。
+        # Release PR(release-please-- 前缀)只改版本相关产物：pyproject / 前端 package.json 的 version、
+        # release-please manifest、CHANGELOG，并由 release-please workflow 推回 uv.lock 同步 commit，
+        # 不含源码逻辑改动。为加快版本 PR 合并，强制 code=false 让 backend/postgres/frontend 直接 skip。
+        # 取舍：lockfile / 版本字段层面的回归不在 PR 阶段拦截，合入 main 后由 push 触发的 CI 兜底。
+        # 其余分支沿用 paths-filter 结果。head_ref 经 env 传入，避免分支名作为表达式注入到 run 脚本。
         env:
           HEAD_REF: ${{ github.head_ref }}
           FILTER_CODE: ${{ steps.filter.outputs.code }}


### PR DESCRIPTION
## 问题

release-please 维护的 Release PR 每次更新（bump 版本、改 manifest 与 CHANGELOG）都会触发 Tests workflow，跑完整 backend / postgres / frontend。Release PR 不改源码逻辑，这几轮完整 CI 是纯噪音，也拖慢每次版本 PR 的合并。

## 改动

在 `changes` job 加一步 `gate`：当 `github.head_ref` 以 `release-please--` 开头时强制输出 `code=false`，其余分支沿用 paths-filter 结果。下游三个重 job 凭现有 `if: needs.changes.outputs.code == 'true'` 自动 skip。

- job 输出 `code` 改指向 `steps.gate.outputs.code`；
- `head_ref` 与 filter 结果均经 `env` 传入 run 脚本，避免分支名作为表达式注入；
- `[[ "$HEAD_REF" == release-please--* ]]` 锚定前缀匹配，分支名中段含该子串的普通 PR 不受影响；
- `ci-required`（`if: always()`）容忍 skip（skip 既非 failure 也非 cancelled），required check 不被阻塞。

## 验证

- `python -c yaml.safe_load` 解析通过，输出/env/run 结构符合预期；
- 手测 gate 逻辑覆盖：Release 分支→false、普通代码 PR→保留 true、docs-only→保留 false、中段含 `release-please--` 的分支→不误伤、push 到 main（head_ref 为空）→沿用 filter；
- 保留 `actions/checkout@v7`，未降级。

Closes #883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 优化了自动化测试的执行条件。
  * 在版本回归类 PR 中会自动跳过与源码相关的后端、数据库和前端测试，减少不必要的等待。
  * 其他常规变更仍会按原有规则正常执行测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->