### PR TITLE
feat(provider): 接入 Agnes 视频生成并修复参考视频生成失败

### DIFF
--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -332,9 +332,10 @@ PROVIDER_SPEC_REGISTRY.update(
 PROVIDER_SPEC_REGISTRY.update(
     {(_KLING_REGISTRY_BACKEND, media_type): _kling_spec(media_type) for media_type in ("image", "video")}
 )
-# agnes 简单族，当前仅图像（文本 / 视频模态另片接入，届时各自登记）；不并入
-# _SIMPLE_IMAGE_VIDEO_PROVIDERS 以免登记尚无 backend 的 video spec。
+# agnes 简单族 image + video 显式登记（文本族在下方文本区随 _TEXT_SIMPLE_PROVIDERS 登记）；
+# 与 kling 同走独立显式登记，不并入 _SIMPLE_IMAGE_VIDEO_PROVIDERS 元组。
 PROVIDER_SPEC_REGISTRY[("agnes", "image")] = _simple_spec("agnes", "image")
+PROVIDER_SPEC_REGISTRY[("agnes", "video")] = _simple_spec("agnes", "video")
 
 # ── 文本族注册 ────────────────────────────────────────────────────
 # 简单文本四家（registry_backend = provider_id 自身）；gemini 两个 provider_id 按 backend 分两行

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -288,6 +288,16 @@ def _agnes_text_pricing(model_id: str, input_rate: float, output_rate: float) ->
     )
 
 
+# Agnes 视频费率（美元/秒），flat 按秒、与分辨率/音频无关；官方原价，当前促销 $0 不建模。
+def _agnes_video_pricing(model_id: str, per_second: float) -> PerSecondMatrix:
+    return PerSecondMatrix(
+        rates={model_id: {("", None): per_second}},
+        default_model=model_id,
+        dimensions="flat",
+        currency="USD",
+    )
+
+
 PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
     "gemini-aistudio": ProviderMeta(
         display_name="AI Studio",
@@ -1192,9 +1202,9 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
     ),
     "agnes": ProviderMeta(
         display_name="Agnes",
-        description="Agnes 多模态平台（OpenAI 风格），使用 Bearer API Key 鉴权；当前支持图像与文本生成。",
+        description="Agnes 多模态平台（OpenAI 风格），使用 Bearer API Key 鉴权；当前支持图像 / 文本 / 视频生成。",
         required_keys=["api_key"],
-        optional_keys=["base_url", "image_max_workers"],
+        optional_keys=["base_url", "image_max_workers", "video_max_workers"],
         secret_keys=["api_key"],
         models={
             # --- text ---
@@ -1218,6 +1228,20 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 default=True,
                 resolutions=["1K", "2K"],
                 pricing=_agnes_image_pricing("agnes-image-2.1-flash", 0.003),
+            ),
+            # --- video ---
+            # agnes-video-v2.0：apihub 异步 /v1/videos，图生 / 首尾帧 / 多图主体参考；fps 固定 24、
+            # 时长 1–18s。resolutions 为保守 UI 档位；实际尺寸由 backend aspect_size 计算、与此无耦合。
+            # max_reference_images 保守值，待 console / 实测核对，不硬编当既成事实。
+            "agnes-video-v2.0": ModelInfo(
+                display_name="Agnes Video 2.0",
+                media_type="video",
+                capabilities=["text_to_video", "image_to_video"],
+                default=True,
+                supported_durations=list(range(1, 19)),
+                resolutions=["480p", "720p", "1080p"],
+                max_reference_images=4,
+                pricing=_agnes_video_pricing("agnes-video-v2.0", 0.005),
             ),
         },
         default_base_url=AGNES_BASE_URL,

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -206,6 +206,7 @@ MESSAGES = {
     "video_reference_images_with_frames_unsupported": "Model {model} cannot combine reference images with a first/last frame; use one or the other",
     "video_start_image_unreadable": "The first-frame image for model {model} is unreadable; generation aborted: {name}; check the first-frame image path",
     "video_end_image_unreadable": "The last-frame image for model {model} is unreadable; generation aborted: {name}; check the last-frame image path",
+    "video_end_image_requires_start_image": "Model {model} does not support a standalone last frame; also provide a first frame (first+last keyframes) or remove the last frame",
     # Agent credentials
     "agent_preset_unknown": "Unknown preset provider: {preset_id}",
     "agent_base_url_required_custom": "base_url is required for custom configuration",

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -203,6 +203,7 @@ MESSAGES = {
     "video_reference_images_unreadable": "Model {model} has reference images that are missing or unreadable; generation aborted: {names}; check the reference image paths",
     "video_reference_images_unsupported": "Model {model} does not support multi-subject reference images; remove the reference images or switch to a model that supports reference-to-video",
     "video_reference_images_exceeded": "Model {model} supports at most {limit} reference images but received {count}; reduce the number of reference images",
+    "video_reference_images_with_frames_unsupported": "Model {model} cannot combine reference images with a first/last frame; use one or the other",
     "video_start_image_unreadable": "The first-frame image for model {model} is unreadable; generation aborted: {name}; check the first-frame image path",
     "video_end_image_unreadable": "The last-frame image for model {model} is unreadable; generation aborted: {name}; check the last-frame image path",
     # Agent credentials

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -204,6 +204,7 @@ MESSAGES = {
     "video_reference_images_unsupported": "Model {model} does not support multi-subject reference images; remove the reference images or switch to a model that supports reference-to-video",
     "video_reference_images_exceeded": "Model {model} supports at most {limit} reference images but received {count}; reduce the number of reference images",
     "video_start_image_unreadable": "The first-frame image for model {model} is unreadable; generation aborted: {name}; check the first-frame image path",
+    "video_end_image_unreadable": "The last-frame image for model {model} is unreadable; generation aborted: {name}; check the last-frame image path",
     # Agent credentials
     "agent_preset_unknown": "Unknown preset provider: {preset_id}",
     "agent_base_url_required_custom": "base_url is required for custom configuration",

--- a/lib/i18n/en/providers.py
+++ b/lib/i18n/en/providers.py
@@ -24,7 +24,7 @@ MESSAGES: dict[str, str] = {
     "provider_desc_dashscope": "Alibaba Cloud Model Studio (DashScope) full-modality platform supporting Qwen text, Qwen-Image / Wan images, and HappyHorse / Wan video (including reference-to-video).",
     "provider_desc_minimax": "MiniMax (Hailuo) multimodal platform with text, image and video generation. Connects to the domestic site by default; set base_url to the international site for overseas access.",
     "provider_desc_kling": "Kuaishou Kling video and image generation platform, authenticated with an Access Key and Secret Key.",
-    "provider_desc_agnes": "Agnes multimodal platform (OpenAI-style), authenticated with a Bearer API key; currently supports image and text generation.",
+    "provider_desc_agnes": "Agnes multimodal platform (OpenAI-style), authenticated with a Bearer API key; currently supports image, text and video generation.",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "DeepSeek official Anthropic-compat endpoint; needs sk- prefixed key.",
     "preset_notes_xiaomi_mimo": "Xiaomi MiMo only accepts known model names; no public model list.",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -203,6 +203,7 @@ MESSAGES = {
     "video_reference_images_unreadable": "Mô hình {model} có ảnh tham chiếu bị thiếu hoặc không đọc được; đã hủy tạo: {names}; hãy kiểm tra đường dẫn ảnh tham chiếu",
     "video_reference_images_unsupported": "Mô hình {model} không hỗ trợ ảnh tham chiếu đa chủ thể; hãy bỏ ảnh tham chiếu hoặc chuyển sang mô hình có hỗ trợ tạo video từ ảnh tham chiếu",
     "video_reference_images_exceeded": "Mô hình {model} hỗ trợ tối đa {limit} ảnh tham chiếu nhưng nhận được {count}; hãy giảm số lượng ảnh tham chiếu",
+    "video_reference_images_with_frames_unsupported": "Mô hình {model} không thể dùng ảnh tham chiếu cùng với khung hình đầu/cuối; hãy chọn một trong hai",
     "video_start_image_unreadable": "Ảnh khung hình đầu của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình đầu",
     "video_end_image_unreadable": "Ảnh khung hình cuối của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình cuối",
     # Agent credentials

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -204,6 +204,7 @@ MESSAGES = {
     "video_reference_images_unsupported": "Mô hình {model} không hỗ trợ ảnh tham chiếu đa chủ thể; hãy bỏ ảnh tham chiếu hoặc chuyển sang mô hình có hỗ trợ tạo video từ ảnh tham chiếu",
     "video_reference_images_exceeded": "Mô hình {model} hỗ trợ tối đa {limit} ảnh tham chiếu nhưng nhận được {count}; hãy giảm số lượng ảnh tham chiếu",
     "video_start_image_unreadable": "Ảnh khung hình đầu của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình đầu",
+    "video_end_image_unreadable": "Ảnh khung hình cuối của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình cuối",
     # Agent credentials
     "agent_preset_unknown": "Nhà cung cấp đặt sẵn không xác định: {preset_id}",
     "agent_base_url_required_custom": "Cấu hình tuỳ chỉnh yêu cầu base_url",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -206,6 +206,7 @@ MESSAGES = {
     "video_reference_images_with_frames_unsupported": "Mô hình {model} không thể dùng ảnh tham chiếu cùng với khung hình đầu/cuối; hãy chọn một trong hai",
     "video_start_image_unreadable": "Ảnh khung hình đầu của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình đầu",
     "video_end_image_unreadable": "Ảnh khung hình cuối của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình cuối",
+    "video_end_image_requires_start_image": "Mô hình {model} không hỗ trợ khung hình cuối độc lập; hãy cung cấp thêm khung hình đầu (chế độ khung đầu+cuối) hoặc bỏ khung hình cuối",
     # Agent credentials
     "agent_preset_unknown": "Nhà cung cấp đặt sẵn không xác định: {preset_id}",
     "agent_base_url_required_custom": "Cấu hình tuỳ chỉnh yêu cầu base_url",

--- a/lib/i18n/vi/providers.py
+++ b/lib/i18n/vi/providers.py
@@ -24,7 +24,7 @@ MESSAGES: dict[str, str] = {
     "provider_desc_dashscope": "Nền tảng đa phương thức Alibaba Cloud Model Studio (DashScope) hỗ trợ văn bản Qwen, ảnh Qwen-Image / Wan và video HappyHorse / Wan (bao gồm video tham chiếu).",
     "provider_desc_minimax": "Nền tảng đa phương thức MiniMax (Hailuo) hỗ trợ tạo văn bản, ảnh và video. Mặc định kết nối site nội địa; đặt base_url sang site quốc tế khi dùng ở nước ngoài.",
     "provider_desc_kling": "Nền tảng tạo video và ảnh Kling của Kuaishou, xác thực bằng Access Key và Secret Key.",
-    "provider_desc_agnes": "Nền tảng đa phương thức Agnes (phong cách OpenAI), xác thực bằng Bearer API key; hiện hỗ trợ tạo ảnh và văn bản.",
+    "provider_desc_agnes": "Nền tảng đa phương thức Agnes (phong cách OpenAI), xác thực bằng Bearer API key; hiện hỗ trợ tạo ảnh, văn bản và video.",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "Endpoint Anthropic-compat chính thức của DeepSeek; cần API key sk-.",
     "preset_notes_xiaomi_mimo": "Xiaomi MiMo chỉ chấp nhận tên model đã biết; không có danh sách model công khai.",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -203,6 +203,7 @@ MESSAGES = {
     "video_reference_images_unreadable": "模型 {model} 有参考图缺失或无法读取，已中止生成：{names}；请检查参考图路径",
     "video_reference_images_unsupported": "模型 {model} 不支持多图主体参考；请移除参考图，或换一个支持参考生视频的模型",
     "video_reference_images_exceeded": "模型 {model} 最多支持 {limit} 张参考图，收到 {count} 张；请减少参考图数量",
+    "video_reference_images_with_frames_unsupported": "模型 {model} 的参考图不能与首帧/尾帧叠加使用；请二选一",
     "video_start_image_unreadable": "模型 {model} 的首帧图无法读取，已中止生成：{name}；请检查首帧图路径",
     "video_end_image_unreadable": "模型 {model} 的尾帧图无法读取，已中止生成：{name}；请检查尾帧图路径",
     # Agent credentials

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -206,6 +206,7 @@ MESSAGES = {
     "video_reference_images_with_frames_unsupported": "模型 {model} 的参考图不能与首帧/尾帧叠加使用；请二选一",
     "video_start_image_unreadable": "模型 {model} 的首帧图无法读取，已中止生成：{name}；请检查首帧图路径",
     "video_end_image_unreadable": "模型 {model} 的尾帧图无法读取，已中止生成：{name}；请检查尾帧图路径",
+    "video_end_image_requires_start_image": "模型 {model} 不支持单独的尾帧；请同时提供首帧（首尾帧模式），或移除尾帧",
     # Agent credentials
     "agent_preset_unknown": "未知预设供应商: {preset_id}",
     "agent_base_url_required_custom": "自定义配置需要填写 base_url",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -204,6 +204,7 @@ MESSAGES = {
     "video_reference_images_unsupported": "模型 {model} 不支持多图主体参考；请移除参考图，或换一个支持参考生视频的模型",
     "video_reference_images_exceeded": "模型 {model} 最多支持 {limit} 张参考图，收到 {count} 张；请减少参考图数量",
     "video_start_image_unreadable": "模型 {model} 的首帧图无法读取，已中止生成：{name}；请检查首帧图路径",
+    "video_end_image_unreadable": "模型 {model} 的尾帧图无法读取，已中止生成：{name}；请检查尾帧图路径",
     # Agent credentials
     "agent_preset_unknown": "未知预设供应商: {preset_id}",
     "agent_base_url_required_custom": "自定义配置需要填写 base_url",

--- a/lib/i18n/zh/providers.py
+++ b/lib/i18n/zh/providers.py
@@ -24,7 +24,7 @@ MESSAGES: dict[str, str] = {
     "provider_desc_dashscope": "阿里云百炼（Model Studio）全模态平台，支持 Qwen 文本、Qwen-Image / 万相图像与 HappyHorse / 万相视频（含参考生视频）。",
     "provider_desc_minimax": "MiniMax（海螺）多模态平台，提供文本、图片、视频生成。默认连接国内站，海外可将 base_url 切换到国际站。",
     "provider_desc_kling": "快手可灵 Kling 视频与图像生成平台，使用 Access Key 与 Secret Key 鉴权。",
-    "provider_desc_agnes": "Agnes 多模态平台（OpenAI 风格），使用 Bearer API Key 鉴权；当前支持图像与文本生成。",
+    "provider_desc_agnes": "Agnes 多模态平台（OpenAI 风格），使用 Bearer API Key 鉴权；当前支持图像 / 文本 / 视频生成。",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "DeepSeek 官方 Anthropic 兼容端点，需 sk- 开头的 API Key",
     "preset_notes_xiaomi_mimo": "小米 MiMo 仅支持已知模型名，未公开模型列表",

--- a/lib/video_backends/__init__.py
+++ b/lib/video_backends/__init__.py
@@ -81,3 +81,9 @@ from lib.providers import PROVIDER_KLING  # noqa: E402
 from lib.video_backends.kling import KlingVideoBackend  # noqa: E402
 
 register_backend(PROVIDER_KLING, KlingVideoBackend)
+
+# Agnes — apihub 异步视频端点（裸 base64 + 轮询 + resume）
+from lib.providers import PROVIDER_AGNES  # noqa: E402
+from lib.video_backends.agnes import AgnesVideoBackend  # noqa: E402
+
+register_backend(PROVIDER_AGNES, AgnesVideoBackend)

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -1,0 +1,400 @@
+"""AgnesVideoBackend — Agnes 视频生成后端（裸 base64 + 异步轮询 + resume）。
+
+走 apihub 网关上的 OpenAI 风格异步端点：submit ``POST /v1/videos``（JSON）取 task_id →
+轮询 ``GET /v1/videos/{task_id}`` 至 ``status=completed`` → 从响应 ``remixed_from_video_id``
+字段取成片 mp4 URL → 下载本地。状态机 ``queued → in_progress → completed / failed``。
+
+能力约束：fps 固定 24；时长 1–18s（内部 ``num_frames = 最近的 8n+1``，由秒 × fps 取整对齐，
+上限 441 帧）；分辨率经 aspect_size 精确算出并显式下发 ``height`` × ``width``（不显式下发时
+上游回落自身默认横屏尺寸）。
+
+关键帧 / 多图映射：无图 → 文生视频；起始图 → 顶层 ``image``；首尾帧 → ``extra_body.image=[s,e]``
++ ``mode="keyframes"``；参考图 → ``extra_body.image=[refs]``。单通道 + mode 不叠加
+（``reference_images_with_start_frame=False``）。
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from pathlib import Path
+
+import httpx
+
+from lib.agnes_shared import agnes_base_url, agnes_headers, resolve_agnes_api_key
+from lib.aspect_size import VIDEO_TIER_SHORT_EDGE, aspect_size, resolution_to_short_edge
+from lib.logging_utils import format_kwargs_for_log
+from lib.providers import PROVIDER_AGNES
+from lib.retry import (
+    DEFAULT_BACKOFF_SECONDS,
+    DEFAULT_MAX_ATTEMPTS,
+    DOWNLOAD_BACKOFF_SECONDS,
+    DOWNLOAD_MAX_ATTEMPTS,
+    with_retry_async,
+)
+from lib.video_backends.base import (
+    ProviderJobIdPersistenceMixin,
+    ResumeExpiredError,
+    VideoCapabilities,
+    VideoCapability,
+    VideoCapabilityError,
+    VideoGenerationRequest,
+    VideoGenerationResult,
+    download_video,
+    poll_with_retry,
+    should_retry_download,
+    should_retry_poll,
+    should_retry_submit,
+    submit_post,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "agnes-video-v2.0"
+
+_VIDEOS_ENDPOINT = "/videos"
+
+# fps 固定 24；num_frames 必须形如 8n+1，上限 441（≈18.4s @24fps）。时长按秒 × fps 取整后
+# 对齐到最近的 8n+1。1–3s 会落到 81 帧以下（25/49/73），文档允许的合法值。
+_FPS = 24
+_FRAME_STEP = 8
+_MAX_NUM_FRAMES = 441
+
+# 参考图（多图主体）上限——保守值，与 registry ModelInfo.max_reference_images 同值（编排层裁剪读
+# registry、backend 生成时防御读此处）。待 Agnes console / 实测核对，不硬编当既成事实。
+_MAX_REFERENCE_IMAGES = 4
+
+# 尺寸约束：长宽被 8 整除、长边收口 1920（保守值，覆盖上游 480p/720p/1080p 三档标准化）。
+# 缺 resolution 时按 720p 短边兜底。待 console / 实测核对像素上限，不硬编当既成事实。
+_VIDEO_ROUND_TO = 8
+_MAX_LONG_EDGE = 1920
+
+# submit 超时 ~300s：覆盖上游争用时的长阻塞，避免可重试的繁忙被 ReadTimeout 包成终态歧义失败。
+_SUBMIT_TIMEOUT_SECONDS = 300.0
+# 轮询 / 下载用较短超时（幂等 GET 正常秒级返回）。
+_POLL_HTTP_TIMEOUT_SECONDS = 60.0
+
+_POLL_INTERVAL_SECONDS = 5.0
+_MIN_POLL_TIMEOUT_SECONDS = 900.0
+_POLL_TIMEOUT_PER_SECOND = 60.0
+
+_KEYFRAMES_MODE = "keyframes"
+
+# 进日志的安全标量白名单；image / extra_body 内的 base64 一律不入日志。
+_SAFE_LOG_KEYS = ("model", "height", "width", "num_frames", "frame_rate", "seed")
+
+
+def _duration_to_num_frames(duration_seconds: int) -> int:
+    """秒 → num_frames：秒 × fps 取整后对齐到最近的 ``8n+1``，上限 441。"""
+    target = max(1, duration_seconds) * _FPS
+    n = round((target - 1) / _FRAME_STEP)
+    num_frames = _FRAME_STEP * n + 1
+    return max(1, min(num_frames, _MAX_NUM_FRAMES))
+
+
+def _resolve_size(resolution: str | None, aspect_ratio: str) -> tuple[int, int]:
+    """比例优先、清晰度其次：短边来自 resolution（档位 / 自定义 / None 兜底 720p），
+    比例精确来自 aspect_ratio、长宽被 8 整除、长边收口 1920。返回 (宽, 高)。
+    """
+    short = resolution_to_short_edge(resolution, tier_map=VIDEO_TIER_SHORT_EDGE)
+    return aspect_size(aspect_ratio, short, round_to=_VIDEO_ROUND_TO, max_long_edge=_MAX_LONG_EDGE)
+
+
+def _image_to_bare_base64(image_path: Path) -> str:
+    """本地图片 → **裸 base64** 字符串（无 ``data:`` 前缀）。
+
+    Agnes 视频端对整串做 base64 解码，带 ``data:`` 前缀会在生成期触发 padding 错误，故不复用
+    仓库通用 data-URI helper（图像端接受 data-URI，视频端不接受，二者不可混用）。
+    """
+    return base64.b64encode(image_path.read_bytes()).decode("ascii")
+
+
+def _safe_body_for_log(body: dict) -> dict:
+    """安全日志视图：白名单标量 + prompt 仅长度 + 图像仅计数（base64 不入日志）。"""
+    view: dict = {key: body[key] for key in _SAFE_LOG_KEYS if key in body}
+    prompt = body.get("prompt")
+    if isinstance(prompt, str):
+        view["prompt_len"] = len(prompt)
+    if body.get("image"):
+        view["image"] = "<start_frame>"
+    extra = body.get("extra_body")
+    if isinstance(extra, dict) and isinstance(extra.get("image"), list):
+        mode = extra.get("mode")
+        view["extra_body"] = f"<{len(extra['image'])} img{f', mode={mode}' if mode else ''}>"
+    return view
+
+
+def _extract_task_id(body: dict) -> str:
+    """从提交响应取轮询用 task_id（``task_id`` 优先，回落 ``id``）。"""
+    for key in ("task_id", "id"):
+        value = body.get(key)
+        if isinstance(value, str) and value:
+            return value
+    raise RuntimeError(f"Agnes 视频提交返回体缺少 task_id: {body}")
+
+
+def _extract_duration_seconds(final: dict, fallback: int) -> int:
+    """从轮询终态取实际时长（``usage.duration_seconds`` 优先，回落顶层 ``seconds``，再回落请求值）。"""
+    usage = final.get("usage")
+    if isinstance(usage, dict):
+        parsed = _coerce_int(usage.get("duration_seconds"))
+        if parsed is not None:
+            return parsed
+    parsed = _coerce_int(final.get("seconds"))
+    if parsed is not None:
+        return parsed
+    return fallback
+
+
+def _coerce_int(value: object) -> int | None:
+    """把 ``"10.0"`` / ``10`` 这类时长值归一化为 int；不可解析回 None。"""
+    if value is None:
+        return None
+    try:
+        return int(float(value))  # pyright: ignore[reportArgumentType]
+    except (TypeError, ValueError):
+        return None
+
+
+def _failure_reason(state: dict) -> str | None:
+    """``status=failed`` → 错误描述；其余 → None。"""
+    if state.get("status") != "failed":
+        return None
+    err = state.get("error")
+    if isinstance(err, dict):
+        message = err.get("message") or err.get("code") or "unknown"
+    else:
+        message = err or "unknown"
+    return f"Agnes 视频生成失败: {message}"
+
+
+class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
+    """Agnes 视频后端（异步 submit/poll，裸 base64 图像，支持 resume）。"""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        http_timeout: float = _POLL_HTTP_TIMEOUT_SECONDS,
+    ) -> None:
+        self._api_key = resolve_agnes_api_key(api_key)
+        self._base_url = agnes_base_url(base_url)
+        self._model = model or DEFAULT_MODEL
+        self._http_timeout = http_timeout
+        self._capabilities: set[VideoCapability] = {
+            VideoCapability.TEXT_TO_VIDEO,
+            VideoCapability.IMAGE_TO_VIDEO,
+        }
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_AGNES
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def capabilities(self) -> set[VideoCapability]:
+        return self._capabilities
+
+    @property
+    def video_capabilities(self) -> VideoCapabilities:
+        # 首帧 + 尾帧（首尾关键帧）+ 多图主体参考；参考图不与首帧叠加（单通道 + mode 不可叠加）。
+        return VideoCapabilities(
+            first_frame=True,
+            last_frame=True,
+            reference_images=True,
+            max_reference_images=_MAX_REFERENCE_IMAGES,
+            reference_images_with_start_frame=False,
+        )
+
+    async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
+        payload = self._build_payload(request)
+        logger.info(
+            "调用 %s 视频 API model=%s body=%s",
+            self.name,
+            self._model,
+            format_kwargs_for_log(_safe_body_for_log(payload)),
+        )
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            task_id = await self._create_task(client, payload)
+            logger.info("Agnes 视频任务已创建: task_id=%s model=%s", task_id, self._model)
+            await self._persist_provider_job_id(request, task_id, provider=PROVIDER_AGNES)
+            return await self._poll_and_build(client, task_id, request, is_resume=False)
+
+    async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
+        """接续已 submit 的 Agnes task：仅轮询 + 下载，不重新提交（ADR 0007）。"""
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            return await self._poll_and_build(client, job_id, request, is_resume=True)
+
+    # ── request building ────────────────────────────────────────────────
+
+    def _build_payload(self, request: VideoGenerationRequest) -> dict:
+        """构建提交体。
+
+        通道优先级（单通道，不叠加）：参考图 → ``extra_body.image=[refs]``；首+尾帧 →
+        ``extra_body.image=[s,e]`` + ``mode=keyframes``；仅起始图 → 顶层 ``image``；都无 → 文生视频。
+        """
+        width, height = _resolve_size(request.resolution, request.aspect_ratio)
+        payload: dict = {
+            "model": self._model,
+            "prompt": request.prompt,
+            "height": height,
+            "width": width,
+            "num_frames": _duration_to_num_frames(request.duration_seconds),
+            "frame_rate": _FPS,
+        }
+        if request.seed is not None:
+            payload["seed"] = request.seed
+
+        reference_images = self._valid_paths(request.reference_images)
+        start_image = self._single_path(request.start_image)
+        end_image = self._single_path(request.end_image)
+
+        if reference_images:
+            if len(reference_images) > _MAX_REFERENCE_IMAGES:
+                raise VideoCapabilityError(
+                    "video_reference_images_exceeded",
+                    model=self._model,
+                    count=len(reference_images),
+                    limit=_MAX_REFERENCE_IMAGES,
+                )
+            payload["extra_body"] = {"image": [self._encode_reference(p) for p in reference_images]}
+        elif start_image is not None and end_image is not None:
+            payload["extra_body"] = {
+                "image": [self._encode_start(start_image), self._encode_start(end_image)],
+                "mode": _KEYFRAMES_MODE,
+            }
+        elif start_image is not None:
+            payload["image"] = self._encode_start(start_image)
+
+        return payload
+
+    @staticmethod
+    def _single_path(value: str | Path | None) -> Path | None:
+        """把请求里的图像字段归一化成 Path；空 / 空串 → None。"""
+        if isinstance(value, (str, Path)) and str(value):
+            return Path(value)
+        return None
+
+    @staticmethod
+    def _valid_paths(values: list[Path] | None) -> list[Path]:
+        return [Path(v) for v in (values or []) if v]
+
+    def _encode_start(self, path: Path) -> str:
+        """裸 base64 编码首/尾帧；缺失或不可读 fail-loud（不静默退化为文生视频）。"""
+        if not path.is_file():
+            raise VideoCapabilityError("video_start_image_unreadable", model=self._model, name=path.name)
+        try:
+            return _image_to_bare_base64(path)
+        except OSError as exc:
+            raise VideoCapabilityError("video_start_image_unreadable", model=self._model, name=path.name) from exc
+
+    def _encode_reference(self, path: Path) -> str:
+        """裸 base64 编码参考图；缺失或不可读 fail-loud（不静默丢弃后照常计费）。"""
+        if not path.is_file():
+            raise VideoCapabilityError("video_reference_images_unreadable", model=self._model, names=path.name)
+        try:
+            return _image_to_bare_base64(path)
+        except OSError as exc:
+            raise VideoCapabilityError("video_reference_images_unreadable", model=self._model, names=path.name) from exc
+
+    # ── HTTP submit / poll / download ───────────────────────────────────
+
+    @with_retry_async(
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+        retry_if=should_retry_submit,
+    )
+    async def _create_task(self, client: httpx.AsyncClient, payload: dict) -> str:
+        # 非幂等的「建任务 + 计费」POST：submit_post 把歧义传输错误转 AmbiguousSubmitError 终态失败，
+        # 避免重试重复建任务 + 重复计费；>=400 抛 HTTPStatusError 交 should_retry_submit 按状态码分流
+        # （5xx/408/429 重试——含上游繁忙 503；确定性 4xx 快失败）。submit 用长超时覆盖上游长阻塞。
+        resp = await submit_post(
+            lambda: client.post(
+                f"{self._base_url}{_VIDEOS_ENDPOINT}",
+                json=payload,
+                headers=agnes_headers(self._api_key),
+                timeout=_SUBMIT_TIMEOUT_SECONDS,
+            ),
+            provider=PROVIDER_AGNES,
+        )
+        return _extract_task_id(resp.json())
+
+    async def _poll_once(self, client: httpx.AsyncClient, task_id: str) -> dict:
+        resp = await client.get(
+            f"{self._base_url}{_VIDEOS_ENDPOINT}/{task_id}",
+            headers=agnes_headers(self._api_key),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _poll_and_build(
+        self,
+        client: httpx.AsyncClient,
+        task_id: str,
+        request: VideoGenerationRequest,
+        *,
+        is_resume: bool,
+    ) -> VideoGenerationResult:
+        # resume 路径下 404 直接转 ResumeExpiredError：should_retry_poll 把轮询 404 当「短暂未就绪」
+        # 重试，对已过期的 resume 任务会一直重到超时、永不落终态，故在此一击转终态异常。非 resume 的
+        # 4xx 原样抛出，交 should_retry_poll 按 status_code 分流。
+        async def _gated_poll() -> dict:
+            try:
+                return await self._poll_once(client, task_id)
+            except httpx.HTTPStatusError as exc:
+                if is_resume and exc.response.status_code == 404:
+                    raise ResumeExpiredError(job_id=task_id, provider=PROVIDER_AGNES) from exc
+                raise
+
+        final = await poll_with_retry(
+            poll_fn=_gated_poll,
+            is_done=lambda state: state.get("status") in ("completed", "failed"),
+            is_failed=_failure_reason,
+            poll_interval=_POLL_INTERVAL_SECONDS,
+            max_wait=self._max_wait(request.duration_seconds),
+            retry_if=should_retry_poll,
+            label="Agnes",
+            on_progress=lambda v, elapsed: logger.info(
+                "Agnes 视频生成中... status=%s progress=%s elapsed=%ds",
+                v.get("status"),
+                v.get("progress"),
+                int(elapsed),
+            ),
+        )
+
+        video_url = final.get("remixed_from_video_id")
+        if not isinstance(video_url, str) or not video_url:
+            raise RuntimeError(f"Agnes 任务完成但缺少 remixed_from_video_id 成片 URL: {final}")
+
+        await self._download_with_retry(video_url, request.output_path)
+        logger.info("Agnes 视频下载完成: %s", request.output_path)
+
+        return VideoGenerationResult(
+            video_path=request.output_path,
+            provider=PROVIDER_AGNES,
+            model=self._model,
+            duration_seconds=_extract_duration_seconds(final, request.duration_seconds),
+            video_uri=video_url,
+            task_id=task_id,
+            seed=request.seed,
+            generate_audio=request.generate_audio,
+        )
+
+    @staticmethod
+    @with_retry_async(
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
+        retry_if=should_retry_download,
+    )
+    async def _download_with_retry(video_url: str, output_path: Path) -> None:
+        """下载成片 URL（幂等 GET），独立的下载重试范围，不回退到重跑生成 POST。"""
+        await download_video(video_url, output_path)
+
+    @staticmethod
+    def _max_wait(duration_seconds: int) -> float:
+        return max(_MIN_POLL_TIMEOUT_SECONDS, duration_seconds * _POLL_TIMEOUT_PER_SECOND)

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -15,14 +15,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import logging
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from pathlib import Path
 
 import httpx
 
 from lib.agnes_shared import agnes_base_url, agnes_headers, resolve_agnes_api_key
 from lib.aspect_size import VIDEO_TIER_SHORT_EDGE, aspect_size, resolution_to_short_edge
+from lib.db.repositories.usage_repo import MAX_BILLED_DURATION_SECONDS
 from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_AGNES
 from lib.retry import (
@@ -80,6 +83,10 @@ _POLL_TIMEOUT_PER_SECOND = 60.0
 
 _KEYFRAMES_MODE = "keyframes"
 
+# 失败终态集合：除文档化的 failed 外，纳入 error / cancelled / canceled，避免上游以非标准失败态
+# 收尾时被当「仍在进行」轮询到超时。
+_FAILED_STATUSES = ("failed", "error", "cancelled", "canceled")
+
 # 进日志的安全标量白名单；image / extra_body 内的 base64 一律不入日志。
 _SAFE_LOG_KEYS = ("model", "height", "width", "num_frames", "frame_rate", "seed")
 
@@ -130,35 +137,45 @@ def _extract_task_id(body: dict) -> str:
         value = body.get(key)
         if isinstance(value, str) and value:
             return value
-    raise RuntimeError(f"Agnes 视频提交返回体缺少 task_id: {body}")
+    # 仅暴露字段名，不回显整串响应（可能含 prompt / 签名 URL 等敏感字段，与 _safe_body_for_log 同口径）。
+    raise RuntimeError(f"Agnes 视频提交返回体缺少 task_id（字段: {sorted(body)}）")
 
 
 def _extract_duration_seconds(final: dict, fallback: int) -> int:
-    """从轮询终态取实际时长（``usage.duration_seconds`` 优先，回落顶层 ``seconds``，再回落请求值）。"""
+    """从轮询终态取实际计费时长（``usage.duration_seconds`` 优先，回落顶层 ``seconds``，再回落请求值）。"""
     usage = final.get("usage")
     if isinstance(usage, dict):
-        parsed = _coerce_int(usage.get("duration_seconds"))
+        parsed = _coerce_duration(usage.get("duration_seconds"))
         if parsed is not None:
             return parsed
-    parsed = _coerce_int(final.get("seconds"))
+    parsed = _coerce_duration(final.get("seconds"))
     if parsed is not None:
         return parsed
     return fallback
 
 
-def _coerce_int(value: object) -> int | None:
-    """把 ``"10.0"`` / ``10`` 这类时长值归一化为 int；不可解析回 None。"""
+def _coerce_duration(value: object) -> int | None:
+    """把 ``"10.0"`` / ``10`` 这类时长值归一化为计费秒数：half-up 取整（4.5→5，不少计），
+    非正值 / 超 24h 上限（防 DB Integer 列溢出）/ 不可解析一律回 None，由 caller 回落请求时长。
+    """
     if value is None:
         return None
     try:
-        return int(float(value))  # pyright: ignore[reportArgumentType]
-    except (TypeError, ValueError):
+        decimal_value = Decimal(str(value))
+        if not 0 < decimal_value <= MAX_BILLED_DURATION_SECONDS:
+            return None
+        return int(decimal_value.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+    except (InvalidOperation, TypeError, ValueError):
         return None
 
 
 def _failure_reason(state: dict) -> str | None:
-    """``status=failed`` → 错误描述；其余 → None。"""
-    if state.get("status") != "failed":
+    """失败终态（failed / error / cancelled / canceled）→ 错误描述；其余 → None。
+
+    不止认 ``failed``：上游若以其他失败态收尾，仅认 completed/failed 会把它当「仍在进行」轮询到
+    max_wait 才抛误导性 TimeoutError，白占 worker 通道；显式枚举失败态让其快速失败。
+    """
+    if state.get("status") not in _FAILED_STATUSES:
         return None
     err = state.get("error")
     if isinstance(err, dict):
@@ -212,7 +229,9 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
         )
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
-        payload = self._build_payload(request)
+        # 读盘 + base64 编码（首尾帧最多 2 张、参考图最多 4 张，可能数 MB）offload 到线程，
+        # 避免阻塞共享 worker 事件循环（与 image 后端及 grok/gemini 视频后端一致）。
+        payload = await asyncio.to_thread(self._build_payload, request)
         logger.info(
             "调用 %s 视频 API model=%s body=%s",
             self.name,
@@ -265,7 +284,7 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
             payload["extra_body"] = {"image": [self._encode_reference(p) for p in reference_images]}
         elif start_image is not None and end_image is not None:
             payload["extra_body"] = {
-                "image": [self._encode_start(start_image), self._encode_start(end_image)],
+                "image": [self._encode_start(start_image), self._encode_end(end_image)],
                 "mode": _KEYFRAMES_MODE,
             }
         elif start_image is not None:
@@ -275,32 +294,39 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
 
     @staticmethod
     def _single_path(value: str | Path | None) -> Path | None:
-        """把请求里的图像字段归一化成 Path；空 / 空串 → None。"""
-        if isinstance(value, (str, Path)) and str(value):
-            return Path(value)
-        return None
+        """把请求里的图像字段归一化成 Path；空 / 空串 / 空 Path（``Path("")`` 会塌成 ``Path(".")``）→ None。"""
+        if value is None:
+            return None
+        text = str(value)
+        if not text or text == ".":
+            return None
+        return Path(text)
 
-    @staticmethod
-    def _valid_paths(values: list[Path] | None) -> list[Path]:
-        return [Path(v) for v in (values or []) if v]
+    @classmethod
+    def _valid_paths(cls, values: list[Path] | None) -> list[Path]:
+        """归一化参考图列表：剔除空 / 空 Path（``[Path(v) for v if v]`` 对 Path 恒真，不起过滤作用）。"""
+        return [p for v in (values or []) if (p := cls._single_path(v)) is not None]
 
     def _encode_start(self, path: Path) -> str:
-        """裸 base64 编码首/尾帧；缺失或不可读 fail-loud（不静默退化为文生视频）。"""
-        if not path.is_file():
-            raise VideoCapabilityError("video_start_image_unreadable", model=self._model, name=path.name)
-        try:
-            return _image_to_bare_base64(path)
-        except OSError as exc:
-            raise VideoCapabilityError("video_start_image_unreadable", model=self._model, name=path.name) from exc
+        """裸 base64 编码首帧；缺失或不可读 fail-loud（不静默退化为文生视频）。"""
+        return self._encode_image(path, error_code="video_start_image_unreadable", name=path.name)
+
+    def _encode_end(self, path: Path) -> str:
+        """裸 base64 编码尾帧；缺失或不可读 fail-loud（错误指向尾帧而非首帧）。"""
+        return self._encode_image(path, error_code="video_end_image_unreadable", name=path.name)
 
     def _encode_reference(self, path: Path) -> str:
         """裸 base64 编码参考图；缺失或不可读 fail-loud（不静默丢弃后照常计费）。"""
+        return self._encode_image(path, error_code="video_reference_images_unreadable", names=path.name)
+
+    def _encode_image(self, path: Path, *, error_code: str, **err_params: str) -> str:
+        """裸 base64 编码图像；缺失或不可读时按通道 error_code / 参数名 fail-loud。"""
         if not path.is_file():
-            raise VideoCapabilityError("video_reference_images_unreadable", model=self._model, names=path.name)
+            raise VideoCapabilityError(error_code, model=self._model, **err_params)
         try:
             return _image_to_bare_base64(path)
         except OSError as exc:
-            raise VideoCapabilityError("video_reference_images_unreadable", model=self._model, names=path.name) from exc
+            raise VideoCapabilityError(error_code, model=self._model, **err_params) from exc
 
     # ── HTTP submit / poll / download ───────────────────────────────────
 
@@ -369,7 +395,8 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
 
         video_url = final.get("remixed_from_video_id")
         if not isinstance(video_url, str) or not video_url:
-            raise RuntimeError(f"Agnes 任务完成但缺少 remixed_from_video_id 成片 URL: {final}")
+            # 仅暴露字段名，不回显整串响应（可能含签名 URL 等敏感字段，与 _safe_body_for_log 同口径）。
+            raise RuntimeError(f"Agnes 任务完成但缺少 remixed_from_video_id 成片 URL（字段: {sorted(final)}）")
 
         await self._download_with_retry(video_url, request.output_path)
         logger.info("Agnes 视频下载完成: %s", request.output_path)
@@ -382,7 +409,9 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
             video_uri=video_url,
             task_id=task_id,
             seed=request.seed,
-            generate_audio=request.generate_audio,
+            # Agnes 视频无音频能力（未声明 GENERATE_AUDIO、提交体不带音频字段），成片恒无声；
+            # 固定 False 与 kling/vidu 无声模型一致，避免下游（计费/版本元数据/剪映导出）误判有声。
+            generate_audio=False,
         )
 
     @staticmethod

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -63,6 +63,11 @@ _FPS = 24
 _FRAME_STEP = 8
 _MAX_NUM_FRAMES = 441
 
+# 后端防御时长边界，与 registry agnes-video-v2.0 的 supported_durations（1..18s）同步。越界请求
+# fail-loud，而非静默截断到 _MAX_NUM_FRAMES——否则 30s 请求实际只生成约 18s，却按原请求秒数计费。
+_MIN_DURATION_SECONDS = 1
+_MAX_DURATION_SECONDS = 18
+
 # 参考图（多图主体）上限——保守值，与 registry ModelInfo.max_reference_images 同值（编排层裁剪读
 # registry、backend 生成时防御读此处）。待 Agnes console / 实测核对，不硬编当既成事实。
 _MAX_REFERENCE_IMAGES = 4
@@ -257,6 +262,7 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
         通道优先级（单通道，不叠加）：参考图 → ``extra_body.image=[refs]``；首+尾帧 →
         ``extra_body.image=[s,e]`` + ``mode=keyframes``；仅起始图 → 顶层 ``image``；都无 → 文生视频。
         """
+        self._reject_out_of_range_duration(request.duration_seconds)
         width, height = _resolve_size(request.resolution, request.aspect_ratio)
         payload: dict = {
             "model": self._model,
@@ -272,6 +278,11 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
         reference_images = self._valid_paths(request.reference_images)
         start_image = self._single_path(request.start_image)
         end_image = self._single_path(request.end_image)
+
+        # 参考图与首/尾帧走互斥的单通道（reference_images_with_start_frame=False）。两者同时给出时
+        # fail-loud，而非静默走参考图分支丢掉用户的首/尾帧。
+        if reference_images and (start_image is not None or end_image is not None):
+            raise VideoCapabilityError("video_reference_images_with_frames_unsupported", model=self._model)
 
         if reference_images:
             if len(reference_images) > _MAX_REFERENCE_IMAGES:
@@ -292,6 +303,16 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
 
         return payload
 
+    def _reject_out_of_range_duration(self, duration_seconds: int) -> None:
+        """时长越界 [_MIN, _MAX] 时 fail-loud；上游若漏校验，避免静默截帧 + 错记计费时长。"""
+        if not _MIN_DURATION_SECONDS <= duration_seconds <= _MAX_DURATION_SECONDS:
+            raise VideoCapabilityError(
+                "video_duration_not_supported",
+                model=self._model,
+                duration=duration_seconds,
+                supported=f"{_MIN_DURATION_SECONDS}-{_MAX_DURATION_SECONDS}",
+            )
+
     @staticmethod
     def _single_path(value: str | Path | None) -> Path | None:
         """把请求里的图像字段归一化成 Path；空 / 空串 / 空 Path（``Path("")`` 会塌成 ``Path(".")``）→ None。"""
@@ -309,15 +330,15 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
 
     def _encode_start(self, path: Path) -> str:
         """裸 base64 编码首帧；缺失或不可读 fail-loud（不静默退化为文生视频）。"""
-        return self._encode_image(path, error_code="video_start_image_unreadable", name=path.name)
+        return self._encode_image(path, error_code="video_start_image_unreadable", name=path.name or str(path))
 
     def _encode_end(self, path: Path) -> str:
         """裸 base64 编码尾帧；缺失或不可读 fail-loud（错误指向尾帧而非首帧）。"""
-        return self._encode_image(path, error_code="video_end_image_unreadable", name=path.name)
+        return self._encode_image(path, error_code="video_end_image_unreadable", name=path.name or str(path))
 
     def _encode_reference(self, path: Path) -> str:
         """裸 base64 编码参考图；缺失或不可读 fail-loud（不静默丢弃后照常计费）。"""
-        return self._encode_image(path, error_code="video_reference_images_unreadable", names=path.name)
+        return self._encode_image(path, error_code="video_reference_images_unreadable", names=path.name or str(path))
 
     def _encode_image(self, path: Path, *, error_code: str, **err_params: str) -> str:
         """裸 base64 编码图像；缺失或不可读时按通道 error_code / 参数名 fail-loud。"""

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -284,6 +284,11 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
         if reference_images and (start_image is not None or end_image is not None):
             raise VideoCapabilityError("video_reference_images_with_frames_unsupported", model=self._model)
 
+        # 尾帧仅在 keyframes（首+尾）模式下生效，无独立尾帧通道。只给尾帧时 fail-loud，而非静默
+        # 退化为文生视频——video_capabilities.last_frame=True 表示支持首尾帧对，不含单独尾帧。
+        if end_image is not None and start_image is None:
+            raise VideoCapabilityError("video_end_image_requires_start_image", model=self._model)
+
         if reference_images:
             if len(reference_images) > _MAX_REFERENCE_IMAGES:
                 raise VideoCapabilityError(

--- a/tests/test_agnes_video_backend.py
+++ b/tests/test_agnes_video_backend.py
@@ -377,6 +377,32 @@ class TestImageChannels:
                 )
             assert ei.value.code == "video_reference_images_exceeded"
 
+    @pytest.mark.parametrize("with_start", [True, False])
+    async def test_reference_images_with_frame_fails_loud(self, tmp_path: Path, with_start: bool):
+        """参考图与首/尾帧同时给出时 fail-loud（单通道互斥），不静默走参考图分支丢掉关键帧。"""
+        ref = _write_image(tmp_path / "r.png", b"ref")
+        frame = _write_image(tmp_path / "f.png", b"frame")
+        client = _mock_client(post=AsyncMock(side_effect=AssertionError("混合输入不应提交")))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(VideoCapabilityError) as ei:
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p",
+                        output_path=tmp_path / "o.mp4",
+                        reference_images=[ref],
+                        start_image=frame if with_start else None,
+                        end_image=None if with_start else frame,
+                        aspect_ratio="9:16",
+                        duration_seconds=5,
+                    )
+                )
+            assert ei.value.code == "video_reference_images_with_frames_unsupported"
+        client.post.assert_not_called()
+
     async def test_missing_start_image_fails_loud(self, tmp_path: Path):
         client = _mock_client(post=AsyncMock(side_effect=AssertionError("缺图不应提交")))
 
@@ -691,6 +717,92 @@ class TestResume:
             assert ei.value.job_id == "task-404"
             assert ei.value.provider == PROVIDER_AGNES
             assert client.get.call_count == 1
+
+
+class TestDurationValidation:
+    @pytest.mark.parametrize("duration", [0, 19, 30])
+    async def test_out_of_range_duration_fails_loud_without_submit(self, tmp_path: Path, duration: int):
+        """越界时长（< 1 或 > 18）在建单前 fail-loud，不静默截帧到 441、不 POST、不错记计费时长。"""
+        client = _mock_client(post=AsyncMock(side_effect=AssertionError("越界时长不应提交")))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(VideoCapabilityError) as ei:
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=duration
+                    )
+                )
+            assert ei.value.code == "video_duration_not_supported"
+        client.post.assert_not_called()
+
+
+class TestProviderJobIdPersistence:
+    async def test_persists_agnes_task_id_for_worker_request(self, tmp_path: Path):
+        """worker 路径（request.task_id 非空）下，submit 返回的 Agnes task_id 作为 job_id 写回，覆盖 resume 契约。"""
+        create_resp = _make_response(200, {"task_id": "agnes-task-42", "status": "queued"})
+        poll_resp = _make_response(200, _completed("agnes-task-42"))
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+        persist = AsyncMock()
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+            patch("lib.video_backends.base.persist_provider_job_id", persist),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.mp4",
+                    aspect_ratio="9:16",
+                    duration_seconds=5,
+                    task_id="worker-task-99",
+                )
+            )
+
+        persist.assert_awaited_once()
+        args, kwargs = persist.call_args
+        assert args[0] == "worker-task-99"  # worker 任务 id
+        assert args[1] == "agnes-task-42"  # Agnes submit 返回的 task_id 作为 job_id 写回
+        assert kwargs["provider"] == PROVIDER_AGNES
+
+    async def test_non_worker_request_skips_persistence(self, tmp_path: Path):
+        """非 worker 路径（task_id=None）不调用持久化，避免空 task_id 写库。"""
+        create_resp = _make_response(200, {"task_id": "agnes-task-1", "status": "queued"})
+        poll_resp = _make_response(200, _completed("agnes-task-1"))
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+        persist = AsyncMock()
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+            patch("lib.video_backends.base.persist_provider_job_id", persist),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        persist.assert_not_called()
 
 
 class TestRegistration:

--- a/tests/test_agnes_video_backend.py
+++ b/tests/test_agnes_video_backend.py
@@ -403,6 +403,28 @@ class TestImageChannels:
             assert ei.value.code == "video_reference_images_with_frames_unsupported"
         client.post.assert_not_called()
 
+    async def test_end_image_only_fails_loud(self, tmp_path: Path):
+        """仅提供尾帧（无首帧）时 fail-loud——Agnes 无独立尾帧通道，不静默退化为文生视频。"""
+        end = _write_image(tmp_path / "e.png", b"end")
+        client = _mock_client(post=AsyncMock(side_effect=AssertionError("仅尾帧不应提交")))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(VideoCapabilityError) as ei:
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p",
+                        output_path=tmp_path / "o.mp4",
+                        end_image=end,
+                        aspect_ratio="9:16",
+                        duration_seconds=5,
+                    )
+                )
+            assert ei.value.code == "video_end_image_requires_start_image"
+        client.post.assert_not_called()
+
     async def test_missing_start_image_fails_loud(self, tmp_path: Path):
         client = _mock_client(post=AsyncMock(side_effect=AssertionError("缺图不应提交")))
 

--- a/tests/test_agnes_video_backend.py
+++ b/tests/test_agnes_video_backend.py
@@ -115,6 +115,38 @@ class TestNumFramesAndSize:
         assert width % 8 == 0 and height % 8 == 0
 
 
+class TestDurationCoercion:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (10, 10),
+            ("10.0", 10),
+            ("9.6", 10),  # half-up 取整，不少计费秒
+            ("9.4", 9),
+            (4.5, 5),
+            (0, None),  # 非正值回 None，由 caller 回落请求时长
+            ("0", None),
+            (-3, None),
+            ("abc", None),
+            (None, None),
+        ],
+    )
+    def test_coerce_duration(self, value: object, expected: int | None):
+        from lib.video_backends.agnes import _coerce_duration
+
+        assert _coerce_duration(value) == expected
+
+    def test_extract_duration_falls_back_when_usage_zero(self):
+        from lib.video_backends.agnes import _extract_duration_seconds
+
+        # usage.duration_seconds=0 不应落到结果对象，回落请求时长
+        assert _extract_duration_seconds({"usage": {"duration_seconds": 0}}, fallback=5) == 5
+        # 优先 usage，其次顶层 seconds，再回落
+        assert _extract_duration_seconds({"usage": {"duration_seconds": "9.6"}}, fallback=5) == 10
+        assert _extract_duration_seconds({"seconds": "7"}, fallback=5) == 7
+        assert _extract_duration_seconds({}, fallback=5) == 5
+
+
 class TestTextToVideo:
     async def test_happy_path_submits_and_polls(self, tmp_path: Path):
         create_resp = _make_response(200, {"task_id": "task-42", "status": "queued"})
@@ -152,6 +184,8 @@ class TestTextToVideo:
         assert result.duration_seconds == 5
         assert result.task_id == "task-42"
         assert result.video_uri == "https://cdn.agnes/out.mp4"
+        # Agnes 无音频能力，成片恒无声
+        assert result.generate_audio is False
 
         post_call = client.post.call_args
         assert post_call.args[0] == "https://apihub.agnes-ai.com/v1/videos"
@@ -362,6 +396,61 @@ class TestImageChannels:
                 )
             assert ei.value.code == "video_start_image_unreadable"
 
+    async def test_missing_end_image_fails_loud_with_end_code(self, tmp_path: Path):
+        """首尾帧模式下尾帧缺失：错误码指向尾帧而非首帧。"""
+        start = _write_image(tmp_path / "s.png", b"start-bytes")
+        client = _mock_client(post=AsyncMock(side_effect=AssertionError("缺尾帧不应提交")))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(VideoCapabilityError) as ei:
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p",
+                        output_path=tmp_path / "o.mp4",
+                        start_image=start,
+                        end_image=tmp_path / "missing-end.png",
+                        aspect_ratio="9:16",
+                        duration_seconds=5,
+                    )
+                )
+            assert ei.value.code == "video_end_image_unreadable"
+
+    async def test_empty_path_objects_degrade_to_text_to_video(self, tmp_path: Path):
+        """空 Path（``Path("")`` 塌成 ``Path(".")``）应归一化为 None，回落文生视频而非误报无法读取。"""
+        create_resp = _make_response(200, {"task_id": "t-empty", "status": "queued"})
+        poll_resp = _make_response(200, _completed("t-empty"))
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.mp4",
+                    start_image=Path(""),
+                    reference_images=[Path("")],
+                    aspect_ratio="9:16",
+                    duration_seconds=5,
+                )
+            )
+
+        body = client.post.call_args.kwargs["json"]
+        assert "image" not in body
+        assert "extra_body" not in body
+
 
 class TestFailureAndTimeout:
     async def test_failed_status_raises(self, tmp_path: Path):
@@ -388,6 +477,34 @@ class TestFailureAndTimeout:
                     )
                 )
 
+        fake_download.assert_not_called()
+
+    async def test_non_failed_terminal_status_fails_fast(self, tmp_path: Path):
+        """上游以 cancelled 等非 failed 失败态收尾时快速失败，不轮询到 timeout。"""
+        create_resp = _make_response(200, {"task_id": "t-cxl", "status": "queued"})
+        cancelled = _make_response(
+            200, {"task_id": "t-cxl", "status": "cancelled", "error": {"message": "user cancelled"}}
+        )
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=cancelled),
+        )
+        fake_download = AsyncMock()
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(RuntimeError, match="user cancelled"):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                    )
+                )
         fake_download.assert_not_called()
 
     async def test_completed_without_video_url_raises(self, tmp_path: Path):

--- a/tests/test_agnes_video_backend.py
+++ b/tests/test_agnes_video_backend.py
@@ -1,0 +1,585 @@
+"""AgnesVideoBackend 单元测试（mock httpx，注入时钟、不打真实墙钟）。"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from lib.providers import PROVIDER_AGNES
+from lib.video_backends.base import (
+    ResumeExpiredError,
+    VideoCapability,
+    VideoCapabilityError,
+    VideoGenerationRequest,
+)
+
+
+def _make_response(status_code: int, json_body: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _make_http_error(status_code: int, message: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://apihub.agnes-ai.com/v1/videos")
+    response = httpx.Response(status_code, request=request, text=message)
+    return httpx.HTTPStatusError(f"Server error '{status_code}'", request=request, response=response)
+
+
+def _fake_download_factory(payload: bytes = b"mp4-bytes"):
+    async def _fake(url: str, output_path: Path, *, timeout: int = 120) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(payload)
+
+    return _fake
+
+
+def _completed(task_id: str = "task-1", url: str = "https://cdn.agnes/out.mp4", **extra) -> dict:
+    body = {
+        "task_id": task_id,
+        "status": "completed",
+        "size": "720x1280",
+        "remixed_from_video_id": url,
+    }
+    body.update(extra)
+    return body
+
+
+def _mock_client(*, post=None, get=None) -> AsyncMock:
+    client = AsyncMock()
+    client.post = post or AsyncMock()
+    client.get = get or AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+def _write_image(path: Path, payload: bytes) -> Path:
+    path.write_bytes(payload)
+    return path
+
+
+class TestCapabilities:
+    def test_name_and_model(self):
+        from lib.video_backends.agnes import AgnesVideoBackend
+
+        backend = AgnesVideoBackend(api_key="sk-test", base_url="https://apihub.agnes-ai.com/v1")
+        assert backend.name == PROVIDER_AGNES
+        assert backend.model == "agnes-video-v2.0"
+
+    def test_default_model_when_unset(self):
+        from lib.video_backends.agnes import AgnesVideoBackend
+
+        backend = AgnesVideoBackend(api_key="sk-test")
+        assert backend.model == "agnes-video-v2.0"
+
+    def test_capabilities_and_video_capabilities(self):
+        from lib.video_backends.agnes import AgnesVideoBackend
+
+        backend = AgnesVideoBackend(api_key="sk-test")
+        assert VideoCapability.TEXT_TO_VIDEO in backend.capabilities
+        assert VideoCapability.IMAGE_TO_VIDEO in backend.capabilities
+        caps = backend.video_capabilities
+        assert caps.first_frame is True
+        assert caps.last_frame is True
+        assert caps.reference_images is True
+        assert caps.max_reference_images == 4
+        # 单通道 + mode 不可叠加：参考图不与首帧并存
+        assert caps.reference_images_with_start_frame is False
+
+
+class TestNumFramesAndSize:
+    @pytest.mark.parametrize(
+        ("duration", "expected_frames"),
+        [(1, 25), (3, 73), (5, 121), (10, 241), (18, 433)],
+    )
+    def test_duration_to_num_frames_aligns_to_8n_plus_1(self, duration: int, expected_frames: int):
+        from lib.video_backends.agnes import _duration_to_num_frames
+
+        frames = _duration_to_num_frames(duration)
+        assert frames == expected_frames
+        assert (frames - 1) % 8 == 0  # 形如 8n+1
+        assert frames <= 441
+
+    def test_resolve_size_portrait_explicit_hw(self):
+        from lib.video_backends.agnes import _resolve_size
+
+        width, height = _resolve_size("720p", "9:16")
+        assert (width, height) == (720, 1280)
+        assert width % 8 == 0 and height % 8 == 0
+
+
+class TestTextToVideo:
+    async def test_happy_path_submits_and_polls(self, tmp_path: Path):
+        create_resp = _make_response(200, {"task_id": "task-42", "status": "queued"})
+        poll_resp = _make_response(200, _completed("task-42", "https://cdn.agnes/out.mp4", seconds="5.0"))
+
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"mp4-bytes"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="sk-test", base_url="https://apihub.agnes-ai.com/v1")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="A cat running",
+                    output_path=tmp_path / "out.mp4",
+                    aspect_ratio="9:16",
+                    resolution="720p",
+                    duration_seconds=5,
+                    seed=7,
+                )
+            )
+
+        assert result.video_path == tmp_path / "out.mp4"
+        assert result.video_path.read_bytes() == b"mp4-bytes"
+        assert result.provider == PROVIDER_AGNES
+        assert result.model == "agnes-video-v2.0"
+        assert result.duration_seconds == 5
+        assert result.task_id == "task-42"
+        assert result.video_uri == "https://cdn.agnes/out.mp4"
+
+        post_call = client.post.call_args
+        assert post_call.args[0] == "https://apihub.agnes-ai.com/v1/videos"
+        body = post_call.kwargs["json"]
+        assert body["model"] == "agnes-video-v2.0"
+        assert body["prompt"] == "A cat running"
+        assert body["height"] == 1280
+        assert body["width"] == 720
+        assert body["num_frames"] == 121
+        assert body["frame_rate"] == 24
+        assert body["seed"] == 7
+        # 文生视频：无任何图像通道
+        assert "image" not in body
+        assert "extra_body" not in body
+        assert post_call.kwargs["headers"]["Authorization"] == "Bearer sk-test"
+        # submit 用长超时覆盖上游长阻塞
+        assert post_call.kwargs["timeout"] == 300.0
+
+        # 下载从 remixed_from_video_id 成片 URL，不带 auth
+        fake_download.assert_called_once()
+        assert fake_download.call_args.args[0] == "https://cdn.agnes/out.mp4"
+
+    async def test_polls_through_in_progress(self, tmp_path: Path):
+        create_resp = _make_response(200, {"task_id": "t3", "status": "queued"})
+        in_progress = _make_response(200, {"task_id": "t3", "status": "in_progress", "progress": 40})
+        completed = _make_response(200, _completed("t3"))
+
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(side_effect=[in_progress, in_progress, completed]),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert result.task_id == "t3"
+        assert client.get.call_count == 3
+        fake_download.assert_called_once()
+
+
+class TestImageChannels:
+    async def test_start_image_is_bare_base64_top_level_image(self, tmp_path: Path):
+        """起始图为裸 base64（无 data: 前缀），未复用 data-URI helper。"""
+        img_bytes = b"\x89PNG\r\nfake-start"
+        img_path = _write_image(tmp_path / "start.png", img_bytes)
+
+        create_resp = _make_response(200, {"task_id": "t1", "status": "queued"})
+        poll_resp = _make_response(200, _completed("t1"))
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.mp4",
+                    start_image=img_path,
+                    aspect_ratio="9:16",
+                    duration_seconds=5,
+                )
+            )
+
+        sent = client.post.call_args.kwargs["json"]["image"]
+        expected = base64.b64encode(img_bytes).decode("ascii")
+        assert sent == expected
+        # 裸 base64，绝不带 data: 前缀
+        assert not sent.startswith("data:")
+        assert "extra_body" not in client.post.call_args.kwargs["json"]
+
+    async def test_first_last_keyframes_extra_body(self, tmp_path: Path):
+        start = _write_image(tmp_path / "s.png", b"start-bytes")
+        end = _write_image(tmp_path / "e.png", b"end-bytes")
+
+        create_resp = _make_response(200, {"task_id": "t-kf", "status": "queued"})
+        poll_resp = _make_response(200, _completed("t-kf"))
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.mp4",
+                    start_image=start,
+                    end_image=end,
+                    aspect_ratio="9:16",
+                    duration_seconds=5,
+                )
+            )
+
+        body = client.post.call_args.kwargs["json"]
+        assert "image" not in body  # 单通道：keyframes 走 extra_body，不占顶层 image
+        extra = body["extra_body"]
+        assert extra["mode"] == "keyframes"
+        assert extra["image"] == [
+            base64.b64encode(b"start-bytes").decode("ascii"),
+            base64.b64encode(b"end-bytes").decode("ascii"),
+        ]
+        assert all(not s.startswith("data:") for s in extra["image"])
+
+    async def test_reference_images_extra_body(self, tmp_path: Path):
+        ref1 = _write_image(tmp_path / "r1.png", b"ref-1")
+        ref2 = _write_image(tmp_path / "r2.png", b"ref-2")
+
+        create_resp = _make_response(200, {"task_id": "t-ref", "status": "queued"})
+        poll_resp = _make_response(200, _completed("t-ref"))
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.mp4",
+                    reference_images=[ref1, ref2],
+                    aspect_ratio="9:16",
+                    duration_seconds=5,
+                )
+            )
+
+        body = client.post.call_args.kwargs["json"]
+        assert "image" not in body
+        extra = body["extra_body"]
+        assert "mode" not in extra  # 参考生视频不带 keyframes mode
+        assert extra["image"] == [
+            base64.b64encode(b"ref-1").decode("ascii"),
+            base64.b64encode(b"ref-2").decode("ascii"),
+        ]
+
+    async def test_reference_images_exceeded_raises(self, tmp_path: Path):
+        refs = [_write_image(tmp_path / f"r{i}.png", f"r{i}".encode()) for i in range(5)]
+        client = _mock_client(post=AsyncMock(side_effect=AssertionError("超限不应提交")))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(VideoCapabilityError) as ei:
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p",
+                        output_path=tmp_path / "o.mp4",
+                        reference_images=refs,
+                        aspect_ratio="9:16",
+                        duration_seconds=5,
+                    )
+                )
+            assert ei.value.code == "video_reference_images_exceeded"
+
+    async def test_missing_start_image_fails_loud(self, tmp_path: Path):
+        client = _mock_client(post=AsyncMock(side_effect=AssertionError("缺图不应提交")))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(VideoCapabilityError) as ei:
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p",
+                        output_path=tmp_path / "o.mp4",
+                        start_image=tmp_path / "missing.png",
+                        aspect_ratio="9:16",
+                        duration_seconds=5,
+                    )
+                )
+            assert ei.value.code == "video_start_image_unreadable"
+
+
+class TestFailureAndTimeout:
+    async def test_failed_status_raises(self, tmp_path: Path):
+        create_resp = _make_response(200, {"task_id": "t2", "status": "queued"})
+        poll_resp = _make_response(200, {"task_id": "t2", "status": "failed", "error": {"message": "upstream down"}})
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock()
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(RuntimeError, match="upstream down"):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                    )
+                )
+
+        fake_download.assert_not_called()
+
+    async def test_completed_without_video_url_raises(self, tmp_path: Path):
+        create_resp = _make_response(200, {"task_id": "t-nourl", "status": "queued"})
+        poll_resp = _make_response(200, {"task_id": "t-nourl", "status": "completed"})
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock()
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(RuntimeError, match="remixed_from_video_id"):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                    )
+                )
+        fake_download.assert_not_called()
+
+    async def test_polling_timeout_raises(self, tmp_path: Path):
+        create_resp = _make_response(200, {"task_id": "t-timeout", "status": "queued"})
+        in_progress = _make_response(200, {"task_id": "t-timeout", "status": "in_progress"})
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=in_progress),
+        )
+        fake_download = AsyncMock()
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes._MIN_POLL_TIMEOUT_SECONDS", 0.01),
+            patch("lib.video_backends.agnes._POLL_TIMEOUT_PER_SECOND", 0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(TimeoutError, match="Agnes"):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                    )
+                )
+        fake_download.assert_not_called()
+
+
+class TestSubmitResilience:
+    async def test_submit_retries_on_503_busy(self, tmp_path: Path):
+        """503 Service busy → 经 should_retry_submit 的 status_code 闸门重试。"""
+        busy = MagicMock()
+        busy.status_code = 503
+        busy.raise_for_status = MagicMock(side_effect=_make_http_error(503, "Service busy"))
+        create_resp = _make_response(200, {"task_id": "t-retry", "status": "queued"})
+        poll_resp = _make_response(200, _completed("t-retry"))
+
+        client = _mock_client(
+            post=AsyncMock(side_effect=[busy, busy, create_resp]),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert result.task_id == "t-retry"
+        assert client.post.call_count == 3
+
+    async def test_submit_non_retryable_4xx_fails_fast(self, tmp_path: Path):
+        bad = _make_response(400, {"error": "bad request"})
+        bad.raise_for_status = MagicMock(side_effect=_make_http_error(400, "bad request"))
+        client = _mock_client(
+            post=AsyncMock(return_value=bad),
+            get=AsyncMock(side_effect=AssertionError("4xx 应在提交阶段失败，不该轮询")),
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(httpx.HTTPStatusError):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                    )
+                )
+        assert client.post.call_count == 1
+
+    async def test_submit_read_timeout_wraps_ambiguous(self, tmp_path: Path):
+        from lib.video_backends.base import AmbiguousSubmitError
+
+        client = _mock_client(
+            post=AsyncMock(side_effect=httpx.ReadTimeout("read timed out")),
+            get=AsyncMock(side_effect=AssertionError("歧义态不该轮询")),
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(AmbiguousSubmitError):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                    )
+                )
+        assert client.post.call_count == 1
+
+
+class TestResume:
+    async def test_resume_polls_existing_job_no_submit(self, tmp_path: Path):
+        poll_resp = _make_response(200, _completed("task-resume", "https://cdn/resumed.mp4"))
+        client = _mock_client(
+            post=AsyncMock(side_effect=AssertionError("resume 不应 POST create")),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"resumed"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            result = await backend.resume_video(
+                "task-resume",
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+                ),
+            )
+
+        client.post.assert_not_called()
+        assert client.get.call_args.args[0].endswith("/videos/task-resume")
+        assert result.task_id == "task-resume"
+        assert (tmp_path / "out.mp4").read_bytes() == b"resumed"
+
+    async def test_resume_404_raises_resume_expired_without_retry(self, tmp_path: Path):
+        not_found = _make_response(404, {"error": "task not found"})
+        not_found.raise_for_status = MagicMock(side_effect=_make_http_error(404, "task not found"))
+        client = _mock_client(get=AsyncMock(return_value=not_found))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(ResumeExpiredError) as ei:
+                await backend.resume_video(
+                    "task-404",
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+                    ),
+                )
+            assert ei.value.job_id == "task-404"
+            assert ei.value.provider == PROVIDER_AGNES
+            assert client.get.call_count == 1
+
+
+class TestRegistration:
+    def test_registered_in_video_backend_registry(self):
+        from lib.video_backends import create_backend, get_registered_backends
+
+        assert PROVIDER_AGNES in get_registered_backends()
+        backend = create_backend(PROVIDER_AGNES, api_key="sk-test", base_url="https://x/v1")
+        assert backend.name == PROVIDER_AGNES

--- a/tests/test_pricing_lookup.py
+++ b/tests/test_pricing_lookup.py
@@ -53,6 +53,20 @@ class TestRegistryHit:
         # 输入 $0.03 / 输出 $0.15 每 1M tokens
         assert pricing.rates["agnes-2.0-flash"] == {"input": 0.03, "output": 0.15}
 
+    def test_agnes_video_flat_per_second(self):
+        from lib.pricing.strategies import PricingParams, calculate_pricing
+
+        pricing = lookup_pricing("agnes", "agnes-video-v2.0", "video")
+        assert isinstance(pricing, PerSecondMatrix)
+        assert pricing.dimensions == "flat"
+        assert pricing.currency == "USD"
+        # flat 按秒 $0.005/s，与分辨率/音频无关
+        amount, currency = calculate_pricing(
+            pricing, PricingParams(call_type="video", model="agnes-video-v2.0", duration_seconds=10)
+        )
+        assert amount == pytest.approx(0.05)
+        assert currency == "USD"
+
 
 class TestUnknownProviderFallsBackToGemini:
     @pytest.mark.parametrize("provider", ["gemini", "unknown", "seedance"])


### PR DESCRIPTION
## 概述

接入 Agnes 视频生成后端（图生视频 / 首尾帧 / 参考生视频），并修复 #747：reference_video 模式下本地参考图以**裸 base64** 传给上游，不再报 `fail_to_fetch_task`。

参照 new-api 家族（异步 base64-JSON）实现 `AgnesVideoBackend`：

- **裸 base64**：参考 / 首尾帧剥离 `data:` 前缀传输，不复用通用 data-URI helper（视频端对带前缀整串解码会 padding 错误）。偏离惯例处已加行为注释。
- **异步状态机**：`POST /v1/videos` submit → 持久化 task_id → 轮询 `GET /v1/videos/{task_id}` 至 `completed` → 取 `remixed_from_video_id` 成片 URL → 下载。
- **提交韧性**：submit 超时 300s（覆盖上游实测最长 256s 长阻塞）；`503 busy` / `429` 走 submit 重试，复用按 HTTP 状态码判定的谓词（5xx/408/429 重试、确定性 4xx 快失败）。
- **能力声明**：fps=24；时长 1–18s（`num_frames = 8n+1` 对齐）；aspect_size 显式下发 h×w。
- **关键帧映射**：无图→文生视频、起始图→顶层 `image`、首尾→`extra_body.image=[s,e]+mode:keyframes`、参考图→`extra_body.image=[refs]`；单通道不叠加。
- **resume**：复用 `ProviderJobIdPersistenceMixin`，`resume_video` 仅轮询不重新 submit、不重复扣费。
- registry 增 `agnes-video-v2.0`；定价按秒 flat $0.005/s（USD），复用 `PerSecondMatrix` flat 形状，`agnes` 已在 `_OWN_TABLE_PROVIDERS`。

## 待实测真值（provisional，保守取值 + 注释标注，未臆造）

受 Agnes 1 req/min 限流未能逐项实测，以下取保守值并在代码注释标「待 console / 实测核对」：

- `max_reference_images=4`、`max_long_edge=1920`、`round_to=8`

已实测确认（勿回退）：繁忙=HTTP 503、限流=HTTP 429（均进重试集）、submit 阻塞实测最长 256s、sub-81 帧被接受（num_frames=25 进 queued）、happy-path 字段形态、显式 h×w 被采用。

## 本地审查发现与修复

`/code-review`（xhigh，多 finder + 独立 verify）后应用的修复：

- 错误信息不再回显上游完整响应体（可能含签名 URL 等敏感字段），仅暴露字段名
- 首尾帧模式尾帧不可读时报错指向尾帧（新增 `video_end_image_unreadable`，三语一致）
- 计费时长改 half-up 取整并拒绝非正 / 超 24h 值（复用 `MAX_BILLED_DURATION_SECONDS`），消除截断与 0 秒透传
- 非 `failed` 失败终态（cancelled / error 等）快速失败，不再轮询到 timeout
- 成片无音频固定 `generate_audio=False`，避免下游计费 / 元数据 / 剪映导出误判
- 空 `Path` 归一化为 None，回落文生视频而非误报无法读取
- base64 编码 offload 到线程，避免阻塞事件循环；三个 encode 方法合并为参数化辅助

未采纳（house pattern / 越界）：`_download_with_retry` 双层重试为全后端统一约定；裸 base64 helper 跨 provider 上提、`_safe_body_for_log` 抽取属更大范围重构，留后续。

## 验证

- `uv run pytest tests/`：5462 passed
- `uv run ruff check` + `format`：clean（改动文件）
- `uv run basedpyright`：0 errors
- rebase 到最新 main（含 #965 / #966），加性冲突已保留双边意图（registry/specs/i18n/test 三模态并存）

Closes #943


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Agnes 现已支持视频生成：启用默认视频模型，支持文生视频、首尾关键帧、多参考图生成；并提供可恢复的任务续跑能力。
  * 扩展 Agnes 视频计费：新增按秒（USD，flat 维度）定价与模型定价回溯校验。
* **Bug 修复**
  * 完善视频相关校验与错误提示：参考图与首/尾帧互斥、首尾帧图片不可读、末帧需配合首帧等场景给出更明确的报错文案（中英/越南语）。
* **文档**
  * 更新 Agnes 提供商说明：从“图像与文本”扩展为“图像、文本与视频”。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->