### PR TITLE
fix(config): 供应商 base_url 收敛为 DB 配置唯一来源，移除环境变量兜底与隐式路由覆盖

### DIFF
--- a/lib/config/url_utils.py
+++ b/lib/config/url_utils.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 from urllib.parse import urlparse
 
@@ -14,13 +13,12 @@ def is_official_openai_base_url(base_url: str | None) -> bool:
     应改用 max_completion_tokens；第三方兼容端点（vLLM、各类中转）对新
     参数支持情况不一，须保守沿用 max_tokens。
 
-    base_url 为空（None/空白串）时，openai SDK 会回落到 OPENAI_BASE_URL
-    环境变量，再回落到官方端点，此处判定与 SDK 行为保持一致。
+    base_url 只来自 DB 配置（唯一来源），为空（None/空白串）时判定为官方端点。
 
     已知限制：指向中转/代理的 base_url 一律判非官方，若中转将 max_tokens
     原样转发给官方推理模型仍会被拒（显式 400，报错信息自描述）。
     """
-    effective = (base_url or "").strip() or (os.environ.get("OPENAI_BASE_URL") or "").strip()
+    effective = (base_url or "").strip()
     if not effective:
         return True
     # hostname 自带小写化与去端口；无 scheme 时 hostname 为 None → 保守判非官方

--- a/lib/config/url_utils.py
+++ b/lib/config/url_utils.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 import re
 from urllib.parse import urlparse
 
+# 官方 OpenAI 端点：既是 is_official_openai_base_url 的判定基准，也是上层
+# 客户端工厂在 base_url 为空时须显式回填的默认值——AsyncOpenAI 对空 base_url
+# 会回落读取 OPENAI_BASE_URL 环境变量，显式传入官方值即断掉该回落。单一来源，
+# 勿散落字面量。
+OFFICIAL_OPENAI_HOSTNAME = "api.openai.com"
+OFFICIAL_OPENAI_BASE_URL = f"https://{OFFICIAL_OPENAI_HOSTNAME}/v1"
+
 
 def is_official_openai_base_url(base_url: str | None) -> bool:
     """判断 OpenAI 兼容 base_url 是否指向官方 api.openai.com。
@@ -22,7 +29,7 @@ def is_official_openai_base_url(base_url: str | None) -> bool:
     if not effective:
         return True
     # hostname 自带小写化与去端口；无 scheme 时 hostname 为 None → 保守判非官方
-    return urlparse(effective).hostname == "api.openai.com"
+    return urlparse(effective).hostname == OFFICIAL_OPENAI_HOSTNAME
 
 
 def ensure_openai_base_url(url: str | None) -> str | None:

--- a/lib/openai_shared.py
+++ b/lib/openai_shared.py
@@ -17,6 +17,8 @@ import logging
 
 from openai import AsyncOpenAI
 
+from lib.config.url_utils import OFFICIAL_OPENAI_BASE_URL
+
 logger = logging.getLogger(__name__)
 
 OPENAI_RETRYABLE_ERRORS: tuple[type[Exception], ...] = ()
@@ -52,12 +54,15 @@ def create_openai_client(
     base_url: str | None = None,
     max_retries: int | None = None,
 ) -> AsyncOpenAI:
-    """创建 AsyncOpenAI 客户端，统一处理 api_key 和 base_url。"""
-    kwargs: dict = {}
+    """创建 AsyncOpenAI 客户端，统一处理 api_key 和 base_url。
+
+    base_url 为空（None/空白）时显式回填官方端点：AsyncOpenAI 对空 base_url
+    会回落读取 OPENAI_BASE_URL 环境变量，环境残留将静默覆盖 DB 配置。base_url
+    的唯一来源是 DB，此处兜死显式值断掉该回落路径。
+    """
+    kwargs: dict = {"base_url": (base_url or "").strip() or OFFICIAL_OPENAI_BASE_URL}
     if api_key:
         kwargs["api_key"] = api_key
-    if base_url:
-        kwargs["base_url"] = base_url
     if max_retries is not None:
         kwargs["max_retries"] = max_retries
     return AsyncOpenAI(**kwargs)

--- a/tests/test_normalize_base_url.py
+++ b/tests/test_normalize_base_url.py
@@ -9,18 +9,18 @@ from lib.config.url_utils import (
 
 
 class TestIsOfficialOpenAIBaseURL:
-    """官方端点判定：决定 OpenAI 后端的输出上限参数名。"""
+    """官方端点判定：决定 OpenAI 后端的输出上限参数名。
 
-    def test_none_without_env_is_official(self, monkeypatch):
-        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    base_url 只来自 DB 配置，不读取任何环境变量。
+    """
+
+    def test_none_is_official(self):
         assert is_official_openai_base_url(None) is True
 
-    def test_empty_string_without_env_is_official(self, monkeypatch):
-        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    def test_empty_string_is_official(self):
         assert is_official_openai_base_url("") is True
 
-    def test_whitespace_without_env_is_official(self, monkeypatch):
-        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    def test_whitespace_is_official(self):
         assert is_official_openai_base_url("   ") is True
 
     def test_official_url_is_official(self):
@@ -39,21 +39,15 @@ class TestIsOfficialOpenAIBaseURL:
     def test_url_without_scheme_is_not_official(self):
         assert is_official_openai_base_url("api.openai.com/v1") is False
 
-    def test_env_whitespace_only_treated_as_unset(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_BASE_URL", "   ")
-        assert is_official_openai_base_url(None) is True
-
-    def test_env_relay_overrides_empty_base_url(self, monkeypatch):
+    def test_env_var_does_not_affect_empty_base_url(self, monkeypatch):
         monkeypatch.setenv("OPENAI_BASE_URL", "https://relay.example.com/v1")
-        assert is_official_openai_base_url(None) is False
-
-    def test_env_official_with_empty_base_url(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
         assert is_official_openai_base_url(None) is True
+        assert is_official_openai_base_url("") is True
 
-    def test_explicit_base_url_ignores_env(self, monkeypatch):
+    def test_env_var_does_not_affect_explicit_base_url(self, monkeypatch):
         monkeypatch.setenv("OPENAI_BASE_URL", "https://relay.example.com/v1")
         assert is_official_openai_base_url("https://api.openai.com/v1") is True
+        assert is_official_openai_base_url("https://vllm.internal:8000/v1") is False
 
 
 class TestNormalizeBaseUrl:

--- a/tests/test_openai_shared.py
+++ b/tests/test_openai_shared.py
@@ -1,0 +1,25 @@
+"""create_openai_client 客户端工厂行为。"""
+
+from lib.config.url_utils import OFFICIAL_OPENAI_BASE_URL
+from lib.openai_shared import create_openai_client
+
+
+class TestCreateOpenAIClientBaseURL:
+    """base_url 唯一来源为 DB 配置：空值兜死官方端点，环境变量不得静默覆盖路由。"""
+
+    def test_empty_base_url_ignores_env_var(self, monkeypatch):
+        # AsyncOpenAI 对空 base_url 会回落读 OPENAI_BASE_URL，工厂须显式兜死官方值
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://relay.example.com/v1")
+        client = create_openai_client(api_key="x", base_url=None)
+        assert str(client.base_url).rstrip("/") == OFFICIAL_OPENAI_BASE_URL.rstrip("/")
+
+    def test_whitespace_base_url_ignores_env_var(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://relay.example.com/v1")
+        client = create_openai_client(api_key="x", base_url="   ")
+        assert str(client.base_url).rstrip("/") == OFFICIAL_OPENAI_BASE_URL.rstrip("/")
+
+    def test_explicit_base_url_preserved(self, monkeypatch):
+        # 显式 base_url 原样透传，不被环境变量或官方默认值篡改
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://relay.example.com/v1")
+        client = create_openai_client(api_key="x", base_url="https://vllm.internal:8000/v1")
+        assert str(client.base_url).rstrip("/") == "https://vllm.internal:8000/v1"

--- a/tests/test_openai_text_backend.py
+++ b/tests/test_openai_text_backend.py
@@ -476,8 +476,7 @@ class TestInstructorFallback:
 class TestMaxOutputTokens:
     """官方端点用 max_completion_tokens，兼容端点保守沿用 max_tokens。"""
 
-    async def test_official_plain_passes_max_completion_tokens(self, monkeypatch):
-        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    async def test_official_plain_passes_max_completion_tokens(self):
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("ok"))
         with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
@@ -490,8 +489,7 @@ class TestMaxOutputTokens:
         assert call_kwargs["max_completion_tokens"] == 32000
         assert "max_tokens" not in call_kwargs
 
-    async def test_official_structured_passes_max_completion_tokens(self, monkeypatch):
-        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    async def test_official_structured_passes_max_completion_tokens(self):
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(json.dumps({"name": "x"})))
         with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
@@ -507,8 +505,7 @@ class TestMaxOutputTokens:
         assert call_kwargs["max_completion_tokens"] == 24000
         assert "max_tokens" not in call_kwargs
 
-    async def test_no_max_tokens_means_key_absent(self, monkeypatch):
-        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    async def test_no_max_tokens_means_key_absent(self):
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("ok"))
         with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
@@ -547,9 +544,8 @@ class TestMaxOutputTokens:
         assert call_kwargs["max_completion_tokens"] == 32000
         assert "max_tokens" not in call_kwargs
 
-    async def test_official_dict_schema_fallback_uses_max_completion_tokens(self, monkeypatch):
+    async def test_official_dict_schema_fallback_uses_max_completion_tokens(self):
         """dict-schema 降级路径（json_object 模式）也按端点选参数。"""
-        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
         mock_client = AsyncMock()
         fallback_json = json.dumps({"name": "x"})
         mock_client.chat.completions.create = AsyncMock(
@@ -593,9 +589,8 @@ class TestMaxOutputTokens:
         assert second_call_kwargs["max_tokens"] == 8000
         assert "max_completion_tokens" not in second_call_kwargs
 
-    async def test_official_instructor_fallback_uses_max_completion_tokens(self, monkeypatch):
+    async def test_official_instructor_fallback_uses_max_completion_tokens(self):
         """Pydantic instructor 降级路径端到端穿透到 create_with_completion。"""
-        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(side_effect=_make_bad_request_error())
 


### PR DESCRIPTION
## 范围

- **动**：OpenAI 兼容供应商的 base_url 解析与客户端构造（`lib/config/url_utils.py`、`lib/openai_shared.py`）。使 base_url 唯一来源收敛为 DB 配置。
- **不动**：密钥围堵机制（启动断言 / `options.env` 空值覆盖 / Bash 剥离，`lib/config/env_keys.py`）——常驻机制，`OPENAI_BASE_URL` 仍在空值覆盖名单以防泄漏进子进程；api_key 空值时 SDK 读 `OPENAI_API_KEY` 的同类行为属围堵范畴，本 PR 不涉及。

## 变更

- `is_official_openai_base_url` 移除对 `OPENAI_BASE_URL` 进程环境变量的兜底，判定只取 DB 传入的 base_url；空值仍判官方端点。
- `create_openai_client` 在 base_url 为空（None/空白）时**显式回填**官方端点，杜绝 `AsyncOpenAI` 对空 base_url 回落读取 `OPENAI_BASE_URL` 静默覆盖实际路由——修复解析与实际路由失联（否则官方参数 `max_completion_tokens` 可能打到只认 `max_tokens` 的中转返回 400）。
- 官方端点抽为 `url_utils` 单一常量（`OFFICIAL_OPENAI_HOSTNAME` / `OFFICIAL_OPENAI_BASE_URL`），判定基准与默认回填共用，不散落字面量。
- 测试：`test_normalize_base_url.py` 改写为验证「环境变量不影响判定」；新增 `test_openai_shared.py` 断言空 base_url + 环境残留时客户端仍路由官方端点；`test_openai_text_backend.py` 清理过时 delenv 脚手架。

## 验收清单

- [x] 本地已跑相关测试：`uv run python -m pytest`（5585 passed）、`ruff check/format`、`basedpyright`（0 error）
- [x] 手动验证：openai 2.42.0 下确证空 base_url + 设 `OPENAI_BASE_URL` 时旧行为会把 client 路由到中转，修复后 `client.base_url` 恒为官方端点
- [x] 新增面向用户文案已加 zh/en 翻译（如适用）：不适用，纯内部逻辑无用户可见文案
- [x] 无新增 ESLint disable
- [x] CODEOWNERS 要求的 review 已请求

## 已知 defer

- 无

Closes #1004


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 现在会优先使用官方 OpenAI 端点，避免因环境变量导致的连接地址不一致。
* **Bug 修复**
  * 修正了空白或未提供 `base_url` 时的判断逻辑，确保默认使用官方地址。
  * 显式配置的地址将按原样生效，不再受环境变量干扰。
* **测试**
  * 补充并更新了相关测试，覆盖默认地址、空白值和显式地址的行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->