### PR TITLE
fix(skills): pr-ai-review-loop 识别 withdrawn 标记并停用未接入的 Codex 触发

### DIFF
--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -11,7 +11,7 @@ PR push 之后,多家 reviewer bot 会产出评论。本 skill 调度 review →
 
 循环的唯一正常出口。宣布通过前逐项核对:
 
-1. **本 PR 参审的每家 AI reviewer**(CodeRabbit / Gemini / Codex)对当前 HEAD 通过。CodeRabbit 始终参审,Gemini 由 cold-start fallback 保证参审,Codex 按其触发决策可不参审;fix-up 顺延时沿用上一已审 HEAD 的通过结论(口径见 reviewers.md「通用约定」)
+1. **本 PR 参审的每家 AI reviewer**(CodeRabbit / Gemini)对当前 HEAD 通过。CodeRabbit 始终参审,Gemini 由 cold-start fallback 保证参审;fix-up 顺延时沿用上一已审 HEAD 的通过结论(口径见 reviewers.md「通用约定」)。Codex 未接入本仓库 GitHub App,不参审、不触发、不计入达标判定(见 reviewers.md「OpenAI Codex(未接入,不参审)」)
 2. **CodeQL 退出门槛**:分析完成且成功、security 无 PR 引入的 open 告警、quality 全量评论逐条已处置——三条细则与"仓库未接入"的跳过口径见 reviewers.md「GitHub code scanning bots」节
 3. 循环期间的所有 actionable 评论均已实施修复或记录 pushback
 
@@ -64,7 +64,7 @@ bash .agents/skills/pr-ai-review-loop/scripts/poll.sh <PR_NUMBER>
 | 以上缺口均消失 | 做目标状态**终核**(含 CodeQL 门槛逐条);全过则正常退出:退出前按 [references/retrospective.md](references/retrospective.md) 产出复盘、随简短汇报交出;发现遗留则按对应缺口处理 |
 | 未全部达成且无可执行动作(reviewer 响应中) | 按「轮询节奏」表等待下一轮 |
 
-**fix-up 跳过**:发触发命令前先跑 `classify_commits.sh`;若本轮 push 全为 fix-up(nit、format、typo、单字段调整、小 bug 修复)**且该家对上一已审 HEAD 已通过**,跳过手动触发 Gemini 与 Codex,沿用其通过结论。前提与范围的完整口径见 reviewers.md「通用约定」fix-up 顺延条,cold-start fallback 例外见其 Gemini「触发」节。
+**fix-up 跳过**:发触发命令前先跑 `classify_commits.sh`;若本轮 push 全为 fix-up(nit、format、typo、单字段调整、小 bug 修复)**且该家对上一已审 HEAD 已通过**,跳过手动触发 Gemini,沿用其通过结论。前提与范围的完整口径见 reviewers.md「通用约定」fix-up 顺延条,cold-start fallback 例外见其 Gemini「触发」节。
 
 执行完触发动作后,按「轮询节奏」表选择延迟,调用 `ScheduleWakeup`。
 
@@ -85,7 +85,7 @@ bash .agents/skills/pr-ai-review-loop/scripts/poll.sh <PR_NUMBER>
 | 场景 | 延迟 | 备注 |
 |---|---|---|
 | 新 HEAD 后首次 poll | 180s | reviewer cold-start;CR 通常 60-90s 跟新 HEAD;Gemini 仅 PR opened 自动 review;CodeQL 分析需数分钟 |
-| 发送 `/gemini review` 或 `@codex review` 之后 | 120s | Gemini 响应通常 90-120s,60s 容易错过 |
+| 发送 `/gemini review` 之后 | 120s | Gemini 响应通常 90-120s,60s 容易错过 |
 | 常规等待(reviewer 响应中) | 60s | 处于 prompt cache 5 分钟窗口内 |
 | 仅剩 CodeQL 分析未完成 | 120s | 等 check 完成做终核 |
 | 超过 15 分钟无响应 | 暂停并询问用户,不再 ScheduleWakeup | 见「故障处理」 |

--- a/.agents/skills/pr-ai-review-loop/references/reviewers.md
+++ b/.agents/skills/pr-ai-review-loop/references/reviewers.md
@@ -81,14 +81,14 @@
 
 ## GitHub code scanning bots(Code Quality + Advanced Security)
 
-同一次 CodeQL 分析的两个投递面:`github-code-quality[bot]` 发质量告警(unused import、empty except 等,附修复建议),`github-advanced-security[bot]` 发安全告警(链接到 `/security/code-scanning/<n>` 的 alert)。与三家 AI reviewer 的本质差异:
+同一次 CodeQL 分析的两个投递面:`github-code-quality[bot]` 发质量告警(unused import、empty except 等,附修复建议),`github-advanced-security[bot]` 发安全告警(链接到 `/security/code-scanning/<n>` 的 alert)。与 CodeRabbit / Gemini 两家参审 AI reviewer 的本质差异:
 
 - **不可触发**,随 push 后的 CodeQL 分析自动产出,可能比 CodeRabbit 慢几分钟
 - **不读 inline 回复**,修复 push 后 alert 自动关闭——修了就不用回
 - **对未修复告警不重复提醒**:同一 alert 只在引入时评论一次,后续 push 不重贴。因此"无遗留告警"**不能**用"本轮无新评论"判定,漏修一条会静默通过
 - quality 告警通常**不会**让 check 变红,光看 CI 红绿会漏
 
-**actionable**:两家所有本轮新 inline 一律算 actionable(量少且都是 CodeQL 高置信度规则),与三家 AI reviewer 的评论合并转交 `receiving-code-review`。pushback(误报、不该提交的产物等)仍由 `receiving-code-review` 判断,但落点是 PR 评论说明或 dismiss alert,**不是**回 inline。
+**actionable**:两家所有本轮新 inline 一律算 actionable(量少且都是 CodeQL 高置信度规则),与 CodeRabbit / Gemini 的评论合并转交 `receiving-code-review`。pushback(误报、不该提交的产物等)仍由 `receiving-code-review` 判断,但落点是 PR 评论说明或 dismiss alert,**不是**回 inline。
 
 **退出门槛**(代替"通过",在准备宣布循环结束时核对):
 

--- a/.agents/skills/pr-ai-review-loop/references/reviewers.md
+++ b/.agents/skills/pr-ai-review-loop/references/reviewers.md
@@ -16,9 +16,11 @@
 |---|---|---|---|---|
 | CodeRabbit | `coderabbitai` | `coderabbitai[bot]` | PR opened 及后续每次 push | `@coderabbitai resume` / `review` / `full review` |
 | Gemini Code Assist | `gemini-code-assist` | `gemini-code-assist[bot]` | **仅 PR opened**(5 分钟内出结果) | `/gemini review` |
-| OpenAI Codex | `chatgpt-codex-connector` | `chatgpt-codex-connector[bot]` | 取决于仓库配置 | `@codex review` |
+| OpenAI Codex(未接入,不参审) | `chatgpt-codex-connector` | `chatgpt-codex-connector[bot]` | 不适用(未接入) | **不触发** |
 | GitHub Code Quality | —(只发 inline) | `github-code-quality[bot]` | 每次 push 后的 CodeQL 分析 | **不可触发** |
 | GitHub Advanced Security | —(只发 inline) | `github-advanced-security[bot]` | 同上 | **不可触发** |
+
+本仓库未接入 Codex GitHub App:循环不发送 `@codex review`、不轮询或等待其响应、达标判定与 fix-up 跳过规则均不涉及 Codex。`## OpenAI Codex(未接入,不参审)` 节保留判定细则作日后接入时的参考。
 
 ## CodeRabbit
 
@@ -61,9 +63,9 @@
 1. 本轮无新 inline,或本轮新 inline 全部为 `low/nit/style` 或全部 `is_ack`
 2. summary 最新一条 body 含明确通过标记(非空不等于通过)
 
-## OpenAI Codex
+## OpenAI Codex(未接入,不参审)
 
-**触发决策**:仓库未开启自动 review 时,是否手动 `@codex review` 综合判断——用户明确意图(提到 codex 通常意味着要触发)、CodeRabbit 与 Gemini 意见冲突需第三方仲裁、改动面值得多看一遍(敏感模块、跨模块影响、新增依赖)、当前 HEAD 未触发过、fix-up 跳过未命中。
+本仓库未接入 Codex GitHub App:循环不发送 `@codex review`、不轮询或等待其响应、达标判定不含 Codex,fix-up 跳过规则也不再涉及它。以下判定规则保留作参考,日后接入 App 时按本节重新纳入参审名单。
 
 **三种 ack 模式**(任一命中即算"对当前 HEAD 无 actionable"):
 

--- a/.agents/skills/pr-ai-review-loop/scripts/classify_commits.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/classify_commits.sh
@@ -24,7 +24,7 @@
 #
 # WHY
 # Skill needs to judge whether the latest push is "fix-up only" (nit/format/typo/small bug) so it can:
-#   (a) skip burning Gemini/Codex quota on a manual re-trigger (the conservative-trigger gate), and
+#   (a) skip burning Gemini quota on a manual re-trigger (the conservative-trigger gate), and
 #   (b) count consecutive nit-only rounds toward the convergence exit.
 # Output is raw metadata (file count, line stats, message text); Claude makes the final call —
 # scripting "is this nit?" would miss semantic cues like "fix typo in error message

--- a/.agents/skills/pr-ai-review-loop/scripts/poll.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/poll.sh
@@ -31,7 +31,10 @@
 #     "reviews":  [{id, submittedAt, state, body}],     # body = review SUMMARY (## Code Review ...) — can contain actionable text not in inline; id = GraphQL node id
 #     "comments": [...]
 #   },
-#   "codex": {
+#   "codex": {                                          # NOT integrated in this repo (no Codex GitHub App) — the loop never
+#                                                       # triggers it and this block is unused by current pass/wait logic.
+#                                                       # Kept as raw data + reference for future re-integration — see
+#                                                       # references/reviewers.md "OpenAI Codex(未接入,不参审)" and PITFALL 4.
 #     "reviews":   [{id, submittedAt, state, body}],    # body contains "Reviewed commit: <SHA>" when present; id = GraphQL node id
 #     "comments":  [...],
 #     "reactions": [{content, created_at}]              # +1 reaction on PR = silent ack — see PITFALL 4
@@ -53,7 +56,7 @@
 #     "open_introduced": [{number, rule, severity, security_severity, tool, path, url}]  # open alerts introduced by this PR
 #   },
 #   "quota_alerts": [...],                              # PR-level issue comments matching quota keywords (bots emit quota errors as plain comments, not reviews)
-#   "own_trigger_comments": [...]                       # human-authored /gemini review / @codex review / @coderabbitai resume
+#   "own_trigger_comments": [...]                       # human-authored /gemini review / @coderabbitai resume
 # }
 #
 # PITFALLS
@@ -71,7 +74,8 @@
 #    REST    `user.login`   = "coderabbitai[bot]" (with [bot] suffix).
 #    This script uses both endpoints; downstream consumers must use the right form for each datum.
 #
-# 4. Codex acks PR in 3 modes — all must be checked (see references/reviewers.md for full table):
+# 4. Codex is NOT integrated in this repo — the loop never triggers or waits on it. The 3 ack modes
+#    below only apply if/when the Codex GitHub App is later connected (see references/reviewers.md):
 #    (a) inline review with body "### 💡 Codex Review" + "Reviewed commit: <SHA>"
 #    (b) PR-level +1 reaction with NO comment (silent pass)
 #    (c) empty-body review (state=COMMENTED, body="") with no new inline
@@ -235,7 +239,9 @@ jq -n \
       end;
 
   def is_ack_body:
-    (test("<!--\\s*<review_comment_addressed>")) or (test("^### Summary"));
+    (test("<!--\\s*<review_comment_addressed>"))
+    or (test("<!--\\s*<review_comment_withdrawn>"))
+    or (test("^### Summary"));
 
   def inline_by_bot:
     [$sub_c[] | select(.user.login | test("(coderabbitai|gemini-code-assist|chatgpt-codex-connector|github-code-quality|github-advanced-security)\\[bot\\]$"))]
@@ -338,7 +344,7 @@ jq -n \
            (.author.login != "coderabbitai"
             and .author.login != "gemini-code-assist"
             and .author.login != "chatgpt-codex-connector")
-           and (.body | test("^[ \\t]*(/gemini review|@codex review|@coderabbitai resume)(\\s|$)"; "i"))
+           and (.body | test("^[ \\t]*(/gemini review|@coderabbitai resume)(\\s|$)"; "i"))
          )
        | {author: .author.login, createdAt, body: (.body | gsub("^\\s+|\\s+$"; ""))}]
   }

--- a/.agents/skills/pr-ai-review-loop/scripts/poll.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/poll.sh
@@ -91,7 +91,9 @@
 #
 # 6. Quota / rate-limit errors from Codex are PR-level ISSUE comments, NOT reviews/inline/reactions.
 #    Codex emits e.g. "You have reached your Codex usage limits..." as a plain PR comment — easy to miss.
-#    Captured into quota_alerts so the skill catches it on the first poll.
+#    Captured into quota_alerts so the skill catches it on the first poll. Codex is NOT integrated
+#    in this repo and the loop never triggers it, but quota_alerts still watches for this pattern
+#    in case a human manually triggers `@codex review` outside the loop.
 #
 # 7. security_alerts.open_introduced subtracts default-branch open alerts by alert number.
 #    The merge-ref analysis covers the whole codebase, so pre-existing alerts (e.g. scheduled
@@ -157,7 +159,8 @@ gh api "repos/${OWNER_REPO}/issues/${PR}/comments" --paginate > "$TMPDIR/sub_a.j
   exit 5
 }
 
-# Sub-query B — PR-level reactions (Codex silent +1 ack path).
+# Sub-query B — PR-level reactions (Codex silent +1 ack path; Codex is NOT integrated in
+# this repo, see PITFALL 4 — kept as raw data for future re-integration reference).
 gh api "repos/${OWNER_REPO}/issues/${PR}/reactions" --paginate > "$TMPDIR/sub_b.json" 2>"$TMPDIR/gh_reactions.err" || {
   echo "POLL_ERROR: REST reactions fetch failed" >&2
   cat "$TMPDIR/gh_reactions.err" >&2
@@ -343,6 +346,10 @@ jq -n \
        | select(
            (.author.login != "coderabbitai"
             and .author.login != "gemini-code-assist"
+            # chatgpt-codex-connector: defensive exclusion, kept even though the trigger regex
+            # below no longer matches "@codex review" — harmless as long as this bot never posts
+            # comments matching the pattern, and cheap insurance against future regex changes
+            # that widen it again.
             and .author.login != "chatgpt-codex-connector")
            and (.body | test("^[ \\t]*(/gemini review|@coderabbitai resume)(\\s|$)"; "i"))
          )


### PR DESCRIPTION
## Summary

Closes #1025

- `poll.sh` 的 `is_ack_body` 新增匹配 CodeRabbit 撤回意见的 `<!-- <review_comment_withdrawn> -->` 标记(在原有 addressed / `### Summary` 判定基础上追加分支),撤回后的意见不再被误判为未处理的 actionable 项。
- Codex 退出参审名单:循环不再发送 `@codex review`、不再轮询或等待其响应,达标判定与 fix-up 跳过规则均不涉及 Codex;`SKILL.md`、`references/reviewers.md`、`scripts/poll.sh`、`scripts/classify_commits.sh` 对参审名单的描述统一收敛。`poll.sh` 的 Codex 数据采集块(reviews/comments/reactions)与 `reviewers.md` 的三种 ack 判定细则保留作日后重新接入的参考,章节标题与总表行加注「(未接入,不参审)」。
- 本地审查追加修复:`reviewers.md` 的 code scanning 节仍写"三家 AI reviewer"(改为 CodeRabbit / Gemini 两家);`poll.sh` 的 PITFALL 6 与 sub-query B 注释补上 Codex 未接入的一致提示;`own_trigger_comments` 排除列表里保留的 `chatgpt-codex-connector` 补上防御性排除的说明注释。均为纯注释/文档修复,不改变判定逻辑。

## 范围说明

改动全部位于 `.agents/skills/pr-ai-review-loop/`,不涉及产品代码(`git diff --stat main -- server/ lib/ frontend/ tests/` 为空),ruff/basedpyright/pytest/pnpm 质量门不适用,未运行。

## 验证说明

- `bash -n` 通过 `poll.sh`、`classify_commits.sh` 语法检查。
- 用 dummy jq 输入独立验证 `is_ack_body`:对 `<!-- <review_comment_addressed> -->`、`<!-- <review_comment_withdrawn> -->`(含无空格变体、正文中段出现两种情形)、`### Summary` 开头样例均返回 `true`;对普通 actionable 文本(`_⚠️ Potential issue_`)返回 `false`;addressed 与 Summary 两类既有判定未受影响。
- 通过 `jq -n "$(cat 提取的程序体)"` 做纯语法解析检查(报错仅为未绑定 slurpfile 变量,无语法错误),确认内嵌 jq 程序整体可解析。
- 全仓库检索确认 `.agents/skills/pr-ai-review-loop/` 目录内 SKILL.md / reviewers.md / poll.sh 对 Codex 状态描述已收敛一致,目录外无相关残留引用(agent-browser 与 docs/research 里的 "Codex" 提及均为无关的工具/模型名)。

## Test plan

- [x] `is_ack_body` withdrawn/addressed/Summary/actionable 四类样例手工核验通过
- [x] `bash -n` 语法检查通过
- [x] jq 内嵌程序语法解析检查通过
- [x] 全仓库 grep 确认 Codex 参审描述无残留漂移
- [x] `git diff --stat main -- server/ lib/ frontend/ tests/` 为空,产品代码质量门不适用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了自动评审循环的判定与等待规则，减少重复触发和误判。
  * 增强了对已确认回复的识别，提升流程稳定性。
* **Chores**
  * 更新了评审协作说明，使当前可用的流程规则更清晰。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->