### PR TITLE
fix(assistant): 新会话首条消息写入失败不再静默丢失，发送方即时收到错误

### DIFF
--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -149,6 +149,9 @@ class ManagedSession:
     # 保证用户条目先于任何 assistant 条目分配身份。
     pending_initial_user_entry: dict[str, Any] | None = None
     initial_user_log_entry: dict[str, Any] | None = None
+    # 首条用户消息落库失败的异常：inbox 任务记录，send_new_session 醒来后
+    # 据此显式回报失败（事件日志是时间线唯一读源，seq 0 缺失不可接受）。
+    initial_user_entry_error: Exception | None = None
     last_user_prompt: str = ""
     assistant_model: str = ""
     interrupt_requested: bool = False
@@ -586,6 +589,8 @@ class SessionManager:
             in case it is stuck elsewhere.
             """
             self.sessions.pop(temp_id, None)
+            # sdk_session_id 就绪后 key swap 已把会话挂到正式 id 下，两个键都清。
+            self.sessions.pop(managed.session_id, None)
             try:
                 await managed.send_disconnect()
             except Exception:
@@ -642,6 +647,21 @@ class SessionManager:
         assert sdk_id is not None
         # Key swap already done in _on_sdk_session_id_received
         assert managed.session_id == sdk_id
+
+        if managed.initial_user_entry_error is not None:
+            # 首条用户消息落库失败即受理失败：事件日志是时间线唯一读源，
+            # seq 0 缺失的会话开头永远无法呈现。与常规受理路径同语义——
+            # 失败显式回报（调用方收到异常）、状态回写 error、会话不再后台
+            # 续跑。先清理再回写状态：inbox 处理 result 时 _finalize_turn
+            # 会写终态，清理完成后写入的 error 才不会被并发覆盖。
+            managed.pending_user_echoes.clear()
+            managed.cancel_pending_questions("initial user entry persist failed")
+            await _cleanup_on_error()
+            try:
+                await self.meta_store.update_status(sdk_id, "error")
+            except Exception:
+                logger.exception("持久化 error 状态失败 session_id=%s", sdk_id)
+            raise RuntimeError("新会话首条用户消息写入事件日志失败") from managed.initial_user_entry_error
 
         return sdk_id
 
@@ -1396,7 +1416,10 @@ class SessionManager:
                     )
                     managed.initial_user_log_entry = authoritative
                     managed.channel.broadcast({"type": "log_entry", "session_id": sdk_id, "entry": authoritative})
-                except Exception:
+                except Exception as exc:
+                    # 不静默吞掉：记录异常供 send_new_session 醒来后显式回报
+                    # 失败（清理会话 + 状态回写 error + 向调用方抛出）。
+                    managed.initial_user_entry_error = exc
                     logger.exception("新会话用户条目写入事件日志失败 session_id=%s", sdk_id)
             # Key swap: replace temp_id with real sdk_id in sessions dict
             # BEFORE signaling the event. This prevents _finalize_turn from

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -656,6 +656,11 @@ class SessionManager:
             # 会写终态，清理完成后写入的 error 才不会被并发覆盖。
             managed.pending_user_echoes.clear()
             managed.cancel_pending_questions("initial user entry persist failed")
+            # 提前置内存态为 error：_cleanup_on_error 取消 _process_task 时，
+            # _process_inbox 的 CancelledError 分支会依据 status == "running"
+            # 判断是否需要走 interrupted 终态；提前置位避免多写一次 interrupted
+            # 并广播一次多余的状态跳变，DB 落库仍留到 cleanup 完成之后。
+            managed.status = "error"
             await _cleanup_on_error()
             try:
                 await self.meta_store.update_status(sdk_id, "error")

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -712,6 +712,11 @@ class SessionManager:
                 if managed.entry_pipeline is not None and managed.resolved_sdk_id is not None:
                     await managed.entry_pipeline.handle_message(msg_dict)
                 if msg_dict.get("type") == "result":
+                    if managed.initial_user_entry_error is not None:
+                        # 首条用户消息落库已失败，send_new_session 的错误清理路径
+                        # 即将取消本任务；此处短路不再 finalize，避免先广播/落库
+                        # 非 error 终态（如 completed），随后又被改写为 error。
+                        continue
                     try:
                         await self._finalize_turn(managed, msg_dict)
                     except Exception:

--- a/server/routers/agent_chat.py
+++ b/server/routers/agent_chat.py
@@ -200,6 +200,9 @@ async def agent_chat(
         raise HTTPException(status_code=504, detail=_t("sdk_session_timeout"))
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc))
+    except Exception:
+        logger.exception("请求处理失败")
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
     # 收集回复（带超时）
     reply, status = await _collect_reply(service, session_id, SYNC_CHAT_TIMEOUT)

--- a/tests/agent_runtime/test_event_log_session_flow.py
+++ b/tests/agent_runtime/test_event_log_session_flow.py
@@ -505,6 +505,7 @@ class TestNewSessionEventLogFlow:
         """新会话首条用户消息落库失败：受理显式失败，会话进入可观察的 error 态。"""
         client = FakeSDKClient(messages=_new_session_messages())
         fake_options = SimpleNamespace(env=None)
+        update_status_spy = AsyncMock(wraps=manager.meta_store.update_status)
 
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
@@ -515,6 +516,7 @@ class TestNewSessionEventLogFlow:
                 "append_user_entry",
                 new=AsyncMock(side_effect=RuntimeError("db down")),
             ),
+            patch.object(manager.meta_store, "update_status", new=update_status_spy),
         ):
             with pytest.raises(RuntimeError):
                 await manager.send_new_session(
@@ -531,6 +533,11 @@ class TestNewSessionEventLogFlow:
         # 会话已随失败清理：不残留内存态、SDK 连接已断开
         assert SDK_ID not in manager.sessions
         assert client.disconnected is True
+        # 内存态提前置 error：cleanup 取消 _process_task 时不应再走 interrupted
+        # 分支多写一次终态（否则 DB 会先落 interrupted 再落 error）
+        statuses_written = [call.args[1] for call in update_status_spy.call_args_list]
+        assert "interrupted" not in statuses_written
+        assert statuses_written.count("error") == 1
 
     async def test_initial_user_entry_retry_after_failure_delivers(self, manager: SessionManager):
         """落库失败后同幂等键重试：条目无残留短路，重试重新受理并分配 seq 0。"""

--- a/tests/agent_runtime/test_event_log_session_flow.py
+++ b/tests/agent_runtime/test_event_log_session_flow.py
@@ -563,8 +563,8 @@ class TestNewSessionEventLogFlow:
                         client_key="ck-retry-new",
                     )
 
-            # 失败会话无用户条目残留，重试不会被幂等键短路
-            assert await manager.event_log_store.find_by_client_key(SDK_ID, "ck-retry-new") is None
+            # 失败会话（SDK_ID）本身无任何条目残留：append 写入真失败，非部分写入
+            assert not await manager.event_log_store.has_entries(SDK_ID)
 
             sdk_id = await manager.send_new_session(
                 "demo",
@@ -578,5 +578,8 @@ class TestNewSessionEventLogFlow:
             assert managed.initial_user_log_entry is not None
             assert managed.initial_user_log_entry["seq"] == 0
             assert managed.initial_user_entry_error is None
+            # 同幂等键在重试会话下正确解析到新写入的条目，未短路到失败会话
+            resolved = await manager.event_log_store.find_by_client_key(retry_sdk_id, "ck-retry-new")
+            assert resolved == managed.initial_user_log_entry
         finally:
             await manager.close_session(retry_sdk_id)

--- a/tests/agent_runtime/test_event_log_session_flow.py
+++ b/tests/agent_runtime/test_event_log_session_flow.py
@@ -539,6 +539,46 @@ class TestNewSessionEventLogFlow:
         assert "interrupted" not in statuses_written
         assert statuses_written.count("error") == 1
 
+    async def test_initial_user_entry_failure_skips_finalize_for_early_result(self, manager: SessionManager):
+        """首条用户消息落库失败后，同一轮内紧跟到达的 result 不应被 finalize：
+        否则会先广播/落库非 error 终态（如 completed），随后又被错误清理路径改写为
+        error，造成状态短暂跳变。"""
+        client = FakeSDKClient(
+            messages=[
+                {"type": "system", "subtype": "init", "session_id": SDK_ID, "uuid": "init-1"},
+                {"type": "result", "subtype": "success", "is_error": False, "session_id": SDK_ID, "uuid": "r-1"},
+            ]
+        )
+        fake_options = SimpleNamespace(env=None)
+        update_status_spy = AsyncMock(wraps=manager.meta_store.update_status)
+
+        with (
+            patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
+            patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
+            patch("server.agent_runtime.session_manager.tag_session", None),
+            patch.object(
+                manager.event_log_store,
+                "append_user_entry",
+                new=AsyncMock(side_effect=RuntimeError("db down")),
+            ),
+            patch.object(manager.meta_store, "update_status", new=update_status_spy),
+        ):
+            with pytest.raises(RuntimeError):
+                await manager.send_new_session(
+                    "demo",
+                    "帮我写分镜",
+                    user_entry=build_user_entry([{"type": "text", "text": "帮我写分镜"}]),
+                    client_key="ck-fail-early-result",
+                )
+
+        meta = await manager.meta_store.get(SDK_ID)
+        assert meta is not None
+        assert meta.status == "error"
+        # "running" 是新会话建立时的常规写入；result 被短路未 finalize，
+        # 不应出现 finalize 才会写入的 completed/idle 等中间终态
+        statuses_written = [call.args[1] for call in update_status_spy.call_args_list]
+        assert statuses_written == ["running", "error"]
+
     async def test_initial_user_entry_retry_after_failure_delivers(self, manager: SessionManager):
         """落库失败后同幂等键重试：条目无残留短路，重试重新受理并分配 seq 0。"""
         retry_sdk_id = "sdk-e2e-retry"

--- a/tests/agent_runtime/test_event_log_session_flow.py
+++ b/tests/agent_runtime/test_event_log_session_flow.py
@@ -500,3 +500,83 @@ class TestNewSessionEventLogFlow:
                 assert client.sent_queries == ["继续"]
             finally:
                 await manager.close_session(SDK_ID)
+
+    async def test_initial_user_entry_write_failure_reports_error(self, manager: SessionManager):
+        """新会话首条用户消息落库失败：受理显式失败，会话进入可观察的 error 态。"""
+        client = FakeSDKClient(messages=_new_session_messages())
+        fake_options = SimpleNamespace(env=None)
+
+        with (
+            patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
+            patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
+            patch("server.agent_runtime.session_manager.tag_session", None),
+            patch.object(
+                manager.event_log_store,
+                "append_user_entry",
+                new=AsyncMock(side_effect=RuntimeError("db down")),
+            ),
+        ):
+            with pytest.raises(RuntimeError):
+                await manager.send_new_session(
+                    "demo",
+                    "帮我写分镜",
+                    user_entry=build_user_entry([{"type": "text", "text": "帮我写分镜"}]),
+                    client_key="ck-fail-new",
+                )
+
+        # 状态回写：会话进入可观察的 error 态而非静默成功
+        meta = await manager.meta_store.get(SDK_ID)
+        assert meta is not None
+        assert meta.status == "error"
+        # 会话已随失败清理：不残留内存态、SDK 连接已断开
+        assert SDK_ID not in manager.sessions
+        assert client.disconnected is True
+
+    async def test_initial_user_entry_retry_after_failure_delivers(self, manager: SessionManager):
+        """落库失败后同幂等键重试：条目无残留短路，重试重新受理并分配 seq 0。"""
+        retry_sdk_id = "sdk-e2e-retry"
+        failing_client = FakeSDKClient(messages=_new_session_messages())
+        retry_client = FakeSDKClient(
+            messages=[
+                {"type": "system", "subtype": "init", "session_id": retry_sdk_id, "uuid": "init-2"},
+                {"type": "result", "subtype": "success", "is_error": False, "session_id": retry_sdk_id, "uuid": "r-2"},
+            ]
+        )
+        clients = iter([failing_client, retry_client])
+        fake_options = SimpleNamespace(env=None)
+
+        with (
+            patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
+            patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: next(clients)),
+            patch("server.agent_runtime.session_manager.tag_session", None),
+        ):
+            with patch.object(
+                manager.event_log_store,
+                "append_user_entry",
+                new=AsyncMock(side_effect=RuntimeError("db down")),
+            ):
+                with pytest.raises(RuntimeError):
+                    await manager.send_new_session(
+                        "demo",
+                        "帮我写分镜",
+                        user_entry=build_user_entry([{"type": "text", "text": "帮我写分镜"}]),
+                        client_key="ck-retry-new",
+                    )
+
+            # 失败会话无用户条目残留，重试不会被幂等键短路
+            assert await manager.event_log_store.find_by_client_key(SDK_ID, "ck-retry-new") is None
+
+            sdk_id = await manager.send_new_session(
+                "demo",
+                "帮我写分镜",
+                user_entry=build_user_entry([{"type": "text", "text": "帮我写分镜"}]),
+                client_key="ck-retry-new",
+            )
+        try:
+            assert sdk_id == retry_sdk_id
+            managed = manager.sessions[retry_sdk_id]
+            assert managed.initial_user_log_entry is not None
+            assert managed.initial_user_log_entry["seq"] == 0
+            assert managed.initial_user_entry_error is None
+        finally:
+            await manager.close_session(retry_sdk_id)

--- a/tests/test_agent_chat_router.py
+++ b/tests/test_agent_chat_router.py
@@ -102,6 +102,22 @@ class TestAgentChatEndpoint:
             )
         assert resp.status_code == 404
 
+    def test_unexpected_error_returns_500(self, monkeypatch):
+        """send_or_create 抛出未被专门捕获的异常（如事件日志写入失败）时，
+        端点须显式回报 500 而非让异常穿透——与 /sessions/send 的兜底语义一致。
+        """
+        mock_service = self._patch_service(monkeypatch)
+        mock_service.send_or_create = AsyncMock(side_effect=RuntimeError("新会话首条用户消息写入事件日志失败"))
+        with _make_client() as client:
+            resp = client.post(
+                "/api/v1/agent/chat",
+                json={
+                    "project_name": "demo",
+                    "message": "帮我写剧本",
+                },
+            )
+        assert resp.status_code == 500
+
     def test_timeout_status_propagated(self, monkeypatch):
         self._patch_service(monkeypatch, reply_text="部分响应", status="timeout")
         with _make_client() as client:


### PR DESCRIPTION
Closes #1063

## 范围

- 动：`server/agent_runtime/session_manager.py`（新会话首条用户消息写入事件日志失败的处理路径）、`server/routers/agent_chat.py`（同步端点的兜底异常捕获）
- 不动：常规消息受理路径（`send_message`）已有的失败处理逻辑，仅参照其语义

## 变更

- 新会话首条用户消息落库失败时不再静默吞掉：记录异常到 `ManagedSession.initial_user_entry_error`，`send_new_session` 醒来后据此清理会话（断连 + 取消 pending 状态）、状态回写 `error`、向调用方显式抛出异常
- `/agent/chat` 同步端点补齐 catch-all 异常处理，避免上述新异常未被专门捕获而穿透（与 `/sessions/send` 已有的兜底语义一致）
- 补充失败路径测试：写入失败即时报错、失败后同幂等键重试可正常受理

## 验证说明

- `uv run python -m pytest`：5681 passed
- `uv run ruff check . && uv run ruff format --check .`：全部通过
- `uv run basedpyright`：0 error（与改动前一致的 753 条既有 warning）
- 本地审查阶段额外跑了一轮 workflow 化 `/code-review`（xhigh），发现并修复两处：
  - `/agent/chat` 端点缺少对新增 RuntimeError 的兜底捕获（已修复并补测试）
  - 重试回归测试的一处断言查错了 session_id，恒真、无法捕捉真实回归（已修正为校验失败会话本身无残留条目 + 重试后幂等键正确解析到新条目）

## 已知 defer

无


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 新会话创建时，首条用户消息落库失败不再仅记录日志：会将错误写入会话状态并显式上报，终止后续处理。
  * 错误场景下避免并发“终态结算”覆盖：若同轮提前收到结果，将跳过常规 finalize 流程。
  * `/agent/chat` 同步会话遇到未覆盖的异常时，返回统一 HTTP 500，避免异常穿透。
* **Tests**
  * 新增/扩展用例覆盖：首条落库失败上报、早到 result 跳过 finalize、失败后重试与事件日志一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->