### PR TITLE
fix(events): 广告参考生视频成片就绪补发视频单元通知

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -205,7 +205,7 @@ content_mode 第三值，产出单个约 `target_duration` 秒的短视频而非
 _Avoid_: 让 ad 落入「非 narration 即 drama」的二值兜底——所有按 content_mode 分派的机制必须显式处理第三值；把 AdShot 与 video_unit 内的 shot（参考生视频子镜头）混为一谈——前者是剧本骨架的平铺镜头、后者是 unit 内时间编排；把 ad 未接入 step1→step2 审核 gate 当作待补缺口——单发生成、无 step1 中间态是有意契约，重访条件见 `.out-of-scope/ad-step1-step2-review-gate.md`。
 
 **video_unit / shot（参考生视频单元）**：
-参考生视频模式下的生成单元：一个 video_unit 含 1–4 个 shot（子镜头），整 unit 共享一组按顺序编号的参考图（`[图N]`），跳过分镜直接由资产图生成。narration/drama 下剧本用 `video_units[]` 而非 `segments[]` / `scenes[]` 组织（unit 内容自包含）；ad 下骨架不变，unit 是从 `shots[]` **派生分组**的轻量索引（剧本 `reference_units[]`，仅引用 shot_id + 继承的参考集，产品参考绝对优先）——连续镜头、每 unit ≤4 shot、总长受供应商时长上限约束，分组为纯函数（`lib/reference_video/ad_units.py`）、可复现，成员与参考集未变的 unit 重派生时保留产物。
+参考生视频模式下的生成单元：一个 video_unit 含 1–4 个 shot（子镜头），整 unit 共享一组按顺序编号的参考图（`[图N]`），跳过分镜直接由资产图生成。narration/drama 下剧本用 `video_units[]` 而非 `segments[]` / `scenes[]` 组织（unit 内容自包含）；ad 下骨架不变，unit 是从 `shots[]` **派生分组**的轻量索引（剧本 `reference_units[]`，仅引用 shot_id + 继承的参考集，产品参考绝对优先）——连续镜头、每 unit ≤4 shot、总长受供应商时长上限约束，分组为纯函数（`lib/reference_video/ad_units.py`）、可复现，成员与参考集未变的 unit 重派生时保留产物。**产物口径以 unit 为准**：ad+参考路径的成片（`generated_assets.video_clip` 等）挂在 `reference_units[]` 各 unit 上，`shots` 不承载该路径产物；所有消费方（计分 `StatusCalculator`、剪映导出、项目事件差分）按项目声明的 generation_mode 分派后一律读 unit 产物，不读 shots、不嗅探数据形状（残留索引不得污染 storyboard 路径行为）。
 _Avoid_: 把 shot 与 segment（说书片段）/ DramaScene（剧集场景）混为一谈；「scene」在参考模式下三义须分辨——场景资产（scene_sheet）、剧本分镜场景（DramaScene）、镜头（shot）；手工增删改 ad 的 reference_units——它是派生物，shots 才是内容唯一真相。
 
 **发声条目（utterance）**：

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -24,7 +24,7 @@ from lib.project_change_hints import (
     register_project_change_batch_listener,
     register_project_change_listener,
 )
-from lib.project_manager import ProjectManager
+from lib.project_manager import ProjectManager, effective_mode
 from lib.script_skeleton import SKELETONS, resolve_script_kind
 from server.sse_channel import IDLE, DropSubscriber, SseChannel
 
@@ -556,6 +556,15 @@ class ProjectEventService:
             )
         }
 
+        # 集级 generation_mode 解析（episode → project → 默认 storyboard，见 ``effective_mode``）：
+        # ad+参考路径的成片挂在派生索引 ``reference_units`` 而非内容骨架 ``shots``，快照需按项目
+        # 声明的生成路径分派才能读到该产物——与 ``StatusCalculator`` / 剪映导出同口径，不嗅探数据形状。
+        episodes_by_file = {
+            ep["script_file"]: ep
+            for ep in project.get("episodes", [])
+            if isinstance(ep, dict) and isinstance(ep.get("script_file"), str)
+        }
+
         scripts: dict[str, Any] = {}
         if scripts_dir.exists():
             for script_path in sorted(scripts_dir.glob("*.json")):
@@ -564,7 +573,9 @@ class ProjectEventService:
                 except Exception:
                     logger.warning("跳过无法解析的剧本快照 project=%s file=%s", project_name, script_path.name)
                     continue
-                scripts[script_path.name] = self._normalize_script_snapshot(script)
+                episode = episodes_by_file.get(f"scripts/{script_path.name}", {})
+                generation_mode = effective_mode(project=project, episode=episode)
+                scripts[script_path.name] = self._normalize_script_snapshot(script, generation_mode=generation_mode)
 
         return {
             "project": {
@@ -578,7 +589,9 @@ class ProjectEventService:
             "scripts": scripts,
         }
 
-    def _normalize_script_snapshot(self, script: dict[str, Any]) -> dict[str, Any]:
+    def _normalize_script_snapshot(
+        self, script: dict[str, Any], *, generation_mode: str | None = None
+    ) -> dict[str, Any]:
         # 取证解析：由剧本数据形状判别骨架种类（narration/drama 走 reference 时 content_mode 仍是
         # narration/drama，二值兜底会把 ad 的 shots 与 reference 的 video_units 全部漏读——差分恒空、
         # 分镜级事件从不发出，正是本次修复的 bug 根因）。键即条目数组键。
@@ -628,7 +641,40 @@ class ProjectEventService:
             "content_mode": content_mode,
             "kind": kind,
             "items": items,
+            "reference_units": self._reference_unit_assets(script, kind=kind, generation_mode=generation_mode),
         }
+
+    @staticmethod
+    def _reference_unit_assets(
+        script: dict[str, Any],
+        *,
+        kind: str,
+        generation_mode: str | None,
+    ) -> dict[str, dict[str, str]]:
+        """ad+参考路径下按 ``unit_id`` 记录派生索引 ``reference_units`` 的 ``video_clip``。
+
+        组合按项目声明的 ``generation_mode`` 分派（``kind == "shots"`` 即 ad 骨架，配
+        ``generation_mode == "reference_video"``），与 ``StatusCalculator`` 同口径、不嗅探数据
+        形状——storyboard 路径的残留索引不进快照，不参与差分。仅记 ``video_clip``：成片就绪的
+        唯一信号；unit 的增删/成员变化是 shots 编辑的派生回声，内容变更由 shots 差分承载。
+        """
+        if not (kind == "shots" and generation_mode == "reference_video"):
+            return {}
+        raw_units = script.get("reference_units")
+        if not isinstance(raw_units, list):
+            return {}
+        units: dict[str, dict[str, str]] = {}
+        for unit in raw_units:
+            if not isinstance(unit, dict):
+                continue
+            unit_id = str(unit.get("unit_id") or "")
+            if not unit_id:
+                continue
+            assets = unit.get("generated_assets")
+            if not isinstance(assets, dict):
+                assets = {}
+            units[unit_id] = {"video_clip": str(assets.get("video_clip") or "")}
+        return units
 
     @staticmethod
     def _item_entities(item: dict[str, Any], chars_field: str | None) -> tuple[list[str], list[str], list[str]]:
@@ -924,6 +970,50 @@ class ProjectEventService:
                             important=True,
                         )
                     )
+            changes.extend(
+                self._diff_reference_units(
+                    previous_meta.get("reference_units", {}),
+                    current_meta.get("reference_units", {}),
+                    script_file=script_file,
+                    episode=current_meta.get("episode"),
+                )
+            )
+        return changes
+
+    def _diff_reference_units(
+        self,
+        previous_units: dict[str, Any],
+        current_units: dict[str, Any],
+        *,
+        script_file: str,
+        episode: Any,
+    ) -> list[dict[str, Any]]:
+        """ad+参考路径的 unit 级成片就绪差分（``video_clip`` 空→非空，每 unit 一条 video_ready）。
+
+        仅比对两侧共有的 unit：unit 的增删是 shots 编辑的派生回声，内容变更由 shots 差分承载，
+        此处不发。实体类型/名词/锚点复用 ``video_units`` 骨架条目（reference_unit /「视频单元」/
+        参考画布锚点），不新造平行枚举——前端据锚点切到 units tab 并选中对应单元。
+        """
+        # 快照仅在 ad+参考组合成立时填充 ``reference_units``，storyboard 路径恒为空 → 无差分。
+        unit_meta = {"kind": "video_units", "episode": episode}
+        changes: list[dict[str, Any]] = []
+        for unit_id in sorted(set(previous_units) & set(current_units)):
+            if self._became_truthy(
+                previous_units[unit_id].get("video_clip"),
+                current_units[unit_id].get("video_clip"),
+            ):
+                changes.append(
+                    self._build_entity_change(
+                        entity_type=self._script_item_entity_type(unit_meta),
+                        action="video_ready",
+                        entity_id=unit_id,
+                        label=self._build_script_item_label(unit_id, unit_meta),
+                        script_file=script_file,
+                        episode=episode if isinstance(episode, int) else None,
+                        focus=self._build_script_item_focus(unit_id, unit_meta),
+                        important=True,
+                    )
+                )
         return changes
 
     @staticmethod

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -446,7 +446,7 @@ class ProjectEventService:
 
         project = self.pm.load_project(project_name)
         current_episodes: dict[int, dict[str, str]] = {}
-        for ep in project.get("episodes", []):
+        for ep in project.get("episodes") or []:
             if not isinstance(ep, dict):
                 continue
             episode_num = ep.get("episode")
@@ -549,7 +549,7 @@ class ProjectEventService:
             for ep in sorted(
                 [
                     ep
-                    for ep in project.get("episodes", [])
+                    for ep in project.get("episodes") or []
                     if isinstance(ep, dict) and isinstance(ep.get("episode"), int)
                 ],
                 key=lambda value: value["episode"],
@@ -561,7 +561,7 @@ class ProjectEventService:
         # 声明的生成路径分派才能读到该产物——与 ``StatusCalculator`` / 剪映导出同口径，不嗅探数据形状。
         episodes_by_file = {
             ep["script_file"]: ep
-            for ep in project.get("episodes", [])
+            for ep in project.get("episodes") or []
             if isinstance(ep, dict) and isinstance(ep.get("script_file"), str)
         }
 

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -105,6 +105,23 @@ class TestProjectEventService:
         # narration 分镜走时间线画布：锚点类型恒为 segment（回归守卫，不得漂移）。
         assert all(c["focus"]["anchor_type"] == "segment" for c in segment_updated)
 
+    def test_build_snapshot_survives_null_episodes(self, tmp_path):
+        # project.json 的 episodes 显式为 null 时快照构建不崩:load_project 直接回读磁盘
+        # JSON、不规范化 episodes,读侧按 fail-soft 用 ``or []`` 兜底而非 ``get(..., [])``。
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        project = pm.load_project("demo")
+        project["episodes"] = None
+        project_file = pm.get_project_path("demo") / ProjectManager.PROJECT_FILE
+        project_file.write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
+
+        service = ProjectEventService(tmp_path)
+        snapshot = service._build_snapshot("demo")
+
+        assert snapshot["project"]["episodes"] == {}
+
     def test_diff_snapshots_reports_project_metadata_and_new_segments(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -725,3 +725,198 @@ class TestProjectEventService:
         assert change["entity_type"] == entity_type
         assert change["focus"]["anchor_type"] == anchor_type
         assert change["focus"]["anchor_id"] == "X1"
+
+    def test_diff_snapshots_reports_ad_reference_unit_video_ready(self, tmp_path):
+        """ad + reference_video：unit 的 video_clip 空→非空发一条 video_ready（实体类型 reference_unit）。
+
+        成片写在派生索引 reference_units 各 unit 的 generated_assets，内容骨架 shots 不承载
+        该路径产物；组合按项目声明的 generation_mode 分派（effective_mode），不嗅探剧本形状。
+        """
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("ad-ref")
+        pm.create_project_metadata("ad-ref", "AdRef", "Anime", "ad", extras={"generation_mode": "reference_video"})
+
+        with project_change_source("filesystem"):
+            pm.save_script(
+                "ad-ref",
+                {
+                    "episode": 1,
+                    "title": "广告",
+                    "content_mode": "ad",
+                    "shots": [
+                        {
+                            "shot_id": "E1S01",
+                            "duration_seconds": 4,
+                            "characters_in_shot": [],
+                            "scenes": [],
+                            "props": [],
+                            "image_prompt": "p",
+                            "video_prompt": "v",
+                            "generated_assets": _pending_assets(),
+                        }
+                    ],
+                    "reference_units": [
+                        {
+                            "unit_id": "E1U01",
+                            "shot_ids": ["E1S01"],
+                            "references": [],
+                            "generated_assets": _pending_assets(),
+                        }
+                    ],
+                },
+                "episode_1.json",
+                validate=False,
+            )
+
+        service = ProjectEventService(tmp_path)
+        previous = service._build_snapshot("ad-ref")
+        prev_meta = previous["scripts"]["episode_1.json"]
+        # ad 骨架恒为 shots，但组合成立时快照额外记录 reference_units 的 video_clip。
+        assert prev_meta["kind"] == "shots"
+        assert prev_meta["reference_units"]["E1U01"]["video_clip"] == ""
+
+        script = pm.load_script("ad-ref", "episode_1.json")
+        script["reference_units"][0]["generated_assets"]["video_clip"] = "videos/E1U01.mp4"
+        with project_change_source("filesystem"):
+            pm.save_script("ad-ref", script, "episode_1.json", validate=False)
+        current = service._build_snapshot("ad-ref")
+
+        changes = service._diff_snapshots(previous, current)
+        unit_ready = [c for c in changes if c["action"] == "video_ready" and c["entity_id"] == "E1U01"]
+        assert len(unit_ready) == 1
+        change = unit_ready[0]
+        # 实体类型/名词/锚点复用 video_units 骨架条目，不新造平行枚举。
+        assert change["entity_type"] == "reference_unit"
+        assert change["label"].startswith("视频单元")
+        assert change["focus"]["anchor_type"] == "reference_unit"
+        assert change["focus"]["anchor_id"] == "E1U01"
+        # shots 不承载该路径产物：不发 shot 级 video_ready。
+        assert not any(c["entity_type"] == "shot" and c["action"] == "video_ready" for c in changes)
+
+    def test_ad_reference_unit_redrive_does_not_emit_unit_events(self, tmp_path):
+        """ad + reference_video：unit 增删/成员变化是 shots 编辑的派生回声，不产生 unit 级事件。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("ad-ref-redrive")
+        pm.create_project_metadata(
+            "ad-ref-redrive", "AdRef", "Anime", "ad", extras={"generation_mode": "reference_video"}
+        )
+
+        def _shot(shot_id: str) -> dict:
+            return {
+                "shot_id": shot_id,
+                "duration_seconds": 4,
+                "characters_in_shot": [],
+                "scenes": [],
+                "props": [],
+                "image_prompt": "p",
+                "video_prompt": "v",
+                "generated_assets": _pending_assets(),
+            }
+
+        with project_change_source("filesystem"):
+            pm.save_script(
+                "ad-ref-redrive",
+                {
+                    "episode": 1,
+                    "title": "广告",
+                    "content_mode": "ad",
+                    "shots": [_shot("E1S01")],
+                    "reference_units": [
+                        {
+                            "unit_id": "E1U01",
+                            "shot_ids": ["E1S01"],
+                            "references": [],
+                            "generated_assets": _pending_assets(),
+                        }
+                    ],
+                },
+                "episode_1.json",
+                validate=False,
+            )
+
+        service = ProjectEventService(tmp_path)
+        previous = service._build_snapshot("ad-ref-redrive")
+
+        # 重派生：既有 unit 成员变化 + 新增 unit，均无 video_clip。
+        script = pm.load_script("ad-ref-redrive", "episode_1.json")
+        script["shots"].append(_shot("E1S02"))
+        script["reference_units"] = [
+            {
+                "unit_id": "E1U01",
+                "shot_ids": ["E1S01", "E1S02"],
+                "references": [],
+                "generated_assets": _pending_assets(),
+            },
+            {"unit_id": "E1U02", "shot_ids": ["E1S02"], "references": [], "generated_assets": _pending_assets()},
+        ]
+        with project_change_source("filesystem"):
+            pm.save_script("ad-ref-redrive", script, "episode_1.json", validate=False)
+        current = service._build_snapshot("ad-ref-redrive")
+
+        changes = service._diff_snapshots(previous, current)
+        # unit 增删/成员变化不发 unit 级事件（内容变更由 shots 差分承载）。
+        assert not any(c["entity_type"] == "reference_unit" for c in changes)
+
+    def test_ad_storyboard_path_ignores_residual_reference_units(self, tmp_path):
+        """generation_mode 非 reference_video 的 ad 项目：残留 reference_units 不发 unit 级事件，
+
+        shots 级行为与现状一致（shots 承载产物，video_clip 空→非空发 shot 级 video_ready）。
+        """
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("ad-sb")
+        # 不设 generation_mode → effective_mode 回退默认 storyboard。
+        pm.create_project_metadata("ad-sb", "AdSb", "Anime", "ad")
+
+        with project_change_source("filesystem"):
+            pm.save_script(
+                "ad-sb",
+                {
+                    "episode": 1,
+                    "title": "广告",
+                    "content_mode": "ad",
+                    "shots": [
+                        {
+                            "shot_id": "E1S01",
+                            "duration_seconds": 4,
+                            "characters_in_shot": [],
+                            "scenes": [],
+                            "props": [],
+                            "image_prompt": "p",
+                            "video_prompt": "v",
+                            "generated_assets": _pending_assets(),
+                        }
+                    ],
+                    # 残留派生索引：storyboard 路径不应据此发 unit 级事件。
+                    "reference_units": [
+                        {
+                            "unit_id": "E1U01",
+                            "shot_ids": ["E1S01"],
+                            "references": [],
+                            "generated_assets": _pending_assets(),
+                        }
+                    ],
+                },
+                "episode_1.json",
+                validate=False,
+            )
+
+        service = ProjectEventService(tmp_path)
+        previous = service._build_snapshot("ad-sb")
+        # 组合不成立：快照不记录残留 reference_units。
+        assert previous["scripts"]["episode_1.json"]["reference_units"] == {}
+
+        script = pm.load_script("ad-sb", "episode_1.json")
+        # shots 承载产物；残留 unit 也填上 video_clip（应被忽略）。
+        script["shots"][0]["generated_assets"]["video_clip"] = "videos/E1S01.mp4"
+        script["reference_units"][0]["generated_assets"]["video_clip"] = "videos/E1U01.mp4"
+        with project_change_source("filesystem"):
+            pm.save_script("ad-sb", script, "episode_1.json", validate=False)
+        current = service._build_snapshot("ad-sb")
+
+        changes = service._diff_snapshots(previous, current)
+        # 残留索引不发 unit 级事件。
+        assert not any(c["entity_type"] == "reference_unit" for c in changes)
+        # storyboard 路径 shots 承载产物：shot 级 video_ready 正常。
+        assert any(
+            c["entity_type"] == "shot" and c["action"] == "video_ready" and c["entity_id"] == "E1S01" for c in changes
+        )


### PR DESCRIPTION
## 问题

广告内容模式走参考生视频路径时,成片写在派生索引 `reference_units` 各视频单元的 `generated_assets` 上,而项目事件的剧本差分只比对内容骨架 `shots` 条目。两个落点错位,导致该组合下视频生成完成从不推送成片就绪通知——与其他模式行为不一致:分镜级 created/updated/storyboard_ready 正常推送,唯独成片就绪静默。

## 修复

事件快照按项目声明的 `generation_mode` 分派(经 `effective_mode` 解析集级模式,与计分 `StatusCalculator`、剪映导出同判定结构,不嗅探派生索引是否存在):

- 组合成立(ad 骨架 + `generation_mode` 为 reference_video)时,快照额外记录 `reference_units` 各单元的 `video_clip`
- 对每个由空转非空的单元发一条成片就绪通知,实体类型/名词/锚点复用参考生视频单元(`reference_unit` /「视频单元」/ units pane)
- 单元增删与成员变化不发通知(内容变更由 shots 差分承载,是 shots 编辑的派生回声)
- storyboard 路径即使剧本残留 `reference_units` 也不受影响

纯后端改动。`CONTEXT.md` 视频单元词条补充产物口径表述:该路径产物以 unit 为口径,消费方(计分/导出/事件)按声明分派后一律读 unit 产物。

## 验证

- 新增三项测试:单元就绪发通知、重派生不发通知、storyboard 路径不受残留索引影响
- 完整测试套件 5671 passed,无回归
- `ruff check` / `ruff format --check` / `basedpyright` 全绿
- 独立审查复核判定口径与 StatusCalculator 结构一致、空→非空差分与交集比对符合契约,无 correctness 缺陷

> 可选后续(非本 PR 阻塞):`episodes_by_file` 的集级 `generation_mode` override 命中路径当前由 project 级回退覆盖,可补一例集级 override 用例锁死 `scripts/` 前缀匹配契约。

Closes #1014


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在 ad + 参考生视频模式下，引入更精确的“成片就绪”事件分派：仅在参考单位对应视频剪辑就绪时，触发相应的参考单位级别通知。

* **Bug 修复**
  * 修正快照重建与差分逻辑，使其按剧本的实际有效生成模式归一化处理；避免残留引用索引导致 storyboard 路径与事件类型混淆。
  * 修复项目 episodes 字段为 `null` 时的快照归一化问题。

* **测试**
  * 新增快照健壮性与多场景差分回归用例，覆盖 reference_units 触发/过滤边界。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->