### PR TITLE
refactor(server): 前端页面服务改用 FastAPI 原生挂载，写请求误入页面路径不再返回页面

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     "claude-agent-sdk>=0.1.76",
     "ffmpeg-python>=0.2.0",
-    "fastapi>=0.135.1",
+    "fastapi>=0.138.2",
     "google-genai>=1.65.0",
     "Pillow>=12.1.1",
     "pydantic>=2.12.5",

--- a/server/app.py
+++ b/server/app.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -600,11 +601,22 @@ async def serve_skill_md(request: Request) -> Response:
     return PlainTextResponse(content, media_type="text/markdown; charset=utf-8")
 
 
-# 前端构建产物：SPA 静态文件服务。fallback 仅对 GET/HEAD 生效，写请求误入页面路径返回 404
+# 前端构建产物：SPA 静态文件服务。fallback 仅对 GET/HEAD 生效，写请求误入页面路径不再返回页面。
+# 挂载条件必须检查 index.html 而非目录：app.frontend 在启动期校验 fallback 文件，
+# 构建产物不完整时会抛 RuntimeError 拖垮整个应用（含全部 API）
 frontend_dist_dir = PROJECT_ROOT / "frontend" / "dist"
 
-if frontend_dist_dir.exists():
+if (frontend_dist_dir / "index.html").is_file():
+
+    @app.get("/app/{_rest:path}", include_in_schema=False)
+    async def spa_deep_link(_rest: str) -> FileResponse:
+        # SPA 深链末段可能带扩展名（如 /app/projects/x/source/chapter1.txt），
+        # app.frontend 的 fallback 会将其判为静态资源请求返回 404，此处显式兜底回 SPA 外壳
+        return FileResponse(frontend_dist_dir / "index.html")
+
     app.frontend("/", directory=frontend_dist_dir, fallback="index.html")
+else:
+    logger.warning("frontend/dist/index.html 不存在，跳过前端页面挂载（API 不受影响）")
 
 
 if __name__ == "__main__":

--- a/server/app.py
+++ b/server/app.py
@@ -21,8 +21,6 @@ from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
-from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -602,24 +600,11 @@ async def serve_skill_md(request: Request) -> Response:
     return PlainTextResponse(content, media_type="text/markdown; charset=utf-8")
 
 
-# 前端构建产物：SPA 静态文件服务（必须在所有显式路由之后挂载）
+# 前端构建产物：SPA 静态文件服务。fallback 仅对 GET/HEAD 生效，写请求误入页面路径返回 404
 frontend_dist_dir = PROJECT_ROOT / "frontend" / "dist"
 
-
-class SPAStaticFiles(StaticFiles):
-    """服务 Vite 构建产物，未匹配的路径回退到 index.html（SPA 路由）。"""
-
-    async def get_response(self, path: str, scope):
-        try:
-            return await super().get_response(path, scope)
-        except StarletteHTTPException as exc:
-            if exc.status_code == 404:
-                return await super().get_response("index.html", scope)
-            raise
-
-
 if frontend_dist_dir.exists():
-    app.mount("/", SPAStaticFiles(directory=frontend_dist_dir, html=True), name="frontend")
+    app.frontend("/", directory=frontend_dist_dir, fallback="index.html")
 
 
 if __name__ == "__main__":

--- a/server/app.py
+++ b/server/app.py
@@ -601,6 +601,21 @@ async def serve_skill_md(request: Request) -> Response:
     return PlainTextResponse(content, media_type="text/markdown; charset=utf-8")
 
 
+@app.middleware("http")
+async def spa_shell_no_cache_middleware(request: Request, call_next):
+    """SPA 入口 HTML 外壳禁止浏览器缓存。
+
+    覆盖 spa_deep_link 与 app.frontend 原生 fallback 两条路径共用的响应特征
+    （text/html），否则重新部署后浏览器可能沿用旧壳加载已被删除的旧哈希资源，
+    导致白屏——按 content-type 而非按路由判定，才能同时管住 "/"、"/login" 等
+    落在原生 fallback 上的入口。
+    """
+    response: Response = await call_next(request)
+    if response.headers.get("content-type", "").startswith("text/html"):
+        response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    return response
+
+
 # 前端构建产物：SPA 静态文件服务。fallback 仅对 GET/HEAD 生效，写请求误入页面路径不再返回页面。
 # 挂载条件必须检查 index.html 而非目录：app.frontend 在启动期校验 fallback 文件，
 # 构建产物不完整时会抛 RuntimeError 拖垮整个应用（含全部 API）

--- a/server/app.py
+++ b/server/app.py
@@ -645,7 +645,14 @@ if (frontend_dist_dir / "index.html").is_file():
     @app.get("/app/{_rest:path}", include_in_schema=False)
     async def spa_deep_link(_rest: str) -> FileResponse:
         # SPA 深链末段可能带扩展名（如 /app/projects/x/source/chapter1.txt），
-        # app.frontend 的 fallback 会将其判为静态资源请求返回 404，此处显式兜底回 SPA 外壳
+        # app.frontend 的 fallback 会将其判为静态资源请求返回 404，此处显式兜底回 SPA 外壳。
+        # 本路由注册在 app.frontend 之前，/app/ 下任何请求都会先到这里——若构建产物中
+        # 恰好存在 dist/app/... 下的真实静态文件（URL 路径与 app.frontend 的映射规则一致，
+        # 即相对 dist 根目录同路径），须优先返回该文件，避免被无条件遮蔽；resolve() 后校验
+        # 仍在 frontend_dist_dir 内，防止 _rest 携带 "../" 越界读取
+        candidate = (frontend_dist_dir / "app" / _rest).resolve()
+        if candidate.is_relative_to(frontend_dist_dir.resolve()) and candidate.is_file():
+            return FileResponse(candidate)
         return FileResponse(frontend_dist_dir / "index.html")
 
     app.frontend("/", directory=frontend_dist_dir, fallback="index.html")

--- a/server/app.py
+++ b/server/app.py
@@ -648,10 +648,13 @@ if (frontend_dist_dir / "index.html").is_file():
         # app.frontend 的 fallback 会将其判为静态资源请求返回 404，此处显式兜底回 SPA 外壳。
         # 本路由注册在 app.frontend 之前，/app/ 下任何请求都会先到这里——若构建产物中
         # 恰好存在 dist/app/... 下的真实静态文件（URL 路径与 app.frontend 的映射规则一致，
-        # 即相对 dist 根目录同路径），须优先返回该文件，避免被无条件遮蔽；resolve() 后校验
-        # 仍在 frontend_dist_dir 内，防止 _rest 携带 "../" 越界读取
-        candidate = (frontend_dist_dir / "app" / _rest).resolve()
-        if candidate.is_relative_to(frontend_dist_dir.resolve()) and candidate.is_file():
+        # 即相对 dist 根目录同路径），须优先返回该文件，避免被无条件遮蔽。
+        # normpath + startswith 做越界守卫而非 resolve()/is_relative_to()：纯字符串规范化，
+        # 且是 CodeQL py/path-injection 能识别的收敛模式（resolve/is_relative_to 不被识别，
+        # 参见 jianying_draft_service.py 同类注释）
+        app_static_root = os.path.normpath(str(frontend_dist_dir / "app"))
+        candidate = os.path.normpath(os.path.join(app_static_root, _rest))
+        if candidate.startswith(app_static_root + os.sep) and os.path.isfile(candidate):
             return FileResponse(candidate)
         return FileResponse(frontend_dist_dir / "index.html")
 

--- a/server/app.py
+++ b/server/app.py
@@ -22,8 +22,10 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
+from starlette.datastructures import MutableHeaders
 from starlette.requests import Request
 from starlette.responses import Response
+from starlette.types import Message, Receive, Scope, Send
 
 from lib import PROJECT_ROOT
 from lib.agent_session_store import session_store_enabled
@@ -601,19 +603,36 @@ async def serve_skill_md(request: Request) -> Response:
     return PlainTextResponse(content, media_type="text/markdown; charset=utf-8")
 
 
-@app.middleware("http")
-async def spa_shell_no_cache_middleware(request: Request, call_next):
+class SPAShellNoCacheMiddleware:
     """SPA 入口 HTML 外壳禁止浏览器缓存。
 
     覆盖 spa_deep_link 与 app.frontend 原生 fallback 两条路径共用的响应特征
     （text/html），否则重新部署后浏览器可能沿用旧壳加载已被删除的旧哈希资源，
     导致白屏——按 content-type 而非按路由判定，才能同时管住 "/"、"/login" 等
-    落在原生 fallback 上的入口。
+    落在原生 fallback 上的入口。纯 ASGI 实现而非 BaseHTTPMiddleware：这是个作用于
+    全部请求的全局中间件，BaseHTTPMiddleware 的 anyio TaskGroup + contextvars
+    复制机制会给每个请求引入额外开销。
     """
-    response: Response = await call_next(request)
-    if response.headers.get("content-type", "").lower().startswith("text/html"):
-        response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
-    return response
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                if headers.get("content-type", "").lower().startswith("text/html"):
+                    headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
+app.add_middleware(SPAShellNoCacheMiddleware)
 
 
 # 前端构建产物：SPA 静态文件服务。fallback 仅对 GET/HEAD 生效，写请求误入页面路径不再返回页面。

--- a/server/app.py
+++ b/server/app.py
@@ -611,7 +611,7 @@ async def spa_shell_no_cache_middleware(request: Request, call_next):
     落在原生 fallback 上的入口。
     """
     response: Response = await call_next(request)
-    if response.headers.get("content-type", "").startswith("text/html"):
+    if response.headers.get("content-type", "").lower().startswith("text/html"):
         response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
     return response
 

--- a/tests/test_frontend_mount.py
+++ b/tests/test_frontend_mount.py
@@ -1,0 +1,72 @@
+"""前端构建产物挂载行为测试（server/app.py 的 frontend_dist_dir 分支）。"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+import lib
+from server import app as app_module
+
+
+async def test_deep_link_with_extension_falls_back_to_index_html(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """构建产物存在时，带扩展名的 SPA 深链应回退到 index.html 而非被当作静态资源返回 404。"""
+    dist_dir = tmp_path / "frontend" / "dist"
+    dist_dir.mkdir(parents=True)
+    (dist_dir / "index.html").write_text("<html>shell</html>", encoding="utf-8")
+    monkeypatch.setattr(lib, "PROJECT_ROOT", tmp_path)
+    importlib.reload(app_module)
+    try:
+        transport = ASGITransport(app=app_module.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            res = await client.get("/app/projects/demo/source/chapter1.txt")
+            assert res.status_code == 200
+            assert "shell" in res.text
+    finally:
+        monkeypatch.undo()
+        importlib.reload(app_module)
+
+
+async def test_missing_index_html_skips_mount_without_crashing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """构建产物目录缺 index.html 时跳过前端挂载，应用仍能正常启动且 API 不受影响。"""
+    dist_dir = tmp_path / "frontend" / "dist"
+    dist_dir.mkdir(parents=True)
+    monkeypatch.setattr(lib, "PROJECT_ROOT", tmp_path)
+    importlib.reload(app_module)
+    try:
+        transport = ASGITransport(app=app_module.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            res = await client.get("/app/anything")
+            assert res.status_code == 404
+    finally:
+        monkeypatch.undo()
+        importlib.reload(app_module)
+
+
+async def test_spa_shell_responses_are_never_cached(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """SPA 外壳（无论走 spa_deep_link 还是 app.frontend 原生 fallback）都不能被浏览器缓存，
+    否则重新部署后旧壳会引用已被删除的旧哈希资源导致白屏。
+    """
+    dist_dir = tmp_path / "frontend" / "dist"
+    dist_dir.mkdir(parents=True)
+    (dist_dir / "index.html").write_text("<html>shell</html>", encoding="utf-8")
+    monkeypatch.setattr(lib, "PROJECT_ROOT", tmp_path)
+    importlib.reload(app_module)
+    try:
+        transport = ASGITransport(app=app_module.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # 带扩展名的深链：命中我们自己注册的 spa_deep_link 路由
+            deep_link_res = await client.get("/app/projects/demo/source/chapter1.txt")
+            assert deep_link_res.status_code == 200
+            assert deep_link_res.headers["cache-control"] == "no-store, no-cache, must-revalidate, max-age=0"
+
+            # 根路径：命中 app.frontend 原生 fallback（非我们自己的路由）
+            root_res = await client.get("/", headers={"accept": "text/html"})
+            assert root_res.status_code == 200
+            assert root_res.headers["cache-control"] == "no-store, no-cache, must-revalidate, max-age=0"
+    finally:
+        monkeypatch.undo()
+        importlib.reload(app_module)

--- a/tests/test_frontend_mount.py
+++ b/tests/test_frontend_mount.py
@@ -30,6 +30,28 @@ async def test_deep_link_with_extension_falls_back_to_index_html(monkeypatch: py
         importlib.reload(app_module)
 
 
+async def test_write_request_to_spa_path_returns_405_not_shell(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """写请求误入 SPA 页面路径（含带扩展名深链与根路径）应返回 405，而非 SPA 外壳。"""
+    dist_dir = tmp_path / "frontend" / "dist"
+    dist_dir.mkdir(parents=True)
+    (dist_dir / "index.html").write_text("<html>shell</html>", encoding="utf-8")
+    monkeypatch.setattr(lib, "PROJECT_ROOT", tmp_path)
+    importlib.reload(app_module)
+    try:
+        transport = ASGITransport(app=app_module.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            deep_link_res = await client.put("/app/projects/demo/source/chapter1.txt")
+            assert deep_link_res.status_code == 405
+            assert "shell" not in deep_link_res.text
+
+            root_res = await client.post("/")
+            assert root_res.status_code == 405
+            assert "shell" not in root_res.text
+    finally:
+        monkeypatch.undo()
+        importlib.reload(app_module)
+
+
 async def test_missing_index_html_skips_mount_without_crashing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """构建产物目录缺 index.html 时跳过前端挂载，应用仍能正常启动且 API 不受影响。"""
     dist_dir = tmp_path / "frontend" / "dist"

--- a/tests/test_frontend_mount.py
+++ b/tests/test_frontend_mount.py
@@ -12,63 +12,74 @@ import lib
 from server import app as app_module
 
 
-async def test_deep_link_with_extension_falls_back_to_index_html(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+@pytest.fixture
+def reload_app_cleanup(monkeypatch: pytest.MonkeyPatch):
+    """还原 lib.PROJECT_ROOT 并重新 reload server.app，恢复成真实构建产物路径。
+
+    setup（写 index.html、monkeypatch、reload）仍留在各测试体内——顺序必须是
+    先落盘构建产物再 reload，模块顶层的 `if index.html.is_file()` 才能读到预期状态。
+    """
+    yield
+    monkeypatch.undo()
+    importlib.reload(app_module)
+
+
+async def test_deep_link_with_extension_falls_back_to_index_html(
+    reload_app_cleanup: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
     """构建产物存在时，带扩展名的 SPA 深链应回退到 index.html 而非被当作静态资源返回 404。"""
     dist_dir = tmp_path / "frontend" / "dist"
     dist_dir.mkdir(parents=True)
     (dist_dir / "index.html").write_text("<html>shell</html>", encoding="utf-8")
     monkeypatch.setattr(lib, "PROJECT_ROOT", tmp_path)
     importlib.reload(app_module)
-    try:
-        transport = ASGITransport(app=app_module.app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            res = await client.get("/app/projects/demo/source/chapter1.txt")
-            assert res.status_code == 200
-            assert "shell" in res.text
-    finally:
-        monkeypatch.undo()
-        importlib.reload(app_module)
+
+    transport = ASGITransport(app=app_module.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.get("/app/projects/demo/source/chapter1.txt")
+        assert res.status_code == 200
+        assert "shell" in res.text
 
 
-async def test_write_request_to_spa_path_returns_405_not_shell(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+async def test_write_request_to_spa_path_returns_405_not_shell(
+    reload_app_cleanup: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
     """写请求误入 SPA 页面路径（含带扩展名深链与根路径）应返回 405，而非 SPA 外壳。"""
     dist_dir = tmp_path / "frontend" / "dist"
     dist_dir.mkdir(parents=True)
     (dist_dir / "index.html").write_text("<html>shell</html>", encoding="utf-8")
     monkeypatch.setattr(lib, "PROJECT_ROOT", tmp_path)
     importlib.reload(app_module)
-    try:
-        transport = ASGITransport(app=app_module.app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            deep_link_res = await client.put("/app/projects/demo/source/chapter1.txt")
-            assert deep_link_res.status_code == 405
-            assert "shell" not in deep_link_res.text
 
-            root_res = await client.post("/")
-            assert root_res.status_code == 405
-            assert "shell" not in root_res.text
-    finally:
-        monkeypatch.undo()
-        importlib.reload(app_module)
+    transport = ASGITransport(app=app_module.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        deep_link_res = await client.put("/app/projects/demo/source/chapter1.txt")
+        assert deep_link_res.status_code == 405
+        assert "shell" not in deep_link_res.text
+
+        root_res = await client.post("/")
+        assert root_res.status_code == 405
+        assert "shell" not in root_res.text
 
 
-async def test_missing_index_html_skips_mount_without_crashing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+async def test_missing_index_html_skips_mount_without_crashing(
+    reload_app_cleanup: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
     """构建产物目录缺 index.html 时跳过前端挂载，应用仍能正常启动且 API 不受影响。"""
     dist_dir = tmp_path / "frontend" / "dist"
     dist_dir.mkdir(parents=True)
     monkeypatch.setattr(lib, "PROJECT_ROOT", tmp_path)
     importlib.reload(app_module)
-    try:
-        transport = ASGITransport(app=app_module.app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            res = await client.get("/app/anything")
-            assert res.status_code == 404
-    finally:
-        monkeypatch.undo()
-        importlib.reload(app_module)
+
+    transport = ASGITransport(app=app_module.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.get("/app/anything")
+        assert res.status_code == 404
 
 
-async def test_spa_shell_responses_are_never_cached(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+async def test_spa_shell_responses_are_never_cached(
+    reload_app_cleanup: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
     """SPA 外壳（无论走 spa_deep_link 还是 app.frontend 原生 fallback）都不能被浏览器缓存，
     否则重新部署后旧壳会引用已被删除的旧哈希资源导致白屏。
     """
@@ -77,18 +88,15 @@ async def test_spa_shell_responses_are_never_cached(monkeypatch: pytest.MonkeyPa
     (dist_dir / "index.html").write_text("<html>shell</html>", encoding="utf-8")
     monkeypatch.setattr(lib, "PROJECT_ROOT", tmp_path)
     importlib.reload(app_module)
-    try:
-        transport = ASGITransport(app=app_module.app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            # 带扩展名的深链：命中我们自己注册的 spa_deep_link 路由
-            deep_link_res = await client.get("/app/projects/demo/source/chapter1.txt")
-            assert deep_link_res.status_code == 200
-            assert deep_link_res.headers["cache-control"] == "no-store, no-cache, must-revalidate, max-age=0"
 
-            # 根路径：命中 app.frontend 原生 fallback（非我们自己的路由）
-            root_res = await client.get("/", headers={"accept": "text/html"})
-            assert root_res.status_code == 200
-            assert root_res.headers["cache-control"] == "no-store, no-cache, must-revalidate, max-age=0"
-    finally:
-        monkeypatch.undo()
-        importlib.reload(app_module)
+    transport = ASGITransport(app=app_module.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # 带扩展名的深链：命中我们自己注册的 spa_deep_link 路由
+        deep_link_res = await client.get("/app/projects/demo/source/chapter1.txt")
+        assert deep_link_res.status_code == 200
+        assert deep_link_res.headers["cache-control"] == "no-store, no-cache, must-revalidate, max-age=0"
+
+        # 根路径：命中 app.frontend 原生 fallback（非我们自己的路由）
+        root_res = await client.get("/", headers={"accept": "text/html"})
+        assert root_res.status_code == 200
+        assert root_res.headers["cache-control"] == "no-store, no-cache, must-revalidate, max-age=0"

--- a/tests/test_frontend_mount.py
+++ b/tests/test_frontend_mount.py
@@ -62,6 +62,48 @@ async def test_write_request_to_spa_path_returns_405_not_shell(
         assert "shell" not in root_res.text
 
 
+async def test_real_static_file_under_app_path_is_not_shadowed_by_shell(
+    reload_app_cleanup: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """dist/app/ 下若存在真实静态文件，spa_deep_link 应优先返回该文件而非无条件回退到 index.html 外壳。"""
+    dist_dir = tmp_path / "frontend" / "dist"
+    (dist_dir / "app").mkdir(parents=True)
+    (dist_dir / "index.html").write_text("<html>shell</html>", encoding="utf-8")
+    (dist_dir / "app" / "logo.png").write_bytes(b"fake-png-bytes")
+    monkeypatch.setattr(lib, "PROJECT_ROOT", tmp_path)
+    importlib.reload(app_module)
+
+    transport = ASGITransport(app=app_module.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.get("/app/logo.png")
+        assert res.status_code == 200
+        assert res.content == b"fake-png-bytes"
+
+
+async def test_deep_link_path_traversal_falls_back_to_shell(
+    reload_app_cleanup: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """_rest 携带 "../" 越界读取时不应逃出构建产物目录，应正常回退到 index.html 外壳。"""
+    dist_dir = tmp_path / "frontend" / "dist"
+    dist_dir.mkdir(parents=True)
+    (dist_dir / "index.html").write_text("<html>shell</html>", encoding="utf-8")
+    secret = tmp_path / "secret.txt"
+    secret.write_text("top-secret", encoding="utf-8")
+    monkeypatch.setattr(lib, "PROJECT_ROOT", tmp_path)
+    importlib.reload(app_module)
+
+    transport = ASGITransport(app=app_module.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # 用 %2e%2e 而非字面 "../"：httpx 会在客户端就地折叠字面 "../"，
+        # 必须让 ".." 以编码形式保留到请求行，才能验证服务端（而非客户端）的越界防护。
+        # 拼接顺序是 dist/app/<_rest>，需要 3 级 ".." 才能越过 app/、dist/、frontend/
+        # 三层目录抵达 tmp_path/secret.txt
+        res = await client.get("/app/%2e%2e/%2e%2e/%2e%2e/secret.txt")
+        assert res.status_code == 200
+        assert "shell" in res.text
+        assert "top-secret" not in res.text
+
+
 async def test_missing_index_html_skips_mount_without_crashing(
     reload_app_cleanup: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ requires-dist = [
     { name = "claude-agent-sdk", specifier = ">=0.1.76" },
     { name = "docx2txt", specifier = ">=0.9" },
     { name = "ebooklib", specifier = ">=0.20" },
-    { name = "fastapi", specifier = ">=0.135.1" },
+    { name = "fastapi", specifier = ">=0.138.2" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "google-genai", specifier = ">=1.65.0" },
     { name = "instructor", specifier = ">=1.14.5" },
@@ -784,7 +784,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.139.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -793,9 +793,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 摘要

- fastapi 0.136.3 → 0.139.0（`pyproject.toml` 下限 `>=0.138.2`，经 `uv add`），取代 dependabot 的 #812（依赖更新后 dependabot 会自动关闭该 PR）
- 删除自定义 `SPAStaticFiles` 类，前端页面服务改用 FastAPI 0.138 原生 `app.frontend()` 挂载：API 路由自动优先，SPA fallback 仅对 GET/HEAD 生效——写请求误入页面路径不再返回 HTML 页面（404/405）
- 兜底修复两处原生挂载与旧实现的行为差异：
  - 挂载条件检查 `index.html` 而非目录存在——`app.frontend()` 在启动期校验 fallback 文件，构建产物不完整时会抛 RuntimeError 拖垮整个应用（含全部 API）；现在跳过挂载并打 warning，API 不受影响
  - 显式注册 `GET /app/{_rest:path}` 返回 SPA 外壳——原生 fallback 要求路径末段无扩展名，`/app/projects/x/source/chapter1.txt` 这类深链（前端路由 `/source/:filename`）刷新会 404

## 升级风险核查

- 0.137.0 破坏性变更（`router.routes` 树状化）：全仓唯一遍历点 `tests/test_grid_router.py` 作用于叶子 router（无嵌套 `include_router`），不受影响
- 0.139.0 无新增破坏性变更

## 测试

- ruff / basedpyright 0 error / pytest 5788 全过
- 冒烟：SPA 路由与带扩展名深链 → 200 HTML；静态资产 → 200；POST 页面路径 → 404/405；`/api/v1/tasks` → 401 JSON（API 优先）；dist 缺 `index.html` 时应用正常启动

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化前端 SPA 回退：当 `frontend/dist/index.html` 存在时，`/app/...` 深层链接与根路径返回同一 HTML 壳；缺失则跳过前端挂载。
* **问题修复**
  * HTML 壳不缓存：对 `text/html` 响应强制设置 `Cache-Control: no-store, no-cache, must-revalidate, max-age=0`。
  * 深链与静态资源：优先返回真实静态文件；对不匹配的方法返回相应错误码，并防止路径越界泄露。
* **依赖更新**
  * 升级 `fastapi` 版本。
* **测试**
  * 新增异步用例，覆盖回退分支、状态码与 `Cache-Control` 精确校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->