### PR TITLE
fix(text-gen): 分集规划超长输出改为清晰报错，patch_project 接受数字型 settings

### DIFF
--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -32,7 +32,12 @@ from lib.episode_ledger import (
 )
 from lib.episode_paths import episode_script_relpath
 from lib.project_manager import ProjectManager, resolve_source_kind
-from lib.text_backends.base import TextGenerationRequest, TextTaskType
+from lib.text_backends.base import (
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    TextGenerationRequest,
+    TextOutputTruncatedError,
+    TextTaskType,
+)
 from lib.text_generator import TextGenerator
 from lib.text_metrics import count_reading_units, reading_unit_noun
 from lib.text_utils import strip_json_code_fences
@@ -42,8 +47,6 @@ logger = logging.getLogger(__name__)
 # 窗口/批量内部默认值；project.json 顶层同名字段可覆盖
 DEFAULT_PLANNING_WINDOW_CHARS = 30000
 DEFAULT_PLANNING_MAX_EPISODES = 20
-
-PLANNING_MAX_OUTPUT_TOKENS = 16000
 
 # LLM 输出未通过 schema / 机械校验时的总尝试次数（含首次）
 _MAX_PLAN_ATTEMPTS = 3
@@ -726,19 +729,30 @@ class EpisodePlanner:
         snap_whitespace_tail: bool = False,
         max_episodes: int | None,
     ) -> tuple[list[NarrationEpisodeDraft], list[int], BaseModel]:
-        """LLM 调用 + schema/机械校验循环；重试 prompt 附上一轮失败原因。"""
+        """LLM 调用 + schema/机械校验循环；重试 prompt 附上一轮失败原因。
+
+        结构化输出被输出上限截断时 :class:`TextOutputTruncatedError` 直接短路本循环——
+        重发同一份必然再截断的请求没有意义；追加本规划器特有的杠杆提示（调小窗口字数 /
+        每批集数）后转为 :class:`EpisodePlanningError` 冒泡（见 docs/adr/0044）。
+        """
         if self.generator is None:
             raise RuntimeError("TextGenerator 未初始化，请使用 EpisodePlanner.create() 工厂方法")
         failure: list[str] | None = None
         for attempt in range(1, self.max_attempts + 1):
-            result = await self.generator.generate(
-                TextGenerationRequest(
-                    prompt=prompt_builder(failure),
-                    response_schema=draft_model,
-                    max_output_tokens=PLANNING_MAX_OUTPUT_TOKENS,
-                ),
-                project_name=self.project_name,
-            )
+            try:
+                result = await self.generator.generate(
+                    TextGenerationRequest(
+                        prompt=prompt_builder(failure),
+                        response_schema=draft_model,
+                        max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
+                    ),
+                    project_name=self.project_name,
+                )
+            except TextOutputTruncatedError as exc:
+                raise EpisodePlanningError(
+                    f"{exc}也可调小项目设置 planning_window_chars（单批窗口字数）或 "
+                    "planning_max_episodes（单批集数上限）以缩小本批输出体量后重试。"
+                ) from exc
             try:
                 draft = self._parse_draft(result.text, draft_model)
                 drafts = list(getattr(draft, "episodes"))

--- a/lib/retry.py
+++ b/lib/retry.py
@@ -3,6 +3,7 @@
 不依赖任何特定供应商 SDK，可被所有后端复用。
 各供应商可通过 retryable_errors 参数注入自己的可重试异常类型，
 或通过 retry_if 谓词实现精细化的条件重试。
+继承 NonRetryableError 的异常类型始终不重试，不受消息文本模式匹配影响。
 """
 
 from __future__ import annotations
@@ -20,6 +21,17 @@ BASE_RETRYABLE_ERRORS: tuple[type[Exception], ...] = (
     ConnectionError,
     TimeoutError,
 )
+
+
+class NonRetryableError(RuntimeError):
+    """标记基类：命中此类型的异常始终不重试。
+
+    _should_retry 的字符串模式匹配（RETRYABLE_STATUS_PATTERNS）按子串比对，若异常消息
+    恰好携带一个数值型细节（如 token 数、行号）而其十进制文本包含 "429"/"500" 等子串，
+    会被误判为瞬态错误进而重试——重发同一份必然复现同一错误的请求没有意义。需要绝对不
+    可重试语义的异常类型应继承本类，在模式匹配之前短路。
+    """
+
 
 # 字符串模式匹配：覆盖异常类型不在列表中但属于瞬态的情况（大小写不敏感）
 RETRYABLE_STATUS_PATTERNS = (
@@ -50,6 +62,8 @@ DOWNLOAD_BACKOFF_SECONDS: tuple[int, ...] = (5, 10, 20, 40)
 
 def _should_retry(exc: Exception, retryable_errors: tuple[type[Exception], ...]) -> bool:
     """判断异常是否应当重试。"""
+    if isinstance(exc, NonRetryableError):
+        return False
     if isinstance(exc, retryable_errors):
         return True
     error_lower = str(exc).lower()

--- a/lib/retry.py
+++ b/lib/retry.py
@@ -92,7 +92,7 @@ def with_retry_async(
                     return await func(*args, **kwargs)
                 except Exception as e:
                     is_last = attempt >= max_attempts - 1
-                    if is_last or not predicate(e):
+                    if is_last or isinstance(e, NonRetryableError) or not predicate(e):
                         raise
                     wait_time = _compute_wait(attempt, backoff_seconds)
                     logger.warning("API 调用异常: %s - %s", type(e).__name__, str(e)[:200])

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -49,15 +49,11 @@ from lib.script_models import (
     merge_drama_visual_into_scenes,
 )
 from lib.script_skeleton import SKELETONS, resolve_declared_kind
-from lib.text_backends.base import TextGenerationRequest, TextTaskType
+from lib.text_backends.base import DEFAULT_MAX_OUTPUT_TOKENS, TextGenerationRequest, TextTaskType
 from lib.text_generator import TextGenerator
 from lib.text_utils import strip_json_code_fences
 
 logger = logging.getLogger(__name__)
-
-# 大型 JSON 剧本输出上限：22+ 场景典型约 14K token，留 2× 安全边际。
-# 注意：受各模型硬上限约束（如 doubao-seed-1-8 ~8192），需选择支持 ≥16K 输出的模型。
-SCRIPT_MAX_OUTPUT_TOKENS = 32000
 
 # 集号前缀正则：仅匹配 `E{数字}` + 紧随 S/U（segment/scene 用 S，video_unit 用 U），
 # 保留后缀（如 `E1S03_2` → `E2S03_2`）。设计契约见 lib/script_models.py。
@@ -298,7 +294,7 @@ class ScriptGenerator:
             TextGenerationRequest(
                 prompt=self._build_drama_step2_prompt(content_scenes, episode),
                 response_schema=DramaVisualScript,
-                max_output_tokens=SCRIPT_MAX_OUTPUT_TOKENS,
+                max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
             ),
             project_name=self.project_path.name,
         )
@@ -370,7 +366,7 @@ class ScriptGenerator:
             TextGenerationRequest(
                 prompt=prompt,
                 response_schema=schema,
-                max_output_tokens=SCRIPT_MAX_OUTPUT_TOKENS,
+                max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
             ),
             project_name=project_name,
         )

--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -83,21 +83,21 @@ class ArkTextBackend:
         return await self._generate_plain(request)
 
     @with_retry_async()
-    async def _call_chat_completions(self, kwargs: dict) -> TextGenerationResult:
-        """单次 chat.completions 调用：日志、发请求、解析与截断告警，瞬态错误重试。"""
+    async def _call_chat_completions(self, kwargs: dict, *, structured: bool) -> TextGenerationResult:
+        """单次 chat.completions 调用：日志、发请求、解析与截断处理，瞬态错误重试。"""
         logger.info("调用 %s 文本 SDK kwargs=%s", self.name, format_kwargs_for_log(kwargs))
         response = await asyncio.to_thread(
             self._client.chat.completions.create,
             **kwargs,
         )
-        return self._parse_chat_response(response)
+        return self._parse_chat_response(response, structured=structured)
 
     async def _generate_plain(self, request: TextGenerationRequest) -> TextGenerationResult:
         messages = self._build_messages(request)
         kwargs: dict = {"model": self._model, "messages": messages}
         if request.max_output_tokens is not None:
             kwargs["max_tokens"] = request.max_output_tokens
-        return await self._call_chat_completions(kwargs)
+        return await self._call_chat_completions(kwargs, structured=False)
 
     async def _generate_structured(self, request: TextGenerationRequest) -> TextGenerationResult:
         messages = self._build_messages(request)
@@ -118,8 +118,14 @@ class ArkTextBackend:
             }
             if request.max_output_tokens is not None:
                 kwargs["max_tokens"] = request.max_output_tokens
+            from lib.text_backends.base import TextOutputTruncatedError
+
             try:
-                native = await self._call_chat_completions(kwargs)
+                native = await self._call_chat_completions(kwargs, structured=True)
+            except TextOutputTruncatedError:
+                # 截断是可操作硬错误，不是"原生通道不兼容"——降级到 Instructor 重发同一份
+                # 必然再截断的请求毫无意义，直接冒泡让调用方感知并换模型/调小规模。
+                raise
             except Exception as exc:
                 logger.warning("原生 response_format 调用或解析失败 (%s)，降级到 Instructor/json_object 路径", exc)
                 return await self._structured_fallback(request, messages)
@@ -187,18 +193,19 @@ class ArkTextBackend:
 
         return messages
 
-    def _parse_chat_response(self, response) -> TextGenerationResult:
-        from lib.text_backends.base import warn_if_truncated
+    def _parse_chat_response(self, response, *, structured: bool) -> TextGenerationResult:
+        from lib.text_backends.base import check_truncation
 
         choice = response.choices[0]
         text = choice.message.content
         input_tokens = getattr(getattr(response, "usage", None), "prompt_tokens", None)
         output_tokens = getattr(getattr(response, "usage", None), "completion_tokens", None)
-        warn_if_truncated(
+        check_truncation(
             getattr(choice, "finish_reason", None),
             provider=PROVIDER_ARK,
             model=self._model,
             output_tokens=output_tokens,
+            structured=structured,
         )
         return TextGenerationResult(
             text=text.strip() if isinstance(text, str) else str(text),

--- a/lib/text_backends/base.py
+++ b/lib/text_backends/base.py
@@ -11,6 +11,8 @@ from typing import Any, Literal, Protocol
 
 from pydantic import BaseModel, ValidationError
 
+from lib.retry import NonRetryableError
+
 _logger = logging.getLogger(__name__)
 
 # Chat Completions 输出上限参数名：官方 OpenAI 端点已弃用 max_tokens（推理模型
@@ -48,11 +50,16 @@ def warn_if_truncated(
     return False
 
 
-class TextOutputTruncatedError(RuntimeError):
+class TextOutputTruncatedError(NonRetryableError):
     """结构化输出被模型输出上限截断，结果不完整、不可直接使用。
 
     仅在请求带 response_schema（结构化输出诉求）时抛出；自由文本截断维持
     ``warn_if_truncated`` 的 log-only 告警，不升级为本异常（见 docs/adr/0044）。
+
+    继承 NonRetryableError（而非直接 RuntimeError）：消息内嵌的 output_tokens 是任意
+    整数，其十进制文本可能偶然包含 with_retry_async 瞬态错误模式的子串（如 429/500/
+    502/503/504），若不显式标记为不可重试，会被误判为瞬态错误进而在各后端的
+    @with_retry_async() 包裹下重发同一份必然再截断的请求。
     """
 
     def __init__(self, *, provider: str, model: str, output_tokens: int | None = None):

--- a/lib/text_backends/base.py
+++ b/lib/text_backends/base.py
@@ -66,9 +66,9 @@ class TextOutputTruncatedError(NonRetryableError):
         self.provider = provider
         self.model = model
         self.output_tokens = output_tokens
+        detail = f"在 output_tokens={output_tokens} 处" if output_tokens is not None else ""
         super().__init__(
-            f"{provider}/{model} 的结构化输出在 output_tokens={output_tokens} 处被模型输出上限截断，"
-            "内容不完整。请改用输出能力更高的文本模型。"
+            f"{provider}/{model} 的结构化输出{detail}被模型输出上限截断，内容不完整。请改用输出能力更高的文本模型。"
         )
 
 

--- a/lib/text_backends/base.py
+++ b/lib/text_backends/base.py
@@ -29,7 +29,9 @@ def warn_if_truncated(
 ) -> bool:
     """检测模型响应是否因 token 上限被截断，若是则 logger.warning。
 
-    返回 True 表示被截断（供调用方用于进一步处理）。
+    返回 True 表示被截断（供调用方用于进一步处理）。自由文本（无 response_schema）
+    的截断处理到此为止，仅告警不抛错；结构化输出的截断须走 :func:`check_truncation`
+    升级为硬错误。
     """
     if finish_reason is None:
         return False
@@ -44,6 +46,60 @@ def warn_if_truncated(
         )
         return True
     return False
+
+
+class TextOutputTruncatedError(RuntimeError):
+    """结构化输出被模型输出上限截断，结果不完整、不可直接使用。
+
+    仅在请求带 response_schema（结构化输出诉求）时抛出；自由文本截断维持
+    ``warn_if_truncated`` 的 log-only 告警，不升级为本异常（见 docs/adr/0044）。
+    """
+
+    def __init__(self, *, provider: str, model: str, output_tokens: int | None = None):
+        self.provider = provider
+        self.model = model
+        self.output_tokens = output_tokens
+        super().__init__(
+            f"{provider}/{model} 的结构化输出在 output_tokens={output_tokens} 处被模型输出上限截断，"
+            "内容不完整。请改用输出能力更高的文本模型。"
+        )
+
+
+# 文本输出上限：非约束安全阀，仅防模型退化性 runaway，不是功能预算——分集规划、剧本生成、
+# drama step1 规范化三处的正常输出体量由各自 schema/内容天然约束，永远不会触碰这个高位值；
+# 只有病态超大批量，或用户配置了输出能力偏低的模型时才会命中。三处共用同一常量，调整只改
+# 这一处（见 docs/adr/0044）。
+DEFAULT_MAX_OUTPUT_TOKENS = 64000
+
+
+def check_truncation(
+    finish_reason: str | None,
+    *,
+    provider: str,
+    model: str,
+    structured: bool,
+    output_tokens: int | None = None,
+    truncation_values: tuple[str, ...] = ("length", "MAX_TOKENS", "max_tokens"),
+) -> None:
+    """检测输出截断：结构化输出（``structured=True``）截断是硬错误，自由文本仅告警。
+
+    ``structured`` 由调用方按本次 ``generate()`` 的原始请求是否带 response_schema 传入——
+    判断口径是"这次生成诉求"而非"这次具体 wire 调用是否真的带了 schema 参数"，故内部降级
+    路径即使为兜底策略（如把 schema 写进 prompt）临时清空了 response_schema，仍应把
+    ``structured=True`` 显式传下来。
+
+    截断即抛 :class:`TextOutputTruncatedError`，天然短路调用方的校验重试循环——重发同一份
+    必然再截断的请求没有意义（见 docs/adr/0044）。
+    """
+    truncated = warn_if_truncated(
+        finish_reason,
+        provider=provider,
+        model=model,
+        output_tokens=output_tokens,
+        truncation_values=truncation_values,
+    )
+    if truncated and structured:
+        raise TextOutputTruncatedError(provider=provider, model=model, output_tokens=output_tokens)
 
 
 class TextCapability(StrEnum):

--- a/lib/text_backends/gemini.py
+++ b/lib/text_backends/gemini.py
@@ -19,11 +19,11 @@ from .base import (
     TextCapability,
     TextGenerationRequest,
     TextGenerationResult,
+    check_truncation,
     is_valid_json,
     resolve_schema,
     structured_fallback_reason,
     summarize_validation_error,
-    warn_if_truncated,
 )
 
 logger = logging.getLogger(__name__)
@@ -199,7 +199,7 @@ class GeminiTextBackend:
         降级也包进重试范围，降级尝试的失败会连带重放已成功的原生调用（重试叠乘），且降级
         穷尽的 ValueError 消息含模型侧动态文本，可能误中重试判定的字符串模式。
         """
-        native = await self._generate_native(request)
+        native = await self._generate_native(request, structured=bool(request.response_schema))
 
         if request.response_schema:
             # 成功路径复验：HTTP 200 后校验返回是否真满足 schema。中转/代理可能静默忽略
@@ -221,8 +221,13 @@ class GeminiTextBackend:
         return native
 
     @with_retry_async()
-    async def _generate_native(self, request: TextGenerationRequest) -> TextGenerationResult:
-        """单次原生 SDK 调用：构造 config/contents、发请求、截断告警与瞬态错误重试。"""
+    async def _generate_native(self, request: TextGenerationRequest, *, structured: bool) -> TextGenerationResult:
+        """单次原生 SDK 调用：构造 config/contents、发请求、截断处理与瞬态错误重试。
+
+        ``structured`` 由调用方按本次 generate() 的原始请求诉求传入，与 ``request.response_schema``
+        本身解耦——:meth:`_prompt_json_fallback` 会把 ``response_schema`` 置空后仍复用本方法
+        （schema 已改写进 prompt），但那仍是一次结构化输出尝试，截断同样要硬错误而非仅告警。
+        """
         config = self._build_config(
             request.response_schema,
             request.system_prompt,
@@ -253,11 +258,12 @@ class GeminiTextBackend:
         if candidates:
             finish_reason = getattr(candidates[0], "finish_reason", None)
             # Gemini finish_reason 可能是枚举对象，转 str 后再比对
-            warn_if_truncated(
+            check_truncation(
                 str(finish_reason).rsplit(".", 1)[-1] if finish_reason is not None else None,
                 provider=PROVIDER_GEMINI,
                 model=self._model,
                 output_tokens=output_tokens,
+                structured=structured,
             )
 
         return TextGenerationResult(
@@ -292,9 +298,10 @@ class GeminiTextBackend:
         last_reason = ""
         for _attempt in range(_FALLBACK_MAX_ATTEMPTS):
             fb_request = replace(request, prompt=base_prompt + feedback, response_schema=None)
-            # 直调 _generate_native 复用日志、截断告警与瞬态错误重试；不经 generate 的
-            # 复验分支，每次降级尝试只产生自己这一层的重试，不与外层调用叠乘。
-            fb_result = await self._generate_native(fb_request)
+            # 直调 _generate_native 复用日志、截断处理与瞬态错误重试；不经 generate 的
+            # 复验分支，每次降级尝试只产生自己这一层的重试，不与外层调用叠乘。structured
+            # 固定 True：response_schema 虽已置空改走 prompt 注入，这仍是一次结构化输出尝试。
+            fb_result = await self._generate_native(fb_request, structured=True)
             if fb_result.input_tokens is not None or total_input is not None:
                 total_input = (total_input or 0) + (fb_result.input_tokens or 0)
             if fb_result.output_tokens is not None or total_output is not None:

--- a/lib/text_backends/grok.py
+++ b/lib/text_backends/grok.py
@@ -14,7 +14,7 @@ from lib.text_backends.base import (
     TextCapability,
     TextGenerationRequest,
     TextGenerationResult,
-    warn_if_truncated,
+    check_truncation,
 )
 
 logger = logging.getLogger(__name__)
@@ -115,11 +115,12 @@ class GrokTextBackend:
             choices = getattr(response, "choices", None) or []
             if choices:
                 finish_reason = getattr(choices[0], "finish_reason", None)
-        warn_if_truncated(
+        check_truncation(
             finish_reason,
             provider=PROVIDER_GROK,
             model=self._model,
             output_tokens=output_tokens,
+            structured=bool(request.response_schema),
         )
 
         return TextGenerationResult(

--- a/lib/text_backends/instructor_support.py
+++ b/lib/text_backends/instructor_support.py
@@ -6,11 +6,18 @@ import logging
 
 import instructor
 from instructor import Mode
+from instructor.core import IncompleteOutputException
 from pydantic import BaseModel
 
-from lib.text_backends.base import TextGenerationResult, TokenParam
+from lib.text_backends.base import TextGenerationResult, TextOutputTruncatedError, TokenParam, check_truncation
 
 logger = logging.getLogger(__name__)
+
+
+def _output_tokens_from_incomplete(exc: IncompleteOutputException) -> int | None:
+    """尽力从截断异常携带的部分响应里取 output_tokens，取不到则 None（不阻断异常转换）。"""
+    usage = getattr(getattr(exc, "last_completion", None), "usage", None)
+    return getattr(usage, "completion_tokens", None) if usage else None
 
 
 def generate_structured_via_instructor(
@@ -22,11 +29,14 @@ def generate_structured_via_instructor(
     max_retries: int = 2,
     max_tokens: int | None = None,
     token_param: TokenParam = "max_tokens",
+    provider: str = "",
 ) -> tuple[str, int | None, int | None]:
     """通过 Instructor 生成结构化输出（同步版，供 Ark 等同步 SDK 使用）。
 
     token_param 决定 max_tokens 值在导线上的参数名，由调用方按端点选择。
-    返回 (json_text, input_tokens, output_tokens)。
+    返回 (json_text, input_tokens, output_tokens)。Instructor 的
+    ``IncompleteOutputException``（输出被 max_tokens 截断）归一为 :class:`TextOutputTruncatedError`，
+    与原生结构化通道的截断行为同口径（见 docs/adr/0044）。
     """
     patched = instructor.from_openai(client, mode=mode)
     if patched is None:
@@ -35,13 +45,18 @@ def generate_structured_via_instructor(
             "请传入 openai.OpenAI 或 openai.AsyncOpenAI 实例"
         )
     extra: dict = {token_param: max_tokens} if max_tokens is not None else {}
-    result, completion = patched.chat.completions.create_with_completion(
-        model=model,
-        messages=messages,  # type: ignore[arg-type]
-        response_model=response_model,
-        max_retries=max_retries,
-        **extra,
-    )
+    try:
+        result, completion = patched.chat.completions.create_with_completion(
+            model=model,
+            messages=messages,  # type: ignore[arg-type]
+            response_model=response_model,
+            max_retries=max_retries,
+            **extra,
+        )
+    except IncompleteOutputException as exc:
+        raise TextOutputTruncatedError(
+            provider=provider, model=model, output_tokens=_output_tokens_from_incomplete(exc)
+        ) from exc
     json_text = result.model_dump_json()
 
     input_tokens = None
@@ -62,11 +77,14 @@ async def generate_structured_via_instructor_async(
     max_retries: int = 2,
     max_tokens: int | None = None,
     token_param: TokenParam = "max_tokens",
+    provider: str = "",
 ) -> tuple[str, int | None, int | None]:
     """通过 Instructor 生成结构化输出（异步版，供 OpenAI AsyncOpenAI 使用）。
 
     token_param 决定 max_tokens 值在导线上的参数名，由调用方按端点选择。
-    返回 (json_text, input_tokens, output_tokens)。
+    返回 (json_text, input_tokens, output_tokens)。Instructor 的
+    ``IncompleteOutputException``（输出被 max_tokens 截断）归一为 :class:`TextOutputTruncatedError`，
+    与原生结构化通道的截断行为同口径（见 docs/adr/0044）。
     """
     patched = instructor.from_openai(client, mode=mode)
     if patched is None:
@@ -75,13 +93,18 @@ async def generate_structured_via_instructor_async(
             "请传入 openai.OpenAI 或 openai.AsyncOpenAI 实例"
         )
     extra: dict = {token_param: max_tokens} if max_tokens is not None else {}
-    result, completion = await patched.chat.completions.create_with_completion(  # type: ignore[misc]
-        model=model,
-        messages=messages,  # type: ignore[arg-type]
-        response_model=response_model,
-        max_retries=max_retries,
-        **extra,
-    )
+    try:
+        result, completion = await patched.chat.completions.create_with_completion(  # type: ignore[misc]
+            model=model,
+            messages=messages,  # type: ignore[arg-type]
+            response_model=response_model,
+            max_retries=max_retries,
+            **extra,
+        )
+    except IncompleteOutputException as exc:
+        raise TextOutputTruncatedError(
+            provider=provider, model=model, output_tokens=_output_tokens_from_incomplete(exc)
+        ) from exc
     json_text = result.model_dump_json()
 
     input_tokens = None
@@ -136,6 +159,7 @@ def instructor_fallback_sync(
             response_model=response_schema,
             max_tokens=max_tokens,
             token_param=token_param,
+            provider=provider,
         )
         return TextGenerationResult(
             text=json_text,
@@ -159,13 +183,14 @@ def instructor_fallback_sync(
     choice = response.choices[0]
     text = choice.message.content or ""
     output_tokens = getattr(usage, "completion_tokens", None) if usage else None
-    from lib.text_backends.base import warn_if_truncated
-
-    warn_if_truncated(
+    # dict schema 仍是结构化输出诉求（response_schema 非空，只是无 Pydantic 模型可走原生
+    # Instructor 通道），截断同样升级为硬错误。
+    check_truncation(
         getattr(choice, "finish_reason", None),
         provider=provider,
         model=model,
         output_tokens=output_tokens,
+        structured=True,
     )
     return TextGenerationResult(
         text=text.strip() if isinstance(text, str) else str(text),
@@ -203,6 +228,7 @@ async def instructor_fallback_async(
             response_model=response_schema,
             max_tokens=max_tokens,
             token_param=token_param,
+            provider=provider,
         )
         return TextGenerationResult(
             text=json_text,
@@ -226,13 +252,14 @@ async def instructor_fallback_async(
     choice = response.choices[0]
     text = choice.message.content or ""
     output_tokens = getattr(usage, "completion_tokens", None) if usage else None
-    from lib.text_backends.base import warn_if_truncated
-
-    warn_if_truncated(
+    # dict schema 仍是结构化输出诉求（response_schema 非空，只是无 Pydantic 模型可走原生
+    # Instructor 通道），截断同样升级为硬错误。
+    check_truncation(
         getattr(choice, "finish_reason", None),
         provider=provider,
         model=model,
         output_tokens=output_tokens,
+        structured=True,
     )
     return TextGenerationResult(
         text=text.strip() if isinstance(text, str) else str(text),

--- a/lib/text_backends/openai.py
+++ b/lib/text_backends/openai.py
@@ -16,9 +16,9 @@ from lib.text_backends.base import (
     TextGenerationRequest,
     TextGenerationResult,
     TokenParam,
+    check_truncation,
     resolve_schema,
     structured_fallback_reason,
-    warn_if_truncated,
 )
 
 logger = logging.getLogger(__name__)
@@ -155,11 +155,12 @@ class OpenAITextBackend:
         output_tokens = usage.completion_tokens if usage else None
         text = choice.message.content or ""
 
-        warn_if_truncated(
+        check_truncation(
             getattr(choice, "finish_reason", None),
             provider=self._provider_name,
             model=self._model,
             output_tokens=output_tokens,
+            structured=bool(request.response_schema),
         )
         return TextGenerationResult(
             text=text,

--- a/server/agent_runtime/sdk_tools/patch_project.py
+++ b/server/agent_runtime/sdk_tools/patch_project.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Callable
 from typing import Any
 
 from claude_agent_sdk import tool
@@ -205,6 +206,14 @@ def _format_overview_result(updated: dict[str, str]) -> str:
     return f"{icon} overview: {summary}"
 
 
+def _coerce_numeric_string(value: str, parser: Callable[[str], int | float], error_message: str) -> int | float:
+    """数字字符串按 parser strip 后解析为落盘用的数值,解析失败抛 error_message。"""
+    try:
+        return parser(value.strip())
+    except ValueError:
+        raise ValueError(error_message) from None
+
+
 def _coerce_setting_value(key: str, value: Any) -> Any:
     """settings 字段值类型校验，返回落盘用的值。新增白名单字段时在此 dispatch。
 
@@ -217,11 +226,7 @@ def _coerce_setting_value(key: str, value: Any) -> Any:
         if value is None:
             return None
         if isinstance(value, str):
-            stripped = value.strip()
-            try:
-                value = int(stripped)
-            except ValueError:
-                raise ValueError(f"{key} 必须是正整数或 null,收到 {value!r}") from None
+            value = _coerce_numeric_string(value, int, f"{key} 必须是正整数或 null,收到 {value!r}")
         if isinstance(value, bool) or not isinstance(value, int) or value < 1:
             raise ValueError(f"{key} 必须是正整数或 null,收到 {value!r}")
         return value
@@ -247,11 +252,7 @@ def _coerce_setting_value(key: str, value: Any) -> Any:
         if value is None:
             return None
         if isinstance(value, str):
-            stripped = value.strip()
-            try:
-                value = float(stripped)
-            except ValueError:
-                raise ValueError(f"narration_speed 必须是正的有限数值或 null,收到 {value!r}") from None
+            value = _coerce_numeric_string(value, float, f"narration_speed 必须是正的有限数值或 null,收到 {value!r}")
         is_number = isinstance(value, (int, float)) and not isinstance(value, bool)
         try:
             is_valid = is_number and math.isfinite(value) and value > 0

--- a/server/agent_runtime/sdk_tools/patch_project.py
+++ b/server/agent_runtime/sdk_tools/patch_project.py
@@ -23,7 +23,7 @@ from server.agent_runtime.sdk_tools._context import ToolContext, tool_error
 # 资产表清单从 ASSET_SPECS 派生，新增资产类型时 schema enum 自动跟进。
 _TABLES = tuple(spec.bucket_key for spec in ASSET_SPECS.values())
 
-# 顶层 settings 白名单。新增项 append 到 tuple,并在 _validate_setting_value 加分支。
+# 顶层 settings 白名单。新增项 append 到 tuple,并在 _coerce_setting_value 加分支。
 # source_language: overview 生成是非必经路径(generate_overview=false / overview 失败时
 # 源语言不会落盘),需要给 agent 在用户确认后写入的恢复通道,带 zh/en/vi enum 校验防乱填。
 # planning_window_chars / planning_max_episodes: 分集规划工具的窗口字数与每批集数覆盖项,
@@ -125,20 +125,23 @@ def _apply_settings(ctx: ToolContext, settings: dict[str, Any]) -> dict[str, Any
 
     返回 { field: ('set', new_value) | ('clear', None) | ('noop', current_value) } 诊断 dict,
     供 _format_settings_result 渲染。整体在校验失败时不落盘(ValueError 冒到 handler 走 tool_error)。
+    数字类字段的字符串形态（如 "10"）在校验阶段一并转换为落盘用的 int/float,写入的是
+    转换后的值,不是原始字符串——见 _coerce_setting_value。
     """
+    coerced: dict[str, Any] = {}
     for key, value in settings.items():
         if key not in _SETTINGS_WHITELIST:
             raise ValueError(f"settings 字段 {key!r} 不在白名单 {list(_SETTINGS_WHITELIST)} 内")
-        _validate_setting_value(key, value)
+        coerced[key] = _coerce_setting_value(key, value)
 
     diagnostics: dict[str, tuple[str, Any]] = {}
 
     def _mutate(project: dict[str, Any]) -> None:
         # brief 仅广告/短片项目可用（与 DataValidator / 路由层同一约束），
         # 在持锁读到 content_mode 后门控，整体失败不落盘
-        if "brief" in settings and project.get("content_mode") != "ad":
+        if "brief" in coerced and project.get("content_mode") != "ad":
             raise ValueError("brief 仅广告/短片项目（content_mode=ad）可用")
-        for key, value in settings.items():
+        for key, value in coerced.items():
             current = project.get(key)
             if value is None:
                 if key in project:
@@ -202,35 +205,53 @@ def _format_overview_result(updated: dict[str, str]) -> str:
     return f"{icon} overview: {summary}"
 
 
-def _validate_setting_value(key: str, value: Any) -> None:
-    """settings 字段值类型校验。新增白名单字段时在此 dispatch。"""
+def _coerce_setting_value(key: str, value: Any) -> Any:
+    """settings 字段值类型校验，返回落盘用的值。新增白名单字段时在此 dispatch。
+
+    MCP 工具的 ``settings`` 入参是无逐字段类型声明的泛型 object，模型常把数字加引号传入
+    （如 ``"10"``）；正整数三项与 ``narration_speed`` 据此额外容忍对应形态的数字字符串,
+    strip 后按目标数值类型解析——解析失败或数值本身非法一律 raise，不静默放行非数字字符串
+    （如 "10.5"/"10.0"/"abc"/""）。原有 int / float / null 输入行为不变，布尔仍被拒。
+    """
     if key in _POSITIVE_INT_SETTINGS:
         if value is None:
-            return
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            try:
+                value = int(stripped)
+            except ValueError:
+                raise ValueError(f"{key} 必须是正整数或 null,收到 {value!r}") from None
         if isinstance(value, bool) or not isinstance(value, int) or value < 1:
             raise ValueError(f"{key} 必须是正整数或 null,收到 {value!r}")
-        return
+        return value
     if key == "source_language":
         if value is None:
-            return
+            return None
         if not isinstance(value, str) or value not in _SOURCE_LANGUAGE_VALUES:
             raise ValueError(f"source_language 必须是 {list(_SOURCE_LANGUAGE_VALUES)} 之一或 null,收到 {value!r}")
-        return
+        return value
     if key == "brief":
         if value is None:
-            return
+            return None
         if not isinstance(value, str):
             raise ValueError(f"brief 必须是字符串或 null,收到 {value!r}")
-        return
+        return value
     if key == "narration_voice":
         if value is None:
-            return
+            return None
         if not isinstance(value, str) or not value.strip():
             raise ValueError(f"narration_voice 必须是非空字符串或 null,收到 {value!r}")
-        return
+        return value
     if key == "narration_speed":
         if value is None:
-            return
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            try:
+                value = float(stripped)
+            except ValueError:
+                raise ValueError(f"narration_speed 必须是正的有限数值或 null,收到 {value!r}") from None
         is_number = isinstance(value, (int, float)) and not isinstance(value, bool)
         try:
             is_valid = is_number and math.isfinite(value) and value > 0
@@ -239,7 +260,7 @@ def _validate_setting_value(key: str, value: Any) -> None:
             is_valid = False
         if not is_valid:
             raise ValueError(f"narration_speed 必须是正的有限数值或 null,收到 {value!r}")
-        return
+        return value
     # 不应到这,白名单校验在调用前
     raise ValueError(f"settings 字段 {key!r} 缺类型校验")
 

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -30,7 +30,7 @@ from lib.project_manager import DEFAULT_SOURCE_KIND, effective_mode
 from lib.prompt_builders_script import build_normalize_prompt
 from lib.script_generator import ScriptGenerator
 from lib.script_models import build_drama_normalized_script_model
-from lib.text_backends.base import TextGenerationRequest, TextTaskType
+from lib.text_backends.base import DEFAULT_MAX_OUTPUT_TOKENS, TextGenerationRequest, TextTaskType
 from lib.text_generator import TextGenerator
 from lib.text_utils import strip_json_code_fences
 from server.agent_runtime.sdk_tools._context import ToolContext, fetch_video_caps, tool_error
@@ -38,10 +38,6 @@ from server.agent_runtime.sdk_tools._context import ToolContext, fetch_video_cap
 logger = logging.getLogger(__name__)
 
 _FALLBACK_SUPPORTED_DURATIONS: list[int] = [4, 6, 8]
-
-# step1 结构化内容（utterances + source_text 逐字 + 视觉描述）比旧 markdown 表更长，
-# 且 source_text 逐字摘录原文，输出体量接近原文级；放宽上限避免长集被截断。
-_NORMALIZE_MAX_OUTPUT_TOKENS = 32000
 
 
 def _parse_normalized_content(response_text: str, model: type[BaseModel]) -> dict:
@@ -382,7 +378,7 @@ def normalize_drama_script_tool(ctx: ToolContext):
                 TextGenerationRequest(
                     prompt=prompt,
                     response_schema=schema,
-                    max_output_tokens=_NORMALIZE_MAX_OUTPUT_TOKENS,
+                    max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
                 ),
                 project_name=ctx.project_name,
             )

--- a/tests/server/agent_runtime/test_patch_tools.py
+++ b/tests/server/agent_runtime/test_patch_tools.py
@@ -836,11 +836,18 @@ class TestPatchProjectSettings:
         assert out.get("is_error") is True
         assert "source_language" not in ctx.pm.load_project("demo")
 
-    @pytest.mark.parametrize("bad_value", ["1000", 0, -5, 1.5, True])
+    @pytest.mark.parametrize("bad_value", [0, -5, 1.5, True, "10.5", "10.0", "abc", ""])
     async def test_invalid_value_rejected(self, ctx: ToolContext, bad_value: Any) -> None:
         out = await _call(patch_project_tool(ctx), {"settings": {"episode_target_units": bad_value}})
         assert out.get("is_error") is True
         assert "episode_target_units" not in ctx.pm.load_project("demo")
+
+    @pytest.mark.parametrize("key", ["episode_target_units", "planning_window_chars", "planning_max_episodes"])
+    async def test_positive_int_setting_accepts_digit_string(self, ctx: ToolContext, key: str) -> None:
+        """MCP object 入参无逐字段类型声明，模型常把数字加引号传入；数字字符串按落盘用 int 容忍。"""
+        out = await _call(patch_project_tool(ctx), {"settings": {key: "10"}})
+        assert out.get("is_error") is not True
+        assert ctx.pm.load_project("demo")[key] == 10
 
     @pytest.mark.parametrize("key", ["planning_window_chars", "planning_max_episodes"])
     async def test_set_and_clear_planning_overrides(self, ctx: ToolContext, key: str) -> None:
@@ -853,7 +860,7 @@ class TestPatchProjectSettings:
         assert key not in ctx.pm.load_project("demo")
 
     @pytest.mark.parametrize("key", ["planning_window_chars", "planning_max_episodes"])
-    @pytest.mark.parametrize("bad_value", ["10", 0, -1, 2.5, True])
+    @pytest.mark.parametrize("bad_value", [0, -1, 2.5, True, "10.5", "10.0", "abc", ""])
     async def test_invalid_planning_override_rejected(self, ctx: ToolContext, key: str, bad_value: Any) -> None:
         out = await _call(patch_project_tool(ctx), {"settings": {key: bad_value}})
         assert out.get("is_error") is True
@@ -918,6 +925,12 @@ class TestPatchProjectNarrationSettings:
         assert out.get("is_error") is not True
         assert ctx.pm.load_project("demo")["narration_speed"] == speed
 
+    async def test_narration_speed_accepts_numeric_string(self, ctx: ToolContext) -> None:
+        """MCP object 入参无逐字段类型声明，模型常把数字加引号传入；有限数值字符串按落盘用 float 容忍。"""
+        out = await _call(patch_project_tool(ctx), {"settings": {"narration_speed": "1.5"}})
+        assert out.get("is_error") is not True
+        assert ctx.pm.load_project("demo")["narration_speed"] == 1.5
+
     async def test_clear_narration_speed(self, ctx: ToolContext) -> None:
         await _call(patch_project_tool(ctx), {"settings": {"narration_speed": 1.2}})
         out = await _call(patch_project_tool(ctx), {"settings": {"narration_speed": None}})
@@ -925,7 +938,7 @@ class TestPatchProjectNarrationSettings:
         assert "narration_speed" not in ctx.pm.load_project("demo")
         assert "已清除" in _text(out)
 
-    @pytest.mark.parametrize("bad", [0, -1.5, float("inf"), float("nan"), True, False, "1.2", "fast", [1.2], 10**400])
+    @pytest.mark.parametrize("bad", [0, -1.5, float("inf"), float("nan"), True, False, "fast", "", [1.2], 10**400])
     async def test_invalid_narration_speed_rejected(self, ctx: ToolContext, bad: Any) -> None:
         out = await _call(patch_project_tool(ctx), {"settings": {"narration_speed": bad}})
         assert out.get("is_error") is True

--- a/tests/test_episode_planner.py
+++ b/tests/test_episode_planner.py
@@ -412,6 +412,33 @@ class TestPlan:
         assert (project_dir / "project.json").read_text(encoding="utf-8") == before
         assert not list((project_dir / "source").glob("episode_*.txt"))
 
+    async def test_plan_truncation_short_circuits_retry_and_hints_leverage(self, tmp_path: Path):
+        """结构化输出被截断时不重试，直接冒泡 EpisodePlanningError 并附带调小窗口/集数的提示（见 docs/adr/0044）。"""
+        from lib.text_backends.base import TextOutputTruncatedError
+
+        class _TruncatingGenerator:
+            model = "fake-model"
+
+            def __init__(self):
+                self.call_count = 0
+
+            async def generate(self, request, project_name=None):
+                self.call_count += 1
+                raise TextOutputTruncatedError(provider="fake", model="fake-model", output_tokens=64000)
+
+        project_dir = _write_project(tmp_path)
+        before = (project_dir / "project.json").read_text(encoding="utf-8")
+        fake = _TruncatingGenerator()
+
+        with pytest.raises(EpisodePlanningError) as exc_info:
+            await EpisodePlanner(project_dir, generator=fake).plan()
+
+        # 截断不重试：只发生一次调用，不像 schema/机械校验失败那样耗尽 max_attempts
+        assert fake.call_count == 1
+        assert "planning_window_chars" in str(exc_info.value)
+        assert "planning_max_episodes" in str(exc_info.value)
+        assert (project_dir / "project.json").read_text(encoding="utf-8") == before
+
     async def test_plan_accepts_uppercase_json_fence(self, tmp_path: Path):
         """模型输出大写 ```JSON 围栏也能解析（围栏标记不区分大小写）。"""
         project_dir = _write_project(tmp_path)

--- a/tests/test_openai_text_backend.py
+++ b/tests/test_openai_text_backend.py
@@ -643,3 +643,47 @@ class TestMaxOutputTokens:
         instructor_kwargs = mock_patched.chat.completions.create_with_completion.call_args[1]
         assert instructor_kwargs["max_completion_tokens"] == 7000
         assert "max_tokens" not in instructor_kwargs
+
+
+class TestTruncation:
+    """结构化输出被截断时抛 TextOutputTruncatedError；自由文本仅告警（见 docs/adr/0044）。"""
+
+    async def test_structured_truncation_raises(self):
+        import pytest
+
+        from lib.text_backends.base import TextOutputTruncatedError
+
+        mock_client = AsyncMock()
+        response = _make_mock_response(json.dumps({"name": "x"}))
+        response.choices[0].finish_reason = "length"
+        mock_client.chat.completions.create = AsyncMock(return_value=response)
+
+        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            class MyModel(BaseModel):
+                name: str
+
+            backend = OpenAITextBackend(api_key="k")
+            with pytest.raises(TextOutputTruncatedError) as exc_info:
+                await backend.generate(TextGenerationRequest(prompt="hi", response_schema=MyModel))
+
+        assert exc_info.value.model == "gpt-5.4-mini"
+
+    async def test_free_text_truncation_only_warns(self, caplog):
+        import logging
+
+        response = _make_mock_response("partial")
+        response.choices[0].finish_reason = "length"
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=response)
+
+        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            backend = OpenAITextBackend(api_key="k")
+            with caplog.at_level(logging.WARNING, logger="lib.text_backends.base"):
+                result = await backend.generate(TextGenerationRequest(prompt="hi"))
+
+        assert result.text == "partial"
+        assert any("被截断" in r.message for r in caplog.records)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -275,6 +275,31 @@ class TestWithRetryAsync:
         assert result == "ok"
         assert mock_fn.call_count == 2
 
+    async def test_custom_retry_if_cannot_override_non_retryable(self):
+        """自定义 retry_if 即便对 NonRetryableError 返回 True，wrapper 仍应短路不重试——
+
+        这个保证须在装饰器内统一判定，不能依赖每个自定义谓词自行调用 _should_retry；
+        否则新增的自定义谓词若忘记处理 NonRetryableError，会破坏模块 docstring 承诺的
+        "继承 NonRetryableError 的异常类型始终不重试"。
+        """
+
+        class _Truncated(NonRetryableError):
+            pass
+
+        mock_fn = AsyncMock(side_effect=_Truncated("boom"))
+
+        @with_retry_async(
+            max_attempts=3,
+            backoff_seconds=(0, 0, 0),
+            retry_if=lambda e: True,
+        )
+        async def fn():
+            return await mock_fn()
+
+        with pytest.raises(_Truncated):
+            await fn()
+        assert mock_fn.call_count == 1
+
 
 class TestDownloadConstants:
     """下载重试常量测试。"""

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -11,6 +11,7 @@ from lib.retry import (
     DOWNLOAD_BACKOFF_SECONDS,
     DOWNLOAD_MAX_ATTEMPTS,
     RETRYABLE_STATUS_PATTERNS,
+    NonRetryableError,
     _should_retry,
     with_retry_async,
 )
@@ -78,6 +79,20 @@ class TestShouldRetry:
         assert _should_retry(MyError("oops"), (MyError,)) is True
         assert _should_retry(MyError("oops"), ()) is False
 
+    def test_non_retryable_error_short_circuits_pattern_match(self):
+        """NonRetryableError 即使消息文本偶然命中瞬态模式子串，也始终不重试。
+
+        回归场景：结构化输出截断错误的消息里嵌入任意 output_tokens 整数，若其十进制
+        文本恰好包含 "500"/"429" 等子串，字符串模式匹配会误判为瞬态错误进而重试。
+        """
+
+        class _Truncated(NonRetryableError):
+            pass
+
+        exc = _Truncated("provider/model 在 output_tokens=8500 处被截断")
+        assert "500" in str(exc)
+        assert _should_retry(exc, ()) is False
+
 
 class TestWithRetryAsync:
     """with_retry_async 装饰器测试。"""
@@ -128,6 +143,22 @@ class TestWithRetryAsync:
             return await mock_fn()
 
         with pytest.raises(ValueError, match="bad input"):
+            await fn()
+        assert mock_fn.call_count == 1
+
+    async def test_no_retry_on_non_retryable_despite_colliding_pattern(self):
+        """NonRetryableError 消息即使包含 "500" 子串也只调用一次，不重试。"""
+
+        class _Truncated(NonRetryableError):
+            pass
+
+        mock_fn = AsyncMock(side_effect=_Truncated("output_tokens=8500 处被截断"))
+
+        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0))
+        async def fn():
+            return await mock_fn()
+
+        with pytest.raises(_Truncated):
             await fn()
         assert mock_fn.call_count == 1
 

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -542,9 +542,9 @@ class TestScriptGenerator:
         assert "duration_seconds" not in props
 
     async def test_generate_sets_script_max_output_tokens(self, tmp_path):
-        """drama step2 generate 应在 TextGenerationRequest 上设置 SCRIPT_MAX_OUTPUT_TOKENS。"""
-        from lib.script_generator import SCRIPT_MAX_OUTPUT_TOKENS
+        """drama step2 generate 应在 TextGenerationRequest 上设置共享输出上限（DEFAULT_MAX_OUTPUT_TOKENS）。"""
         from lib.script_models import DramaVisualMergeError
+        from lib.text_backends.base import DEFAULT_MAX_OUTPUT_TOKENS
 
         project_path = tmp_path / "demo"
         _write_drama_ledger_project(
@@ -560,8 +560,8 @@ class TestScriptGenerator:
         with pytest.raises(DramaVisualMergeError):
             await generator.generate(1)
 
-        assert fake.backend.last_request.max_output_tokens == SCRIPT_MAX_OUTPUT_TOKENS
-        assert SCRIPT_MAX_OUTPUT_TOKENS >= 16000
+        assert fake.backend.last_request.max_output_tokens == DEFAULT_MAX_OUTPUT_TOKENS
+        assert DEFAULT_MAX_OUTPUT_TOKENS >= 16000
 
     async def test_generate_without_backend_raises(self, tmp_path):
         """未注入 backend 时调用 generate() 应抛 RuntimeError。"""

--- a/tests/test_text_backends/test_ark.py
+++ b/tests/test_text_backends/test_ark.py
@@ -221,6 +221,33 @@ class TestCapabilityAwareStructured:
 
         assert any("被截断" in r.message for r in caplog.records)
 
+    async def test_native_structured_truncation_raises_and_skips_instructor_fallback(
+        self, backend_with_structured, sync_to_thread
+    ):
+        """原生 structured 通道截断直接抛 TextOutputTruncatedError，不降级到 Instructor 重试。"""
+        from lib.text_backends.base import TextOutputTruncatedError
+
+        mock_resp = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="partial"),
+                    finish_reason="length",
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=8192),
+        )
+        backend_with_structured._test_client.chat.completions.create = MagicMock(return_value=mock_resp)
+
+        with patch("lib.text_backends.instructor_support.instructor_fallback_sync") as mock_fallback:
+            with pytest.raises(TextOutputTruncatedError) as exc_info:
+                await backend_with_structured.generate(
+                    TextGenerationRequest(prompt="gen", response_schema={"type": "object"})
+                )
+            mock_fallback.assert_not_called()
+
+        assert exc_info.value.provider == "ark"
+        assert exc_info.value.model == "mock-model-with-structured"
+
     async def test_max_output_tokens_plain(self, backend_no_structured, sync_to_thread):
         """plain 路径透传 max_tokens。"""
         mock_resp = SimpleNamespace(

--- a/tests/test_text_backends/test_base.py
+++ b/tests/test_text_backends/test_base.py
@@ -321,3 +321,46 @@ class TestWarnIfTruncated:
 
         with caplog.at_level(logging.WARNING, logger="lib.text_backends.base"):
             assert warn_if_truncated("MAX_TOKENS", provider="gemini", model="g") is True
+
+
+class TestCheckTruncation:
+    """结构化输出截断升级为硬错误，自由文本维持仅告警（见 docs/adr/0044）。"""
+
+    def test_structured_truncation_raises(self, caplog):
+        import logging
+
+        import pytest
+
+        from lib.text_backends.base import TextOutputTruncatedError, check_truncation
+
+        with caplog.at_level(logging.WARNING, logger="lib.text_backends.base"):
+            with pytest.raises(TextOutputTruncatedError) as exc_info:
+                check_truncation("length", provider="ark", model="doubao", output_tokens=8192, structured=True)
+
+        exc = exc_info.value
+        assert exc.provider == "ark"
+        assert exc.model == "doubao"
+        assert exc.output_tokens == 8192
+        # 点名当前模型 + 换模型建议
+        assert "ark/doubao" in str(exc)
+        assert "输出能力更高的文本模型" in str(exc)
+
+    def test_free_text_truncation_only_warns(self, caplog):
+        import logging
+
+        from lib.text_backends.base import check_truncation
+
+        with caplog.at_level(logging.WARNING, logger="lib.text_backends.base"):
+            check_truncation("length", provider="ark", model="doubao", structured=False)
+
+        assert any("被截断" in r.message for r in caplog.records)
+
+    def test_no_truncation_structured_does_not_raise(self):
+        from lib.text_backends.base import check_truncation
+
+        check_truncation("stop", provider="ark", model="doubao", structured=True)
+
+    def test_none_finish_reason_structured_does_not_raise(self):
+        from lib.text_backends.base import check_truncation
+
+        check_truncation(None, provider="ark", model="doubao", structured=True)

--- a/tests/test_text_backends/test_base.py
+++ b/tests/test_text_backends/test_base.py
@@ -364,3 +364,12 @@ class TestCheckTruncation:
         from lib.text_backends.base import check_truncation
 
         check_truncation(None, provider="ark", model="doubao", structured=True)
+
+    def test_truncated_error_is_non_retryable(self):
+        """TextOutputTruncatedError 须是 NonRetryableError,否则消息里的 output_tokens 整数
+        偶然命中 with_retry_async 的瞬态错误模式子串（如 429/500）时会被误判重试
+        （见 lib/retry.py::NonRetryableError）。"""
+        from lib.retry import NonRetryableError
+        from lib.text_backends.base import TextOutputTruncatedError
+
+        assert issubclass(TextOutputTruncatedError, NonRetryableError)

--- a/tests/test_text_backends/test_base.py
+++ b/tests/test_text_backends/test_base.py
@@ -344,6 +344,18 @@ class TestCheckTruncation:
         # 点名当前模型 + 换模型建议
         assert "ark/doubao" in str(exc)
         assert "输出能力更高的文本模型" in str(exc)
+        assert "output_tokens=8192" in str(exc)
+
+    def test_structured_truncation_without_output_tokens_omits_placeholder(self):
+        """供应商响应缺失 usage 信息时 output_tokens 为 None，错误消息不应显示 "output_tokens=None"。"""
+        import pytest
+
+        from lib.text_backends.base import TextOutputTruncatedError, check_truncation
+
+        with pytest.raises(TextOutputTruncatedError) as exc_info:
+            check_truncation("length", provider="ark", model="doubao", output_tokens=None, structured=True)
+
+        assert "None" not in str(exc_info.value)
 
     def test_free_text_truncation_only_warns(self, caplog):
         import logging

--- a/tests/test_text_backends/test_gemini.py
+++ b/tests/test_text_backends/test_gemini.py
@@ -86,6 +86,40 @@ class TestGenerate:
         assert config["response_mime_type"] == "application/json"
         assert config["response_json_schema"] == schema
 
+    async def test_structured_truncation_raises(self, backend):
+        """结构化输出被 MAX_TOKENS 截断时抛 TextOutputTruncatedError（见 docs/adr/0044）。"""
+        from lib.text_backends.base import TextOutputTruncatedError
+
+        mock_resp = SimpleNamespace(
+            text='{"key": "value"}',
+            usage_metadata=SimpleNamespace(prompt_token_count=20, candidates_token_count=10),
+            candidates=[SimpleNamespace(finish_reason="MAX_TOKENS")],
+        )
+        backend._test_client.aio.models.generate_content = AsyncMock(return_value=mock_resp)
+
+        schema = {"type": "object", "properties": {"key": {"type": "string"}}}
+        with pytest.raises(TextOutputTruncatedError) as exc_info:
+            await backend.generate(TextGenerationRequest(prompt="gen", response_schema=schema))
+
+        assert exc_info.value.provider == "gemini"
+
+    async def test_free_text_truncation_only_warns(self, backend, caplog):
+        """自由文本（无 response_schema）被截断时维持 log-only 告警，不抛错。"""
+        import logging
+
+        mock_resp = SimpleNamespace(
+            text="partial",
+            usage_metadata=SimpleNamespace(prompt_token_count=20, candidates_token_count=10),
+            candidates=[SimpleNamespace(finish_reason="MAX_TOKENS")],
+        )
+        backend._test_client.aio.models.generate_content = AsyncMock(return_value=mock_resp)
+
+        with caplog.at_level(logging.WARNING, logger="lib.text_backends.base"):
+            result = await backend.generate(TextGenerationRequest(prompt="gen"))
+
+        assert result.text == "partial"
+        assert any("被截断" in r.message for r in caplog.records)
+
     async def test_structured_output_pydantic_class_resolved_to_json_schema(self, backend):
         """传入 Pydantic 类时解析为 JSON Schema dict 走 response_json_schema。
 

--- a/tests/test_text_backends/test_grok.py
+++ b/tests/test_text_backends/test_grok.py
@@ -99,3 +99,35 @@ class TestGenerate:
 
         call_kwargs = backend._test_client.chat.create.call_args.kwargs
         assert call_kwargs["max_tokens"] == 16000
+
+    async def test_structured_truncation_raises(self, backend):
+        """结构化输出被截断时抛 TextOutputTruncatedError（见 docs/adr/0044）。"""
+        from lib.text_backends.base import TextOutputTruncatedError
+
+        mock_chat = MagicMock()
+        mock_response = SimpleNamespace(content='{"name": "test"}', finish_reason="length")
+        mock_parsed = MagicMock()
+        mock_parsed.model_dump_json.return_value = '{"name": "test"}'
+        mock_chat.parse = AsyncMock(return_value=(mock_response, mock_parsed))
+        backend._test_client.chat.create.return_value = mock_chat
+
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+        with pytest.raises(TextOutputTruncatedError) as exc_info:
+            await backend.generate(TextGenerationRequest(prompt="gen", response_schema=schema))
+
+        assert exc_info.value.provider == "grok"
+
+    async def test_free_text_truncation_only_warns(self, backend, caplog):
+        """自由文本（无 response_schema）被截断时维持 log-only 告警，不抛错。"""
+        import logging
+
+        mock_chat = MagicMock()
+        mock_response = SimpleNamespace(content="partial", finish_reason="length")
+        mock_chat.sample = AsyncMock(return_value=mock_response)
+        backend._test_client.chat.create.return_value = mock_chat
+
+        with caplog.at_level(logging.WARNING, logger="lib.text_backends.base"):
+            result = await backend.generate(TextGenerationRequest(prompt="hi"))
+
+        assert result.text == "partial"
+        assert any("被截断" in r.message for r in caplog.records)

--- a/tests/test_text_backends/test_instructor_support.py
+++ b/tests/test_text_backends/test_instructor_support.py
@@ -3,8 +3,11 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+from instructor.core import IncompleteOutputException
 from pydantic import BaseModel
 
+from lib.text_backends.base import TextOutputTruncatedError
 from lib.text_backends.instructor_support import (
     generate_structured_via_instructor,
     generate_structured_via_instructor_async,
@@ -153,6 +156,26 @@ class TestGenerateStructuredViaInstructor:
             assert call_kwargs["max_completion_tokens"] == 1234
             assert "max_tokens" not in call_kwargs
 
+    def test_incomplete_output_maps_to_truncated_error(self):
+        """Instructor 的 IncompleteOutputException（max_tokens 截断）归一为 TextOutputTruncatedError。"""
+        with patch("lib.text_backends.instructor_support.instructor") as mock_instructor:
+            mock_patched = MagicMock()
+            mock_instructor.from_openai.return_value = mock_patched
+            mock_patched.chat.completions.create_with_completion.side_effect = IncompleteOutputException()
+
+            with pytest.raises(TextOutputTruncatedError) as exc_info:
+                generate_structured_via_instructor(
+                    client=MagicMock(),
+                    model="test-model",
+                    messages=[{"role": "user", "content": "test"}],
+                    response_model=SampleModel,
+                    provider="test-provider",
+                )
+
+        assert exc_info.value.provider == "test-provider"
+        assert exc_info.value.model == "test-model"
+        assert isinstance(exc_info.value.__cause__, IncompleteOutputException)
+
 
 class TestGenerateStructuredViaInstructorAsync:
     async def test_explicit_token_param_max_completion_tokens(self):
@@ -177,6 +200,25 @@ class TestGenerateStructuredViaInstructorAsync:
             call_kwargs = mock_patched.chat.completions.create_with_completion.call_args[1]
             assert call_kwargs["max_completion_tokens"] == 2345
             assert "max_tokens" not in call_kwargs
+
+    async def test_incomplete_output_maps_to_truncated_error(self):
+        """异步版 IncompleteOutputException 同样归一为 TextOutputTruncatedError。"""
+        with patch("lib.text_backends.instructor_support.instructor") as mock_instructor:
+            mock_patched = MagicMock()
+            mock_instructor.from_openai.return_value = mock_patched
+            mock_patched.chat.completions.create_with_completion = AsyncMock(side_effect=IncompleteOutputException())
+
+            with pytest.raises(TextOutputTruncatedError) as exc_info:
+                await generate_structured_via_instructor_async(
+                    client=AsyncMock(),
+                    model="async-model",
+                    messages=[{"role": "user", "content": "test"}],
+                    response_model=SampleModel,
+                    provider="async-provider",
+                )
+
+        assert exc_info.value.provider == "async-provider"
+        assert exc_info.value.model == "async-model"
 
 
 class TestInstructorFallbackSync:
@@ -294,6 +336,29 @@ class TestInstructorFallbackSync:
         assert call_kwargs["max_completion_tokens"] == 500
         assert "max_tokens" not in call_kwargs
 
+    def test_dict_schema_truncation_raises(self):
+        """dict schema（response_schema 非空，无 Pydantic 模型）截断同样升级为硬错误。"""
+        mock_client = MagicMock()
+        mock_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(message=SimpleNamespace(content="partial"), finish_reason="length"),
+            ],
+            usage=SimpleNamespace(prompt_tokens=10, completion_tokens=999),
+        )
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with pytest.raises(TextOutputTruncatedError) as exc_info:
+            instructor_fallback_sync(
+                client=mock_client,
+                model="test-model",
+                messages=[{"role": "user", "content": "test"}],
+                response_schema={"type": "object"},
+                provider="test-provider",
+            )
+
+        assert exc_info.value.provider == "test-provider"
+        assert exc_info.value.model == "test-model"
+
 
 class TestInstructorFallbackAsync:
     """instructor_fallback_async 高层函数测试。"""
@@ -407,3 +472,26 @@ class TestInstructorFallbackAsync:
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert call_kwargs["max_completion_tokens"] == 600
         assert "max_tokens" not in call_kwargs
+
+    async def test_dict_schema_truncation_raises_async(self):
+        """异步 dict schema 截断同样升级为硬错误。"""
+        mock_client = AsyncMock()
+        mock_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(message=SimpleNamespace(content="partial"), finish_reason="length"),
+            ],
+            usage=SimpleNamespace(prompt_tokens=10, completion_tokens=999),
+        )
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with pytest.raises(TextOutputTruncatedError) as exc_info:
+            await instructor_fallback_async(
+                client=mock_client,
+                model="async-model",
+                messages=[{"role": "user", "content": "test"}],
+                response_schema={"type": "object"},
+                provider="async-provider",
+            )
+
+        assert exc_info.value.provider == "async-provider"
+        assert exc_info.value.model == "async-model"


### PR DESCRIPTION
## Summary

- 分集规划/剧本生成/drama 分集规范化三处的文本输出上限统一提升至共享的非约束安全阀值（64000），不再把功能预算压得过低导致大规模小说的正常分集规划输出被切断
- 结构化输出被模型输出上限截断时，四个文本供应商后端 + Instructor 降级路径统一抛出 typed 硬错误（不再重试同一份必然再截断的请求），并提示用户更换输出能力更高的模型或调小分集规划的窗口字数/每批集数
- `patch_project` 的 `settings` 数字字段（`episode_target_units`/`planning_window_chars`/`planning_max_episodes`/`narration_speed`）现在容忍智能体传入的数字字符串（如 `"10"`），解除 Bug 2 对 Bug 1 运行时调参规避路径的阻塞

设计取舍见 `docs/adr/0044-text-output-token-nonbinding-ceiling.md`。

## 本地审查发现与修复

`/code-review high --fix` 发现并修复一处正确性问题：`TextOutputTruncatedError` 的错误消息内嵌任意 `output_tokens` 整数，其十进制文本偶然包含重试模块的瞬态错误子串（如 "429"/"500"/"502"/"503"/"504"）时，会被 `with_retry_async` 的字符串模式匹配误判为瞬态错误进而重试——违背了该错误 fail-fast 的设计初衷。修复：新增 `NonRetryableError` 标记基类，在模式匹配前短路，`TextOutputTruncatedError` 继承之。顺带消除 `patch_project.py` 数字字符串解析的重复代码。

## Test plan

- [x] `uv run python -m pytest -q`（5745 passed）
- [x] `uv run ruff check` + `uv run ruff format --check`
- [x] `uv run basedpyright`（0 errors）
- [x] rebase 到最新 main 后重新跑通全量测试与类型检查

Closes #984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 改善长内容生成的截断处理：结构化输出一旦被截断将直接报错，并提示通过调整窗口字数/每批集数缩小输出范围。
  * 多个生成流程统一使用默认输出上限，使行为更一致。
* **Bug Fixes**
  * 结构化结果截断不再静默降级或无效重试；新增“不可重试”异常识别，避免重复尝试。
  * 设置写入支持将数字字符串按规则转换后落盘，减少输入格式导致的校验问题。
* **Tests**
  * 补充/更新截断、重试短路与数值设置解析相关测试用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->