### PR TITLE
feat(script): drama 说话量超场景时长上界时提示可能说不完

### DIFF
--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -24,6 +24,14 @@ from lib.script_models import (
     REFERENCE_SHOT_DURATION_RANGE,
     ad_script_total_duration,
 )
+from lib.speech_rate import estimate_spoken_seconds
+
+#: drama 场景说话量（台词 + 画外音）对场景时长的单向上界容差（比例）。语速估算
+#: （``lib.speech_rate`` 单一真相源）是近似值，给 20% 余量只在说话量明显超过画面时长时才
+#: warn（长对白塞进固定秒数会说不完 / 语速畸快）。单向上界：只警告「说不完」，不管「说话太少」
+#: ——duration 由画面驱动、留白合法，不被此约束反向改写。仅 DataValidator 消费，与 ad 总时长
+#: 漂移阈值同量级、同「只 warn 不阻塞」语义。
+DRAMA_SPEECH_OVERFLOW_TOLERANCE = 0.20
 
 
 @dataclass
@@ -582,8 +590,12 @@ class DataValidator:
         warnings: list[str],
         *,
         project_dir: Path | None = None,
+        language: str | None = None,
     ) -> None:
-        """验证 scenes（drama 模式）"""
+        """验证 scenes（drama 模式）。
+
+        ``language`` 为项目 ``source_language``（说话量上界 warning 的语速按此取，与字幕派生同口径）。
+        """
         if not scenes:
             errors.append("scenes 数组为空")
             return
@@ -638,6 +650,10 @@ class DataValidator:
             # kind ⇄ speaker 约束，与上方 characters_in_scene 等同口径（逐项 append、不 raise）。
             self._validate_utterances(scene.get("utterances"), prefix, errors)
 
+            # 说话量（台词 + 画外音）对场景时长的单向上界 warning：估算说话时长超 duration × 容差
+            # 时仅提示「说不完」，不阻塞、不改写 duration（duration 由画面驱动）。
+            self._warn_scene_speech_overflow(scene, prefix, language, warnings)
+
             if not scene.get("image_prompt"):
                 errors.append(f"{prefix}: 缺少必填字段 image_prompt")
             if not scene.get("video_prompt"):
@@ -689,6 +705,41 @@ class DataValidator:
                 errors.append(f"{uprefix} dialogue 必须带非空 speaker")
             elif kind == "voiceover" and has_speaker:
                 errors.append(f"{uprefix} voiceover 不得带 speaker")
+
+    @staticmethod
+    def _warn_scene_speech_overflow(
+        scene: dict[str, Any],
+        prefix: str,
+        language: str | None,
+        warnings: list[str],
+    ) -> None:
+        """场景说话量（台词 + 画外音）估算时长超 ``duration ×（1 + 容差）`` 时仅 warn（单向上界，不阻塞）。
+
+        说话时长按 ``estimate_spoken_seconds``（语速估算单一真相源）对 utterances 逐条求和，与 drama
+        字幕 span 派生同口径；空 / 纯空白 / 脏数据条目估 0 秒。duration 仍由画面驱动、不被此约束反向
+        改写。单向：只警告「说不完」（估算超上界），不管「说话太少」。duration 非正整数、无 utterances
+        时跳过——与 ad 总时长漂移那条同样「只 warn 不阻塞」、不推前端。
+        """
+        duration = scene.get("duration_seconds")
+        if not isinstance(duration, int) or isinstance(duration, bool) or duration <= 0:
+            return
+        utterances = scene.get("utterances")
+        if not isinstance(utterances, list):
+            return
+        spoken = 0.0
+        for item in utterances:
+            if not isinstance(item, dict):
+                continue
+            text = item.get("text")
+            if isinstance(text, str):
+                spoken += estimate_spoken_seconds(text, language)
+        budget = duration * (1 + DRAMA_SPEECH_OVERFLOW_TOLERANCE)
+        if spoken > budget:
+            warnings.append(
+                f"{prefix}: 估算说话时长 {spoken:.1f} 秒超过场景时长 {duration} 秒逾 "
+                f"{DRAMA_SPEECH_OVERFLOW_TOLERANCE:.0%}（容差上界 {budget:.1f} 秒），"
+                f"长对白可能说不完或语速畸快（仅提示，不阻塞保存）"
+            )
 
     def _validate_shots(
         self,
@@ -990,6 +1041,10 @@ class DataValidator:
         if novel is not None and not isinstance(novel, dict):
             errors.append("novel 字段必须是对象")
 
+        # drama 说话量上界 warning 的语速按项目 source_language 取（唯一真相源，缺失 / 脏值回退默认语速）。
+        source_language = project.get("source_language")
+        scene_language = source_language if isinstance(source_language, str) else None
+
         # "视频来源"维度由 generation_mode 表达；content_mode 决定剧本数据排布
         # （segments / scenes / shots）。ad 剧本骨架唯一、不随生成路径更换：
         # 即使 generation_mode=reference_video 也按 shots 校验（见 docs/adr/0033）。
@@ -1050,6 +1105,7 @@ class DataValidator:
                 errors,
                 warnings,
                 project_dir=project_dir,
+                language=scene_language,
             )
 
     def validate_episode(self, project_name: str, episode_file: str) -> ValidationResult:

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -3,7 +3,13 @@ from pathlib import Path
 
 import pytest
 
-from lib.data_validator import DataValidator, validate_episode, validate_project
+from lib.data_validator import (
+    DRAMA_SPEECH_OVERFLOW_TOLERANCE,
+    DataValidator,
+    validate_episode,
+    validate_project,
+)
+from lib.speech_rate import estimate_spoken_seconds
 
 
 def _write_json(path: Path, payload: dict):
@@ -376,6 +382,66 @@ class TestDataValidator:
         # 存量 drama（无 utterances、残留旧 voiceover）走读时迁移，校验层放行、不阻塞导出
         result = self._drama_episode_with_scene(tmp_path, {"voiceover": ["旧画外音"]})
         assert result.valid
+
+    def test_validate_episode_drama_warns_when_speech_overflows_scene(self, tmp_path):
+        # 单向上界：估算说话时长（台词）超场景 duration × 容差 → 仅 warn，不阻塞保存
+        long_line = "台词" * 60  # 120 个汉字阅读单位，远超 8 秒场景的容差上界
+        assert estimate_spoken_seconds(long_line, None) > 8 * (1 + DRAMA_SPEECH_OVERFLOW_TOLERANCE)
+        result = self._drama_episode_with_scene(
+            tmp_path,
+            {
+                "duration_seconds": 8,
+                "utterances": [{"kind": "dialogue", "speaker": "姜月茴", "text": long_line}],
+            },
+        )
+        assert result.valid, result.errors
+        assert any("说话时长" in w for w in result.warnings)
+
+    def test_validate_episode_drama_speech_overflow_counts_voiceover(self, tmp_path):
+        # 说话量含画外音：台词 + 画外音一并计入估算（与字幕派生同口径）
+        long_vo = "旁白" * 60
+        result = self._drama_episode_with_scene(
+            tmp_path,
+            {
+                "duration_seconds": 8,
+                "utterances": [{"kind": "voiceover", "speaker": None, "text": long_vo}],
+            },
+        )
+        assert result.valid, result.errors
+        assert any("说话时长" in w for w in result.warnings)
+
+    def test_validate_episode_drama_no_warning_when_speech_fits(self, tmp_path):
+        # 界内：说话量在场景 duration × 容差以内 → 不产说话量 warning
+        result = self._drama_episode_with_scene(
+            tmp_path,
+            {
+                "duration_seconds": 8,
+                "utterances": [
+                    {"kind": "dialogue", "speaker": "姜月茴", "text": "你来了。"},
+                    {"kind": "voiceover", "speaker": None, "text": "夜色渐深。"},
+                ],
+            },
+        )
+        assert result.valid, result.errors
+        assert not any("说话时长" in w for w in result.warnings)
+
+    def test_validate_episode_drama_no_warning_when_speech_far_under_duration(self, tmp_path):
+        # 单向上界：说话量远少于场景时长不警告（duration 由画面驱动、留白合法，不管「说话太少」）
+        result = self._drama_episode_with_scene(
+            tmp_path,
+            {
+                "duration_seconds": 30,
+                "utterances": [{"kind": "dialogue", "speaker": "姜月茴", "text": "嗯。"}],
+            },
+        )
+        assert result.valid, result.errors
+        assert not any("说话时长" in w for w in result.warnings)
+
+    def test_validate_episode_drama_no_speech_warning_without_utterances(self, tmp_path):
+        # 无 utterances（存量 / 未填）→ 不产说话量 warning，也不崩
+        result = self._drama_episode_with_scene(tmp_path, {"duration_seconds": 8})
+        assert result.valid, result.errors
+        assert not any("说话时长" in w for w in result.warnings)
 
     def test_validate_helpers_on_missing_files(self, tmp_path):
         result = validate_project("missing", projects_root=str(tmp_path / "projects"))


### PR DESCRIPTION
## 问题

drama 剧集场景时长由画面驱动（固定秒数），但场景里的台词 + 画外音若过长，配音会说不完或语速畸快，此前数据校验层对此无任何提示。

## 改动

`lib/data_validator.py` 新增场景说话量对时长的**单向上界** warning：

- 按 `lib.speech_rate.estimate_spoken_seconds`（语速估算单一真相源，与成片字幕同口径）对场景 utterances（台词 + 画外音）逐条估算说话时长求和；
- 超过 `duration_seconds ×（1 + 容差）`（`DRAMA_SPEECH_OVERFLOW_TOLERANCE = 0.20`，与 ad 总时长漂移阈值同量级）时产出 warning，提示「长对白可能说不完或语速畸快」；
- **仅 warn、不阻塞保存**：写入 `warnings` 而非 `errors`；场景时长仍由画面驱动、不被该约束反向改写；
- 单向上界：只警告「说不完」，不管「说话太少」（留白合法）；
- 语速按项目 `source_language` 取（唯一真相源，缺失/脏值回退默认语速），与剪映字幕派生同口径；
- 脏数据（无 utterances、非数组、条目非 dict、text 非 str、duration 非正整数/含 bool）一律跳过、不崩。

决策依据见 `docs/adr/0040-drama-utterances-ordered-spoken-content.md`。

## 验证

- 新增 5 个测试：超界出 warning（台词）、画外音计入、界内不出、远低于时长不出（单向）、无 utterances 不崩；均断言 `result.valid`（不阻塞），沿用 ad 总时长漂移 warning 的「只 warn 不阻塞」断言模式。
- `uv run ruff check` / `ruff format --check`：通过
- `uv run basedpyright`：0 error（6 条既有 warning 均在未改动方法，与本改动无关）
- `uv run python -m pytest tests/test_data_validator.py`：87 passed

Closes #919


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 在 drama 模式下新增场景说话时长预警：当对白与画外音的预估口播时长超过场景时长的容差范围时，会提示 warning，但不会阻止保存。
  * 支持按项目语言进行口播时长估算，提升校验结果的一致性。
  * 对于场景时长无效、台词列表缺失或格式不正确的情况，会自动跳过该项检查。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->