### PR TITLE
refactor(script): 剧本骨架分派深收口与消费方穷尽性断言

### DIFF
--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -24,6 +24,7 @@ from lib.script_models import (
     REFERENCE_SHOT_DURATION_RANGE,
     ad_script_total_duration,
 )
+from lib.script_skeleton import resolve_declared_kind
 from lib.speech_rate import estimate_spoken_seconds
 
 #: drama 场景说话量（台词 + 画外音）对场景时长的单向上界容差（比例）。语速估算
@@ -1051,11 +1052,13 @@ class DataValidator:
         source_language = project.get("source_language")
         scene_language = source_language if isinstance(source_language, str) else None
 
-        # "视频来源"维度由 generation_mode 表达；content_mode 决定剧本数据排布
-        # （segments / scenes / shots）。ad 剧本骨架唯一、不随生成路径更换：
-        # 即使 generation_mode=reference_video 也按 shots 校验（见 docs/adr/0033）。
-        is_reference = content_mode != "ad" and effective_mode(project=project, episode=episode) == "reference_video"
-        if is_reference:
+        # "视频来源"维度由 generation_mode 表达；骨架种类经规范解析统一判别，不再自建
+        # (content_mode, generation_mode) 轴交互的四路 if-elif。ad 剧本骨架唯一、不随生成
+        # 路径更换（见 docs/adr/0033），resolve_declared_kind 已内置该恒定映射。四个 validator
+        # 函数及各自签名（products / reference_mode / language）保留，校验行为不变。
+        gen_mode = effective_mode(project=project, episode=episode)
+        kind = resolve_declared_kind(content_mode, gen_mode)
+        if kind == "video_units":
             self._validate_reference_video_script(
                 episode.get("video_units", []),
                 project_characters,
@@ -1065,7 +1068,7 @@ class DataValidator:
                 warnings,
                 project_dir=project_dir,
             )
-        elif content_mode == "narration":
+        elif kind == "segments":
             self._validate_segments(
                 episode.get("segments", []),
                 project_characters,
@@ -1075,7 +1078,7 @@ class DataValidator:
                 warnings,
                 project_dir=project_dir,
             )
-        elif content_mode == "ad":
+        elif kind == "shots":
             raw_products = project.get("products")
             shots = episode.get("shots", [])
             self._validate_shots(
@@ -1087,7 +1090,7 @@ class DataValidator:
                 errors,
                 warnings,
                 project_dir=project_dir,
-                reference_mode=effective_mode(project=project, episode=episode) == "reference_video",
+                reference_mode=gen_mode == "reference_video",
             )
             self._warn_ad_target_duration_drift(project, shots, warnings)
             self._validate_ad_reference_units(
@@ -1102,7 +1105,7 @@ class DataValidator:
                 errors,
                 warnings,
             )
-        else:
+        elif kind == "scenes":
             self._validate_scenes(
                 episode.get("scenes", []),
                 project_characters,
@@ -1113,6 +1116,8 @@ class DataValidator:
                 project_dir=project_dir,
                 language=scene_language,
             )
+        else:  # pragma: no cover - resolve_declared_kind 只回四种骨架；第五种未处置即报错
+            raise ValueError(f"未处置的骨架种类: {kind!r}")
 
     def validate_episode(self, project_name: str, episode_file: str) -> ValidationResult:
         """验证 episode JSON"""

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -12,7 +12,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Optional
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 
 from lib.config.registry import PROVIDER_REGISTRY
@@ -67,6 +67,33 @@ _EID_PREFIX_RE = re.compile(r"^E\d+(?=[SU])")
 _QUALITY_PROBE_SCENE_MIN_LEN = 40
 _QUALITY_PROBE_ACTION_MIN_LEN = 25
 _QUALITY_PROBE_SHOT_TEXT_MIN_LEN = 15
+
+# 骨架种类 → 响应校验模型。模型类属上层依赖、不进 SKELETONS 窄表，映射留本地。
+# 键与 SKELETONS 逐一对应；新增第五种骨架时穷尽性断言逐个报红。
+_KIND_PARSE_SCHEMA: dict[str, type[BaseModel]] = {
+    "segments": NarrationEpisodeScript,
+    "scenes": DramaEpisodeScript,
+    "shots": AdEpisodeScript,
+    "video_units": ReferenceVideoScript,
+}
+
+# 骨架种类 → metadata 统计的计数键名。计数键名为业务附着（video_units→total_units 非
+# f"total_{kind}"），随 kind 显式保留、不进 SKELETONS 窄表。
+_METADATA_COUNT_KEY: dict[str, str] = {
+    "segments": "total_segments",
+    "scenes": "total_scenes",
+    "shots": "total_shots",
+    "video_units": "total_units",
+}
+
+# 骨架种类 → 缺 duration_seconds 时的兜底时长（秒）。业务附着值：segments/scenes 沿用
+# 历史默认，video_units 缺失按 0 计。shots（ad）无单镜头默认时长、改走 ad_script_total_duration
+# 稳健求和，故不在此表——第五种非 ad 骨架未登记即在 _add_metadata 处 KeyError 报红。
+_METADATA_FALLBACK_DURATION: dict[str, int] = {
+    "segments": 4,
+    "scenes": 8,
+    "video_units": 0,
+}
 
 
 def _rewrite_episode_prefix(rid: object, ep: int) -> object:
@@ -677,17 +704,12 @@ class ScriptGenerator:
         except json.JSONDecodeError as e:
             raise ValueError(f"JSON 解析失败: {e}")
 
-        # Pydantic 验证。ad 先于 generation_mode 判别：骨架唯一，reference 路径仍是 shots[]。
+        # 校验模型经规范解析定骨架种类（ad→shots 骨架唯一，reference→video_units），
+        # kind→模型映射留本地（模型属上层依赖，不进 SKELETONS 窄表）。
+        kind = resolve_declared_kind(self.content_mode, self._effective_generation_mode(episode))
+        schema = _KIND_PARSE_SCHEMA[kind]
         try:
-            if self.content_mode == "ad":
-                validated = AdEpisodeScript.model_validate(data)
-            elif self._effective_generation_mode(episode) == "reference_video":
-                validated = ReferenceVideoScript.model_validate(data)
-            elif self.content_mode == "narration":
-                validated = NarrationEpisodeScript.model_validate(data)
-            else:
-                validated = DramaEpisodeScript.model_validate(data)
-            return validated.model_dump()
+            return schema.model_validate(data).model_dump()
         except ValidationError as e:
             logger.warning("数据验证警告: %s", e)
             # 返回原始数据，允许部分不符合 schema
@@ -767,18 +789,14 @@ class ScriptGenerator:
         # 兜底改写 segment/scene/unit ID 中的 E\d+ 前缀，避免 LLM 写错集号导致文件
         # 名跨集冲突（如 storyboards/scene_E1S01.png 被 E2 重新覆盖）。
         ep = int(episode)
-        if self.content_mode != "ad" and gen_mode == "reference_video":
-            for u in script_data.get("video_units") or []:
-                if isinstance(u, dict) and "unit_id" in u:
-                    u["unit_id"] = _rewrite_episode_prefix(u.get("unit_id"), ep)
-        else:
-            # narration/drama/ad 统一经规范解析定骨架（ad 骨架唯一，不随生成路径换判别）；
-            # self.content_mode 为项目级校验值，解析不会 fail-loud。
-            kind = resolve_declared_kind(self.content_mode, gen_mode)
-            id_field = SKELETONS[kind].id_field
-            for s in script_data.get(kind) or []:
-                if isinstance(s, dict) and id_field in s:
-                    s[id_field] = _rewrite_episode_prefix(s.get(id_field), ep)
+        # segment/scene/shot/unit ID 前缀统一经规范解析定骨架 + SKELETONS 查 id 字段改写
+        # （ad 骨架唯一、reference→video_units；不再手写 reference 分支）。self.content_mode
+        # 为项目级校验值，解析不会 fail-loud。kind 复用到下方 metadata 统计。
+        kind = resolve_declared_kind(self.content_mode, gen_mode)
+        id_field = SKELETONS[kind].id_field
+        for s in script_data.get(kind) or []:
+            if isinstance(s, dict) and id_field in s:
+                s[id_field] = _rewrite_episode_prefix(s.get(id_field), ep)
         # content_mode 严格只是"内容类型"（narration/drama）；reference_video 属于
         # "视频来源"维度，由 generation_mode 表达。
         # 参考视频集必须强制覆盖：ReferenceVideoScript.content_mode 有 Pydantic 默认值
@@ -823,26 +841,18 @@ class ScriptGenerator:
         script_data["metadata"]["updated_at"] = now
         script_data["metadata"]["generator"] = self.generator.model if self.generator else "unknown"
 
-        # 计算统计信息（episode 级角色/场景/道具聚合由 StatusCalculator 读时计算）
-        if self.content_mode == "ad":
-            # shots 无单镜头默认时长偏好，缺失按 0 计（与 StatusCalculator 口径一致）。
-            # 校验失败降级保存的原始 dict 里 shots 可能为 null / 含脏条目，求和走稳健口径。
-            raw_shots = script_data.get("shots")
-            shots = raw_shots if isinstance(raw_shots, list) else []
-            script_data["metadata"]["total_shots"] = len(shots)
-            script_data["duration_seconds"] = ad_script_total_duration(shots)
-        elif gen_mode == "reference_video":
-            units = script_data.get("video_units", [])
-            script_data["metadata"]["total_units"] = len(units)
-            script_data["duration_seconds"] = sum(int(u.get("duration_seconds", 0)) for u in units)
-        elif self.content_mode == "narration":
-            segments = script_data.get("segments", [])
-            script_data["metadata"]["total_segments"] = len(segments)
-            script_data["duration_seconds"] = sum(int(s.get("duration_seconds", 4)) for s in segments)
+        # 计算统计信息（episode 级角色/场景/道具聚合由 StatusCalculator 读时计算）。
+        # 数组键经上方规范解析所得 kind 查表；计数键名与兜底时长为业务附着、随 kind 显式保留。
+        # 校验失败降级保存的原始 dict 里数组可能为 null / 含脏条目，isinstance 守卫走稳健口径。
+        raw_items = script_data.get(kind)
+        items = raw_items if isinstance(raw_items, list) else []
+        script_data["metadata"][_METADATA_COUNT_KEY[kind]] = len(items)
+        if kind == "shots":
+            # ad 逐镜头按 target_duration 预算规划、无单镜头默认时长，走 ad_script_total_duration。
+            script_data["duration_seconds"] = ad_script_total_duration(items)
         else:
-            scenes = script_data.get("scenes", [])
-            script_data["metadata"]["total_scenes"] = len(scenes)
-            script_data["duration_seconds"] = sum(int(s.get("duration_seconds", 8)) for s in scenes)
+            fallback = _METADATA_FALLBACK_DURATION[kind]
+            script_data["duration_seconds"] = sum(int(i.get("duration_seconds", fallback)) for i in items)
 
         # 剥离废弃的 episode 级聚合字段（改为读时计算）
         script_data.pop("characters_in_episode", None)
@@ -862,12 +872,17 @@ class ScriptGenerator:
         try:
             short_ids: list[str] = []
 
-            gen_mode = self._effective_generation_mode(episode)
-            if self.content_mode != "ad" and gen_mode == "reference_video":
-                for u in script_data.get("video_units") or []:
+            # 骨架经规范解析统一判别、id 字段查 SKELETONS（同 _add_metadata id 改写处置）。
+            # video_units 的过短样本落在 unit 内嵌 shots.text，与 narration/drama/ad 平铺条目的
+            # image_prompt/video_prompt 探针数据形状不同——结构分支按 kind 显式区分、非骨架分派。
+            kind = resolve_declared_kind(self.content_mode, self._effective_generation_mode(episode))
+            id_key = SKELETONS[kind].id_field
+            items = script_data.get(kind) or []
+            if kind == "video_units":
+                for u in items:
                     if not isinstance(u, dict):
                         continue
-                    uid = str(u.get("unit_id") or "?")
+                    uid = str(u.get(id_key) or "?")
                     for shot in u.get("shots") or []:
                         if not isinstance(shot, dict):
                             continue
@@ -875,11 +890,6 @@ class ScriptGenerator:
                         if len(text) < _QUALITY_PROBE_SHOT_TEXT_MIN_LEN:
                             short_ids.append(uid)
             else:
-                # narration/drama/ad 统一经规范解析定骨架；ad 骨架唯一，两条生成路径
-                # 都按 shots 探针，与 narration/drama 共用 scene/action 的过短判定。
-                kind = resolve_declared_kind(self.content_mode, gen_mode)
-                items = script_data.get(kind) or []
-                id_key = SKELETONS[kind].id_field
                 for item in items:
                     if not isinstance(item, dict):
                         continue

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -109,6 +109,24 @@ def _rewrite_episode_prefix(rid: object, ep: int) -> object:
     return new_rid
 
 
+def _coerce_duration(item: object, fallback: int) -> int:
+    """降级保存路径按稳健口径取单条时长:校验失败时保存的原始 dict 里数组可能含脏条目，
+    直接 ``int(item.get(...))`` 会在非 dict 或 duration_seconds 非数字时崩溃。
+
+    非 dict 条目无时长语义、记 0；dict 内 duration_seconds 缺失或非数字（None / 布尔 /
+    非数字字符串）回退 ``fallback``。
+    """
+    if not isinstance(item, dict):
+        return 0
+    value = item.get("duration_seconds", fallback)
+    if isinstance(value, bool):
+        return fallback
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
 class ScriptGenerator:
     """
     剧本生成器
@@ -794,7 +812,10 @@ class ScriptGenerator:
         # 为项目级校验值，解析不会 fail-loud。kind 复用到下方 metadata 统计。
         kind = resolve_declared_kind(self.content_mode, gen_mode)
         id_field = SKELETONS[kind].id_field
-        for s in script_data.get(kind) or []:
+        # 校验失败降级保存的原始 dict 里该数组可能为非列表脏值（LLM 误写标量），
+        # `... or []` 只挡 falsy、挡不住真值标量，isinstance 守卫避免 `for` 迭代崩溃。
+        raw_rewrite_items = script_data.get(kind)
+        for s in raw_rewrite_items if isinstance(raw_rewrite_items, list) else []:
             if isinstance(s, dict) and id_field in s:
                 s[id_field] = _rewrite_episode_prefix(s.get(id_field), ep)
         # content_mode 严格只是"内容类型"（narration/drama）；reference_video 属于
@@ -852,7 +873,7 @@ class ScriptGenerator:
             script_data["duration_seconds"] = ad_script_total_duration(items)
         else:
             fallback = _METADATA_FALLBACK_DURATION[kind]
-            script_data["duration_seconds"] = sum(int(i.get("duration_seconds", fallback)) for i in items)
+            script_data["duration_seconds"] = sum(_coerce_duration(i, fallback) for i in items)
 
         # 剥离废弃的 episode 级聚合字段（改为读时计算）
         script_data.pop("characters_in_episode", None)

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -113,8 +113,8 @@ def _coerce_duration(item: object, fallback: int) -> int:
     """降级保存路径按稳健口径取单条时长:校验失败时保存的原始 dict 里数组可能含脏条目，
     直接 ``int(item.get(...))`` 会在非 dict 或 duration_seconds 非数字时崩溃。
 
-    非 dict 条目无时长语义、记 0；dict 内 duration_seconds 缺失或非数字（None / 布尔 /
-    非数字字符串）回退 ``fallback``。
+    非 dict 条目无时长语义、记 0；dict 内 duration_seconds 缺失、非数字（None / 布尔 /
+    非数字字符串）或非正数（校验器亦按 ``duration <= 0`` 判无效）回退 ``fallback``。
     """
     if not isinstance(item, dict):
         return 0
@@ -122,9 +122,10 @@ def _coerce_duration(item: object, fallback: int) -> int:
     if isinstance(value, bool):
         return fallback
     try:
-        return int(value)
+        parsed = int(value)
     except (TypeError, ValueError):
         return fallback
+    return parsed if parsed > 0 else fallback
 
 
 class ScriptGenerator:

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -899,13 +899,17 @@ class ScriptGenerator:
             # image_prompt/video_prompt 探针数据形状不同——结构分支按 kind 显式区分、非骨架分派。
             kind = resolve_declared_kind(self.content_mode, self._effective_generation_mode(episode))
             id_key = SKELETONS[kind].id_field
-            items = script_data.get(kind) or []
+            # 降级保存的原始 dict 里数组可能为非列表脏值；`... or []` 挡不住真值标量，
+            # isinstance 守卫避免 `for` 迭代崩溃（外层 try/except 会吞异常但会误跳过整段探针）。
+            raw_items = script_data.get(kind)
+            items = raw_items if isinstance(raw_items, list) else []
             if kind == "video_units":
                 for u in items:
                     if not isinstance(u, dict):
                         continue
                     uid = str(u.get(id_key) or "?")
-                    for shot in u.get("shots") or []:
+                    raw_shots = u.get("shots")
+                    for shot in raw_shots if isinstance(raw_shots, list) else []:
                         if not isinstance(shot, dict):
                             continue
                         text = str(shot.get("text") or "")

--- a/lib/storyboard_sequence.py
+++ b/lib/storyboard_sequence.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from lib.script_editor import resolve_items
+from lib.script_skeleton import SKELETONS
 
 
 @dataclass(frozen=True)
@@ -26,31 +27,30 @@ PREVIOUS_STORYBOARD_REFERENCE_DESCRIPTION = (
 )
 
 
-def get_storyboard_items(script: dict) -> tuple[list[dict], str, str, str, str]:
+def get_storyboard_items(script: dict) -> tuple[list[dict], str, str | None, str, str]:
     """返回 narration/drama/ad 模式剧本的分镜列表 + 各引用字段名。
 
     ``reference_video`` 模式没有 storyboard 一说（视频按 ``video_units`` 直出，
     见 ``server/agent_runtime/sdk_tools/enqueue_videos.py`` 的 reference 分支），
     这里硬返回空列表是「该模式下不存在 storyboard 任务」的明示，调用方据此跳过。
+    该分支的 ``char_field`` 取 ``SKELETONS`` 声明的缺位（``None``）——``video_units`` 无逐条
+    角色名单（角色以 ``references`` 条目形态存在），不返回假字段名让调用方 ``get()`` 静默取空。
 
     narration/drama 路径委托给 ``lib.script_editor.resolve_items``——与写盘咽喉
     / 编辑核心 / 元数据重算共用同一判别（``narration→segments``、``drama→scenes``、
-    以及 narration 数据落 scenes 键的历史兼容）。``segments`` / ``scenes`` 键存在
-    但值非 list（如 ``null``）时 ``resolve_items`` 抛 ``ScriptEditError``——读取侧的
-    调用方（``cost_estimation`` / 路由 / enqueue 工具）应让异常上冒，避免脏数据
-    被静默吞成 ``TypeError: 'NoneType' is not iterable``。
+    以及 narration 数据落 scenes 键的历史兼容）。``char_field`` 改查 ``SKELETONS`` 单一
+    真相源（``.get(kind, ...)`` 静默兜底删除），第五种骨架出现时未登记即随查表报错。
+    ``segments`` / ``scenes`` 键存在但值非 list（如 ``null``）时 ``resolve_items`` 抛
+    ``ScriptEditError``——读取侧的调用方（``cost_estimation`` / 路由 / enqueue 工具）应让
+    异常上冒，避免脏数据被静默吞成 ``TypeError: 'NoneType' is not iterable``。
     """
     if script.get("generation_mode") == "reference_video":
-        return ([], "unit_id", "characters_in_unit", "scenes", "props")
+        unit = SKELETONS["video_units"]
+        return ([], unit.id_field, unit.chars_field, "scenes", "props")
 
     items, id_field, kind = resolve_items(script)
-    # 角色引用字段名按 kind 显式分派；未知 kind 沿用历史兜底落 scenes 字段名
-    # （narration 数据落 scenes 键的历史兼容路径也归于此）。
-    char_field = {
-        "segments": "characters_in_segment",
-        "scenes": "characters_in_scene",
-        "shots": "characters_in_shot",
-    }.get(kind, "characters_in_scene")
+    # 角色引用字段名改查 SKELETONS 单一真相源（video_units→None 强制显式决策）。
+    char_field = SKELETONS[kind].chars_field
     return (items, id_field, char_field, "scenes", "props")
 
 

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -403,7 +403,7 @@ def _collect_sheet_paths(
     project_path: Path,
     items: list[dict],
     *,
-    char_field: str,
+    char_field: str | None,
     scene_field: str,
     prop_field: str,
     max_count: int = 0,
@@ -412,6 +412,9 @@ def _collect_sheet_paths(
 
     Returns (list of existing Paths, set of relative sheet strings for dedup).
     If *max_count* > 0 collection stops after that many images.
+
+    ``char_field`` 为 ``None`` 表示该骨架无逐条角色名单字段（video_units：角色以
+    references 条目形态存在），``item.get(None, [])`` 天然跳过角色 sheet 收集。
     """
     seen: set[str] = set()
     paths: list[Path] = []
@@ -453,7 +456,7 @@ def _collect_reference_images(
     project_path: Path,
     target_item: dict,
     *,
-    char_field: str,
+    char_field: str | None,
     scene_field: str,
     prop_field: str,
     extra_reference_images: list[str] | None = None,

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -1179,3 +1179,51 @@ class TestSourceKindValidation:
         )
         result = validate_episode("demo", "episode_1.json", projects_root=str(tmp_path / "projects"))
         assert result.valid, result.errors
+
+
+# 骨架种类 → 触发该骨架的 (content_mode, generation_mode)，即 resolve_declared_kind 的逆。
+_KIND_TO_MODES = {
+    "segments": ("narration", None),
+    "scenes": ("drama", None),
+    "shots": ("ad", None),
+    "video_units": ("narration", "reference_video"),
+}
+# 骨架种类 → 该骨架应触达的 validator 方法名。
+_KIND_TO_VALIDATOR = {
+    "segments": "_validate_segments",
+    "scenes": "_validate_scenes",
+    "shots": "_validate_shots",
+    "video_units": "_validate_reference_video_script",
+}
+
+
+class TestDataValidatorSkeletonExhaustiveness:
+    """穷尽性断言：_validate_episode_payload 的骨架→validator 分派覆盖 SKELETONS 全部键。
+
+    第五种骨架加入 SKELETONS（+ 规范解析映射）时，分派 else 分支 fail-loud，此测试逐个报红。
+    """
+
+    @pytest.mark.parametrize("kind", list(_KIND_TO_MODES))
+    def test_episode_dispatch_covers_every_skeleton_kind(self, kind, tmp_path, monkeypatch):
+        from lib.script_skeleton import SKELETONS
+
+        # 遍历 SKELETONS 全键：新增第五种骨架而下方映射未登记即 KeyError 报红。
+        assert set(_KIND_TO_MODES) == set(SKELETONS)
+        assert set(_KIND_TO_VALIDATOR) == set(SKELETONS)
+
+        content_mode, gen_mode = _KIND_TO_MODES[kind]
+        called: list[str] = []
+        spied = (*_KIND_TO_VALIDATOR.values(), "_warn_ad_target_duration_drift", "_validate_ad_reference_units")
+        for name in spied:
+            monkeypatch.setattr(DataValidator, name, lambda *a, _n=name, **k: called.append(_n))
+
+        project = {"content_mode": content_mode, "products": {}}
+        episode = {"episode": 1, "title": "第一集", "content_mode": content_mode}
+        if gen_mode:
+            project["generation_mode"] = gen_mode
+            episode["generation_mode"] = gen_mode
+
+        validator = DataValidator(projects_root=str(tmp_path / "projects"))
+        validator._validate_episode_payload(tmp_path, project, episode, [], [])
+
+        assert _KIND_TO_VALIDATOR[kind] in called

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -888,6 +888,7 @@ class TestScriptGeneratorSkeletonExhaustiveness:
                     "junk_not_a_dict",
                     {"segment_id": "E1S02"},
                     {"segment_id": "E1S03", "duration_seconds": None},
+                    {"segment_id": "E1S04", "duration_seconds": -5},
                 ]
             },
             episode=2,
@@ -897,10 +898,11 @@ class TestScriptGeneratorSkeletonExhaustiveness:
         assert out["segments"][0]["segment_id"] == "E2S01"
         assert out["segments"][1] == "junk_not_a_dict"
         assert out["segments"][2]["segment_id"] == "E2S02"
+        assert out["segments"][4]["segment_id"] == "E2S04"
         # 计数取列表长度（含脏条目），与既有口径一致
-        assert out["metadata"]["total_segments"] == 4
-        # 时长：5(有效) + 0(非 dict) + 4(缺失→兜底) + 4(None→兜底) = 13
-        assert out["duration_seconds"] == 13
+        assert out["metadata"]["total_segments"] == 5
+        # 时长：5(有效) + 0(非 dict) + 4(缺失→兜底) + 4(None→兜底) + 4(非正数→兜底) = 17
+        assert out["duration_seconds"] == 17
 
     def test_add_metadata_survives_non_list_array(self, tmp_path: Path):
         # 数组键为真值标量（LLM 误写）时 `... or []` 挡不住，isinstance 守卫避免迭代/求和崩溃。

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -876,6 +876,41 @@ class TestScriptGeneratorSkeletonExhaustiveness:
         # 计数键随 kind 显式落位
         assert out["metadata"][_METADATA_COUNT_KEY[kind]] == 1
 
+    def test_add_metadata_survives_dirty_degraded_items(self, tmp_path: Path):
+        # 校验失败降级保存的原始 dict 里 segments 可能含非 dict / duration_seconds 非数字的脏条目；
+        # 前缀改写与时长求和都不得崩溃，时长按稳健口径逐条兜底。
+        sg = _bare_generator(tmp_path, {"content_mode": "narration"})
+
+        out = sg._add_metadata(
+            {
+                "segments": [
+                    {"segment_id": "E1S01", "duration_seconds": 5},
+                    "junk_not_a_dict",
+                    {"segment_id": "E1S02"},
+                    {"segment_id": "E1S03", "duration_seconds": None},
+                ]
+            },
+            episode=2,
+        )
+
+        # dict 条目前缀改写；非 dict 条目原样保留、不参与改写
+        assert out["segments"][0]["segment_id"] == "E2S01"
+        assert out["segments"][1] == "junk_not_a_dict"
+        assert out["segments"][2]["segment_id"] == "E2S02"
+        # 计数取列表长度（含脏条目），与既有口径一致
+        assert out["metadata"]["total_segments"] == 4
+        # 时长：5(有效) + 0(非 dict) + 4(缺失→兜底) + 4(None→兜底) = 13
+        assert out["duration_seconds"] == 13
+
+    def test_add_metadata_survives_non_list_array(self, tmp_path: Path):
+        # 数组键为真值标量（LLM 误写）时 `... or []` 挡不住，isinstance 守卫避免迭代/求和崩溃。
+        sg = _bare_generator(tmp_path, {"content_mode": "narration"})
+
+        out = sg._add_metadata({"segments": 123}, episode=1)
+
+        assert out["metadata"]["total_segments"] == 0
+        assert out["duration_seconds"] == 0
+
 
 def _step1_seg(
     segment_id: str,

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -820,6 +820,63 @@ def _bare_generator(tmp_path: Path, project_extra: dict | None = None) -> Script
     return sg
 
 
+# 骨架种类 → 触发该骨架的 (content_mode, generation_mode)，即 resolve_declared_kind 的逆。
+_KIND_TO_MODES: dict[str, tuple[str, str | None]] = {
+    "segments": ("narration", None),
+    "scenes": ("drama", None),
+    "shots": ("ad", None),
+    "video_units": ("narration", "reference_video"),
+}
+
+
+class TestScriptGeneratorSkeletonExhaustiveness:
+    """穷尽性断言：script_generator 的骨架分派覆盖 SKELETONS 全部键。
+
+    第五种骨架加入 SKELETONS（+ 规范解析映射）时，未登记的本地映射与未处置的分派逐个报红。
+    """
+
+    def test_parse_schema_covers_every_skeleton_kind(self):
+        from lib.script_generator import _KIND_PARSE_SCHEMA
+        from lib.script_skeleton import SKELETONS
+
+        assert set(_KIND_PARSE_SCHEMA) == set(SKELETONS)
+
+    def test_metadata_count_key_covers_every_skeleton_kind(self):
+        from lib.script_generator import _METADATA_COUNT_KEY
+        from lib.script_skeleton import SKELETONS
+
+        assert set(_METADATA_COUNT_KEY) == set(SKELETONS)
+
+    def test_metadata_fallback_duration_covers_non_shots_kinds(self):
+        # shots（ad）走 ad_script_total_duration、不进兜底时长表；其余骨架均须登记。
+        from lib.script_generator import _METADATA_FALLBACK_DURATION
+        from lib.script_skeleton import SKELETONS
+
+        assert set(_METADATA_FALLBACK_DURATION) == set(SKELETONS) - {"shots"}
+
+    @pytest.mark.parametrize("kind", list(_KIND_TO_MODES))
+    def test_add_metadata_handles_every_skeleton_kind(self, kind: str, tmp_path: Path):
+        from lib.script_generator import _METADATA_COUNT_KEY
+        from lib.script_skeleton import SKELETONS
+
+        # 参数化遍历 SKELETONS 全键：新增第五种骨架而 _KIND_TO_MODES 未登记即 KeyError 报红。
+        assert set(_KIND_TO_MODES) == set(SKELETONS)
+
+        content_mode, gen_mode = _KIND_TO_MODES[kind]
+        extra: dict = {"content_mode": content_mode}
+        if gen_mode:
+            extra["generation_mode"] = gen_mode
+        sg = _bare_generator(tmp_path, extra)
+
+        id_field = SKELETONS[kind].id_field
+        out = sg._add_metadata({kind: [{id_field: "E1S01"}]}, episode=2)
+
+        # 数组键 + id 字段经查表：前缀改写为当前集号
+        assert out[kind][0][id_field] == "E2S01"
+        # 计数键随 kind 显式落位
+        assert out["metadata"][_METADATA_COUNT_KEY[kind]] == 1
+
+
 def _step1_seg(
     segment_id: str,
     novel_text: str,

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -913,6 +913,16 @@ class TestScriptGeneratorSkeletonExhaustiveness:
         assert out["metadata"]["total_segments"] == 0
         assert out["duration_seconds"] == 0
 
+    def test_quality_probe_survives_non_list_array(self, tmp_path: Path, caplog):
+        # 数组键为真值标量时,_quality_probe 应被 isinstance 守卫收敛为空;外层 try/except 虽会
+        # 吞异常,但不得走 “quality probe skipped” 兜底(那意味着守卫失效、整段探针被误跳过)。
+        sg = _bare_generator(tmp_path, {"content_mode": "narration"})
+
+        with caplog.at_level("WARNING", logger="lib.script_generator"):
+            sg._quality_probe({"segments": 123}, episode=1)
+
+        assert not any("quality probe skipped" in r.message for r in caplog.records)
+
 
 def _step1_seg(
     segment_id: str,

--- a/tests/test_status_calculator.py
+++ b/tests/test_status_calculator.py
@@ -648,3 +648,39 @@ class TestAdStatusCalculation:
         assert kind == "segments"
         kind, _ = StatusCalculator._select_kind_and_items({"scenes": [{}], "shots": [{}]})
         assert kind == "scenes"
+
+
+# 骨架种类 → 触发该骨架的 (content_mode, generation_mode)，即 resolve_declared_kind 的逆。
+_KIND_TO_MODES = {
+    "segments": ("narration", None),
+    "scenes": ("drama", None),
+    "shots": ("ad", None),
+    "video_units": ("narration", "reference_video"),
+}
+
+
+class TestStatusCalculatorSkeletonExhaustiveness:
+    """穷尽性断言：calculate_episode_stats 的按 kind 分派覆盖 SKELETONS 全部键。
+
+    第五种骨架加入 SKELETONS（+ 规范解析映射）时，_FALLBACK_ITEM_DURATIONS 查表 KeyError，逐个报红。
+    """
+
+    @pytest.mark.parametrize("kind", list(_KIND_TO_MODES))
+    def test_calculate_episode_stats_covers_every_skeleton_kind(self, kind, tmp_path):
+        from lib.script_skeleton import SKELETONS
+
+        # 遍历 SKELETONS 全键：新增第五种骨架而 _KIND_TO_MODES 未登记即 KeyError 报红。
+        assert set(_KIND_TO_MODES) == set(SKELETONS)
+
+        content_mode, gen_mode = _KIND_TO_MODES[kind]
+        id_field = SKELETONS[kind].id_field
+        script = {"content_mode": content_mode, kind: [{id_field: "E1S01"}]}
+        if gen_mode:
+            script["generation_mode"] = gen_mode
+
+        calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
+        stats = calc.calculate_episode_stats("demo", script, generation_mode=gen_mode)
+
+        assert isinstance(stats, dict)
+        assert "status" in stats
+        assert stats["scenes_count"] == 1

--- a/tests/test_storyboard_sequence.py
+++ b/tests/test_storyboard_sequence.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from lib.storyboard_sequence import (
     build_storyboard_dependency_plan,
     get_storyboard_items,
@@ -118,3 +120,29 @@ class TestAdStoryboardItems:
         assert char_field == "characters_in_shot"
         assert (scenes_field, props_field) == ("scenes", "props")
         assert items[0]["shot_id"] == "E1S01"
+
+
+# 骨架种类 → 触发该骨架的最小剧本（取证解析 / reference 短路各覆盖）。
+_SCRIPT_BY_KIND = {
+    "segments": {"content_mode": "narration", "segments": [{"segment_id": "E1S01"}]},
+    "scenes": {"content_mode": "drama", "scenes": [{"scene_id": "E1S01"}]},
+    "shots": {"content_mode": "ad", "shots": [{"shot_id": "E1S01"}]},
+    "video_units": {"generation_mode": "reference_video", "video_units": [{"unit_id": "E1U01"}]},
+}
+
+
+class TestStoryboardSkeletonExhaustiveness:
+    """穷尽性断言：get_storyboard_items 的 char_field 覆盖 SKELETONS 全部键。
+
+    char_field 直接查 SKELETONS，第五种骨架加入时 _SCRIPT_BY_KIND 未登记即报红。
+    """
+
+    @pytest.mark.parametrize("kind", list(_SCRIPT_BY_KIND))
+    def test_get_storyboard_items_char_field_matches_registry(self, kind):
+        from lib.script_skeleton import SKELETONS
+
+        # 遍历 SKELETONS 全键：新增第五种骨架而 _SCRIPT_BY_KIND 未登记即 KeyError 报红。
+        assert set(_SCRIPT_BY_KIND) == set(SKELETONS)
+
+        _items, _id_field, char_field, _scenes, _props = get_storyboard_items(_SCRIPT_BY_KIND[kind])
+        assert char_field == SKELETONS[kind].chars_field


### PR DESCRIPTION
## 目标

一类点位清单中剩余手写骨架分派的深收口（承接 PR1 #1010 的骨架单一真相源 `SKELETONS`）：消灭手写四路 if-elif 与二值兜底，并为每个含骨架分派的消费方建立穷尽性参数化断言。设计权威：`docs/adr/0045`。

Closes #999。

## 改动

**一类点位深收口（手写四路 if-elif / 二值兜底 → 规范解析 + 查表）**

- `lib/script_generator.py`
  - `_parse_response`：(mode, gen_mode)→校验模型的四路手写改经 `resolve_declared_kind` 定 kind，`kind→模型`映射（`_KIND_PARSE_SCHEMA`）留本地（模型属上层依赖，不进窄表）。
  - `_add_metadata` id 前缀改写：reference 硬编码分支删除，统一经规范解析 + `SKELETONS` 查 id_field。
  - `_add_metadata` 统计：数组键经查表；计数键名（`_METADATA_COUNT_KEY`）/兜底时长（`_METADATA_FALLBACK_DURATION`）为业务附着，随 kind 显式保留；数组统一走 `isinstance` 守卫稳健口径。
  - `_quality_probe`：同 id 改写处置；video_units 内嵌 shots.text 与平铺条目探针数据形状差异按 kind 显式区分。
- `lib/data_validator.py`：骨架→validator 分派的自建轴交互四路 if-elif 换 `resolve_declared_kind`；四个 validator 函数及签名保留。**行为 delta（lead 已裁决，PRD user story 9）**：显式脏值 `content_mode` 由静默按 scenes 校验改 fail-loud（`ValueError`）；缺失 content_mode 仍默认 narration，正常路径不受影响。
- `lib/storyboard_sequence.py`：`char_field` 改查 `SKELETONS`（`.get(kind, "characters_in_scene")` 静默兜底删除），返回类型放宽为 `str | None`（video_units 无逐条角色名单字段）。
- `server/services/generation_tasks.py`：分镜参考图收集两个 helper 的 `char_field` 形参随上游放宽为 `str | None`；`item.get(None, [])` 天然跳过角色 sheet 收集，运行时行为不变（该路径由空列表哨兵在上游短路，实际不传入 None）。

**穷尽性参数化断言**

四个含骨架分派的消费方（script_generator / data_validator / status_calculator / storyboard_sequence）各补一条遍历 `SKELETONS` 键的参数化测试——第五种骨架出现时未处置消费方逐个报红。status_calculator 分派已在 PR1 迁移，本 PR 仅补断言。

## 验证

- 全量 `pytest`：5578 passed。
- `ruff check` + `ruff format --check`：passed。
- `basedpyright`：0 error（审查阶段修复了 `generation_tasks.py` 一处 `char_field` 类型贯通缺口）。
- 穷尽性机制核验：临时向 `SKELETONS` 加第五种骨架，四消费方断言逐个报红共 19 条，还原后全绿。
- 二类/三类点位（content_mode 业务分派 / (content_mode, generation_mode) 轴交互业务规则）零改动。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 脚本解析、数据校验、元数据写入与状态/总时长统计现已统一按“骨架种类”驱动识别与处理。
  * 分镜/角色引用字段可随骨架类型自动适配；缺少逐条角色字段的形态现在也能正常兼容。
* **Bug Fixes**
  * 修复脏数据（如缺失/非法 `duration_seconds`、`segments` 非数组等）导致的统计不稳定或崩溃问题，并确保兜底口径一致。
  * 对未登记的骨架种类将更明确报错，避免静默遗漏。
* **Tests**
  * 新增多处骨架种类穷尽性测试，覆盖解析分派、元数据重写、探针与状态统计逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->