### PR TITLE
fix(assistant): 清理事件日志管道 4 条遗留缺陷——幂等持久化、跨 turn 投影、异常匹配、重复实现

### DIFF
--- a/alembic/versions/bd25b66f82e8_add_client_key_lookup_index_for_cross_.py
+++ b/alembic/versions/bd25b66f82e8_add_client_key_lookup_index_for_cross_.py
@@ -1,0 +1,40 @@
+"""add client_key lookup index for cross-session idempotency
+
+Revision ID: bd25b66f82e8
+Revises: 3b841838ac16
+Create Date: 2026-07-07 13:14:23.784371
+
+client_key 唯一索引按 (session_id, client_key) 分区，覆盖不到 session_id
+尚不存在的新会话受理去重；跨会话按 client_key 的兜底查询需要以 client_key
+打头的检索索引。部分索引（client_key IS NOT NULL）避免为占多数的空键行建项。
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "bd25b66f82e8"
+down_revision: str | Sequence[str] | None = "3b841838ac16"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_index(
+        "ix_agent_event_log_client_key",
+        "agent_session_event_log",
+        ["client_key"],
+        unique=False,
+        postgresql_where=sa.text("client_key IS NOT NULL"),
+        sqlite_where=sa.text("client_key IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_agent_event_log_client_key", table_name="agent_session_event_log")

--- a/frontend/src/utils/entry-projection.test.ts
+++ b/frontend/src/utils/entry-projection.test.ts
@@ -71,6 +71,45 @@ describe("projectEntriesToTurns", () => {
     expect(block.is_error).toBe(true);
   });
 
+  it("backfills tool_result into its tool_use across a turn boundary (turn flushed before the result arrived)", () => {
+    const turns = projectEntriesToTurns([
+      entry({
+        type: "assistant",
+        content: [{ type: "tool_use", id: "tu-1", name: "Bash", input: {} }],
+        uuid: "a-1",
+      }),
+      entry({ type: "system", subtype: "interrupt", uuid: "i-1" }),
+      entry({ type: "tool_result", tool_use_id: "tu-1", content: "迟到的结果", is_error: false, uuid: "tr-1" }),
+    ]);
+    expect(turns.map((t) => t.type)).toEqual(["assistant", "system"]);
+    const toolUse = turns[0].content[0];
+    expect(toolUse.result).toBe("迟到的结果");
+    expect(toolUse.is_error).toBe(false);
+    // 已回填锚点，不再另开孤儿 tool_result 块
+    expect(turns.flatMap((t) => t.content).filter((b) => b.type === "tool_result")).toHaveLength(0);
+  });
+
+  it("updates a task block in place across a turn boundary instead of duplicating it", () => {
+    const turns = projectEntriesToTurns([
+      entry({ type: "assistant", content: [{ type: "text", text: "启动后台任务" }], uuid: "a-1" }),
+      entry({ type: "system", subtype: "task_started", task_id: "t1", description: "分析", uuid: "s-1" }),
+      userEntry("继续下一个问题"),
+      entry({
+        type: "system",
+        subtype: "task_notification",
+        task_id: "t1",
+        summary: "完成",
+        task_status: "completed",
+        uuid: "s-2",
+      }),
+    ]);
+    const taskBlocks = turns.flatMap((t) => t.content).filter((b) => b.type === "task_progress");
+    expect(taskBlocks).toHaveLength(1);
+    expect(taskBlocks[0].status).toBe("task_notification");
+    expect(taskBlocks[0].task_status).toBe("completed");
+    expect(taskBlocks[0].summary).toBe("完成");
+  });
+
   it("renders typed interrupt entries as interrupt_notice system turns", () => {
     const turns = projectEntriesToTurns([
       userEntry("做点什么"),

--- a/frontend/src/utils/entry-projection.test.ts
+++ b/frontend/src/utils/entry-projection.test.ts
@@ -89,6 +89,31 @@ describe("projectEntriesToTurns", () => {
     expect(turns.flatMap((t) => t.content).filter((b) => b.type === "tool_result")).toHaveLength(0);
   });
 
+  it("backfills question_answer into its tool_use across a turn boundary", () => {
+    const turns = projectEntriesToTurns([
+      entry({
+        type: "assistant",
+        content: [{ type: "tool_use", id: "ask-1", name: "AskUserQuestion", input: {} }],
+        uuid: "a-1",
+      }),
+      entry({ type: "system", subtype: "interrupt", uuid: "i-1" }),
+      entry({
+        type: "user",
+        subtype: "question_answer",
+        tool_use_id: "ask-1",
+        content: "选择 A",
+        answers: { question: "A" },
+        uuid: "u-1",
+      }),
+    ]);
+
+    const toolUse = turns[0].content[0];
+    expect(toolUse.result).toBe("选择 A");
+    expect(toolUse.is_error).toBe(false);
+    expect(toolUse.answers).toEqual({ question: "A" });
+    expect(turns.some((t) => t.type === "user")).toBe(true);
+  });
+
   it("updates a task block in place across a turn boundary instead of duplicating it", () => {
     const turns = projectEntriesToTurns([
       entry({ type: "assistant", content: [{ type: "text", text: "启动后台任务" }], uuid: "a-1" }),

--- a/frontend/src/utils/entry-projection.ts
+++ b/frontend/src/utils/entry-projection.ts
@@ -207,41 +207,41 @@ export function createTimelineProjector(): TimelineProjector {
     return null;
   }
 
+  /**
+   * 按 task_id 定位既有 task 块：先查当前 turn（常见路径），未命中回退
+   * 已 flush 的 committed turns（新近优先）——turn 边界之后到达的 task 更新
+   * 仍要归属原块就地更新，否则原块永久停在 task_started 未完成态。返回
+   * 命中块所在的 turn，供调用方 touch 到正确的缓存失效范围（可能不是
+   * fold.cursor）。
+   */
+  function findTaskSite(fold: Fold, taskId: string): { turn: InternalTurn; block: ContentBlock } | null {
+    if (fold.cursor) {
+      const found = findTaskBlock(fold.cursor.content, taskId);
+      if (found) return { turn: fold.cursor, block: found };
+    }
+    for (let i = fold.committed.length - 1; i >= 0; i -= 1) {
+      const turn = fold.committed[i];
+      const found = findTaskBlock(turn.content, taskId);
+      if (found) return { turn, block: found };
+    }
+    return null;
+  }
+
   function applyTaskBlock(fold: Fold, entry: TimelineEntry, taskBlock: ContentBlock, updateOnly: boolean): void {
     const taskId = taskBlock.task_id;
-    if (taskId && updateOnly && fold.cursor) {
-      const existing = findTaskBlock(fold.cursor.content, taskId);
-      if (existing) {
+    if (taskId && updateOnly) {
+      const site = findTaskSite(fold, taskId);
+      if (site) {
+        const existing = site.block;
         existing.status = taskBlock.status;
         if (taskBlock.summary) existing.summary = taskBlock.summary;
         if (taskBlock.task_status) existing.task_status = taskBlock.task_status;
         if (taskBlock.usage) existing.usage = taskBlock.usage;
-        touch(fold, fold.cursor);
+        touch(fold, site.turn);
         return;
       }
     }
     attachSystemBlock(fold, entry, taskBlock);
-  }
-
-  /** tool_result 回填当前 turn 内的发起 tool_use；无匹配时追加独立结果块。 */
-  function attachToolResult(turnContent: ContentBlock[], entry: TimelineEntry): void {
-    const toolUseId = entry.tool_use_id;
-    const resultText = typeof entry.content === "string" ? entry.content : blocksText(entryBlocks(entry));
-    if (toolUseId) {
-      for (const block of turnContent) {
-        if (block.type === "tool_use" && block.id === toolUseId) {
-          block.result = resultText;
-          block.is_error = Boolean(entry.is_error);
-          return;
-        }
-      }
-    }
-    turnContent.push({
-      type: "tool_result",
-      tool_use_id: toolUseId ?? undefined,
-      content: resultText,
-      is_error: Boolean(entry.is_error),
-    });
   }
 
   /** 登记 tool_use 块位置（同 id 首次登记生效），并锚定等待中的 subagent 组。 */
@@ -301,14 +301,25 @@ export function createTimelineProjector(): TimelineProjector {
     }
 
     if (entry.type === "tool_result") {
-      if (fold.cursor && fold.cursor.type === "assistant") {
-        attachToolResult(fold.cursor.content, entry);
-        touch(fold, fold.cursor);
+      const resultText = typeof entry.content === "string" ? entry.content : blocksText(entryBlocks(entry));
+      // 回填锚点按登记索引 O(1) 定位，限定同一时间线：turn 边界之后到达的
+      // tool_result（如中断先把该 turn flush 出去）仍要能回填对应
+      // tool_use，否则其结果状态永久悬挂在未完成态（与 question_answer
+      // 回填口径一致）。
+      let site: ToolUseSite | null = null;
+      if (entry.tool_use_id) {
+        const hit = toolUseSites.get(entry.tool_use_id);
+        if (hit && hit.fold === fold) site = hit;
+      }
+      if (site) {
+        site.block.result = resultText;
+        site.block.is_error = Boolean(entry.is_error);
+        touch(site.fold, site.turn);
       } else {
         attachSystemBlock(fold, entry, {
           type: "tool_result",
           tool_use_id: entry.tool_use_id ?? undefined,
-          content: typeof entry.content === "string" ? entry.content : blocksText(entryBlocks(entry)),
+          content: resultText,
           is_error: Boolean(entry.is_error),
         });
       }

--- a/lib/db/models/session_event.py
+++ b/lib/db/models/session_event.py
@@ -34,4 +34,12 @@ class AgentSessionEventLogEntry(TimestampMixin, UserOwnedMixin, Base):
             postgresql_where=text("client_key IS NOT NULL"),
             sqlite_where=text("client_key IS NOT NULL"),
         ),
+        # 跨会话幂等兜底查询（find_new_session_by_client_key）的检索索引：
+        # 唯一索引以 session_id 打头，服务不了仅按 client_key 的查找。
+        Index(
+            "ix_agent_event_log_client_key",
+            "client_key",
+            postgresql_where=text("client_key IS NOT NULL"),
+            sqlite_where=text("client_key IS NOT NULL"),
+        ),
     )

--- a/server/agent_runtime/event_log.py
+++ b/server/agent_runtime/event_log.py
@@ -424,24 +424,35 @@ def _assistant_tool_use_ids(message: Any) -> list[str]:
     return ids
 
 
+def _first_driver_attr(exc: IntegrityError, *attr_names: str) -> Any:
+    """沿 ``exc.orig`` 的 ``__cause__`` 链查找首个非 None 的驱动侧属性值。
+
+    SQLAlchemy 的 asyncpg 适配把原始驱动异常挂在翻译后异常的 cause 上，
+    唯一约束判定与 client_key 冲突判定都需要沿此链探测驱动暴露的属性。
+    """
+    err: BaseException | None = exc.orig
+    while err is not None:
+        for name in attr_names:
+            value = getattr(err, name, None)
+            if value is not None:
+                return value
+        err = err.__cause__
+    return None
+
+
 def _is_unique_violation(exc: IntegrityError) -> bool:
     """判定唯一约束冲突：错误码优先（PostgreSQL SQLSTATE / SQLite errorname），
     文案子串仅作兜底。
 
     PostgreSQL 错误文案随服务端 lc_messages 本地化，非英文环境下不含
-    "duplicate key" 字样，子串匹配会把可重试的竞态误判为真实错误。错误码
-    沿 ``__cause__`` 链查找——SQLAlchemy 的 asyncpg 适配把原始驱动异常挂在
-    翻译后异常的 cause 上。
+    "duplicate key" 字样，子串匹配会把可重试的竞态误判为真实错误。
     """
-    err: BaseException | None = exc.orig
-    while err is not None:
-        sqlstate = getattr(err, "sqlstate", None) or getattr(err, "pgcode", None)
-        if sqlstate is not None:
-            return str(sqlstate) == _PG_UNIQUE_VIOLATION_SQLSTATE
-        errorname = getattr(err, "sqlite_errorname", None)
-        if errorname is not None:
-            return errorname in _SQLITE_UNIQUE_ERRORNAMES
-        err = err.__cause__
+    sqlstate = _first_driver_attr(exc, "sqlstate", "pgcode")
+    if sqlstate is not None:
+        return str(sqlstate) == _PG_UNIQUE_VIOLATION_SQLSTATE
+    errorname = _first_driver_attr(exc, "sqlite_errorname")
+    if errorname is not None:
+        return errorname in _SQLITE_UNIQUE_ERRORNAMES
     msg = str(exc.orig) if exc.orig else str(exc)
     return "UNIQUE" in msg or "duplicate key" in msg
 
@@ -449,12 +460,9 @@ def _is_unique_violation(exc: IntegrityError) -> bool:
 def _is_client_key_violation(exc: IntegrityError) -> bool:
     """判定冲突是否落在 client_key 唯一索引：约束名优先（不随 locale 翻译），
     驱动未暴露约束名时回退错误文本——两个后端的文案都会带索引/列名。"""
-    err: BaseException | None = exc.orig
-    while err is not None:
-        constraint = getattr(err, "constraint_name", None)
-        if constraint:
-            return "client_key" in str(constraint)
-        err = err.__cause__
+    constraint = _first_driver_attr(exc, "constraint_name")
+    if constraint:
+        return "client_key" in str(constraint)
     msg = str(exc.orig) if exc.orig else str(exc)
     return "client_key" in msg
 

--- a/server/agent_runtime/event_log.py
+++ b/server/agent_runtime/event_log.py
@@ -430,10 +430,13 @@ def _first_driver_attr(exc: IntegrityError, *attr_names: str) -> Any:
     SQLAlchemy 的 asyncpg 适配把原始驱动异常挂在翻译后异常的 cause 上，
     唯一约束判定与 client_key 冲突判定都需要沿此链探测驱动暴露的属性。
     优先取显式 ``__cause__``（``raise ... from ...``）；驱动或中间层改为隐式
-    包装（裸 ``raise``）时回退 ``__context__``，避免链路断裂导致探测落空。
+    包装（裸 ``raise``）时回退 ``__context__``。按 ``id()`` 记录已访问异常，
+    防御性异常链本身出现环（正常传播不会产生，但不排除病态构造）导致死循环。
     """
     err: BaseException | None = exc.orig
-    while err is not None:
+    seen: set[int] = set()
+    while err is not None and id(err) not in seen:
+        seen.add(id(err))
         for name in attr_names:
             value = getattr(err, name, None)
             if value is not None:

--- a/server/agent_runtime/event_log.py
+++ b/server/agent_runtime/event_log.py
@@ -425,10 +425,12 @@ def _assistant_tool_use_ids(message: Any) -> list[str]:
 
 
 def _first_driver_attr(exc: IntegrityError, *attr_names: str) -> Any:
-    """沿 ``exc.orig`` 的 ``__cause__`` 链查找首个非 None 的驱动侧属性值。
+    """沿 ``exc.orig`` 的 ``__cause__``/``__context__`` 链查找首个非 None 的驱动侧属性值。
 
     SQLAlchemy 的 asyncpg 适配把原始驱动异常挂在翻译后异常的 cause 上，
     唯一约束判定与 client_key 冲突判定都需要沿此链探测驱动暴露的属性。
+    优先取显式 ``__cause__``（``raise ... from ...``）；驱动或中间层改为隐式
+    包装（裸 ``raise``）时回退 ``__context__``，避免链路断裂导致探测落空。
     """
     err: BaseException | None = exc.orig
     while err is not None:
@@ -436,7 +438,7 @@ def _first_driver_attr(exc: IntegrityError, *attr_names: str) -> Any:
             value = getattr(err, name, None)
             if value is not None:
                 return value
-        err = err.__cause__
+        err = err.__cause__ or err.__context__
     return None
 
 

--- a/server/agent_runtime/event_log.py
+++ b/server/agent_runtime/event_log.py
@@ -12,7 +12,6 @@ import asyncio
 import logging
 import random
 import re
-import weakref
 from pathlib import Path
 from typing import Any, Protocol
 from uuid import uuid4
@@ -24,6 +23,7 @@ from sqlalchemy.exc import IntegrityError
 from lib.db import safe_session_factory
 from lib.db.base import DEFAULT_USER_ID, utc_now
 from lib.db.models.session_event import AgentSessionEventLogEntry
+from server.agent_runtime.keyed_locks import KeyedLocks
 from server.agent_runtime.message_serialization import utc_now_iso
 from server.agent_runtime.turn_schema import _stringify_content, normalize_content
 
@@ -62,6 +62,14 @@ _ASK_USER_QUESTION_TOOL = "askuserquestion"
 # 与 DbSessionStore.append 相同的 seq 竞争重试参数。
 _MAX_APPEND_RETRY = 16
 _APPEND_BACKOFF_CAP_S = 0.05
+
+# PostgreSQL 唯一约束冲突的 SQLSTATE（asyncpg 经 SQLAlchemy 适配后暴露在
+# exc.orig.sqlstate / pgcode）。
+_PG_UNIQUE_VIOLATION_SQLSTATE = "23505"
+
+# SQLite 唯一约束冲突的扩展错误名：复合主键走 PRIMARYKEY、普通唯一索引走
+# UNIQUE，两者对本表都意味着唯一约束冲突。
+_SQLITE_UNIQUE_ERRORNAMES = {"SQLITE_CONSTRAINT_UNIQUE", "SQLITE_CONSTRAINT_PRIMARYKEY"}
 
 # 标记 SDK 回放的用户消息副本（POST 受理时已写日志），供写入点跳过。
 # 只存活在进程内消息 dict 上，不落任何持久化层。
@@ -416,6 +424,41 @@ def _assistant_tool_use_ids(message: Any) -> list[str]:
     return ids
 
 
+def _is_unique_violation(exc: IntegrityError) -> bool:
+    """判定唯一约束冲突：错误码优先（PostgreSQL SQLSTATE / SQLite errorname），
+    文案子串仅作兜底。
+
+    PostgreSQL 错误文案随服务端 lc_messages 本地化，非英文环境下不含
+    "duplicate key" 字样，子串匹配会把可重试的竞态误判为真实错误。错误码
+    沿 ``__cause__`` 链查找——SQLAlchemy 的 asyncpg 适配把原始驱动异常挂在
+    翻译后异常的 cause 上。
+    """
+    err: BaseException | None = exc.orig
+    while err is not None:
+        sqlstate = getattr(err, "sqlstate", None) or getattr(err, "pgcode", None)
+        if sqlstate is not None:
+            return str(sqlstate) == _PG_UNIQUE_VIOLATION_SQLSTATE
+        errorname = getattr(err, "sqlite_errorname", None)
+        if errorname is not None:
+            return errorname in _SQLITE_UNIQUE_ERRORNAMES
+        err = err.__cause__
+    msg = str(exc.orig) if exc.orig else str(exc)
+    return "UNIQUE" in msg or "duplicate key" in msg
+
+
+def _is_client_key_violation(exc: IntegrityError) -> bool:
+    """判定冲突是否落在 client_key 唯一索引：约束名优先（不随 locale 翻译），
+    驱动未暴露约束名时回退错误文本——两个后端的文案都会带索引/列名。"""
+    err: BaseException | None = exc.orig
+    while err is not None:
+        constraint = getattr(err, "constraint_name", None)
+        if constraint:
+            return "client_key" in str(constraint)
+        err = err.__cause__
+    msg = str(exc.orig) if exc.orig else str(exc)
+    return "client_key" in msg
+
+
 class EventLogStore:
     """事件日志 DB 访问：seq 单调分配（append-only）+ 幂等键查重。"""
 
@@ -441,9 +484,9 @@ class EventLogStore:
             try:
                 return await self._append_once(session_id, entries, client_key)
             except IntegrityError as exc:
-                msg = str(exc.orig) if exc.orig else str(exc)
-                unique_violation = "UNIQUE" in msg or "duplicate key" in msg
-                if unique_violation and "client_key" in msg and client_key is not None:
+                unique_violation = _is_unique_violation(exc)
+                client_key_conflict = unique_violation and _is_client_key_violation(exc)
+                if client_key_conflict and client_key is not None:
                     # 幂等键并发冲突：另一请求已写入同键条目，返回其权威条目。
                     existing = await self.find_by_client_key(session_id, client_key)
                     if existing is not None:
@@ -452,7 +495,7 @@ class EventLogStore:
                 # 表上只有两个唯一约束（(session_id, seq) 主键 + client_key 唯一索引）；
                 # 排除 client_key 冲突即可确定是 seq 竞争，不依赖驱动/配置相关的
                 # 错误信息措辞（不同驱动对主键冲突的 DETAIL 文案不一定含 "seq"）。
-                is_seq_race = unique_violation and "client_key" not in msg
+                is_seq_race = unique_violation and not client_key_conflict
                 if not is_seq_race or attempt == _MAX_APPEND_RETRY - 1:
                     raise
                 delay = random.uniform(0, min(_APPEND_BACKOFF_CAP_S, 0.001 * (2**attempt)))
@@ -526,6 +569,33 @@ class EventLogStore:
         if row is None:
             return None
         return {"seq": int(row.seq), **row.payload}
+
+    async def find_new_session_by_client_key(self, client_key: str) -> tuple[str, dict[str, Any]] | None:
+        """跨会话按幂等键定位新会话的受理条目（seq 0），返回 (session_id, 权威条目)。
+
+        client_key 唯一索引按 (session_id, client_key) 分区，覆盖不到
+        session_id 尚不存在的新会话受理；进程内映射在重启 / LRU 淘汰后丢失时，
+        由本查询兜底让重试命中既有会话，而非重复建会话。限定 seq 0 是因为只有
+        新会话的首条用户条目落在该位置，常规消息的幂等键不参与匹配。
+        """
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(
+                    AgentSessionEventLogEntry.session_id,
+                    AgentSessionEventLogEntry.seq,
+                    AgentSessionEventLogEntry.payload,
+                )
+                .where(
+                    AgentSessionEventLogEntry.client_key == client_key,
+                    AgentSessionEventLogEntry.seq == 0,
+                )
+                .order_by(AgentSessionEventLogEntry.created_at)
+                .limit(1)
+            )
+            row = result.first()
+        if row is None:
+            return None
+        return str(row.session_id), {"seq": int(row.seq), **row.payload}
 
     async def list_after(self, session_id: str, after_seq: int = -1) -> list[dict[str, Any]]:
         async with self._session_factory() as session:
@@ -601,8 +671,8 @@ class EventLogService:
     def __init__(self, store: EventLogStore, transcript_adapter: TranscriptReader):
         self._store = store
         self._adapter = transcript_adapter
-        # 弱引用：无协程持有/等待时锁对象自动回收，避免空会话锁永久残留内存
-        self._backfill_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
+        # 每会话一把懒生成锁：无协程持有/等待时自动回收，空会话锁不残留内存
+        self._backfill_locks = KeyedLocks()
 
     @property
     def store(self) -> EventLogStore:
@@ -617,7 +687,7 @@ class EventLogService:
         """
         if await self._store.has_entries(session_id):
             return
-        lock = self._backfill_locks.setdefault(session_id, asyncio.Lock())
+        lock = self._backfill_locks.lock_for(session_id)
         async with lock:
             if await self._store.has_entries(session_id):
                 return
@@ -660,7 +730,7 @@ class EventLogService:
                 # 仅在写入成功后清锁引用：此后 has_entries 恒真，旧锁等待者与
                 # 新造锁的后来者都会在二次检查处短路。空 transcript 时保留锁，
                 # 否则后来者 setdefault 出新锁，与旧锁等待者并发重放、重复灌入。
-                self._backfill_locks.pop(session_id, None)
+                self._backfill_locks.discard(session_id)
 
     async def list_entries(
         self,

--- a/server/agent_runtime/event_log.py
+++ b/server/agent_runtime/event_log.py
@@ -464,11 +464,18 @@ def _is_unique_violation(exc: IntegrityError) -> bool:
 
 def _is_client_key_violation(exc: IntegrityError) -> bool:
     """判定冲突是否落在 client_key 唯一索引：约束名优先（不随 locale 翻译），
-    驱动未暴露约束名时回退错误文本——两个后端的文案都会带索引/列名。"""
+    驱动未暴露约束名时回退错误文本——两个后端的文案都会带索引/列名。
+
+    ``exc.orig`` 为 None 时的兜底不能直接用 ``str(exc)`` 全文匹配：
+    SQLAlchemy 的 ``StatementError`` 文本里带 ``[SQL: INSERT INTO ...
+    client_key ...]``，INSERT 语句本身的列名就含 "client_key"，会让任何
+    （包括与 client_key 无关的 seq 主键竞争）异常都误判为 client_key 冲突，
+    需先剥离 ``[SQL: ...]`` 之后的部分再匹配。
+    """
     constraint = _first_driver_attr(exc, "constraint_name")
     if constraint:
         return "client_key" in str(constraint)
-    msg = str(exc.orig) if exc.orig else str(exc)
+    msg = str(exc.orig) if exc.orig else str(exc).split("[SQL:", 1)[0]
     return "client_key" in msg
 
 
@@ -498,7 +505,11 @@ class EventLogStore:
                 return await self._append_once(session_id, entries, client_key)
             except IntegrityError as exc:
                 unique_violation = _is_unique_violation(exc)
-                client_key_conflict = unique_violation and _is_client_key_violation(exc)
+                # client_key 为 None 时本次写入根本没有 client_key 值，不可能
+                # 是 client_key 唯一约束冲突——即便 _is_client_key_violation
+                # 因兜底文本匹配误判，也在此结构性排除，不让它把普通 seq
+                # 竞争的重试关掉。
+                client_key_conflict = unique_violation and client_key is not None and _is_client_key_violation(exc)
                 if client_key_conflict and client_key is not None:
                     # 幂等键并发冲突：另一请求已写入同键条目，返回其权威条目。
                     existing = await self.find_by_client_key(session_id, client_key)

--- a/server/agent_runtime/keyed_locks.py
+++ b/server/agent_runtime/keyed_locks.py
@@ -1,0 +1,32 @@
+"""按字符串键分配 asyncio.Lock 的弱引用注册表（进程内互斥的共享原语）。"""
+
+from __future__ import annotations
+
+import asyncio
+import weakref
+
+
+class KeyedLocks:
+    """同键请求共享同一把锁；无协程持有/等待时锁对象随弱引用自动回收。
+
+    适用于按 key 串行化的临界区（如会话懒生成、同幂等键的新会话创建）：
+    调用方在 ``async with lock_for(key)`` 期间持有强引用，锁存活；临界区
+    退出且再无等待者后自动从注册表消失，不为每个键永久驻留内存。
+    """
+
+    def __init__(self) -> None:
+        self._locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
+
+    def lock_for(self, key: str) -> asyncio.Lock:
+        """取该键的锁，不存在时创建；并发调用者拿到同一实例。"""
+        return self._locks.setdefault(key, asyncio.Lock())
+
+    def discard(self, key: str) -> None:
+        """主动清除键的锁引用；已持有锁对象的等待者不受影响。"""
+        self._locks.pop(key, None)
+
+    def __len__(self) -> int:
+        return len(self._locks)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._locks

--- a/server/agent_runtime/keyed_locks.py
+++ b/server/agent_runtime/keyed_locks.py
@@ -19,7 +19,11 @@ class KeyedLocks:
 
     def lock_for(self, key: str) -> asyncio.Lock:
         """取该键的锁，不存在时创建；并发调用者拿到同一实例。"""
-        return self._locks.setdefault(key, asyncio.Lock())
+        lock = self._locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[key] = lock
+        return lock
 
     def discard(self, key: str) -> None:
         """主动清除键的锁引用；已持有锁对象的等待者不受影响。"""

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -290,8 +290,12 @@ class AssistantService:
             entry = await self.event_log_store.find_by_client_key(mapped_session_id, client_key)
             if entry is not None:
                 # 命中即刷新 LRU 位置：否则被频繁重试命中的 key 仍按插入
-                # 顺序（而非访问顺序）淘汰，退化成 FIFO。
-                self._new_session_client_keys.move_to_end(client_key)
+                # 顺序（而非访问顺序）淘汰，退化成 FIFO。上一行 await 期间
+                # 该 key 可能已被其他并发请求的淘汰逻辑移除，直接
+                # move_to_end 对不存在的键会抛 KeyError；复用
+                # _record_new_session_client_key 的赋值语义（不存在则插入，
+                # 存在则原地更新）再显式挪到最近使用端，两种情形都安全。
+                self._record_new_session_client_key(client_key, mapped_session_id)
                 return {"status": "accepted", "session_id": mapped_session_id, "entry": entry}
             # 映射指向的会话条目已不存在（如会话已被删除）：映射已失效，
             # 清掉后继续向下探测，避免返回指向已删除会话的幽灵 "accepted"

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -299,13 +299,22 @@ class AssistantService:
                 return {"status": "accepted", "session_id": mapped_session_id, "entry": entry}
             # 映射指向的会话条目已不存在（如会话已被删除）：映射已失效，
             # 清掉后继续向下探测，避免返回指向已删除会话的幽灵 "accepted"
-            # 响应——调用方会据此连接一个不存在的会话，消息静默丢失。
-            self._new_session_client_keys.pop(client_key, None)
+            # 响应——调用方会据此连接一个不存在的会话，消息静默丢失。上一行
+            # await 期间该 key 可能已被其他并发请求写入更新的映射；仅当当前
+            # 值仍是本次读到的旧值时才清，避免清掉并发写入的新映射（DB 兜底
+            # 查询本身按 client_key 定位一定命中同一权威会话，误删只是白跑
+            # 一次查询，但仍以精确条件避免这层不必要的抖动）。
+            if self._new_session_client_keys.get(client_key) == mapped_session_id:
+                self._new_session_client_keys.pop(client_key, None)
         recovered = await self.event_log_store.find_new_session_by_client_key(client_key)
         if recovered is None:
             return None
         session_id, entry = recovered
-        self._record_new_session_client_key(client_key, session_id)
+        # 上一行 await 期间该 key 可能已被其他并发请求记入新映射；仅当当前
+        # 无映射或已是同一 session_id 时才写入，避免用本次查到的（较旧）
+        # session_id 覆盖并发写入的映射。
+        if self._new_session_client_keys.get(client_key) in (None, session_id):
+            self._record_new_session_client_key(client_key, session_id)
         return {"status": "accepted", "session_id": session_id, "entry": entry}
 
     def _record_new_session_client_key(self, client_key: str, session_id: str) -> None:

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -288,7 +288,12 @@ class AssistantService:
         if mapped_session_id is not None:
             # 幂等重试：首次受理已建会话并投递，返回同一会话的权威条目。
             entry = await self.event_log_store.find_by_client_key(mapped_session_id, client_key)
-            return {"status": "accepted", "session_id": mapped_session_id, "entry": entry}
+            if entry is not None:
+                return {"status": "accepted", "session_id": mapped_session_id, "entry": entry}
+            # 映射指向的会话条目已不存在（如会话已被删除）：映射已失效，
+            # 清掉后继续向下探测，避免返回指向已删除会话的幽灵 "accepted"
+            # 响应——调用方会据此连接一个不存在的会话，消息静默丢失。
+            self._new_session_client_keys.pop(client_key, None)
         recovered = await self.event_log_store.find_new_session_by_client_key(client_key)
         if recovered is None:
             return None

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -6,7 +6,6 @@ import asyncio
 import copy
 import logging
 import os
-import weakref
 from collections import OrderedDict
 from collections.abc import AsyncGenerator, AsyncIterator
 from pathlib import Path
@@ -37,6 +36,7 @@ from lib.i18n import DEFAULT_LOCALE, get_locale
 from lib.profile_manifest import VALID_CONTENT_MODES
 from lib.project_manager import ProjectManager
 from server.agent_runtime.event_log import EventLogService, EventLogStore, build_user_entry
+from server.agent_runtime.keyed_locks import KeyedLocks
 from server.agent_runtime.models import Heartbeat, LiveMessage, SessionMeta, SessionStatus, SubscriptionReady
 from server.agent_runtime.sdk_transcript_adapter import SdkTranscriptAdapter
 from server.agent_runtime.session_manager import SessionManager
@@ -72,12 +72,12 @@ class AssistantService:
         self._startup_done = False
         # 新会话幂等映射：client_key 唯一索引按 (session_id, client_key) 分区，
         # 覆盖不到 session_id 尚不存在的新会话受理——响应丢失后的重试若再走
-        # 新会话分支会重复建会话、重复执行同一 prompt。进程内 LRU 兜底。
+        # 新会话分支会重复建会话、重复执行同一 prompt。进程内 LRU 为快路径，
+        # 重启 / 淘汰后由事件日志的跨会话查询兜底（_find_accepted_new_session）。
         self._new_session_client_keys: OrderedDict[str, str] = OrderedDict()
         self._new_session_client_keys_max = 256
-        # 同一 client_key 的并发新建请求在此串行化，避免在途窗口内重复建会话；
-        # 无协程持有/等待时锁对象自动回收
-        self._new_session_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
+        # 同一 client_key 的并发新建请求在此串行化，避免在途窗口内重复建会话
+        self._new_session_locks = KeyedLocks()
         self.stream_heartbeat_seconds = int(os.environ.get("ASSISTANT_STREAM_HEARTBEAT_SECONDS", "20"))
 
     async def startup(self, *, in_docker: bool = False, sandbox_enabled: bool = True) -> None:
@@ -264,26 +264,42 @@ class AssistantService:
             if not client_key:
                 return await self._create_new_session(project_name, content, images, locale, client_key)
 
-            mapped_session_id = self._new_session_client_keys.get(client_key)
-            if mapped_session_id is not None:
-                # 幂等重试：首次受理已建会话并投递，返回同一会话的权威条目。
-                entry = await self.event_log_store.find_by_client_key(mapped_session_id, client_key)
-                return {"status": "accepted", "session_id": mapped_session_id, "entry": entry}
+            existing = await self._find_accepted_new_session(client_key)
+            if existing is not None:
+                return existing
 
             # 同一 client_key 的并发请求在此串行化：send_new_session 在途期间
             # 后来者等锁而非各自建会话，避免重复执行同一 prompt。
-            lock = self._new_session_locks.setdefault(client_key, asyncio.Lock())
+            lock = self._new_session_locks.lock_for(client_key)
             async with lock:
                 # 双重检查：等锁期间先行者可能已完成同一 client_key 的建会话。
-                mapped_session_id = self._new_session_client_keys.get(client_key)
-                if mapped_session_id is not None:
-                    entry = await self.event_log_store.find_by_client_key(mapped_session_id, client_key)
-                    return {"status": "accepted", "session_id": mapped_session_id, "entry": entry}
+                existing = await self._find_accepted_new_session(client_key)
+                if existing is not None:
+                    return existing
                 result = await self._create_new_session(project_name, content, images, locale, client_key)
-                self._new_session_client_keys[client_key] = result["session_id"]
-                while len(self._new_session_client_keys) > self._new_session_client_keys_max:
-                    self._new_session_client_keys.popitem(last=False)
+                self._record_new_session_client_key(client_key, result["session_id"])
                 return result
+
+    async def _find_accepted_new_session(self, client_key: str) -> dict[str, Any] | None:
+        """按幂等键定位已受理的新会话：进程内映射为快路径，事件日志跨会话
+        查询兜底——进程重启 / LRU 淘汰后映射丢失，受理已落库的重试仍须命中
+        既有会话而非重复建会话（重复执行同一 prompt、重复计费）。"""
+        mapped_session_id = self._new_session_client_keys.get(client_key)
+        if mapped_session_id is not None:
+            # 幂等重试：首次受理已建会话并投递，返回同一会话的权威条目。
+            entry = await self.event_log_store.find_by_client_key(mapped_session_id, client_key)
+            return {"status": "accepted", "session_id": mapped_session_id, "entry": entry}
+        recovered = await self.event_log_store.find_new_session_by_client_key(client_key)
+        if recovered is None:
+            return None
+        session_id, entry = recovered
+        self._record_new_session_client_key(client_key, session_id)
+        return {"status": "accepted", "session_id": session_id, "entry": entry}
+
+    def _record_new_session_client_key(self, client_key: str, session_id: str) -> None:
+        self._new_session_client_keys[client_key] = session_id
+        while len(self._new_session_client_keys) > self._new_session_client_keys_max:
+            self._new_session_client_keys.popitem(last=False)
 
     async def _create_new_session(
         self,

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -289,6 +289,9 @@ class AssistantService:
             # 幂等重试：首次受理已建会话并投递，返回同一会话的权威条目。
             entry = await self.event_log_store.find_by_client_key(mapped_session_id, client_key)
             if entry is not None:
+                # 命中即刷新 LRU 位置：否则被频繁重试命中的 key 仍按插入
+                # 顺序（而非访问顺序）淘汰，退化成 FIFO。
+                self._new_session_client_keys.move_to_end(client_key)
                 return {"status": "accepted", "session_id": mapped_session_id, "entry": entry}
             # 映射指向的会话条目已不存在（如会话已被删除）：映射已失效，
             # 清掉后继续向下探测，避免返回指向已删除会话的幽灵 "accepted"
@@ -303,6 +306,7 @@ class AssistantService:
 
     def _record_new_session_client_key(self, client_key: str, session_id: str) -> None:
         self._new_session_client_keys[client_key] = session_id
+        self._new_session_client_keys.move_to_end(client_key)
         while len(self._new_session_client_keys) > self._new_session_client_keys_max:
             self._new_session_client_keys.popitem(last=False)
 

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -729,6 +729,33 @@ class TestEventLogStore:
 
         assert result == [existing]
 
+    async def test_append_client_key_conflict_detected_via_context_without_explicit_cause(
+        self, log_store: EventLogStore, monkeypatch
+    ):
+        """约束名探测优先走 ``__cause__``，驱动异常仅隐式关联（无显式
+        ``raise ... from``）时回退 ``__context__``：不因链路断裂漏判 client_key
+        冲突，误当作普通 seq 竞争重试到耗尽。"""
+        from sqlalchemy.exc import IntegrityError
+
+        entry = build_user_entry([{"type": "text", "text": "hi"}])
+        existing = (await log_store.append("s1", [entry], client_key="ck-1"))[0]
+
+        driver_error = _FakeDriverError("duplicate key value violates unique constraint", sqlstate="23505")
+        driver_error.__context__ = _FakeDriverError(
+            "original pg error", constraint_name="uq_agent_event_log_client_key"
+        )
+        assert driver_error.__cause__ is None  # 隐式关联，未显式 raise ... from
+
+        async def _conflicting_append_once(session_id, entries, client_key):
+            raise IntegrityError("INSERT INTO agent_session_event_log ...", {}, driver_error)
+
+        monkeypatch.setattr(log_store, "_append_once", _conflicting_append_once)
+
+        retry = build_user_entry([{"type": "text", "text": "hi"}])
+        result = await log_store.append("s1", [retry], client_key="ck-1")
+
+        assert result == [existing]
+
     async def test_append_raises_non_unique_integrity_error_without_retry(self, log_store: EventLogStore, monkeypatch):
         """非唯一约束的 IntegrityError（如外键冲突 SQLSTATE 23503）不属于
         seq 竞争，应立即抛出而非重试。"""

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -774,6 +774,56 @@ class TestEventLogStore:
 
         assert result is None
 
+    async def test_is_client_key_violation_ignores_sql_statement_text_when_orig_is_none(self):
+        """``exc.orig`` 为 None 时的兜底不能对 ``str(exc)`` 全文匹配：
+        SQLAlchemy 把 INSERT 语句（含 client_key 列名）拼进异常文本，任何
+        与 client_key 无关的异常（如 seq 主键竞争）都会被误判为 client_key
+        冲突；需先剥离 ``[SQL: ...]`` 之后的部分再匹配。"""
+        from sqlalchemy.exc import IntegrityError
+
+        from server.agent_runtime.event_log import _is_client_key_violation  # pyright: ignore[reportPrivateUsage]
+
+        exc = IntegrityError(
+            "INSERT INTO agent_session_event_log (session_id, seq, client_key, payload) VALUES (?, ?, ?, ?)",
+            {"session_id": "s1", "seq": 0, "client_key": None, "payload": "{}"},
+            None,
+        )
+
+        assert _is_client_key_violation(exc) is False
+
+    async def test_append_seq_race_retries_when_client_key_absent_despite_false_positive_violation_check(
+        self, log_store: EventLogStore, monkeypatch
+    ):
+        """本次调用未传 client_key 时，即便 ``_is_client_key_violation``
+        误判为 True（无论因何种原因），也应结构性排除 client_key 冲突分类
+        ——未传 client_key 的写入根本不可能撞上 client_key 唯一约束，不能
+        让误判把普通 seq 竞争的重试关掉。"""
+        from sqlalchemy.exc import IntegrityError
+
+        import server.agent_runtime.event_log as event_log_module
+
+        monkeypatch.setattr(event_log_module, "_is_client_key_violation", lambda exc: True)
+
+        calls = {"n": 0}
+        original_append_once = log_store._append_once  # pyright: ignore[reportPrivateUsage]
+
+        async def _flaky_append_once(session_id, entries, client_key):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise IntegrityError(
+                    "INSERT INTO agent_session_event_log ...",
+                    {},
+                    _FakeDriverError("constraint failed", sqlite_errorname="SQLITE_CONSTRAINT_PRIMARYKEY"),
+                )
+            return await original_append_once(session_id, entries, client_key)
+
+        monkeypatch.setattr(log_store, "_append_once", _flaky_append_once)
+
+        result = await log_store.append("s1", [{"type": "user", "uuid": "u1"}])  # client_key 默认 None
+
+        assert calls["n"] == 2
+        assert result[0]["uuid"] == "u1"
+
     async def test_append_raises_non_unique_integrity_error_without_retry(self, log_store: EventLogStore, monkeypatch):
         """非唯一约束的 IntegrityError（如外键冲突 SQLSTATE 23503）不属于
         seq 竞争，应立即抛出而非重试。"""

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -53,6 +53,27 @@ async def file_log_store(tmp_path):
     await engine.dispose()
 
 
+class _FakeDriverError(Exception):
+    """带驱动侧属性的伪 DBAPI 错误（asyncpg 的 sqlstate/constraint_name、
+    sqlite3 的 sqlite_errorname），用于构造本地化文案下的 IntegrityError。"""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        sqlstate: str | None = None,
+        constraint_name: str | None = None,
+        sqlite_errorname: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        if sqlstate is not None:
+            self.sqlstate = sqlstate
+        if constraint_name is not None:
+            self.constraint_name = constraint_name
+        if sqlite_errorname is not None:
+            self.sqlite_errorname = sqlite_errorname
+
+
 # ---------------------------------------------------------------------------
 # normalize_sdk_message_to_entries — 写入点定型纯函数
 # ---------------------------------------------------------------------------
@@ -653,6 +674,123 @@ class TestEventLogStore:
 
         assert calls["n"] == 2  # 首次撞主键冲突后重试一次即成功
         assert result[0]["uuid"] == "u1"
+
+    async def test_append_retries_seq_race_with_localized_pg_error_via_sqlstate(
+        self, log_store: EventLogStore, monkeypatch
+    ):
+        """唯一约束冲突判定以 SQLSTATE 为准：PostgreSQL 错误文案随 lc_messages
+        本地化，非英文环境下不含 "duplicate key"/"UNIQUE" 字样，子串匹配会把
+        可重试的 seq 竞争误判为真实错误抛成 500。"""
+        from sqlalchemy.exc import IntegrityError
+
+        localized = _FakeDriverError(
+            "doppelter Schlüsselwert verletzt Unique-Constraint »agent_session_event_log_pkey«",
+            sqlstate="23505",
+        )
+        calls = {"n": 0}
+        original_append_once = log_store._append_once  # pyright: ignore[reportPrivateUsage]
+
+        async def _flaky_append_once(session_id, entries, client_key):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise IntegrityError("INSERT INTO agent_session_event_log ...", {}, localized)
+            return await original_append_once(session_id, entries, client_key)
+
+        monkeypatch.setattr(log_store, "_append_once", _flaky_append_once)
+
+        result = await log_store.append("s1", [{"type": "user", "uuid": "u1"}])
+
+        assert calls["n"] == 2
+        assert result[0]["uuid"] == "u1"
+
+    async def test_append_client_key_conflict_detected_by_constraint_name_when_localized(
+        self, log_store: EventLogStore, monkeypatch
+    ):
+        """client_key 冲突判定优先用驱动暴露的约束名（不随 locale 翻译）：
+        本地化文案下仍能走幂等短路，返回既有条目而非抛出。"""
+        from sqlalchemy.exc import IntegrityError
+
+        entry = build_user_entry([{"type": "text", "text": "hi"}])
+        existing = (await log_store.append("s1", [entry], client_key="ck-1"))[0]
+
+        localized = _FakeDriverError(
+            "doppelter Schlüsselwert verletzt Unique-Constraint »uq_agent_event_log_client_key«",
+            sqlstate="23505",
+            constraint_name="uq_agent_event_log_client_key",
+        )
+
+        async def _conflicting_append_once(session_id, entries, client_key):
+            raise IntegrityError("INSERT INTO agent_session_event_log ...", {}, localized)
+
+        monkeypatch.setattr(log_store, "_append_once", _conflicting_append_once)
+
+        retry = build_user_entry([{"type": "text", "text": "hi"}])
+        result = await log_store.append("s1", [retry], client_key="ck-1")
+
+        assert result == [existing]
+
+    async def test_append_raises_non_unique_integrity_error_without_retry(self, log_store: EventLogStore, monkeypatch):
+        """非唯一约束的 IntegrityError（如外键冲突 SQLSTATE 23503）不属于
+        seq 竞争，应立即抛出而非重试。"""
+        from sqlalchemy.exc import IntegrityError
+
+        calls = {"n": 0}
+
+        async def _failing_append_once(session_id, entries, client_key):
+            calls["n"] += 1
+            raise IntegrityError(
+                "INSERT INTO agent_session_event_log ...",
+                {},
+                _FakeDriverError("verletzt Fremdschlüssel-Constraint", sqlstate="23503"),
+            )
+
+        monkeypatch.setattr(log_store, "_append_once", _failing_append_once)
+
+        with pytest.raises(IntegrityError):
+            await log_store.append("s1", [{"type": "user", "uuid": "u1"}])
+        assert calls["n"] == 1
+
+    async def test_append_retries_seq_race_via_sqlite_errorname(self, log_store: EventLogStore, monkeypatch):
+        """SQLite 侧用 sqlite_errorname 判定（PRIMARYKEY/UNIQUE 两个扩展码都算），
+        不依赖错误文案。"""
+        from sqlalchemy.exc import IntegrityError
+
+        driver_error = _FakeDriverError("constraint failed", sqlite_errorname="SQLITE_CONSTRAINT_PRIMARYKEY")
+        calls = {"n": 0}
+        original_append_once = log_store._append_once  # pyright: ignore[reportPrivateUsage]
+
+        async def _flaky_append_once(session_id, entries, client_key):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise IntegrityError("INSERT INTO agent_session_event_log ...", {}, driver_error)
+            return await original_append_once(session_id, entries, client_key)
+
+        monkeypatch.setattr(log_store, "_append_once", _flaky_append_once)
+
+        result = await log_store.append("s1", [{"type": "user", "uuid": "u1"}])
+
+        assert calls["n"] == 2
+        assert result[0]["uuid"] == "u1"
+
+    async def test_find_new_session_by_client_key_scans_across_sessions(self, log_store: EventLogStore):
+        """跨会话按幂等键定位新会话受理条目（seq 0）：进程内映射重启/淘汰
+        丢失后，重试凭此命中既有会话而非重复建会话。"""
+        first = build_user_entry([{"type": "text", "text": "hi"}])
+        await log_store.append("sdk-a", [first], client_key="ck-new")
+        await log_store.append("sdk-b", [build_user_entry([{"type": "text", "text": "other"}])])
+        # 非首条（seq>0）的常规消息幂等键不属于新会话受理，不参与匹配
+        mid = build_user_entry([{"type": "text", "text": "mid"}])
+        await log_store.append("sdk-b", [mid], client_key="ck-mid")
+
+        found = await log_store.find_new_session_by_client_key("ck-new")
+        assert found is not None
+        session_id, entry = found
+        assert session_id == "sdk-a"
+        assert entry["seq"] == 0
+        assert entry["uuid"] == first["uuid"]
+
+        assert await log_store.find_new_session_by_client_key("ck-mid") is None
+        assert await log_store.find_new_session_by_client_key("ck-unknown") is None
 
     async def test_has_entries(self, log_store: EventLogStore):
         assert await log_store.has_entries("s1") is False

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -800,7 +800,7 @@ class TestEventLogStore:
         让误判把普通 seq 竞争的重试关掉。"""
         from sqlalchemy.exc import IntegrityError
 
-        import server.agent_runtime.event_log as event_log_module
+        from server.agent_runtime import event_log as event_log_module
 
         monkeypatch.setattr(event_log_module, "_is_client_key_violation", lambda exc: True)
 

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -756,6 +756,24 @@ class TestEventLogStore:
 
         assert result == [existing]
 
+    async def test_first_driver_attr_terminates_on_cyclic_exception_chain(self):
+        """``__cause__``/``__context__`` 链人为构造成环（正常异常传播不会产生,
+        但不排除病态构造）时按 id() 去重仍能终止,不陷入死循环。"""
+        from sqlalchemy.exc import IntegrityError
+
+        from server.agent_runtime.event_log import _first_driver_attr  # pyright: ignore[reportPrivateUsage]
+
+        err_a = _FakeDriverError("a")
+        err_b = _FakeDriverError("b")
+        err_a.__context__ = err_b
+        err_b.__context__ = err_a  # 环：a -> b -> a -> ...
+
+        exc = IntegrityError("INSERT INTO agent_session_event_log ...", {}, err_a)
+
+        result = _first_driver_attr(exc, "sqlstate", "constraint_name")
+
+        assert result is None
+
     async def test_append_raises_non_unique_integrity_error_without_retry(self, log_store: EventLogStore, monkeypatch):
         """非唯一约束的 IntegrityError（如外键冲突 SQLSTATE 23503）不属于
         seq 竞争，应立即抛出而非重试。"""

--- a/tests/agent_runtime/test_keyed_locks.py
+++ b/tests/agent_runtime/test_keyed_locks.py
@@ -1,0 +1,53 @@
+"""KeyedLocks — 按键弱引用锁注册表。"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+
+from server.agent_runtime.keyed_locks import KeyedLocks
+
+
+class TestKeyedLocks:
+    async def test_same_key_shares_lock_instance(self):
+        locks = KeyedLocks()
+        a = locks.lock_for("k1")
+        b = locks.lock_for("k1")
+        assert a is b
+
+    async def test_different_keys_get_independent_locks(self):
+        locks = KeyedLocks()
+        assert locks.lock_for("k1") is not locks.lock_for("k2")
+
+    async def test_lock_serializes_concurrent_holders(self):
+        locks = KeyedLocks()
+        order: list[str] = []
+
+        async def _critical(tag: str) -> None:
+            async with locks.lock_for("k"):
+                order.append(f"{tag}-in")
+                await asyncio.sleep(0)
+                order.append(f"{tag}-out")
+
+        await asyncio.gather(_critical("a"), _critical("b"))
+        assert order in (["a-in", "a-out", "b-in", "b-out"], ["b-in", "b-out", "a-in", "a-out"])
+
+    async def test_unreferenced_lock_is_collected(self):
+        """无协程持有/等待时锁对象自动回收，不为每个键永久驻留内存。"""
+        locks = KeyedLocks()
+        locks.lock_for("k1")
+        gc.collect()
+        assert len(locks) == 0
+        assert "k1" not in locks
+
+    async def test_discard_clears_registry_entry(self):
+        locks = KeyedLocks()
+        held = locks.lock_for("k1")
+        assert "k1" in locks
+        locks.discard("k1")
+        assert "k1" not in locks
+        # 已持有的锁对象仍可正常使用
+        async with held:
+            pass
+        # discard 后再取拿到新实例
+        assert locks.lock_for("k1") is not held

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -360,6 +360,54 @@ class TestAssistantServiceMore:
         await engine.dispose()
 
     @pytest.mark.asyncio
+    async def test_send_or_create_hit_refreshes_lru_position(self, tmp_path):
+        """命中进程内映射时刷新 LRU 位置：被频繁重试命中的 key 不因插入顺序
+        在先，被之后新到达但只访问一次的 key 挤出缓存（退化为 FIFO）。"""
+        from server.agent_runtime.event_log import EventLogStore
+
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        store = EventLogStore(session_factory=factory)
+
+        service = AssistantService(project_root=tmp_path)
+        sm = _FakeSessionManager()
+        service.pm = _FakePM(valid_project="demo")
+        service.session_manager = sm
+        service.meta_store = _FakeMetaStore([])
+        service.event_log = _FakeEventLogService()
+        service.event_log_store = store
+        service._new_session_client_keys_max = 2
+
+        async def send_new_session(project_name, prompt, *, user_entry=None, client_key=None, **kwargs):
+            sid = f"sdk-{len(sm.new_sessions)}"
+            sm.new_sessions.append((project_name, prompt))
+            if user_entry is not None:
+                await store.append_user_entry(sid, user_entry, client_key=client_key)
+            return sid
+
+        sm.send_new_session = send_new_session
+
+        await service.send_or_create("demo", "hello-a", client_key="ck-a")
+        await service.send_or_create("demo", "hello-b", client_key="ck-b")
+        assert list(service._new_session_client_keys) == ["ck-a", "ck-b"]
+
+        # 命中 ck-a（幂等重试，不新建会话）：应把 ck-a 刷新到最近使用端
+        hit = await service.send_or_create("demo", "hello-a", client_key="ck-a")
+        assert hit["session_id"] == "sdk-0"
+        assert list(service._new_session_client_keys) == ["ck-b", "ck-a"]
+
+        # 第三个 key 到达挤出缓存：应淘汰最久未使用的 ck-b，而非刚被命中的 ck-a
+        await service.send_or_create("demo", "hello-c", client_key="ck-c")
+
+        assert "ck-a" in service._new_session_client_keys
+        assert "ck-b" not in service._new_session_client_keys
+        assert len(sm.new_sessions) == 3  # a/b/c 三次真正新建，命中未重复建会话
+
+        await engine.dispose()
+
+    @pytest.mark.asyncio
     async def test_send_or_create_falls_back_when_cached_mapping_points_to_deleted_session(self, tmp_path):
         """进程内映射指向的会话条目已不存在（如会话被删除后映射未清）时，
         不应把幽灵 "accepted" 响应（entry=None）返回给调用方——应清掉失效

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -264,7 +264,11 @@ class TestAssistantServiceMore:
         async def fake_find_by_client_key(session_id, client_key):
             return {"seq": 0, "type": "user", "content": []}
 
+        async def fake_find_new_session_by_client_key(client_key):
+            return None
+
         service.event_log_store.find_by_client_key = fake_find_by_client_key
+        service.event_log_store.find_new_session_by_client_key = fake_find_new_session_by_client_key
 
         task1 = asyncio.create_task(service.send_or_create("demo", "hello", client_key="ck-race"))
         await asyncio.wait_for(entered.wait(), timeout=0.2)
@@ -277,6 +281,83 @@ class TestAssistantServiceMore:
 
         assert len(sm.new_sessions) == 1  # 只建了一个会话，未因在途窗口重复投递
         assert result1["session_id"] == result2["session_id"] == "sdk-new-id"
+
+    @pytest.mark.asyncio
+    async def test_send_or_create_recovers_client_key_mapping_from_db_after_restart(self, tmp_path):
+        """进程内幂等映射重启丢失后，受理已落库（新会话首条条目 seq 0 携带
+        client_key）的重试应经 DB 兜底命中既有会话，不再重复建会话。"""
+        from server.agent_runtime.event_log import EventLogStore, build_user_entry
+
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        store = EventLogStore(session_factory=factory)
+
+        # 首次受理（重启前）：新会话首条用户条目已随 client_key 落库
+        accepted_entry = build_user_entry([{"type": "text", "text": "hello"}])
+        await store.append("sdk-prev", [accepted_entry], client_key="ck-restart")
+
+        service = AssistantService(project_root=tmp_path)
+        sm = _FakeSessionManager()
+        service.pm = _FakePM(valid_project="demo")
+        service.session_manager = sm
+        service.meta_store = _FakeMetaStore([])
+        service.event_log = _FakeEventLogService()
+        service.event_log_store = store
+        assert service._new_session_client_keys == {}  # 重启后进程内映射为空
+
+        result = await service.send_or_create("demo", "hello", client_key="ck-restart")
+
+        assert sm.new_sessions == []  # 未重复建会话
+        assert result["session_id"] == "sdk-prev"
+        assert result["entry"] is not None
+        assert result["entry"]["uuid"] == accepted_entry["uuid"]
+        # 命中后回填进程内映射，后续重试走快路径
+        assert service._new_session_client_keys["ck-restart"] == "sdk-prev"
+
+        await engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_send_or_create_recovers_client_key_after_lru_eviction(self, tmp_path):
+        """进程内 LRU 淘汰旧键后，同键重试经 DB 兜底命中原会话。"""
+        from server.agent_runtime.event_log import EventLogStore
+
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        store = EventLogStore(session_factory=factory)
+
+        service = AssistantService(project_root=tmp_path)
+        sm = _FakeSessionManager()
+        service.pm = _FakePM(valid_project="demo")
+        service.session_manager = sm
+        service.meta_store = _FakeMetaStore([])
+        service.event_log = _FakeEventLogService()
+        service.event_log_store = store
+        service._new_session_client_keys_max = 1
+
+        # 模拟 SessionManager 的受理落库：新会话首条条目随 client_key 写入
+        async def send_new_session(project_name, prompt, *, user_entry=None, client_key=None, **kwargs):
+            sid = f"sdk-{len(sm.new_sessions)}"
+            sm.new_sessions.append((project_name, prompt))
+            if user_entry is not None:
+                await store.append_user_entry(sid, user_entry, client_key=client_key)
+            return sid
+
+        sm.send_new_session = send_new_session
+
+        first = await service.send_or_create("demo", "hello", client_key="ck-a")
+        await service.send_or_create("demo", "another", client_key="ck-b")
+        assert "ck-a" not in service._new_session_client_keys  # LRU 已淘汰
+
+        retry = await service.send_or_create("demo", "hello", client_key="ck-a")
+
+        assert len(sm.new_sessions) == 2  # 重试未新建第三个会话
+        assert retry["session_id"] == first["session_id"] == "sdk-0"
+
+        await engine.dispose()
 
     @pytest.mark.asyncio
     async def test_delete_session_closes_active_session_before_delete(self, tmp_path):

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -360,6 +360,39 @@ class TestAssistantServiceMore:
         await engine.dispose()
 
     @pytest.mark.asyncio
+    async def test_send_or_create_falls_back_when_cached_mapping_points_to_deleted_session(self, tmp_path):
+        """进程内映射指向的会话条目已不存在（如会话被删除后映射未清）时，
+        不应把幽灵 "accepted" 响应（entry=None）返回给调用方——应清掉失效
+        映射并按正常路径新建会话，而不是让调用方连接一个不存在的会话。"""
+        from server.agent_runtime.event_log import EventLogStore
+
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        store = EventLogStore(session_factory=factory)
+
+        service = AssistantService(project_root=tmp_path)
+        sm = _FakeSessionManager()
+        service.pm = _FakePM(valid_project="demo")
+        service.session_manager = sm
+        service.meta_store = _FakeMetaStore([])
+        service.event_log = _FakeEventLogService()
+        service.event_log_store = store
+        # 模拟会话已被删除但进程内映射未清（delete_session 不感知该映射）。
+        service._new_session_client_keys["ck-stale"] = "sdk-deleted"
+
+        result = await service.send_or_create("demo", "hello", client_key="ck-stale")
+
+        assert len(sm.new_sessions) == 1  # 未拿到幽灵响应，走了正常新建路径
+        assert result["session_id"] == "sdk-new-id"
+        assert result["session_id"] != "sdk-deleted"
+        # 映射已刷新为新会话，不再指向已删除的会话
+        assert service._new_session_client_keys["ck-stale"] == "sdk-new-id"
+
+        await engine.dispose()
+
+    @pytest.mark.asyncio
     async def test_delete_session_closes_active_session_before_delete(self, tmp_path):
         service = AssistantService(project_root=tmp_path)
         meta = make_session_meta(id="s1")

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -408,6 +408,56 @@ class TestAssistantServiceMore:
         await engine.dispose()
 
     @pytest.mark.asyncio
+    async def test_send_or_create_hit_survives_concurrent_eviction_during_db_lookup(self, tmp_path, monkeypatch):
+        """命中路径在 `await find_by_client_key(...)` 期间，该 key 被其他并发
+        请求的淘汰逻辑移除：刷新 LRU 位置的收尾步骤须安全处理键已不存在的
+        情形（不能直接 move_to_end 抛 KeyError 把幂等命中打成未处理异常）。"""
+        from server.agent_runtime.event_log import EventLogStore
+
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        store = EventLogStore(session_factory=factory)
+
+        service = AssistantService(project_root=tmp_path)
+        sm = _FakeSessionManager()
+        service.pm = _FakePM(valid_project="demo")
+        service.session_manager = sm
+        service.meta_store = _FakeMetaStore([])
+        service.event_log = _FakeEventLogService()
+        service.event_log_store = store
+
+        async def send_new_session(project_name, prompt, *, user_entry=None, client_key=None, **kwargs):
+            sid = f"sdk-{len(sm.new_sessions)}"
+            sm.new_sessions.append((project_name, prompt))
+            if user_entry is not None:
+                await store.append_user_entry(sid, user_entry, client_key=client_key)
+            return sid
+
+        sm.send_new_session = send_new_session
+
+        first = await service.send_or_create("demo", "hello", client_key="ck-a")
+        assert "ck-a" in service._new_session_client_keys
+
+        original_find_by_client_key = store.find_by_client_key
+
+        async def find_by_client_key_with_concurrent_eviction(session_id, client_key):
+            # 模拟另一并发请求在本次 DB 查询期间把该 key 挤出缓存。
+            service._new_session_client_keys.pop(client_key, None)
+            return await original_find_by_client_key(session_id, client_key)
+
+        monkeypatch.setattr(store, "find_by_client_key", find_by_client_key_with_concurrent_eviction)
+
+        retry = await service.send_or_create("demo", "hello", client_key="ck-a")
+
+        assert retry["session_id"] == first["session_id"] == "sdk-0"
+        assert len(sm.new_sessions) == 1  # 未因异常或键缺失而重复建会话
+        assert service._new_session_client_keys["ck-a"] == "sdk-0"  # 命中后已安全重新记入
+
+        await engine.dispose()
+
+    @pytest.mark.asyncio
     async def test_send_or_create_falls_back_when_cached_mapping_points_to_deleted_session(self, tmp_path):
         """进程内映射指向的会话条目已不存在（如会话被删除后映射未清）时，
         不应把幽灵 "accepted" 响应（entry=None）返回给调用方——应清掉失效

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -491,6 +491,68 @@ class TestAssistantServiceMore:
         await engine.dispose()
 
     @pytest.mark.asyncio
+    async def test_ghost_mapping_cleanup_does_not_clobber_concurrent_fresh_mapping(self, tmp_path):
+        """幽灵映射清理在 `await find_by_client_key(...)` 期间该 key 被其他
+        并发请求写入了新的有效映射：清理不应无条件 pop，否则会误删并发
+        写入的新映射（即便 DB 兜底之后仍能查回正确会话，也不应制造这层
+        可避免的抖动窗口）。"""
+        service = AssistantService(project_root=tmp_path)
+        service.pm = _FakePM(valid_project="demo")
+        service.session_manager = _FakeSessionManager()
+        service.meta_store = _FakeMetaStore([])
+        service.event_log = _FakeEventLogService()
+
+        async def find_by_client_key(session_id, client_key):
+            # 模拟另一并发请求在本次查询期间把该 key 更新为新的有效映射。
+            service._new_session_client_keys[client_key] = "sdk-fresh"
+            return None  # 旧会话（sdk-deleted）条目已不存在
+
+        async def find_new_session_by_client_key(client_key):
+            return None  # 本测试只关心清理分支，不需要真的兜底恢复
+
+        service.event_log_store = SimpleNamespace(
+            find_by_client_key=find_by_client_key,
+            find_new_session_by_client_key=find_new_session_by_client_key,
+        )
+        service._new_session_client_keys["ck-a"] = "sdk-deleted"
+
+        result = await service._find_accepted_new_session("ck-a")  # pyright: ignore[reportPrivateUsage]
+
+        assert result is None  # 本测试的兜底查询返回 None，不影响本次断言重点
+        assert service._new_session_client_keys["ck-a"] == "sdk-fresh"  # 未被误删
+
+    @pytest.mark.asyncio
+    async def test_recovered_mapping_does_not_overwrite_concurrent_fresher_mapping(self, tmp_path):
+        """DB 兜底恢复在 `await find_new_session_by_client_key(...)` 期间该 key
+        已被其他并发请求记入更新的映射：不应用本次查到的（较旧）session_id
+        覆盖并发写入的映射。"""
+        service = AssistantService(project_root=tmp_path)
+        service.pm = _FakePM(valid_project="demo")
+        service.session_manager = _FakeSessionManager()
+        service.meta_store = _FakeMetaStore([])
+        service.event_log = _FakeEventLogService()
+
+        async def find_by_client_key(session_id, client_key):
+            return None
+
+        async def find_new_session_by_client_key(client_key):
+            # 模拟另一并发请求在本次查询期间已经建好新会话并记入映射。
+            service._new_session_client_keys[client_key] = "sdk-fresh"
+            return "sdk-old", {"seq": 0, "type": "user"}
+
+        service.event_log_store = SimpleNamespace(
+            find_by_client_key=find_by_client_key,
+            find_new_session_by_client_key=find_new_session_by_client_key,
+        )
+
+        result = await service._find_accepted_new_session("ck-b")  # pyright: ignore[reportPrivateUsage]
+
+        assert result is not None
+        assert result["session_id"] == "sdk-old"  # 本次调用仍返回自己查到的权威条目
+        # 但不应覆盖并发写入的更新映射
+        assert service._new_session_client_keys["ck-b"] == "sdk-fresh"
+
+    @pytest.mark.asyncio
     async def test_delete_session_closes_active_session_before_delete(self, tmp_path):
         service = AssistantService(project_root=tmp_path)
         meta = make_session_meta(id="s1")


### PR DESCRIPTION
## 范围

聚焦 #1064：#1053 引入并已合入 main 的 4 条遗留缺陷（client_key 幂等持久化、entry-projection 跨 turn 回填、event_log.append 的 IntegrityError 子串匹配、重复实现）。不涉及 #1063/PR #1068 已合入的首条消息落库失败清理路径（`session_manager.py`），也不涉及尚未合并的 #1058 前端增量投影重构。

## 变更

- client_key 幂等持久化：新增跨会话 DB 兜底查询 `find_new_session_by_client_key`，进程内 LRU 映射为快路径；新增迁移 `bd25b66f82e8`（client_key 检索索引；`(session_id, client_key)` 分区唯一索引非全局唯一，是既定取舍）
- entry-projection 跨 turn 回填：tool_result / task 更新在当前 turn 未命中时回退到已 flush 的 turns，不再永久悬挂在未完成态
- event_log.append 的 IntegrityError 判定改为错误码优先（PostgreSQL SQLSTATE / SQLite errorname），文案子串仅作兜底；client_key 冲突判定优先用驱动暴露的约束名
- 重复实现收敛：`DraftAssistantProjector` 经核实已随 #1062 删除，当前仅 `DraftAccumulator` 一套草稿投影；`EventLogService` 与 `AssistantService` 各自维护的 weakref keyed-lock 合并为共享 `KeyedLocks`
- 本地审查追加修复：`_find_accepted_new_session` 的进程内映射指向已删除会话（entry 查不到）时不再返回幽灵 "accepted" 响应，改为清掉旧映射后继续探测/新建
- 本地审查追加清理：前端 tool_result / 提问答复回填共用的锚点查找逻辑合并为 `findToolUseAnchor`；后端唯一约束判定与 client_key 冲突判定共用的驱动异常属性遍历合并为 `_first_driver_attr`

## 验收清单

- [x] 本地已跑相关测试：`uv run python -m pytest`（5705 passed）、`uv run ruff check . && uv run ruff format --check .`（clean）、`uv run basedpyright`（0 errors）；`cd frontend && pnpm lint && pnpm check`（typecheck + eslint + vitest 854 passed）
- [x] 手动验证了改动所声称的行为：重启/LRU 淘汰后幂等恢复、跨 turn 回填、locale 化 IntegrityError 判定、幽灵会话响应回归测试均有对应用例覆盖
- [x] 新增面向用户文案已加 zh/en 翻译（本 PR 无新增用户可见文案，不适用）
- [x] 无新增 ESLint disable
- [x] CODEOWNERS 要求的 review 已请求（仓库唯一 owner）

## 已知 defer

- 首条用户消息落库失败清理窗口期内，非-result 消息仍可能被持久化产生孤儿事件日志行——该逻辑随 #1063/PR #1068 引入，不在本 PR 改动范围，已开 #1071 跟踪
- 跨会话 client_key 兜底查询依赖 `seq==0` 启发式，理论上可能与既有会话首条消息巧合冲突——已开 #1072 跟踪

Closes #1064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 新增基于客户端键的跨会话检索与幂等建会话恢复能力。
  * 引入按客户端键的并发串行化锁，提升同键建会话一致性。
  * 强化多轮对话投影回填：任务进度、工具结果与问答可跨轮次更准确匹配。
* **Bug Fixes**
  * 完善数据库唯一性冲突识别与重试/幂等短路策略，降低重复会话与误判。
  * 新增客户端键部分过滤索引，提升回查效率。
* **Tests**
  * 扩展建会话并发幂等、锁行为与跨轮次回填等测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->