### PR TITLE
fix(script): step1 文件名与剧本路径收敛到单一来源，杜绝审核 gate 被文件名漂移静默绕过

### DIFF
--- a/lib/episode_ledger.py
+++ b/lib/episode_ledger.py
@@ -23,6 +23,7 @@ from typing import Any, Literal, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from lib.episode_paths import episode_script_relpath
 from lib.path_safety import safe_exists
 
 logger = logging.getLogger(__name__)
@@ -238,7 +239,7 @@ def _has_downstream(project_dir: Path, episode_num: int, entry: Mapping[str, Any
     script_file = entry.get("script_file")
     if isinstance(script_file, str) and safe_exists(project_dir, script_file):
         return True
-    if (project_dir / "scripts" / f"episode_{episode_num}.json").is_file():
+    if (project_dir / episode_script_relpath(episode_num)).is_file():
         return True
     drafts_dir = project_dir / "drafts" / f"episode_{episode_num}"
     return drafts_dir.is_dir() and any(drafts_dir.glob("step1_*.md"))
@@ -303,7 +304,7 @@ def backfill_episode_ledger(project_dir: Path, project: Mapping[str, Any]) -> di
     # script_file 填规范预期路径，剧本生成时 _apply_episode_sync 按集号命中本条目回填真实值
     for num in sorted(episode_files):
         if num not in by_num:
-            entry = {"episode": num, "title": "", "script_file": f"scripts/episode_{num}.json"}
+            entry = {"episode": num, "title": "", "script_file": episode_script_relpath(num)}
             episodes.append(entry)
             by_num[num] = entry
 

--- a/lib/episode_ledger.py
+++ b/lib/episode_ledger.py
@@ -23,7 +23,7 @@ from typing import Any, Literal, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from lib.episode_paths import episode_script_relpath
+from lib.episode_paths import episode_drafts_dir, episode_script_relpath
 from lib.path_safety import safe_exists
 
 logger = logging.getLogger(__name__)
@@ -241,8 +241,10 @@ def _has_downstream(project_dir: Path, episode_num: int, entry: Mapping[str, Any
         return True
     if (project_dir / episode_script_relpath(episode_num)).is_file():
         return True
-    drafts_dir = project_dir / "drafts" / f"episode_{episode_num}"
-    return drafts_dir.is_dir() and any(drafts_dir.glob("step1_*.md"))
+    drafts_dir = episode_drafts_dir(project_dir, episode_num)
+    # step1_* 匹配任意格式（结构化 .json / 旧版 .md / reference_units.md），format-agnostic 地
+    # 覆盖所有 content_mode 的 step1 产物：只要拆过段就算已有下游，避免被重规划覆盖。
+    return drafts_dir.is_dir() and any(drafts_dir.glob("step1_*"))
 
 
 def _derive_cursor(

--- a/lib/episode_paths.py
+++ b/lib/episode_paths.py
@@ -1,0 +1,67 @@
+"""step1 中间态文件名与 episode 剧本路径的单一真相源。
+
+这些路径原本散落在审核 gate、状态计算、web 草稿读写层、剧本生成器与 SDK 文本工具中各自
+硬编码同名字面量。审核 gate 找不到 step1 文件时按 ``no_step1`` 放行 step2（文件不存在不等于
+故障），因此任一写盘侧文件名 / 目录漂移都会让 gate 静默绕过且无报错。本模块把这些映射收敛到
+一处：新增走结构化两段式的 content_mode 只需在 ``STEP1_FILENAMES`` 登记结构化文件名，gate、
+状态计算、web 读取与写盘自动一致。
+
+保留既有语义差异（收敛时不许抹平）：
+
+- 审核 gate 只认结构化 ``.json``（``STEP1_FILENAMES`` / ``step1_filename``）；
+- 状态计算与 web 读取层额外兼认旧版 ``.md`` 别名（``STEP1_LEGACY_FILENAMES`` /
+  ``step1_read_candidates``），令存量在制品仍被识别 / 可浏览——「是否分过段」与「格式迁移」
+  是两回事。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+#: 结构化 step1 中间态文件名（按 content_mode）。审核 gate 仅认这两类。
+#: 新增走结构化两段式的 content_mode 在此登记一处即可让 gate / 状态计算 / web 读取 / 写盘一致。
+STEP1_FILENAMES: dict[str, str] = {
+    "drama": "step1_normalized_script.json",
+    "narration": "step1_segments.json",
+}
+
+#: 旧版非结构化 step1 别名（按 content_mode）。仅供状态计算 / web 读取层兼认存量在制品，
+#: 审核 gate 与写盘侧不认。新增 content_mode 无历史遗留，无需登记于此。
+STEP1_LEGACY_FILENAMES: dict[str, tuple[str, ...]] = {
+    "drama": ("step1_normalized_script.md",),
+    "narration": ("step1_segments.md",),
+}
+
+#: reference_video 的 step1 为自由文本 markdown（非结构化中间态），不纳入审核 gate。
+REFERENCE_VIDEO_STEP1_FILENAME = "step1_reference_units.md"
+
+
+def step1_filename(content_mode: str) -> str | None:
+    """该 content_mode 的结构化 step1 文件名；不走结构化 step1（如 ad）时返回 None。"""
+    return STEP1_FILENAMES.get(content_mode)
+
+
+def step1_read_candidates(content_mode: str) -> tuple[str, ...]:
+    """结构化 step1 文件名 + 旧版 ``.md`` 别名（读取 / 浏览侧候选，主文件缺失时回落探测）。
+
+    不走结构化 step1 的模式返回空元组。审核 gate 不用此函数（只认结构化 ``.json``）。
+    """
+    primary = STEP1_FILENAMES.get(content_mode)
+    if primary is None:
+        return ()
+    return (primary, *STEP1_LEGACY_FILENAMES.get(content_mode, ()))
+
+
+def episode_drafts_dir(project_path: Path, episode: int) -> Path:
+    """该集 step1 草稿目录 ``{project}/drafts/episode_N``。"""
+    return project_path / "drafts" / f"episode_{episode}"
+
+
+def episode_script_filename(episode: int) -> str:
+    """该集剧本文件名 ``episode_N.json``（不含 ``scripts/`` 目录前缀）。"""
+    return f"episode_{episode}.json"
+
+
+def episode_script_relpath(episode: int) -> str:
+    """该集剧本相对项目根的默认路径 ``scripts/episode_N.json``。"""
+    return f"scripts/{episode_script_filename(episode)}"

--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -30,6 +30,7 @@ from lib.episode_ledger import (
     normalize_source_text,
     parse_episode_num,
 )
+from lib.episode_paths import episode_script_relpath
 from lib.project_manager import ProjectManager, resolve_source_kind
 from lib.text_backends.base import TextGenerationRequest, TextTaskType
 from lib.text_generator import TextGenerator
@@ -315,7 +316,7 @@ def _ledger_entry_from_draft(
     entry: dict[str, Any] = {
         "episode": num,
         "title": draft_ep.title,
-        "script_file": script_file or f"scripts/episode_{num}.json",
+        "script_file": script_file or episode_script_relpath(num),
         "source_range": {"source_file": source_rel, "start": start, "end": end},
         "hook": draft_ep.hook,
         "ledger_status": status,

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, Field
 from lib.agent_profile import agent_profile_dir
 from lib.asset_types import ASSET_SPECS, validate_asset_name
 from lib.episode_ledger import SOURCE_TEXT_SUFFIXES
+from lib.episode_paths import episode_script_relpath
 from lib.json_io import atomic_write_json, load_json, load_json_or_none
 from lib.profile_manifest import (
     VALID_CONTENT_MODES,
@@ -1509,7 +1510,7 @@ class ProjectManager:
             project.pop("video_model_settings", None)
 
     # 广告/短片项目恒单集：episodes 恒为第 1 集单条，剧本即第 1 集脚本文件
-    AD_SINGLE_EPISODE = {"episode": 1, "title": "", "script_file": "scripts/episode_1.json"}
+    AD_SINGLE_EPISODE = {"episode": 1, "title": "", "script_file": episode_script_relpath(1)}
     # 创建入口未传 target_duration 时的数据层兜底（与创建向导默认档位同值）
     AD_DEFAULT_TARGET_DURATION = 60
 

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -550,7 +550,9 @@ class ScriptGenerator:
         if gen_mode == "reference_video":
             step1_path = drafts_path / REFERENCE_VIDEO_STEP1_FILENAME
         else:
-            step1_path = drafts_path / STEP1_FILENAMES["drama"]
+            # 本方法只服务 drama 及未来其它走 drama 形状两段式的结构化模式（narration 另经
+            # _load_narration_step1）；按 content_mode 取登记的结构化文件名，脏值兜底 drama。
+            step1_path = drafts_path / STEP1_FILENAMES.get(self.content_mode, STEP1_FILENAMES["drama"])
 
         if not step1_path.exists():
             raise FileNotFoundError(

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -18,6 +18,13 @@ from sqlalchemy.exc import SQLAlchemyError
 from lib.config.registry import PROVIDER_REGISTRY
 from lib.config.resolver import ConfigResolver
 from lib.db import async_session_factory
+from lib.episode_paths import (
+    REFERENCE_VIDEO_STEP1_FILENAME,
+    STEP1_FILENAMES,
+    STEP1_LEGACY_FILENAMES,
+    episode_drafts_dir,
+    episode_script_filename,
+)
 from lib.project_manager import ProjectManager, effective_mode
 from lib.prompt_builders_ad import build_ad_prompt
 from lib.prompt_builders_reference import build_reference_video_prompt
@@ -256,7 +263,7 @@ class ScriptGenerator:
         script_data = {"title": content.get("title") or f"第{episode}集", "scenes": merged_scenes}
         script_data = self._add_metadata(script_data, episode)
 
-        filename = output_filename or f"episode_{episode}.json"
+        filename = output_filename or episode_script_filename(episode)
         pm = ProjectManager(str(self.project_path.parent))
         output_path = pm.save_script(self.project_path.name, script_data, filename, validate=True)
 
@@ -336,7 +343,7 @@ class ScriptGenerator:
         # 经写盘统一入口保存：整集生成无「改前」，按严格结构校验（等价原 response_schema 的
         # Pydantic 校验），并继承 metadata 重算、加锁、filename↔episode 一致性与 project.json
         # 同步——消除「裸 json.dump 旁路」，使 _write_script_unlocked 成为剧本唯一写入点。
-        filename = output_filename or f"episode_{episode}.json"
+        filename = output_filename or episode_script_filename(episode)
         pm = ProjectManager(str(self.project_path.parent))
         output_path = pm.save_script(self.project_path.name, script_data, filename, validate=True)
 
@@ -538,12 +545,12 @@ class ScriptGenerator:
         narration（storyboard/grid）走结构化两段式，单独经 ``_load_narration_step1`` 读
         ``step1_segments.json``，不进本方法。
         """
-        drafts_path = self.project_path / "drafts" / f"episode_{episode}"
+        drafts_path = episode_drafts_dir(self.project_path, episode)
         gen_mode = self._effective_generation_mode(episode)
         if gen_mode == "reference_video":
-            step1_path = drafts_path / "step1_reference_units.md"
+            step1_path = drafts_path / REFERENCE_VIDEO_STEP1_FILENAME
         else:
-            step1_path = drafts_path / "step1_normalized_script.json"
+            step1_path = drafts_path / STEP1_FILENAMES["drama"]
 
         if not step1_path.exists():
             raise FileNotFoundError(
@@ -564,14 +571,15 @@ class ScriptGenerator:
         仅存在结构化前的旧 ``step1_segments.md`` 时给明确的「重跑拆分」报错——不写
         md→json 迁移器（旧 md 产于结构化中间态引入前、不含手工编辑）。
         """
-        drafts_path = self.project_path / "drafts" / f"episode_{episode}"
-        step1_json = drafts_path / "step1_segments.json"
+        drafts_path = episode_drafts_dir(self.project_path, episode)
+        narration_json = STEP1_FILENAMES["narration"]
+        step1_json = drafts_path / narration_json
         if not step1_json.exists():
-            legacy_md = drafts_path / "step1_segments.md"
+            legacy_md = drafts_path / STEP1_LEGACY_FILENAMES["narration"][0]
             if legacy_md.exists():
                 raise FileNotFoundError(
                     f"仅找到结构化前的旧拆分表 {legacy_md}，未找到 {step1_json}；"
-                    "请重跑 split-narration-segments 产出结构化 step1_segments.json"
+                    f"请重跑 split-narration-segments 产出结构化 {narration_json}"
                 )
             raise FileNotFoundError(
                 f"未找到 Step 1 中间文件: {step1_json}；content_mode=narration 期望该文件，请先完成片段拆分"

--- a/lib/script_review.py
+++ b/lib/script_review.py
@@ -22,17 +22,12 @@ import json
 from pathlib import Path
 from typing import Any, Literal
 
+from lib.episode_paths import STEP1_FILENAMES, episode_drafts_dir, episode_script_relpath
 from lib.project_manager import effective_mode
 
 #: 审核状态：not_applicable=该集不走 gate；no_step1=适用但 step1 未产出；
 #: pending_review=step1 已产出但未经确认（或确认后内容又变）→ 阻塞 step2；confirmed=已确认放行。
 ReviewStatus = Literal["not_applicable", "no_step1", "pending_review", "confirmed"]
-
-#: 结构化 step1 中间态文件名（按 content_mode）。仅这两类纳入 gate。
-_STEP1_FILENAME: dict[str, str] = {
-    "drama": "step1_normalized_script.json",
-    "narration": "step1_segments.json",
-}
 
 #: 确认记录在 episode 条目上的字段名：``{"fingerprint": str, "confirmed_at": ISO8601}``。
 REVIEW_FIELD = "step1_review"
@@ -48,7 +43,7 @@ def find_episode(project: dict[str, Any], episode: int) -> dict[str, Any] | None
 
 def is_applicable(project: dict[str, Any], episode: int) -> bool:
     """gate 是否适用于该集：content_mode ∈ {drama, narration} 且 effective_mode 非 reference_video。"""
-    if project.get("content_mode") not in _STEP1_FILENAME:
+    if project.get("content_mode") not in STEP1_FILENAMES:
         return False
     return effective_mode(project=project, episode=find_episode(project, episode) or {}) != "reference_video"
 
@@ -57,8 +52,8 @@ def step1_path(project_path: Path, project: dict[str, Any], episode: int) -> Pat
     """该集结构化 step1 中间态文件路径；不适用 gate 时返回 None。"""
     if not is_applicable(project, episode):
         return None
-    # is_applicable 为真 ⇒ content_mode ∈ _STEP1_FILENAME；索引取值（非 .get）避免 Any | None。
-    return project_path / "drafts" / f"episode_{episode}" / _STEP1_FILENAME[project["content_mode"]]
+    # is_applicable 为真 ⇒ content_mode ∈ STEP1_FILENAMES；索引取值（非 .get）避免 Any | None。
+    return episode_drafts_dir(project_path, episode) / STEP1_FILENAMES[project["content_mode"]]
 
 
 def content_fingerprint(path: Path) -> str | None:
@@ -92,7 +87,7 @@ def step2_generated(project_path: Path, project: dict[str, Any], episode: int) -
     ScriptGenerator 固定写出口径一致）。
     """
     ep = find_episode(project, episode) or {}
-    script_file = ep.get("script_file") or f"scripts/episode_{episode}.json"
+    script_file = ep.get("script_file") or episode_script_relpath(episode)
     return (project_path / script_file).exists()
 
 

--- a/lib/status_calculator.py
+++ b/lib/status_calculator.py
@@ -7,6 +7,7 @@
 
 import logging
 
+from lib.episode_paths import STEP1_FILENAMES, STEP1_LEGACY_FILENAMES
 from lib.path_safety import safe_exists
 from lib.project_manager import effective_mode
 from lib.script_models import SCRIPT_SHAPES, ad_script_total_duration
@@ -18,17 +19,25 @@ logger = logging.getLogger(__name__)
 # 逐镜头规划），缺失按 0 计入，避免杜撰值污染与目标总时长的对照。
 _FALLBACK_ITEM_DURATIONS: dict[str, int] = {"narration": 4, "drama": 8, "ad": 0}
 
-# 剧本缺失时按 content_mode 探测的 step1 草稿候选文件名（按优先序，任一存在即视为已分段）。
-# narration 同时认结构化 step1_segments.json 与旧版 step1_segments.md：「是否分过段」与「格式
-# 迁移」是两回事，存量 .md-only 项目也算已分段（迁移到 .json 由生成阶段的重切提示兜住），不被
-# 误判为「从未开始」。drama 内容抽取前移后 step1 是结构化 JSON（见 ADR 0041），旧 .md 残留不再
-# 视为有效 step1——仅 .md 无剧本 JSON 的在制品会被路由回重跑 step1。ad 不走拆分中间稿
-# （brief 不经 source_loader），空元组表示无草稿可探测；未知值沿用历史兜底落 drama 草稿名。
-_DRAFT_FILENAMES: dict[str, tuple[str, ...]] = {
-    "narration": ("step1_segments.json", "step1_segments.md"),
-    "drama": ("step1_normalized_script.json",),
-    "ad": (),
-}
+# 「是否分过段」判定中兼认旧版 .md 别名的 content_mode：narration 的旧 step1_segments.md
+# 代表真实的分段工作、兼认；drama 的旧 .md 早于内容抽取前移（见 ADR 0041），不再视为有效
+# step1——仅 .md 无剧本 JSON 的在制品会被路由回重跑 step1，故不在此集合。这与 gate 只认结构化
+# .json、web 读取层兼认双模式旧 .md 的语义有意不同。
+_SEGMENTED_LEGACY_MODES: frozenset[str] = frozenset({"narration"})
+
+
+def _draft_candidates(content_mode: str) -> tuple[str, ...]:
+    """剧本缺失时按 content_mode 探测的 step1 草稿候选文件名（任一存在即视为已分段）。
+
+    结构化文件名取自单一真相源 ``lib.episode_paths.STEP1_FILENAMES``，新增 content_mode 自动覆盖。
+    ad 不走拆分中间稿（brief 不经 source_loader），返回空元组表示无草稿可探测；未知值沿用历史
+    兜底探 drama 结构化草稿名。旧版 .md 仅对 ``_SEGMENTED_LEGACY_MODES`` 内的模式附加。
+    """
+    if content_mode == "ad":
+        return ()
+    primary = STEP1_FILENAMES.get(content_mode) or STEP1_FILENAMES["drama"]
+    legacy = STEP1_LEGACY_FILENAMES.get(content_mode, ()) if content_mode in _SEGMENTED_LEGACY_MODES else ()
+    return (primary, *legacy)
 
 
 class StatusCalculator:
@@ -204,7 +213,7 @@ class StatusCalculator:
                 safe_num = int(episode_num)
             except (ValueError, TypeError):
                 return "none", None
-            draft_filenames = _DRAFT_FILENAMES.get(content_mode, _DRAFT_FILENAMES["drama"])
+            draft_filenames = _draft_candidates(content_mode)
             if not draft_filenames:
                 return "none", None
             drafts_dir = project_dir / f"drafts/episode_{safe_num}"

--- a/lib/status_calculator.py
+++ b/lib/status_calculator.py
@@ -7,7 +7,7 @@
 
 import logging
 
-from lib.episode_paths import STEP1_FILENAMES, STEP1_LEGACY_FILENAMES
+from lib.episode_paths import STEP1_FILENAMES, STEP1_LEGACY_FILENAMES, episode_drafts_dir
 from lib.path_safety import safe_exists
 from lib.project_manager import effective_mode
 from lib.script_models import SCRIPT_SHAPES, ad_script_total_duration
@@ -216,7 +216,7 @@ class StatusCalculator:
             draft_filenames = _draft_candidates(content_mode)
             if not draft_filenames:
                 return "none", None
-            drafts_dir = project_dir / f"drafts/episode_{safe_num}"
+            drafts_dir = episode_drafts_dir(project_dir, safe_num)
             segmented = any((drafts_dir / name).exists() for name in draft_filenames)
             return ("segmented" if segmented else "none"), None
         except ValueError as e:

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -123,9 +123,10 @@ def _resolve_step1_path(project_path: Path, episode: int, project_data: dict[str
     drafts_path = episode_drafts_dir(project_path, episode)
     if generation_mode == "reference_video":
         return drafts_path / REFERENCE_VIDEO_STEP1_FILENAME, "split-reference-video-units subagent (Step 1)"
-    if content_mode == "drama":
-        # 内容抽取前移后 drama step1 是结构化 JSON（见 ADR 0041）
-        return drafts_path / STEP1_FILENAMES["drama"], "normalize_drama_script tool"
+    if content_mode != "narration" and content_mode in STEP1_FILENAMES:
+        # drama 及未来其它走 drama 形状两段式的结构化模式：step1 是结构化 JSON（见 ADR 0041）。
+        # narration 虽也在 STEP1_FILENAMES，但另有旧 .md 迁移提示分支，需先排除。
+        return drafts_path / STEP1_FILENAMES[content_mode], "normalize_drama_script tool"
     # narration 生成需结构化 step1 JSON；仅存旧版 .md 时给出与
     # ScriptGenerator._load_narration_step1 一致的重切迁移提示，而非笼统的缺文件错误。
     narration_json = STEP1_FILENAMES["narration"]

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -19,6 +19,12 @@ from lib import script_review
 from lib.config.resolver import ConfigResolver
 from lib.db import async_session_factory
 from lib.episode_ledger import episode_outline_context
+from lib.episode_paths import (
+    REFERENCE_VIDEO_STEP1_FILENAME,
+    STEP1_FILENAMES,
+    STEP1_LEGACY_FILENAMES,
+    episode_drafts_dir,
+)
 from lib.json_io import atomic_write_json
 from lib.project_manager import DEFAULT_SOURCE_KIND, effective_mode
 from lib.prompt_builders_script import build_normalize_prompt
@@ -114,17 +120,19 @@ def _resolve_step1_path(project_path: Path, episode: int, project_data: dict[str
         {},
     )
     generation_mode = effective_mode(project=project_data, episode=episode_dict)
-    drafts_path = project_path / "drafts" / f"episode_{episode}"
+    drafts_path = episode_drafts_dir(project_path, episode)
     if generation_mode == "reference_video":
-        return drafts_path / "step1_reference_units.md", "split-reference-video-units subagent (Step 1)"
+        return drafts_path / REFERENCE_VIDEO_STEP1_FILENAME, "split-reference-video-units subagent (Step 1)"
     if content_mode == "drama":
         # 内容抽取前移后 drama step1 是结构化 JSON（见 ADR 0041）
-        return drafts_path / "step1_normalized_script.json", "normalize_drama_script tool"
-    # narration 生成需结构化 step1_segments.json；仅存旧 step1_segments.md 时给出与
+        return drafts_path / STEP1_FILENAMES["drama"], "normalize_drama_script tool"
+    # narration 生成需结构化 step1 JSON；仅存旧版 .md 时给出与
     # ScriptGenerator._load_narration_step1 一致的重切迁移提示，而非笼统的缺文件错误。
-    step1_json = drafts_path / "step1_segments.json"
-    if not step1_json.exists() and (drafts_path / "step1_segments.md").exists():
-        return step1_json, "重跑 split-narration-segments 把旧 step1_segments.md 重新拆分为结构化 step1_segments.json"
+    narration_json = STEP1_FILENAMES["narration"]
+    narration_legacy_md = STEP1_LEGACY_FILENAMES["narration"][0]
+    step1_json = drafts_path / narration_json
+    if not step1_json.exists() and (drafts_path / narration_legacy_md).exists():
+        return step1_json, f"重跑 split-narration-segments 把旧 {narration_legacy_md} 重新拆分为结构化 {narration_json}"
     return step1_json, "split-narration-segments subagent (Step 1)"
 
 
@@ -385,9 +393,9 @@ def normalize_drama_script_tool(ctx: ToolContext):
             if not isinstance(raw_scenes, list) or not raw_scenes:
                 raise ValueError("step1 规范化内容结构异常：scenes 必须是非空的场景对象数组")
 
-            drafts_dir = project_path / "drafts" / f"episode_{episode}"
+            drafts_dir = episode_drafts_dir(project_path, episode)
             drafts_dir.mkdir(parents=True, exist_ok=True)
-            step1_path = drafts_dir / "step1_normalized_script.json"
+            step1_path = drafts_dir / STEP1_FILENAMES["drama"]
             # step1 真相源须原子写入：复用 atomic_write_json（同目录 tempfile + os.replace），
             # 避免 normalize 中断 / 并发重跑留下半写 JSON 被下游当成损坏草稿。
             atomic_write_json(step1_path, content)

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -803,8 +803,10 @@ async def update_draft_content(
             # drama step1 落结构化 .json：写入前与 _load_drama_step1_content 的读取契约同口径校验
             # ——合法 JSON、顶层对象、scenes 为非空且每项为带非空 scene_id 的对象，避免任意文本 / 空剧本 /
             # 非对象场景项 / 缺失或空 scene_id 写进结构化草稿、拖到生成阶段才解析失败（前端保存成功但生成必然
-            # 失败）。仅约束 drama 的结构化 step1；narration / reference 的 step1 草稿不在此校验。
-            if content_mode == "drama" and draft_path.suffix == ".json":
+            # 失败）。按目标文件名而非 content_mode 触发：_get_step_files 对未知模式回落到 drama 的
+            # 结构化文件名，仅凭 content_mode 判定会让脏值绕过校验把任意文本写成 drama JSON。narration /
+            # reference 的 step1 落各自文件名，不匹配此校验。
+            if draft_path.name == STEP1_FILENAMES["drama"]:
                 try:
                     parsed = json.loads(content)
                 except json.JSONDecodeError:

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -667,16 +667,17 @@ def _extract_step_number(filename: str) -> int:
 def _get_step_files(content_mode: str, generation_mode: str | None = None) -> dict:
     """根据 generation_mode / content_mode 获取步骤文件名映射
 
-    reference_video 走 split-reference-video-units subagent → step1_reference_units.md，
-    ad 不走结构化 step1（与 status_calculator._draft_candidates 同口径显式排除），返回空映射，
-    调用方据此给出「无此步骤」而非误落 drama 文件名的 404。其他模式回落到 content_mode 的结构化
-    step1 文件名（未知 content_mode 兜底 drama）。结构化文件名取自单一真相源 STEP1_FILENAMES，
-    新增 content_mode 自动覆盖。
+    ad 不走结构化 step1（与 _resolve_step1_path / status_calculator._draft_candidates 同口径显式
+    排除），即便带 reference_video generation_mode 也无 step1，故先于 generation_mode 判断返回空
+    映射，调用方据此给出「无此步骤」而非误落 drama / reference 文件名。reference_video 走
+    split-reference-video-units subagent → step1_reference_units.md；其他模式回落到 content_mode
+    的结构化 step1 文件名（未知 content_mode 兜底 drama）。结构化文件名取自单一真相源
+    STEP1_FILENAMES，新增 content_mode 自动覆盖。
     """
-    if generation_mode == "reference_video":
-        return {1: REFERENCE_VIDEO_STEP1_FILENAME}
     if content_mode == "ad":
         return {}
+    if generation_mode == "reference_video":
+        return {1: REFERENCE_VIDEO_STEP1_FILENAME}
     return {1: STEP1_FILENAMES.get(content_mode, STEP1_FILENAMES["drama"])}
 
 

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -686,7 +686,12 @@ _STEP1_FAMILY[REFERENCE_VIDEO_STEP1_FILENAME] = [REFERENCE_VIDEO_STEP1_FILENAME]
 
 # step1 实际文件候选 —— 主文件不存在时用于 fallback 探测，兼容 episode 级 generation_mode 覆盖。
 # 结构化 .json 与旧 .md 候选均由单一真相源派生；各自保留旧 .md 以便存量在制品仍可浏览。
-_STEP1_CANDIDATES = list(dict.fromkeys(name for family in _STEP1_FAMILY.values() for name in family))
+# 跨模式遗留回落的探测优先级固定为 reference_video → narration → drama（保持历史 tie-break，
+# 避免收敛后跨模式选到的遗留文件与旧实现不一致）；未登记于此序列的未来 content_mode 附加在后。
+_STEP1_PROBE_ORDER = [REFERENCE_VIDEO_STEP1_FILENAME, STEP1_FILENAMES["narration"], STEP1_FILENAMES["drama"]]
+_STEP1_CANDIDATES = list(
+    dict.fromkeys(name for key in [*_STEP1_PROBE_ORDER, *_STEP1_FAMILY] for name in _STEP1_FAMILY[key])
+)
 
 
 def _get_step_title(filename: str, _t: Callable[..., str]) -> str:

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -19,6 +19,12 @@ from fastapi.responses import FileResponse, PlainTextResponse
 
 from lib.app_data_dir import app_data_dir
 from lib.asset_types import GLOBAL_LIBRARY_ASSET_TYPES
+from lib.episode_paths import (
+    REFERENCE_VIDEO_STEP1_FILENAME,
+    STEP1_FILENAMES,
+    episode_drafts_dir,
+    step1_read_candidates,
+)
 from lib.i18n import Translator
 from lib.image_utils import normalize_uploaded_image, validate_image_bytes
 from lib.project_change_hints import emit_project_change_batch, project_change_source
@@ -662,45 +668,35 @@ def _get_step_files(content_mode: str, generation_mode: str | None = None) -> di
     """根据 generation_mode / content_mode 获取步骤文件名映射
 
     reference_video 走 split-reference-video-units subagent → step1_reference_units.md，
-    其他模式回落到 content_mode 的 narration/drama 分支。
+    其他模式回落到 content_mode 的结构化 step1 文件名（未知 content_mode 兜底 drama）。
+    结构化文件名取自单一真相源 STEP1_FILENAMES，新增 content_mode 自动覆盖。
     """
     if generation_mode == "reference_video":
-        return {1: "step1_reference_units.md"}
-    if content_mode == "narration":
-        return {1: "step1_segments.json"}
-    # drama 内容抽取前移后 step1 是结构化 JSON（见 ADR 0041）
-    return {1: "step1_normalized_script.json"}
+        return {1: REFERENCE_VIDEO_STEP1_FILENAME}
+    return {1: STEP1_FILENAMES.get(content_mode, STEP1_FILENAMES["drama"])}
 
-
-# step1 实际文件候选 —— 主文件不存在时用于 fallback 探测，兼容 episode 级 generation_mode 覆盖。
-# narration 结构化中间态为 step1_segments.json、drama 为 step1_normalized_script.json；
-# 各自保留旧 .md 候选以便存量在制品仍可浏览。
-_STEP1_CANDIDATES = [
-    "step1_reference_units.md",
-    "step1_segments.json",
-    "step1_segments.md",
-    "step1_normalized_script.json",
-    "step1_normalized_script.md",
-]
 
 # 按 primary 文件名分组的优先候选（mode 感知）：先在本模式自家候选里回落，再兜底其他模式遗留文件。
+# 每模式的结构化 .json + 旧版 .md 取自单一真相源；reference_video 只认自家 md。
 # narration 优先结构化 .json、再旧版 .md，杜绝跨模式切换遗留把 narration 误选到 reference_units.md。
 _STEP1_FAMILY: dict[str, list[str]] = {
-    "step1_segments.json": ["step1_segments.json", "step1_segments.md"],
-    "step1_normalized_script.json": ["step1_normalized_script.json", "step1_normalized_script.md"],
-    "step1_reference_units.md": ["step1_reference_units.md"],
+    STEP1_FILENAMES[mode]: list(step1_read_candidates(mode)) for mode in STEP1_FILENAMES
 }
+_STEP1_FAMILY[REFERENCE_VIDEO_STEP1_FILENAME] = [REFERENCE_VIDEO_STEP1_FILENAME]
+
+# step1 实际文件候选 —— 主文件不存在时用于 fallback 探测，兼容 episode 级 generation_mode 覆盖。
+# 结构化 .json 与旧 .md 候选均由单一真相源派生；各自保留旧 .md 以便存量在制品仍可浏览。
+_STEP1_CANDIDATES = list(dict.fromkeys(name for family in _STEP1_FAMILY.values() for name in family))
 
 
 def _get_step_title(filename: str, _t: Callable[..., str]) -> str:
-    """获取步骤标题"""
-    titles = {
-        "step1_normalized_script.json": _t("normalized_script"),
-        "step1_normalized_script.md": _t("normalized_script"),
-        "step1_segments.json": _t("segment_splitting"),
-        "step1_segments.md": _t("segment_splitting"),
-        "step1_reference_units.md": _t("segment_splitting"),
-    }
+    """获取步骤标题：每种 step1（含旧 .md 别名）映射到其展示名 i18n key。"""
+    titles: dict[str, str] = {}
+    for name in step1_read_candidates("drama"):
+        titles[name] = _t("normalized_script")
+    for name in step1_read_candidates("narration"):
+        titles[name] = _t("segment_splitting")
+    titles[REFERENCE_VIDEO_STEP1_FILENAME] = _t("segment_splitting")
     return titles.get(filename, filename)
 
 
@@ -751,7 +747,7 @@ async def get_draft_content(project_name: str, episode: int, step_num: int, _use
             if step_num not in step_files:
                 raise HTTPException(status_code=400, detail=_t("invalid_step_num", step_num=step_num))
 
-            drafts_dir = project_dir / "drafts" / f"episode_{episode}"
+            drafts_dir = episode_drafts_dir(project_dir, episode)
             draft_path = _resolve_step1_path(drafts_dir, step_num, drafts_dir / step_files[step_num])
 
             if not draft_path.exists():
@@ -786,7 +782,7 @@ async def update_draft_content(
             if step_num not in step_files:
                 raise HTTPException(status_code=400, detail=_t("invalid_step_num", step_num=step_num))
 
-            drafts_dir = project_dir / "drafts" / f"episode_{episode}"
+            drafts_dir = episode_drafts_dir(project_dir, episode)
             drafts_dir.mkdir(parents=True, exist_ok=True)
 
             # 写入始终落到当前模式的目标文件；fallback 仅用于读取/删除（兼容跨模式切换的旧 step1）。
@@ -857,7 +853,7 @@ async def delete_draft(project_name: str, episode: int, step_num: int, _user: Cu
             if step_num not in step_files:
                 raise HTTPException(status_code=400, detail=_t("invalid_step_num", step_num=step_num))
 
-            drafts_dir = project_dir / "drafts" / f"episode_{episode}"
+            drafts_dir = episode_drafts_dir(project_dir, episode)
             draft_path = _resolve_step1_path(drafts_dir, step_num, drafts_dir / step_files[step_num])
 
             if draft_path.exists():

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -668,11 +668,15 @@ def _get_step_files(content_mode: str, generation_mode: str | None = None) -> di
     """根据 generation_mode / content_mode 获取步骤文件名映射
 
     reference_video 走 split-reference-video-units subagent → step1_reference_units.md，
-    其他模式回落到 content_mode 的结构化 step1 文件名（未知 content_mode 兜底 drama）。
-    结构化文件名取自单一真相源 STEP1_FILENAMES，新增 content_mode 自动覆盖。
+    ad 不走结构化 step1（与 status_calculator._draft_candidates 同口径显式排除），返回空映射，
+    调用方据此给出「无此步骤」而非误落 drama 文件名的 404。其他模式回落到 content_mode 的结构化
+    step1 文件名（未知 content_mode 兜底 drama）。结构化文件名取自单一真相源 STEP1_FILENAMES，
+    新增 content_mode 自动覆盖。
     """
     if generation_mode == "reference_video":
         return {1: REFERENCE_VIDEO_STEP1_FILENAME}
+    if content_mode == "ad":
+        return {}
     return {1: STEP1_FILENAMES.get(content_mode, STEP1_FILENAMES["drama"])}
 
 

--- a/tests/test_episode_ledger.py
+++ b/tests/test_episode_ledger.py
@@ -64,6 +64,16 @@ class TestBackfillAnchoring:
         result = backfill_episode_ledger(d, {"episodes": []})
         assert result["episodes"][0]["ledger_status"] == "consumed"
 
+    def test_consumed_via_structured_json_step1_draft(self, tmp_path: Path):
+        """结构化 .json step1（无旧 .md）也算已有下游：拆过段的集不被重规划覆盖。"""
+        d = _project(tmp_path)
+        _write_episode(d, 1, NOVEL[:CUT_1])
+        draft = d / "drafts" / "episode_1" / "step1_normalized_script.json"
+        draft.parent.mkdir(parents=True)
+        draft.write_text('{"scenes": []}', encoding="utf-8")
+        result = backfill_episode_ledger(d, {"episodes": []})
+        assert result["episodes"][0]["ledger_status"] == "consumed"
+
     def test_consumed_via_entry_script_file_nonstandard_name(self, tmp_path: Path):
         d = _project(tmp_path)
         _write_episode(d, 1, NOVEL[:CUT_1])

--- a/tests/test_episode_paths.py
+++ b/tests/test_episode_paths.py
@@ -66,8 +66,10 @@ def test_new_content_mode_registered_once_covers_gate_web_and_status(monkeypatch
 
 def test_ad_has_no_structured_step1_across_web_and_agent(tmp_path):
     """ad 不走结构化 step1：web 步骤映射为空、agent 写盘解析为 None（与状态计算显式排除同口径）。"""
-    # web 草稿读写：ad 不误落 drama 文件名，返回空映射
+    # web 草稿读写：ad 不误落 drama 文件名，返回空映射；ad 优先于 generation_mode，
+    # 带 reference_video 戳同样无 step1（与 _resolve_step1_path 先判 ad 同序）
     assert files._get_step_files("ad") == {}
+    assert files._get_step_files("ad", generation_mode="reference_video") == {}
     # agent 写盘：ad 不依赖 step1
     assert (
         text_generation._resolve_step1_path(tmp_path, 1, {"content_mode": "ad", "episodes": [{"episode": 1}]}) is None

--- a/tests/test_episode_paths.py
+++ b/tests/test_episode_paths.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from lib import episode_paths, script_review, status_calculator
+from server.agent_runtime.sdk_tools import text_generation
 from server.routers import files
 
 
@@ -54,8 +55,25 @@ def test_new_content_mode_registered_once_covers_gate_web_and_status(monkeypatch
     # web 草稿读写：_get_step_files 返回同一文件名
     assert files._get_step_files("docudrama") == {1: "step1_docu.json"}
 
+    # agent 写盘：_resolve_step1_path 指向同一结构化文件名，不因 == "drama" 硬编码误落 narration
+    resolved = text_generation._resolve_step1_path(tmp_path, 1, project)
+    assert resolved is not None
+    assert resolved[0] == tmp_path / "drafts" / "episode_1" / "step1_docu.json"
+
     # 状态计算：新模式的草稿探测覆盖登记的结构化文件名
     assert "step1_docu.json" in status_calculator._draft_candidates("docudrama")
+
+
+def test_ad_has_no_structured_step1_across_web_and_agent(tmp_path):
+    """ad 不走结构化 step1：web 步骤映射为空、agent 写盘解析为 None（与状态计算显式排除同口径）。"""
+    # web 草稿读写：ad 不误落 drama 文件名，返回空映射
+    assert files._get_step_files("ad") == {}
+    # agent 写盘：ad 不依赖 step1
+    assert (
+        text_generation._resolve_step1_path(tmp_path, 1, {"content_mode": "ad", "episodes": [{"episode": 1}]}) is None
+    )
+    # 状态计算：ad 无草稿可探测
+    assert status_calculator._draft_candidates("ad") == ()
 
 
 def test_gate_only_json_status_and_web_also_md():

--- a/tests/test_episode_paths.py
+++ b/tests/test_episode_paths.py
@@ -1,0 +1,69 @@
+"""step1 / episode 路径单一真相源的行为测试。
+
+只测外部可观察契约：结构化 step1 文件名解析、旧版 .md 兼认边界、episode 剧本路径，
+以及"新增 content_mode 登记一处即被 gate / web / 状态计算共同覆盖"这一收敛不变量。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lib import episode_paths, script_review, status_calculator
+from server.routers import files
+
+
+def test_step1_filename_by_content_mode():
+    assert episode_paths.step1_filename("drama") == "step1_normalized_script.json"
+    assert episode_paths.step1_filename("narration") == "step1_segments.json"
+    # ad 不走结构化 step1
+    assert episode_paths.step1_filename("ad") is None
+    assert episode_paths.step1_filename("unknown") is None
+
+
+def test_step1_read_candidates_includes_legacy_md():
+    assert episode_paths.step1_read_candidates("narration") == (
+        "step1_segments.json",
+        "step1_segments.md",
+    )
+    assert episode_paths.step1_read_candidates("drama") == (
+        "step1_normalized_script.json",
+        "step1_normalized_script.md",
+    )
+    assert episode_paths.step1_read_candidates("ad") == ()
+
+
+def test_episode_script_paths():
+    assert episode_paths.episode_script_filename(3) == "episode_3.json"
+    assert episode_paths.episode_script_relpath(3) == "scripts/episode_3.json"
+
+
+def test_episode_drafts_dir():
+    assert episode_paths.episode_drafts_dir(Path("/p"), 2) == Path("/p/drafts/episode_2")
+
+
+def test_new_content_mode_registered_once_covers_gate_web_and_status(monkeypatch, tmp_path):
+    """在 STEP1_FILENAMES 登记一处新模式，gate 路径、web 步骤文件、状态草稿探测应自动一致。"""
+    monkeypatch.setitem(episode_paths.STEP1_FILENAMES, "docudrama", "step1_docu.json")
+
+    # 审核 gate：step1_path 指向登记的结构化文件名
+    project = {"content_mode": "docudrama", "episodes": [{"episode": 1}]}
+    gate_path = script_review.step1_path(tmp_path, project, 1)
+    assert gate_path is not None
+    assert gate_path == tmp_path / "drafts" / "episode_1" / "step1_docu.json"
+
+    # web 草稿读写：_get_step_files 返回同一文件名
+    assert files._get_step_files("docudrama") == {1: "step1_docu.json"}
+
+    # 状态计算：新模式的草稿探测覆盖登记的结构化文件名
+    assert "step1_docu.json" in status_calculator._draft_candidates("docudrama")
+
+
+def test_gate_only_json_status_and_web_also_md():
+    """gate 只认结构化 .json；状态计算与 web 读取兼认旧版 .md（既有语义差异）。"""
+    # gate 的登记表不含任何 .md
+    assert all(name.endswith(".json") for name in episode_paths.STEP1_FILENAMES.values())
+    # web 读取候选含旧 .md
+    assert "step1_segments.md" in episode_paths.step1_read_candidates("narration")
+    # 状态计算：narration 旧 .md 认作已分段，drama 旧 .md 不认（见 ADR 0041）
+    assert "step1_segments.md" in status_calculator._draft_candidates("narration")
+    assert "step1_normalized_script.md" not in status_calculator._draft_candidates("drama")

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -413,6 +413,17 @@ class TestFilesRouter:
             missing_step = client.delete("/api/v1/projects/demo/drafts/2/step9")
             assert missing_step.status_code == 400
 
+            # 未登记 content_mode 回落到 drama 结构化文件名时同样触发校验（按目标文件名而非 content_mode）：
+            # 任意文本不再绕过校验被写成结构化 drama JSON，拖到生成阶段才失败
+            payload["content_mode"] = "future_unregistered_mode"
+            project_json.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+            reject_dirty_mode = client.put(
+                "/api/v1/projects/demo/drafts/3/step1",
+                content="not json at all",
+                headers={"content-type": "text/plain"},
+            )
+            assert reject_dirty_mode.status_code == 400
+
             # step2 and step3 should now be invalid
             step2_resp = client.get("/api/v1/projects/demo/drafts/1/step2")
             assert step2_resp.status_code == 400


### PR DESCRIPTION
## 背景

step1 中间态文件名（drama `step1_normalized_script.json` / narration `step1_segments.json`）与 episode 剧本路径 `scripts/episode_N.json`，此前在审核 gate、状态计算、web 草稿读写、剧本生成器、SDK 文本工具等多个入口各自硬编码同一批字面量。任一写盘侧的文件名/目录漂移（改名、换目录、新增 content_mode 漏登记）都会让审核 gate 检测不到 step1 产物，从而按 `no_step1` 静默放行 step2、绕过审核保护且不报错。

## 改动

- 新增 `lib/episode_paths.py` 作为单一真相源：`STEP1_FILENAMES`（结构化文件名）、`STEP1_LEGACY_FILENAMES`（旧版 .md 别名）、`REFERENCE_VIDEO_STEP1_FILENAME`，以及 `step1_filename` / `step1_read_candidates` / `episode_drafts_dir` / `episode_script_relpath` 等 helper。
- gate、StatusCalculator、web 文件路由、剧本生成器、SDK 文本工具、分集规划器、账本回填等所有读写与判定入口改为引用该来源，不再各自硬编码字面量。
- 新增 content_mode 只需在 `STEP1_FILENAMES` 登记一处，gate / 状态计算 / web 读取 / 写盘自动一致。

### 保留的既有语义差异（收敛时未抹平）

- 审核 gate 只认结构化 `.json`（`STEP1_FILENAMES`）。
- StatusCalculator 仅 narration 兼认旧 `.md`（`_SEGMENTED_LEGACY_MODES`）；drama 旧 `.md` 不再视为有效 step1。
- web 文件读取层双模式（drama/narration）均兼认旧 `.md` 别名，令存量在制品仍可浏览。

### 本地审查修复

- `episode_ledger._has_downstream` 原仅 `glob("step1_*.md")`，结构化迁移后 `.json` step1 漏检——拆过段但尚未生成剧本的集会被误判为无下游产物、可能被重规划覆盖。广化为 `glob("step1_*")`，format-agnostic 覆盖任意格式 step1，并补回归测试。
- `files._STEP1_CANDIDATES` 由 `_STEP1_FAMILY` 派生后跨模式兜底探测顺序发生翻转；还原为历史优先级（reference_video → narration → drama），保持收敛后跨模式回落行为与旧实现逐项等价。
- `episode_ledger` / `status_calculator` 复用 `episode_drafts_dir` helper，收敛残留的 `drafts/episode_N` 目录字面量。

## 验证

- 全量测试 `uv run python -m pytest`：5532 passed。
- `uv run ruff check` + `ruff format --check`：通过。
- `uv run basedpyright`：改动文件 0 error 0 warning。
- 单独校验 `_STEP1_CANDIDATES` 收敛后顺序与旧实现逐项一致。

## 范围说明

未触及以下有意契约：给 ad / reference_video 接入 gate、改 `no_step1` 放行语义、迁移或重命名现有 step1 文件。

Closes #985


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 统一按内容模式定位分集 Step1 草稿与剧本文件（包括 reference、drama、narration），并在各入口间收敛读取/写入规则。
  * drama 写入结构化 JSON 时增加校验，避免写入无效内容。
* **Bug 修复**
  * 修复分集账本回填中“下游产物”判定与孤儿派生条目脚本路径生成不一致的问题。
  * 修复仅存在结构化 Step1 草稿时账本状态判定不正确的问题。
* **测试**
  * 新增覆盖分集路径契约与回填状态的用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->