### PR TITLE
feat: 供应商可声明出厂默认并发，未配置时按供应商回退

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,7 +62,7 @@ _Avoid_: job（无此概念）。
 中间状态，表示 cancel 信号已发出但 worker 内 asyncio task 尚未走完 finally 收尾。cancel API 把 DB 从 `running` 改成 `cancelling` 后立即返回；worker finally 在 mark 终态时只能从 `cancelling` 转 `cancelled`（不再走 succeeded/failed 分支）。这是状态机里唯一一个**从 `running` 出发、由 worker 之外的代码改写的非终态**——`queued` 由 enqueue API 写、`cancelled` 直接由 cancel queued 路径写都属于「外部写入」，但前者不从 running 出发、后者是终态。
 
 **slot（执行槽）**：
-GenerationWorker 内并发执行 task 的容量，维度是 **provider × media_type**（不是简单的 image/video 两条总通道）。slot 拆成两件性质不同的东西：**容量**是 provider config 给的上限标量（唯一真相，用户改设置才变），默认 `IMAGE_MAX_WORKERS=5` / `VIDEO_MAX_WORKERS=3`，可在 provider config 里覆盖；**占用**是 worker 内存里在跑 / 排队的 task 记账（随 task 来去一直在变）。TTS 落地后并列新增 audio 容量（`AUDIO_MAX_WORKERS`，默认值随实现设定——TTS 便宜快、倾向放宽，见 `docs/adr/0010`）。一个 provider 的 video 池满，**只阻塞该 provider 的 video 任务**，不影响其他 provider；但若用户的项目只配了一个 video provider，这等于阻塞所有 video 任务。
+GenerationWorker 内并发执行 task 的容量，维度是 **provider × media_type**（不是简单的 image/video 两条总通道）。slot 拆成两件性质不同的东西：**容量**是 provider config 给的上限标量（唯一真相，用户改设置才变），默认 `IMAGE_MAX_WORKERS=5` / `VIDEO_MAX_WORKERS=3`，可在 provider config 里覆盖；每条 lane 按三层回退取值——**用户配置值 > 供应商在注册表（`ProviderMeta.default_concurrency`）声明的出厂默认 > 全局默认**，声明默认是给上游容量受限的供应商出厂即串行/限并发的中间层，未声明的供应商仍退全局默认；**占用**是 worker 内存里在跑 / 排队的 task 记账（随 task 来去一直在变）。TTS 落地后并列新增 audio 容量（`AUDIO_MAX_WORKERS`，默认值随实现设定——TTS 便宜快、倾向放宽，见 `docs/adr/0010`）。一个 provider 的 video 池满，**只阻塞该 provider 的 video 任务**，不影响其他 provider；但若用户的项目只配了一个 video provider，这等于阻塞所有 video 任务。
 _Avoid_: concurrency limit（太泛）。
 
 **CapacityTable / SlotTable**：

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -69,9 +69,10 @@ class ProviderMeta:
                 raise ValueError(
                     f"{self.display_name} default_concurrency 含未知 lane {lane!r}，合法值：{sorted(_VALID_LANES)}"
                 )
-            # isinstance 看似多余（声明类型已是 int），但注册表是手写静态数据，运行时
-            # Python 不强制注解；此处兜住作者笔误（如字符串 "1"、浮点 3.0）违反声明类型。
-            if not isinstance(limit, int) or limit < 1:  # pyright: ignore[reportUnnecessaryIsInstance]
+            # 注册表是手写静态数据，运行时 Python 不强制注解；用精确类型判定兜住作者笔误。
+            # bool 是 int 子类，isinstance(True, int) 为真会把 True 当并发 1 静默放行；字符串
+            # "1"、浮点 3.0 同样违反声明类型。type() is int 把这几类一并挡在 import 期。
+            if type(limit) is not int or limit < 1:
                 raise ValueError(f"{self.display_name} default_concurrency[{lane!r}] 必须是 >=1 的整数，得到 {limit!r}")
 
     @property

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -41,6 +41,10 @@ class ModelInfo:
     api_model_name: str | None = None
 
 
+# 合法并发 lane 名，与 CapacityTable 的 image/video/audio 三条容量通道对齐。
+_VALID_LANES = frozenset({"image", "video", "audio"})
+
+
 @dataclass(frozen=True)
 class ProviderMeta:
     display_name: str
@@ -52,8 +56,23 @@ class ProviderMeta:
     default_base_url: str | None = None
     # 按 lane（image / video / audio）声明的出厂默认并发上限；某条 lane 未列入则该 lane
     # 走全局默认。容量回退优先级：用户配置值 > 此处声明默认 > 全局默认。声明给不支持的
-    # lane 无害——_lane_limits 会按 media_types 把不支持的 lane 投影为 0。
+    # lane 无害——_lane_limits 会按 media_types 把不支持的 lane 投影为 0。键名与上限值在
+    # __post_init__ 校验。
     default_concurrency: dict[str, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # default_concurrency 是注册表静态声明：拼错的 lane key 会被静默忽略、该 lane 漂回
+        # 全局默认（限并发失效），非正整数上限则在投影后变成 capacity<=0、把支持的 lane 误判为
+        # 不支持。这两类都是 import 期就该 fail-fast 的作者笔误，而非到 worker 装载容量表时才暴露。
+        for lane, limit in self.default_concurrency.items():
+            if lane not in _VALID_LANES:
+                raise ValueError(
+                    f"{self.display_name} default_concurrency 含未知 lane {lane!r}，合法值：{sorted(_VALID_LANES)}"
+                )
+            # isinstance 看似多余（声明类型已是 int），但注册表是手写静态数据，运行时
+            # Python 不强制注解；此处兜住作者笔误（如字符串 "1"、浮点 3.0）违反声明类型。
+            if not isinstance(limit, int) or limit < 1:  # pyright: ignore[reportUnnecessaryIsInstance]
+                raise ValueError(f"{self.display_name} default_concurrency[{lane!r}] 必须是 >=1 的整数，得到 {limit!r}")
 
     @property
     def media_types(self) -> list[str]:

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -50,6 +50,10 @@ class ProviderMeta:
     secret_keys: list[str] = field(default_factory=list)
     models: dict[str, ModelInfo] = field(default_factory=dict)
     default_base_url: str | None = None
+    # 按 lane（image / video / audio）声明的出厂默认并发上限；某条 lane 未列入则该 lane
+    # 走全局默认。容量回退优先级：用户配置值 > 此处声明默认 > 全局默认。声明给不支持的
+    # lane 无害——_lane_limits 会按 media_types 把不支持的 lane 投影为 0。
+    default_concurrency: dict[str, int] = field(default_factory=dict)
 
     @property
     def media_types(self) -> list[str]:

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -122,6 +122,14 @@ class CapacityTable:
             "audio": audio if "audio" in media_types else 0,
         }
 
+    @staticmethod
+    def _lane_default(meta: Any, lane: str, global_default: int) -> int:
+        """某条 lane 在用户未配时的回退默认：供应商注册表声明默认（若有）→ 否则全局默认。
+
+        三层回退的中间层单点：from_env / from_db 共用，避免两路漂移。
+        """
+        return meta.default_concurrency.get(lane, global_default)
+
     @classmethod
     def from_env(cls) -> CapacityTable:
         """从环境变量 / 默认值构造（DB 不可用前或测试用）。"""
@@ -130,8 +138,14 @@ class CapacityTable:
         image_max = _read_int_env("IMAGE_MAX_WORKERS", 5, minimum=1)
         video_max = _read_int_env("VIDEO_MAX_WORKERS", 3, minimum=1)
         audio_max = _read_int_env("AUDIO_MAX_WORKERS", 10, minimum=1)
+        # 无用户配置的装载路径：每条 lane 取声明默认（若有）→ 否则全局默认
         limits = {
-            pid: cls._lane_limits(meta.media_types, image_max, video_max, audio_max)
+            pid: cls._lane_limits(
+                meta.media_types,
+                cls._lane_default(meta, "image", image_max),
+                cls._lane_default(meta, "video", video_max),
+                cls._lane_default(meta, "audio", audio_max),
+            )
             for pid, meta in PROVIDER_REGISTRY.items()
         }
         return cls(_limits=limits, _defaults={"image": image_max, "video": video_max, "audio": audio_max})
@@ -155,9 +169,17 @@ class CapacityTable:
             all_configs = await svc.get_all_provider_configs()
             for provider_id, meta in PROVIDER_REGISTRY.items():
                 config = all_configs.get(provider_id, {})
-                image_max = _parse_lane_max(config, "image_max_workers", default_image, provider_id)
-                video_max = _parse_lane_max(config, "video_max_workers", default_video, provider_id)
-                audio_max = _parse_lane_max(config, "audio_max_workers", default_audio, provider_id)
+                # 用户未配某条 lane 时，_parse_lane_max 回退到此处给的 default——
+                # 即声明默认（若有）→ 否则全局默认；用户配了则解析值覆盖之
+                image_max = _parse_lane_max(
+                    config, "image_max_workers", cls._lane_default(meta, "image", default_image), provider_id
+                )
+                video_max = _parse_lane_max(
+                    config, "video_max_workers", cls._lane_default(meta, "video", default_video), provider_id
+                )
+                audio_max = _parse_lane_max(
+                    config, "audio_max_workers", cls._lane_default(meta, "audio", default_audio), provider_id
+                )
                 # _lane_limits 统一负责"不支持的 lane → 0"，三个装载路径共用同一投影点
                 limits[provider_id] = cls._lane_limits(meta.media_types, image_max, video_max, audio_max)
 

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -13,7 +13,10 @@ import os
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lib.config.registry import ProviderMeta
 
 logger = logging.getLogger(__name__)
 
@@ -123,10 +126,11 @@ class CapacityTable:
         }
 
     @staticmethod
-    def _lane_default(meta: Any, lane: str, global_default: int) -> int:
+    def _lane_default(meta: ProviderMeta, lane: str, global_default: int) -> int:
         """某条 lane 在用户未配时的回退默认：供应商注册表声明默认（若有）→ 否则全局默认。
 
-        三层回退的中间层单点：from_env / from_db 共用，避免两路漂移。
+        三层回退的中间层单点：from_env / from_db 共用，避免两路漂移。声明默认的合法性
+        （key 是合法 lane、值为 >=1 整数）由 ProviderMeta.__post_init__ 在 import 期保证。
         """
         return meta.default_concurrency.get(lane, global_default)
 

--- a/tests/test_config_registry_models.py
+++ b/tests/test_config_registry_models.py
@@ -95,7 +95,9 @@ class TestProviderMeta:
                 default_concurrency={"vidoe": 1},
             )
 
-    @pytest.mark.parametrize("bad_limit", [0, -1, "1", 3.0])
+    # True 是 int 子类、值等于 1，须显式拦截，否则配置笔误 default_concurrency={"video": True}
+    # 会被静默当成并发 1。
+    @pytest.mark.parametrize("bad_limit", [0, -1, "1", 3.0, True])
     def test_default_concurrency_non_positive_int_raises(self, bad_limit):
         with pytest.raises(ValueError, match=">=1 的整数"):
             ProviderMeta(

--- a/tests/test_config_registry_models.py
+++ b/tests/test_config_registry_models.py
@@ -1,5 +1,7 @@
 """Test ProviderMeta with ModelInfo structure."""
 
+import pytest
+
 from lib.config.registry import PROVIDER_REGISTRY, ModelInfo, ProviderMeta
 
 
@@ -63,6 +65,45 @@ class TestProviderMeta:
         )
         assert meta.media_types == []
         assert meta.capabilities == []
+
+    def test_default_concurrency_valid_declaration(self):
+        meta = ProviderMeta(
+            display_name="T",
+            description="T",
+            required_keys=[],
+            default_concurrency={"video": 1, "image": 5},
+        )
+        assert meta.default_concurrency == {"video": 1, "image": 5}
+
+    def test_default_concurrency_for_unsupported_lane_is_allowed(self):
+        # 声明合法 lane 名即便该 provider 不支持该 media_type 也无害（投影期再归零），不报错
+        meta = ProviderMeta(
+            display_name="T",
+            description="T",
+            required_keys=[],
+            models={"vid": ModelInfo("V", "video", [])},
+            default_concurrency={"image": 2},
+        )
+        assert meta.default_concurrency == {"image": 2}
+
+    def test_default_concurrency_unknown_lane_raises(self):
+        with pytest.raises(ValueError, match="未知 lane"):
+            ProviderMeta(
+                display_name="T",
+                description="T",
+                required_keys=[],
+                default_concurrency={"vidoe": 1},
+            )
+
+    @pytest.mark.parametrize("bad_limit", [0, -1, "1", 3.0])
+    def test_default_concurrency_non_positive_int_raises(self, bad_limit):
+        with pytest.raises(ValueError, match=">=1 的整数"):
+            ProviderMeta(
+                display_name="T",
+                description="T",
+                required_keys=[],
+                default_concurrency={"video": bad_limit},
+            )
 
 
 class TestProviderRegistry:

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -332,6 +332,92 @@ class TestCapacityTable:
         assert table.get("ark", "video") == 0
         assert "video_max_workers" in caplog.text
 
+    @staticmethod
+    def _registry_with_declared_defaults(monkeypatch) -> None:
+        """注入带 per-lane 默认并发声明的合成注册表，避免耦合任何真实供应商真值。
+
+        - ``declared-video``：支持 image+video，声明 video 默认 1（声明默认 < 全局默认 3）。
+        - ``plain-video``：支持 video，无声明 → 走全局默认。
+        - ``declared-unsupported``：仅支持 video，却声明 image 默认 → 该 lane 仍投影为 0。
+        """
+        from lib.config.registry import ModelInfo, ProviderMeta
+
+        def _model(media_type: str) -> ModelInfo:
+            return ModelInfo(display_name="M", media_type=media_type, capabilities=[])
+
+        registry = {
+            "declared-video": ProviderMeta(
+                display_name="t",
+                description="",
+                required_keys=[],
+                models={"img": _model("image"), "vid": _model("video")},
+                default_concurrency={"video": 1},
+            ),
+            "plain-video": ProviderMeta(
+                display_name="t",
+                description="",
+                required_keys=[],
+                models={"vid": _model("video")},
+            ),
+            "declared-unsupported": ProviderMeta(
+                display_name="t",
+                description="",
+                required_keys=[],
+                models={"vid": _model("video")},
+                default_concurrency={"image": 2},
+            ),
+        }
+        monkeypatch.setattr("lib.config.registry.PROVIDER_REGISTRY", registry)
+
+    def test_from_env_uses_registry_declared_default(self, monkeypatch):
+        self._registry_with_declared_defaults(monkeypatch)
+        monkeypatch.delenv("IMAGE_MAX_WORKERS", raising=False)
+        monkeypatch.delenv("VIDEO_MAX_WORKERS", raising=False)
+
+        table = CapacityTable.from_env()
+
+        # 声明了 video=1 → 取声明默认，而非全局默认 3
+        assert table.get("declared-video", "video") == 1
+        # 同 provider 未声明的 image lane → 全局默认 5
+        assert table.get("declared-video", "image") == 5
+        # 未声明默认的 provider → 全局默认
+        assert table.get("plain-video", "video") == 3
+        # 声明了 image 默认但该 provider 不支持 image → 投影为 0（_lane_limits 不回归）
+        assert table.get("declared-unsupported", "image") == 0
+
+    async def test_from_db_declared_default_when_user_unconfigured(self, monkeypatch):
+        """用户未配 → 取注册表声明默认（而非全局默认）；未声明 provider 仍走全局默认。"""
+        self._registry_with_declared_defaults(monkeypatch)
+        self._stub_from_db_sources(monkeypatch, {})
+
+        table = await CapacityTable.from_db()
+
+        assert table.get("declared-video", "video") == 1
+        assert table.get("declared-video", "image") == 5
+        assert table.get("plain-video", "video") == 3
+        assert table.get("declared-unsupported", "image") == 0
+
+    async def test_from_db_user_value_overrides_declared_default(self, monkeypatch):
+        """用户配了值 → 覆盖注册表声明默认。"""
+        self._registry_with_declared_defaults(monkeypatch)
+        self._stub_from_db_sources(monkeypatch, {"declared-video": {"video_max_workers": "4"}})
+
+        table = await CapacityTable.from_db()
+
+        assert table.get("declared-video", "video") == 4
+
+    async def test_from_db_and_from_env_consistent_fallback(self, monkeypatch):
+        """两条装载路径对同一回退语义（用户未配）逐 lane 结果一致。"""
+        self._registry_with_declared_defaults(monkeypatch)
+        self._stub_from_db_sources(monkeypatch, {})
+
+        db_table = await CapacityTable.from_db()
+        env_table = CapacityTable.from_env()
+
+        for pid in ("declared-video", "plain-video", "declared-unsupported"):
+            for lane in ("image", "video", "audio"):
+                assert db_table.get(pid, lane) == env_table.get(pid, lane)
+
 
 class TestGenerationWorker:
     @pytest.mark.asyncio

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -337,6 +337,8 @@ class TestCapacityTable:
         """注入带 per-lane 默认并发声明的合成注册表，避免耦合任何真实供应商真值。
 
         - ``declared-video``：支持 image+video，声明 video 默认 1（声明默认 < 全局默认 3）。
+        - ``declared-audio``：支持 audio，声明 audio 默认 12（声明默认 > 全局默认 10），覆盖
+          audio lane 的正向回退（声明默认胜过全局默认）。
         - ``plain-video``：支持 video，无声明 → 走全局默认。
         - ``declared-unsupported``：仅支持 video，却声明 image 默认 → 该 lane 仍投影为 0。
         """
@@ -352,6 +354,13 @@ class TestCapacityTable:
                 required_keys=[],
                 models={"img": _model("image"), "vid": _model("video")},
                 default_concurrency={"video": 1},
+            ),
+            "declared-audio": ProviderMeta(
+                display_name="t",
+                description="",
+                required_keys=[],
+                models={"aud": _model("audio")},
+                default_concurrency={"audio": 12},
             ),
             "plain-video": ProviderMeta(
                 display_name="t",
@@ -373,6 +382,7 @@ class TestCapacityTable:
         self._registry_with_declared_defaults(monkeypatch)
         monkeypatch.delenv("IMAGE_MAX_WORKERS", raising=False)
         monkeypatch.delenv("VIDEO_MAX_WORKERS", raising=False)
+        monkeypatch.delenv("AUDIO_MAX_WORKERS", raising=False)
 
         table = CapacityTable.from_env()
 
@@ -380,6 +390,8 @@ class TestCapacityTable:
         assert table.get("declared-video", "video") == 1
         # 同 provider 未声明的 image lane → 全局默认 5
         assert table.get("declared-video", "image") == 5
+        # 支持 audio 且声明 audio=12 → 取声明默认（高于全局默认 10），audio lane 正向回退
+        assert table.get("declared-audio", "audio") == 12
         # 未声明默认的 provider → 全局默认
         assert table.get("plain-video", "video") == 3
         # 声明了 image 默认但该 provider 不支持 image → 投影为 0（_lane_limits 不回归）
@@ -394,6 +406,7 @@ class TestCapacityTable:
 
         assert table.get("declared-video", "video") == 1
         assert table.get("declared-video", "image") == 5
+        assert table.get("declared-audio", "audio") == 12
         assert table.get("plain-video", "video") == 3
         assert table.get("declared-unsupported", "image") == 0
 
@@ -414,7 +427,7 @@ class TestCapacityTable:
         db_table = await CapacityTable.from_db()
         env_table = CapacityTable.from_env()
 
-        for pid in ("declared-video", "plain-video", "declared-unsupported"):
+        for pid in ("declared-video", "declared-audio", "plain-video", "declared-unsupported"):
             for lane in ("image", "video", "audio"):
                 assert db_table.get(pid, lane) == env_table.get(pid, lane)
 


### PR DESCRIPTION
## 背景

PRD #936（供应商级并发配置）子切片。让供应商能在注册表声明出厂默认并发，作为某条 lane 未被用户配置时的回退，替代当前不分供应商的全局默认。这是 #937（Agnes 接入，video 默认并发 1）的硬依赖落点——本切片只提供机制，不写入任何具体供应商的并发真值。

## 改动

- 供应商可声明按 lane（image / video / audio）的出厂默认并发上限；未声明的 lane 与供应商行为与现状完全一致。
- 容量表的两条装载路径（DB 配置 / 环境变量）统一改为三层回退：**用户配置值 > 供应商声明的出厂默认 > 全局默认**，两路共享同一中间层避免漂移。
- 不支持的 lane 仍投影为 0；改并发配置后 worker 不重启即生效的 reload 路径不回归。
- CONTEXT.md `slot` 词条补充声明默认这一回退层。
- 出厂默认声明在构造期 fail-fast 校验：拼错的 lane 名或非正整数上限直接报错，避免限并发被静默忽略或把支持的 lane 误判为不支持。

## 验收标准覆盖

- [x] 支持声明可选 per-lane 默认并发；未声明供应商行为不变
- [x] 两条装载路径回退语义一致：用户未配取声明默认、用户配了取用户值
- [x] 未声明默认的供应商：用户未配仍取全局默认（不回归）
- [x] 不支持的 lane 仍投影为 0（不回归）
- [x] 改并发配置 worker 不重启即生效（reload 路径不回归）
- [x] CONTEXT.md `slot` 词条补回退层
- [x] 覆盖三层回退与校验的单测齐备

## 验证

- `uv run pytest tests/` — 5316 passed
- `uv run ruff check` + `ruff format --check` — 干净
- `uv run basedpyright` — 0 errors, 0 warnings
- xhigh 多智能体 code-review：3 条发现（声明默认未 clamp、lane key 未校验、回退中间层缺类型标注）已全部修复

Closes #938


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 并发上限默认回退逻辑升级：按 lane 分层优先级为“用户配置 > 供应商声明默认 > 全局默认”，并对未声明的 lane 继续回退到全局。
* **错误修复**
  * 加强并发配置校验：对未知 lane 或非正整数并发值将尽早报错，提升配置可靠性。
  * 更一致的容量加载表现：对不支持的 lane 会按规则投影为 0，避免误用默认值。
* **文档**
  * 补充并澄清容量（slot）按 lane 的三层回退规则说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->