### PR TITLE
fix(events): 参考生视频通知点击定位到对应视频单元，各骨架通知标签一致

### DIFF
--- a/frontend/src/hooks/useProjectEventsSSE.test.tsx
+++ b/frontend/src/hooks/useProjectEventsSSE.test.tsx
@@ -113,6 +113,66 @@ describe("useProjectEventsSSE", () => {
     expect(useAppStore.getState().assistantToolActivitySuppressed).toBe(true);
   });
 
+  it("navigates reference video units to the reference canvas via reference_unit target", async () => {
+    let capturedOptions: ProjectEventStreamOptions | undefined;
+    vi.spyOn(API, "openProjectEventStream").mockImplementation((options) => {
+      capturedOptions = options;
+      return { close: vi.fn() } as unknown as EventSource;
+    });
+
+    renderHarness("/episodes/1");
+
+    act(() => {
+      capturedOptions?.onChanges?.(
+        {
+          project_name: "demo",
+          batch_id: "batch-ref",
+          fingerprint: "fp-ref",
+          generated_at: "2026-03-01T00:00:00Z",
+          source: "worker",
+          changes: [
+            {
+              entity_type: "reference_unit",
+              action: "created",
+              entity_id: "E1U01",
+              label: "视频单元「E1U01」",
+              episode: 1,
+              focus: {
+                pane: "episode",
+                episode: 1,
+                anchor_type: "reference_unit",
+                anchor_id: "E1U01",
+              },
+              important: true,
+            },
+          ],
+        },
+        new MessageEvent("changes"),
+      );
+    });
+
+    await waitFor(() => {
+      expect(API.getProject).toHaveBeenCalledWith("demo");
+      expect(useAppStore.getState().scrollTarget).toEqual(
+        expect.objectContaining({
+          type: "reference_unit",
+          id: "E1U01",
+          route: "/episodes/1",
+        }),
+      );
+    });
+    expect(useAppStore.getState().workspaceNotifications[0]).toEqual(
+      expect.objectContaining({
+        text: "AI 刚新增了 视频单元「E1U01」，点击查看",
+        target: expect.objectContaining({
+          type: "reference_unit",
+          id: "E1U01",
+          route: "/episodes/1",
+        }),
+      }),
+    );
+  });
+
   it("defers focus when the user is editing", async () => {
     let capturedOptions: ProjectEventStreamOptions | undefined;
     vi.spyOn(API, "openProjectEventStream").mockImplementation((options) => {

--- a/frontend/src/hooks/useProjectEventsSSE.ts
+++ b/frontend/src/hooks/useProjectEventsSSE.ts
@@ -21,6 +21,10 @@ import {
 
 const CHANGE_PRIORITY: Record<string, number> = {
   "segment:updated": 0,
+  // drama/ad/参考生视频骨架条目的 updated 与 narration 分镜同优先级，四种骨架通知排序一致。
+  "drama_scene:updated": 0,
+  "shot:updated": 0,
+  "reference_unit:updated": 0,
   "character:created": 1,
   "character:updated": 2,
   "scene:created": 3,

--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -3,13 +3,29 @@ export type ProjectEventSource = "webui" | "worker" | "filesystem";
 export interface ProjectChangeFocus {
   pane: "characters" | "scenes" | "props" | "episode";
   episode?: number;
-  anchor_type?: "character" | "scene" | "prop" | "segment";
+  // segment/drama_scene/shot 三种骨架条目走时间线画布，锚点类型统一为 segment；video_units 走参考
+  // 生视频画布，锚点类型为 reference_unit（与 WorkspaceFocusTarget["type"] 及画布守卫对齐）。
+  anchor_type?: "character" | "scene" | "prop" | "segment" | "reference_unit";
   anchor_id?: string;
   tab?: string;
 }
 
 export interface ProjectChange {
-  entity_type: "project" | "character" | "scene" | "prop" | "segment" | "episode" | "overview" | "draft" | "grid";
+  // segment/drama_scene/shot/reference_unit 为四种剧本骨架条目类型（narration/drama/ad/参考生视频），
+  // 驱动分组标签映射；drama 用 drama_scene 避免与命名实体 scene 撞组。
+  entity_type:
+    | "project"
+    | "character"
+    | "scene"
+    | "prop"
+    | "segment"
+    | "drama_scene"
+    | "shot"
+    | "reference_unit"
+    | "episode"
+    | "overview"
+    | "draft"
+    | "grid";
   action:
     | "created"
     | "updated"

--- a/frontend/src/utils/project-changes.test.ts
+++ b/frontend/src/utils/project-changes.test.ts
@@ -67,4 +67,38 @@ describe("project-changes utils", () => {
       "AI 刚新增了 6 个角色：张三、李四、王五、赵六、钱七…等，点击查看",
     );
   });
+
+  it("labels each skeleton kind's group title and item nouns consistently", () => {
+    // 四种骨架 created 分组的标题名词须与条目名词一致：分镜/场景/镜头/视频单元。
+    const cases: Array<{
+      entityType: ProjectChange["entity_type"];
+      noun: string;
+    }> = [
+      { entityType: "segment", noun: "分镜" },
+      { entityType: "drama_scene", noun: "场景" },
+      { entityType: "shot", noun: "镜头" },
+      { entityType: "reference_unit", noun: "视频单元" },
+    ];
+
+    for (const { entityType, noun } of cases) {
+      const [group] = groupChangesByType([
+        makeChange({
+          entity_type: entityType,
+          action: "created",
+          entity_id: "E1X01",
+          label: `${noun}「E1X01」`,
+        }),
+        makeChange({
+          entity_type: entityType,
+          action: "created",
+          entity_id: "E1X02",
+          label: `${noun}「E1X02」`,
+        }),
+      ]);
+      // 分组标题用 entity_type 名词，条目名单用裸 id（与既有 segment 行为一致）。
+      expect(formatGroupedNotificationText(group)).toBe(
+        `新增了 2 个${noun}：E1X01、E1X02`,
+      );
+    }
+  });
 });

--- a/frontend/src/utils/project-changes.ts
+++ b/frontend/src/utils/project-changes.ts
@@ -8,6 +8,9 @@ const ENTITY_LABELS: Record<ProjectChange["entity_type"], string> = {
   scene: "场景",
   prop: "道具",
   segment: "分镜",
+  drama_scene: "场景",
+  shot: "镜头",
+  reference_unit: "视频单元",
   episode: "剧集",
   overview: "项目概览",
   draft: "预处理",
@@ -85,7 +88,10 @@ function getChangeListLabel(change: ProjectChange): string {
     change.entity_type === "character" ||
     change.entity_type === "scene" ||
     change.entity_type === "prop" ||
-    change.entity_type === "segment"
+    change.entity_type === "segment" ||
+    change.entity_type === "drama_scene" ||
+    change.entity_type === "shot" ||
+    change.entity_type === "reference_unit"
   ) {
     return change.entity_id;
   }

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -41,6 +41,26 @@ _SKELETON_ITEM_NOUNS: dict[str, str] = {
     "video_units": "视频单元",
 }
 
+# 分镜级事件的实体类型按骨架种类推导，与 ``_SKELETON_ITEM_NOUNS`` 同源。驱动前端分组标签映射
+# （``ENTITY_LABELS``），使四种骨架各显分镜/场景/镜头/视频单元，而非恒为「分镜」。取值与既有
+# ``entity_type`` 枚举不冲突（drama 用 ``drama_scene`` 避免与命名实体 ``scene`` 撞组）。
+_SKELETON_ENTITY_TYPES: dict[str, str] = {
+    "segments": "segment",
+    "scenes": "drama_scene",
+    "shots": "shot",
+    "video_units": "reference_unit",
+}
+
+# 分镜级事件的锚点类型按骨架种类推导，取值与前端各画布的滚动目标类型守卫对齐：video_units 归
+# ``reference_unit``（参考生视频画布按此选中并高亮对应视频单元），其余归 ``segment``
+# （narration/drama/ad 共用时间线镜头拆分视图，按 id 选中条目）。
+_SKELETON_ANCHOR_TYPES: dict[str, str] = {
+    "segments": "segment",
+    "scenes": "segment",
+    "shots": "segment",
+    "video_units": "reference_unit",
+}
+
 
 def _utc_now_iso() -> str:
     return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -850,6 +870,7 @@ class ProjectEventService:
                         important=False,
                     )
                 )
+            entity_type = self._script_item_entity_type(current_meta)
             for item_id in sorted(set(previous_items) & set(current_items)):
                 previous_item = previous_items[item_id]
                 current_item = current_items[item_id]
@@ -861,7 +882,7 @@ class ProjectEventService:
                 ):
                     changes.append(
                         self._build_entity_change(
-                            entity_type="segment",
+                            entity_type=entity_type,
                             action="storyboard_ready",
                             entity_id=item_id,
                             label=label,
@@ -877,7 +898,7 @@ class ProjectEventService:
                 ):
                     changes.append(
                         self._build_entity_change(
-                            entity_type="segment",
+                            entity_type=entity_type,
                             action="video_ready",
                             entity_id=item_id,
                             label=label,
@@ -893,7 +914,7 @@ class ProjectEventService:
                 if previous_body != current_body:
                     changes.append(
                         self._build_entity_change(
-                            entity_type="segment",
+                            entity_type=entity_type,
                             action="updated",
                             entity_id=item_id,
                             label=label,
@@ -906,6 +927,16 @@ class ProjectEventService:
         return changes
 
     @staticmethod
+    def _script_item_entity_type(script_meta: dict[str, Any]) -> str:
+        kind = str(script_meta.get("kind") or "segments")
+        return _SKELETON_ENTITY_TYPES.get(kind, "segment")
+
+    @staticmethod
+    def _script_item_anchor_type(script_meta: dict[str, Any]) -> str:
+        kind = str(script_meta.get("kind") or "segments")
+        return _SKELETON_ANCHOR_TYPES.get(kind, "segment")
+
+    @staticmethod
     def _build_script_item_focus(
         item_id: str,
         script_meta: dict[str, Any],
@@ -913,7 +944,7 @@ class ProjectEventService:
         return {
             "pane": "episode",
             "episode": script_meta.get("episode"),
-            "anchor_type": "segment",
+            "anchor_type": ProjectEventService._script_item_anchor_type(script_meta),
             "anchor_id": item_id,
         }
 
@@ -934,7 +965,7 @@ class ProjectEventService:
     ) -> dict[str, Any]:
         focus = self._build_script_item_focus(item_id, script_meta) if action != "deleted" else None
         return self._build_entity_change(
-            entity_type="segment",
+            entity_type=self._script_item_entity_type(script_meta),
             action=action,
             entity_id=item_id,
             label=self._build_script_item_label(item_id, script_meta),

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -927,14 +927,17 @@ class ProjectEventService:
         return changes
 
     @staticmethod
+    def _script_kind(script_meta: dict[str, Any]) -> str:
+        # 单一读取点，让名词/实体类型/锚点类型三者按同一 kind 归一，回退口径不会分叉。
+        return str(script_meta.get("kind") or "segments")
+
+    @staticmethod
     def _script_item_entity_type(script_meta: dict[str, Any]) -> str:
-        kind = str(script_meta.get("kind") or "segments")
-        return _SKELETON_ENTITY_TYPES.get(kind, "segment")
+        return _SKELETON_ENTITY_TYPES.get(ProjectEventService._script_kind(script_meta), "segment")
 
     @staticmethod
     def _script_item_anchor_type(script_meta: dict[str, Any]) -> str:
-        kind = str(script_meta.get("kind") or "segments")
-        return _SKELETON_ANCHOR_TYPES.get(kind, "segment")
+        return _SKELETON_ANCHOR_TYPES.get(ProjectEventService._script_kind(script_meta), "segment")
 
     @staticmethod
     def _build_script_item_focus(
@@ -950,8 +953,7 @@ class ProjectEventService:
 
     @staticmethod
     def _build_script_item_label(item_id: str, script_meta: dict[str, Any]) -> str:
-        kind = str(script_meta.get("kind") or "segments")
-        noun = _SKELETON_ITEM_NOUNS.get(kind, "分镜")
+        noun = _SKELETON_ITEM_NOUNS.get(ProjectEventService._script_kind(script_meta), "分镜")
         return f"{noun}「{item_id}」"
 
     def _build_script_item_change(

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -7,6 +7,8 @@ from lib.project_change_hints import emit_project_change_batch, project_change_s
 from lib.project_manager import ProjectManager
 from lib.script_skeleton import SKELETONS
 from server.services.project_events import (
+    _SKELETON_ANCHOR_TYPES,
+    _SKELETON_ENTITY_TYPES,
     _SKELETON_ITEM_NOUNS,
     ProjectEventService,
 )
@@ -98,7 +100,10 @@ class TestProjectEventService:
 
         assert any(change["entity_type"] == "character" and change["action"] == "created" for change in changes)
         assert any(change["action"] == "storyboard_ready" for change in changes)
-        assert any(change["entity_type"] == "segment" and change["action"] == "updated" for change in changes)
+        segment_updated = [c for c in changes if c["entity_type"] == "segment" and c["action"] == "updated"]
+        assert segment_updated
+        # narration 分镜走时间线画布：锚点类型恒为 segment（回归守卫，不得漂移）。
+        assert all(c["focus"]["anchor_type"] == "segment" for c in segment_updated)
 
     def test_diff_snapshots_reports_project_metadata_and_new_segments(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
@@ -435,7 +440,10 @@ class TestProjectEventService:
         assert any(c["action"] == "created" and c["entity_id"] == "E1S02" for c in changes)
         assert any(c["action"] == "storyboard_ready" and c["entity_id"] == "E1S01" for c in changes)
         assert any(c["action"] == "updated" and c["entity_id"] == "E1S01" for c in changes)
-        assert all(c["label"].startswith("镜头") for c in changes if c["entity_type"] == "segment")
+        shot_changes = [c for c in changes if c["entity_type"] == "shot"]
+        assert shot_changes and all(c["label"].startswith("镜头") for c in shot_changes)
+        # ad 镜头走时间线画布：可导航事件的锚点类型为 segment（ShotSplitView 守卫）。
+        assert all(c["focus"]["anchor_type"] == "segment" for c in shot_changes if c["focus"] is not None)
 
         script = pm.load_script("ad-demo", "episode_1.json")
         script["shots"][0]["generated_assets"]["video_clip"] = "videos/E1S01.mp4"
@@ -503,7 +511,10 @@ class TestProjectEventService:
         assert any(c["action"] == "created" and c["entity_id"] == "E1S02" for c in changes)
         assert any(c["action"] == "storyboard_ready" and c["entity_id"] == "E1S01" for c in changes)
         assert any(c["action"] == "video_ready" and c["entity_id"] == "E1S01" for c in changes)
-        assert all(c["label"].startswith("场景") for c in changes if c["entity_type"] == "segment")
+        scene_changes = [c for c in changes if c["entity_type"] == "drama_scene"]
+        assert scene_changes and all(c["label"].startswith("场景") for c in scene_changes)
+        # drama 场景走时间线画布：可导航事件的锚点类型为 segment。
+        assert all(c["focus"]["anchor_type"] == "segment" for c in scene_changes if c["focus"] is not None)
 
     def test_diff_snapshots_reports_reference_video_unit_lifecycle_events(self, tmp_path):
         """reference_video(video_units) 项目的分镜级事件全周期，且 characters 从 references 派生。"""
@@ -565,7 +576,12 @@ class TestProjectEventService:
         assert any(c["action"] == "created" and c["entity_id"] == "E1U02" for c in changes)
         assert any(c["action"] == "storyboard_ready" and c["entity_id"] == "E1U01" for c in changes)
         assert any(c["action"] == "updated" and c["entity_id"] == "E1U01" for c in changes)
-        assert all(c["label"].startswith("视频单元") for c in changes if c["entity_type"] == "segment")
+        unit_changes = [c for c in changes if c["entity_type"] == "reference_unit"]
+        assert unit_changes and all(c["label"].startswith("视频单元") for c in unit_changes)
+        # 参考生视频单元走参考画布：可导航事件（created/updated）的锚点类型为 reference_unit，
+        # 前端据此切到 units tab 并选中对应单元——本 issue 的核心修复。
+        navigable = [c for c in unit_changes if c["action"] in ("created", "updated")]
+        assert navigable and all(c["focus"]["anchor_type"] == "reference_unit" for c in navigable)
 
         script = pm.load_script("ref-demo", "episode_1.json")
         script["video_units"][0]["generated_assets"]["video_clip"] = "videos/E1U01.mp4"
@@ -666,3 +682,46 @@ class TestProjectEventService:
     def test_every_skeleton_kind_has_label_noun(self):
         """标签名词表覆盖全部骨架种类——第五种骨架出现时此处失败，逼出名词补全。"""
         assert set(_SKELETON_ITEM_NOUNS) == set(SKELETONS)
+
+    def test_every_skeleton_kind_has_entity_and_anchor_type(self):
+        """实体/锚点类型表覆盖全部骨架种类——第五种骨架出现时此处失败，逼出补全。"""
+        assert set(_SKELETON_ENTITY_TYPES) == set(SKELETONS)
+        assert set(_SKELETON_ANCHOR_TYPES) == set(SKELETONS)
+
+    @pytest.mark.parametrize(
+        ("kind", "content_mode", "generation_mode", "entity_type", "anchor_type"),
+        [
+            ("segments", "narration", None, "segment", "segment"),
+            ("scenes", "drama", None, "drama_scene", "segment"),
+            ("shots", "ad", None, "shot", "segment"),
+            ("video_units", "narration", "reference_video", "reference_unit", "reference_unit"),
+        ],
+    )
+    def test_script_item_change_carries_kind_specific_types(
+        self, tmp_path, kind, content_mode, generation_mode, entity_type, anchor_type
+    ):
+        """分镜级事件的 entity_type（分组标签）与 focus.anchor_type（画布滚动目标）按骨架种类推导。"""
+        skeleton = SKELETONS[kind]
+        item: dict = {skeleton.id_field: "X1"}
+        if skeleton.chars_field is not None:
+            item[skeleton.chars_field] = ["Hero"]
+        else:
+            item["references"] = [{"type": "character", "name": "Hero"}]
+        script: dict = {"episode": 1, "content_mode": content_mode, kind: [item]}
+        if generation_mode is not None:
+            script["generation_mode"] = generation_mode
+
+        service = ProjectEventService(tmp_path)
+        meta = service._normalize_script_snapshot(script)
+        assert meta["kind"] == kind
+
+        change = service._build_script_item_change(
+            action="created",
+            item_id="X1",
+            script_file="episode_1.json",
+            script_meta=meta,
+            important=True,
+        )
+        assert change["entity_type"] == entity_type
+        assert change["focus"]["anchor_type"] == anchor_type
+        assert change["focus"]["anchor_id"] == "X1"


### PR DESCRIPTION
## 问题

参考生视频项目里，AI 变更通知（条目 created/updated）点击后只切到剧集路由，不选中、不高亮对应视频单元。根因：后端项目事件服务对四种剧本骨架（segments/scenes/shots/video_units）一律输出 `anchor_type: "segment"` 与 `entity_type: "segment"`，而参考生视频画布只响应 `reference_unit` 滚动目标，`segment` 被忽略。同时通知分组标题恒显示「分镜」，与条目名词（镜头/场景/视频单元）在同一条通知内不一致。

## 修复

分镜级事件的锚点类型与实体类型按剧本骨架种类推导：

- `anchor_type` 取导航型双值——video_units → `reference_unit`（参考生视频画布据此切到 units tab 并选中高亮），其余骨架 → `segment`（narration/drama/ad 共用时间线镜头拆分视图）。取值与既有 `task-target.ts` 生产者及各画布滚动目标守卫一致。
- `entity_type` 按骨架四值区分（segment/drama_scene/shot/reference_unit），仅用于分组标签，使四种骨架的分组标题与条目名词一致：分镜/场景/镜头/视频单元。
- 前端 `ProjectChange`、`ProjectChangeFocus` 联合类型、`ENTITY_LABELS` 标签映射、通知排序优先级同步扩展，与后端新枚举对齐。

## 验证

- 后端 `tests/test_project_events_service.py`：新增参数化测试覆盖四骨架各自的 `entity_type` 与 `focus.anchor_type`，并加回归守卫（narration/drama/ad 锚点恒 segment、参考单元可导航事件锚点恒 reference_unit）；21 passed。
- 前端 `useProjectEventsSSE.test.tsx` / `project-changes.test.ts`：新增参考单元导航到 `reference_unit` 目标、四骨架分组标题与条目名词一致的用例；`pnpm lint && pnpm check` 全绿（799 tests）。
- `uv run ruff check/format`、`uv run basedpyright` 0 error。

Closes #1015


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 现在项目变更通知会更准确地识别不同内容类型，并支持跳转到“参考画布”等对应位置。
  * 部分新增内容会以更合适的名称显示在通知和列表中。

* **Bug 修复**
  * 修正了变更通知的排序与聚焦顺序，让相关提醒更靠前、更容易定位。
  * 改善了多种脚本条目变更时的导航锚点，减少跳转到错误位置的情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->