### PR TITLE
feat(agnes): 视频出厂默认并发 1，避免主动触发上游 503

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -1245,6 +1245,9 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             ),
         },
         default_base_url=AGNES_BASE_URL,
+        # Agnes 视频上游对并发敏感，出厂串行（默认 1）避免主动制造 503 Service busy；
+        # 用户可经 video_max_workers 覆盖。其余 lane 未声明，走全局默认。
+        default_concurrency={"video": 1},
     ),
 }
 

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -242,10 +242,11 @@ class TestCapacityTable:
 
         monkeypatch.delenv("IMAGE_MAX_WORKERS", raising=False)
         monkeypatch.delenv("VIDEO_MAX_WORKERS", raising=False)
+        monkeypatch.delenv("AUDIO_MAX_WORKERS", raising=False)
         table = CapacityTable.from_env()
         for pid, meta in PROVIDER_REGISTRY.items():
             assert pid in table._limits
-            for lane, global_default in (("image", 5), ("video", 3)):
+            for lane, global_default in (("image", 5), ("video", 3), ("audio", 10)):
                 if lane not in meta.media_types:
                     assert table.get(pid, lane) == 0  # 不支持的 lane → 投影为 0
                 elif lane not in meta.default_concurrency:

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -245,8 +245,15 @@ class TestCapacityTable:
         table = CapacityTable.from_env()
         for pid, meta in PROVIDER_REGISTRY.items():
             assert pid in table._limits
-            assert table.get(pid, "image") == (5 if "image" in meta.media_types else 0)
-            assert table.get(pid, "video") == (3 if "video" in meta.media_types else 0)
+            for lane, global_default in (("image", 5), ("video", 3)):
+                if lane not in meta.media_types:
+                    assert table.get(pid, lane) == 0  # 不支持的 lane → 投影为 0
+                elif lane not in meta.default_concurrency:
+                    # 未声明出厂默认的 lane 必须落到硬编码全局默认。这条断言不读
+                    # meta.default_concurrency，故非重言——能抓住装载回退漂移。声明了默认的
+                    # lane（如 agnes video）由该 provider 的专项测试钉死字面值；此处不用 meta
+                    # 反推，否则对任何声明值都恒真，等于不设防。
+                    assert table.get(pid, lane) == global_default
 
     def test_from_env_reads_env(self, monkeypatch):
         monkeypatch.setenv("IMAGE_MAX_WORKERS", "7")
@@ -491,6 +498,23 @@ class TestCapacityTable:
         for pid in ("declared-video", "declared-audio", "plain-video", "declared-unsupported"):
             for lane in ("image", "video", "audio"):
                 assert db_table.get(pid, lane) == env_table.get(pid, lane)
+
+    def test_agnes_video_default_one_outranks_active_global_env(self, monkeypatch):
+        """真实注册表：Agnes 视频 lane 出厂钉死 1，即便部署把全局 VIDEO_MAX_WORKERS 调高也不解除。
+
+        这是本切片要的 503 规避保证——声明默认压过「活跃的」全局 env（而非仅压过缺省值）。
+        顺带验证两条隔离性质：声明只作用于 video lane（image 仍随全局默认）；钉死是 Agnes 专属，
+        未声明默认的视频供应商（ark）仍跟随全局 env。机制本身（声明默认 > 全局、用户值 > 声明默认、
+        跨 from_env/from_db 一致）已由上面的合成 declared-* 测试覆盖，此处只钉真实条目的接线。
+        """
+        monkeypatch.delenv("IMAGE_MAX_WORKERS", raising=False)
+        monkeypatch.setenv("VIDEO_MAX_WORKERS", "5")
+
+        table = CapacityTable.from_env()
+
+        assert table.get("agnes", "video") == 1  # 声明默认压过活跃的全局 5
+        assert table.get("agnes", "image") == 5  # 声明不外溢到未声明的 image lane
+        assert table.get("ark", "video") == 5  # 未声明默认的视频供应商仍跟随全局 env
 
 
 class TestGenerationWorker:


### PR DESCRIPTION
## 背景

Agnes 视频上游对并发敏感，并发偏高会主动触发 `503 Service busy`。此前 Agnes 视频 lane 跟随全局默认并发（3），出厂即可能制造上游过载。

## 改动

- registry `"agnes"` 条目声明 `default_concurrency={"video": 1}`：用户未配置时视频 lane 出厂即串行，避免主动触发上游 503。
- 用户仍可在设置页经 `video_max_workers` 覆盖（`video_max_workers` 已在 `optional_keys`）。
- 回退优先级：用户配置值 > 注册表声明默认（1）> 全局默认。机制由现有 `ProviderMeta.default_concurrency` 校验 + `CapacityTable` 三层回退提供，本改动为声明性接线。

## 测试

- 新增 `test_agnes_video_default_one_outranks_active_global_env`：真实注册表下，即便把全局 `VIDEO_MAX_WORKERS` 调高，Agnes 视频仍钉死 1（声明默认压过活跃 env）；声明不外溢到 image lane；未声明默认的视频供应商（ark）仍跟随全局 env。
- 调整既有 `test_from_env_derives_support_and_defaults`：对未声明默认的 lane 断言硬编码全局默认（非重言，能抓住回退漂移），声明默认的 lane 由专项测试钉死字面值。
- 同时复用现有合成 `declared-*` 测试覆盖通用机制（声明默认 > 全局、用户值 > 声明默认、from_env/from_db 一致）。

质量门全绿：`uv run pytest tests/`（5471 passed）、`uv run ruff check . && uv run ruff format .`、`uv run basedpyright`（0 errors）。

Closes #944


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 部分供应商的视频任务现在采用更保守的默认并发（默认为串行），以降低服务繁忙风险。
  - 未单独配置的处理通道继续沿用全局默认，并可通过环境配置覆盖视频通道默认值。

- **Bug Fixes**
  - 修正高并发下视频通道可能触发 `503 Service busy` 的问题。
  - 确保供应商级视频默认优先级高于全局环境设置。

- **Tests**
  - 完善容量默认与回退逻辑校验，并新增对视频默认优先级的覆盖用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->