### PR TITLE
ci: Release PR 不再触发 CodeQL 分析，并为 test/codeql 工作流补最小权限

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       code: ${{ steps.gate.outputs.code }}
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,11 +8,14 @@ on:
   schedule:
     - cron: "22 9 * * 3"
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      code: ${{ steps.gate.outputs.code }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -26,6 +29,20 @@ jobs:
               - '!LICENSE'
               - '!.github/ISSUE_TEMPLATE/**'
               - '!.github/pull_request_template.md'
+      - id: gate
+        # Release PR(release-please-- 前缀)只改版本相关产物：pyproject / 前端 package.json 的 version、
+        # release-please manifest、CHANGELOG，不含源码逻辑改动。为加快版本 PR 合并，强制 code=false
+        # 让 analyze 的两个语言 build 直接 skip。schedule 定时全量扫描与普通 PR/push 不受影响。
+        # 其余分支沿用 paths-filter 结果。head_ref 经 env 传入，避免分支名作为表达式注入到 run 脚本。
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          FILTER_CODE: ${{ steps.filter.outputs.code }}
+        run: |
+          if [[ "$HEAD_REF" == release-please--* ]]; then
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=$FILTER_CODE" >> "$GITHUB_OUTPUT"
+          fi
 
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ permissions:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       code: ${{ steps.gate.outputs.code }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 背景

CodeQL workflow 的 `changes` job 此前没有 Release PR 短路：Release PR 改动含版本/manifest 等 `.json` 文件，被 `dorny/paths-filter` 判为 `code=true`，导致 `analyze`（javascript-typescript 与 python 两个 build）在每个 Release PR 上仍全量运行，纯属噪音并拖慢版本 PR 合并。Tests workflow 早已用 gate 步骤短路这种情况，CodeQL 未跟进。同时两个 workflow 都缺少 workflow 级最小权限声明。

## 改动

- **CodeQL 复用 test.yml 的 gate 模式**：`changes` job 新增 `gate` 步骤，`head_ref` 以 `release-please--` 前缀开头时强制 `code=false`，其余分支沿用 paths-filter 结果；job 的 `code` output 改取自 gate 步骤。结果：Release PR 不再触发 CodeQL `analyze`（两个语言 build 一并 skip），与 Tests workflow 行为一致。
- `analyze` 的运行条件（含 `schedule` 分支）保持不变——定时全量扫描与普通 PR/push 照常分析。
- **补最小权限**：两个 workflow 各加 workflow 级 `permissions: contents: read`；CodeQL 的 `analyze` job 保留其现有 job 级提升权限（`security-events: write` / `packages: read` / `actions: read` / `contents: read`），`changes` 与汇总 job 继承只读默认。
- gate 沿用宽前缀 `release-please--*`、各自内联一份 shell（有意接受重复、不抽 composite）、经 env 传入 `HEAD_REF` 避免分支名注入——均与 Tests workflow 保持一致。

## 验证

- `actionlint .github/workflows/{codeql,test}.yml` 通过（含 run 脚本的 shellcheck），YAML 解析有效。
- 逐条核对验收标准：
  - Release PR（`release-please--*`）→ gate 置 `code=false`，`analyze` 两个 build 均 skip。
  - 普通 PR/push 走 paths-filter 结果；`schedule` 经 `|| github.event_name == 'schedule'` 照常全量分析。
  - `changes` 的 `code` output 取自 gate 步骤，`HEAD_REF` 经 env 传入。
  - 两 workflow 均有 workflow 级 `contents: read`；`analyze` 保留 job 级提升；`changes` 与汇总 job 继承只读。
  - 汇总 job `if: always()` 语义不变，容忍 skip。
- 权限收敛安全性已复核：仓库为 public 且 `default_workflow_permissions` 本就是 `read`，当前 workflow 无 permissions 块即等效 `contents: read`/`pull-requests: none`，`dorny/paths-filter` 的 `pulls.listFiles` 在该权限下对 public PR 一直可用（现存 PR 均经 required check 合并为证）。显式声明仅把既有默认固化，effective 权限不变。

Closes #907


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **变更**
  * 调整了 CodeQL 安全扫描的触发判定：在特定发布类拉取请求场景下跳过语言构建/分析；常规分支仍按路径变更结果进行门控，而定时扫描保持全量执行。
  * 收紧了工作流权限设置，将仓库内容权限限制为只读，并为门控步骤补充最小的拉取请求读取权限。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->