### PR TITLE
feat(provider): 接入 Agnes 内置供应商与图像生成

### DIFF
--- a/lib/agnes_shared.py
+++ b/lib/agnes_shared.py
@@ -1,0 +1,46 @@
+"""Agnes 共享工具模块。
+
+供 image_backends / video_backends / text_backends / config / 连接测试复用。Agnes 经
+apihub 网关提供 OpenAI 风格端点，单 `/v1` base，Bearer 单 key 鉴权：
+- AGNES_BASE_URL — 默认 base（含 `/v1`）
+- resolve_agnes_api_key — Bearer API Key 解析（缺失即 raise，不走 env fallback）
+- agnes_base_url — 归一化为 {host}/v1，容忍用户填 host 或带 `/v1` 后缀
+- agnes_headers — Bearer 鉴权头
+"""
+
+from __future__ import annotations
+
+# 默认 base（含 /v1）；用户可经配置覆盖 base_url 指向自建中转。
+AGNES_BASE_URL = "https://apihub.agnes-ai.com/v1"
+
+# 单一已知路径后缀，归一化 host 时剥除以容忍用户填入完整 base。
+_V1_SUFFIX = "/v1"
+
+
+def resolve_agnes_api_key(api_key: str | None = None) -> str:
+    if api_key is None or not api_key.strip():
+        raise ValueError("请到系统配置页填写 Agnes API Key")
+    return api_key.strip()
+
+
+def _agnes_host(configured: str | None) -> str:
+    """从配置的 base_url 提取 host 段（剥除 `/v1` 后缀），缺省回落默认 host。"""
+    # 先 strip 再判空：纯空白串（"   "）是真值会绕过 or，回落必须在 strip 之后，
+    # 否则 base 变空串、派生出 "/v1" 这类非法相对 URL。
+    base = ((configured or "").strip() or AGNES_BASE_URL).rstrip("/")
+    if base.endswith(_V1_SUFFIX):
+        return base[: -len(_V1_SUFFIX)]
+    return base
+
+
+def agnes_base_url(configured: str | None = None) -> str:
+    """OpenAI 兼容 base：{host}/v1。"""
+    return f"{_agnes_host(configured)}{_V1_SUFFIX}"
+
+
+def agnes_headers(api_key: str) -> dict[str, str]:
+    """Bearer 鉴权头。"""
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }

--- a/lib/agnes_shared.py
+++ b/lib/agnes_shared.py
@@ -39,7 +39,12 @@ def agnes_base_url(configured: str | None = None) -> str:
 
 
 def agnes_headers(api_key: str) -> dict[str, str]:
-    """Bearer 鉴权头。"""
+    """Bearer 鉴权头。
+
+    复用 resolve_agnes_api_key 校验：空串 / 纯空白即本地 raise，避免拼出
+    ``Authorization: Bearer `` 把缺失 key 拖到请求期才收上游 401。
+    """
+    api_key = resolve_agnes_api_key(api_key)
     return {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",

--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -330,6 +330,9 @@ PROVIDER_SPEC_REGISTRY.update(
 PROVIDER_SPEC_REGISTRY.update(
     {(_KLING_REGISTRY_BACKEND, media_type): _kling_spec(media_type) for media_type in ("image", "video")}
 )
+# agnes 简单族，当前仅图像（文本 / 视频模态另片接入，届时各自登记）；不并入
+# _SIMPLE_IMAGE_VIDEO_PROVIDERS 以免登记尚无 backend 的 video spec。
+PROVIDER_SPEC_REGISTRY[("agnes", "image")] = _simple_spec("agnes", "image")
 
 # ── 文本族注册 ────────────────────────────────────────────────────
 # 简单文本三家（registry_backend = provider_id 自身）；gemini 两个 provider_id 按 backend 分两行

--- a/lib/config/env_keys.py
+++ b/lib/config/env_keys.py
@@ -24,6 +24,7 @@ OTHER_PROVIDER_ENV_KEYS: tuple[str, ...] = (
     "VIDU_API_KEY",
     "DASHSCOPE_API_KEY",
     "MINIMAX_API_KEY",
+    "AGNES_API_KEY",
     "OPENAI_API_KEY",
     "GOOGLE_APPLICATION_CREDENTIALS",
     # OpenAI SDK 在 client 未显式传值时回落读的 env 旋钮（非密钥命名，
@@ -53,6 +54,7 @@ PROVIDER_SECRET_KEYS: frozenset[str] = frozenset(
         "VIDU_API_KEY",
         "DASHSCOPE_API_KEY",
         "MINIMAX_API_KEY",
+        "AGNES_API_KEY",
         "OPENAI_API_KEY",
         "GOOGLE_APPLICATION_CREDENTIALS",
     }

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from lib.agnes_shared import AGNES_BASE_URL
 from lib.ark_shared import ARK_BASE_URL
 from lib.dashscope_shared import DASHSCOPE_BASE_URL
 from lib.minimax_shared import MINIMAX_BASE_URL
@@ -247,6 +248,11 @@ def _kling_image_flat_pricing(model_id: str, per_image: float) -> PerImageFlat:
 
 def _kling_image_by_resolution_pricing(model_id: str, rates: dict[str, float]) -> PerImageByResolution:
     return PerImageByResolution(rates={model_id: rates}, default_model=model_id, currency="CNY")
+
+
+# Agnes 图片费率（美元/张），官方原价；当前促销 $0 不建模。
+def _agnes_image_pricing(model_id: str, per_image: float) -> PerImageFlat:
+    return PerImageFlat(rates={model_id: per_image}, default_model=model_id, currency="USD")
 
 
 PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
@@ -1149,6 +1155,28 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             ),
         },
         default_base_url="https://api.klingai.com/v1",
+    ),
+    "agnes": ProviderMeta(
+        display_name="Agnes",
+        description="Agnes 多模态平台（OpenAI 风格），使用 Bearer API Key 鉴权；当前支持图像生成。",
+        required_keys=["api_key"],
+        optional_keys=["base_url", "image_max_workers"],
+        secret_keys=["api_key"],
+        models={
+            # --- image ---
+            # agnes-image-2.1-flash：OpenAI 兼容 /images/generations 单步同步，T2I + I2I。
+            # 仅注册 2.1（2.0 与其价格 / 字段实测无差异，model 目录收敛）。
+            # resolutions 为保守 UI 档位（未逐档实测）；实际尺寸由 backend aspect_size 计算、与此无耦合。
+            "agnes-image-2.1-flash": ModelInfo(
+                display_name="Agnes Image 2.1 Flash",
+                media_type="image",
+                capabilities=["text_to_image", "image_to_image"],
+                default=True,
+                resolutions=["1K", "2K"],
+                pricing=_agnes_image_pricing("agnes-image-2.1-flash", 0.003),
+            ),
+        },
+        default_base_url=AGNES_BASE_URL,
     ),
 }
 

--- a/lib/i18n/en/providers.py
+++ b/lib/i18n/en/providers.py
@@ -12,6 +12,7 @@ MESSAGES: dict[str, str] = {
     "provider_name_dashscope": "Alibaba Model Studio",
     "provider_name_minimax": "MiniMax",
     "provider_name_kling": "Kling",
+    "provider_name_agnes": "Agnes",
     # Provider descriptions
     "provider_desc_gemini-aistudio": "Google AI Studio provides Gemini models with image and video generation, ideal for rapid prototyping and personal projects.",
     "provider_desc_gemini-vertex": "Google Cloud Vertex AI enterprise platform supporting Gemini and Imagen models with higher quotas and audio generation.",
@@ -23,6 +24,7 @@ MESSAGES: dict[str, str] = {
     "provider_desc_dashscope": "Alibaba Cloud Model Studio (DashScope) full-modality platform supporting Qwen text, Qwen-Image / Wan images, and HappyHorse / Wan video (including reference-to-video).",
     "provider_desc_minimax": "MiniMax (Hailuo) multimodal platform with text, image and video generation. Connects to the domestic site by default; set base_url to the international site for overseas access.",
     "provider_desc_kling": "Kuaishou Kling video and image generation platform, authenticated with an Access Key and Secret Key.",
+    "provider_desc_agnes": "Agnes multimodal platform (OpenAI-style), authenticated with a Bearer API key; currently supports image generation.",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "DeepSeek official Anthropic-compat endpoint; needs sk- prefixed key.",
     "preset_notes_xiaomi_mimo": "Xiaomi MiMo only accepts known model names; no public model list.",

--- a/lib/i18n/vi/providers.py
+++ b/lib/i18n/vi/providers.py
@@ -12,6 +12,7 @@ MESSAGES: dict[str, str] = {
     "provider_name_dashscope": "Alibaba Model Studio",
     "provider_name_minimax": "MiniMax",
     "provider_name_kling": "Kling",
+    "provider_name_agnes": "Agnes",
     # Provider descriptions
     "provider_desc_gemini-aistudio": "Google AI Studio cung cấp các mô hình Gemini hỗ trợ tạo ảnh và video, phù hợp cho việc dựng prototype nhanh và dự án cá nhân.",
     "provider_desc_gemini-vertex": "Nền tảng doanh nghiệp Vertex AI của Google Cloud hỗ trợ các mô hình Gemini và Imagen với hạn mức cao hơn cùng khả năng tạo âm thanh.",
@@ -23,6 +24,7 @@ MESSAGES: dict[str, str] = {
     "provider_desc_dashscope": "Nền tảng đa phương thức Alibaba Cloud Model Studio (DashScope) hỗ trợ văn bản Qwen, ảnh Qwen-Image / Wan và video HappyHorse / Wan (bao gồm video tham chiếu).",
     "provider_desc_minimax": "Nền tảng đa phương thức MiniMax (Hailuo) hỗ trợ tạo văn bản, ảnh và video. Mặc định kết nối site nội địa; đặt base_url sang site quốc tế khi dùng ở nước ngoài.",
     "provider_desc_kling": "Nền tảng tạo video và ảnh Kling của Kuaishou, xác thực bằng Access Key và Secret Key.",
+    "provider_desc_agnes": "Nền tảng đa phương thức Agnes (phong cách OpenAI), xác thực bằng Bearer API key; hiện hỗ trợ tạo ảnh.",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "Endpoint Anthropic-compat chính thức của DeepSeek; cần API key sk-.",
     "preset_notes_xiaomi_mimo": "Xiaomi MiMo chỉ chấp nhận tên model đã biết; không có danh sách model công khai.",

--- a/lib/i18n/zh/providers.py
+++ b/lib/i18n/zh/providers.py
@@ -12,6 +12,7 @@ MESSAGES: dict[str, str] = {
     "provider_name_dashscope": "阿里百炼",
     "provider_name_minimax": "MiniMax",
     "provider_name_kling": "可灵 Kling",
+    "provider_name_agnes": "Agnes",
     # Provider descriptions
     "provider_desc_gemini-aistudio": "Google AI Studio 提供 Gemini 系列模型，支持图片和视频生成，适合快速原型和个人项目。",
     "provider_desc_gemini-vertex": "Google Cloud Vertex AI 企业级平台，支持 Gemini 和 Imagen 模型，提供更高配额和音频生成能力。",
@@ -23,6 +24,7 @@ MESSAGES: dict[str, str] = {
     "provider_desc_dashscope": "阿里云百炼（Model Studio）全模态平台，支持 Qwen 文本、Qwen-Image / 万相图像与 HappyHorse / 万相视频（含参考生视频）。",
     "provider_desc_minimax": "MiniMax（海螺）多模态平台，提供文本、图片、视频生成。默认连接国内站，海外可将 base_url 切换到国际站。",
     "provider_desc_kling": "快手可灵 Kling 视频与图像生成平台，使用 Access Key 与 Secret Key 鉴权。",
+    "provider_desc_agnes": "Agnes 多模态平台（OpenAI 风格），使用 Bearer API Key 鉴权；当前支持图像生成。",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "DeepSeek 官方 Anthropic 兼容端点，需 sk- 开头的 API Key",
     "preset_notes_xiaomi_mimo": "小米 MiMo 仅支持已知模型名，未公开模型列表",

--- a/lib/image_backends/__init__.py
+++ b/lib/image_backends/__init__.py
@@ -61,3 +61,8 @@ from lib.image_backends.kling import KlingImageBackend
 from lib.providers import PROVIDER_KLING
 
 register_backend(PROVIDER_KLING, KlingImageBackend)
+
+from lib.image_backends.agnes import AgnesImageBackend
+from lib.providers import PROVIDER_AGNES
+
+register_backend(PROVIDER_AGNES, AgnesImageBackend)

--- a/lib/image_backends/agnes.py
+++ b/lib/image_backends/agnes.py
@@ -45,27 +45,15 @@ _DEFAULT_SHORT = 1440
 _SAFE_LOG_KEYS = ("model", "size", "n")
 
 
-def _extract_image_url(payload: object) -> str | None:
-    """从 OpenAI 兼容响应 ``data[].url`` 取首个 URL；无则 None。"""
+def _extract_first_str(payload: object, key: str) -> str | None:
+    """从 OpenAI 兼容响应 ``data[].<key>`` 取首个非空字符串（url / b64_json 共用）；无则 None。"""
     data = payload.get("data") if isinstance(payload, dict) else None
     if isinstance(data, list):
         for item in data:
             if isinstance(item, dict):
-                url = item.get("url")
-                if isinstance(url, str) and url:
-                    return url
-    return None
-
-
-def _extract_image_base64(payload: object) -> str | None:
-    """从 OpenAI 兼容响应 ``data[].b64_json`` 取首个 base64；无则 None。"""
-    data = payload.get("data") if isinstance(payload, dict) else None
-    if isinstance(data, list):
-        for item in data:
-            if isinstance(item, dict):
-                b64 = item.get("b64_json")
-                if isinstance(b64, str) and b64:
-                    return b64
+                value = item.get(key)
+                if isinstance(value, str) and value:
+                    return value
     return None
 
 
@@ -204,12 +192,12 @@ class AgnesImageBackend:
 
         优先 URL（立即下载），URL 缺失降级 base64 解码写盘；两者皆空即报错。
         """
-        url = _extract_image_url(data)
+        url = _extract_first_str(data, "url")
         if url:
             await self._download_result(url, output_path)
             return url
 
-        b64 = _extract_image_base64(data)
+        b64 = _extract_first_str(data, "b64_json")
         if b64:
             await _write_base64_image(b64, output_path)
             return None

--- a/lib/image_backends/agnes.py
+++ b/lib/image_backends/agnes.py
@@ -190,21 +190,33 @@ class AgnesImageBackend:
     async def _persist_image(self, data: dict, output_path: Path) -> str | None:
         """把 images/generations 响应落地为本地文件，返回远端 URL（base64 路径返回 None）。
 
-        优先 URL（立即下载），URL 缺失降级 base64 解码写盘；两者皆空即报错。
+        优先 URL（立即下载）；URL 缺失或下载失败时降级到同响应内 base64 解码写盘，
+        避免一次已计费的成功生成因下载环节失败而无法落盘；两者皆空即报错。
         """
         url = _extract_first_str(data, "url")
-        if url:
-            await self._download_result(url, output_path)
-            return url
-
         b64 = _extract_first_str(data, "b64_json")
+        if url:
+            try:
+                await self._download_result(url, output_path)
+                return url
+            except Exception:
+                if not b64:
+                    raise
+                logger.warning("Agnes 结果 URL 下载失败，改用响应内 b64_json 落盘")
+
         if b64:
             await _write_base64_image(b64, output_path)
             return None
 
-        # 完整响应体记日志便于诊断，但不嵌进异常消息——避免 body 里的 "503"/"timeout" 等子串
-        # 被默认 _should_retry 误判为可重试（仓库已确立按状态码而非字符串判重试）。
-        logger.error("Agnes 图像响应缺少 url/b64_json: %s", data)
+        # 完整响应体可能含 prompt / 签名 URL 等敏感字段，与请求日志脱敏策略一致：只记键名与
+        # data 条数，不落整 body；异常消息同样不嵌 body——避免 "503"/"timeout" 子串被默认
+        # _should_retry 误判为可重试（仓库已确立按状态码而非字符串判重试）。
+        data_items = data.get("data")
+        logger.error(
+            "Agnes 图像响应缺少 url/b64_json: keys=%s data_count=%s",
+            sorted(str(key) for key in data),
+            len(data_items) if isinstance(data_items, list) else None,
+        )
         raise RuntimeError("Agnes 图像响应缺少 url/b64_json")
 
     @with_retry_async(

--- a/lib/image_backends/agnes.py
+++ b/lib/image_backends/agnes.py
@@ -176,7 +176,7 @@ class AgnesImageBackend:
                 raise ImageCapabilityError(
                     "image_reference_images_unreadable",
                     model=self._model,
-                    names=path.name if path else f"#{idx}",
+                    names=path.name if path and path.name else f"#{idx}",
                 )
             try:
                 uris.append(image_to_base64_data_uri(path))

--- a/lib/image_backends/agnes.py
+++ b/lib/image_backends/agnes.py
@@ -1,0 +1,249 @@
+"""AgnesImageBackend — Agnes 图像生成后端（单步同步，OpenAI 兼容）。
+
+走 apihub 网关上的 OpenAI 兼容 ``/images/generations`` 同步端点：单次 POST 直接返回图片
+URL 或 base64，立即落地为本地资产。T2I 与 I2I 共用同一端点，I2I 把参考图随请求体下发。
+尺寸按 ADR 0011 aspect_size 精确算出并显式下发 ``size``（不依赖上游默认横屏尺寸）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from pathlib import Path
+
+import httpx
+
+from lib.agnes_shared import agnes_base_url, agnes_headers, resolve_agnes_api_key
+from lib.aspect_size import IMAGE_TIER_SHORT_EDGE, aspect_size, resolution_to_short_edge
+from lib.image_backends.base import (
+    ImageCapability,
+    ImageCapabilityError,
+    ImageGenerationRequest,
+    ImageGenerationResult,
+    download_image_to_path,
+    image_to_base64_data_uri,
+)
+from lib.logging_utils import format_kwargs_for_log
+from lib.providers import PROVIDER_AGNES
+from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
+from lib.video_backends.base import should_retry_download, should_retry_submit, submit_post
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "agnes-image-2.1-flash"
+
+_IMAGE_ENDPOINT = "/images/generations"
+
+# 尺寸约束：长宽被 8 整除、长边收口 2048（保守值，覆盖常见 flash 图像档）。缺 image_size
+# 时按 2K 短边兜底，经长边收口后竖屏得 1152x2048。
+_ROUND_TO = 8
+_MAX_LONG_EDGE = 2048
+_DEFAULT_SHORT = 1440
+
+# 仅允许进日志的标量字段白名单；prompt 仅记长度、image 仅计数，base64/URL 一律不入日志。
+_SAFE_LOG_KEYS = ("model", "size", "n")
+
+
+def _extract_image_url(payload: object) -> str | None:
+    """从 OpenAI 兼容响应 ``data[].url`` 取首个 URL；无则 None。"""
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict):
+                url = item.get("url")
+                if isinstance(url, str) and url:
+                    return url
+    return None
+
+
+def _extract_image_base64(payload: object) -> str | None:
+    """从 OpenAI 兼容响应 ``data[].b64_json`` 取首个 base64；无则 None。"""
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict):
+                b64 = item.get("b64_json")
+                if isinstance(b64, str) and b64:
+                    return b64
+    return None
+
+
+def _safe_body_for_log(body: dict) -> dict:
+    """生成安全日志视图：白名单标量 + prompt 仅长度 + image 仅计数。"""
+    view: dict = {key: body[key] for key in _SAFE_LOG_KEYS if key in body}
+    prompt = body.get("prompt")
+    if isinstance(prompt, str):
+        view["prompt_len"] = len(prompt)
+    images = body.get("image")
+    if isinstance(images, list) and images:
+        view["image"] = f"<{len(images)} ref>"
+    return view
+
+
+class AgnesImageBackend:
+    """Agnes 图像后端（单步同步 OpenAI 兼容 images/generations 端点）。"""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        http_timeout: float = 120.0,
+    ) -> None:
+        self._api_key = resolve_agnes_api_key(api_key)
+        self._base_url = agnes_base_url(base_url)
+        self._model = model or DEFAULT_MODEL
+        self._http_timeout = http_timeout
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_AGNES
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def capabilities(self) -> set[ImageCapability]:
+        return {ImageCapability.TEXT_TO_IMAGE, ImageCapability.IMAGE_TO_IMAGE}
+
+    async def generate(self, request: ImageGenerationRequest) -> ImageGenerationResult:
+        # 编排层不带重试：把非幂等的「建图 + 计费」submit 与幂等的结果下载隔离到各自的
+        # 重试范围（_submit / _download_result），避免下载失败回退到重跑生成 POST 造成重复计费。
+        width, height = self._resolve_dimensions(request)
+
+        # 不发 response_format：上游 litellm 网关对该参数报 UnsupportedParamsError；
+        # 响应默认同时带 url 与 b64_json，由 _persist_image 优先取 url。
+        payload: dict = {
+            "model": self._model,
+            "prompt": request.prompt,
+            "n": 1,
+            "size": f"{width}x{height}",
+        }
+        if request.reference_images:
+            # I2I 参考图随同一请求体下发 data-URI 列表（image 字段）。读盘 + base64 编码
+            # （可能数 MB）offload 到线程，避免阻塞事件循环。
+            payload["image"] = await asyncio.to_thread(self._build_reference_images, request)
+
+        data = await self._submit(payload)
+        image_uri = await self._persist_image(data, request.output_path)
+        logger.info("Agnes 图片生成完成: %s", request.output_path)
+
+        return ImageGenerationResult(
+            image_path=request.output_path,
+            provider=PROVIDER_AGNES,
+            model=self._model,
+            image_uri=image_uri,
+        )
+
+    @with_retry_async(retry_if=should_retry_submit)
+    async def _submit(self, payload: dict) -> dict:
+        """单步图像生成 POST（非幂等「建图 + 计费」），返回解析后的响应体。
+
+        重试范围严格限定在本方法内、不含下载——下载失败不会触发整流程重试导致重复建图与
+        重复计费。submit_post 把歧义传输错误转 AmbiguousSubmitError 终态失败避免重复计费；
+        >=400 落 body 日志 + 抛 HTTPStatusError，交 should_retry_submit 按状态码分流。
+        """
+        logger.info(
+            "调用 %s 图片 API model=%s body=%s",
+            self.name,
+            self._model,
+            format_kwargs_for_log(_safe_body_for_log(payload)),
+        )
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            resp = await submit_post(
+                lambda: client.post(
+                    f"{self._base_url}{_IMAGE_ENDPOINT}",
+                    json=payload,
+                    headers=agnes_headers(self._api_key),
+                ),
+                provider=PROVIDER_AGNES,
+            )
+            return resp.json()
+
+    def _resolve_dimensions(self, request: ImageGenerationRequest) -> tuple[int, int]:
+        """按「比例优先、清晰度其次」算出 (宽, 高)。
+
+        比例永远来自 aspect_ratio；image_size（档位词 / 自定义 宽*高 / None）只决定清晰度短边，
+        自定义值剥离其自带比例（取 min）。结果被 8 整除、长边受 2048 收口。
+        """
+        short = resolution_to_short_edge(
+            request.image_size or None, tier_map=IMAGE_TIER_SHORT_EDGE, default_short=_DEFAULT_SHORT
+        )
+        return aspect_size(request.aspect_ratio, short, round_to=_ROUND_TO, max_long_edge=_MAX_LONG_EDGE)
+
+    def _build_reference_images(self, request: ImageGenerationRequest) -> list[str]:
+        """构建 I2I 参考图列表（data-URI base64）。
+
+        任一参考图缺失 / 读取失败即 fail-loud，报 image_reference_images_unreadable，让用户
+        感知有图未被使用而非静默丢弃后照常计费。
+        """
+        uris: list[str] = []
+        for idx, ref in enumerate(request.reference_images, start=1):
+            # 空路径无文件名可显示，用序号标识，避免中文占位漏进非中文报错模板。
+            path = Path(ref.path) if ref.path else None
+            if path is None or not path.is_file():
+                raise ImageCapabilityError(
+                    "image_reference_images_unreadable",
+                    model=self._model,
+                    names=path.name if path else f"#{idx}",
+                )
+            try:
+                uris.append(image_to_base64_data_uri(path))
+            except OSError as exc:
+                logger.warning("Agnes 参考图读取失败: %s (%s)", path, exc)
+                raise ImageCapabilityError(
+                    "image_reference_images_unreadable", model=self._model, names=path.name
+                ) from exc
+        return uris
+
+    async def _persist_image(self, data: dict, output_path: Path) -> str | None:
+        """把 images/generations 响应落地为本地文件，返回远端 URL（base64 路径返回 None）。
+
+        优先 URL（立即下载），URL 缺失降级 base64 解码写盘；两者皆空即报错。
+        """
+        url = _extract_image_url(data)
+        if url:
+            await self._download_result(url, output_path)
+            return url
+
+        b64 = _extract_image_base64(data)
+        if b64:
+            await _write_base64_image(b64, output_path)
+            return None
+
+        # 完整响应体记日志便于诊断，但不嵌进异常消息——避免 body 里的 "503"/"timeout" 等子串
+        # 被默认 _should_retry 误判为可重试（仓库已确立按状态码而非字符串判重试）。
+        logger.error("Agnes 图像响应缺少 url/b64_json: %s", data)
+        raise RuntimeError("Agnes 图像响应缺少 url/b64_json")
+
+    @with_retry_async(
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
+        retry_if=should_retry_download,
+    )
+    async def _download_result(self, url: str, output_path: Path) -> None:
+        """下载已签发的结果图 URL（幂等 GET），独立的下载重试范围。
+
+        瞬态失败在本层重试，绝不回退到重跑非幂等的生成 POST；4xx 快速失败。
+        """
+        await download_image_to_path(url, output_path)
+
+
+async def _write_base64_image(b64: str, output_path: Path) -> None:
+    """解码 base64 图片并写盘（解码 + 写盘 offload 到线程）。
+
+    容忍少数中转返回 data URI（``data:image/...;base64,<payload>``）：剥前缀后再解码。
+    """
+    payload = b64
+    if payload.startswith("data:") and "," in payload:
+        payload = payload.split(",", 1)[1]
+
+    def _decode_and_save() -> None:
+        image_bytes = base64.b64decode(payload)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(image_bytes)
+
+    await asyncio.to_thread(_decode_and_save)

--- a/lib/pricing/lookup.py
+++ b/lib/pricing/lookup.py
@@ -10,6 +10,7 @@ import logging
 
 from lib.pricing.types import PerToken, Pricing, ViduDelegate
 from lib.providers import (
+    PROVIDER_AGNES,
     PROVIDER_ANTHROPIC,
     PROVIDER_ARK,
     PROVIDER_DASHSCOPE,
@@ -26,7 +27,7 @@ logger = logging.getLogger(__name__)
 # （gemini-aistudio/vertex、裸 gemini、ark-agent-plan、未知）一律回落 Gemini 家族通用默认费率，
 # 复刻历史「仅 ark/grok/openai 走专属表、其余皆走全局 Gemini 表」的路由。
 _OWN_TABLE_PROVIDERS = frozenset(
-    {PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI, PROVIDER_DASHSCOPE, PROVIDER_MINIMAX, PROVIDER_KLING}
+    {PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI, PROVIDER_DASHSCOPE, PROVIDER_MINIMAX, PROVIDER_KLING, PROVIDER_AGNES}
 )
 
 # Anthropic 不在 PROVIDER_REGISTRY（无 ModelInfo 落点），文本定价作为 registry-external 例外。

--- a/lib/providers.py
+++ b/lib/providers.py
@@ -12,6 +12,7 @@ PROVIDER_NEWAPI = "newapi"
 PROVIDER_DASHSCOPE = "dashscope"
 PROVIDER_MINIMAX = "minimax"
 PROVIDER_KLING = "kling"
+PROVIDER_AGNES = "agnes"
 PROVIDER_ANTHROPIC = "anthropic"
 
 CallType = Literal["image", "video", "text", "audio"]

--- a/tests/test_agnes_image_backend.py
+++ b/tests/test_agnes_image_backend.py
@@ -247,6 +247,65 @@ class TestResponseHandling:
             with pytest.raises(RuntimeError):
                 await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
 
+    async def test_url_download_failure_falls_back_to_b64(self, tmp_path: Path):
+        # URL 下载失败但同响应带 b64_json：回退落盘，不丢弃已计费的成功生成
+        raw = b"\x89PNG\r\nfallback"
+        b64 = base64.b64encode(raw).decode("ascii")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"created": 1, "data": [{"url": "https://x/out.png", "b64_json": b64}]}
+        client = _mock_client(resp)
+        download = AsyncMock(side_effect=RuntimeError("download boom"))
+        out = tmp_path / "o.png"
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.agnes import AgnesImageBackend
+
+            b = AgnesImageBackend(api_key="sk")
+            result = await b.generate(ImageGenerationRequest(prompt="x", output_path=out))
+
+        assert out.read_bytes() == raw
+        # 走 b64 回退路径，无远端 URL
+        assert result.image_uri is None
+        download.assert_called()
+
+    async def test_url_download_failure_without_b64_still_raises(self, tmp_path: Path):
+        # 仅有 url 且下载失败、无 b64 兜底：照常上抛，不静默吞错
+        client = _mock_client(_img_response())
+        download = AsyncMock(side_effect=RuntimeError("download boom"))
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.agnes import AgnesImageBackend
+
+            b = AgnesImageBackend(api_key="sk")
+            with pytest.raises(RuntimeError):
+                await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
+
+    async def test_missing_url_b64_log_redacts_body(self, tmp_path: Path, caplog):
+        # 响应缺 url/b64 时只记键名与 data 条数，敏感字段值不落日志
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "created": 1,
+            "data": [{"prompt": "secret-prompt"}],
+            "signed_url": "https://x/secret?sig=abc",
+        }
+        client = _mock_client(resp)
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2, caplog.at_level("ERROR"):
+            from lib.image_backends.agnes import AgnesImageBackend
+
+            b = AgnesImageBackend(api_key="sk")
+            with pytest.raises(RuntimeError):
+                await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
+
+        log_text = caplog.text
+        assert "secret-prompt" not in log_text
+        assert "sig=abc" not in log_text
+        # 键名进日志便于诊断
+        assert "signed_url" in log_text
+
 
 class TestHttpErrors:
     async def test_400_surfaces_httpstatuserror_single_call(self, tmp_path: Path):

--- a/tests/test_agnes_image_backend.py
+++ b/tests/test_agnes_image_backend.py
@@ -1,0 +1,306 @@
+"""AgnesImageBackend 单元测试（mock httpx，单步同步 OpenAI 兼容端点，不打真实 HTTP）。"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from lib.image_backends.base import (
+    ImageCapability,
+    ImageCapabilityError,
+    ImageGenerationRequest,
+    ReferenceImage,
+)
+from lib.providers import PROVIDER_AGNES
+
+
+def _img_response(url: str = "https://x/out.png") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"created": 1, "data": [{"url": url}]}
+    return resp
+
+
+def _b64_response(b64: str) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"created": 1, "data": [{"b64_json": b64}]}
+    return resp
+
+
+def _mock_client(resp: MagicMock) -> AsyncMock:
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+def _make_ref(tmp_path: Path, name: str) -> ReferenceImage:
+    p = tmp_path / name
+    p.write_bytes(b"\x89PNG\r\nfake")
+    return ReferenceImage(path=str(p))
+
+
+def _http_error(status_code: int, message: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://x/v1/images/generations")
+    response = httpx.Response(status_code, request=request, text=message)
+    return httpx.HTTPStatusError(f"error {status_code}", request=request, response=response)
+
+
+def _error_response(status_code: int) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = "boom"
+    resp.raise_for_status = MagicMock(side_effect=_http_error(status_code, "boom"))
+    return resp
+
+
+def _patches(client: AsyncMock, download: AsyncMock):
+    return (
+        patch("httpx.AsyncClient", return_value=client),
+        patch("lib.image_backends.agnes.download_image_to_path", download),
+    )
+
+
+class TestCapabilities:
+    def test_t2i_and_i2i(self):
+        from lib.image_backends.agnes import AgnesImageBackend
+
+        b = AgnesImageBackend(api_key="sk", model="agnes-image-2.1-flash")
+        assert b.name == PROVIDER_AGNES
+        assert b.model == "agnes-image-2.1-flash"
+        assert b.capabilities == {ImageCapability.TEXT_TO_IMAGE, ImageCapability.IMAGE_TO_IMAGE}
+
+    def test_default_model_when_unset(self):
+        from lib.image_backends.agnes import AgnesImageBackend
+
+        assert AgnesImageBackend(api_key="sk").model == "agnes-image-2.1-flash"
+
+    def test_registered_in_factory(self):
+        from lib.image_backends import create_backend, get_registered_backends
+        from lib.image_backends.agnes import AgnesImageBackend
+
+        assert PROVIDER_AGNES in get_registered_backends()
+        assert isinstance(create_backend(PROVIDER_AGNES, api_key="sk"), AgnesImageBackend)
+
+
+class TestTextToImage:
+    async def test_t2i_request_build(self, tmp_path: Path):
+        client = _mock_client(_img_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.agnes import AgnesImageBackend
+
+            b = AgnesImageBackend(api_key="sk", model="agnes-image-2.1-flash", base_url="https://apihub.agnes-ai.com")
+            result = await b.generate(ImageGenerationRequest(prompt="a fox", output_path=tmp_path / "o.png"))
+
+        body = client.post.call_args.kwargs["json"]
+        assert body["model"] == "agnes-image-2.1-flash"
+        assert body["prompt"] == "a fox"
+        assert body["n"] == 1
+        # 上游 litellm 网关拒绝 response_format（UnsupportedParamsError）——不得下发
+        assert "response_format" not in body
+        assert "image" not in body
+        # 默认 aspect_ratio=9:16 精确算、受单边 2048 收口
+        assert body["size"] == "1152x2048"
+        # 端点：base host 派生 /v1 + /images/generations
+        assert client.post.call_args.args[0] == "https://apihub.agnes-ai.com/v1/images/generations"
+        assert client.post.call_args.kwargs["headers"]["Authorization"] == "Bearer sk"
+        assert result.provider == PROVIDER_AGNES
+        assert result.model == "agnes-image-2.1-flash"
+        assert result.image_uri == "https://x/out.png"
+        download.assert_called_once()
+
+    async def test_default_endpoint(self, tmp_path: Path):
+        client = _mock_client(_img_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.agnes import AgnesImageBackend
+
+            b = AgnesImageBackend(api_key="sk")
+            await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
+
+        assert client.post.call_args.args[0] == "https://apihub.agnes-ai.com/v1/images/generations"
+
+
+class TestDimensions:
+    async def _size(self, tmp_path: Path, **req_kwargs) -> str:
+        client = _mock_client(_img_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.agnes import AgnesImageBackend
+
+            b = AgnesImageBackend(api_key="sk")
+            await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png", **req_kwargs))
+        return client.post.call_args.kwargs["json"]["size"]
+
+    async def test_landscape_picks_wide(self, tmp_path: Path):
+        assert await self._size(tmp_path, aspect_ratio="16:9") == "2048x1152"
+
+    async def test_square(self, tmp_path: Path):
+        assert await self._size(tmp_path, aspect_ratio="1:1") == "1440x1440"
+
+    async def test_explicit_1k_tier(self, tmp_path: Path):
+        assert await self._size(tmp_path, aspect_ratio="9:16", image_size="1K") == "1008x1792"
+
+    async def test_custom_pixel_strips_embedded_ratio(self, tmp_path: Path):
+        # 自定义像素 16:9 的 1920*1080 只贡献 min=1080 当短边，比例仍由项目 aspect_ratio=9:16 决定
+        size = await self._size(tmp_path, aspect_ratio="9:16", image_size="1920*1080")
+        w, h = (int(v) for v in size.split("x"))
+        assert w * 16 == h * 9 and w < h
+
+    @pytest.mark.parametrize("aspect", ["9:16", "16:9", "1:1", "3:4", "4:3", "2:3", "3:2"])
+    async def test_dims_multiple_of_8(self, tmp_path: Path, aspect: str):
+        size = await self._size(tmp_path, aspect_ratio=aspect)
+        w, h = (int(v) for v in size.split("x"))
+        assert w % 8 == 0 and h % 8 == 0
+        assert max(w, h) <= 2048
+
+
+class TestImageToImage:
+    async def test_i2i_reference_images_as_data_uri_list(self, tmp_path: Path):
+        client = _mock_client(_img_response())
+        download = AsyncMock()
+        refs = [_make_ref(tmp_path, f"r{i}.png") for i in range(2)]
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.agnes import AgnesImageBackend
+
+            b = AgnesImageBackend(api_key="sk")
+            await b.generate(
+                ImageGenerationRequest(prompt="hero", output_path=tmp_path / "o.png", reference_images=refs)
+            )
+
+        images = client.post.call_args.kwargs["json"]["image"]
+        assert isinstance(images, list)
+        assert len(images) == 2
+        assert all(item.startswith("data:image/png;base64,") for item in images)
+        # I2I 仍显式下发 size
+        assert "size" in client.post.call_args.kwargs["json"]
+
+    async def test_missing_ref_raises_unreadable(self, tmp_path: Path):
+        from lib.image_backends.agnes import AgnesImageBackend
+
+        b = AgnesImageBackend(api_key="sk")
+        with pytest.raises(ImageCapabilityError) as ei:
+            await b.generate(
+                ImageGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.png",
+                    reference_images=[ReferenceImage(path=str(tmp_path / "nope.png"))],
+                )
+            )
+        assert ei.value.code == "image_reference_images_unreadable"
+
+    async def test_empty_ref_path_treated_as_missing(self, tmp_path: Path):
+        from lib.image_backends.agnes import AgnesImageBackend
+
+        b = AgnesImageBackend(api_key="sk")
+        with pytest.raises(ImageCapabilityError) as ei:
+            await b.generate(
+                ImageGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.png", reference_images=[ReferenceImage(path="")]
+                )
+            )
+        assert ei.value.code == "image_reference_images_unreadable"
+
+
+class TestResponseHandling:
+    async def test_base64_response_decoded_and_saved(self, tmp_path: Path):
+        raw = b"\x89PNG\r\nhello-bytes"
+        b64 = base64.b64encode(raw).decode("ascii")
+        client = _mock_client(_b64_response(b64))
+        out = tmp_path / "o.png"
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.image_backends.agnes import AgnesImageBackend
+
+            b = AgnesImageBackend(api_key="sk")
+            result = await b.generate(ImageGenerationRequest(prompt="x", output_path=out))
+
+        assert out.read_bytes() == raw
+        # base64 路径无远端 URL
+        assert result.image_uri is None
+
+    async def test_base64_data_uri_prefix_stripped(self, tmp_path: Path):
+        raw = b"PNGDATA"
+        b64 = "data:image/png;base64," + base64.b64encode(raw).decode("ascii")
+        client = _mock_client(_b64_response(b64))
+        out = tmp_path / "o.png"
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.image_backends.agnes import AgnesImageBackend
+
+            b = AgnesImageBackend(api_key="sk")
+            await b.generate(ImageGenerationRequest(prompt="x", output_path=out))
+
+        assert out.read_bytes() == raw
+
+    async def test_empty_data_raises_runtime(self, tmp_path: Path):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"created": 1, "data": []}
+        client = _mock_client(resp)
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.agnes import AgnesImageBackend
+
+            b = AgnesImageBackend(api_key="sk")
+            with pytest.raises(RuntimeError):
+                await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
+
+
+class TestHttpErrors:
+    async def test_400_surfaces_httpstatuserror_single_call(self, tmp_path: Path):
+        client = _mock_client(_error_response(400))
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.agnes import AgnesImageBackend
+
+            b = AgnesImageBackend(api_key="sk")
+            with pytest.raises(httpx.HTTPStatusError) as ei:
+                await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
+        assert ei.value.response.status_code == 400
+        assert client.post.call_count == 1
+        download.assert_not_called()
+
+
+class TestRetryScope:
+    async def test_download_failure_does_not_retrigger_generation(self, tmp_path: Path, monkeypatch):
+        # 下载阶段瞬态失败只在下载层重试，绝不回退到重跑非幂等的生成 POST（防重复建图 + 重复计费）。
+        from lib.retry import DOWNLOAD_MAX_ATTEMPTS
+
+        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
+        client = _mock_client(_img_response())
+        download = AsyncMock(side_effect=httpx.ConnectError("conn reset"))
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.image_backends.agnes import AgnesImageBackend
+
+            b = AgnesImageBackend(api_key="sk")
+            with pytest.raises(httpx.ConnectError):
+                await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
+        # 生成 POST 恰好一次（计费一次）；重试全部发生在下载层
+        assert client.post.call_count == 1
+        assert download.call_count == DOWNLOAD_MAX_ATTEMPTS
+
+
+class TestPricing:
+    def test_per_image_flat_usd(self):
+        from lib.pricing.lookup import lookup_pricing
+        from lib.pricing.strategies import PricingParams, calculate_pricing
+        from lib.pricing.types import PerImageFlat
+
+        pricing = lookup_pricing(PROVIDER_AGNES, "agnes-image-2.1-flash", "image")
+        assert isinstance(pricing, PerImageFlat)
+        amount, currency = calculate_pricing(pricing, PricingParams(call_type="image", model="agnes-image-2.1-flash"))
+        assert amount == pytest.approx(0.003)
+        assert currency == "USD"

--- a/tests/test_agnes_image_backend.py
+++ b/tests/test_agnes_image_backend.py
@@ -32,7 +32,7 @@ def _b64_response(b64: str) -> MagicMock:
     return resp
 
 
-def _mock_client(resp: MagicMock) -> AsyncMock:
+def _mock_client(resp: MagicMock | httpx.Response) -> AsyncMock:
     client = AsyncMock()
     client.post = AsyncMock(return_value=resp)
     client.__aenter__ = AsyncMock(return_value=client)
@@ -46,18 +46,9 @@ def _make_ref(tmp_path: Path, name: str) -> ReferenceImage:
     return ReferenceImage(path=str(p))
 
 
-def _http_error(status_code: int, message: str) -> httpx.HTTPStatusError:
+def _error_response(status_code: int) -> httpx.Response:
     request = httpx.Request("POST", "https://x/v1/images/generations")
-    response = httpx.Response(status_code, request=request, text=message)
-    return httpx.HTTPStatusError(f"error {status_code}", request=request, response=response)
-
-
-def _error_response(status_code: int) -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status_code
-    resp.text = "boom"
-    resp.raise_for_status = MagicMock(side_effect=_http_error(status_code, "boom"))
-    return resp
+    return httpx.Response(status_code, request=request, text="boom")
 
 
 def _patches(client: AsyncMock, download: AsyncMock):

--- a/tests/test_agnes_shared.py
+++ b/tests/test_agnes_shared.py
@@ -56,3 +56,12 @@ class TestHeaders:
         h = agnes_headers("sk-abc")
         assert h["Authorization"] == "Bearer sk-abc"
         assert h["Content-Type"] == "application/json"
+
+    def test_strips_whitespace_key(self):
+        # 复用 resolve_agnes_api_key：构造头前先归一化，不把首尾空白带进 Bearer
+        assert agnes_headers("  sk-abc  ")["Authorization"] == "Bearer sk-abc"
+
+    def test_blank_key_raises(self):
+        # 空白 key 本地即 raise，不拼出 "Bearer " 拖到请求期才 401
+        with pytest.raises(ValueError):
+            agnes_headers("   ")

--- a/tests/test_agnes_shared.py
+++ b/tests/test_agnes_shared.py
@@ -1,0 +1,58 @@
+"""lib.agnes_shared 纯函数单元测试（不打真实 HTTP）。"""
+
+from __future__ import annotations
+
+import pytest
+
+from lib.agnes_shared import (
+    AGNES_BASE_URL,
+    agnes_base_url,
+    agnes_headers,
+    resolve_agnes_api_key,
+)
+
+
+class TestBaseUrlDerivation:
+    def test_default_base(self):
+        assert agnes_base_url(None) == AGNES_BASE_URL
+        assert AGNES_BASE_URL == "https://apihub.agnes-ai.com/v1"
+
+    def test_host_only_gets_v1_suffix(self):
+        # 用户只填 host，派生时补 /v1
+        assert agnes_base_url("https://apihub.agnes-ai.com") == "https://apihub.agnes-ai.com/v1"
+
+    def test_full_v1_base_is_idempotent(self):
+        assert agnes_base_url("https://apihub.agnes-ai.com/v1") == "https://apihub.agnes-ai.com/v1"
+
+    def test_trailing_slash_stripped(self):
+        assert agnes_base_url("https://apihub.agnes-ai.com/v1/") == "https://apihub.agnes-ai.com/v1"
+        assert agnes_base_url("https://apihub.agnes-ai.com/") == "https://apihub.agnes-ai.com/v1"
+
+    def test_custom_relay_host(self):
+        assert agnes_base_url("https://relay.example.com") == "https://relay.example.com/v1"
+
+    def test_whitespace_falls_back_to_default(self):
+        # 纯空白 base_url 是真值会绕过 or，须 strip 后回落默认 host，
+        # 不能 strip 成空串派生出 "/v1" 这类非法相对 URL
+        assert agnes_base_url("   ") == AGNES_BASE_URL
+
+
+class TestApiKeyResolution:
+    def test_strips_and_returns(self):
+        assert resolve_agnes_api_key("  sk-abc  ") == "sk-abc"
+
+    def test_missing_raises(self):
+        with pytest.raises(ValueError):
+            resolve_agnes_api_key(None)
+
+    def test_blank_raises(self):
+        # 不走 env fallback：缺失即明确报错
+        with pytest.raises(ValueError):
+            resolve_agnes_api_key("   ")
+
+
+class TestHeaders:
+    def test_bearer_and_content_type(self):
+        h = agnes_headers("sk-abc")
+        assert h["Authorization"] == "Bearer sk-abc"
+        assert h["Content-Type"] == "application/json"

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -13,6 +13,7 @@ def test_all_providers_registered():
         "dashscope",
         "minimax",
         "kling",
+        "agnes",
     }
 
 

--- a/tests/test_config_registry_models.py
+++ b/tests/test_config_registry_models.py
@@ -66,8 +66,8 @@ class TestProviderMeta:
 
 
 class TestProviderRegistry:
-    # vidu 仅图片+视频、kling 为仅身份注册（无 models），均跳过文本相关断言
-    _TEXT_PROVIDERS = [pid for pid in PROVIDER_REGISTRY if pid not in ("vidu", "kling")]
+    # vidu 仅图片+视频、kling 为仅身份注册（无 models）、agnes 当前仅图像，均跳过文本相关断言
+    _TEXT_PROVIDERS = [pid for pid in PROVIDER_REGISTRY if pid not in ("vidu", "kling", "agnes")]
 
     def test_all_providers_have_text_models(self):
         for provider_id in self._TEXT_PROVIDERS:

--- a/tests/test_pricing_lookup.py
+++ b/tests/test_pricing_lookup.py
@@ -12,6 +12,7 @@ from lib.config.registry import PROVIDER_REGISTRY
 from lib.pricing.lookup import lookup_pricing
 from lib.pricing.types import (
     PerImageByResolution,
+    PerImageFlat,
     PerImageOpenAIToken,
     PerSecondMatrix,
     PerToken,
@@ -93,6 +94,16 @@ class TestUnknownModelFallback:
         # 回落到 ark 默认视频模型（mini）
         assert "doubao-seedance-2-0-mini-260615" in pricing.rates
         assert any("no-such-model" in r.getMessage() for r in caplog.records)
+
+    def test_agnes_unknown_image_model_falls_back_to_own_default(self, caplog):
+        # agnes 有专属 PerImageFlat 表，未知 model 应回落 agnes 自有默认（$0.003 USD），
+        # 而非 Gemini 通用图像费率——故 agnes 须在 _OWN_TABLE_PROVIDERS 内。
+        with caplog.at_level(logging.WARNING, logger="lib.pricing.lookup"):
+            pricing = lookup_pricing("agnes", "agnes-image-2.0-unregistered", "image")
+        assert isinstance(pricing, PerImageFlat)
+        assert pricing.rates["agnes-image-2.1-flash"] == 0.003
+        assert pricing.currency == "USD"
+        assert any("agnes-image-2.0-unregistered" in r.getMessage() for r in caplog.records)
 
     def test_agent_plan_no_pricing_falls_back_to_gemini_quietly(self, caplog):
         with caplog.at_level(logging.WARNING, logger="lib.pricing.lookup"):


### PR DESCRIPTION
属 PRD #937 的「Agnes 基座 + 图像后端」切片。完成后用户在设置页可看到「Agnes」内置供应商，填 Bearer `api_key`（默认 base `https://apihub.agnes-ai.com/v1`），用 `agnes-image-2.1-flash` 出分镜图。

Closes #941

## 实现要点

**基座（被后续文本 / 视频模态复用）**
- `PROVIDER_AGNES` 常量；`agnes_shared` 共享模块（Bearer 单 key 解析、缺失即报错不走 env 兜底、base_url 归一化为 `{host}/v1`、Bearer header 构造），仿 MiniMax 单 key Bearer 模块。
- `PROVIDER_REGISTRY` 新增 `agnes` 条目（`required_keys/secret_keys=["api_key"]`、`optional_keys` 含 `base_url`、`default_base_url`）。
- `AGNES_API_KEY` 接入 env / 脱敏名单；`provider_name_agnes` / `provider_desc_agnes` 三语 i18n。

**图像模态**
- `AgnesImageBackend`：OpenAI 兼容 `POST /v1/images/generations` 同步端点，TEXT_TO_IMAGE + IMAGE_TO_IMAGE；`register_backend` + backend_assembly spec 接线（`_simple_spec` 透传 api_key/base_url/model）。
- registry 仅注册 `agnes-image-2.1-flash`（默认），不含 2.0（实测无差异，model 目录收敛）。
- 声明式定价：`PerImageFlat $0.003/img`（USD），复用现有 pricing kind。

## 独立审查与修复

未参与实现的干净上下文做了一遍 xhigh 审查（8 finder 角度 + 逐条 verifier），未发现高置信度回归。已就地修复两项：

1. **定价回落补全**（`lib/pricing/lookup.py`）：Agnes 声明了专属 `PerImageFlat` USD 费率表，却缺席 `_OWN_TABLE_PROVIDERS`（ark/grok/openai/dashscope/minimax/kling 均在内）。导致任何非注册的 agnes 图像 model（model 名漂移 / 未来模型）按 Gemini 默认图像费率计价而非 $0.003/img，统计与预估金额虚高。已补登记并加回落测试。
2. **抽取函数去重**（`lib/image_backends/agnes.py`）：合并 `data[].url` / `data[].b64_json` 两个近乎相同的抽取函数为单一 `_extract_first_str(payload, key)`。

已评估、本切片暂不处理（留 triage / 后续模态）：
- 连接测试派发：Agnes 未进 `server/routers/providers.py` 的 `_TEST_DISPATCH`（同 kling，「测试连接」返回 unsupported_test）。属切片边界，不在本 issue 验收标准内。
- 图像后端若干与 minimax 参考实现的辅助函数重复（base64 写盘、日志脱敏、base_url 归一化）：恰当去重需跨文件上提至 `base.py` / 重连 minimax，超出本切片范围，留作 OpenAI-compat 供应商统一重构。
- `_resolve_dimensions` 未做 minimax 式的最小边钳制 / max_ratio：需要 Agnes 真实最小边约束（未实测的外部数据），不臆造。

## 实测真值（勿改回）
- I2I 参考图经 `image: [data-uri]` 字段下发（实测 HTTP200 确认）。
- 不发 `response_format`（上游 litellm 网关报 UnsupportedParamsError 400）。

## 验证
- `uv run pytest tests/`：**5342 passed**（含新增 agnes 定价回落测试）。
- `uv run ruff check .`：clean；改动文件 `ruff format --check` 全过。
- `uv run basedpyright`：**0 errors**。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 Agnes 作为图像生成提供方：提供默认配置、Bearer 鉴权与图片生成能力。
  * 在界面及多语言文案中展示 Agnes 提供方名称与能力说明。
  * 为 Agnes 增加图像专属计价回落支持。
* **Bug 修复**
  * 优化参考图（I2I）读取与编码、图片结果下载/落盘回退（URL 与 base64）、以及尺寸推导与请求体参数下发规则。
* **测试**
  * 新增/更新单元测试，覆盖配置解析、鉴权、生成流程、错误传播与定价逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->