### PR TITLE
fix(providers): 可灵 Kling 设置页补齐图片与视频并发上限配置

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -1078,8 +1078,8 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
         required_keys=["access_key", "secret_key"],
         optional_keys=["image_max_workers", "video_max_workers"],
         secret_keys=["access_key", "secret_key"],
-        # JWT 直连视频：默认 kling-v2-5-turbo（性价比走量）+ v3/v3-omni（旗舰 4K + 多图主体）、
-        # v2-6（pro 人声）、video-o1（多图主体 R2V）。图像模型留后续片接入。
+        # JWT 直连：视频默认 kling-v2-5-turbo（性价比走量）+ v3/v3-omni（旗舰 4K + 多图主体）、
+        # v2-6（pro 人声）、video-o1（多图主体 R2V）；图像 kling-image-o1（默认）+ v3-omni（两栖）。
         models={
             "kling-v2-5-turbo": ModelInfo(
                 display_name="可灵 2.5 Turbo",

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -1076,6 +1076,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
         # 首个需要两个 secret 字符串的内置 provider（JWT HS256 鉴权），凭证按 registry key 名
         # 存入 provider_credential 的 access_key / secret_key 定型列（见 ADR 0037）。
         required_keys=["access_key", "secret_key"],
+        optional_keys=["image_max_workers", "video_max_workers"],
         secret_keys=["access_key", "secret_key"],
         # JWT 直连视频：默认 kling-v2-5-turbo（性价比走量）+ v3/v3-omni（旗舰 4K + 多图主体）、
         # v2-6（pro 人声）、video-o1（多图主体 R2V）。图像模型留后续片接入。

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -71,7 +71,7 @@ def test_optional_keys_have_no_worker_for_unsupported_lane():
     for name, meta in PROVIDER_REGISTRY.items():
         supported_worker_keys = {_LANE_WORKER_KEY[m] for m in meta.media_types if m in _LANE_WORKER_KEY}
         for key in meta.optional_keys:
-            if key.endswith("_max_workers"):
+            if key in _LANE_WORKER_KEY.values():
                 assert key in supported_worker_keys, f"{name}: optional_keys 含 {key} 但 provider 不支持对应 lane"
 
 

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -47,6 +47,34 @@ def test_secret_keys_are_subset_of_required_or_optional():
             assert sk in all_keys, f"{name}: secret key {sk} not in all keys"
 
 
+# 媒体 lane → 并发上限可选键：凡 provider 模型覆盖某条 lane，设置页就应能配该 lane 的并发。
+_LANE_WORKER_KEY = {
+    "image": "image_max_workers",
+    "video": "video_max_workers",
+    "audio": "audio_max_workers",
+}
+
+
+def test_optional_keys_cover_every_supported_lane_worker():
+    """每个 provider 支持的每条媒体 lane 都须在 optional_keys 声明对应 *_max_workers。"""
+    for name, meta in PROVIDER_REGISTRY.items():
+        optional = set(meta.optional_keys)
+        for media_type in meta.media_types:
+            worker_key = _LANE_WORKER_KEY.get(media_type)
+            if worker_key is None:
+                continue
+            assert worker_key in optional, f"{name}: 支持 {media_type} lane 但 optional_keys 未声明 {worker_key}"
+
+
+def test_optional_keys_have_no_worker_for_unsupported_lane():
+    """provider 不支持的 lane 不应声明其 *_max_workers，避免设置页渲染无效字段。"""
+    for name, meta in PROVIDER_REGISTRY.items():
+        supported_worker_keys = {_LANE_WORKER_KEY[m] for m in meta.media_types if m in _LANE_WORKER_KEY}
+        for key in meta.optional_keys:
+            if key.endswith("_max_workers"):
+                assert key in supported_worker_keys, f"{name}: optional_keys 含 {key} 但 provider 不支持对应 lane"
+
+
 class TestModelInfoDurations:
     def test_video_models_have_supported_durations(self):
         """所有预置视频模型必须声明 supported_durations。"""

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -64,6 +64,14 @@ def test_kling_credentials_and_base_url() -> None:
     assert p.default_base_url == "https://api.klingai.com/v1"
 
 
+def test_kling_declares_image_and_video_max_workers() -> None:
+    """可灵覆盖 image + video 两条 lane，optional_keys 须声明两者的并发上限字段。"""
+    p = PROVIDER_REGISTRY["kling"]
+    assert {"image", "video"} <= set(p.media_types)
+    assert "image_max_workers" in p.optional_keys
+    assert "video_max_workers" in p.optional_keys
+
+
 def test_kling_default_video_model_v2_5_turbo() -> None:
     """JWT 直连视频默认模型 kling-v2-5-turbo，能力声明齐备。"""
     p = PROVIDER_REGISTRY["kling"]


### PR DESCRIPTION
## 背景

PRD #936（供应商级并发配置）子项。内置供应商注册表里 `optional_keys` 决定设置页能配置哪些字段；可灵 Kling 此前 `optional_keys` 为空，导致它支持的图片与视频两条 lane 都无法在设置页配置并发上限。

## 改动

- 为可灵 Kling 的 `optional_keys` 补齐 `image_max_workers` + `video_max_workers`，使其设置页可见可配这两条 lane 的并发上限。
- 修正可灵注册块里一处与实际模型声明矛盾的陈旧注释。
- 新增两个注册表不变量测试，遍历全部内置供应商：
  - 正向——凡支持某 media lane（image/video/audio）必须在 `optional_keys` 声明对应 `*_max_workers`；
  - 反向——不支持的 lane 不得声明其 `*_max_workers`，避免设置页渲染无效字段。

仅做键的存在性对齐，不预设任何并发数值；不改设置页字段元数据、不改并发装载逻辑、不改全局默认值。

## 审查与核验（独立视角）

- 枚举全部 10 个内置供应商，比对各自从模型派生的 `media_types` 与 `optional_keys` 的 worker 键，**零 mismatch**——唯一缺口是可灵，其余 9 个本就对齐。
- `media_types` 是从实际声明的模型派生的属性（非手填字段），故不变量测试是对齐真实模型能力，不会与字段漂移。
- 可灵确实覆盖 image lane（`kling-image-o1` 默认 + `kling-v3-omni-image` 两栖模型），补 `image_max_workers` 站得住，非给不支持的 lane 补无效字段。
- audio lane 全量仅 dashscope 一家有模型，且已声明 `audio_max_workers`，无缺口。
- 设置页 `get_provider_config` 遍历 `optional_keys` 渲染字段，字段元数据已含三个 worker 字段。

## 验证

- `uv run ruff check` + `ruff format --check`：通过
- `uv run basedpyright`：0 error
- `uv run python -m pytest tests/`：5308 passed

Closes #939


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化 Kling 配置说明的展示内容，细化默认模型组合描述，提升可读性与清晰度。
  * 增强配置校验：确保媒体类型仅在相应支持范围内声明对应的并发上限字段，从而减少设置页出现无效项。 
  * 新增测试覆盖 Kling 对 image/video 并发上限字段声明及媒体类型匹配规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->