### PR TITLE
fix(timeline): 剧集分镜详情可编辑角色对白

### DIFF
--- a/frontend/src/components/canvas/timeline/ShotDetail.drama.test.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.drama.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ShotDetail } from "./ShotDetail";
+import type { DramaScene, Utterance } from "@/types";
+
+const sampleUtterances: Utterance[] = [
+  { kind: "voiceover", speaker: null, text: "三年后。" },
+  { kind: "dialogue", speaker: "阿离", text: "你终于回来了。" },
+];
+
+function makeScene(overrides: Partial<DramaScene> = {}): DramaScene {
+  return {
+    scene_id: "E1S01",
+    duration_seconds: 8,
+    segment_break: false,
+    characters_in_scene: ["阿离"],
+    scenes: [],
+    props: [],
+    image_prompt: {
+      scene: "重逢",
+      composition: { shot_type: "Medium Shot", lighting: "暖光", ambiance: "怀旧" },
+    },
+    video_prompt: { action: "推门而入", camera_motion: "Static", ambiance_audio: "风声", dialogue: [] },
+    utterances: sampleUtterances,
+    transition_to_next: "cut",
+    ...overrides,
+  };
+}
+
+function renderDetail(props: Partial<Parameters<typeof ShotDetail>[0]> = {}) {
+  const scene = makeScene();
+  return render(
+    <ShotDetail
+      segment={scene}
+      segmentId={scene.scene_id}
+      contentMode="drama"
+      aspectRatio="9:16"
+      projectName="demo"
+      scriptFile="episode_1.json"
+      selectedIndex={0}
+      totalCount={3}
+      onPrev={() => {}}
+      onNext={() => {}}
+      durationOptions={[8]}
+      {...props}
+    />,
+  );
+}
+
+describe("ShotDetail drama 模式", () => {
+  it("渲染 UtteranceListEditor：按时序展示画外音与带说话人的台词", () => {
+    renderDetail();
+    expect(screen.getByDisplayValue("三年后。")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("阿离")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("你终于回来了。")).toBeInTheDocument();
+    // drama 不再渲染扁平对白编辑器的空态占位
+    expect(screen.queryByText("（暂无对话）")).toBeNull();
+  });
+
+  it("编辑发声文本后保存，提交 { utterances } patch", () => {
+    const onUpdatePrompt = vi.fn();
+    renderDetail({ onUpdatePrompt });
+
+    fireEvent.change(screen.getByDisplayValue("你终于回来了。"), {
+      target: { value: "我回来了。" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+    expect(onUpdatePrompt).toHaveBeenCalledWith(
+      "E1S01",
+      expect.objectContaining({
+        utterances: [
+          { kind: "voiceover", speaker: null, text: "三年后。" },
+          { kind: "dialogue", speaker: "阿离", text: "我回来了。" },
+        ],
+      }),
+    );
+  });
+
+  it("新增画外音条目后保存，随 utterances 一并提交", () => {
+    const onUpdatePrompt = vi.fn();
+    renderDetail({ onUpdatePrompt });
+
+    fireEvent.click(screen.getByText("添加画外音"));
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+    expect(onUpdatePrompt).toHaveBeenCalledWith(
+      "E1S01",
+      expect.objectContaining({
+        utterances: [...sampleUtterances, { kind: "voiceover", speaker: null, text: "" }],
+      }),
+    );
+  });
+
+  it("上游静默更新时：干净草稿跟随新 utterances", () => {
+    const { rerender } = renderDetail();
+
+    const updated = makeScene({
+      utterances: [{ kind: "dialogue", speaker: "阿离", text: "上游改写后的台词。" }],
+    });
+    rerender(
+      <ShotDetail
+        segment={updated}
+        segmentId={updated.scene_id}
+        contentMode="drama"
+        aspectRatio="9:16"
+        projectName="demo"
+        scriptFile="episode_1.json"
+        selectedIndex={0}
+        totalCount={3}
+        onPrev={() => {}}
+        onNext={() => {}}
+        durationOptions={[8]}
+      />,
+    );
+    expect(screen.getByDisplayValue("上游改写后的台词。")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("你终于回来了。")).toBeNull();
+  });
+});

--- a/frontend/src/components/canvas/timeline/ShotDetail.drama.test.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.drama.test.tsx
@@ -27,9 +27,9 @@ function makeScene(overrides: Partial<DramaScene> = {}): DramaScene {
   };
 }
 
-function renderDetail(props: Partial<Parameters<typeof ShotDetail>[0]> = {}) {
-  const scene = makeScene();
-  return render(
+// 统一构造 ShotDetail 元素，供首渲染与 rerender 共用，避免重复整段 props 列表。
+function detailElement(scene: DramaScene, props: Partial<Parameters<typeof ShotDetail>[0]> = {}) {
+  return (
     <ShotDetail
       segment={scene}
       segmentId={scene.scene_id}
@@ -43,8 +43,12 @@ function renderDetail(props: Partial<Parameters<typeof ShotDetail>[0]> = {}) {
       onNext={() => {}}
       durationOptions={[8]}
       {...props}
-    />,
+    />
   );
+}
+
+function renderDetail(props: Partial<Parameters<typeof ShotDetail>[0]> = {}) {
+  return render(detailElement(makeScene(), props));
 }
 
 describe("ShotDetail drama 模式", () => {
@@ -97,22 +101,31 @@ describe("ShotDetail drama 模式", () => {
     const updated = makeScene({
       utterances: [{ kind: "dialogue", speaker: "阿离", text: "上游改写后的台词。" }],
     });
-    rerender(
-      <ShotDetail
-        segment={updated}
-        segmentId={updated.scene_id}
-        contentMode="drama"
-        aspectRatio="9:16"
-        projectName="demo"
-        scriptFile="episode_1.json"
-        selectedIndex={0}
-        totalCount={3}
-        onPrev={() => {}}
-        onNext={() => {}}
-        durationOptions={[8]}
-      />,
-    );
+    rerender(detailElement(updated));
     expect(screen.getByDisplayValue("上游改写后的台词。")).toBeInTheDocument();
     expect(screen.queryByDisplayValue("你终于回来了。")).toBeNull();
+  });
+
+  it("上游画外音缺省 speaker 时：类型往返切换不产生虚假脏态（归一化签名）", () => {
+    // 存量画外音只有 kind/text、缺 speaker 键（类型允许 speaker?: null）
+    const scene = makeScene({ utterances: [{ kind: "voiceover", text: "三年后。" }] });
+    render(detailElement(scene, { onUpdatePrompt: vi.fn() }));
+    // 初始干净：保存栏不渲染
+    expect(screen.queryByRole("button", { name: "保存" })).toBeNull();
+
+    const toggleTitle = "在台词与画外音间切换";
+    // 切到台词：真实变更 → 变脏 → 保存栏出现
+    fireEvent.click(screen.getByTitle(toggleTitle));
+    expect(screen.queryByRole("button", { name: "保存" })).not.toBeNull();
+    // 切回画外音（speaker 归 null，文本不变）：归一化后与上游等价 → 复归干净 → 保存栏消失
+    fireEvent.click(screen.getByTitle(toggleTitle));
+    expect(screen.queryByRole("button", { name: "保存" })).toBeNull();
+  });
+
+  it("只读模式（缺 onUpdatePrompt）：发声编辑器禁用，无法进入脏态", () => {
+    renderDetail();
+    expect(screen.getByText("添加画外音").closest("button")).toBeDisabled();
+    expect(screen.getByText("添加台词").closest("button")).toBeDisabled();
+    expect(screen.getByDisplayValue("你终于回来了。")).toBeDisabled();
   });
 });

--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -455,11 +455,11 @@ export function ShotDetail({
     }
     if (isDrama) {
       const draftUtterances = draft.utterances ?? EMPTY_UTTERANCES;
-      if (utterancesSig(draftUtterances) !== upstreamUtterancesSig)
+      if (draftUtterances !== upstreamUtterances && utterancesSig(draftUtterances) !== upstreamUtterancesSig)
         patch.utterances = draftUtterances;
     }
     return patch;
-  }, [draft, ip, vp, isAd, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterancesSig]);
+  }, [draft, ip, vp, isAd, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterances, upstreamUtterancesSig]);
 
   const dirty = Object.keys(dirtyPatch).length > 0;
 

--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -420,6 +420,9 @@ export function ShotDetail({
       ),
     [isAd, ip, vp, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterances],
   );
+  // 上游发声序列签名单独记忆化：dirtyPatch 随每次 keystroke 重算，
+  // 但上游极少变，避免逐键重复序列化整个 upstreamUtterances。
+  const upstreamUtterancesSig = useMemo(() => utterancesSig(upstreamUtterances), [upstreamUtterances]);
   // 上游变更（保存完成 / agent 编辑）：草稿干净时静默跟随；脏时保留用户输入。
   // 渲染阶段状态同步（React 推荐）：本次渲染内直接比对上游签名并校正草稿，
   // 免去 useEffect 的额外渲染周期与依赖项管理。draft 直接读当前渲染值，无需 ref 镜像。
@@ -452,11 +455,11 @@ export function ShotDetail({
     }
     if (isDrama) {
       const draftUtterances = draft.utterances ?? EMPTY_UTTERANCES;
-      if (utterancesSig(draftUtterances) !== utterancesSig(upstreamUtterances))
+      if (utterancesSig(draftUtterances) !== upstreamUtterancesSig)
         patch.utterances = draftUtterances;
     }
     return patch;
-  }, [draft, ip, vp, isAd, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterances]);
+  }, [draft, ip, vp, isAd, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterancesSig]);
 
   const dirty = Object.keys(dirtyPatch).length > 0;
 

--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ImageIcon,
@@ -107,6 +107,16 @@ const stableSig = (value: unknown): string => JSON.stringify(value ?? null);
 // 产出新数组、从不就地改写，故共享此常量安全。
 const EMPTY_UTTERANCES: Utterance[] = [];
 
+// voiceover 的 speaker 允许缺省或 null，两种写法语义等价（无说话人）。签名前归一：
+// voiceover speaker 统一为 null、并固定键序，避免 `{}` 与 `{ speaker: null }` 判成不同，
+// 否则上游把画外音字段规范化后 dirty 清不掉，切镜与生成会持续被禁用。
+const canonicalUtterance = (u: Utterance): Utterance =>
+  u.kind === "dialogue"
+    ? { kind: "dialogue", speaker: u.speaker, text: u.text }
+    : { kind: "voiceover", speaker: null, text: u.text };
+
+const utterancesSig = (list: Utterance[]): string => stableSig(list.map(canonicalUtterance));
+
 /** 由上游值构造干净草稿（useState 初始化 / 上游静默跟随 / 取消编辑三处共用）。 */
 function baselineDraft(
   ip: ImagePromptValue,
@@ -131,7 +141,7 @@ function draftSig(d: DraftState, isAd: boolean, isDrama: boolean): string {
     ip: d.image_prompt,
     vp: d.video_prompt,
     ...(isAd ? { voiceover_text: d.voiceover_text ?? "", section: d.section ?? "" } : {}),
-    ...(isDrama ? { utterances: d.utterances ?? [] } : {}),
+    ...(isDrama ? { utterances: (d.utterances ?? EMPTY_UTTERANCES).map(canonicalUtterance) } : {}),
   });
 }
 
@@ -410,22 +420,16 @@ export function ShotDetail({
       ),
     [isAd, ip, vp, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterances],
   );
-  const baselineSigRef = useRef(upstreamSig);
-  const draftRef = useRef(draft);
-  // 同步 draft 到 ref，供下方 effect 读取最新草稿而无需把 draft 加入 deps
-  useEffect(() => {
-    draftRef.current = draft;
-  }, [draft]);
-
   // 上游变更（保存完成 / agent 编辑）：草稿干净时静默跟随；脏时保留用户输入。
-  // 把 draft 放到 ref 里读，避免每次 keystroke 都重跑 effect+stringify。
-  useEffect(() => {
-    if (baselineSigRef.current === upstreamSig) return;
-    if (draftSig(draftRef.current, isAd, isDrama) === baselineSigRef.current) {
+  // 渲染阶段状态同步（React 推荐）：本次渲染内直接比对上游签名并校正草稿，
+  // 免去 useEffect 的额外渲染周期与依赖项管理。draft 直接读当前渲染值，无需 ref 镜像。
+  const [syncedUpstreamSig, setSyncedUpstreamSig] = useState(upstreamSig);
+  if (syncedUpstreamSig !== upstreamSig) {
+    if (draftSig(draft, isAd, isDrama) === syncedUpstreamSig) {
       setDraft(baselineDraft(ip, vp, isAd, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterances));
     }
-    baselineSigRef.current = upstreamSig;
-  }, [upstreamSig, ip, vp, isAd, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterances]);
+    setSyncedUpstreamSig(upstreamSig);
+  }
 
   // 引用相等优先：未编辑过的字段直接跳过 stringify。
   const dirtyPatch = useMemo<Record<string, unknown>>(() => {
@@ -448,7 +452,7 @@ export function ShotDetail({
     }
     if (isDrama) {
       const draftUtterances = draft.utterances ?? EMPTY_UTTERANCES;
-      if (stableSig(draftUtterances) !== stableSig(upstreamUtterances))
+      if (utterancesSig(draftUtterances) !== utterancesSig(upstreamUtterances))
         patch.utterances = draftUtterances;
     }
     return patch;
@@ -515,7 +519,7 @@ export function ShotDetail({
     setSaving(true);
     try {
       await onUpdatePrompt?.(segmentId, dirtyPatch);
-      // 上游会刷新 → useEffect 检测到 baselineSig 变化 → 草稿等于新基线时保持干净
+      // 上游会刷新 → 渲染阶段同步检测到上游签名变化 → 草稿等于新基线时保持干净
     } finally {
       setSaving(false);
     }
@@ -662,7 +666,7 @@ export function ShotDetail({
           <UtteranceListEditor
             utterances={draft.utterances ?? EMPTY_UTTERANCES}
             onChange={handleUtterancesChange}
-            disabled={saving}
+            disabled={saving || refsReadOnly}
           />
         </div>
       ) : (

--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -18,11 +18,13 @@ import type {
   ImagePrompt,
   VideoPrompt,
   Dialogue,
+  Utterance,
 } from "@/types";
 import { AD_SECTION_VALUES } from "@/types";
 import { ImagePromptEditor } from "./ImagePromptEditor";
 import { VideoPromptEditor } from "./VideoPromptEditor";
 import { DialogueListEditor } from "./DialogueListEditor";
+import { UtteranceListEditor } from "./UtteranceListEditor";
 import { ResponsiveDetailGrid } from "./ResponsiveDetailGrid";
 import { MediaCard } from "./MediaCard";
 import { NarrationAudioCard } from "./NarrationAudioCard";
@@ -92,11 +94,18 @@ interface DraftState {
   voiceover_text?: string;
   /** 仅 ad 模式：带货框架段落标签草稿 */
   section?: string;
+  /** 仅 drama 模式：场景级有序发声序列草稿（台词 + 画外音） */
+  utterances?: Utterance[];
 }
 
 // 字段集合稳定（ImagePrompt/VideoPrompt/string），JSON.stringify 即可作等值签名：
 // 任何字段顺序差异都来自我们自己的 setter 或上游同一构造路径，键序一致。
 const stableSig = (value: unknown): string => JSON.stringify(value ?? null);
+
+// 稳定空 utterances 引用：缺省 / 非 drama 时统一指向同一常量，避免每次渲染新建 `[]`
+// 让 upstreamSig memo 依赖失效而做无谓 stringify。UtteranceListEditor 只经 map/filter/spread
+// 产出新数组、从不就地改写，故共享此常量安全。
+const EMPTY_UTTERANCES: Utterance[] = [];
 
 /** 由上游值构造干净草稿（useState 初始化 / 上游静默跟随 / 取消编辑三处共用）。 */
 function baselineDraft(
@@ -105,26 +114,25 @@ function baselineDraft(
   isAd: boolean,
   voiceover: string,
   section: string,
+  isDrama: boolean,
+  utterances: Utterance[],
 ): DraftState {
   return {
     image_prompt: ip,
     video_prompt: vp,
     ...(isAd ? { voiceover_text: voiceover, section } : {}),
+    ...(isDrama ? { utterances } : {}),
   };
 }
 
 /** 草稿等值签名：与上游基线签名同键形状（漂移会让"干净草稿静默跟随上游"失效）。 */
-function draftSig(d: DraftState, isAd: boolean): string {
-  return stableSig(
-    isAd
-      ? {
-          ip: d.image_prompt,
-          vp: d.video_prompt,
-          voiceover_text: d.voiceover_text ?? "",
-          section: d.section ?? "",
-        }
-      : { ip: d.image_prompt, vp: d.video_prompt },
-  );
+function draftSig(d: DraftState, isAd: boolean, isDrama: boolean): string {
+  return stableSig({
+    ip: d.image_prompt,
+    vp: d.video_prompt,
+    ...(isAd ? { voiceover_text: d.voiceover_text ?? "", section: d.section ?? "" } : {}),
+    ...(isDrama ? { utterances: d.utterances ?? [] } : {}),
+  });
 }
 
 interface DurationPillProps {
@@ -354,12 +362,16 @@ export function ShotDetail({
   const adShot = isAd ? (segment as AdShot) : null;
   const upstreamVoiceover = adShot?.voiceover_text ?? "";
   const upstreamSection = adShot?.section ?? "";
+  const isDrama = contentMode === "drama";
+  const dramaScene = isDrama ? (segment as DramaScene) : null;
+  // drama 场景级发声序列（迁移后存量数据可能缺省，读到空即无发声）。
+  const upstreamUtterances = dramaScene?.utterances ?? EMPTY_UTTERANCES;
 
   // 草稿：本地编辑直到用户点击 Save。父级 ShotSplitView 通过 key={segmentId}
   // 在切镜头时硬重置整个组件，所以这里只需处理"上游同字段静默更新"的情况。
   // 备注不进入草稿，由 NotesDrawer 收起时直接落库。
   const [draft, setDraft] = useState<DraftState>(() =>
-    baselineDraft(ip, vp, isAd, upstreamVoiceover, upstreamSection),
+    baselineDraft(ip, vp, isAd, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterances),
   );
   const [saving, setSaving] = useState(false);
   const [uploadingKind, setUploadingKind] = useState<"storyboard" | "video" | null>(null);
@@ -390,8 +402,13 @@ export function ShotDetail({
   };
 
   const upstreamSig = useMemo(
-    () => draftSig(baselineDraft(ip, vp, isAd, upstreamVoiceover, upstreamSection), isAd),
-    [isAd, ip, vp, upstreamVoiceover, upstreamSection],
+    () =>
+      draftSig(
+        baselineDraft(ip, vp, isAd, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterances),
+        isAd,
+        isDrama,
+      ),
+    [isAd, ip, vp, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterances],
   );
   const baselineSigRef = useRef(upstreamSig);
   const draftRef = useRef(draft);
@@ -404,11 +421,11 @@ export function ShotDetail({
   // 把 draft 放到 ref 里读，避免每次 keystroke 都重跑 effect+stringify。
   useEffect(() => {
     if (baselineSigRef.current === upstreamSig) return;
-    if (draftSig(draftRef.current, isAd) === baselineSigRef.current) {
-      setDraft(baselineDraft(ip, vp, isAd, upstreamVoiceover, upstreamSection));
+    if (draftSig(draftRef.current, isAd, isDrama) === baselineSigRef.current) {
+      setDraft(baselineDraft(ip, vp, isAd, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterances));
     }
     baselineSigRef.current = upstreamSig;
-  }, [upstreamSig, ip, vp, isAd, upstreamVoiceover, upstreamSection]);
+  }, [upstreamSig, ip, vp, isAd, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterances]);
 
   // 引用相等优先：未编辑过的字段直接跳过 stringify。
   const dirtyPatch = useMemo<Record<string, unknown>>(() => {
@@ -429,8 +446,13 @@ export function ShotDetail({
       if ((draft.section ?? "") !== upstreamSection)
         patch.section = draft.section ?? "";
     }
+    if (isDrama) {
+      const draftUtterances = draft.utterances ?? EMPTY_UTTERANCES;
+      if (stableSig(draftUtterances) !== stableSig(upstreamUtterances))
+        patch.utterances = draftUtterances;
+    }
     return patch;
-  }, [draft, ip, vp, isAd, upstreamVoiceover, upstreamSection]);
+  }, [draft, ip, vp, isAd, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterances]);
 
   const dirty = Object.keys(dirtyPatch).length > 0;
 
@@ -471,6 +493,10 @@ export function ShotDetail({
     handleVidUpdate({ dialogue });
   };
 
+  const handleUtterancesChange = (utterances: Utterance[]) => {
+    setDraft((d) => ({ ...d, utterances }));
+  };
+
   const handleImgStringChange = (val: string) => {
     setDraft((d) => ({ ...d, image_prompt: val }));
   };
@@ -497,7 +523,7 @@ export function ShotDetail({
 
   const handleCancel = () => {
     if (saving) return;
-    setDraft(baselineDraft(ip, vp, isAd, upstreamVoiceover, upstreamSection));
+    setDraft(baselineDraft(ip, vp, isAd, upstreamVoiceover, upstreamSection, isDrama, upstreamUtterances));
   };
 
   const sbEstimate = segCost?.estimate?.image;
@@ -619,9 +645,27 @@ export function ShotDetail({
         disabled={dirty || saving || refsReadOnly}
         disabledHint={dirty ? dirtyHint : undefined}
       />
-      {/* drama 口播已迁到 step1 审核 gate 的 utterances 富编辑：此处编辑 video_prompt.dialogue
-          仅服务 narration / ad（drama 的 video_prompt 不含 dialogue）。 */}
-      {contentMode !== "drama" && (
+      {/* 对白编辑：narration / ad 编辑扁平 video_prompt.dialogue；drama 台词已迁到场景级
+          utterances（判别式台词 + 画外音），此处直接编辑 scene.utterances 并双向保存同步。 */}
+      {isDrama ? (
+        <div>
+          <div
+            className="mb-2 text-[10.5px] font-bold uppercase"
+            style={{
+              color: "var(--color-text-4)",
+              letterSpacing: "1px",
+              fontFamily: "var(--font-mono)",
+            }}
+          >
+            {t("detail_section_utterances")}
+          </div>
+          <UtteranceListEditor
+            utterances={draft.utterances ?? EMPTY_UTTERANCES}
+            onChange={handleUtterancesChange}
+            disabled={saving}
+          />
+        </div>
+      ) : (
         <div>
           <div
             className="mb-2 text-[10.5px] font-bold uppercase"

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1226,6 +1226,7 @@ export default {
   'shot_notes_close': 'Close notes',
   'shot_notes_title': 'NOTES',
   'detail_section_dialogue': 'DIALOGUE',
+  'detail_section_utterances': 'UTTERANCES',
   'detail_section_novel': 'ORIGINAL TEXT',
   'detail_section_voiceover': 'VOICEOVER',
   'detail_voiceover_placeholder': 'Voiceover line for this shot, ready to record; leave empty for visual-only shots…',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1117,6 +1117,7 @@ export default {
   'detail_image_prompt_placeholder': 'Mô tả khung hình: bối cảnh, nhân vật, hành động, bố cục…',
   'detail_image_prompt_title': 'Image Prompt · Phân cảnh',
   'detail_section_dialogue': 'DIALOGUE',
+  'detail_section_utterances': 'LỜI NÓI',
   'detail_section_novel': 'ORIGINAL TEXT',
   'detail_section_voiceover': 'LỜI THOẠI QUẢNG CÁO',
   'detail_voiceover_placeholder': 'Lời thoại của cảnh này, sẵn sàng để thu âm; để trống nếu cảnh chỉ có hình ảnh…',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1227,6 +1227,7 @@ export default {
   'shot_notes_close': '关闭备注',
   'shot_notes_title': '备注',
   'detail_section_dialogue': '对话',
+  'detail_section_utterances': '发声序列',
   'detail_section_novel': '原文',
   'detail_section_voiceover': '口播文案',
   'detail_voiceover_placeholder': '这一镜的口播台词，照稿可配音；纯画面镜头留空…',

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -881,6 +881,7 @@ async def update_scene(name: str, scene_id: str, req: UpdateSceneRequest, _user:
                                     "scenes",
                                     "props",
                                     "segment_break",
+                                    "utterances",
                                     "note",
                                 ]:
                                     if value is None and key != "note":

--- a/tests/test_project_manager_save_validation.py
+++ b/tests/test_project_manager_save_validation.py
@@ -128,6 +128,70 @@ class TestValidateDefaultsOn:
         assert pm.load_script("demo", "episode_1.json")["segments"][0]["video_prompt"] == "坏形状"
 
 
+def _drama_scene(scene_id: str = "E1S01") -> dict:
+    return {
+        "scene_id": scene_id,
+        "duration_seconds": 8,
+        "characters_in_scene": ["角色A"],
+        "scenes": [],
+        "props": [],
+        "image_prompt": {
+            "scene": "场景描述",
+            "composition": {"shot_type": "Medium Shot", "lighting": "暖光", "ambiance": "薄雾"},
+        },
+        "video_prompt": {"action": "转身", "camera_motion": "Static", "ambiance_audio": "风声"},
+        "utterances": [{"kind": "dialogue", "speaker": "角色A", "text": "你来了。"}],
+    }
+
+
+def _valid_drama_script(scenes: list[dict] | None = None) -> dict:
+    return {
+        "episode": 1,
+        "title": "标题",
+        "content_mode": "drama",
+        "novel": {"title": "小说", "chapter": "第一章"},
+        "scenes": scenes if scenes is not None else [_drama_scene()],
+    }
+
+
+def _pm_drama(tmp_path: Path) -> ProjectManager:
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Demo", "Anime", "drama")
+    return pm
+
+
+class TestUtterancesEditGuard:
+    """分镜详情编辑 drama 场景级 utterances 走 locked_script → 「不更坏」guard 的写盘校验。"""
+
+    def test_valid_utterances_edit_persists(self, tmp_path: Path):
+        """合法 utterances 编辑（dialogue 带 speaker、voiceover 无 speaker）落库。"""
+        pm = _pm_drama(tmp_path)
+        pm.save_script("demo", _valid_drama_script(), "episode_1.json")
+
+        with pm.locked_script("demo", "episode_1.json") as script:
+            script["scenes"][0]["utterances"] = [
+                {"kind": "dialogue", "speaker": "角色A", "text": "改后的台词。"},
+                {"kind": "voiceover", "speaker": None, "text": "旁白。"},
+            ]
+
+        saved = pm.load_script("demo", "episode_1.json")["scenes"][0]["utterances"]
+        assert saved[0] == {"kind": "dialogue", "speaker": "角色A", "text": "改后的台词。"}
+        assert saved[1]["kind"] == "voiceover"
+
+    def test_illegal_utterance_kind_speaker_is_rejected(self, tmp_path: Path):
+        """dialogue 缺非空 speaker → guard 拒绝，旧内容保留（不写坏 project.json）。"""
+        pm = _pm_drama(tmp_path)
+        pm.save_script("demo", _valid_drama_script(), "episode_1.json")
+
+        with pytest.raises(ScriptStructureValidationError):
+            with pm.locked_script("demo", "episode_1.json") as script:
+                script["scenes"][0]["utterances"] = [{"kind": "dialogue", "speaker": "", "text": "无主台词"}]
+
+        saved = pm.load_script("demo", "episode_1.json")["scenes"][0]["utterances"]
+        assert saved == [{"kind": "dialogue", "speaker": "角色A", "text": "你来了。"}]
+
+
 def _unit(unit_id: str = "E1U1") -> dict:
     shots = [{"duration": 3, "text": "镜头1"}, {"duration": 4, "text": "镜头2"}]
     return {

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -648,6 +648,39 @@ class TestProjectsRouter:
             assert update_overview.status_code == 200
             assert update_overview.json()["overview"]["synopsis"] == "new synopsis"
 
+    def test_update_scene_accepts_utterances(self, tmp_path, monkeypatch):
+        # drama 分镜详情编辑场景级发声序列：utterances 在白名单内，PATCH 写回并持久化
+        fake_pm = _FakePM(tmp_path)
+        fake_pm.scripts[("ready", "episode_1.json")] = {
+            "content_mode": "drama",
+            "scenes": [
+                {
+                    "scene_id": "001",
+                    "duration_seconds": 8,
+                    "characters_in_scene": ["Alice"],
+                    "scenes": [],
+                    "props": [],
+                    "utterances": [],
+                }
+            ],
+        }
+
+        client = _client(monkeypatch, fake_pm, _FakeCalc())
+        utterances = [
+            {"kind": "dialogue", "speaker": "Alice", "text": "你来了。"},
+            {"kind": "voiceover", "speaker": None, "text": "命运就此转向。"},
+        ]
+
+        with client:
+            patched = client.patch(
+                "/api/v1/projects/ready/script-scenes/001",
+                json={"script_file": "episode_1.json", "updates": {"utterances": utterances}},
+            )
+            assert patched.status_code == 200
+            assert patched.json()["scene"]["utterances"] == utterances
+            # 落库持久化（不被白名单静默丢弃）
+            assert fake_pm.scripts[("ready", "episode_1.json")]["scenes"][0]["utterances"] == utterances
+
     @staticmethod
     def _ad_script(shot_ids: list[str]) -> dict:
         return {


### PR DESCRIPTION
## 问题

剧集（drama）项目下，分镜详情（时间轴镜头面板）看不到、也改不了角色对白。

根因是两次结构重构叠加的展示层回归：角色对白迁到了场景级 utterances（判别式台词 + 画外音），而分镜详情仍读迁移后恒空的旧扁平对白字段，且整段被内容模式 gate 排除——对白在分镜详情彻底消失，只有前处理审核页能看到。

## 修复

在分镜详情里让 drama 的场景级对白（台词 + 画外音）可编辑并双向保存同步：

- 前端：drama 分支复用发声序列编辑器，接进镜头详情既有的草稿 / 未保存标记 / 保存机制；说书、带货模式仍走原对白编辑器。编辑改写的是最终剧本（视频与字幕的真相源），不回流前处理草稿——与镜头详情其它字段行为一致。
- 后端：分镜场景 PATCH 放开 `utterances` 字段，此前会被字段白名单静默丢弃。写盘结构校验拦截非法条目（台词缺说话人 / 画外音带说话人），返回 422 且不写坏剧本。
- 三语补全对白区块标题文案。

## 测试

- 后端：新增场景 PATCH 接受并持久化 utterances 的路由测试；真实写盘经「不更坏」守卫的集成测试（合法编辑落库、非法组合被拒且旧内容保留）。
- 前端：新增分镜详情 drama 分支测试（渲染发声序列、编辑 / 新增后保存提交对应 patch、干净草稿跟随上游刷新）。
- 全量：前端 789 项、后端相关 186 项全绿；typecheck / eslint / ruff / basedpyright 无错。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Drama 场景支持“发声序列”台词/画外音草稿展示与编辑，支持新增、修改并保存。
  * 增加“发声序列/UTTERANCES/LỜI NÓI”相关多语言界面文案。
* **Bug 修复**
  * 静默同步后草稿与界面保持一致，避免残留或保存时内容被丢弃。
  * 只读模式下新增/保存等交互按预期禁用，往返切换不产生误判。
* **测试**
  * 补充 drama 编辑保存、生效“不更坏”校验，以及路由更新接收 utterances 的用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->