### PR TITLE
feat(kling): 内置可灵供应商支持 API Key 单密钥鉴权、域名迁移与 base_url 手动配置

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,7 +50,7 @@ ArcReel 支持多个供应商，**至少配置一个**即可开始使用：
 | **Vidu** (生数科技) | [Vidu 平台](https://platform.vidu.com/) | 按积分折算计费 (CNY) |
 | **阿里百炼** (DashScope) | [阿里云百炼控制台](https://bailian.console.aliyun.com) | 全模态：文本 / 图像 / 视频 / TTS (CNY) |
 | **MiniMax** | [MiniMax 开放平台](https://platform.minimaxi.com/console) | 国内站，海外可切换国际站 (CNY) |
-| **可灵 Kling** (快手) | [可灵开放平台](https://klingai.com/dev) | 双密钥（Access Key + Secret Key）(CNY) |
+| **可灵 Kling** (快手) | [可灵开放平台](https://klingai.com/dev) | API Key 或双密钥（Access Key + Secret Key）二选一 (CNY) |
 
 也可以在部署后通过设置页添加**自定义供应商**（任何 OpenAI 兼容 / Google 兼容 API）。
 

--- a/frontend/src/components/pages/CredentialList.test.tsx
+++ b/frontend/src/components/pages/CredentialList.test.tsx
@@ -181,3 +181,142 @@ describe("pages/CredentialList two-secret (Kling)", () => {
     expect(await screen.findByText(/SKse…4321/)).toBeInTheDocument();
   });
 });
+
+describe("pages/CredentialList credential groups (api_key OR access_key+secret_key)", () => {
+  const KLING_SECRET_FIELDS = [
+    { key: "api_key", label: "API Key" },
+    { key: "access_key", label: "Access Key" },
+    { key: "secret_key", label: "Secret Key" },
+  ];
+  const KLING_SECRET_FIELD_GROUPS = [["api_key"], ["access_key", "secret_key"]];
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows an OR hint describing the two credential groups", async () => {
+    vi.spyOn(API, "listCredentials").mockResolvedValue({ credentials: [] });
+    render(
+      <CredentialList
+        providerId="kling"
+        supportsBaseUrl
+        secretFields={KLING_SECRET_FIELDS}
+        secretFieldGroups={KLING_SECRET_FIELD_GROUPS}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /添加供应商/ }));
+
+    expect(await screen.findByText("API Key 或 Access Key + Secret Key")).toBeInTheDocument();
+  });
+
+  it("renders all three secret inputs regardless of grouping", async () => {
+    vi.spyOn(API, "listCredentials").mockResolvedValue({ credentials: [] });
+    render(
+      <CredentialList
+        providerId="kling"
+        supportsBaseUrl
+        secretFields={KLING_SECRET_FIELDS}
+        secretFieldGroups={KLING_SECRET_FIELD_GROUPS}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /添加供应商/ }));
+
+    expect(await screen.findByLabelText(/^API Key/)).toBeInTheDocument();
+    expect(await screen.findByLabelText(/Access Key/)).toBeInTheDocument();
+    expect(await screen.findByLabelText(/Secret Key/)).toBeInTheDocument();
+  });
+
+  it("submits with only api_key filled (access_key/secret_key left empty)", async () => {
+    vi.spyOn(API, "listCredentials").mockResolvedValue({ credentials: [] });
+    const createSpy = vi.spyOn(API, "createCredential").mockResolvedValue({} as never);
+    render(
+      <CredentialList
+        providerId="kling"
+        supportsBaseUrl={false}
+        secretFields={KLING_SECRET_FIELDS}
+        secretFieldGroups={KLING_SECRET_FIELD_GROUPS}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /添加供应商/ }));
+    fireEvent.change(await screen.findByLabelText(/名称/), { target: { value: "可灵账号" } });
+    fireEvent.change(await screen.findByLabelText(/^API Key/), { target: { value: "sk-api-1" } });
+    fireEvent.click(screen.getByRole("button", { name: /添加$/ }));
+
+    await vi.waitFor(() => {
+      expect(createSpy).toHaveBeenCalledWith(
+        "kling",
+        expect.objectContaining({ name: "可灵账号", api_key: "sk-api-1" }),
+      );
+    });
+  });
+
+  it("submits with only access_key+secret_key filled (api_key left empty)", async () => {
+    vi.spyOn(API, "listCredentials").mockResolvedValue({ credentials: [] });
+    const createSpy = vi.spyOn(API, "createCredential").mockResolvedValue({} as never);
+    render(
+      <CredentialList
+        providerId="kling"
+        supportsBaseUrl={false}
+        secretFields={KLING_SECRET_FIELDS}
+        secretFieldGroups={KLING_SECRET_FIELD_GROUPS}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /添加供应商/ }));
+    fireEvent.change(await screen.findByLabelText(/名称/), { target: { value: "可灵账号" } });
+    fireEvent.change(await screen.findByLabelText(/Access Key/), { target: { value: "AK-1" } });
+    fireEvent.change(await screen.findByLabelText(/Secret Key/), { target: { value: "SK-1" } });
+    fireEvent.click(screen.getByRole("button", { name: /添加$/ }));
+
+    await vi.waitFor(() => {
+      expect(createSpy).toHaveBeenCalledWith(
+        "kling",
+        expect.objectContaining({ name: "可灵账号", access_key: "AK-1", secret_key: "SK-1" }),
+      );
+    });
+  });
+
+  it("rejects submit when no group is fully filled", async () => {
+    vi.spyOn(API, "listCredentials").mockResolvedValue({ credentials: [] });
+    const createSpy = vi.spyOn(API, "createCredential").mockResolvedValue({} as never);
+    render(
+      <CredentialList
+        providerId="kling"
+        supportsBaseUrl={false}
+        secretFields={KLING_SECRET_FIELDS}
+        secretFieldGroups={KLING_SECRET_FIELD_GROUPS}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /添加供应商/ }));
+    fireEvent.change(await screen.findByLabelText(/名称/), { target: { value: "可灵账号" } });
+    // 只填一半的双键组（access_key 无 secret_key），且未填 api_key —— 两组都不完整
+    fireEvent.change(await screen.findByLabelText(/Access Key/), { target: { value: "AK-1" } });
+    fireEvent.click(screen.getByRole("button", { name: /添加$/ }));
+
+    expect(await screen.findByText("请至少完整填写一组鉴权字段")).toBeInTheDocument();
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not mark any single field as required when multiple groups exist", async () => {
+    vi.spyOn(API, "listCredentials").mockResolvedValue({ credentials: [] });
+    render(
+      <CredentialList
+        providerId="kling"
+        supportsBaseUrl={false}
+        secretFields={KLING_SECRET_FIELDS}
+        secretFieldGroups={KLING_SECRET_FIELD_GROUPS}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /添加供应商/ }));
+    await screen.findByLabelText(/^API Key/);
+
+    // 二选一场景下三个 secret 字段都不应标必填星标（* ），只有 Name 字段仍是无条件必填，
+    // 否则会误导用户以为「三个都要填」
+    expect(screen.getAllByText("*")).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/pages/CredentialList.tsx
+++ b/frontend/src/components/pages/CredentialList.tsx
@@ -390,11 +390,22 @@ interface AddFormProps {
   isVertex: boolean;
   supportsBaseUrl: boolean;
   secretFields: CredentialSecretField[];
+  // 凭证「二选一」分组：满足任一组即视为凭证完整。单组（绝大多数 provider）等价于旧版
+  // 「全部必填」；可灵等多组 provider 下没有单个字段是无条件必填的，故不渲染红色必填星标。
+  secretFieldGroups: string[][];
   onCreated: () => void;
   onCancel: () => void;
 }
 
-function AddCredentialForm({ providerId, isVertex, supportsBaseUrl, secretFields, onCreated, onCancel }: AddFormProps) {
+function AddCredentialForm({
+  providerId,
+  isVertex,
+  supportsBaseUrl,
+  secretFields,
+  secretFieldGroups,
+  onCreated,
+  onCancel,
+}: AddFormProps) {
   const { t } = useTranslation("dashboard");
   const [name, setName] = useState("");
   const [secrets, setSecrets] = useState<Record<string, string>>({});
@@ -406,6 +417,14 @@ function AddCredentialForm({ providerId, isVertex, supportsBaseUrl, secretFields
   const nameRef = useAutoFocus<HTMLInputElement>();
 
   const labelFor = (field: CredentialSecretField): string => secretFieldLabel(t, field);
+  const fieldByKey = new Map(secretFields.map((f) => [f.key, f]));
+  const labelForKey = (key: string): string => labelFor(fieldByKey.get(key) ?? { key, label: key });
+  // 兜底：调用方未传分组时退化为单一必填组（= 全部 secret_fields），与旧版语义一致。
+  const groups = secretFieldGroups.length > 0 ? secretFieldGroups : [secretFields.map((f) => f.key)];
+  // 仅单一必填组时，组内每个字段才是无条件必填（旧版行为）；多组二选一时不标红星，
+  // 靠下方 orHint 提示组合关系，避免误导用户以为要填满所有字段。
+  const fieldsUnconditionallyRequired = groups.length <= 1;
+  const orHint = groups.length > 1 ? groups.map((g) => g.map(labelForKey).join(" + ")).join(` ${t("or_label")} `) : null;
 
   const handleSubmit = async () => {
     if (!name.trim()) return;
@@ -421,9 +440,10 @@ function AddCredentialForm({ providerId, isVertex, supportsBaseUrl, secretFields
         }
         await API.uploadVertexCredential(name, file);
       } else {
-        // 所有 secret 字段均必填（按 provider 的 required_keys 渲染）
-        if (secretFields.some((f) => !(secrets[f.key] ?? "").trim())) {
-          setError(t("enter_credentials_required"));
+        // 至少一组（组内字段全填）即视为凭证完整；单组场景等价于旧版「全部必填」。
+        const groupSatisfied = (group: string[]) => group.every((k) => (secrets[k] ?? "").trim());
+        if (!groups.some(groupSatisfied)) {
+          setError(groups.length > 1 ? t("enter_credentials_required_any_group") : t("enter_credentials_required"));
           setSaving(false);
           return;
         }
@@ -490,9 +510,10 @@ function AddCredentialForm({ providerId, isVertex, supportsBaseUrl, secretFields
         </div>
       ) : (
         <>
+          {orHint && <p className="text-[11px] text-text-4">{orHint}</p>}
           {secretFields.map((field) => (
             <div key={field.key}>
-              <FieldLabel htmlFor={`cred-add-${field.key}`} required>
+              <FieldLabel htmlFor={`cred-add-${field.key}`} required={fieldsUnconditionallyRequired}>
                 {labelFor(field)}
               </FieldLabel>
               <input
@@ -566,11 +587,14 @@ interface Props {
   providerId: string;
   supportsBaseUrl: boolean;
   secretFields?: CredentialSecretField[];
+  // 凭证「二选一」分组，见 AddFormProps 注释；未传时按单组全字段回退（旧版行为）。
+  secretFieldGroups?: string[][];
   onChanged?: () => void;
 }
 
-export function CredentialList({ providerId, supportsBaseUrl, secretFields, onChanged }: Props) {
+export function CredentialList({ providerId, supportsBaseUrl, secretFields, secretFieldGroups, onChanged }: Props) {
   const fields = secretFields ?? DEFAULT_SECRET_FIELDS;
+  const fieldGroups = secretFieldGroups ?? [fields.map((f) => f.key)];
   const { t } = useTranslation("dashboard");
   const [credentials, setCredentials] = useState<ProviderCredential[]>([]);
   const [loading, setLoading] = useState(true);
@@ -669,6 +693,7 @@ export function CredentialList({ providerId, supportsBaseUrl, secretFields, onCh
             isVertex={isVertex}
             supportsBaseUrl={supportsBaseUrl}
             secretFields={fields}
+            secretFieldGroups={fieldGroups}
             onCreated={() => {
               setShowAdd(false);
               void handleChanged();

--- a/frontend/src/components/pages/ProviderDetail.tsx
+++ b/frontend/src/components/pages/ProviderDetail.tsx
@@ -393,6 +393,7 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
         providerId={providerId}
         supportsBaseUrl={detail.supports_base_url}
         secretFields={detail.secret_fields}
+        secretFieldGroups={detail.secret_field_groups}
         onChanged={voidPromise(handleCredentialChanged)}
       />
 

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1020,6 +1020,8 @@ export default {
   'access_key_label': 'Access Key',
   'secret_key_label': 'Secret Key',
   'enter_credentials_required': 'Please fill in all secret fields',
+  'enter_credentials_required_any_group': 'Please fully fill in at least one credential group',
+  'or_label': 'or',
 
   // ProviderModelSelect
   'select_model_placeholder': 'Select model...',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -989,6 +989,8 @@ export default {
   'access_key_label': 'Access Key',
   'secret_key_label': 'Secret Key',
   'enter_credentials_required': 'Vui lòng điền tất cả các trường khóa bí mật',
+  'enter_credentials_required_any_group': 'Vui lòng điền đầy đủ ít nhất một nhóm thông tin xác thực',
+  'or_label': 'hoặc',
 
   // ProviderModelSelect
   'select_model_placeholder': 'Chọn mô hình...',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1021,6 +1021,8 @@ export default {
   'access_key_label': 'Access Key',
   'secret_key_label': 'Secret Key',
   'enter_credentials_required': '请填写所有密钥字段',
+  'enter_credentials_required_any_group': '请至少完整填写一组鉴权字段',
+  'or_label': '或',
 
   // ProviderModelSelect
   'select_model_placeholder': '选择模型…',

--- a/frontend/src/types/provider.ts
+++ b/frontend/src/types/provider.ts
@@ -49,6 +49,9 @@ export interface ProviderConfigDetail {
   supports_base_url: boolean;
   // 凭证表单应渲染的 secret 字段（有序）
   secret_fields: CredentialSecretField[];
+  // 凭证「二选一」分组：满足任一组（组内字段全填）即视为凭证完整；单组场景（绝大多数
+  // provider）等价于「全部 secret_fields 必填」的旧语义。可灵为 [["api_key"], ["access_key", "secret_key"]]。
+  secret_field_groups: string[][];
 }
 
 export interface ProviderTestResult {

--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -134,23 +134,30 @@ def _gemini_spec(provider_id: str, media_type: str, *, backend_type: str) -> Pro
 
 
 # ── kling 特例族 ──────────────────────────────────────────────────
-# JWT 直连：双 secret（access_key + secret_key 按列名直取，无条件透传含 None，由 backend 内
-# resolve_kling_jwt_credentials 处理）+ auth_mode=jwt。base_url 兜底：db_config 显式填写 > registry
-# default_base_url > 不传（KlingBackend 自带 KLING_BASE_URL 兜底）。image/video 共用单一构造 helper，
-# 仅 image 侧额外注入 api_model_name 解耦（两栖别名键如 kling-v3-omni-image 读 registry api_model_name
-# 发真实 API 名）；video backend 不接受 api_model_name 参数，故该注入仅对 image media_type 生效。
+# 双模式鉴权二选一（同时填写 api_key 优先，见 issue #1074）：
+# - api_key 非空 → auth_mode=bearer（官方 API Key，全模型适用）；
+# - 否则 → auth_mode=jwt（access_key + secret_key，官方标注仅 3.0 及更早模型），
+#   双 secret 按列名直取，无条件透传含 None，由 backend 内 resolve_kling_jwt_credentials 处理。
+# base_url 兜底：db_config 显式填写 > registry default_base_url > 不传（KlingBackend 自带
+# KLING_BASE_URL 兜底）。image/video 共用单一构造 helper，仅 image 侧额外注入 api_model_name 解耦
+# （两栖别名键如 kling-v3-omni-image 读 registry api_model_name 发真实 API 名）；video backend 不
+# 接受 api_model_name 参数，故该注入仅对 image media_type 生效。
 
 _KLING_REGISTRY_BACKEND = "kling"
 
 
 def _build_kling(config: LoadedConfig, model_id: str | None, *, media_type: str) -> Any:
-    """kling 通用构造：JWT 双 secret + auth_mode=jwt + base_url 兜底；image 侧叠加 api_model_name 注入。"""
-    kwargs: dict[str, Any] = {
-        "auth_mode": "jwt",
-        "access_key": config.credentials.get("access_key"),
-        "secret_key": config.credentials.get("secret_key"),
-        "model": model_id,
-    }
+    """kling 通用构造：按凭证形态分派 auth_mode（api_key 优先于双 secret）；image 侧叠加 api_model_name 注入。"""
+    api_key = config.credentials.get("api_key")
+    if api_key:
+        kwargs: dict[str, Any] = {"auth_mode": "bearer", "api_key": api_key, "model": model_id}
+    else:
+        kwargs = {
+            "auth_mode": "jwt",
+            "access_key": config.credentials.get("access_key"),
+            "secret_key": config.credentials.get("secret_key"),
+            "model": model_id,
+        }
     if media_type == "image":
         # 两栖别名键读 registry api_model_name 发真实 API 名；video backend 不接受该参数，仅 image 注入。
         model_info = config.provider_meta.models.get(model_id) if (config.provider_meta and model_id) else None

--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
+from lib.kling_shared import kling_auth_mode
+
 if TYPE_CHECKING:
     from lib.backend_assembly.loaded_config import LoadedConfig
 
@@ -134,7 +136,8 @@ def _gemini_spec(provider_id: str, media_type: str, *, backend_type: str) -> Pro
 
 
 # ── kling 特例族 ──────────────────────────────────────────────────
-# 双模式鉴权二选一（同时填写 api_key 优先，见 issue #1074）：
+# 双模式鉴权二选一（同时填写 api_key 优先，判定收口于 lib.kling_shared.kling_auth_mode，
+# backend_assembly 与 providers._test_kling 共用同一判定，避免两处各写一份分派逻辑漂移）：
 # - api_key 非空 → auth_mode=bearer（官方 API Key，全模型适用）；
 # - 否则 → auth_mode=jwt（access_key + secret_key，官方标注仅 3.0 及更早模型），
 #   双 secret 按列名直取，无条件透传含 None，由 backend 内 resolve_kling_jwt_credentials 处理。
@@ -148,9 +151,12 @@ _KLING_REGISTRY_BACKEND = "kling"
 
 def _build_kling(config: LoadedConfig, model_id: str | None, *, media_type: str) -> Any:
     """kling 通用构造：按凭证形态分派 auth_mode（api_key 优先于双 secret）；image 侧叠加 api_model_name 注入。"""
-    api_key = config.credentials.get("api_key")
-    if api_key:
-        kwargs: dict[str, Any] = {"auth_mode": "bearer", "api_key": api_key, "model": model_id}
+    if kling_auth_mode(config.credentials) == "bearer":
+        kwargs: dict[str, Any] = {
+            "auth_mode": "bearer",
+            "api_key": config.credentials.get("api_key"),
+            "model": model_id,
+        }
     else:
         kwargs = {
             "auth_mode": "jwt",

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -55,6 +55,12 @@ class ProviderMeta:
     secret_keys: list[str] = field(default_factory=list)
     models: dict[str, ModelInfo] = field(default_factory=dict)
     default_base_url: str | None = None
+    # 凭证「二选一」分组：非空时凭证表单按「满足任一组」校验（组内字段全填），而非默认的
+    # 「required_keys ∩ secret_keys 全填」。目前仅可灵需要（api_key 单键 / access_key+secret_key
+    # 双键二选一，见 issue #1074）；空列表（默认）保持原语义不变，由 router 按
+    # [[全部 secret 字段]] 回退成单一必填组。声明的每个 key 须是 required_keys ∩ secret_keys 的
+    # 子集，在 __post_init__ 校验，misconfig fail-fast。
+    credential_groups: list[list[str]] = field(default_factory=list)
     # 按 lane（image / video / audio）声明的出厂默认并发上限；某条 lane 未列入则该 lane
     # 走全局默认。容量回退优先级：用户配置值 > 此处声明默认 > 全局默认。声明给不支持的
     # lane 无害——_lane_limits 会按 media_types 把不支持的 lane 投影为 0。键名与上限值在
@@ -75,6 +81,14 @@ class ProviderMeta:
             # "1"、浮点 3.0 同样违反声明类型。type() is int 把这几类一并挡在 import 期。
             if type(limit) is not int or limit < 1:
                 raise ValueError(f"{self.display_name} default_concurrency[{lane!r}] 必须是 >=1 的整数，得到 {limit!r}")
+        if self.credential_groups:
+            allowed = set(self.required_keys) & set(self.secret_keys)
+            for group in self.credential_groups:
+                unknown = set(group) - allowed
+                if unknown:
+                    raise ValueError(
+                        f"{self.display_name} credential_groups 含未登记为 required∩secret 的 key {sorted(unknown)}"
+                    )
 
     @property
     def media_types(self) -> list[str]:
@@ -1121,12 +1135,19 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
     ),
     "kling": ProviderMeta(
         display_name="可灵 Kling",
-        description="快手可灵 Kling 视频与图像生成平台，JWT（access_key + secret_key）鉴权。",
+        description=(
+            "快手可灵 Kling 视频与图像生成平台。API Key（Bearer）适用于全部模型；"
+            "Access Key + Secret Key（JWT）仅适用于 3.0 及更早模型，二者二选一，同时填写时 API Key 优先。"
+        ),
         # 首个需要两个 secret 字符串的内置 provider（JWT HS256 鉴权），凭证按 registry key 名
-        # 存入 provider_credential 的 access_key / secret_key 定型列（见 ADR 0037）。
-        required_keys=["access_key", "secret_key"],
-        optional_keys=["image_max_workers", "video_max_workers"],
-        secret_keys=["access_key", "secret_key"],
+        # 存入 provider_credential 的 access_key / secret_key 定型列（见 ADR 0037）。api_key 复用
+        # 该表已有的 api_key 定型列（其余 provider 的静态 Bearer key 同列），无需新迁移。
+        required_keys=["api_key", "access_key", "secret_key"],
+        optional_keys=["base_url", "image_max_workers", "video_max_workers"],
+        secret_keys=["api_key", "access_key", "secret_key"],
+        # api_key 单键 / access_key+secret_key 双键二选一（官方 API Key 鉴权全模型可用，AK/SK JWT
+        # 仅 3.0 及更早模型，见 issue #1074 核实结论）；同时填写时 backend_assembly 按 api_key 优先分派。
+        credential_groups=[["api_key"], ["access_key", "secret_key"]],
         # JWT 直连：视频默认 kling-v2-5-turbo（性价比走量）+ v3/v3-omni（旗舰 4K + 多图主体）、
         # v2-6（pro 人声）、video-o1（多图主体 R2V）；图像 kling-image-o1（默认）+ v3-omni（两栖）。
         models={
@@ -1198,7 +1219,9 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 pricing=_kling_video_pricing("kling-video-o1"),
             ),
         },
-        default_base_url="https://api.klingai.com/v1",
+        # 国内调用域名官方已由 api.klingai.com 迁移至 api-beijing.klingai.com（旧域名仍可用，见
+        # issue #1074 核实结论）；仅影响未显式配置 base_url 的新用户，存量显式配置不受影响。
+        default_base_url="https://api-beijing.klingai.com/v1",
     ),
     "agnes": ProviderMeta(
         display_name="Agnes",

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -57,7 +57,7 @@ class ProviderMeta:
     default_base_url: str | None = None
     # 凭证「二选一」分组：非空时凭证表单按「满足任一组」校验（组内字段全填），而非默认的
     # 「required_keys ∩ secret_keys 全填」。目前仅可灵需要（api_key 单键 / access_key+secret_key
-    # 双键二选一，见 issue #1074）；空列表（默认）保持原语义不变，由 router 按
+    # 双键二选一）；空列表（默认）保持原语义不变，由 router 按
     # [[全部 secret 字段]] 回退成单一必填组。声明的每个 key 须是 required_keys ∩ secret_keys 的
     # 子集，在 __post_init__ 校验，misconfig fail-fast。
     credential_groups: list[list[str]] = field(default_factory=list)
@@ -1146,7 +1146,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
         optional_keys=["base_url", "image_max_workers", "video_max_workers"],
         secret_keys=["api_key", "access_key", "secret_key"],
         # api_key 单键 / access_key+secret_key 双键二选一（官方 API Key 鉴权全模型可用，AK/SK JWT
-        # 仅 3.0 及更早模型，见 issue #1074 核实结论）；同时填写时 backend_assembly 按 api_key 优先分派。
+        # 仅 3.0 及更早模型）；同时填写时 backend_assembly 按 api_key 优先分派。
         credential_groups=[["api_key"], ["access_key", "secret_key"]],
         # JWT 直连：视频默认 kling-v2-5-turbo（性价比走量）+ v3/v3-omni（旗舰 4K + 多图主体）、
         # v2-6（pro 人声）、video-o1（多图主体 R2V）；图像 kling-image-o1（默认）+ v3-omni（两栖）。
@@ -1219,8 +1219,8 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 pricing=_kling_video_pricing("kling-video-o1"),
             ),
         },
-        # 国内调用域名官方已由 api.klingai.com 迁移至 api-beijing.klingai.com（旧域名仍可用，见
-        # issue #1074 核实结论）；仅影响未显式配置 base_url 的新用户，存量显式配置不受影响。
+        # 国内调用域名官方已由 api.klingai.com 迁移至 api-beijing.klingai.com（旧域名仍可用，
+        # 未强制下线）；仅影响未显式配置 base_url 的新用户，存量显式配置不受影响。
         default_base_url="https://api-beijing.klingai.com/v1",
     ),
     "agnes": ProviderMeta(

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -83,12 +83,22 @@ class ProviderMeta:
                 raise ValueError(f"{self.display_name} default_concurrency[{lane!r}] 必须是 >=1 的整数，得到 {limit!r}")
         if self.credential_groups:
             allowed = set(self.required_keys) & set(self.secret_keys)
+            covered: set[str] = set()
             for group in self.credential_groups:
+                # 空分组会被 unknown=set() 判定为合法、前端 group.every(...) 对空数组恒真，
+                # 误判该分组"已满足"——同属 import 期该拦的作者笔误。
+                if not group:
+                    raise ValueError(f"{self.display_name} credential_groups 含空分组")
                 unknown = set(group) - allowed
                 if unknown:
                     raise ValueError(
                         f"{self.display_name} credential_groups 含未登记为 required∩secret 的 key {sorted(unknown)}"
                     )
+                covered |= set(group)
+            # 未被任何分组覆盖的 key 既不受旧版"全部必填"约束，也不受任何分组约束——
+            # 声明了分组却漏登记某个 key，前端会误判该 key 为可选。
+            if covered != allowed:
+                raise ValueError(f"{self.display_name} credential_groups 未覆盖 {sorted(allowed - covered)}")
 
     @property
     def media_types(self) -> list[str]:

--- a/lib/i18n/en/providers.py
+++ b/lib/i18n/en/providers.py
@@ -23,7 +23,7 @@ MESSAGES: dict[str, str] = {
     "provider_desc_vidu": "Shengshu Vidu video platform supporting text-to-video, image-to-video, first-last frame, reference-to-video and reference-to-image. Image and video only.",
     "provider_desc_dashscope": "Alibaba Cloud Model Studio (DashScope) full-modality platform supporting Qwen text, Qwen-Image / Wan images, and HappyHorse / Wan video (including reference-to-video).",
     "provider_desc_minimax": "MiniMax (Hailuo) multimodal platform with text, image and video generation. Connects to the domestic site by default; set base_url to the international site for overseas access.",
-    "provider_desc_kling": "Kuaishou Kling video and image generation platform, authenticated with an Access Key and Secret Key.",
+    "provider_desc_kling": "Kuaishou Kling video and image generation platform. API Key authentication works with all models; Access Key + Secret Key (JWT) only supports 3.0-and-earlier models. Choose either — when both are set, API Key takes priority.",
     "provider_desc_agnes": "Agnes multimodal platform (OpenAI-style), authenticated with a Bearer API key; currently supports image, text and video generation.",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "DeepSeek official Anthropic-compat endpoint; needs sk- prefixed key.",

--- a/lib/i18n/vi/providers.py
+++ b/lib/i18n/vi/providers.py
@@ -23,7 +23,7 @@ MESSAGES: dict[str, str] = {
     "provider_desc_vidu": "Nền tảng Vidu của Shengshu hỗ trợ tạo video từ văn bản, từ ảnh, khung đầu–cuối, video tham chiếu và ảnh tham chiếu. Chỉ hỗ trợ ảnh và video.",
     "provider_desc_dashscope": "Nền tảng đa phương thức Alibaba Cloud Model Studio (DashScope) hỗ trợ văn bản Qwen, ảnh Qwen-Image / Wan và video HappyHorse / Wan (bao gồm video tham chiếu).",
     "provider_desc_minimax": "Nền tảng đa phương thức MiniMax (Hailuo) hỗ trợ tạo văn bản, ảnh và video. Mặc định kết nối site nội địa; đặt base_url sang site quốc tế khi dùng ở nước ngoài.",
-    "provider_desc_kling": "Nền tảng tạo video và ảnh Kling của Kuaishou, xác thực bằng Access Key và Secret Key.",
+    "provider_desc_kling": "Nền tảng tạo video và ảnh Kling của Kuaishou. Xác thực bằng API Key áp dụng cho mọi model; Access Key + Secret Key (JWT) chỉ áp dụng cho model từ 3.0 trở về trước. Chọn một trong hai — nếu điền cả hai, API Key được ưu tiên.",
     "provider_desc_agnes": "Nền tảng đa phương thức Agnes (phong cách OpenAI), xác thực bằng Bearer API key; hiện hỗ trợ tạo ảnh, văn bản và video.",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "Endpoint Anthropic-compat chính thức của DeepSeek; cần API key sk-.",

--- a/lib/i18n/zh/providers.py
+++ b/lib/i18n/zh/providers.py
@@ -23,7 +23,7 @@ MESSAGES: dict[str, str] = {
     "provider_desc_vidu": "生数科技 Vidu 视频生成平台，支持文生视频、图生视频、首尾帧、参考生视频与参考生图，仅图片与视频能力。",
     "provider_desc_dashscope": "阿里云百炼（Model Studio）全模态平台，支持 Qwen 文本、Qwen-Image / 万相图像与 HappyHorse / 万相视频（含参考生视频）。",
     "provider_desc_minimax": "MiniMax（海螺）多模态平台，提供文本、图片、视频生成。默认连接国内站，海外可将 base_url 切换到国际站。",
-    "provider_desc_kling": "快手可灵 Kling 视频与图像生成平台，使用 Access Key 与 Secret Key 鉴权。",
+    "provider_desc_kling": "快手可灵 Kling 视频与图像生成平台。API Key 鉴权适用于全部模型；Access Key + Secret Key（JWT）仅适用于 3.0 及更早模型，二者二选一，同时填写时 API Key 优先。",
     "provider_desc_agnes": "Agnes 多模态平台（OpenAI 风格），使用 Bearer API Key 鉴权；当前支持图像 / 文本 / 视频生成。",
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "DeepSeek 官方 Anthropic 兼容端点，需 sk- 开头的 API Key",

--- a/lib/kling_shared.py
+++ b/lib/kling_shared.py
@@ -15,14 +15,15 @@ from __future__ import annotations
 
 import base64
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
+from typing import Literal
 
 import jwt
 
 # 官方 base（含 /v1），对齐 ark_shared.ARK_BASE_URL 约定。国内调用域名官方已由 api.klingai.com
-# 迁移至 api-beijing.klingai.com（旧域名仍可用，未强制下线，见 issue #1074 核实结论）；此处只影响
-# 未显式配置 base_url 的新用户，registry.default_base_url 同步该值（两处保持一致，单一真相源）。
+# 迁移至 api-beijing.klingai.com（旧域名仍可用，未强制下线）；此处只影响未显式配置 base_url 的
+# 新用户，registry.default_base_url 同步该值（两处保持一致，单一真相源）。
 KLING_BASE_URL = "https://api-beijing.klingai.com/v1"
 
 # JWT token 寿命与刷新策略。
@@ -110,12 +111,21 @@ def resolve_kling_api_key(api_key: str | None) -> str:
     """校验并归一化 bearer 模式静态 api_key；缺失即 raise。
 
     bearer 模式现有两条调用路径共用本校验：自定义 endpoint（中转站 Bearer key）与内置
-    provider 的 API Key 单键模式（见 issue #1074），故报错文案不专指其中一条。
+    provider 的 API Key 单键模式，故报错文案不专指其中一条。
     """
     key = (api_key or "").strip()
     if not key:
         raise ValueError("请填写可灵 Kling 的 API Key")
     return key
+
+
+def kling_auth_mode(credentials: Mapping[str, str | None]) -> Literal["bearer", "jwt"]:
+    """按凭证形态决定 auth_mode：``api_key`` 非空优先 bearer，否则 jwt（access_key + secret_key）。
+
+    内置 provider 构造（backend_assembly._build_kling）与连接测试（providers._test_kling）共用
+    本判定，避免"api_key 优先"这条业务规则在两处各写一份、调整时改一处漏另一处。
+    """
+    return "bearer" if credentials.get("api_key") else "jwt"
 
 
 def image_to_base64(image_path: Path) -> str:

--- a/lib/kling_shared.py
+++ b/lib/kling_shared.py
@@ -124,8 +124,13 @@ def kling_auth_mode(credentials: Mapping[str, str | None]) -> Literal["bearer", 
 
     内置 provider 构造（backend_assembly._build_kling）与连接测试（providers._test_kling）共用
     本判定，避免"api_key 优先"这条业务规则在两处各写一份、调整时改一处漏另一处。
+
+    ``.strip()`` 后判空：纯空格 api_key（如误粘贴产生的空白字符串）不应误判为已填写 bearer
+    模式、静默吞掉同时存在的有效 access_key/secret_key（resolve_kling_api_key 对空白输入的
+    校验在其后才触发，本判定须先与之口径一致）。
     """
-    return "bearer" if credentials.get("api_key") else "jwt"
+    api_key = credentials.get("api_key")
+    return "bearer" if api_key and api_key.strip() else "jwt"
 
 
 def image_to_base64(image_path: Path) -> str:
@@ -146,16 +151,13 @@ def _as_str(value: object) -> str:
     return value if isinstance(value, str) else ""
 
 
-def kling_response_error(payload: dict) -> str | None:
-    """``code != 0`` → 错误描述；0 或缺失 → None。
-
-    可灵所有响应带顶层 ``code`` / ``message``，0 表成功。提交/查询接口本身失败（鉴权、参数
-    非法等）即在此暴露（鉴权失败等也可能另走 4xx，由 submit_post / raise_for_status 兜住）。
+def _code_error(scope: dict, message_key: str) -> str | None:
+    """从 ``scope`` 取 ``code`` / ``scope[message_key]`` 构造错误描述；``code`` 为 0 或缺失 → None。
 
     ``code`` 归一化为 int 再比较：bearer / 中转 endpoint 可能把 code 序列化成字符串（``"0"``）
     或浮点，直接 ``code != 0`` 会把字符串 ``"0"`` 误判为错误；无法解析的 code 一律视为错误暴露原值。
     """
-    code = payload.get("code")
+    code = scope.get("code")
     if code is None:
         return None
     try:
@@ -163,8 +165,22 @@ def kling_response_error(payload: dict) -> str | None:
     except (TypeError, ValueError, OverflowError):
         is_error = True
     if is_error:
-        return f"Kling API code={code}: {_as_str(payload.get('message'))}".strip()
+        return f"Kling API code={code}: {_as_str(scope.get(message_key))}".strip()
     return None
+
+
+def kling_response_error(payload: dict) -> str | None:
+    """``code != 0`` → 错误描述；0 或缺失 → None。
+
+    可灵所有响应带顶层 ``code`` / ``message``，0 表成功。提交/查询接口本身失败（鉴权、参数
+    非法等）即在此暴露（鉴权失败等也可能另走 4xx，由 submit_post / raise_for_status 兜住）。
+
+    部分接口（如 ``account/costs``）额外在 ``data`` 内嵌一层业务级 ``code`` / ``msg``——与顶层
+    信封状态分离，专指该次业务查询本身的成功/失败（如参数非法、资源包不存在）；顶层通过后
+    接着查这层，任一层非 0 即视为错误。提交/轮询类接口的 ``data``（``task_id`` /
+    ``task_status`` 等）不含 ``code`` 键，该检查对其为 no-op。
+    """
+    return _code_error(payload, "message") or _code_error(_as_dict(payload.get("data")), "msg")
 
 
 def extract_kling_task_id(submit_payload: dict) -> str:

--- a/lib/kling_shared.py
+++ b/lib/kling_shared.py
@@ -169,7 +169,7 @@ def _code_error(scope: dict, message_key: str) -> str | None:
     return None
 
 
-def kling_response_error(payload: dict) -> str | None:
+def kling_response_error(payload: object) -> str | None:
     """``code != 0`` → 错误描述；0 或缺失 → None。
 
     可灵所有响应带顶层 ``code`` / ``message``，0 表成功。提交/查询接口本身失败（鉴权、参数
@@ -179,7 +179,11 @@ def kling_response_error(payload: dict) -> str | None:
     信封状态分离，专指该次业务查询本身的成功/失败（如参数非法、资源包不存在）；顶层通过后
     接着查这层，任一层非 0 即视为错误。提交/轮询类接口的 ``data``（``task_id`` /
     ``task_status`` 等）不含 ``code`` 键，该检查对其为 no-op。
+
+    ``payload`` 归一化为 dict：中转 endpoint / 异常网关可能返回非对象 JSON（数组、字符串等），
+    此时按空 dict 处理（无 ``code`` 键 → 视为无错误），避免 ``.get()`` 触发 AttributeError。
     """
+    payload = payload if isinstance(payload, dict) else {}
     return _code_error(payload, "message") or _code_error(_as_dict(payload.get("data")), "msg")
 
 

--- a/lib/kling_shared.py
+++ b/lib/kling_shared.py
@@ -20,8 +20,10 @@ from pathlib import Path
 
 import jwt
 
-# 官方 base（含 /v1），对齐 ark_shared.ARK_BASE_URL 约定。
-KLING_BASE_URL = "https://api.klingai.com/v1"
+# 官方 base（含 /v1），对齐 ark_shared.ARK_BASE_URL 约定。国内调用域名官方已由 api.klingai.com
+# 迁移至 api-beijing.klingai.com（旧域名仍可用，未强制下线，见 issue #1074 核实结论）；此处只影响
+# 未显式配置 base_url 的新用户，registry.default_base_url 同步该值（两处保持一致，单一真相源）。
+KLING_BASE_URL = "https://api-beijing.klingai.com/v1"
 
 # JWT token 寿命与刷新策略。
 _TOKEN_TTL_SECONDS = 1800  # 约 30 分钟过期（官方）。
@@ -105,10 +107,14 @@ def resolve_kling_jwt_credentials(access_key: str | None, secret_key: str | None
 
 
 def resolve_kling_api_key(api_key: str | None) -> str:
-    """校验并归一化 bearer 模式静态 api_key；缺失即 raise。"""
+    """校验并归一化 bearer 模式静态 api_key；缺失即 raise。
+
+    bearer 模式现有两条调用路径共用本校验：自定义 endpoint（中转站 Bearer key）与内置
+    provider 的 API Key 单键模式（见 issue #1074），故报错文案不专指其中一条。
+    """
     key = (api_key or "").strip()
     if not key:
-        raise ValueError("请填写可灵 endpoint 的 API Key")
+        raise ValueError("请填写可灵 Kling 的 API Key")
     return key
 
 

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -339,8 +339,10 @@ async def get_provider_config(
     ]
     # 空声明（绝大多数单 secret / 双 secret-AND provider）回退为单一必填组 = 全部 secret_fields，
     # 与迁移前「全部必填」语义等价；仅可灵声明了非空 credential_groups（api_key 单键 /
-    # access_key+secret_key 双键二选一）。
-    secret_field_groups = meta.credential_groups or [[f.key for f in secret_fields]]
+    # access_key+secret_key 双键二选一）。secret_fields 为空时（当前仅 gemini-vertex，走文件
+    # 上传分支不经过分组校验）不合成 [[]]——与 registry.py 的空分组 fail-fast 语义保持一致，
+    # 避免未来新增"无 secret 字段但走普通凭证表单"的 provider 时该分组恒真、静默绕过校验。
+    secret_field_groups = meta.credential_groups or ([[f.key for f in secret_fields]] if secret_fields else [])
 
     return ProviderConfigResponse(
         id=provider_id,

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -788,12 +788,19 @@ def _test_kling(config: dict[str, str], _t: Callable[..., str]) -> ConnectionTes
     )
     # JSON 错误体先于 raise_for_status 解析：鉴权失败等场景可灵仍带 JSON 错误体（业务 code +
     # message，如"access key 不存在"），先于 raise_for_status 提取能保留这份具体原因；否则
-    # 4xx/5xx 直接 raise 会丢弃响应体，只剩泛泛的 HTTP 状态文案。非 JSON 响应体（如网关错误页）
-    # 跳过解析，走 raise_for_status 兜底暴露 HTTP 状态。
+    # 4xx/5xx 直接 raise 会丢弃响应体，只剩泛泛的 HTTP 状态文案。content-type 声称 JSON 但
+    # 实际非法/空体（如异常网关截断响应）时解析会抛 JSONDecodeError——按声明的 content-type
+    # 判断是否尝试解析，不代表响应体一定合法，解析失败即放弃业务错误提取，跳过、直接走
+    # raise_for_status 兜底暴露 HTTP 状态，而非让解析异常本身掩盖更具体的 HTTP 错误。
     if "application/json" in resp.headers.get("content-type", ""):
-        err = kling_response_error(resp.json())
-        if err is not None:
-            raise RuntimeError(err)
+        try:
+            payload = resp.json()
+        except ValueError:
+            payload = None
+        if payload is not None:
+            err = kling_response_error(payload)
+            if err is not None:
+                raise RuntimeError(err)
     resp.raise_for_status()
     return ConnectionTestResponse(
         success=True,

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -107,8 +107,9 @@ class FieldInfo(BaseModel):
 class CredentialSecretField(BaseModel):
     """凭证表单需渲染的 secret 输入字段（按 provider 的 required ∩ secret ∩ 凭证键派生）。
 
-    驱动设置页凭证表单渲染：单 secret provider 给 ``[api_key]``，可灵给
-    ``[access_key, secret_key]``（见 ADR 0037）。key 名全程同名，前端据此读写各字段。
+    驱动设置页凭证表单渲染：单 secret provider 给 ``[api_key]``（见 ADR 0037），可灵给
+    ``[api_key, access_key, secret_key]``（二选一分组见 ``secret_field_groups``）。
+    key 名全程同名，前端据此读写各字段。
     """
 
     key: str
@@ -129,7 +130,7 @@ class ProviderConfigResponse(BaseModel):
     secret_fields: list[CredentialSecretField]
     # 凭证「二选一」分组：前端据此校验「至少一组的字段全部填写」而非「全部字段都填写」
     # （真相源：registry credential_groups；空声明时 router 回退为 [全部 secret_fields]，
-    # 与迁移前「全部必填」语义等价）。单一真相源：可灵二选一见 issue #1074。
+    # 与迁移前「全部必填」语义等价）。
     secret_field_groups: list[list[str]]
 
 
@@ -328,7 +329,8 @@ async def get_provider_config(
             fields.append(_build_field(key, required=False, db_entry=db_values.get(key)))
 
     # 凭证表单的 secret 输入字段：required ∩ secret ∩ 凭证键，保留 required_keys 顺序。
-    # 单 secret provider → [api_key]；可灵 → [access_key, secret_key]（见 ADR 0037）。
+    # 单 secret provider → [api_key]（见 ADR 0037）；可灵 → [api_key, access_key, secret_key]，
+    # 二选一分组见下方 secret_field_groups。
     secret_keys = set(meta.secret_keys)
     secret_fields = [
         CredentialSecretField(key=key, label=_FIELD_META.get(key, {"label": key})["label"])
@@ -749,10 +751,10 @@ def _test_minimax(config: dict[str, str], _t: Callable[..., str]) -> ConnectionT
 def _test_kling(config: dict[str, str], _t: Callable[..., str]) -> ConnectionTestResponse:
     """通过查询账户资源包余量验证可灵凭证（``GET /account/costs``，官方标注 free-to-call、无副作用）。
 
-    双模式鉴权二选一，api_key 优先，与 backend_assembly._build_kling 的分派顺序一致；缺失时
-    resolve_kling_api_key / resolve_kling_jwt_credentials 抛出的 ValueError 经上层 except 转成
-    明确的 connection_failed 文案。account/costs 挂在域名根路径（不带 /v1 版本前缀），需从
-    base_url 剥离该后缀。
+    双模式鉴权二选一，判定收口于 kling_auth_mode（与 backend_assembly._build_kling 共用，保证
+    实际生成任务与连接测试的分派顺序恒一致）；缺失时 resolve_kling_api_key /
+    resolve_kling_jwt_credentials 抛出的 ValueError 经上层 except 转成明确的 connection_failed
+    文案。account/costs 挂在域名根路径（不带 /v1 版本前缀），需从 base_url 剥离该后缀。
     """
     import time
 
@@ -761,15 +763,15 @@ def _test_kling(config: dict[str, str], _t: Callable[..., str]) -> ConnectionTes
     from lib.kling_shared import (
         KLING_BASE_URL,
         KlingJWTManager,
+        kling_auth_mode,
         kling_bearer_headers,
         kling_response_error,
         resolve_kling_api_key,
         resolve_kling_jwt_credentials,
     )
 
-    api_key = config.get("api_key")
-    if api_key:
-        headers = kling_bearer_headers(resolve_kling_api_key(api_key))
+    if kling_auth_mode(config) == "bearer":
+        headers = kling_bearer_headers(resolve_kling_api_key(config.get("api_key")))
     else:
         access_key, secret_key = resolve_kling_jwt_credentials(config.get("access_key"), config.get("secret_key"))
         headers = KlingJWTManager(access_key, secret_key).auth_headers()

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -127,6 +127,10 @@ class ProviderConfigResponse(BaseModel):
     supports_base_url: bool
     # 凭证表单应渲染的 secret 字段（有序，真相源：registry required_keys ∩ secret_keys ∩ 凭证键）。
     secret_fields: list[CredentialSecretField]
+    # 凭证「二选一」分组：前端据此校验「至少一组的字段全部填写」而非「全部字段都填写」
+    # （真相源：registry credential_groups；空声明时 router 回退为 [全部 secret_fields]，
+    # 与迁移前「全部必填」语义等价）。单一真相源：可灵二选一见 issue #1074。
+    secret_field_groups: list[list[str]]
 
 
 class ConnectionTestResponse(BaseModel):
@@ -331,6 +335,10 @@ async def get_provider_config(
         for key in meta.required_keys
         if key in _CREDENTIAL_KEYS and key in secret_keys
     ]
+    # 空声明（绝大多数单 secret / 双 secret-AND provider）回退为单一必填组 = 全部 secret_fields，
+    # 与迁移前「全部必填」语义等价；仅可灵声明了非空 credential_groups（api_key 单键 /
+    # access_key+secret_key 双键二选一）。
+    secret_field_groups = meta.credential_groups or [[f.key for f in secret_fields]]
 
     return ProviderConfigResponse(
         id=provider_id,
@@ -341,6 +349,7 @@ async def get_provider_config(
         fields=fields,
         supports_base_url="base_url" in meta.optional_keys,
         secret_fields=secret_fields,
+        secret_field_groups=secret_field_groups,
     )
 
 
@@ -737,6 +746,55 @@ def _test_minimax(config: dict[str, str], _t: Callable[..., str]) -> ConnectionT
     )
 
 
+def _test_kling(config: dict[str, str], _t: Callable[..., str]) -> ConnectionTestResponse:
+    """通过查询账户资源包余量验证可灵凭证（``GET /account/costs``，官方标注 free-to-call、无副作用）。
+
+    双模式鉴权二选一，api_key 优先，与 backend_assembly._build_kling 的分派顺序一致；缺失时
+    resolve_kling_api_key / resolve_kling_jwt_credentials 抛出的 ValueError 经上层 except 转成
+    明确的 connection_failed 文案。account/costs 挂在域名根路径（不带 /v1 版本前缀），需从
+    base_url 剥离该后缀。
+    """
+    import time
+
+    import httpx
+
+    from lib.kling_shared import (
+        KLING_BASE_URL,
+        KlingJWTManager,
+        kling_bearer_headers,
+        kling_response_error,
+        resolve_kling_api_key,
+        resolve_kling_jwt_credentials,
+    )
+
+    api_key = config.get("api_key")
+    if api_key:
+        headers = kling_bearer_headers(resolve_kling_api_key(api_key))
+    else:
+        access_key, secret_key = resolve_kling_jwt_credentials(config.get("access_key"), config.get("secret_key"))
+        headers = KlingJWTManager(access_key, secret_key).auth_headers()
+
+    base_url = (config.get("base_url") or KLING_BASE_URL).rstrip("/")
+    root = base_url.removesuffix("/v1")
+    now_ms = int(time.time() * 1000)
+    one_day_ms = 24 * 60 * 60 * 1000
+    resp = httpx.get(
+        f"{root}/account/costs",
+        params={"start_time": now_ms - one_day_ms, "end_time": now_ms},
+        headers=headers,
+        timeout=_CONNECTION_TEST_TIMEOUT,
+    )
+    resp.raise_for_status()
+    err = kling_response_error(resp.json())
+    if err is not None:
+        raise RuntimeError(err)
+    return ConnectionTestResponse(
+        success=True,
+        available_models=[],
+        message=_t("connection_success"),
+    )
+
+
 _TEST_DISPATCH: dict[str, Callable[[dict[str, str], Any], ConnectionTestResponse]] = {
     "gemini-aistudio": _test_gemini_aistudio,
     "gemini-vertex": _test_gemini_vertex,
@@ -747,6 +805,7 @@ _TEST_DISPATCH: dict[str, Callable[[dict[str, str], Any], ConnectionTestResponse
     "vidu": _test_vidu,
     "dashscope": _test_dashscope,
     "minimax": _test_minimax,
+    "kling": _test_kling,
 }
 
 

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -786,10 +786,15 @@ def _test_kling(config: dict[str, str], _t: Callable[..., str]) -> ConnectionTes
         headers=headers,
         timeout=_CONNECTION_TEST_TIMEOUT,
     )
+    # JSON 错误体先于 raise_for_status 解析：鉴权失败等场景可灵仍带 JSON 错误体（业务 code +
+    # message，如"access key 不存在"），先于 raise_for_status 提取能保留这份具体原因；否则
+    # 4xx/5xx 直接 raise 会丢弃响应体，只剩泛泛的 HTTP 状态文案。非 JSON 响应体（如网关错误页）
+    # 跳过解析，走 raise_for_status 兜底暴露 HTTP 状态。
+    if "application/json" in resp.headers.get("content-type", ""):
+        err = kling_response_error(resp.json())
+        if err is not None:
+            raise RuntimeError(err)
     resp.raise_for_status()
-    err = kling_response_error(resp.json())
-    if err is not None:
-        raise RuntimeError(err)
     return ConnectionTestResponse(
         success=True,
         available_models=[],

--- a/tests/test_backend_assembly_loader.py
+++ b/tests/test_backend_assembly_loader.py
@@ -133,7 +133,7 @@ class TestAssembleBuiltinEndToEnd:
             secret_key="sk-1",
             model="kling-v3-omni-image",
             api_model_name="kling-v3-omni",
-            base_url="https://api.klingai.com/v1",
+            base_url="https://api-beijing.klingai.com/v1",
         )
 
 

--- a/tests/test_backend_assembly_specs.py
+++ b/tests/test_backend_assembly_specs.py
@@ -202,8 +202,9 @@ class TestGeminiSpec:
 
 
 class TestKlingSpec:
-    """kling 特例族：JWT 双 secret（access_key + secret_key 按列名直取）、auth_mode=jwt、
-    image 侧 api_model_name 解耦（两栖别名键读 registry api_model_name）、base_url 兜底（db > registry default）。
+    """kling 特例族：双模式鉴权二选一（api_key 优先 → auth_mode=bearer；否则 access_key+secret_key
+    → auth_mode=jwt），image 侧 api_model_name 解耦（两栖别名键读 registry api_model_name）、
+    base_url 兜底（db > registry default，国内域名已迁移至 api-beijing，见 issue #1074）。
     video backend 不接受 api_model_name —— 非对称，video 闭包不传。"""
 
     @patch("lib.image_backends.registry.create_backend")
@@ -222,7 +223,7 @@ class TestKlingSpec:
             access_key="ak-1",
             secret_key="sk-1",
             model="kling-image-o1",
-            base_url="https://api.klingai.com/v1",
+            base_url="https://api-beijing.klingai.com/v1",
         )
 
     @patch("lib.image_backends.registry.create_backend")
@@ -242,7 +243,7 @@ class TestKlingSpec:
             secret_key="sk-1",
             model="kling-v3-omni-image",
             api_model_name="kling-v3-omni",
-            base_url="https://api.klingai.com/v1",
+            base_url="https://api-beijing.klingai.com/v1",
         )
 
     @patch("lib.image_backends.registry.create_backend")
@@ -280,7 +281,62 @@ class TestKlingSpec:
             access_key="ak-1",
             secret_key="sk-1",
             model="kling-v3",
-            base_url="https://api.klingai.com/v1",
+            base_url="https://api-beijing.klingai.com/v1",
+        )
+
+    @patch("lib.video_backends.registry.create_backend")
+    def test_video_api_key_dispatches_bearer_mode(self, mock_create):
+        """单填 api_key（无 access_key/secret_key）→ auth_mode=bearer，不透传 access_key/secret_key。"""
+        spec = get_provider_spec("kling", "video")
+        config = LoadedConfig(
+            credentials={"api_key": "sk-api-1"},
+            provider_meta=PROVIDER_REGISTRY.get("kling"),
+            rate_limiter=None,
+        )
+        spec.build_backend(config, "kling-v3")
+        mock_create.assert_called_once_with(
+            "kling",
+            auth_mode="bearer",
+            api_key="sk-api-1",
+            model="kling-v3",
+            base_url="https://api-beijing.klingai.com/v1",
+        )
+
+    @patch("lib.image_backends.registry.create_backend")
+    def test_image_api_key_dispatches_bearer_mode_with_api_model_name(self, mock_create):
+        """image 侧 bearer 模式同样叠加 api_model_name 解耦（两栖别名键）。"""
+        spec = get_provider_spec("kling", "image")
+        config = LoadedConfig(
+            credentials={"api_key": "sk-api-1"},
+            provider_meta=PROVIDER_REGISTRY.get("kling"),
+            rate_limiter=None,
+        )
+        spec.build_backend(config, "kling-v3-omni-image")
+        mock_create.assert_called_once_with(
+            "kling",
+            auth_mode="bearer",
+            api_key="sk-api-1",
+            model="kling-v3-omni-image",
+            api_model_name="kling-v3-omni",
+            base_url="https://api-beijing.klingai.com/v1",
+        )
+
+    @patch("lib.video_backends.registry.create_backend")
+    def test_api_key_takes_priority_over_dual_secret_when_both_set(self, mock_create):
+        """两者都填时 api_key 优先（不透传 access_key/secret_key），见 issue #1074 desired behavior。"""
+        spec = get_provider_spec("kling", "video")
+        config = LoadedConfig(
+            credentials={"api_key": "sk-api-1", "access_key": "ak-1", "secret_key": "sk-1"},
+            provider_meta=PROVIDER_REGISTRY.get("kling"),
+            rate_limiter=None,
+        )
+        spec.build_backend(config, "kling-v3")
+        mock_create.assert_called_once_with(
+            "kling",
+            auth_mode="bearer",
+            api_key="sk-api-1",
+            model="kling-v3",
+            base_url="https://api-beijing.klingai.com/v1",
         )
 
 

--- a/tests/test_backend_assembly_specs.py
+++ b/tests/test_backend_assembly_specs.py
@@ -204,7 +204,7 @@ class TestGeminiSpec:
 class TestKlingSpec:
     """kling 特例族：双模式鉴权二选一（api_key 优先 → auth_mode=bearer；否则 access_key+secret_key
     → auth_mode=jwt），image 侧 api_model_name 解耦（两栖别名键读 registry api_model_name）、
-    base_url 兜底（db > registry default，国内域名已迁移至 api-beijing，见 issue #1074）。
+    base_url 兜底（db > registry default，国内域名已迁移至 api-beijing）。
     video backend 不接受 api_model_name —— 非对称，video 闭包不传。"""
 
     @patch("lib.image_backends.registry.create_backend")
@@ -323,7 +323,7 @@ class TestKlingSpec:
 
     @patch("lib.video_backends.registry.create_backend")
     def test_api_key_takes_priority_over_dual_secret_when_both_set(self, mock_create):
-        """两者都填时 api_key 优先（不透传 access_key/secret_key），见 issue #1074 desired behavior。"""
+        """两者都填时 api_key 优先（不透传 access_key/secret_key）。"""
         spec = get_provider_spec("kling", "video")
         config = LoadedConfig(
             credentials={"api_key": "sk-api-1", "access_key": "ak-1", "secret_key": "sk-1"},

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -145,3 +145,23 @@ class TestCredentialGroups:
             credential_groups=[["api_key"], ["access_key", "secret_key"]],
         )
         assert meta.credential_groups == [["api_key"], ["access_key", "secret_key"]]
+
+    def test_empty_group_rejected(self):
+        with pytest.raises(ValueError, match="空分组"):
+            ProviderMeta(
+                display_name="t",
+                description="t",
+                required_keys=["api_key", "access_key", "secret_key"],
+                secret_keys=["api_key", "access_key", "secret_key"],
+                credential_groups=[["api_key"], []],
+            )
+
+    def test_uncovered_key_rejected(self):
+        with pytest.raises(ValueError, match="未覆盖"):
+            ProviderMeta(
+                display_name="t",
+                description="t",
+                required_keys=["api_key", "access_key", "secret_key"],
+                secret_keys=["api_key", "access_key", "secret_key"],
+                credential_groups=[["api_key"]],
+            )

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -120,7 +120,7 @@ class TestModelInfoDurations:
 
 
 class TestCredentialGroups:
-    """凭证「二选一」分组声明的 fail-fast 校验（见 issue #1074）。"""
+    """凭证「二选一」分组声明的 fail-fast 校验。"""
 
     def test_default_empty(self):
         meta = ProviderMeta(display_name="t", description="t", required_keys=["api_key"], secret_keys=["api_key"])

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -1,3 +1,5 @@
+import pytest
+
 from lib.config.registry import PROVIDER_REGISTRY, ModelInfo, ProviderMeta
 
 
@@ -115,3 +117,31 @@ class TestModelInfoDurations:
         mi = ModelInfo(display_name="test", media_type="text", capabilities=[])
         assert mi.supported_durations == []
         assert mi.duration_resolution_constraints == {}
+
+
+class TestCredentialGroups:
+    """凭证「二选一」分组声明的 fail-fast 校验（见 issue #1074）。"""
+
+    def test_default_empty(self):
+        meta = ProviderMeta(display_name="t", description="t", required_keys=["api_key"], secret_keys=["api_key"])
+        assert meta.credential_groups == []
+
+    def test_group_keys_must_be_subset_of_required_and_secret(self):
+        with pytest.raises(ValueError, match="credential_groups"):
+            ProviderMeta(
+                display_name="t",
+                description="t",
+                required_keys=["api_key"],
+                secret_keys=["api_key"],
+                credential_groups=[["api_key"], ["access_key"]],
+            )
+
+    def test_valid_groups_accepted(self):
+        meta = ProviderMeta(
+            display_name="t",
+            description="t",
+            required_keys=["api_key", "access_key", "secret_key"],
+            secret_keys=["api_key", "access_key", "secret_key"],
+            credential_groups=[["api_key"], ["access_key", "secret_key"]],
+        )
+        assert meta.credential_groups == [["api_key"], ["access_key", "secret_key"]]

--- a/tests/test_kling_shared.py
+++ b/tests/test_kling_shared.py
@@ -168,6 +168,16 @@ class TestResponseParsing:
         # 提交/轮询类接口的 data（task_id / task_status 等）不含 code 键，该检查为 no-op。
         assert kling_response_error({"code": 0, "data": {"task_id": "t-1", "task_status": "submitted"}}) is None
 
+    def test_non_dict_payload_normalized_not_error(self):
+        # 中转 endpoint / 异常网关可能返回非对象 JSON（数组、字符串等），按空 dict 处理，
+        # 不因 .get() 触发 AttributeError。
+        assert kling_response_error([]) is None
+        assert kling_response_error("oops") is None
+
+    def test_non_dict_nested_data_normalized_not_error(self):
+        # data 字段本身也可能是非对象 JSON（如字符串错误信息），同样归一化为空 dict。
+        assert kling_response_error({"code": 0, "message": "", "data": "unexpected"}) is None
+
     def test_terminal_states(self):
         assert is_kling_task_terminal({"data": {"task_status": "succeed"}}) is True
         assert is_kling_task_terminal({"data": {"task_status": "failed"}}) is True

--- a/tests/test_kling_shared.py
+++ b/tests/test_kling_shared.py
@@ -108,7 +108,7 @@ class TestCredentialResolution:
 
 class TestResponseParsing:
     def test_base_url_constant(self):
-        assert KLING_BASE_URL == "https://api.klingai.com/v1"
+        assert KLING_BASE_URL == "https://api-beijing.klingai.com/v1"
 
     def test_extract_task_id(self):
         payload = {"code": 0, "message": "SUCCEED", "data": {"task_id": "t-1", "task_status": "submitted"}}

--- a/tests/test_kling_shared.py
+++ b/tests/test_kling_shared.py
@@ -15,6 +15,7 @@ from lib.kling_shared import (
     extract_kling_task_id,
     extract_kling_video_url,
     is_kling_task_terminal,
+    kling_auth_mode,
     kling_bearer_headers,
     kling_response_error,
     kling_task_failure_reason,
@@ -90,6 +91,25 @@ class TestBearerMode:
         headers = kling_bearer_headers("static-api-key")
         # bearer 模式旁路 JWT：Authorization 直接是静态 key，不是签名 token
         assert headers["Authorization"] == "Bearer static-api-key"
+
+
+class TestAuthModeDispatch:
+    """kling_auth_mode：内置 provider 构造与连接测试共用的凭证形态判定（api_key 优先）。"""
+
+    def test_api_key_present_dispatches_bearer(self):
+        assert kling_auth_mode({"api_key": "sk-1", "access_key": None, "secret_key": None}) == "bearer"
+
+    def test_only_dual_secret_dispatches_jwt(self):
+        assert kling_auth_mode({"api_key": None, "access_key": "ak-1", "secret_key": "sk-1"}) == "jwt"
+
+    def test_both_set_prefers_bearer(self):
+        assert kling_auth_mode({"api_key": "sk-1", "access_key": "ak-1", "secret_key": "sk-1"}) == "bearer"
+
+    def test_empty_api_key_falls_back_to_jwt(self):
+        assert kling_auth_mode({"api_key": "", "access_key": "ak-1", "secret_key": "sk-1"}) == "jwt"
+
+    def test_neither_set_falls_back_to_jwt(self):
+        assert kling_auth_mode({}) == "jwt"
 
 
 class TestCredentialResolution:

--- a/tests/test_kling_shared.py
+++ b/tests/test_kling_shared.py
@@ -111,6 +111,10 @@ class TestAuthModeDispatch:
     def test_neither_set_falls_back_to_jwt(self):
         assert kling_auth_mode({}) == "jwt"
 
+    def test_whitespace_only_api_key_falls_back_to_jwt(self):
+        # 纯空格 api_key 不应误判为已填写 bearer，静默吞掉同时存在的有效 AK/SK。
+        assert kling_auth_mode({"api_key": "   ", "access_key": "ak-1", "secret_key": "sk-1"}) == "jwt"
+
 
 class TestCredentialResolution:
     def test_jwt_credentials_strip_and_return(self):
@@ -150,6 +154,19 @@ class TestResponseParsing:
         assert kling_response_error({"code": "5", "message": "boom"}) == "Kling API code=5: boom"
         # 无法解析的 code 视为错误，暴露原值。
         assert kling_response_error({"code": "oops", "message": "bad"}) == "Kling API code=oops: bad"
+
+    def test_inner_data_code_error(self):
+        # account/costs 等接口顶层 code=0 通过后，data 内嵌的业务级 code/msg 仍需暴露。
+        payload = {"code": 0, "message": "", "data": {"code": 1234, "msg": "resource pack not found"}}
+        assert kling_response_error(payload) == "Kling API code=1234: resource pack not found"
+
+    def test_inner_data_code_zero_not_error(self):
+        payload = {"code": 0, "message": "", "data": {"code": 0, "msg": ""}}
+        assert kling_response_error(payload) is None
+
+    def test_inner_data_without_code_key_not_error(self):
+        # 提交/轮询类接口的 data（task_id / task_status 等）不含 code 键，该检查为 no-op。
+        assert kling_response_error({"code": 0, "data": {"task_id": "t-1", "task_status": "submitted"}}) is None
 
     def test_terminal_states(self):
         assert is_kling_task_terminal({"data": {"task_status": "succeed"}}) is True

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -57,11 +57,25 @@ def test_ark_agent_plan_model_id_format_differs_from_ark() -> None:
 
 
 def test_kling_credentials_and_base_url() -> None:
-    """可灵双 secret required/secret key + 默认 base_url（JWT 直连，见 ADR 0037）。"""
+    """可灵三键 required/secret key（api_key 单键 / access_key+secret_key 双键二选一）+
+    默认 base_url（国内域名已迁移至 api-beijing，见 issue #1074）。"""
     p = PROVIDER_REGISTRY["kling"]
-    assert p.required_keys == ["access_key", "secret_key"]
-    assert p.secret_keys == ["access_key", "secret_key"]
-    assert p.default_base_url == "https://api.klingai.com/v1"
+    assert p.required_keys == ["api_key", "access_key", "secret_key"]
+    assert p.secret_keys == ["api_key", "access_key", "secret_key"]
+    assert "base_url" in p.optional_keys
+    assert p.default_base_url == "https://api-beijing.klingai.com/v1"
+
+
+def test_kling_credential_groups_api_key_or_dual_secret() -> None:
+    """凭证二选一分组：api_key 单键，或 access_key+secret_key 双键（见 issue #1074）。"""
+    p = PROVIDER_REGISTRY["kling"]
+    assert p.credential_groups == [["api_key"], ["access_key", "secret_key"]]
+
+
+def test_provider_meta_credential_groups_default_empty() -> None:
+    """未声明 credential_groups 的 provider（绝大多数）保持空列表默认，语义不变。"""
+    assert PROVIDER_REGISTRY["gemini-aistudio"].credential_groups == []
+    assert PROVIDER_REGISTRY["dashscope"].credential_groups == []
 
 
 def test_kling_declares_image_and_video_max_workers() -> None:

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -58,7 +58,7 @@ def test_ark_agent_plan_model_id_format_differs_from_ark() -> None:
 
 def test_kling_credentials_and_base_url() -> None:
     """可灵三键 required/secret key（api_key 单键 / access_key+secret_key 双键二选一）+
-    默认 base_url（国内域名已迁移至 api-beijing，见 issue #1074）。"""
+    默认 base_url（国内域名已迁移至 api-beijing）。"""
     p = PROVIDER_REGISTRY["kling"]
     assert p.required_keys == ["api_key", "access_key", "secret_key"]
     assert p.secret_keys == ["api_key", "access_key", "secret_key"]
@@ -67,7 +67,7 @@ def test_kling_credentials_and_base_url() -> None:
 
 
 def test_kling_credential_groups_api_key_or_dual_secret() -> None:
-    """凭证二选一分组：api_key 单键，或 access_key+secret_key 双键（见 issue #1074）。"""
+    """凭证二选一分组：api_key 单键，或 access_key+secret_key 双键。"""
     p = PROVIDER_REGISTRY["kling"]
     assert p.credential_groups == [["api_key"], ["access_key", "secret_key"]]
 

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -877,6 +877,23 @@ class TestTestProviderConnection:
             with pytest.raises(httpx.HTTPStatusError, match="502 Bad Gateway"):
                 providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
 
+    def test_kling_test_fn_falls_back_to_raise_for_status_on_malformed_json(self):
+        """content-type 声称 JSON 但响应体非法/空（如异常网关截断）→ 解析失败不崩溃，走 raise_for_status 兜底。"""
+
+        class _MalformedJsonResponse(self._FakeKlingResponse):
+            def json(self) -> dict:
+                raise ValueError("Expecting value: line 1 column 1 (char 0)")
+
+            def raise_for_status(self) -> None:
+                raise httpx.HTTPStatusError("504 Gateway Timeout", request=MagicMock(), response=MagicMock())
+
+        def _fake_get(url, params=None, headers=None, timeout=None):
+            return _MalformedJsonResponse({})
+
+        with patch("httpx.get", _fake_get):
+            with pytest.raises(httpx.HTTPStatusError, match="504 Gateway Timeout"):
+                providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
+
     def test_kling_test_fn_raises_on_inner_data_code_error(self):
         """顶层 code=0 但 data 内嵌业务级 code != 0（如资源包查询失败）→ 同样 RuntimeError。"""
 

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -763,8 +764,9 @@ class TestTestProviderConnection:
         assert "kling" in providers._TEST_DISPATCH
 
     class _FakeKlingResponse:
-        def __init__(self, payload: dict):
+        def __init__(self, payload: dict, *, content_type: str = "application/json"):
             self._payload = payload
+            self.headers = {"content-type": content_type}
 
         def raise_for_status(self) -> None:
             pass
@@ -845,6 +847,34 @@ class TestTestProviderConnection:
 
         with patch("httpx.get", _fake_get):
             with pytest.raises(RuntimeError, match="auth failed"):
+                providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
+
+    def test_kling_test_fn_prefers_json_body_error_over_raise_for_status(self):
+        """HTTP 状态非 2xx 但响应体带 JSON 业务错误 → 优先暴露具体原因，而非泛化的 HTTP 状态文案。"""
+
+        class _FailingResponse(self._FakeKlingResponse):
+            def raise_for_status(self) -> None:
+                raise httpx.HTTPStatusError("401 Unauthorized", request=MagicMock(), response=MagicMock())
+
+        def _fake_get(url, params=None, headers=None, timeout=None):
+            return _FailingResponse({"code": 1101, "message": "access key not found", "data": {}})
+
+        with patch("httpx.get", _fake_get):
+            with pytest.raises(RuntimeError, match="access key not found"):
+                providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
+
+    def test_kling_test_fn_raises_http_status_error_when_body_not_json(self):
+        """非 JSON 响应体（如网关错误页）跳过业务错误解析，走 raise_for_status 兜底暴露 HTTP 状态。"""
+
+        class _FailingResponse(self._FakeKlingResponse):
+            def raise_for_status(self) -> None:
+                raise httpx.HTTPStatusError("502 Bad Gateway", request=MagicMock(), response=MagicMock())
+
+        def _fake_get(url, params=None, headers=None, timeout=None):
+            return _FailingResponse({}, content_type="text/html")
+
+        with patch("httpx.get", _fake_get):
+            with pytest.raises(httpx.HTTPStatusError, match="502 Bad Gateway"):
                 providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
 
     def test_kling_test_fn_raises_on_inner_data_code_error(self):

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -355,7 +355,7 @@ class TestGetProviderConfig:
         assert "secret_key" not in field_keys
 
     def test_secret_field_groups_kling_api_key_or_dual_secret(self):
-        """可灵 secret_field_groups 二选一分组：[api_key] 或 [access_key, secret_key]（见 issue #1074）。"""
+        """可灵 secret_field_groups 二选一分组：[api_key] 或 [access_key, secret_key]。"""
         app, _ = _make_session_app()
         with (
             patch("server.routers.providers.ConfigService", return_value=self._mock_svc_empty()),

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -380,7 +380,11 @@ class TestGetProviderConfig:
         assert resp.json()["secret_field_groups"] == [["api_key"]]
 
     def test_secret_fields_vertex_empty(self):
-        """gemini-vertex 凭证是文件路径（非 secret）→ secret_fields 为空，前端走文件上传。"""
+        """gemini-vertex 凭证是文件路径（非 secret）→ secret_fields 为空，前端走文件上传。
+
+        secret_field_groups 回退不合成 [[]]（与 registry.py 的空分组 fail-fast 语义对称，
+        避免未来"无 secret 字段但走普通凭证表单"的 provider 因空分组恒真而绕过校验）。
+        """
         app, _ = _make_session_app()
         with (
             patch("server.routers.providers.ConfigService", return_value=self._mock_svc_empty()),
@@ -390,7 +394,7 @@ class TestGetProviderConfig:
                 resp = client.get("/api/v1/providers/gemini-vertex/config")
         assert resp.status_code == 200
         assert resp.json()["secret_fields"] == []
-        assert resp.json()["secret_field_groups"] == [[]]
+        assert resp.json()["secret_field_groups"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -847,6 +847,18 @@ class TestTestProviderConnection:
             with pytest.raises(RuntimeError, match="auth failed"):
                 providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
 
+    def test_kling_test_fn_raises_on_inner_data_code_error(self):
+        """顶层 code=0 但 data 内嵌业务级 code != 0（如资源包查询失败）→ 同样 RuntimeError。"""
+
+        def _fake_get(url, params=None, headers=None, timeout=None):
+            return self._FakeKlingResponse(
+                {"code": 0, "message": "", "data": {"code": 1234, "msg": "resource pack not found"}}
+            )
+
+        with patch("httpx.get", _fake_get):
+            with pytest.raises(RuntimeError, match="resource pack not found"):
+                providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
+
     def test_kling_connection_test_via_router_with_api_key_only(self):
         """端到端：只填 api_key 的可灵凭证通过 /test 端点即可测通（验收标准之一）。
 

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 
 from lib.config.service import ConfigService, ProviderStatus
 from lib.db import get_async_session
+from lib.db.models.credential import ProviderCredential
 from lib.db.repositories.credential_repository import CredentialRepository
 from lib.i18n import get_translator
 from server.dependencies import get_config_service
@@ -334,8 +335,8 @@ class TestGetProviderConfig:
         assert resp.status_code == 200
         assert [f["key"] for f in resp.json()["secret_fields"]] == ["api_key"]
 
-    def test_secret_fields_kling_two_ordered_secrets(self):
-        """可灵 → secret_fields = [access_key, secret_key]（保留 required_keys 顺序）。"""
+    def test_secret_fields_kling_three_ordered_secrets(self):
+        """可灵 → secret_fields = [api_key, access_key, secret_key]（保留 required_keys 顺序）。"""
         app, _ = _make_session_app()
         with (
             patch("server.routers.providers.ConfigService", return_value=self._mock_svc_empty()),
@@ -345,12 +346,37 @@ class TestGetProviderConfig:
                 resp = client.get("/api/v1/providers/kling/config")
         assert resp.status_code == 200
         secret_fields = resp.json()["secret_fields"]
-        assert [f["key"] for f in secret_fields] == ["access_key", "secret_key"]
-        assert [f["label"] for f in secret_fields] == ["Access Key", "Secret Key"]
-        # 两 secret 走凭证表单，不进 advanced fields
+        assert [f["key"] for f in secret_fields] == ["api_key", "access_key", "secret_key"]
+        assert [f["label"] for f in secret_fields] == ["API Key", "Access Key", "Secret Key"]
+        # 三 secret 走凭证表单，不进 advanced fields
         field_keys = {f["key"] for f in resp.json()["fields"]}
+        assert "api_key" not in field_keys
         assert "access_key" not in field_keys
         assert "secret_key" not in field_keys
+
+    def test_secret_field_groups_kling_api_key_or_dual_secret(self):
+        """可灵 secret_field_groups 二选一分组：[api_key] 或 [access_key, secret_key]（见 issue #1074）。"""
+        app, _ = _make_session_app()
+        with (
+            patch("server.routers.providers.ConfigService", return_value=self._mock_svc_empty()),
+            patch("server.routers.providers.CredentialRepository", return_value=self._mock_cred_repo_empty()),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/api/v1/providers/kling/config")
+        assert resp.status_code == 200
+        assert resp.json()["secret_field_groups"] == [["api_key"], ["access_key", "secret_key"]]
+
+    def test_secret_field_groups_single_secret_provider_falls_back_to_one_group(self):
+        """未声明 credential_groups 的 provider → secret_field_groups 回退为 [全部 secret_fields] 单组。"""
+        app, _ = _make_session_app()
+        with (
+            patch("server.routers.providers.ConfigService", return_value=self._mock_svc_empty()),
+            patch("server.routers.providers.CredentialRepository", return_value=self._mock_cred_repo_empty()),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/api/v1/providers/gemini-aistudio/config")
+        assert resp.status_code == 200
+        assert resp.json()["secret_field_groups"] == [["api_key"]]
 
     def test_secret_fields_vertex_empty(self):
         """gemini-vertex 凭证是文件路径（非 secret）→ secret_fields 为空，前端走文件上传。"""
@@ -363,6 +389,7 @@ class TestGetProviderConfig:
                 resp = client.get("/api/v1/providers/gemini-vertex/config")
         assert resp.status_code == 200
         assert resp.json()["secret_fields"] == []
+        assert resp.json()["secret_field_groups"] == [[]]
 
 
 # ---------------------------------------------------------------------------
@@ -729,6 +756,118 @@ class TestTestProviderConnection:
         # 仅暴露 minimax/abab 模型，过滤掉 embedding 等
         assert resp.available_models == ["MiniMax-M2.7", "abab6.5s-chat"]
         assert resp.success is True
+
+    def test_kling_registered_in_dispatch(self):
+        # kling 作为内置 provider 暴露在设置页，连接测试必须有 dispatcher，
+        # 否则点"测试连接"会落到 unsupported_test 分支（即便凭证有效）
+        assert "kling" in providers._TEST_DISPATCH
+
+    class _FakeKlingResponse:
+        def __init__(self, payload: dict):
+            self._payload = payload
+
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict:
+            return self._payload
+
+    def test_kling_test_fn_uses_bearer_when_api_key_set(self):
+        """填了 api_key → bearer 静态头，不走 JWT（与 _build_kling 的优先级一致）。"""
+        captured: dict = {}
+
+        def _fake_get(url, params=None, headers=None, timeout=None):
+            captured.update(url=url, params=params, headers=headers, timeout=timeout)
+            return self._FakeKlingResponse({"code": 0, "message": "", "data": {}})
+
+        with patch("httpx.get", _fake_get):
+            resp = providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
+        assert resp.success is True
+        assert captured["headers"]["Authorization"] == "Bearer sk-kling"
+        # account/costs 挂域名根路径，不带 /v1；默认 base_url 已迁移至 api-beijing
+        assert captured["url"] == "https://api-beijing.klingai.com/account/costs"
+        assert "start_time" in captured["params"]
+        assert "end_time" in captured["params"]
+
+    def test_kling_test_fn_uses_jwt_when_only_dual_secret_set(self):
+        """只填 access_key + secret_key（无 api_key）→ JWT Bearer token（三段式）。"""
+        captured: dict = {}
+
+        def _fake_get(url, params=None, headers=None, timeout=None):
+            captured.update(headers=headers)
+            return self._FakeKlingResponse({"code": 0, "message": "", "data": {}})
+
+        with patch("httpx.get", _fake_get):
+            resp = providers._test_kling({"access_key": "ak-1", "secret_key": "s" * 40}, lambda k, **kw: k)
+        assert resp.success is True
+        auth = captured["headers"]["Authorization"]
+        assert auth.startswith("Bearer ")
+        assert auth.removeprefix("Bearer ").count(".") == 2  # JWT: header.payload.signature
+
+    def test_kling_test_fn_api_key_takes_priority_when_both_set(self):
+        """两者都填时 api_key 优先，与 _build_kling 分派顺序一致。"""
+        captured: dict = {}
+
+        def _fake_get(url, params=None, headers=None, timeout=None):
+            captured.update(headers=headers)
+            return self._FakeKlingResponse({"code": 0, "message": "", "data": {}})
+
+        with patch("httpx.get", _fake_get):
+            providers._test_kling(
+                {"api_key": "sk-kling", "access_key": "ak-1", "secret_key": "s" * 40}, lambda k, **kw: k
+            )
+        assert captured["headers"]["Authorization"] == "Bearer sk-kling"
+
+    def test_kling_test_fn_strips_v1_suffix_for_account_costs_root_path(self):
+        """自定义 base_url 带 /v1 后缀 → account/costs 请求剥离该后缀，落到域名根路径。"""
+        captured: dict = {}
+
+        def _fake_get(url, params=None, headers=None, timeout=None):
+            captured.update(url=url)
+            return self._FakeKlingResponse({"code": 0, "message": "", "data": {}})
+
+        with patch("httpx.get", _fake_get):
+            providers._test_kling(
+                {"api_key": "sk-kling", "base_url": "https://relay.example.com/v1"}, lambda k, **kw: k
+            )
+        assert captured["url"] == "https://relay.example.com/account/costs"
+
+    def test_kling_test_fn_raises_clear_error_when_no_credentials(self):
+        """两种凭证形态都未填 → 明确报错（不静默发出无鉴权请求）。"""
+        with pytest.raises(ValueError, match="Access Key"):
+            providers._test_kling({}, lambda k, **kw: k)
+
+    def test_kling_test_fn_raises_on_code_error(self):
+        """响应 code != 0 → RuntimeError 携带官方错误信息，经上层转 connection_failed 文案。"""
+
+        def _fake_get(url, params=None, headers=None, timeout=None):
+            return self._FakeKlingResponse({"code": 1101, "message": "auth failed", "data": {}})
+
+        with patch("httpx.get", _fake_get):
+            with pytest.raises(RuntimeError, match="auth failed"):
+                providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
+
+    def test_kling_connection_test_via_router_with_api_key_only(self):
+        """端到端：只填 api_key 的可灵凭证通过 /test 端点即可测通（验收标准之一）。
+
+        用真实 ProviderCredential（而非 MagicMock）：路由调用 cred.overlay_config(config) 靠
+        真实方法把 api_key 合入 config dict，MagicMock 的 overlay_config 不会真的修改 config。
+        """
+        cred = ProviderCredential(provider="kling", name="可灵账号", api_key="sk-kling", is_active=True)
+        repo = MagicMock(spec=CredentialRepository)
+        repo.get_by_id = AsyncMock(return_value=cred)
+        repo.get_active = AsyncMock(return_value=cred)
+
+        app, _ = _make_session_app()
+        with (
+            patch("server.routers.providers.CredentialRepository", return_value=repo),
+            patch("server.routers.providers.ConfigService", return_value=self._mock_svc()),
+            patch("httpx.get", return_value=self._FakeKlingResponse({"code": 0, "message": "", "data": {}})),
+        ):
+            with TestClient(app) as client:
+                resp = client.post("/api/v1/providers/kling/test")
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
 
     def test_specific_credential_id(self):
         """使用 credential_id 参数测试特定凭证。"""


### PR DESCRIPTION
## Summary

- 可灵内置供应商新增 API Key（Bearer）单密钥鉴权模式，与既有 Access Key + Secret Key（JWT）二选一；同时填写时 API Key 优先，存量 AK/SK 用户零迁移、行为不变
- 默认调用域名由 `api.klingai.com` 迁移到官方新域名 `api-beijing.klingai.com`（旧域名仍可用，仅影响未显式配置 base_url 的用户）
- 放开可灵 base_url 手动配置（覆盖国际站/中转代理等场景）
- 设置页凭证表单支持"至少一组字段全填"的二选一校验，新增连接测试（`GET /account/costs`，只读免费）
- 新增文案 zh/en/vi 三语齐备

Closes #1074

## 验证说明

- `uv run pytest`：5736 passed（含本次新增用例）
- `uv run ruff check . && uv run ruff format --check .`：全绿
- `uv run basedpyright`：0 errors
- 前端 `pnpm check`（typecheck + eslint + vitest）：全绿
- 本地审查复核 issue 验收标准逐条核对，修复过期文档引用（`docs/getting-started.md` 凭证说明、代码注释里已过期的字段数描述），并将 `_build_kling`/`_test_kling` 重复的"api_key 优先"分派逻辑收口到共享 `kling_auth_mode` helper（含新增单测）
- `_test_kling` 未用真实凭证跑通（issue 验收标准注明"真实凭证由维护者验证"）

## Test plan

- [x] 后端全量测试通过
- [x] 前端全量测试通过（含新增 OR 分组校验用例）
- [x] ruff / basedpyright 质量门通过
- [ ] 维护者用真实可灵凭证验证连接测试与实际生成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 可灵供应商凭证支持“API Key 或 Access Key + Secret Key”二选一分组，并在新增表单中按分组提示与引导。
  * 可灵连接测试根据凭证形态自动选择鉴权方式并执行连通性校验。
* **改进**
  * 凭据校验调整为“至少完整填写一组”；表单仅提交已满足分组的鉴权字段。
  * 可灵默认服务域名切换为北京域名，并按凭证形态切换鉴权逻辑。
* **文案与文档**
  * 更新中英文及越南语提示文案；文档同步说明“API Key 或双密钥（二选一）”，并更新可灵提供商描述。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->