### PR TITLE
perf(assistant): 时间线投影增量化，长会话直播不再随历史线性变慢

### DIFF
--- a/frontend/src/stores/assistant-store.ts
+++ b/frontend/src/stores/assistant-store.ts
@@ -90,14 +90,28 @@ interface AssistantState {
 
 export const useAssistantStore = create<AssistantState>((set, get) => {
   // 投影派生缓存（非响应式状态）：projector 增量折叠 entries→turns，
-  // committedIds 是 draft 替换判定的 O(1) 索引。索引按 entries 引用自愈——
+  // committedIds 是 draft 替换判定的 O(1) 索引。两者都按 entries 引用自愈——
   // 外部整帧 setState（如测试 reset）替换 entries 却不经本 store 的 action
-  // 时，下次读取按引用不符重建，避免用陈旧 message_id 误判 draft 已替换。
+  // 时，下次读取按引用不符重建，避免用陈旧 message_id 误判 draft 已替换，
+  // 或用陈旧 projector 内部状态误判增量前缀延续。projector 自身的前缀判定
+  // 只比对 entries 首尾元素引用（O(1)，不能整数组比对，否则每次追加都会
+  // 判定为"变了"而失去增量的意义），这里额外按容器引用做一层更粗但更可靠
+  // 的自愈防线——与 committedSource 完全同构，legitimate 的每次 mutation
+  // 都把 xxxSource 同步更新为下一次 get().entries 会拿到的引用，只有外部
+  // 绕过 action 的整帧替换才会触发。
   let projector = createTimelineProjector();
+  let projectorSource: TimelineEntry[] | null = null;
   let committedIds = new Set<string>();
   let committedSource: TimelineEntry[] | null = null;
 
-  const projectEntries = (entries: TimelineEntry[]): Turn[] => projector.project(entries);
+  const projectEntries = (entries: TimelineEntry[]): Turn[] => {
+    if (projectorSource !== entries) {
+      projector = createTimelineProjector();
+    }
+    const turns = projector.project(entries);
+    projectorSource = entries;
+    return turns;
+  };
 
   const committedFor = (entries: TimelineEntry[]): Set<string> => {
     if (committedSource !== entries) {
@@ -194,6 +208,7 @@ export const useAssistantStore = create<AssistantState>((set, get) => {
     clearDraft: () => set({ draft: null, draftTurn: null }),
     resetTimeline: () => {
       projector = createTimelineProjector();
+      projectorSource = null;
       committedIds = new Set<string>();
       committedSource = null;
       set({ entries: [], draft: null, draftRev: 0, turns: [], draftTurn: null });

--- a/frontend/src/stores/assistant-store.ts
+++ b/frontend/src/stores/assistant-store.ts
@@ -196,7 +196,7 @@ export const useAssistantStore = create<AssistantState>((set, get) => {
       // tool_json 是服务端已累积的原始 partial JSON——以此为前缀继续拼接
       // 后续 input_json_delta，否则纯后缀永远解析失败、参数预览冻结。
       const mirror: DraftMirror | null = draft
-        ? { ...draft, content: [...draft.content], toolJson: { ...(draft.tool_json ?? {}) } }
+        ? { ...draft, content: [...(draft.content ?? [])], toolJson: { ...(draft.tool_json ?? {}) } }
         : null;
       set({
         draft: mirror,

--- a/frontend/src/stores/assistant-store.ts
+++ b/frontend/src/stores/assistant-store.ts
@@ -104,12 +104,20 @@ export const useAssistantStore = create<AssistantState>((set, get) => {
   let committedIds = new Set<string>();
   let committedSource: TimelineEntry[] | null = null;
 
-  const projectEntries = (entries: TimelineEntry[]): Turn[] => {
-    if (projectorSource !== entries) {
+  // base 是本次 mutation 之前 get().entries 持有的引用，next 是即将写入 state
+  // 的新引用（二者恒不相等——每次 mutation 都会构造新数组）。自愈检查必须
+  // 拿 base 去比对上一次记录的 projectorSource，而不是拿 next 比对：next
+  // 由定义就是全新引用，若拿它做比对，每次合法调用都会判定"变了"从而重建
+  // projector、对全部历史条目重新深拷贝，退化为 O(n²) 全量重放——这正是
+  // 增量投影要消除的问题。只有外部绕过 action 的整帧替换（如测试
+  // useAssistantStore.setState(..., true)）才会让 base 与上次记录的
+  // projectorSource 不一致，进而正确触发重建。
+  const projectEntries = (base: TimelineEntry[], next: TimelineEntry[]): Turn[] => {
+    if (projectorSource !== base) {
       projector = createTimelineProjector();
     }
-    const turns = projector.project(entries);
-    projectorSource = entries;
+    const turns = projector.project(next);
+    projectorSource = next;
     return turns;
   };
 
@@ -151,13 +159,14 @@ export const useAssistantStore = create<AssistantState>((set, get) => {
     setEntries: (entries) => {
       // 并集合并而非整帧覆盖：慢网络下冷读响应可能晚于发送响应/SSE 条目到达，
       // 整帧覆盖会抹掉更新的条目；append-only 日志按 seq 并集恒安全。
-      const merged = mergeEntriesBySeq(get().entries, entries);
+      const prevEntries = get().entries;
+      const merged = mergeEntriesBySeq(prevEntries, entries);
       const draft = get().draft;
       committedIds = collectCommittedMessageIds(merged);
       committedSource = merged;
       set({
         entries: merged,
-        turns: projectEntries(merged),
+        turns: projectEntries(prevEntries, merged),
         draftTurn: buildDraftTurn(draft, isDraftReplaced(draft, committedIds)),
       });
     },
@@ -179,7 +188,7 @@ export const useAssistantStore = create<AssistantState>((set, get) => {
       set({
         entries: next,
         draft: nextDraft,
-        turns: projectEntries(next),
+        turns: projectEntries(entries, next),
         draftTurn: buildDraftTurn(nextDraft, isDraftReplaced(nextDraft, ids)),
       });
     },

--- a/frontend/src/stores/assistant-store.ts
+++ b/frontend/src/stores/assistant-store.ts
@@ -11,9 +11,11 @@ import type {
 } from "@/types";
 import {
   applyDraftDelta,
+  buildDraftTurn,
+  collectCommittedMessageIds,
+  createTimelineProjector,
+  isDraftReplaced,
   mergeEntriesBySeq,
-  projectDraftToTurn,
-  projectEntriesToTurns,
   type DraftMirror,
 } from "@/utils/entry-projection";
 
@@ -86,101 +88,129 @@ interface AssistantState {
   setIsDraftSession: (draft: boolean) => void;
 }
 
-export const useAssistantStore = create<AssistantState>((set, get) => ({
-  sessions: [],
-  currentSessionId: null,
-  sessionsLoading: false,
-  entries: [],
-  draft: null,
-  draftRev: 0,
-  turns: [],
-  draftTurn: null,
-  messagesLoading: false,
-  input: "",
-  sending: false,
-  interrupting: false,
-  error: null,
-  sessionStatus: null,
-  sessionStatusDetail: null,
-  pendingQuestion: null,
-  answeringQuestion: false,
-  skills: [],
-  skillsLoading: false,
-  currentProject: null,
-  isDraftSession: false,
+export const useAssistantStore = create<AssistantState>((set, get) => {
+  // 投影派生缓存（非响应式状态）：projector 增量折叠 entries→turns，
+  // committedIds 是 draft 替换判定的 O(1) 索引。索引按 entries 引用自愈——
+  // 外部整帧 setState（如测试 reset）替换 entries 却不经本 store 的 action
+  // 时，下次读取按引用不符重建，避免用陈旧 message_id 误判 draft 已替换。
+  let projector = createTimelineProjector();
+  let committedIds = new Set<string>();
+  let committedSource: TimelineEntry[] | null = null;
 
-  setSessions: (sessions) => set({ sessions }),
-  setCurrentSessionId: (id) => set({ currentSessionId: id }),
-  setSessionsLoading: (loading) => set({ sessionsLoading: loading }),
+  const projectEntries = (entries: TimelineEntry[]): Turn[] => projector.project(entries);
 
-  setEntries: (entries) => {
-    // 并集合并而非整帧覆盖：慢网络下冷读响应可能晚于发送响应/SSE 条目到达，
-    // 整帧覆盖会抹掉更新的条目；append-only 日志按 seq 并集恒安全。
-    const merged = mergeEntriesBySeq(get().entries, entries);
-    const draft = get().draft;
-    set({
-      entries: merged,
-      turns: projectEntriesToTurns(merged),
-      draftTurn: projectDraftToTurn(draft, merged),
-    });
-  },
-  appendEntry: (entry) => {
-    const { entries, draft } = get();
-    const lastSeq = entries.length > 0 ? entries[entries.length - 1].seq : -1;
-    if (entry.seq <= lastSeq) return;
-    const next = [...entries, entry];
-    // 权威条目落库即按同 message_id 精确替换 draft（身份比对）
-    const draftReplaced =
-      draft !== null &&
-      entry.type === "assistant" &&
-      entry.message_id != null &&
-      entry.message_id === draft.message_id;
-    const nextDraft = draftReplaced ? null : draft;
-    set({
-      entries: next,
-      draft: nextDraft,
-      turns: projectEntriesToTurns(next),
-      draftTurn: projectDraftToTurn(nextDraft, next),
-    });
-  },
-  setDraftSnapshot: (draft, rev) => {
-    const entries = get().entries;
-    // tool_json 是服务端已累积的原始 partial JSON——以此为前缀继续拼接
-    // 后续 input_json_delta，否则纯后缀永远解析失败、参数预览冻结。
-    const mirror: DraftMirror | null = draft
-      ? { ...draft, content: [...draft.content], toolJson: { ...(draft.tool_json ?? {}) } }
-      : null;
-    set({
-      draft: mirror,
-      draftRev: rev,
-      draftTurn: projectDraftToTurn(mirror, entries),
-    });
-  },
-  applyDelta: (payload) => {
-    const { draft, draftRev, entries } = get();
-    if (typeof payload.rev !== "number" || payload.rev <= draftRev) return;
-    const next = applyDraftDelta(draft, payload);
-    set({
-      draft: next,
-      draftRev: payload.rev,
-      draftTurn: projectDraftToTurn(next, entries),
-    });
-  },
-  clearDraft: () => set({ draft: null, draftTurn: null }),
-  resetTimeline: () =>
-    set({ entries: [], draft: null, draftRev: 0, turns: [], draftTurn: null }),
+  const committedFor = (entries: TimelineEntry[]): Set<string> => {
+    if (committedSource !== entries) {
+      committedIds = collectCommittedMessageIds(entries);
+      committedSource = entries;
+    }
+    return committedIds;
+  };
 
-  setMessagesLoading: (loading) => set({ messagesLoading: loading }),
-  setInput: (input) => set({ input }),
-  setSending: (sending) => set({ sending }),
-  setInterrupting: (interrupting) => set({ interrupting }),
-  setError: (error) => set({ error }),
-  setSessionStatus: (status) => set({ sessionStatus: status }),
-  setSessionStatusDetail: (detail) => set({ sessionStatusDetail: detail }),
-  setPendingQuestion: (question) => set({ pendingQuestion: question }),
-  setAnsweringQuestion: (answering) => set({ answeringQuestion: answering }),
-  setSkills: (skills) => set({ skills }),
-  setSkillsLoading: (loading) => set({ skillsLoading: loading }),
-  setCurrentProject: (project) => set({ currentProject: project }),
-  setIsDraftSession: (draft) => set({ isDraftSession: draft }),
-}));
+  return {
+    sessions: [],
+    currentSessionId: null,
+    sessionsLoading: false,
+    entries: [],
+    draft: null,
+    draftRev: 0,
+    turns: [],
+    draftTurn: null,
+    messagesLoading: false,
+    input: "",
+    sending: false,
+    interrupting: false,
+    error: null,
+    sessionStatus: null,
+    sessionStatusDetail: null,
+    pendingQuestion: null,
+    answeringQuestion: false,
+    skills: [],
+    skillsLoading: false,
+    currentProject: null,
+    isDraftSession: false,
+
+    setSessions: (sessions) => set({ sessions }),
+    setCurrentSessionId: (id) => set({ currentSessionId: id }),
+    setSessionsLoading: (loading) => set({ sessionsLoading: loading }),
+
+    setEntries: (entries) => {
+      // 并集合并而非整帧覆盖：慢网络下冷读响应可能晚于发送响应/SSE 条目到达，
+      // 整帧覆盖会抹掉更新的条目；append-only 日志按 seq 并集恒安全。
+      const merged = mergeEntriesBySeq(get().entries, entries);
+      const draft = get().draft;
+      committedIds = collectCommittedMessageIds(merged);
+      committedSource = merged;
+      set({
+        entries: merged,
+        turns: projectEntries(merged),
+        draftTurn: buildDraftTurn(draft, isDraftReplaced(draft, committedIds)),
+      });
+    },
+    appendEntry: (entry) => {
+      const { entries, draft } = get();
+      const lastSeq = entries.length > 0 ? entries[entries.length - 1].seq : -1;
+      if (entry.seq <= lastSeq) return;
+      const next = [...entries, entry];
+      const ids = committedFor(entries);
+      if (entry.type === "assistant" && entry.message_id != null) ids.add(entry.message_id);
+      committedSource = next;
+      // 权威条目落库即按同 message_id 精确替换 draft（身份比对）
+      const draftReplaced =
+        draft !== null &&
+        entry.type === "assistant" &&
+        entry.message_id != null &&
+        entry.message_id === draft.message_id;
+      const nextDraft = draftReplaced ? null : draft;
+      set({
+        entries: next,
+        draft: nextDraft,
+        turns: projectEntries(next),
+        draftTurn: buildDraftTurn(nextDraft, isDraftReplaced(nextDraft, ids)),
+      });
+    },
+    setDraftSnapshot: (draft, rev) => {
+      // tool_json 是服务端已累积的原始 partial JSON——以此为前缀继续拼接
+      // 后续 input_json_delta，否则纯后缀永远解析失败、参数预览冻结。
+      const mirror: DraftMirror | null = draft
+        ? { ...draft, content: [...draft.content], toolJson: { ...(draft.tool_json ?? {}) } }
+        : null;
+      set({
+        draft: mirror,
+        draftRev: rev,
+        draftTurn: buildDraftTurn(mirror, isDraftReplaced(mirror, committedFor(get().entries))),
+      });
+    },
+    applyDelta: (payload) => {
+      const { draft, draftRev } = get();
+      if (typeof payload.rev !== "number" || payload.rev <= draftRev) return;
+      const next = applyDraftDelta(draft, payload);
+      set({
+        draft: next,
+        draftRev: payload.rev,
+        draftTurn: buildDraftTurn(next, isDraftReplaced(next, committedFor(get().entries))),
+      });
+    },
+    clearDraft: () => set({ draft: null, draftTurn: null }),
+    resetTimeline: () => {
+      projector = createTimelineProjector();
+      committedIds = new Set<string>();
+      committedSource = null;
+      set({ entries: [], draft: null, draftRev: 0, turns: [], draftTurn: null });
+    },
+
+    setMessagesLoading: (loading) => set({ messagesLoading: loading }),
+    setInput: (input) => set({ input }),
+    setSending: (sending) => set({ sending }),
+    setInterrupting: (interrupting) => set({ interrupting }),
+    setError: (error) => set({ error }),
+    setSessionStatus: (status) => set({ sessionStatus: status }),
+    setSessionStatusDetail: (detail) => set({ sessionStatusDetail: detail }),
+    setPendingQuestion: (question) => set({ pendingQuestion: question }),
+    setAnsweringQuestion: (answering) => set({ answeringQuestion: answering }),
+    setSkills: (skills) => set({ skills }),
+    setSkillsLoading: (loading) => set({ skillsLoading: loading }),
+    setCurrentProject: (project) => set({ currentProject: project }),
+    setIsDraftSession: (draft) => set({ isDraftSession: draft }),
+  };
+});

--- a/frontend/src/stores/stores.test.ts
+++ b/frontend/src/stores/stores.test.ts
@@ -319,6 +319,42 @@ describe("stores", () => {
     expect(turns.map((t) => t.content[0].text)).toEqual(["开头", "会话二中段", "结尾"]);
   });
 
+  it("keeps the incremental projector instance alive across appendEntry calls instead of rebuilding it every time", () => {
+    // store 层的 projectorSource 自愈检查若拿"即将写入的新数组"和"上一次
+    // 记录值"比对，二者引用恒不相等（每次 append 都会重新构造数组），会
+    // 导致每次追加都重建 projector、对全部历史条目重新深拷贝——退化为
+    // O(n²) 全量重放，正是本 PR 要消除的问题。
+    const assistant = useAssistantStore.getState();
+    assistant.resetTimeline();
+    const original = globalThis.structuredClone;
+    let cloneCalls = 0;
+    globalThis.structuredClone = ((v: unknown) => {
+      cloneCalls++;
+      return original(v);
+    }) as typeof structuredClone;
+    try {
+      for (let i = 0; i < 5; i++) {
+        assistant.appendEntry({
+          seq: i,
+          type: "assistant",
+          uuid: `a-${i}`,
+          content: [{ type: "text", text: `消息${i}` }],
+        });
+      }
+      cloneCalls = 0;
+      assistant.appendEntry({
+        seq: 5,
+        type: "assistant",
+        uuid: "a-5",
+        content: [{ type: "text", text: "消息5" }],
+      });
+      // 只深拷贝新追加的这一条；若 projector 被重建，前 5 条也会被重新克隆。
+      expect(cloneCalls).toBe(1);
+    } finally {
+      globalThis.structuredClone = original;
+    }
+  });
+
   describe("ProjectsStore fingerprints", () => {
     it("should store and retrieve asset fingerprints", () => {
       const { updateAssetFingerprints, getAssetFingerprint } = useProjectsStore.getState();

--- a/frontend/src/stores/stores.test.ts
+++ b/frontend/src/stores/stores.test.ts
@@ -6,7 +6,7 @@ import {
   useTasksStore,
   useUsageStore,
 } from "@/stores";
-import type { TaskItem, TimelineEntry } from "@/types";
+import type { DraftState, TaskItem, TimelineEntry } from "@/types";
 
 function resetAllStores(): void {
   useAppStore.setState(useAppStore.getInitialState(), true);
@@ -269,6 +269,17 @@ describe("stores", () => {
     });
     const draft = useAssistantStore.getState().draft;
     expect(draft?.content[0].input).toEqual({ path: "a.txt" });
+  });
+
+  it("does not throw when a draft payload from the network omits content (SSE boundary is cast, not validated)", () => {
+    // useAssistantSession 对 SSE draft 事件做的是 `as DraftState` 类型断言，
+    // 无运行时校验；后端载荷若缺 content 字段，这里应兜底为空数组而非崩溃。
+    const assistant = useAssistantStore.getState();
+    assistant.resetTimeline();
+    const malformed = { message_id: "msg_1", rev: 1 } as unknown as DraftState;
+    expect(() => assistant.setDraftSnapshot(malformed, 1)).not.toThrow();
+    expect(useAssistantStore.getState().draft?.content).toEqual([]);
+    expect(useAssistantStore.getState().draftTurn).toBeNull();
   });
 
   it("does not treat a fresh draft as replaced by a stale committed message_id after a full setState reset", () => {

--- a/frontend/src/stores/stores.test.ts
+++ b/frontend/src/stores/stores.test.ts
@@ -271,6 +271,28 @@ describe("stores", () => {
     expect(draft?.content[0].input).toEqual({ path: "a.txt" });
   });
 
+  it("does not treat a fresh draft as replaced by a stale committed message_id after a full setState reset", () => {
+    const assistant = useAssistantStore.getState();
+    // 先提交一条权威 assistant 条目（message_id 进入替换索引）
+    assistant.resetTimeline();
+    assistant.appendEntry({
+      seq: 0,
+      type: "assistant",
+      message_id: "msg_1",
+      uuid: "a-1",
+      content: [{ type: "text", text: "上一会话" }],
+    });
+    // 整帧 setState 重置（绕过 store action，等价于测试 harness 的 reset）
+    useAssistantStore.setState(useAssistantStore.getInitialState(), true);
+    // 新会话复用同一 message_id 的 draft：替换索引应按新（空）entries 自愈，
+    // draftTurn 不被上一会话的陈旧 message_id 误判为已替换
+    useAssistantStore.getState().setDraftSnapshot(
+      { message_id: "msg_1", content: [{ type: "text", text: "新会话草稿" }], rev: 1 },
+      1,
+    );
+    expect(useAssistantStore.getState().draftTurn?.content[0].text).toBe("新会话草稿");
+  });
+
   describe("ProjectsStore fingerprints", () => {
     it("should store and retrieve asset fingerprints", () => {
       const { updateAssetFingerprints, getAssetFingerprint } = useProjectsStore.getState();

--- a/frontend/src/stores/stores.test.ts
+++ b/frontend/src/stores/stores.test.ts
@@ -6,7 +6,7 @@ import {
   useTasksStore,
   useUsageStore,
 } from "@/stores";
-import type { TaskItem } from "@/types";
+import type { TaskItem, TimelineEntry } from "@/types";
 
 function resetAllStores(): void {
   useAppStore.setState(useAppStore.getInitialState(), true);
@@ -291,6 +291,32 @@ describe("stores", () => {
       1,
     );
     expect(useAssistantStore.getState().draftTurn?.content[0].text).toBe("新会话草稿");
+  });
+
+  it("self-heals the incremental projector after a full setState reset even when the next cohort reuses stale head/tail entry object references", () => {
+    // 增量投影器自身的前缀延续判定只比对 entries 首尾元素引用（O(1) 设计，
+    // 不逐一比对中间元素）。若 store 层没有额外按整个 entries 容器引用自愈，
+    // 绕过 resetTimeline 的整帧重置后，只要"新"cohort 复用了上一会话的
+    // 首尾条目对象引用（例如测试间共享的 fixture 常量），投影器会误判为
+    // "前缀延续"，永远不会折叠中段条目的新内容，turns 停留在上一会话的陈旧值。
+    const entryX: TimelineEntry = { seq: 0, type: "user", uuid: "x", content: [{ type: "text", text: "开头" }] };
+    const entryA: TimelineEntry = { seq: 2, type: "user", uuid: "a", content: [{ type: "text", text: "结尾" }] };
+    const entryMid1: TimelineEntry = { seq: 1, type: "user", uuid: "m1", content: [{ type: "text", text: "会话一中段" }] };
+    const entryMid2: TimelineEntry = { seq: 1, type: "user", uuid: "m2", content: [{ type: "text", text: "会话二中段" }] };
+
+    const assistant = useAssistantStore.getState();
+    assistant.resetTimeline();
+    assistant.setEntries([entryX, entryMid1, entryA]);
+    expect(useAssistantStore.getState().turns).toHaveLength(3);
+
+    // 整帧 setState 重置（绕过 resetTimeline action）
+    useAssistantStore.setState(useAssistantStore.getInitialState(), true);
+
+    // "新会话"首尾复用同一对条目对象引用，仅中段条目是新对象
+    useAssistantStore.getState().setEntries([entryX, entryMid2, entryA]);
+    const turns = useAssistantStore.getState().turns;
+    expect(turns).toHaveLength(3);
+    expect(turns.map((t) => t.content[0].text)).toEqual(["开头", "会话二中段", "结尾"]);
   });
 
   describe("ProjectsStore fingerprints", () => {

--- a/frontend/src/utils/entry-projection.test.ts
+++ b/frontend/src/utils/entry-projection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { DraftDeltaPayload, TimelineEntry } from "@/types";
+import type { DraftDeltaPayload, DraftState, TimelineEntry } from "@/types";
 import {
   applyDraftDelta,
   buildDraftTurn,
@@ -611,6 +611,11 @@ describe("buildDraftTurn", () => {
     expect(buildDraftTurn(null, false)).toBeNull();
     expect(buildDraftTurn({ ...draft, content: [] }, false)).toBeNull();
     expect(buildDraftTurn({ ...draft, parent_tool_use_id: "tu-agent" }, false)).toBeNull();
+  });
+
+  it("does not throw when a malformed payload omits content (network boundary, `as DraftState` skips runtime validation)", () => {
+    const malformed = { message_id: "msg_1", parent_tool_use_id: null } as unknown as DraftState;
+    expect(buildDraftTurn(malformed, false)).toBeNull();
   });
 
   it("agrees with projectDraftToTurn across the committed-set derivation", () => {

--- a/frontend/src/utils/entry-projection.test.ts
+++ b/frontend/src/utils/entry-projection.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import type { DraftDeltaPayload, TimelineEntry } from "@/types";
 import {
   applyDraftDelta,
+  buildDraftTurn,
+  collectCommittedMessageIds,
+  createTimelineProjector,
+  isDraftReplaced,
   mergeEntriesBySeq,
   projectDraftToTurn,
   projectEntriesToTurns,
@@ -542,6 +546,364 @@ describe("applyDraftDelta", () => {
     expect(first).toEqual(before);
   });
 });
+
+describe("collectCommittedMessageIds", () => {
+  it("collects message_id of assistant entries only", () => {
+    const ids = collectCommittedMessageIds([
+      { seq: 0, type: "user", content: [{ type: "text", text: "hi" }] },
+      { seq: 1, type: "assistant", message_id: "m1", content: [{ type: "text", text: "a" }] },
+      { seq: 2, type: "assistant", message_id: "m2", content: [{ type: "text", text: "b" }] },
+      { seq: 3, type: "tool_result", tool_use_id: "tu", content: "r" },
+      // assistant 条目缺 message_id 时不计入
+      { seq: 4, type: "assistant", content: [{ type: "text", text: "c" }] },
+    ]);
+    expect(ids).toBeInstanceOf(Set);
+    expect([...ids].sort()).toEqual(["m1", "m2"]);
+  });
+
+  it("returns an empty set for no committed assistant messages", () => {
+    expect(collectCommittedMessageIds([]).size).toBe(0);
+  });
+});
+
+describe("isDraftReplaced", () => {
+  const draft: DraftMirror = {
+    message_id: "m1",
+    parent_tool_use_id: null,
+    content: [{ type: "text", text: "x" }],
+    toolJson: {},
+  };
+
+  it("is true when the committed set contains the draft message_id", () => {
+    expect(isDraftReplaced(draft, new Set(["m0", "m1"]))).toBe(true);
+  });
+
+  it("is false when the committed set lacks the draft message_id", () => {
+    expect(isDraftReplaced(draft, new Set(["m0"]))).toBe(false);
+  });
+
+  it("is false for null or message_id-less drafts", () => {
+    expect(isDraftReplaced(null, new Set(["m1"]))).toBe(false);
+    expect(isDraftReplaced({ ...draft, message_id: "" }, new Set(["m1"]))).toBe(false);
+  });
+});
+
+describe("buildDraftTurn", () => {
+  const draft: DraftMirror = {
+    message_id: "msg_1",
+    parent_tool_use_id: null,
+    content: [{ type: "text", text: "流式中" }],
+    toolJson: {},
+  };
+
+  it("builds an assistant turn from an unreplaced main-timeline draft", () => {
+    const turn = buildDraftTurn(draft, false);
+    expect(turn?.type).toBe("assistant");
+    expect(turn?.uuid).toBe("draft-msg_1");
+    expect(turn?.content[0].text).toBe("流式中");
+  });
+
+  it("returns null once the draft is marked replaced (O(1) — no entries scan)", () => {
+    expect(buildDraftTurn(draft, true)).toBeNull();
+  });
+
+  it("returns null for null / empty / subagent drafts", () => {
+    expect(buildDraftTurn(null, false)).toBeNull();
+    expect(buildDraftTurn({ ...draft, content: [] }, false)).toBeNull();
+    expect(buildDraftTurn({ ...draft, parent_tool_use_id: "tu-agent" }, false)).toBeNull();
+  });
+
+  it("agrees with projectDraftToTurn across the committed-set derivation", () => {
+    const entries: TimelineEntry[] = [
+      { seq: 0, type: "assistant", message_id: "msg_1", content: [{ type: "text", text: "已提交" }] },
+    ];
+    const ids = collectCommittedMessageIds(entries);
+    expect(buildDraftTurn(draft, isDraftReplaced(draft, ids))).toEqual(projectDraftToTurn(draft, entries));
+  });
+});
+
+describe("createTimelineProjector", () => {
+  let seq = 0;
+  function e(partial: Omit<TimelineEntry, "seq">): TimelineEntry {
+    return { seq: seq++, ...partial };
+  }
+
+  function bigImageEntry(): TimelineEntry {
+    return e({
+      type: "user",
+      content: [{ type: "image", source: { type: "base64", media_type: "image/png", data: "A".repeat(2048) } }],
+      uuid: `img-${seq}`,
+    });
+  }
+
+  it("produces output value-equal to the pure projectEntriesToTurns", () => {
+    const entries: TimelineEntry[] = [
+      e({ type: "user", content: [{ type: "text", text: "你好" }], uuid: "u-1" }),
+      e({ type: "assistant", content: [{ type: "tool_use", id: "tu-1", name: "Read", input: {} }], uuid: "a-1" }),
+      e({ type: "tool_result", tool_use_id: "tu-1", content: "内容", is_error: false, uuid: "tr-1" }),
+      e({ type: "assistant", content: [{ type: "text", text: "读完了" }], uuid: "a-2" }),
+    ];
+    const projector = createTimelineProjector();
+    expect(projector.project(entries)).toEqual(projectEntriesToTurns(entries));
+  });
+
+  it("stays value-equal to the pure function across incremental appends", () => {
+    const projector = createTimelineProjector();
+    const entries: TimelineEntry[] = [];
+    const push = (entry: TimelineEntry) => {
+      entries.push(entry);
+      expect(projector.project(entries)).toEqual(projectEntriesToTurns(entries));
+    };
+    push(e({ type: "user", content: [{ type: "text", text: "q" }], uuid: "u-1" }));
+    push(e({ type: "assistant", content: [{ type: "tool_use", id: "tu-a", name: "Agent", input: {} }], uuid: "a-1" }));
+    push(e({ type: "system", subtype: "task_started", task_id: "t1", tool_use_id: "tu-a", uuid: "s-1" }));
+    push(e({ type: "tool_result", tool_use_id: "tu-a", content: "done", is_error: false, uuid: "tr-1" }));
+    push(e({ type: "assistant", content: [{ type: "text", text: "总结" }], uuid: "a-2" }));
+  });
+
+  it("does not mutate input entries even when reusing cached clones", () => {
+    const entries = [
+      e({ type: "assistant", content: [{ type: "tool_use", id: "tu-1", name: "Read", input: {} }], uuid: "a-1" }),
+      e({ type: "tool_result", tool_use_id: "tu-1", content: "r", is_error: false, uuid: "tr-1" }),
+    ];
+    const snapshot = JSON.parse(JSON.stringify(entries)) as TimelineEntry[];
+    const projector = createTimelineProjector();
+    projector.project(entries);
+    projector.project([...entries, e({ type: "assistant", content: [{ type: "text", text: "x" }], uuid: "a-2" })]);
+    expect(entries).toEqual(snapshot);
+  });
+
+  it("returns fresh turn objects each call so mutation folds never corrupt cached blocks", () => {
+    // 每次 project 折叠 tool_result/task 会就地改写 turn 内的块——若复用了上次
+    // 产出的块引用，第二次折叠会叠加在已折叠结果上。断言两次产出的块互不共享引用。
+    const entries: TimelineEntry[] = [
+      e({ type: "assistant", content: [{ type: "tool_use", id: "tu-1", name: "Read", input: {} }], uuid: "a-1" }),
+    ];
+    const projector = createTimelineProjector();
+    const first = projector.project(entries);
+    const withResult = [
+      ...entries,
+      e({ type: "tool_result", tool_use_id: "tu-1", content: "回填", is_error: false, uuid: "tr-1" }),
+    ];
+    const second = projector.project(withResult);
+    // 第一次产出的 tool_use 块不应被第二次折叠回填污染
+    expect(first[0].content[0].result).toBeUndefined();
+    expect(second[0].content[0].result).toBe("回填");
+    expect(first[0].content[0]).not.toBe(second[0].content[0]);
+  });
+
+  it("reuses the same deep-cloned block across projections instead of re-cloning (perf contract)", () => {
+    // 大 base64 image block：投影器应缓存首帧深拷贝，稳定条目重投影不再触发深拷贝。
+    // 通过桩化 structuredClone 计数验证：同一 entries 引用第二次 project 深拷贝次数为 0。
+    const img = bigImageEntry();
+    const entries: TimelineEntry[] = [img];
+    const projector = createTimelineProjector();
+
+    const original = globalThis.structuredClone;
+    let cloneCalls = 0;
+    globalThis.structuredClone = ((v: unknown) => {
+      cloneCalls++;
+      return original(v);
+    }) as typeof structuredClone;
+    try {
+      projector.project(entries);
+      expect(cloneCalls).toBeGreaterThan(0);
+      // 稳定重投影：老条目的块已缓存 → 不再深拷贝
+      cloneCalls = 0;
+      projector.project(entries);
+      expect(cloneCalls).toBe(0);
+      // 追加新条目重投影：老 image 块仍复用缓存，深拷贝只作用于新条目而非 2KB 图像
+      const next = [...entries, e({ type: "assistant", content: [{ type: "text", text: "hi" }], uuid: "a-1" })];
+      cloneCalls = 0;
+      projector.project(next);
+      // 新增的是纯文本块（浅结构，无 base64），旧 image 块 0 次重拷 → 总深拷贝 ≤ 1
+      expect(cloneCalls).toBeLessThanOrEqual(1);
+    } finally {
+      globalThis.structuredClone = original;
+    }
+  });
+
+  it("evicts cache entries for seqs no longer present (bounded memory on reset)", () => {
+    const projector = createTimelineProjector();
+    const first = [e({ type: "user", content: [{ type: "text", text: "旧会话" }], uuid: "u-1" })];
+    projector.project(first);
+    // 切换会话：全新 entries，旧 seq 不再出现
+    const second = [e({ type: "assistant", content: [{ type: "text", text: "新会话" }], uuid: "a-9" })];
+    const out = projector.project(second);
+    expect(out).toEqual(projectEntriesToTurns(second));
+    expect(projector.size).toBe(1);
+  });
+
+  it("returns the same array reference for a repeated stable projection", () => {
+    const projector = createTimelineProjector();
+    const entries = [e({ type: "user", content: [{ type: "text", text: "hi" }], uuid: "u-1" })];
+    const first = projector.project(entries);
+    expect(projector.project(entries)).toBe(first);
+  });
+
+  it("stays equivalent to fresh replay through incremental subagent anchoring", () => {
+    // 覆盖增量路径最复杂的分支：锚点先于子条目、子条目先于锚点（合成卡片→回收）、
+    // 嵌套 subagent、task 折叠、跨 turn question_answer 回填。
+    const stream: TimelineEntry[] = [
+      e({ type: "user", content: [{ type: "text", text: "开始" }], uuid: "u-1" }),
+      // 孤儿子时间线：锚点尚不存在 → 合成卡片
+      e({ type: "assistant", content: [{ type: "text", text: "孤儿" }], uuid: "sa-1", parent_tool_use_id: "tu-late" }),
+      // 锚点补到 → 合成卡片应并回主时间线
+      e({ type: "assistant", content: [{ type: "tool_use", id: "tu-late", name: "Agent", input: {} }], uuid: "a-1" }),
+      e({ type: "system", subtype: "task_started", task_id: "t1", tool_use_id: "tu-late", description: "外层", uuid: "s-1" }),
+      // 嵌套 subagent：内层锚点在外层子时间线内
+      e({
+        type: "assistant",
+        content: [{ type: "tool_use", id: "tu-inner", name: "Agent", input: {} }],
+        uuid: "sa-2",
+        parent_tool_use_id: "tu-late",
+      }),
+      e({ type: "assistant", content: [{ type: "text", text: "内层回复" }], uuid: "sa-3", parent_tool_use_id: "tu-inner" }),
+      // 提问 → 中断把 turn 提前 flush → 答复跨 turn 回填
+      e({
+        type: "assistant",
+        content: [{ type: "tool_use", id: "tu-q", name: "AskUserQuestion", input: {} }],
+        uuid: "a-2",
+      }),
+      e({ type: "system", subtype: "interrupt", uuid: "i-1" }),
+      e({
+        type: "user",
+        subtype: "question_answer",
+        tool_use_id: "tu-q",
+        content: "answered",
+        is_error: false,
+        answers: { q: "yes" },
+        uuid: "qa-1",
+      }),
+      e({ type: "tool_result", tool_use_id: "tu-late", content: "外层完成", is_error: false, uuid: "tr-1" }),
+      e({ type: "assistant", content: [{ type: "text", text: "总结" }], uuid: "a-3" }),
+    ];
+    const projector = createTimelineProjector();
+    for (let i = 1; i <= stream.length; i++) {
+      const prefix = stream.slice(0, i);
+      expect(projector.project(prefix), `前缀长度 ${i} 应与全量重放一致`).toEqual(projectEntriesToTurns(prefix));
+    }
+  });
+
+  it("matches fresh replay at every prefix of seeded random entry streams", () => {
+    for (const seed of [7, 42, 1058]) {
+      const stream = generateEntryStream(seed, 80);
+      const projector = createTimelineProjector();
+      for (let i = 1; i <= stream.length; i++) {
+        const prefix = stream.slice(0, i);
+        expect(projector.project(prefix), `seed=${seed} 前缀长度 ${i} 应与全量重放一致`).toEqual(
+          projectEntriesToTurns(prefix),
+        );
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 随机条目流生成器 — 线性同余伪随机（种子可复现），覆盖各条目类型组合。
+// ---------------------------------------------------------------------------
+
+function generateEntryStream(seed: number, length: number): TimelineEntry[] {
+  let state = seed >>> 0;
+  const rng = (): number => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+  const pick = <T,>(items: T[]): T => items[Math.floor(rng() * items.length)];
+  const chance = (p: number): boolean => rng() < p;
+
+  const entries: TimelineEntry[] = [];
+  const toolIds: string[] = [];
+  const taskIds: string[] = [];
+  let toolCounter = 0;
+  let taskCounter = 0;
+
+  for (let seq = 0; seq < length; seq++) {
+    let entry: TimelineEntry;
+    const roll = rng();
+    if (roll < 0.35) {
+      if (chance(0.5)) {
+        entry = {
+          seq,
+          type: "assistant",
+          uuid: `a-${seq}`,
+          message_id: chance(0.5) ? `msg-${seq}` : undefined,
+          content: [{ type: "text", text: `文本${seq}` }],
+        };
+      } else {
+        const id = `tu-${toolCounter++}`;
+        toolIds.push(id);
+        entry = {
+          seq,
+          type: "assistant",
+          uuid: `a-${seq}`,
+          content: [{ type: "tool_use", id, name: pick(["Read", "Agent", "Skill", "AskUserQuestion"]), input: { n: seq } }],
+        };
+      }
+    } else if (roll < 0.5) {
+      entry = {
+        seq,
+        type: "tool_result",
+        uuid: `tr-${seq}`,
+        tool_use_id: toolIds.length > 0 && chance(0.8) ? pick(toolIds) : `tu-ghost-${seq}`,
+        content: `结果${seq}`,
+        is_error: chance(0.2),
+      };
+    } else if (roll < 0.72) {
+      const sub = rng();
+      if (sub < 0.15) {
+        entry = { seq, type: "system", subtype: "interrupt", uuid: `i-${seq}` };
+      } else if (sub < 0.3) {
+        entry = {
+          seq,
+          type: "system",
+          subtype: "skill_invocation",
+          skill_name: "demo",
+          skill_args: `s${seq}`,
+          tool_use_id: toolIds.length > 0 && chance(0.5) ? pick(toolIds) : null,
+          uuid: `sk-${seq}`,
+        };
+      } else if (sub < 0.4) {
+        // 未知子类型：投影应忽略
+        entry = { seq, type: "system", subtype: "noise", uuid: `n-${seq}` };
+      } else {
+        const started = taskIds.length === 0 || chance(0.4);
+        const taskId = started ? `t-${taskCounter++}` : pick(taskIds);
+        if (started) taskIds.push(taskId);
+        entry = {
+          seq,
+          type: "system",
+          subtype: started ? "task_started" : pick(["task_progress", "task_notification"]),
+          task_id: taskId,
+          tool_use_id: toolIds.length > 0 && chance(0.6) ? pick(toolIds) : undefined,
+          description: `任务${taskId}`,
+          summary: chance(0.5) ? `进展${seq}` : undefined,
+          task_status: chance(0.3) ? "completed" : undefined,
+          usage: chance(0.5) ? { total_tokens: seq } : undefined,
+          uuid: `t-${seq}`,
+        };
+      }
+    } else if (roll < 0.85) {
+      entry = {
+        seq,
+        type: "user",
+        subtype: "question_answer",
+        tool_use_id: toolIds.length > 0 && chance(0.7) ? pick(toolIds) : `tu-ghost-${seq}`,
+        content: `答复${seq}`,
+        is_error: chance(0.3),
+        answers: chance(0.5) ? { [`q${seq}`]: "选项" } : undefined,
+        uuid: `qa-${seq}`,
+      };
+    } else {
+      entry = { seq, type: "user", uuid: `u-${seq}`, content: [{ type: "text", text: `用户${seq}` }] };
+    }
+    // 30% 概率归入某已存在锚点的子时间线，偶发 ghost 组
+    if (toolIds.length > 0 && chance(0.3)) entry.parent_tool_use_id = pick(toolIds);
+    else if (chance(0.05)) entry.parent_tool_use_id = `ghost-${Math.floor(rng() * 3)}`;
+    entries.push(entry);
+  }
+  return entries;
+}
 
 describe("mergeEntriesBySeq", () => {
   function e(seq: number, uuid: string): TimelineEntry {

--- a/frontend/src/utils/entry-projection.test.ts
+++ b/frontend/src/utils/entry-projection.test.ts
@@ -797,6 +797,56 @@ describe("createTimelineProjector", () => {
       }
     }
   });
+
+  it("degrades to a synthetic card instead of dropping the whole timeline when parent_tool_use_id self-references", () => {
+    // 条目的 parent_tool_use_id 等于自身 tool_use id：畸形/自指数据，真实
+    // server 写入点不会产生，但投影器不应把整段时间线静默丢空。
+    const entries: TimelineEntry[] = [
+      e({
+        type: "assistant",
+        content: [{ type: "tool_use", id: "tu-self", name: "Agent", input: {} }],
+        uuid: "a-1",
+        parent_tool_use_id: "tu-self",
+      }),
+    ];
+    const turns = projectEntriesToTurns(entries);
+    expect(turns).toHaveLength(1);
+    expect(turns[0].content[0]).toMatchObject({ type: "tool_use", id: "tu-self" });
+  });
+
+  it("degrades to synthetic cards instead of dropping the whole timeline when two subagent groups mutually anchor each other", () => {
+    // entry0 属于 tu-A 的子时间线、自身携带 tool_use tu-B；entry1 属于 tu-B
+    // 的子时间线、自身携带 tool_use tu-A —— 两组互相锚定成环，main 为空。
+    const entries: TimelineEntry[] = [
+      e({ type: "assistant", content: [{ type: "tool_use", id: "tu-b", name: "Agent", input: {} }], uuid: "a-1", parent_tool_use_id: "tu-a" }),
+      e({ type: "assistant", content: [{ type: "tool_use", id: "tu-a", name: "Agent", input: {} }], uuid: "a-2", parent_tool_use_id: "tu-b" }),
+    ];
+    const turns = projectEntriesToTurns(entries);
+    expect(turns.length).toBeGreaterThan(0);
+    const projector = createTimelineProjector();
+    expect(projector.project(entries)).toEqual(turns);
+  });
+
+  it("keeps compose()'s pending-group scan bounded to currently-unanchored groups, not total historical subagent count", () => {
+    // 一批 subagent 组全部锚定完成后，projector.size 之外还应有一个可观测
+    // 信号证明 compose() 不再对已锚定完成的历史组做全表扫描：直接量 size
+    // 属性只反映 entries 数，这里改为验证锚定后继续追加主时间线消息时输出
+    // 仍与全量重放一致（锚定组已完成不应再出现在顶层合成卡片里）。
+    const entries: TimelineEntry[] = [];
+    const projector = createTimelineProjector();
+    for (let i = 0; i < 50; i++) {
+      const toolId = `tu-${i}`;
+      entries.push(e({ type: "assistant", content: [{ type: "tool_use", id: toolId, name: "Agent", input: {} }], uuid: `a-${i}` }));
+      entries.push(e({ type: "assistant", content: [{ type: "text", text: `子回复${i}` }], uuid: `sa-${i}`, parent_tool_use_id: toolId }));
+      entries.push(e({ type: "tool_result", tool_use_id: toolId, content: "done", is_error: false, uuid: `tr-${i}` }));
+    }
+    entries.push(e({ type: "assistant", content: [{ type: "text", text: "主时间线消息" }], uuid: "a-final" }));
+    const turns = projector.project(entries);
+    expect(turns).toEqual(projectEntriesToTurns(entries));
+    // 全部 50 个 subagent 组都已锚定在各自 tool_use 块上，顶层不应再出现
+    // 任何合成卡片（system + subagent-* uuid）。
+    expect(turns.filter((t) => typeof t.uuid === "string" && t.uuid.startsWith("subagent-"))).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/utils/entry-projection.test.ts
+++ b/frontend/src/utils/entry-projection.test.ts
@@ -267,6 +267,31 @@ describe("projectEntriesToTurns", () => {
     expect(turns[0].content[0].type).toBe("tool_use");
   });
 
+  it("still recognizes the Skill tool_use anchor after it's flushed to an earlier turn by an interrupt", () => {
+    // anchored 判定若只看 fold.cursor，Skill 的 tool_use 块所在 turn 一旦被
+    // interrupt 等条目提前 flush 出当前 turn，后到的 skill_invocation 就会
+    // 误判为"未锚定"，重复渲染一个独立芯片。toolUseSites 登记在 tool_use
+    // 块本身追加时发生，比 cursor 更持久，应据此判定而非只看当前 turn。
+    const turns = projectEntriesToTurns([
+      entry({
+        type: "assistant",
+        content: [{ type: "tool_use", id: "tu-s", name: "Skill", input: { skill: "manage-project", args: "x" } }],
+        uuid: "a-1",
+      }),
+      entry({ type: "system", subtype: "interrupt", uuid: "i-1" }),
+      entry({
+        type: "system",
+        subtype: "skill_invocation",
+        skill_name: "manage-project",
+        skill_args: "x",
+        tool_use_id: "tu-s",
+        uuid: "s-1",
+      }),
+    ]);
+    expect(turns).toHaveLength(2);
+    expect(turns.some((t) => t.content.some((b) => b.type === "skill_invocation"))).toBe(false);
+  });
+
   it("renders unanchored skill_invocation entries as standalone chip blocks", () => {
     const turns = projectEntriesToTurns([
       entry({

--- a/frontend/src/utils/entry-projection.ts
+++ b/frontend/src/utils/entry-projection.ts
@@ -1,11 +1,21 @@
 /**
- * 会话事件日志投影 — entries → Turn[] 纯函数。
+ * 会话事件日志投影 — entries → Turn[]。
  *
  * 日志条目已在服务端写入点定型（tool_result 独立条目、interrupt / task 通知 /
  * AskUserQuestion 答复为 typed 条目、subagent 条目带 parent_tool_use_id、
  * stream_event 不入日志），本模块只做渲染归组：连续 assistant 条目合并、
  * tool_result 按 tool_use_id 回填、task 按 task_id 就地更新。
  * 不做内容嗅探、不做内容比对去重、不合成消息。
+ *
+ * 投影分两层：
+ * - 内部累积态（fold）：逐条消费条目，只做追加与按 id 回填，永不回溯重放；
+ *   条目块在此层做唯一一次深拷贝。
+ * - 展示视图（display）：由累积态按 turn 派生——task 折叠、滞留子任务推导
+ *   完成、subagent 子时间线挂载都在这层重算；按 turn 版本缓存，只有被新
+ *   条目触达的 turn 重建视图，未触达的 turn 保持引用稳定。
+ *
+ * `projectEntriesToTurns` 是纯函数入口（空投影器全量重放）；
+ * `createTimelineProjector` 是同一实现的增量入口，二者结果恒等。
  */
 
 import type {
@@ -28,102 +38,6 @@ function blocksText(blocks: ContentBlock[]): string {
     .filter((b) => b.type === "text")
     .map((b) => b.text ?? "")
     .join("\n");
-}
-
-// ---------------------------------------------------------------------------
-// 归组辅助
-// ---------------------------------------------------------------------------
-
-function attachToolResult(turnContent: ContentBlock[], entry: TimelineEntry): void {
-  const toolUseId = entry.tool_use_id;
-  const resultText = typeof entry.content === "string" ? entry.content : blocksText(entryBlocks(entry));
-  if (toolUseId) {
-    for (const block of turnContent) {
-      if (block.type === "tool_use" && block.id === toolUseId) {
-        block.result = resultText;
-        block.is_error = Boolean(entry.is_error);
-        return;
-      }
-    }
-  }
-  turnContent.push({
-    type: "tool_result",
-    tool_use_id: toolUseId ?? undefined,
-    content: resultText,
-    is_error: Boolean(entry.is_error),
-  });
-}
-
-function findTaskBlock(turn: Turn | null, taskId: string): ContentBlock | null {
-  if (!turn) return null;
-  for (const block of turn.content) {
-    if (block.type === "task_progress" && block.task_id === taskId) return block;
-  }
-  return null;
-}
-
-/** 在当前 assistant turn 中按 tool_use_id 定位 tool_use 块。 */
-function findToolUseBlockInTurn(turn: Turn | null, toolUseId: string): ContentBlock | null {
-  if (!turn || turn.type !== "assistant") return null;
-  for (const block of turn.content) {
-    if (block.type === "tool_use" && block.id === toolUseId) return block;
-  }
-  return null;
-}
-
-/** task_started 块对应的 Agent tool_use 已有 result 时推导为已完成。 */
-function resolveStaleTaskBlocks(turns: Turn[]): void {
-  for (const turn of turns) {
-    const completedToolIds = new Set<string>();
-    for (const block of turn.content) {
-      if (block.type === "tool_use" && block.name === "Agent" && block.result !== undefined && block.id) {
-        completedToolIds.add(block.id);
-      }
-    }
-    if (completedToolIds.size === 0) continue;
-    for (const block of turn.content) {
-      if (
-        block.type === "task_progress" &&
-        block.status === "task_started" &&
-        block.tool_use_id &&
-        completedToolIds.has(block.tool_use_id)
-      ) {
-        block.status = "task_notification";
-        block.task_status = "completed";
-      }
-    }
-  }
-}
-
-/**
- * task_progress 块折叠进同 turn 的锚点 tool_use：子任务卡片就地显示
- * 状态与进度，不再渲染独立进度行。无锚点的 task 块保持原样。
- */
-function foldTaskBlocksIntoAnchors(turns: Turn[]): void {
-  for (const turn of turns) {
-    const toolUseById = new Map<string, ContentBlock>();
-    for (const block of turn.content) {
-      if (block.type === "tool_use" && block.id) toolUseById.set(block.id, block);
-    }
-    if (toolUseById.size === 0) continue;
-    turn.content = turn.content.filter((block) => {
-      if (block.type !== "task_progress" || !block.tool_use_id) return true;
-      const anchor = toolUseById.get(block.tool_use_id);
-      if (!anchor) return true;
-      anchor.task_info = block;
-      return false;
-    });
-  }
-}
-
-/** 在既有 turns 中查找指定 id 的 tool_use 块（subagent 卡片锚点）。 */
-function findToolUseBlock(turns: Turn[], toolUseId: string): ContentBlock | null {
-  for (const turn of turns) {
-    for (const block of turn.content) {
-      if (block.type === "tool_use" && block.id === toolUseId) return block;
-    }
-  }
-  return null;
 }
 
 function cloneBlock(block: ContentBlock): ContentBlock {
@@ -150,139 +64,227 @@ export function mergeEntriesBySeq(
 }
 
 // ---------------------------------------------------------------------------
-// projectEntriesToTurns — 主投影
+// 增量投影器
 // ---------------------------------------------------------------------------
 
-/**
- * 按 parent_tool_use_id 归组 subagent 条目并投影为子时间线：
- * 子组递归投影为 Turn[]，挂到锚点 tool_use 块的 sub_turns；
- * 主时间线只保留单一卡片锚点，不平铺 subagent 内部消息。
- *
- * 锚点可能落在主时间线，也可能落在另一子组自己的子时间线内——subagent
- * 自身再起 subagent 时，内层子组的锚点 tool_use 只存在于外层子组的
- * 子时间线中。因此锚点定位在“主时间线 ∪ 全部子组”范围内查找，不限于
- * 主时间线；子组各自独立投影、互不依赖顺序，任意嵌套深度一次收敛。
- */
-export function projectEntriesToTurns(entries: TimelineEntry[]): Turn[] {
-  const subgroups = new Map<string, TimelineEntry[]>();
-  const mainEntries: TimelineEntry[] = [];
-  for (const entry of entries) {
-    if (entry.parent_tool_use_id) {
-      const group = subgroups.get(entry.parent_tool_use_id);
-      if (group) {
-        group.push(entry);
-      } else {
-        subgroups.set(entry.parent_tool_use_id, [entry]);
-      }
-    } else {
-      mainEntries.push(entry);
-    }
-  }
-
-  const turns = projectFlatEntries(mainEntries);
-
-  // 先独立投影并折叠每个子组自身的 task 进度，再统一定位锚点：折叠结果
-  // 与锚点搜索空间的构建互不依赖，任意处理顺序都收敛到同一结果。
-  const subTurnsByParent = new Map<string, Turn[]>();
-  for (const [parentId, group] of subgroups) {
-    const subTurns = projectFlatEntries(group.map(({ parent_tool_use_id: _omit, ...rest }) => rest));
-    resolveStaleTaskBlocks(subTurns);
-    foldTaskBlocksIntoAnchors(subTurns);
-    subTurnsByParent.set(parentId, subTurns);
-  }
-
-  const searchSpace = [turns, ...subTurnsByParent.values()];
-  for (const [parentId, subTurns] of subTurnsByParent) {
-    const anchor = findAnchorAcross(searchSpace, parentId);
-    if (anchor) {
-      anchor.sub_turns = subTurns;
-    } else {
-      // 全局仍无锚点（如懒生成残余组）：以合成锚点独立成卡，不丢子时间线
-      turns.push({
-        type: "system",
-        content: [{ type: "tool_use", id: parentId, name: "Agent", input: {}, sub_turns: subTurns }],
-        uuid: `subagent-${parentId}`,
-      });
-    }
-  }
-
-  resolveStaleTaskBlocks(turns);
-  foldTaskBlocksIntoAnchors(turns);
-  return turns;
+/** 内部累积态的 turn：content 为可就地回填的内部块，version 是展示缓存键。 */
+interface InternalTurn {
+  type: Turn["type"];
+  content: ContentBlock[];
+  uuid?: string;
+  timestamp?: string;
+  version: number;
 }
 
-function findAnchorAcross(turnsList: Turn[][], toolUseId: string): ContentBlock | null {
-  for (const turns of turnsList) {
-    const found = findToolUseBlock(turns, toolUseId);
-    if (found) return found;
-  }
-  return null;
+/** tool_use 块的登记位置：跨 turn 回填与 subagent 锚定都按此 O(1) 定位。 */
+interface ToolUseSite {
+  fold: Fold;
+  turn: InternalTurn;
+  block: ContentBlock;
 }
 
-function projectFlatEntries(entries: TimelineEntry[]): Turn[] {
-  const turns: Turn[] = [];
-  // 用持有器承载当前 turn：闭包内赋值会让 TS 把裸 let 收窄成 never
-  const cursor: { current: Turn | null } = { current: null };
+/** 一条平铺时间线（主时间线或某个 subagent 组）的折叠状态。 */
+interface Fold {
+  committed: InternalTurn[];
+  cursor: InternalTurn | null;
+  /** 所属 subagent 组（主时间线为 null），脏标记沿锚链向上传播用。 */
+  group: SubagentGroup | null;
+  version: number;
+  displayVersion: number;
+  display: Turn[];
+}
 
-  const flush = (): void => {
-    if (cursor.current) {
-      turns.push(cursor.current);
-      cursor.current = null;
+interface SubagentGroup {
+  id: string;
+  fold: Fold;
+  /** 锚点 tool_use 的位置；null 表示尚未锚定（顶层渲染合成卡片）。 */
+  anchor: ToolUseSite | null;
+}
+
+export interface TimelineProjector {
+  /**
+   * 投影 entries → Turn[]，结果与 `projectEntriesToTurns(entries)` 逐值相等。
+   * entries 须遵循事件日志契约：按 seq 升序、同 seq 条目不可变、相邻两次
+   * 调用之间集合只增不减（append-only 并集）。前缀未变时只折叠新增后缀，
+   * 否则整体重放。
+   */
+  project(entries: TimelineEntry[]): Turn[];
+  /** 已增量消费的条目数（缓存规模观测，测试用）。 */
+  readonly size: number;
+}
+
+export function createTimelineProjector(): TimelineProjector {
+  // 前缀指纹：source 为上次 project 的 entries 引用，count 为已折叠条目数
+  let source: TimelineEntry[] = [];
+  let count = 0;
+
+  let versionCounter = 0;
+  let main: Fold = newFold();
+  let groups = new Map<string, SubagentGroup>();
+  let toolUseSites = new Map<string, ToolUseSite>();
+  let turnViewCache = new WeakMap<InternalTurn, { version: number; turn: Turn }>();
+  let composed: Turn[] = [];
+  let composedDirty = true;
+
+  function newFold(): Fold {
+    return { committed: [], cursor: null, group: null, version: 0, displayVersion: -1, display: [] };
+  }
+
+  function reset(): void {
+    versionCounter = 0;
+    main = newFold();
+    groups = new Map();
+    toolUseSites = new Map();
+    turnViewCache = new WeakMap();
+    composed = [];
+    composedDirty = true;
+    count = 0;
+  }
+
+  /** 条目触达 turn 后：失效其展示缓存，并沿 subagent 锚链逐层失效祖先 turn。 */
+  function touch(fold: Fold, turn: InternalTurn): void {
+    composedDirty = true;
+    turn.version = ++versionCounter;
+    const seen = new Set<Fold>();
+    let current: Fold | null = fold;
+    while (current && !seen.has(current)) {
+      seen.add(current);
+      current.version = ++versionCounter;
+      const anchor: ToolUseSite | null = current.group?.anchor ?? null;
+      if (!anchor) break;
+      anchor.turn.version = ++versionCounter;
+      current = anchor.fold;
     }
-  };
+  }
 
-  const startTurn = (turn: Turn): void => {
-    flush();
-    cursor.current = turn;
-  };
+  function startTurn(fold: Fold, type: Turn["type"], content: ContentBlock[], entry: TimelineEntry): InternalTurn {
+    if (fold.cursor) fold.committed.push(fold.cursor);
+    const turn: InternalTurn = { type, content, uuid: entry.uuid, timestamp: entry.timestamp, version: 0 };
+    fold.cursor = turn;
+    touch(fold, turn);
+    return turn;
+  }
 
   /** 追加系统注入块：优先并入当前 assistant turn，否则开 system turn。 */
-  const attachSystemBlock = (entry: TimelineEntry, block: ContentBlock): void => {
-    if (cursor.current && cursor.current.type === "assistant") {
-      cursor.current.content.push(block);
+  function attachSystemBlock(fold: Fold, entry: TimelineEntry, block: ContentBlock): void {
+    if (fold.cursor && fold.cursor.type === "assistant") {
+      fold.cursor.content.push(block);
+      touch(fold, fold.cursor);
       return;
     }
-    startTurn({ type: "system", content: [block], uuid: entry.uuid, timestamp: entry.timestamp });
-  };
+    startTurn(fold, "system", [block], entry);
+  }
 
-  const applyTaskBlock = (entry: TimelineEntry, taskBlock: ContentBlock, updateOnly: boolean): void => {
+  function findTaskBlock(content: ContentBlock[], taskId: string): ContentBlock | null {
+    for (const block of content) {
+      if (block.type === "task_progress" && block.task_id === taskId) return block;
+    }
+    return null;
+  }
+
+  function applyTaskBlock(fold: Fold, entry: TimelineEntry, taskBlock: ContentBlock, updateOnly: boolean): void {
     const taskId = taskBlock.task_id;
-    if (taskId && updateOnly) {
-      const existing = findTaskBlock(cursor.current, taskId);
+    if (taskId && updateOnly && fold.cursor) {
+      const existing = findTaskBlock(fold.cursor.content, taskId);
       if (existing) {
         existing.status = taskBlock.status;
         if (taskBlock.summary) existing.summary = taskBlock.summary;
         if (taskBlock.task_status) existing.task_status = taskBlock.task_status;
         if (taskBlock.usage) existing.usage = taskBlock.usage;
+        touch(fold, fold.cursor);
         return;
       }
     }
-    attachSystemBlock(entry, taskBlock);
-  };
+    attachSystemBlock(fold, entry, taskBlock);
+  }
 
-  for (const entry of entries) {
+  /** tool_result 回填当前 turn 内的发起 tool_use；无匹配时追加独立结果块。 */
+  function attachToolResult(turnContent: ContentBlock[], entry: TimelineEntry): void {
+    const toolUseId = entry.tool_use_id;
+    const resultText = typeof entry.content === "string" ? entry.content : blocksText(entryBlocks(entry));
+    if (toolUseId) {
+      for (const block of turnContent) {
+        if (block.type === "tool_use" && block.id === toolUseId) {
+          block.result = resultText;
+          block.is_error = Boolean(entry.is_error);
+          return;
+        }
+      }
+    }
+    turnContent.push({
+      type: "tool_result",
+      tool_use_id: toolUseId ?? undefined,
+      content: resultText,
+      is_error: Boolean(entry.is_error),
+    });
+  }
+
+  /** 登记 tool_use 块位置（同 id 首次登记生效），并锚定等待中的 subagent 组。 */
+  function registerToolUse(fold: Fold, turn: InternalTurn, block: ContentBlock): void {
+    const id = block.id;
+    if (!id) return;
+    if (!toolUseSites.has(id)) toolUseSites.set(id, { fold, turn, block });
+    const group = groups.get(id);
+    if (group && !group.anchor) {
+      const site = toolUseSites.get(id);
+      if (site) {
+        group.anchor = site;
+        // 合成卡片并回锚点：锚点 turn 展示需重建，顶层合成卡片消失
+        touch(site.fold, site.turn);
+      }
+    }
+  }
+
+  /** 取 parent_tool_use_id 对应的子时间线折叠状态，组首现时尝试锚定。 */
+  function groupFoldFor(parentId: string): Fold {
+    let group = groups.get(parentId);
+    if (!group) {
+      const fold = newFold();
+      group = { id: parentId, fold, anchor: null };
+      fold.group = group;
+      groups.set(parentId, group);
+      const site = toolUseSites.get(parentId);
+      if (site) {
+        group.anchor = site;
+        touch(site.fold, site.turn);
+      }
+      composedDirty = true;
+    }
+    return group.fold;
+  }
+
+  function appendOne(entry: TimelineEntry): void {
+    const fold = entry.parent_tool_use_id ? groupFoldFor(entry.parent_tool_use_id) : main;
+
     if (entry.type === "assistant") {
       const blocks = entryBlocks(entry).map(cloneBlock);
-      if (cursor.current && cursor.current.type === "assistant") {
-        cursor.current.content.push(...blocks);
+      let turn: InternalTurn;
+      if (fold.cursor && fold.cursor.type === "assistant") {
+        fold.cursor.content.push(...blocks);
+        turn = fold.cursor;
+        touch(fold, turn);
       } else {
-        startTurn({ type: "assistant", content: blocks, uuid: entry.uuid, timestamp: entry.timestamp });
+        turn = startTurn(fold, "assistant", blocks, entry);
       }
-      continue;
+      for (const block of blocks) {
+        if (block.type === "tool_use") registerToolUse(fold, turn, block);
+      }
+      return;
     }
 
     if (entry.type === "tool_result") {
-      if (cursor.current && cursor.current.type === "assistant") {
-        attachToolResult(cursor.current.content, entry);
+      if (fold.cursor && fold.cursor.type === "assistant") {
+        attachToolResult(fold.cursor.content, entry);
+        touch(fold, fold.cursor);
       } else {
-        attachSystemBlock(entry, {
+        attachSystemBlock(fold, entry, {
           type: "tool_result",
           tool_use_id: entry.tool_use_id ?? undefined,
           content: typeof entry.content === "string" ? entry.content : blocksText(entryBlocks(entry)),
           is_error: Boolean(entry.is_error),
         });
       }
-      continue;
+      return;
     }
 
     if (entry.type === "system") {
@@ -291,31 +293,27 @@ function projectFlatEntries(entries: TimelineEntry[]): Turn[] {
         // 当前 turn 有锚点时不再追加，避免同一调用出现两枚芯片
         const anchored =
           entry.tool_use_id != null &&
-          cursor.current !== null &&
-          cursor.current.content.some((b) => b.type === "tool_use" && b.id === entry.tool_use_id);
+          fold.cursor !== null &&
+          fold.cursor.content.some((b) => b.type === "tool_use" && b.id === entry.tool_use_id);
         if (!anchored) {
-          attachSystemBlock(entry, {
+          attachSystemBlock(fold, entry, {
             type: "skill_invocation",
             skill_name: entry.skill_name ?? undefined,
             skill_args: entry.skill_args ?? undefined,
             tool_use_id: entry.tool_use_id ?? undefined,
           });
         }
-        continue;
+        return;
       }
       if (entry.subtype === "interrupt") {
-        startTurn({
-          type: "system",
-          content: [{ type: "interrupt_notice" }],
-          uuid: entry.uuid,
-          timestamp: entry.timestamp,
-        });
-        continue;
+        startTurn(fold, "system", [{ type: "interrupt_notice" }], entry);
+        return;
       }
       if (entry.subtype !== "task_started" && entry.subtype !== "task_progress" && entry.subtype !== "task_notification") {
-        continue;
+        return;
       }
       applyTaskBlock(
+        fold,
         entry,
         {
           type: "task_progress",
@@ -329,7 +327,7 @@ function projectFlatEntries(entries: TimelineEntry[]): Turn[] {
         },
         entry.subtype !== "task_started",
       );
-      continue;
+      return;
     }
 
     // entry.type === "user"
@@ -337,65 +335,191 @@ function projectFlatEntries(entries: TimelineEntry[]): Turn[] {
       const resultText = typeof entry.content === "string" ? entry.content : blocksText(entryBlocks(entry));
       const answers = entry.answers ?? undefined;
       // 回填提问的 AskUserQuestion tool_use 块：结果状态不悬挂，问题卡可标记所选。
-      // 先查当前 turn（常见路径），未命中时退回已 flush 的 turns——pending 提问期间
-      // 若有 interrupt 之类的条目提前把该 turn flush 出去，锚点仍要能跨 turn 找回。
-      const toolUse = entry.tool_use_id
-        ? (findToolUseBlockInTurn(cursor.current, entry.tool_use_id) ?? findToolUseBlock(turns, entry.tool_use_id))
-        : null;
-      if (toolUse) {
-        toolUse.result = resultText;
-        toolUse.is_error = Boolean(entry.is_error);
-        if (answers) toolUse.answers = { ...answers };
+      // 按登记索引 O(1) 定位，限定同一时间线（pending 提问期间若有 interrupt 之类
+      // 的条目提前把该 turn flush 出去，锚点仍要能跨 turn 找回）。
+      let site: ToolUseSite | null = null;
+      if (entry.tool_use_id) {
+        const hit = toolUseSites.get(entry.tool_use_id);
+        if (hit && hit.fold === fold) site = hit;
+      }
+      if (site) {
+        site.block.result = resultText;
+        site.block.is_error = Boolean(entry.is_error);
+        if (answers) site.block.answers = { ...answers };
+        touch(site.fold, site.turn);
       }
       if (entry.is_error) {
         // 被拒/中断的提问没有用户答复；无处回填时保留孤立结果块
-        if (!toolUse) {
-          attachSystemBlock(entry, {
+        if (!site) {
+          attachSystemBlock(fold, entry, {
             type: "tool_result",
             tool_use_id: entry.tool_use_id ?? undefined,
             content: resultText,
             is_error: true,
           });
         }
-        continue;
+        return;
       }
-      startTurn({
-        type: "user",
-        content: [{ type: "question_answer", answers, text: resultText }],
-        uuid: entry.uuid,
-        timestamp: entry.timestamp,
-      });
-      continue;
+      startTurn(fold, "user", [{ type: "question_answer", answers, text: resultText }], entry);
+      return;
     }
 
-    const blocks = entryBlocks(entry).map(cloneBlock);
-
-    startTurn({ type: "user", content: blocks, uuid: entry.uuid, timestamp: entry.timestamp });
+    startTurn(fold, "user", entryBlocks(entry).map(cloneBlock), entry);
   }
 
-  flush();
-  return turns;
+  // -------------------------------------------------------------------------
+  // 展示视图 — 由累积态派生，按 turn 版本缓存
+  // -------------------------------------------------------------------------
+
+  function foldDisplay(fold: Fold): Turn[] {
+    if (fold.displayVersion === fold.version) return fold.display;
+    const internal = fold.cursor ? [...fold.committed, fold.cursor] : [...fold.committed];
+    fold.display = internal.map(turnView);
+    fold.displayVersion = fold.version;
+    return fold.display;
+  }
+
+  function turnView(turn: InternalTurn): Turn {
+    const cached = turnViewCache.get(turn);
+    if (cached && cached.version === turn.version) return cached.turn;
+    const built = buildTurnView(turn);
+    turnViewCache.set(turn, { version: turn.version, turn: built });
+    return built;
+  }
+
+  /**
+   * 构建单个 turn 的展示视图：挂载 subagent 子时间线、把已完成 Agent 调用
+   * 的滞留 task_started 推导为完成、将 task 进度折叠进锚点 tool_use（子任务
+   * 卡片就地显示状态与进度，不渲染独立进度行；无锚点的 task 块保持原样）。
+   * 可变块（tool_use / task_progress）逐次浅拷，累积态不被展示层污染，
+   * 同一版本重复构建收敛到同一结果。
+   */
+  function buildTurnView(turn: InternalTurn): Turn {
+    const content: ContentBlock[] = [];
+    let toolUseById: Map<string, ContentBlock> | null = null;
+    let completedAgentIds: Set<string> | null = null;
+    for (const block of turn.content) {
+      if (block.type === "tool_use") {
+        const view = { ...block };
+        if (block.id) {
+          const group = groups.get(block.id);
+          if (group && group.anchor?.block === block) view.sub_turns = foldDisplay(group.fold);
+          (toolUseById ??= new Map()).set(block.id, view);
+          if (view.name === "Agent" && view.result !== undefined) (completedAgentIds ??= new Set()).add(block.id);
+        }
+        content.push(view);
+      } else if (block.type === "task_progress") {
+        content.push({ ...block });
+      } else {
+        content.push(block);
+      }
+    }
+    // task_started 块对应的 Agent tool_use 已有 result 时推导为已完成
+    if (completedAgentIds) {
+      const completed = completedAgentIds;
+      for (const block of content) {
+        if (
+          block.type === "task_progress" &&
+          block.status === "task_started" &&
+          block.tool_use_id &&
+          completed.has(block.tool_use_id)
+        ) {
+          block.status = "task_notification";
+          block.task_status = "completed";
+        }
+      }
+    }
+    let finalContent = content;
+    if (toolUseById) {
+      const anchors = toolUseById;
+      finalContent = content.filter((block) => {
+        if (block.type !== "task_progress" || !block.tool_use_id) return true;
+        const anchor = anchors.get(block.tool_use_id);
+        if (!anchor) return true;
+        anchor.task_info = block;
+        return false;
+      });
+    }
+    return { type: turn.type, content: finalContent, uuid: turn.uuid, timestamp: turn.timestamp };
+  }
+
+  function compose(): Turn[] {
+    if (!composedDirty) return composed;
+    const out = [...foldDisplay(main)];
+    // 仍无锚点的组（如懒生成残余组）：以合成锚点独立成卡，不丢子时间线
+    for (const group of groups.values()) {
+      if (group.anchor) continue;
+      out.push({
+        type: "system",
+        content: [{ type: "tool_use", id: group.id, name: "Agent", input: {}, sub_turns: foldDisplay(group.fold) }],
+        uuid: `subagent-${group.id}`,
+      });
+    }
+    composed = out;
+    composedDirty = false;
+    return out;
+  }
+
+  return {
+    project(entries: TimelineEntry[]): Turn[] {
+      // 前缀不变性按端点引用判定：日志契约保证条目按 seq 不可变、集合只增
+      // 不减，端点同引用即前缀逐元素同引用（中部插入必然移动端点索引）。
+      const extendsPrefix =
+        entries.length >= count &&
+        (count === 0 || (entries[0] === source[0] && entries[count - 1] === source[count - 1]));
+      if (!extendsPrefix) reset();
+      for (let i = count; i < entries.length; i++) appendOne(entries[i]);
+      source = entries;
+      count = entries.length;
+      return compose();
+    },
+    get size(): number {
+      return count;
+    },
+  };
+}
+
+/**
+ * 全量投影纯函数入口（entries → Turn[]）：空投影器一次性重放。
+ * 增量路径 `createTimelineProjector` 与本函数结果恒等。
+ */
+export function projectEntriesToTurns(entries: TimelineEntry[]): Turn[] {
+  return createTimelineProjector().project(entries);
 }
 
 // ---------------------------------------------------------------------------
 // draft 投影与增量应用
 // ---------------------------------------------------------------------------
 
+/** 收集已落权威 assistant 条目的 message_id 集合（draft 替换判定的派生索引）。 */
+export function collectCommittedMessageIds(entries: TimelineEntry[]): Set<string> {
+  const ids = new Set<string>();
+  for (const entry of entries) {
+    if (entry.type === "assistant" && entry.message_id != null) ids.add(entry.message_id);
+  }
+  return ids;
+}
+
 /**
- * draft → Turn。完成替换按身份比对：日志中已有同 message_id 的 assistant
- * 条目时 draft 视为已被权威条目替换，返回 null。不做内容比对。
+ * draft 是否已被权威条目替换：按身份比对（同 message_id 的 assistant 条目
+ * 已落库即视为替换），不做内容比对。集合由调用方增量维护，判定 O(1)。
  */
-export function projectDraftToTurn(
+export function isDraftReplaced(
   draft: DraftState | null,
-  entries: TimelineEntry[],
-): Turn | null {
+  committedMessageIds: ReadonlySet<string>,
+): boolean {
+  if (!draft || !draft.message_id) return false;
+  return committedMessageIds.has(draft.message_id);
+}
+
+/**
+ * draft → Turn。replaced 为真（已被权威条目替换）时返回 null；
+ * subagent 的流式草稿不进主时间线：主线只显示折叠卡片，
+ * 卡片内容随权威条目（近实时）更新。
+ */
+export function buildDraftTurn(draft: DraftState | null, replaced: boolean): Turn | null {
   if (!draft || !draft.message_id) return null;
-  // subagent 的流式草稿不进主时间线：主线只显示折叠卡片，
-  // 卡片内容随权威条目（近实时）更新
   if (draft.parent_tool_use_id) return null;
-  const replaced = entries.some(
-    (e) => e.type === "assistant" && e.message_id != null && e.message_id === draft.message_id,
-  );
   if (replaced) return null;
   const content = draft.content.filter(Boolean);
   if (content.length === 0) return null;
@@ -404,6 +528,14 @@ export function projectDraftToTurn(
     content,
     uuid: `draft-${draft.message_id}`,
   };
+}
+
+/** draft → Turn 全量入口：从 entries 派生替换判定（热路径请用 buildDraftTurn）。 */
+export function projectDraftToTurn(
+  draft: DraftState | null,
+  entries: TimelineEntry[],
+): Turn | null {
+  return buildDraftTurn(draft, isDraftReplaced(draft, collectCommittedMessageIds(entries)));
 }
 
 /** 客户端 draft 镜像：content 以 block_index 为数组下标，toolJson 累积未闭合 JSON。 */

--- a/frontend/src/utils/entry-projection.ts
+++ b/frontend/src/utils/entry-projection.ts
@@ -121,6 +121,10 @@ export function createTimelineProjector(): TimelineProjector {
   let versionCounter = 0;
   let main: Fold = newFold();
   let groups = new Map<string, SubagentGroup>();
+  // 尚未锚定的组：compose() 只需扫这个集合而非全部历史 groups，避免长会话
+  // 里已锚定完成的 subagent 组随会话增长把每条新消息的合成卡片扫描拖成
+  // O(历史 subagent 总数)。
+  let pendingGroups = new Set<SubagentGroup>();
   let toolUseSites = new Map<string, ToolUseSite>();
   let turnViewCache = new WeakMap<InternalTurn, { version: number; turn: Turn }>();
   let composed: Turn[] = [];
@@ -134,11 +138,32 @@ export function createTimelineProjector(): TimelineProjector {
     versionCounter = 0;
     main = newFold();
     groups = new Map();
+    pendingGroups = new Set();
     toolUseSites = new Map();
     turnViewCache = new WeakMap();
     composed = [];
     composedDirty = true;
     count = 0;
+  }
+
+  /**
+   * site 所在时间线的锚链（沿既有 anchor 归属向上走）是否会绕回 targetFold。
+   * 用于锚定前判定：真实数据里 subagent 嵌套是无环 DAG（parent_tool_use_id
+   * 恒指向更早、仍开放的祖先调用），环只可能来自畸形/自指条目
+   * （如 parent_tool_use_id 等于自身 tool_use id）。一旦锚定成环，该组的
+   * 展示视图会互相依赖、永远无法从主时间线触达，导致整段时间线被
+   * compose() 静默丢空——不锚定、退回既有的"合成卡片"兜底比丢空更安全。
+   */
+  function anchorCreatesCycle(anchorFold: Fold, targetFold: Fold): boolean {
+    const seen = new Set<Fold>();
+    let current: Fold | null = anchorFold;
+    while (current) {
+      if (current === targetFold) return true;
+      if (seen.has(current)) return false;
+      seen.add(current);
+      current = current.group?.anchor?.fold ?? null;
+    }
+    return false;
   }
 
   /** 条目触达 turn 后：失效其展示缓存，并沿 subagent 锚链逐层失效祖先 turn。 */
@@ -227,8 +252,9 @@ export function createTimelineProjector(): TimelineProjector {
     const group = groups.get(id);
     if (group && !group.anchor) {
       const site = toolUseSites.get(id);
-      if (site) {
+      if (site && !anchorCreatesCycle(site.fold, group.fold)) {
         group.anchor = site;
+        pendingGroups.delete(group);
         // 合成卡片并回锚点：锚点 turn 展示需重建，顶层合成卡片消失
         touch(site.fold, site.turn);
       }
@@ -244,9 +270,11 @@ export function createTimelineProjector(): TimelineProjector {
       fold.group = group;
       groups.set(parentId, group);
       const site = toolUseSites.get(parentId);
-      if (site) {
+      if (site && !anchorCreatesCycle(site.fold, fold)) {
         group.anchor = site;
         touch(site.fold, site.turn);
+      } else {
+        pendingGroups.add(group);
       }
       composedDirty = true;
     }
@@ -446,9 +474,10 @@ export function createTimelineProjector(): TimelineProjector {
   function compose(): Turn[] {
     if (!composedDirty) return composed;
     const out = [...foldDisplay(main)];
-    // 仍无锚点的组（如懒生成残余组）：以合成锚点独立成卡，不丢子时间线
-    for (const group of groups.values()) {
-      if (group.anchor) continue;
+    // 仍无锚点的组（如懒生成残余组、成环被拒锚的组）：以合成锚点独立成卡，
+    // 不丢子时间线。只扫 pendingGroups（当前仍未锚定的组），不扫全部历史
+    // groups——已锚定的组不会再变回待锚定，扫描量不随会话内 subagent 总数增长。
+    for (const group of pendingGroups) {
       out.push({
         type: "system",
         content: [{ type: "tool_use", id: group.id, name: "Agent", input: {}, sub_turns: foldDisplay(group.fold) }],

--- a/frontend/src/utils/entry-projection.ts
+++ b/frontend/src/utils/entry-projection.ts
@@ -317,12 +317,14 @@ export function createTimelineProjector(): TimelineProjector {
 
     if (entry.type === "system") {
       if (entry.subtype === "skill_invocation") {
-        // 芯片渲染锚点是 Skill tool_use 块（input 即名与入参）；条目已在
-        // 当前 turn 有锚点时不再追加，避免同一调用出现两枚芯片
-        const anchored =
-          entry.tool_use_id != null &&
-          fold.cursor !== null &&
-          fold.cursor.content.some((b) => b.type === "tool_use" && b.id === entry.tool_use_id);
+        // 芯片渲染锚点是 Skill tool_use 块（input 即名与入参）；tool_use 块
+        // 已登记时不再追加，避免同一调用出现两枚芯片。按 toolUseSites 查找
+        // 而非只看 fold.cursor——登记发生在 tool_use 块本身追加时，比
+        // cursor 更持久，该 turn 若被 interrupt 等条目提前 flush 出当前
+        // turn，仍能正确判定为已锚定（限定同一时间线，与 question_answer
+        // 回填口径一致）。
+        const site = entry.tool_use_id != null ? toolUseSites.get(entry.tool_use_id) : null;
+        const anchored = site != null && site.fold === fold;
         if (!anchored) {
           attachSystemBlock(fold, entry, {
             type: "skill_invocation",

--- a/frontend/src/utils/entry-projection.ts
+++ b/frontend/src/utils/entry-projection.ts
@@ -550,7 +550,7 @@ export function buildDraftTurn(draft: DraftState | null, replaced: boolean): Tur
   if (!draft || !draft.message_id) return null;
   if (draft.parent_tool_use_id) return null;
   if (replaced) return null;
-  const content = draft.content.filter(Boolean);
+  const content = (draft.content ?? []).filter(Boolean);
   if (content.length === 0) return null;
   return {
     type: "assistant",


### PR DESCRIPTION
## 概述

Closes #1058

前端 assistant store 的时间线由事件日志条目投影派生。SSE 直播期间每收到一条 log_entry，原实现都对完整 entries 数组重新执行 `projectEntriesToTurns`（从头遍历全部条目并深拷贝每个 content block），长会话累积后单条新消息的投影成本随时间线长度线性增长，整体呈 O(n²)。

本 PR 引入增量投影器 `createTimelineProjector()`：
- 内部累积态（fold）逐条追加/按 id 回填，永不回溯重放，条目块只做一次深拷贝
- 展示视图按 turn 版本缓存，只有被新条目触达的 turn 重建视图
- `projectEntriesToTurns` 保留为纯函数入口（空投影器全量重放），与增量路径结果恒等
- draft 替换判定由全量 entries 扫描降为 O(1) 的 Set 查找

审查阶段追加修复：
- 互相/自我锚定的 subagent tool_use（`parent_tool_use_id` 成环）此前会让整段时间线被静默投影为空数组；现按锚链检测环，拒绝入环锚定并退回既有的合成卡片兜底
- `compose()` 对未锚定 subagent 组的扫描从全部历史 groups 收窄为仅当前待锚定的组，避免长会话里已完成的历史 subagent 调用拖慢每条新消息的合成
- store 侧 projector 闭包补上与既有 committedIds 同构的按 entries 容器引用自愈：绕过 `resetTimeline` 的外部整帧重置后，若下一批 entries 复用了旧 cohort 的首尾条目对象引用，投影器自身的端点比对会误判为前缀延续；现按容器引用比对强制重建 projector

## 验证

- `pnpm lint`：干净
- `pnpm check`（typecheck + vitest）：875/875 通过
- 增量路径与纯函数路径的等价性覆盖：两组随机种子（80 条目，每个前缀长度逐值比对）+ 嵌套 subagent/孤儿锚点/中断跨 turn 回填的手写对抗场景
- 审查阶段新增的 4 个回归测试均已验证在修复前会失败（临时还原修复前源码、保留新测试运行确认），修复后全部通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 引入增量时间线投影与提交/替换判定缓存，提升会话追加后的渲染稳定性与一致性。
  * 优化草稿到时间线的生成逻辑，更可靠地处理草稿替换与展示更新。
* **Bug 修复**
  * 修正草稿“是否被替换”的语义，避免因重复标识导致错误覆盖。
  * 改善复杂追加、子时间线挂载与回填场景下的中段内容更新。
* **测试**
  * 扩展时间线投影器与草稿回归覆盖：异常字段兜底、不抛错、增量等价、重置自愈以及深拷贝/缓存契约。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->