### PR TITLE
fix(provider): 可灵 Kling 在供应商设置显示品牌图标

### DIFF
--- a/frontend/src/components/pages/settings/CustomProviderDetail.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderDetail.tsx
@@ -142,7 +142,7 @@ export function CustomProviderDetail({ providerId, onDeleted, onSaved }: CustomP
                 border: "1px solid var(--color-hairline-strong)",
               }}
             >
-              {Array.from(provider.display_name ?? "")[0] ?? "?"}
+              {Array.from(provider.display_name)[0] ?? "?"}
             </span>
             <div className="min-w-0">
               <div className="flex items-center gap-2.5">

--- a/frontend/src/components/pages/settings/CustomProviderDetail.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderDetail.tsx
@@ -134,6 +134,7 @@ export function CustomProviderDetail({ providerId, onDeleted, onSaved }: CustomP
         <div className="max-w-2xl space-y-6">
           {/* Header */}
           <div className="flex items-start gap-3">
+            {/* 自定义 provider 恒用字母徽章，不按名字猜品牌（理由见 CustomProviderSection） */}
             <span
               className="mt-0.5 inline-flex h-7 w-7 items-center justify-center rounded-[6px] font-mono text-[11px] font-bold uppercase text-text-2"
               style={{
@@ -141,7 +142,7 @@ export function CustomProviderDetail({ providerId, onDeleted, onSaved }: CustomP
                 border: "1px solid var(--color-hairline-strong)",
               }}
             >
-              {provider.display_name?.[0] ?? "?"}
+              {Array.from(provider.display_name ?? "")[0] ?? "?"}
             </span>
             <div className="min-w-0">
               <div className="flex items-center gap-2.5">

--- a/frontend/src/components/pages/settings/CustomProviderSection.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderSection.tsx
@@ -43,8 +43,11 @@ export function CustomProviderSection({ providers, selectedId, onSelect, onAdd }
               : "border-l-2 border-transparent text-text-3 hover:bg-bg-grad-a/40 hover:text-text"
           }`}
         >
+          {/* 自定义 provider 恒用字母徽章，不按 display_name 猜品牌：中转站协议无关，
+              打某品牌图标会名不副实，且自由文本名匹配对中文名割裂。将来若要品牌化，
+              走用户显式选图标，而非名字猜测。 */}
           <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded border border-hairline-soft bg-bg-grad-b/70 font-mono text-[10px] font-bold uppercase text-text-2">
-            {p.display_name?.[0] ?? "?"}
+            {Array.from(p.display_name ?? "")[0] ?? "?"}
           </span>
           <span className="min-w-0 flex-1 truncate">{p.display_name}</span>
           <CustomStatusDot provider={p} />

--- a/frontend/src/components/pages/settings/CustomProviderSection.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderSection.tsx
@@ -47,7 +47,7 @@ export function CustomProviderSection({ providers, selectedId, onSelect, onAdd }
               打某品牌图标会名不副实，且自由文本名匹配对中文名割裂。将来若要品牌化，
               走用户显式选图标，而非名字猜测。 */}
           <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded border border-hairline-soft bg-bg-grad-b/70 font-mono text-[10px] font-bold uppercase text-text-2">
-            {Array.from(p.display_name ?? "")[0] ?? "?"}
+            {Array.from(p.display_name)[0] ?? "?"}
           </span>
           <span className="min-w-0 flex-1 truncate">{p.display_name}</span>
           <CustomStatusDot provider={p} />

--- a/frontend/src/components/ui/ProviderIcon.test.tsx
+++ b/frontend/src/components/ui/ProviderIcon.test.tsx
@@ -39,4 +39,11 @@ describe("ProviderIcon", () => {
     render(<ProviderIcon providerId={providerId} />);
     expect(screen.getByTestId("lobehub-stub-icon")).toBeInTheDocument();
   });
+
+  // 守住 Array.from 回退：首字符为星平面（非 BMP）字符时取整字，而非半个代理对。
+  it("renders the full first Unicode character in the monogram fallback", () => {
+    render(<ProviderIcon providerId="𠮷-provider" />);
+    expect(screen.queryByTestId("lobehub-stub-icon")).not.toBeInTheDocument();
+    expect(screen.getByText("𠮷")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/ui/ProviderIcon.test.tsx
+++ b/frontend/src/components/ui/ProviderIcon.test.tsx
@@ -19,4 +19,24 @@ describe("ProviderIcon", () => {
     expect(screen.queryByTestId("lobehub-stub-icon")).not.toBeInTheDocument();
     expect(screen.getByText("z")).toBeInTheDocument();
   });
+
+  // 回归测试：守住已接线的内置 provider 图标不退化。
+  // 注意这不是覆盖保证——图标库没有的内置 provider（如 Agnes）合法地走字母徽章，
+  // 故本表只列「已接线」的 id，新增无图标 provider 不会、也不该让它变红。
+  const WIRED_BUILTIN_PROVIDER_IDS = [
+    "gemini-aistudio",
+    "gemini-vertex",
+    "grok",
+    "ark",
+    "ark-agent-plan",
+    "dashscope",
+    "minimax",
+    "openai",
+    "vidu",
+    "kling",
+  ];
+  it.each(WIRED_BUILTIN_PROVIDER_IDS)("renders a brand icon for built-in provider %s", (providerId) => {
+    render(<ProviderIcon providerId={providerId} />);
+    expect(screen.getByTestId("lobehub-stub-icon")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/ui/ProviderIcon.tsx
+++ b/frontend/src/components/ui/ProviderIcon.tsx
@@ -1,11 +1,13 @@
 import BailianColor from "@lobehub/icons/es/Bailian/components/Color";
 import GeminiColor from "@lobehub/icons/es/Gemini/components/Color";
 import GrokMono from "@lobehub/icons/es/Grok/components/Mono";
+import KlingColor from "@lobehub/icons/es/Kling/components/Color";
 import MinimaxColor from "@lobehub/icons/es/Minimax/components/Color";
 import OpenAIMono from "@lobehub/icons/es/OpenAI/components/Mono";
 import VertexAIColor from "@lobehub/icons/es/VertexAI/components/Color";
 import ViduColor from "@lobehub/icons/es/Vidu/components/Color";
 import VolcengineColor from "@lobehub/icons/es/Volcengine/components/Color";
+import type { ComponentType } from "react";
 
 export const PROVIDER_NAMES: Record<string, string> = {
   "gemini-aistudio": "AI Studio",
@@ -17,23 +19,51 @@ export const PROVIDER_NAMES: Record<string, string> = {
 };
 
 /**
- * 根据 providerId 渲染对应的供应商图标。
- * 支持 gemini-aistudio、gemini-vertex、grok、ark（含 ark-agent-plan）、dashscope、minimax、openai、vidu，其余显示首字母。
+ * 内置 provider 的 canonical id → lobehub 具名图标组件。逐个静态 import 保持 tree-shaking。
+ * 键为规范化后的小写 id（仅 a-z0-9）；id 与 lobehub 图标名不一致的（如 ark/dashscope）
+ * 由 resolveIconKey 折叠到这里的规范键。图标库本就没有的内置 provider（如 Agnes）不登记，
+ * 自然回落字母徽章——徽章是合法终态而非缺漏，不必为「覆盖全部 provider」造假图标。
+ */
+const ICON_REGISTRY: Record<string, ComponentType<{ className?: string }>> = {
+  gemini: GeminiColor,
+  vertexai: VertexAIColor,
+  grok: GrokMono,
+  volcengine: VolcengineColor,
+  bailian: BailianColor,
+  minimax: MinimaxColor,
+  openai: OpenAIMono,
+  vidu: ViduColor,
+  kling: KlingColor,
+};
+
+/**
+ * 内置 provider 的 canonical id → ICON_REGISTRY 的规范键。
+ * id 的前缀/别名家族（gemini-vertex、gemini-*、grok-*、ark-*、dashscope）在此折叠。
+ * 仅吃 canonical id：自定义 provider 不走这里（恒用字母徽章、不按名字猜品牌），
+ * 故前缀规则不会误配自由文本名（如 Arknights 不会被 ark-* 命中火山方舟）。
+ */
+function resolveIconKey(providerId: string): string {
+  const id = providerId.toLowerCase();
+  if (id === "gemini-vertex") return "vertexai";
+  if (id.startsWith("gemini")) return "gemini";
+  if (id.startsWith("grok")) return "grok";
+  if (id.startsWith("ark")) return "volcengine";
+  if (id === "dashscope") return "bailian";
+  return id.replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * 按内置 provider 的 canonical id 渲染品牌图标，命中 ICON_REGISTRY 则出图标，
+ * 否则回落字母徽章（图标库没有该供应商时的合法终态）。
  */
 export function ProviderIcon({ providerId, className }: { providerId: string; className?: string }) {
   const cls = className ?? "h-6 w-6";
-  if (providerId === "gemini-vertex") return <VertexAIColor className={cls} />;
-  if (providerId.startsWith("gemini")) return <GeminiColor className={cls} />;
-  if (providerId.startsWith("grok")) return <GrokMono className={cls} />;
-  if (providerId.startsWith("ark")) return <VolcengineColor className={cls} />;
-  if (providerId === "dashscope") return <BailianColor className={cls} />;
-  if (providerId === "minimax") return <MinimaxColor className={cls} />;
-  if (providerId === "openai") return <OpenAIMono className={cls} />;
-  if (providerId === "vidu") return <ViduColor className={cls} />;
-  // Fallback: first letter badge
+  const Icon = ICON_REGISTRY[resolveIconKey(providerId)];
+  if (Icon) return <Icon className={cls} />;
+  // Fallback: 字母徽章。Array.from 取首字符避免星平面字符被截成半个代理对。
   return (
     <span className={`inline-flex items-center justify-center rounded border border-hairline-soft bg-bg-grad-b/70 text-xs font-bold uppercase text-text-2 ${cls}`}>
-      {providerId[0]}
+      {Array.from(providerId ?? "")[0] ?? "?"}
     </span>
   );
 }

--- a/frontend/src/components/ui/ProviderIcon.tsx
+++ b/frontend/src/components/ui/ProviderIcon.tsx
@@ -60,10 +60,11 @@ export function ProviderIcon({ providerId, className }: { providerId: string; cl
   const cls = className ?? "h-6 w-6";
   const Icon = ICON_REGISTRY[resolveIconKey(providerId)];
   if (Icon) return <Icon className={cls} />;
-  // Fallback: 字母徽章。Array.from 取首字符避免星平面字符被截成半个代理对。
+  // Fallback: 字母徽章。providerId 类型即 string（resolveIconKey 已直接 .toLowerCase()），
+  // 这里同样信任契约不再 ?? ""；Array.from 取首字符避免星平面字符被截成半个代理对。
   return (
     <span className={`inline-flex items-center justify-center rounded border border-hairline-soft bg-bg-grad-b/70 text-xs font-bold uppercase text-text-2 ${cls}`}>
-      {Array.from(providerId ?? "")[0] ?? "?"}
+      {Array.from(providerId)[0] ?? "?"}
     </span>
   );
 }


### PR DESCRIPTION
## 问题
内置可灵 Kling 供应商在供应商设置页显示首字母「K」而非品牌图标——ProviderIcon 缺 kling 映射。

## 修复
- ProviderIcon 改为单一 ICON_REGISTRY 按 canonical id 解析图标，接入 Kling 品牌图标。
- 字母徽章改用 Array.from 取首字符，兼容星平面字符（如生僻汉字）。
- 自定义供应商维持字母徽章、不按名字猜品牌（中转站协议无关，品牌图标名不副实）。

## 测试
- 新增已接线内置供应商图标回归测试。
- ESLint / tsc / vitest 全绿。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持更多供应商图标识别与展示（新增 `kling`）。  
* **Bug 修复**
  * 改进图标匹配与字母徽章回退：对大小写/别名前缀更准确，兼容非 BMP/代理对的首字符提取，避免徽章截断异常。
  * 字母徽章统一按既定规则显示，不再根据名称推断品牌图标。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->