### PR TITLE
fix(providers): 并发上限禁止填 0，要求 ≥1 或留空回退默认

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,7 +62,7 @@ _Avoid_: job（无此概念）。
 中间状态，表示 cancel 信号已发出但 worker 内 asyncio task 尚未走完 finally 收尾。cancel API 把 DB 从 `running` 改成 `cancelling` 后立即返回；worker finally 在 mark 终态时只能从 `cancelling` 转 `cancelled`（不再走 succeeded/failed 分支）。这是状态机里唯一一个**从 `running` 出发、由 worker 之外的代码改写的非终态**——`queued` 由 enqueue API 写、`cancelled` 直接由 cancel queued 路径写都属于「外部写入」，但前者不从 running 出发、后者是终态。
 
 **slot（执行槽）**：
-GenerationWorker 内并发执行 task 的容量，维度是 **provider × media_type**（不是简单的 image/video 两条总通道）。slot 拆成两件性质不同的东西：**容量**是 provider config 给的上限标量（唯一真相，用户改设置才变），默认 `IMAGE_MAX_WORKERS=5` / `VIDEO_MAX_WORKERS=3`，可在 provider config 里覆盖；每条 lane 按三层回退取值——**用户配置值 > 供应商在注册表（`ProviderMeta.default_concurrency`）声明的出厂默认 > 全局默认**，声明默认是给上游容量受限的供应商出厂即串行/限并发的中间层，未声明的供应商仍退全局默认；**占用**是 worker 内存里在跑 / 排队的 task 记账（随 task 来去一直在变）。TTS 落地后并列新增 audio 容量（`AUDIO_MAX_WORKERS`，默认值随实现设定——TTS 便宜快、倾向放宽，见 `docs/adr/0010`）。一个 provider 的 video 池满，**只阻塞该 provider 的 video 任务**，不影响其他 provider；但若用户的项目只配了一个 video provider，这等于阻塞所有 video 任务。
+GenerationWorker 内并发执行 task 的容量，维度是 **provider × media_type**（不是简单的 image/video 两条总通道）。slot 拆成两件性质不同的东西：**容量**是 provider config 给的上限标量（唯一真相，用户改设置才变），默认 `IMAGE_MAX_WORKERS=5` / `VIDEO_MAX_WORKERS=3`，可在 provider config 里覆盖；每条 lane 按三层回退取值——**用户配置值 > 供应商在注册表（`ProviderMeta.default_concurrency`）声明的出厂默认 > 全局默认**，声明默认是给上游容量受限的供应商出厂即串行/限并发的中间层，未声明的供应商仍退全局默认；**占用**是 worker 内存里在跑 / 排队的 task 记账（随 task 来去一直在变）。TTS 落地后并列新增 audio 容量（`AUDIO_MAX_WORKERS`，默认值随实现设定——TTS 便宜快、倾向放宽，见 `docs/adr/0010`）。一个 provider 的 video 池满，**只阻塞该 provider 的 video 任务**，不影响其他 provider；但若用户的项目只配了一个 video provider，这等于阻塞所有 video 任务。用户可配的并发上限是 **≥1 的整数，或留空（= 回退默认）**；`0` 不是合法用户输入，仅作 CapacityTable 内部「不支持该 lane」哨兵（由 `_lane_limits` 按 `media_types` 投影产生），见 `docs/adr/0043`。
 _Avoid_: concurrency limit（太泛）。
 
 **CapacityTable / SlotTable**：

--- a/alembic/versions/a7a9749a1ae0_add_max_workers_columns_to_custom_.py
+++ b/alembic/versions/a7a9749a1ae0_add_max_workers_columns_to_custom_.py
@@ -22,37 +22,38 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     """Upgrade schema.
 
-    Additive nullable per-lane concurrency columns with DB-level non-negative
-    CHECK constraints. No backfill — existing rows are correct with NULL
+    Additive nullable per-lane concurrency columns with DB-level positive
+    (>= 1) CHECK constraints. No backfill — existing rows are correct with NULL
     (NULL = unset → capacity loader falls back to global default), and none of
     the columns participates in any WHERE/filter. The CHECK constraints enforce
-    the NULL/0/positive semantics at the storage layer so repo writes and manual
-    SQL cannot persist negative worker counts.
+    the NULL/positive semantics at the storage layer so repo writes and manual
+    SQL cannot persist zero or negative worker counts (0 is reserved as the
+    CapacityTable internal unsupported-lane sentinel, never a user input).
     """
     with op.batch_alter_table("custom_provider", schema=None) as batch_op:
         batch_op.add_column(sa.Column("image_max_workers", sa.Integer(), nullable=True))
         batch_op.add_column(sa.Column("video_max_workers", sa.Integer(), nullable=True))
         batch_op.add_column(sa.Column("audio_max_workers", sa.Integer(), nullable=True))
         batch_op.create_check_constraint(
-            "ck_custom_provider_image_max_workers_non_negative",
-            "image_max_workers IS NULL OR image_max_workers >= 0",
+            "ck_custom_provider_image_max_workers_positive",
+            "image_max_workers IS NULL OR image_max_workers >= 1",
         )
         batch_op.create_check_constraint(
-            "ck_custom_provider_video_max_workers_non_negative",
-            "video_max_workers IS NULL OR video_max_workers >= 0",
+            "ck_custom_provider_video_max_workers_positive",
+            "video_max_workers IS NULL OR video_max_workers >= 1",
         )
         batch_op.create_check_constraint(
-            "ck_custom_provider_audio_max_workers_non_negative",
-            "audio_max_workers IS NULL OR audio_max_workers >= 0",
+            "ck_custom_provider_audio_max_workers_positive",
+            "audio_max_workers IS NULL OR audio_max_workers >= 1",
         )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
     with op.batch_alter_table("custom_provider", schema=None) as batch_op:
-        batch_op.drop_constraint("ck_custom_provider_audio_max_workers_non_negative", type_="check")
-        batch_op.drop_constraint("ck_custom_provider_video_max_workers_non_negative", type_="check")
-        batch_op.drop_constraint("ck_custom_provider_image_max_workers_non_negative", type_="check")
+        batch_op.drop_constraint("ck_custom_provider_audio_max_workers_positive", type_="check")
+        batch_op.drop_constraint("ck_custom_provider_video_max_workers_positive", type_="check")
+        batch_op.drop_constraint("ck_custom_provider_image_max_workers_positive", type_="check")
         batch_op.drop_column("audio_max_workers")
         batch_op.drop_column("video_max_workers")
         batch_op.drop_column("image_max_workers")

--- a/docs/adr/0043-forbid-zero-user-concurrency-keep-internal-sentinel.md
+++ b/docs/adr/0043-forbid-zero-user-concurrency-keep-internal-sentinel.md
@@ -1,0 +1,18 @@
+---
+status: accepted
+---
+
+# 供应商并发上限禁止 0 作用户输入（要求 ≥1 或留空），0 仅保留为内部不支持-lane 哨兵
+
+`0` 在并发体系里身兼两职、彼此冲突：CapacityTable 内部把某 lane 容量 `0` 当作「该供应商不支持此媒体」哨兵（`_lane_limits` 按 `media_types` 把未支持的 lane 投影为 `0`，worker `if cap <= 0` 即 `mark_failed("provider_unsupported_media")` fast-fail）；而用户可配的并发上限字段（内置经 `_validate_value`、自定义经 API `ge=0` + DB `CHECK >= 0`）此前一律**接受** `0`。用户填 `0`（误读「默认」占位符、或以为 `0`=不限）会静默把该 lane 关死，之后每个任务报「供应商不支持此媒体」——一个无声且失败信息答非所问的 footgun。注册表出厂默认 `ProviderMeta.default_concurrency` 早已要求 `>= 1`，唯独用户值放行 `0`，两侧不对称。
+
+我们决定**把 `0` 从合法用户输入中移除**：所有用户输入层（前端表单、自定义供应商 API `Field(ge=1)`、内置 `_validate_value` 的 `parsed < 1`）与 DB CHECK（`custom_provider` 三列 `>= 1`）统一要求 `>= 1`，留空 / `NULL` 仍表示「回退默认」。`0` 仅保留为 CapacityTable 内部「不支持该 lane」哨兵，不对用户开放。承自定义供应商并发上线（ADR 0042）尚未发版，DB CHECK 的收紧**直接改写其加列迁移**（`>= 0` → `>= 1`、约束名 `_non_negative` → `_positive`），不新增迁移、无数据回填（`0` 无自动来源，唯一来源是用户输入，堵在门口即不再产生）。运行时 `if cap <= 0` / `_lane_limits` / `provider_unsupported_media` 一概不动——`0` 此后只可能源自「该供应商本就不支持此媒体」，失败码语义恰好正确。
+
+**明确不采用**：把 `0` 立为「禁用该 lane」一等公民。provider 在入队时即绑定，`0` 不会把任务改道到别的供应商、只会 fast-fail，实现不了「优雅禁用」；三层回退已用留空 / `NULL` 干净表达「用默认」，`0` 无须承担第二语义；不想用某供应商跑某 lane 的诚实做法是不为该 lane 选它。若将来「禁用某供应商的某 lane」成为真实需求，应另设显式开关并配诚实的失败码，而非重载 `0`。
+
+## Consequences
+
+- **两个 `0` 角色彻底分离**：用户契约层「并发上限是 ≥1 整数或留空」与内部「容量 `0` = 不支持该 lane」不再混用同一个用户可达的值；CONTEXT.md「容量」词条同步补记用户契约面。
+- **改写已合入 main 的迁移**：并进的其他 worktree / dev DB 若已 `alembic upgrade head` 跑过旧（`>= 0`）版本，CHECK 不会自动收紧（alembic 不重跑已应用 revision），需 `downgrade -1 && upgrade head` 或重建 dev DB。因未发版且 `0` 无自动来源，实践无害；这是「未发布迁移可就地改写」的有意取舍，发布后不可再用此手法。
+- **改动收敛**：三处输入层校验 + 三列 DB CHECK + 原迁移就地收紧 + i18n 文案（后端 `max_workers_must_be_positive_integer`、前端「正整数」与帮助文案）+ 相应测试。运行时调度、SlotTable、lane 隔离、reload 一概不动。
+- **守住边界**：与注册表 `default_concurrency >= 1` 规则统一；上承 ADR 0042（自定义供应商并发定型列）。

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -133,15 +133,15 @@ function workersToStr(n?: number | null): string {
   return n != null ? String(n) : "";
 }
 
-// 空串 = 未设置（null，走全局默认）；否则必须是非负整数。返回 undefined 表示非法
-// 输入（小数、科学计数、负号、含非数字字符），由 handleSave 拦截并提示——不再用 parseInt
-// 静默截断（"1.5"→1、"1e3"→1）把非法值写成错误配置。
+// 空串 = 未设置（null，走全局默认）；否则必须是正整数（≥1）。返回 undefined 表示非法
+// 输入（0、小数、科学计数、负号、含非数字字符），由 handleSave 拦截并提示——不再用 parseInt
+// 静默截断（"1.5"→1、"1e3"→1）把非法值写成错误配置。0 不是合法用户输入。
 function parseWorkers(s: string): number | null | undefined {
   const trimmed = s.trim();
   if (!trimmed) return null;
   if (!/^\d+$/.test(trimmed)) return undefined;
   const n = Number(trimmed);
-  return Number.isSafeInteger(n) ? n : undefined;
+  return Number.isSafeInteger(n) && n >= 1 ? n : undefined;
 }
 
 function WorkersInput({
@@ -163,7 +163,7 @@ function WorkersInput({
       <input
         id={id}
         type="number"
-        min={0}
+        min={1}
         step={1}
         inputMode="numeric"
         autoComplete="off"

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -783,12 +783,12 @@ export default {
   'enable_one_model': 'At least one model must be enabled',
   'enabled_model_needs_id': 'Enabled models must have a model_id',
   'cp_concurrency_label': 'Concurrency Limits',
-  'cp_concurrency_help': 'Max concurrent tasks per media lane (image / video / audio). Leave blank to use the global default.',
+  'cp_concurrency_help': 'Max concurrent tasks per media lane (image / video / audio). Leave blank for the global default; minimum 1.',
   'cp_image_max_workers_label': 'Image Concurrency',
   'cp_video_max_workers_label': 'Video Concurrency',
   'cp_audio_max_workers_label': 'Audio Concurrency',
   'cp_max_workers_placeholder': 'Default',
-  'max_workers_invalid': 'Concurrency limits must be non-negative integers. Check the image / video / audio inputs.',
+  'max_workers_invalid': 'Concurrency limits must be positive integers. Check the image / video / audio inputs.',
 
   // CustomProviderDetail
   'discovery_format_label': 'Model Discovery Protocol',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -760,12 +760,12 @@ export default {
   'enable_one_model': 'Phải bật ít nhất một mô hình',
   'enabled_model_needs_id': 'Mô hình đã bật phải có model_id',
   'cp_concurrency_label': 'Giới hạn đồng thời',
-  'cp_concurrency_help': 'Số tác vụ đồng thời tối đa cho mỗi luồng phương tiện (ảnh / video / âm thanh). Để trống để dùng mặc định toàn cục.',
+  'cp_concurrency_help': 'Số tác vụ đồng thời tối đa cho mỗi luồng phương tiện (ảnh / video / âm thanh). Để trống = mặc định toàn cục; tối thiểu 1.',
   'cp_image_max_workers_label': 'Đồng thời ảnh',
   'cp_video_max_workers_label': 'Đồng thời video',
   'cp_audio_max_workers_label': 'Đồng thời âm thanh',
   'cp_max_workers_placeholder': 'Mặc định',
-  'max_workers_invalid': 'Giới hạn đồng thời phải là số nguyên không âm. Kiểm tra ô nhập hình ảnh / video / âm thanh.',
+  'max_workers_invalid': 'Giới hạn đồng thời phải là số nguyên dương. Kiểm tra ô nhập hình ảnh / video / âm thanh.',
 
   // CustomProviderDetail
   'discovery_format_label': 'Giao thức phát hiện mô hình',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -784,12 +784,12 @@ export default {
   'enable_one_model': '至少启用一个模型',
   'enabled_model_needs_id': '已启用的模型必须填写 model_id',
   'cp_concurrency_label': '并发上限',
-  'cp_concurrency_help': '各媒体通道（图片 / 视频 / 音频）的最大并发任务数。留空则使用全局默认。',
+  'cp_concurrency_help': '各媒体通道（图片 / 视频 / 音频）的最大并发任务数。留空 = 全局默认，最小 1。',
   'cp_image_max_workers_label': '图片并发',
   'cp_video_max_workers_label': '视频并发',
   'cp_audio_max_workers_label': '音频并发',
   'cp_max_workers_placeholder': '默认',
-  'max_workers_invalid': '并发上限必须为非负整数，请检查图片 / 视频 / 音频并发输入。',
+  'max_workers_invalid': '并发上限必须为正整数，请检查图片 / 视频 / 音频并发输入。',
 
   // CustomProviderDetail
   'discovery_format_label': '模型发现协议',

--- a/lib/config/service.py
+++ b/lib/config/service.py
@@ -26,10 +26,10 @@ _DEFAULT_NARRATION_VOICE = "Cherry"
 _DEFAULT_REFERENCE_TOTAL_MAX_BYTES = 8 * 1024 * 1024
 _DEFAULT_REFERENCE_SINGLE_MAX_BYTES = 4 * 1024 * 1024
 
-# 写入层校验为非负整数的容量键（与 CapacityTable 的三条 lane 一一对应）。
+# 写入层校验为正整数的容量键（与 CapacityTable 的三条 lane 一一对应）。
 # 其余 number 字段（image_rpm / video_rpm / request_gap）语义不同（允许小数），不在此列。
 _MAX_WORKERS_KEYS = frozenset({"image_max_workers", "video_max_workers", "audio_max_workers"})
-_MAX_WORKERS_CODE = "max_workers_must_be_nonnegative_integer"
+_MAX_WORKERS_CODE = "max_workers_must_be_positive_integer"
 
 
 class ProviderConfigValueError(ValueError):
@@ -261,10 +261,11 @@ class ConfigService:
 
     @staticmethod
     def _validate_value(provider: str, key: str, value: str) -> None:
-        """容量键写入校验：非负整数（0 合法，语义=该 lane 容量为 0 即 fail-fast）。
+        """容量键写入校验：正整数（≥1）。留空即不写该 key（回退默认），不会走到这里。
 
-        坏值一旦入库，容量 reload 只能逐 key 回退默认值，配置变更静默失效，
-        因此在写入口拦下。
+        0 不是合法用户输入——它仅作 CapacityTable 内部「不支持该 lane」哨兵，由 lane 投影
+        在内存里产生，绝不写回。坏值一旦入库，容量 reload 只能逐 key 回退默认值，配置变更
+        静默失效，因此在写入口拦下。
         """
         if key not in _MAX_WORKERS_KEYS:
             return
@@ -272,7 +273,7 @@ class ConfigService:
             parsed = int(value)
         except ValueError:
             raise ProviderConfigValueError(provider, key, value, code=_MAX_WORKERS_CODE) from None
-        if parsed < 0:
+        if parsed < 1:
             raise ProviderConfigValueError(provider, key, value, code=_MAX_WORKERS_CODE)
 
     @staticmethod

--- a/lib/db/models/custom_provider.py
+++ b/lib/db/models/custom_provider.py
@@ -12,20 +12,21 @@ class CustomProvider(TimestampMixin, Base):
     """用户自定义的 AI 供应商。"""
 
     __tablename__ = "custom_provider"
-    # 与加列迁移保持同步：三条并发上限列在 DB 层强制非负，repo 直写或手工 SQL 都无法
-    # 写入负值；NULL=未设置回退默认、0=该 lane 不支持仍然合法。
+    # 与加列迁移保持同步：三条并发上限列在 DB 层强制 ≥1，repo 直写或手工 SQL 都无法写入
+    # 0 或负值；NULL=未设置回退默认。0 不是合法用户输入，仅作 CapacityTable 内部「不支持该
+    # lane」哨兵（由 lane 投影在内存里产生，绝不写回这些列）。
     __table_args__ = (
         CheckConstraint(
-            "image_max_workers IS NULL OR image_max_workers >= 0",
-            name="ck_custom_provider_image_max_workers_non_negative",
+            "image_max_workers IS NULL OR image_max_workers >= 1",
+            name="ck_custom_provider_image_max_workers_positive",
         ),
         CheckConstraint(
-            "video_max_workers IS NULL OR video_max_workers >= 0",
-            name="ck_custom_provider_video_max_workers_non_negative",
+            "video_max_workers IS NULL OR video_max_workers >= 1",
+            name="ck_custom_provider_video_max_workers_positive",
         ),
         CheckConstraint(
-            "audio_max_workers IS NULL OR audio_max_workers >= 0",
-            name="ck_custom_provider_audio_max_workers_non_negative",
+            "audio_max_workers IS NULL OR audio_max_workers >= 1",
+            name="ck_custom_provider_audio_max_workers_positive",
         ),
     )
 

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -91,7 +91,7 @@ MESSAGES = {
     "source_conflict": "Source file '{existing}' already exists; suggested rename: '{suggested}'",
     # Providers
     "unknown_provider": "Unknown provider: {provider_id}",
-    "max_workers_must_be_nonnegative_integer": "{field} must be a non-negative integer, got: {value}",
+    "max_workers_must_be_positive_integer": "{field} must be a positive integer, got: {value}",
     "credentials_not_found": "Credentials not found",
     "vertex_json_read_failed": "Failed to read the uploaded file",
     "vertex_json_too_large": "Credentials file is too large",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -91,7 +91,7 @@ MESSAGES = {
     "source_conflict": "Tệp nguồn '{existing}' đã tồn tại; gợi ý đổi tên: '{suggested}'",
     # Providers
     "unknown_provider": "Nhà cung cấp không xác định: {provider_id}",
-    "max_workers_must_be_nonnegative_integer": "{field} phải là số nguyên không âm, đã nhận: {value}",
+    "max_workers_must_be_positive_integer": "{field} phải là số nguyên dương, đã nhận: {value}",
     "credentials_not_found": "Không tìm thấy thông tin xác thực",
     "vertex_json_read_failed": "Không đọc được tệp đã tải lên",
     "vertex_json_too_large": "Tệp thông tin xác thực quá lớn",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -91,7 +91,7 @@ MESSAGES = {
     "source_conflict": "源文件「{existing}」已存在，建议改名为「{suggested}」",
     # Providers
     "unknown_provider": "未知供应商: {provider_id}",
-    "max_workers_must_be_nonnegative_integer": "{field} 必须是非负整数，收到：{value}",
+    "max_workers_must_be_positive_integer": "{field} 必须是正整数，收到：{value}",
     "credentials_not_found": "凭证不存在",
     "vertex_json_read_failed": "读取上传文件失败",
     "vertex_json_too_large": "凭证文件过大",

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -44,8 +44,8 @@ def _validate_endpoint(value: str) -> str:
 EndpointType = Annotated[str, AfterValidator(_validate_endpoint)]
 DiscoveryFormatLiteral = Literal["openai", "google"]
 
-# 并发上限定型字段：可空非负整数；None = 未设置 → 容量装载回退全局默认。
-MaxWorkers = Annotated[int | None, Field(default=None, ge=0)]
+# 并发上限定型字段：可空正整数（≥1）；None = 未设置 → 容量装载回退全局默认。
+MaxWorkers = Annotated[int | None, Field(default=None, ge=1)]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_alembic_custom_provider_max_workers.py
+++ b/tests/test_alembic_custom_provider_max_workers.py
@@ -89,9 +89,12 @@ def test_upgrade_adds_columns_existing_row_null(alembic_cfg: Config, revisions: 
         engine.dispose()
 
 
+@pytest.mark.parametrize("bad_value", [-1, 0])
 @pytest.mark.parametrize("col", _COLS)
-def test_upgrade_rejects_negative_workers(alembic_cfg: Config, revisions: tuple[str, str], col: str):
-    """升级后三列各带非负 CHECK 约束，写入负值被 DB 拒绝；NULL 与 0 仍合法。"""
+def test_upgrade_rejects_non_positive_workers(
+    alembic_cfg: Config, revisions: tuple[str, str], col: str, bad_value: int
+):
+    """升级后三列各带正整数 CHECK 约束，写入 0 与负值被 DB 拒绝；NULL 与 ≥1 仍合法。"""
     revision_id, _ = revisions
     command.upgrade(alembic_cfg, revision_id)
 
@@ -104,22 +107,22 @@ def test_upgrade_rejects_negative_workers(alembic_cfg: Config, revisions: tuple[
                 sa.text(
                     "INSERT INTO custom_provider "
                     f"(id, display_name, discovery_format, base_url, api_key, {col}, created_at, updated_at) "
-                    "VALUES (1, 'P', 'openai', 'https://x', 'k', -1, "
+                    f"VALUES (1, 'P', 'openai', 'https://x', 'k', {bad_value}, "
                     "'2026-06-29 00:00:00', '2026-06-29 00:00:00')"
                 )
             )
-        # 0 与 NULL 合法
+        # ≥1 合法
         with engine.begin() as conn:
             conn.execute(
                 sa.text(
                     "INSERT INTO custom_provider "
                     f"(id, display_name, discovery_format, base_url, api_key, {col}, created_at, updated_at) "
-                    "VALUES (2, 'P', 'openai', 'https://x', 'k', 0, "
+                    "VALUES (2, 'P', 'openai', 'https://x', 'k', 1, "
                     "'2026-06-29 00:00:00', '2026-06-29 00:00:00')"
                 )
             )
             value = conn.execute(sa.text(f"SELECT {col} FROM custom_provider WHERE id = 2")).scalar_one()
-        assert value == 0
+        assert value == 1
     finally:
         engine.dispose()
 

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -92,7 +92,7 @@ async def test_unknown_provider_raises(config_service: ConfigService):
 
 
 @pytest.mark.parametrize("key", ["image_max_workers", "video_max_workers", "audio_max_workers"])
-@pytest.mark.parametrize("value", ["", "3.7", "abc", "-1"])
+@pytest.mark.parametrize("value", ["", "3.7", "abc", "-1", "0"])
 async def test_set_max_workers_rejects_invalid_values(config_service: ConfigService, key: str, value: str):
     from lib.config.service import ProviderConfigValueError
 
@@ -101,12 +101,12 @@ async def test_set_max_workers_rejects_invalid_values(config_service: ConfigServ
     assert exc_info.value.key == key
     assert exc_info.value.value == value
     # router 依赖 code/params 泛化渲染 i18n 文案，契约在此 pin 住
-    assert exc_info.value.code == "max_workers_must_be_nonnegative_integer"
+    assert exc_info.value.code == "max_workers_must_be_positive_integer"
     assert exc_info.value.params == {"field": key, "value": value}
 
 
-@pytest.mark.parametrize("value", ["0", "5"])
-async def test_set_max_workers_accepts_nonnegative_integers(config_service: ConfigService, value: str):
+@pytest.mark.parametrize("value", ["1", "5"])
+async def test_set_max_workers_accepts_positive_integers(config_service: ConfigService, value: str):
     await config_service.set_provider_config("ark", "image_max_workers", value)
     config = await config_service.get_provider_config("ark")
     assert config["image_max_workers"] == value

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -121,7 +121,7 @@ async def test_set_max_workers_canonicalizes_on_write(config_service: ConfigServ
 
 
 async def test_set_other_number_keys_not_restricted_to_integers(config_service: ConfigService):
-    # request_gap / *_rpm 语义允许小数，不受容量键的非负整数校验约束
+    # request_gap / *_rpm 语义允许小数，不受容量键的正整数校验约束
     await config_service.set_provider_config("gemini-aistudio", "request_gap", "0.5")
     config = await config_service.get_provider_config("gemini-aistudio")
     assert config["request_gap"] == "0.5"

--- a/tests/test_custom_provider_repo.py
+++ b/tests/test_custom_provider_repo.py
@@ -193,14 +193,14 @@ class TestConcurrencyColumns:
             api_key="k",
             image_max_workers=2,
             video_max_workers=7,
-            audio_max_workers=0,
+            audio_max_workers=1,
         )
         await session.flush()
         got = await repo.get_provider(p.id)
         assert got is not None
         assert got.image_max_workers == 2
         assert got.video_max_workers == 7
-        assert got.audio_max_workers == 0
+        assert got.audio_max_workers == 1
 
     async def test_update_workers_including_clear_to_null(self, session: AsyncSession):
         repo = CustomProviderRepository(session)
@@ -222,8 +222,11 @@ class TestConcurrencyColumns:
         assert got.video_max_workers == 4
 
     @pytest.mark.parametrize("field", ["image_max_workers", "video_max_workers", "audio_max_workers"])
-    async def test_create_negative_workers_rejected_by_check_constraint(self, session: AsyncSession, field: str):
-        """DB 层 CHECK 约束拦截负值，repo 直写也无法绕过（create_provider 内部 flush 即触发）。"""
+    @pytest.mark.parametrize("value", [-1, 0])
+    async def test_create_non_positive_workers_rejected_by_check_constraint(
+        self, session: AsyncSession, field: str, value: int
+    ):
+        """DB 层 CHECK 约束拦截 0 与负值，repo 直写也无法绕过（create_provider 内部 flush 即触发）。"""
         from sqlalchemy.exc import IntegrityError
 
         repo = CustomProviderRepository(session)
@@ -233,7 +236,7 @@ class TestConcurrencyColumns:
                 discovery_format="openai",
                 base_url="https://x",
                 api_key="k",
-                **{field: -1},
+                **{field: value},
             )
 
 

--- a/tests/test_custom_providers_api.py
+++ b/tests/test_custom_providers_api.py
@@ -980,7 +980,7 @@ class TestFullUpdateProvider:
 
 
 class TestConcurrencyFields:
-    """image/video/audio_max_workers 经 POST / PUT 保存后回显，留空 → null，负值 → 422。"""
+    """image/video/audio_max_workers 经 POST / PUT 保存后回显，留空 → null，0/负值 → 422。"""
 
     def test_create_echoes_workers(self, client: TestClient):
         with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
@@ -994,14 +994,14 @@ class TestConcurrencyFields:
                     "models": [],
                     "image_max_workers": 2,
                     "video_max_workers": 7,
-                    "audio_max_workers": 0,
+                    "audio_max_workers": 1,
                 },
             )
         assert resp.status_code == 201
         body = resp.json()
         assert body["image_max_workers"] == 2
         assert body["video_max_workers"] == 7
-        assert body["audio_max_workers"] == 0
+        assert body["audio_max_workers"] == 1
 
     def test_create_defaults_to_null_when_omitted(self, client: TestClient):
         with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
@@ -1021,7 +1021,8 @@ class TestConcurrencyFields:
         assert body["video_max_workers"] is None
         assert body["audio_max_workers"] is None
 
-    def test_create_rejects_negative(self, client: TestClient):
+    @pytest.mark.parametrize("bad_value", [-1, 0])
+    def test_create_rejects_below_one(self, client: TestClient, bad_value: int):
         resp = client.post(
             "/api/v1/custom-providers",
             json={
@@ -1030,7 +1031,7 @@ class TestConcurrencyFields:
                 "base_url": "https://x.com",
                 "api_key": "sk-test-key-12345678",
                 "models": [],
-                "image_max_workers": -1,
+                "image_max_workers": bad_value,
             },
         )
         assert resp.status_code == 422

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -517,7 +517,7 @@ class TestPatchProviderConfigMaxWorkersValidation:
         app.include_router(providers.router, prefix="/api/v1")
         return app
 
-    @pytest.mark.parametrize("bad_value", ["", "3.7", "abc", "-1"])
+    @pytest.mark.parametrize("bad_value", ["", "3.7", "abc", "-1", "0"])
     @pytest.mark.parametrize("key", ["image_max_workers", "video_max_workers", "audio_max_workers"])
     def test_invalid_value_returns_422(self, key: str, bad_value: str):
         with TestClient(self._make_db_app()) as client:
@@ -525,7 +525,7 @@ class TestPatchProviderConfigMaxWorkersValidation:
         assert resp.status_code == 422
         detail = resp.json()["detail"]
         # 消息已经过 Translator 渲染（非裸 key id），且包含 UI 同款字段 Label 便于定位
-        assert detail != "max_workers_must_be_nonnegative_integer"
+        assert detail != "max_workers_must_be_positive_integer"
         assert providers._FIELD_META[key]["label"] in detail
 
     @pytest.mark.parametrize("locale", ["zh", "en", "vi"])
@@ -534,11 +534,11 @@ class TestPatchProviderConfigMaxWorkersValidation:
             resp = client.patch("/api/v1/providers/dashscope/config", json={"video_max_workers": "abc"})
         assert resp.status_code == 422
         detail = resp.json()["detail"]
-        assert detail != "max_workers_must_be_nonnegative_integer"
+        assert detail != "max_workers_must_be_positive_integer"
         assert providers._FIELD_META["video_max_workers"]["label"] in detail
         assert "abc" in detail
 
-    @pytest.mark.parametrize("good_value", ["0", "5"])
+    @pytest.mark.parametrize("good_value", ["1", "5"])
     def test_valid_value_returns_204(self, good_value: str):
         with TestClient(self._make_db_app()) as client:
             resp = client.patch("/api/v1/providers/dashscope/config", json={"audio_max_workers": good_value})


### PR DESCRIPTION
Closes #972

## 背景

`0` 在并发体系里身兼两职：CapacityTable 内部把某 lane 容量 `0` 当作「该供应商不支持此媒体」哨兵（fast-fail），而用户可配的并发上限字段此前一律**接受** `0`。用户填 `0`（误读「默认」占位符、或以为 `0`=不限）会静默把该 lane 关死，之后每个任务都报「供应商不支持此媒体」——一个无声且失败信息答非所问的 footgun。

## 改动

并发上限对用户统一收紧为「**≥1 的整数，或留空（= 回退默认）**」，`0` 仅保留为 CapacityTable 内部哨兵、不对用户开放：

- **输入层**：自定义表单严格整数解析拒 `0`、`min=1`；自定义 API `Field(ge=1)` → 传 `0` 返回 422；内置配置校验 `parsed < 1`。
- **DB CHECK（defense-in-depth）**：`custom_provider` 三列 CHECK `>= 0` → `>= 1`，约束名 `_non_negative` → `_positive`。承 ADR 0042 加列迁移**尚未发版**，就地改写其加列迁移 `a7a9749a1ae0`，不新增迁移、无数据回填（`0` 无自动来源）。
- **i18n**：后端 key `max_workers_must_be_nonnegative_integer` → `max_workers_must_be_positive_integer`，三语文案改「正整数」；前端 `max_workers_invalid`/`cp_concurrency_help` 同步。
- **文档**：新增 ADR 0043，CONTEXT.md「容量」词条补用户契约。
- **运行时不动**：`if cap <= 0` fast-fail、`_lane_limits` 投影、`provider_unsupported_media` 失败码全部保留——`0` 此后只可能源自「供应商本就不支持此媒体」，语义恰好正确。

## 零回归

留空仍 = 回退全局默认；负数、小数仍拒；既有 `≥1` 配置路径不变。

## 验证

- `uv run ruff check` / `ruff format --check`：通过
- `uv run basedpyright`：0 error
- `uv run pytest`（config_service / alembic / custom_provider repo+api / providers_api）：206 passed
- `tests/test_i18n_consistency.py`：12 passed
- 前端 `pnpm lint` / `pnpm check`（typecheck + 765 vitest）：通过

## 审查说明

以独立视角复核后跑了 workflow code-review（xhigh）。所有 CONFIRMED 项均为本 issue 经 grilling 显式接受、ADR 0043 已载明的有意取舍：
- 就地改写已合入 main 的迁移 → 已 `alembic upgrade head` 的 dev DB/worktree CHECK 不会自动收紧（需 `downgrade -1 && upgrade head` 或重建库）。ADR Consequences 已记，未发版且 `0` 无自动来源，实践无害。
- 含残留 `0` 的记录在表单需先把该字段改为 ≥1 才能保存——即对 footgun 的正确补救。

其余为 REFUTED（多层校验是有意 defense-in-depth；内置 provider 表单仅提交已编辑字段，残留 `0` 不会被重提交而 422）或低价值 PLAUSIBLE（哨兵语义注释跨文件重复，纯可维护性、未来式触发）。无需代码改动；仅校正一处测试注释口径。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 自定义供应商的并发上限现在支持更明确的输入提示，留空会使用全局默认值，且最小值为 1。

* **Bug 修复**
  * 修正了并发上限允许输入 0 的问题；现在 0 和负数都会被拒绝。
  * 更新了相关错误提示与多语言文案，使校验规则在界面、接口和存储层保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->