### PR TITLE
refactor(agent): SDK options 装配析出为持依赖装配器

### DIFF
--- a/lib/config/service.py
+++ b/lib/config/service.py
@@ -67,7 +67,7 @@ assert set(_ANTHROPIC_ENV_MAP.values()) == set(ANTHROPIC_ENV_KEYS), (
 async def build_anthropic_env_dict(session: AsyncSession) -> dict[str, str]:
     """从 DB 读 active credential，返回 {ENV_KEY: value} dict，**不写 os.environ**。
 
-    返回值由 SessionManager._build_provider_env_overrides() 注入到
+    返回值由 OptionsAssembler 的凭证注入（load_provider_env_overrides）注入到
     ClaudeAgentOptions.env。
 
     双轨期 fallback：active credential 字段为空时从 system_settings 兜底。

--- a/server/agent_runtime/options_assembler.py
+++ b/server/agent_runtime/options_assembler.py
@@ -1,0 +1,644 @@
+"""SDK options 装配器：持依赖、允许 I/O，异步 build 产出 ClaudeAgentOptions。
+
+从 SessionManager 析出会话冷启动/重连时"现场收集"的全部装配职责：DB 凭证注入
+（Anthropic 真值 + 其他供应商空值覆盖）、prompt 变体与项目上下文装配、各 PreToolUse/
+PostToolUse hook 工厂（含 JSON 校验 hook）、以及 AgentAccessPolicy 的 settings 编译与
+裁决 adapter 接线。与 AgentAccessPolicy 的 I/O 分工遵循同一判据：规则静态则零 I/O 归
+policy，装配天职是开会话时现场读 DB / 扫盘则允许 I/O 归本类。
+
+访问规则本身不在此类——policy 通过 ``access_policy_provider`` 每次 build 时现取，
+``configure_sandbox_runtime`` 整体换新 policy 后对后续所有会话立即生效。
+"""
+
+import json
+import logging
+from collections.abc import Awaitable, Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+from lib.agent_session_store import (
+    is_known_session_store_mode,
+    session_store_flush_mode,
+    session_store_mode,
+)
+from lib.agent_session_store.store import DbSessionStore
+from lib.db.base import DEFAULT_USER_ID
+from lib.db.engine import async_session_factory as default_async_session_factory
+from lib.i18n import DEFAULT_LOCALE, LOCALE_LANGUAGE_MAP
+from server.agent_runtime.agent_access_policy import AgentAccessPolicy
+from server.agent_runtime.sdk_tools import build_arcreel_mcp_server
+
+logger = logging.getLogger(__name__)
+
+from claude_agent_sdk import ClaudeAgentOptions
+from claude_agent_sdk.types import HookMatcher, SystemPromptPreset
+
+SDK_AVAILABLE = True
+
+
+async def load_provider_env_overrides() -> dict[str, str]:
+    """构造 options.env 注入字典。
+
+    - ANTHROPIC_* 从 DB active credential 取真值
+    - 其他 provider env 全部空值覆盖（防御性兜底）
+
+    环境变量名单以 ``env_keys`` 为单一真相源；SDK 子进程只认 env 认证，父进程环境
+    又是外部输入，故真值注入与空值围堵是常驻机制而非技术债（见 ADR）。
+    """
+    from lib.config.env_keys import OTHER_PROVIDER_ENV_KEYS
+    from lib.config.service import build_anthropic_env_dict
+    from lib.db import async_session_factory
+
+    async with async_session_factory() as session:
+        anthropic_env = await build_anthropic_env_dict(session)
+
+    result = dict(anthropic_env)
+    for key in OTHER_PROVIDER_ENV_KEYS:
+        result[key] = ""
+    return result
+
+
+_PERSONA_PROMPT = """\
+## 身份
+
+你是 ArcReel 智能体，一个专业的 AI 视频内容创作助手。你的职责是将小说转化为可发布的短视频内容。
+
+## 行为准则
+
+- 主动引导用户完成视频创作工作流，而不仅仅被动回答问题
+- 遇到不确定的创作决策时，向用户提出选项并给出建议，而不是自行决定
+- 涉及多步骤任务时，使用 TodoWrite 跟踪进度并向用户汇报
+- Write/Edit 不要写入代码文件（扩展名 .py/.js/.ts/.tsx/.sh/.yaml/.yml/.toml）；数据文件（.json/.md/.txt/.html/.csv 等）可以正常写入。代码逻辑应通过现有 skill 脚本完成
+- 你是用户的视频制作搭档，专业、友善、高效"""
+
+
+class OptionsAssembler:
+    """把开会话时现场收集的依赖装配成 ClaudeAgentOptions。
+
+    构造参数分两类：静态依赖（``data_dir`` / ``projects_root`` / ``allowed_tools`` /
+    ``setting_sources``）在实例化时锁定；随运行时变化的依赖用 provider 回调每次 build
+    时现取——``access_policy_provider``（``configure_sandbox_runtime`` 会整体换新）与
+    ``max_turns_provider``（``refresh_config`` 会改写）。``resolve_project_cwd`` 由
+    SessionManager 注入（项目名校验/作用域是会话管理侧职责）。
+    """
+
+    def __init__(
+        self,
+        *,
+        data_dir: Path,
+        projects_root: Path,
+        allowed_tools: Sequence[str],
+        setting_sources: Sequence[str],
+        access_policy_provider: Callable[[], AgentAccessPolicy],
+        max_turns_provider: Callable[[], int | None],
+        resolve_project_cwd: Callable[[str], Path],
+        provider_env_loader: Callable[[], Awaitable[dict[str, str]]] | None = None,
+        session_factory: Any = None,
+        user_id: str = DEFAULT_USER_ID,
+    ) -> None:
+        self.data_dir = Path(data_dir)
+        self.projects_root = Path(projects_root)
+        self._allowed_tools = list(allowed_tools)
+        self._setting_sources = list(setting_sources)
+        self._access_policy_provider = access_policy_provider
+        self._max_turns_provider = max_turns_provider
+        self._resolve_project_cwd = resolve_project_cwd
+        self._provider_env_loader = provider_env_loader
+        self._session_factory = session_factory
+        self._user_id = user_id
+        # session store 单例缓存：每个 assembler 一份，避免每次 build 都新建 store。
+        self._cached_session_store: DbSessionStore | None = None
+        self._session_store_resolved = False
+
+    async def build_provider_env_overrides(self) -> dict[str, str]:
+        """DB 凭证注入入口。默认走模块级 ``load_provider_env_overrides``（现取 module
+        global 以便测试 patch）；构造时注入 ``provider_env_loader`` 则改用注入源。"""
+        loader = self._provider_env_loader or load_provider_env_overrides
+        return await loader()
+
+    def _build_append_prompt(self, project_name: str, locale: str = DEFAULT_LOCALE) -> str:
+        """Build the append portion for SystemPromptPreset.
+
+        Combines the ArcReel persona, the locale language regulation, and the
+        session-invariant project context (identity, cwd, operating rules).
+        Mutable project metadata is not included here — it lives in project.json
+        and is read on demand. The project's CLAUDE.md (mode variant projected
+        into the cwd) is auto-loaded by the SDK via setting_sources=["project"].
+        """
+        parts = [_PERSONA_PROMPT]
+
+        lang = LOCALE_LANGUAGE_MAP.get(locale, "中文")
+        parts.append(
+            f"\n## 语言规范\n\n"
+            f"- **回答用户必须使用{lang}**：所有回复、思考过程、任务清单及计划文件，均须使用{lang}\n"
+            f"- **视频内容语言**：所有生成的视频对话、旁白、字幕均使用{lang}\n"
+            f"- **文档使用{lang}**：所有的 Markdown 文件均使用{lang}编写\n"
+            f"- **Prompt 使用{lang}**：图片生成/视频生成使用的 prompt 应使用{lang}编写"
+        )
+
+        project_context = self._build_project_context(project_name)
+        if project_context:
+            parts.append(project_context)
+
+        return "\n".join(parts)
+
+    def _build_project_context(self, project_name: str) -> str:
+        """Build session-invariant project context for the system prompt.
+
+        Holds only facts that cannot change within a session: project identity,
+        cwd, and static operating rules. Mutable metadata (title, style,
+        overview, ...) lives in project.json and is read on demand by the agent
+        and tools — never baked into the session-fixed system prompt.
+        """
+        try:
+            project_cwd = self._resolve_project_cwd(project_name)
+        except (ValueError, FileNotFoundError):
+            return ""
+
+        parts = [
+            "## 当前项目上下文",
+            "",
+            f"- 项目标识：{project_name}",
+            f"- 项目目录（即当前工作目录 cwd）：{project_cwd.as_posix()}",
+            "- 项目元数据（标题、风格、概述等）存于 project.json，需要时读取。",
+            "- Bash 命令必须写在单行，禁止使用 `\\` 换行，JSON 参数使用紧凑格式。",
+        ]
+        return "\n".join(parts)
+
+    def build_session_store(self) -> DbSessionStore | None:
+        """Return a cached per-user DbSessionStore, or None when env disables it.
+
+        Set ARCREEL_SDK_SESSION_STORE=off to roll back to SDK's filesystem path.
+        The result is cached on first call so every session shares one instance
+        instead of allocating a fresh store per ``build`` invocation.
+        """
+        if self._cached_session_store is not None or self._session_store_resolved:
+            return self._cached_session_store
+
+        mode = session_store_mode()
+        store: DbSessionStore | None
+        if mode == "off":
+            store = None
+        else:
+            if not is_known_session_store_mode(mode):
+                logger.warning("Unknown ARCREEL_SDK_SESSION_STORE=%r; defaulting to db", mode)
+            factory = self._session_factory or default_async_session_factory
+            store = DbSessionStore(factory, user_id=self._user_id)
+        self._cached_session_store = store
+        self._session_store_resolved = True
+        return store
+
+    async def build(
+        self,
+        project_name: str,
+        resume_id: str | None = None,
+        can_use_tool: Callable[[str, dict[str, Any], Any], Any] | None = None,
+        locale: str = DEFAULT_LOCALE,
+        stderr: Callable[[str], None] | None = None,
+    ) -> Any:
+        """Build ClaudeAgentOptions for a session.
+
+        ``stderr`` 在 SDK 子进程退出非 0 时是唯一拿到真实错误的途径
+        （``ProcessError.stderr`` 在 SDK 内部被写死为占位符）；上层应在
+        会话启动失败时把回调累积的行包装到 ``AgentStartupError`` 透传。
+        """
+        if not SDK_AVAILABLE or ClaudeAgentOptions is None:
+            raise RuntimeError("claude_agent_sdk is not installed")
+
+        policy = self._access_policy_provider()
+
+        transcripts_dir = self.data_dir / "transcripts"
+        transcripts_dir.mkdir(parents=True, exist_ok=True)
+        project_cwd = self._resolve_project_cwd(project_name)
+
+        # Build PreToolUse hooks — file access control MUST use hooks because
+        # Read/Glob/Grep are matched by allow rules (step 4 in the SDK
+        # permission chain) before reaching can_use_tool (step 5).  Hooks
+        # (step 1) fire for ALL tool calls and can override allow rules.
+        hooks = None
+        if HookMatcher is not None:
+            hook_callbacks: list[Any] = [
+                self._build_file_access_hook(project_cwd),
+            ]
+            if can_use_tool is not None:
+                # Official Python SDK guidance: keep stream open when using
+                # can_use_tool.
+                hook_callbacks.insert(0, self._keep_stream_open_hook)
+
+            # Shared dict: PreToolUse saves file backup, PostToolUse restores
+            # on corruption.  Keyed by tool_use_id.
+            json_backups: dict[str, tuple[Path, str]] = {}
+
+            hooks = {
+                "PreToolUse": [
+                    HookMatcher(matcher=None, hooks=hook_callbacks),
+                    HookMatcher(
+                        matcher="Bash",
+                        hooks=[self._bash_env_scrub_hook],  # type: ignore[list-item]
+                    ),
+                    HookMatcher(
+                        matcher="Write|Edit",
+                        hooks=[
+                            self._build_json_validation_hook(project_cwd, json_backups),
+                        ],
+                    ),
+                ],
+                "PostToolUse": [
+                    HookMatcher(
+                        matcher="Write|Edit",
+                        hooks=[
+                            self._build_json_post_validation_hook(project_cwd, json_backups),
+                        ],
+                    ),
+                ],
+            }
+
+        provider_env = await self.build_provider_env_overrides()
+        sandbox_typed = policy.build_sandbox_settings(project_cwd)
+
+        # Windows 回退：sandbox 关闭时 Bash 系列被剥离出 allowed_tools，
+        # 让 _can_use_tool 接管 prefix 白名单匹配。
+        allowed_tools = policy.filter_allowed_tools(self._allowed_tools)
+        # 内置 ArcReel SDK MCP server — handler 跑在主进程，绕过 sandbox。
+        # 通配符让后续新增 tool 不必同步改 allowed_tools。
+        allowed_tools.append("mcp__arcreel__*")
+
+        arcreel_server = build_arcreel_mcp_server(
+            project_name=project_name,
+            projects_root=self.projects_root,
+        )
+
+        return ClaudeAgentOptions(
+            cwd=str(project_cwd),
+            setting_sources=self._setting_sources,  # type: ignore[arg-type]
+            allowed_tools=allowed_tools,
+            max_turns=self._max_turns_provider(),
+            system_prompt=SystemPromptPreset(
+                type="preset",
+                preset="claude_code",
+                append=self._build_append_prompt(project_name, locale=locale),
+            ),
+            include_partial_messages=True,
+            resume=resume_id,
+            can_use_tool=can_use_tool,
+            hooks=hooks,  # type: ignore[arg-type]
+            mcp_servers={"arcreel": arcreel_server},
+            session_store=self.build_session_store(),  # type: ignore[arg-type]
+            session_store_flush=session_store_flush_mode(),
+            sandbox=sandbox_typed,  # type: ignore[arg-type]
+            env=provider_env,
+            stderr=stderr,
+        )
+
+    @staticmethod
+    async def _keep_stream_open_hook(
+        _input_data: dict[str, Any], _tool_use_id: str | None, _context: Any
+    ) -> dict[str, bool]:
+        """Required keep-alive hook for Python can_use_tool callback."""
+        return {"continue_": True}
+
+    async def _bash_env_scrub_hook(
+        self,
+        input_data: dict[str, Any],
+        _tool_use_id: str | None,
+        _context: Any,
+    ) -> dict[str, Any]:
+        """Bash 密钥剥离 hook（SDK 封皮）：变换语义与 Windows 回退跳包装的约束见
+        ``AgentAccessPolicy.wrap_bash_command_for_env_scrub``。
+
+        只返回 ``updatedInput``、不返回 ``permissionDecision``：PreToolUse hook
+        是权限链第 1 步，``allow`` 会短路后续所有步骤（包括 ``_can_use_tool``）。
+        sandbox 启用时 Bash 在 allowed_tools 内，包装后的命令由 allow 规则放行；
+        权限决策始终留给链上后续步骤。不包装时（Windows 回退 / 空命令）直接
+        continue，原始命令落到 ``_can_use_tool`` 做白名单匹配。
+        """
+        tool_input = input_data.get("tool_input") or {}
+        wrapped = self._access_policy_provider().wrap_bash_command_for_env_scrub(tool_input.get("command"))
+        if wrapped is None:
+            return {"continue_": True}
+        updated_input = {**tool_input, "command": wrapped}
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "updatedInput": updated_input,
+            },
+        }
+
+    def _build_file_access_hook(
+        self,
+        project_cwd: Path,
+    ) -> Callable[..., Any]:
+        """Build a PreToolUse hook callback that enforces file access control.
+
+        PreToolUse hooks are step 1 in the SDK permission chain and fire for
+        **every** tool call, including Read/Glob/Grep which would otherwise
+        be auto-approved by allow rules at step 4.
+        """
+
+        async def _file_access_hook(
+            input_data: dict[str, Any],
+            _tool_use_id: str | None,
+            _context: Any,
+        ) -> dict[str, Any]:
+            policy = self._access_policy_provider()
+            tool_name = input_data.get("tool_name", "")
+            path_tools = policy.PATH_TOOLS
+            if tool_name not in path_tools:
+                return {"continue_": True}
+
+            tool_input = input_data.get("tool_input", {})
+            path_key = path_tools[tool_name]
+            file_path = tool_input.get(path_key)
+
+            if file_path:
+                allowed, deny_reason = policy.check_path_access(
+                    file_path,
+                    tool_name,
+                    project_cwd,
+                )
+                if not allowed:
+                    return {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "permissionDecision": "deny",
+                            "permissionDecisionReason": deny_reason,
+                        },
+                    }
+
+            return {"continue_": True}
+
+        return _file_access_hook
+
+    def _build_json_validation_hook(
+        self,
+        project_cwd: Path,
+        json_backups: dict[str, tuple[Path, str]] | None = None,
+    ) -> Callable[..., Any]:
+        """Build a PreToolUse hook that blocks Write/Edit when the result would
+        produce invalid JSON.
+
+        For Edit: reads the current file, simulates the string replacement, and
+        validates the result with ``json.loads()``.
+        For Write: validates the ``content`` parameter directly.
+
+        When *json_backups* is provided, the hook saves the current file
+        content before the edit so the PostToolUse hook can restore it if
+        the actual result turns out to be invalid.
+
+        Returns ``permissionDecision: "deny"`` to block the operation before it
+        executes, giving the agent a chance to fix its input and retry.
+        """
+
+        async def _json_validation_hook(
+            input_data: dict[str, Any],
+            _tool_use_id: str | None,
+            _context: Any,
+        ) -> dict[str, Any]:
+            tool_name = input_data.get("tool_name", "")
+            tool_input = input_data.get("tool_input", {})
+
+            file_path = tool_input.get("file_path", "")
+            if not file_path or not file_path.endswith(".json"):
+                return {}
+
+            # --- Reject curly/smart quotes that would corrupt JSON ---
+            _CURLY_QUOTES = "“”„‟"  # ""„‟
+
+            def _has_curly_quotes(text: str) -> bool:
+                """Return True if *text* contains Unicode curly/smart quotes."""
+                return any(ch in _CURLY_QUOTES for ch in text)
+
+            # --- Simulate the result without touching the file ---
+            simulated: str | None = None
+
+            if tool_name == "Write":
+                simulated = tool_input.get("content")
+                logger.info(
+                    "JSON 校验 hook: tool=Write file=%s content_len=%s",
+                    file_path,
+                    len(simulated) if simulated else 0,
+                )
+            elif tool_name == "Edit":
+                old_string = tool_input.get("old_string", "")
+                new_string = tool_input.get("new_string", "")
+                if not old_string:
+                    logger.info(
+                        "JSON 校验 hook: tool=Edit file=%s skip=old_string为空",
+                        file_path,
+                    )
+                    return {}
+
+                # Detect curly quotes early — Claude Code may normalise
+                # old_string internally (allowing the edit to succeed) while
+                # the hook's exact-match ``old_string not in current`` check
+                # below would skip validation, letting curly quotes slip into
+                # the file and corrupt JSON.
+                if _has_curly_quotes(new_string):
+                    curly_found = [f"U+{ord(ch):04X}" for ch in new_string if ch in _CURLY_QUOTES]
+                    logger.warning(
+                        "PreToolUse JSON 校验拦截(弯引号): file=%s curly=%s",
+                        file_path,
+                        curly_found[:5],
+                    )
+                    return {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "permissionDecision": "deny",
+                            "permissionDecisionReason": (
+                                "操作被阻止：new_string 包含弯引号"
+                                "（“ 或 ”），"
+                                "这会破坏 JSON 格式。"
+                                "请将所有弯引号替换为标准 ASCII "
+                                "双引号 (U+0022) 后重试。"
+                            ),
+                        },
+                    }
+
+                p = Path(file_path)
+                resolved = (project_cwd / p).resolve() if not p.is_absolute() else p.resolve()
+                try:
+                    current = resolved.read_text(encoding="utf-8")
+                except OSError as read_err:
+                    logger.info(
+                        "JSON 校验 hook: tool=Edit file=%s skip=读取失败 error=%s",
+                        file_path,
+                        read_err,
+                    )
+                    return {}
+
+                # Save backup for PostToolUse restore on corruption
+                if json_backups is not None and _tool_use_id:
+                    json_backups[_tool_use_id] = (resolved, current)
+
+                if old_string not in current:
+                    # Edit tool will fail on its own; no need to intervene.
+                    logger.info(
+                        "JSON 校验 hook: tool=Edit file=%s skip=old_string未匹配 old_len=%d new_len=%d file_len=%d",
+                        file_path,
+                        len(old_string),
+                        len(new_string),
+                        len(current),
+                    )
+                    return {}
+
+                replace_all = tool_input.get("replace_all", False)
+                if replace_all:
+                    simulated = current.replace(old_string, new_string)
+                else:
+                    simulated = current.replace(old_string, new_string, 1)
+
+                logger.info(
+                    "JSON 校验 hook: tool=Edit file=%s matched=True "
+                    "old_len=%d new_len=%d simulated_len=%d replace_all=%s",
+                    file_path,
+                    len(old_string),
+                    len(new_string),
+                    len(simulated),
+                    replace_all,
+                )
+
+            if simulated is None:
+                return {}
+
+            try:
+                json.loads(simulated)
+                logger.info(
+                    "JSON 校验 hook: tool=%s file=%s result=valid",
+                    tool_name,
+                    file_path,
+                )
+                return {}
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "PreToolUse JSON 校验拦截: file=%s tool=%s error=%s",
+                    file_path,
+                    tool_name,
+                    exc,
+                )
+                return {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": (
+                            f"操作被阻止：此次 {tool_name} 会导致 {file_path} "
+                            f"变成无效 JSON。错误：{exc}。"
+                            "请检查你的输入内容中是否包含未转义的双引号或其他"
+                            "JSON 语法问题，修正后重试。"
+                        ),
+                    },
+                }
+
+        return _json_validation_hook
+
+    def _build_json_post_validation_hook(
+        self,
+        project_cwd: Path,
+        json_backups: dict[str, tuple[Path, str]],
+    ) -> Callable[..., Any]:
+        """Build a PostToolUse hook that validates JSON files after Write/Edit.
+
+        This is a safety net for cases where the PreToolUse simulation fails
+        to catch invalid edits (e.g. due to old_string mismatch or escaping
+        differences between the hook simulation and the actual Edit tool).
+
+        If the file is invalid JSON after the edit, the hook:
+        1. Restores the file from the backup saved by the PreToolUse hook
+        2. Returns ``additionalContext`` telling the agent what went wrong
+        """
+
+        async def _json_post_validation_hook(
+            input_data: dict[str, Any],
+            tool_use_id: str | None,
+            _context: Any,
+        ) -> dict[str, Any]:
+            # Top-level guard: unhandled exceptions in hooks interrupt the
+            # agent (per SDK docs), so we catch everything and log.
+            try:
+                return await _json_post_validation_impl(
+                    input_data,
+                    tool_use_id,
+                )
+            except Exception:
+                logger.exception("PostToolUse JSON 校验 hook 异常")
+                return {}
+
+        async def _json_post_validation_impl(
+            input_data: dict[str, Any],
+            tool_use_id: str | None,
+        ) -> dict[str, Any]:
+            tool_name = input_data.get("tool_name", "")
+            tool_input = input_data.get("tool_input", {})
+
+            file_path = tool_input.get("file_path", "")
+            if not file_path or not file_path.endswith(".json"):
+                return {}
+
+            # Pop the backup regardless of outcome to avoid memory leaks
+            backup = json_backups.pop(tool_use_id, None) if tool_use_id else None
+
+            p = Path(file_path)
+            resolved = (project_cwd / p).resolve() if not p.is_absolute() else p.resolve()
+
+            try:
+                actual = resolved.read_text(encoding="utf-8")
+            except OSError:
+                return {}
+
+            try:
+                json.loads(actual)
+                logger.info(
+                    "PostToolUse JSON 校验: tool=%s file=%s result=valid",
+                    tool_name,
+                    file_path,
+                )
+                return {}
+            except json.JSONDecodeError as exc:
+                # File is corrupt — restore from backup if available
+                restored = False
+                if backup:
+                    backup_path, backup_content = backup
+                    try:
+                        backup_path.write_text(backup_content, encoding="utf-8")
+                        restored = True
+                        logger.warning(
+                            "PostToolUse JSON 校验拦截并恢复: file=%s tool=%s error=%s backup_restored=True",
+                            file_path,
+                            tool_name,
+                            exc,
+                        )
+                    except OSError as write_err:
+                        logger.error(
+                            "PostToolUse JSON 备份恢复失败: file=%s error=%s",
+                            file_path,
+                            write_err,
+                        )
+                else:
+                    logger.warning(
+                        "PostToolUse JSON 校验拦截(无备份): file=%s tool=%s error=%s",
+                        file_path,
+                        tool_name,
+                        exc,
+                    )
+
+                if restored:
+                    ctx = (
+                        f"⚠ JSON 损坏已检测并回滚：{tool_name} 导致 "
+                        f"{file_path} 变成无效 JSON（{exc}）。"
+                        "文件已恢复到编辑前状态，请修正后重试。"
+                    )
+                else:
+                    ctx = (
+                        f"⚠ JSON 损坏已检测但无法恢复：{tool_name} 导致 "
+                        f"{file_path} 变成无效 JSON（{exc}）。"
+                        "文件当前仍为损坏状态（无可用备份或恢复写入失败），"
+                        "请先读取文件确认内容，再手动修正为合法 JSON。"
+                    )
+
+                return {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PostToolUse",
+                        "additionalContext": ctx,
+                    },
+                }
+
+        return _json_post_validation_hook

--- a/server/agent_runtime/options_assembler.py
+++ b/server/agent_runtime/options_assembler.py
@@ -80,6 +80,11 @@ class OptionsAssembler:
     时现取——``access_policy_provider``（``configure_sandbox_runtime`` 会整体换新）与
     ``max_turns_provider``（``refresh_config`` 会改写）。``resolve_project_cwd`` 由
     SessionManager 注入（项目名校验/作用域是会话管理侧职责）。
+
+    ``session_factory_provider`` / ``user_id_provider`` 同样用回调而非构造期快照：
+    store 在首次 ``build_session_store`` 时按当时取值建好并缓存，与析出前
+    ``_build_session_store`` 惰性读 SessionManager 属性的时点一致——避免用量记录
+    （实时读 ``_user_id``）与 transcript store 落到不同的 per-user 命名空间。
     """
 
     def __init__(
@@ -93,8 +98,8 @@ class OptionsAssembler:
         max_turns_provider: Callable[[], int | None],
         resolve_project_cwd: Callable[[str], Path],
         provider_env_loader: Callable[[], Awaitable[dict[str, str]]] | None = None,
-        session_factory: Any = None,
-        user_id: str = DEFAULT_USER_ID,
+        session_factory_provider: Callable[[], Any] | None = None,
+        user_id_provider: Callable[[], str] | None = None,
     ) -> None:
         self.data_dir = Path(data_dir)
         self.projects_root = Path(projects_root)
@@ -104,8 +109,8 @@ class OptionsAssembler:
         self._max_turns_provider = max_turns_provider
         self._resolve_project_cwd = resolve_project_cwd
         self._provider_env_loader = provider_env_loader
-        self._session_factory = session_factory
-        self._user_id = user_id
+        self._session_factory_provider = session_factory_provider or (lambda: None)
+        self._user_id_provider = user_id_provider or (lambda: DEFAULT_USER_ID)
         # session store 单例缓存：每个 assembler 一份，避免每次 build 都新建 store。
         self._cached_session_store: DbSessionStore | None = None
         self._session_store_resolved = False
@@ -182,8 +187,8 @@ class OptionsAssembler:
         else:
             if not is_known_session_store_mode(mode):
                 logger.warning("Unknown ARCREEL_SDK_SESSION_STORE=%r; defaulting to db", mode)
-            factory = self._session_factory or default_async_session_factory
-            store = DbSessionStore(factory, user_id=self._user_id)
+            factory = self._session_factory_provider() or default_async_session_factory
+            store = DbSessionStore(factory, user_id=self._user_id_provider())
         self._cached_session_store = store
         self._session_store_resolved = True
         return store

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -15,11 +15,8 @@ from pathlib import Path
 from typing import Any, Optional
 from uuid import uuid4
 
-from lib.agent_session_store import session_store_flush_mode
-from lib.agent_session_store.store import DbSessionStore
 from lib.db.base import DEFAULT_USER_ID
-from lib.db.engine import async_session_factory as default_async_session_factory
-from lib.i18n import DEFAULT_LOCALE, LOCALE_LANGUAGE_MAP
+from lib.i18n import DEFAULT_LOCALE
 from lib.logging_config import resolve_log_dir
 from server.agent_runtime.agent_access_policy import AgentAccessPolicy
 from server.agent_runtime.message_serialization import (
@@ -38,7 +35,7 @@ from server.agent_runtime.models import (
     SessionStatus,
     SessionStreamEvent,
 )
-from server.agent_runtime.sdk_tools import build_arcreel_mcp_server
+from server.agent_runtime.options_assembler import OptionsAssembler
 from server.agent_runtime.session_actor import SessionActor, SessionCommand
 from server.agent_runtime.session_store import SessionMetaStore
 from server.agent_runtime.usage_extraction import (
@@ -50,12 +47,10 @@ from server.agent_runtime.usage_extraction import (
 
 logger = logging.getLogger(__name__)
 
-from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient, tag_session
+from claude_agent_sdk import ClaudeSDKClient, tag_session
 from claude_agent_sdk.types import (
-    HookMatcher,
     PermissionResultAllow,
     PermissionResultDeny,
-    SystemPromptPreset,
 )
 
 from lib.config.service import ConfigService
@@ -391,6 +386,21 @@ class SessionManager:
         )
         self._load_config()
         self.usage_tracker = UsageTracker(session_factory=getattr(meta_store, "_session_factory", None))
+        # Options 装配器：持依赖、允许 I/O，异步 build 产出 SDK options。access_policy
+        # 与 max_turns 用 provider 回调现取——configure_sandbox_runtime / refresh_config
+        # 换新后对后续所有会话立即生效；_resolve_project_cwd（项目名校验/作用域）留在
+        # 会话管理侧，作为依赖注入。
+        self._options_assembler = OptionsAssembler(
+            data_dir=self.data_dir,
+            projects_root=self.projects_root,
+            allowed_tools=self.DEFAULT_ALLOWED_TOOLS,
+            setting_sources=self.DEFAULT_SETTING_SOURCES,
+            access_policy_provider=lambda: self.access_policy,
+            max_turns_provider=lambda: self.max_turns,
+            resolve_project_cwd=self._resolve_project_cwd,
+            session_factory=getattr(self, "_session_factory", None),
+            user_id=getattr(self, "_user_id", DEFAULT_USER_ID),
+        )
 
     def configure_sandbox_runtime(self, *, in_docker: bool, sandbox_enabled: bool) -> None:
         """startup 期注入平台运行时事实（Docker 嵌套、内核沙箱可用性）。
@@ -430,115 +440,6 @@ class SessionManager:
         # Fallback to env var
         self._load_config()
 
-    _PERSONA_PROMPT = """\
-## 身份
-
-你是 ArcReel 智能体，一个专业的 AI 视频内容创作助手。你的职责是将小说转化为可发布的短视频内容。
-
-## 行为准则
-
-- 主动引导用户完成视频创作工作流，而不仅仅被动回答问题
-- 遇到不确定的创作决策时，向用户提出选项并给出建议，而不是自行决定
-- 涉及多步骤任务时，使用 TodoWrite 跟踪进度并向用户汇报
-- Write/Edit 不要写入代码文件（扩展名 .py/.js/.ts/.tsx/.sh/.yaml/.yml/.toml）；数据文件（.json/.md/.txt/.html/.csv 等）可以正常写入。代码逻辑应通过现有 skill 脚本完成
-- 你是用户的视频制作搭档，专业、友善、高效"""
-
-    def _build_append_prompt(self, project_name: str, locale: str = DEFAULT_LOCALE) -> str:
-        """Build the append portion for SystemPromptPreset.
-
-        Combines the ArcReel persona, the locale language regulation, and the
-        session-invariant project context (identity, cwd, operating rules).
-        Mutable project metadata is not included here — it lives in project.json
-        and is read on demand. The project's CLAUDE.md (mode variant projected
-        into the cwd) is auto-loaded by the SDK via setting_sources=["project"].
-        """
-        parts = [self._PERSONA_PROMPT]
-
-        lang = LOCALE_LANGUAGE_MAP.get(locale, "中文")
-        parts.append(
-            f"\n## 语言规范\n\n"
-            f"- **回答用户必须使用{lang}**：所有回复、思考过程、任务清单及计划文件，均须使用{lang}\n"
-            f"- **视频内容语言**：所有生成的视频对话、旁白、字幕均使用{lang}\n"
-            f"- **文档使用{lang}**：所有的 Markdown 文件均使用{lang}编写\n"
-            f"- **Prompt 使用{lang}**：图片生成/视频生成使用的 prompt 应使用{lang}编写"
-        )
-
-        project_context = self._build_project_context(project_name)
-        if project_context:
-            parts.append(project_context)
-
-        return "\n".join(parts)
-
-    def _build_project_context(self, project_name: str) -> str:
-        """Build session-invariant project context for the system prompt.
-
-        Holds only facts that cannot change within a session: project identity,
-        cwd, and static operating rules. Mutable metadata (title, style,
-        overview, ...) lives in project.json and is read on demand by the agent
-        and tools — never baked into the session-fixed system prompt.
-        """
-        try:
-            project_cwd = self._resolve_project_cwd(project_name)
-        except (ValueError, FileNotFoundError):
-            return ""
-
-        parts = [
-            "## 当前项目上下文",
-            "",
-            f"- 项目标识：{project_name}",
-            f"- 项目目录（即当前工作目录 cwd）：{project_cwd.as_posix()}",
-            "- 项目元数据（标题、风格、概述等）存于 project.json，需要时读取。",
-            "- Bash 命令必须写在单行，禁止使用 `\\` 换行，JSON 参数使用紧凑格式。",
-        ]
-        return "\n".join(parts)
-
-    def _build_session_store(self) -> DbSessionStore | None:
-        """Return a cached per-user DbSessionStore, or None when env disables it.
-
-        Set ARCREEL_SDK_SESSION_STORE=off to roll back to SDK's filesystem path.
-        The result is cached on first call so every session shares one instance
-        instead of allocating a fresh store per ``_build_options`` invocation.
-        """
-        cached = getattr(self, "_cached_session_store", None)
-        if cached is not None or getattr(self, "_session_store_resolved", False):
-            return cached
-        from lib.agent_session_store import (
-            is_known_session_store_mode,
-            session_store_mode,
-        )
-
-        mode = session_store_mode()
-        store: DbSessionStore | None
-        if mode == "off":
-            store = None
-        else:
-            if not is_known_session_store_mode(mode):
-                logger.warning("Unknown ARCREEL_SDK_SESSION_STORE=%r; defaulting to db", mode)
-            factory = getattr(self, "_session_factory", None) or default_async_session_factory
-            user_id = getattr(self, "_user_id", DEFAULT_USER_ID)
-            store = DbSessionStore(factory, user_id=user_id)
-        self._cached_session_store = store
-        self._session_store_resolved = True
-        return store
-
-    async def _build_provider_env_overrides(self) -> dict[str, str]:
-        """构造 options.env 注入字典。
-
-        - ANTHROPIC_* 从 DB active credential 取真值
-        - 其他 provider env 全部空值覆盖（防御性兜底）
-        """
-        from lib.config.env_keys import OTHER_PROVIDER_ENV_KEYS
-        from lib.config.service import build_anthropic_env_dict
-        from lib.db import async_session_factory
-
-        async with async_session_factory() as session:
-            anthropic_env = await build_anthropic_env_dict(session)
-
-        result = dict(anthropic_env)
-        for key in OTHER_PROVIDER_ENV_KEYS:
-            result[key] = ""
-        return result
-
     async def _build_options(
         self,
         project_name: str,
@@ -547,449 +448,20 @@ class SessionManager:
         locale: str = DEFAULT_LOCALE,
         stderr: Callable[[str], None] | None = None,
     ) -> Any:
-        """Build ClaudeAgentOptions for a session.
-
-        ``stderr`` 在 SDK 子进程退出非 0 时是唯一拿到真实错误的途径
-        （``ProcessError.stderr`` 在 SDK 内部被写死为占位符）；上层应在
-        会话启动失败时把回调累积的行包装到 ``AgentStartupError`` 透传。
-        """
-        if not SDK_AVAILABLE or ClaudeAgentOptions is None:
-            raise RuntimeError("claude_agent_sdk is not installed")
-
-        transcripts_dir = self.data_dir / "transcripts"
-        transcripts_dir.mkdir(parents=True, exist_ok=True)
-        project_cwd = self._resolve_project_cwd(project_name)
-
-        # Build PreToolUse hooks — file access control MUST use hooks because
-        # Read/Glob/Grep are matched by allow rules (step 4 in the SDK
-        # permission chain) before reaching can_use_tool (step 5).  Hooks
-        # (step 1) fire for ALL tool calls and can override allow rules.
-        hooks = None
-        if HookMatcher is not None:
-            hook_callbacks: list[Any] = [
-                self._build_file_access_hook(project_cwd),
-            ]
-            if can_use_tool is not None:
-                # Official Python SDK guidance: keep stream open when using
-                # can_use_tool.
-                hook_callbacks.insert(0, self._keep_stream_open_hook)
-
-            # Shared dict: PreToolUse saves file backup, PostToolUse restores
-            # on corruption.  Keyed by tool_use_id.
-            json_backups: dict[str, tuple[Path, str]] = {}
-
-            hooks = {
-                "PreToolUse": [
-                    HookMatcher(matcher=None, hooks=hook_callbacks),
-                    HookMatcher(
-                        matcher="Bash",
-                        hooks=[self._bash_env_scrub_hook],  # type: ignore[list-item]
-                    ),
-                    HookMatcher(
-                        matcher="Write|Edit",
-                        hooks=[
-                            self._build_json_validation_hook(project_cwd, json_backups),
-                        ],
-                    ),
-                ],
-                "PostToolUse": [
-                    HookMatcher(
-                        matcher="Write|Edit",
-                        hooks=[
-                            self._build_json_post_validation_hook(project_cwd, json_backups),
-                        ],
-                    ),
-                ],
-            }
-
-        provider_env = await self._build_provider_env_overrides()
-        sandbox_typed = self.access_policy.build_sandbox_settings(project_cwd)
-
-        # Windows 回退：sandbox 关闭时 Bash 系列被剥离出 allowed_tools，
-        # 让 _can_use_tool 接管 prefix 白名单匹配。
-        allowed_tools = self.access_policy.filter_allowed_tools(self.DEFAULT_ALLOWED_TOOLS)
-        # 内置 ArcReel SDK MCP server — handler 跑在主进程，绕过 sandbox。
-        # 通配符让后续新增 tool 不必同步改 allowed_tools。
-        allowed_tools.append("mcp__arcreel__*")
-
-        arcreel_server = build_arcreel_mcp_server(
-            project_name=project_name,
-            projects_root=self.projects_root,
-        )
-
-        return ClaudeAgentOptions(
-            cwd=str(project_cwd),
-            setting_sources=self.DEFAULT_SETTING_SOURCES,  # type: ignore[arg-type]
-            allowed_tools=allowed_tools,
-            max_turns=self.max_turns,
-            system_prompt=SystemPromptPreset(
-                type="preset",
-                preset="claude_code",
-                append=self._build_append_prompt(project_name, locale=locale),
-            ),
-            include_partial_messages=True,
-            resume=resume_id,
+        """委派给 ``OptionsAssembler.build``——SessionManager 不再直接构建 options 与
+        hook，仅调用装配器；凭证注入、prompt 装配、hook 工厂均由装配器持有。"""
+        return await self._options_assembler.build(
+            project_name,
+            resume_id=resume_id,
             can_use_tool=can_use_tool,
-            hooks=hooks,  # type: ignore[arg-type]
-            mcp_servers={"arcreel": arcreel_server},
-            session_store=self._build_session_store(),  # type: ignore[arg-type]
-            session_store_flush=session_store_flush_mode(),
-            sandbox=sandbox_typed,  # type: ignore[arg-type]
-            env=provider_env,
+            locale=locale,
             stderr=stderr,
         )
 
-    @staticmethod
-    async def _keep_stream_open_hook(
-        _input_data: dict[str, Any], _tool_use_id: str | None, _context: Any
-    ) -> dict[str, bool]:
-        """Required keep-alive hook for Python can_use_tool callback."""
-        return {"continue_": True}
-
-    async def _bash_env_scrub_hook(
-        self,
-        input_data: dict[str, Any],
-        _tool_use_id: str | None,
-        _context: Any,
-    ) -> dict[str, Any]:
-        """Bash 密钥剥离 hook（SDK 封皮）：变换语义与 Windows 回退跳包装的约束见
-        ``AgentAccessPolicy.wrap_bash_command_for_env_scrub``。
-
-        只返回 ``updatedInput``、不返回 ``permissionDecision``：PreToolUse hook
-        是权限链第 1 步，``allow`` 会短路后续所有步骤（包括 ``_can_use_tool``）。
-        sandbox 启用时 Bash 在 allowed_tools 内，包装后的命令由 allow 规则放行；
-        权限决策始终留给链上后续步骤。不包装时（Windows 回退 / 空命令）直接
-        continue，原始命令落到 ``_can_use_tool`` 做白名单匹配。
-        """
-        tool_input = input_data.get("tool_input") or {}
-        wrapped = self.access_policy.wrap_bash_command_for_env_scrub(tool_input.get("command"))
-        if wrapped is None:
-            return {"continue_": True}
-        updated_input = {**tool_input, "command": wrapped}
-        return {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "updatedInput": updated_input,
-            },
-        }
-
-    def _build_file_access_hook(
-        self,
-        project_cwd: Path,
-    ) -> Callable[..., Any]:
-        """Build a PreToolUse hook callback that enforces file access control.
-
-        PreToolUse hooks are step 1 in the SDK permission chain and fire for
-        **every** tool call, including Read/Glob/Grep which would otherwise
-        be auto-approved by allow rules at step 4.
-        """
-
-        async def _file_access_hook(
-            input_data: dict[str, Any],
-            _tool_use_id: str | None,
-            _context: Any,
-        ) -> dict[str, Any]:
-            tool_name = input_data.get("tool_name", "")
-            path_tools = self.access_policy.PATH_TOOLS
-            if tool_name not in path_tools:
-                return {"continue_": True}
-
-            tool_input = input_data.get("tool_input", {})
-            path_key = path_tools[tool_name]
-            file_path = tool_input.get(path_key)
-
-            if file_path:
-                allowed, deny_reason = self.access_policy.check_path_access(
-                    file_path,
-                    tool_name,
-                    project_cwd,
-                )
-                if not allowed:
-                    return {
-                        "hookSpecificOutput": {
-                            "hookEventName": "PreToolUse",
-                            "permissionDecision": "deny",
-                            "permissionDecisionReason": deny_reason,
-                        },
-                    }
-
-            return {"continue_": True}
-
-        return _file_access_hook
-
-    def _build_json_validation_hook(
-        self,
-        project_cwd: Path,
-        json_backups: dict[str, tuple[Path, str]] | None = None,
-    ) -> Callable[..., Any]:
-        """Build a PreToolUse hook that blocks Write/Edit when the result would
-        produce invalid JSON.
-
-        For Edit: reads the current file, simulates the string replacement, and
-        validates the result with ``json.loads()``.
-        For Write: validates the ``content`` parameter directly.
-
-        When *json_backups* is provided, the hook saves the current file
-        content before the edit so the PostToolUse hook can restore it if
-        the actual result turns out to be invalid.
-
-        Returns ``permissionDecision: "deny"`` to block the operation before it
-        executes, giving the agent a chance to fix its input and retry.
-        """
-
-        async def _json_validation_hook(
-            input_data: dict[str, Any],
-            _tool_use_id: str | None,
-            _context: Any,
-        ) -> dict[str, Any]:
-            tool_name = input_data.get("tool_name", "")
-            tool_input = input_data.get("tool_input", {})
-
-            file_path = tool_input.get("file_path", "")
-            if not file_path or not file_path.endswith(".json"):
-                return {}
-
-            # --- Reject curly/smart quotes that would corrupt JSON ---
-            _CURLY_QUOTES = "\u201c\u201d\u201e\u201f"  # ""„‟
-
-            def _has_curly_quotes(text: str) -> bool:
-                """Return True if *text* contains Unicode curly/smart quotes."""
-                return any(ch in _CURLY_QUOTES for ch in text)
-
-            # --- Simulate the result without touching the file ---
-            simulated: str | None = None
-
-            if tool_name == "Write":
-                simulated = tool_input.get("content")
-                logger.info(
-                    "JSON 校验 hook: tool=Write file=%s content_len=%s",
-                    file_path,
-                    len(simulated) if simulated else 0,
-                )
-            elif tool_name == "Edit":
-                old_string = tool_input.get("old_string", "")
-                new_string = tool_input.get("new_string", "")
-                if not old_string:
-                    logger.info(
-                        "JSON 校验 hook: tool=Edit file=%s skip=old_string为空",
-                        file_path,
-                    )
-                    return {}
-
-                # Detect curly quotes early — Claude Code may normalise
-                # old_string internally (allowing the edit to succeed) while
-                # the hook's exact-match ``old_string not in current`` check
-                # below would skip validation, letting curly quotes slip into
-                # the file and corrupt JSON.
-                if _has_curly_quotes(new_string):
-                    curly_found = [f"U+{ord(ch):04X}" for ch in new_string if ch in _CURLY_QUOTES]
-                    logger.warning(
-                        "PreToolUse JSON 校验拦截(弯引号): file=%s curly=%s",
-                        file_path,
-                        curly_found[:5],
-                    )
-                    return {
-                        "hookSpecificOutput": {
-                            "hookEventName": "PreToolUse",
-                            "permissionDecision": "deny",
-                            "permissionDecisionReason": (
-                                "操作被阻止：new_string 包含弯引号"
-                                "（\u201c 或 \u201d），"
-                                "这会破坏 JSON 格式。"
-                                "请将所有弯引号替换为标准 ASCII "
-                                "双引号 (U+0022) 后重试。"
-                            ),
-                        },
-                    }
-
-                p = Path(file_path)
-                resolved = (project_cwd / p).resolve() if not p.is_absolute() else p.resolve()
-                try:
-                    current = resolved.read_text(encoding="utf-8")
-                except OSError as read_err:
-                    logger.info(
-                        "JSON 校验 hook: tool=Edit file=%s skip=读取失败 error=%s",
-                        file_path,
-                        read_err,
-                    )
-                    return {}
-
-                # Save backup for PostToolUse restore on corruption
-                if json_backups is not None and _tool_use_id:
-                    json_backups[_tool_use_id] = (resolved, current)
-
-                if old_string not in current:
-                    # Edit tool will fail on its own; no need to intervene.
-                    logger.info(
-                        "JSON 校验 hook: tool=Edit file=%s skip=old_string未匹配 old_len=%d new_len=%d file_len=%d",
-                        file_path,
-                        len(old_string),
-                        len(new_string),
-                        len(current),
-                    )
-                    return {}
-
-                replace_all = tool_input.get("replace_all", False)
-                if replace_all:
-                    simulated = current.replace(old_string, new_string)
-                else:
-                    simulated = current.replace(old_string, new_string, 1)
-
-                logger.info(
-                    "JSON 校验 hook: tool=Edit file=%s matched=True "
-                    "old_len=%d new_len=%d simulated_len=%d replace_all=%s",
-                    file_path,
-                    len(old_string),
-                    len(new_string),
-                    len(simulated),
-                    replace_all,
-                )
-
-            if simulated is None:
-                return {}
-
-            try:
-                json.loads(simulated)
-                logger.info(
-                    "JSON 校验 hook: tool=%s file=%s result=valid",
-                    tool_name,
-                    file_path,
-                )
-                return {}
-            except json.JSONDecodeError as exc:
-                logger.warning(
-                    "PreToolUse JSON 校验拦截: file=%s tool=%s error=%s",
-                    file_path,
-                    tool_name,
-                    exc,
-                )
-                return {
-                    "hookSpecificOutput": {
-                        "hookEventName": "PreToolUse",
-                        "permissionDecision": "deny",
-                        "permissionDecisionReason": (
-                            f"操作被阻止：此次 {tool_name} 会导致 {file_path} "
-                            f"变成无效 JSON。错误：{exc}。"
-                            "请检查你的输入内容中是否包含未转义的双引号或其他"
-                            "JSON 语法问题，修正后重试。"
-                        ),
-                    },
-                }
-
-        return _json_validation_hook
-
-    def _build_json_post_validation_hook(
-        self,
-        project_cwd: Path,
-        json_backups: dict[str, tuple[Path, str]],
-    ) -> Callable[..., Any]:
-        """Build a PostToolUse hook that validates JSON files after Write/Edit.
-
-        This is a safety net for cases where the PreToolUse simulation fails
-        to catch invalid edits (e.g. due to old_string mismatch or escaping
-        differences between the hook simulation and the actual Edit tool).
-
-        If the file is invalid JSON after the edit, the hook:
-        1. Restores the file from the backup saved by the PreToolUse hook
-        2. Returns ``additionalContext`` telling the agent what went wrong
-        """
-
-        async def _json_post_validation_hook(
-            input_data: dict[str, Any],
-            tool_use_id: str | None,
-            _context: Any,
-        ) -> dict[str, Any]:
-            # Top-level guard: unhandled exceptions in hooks interrupt the
-            # agent (per SDK docs), so we catch everything and log.
-            try:
-                return await _json_post_validation_impl(
-                    input_data,
-                    tool_use_id,
-                )
-            except Exception:
-                logger.exception("PostToolUse JSON 校验 hook 异常")
-                return {}
-
-        async def _json_post_validation_impl(
-            input_data: dict[str, Any],
-            tool_use_id: str | None,
-        ) -> dict[str, Any]:
-            tool_name = input_data.get("tool_name", "")
-            tool_input = input_data.get("tool_input", {})
-
-            file_path = tool_input.get("file_path", "")
-            if not file_path or not file_path.endswith(".json"):
-                return {}
-
-            # Pop the backup regardless of outcome to avoid memory leaks
-            backup = json_backups.pop(tool_use_id, None) if tool_use_id else None
-
-            p = Path(file_path)
-            resolved = (project_cwd / p).resolve() if not p.is_absolute() else p.resolve()
-
-            try:
-                actual = resolved.read_text(encoding="utf-8")
-            except OSError:
-                return {}
-
-            try:
-                json.loads(actual)
-                logger.info(
-                    "PostToolUse JSON 校验: tool=%s file=%s result=valid",
-                    tool_name,
-                    file_path,
-                )
-                return {}
-            except json.JSONDecodeError as exc:
-                # File is corrupt — restore from backup if available
-                restored = False
-                if backup:
-                    backup_path, backup_content = backup
-                    try:
-                        backup_path.write_text(backup_content, encoding="utf-8")
-                        restored = True
-                        logger.warning(
-                            "PostToolUse JSON 校验拦截并恢复: file=%s tool=%s error=%s backup_restored=True",
-                            file_path,
-                            tool_name,
-                            exc,
-                        )
-                    except OSError as write_err:
-                        logger.error(
-                            "PostToolUse JSON 备份恢复失败: file=%s error=%s",
-                            file_path,
-                            write_err,
-                        )
-                else:
-                    logger.warning(
-                        "PostToolUse JSON 校验拦截(无备份): file=%s tool=%s error=%s",
-                        file_path,
-                        tool_name,
-                        exc,
-                    )
-
-                if restored:
-                    ctx = (
-                        f"⚠ JSON 损坏已检测并回滚：{tool_name} 导致 "
-                        f"{file_path} 变成无效 JSON（{exc}）。"
-                        "文件已恢复到编辑前状态，请修正后重试。"
-                    )
-                else:
-                    ctx = (
-                        f"⚠ JSON 损坏已检测但无法恢复：{tool_name} 导致 "
-                        f"{file_path} 变成无效 JSON（{exc}）。"
-                        "文件当前仍为损坏状态（无可用备份或恢复写入失败），"
-                        "请先读取文件确认内容，再手动修正为合法 JSON。"
-                    )
-
-                return {
-                    "hookSpecificOutput": {
-                        "hookEventName": "PostToolUse",
-                        "additionalContext": ctx,
-                    },
-                }
-
-        return _json_post_validation_hook
+    def _build_session_store(self):
+        """委派给装配器的 session store 单例。AssistantService 经此拿到与 SDK options
+        同一份 store 实例（同一 per-user 命名空间），读写共享缓存。"""
+        return self._options_assembler.build_session_store()
 
     def _resolve_project_cwd(self, project_name: str) -> Path:
         """Resolve and validate per-session project working directory."""

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -386,10 +386,12 @@ class SessionManager:
         )
         self._load_config()
         self.usage_tracker = UsageTracker(session_factory=getattr(meta_store, "_session_factory", None))
-        # Options 装配器：持依赖、允许 I/O，异步 build 产出 SDK options。access_policy
-        # 与 max_turns 用 provider 回调现取——configure_sandbox_runtime / refresh_config
-        # 换新后对后续所有会话立即生效；_resolve_project_cwd（项目名校验/作用域）留在
-        # 会话管理侧，作为依赖注入。
+        # Options 装配器：持依赖、允许 I/O，异步 build 产出 SDK options。access_policy /
+        # max_turns / session_factory / user_id 一律用 provider 回调现取——前两者
+        # configure_sandbox_runtime / refresh_config 换新后对后续会话立即生效；后两者
+        # 保持析出前惰性读 self 属性的时点，与用量记录侧 _finalize_turn 实时读 _user_id
+        # 同源，避免 store 与用量落到不同 per-user 命名空间。_resolve_project_cwd
+        # （项目名校验/作用域）留在会话管理侧，作为依赖注入。
         self._options_assembler = OptionsAssembler(
             data_dir=self.data_dir,
             projects_root=self.projects_root,
@@ -398,8 +400,8 @@ class SessionManager:
             access_policy_provider=lambda: self.access_policy,
             max_turns_provider=lambda: self.max_turns,
             resolve_project_cwd=self._resolve_project_cwd,
-            session_factory=getattr(self, "_session_factory", None),
-            user_id=getattr(self, "_user_id", DEFAULT_USER_ID),
+            session_factory_provider=lambda: getattr(self, "_session_factory", None),
+            user_id_provider=lambda: getattr(self, "_user_id", DEFAULT_USER_ID),
         )
 
     def configure_sandbox_runtime(self, *, in_docker: bool, sandbox_enabled: bool) -> None:

--- a/tests/agent_runtime/test_agent_startup_error.py
+++ b/tests/agent_runtime/test_agent_startup_error.py
@@ -65,10 +65,10 @@ async def test_build_options_forwards_stderr_callback(
 ) -> None:
     """_build_options 必须把 stderr 回调透传给 ClaudeAgentOptions。"""
 
-    async def fake_env(_self):
+    async def fake_env():
         return {"ANTHROPIC_API_KEY": "sk"}
 
-    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", fake_env)
+    monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
 
     captured: list[str] = []
 
@@ -89,10 +89,10 @@ async def test_send_new_session_wraps_actor_failure_with_stderr(
 ) -> None:
     """actor.start() 抛错时应收集 stderr 并包装为 AgentStartupError 抛出。"""
 
-    async def fake_env(_self):
+    async def fake_env():
         return {"ANTHROPIC_API_KEY": "sk"}
 
-    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", fake_env)
+    monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
 
     captured_stderr_cb: list = []
 
@@ -145,10 +145,10 @@ async def test_send_new_session_no_stderr_still_wraps(
 ) -> None:
     """即使 SDK 没产生 stderr，actor.start 失败也应包装为 AgentStartupError（保留原因链）。"""
 
-    async def fake_env(_self):
+    async def fake_env():
         return {"ANTHROPIC_API_KEY": "sk"}
 
-    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", fake_env)
+    monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
 
     class _FakeActor:
         def __init__(self, *_, on_message=None, client_factory=None):
@@ -183,10 +183,10 @@ async def test_get_or_connect_wraps_actor_failure_with_stderr(
     """
     from tests.factories import make_session_meta
 
-    async def fake_env(_self):
+    async def fake_env():
         return {"ANTHROPIC_API_KEY": "sk"}
 
-    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", fake_env)
+    monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
 
     captured_stderr_cb: list = []
 
@@ -235,10 +235,10 @@ async def test_stderr_buffer_caps_to_maxlen(session_manager: SessionManager, mon
     可控；这里直接打超过上限的行数，断言 sdk_stderr 行数受限。
     """
 
-    async def fake_env(_self):
+    async def fake_env():
         return {"ANTHROPIC_API_KEY": "sk"}
 
-    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", fake_env)
+    monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
 
     captured_stderr_cb: list = []
     overflow_count = _SDK_STDERR_BUFFER_MAX + 50

--- a/tests/agent_runtime/test_options_assembler.py
+++ b/tests/agent_runtime/test_options_assembler.py
@@ -1,0 +1,160 @@
+"""OptionsAssembler 单元测试：以注入假依赖驱动，不 monkeypatch 私有方法。
+
+装配器持依赖、允许 I/O，异步 build 产出 SDK options。这里用注入的假 policy /
+project_cwd 解析器 / 凭证 loader 直接构造装配器，断言凭证注入的空值覆盖、prompt
+装配、options 字段与 hook 注册——与 SessionManager 解耦。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from server.agent_runtime.agent_access_policy import AgentAccessPolicy
+from server.agent_runtime.options_assembler import (
+    OptionsAssembler,
+    load_provider_env_overrides,
+)
+
+_ALLOWED_TOOLS = ["Skill", "Task", "Bash", "BashOutput", "KillBash", "Read", "Write", "Edit"]
+_SETTING_SOURCES = ["project"]
+
+
+def _make_policy(tmp_path: Path, *, sandbox_enabled: bool = True) -> AgentAccessPolicy:
+    return AgentAccessPolicy(
+        project_root=(tmp_path / "repo").resolve(),
+        projects_root=(tmp_path / "projects").resolve(),
+        agent_profile_root=(tmp_path / "profile").resolve(),
+        log_dir=(tmp_path / "logs").resolve(),
+        sandbox_enabled=sandbox_enabled,
+        in_docker=False,
+    )
+
+
+def _make_assembler(
+    tmp_path: Path,
+    *,
+    policy: AgentAccessPolicy | None = None,
+    max_turns: int | None = None,
+    provider_env_loader=None,
+) -> OptionsAssembler:
+    projects_root = (tmp_path / "projects").resolve()
+    projects_root.mkdir(parents=True, exist_ok=True)
+    (projects_root / "demo").mkdir(exist_ok=True)
+    resolved_policy = policy or _make_policy(tmp_path)
+    return OptionsAssembler(
+        data_dir=tmp_path / "data",
+        projects_root=projects_root,
+        allowed_tools=_ALLOWED_TOOLS,
+        setting_sources=_SETTING_SOURCES,
+        access_policy_provider=lambda: resolved_policy,
+        max_turns_provider=lambda: max_turns,
+        resolve_project_cwd=lambda name: projects_root / name,
+        provider_env_loader=provider_env_loader,
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_provider_env_overrides_injects_anthropic_and_empties() -> None:
+    """凭证注入：ANTHROPIC_* 取真值，其他 provider env 全部空值覆盖。"""
+    fake_dict = {
+        "ANTHROPIC_API_KEY": "sk-from-db",
+        "ANTHROPIC_BASE_URL": "https://anthropic.example.com",
+    }
+
+    async def fake_build(_session):
+        return fake_dict
+
+    with patch("lib.config.service.build_anthropic_env_dict", side_effect=fake_build):
+        env = await load_provider_env_overrides()
+
+    assert env["ANTHROPIC_API_KEY"] == "sk-from-db"
+    assert env["ANTHROPIC_BASE_URL"] == "https://anthropic.example.com"
+    # 其他 provider 空值覆盖
+    assert env["ARK_API_KEY"] == ""
+    assert env["XAI_API_KEY"] == ""
+    assert env["GEMINI_API_KEY"] == ""
+    assert env["GOOGLE_APPLICATION_CREDENTIALS"] == ""
+
+
+@pytest.mark.asyncio
+async def test_build_provider_env_overrides_uses_injected_loader(tmp_path: Path) -> None:
+    """注入 provider_env_loader 时，build_provider_env_overrides 走注入源而非 DB。"""
+    sentinel = {"ANTHROPIC_API_KEY": "injected"}
+
+    async def fake_loader():
+        return sentinel
+
+    assembler = _make_assembler(tmp_path, provider_env_loader=fake_loader)
+    assert await assembler.build_provider_env_overrides() == sentinel
+
+
+@pytest.mark.asyncio
+async def test_build_threads_injected_deps_into_options(tmp_path: Path) -> None:
+    """build 把注入的 cwd / 凭证 / max_turns 逐一装进 ClaudeAgentOptions。"""
+    projects_root = (tmp_path / "projects").resolve()
+
+    async def fake_loader():
+        return {"ANTHROPIC_API_KEY": "sk"}
+
+    assembler = _make_assembler(tmp_path, max_turns=7, provider_env_loader=fake_loader)
+    options = await assembler.build("demo")
+
+    assert options.cwd == str(projects_root / "demo")
+    assert options.env == {"ANTHROPIC_API_KEY": "sk"}
+    assert options.max_turns == 7
+    assert list(options.setting_sources) == _SETTING_SOURCES
+    # file access hook 恒注册
+    assert "PreToolUse" in options.hooks
+    # sandbox 启用 → sandbox settings 编译进 options
+    assert options.sandbox.get("enabled") is True
+
+
+@pytest.mark.asyncio
+async def test_build_adds_keep_alive_hook_with_can_use_tool(tmp_path: Path) -> None:
+    """can_use_tool 存在时，keep-alive hook 排在 file access hook 之前。"""
+
+    async def fake_loader():
+        return {}
+
+    async def _can_use_tool(_tool, _input, _ctx):
+        return None
+
+    assembler = _make_assembler(tmp_path, provider_env_loader=fake_loader)
+    without = await assembler.build("demo")
+    with_cut = await assembler.build("demo", can_use_tool=_can_use_tool)
+
+    pre_without = without.hooks["PreToolUse"][0].hooks
+    pre_with = with_cut.hooks["PreToolUse"][0].hooks
+    assert len(pre_without) == 1
+    assert len(pre_with) == 2
+    assert pre_with[0] is assembler._keep_stream_open_hook
+
+
+@pytest.mark.asyncio
+async def test_build_append_prompt_carries_locale_language(tmp_path: Path) -> None:
+    """prompt 装配按 locale 渲染语言规范段。"""
+    assembler = _make_assembler(tmp_path)
+    prompt = assembler._build_append_prompt("demo", locale="vi")
+    assert "Tiếng Việt" in prompt or "vi" in prompt.lower()
+    # persona 恒在
+    assert "ArcReel 智能体" in prompt
+
+
+@pytest.mark.asyncio
+async def test_build_sandbox_disabled_strips_bash(tmp_path: Path) -> None:
+    """sandbox 关闭（Windows 回退）→ Bash 系列剥离出 allowed_tools。"""
+
+    async def fake_loader():
+        return {}
+
+    policy = _make_policy(tmp_path, sandbox_enabled=False)
+    assembler = _make_assembler(tmp_path, policy=policy, provider_env_loader=fake_loader)
+    options = await assembler.build("demo")
+
+    for tool in AgentAccessPolicy.BASH_TOOLS:
+        assert tool not in options.allowed_tools
+    assert "Read" in options.allowed_tools
+    assert options.sandbox == {"enabled": False}

--- a/tests/agent_runtime/test_session_manager_sandbox.py
+++ b/tests/agent_runtime/test_session_manager_sandbox.py
@@ -45,7 +45,7 @@ async def test_provider_env_overrides_includes_anthropic_and_empties(
         return fake_dict
 
     with patch("lib.config.service.build_anthropic_env_dict", side_effect=fake_build):
-        env = await session_manager._build_provider_env_overrides()
+        env = await session_manager._options_assembler.build_provider_env_overrides()
 
     # Anthropic 注入真值
     assert env["ANTHROPIC_API_KEY"] == "sk-from-db"
@@ -74,10 +74,10 @@ async def test_build_options_includes_sandbox_settings(
     proj_dir.mkdir(parents=True)
     (proj_dir / "project.json").write_text('{"title": "t"}', encoding="utf-8")
 
-    async def fake_env(_self):
+    async def fake_env():
         return {"ANTHROPIC_API_KEY": "sk", "ARK_API_KEY": ""}
 
-    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", fake_env)
+    monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
 
     opts = await session_manager._build_options("test_proj")
 
@@ -151,7 +151,7 @@ async def test_bash_env_scrub_hook_wraps_command_with_env_unset(session_manager:
     后续所有步骤；包装后的命令应由 allowed_tools 的 Bash allow 规则放行。"""
     from lib.config.env_keys import ANTHROPIC_ENV_KEYS
 
-    result = await session_manager._bash_env_scrub_hook(
+    result = await session_manager._options_assembler._bash_env_scrub_hook(
         {"tool_name": "Bash", "tool_input": {"command": "env | grep ANTHROPIC"}},
         None,
         None,
@@ -177,7 +177,7 @@ async def test_bash_env_scrub_hook_skips_wrap_when_sandbox_disabled(tmp_path: Pa
     hook 不包装也不给权限决策，原始命令落到 _can_use_tool 做白名单匹配
     （包装后命令以 ``env -u`` 开头，会让白名单永远匹配不上）。"""
     sm = _make_session_manager(tmp_path, sandbox_enabled=False)
-    result = await sm._bash_env_scrub_hook(
+    result = await sm._options_assembler._bash_env_scrub_hook(
         {"tool_name": "Bash", "tool_input": {"command": "ffmpeg -i in.mp4 out.mp4"}},
         None,
         None,
@@ -188,7 +188,7 @@ async def test_bash_env_scrub_hook_skips_wrap_when_sandbox_disabled(tmp_path: Pa
 @pytest.mark.asyncio
 async def test_bash_env_scrub_hook_handles_single_quotes(session_manager: SessionManager) -> None:
     """命令含单引号时不能破坏 shell 引号闭合。"""
-    result = await session_manager._bash_env_scrub_hook(
+    result = await session_manager._options_assembler._bash_env_scrub_hook(
         {"tool_name": "Bash", "tool_input": {"command": "echo 'hello world'"}},
         None,
         None,
@@ -201,7 +201,7 @@ async def test_bash_env_scrub_hook_handles_single_quotes(session_manager: Sessio
 @pytest.mark.asyncio
 async def test_bash_env_scrub_hook_passthrough_when_no_command(session_manager: SessionManager) -> None:
     """空 command 时直接放行，不做包装。"""
-    result = await session_manager._bash_env_scrub_hook(
+    result = await session_manager._options_assembler._bash_env_scrub_hook(
         {"tool_name": "Bash", "tool_input": {}},
         None,
         None,
@@ -239,10 +239,10 @@ async def test_build_options_bash_in_allowed_tools_by_sandbox(
     proj_dir.mkdir(parents=True, exist_ok=True)
     (proj_dir / "project.json").write_text('{"title":"t"}', encoding="utf-8")
 
-    async def fake_env(_self):
+    async def fake_env():
         return {"ANTHROPIC_API_KEY": "sk"}
 
-    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", fake_env)
+    monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
     opts = await sm._build_options("test_proj")
 
     for tool in AgentAccessPolicy.BASH_TOOLS:

--- a/tests/agent_runtime/test_session_manager_store_injection.py
+++ b/tests/agent_runtime/test_session_manager_store_injection.py
@@ -10,7 +10,7 @@ from lib.agent_session_store.store import DbSessionStore
 from server.agent_runtime.session_manager import SessionManager
 
 
-async def _fake_provider_env(_self):
+async def _fake_provider_env():
     """Stub: 跳过 DB 访问，返回空 dict（不影响 session_store/flush 字段断言）。"""
     return {}
 
@@ -57,13 +57,13 @@ def test_store_db_explicit_returns_store(monkeypatch, tmp_path):
 
 
 def test_store_uses_session_factory_seam(monkeypatch, tmp_path):
-    """If sm._session_factory is set, _build_session_store uses it."""
+    """装配器的 session_factory / user_id 注入生效于 build_session_store。"""
     monkeypatch.delenv("ARCREEL_SDK_SESSION_STORE", raising=False)
     sm = _build_sm(tmp_path)
 
     sentinel = object()
-    sm._session_factory = sentinel  # type: ignore[attr-defined]
-    sm._user_id = "test-user"  # type: ignore[attr-defined]
+    sm._options_assembler._session_factory = sentinel  # type: ignore[attr-defined]
+    sm._options_assembler._user_id = "test-user"  # type: ignore[attr-defined]
 
     store = sm._build_session_store()
     assert isinstance(store, DbSessionStore)
@@ -75,7 +75,7 @@ def test_store_uses_session_factory_seam(monkeypatch, tmp_path):
 async def test_flush_mode_passed_to_options_default(monkeypatch, tmp_path):
     """No env → ClaudeAgentOptions.session_store_flush == 'eager'."""
     monkeypatch.delenv("ARCREEL_SDK_SESSION_STORE_FLUSH", raising=False)
-    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", _fake_provider_env)
+    monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
     sm = _build_sm(tmp_path)
 
     project_cwd = tmp_path / "projects" / "demo"
@@ -89,7 +89,7 @@ async def test_flush_mode_passed_to_options_default(monkeypatch, tmp_path):
 async def test_flush_mode_passed_to_options_batched(monkeypatch, tmp_path):
     """env=batched → options.session_store_flush == 'batched'."""
     monkeypatch.setenv("ARCREEL_SDK_SESSION_STORE_FLUSH", "batched")
-    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", _fake_provider_env)
+    monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
     sm = _build_sm(tmp_path)
     project_cwd = tmp_path / "projects" / "demo"
     project_cwd.mkdir(parents=True)
@@ -108,7 +108,7 @@ async def test_flush_mode_passed_to_options_when_store_off(monkeypatch, tmp_path
     """
     monkeypatch.setenv("ARCREEL_SDK_SESSION_STORE", "off")
     monkeypatch.delenv("ARCREEL_SDK_SESSION_STORE_FLUSH", raising=False)
-    monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", _fake_provider_env)
+    monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
     sm = _build_sm(tmp_path)
 
     project_cwd = tmp_path / "projects" / "demo"

--- a/tests/agent_runtime/test_session_manager_store_injection.py
+++ b/tests/agent_runtime/test_session_manager_store_injection.py
@@ -57,13 +57,14 @@ def test_store_db_explicit_returns_store(monkeypatch, tmp_path):
 
 
 def test_store_uses_session_factory_seam(monkeypatch, tmp_path):
-    """装配器的 session_factory / user_id 注入生效于 build_session_store。"""
+    """SessionManager 的 _session_factory / _user_id 经装配器 provider 现取生效于
+    build_session_store（store 首次构建时按当时属性值取，与析出前时点一致）。"""
     monkeypatch.delenv("ARCREEL_SDK_SESSION_STORE", raising=False)
     sm = _build_sm(tmp_path)
 
     sentinel = object()
-    sm._options_assembler._session_factory = sentinel  # type: ignore[attr-defined]
-    sm._options_assembler._user_id = "test-user"  # type: ignore[attr-defined]
+    sm._session_factory = sentinel  # type: ignore[attr-defined]
+    sm._user_id = "test-user"  # type: ignore[attr-defined]
 
     store = sm._build_session_store()
     assert isinstance(store, DbSessionStore)

--- a/tests/test_session_manager_more.py
+++ b/tests/test_session_manager_more.py
@@ -76,10 +76,10 @@ async def _cold_revival_clients(session_manager, monkeypatch):
     ``options.kwargs["system_prompt"]["append"]`` carries the rebuilt prompt, so
     tests can assert which locale the language regulation was rendered with."""
 
-    async def _fake_env(_self):
+    async def _fake_env():
         return {}
 
-    monkeypatch.setattr(sm_mod.SessionManager, "_build_provider_env_overrides", _fake_env)
+    monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_env)
 
     created_clients: list[_FakeClaudeClient] = []
 
@@ -90,9 +90,10 @@ async def _cold_revival_clients(session_manager, monkeypatch):
 
     with monkeypatch.context() as m:
         m.setattr(sm_mod, "SDK_AVAILABLE", True)
-        m.setattr(sm_mod, "ClaudeAgentOptions", _FakeOptions)
+        m.setattr("server.agent_runtime.options_assembler.SDK_AVAILABLE", True)
+        m.setattr("server.agent_runtime.options_assembler.ClaudeAgentOptions", _FakeOptions)
         m.setattr(sm_mod, "ClaudeSDKClient", _track_client)
-        m.setattr(sm_mod, "HookMatcher", None)
+        m.setattr("server.agent_runtime.options_assembler.HookMatcher", None)
         yield created_clients
 
 
@@ -149,13 +150,13 @@ class TestSessionManagerMore:
 
     @pytest.mark.asyncio
     async def test_build_options_and_connect_paths(self, session_manager, meta_store, tmp_path, monkeypatch):
-        async def _fake_env(_self):
+        async def _fake_env():
             return {}
 
-        monkeypatch.setattr(sm_mod.SessionManager, "_build_provider_env_overrides", _fake_env)
+        monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_env)
 
         with monkeypatch.context() as m:
-            m.setattr(sm_mod, "SDK_AVAILABLE", False)
+            m.setattr("server.agent_runtime.options_assembler.SDK_AVAILABLE", False)
             with pytest.raises(RuntimeError):
                 await session_manager._build_options("demo")
 
@@ -172,9 +173,10 @@ class TestSessionManagerMore:
 
         with monkeypatch.context() as m:
             m.setattr(sm_mod, "SDK_AVAILABLE", True)
-            m.setattr(sm_mod, "ClaudeAgentOptions", _FakeOptions)
+            m.setattr("server.agent_runtime.options_assembler.SDK_AVAILABLE", True)
+            m.setattr("server.agent_runtime.options_assembler.ClaudeAgentOptions", _FakeOptions)
             m.setattr(sm_mod, "ClaudeSDKClient", _track_client)
-            m.setattr(sm_mod, "HookMatcher", None)
+            m.setattr("server.agent_runtime.options_assembler.HookMatcher", None)
             managed = await session_manager.get_or_connect(meta.id)
             # Let the actor enter the async-context (connect).
             await asyncio.sleep(0)
@@ -183,7 +185,7 @@ class TestSessionManagerMore:
             # Graceful teardown so the actor task doesn't leak.
             await session_manager.close_session(meta.id)
 
-        assert await session_manager._keep_stream_open_hook({}, None, None) == {"continue_": True}
+        assert await session_manager._options_assembler._keep_stream_open_hook({}, None, None) == {"continue_": True}
 
     @pytest.mark.asyncio
     async def test_get_or_connect_threads_locale_into_system_prompt(
@@ -518,7 +520,7 @@ class TestSessionManagerMore:
             meta_store=meta_store,
         )
 
-        hook = mgr._build_file_access_hook(own_project)
+        hook = mgr._options_assembler._build_file_access_hook(own_project)
 
         # Read own project file — allowed (within project_cwd)
         result = await hook(
@@ -566,7 +568,7 @@ class TestSessionManagerMore:
             meta_store=meta_store,
         )
 
-        hook = mgr._build_file_access_hook(own_project)
+        hook = mgr._options_assembler._build_file_access_hook(own_project)
 
         # Write own project file — allowed
         result = await hook(
@@ -604,7 +606,7 @@ class TestSessionManagerMore:
             meta_store=meta_store,
         )
 
-        hook = mgr._build_file_access_hook(own_project)
+        hook = mgr._options_assembler._build_file_access_hook(own_project)
 
         # Bash — not a path tool, hook continues
         result = await hook(
@@ -638,7 +640,7 @@ class TestSessionManagerMore:
             meta_store=meta_store,
         )
 
-        hook = mgr._build_file_access_hook(own_project)
+        hook = mgr._options_assembler._build_file_access_hook(own_project)
 
         # Write .py in project dir — denied (code extension)
         result = await hook(
@@ -730,7 +732,7 @@ class TestSessionManagerMore:
             meta_store=meta_store,
         )
 
-        hook = mgr._build_file_access_hook(own_project)
+        hook = mgr._options_assembler._build_file_access_hook(own_project)
 
         # Read agent_runtime_profile/CLAUDE.md — allowed (readonly dir)
         result = await hook(
@@ -765,7 +767,7 @@ class TestSessionManagerMore:
         # SDK 会话数据基准目录是 policy 的构造参数：换新 policy 即注入测试位置
         mgr.access_policy = replace(mgr.access_policy, claude_projects_dir=claude_home)
 
-        hook = mgr._build_file_access_hook(own_project)
+        hook = mgr._options_assembler._build_file_access_hook(own_project)
         return hook, own_project, claude_home, engine
 
     @pytest.mark.asyncio
@@ -896,7 +898,7 @@ class TestJsonValidationHook:
         """Helper: invoke the JSON validation hook callback directly."""
         from pathlib import Path
 
-        hook_fn = manager._build_json_validation_hook(
+        hook_fn = manager._options_assembler._build_json_validation_hook(
             Path(project_cwd) if project_cwd else Path("/tmp"),
         )
         input_data = {
@@ -1140,7 +1142,7 @@ class TestJsonPostValidationHook:
     ):
         from pathlib import Path
 
-        hook_fn = manager._build_json_post_validation_hook(
+        hook_fn = manager._options_assembler._build_json_post_validation_hook(
             Path(project_cwd) if project_cwd else Path("/tmp"),
             json_backups if json_backups is not None else {},
         )

--- a/tests/test_session_manager_project_scope.py
+++ b/tests/test_session_manager_project_scope.py
@@ -32,8 +32,8 @@ async def _make_store():
     return store, engine
 
 
-async def _fake_provider_env(_self):
-    """Stub for SessionManager._build_provider_env_overrides — 跳过 DB 访问。"""
+async def _fake_provider_env():
+    """Stub for OptionsAssembler 凭证注入 — 跳过 DB 访问。"""
     return {}
 
 
@@ -48,11 +48,11 @@ class TestSessionManagerProjectScope:
             data_dir=tmp_path,
             meta_store=store,
         )
-        monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", _fake_provider_env)
+        monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
 
-        with patch("server.agent_runtime.session_manager.SDK_AVAILABLE", True):
+        with patch("server.agent_runtime.options_assembler.SDK_AVAILABLE", True):
             with patch(
-                "server.agent_runtime.session_manager.ClaudeAgentOptions",
+                "server.agent_runtime.options_assembler.ClaudeAgentOptions",
                 _FakeOptions,
             ):
                 options = await manager._build_options("demo")
@@ -69,11 +69,11 @@ class TestSessionManagerProjectScope:
             data_dir=tmp_path,
             meta_store=store,
         )
-        monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", _fake_provider_env)
+        monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
 
-        with patch("server.agent_runtime.session_manager.SDK_AVAILABLE", True):
+        with patch("server.agent_runtime.options_assembler.SDK_AVAILABLE", True):
             with patch(
-                "server.agent_runtime.session_manager.ClaudeAgentOptions",
+                "server.agent_runtime.options_assembler.ClaudeAgentOptions",
                 _FakeOptions,
             ):
                 with pytest.raises(FileNotFoundError):
@@ -92,15 +92,15 @@ class TestSessionManagerProjectScope:
             data_dir=tmp_path,
             meta_store=store,
         )
-        monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", _fake_provider_env)
+        monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
 
-        with patch("server.agent_runtime.session_manager.SDK_AVAILABLE", True):
+        with patch("server.agent_runtime.options_assembler.SDK_AVAILABLE", True):
             with patch(
-                "server.agent_runtime.session_manager.ClaudeAgentOptions",
+                "server.agent_runtime.options_assembler.ClaudeAgentOptions",
                 _FakeOptions,
             ):
                 with patch(
-                    "server.agent_runtime.session_manager.HookMatcher",
+                    "server.agent_runtime.options_assembler.HookMatcher",
                     _FakeHookMatcher,
                 ):
                     options = await manager._build_options("demo")
@@ -111,7 +111,7 @@ class TestSessionManagerProjectScope:
         assert matcher.matcher is None
         # Without can_use_tool: only file_access_hook
         assert len(matcher.hooks) == 1
-        assert matcher.hooks[0] is not manager._keep_stream_open_hook
+        assert matcher.hooks[0] is not manager._options_assembler._keep_stream_open_hook
 
         await engine.dispose()
 
@@ -126,18 +126,18 @@ class TestSessionManagerProjectScope:
             data_dir=tmp_path,
             meta_store=store,
         )
-        monkeypatch.setattr(SessionManager, "_build_provider_env_overrides", _fake_provider_env)
+        monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
 
         async def _can_use_tool(_tool_name, _input_data, _context):
             return None
 
-        with patch("server.agent_runtime.session_manager.SDK_AVAILABLE", True):
+        with patch("server.agent_runtime.options_assembler.SDK_AVAILABLE", True):
             with patch(
-                "server.agent_runtime.session_manager.ClaudeAgentOptions",
+                "server.agent_runtime.options_assembler.ClaudeAgentOptions",
                 _FakeOptions,
             ):
                 with patch(
-                    "server.agent_runtime.session_manager.HookMatcher",
+                    "server.agent_runtime.options_assembler.HookMatcher",
                     _FakeHookMatcher,
                 ):
                     options = await manager._build_options(
@@ -150,7 +150,7 @@ class TestSessionManagerProjectScope:
         matcher = hooks["PreToolUse"][0]
         assert matcher.matcher is None
         assert len(matcher.hooks) == 2
-        assert matcher.hooks[0] is manager._keep_stream_open_hook
+        assert matcher.hooks[0] is manager._options_assembler._keep_stream_open_hook
 
         await engine.dispose()
 
@@ -186,7 +186,7 @@ class TestSessionManagerProjectScope:
             meta_store=store,
         )
 
-        prompt = manager._build_project_context("demo")
+        prompt = manager._options_assembler._build_project_context("demo")
 
         # Session-invariant facts are present
         assert "项目标识：demo" in prompt
@@ -236,7 +236,7 @@ class TestSessionManagerProjectScope:
             meta_store=store,
         )
 
-        prompt = manager._build_project_context("empty")
+        prompt = manager._options_assembler._build_project_context("empty")
 
         assert "项目标识：empty" in prompt
         assert f"项目目录（即当前工作目录 cwd）：{project_dir.resolve().as_posix()}" in prompt
@@ -296,6 +296,6 @@ class TestSystemPromptProjectContext:
             meta_store=store,
         )
 
-        prompt = manager._build_project_context("does-not-exist")
+        prompt = manager._options_assembler._build_project_context("does-not-exist")
         assert prompt == ""
         await engine.dispose()


### PR DESCRIPTION
## 范围

从 `SessionManager` 析出 **Options 装配器**（`OptionsAssembler`）：持依赖、允许 I/O，异步 `build()` 产出 `ClaudeAgentOptions`。纯结构重组，行为逐字保留。不动 #1005 析出的 `AgentAccessPolicy` 接缝（按 issue 明示保持既有接缝）。

## 变更

- 新增 `server/agent_runtime/options_assembler.py`：装配 DB 凭证注入（Anthropic 真值 + 其他供应商空值覆盖）、prompt 变体与项目上下文、各 PreToolUse/PostToolUse hook 工厂（含 JSON 校验 hook）、`AgentAccessPolicy` 的 settings 编译与裁决 adapter 接线。
- `SessionManager._build_options` / `_build_session_store` 收敛为薄委派；`access_policy` / `max_turns` / `session_factory` / `user_id` 一律用 provider 回调现取，`configure_sandbox_runtime` / `refresh_config` 换新后对后续会话立即生效。
- 凭证注入析出为模块级 `load_provider_env_overrides`，函数体与原 `_build_provider_env_overrides` 逐字一致（环境变量名单仍以 `env_keys` 为单一真相源）。
- 新增 `tests/agent_runtime/test_options_assembler.py`（以注入假依赖驱动，不 monkeypatch 私有方法）；5 个既有测试文件断言逐字搬家，触点指向装配器。

## 验收清单

- [x] 本地已跑相关测试：`uv run python -m pytest`（全量 **5629 passed**）；`uv run ruff check/format`（绿）；`uv run basedpyright`（0 error）
- [x] 手动验证：逐段比对父提交 `_build_options` 与装配器，凭证注入顺序/内容、hook 注册、cold-start/reconnect/locale 重建、store 单例共享（AssistantService 与 SDK build 同一实例）均等价
- [x] 新增面向用户文案已加 zh/en 翻译（如适用）：本 PR 无面向用户文案（仅 agent 侧字符串，豁免 i18n）
- [x] 无新增 ESLint disable
- [x] CODEOWNERS 要求的 review 已请求

## 本地审查修复

独立审查（xhigh 多 agent /code-review）发现并修复一处：装配器原在 `__init__` 急切快照 `_session_factory` / `_user_id`，而析出前 `_build_session_store` 惰性读 `SessionManager` 属性，且用量记录 `_finalize_turn` 仍实时读 `_user_id`——两条 seam 分叉，后续按会话注入 per-user 时会让 transcript store 与用量行落到不同命名空间。已改为 provider 回调现取，恢复析出前时点（生产无触发者，属超前防御 + 恢复逐字等价）。

## 已知 defer

- `transcripts_dir` 每次 build 都 mkdir 但从不读取（父提交即有的死代码，逐字搬迁）；纯重构 PR 内移除会偏离逐字保留，单列 follow-up：#1021

Closes #1007


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增会话选项装配流程，启动和重连时可自动组装运行所需配置、权限与提示内容。
  * 增加更完善的工具执行保护，包括文件访问校验、Bash 环境清理和 JSON 写入校验。

* **Bug Fixes**
  * 优化会话启动失败时的错误信息传递与缓冲处理，便于更快定位问题。

* **测试**
  * 新增并更新多项测试，覆盖选项装配、会话存储、沙箱与安全钩子行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->