### PR TITLE
fix(events): ad 与参考生视频项目恢复分镜级实时事件推送

### DIFF
--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -25,10 +25,20 @@ from lib.project_change_hints import (
     register_project_change_listener,
 )
 from lib.project_manager import ProjectManager
+from lib.script_skeleton import SKELETONS, resolve_script_kind
 
 logger = logging.getLogger(__name__)
 
 PROJECT_EVENTS_POLL_SECONDS = 0.5
+
+# 条目名词按骨架种类硬编码——用于分镜级事件标签（如「镜头「E1S01」」）。名词 i18n 化是
+# 独立议题（与 ``_diff_named_entities`` 的「角色」/「线索」同为既有硬编码形态），不在此处收敛。
+_SKELETON_ITEM_NOUNS: dict[str, str] = {
+    "segments": "分镜",
+    "scenes": "场景",
+    "shots": "镜头",
+    "video_units": "视频单元",
+}
 
 
 def _utc_now_iso() -> str:
@@ -541,18 +551,21 @@ class ProjectEventService:
         }
 
     def _normalize_script_snapshot(self, script: dict[str, Any]) -> dict[str, Any]:
+        # 取证解析：由剧本数据形状判别骨架种类（narration/drama 走 reference 时 content_mode 仍是
+        # narration/drama，二值兜底会把 ad 的 shots 与 reference 的 video_units 全部漏读——差分恒空、
+        # 分镜级事件从不发出，正是本次修复的 bug 根因）。键即条目数组键。
         content_mode = str(script.get("content_mode") or "narration")
-        raw_items = script.get("segments" if content_mode == "narration" else "scenes", [])
+        kind = resolve_script_kind(script)
+        skeleton = SKELETONS[kind]
+        raw_items = script.get(kind, [])
         if not isinstance(raw_items, list):
             raw_items = []
-        id_field = "segment_id" if content_mode == "narration" else "scene_id"
-        chars_field = "characters_in_segment" if content_mode == "narration" else "characters_in_scene"
 
         items: dict[str, Any] = {}
         for item in raw_items:
             if not isinstance(item, dict):
                 continue
-            item_id = str(item.get(id_field) or "")
+            item_id = str(item.get(skeleton.id_field) or "")
             if not item_id:
                 continue
             assets = item.get("generated_assets")
@@ -561,7 +574,7 @@ class ProjectEventService:
             items[item_id] = {
                 "duration_seconds": item.get("duration_seconds"),
                 "segment_break": bool(item.get("segment_break")),
-                "characters": sorted(str(name) for name in item.get(chars_field, []) or []),
+                "characters": self._item_characters(item, skeleton.chars_field),
                 "scenes": sorted(str(name) for name in item.get("scenes", []) or []),
                 "props": sorted(str(name) for name in item.get("props", []) or []),
                 "image_prompt": item.get("image_prompt"),
@@ -578,8 +591,27 @@ class ProjectEventService:
             "episode": script.get("episode"),
             "title": str(script.get("title") or ""),
             "content_mode": content_mode,
+            "kind": kind,
             "items": items,
         }
+
+    @staticmethod
+    def _item_characters(item: dict[str, Any], chars_field: str | None) -> list[str]:
+        """条目出场角色名单（排序）。
+
+        ``chars_field`` 非 ``None`` 时读逐条角色字段；为 ``None``（video_units 无该字段的显式缺位，
+        见 ``SKELETONS``）时从条目 ``references`` 中过滤 ``type == "character"`` 派生。
+        """
+        if chars_field is not None:
+            return sorted(str(name) for name in item.get(chars_field, []) or [])
+        references = item.get("references")
+        if not isinstance(references, list):
+            return []
+        return sorted(
+            str(ref["name"])
+            for ref in references
+            if isinstance(ref, dict) and ref.get("type") == "character" and ref.get("name")
+        )
 
     def _diff_snapshots(
         self,
@@ -843,8 +875,8 @@ class ProjectEventService:
 
     @staticmethod
     def _build_script_item_label(item_id: str, script_meta: dict[str, Any]) -> str:
-        content_mode = str(script_meta.get("content_mode") or "narration")
-        noun = "分镜" if content_mode == "narration" else "场景"
+        kind = str(script_meta.get("kind") or "segments")
+        noun = _SKELETON_ITEM_NOUNS.get(kind, "分镜")
         return f"{noun}「{item_id}」"
 
     def _build_script_item_change(

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -559,6 +559,11 @@ class ProjectEventService:
         skeleton = SKELETONS[kind]
         raw_items = script.get(kind, [])
         if not isinstance(raw_items, list):
+            logger.warning(
+                "剧本条目字段非列表，按空快照处理 kind=%s type=%s",
+                kind,
+                type(raw_items).__name__,
+            )
             raw_items = []
 
         items: dict[str, Any] = {}
@@ -607,9 +612,12 @@ class ProjectEventService:
         使 video_unit 的场景/道具引用编辑也能进入差分）。
         """
         if chars_field is not None:
-            characters = sorted(str(name) for name in item.get(chars_field, []) or [])
-            scenes = sorted(str(name) for name in item.get("scenes", []) or [])
-            props = sorted(str(name) for name in item.get("props", []) or [])
+            chars_raw = item.get(chars_field)
+            scenes_raw = item.get("scenes")
+            props_raw = item.get("props")
+            characters = sorted({str(name) for name in chars_raw}) if isinstance(chars_raw, list) else []
+            scenes = sorted({str(name) for name in scenes_raw}) if isinstance(scenes_raw, list) else []
+            props = sorted({str(name) for name in props_raw}) if isinstance(props_raw, list) else []
             return characters, scenes, props
         buckets: dict[str, set[str]] = {"character": set(), "scene": set(), "prop": set()}
         references = item.get("references")

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -571,12 +571,14 @@ class ProjectEventService:
             assets = item.get("generated_assets")
             if not isinstance(assets, dict):
                 assets = {}
+            characters, scenes, props = self._item_entities(item, skeleton.chars_field)
             items[item_id] = {
                 "duration_seconds": item.get("duration_seconds"),
                 "segment_break": bool(item.get("segment_break")),
-                "characters": self._item_characters(item, skeleton.chars_field),
-                "scenes": sorted(str(name) for name in item.get("scenes", []) or []),
-                "props": sorted(str(name) for name in item.get("props", []) or []),
+                "characters": characters,
+                "scenes": scenes,
+                "props": props,
+                "shots": self._item_member_shots(item.get("shots")),
                 "image_prompt": item.get("image_prompt"),
                 "video_prompt": item.get("video_prompt"),
                 "generated_assets": {
@@ -596,22 +598,48 @@ class ProjectEventService:
         }
 
     @staticmethod
-    def _item_characters(item: dict[str, Any], chars_field: str | None) -> list[str]:
-        """条目出场角色名单（排序）。
+    def _item_entities(item: dict[str, Any], chars_field: str | None) -> tuple[list[str], list[str], list[str]]:
+        """条目出场的 (角色, 场景, 道具) 名单（各自排序、去重）。
 
-        ``chars_field`` 非 ``None`` 时读逐条角色字段；为 ``None``（video_units 无该字段的显式缺位，
-        见 ``SKELETONS``）时从条目 ``references`` 中过滤 ``type == "character"`` 派生。
+        ``chars_field`` 非 ``None`` 时角色读逐条字段、场景/道具读顶层 ``scenes`` / ``props``；为
+        ``None``（video_units 无逐条实体字段的显式缺位，见 ``SKELETONS``）时三者均从条目
+        ``references`` 按 ``type == character/scene/prop`` 派生（与 ``status_calculator`` 同规则，
+        使 video_unit 的场景/道具引用编辑也能进入差分）。
         """
         if chars_field is not None:
-            return sorted(str(name) for name in item.get(chars_field, []) or [])
+            characters = sorted(str(name) for name in item.get(chars_field, []) or [])
+            scenes = sorted(str(name) for name in item.get("scenes", []) or [])
+            props = sorted(str(name) for name in item.get("props", []) or [])
+            return characters, scenes, props
+        buckets: dict[str, set[str]] = {"character": set(), "scene": set(), "prop": set()}
         references = item.get("references")
-        if not isinstance(references, list):
+        if isinstance(references, list):
+            for ref in references:
+                if not isinstance(ref, dict):
+                    continue
+                name = ref.get("name")
+                if not name:
+                    continue
+                ref_type = ref.get("type")
+                target = buckets.get(ref_type) if isinstance(ref_type, str) else None
+                if target is not None:
+                    target.add(str(name))
+        return sorted(buckets["character"]), sorted(buckets["scene"]), sorted(buckets["prop"])
+
+    @staticmethod
+    def _item_member_shots(shots: Any) -> list[dict[str, Any]]:
+        """video_units 成员镜头的内容体（``text`` / ``duration``），供 ``updated`` 差分捕获镜头
+        文本或时长编辑——这些内容不落在 ``characters`` / ``duration_seconds`` 上，不纳入则单元
+        内容改动无事件。storyboard 骨架（segments/scenes/shots）条目无成员镜头子列表，返回空列表。
+        """
+        if not isinstance(shots, list):
             return []
-        return sorted(
-            str(ref["name"])
-            for ref in references
-            if isinstance(ref, dict) and ref.get("type") == "character" and ref.get("name")
-        )
+        normalized: list[dict[str, Any]] = []
+        for shot in shots:
+            if not isinstance(shot, dict):
+                continue
+            normalized.append({"text": str(shot.get("text") or ""), "duration": shot.get("duration")})
+        return normalized
 
     def _diff_snapshots(
         self,

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -5,7 +5,20 @@ import pytest
 
 from lib.project_change_hints import emit_project_change_batch, project_change_source
 from lib.project_manager import ProjectManager
-from server.services.project_events import ProjectEventService
+from lib.script_skeleton import SKELETONS
+from server.services.project_events import (
+    _SKELETON_ITEM_NOUNS,
+    ProjectEventService,
+)
+
+
+def _pending_assets() -> dict:
+    return {
+        "storyboard_image": None,
+        "video_clip": None,
+        "video_uri": None,
+        "status": "pending",
+    }
 
 
 async def _next_event(stream, *, timeout: float) -> tuple[str, dict]:
@@ -285,3 +298,234 @@ class TestProjectEventService:
 
         assert service.pm.projects_root == custom_projects.resolve()
         assert service.pm.get_project_path("demo") == (custom_projects / "demo").resolve()
+
+    def test_diff_snapshots_reports_ad_shot_lifecycle_events(self, tmp_path):
+        """ad(shots) 项目的分镜级事件：created / storyboard_ready / video_ready / updated。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("ad-demo")
+        pm.create_project_metadata("ad-demo", "Ad", "Anime", "ad")
+
+        with project_change_source("filesystem"):
+            pm.save_script(
+                "ad-demo",
+                {
+                    "episode": 1,
+                    "title": "广告",
+                    "content_mode": "ad",
+                    "shots": [
+                        {
+                            "shot_id": "E1S01",
+                            "duration_seconds": 4,
+                            "characters_in_shot": ["Hero"],
+                            "scenes": [],
+                            "props": [],
+                            "image_prompt": "old",
+                            "video_prompt": "old",
+                            "generated_assets": _pending_assets(),
+                        }
+                    ],
+                },
+                "episode_1.json",
+                validate=False,
+            )
+
+        service = ProjectEventService(tmp_path)
+        previous = service._build_snapshot("ad-demo")
+        assert previous["scripts"]["episode_1.json"]["kind"] == "shots"
+        assert previous["scripts"]["episode_1.json"]["items"]["E1S01"]["characters"] == ["Hero"]
+
+        script = pm.load_script("ad-demo", "episode_1.json")
+        script["shots"][0]["image_prompt"] = "new"
+        script["shots"][0]["generated_assets"]["storyboard_image"] = "storyboards/E1S01.png"
+        script["shots"].append(
+            {
+                "shot_id": "E1S02",
+                "duration_seconds": 4,
+                "characters_in_shot": [],
+                "scenes": [],
+                "props": [],
+                "image_prompt": "p",
+                "video_prompt": "v",
+                "generated_assets": _pending_assets(),
+            }
+        )
+        with project_change_source("filesystem"):
+            pm.save_script("ad-demo", script, "episode_1.json", validate=False)
+
+        mid = service._build_snapshot("ad-demo")
+        changes = service._diff_snapshots(previous, mid)
+        assert any(c["action"] == "created" and c["entity_id"] == "E1S02" for c in changes)
+        assert any(c["action"] == "storyboard_ready" and c["entity_id"] == "E1S01" for c in changes)
+        assert any(c["action"] == "updated" and c["entity_id"] == "E1S01" for c in changes)
+        assert all(c["label"].startswith("镜头") for c in changes if c["entity_type"] == "segment")
+
+        script = pm.load_script("ad-demo", "episode_1.json")
+        script["shots"][0]["generated_assets"]["video_clip"] = "videos/E1S01.mp4"
+        with project_change_source("filesystem"):
+            pm.save_script("ad-demo", script, "episode_1.json", validate=False)
+        final = service._build_snapshot("ad-demo")
+        video_changes = service._diff_snapshots(mid, final)
+        assert any(c["action"] == "video_ready" and c["entity_id"] == "E1S01" for c in video_changes)
+
+    def test_diff_snapshots_reports_drama_scene_lifecycle_events(self, tmp_path):
+        """drama(scenes) 项目的分镜级事件：created / storyboard_ready / video_ready。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("drama-demo")
+        pm.create_project_metadata("drama-demo", "Drama", "Anime", "drama")
+
+        with project_change_source("filesystem"):
+            pm.save_script(
+                "drama-demo",
+                {
+                    "episode": 1,
+                    "title": "剧集",
+                    "content_mode": "drama",
+                    "scenes": [
+                        {
+                            "scene_id": "E1S01",
+                            "duration_seconds": 8,
+                            "characters_in_scene": ["Hero"],
+                            "scenes": [],
+                            "props": [],
+                            "image_prompt": "old",
+                            "video_prompt": "old",
+                            "generated_assets": _pending_assets(),
+                        }
+                    ],
+                },
+                "episode_1.json",
+                validate=False,
+            )
+
+        service = ProjectEventService(tmp_path)
+        previous = service._build_snapshot("drama-demo")
+        assert previous["scripts"]["episode_1.json"]["kind"] == "scenes"
+        assert previous["scripts"]["episode_1.json"]["items"]["E1S01"]["characters"] == ["Hero"]
+
+        script = pm.load_script("drama-demo", "episode_1.json")
+        script["scenes"][0]["generated_assets"]["storyboard_image"] = "storyboards/E1S01.png"
+        script["scenes"][0]["generated_assets"]["video_clip"] = "videos/E1S01.mp4"
+        script["scenes"].append(
+            {
+                "scene_id": "E1S02",
+                "duration_seconds": 8,
+                "characters_in_scene": [],
+                "scenes": [],
+                "props": [],
+                "image_prompt": "p",
+                "video_prompt": "v",
+                "generated_assets": _pending_assets(),
+            }
+        )
+        with project_change_source("filesystem"):
+            pm.save_script("drama-demo", script, "episode_1.json", validate=False)
+
+        current = service._build_snapshot("drama-demo")
+        changes = service._diff_snapshots(previous, current)
+        assert any(c["action"] == "created" and c["entity_id"] == "E1S02" for c in changes)
+        assert any(c["action"] == "storyboard_ready" and c["entity_id"] == "E1S01" for c in changes)
+        assert any(c["action"] == "video_ready" and c["entity_id"] == "E1S01" for c in changes)
+        assert all(c["label"].startswith("场景") for c in changes if c["entity_type"] == "segment")
+
+    def test_diff_snapshots_reports_reference_video_unit_lifecycle_events(self, tmp_path):
+        """reference_video(video_units) 项目的分镜级事件全周期，且 characters 从 references 派生。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("ref-demo")
+        pm.create_project_metadata("ref-demo", "Ref", "Anime", "narration")
+
+        with project_change_source("filesystem"):
+            pm.save_script(
+                "ref-demo",
+                {
+                    "episode": 1,
+                    "title": "参考",
+                    "content_mode": "narration",
+                    "generation_mode": "reference_video",
+                    "video_units": [
+                        {
+                            "unit_id": "E1U01",
+                            "duration_seconds": 8,
+                            "shots": [{"duration": 4, "text": "@[Hero] 登场"}],
+                            "references": [
+                                {"type": "character", "name": "Hero"},
+                                {"type": "scene", "name": "街道"},
+                            ],
+                            "generated_assets": _pending_assets(),
+                        }
+                    ],
+                },
+                "episode_1.json",
+                validate=False,
+            )
+
+        service = ProjectEventService(tmp_path)
+        previous = service._build_snapshot("ref-demo")
+        prev_meta = previous["scripts"]["episode_1.json"]
+        assert prev_meta["kind"] == "video_units"
+        # characters 只取 references 中 type==character 的条目，不含 scene。
+        assert prev_meta["items"]["E1U01"]["characters"] == ["Hero"]
+
+        script = pm.load_script("ref-demo", "episode_1.json")
+        script["video_units"][0]["generated_assets"]["storyboard_image"] = "storyboards/E1U01.png"
+        script["video_units"][0]["references"].append({"type": "character", "name": "Villain"})
+        script["video_units"].append(
+            {
+                "unit_id": "E1U02",
+                "duration_seconds": 6,
+                "shots": [{"duration": 6, "text": "空镜"}],
+                "references": [],
+                "generated_assets": _pending_assets(),
+            }
+        )
+        with project_change_source("filesystem"):
+            pm.save_script("ref-demo", script, "episode_1.json", validate=False)
+
+        mid = service._build_snapshot("ref-demo")
+        # 新增的 reference 角色反映进 characters。
+        assert mid["scripts"]["episode_1.json"]["items"]["E1U01"]["characters"] == ["Hero", "Villain"]
+        changes = service._diff_snapshots(previous, mid)
+        assert any(c["action"] == "created" and c["entity_id"] == "E1U02" for c in changes)
+        assert any(c["action"] == "storyboard_ready" and c["entity_id"] == "E1U01" for c in changes)
+        assert any(c["action"] == "updated" and c["entity_id"] == "E1U01" for c in changes)
+        assert all(c["label"].startswith("视频单元") for c in changes if c["entity_type"] == "segment")
+
+        script = pm.load_script("ref-demo", "episode_1.json")
+        script["video_units"][0]["generated_assets"]["video_clip"] = "videos/E1U01.mp4"
+        with project_change_source("filesystem"):
+            pm.save_script("ref-demo", script, "episode_1.json", validate=False)
+        final = service._build_snapshot("ref-demo")
+        video_changes = service._diff_snapshots(mid, final)
+        assert any(c["action"] == "video_ready" and c["entity_id"] == "E1U01" for c in video_changes)
+
+    @pytest.mark.parametrize("kind", sorted(SKELETONS))
+    def test_normalize_snapshot_covers_every_skeleton_kind(self, tmp_path, kind):
+        """每个骨架种类都被 _normalize_script_snapshot 正确抽取条目——
+
+        新增第五种骨架而未在归一化里处置时，本参数化断言会为该 kind 失败，
+        而非复刻 ad/reference_video 被静默跳过的路径。
+        """
+        content_mode = {
+            "segments": "narration",
+            "scenes": "drama",
+            "shots": "ad",
+            "video_units": "narration",
+        }[kind]
+        skeleton = SKELETONS[kind]
+        item: dict = {skeleton.id_field: "X1"}
+        if skeleton.chars_field is not None:
+            item[skeleton.chars_field] = ["Hero"]
+        else:
+            item["references"] = [{"type": "character", "name": "Hero"}]
+        script = {"content_mode": content_mode, kind: [item]}
+
+        service = ProjectEventService(tmp_path)
+        normalized = service._normalize_script_snapshot(script)
+        assert normalized["kind"] == kind
+        assert "X1" in normalized["items"]
+        assert normalized["items"]["X1"]["characters"] == ["Hero"]
+        label = service._build_script_item_label("X1", normalized)
+        assert label.endswith("「X1」") and not label.startswith("「")
+
+    def test_every_skeleton_kind_has_label_noun(self):
+        """标签名词表覆盖全部骨架种类——第五种骨架出现时此处失败，逼出名词补全。"""
+        assert set(_SKELETON_ITEM_NOUNS) == set(SKELETONS)

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -497,6 +497,65 @@ class TestProjectEventService:
         video_changes = service._diff_snapshots(mid, final)
         assert any(c["action"] == "video_ready" and c["entity_id"] == "E1U01" for c in video_changes)
 
+    def test_diff_snapshots_reports_reference_video_content_edits(self, tmp_path):
+        """reference_video 单元的内容体编辑（成员镜头文本 / 场景引用）触发 updated 事件——
+
+        角色引用之外的内容改动此前不发 updated：快照只捕获 characters 与 duration，未纳成员镜头
+        文本与非角色引用，单元内容真实变更却在差分里恒等。
+        """
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("ref-edit")
+        pm.create_project_metadata("ref-edit", "Ref", "Anime", "narration")
+
+        with project_change_source("filesystem"):
+            pm.save_script(
+                "ref-edit",
+                {
+                    "episode": 1,
+                    "title": "参考",
+                    "content_mode": "narration",
+                    "generation_mode": "reference_video",
+                    "video_units": [
+                        {
+                            "unit_id": "E1U01",
+                            "duration_seconds": 8,
+                            "shots": [{"duration": 4, "text": "@[Hero] 登场"}],
+                            "references": [{"type": "character", "name": "Hero"}],
+                            "generated_assets": _pending_assets(),
+                        }
+                    ],
+                },
+                "episode_1.json",
+                validate=False,
+            )
+
+        service = ProjectEventService(tmp_path)
+        previous = service._build_snapshot("ref-edit")
+
+        # 仅改成员镜头文本，不动角色 / 时长 / 资产。
+        script = pm.load_script("ref-edit", "episode_1.json")
+        script["video_units"][0]["shots"][0]["text"] = "@[Hero] 转身离去"
+        with project_change_source("filesystem"):
+            pm.save_script("ref-edit", script, "episode_1.json", validate=False)
+        after_text = service._build_snapshot("ref-edit")
+        assert after_text["scripts"]["episode_1.json"]["items"]["E1U01"]["shots"] == [
+            {"text": "@[Hero] 转身离去", "duration": 4}
+        ]
+        text_changes = service._diff_snapshots(previous, after_text)
+        assert any(c["action"] == "updated" and c["entity_id"] == "E1U01" for c in text_changes)
+
+        # 追加场景引用（非角色）：触发 updated 且派生进 scenes（不误入 characters）。
+        script = pm.load_script("ref-edit", "episode_1.json")
+        script["video_units"][0]["references"].append({"type": "scene", "name": "码头"})
+        with project_change_source("filesystem"):
+            pm.save_script("ref-edit", script, "episode_1.json", validate=False)
+        after_scene = service._build_snapshot("ref-edit")
+        scene_item = after_scene["scripts"]["episode_1.json"]["items"]["E1U01"]
+        assert scene_item["scenes"] == ["码头"]
+        assert scene_item["characters"] == ["Hero"]
+        scene_changes = service._diff_snapshots(after_text, after_scene)
+        assert any(c["action"] == "updated" and c["entity_id"] == "E1U01" for c in scene_changes)
+
     @pytest.mark.parametrize("kind", sorted(SKELETONS))
     def test_normalize_snapshot_covers_every_skeleton_kind(self, tmp_path, kind):
         """每个骨架种类都被 _normalize_script_snapshot 正确抽取条目——


### PR DESCRIPTION
## 问题

项目事件快照归一化用「非 narration 即 scenes」二值兜底读条目数组，ad 的 `shots` 与参考生视频的 `video_units` 全部落空，差分两侧恒为空——这两类项目的分镜级实时事件（镜头新建 / 分镜图就绪 / 视频就绪 / 条目更新）恒不发出。该路径此前无回归覆盖，正是 bug 溜过的原因。

## 修复

- `_normalize_script_snapshot` 改经取证解析器（`resolve_script_kind`）判别骨架种类 + 查 `SKELETONS` 取条目数组键，取代二值兜底。
- `video_units` 无逐条角色字段（`chars_field=None` 的显式决策），角色从条目 `references` 中 `type == "character"` 派生。
- 条目名词按四骨架 kind 补全（`分镜` / `场景` / `镜头` / `视频单元`）；名词 i18n 化为独立议题，不在本 PR。
- 快照差分与 SSE 广播机制本体零改动，其对 ad/参考的正确性由上述修复兑现。

### 审查补充

本地审查（xhigh code-review）另发现：参考生视频单元仅改成员镜头文本或场景/道具引用时，`updated` 事件不发（快照只捕获角色与时长）。已一并修复——归一化从 `references` 派生角色/场景/道具（与状态计算同规则），并纳入成员镜头文本/时长内容体，使单元内容真实变更如实进差分。

## 范围说明

参考生视频 / ad 完整表面另有若干缺口超出本 issue 圈定范围（ad+参考生视频组合的 `video_ready`、前端 reference_unit 深链锚点、分组通知名词），本 PR 不卷入，另行处置。

## 验证

- 新增 ad(shots) / drama(scenes) / reference_video(video_units) 三路快照差分回归测试，覆盖 created / storyboard_ready / video_ready / updated 全周期。
- 新增参考生视频单元内容体编辑（镜头文本 / 场景引用）触发 updated 的回归。
- 骨架种类穷尽性参数化断言：新增第五种骨架未在归一化处置时会失败，杜绝再次静默跳过。
- 全量 pytest 5568 passed；ruff + basedpyright 0 error；narration 既有用例不回归。

## 父 issue

PRD #994（剧本骨架收口）。设计权威：`docs/adr/0045-script-skeleton-registry-dual-resolvers.md`。

Closes #998

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 剧本快照支持按骨架类型自动解析条目，返回统一的 `items` 结构，并补充 `kind` 信息。
  * 镜头信息会进行统一归一化，输出更一致的文本与时长展示。
  * 事件标签命名基于脚本的骨架类型生成，条目名更贴合对应内容（含默认回退）。
* **Bug 修复**
  * 改进角色/场景/道具等内容的派生逻辑，减少因逐条字段缺失导致的数据不完整或误归类。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->