### PR TITLE
fix(custom-provider): 补全挂载路径下的 Seedance API root

### DIFF
--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -150,8 +150,8 @@ def _build_newapi_video(provider, model_id: str) -> CustomVideoBackend:
 
 
 def _ensure_url_path_suffix(base_url: str | None, suffix: str) -> str | None:
-    """用户只填到 host 时补全协议已知挂载路径（ark /api/v3、vidu /ent/v2、kling /v1）；
-    已带显式路径则原样信任，避免错误叠加。供 ark/vidu/kling 闭包复用。
+    """补全协议已知挂载路径（ark /api/v3、vidu /ent/v2、kling /v1）；
+    已带对应协议路径则原样信任，避免重复叠加。供 ark/vidu/kling 闭包复用。
 
     纯域名（无 scheme，如 ``relay.example.com``）会被 urlsplit 整体当作 path，
     先补 ``https://`` 再判定，否则 host-only 配置既补不上协议也挂不上路径。
@@ -160,9 +160,9 @@ def _ensure_url_path_suffix(base_url: str | None, suffix: str) -> str | None:
     if not s:
         return None
     normalized = s if "://" in s else f"https://{s}"
-    if urlsplit(normalized).path in ("", "/"):
-        return normalized + suffix
-    return normalized
+    if urlsplit(normalized).path.rstrip("/").endswith(suffix):
+        return normalized
+    return normalized + suffix
 
 
 def _build_v2_video_generations(provider, model_id: str) -> CustomVideoBackend:

--- a/tests/test_custom_provider_factory.py
+++ b/tests/test_custom_provider_factory.py
@@ -257,6 +257,14 @@ class TestUrlNormalization:
             api_key="sk-test", base_url="https://relay.example.com/api/v3", model="doubao-seedance-2-0"
         )
 
+    @patch("lib.custom_provider.endpoints.ArkVideoBackend")
+    def test_ark_mounted_base_url_appends_api_v3(self, mock_cls):
+        provider = _make_provider(base_url="https://relay.example.com/seedance")
+        create_custom_backend(provider=provider, model_id="doubao-seedance-2-0", endpoint="ark-seedance")
+        mock_cls.assert_called_once_with(
+            api_key="sk-test", base_url="https://relay.example.com/seedance/api/v3", model="doubao-seedance-2-0"
+        )
+
     @patch("lib.custom_provider.endpoints.ViduVideoBackend")
     def test_vidu_explicit_path_passthrough(self, mock_cls):
         provider = _make_provider(base_url="https://api.vidu.cn/ent/v2")


### PR DESCRIPTION
## 范围

修复自定义供应商选择「火山方舟 (Seedance)」时，第三方网关带挂载路径的 Base URL 没有自动补全 `/api/v3` 的问题。

不涉及前端展示、数据库 schema、用户配置模型或真实服务调用逻辑改动。

## 变更

- 调整 `lib/custom_provider/endpoints.py` 的协议路径补全逻辑：只要 URL path 未以目标 suffix 结尾，就追加该 suffix。
- 增加 `ark-seedance` 回归测试，覆盖 `https://relay.example.com/seedance -> https://relay.example.com/seedance/api/v3`。

## 验收清单

- [x] 本地已跑相关测试（`conda run -n arcreel python -m pytest tests/test_custom_provider_factory.py tests/test_custom_provider_endpoints.py -q`，133 passed）
- [x] 手动验证了改动所声称的行为（新增回归测试先 RED，修复后 GREEN；确认 mounted base URL 会补 `/api/v3`）
- [x] 新增面向用户文案已加 zh/en 翻译（不适用，未新增用户文案）
- [x] 无新增 ESLint disable；若有，已在本 PR 底部以表格列出 `rule | file:line | 理由`（不适用，未改前端/ESLint）
- [x] CODEOWNERS 要求的 review 已请求（不适用，未触发明确 CODEOWNERS 指派）

## 已知 defer

无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了自定义服务地址的路径归一化逻辑，避免在基础地址已包含目标路径时重复追加。
  * 当地址已带有对应挂载路径时，系统现在会直接沿用原地址，减少配置下的访问错误。
  * 新增覆盖测试，验证带有子路径的服务地址在相关端点下可正确补全路径。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->