### PR TITLE
fix(script): 分集规划容忍原文与回显的标点全/半角及空白宽度差异，避免规划失败

### DIFF
--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+import unicodedata
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -205,8 +206,11 @@ def _find_all_overlapping(haystack: str, needle: str) -> list[int]:
     """收集 needle 在 haystack 内的全部起点（允许重叠）。
 
     str.count 只统计非重叠匹配，会把重叠出现（如 "aaaa" 中的 "aaa"）误判为唯一；
-    步进 1 滑动查找，按允许重叠的口径判定 0/1/多次。
+    步进 1 滑动查找，按允许重叠的口径判定 0/1/多次。空 needle 直接返回空列表
+    （调用方的 anchor 受 min_length=2 约束不会为空，此处仅作 helper 的防御边界）。
     """
+    if not needle:
+        return []
     starts: list[int] = []
     found = haystack.find(needle)
     while found != -1:
@@ -230,10 +234,11 @@ def _resolve_boundaries(
     全文结尾窗口，贴齐后每个字符都归属某一集）。``cover_to_end=True`` 时残留
     非空白尾巴视为校验失败。
 
-    锚点定位分级：先精确 ``find``（命中即与逐字节匹配完全一致）；精确落空时按折叠
+    锚点定位分级：先精确 ``find``（命中即与逐字节匹配完全一致，Tier1 不做任何归一）；
+    精确落空时退化到容错——先对锚副本做 NFC 归一（window 本就是 NFC 坐标系），再按折叠
     全/半角标点 + 折叠空白宽度的等价口径在折叠副本上扫描，折叠为 1:1 等长映射，命中
-    起点即 NFC 坐标系下的精确起点（切片仍取原文，不改写源文标点）。折叠后仍多处命中
-    时维持「无法唯一定位」拒绝。
+    起点即 NFC 坐标系下的精确起点、跨度取 NFC 锚长（切片仍取原文，不改写源文标点）。
+    折叠后仍多处命中时维持「无法唯一定位」拒绝。
     """
     reasons: list[str] = []
     ends: list[int] = []
@@ -242,14 +247,20 @@ def _resolve_boundaries(
     folded_window: str | None = None  # 懒构造：仅在精确匹配落空时折叠一次
     for idx, ep in enumerate(drafts, start=1):
         anchor = ep.end_anchor
+        match_len = len(anchor)  # 精确命中：跨度即原 anchor 长度（与 window 逐字节一致）
         starts = _find_all_overlapping(window, anchor)
         matched_by_fold = False
         if not starts:
-            # 精确落空：退化到标点 / 空白宽度容错，在等长折叠副本上定位精确偏移
+            # 精确落空：退化到容错匹配。仅对「匹配用的锚副本」先 NFC 归一（window 已是
+            # normalize_source_text 的 NFC 产物），再折叠标点全/半角与空白宽度，在等长折叠
+            # 副本上定位精确偏移；Tier1 字节级行为与源文坐标不变，跨度按 NFC 锚长与 NFC 坐标对齐。
             if folded_window is None:
                 folded_window = _fold_for_match(window)
-            starts = _find_all_overlapping(folded_window, _fold_for_match(anchor))
-            matched_by_fold = bool(starts)
+            nfc_anchor = unicodedata.normalize("NFC", anchor)
+            starts = _find_all_overlapping(folded_window, _fold_for_match(nfc_anchor))
+            if starts:
+                matched_by_fold = True
+                match_len = len(nfc_anchor)
         if not starts:
             reasons.append(f"第 {idx} 条的 end_anchor 在原文窗口中不存在（必须逐字摘抄，含标点）: {anchor!r}")
             ordering_valid = False
@@ -259,7 +270,7 @@ def _resolve_boundaries(
                 # 折叠路径的「出现 N 次」是标点 / 空白折叠对齐后的计数；模型按字面 anchor 逐字数
                 # 往往是 0 次，必须点明计数口径，否则模型对不上、可能反复重交同一 anchor 耗尽重试
                 reasons.append(
-                    f"第 {idx} 条的 end_anchor 在原文窗口中按标点全/半角与空白折叠对齐后出现 {len(starts)} 次"
+                    f"第 {idx} 条的 end_anchor 在原文窗口中按 NFC 归一与标点全/半角、空白折叠对齐后出现 {len(starts)} 次"
                     f"（逐字精确匹配可能为 0 次），无法唯一定位，请改用更长或更独特、与原文逐字一致的片段: {anchor!r}"
                 )
             else:
@@ -269,7 +280,7 @@ def _resolve_boundaries(
                 )
             ordering_valid = False
             continue
-        end = starts[0] + len(anchor)
+        end = starts[0] + match_len
         if ordering_valid and end <= pos:
             reasons.append(
                 f"第 {idx} 条的 end_anchor 位置不在上一集结尾之后（各集范围必须连续推进、不重叠）: {anchor!r}"

--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -177,14 +177,17 @@ _PUNCT_FOLD: dict[str, str] = {
     "）": ")",  # U+FF09 全角右括号
     "～": "~",  # U+FF5E 全角波浪号
 }
+# 折叠值必须是单字符：_fold_for_match 的逐字符 1:1 等长依赖于此。一旦某条映射折成多字符，
+# 折叠串偏移就相对 NFC 原文漂移，end = start + len(anchor) 会算出错误切点。导入期即拦截违例。
+assert all(len(dst) == 1 for dst in _PUNCT_FOLD.values()), "折叠表的值必须是单字符以保证等长映射"
 
 
 def _fold_for_match(text: str) -> str:
-    """构造匹配用折叠副本：折叠全/半角标点 + 把各类空白折成单个半角空格。
+    """构造匹配用折叠副本：折叠全/半角标点 + 把每个空白字符折成一个半角空格（逐字符等长，不合并连续空白）。
 
-    严格逐字符 1:1 映射（每个字符映射为恰好一个字符），长度与原文一致，
-    因而折叠串上的偏移即原文 NFC 坐标系内的精确偏移。容差只限定在标点全/半角与
-    空白宽度，不做编辑距离 / 语义级模糊匹配。
+    严格逐字符 1:1 映射（每个字符映射为恰好一个字符，连续空白按原数量逐个保留、不压缩），
+    长度与原文一致，因而折叠串上的偏移即原文 NFC 坐标系内的精确偏移。容差只限定在标点
+    全/半角与单个空白字符的宽度，不做编辑距离 / 语义级模糊匹配。
     """
     out: list[str] = []
     for ch in text:
@@ -240,20 +243,30 @@ def _resolve_boundaries(
     for idx, ep in enumerate(drafts, start=1):
         anchor = ep.end_anchor
         starts = _find_all_overlapping(window, anchor)
+        matched_by_fold = False
         if not starts:
             # 精确落空：退化到标点 / 空白宽度容错，在等长折叠副本上定位精确偏移
             if folded_window is None:
                 folded_window = _fold_for_match(window)
             starts = _find_all_overlapping(folded_window, _fold_for_match(anchor))
+            matched_by_fold = bool(starts)
         if not starts:
             reasons.append(f"第 {idx} 条的 end_anchor 在原文窗口中不存在（必须逐字摘抄，含标点）: {anchor!r}")
             ordering_valid = False
             continue
         if len(starts) > 1:
-            reasons.append(
-                f"第 {idx} 条的 end_anchor 在原文窗口中出现 {len(starts)} 次，无法唯一定位，"
-                f"请改用更长或更独特的片段: {anchor!r}"
-            )
+            if matched_by_fold:
+                # 折叠路径的「出现 N 次」是标点 / 空白折叠对齐后的计数；模型按字面 anchor 逐字数
+                # 往往是 0 次，必须点明计数口径，否则模型对不上、可能反复重交同一 anchor 耗尽重试
+                reasons.append(
+                    f"第 {idx} 条的 end_anchor 在原文窗口中按标点全/半角与空白折叠对齐后出现 {len(starts)} 次"
+                    f"（逐字精确匹配可能为 0 次），无法唯一定位，请改用更长或更独特、与原文逐字一致的片段: {anchor!r}"
+                )
+            else:
+                reasons.append(
+                    f"第 {idx} 条的 end_anchor 在原文窗口中出现 {len(starts)} 次，无法唯一定位，"
+                    f"请改用更长或更独特的片段: {anchor!r}"
+                )
             ordering_valid = False
             continue
         end = starts[0] + len(anchor)

--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import json
 import logging
-import unicodedata
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -235,10 +234,12 @@ def _resolve_boundaries(
     非空白尾巴视为校验失败。
 
     锚点定位分级：先精确 ``find``（命中即与逐字节匹配完全一致，Tier1 不做任何归一）；
-    精确落空时退化到容错——先对锚副本做 NFC 归一（window 本就是 NFC 坐标系），再按折叠
-    全/半角标点 + 折叠空白宽度的等价口径在折叠副本上扫描，折叠为 1:1 等长映射，命中
-    起点即 NFC 坐标系下的精确起点、跨度取 NFC 锚长（切片仍取原文，不改写源文标点）。
-    折叠后仍多处命中时维持「无法唯一定位」拒绝。
+    精确落空时退化到容错——先对锚副本施加与 window 相同的 ``normalize_source_text`` 归一
+    （NFC + 换行统一），把「window 已归一、anchor 未归一」整类失配一次性闭合，再按折叠
+    全/半角标点 + 折叠空白宽度的等价口径在折叠副本上扫描。折叠对 window 为 1:1 等长映射，
+    故命中起点即归一坐标系下的精确起点；跨度取归一后的锚长（``normalize_source_text`` 非
+    长度保持，end 必须用归一锚长而非原 anchor 长，否则 \\r 或组合字符撑长会让偏移漂移）。
+    切片仍取归一后的原文、不改写源文标点。折叠后仍多处命中时维持「无法唯一定位」拒绝。
     """
     reasons: list[str] = []
     ends: list[int] = []
@@ -251,16 +252,18 @@ def _resolve_boundaries(
         starts = _find_all_overlapping(window, anchor)
         matched_by_fold = False
         if not starts:
-            # 精确落空：退化到容错匹配。仅对「匹配用的锚副本」先 NFC 归一（window 已是
-            # normalize_source_text 的 NFC 产物），再折叠标点全/半角与空白宽度，在等长折叠
-            # 副本上定位精确偏移；Tier1 字节级行为与源文坐标不变，跨度按 NFC 锚长与 NFC 坐标对齐。
+            # 精确落空：退化到容错匹配。对「匹配用的锚副本」施加与 window 完全相同的归一
+            # （normalize_source_text：NFC + 换行统一，window 本就经它产出），再折叠标点全/半角
+            # 与空白宽度，在对 window 等长的折叠副本上定位精确偏移；Tier1 字节级行为与源文坐标
+            # 不变。normalize_source_text 非长度保持，故 end 跨度取归一后锚长 match_len（不是原
+            # anchor 长），与归一坐标系对齐，避免 \r / 组合字符撑长导致偏移漂移、损坏切片坐标。
             if folded_window is None:
                 folded_window = _fold_for_match(window)
-            nfc_anchor = unicodedata.normalize("NFC", anchor)
-            starts = _find_all_overlapping(folded_window, _fold_for_match(nfc_anchor))
+            normalized_anchor = normalize_source_text(anchor)
+            starts = _find_all_overlapping(folded_window, _fold_for_match(normalized_anchor))
             if starts:
                 matched_by_fold = True
-                match_len = len(nfc_anchor)
+                match_len = len(normalized_anchor)
         if not starts:
             reasons.append(f"第 {idx} 条的 end_anchor 在原文窗口中不存在（必须逐字摘抄，含标点）: {anchor!r}")
             ordering_valid = False
@@ -270,7 +273,7 @@ def _resolve_boundaries(
                 # 折叠路径的「出现 N 次」是标点 / 空白折叠对齐后的计数；模型按字面 anchor 逐字数
                 # 往往是 0 次，必须点明计数口径，否则模型对不上、可能反复重交同一 anchor 耗尽重试
                 reasons.append(
-                    f"第 {idx} 条的 end_anchor 在原文窗口中按 NFC 归一与标点全/半角、空白折叠对齐后出现 {len(starts)} 次"
+                    f"第 {idx} 条的 end_anchor 在原文窗口中按归一（NFC 与换行统一）及标点全/半角、空白折叠对齐后出现 {len(starts)} 次"
                     f"（逐字精确匹配可能为 0 次），无法唯一定位，请改用更长或更独特、与原文逐字一致的片段: {anchor!r}"
                 )
             else:

--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -163,6 +163,55 @@ class _DraftRejected(Exception):
         self.reasons = reasons
 
 
+# 全/半角标点折叠表：把同一标点的全角 / 表意形态映射到半角规范形，仅供匹配时构造
+# 折叠副本用，绝不落库。逐字符 1:1 映射（长度不变），折叠坐标即 NFC 精确坐标。
+_PUNCT_FOLD: dict[str, str] = {
+    "。": ".",  # U+3002 表意句号
+    "．": ".",  # U+FF0E 全角句点
+    "，": ",",  # U+FF0C 全角逗号
+    "！": "!",  # U+FF01 全角叹号
+    "？": "?",  # U+FF1F 全角问号
+    "：": ":",  # U+FF1A 全角冒号
+    "；": ";",  # U+FF1B 全角分号
+    "（": "(",  # U+FF08 全角左括号
+    "）": ")",  # U+FF09 全角右括号
+    "～": "~",  # U+FF5E 全角波浪号
+}
+
+
+def _fold_for_match(text: str) -> str:
+    """构造匹配用折叠副本：折叠全/半角标点 + 把各类空白折成单个半角空格。
+
+    严格逐字符 1:1 映射（每个字符映射为恰好一个字符），长度与原文一致，
+    因而折叠串上的偏移即原文 NFC 坐标系内的精确偏移。容差只限定在标点全/半角与
+    空白宽度，不做编辑距离 / 语义级模糊匹配。
+    """
+    out: list[str] = []
+    for ch in text:
+        folded = _PUNCT_FOLD.get(ch)
+        if folded is not None:
+            out.append(folded)
+        elif ch.isspace():
+            out.append(" ")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def _find_all_overlapping(haystack: str, needle: str) -> list[int]:
+    """收集 needle 在 haystack 内的全部起点（允许重叠）。
+
+    str.count 只统计非重叠匹配，会把重叠出现（如 "aaaa" 中的 "aaa"）误判为唯一；
+    步进 1 滑动查找，按允许重叠的口径判定 0/1/多次。
+    """
+    starts: list[int] = []
+    found = haystack.find(needle)
+    while found != -1:
+        starts.append(found)
+        found = haystack.find(needle, found + 1)
+    return starts
+
+
 def _resolve_boundaries(
     window: str,
     drafts: list[NarrationEpisodeDraft],
@@ -177,20 +226,25 @@ def _resolve_boundaries(
     ``snap_whitespace_tail`` 任一生效——前者是 replan 闭合范围，后者是 plan 的
     全文结尾窗口，贴齐后每个字符都归属某一集）。``cover_to_end=True`` 时残留
     非空白尾巴视为校验失败。
+
+    锚点定位分级：先精确 ``find``（命中即与逐字节匹配完全一致）；精确落空时按折叠
+    全/半角标点 + 折叠空白宽度的等价口径在折叠副本上扫描，折叠为 1:1 等长映射，命中
+    起点即 NFC 坐标系下的精确起点（切片仍取原文，不改写源文标点）。折叠后仍多处命中
+    时维持「无法唯一定位」拒绝。
     """
     reasons: list[str] = []
     ends: list[int] = []
     pos = 0
     ordering_valid = True
+    folded_window: str | None = None  # 懒构造：仅在精确匹配落空时折叠一次
     for idx, ep in enumerate(drafts, start=1):
         anchor = ep.end_anchor
-        # str.count 只统计非重叠匹配，会把重叠出现（如 "aaaa" 中的 "aaa"）误判为唯一；
-        # 步进 1 滑动查找收集所有起点，按允许重叠的口径判定 0/1/多次
-        starts: list[int] = []
-        found = window.find(anchor)
-        while found != -1:
-            starts.append(found)
-            found = window.find(anchor, found + 1)
+        starts = _find_all_overlapping(window, anchor)
+        if not starts:
+            # 精确落空：退化到标点 / 空白宽度容错，在等长折叠副本上定位精确偏移
+            if folded_window is None:
+                folded_window = _fold_for_match(window)
+            starts = _find_all_overlapping(folded_window, _fold_for_match(anchor))
         if not starts:
             reasons.append(f"第 {idx} 条的 end_anchor 在原文窗口中不存在（必须逐字摘抄，含标点）: {anchor!r}")
             ordering_valid = False

--- a/tests/test_episode_planner.py
+++ b/tests/test_episode_planner.py
@@ -227,9 +227,9 @@ class TestPlan:
         assert [s.title for s in result.episodes] == ["乙"]
 
     async def test_plan_resolves_anchor_with_halfwidth_punctuation(self, tmp_path: Path):
-        """锚点与源文仅差全/半角标点宽度（。→ .）：折叠容错还原精确 NFC 偏移，一次通过不重试。"""
+        """锚点与源文仅差全/半角标点宽度（，→ , 与 。→ .）：折叠容错还原精确 NFC 偏移，一次通过不重试。"""
         project_dir = _write_project(tmp_path)
-        half_width_anchor = "玉中藏着剑诀."  # 源文是全角 。，模型回显成半角 .
+        half_width_anchor = "古玉,玉中藏着剑诀."  # 源文是全角 ，与 。，模型回显成半角 , 与 .
         fake = _FakeTextGenerator(
             [_plan_response([{"title": "古玉藏诀", "hook": "玉中剑诀来历成谜", "end_anchor": half_width_anchor}])]
         )
@@ -246,7 +246,7 @@ class TestPlan:
         assert [s.title for s in result.episodes] == ["古玉藏诀"]
 
     async def test_plan_drama_resolves_anchor_with_punctuation_width_mismatch(self, tmp_path: Path):
-        """drama 草稿同样走折叠容错：标点宽度不匹配（。→ .、，→ ,）时解析到正确精确偏移。"""
+        """drama 草稿同样走折叠容错：标点宽度不匹配（。→ .）时解析到正确精确偏移。"""
         project_dir = _write_project(tmp_path, content_mode="drama")
         half_width_anchor = "被追杀的少女."  # 源文全角 。
         fake = _FakeTextGenerator(

--- a/tests/test_episode_planner.py
+++ b/tests/test_episode_planner.py
@@ -226,6 +226,91 @@ class TestPlan:
         assert "2 次" in fake.requests[1].prompt  # 按允许重叠的口径计数
         assert [s.title for s in result.episodes] == ["乙"]
 
+    async def test_plan_resolves_anchor_with_halfwidth_punctuation(self, tmp_path: Path):
+        """锚点与源文仅差全/半角标点宽度（。→ .）：折叠容错还原精确 NFC 偏移，一次通过不重试。"""
+        project_dir = _write_project(tmp_path)
+        half_width_anchor = "玉中藏着剑诀."  # 源文是全角 。，模型回显成半角 .
+        fake = _FakeTextGenerator(
+            [_plan_response([{"title": "古玉藏诀", "hook": "玉中剑诀来历成谜", "end_anchor": half_width_anchor}])]
+        )
+
+        result = await EpisodePlanner(project_dir, generator=fake).plan()
+
+        assert len(fake.requests) == 1  # 容错命中，未触发重试
+        eps = _load_project(project_dir)["episodes"]
+        # 还原出的偏移与精确匹配口径逐字节一致
+        assert eps[0]["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": _end_of(ANCHOR_EP1)}
+        ep1 = (project_dir / "source" / "episode_1.txt").read_text(encoding="utf-8")
+        assert ep1 == SOURCE[: _end_of(ANCHOR_EP1)]
+        assert ep1.endswith("玉中藏着剑诀。")  # 源文标点未被改写（仍是全角 。）
+        assert [s.title for s in result.episodes] == ["古玉藏诀"]
+
+    async def test_plan_drama_resolves_anchor_with_punctuation_width_mismatch(self, tmp_path: Path):
+        """drama 草稿同样走折叠容错：标点宽度不匹配（。→ .、，→ ,）时解析到正确精确偏移。"""
+        project_dir = _write_project(tmp_path, content_mode="drama")
+        half_width_anchor = "被追杀的少女."  # 源文全角 。
+        fake = _FakeTextGenerator(
+            [
+                _plan_response(
+                    [
+                        {
+                            "title": "城门遇袭",
+                            "hook": "少女为何被追杀",
+                            "end_anchor": half_width_anchor,
+                            "story_beats": ["辞别师父", "城门遇袭"],
+                            "next_episode_teaser": "风波将起",
+                        }
+                    ]
+                )
+            ]
+        )
+
+        result = await EpisodePlanner(project_dir, generator=fake).plan()
+
+        assert len(fake.requests) == 1  # 容错命中，未触发重试
+        eps = _load_project(project_dir)["episodes"]
+        assert eps[0]["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": _end_of(ANCHOR_EP2)}
+        assert eps[0]["outline"]["story_beats"] == ["辞别师父", "城门遇袭"]
+        ep1 = (project_dir / "source" / "episode_1.txt").read_text(encoding="utf-8")
+        assert ep1 == SOURCE[: _end_of(ANCHOR_EP2)]
+        assert [s.title for s in result.episodes] == ["城门遇袭"]
+
+    async def test_plan_resolves_anchor_with_whitespace_width_mismatch(self, tmp_path: Path):
+        """锚点空白宽度不匹配（全角空格 ↔ 半角空格）：折叠容错还原精确偏移。"""
+        source = "The hero　rose at dawn. Then darkness fell over the land."  # 含全角空格 U+3000
+        project_dir = _write_project(tmp_path, source_text=source)
+        half_width_anchor = "The hero rose at dawn."  # 模型回显成半角空格
+        fake = _FakeTextGenerator(
+            [_plan_response([{"title": "Dawn", "hook": "hook", "end_anchor": half_width_anchor}])]
+        )
+
+        result = await EpisodePlanner(project_dir, generator=fake).plan()
+
+        assert len(fake.requests) == 1
+        eps = _load_project(project_dir)["episodes"]
+        end = source.index("dawn.") + len("dawn.")
+        assert eps[0]["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": end}
+        assert (project_dir / "source" / "episode_1.txt").read_text(encoding="utf-8") == source[:end]
+        assert [s.title for s in result.episodes] == ["Dawn"]
+
+    async def test_plan_rejects_anchor_ambiguous_after_punctuation_folding(self, tmp_path: Path):
+        """折叠后仍命中多处：维持「无法唯一定位」拒绝并重试，不静默挑第一处。"""
+        source = "他说好的。她说好的。后来他离开了。"  # 两处「说好的。」全角句号
+        project_dir = _write_project(tmp_path, source_text=source)
+        fake = _FakeTextGenerator(
+            [
+                _plan_response([{"title": "甲", "hook": "甲", "end_anchor": "说好的."}]),  # 半角 .，折叠后命中两处
+                _plan_response([{"title": "乙", "hook": "乙", "end_anchor": "后来他离开了。"}]),
+            ]
+        )
+
+        result = await EpisodePlanner(project_dir, generator=fake).plan()
+
+        assert len(fake.requests) == 2
+        assert "无法唯一定位" in fake.requests[1].prompt
+        assert "2 次" in fake.requests[1].prompt
+        assert [s.title for s in result.episodes] == ["乙"]
+
     async def test_plan_ignores_negative_cursor_offset(self, tmp_path: Path):
         """游标 offset 为负：按非法游标忽略，从源文开头规划而非尾部静默取段。"""
         project_dir = _write_project(tmp_path, planning_cursor={"source_file": "source/novel.txt", "offset": -5})

--- a/tests/test_episode_planner.py
+++ b/tests/test_episode_planner.py
@@ -306,8 +306,8 @@ class TestPlan:
         assert [s.title for s in result.episodes] == ["Dawn"]
 
     async def test_plan_resolves_anchor_with_unicode_nfc_mismatch(self, tmp_path: Path):
-        """锚点与源文 Unicode 规范形不一致（锚为 NFD 分解形 ↔ 源文 NFC）：折叠兜底先对
-        锚副本做 NFC 归一再匹配，还原精确 NFC 偏移；Tier1 字节级行为与源文坐标不变。"""
+        """锚点与源文 Unicode 规范形不一致（锚为 NFD 分解形 ↔ 源文 NFC）：折叠兜底对锚副本
+        施加与 window 相同的 normalize_source_text 归一再匹配，还原精确偏移；Tier1 与源文坐标不变。"""
         source = unicodedata.normalize("NFC", "Tôi yêu tiếng Việt. Hôm nay trời đẹp lắm.")
         project_dir = _write_project(tmp_path, source_text=source)
         nfc_anchor = "Tôi yêu tiếng Việt."
@@ -323,6 +323,32 @@ class TestPlan:
         assert eps[0]["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": end}
         ep1 = (project_dir / "source" / "episode_1.txt").read_text(encoding="utf-8")
         assert ep1 == source[:end]  # 切片取 NFC 原文，未改写源文
+        assert [s.title for s in result.episodes] == ["Mở đầu"]
+
+    async def test_plan_resolves_anchor_with_crlf_and_combining_length_change(self, tmp_path: Path):
+        """长度护栏：锚同时含 \\r\\n 与会改变长度的组合字符（NFD），两者都让锚比源文对应子串更长。
+        归一副本走 normalize_source_text（NFC + 换行统一），end 跨度按归一锚长还原，断言源文偏移/
+        切片逐字节落在归一坐标系上、不被 \\r 或组合字符撑长漂移；Tier1 仍逐字节不变。"""
+        # 源文已是存储坐标系形态（NFC + \n）；窗口与切片均在此坐标系上
+        source = "Tôi yêu tiếng Việt.\nHôm nay trời đẹp lắm. Mọi thứ thật tuyệt vời."
+        project_dir = _write_project(tmp_path, source_text=source)
+        nfc_sub = "Tôi yêu tiếng Việt.\nHôm nay"  # 源文中的精确子串（NFC + \n）
+        # 模型回显：组合字符分解（NFD，变长）+ 换行写成 \r\n（再 +1）
+        crlf_nfd_anchor = unicodedata.normalize("NFD", nfc_sub).replace("\n", "\r\n")
+        assert "\r\n" in crlf_nfd_anchor and len(crlf_nfd_anchor) > len(nfc_sub)
+
+        fake = _FakeTextGenerator(
+            [_plan_response([{"title": "Mở đầu", "hook": "hook", "end_anchor": crlf_nfd_anchor}])]
+        )
+
+        result = await EpisodePlanner(project_dir, generator=fake).plan()
+
+        assert len(fake.requests) == 1  # 容错命中，未触发重试
+        eps = _load_project(project_dir)["episodes"]
+        end = source.index(nfc_sub) + len(nfc_sub)  # 归一坐标系下的精确末偏移（非锚原长）
+        assert eps[0]["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": end}
+        ep1 = (project_dir / "source" / "episode_1.txt").read_text(encoding="utf-8")
+        assert ep1 == source[:end]  # 切片逐字节落在源文坐标上，未被 \r/组合字符撑长漂移
         assert [s.title for s in result.episodes] == ["Mở đầu"]
 
     async def test_plan_rejects_anchor_ambiguous_after_punctuation_folding(self, tmp_path: Path):

--- a/tests/test_episode_planner.py
+++ b/tests/test_episode_planner.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import json
+import unicodedata
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,7 @@ from lib.episode_planner import (
     EpisodePlanningError,
     PlanningConflictError,
     ReplanConfirmationRequired,
+    _find_all_overlapping,
 )
 from lib.text_backends.base import TextGenerationResult
 
@@ -87,6 +89,16 @@ def _load_project(project_dir: Path) -> dict:
 
 def _plan_response(episodes: list[dict]) -> str:
     return json.dumps({"episodes": episodes}, ensure_ascii=False)
+
+
+class TestFindAllOverlapping:
+    def test_collects_overlapping_starts(self):
+        assert _find_all_overlapping("aaaa", "aaa") == [0, 1]
+
+    def test_empty_needle_returns_empty_without_hanging(self):
+        # 空 needle 防御边界：直接返回 []，不进入逐位滑动（调用方 anchor 受 min_length=2 约束）
+        assert _find_all_overlapping("abcabc", "") == []
+        assert _find_all_overlapping("", "") == []
 
 
 class TestPlan:
@@ -292,6 +304,26 @@ class TestPlan:
         assert eps[0]["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": end}
         assert (project_dir / "source" / "episode_1.txt").read_text(encoding="utf-8") == source[:end]
         assert [s.title for s in result.episodes] == ["Dawn"]
+
+    async def test_plan_resolves_anchor_with_unicode_nfc_mismatch(self, tmp_path: Path):
+        """锚点与源文 Unicode 规范形不一致（锚为 NFD 分解形 ↔ 源文 NFC）：折叠兜底先对
+        锚副本做 NFC 归一再匹配，还原精确 NFC 偏移；Tier1 字节级行为与源文坐标不变。"""
+        source = unicodedata.normalize("NFC", "Tôi yêu tiếng Việt. Hôm nay trời đẹp lắm.")
+        project_dir = _write_project(tmp_path, source_text=source)
+        nfc_anchor = "Tôi yêu tiếng Việt."
+        nfd_anchor = unicodedata.normalize("NFD", nfc_anchor)  # 模型回显成分解形
+        assert nfd_anchor != nfc_anchor and len(nfd_anchor) != len(nfc_anchor)
+        fake = _FakeTextGenerator([_plan_response([{"title": "Mở đầu", "hook": "hook", "end_anchor": nfd_anchor}])])
+
+        result = await EpisodePlanner(project_dir, generator=fake).plan()
+
+        assert len(fake.requests) == 1  # 容错命中，未触发重试
+        eps = _load_project(project_dir)["episodes"]
+        end = source.index(nfc_anchor) + len(nfc_anchor)  # 精确 NFC 偏移
+        assert eps[0]["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": end}
+        ep1 = (project_dir / "source" / "episode_1.txt").read_text(encoding="utf-8")
+        assert ep1 == source[:end]  # 切片取 NFC 原文，未改写源文
+        assert [s.title for s in result.episodes] == ["Mở đầu"]
 
     async def test_plan_rejects_anchor_ambiguous_after_punctuation_folding(self, tmp_path: Path):
         """折叠后仍命中多处：维持「无法唯一定位」拒绝并重试，不静默挑第一处。"""


### PR DESCRIPTION
## 问题
分集规划要求 LLM 为每集回显一段原文 `end_anchor`，边界解析用精确子串在 NFC 归一化窗口里定位结束偏移。网文源常全/半角标点混排，模型回显时又倾向顺手清洗标点，于是 anchor 与窗口差一个标点宽度（`。`/`.`、`，`/`,`、`！`/`!` 等）即被判「锚点不存在」，连续重试耗尽后整轮分集规划失败。

## 方案
锚点边界解析加入分级容错匹配：

1. **Tier 1（精确）**：保持现状先做精确 `find`，命中即与改动前逐字节一致。
2. **Tier 2（标点/空白宽度容错）**：精确落空时，按「折叠全/半角标点 + 把每个空白字符折成一个半角空格」的等价口径在窗口的折叠副本上扫描。折叠为严格逐字符 1:1 等长映射，命中起点即 NFC 坐标系下的精确偏移；`end = start + len(anchor)` 直接落回原文坐标。
3. 折叠后多处命中维持「无法唯一定位」拒绝并重试；唯一性 / 递增 / 连续不重叠 / cover-to-end 既有机械校验照常在还原出的精确偏移上执行。

**守住的不变量**：`source_range` 偏移仍是 NFC 坐标系下的单一真相源；切片始终取**原文**，绝不改写源文标点，存量项目已存偏移不受影响、无需数据迁移。容错范围严格限定在标点全/半角与单个空白字符宽度，不引入编辑距离/语义级模糊匹配。

## 本地审查补强（第二阶段，xhigh 工作流复审后）
- 折叠路径下「无法唯一定位」的拒绝理由点明计数口径是折叠对齐后的次数（模型按字面 anchor 逐字数往往为 0 次），避免模型对不上计数、反复重交同一 anchor 耗尽重试。
- 折叠表新增**导入期断言**强制每条映射值为单字符，把「等长映射」这一承重不变量从注释升级为可执行守卫——杜绝后续误加多字符映射（如 `…`→`...`）导致偏移漂移。
- 澄清 `_fold_for_match` 文档（逐字符等长、连续空白不压缩）。
- 单测补全**全角逗号**折叠覆盖，并修正 drama 测试 docstring 与实际口径一致。

### 已知边界（非本 issue 范围，留作后续）
- 弯引号（`“” ‘’`→`" '`）等非「全/半角宽度」的典型化归一不在折叠表内；属 issue 明确划定的范围外（容错限定在标点全/半角与空白宽度），如需可另立 issue。
- 连续空白「数量」差异（run-count，非单字符宽度）不予容错——折叠保持 1:1 等长是偏移还原的前提，压缩连续空白会破坏该不变量。

## 验证
- `uv run python -m pytest tests/test_episode_planner.py` — 49 passed（含本 issue 新增 4 例：narration 全角逗号+句号、drama 句号、英文全角空格、折叠后多命中拒绝重试）
- `uv run ruff check` + `ruff format --check` — clean
- `uv run basedpyright` — 0 errors（仅既有 `_FakeTextGenerator` duck-typing warnings，tests/ 内已降级）

Closes #912


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 锚点定位支持全/半角标点、空白折叠容错，并在 Unicode NFC 归一化后重新定位；必要时保持唯一性校验。
  * `content_mode="drama"` 规划会写入/保留结构化大纲字段（如故事节拍）。
* **Bug 修复**
  * 改进不可唯一定位的拒绝原因与重试提示，避免静默选择首个命中。
  * 修复 CRLF 与组合字符导致的锚长度变化，确保端点偏移与源文切片一致。
* **测试**
  * 新增重叠起点收集及多场景锚点折叠/归一化命中、拒绝与重试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->