### PR TITLE
fix(frontend): 修复 pnpm-lock.yaml 重复 key 导致的前端依赖安装失败

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -2551,20 +2551,6 @@ packages:
       react-dom:
         optional: true
 
-  framer-motion@12.42.0:
-    resolution: {integrity: sha512-wp7EJnfWaaEScVygKv3e20udoRz+LbtxScsuTkakAxfXmt+ReC6WyPW2nINRAGvd+hG9odwcjBLyOTPjH5pBRA==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3424,9 +3410,6 @@ packages:
   mixin-deep@1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
     engines: {node: '>=0.10.0'}
-
-  motion-dom@12.42.0:
-    resolution: {integrity: sha512-M63h4n8R+quJdNhBwuLlgxM+OLYa9+I/T2pzDRboB9fLXRdbou+Gw7Zury+SkpaCyACP1JHSjHgZ1EgTkBr30w==}
 
   motion-dom@12.42.0:
     resolution: {integrity: sha512-M63h4n8R+quJdNhBwuLlgxM+OLYa9+I/T2pzDRboB9fLXRdbou+Gw7Zury+SkpaCyACP1JHSjHgZ1EgTkBr30w==}
@@ -7409,16 +7392,6 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  framer-motion@12.42.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      motion-dom: 12.42.0
-      motion-utils: 12.39.0
-      tslib: 2.8.1
-    optionalDependencies:
-      '@emotion/is-prop-valid': 1.4.0
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   fsevents@2.3.3:
     optional: true
 
@@ -8657,10 +8630,6 @@ snapshots:
     dependencies:
       for-in: 1.0.2
       is-extendable: 1.0.1
-
-  motion-dom@12.42.0:
-    dependencies:
-      motion-utils: 12.39.0
 
   motion-dom@12.42.0:
     dependencies:


### PR DESCRIPTION
## 范围

仅 `frontend/pnpm-lock.yaml`（去重）。不动 `package.json`，不改任何依赖版本。

## 变更

- dependabot 合入 vite-tailwind 组升级（#955）时，lockfile 出现 YAML 重复 key，导致 `pnpm install --frozen-lockfile` 报 `ERR_PNPM_BROKEN_LOCKFILE`，main 的 Tests/Docker workflow 红灯。
- 根因是那次合并把 `packages:` 与 `snapshots:` 两节的 `framer-motion@12.42.0`、`motion-dom@12.42.0` 各复制了一份完全一致的块（该两包版本在升级前后均为 12.42.0，属合并残留而非版本变更）。
- 精确删除 4 个字节一致的重复块（共 -31 行，0 增），不触碰其余任何条目，framer-motion / motion-dom 及全部依赖版本零漂移。

## 验收清单

- [x] 本地已跑相关测试：
  - 严格 YAML loader（禁重复 key，递归深构造）解析通过
  - `pnpm install --frozen-lockfile` 干净通过（EXIT=0），未改写 lockfile
  - `pnpm lint` 通过；`pnpm check`（tsc + eslint + vitest 98 文件 / 797 测试）全绿
- [x] 手动验证了改动所声称的行为：diff 收敛于 4 个重复块删除，版本无漂移（framer-motion `^12.40.0`→12.42.0、@vitejs/plugin-react `^6.0.2`→6.0.3、vite `^8.0.14`→8.1.0、tailwindcss `^4.3.0`→4.3.1，均满足声明且保留 dependabot 升级意图）
- [ ] 新增面向用户文案已加 zh/en 翻译（如适用）— 不适用，无文案改动
- [x] 无新增 ESLint disable
- [ ] CODEOWNERS 要求的 review 已请求 — 由 lead 处理合并

## 已知 defer

无
