### PR TITLE
test(script): 散落骨架映射专测删留收尾与 ADR/CONTEXT 文档定稿 [PRD #994]

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -193,7 +193,7 @@ _Avoid_: 在新代码/文档里用 clue/线索 指代场景或道具——规范
 ### 剧本与分镜
 
 **骨架（skeleton / 骨架种类 skeleton kind）**：
-剧本条目数组的结构种类，四值：`segments`（说书片段）/ `scenes`（剧集场景）/ `shots`（广告镜头）/ `video_units`（参考生视频单元）。骨架是由 content_mode 与 generation_mode 两轴**派生**的概念，本身不是第三条轴：narration/drama/ad 各对应前三种骨架；narration/drama 在 generation_mode=reference_video 下整体换用 video_units 骨架，ad 骨架恒为 shots、不随生成路径变（见 `docs/adr/0033`）。对骨架有两种合法提问——**规范性**（按项目/剧集的模式配置，这份剧本*应该*是什么骨架）与**取证性**（这份剧本数据*实际*是什么骨架）；两者在部分迁移等中间态下可能不一致，取证以数据形状优先。
+剧本条目数组的结构种类，四值：`segments`（说书片段）/ `scenes`（剧集场景）/ `shots`（广告镜头）/ `video_units`（参考生视频单元）。骨架是由 content_mode 与 generation_mode 两轴**派生**的概念，本身不是第三条轴：narration/drama/ad 各对应前三种骨架；narration/drama 在 generation_mode=reference_video 下整体换用 video_units 骨架，ad 骨架恒为 shots、不随生成路径变（见 `docs/adr/0033`）。对骨架有两种合法提问——**规范性**（按项目/剧集的模式配置，这份剧本*应该*是什么骨架）与**取证性**（这份剧本数据*实际*是什么骨架）；两者在部分迁移等中间态下可能不一致，取证以数据形状优先。骨架知识收归零依赖叶子模块 `lib/script_skeleton.py`：以骨架种类为键的窄表 `SKELETONS`（键即条目数组键，行 `Skeleton(id_field, chars_field)`，`video_units` 无逐条角色名单故 `chars_field=None`）+ **规范解析** `resolve_declared_kind(content_mode, generation_mode)`（服务手持项目配置的消费方，未知/缺失 content_mode 抛 `ValueError`）+ **取证解析** `resolve_script_kind(script)`（服务手持剧本数据的消费方，保留数据形状优先的容忍阶梯）；两个解析器是全体消费方分派骨架的单一入口，设计依据见 `docs/adr/0045`。
 _Avoid_: 把骨架当第四个 content_mode 或 content_mode 的同义词（三值轴推不出四种骨架）；把规范性与取证性两问混同（配置已改 reference_video 但数据仍在 segments 时，编辑要跟数据走）；对未知模式做「非 narration 即 drama」式二值兜底（`docs/adr/0033` 禁令）。
 
 **宫格（grid）**：

--- a/docs/adr/0045-script-skeleton-registry-dual-resolvers.md
+++ b/docs/adr/0045-script-skeleton-registry-dual-resolvers.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # 剧本骨架注册表以骨架种类为键，轴交互收口进规范/取证双解析器
@@ -26,4 +26,4 @@ status: proposed
 - 落地实现时，`project_events` 快照 bug 的修复随本收口的实现一并交付（不单独出临时修复 PR），ad 与 reference_video 项目届时恢复分镜级事件推送；video_units 条目快照的 `characters` 从 `references` 过滤 character 类型派生。
 - `script_shape()` 兜底删除是行为变更，现有 4 个注册表消费方的传值须逐个核对。
 - 约 45 处 content_mode 字面量分派须三分类处置：骨架-结构类（迁移查表/解析器）、内容-行为类（step1 路径、prompt 选择——content_mode 轴的正当业务分派，保留）、轴交互业务规则（如 ad / reference_video 跳过分镜估价，保留）；分类清单、PR 切分与散落分派测试的删留归 PRD 阶段。
-- 本 ADR status=proposed：`SKELETONS` / `script_skeleton` 等新名待实现落盘后再写入 `CONTEXT.md`（「骨架」概念本身描述现状，已收录）。后续 PR 若想引入复合键、把行为写入注册表、或恢复静默兜底，须先 deprecate 本 ADR。
+- 本 ADR status=accepted：设计已落地为 `lib/script_skeleton.py`（`SKELETONS` 窄表 + 规范解析 `resolve_declared_kind` + 取证解析 `resolve_script_kind`），实现落盘后的新名已写入 `CONTEXT.md`「骨架」条。后续 PR 若想引入复合键、把行为写入注册表、或恢复静默兜底，须先 deprecate 本 ADR。

--- a/tests/test_script_editor.py
+++ b/tests/test_script_editor.py
@@ -102,61 +102,11 @@ class TestResolveItems:
         assert kind == "segments"
         assert len(items) == 2
 
-    def test_drama(self):
-        _items, id_field, kind = resolve_items(_drama())
-        assert id_field == "scene_id"
-        assert kind == "scenes"
-
-    def test_reference_data_shape_picks_video_units(self):
-        # video_units 唯一存在(无 segments/scenes)时走 video_units——按数据形状路由,
-        # 与 generation_mode / content_mode 标记无关。
-        _items, id_field, kind = resolve_items(_reference())
-        assert id_field == "unit_id"
-        assert kind == "video_units"
-
-    def test_partial_migration_data_shape_wins_over_generation_mode(self):
-        # partial migration 中间态:generation_mode 改成了 reference_video 但数据还在 segments,
-        # 数据形状优先让 agent 仍能通过 MCP 工具编辑 segments(旧版让 generation_mode 单向赢
-        # 会导致 resolve_items 返回 [],按 id 编辑都报"未找到",整集脚本对所有工具不可触达)。
-        script = {
-            "title": "标题",
-            "content_mode": "narration",
-            "generation_mode": "reference_video",
-            "episode": 1,
-            "summary": "摘要",
-            "novel": {"title": "小说", "chapter": "第一章"},
-            "segments": [_segment("E1S01")],
-        }
-        items, id_field, kind = resolve_items(script)
-        assert kind == "segments"
-        assert id_field == "segment_id"
-        assert len(items) == 1
-        assert items[0]["segment_id"] == "E1S01"
-
     def test_returned_list_is_live_reference(self):
         script = _narration()
         items, _id, _kind = resolve_items(script)
         items.append(_segment("E1S03"))
         assert len(script["segments"]) == 3
-
-    def test_stray_video_units_do_not_hijack_storyboard_script(self):
-        # 历史脏数据：storyboard 脚本被误塞游离 video_units（无 generation_mode/content_mode）。
-        # video_units 与 segments 并存时不认定为 reference，编辑/metadata 仍作用于真实 segments。
-        script = {
-            "segments": [_segment("E1S01"), _segment("E1S02")],
-            "video_units": [{"unit_id": "E1U1", "generated_assets": {"status": "pending"}}],
-        }
-        items, id_field, kind = resolve_items(script)
-        assert kind == "segments"
-        assert id_field == "segment_id"
-        assert len(items) == 2
-
-    def test_bare_video_units_without_segments_is_reference(self):
-        # video_units 为唯一结构（无 segments/scenes、无显式 mode）→ 仍判为 reference
-        script = {"video_units": [{"unit_id": "E1U1"}]}
-        _items, id_field, kind = resolve_items(script)
-        assert kind == "video_units"
-        assert id_field == "unit_id"
 
     def test_missing_key_is_empty_list(self):
         # 内容数组键缺失 → 空列表（合法的「空草稿」），不报错

--- a/tests/test_script_skeleton.py
+++ b/tests/test_script_skeleton.py
@@ -114,6 +114,12 @@ class TestScriptResolver:
         # content_mode=narration 但数据落 scenes 键（无 segments）→ 回退 scenes。
         assert resolve_script_kind({"content_mode": "narration", "scenes": []}) == "scenes"
 
+    def test_generation_mode_ignored_data_shape_wins(self):
+        # partial migration 中间态：generation_mode 已改 reference_video 但数据仍在
+        # segments——取证解析不读 generation_mode，按数据形状返回 segments，编辑能力不丢失。
+        script = {"content_mode": "narration", "generation_mode": "reference_video", "segments": []}
+        assert resolve_script_kind(script) == "segments"
+
     def test_step4_key_existence_inference_when_content_mode_absent(self):
         assert resolve_script_kind({"scenes": []}) == "scenes"
         assert resolve_script_kind({"shots": []}) == "shots"

--- a/tests/test_script_skeleton.py
+++ b/tests/test_script_skeleton.py
@@ -105,6 +105,12 @@ class TestScriptResolver:
         # 游离 video_units 不抢走 storyboard 脚本的判别。
         assert resolve_script_kind({"video_units": [], "segments": [], "content_mode": "narration"}) == "segments"
 
+    def test_step1_floating_video_units_hijack_guard_without_content_mode(self):
+        # 游离 video_units + segments 并存但无 content_mode：step1 守卫仍挡住 video_units 抢判，
+        # 缺 content_mode 落键存在性阶梯（step4/终兜底）返回 segments。覆盖历史脏数据 storyboard
+        # 脚本（被误塞游离 video_units、无 content_mode 戳）不被误判为 reference 的取证路径。
+        assert resolve_script_kind({"video_units": [], "segments": []}) == "segments"
+
     def test_step2_content_mode_authority(self):
         assert resolve_script_kind({"content_mode": "ad"}) == "shots"
         assert resolve_script_kind({"content_mode": "drama"}) == "scenes"

--- a/tests/test_status_calculator.py
+++ b/tests/test_status_calculator.py
@@ -482,27 +482,11 @@ class TestStatusCalculator:
 class TestAdStatusCalculation:
     """广告/短片模式（平铺 shots[]）的状态与统计计算。"""
 
-    def test_select_ad_mode_and_items(self):
-        kind, items = StatusCalculator._select_kind_and_items({"content_mode": "ad", "shots": [{"shot_id": "E1S01"}]})
-        assert kind == "shots"
-        assert len(items) == 1
-
     def test_select_ad_by_duck_typing_when_content_mode_absent(self):
+        # 本地 legacy 容忍：缺 content_mode 的存量 ad 剧本按 shots 键鸭子推断（矩阵不覆盖本地阶梯）。
         kind, items = StatusCalculator._select_kind_and_items({"shots": [{"shot_id": "E1S01"}]})
         assert kind == "shots"
         assert len(items) == 1
-
-    def test_ad_with_reference_generation_mode_still_dispatches_shots(self):
-        """ad 剧本骨架唯一：残留 generation_mode 戳也按 shots 分派，不找 video_units。"""
-        kind, items = StatusCalculator._select_kind_and_items(
-            {
-                "content_mode": "ad",
-                "generation_mode": "reference_video",
-                "shots": [{"shot_id": "E1S01"}, {"shot_id": "E1S02"}],
-            }
-        )
-        assert kind == "shots"
-        assert len(items) == 2
 
     def test_calculate_episode_stats_for_ad(self, tmp_path):
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))

--- a/tests/test_storyboard_sequence.py
+++ b/tests/test_storyboard_sequence.py
@@ -10,26 +10,6 @@ from lib.storyboard_sequence import (
 
 
 class TestStoryboardSequence:
-    def test_get_storyboard_items_supports_narration_and_drama(self):
-        narration = {"content_mode": "narration", "segments": [{"segment_id": "E1S01"}]}
-        drama = {"content_mode": "drama", "scenes": [{"scene_id": "E1S01"}]}
-
-        narration_items = get_storyboard_items(narration)
-        drama_items = get_storyboard_items(drama)
-
-        assert narration_items[1:] == (
-            "segment_id",
-            "characters_in_segment",
-            "scenes",
-            "props",
-        )
-        assert drama_items[1:] == (
-            "scene_id",
-            "characters_in_scene",
-            "scenes",
-            "props",
-        )
-
     def test_resolve_previous_storyboard_path_respects_first_item_and_segment_break(self, tmp_path: Path):
         project_path = tmp_path / "demo"
         (project_path / "storyboards").mkdir(parents=True)
@@ -132,17 +112,21 @@ _SCRIPT_BY_KIND = {
 
 
 class TestStoryboardSkeletonExhaustiveness:
-    """穷尽性断言：get_storyboard_items 的 char_field 覆盖 SKELETONS 全部键。
+    """穷尽性断言：get_storyboard_items 的 id_field / char_field 覆盖 SKELETONS 全部键。
 
-    char_field 直接查 SKELETONS，第五种骨架加入时 _SCRIPT_BY_KIND 未登记即报红。
+    id_field / char_field 直接查 SKELETONS，第五种骨架加入时 _SCRIPT_BY_KIND 未登记即报红；
+    原按模式硬编码的 narration/drama 映射断言收敛到此。
     """
 
     @pytest.mark.parametrize("kind", list(_SCRIPT_BY_KIND))
-    def test_get_storyboard_items_char_field_matches_registry(self, kind):
+    def test_get_storyboard_items_fields_match_registry(self, kind):
         from lib.script_skeleton import SKELETONS
 
         # 遍历 SKELETONS 全键：新增第五种骨架而 _SCRIPT_BY_KIND 未登记即 KeyError 报红。
         assert set(_SCRIPT_BY_KIND) == set(SKELETONS)
 
-        _items, _id_field, char_field, _scenes, _props = get_storyboard_items(_SCRIPT_BY_KIND[kind])
+        _items, id_field, char_field, scenes_field, props_field = get_storyboard_items(_SCRIPT_BY_KIND[kind])
+        assert id_field == SKELETONS[kind].id_field
         assert char_field == SKELETONS[kind].chars_field
+        # scenes / props 资产键为项目级常量，不随骨架变。
+        assert (scenes_field, props_field) == ("scenes", "props")


### PR DESCRIPTION
## 范围

剧本骨架收口 PRD #994 的收尾批次：**只动测试与文档**，不改产品/源代码。落实散落骨架映射专测的删留清单、定稿 ADR 0045、CONTEXT.md 收录实现新名。

## 变更

- `tests/test_script_editor.py`：删 4 个 `resolve_items` 判别用例（drama、reference 数据形状路由、partial-migration 数据形状优先、stray/bare video_units），仅留 resolve_items 自身契约与非 list/null fail-loud 留守；判别语义迁入集中矩阵。
- `tests/test_status_calculator.py`：删 2 个纯映射专测（ad→shots、ad+reference→shots，`resolve_declared_kind` 矩阵已覆盖）；本地 legacy 鸭子类型/优先级行为测试保留并标注「矩阵不覆盖本地阶梯」。
- `tests/test_storyboard_sequence.py`：删按模式硬编码的 narration/drama 映射断言，穷尽性参数化断言从 char_field 扩为同测 id_field + scenes/props 常量，遍历 SKELETONS 全键。
- `tests/test_script_skeleton.py`：集中矩阵补 `test_generation_mode_ignored_data_shape_wins`（partial-migration 台阶）；**本地审查补** `test_step1_floating_video_units_hijack_guard_without_content_mode`——闭合被删 stray-video_units 用例其 content_mode 缺失变体在矩阵中无对应行的覆盖缺口。
- `docs/adr/0045-*`：status proposed → accepted，正文记录落盘实现名。
- `CONTEXT.md`：「骨架」条收录 `lib/script_skeleton.py` / `SKELETONS` / 规范解析 `resolve_declared_kind` / 取证解析 `resolve_script_kind`。

## 验收清单

- [x] 本地已跑相关测试：`uv run pytest`（全量 5583 passed）+ 骨架/消费方模块定向组 132 passed
- [x] 手动核对每处删除断言在集中矩阵/穷尽性断言中有对应覆盖，无断言被静默丢弃
- [x] 无新增面向用户文案（测试+文档）
- [x] `uv run ruff check .` 通过；`uv run basedpyright` 0 error
- [x] ADR 0045 = accepted；CONTEXT.md 新名与 `lib/script_skeleton.py` 实现一致

## 已知 defer

- 无

Closes #1000


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 统一了脚本“骨架”类型的识别规则，增强了不同内容形态的自动判别能力。
  * 补充了更清晰的骨架分类说明，便于理解不同脚本结构的对应关系。

* **Bug 修复**
  * 提升了在缺少部分字段时的判别稳定性，减少误判为不合适骨架类型的情况。
  * 调整了故事板项的字段一致性校验，结果更符合预期。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->