### PR TITLE
feat(assistant): 会话时间线切换为事件日志单一读源，断线重连按游标续传

### DIFF
--- a/alembic/versions/f3d21ac90b17_add_session_event_log_table.py
+++ b/alembic/versions/f3d21ac90b17_add_session_event_log_table.py
@@ -1,0 +1,57 @@
+"""add session event log table
+
+Revision ID: f3d21ac90b17
+Revises: a7a9749a1ae0
+Create Date: 2026-07-06 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f3d21ac90b17"
+down_revision: str | Sequence[str] | None = "a7a9749a1ae0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "agent_session_event_log",
+        sa.Column("session_id", sa.String(), nullable=False),
+        sa.Column("seq", sa.BigInteger(), nullable=False),
+        sa.Column("entry_type", sa.String(), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("client_key", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("user_id", sa.String(), server_default="default", nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("session_id", "seq"),
+    )
+    with op.batch_alter_table("agent_session_event_log", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_agent_session_event_log_user_id"),
+            ["user_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            "uq_agent_event_log_client_key",
+            ["session_id", "client_key"],
+            unique=True,
+            postgresql_where=sa.text("client_key IS NOT NULL"),
+            sqlite_where=sa.text("client_key IS NOT NULL"),
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("agent_session_event_log", schema=None) as batch_op:
+        batch_op.drop_index("uq_agent_event_log_client_key")
+        batch_op.drop_index(batch_op.f("ix_agent_session_event_log_user_id"))
+    op.drop_table("agent_session_event_log")

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -368,7 +368,7 @@ describe("API", () => {
 
       await API.listAssistantSessions("demo", "running");
       await API.getAssistantSession("demo", "session-1");
-      await API.getAssistantSnapshot("demo", "session-1");
+      await API.listAssistantEntries("demo", "session-1", 5);
       await API.sendAssistantMessage("demo", "hello", "session-1");
       await API.interruptAssistantSession("demo", "session-1");
       await API.answerAssistantQuestion("demo", "session-1", "q-1", { key: "a" });
@@ -402,6 +402,9 @@ describe("API", () => {
       expect(requestSpy).toHaveBeenCalledWith(
         "/projects/demo/assistant/sessions?status=running",
       );
+      expect(requestSpy).toHaveBeenCalledWith(
+        "/projects/demo/assistant/sessions/session-1/entries?after=5",
+      );
       expect(requestSpy).toHaveBeenCalledWith("/projects/demo/assistant/skills");
       expect(requestSpy).toHaveBeenCalledWith(
         "/usage/stats?project_name=demo&start_date=2026-01-01&end_date=2026-02-01",
@@ -419,8 +422,11 @@ describe("API", () => {
       expect(API.getFileUrl("my project", "source/a.txt", 3)).toBe(
         "/api/v1/files/my%20project/source/a.txt?v=3",
       );
-      expect(API.getAssistantStreamUrl("demo", "session-1")).toBe(
-        "/api/v1/projects/demo/assistant/sessions/session-1/stream",
+      expect(API.getAssistantEntriesStreamUrl("demo", "session-1")).toBe(
+        "/api/v1/projects/demo/assistant/sessions/session-1/entries/stream",
+      );
+      expect(API.getAssistantEntriesStreamUrl("demo", "session-1", 7)).toBe(
+        "/api/v1/projects/demo/assistant/sessions/session-1/entries/stream?after=7",
       );
     });
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -16,7 +16,8 @@ import type {
   TaskItem,
   TaskStats,
   SessionMeta,
-  AssistantSnapshot,
+  EntriesResponse,
+  TimelineEntry,
   SkillInfo,
   ProjectOverview,
   ProjectChangeBatchPayload,
@@ -1599,12 +1600,15 @@ class API {
     );
   }
 
-  static async getAssistantSnapshot(
+  /** 冷读会话事件日志（after 为 seq 游标，-1 表示从头）。 */
+  static async listAssistantEntries(
     projectName: string,
-    sessionId: string
-  ): Promise<AssistantSnapshot> {
+    sessionId: string,
+    after: number = -1
+  ): Promise<EntriesResponse> {
+    const query = after >= 0 ? `?after=${after}` : "";
     return this.request(
-      `${this.assistantBase(projectName)}/sessions/${encodeURIComponent(sessionId)}/snapshot`
+      `${this.assistantBase(projectName)}/sessions/${encodeURIComponent(sessionId)}/entries${query}`
     );
   }
 
@@ -1612,14 +1616,16 @@ class API {
     projectName: string,
     content: string,
     sessionId?: string | null,
-    images?: Array<{ data: string; media_type: string }>
-  ): Promise<{ session_id: string; status: string }> {
+    images?: Array<{ data: string; media_type: string }>,
+    clientKey?: string
+  ): Promise<{ session_id: string; status: string; entry: TimelineEntry | null }> {
     return this.request(`${this.assistantBase(projectName)}/sessions/send`, {
       method: "POST",
       body: JSON.stringify({
         content,
         session_id: sessionId || undefined,
         images: images || [],
+        client_key: clientKey || undefined,
       }),
     });
   }
@@ -1651,8 +1657,15 @@ class API {
     );
   }
 
-  static getAssistantStreamUrl(projectName: string, sessionId: string): string {
-    return withAuthQuery(`${API_BASE}${this.assistantBase(projectName)}/sessions/${encodeURIComponent(sessionId)}/stream`);
+  /** entry 流 SSE URL（after 为 seq 游标；重连续传由 EventSource Last-Event-ID 承担）。 */
+  static getAssistantEntriesStreamUrl(
+    projectName: string,
+    sessionId: string,
+    after: number = -1
+  ): string {
+    const base = `${API_BASE}${this.assistantBase(projectName)}/sessions/${encodeURIComponent(sessionId)}/entries/stream`;
+    const url = after >= 0 ? `${base}?after=${after}` : base;
+    return withAuthQuery(url);
   }
 
   static async listAssistantSkills(

--- a/frontend/src/components/copilot/AgentCopilot.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.tsx
@@ -265,15 +265,22 @@ export function AgentCopilot() {
   const handleSend = useCallback(() => {
     if (inputDisabled || (!localInput.trim() && attachedImages.length === 0)) return;
     imageGenRef.current += 1; // invalidate pending FileReader callbacks
-    voidCall(sendMessage(localInput.trim(), attachedImages.length > 0 ? attachedImages : undefined));
-    setLocalInput("");
-    setAttachedImages([]);
-    setAttachError(null);
     setShowSlashMenu(false);
-    // Reset textarea height
-    if (textareaRef.current) {
-      textareaRef.current.style.height = "auto";
-    }
+    // 发送期间输入锁定（sending 置位）；受理成功才清空，失败保留内容供重试
+    voidCall(
+      sendMessage(localInput.trim(), attachedImages.length > 0 ? attachedImages : undefined).then(
+        (accepted) => {
+          if (!accepted) return;
+          setLocalInput("");
+          setAttachedImages([]);
+          setAttachError(null);
+          // Reset textarea height
+          if (textareaRef.current) {
+            textareaRef.current.style.height = "auto";
+          }
+        },
+      ),
+    );
   }, [inputDisabled, localInput, attachedImages, sendMessage]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -402,7 +409,7 @@ export function AgentCopilot() {
           >
             <Bot className="h-3.5 w-3.5" />
           </div>
-          {isRunning ? (
+          {isRunning || sending ? (
             <span
               className="flex shrink-0 items-center gap-1.5 whitespace-nowrap text-[12px]"
               style={{ color: "var(--color-accent-2)" }}

--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -540,4 +540,43 @@ describe("useAssistantSession", () => {
       expect(sendResult).toBe(false);
     });
   });
+
+  it("resolves false when currentSessionId changes without going through invalidatePendingSend", async () => {
+    // 独立于版本号的第二道防线：currentSessionId 是跨 hook 实例共享的全局 store 字段，
+    // 可能被本实例之外的路径直接改写（不经过 invalidatePendingSend）。即便版本号未失配，
+    // 只要响应回来时 currentSessionId 已不是发送时的会话，也不能返回 true 清空新会话输入框。
+    mockIdleSession();
+    const deferred = createDeferred<{ session_id: string; status: string; entry: TimelineEntry | null }>();
+    vi.spyOn(API, "sendAssistantMessage").mockReturnValue(deferred.promise);
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    let sendResult: boolean | undefined;
+    act(() => {
+      void result.current.sendMessage("hello").then((accepted) => {
+        sendResult = accepted;
+      });
+    });
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().sending).toBe(true);
+    });
+
+    act(() => {
+      useAssistantStore.getState().setCurrentSessionId("session-2");
+    });
+
+    await act(async () => {
+      deferred.resolve({ session_id: "session-1", status: "accepted", entry: userEntry(0, "hello") });
+      await deferred.promise;
+    });
+
+    await waitFor(() => {
+      expect(sendResult).toBe(false);
+    });
+  });
 });

--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -493,4 +493,51 @@ describe("useAssistantSession", () => {
     expect(useAssistantStore.getState().currentSessionId).toBe("session-2");
     expect(useAssistantStore.getState().turns).toHaveLength(1);
   });
+
+  it("resolves false for a send invalidated by switching sessions mid-flight", async () => {
+    // 版本失配分支必须与失败路径一致返回 false：调用方（AgentCopilot.handleSend）
+    // 依据返回值清空输入框，误返回 true 会清空用户已切换到的新会话里刚输入的内容。
+    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+      sessions: [
+        makeSession("session-1", "idle"),
+        makeSession("session-2", "idle"),
+      ],
+    });
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (_projectName, sessionId) => ({
+      session: makeSession(sessionId, "idle"),
+    }));
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+    const deferred = createDeferred<{ session_id: string; status: string; entry: TimelineEntry | null }>();
+    vi.spyOn(API, "sendAssistantMessage").mockReturnValue(deferred.promise);
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    let sendResult: boolean | undefined;
+    act(() => {
+      void result.current.sendMessage("hello").then((accepted) => {
+        sendResult = accepted;
+      });
+    });
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().sending).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.switchSession("session-2");
+    });
+
+    await act(async () => {
+      deferred.resolve({ session_id: "session-1", status: "accepted", entry: userEntry(0, "hello") });
+      await deferred.promise;
+    });
+
+    await waitFor(() => {
+      expect(sendResult).toBe(false);
+    });
+  });
 });

--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -2,14 +2,18 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { API } from "@/api";
 import { useAssistantStore } from "@/stores/assistant-store";
-import type { AssistantSnapshot, PendingQuestion, SessionMeta } from "@/types";
+import type { EntriesResponse, PendingQuestion, SessionMeta, TimelineEntry } from "@/types";
 import { useAssistantSession } from "./useAssistantSession";
 
 class MockEventSource {
   static instances: MockEventSource[] = [];
+  static readonly CLOSED = 2;
 
+  readyState = 0;
   onerror: ((event: Event) => void) | null = null;
-  close = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = MockEventSource.CLOSED;
+  });
   private readonly listeners = new Map<string, Array<(event: MessageEvent) => void>>();
 
   constructor(public readonly url: string) {
@@ -59,15 +63,19 @@ function makePendingQuestion(questionId: string = "q-1"): PendingQuestion {
   };
 }
 
-function makeSnapshot(overrides: Partial<AssistantSnapshot> = {}): AssistantSnapshot {
+function makeEntriesResponse(overrides: Partial<EntriesResponse> = {}): EntriesResponse {
   return {
     session_id: "session-1",
     status: "idle",
-    turns: [],
-    draft_turn: null,
-    pending_questions: [],
+    entries: [],
+    draft: null,
+    draft_rev: 0,
     ...overrides,
   };
+}
+
+function userEntry(seq: number, text: string): TimelineEntry {
+  return { seq, type: "user", content: [{ type: "text", text }], uuid: `u-${seq}` };
 }
 
 function createDeferred<T>() {
@@ -80,13 +88,146 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
+function mockIdleSession(entries: TimelineEntry[] = []) {
+  vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+    sessions: [makeSession("session-1", "idle")],
+  });
+  vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "idle") });
+  vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries }));
+}
+
 describe("useAssistantSession", () => {
   beforeEach(() => {
     useAssistantStore.setState(useAssistantStore.getInitialState(), true);
     MockEventSource.instances = [];
+    localStorage.clear();
     vi.restoreAllMocks();
     vi.stubGlobal("EventSource", MockEventSource as unknown as typeof EventSource);
     vi.spyOn(API, "listAssistantSkills").mockResolvedValue({ skills: [] });
+  });
+
+  it("loads idle session timeline from the entries endpoint (cold read)", async () => {
+    mockIdleSession([userEntry(0, "历史消息"), { seq: 1, type: "assistant", content: [{ type: "text", text: "回复" }], uuid: "a-1" }]);
+
+    renderHook(() => useAssistantSession("demo"));
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().turns).toHaveLength(2);
+    });
+    expect(useAssistantStore.getState().turns[0].content[0].text).toBe("历史消息");
+    // 非 running 会话不建 SSE 流
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it("connects entry stream for running sessions and appends entries in seq order", async () => {
+    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+      sessions: [makeSession("session-1", "running")],
+    });
+    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "running") });
+
+    renderHook(() => useAssistantSession("demo"));
+
+    await waitFor(() => {
+      expect(MockEventSource.instances).toHaveLength(1);
+    });
+
+    act(() => {
+      MockEventSource.instances[0].emit("entry", userEntry(0, "hello"));
+      MockEventSource.instances[0].emit("entry", {
+        seq: 1,
+        type: "assistant",
+        content: [{ type: "text", text: "hi" }],
+        uuid: "a-1",
+      });
+      // 重复 seq：身份（seq）门槛去重，不做内容比对
+      MockEventSource.instances[0].emit("entry", { ...userEntry(1, "重复"), type: "assistant" });
+    });
+
+    const state = useAssistantStore.getState();
+    expect(state.entries.map((e) => e.seq)).toEqual([0, 1]);
+    expect(state.turns.map((t) => t.type)).toEqual(["user", "assistant"]);
+  });
+
+  it("applies draft snapshot and rev-gated deltas, then replaces draft by message_id identity", async () => {
+    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+      sessions: [makeSession("session-1", "running")],
+    });
+    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "running") });
+
+    renderHook(() => useAssistantSession("demo"));
+
+    await waitFor(() => {
+      expect(MockEventSource.instances).toHaveLength(1);
+    });
+
+    act(() => {
+      // 重连首帧快照：携带累积态 + rev 门槛
+      MockEventSource.instances[0].emit("draft", {
+        session_id: "session-1",
+        draft: { message_id: "msg_1", content: [{ type: "text", text: "部分" }], rev: 5 },
+        rev: 5,
+      });
+      // 订阅间隙重复投递的 delta（rev ≤ 门槛）须被过滤
+      MockEventSource.instances[0].emit("delta", {
+        message_id: "msg_1",
+        delta_type: "text_delta",
+        block_index: 0,
+        rev: 5,
+        text: "重复",
+      });
+      MockEventSource.instances[0].emit("delta", {
+        message_id: "msg_1",
+        delta_type: "text_delta",
+        block_index: 0,
+        rev: 6,
+        text: "内容",
+      });
+    });
+
+    expect(useAssistantStore.getState().draftTurn?.content[0].text).toBe("部分内容");
+
+    act(() => {
+      // 同 message_id 的权威条目落库：draft 被精确替换（身份比对）
+      MockEventSource.instances[0].emit("entry", {
+        seq: 0,
+        type: "assistant",
+        message_id: "msg_1",
+        content: [{ type: "text", text: "部分内容（权威）" }],
+        uuid: "a-1",
+      });
+    });
+
+    const state = useAssistantStore.getState();
+    expect(state.draftTurn).toBeNull();
+    expect(state.turns).toHaveLength(1);
+    expect(state.turns[0].content[0].text).toBe("部分内容（权威）");
+  });
+
+  it("clears draft and closes stream on terminal status, keeps draft when interrupted", async () => {
+    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+      sessions: [makeSession("session-1", "running")],
+    });
+    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "running") });
+
+    renderHook(() => useAssistantSession("demo"));
+
+    await waitFor(() => {
+      expect(MockEventSource.instances).toHaveLength(1);
+    });
+
+    act(() => {
+      MockEventSource.instances[0].emit("draft", {
+        session_id: "session-1",
+        draft: { message_id: "msg_1", content: [{ type: "text", text: "被中断的回复" }], rev: 1 },
+        rev: 1,
+      });
+      MockEventSource.instances[0].emit("status", { status: "interrupted" });
+    });
+
+    // 中断保留 draft（被中断内容不入日志，刷新后自然消失）
+    expect(useAssistantStore.getState().draftTurn?.content[0].text).toBe("被中断的回复");
+    expect(useAssistantStore.getState().sessionStatus).toBe("interrupted");
+    expect(MockEventSource.instances[0].close).toHaveBeenCalled();
   });
 
   it("writes pendingQuestion from question SSE events", async () => {
@@ -110,29 +251,8 @@ describe("useAssistantSession", () => {
     expect(useAssistantStore.getState().answeringQuestion).toBe(false);
   });
 
-  it("restores pendingQuestion from idle snapshots", async () => {
-    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
-      sessions: [makeSession("session-1", "idle")],
-    });
-    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "idle") });
-    vi.spyOn(API, "getAssistantSnapshot").mockResolvedValue(
-      makeSnapshot({ pending_questions: [makePendingQuestion()] }),
-    );
-
-    renderHook(() => useAssistantSession("demo"));
-
-    await waitFor(() => {
-      expect(useAssistantStore.getState().pendingQuestion?.question_id).toBe("q-1");
-    });
-    expect(useAssistantStore.getState().answeringQuestion).toBe(false);
-  });
-
   it("submits answers successfully and clears pendingQuestion", async () => {
-    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
-      sessions: [makeSession("session-1", "idle")],
-    });
-    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "idle") });
-    vi.spyOn(API, "getAssistantSnapshot").mockResolvedValue(makeSnapshot());
+    mockIdleSession();
     const answerSpy = vi
       .spyOn(API, "answerAssistantQuestion")
       .mockResolvedValue({ success: true });
@@ -159,11 +279,7 @@ describe("useAssistantSession", () => {
   });
 
   it("keeps pendingQuestion and surfaces errors when answer submission fails", async () => {
-    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
-      sessions: [makeSession("session-1", "idle")],
-    });
-    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "idle") });
-    vi.spyOn(API, "getAssistantSnapshot").mockResolvedValue(makeSnapshot());
+    mockIdleSession();
     vi.spyOn(API, "answerAssistantQuestion").mockRejectedValue(new Error("回答失败"));
 
     const { result } = renderHook(() => useAssistantSession("demo"));
@@ -195,7 +311,7 @@ describe("useAssistantSession", () => {
     vi.spyOn(API, "getAssistantSession").mockImplementation(async (_projectName, sessionId) => ({
       session: makeSession(sessionId, "idle"),
     }));
-    vi.spyOn(API, "getAssistantSnapshot").mockResolvedValue(makeSnapshot());
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse());
 
     const { result } = renderHook(() => useAssistantSession("demo"));
 
@@ -209,7 +325,7 @@ describe("useAssistantSession", () => {
     });
 
     await act(async () => {
-      await result.current.createNewSession();
+      result.current.createNewSession();
     });
 
     expect(useAssistantStore.getState().pendingQuestion).toBeNull();
@@ -229,13 +345,82 @@ describe("useAssistantSession", () => {
     expect(useAssistantStore.getState().answeringQuestion).toBe(false);
   });
 
-  it("restores session state and removes optimistic turn when send fails", async () => {
-    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
-      sessions: [makeSession("session-1", "idle")],
+  it("appends the authoritative entry from the send response and connects the entry stream", async () => {
+    mockIdleSession();
+    const sendSpy = vi.spyOn(API, "sendAssistantMessage").mockResolvedValue({
+      session_id: "session-1",
+      status: "accepted",
+      entry: userEntry(0, "hello"),
     });
-    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "idle") });
-    vi.spyOn(API, "getAssistantSnapshot").mockResolvedValue(makeSnapshot());
-    vi.spyOn(API, "sendAssistantMessage").mockRejectedValue(new Error("发送失败"));
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    let accepted = false;
+    await act(async () => {
+      accepted = await result.current.sendMessage("hello");
+    });
+
+    expect(accepted).toBe(true);
+    // 无本地合成消息：时间线唯一来源是响应携带的权威条目
+    expect(useAssistantStore.getState().entries.map((e) => e.seq)).toEqual([0]);
+    expect(useAssistantStore.getState().turns).toEqual([
+      { type: "user", content: [{ type: "text", text: "hello" }], uuid: "u-0", timestamp: undefined },
+    ]);
+    expect(useAssistantStore.getState().sessionStatus).toBe("running");
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toContain("/entries/stream");
+    // 游标续传：冷订阅从已有条目之后开始
+    expect(MockEventSource.instances[0].url).toContain("after=0");
+    // client_key 随请求发送
+    expect(sendSpy.mock.calls[0][4]).toEqual(expect.any(String));
+  });
+
+  it("keeps timeline unchanged on send failure and reuses the idempotency key on retry", async () => {
+    mockIdleSession();
+    const sendSpy = vi
+      .spyOn(API, "sendAssistantMessage")
+      .mockRejectedValueOnce(new Error("发送失败"))
+      .mockResolvedValueOnce({ session_id: "session-1", status: "accepted", entry: userEntry(0, "hello") });
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    let accepted = true;
+    await act(async () => {
+      accepted = await result.current.sendMessage("hello");
+    });
+
+    // 失败：无合成消息可回滚，时间线不变、状态不变、输入由调用方保留
+    expect(accepted).toBe(false);
+    expect(useAssistantStore.getState().sending).toBe(false);
+    expect(useAssistantStore.getState().sessionStatus).toBe("idle");
+    expect(useAssistantStore.getState().turns).toEqual([]);
+    expect(useAssistantStore.getState().error).toBe("发送失败");
+    expect(MockEventSource.instances).toHaveLength(0);
+
+    await act(async () => {
+      accepted = await result.current.sendMessage("hello");
+    });
+
+    expect(accepted).toBe(true);
+    // 同内容重试复用同一幂等键：服务端按键去重，不产生重复
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+    expect(sendSpy.mock.calls[1][4]).toBe(sendSpy.mock.calls[0][4]);
+  });
+
+  it("uses a fresh idempotency key for different content", async () => {
+    mockIdleSession();
+    const sendSpy = vi
+      .spyOn(API, "sendAssistantMessage")
+      .mockRejectedValueOnce(new Error("发送失败"))
+      .mockResolvedValueOnce({ session_id: "session-1", status: "accepted", entry: userEntry(0, "另一条") });
 
     const { result } = renderHook(() => useAssistantSession("demo"));
 
@@ -246,12 +431,11 @@ describe("useAssistantSession", () => {
     await act(async () => {
       await result.current.sendMessage("hello");
     });
+    await act(async () => {
+      await result.current.sendMessage("另一条");
+    });
 
-    expect(useAssistantStore.getState().sending).toBe(false);
-    expect(useAssistantStore.getState().sessionStatus).toBe("idle");
-    expect(useAssistantStore.getState().turns).toEqual([]);
-    expect(useAssistantStore.getState().error).toBe("发送失败");
-    expect(MockEventSource.instances).toHaveLength(0);
+    expect(sendSpy.mock.calls[1][4]).not.toBe(sendSpy.mock.calls[0][4]);
   });
 
   it("ignores delayed send completions after switching sessions", async () => {
@@ -264,15 +448,15 @@ describe("useAssistantSession", () => {
     vi.spyOn(API, "getAssistantSession").mockImplementation(async (_projectName, sessionId) => ({
       session: makeSession(sessionId, "idle"),
     }));
-    vi.spyOn(API, "getAssistantSnapshot").mockImplementation(async (_projectName, sessionId) =>
-      makeSnapshot({
+    vi.spyOn(API, "listAssistantEntries").mockImplementation(async (_projectName, sessionId) =>
+      makeEntriesResponse({
         session_id: sessionId,
-        turns: sessionId === "session-2"
-          ? [{ type: "assistant", content: [{ type: "text", text: "session-2" }] }]
+        entries: sessionId === "session-2"
+          ? [{ seq: 0, type: "assistant", content: [{ type: "text", text: "session-2" }], uuid: "a-1" }]
           : [],
       }),
     );
-    const deferred = createDeferred<{ session_id: string; status: string }>();
+    const deferred = createDeferred<{ session_id: string; status: string; entry: TimelineEntry | null }>();
     vi.spyOn(API, "sendAssistantMessage").mockReturnValue(deferred.promise);
 
     const { result } = renderHook(() => useAssistantSession("demo"));
@@ -296,137 +480,17 @@ describe("useAssistantSession", () => {
     expect(useAssistantStore.getState().currentSessionId).toBe("session-2");
     expect(useAssistantStore.getState().sending).toBe(false);
     expect(useAssistantStore.getState().turns).toEqual([
-      { type: "assistant", content: [{ type: "text", text: "session-2" }] },
+      { type: "assistant", content: [{ type: "text", text: "session-2" }], uuid: "a-1", timestamp: undefined },
     ]);
 
     await act(async () => {
-      deferred.resolve({ session_id: "session-1", status: "running" });
+      deferred.resolve({ session_id: "session-1", status: "accepted", entry: userEntry(0, "hello") });
       await deferred.promise;
     });
 
+    // 迟到的发送完成不得污染已切换会话的时间线
     expect(MockEventSource.instances).toHaveLength(0);
     expect(useAssistantStore.getState().currentSessionId).toBe("session-2");
-  });
-
-  it("drops optimistic turn once snapshot contains the committed user turn", async () => {
-    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
-      sessions: [makeSession("session-1", "idle")],
-    });
-    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "idle") });
-    vi.spyOn(API, "getAssistantSnapshot").mockResolvedValue(makeSnapshot());
-    vi.spyOn(API, "sendAssistantMessage").mockResolvedValue({ session_id: "session-1", status: "running" });
-
-    const { result } = renderHook(() => useAssistantSession("demo"));
-
-    await waitFor(() => {
-      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
-    });
-
-    await act(async () => {
-      await result.current.sendMessage("hello");
-    });
-
-    await waitFor(() => {
-      expect(MockEventSource.instances).toHaveLength(1);
-    });
-
-    act(() => {
-      MockEventSource.instances[0].emit("snapshot", makeSnapshot({
-        status: "running",
-        turns: [
-          {
-            type: "user",
-            uuid: "real-user-1",
-            timestamp: "2099-01-01T00:00:00Z",
-            content: [{ type: "text", text: "hello" }],
-          },
-          {
-            type: "assistant",
-            uuid: "assistant-1",
-            timestamp: "2099-01-01T00:00:01Z",
-            content: [{ type: "text", text: "hi" }],
-          },
-        ],
-      }));
-    });
-
-    expect(useAssistantStore.getState().turns).toEqual([
-      {
-        type: "user",
-        uuid: "real-user-1",
-        timestamp: "2099-01-01T00:00:00Z",
-        content: [{ type: "text", text: "hello" }],
-      },
-      {
-        type: "assistant",
-        uuid: "assistant-1",
-        timestamp: "2099-01-01T00:00:01Z",
-        content: [{ type: "text", text: "hi" }],
-      },
-    ]);
-  });
-
-  it("keeps optimistic turn when same-text snapshot only contains an older round", async () => {
-    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
-      sessions: [makeSession("session-1", "idle")],
-    });
-    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "idle") });
-    vi.spyOn(API, "getAssistantSnapshot").mockResolvedValue(makeSnapshot({
-      turns: [
-        {
-          type: "user",
-          uuid: "old-user-1",
-          timestamp: "2026-01-01T00:00:00Z",
-          content: [{ type: "text", text: "hello" }],
-        },
-        {
-          type: "assistant",
-          uuid: "old-assistant-1",
-          timestamp: "2026-01-01T00:00:01Z",
-          content: [{ type: "text", text: "first reply" }],
-        },
-      ],
-    }));
-    vi.spyOn(API, "sendAssistantMessage").mockResolvedValue({ session_id: "session-1", status: "running" });
-
-    const { result } = renderHook(() => useAssistantSession("demo"));
-
-    await waitFor(() => {
-      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
-    });
-
-    await act(async () => {
-      await result.current.sendMessage("hello");
-    });
-
-    await waitFor(() => {
-      expect(MockEventSource.instances).toHaveLength(1);
-    });
-
-    act(() => {
-      MockEventSource.instances[0].emit("snapshot", makeSnapshot({
-        status: "running",
-        turns: [
-          {
-            type: "user",
-            uuid: "old-user-1",
-            timestamp: "2026-01-01T00:00:00Z",
-            content: [{ type: "text", text: "hello" }],
-          },
-          {
-            type: "assistant",
-            uuid: "old-assistant-1",
-            timestamp: "2026-01-01T00:00:01Z",
-            content: [{ type: "text", text: "first reply" }],
-          },
-        ],
-      }));
-    });
-
-    const turns = useAssistantStore.getState().turns;
-    expect(turns).toHaveLength(3);
-    expect(turns[0].uuid).toBe("old-user-1");
-    expect(turns[1].uuid).toBe("old-assistant-1");
-    expect(turns[2].uuid?.startsWith("optimistic-")).toBe(true);
+    expect(useAssistantStore.getState().turns).toHaveLength(1);
   });
 });

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -4,11 +4,11 @@ import { API } from "@/api";
 import { uid } from "@/utils/id";
 import { useAssistantStore } from "@/stores/assistant-store";
 import type {
-  AssistantSnapshot,
+  DraftDeltaPayload,
+  DraftState,
   PendingQuestion,
   SessionMeta,
-  SessionStatus,
-  Turn,
+  TimelineEntry,
 } from "@/types";
 
 export interface AttachedImage {
@@ -18,7 +18,7 @@ export interface AttachedImage {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers — 从旧 use-assistant-state.js 移植
+// Helpers
 // ---------------------------------------------------------------------------
 
 function parseSsePayload(event: MessageEvent): Record<string, unknown> {
@@ -29,52 +29,10 @@ function parseSsePayload(event: MessageEvent): Record<string, unknown> {
   }
 }
 
-function applyTurnPatch(prev: Turn[], patch: Record<string, unknown>): Turn[] {
-  const op = patch.op as string;
-  if (op === "reset") return (patch.turns as Turn[]) ?? [];
-  if (op === "append" && patch.turn) {
-    const newTurn = patch.turn as Turn;
-    // 当后端 append 真实 user turn 时，移除末尾的 optimistic turn 避免重复
-    if (
-      newTurn.type === "user" &&
-      prev.length > 0 &&
-      prev.at(-1)?.uuid?.startsWith(OPTIMISTIC_PREFIX)
-    ) {
-      return [...prev.slice(0, -1), newTurn];
-    }
-    return [...prev, newTurn];
-  }
-  if (op === "replace_last" && patch.turn) {
-    return prev.length === 0
-      ? [patch.turn as Turn]
-      : [...prev.slice(0, -1), patch.turn as Turn];
-  }
-  return prev;
-}
-
 const TERMINAL = new Set(["completed", "error", "interrupted"]);
-const OPTIMISTIC_PREFIX = "optimistic-";
 
-function extractTurnText(turn: Turn): string {
-  return (
-    turn.content
-      ?.filter((b) => b.type === "text")
-      .map((b) => b.text ?? "")
-      .join("") ?? ""
-  );
-}
-
-function parseTurnTimestamp(turn: Turn | null): number | null {
-  if (!turn?.timestamp) return null;
-  const parsed = Date.parse(turn.timestamp);
-  return Number.isNaN(parsed) ? null : parsed;
-}
-
-function findLatestUserTurn(turns: Turn[]): Turn | null {
-  for (let i = turns.length - 1; i >= 0; i--) {
-    if (turns[i].type === "user") return turns[i];
-  }
-  return null;
+function lastEntrySeq(entries: TimelineEntry[]): number {
+  return entries.length > 0 ? entries[entries.length - 1].seq : -1;
 }
 
 // ---------------------------------------------------------------------------
@@ -108,11 +66,11 @@ function saveLastSessionId(projectName: string, sessionId: string): void {
 // ---------------------------------------------------------------------------
 
 /**
- * 管理 AI 助手会话生命周期：
- * - 加载/创建会话
- * - 发送消息
- * - SSE 流式接收
- * - 中断会话
+ * 管理 AI 助手会话生命周期，时间线唯一读源为会话事件日志：
+ * - 冷读 GET entries（历史回放）
+ * - SSE entry 流实时接收（事件 id 即 seq，断线按游标续传）
+ * - 发送消息：服务端先写日志分配身份，响应回传权威条目；
+ *   client_key 幂等，重试不产生重复；不渲染本地合成消息
  */
 export function useAssistantSession(projectName: string | null) {
   const store = useAssistantStore;
@@ -121,6 +79,8 @@ export function useAssistantSession(projectName: string | null) {
   const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const statusRef = useRef<string>("idle");
   const pendingSendVersionRef = useRef(0);
+  // 失败重试复用同一幂等键（同内容签名），成功后清除
+  const failedSendRef = useRef<{ clientKey: string; signature: string } | null>(null);
 
   const syncPendingQuestion = useCallback((question: PendingQuestion | null) => {
     store.getState().setPendingQuestion(question);
@@ -136,59 +96,6 @@ export function useAssistantSession(projectName: string | null) {
     store.getState().setSending(false);
   }, [store]);
 
-  const restoreFailedSend = useCallback((
-    sessionId: string,
-    optimisticUuid: string,
-    previousStatus: SessionStatus | null,
-  ) => {
-    if (store.getState().currentSessionId !== sessionId) return;
-
-    store.getState().setTurns(
-      store.getState().turns.filter((turn) => turn.uuid !== optimisticUuid),
-    );
-    statusRef.current = previousStatus ?? "idle";
-    store.getState().setSessionStatus(previousStatus ?? "idle");
-    store.getState().setSending(false);
-  }, [store]);
-
-  const applySnapshot = useCallback((snapshot: Partial<AssistantSnapshot>) => {
-    const snapshotTurns = (snapshot.turns as Turn[]) ?? [];
-    const currentTurns = store.getState().turns;
-
-    // 保留末尾的 optimistic turn：仅当 snapshot 尚未包含当前轮 user 时。
-    // 使用内容匹配而非 UUID（optimistic UUID 永远不会匹配后端真实 UUID）。
-    const lastTurn = currentTurns.at(-1);
-    let shouldPreserveOptimistic = false;
-
-    if (lastTurn?.uuid?.startsWith(OPTIMISTIC_PREFIX)) {
-      const optText = extractTurnText(lastTurn);
-
-      if (optText) {
-        const latestUserTurn = findLatestUserTurn(snapshotTurns);
-        if (!latestUserTurn || extractTurnText(latestUserTurn) !== optText) {
-          shouldPreserveOptimistic = true;
-        } else {
-          const latestUserTs = parseTurnTimestamp(latestUserTurn);
-          const optimisticTs = parseTurnTimestamp(lastTurn);
-          shouldPreserveOptimistic = Boolean(
-            latestUserTs !== null &&
-            optimisticTs !== null &&
-            latestUserTs < optimisticTs,
-          );
-        }
-      }
-    }
-
-    if (shouldPreserveOptimistic && lastTurn) {
-      store.getState().setTurns([...snapshotTurns, lastTurn]);
-    } else {
-      store.getState().setTurns(snapshotTurns);
-    }
-
-    store.getState().setDraftTurn((snapshot.draft_turn as Turn) ?? null);
-    syncPendingQuestion(getPendingQuestionFromSnapshot(snapshot));
-  }, [store, syncPendingQuestion]);
-
   // 关闭流
   const closeStream = useCallback(() => {
     if (reconnectRef.current) {
@@ -202,7 +109,7 @@ export function useAssistantSession(projectName: string | null) {
     streamSessionRef.current = null;
   }, []);
 
-  // 连接 SSE 流
+  // 连接 SSE entry 流
   const connectStream = useCallback(
     (sessionId: string) => {
       // 如果已连接到同一 session 且连接健康，跳过重连
@@ -217,7 +124,9 @@ export function useAssistantSession(projectName: string | null) {
       closeStream();
       streamSessionRef.current = sessionId;
 
-      const url = API.getAssistantStreamUrl(projectName!, sessionId);
+      // 冷订阅游标：已有条目之后；浏览器自动重连由 Last-Event-ID 续传
+      const after = lastEntrySeq(store.getState().entries);
+      const url = API.getAssistantEntriesStreamUrl(projectName!, sessionId, after);
       const source = new EventSource(url);
       streamRef.current = source;
       const isActiveStream = () =>
@@ -225,45 +134,27 @@ export function useAssistantSession(projectName: string | null) {
         streamSessionRef.current === sessionId &&
         store.getState().currentSessionId === sessionId;
 
-      source.addEventListener("snapshot", (event) => {
+      source.addEventListener("entry", (event) => {
         if (!isActiveStream()) return;
-        const data = parseSsePayload(event);
-        const isSending = store.getState().sending;
-
-        // 正在发送消息时，后端可能尚未将 session 切为 "running"，
-        // 此时 SSE 连接到旧 "completed" session 会立即收到旧 snapshot + status 后断开。
-        // 忽略这种 stale snapshot 的 turns 和 status，保留前端的 optimistic 状态。
-        if (isSending && typeof data.status === "string" && data.status !== "running") {
-          return;
-        }
-
-        applySnapshot(data);
-
-        if (typeof data.status === "string") {
-          store.getState().setSessionStatus(data.status as "idle");
-          statusRef.current = data.status;
-          // 收到任何有效 status 都清除 sending（stale 的已在上方过滤）。
-          // 特别是 "running" 表示后端已确认收到消息，必须清除 sending，
-          // 否则后续的 "completed" 会被 status handler 的 isSending 守卫过滤掉。
-          store.getState().setSending(false);
+        const entry = parseSsePayload(event);
+        if (typeof entry.seq === "number" && typeof entry.type === "string") {
+          store.getState().appendEntry(entry as unknown as TimelineEntry);
         }
       });
 
-      source.addEventListener("patch", (event) => {
+      source.addEventListener("draft", (event) => {
         if (!isActiveStream()) return;
         const payload = parseSsePayload(event);
-        const patch = (payload.patch ?? payload) as Record<string, unknown>;
-        store.getState().setTurns(applyTurnPatch(store.getState().turns, patch));
-        if ("draft_turn" in payload) {
-          store.getState().setDraftTurn((payload.draft_turn as Turn) ?? null);
-        }
+        const draft = (payload.draft ?? null) as DraftState | null;
+        const rev = typeof payload.rev === "number" ? payload.rev : 0;
+        store.getState().setDraftSnapshot(draft, rev);
       });
 
       source.addEventListener("delta", (event) => {
         if (!isActiveStream()) return;
         const payload = parseSsePayload(event);
-        if ("draft_turn" in payload) {
-          store.getState().setDraftTurn((payload.draft_turn as Turn) ?? null);
+        if (typeof payload.message_id === "string" && typeof payload.rev === "number") {
+          store.getState().applyDelta(payload as unknown as DraftDeltaPayload);
         }
       });
 
@@ -271,15 +162,6 @@ export function useAssistantSession(projectName: string | null) {
         if (!isActiveStream()) return;
         const data = parseSsePayload(event);
         const status = (data.status as string) ?? statusRef.current;
-        const isSending = store.getState().sending;
-
-        // 正在发送消息时，忽略旧 session 的 terminal status。
-        // 后端对非 running session 的 SSE 会发 status:"completed" 后关闭连接，
-        // 不应让这个 stale status 触发 closeStream / setSending(false)。
-        // onerror 回调会在连接断开后自动重连到已变为 "running" 的 session。
-        if (isSending && TERMINAL.has(status) && status !== "error") {
-          return;
-        }
 
         statusRef.current = status;
         store.getState().setSessionStatus(status as "idle");
@@ -288,8 +170,9 @@ export function useAssistantSession(projectName: string | null) {
           store.getState().setSending(false);
           store.getState().setInterrupting(false);
           clearPendingQuestion();
+          // 中断时保留 draft：被中断的流式内容不入日志，刷新后自然消失
           if (status !== "interrupted") {
-            store.getState().setDraftTurn(null);
+            store.getState().clearDraft();
           }
           closeStream();
 
@@ -314,10 +197,12 @@ export function useAssistantSession(projectName: string | null) {
 
       source.onerror = () => {
         if (!isActiveStream()) return;
-        // 重连条件：session 正在运行，或者前端正在发送消息。
-        // 后者处理后端对旧 "completed" session 的 SSE 立即关闭的情况：
-        // 连接断开后需要重连，此时后端已将 session 设为 "running"。
-        if (statusRef.current === "running" || store.getState().sending) {
+        // 浏览器原生自动重连携带 Last-Event-ID 续传；此处仅兜底
+        // 连接被判死（CLOSED）的场景，运行中或发送中才重建。
+        if (
+          source.readyState === EventSource.CLOSED &&
+          (statusRef.current === "running" || store.getState().sending)
+        ) {
           reconnectRef.current = setTimeout(() => {
             // 自引用 SSE 重连：useEffectEvent 不允许在 setTimeout 内调用，
             // 用 ref 中转又被 immutability 规则禁止。当前写法是延迟到下一 tick
@@ -328,8 +213,27 @@ export function useAssistantSession(projectName: string | null) {
         }
       };
     },
-    [applySnapshot, clearPendingQuestion, projectName, closeStream, store, syncPendingQuestion],
+    [clearPendingQuestion, projectName, closeStream, store, syncPendingQuestion],
   );
+
+  // 加载指定会话时间线：非 running 冷读日志；running 交给 entry 流回放
+  const loadSession = useCallback(async (sessionId: string) => {
+    const res = await API.getAssistantSession(projectName!, sessionId);
+    const raw = res as Record<string, unknown>;
+    const sessionObj = (raw.session ?? raw) as Record<string, unknown>;
+    const status = (sessionObj.status as string) ?? "idle";
+    statusRef.current = status;
+    store.getState().setSessionStatus(status as "idle");
+
+    if (status === "running") {
+      connectStream(sessionId);
+    } else {
+      const data = await API.listAssistantEntries(projectName!, sessionId);
+      if (store.getState().currentSessionId !== sessionId) return;
+      store.getState().setEntries(data.entries ?? []);
+      store.getState().setDraftSnapshot(data.draft ?? null, data.draft_rev ?? 0);
+    }
+  }, [projectName, connectStream, store]);
 
   // 加载会话
   useEffect(() => {
@@ -358,22 +262,7 @@ export function useAssistantSession(projectName: string | null) {
         if (cancelled) return;
 
         store.getState().setCurrentSessionId(sessionId);
-
-        // 加载会话快照
-        const session = await API.getAssistantSession(projectName!, sessionId);
-        const raw = session as Record<string, unknown>;
-        const sessionObj = (raw.session ?? raw) as Record<string, unknown>;
-        const status = (sessionObj.status as string) ?? "idle";
-        statusRef.current = status;
-        store.getState().setSessionStatus(status as "idle");
-
-        if (status === "running") {
-          connectStream(sessionId);
-        } else {
-          const snapshot = await API.getAssistantSnapshot(projectName!, sessionId);
-          if (cancelled) return;
-          applySnapshot(snapshot);
-        }
+        await loadSession(sessionId);
       } catch {
         // 静默失败
       } finally {
@@ -397,66 +286,50 @@ export function useAssistantSession(projectName: string | null) {
     };
   }, [
     projectName,
-    applySnapshot,
     clearPendingQuestion,
-    connectStream,
     closeStream,
     invalidatePendingSend,
+    loadSession,
     store,
   ]);
 
-  // 发送消息
+  // 发送消息。返回是否受理成功——失败时调用方保留输入内容。
   const sendMessage = useCallback(
-    async (content: string, images?: AttachedImage[]) => {
-      if ((!content.trim() && (!images || images.length === 0)) || store.getState().sending) return;
+    async (content: string, images?: AttachedImage[]): Promise<boolean> => {
+      if ((!content.trim() && (!images || images.length === 0)) || store.getState().sending) {
+        return false;
+      }
 
       const sendVersion = pendingSendVersionRef.current + 1;
       pendingSendVersionRef.current = sendVersion;
-      const previousStatus = store.getState().sessionStatus;
       let sessionId = store.getState().currentSessionId;
-      let optimisticUuid = "";
       store.getState().setSending(true);
       store.getState().setError(null);
 
+      // 提取 base64 数据
+      const imagePayload = images?.map((img) => ({
+        data: img.dataUrl.split(",")[1] ?? "",
+        media_type: img.mimeType,
+      }));
+
+      // 请求侧幂等键：同一内容失败重试复用同键，服务端按键去重不产生重复
+      const signature = JSON.stringify([sessionId, content.trim(), imagePayload ?? []]);
+      const clientKey =
+        failedSendRef.current?.signature === signature
+          ? failedSendRef.current.clientKey
+          : uid();
+
       try {
-        // 提取 base64 数据
-        const imagePayload = images?.map((img) => ({
-          data: img.dataUrl.split(",")[1] ?? "",
-          media_type: img.mimeType,
-        }));
-
-        // 乐观更新：立即在 UI 上显示用户消息
-        const optimisticContent: import("@/types").ContentBlock[] = [
-          ...(imagePayload ?? []).map((img) => ({
-            type: "image" as const,
-            source: {
-              type: "base64" as const,
-              media_type: img.media_type,
-              data: img.data,
-            },
-          })),
-          ...(content.trim() ? [{ type: "text" as const, text: content.trim() }] : []),
-        ];
-        const optimisticTurn: Turn = {
-          type: "user",
-          content: optimisticContent,
-          uuid: `${OPTIMISTIC_PREFIX}${uid()}`,
-          timestamp: new Date().toISOString(),
-        };
-        optimisticUuid = optimisticTurn.uuid ?? "";
-        store.getState().setTurns([...store.getState().turns, optimisticTurn]);
-        statusRef.current = "running";
-        store.getState().setSessionStatus("running");
-
-        // 统一发送（新建或已有会话）
         const result = await API.sendAssistantMessage(
           projectName!,
           content,
           sessionId,  // null for new session
           imagePayload,
+          clientKey,
         );
 
-        if (pendingSendVersionRef.current !== sendVersion) return;
+        if (pendingSendVersionRef.current !== sendVersion) return true;
+        failedSendRef.current = null;
 
         const returnedSessionId = result.session_id;
 
@@ -477,25 +350,27 @@ export function useAssistantSession(projectName: string | null) {
           sessionId = returnedSessionId;
         }
 
-        if (store.getState().currentSessionId !== sessionId) return;
-        connectStream(sessionId);
-      } catch (err) {
-        if (pendingSendVersionRef.current !== sendVersion) return;
-        store.getState().setError(errMsg(err, "发送失败"));
-        if (sessionId && optimisticUuid) {
-          restoreFailedSend(sessionId, optimisticUuid, previousStatus);
-        } else {
-          // 新会话创建失败：回滚到 draft 模式
-          store.getState().setTurns(store.getState().turns.filter(t => t.uuid !== optimisticUuid));
-          store.getState().setIsDraftSession(true);
-          store.getState().setCurrentSessionId(null);
-          statusRef.current = previousStatus ?? "idle";
-          store.getState().setSessionStatus(previousStatus ?? "idle");
-          store.getState().setSending(false);
+        if (store.getState().currentSessionId !== sessionId) return true;
+
+        // 响应携带的权威条目（服务端已写日志分配身份），seq 门槛去重
+        if (result.entry) {
+          store.getState().appendEntry(result.entry);
         }
+        statusRef.current = "running";
+        store.getState().setSessionStatus("running");
+        store.getState().setSending(false);
+        connectStream(sessionId);
+        return true;
+      } catch (err) {
+        if (pendingSendVersionRef.current !== sendVersion) return false;
+        // 失败：无本地合成消息可回滚，仅记录幂等键供重试复用
+        failedSendRef.current = { clientKey, signature };
+        store.getState().setError(errMsg(err, "发送失败"));
+        store.getState().setSending(false);
+        return false;
       }
     },
-    [projectName, connectStream, restoreFailedSend, store],
+    [projectName, connectStream, store],
   );
 
   const answerQuestion = useCallback(
@@ -538,8 +413,7 @@ export function useAssistantSession(projectName: string | null) {
 
     invalidatePendingSend();
     closeStream();
-    store.getState().setTurns([]);
-    store.getState().setDraftTurn(null);
+    store.getState().resetTimeline();
     store.getState().setSessionStatus("idle");
     clearPendingQuestion();
     store.getState().setCurrentSessionId(null);
@@ -555,8 +429,7 @@ export function useAssistantSession(projectName: string | null) {
     closeStream();
     store.getState().setCurrentSessionId(sessionId);
     store.getState().setIsDraftSession(false);
-    store.getState().setTurns([]);
-    store.getState().setDraftTurn(null);
+    store.getState().resetTimeline();
     clearPendingQuestion();
     store.getState().setMessagesLoading(true);
 
@@ -564,25 +437,13 @@ export function useAssistantSession(projectName: string | null) {
     if (projectName) saveLastSessionId(projectName, sessionId);
 
     try {
-      const res = await API.getAssistantSession(projectName!, sessionId);
-      const raw = res as Record<string, unknown>;
-      const sessionObj = (raw.session ?? raw) as Record<string, unknown>;
-      const status = (sessionObj.status as string) ?? "idle";
-      statusRef.current = status;
-      store.getState().setSessionStatus(status as "idle");
-
-      if (status === "running") {
-        connectStream(sessionId);
-      } else {
-        const snapshot = await API.getAssistantSnapshot(projectName!, sessionId);
-        applySnapshot(snapshot);
-      }
+      await loadSession(sessionId);
     } catch {
       // 静默失败
     } finally {
       store.getState().setMessagesLoading(false);
     }
-  }, [projectName, applySnapshot, clearPendingQuestion, closeStream, connectStream, invalidatePendingSend, store]);
+  }, [projectName, clearPendingQuestion, closeStream, invalidatePendingSend, loadSession, store]);
 
   // 删除会话
   const deleteSession = useCallback(async (sessionId: string) => {
@@ -600,8 +461,7 @@ export function useAssistantSession(projectName: string | null) {
           invalidatePendingSend();
           closeStream();
           store.getState().setCurrentSessionId(null);
-          store.getState().setTurns([]);
-          store.getState().setDraftTurn(null);
+          store.getState().resetTimeline();
           store.getState().setSessionStatus(null);
           clearPendingQuestion();
           statusRef.current = "idle";
@@ -613,27 +473,6 @@ export function useAssistantSession(projectName: string | null) {
   }, [projectName, clearPendingQuestion, closeStream, invalidatePendingSend, switchSession, store]);
 
   return { sendMessage, answerQuestion, interrupt, createNewSession, switchSession, deleteSession };
-}
-
-function getPendingQuestionFromSnapshot(
-  snapshot: Partial<AssistantSnapshot> | Record<string, unknown>,
-): PendingQuestion | null {
-  const questions = snapshot.pending_questions as Array<Record<string, unknown>> | undefined;
-  const pending = questions?.find(
-    (question) =>
-      typeof question?.question_id === "string" &&
-      Array.isArray(question.questions) &&
-      question.questions.length > 0,
-  );
-
-  if (!pending) {
-    return null;
-  }
-
-  return {
-    question_id: pending.question_id as string,
-    questions: pending.questions as PendingQuestion["questions"],
-  };
 }
 
 function getPendingQuestionFromEvent(payload: Record<string, unknown>): PendingQuestion | null {

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -224,6 +224,9 @@ export function useAssistantSession(projectName: string | null) {
     const status = (sessionObj.status as string) ?? "idle";
     statusRef.current = status;
     store.getState().setSessionStatus(status as "idle");
+    // 清掉跨挂载残留的过期问题（zustand 全局 store 在组件卸载后仍保留）；
+    // running 会话的未决问题由 entry 流的 question 事件重新投递。
+    clearPendingQuestion();
 
     if (status === "running") {
       connectStream(sessionId);
@@ -233,7 +236,7 @@ export function useAssistantSession(projectName: string | null) {
       store.getState().setEntries(data.entries ?? []);
       store.getState().setDraftSnapshot(data.draft ?? null, data.draft_rev ?? 0);
     }
-  }, [projectName, connectStream, store]);
+  }, [projectName, clearPendingQuestion, connectStream, store]);
 
   // 加载会话
   useEffect(() => {
@@ -354,6 +357,18 @@ export function useAssistantSession(projectName: string | null) {
 
         // 响应携带的权威条目（服务端已写日志分配身份），seq 门槛去重
         if (result.entry) {
+          const lastSeq = lastEntrySeq(store.getState().entries);
+          if (result.entry.seq > lastSeq + 1) {
+            // seq 跳档：其他客户端在本地未订阅期间产生了轮次，先冷读补齐缺口，
+            // 否则订阅游标越过缺口后中间条目永远不会被拉取
+            try {
+              const gap = await API.listAssistantEntries(projectName!, sessionId, lastSeq);
+              if (store.getState().currentSessionId !== sessionId) return true;
+              store.getState().setEntries(gap.entries ?? []);
+            } catch {
+              // 静默失败：缺口留待刷新兜底
+            }
+          }
           store.getState().appendEntry(result.entry);
         }
         statusRef.current = "running";

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -353,7 +353,7 @@ export function useAssistantSession(projectName: string | null) {
           sessionId = returnedSessionId;
         }
 
-        if (store.getState().currentSessionId !== sessionId) return true;
+        if (store.getState().currentSessionId !== sessionId) return false;
 
         // 响应携带的权威条目（服务端已写日志分配身份），seq 门槛去重
         if (result.entry) {
@@ -363,7 +363,7 @@ export function useAssistantSession(projectName: string | null) {
             // 否则订阅游标越过缺口后中间条目永远不会被拉取
             try {
               const gap = await API.listAssistantEntries(projectName!, sessionId, lastSeq);
-              if (store.getState().currentSessionId !== sessionId) return true;
+              if (store.getState().currentSessionId !== sessionId) return false;
               store.getState().setEntries(gap.entries ?? []);
             } catch {
               // 静默失败：缺口留待刷新兜底

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -331,7 +331,7 @@ export function useAssistantSession(projectName: string | null) {
           clientKey,
         );
 
-        if (pendingSendVersionRef.current !== sendVersion) return true;
+        if (pendingSendVersionRef.current !== sendVersion) return false;
         failedSendRef.current = null;
 
         const returnedSessionId = result.session_id;

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -105,8 +105,7 @@ function StudioWorkspace() {
     const assistantState = useAssistantStore.getState();
     assistantState.setSessions([]);
     assistantState.setCurrentSessionId(null);
-    assistantState.setTurns([]);
-    assistantState.setDraftTurn(null);
+    assistantState.resetTimeline();
     assistantState.setSessionStatus(null);
     assistantState.setIsDraftSession(false);
 

--- a/frontend/src/stores/assistant-store.ts
+++ b/frontend/src/stores/assistant-store.ts
@@ -1,5 +1,20 @@
 import { create } from "zustand";
-import type { SessionMeta, Turn, PendingQuestion, SkillInfo, SessionStatus } from "@/types";
+import type {
+  DraftDeltaPayload,
+  DraftState,
+  PendingQuestion,
+  SessionMeta,
+  SessionStatus,
+  SkillInfo,
+  TimelineEntry,
+  Turn,
+} from "@/types";
+import {
+  applyDraftDelta,
+  projectDraftToTurn,
+  projectEntriesToTurns,
+  type DraftMirror,
+} from "@/utils/entry-projection";
 
 interface AssistantState {
   // Sessions
@@ -7,7 +22,11 @@ interface AssistantState {
   currentSessionId: string | null;
   sessionsLoading: boolean;
 
-  // Messages
+  // Timeline（事件日志唯一读源）
+  entries: TimelineEntry[];
+  draft: DraftMirror | null;
+  draftRev: number;
+  // 由 entries/draft 投影派生，仅 timeline actions 写入
   turns: Turn[];
   draftTurn: Turn | null;
   messagesLoading: boolean;
@@ -36,12 +55,21 @@ interface AssistantState {
   // Draft session (lazy creation)
   isDraftSession: boolean;
 
-  // Actions (basic setters -- full logic migrated later)
+  // Actions
   setSessions: (sessions: SessionMeta[]) => void;
   setCurrentSessionId: (id: string | null) => void;
   setSessionsLoading: (loading: boolean) => void;
-  setTurns: (turns: Turn[]) => void;
-  setDraftTurn: (turn: Turn | null) => void;
+  /** 整帧替换日志条目（冷读 / 切换会话）。 */
+  setEntries: (entries: TimelineEntry[]) => void;
+  /** 追加单条权威条目；seq 门槛去重（身份比对，非内容比对）。 */
+  appendEntry: (entry: TimelineEntry) => void;
+  /** draft 首帧快照（重连携带累积态 + rev 过滤门槛）。 */
+  setDraftSnapshot: (draft: DraftState | null, rev: number) => void;
+  /** 应用一条流式 delta；rev 未超过门槛时忽略。 */
+  applyDelta: (payload: DraftDeltaPayload) => void;
+  clearDraft: () => void;
+  /** 清空时间线（项目切换 / 新会话）。 */
+  resetTimeline: () => void;
   setMessagesLoading: (loading: boolean) => void;
   setInput: (input: string) => void;
   setSending: (sending: boolean) => void;
@@ -57,10 +85,13 @@ interface AssistantState {
   setIsDraftSession: (draft: boolean) => void;
 }
 
-export const useAssistantStore = create<AssistantState>((set) => ({
+export const useAssistantStore = create<AssistantState>((set, get) => ({
   sessions: [],
   currentSessionId: null,
   sessionsLoading: false,
+  entries: [],
+  draft: null,
+  draftRev: 0,
   turns: [],
   draftTurn: null,
   messagesLoading: false,
@@ -80,8 +111,59 @@ export const useAssistantStore = create<AssistantState>((set) => ({
   setSessions: (sessions) => set({ sessions }),
   setCurrentSessionId: (id) => set({ currentSessionId: id }),
   setSessionsLoading: (loading) => set({ sessionsLoading: loading }),
-  setTurns: (turns) => set({ turns }),
-  setDraftTurn: (turn) => set({ draftTurn: turn }),
+
+  setEntries: (entries) => {
+    const draft = get().draft;
+    set({
+      entries,
+      turns: projectEntriesToTurns(entries),
+      draftTurn: projectDraftToTurn(draft, entries),
+    });
+  },
+  appendEntry: (entry) => {
+    const { entries, draft } = get();
+    const lastSeq = entries.length > 0 ? entries[entries.length - 1].seq : -1;
+    if (entry.seq <= lastSeq) return;
+    const next = [...entries, entry];
+    // 权威条目落库即按同 message_id 精确替换 draft（身份比对）
+    const draftReplaced =
+      draft !== null &&
+      entry.type === "assistant" &&
+      entry.message_id != null &&
+      entry.message_id === draft.message_id;
+    const nextDraft = draftReplaced ? null : draft;
+    set({
+      entries: next,
+      draft: nextDraft,
+      turns: projectEntriesToTurns(next),
+      draftTurn: projectDraftToTurn(nextDraft, next),
+    });
+  },
+  setDraftSnapshot: (draft, rev) => {
+    const entries = get().entries;
+    const mirror: DraftMirror | null = draft
+      ? { ...draft, content: [...draft.content], toolJson: {} }
+      : null;
+    set({
+      draft: mirror,
+      draftRev: rev,
+      draftTurn: projectDraftToTurn(mirror, entries),
+    });
+  },
+  applyDelta: (payload) => {
+    const { draft, draftRev, entries } = get();
+    if (typeof payload.rev !== "number" || payload.rev <= draftRev) return;
+    const next = applyDraftDelta(draft, payload);
+    set({
+      draft: next,
+      draftRev: payload.rev,
+      draftTurn: projectDraftToTurn(next, entries),
+    });
+  },
+  clearDraft: () => set({ draft: null, draftTurn: null }),
+  resetTimeline: () =>
+    set({ entries: [], draft: null, draftRev: 0, turns: [], draftTurn: null }),
+
   setMessagesLoading: (loading) => set({ messagesLoading: loading }),
   setInput: (input) => set({ input }),
   setSending: (sending) => set({ sending }),

--- a/frontend/src/stores/assistant-store.ts
+++ b/frontend/src/stores/assistant-store.ts
@@ -11,6 +11,7 @@ import type {
 } from "@/types";
 import {
   applyDraftDelta,
+  mergeEntriesBySeq,
   projectDraftToTurn,
   projectEntriesToTurns,
   type DraftMirror,
@@ -113,11 +114,14 @@ export const useAssistantStore = create<AssistantState>((set, get) => ({
   setSessionsLoading: (loading) => set({ sessionsLoading: loading }),
 
   setEntries: (entries) => {
+    // 并集合并而非整帧覆盖：慢网络下冷读响应可能晚于发送响应/SSE 条目到达，
+    // 整帧覆盖会抹掉更新的条目；append-only 日志按 seq 并集恒安全。
+    const merged = mergeEntriesBySeq(get().entries, entries);
     const draft = get().draft;
     set({
-      entries,
-      turns: projectEntriesToTurns(entries),
-      draftTurn: projectDraftToTurn(draft, entries),
+      entries: merged,
+      turns: projectEntriesToTurns(merged),
+      draftTurn: projectDraftToTurn(draft, merged),
     });
   },
   appendEntry: (entry) => {
@@ -141,8 +145,10 @@ export const useAssistantStore = create<AssistantState>((set, get) => ({
   },
   setDraftSnapshot: (draft, rev) => {
     const entries = get().entries;
+    // tool_json 是服务端已累积的原始 partial JSON——以此为前缀继续拼接
+    // 后续 input_json_delta，否则纯后缀永远解析失败、参数预览冻结。
     const mirror: DraftMirror | null = draft
-      ? { ...draft, content: [...draft.content], toolJson: {} }
+      ? { ...draft, content: [...draft.content], toolJson: { ...(draft.tool_json ?? {}) } }
       : null;
     set({
       draft: mirror,

--- a/frontend/src/stores/stores.test.ts
+++ b/frontend/src/stores/stores.test.ts
@@ -236,6 +236,41 @@ describe("stores", () => {
     expect(state.isDraftSession).toBe(true);
   });
 
+  it("setEntries merges by seq instead of overwriting newer local entries", () => {
+    const assistant = useAssistantStore.getState();
+    assistant.resetTimeline();
+    // 发送响应先落 seq 2；迟到的冷读整帧只有 seq 0-1
+    assistant.appendEntry({ seq: 2, type: "user", uuid: "sent", content: [{ type: "text", text: "新" }] });
+    assistant.setEntries([
+      { seq: 0, type: "user", uuid: "a", content: [{ type: "text", text: "旧1" }] },
+      { seq: 1, type: "assistant", uuid: "b", content: [{ type: "text", text: "旧2" }] },
+    ]);
+    expect(useAssistantStore.getState().entries.map((e) => e.seq)).toEqual([0, 1, 2]);
+  });
+
+  it("setDraftSnapshot restores accumulated tool JSON so later suffix deltas parse", () => {
+    const assistant = useAssistantStore.getState();
+    assistant.resetTimeline();
+    assistant.setDraftSnapshot(
+      {
+        message_id: "msg_1",
+        content: [{ type: "tool_use", id: "tu-1", name: "Write", input: {} }],
+        rev: 5,
+        tool_json: { 0: '{"path": "a' },
+      },
+      5,
+    );
+    assistant.applyDelta({
+      message_id: "msg_1",
+      delta_type: "input_json_delta",
+      block_index: 0,
+      rev: 6,
+      partial_json: '.txt"}',
+    });
+    const draft = useAssistantStore.getState().draft;
+    expect(draft?.content[0].input).toEqual({ path: "a.txt" });
+  });
+
   describe("ProjectsStore fingerprints", () => {
     it("should store and retrieve asset fingerprints", () => {
       const { updateAssetFingerprints, getAssetFingerprint } = useProjectsStore.getState();

--- a/frontend/src/stores/stores.test.ts
+++ b/frontend/src/stores/stores.test.ts
@@ -209,8 +209,7 @@ describe("stores", () => {
     ]);
     assistant.setCurrentSessionId("s1");
     assistant.setSessionsLoading(true);
-    assistant.setTurns([{ type: "user", content: [{ type: "text", text: "hi" }] }]);
-    assistant.setDraftTurn({ type: "assistant", content: [{ type: "text", text: "draft" }] });
+    assistant.setEntries([{ seq: 0, type: "user", content: [{ type: "text", text: "hi" }] }]);
     assistant.setMessagesLoading(true);
     assistant.setInput("hello");
     assistant.setSending(true);

--- a/frontend/src/types/assistant.ts
+++ b/frontend/src/types/assistant.ts
@@ -89,6 +89,8 @@ export interface DraftState {
   parent_tool_use_id?: string | null;
   content: ContentBlock[];
   rev?: number;
+  /** 各 tool_use 块已累积的原始 partial JSON（重连后续拼 input_json_delta 的前缀）。 */
+  tool_json?: Record<number, string>;
 }
 
 /** delta SSE 事件载荷（引用 message_id + block index，rev 单调用于重连过滤）。 */

--- a/frontend/src/types/assistant.ts
+++ b/frontend/src/types/assistant.ts
@@ -2,9 +2,10 @@
  * Assistant / agent runtime type definitions.
  *
  * Maps to backend models in:
- * - webui/server/agent_runtime/models.py (SessionMeta, SessionStatus, AssistantSnapshotV2)
- * - webui/server/agent_runtime/turn_grouper.py (Turn, ContentBlock structure)
- * - webui/server/agent_runtime/service.py (SkillInfo, stream events)
+ * - server/agent_runtime/models.py (SessionMeta, SessionStatus)
+ * - server/agent_runtime/event_log.py (TimelineEntry payload structure)
+ * - server/agent_runtime/entry_pipeline.py (DraftState / DraftDeltaPayload)
+ * - server/agent_runtime/service.py (SkillInfo, entry stream events)
  */
 
 export type SessionStatus = "idle" | "running" | "completed" | "error" | "interrupted";
@@ -59,12 +60,57 @@ export interface PendingQuestion {
   }>;
 }
 
-export interface AssistantSnapshot {
+/** 会话事件日志条目（UI 时间线唯一读源；seq 为会话内单调序号）。 */
+export interface TimelineEntry {
+  seq: number;
+  type: "user" | "assistant" | "tool_result" | "system";
+  content?: ContentBlock[] | string;
+  uuid?: string;
+  timestamp?: string;
+  /** assistant 条目携带，供 draft 按身份精确替换。 */
+  message_id?: string | null;
+  /** subagent 消息标记（归组渲染后置，当前仅用于抑制内部注入文本）。 */
+  parent_tool_use_id?: string;
+  // tool_result 条目字段
+  tool_use_id?: string | null;
+  is_error?: boolean;
+  // system 条目字段（task_* 子类型）
+  subtype?: string;
+  task_id?: string | null;
+  description?: string;
+  summary?: string | null;
+  task_status?: string | null;
+  usage?: { total_tokens?: number; tool_uses?: number; duration_ms?: number } | null;
+}
+
+/** 服务端流式预览态快照（身份为 message_id，不入日志）。 */
+export interface DraftState {
+  message_id: string;
+  parent_tool_use_id?: string | null;
+  content: ContentBlock[];
+  rev?: number;
+}
+
+/** delta SSE 事件载荷（引用 message_id + block index，rev 单调用于重连过滤）。 */
+export interface DraftDeltaPayload {
+  message_id: string;
+  parent_tool_use_id?: string | null;
+  delta_type: "block_start" | "text_delta" | "thinking_delta" | "input_json_delta";
+  block_index: number;
+  rev: number;
+  block?: ContentBlock;
+  text?: string;
+  thinking?: string;
+  partial_json?: string;
+}
+
+/** GET /sessions/{id}/entries 响应。 */
+export interface EntriesResponse {
   session_id: string;
   status: SessionStatus;
-  turns: Turn[];
-  draft_turn: Turn | null;
-  pending_questions: PendingQuestion[];
+  entries: TimelineEntry[];
+  draft: DraftState | null;
+  draft_rev: number;
 }
 
 export interface SkillInfo {

--- a/frontend/src/utils/entry-projection.test.ts
+++ b/frontend/src/utils/entry-projection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { DraftDeltaPayload, TimelineEntry } from "@/types";
 import {
   applyDraftDelta,
+  mergeEntriesBySeq,
   projectDraftToTurn,
   projectEntriesToTurns,
   type DraftMirror,
@@ -259,5 +260,30 @@ describe("applyDraftDelta", () => {
     const before = JSON.parse(JSON.stringify(first)) as DraftMirror;
     applyDraftDelta(first, delta({ text: "好", rev: 2 }));
     expect(first).toEqual(before);
+  });
+});
+
+describe("mergeEntriesBySeq", () => {
+  function e(seq: number, uuid: string): TimelineEntry {
+    return { seq, type: "user", uuid };
+  }
+
+  it("unions two entry lists sorted by seq without duplicates", () => {
+    const merged = mergeEntriesBySeq([e(0, "a"), e(2, "c")], [e(1, "b"), e(2, "c-dup"), e(3, "d")]);
+    expect(merged.map((x) => x.seq)).toEqual([0, 1, 2, 3]);
+    // 同 seq 条目不可变，保留既有引用
+    expect(merged[2].uuid).toBe("c");
+  });
+
+  it("keeps newer local entries when a stale cold read arrives late", () => {
+    // 冷读整帧只到 seq 1，本地已有发送响应的 seq 2 —— 并集不丢新条目
+    const merged = mergeEntriesBySeq([e(2, "sent")], [e(0, "a"), e(1, "b")]);
+    expect(merged.map((x) => x.seq)).toEqual([0, 1, 2]);
+  });
+
+  it("handles empty sides", () => {
+    expect(mergeEntriesBySeq([], [e(1, "b"), e(0, "a")]).map((x) => x.seq)).toEqual([0, 1]);
+    const existing = [e(0, "a")];
+    expect(mergeEntriesBySeq(existing, [])).toBe(existing);
   });
 });

--- a/frontend/src/utils/entry-projection.test.ts
+++ b/frontend/src/utils/entry-projection.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "vitest";
+import type { DraftDeltaPayload, TimelineEntry } from "@/types";
+import {
+  applyDraftDelta,
+  projectDraftToTurn,
+  projectEntriesToTurns,
+  type DraftMirror,
+} from "./entry-projection";
+
+let seqCounter = 0;
+
+function entry(partial: Omit<TimelineEntry, "seq">): TimelineEntry {
+  return { seq: seqCounter++, ...partial };
+}
+
+function userEntry(text: string, extra: Partial<TimelineEntry> = {}): TimelineEntry {
+  return entry({ type: "user", content: [{ type: "text", text }], uuid: `u-${seqCounter}`, ...extra });
+}
+
+describe("projectEntriesToTurns", () => {
+  it("projects user and assistant entries into separate turns", () => {
+    const turns = projectEntriesToTurns([
+      userEntry("你好"),
+      entry({ type: "assistant", content: [{ type: "text", text: "你好！" }], uuid: "a-1" }),
+    ]);
+    expect(turns.map((t) => t.type)).toEqual(["user", "assistant"]);
+    expect(turns[0].content[0].text).toBe("你好");
+    expect(turns[1].content[0].text).toBe("你好！");
+  });
+
+  it("merges consecutive assistant entries into one turn", () => {
+    const turns = projectEntriesToTurns([
+      entry({ type: "assistant", content: [{ type: "text", text: "第一段" }], uuid: "a-1" }),
+      entry({ type: "assistant", content: [{ type: "text", text: "第二段" }], uuid: "a-2" }),
+    ]);
+    expect(turns).toHaveLength(1);
+    expect(turns[0].content.map((b) => b.text)).toEqual(["第一段", "第二段"]);
+  });
+
+  it("backfills tool_result into matching tool_use without breaking the assistant merge", () => {
+    const turns = projectEntriesToTurns([
+      entry({
+        type: "assistant",
+        content: [{ type: "tool_use", id: "tu-1", name: "Read", input: {} }],
+        uuid: "a-1",
+      }),
+      entry({ type: "tool_result", tool_use_id: "tu-1", content: "文件内容", is_error: false, uuid: "tr-1" }),
+      entry({ type: "assistant", content: [{ type: "text", text: "读完了" }], uuid: "a-2" }),
+    ]);
+    expect(turns).toHaveLength(1);
+    const toolUse = turns[0].content[0];
+    expect(toolUse.result).toBe("文件内容");
+    expect(toolUse.is_error).toBe(false);
+    expect(turns[0].content[1].text).toBe("读完了");
+  });
+
+  it("appends unmatched tool_result as a standalone block", () => {
+    const turns = projectEntriesToTurns([
+      entry({ type: "assistant", content: [{ type: "text", text: "hi" }], uuid: "a-1" }),
+      entry({ type: "tool_result", tool_use_id: "tu-x", content: "孤儿结果", is_error: true, uuid: "tr-1" }),
+    ]);
+    expect(turns).toHaveLength(1);
+    const block = turns[0].content[1];
+    expect(block.type).toBe("tool_result");
+    expect(block.content).toBe("孤儿结果");
+    expect(block.is_error).toBe(true);
+  });
+
+  it("converts interrupt echo into interrupt_notice system turn and dedups adjacent echoes", () => {
+    const turns = projectEntriesToTurns([
+      userEntry("做点什么"),
+      userEntry("[Request interrupted by user]"),
+      userEntry("[Request interrupted by user for tool use]"),
+    ]);
+    expect(turns.map((t) => t.type)).toEqual(["user", "system"]);
+    expect(turns[1].content).toEqual([{ type: "interrupt_notice" }]);
+  });
+
+  it("maps system task entries to task_progress blocks and updates by task_id", () => {
+    const turns = projectEntriesToTurns([
+      entry({ type: "assistant", content: [{ type: "text", text: "启动子任务" }], uuid: "a-1" }),
+      entry({ type: "system", subtype: "task_started", task_id: "t1", description: "分析", uuid: "s-1" }),
+      entry({
+        type: "system",
+        subtype: "task_notification",
+        task_id: "t1",
+        summary: "完成",
+        task_status: "completed",
+        uuid: "s-2",
+      }),
+    ]);
+    expect(turns).toHaveLength(1);
+    const taskBlocks = turns[0].content.filter((b) => b.type === "task_progress");
+    expect(taskBlocks).toHaveLength(1);
+    expect(taskBlocks[0].status).toBe("task_notification");
+    expect(taskBlocks[0].summary).toBe("完成");
+    expect(taskBlocks[0].task_status).toBe("completed");
+  });
+
+  it("parses task-notification XML user entries and updates the existing task block", () => {
+    const xml =
+      "<task-notification><task-id>t9</task-id><tool-use-id>tu-9</tool-use-id>" +
+      "<status>completed</status><summary>子任务完成</summary></task-notification>";
+    const turns = projectEntriesToTurns([
+      entry({ type: "assistant", content: [{ type: "text", text: "spawn" }], uuid: "a-1" }),
+      entry({ type: "system", subtype: "task_started", task_id: "t9", description: "d", uuid: "s-1" }),
+      userEntry(xml),
+    ]);
+    expect(turns).toHaveLength(1);
+    const taskBlocks = turns[0].content.filter((b) => b.type === "task_progress");
+    expect(taskBlocks).toHaveLength(1);
+    expect(taskBlocks[0].summary).toBe("子任务完成");
+    expect(taskBlocks[0].task_status).toBe("completed");
+  });
+
+  it("attaches skill content text to the latest Skill tool_use", () => {
+    const turns = projectEntriesToTurns([
+      entry({
+        type: "assistant",
+        content: [{ type: "tool_use", id: "tu-s", name: "Skill", input: { command: "manage-project" } }],
+        uuid: "a-1",
+      }),
+      userEntry("Base directory for this skill: /skills/manage-project"),
+    ]);
+    expect(turns).toHaveLength(1);
+    expect(turns[0].content[0].skill_content).toContain("Base directory");
+  });
+
+  it("renders skill content as skill_content block when no Skill tool_use exists", () => {
+    const turns = projectEntriesToTurns([
+      userEntry("Skill content: 这里是技能正文"),
+    ]);
+    expect(turns).toHaveLength(1);
+    expect(turns[0].type).toBe("system");
+    expect(turns[0].content[0].type).toBe("skill_content");
+  });
+
+  it("suppresses subagent-injected plain text but merges subagent assistant entries", () => {
+    const turns = projectEntriesToTurns([
+      entry({ type: "assistant", content: [{ type: "text", text: "主线" }], uuid: "a-1" }),
+      userEntry("subagent 内部 prompt", { parent_tool_use_id: "tu-agent" }),
+      entry({
+        type: "assistant",
+        content: [{ type: "text", text: "subagent 回复" }],
+        uuid: "a-2",
+        parent_tool_use_id: "tu-agent",
+      }),
+    ]);
+    expect(turns).toHaveLength(1);
+    expect(turns[0].content.map((b) => b.text)).toEqual(["主线", "subagent 回复"]);
+  });
+
+  it("auto-completes stale task_started blocks whose Agent tool_use has a result", () => {
+    const turns = projectEntriesToTurns([
+      entry({
+        type: "assistant",
+        content: [{ type: "tool_use", id: "tu-a", name: "Agent", input: {} }],
+        uuid: "a-1",
+      }),
+      entry({ type: "system", subtype: "task_started", task_id: "t2", tool_use_id: "tu-a", uuid: "s-1" }),
+      entry({ type: "tool_result", tool_use_id: "tu-a", content: "done", is_error: false, uuid: "tr-1" }),
+    ]);
+    const taskBlock = turns[0].content.find((b) => b.type === "task_progress");
+    expect(taskBlock?.status).toBe("task_notification");
+    expect(taskBlock?.task_status).toBe("completed");
+  });
+
+  it("does not mutate input entries", () => {
+    const source = [
+      entry({
+        type: "assistant" as const,
+        content: [{ type: "tool_use" as const, id: "tu-1", name: "Read", input: {} }],
+        uuid: "a-1",
+      }),
+      entry({ type: "tool_result" as const, tool_use_id: "tu-1", content: "r", is_error: false, uuid: "tr-1" }),
+    ];
+    const copy = JSON.parse(JSON.stringify(source)) as TimelineEntry[];
+    projectEntriesToTurns(source);
+    expect(source).toEqual(copy);
+  });
+});
+
+describe("projectDraftToTurn", () => {
+  const draft: DraftMirror = {
+    message_id: "msg_1",
+    parent_tool_use_id: null,
+    content: [{ type: "text", text: "流式中" }],
+    toolJson: {},
+  };
+
+  it("returns an assistant turn for an active draft", () => {
+    const turn = projectDraftToTurn(draft, []);
+    expect(turn?.type).toBe("assistant");
+    expect(turn?.uuid).toBe("draft-msg_1");
+    expect(turn?.content[0].text).toBe("流式中");
+  });
+
+  it("returns null when a same-message_id authoritative entry exists (identity match, not content compare)", () => {
+    const entries: TimelineEntry[] = [
+      { seq: 0, type: "assistant", message_id: "msg_1", content: [{ type: "text", text: "完全不同的内容" }] },
+    ];
+    expect(projectDraftToTurn(draft, entries)).toBeNull();
+  });
+
+  it("returns null for null or empty drafts", () => {
+    expect(projectDraftToTurn(null, [])).toBeNull();
+    expect(projectDraftToTurn({ ...draft, content: [] }, [])).toBeNull();
+  });
+});
+
+describe("applyDraftDelta", () => {
+  function delta(partial: Partial<DraftDeltaPayload>): DraftDeltaPayload {
+    return {
+      message_id: "msg_1",
+      delta_type: "text_delta",
+      block_index: 0,
+      rev: 1,
+      ...partial,
+    };
+  }
+
+  it("accumulates text deltas by block index", () => {
+    let draft = applyDraftDelta(null, delta({ text: "你" }));
+    draft = applyDraftDelta(draft, delta({ text: "好", rev: 2 }));
+    expect(draft.content[0]).toEqual({ type: "text", text: "你好" });
+  });
+
+  it("starts a fresh draft when message_id changes", () => {
+    const first = applyDraftDelta(null, delta({ text: "旧" }));
+    const second = applyDraftDelta(first, delta({ message_id: "msg_2", text: "新", rev: 2 }));
+    expect(second.message_id).toBe("msg_2");
+    expect(second.content[0].text).toBe("新");
+  });
+
+  it("applies block_start with the provided block", () => {
+    const draft = applyDraftDelta(
+      null,
+      delta({ delta_type: "block_start", block: { type: "tool_use", id: "tu-1", name: "Read", input: {} } }),
+    );
+    expect(draft.content[0].type).toBe("tool_use");
+    expect(draft.content[0].name).toBe("Read");
+  });
+
+  it("accumulates thinking deltas", () => {
+    let draft = applyDraftDelta(null, delta({ delta_type: "thinking_delta", thinking: "思" }));
+    draft = applyDraftDelta(draft, delta({ delta_type: "thinking_delta", thinking: "考", rev: 2 }));
+    expect(draft.content[0]).toEqual({ type: "thinking", thinking: "思考" });
+  });
+
+  it("accumulates partial JSON and parses once complete", () => {
+    let draft = applyDraftDelta(null, delta({ delta_type: "input_json_delta", partial_json: '{"path": "a' }));
+    expect(draft.content[0].input).toEqual({});
+    draft = applyDraftDelta(draft, delta({ delta_type: "input_json_delta", partial_json: '.txt"}', rev: 2 }));
+    expect(draft.content[0].input).toEqual({ path: "a.txt" });
+  });
+
+  it("does not mutate the previous draft object", () => {
+    const first = applyDraftDelta(null, delta({ text: "你" }));
+    const before = JSON.parse(JSON.stringify(first)) as DraftMirror;
+    applyDraftDelta(first, delta({ text: "好", rev: 2 }));
+    expect(first).toEqual(before);
+  });
+});

--- a/frontend/src/utils/entry-projection.ts
+++ b/frontend/src/utils/entry-projection.ts
@@ -145,7 +145,26 @@ function resolveStaleTaskBlocks(turns: Turn[]): void {
 }
 
 function cloneBlock(block: ContentBlock): ContentBlock {
-  return JSON.parse(JSON.stringify(block)) as ContentBlock;
+  return structuredClone(block);
+}
+
+/**
+ * 按 seq 合并两组日志条目（并集、升序、seq 去重）。日志 append-only 且条目
+ * 按 seq 不可变，任一来源（冷读整帧 / SSE 直播 / 发送响应）先到后到均可安全
+ * 并集，不存在覆盖语义。
+ */
+export function mergeEntriesBySeq(
+  existing: TimelineEntry[],
+  incoming: TimelineEntry[],
+): TimelineEntry[] {
+  if (existing.length === 0) return [...incoming].sort((a, b) => a.seq - b.seq);
+  if (incoming.length === 0) return existing;
+  const bySeq = new Map<number, TimelineEntry>();
+  for (const entry of existing) bySeq.set(entry.seq, entry);
+  for (const entry of incoming) {
+    if (!bySeq.has(entry.seq)) bySeq.set(entry.seq, entry);
+  }
+  return [...bySeq.values()].sort((a, b) => a.seq - b.seq);
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/utils/entry-projection.ts
+++ b/frontend/src/utils/entry-projection.ts
@@ -1,0 +1,406 @@
+/**
+ * 会话事件日志投影 — entries → Turn[] 纯函数。
+ *
+ * 日志条目已在服务端写入点定型（tool_result 独立条目、subagent 条目带
+ * parent_tool_use_id、stream_event 不入日志），本模块只做渲染归组：
+ * 连续 assistant 条目合并、tool_result 按 tool_use_id 回填、task/skill/
+ * 中断等过渡期通用条目映射为既有渲染块。不做内容比对去重、不合成消息。
+ */
+
+import type {
+  ContentBlock,
+  DraftDeltaPayload,
+  DraftState,
+  TimelineEntry,
+  Turn,
+} from "@/types";
+
+// ---------------------------------------------------------------------------
+// 过渡期通用条目识别（与后端 turn_grouper 同口径）
+// ---------------------------------------------------------------------------
+
+const SKILL_BASE_DIR_PREFIX = "Base directory for this skill:";
+const SKILL_CONTENT_PREFIX = "Skill content:";
+const INTERRUPT_ECHO_PREFIX = "[Request interrupted";
+const TASK_NOTIFICATION_RE = /<task-notification>\s*[\s\S]*?<\/task-notification>/;
+
+function isSkillContentText(text: string): boolean {
+  return text.startsWith(SKILL_BASE_DIR_PREFIX) || text.startsWith(SKILL_CONTENT_PREFIX);
+}
+
+function entryBlocks(entry: TimelineEntry): ContentBlock[] {
+  const content = entry.content;
+  if (Array.isArray(content)) return content;
+  if (typeof content === "string" && content) return [{ type: "text", text: content }];
+  return [];
+}
+
+function blocksText(blocks: ContentBlock[]): string {
+  return blocks
+    .filter((b) => b.type === "text")
+    .map((b) => b.text ?? "")
+    .join("\n");
+}
+
+function isInterruptEcho(blocks: ContentBlock[]): boolean {
+  if (blocks.length !== 1 || blocks[0].type !== "text") return false;
+  return (blocks[0].text ?? "").trim().startsWith(INTERRUPT_ECHO_PREFIX);
+}
+
+interface TaskNotificationInfo {
+  task_id: string;
+  tool_use_id: string;
+  status: string;
+  summary: string;
+}
+
+function extractTaskNotification(blocks: ContentBlock[]): TaskNotificationInfo | null {
+  const text = blocksText(blocks);
+  const match = TASK_NOTIFICATION_RE.exec(text);
+  if (!match) return null;
+  const xml = match[0];
+  const tag = (name: string): string => {
+    const m = new RegExp(`<${name}>([\\s\\S]*?)</${name}>`).exec(xml);
+    return m ? m[1].trim() : "";
+  };
+  return {
+    task_id: tag("task-id"),
+    tool_use_id: tag("tool-use-id"),
+    status: tag("status"),
+    summary: tag("summary"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 归组辅助
+// ---------------------------------------------------------------------------
+
+function attachToolResult(turnContent: ContentBlock[], entry: TimelineEntry): void {
+  const toolUseId = entry.tool_use_id;
+  const resultText = typeof entry.content === "string" ? entry.content : blocksText(entryBlocks(entry));
+  if (toolUseId) {
+    for (const block of turnContent) {
+      if (block.type === "tool_use" && block.id === toolUseId) {
+        block.result = resultText;
+        block.is_error = Boolean(entry.is_error);
+        return;
+      }
+    }
+  }
+  turnContent.push({
+    type: "tool_result",
+    tool_use_id: toolUseId ?? undefined,
+    content: resultText,
+    is_error: Boolean(entry.is_error),
+  });
+}
+
+function attachSkillText(turnContent: ContentBlock[], text: string): void {
+  for (let i = turnContent.length - 1; i >= 0; i--) {
+    const block = turnContent[i];
+    if (block.type === "tool_use" && block.name === "Skill") {
+      block.skill_content = text;
+      return;
+    }
+  }
+  turnContent.push({ type: "skill_content", text });
+}
+
+function findTaskBlock(turn: Turn | null, taskId: string): ContentBlock | null {
+  if (!turn) return null;
+  for (const block of turn.content) {
+    if (block.type === "task_progress" && block.task_id === taskId) return block;
+  }
+  return null;
+}
+
+function lastTurnIsInterruptNotice(turn: Turn | null): boolean {
+  if (!turn || turn.type !== "system") return false;
+  const blocks = turn.content;
+  return blocks.length > 0 && blocks[blocks.length - 1].type === "interrupt_notice";
+}
+
+/** task_started 块对应的 Agent tool_use 已有 result 时推导为已完成。 */
+function resolveStaleTaskBlocks(turns: Turn[]): void {
+  for (const turn of turns) {
+    const completedToolIds = new Set<string>();
+    for (const block of turn.content) {
+      if (block.type === "tool_use" && block.name === "Agent" && block.result !== undefined && block.id) {
+        completedToolIds.add(block.id);
+      }
+    }
+    if (completedToolIds.size === 0) continue;
+    for (const block of turn.content) {
+      if (
+        block.type === "task_progress" &&
+        block.status === "task_started" &&
+        block.tool_use_id &&
+        completedToolIds.has(block.tool_use_id)
+      ) {
+        block.status = "task_notification";
+        block.task_status = "completed";
+      }
+    }
+  }
+}
+
+function cloneBlock(block: ContentBlock): ContentBlock {
+  return JSON.parse(JSON.stringify(block)) as ContentBlock;
+}
+
+// ---------------------------------------------------------------------------
+// projectEntriesToTurns — 主投影
+// ---------------------------------------------------------------------------
+
+export function projectEntriesToTurns(entries: TimelineEntry[]): Turn[] {
+  const turns: Turn[] = [];
+  // 用持有器承载当前 turn：闭包内赋值会让 TS 把裸 let 收窄成 never
+  const cursor: { current: Turn | null } = { current: null };
+
+  const flush = (): void => {
+    if (cursor.current) {
+      turns.push(cursor.current);
+      cursor.current = null;
+    }
+  };
+
+  const startTurn = (turn: Turn): void => {
+    flush();
+    cursor.current = turn;
+  };
+
+  /** 追加系统注入块：优先并入当前 assistant turn，否则开 system turn。 */
+  const attachSystemBlock = (entry: TimelineEntry, block: ContentBlock): void => {
+    if (cursor.current && cursor.current.type === "assistant") {
+      cursor.current.content.push(block);
+      return;
+    }
+    startTurn({ type: "system", content: [block], uuid: entry.uuid, timestamp: entry.timestamp });
+  };
+
+  const applyTaskBlock = (entry: TimelineEntry, taskBlock: ContentBlock, updateOnly: boolean): void => {
+    const taskId = taskBlock.task_id;
+    if (taskId && updateOnly) {
+      const existing = findTaskBlock(cursor.current, taskId);
+      if (existing) {
+        existing.status = taskBlock.status;
+        if (taskBlock.summary) existing.summary = taskBlock.summary;
+        if (taskBlock.task_status) existing.task_status = taskBlock.task_status;
+        if (taskBlock.usage) existing.usage = taskBlock.usage;
+        return;
+      }
+    }
+    attachSystemBlock(entry, taskBlock);
+  };
+
+  for (const entry of entries) {
+    if (entry.type === "assistant") {
+      const blocks = entryBlocks(entry).map(cloneBlock);
+      if (cursor.current && cursor.current.type === "assistant") {
+        cursor.current.content.push(...blocks);
+      } else {
+        startTurn({ type: "assistant", content: blocks, uuid: entry.uuid, timestamp: entry.timestamp });
+      }
+      continue;
+    }
+
+    if (entry.type === "tool_result") {
+      if (cursor.current && cursor.current.type === "assistant") {
+        attachToolResult(cursor.current.content, entry);
+      } else {
+        attachSystemBlock(entry, {
+          type: "tool_result",
+          tool_use_id: entry.tool_use_id ?? undefined,
+          content: typeof entry.content === "string" ? entry.content : blocksText(entryBlocks(entry)),
+          is_error: Boolean(entry.is_error),
+        });
+      }
+      continue;
+    }
+
+    if (entry.type === "system") {
+      if (entry.subtype !== "task_started" && entry.subtype !== "task_progress" && entry.subtype !== "task_notification") {
+        continue;
+      }
+      applyTaskBlock(
+        entry,
+        {
+          type: "task_progress",
+          task_id: entry.task_id ?? undefined,
+          status: entry.subtype,
+          description: entry.description ?? "",
+          summary: entry.summary ?? undefined,
+          task_status: entry.task_status ?? undefined,
+          usage: entry.usage ?? undefined,
+          tool_use_id: entry.tool_use_id ?? undefined,
+        },
+        entry.subtype !== "task_started",
+      );
+      continue;
+    }
+
+    // entry.type === "user"
+    const blocks = entryBlocks(entry).map(cloneBlock);
+
+    if (isInterruptEcho(blocks)) {
+      if (lastTurnIsInterruptNotice(cursor.current)) continue;
+      startTurn({
+        type: "system",
+        content: [{ type: "interrupt_notice" }],
+        uuid: entry.uuid,
+        timestamp: entry.timestamp,
+      });
+      continue;
+    }
+
+    const taskInfo = extractTaskNotification(blocks);
+    if (taskInfo) {
+      applyTaskBlock(
+        entry,
+        {
+          type: "task_progress",
+          task_id: taskInfo.task_id || undefined,
+          status: "task_notification",
+          description: "",
+          summary: taskInfo.summary || undefined,
+          task_status: taskInfo.status || undefined,
+          tool_use_id: taskInfo.tool_use_id || undefined,
+        },
+        Boolean(taskInfo.task_id),
+      );
+      continue;
+    }
+
+    if (entry.parent_tool_use_id) {
+      // subagent 内部注入：抑制纯文本（内部 prompt/遥测），其余块并入。
+      const filtered = blocks.filter((b) => b.type !== "text" || isSkillContentText((b.text ?? "").trim()));
+      if (filtered.length === 0) continue;
+      for (const block of filtered) {
+        if (block.type === "text") {
+          if (cursor.current && cursor.current.type === "assistant") {
+            attachSkillText(cursor.current.content, (block.text ?? "").trim());
+          } else {
+            attachSystemBlock(entry, { type: "skill_content", text: (block.text ?? "").trim() });
+          }
+        } else {
+          attachSystemBlock(entry, block);
+        }
+      }
+      continue;
+    }
+
+    const nonEmpty = blocks.filter((b) => b.type !== "text" || (b.text ?? "").trim() !== "");
+    const allSkillText = nonEmpty.length > 0 && nonEmpty.every(
+      (b) => b.type === "text" && isSkillContentText((b.text ?? "").trim()),
+    );
+    if (allSkillText) {
+      for (const block of nonEmpty) {
+        const text = (block.text ?? "").trim();
+        if (cursor.current && cursor.current.type === "assistant") {
+          attachSkillText(cursor.current.content, text);
+        } else {
+          attachSystemBlock(entry, { type: "skill_content", text });
+        }
+      }
+      continue;
+    }
+
+    startTurn({ type: "user", content: blocks, uuid: entry.uuid, timestamp: entry.timestamp });
+  }
+
+  flush();
+  resolveStaleTaskBlocks(turns);
+  return turns;
+}
+
+// ---------------------------------------------------------------------------
+// draft 投影与增量应用
+// ---------------------------------------------------------------------------
+
+/**
+ * draft → Turn。完成替换按身份比对：日志中已有同 message_id 的 assistant
+ * 条目时 draft 视为已被权威条目替换，返回 null。不做内容比对。
+ */
+export function projectDraftToTurn(
+  draft: DraftState | null,
+  entries: TimelineEntry[],
+): Turn | null {
+  if (!draft || !draft.message_id) return null;
+  const replaced = entries.some(
+    (e) => e.type === "assistant" && e.message_id != null && e.message_id === draft.message_id,
+  );
+  if (replaced) return null;
+  const content = draft.content.filter(Boolean);
+  if (content.length === 0) return null;
+  return {
+    type: "assistant",
+    content,
+    uuid: `draft-${draft.message_id}`,
+  };
+}
+
+/** 客户端 draft 镜像：content 以 block_index 为数组下标，toolJson 累积未闭合 JSON。 */
+export interface DraftMirror extends DraftState {
+  toolJson: Record<number, string>;
+}
+
+/**
+ * 应用一条 delta（纯函数，返回新对象）。调用方须先按 rev 门槛过滤；
+ * message_id 变化时另起新 draft（身份切换即上一条已由权威条目收尾）。
+ */
+export function applyDraftDelta(
+  draft: DraftMirror | null,
+  payload: DraftDeltaPayload,
+): DraftMirror {
+  const base: DraftMirror =
+    draft && draft.message_id === payload.message_id
+      ? { ...draft, content: [...draft.content], toolJson: { ...draft.toolJson } }
+      : {
+          message_id: payload.message_id,
+          parent_tool_use_id: payload.parent_tool_use_id ?? null,
+          content: [],
+          toolJson: {},
+        };
+  const index = payload.block_index;
+
+  if (payload.delta_type === "block_start") {
+    base.content[index] = payload.block ? cloneBlock(payload.block) : { type: "text", text: "" };
+    return base;
+  }
+
+  if (payload.delta_type === "text_delta") {
+    const block = base.content[index]?.type === "text" ? { ...base.content[index] } : { type: "text" as const, text: "" };
+    block.text = `${block.text ?? ""}${payload.text ?? ""}`;
+    base.content[index] = block;
+    return base;
+  }
+
+  if (payload.delta_type === "thinking_delta") {
+    const block =
+      base.content[index]?.type === "thinking" ? { ...base.content[index] } : { type: "thinking" as const, thinking: "" };
+    block.thinking = `${block.thinking ?? ""}${payload.thinking ?? ""}`;
+    base.content[index] = block;
+    return base;
+  }
+
+  if (payload.delta_type === "input_json_delta") {
+    const block =
+      base.content[index]?.type === "tool_use"
+        ? { ...base.content[index] }
+        : { type: "tool_use" as const, id: undefined, name: "", input: {} };
+    const updated = `${base.toolJson[index] ?? ""}${payload.partial_json ?? ""}`;
+    base.toolJson[index] = updated;
+    try {
+      const parsed: unknown = JSON.parse(updated);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        block.input = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // 未闭合 JSON：继续累积
+    }
+    base.content[index] = block;
+    return base;
+  }
+
+  return base;
+}

--- a/lib/db/models/__init__.py
+++ b/lib/db/models/__init__.py
@@ -8,6 +8,7 @@ from lib.db.models.config import ProviderConfig, SystemSetting
 from lib.db.models.credential import ProviderCredential
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 from lib.db.models.session import AgentSession
+from lib.db.models.session_event import AgentSessionEventLogEntry
 from lib.db.models.task import Task, TaskEvent, WorkerLease
 from lib.db.models.user import User
 
@@ -17,6 +18,7 @@ __all__ = [
     "WorkerLease",
     "ApiCall",
     "AgentSession",
+    "AgentSessionEventLogEntry",
     "ApiKey",
     "ProviderConfig",
     "SystemSetting",

--- a/lib/db/models/session_event.py
+++ b/lib/db/models/session_event.py
@@ -1,0 +1,37 @@
+"""会话事件日志 ORM 模型 — UI 时间线唯一读源。"""
+
+from __future__ import annotations
+
+from sqlalchemy import JSON, BigInteger, Index, PrimaryKeyConstraint, String, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from lib.db.base import Base, TimestampMixin, UserOwnedMixin
+
+
+class AgentSessionEventLogEntry(TimestampMixin, UserOwnedMixin, Base):
+    """会话事件日志条目 — 每会话单调递增 seq、append-only。
+
+    与 SDK transcript 镜像表（agent_session_entries）并存是有意双写：
+    本表是 UI 读模型，条目在写入点定型；transcript 是 agent 记忆。
+    """
+
+    __tablename__ = "agent_session_event_log"
+
+    session_id: Mapped[str] = mapped_column(String, nullable=False)
+    seq: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    entry_type: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False)
+    # 用户消息受理的请求侧幂等键；同键重试返回既有条目，不产生重复。
+    client_key: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    __table_args__ = (
+        PrimaryKeyConstraint("session_id", "seq"),
+        Index(
+            "uq_agent_event_log_client_key",
+            "session_id",
+            "client_key",
+            unique=True,
+            postgresql_where=text("client_key IS NOT NULL"),
+            sqlite_where=text("client_key IS NOT NULL"),
+        ),
+    )

--- a/server/agent_runtime/entry_pipeline.py
+++ b/server/agent_runtime/entry_pipeline.py
@@ -9,7 +9,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import copy
+import json
 import logging
 from collections.abc import Callable
 from typing import Any
@@ -19,10 +21,34 @@ from server.agent_runtime.event_log import (
     EventLogStore,
     normalize_sdk_message_to_entries,
 )
-from server.agent_runtime.stream_projector import _coerce_index, _safe_json_parse
 from server.agent_runtime.turn_schema import normalize_block
 
 logger = logging.getLogger(__name__)
+
+# 落库瞬时失败（SQLite busy / 连接抖动）的有界重试；重试耗尽才放弃该条目。
+_APPEND_ATTEMPTS = 3
+_APPEND_RETRY_BASE_S = 0.05
+
+
+def _coerce_index(value: Any) -> int | None:
+    """Normalize stream event block index."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.isdigit():
+            return int(stripped)
+    return None
+
+
+def _safe_json_parse(value: str) -> Any | None:
+    """Parse JSON string and return None when incomplete/invalid."""
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return None
 
 
 class DraftAccumulator:
@@ -56,12 +82,18 @@ class DraftAccumulator:
             message_id = raw_message.get("id") if isinstance(raw_message, dict) else None
             self._reset_blocks()
             self._message_id = str(message_id) if message_id else None
-            self._parent_tool_use_id = message.get("parent_tool_use_id")
+            self._parent_tool_use_id = message.get("parent_tool_use_id") or None
             return None
 
         if self._message_id is None:
             # 无身份的孤儿事件（message_start 缺失）：draft 契约以 message_id
             # 为身份，无法归属的增量不进入预览态。
+            return None
+
+        if (message.get("parent_tool_use_id") or None) != self._parent_tool_use_id:
+            # 并行流式（多 subagent）交错：预览态是单槽结构，取最近一次
+            # message_start 的消息；其它流的增量按 parent 归属过滤丢弃，
+            # 避免拼进错误消息的草稿。被丢弃流的完整内容随权威条目落库。
             return None
 
         if event_type == "content_block_start":
@@ -133,7 +165,11 @@ class DraftAccumulator:
         self._parent_tool_use_id = None
 
     def snapshot(self) -> dict[str, Any] | None:
-        """重连首帧快照：当前累积态（无活跃 draft 时为 None）。"""
+        """重连首帧快照：当前累积态（无活跃 draft 时为 None）。
+
+        ``tool_json`` 携带各 tool_use 块已累积的原始 partial JSON——重连客户端
+        以此为前缀继续拼接后续 input_json_delta，否则纯后缀永远解析失败。
+        """
         if self._message_id is None or not self._blocks:
             return None
         ordered = [copy.deepcopy(self._blocks[index]) for index in sorted(self._blocks)]
@@ -142,6 +178,7 @@ class DraftAccumulator:
             "parent_tool_use_id": self._parent_tool_use_id,
             "content": ordered,
             "rev": self._rev,
+            "tool_json": dict(self._tool_input_json),
         }
 
     def _reset_blocks(self) -> None:
@@ -224,14 +261,28 @@ class SessionEntryPipeline:
         if msg_type == "result":
             # 轮次终结：未被权威条目替换的 draft（中断/错误）随内存丢弃。
             self.draft.clear()
+            # 本轮全部条目已（按 inbox 串行序）落库并广播完毕的标记：entry 流
+            # 以此产出终态，避免原始 result 广播抢在末条 log_entry 之前送达。
+            self._broadcast({"type": "log_turn_complete", "session_id": session_id})
             return
 
         entries = normalize_sdk_message_to_entries(msg_dict)
         if not entries:
             return
-        appended = await self._store.append(session_id, entries)
+        appended = await self._append_with_retry(session_id, entries)
         for entry in appended:
             self._broadcast({"type": "log_entry", "session_id": session_id, "entry": entry})
         for entry in appended:
             if entry.get("type") == ENTRY_TYPE_ASSISTANT and self.draft.clear_for_message(entry.get("message_id")):
                 break
+
+    async def _append_with_retry(self, session_id: str, entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """有界重试落库：瞬时 DB 错误不至于在 append-only 日志上留下永久空洞。"""
+        for attempt in range(_APPEND_ATTEMPTS):
+            try:
+                return await self._store.append(session_id, entries)
+            except Exception:
+                if attempt == _APPEND_ATTEMPTS - 1:
+                    raise
+                await asyncio.sleep(_APPEND_RETRY_BASE_S * (attempt + 1))
+        raise RuntimeError("unreachable")  # pragma: no cover

--- a/server/agent_runtime/entry_pipeline.py
+++ b/server/agent_runtime/entry_pipeline.py
@@ -1,0 +1,237 @@
+"""Live 写入点管道：SDK 消息流 → 事件日志条目 + 流式预览态（draft）。
+
+- 条目：normalize 后落库分配 seq，再以 ``log_entry`` 广播（SSE 事件 id 即 seq）。
+- draft：服务端内存态，身份为消息 ``message_id``；delta 为瞬时广播事件
+  （引用 message_id + block index），不入日志；消息完成时被同 message_id
+  的权威条目精确清除。``rev`` 单调递增，重连首帧快照携带当前 rev，客户端
+  以此过滤订阅间隙内重复投递的 delta——身份比对，不做内容比对。
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from server.agent_runtime.event_log import (
+    ENTRY_TYPE_ASSISTANT,
+    EventLogStore,
+    normalize_sdk_message_to_entries,
+)
+from server.agent_runtime.stream_projector import _coerce_index, _safe_json_parse
+from server.agent_runtime.turn_schema import normalize_block
+
+logger = logging.getLogger(__name__)
+
+
+class DraftAccumulator:
+    """流式预览态：按 message_id 累积 content block，服务端内存态、不落盘。"""
+
+    def __init__(self) -> None:
+        self._message_id: str | None = None
+        self._parent_tool_use_id: str | None = None
+        self._blocks: dict[int, dict[str, Any]] = {}
+        self._tool_input_json: dict[int, str] = {}
+        # 跨消息单调递增：快照携带的 rev 是重连客户端的 delta 过滤门槛。
+        self._rev = 0
+
+    @property
+    def message_id(self) -> str | None:
+        return self._message_id
+
+    @property
+    def rev(self) -> int:
+        return self._rev
+
+    def apply_stream_event(self, message: dict[str, Any]) -> dict[str, Any] | None:
+        """处理一条 stream_event 消息，返回要广播的瞬时 delta 载荷（或 None）。"""
+        event = message.get("event")
+        if not isinstance(event, dict):
+            return None
+        event_type = event.get("type")
+
+        if event_type == "message_start":
+            raw_message = event.get("message")
+            message_id = raw_message.get("id") if isinstance(raw_message, dict) else None
+            self._reset_blocks()
+            self._message_id = str(message_id) if message_id else None
+            self._parent_tool_use_id = message.get("parent_tool_use_id")
+            return None
+
+        if self._message_id is None:
+            # 无身份的孤儿事件（message_start 缺失）：draft 契约以 message_id
+            # 为身份，无法归属的增量不进入预览态。
+            return None
+
+        if event_type == "content_block_start":
+            index = self._resolve_index(event)
+            content_block = event.get("content_block")
+            if not isinstance(content_block, dict):
+                content_block = {"type": "text", "text": ""}
+            block = normalize_block(content_block)
+            self._blocks[index] = block
+            return self._delta_payload("block_start", index, {"block": copy.deepcopy(block)})
+
+        if event_type == "content_block_delta":
+            delta = event.get("delta")
+            if not isinstance(delta, dict):
+                return None
+            delta_type = delta.get("type")
+
+            if delta_type == "text_delta":
+                chunk = delta.get("text")
+                if not isinstance(chunk, str) or chunk == "":
+                    return None
+                index = self._resolve_index(event)
+                block = self._ensure_block(index, "text")
+                block["type"] = "text"
+                block["text"] = f"{block.get('text', '')}{chunk}"
+                return self._delta_payload("text_delta", index, {"text": chunk})
+
+            if delta_type == "thinking_delta":
+                chunk = delta.get("thinking")
+                if not isinstance(chunk, str) or chunk == "":
+                    return None
+                index = self._resolve_index(event)
+                block = self._ensure_block(index, "thinking")
+                block["type"] = "thinking"
+                block["thinking"] = f"{block.get('thinking', '')}{chunk}"
+                return self._delta_payload("thinking_delta", index, {"thinking": chunk})
+
+            if delta_type == "input_json_delta":
+                chunk = delta.get("partial_json")
+                if not isinstance(chunk, str) or chunk == "":
+                    return None
+                index = self._resolve_index(event)
+                block = self._ensure_block(index, "tool_use")
+                block["type"] = "tool_use"
+                if not isinstance(block.get("input"), dict):
+                    block["input"] = {}
+                updated_json = f"{self._tool_input_json.get(index, '')}{chunk}"
+                self._tool_input_json[index] = updated_json
+                parsed = _safe_json_parse(updated_json)
+                if isinstance(parsed, dict):
+                    block["input"] = parsed
+                return self._delta_payload("input_json_delta", index, {"partial_json": chunk})
+
+        return None
+
+    def clear_for_message(self, message_id: Any) -> bool:
+        """权威条目落库后按同 message_id 精确清除对应 draft。"""
+        if not message_id or message_id != self._message_id:
+            return False
+        self._reset_blocks()
+        self._message_id = None
+        self._parent_tool_use_id = None
+        return True
+
+    def clear(self) -> None:
+        """轮次终结（result / 中断）：预览态随内存丢弃。"""
+        self._reset_blocks()
+        self._message_id = None
+        self._parent_tool_use_id = None
+
+    def snapshot(self) -> dict[str, Any] | None:
+        """重连首帧快照：当前累积态（无活跃 draft 时为 None）。"""
+        if self._message_id is None or not self._blocks:
+            return None
+        ordered = [copy.deepcopy(self._blocks[index]) for index in sorted(self._blocks)]
+        return {
+            "message_id": self._message_id,
+            "parent_tool_use_id": self._parent_tool_use_id,
+            "content": ordered,
+            "rev": self._rev,
+        }
+
+    def _reset_blocks(self) -> None:
+        self._blocks.clear()
+        self._tool_input_json.clear()
+
+    def _resolve_index(self, event: dict[str, Any]) -> int:
+        index = _coerce_index(event.get("index"))
+        if index is not None:
+            return index
+        if not self._blocks:
+            return 0
+        return max(self._blocks.keys())
+
+    def _ensure_block(self, index: int, block_type: str) -> dict[str, Any]:
+        block = self._blocks.get(index)
+        if isinstance(block, dict):
+            return block
+        if block_type == "tool_use":
+            block = {"type": "tool_use", "id": None, "name": "", "input": {}}
+        elif block_type == "thinking":
+            block = {"type": "thinking", "thinking": ""}
+        else:
+            block = {"type": "text", "text": ""}
+        self._blocks[index] = block
+        return block
+
+    def _delta_payload(self, delta_type: str, index: int, extra: dict[str, Any]) -> dict[str, Any]:
+        self._rev += 1
+        return {
+            "message_id": self._message_id,
+            "parent_tool_use_id": self._parent_tool_use_id,
+            "delta_type": delta_type,
+            "block_index": index,
+            "rev": self._rev,
+            **extra,
+        }
+
+
+class SessionEntryPipeline:
+    """每会话一个：消费 inbox 消息，产出日志条目写入与 log_entry / log_delta 广播。"""
+
+    def __init__(
+        self,
+        store: EventLogStore,
+        *,
+        session_id_provider: Callable[[], str | None],
+        broadcast: Callable[[dict[str, Any]], None],
+    ) -> None:
+        self._store = store
+        self._session_id_provider = session_id_provider
+        self._broadcast = broadcast
+        self.draft = DraftAccumulator()
+
+    async def handle_message(self, msg_dict: dict[str, Any]) -> None:
+        """写入点入口。失败只记日志不打断会话——时间线的修复手段是重放重建。"""
+        try:
+            await self._handle(msg_dict)
+        except Exception:
+            logger.exception(
+                "事件日志写入点处理失败 session_id=%s msg_type=%s",
+                self._session_id_provider(),
+                msg_dict.get("type") if isinstance(msg_dict, dict) else type(msg_dict),
+            )
+
+    async def _handle(self, msg_dict: dict[str, Any]) -> None:
+        if not isinstance(msg_dict, dict):
+            return
+        session_id = self._session_id_provider()
+        if not session_id:
+            return
+        msg_type = msg_dict.get("type")
+
+        if msg_type == "stream_event":
+            delta = self.draft.apply_stream_event(msg_dict)
+            if delta is not None:
+                self._broadcast({"type": "log_delta", "session_id": session_id, **delta})
+            return
+
+        if msg_type == "result":
+            # 轮次终结：未被权威条目替换的 draft（中断/错误）随内存丢弃。
+            self.draft.clear()
+            return
+
+        entries = normalize_sdk_message_to_entries(msg_dict)
+        if not entries:
+            return
+        appended = await self._store.append(session_id, entries)
+        for entry in appended:
+            self._broadcast({"type": "log_entry", "session_id": session_id, "entry": entry})
+        for entry in appended:
+            if entry.get("type") == ENTRY_TYPE_ASSISTANT and self.draft.clear_for_message(entry.get("message_id")):
+                break

--- a/server/agent_runtime/event_log.py
+++ b/server/agent_runtime/event_log.py
@@ -1,0 +1,323 @@
+"""会话事件日志 — UI 时间线唯一读源。
+
+条目在写入点定型：SDK 消息流在入日志一处完成规范化（tool_result 定型为独立
+条目、subagent 消息带 parent_tool_use_id 标记、stream_event 不进日志），
+渲染端与读取端不做语义嗅探、不做去重。日志是 SDK transcript 的物化视图：
+仅有 transcript 的旧会话首次访问时重放重建（懒生成）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from pathlib import Path
+from typing import Any, Protocol
+from uuid import uuid4
+
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import exists, func, select
+from sqlalchemy.exc import IntegrityError
+
+from lib.db import safe_session_factory
+from lib.db.base import DEFAULT_USER_ID, utc_now
+from lib.db.models.session_event import AgentSessionEventLogEntry
+from server.agent_runtime.message_serialization import utc_now_iso
+from server.agent_runtime.turn_schema import normalize_content
+
+logger = logging.getLogger(__name__)
+
+ENTRY_TYPE_USER = "user"
+ENTRY_TYPE_ASSISTANT = "assistant"
+ENTRY_TYPE_TOOL_RESULT = "tool_result"
+ENTRY_TYPE_SYSTEM = "system"
+
+_TASK_SUBTYPES = {"task_started", "task_progress", "task_notification"}
+
+# 与 DbSessionStore.append 相同的 seq 竞争重试参数。
+_MAX_APPEND_RETRY = 16
+_APPEND_BACKOFF_CAP_S = 0.05
+
+# 标记 SDK 回放的用户消息副本（POST 受理时已写日志），供写入点跳过。
+# 只存活在进程内消息 dict 上，不落任何持久化层。
+REPLAYED_USER_ECHO_KEY = "_replayed_user_echo"
+
+
+def _copy_parent(message: dict[str, Any], entry: dict[str, Any]) -> None:
+    parent = message.get("parent_tool_use_id")
+    if isinstance(parent, str) and parent.strip():
+        entry["parent_tool_use_id"] = parent
+
+
+def build_user_entry(
+    content_blocks: list[dict[str, Any]],
+    *,
+    timestamp: str | None = None,
+) -> dict[str, Any]:
+    """构造用户消息受理时的权威条目（POST 先写日志分配身份再回显）。"""
+    return {
+        "type": ENTRY_TYPE_USER,
+        "content": normalize_content(content_blocks),
+        "uuid": f"user-{uuid4().hex}",
+        "timestamp": timestamp or utc_now_iso(),
+    }
+
+
+def normalize_sdk_message_to_entries(message: Any) -> list[dict[str, Any]]:
+    """写入点定型：把一条 SDK 消息 dict 规范化为零或多个日志条目。
+
+    - assistant → 单条 assistant 条目（携带 message_id，供 draft 精确替换）
+    - user → tool_result 块定型为独立条目（引用 tool_use_id）；其余内容
+      （含过渡期的 interrupt 回显、task 通知 XML、skill 注入、subagent 消息）
+      以通用 user 条目收录；local_echo 与 SDK 回放副本不入日志
+    - system(task_*) → 通用 system 条目（专属定型由后续片承接）
+    - stream_event / result / 其它 → 不进日志
+    """
+    if not isinstance(message, dict):
+        return []
+    msg_type = message.get("type")
+
+    if msg_type == "assistant":
+        entry: dict[str, Any] = {
+            "type": ENTRY_TYPE_ASSISTANT,
+            "content": normalize_content(message.get("content", [])),
+            "message_id": message.get("message_id"),
+            "uuid": message.get("uuid") or f"entry-{uuid4().hex}",
+            "timestamp": message.get("timestamp") or utc_now_iso(),
+        }
+        _copy_parent(message, entry)
+        return [entry]
+
+    if msg_type == "user":
+        if message.get("local_echo") or message.get(REPLAYED_USER_ECHO_KEY):
+            return []
+        blocks = normalize_content(message.get("content", ""))
+        tool_results = [b for b in blocks if b.get("type") == "tool_result"]
+        others = [b for b in blocks if b.get("type") != "tool_result"]
+        timestamp = message.get("timestamp") or utc_now_iso()
+        base_uuid = message.get("uuid")
+        entries: list[dict[str, Any]] = []
+        for i, block in enumerate(tool_results):
+            tr_entry: dict[str, Any] = {
+                "type": ENTRY_TYPE_TOOL_RESULT,
+                "tool_use_id": block.get("tool_use_id"),
+                "content": block.get("content", ""),
+                "is_error": bool(block.get("is_error", False)),
+                "uuid": f"{base_uuid}-tr{i}" if base_uuid else f"entry-{uuid4().hex}",
+                "timestamp": timestamp,
+            }
+            _copy_parent(message, tr_entry)
+            entries.append(tr_entry)
+        if others:
+            user_entry: dict[str, Any] = {
+                "type": ENTRY_TYPE_USER,
+                "content": others,
+                "uuid": base_uuid or f"entry-{uuid4().hex}",
+                "timestamp": timestamp,
+            }
+            _copy_parent(message, user_entry)
+            entries.append(user_entry)
+        return entries
+
+    if msg_type == "system" and message.get("subtype") in _TASK_SUBTYPES:
+        sys_entry: dict[str, Any] = {
+            "type": ENTRY_TYPE_SYSTEM,
+            "subtype": message.get("subtype"),
+            "task_id": message.get("task_id"),
+            "description": message.get("description", ""),
+            "summary": message.get("summary"),
+            "task_status": message.get("status"),
+            "usage": message.get("usage"),
+            "tool_use_id": message.get("tool_use_id"),
+            "uuid": message.get("uuid") or f"entry-{uuid4().hex}",
+            "timestamp": message.get("timestamp") or utc_now_iso(),
+        }
+        _copy_parent(message, sys_entry)
+        return [sys_entry]
+
+    return []
+
+
+class EventLogStore:
+    """事件日志 DB 访问：seq 单调分配（append-only）+ 幂等键查重。"""
+
+    def __init__(self, *, session_factory=None, user_id: str = DEFAULT_USER_ID):
+        self._session_factory = session_factory or safe_session_factory
+        self._user_id = user_id
+
+    async def append(
+        self,
+        session_id: str,
+        entries: list[dict[str, Any]],
+        *,
+        client_key: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """追加条目并返回带 seq 的权威条目列表。
+
+        seq 分配采用 max+1 + 主键冲突重试（与 DbSessionStore.append 同模式）；
+        ``client_key`` 只对单条 user 条目有意义，唯一索引兜底并发重试。
+        """
+        if not entries:
+            return []
+        for attempt in range(_MAX_APPEND_RETRY):
+            try:
+                return await self._append_once(session_id, entries, client_key)
+            except IntegrityError as exc:
+                msg = str(exc.orig) if exc.orig else str(exc)
+                unique_violation = "UNIQUE" in msg or "duplicate key" in msg
+                if unique_violation and "client_key" in msg and client_key is not None:
+                    # 幂等键并发冲突：另一请求已写入同键条目，返回其权威条目。
+                    existing = await self.find_by_client_key(session_id, client_key)
+                    if existing is not None:
+                        return [existing]
+                    raise
+                is_seq_race = unique_violation and "seq" in msg
+                if not is_seq_race or attempt == _MAX_APPEND_RETRY - 1:
+                    raise
+                delay = random.uniform(0, min(_APPEND_BACKOFF_CAP_S, 0.001 * (2**attempt)))
+                await asyncio.sleep(delay)
+        raise RuntimeError("unreachable")  # pragma: no cover
+
+    async def _append_once(
+        self,
+        session_id: str,
+        entries: list[dict[str, Any]],
+        client_key: str | None,
+    ) -> list[dict[str, Any]]:
+        now_dt = utc_now()
+        async with self._session_factory() as session:
+            seq_start_row = await session.execute(
+                select(func.coalesce(func.max(AgentSessionEventLogEntry.seq), -1) + 1).where(
+                    AgentSessionEventLogEntry.session_id == session_id,
+                )
+            )
+            seq_start = int(seq_start_row.scalar_one())
+            enriched: list[dict[str, Any]] = []
+            for i, entry in enumerate(entries):
+                seq = seq_start + i
+                session.add(
+                    AgentSessionEventLogEntry(
+                        session_id=session_id,
+                        seq=seq,
+                        entry_type=str(entry.get("type") or ""),
+                        payload=entry,
+                        client_key=client_key if len(entries) == 1 else None,
+                        user_id=self._user_id,
+                        created_at=now_dt,
+                        updated_at=now_dt,
+                    )
+                )
+                enriched.append({"seq": seq, **entry})
+            await session.commit()
+        return enriched
+
+    async def append_user_entry(
+        self,
+        session_id: str,
+        entry: dict[str, Any],
+        *,
+        client_key: str | None = None,
+    ) -> tuple[dict[str, Any], bool]:
+        """幂等追加用户条目：同一幂等键重试返回既有条目，不产生重复。
+
+        Returns:
+            (权威条目, 是否新写入)
+        """
+        if client_key:
+            existing = await self.find_by_client_key(session_id, client_key)
+            if existing is not None:
+                return existing, False
+        appended = await self.append(session_id, [entry], client_key=client_key)
+        authoritative = appended[0]
+        # append 在幂等键冲突时返回既有条目；用 uuid 区分是否为本次写入。
+        created = authoritative.get("uuid") == entry.get("uuid")
+        return authoritative, created
+
+    async def find_by_client_key(self, session_id: str, client_key: str) -> dict[str, Any] | None:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(AgentSessionEventLogEntry.seq, AgentSessionEventLogEntry.payload).where(
+                    AgentSessionEventLogEntry.session_id == session_id,
+                    AgentSessionEventLogEntry.client_key == client_key,
+                )
+            )
+            row = result.first()
+        if row is None:
+            return None
+        return {"seq": int(row.seq), **row.payload}
+
+    async def list_after(self, session_id: str, after_seq: int = -1) -> list[dict[str, Any]]:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(AgentSessionEventLogEntry.seq, AgentSessionEventLogEntry.payload)
+                .where(
+                    AgentSessionEventLogEntry.session_id == session_id,
+                    AgentSessionEventLogEntry.seq > after_seq,
+                )
+                .order_by(AgentSessionEventLogEntry.seq)
+            )
+            rows = result.all()
+        return [{"seq": int(row.seq), **row.payload} for row in rows]
+
+    async def delete_session(self, session_id: str) -> None:
+        async with self._session_factory() as session:
+            await session.execute(
+                sa_delete(AgentSessionEventLogEntry).where(AgentSessionEventLogEntry.session_id == session_id)
+            )
+            await session.commit()
+
+    async def has_entries(self, session_id: str) -> bool:
+        async with self._session_factory() as session:
+            result = await session.execute(select(exists().where(AgentSessionEventLogEntry.session_id == session_id)))
+            return bool(result.scalar())
+
+
+class TranscriptReader(Protocol):
+    """懒生成读取 transcript 的最小接口（SdkTranscriptAdapter 满足）。"""
+
+    async def read_raw_messages(
+        self,
+        sdk_session_id: str | None,
+        project_cwd: Path | str | None = None,
+    ) -> list[dict[str, Any]]: ...
+
+
+class EventLogService:
+    """事件日志读取入口：懒生成 + 游标列举。"""
+
+    def __init__(self, store: EventLogStore, transcript_adapter: TranscriptReader):
+        self._store = store
+        self._adapter = transcript_adapter
+        self._backfill_locks: dict[str, asyncio.Lock] = {}
+
+    @property
+    def store(self) -> EventLogStore:
+        return self._store
+
+    async def ensure_backfilled(self, session_id: str, project_cwd: Path | str | None) -> None:
+        """仅有 transcript 的旧会话首次访问时重放重建日志（主时间线）。
+
+        subagent subpath 的归组重建由后续片承接；此处只回放主时间线。
+        """
+        if await self._store.has_entries(session_id):
+            return
+        lock = self._backfill_locks.setdefault(session_id, asyncio.Lock())
+        async with lock:
+            if await self._store.has_entries(session_id):
+                return
+            raw_messages = await self._adapter.read_raw_messages(session_id, project_cwd)
+            entries = [entry for message in raw_messages for entry in normalize_sdk_message_to_entries(message)]
+            if entries:
+                await self._store.append(session_id, entries)
+        # 无并发等待者时清引用；等待者持有锁对象引用，二次检查保证正确性。
+        self._backfill_locks.pop(session_id, None)
+
+    async def list_entries(
+        self,
+        session_id: str,
+        project_cwd: Path | str | None,
+        *,
+        after_seq: int = -1,
+    ) -> list[dict[str, Any]]:
+        await self.ensure_backfilled(session_id, project_cwd)
+        return await self._store.list_after(session_id, after_seq)

--- a/server/agent_runtime/event_log.py
+++ b/server/agent_runtime/event_log.py
@@ -259,6 +259,18 @@ class EventLogStore:
             rows = result.all()
         return [{"seq": int(row.seq), **row.payload} for row in rows]
 
+    async def delete_entry(self, session_id: str, seq: int) -> None:
+        """补偿删除单条条目（仅限受理失败回滚：SDK 投递失败时撤销刚写入的
+        用户条目，否则同幂等键重试会短路而永不投递）。"""
+        async with self._session_factory() as session:
+            await session.execute(
+                sa_delete(AgentSessionEventLogEntry).where(
+                    AgentSessionEventLogEntry.session_id == session_id,
+                    AgentSessionEventLogEntry.seq == seq,
+                )
+            )
+            await session.commit()
+
     async def delete_session(self, session_id: str) -> None:
         async with self._session_factory() as session:
             await session.execute(
@@ -309,8 +321,10 @@ class EventLogService:
             entries = [entry for message in raw_messages for entry in normalize_sdk_message_to_entries(message)]
             if entries:
                 await self._store.append(session_id, entries)
-        # 无并发等待者时清引用；等待者持有锁对象引用，二次检查保证正确性。
-        self._backfill_locks.pop(session_id, None)
+                # 仅在写入成功后清锁引用：此后 has_entries 恒真，旧锁等待者与
+                # 新造锁的后来者都会在二次检查处短路。空 transcript 时保留锁，
+                # 否则后来者 setdefault 出新锁，与旧锁等待者并发重放、重复灌入。
+                self._backfill_locks.pop(session_id, None)
 
     async def list_entries(
         self,

--- a/server/agent_runtime/event_log.py
+++ b/server/agent_runtime/event_log.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+import weakref
 from pathlib import Path
 from typing import Any, Protocol
 from uuid import uuid4
@@ -300,7 +301,8 @@ class EventLogService:
     def __init__(self, store: EventLogStore, transcript_adapter: TranscriptReader):
         self._store = store
         self._adapter = transcript_adapter
-        self._backfill_locks: dict[str, asyncio.Lock] = {}
+        # 弱引用：无协程持有/等待时锁对象自动回收，避免空会话锁永久残留内存
+        self._backfill_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
 
     @property
     def store(self) -> EventLogStore:

--- a/server/agent_runtime/event_log.py
+++ b/server/agent_runtime/event_log.py
@@ -172,7 +172,10 @@ class EventLogStore:
                     if existing is not None:
                         return [existing]
                     raise
-                is_seq_race = unique_violation and "seq" in msg
+                # 表上只有两个唯一约束（(session_id, seq) 主键 + client_key 唯一索引）；
+                # 排除 client_key 冲突即可确定是 seq 竞争，不依赖驱动/配置相关的
+                # 错误信息措辞（不同驱动对主键冲突的 DETAIL 文案不一定含 "seq"）。
+                is_seq_race = unique_violation and "client_key" not in msg
                 if not is_seq_race or attempt == _MAX_APPEND_RETRY - 1:
                     raise
                 delay = random.uniform(0, min(_APPEND_BACKOFF_CAP_S, 0.001 * (2**attempt)))

--- a/server/agent_runtime/event_log.py
+++ b/server/agent_runtime/event_log.py
@@ -320,7 +320,14 @@ class EventLogService:
             if await self._store.has_entries(session_id):
                 return
             raw_messages = await self._adapter.read_raw_messages(session_id, project_cwd)
-            entries = [entry for message in raw_messages for entry in normalize_sdk_message_to_entries(message)]
+            entries: list[dict[str, Any]] = []
+            for message in raw_messages:
+                try:
+                    entries.extend(normalize_sdk_message_to_entries(message))
+                except Exception:
+                    # 容错：历史 transcript 跨版本演进，单条脏数据不应让整个旧
+                    # 会话的历史记录懒生成失败。
+                    logger.exception("历史消息规范化失败，跳过该条 session_id=%s", session_id)
             if entries:
                 await self._store.append(session_id, entries)
                 # 仅在写入成功后清锁引用：此后 has_entries 恒真，旧锁等待者与

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -36,6 +36,7 @@ from lib.app_data_dir import app_data_dir
 from lib.i18n import DEFAULT_LOCALE, get_locale
 from lib.profile_manifest import VALID_CONTENT_MODES
 from lib.project_manager import ProjectManager
+from server.agent_runtime.event_log import EventLogService, EventLogStore, build_user_entry
 from server.agent_runtime.message_utils import extract_plain_user_content
 from server.agent_runtime.models import Heartbeat, LiveMessage, ReplayBatch, SessionMeta, SessionStatus
 from server.agent_runtime.sdk_transcript_adapter import SdkTranscriptAdapter
@@ -57,17 +58,22 @@ class AssistantService:
 
         self.pm = ProjectManager(self.projects_root)
         self.meta_store = SessionMetaStore()
+        # 会话事件日志：UI 时间线唯一读源。store 与 SessionManager 共享同一实例，
+        # live 写入点（entry pipeline）与读取端（REST / SSE / 懒生成）落同一张表。
+        self.event_log_store = EventLogStore()
         self.session_manager = SessionManager(
             project_root=self.project_root,
             data_dir=self.data_dir,
             meta_store=self.meta_store,
             projects_root=self.projects_root,
+            event_log_store=self.event_log_store,
         )
         # Shared with SessionManager (lazy-cached there) so reads via the
         # adapter and writes via SDK options use the same per-user namespace.
         # None when ARCREEL_SDK_SESSION_STORE=off.
         self._session_store = self.session_manager._build_session_store()
         self.transcript_adapter = SdkTranscriptAdapter(store=self._session_store)
+        self.event_log = EventLogService(self.event_log_store, self.transcript_adapter)
         self._startup_lock = asyncio.Lock()
         self._startup_done = False
         self._snapshot_cache: OrderedDict[str, dict[str, Any]] = OrderedDict()
@@ -179,6 +185,11 @@ class AssistantService:
             except Exception:
                 logger.warning("sdk delete_session failed for %s", session_id, exc_info=True)
 
+        try:
+            await self.event_log_store.delete_session(session_id)
+        except Exception:
+            logger.warning("删除会话事件日志失败 session_id=%s", session_id, exc_info=True)
+
         self._snapshot_cache.pop(session_id, None)
         return await self.meta_store.delete(session_id)
 
@@ -238,6 +249,12 @@ class AssistantService:
             return text, sdk_prompt, echo_blocks
         return text, None, None
 
+    @staticmethod
+    def _build_user_log_entry(text: str, echo_blocks: list[dict[str, Any]] | None) -> dict[str, Any]:
+        """构造用户消息的受理条目（写入点定型；POST 先写日志分配身份再回显）。"""
+        blocks = echo_blocks if echo_blocks is not None else [{"type": "text", "text": text}]
+        return build_user_entry(blocks)
+
     async def send_or_create(
         self,
         project_name: str,
@@ -246,8 +263,14 @@ class AssistantService:
         session_id: str | None = None,
         images: list["ImageAttachment"] | None = None,
         locale: str = DEFAULT_LOCALE,
+        client_key: str | None = None,
     ) -> dict[str, Any]:
-        """Unified send: create new session or send to existing one."""
+        """Unified send: create new session or send to existing one.
+
+        响应携带权威日志条目（``entry``）：服务端先写日志分配身份，前端
+        直接以该条目回显，不渲染任何本地合成消息；``client_key`` 为请求侧
+        幂等键，重试不产生重复条目。
+        """
         self.pm.get_project_path(project_name)  # Validate project
 
         if session_id:
@@ -260,25 +283,37 @@ class AssistantService:
             self._snapshot_cache.pop(session_id, None)
             # Build prompt
             text, sdk_prompt, echo_blocks = self._prepare_prompt(content, images)
-            if sdk_prompt is not None:
-                await self.session_manager.send_message(
-                    session_id, sdk_prompt, echo_text=text, echo_content=echo_blocks, meta=meta, locale=locale
-                )
-            else:
-                await self.session_manager.send_message(session_id, text, meta=meta, locale=locale)
-            return {"status": "accepted", "session_id": session_id}
+            # 旧会话懒生成先行：保证受理条目排在重放重建的历史之后。
+            await self.event_log.ensure_backfilled(session_id, self._resolve_project_cwd_safe(meta.project_name))
+            user_entry = self._build_user_log_entry(text, echo_blocks)
+            entry = await self.session_manager.send_message(
+                session_id,
+                sdk_prompt if sdk_prompt is not None else text,
+                echo_text=text,
+                echo_content=echo_blocks,
+                meta=meta,
+                locale=locale,
+                user_entry=user_entry,
+                client_key=client_key,
+            )
+            return {"status": "accepted", "session_id": session_id, "entry": entry}
         else:
             # New session
             text, sdk_prompt, echo_blocks = self._prepare_prompt(content, images)
             prompt = sdk_prompt if sdk_prompt is not None else text
+            user_entry = self._build_user_log_entry(text, echo_blocks)
             new_sdk_session_id = await self.session_manager.send_new_session(
                 project_name,
                 prompt,
                 echo_text=text,
                 echo_content=echo_blocks,
                 locale=locale,
+                user_entry=user_entry,
+                client_key=client_key,
             )
-            return {"status": "accepted", "session_id": new_sdk_session_id}
+            managed = self.session_manager.sessions.get(new_sdk_session_id)
+            entry = managed.initial_user_log_entry if managed is not None else None
+            return {"status": "accepted", "session_id": new_sdk_session_id, "entry": entry}
 
     @staticmethod
     def _image_block(img: "ImageAttachment") -> dict[str, Any]:
@@ -413,6 +448,162 @@ class AssistantService:
                     yield event
                 if should_break:
                     break
+
+    # ==================== 会话事件日志（UI 时间线唯一读源） ====================
+
+    async def list_session_entries(
+        self,
+        session_id: str,
+        *,
+        meta: SessionMeta | None = None,
+        after_seq: int = -1,
+    ) -> dict[str, Any]:
+        """冷读事件日志（历史回放 / 非 running 会话初始加载）。"""
+        if meta is None:
+            meta = await self.meta_store.get(session_id)
+            if meta is None:
+                raise FileNotFoundError(f"session not found: {session_id}")
+        status = await self.session_manager.get_status(session_id) or meta.status
+        project_cwd = self._resolve_project_cwd_safe(meta.project_name)
+        entries = await self.event_log.list_entries(session_id, project_cwd, after_seq=after_seq)
+        draft_state = (
+            self.session_manager.get_draft_state(session_id) if status == "running" else {"draft": None, "rev": 0}
+        )
+        return {
+            "session_id": session_id,
+            "status": status,
+            "entries": entries,
+            "draft": draft_state["draft"],
+            "draft_rev": draft_state["rev"],
+        }
+
+    async def stream_entry_events(
+        self,
+        session_id: str,
+        *,
+        meta: SessionMeta | None = None,
+        request: Request | None = None,
+        after_seq: int = -1,
+    ) -> AsyncIterator[ServerSentEvent]:
+        """SSE entry 流：事件 ``id`` 即 seq，断线重连按 cursor 续传、不整帧重算。
+
+        序列协议：``entry``×N（cursor 之后的存量）→ ``draft``（首帧快照携带
+        流式累积态 + rev 过滤门槛）→ ``question``×N（未决问题）→ 直播
+        （entry / delta / question / status）。非 running 会话产出存量 entry
+        与终态 status 后即结束。
+        """
+        if meta is None:
+            meta = await self.meta_store.get(session_id)
+            if meta is None:
+                raise FileNotFoundError(f"session not found: {session_id}")
+
+        initial_status = await self.session_manager.get_status(session_id) or meta.status
+        project_cwd = self._resolve_project_cwd_safe(meta.project_name)
+
+        if initial_status != "running":
+            for entry in await self.event_log.list_entries(session_id, project_cwd, after_seq=after_seq):
+                yield self._entry_sse_event(entry)
+            yield self._sse_event(
+                "status",
+                self._build_status_event_payload(status=initial_status, session_id=session_id),
+            )
+            return
+
+        locale = get_locale(request) if request is not None else DEFAULT_LOCALE
+        last_seq = after_seq
+        async with self.session_manager.stream_messages(
+            session_id, replay=False, idle_timeout=self.stream_heartbeat_seconds, locale=locale
+        ) as stream:
+            replay = await anext(stream, None)
+            if not isinstance(replay, ReplayBatch):
+                return
+            # 订阅已先行建立（无缝隙）；订阅与库读之间重复投递的条目由 seq
+            # 门槛过滤——身份比对，非内容比对。
+            for entry in await self.event_log.list_entries(session_id, project_cwd, after_seq=last_seq):
+                last_seq = max(last_seq, self._entry_seq(entry))
+                yield self._entry_sse_event(entry)
+
+            draft_state = self.session_manager.get_draft_state(session_id)
+            yield self._sse_event("draft", {"session_id": session_id, **draft_state})
+
+            for question in await self.session_manager.get_pending_questions_snapshot(session_id):
+                yield self._sse_event("question", {**question, "session_id": session_id})
+
+            status: SessionStatus = await self.session_manager.get_status(session_id) or initial_status
+            if status != "running":
+                yield self._sse_event(
+                    "status",
+                    self._build_status_event_payload(status=status, session_id=session_id),
+                )
+                return
+
+            async for stream_event in stream:
+                if request is not None and await request.is_disconnected():
+                    break
+
+                if isinstance(stream_event, Heartbeat):
+                    live_status = await self.session_manager.get_status(session_id) or status
+                    if live_status != "running":
+                        yield self._sse_event(
+                            "status",
+                            self._build_status_event_payload(status=live_status, session_id=session_id),
+                        )
+                        break
+                    continue
+
+                if not isinstance(stream_event, LiveMessage):
+                    continue
+
+                message = stream_event.message
+                msg_type = message.get("type", "")
+
+                if msg_type == "log_entry":
+                    entry = message.get("entry")
+                    if isinstance(entry, dict):
+                        seq = self._entry_seq(entry)
+                        if seq > last_seq:
+                            last_seq = seq
+                            yield self._entry_sse_event(entry)
+                    continue
+
+                if msg_type == "log_delta":
+                    yield self._sse_event("delta", {k: v for k, v in message.items() if k != "type"})
+                    continue
+
+                if msg_type == "ask_user_question":
+                    yield self._sse_event(
+                        "question",
+                        await self._with_session_metadata(copy.deepcopy(message), session_id=session_id),
+                    )
+                    continue
+
+                if msg_type == "runtime_status":
+                    terminal = self._check_runtime_status_terminal(message, session_id)
+                    if terminal is not None:
+                        yield terminal
+                        break
+                    continue
+
+                if msg_type == "result":
+                    yield self._sse_event(
+                        "status",
+                        self._build_status_event_payload(
+                            status=self._resolve_result_status(message),
+                            session_id=session_id,
+                            result_message=message,
+                        ),
+                    )
+                    break
+
+    @staticmethod
+    def _entry_seq(entry: dict[str, Any]) -> int:
+        seq = entry.get("seq")
+        return seq if isinstance(seq, int) else -1
+
+    @staticmethod
+    def _entry_sse_event(entry: dict[str, Any]) -> ServerSentEvent:
+        """entry 事件：SSE ``id`` 字段即 seq，EventSource 原生 Last-Event-ID 续传。"""
+        return ServerSentEvent(event="entry", data=entry, id=str(entry.get("seq")))
 
     async def _emit_completed_snapshot(
         self, meta: SessionMeta, session_id: str, status: SessionStatus

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -78,6 +78,11 @@ class AssistantService:
         self._startup_done = False
         self._snapshot_cache: OrderedDict[str, dict[str, Any]] = OrderedDict()
         self._snapshot_cache_max = 128
+        # 新会话幂等映射：client_key 唯一索引按 (session_id, client_key) 分区，
+        # 覆盖不到 session_id 尚不存在的新会话受理——响应丢失后的重试若再走
+        # 新会话分支会重复建会话、重复执行同一 prompt。进程内 LRU 兜底。
+        self._new_session_client_keys: OrderedDict[str, str] = OrderedDict()
+        self._new_session_client_keys_max = 256
         self.stream_heartbeat_seconds = int(os.environ.get("ASSISTANT_STREAM_HEARTBEAT_SECONDS", "20"))
 
     async def startup(self, *, in_docker: bool = False, sandbox_enabled: bool = True) -> None:
@@ -299,6 +304,12 @@ class AssistantService:
             return {"status": "accepted", "session_id": session_id, "entry": entry}
         else:
             # New session
+            if client_key:
+                mapped_session_id = self._new_session_client_keys.get(client_key)
+                if mapped_session_id is not None:
+                    # 幂等重试：首次受理已建会话并投递，返回同一会话的权威条目。
+                    entry = await self.event_log_store.find_by_client_key(mapped_session_id, client_key)
+                    return {"status": "accepted", "session_id": mapped_session_id, "entry": entry}
             text, sdk_prompt, echo_blocks = self._prepare_prompt(content, images)
             prompt = sdk_prompt if sdk_prompt is not None else text
             user_entry = self._build_user_log_entry(text, echo_blocks)
@@ -311,6 +322,10 @@ class AssistantService:
                 user_entry=user_entry,
                 client_key=client_key,
             )
+            if client_key:
+                self._new_session_client_keys[client_key] = new_sdk_session_id
+                while len(self._new_session_client_keys) > self._new_session_client_keys_max:
+                    self._new_session_client_keys.popitem(last=False)
             managed = self.session_manager.sessions.get(new_sdk_session_id)
             entry = managed.initial_user_log_entry if managed is not None else None
             return {"status": "accepted", "session_id": new_sdk_session_id, "entry": entry}
@@ -537,11 +552,23 @@ class AssistantService:
                 )
                 return
 
+            # 原始 result 由 actor 回调同步广播，而末条 log_entry 由 inbox 任务
+            # 落库后才广播——在 result 处直接终结会丢末条条目。改为暂存 result，
+            # 等 inbox 串行序上的 log_turn_complete（此时本轮条目已全部广播）
+            # 再产出终态；心跳兜底防 inbox 停摆时悬挂。
+            pending_result: dict[str, Any] | None = None
+            drain_beats = 0
             async for stream_event in stream:
                 if request is not None and await request.is_disconnected():
                     break
 
                 if isinstance(stream_event, Heartbeat):
+                    if pending_result is not None:
+                        drain_beats += 1
+                        if drain_beats >= 2:
+                            yield self._result_status_event(pending_result, session_id)
+                            break
+                        continue
                     live_status = await self.session_manager.get_status(session_id) or status
                     if live_status != "running":
                         yield self._sse_event(
@@ -570,6 +597,12 @@ class AssistantService:
                     yield self._sse_event("delta", {k: v for k, v in message.items() if k != "type"})
                     continue
 
+                if msg_type == "log_turn_complete":
+                    if pending_result is not None:
+                        yield self._result_status_event(pending_result, session_id)
+                        break
+                    continue
+
                 if msg_type == "ask_user_question":
                     yield self._sse_event(
                         "question",
@@ -585,15 +618,18 @@ class AssistantService:
                     continue
 
                 if msg_type == "result":
-                    yield self._sse_event(
-                        "status",
-                        self._build_status_event_payload(
-                            status=self._resolve_result_status(message),
-                            session_id=session_id,
-                            result_message=message,
-                        ),
-                    )
-                    break
+                    pending_result = message
+                    continue
+
+    def _result_status_event(self, result_message: dict[str, Any], session_id: str) -> ServerSentEvent:
+        return self._sse_event(
+            "status",
+            self._build_status_event_payload(
+                status=self._resolve_result_status(result_message),
+                session_id=session_id,
+                result_message=result_message,
+            ),
+        )
 
     @staticmethod
     def _entry_seq(entry: dict[str, Any]) -> int:

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -6,6 +6,7 @@ import asyncio
 import copy
 import logging
 import os
+import weakref
 from collections import OrderedDict
 from collections.abc import AsyncGenerator, AsyncIterator
 from datetime import UTC, datetime
@@ -83,6 +84,9 @@ class AssistantService:
         # 新会话分支会重复建会话、重复执行同一 prompt。进程内 LRU 兜底。
         self._new_session_client_keys: OrderedDict[str, str] = OrderedDict()
         self._new_session_client_keys_max = 256
+        # 同一 client_key 的并发新建请求在此串行化，避免在途窗口内重复建会话；
+        # 无协程持有/等待时锁对象自动回收
+        self._new_session_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
         self.stream_heartbeat_seconds = int(os.environ.get("ASSISTANT_STREAM_HEARTBEAT_SECONDS", "20"))
 
     async def startup(self, *, in_docker: bool = False, sandbox_enabled: bool = True) -> None:
@@ -304,31 +308,54 @@ class AssistantService:
             return {"status": "accepted", "session_id": session_id, "entry": entry}
         else:
             # New session
-            if client_key:
+            if not client_key:
+                return await self._create_new_session(project_name, content, images, locale, client_key)
+
+            mapped_session_id = self._new_session_client_keys.get(client_key)
+            if mapped_session_id is not None:
+                # 幂等重试：首次受理已建会话并投递，返回同一会话的权威条目。
+                entry = await self.event_log_store.find_by_client_key(mapped_session_id, client_key)
+                return {"status": "accepted", "session_id": mapped_session_id, "entry": entry}
+
+            # 同一 client_key 的并发请求在此串行化：send_new_session 在途期间
+            # 后来者等锁而非各自建会话，避免重复执行同一 prompt。
+            lock = self._new_session_locks.setdefault(client_key, asyncio.Lock())
+            async with lock:
+                # 双重检查：等锁期间先行者可能已完成同一 client_key 的建会话。
                 mapped_session_id = self._new_session_client_keys.get(client_key)
                 if mapped_session_id is not None:
-                    # 幂等重试：首次受理已建会话并投递，返回同一会话的权威条目。
                     entry = await self.event_log_store.find_by_client_key(mapped_session_id, client_key)
                     return {"status": "accepted", "session_id": mapped_session_id, "entry": entry}
-            text, sdk_prompt, echo_blocks = self._prepare_prompt(content, images)
-            prompt = sdk_prompt if sdk_prompt is not None else text
-            user_entry = self._build_user_log_entry(text, echo_blocks)
-            new_sdk_session_id = await self.session_manager.send_new_session(
-                project_name,
-                prompt,
-                echo_text=text,
-                echo_content=echo_blocks,
-                locale=locale,
-                user_entry=user_entry,
-                client_key=client_key,
-            )
-            if client_key:
-                self._new_session_client_keys[client_key] = new_sdk_session_id
+                result = await self._create_new_session(project_name, content, images, locale, client_key)
+                self._new_session_client_keys[client_key] = result["session_id"]
                 while len(self._new_session_client_keys) > self._new_session_client_keys_max:
                     self._new_session_client_keys.popitem(last=False)
-            managed = self.session_manager.sessions.get(new_sdk_session_id)
-            entry = managed.initial_user_log_entry if managed is not None else None
-            return {"status": "accepted", "session_id": new_sdk_session_id, "entry": entry}
+                return result
+
+    async def _create_new_session(
+        self,
+        project_name: str,
+        content: str,
+        images: list["ImageAttachment"] | None,
+        locale: str,
+        client_key: str | None,
+    ) -> dict[str, Any]:
+        """实际创建新会话并投递首条消息，不涉及 client_key 幂等映射记账。"""
+        text, sdk_prompt, echo_blocks = self._prepare_prompt(content, images)
+        prompt = sdk_prompt if sdk_prompt is not None else text
+        user_entry = self._build_user_log_entry(text, echo_blocks)
+        new_sdk_session_id = await self.session_manager.send_new_session(
+            project_name,
+            prompt,
+            echo_text=text,
+            echo_content=echo_blocks,
+            locale=locale,
+            user_entry=user_entry,
+            client_key=client_key,
+        )
+        managed = self.session_manager.sessions.get(new_sdk_session_id)
+        entry = managed.initial_user_log_entry if managed is not None else None
+        return {"status": "accepted", "session_id": new_sdk_session_id, "entry": entry}
 
     @staticmethod
     def _image_block(img: "ImageAttachment") -> dict[str, Any]:

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -164,7 +164,7 @@ class ManagedSession:
     _interrupting: bool = False  # send_interrupt re-entry guard (distinct from interrupt_requested)
 
     # Message types that must never be silently dropped from subscriber queues.
-    _CRITICAL_MESSAGE_TYPES = {"result", "runtime_status", "user", "assistant", "log_entry"}
+    _CRITICAL_MESSAGE_TYPES = {"result", "runtime_status", "user", "assistant", "log_entry", "log_turn_complete"}
     # Transient types that are evicted first when buffer is full.
     _TRANSIENT_BUFFER_TYPES = {"stream_event"}
 
@@ -859,6 +859,14 @@ class SessionManager:
         """
         managed = await self.get_or_connect(session_id, meta=meta, locale=locale)
         managed.last_activity = time.monotonic()
+
+        # 幂等预检先于 running 拦截：受理已成功（响应在网络层丢失）的重试
+        # 应得到幂等成功响应，而非"会话正在处理中"的 400。
+        if user_entry is not None and client_key is not None:
+            existing = await self.event_log_store.find_by_client_key(session_id, client_key)
+            if existing is not None:
+                return existing
+
         # 取消待执行的 cleanup（会话恢复活跃）
         if managed._cleanup_task and not managed._cleanup_task.done():
             managed._cleanup_task.cancel()
@@ -877,8 +885,8 @@ class SessionManager:
                 client_key=client_key,
             )
             if not created:
-                # 幂等重试：条目已存在说明上一次受理已（或正在）送入 SDK，
-                # 直接返回权威条目，不重复投递。
+                # 幂等重试：条目存在即上一次受理已（或正在）送入 SDK——投递
+                # 失败的条目会被补偿删除，不会残留到这里。直接返回权威条目。
                 return log_entry
             managed.channel.broadcast({"type": "log_entry", "session_id": session_id, "entry": log_entry})
 
@@ -908,6 +916,13 @@ class SessionManager:
         except Exception:
             logger.exception("会话消息处理失败")
             managed.pending_user_echoes.clear()
+            if log_entry is not None:
+                # 补偿删除受理条目：投递失败即受理失败，条目残留会让同幂等键
+                # 重试在预检处短路，prompt 永远不会送入 SDK。
+                try:
+                    await self.event_log_store.delete_entry(session_id, int(log_entry["seq"]))
+                except Exception:
+                    logger.exception("回滚受理条目失败 session_id=%s seq=%s", session_id, log_entry.get("seq"))
             try:
                 await self.meta_store.update_status(session_id, "error")
             except Exception:
@@ -931,7 +946,10 @@ class SessionManager:
         if managed.status != "running":
             return managed.status
 
-        managed.pending_user_echoes.clear()
+        # 不清 pending_user_echoes：SDK 可能尚未回放刚受理的用户消息副本，
+        # 清空会让回放副本失去 REPLAYED_USER_ECHO 标记、被写入点当作新用户
+        # 消息二次落库（append-only 日志无法自愈）。残留由 _finalize_turn /
+        # _mark_session_terminal 在轮次终结时清理。
         managed.interrupt_requested = True
         managed.cancel_pending_questions("session interrupted by user")
 

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -888,7 +888,6 @@ class SessionManager:
                 # 幂等重试：条目存在即上一次受理已（或正在）送入 SDK——投递
                 # 失败的条目会被补偿删除，不会残留到这里。直接返回权威条目。
                 return log_entry
-            managed.channel.broadcast({"type": "log_entry", "session_id": session_id, "entry": log_entry})
 
         # Determine the display text for echo dedup (pending_user_echoes).
         # For image-only messages display_text is empty; use a sentinel so the
@@ -928,6 +927,10 @@ class SessionManager:
             except Exception:
                 logger.exception("持久化 error 状态失败 session_id=%s", session_id)
             raise
+        if log_entry is not None:
+            # send_query 确认投递成功后再广播：避免失败回滚已删条目后，
+            # 在线 SSE 订阅者仍残留一条已撤销的用户消息。
+            managed.channel.broadcast({"type": "log_entry", "session_id": session_id, "entry": log_entry})
         return log_entry
 
     async def interrupt_session(self, session_id: str) -> SessionStatus:

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -19,6 +19,12 @@ from lib.db.base import DEFAULT_USER_ID
 from lib.i18n import DEFAULT_LOCALE
 from lib.logging_config import resolve_log_dir
 from server.agent_runtime.agent_access_policy import AgentAccessPolicy
+from server.agent_runtime.entry_pipeline import SessionEntryPipeline
+from server.agent_runtime.event_log import (
+    REPLAYED_USER_ECHO_KEY,
+    EventLogStore,
+    build_user_entry,
+)
 from server.agent_runtime.message_serialization import (
     IMAGE_ONLY_SENTINEL,
     build_runtime_status_message,
@@ -141,6 +147,12 @@ class ManagedSession:
     buffer_max_size: int = 100
     pending_questions: dict[str, PendingQuestion] = field(default_factory=dict)
     pending_user_echoes: list[str] = field(default_factory=list)
+    # 事件日志写入点管道（UI 时间线唯一读源的 live 写侧）。
+    entry_pipeline: SessionEntryPipeline | None = None
+    # 新会话首条用户消息：sdk_session_id 就绪后由 inbox 任务写入日志（seq 0），
+    # 保证用户条目先于任何 assistant 条目分配身份。
+    pending_initial_user_entry: dict[str, Any] | None = None
+    initial_user_log_entry: dict[str, Any] | None = None
     last_user_prompt: str = ""
     assistant_model: str = ""
     interrupt_requested: bool = False
@@ -152,7 +164,7 @@ class ManagedSession:
     _interrupting: bool = False  # send_interrupt re-entry guard (distinct from interrupt_requested)
 
     # Message types that must never be silently dropped from subscriber queues.
-    _CRITICAL_MESSAGE_TYPES = {"result", "runtime_status", "user", "assistant"}
+    _CRITICAL_MESSAGE_TYPES = {"result", "runtime_status", "user", "assistant", "log_entry"}
     # Transient types that are evicted first when buffer is full.
     _TRANSIENT_BUFFER_TYPES = {"stream_event"}
 
@@ -286,7 +298,9 @@ class SessionManager:
         projects_root: Path | None = None,
         in_docker: bool = False,
         sandbox_enabled: bool = True,
+        event_log_store: EventLogStore | None = None,
     ):
+        self.event_log_store = event_log_store or EventLogStore()
         self.project_root = Path(project_root)
         self.data_dir = Path(data_dir)
         # Tests construct SessionManager directly without going through
@@ -419,6 +433,18 @@ class SessionManager:
             raise FileNotFoundError(f"project not found: {project_name}")
         return project_cwd
 
+    def _build_entry_pipeline(self, managed: "ManagedSession") -> SessionEntryPipeline:
+        """构建会话的事件日志写入点管道。
+
+        session_id 用 provider 现取：新会话在 sdk_session_id 就绪前为 None，
+        管道自动跳过（该窗口内只有 init 系统消息，本就不入日志）。
+        """
+        return SessionEntryPipeline(
+            self.event_log_store,
+            session_id_provider=lambda: managed.resolved_sdk_id,
+            broadcast=managed.channel.broadcast,
+        )
+
     def _make_actor_message_callback(
         self,
         managed_ref: list["ManagedSession | None"],
@@ -441,6 +467,9 @@ class SessionManager:
             if not isinstance(msg_dict, dict):
                 return
             if is_duplicate_user_echo(managed.pending_user_echoes, msg_dict):
+                # SDK 回放的用户消息副本：POST 受理时已写日志分配身份，
+                # 打标让事件日志写入点跳过，不产生重复条目。
+                msg_dict[REPLAYED_USER_ECHO_KEY] = True
                 managed._inbox.put_nowait(msg_dict)
                 return
             self._handle_special_message(managed, msg_dict)
@@ -500,8 +529,15 @@ class SessionManager:
         echo_text: str | None = None,
         echo_content: list[dict[str, Any]] | None = None,
         locale: str = DEFAULT_LOCALE,
+        user_entry: dict[str, Any] | None = None,
+        client_key: str | None = None,
     ) -> str:
-        """Create a new session via send-first: start actor, send query, wait for sdk_session_id."""
+        """Create a new session via send-first: start actor, send query, wait for sdk_session_id.
+
+        ``user_entry`` 是本条用户消息的事件日志条目（写入点定型后的形态）；
+        sdk_session_id 就绪后由 inbox 任务先写日志（seq 0）再放行等待，权威
+        条目落在 ``managed.initial_user_log_entry`` 供受理响应回传。
+        """
         if not SDK_AVAILABLE or ClaudeSDKClient is None:
             raise RuntimeError("claude_agent_sdk is not installed")
 
@@ -540,6 +576,9 @@ class SessionManager:
             project_name=project_name,
             assistant_model=assistant_model,
         )
+        if user_entry is not None:
+            managed.pending_initial_user_entry = {"entry": user_entry, "client_key": client_key}
+        managed.entry_pipeline = self._build_entry_pipeline(managed)
         managed_ref[0] = managed
         managed.last_activity = time.monotonic()
         self.sessions[temp_id] = managed
@@ -667,6 +706,10 @@ class SessionManager:
                             "sdk_session_id 处理失败 session_id=%s",
                             managed.session_id,
                         )
+                # 事件日志写入点：sdk_session_id 就绪后逐条定型入日志。
+                # handle_message 内部吞异常，不会打断会话消费。
+                if managed.entry_pipeline is not None and managed.resolved_sdk_id is not None:
+                    await managed.entry_pipeline.handle_message(msg_dict)
                 if msg_dict.get("type") == "result":
                     try:
                         await self._finalize_turn(managed, msg_dict)
@@ -769,6 +812,7 @@ class SessionManager:
                 resolved_sdk_id=meta.id,  # 标记为已注册，防止重复创建 DB 记录
             )
             managed.sdk_id_event.set()  # 已有会话不需要等待 sdk_id
+            managed.entry_pipeline = self._build_entry_pipeline(managed)
             managed_ref[0] = managed
             managed.last_activity = time.monotonic()
             self.sessions[session_id] = managed
@@ -800,12 +844,18 @@ class SessionManager:
         echo_content: list[dict[str, Any]] | None = None,
         meta: SessionMeta | None = None,
         locale: str = DEFAULT_LOCALE,
-    ) -> None:
+        user_entry: dict[str, Any] | None = None,
+        client_key: str | None = None,
+    ) -> dict[str, Any] | None:
         """Send a message via the session actor.
 
         ``locale`` is forwarded to ``get_or_connect`` so a cold-recovered
         session rebuilds its language regulation from the current request's
         locale rather than the default.
+
+        ``user_entry`` 是本条用户消息的事件日志条目：先写日志分配身份（并发
+        与容量校验之后、送入 SDK 之前），返回权威条目供受理响应回传；同一
+        ``client_key`` 重试命中既有条目时不再重复送 SDK。
         """
         managed = await self.get_or_connect(session_id, meta=meta, locale=locale)
         managed.last_activity = time.monotonic()
@@ -818,6 +868,19 @@ class SessionManager:
             raise ValueError("会话正在处理中，请等待当前回复完成后再发送新消息")
 
         self._prune_transient_buffer(managed)
+
+        log_entry: dict[str, Any] | None = None
+        if user_entry is not None:
+            log_entry, created = await self.event_log_store.append_user_entry(
+                session_id,
+                user_entry,
+                client_key=client_key,
+            )
+            if not created:
+                # 幂等重试：条目已存在说明上一次受理已（或正在）送入 SDK，
+                # 直接返回权威条目，不重复投递。
+                return log_entry
+            managed.channel.broadcast({"type": "log_entry", "session_id": session_id, "entry": log_entry})
 
         # Determine the display text for echo dedup (pending_user_echoes).
         # For image-only messages display_text is empty; use a sentinel so the
@@ -850,6 +913,7 @@ class SessionManager:
             except Exception:
                 logger.exception("持久化 error 状态失败 session_id=%s", session_id)
             raise
+        return log_entry
 
     async def interrupt_session(self, session_id: str) -> SessionStatus:
         """Interrupt a running session via the actor."""
@@ -972,6 +1036,18 @@ class SessionManager:
                     "timestamp": utc_now_iso(),
                 }
             )
+            # 事件日志侧同步收录中断回显（过渡期通用条目形态）：此路径下
+            # inbox 处理已终止，SDK 自己的回显不会再经写入点入日志。
+            if managed.resolved_sdk_id is not None:
+                try:
+                    interrupt_entry = build_user_entry([{"type": "text", "text": "[Request interrupted by user]"}])
+                    appended = await self.event_log_store.append(managed.resolved_sdk_id, [interrupt_entry])
+                    for entry in appended:
+                        managed.channel.broadcast(
+                            {"type": "log_entry", "session_id": managed.resolved_sdk_id, "entry": entry}
+                        )
+                except Exception:
+                    logger.exception("中断条目写入事件日志失败 session_id=%s", managed.resolved_sdk_id)
 
         # Broadcast terminal status so SSE subscribers unblock immediately
         # instead of waiting for the heartbeat timeout.
@@ -1356,6 +1432,22 @@ class SessionManager:
                 *([] if tag_coro is None else [tag_coro]),
             )
             await self.meta_store.update_status(sdk_id, "running")
+            # 新会话首条用户消息先写日志分配身份（seq 0）：本方法在 inbox 任务
+            # 内串行执行于任何 assistant 条目定型之前，保证时间线顺序；写入
+            # 完成后才 set sdk_id_event，send_new_session 醒来即可拿到权威条目。
+            pending_user = managed.pending_initial_user_entry
+            if pending_user is not None:
+                managed.pending_initial_user_entry = None
+                try:
+                    authoritative, _created = await self.event_log_store.append_user_entry(
+                        sdk_id,
+                        pending_user["entry"],
+                        client_key=pending_user.get("client_key"),
+                    )
+                    managed.initial_user_log_entry = authoritative
+                    managed.channel.broadcast({"type": "log_entry", "session_id": sdk_id, "entry": authoritative})
+                except Exception:
+                    logger.exception("新会话用户条目写入事件日志失败 session_id=%s", sdk_id)
             # Key swap: replace temp_id with real sdk_id in sessions dict
             # BEFORE signaling the event. This prevents _finalize_turn from
             # using the stale temp_id if it runs before send_new_session
@@ -1393,6 +1485,18 @@ class SessionManager:
         if not managed:
             return []
         return list(managed.message_buffer)
+
+    def get_draft_state(self, session_id: str) -> dict[str, Any]:
+        """流式预览态（draft）重连首帧快照：当前累积态 + rev 过滤门槛。
+
+        ``rev`` 在无活跃 draft 时也返回：订阅与快照之间已入队的旧 delta
+        （rev <= 门槛）由客户端按 rev 丢弃，不做内容比对。
+        """
+        managed = self.sessions.get(session_id)
+        if managed is None or managed.entry_pipeline is None:
+            return {"draft": None, "rev": 0}
+        draft = managed.entry_pipeline.draft
+        return {"draft": draft.snapshot(), "rev": draft.rev}
 
     async def get_pending_questions_snapshot(self, session_id: str) -> list[dict[str, Any]]:
         """Get unresolved AskUserQuestion payloads for reconnect."""

--- a/server/routers/assistant.py
+++ b/server/routers/assistant.py
@@ -59,6 +59,8 @@ class SendRequest(BaseModel):
     content: str = ""
     images: list[ImageAttachment] = Field(default_factory=list, max_length=5)
     session_id: str | None = None
+    # 请求侧幂等键：同键重试返回既有权威条目，不产生重复。
+    client_key: str | None = Field(default=None, max_length=128)
 
 
 class AnswerQuestionRequest(BaseModel):
@@ -81,6 +83,7 @@ async def send_message(
             session_id=req.session_id,
             images=req.images,
             locale=get_locale(request),
+            client_key=req.client_key,
         )
         return result
     except SessionCapacityError as exc:
@@ -170,6 +173,61 @@ async def get_snapshot(project_name: str, session_id: str, _user: CurrentUser, _
         raise
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=_t("session_not_found", session_id=session_id))
+    except Exception:
+        logger.exception("请求处理失败")
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
+
+
+@router.get("/sessions/{session_id}/entries")
+async def list_entries(
+    project_name: str,
+    session_id: str,
+    _user: CurrentUser,
+    _t: Translator,
+    after: int = Query(default=-1, ge=-1),
+):
+    """冷读会话事件日志（历史回放；``after`` 为 seq 游标）。"""
+    try:
+        service = get_assistant_service()
+        meta = await _validate_session_ownership(service, session_id, project_name, _t)
+        return await service.list_session_entries(session_id, meta=meta, after_seq=after)
+    except HTTPException:
+        raise
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=_t("session_not_found", session_id=session_id))
+    except Exception:
+        logger.exception("请求处理失败")
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
+
+
+@router.get("/sessions/{session_id}/entries/stream", response_class=EventSourceResponse)
+async def stream_entries(
+    project_name: str,
+    session_id: str,
+    request: Request,
+    _user: CurrentUserFlexible,
+    _t: Translator,
+    after: int = Query(default=-1, ge=-1),
+    deps: tuple[AssistantService, SessionMeta] = Depends(_assistant_service_for_stream),
+) -> AsyncIterator[ServerSentEvent]:
+    """SSE entry 流：事件 id 即 seq。
+
+    游标优先级：EventSource 自动重连携带的 ``Last-Event-ID`` > ``?after=<seq>``
+    （冷订阅）。
+    """
+    service, meta = deps
+    cursor = after
+    last_event_id = request.headers.get("last-event-id", "").strip()
+    if last_event_id:
+        try:
+            cursor = int(last_event_id)
+        except ValueError:
+            pass
+    try:
+        async for event in service.stream_entry_events(session_id, meta=meta, request=request, after_seq=cursor):
+            yield event
+    except HTTPException:
+        raise
     except Exception:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=_t("internal_server_error"))

--- a/server/routers/assistant.py
+++ b/server/routers/assistant.py
@@ -222,7 +222,7 @@ async def stream_entries(
         try:
             cursor = int(last_event_id)
         except ValueError:
-            pass
+            logger.debug("忽略无效的 Last-Event-ID: %r，回退到游标 %s", last_event_id, cursor)
     try:
         async for event in service.stream_entry_events(session_id, meta=meta, request=request, after_seq=cursor):
             yield event

--- a/tests/agent_runtime/test_entry_pipeline.py
+++ b/tests/agent_runtime/test_entry_pipeline.py
@@ -1,0 +1,224 @@
+"""Live 写入点管道：draft 累积、log_entry/log_delta 广播、精确替换。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from server.agent_runtime.entry_pipeline import DraftAccumulator, SessionEntryPipeline
+
+
+class _RecordingStore:
+    """记录 append 调用并模拟 seq 分配的假事件日志存储。"""
+
+    def __init__(self):
+        self.entries: list[dict[str, Any]] = []
+
+    async def append(self, session_id: str, entries: list[dict], *, client_key=None) -> list[dict]:
+        appended = []
+        for entry in entries:
+            appended.append({"seq": len(self.entries), **entry})
+            self.entries.append(appended[-1])
+        return appended
+
+
+def _make_pipeline(session_id: str | None = "s1"):
+    store = _RecordingStore()
+    broadcasts: list[dict] = []
+    pipeline = SessionEntryPipeline(
+        store,  # type: ignore[arg-type]
+        session_id_provider=lambda: session_id,
+        broadcast=broadcasts.append,
+    )
+    return pipeline, store, broadcasts
+
+
+def _stream_event(event: dict, *, parent: str | None = None) -> dict:
+    msg: dict[str, Any] = {"type": "stream_event", "event": event}
+    if parent:
+        msg["parent_tool_use_id"] = parent
+    return msg
+
+
+def _message_start(message_id: str = "msg_01") -> dict:
+    return _stream_event({"type": "message_start", "message": {"id": message_id}})
+
+
+def _text_delta(text: str, index: int = 0) -> dict:
+    return _stream_event({"type": "content_block_delta", "index": index, "delta": {"type": "text_delta", "text": text}})
+
+
+class TestDraftAccumulator:
+    def test_message_start_captures_message_id(self):
+        draft = DraftAccumulator()
+        draft.apply_stream_event(_message_start("msg_42"))
+        assert draft.message_id == "msg_42"
+
+    def test_text_accumulation_and_snapshot(self):
+        draft = DraftAccumulator()
+        draft.apply_stream_event(_message_start())
+        d1 = draft.apply_stream_event(_text_delta("你"))
+        d2 = draft.apply_stream_event(_text_delta("好"))
+        assert d1 is not None and d1["delta_type"] == "text_delta" and d1["text"] == "你"
+        assert d2 is not None and d2["rev"] > d1["rev"]
+
+        snapshot = draft.snapshot()
+        assert snapshot is not None
+        assert snapshot["message_id"] == "msg_01"
+        assert snapshot["content"] == [{"type": "text", "text": "你好"}]
+        assert snapshot["rev"] == d2["rev"]
+
+    def test_block_start_broadcasts_normalized_block(self):
+        draft = DraftAccumulator()
+        draft.apply_stream_event(_message_start())
+        delta = draft.apply_stream_event(
+            _stream_event(
+                {
+                    "type": "content_block_start",
+                    "index": 1,
+                    "content_block": {"type": "tool_use", "id": "tu-1", "name": "Bash", "input": {}},
+                }
+            )
+        )
+        assert delta is not None
+        assert delta["delta_type"] == "block_start"
+        assert delta["block_index"] == 1
+        assert delta["block"]["name"] == "Bash"
+
+    def test_input_json_delta_accumulates(self):
+        draft = DraftAccumulator()
+        draft.apply_stream_event(_message_start())
+        draft.apply_stream_event(
+            _stream_event(
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "tool_use", "id": "tu-1", "name": "Bash", "input": {}},
+                }
+            )
+        )
+        draft.apply_stream_event(
+            _stream_event(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "input_json_delta", "partial_json": '{"comm'},
+                }
+            )
+        )
+        draft.apply_stream_event(
+            _stream_event(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "input_json_delta", "partial_json": 'and": "ls"}'},
+                }
+            )
+        )
+        snapshot = draft.snapshot()
+        assert snapshot is not None
+        assert snapshot["content"][0]["input"] == {"command": "ls"}
+
+    def test_orphan_delta_without_message_start_ignored(self):
+        draft = DraftAccumulator()
+        assert draft.apply_stream_event(_text_delta("x")) is None
+        assert draft.snapshot() is None
+
+    def test_clear_for_message_only_matches_same_id(self):
+        draft = DraftAccumulator()
+        draft.apply_stream_event(_message_start("msg_01"))
+        draft.apply_stream_event(_text_delta("hi"))
+        assert draft.clear_for_message("msg_other") is False
+        assert draft.snapshot() is not None
+        assert draft.clear_for_message("msg_01") is True
+        assert draft.snapshot() is None
+
+    def test_rev_is_monotonic_across_messages(self):
+        draft = DraftAccumulator()
+        draft.apply_stream_event(_message_start("msg_01"))
+        d1 = draft.apply_stream_event(_text_delta("a"))
+        draft.apply_stream_event(_message_start("msg_02"))
+        d2 = draft.apply_stream_event(_text_delta("b"))
+        assert d1 is not None and d2 is not None
+        assert d2["rev"] > d1["rev"]
+
+
+class TestSessionEntryPipeline:
+    async def test_assistant_message_appends_entry_and_clears_matching_draft(self):
+        pipeline, store, broadcasts = _make_pipeline()
+        await pipeline.handle_message(_message_start("msg_01"))
+        await pipeline.handle_message(_text_delta("你好"))
+        assert pipeline.draft.snapshot() is not None
+
+        await pipeline.handle_message(
+            {
+                "type": "assistant",
+                "message_id": "msg_01",
+                "uuid": "a-1",
+                "content": [{"type": "text", "text": "你好"}],
+            }
+        )
+
+        assert len(store.entries) == 1
+        assert store.entries[0]["type"] == "assistant"
+        assert store.entries[0]["message_id"] == "msg_01"
+        # draft 被同 message_id 权威条目精确替换
+        assert pipeline.draft.snapshot() is None
+
+        entry_events = [b for b in broadcasts if b["type"] == "log_entry"]
+        delta_events = [b for b in broadcasts if b["type"] == "log_delta"]
+        assert len(entry_events) == 1
+        assert entry_events[0]["entry"]["seq"] == 0
+        assert len(delta_events) == 1
+
+    async def test_assistant_with_other_message_id_keeps_draft(self):
+        pipeline, _store, _broadcasts = _make_pipeline()
+        await pipeline.handle_message(_message_start("msg_02"))
+        await pipeline.handle_message(_text_delta("进行中"))
+
+        await pipeline.handle_message({"type": "assistant", "message_id": "msg_01", "uuid": "a-0", "content": []})
+        assert pipeline.draft.snapshot() is not None
+
+    async def test_result_clears_draft_without_logging(self):
+        pipeline, store, _broadcasts = _make_pipeline()
+        await pipeline.handle_message(_message_start("msg_01"))
+        await pipeline.handle_message(_text_delta("部分内容"))
+
+        await pipeline.handle_message({"type": "result", "subtype": "error_during_execution"})
+
+        assert store.entries == []
+        assert pipeline.draft.snapshot() is None
+
+    async def test_tool_result_user_message_becomes_independent_entries(self):
+        pipeline, store, broadcasts = _make_pipeline()
+        await pipeline.handle_message(
+            {
+                "type": "user",
+                "uuid": "u-1",
+                "content": [{"type": "tool_result", "tool_use_id": "tu-1", "content": "ok"}],
+            }
+        )
+        assert len(store.entries) == 1
+        assert store.entries[0]["type"] == "tool_result"
+        assert store.entries[0]["tool_use_id"] == "tu-1"
+        assert broadcasts[0]["entry"]["seq"] == 0
+
+    async def test_no_session_id_skips_everything(self):
+        pipeline, store, broadcasts = _make_pipeline(session_id=None)
+        await pipeline.handle_message({"type": "assistant", "content": [{"type": "text", "text": "x"}]})
+        assert store.entries == []
+        assert broadcasts == []
+
+    async def test_store_failure_is_swallowed(self):
+        class _BrokenStore:
+            async def append(self, *args, **kwargs):
+                raise RuntimeError("db down")
+
+        broadcasts: list[dict] = []
+        pipeline = SessionEntryPipeline(
+            _BrokenStore(),  # type: ignore[arg-type]
+            session_id_provider=lambda: "s1",
+            broadcast=broadcasts.append,
+        )
+        # 不抛出——时间线修复手段是重放重建，不打断会话
+        await pipeline.handle_message({"type": "assistant", "content": [{"type": "text", "text": "x"}]})
+        assert broadcasts == []

--- a/tests/agent_runtime/test_entry_pipeline.py
+++ b/tests/agent_runtime/test_entry_pipeline.py
@@ -118,6 +118,46 @@ class TestDraftAccumulator:
         assert snapshot is not None
         assert snapshot["content"][0]["input"] == {"command": "ls"}
 
+    def test_snapshot_carries_accumulated_tool_json(self):
+        """快照携带原始 partial JSON，重连客户端以此为前缀续拼后续 delta。"""
+        draft = DraftAccumulator()
+        draft.apply_stream_event(_message_start())
+        draft.apply_stream_event(
+            _stream_event(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "input_json_delta", "partial_json": '{"file": "a'},
+                }
+            )
+        )
+        snapshot = draft.snapshot()
+        assert snapshot is not None
+        assert snapshot["tool_json"] == {0: '{"file": "a'}
+
+    def test_cross_parent_delta_filtered(self):
+        """并行 subagent 流交错：非当前 parent 的增量被丢弃，不污染单槽草稿。"""
+        draft = DraftAccumulator()
+        draft.apply_stream_event(_stream_event({"type": "message_start", "message": {"id": "msg_b"}}, parent="tu-b"))
+        draft.apply_stream_event(
+            _stream_event(
+                {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "B文本"}},
+                parent="tu-b",
+            )
+        )
+        # 另一条并行流（parent 不同）的增量不得拼入当前草稿
+        stolen = draft.apply_stream_event(
+            _stream_event(
+                {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "A文本"}},
+                parent="tu-a",
+            )
+        )
+        assert stolen is None
+        snapshot = draft.snapshot()
+        assert snapshot is not None
+        assert snapshot["content"] == [{"type": "text", "text": "B文本"}]
+        assert snapshot["parent_tool_use_id"] == "tu-b"
+
     def test_orphan_delta_without_message_start_ignored(self):
         draft = DraftAccumulator()
         assert draft.apply_stream_event(_text_delta("x")) is None
@@ -179,7 +219,7 @@ class TestSessionEntryPipeline:
         assert pipeline.draft.snapshot() is not None
 
     async def test_result_clears_draft_without_logging(self):
-        pipeline, store, _broadcasts = _make_pipeline()
+        pipeline, store, broadcasts = _make_pipeline()
         await pipeline.handle_message(_message_start("msg_01"))
         await pipeline.handle_message(_text_delta("部分内容"))
 
@@ -187,6 +227,8 @@ class TestSessionEntryPipeline:
 
         assert store.entries == []
         assert pipeline.draft.snapshot() is None
+        # 轮次终结标记：entry 流以此产出终态，保证末条 log_entry 先送达
+        assert broadcasts[-1] == {"type": "log_turn_complete", "session_id": "s1"}
 
     async def test_tool_result_user_message_becomes_independent_entries(self):
         pipeline, store, broadcasts = _make_pipeline()
@@ -219,6 +261,32 @@ class TestSessionEntryPipeline:
             session_id_provider=lambda: "s1",
             broadcast=broadcasts.append,
         )
-        # 不抛出——时间线修复手段是重放重建，不打断会话
+        # 重试耗尽后不抛出——不打断会话消费
         await pipeline.handle_message({"type": "assistant", "content": [{"type": "text", "text": "x"}]})
         assert broadcasts == []
+
+    async def test_transient_store_failure_retried(self):
+        """瞬时落库失败（SQLite busy 等）有界重试，避免时间线永久空洞。"""
+
+        class _FlakyStore(_RecordingStore):
+            def __init__(self):
+                super().__init__()
+                self.attempts = 0
+
+            async def append(self, session_id, entries, *, client_key=None):
+                self.attempts += 1
+                if self.attempts == 1:
+                    raise RuntimeError("db busy")
+                return await super().append(session_id, entries, client_key=client_key)
+
+        store = _FlakyStore()
+        broadcasts: list[dict] = []
+        pipeline = SessionEntryPipeline(
+            store,  # type: ignore[arg-type]
+            session_id_provider=lambda: "s1",
+            broadcast=broadcasts.append,
+        )
+        await pipeline.handle_message({"type": "assistant", "uuid": "a-1", "content": [{"type": "text", "text": "x"}]})
+        assert store.attempts == 2
+        assert len(store.entries) == 1
+        assert [b["type"] for b in broadcasts] == ["log_entry"]

--- a/tests/agent_runtime/test_entry_stream.py
+++ b/tests/agent_runtime/test_entry_stream.py
@@ -145,6 +145,7 @@ class TestStreamEntryEvents:
             }
         )
         manager.queue.put_nowait({"type": "result", "subtype": "success", "is_error": False})
+        manager.queue.put_nowait({"type": "log_turn_complete", "session_id": SESSION_ID})
 
         events = [_collect(e) async for e in service.stream_entry_events(SESSION_ID, after_seq=-1)]
 
@@ -172,11 +173,36 @@ class TestStreamEntryEvents:
             [{"type": "user", "uuid": "a"}, {"type": "assistant", "uuid": "b"}, {"type": "tool_result", "uuid": "c"}],
         )
         manager.queue.put_nowait({"type": "result", "subtype": "success", "is_error": False})
+        manager.queue.put_nowait({"type": "log_turn_complete", "session_id": SESSION_ID})
 
         events = [_collect(e) async for e in service.stream_entry_events(SESSION_ID, after_seq=1)]
 
         entry_events = [e for e in events if e[0] == "entry"]
         assert [e[2] for e in entry_events] == ["2"]
+
+    async def test_final_entry_after_raw_result_still_delivered(self, entry_service):
+        """末条 log_entry 晚于原始 result 广播到达（inbox 落库延迟）时仍须送达。
+
+        终态由 log_turn_complete 触发，不在原始 result 处提前终结。
+        """
+        service, store = entry_service
+        manager = _FakeEntrySessionManager(status="running")
+        service.session_manager = manager
+        await store.append(SESSION_ID, [{"type": "user", "uuid": "a"}])
+
+        # actor 回调先广播原始 result，末条 assistant 的 log_entry 随后才到
+        manager.queue.put_nowait({"type": "result", "subtype": "success", "is_error": False})
+        manager.queue.put_nowait(
+            {"type": "log_entry", "session_id": SESSION_ID, "entry": {"seq": 1, "type": "assistant", "uuid": "b"}}
+        )
+        manager.queue.put_nowait({"type": "log_turn_complete", "session_id": SESSION_ID})
+
+        events = [_collect(e) async for e in service.stream_entry_events(SESSION_ID)]
+
+        names = [name for name, _, _ in events]
+        assert names[-2:] == ["entry", "status"]
+        assert [e[2] for e in events if e[0] == "entry"] == ["0", "1"]
+        assert events[-1][1]["status"] == "completed"
 
     async def test_pending_questions_replayed_on_subscribe(self, entry_service):
         service, store = entry_service
@@ -184,6 +210,7 @@ class TestStreamEntryEvents:
         manager = _FakeEntrySessionManager(status="running", pending=[question])
         service.session_manager = manager
         manager.queue.put_nowait({"type": "result", "subtype": "success", "is_error": False})
+        manager.queue.put_nowait({"type": "log_turn_complete", "session_id": SESSION_ID})
 
         events = [_collect(e) async for e in service.stream_entry_events(SESSION_ID)]
 

--- a/tests/agent_runtime/test_entry_stream.py
+++ b/tests/agent_runtime/test_entry_stream.py
@@ -1,0 +1,291 @@
+"""SSE entry 流与 REST entries：cursor 续传、draft 首帧、状态事件。"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+from fastapi import FastAPI
+from fastapi.sse import ServerSentEvent
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from lib.db.base import Base
+from lib.i18n import DEFAULT_LOCALE, get_translator
+from server.agent_runtime.event_log import EventLogService, EventLogStore
+from server.agent_runtime.models import LiveMessage, ReplayBatch
+from server.agent_runtime.service import AssistantService
+from server.auth import CurrentUserInfo, get_current_user, get_current_user_flexible
+from server.routers import assistant
+from tests.conftest import make_translator
+from tests.factories import make_session_meta
+
+SESSION_ID = "entry-stream-s1"
+
+
+class _FakeMetaStore:
+    def __init__(self, meta):
+        self._meta = meta
+
+    async def get(self, session_id):
+        return self._meta if session_id == self._meta.id else None
+
+
+class _FakeAdapter:
+    def __init__(self, messages=None):
+        self._messages = messages or []
+
+    async def read_raw_messages(self, sdk_session_id=None, project_cwd=None):
+        return list(self._messages)
+
+
+class _FakeEntrySessionManager:
+    def __init__(self, status="running", draft_state=None, pending=None):
+        self.status_value = status
+        self.queue: asyncio.Queue = asyncio.Queue()
+        self.draft_state = draft_state or {"draft": None, "rev": 0}
+        self.pending = pending or []
+
+    async def get_status(self, session_id):
+        return self.status_value
+
+    def get_draft_state(self, session_id):
+        return dict(self.draft_state)
+
+    async def get_pending_questions_snapshot(self, session_id):
+        return list(self.pending)
+
+    @contextlib.asynccontextmanager
+    async def stream_messages(self, session_id, *, replay=True, idle_timeout=20.0, locale=DEFAULT_LOCALE):
+        async def _iter():
+            yield ReplayBatch(messages=[])
+            while True:
+                message = await self.queue.get()
+                if message is None:
+                    return
+                yield LiveMessage(message=message)
+
+        yield _iter()
+
+
+@pytest.fixture()
+async def entry_service(tmp_path):
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    store = EventLogStore(session_factory=factory)
+
+    service = AssistantService(project_root=tmp_path)
+    meta = make_session_meta(id=SESSION_ID, status="running")
+    service.meta_store = _FakeMetaStore(meta)
+    service.event_log_store = store
+    service.event_log = EventLogService(store, _FakeAdapter())
+    yield service, store
+    await engine.dispose()
+
+
+def _collect(event: ServerSentEvent) -> tuple[str, dict, str | None]:
+    data = event.data if isinstance(event.data, dict) else {}
+    return event.event or "", data, event.id
+
+
+class TestStreamEntryEvents:
+    async def test_non_running_emits_entries_then_terminal_status(self, entry_service):
+        service, store = entry_service
+        service.session_manager = _FakeEntrySessionManager(status="completed")
+        await store.append(SESSION_ID, [{"type": "user", "uuid": "a"}, {"type": "assistant", "uuid": "b"}])
+
+        events = [_collect(e) async for e in service.stream_entry_events(SESSION_ID)]
+
+        assert [name for name, _, _ in events] == ["entry", "entry", "status"]
+        # SSE 事件 id 即 seq
+        assert [sse_id for _, _, sse_id in events[:2]] == ["0", "1"]
+        assert events[2][1]["status"] == "completed"
+
+    async def test_after_cursor_skips_earlier_entries(self, entry_service):
+        service, store = entry_service
+        service.session_manager = _FakeEntrySessionManager(status="completed")
+        await store.append(SESSION_ID, [{"type": "user", "uuid": "a"}, {"type": "assistant", "uuid": "b"}])
+
+        events = [_collect(e) async for e in service.stream_entry_events(SESSION_ID, after_seq=0)]
+
+        entry_events = [e for e in events if e[0] == "entry"]
+        assert len(entry_events) == 1
+        assert entry_events[0][2] == "1"
+
+    async def test_running_stream_backlog_draft_live_and_dedup(self, entry_service):
+        service, store = entry_service
+        draft_state = {
+            "draft": {"message_id": "msg_9", "content": [{"type": "text", "text": "部分"}], "rev": 7},
+            "rev": 7,
+        }
+        manager = _FakeEntrySessionManager(status="running", draft_state=draft_state)
+        service.session_manager = manager
+        await store.append(SESSION_ID, [{"type": "user", "uuid": "a"}, {"type": "assistant", "uuid": "b"}])
+
+        # 直播队列：重复条目（seq 1，已在存量中）须被 seq 门槛跳过；
+        # 新条目 seq 2 放行；delta 透传；result 产出终态 status 并结束。
+        manager.queue.put_nowait(
+            {"type": "log_entry", "session_id": SESSION_ID, "entry": {"seq": 1, "type": "assistant", "uuid": "b"}}
+        )
+        manager.queue.put_nowait(
+            {"type": "log_entry", "session_id": SESSION_ID, "entry": {"seq": 2, "type": "tool_result", "uuid": "c"}}
+        )
+        manager.queue.put_nowait(
+            {
+                "type": "log_delta",
+                "session_id": SESSION_ID,
+                "message_id": "msg_9",
+                "delta_type": "text_delta",
+                "block_index": 0,
+                "text": "内容",
+                "rev": 8,
+            }
+        )
+        manager.queue.put_nowait({"type": "result", "subtype": "success", "is_error": False})
+
+        events = [_collect(e) async for e in service.stream_entry_events(SESSION_ID, after_seq=-1)]
+
+        names = [name for name, _, _ in events]
+        assert names == ["entry", "entry", "draft", "entry", "delta", "status"]
+        # 存量 entry：seq 0、1；直播放行的只有 seq 2（seq 1 重复被跳过）
+        assert [e[2] for e in events if e[0] == "entry"] == ["0", "1", "2"]
+        # draft 首帧快照携带累积态与 rev 门槛
+        draft_payload = events[2][1]
+        assert draft_payload["draft"]["message_id"] == "msg_9"
+        assert draft_payload["rev"] == 7
+        # delta 事件不带 SSE id（不推进 Last-Event-ID）
+        delta_event = next(e for e in events if e[0] == "delta")
+        assert delta_event[2] is None
+        assert delta_event[1]["text"] == "内容"
+        assert events[-1][1]["status"] == "completed"
+
+    async def test_running_stream_reconnect_cursor_no_full_replay(self, entry_service):
+        """携带 cursor 订阅只收到其后的条目，重连不整帧重算。"""
+        service, store = entry_service
+        manager = _FakeEntrySessionManager(status="running")
+        service.session_manager = manager
+        await store.append(
+            SESSION_ID,
+            [{"type": "user", "uuid": "a"}, {"type": "assistant", "uuid": "b"}, {"type": "tool_result", "uuid": "c"}],
+        )
+        manager.queue.put_nowait({"type": "result", "subtype": "success", "is_error": False})
+
+        events = [_collect(e) async for e in service.stream_entry_events(SESSION_ID, after_seq=1)]
+
+        entry_events = [e for e in events if e[0] == "entry"]
+        assert [e[2] for e in entry_events] == ["2"]
+
+    async def test_pending_questions_replayed_on_subscribe(self, entry_service):
+        service, store = entry_service
+        question = {"type": "ask_user_question", "question_id": "aq-1", "questions": [{"question": "选哪个?"}]}
+        manager = _FakeEntrySessionManager(status="running", pending=[question])
+        service.session_manager = manager
+        manager.queue.put_nowait({"type": "result", "subtype": "success", "is_error": False})
+
+        events = [_collect(e) async for e in service.stream_entry_events(SESSION_ID)]
+
+        question_events = [e for e in events if e[0] == "question"]
+        assert len(question_events) == 1
+        assert question_events[0][1]["question_id"] == "aq-1"
+
+
+class TestListSessionEntries:
+    async def test_response_shape_with_draft(self, entry_service):
+        service, store = entry_service
+        draft_state = {"draft": {"message_id": "m", "content": [], "rev": 3}, "rev": 3}
+        service.session_manager = _FakeEntrySessionManager(status="running", draft_state=draft_state)
+        await store.append(SESSION_ID, [{"type": "user", "uuid": "a"}])
+
+        result = await service.list_session_entries(SESSION_ID)
+
+        assert result["session_id"] == SESSION_ID
+        assert result["status"] == "running"
+        assert [e["seq"] for e in result["entries"]] == [0]
+        assert result["draft"]["message_id"] == "m"
+        assert result["draft_rev"] == 3
+
+    async def test_non_running_has_no_draft(self, entry_service):
+        service, store = entry_service
+        service.session_manager = _FakeEntrySessionManager(status="idle")
+        result = await service.list_session_entries(SESSION_ID, after_seq=-1)
+        assert result["draft"] is None
+        assert result["entries"] == []
+
+
+_FAKE_USER = CurrentUserInfo(id="default", sub="testuser", role="admin")
+PROJECT = "demo"
+PREFIX = f"/api/v1/projects/{PROJECT}/assistant"
+
+
+class _CursorCapturingService:
+    """记录 stream_entry_events 收到的 after_seq，验证路由层游标优先级。"""
+
+    def __init__(self):
+        self.captured_after = None
+        self.meta = make_session_meta(id=SESSION_ID, status="idle", project_name=PROJECT)
+
+    async def get_session(self, session_id):
+        return self.meta if session_id == SESSION_ID else None
+
+    async def stream_entry_events(self, session_id, *, meta=None, request=None, after_seq=-1):
+        self.captured_after = after_seq
+        yield ServerSentEvent(event="status", data={"status": "idle"})
+
+    async def list_session_entries(self, session_id, *, meta=None, after_seq=-1):
+        self.captured_after = after_seq
+        return {"session_id": session_id, "status": "idle", "entries": [], "draft": None, "draft_rev": 0}
+
+
+def _build_client(monkeypatch, fake_service) -> TestClient:
+    monkeypatch.setattr(assistant, "get_assistant_service", lambda: fake_service)
+    app = FastAPI()
+    app.dependency_overrides[get_current_user] = lambda: _FAKE_USER
+    app.dependency_overrides[get_current_user_flexible] = lambda: _FAKE_USER
+    app.dependency_overrides[get_translator] = lambda: make_translator()
+    app.include_router(assistant.router, prefix="/api/v1/projects/{project_name}/assistant")
+    return TestClient(app)
+
+
+class TestEntryStreamRouter:
+    def test_last_event_id_takes_precedence_over_after(self, monkeypatch):
+        fake = _CursorCapturingService()
+        with _build_client(monkeypatch, fake) as client:
+            resp = client.get(
+                f"{PREFIX}/sessions/{SESSION_ID}/entries/stream?after=2",
+                headers={"Last-Event-ID": "5"},
+            )
+        assert resp.status_code == 200
+        assert fake.captured_after == 5
+
+    def test_after_query_used_without_last_event_id(self, monkeypatch):
+        fake = _CursorCapturingService()
+        with _build_client(monkeypatch, fake) as client:
+            resp = client.get(f"{PREFIX}/sessions/{SESSION_ID}/entries/stream?after=3")
+        assert resp.status_code == 200
+        assert fake.captured_after == 3
+
+    def test_invalid_last_event_id_falls_back_to_after(self, monkeypatch):
+        fake = _CursorCapturingService()
+        with _build_client(monkeypatch, fake) as client:
+            client.get(
+                f"{PREFIX}/sessions/{SESSION_ID}/entries/stream?after=4",
+                headers={"Last-Event-ID": "not-a-number"},
+            )
+        assert fake.captured_after == 4
+
+    def test_entries_rest_endpoint(self, monkeypatch):
+        fake = _CursorCapturingService()
+        with _build_client(monkeypatch, fake) as client:
+            resp = client.get(f"{PREFIX}/sessions/{SESSION_ID}/entries?after=7")
+        assert resp.status_code == 200
+        assert resp.json()["session_id"] == SESSION_ID
+        assert fake.captured_after == 7
+
+    def test_entries_404_for_unknown_session(self, monkeypatch):
+        fake = _CursorCapturingService()
+        with _build_client(monkeypatch, fake) as client:
+            resp = client.get(f"{PREFIX}/sessions/unknown/entries")
+        assert resp.status_code == 404

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -227,6 +227,20 @@ class TestEventLogStore:
         await log_store.append("s1", [{"type": "user", "uuid": "a"}])
         assert await log_store.has_entries("s1") is True
 
+    async def test_delete_entry_rolls_back_accepted_user_entry(self, log_store: EventLogStore):
+        """受理失败补偿删除：条目连同幂等键一起消失，重试可重新受理。"""
+        entry = build_user_entry([{"type": "text", "text": "hi"}])
+        appended, _created = await log_store.append_user_entry("s1", entry, client_key="ck-1")
+
+        await log_store.delete_entry("s1", appended["seq"])
+
+        assert await log_store.list_after("s1") == []
+        assert await log_store.find_by_client_key("s1", "ck-1") is None
+        retry = build_user_entry([{"type": "text", "text": "hi"}])
+        again, created = await log_store.append_user_entry("s1", retry, client_key="ck-1")
+        assert created is True
+        assert again["seq"] == 0
+
 
 # ---------------------------------------------------------------------------
 # EventLogService — 懒生成
@@ -293,3 +307,19 @@ class TestLazyBackfill:
 
         entries = await service.list_entries("s1", None, after_seq=0)
         assert [e["uuid"] for e in entries] == ["b"]
+
+    async def test_backfill_lock_retained_when_transcript_empty(self, log_store: EventLogStore):
+        """空 transcript 不写入也不清锁：后来者与旧锁等待者保持互斥，
+        transcript 出现内容后并发首访不会重复灌入。"""
+        adapter = _FakeAdapter([])
+        service = EventLogService(log_store, adapter)
+
+        await service.ensure_backfilled("old", None)
+        assert "old" in service._backfill_locks  # pyright: ignore[reportPrivateUsage]
+
+        # transcript 补齐内容后，并发访问只灌入一次
+        adapter._messages = [{"type": "user", "content": "hi", "uuid": "u1"}]  # pyright: ignore[reportPrivateUsage]
+        await asyncio.gather(*[service.ensure_backfilled("old", None) for _ in range(5)])
+        assert len(await log_store.list_after("old")) == 1
+        # 写入成功后锁引用被清理
+        assert "old" not in service._backfill_locks  # pyright: ignore[reportPrivateUsage]

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -328,8 +328,6 @@ class TestLazyBackfill:
 
     async def test_backfill_skips_message_that_fails_normalization(self, log_store: EventLogStore, monkeypatch):
         """历史消息规范化单条抛异常时容错跳过，不让整个懒生成因一条脏数据失败。"""
-        import server.agent_runtime.event_log as event_log_module
-
         adapter = _FakeAdapter(
             [
                 {"type": "user", "content": "ok-1", "uuid": "u1", "timestamp": "2026-01-01T00:00:00Z"},
@@ -339,14 +337,12 @@ class TestLazyBackfill:
         )
         service = EventLogService(log_store, adapter)
 
-        original = event_log_module.normalize_sdk_message_to_entries
-
         def _boom_on_poison(message):
             if message.get("uuid") == "poison":
                 raise ValueError("boom")
-            return original(message)
+            return normalize_sdk_message_to_entries(message)
 
-        monkeypatch.setattr(event_log_module, "normalize_sdk_message_to_entries", _boom_on_poison)
+        monkeypatch.setattr("server.agent_runtime.event_log.normalize_sdk_message_to_entries", _boom_on_poison)
 
         entries = await service.list_entries("session-with-poison", None)
         assert [e["uuid"] for e in entries] == ["u1", "u2"]

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -308,14 +308,16 @@ class TestLazyBackfill:
         entries = await service.list_entries("s1", None, after_seq=0)
         assert [e["uuid"] for e in entries] == ["b"]
 
-    async def test_backfill_lock_retained_when_transcript_empty(self, log_store: EventLogStore):
-        """空 transcript 不写入也不清锁：后来者与旧锁等待者保持互斥，
-        transcript 出现内容后并发首访不会重复灌入。"""
+    async def test_backfill_lock_not_leaked_when_transcript_empty(self, log_store: EventLogStore):
+        """空 transcript 不写入：无协程持有/等待时锁对象随弱引用字典自动回收，
+        不会为每个空/无效会话永久驻留内存；转为有内容后并发首访仍只灌入一次
+        （互斥性质不受回收影响——同一 session_id 的并发等待者共享同一锁对象）。"""
         adapter = _FakeAdapter([])
         service = EventLogService(log_store, adapter)
 
-        await service.ensure_backfilled("old", None)
-        assert "old" in service._backfill_locks  # pyright: ignore[reportPrivateUsage]
+        for i in range(50):
+            await service.ensure_backfilled(f"empty-{i}", None)
+        assert len(service._backfill_locks) == 0  # pyright: ignore[reportPrivateUsage]
 
         # transcript 补齐内容后，并发访问只灌入一次
         adapter._messages = [{"type": "user", "content": "hi", "uuid": "u1"}]  # pyright: ignore[reportPrivateUsage]

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -222,6 +222,34 @@ class TestEventLogStore:
         assert [e["seq"] for e in entries] == list(range(8))
         assert {e["uuid"] for e in entries} == {f"u{i}" for i in range(8)}
 
+    async def test_append_retries_pk_conflict_even_without_literal_seq_in_message(
+        self, log_store: EventLogStore, monkeypatch
+    ):
+        """seq 竞争判定不依赖错误信息字面包含 "seq"：驱动/配置不同,主键冲突的
+        DETAIL 文案未必带这个词,只要不是 client_key 冲突就该按 seq 竞争重试
+        （该表仅有 (session_id, seq) 主键与 client_key 唯一索引两个约束）。"""
+        from sqlalchemy.exc import IntegrityError
+
+        calls = {"n": 0}
+        original_append_once = log_store._append_once  # pyright: ignore[reportPrivateUsage]
+
+        async def _flaky_append_once(session_id, entries, client_key):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise IntegrityError(
+                    "INSERT INTO agent_session_event_log ...",
+                    {},
+                    Exception('duplicate key value violates unique constraint "agent_session_event_log_pkey"'),
+                )
+            return await original_append_once(session_id, entries, client_key)
+
+        monkeypatch.setattr(log_store, "_append_once", _flaky_append_once)
+
+        result = await log_store.append("s1", [{"type": "user", "uuid": "u1"}])
+
+        assert calls["n"] == 2  # 首次撞主键冲突后重试一次即成功
+        assert result[0]["uuid"] == "u1"
+
     async def test_has_entries(self, log_store: EventLogStore):
         assert await log_store.has_entries("s1") is False
         await log_store.append("s1", [{"type": "user", "uuid": "a"}])

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -1,0 +1,295 @@
+"""会话事件日志：写入点定型、seq 单调、幂等键、懒生成。"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from lib.db.base import Base
+from server.agent_runtime.event_log import (
+    REPLAYED_USER_ECHO_KEY,
+    EventLogService,
+    EventLogStore,
+    build_user_entry,
+    normalize_sdk_message_to_entries,
+)
+
+
+@pytest.fixture()
+async def log_store():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield EventLogStore(session_factory=factory)
+    await engine.dispose()
+
+
+@pytest.fixture()
+async def file_log_store(tmp_path):
+    """文件 SQLite + NullPool：并发测试需要独立连接（内存库 StaticPool 会串扰）。"""
+    from sqlalchemy import event, pool
+
+    db_path = tmp_path / "event-log.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", poolclass=pool.NullPool)
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _set_sqlite_pragma(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA busy_timeout=30000")
+        cursor.execute("PRAGMA foreign_keys=OFF")
+        cursor.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield EventLogStore(session_factory=factory)
+    await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# normalize_sdk_message_to_entries — 写入点定型纯函数
+# ---------------------------------------------------------------------------
+
+
+class TestNormalize:
+    def test_assistant_message_becomes_single_entry_with_message_id(self):
+        entries = normalize_sdk_message_to_entries(
+            {
+                "type": "assistant",
+                "message_id": "msg_01",
+                "uuid": "u-1",
+                "content": [{"type": "text", "text": "你好"}],
+            }
+        )
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["type"] == "assistant"
+        assert entry["message_id"] == "msg_01"
+        assert entry["uuid"] == "u-1"
+        assert entry["content"] == [{"type": "text", "text": "你好"}]
+        assert entry["timestamp"]
+
+    def test_assistant_infers_untyped_blocks(self):
+        entries = normalize_sdk_message_to_entries(
+            {
+                "type": "assistant",
+                "content": [{"id": "tu-1", "name": "Bash", "input": {"command": "ls"}}],
+            }
+        )
+        assert entries[0]["content"][0]["type"] == "tool_use"
+
+    def test_tool_result_blocks_become_independent_entries(self):
+        entries = normalize_sdk_message_to_entries(
+            {
+                "type": "user",
+                "uuid": "u-2",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu-1", "content": "ok", "is_error": False},
+                    {"tool_use_id": "tu-2", "content": [{"type": "text", "text": "boom"}], "is_error": True},
+                ],
+            }
+        )
+        assert [e["type"] for e in entries] == ["tool_result", "tool_result"]
+        assert entries[0]["tool_use_id"] == "tu-1"
+        assert entries[0]["content"] == "ok"
+        assert entries[1]["tool_use_id"] == "tu-2"
+        assert entries[1]["content"] == "boom"
+        assert entries[1]["is_error"] is True
+        # 独立条目、不同 uuid
+        assert entries[0]["uuid"] != entries[1]["uuid"]
+
+    def test_mixed_user_content_splits_tool_results_from_text(self):
+        entries = normalize_sdk_message_to_entries(
+            {
+                "type": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu-1", "content": "ok"},
+                    {"type": "text", "text": "继续"},
+                ],
+            }
+        )
+        assert [e["type"] for e in entries] == ["tool_result", "user"]
+        assert entries[1]["content"] == [{"type": "text", "text": "继续"}]
+
+    def test_subagent_message_carries_parent_tool_use_id(self):
+        entries = normalize_sdk_message_to_entries(
+            {
+                "type": "assistant",
+                "parent_tool_use_id": "tu-parent",
+                "content": [{"type": "text", "text": "sub"}],
+            }
+        )
+        assert entries[0]["parent_tool_use_id"] == "tu-parent"
+
+        entries = normalize_sdk_message_to_entries(
+            {
+                "type": "user",
+                "parent_tool_use_id": "tu-parent",
+                "content": [{"type": "tool_result", "tool_use_id": "tu-sub", "content": "x"}],
+            }
+        )
+        assert entries[0]["parent_tool_use_id"] == "tu-parent"
+
+    def test_local_echo_and_replayed_echo_are_skipped(self):
+        assert normalize_sdk_message_to_entries({"type": "user", "content": "hi", "local_echo": True}) == []
+        assert normalize_sdk_message_to_entries({"type": "user", "content": "hi", REPLAYED_USER_ECHO_KEY: True}) == []
+
+    def test_stream_event_and_result_are_not_logged(self):
+        assert normalize_sdk_message_to_entries({"type": "stream_event", "event": {"type": "message_start"}}) == []
+        assert normalize_sdk_message_to_entries({"type": "result", "subtype": "success"}) == []
+        assert normalize_sdk_message_to_entries({"type": "runtime_status", "status": "idle"}) == []
+
+    def test_task_system_message_becomes_generic_system_entry(self):
+        entries = normalize_sdk_message_to_entries(
+            {
+                "type": "system",
+                "subtype": "task_notification",
+                "task_id": "t1",
+                "status": "completed",
+                "summary": "done",
+                "tool_use_id": "tu-1",
+            }
+        )
+        assert len(entries) == 1
+        assert entries[0]["type"] == "system"
+        assert entries[0]["subtype"] == "task_notification"
+        assert entries[0]["task_id"] == "t1"
+        assert entries[0]["task_status"] == "completed"
+
+    def test_other_system_subtypes_are_ignored(self):
+        assert normalize_sdk_message_to_entries({"type": "system", "subtype": "init", "session_id": "s"}) == []
+        assert normalize_sdk_message_to_entries({"type": "system", "subtype": "compact_boundary"}) == []
+
+    def test_plain_string_user_content(self):
+        entries = normalize_sdk_message_to_entries({"type": "user", "content": "[Request interrupted by user]"})
+        assert len(entries) == 1
+        assert entries[0]["type"] == "user"
+        assert entries[0]["content"] == [{"type": "text", "text": "[Request interrupted by user]"}]
+
+
+# ---------------------------------------------------------------------------
+# EventLogStore — seq 单调 / 幂等键 / 游标
+# ---------------------------------------------------------------------------
+
+
+class TestEventLogStore:
+    async def test_seq_is_monotonic_across_appends(self, log_store: EventLogStore):
+        first = await log_store.append("s1", [{"type": "user", "uuid": "a"}])
+        second = await log_store.append(
+            "s1", [{"type": "assistant", "uuid": "b"}, {"type": "tool_result", "uuid": "c"}]
+        )
+        assert [e["seq"] for e in first] == [0]
+        assert [e["seq"] for e in second] == [1, 2]
+
+    async def test_seq_isolated_per_session(self, log_store: EventLogStore):
+        await log_store.append("s1", [{"type": "user", "uuid": "a"}])
+        other = await log_store.append("s2", [{"type": "user", "uuid": "b"}])
+        assert other[0]["seq"] == 0
+
+    async def test_list_after_returns_only_later_entries(self, log_store: EventLogStore):
+        await log_store.append("s1", [{"type": "user", "uuid": "a"}, {"type": "assistant", "uuid": "b"}])
+        await log_store.append("s1", [{"type": "assistant", "uuid": "c"}])
+        entries = await log_store.list_after("s1", after_seq=0)
+        assert [e["uuid"] for e in entries] == ["b", "c"]
+        assert await log_store.list_after("s1", after_seq=2) == []
+
+    async def test_append_user_entry_idempotent_by_client_key(self, log_store: EventLogStore):
+        entry = build_user_entry([{"type": "text", "text": "hi"}])
+        first, created_first = await log_store.append_user_entry("s1", entry, client_key="ck-1")
+        retry = build_user_entry([{"type": "text", "text": "hi"}])
+        second, created_second = await log_store.append_user_entry("s1", retry, client_key="ck-1")
+
+        assert created_first is True
+        assert created_second is False
+        assert second["seq"] == first["seq"]
+        assert second["uuid"] == first["uuid"]
+        assert len(await log_store.list_after("s1")) == 1
+
+    async def test_append_user_entry_without_client_key(self, log_store: EventLogStore):
+        entry = build_user_entry([{"type": "text", "text": "hi"}])
+        result, created = await log_store.append_user_entry("s1", entry)
+        assert created is True
+        assert result["seq"] == 0
+
+    @pytest.mark.sqlite_only
+    async def test_concurrent_appends_keep_seq_unique(self, file_log_store: EventLogStore):
+        await asyncio.gather(*[file_log_store.append("s1", [{"type": "assistant", "uuid": f"u{i}"}]) for i in range(8)])
+        entries = await file_log_store.list_after("s1")
+        assert [e["seq"] for e in entries] == list(range(8))
+        assert {e["uuid"] for e in entries} == {f"u{i}" for i in range(8)}
+
+    async def test_has_entries(self, log_store: EventLogStore):
+        assert await log_store.has_entries("s1") is False
+        await log_store.append("s1", [{"type": "user", "uuid": "a"}])
+        assert await log_store.has_entries("s1") is True
+
+
+# ---------------------------------------------------------------------------
+# EventLogService — 懒生成
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapter:
+    def __init__(self, messages):
+        self._messages = messages
+        self.read_count = 0
+
+    async def read_raw_messages(self, sdk_session_id, project_cwd=None):
+        self.read_count += 1
+        return list(self._messages)
+
+
+class TestLazyBackfill:
+    async def test_backfills_from_transcript_once(self, log_store: EventLogStore):
+        adapter = _FakeAdapter(
+            [
+                {"type": "user", "content": "写第一章", "uuid": "u1", "timestamp": "2026-01-01T00:00:00Z"},
+                {
+                    "type": "assistant",
+                    "content": [{"type": "text", "text": "好的"}],
+                    "uuid": "a1",
+                    "timestamp": "2026-01-01T00:00:01Z",
+                },
+                {"type": "result", "subtype": "success", "uuid": "r1"},
+            ]
+        )
+        service = EventLogService(log_store, adapter)
+
+        entries = await service.list_entries("old-session", None)
+        assert [e["type"] for e in entries] == ["user", "assistant"]
+        assert [e["seq"] for e in entries] == [0, 1]
+        assert entries[0]["timestamp"] == "2026-01-01T00:00:00Z"
+
+        # 第二次访问不重复重放
+        again = await service.list_entries("old-session", None)
+        assert len(again) == 2
+        assert adapter.read_count == 1
+
+    async def test_concurrent_first_access_backfills_once(self, log_store: EventLogStore):
+        adapter = _FakeAdapter([{"type": "user", "content": "hi", "uuid": "u1"}])
+        service = EventLogService(log_store, adapter)
+
+        results = await asyncio.gather(*[service.list_entries("old", None) for _ in range(5)])
+        assert all(len(r) == 1 for r in results)
+        assert len(await log_store.list_after("old")) == 1
+
+    async def test_no_backfill_when_log_already_has_entries(self, log_store: EventLogStore):
+        adapter = _FakeAdapter([{"type": "user", "content": "transcript", "uuid": "t1"}])
+        service = EventLogService(log_store, adapter)
+        await log_store.append("s1", [{"type": "user", "uuid": "live", "content": []}])
+
+        entries = await service.list_entries("s1", None)
+        assert [e["uuid"] for e in entries] == ["live"]
+        assert adapter.read_count == 0
+
+    async def test_cursor_filtering(self, log_store: EventLogStore):
+        adapter = _FakeAdapter([])
+        service = EventLogService(log_store, adapter)
+        await log_store.append("s1", [{"type": "user", "uuid": "a"}, {"type": "assistant", "uuid": "b"}])
+
+        entries = await service.list_entries("s1", None, after_seq=0)
+        assert [e["uuid"] for e in entries] == ["b"]

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -325,3 +325,28 @@ class TestLazyBackfill:
         assert len(await log_store.list_after("old")) == 1
         # 写入成功后锁引用被清理
         assert "old" not in service._backfill_locks  # pyright: ignore[reportPrivateUsage]
+
+    async def test_backfill_skips_message_that_fails_normalization(self, log_store: EventLogStore, monkeypatch):
+        """历史消息规范化单条抛异常时容错跳过，不让整个懒生成因一条脏数据失败。"""
+        import server.agent_runtime.event_log as event_log_module
+
+        adapter = _FakeAdapter(
+            [
+                {"type": "user", "content": "ok-1", "uuid": "u1", "timestamp": "2026-01-01T00:00:00Z"},
+                {"type": "assistant", "content": [{"type": "text", "text": "poison"}], "uuid": "poison"},
+                {"type": "user", "content": "ok-2", "uuid": "u2", "timestamp": "2026-01-01T00:00:02Z"},
+            ]
+        )
+        service = EventLogService(log_store, adapter)
+
+        original = event_log_module.normalize_sdk_message_to_entries
+
+        def _boom_on_poison(message):
+            if message.get("uuid") == "poison":
+                raise ValueError("boom")
+            return original(message)
+
+        monkeypatch.setattr(event_log_module, "normalize_sdk_message_to_entries", _boom_on_poison)
+
+        entries = await service.list_entries("session-with-poison", None)
+        assert [e["uuid"] for e in entries] == ["u1", "u2"]

--- a/tests/agent_runtime/test_event_log_session_flow.py
+++ b/tests/agent_runtime/test_event_log_session_flow.py
@@ -204,3 +204,91 @@ class TestNewSessionEventLogFlow:
             assert len(entries) == 1
         finally:
             await manager.close_session(SDK_ID)
+
+    async def test_retry_while_running_returns_idempotent_success(self, manager: SessionManager):
+        """受理成功但响应丢失、轮次仍在运行时，同幂等键重试得到条目而非 400。"""
+        meta = await manager.meta_store.create("demo", SDK_ID)
+        client = FakeSDKClient(messages=[{"type": "result", "subtype": "success", "session_id": SDK_ID, "uuid": "r-1"}])
+        fake_options = SimpleNamespace(env=None)
+
+        with (
+            patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
+            patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
+            patch("server.agent_runtime.session_manager.tag_session", None),
+        ):
+            first = await manager.send_message(
+                SDK_ID,
+                "继续",
+                meta=meta,
+                user_entry=build_user_entry([{"type": "text", "text": "继续"}]),
+                client_key="ck-run",
+            )
+            try:
+                assert first is not None
+                manager.sessions[SDK_ID].status = "running"  # 模拟轮次仍在执行
+
+                retry = await manager.send_message(
+                    SDK_ID,
+                    "继续",
+                    meta=meta,
+                    user_entry=build_user_entry([{"type": "text", "text": "继续"}]),
+                    client_key="ck-run",
+                )
+                assert retry is not None
+                assert retry["seq"] == first["seq"]
+                assert client.sent_queries == ["继续"]  # 未重复投递
+            finally:
+                await manager.close_session(SDK_ID)
+
+    async def test_send_query_failure_rolls_back_entry_and_retry_delivers(self, manager: SessionManager):
+        """投递失败即受理失败：条目补偿删除，同幂等键重试重新受理并送达 SDK。"""
+        meta = await manager.meta_store.create("demo", SDK_ID)
+
+        class _FlakyQueryClient(FakeSDKClient):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.fail_next_query = True
+
+            async def query(self, prompt, session_id: str = "default") -> None:
+                if self.fail_next_query:
+                    self.fail_next_query = False
+                    raise RuntimeError("transport down")
+                await super().query(prompt, session_id)
+
+        client = _FlakyQueryClient(
+            messages=[{"type": "result", "subtype": "success", "session_id": SDK_ID, "uuid": "r-1"}]
+        )
+        fake_options = SimpleNamespace(env=None)
+
+        with (
+            patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
+            patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
+            patch("server.agent_runtime.session_manager.tag_session", None),
+        ):
+            with pytest.raises(RuntimeError):
+                await manager.send_message(
+                    SDK_ID,
+                    "继续",
+                    meta=meta,
+                    user_entry=build_user_entry([{"type": "text", "text": "继续"}]),
+                    client_key="ck-fail",
+                )
+            try:
+                # 受理条目已回滚，日志无残留
+                assert await manager.event_log_store.list_after(SDK_ID) == []
+
+                # actor 已随失败退出；关闭会话模拟冷恢复后重试
+                await manager.close_session(SDK_ID)
+                retry = await manager.send_message(
+                    SDK_ID,
+                    "继续",
+                    meta=meta,
+                    user_entry=build_user_entry([{"type": "text", "text": "继续"}]),
+                    client_key="ck-fail",
+                )
+                # 重试重新受理（seq 重新分配）且真正送达 SDK
+                assert retry is not None
+                assert retry["seq"] == 0
+                assert client.sent_queries == ["继续"]
+            finally:
+                await manager.close_session(SDK_ID)

--- a/tests/agent_runtime/test_event_log_session_flow.py
+++ b/tests/agent_runtime/test_event_log_session_flow.py
@@ -1,0 +1,206 @@
+"""FakeSDKClient 驱动会话：事件日志端到端产出（验收：seq 单调、类型正确）。"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from lib.db.base import Base
+from server.agent_runtime.event_log import EventLogStore, build_user_entry
+from server.agent_runtime.session_manager import SessionManager
+from server.agent_runtime.session_store import SessionMetaStore
+from tests.fakes import FakeSDKClient
+
+SDK_ID = "sdk-e2e-1"
+
+
+@pytest.fixture()
+async def db_factory(tmp_path):
+    """文件 SQLite + NullPool：本测试的写入（inbox 任务）与轮询读并发，
+    内存库 StaticPool 共享单连接会让事务交错互相破坏。"""
+    from sqlalchemy import event, pool
+
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'flow.db'}",
+        poolclass=pool.NullPool,
+    )
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _set_sqlite_pragma(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA busy_timeout=30000")
+        cursor.execute("PRAGMA foreign_keys=OFF")
+        cursor.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture()
+async def manager(tmp_path, db_factory):
+    return SessionManager(
+        project_root=tmp_path,
+        data_dir=tmp_path / "data",
+        meta_store=SessionMetaStore(session_factory=db_factory),
+        event_log_store=EventLogStore(session_factory=db_factory),
+    )
+
+
+def _new_session_messages() -> list[dict]:
+    """一轮完整对话：init → 用户回放 → 流式 → assistant(工具) → tool_result → subagent → result。"""
+    return [
+        {"type": "system", "subtype": "init", "session_id": SDK_ID, "uuid": "init-1"},
+        # SDK 回放的用户消息（POST 受理时已写日志，须被跳过）
+        {"type": "user", "content": "帮我写分镜", "uuid": "sdk-u1", "session_id": SDK_ID},
+        {
+            "type": "stream_event",
+            "session_id": SDK_ID,
+            "uuid": "se-1",
+            "event": {"type": "message_start", "message": {"id": "msg_01"}},
+        },
+        {
+            "type": "stream_event",
+            "session_id": SDK_ID,
+            "uuid": "se-2",
+            "event": {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "好的"}},
+        },
+        {
+            "type": "assistant",
+            "message_id": "msg_01",
+            "uuid": "a-1",
+            "session_id": SDK_ID,
+            "content": [
+                {"type": "text", "text": "好的"},
+                {"type": "tool_use", "id": "tu-1", "name": "Bash", "input": {"command": "ls"}},
+            ],
+        },
+        {
+            "type": "user",
+            "uuid": "u-tr-1",
+            "session_id": SDK_ID,
+            "content": [{"type": "tool_result", "tool_use_id": "tu-1", "content": "file.txt", "is_error": False}],
+        },
+        {
+            "type": "assistant",
+            "message_id": "msg_02",
+            "uuid": "a-sub",
+            "session_id": SDK_ID,
+            "parent_tool_use_id": "tu-1",
+            "content": [{"type": "text", "text": "子任务输出"}],
+        },
+        {"type": "result", "subtype": "success", "is_error": False, "session_id": SDK_ID, "uuid": "r-1"},
+    ]
+
+
+async def _wait_for_entries(store: EventLogStore, session_id: str, count: int, timeout: float = 5.0) -> list[dict]:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        entries = await store.list_after(session_id)
+        if len(entries) >= count:
+            return entries
+        if asyncio.get_running_loop().time() >= deadline:
+            return entries
+        await asyncio.sleep(0.02)
+
+
+class TestNewSessionEventLogFlow:
+    async def test_full_round_produces_typed_monotonic_entries(self, manager: SessionManager):
+        client = FakeSDKClient(messages=_new_session_messages())
+        fake_options = SimpleNamespace(env=None)
+
+        with (
+            patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
+            patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
+            patch("server.agent_runtime.session_manager.tag_session", None),
+        ):
+            user_entry = build_user_entry([{"type": "text", "text": "帮我写分镜"}])
+            sdk_id = await manager.send_new_session(
+                "demo",
+                "帮我写分镜",
+                user_entry=user_entry,
+                client_key="ck-new-1",
+            )
+
+        assert sdk_id == SDK_ID
+        # POST 受理响应的权威条目：seq 0、身份已分配
+        managed = manager.sessions[SDK_ID]
+        assert managed.initial_user_log_entry is not None
+        assert managed.initial_user_log_entry["seq"] == 0
+        assert managed.initial_user_log_entry["type"] == "user"
+
+        entries = await _wait_for_entries(manager.event_log_store, SDK_ID, 4)
+        try:
+            assert [e["seq"] for e in entries] == [0, 1, 2, 3]
+            assert [e["type"] for e in entries] == ["user", "assistant", "tool_result", "assistant"]
+
+            # 用户条目（受理写入，SDK 回放副本未产生重复）
+            assert entries[0]["content"] == [{"type": "text", "text": "帮我写分镜"}]
+
+            # assistant 条目携带 message_id（draft 精确替换身份）
+            assert entries[1]["message_id"] == "msg_01"
+            assert entries[1]["content"][1]["type"] == "tool_use"
+
+            # tool_result 是独立条目且引用 tool_use_id，不伪装成 user 消息
+            assert entries[2]["tool_use_id"] == "tu-1"
+            assert entries[2]["content"] == "file.txt"
+            assert entries[2]["is_error"] is False
+
+            # subagent 条目带 parent_tool_use_id 收录
+            assert entries[3]["parent_tool_use_id"] == "tu-1"
+
+            # 一轮结束后 draft 已随 result 丢弃
+            assert manager.get_draft_state(SDK_ID)["draft"] is None
+        finally:
+            await manager.close_session(SDK_ID)
+
+    async def test_send_message_writes_user_entry_before_query(self, manager: SessionManager, db_factory):
+        meta = await manager.meta_store.create("demo", SDK_ID)
+        client = FakeSDKClient(messages=[{"type": "result", "subtype": "success", "session_id": SDK_ID, "uuid": "r-1"}])
+        fake_options = SimpleNamespace(env=None)
+
+        with (
+            patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
+            patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
+            patch("server.agent_runtime.session_manager.tag_session", None),
+        ):
+            user_entry = build_user_entry([{"type": "text", "text": "继续"}])
+            log_entry = await manager.send_message(
+                SDK_ID,
+                "继续",
+                meta=meta,
+                user_entry=user_entry,
+                client_key="ck-2",
+            )
+
+        try:
+            assert log_entry is not None
+            assert log_entry["seq"] == 0
+            assert client.sent_queries == ["继续"]
+
+            # 同一幂等键重试：返回既有条目，不重复送 SDK
+            retry_entry = build_user_entry([{"type": "text", "text": "继续"}])
+            managed = manager.sessions[SDK_ID]
+            managed.status = "idle"  # 模拟上一轮已结束
+            second = await manager.send_message(
+                SDK_ID,
+                "继续",
+                meta=meta,
+                user_entry=retry_entry,
+                client_key="ck-2",
+            )
+            assert second is not None
+            assert second["seq"] == log_entry["seq"]
+            assert second["uuid"] == log_entry["uuid"]
+            assert client.sent_queries == ["继续"]  # 未重复投递
+            entries = await manager.event_log_store.list_after(SDK_ID)
+            assert len(entries) == 1
+        finally:
+            await manager.close_session(SDK_ID)

--- a/tests/test_assistant_router_full.py
+++ b/tests/test_assistant_router_full.py
@@ -21,7 +21,7 @@ class _FakeService:
             "bad": make_session_meta(id="bad", project_name=PROJECT),
         }
 
-    async def send_or_create(self, project_name, content, session_id=None, images=None, locale=None):
+    async def send_or_create(self, project_name, content, session_id=None, images=None, locale=None, client_key=None):
         if project_name == "missing":
             raise FileNotFoundError(project_name)
         if not content.strip() and not images:
@@ -186,7 +186,9 @@ class TestAssistantRouterFull:
         """TimeoutError 应返回 504。"""
         fake = _FakeService()
 
-        async def _timeout_send_or_create(project_name, content, session_id=None, images=None, locale=None):
+        async def _timeout_send_or_create(
+            project_name, content, session_id=None, images=None, locale=None, client_key=None
+        ):
             raise TimeoutError("timeout")
 
         fake.send_or_create = _timeout_send_or_create

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -36,6 +36,16 @@ class _FakeMetaStore:
         return self.metas.pop(session_id, None) is not None
 
 
+class _FakeEventLogService:
+    """No-op 事件日志：单测聚焦 service 编排，不触达真实 DB。"""
+
+    def __init__(self):
+        self.backfilled = []
+
+    async def ensure_backfilled(self, session_id, project_cwd):
+        self.backfilled.append(session_id)
+
+
 class _FakeSessionManager:
     def __init__(self):
         self.sessions = {}
@@ -169,6 +179,7 @@ class TestAssistantServiceMore:
         service.pm = _FakePM(valid_project="demo")
         service.session_manager = sm
         service.meta_store = _FakeMetaStore([meta])
+        service.event_log = _FakeEventLogService()
 
         listed = await service.list_sessions()
         assert len(listed) == 1
@@ -181,13 +192,13 @@ class TestAssistantServiceMore:
 
         # send_or_create — new session (no session_id)
         new_result = await service.send_or_create("demo", "hello")
-        assert new_result == {"status": "accepted", "session_id": "sdk-new-id"}
+        assert new_result == {"status": "accepted", "session_id": "sdk-new-id", "entry": None}
         assert len(sm.new_sessions) == 1
         assert sm.new_sessions[0][0] == "demo"
 
         # send_or_create — existing session
         existing_result = await service.send_or_create("demo", "world", session_id="s1")
-        assert existing_result == {"status": "accepted", "session_id": "s1"}
+        assert existing_result == {"status": "accepted", "session_id": "s1", "entry": None}
         assert sm.sent == [("s1", "world")]
 
         # send_or_create — empty message raises ValueError
@@ -223,6 +234,7 @@ class TestAssistantServiceMore:
         service.pm = _FakePM(valid_project="demo")
         service.session_manager = sm
         service.meta_store = _FakeMetaStore([meta])
+        service.event_log = _FakeEventLogService()
 
         await service.send_or_create("demo", "world", session_id="s1", locale="en")
 
@@ -240,6 +252,7 @@ class TestAssistantServiceMore:
         service.pm = _FakePM(valid_project="demo")
         service.session_manager = sm
         service.meta_store = _FakeMetaStore([meta])
+        service.event_log = _FakeEventLogService()
 
         image = SimpleNamespace(data="ZmFrZQ==", media_type="image/png")
         await service.send_or_create("demo", "hello", session_id="s1", images=[image], locale="vi")

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -261,6 +261,45 @@ class TestAssistantServiceMore:
         assert sm.sent_kwargs[0]["echo_content"] is not None
 
     @pytest.mark.asyncio
+    async def test_send_or_create_concurrent_same_client_key_creates_one_session(self, tmp_path):
+        """同一 client_key 的并发新建请求应在 send_new_session 完成前互斥等待，
+        不因在途窗口各自建会话、重复执行同一 prompt。"""
+        service = AssistantService(project_root=tmp_path)
+        sm = _FakeSessionManager()
+        service.pm = _FakePM(valid_project="demo")
+        service.session_manager = sm
+        service.meta_store = _FakeMetaStore([])
+        service.event_log = _FakeEventLogService()
+
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_send_new_session(project_name, prompt, **kwargs):
+            entered.set()
+            await release.wait()
+            sm.new_sessions.append((project_name, prompt))
+            return "sdk-new-id"
+
+        sm.send_new_session = slow_send_new_session
+
+        async def fake_find_by_client_key(session_id, client_key):
+            return {"seq": 0, "type": "user", "content": []}
+
+        service.event_log_store.find_by_client_key = fake_find_by_client_key
+
+        task1 = asyncio.create_task(service.send_or_create("demo", "hello", client_key="ck-race"))
+        await asyncio.wait_for(entered.wait(), timeout=0.2)
+        task2 = asyncio.create_task(service.send_or_create("demo", "hello", client_key="ck-race"))
+        await asyncio.sleep(0)  # 让 task2 跑到锁等待处挂起
+        release.set()
+
+        result1 = await task1
+        result2 = await task2
+
+        assert len(sm.new_sessions) == 1  # 只建了一个会话，未因在途窗口重复投递
+        assert result1["session_id"] == result2["session_id"] == "sdk-new-id"
+
+    @pytest.mark.asyncio
     async def test_delete_session_closes_active_session_before_delete(self, tmp_path):
         service = AssistantService(project_root=tmp_path)
         meta = make_session_meta(id="s1")


### PR DESCRIPTION
## 范围

- 后端 `server/agent_runtime/`：新增 `event_log.py`（事件日志存储 + 懒生成）、`entry_pipeline.py`（live 写入点 + draft 累积）；`service.py` / `session_manager.py` 接入受理写日志、entry SSE 流；`routers/assistant.py` 新增 `GET /sessions/{id}/entries` 与 `GET /sessions/{id}/entries/stream`
- 数据层：新增 `agent_session_event_log` 表（每会话单调 seq、append-only）与迁移；与 SDK transcript 表并存是有意双写（前者 UI 读模型、后者 agent 记忆）
- 前端：`entry-projection.ts`（entries → Turn[] 纯函数投影）、assistant store 改为 entries/draft 驱动、`useAssistantSession` 改走 entry 流 + 游标续传
- **明确不动**：旧 `/sessions/{id}/stream` SSE 端点与 StreamProjector 管线（死代码清理由 #1057 承接）；interrupt / task 通知 / skill / subagent 的专属定型与归组呈现（#1054、#1056 承接）；status 状态机不变

## 变更

- 会话事件日志端到端闭环：SDK 消息流在写入点定型入库（tool_result 独立条目引用 tool_use_id；subagent 条目带 parent_tool_use_id；stream_event 不入日志）
- 用户消息受理新契约：POST 先写日志分配身份、响应即权威条目；client_key 幂等（含新会话路径与 running 期间重试）；发送期间输入锁定、失败内容保留原地
- SSE entry 流：事件 id 即 seq，Last-Event-ID / `?after=` 游标续传；终态由 log_turn_complete 触发，保证末条条目先于终态送达
- 流式预览（draft）：服务端内存态、身份为 message_id；delta 瞬时事件；重连首帧快照携带累积态（含工具参数 partial JSON 前缀）；完成时被同 id 权威条目精确替换
- 旧会话首次访问从 transcript 懒生成主时间线；前端实时 / 刷新 / 历史回放统一读日志，无本地合成消息、无内容比对去重
- 可靠性加固（本地审查修复）：投递失败补偿删除受理条目、写入点落库有界重试、懒生成锁竞态修复、中断竞态不再产生重复用户条目、并行 subagent 流式增量按 parent 过滤、前端冷读按 seq 并集合并 + 发送跳档补缺口

## 验收清单

- [x] 本地已跑相关测试：`uv run python -m pytest`（5728 passed）；`cd frontend && pnpm lint && pnpm check`（828 passed）；`uv run ruff check . && uv run basedpyright`（0 error）
- [x] 手动验证了改动所声称的行为：验收标准逐条对照测试覆盖（seq 单调与条目定型 `test_event_log_session_flow`、游标续传 `test_entry_stream`、幂等受理 `test_event_log` / `test_event_log_session_flow`、draft 精确替换 `test_entry_pipeline`、懒生成 `test_event_log`、投影纯函数 `entry-projection.test.ts`）
- [ ] 新增面向用户文案已加 zh/en 翻译（如适用）——本 PR 无新增面向用户文案
- [x] 无新增 ESLint disable；若有，已在本 PR 底部以表格列出 `rule | file:line | 理由`（`useAssistantSession.ts` 内 1 处 `react-hooks/immutability` 为 SSE 自引用重连所需，注释已说明）
- [ ] CODEOWNERS 要求的 review 已请求

## 已知 defer

- 前端每条直播条目全量重投影的 O(n²) 开销：#1058
- 旧 snapshot / turn patch SSE 管线（含 DraftAssistantProjector 与内容比对去重）为死代码，删除由 #1057 承接

Closes #1053


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 引入“会话事件条目”作为唯一时间线渲染来源，支持 draft/delta 预览与断点续订的冷读分页及 Entries SSE（游标与 Last-Event-ID）。
  * 新增会话条目查询与流式接口；发送支持图片，并加入请求幂等键（client_key），成功返回权威条目/状态。
* **Bug 修复**
  * 仅在发送被接受后才清空输入/附件；发送阶段提示更准确；失败不生成乐观内容并保持可重试状态。
* **测试**
  * 重构并新增 entries、草稿投影、事件日志与 SSE 的全面用例覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->