### PR TITLE
fix(project-events): 页面刷新或多标签切换时项目实时更新不再漏推

### DIFF
--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -149,15 +149,19 @@ class ProjectEventService:
         )
 
     async def _stop_watch(self, project_name: str) -> None:
-        """末订阅者钩子：停止后台扫描任务并注销通道。"""
-        channel = self._channels.get(project_name)
+        """末订阅者钩子：停止后台扫描任务并注销通道。
+
+        先从注册表摘除通道再 await watch task 退出——摘除与取回之间无让出点，
+        摘的正是当前通道。收尾期间让出事件循环时，并发进入的新订阅者取不到这个
+        将死通道，会新建独立通道注册入表，不会被本次收尾的删除连带摘掉。
+        """
+        channel = self._channels.pop(project_name, None)
         if channel is None:
             return
         task = channel.task
         if task is not None:
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
-        self._channels.pop(project_name, None)
 
     async def _subscribe(self, project_name: str) -> tuple[SseChannel, asyncio.Queue, dict[str, Any]]:
         """Register a queue for *project_name* and return it with the initial snapshot.

--- a/server/sse_channel.py
+++ b/server/sse_channel.py
@@ -164,12 +164,18 @@ class SseChannel:
 
         注册前集合为空时触发 ``on_first_subscriber``（注册完成后才调用，
         钩子内可见新订阅者——项目事件流的后台扫描以 has_subscribers 判存活）。
+        钩子抛异常时回退这个新队列再向上抛出：调用方拿不到队列、无从退订，
+        队列不能滞留集合。
         """
         was_empty = not self._subscribers
         queue: asyncio.Queue = asyncio.Queue(maxsize=self._queue_maxsize)
         self._subscribers.add(queue)
         if was_empty and self._on_first_subscriber is not None:
-            self._on_first_subscriber()
+            try:
+                self._on_first_subscriber()
+            except BaseException:
+                self._subscribers.discard(queue)
+                raise
         return queue
 
     async def unsubscribe(self, queue: asyncio.Queue) -> None:

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -284,6 +284,76 @@ class TestProjectEventService:
 
         await service.shutdown()
 
+    @pytest.mark.asyncio
+    async def test_new_subscriber_entering_during_stop_watch_stays_registered(self, tmp_path, monkeypatch):
+        """末订阅者收尾挂起在 watch task 收尾等待点时，并发进入的新订阅者归属注册表现行通道，
+        收得到经注册表路由的 hint 广播，且旧 watch task 退役、无脱离注册表的 task。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        service = ProjectEventService(tmp_path, poll_interval=1.0)
+        await service.start()
+
+        entered_cancel = asyncio.Event()
+        allow_exit = asyncio.Event()
+
+        async def _controlled_watch(project_name, channel):
+            # 立即放行 _subscribe 的 ready 等待；被取消时停在收尾点，撑开竞态窗口。
+            channel.ready_event.set()
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                entered_cancel.set()
+                await allow_exit.wait()
+                raise
+
+        monkeypatch.setattr(service, "_watch_project", _controlled_watch)
+
+        # 订阅者 A 拉起旧通道与旧 watch task。
+        _sse_a, queue_a, _snap_a = await service._subscribe("demo")
+        old_channel = service._channels["demo"]
+        old_watch_task = old_channel.task
+
+        # A 退订触发末订阅者钩子；钩子停在等已取消 watch task 退出的收尾点。
+        stop_task = asyncio.create_task(service._unsubscribe("demo", queue_a))
+        await asyncio.wait_for(entered_cancel.wait(), timeout=1.0)
+
+        # 窗口内新订阅者 B 进入。
+        _sse_b, queue_b, _snap_b = await service._subscribe("demo")
+
+        # 放行旧 watch task，让末订阅者钩子跑完收尾。
+        allow_exit.set()
+        await asyncio.wait_for(stop_task, timeout=1.0)
+
+        # B 归属注册表中的现行通道，旧通道已退役。
+        assert "demo" in service._channels
+        assert service._channels["demo"] is not old_channel
+
+        # 经注册表路由的 hint 广播抵达 B。
+        service._apply_emitted_batch(
+            "demo",
+            "worker",
+            (
+                {
+                    "entity_type": "segment",
+                    "action": "storyboard_ready",
+                    "entity_id": "E1S01",
+                    "label": "分镜「E1S01」",
+                    "focus": None,
+                    "important": True,
+                },
+            ),
+        )
+        await asyncio.gather(*list(service._pending_batch_tasks), return_exceptions=True)
+        event_name, _payload = queue_b.get_nowait()
+        assert event_name == "changes"
+
+        # 旧 watch task 退役，未脱离注册表继续运行。
+        assert old_watch_task.done()
+
+        await service.shutdown()
+
     def test_projects_root_kwarg_overrides_default_subdir(self, tmp_path):
         """显式传 projects_root 时，service.pm 走该目录而非 project_root/'projects'。
 

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -297,62 +297,70 @@ class TestProjectEventService:
 
         entered_cancel = asyncio.Event()
         allow_exit = asyncio.Event()
+        stop_task: asyncio.Task | None = None
 
-        async def _controlled_watch(project_name, channel):
-            # 立即放行 _subscribe 的 ready 等待；被取消时停在收尾点，撑开竞态窗口。
-            channel.ready_event.set()
-            try:
-                await asyncio.sleep(3600)
-            except asyncio.CancelledError:
-                entered_cancel.set()
-                await allow_exit.wait()
-                raise
+        try:
 
-        monkeypatch.setattr(service, "_watch_project", _controlled_watch)
+            async def _controlled_watch(project_name, channel):
+                # 立即放行 _subscribe 的 ready 等待；被取消时停在收尾点，撑开竞态窗口。
+                channel.ready_event.set()
+                try:
+                    await asyncio.sleep(3600)
+                except asyncio.CancelledError:
+                    entered_cancel.set()
+                    await allow_exit.wait()
+                    raise
 
-        # 订阅者 A 拉起旧通道与旧 watch task。
-        _sse_a, queue_a, _snap_a = await service._subscribe("demo")
-        old_channel = service._channels["demo"]
-        old_watch_task = old_channel.task
+            monkeypatch.setattr(service, "_watch_project", _controlled_watch)
 
-        # A 退订触发末订阅者钩子；钩子停在等已取消 watch task 退出的收尾点。
-        stop_task = asyncio.create_task(service._unsubscribe("demo", queue_a))
-        await asyncio.wait_for(entered_cancel.wait(), timeout=1.0)
+            # 订阅者 A 拉起旧通道与旧 watch task。
+            _sse_a, queue_a, _snap_a = await service._subscribe("demo")
+            old_channel = service._channels["demo"]
+            old_watch_task = old_channel.task
 
-        # 窗口内新订阅者 B 进入。
-        _sse_b, queue_b, _snap_b = await service._subscribe("demo")
+            # A 退订触发末订阅者钩子；钩子停在等已取消 watch task 退出的收尾点。
+            stop_task = asyncio.create_task(service._unsubscribe("demo", queue_a))
+            await asyncio.wait_for(entered_cancel.wait(), timeout=1.0)
 
-        # 放行旧 watch task，让末订阅者钩子跑完收尾。
-        allow_exit.set()
-        await asyncio.wait_for(stop_task, timeout=1.0)
+            # 窗口内新订阅者 B 进入。
+            _sse_b, queue_b, _snap_b = await service._subscribe("demo")
 
-        # B 归属注册表中的现行通道，旧通道已退役。
-        assert "demo" in service._channels
-        assert service._channels["demo"] is not old_channel
+            # 放行旧 watch task，让末订阅者钩子跑完收尾。
+            allow_exit.set()
+            await asyncio.wait_for(stop_task, timeout=1.0)
 
-        # 经注册表路由的 hint 广播抵达 B。
-        service._apply_emitted_batch(
-            "demo",
-            "worker",
-            (
-                {
-                    "entity_type": "segment",
-                    "action": "storyboard_ready",
-                    "entity_id": "E1S01",
-                    "label": "分镜「E1S01」",
-                    "focus": None,
-                    "important": True,
-                },
-            ),
-        )
-        await asyncio.gather(*list(service._pending_batch_tasks), return_exceptions=True)
-        event_name, _payload = queue_b.get_nowait()
-        assert event_name == "changes"
+            # B 归属注册表中的现行通道，旧通道已退役。
+            assert "demo" in service._channels
+            assert service._channels["demo"] is not old_channel
 
-        # 旧 watch task 退役，未脱离注册表继续运行。
-        assert old_watch_task.done()
+            # 经注册表路由的 hint 广播抵达 B。
+            service._apply_emitted_batch(
+                "demo",
+                "worker",
+                (
+                    {
+                        "entity_type": "segment",
+                        "action": "storyboard_ready",
+                        "entity_id": "E1S01",
+                        "label": "分镜「E1S01」",
+                        "focus": None,
+                        "important": True,
+                    },
+                ),
+            )
+            await asyncio.gather(*list(service._pending_batch_tasks), return_exceptions=True)
+            event_name, _payload = queue_b.get_nowait()
+            assert event_name == "changes"
 
-        await service.shutdown()
+            # 旧 watch task 退役，未脱离注册表继续运行。
+            assert old_watch_task.done()
+        finally:
+            # 断言或 wait_for 提前失败时，被刻意挂起的 watch/stop task 仍需释放，
+            # 否则会跨用例泄漏后台任务与 project_change_hints 的全局监听注册。
+            allow_exit.set()
+            if stop_task is not None and not stop_task.done():
+                await asyncio.gather(stop_task, return_exceptions=True)
+            await service.shutdown()
 
     def test_projects_root_kwarg_overrides_default_subdir(self, tmp_path):
         """显式传 projects_root 时，service.pm 走该目录而非 project_root/'projects'。

--- a/tests/test_sse_channel.py
+++ b/tests/test_sse_channel.py
@@ -6,6 +6,8 @@
 
 import asyncio
 
+import pytest
+
 from server.sse_channel import IDLE, DropSubscriber, EvictNonCriticalAndSignal, SseChannel
 
 
@@ -223,3 +225,16 @@ class TestLifecycleHooks:
         assert channel.unsubscribe_nowait(first) is False
         assert channel.unsubscribe_nowait(second) is True
         assert events == ["first"]  # 不触发末位钩子，收尾由调用方自理
+
+    async def test_first_subscriber_hook_exception_propagates_and_unwinds_queue(self):
+        def _boom() -> None:
+            raise RuntimeError("hook failed")
+
+        channel = SseChannel(overflow=DropSubscriber(), on_first_subscriber=_boom)
+
+        with pytest.raises(RuntimeError, match="hook failed"):
+            channel.subscribe()
+
+        # 钩子抛异常时新注册的队列回退，订阅集合复原到调用前状态。
+        assert not channel.has_subscribers
+        assert channel.subscriber_count == 0


### PR DESCRIPTION
Closes #1026

## 问题

项目事件流在页面刷新、多标签页开关等末订阅者退订与新订阅进入交错的时序下，存在竞态窗口：末订阅者收尾钩子 `_stop_watch` 先 await 已取消 watch task 退出、之后才把通道移出注册表，让出事件循环期间进入的新订阅者会取到同一将死通道并注册，收尾恢复后连同该新订阅者与新起 watch task 一并被摘出注册表——该订阅者收不到经注册表路由的 hint 触发广播，只剩自身通道定时扫描结果，游离 watch task 空转到断开。命中时表现为项目实时更新漏推，需刷新重连才自愈。

## 修复

- `ProjectEventService._stop_watch`：把 `self._channels.pop` 提到 `await` 之前——摘除与取回之间无让出点，收尾期间进入的新订阅者取不到将死通道，转而新建独立通道注册入表，不再被本次收尾连带摘掉。
- `SseChannel.subscribe`：首订阅者钩子抛异常时 `discard` 掉刚注册的队列再向上抛出，调用方拿不到队列也就无从退订，队列不再永久滞留订阅集合（防御性缺口，当前消费方钩子不抛异常，路径不可达）。

纯行为修复，不重构通道生命周期结构，未越出 SseChannel「订阅/退订、广播、心跳、溢出」的既定边界。

## 验证

- 新增确定性回归测试：
  - `test_new_subscriber_entering_during_stop_watch_stays_registered`——末订阅者收尾挂起在 watch task 收尾等待点时，并发进入的新订阅者归属注册表现行通道、收得到 hint 广播，旧 watch task 退役无脱离注册表的 task。
  - `test_first_subscriber_hook_exception_propagates_and_unwinds_queue`——首订阅者钩子抛异常时订阅调用上抛，通道 `has_subscribers` 为 False。
- `pytest tests/test_project_events_service.py tests/test_sse_channel.py` — 32 passed。
- `ruff check` / `ruff format --check` 通过；`basedpyright` 0 error。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 调整了后台监控停止与通道清理的时序，避免并发新订阅被误影响，确保正确完成注销与退出。
  * 在首次订阅回调抛出异常时，自动回退刚创建的订阅队列，避免异常后残留无效订阅状态。
* **Tests**
  * 新增并发竞态回归测试，覆盖“停止收尾期间新订阅进入”的场景。
  * 新增异常传播与回退的订阅生命周期测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->