### PR TITLE
feat(jianying): drama 成片导出对话/旁白字幕轨

### DIFF
--- a/lib/speech_rate.py
+++ b/lib/speech_rate.py
@@ -1,0 +1,52 @@
+"""语速估算单一真相源。
+
+把「一段口播文本朗读需多少秒」收敛到一处，供 drama 成片字幕定时与说话量对场景
+时长的上界校验共用，避免两处各自维护一套语速常量而漂移。
+
+语速以「阅读单位 / 秒」表示，阅读单位的语言裁剪口径复用 ``lib.text_metrics``
+（zh 计汉字 / CJK 标点，en / vi 计词）——因此单位换算天然随语言切换，不必为
+中英文各写一套字符规则。语速值可调、按 ``source_language`` 覆盖、缺省回退默认；
+新增语言只在 ``SPEECH_RATE_UPS_BY_LANGUAGE`` 登记，调用点不写死任何数值。
+"""
+
+from __future__ import annotations
+
+from lib.text_metrics import count_reading_units
+
+#: 默认语速（阅读单位 / 秒）。中文可懂配音常见约 4–6 字 / 秒，取 5 为中位。
+#: 未登记 / 缺失语言回退此值（与 ``count_reading_units`` 未知语言按 zh 计字的口径对齐）。
+DEFAULT_SPEECH_RATE_UPS: float = 5.0
+
+#: 按语言代码覆盖语速（阅读单位 / 秒），键用项目 ``source_language``（zh / en / vi）。
+#: en / vi 的阅读单位是「词」，正常口语约 2–3 词 / 秒，取 2.5；与 zh 的「字 / 秒」不可
+#: 直接通约，故必须分语言登记而非全局一个数值。值为可调估算，按实际配音节奏微调。
+SPEECH_RATE_UPS_BY_LANGUAGE: dict[str, float] = {
+    "zh": 5.0,
+    "en": 2.5,
+    "vi": 2.5,
+}
+
+
+def speech_rate_units_per_second(language: str | None = None) -> float:
+    """返回该语言的语速（阅读单位 / 秒）。
+
+    语言代码大小写不敏感；``None`` / 空 / 未登记语言回退 ``DEFAULT_SPEECH_RATE_UPS``。
+    """
+    if not language:
+        return DEFAULT_SPEECH_RATE_UPS
+    return SPEECH_RATE_UPS_BY_LANGUAGE.get(language.strip().lower(), DEFAULT_SPEECH_RATE_UPS)
+
+
+def estimate_spoken_seconds(text: str | None, language: str | None = None) -> float:
+    """估算 ``text`` 以 ``language`` 朗读所需秒数。
+
+    口径：阅读单位数 ÷ 语速（阅读单位计法见 ``lib.text_metrics.count_reading_units``）。
+    None / 空串 / 纯空白 / 纯标点（无阅读单位）一律计 0 秒——既是字幕单条定时的输入，
+    也是说话量求和的单项，两处共用同一换算、不在调用点重复。
+    """
+    if not text:
+        return 0.0
+    units = count_reading_units(text, language)
+    if units <= 0:
+        return 0.0
+    return units / speech_rate_units_per_second(language)

--- a/server/services/jianying_draft_service.py
+++ b/server/services/jianying_draft_service.py
@@ -36,19 +36,58 @@ _TRANSITION_MAP: dict[str, TransitionType] = {
     "dissolve": TransitionType.叠化,
 }
 
-# content_mode → 字幕文案源字段。narration 按朗读原文、ad 按每镜头口播文案；
-# 未注册的模式（drama / 未知脏值）不挂字幕轨。
+# content_mode → 整段单字幕文案源字段。narration 按朗读原文、ad 按每镜头口播文案，
+# 整段共用一条字幕。drama 不走单字段：口播是场景级有序 utterances，按 span 逐条派生
+# （见 _SPAN_SUBTITLE_MODES / _utterance_subtitle_spans），故不登记于此。
 _SUBTITLE_TEXT_FIELDS: dict[str, str] = {
     "narration": "novel_text",
     "ad": "voiceover_text",
 }
 
+# 字幕由有序 span 派生（而非单字段）的内容模式。drama 从 utterances 派生 subtitle_spans；
+# ad + reference_video 路径虽也产 span，但 content_mode 仍是 ad（已在 _SUBTITLE_TEXT_FIELDS），
+# 故此处只列 drama。未注册且不在此集合的模式（未知脏值）不挂字幕轨。
+_SPAN_SUBTITLE_MODES: frozenset[str] = frozenset({"drama"})
+
 from lib.path_safety import safe_resolve
 from lib.project_manager import ProjectManager, effective_mode
 from lib.reference_video.ad_units import ad_shots_by_id
 from lib.script_models import ad_shot_duration_seconds, script_shape
+from lib.speech_rate import estimate_spoken_seconds
 
 logger = logging.getLogger(__name__)
+
+
+def _has_subtitle_track(content_mode: str) -> bool:
+    """该内容模式是否注册为字幕模式（生成字幕轨）。
+
+    单字段模式（narration / ad）与 span 派生模式（drama）都为真；未注册的未知脏值为假。
+    """
+    return content_mode in _SUBTITLE_TEXT_FIELDS or content_mode in _SPAN_SUBTITLE_MODES
+
+
+def _utterance_subtitle_spans(utterances: object, language: str | None) -> list[dict[str, Any]]:
+    """从 drama 场景的有序 utterances 派生 subtitle_spans。
+
+    台词（dialogue）与画外音（voiceover）一并成字幕、按 utterances 真实先后排列；每条时长
+    按语速估算（``estimate_spoken_seconds``，单一真相源），顺次摆放、offset 累加。空 / 纯空白
+    text、非 dict 条目、估时长为 0 的条目跳过且不占 offset——既不产退化字幕，也不留空位。
+    不依场景时长拉伸：估算总时长可短于场景，余下自然留白、不撑满场景。
+    """
+    spans: list[dict[str, Any]] = []
+    offset = 0.0
+    for utterance in utterances if isinstance(utterances, list) else []:
+        if not isinstance(utterance, dict):
+            continue
+        text = utterance.get("text")
+        if not isinstance(text, str) or not text.strip():
+            continue
+        duration = estimate_spoken_seconds(text, language)
+        if duration <= 0:
+            continue
+        spans.append({"offset_seconds": offset, "duration_seconds": duration, "text": text})
+        offset += duration
+    return spans
 
 
 def _script_content_mode(script: dict) -> str:
@@ -90,12 +129,15 @@ class JianyingDraftService:
         project_dir: Path,
         *,
         generation_mode: str | None = None,
+        language: str | None = None,
     ) -> list[dict[str, Any]]:
         """从剧本中提取已完成视频的片段列表
 
         分镜列表与 id 字段按 ``script_shape`` 分派（narration→segments、drama→scenes、
         ad→shots，未知模式沿用 drama 形状兜底）；字幕文案按 ``_SUBTITLE_TEXT_FIELDS``
-        取各模式的文案源字段，归一到 ``subtitle_text``。
+        取各模式的文案源字段，归一到 ``subtitle_text``。drama 改走 span 派生：从场景级
+        有序 ``utterances`` 按语速估算出 ``subtitle_spans``（``language`` 决定语速，由调用方
+        按项目 ``source_language`` 传入），整段 ``subtitle_text`` 留空。
 
         ad + reference_video 路径成片是 unit 级视频（``reference_units`` 派生索引），
         按 unit 收集；``generation_mode`` 须由调用方按 project.json 解析传入——
@@ -107,6 +149,7 @@ class JianyingDraftService:
         shape = script_shape(content_mode)
         items = script.get(shape.items_key, [])
         subtitle_field = _SUBTITLE_TEXT_FIELDS.get(content_mode)
+        is_drama = content_mode == "drama"
 
         clips = []
         for item in items:
@@ -124,17 +167,19 @@ class JianyingDraftService:
             # 不让单镜头脏数据把整次导出带崩（TextSegment 对非 str 序列化即抛错）
             subtitle_value = item.get(subtitle_field) if subtitle_field else None
 
-            clips.append(
-                {
-                    "id": item.get(shape.id_field, ""),
-                    "duration_seconds": item.get("duration_seconds", 8),
-                    "video_clip": video_clip,
-                    "abs_path": abs_path,
-                    "subtitle_text": subtitle_value if isinstance(subtitle_value, str) else "",
-                    "transition_to_next": item.get("transition_to_next", "cut"),
-                    "narration_audio_abs": safe_resolve(project_dir, assets.get("narration_audio")),
-                }
-            )
+            clip: dict[str, Any] = {
+                "id": item.get(shape.id_field, ""),
+                "duration_seconds": item.get("duration_seconds", 8),
+                "video_clip": video_clip,
+                "abs_path": abs_path,
+                "subtitle_text": subtitle_value if isinstance(subtitle_value, str) else "",
+                "transition_to_next": item.get("transition_to_next", "cut"),
+                "narration_audio_abs": safe_resolve(project_dir, assets.get("narration_audio")),
+            }
+            # drama：从场景 utterances 派生有序字幕 span（台词 + 画外音按真实先后，按语速估时长）
+            if is_drama:
+                clip["subtitle_spans"] = _utterance_subtitle_spans(item.get("utterances"), language)
+            clips.append(clip)
 
         return clips
 
@@ -241,8 +286,8 @@ class JianyingDraftService:
         # 视频轨
         script_file.add_track(TrackType.video)
 
-        # 字幕轨：仅注册了字幕文案源字段的模式（narration/ad）生成；drama 无字幕轨
-        has_subtitle = content_mode in _SUBTITLE_TEXT_FIELDS
+        # 字幕轨：注册为字幕模式的内容模式生成（narration / ad 单字段、drama 从 utterances 派生 span）
+        has_subtitle = _has_subtitle_track(content_mode)
         text_style: TextStyle | None = None
         text_border: TextBorder | None = None
         text_shadow: TextShadow | None = None
@@ -422,10 +467,13 @@ class JianyingDraftService:
         # 2. 收集已完成视频（生成路径按 project.json 解析：ad 参考直出收集 unit 级片段）
         content_mode = _script_content_mode(script_data)
         ep_entry = next((e for e in project.get("episodes", []) if e.get("episode") == episode), None)
+        # drama 字幕语速按项目源语言取（source_language 是唯一真相源，缺失 / 脏值时回退默认语速）
+        source_language = project.get("source_language")
         clips = self._collect_video_clips(
             script_data,
             project_dir,
             generation_mode=effective_mode(project=project, episode=ep_entry or {}),
+            language=source_language if isinstance(source_language, str) else None,
         )
         if not clips:
             raise ValueError(f"第 {episode} 集没有已完成的视频片段，请先生成视频")

--- a/tests/test_jianying_draft_service.py
+++ b/tests/test_jianying_draft_service.py
@@ -78,6 +78,112 @@ class TestCollectVideoClips:
         assert clips[0]["id"] == "E1S01"
         assert clips[0]["subtitle_text"] == ""
 
+    def test_drama_mode_derives_subtitle_spans_from_utterances(self, tmp_path):
+        """drama：从 utterances 按真实先后派生 subtitle_spans，台词 / 画外音交错保持顺序，
+        时长按语速估算、顺次摆放（offset 累加）。"""
+        from lib.speech_rate import estimate_spoken_seconds
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        project_dir = tmp_path / "projects" / "demo"
+        videos_dir = project_dir / "videos"
+        videos_dir.mkdir(parents=True)
+        (videos_dir / "scene_E1S01.mp4").write_bytes(b"fake")
+
+        utterances = [
+            {"kind": "voiceover", "speaker": None, "text": "三年后"},
+            {"kind": "dialogue", "speaker": "小明", "text": "我回来了"},
+            {"kind": "voiceover", "speaker": None, "text": "他终于明白母亲的苦心"},
+        ]
+        script = {
+            "content_mode": "drama",
+            "scenes": [
+                {
+                    "scene_id": "E1S01",
+                    "duration_seconds": 8,
+                    "utterances": utterances,
+                    "generated_assets": {"video_clip": "videos/scene_E1S01.mp4", "status": "completed"},
+                },
+            ],
+        }
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        clips = svc._collect_video_clips(script, project_dir)
+
+        assert len(clips) == 1
+        spans = clips[0]["subtitle_spans"]
+        # 台词 + 画外音全部成字幕，按 utterances 真实先后排列
+        assert [s["text"] for s in spans] == ["三年后", "我回来了", "他终于明白母亲的苦心"]
+        # drama 走 span 派生，整段单字幕文案为空
+        assert clips[0]["subtitle_text"] == ""
+        # 时长按语速估算（口径取自单一真相源），顺次摆放
+        expected = [estimate_spoken_seconds(u["text"], None) for u in utterances]
+        assert [s["duration_seconds"] for s in spans] == pytest.approx(expected)
+        offset = 0.0
+        for span, dur in zip(spans, expected):
+            assert span["offset_seconds"] == pytest.approx(offset)
+            offset += dur
+
+    def test_drama_subtitle_spans_allow_gap_not_filling_scene(self, tmp_path):
+        """drama：短台词按语速估时长，不撑满长场景，余下留白。"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        project_dir = tmp_path / "projects" / "demo"
+        videos_dir = project_dir / "videos"
+        videos_dir.mkdir(parents=True)
+        (videos_dir / "scene_E1S01.mp4").write_bytes(b"fake")
+
+        script = {
+            "content_mode": "drama",
+            "scenes": [
+                {
+                    "scene_id": "E1S01",
+                    "duration_seconds": 30,
+                    "utterances": [{"kind": "dialogue", "speaker": "小明", "text": "你好"}],
+                    "generated_assets": {"video_clip": "videos/scene_E1S01.mp4", "status": "completed"},
+                },
+            ],
+        }
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        clips = svc._collect_video_clips(script, project_dir)
+
+        clip = clips[0]
+        assert clip["duration_seconds"] == 30
+        spans_total = sum(s["duration_seconds"] for s in clip["subtitle_spans"])
+        assert spans_total < clip["duration_seconds"]
+
+    def test_drama_subtitle_spans_skip_empty_and_malformed_utterances(self, tmp_path):
+        """drama：空 / 纯空白 text 与非 dict 条目不产 span、不阻断收集，offset 不留空位。"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        project_dir = tmp_path / "projects" / "demo"
+        videos_dir = project_dir / "videos"
+        videos_dir.mkdir(parents=True)
+        (videos_dir / "scene_E1S01.mp4").write_bytes(b"fake")
+
+        script = {
+            "content_mode": "drama",
+            "scenes": [
+                {
+                    "scene_id": "E1S01",
+                    "duration_seconds": 8,
+                    "utterances": [
+                        {"kind": "voiceover", "speaker": None, "text": "   "},
+                        "not-a-dict",
+                        {"kind": "dialogue", "speaker": "小明", "text": "开始"},
+                    ],
+                    "generated_assets": {"video_clip": "videos/scene_E1S01.mp4", "status": "completed"},
+                },
+            ],
+        }
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        clips = svc._collect_video_clips(script, project_dir)
+
+        spans = clips[0]["subtitle_spans"]
+        assert [s["text"] for s in spans] == ["开始"]
+        assert spans[0]["offset_seconds"] == 0
+
     def test_ad_mode_collects_shots_with_voiceover_subtitle(self, tmp_path):
         """ad 模式：收集 shots，字幕文案取每镜头 voiceover_text"""
         from server.services.jianying_draft_service import JianyingDraftService
@@ -365,24 +471,67 @@ class TestGenerateDraft:
         for text_seg in text_track["segments"]:
             assert text_seg["clip"]["transform"]["y"] == pytest.approx(-0.75)
 
-    def test_drama_mode_no_subtitle_track(self, tmp_path):
-        """drama 模式不生成字幕轨"""
+    def test_drama_mode_includes_subtitle_track(self, tmp_path):
+        """drama 注册为字幕模式：携带 subtitle_spans 时生成字幕轨并按 span 在片段内逐条渲染。"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        videos_dir = tmp_path / "videos"
+        videos_dir.mkdir()
+        make_test_video(videos_dir / "scene_S1.mp4", duration_sec=5.0)
+
+        draft_dir = tmp_path / "drafts" / "剧集字幕草稿"
+
+        clips = [
+            {
+                "id": "S1",
+                "local_path": str(videos_dir / "scene_S1.mp4"),
+                "subtitle_text": "",
+                "subtitle_spans": [
+                    {"offset_seconds": 0, "duration_seconds": 1.0, "text": "三年后"},
+                    {"offset_seconds": 1.0, "duration_seconds": 1.5, "text": "我回来了"},
+                ],
+            },
+        ]
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        svc._generate_draft(
+            draft_dir=draft_dir,
+            draft_name="剧集字幕草稿",
+            clips=clips,
+            width=1080,
+            height=1920,
+            content_mode="drama",
+        )
+
+        content = json.loads((draft_dir / "draft_content.json").read_text(encoding="utf-8"))
+        tracks = content.get("tracks", [])
+        # 视频轨 + 字幕轨
+        assert len(tracks) == 2
+        texts = content.get("materials", {}).get("texts", [])
+        assert len(texts) == 2
+        text_track = next(t for t in tracks if t.get("type") == "text")
+        starts = sorted(seg["target_timerange"]["start"] for seg in text_track["segments"])
+        assert starts[0] == 0
+        assert starts[1] == 1_000_000
+
+    def test_drama_mode_without_utterances_has_empty_subtitle_track(self, tmp_path):
+        """drama 无 utterances（spans 为空）：仍注册字幕轨，但不落字幕片段。"""
         from server.services.jianying_draft_service import JianyingDraftService
 
         videos_dir = tmp_path / "videos"
         videos_dir.mkdir()
         make_test_video(videos_dir / "scene_S1.mp4")
 
-        draft_dir = tmp_path / "drafts" / "无字幕草稿"
+        draft_dir = tmp_path / "drafts" / "空字幕草稿"
 
         clips = [
-            {"id": "S1", "local_path": str(videos_dir / "scene_S1.mp4"), "subtitle_text": ""},
+            {"id": "S1", "local_path": str(videos_dir / "scene_S1.mp4"), "subtitle_text": "", "subtitle_spans": []},
         ]
 
         svc = JianyingDraftService.__new__(JianyingDraftService)
         svc._generate_draft(
             draft_dir=draft_dir,
-            draft_name="无字幕草稿",
+            draft_name="空字幕草稿",
             clips=clips,
             width=1920,
             height=1080,
@@ -391,7 +540,9 @@ class TestGenerateDraft:
 
         content = json.loads((draft_dir / "draft_content.json").read_text(encoding="utf-8"))
         tracks = content.get("tracks", [])
-        assert len(tracks) == 1
+        # 视频轨 + 字幕轨；字幕轨存在但无字幕片段（与 narration / ad 空字幕一致）
+        assert len(tracks) == 2
+        assert content.get("materials", {}).get("texts", []) == []
 
 
 class TestNarrationAudioTrack:

--- a/tests/test_speech_rate.py
+++ b/tests/test_speech_rate.py
@@ -1,0 +1,60 @@
+"""lib.speech_rate 语速估算单一真相源测试。
+
+只测公开行为（按语言取速率、按口径估时长、缺省回退），数值断言取自单一真相源
+helper / 常量而非写死，避免与可调常量耦合。
+"""
+
+import pytest
+
+from lib.speech_rate import (
+    DEFAULT_SPEECH_RATE_UPS,
+    estimate_spoken_seconds,
+    speech_rate_units_per_second,
+)
+
+
+class TestSpeechRateUnitsPerSecond:
+    def test_none_and_empty_fall_back_to_default(self):
+        assert speech_rate_units_per_second(None) == DEFAULT_SPEECH_RATE_UPS
+        assert speech_rate_units_per_second("") == DEFAULT_SPEECH_RATE_UPS
+
+    def test_unregistered_language_falls_back_to_default(self):
+        assert speech_rate_units_per_second("klingon") == DEFAULT_SPEECH_RATE_UPS
+
+    def test_registered_languages_return_positive_rate(self):
+        assert speech_rate_units_per_second("zh") > 0
+        assert speech_rate_units_per_second("en") > 0
+        assert speech_rate_units_per_second("vi") > 0
+
+    def test_language_code_is_case_insensitive(self):
+        assert speech_rate_units_per_second("EN") == speech_rate_units_per_second("en")
+
+
+class TestEstimateSpokenSeconds:
+    def test_empty_or_whitespace_is_zero(self):
+        assert estimate_spoken_seconds("", "zh") == 0.0
+        assert estimate_spoken_seconds("   ", "zh") == 0.0
+
+    def test_none_text_is_zero(self):
+        assert estimate_spoken_seconds(None, "zh") == 0.0
+
+    def test_duration_is_reading_units_over_rate(self):
+        # 5 个汉字阅读单位 ÷ zh 语速；口径取自单一真相源 helper，不写死秒数。
+        expected = 5 / speech_rate_units_per_second("zh")
+        assert estimate_spoken_seconds("一二三四五", "zh") == pytest.approx(expected)
+
+    def test_longer_text_takes_longer(self):
+        short = estimate_spoken_seconds("一二", "zh")
+        longer = estimate_spoken_seconds("一二三四五六七八", "zh")
+        assert longer > short
+
+    def test_language_changes_timing(self):
+        # 同为 5 个阅读单位，zh（计字）与 en（计词）语速不同 → 时长不同，
+        # 证明语速随语言变化、非全局写死单值。
+        zh = estimate_spoken_seconds("一二三四五", "zh")
+        en = estimate_spoken_seconds("one two three four five", "en")
+        assert zh != en
+
+    def test_unknown_language_uses_default_rate(self):
+        expected = 5 / DEFAULT_SPEECH_RATE_UPS
+        assert estimate_spoken_seconds("一二三四五", None) == pytest.approx(expected)


### PR DESCRIPTION
## 背景

drama 成片此前不挂字幕轨——剧集动画导出剪映后没有对话/旁白字幕，需用户在剪映里手动逐条补。本切片把场景 `utterances` 落地为成片字幕。

## 改动

- **drama 注册为剪映字幕模式**：导出的成片携带对话/旁白字幕轨。
- **从 `utterances` 派生 `subtitle_spans`**：台词（dialogue）与画外音（voiceover）一并成字幕，按 utterances 真实先后排列；每条按语速估时长、顺次摆放、offset 累加，允许场景内留白、不撑满场景。复用既有 span 渲染与单字幕兜底。
- **语速估算单一真相源**（`lib/speech_rate.py`）：语速常量可调、按语言覆盖、缺省回退默认值，调用点不写死任何数值；阅读单位口径复用 `lib.text_metrics`，单位换算随语言切换。本切片由字幕定时消费；后续时长校验（#919）复用同一套。
- **脏数据稳健**：空/纯空白 text、非 dict 条目、估时长为 0 的条目跳过且不占 offset，不产退化字幕、不留空位、不阻断导出。

## 验证

- 新增测试覆盖：utterances 顺序（台词/画外音交错）、语速定时与 offset 累加、留白不撑满场景、空/畸形条目跳过；`lib.speech_rate` 公开行为（按语言取速率、按口径估时长、缺省回退、大小写不敏感）。
- 质量门全绿：`ruff check` / `ruff format --check` / `basedpyright`（0 error）/ `pytest`（changed 测试 55 passed）。纯后端改动，无前端。

## 已知限制

字幕语速按项目 `source_language`（源小说语言）选取。当源语言为 en/vi 但成片文案为中文（novel 改编、目标语言默认中文）时，中文文案会按拉丁词口径计数而低估时长。中文源→中文剧集的主路径正确；该跨语言场景待目标语言追踪能力完善后处理。

Closes #918


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 导出字幕时支持更准确的语速估算，并根据语言自动调整字幕时长。
  * 在剧情模式下，字幕可按场景中的发言片段拆分生成，更贴近实际说话节奏。

* **Bug 修复**
  * 修复了部分场景下字幕轨道不生成或时间对不齐的问题。
  * 处理空文本、空白文本和未知语言时，避免生成无效字幕片段。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->