### PR TITLE
feat(providers): 自定义供应商可单独配置图片/视频/音频并发上限

### DIFF
--- a/alembic/versions/a7a9749a1ae0_add_max_workers_columns_to_custom_.py
+++ b/alembic/versions/a7a9749a1ae0_add_max_workers_columns_to_custom_.py
@@ -22,19 +22,37 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     """Upgrade schema.
 
-    Additive nullable per-lane concurrency columns. No backfill — existing rows
-    are correct with NULL (NULL = unset → capacity loader falls back to global
-    default), and none of the columns participates in any WHERE/filter.
+    Additive nullable per-lane concurrency columns with DB-level non-negative
+    CHECK constraints. No backfill — existing rows are correct with NULL
+    (NULL = unset → capacity loader falls back to global default), and none of
+    the columns participates in any WHERE/filter. The CHECK constraints enforce
+    the NULL/0/positive semantics at the storage layer so repo writes and manual
+    SQL cannot persist negative worker counts.
     """
     with op.batch_alter_table("custom_provider", schema=None) as batch_op:
         batch_op.add_column(sa.Column("image_max_workers", sa.Integer(), nullable=True))
         batch_op.add_column(sa.Column("video_max_workers", sa.Integer(), nullable=True))
         batch_op.add_column(sa.Column("audio_max_workers", sa.Integer(), nullable=True))
+        batch_op.create_check_constraint(
+            "ck_custom_provider_image_max_workers_non_negative",
+            "image_max_workers IS NULL OR image_max_workers >= 0",
+        )
+        batch_op.create_check_constraint(
+            "ck_custom_provider_video_max_workers_non_negative",
+            "video_max_workers IS NULL OR video_max_workers >= 0",
+        )
+        batch_op.create_check_constraint(
+            "ck_custom_provider_audio_max_workers_non_negative",
+            "audio_max_workers IS NULL OR audio_max_workers >= 0",
+        )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
     with op.batch_alter_table("custom_provider", schema=None) as batch_op:
+        batch_op.drop_constraint("ck_custom_provider_audio_max_workers_non_negative", type_="check")
+        batch_op.drop_constraint("ck_custom_provider_video_max_workers_non_negative", type_="check")
+        batch_op.drop_constraint("ck_custom_provider_image_max_workers_non_negative", type_="check")
         batch_op.drop_column("audio_max_workers")
         batch_op.drop_column("video_max_workers")
         batch_op.drop_column("image_max_workers")

--- a/alembic/versions/a7a9749a1ae0_add_max_workers_columns_to_custom_.py
+++ b/alembic/versions/a7a9749a1ae0_add_max_workers_columns_to_custom_.py
@@ -1,0 +1,40 @@
+"""add max_workers columns to custom_provider
+
+Revision ID: a7a9749a1ae0
+Revises: 7fb52d06b50e
+Create Date: 2026-06-29 10:56:55.664949
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a7a9749a1ae0"
+down_revision: str | Sequence[str] | None = "7fb52d06b50e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Additive nullable per-lane concurrency columns. No backfill — existing rows
+    are correct with NULL (NULL = unset → capacity loader falls back to global
+    default), and none of the columns participates in any WHERE/filter.
+    """
+    with op.batch_alter_table("custom_provider", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("image_max_workers", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("video_max_workers", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("audio_max_workers", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("custom_provider", schema=None) as batch_op:
+        batch_op.drop_column("audio_max_workers")
+        batch_op.drop_column("video_max_workers")
+        batch_op.drop_column("image_max_workers")

--- a/docs/adr/0042-custom-provider-concurrency-typed-columns.md
+++ b/docs/adr/0042-custom-provider-concurrency-typed-columns.md
@@ -1,0 +1,18 @@
+---
+status: accepted
+---
+
+# 自定义供应商并发上限用按 lane 命名的定型列存储，不用 JSON / kv / 子表
+
+内置供应商的并发上限已走 `provider_credential` / `ProviderConfig` 的 `image_max_workers` / `video_max_workers` / `audio_max_workers` 配置键，由 `CapacityTable.from_db` 装载、按 lane 投影成容量表。自定义供应商（`custom_provider` 表，运行时 id 形如 `custom-{id}`）此前在 `from_db` 里一律套全局默认，用户无法为某个自定义供应商单独限并发——与内置供应商不对称。
+
+我们决定**给 `custom_provider` 表新增按 lane 命名的定型列** `image_max_workers` / `video_max_workers` / `audio_max_workers`（nullable Integer），`NULL` 表示「未设置 → 走全局默认」。`CapacityTable.from_db` 装载自定义供应商时逐列取值，`NULL` 即回退全局默认（替代原先一律套全局默认的逻辑）；投影仍走 `_lane_limits`，复用三层回退切片建立的语义。自定义供应商不在内置注册表 `PROVIDER_REGISTRY`，没有「供应商声明默认」中间层，故其回退为两层（用户列值 → 全局默认），而非内置供应商的三层。**明确不采用**：① 通用 JSON `extra` 列（要补逐字段读改写与校验管线，单字段并发读改写复杂，ADR 0016 已嫌弃，本场景仅三个标量上限不划算）；② KV 配置表（自定义供应商配置不进 `ProviderConfig` 的预置供应商 KV 体系，复用要给 resolver 开特例、绕过本表的单一真相）；③ 并发字段子表（为三个标量上限引入一张表 + join，机械量最大）。
+
+这是 YAGNI 取舍：当前只需三条固定 lane 的整数上限，字段集稳定、与内置供应商对称，定型列直接、可索引、迁移最简，与 ADR 0037（内置 provider 多 secret 定型列）同构——同样是「字段集已知且稳定时优先定型列、把 JSON / 子表留给真正动态的场景」。
+
+## Consequences
+
+- **列稀疏显式接受**：三列对未配并发的自定义供应商恒为 `NULL`（多数行如此）；靠本 ADR 与 `from_db` 的两层回退注释解释，不视作待清理的死字段。
+- **重构触发点**：当自定义供应商需要 per-model 并发、或 lane 维度从固定三条变为动态可扩展时，应重新评估升级到 JSON `extra` 列或并发字段子表——届时是有依据的重构，本 ADR 转 superseded。
+- **改动收敛**：模型 + 一条 additive nullable 加列迁移（无 backfill，三列不进任何 `WHERE`）、`CustomProviderRepository.create_provider` / `update_provider` 透传、CRUD schema（POST / PUT 请求体 + 响应回显）、`CapacityTable.from_db` 自定义供应商接线、设置页表单三个可空 number 输入。不改 SlotTable 占用台账、lane 隔离、reload 机制；不引入 per-model 并发。
+- **守住既有边界**：上承三层回退切片（自定义供应商为其两层特例）与 ADR 0037（字段集稳定时用定型列）。任何后续 PR 想改用 JSON / kv / 子表须先 deprecate 本 ADR。

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1891,7 +1891,7 @@ class API {
     return this.request(`/custom-providers/${id}`);
   }
 
-  static async updateCustomProvider(id: number, data: Partial<Omit<CustomProviderCreateRequest, "discovery_format" | "models">>): Promise<void> {
+  static async updateCustomProvider(id: number, data: Partial<Omit<CustomProviderCreateRequest, "discovery_format" | "models" | "image_max_workers" | "video_max_workers" | "audio_max_workers">>): Promise<void> {
     return this.request(`/custom-providers/${id}`, { method: "PATCH", body: JSON.stringify(data) });
   }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -34,6 +34,7 @@ import type {
   CustomProviderInfo,
   CustomProviderModelInfo,
   CustomProviderCreateRequest,
+  CustomProviderFullUpdateRequest,
   CustomProviderModelInput,
   DiscoveredModel,
   EndpointDescriptor,
@@ -1894,7 +1895,7 @@ class API {
     return this.request(`/custom-providers/${id}`, { method: "PATCH", body: JSON.stringify(data) });
   }
 
-  static async fullUpdateCustomProvider(id: number, data: { display_name: string; base_url: string; api_key?: string; models: CustomProviderModelInput[] }): Promise<CustomProviderInfo> {
+  static async fullUpdateCustomProvider(id: number, data: CustomProviderFullUpdateRequest): Promise<CustomProviderInfo> {
     return this.request(`/custom-providers/${id}`, { method: "PUT", body: JSON.stringify(data) });
   }
 

--- a/frontend/src/components/agent/__tests__/AddCredentialModal.test.tsx
+++ b/frontend/src/components/agent/__tests__/AddCredentialModal.test.tsx
@@ -306,6 +306,9 @@ describe("AddCredentialModal", () => {
       api_key_masked: "sk-abcd…1234",
       models: [],
       created_at: "2026-05-11T00:00:00Z",
+      image_max_workers: null,
+      video_max_workers: null,
+      audio_max_workers: null,
     };
 
     it("hides import button when no custom providers configured", async () => {

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -133,11 +133,15 @@ function workersToStr(n?: number | null): string {
   return n != null ? String(n) : "";
 }
 
-function parseWorkers(s: string): number | null {
+// 空串 = 未设置（null，走全局默认）；否则必须是非负整数。返回 undefined 表示非法
+// 输入（小数、科学计数、负号、含非数字字符），由 handleSave 拦截并提示——不再用 parseInt
+// 静默截断（"1.5"→1、"1e3"→1）把非法值写成错误配置。
+function parseWorkers(s: string): number | null | undefined {
   const trimmed = s.trim();
   if (!trimmed) return null;
-  const n = parseInt(trimmed, 10);
-  return Number.isNaN(n) ? null : n;
+  if (!/^\d+$/.test(trimmed)) return undefined;
+  const n = Number(trimmed);
+  return Number.isSafeInteger(n) ? n : undefined;
 }
 
 function WorkersInput({
@@ -406,6 +410,14 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
       }
       return;
     }
+    // 并发上限严格解析：非法（小数/科学计数/负号/非数字）→ undefined，阻断保存并提示
+    const imageMax = parseWorkers(imageMaxWorkers);
+    const videoMax = parseWorkers(videoMaxWorkers);
+    const audioMax = parseWorkers(audioMaxWorkers);
+    if (imageMax === undefined || videoMax === undefined || audioMax === undefined) {
+      showError(t("max_workers_invalid"));
+      return;
+    }
     setSaving(true);
     try {
       if (isEdit && existing) {
@@ -415,9 +427,9 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
           base_url: baseUrl,
           ...(apiKey ? { api_key: apiKey } : {}),
           models: payloadModels,
-          image_max_workers: parseWorkers(imageMaxWorkers),
-          video_max_workers: parseWorkers(videoMaxWorkers),
-          audio_max_workers: parseWorkers(audioMaxWorkers),
+          image_max_workers: imageMax,
+          video_max_workers: videoMax,
+          audio_max_workers: audioMax,
         });
       } else {
         await API.createCustomProvider({
@@ -426,9 +438,9 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
           base_url: baseUrl,
           api_key: apiKey,
           models: payloadModels,
-          image_max_workers: parseWorkers(imageMaxWorkers),
-          video_max_workers: parseWorkers(videoMaxWorkers),
-          audio_max_workers: parseWorkers(audioMaxWorkers),
+          image_max_workers: imageMax,
+          video_max_workers: videoMax,
+          audio_max_workers: audioMax,
         });
       }
       onSaved();

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -128,6 +128,50 @@ function rowToInput(r: ModelRow): CustomProviderModelInput {
   };
 }
 
+// 并发上限：number 输入用受控字符串存储；空串 = 未设置（null，走全局默认）。
+function workersToStr(n?: number | null): string {
+  return n != null ? String(n) : "";
+}
+
+function parseWorkers(s: string): number | null {
+  const trimmed = s.trim();
+  if (!trimmed) return null;
+  const n = parseInt(trimmed, 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+function WorkersInput({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+}) {
+  return (
+    <div className="min-w-[110px]">
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <input
+        id={id}
+        type="number"
+        min={0}
+        step={1}
+        inputMode="numeric"
+        autoComplete="off"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className={`${INPUT_CLS} max-w-[120px]`}
+      />
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // DurationsInputRow — 视频模型行内的 supported_durations 输入
 // ---------------------------------------------------------------------------
@@ -226,6 +270,9 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
   const [models, setModels] = useState<ModelRow[]>(
     existing ? existing.models.map(existingToRow) : [],
   );
+  const [imageMaxWorkers, setImageMaxWorkers] = useState(workersToStr(existing?.image_max_workers));
+  const [videoMaxWorkers, setVideoMaxWorkers] = useState(workersToStr(existing?.video_max_workers));
+  const [audioMaxWorkers, setAudioMaxWorkers] = useState(workersToStr(existing?.audio_max_workers));
 
   // --- Loading / status ---
   const [discovering, setDiscovering] = useState(false);
@@ -368,6 +415,9 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
           base_url: baseUrl,
           ...(apiKey ? { api_key: apiKey } : {}),
           models: payloadModels,
+          image_max_workers: parseWorkers(imageMaxWorkers),
+          video_max_workers: parseWorkers(videoMaxWorkers),
+          audio_max_workers: parseWorkers(audioMaxWorkers),
         });
       } else {
         await API.createCustomProvider({
@@ -376,6 +426,9 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
           base_url: baseUrl,
           api_key: apiKey,
           models: payloadModels,
+          image_max_workers: parseWorkers(imageMaxWorkers),
+          video_max_workers: parseWorkers(videoMaxWorkers),
+          audio_max_workers: parseWorkers(audioMaxWorkers),
         });
       }
       onSaved();
@@ -384,7 +437,21 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
     } finally {
       setSaving(false);
     }
-  }, [displayName, discoveryFormat, baseUrl, apiKey, models, isEdit, existing, onSaved, showError, t]);
+  }, [
+    displayName,
+    discoveryFormat,
+    baseUrl,
+    apiKey,
+    models,
+    imageMaxWorkers,
+    videoMaxWorkers,
+    audioMaxWorkers,
+    isEdit,
+    existing,
+    onSaved,
+    showError,
+    t,
+  ]);
 
   // --- Model row helpers ---
   const updateModel = (key: string, patch: Partial<ModelRow>) => {
@@ -732,6 +799,37 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
             </button>
           </div>
         )}
+
+        {/* Concurrency limits */}
+        <div>
+          <div className="mb-1 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-accent-2">
+            {t("cp_concurrency_label")}
+          </div>
+          <p className="mb-3 text-[11px] text-text-4">{t("cp_concurrency_help")}</p>
+          <div className="flex flex-wrap gap-4">
+            <WorkersInput
+              id="cp-image-workers"
+              label={t("cp_image_max_workers_label")}
+              value={imageMaxWorkers}
+              onChange={setImageMaxWorkers}
+              placeholder={t("cp_max_workers_placeholder")}
+            />
+            <WorkersInput
+              id="cp-video-workers"
+              label={t("cp_video_max_workers_label")}
+              value={videoMaxWorkers}
+              onChange={setVideoMaxWorkers}
+              placeholder={t("cp_max_workers_placeholder")}
+            />
+            <WorkersInput
+              id="cp-audio-workers"
+              label={t("cp_audio_max_workers_label")}
+              value={audioMaxWorkers}
+              onChange={setAudioMaxWorkers}
+              placeholder={t("cp_max_workers_placeholder")}
+            />
+          </div>
+        </div>
 
         {/* Test result */}
         {testResult && (

--- a/frontend/src/components/shared/ImageModelDualSelect.test.tsx
+++ b/frontend/src/components/shared/ImageModelDualSelect.test.tsx
@@ -46,6 +46,9 @@ const CUSTOM_PROVIDERS: CustomProviderInfo[] = [
     base_url: "https://x.example.com",
     api_key_masked: "sk-***",
     created_at: "2026-01-01T00:00:00Z",
+    image_max_workers: null,
+    video_max_workers: null,
+    audio_max_workers: null,
     models: [
       {
         id: 1,

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -782,6 +782,12 @@ export default {
   'fill_api_key': 'Please fill in API Key',
   'enable_one_model': 'At least one model must be enabled',
   'enabled_model_needs_id': 'Enabled models must have a model_id',
+  'cp_concurrency_label': 'Concurrency Limits',
+  'cp_concurrency_help': 'Max concurrent tasks per media lane (image / video / audio). Leave blank to use the global default.',
+  'cp_image_max_workers_label': 'Image Concurrency',
+  'cp_video_max_workers_label': 'Video Concurrency',
+  'cp_audio_max_workers_label': 'Audio Concurrency',
+  'cp_max_workers_placeholder': 'Default',
 
   // CustomProviderDetail
   'discovery_format_label': 'Model Discovery Protocol',

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -788,6 +788,7 @@ export default {
   'cp_video_max_workers_label': 'Video Concurrency',
   'cp_audio_max_workers_label': 'Audio Concurrency',
   'cp_max_workers_placeholder': 'Default',
+  'max_workers_invalid': 'Concurrency limits must be non-negative integers. Check the image / video / audio inputs.',
 
   // CustomProviderDetail
   'discovery_format_label': 'Model Discovery Protocol',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -759,6 +759,12 @@ export default {
   'fill_api_key': 'Vui lòng điền khóa API',
   'enable_one_model': 'Phải bật ít nhất một mô hình',
   'enabled_model_needs_id': 'Mô hình đã bật phải có model_id',
+  'cp_concurrency_label': 'Giới hạn đồng thời',
+  'cp_concurrency_help': 'Số tác vụ đồng thời tối đa cho mỗi luồng phương tiện (ảnh / video / âm thanh). Để trống để dùng mặc định toàn cục.',
+  'cp_image_max_workers_label': 'Đồng thời ảnh',
+  'cp_video_max_workers_label': 'Đồng thời video',
+  'cp_audio_max_workers_label': 'Đồng thời âm thanh',
+  'cp_max_workers_placeholder': 'Mặc định',
 
   // CustomProviderDetail
   'discovery_format_label': 'Giao thức phát hiện mô hình',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -765,6 +765,7 @@ export default {
   'cp_video_max_workers_label': 'Đồng thời video',
   'cp_audio_max_workers_label': 'Đồng thời âm thanh',
   'cp_max_workers_placeholder': 'Mặc định',
+  'max_workers_invalid': 'Giới hạn đồng thời phải là số nguyên không âm. Kiểm tra ô nhập hình ảnh / video / âm thanh.',
 
   // CustomProviderDetail
   'discovery_format_label': 'Giao thức phát hiện mô hình',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -789,6 +789,7 @@ export default {
   'cp_video_max_workers_label': '视频并发',
   'cp_audio_max_workers_label': '音频并发',
   'cp_max_workers_placeholder': '默认',
+  'max_workers_invalid': '并发上限必须为非负整数，请检查图片 / 视频 / 音频并发输入。',
 
   // CustomProviderDetail
   'discovery_format_label': '模型发现协议',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -783,6 +783,12 @@ export default {
   'fill_api_key': '请填写 API Key',
   'enable_one_model': '至少启用一个模型',
   'enabled_model_needs_id': '已启用的模型必须填写 model_id',
+  'cp_concurrency_label': '并发上限',
+  'cp_concurrency_help': '各媒体通道（图片 / 视频 / 音频）的最大并发任务数。留空则使用全局默认。',
+  'cp_image_max_workers_label': '图片并发',
+  'cp_video_max_workers_label': '视频并发',
+  'cp_audio_max_workers_label': '音频并发',
+  'cp_max_workers_placeholder': '默认',
 
   // CustomProviderDetail
   'discovery_format_label': '模型发现协议',

--- a/frontend/src/stores/config-status-store.test.ts
+++ b/frontend/src/stores/config-status-store.test.ts
@@ -167,6 +167,9 @@ describe("config-status-store", () => {
           base_url: "http://localhost:8000/v1",
           api_key_masked: "sk-***",
           created_at: "2026-01-01T00:00:00Z",
+          image_max_workers: null,
+          video_max_workers: null,
+          audio_max_workers: null,
           models: [
             {
               id: 1,

--- a/frontend/src/types/custom-provider.ts
+++ b/frontend/src/types/custom-provider.ts
@@ -26,6 +26,10 @@ export interface CustomProviderInfo {
   api_key_masked: string;
   models: CustomProviderModelInfo[];
   created_at: string;
+  /** 各 lane 并发上限；null = 未设置（走全局默认）。 */
+  image_max_workers: number | null;
+  video_max_workers: number | null;
+  audio_max_workers: number | null;
 }
 
 export interface CustomProviderModelInfo {
@@ -57,6 +61,21 @@ export interface CustomProviderCreateRequest {
   base_url: string;
   api_key: string;
   models: CustomProviderModelInput[];
+  /** 各 lane 并发上限；省略或 null = 未设置（走全局默认）。 */
+  image_max_workers?: number | null;
+  video_max_workers?: number | null;
+  audio_max_workers?: number | null;
+}
+
+export interface CustomProviderFullUpdateRequest {
+  display_name: string;
+  base_url: string;
+  api_key?: string;
+  models: CustomProviderModelInput[];
+  /** PUT 为并发上限权威来源：null 即清除（走全局默认）。 */
+  image_max_workers?: number | null;
+  video_max_workers?: number | null;
+  audio_max_workers?: number | null;
 }
 
 export interface CustomProviderModelInput {

--- a/frontend/src/types/custom-provider.ts
+++ b/frontend/src/types/custom-provider.ts
@@ -72,10 +72,11 @@ export interface CustomProviderFullUpdateRequest {
   base_url: string;
   api_key?: string;
   models: CustomProviderModelInput[];
-  /** PUT 为并发上限权威来源：null 即清除（走全局默认）。 */
-  image_max_workers?: number | null;
-  video_max_workers?: number | null;
-  audio_max_workers?: number | null;
+  /** PUT 为并发上限权威来源：必填，null 即清除（走全局默认）。省略字段会被服务端当作
+   *  清空，故类型上设为必填，防止调用方静默漏传意外清掉已有配置。 */
+  image_max_workers: number | null;
+  video_max_workers: number | null;
+  audio_max_workers: number | null;
 }
 
 export interface CustomProviderModelInput {

--- a/lib/db/models/custom_provider.py
+++ b/lib/db/models/custom_provider.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlalchemy import Boolean, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, CheckConstraint, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from lib.db.base import Base, TimestampMixin
@@ -12,6 +12,22 @@ class CustomProvider(TimestampMixin, Base):
     """用户自定义的 AI 供应商。"""
 
     __tablename__ = "custom_provider"
+    # 与加列迁移保持同步：三条并发上限列在 DB 层强制非负，repo 直写或手工 SQL 都无法
+    # 写入负值；NULL=未设置回退默认、0=该 lane 不支持仍然合法。
+    __table_args__ = (
+        CheckConstraint(
+            "image_max_workers IS NULL OR image_max_workers >= 0",
+            name="ck_custom_provider_image_max_workers_non_negative",
+        ),
+        CheckConstraint(
+            "video_max_workers IS NULL OR video_max_workers >= 0",
+            name="ck_custom_provider_video_max_workers_non_negative",
+        ),
+        CheckConstraint(
+            "audio_max_workers IS NULL OR audio_max_workers >= 0",
+            name="ck_custom_provider_audio_max_workers_non_negative",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     display_name: Mapped[str] = mapped_column(String(128), nullable=False)

--- a/lib/db/models/custom_provider.py
+++ b/lib/db/models/custom_provider.py
@@ -18,6 +18,11 @@ class CustomProvider(TimestampMixin, Base):
     discovery_format: Mapped[str] = mapped_column(String(32), nullable=False)  # "openai" | "google"
     base_url: Mapped[str] = mapped_column(Text, nullable=False)
     api_key: Mapped[str] = mapped_column(Text, nullable=False)  # sensitive, masked in API responses
+    # 按 lane 命名的并发上限定型列；NULL = 未设置 → 容量装载回退全局默认。自定义供应商不在
+    # 内置注册表，故无声明默认层，回退为两层（用户列值 → 全局默认）。
+    image_max_workers: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    video_max_workers: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    audio_max_workers: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     @property
     def provider_id(self) -> str:

--- a/lib/db/repositories/custom_provider_repo.py
+++ b/lib/db/repositories/custom_provider_repo.py
@@ -20,6 +20,10 @@ class CustomProviderRepository(BaseRepository):
         base_url: str,
         api_key: str,
         models: list[dict] | None = None,
+        *,
+        image_max_workers: int | None = None,
+        video_max_workers: int | None = None,
+        audio_max_workers: int | None = None,
     ) -> CustomProvider:
         """创建供应商，可选同时创建模型列表。"""
         provider = CustomProvider(
@@ -27,6 +31,9 @@ class CustomProviderRepository(BaseRepository):
             discovery_format=discovery_format,
             base_url=base_url,
             api_key=api_key,
+            image_max_workers=image_max_workers,
+            video_max_workers=video_max_workers,
+            audio_max_workers=audio_max_workers,
         )
         self.session.add(provider)
         await self.session.flush()  # 获取 provider.id

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -191,7 +191,12 @@ class CapacityTable:
             for provider, models in await repo.list_providers_with_models():
                 pid = provider.provider_id  # "custom-{id}"
                 media_types = {endpoint_to_media_type(m.endpoint) for m in models if m.is_enabled}
-                limits[pid] = cls._lane_limits(media_types, default_image, default_video, default_audio)
+                # 自定义供应商不在内置注册表，无声明默认层 → 两层回退：列有值取列值，
+                # 列为 NULL 走全局默认。投影仍交给 _lane_limits 统一处理不支持的 lane。
+                image_max = provider.image_max_workers if provider.image_max_workers is not None else default_image
+                video_max = provider.video_max_workers if provider.video_max_workers is not None else default_video
+                audio_max = provider.audio_max_workers if provider.audio_max_workers is not None else default_audio
+                limits[pid] = cls._lane_limits(media_types, image_max, video_max, audio_max)
 
         logger.info("从 DB 加载供应商容量表: %s", limits)
         return cls(

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import AfterValidator, BaseModel
+from pydantic import AfterValidator, BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lib.config.repository import mask_secret
@@ -43,6 +43,9 @@ def _validate_endpoint(value: str) -> str:
 # 响应路径不需校验，直接 str。
 EndpointType = Annotated[str, AfterValidator(_validate_endpoint)]
 DiscoveryFormatLiteral = Literal["openai", "google"]
+
+# 并发上限定型字段：可空非负整数；None = 未设置 → 容量装载回退全局默认。
+MaxWorkers = Annotated[int | None, Field(default=None, ge=0)]
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +125,9 @@ class CreateProviderRequest(BaseModel):
     base_url: str
     api_key: str
     models: list[ModelInput] = []
+    image_max_workers: MaxWorkers
+    video_max_workers: MaxWorkers
+    audio_max_workers: MaxWorkers
 
 
 class UpdateProviderRequest(BaseModel):
@@ -137,6 +143,10 @@ class FullUpdateProviderRequest(BaseModel):
     base_url: str
     api_key: str | None = None  # None = 不修改
     models: list[ModelInput]
+    # 并发上限随 PUT 全量提交（空输入 → None → 全局默认）；None 即清除，非"不修改"。
+    image_max_workers: MaxWorkers
+    video_max_workers: MaxWorkers
+    audio_max_workers: MaxWorkers
 
 
 class ProviderConnectionRequest(BaseModel):
@@ -173,6 +183,9 @@ class ProviderResponse(BaseModel):
     api_key_masked: str
     models: list[ModelResponse]
     created_at: str | None = None
+    image_max_workers: int | None = None
+    video_max_workers: int | None = None
+    audio_max_workers: int | None = None
 
 
 class ConnectionTestResponse(BaseModel):
@@ -243,6 +256,9 @@ def _provider_to_response(provider, models) -> ProviderResponse:
         api_key_masked=mask_secret(provider.api_key),
         models=[_model_to_response(m) for m in models],
         created_at=dt_to_iso(provider.created_at),
+        image_max_workers=provider.image_max_workers,
+        video_max_workers=provider.video_max_workers,
+        audio_max_workers=provider.audio_max_workers,
     )
 
 
@@ -382,6 +398,9 @@ async def create_provider(
         base_url=body.base_url,
         api_key=body.api_key,
         models=model_dicts,
+        image_max_workers=body.image_max_workers,
+        video_max_workers=body.video_max_workers,
+        audio_max_workers=body.audio_max_workers,
     )
     await session.commit()
     await _invalidate_caches(request)
@@ -474,7 +493,14 @@ async def full_update_provider(
     _check_duplicate_model_ids(body.models, _t)
     _check_unique_defaults(body.models, _t)
     repo = CustomProviderRepository(session)
-    kwargs: dict = {"display_name": body.display_name, "base_url": body.base_url}
+    kwargs: dict = {
+        "display_name": body.display_name,
+        "base_url": body.base_url,
+        # PUT 为并发上限的权威来源：始终写入（含 None 清除），不做"仅非空更新"
+        "image_max_workers": body.image_max_workers,
+        "video_max_workers": body.video_max_workers,
+        "audio_max_workers": body.audio_max_workers,
+    }
     if body.api_key is not None:
         kwargs["api_key"] = body.api_key
     provider = await repo.update_provider(provider_id, **kwargs)

--- a/tests/test_alembic_custom_provider_max_workers.py
+++ b/tests/test_alembic_custom_provider_max_workers.py
@@ -1,0 +1,118 @@
+"""Alembic 迁移：custom_provider 三个并发上限定型列的 upgrade / downgrade。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.config import Config
+
+from alembic import command
+
+
+@pytest.fixture
+def alembic_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Config:
+    """指向项目 alembic 脚本，DB 用临时 sqlite（env.py 经 DATABASE_URL 读取）。
+
+    刻意不传 alembic.ini 路径：env.py 在 config_file_name 为 None 时跳过 fileConfig()，
+    避免 alembic.ini 的 logging section 在测试中重置 root logger。
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = Config()
+    cfg.set_main_option("script_location", str(repo_root / "alembic"))
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    cfg.attributes["_test_db_path"] = str(db_path)
+    return cfg
+
+
+@pytest.fixture
+def revisions() -> tuple[str, str]:
+    """读出加列迁移的 (revision, down_revision)。"""
+    repo_root = Path(__file__).resolve().parent.parent
+    versions_dir = repo_root / "alembic" / "versions"
+    matches = list(versions_dir.glob("*_add_max_workers_columns_to_custom_.py"))
+    assert len(matches) == 1, f"找到 {len(matches)} 个加列迁移文件，期望 1"
+    text = matches[0].read_text()
+    revision: str | None = None
+    down_revision: str | None = None
+    for line in text.splitlines():
+        if line.startswith("revision: str ="):
+            revision = line.split("=")[1].strip().strip('"').strip("'")
+        elif line.startswith("down_revision:"):
+            down_revision = line.split("=")[1].strip().strip('"').strip("'")
+    if not revision or not down_revision:
+        raise RuntimeError("未在迁移文件中找到 revision / down_revision")
+    return revision, down_revision
+
+
+_COLS = ("image_max_workers", "video_max_workers", "audio_max_workers")
+
+
+def _columns(engine: sa.Engine) -> set[str]:
+    with engine.begin() as conn:
+        rows = conn.execute(sa.text("PRAGMA table_info(custom_provider)")).fetchall()
+    return {r[1] for r in rows}
+
+
+def test_upgrade_adds_columns_existing_row_null(alembic_cfg: Config, revisions: tuple[str, str]):
+    """升到加列前插一行，升级后三列存在且该行为 NULL（零回归）。"""
+    revision_id, parent_id = revisions
+    command.upgrade(alembic_cfg, parent_id)
+
+    db_path = alembic_cfg.attributes["_test_db_path"]
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        assert not (set(_COLS) & _columns(engine)), "加列前不应存在并发列"
+        with engine.begin() as conn:
+            conn.execute(
+                sa.text(
+                    "INSERT INTO custom_provider "
+                    "(id, display_name, discovery_format, base_url, api_key, created_at, updated_at) "
+                    "VALUES (1, 'P', 'openai', 'https://x', 'k', "
+                    "'2026-06-29 00:00:00', '2026-06-29 00:00:00')"
+                )
+            )
+
+        command.upgrade(alembic_cfg, revision_id)
+
+        assert set(_COLS) <= _columns(engine)
+        with engine.begin() as conn:
+            row = conn.execute(
+                sa.text(
+                    "SELECT image_max_workers, video_max_workers, audio_max_workers FROM custom_provider WHERE id = 1"
+                )
+            ).fetchone()
+        assert row == (None, None, None)
+    finally:
+        engine.dispose()
+
+
+def test_downgrade_drops_columns(alembic_cfg: Config, revisions: tuple[str, str]):
+    """downgrade 回退后三列消失，其余数据保留。"""
+    revision_id, parent_id = revisions
+    command.upgrade(alembic_cfg, revision_id)
+
+    db_path = alembic_cfg.attributes["_test_db_path"]
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                sa.text(
+                    "INSERT INTO custom_provider "
+                    "(id, display_name, discovery_format, base_url, api_key, "
+                    "image_max_workers, created_at, updated_at) "
+                    "VALUES (1, 'P', 'openai', 'https://x', 'k', 3, "
+                    "'2026-06-29 00:00:00', '2026-06-29 00:00:00')"
+                )
+            )
+
+        command.downgrade(alembic_cfg, parent_id)
+
+        assert not (set(_COLS) & _columns(engine))
+        with engine.begin() as conn:
+            name = conn.execute(sa.text("SELECT display_name FROM custom_provider WHERE id = 1")).scalar_one()
+        assert name == "P"
+    finally:
+        engine.dispose()

--- a/tests/test_alembic_custom_provider_max_workers.py
+++ b/tests/test_alembic_custom_provider_max_workers.py
@@ -89,6 +89,41 @@ def test_upgrade_adds_columns_existing_row_null(alembic_cfg: Config, revisions: 
         engine.dispose()
 
 
+@pytest.mark.parametrize("col", _COLS)
+def test_upgrade_rejects_negative_workers(alembic_cfg: Config, revisions: tuple[str, str], col: str):
+    """升级后三列各带非负 CHECK 约束，写入负值被 DB 拒绝；NULL 与 0 仍合法。"""
+    revision_id, _ = revisions
+    command.upgrade(alembic_cfg, revision_id)
+
+    db_path = alembic_cfg.attributes["_test_db_path"]
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        # 失败写入放在非自动提交连接里，约束触发即回滚，不污染后续断言
+        with engine.connect() as conn, pytest.raises(sa.exc.IntegrityError):
+            conn.execute(
+                sa.text(
+                    "INSERT INTO custom_provider "
+                    f"(id, display_name, discovery_format, base_url, api_key, {col}, created_at, updated_at) "
+                    "VALUES (1, 'P', 'openai', 'https://x', 'k', -1, "
+                    "'2026-06-29 00:00:00', '2026-06-29 00:00:00')"
+                )
+            )
+        # 0 与 NULL 合法
+        with engine.begin() as conn:
+            conn.execute(
+                sa.text(
+                    "INSERT INTO custom_provider "
+                    f"(id, display_name, discovery_format, base_url, api_key, {col}, created_at, updated_at) "
+                    "VALUES (2, 'P', 'openai', 'https://x', 'k', 0, "
+                    "'2026-06-29 00:00:00', '2026-06-29 00:00:00')"
+                )
+            )
+            value = conn.execute(sa.text(f"SELECT {col} FROM custom_provider WHERE id = 2")).scalar_one()
+        assert value == 0
+    finally:
+        engine.dispose()
+
+
 def test_downgrade_drops_columns(alembic_cfg: Config, revisions: tuple[str, str]):
     """downgrade 回退后三列消失，其余数据保留。"""
     revision_id, parent_id = revisions

--- a/tests/test_custom_provider_models.py
+++ b/tests/test_custom_provider_models.py
@@ -38,7 +38,18 @@ class TestCustomProviderTable:
             columns = await conn.run_sync(
                 lambda sync_conn: {c["name"] for c in inspect(sync_conn).get_columns("custom_provider")}
             )
-        expected = {"id", "display_name", "discovery_format", "base_url", "api_key", "created_at", "updated_at"}
+        expected = {
+            "id",
+            "display_name",
+            "discovery_format",
+            "base_url",
+            "api_key",
+            "image_max_workers",
+            "video_max_workers",
+            "audio_max_workers",
+            "created_at",
+            "updated_at",
+        }
         assert columns == expected
 
 

--- a/tests/test_custom_provider_repo.py
+++ b/tests/test_custom_provider_repo.py
@@ -221,6 +221,21 @@ class TestConcurrencyColumns:
         assert got.image_max_workers is None
         assert got.video_max_workers == 4
 
+    @pytest.mark.parametrize("field", ["image_max_workers", "video_max_workers", "audio_max_workers"])
+    async def test_create_negative_workers_rejected_by_check_constraint(self, session: AsyncSession, field: str):
+        """DB 层 CHECK 约束拦截负值，repo 直写也无法绕过（create_provider 内部 flush 即触发）。"""
+        from sqlalchemy.exc import IntegrityError
+
+        repo = CustomProviderRepository(session)
+        with pytest.raises(IntegrityError):
+            await repo.create_provider(
+                display_name="P",
+                discovery_format="openai",
+                base_url="https://x",
+                api_key="k",
+                **{field: -1},
+            )
+
 
 class TestModelManagement:
     async def _make_provider(self, repo: CustomProviderRepository, session: AsyncSession) -> int:

--- a/tests/test_custom_provider_repo.py
+++ b/tests/test_custom_provider_repo.py
@@ -168,6 +168,60 @@ class TestProviderCRUD:
         await repo.delete_provider(999)
 
 
+class TestConcurrencyColumns:
+    async def test_create_without_workers_defaults_to_null(self, session: AsyncSession):
+        repo = CustomProviderRepository(session)
+        p = await repo.create_provider(
+            display_name="P",
+            discovery_format="openai",
+            base_url="https://x",
+            api_key="k",
+        )
+        await session.flush()
+        got = await repo.get_provider(p.id)
+        assert got is not None
+        assert got.image_max_workers is None
+        assert got.video_max_workers is None
+        assert got.audio_max_workers is None
+
+    async def test_create_with_workers_round_trip(self, session: AsyncSession):
+        repo = CustomProviderRepository(session)
+        p = await repo.create_provider(
+            display_name="P",
+            discovery_format="openai",
+            base_url="https://x",
+            api_key="k",
+            image_max_workers=2,
+            video_max_workers=7,
+            audio_max_workers=0,
+        )
+        await session.flush()
+        got = await repo.get_provider(p.id)
+        assert got is not None
+        assert got.image_max_workers == 2
+        assert got.video_max_workers == 7
+        assert got.audio_max_workers == 0
+
+    async def test_update_workers_including_clear_to_null(self, session: AsyncSession):
+        repo = CustomProviderRepository(session)
+        p = await repo.create_provider(
+            display_name="P",
+            discovery_format="openai",
+            base_url="https://x",
+            api_key="k",
+            image_max_workers=5,
+        )
+        await session.flush()
+
+        await repo.update_provider(p.id, image_max_workers=None, video_max_workers=4)
+        await session.flush()
+
+        got = await repo.get_provider(p.id)
+        assert got is not None
+        assert got.image_max_workers is None
+        assert got.video_max_workers == 4
+
+
 class TestModelManagement:
     async def _make_provider(self, repo: CustomProviderRepository, session: AsyncSession) -> int:
         p = await repo.create_provider(

--- a/tests/test_custom_providers_api.py
+++ b/tests/test_custom_providers_api.py
@@ -979,6 +979,94 @@ class TestFullUpdateProvider:
         assert resp.status_code == 404
 
 
+class TestConcurrencyFields:
+    """image/video/audio_max_workers 经 POST / PUT 保存后回显，留空 → null，负值 → 422。"""
+
+    def test_create_echoes_workers(self, client: TestClient):
+        with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
+            resp = client.post(
+                "/api/v1/custom-providers",
+                json={
+                    "display_name": "P",
+                    "discovery_format": "openai",
+                    "base_url": "https://x.com",
+                    "api_key": "sk-test-key-12345678",
+                    "models": [],
+                    "image_max_workers": 2,
+                    "video_max_workers": 7,
+                    "audio_max_workers": 0,
+                },
+            )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["image_max_workers"] == 2
+        assert body["video_max_workers"] == 7
+        assert body["audio_max_workers"] == 0
+
+    def test_create_defaults_to_null_when_omitted(self, client: TestClient):
+        with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
+            resp = client.post(
+                "/api/v1/custom-providers",
+                json={
+                    "display_name": "P",
+                    "discovery_format": "openai",
+                    "base_url": "https://x.com",
+                    "api_key": "sk-test-key-12345678",
+                    "models": [],
+                },
+            )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["image_max_workers"] is None
+        assert body["video_max_workers"] is None
+        assert body["audio_max_workers"] is None
+
+    def test_create_rejects_negative(self, client: TestClient):
+        resp = client.post(
+            "/api/v1/custom-providers",
+            json={
+                "display_name": "P",
+                "discovery_format": "openai",
+                "base_url": "https://x.com",
+                "api_key": "sk-test-key-12345678",
+                "models": [],
+                "image_max_workers": -1,
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_full_update_overwrites_and_clears(self, client: TestClient):
+        with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
+            create_resp = client.post(
+                "/api/v1/custom-providers",
+                json={
+                    "display_name": "P",
+                    "discovery_format": "openai",
+                    "base_url": "https://x.com",
+                    "api_key": "sk-test-key-12345678",
+                    "models": [],
+                    "image_max_workers": 3,
+                    "video_max_workers": 4,
+                },
+            )
+            pid = create_resp.json()["id"]
+            # PUT 不带 image_max_workers → 视为 null（权威清除）；video 覆盖为 9
+            resp = client.put(
+                f"/api/v1/custom-providers/{pid}",
+                json={
+                    "display_name": "P",
+                    "base_url": "https://x.com",
+                    "models": [],
+                    "video_max_workers": 9,
+                },
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["image_max_workers"] is None
+        assert body["video_max_workers"] == 9
+        assert body["audio_max_workers"] is None
+
+
 class TestValidateBackendValueCustomPrefix:
     """回归: validate_backend_value 应接受 custom-* 前缀。"""
 

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -273,8 +273,12 @@ class TestCapacityTable:
                 assert table.get(pid, "video") == 0
 
     @staticmethod
-    def _stub_from_db_sources(monkeypatch, configs: dict[str, dict[str, str]]) -> None:
-        """把 from_db 的两个数据源（provider config / 自定义供应商）替换为内存数据。"""
+    def _stub_from_db_sources(monkeypatch, configs: dict[str, dict[str, str]], custom_providers=None) -> None:
+        """把 from_db 的两个数据源（provider config / 自定义供应商）替换为内存数据。
+
+        custom_providers：``list_providers_with_models`` 的返回值，形如
+        ``[(provider, models), ...]``；默认空。
+        """
         from unittest.mock import AsyncMock, MagicMock
 
         for env in ("IMAGE_MAX_WORKERS", "VIDEO_MAX_WORKERS", "AUDIO_MAX_WORKERS"):
@@ -294,8 +298,65 @@ class TestCapacityTable:
         )
         monkeypatch.setattr(
             "lib.db.repositories.custom_provider_repo.CustomProviderRepository.list_providers_with_models",
-            AsyncMock(return_value=[]),
+            AsyncMock(return_value=custom_providers or []),
         )
+
+    @staticmethod
+    def _fake_custom_provider(pid: str, *, image=None, video=None, audio=None, endpoints=("openai-images",)):
+        """构造 ``(provider, models)`` 元组，供 list_providers_with_models 返回。"""
+        from types import SimpleNamespace
+
+        provider = SimpleNamespace(
+            provider_id=pid,
+            image_max_workers=image,
+            video_max_workers=video,
+            audio_max_workers=audio,
+        )
+        models = [SimpleNamespace(endpoint=ep, is_enabled=True) for ep in endpoints]
+        return provider, models
+
+    async def test_from_db_custom_provider_columns_used(self, monkeypatch):
+        """自定义供应商：列有值 → 取列值（投影到其支持的 lane）。"""
+        self._stub_from_db_sources(
+            monkeypatch,
+            {},
+            custom_providers=[
+                self._fake_custom_provider(
+                    "custom-1",
+                    image=2,
+                    video=7,
+                    endpoints=("openai-images", "newapi-video"),
+                )
+            ],
+        )
+
+        table = await CapacityTable.from_db()
+
+        assert table.get("custom-1", "image") == 2
+        assert table.get("custom-1", "video") == 7
+        # 不支持的 lane（无 audio 模型）投影为 0
+        assert table.get("custom-1", "audio") == 0
+
+    async def test_from_db_custom_provider_null_falls_back_to_global_default(self, monkeypatch):
+        """自定义供应商：列为 None → 回退全局默认（两层回退，无声明默认层）。"""
+        self._stub_from_db_sources(
+            monkeypatch,
+            {},
+            custom_providers=[
+                self._fake_custom_provider(
+                    "custom-9",
+                    image=None,
+                    video=None,
+                    endpoints=("openai-images", "newapi-video"),
+                )
+            ],
+        )
+
+        table = await CapacityTable.from_db()
+
+        # 全局默认 image=5 / video=3（env 已在 _stub 中清除）
+        assert table.get("custom-9", "image") == 5
+        assert table.get("custom-9", "video") == 3
 
     @pytest.mark.parametrize("dirty", ["", "3.7", "abc"])
     async def test_from_db_dirty_value_falls_back_per_key(self, monkeypatch, caplog, dirty):


### PR DESCRIPTION
Closes #940（父 PRD #936）。

## 背景

内置供应商已能按 image / video / audio 三条 lane 单独设并发上限，自定义供应商缺这能力——`CapacityTable.from_db` 装载自定义供应商时一律套全局默认。本切片补齐对称能力，端到端贯通 schema → 迁移 → repo → API → 设置页 UI → i18n。

## 改动

- **Schema + 迁移**：`custom_provider` 表新增 3 个 nullable int 列 `image_max_workers` / `video_max_workers` / `audio_max_workers`；迁移 `a7a9749a1ae0`（additive、无 backfill，存量行三列为 `NULL`）。`NULL` = 未设置 → 走全局默认。
- **Repository / API**：`create_provider` / `update_provider` 透传三列；POST / PUT 请求体与响应回显贯通。PUT 为并发上限权威来源（缺省 = `None` = 清除，非"不修改"），与 `api_key` 的 `None`="不修改" 语义有意区分。
- **容量装载**：`CapacityTable.from_db` 对自定义供应商两层回退——列有值取列值，`NULL` 走全局默认（自定义供应商不在内置注册表，无"声明默认"中间层，故为两层而非内置的三层）。投影仍交给 `_lane_limits` 统一处理不支持的 lane。reload 即生效，不重启 worker。
- **设置页 UI**：自定义供应商表单新增 image / video / audio 三个可空 number 输入，留空 = 全局默认，交互对齐内置设置页（`ge=0` 与内置 `nonnegative` 校验一致）。
- **i18n**：6 个 dashboard key 三语（zh / en / vi）齐备。
- **ADR**：新增 ADR 0042，记录"按 lane 命名的定型列"决策，仿 ADR 0037 论证结构，否决 JSON / kv / 子表。

## 本地审查（独立复审 + /code-review xhigh）

以未参与实现的视角逐条核对验收标准，全部覆盖。xhigh 工作流审查的发现处置：

- **`max_workers=0` 会把受支持的 lane 容量置 0、被 `cap<=0` 当作"不支持该媒体"而 fail-fast** — 经核实这是与内置供应商的**忠实对等**：内置 `_validate_value` 同样只拒 `parsed < 0`（即 `0` 合法），AC 明确要求"交互对齐内置设置页"。0 的语义（禁用 lane vs 误配）是跨内置/自定义两个面的产品决策，不在本切片单方面收紧以免引入不一致；建议另开 issue 统一处置（含帮助文案）。
- **PATCH 客户端类型透传并发字段被后端静默丢弃** — 已修复（commit `59c77ba6`）：`updateCustomProvider` 的 `Omit` 排除三个并发字段，使类型准确反映 PATCH 后端只处理 display_name / base_url / api_key，并发改动走 PUT。
- 其余候选（小数 `parseInt` 截断、负值整单 422、PUT 全量替换语义）均为与内置一致或有意设计，不改。

## 验证

- 后端 `uv run python -m pytest tests/`：5331 passed
- `uv run ruff check .` / `ruff format --check`：clean
- `uv run basedpyright`：0 errors
- 前端 `pnpm lint` / `pnpm check`（typecheck + 765 vitest）：全绿
- 覆盖列 round-trip、迁移 upgrade/downgrade、`CapacityTable.from_db` 两层回退、API POST/PUT 回显与负值 422 的测试齐备
- 分支基线：rebase 到含 #951 / #956 的最新 main（HEAD `59c77ba6`），单 alembic head 保持


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 自定义供应商新增图片/视频/音频三类并发上限配置（可分别填写或留空）。
  * 设置页新增“并发限制”区域，并提供中英文/越南文界面文案与输入校验提示。
* **Bug Fixes**
  * 保存、编辑与全量更新时可正确写入、清空并回显并发上限；留空时自动回退到默认值。
  * 同时增加非负约束校验，拒绝负数输入。
* **Tests**
  * 补充迁移、API、仓储、前端与容量计算相关用例覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->