### PR TITLE
feat(script): drama 生成分镜时长兼顾台词口播长度，减少台词说不完

### DIFF
--- a/docs/adr/0040-drama-utterances-ordered-spoken-content.md
+++ b/docs/adr/0040-drama-utterances-ordered-spoken-content.md
@@ -4,7 +4,7 @@ status: accepted
 
 # drama 口播内容统一为有序 utterances，取代 dialogue/voiceover 双字段
 
-drama 的口播内容（角色台词 + 画外音）统一为一条**场景级、有序的判别式联合列表** `scene.utterances: list[Utterance]`，每条 `Utterance{kind: "dialogue"|"voiceover", speaker: str|None, text: str}`：插入顺序即时序（表达台词与画外音在一个场景里的先后），`kind` 决定下游路由（dialogue 进视频 YAML 交供应商生成口型音轨、voiceover 不作为视频提示词、留给字幕与日后 TTS；判别标准为是否归属具体说话角色，voiceover 仅承载无说话人的旁白解说），口播内容单一真相落在 utterances（`dialogue` 不嵌在 `video_prompt` 内）。这条统一序列是下游三处消费的共同地基——成片字幕从它派生、场景说话量对时长的约束按它估算、step1 结构化产出以它为目标；若口播分散在多个无序字段，字幕无源、跨类型先后丢失、对话量与时长脱钩、novel 叙述内容只能塞进画面而失真。配套：novel 源画外音克制放开（prompt 给语境创作判断、不给规则或类别白名单、不定性为兜底；screenplay 逐字提取）；场景级 `source_text`（逐字原文摘录，类比说书 `novel_text`，但纯作追溯锚、不被朗读）支撑人工审阅、单场景重生成与失真定位；成片字幕从 utterances 派生 `subtitle_spans`（按语速估时长、顺次摆放、允许留白、不撑满场景）落地剪映；场景说话量对时长取**单向上界**（估算说话时长超 duration 仅 warn 不阻塞，duration 仍由画面驱动）。
+drama 的口播内容（角色台词 + 画外音）统一为一条**场景级、有序的判别式联合列表** `scene.utterances: list[Utterance]`，每条 `Utterance{kind: "dialogue"|"voiceover", speaker: str|None, text: str}`：插入顺序即时序（表达台词与画外音在一个场景里的先后），`kind` 决定下游路由（dialogue 进视频 YAML 交供应商生成口型音轨、voiceover 不作为视频提示词、留给字幕与日后 TTS；判别标准为是否归属具体说话角色，voiceover 仅承载无说话人的旁白解说），口播内容单一真相落在 utterances（`dialogue` 不嵌在 `video_prompt` 内）。这条统一序列是下游三处消费的共同地基——成片字幕从它派生、场景说话量对时长的约束按它估算、step1 结构化产出以它为目标；若口播分散在多个无序字段，字幕无源、跨类型先后丢失、对话量与时长脱钩、novel 叙述内容只能塞进画面而失真。配套：novel 源画外音克制放开（prompt 给语境创作判断、不给规则或类别白名单、不定性为兜底；screenplay 逐字提取）；场景级 `source_text`（逐字原文摘录，类比说书 `novel_text`，但纯作追溯锚、不被朗读）支撑人工审阅、单场景重生成与失真定位；成片字幕从 utterances 派生 `subtitle_spans`（按语速估时长、顺次摆放、允许留白、不撑满场景）落地剪映；场景说话量对时长取**单向约束**（台词只把时长顶上去、永不压下来）：保存期估算说话时长超 duration 仅 warn 不阻塞，生成期 step1 时长指引另引导模型为每场选不低于口播估算时长的档位，duration 仍由画面驱动、不机械改写。
 
 ## Considered Options
 
@@ -17,5 +17,6 @@ drama 的口播内容（角色台词 + 画外音）统一为一条**场景级、
 - `lib/script_models.py`：`DramaScene` 的口播内容为 `utterances`（`Utterance{kind, speaker, text}`，`kind ⇄ speaker` 校验：dialogue⇒speaker 非空、voiceover⇒speaker 为 None），并有场景级 `source_text`。泛指群演 speaker（`老人甲`）照填原文称呼、不进 characters_in_scene、无机械校验。`VideoPrompt.dialogue` 是否保留按 narration / ad 是否消费该字段定：均不消费则共享模型不再带 dialogue、有消费则 drama 用无-dialogue 变体。
 - 存量数据走「读时迁移」（`model_validator(before)`，仿 `LEGACY_DROPPED_FIELDS`）：老脚本 `video_prompt.dialogue` + `voiceover` 合成 `utterances` 并剥离旧字段（`extra="forbid"` + 「不更坏」守卫才不报错）；旧数据无交错信息、混合场景本就罕见，合并顺序按确定性 best-effort（dialogue 段在前、voiceover 段在后），不假装还原。
 - `lib/data_validator.py`：校验 utterances 结构与 `kind ⇄ speaker`、`source_text`；新增「估算说话时长 > duration × 容差」的 **warning**（沿用 ad 总时长漂移那条「只 warn 不阻塞」）。语速常量单一真相源、可调（可随 `target_language`），与字幕共用、不写死。
+- 说话量对时长为**方向对称的单向约束**、两处消费同一语速真相源（`lib/speech_rate.py`，按 `source_language` 取）：保存期取**单向上界 warning**（上条，`lib/data_validator.py` 估算超容差仅 warn 不阻塞、不改写）；生成期取**单向下界软指引**（`lib/prompt_builders_script.py` 的 drama step1 时长约束 prompt 引导模型为每场选**不低于**该场 utterances 估算口播时长的档位；口播超最长档时取最长档，仍由保存期 warning 兜底暴露）。二者只把时长「顶上去」、永不「压下来」：画面 / 留白可把 duration 撑过下界，无机械逻辑改写模型已选的 duration，「画面驱动 + 留白合法」立场不变。
 - `server/services/jianying_draft_service.py`：drama 注册为字幕模式，从 utterances 派生 `subtitle_spans`（复用既有 span 渲染与单字幕兜底）；`_SUBTITLE_TEXT_FIELDS` 的「单字段」模型对 drama 不适用，改用 utterance→spans builder（类比 `_collect_ad_reference_unit_clips`）。
 - step1 / step2 流水线如何产出 utterances（结构化 step1、透传 step2、web 审核 gate）见 ADR 0041。

--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -33,7 +33,7 @@ from lib.episode_ledger import (
 from lib.project_manager import ProjectManager, resolve_source_kind
 from lib.text_backends.base import TextGenerationRequest, TextTaskType
 from lib.text_generator import TextGenerator
-from lib.text_metrics import count_reading_units
+from lib.text_metrics import count_reading_units, reading_unit_noun
 from lib.text_utils import strip_json_code_fences
 
 logger = logging.getLogger(__name__)
@@ -968,7 +968,7 @@ def _build_planning_prompt(
     """
     overview = project.get("overview") or {}
     language = str(project.get("source_language") or "zh")
-    unit_name = "词" if language in ("en", "vi") else "字"
+    unit_name = reading_unit_noun(language)
     target_units = project.get("episode_target_units")
     is_screenplay = resolve_source_kind(project) == "screenplay"
 

--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -967,8 +967,7 @@ def _build_planning_prompt(
     本段无关的部分由其他段落实。
     """
     overview = project.get("overview") or {}
-    language = str(project.get("source_language") or "zh")
-    unit_name = reading_unit_noun(language)
+    unit_name = reading_unit_noun(_language_of(project))
     target_units = project.get("episode_target_units")
     is_screenplay = resolve_source_kind(project) == "screenplay"
 

--- a/lib/prompt_builders_script.py
+++ b/lib/prompt_builders_script.py
@@ -11,6 +11,7 @@
 
 from lib.prompt_rules import is_v2_enabled
 from lib.prompt_rules.episode_pacing import render_pacing_section
+from lib.speech_rate import speech_rate_units_per_second
 
 
 def _format_names(items: dict) -> str:
@@ -40,6 +41,18 @@ def _format_duration_constraint(supported_durations: list[int], default_duration
             )
         return f"时长：{body}，默认 {default_duration} 秒"
     return f"时长：{body}，按内容节奏自行决定"
+
+
+def _reading_unit_label(language: str | None) -> str:
+    """口播时长估算里『阅读单位』的中文称谓：zh 计字、en / vi 计词。
+
+    与 ``lib.text_metrics.count_reading_units`` 的按语言计数口径对齐（语速真相源同源），
+    使生成期下界软指引里「N 字 / 秒」「N 词 / 秒」的单位名与实际估算口径一致。
+    """
+    code = (language or "").strip().lower()
+    if code in ("en", "vi"):
+        return "词"
+    return "字"
 
 
 def _format_aspect_ratio_desc(aspect_ratio: str) -> str:
@@ -467,6 +480,7 @@ def build_normalize_prompt(
     episode: int,
     source_kind: str = "novel",
     target_language: str = "中文",
+    source_language: str | None = None,
     episode_outline: dict | None = None,
     next_episode_outline: dict | None = None,
 ) -> str:
@@ -479,6 +493,9 @@ def build_normalize_prompt(
     ``source_kind="screenplay"`` 翻为「提取/逐字保留」：台词与画外音逐字落 utterances、视觉转写为
     scene_description；默认 ``"novel"`` 维持「改编」语义、画外音由语境判断放开。``episode_outline`` /
     ``next_episode_outline`` 来自分集账本，驱动内容覆盖故事节点、末场落地集尾钩子。
+
+    ``source_language`` 供时长指引的「台词口播时长」单向下界软指引取语速（阅读单位 / 秒，来自
+    ``lib.speech_rate`` 单一真相源，与保存期上界 warning、字幕派生同口径）；缺省 / 未登记回退默认语速。
     """
     char_list = _format_names(characters)
     scene_list = _format_names(scenes)
@@ -526,15 +543,28 @@ def build_normalize_prompt(
     durations_str = ", ".join(str(d) for d in normalized_durations)
     max_dur = normalized_durations[-1]
     if default_duration is not None:
-        duration_rule = (
+        base_duration_rule = (
             f"只能取 {durations_str} 中的值（该视频模型支持的秒数集合）；默认 {default_duration} 秒，"
             f"打斗 / 大场面 / 情绪铺陈等画面可取更长值至上限 {max_dur} 秒，不要默认挑最短值"
         )
     else:
-        duration_rule = (
+        base_duration_rule = (
             f"只能取 {durations_str} 中的值（该视频模型支持的秒数集合）；"
             f"按画面内容复杂度匹配合适时长（最长 {max_dur} 秒），不强制默认值"
         )
+    # 台词口播时长单向下界软指引：模型为某场选 duration 时，不应选到装不下该场 utterances 口播的短档。
+    # 语速（阅读单位 / 秒）从 lib.speech_rate 单一真相源按 source_language 注入、不写死，与保存期上界
+    # warning、字幕派生同口径。纯软约束：只在 prompt 里下发靠模型遵守，不加生成后机械改写、不加硬阻塞。
+    speech_rate = speech_rate_units_per_second(source_language)
+    unit_label = _reading_unit_label(source_language)
+    duration_lower_bound_rule = (
+        "再按台词口播长度设下界：先估算该场 utterances（台词 + 画外音）逐字念完约需的秒数"
+        f"（口播语速约 {speech_rate:g} {unit_label}/秒），在上述可选值里取**不低于**这个秒数的最接近档位；"
+        "这是单向下界——画面 / 情绪留白可继续把时长往上撑，但台词永不把时长压到念不完的短档，"
+        "utterances 为空（纯画面、无口播）的场景没有此下界、按画面自行取值；"
+        f"若口播估算已超过最长 {max_dur} 秒，取最长档即可（不裁台词、不硬塞），保存时会另有提示"
+    )
+    duration_rule = f"{base_duration_rule}。{duration_lower_bound_rule}"
     pacing_block = (render_pacing_section("drama") + "\n\n") if is_v2_enabled() else ""
 
     return f"""{task_line}

--- a/lib/prompt_builders_script.py
+++ b/lib/prompt_builders_script.py
@@ -547,7 +547,7 @@ def build_normalize_prompt(
     speech_rate = speech_rate_units_per_second(source_language)
     unit_label = reading_unit_noun(source_language)
     duration_lower_bound_rule = (
-        "再按台词口播长度设下界：先估算该场 utterances（台词 + 画外音）逐字念完约需的秒数"
+        "再按台词口播长度设下界：先估算该场 utterances（台词 + 画外音）念完约需的秒数"
         f"（口播语速约 {speech_rate:g} {unit_label}/秒），在上述可选值里取**不低于**这个秒数的最接近档位；"
         "这是单向下界——画面 / 情绪留白可继续把时长往上撑，但台词永不把时长压到念不完的短档，"
         "utterances 为空（纯画面、无口播）的场景没有此下界、按画面自行取值；"

--- a/lib/prompt_builders_script.py
+++ b/lib/prompt_builders_script.py
@@ -544,6 +544,9 @@ def build_normalize_prompt(
     # 台词口播时长单向下界软指引：模型为某场选 duration 时，不应选到装不下该场 utterances 口播的短档。
     # 语速（阅读单位 / 秒）从 lib.speech_rate 单一真相源按 source_language 注入、不写死，与保存期上界
     # warning、字幕派生同口径。纯软约束：只在 prompt 里下发靠模型遵守，不加生成后机械改写、不加硬阻塞。
+    # source_language 来自 project.json，可能是非字符串脏数据；非字符串回退 None，避免下游
+    # speech_rate / reading_unit_noun 的 .strip() 触发 AttributeError（与保存期上界 warning 同口径守卫）。
+    source_language = source_language if isinstance(source_language, str) else None
     speech_rate = speech_rate_units_per_second(source_language)
     unit_label = reading_unit_noun(source_language)
     duration_lower_bound_rule = (

--- a/lib/prompt_builders_script.py
+++ b/lib/prompt_builders_script.py
@@ -12,6 +12,7 @@
 from lib.prompt_rules import is_v2_enabled
 from lib.prompt_rules.episode_pacing import render_pacing_section
 from lib.speech_rate import speech_rate_units_per_second
+from lib.text_metrics import reading_unit_noun
 
 
 def _format_names(items: dict) -> str:
@@ -41,18 +42,6 @@ def _format_duration_constraint(supported_durations: list[int], default_duration
             )
         return f"时长：{body}，默认 {default_duration} 秒"
     return f"时长：{body}，按内容节奏自行决定"
-
-
-def _reading_unit_label(language: str | None) -> str:
-    """口播时长估算里『阅读单位』的中文称谓：zh 计字、en / vi 计词。
-
-    与 ``lib.text_metrics.count_reading_units`` 的按语言计数口径对齐（语速真相源同源），
-    使生成期下界软指引里「N 字 / 秒」「N 词 / 秒」的单位名与实际估算口径一致。
-    """
-    code = (language or "").strip().lower()
-    if code in ("en", "vi"):
-        return "词"
-    return "字"
 
 
 def _format_aspect_ratio_desc(aspect_ratio: str) -> str:
@@ -556,7 +545,7 @@ def build_normalize_prompt(
     # 语速（阅读单位 / 秒）从 lib.speech_rate 单一真相源按 source_language 注入、不写死，与保存期上界
     # warning、字幕派生同口径。纯软约束：只在 prompt 里下发靠模型遵守，不加生成后机械改写、不加硬阻塞。
     speech_rate = speech_rate_units_per_second(source_language)
-    unit_label = _reading_unit_label(source_language)
+    unit_label = reading_unit_noun(source_language)
     duration_lower_bound_rule = (
         "再按台词口播长度设下界：先估算该场 utterances（台词 + 画外音）逐字念完约需的秒数"
         f"（口播语速约 {speech_rate:g} {unit_label}/秒），在上述可选值里取**不低于**这个秒数的最接近档位；"

--- a/lib/text_metrics.py
+++ b/lib/text_metrics.py
@@ -46,6 +46,16 @@ def count_reading_units(text: str, language: str | None) -> int:
     return len(_pattern_for(language).findall(text))
 
 
+def reading_unit_noun(language: str | None) -> str:
+    """该语言『阅读单位』的中文量词：词（按词计的 en / vi 等）/ 字（zh 及未知语言按字计）。
+
+    量词名直接由 ``_pattern_for`` 的分类派生，与 ``count_reading_units`` 天然同源——
+    新增按词计的语言只在 ``_pattern_for`` 加分支，本函数自动跟随，避免各调用点各写一套
+    「词 / 字」映射而与实际计数口径漂移（prompt 里「N 词 / 秒」「N 字一集」等描述据此取名）。
+    """
+    return "词" if _pattern_for(language) is _LATIN_WORD_PATTERN else "字"
+
+
 def find_reading_unit_offset(text: str, target_units: int, language: str | None) -> int:
     """返回第 ``target_units`` 个阅读单位末尾的字符偏移（含尾）。
 

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -349,6 +349,9 @@ def normalize_drama_script_tool(ctx: ToolContext):
                 # 输出语言取项目 source_language（生成内容语言的唯一真相源）；缺省回退默认中文，
                 # 非中文项目的 step1 内容据此用目标语言产出，而非默认中文。
                 target_language=project.get("source_language") or "中文",
+                # source_language（zh / en / vi 或 None）另供时长下界软指引取语速：drama step1 引导模型为
+                # 每场选不低于该场 utterances 口播时长的档位，语速按此从 lib.speech_rate 单一真相源注入。
+                source_language=project.get("source_language"),
             )
 
             if dry_run:

--- a/tests/test_prompt_builders_script.py
+++ b/tests/test_prompt_builders_script.py
@@ -413,6 +413,13 @@ class TestDramaDurationSpeechLowerBound:
         default_rate = speech_rate_units_per_second(None)
         assert f"{default_rate:g}" in self._normalize()
 
+    def test_non_string_source_language_falls_back_to_default_rate(self):
+        # source_language 为非字符串脏数据（project.json 类型未强校验）→ 回退默认语速不崩溃，
+        # 与保存期上界 warning 同口径守卫；回退 None 走 zh 计字口径
+        default_rate = speech_rate_units_per_second(None)
+        for dirty in (5, ["zh"]):
+            assert f"{default_rate:g} 字/秒" in self._normalize(source_language=dirty)
+
     def test_narration_and_step2_drama_have_no_speech_lower_bound(self):
         # 生成期时长下界只在 drama step1（normalize）；narration step2 与 drama step2 视觉层不含
         narration = build_narration_prompt(

--- a/tests/test_prompt_builders_script.py
+++ b/tests/test_prompt_builders_script.py
@@ -1,3 +1,4 @@
+from lib.prompt_builders_ad import build_ad_prompt
 from lib.prompt_builders_script import (
     _format_names,
     build_drama_prompt,
@@ -6,6 +7,7 @@ from lib.prompt_builders_script import (
     build_overview_prompt,
     render_drama_content_for_step2,
 )
+from lib.speech_rate import speech_rate_units_per_second
 
 
 class TestPromptBuildersScript:
@@ -335,3 +337,119 @@ class TestOverviewPrompt:
     def test_default_source_kind_is_novel(self):
         content = "源文本"
         assert build_overview_prompt(content) == build_overview_prompt(content, source_kind="novel")
+
+
+class TestDramaDurationSpeechLowerBound:
+    """drama step1 时长指引的「台词口播时长」单向下界软指引（生成期，纯 prompt 软约束）。
+
+    语速从 lib.speech_rate 单一真相源按项目 source_language 注入；drama prompt 内不写死语速数字。
+    单向：画面 / 留白可把时长撑长，台词永不把时长压短；空 utterances 无下界、行为同今日。
+    narration / ad / step2 视觉层不受影响。只断言语义关键词与注入值，不锁逐字措辞。
+    """
+
+    _SPEECH_MARKER = "口播语速约"
+
+    def _normalize(self, **overrides) -> str:
+        kwargs = dict(
+            novel_text="【第1集】角色甲：「你好」",
+            project_overview={"synopsis": "S", "genre": "G", "theme": "T", "world_setting": "W"},
+            style="动漫",
+            characters={"角色甲": {}},
+            scenes={},
+            props={},
+            default_duration=8,
+            supported_durations=[4, 6, 8],
+            episode=1,
+        )
+        kwargs.update(overrides)
+        return build_normalize_prompt(**kwargs)
+
+    def test_speech_rate_injected_from_single_source(self):
+        # 语速数字来自 lib.speech_rate 单一真相源，按 source_language 取；zh 计字、en / vi 计词
+        for lang in ("zh", "en", "vi"):
+            rate = speech_rate_units_per_second(lang)
+            assert f"{rate:g}" in self._normalize(source_language=lang)
+        assert "字/秒" in self._normalize(source_language="zh")
+        assert "词/秒" in self._normalize(source_language="en")
+        assert "词/秒" in self._normalize(source_language="vi")
+
+    def test_no_hardcoded_speech_rate_number(self):
+        # 语速随语言变化 → 证明是注入而非写死；zh（字/秒）与 en（词/秒）语速不同则两处数字不同
+        zh_rate = speech_rate_units_per_second("zh")
+        en_rate = speech_rate_units_per_second("en")
+        assert zh_rate != en_rate  # 前置：两语言语速确实不同
+        assert f"{zh_rate:g} 字/秒" in self._normalize(source_language="zh")
+        assert f"{en_rate:g} 词/秒" in self._normalize(source_language="en")
+
+    def test_lower_bound_is_single_directional_soft_guidance(self):
+        prompt = self._normalize(source_language="zh")
+        # 下界软指引在场：按口播估算取不低于的档位
+        assert self._SPEECH_MARKER in prompt
+        assert "下界" in prompt
+        assert "不低于" in prompt
+        assert "口播" in prompt
+        # 单向：画面可撑长、台词不压短
+        assert "单向" in prompt
+
+    def test_empty_utterances_have_no_lower_bound(self):
+        # 空 utterances（纯画面）场景明确无下界，行为同今日逐字一致
+        prompt = self._normalize(source_language="zh")
+        assert "utterances 为空" in prompt
+        assert "没有此下界" in prompt
+
+    def test_exceeds_max_takes_longest_tier(self):
+        # 口播超过最长档时取最长档、不裁台词，保存期 warning 兜底
+        prompt = self._normalize(source_language="zh", supported_durations=[4, 6, 8], default_duration=8)
+        assert "取最长档" in prompt
+
+    def test_lower_bound_present_without_default_duration(self):
+        # default_duration 为 null 的分支同样带下界软指引
+        prompt = self._normalize(source_language="zh", default_duration=None)
+        assert self._SPEECH_MARKER in prompt
+        assert "不低于" in prompt
+
+    def test_missing_source_language_falls_back_to_default_rate(self):
+        # source_language 缺省 → 回退默认语速（speech_rate 单一真相源同口径），向后兼容
+        default_rate = speech_rate_units_per_second(None)
+        assert f"{default_rate:g}" in self._normalize()
+
+    def test_narration_and_step2_drama_have_no_speech_lower_bound(self):
+        # 生成期时长下界只在 drama step1（normalize）；narration step2 与 drama step2 视觉层不含
+        narration = build_narration_prompt(
+            project_overview={"synopsis": "S", "genre": "G", "theme": "T", "world_setting": "W"},
+            style="古风",
+            style_description="cinematic",
+            characters={"角色甲": {}},
+            scenes={},
+            props={},
+            step1_segments=[
+                {"segment_id": "E1S01", "novel_text": "原文", "duration_seconds": 4, "segment_break": False}
+            ],
+            episode=1,
+        )
+        assert self._SPEECH_MARKER not in narration
+        drama_step2 = build_drama_prompt(
+            project_overview={"synopsis": "S", "genre": "G", "theme": "T", "world_setting": "W"},
+            style="动漫",
+            style_description="cinematic",
+            scenes_content="### E1S01（时长 4 秒）",
+            episode=1,
+        )
+        assert self._SPEECH_MARKER not in drama_step2
+
+    def test_ad_prompt_unaffected(self):
+        # ad step1 时长指引不受本 issue 改动（ad 的字数→时长折算既存漂移不在范围内）
+        ad = build_ad_prompt(
+            project_overview={"synopsis": "S", "genre": "G", "theme": "T", "world_setting": "W"},
+            style="动漫",
+            style_description="cinematic",
+            characters={"角色甲": {}},
+            scenes={},
+            props={},
+            products={},
+            brief="卖点",
+            target_duration=30,
+            generation_mode="image",
+            supported_durations=[4, 6, 8],
+        )
+        assert self._SPEECH_MARKER not in ad

--- a/tests/test_text_metrics.py
+++ b/tests/test_text_metrics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from lib.text_metrics import count_reading_units, find_reading_unit_offset
+from lib.text_metrics import count_reading_units, find_reading_unit_offset, reading_unit_noun
 
 
 class TestZh:
@@ -141,3 +141,24 @@ class TestFindReadingUnitOffset:
         # ja / None / "" 走 zh 路径,英文字符不计入 → 应返回 0(没有阅读单位)
         # 但因为没找到第 N 个单位,会走到末尾分支
         assert find_reading_unit_offset("hello world", 1, "ja") == 11
+
+
+class TestReadingUnitNoun:
+    """量词名与 count_reading_units 的语言分类同源：按词计 → 词，按字计 → 字。"""
+
+    def test_word_based_languages_use_ci(self) -> None:
+        assert reading_unit_noun("en") == "词"
+        assert reading_unit_noun("vi") == "词"
+
+    def test_char_based_language_uses_zi(self) -> None:
+        assert reading_unit_noun("zh") == "字"
+
+    def test_case_insensitive(self) -> None:
+        assert reading_unit_noun("EN") == "词"
+        assert reading_unit_noun(" Vi ") == "词"
+
+    def test_fallback_to_zi_for_unknown_or_missing(self) -> None:
+        # 未知 / None / 空 language 与 count_reading_units 同走 zh 路径 → 字
+        assert reading_unit_noun(None) == "字"
+        assert reading_unit_noun("") == "字"
+        assert reading_unit_noun("ja") == "字"


### PR DESCRIPTION
Closes #929

## 背景

drama 场景 `duration_seconds` 在 step1 内容规范化时由模型选定，原时长约束 prompt 只按画面复杂度取值，不参考台词口播长度。台词多的场景生成期就可能选到塞不下口播的短时长，事后才被保存期上界 warning 暴露，表现为「台词说不完 / 语速畸快」。

## 改动

- **生成期单向下界软指引**：drama step1 时长指引新增引导——模型为每场选 `duration_seconds` 时，应取不低于该场 utterances 估算口播时长的档位（在模型 supported_durations 内取满足下界的最近档）。
- **单向且纯软约束**：画面 / 情绪留白仍可把时长往上撑，台词永不把时长压短；不加生成后机械改写、不加校验层硬阻塞，保存期上界 warning 原样保留作安全网。
- **语速单一真相源**：prompt 里「约 N 字 / 秒」按项目 `source_language` 从 `lib.speech_rate` 注入，drama prompt 内不写死语速数字，与保存期 warning、字幕派生同口径。
- **边界**：空 utterances（纯画面）场景无下界、行为向后兼容；口播估算超最长档时取最长档（不裁台词、不硬塞）。narration 与 ad 时长指引未改。
- **ADR 0040** consequence 精修，记上生成期单向下界软指引（属精修非反转）。

## 本地审查修复

独立审查发现「词 / 字」阅读单位量词映射在 `prompt_builders_script` 与 `episode_planner` 各自内联、与 `lib.text_metrics` 的按语言计数分类重复，存在新增语言时漂移风险。已收敛为 `lib.text_metrics.reading_unit_noun`——量词名直接由计数分类派生，随分类自动跟随。

## 验证

- `uv run python -m pytest`：5497 passed
- `uv run ruff check . && uv run ruff format --check .`：clean
- `uv run basedpyright`：0 errors
- `test_subagent_md_sync.py` 保持绿（下界指引随每项目动态值注入、留在 builder 侧，未触及镜像到 subagent .md 的共享 prompt 常量）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 剧集口播内容统一为场景级有序片段结构，并保留说话人/类型信息以驱动下游处理。
  * 口播时长规则升级：基于源语言的语速“下界软指引”生成档位；空口播不施加下界，超过最大档位则选择最长档。
* **文档**
  * 补充保存期/生成期的时长约束口径及字幕跨度从口播片段派生的说明。
* **测试**
  * 新增覆盖语速单位（字/词）与下界软指引生成期范围的用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->