### PR TITLE
fix(server): 项目删除后事件流终止轮询，消除 ERROR 刷屏

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -22,6 +22,7 @@ import type {
   ProjectOverview,
   ProjectChangeBatchPayload,
   ProjectEventSnapshotPayload,
+  ProjectDeletedPayload,
   GetSystemConfigResponse,
   GetSystemVersionResponse,
   SystemConfigPatch,
@@ -150,6 +151,8 @@ export interface ProjectEventStreamOptions {
   projectName: string;
   onSnapshot?: (payload: ProjectEventSnapshotPayload, event: MessageEvent) => void;
   onChanges?: (payload: ProjectChangeBatchPayload, event: MessageEvent) => void;
+  /** 项目目录被删除后收到一次，随后流正常结束（浏览器会紧接着触发一次 onError）。 */
+  onProjectDeleted?: (payload: ProjectDeletedPayload, event: MessageEvent) => void;
   onError?: (event: Event) => void;
 }
 
@@ -1485,6 +1488,7 @@ class API {
 
     source.addEventListener("snapshot", createHandler(options.onSnapshot));
     source.addEventListener("changes", createHandler(options.onChanges));
+    source.addEventListener("project_deleted", createHandler(options.onProjectDeleted));
 
     source.onerror = (event: Event) => {
       if (typeof options.onError === "function") {

--- a/frontend/src/hooks/useProjectEventsSSE.test.tsx
+++ b/frontend/src/hooks/useProjectEventsSSE.test.tsx
@@ -522,4 +522,42 @@ describe("useProjectEventsSSE", () => {
 
     expect(openSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("clears an already-pending reconnect timer when the project_deleted event arrives", async () => {
+    let capturedOptions: ProjectEventStreamOptions | undefined;
+    const closeMock = vi.fn();
+    const openSpy = vi.spyOn(API, "openProjectEventStream").mockImplementation((options) => {
+      capturedOptions = options;
+      return { close: closeMock } as unknown as EventSource;
+    });
+
+    renderHarness("/");
+    expect(openSpy).toHaveBeenCalledTimes(1);
+
+    vi.useFakeTimers();
+    try {
+      // 先触发一次普通 onError，排入 3s 后的重连定时器。
+      act(() => {
+        capturedOptions?.onError?.(new Event("error"));
+      });
+
+      // 定时器排队期间收到终止事件：onProjectDeleted 应清掉这个待触发的重连定时器，
+      // 而不仅是处理之后新触发的 onError（见上一条用例）。
+      act(() => {
+        capturedOptions?.onProjectDeleted?.(
+          { project_name: "demo" },
+          new MessageEvent("project_deleted"),
+        );
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    // 若定时器未被清除，会在 3s 时触发 connect() 导致 openSpy 被再次调用。
+    expect(openSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/hooks/useProjectEventsSSE.test.tsx
+++ b/frontend/src/hooks/useProjectEventsSSE.test.tsx
@@ -486,4 +486,40 @@ describe("useProjectEventsSSE", () => {
     // fingerprints 应立即（同步）写入 store，无需等待 getProject
     expect(useProjectsStore.getState().getAssetFingerprint("storyboards/scene_E1S01.png")).toBe(1710288000);
   });
+
+  it("stops the reconnect loop after the project_deleted termination event", async () => {
+    let capturedOptions: ProjectEventStreamOptions | undefined;
+    const closeMock = vi.fn();
+    const openSpy = vi.spyOn(API, "openProjectEventStream").mockImplementation((options) => {
+      capturedOptions = options;
+      return { close: closeMock } as unknown as EventSource;
+    });
+
+    renderHarness("/");
+    expect(openSpy).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      capturedOptions?.onProjectDeleted?.(
+        { project_name: "demo" },
+        new MessageEvent("project_deleted"),
+      );
+    });
+    expect(closeMock).toHaveBeenCalledTimes(1);
+
+    vi.useFakeTimers();
+    try {
+      // 浏览器原生行为：流被服务端关闭后，EventSource 紧接着会触发一次 onerror；
+      // terminatedRef 应拦住它排的重连，即便等过了原本的 3s 重连延迟。
+      act(() => {
+        capturedOptions?.onError?.(new Event("error"));
+      });
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/hooks/useProjectEventsSSE.ts
+++ b/frontend/src/hooks/useProjectEventsSSE.ts
@@ -144,6 +144,8 @@ export function useProjectEventsSSE(projectName?: string | null): void {
   const refreshingRef = useRef(false);
   const needsRefreshRef = useRef(false);
   const queuedFocusRef = useRef<WorkspaceNotificationTarget | null>(null);
+  // 项目已被删除（收到终止事件）：停止断线重连循环，不再对已删项目周期性发起请求。
+  const terminatedRef = useRef(false);
 
   const executeFocus = useCallback(
     (target: WorkspaceNotificationTarget) => {
@@ -208,6 +210,7 @@ export function useProjectEventsSSE(projectName?: string | null): void {
     queuedFocusRef.current = null;
     needsRefreshRef.current = false;
     refreshingRef.current = false;
+    terminatedRef.current = false;
     clearScrollTarget();
     clearWorkspaceNotifications();
     return () => {
@@ -324,8 +327,23 @@ export function useProjectEventsSSE(projectName?: string | null): void {
             useAppStore.getState().invalidateGrids();
           }
         },
+        onProjectDeleted() {
+          if (disposed) return;
+          // 项目目录已被删除：后端已正常关流，停止重连循环——不对已删项目周期性发起请求。
+          // 浏览器随后会因连接结束触发一次 onError；terminatedRef 拦住它排的重连。
+          terminatedRef.current = true;
+          if (reconnectTimerRef.current) {
+            clearTimeout(reconnectTimerRef.current);
+            reconnectTimerRef.current = null;
+          }
+          if (sourceRef.current) {
+            sourceRef.current.close();
+            sourceRef.current = null;
+          }
+        },
         onError() {
           if (disposed) return;
+          if (terminatedRef.current) return;
           if (sourceRef.current) {
             sourceRef.current.close();
             sourceRef.current = null;

--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -57,6 +57,11 @@ export interface ProjectEventSnapshotPayload {
   generated_at: string;
 }
 
+/** 项目事件流终止事件负载——项目目录被删除后下发，随后流正常结束。 */
+export interface ProjectDeletedPayload {
+  project_name: string;
+}
+
 export interface WorkspaceFocusTarget {
   request_id: string;
   type: "character" | "scene" | "prop" | "segment" | "grid" | "reference_unit";

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
         "src/stores/**/*.ts",
         "src/hooks/useTasksSSE.ts",
         "src/hooks/useScrollTarget.ts",
+        "src/hooks/useProjectEventsSSE.ts",
         "src/router.tsx",
         "src/components/pages/ProjectsPage.tsx",
         "src/components/canvas/StudioCanvasRouter.tsx",

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -260,15 +260,15 @@ class ProjectManager:
 
         return project_dir
 
-    def delete_project_directory(self, name: str) -> None:
-        """删除项目目录，容忍并发扫描与本次删除竞态产生的 ``ENOTEMPTY``。
+    # 并发读者（如 ProjectEventService 的轮询扫描）触发的 _project_lock 可能在
+    # rmtree 清空目录内容之后、移除目录本身之前重新 touch 出锁文件：POSIX 上表现为
+    # rmdir 因目录非空失败（ENOTEMPTY），Windows 上锁文件仍被对端进程持有的文件锁
+    # 占用，表现为访问被拒（PermissionError / EACCES）。两者都是同一竞态的平台
+    # 特定症状，重试让锁文件在下一轮清理中一并删除。
+    _DELETE_RETRYABLE_ERRNOS = (errno.ENOTEMPTY, errno.EACCES)
 
-        ``shutil.rmtree`` 非原子：并发读者（如 ``ProjectEventService`` 的轮询扫描）
-        调用 ``load_project``/``save_project`` 触发的 :meth:`_project_lock` 会
-        ``touch`` 隐藏锁文件；若恰好发生在 rmtree 清空目录内容之后、``rmdir`` 之前，
-        会在目录内重新创建该锁文件，导致 ``rmdir`` 因目录非空失败。重试让锁文件在
-        下一轮清理中一并删除。
-        """
+    def delete_project_directory(self, name: str) -> None:
+        """删除项目目录，容忍并发扫描与本次删除竞态产生的临时性错误。"""
         project_dir = self.get_project_path(name)
         attempts = 5
         for attempt in range(attempts):
@@ -276,7 +276,7 @@ class ProjectManager:
                 shutil.rmtree(project_dir)
                 return
             except OSError as exc:
-                if exc.errno != errno.ENOTEMPTY or attempt == attempts - 1:
+                if exc.errno not in self._DELETE_RETRYABLE_ERRNOS or attempt == attempts - 1:
                     raise
 
     def sync_agent_profile(

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -276,6 +276,10 @@ class ProjectManager:
             try:
                 shutil.rmtree(project_dir)
                 return
+            except FileNotFoundError:
+                # 目录已不存在——上一次重试已经成功,或并发的另一次删除已经完成,
+                # 删除目的已达成,无需继续重试或报错。
+                return
             except OSError as exc:
                 if exc.errno not in self._DELETE_RETRYABLE_ERRNOS or attempt == attempts - 1:
                     raise

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -12,6 +12,7 @@ import os
 import re
 import secrets
 import shutil
+import time
 import unicodedata
 from collections.abc import Callable, Mapping
 from contextlib import contextmanager
@@ -278,6 +279,7 @@ class ProjectManager:
             except OSError as exc:
                 if exc.errno not in self._DELETE_RETRYABLE_ERRNOS or attempt == attempts - 1:
                     raise
+                time.sleep(0.05)
 
     def sync_agent_profile(
         self,

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -5,6 +5,7 @@
 """
 
 import copy
+import errno
 import json
 import logging
 import os
@@ -258,6 +259,25 @@ class ProjectManager:
             raise
 
         return project_dir
+
+    def delete_project_directory(self, name: str) -> None:
+        """删除项目目录，容忍并发扫描与本次删除竞态产生的 ``ENOTEMPTY``。
+
+        ``shutil.rmtree`` 非原子：并发读者（如 ``ProjectEventService`` 的轮询扫描）
+        调用 ``load_project``/``save_project`` 触发的 :meth:`_project_lock` 会
+        ``touch`` 隐藏锁文件；若恰好发生在 rmtree 清空目录内容之后、``rmdir`` 之前，
+        会在目录内重新创建该锁文件，导致 ``rmdir`` 因目录非空失败。重试让锁文件在
+        下一轮清理中一并删除。
+        """
+        project_dir = self.get_project_path(name)
+        attempts = 5
+        for attempt in range(attempts):
+            try:
+                shutil.rmtree(project_dir)
+                return
+            except OSError as exc:
+                if exc.errno != errno.ENOTEMPTY or attempt == attempts - 1:
+                    raise
 
     def sync_agent_profile(
         self,

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -818,8 +818,7 @@ async def delete_project(name: str, _user: CurrentUser, _t: Translator):
     try:
 
         def _sync():
-            project_dir = get_project_manager().get_project_path(name)
-            shutil.rmtree(project_dir)
+            get_project_manager().delete_project_directory(name)
             return {"success": True, "message": _t("project_deleted", name=name)}
 
         return await asyncio.to_thread(_sync)

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -340,10 +340,9 @@ class ProjectEventService:
         try:
             snapshot, fingerprint = await asyncio.to_thread(self._rebuild_snapshot, project_name)
         except FileNotFoundError:
-            if await asyncio.to_thread(self._project_directory_gone, project_name):
-                self._handle_project_deleted(project_name, channel)
-                return
-            logger.exception("构建显式项目事件快照失败 project=%s", project_name)
+            await self._handle_scan_file_not_found(
+                project_name, channel, log_message="构建显式项目事件快照失败 project=%s"
+            )
             return
         except Exception:
             logger.exception("构建显式项目事件快照失败 project=%s", project_name)
@@ -402,6 +401,21 @@ class ProjectEventService:
         if task is not None and task is not asyncio.current_task():
             task.cancel()
 
+    async def _handle_scan_file_not_found(
+        self, project_name: str, channel: _ProjectChannel, *, log_message: str
+    ) -> bool:
+        """扫描 / hint 重建路径捕获 ``FileNotFoundError`` 后的统一处理：复核目录是否确已
+        消失，是则终止通道并返回 ``True``；否则维持现状按 ERROR 兜底并返回 ``False``。
+
+        供 :meth:`_async_rebuild_and_broadcast` 与 :meth:`_watch_project` 两条独立路径
+        共用，避免各自维护一份相同判定逻辑、日后修改判定条件时漏改其中一处。
+        """
+        if await asyncio.to_thread(self._project_directory_gone, project_name):
+            self._handle_project_deleted(project_name, channel)
+            return True
+        logger.exception(log_message, project_name)
+        return False
+
     async def _watch_project(self, project_name: str, channel: _ProjectChannel) -> None:
         try:
             while channel.sse.has_subscribers:
@@ -413,10 +427,10 @@ class ProjectEventService:
                 except asyncio.CancelledError:
                     raise
                 except FileNotFoundError:
-                    if await asyncio.to_thread(self._project_directory_gone, project_name):
-                        self._handle_project_deleted(project_name, channel)
+                    if await self._handle_scan_file_not_found(
+                        project_name, channel, log_message="项目事件扫描失败 project=%s"
+                    ):
                         return
-                    logger.exception("项目事件扫描失败 project=%s", project_name)
                 except Exception:
                     logger.exception("项目事件扫描失败 project=%s", project_name)
                 finally:

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -32,6 +32,10 @@ logger = logging.getLogger(__name__)
 
 PROJECT_EVENTS_POLL_SECONDS = 0.5
 
+# 项目目录被删除后向订阅者广播的终止事件名——流在其后正常结束（见 stream_events._iter）。
+PROJECT_DELETED_EVENT = "project_deleted"
+
+
 # 条目名词按骨架种类硬编码——用于分镜级事件标签（如「镜头「E1S01」」）。名词 i18n 化是
 # 独立议题（与 ``_diff_named_entities`` 的「角色」/「线索」同为既有硬编码形态），不在此处收敛。
 _SKELETON_ITEM_NOUNS: dict[str, str] = {
@@ -246,6 +250,9 @@ class ProjectEventService:
             yield ("snapshot", snapshot)
             async for item in sse.iterate(queue, idle_timeout=idle_timeout):
                 yield {"type": "_idle"} if item is IDLE else item
+                # 项目已被删除：终止事件之后流正常结束，不再等待下一条广播或空闲心跳。
+                if isinstance(item, tuple) and item[0] == PROJECT_DELETED_EVENT:
+                    return
 
         try:
             yield _iter()
@@ -332,6 +339,12 @@ class ProjectEventService:
         """文件 I/O 在线程中执行，状态更新和广播在事件循环线程中执行。"""
         try:
             snapshot, fingerprint = await asyncio.to_thread(self._rebuild_snapshot, project_name)
+        except FileNotFoundError:
+            if await asyncio.to_thread(self._project_directory_gone, project_name):
+                self._handle_project_deleted(project_name, channel)
+                return
+            logger.exception("构建显式项目事件快照失败 project=%s", project_name)
+            return
         except Exception:
             logger.exception("构建显式项目事件快照失败 project=%s", project_name)
             return
@@ -357,6 +370,38 @@ class ProjectEventService:
         snapshot = self._build_snapshot(project_name)
         return snapshot, _fingerprint(snapshot)
 
+    def _project_directory_gone(self, project_name: str) -> bool:
+        """判定项目目录当前是否确已不存在（``get_project_path`` 语义）。
+
+        供扫描 / hint 重建路径捕获 ``FileNotFoundError`` 后做一次独立的现状复核，
+        与「project.json 等深层文件缺失但目录仍在」区分——后者维持现状，按通用
+        异常兜底记 ERROR，不触发终止流程。用复核而非扫描起点的一次性判断，是因为
+        目录删除（如 ``shutil.rmtree``）本身非原子：扫描可能在删除过程中的任意
+        中间状态命中 ``FileNotFoundError``（如 project.json 先于目录本身被移除），
+        起点检查会误判为「未删除」；复核反映的是异常发生后的当前实况。
+        """
+        try:
+            self.pm.get_project_path(project_name)
+        except FileNotFoundError:
+            return True
+        return False
+
+    def _handle_project_deleted(self, project_name: str, channel: _ProjectChannel) -> None:
+        """项目目录已被删除：终止该通道——广播终止事件、移出注册表、取消 watch task。
+
+        轮询扫描与 hint 重建两条路径都可能独立探测到同一次删除并落到本方法；
+        按「本通道是否仍是注册表现行通道」判定是否为首次终止，避免重复广播/
+        重复日志，也避免误杀同名项目重建后已注册的新通道。
+        """
+        if self._channels.get(project_name) is not channel:
+            return
+        self._channels.pop(project_name, None)
+        channel.sse.broadcast((PROJECT_DELETED_EVENT, {"project_name": project_name}))
+        logger.info("项目已被删除，终止事件流 project=%s", project_name)
+        task = channel.task
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+
     async def _watch_project(self, project_name: str, channel: _ProjectChannel) -> None:
         try:
             while channel.sse.has_subscribers:
@@ -367,6 +412,11 @@ class ProjectEventService:
                     self._apply_scan_result(project_name, channel, snapshot, fingerprint)
                 except asyncio.CancelledError:
                     raise
+                except FileNotFoundError:
+                    if await asyncio.to_thread(self._project_directory_gone, project_name):
+                        self._handle_project_deleted(project_name, channel)
+                        return
+                    logger.exception("项目事件扫描失败 project=%s", project_name)
                 except Exception:
                     logger.exception("项目事件扫描失败 project=%s", project_name)
                 finally:

--- a/tests/test_project_events_router.py
+++ b/tests/test_project_events_router.py
@@ -148,3 +148,43 @@ async def test_stream_project_events_breaks_on_disconnect_during_continuous_even
     with pytest.raises(StopAsyncIteration):
         await anext(stream)
     assert service.unsubscribed is True
+
+
+@pytest.mark.asyncio
+async def test_stream_project_events_ends_naturally_after_project_deleted_event():
+    """终止事件（project_deleted）之后流自然结束——非因客户端断线，路由层原样透传该事件。
+
+    ``_FakeRequest`` 永不断线（``disconnect_after=None``），流的结束只能来自
+    service 侧 ``_iter()`` 在终止事件后主动 return，验证路由层对该事件不作特殊拦截。
+    """
+
+    class _DeletedService:
+        def __init__(self):
+            self.unsubscribed = False
+            self.pm = _FakePM()
+
+        @contextlib.asynccontextmanager
+        async def stream_events(self, project_name: str, *, idle_timeout: float = 1.0):
+            async def _iter():
+                yield ("snapshot", {"project_name": project_name, "fingerprint": "fp-0"})
+                yield ("project_deleted", {"project_name": project_name})
+
+            try:
+                yield _iter()
+            finally:
+                self.unsubscribed = True
+
+    service = _DeletedService()
+    app = SimpleNamespace(state=SimpleNamespace(project_event_service=service))
+    request = _FakeRequest(app)
+
+    stream = project_events_router.stream_project_events("demo", request, _user={"sub": "testuser"}, service=service)
+
+    assert (await anext(stream)).event == "snapshot"
+    deleted_event = await anext(stream)
+    assert deleted_event.event == "project_deleted"
+    assert deleted_event.data == {"project_name": "demo"}
+
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+    assert service.unsubscribed is True

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import shutil
 
 import pytest
 
@@ -957,7 +956,7 @@ class TestProjectEventService:
                 first = await anext(stream)
                 assert first[0] == "snapshot"
 
-                shutil.rmtree(pm.get_project_path("demo"))
+                pm.delete_project_directory("demo")
 
                 event_name, payload = await _next_event(stream, timeout=1.5)
                 assert event_name == PROJECT_DELETED_EVENT
@@ -1015,7 +1014,7 @@ class TestProjectEventService:
                 first = await anext(stream)
                 assert first[0] == "snapshot"
 
-                shutil.rmtree(pm.get_project_path("demo"))
+                pm.delete_project_directory("demo")
 
                 emit_project_change_batch(
                     "demo",
@@ -1055,7 +1054,7 @@ class TestProjectEventService:
             first = await anext(stream)
             assert first[0] == "snapshot"
 
-            shutil.rmtree(pm.get_project_path("demo"))
+            pm.delete_project_directory("demo")
 
             event_name, _payload = await _next_event(stream, timeout=1.5)
             assert event_name == PROJECT_DELETED_EVENT

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -1,5 +1,7 @@
 import asyncio
 import json
+import logging
+import shutil
 
 import pytest
 
@@ -10,6 +12,7 @@ from server.services.project_events import (
     _SKELETON_ANCHOR_TYPES,
     _SKELETON_ENTITY_TYPES,
     _SKELETON_ITEM_NOUNS,
+    PROJECT_DELETED_EVENT,
     ProjectEventService,
 )
 
@@ -937,3 +940,103 @@ class TestProjectEventService:
         assert any(
             c["entity_type"] == "shot" and c["action"] == "video_ready" and c["entity_id"] == "E1S01" for c in changes
         )
+
+    @pytest.mark.asyncio
+    async def test_watch_terminates_stream_when_project_directory_deleted(self, tmp_path, caplog):
+        """订阅存续期间删除项目目录：一个轮询周期内扫描终止——广播终止事件、
+        流正常结束、通道从注册表移除，仅记一条 INFO 日志，无 ERROR/traceback。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        service = ProjectEventService(tmp_path, poll_interval=0.05)
+        await service.start()
+
+        with caplog.at_level(logging.INFO, logger="server.services.project_events"):
+            async with service.stream_events("demo", idle_timeout=0.1) as stream:
+                first = await anext(stream)
+                assert first[0] == "snapshot"
+
+                shutil.rmtree(pm.get_project_path("demo"))
+
+                event_name, payload = await _next_event(stream, timeout=1.5)
+                assert event_name == PROJECT_DELETED_EVENT
+                assert payload == {"project_name": "demo"}
+
+                # 终止事件之后流正常结束（不是因为消费方主动断线）。
+                with pytest.raises(StopAsyncIteration):
+                    await anext(stream)
+
+        assert "demo" not in service._channels
+        assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+        info_records = [
+            record for record in caplog.records if record.levelno == logging.INFO and "已被删除" in record.message
+        ]
+        assert len(info_records) == 1
+
+        await service.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_watch_keeps_error_logging_when_only_project_json_missing(self, tmp_path, caplog):
+        """项目目录仍存在、仅 project.json 缺失——不属于本次修复范围：维持现状，
+        按通用异常兜底记 ERROR，通道不终止、继续轮询重试。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        service = ProjectEventService(tmp_path, poll_interval=0.05)
+        await service.start()
+
+        with caplog.at_level(logging.INFO, logger="server.services.project_events"):
+            async with service.stream_events("demo", idle_timeout=0.1):
+                (pm.get_project_path("demo") / ProjectManager.PROJECT_FILE).unlink()
+                # 等至少一个轮询周期，让扫描命中缺失的 project.json。
+                await asyncio.sleep(0.3)
+                assert "demo" in service._channels  # 通道未终止，仍在注册表中
+
+        assert any(record.levelno >= logging.ERROR for record in caplog.records)
+        assert not any("已被删除" in record.message for record in caplog.records)
+
+        await service.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_hint_rebuild_terminates_channel_without_error_when_project_deleted(self, tmp_path, caplog):
+        """hint 触发的显式重建路径对已删除项目同样走终止处理，不产生 ERROR 日志。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        # 轮询间隔调大，确保观察到的是 hint 路径而非后台轮询先行探测到删除。
+        service = ProjectEventService(tmp_path, poll_interval=5.0)
+        await service.start()
+
+        with caplog.at_level(logging.INFO, logger="server.services.project_events"):
+            async with service.stream_events("demo", idle_timeout=0.1) as stream:
+                first = await anext(stream)
+                assert first[0] == "snapshot"
+
+                shutil.rmtree(pm.get_project_path("demo"))
+
+                emit_project_change_batch(
+                    "demo",
+                    [
+                        {
+                            "entity_type": "segment",
+                            "action": "updated",
+                            "entity_id": "E1S01",
+                            "label": "分镜「E1S01」",
+                            "focus": None,
+                            "important": False,
+                        }
+                    ],
+                    source="worker",
+                )
+
+                event_name, payload = await _next_event(stream, timeout=1.5)
+                assert event_name == PROJECT_DELETED_EVENT
+                assert payload == {"project_name": "demo"}
+
+        assert "demo" not in service._channels
+        assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+
+        await service.shutdown()

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -1040,3 +1040,35 @@ class TestProjectEventService:
         assert not any(record.levelno >= logging.ERROR for record in caplog.records)
 
         await service.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_new_subscriber_after_project_recreated_gets_fresh_channel(self, tmp_path):
+        """项目删除后原通道终止；同名项目重建后新订阅走全新通道，行为与现在一致。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        service = ProjectEventService(tmp_path, poll_interval=0.05)
+        await service.start()
+
+        async with service.stream_events("demo", idle_timeout=0.1) as stream:
+            first = await anext(stream)
+            assert first[0] == "snapshot"
+
+            shutil.rmtree(pm.get_project_path("demo"))
+
+            event_name, _payload = await _next_event(stream, timeout=1.5)
+            assert event_name == PROJECT_DELETED_EVENT
+
+        assert "demo" not in service._channels
+
+        # 同名项目重建：新订阅应走全新通道，正常收到 snapshot 与后续变更（不复用将死通道）。
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo Reborn", "Anime", "narration")
+
+        async with service.stream_events("demo", idle_timeout=0.1) as stream:
+            first = await anext(stream)
+            assert first[0] == "snapshot"
+            assert "demo" in service._channels
+
+        await service.shutdown()

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1,4 +1,5 @@
 import re
+import shutil
 from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
@@ -69,6 +70,9 @@ class _FakePM:
         if not path.exists():
             raise FileNotFoundError(name)
         return path
+
+    def delete_project_directory(self, name):
+        shutil.rmtree(self.get_project_path(name))
 
     def get_project_status(self, name):
         return {"current_stage": "source_ready"}


### PR DESCRIPTION
## Summary

- 项目被删除后 `ProjectEventService` 后台轮询扫描与 hint 重建路径继续对不存在的项目重建快照，`FileNotFoundError` 被通用异常兜底后以 ERROR 级记录完整 traceback，订阅不终止、扫描不停止，直至订阅端主动断开
- 现改为：捕获 `FileNotFoundError` 后独立复核项目目录是否确已不存在（区分「目录已删除」与「project.json 等深层文件缺失但目录仍在」，后者维持现状按 ERROR 兜底），确已不存在则向该项目通道所有订阅者广播 `project_deleted` 终止事件、结束 watch task、从通道注册表移除，仅记一条 INFO 日志
- hint 触发的显式重建路径同样接入该判定，不产生 ERROR 噪音
- 前端 `useProjectEventsSSE` 收到终止事件后停止断线重连循环（并拦截浏览器原生紧随其后的伴生 `onerror`），不再对已删项目周期性发起请求
- 同名项目重建后，新订阅走全新通道，行为与现在一致；项目存在时的既有流行为不变

Closes #1031

## 验证说明

- `uv run python -m pytest`：5718 passed（含新增回归测试：轮询路径终止、hint 路径终止、project.json 缺失但目录仍在时维持 ERROR 兜底、同名项目重建后新订阅走全新通道）
- `pnpm check`：typecheck + eslint + vitest 全绿（含新增测试：终止事件后拦截伴生 onerror、停止重连）
- `uv run ruff check/format`：通过
- `uv run basedpyright`：0 error（CI 口径）
- 本地审查追加：/code-review high --fix 复审发现一处清理类问题（两处调用点重复维护同一份 `FileNotFoundError` 判定逻辑），已提取共享 helper `_handle_scan_file_not_found` 消除重复，复跑测试确认行为不变
- 已 rebase 到最新 main

## Test plan

- [x] 后端全量测试通过（`uv run python -m pytest`）
- [x] 前端全量测试通过（`pnpm check`）
- [x] ruff / basedpyright 质量门通过
- [x] /code-review high --fix 复审并修复

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“项目目录被删除”事件（SSE）：前端可接收负载并立即停止后续处理；服务端在确认删除后终止事件流。
* **Bug 修复**
  * 终止后不再触发重连；切换项目/重连后恢复默认重连行为。
  * 删除检测更精准：仅在确认为目录被删且通道仍有效时广播终止事件，并对缺失文件做一致处理。
* **测试**
  * 补齐前后端终止、重连定时器清理、流自然结束、旧通道不复用等用例，并将相关 Hook 纳入覆盖率统计。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->