### PR TITLE
fix(custom-providers): 获取模型合并默认互斥，避免编辑保存报错

### DIFF
--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -326,27 +326,19 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
         ? await API.discoverModelsForProvider(existing.id)
         : await API.discoverModels({ discovery_format: discoveryFormat, base_url: baseUrl, api_key: apiKey });
       const discovered = res.models.map(discoveredToRow);
-      setModels((prev) =>
-        mergeDiscoveredModels(prev, discovered, endpointToMediaType, endpointToImageCapabilities),
-      );
+      // 用 getState 读最新 catalog 映射，而非 handleDiscover 闭包捕获的渲染期值：catalog 在
+      // mount 时异步拉取，若用户在其就绪前点「获取模型」，闭包里仍是空 map，合并会跳过默认
+      // 消解，保存时可能 default_model_conflict。
+      const { endpointToMediaType: mediaMap, endpointToImageCapabilities: capsMap } =
+        useEndpointCatalogStore.getState();
+      setModels((prev) => mergeDiscoveredModels(prev, discovered, mediaMap, capsMap));
       setModelFilter("");
     } catch (e) {
       showError(errMsg(e, t("fetch_models_failed")));
     } finally {
       setDiscovering(false);
     }
-  }, [
-    discoveryFormat,
-    baseUrl,
-    apiKey,
-    useStoredCredential,
-    baseUrlChanged,
-    existing,
-    endpointToMediaType,
-    endpointToImageCapabilities,
-    showError,
-    t,
-  ]);
+  }, [discoveryFormat, baseUrl, apiKey, useStoredCredential, baseUrlChanged, existing, showError, t]);
 
   // --- Test connection ---
   const handleTest = useCallback(async () => {

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -12,7 +12,13 @@ import type {
   DiscoveredModel,
   EndpointKey,
 } from "@/types";
-import { priceLabel, urlPreviewFor, toggleDefaultReducer, type DiscoveryFormat } from "./customProviderHelpers";
+import {
+  priceLabel,
+  urlPreviewFor,
+  toggleDefaultReducer,
+  mergeDiscoveredModels,
+  type DiscoveryFormat,
+} from "./customProviderHelpers";
 import { EndpointSelect } from "./EndpointSelect";
 import { ResolutionPicker } from "@/components/shared/ResolutionPicker";
 import { IMAGE_STANDARD_RESOLUTIONS, VIDEO_STANDARD_RESOLUTIONS } from "@/utils/provider-models";
@@ -320,31 +326,27 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
         ? await API.discoverModelsForProvider(existing.id)
         : await API.discoverModels({ discovery_format: discoveryFormat, base_url: baseUrl, api_key: apiKey });
       const discovered = res.models.map(discoveredToRow);
-      setModels((prev) => {
-        const existingIds = new Map(prev.map((r) => [r.model_id, r]));
-        const merged: ModelRow[] = [];
-        for (const d of discovered) {
-          const existing = existingIds.get(d.model_id);
-          if (existing) {
-            merged.push(existing);
-            existingIds.delete(d.model_id);
-          } else {
-            merged.push(d);
-          }
-        }
-        // Keep manually added models that weren't in the discovery response
-        for (const r of existingIds.values()) {
-          merged.push(r);
-        }
-        return merged;
-      });
+      setModels((prev) =>
+        mergeDiscoveredModels(prev, discovered, endpointToMediaType, endpointToImageCapabilities),
+      );
       setModelFilter("");
     } catch (e) {
       showError(errMsg(e, t("fetch_models_failed")));
     } finally {
       setDiscovering(false);
     }
-  }, [discoveryFormat, baseUrl, apiKey, useStoredCredential, baseUrlChanged, existing, showError, t]);
+  }, [
+    discoveryFormat,
+    baseUrl,
+    apiKey,
+    useStoredCredential,
+    baseUrlChanged,
+    existing,
+    endpointToMediaType,
+    endpointToImageCapabilities,
+    showError,
+    t,
+  ]);
 
   // --- Test connection ---
   const handleTest = useCallback(async () => {

--- a/frontend/src/components/pages/settings/customProviderHelpers.test.ts
+++ b/frontend/src/components/pages/settings/customProviderHelpers.test.ts
@@ -252,4 +252,27 @@ describe("mergeDiscoveredModels", () => {
       "z-chat",
     ]);
   });
+
+  it("keeps multiple manually-added rows with empty model_id (no Map key collision)", () => {
+    // 用户连点「手动添加」加了两行未填 model_id（都为 ""），再点获取模型。
+    // 若用 model_id 建 Map 去重，两空行键冲突会静默丢一行；修复后两行都应保留。
+    const prev = [
+      row("", "openai-chat", false),
+      row("", "newapi-video", false),
+      row("z-chat", "openai-chat", true),
+    ];
+    const discovered = [row("z-chat", "openai-chat", false), row("a-chat", "openai-chat", true)];
+    const merged = mergeDiscoveredModels(prev, discovered, ENDPOINT_TO_MEDIA);
+    expect(merged.filter((m) => m.model_id === "").length).toBe(2);
+    // 既存默认仍受保护，发现的同 media_type 默认让出
+    expect(merged.filter((m) => m.is_default).map((m) => m.model_id)).toEqual(["z-chat"]);
+  });
+
+  it("create-mode passthrough does not reconcile discovery defaults", () => {
+    // create 模式原样透传 discovery 响应、不做槽位消解：实际 discovery 每个 media_type 至多
+    // 一个默认（不会冲突），此处用人造的重叠默认锁定「不改写 discovery」契约，冲突交后端校验。
+    const discovered = [row("w", "openai-images", true), row("e", "openai-images-edits", true)];
+    const merged = mergeDiscoveredModels([], discovered, ENDPOINT_TO_MEDIA, ENDPOINT_TO_CAPS);
+    expect(merged.filter((m) => m.is_default).map((m) => m.model_id)).toEqual(["w", "e"]);
+  });
 });

--- a/frontend/src/components/pages/settings/customProviderHelpers.test.ts
+++ b/frontend/src/components/pages/settings/customProviderHelpers.test.ts
@@ -4,6 +4,7 @@ import {
   priceLabel,
   urlPreviewFor,
   toggleDefaultReducer,
+  mergeDiscoveredModels,
 } from "./customProviderHelpers";
 
 const id = (k: string) => k;
@@ -174,5 +175,81 @@ describe("toggleDefaultReducer", () => {
     const result = toggleDefaultReducer(rows, "a", ENDPOINT_TO_MEDIA);
     expect(result.find((r) => r.key === "a")?.is_default).toBe(false);
     expect(result.find((r) => r.key === "b")?.is_default).toBe(true);
+  });
+});
+
+describe("mergeDiscoveredModels", () => {
+  const row = (model_id: string, endpoint: string, is_default: boolean) => ({
+    model_id,
+    endpoint,
+    is_default,
+  });
+
+  it("keeps existing default and drops discovered default in same media_type (regression)", () => {
+    // 既存 provider：文本默认 = z-chat。上游新增排序更靠前的 a-chat，发现接口把首项 a-chat 标默认。
+    // 朴素合并会得到两个 text 默认 → 保存被后端 default_model_conflict 拒绝。消解后只保留既存默认。
+    const prev = [row("z-chat", "openai-chat", true)];
+    const discovered = [row("a-chat", "openai-chat", true), row("z-chat", "openai-chat", false)];
+    const merged = mergeDiscoveredModels(prev, discovered, ENDPOINT_TO_MEDIA);
+    expect(merged.filter((m) => m.is_default).map((m) => m.model_id)).toEqual(["z-chat"]);
+  });
+
+  it("lets a discovered default fill an empty media slot", () => {
+    // 既存仅文本默认；发现新增视频模型 → 视频槽空 → 允许补默认
+    const prev = [row("z-chat", "openai-chat", true)];
+    const discovered = [row("z-chat", "openai-chat", false), row("v1", "newapi-video", true)];
+    const merged = mergeDiscoveredModels(prev, discovered, ENDPOINT_TO_MEDIA);
+    expect(merged.find((m) => m.model_id === "z-chat")?.is_default).toBe(true);
+    expect(merged.find((m) => m.model_id === "v1")?.is_default).toBe(true);
+  });
+
+  it("preserves manually-added models absent from the discovery response", () => {
+    const prev = [row("manual", "openai-chat", false), row("z-chat", "openai-chat", true)];
+    const discovered = [row("z-chat", "openai-chat", false)];
+    const merged = mergeDiscoveredModels(prev, discovered, ENDPOINT_TO_MEDIA);
+    expect(merged.map((m) => m.model_id).sort()).toEqual(["manual", "z-chat"]);
+    expect(merged.find((m) => m.model_id === "z-chat")?.is_default).toBe(true);
+  });
+
+  it("keeps disjoint-capability image defaults (split generations vs edits)", () => {
+    // 既存 -edits(I2I) 默认；发现 -generations(T2I) 标默认 → capability 不交叠 → 两者都保留
+    const prev = [row("e", "openai-images-edits", true)];
+    const discovered = [
+      row("g", "openai-images-generations", true),
+      row("e", "openai-images-edits", false),
+    ];
+    const merged = mergeDiscoveredModels(prev, discovered, ENDPOINT_TO_MEDIA, ENDPOINT_TO_CAPS);
+    expect(merged.find((m) => m.model_id === "g")?.is_default).toBe(true);
+    expect(merged.find((m) => m.model_id === "e")?.is_default).toBe(true);
+  });
+
+  it("makes a discovered wildcard-image default yield to an overlapping existing default", () => {
+    // 既存 -edits(I2I) 默认；发现 wildcard image(T2I+I2I) 标默认 → I2I 槽已占 → wildcard 让出
+    const prev = [row("e", "openai-images-edits", true)];
+    const discovered = [row("w", "openai-images", true), row("e", "openai-images-edits", false)];
+    const merged = mergeDiscoveredModels(prev, discovered, ENDPOINT_TO_MEDIA, ENDPOINT_TO_CAPS);
+    expect(merged.find((m) => m.model_id === "e")?.is_default).toBe(true);
+    expect(merged.find((m) => m.model_id === "w")?.is_default).toBe(false);
+  });
+
+  it("leaves create-mode (empty prev) discovery defaults intact", () => {
+    const discovered = [
+      row("a-chat", "openai-chat", true),
+      row("b-chat", "openai-chat", false),
+      row("v1", "newapi-video", true),
+    ];
+    const merged = mergeDiscoveredModels([], discovered, ENDPOINT_TO_MEDIA);
+    expect(merged.filter((m) => m.is_default).map((m) => m.model_id)).toEqual(["a-chat", "v1"]);
+  });
+
+  it("does not reconcile when catalog is unloaded (unknown endpoints never claim slots)", () => {
+    // catalog 未加载 → 所有 endpoint media 未知 → 不消解（与 toggleDefaultReducer 的降级一致）
+    const prev = [row("z-chat", "openai-chat", true)];
+    const discovered = [row("a-chat", "openai-chat", true), row("z-chat", "openai-chat", false)];
+    const merged = mergeDiscoveredModels(prev, discovered, {});
+    expect(merged.filter((m) => m.is_default).map((m) => m.model_id).sort()).toEqual([
+      "a-chat",
+      "z-chat",
+    ]);
   });
 });

--- a/frontend/src/components/pages/settings/customProviderHelpers.ts
+++ b/frontend/src/components/pages/settings/customProviderHelpers.ts
@@ -87,45 +87,67 @@ export type MergeRow = { model_id: string; endpoint: EndpointKey; is_default: bo
 
 /** 合并「获取模型」结果到当前表单行，并消解默认冲突。
  *
- *  合并：按 discovered 顺序保留已有行（含其 is_default 与价格等编辑态），新发现行
- *  追加在对应位置，未被发现响应覆盖的手动行保留在末尾。
+ *  create 模式（prev 为空）：直接返回 discovery 响应的浅拷贝，不做消解——无既存默认需
+ *  保护，且发现接口对每个 media_type 至多标一个默认（见后端 discovery _build_result_list），
+ *  响应本身无冲突。保持「create 模式原样透传 discovery」的约束。
  *
- *  默认消解：发现接口对每个 media_type 取首项 is_default=true（见后端 discovery
- *  _build_result_list）。编辑模式下若该槽位已有用户既存默认，朴素合并会得到「同一
- *  media_type 两个默认」，保存时被后端 _check_unique_defaults 拒绝（default_model_conflict）。
- *  故合并后做一次消解：既存行优先占据其槽位，新发现行命中已占槽位时让出
- *  （is_default→false）；空槽位仍允许新发现行补默认。endpoint 未知 / catalog 未加载的行
- *  不占槽也不让出。 */
+ *  合并（编辑模式）：按 discovered 顺序保留已有行（含其 is_default 与价格等编辑态），新发现行
+ *  追加在对应位置，未被发现响应覆盖的既存行保留在末尾。未填 model_id 的手动行（model_id 同为
+ *  空串）不进 Map 去重，否则键冲突会静默丢行；单独按原顺序补在末尾。
+ *
+ *  默认消解：编辑模式下若某槽位已有用户既存默认，朴素合并会得到「同一 media_type 两个默认」，
+ *  保存时被后端 _check_unique_defaults 拒绝（default_model_conflict）。故合并后做一次消解：
+ *  既存行优先占据其槽位，新发现行命中已占槽位时让出（is_default→false）；空槽位仍允许新发现行
+ *  补默认。endpoint 未知 / catalog 未加载的行不占槽也不让出。 */
 export function mergeDiscoveredModels<T extends MergeRow>(
   prev: T[],
   discovered: T[],
   endpointToMediaType: Record<string, MediaType>,
   endpointToImageCaps: Record<string, ImageCap[] | undefined> = {},
 ): T[] {
-  const remaining = new Map(prev.map((r) => [r.model_id, r]));
+  if (prev.length === 0) {
+    return discovered.map((row) => ({ ...row }));
+  }
+
+  // 未填 model_id 的手动行 model_id 同为空串，进 Map 会互相覆盖（键唯一）导致静默丢行；
+  // 单独留存，按原顺序补在末尾。
+  const remaining = new Map<string, T>();
+  const emptyIdRows: T[] = [];
+  for (const r of prev) {
+    const key = r.model_id.trim();
+    if (key) remaining.set(key, r);
+    else emptyIdRows.push(r);
+  }
+
   const merged: { row: T; fromExisting: boolean }[] = [];
   for (const d of discovered) {
-    const existing = remaining.get(d.model_id);
+    const key = d.model_id.trim();
+    const existing = key ? remaining.get(key) : undefined;
     if (existing) {
       merged.push({ row: existing, fromExisting: true });
-      remaining.delete(d.model_id);
+      remaining.delete(key);
     } else {
       merged.push({ row: d, fromExisting: false });
     }
   }
-  // 保留未被发现响应覆盖的手动行
+  // 保留未被发现响应覆盖的既存行（含未填 model_id 的手动行）
   for (const r of remaining.values()) {
+    merged.push({ row: r, fromExisting: true });
+  }
+  for (const r of emptyIdRows) {
     merged.push({ row: r, fromExisting: true });
   }
 
   // 既存行先占槽（prev 来自已通过后端校验的 DB，内部无冲突），新发现行后处理、命中即让出
   const claimed = new Set<string>();
   const out = merged.map(({ row }) => ({ ...row }));
-  const order = [
-    ...merged.map((_, i) => i).filter((i) => merged[i].fromExisting),
-    ...merged.map((_, i) => i).filter((i) => !merged[i].fromExisting),
-  ];
-  for (const i of order) {
+  const existingIndices: number[] = [];
+  const newIndices: number[] = [];
+  merged.forEach((item, i) => {
+    if (item.fromExisting) existingIndices.push(i);
+    else newIndices.push(i);
+  });
+  for (const i of [...existingIndices, ...newIndices]) {
     const row = out[i];
     if (!row.is_default) continue;
     const slots = defaultSlotsFor(row.endpoint, endpointToMediaType, endpointToImageCaps);

--- a/frontend/src/components/pages/settings/customProviderHelpers.ts
+++ b/frontend/src/components/pages/settings/customProviderHelpers.ts
@@ -68,3 +68,72 @@ export function toggleDefaultReducer<T extends ModelLike>(
     return overlap ? { ...r, is_default: false } : r;
   });
 }
+
+/** 一行模型占用的「默认槽位」集合：非 image → media_type 自身；image → 各 capability
+ *  前缀 `image:`。endpoint 不在 catalog（如 anthropic-messages）或 catalog 未加载 →
+ *  空集，该行不参与互斥（与后端 _check_unique_defaults 对未知 endpoint 跳过校验一致）。 */
+function defaultSlotsFor(
+  endpoint: EndpointKey,
+  endpointToMediaType: Record<string, MediaType>,
+  endpointToImageCaps: Record<string, ImageCap[] | undefined>,
+): string[] {
+  const media = endpointToMediaType[endpoint];
+  if (media === undefined) return [];
+  if (media !== "image") return [media];
+  return (endpointToImageCaps[endpoint] ?? []).map((c) => `image:${c}`);
+}
+
+export type MergeRow = { model_id: string; endpoint: EndpointKey; is_default: boolean };
+
+/** 合并「获取模型」结果到当前表单行，并消解默认冲突。
+ *
+ *  合并：按 discovered 顺序保留已有行（含其 is_default 与价格等编辑态），新发现行
+ *  追加在对应位置，未被发现响应覆盖的手动行保留在末尾。
+ *
+ *  默认消解：发现接口对每个 media_type 取首项 is_default=true（见后端 discovery
+ *  _build_result_list）。编辑模式下若该槽位已有用户既存默认，朴素合并会得到「同一
+ *  media_type 两个默认」，保存时被后端 _check_unique_defaults 拒绝（default_model_conflict）。
+ *  故合并后做一次消解：既存行优先占据其槽位，新发现行命中已占槽位时让出
+ *  （is_default→false）；空槽位仍允许新发现行补默认。endpoint 未知 / catalog 未加载的行
+ *  不占槽也不让出。 */
+export function mergeDiscoveredModels<T extends MergeRow>(
+  prev: T[],
+  discovered: T[],
+  endpointToMediaType: Record<string, MediaType>,
+  endpointToImageCaps: Record<string, ImageCap[] | undefined> = {},
+): T[] {
+  const remaining = new Map(prev.map((r) => [r.model_id, r]));
+  const merged: { row: T; fromExisting: boolean }[] = [];
+  for (const d of discovered) {
+    const existing = remaining.get(d.model_id);
+    if (existing) {
+      merged.push({ row: existing, fromExisting: true });
+      remaining.delete(d.model_id);
+    } else {
+      merged.push({ row: d, fromExisting: false });
+    }
+  }
+  // 保留未被发现响应覆盖的手动行
+  for (const r of remaining.values()) {
+    merged.push({ row: r, fromExisting: true });
+  }
+
+  // 既存行先占槽（prev 来自已通过后端校验的 DB，内部无冲突），新发现行后处理、命中即让出
+  const claimed = new Set<string>();
+  const out = merged.map(({ row }) => ({ ...row }));
+  const order = [
+    ...merged.map((_, i) => i).filter((i) => merged[i].fromExisting),
+    ...merged.map((_, i) => i).filter((i) => !merged[i].fromExisting),
+  ];
+  for (const i of order) {
+    const row = out[i];
+    if (!row.is_default) continue;
+    const slots = defaultSlotsFor(row.endpoint, endpointToMediaType, endpointToImageCaps);
+    if (slots.some((s) => claimed.has(s))) {
+      row.is_default = false;
+    } else {
+      for (const s of slots) claimed.add(s);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## 问题

编辑自定义供应商时点击「获取模型」，再点保存会报 422 `default_model_conflict`。

「获取模型」的合并逻辑没有消解默认冲突：后端发现接口对每个 media_type 取首项标 `is_default=true`，前端合并时既存行的默认与新发现行的默认各自独立保留。当上游新增了一个在该 media_type 里排序更靠前的模型时，同一槽位会出现两个默认，保存被后端 `_check_unique_defaults` 拒绝。这是唯一绕过前端 `toggleDefaultReducer` 互斥约束的改默认路径。

## 修复

- 抽出纯函数 `mergeDiscoveredModels`：合并后做默认消解——既存行优先占据槽位（text/video/audio 按 media_type，image 按 capability，与后端约束对齐），新发现行命中已占槽位时让出 `is_default→false`，空槽位仍允许补默认；endpoint 未知 / catalog 未加载的行不参与消解。
- `handleDiscover` 内联合并替换为调用该函数，并补全 `useCallback` 依赖。
- create 模式（无既存行）输出与发现接口原样一致，不引入回归。

## 测试

- 新增 7 个回归用例（核心冲突、空槽位补默认、保留手动行、image capability 不交叠共存、wildcard 让出、create 模式、catalog 未加载降级）
- 完整 `pnpm lint && pnpm check`：97 文件 / 772 测试全过，typecheck + eslint 0 error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化了“发现模型”后的结果合并：新增的模型会与现有列表自动合并，并更智能地处理默认项冲突。
* **Bug 修复**
  * 修复了同一媒体类型或图片能力下可能出现多个默认模型的问题。
  * 保留手动添加但未被发现结果覆盖的模型。
* **测试**
  * 补充了相关合并与默认值冲突处理的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->