### PR TITLE
fix(agent): 同步对话不再把截断回复当完整文本静默返回

### DIFF
--- a/server/routers/agent_chat.py
+++ b/server/routers/agent_chat.py
@@ -34,6 +34,7 @@ class AgentChatResponse(BaseModel):
     session_id: str
     reply: str
     status: str  # "completed" | "timeout" | "error"
+    truncated: bool = False  # 回复可能不完整且未能从事件日志确认补齐
 
 
 def _extract_text_from_assistant_message(msg: dict) -> str:
@@ -160,6 +161,7 @@ async def agent_chat(
     - 若传入 session_id，则在该会话上下文中继续对话
     - 内部对接 AssistantService，收集完整响应后返回
     - 超过 120 秒返回已收集的部分响应，status 为 "timeout"
+    - 流异常收尾时从事件日志补齐回复；无法确认完整的非空回复以 truncated=true 标记
     """
     service = get_assistant_service()
 
@@ -203,20 +205,33 @@ async def agent_chat(
 
     # 收集回复（带超时）
     reply, status = await _collect_reply(service, session_id, SYNC_CHAT_TIMEOUT)
+    truncated = False
 
-    # 订阅建立前回复已完成（或部分广播已错过）时，直播收集为空；
-    # 事件日志是唯一读源，从本轮用户条目之后的主线 assistant 条目兜底提取。
-    if not reply:
+    # 事件日志是唯一可靠读源，两类情形需要回读兜底：
+    # - 直播收集为空：订阅建立前回复已完成，或部分广播已错过；
+    # - 流异常收尾（error / interrupted，如订阅队列溢出）：直播回复可能非空但被截断，
+    #   不能当作完整回复放行——回读补齐，补不齐则标记截断态。
+    stream_aborted = status not in ("completed", "timeout")
+    if not reply or stream_aborted:
         try:
             user_entry = result.get("entry")
             user_seq = user_entry.get("seq", -1) if isinstance(user_entry, dict) else -1
             payload = await service.list_session_entries(session_id, after_seq=user_seq)
-            reply = _extract_reply_from_entries(payload.get("entries", []), user_seq)
+            log_reply = _extract_reply_from_entries(payload.get("entries", []), user_seq)
+            session_running = payload.get("status") == "running"
+            # 直播广播先于日志落库：会话仍在 running 时日志可能滞后于直播已收文本，
+            # 仅在直播为空时才取日志部分文本；终态会话的日志已收全本轮条目，
+            # 主线回复以日志为准（补齐）。
+            if log_reply and (not reply or not session_running):
+                reply = log_reply
+            truncated = stream_aborted and session_running and bool(reply)
         except Exception as exc:
             logger.warning("从事件日志提取回复失败 session_id=%s: %s", session_id, exc)
+            truncated = stream_aborted and bool(reply)
 
     return AgentChatResponse(
         session_id=session_id,
         reply=reply,
         status=status,
+        truncated=truncated,
     )

--- a/server/routers/agent_chat.py
+++ b/server/routers/agent_chat.py
@@ -218,9 +218,12 @@ async def agent_chat(
             user_seq = user_entry.get("seq", -1) if isinstance(user_entry, dict) else -1
             payload = await service.list_session_entries(session_id, after_seq=user_seq)
             log_reply = _extract_reply_from_entries(payload.get("entries", []), user_seq)
+            session_running = payload.get("status") == "running"
             if not reply:
-                # 直播收集为空：按既有兜底语义采用日志内容（日志同样为空则维持空回复）。
+                # 直播收集为空：按既有兜底语义采用日志内容（日志同样为空则维持空回复）；
+                # 但异常收尾且会话仍在 running 时，日志内容同样未收全，不能当作已确认完整。
                 reply = log_reply
+                truncated = stream_aborted and session_running and bool(log_reply)
             else:
                 # 流异常收尾但直播已收到非空文本：会话运行态标志本身存在竞态——
                 # 中断/取消路径会丢弃已广播但未及落库的尾部消息，异步落库也可能滞后
@@ -228,7 +231,6 @@ async def agent_chat(
                 # 仅当会话已转终态、且日志文本不短于直播已收文本时才视为确认完整，
                 # 可放心整体替换；否则保留直播文本，标记截断态，避免被更短、更旧
                 # 的日志内容静默覆盖。
-                session_running = payload.get("status") == "running"
                 if not session_running and len(log_reply) >= len(reply):
                     reply = log_reply
                 else:

--- a/server/routers/agent_chat.py
+++ b/server/routers/agent_chat.py
@@ -33,7 +33,7 @@ class AgentChatRequest(BaseModel):
 class AgentChatResponse(BaseModel):
     session_id: str
     reply: str
-    status: str  # "completed" | "timeout" | "error"
+    status: str  # "completed" | "timeout" | "error" | "interrupted"
     truncated: bool = False  # 回复可能不完整且未能从事件日志确认补齐
 
 
@@ -218,13 +218,21 @@ async def agent_chat(
             user_seq = user_entry.get("seq", -1) if isinstance(user_entry, dict) else -1
             payload = await service.list_session_entries(session_id, after_seq=user_seq)
             log_reply = _extract_reply_from_entries(payload.get("entries", []), user_seq)
-            session_running = payload.get("status") == "running"
-            # 直播广播先于日志落库：会话仍在 running 时日志可能滞后于直播已收文本，
-            # 仅在直播为空时才取日志部分文本；终态会话的日志已收全本轮条目，
-            # 主线回复以日志为准（补齐）。
-            if log_reply and (not reply or not session_running):
+            if not reply:
+                # 直播收集为空：按既有兜底语义采用日志内容（日志同样为空则维持空回复）。
                 reply = log_reply
-            truncated = stream_aborted and session_running and bool(reply)
+            else:
+                # 流异常收尾但直播已收到非空文本：会话运行态标志本身存在竞态——
+                # 中断/取消路径会丢弃已广播但未及落库的尾部消息，异步落库也可能滞后
+                # 于直播广播——单凭"非 running"不足以证明日志已收全本轮内容。
+                # 仅当会话已转终态、且日志文本不短于直播已收文本时才视为确认完整，
+                # 可放心整体替换；否则保留直播文本，标记截断态，避免被更短、更旧
+                # 的日志内容静默覆盖。
+                session_running = payload.get("status") == "running"
+                if not session_running and len(log_reply) >= len(reply):
+                    reply = log_reply
+                else:
+                    truncated = stream_aborted
         except Exception as exc:
             logger.warning("从事件日志提取回复失败 session_id=%s: %s", session_id, exc)
             truncated = stream_aborted and bool(reply)

--- a/tests/test_agent_chat_router.py
+++ b/tests/test_agent_chat_router.py
@@ -272,8 +272,8 @@ class TestTruncatedReplyBackfill:
     """非空但被截断的直播回复不得当作完整回复静默返回：或从事件日志补齐、或标记截断。"""
 
     def _patch_truncated_service(self, monkeypatch, *, live_reply, live_status, entries_payload=None, entries_exc=None):
-        assert entries_payload is not None or entries_exc is not None, (
-            "必须显式提供 entries_payload 或 entries_exc 之一，避免误配置的 mock 悄悄落入异常分支"
+        assert (entries_payload is not None) != (entries_exc is not None), (
+            "必须显式提供 entries_payload 或 entries_exc 之一（且仅提供一个），避免误配置的 mock 悄悄落入异常分支"
         )
         mock_service = AsyncMock()
         pm = MagicMock()
@@ -391,6 +391,30 @@ class TestTruncatedReplyBackfill:
         assert body["reply"] == "被截断的部分"
         assert body["truncated"] is True
 
+    def test_empty_live_reply_session_still_running_marks_truncated(self, monkeypatch):
+        """直播收集为空且异常收尾：回读时会话仍在 running，日志内容同样未收全，需标记截断态。"""
+        self._patch_truncated_service(
+            monkeypatch,
+            live_reply="",
+            live_status="error",
+            entries_payload={
+                "session_id": "sess-1",
+                "status": "running",
+                "entries": [
+                    {"seq": 4, "type": "user", "content": [{"type": "text", "text": "问题"}]},
+                    {"seq": 5, "type": "assistant", "content": [{"type": "text", "text": "日志滞后文本"}]},
+                ],
+                "draft": None,
+                "draft_rev": 0,
+            },
+        )
+        with _make_client() as client:
+            resp = client.post("/api/v1/agent/chat", json={"project_name": "demo", "message": "问题"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reply"] == "日志滞后文本"
+        assert body["truncated"] is True
+
     def test_backfill_failure_keeps_partial_reply_marked_truncated(self, monkeypatch):
         """事件日志回读失败时，保留部分回复但显式标记截断态，不静默放行。"""
         self._patch_truncated_service(
@@ -427,6 +451,27 @@ class TestTruncatedReplyBackfill:
         body = resp.json()
         assert body["reply"] == "被截断的部分"
         assert body["truncated"] is True
+
+    def test_empty_live_reply_and_empty_log_stays_untruncated(self, monkeypatch):
+        """直播与日志均为空：没有任何内容可言截断，即使会话仍在 running 也不误标。"""
+        self._patch_truncated_service(
+            monkeypatch,
+            live_reply="",
+            live_status="error",
+            entries_payload={
+                "session_id": "sess-1",
+                "status": "running",
+                "entries": [{"seq": 4, "type": "user", "content": [{"type": "text", "text": "问题"}]}],
+                "draft": None,
+                "draft_rev": 0,
+            },
+        )
+        with _make_client() as client:
+            resp = client.post("/api/v1/agent/chat", json={"project_name": "demo", "message": "问题"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reply"] == ""
+        assert body["truncated"] is False
 
     def test_interrupted_status_also_backfills(self, monkeypatch):
         """interrupted 收尾同属流异常路径：非空部分回复同样从终态日志补齐。"""

--- a/tests/test_agent_chat_router.py
+++ b/tests/test_agent_chat_router.py
@@ -272,6 +272,9 @@ class TestTruncatedReplyBackfill:
     """非空但被截断的直播回复不得当作完整回复静默返回：或从事件日志补齐、或标记截断。"""
 
     def _patch_truncated_service(self, monkeypatch, *, live_reply, live_status, entries_payload=None, entries_exc=None):
+        assert entries_payload is not None or entries_exc is not None, (
+            "必须显式提供 entries_payload 或 entries_exc 之一，避免误配置的 mock 悄悄落入异常分支"
+        )
         mock_service = AsyncMock()
         pm = MagicMock()
         pm.get_project_path = MagicMock(return_value="/fake/path")
@@ -316,6 +319,53 @@ class TestTruncatedReplyBackfill:
         assert body["reply"] == "被截断的部分与完整后续"
         assert body["status"] == "error"
         assert body["truncated"] is False
+
+    def test_terminal_session_but_log_shorter_than_live_keeps_live_marks_truncated(self, monkeypatch):
+        """会话已转终态但日志比直播已收文本更短（如取消路径丢弃了已广播未落库的尾部消息）：
+        不得用更短的日志内容覆盖直播回复，且不能当作已确认完整。"""
+        self._patch_truncated_service(
+            monkeypatch,
+            live_reply="第一部分第二部分",
+            live_status="interrupted",
+            entries_payload={
+                "session_id": "sess-1",
+                "status": "interrupted",
+                "entries": [
+                    {"seq": 4, "type": "user", "content": [{"type": "text", "text": "问题"}]},
+                    {"seq": 5, "type": "assistant", "content": [{"type": "text", "text": "第一部分"}]},
+                ],
+                "draft": None,
+                "draft_rev": 0,
+            },
+        )
+        with _make_client() as client:
+            resp = client.post("/api/v1/agent/chat", json={"project_name": "demo", "message": "问题"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reply"] == "第一部分第二部分"
+        assert body["truncated"] is True
+
+    def test_terminal_session_but_empty_log_keeps_live_marks_truncated(self, monkeypatch):
+        """会话已转终态但日志本轮无主线回复条目（未给出任何佐证）：
+        保留直播部分文本，且不能仅凭终态就当作已确认完整。"""
+        self._patch_truncated_service(
+            monkeypatch,
+            live_reply="被截断的部分",
+            live_status="error",
+            entries_payload={
+                "session_id": "sess-1",
+                "status": "completed",
+                "entries": [{"seq": 4, "type": "user", "content": [{"type": "text", "text": "问题"}]}],
+                "draft": None,
+                "draft_rev": 0,
+            },
+        )
+        with _make_client() as client:
+            resp = client.post("/api/v1/agent/chat", json={"project_name": "demo", "message": "问题"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reply"] == "被截断的部分"
+        assert body["truncated"] is True
 
     def test_session_still_running_marks_truncated(self, monkeypatch):
         """回读时会话仍在 running：日志同样未收全，保留直播部分文本并标记截断态。"""

--- a/tests/test_agent_chat_router.py
+++ b/tests/test_agent_chat_router.py
@@ -268,6 +268,157 @@ class TestEntryLogFallback:
         assert resp.json()["reply"] == "日志兜底回复"
 
 
+class TestTruncatedReplyBackfill:
+    """非空但被截断的直播回复不得当作完整回复静默返回：或从事件日志补齐、或标记截断。"""
+
+    def _patch_truncated_service(self, monkeypatch, *, live_reply, live_status, entries_payload=None, entries_exc=None):
+        mock_service = AsyncMock()
+        pm = MagicMock()
+        pm.get_project_path = MagicMock(return_value="/fake/path")
+        mock_service.pm = pm
+        mock_service.get_session = AsyncMock(return_value=_fake_session())
+        mock_service.send_or_create = AsyncMock(
+            return_value={
+                "status": "accepted",
+                "session_id": "sess-1",
+                "entry": {"seq": 4, "type": "user", "content": [{"type": "text", "text": "问题"}]},
+            }
+        )
+        if entries_exc is not None:
+            mock_service.list_session_entries = AsyncMock(side_effect=entries_exc)
+        else:
+            mock_service.list_session_entries = AsyncMock(return_value=entries_payload)
+        monkeypatch.setattr(agent_chat, "get_assistant_service", lambda: mock_service)
+        monkeypatch.setattr(agent_chat, "_collect_reply", AsyncMock(return_value=(live_reply, live_status)))
+        return mock_service
+
+    def test_error_status_backfills_nonempty_truncated_reply(self, monkeypatch):
+        """error 收尾（如订阅队列溢出）时，非空的部分回复也从事件日志补齐为完整回复。"""
+        self._patch_truncated_service(
+            monkeypatch,
+            live_reply="被截断的部分",
+            live_status="error",
+            entries_payload={
+                "session_id": "sess-1",
+                "status": "completed",
+                "entries": [
+                    {"seq": 4, "type": "user", "content": [{"type": "text", "text": "问题"}]},
+                    {"seq": 5, "type": "assistant", "content": [{"type": "text", "text": "被截断的部分与完整后续"}]},
+                ],
+                "draft": None,
+                "draft_rev": 0,
+            },
+        )
+        with _make_client() as client:
+            resp = client.post("/api/v1/agent/chat", json={"project_name": "demo", "message": "问题"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reply"] == "被截断的部分与完整后续"
+        assert body["status"] == "error"
+        assert body["truncated"] is False
+
+    def test_session_still_running_marks_truncated(self, monkeypatch):
+        """回读时会话仍在 running：日志同样未收全，保留直播部分文本并标记截断态。"""
+        self._patch_truncated_service(
+            monkeypatch,
+            live_reply="被截断的部分",
+            live_status="error",
+            entries_payload={
+                "session_id": "sess-1",
+                "status": "running",
+                "entries": [
+                    {"seq": 4, "type": "user", "content": [{"type": "text", "text": "问题"}]},
+                    {"seq": 5, "type": "assistant", "content": [{"type": "text", "text": "日志滞后文本"}]},
+                ],
+                "draft": None,
+                "draft_rev": 0,
+            },
+        )
+        with _make_client() as client:
+            resp = client.post("/api/v1/agent/chat", json={"project_name": "demo", "message": "问题"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reply"] == "被截断的部分"
+        assert body["truncated"] is True
+
+    def test_backfill_failure_keeps_partial_reply_marked_truncated(self, monkeypatch):
+        """事件日志回读失败时，保留部分回复但显式标记截断态，不静默放行。"""
+        self._patch_truncated_service(
+            monkeypatch,
+            live_reply="被截断的部分",
+            live_status="error",
+            entries_exc=RuntimeError("db unavailable"),
+        )
+        with _make_client() as client:
+            resp = client.post("/api/v1/agent/chat", json={"project_name": "demo", "message": "问题"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reply"] == "被截断的部分"
+        assert body["status"] == "error"
+        assert body["truncated"] is True
+
+    def test_empty_log_extraction_keeps_live_reply(self, monkeypatch):
+        """日志暂无主线回复条目时保留直播部分文本；会话仍 running 则标记截断。"""
+        self._patch_truncated_service(
+            monkeypatch,
+            live_reply="被截断的部分",
+            live_status="error",
+            entries_payload={
+                "session_id": "sess-1",
+                "status": "running",
+                "entries": [{"seq": 4, "type": "user", "content": [{"type": "text", "text": "问题"}]}],
+                "draft": None,
+                "draft_rev": 0,
+            },
+        )
+        with _make_client() as client:
+            resp = client.post("/api/v1/agent/chat", json={"project_name": "demo", "message": "问题"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reply"] == "被截断的部分"
+        assert body["truncated"] is True
+
+    def test_interrupted_status_also_backfills(self, monkeypatch):
+        """interrupted 收尾同属流异常路径：非空部分回复同样从终态日志补齐。"""
+        self._patch_truncated_service(
+            monkeypatch,
+            live_reply="被截断的部分",
+            live_status="interrupted",
+            entries_payload={
+                "session_id": "sess-1",
+                "status": "interrupted",
+                "entries": [
+                    {"seq": 4, "type": "user", "content": [{"type": "text", "text": "问题"}]},
+                    {"seq": 5, "type": "assistant", "content": [{"type": "text", "text": "中断前完整文本"}]},
+                ],
+                "draft": None,
+                "draft_rev": 0,
+            },
+        )
+        with _make_client() as client:
+            resp = client.post("/api/v1/agent/chat", json={"project_name": "demo", "message": "问题"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reply"] == "中断前完整文本"
+        assert body["truncated"] is False
+
+    def test_completed_nonempty_reply_skips_backfill(self, monkeypatch):
+        """正常完成的非空回复不触发日志回读，truncated 恒为 False。"""
+        mock_service = self._patch_truncated_service(
+            monkeypatch,
+            live_reply="完整回复",
+            live_status="completed",
+            entries_payload={"session_id": "sess-1", "status": "completed", "entries": []},
+        )
+        with _make_client() as client:
+            resp = client.post("/api/v1/agent/chat", json={"project_name": "demo", "message": "问题"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reply"] == "完整回复"
+        assert body["truncated"] is False
+        mock_service.list_session_entries.assert_not_awaited()
+
+
 class TestExtractTextFromAssistantMessage:
     def test_list_content(self):
         msg = {"type": "assistant", "content": [{"type": "text", "text": "你好"}]}


### PR DESCRIPTION
## 范围

`/agent/chat` 同步端点的事件日志兜底回读逻辑（`server/routers/agent_chat.py`）。不涉及 SSE 流式助手端点。

## 变更

- 兜底守卫从"仅直播回复为空"扩为"直播回复为空或流异常收尾（error / interrupted，如订阅队列溢出）"
- 流异常收尾且直播回复非空时：回读事件日志，能确认日志已收全（会话已转终态且日志文本不短于直播已收文本）则整体补齐替换；不能确认则保留直播部分文本，并以新增的 `truncated` 字段显式标记
- 修正确认完整性的判据：不再仅凭会话"非 running"状态标志判定日志已收全——中断/取消路径会丢弃已广播但未及落库的尾部消息、异步落库也可能滞后于直播广播，仅凭该标志会把更短、更旧的日志内容静默覆盖更完整的直播回复，且错误标记为非截断
- 补全 `status` 字段行内注释遗漏的 `"interrupted"` 取值
- 测试 helper 增加显式参数校验，避免误配置的 mock 静默落入异常分支

## 验证清单

- [x] 本地已跑相关测试：`uv run python -m pytest tests/test_agent_chat_router.py -v`（25 passed，含 2 个新增回归测试，已用 stash 验证在修复前的代码上会失败）
- [x] 全量测试套件：`uv run python -m pytest`（5686 passed）
- [x] `uv run ruff check . && uv run ruff format --check .`、`uv run basedpyright`（0 error）
- [ ] 手动验证了改动所声称的行为（本 PR 为纯后端逻辑修正，覆盖场景已由单测固定，未做手工调用验证）
- [ ] 新增面向用户文案已加 zh/en 翻译（不适用：`truncated` 字段仅供外部 Agent 调用方消费，非用户可见文案）
- [x] 无新增 ESLint disable
- [ ] CODEOWNERS 要求的 review 已请求（不适用/待自动化 review 流程处理）

## 已知 defer

- `status` 字段在回填成功恢复完整回复后仍报告原始异常收尾值（`"error"`/`"interrupted"`），是否应提升为反映内容已完整的状态，涉及外部调用方（如 OpenClaw）的 API 契约语义，需要单独决策 → #1066
- 直播文本收集与事件日志提取在 `parent_tool_use_id` 过滤口径上的既有不一致，以及直播为空、整体判定为 completed/timeout 路径下日志回读自身的时序假设局限 → #1067

Closes #1065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * `/agent/chat` 的同步响应新增 `truncated` 标记，用于提示回复是否被截断；响应状态说明扩展为包含 `interrupted`。
* **Bug Fixes**
  * 当流式回复非完整（中断/错误/超时等）时，会尝试从会话事件记录中回填补齐；若回填失败或仍不足以确认完整，则保留已接收内容并将 `truncated` 标记为 `True`。
* **Tests**
  * 新增端到端测试用例覆盖多种回填与截断判定场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->