### PR TITLE
docs(license): 补充 NOTICE 附加条款、README 许可证说明与关于页署名

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,46 @@
+ArcReel Notices
+
+ArcReel
+Copyright © 2026 Pollo3470 and ArcReel contributors.
+
+This project is licensed under the GNU Affero General Public License v3.0.
+See LICENSE for the full project license terms.
+
+==== Additional Terms under AGPLv3 Section 7 ====
+
+Pursuant to Section 7(b) of the GNU Affero General Public License version 3,
+the following reasonable legal notice and author attribution must be preserved
+by modified versions in the Appropriate Legal Notices and in any prominent
+about, legal, footer, or attribution location presented by the user interface:
+
+"Powered by ArcReel — https://github.com/ArcReel/ArcReel"
+
+Modified versions that present a user interface must also preserve a visible
+link to the original project repository in a prominent about, legal, footer,
+or attribution location:
+
+https://github.com/ArcReel/ArcReel
+
+Modified versions must not misrepresent the origin of the software and must
+mark their changes in accordance with AGPLv3 Section 7(c).
+
+==== 依据 AGPLv3 第 7 条的附加条款（中文对照）====
+
+根据 GNU Affero 通用公共许可证第 3 版第 7(b) 条，修改版本必须在"适当的法律
+声明"（Appropriate Legal Notices）以及用户界面呈现的显著位置（关于页、法律
+声明、页脚或署名区域）保留以下法律声明与作者署名：
+
+"Powered by ArcReel — https://github.com/ArcReel/ArcReel"
+
+呈现用户界面的修改版本，还必须在上述显著位置保留指向原项目仓库的可见链接：
+
+https://github.com/ArcReel/ArcReel
+
+修改版本不得歪曲软件来源，并须依照 AGPLv3 第 7(c) 条标明其所做的修改。
+
+==== Trademark / 商标 ====
+
+The ArcReel name and logo are not licensed under AGPL-3.0.
+ArcReel 名称与标识不在 AGPL-3.0 授权范围内。
+
+==== End of Notices ====

--- a/README.en.md
+++ b/README.en.md
@@ -317,9 +317,16 @@ python -m pytest
 cd frontend && pnpm check
 ```
 
-## License
+## 📜 License
 
-[AGPL-3.0](LICENSE)
+This project is licensed under the [GNU Affero General Public License v3.0 (AGPL-3.0)](./LICENSE),
+with additional terms in [NOTICE](./NOTICE).
+
+Copyright © 2026 Pollo3470 and ArcReel contributors
+
+If your organization's policy does not allow the use of AGPL-3.0 licensed software,
+or you wish to use this project commercially without the AGPL-3.0 open-source
+obligations, please contact: [support@arc-reel.com](mailto:support@arc-reel.com)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -299,9 +299,15 @@ uv run pre-commit install
 
 安装 pre-commit 钩子（ruff check + format、frontend eslint、workflow tripwire），避免把可被自动修复的问题推到 CI。
 
-## 许可证
+## 📜 许可证
 
-[AGPL-3.0](LICENSE)
+本项目采用 [GNU Affero 通用公共许可证 v3.0 (AGPL-3.0)](./LICENSE) 授权，
+附加条款见 [NOTICE](./NOTICE)。
+
+Copyright © 2026 Pollo3470 and ArcReel contributors
+
+如果您所在组织的政策不允许使用 AGPL-3.0 许可的软件，或您希望在不承担
+AGPL-3.0 开源义务的前提下商用本项目，请联系：[support@arc-reel.com](mailto:support@arc-reel.com)
 
 ---
 

--- a/frontend/src/components/pages/settings/AboutSection.tsx
+++ b/frontend/src/components/pages/settings/AboutSection.tsx
@@ -259,6 +259,30 @@ export function AboutSection() {
           </p>
         )}
       </div>
+
+      {/* Copyright & attribution — NOTICE §7(b) 要求的署名句与仓库链接，逐字保留，不走品牌占位 */}
+      <div
+        className="rounded-[12px] border border-hairline p-6"
+        style={CARD_STYLE}
+      >
+        <div className="mb-3 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-accent-2">
+          {t("about_legal_title")}
+        </div>
+        <div className="space-y-1 text-[12.5px] text-text-3">
+          <p>Copyright © 2026 Pollo3470 and ArcReel contributors</p>
+          <p>
+            Powered by ArcReel —{" "}
+            <a
+              href="https://github.com/ArcReel/ArcReel"
+              target="_blank"
+              rel="noreferrer"
+              className="break-all text-accent-2 transition-colors hover:text-accent"
+            >
+              https://github.com/ArcReel/ArcReel
+            </a>
+          </p>
+        </div>
+      </div>
     </section>
   );
 }

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -96,6 +96,7 @@ export default {
   'about_load_failed': 'Failed to load version info',
   'about_published_at': 'Published: {{date}}',
   'about_checked_at': 'Last checked: {{date}}',
+  'about_legal_title': 'Copyright & Attribution',
   'diagnostics_section_title': 'Diagnostic logs',
   'diagnostics_section_desc': 'Bundle the last 7 days of logs and system info (API keys masked) for bug reports.',
   'diagnostics_download': 'Download diagnostic logs',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -97,6 +97,7 @@ export default {
   'about_load_failed': 'Tải thông tin phiên bản thất bại',
   'about_published_at': 'Phát hành: {{date}}',
   'about_checked_at': 'Kiểm tra lần cuối: {{date}}',
+  'about_legal_title': 'Bản quyền & ghi công',
   'diagnostics_section_title': 'Nhật ký chẩn đoán',
   'diagnostics_section_desc': 'Đóng gói nhật ký 7 ngày gần nhất và thông tin hệ thống (API key đã ẩn) để báo lỗi.',
   'diagnostics_download': 'Tải nhật ký chẩn đoán',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -97,6 +97,7 @@ export default {
   'about_load_failed': '加载版本信息失败',
   'about_published_at': '发布时间：{{date}}',
   'about_checked_at': '最近检查：{{date}}',
+  'about_legal_title': '版权与署名',
   'diagnostics_section_title': '诊断日志',
   'diagnostics_section_desc': '打包最近 7 天的日志与系统信息（已脱敏 API 密钥），用于反馈 bug。',
   'diagnostics_download': '下载诊断日志',


### PR DESCRIPTION
## 范围

版权保护相关的声明与入口：根目录 NOTICE、两份 README 的许可证节、设置-关于页署名卡片（含 i18n 三语）。不涉及后端、生成流水线与其他前端页面。

## 变更

- 新建 `NOTICE`：声明 AGPL-3.0 授权；依据 AGPL §7(b) 附加条款（中英对照）要求修改版在 Appropriate Legal Notices 及界面显著位置保留 `Powered by ArcReel — https://github.com/ArcReel/ArcReel` 署名与原仓库可见链接，并按 §7(c) 标明修改；声明 ArcReel 名称与标识不在 AGPL-3.0 授权范围内
- `README.md` / `README.en.md` 许可证节：指向 LICENSE + NOTICE，补版权行与商业许可联系方式（support@arc-reel.com，mailto 链接）
- 设置-关于页新增「版权与署名」卡片：版权行 + 署名句 + 仓库链接（`target="_blank" rel="noreferrer"`），卡片标题走 i18n（zh/en/vi），署名句与链接为专名不翻译、不走品牌占位

## 验收清单

- [x] 本地已跑相关测试：`cd frontend && pnpm lint && pnpm check`（799 tests passed）、`uv run python -m pytest tests/test_i18n_consistency.py`（12 passed）
- [x] 手动验证了改动所声称的行为：启动前后端后实际驱动关于页——卡片渲染正常、仓库链接可点击并正确打开、zh/en/vi 切换下标题分别为「版权与署名 / Copyright & Attribution / Bản quyền & ghi công」、窄视口下长链接 break-all 换行无横向溢出
- [x] 新增面向用户文案已加 zh/en 翻译（vi 亦已补全）
- [x] 无新增 ESLint disable
- [x] CODEOWNERS 要求的 review 已请求（CODEOWNERS 均为 PR 作者本人，无需额外请求）

## 已知 defer

- 诊断日志下载 Blob URL 在 click 后立即回收、部分浏览器可能偶发下载失败（review 中 CodeRabbit 提出，属既有代码非本 PR 变更）→ #1040

## 备注

§7(b) 附加条款仅约束其加入之后发布的版本，建议尽快合入并随下个 release 发布。
