### PR TITLE
chore: 清理两处已确认无引用的死代码

### DIFF
--- a/frontend/src/utils/project-changes.ts
+++ b/frontend/src/utils/project-changes.ts
@@ -31,22 +31,6 @@ export function buildEntityRevisionKey(
   return `${entityType}:${entityId}`;
 }
 
-export function buildVersionResourceRevisionKey(
-  resourceType: "storyboards" | "videos" | "characters" | "scenes" | "props",
-  resourceId: string,
-): string {
-  if (resourceType === "storyboards" || resourceType === "videos") {
-    return buildEntityRevisionKey("segment", resourceId);
-  }
-  if (resourceType === "characters") {
-    return buildEntityRevisionKey("character", resourceId);
-  }
-  if (resourceType === "scenes") {
-    return buildEntityRevisionKey("scene", resourceId);
-  }
-  return buildEntityRevisionKey("prop", resourceId);
-}
-
 export function groupChangesByType(
   changes: ProjectChange[],
 ): GroupedProjectChange[] {

--- a/server/agent_runtime/options_assembler.py
+++ b/server/agent_runtime/options_assembler.py
@@ -212,8 +212,6 @@ class OptionsAssembler:
 
         policy = self._access_policy_provider()
 
-        transcripts_dir = self.data_dir / "transcripts"
-        transcripts_dir.mkdir(parents=True, exist_ok=True)
         project_cwd = self._resolve_project_cwd(project_name)
 
         # Build PreToolUse hooks — file access control MUST use hooks because


### PR DESCRIPTION
Closes #1021

## 改动

删除两处已确认无引用的死代码，系统行为不变：

- `server/agent_runtime/options_assembler.py`：移除 `build()` 中冗余的 `transcripts_dir` 目录创建两行——该目录创建后无任何读者，transcript 已由 DB session store 持久化。
- `frontend/src/utils/project-changes.ts`：移除全前端无调用点的 `buildVersionResourceRevisionKey` 函数（仅存定义，且曾诱发 AI reviewer 误报）。仅它使用的私有 helper 无，`buildEntityRevisionKey` 仍被 `StudioCanvasRouter` / `useProjectEventsSSE` 引用，保留。

## 验证

- 后端：`ruff check` 通过、`basedpyright` 0 error（2 处 warning 为改动前既有，与本次无关）、`pytest -k options` 35 passed。
- 前端：`pnpm lint` 通过、`pnpm check` 902 tests passed（102 files）。
- 全仓 grep 确认：`data_dir / "transcripts"` 活代码零命中；`buildVersionResourceRevisionKey` 前端零命中。
- `/code-review xhigh`：1 条 cleanup 发现（详见下），经研判超出本 issue 范围，转 follow-up。

## 审查发现（follow-up 候选，未纳入本 PR）

移除 mkdir 后，`OptionsAssembler.data_dir` 变为无读者的死状态。经全仓核实，`.agent_data` 目录仅由 `service.py` 创建、且 `data_dir` 沿 `service → SessionManager → OptionsAssembler` 三级构造链透传后无任何实际读取——即整条 `data_dir` / `.agent_data` 机制在本次删除后已死。完整清理需改动 `session_manager.py`、`service.py`（均在本 issue diff 之外），且触及本 issue 明确划定的范围外（"不改动其余 options 装配逻辑" / "其余疑似死代码的主动排查"），故不纳入本 PR，另行 triage。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **重构**
  * 优化项目变更的实体修订标识生成方式，支持直接基于实体类型和实体 ID 生成标识。
  * 简化会话配置装配流程，不再自动创建 transcript 目录。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->