### PR TITLE
fix(timeline): 修复审核面板发声列表编辑串位，加载失败区分错误态并支持重试

### DIFF
--- a/frontend/src/components/canvas/timeline/ScriptReviewGate.test.tsx
+++ b/frontend/src/components/canvas/timeline/ScriptReviewGate.test.tsx
@@ -183,6 +183,25 @@ describe("ScriptReviewGate", () => {
     expect(screen.queryByText("暂无预处理内容")).not.toBeInTheDocument();
   });
 
+  it("surfaces an error with retry when a refetch fails after an empty state", async () => {
+    const get = vi
+      .spyOn(API, "getScriptReview")
+      .mockResolvedValueOnce(dramaState({ status: "no_step1", content: null, fingerprint: null }))
+      .mockRejectedValue(new Error("刷新失败"));
+    render(<ScriptReviewGate projectName="p" episode={1} contentMode="drama" />);
+    await waitFor(() => expect(screen.getByText("暂无预处理内容")).toBeInTheDocument());
+
+    // 空态无真实内容可保留：revision 静默刷新失败应进错误态（区别于空态）并给重试，不滞留在过时空态。
+    act(() => {
+      useAppStore.getState().invalidateEntities(["draft:episode_1_step1"]);
+    });
+
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("无法加载预处理内容")).toBeInTheDocument();
+    expect(screen.getByText("重试")).toBeInTheDocument();
+    expect(screen.queryByText("暂无预处理内容")).not.toBeInTheDocument();
+  });
+
   it("keeps existing content when a silent refetch fails", async () => {
     const get = vi
       .spyOn(API, "getScriptReview")

--- a/frontend/src/components/canvas/timeline/ScriptReviewGate.test.tsx
+++ b/frontend/src/components/canvas/timeline/ScriptReviewGate.test.tsx
@@ -171,4 +171,50 @@ describe("ScriptReviewGate", () => {
     render(<ScriptReviewGate projectName="p" episode={1} contentMode="drama" />);
     await waitFor(() => expect(screen.getByText("暂无预处理内容")).toBeInTheDocument());
   });
+
+  it("renders a load-error state distinct from the empty state", async () => {
+    vi.spyOn(API, "getScriptReview").mockRejectedValue(new Error("网络异常"));
+    render(<ScriptReviewGate projectName="p" episode={1} contentMode="drama" />);
+
+    await waitFor(() => expect(screen.getByText("无法加载预处理内容")).toBeInTheDocument());
+    // 错误态展示服务端错误信息与重试入口，且不与空态文案混淆。
+    expect(screen.getByText("网络异常")).toBeInTheDocument();
+    expect(screen.getByText("重试")).toBeInTheDocument();
+    expect(screen.queryByText("暂无预处理内容")).not.toBeInTheDocument();
+  });
+
+  it("keeps existing content when a silent refetch fails", async () => {
+    const get = vi
+      .spyOn(API, "getScriptReview")
+      .mockResolvedValueOnce(dramaState())
+      .mockRejectedValue(new Error("刷新失败"));
+    render(<ScriptReviewGate projectName="p" episode={1} contentMode="drama" />);
+    await waitFor(() => expect(screen.getByDisplayValue("你终于回来了。")).toBeInTheDocument());
+
+    // revision 触发静默刷新失败：应保留已加载内容，不闪错误态 / 空态。
+    act(() => {
+      useAppStore.getState().invalidateEntities(["draft:episode_1_step1"]);
+    });
+
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(2));
+    expect(screen.getByDisplayValue("你终于回来了。")).toBeInTheDocument();
+    expect(screen.queryByText("无法加载预处理内容")).not.toBeInTheDocument();
+    expect(screen.queryByText("暂无预处理内容")).not.toBeInTheDocument();
+  });
+
+  it("retries after a load error and recovers to normal content", async () => {
+    const get = vi
+      .spyOn(API, "getScriptReview")
+      .mockRejectedValueOnce(new Error("网络异常"))
+      .mockResolvedValue(dramaState());
+    render(<ScriptReviewGate projectName="p" episode={1} contentMode="drama" />);
+
+    await waitFor(() => expect(screen.getByText("重试")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("重试"));
+
+    await waitFor(() => expect(screen.getByDisplayValue("你终于回来了。")).toBeInTheDocument());
+    expect(screen.queryByText("无法加载预处理内容")).not.toBeInTheDocument();
+    expect(get).toHaveBeenCalledTimes(2);
+  });
 });

--- a/frontend/src/components/canvas/timeline/ScriptReviewGate.tsx
+++ b/frontend/src/components/canvas/timeline/ScriptReviewGate.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { CheckCircle2, Clock, Lock, Save } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Clock, Lock, RotateCcw, Save } from "lucide-react";
 import { API } from "@/api";
 import type {
   DramaNormalizedScript,
@@ -18,6 +18,7 @@ import {
   ACCENT_BTN_CLS,
   CARD_STYLE,
   GHOST_BTN_CLS,
+  GHOST_BTN_LG_CLS,
 } from "@/components/ui/darkroom-tokens";
 import { UtteranceListEditor } from "./UtteranceListEditor";
 
@@ -172,6 +173,8 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
   const [state, setState] = useState<ScriptReviewState | null>(null);
   const [draft, setDraft] = useState<DramaNormalizedScript | NarrationStep1Draft | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<{ message: string } | null>(null);
+  const [reloadNonce, setReloadNonce] = useState(0);
   const [saving, setSaving] = useState(false);
   const [confirming, setConfirming] = useState(false);
 
@@ -194,14 +197,22 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
     );
   }, []);
 
+  const handleRetry = useCallback(() => {
+    setLoadError(null);
+    setLoading(true);
+    setReloadNonce((n) => n + 1);
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
-    // 仅首次加载显示加载态；revision 触发的重新拉取静默刷新，避免闪烁。
+    const hadContent = state != null;
+    // 仅首次加载 / 重试（尚无内容）显示加载态；revision 触发的重新拉取静默刷新，避免闪烁。
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (!state) setLoading(true);
+    if (!hadContent) setLoading(true);
     API.getScriptReview(projectName, episode)
       .then((next) => {
         if (cancelled) return;
+        setLoadError(null);
         setState(next);
         // 外部刷新（挂载 / agent 改 step1 触发的 revision）：用户无未保存编辑时采用服务端内容，
         // 有编辑则仅更新服务端态、保留用户草稿。dirtyRef 读取在 effect 内安全（非 render 期）。
@@ -213,8 +224,11 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
           );
         }
       })
-      .catch(() => {
-        if (!cancelled) setState(null);
+      .catch((err) => {
+        if (cancelled) return;
+        // 首次加载失败 → 进入错误态（区别于空态），提供重试；
+        // 静默刷新（已有内容）失败则保留现有内容，不破坏用户视图。
+        if (!hadContent) setLoadError({ message: errorMessage(err) });
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -222,8 +236,8 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- state 仅用于决定是否显示加载态，加入 deps 会在每次刷新后重新拉取造成循环
-  }, [projectName, episode, draftRevision]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- state 仅用于决定是否显示加载态/错误态，加入 deps 会在每次刷新后重新拉取造成循环
+  }, [projectName, episode, draftRevision, reloadNonce]);
 
   const handleSave = useCallback(async () => {
     if (!draft) return;
@@ -269,6 +283,25 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
 
   if (loading) {
     return <div className="flex h-64 items-center justify-center text-text-4">{t("dashboard:loading_preprocessing")}</div>;
+  }
+
+  // 加载错误态：区别于「无 step1 产物」空态，展示错误信息 + 重试入口。
+  if (loadError) {
+    return (
+      <div role="alert" className="flex h-64 flex-col items-center justify-center gap-3 text-center">
+        <AlertTriangle className="h-6 w-6 text-amber-400" aria-hidden="true" />
+        <div className="flex flex-col gap-1">
+          <p className="text-[13px] font-medium text-text-2">{t("dashboard:review_load_failed")}</p>
+          {loadError.message && (
+            <p className="max-w-sm px-4 font-mono text-[11px] text-text-4">{loadError.message}</p>
+          )}
+        </div>
+        <button type="button" onClick={handleRetry} className={GHOST_BTN_LG_CLS}>
+          <RotateCcw className="h-3.5 w-3.5" />
+          {t("dashboard:review_retry")}
+        </button>
+      </div>
+    );
   }
 
   const status = state?.status ?? "no_step1";

--- a/frontend/src/components/canvas/timeline/ScriptReviewGate.tsx
+++ b/frontend/src/components/canvas/timeline/ScriptReviewGate.tsx
@@ -205,10 +205,12 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
 
   useEffect(() => {
     let cancelled = false;
-    const hadContent = state != null;
-    // 仅首次加载 / 重试（尚无内容）显示加载态；revision 触发的重新拉取静默刷新，避免闪烁。
+    // 已拿到过任一响应（空态或内容态）后，revision 触发的重新拉取静默刷新、不闪加载态；
+    const hadResponse = state != null;
+    // 屏上有真实内容可保留时，刷新失败静默保留、不破坏用户视图；无内容（首屏，或空态）时失败才进错误态。
+    const hasContent = draft != null;
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (!hadContent) setLoading(true);
+    if (!hadResponse) setLoading(true);
     API.getScriptReview(projectName, episode)
       .then((next) => {
         if (cancelled) return;
@@ -226,9 +228,9 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
       })
       .catch((err) => {
         if (cancelled) return;
-        // 首次加载失败 → 进入错误态（区别于空态），提供重试；
-        // 静默刷新（已有内容）失败则保留现有内容，不破坏用户视图。
-        if (!hadContent) setLoadError({ message: errorMessage(err) });
+        // 屏上无真实内容（首屏失败，或空态后 revision 刷新失败）→ 错误态（区别于空态）+ 重试；
+        // 已有内容的静默刷新失败则保留现有内容，不破坏用户视图。
+        if (!hasContent) setLoadError({ message: errorMessage(err) });
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -236,7 +238,7 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- state 仅用于决定是否显示加载态/错误态，加入 deps 会在每次刷新后重新拉取造成循环
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- state/draft 仅用于决定加载态与错误态分支，加入 deps 会在每次刷新后重新拉取造成循环
   }, [projectName, episode, draftRevision, reloadNonce]);
 
   const handleSave = useCallback(async () => {

--- a/frontend/src/components/canvas/timeline/UtteranceListEditor.test.tsx
+++ b/frontend/src/components/canvas/timeline/UtteranceListEditor.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { UtteranceListEditor } from "./UtteranceListEditor";
@@ -7,6 +8,12 @@ const sample: Utterance[] = [
   { kind: "voiceover", speaker: null, text: "三年后。" },
   { kind: "dialogue", speaker: "阿离", text: "你终于回来了。" },
 ];
+
+/** 受控宿主：把 onChange 回写进 state，还原真实的删除 / 移动后重渲染。 */
+function Harness({ initial }: { initial: Utterance[] }) {
+  const [utterances, setUtterances] = useState(initial);
+  return <UtteranceListEditor utterances={utterances} onChange={setUtterances} />;
+}
 
 describe("UtteranceListEditor", () => {
   it("renders dialogue with a speaker and voiceover without one, in order", () => {
@@ -67,5 +74,45 @@ describe("UtteranceListEditor", () => {
   it("shows an empty hint when there are no utterances", () => {
     render(<UtteranceListEditor utterances={[]} onChange={() => {}} />);
     expect(screen.getByText("本场景暂无发声内容。")).toBeInTheDocument();
+  });
+
+  // 稳定 key 回归：数组索引作 key 时删除 / 移动会按位复用受控输入节点，
+  // 焦点跳到错误行、编辑内容串位。以下断言焦点始终跟随原条目。
+  it("keeps focus on a later row after an earlier row is removed", () => {
+    const rows: Utterance[] = [
+      { kind: "voiceover", speaker: null, text: "首行画外音。" },
+      { kind: "dialogue", speaker: "阿离", text: "中间台词。" },
+      { kind: "voiceover", speaker: null, text: "末行画外音。" },
+    ];
+    render(<Harness initial={rows} />);
+
+    const lastRow = screen.getByDisplayValue("末行画外音。") as HTMLTextAreaElement;
+    lastRow.focus();
+    expect(document.activeElement).toBe(lastRow);
+
+    fireEvent.click(screen.getAllByLabelText("删除发声")[0]);
+
+    // 末行条目仍在、内容不变，且焦点仍停在同一节点（未被前移的节点顶替）。
+    const stillLast = screen.getByDisplayValue("末行画外音。");
+    expect(document.activeElement).toBe(stillLast);
+    expect(screen.queryByDisplayValue("首行画外音。")).not.toBeInTheDocument();
+  });
+
+  it("keeps a moved row's focus and content bound to the same row", () => {
+    const rows: Utterance[] = [
+      { kind: "voiceover", speaker: null, text: "首行画外音。" },
+      { kind: "dialogue", speaker: "阿离", text: "中间台词。" },
+      { kind: "voiceover", speaker: null, text: "末行画外音。" },
+    ];
+    render(<Harness initial={rows} />);
+
+    const lastRow = screen.getByDisplayValue("末行画外音。") as HTMLTextAreaElement;
+    lastRow.focus();
+
+    // 上移末行：其内容与焦点应随条目移动，不被相邻行内容顶替。
+    fireEvent.click(screen.getAllByLabelText("上移")[2]);
+
+    const focused = document.activeElement as HTMLTextAreaElement;
+    expect(focused.value).toBe("末行画外音。");
   });
 });

--- a/frontend/src/components/canvas/timeline/UtteranceListEditor.tsx
+++ b/frontend/src/components/canvas/timeline/UtteranceListEditor.tsx
@@ -23,8 +23,10 @@ function makeUtterance(kind: UtteranceKind): Utterance {
     : { kind: "voiceover", speaker: null, text: "" };
 }
 
-/** 下一个稳定 key：取现有 key 数字后缀最大值 +1。纯函数，StrictMode 双调用幂等。 */
+/** 下一个稳定 key：取现有 key 数字后缀最大值 +1；空序列从 u0 起，与初始化命名对齐。
+ *  纯函数，StrictMode 双调用幂等。 */
 function nextKey(keys: string[]): string {
+  if (keys.length === 0) return "u0";
   const max = keys.reduce((m, k) => Math.max(m, Number(k.slice(1)) || 0), 0);
   return `u${max + 1}`;
 }

--- a/frontend/src/components/canvas/timeline/UtteranceListEditor.tsx
+++ b/frontend/src/components/canvas/timeline/UtteranceListEditor.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ChevronDown,
@@ -20,6 +21,12 @@ function makeUtterance(kind: UtteranceKind): Utterance {
   return kind === "dialogue"
     ? { kind: "dialogue", speaker: "", text: "" }
     : { kind: "voiceover", speaker: null, text: "" };
+}
+
+/** 下一个稳定 key：取现有 key 数字后缀最大值 +1。纯函数，StrictMode 双调用幂等。 */
+function nextKey(keys: string[]): string {
+  const max = keys.reduce((m, k) => Math.max(m, Number(k.slice(1)) || 0), 0);
+  return `u${max + 1}`;
 }
 
 /** Flip an utterance's kind, preserving text. dialogue→voiceover drops the
@@ -168,12 +175,26 @@ function UtteranceRow({
 export function UtteranceListEditor({ utterances, onChange, disabled = false }: UtteranceListEditorProps) {
   const { t } = useTranslation("dashboard");
 
+  // 数据模型无 id：在编辑态派生与条目一一绑定的稳定 key，增删移动时同步搬运，
+  // 使受控输入节点按条目（而非按位置）复用，避免删除中间项 / 移动后焦点跳行、编辑内容串到相邻行。
+  const [keys, setKeys] = useState<string[]>(() => utterances.map((_, i) => `u${i}`));
+
+  // 外部整体替换（挂载后 adopt / revision 静默刷新）导致条目数与 key 数漂移时对齐：按位复用已有 key、
+  // 尾部补新 key、裁掉多余。本地增删移动已同步搬运 key，长度恒等，不触发此分支。
+  let renderKeys = keys;
+  if (keys.length !== utterances.length) {
+    renderKeys = keys.slice(0, utterances.length);
+    while (renderKeys.length < utterances.length) renderKeys.push(nextKey(renderKeys));
+    setKeys(renderKeys);
+  }
+
   const updateAt = (index: number, next: Utterance) => {
     onChange(utterances.map((u, i) => (i === index ? next : u)));
   };
 
   const removeAt = (index: number) => {
     onChange(utterances.filter((_, i) => i !== index));
+    setKeys((prev) => prev.filter((_, i) => i !== index));
   };
 
   const moveAt = (index: number, delta: -1 | 1) => {
@@ -182,10 +203,16 @@ export function UtteranceListEditor({ utterances, onChange, disabled = false }: 
     const next = [...utterances];
     [next[index], next[target]] = [next[target], next[index]];
     onChange(next);
+    setKeys((prev) => {
+      const swapped = [...prev];
+      [swapped[index], swapped[target]] = [swapped[target], swapped[index]];
+      return swapped;
+    });
   };
 
   const add = (kind: UtteranceKind) => {
     onChange([...utterances, makeUtterance(kind)]);
+    setKeys((prev) => [...prev, nextKey(prev)]);
   };
 
   return (
@@ -196,7 +223,7 @@ export function UtteranceListEditor({ utterances, onChange, disabled = false }: 
         <div role="list">
           {utterances.map((u, i) => (
             <UtteranceRow
-              key={i}
+              key={renderKeys[i]}
               value={u}
               index={i}
               total={utterances.length}

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1079,6 +1079,8 @@ export default {
   'review_saved': 'Step 1 content saved',
   'review_confirmed': 'Confirmed — visual generation unlocked',
   'review_confirm_failed': 'Could not confirm, please try again',
+  'review_load_failed': "Couldn't load preprocessing content",
+  'review_retry': 'Retry',
   'image_prompt_placeholder': 'Storyboard description...',
   'video_prompt_placeholder': 'Video action description...',
 

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1045,6 +1045,8 @@ export default {
   'review_saved': 'Đã lưu nội dung Step 1',
   'review_confirmed': 'Đã xác nhận — đã mở khoá tạo hình ảnh',
   'review_confirm_failed': 'Không thể xác nhận, vui lòng thử lại',
+  'review_load_failed': 'Không thể tải nội dung tiền xử lý',
+  'review_retry': 'Thử lại',
   'image_prompt_placeholder': 'Mô tả phân cảnh...',
   'video_prompt_placeholder': 'Mô tả hành động video...',
 

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1080,6 +1080,8 @@ export default {
   'review_saved': 'step1 内容已保存',
   'review_confirmed': '已确认 — 视觉生成已放行',
   'review_confirm_failed': '确认失败，请重试',
+  'review_load_failed': '无法加载预处理内容',
+  'review_retry': '重试',
   'image_prompt_placeholder': '分镜图描述...',
   'video_prompt_placeholder': '视频动作描述...',
 


### PR DESCRIPTION
Closes #986

## 问题

审核面板（step1→step2 web 审核 gate）存在两处交互层缺陷：

1. **发声列表编辑串位**：`UtteranceListEditor` 以数组索引作 React key，而列表支持上移/下移/删除。删除中间项或移动时 React 按位置复用受控输入节点，导致焦点跳到错误行、未失焦的编辑内容串到相邻行（提交数据本身仍正确）。
2. **加载失败伪装成空态**：`ScriptReviewGate` 加载 step1 中间态失败时被吞成空状态，与「尚无 step1 产物」共用同一空态文案，加载出错与空态不可区分，无重试入口、无独立错误文案。

## 修复

- **稳定 key**：数据模型无 id，在编辑态派生与条目一一绑定的稳定 key，增/删/移动时同步搬运，使输入节点按条目（而非位置）复用；外部整体替换（挂载 adopt / revision 静默刷新）按位对齐、尾部补新 key。焦点与各行编辑内容不再串位。
- **三终态分区**：区分正常内容、空态（无 step1 产物）、加载错误态。错误态展示服务端错误信息与重试入口，重试重新执行加载；三语 i18n 文案齐全（`review_load_failed` / `review_retry`）。
- **保留静默刷新既有行为**：revision 触发的静默刷新在已有内容时不闪加载态、失败保留现有内容。「刷新失败是否保留」以「屏上是否有真实内容」判定——无内容（首屏或空态）时刷新失败进错误态并给重试，避免空态后刷新失败滞留在过时空态。

## 验证

- 新增回归测试覆盖：删除/上下移后焦点与编辑内容不串位；加载失败错误态区别于空态；重试后恢复正常内容；静默刷新失败保留内容；空态后刷新失败进错误态+重试。
- 质量门：`pnpm lint` 干净、`tsc --noEmit` 干净、`vitest` 98 文件 / 797 测试全过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 审核内容预处理加载失败时新增可见错误提示与重试入口。
  * 刷新过程更细致地区分加载错误、空状态与静默刷新，减少页面闪烁。
* **Bug 修复**
  * 删除或上移条目后，输入焦点与对应行内容不再串位。
  * 重试失败/成功后按预期恢复到正确的错误或内容展示状态，必要时保留已加载内容。
* **文案**
  * 新增审核流程“加载失败/重试”多语言提示（中/英/越南语）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->