### PR TITLE
fix(settings): 修复火山方舟 Agent Plan 供应商图标显示

### DIFF
--- a/frontend/src/components/ui/ProviderIcon.test.tsx
+++ b/frontend/src/components/ui/ProviderIcon.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ProviderIcon } from "@/components/ui/ProviderIcon";
+
+describe("ProviderIcon", () => {
+  it("renders the Volcengine icon for the bare ark provider", () => {
+    render(<ProviderIcon providerId="ark" />);
+    expect(screen.getByTestId("lobehub-stub-icon")).toBeInTheDocument();
+  });
+
+  it("renders the Volcengine icon for ark-agent-plan, not the monogram fallback", () => {
+    render(<ProviderIcon providerId="ark-agent-plan" />);
+    expect(screen.getByTestId("lobehub-stub-icon")).toBeInTheDocument();
+  });
+
+  it("falls back to a monogram badge for an unknown provider", () => {
+    render(<ProviderIcon providerId="zeta" />);
+    expect(screen.queryByTestId("lobehub-stub-icon")).not.toBeInTheDocument();
+    expect(screen.getByText("z")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/ProviderIcon.tsx
+++ b/frontend/src/components/ui/ProviderIcon.tsx
@@ -18,14 +18,14 @@ export const PROVIDER_NAMES: Record<string, string> = {
 
 /**
  * 根据 providerId 渲染对应的供应商图标。
- * 支持 gemini-aistudio、gemini-vertex、grok、ark、dashscope、minimax、openai、vidu，其余显示首字母。
+ * 支持 gemini-aistudio、gemini-vertex、grok、ark（含 ark-agent-plan）、dashscope、minimax、openai、vidu，其余显示首字母。
  */
 export function ProviderIcon({ providerId, className }: { providerId: string; className?: string }) {
   const cls = className ?? "h-6 w-6";
   if (providerId === "gemini-vertex") return <VertexAIColor className={cls} />;
   if (providerId.startsWith("gemini")) return <GeminiColor className={cls} />;
   if (providerId.startsWith("grok")) return <GrokMono className={cls} />;
-  if (providerId === "ark") return <VolcengineColor className={cls} />;
+  if (providerId.startsWith("ark")) return <VolcengineColor className={cls} />;
   if (providerId === "dashscope") return <BailianColor className={cls} />;
   if (providerId === "minimax") return <MinimaxColor className={cls} />;
   if (providerId === "openai") return <OpenAIMono className={cls} />;


### PR DESCRIPTION
## 问题

供应商 `ark-agent-plan`（火山方舟 Agent Plan）在「设置 → 供应商」的列表与详情页未显示火山图标，而是退化为首字母「a」徽标。

## 原因

`ProviderIcon` 用精确匹配 `providerId === "ark"` 判定火山图标，`ark-agent-plan` 未命中，落到首字母兜底分支。

## 改动

- 将判定放宽为 `providerId.startsWith("ark")`，与同文件 `gemini` / `grok` 的前缀匹配写法一致，一并覆盖 `ark` 与 `ark-agent-plan`（及未来的 `ark-*` 变体）。
- 新增 `ProviderIcon` 回归测试：`ark` 与 `ark-agent-plan` 均渲染火山图标，未知供应商仍走首字母兜底。

## 测试

前端 `pnpm check`（typecheck + lint + vitest）全绿，750 passed。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了供应商图标的显示逻辑，`ark` 相关标识现在也适用于以 `ark` 开头的值，避免部分场景下图标显示不正确。
  * 对未知供应商保留首字母徽标显示，确保界面在未识别的情况下仍有明确可见的标识。

* **Tests**
  * 新增了相关单元测试，覆盖 `ark`、`ark-agent-plan` 和未知值等渲染场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->