### PR TITLE
fix(text): 火山方舟结构化生成对违例 JSON 自动降级到带校验路径

### DIFF
--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -124,8 +124,15 @@ class ArkTextBackend:
                 logger.warning("原生 response_format %s，降级到带校验的 Instructor 路径", fallback_reason)
                 result = await self._structured_fallback(request, messages)
                 # 这次原生 200 调用已被代理计费，把它的 token 并入降级结果，否则会系统性漏记。
-                result.input_tokens = (result.input_tokens or 0) + (native.input_tokens or 0)
-                result.output_tokens = (result.output_tokens or 0) + (native.output_tokens or 0)
+                # 仅在至少一侧有计量时相加；两侧皆 None（未追踪）保持 None，不塌成字面 0 token。
+                if result.input_tokens is not None or native.input_tokens is not None:
+                    result.input_tokens = (result.input_tokens if result.input_tokens is not None else 0) + (
+                        native.input_tokens if native.input_tokens is not None else 0
+                    )
+                if result.output_tokens is not None or native.output_tokens is not None:
+                    result.output_tokens = (result.output_tokens if result.output_tokens is not None else 0) + (
+                        native.output_tokens if native.output_tokens is not None else 0
+                    )
                 return result
             return native
 

--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -93,7 +93,7 @@ class ArkTextBackend:
         messages = self._build_messages(request)
 
         if TextCapability.STRUCTURED_OUTPUT in self._capabilities:
-            from lib.text_backends.base import resolve_schema
+            from lib.text_backends.base import resolve_schema, structured_fallback_reason
 
             if request.response_schema is None:
                 raise ValueError("structured 模式要求 response_schema 非空")
@@ -111,9 +111,23 @@ class ArkTextBackend:
             logger.info("调用 %s 文本 SDK kwargs=%s", self.name, format_kwargs_for_log(kwargs))
             try:
                 response = await asyncio.to_thread(self._client.chat.completions.create, **kwargs)
-                return self._parse_chat_response(response)
+                native = self._parse_chat_response(response)
             except Exception as exc:
-                logger.warning("原生 response_format 失败 (%s)，降级到 Instructor/json_object 路径", exc)
+                logger.warning("原生 response_format 调用或解析失败 (%s)，降级到 Instructor/json_object 路径", exc)
+                return await self._structured_fallback(request, messages)
+
+            # 成功路径复验：HTTP 200 后校验返回是否真满足 schema，违例（非 JSON / 违反 schema）则降级。
+            # 不严格强制 schema 的模型/中转会返回违例 JSON，若直接放行会一路漏到下游校验才报错。
+            # ark 原生 response_format 未声明 strict，复验同样用 strict=False，避免对可强转值误判违例。
+            fallback_reason = structured_fallback_reason(native.text, request.response_schema, strict=False)
+            if fallback_reason:
+                logger.warning("原生 response_format %s，降级到带校验的 Instructor 路径", fallback_reason)
+                result = await self._structured_fallback(request, messages)
+                # 这次原生 200 调用已被代理计费，把它的 token 并入降级结果，否则会系统性漏记。
+                result.input_tokens = (result.input_tokens or 0) + (native.input_tokens or 0)
+                result.output_tokens = (result.output_tokens or 0) + (native.output_tokens or 0)
+                return result
+            return native
 
         return await self._structured_fallback(request, messages)
 

--- a/lib/text_backends/base.py
+++ b/lib/text_backends/base.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal, Protocol
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -125,6 +126,63 @@ def resolve_schema(schema: dict | type[BaseModel]) -> dict:
     result: dict = _inline(schema_dict)
     result.pop("$defs", None)
     return result
+
+
+def is_valid_json(text: str) -> bool:
+    """判断字符串是否为合法 JSON。
+
+    一些原生结构化通道（OpenAI 兼容代理、自定义供应商常见情况）会静默忽略结构化输出
+    参数并返回纯文本/markdown，需要据此触发降级。
+    """
+    if not text or not text.strip():
+        return False
+    try:
+        json.loads(text)
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def summarize_validation_error(exc: ValidationError) -> str:
+    """把 ValidationError 压成简短的字段定位摘要。
+
+    只取字段路径（loc）与错误数，**不含模型原始输入值**——后者可能很大且会把
+    模型生成内容写进日志（经诊断日志打包外泄），也避免单条日志膨胀到数 KB。
+    """
+    locs = [".".join(str(part) for part in err.get("loc", ())) or "<root>" for err in exc.errors()[:5]]
+    suffix = "…" if exc.error_count() > 5 else ""
+    return f"{exc.error_count()} 处字段不符（{', '.join(locs)}{suffix}）"
+
+
+def structured_fallback_reason(text: str, response_schema: dict | type | None, *, strict: bool = True) -> str | None:
+    """判断原生结构化调用 HTTP 200 的返回是否需要降级到带校验的路径。
+
+    与 provider / client 类型 / 原生 API 形态无关的纯函数，全文本后端共享。返回降级原因
+    （用于日志）；None 表示原生输出可直接采用。两类触发场景：
+
+    1. 返回非 JSON：供应商静默忽略结构化输出参数，吐出纯文本/markdown。
+    2. 返回违反 schema 的合法 JSON：供应商接受结构化输出参数却不真正强制 schema（国内中转 /
+       非原厂模型常见），枚举值非法或缺必填字段。此类违例 JSON 若直接放行，会一路漏到下游
+       Pydantic 校验或渲染处才抛裸 ValidationError。
+
+    ``strict`` 由调用方按各后端原生请求是否声明 strict 传入对齐：声明了 strict 的后端用
+    strict=True（可强转但类型不严格匹配的值，如 int 字段给 "30"，也判为未强制 schema）；
+    未声明 strict 的后端用 strict=False（容忍可强转值，只对真正无法满足 schema 的输出降级），
+    避免对供应商已接受的合法响应触发多余的计费降级调用。
+
+    仅 Pydantic 模型可做 schema 校验；dict schema 无对应模型，沿用「仅校验是否合法 JSON」的
+    既有行为，不额外收紧。
+    """
+    if isinstance(response_schema, type) and issubclass(response_schema, BaseModel):
+        # model_validate_json 单次解析即同时覆盖「非 JSON」与「违反 schema」两种情况。
+        try:
+            response_schema.model_validate_json(text, strict=strict)
+        except ValidationError as exc:
+            return f"返回内容不满足 response_schema（供应商可能未强制 schema）：{summarize_validation_error(exc)}"
+        return None
+    if not is_valid_json(text):
+        return "返回非 JSON 内容（供应商可能未支持结构化输出）"
+    return None
 
 
 class TextBackend(Protocol):

--- a/lib/text_backends/base.py
+++ b/lib/text_backends/base.py
@@ -171,8 +171,11 @@ def structured_fallback_reason(text: str, response_schema: dict | type | None, *
     避免对供应商已接受的合法响应触发多余的计费降级调用。
 
     仅 Pydantic 模型可做 schema 校验；dict schema 无对应模型，沿用「仅校验是否合法 JSON」的
-    既有行为，不额外收紧。
+    既有行为，不额外收紧。response_schema 为 None（无结构化输出诉求）直接视为无需降级。
     """
+    if response_schema is None:
+        # 纯文本生成无结构化诉求，原生输出直接采用，不能按「非 JSON」误判触发降级。
+        return None
     if isinstance(response_schema, type) and issubclass(response_schema, BaseModel):
         # model_validate_json 单次解析即同时覆盖「非 JSON」与「违反 schema」两种情况。
         try:

--- a/lib/text_backends/base.py
+++ b/lib/text_backends/base.py
@@ -148,8 +148,11 @@ def summarize_validation_error(exc: ValidationError) -> str:
 
     只取字段路径（loc）与错误数，**不含模型原始输入值**——后者可能很大且会把
     模型生成内容写进日志（经诊断日志打包外泄），也避免单条日志膨胀到数 KB。
+    用 include_input=False 在源头剔除 input，不让原始值进入 error dict（防御纵深）。
     """
-    locs = [".".join(str(part) for part in err.get("loc", ())) or "<root>" for err in exc.errors()[:5]]
+    locs = [
+        ".".join(str(part) for part in err.get("loc", ())) or "<root>" for err in exc.errors(include_input=False)[:5]
+    ]
     suffix = "…" if exc.error_count() > 5 else ""
     return f"{exc.error_count()} 处字段不符（{', '.join(locs)}{suffix}）"
 

--- a/lib/text_backends/openai.py
+++ b/lib/text_backends/openai.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import json
 import logging
 
 from openai import AsyncOpenAI, BadRequestError
-from pydantic import BaseModel, ValidationError
 
 from lib.config.url_utils import is_official_openai_base_url
 from lib.logging_utils import format_kwargs_for_log
@@ -19,6 +17,7 @@ from lib.text_backends.base import (
     TextGenerationResult,
     TokenParam,
     resolve_schema,
+    structured_fallback_reason,
     warn_if_truncated,
 )
 
@@ -119,7 +118,7 @@ class OpenAITextBackend:
         text = choice.message.content or ""
 
         if request.response_schema:
-            fallback_reason = _structured_fallback_reason(text, request.response_schema)
+            fallback_reason = structured_fallback_reason(text, request.response_schema)
             if fallback_reason:
                 logger.warning(
                     "原生 response_format %s，降级到带校验的 Instructor 路径",
@@ -188,59 +187,6 @@ _SCHEMA_ERROR_KEYWORDS = (
     "Cannot find field",
     "Invalid JSON payload",
 )
-
-
-def _is_valid_json(text: str) -> bool:
-    """判断字符串是否为合法 JSON。
-
-    一些 OpenAI 兼容代理（自定义供应商常见情况）会静默忽略 response_format
-    参数并返回纯文本/markdown，需要据此触发 Instructor 降级。
-    """
-    if not text or not text.strip():
-        return False
-    try:
-        json.loads(text)
-        return True
-    except (ValueError, TypeError):
-        return False
-
-
-def _structured_fallback_reason(text: str, response_schema: dict | type | None) -> str | None:
-    """判断原生 response_format 的返回是否需要降级到带校验的 Instructor 路径。
-
-    返回降级原因（用于日志）；None 表示原生输出可直接采用。两类触发场景：
-
-    1. 返回非 JSON：代理静默忽略 response_format，吐出纯文本/markdown。
-    2. 返回违反 schema 的合法 JSON：代理接受 response_format 参数却不真正强制
-       schema（国内中转 / 非 OpenAI 模型常见），枚举值非法或缺必填字段。此类
-       违例 JSON 若直接放行，会一路漏到下游 Pydantic 校验才抛裸 ValidationError。
-
-    仅 Pydantic 模型可做 schema 校验；dict schema 无对应模型，沿用「仅校验是否合法
-    JSON」的既有行为，不额外收紧。
-    """
-    if isinstance(response_schema, type) and issubclass(response_schema, BaseModel):
-        # model_validate_json 单次解析即同时覆盖「非 JSON」与「违反 schema」两种情况；
-        # strict=True 与原生请求的 response_format.json_schema.strict=True 对齐——代理若
-        # 返回可强转但类型不严格匹配的 JSON（如 int 字段给 "30"），同样判定为未强制 schema。
-        try:
-            response_schema.model_validate_json(text, strict=True)
-        except ValidationError as exc:
-            return f"返回内容不满足 response_schema（代理可能未强制 schema）：{_summarize_validation_error(exc)}"
-        return None
-    if not _is_valid_json(text):
-        return "返回非 JSON 内容（代理可能未支持 response_format）"
-    return None
-
-
-def _summarize_validation_error(exc: ValidationError) -> str:
-    """把 ValidationError 压成简短的字段定位摘要。
-
-    只取字段路径（loc）与错误数，**不含模型原始输入值**——后者可能很大且会把
-    模型生成内容写进日志（经 /system/logs/download 外泄），也避免单条日志膨胀到数 KB。
-    """
-    locs = [".".join(str(part) for part in err.get("loc", ())) or "<root>" for err in exc.errors()[:5]]
-    suffix = "…" if exc.error_count() > 5 else ""
-    return f"{exc.error_count()} 处字段不符（{', '.join(locs)}{suffix}）"
 
 
 def _is_schema_error(exc: BaseException) -> bool:

--- a/tests/test_text_backends/test_ark.py
+++ b/tests/test_text_backends/test_ark.py
@@ -377,6 +377,33 @@ class TestSuccessPathReverify:
         assert result.input_tokens == 10
         assert result.output_tokens == 5
 
+    async def test_both_usages_none_preserves_none_not_zero(self, backend, sync_to_thread):
+        """原生与 Instructor 计量皆 None → 合并后保持 None（未追踪），不塌成字面 0。"""
+        from pydantic import BaseModel
+
+        class Person(BaseModel):
+            name: str
+            age: int
+
+        # 原生 200 返回非 JSON 触发降级，且原生 usage 缺失
+        mock_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="## markdown not json"))],
+            usage=None,
+        )
+        backend._test_client.chat.completions.create = MagicMock(return_value=mock_resp)
+
+        instructor_result = Person(name="Bob", age=25)
+        completion = SimpleNamespace(usage=None)
+        mock_patched = MagicMock()
+        mock_patched.chat.completions.create_with_completion = MagicMock(return_value=(instructor_result, completion))
+
+        with patch("instructor.from_openai", return_value=mock_patched):
+            result = await backend.generate(TextGenerationRequest(prompt="x", response_schema=Person))
+
+        assert result.text == instructor_result.model_dump_json()
+        assert result.input_tokens is None
+        assert result.output_tokens is None
+
     async def test_valid_json_satisfying_schema_no_fallback(self, backend, sync_to_thread):
         """原生 200 + 满足 schema 的 JSON → 直接采用，不降级。"""
         from pydantic import BaseModel

--- a/tests/test_text_backends/test_ark.py
+++ b/tests/test_text_backends/test_ark.py
@@ -308,6 +308,199 @@ class TestCapabilityAwareStructured:
         backend_with_structured._openai_client.chat.completions.create.assert_called_once()
 
 
+class TestSuccessPathReverify:
+    """原生 200 后复验 schema：违例则降级带校验路径，并合并原生计费 token。"""
+
+    @pytest.fixture
+    def backend(self, mock_ark):
+        _, mock_client = mock_ark
+        b = ArkTextBackend(api_key="k", model="mock-model-with-structured")
+        b._test_client = mock_client
+        b._capabilities.add(TextCapability.STRUCTURED_OUTPUT)
+        return b
+
+    async def test_violating_json_pydantic_triggers_fallback_with_token_merge(self, backend, sync_to_thread):
+        """原生 200 + 违反 Pydantic schema 的 JSON → 降级 + token 合并。"""
+        import json
+
+        from pydantic import BaseModel
+
+        class Person(BaseModel):
+            name: str
+            age: int
+
+        violating = json.dumps({"name": "Alice", "age": "三十"}, ensure_ascii=False)
+        mock_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=violating))],
+            usage=SimpleNamespace(prompt_tokens=100, completion_tokens=60),
+        )
+        backend._test_client.chat.completions.create = MagicMock(return_value=mock_resp)
+
+        instructor_result = Person(name="Alice", age=30)
+        completion = SimpleNamespace(usage=SimpleNamespace(prompt_tokens=80, completion_tokens=30))
+        mock_patched = MagicMock()
+        mock_patched.chat.completions.create_with_completion = MagicMock(return_value=(instructor_result, completion))
+
+        with patch("instructor.from_openai", return_value=mock_patched):
+            result = await backend.generate(TextGenerationRequest(prompt="x", response_schema=Person))
+
+        assert result.text == instructor_result.model_dump_json()
+        # 原生 200 调用（100/60）已被代理计费，与 Instructor 调用（80/30）合并
+        assert result.input_tokens == 180
+        assert result.output_tokens == 90
+        backend._test_client.chat.completions.create.assert_called_once()
+
+    async def test_non_json_triggers_fallback(self, backend, sync_to_thread):
+        """原生 200 + 非 JSON（代理静默忽略 response_format）→ 降级。"""
+        from pydantic import BaseModel
+
+        class Person(BaseModel):
+            name: str
+            age: int
+
+        mock_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="## markdown not json"))],
+            usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5),
+        )
+        backend._test_client.chat.completions.create = MagicMock(return_value=mock_resp)
+
+        instructor_result = Person(name="Bob", age=25)
+        completion = SimpleNamespace(usage=None)
+        mock_patched = MagicMock()
+        mock_patched.chat.completions.create_with_completion = MagicMock(return_value=(instructor_result, completion))
+
+        with patch("instructor.from_openai", return_value=mock_patched):
+            result = await backend.generate(TextGenerationRequest(prompt="x", response_schema=Person))
+
+        assert result.text == instructor_result.model_dump_json()
+        # Instructor usage 为 None，结果 token 即原生 200 调用计费量（10/5）
+        assert result.input_tokens == 10
+        assert result.output_tokens == 5
+
+    async def test_valid_json_satisfying_schema_no_fallback(self, backend, sync_to_thread):
+        """原生 200 + 满足 schema 的 JSON → 直接采用，不降级。"""
+        from pydantic import BaseModel
+
+        class Person(BaseModel):
+            name: str
+            age: int
+
+        import json
+
+        valid = json.dumps({"name": "Alice", "age": 30})
+        mock_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=valid))],
+            usage=SimpleNamespace(prompt_tokens=20, completion_tokens=10),
+        )
+        backend._test_client.chat.completions.create = MagicMock(return_value=mock_resp)
+
+        with patch("instructor.from_openai") as mock_from_openai:
+            result = await backend.generate(TextGenerationRequest(prompt="x", response_schema=Person))
+
+        assert result.text == valid
+        assert result.input_tokens == 20
+        assert result.output_tokens == 10
+        mock_from_openai.assert_not_called()
+
+    async def test_dict_schema_non_json_falls_back_to_json_object_with_token_merge(self, backend, sync_to_thread):
+        """dict schema 原生 200 返回非 JSON → json_object 降级，并合并原生 token。"""
+        mock_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="not json"))],
+            usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5),
+        )
+        backend._test_client.chat.completions.create = MagicMock(return_value=mock_resp)
+
+        fb = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content='{"key": "value"}'))],
+            usage=SimpleNamespace(prompt_tokens=30, completion_tokens=15),
+        )
+        backend._openai_client.chat.completions.create = MagicMock(return_value=fb)
+
+        result = await backend.generate(TextGenerationRequest(prompt="x", response_schema={"type": "object"}))
+
+        assert result.text == '{"key": "value"}'
+        # 原生 10/5 与 json_object 降级 30/15 合并
+        assert result.input_tokens == 40
+        assert result.output_tokens == 20
+        call_kwargs = backend._openai_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["response_format"] == {"type": "json_object"}
+
+    async def test_dict_schema_valid_json_no_fallback(self, backend, sync_to_thread):
+        """dict schema 原生 200 + 合法 JSON（即便违反声明类型）→ 不降级。"""
+        import json
+
+        violating = json.dumps({"key": "value", "age": "thirty"})
+        mock_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=violating))],
+            usage=SimpleNamespace(prompt_tokens=20, completion_tokens=10),
+        )
+        backend._test_client.chat.completions.create = MagicMock(return_value=mock_resp)
+        backend._openai_client.chat.completions.create = MagicMock()
+
+        result = await backend.generate(
+            TextGenerationRequest(
+                prompt="x",
+                response_schema={"type": "object", "properties": {"age": {"type": "integer"}}},
+            )
+        )
+
+        assert result.text == violating
+        backend._openai_client.chat.completions.create.assert_not_called()
+
+    async def test_coercible_value_does_not_trigger_fallback(self, backend, sync_to_thread):
+        """原生 200 + 可强转值（int 字段给 "30"）→ 不降级。
+
+        ark 原生 response_format 未声明 strict，复验同样 strict=False，容忍可强转值，
+        避免对供应商已接受的合法响应触发多余的计费降级调用。
+        """
+        import json
+
+        from pydantic import BaseModel
+
+        class Person(BaseModel):
+            name: str
+            age: int
+
+        coercible = json.dumps({"name": "Alice", "age": "30"})
+        mock_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=coercible))],
+            usage=SimpleNamespace(prompt_tokens=20, completion_tokens=10),
+        )
+        backend._test_client.chat.completions.create = MagicMock(return_value=mock_resp)
+
+        with patch("instructor.from_openai") as mock_from_openai:
+            result = await backend.generate(TextGenerationRequest(prompt="x", response_schema=Person))
+
+        assert result.text == coercible
+        assert result.input_tokens == 20
+        assert result.output_tokens == 10
+        mock_from_openai.assert_not_called()
+
+    async def test_empty_choices_on_200_falls_back(self, backend, sync_to_thread):
+        """原生 200 但 choices 为空（中转/内容审核）→ 解析异常被 catch → 降级，不逃逸。"""
+        from pydantic import BaseModel
+
+        class Person(BaseModel):
+            name: str
+            age: int
+
+        mock_resp = SimpleNamespace(choices=[], usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5))
+        backend._test_client.chat.completions.create = MagicMock(return_value=mock_resp)
+
+        instructor_result = Person(name="Bob", age=25)
+        completion = SimpleNamespace(usage=SimpleNamespace(prompt_tokens=80, completion_tokens=30))
+        mock_patched = MagicMock()
+        mock_patched.chat.completions.create_with_completion = MagicMock(return_value=(instructor_result, completion))
+
+        with patch("instructor.from_openai", return_value=mock_patched):
+            result = await backend.generate(TextGenerationRequest(prompt="x", response_schema=Person))
+
+        # 解析异常落入 except → 降级路径，返回带校验结果（不并入原生 token：原生未成功解析）
+        assert result.text == instructor_result.model_dump_json()
+        assert result.input_tokens == 80
+        assert result.output_tokens == 30
+
+
 class TestBaseUrl:
     def test_custom_base_url_passes_to_both_clients(self):
         with patch("lib.text_backends.ark.create_ark_client") as mock_ark_create:

--- a/tests/test_text_backends/test_base.py
+++ b/tests/test_text_backends/test_base.py
@@ -245,6 +245,14 @@ class TestStructuredFallbackReason:
 
         assert structured_fallback_reason("not json", {"type": "object"}) is not None
 
+    def test_none_schema_never_triggers_fallback(self):
+        from lib.text_backends.base import structured_fallback_reason
+
+        # response_schema 为 None（纯文本生成）时，纯文本不得被误判为需降级
+        assert structured_fallback_reason("plain text, not json", None) is None
+        assert structured_fallback_reason('{"a": 1}', None) is None
+        assert structured_fallback_reason("", None) is None
+
 
 class TestIsValidJson:
     def test_valid(self):

--- a/tests/test_text_backends/test_base.py
+++ b/tests/test_text_backends/test_base.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+from pydantic import BaseModel
+
 from lib.text_backends.base import (
     ImageInput,
     TextBackend,
@@ -162,6 +164,122 @@ class TestTextBackendProtocol:
         assert backend.name == "fake"
         assert backend.model == "fake-model"
         assert TextCapability.TEXT_GENERATION in backend.capabilities
+
+
+class _Person(BaseModel):
+    name: str
+    age: int
+
+
+class TestStructuredFallbackReason:
+    """共享复验纯函数：openai/ark/gemini 复用同一实现。"""
+
+    def test_valid_json_satisfying_pydantic_returns_none(self):
+        import json
+
+        from lib.text_backends.base import structured_fallback_reason
+
+        assert structured_fallback_reason(json.dumps({"name": "A", "age": 30}), _Person) is None
+
+    def test_non_json_returns_reason(self):
+        from lib.text_backends.base import structured_fallback_reason
+
+        reason = structured_fallback_reason("## markdown not json", _Person)
+        assert reason is not None
+        assert "JSON" in reason or "schema" in reason
+
+    def test_schema_violating_json_returns_reason(self):
+        import json
+
+        from lib.text_backends.base import structured_fallback_reason
+
+        # 合法 JSON 但 age 为中文字符串、违反 int 约束
+        violating = json.dumps({"name": "A", "age": "三十"}, ensure_ascii=False)
+        assert structured_fallback_reason(violating, _Person) is not None
+
+    def test_coercible_but_non_strict_returns_reason(self):
+        import json
+
+        from lib.text_backends.base import structured_fallback_reason
+
+        # strict=True 下 "30" 不被强转为 30，判定为未强制 schema
+        assert structured_fallback_reason(json.dumps({"name": "A", "age": "30"}), _Person) is not None
+
+    def test_strict_false_tolerates_coercible_returns_none(self):
+        import json
+
+        from lib.text_backends.base import structured_fallback_reason
+
+        # strict=False（对齐未声明 strict 的后端）容忍可强转值 "30"，不触发降级
+        assert structured_fallback_reason(json.dumps({"name": "A", "age": "30"}), _Person, strict=False) is None
+
+    def test_strict_false_still_flags_genuine_violation(self):
+        import json
+
+        from lib.text_backends.base import structured_fallback_reason
+
+        # strict=False 仍对真正无法满足 schema 的输出降级：不可强转的 int + 缺必填字段
+        non_coercible = json.dumps({"name": "A", "age": "三十"}, ensure_ascii=False)
+        assert structured_fallback_reason(non_coercible, _Person, strict=False) is not None
+        assert structured_fallback_reason(json.dumps({"name": "A"}), _Person, strict=False) is not None
+
+    def test_missing_required_field_returns_reason(self):
+        import json
+
+        from lib.text_backends.base import structured_fallback_reason
+
+        assert structured_fallback_reason(json.dumps({"name": "A"}), _Person) is not None
+
+    def test_dict_schema_valid_json_returns_none(self):
+        import json
+
+        from lib.text_backends.base import structured_fallback_reason
+
+        # dict schema 仅校验是否合法 JSON，即便类型违反声明也不收紧
+        violating = json.dumps({"name": "A", "age": "thirty"})
+        schema = {"type": "object", "properties": {"name": {"type": "string"}, "age": {"type": "integer"}}}
+        assert structured_fallback_reason(violating, schema) is None
+
+    def test_dict_schema_non_json_returns_reason(self):
+        from lib.text_backends.base import structured_fallback_reason
+
+        assert structured_fallback_reason("not json", {"type": "object"}) is not None
+
+
+class TestIsValidJson:
+    def test_valid(self):
+        from lib.text_backends.base import is_valid_json
+
+        assert is_valid_json('{"a": 1}') is True
+
+    def test_empty_and_whitespace(self):
+        from lib.text_backends.base import is_valid_json
+
+        assert is_valid_json("") is False
+        assert is_valid_json("   ") is False
+
+    def test_non_json(self):
+        from lib.text_backends.base import is_valid_json
+
+        assert is_valid_json("hello") is False
+
+
+class TestSummarizeValidationError:
+    def test_no_raw_input_in_summary(self):
+        import json
+
+        from pydantic import ValidationError
+
+        from lib.text_backends.base import summarize_validation_error
+
+        try:
+            _Person.model_validate_json(json.dumps({"name": "A", "age": "三十"}, ensure_ascii=False), strict=True)
+            raise AssertionError("应抛 ValidationError")
+        except ValidationError as exc:
+            summary = summarize_validation_error(exc)
+        assert "age" in summary
+        # 摘要不含模型原始输入值
+        assert "三十" not in summary
 
 
 class TestWarnIfTruncated:


### PR DESCRIPTION
## 背景

文本后端结构化生成走「原生结构化调用 → 降级」两段式。openai 后端在原生 `response_format` 调用 HTTP 200 后会复验返回是否真满足 `response_schema`，违例（非 JSON、或违反 schema 的合法 JSON）则降级到带校验的 Instructor 路径。火山方舟（ark）走同形态的 OpenAI 兼容调用，但此前**只在原生调用抛异常时降级**，HTTP 200 成功路径直接解析返回、不复验——经不严格强制 schema 的模型/中转时，违例 JSON 被当成功结果返回，一路漏到下游 Pydantic 校验或渲染处才报错。

## 本 PR 交付

- **复验判定上移为全后端共享纯函数** `base.structured_fallback_reason(text, response_schema, *, strict)`：与 provider / client 类型 / 原生 API 形态无关，openai 复用同一实现，未来新后端可直接调用。配套 `is_valid_json`、`summarize_validation_error`（错误摘要只取字段路径与错误数，不含模型原始输入值，避免经诊断日志外泄）一并上移。
- **火山方舟成功路径新增复验**：HTTP 200 后校验返回是否真满足 schema，违例则降级到带校验的 Instructor 路径，原生已计费 token 并入降级结果，不再把违例 JSON 当成功返回。
- **复验严格度按各后端原生请求是否声明 strict 对齐**：openai 原生声明 strict 用 `strict=True`；ark 原生未声明用 `strict=False`，容忍供应商已接受的可强转值（如 int 字段给 `"30"`），只对真正无法满足 schema 的输出降级，避免触发多余的计费降级调用。
- **修复 ark 成功路径解析异常不降级的回归**：原生响应解析移回 `try` 内，恢复「200 但 choices 为空（中转/内容审核）等解析异常 → 降级」覆盖。

## 范围说明（Part of #906）

部分交付。issue 还要求 gemini 成功路径经 `instructor.from_genai` 降级，但该方案在本仓库**不可行**，本 PR 不含 gemini 改动、保持其原有行为：

- instructor 的 google-genai 适配器（TOOLS 与 JSON 两种 mode）都依赖未声明的 `jsonref` 包（仓库未安装、lock 文件中不存在），降级会在任何网络调用前硬失败；
- 即便补上依赖，该适配器把 enum 建模为字符串数组，无法表达原生路径专门工程化的整数 enum 硬约束（如 `duration_seconds` 的 `Literal[4,6,8]`），对主力剧集 schema 仍会失败。

gemini 降级需改用原生 google.genai `response_json_schema` 通道做「校验 → 修复重试」（该通道支持整数 enum），属设计层改动，拆为独立 follow-up；上游 issue 保持开放待定夺。

## 验证

- `pytest tests/test_text_backends/`（含火山方舟成功路径复验/降级/计费合并、可强转值不误触发、空 choices 解析异常降级，及共享纯函数 strict 行为）+ `tests/test_i18n_consistency.py`：123 passed
- `ruff check` / `ruff format`：clean
- `basedpyright`：0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 结构化输出在原生返回成功后，会再次校验内容是否满足目标 schema；若不符合则自动降级到更稳妥的结构化路径。
* **Bug 修复**
  * 修复降级时 token 统计可能被错误归零：当两次调用均有用量时会合并；在任一侧缺失用量时不会用字面 0 填充。
  * 改进对非 JSON、schema 校验失败与空/异常结果的降级触发，更加准确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->