### PR TITLE
fix(archive): 修复广告参考视频项目归档导入不再自愈，损坏骨架条目不再崩溃导入

### DIFF
--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -507,7 +507,7 @@ class DataValidator:
 
     def _validate_segments(
         self,
-        segments: list[dict[str, Any]],
+        segments: list[dict[str, Any]] | Any,
         project_characters: set[str],
         project_scenes: set[str],
         project_props: set[str],
@@ -517,12 +517,18 @@ class DataValidator:
         project_dir: Path | None = None,
     ) -> None:
         """验证 segments（narration 模式）"""
+        if not isinstance(segments, list):
+            errors.append("segments 必须是数组")
+            return
         if not segments:
             errors.append("segments 数组为空")
             return
 
         for index, segment in enumerate(segments):
             prefix = f"segments[{index}]"
+            if not isinstance(segment, dict):
+                errors.append(f"{prefix}: 必须是对象")
+                continue
 
             segment_id = segment.get("segment_id")
             if not segment_id:
@@ -583,7 +589,7 @@ class DataValidator:
 
     def _validate_scenes(
         self,
-        scenes: list[dict[str, Any]],
+        scenes: list[dict[str, Any]] | Any,
         project_characters: set[str],
         project_scenes: set[str],
         project_props: set[str],
@@ -597,12 +603,18 @@ class DataValidator:
 
         ``language`` 为项目 ``source_language``（说话量上界 warning 的语速按此取，与字幕派生同口径）。
         """
+        if not isinstance(scenes, list):
+            errors.append("scenes 必须是数组")
+            return
         if not scenes:
             errors.append("scenes 数组为空")
             return
 
         for index, scene in enumerate(scenes):
             prefix = f"scenes[{index}]"
+            if not isinstance(scene, dict):
+                errors.append(f"{prefix}: 必须是对象")
+                continue
 
             scene_id = scene.get("scene_id")
             if not scene_id:

--- a/server/services/project_archive.py
+++ b/server/services/project_archive.py
@@ -727,9 +727,14 @@ class ProjectArchiveService:
         content_mode = raw_content_mode
         generation_mode = effective_mode(project=project_payload, episode=script_payload)
 
-        # reference_video 模式的剧本用 video_units 组织，结构与 narration/drama 的
-        # segments/scenes 不同，单独走专用修复分支。
-        if generation_mode == "reference_video":
+        # 修复分流按规范解析的骨架种类走，而非 generation_mode：ad 项目 generation_mode
+        # 可为 reference_video 但骨架恒为 shots（不含 video_units），按 generation_mode
+        # 分流会把它错误送进 video_units 专用分支而静默 no-op。
+        kind = resolve_declared_kind(content_mode, generation_mode)
+
+        # video_units 骨架（narration/drama + 参考生视频）用 references 组织资产，结构与
+        # storyboard 骨架的 characters/scenes/props 不同，单独走专用修复分支。
+        if kind == "video_units":
             units_changed, units_project_changed = self._repair_video_units_payload(
                 project_dir,
                 script_path_rel=script_path_rel,
@@ -744,12 +749,11 @@ class ProjectArchiveService:
             )
             return script_changed or units_changed, project_changed or units_project_changed
 
-        # 非 reference 路径：骨架种类经规范解析（未知/缺失 content_mode fail-loud）。
-        kind = resolve_declared_kind(content_mode, generation_mode)
+        # storyboard 骨架（segments/scenes/shots，含 ad 的 shots）逐条补全字段与资产回填。
         items_key = kind
         id_field = SKELETONS[kind].id_field
         chars_field = SKELETONS[kind].chars_field
-        # storyboard 骨架（segments/scenes/shots）必有 chars_field；reference 已在上分支返回。
+        # storyboard 骨架必有 chars_field；video_units 已在上分支返回。
         assert chars_field is not None
 
         raw_items = script_payload.get(items_key)
@@ -847,7 +851,52 @@ class ProjectArchiveService:
                     ):
                         script_changed = True
 
+        # ad 参考直出的派生索引 reference_units 挂在 shots 之外，storyboard 循环不触及；
+        # 就地补全各 unit 的 generated_assets 缺失字段。
+        if kind == "shots" and self._repair_ad_reference_units(
+            script_path_rel=script_path_rel,
+            script_payload=script_payload,
+            content_mode=content_mode,
+            diagnostics=diagnostics,
+        ):
+            script_changed = True
+
         return script_changed, project_changed
+
+    def _repair_ad_reference_units(
+        self,
+        *,
+        script_path_rel: str,
+        script_payload: dict[str, Any],
+        content_mode: str,
+        diagnostics: ArchiveDiagnostics,
+    ) -> bool:
+        """回填 ad 参考直出派生索引 reference_units 各 unit 的 generated_assets（就地，缺字段才补）。
+
+        reference_units 是 shots 的派生索引，产物挂在 unit 上而非 shots。这里只对已存在的
+        unit 就地补全缺失的 generated_assets 字段——不从 shots 重派生分组：重派生需供应商时长
+        上限（归档修复时不可得），分组一旦改变会让既有产物指针错位丢失。既有资产值一律保留、
+        仅补缺失键，与派生索引 merge 的资产保留语义一致。
+        """
+        units = script_payload.get("reference_units")
+        if not isinstance(units, list):
+            return False
+
+        changed = False
+        for index, unit in enumerate(units):
+            if not isinstance(unit, dict):
+                continue
+            _, assets_changed = self._backfill_generated_assets(
+                unit,
+                content_mode=content_mode,
+                label="reference_units",
+                index=index,
+                location_prefix=f"{script_path_rel}:reference_units[{index}]",
+                diagnostics=diagnostics,
+            )
+            if assets_changed:
+                changed = True
+        return changed
 
     def _backfill_generated_assets(
         self,

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -1181,6 +1181,67 @@ class TestSourceKindValidation:
         assert result.valid, result.errors
 
 
+def _episode_for_kind(kind: str, items: object) -> tuple[dict, dict]:
+    """按骨架种类构造 (project, episode)：episode 的骨架数组键置为传入的 items（可为非法值）。"""
+    array_key, content_mode, gen_mode = {
+        "segments": ("segments", "narration", None),
+        "scenes": ("scenes", "drama", None),
+        "shots": ("shots", "ad", None),
+        "video_units": ("video_units", "narration", "reference_video"),
+    }[kind]
+    if content_mode == "ad":
+        project = _ad_project_payload()
+    else:
+        project = _project_payload(content_mode)
+    episode: dict = {"episode": 1, "title": "第一集", "content_mode": content_mode, array_key: items}
+    if gen_mode:
+        project["generation_mode"] = gen_mode
+        episode["generation_mode"] = gen_mode
+    return project, episode
+
+
+class TestSkeletonEntryTypeGuards:
+    """四种骨架的校验循环遇非 dict 条目 / 骨架字段非 list：记错误、valid=False、不抛异常。"""
+
+    def _validate(self, tmp_path, project: dict, episode: dict):
+        project_dir = tmp_path / "projects" / "demo"
+        _write_json(project_dir / "project.json", project)
+        _write_json(project_dir / "scripts" / "episode_1.json", episode)
+        return DataValidator(projects_root=str(tmp_path / "projects")).validate_episode("demo", "episode_1.json")
+
+    @pytest.mark.parametrize(
+        ("kind", "array_key"),
+        [
+            ("segments", "segments"),
+            ("scenes", "scenes"),
+            ("shots", "shots"),
+            ("video_units", "video_units"),
+        ],
+    )
+    def test_non_dict_entry_reported_not_crash(self, tmp_path, kind, array_key):
+        # 骨架数组含非 dict 条目（字符串）：记「条目类型错误」并继续，valid=False，不抛异常
+        project, episode = _episode_for_kind(kind, ["不是对象", {}])
+        result = self._validate(tmp_path, project, episode)
+        assert not result.valid
+        assert any(f"{array_key}[0]" in error for error in result.errors), result.errors
+
+    @pytest.mark.parametrize(
+        ("kind", "array_key"),
+        [
+            ("segments", "segments"),
+            ("scenes", "scenes"),
+            ("shots", "shots"),
+            ("video_units", "video_units"),
+        ],
+    )
+    def test_non_list_skeleton_field_reported_not_crash(self, tmp_path, kind, array_key):
+        # 骨架数组字段本身非 list（dict）：记「必须是数组」，valid=False，不抛异常
+        project, episode = _episode_for_kind(kind, {"E1S01": {}})
+        result = self._validate(tmp_path, project, episode)
+        assert not result.valid
+        assert any(array_key in error and "数组" in error for error in result.errors), result.errors
+
+
 # 骨架种类 → 触发该骨架的 (content_mode, generation_mode)，即 resolve_declared_kind 的逆。
 _KIND_TO_MODES = {
     "segments": ("narration", None),

--- a/tests/test_project_archive_ad_reference.py
+++ b/tests/test_project_archive_ad_reference.py
@@ -1,0 +1,153 @@
+"""归档导入针对 ad + 参考生视频（shots 骨架 + reference_units 派生索引）的修复测试。
+
+覆盖：修复分流此前按 generation_mode==reference_video 走 video_units 专用分支，
+ad+参考项目骨架恒为 shots、不含 video_units，导致 shots 的 generated_assets 回填、
+scenes/props 字段补全全部静默跳过，reference_units 派生索引也无任何修复路径。
+"""
+
+import json
+import shutil
+import zipfile
+from pathlib import Path
+
+from lib.project_manager import ProjectManager
+from server.services.project_archive import ProjectArchiveService
+
+
+def _write_bytes(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _make_manual_zip(project_dir: Path, zip_path: Path) -> None:
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for item in sorted(project_dir.rglob("*")):
+            relative = item.relative_to(project_dir)
+            if item.is_dir():
+                info = zipfile.ZipInfo(relative.as_posix().rstrip("/") + "/")
+                archive.writestr(info, b"")
+            else:
+                archive.write(item, arcname=relative.as_posix())
+
+
+def _ad_shot(**overrides) -> dict:
+    shot = {
+        "shot_id": "E1S01",
+        "section": "hook",
+        "duration_seconds": 4,
+        "voiceover_text": "三秒速干",
+        "characters_in_shot": [],
+        "image_prompt": "img",
+        "video_prompt": "vid",
+    }
+    shot.update(overrides)
+    return shot
+
+
+def _create_ad_reference_project(
+    pm: ProjectManager,
+    *,
+    name: str = "addemo",
+    shots: list[dict] | None = None,
+    reference_units: list[dict] | None = None,
+) -> Path:
+    pm.create_project(name, content_mode="ad")
+    pm.create_project_metadata(name, "AdDemo", "Realistic", "ad", target_duration=12)
+
+    project = pm.load_project(name)
+    project["generation_mode"] = "reference_video"
+    project["characters"] = {"主播": {"description": "出镜模特"}}
+    project["scenes"] = {"客厅": {"description": "现代客厅"}}
+    project["props"] = {"速干杯": {"description": "主推产品"}}
+    project["episodes"] = [{"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"}]
+    pm.save_project(name, project)
+
+    if shots is None:
+        shots = [_ad_shot()]
+    episode: dict = {
+        "episode": 1,
+        "title": "第一集",
+        "content_mode": "ad",
+        "generation_mode": "reference_video",
+        "shots": shots,
+    }
+    if reference_units is not None:
+        episode["reference_units"] = reference_units
+
+    project_dir = pm.get_project_path(name)
+    _write_json(project_dir / "scripts" / "episode_1.json", episode)
+    return project_dir
+
+
+def _import_via_manual_zip(service: ProjectArchiveService, project_dir: Path, tmp_path: Path):
+    archive_path = tmp_path / "ad-reference.zip"
+    _make_manual_zip(project_dir, archive_path)
+    shutil.rmtree(project_dir)
+    return service.import_project_archive(archive_path, uploaded_filename="ad-reference.zip")
+
+
+class TestProjectArchiveAdReference:
+    def test_shots_generated_assets_and_fields_backfilled(self, tmp_path):
+        # shots 缺 generated_assets / scenes / props：走 storyboard 修复分支补全，诊断含 auto_fixed
+        pm = ProjectManager(tmp_path / "projects")
+        project_dir = _create_ad_reference_project(pm, shots=[_ad_shot()])
+        service = ProjectArchiveService(pm)
+
+        result = _import_via_manual_zip(service, project_dir, tmp_path)
+
+        imported = json.loads(
+            (pm.get_project_path(result.project_name) / "scripts" / "episode_1.json").read_text(encoding="utf-8")
+        )
+        shot = imported["shots"][0]
+        assert isinstance(shot["generated_assets"], dict)
+        assert shot["generated_assets"]["status"] == "pending"
+        assert shot["scenes"] == []
+        assert shot["props"] == []
+        assert result.diagnostics["auto_fixed"]
+
+    def test_reference_units_generated_assets_backfilled(self, tmp_path):
+        # reference_units 条目缺 generated_assets：就地回填
+        pm = ProjectManager(tmp_path / "projects")
+        units = [{"unit_id": "E1U1", "shot_ids": ["E1S01"], "references": []}]
+        project_dir = _create_ad_reference_project(pm, shots=[_ad_shot()], reference_units=units)
+        service = ProjectArchiveService(pm)
+
+        result = _import_via_manual_zip(service, project_dir, tmp_path)
+
+        imported = json.loads(
+            (pm.get_project_path(result.project_name) / "scripts" / "episode_1.json").read_text(encoding="utf-8")
+        )
+        unit = imported["reference_units"][0]
+        assert isinstance(unit["generated_assets"], dict)
+        assert unit["generated_assets"]["status"] == "pending"
+
+    def test_reference_units_preserves_existing_assets(self, tmp_path):
+        # reference_units 条目已有 generated_assets（video_clip 已生成）：既有资产不被覆盖
+        pm = ProjectManager(tmp_path / "projects")
+        units = [
+            {
+                "unit_id": "E1U1",
+                "shot_ids": ["E1S01"],
+                "references": [],
+                "generated_assets": {"video_clip": "reference_videos/E1U1.mp4", "status": "completed"},
+            }
+        ]
+        project_dir = _create_ad_reference_project(pm, shots=[_ad_shot()], reference_units=units)
+        _write_bytes(project_dir / "reference_videos" / "E1U1.mp4", b"mp4")
+        service = ProjectArchiveService(pm)
+
+        result = _import_via_manual_zip(service, project_dir, tmp_path)
+
+        imported = json.loads(
+            (pm.get_project_path(result.project_name) / "scripts" / "episode_1.json").read_text(encoding="utf-8")
+        )
+        assets = imported["reference_units"][0]["generated_assets"]
+        assert assets["video_clip"] == "reference_videos/E1U1.mp4"
+        assert assets["status"] == "completed"
+        # 缺失字段被补齐，既有值保留
+        assert "video_thumbnail" in assets


### PR DESCRIPTION
Closes #1016

## 问题

广告 + 参考生视频项目（content_mode=ad × generation_mode=reference_video）的剧本骨架恒为 `shots` 加派生索引 `reference_units`、不含 `video_units`。归档导入的自愈修复此前按「generation_mode 是否 reference_video」分流，把这类项目误送进 `video_units` 专用分支而静默 no-op：`shots` 的 generated_assets 回填、scenes/props 字段补全、废弃字段清理全部跳过，`reference_units` 也无任何修复路径。

此外，数据校验器对骨架条目直接调 `.get()`，遇非 dict 条目（损坏归档或手工改档）会抛未捕获异常，中断导入而非按契约记错误。

## 修复

- 归档自愈分流改按规范解析的骨架种类（`resolve_declared_kind`）走：`video_units` 骨架仍走专用分支，其余骨架（含广告的 `shots`）走 storyboard 修复分支，获得与说书/剧集相同的字段补全与资产回填。
- 新增 `reference_units` 派生索引的最小回填：条目 generated_assets 缺失/缺字段时就地补全，既有资产值一律保留、仅补缺失键（与派生索引 merge 的资产保留语义一致）。不从 shots 重派生分组——重派生需供应商时长上限（归档修复时不可得），且会让既有产物指针错位。
- 数据校验器的 segments/scenes 条目循环补类型守卫：骨架字段非数组时记「必须是数组」并跳过；条目非对象时记「必须是对象」并继续校验其余条目，最终 valid=False，不再抛异常。至此四种骨架的校验循环行为一致。

## 验证

- `uv run python -m pytest`：5663 passed
- `uv run ruff check` / `ruff format --check`：通过
- `uv run basedpyright`：0 error（4 个 reportUnnecessaryIsInstance warning，与既有 shots/video_units 守卫同款，CI 仅强制 0 error）
- 新增测试：广告参考项目归档导入 shots 字段与资产回填、reference_units 回填、reference_units 既有资产保留；四骨架非 dict 条目 / 非 list 字段的校验守卫（参数化）

## 审查说明

对本分支跑了一轮独立多 agent 审查，返回 3 条发现，逐条裁定后均判为无需改动：

1. `resolve_declared_kind` 现无条件先调用，损坏/未来版本归档的未知 content_mode 会 fail-loud 抛错——这是该函数的既定契约，且与本函数对非字符串 content_mode 的既有 fail-loud、以及非参考路径的既有行为一致。
2. `reference_units` 未做 `video_units` 分支那样的视频路径规范化——属本次「最小修复」的刻意范围外，可作后续增强。
3. `reference_units` 回填位于 storyboard 分支早返回之后，`shots` 非数组时被跳过——该状态本身已是 blocking 校验错误、整集被拦，无可观测影响。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 提升了导入与校验的容错性：当骨架数据不是数组、为空，或包含非对象条目时，会返回清晰错误而不中断流程。
  * 修复了归档导入时部分项目的自动修复逻辑，确保相关内容能按正确类型进入对应修复分支。
  * 导入参考生视频内容时，会补全缺失字段并保留已有资源，不再意外覆盖现有结果。

* **Tests**
  * 新增回归测试，覆盖骨架类型异常、条目类型异常，以及归档导入后的自动修复行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->