### PR TITLE
fix(storyboard): 对话台词改用自适应多行输入，长台词不再被截断

### DIFF
--- a/frontend/src/components/canvas/timeline/DialogueListEditor.test.tsx
+++ b/frontend/src/components/canvas/timeline/DialogueListEditor.test.tsx
@@ -41,6 +41,23 @@ describe("DialogueListEditor", () => {
     ]);
   });
 
+  it("blocks Enter so a dialogue line stays single-line", () => {
+    render(<DialogueListEditor dialogue={dialogue} onChange={() => {}} />);
+    const prevented = !fireEvent.keyDown(screen.getByDisplayValue(dialogue[0].line), {
+      key: "Enter",
+    });
+    expect(prevented).toBe(true);
+  });
+
+  it("lets IME use Enter to commit a candidate", () => {
+    render(<DialogueListEditor dialogue={dialogue} onChange={() => {}} />);
+    const prevented = !fireEvent.keyDown(screen.getByDisplayValue(dialogue[0].line), {
+      key: "Enter",
+      isComposing: true,
+    });
+    expect(prevented).toBe(false);
+  });
+
   it("appends an empty pair on add", () => {
     const onChange = vi.fn();
     render(<DialogueListEditor dialogue={dialogue} onChange={onChange} />);

--- a/frontend/src/components/canvas/timeline/DialogueListEditor.test.tsx
+++ b/frontend/src/components/canvas/timeline/DialogueListEditor.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { DialogueListEditor } from "./DialogueListEditor";
+import type { Dialogue } from "@/types";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en" },
+  }),
+}));
+
+const dialogue: Dialogue[] = [
+  { speaker: "韩青", line: "好险的关隘！田单未能攻破，正面尚未被攻破？" },
+];
+
+describe("DialogueListEditor", () => {
+  it("renders the line as a textarea so long dialogue wraps instead of clipping", () => {
+    render(<DialogueListEditor dialogue={dialogue} onChange={() => {}} />);
+    const line = screen.getByDisplayValue(dialogue[0].line);
+    expect(line.tagName).toBe("TEXTAREA");
+  });
+
+  it("emits the updated line on change", () => {
+    const onChange = vi.fn();
+    render(<DialogueListEditor dialogue={dialogue} onChange={onChange} />);
+    fireEvent.change(screen.getByDisplayValue(dialogue[0].line), {
+      target: { value: "新台词" },
+    });
+    expect(onChange).toHaveBeenCalledWith([{ speaker: "韩青", line: "新台词" }]);
+  });
+
+  it("emits the updated speaker on change", () => {
+    const onChange = vi.fn();
+    render(<DialogueListEditor dialogue={dialogue} onChange={onChange} />);
+    fireEvent.change(screen.getByDisplayValue("韩青"), {
+      target: { value: "田单" },
+    });
+    expect(onChange).toHaveBeenCalledWith([
+      { speaker: "田单", line: dialogue[0].line },
+    ]);
+  });
+
+  it("appends an empty pair on add", () => {
+    const onChange = vi.fn();
+    render(<DialogueListEditor dialogue={dialogue} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "add_dialogue" }));
+    expect(onChange).toHaveBeenCalledWith([
+      ...dialogue,
+      { speaker: "", line: "" },
+    ]);
+  });
+
+  it("removes a pair on delete", () => {
+    const onChange = vi.fn();
+    render(<DialogueListEditor dialogue={dialogue} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "dialogue_remove" }));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/frontend/src/components/canvas/timeline/DialogueListEditor.tsx
+++ b/frontend/src/components/canvas/timeline/DialogueListEditor.tsx
@@ -1,10 +1,55 @@
 import { useTranslation } from "react-i18next";
 import { Plus, X } from "lucide-react";
 import type { Dialogue } from "@/types";
+import { useAutoResizeTextarea } from "@/hooks/useAutoResizeTextarea";
 
 interface DialogueListEditorProps {
   dialogue: Dialogue[];
   onChange: (dialogue: Dialogue[]) => void;
+}
+
+interface DialogueRowProps {
+  value: Dialogue;
+  onUpdate: (patch: Partial<Dialogue>) => void;
+  onRemove: () => void;
+}
+
+/** A single speaker/line pair. The line uses an auto-growing textarea so long
+ *  dialogue wraps and stays fully visible instead of being clipped. */
+function DialogueRow({ value, onUpdate, onRemove }: DialogueRowProps) {
+  const { t } = useTranslation("dashboard");
+  const { ref, resize } = useAutoResizeTextarea(value.line);
+
+  return (
+    <div className="flex items-start gap-1.5">
+      <input
+        type="text"
+        value={value.speaker}
+        onChange={(e) => onUpdate({ speaker: e.target.value })}
+        placeholder={t("speaker_placeholder")}
+        className="dlg-input dlg-input--speaker w-16 shrink-0"
+      />
+      <textarea
+        ref={ref}
+        value={value.line}
+        onChange={(e) => onUpdate({ line: e.target.value })}
+        onInput={resize}
+        placeholder={t("line_placeholder")}
+        rows={1}
+        className="dlg-input min-w-0 flex-1 resize-none overflow-hidden"
+      />
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={t("dialogue_remove")}
+        title={t("dialogue_remove")}
+        className="focus-ring grid h-7 w-7 shrink-0 place-items-center rounded-md transition-colors hover:bg-[oklch(1_0_0_/_0.05)]"
+        style={{ color: "var(--color-text-4)" }}
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
 }
 
 /** Editable list of speaker/line dialogue pairs. */
@@ -32,32 +77,12 @@ export function DialogueListEditor({
   return (
     <div className="flex flex-col gap-1.5">
       {dialogue.map((d, i) => (
-        <div key={i} className="flex items-start gap-1.5">
-          <input
-            type="text"
-            value={d.speaker}
-            onChange={(e) => update(i, { speaker: e.target.value })}
-            placeholder={t("speaker_placeholder")}
-            className="dlg-input dlg-input--speaker w-16 shrink-0"
-          />
-          <input
-            type="text"
-            value={d.line}
-            onChange={(e) => update(i, { line: e.target.value })}
-            placeholder={t("line_placeholder")}
-            className="dlg-input min-w-0 flex-1"
-          />
-          <button
-            type="button"
-            onClick={() => remove(i)}
-            aria-label={t("dialogue_remove")}
-            title={t("dialogue_remove")}
-            className="focus-ring grid h-7 w-7 shrink-0 place-items-center rounded-md transition-colors hover:bg-[oklch(1_0_0_/_0.05)]"
-            style={{ color: "var(--color-text-4)" }}
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        </div>
+        <DialogueRow
+          key={i}
+          value={d}
+          onUpdate={(patch) => update(i, patch)}
+          onRemove={() => remove(i)}
+        />
       ))}
 
       <button

--- a/frontend/src/components/canvas/timeline/DialogueListEditor.tsx
+++ b/frontend/src/components/canvas/timeline/DialogueListEditor.tsx
@@ -33,6 +33,14 @@ function DialogueRow({ value, onUpdate, onRemove }: DialogueRowProps) {
         ref={ref}
         value={value.line}
         onChange={(e) => onUpdate({ line: e.target.value })}
+        onKeyDown={(e) => {
+          // A dialogue line stays single-line; the textarea only wraps long
+          // text. Block Enter from inserting a newline, but let IME use it to
+          // commit a candidate (isComposing).
+          if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+            e.preventDefault();
+          }
+        }}
         onInput={resize}
         placeholder={t("line_placeholder")}
         rows={1}

--- a/frontend/src/components/ui/AutoTextarea.tsx
+++ b/frontend/src/components/ui/AutoTextarea.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback } from "react";
+import { useAutoResizeTextarea } from "@/hooks/useAutoResizeTextarea";
 
 interface AutoTextareaProps {
   value: string;
@@ -18,19 +18,7 @@ export function AutoTextarea({
   id,
   "aria-labelledby": ariaLabelledBy,
 }: AutoTextareaProps) {
-  const ref = useRef<HTMLTextAreaElement>(null);
-
-  const resize = useCallback(() => {
-    const el = ref.current;
-    if (el) {
-      el.style.height = "auto";
-      el.style.height = `${el.scrollHeight}px`;
-    }
-  }, []);
-
-  useEffect(() => {
-    resize();
-  }, [value, resize]);
+  const { ref, resize } = useAutoResizeTextarea(value);
 
   return (
     <textarea

--- a/frontend/src/hooks/useAutoResizeTextarea.ts
+++ b/frontend/src/hooks/useAutoResizeTextarea.ts
@@ -12,7 +12,14 @@ export function useAutoResizeTextarea(value: string) {
     const el = ref.current;
     if (el) {
       el.style.height = "auto";
-      el.style.height = `${el.scrollHeight}px`;
+      // scrollHeight excludes the border, so under box-sizing: border-box the
+      // element ends up 2px short and clips its last line. Add the border back.
+      const style = window.getComputedStyle(el);
+      const borderHeight =
+        style.boxSizing === "border-box"
+          ? parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth)
+          : 0;
+      el.style.height = `${el.scrollHeight + borderHeight}px`;
     }
   }, []);
 

--- a/frontend/src/hooks/useAutoResizeTextarea.ts
+++ b/frontend/src/hooks/useAutoResizeTextarea.ts
@@ -7,20 +7,24 @@ import { useCallback, useEffect, useRef } from "react";
  */
 export function useAutoResizeTextarea(value: string) {
   const ref = useRef<HTMLTextAreaElement>(null);
+  const borderHeightRef = useRef<number | null>(null);
 
   const resize = useCallback(() => {
     const el = ref.current;
-    if (el) {
-      el.style.height = "auto";
-      // scrollHeight excludes the border, so under box-sizing: border-box the
-      // element ends up 2px short and clips its last line. Add the border back.
+    if (!el) return;
+    // scrollHeight excludes the border, so under box-sizing: border-box the
+    // element ends up 2px short and clips its last line. The border width is
+    // static, so measure it once and reuse it instead of forcing a style
+    // recalc on every keystroke.
+    if (borderHeightRef.current === null) {
       const style = window.getComputedStyle(el);
-      const borderHeight =
+      borderHeightRef.current =
         style.boxSizing === "border-box"
           ? parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth)
           : 0;
-      el.style.height = `${el.scrollHeight + borderHeight}px`;
     }
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight + borderHeightRef.current}px`;
   }, []);
 
   useEffect(() => {

--- a/frontend/src/hooks/useAutoResizeTextarea.ts
+++ b/frontend/src/hooks/useAutoResizeTextarea.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Keeps a textarea sized to its content. Returns a ref to attach to the
+ * `<textarea>` and a `resize` callback to wire on `onInput` for immediate
+ * feedback while typing (before the controlled value round-trips).
+ */
+export function useAutoResizeTextarea(value: string) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  const resize = useCallback(() => {
+    const el = ref.current;
+    if (el) {
+      el.style.height = "auto";
+      el.style.height = `${el.scrollHeight}px`;
+    }
+  }, []);
+
+  useEffect(() => {
+    resize();
+  }, [value, resize]);
+
+  return { ref, resize };
+}


### PR DESCRIPTION
## 问题

分镜编辑器「剧本 / 对话 / 备注」面板里，对话台词字段用的是单行 `<input>`。HTML 原生 input 不换行，台词超出宽度后只是内部水平滚动，失焦时只能看到开头一段，长台词显示不全。

## 修复

- 台词字段从单行 `<input>` 换成自动换行、随内容自适应高度的多行 `<textarea>`，保持原有 `.dlg-input` 视觉风格；角色名字段、删除、添加对话交互不变。
- 把自适应撑高逻辑（`ref + scrollHeight`）抽成共享 hook `useAutoResizeTextarea`，并让既有的 `AutoTextarea` 复用，去掉重复实现。
- 因 hook 不能在 `map` 回调里调用，单行抽成 `DialogueRow` 子组件。
- 复用现有 i18n key，无新增面向用户文案。

排查范围内的其余截断点（版本提示词浮层预览、资产描述 hover 浮窗、参考单元列表预览、各卡片标题）均为只读预览/列表/悬浮里的有意缩略，完整内容在对应编辑面板可见，本次不改。

## 测试

- 新增 `DialogueListEditor.test.tsx`：台词渲染为 textarea 而非 input、台词/角色名编辑回传、增删条目。
- `pnpm check`（typecheck + lint + vitest）全绿，745 个测试通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 对话编辑区长文本输入框改为自适应高度显示，提升多行编辑体验；并复用统一的自动伸缩文本框能力。
* **Bug 修复**
  * 优化对话内容与说话人修改的联动行为：更新时仅替换对应字段，新增/删除后列表状态更一致；键盘交互按 IME 状态拦截/放行回车。
* **测试**
  * 新增对话列表编辑用例，覆盖输入变更、添加与删除交互。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->