### PR TITLE
fix(server): 手动预拆分分集在空账本下自愈登记，解除审核确认死锁

### DIFF
--- a/server/services/script_review.py
+++ b/server/services/script_review.py
@@ -17,6 +17,7 @@ from typing import Any
 from pydantic import BaseModel, ValidationError
 
 from lib import script_review
+from lib.episode_ledger import backfill_episode_ledger, discover_episode_files
 from lib.json_io import atomic_write_json, load_json_or_none
 from lib.project_manager import ProjectManager
 from lib.script_models import DramaNormalizedScript, NarrationStep1Draft
@@ -45,14 +46,44 @@ class ScriptReviewService:
     def __init__(self, pm: ProjectManager):
         self.pm = pm
 
-    def _require_episode(self, project: dict[str, Any], episode: int) -> None:
-        """gate 适用时校验该集已在 project.json ``episodes[]`` 登记，缺失抛 episode_not_found。
+    def _require_episode(self, project_name: str, project: dict[str, Any], episode: int) -> dict[str, Any]:
+        """gate 适用时校验该集已在 project.json ``episodes[]`` 登记，返回（必要时已自愈的）project。
 
         与 ``confirm`` 的写入前置一致：避免 ``get_state`` 把未登记分集误报成 no_step1、
         ``save_content`` 给未登记分集写出永远无法与 project.json 关联的孤儿 step1 文件。
+
+        条目缺失时不立即拒绝：若该集的派生文件 ``source/episode_N.txt`` 实际存在（用户绕过
+        分集规划器、手动预拆分上传的存量场景），先用 ``backfill_episode_ledger`` 自愈补建条目
+        再重新校验，而非直接判死锁——手动预拆分与账本为空同时出现时，唯一的登记来源就是这次
+        自愈，不做即无法登记、也无法确认。派生文件也不存在时（真正缺失的集号）不自愈，直接抛出。
         """
+        if script_review.find_episode(project, episode) is not None:
+            return project
+        project_path = self.pm.get_project_path(project_name)
+        if episode not in discover_episode_files(project_path):
+            raise ScriptReviewError("episode_not_found")
+        project = self._backfill_ledger(project_name)
         if script_review.find_episode(project, episode) is None:
             raise ScriptReviewError("episode_not_found")
+        return project
+
+    def _backfill_ledger(self, project_name: str) -> dict[str, Any]:
+        """在项目锁内运行一次 ``backfill_episode_ledger`` 并落盘，返回自愈后的 project。
+
+        落盘走 ``ProjectManager.update_project`` 的锁内 read-modify-write，不绕锁直写
+        project.json。``backfill_episode_ledger`` 是不修改入参的纯函数，返回新 dict；
+        这里在回调内把结果拷回被就地修改的 ``p``，桥接纯函数输出与 update_project 的
+        原地修改约定。已带 ``ledger_status`` 的条目在纯函数内部即被跳过，重复触发不会
+        重写既有条目或产生重复集号。
+        """
+        project_path = self.pm.get_project_path(project_name)
+
+        def _mutate(p: dict[str, Any]) -> None:
+            healed = backfill_episode_ledger(project_path, p)
+            p.clear()
+            p.update(healed)
+
+        return self.pm.update_project(project_name, _mutate)
 
     def get_state(self, project_name: str, episode: int) -> dict[str, Any]:
         """返回该集审核状态 + 结构化中间态内容（供 web 渲染）。
@@ -66,7 +97,7 @@ class ScriptReviewService:
         if path is not None:
             # 适用 gate（drama / narration 非 reference_video）才要求分集已登记；
             # not_applicable（ad / reference_video）与分集存在性无关，保持原样返回。
-            self._require_episode(project, episode)
+            project = self._require_episode(project_name, project, episode)
         fingerprint = script_review.content_fingerprint(path) if path is not None else None
         return {
             "episode": episode,
@@ -87,7 +118,7 @@ class ScriptReviewService:
         path = script_review.step1_path(project_path, project, episode)
         if path is None:
             raise ScriptReviewError("not_applicable")
-        self._require_episode(project, episode)
+        project = self._require_episode(project_name, project, episode)
         model = _CONTENT_MODEL[project["content_mode"]]
         try:
             validated = model.model_validate(content).model_dump()
@@ -107,7 +138,7 @@ class ScriptReviewService:
         path = script_review.step1_path(project_path, project, episode)
         if path is None:
             raise ScriptReviewError("not_applicable")
-        self._require_episode(project, episode)
+        project = self._require_episode(project_name, project, episode)
         fingerprint = script_review.content_fingerprint(path)
         if fingerprint is None:
             raise ScriptReviewError("no_step1")

--- a/tests/test_script_review.py
+++ b/tests/test_script_review.py
@@ -90,6 +90,22 @@ def _write_step2(pm: ProjectManager) -> Path:
     return path
 
 
+def _make_manual_split_project(tmp_path: Path, content_mode: str) -> ProjectManager:
+    """手动预拆分场景：绕过分集规划器，``episodes[]`` 账本为空，仅有派生 source/episode_N.txt。"""
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Demo", "Anime", content_mode)
+    return pm
+
+
+def _write_source_text(pm: ProjectManager, filename: str, text: str) -> Path:
+    source_dir = pm.get_project_path("demo") / "source"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    path = source_dir / filename
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
 # ---------------------------------------------------------------------------
 # 状态流转（drama）
 # ---------------------------------------------------------------------------
@@ -339,3 +355,111 @@ class TestLegacyEnumeration:
         edited["scenes"][0]["source_text"] = "改写后的原文锚"
         ScriptReviewService(pm).save_content("demo", 1, edited)
         assert ScriptReviewService(pm).get_state("demo", 1)["status"] == "pending_review"
+
+
+# ---------------------------------------------------------------------------
+# 手动预拆分自愈：episodes[] 账本为空但 source/episode_N.txt 派生文件已存在时，
+# _require_episode 自愈补建条目而非直接判死锁。
+# ---------------------------------------------------------------------------
+
+
+class TestManualSplitSelfHeal:
+    def test_get_state_self_heals_unanchored_orphan(self, tmp_path):
+        """无可匹配原文 → 自愈为 unanchored 条目（source_range 为 null），get_state 不再 episode_not_found。"""
+        pm = _make_manual_split_project(tmp_path, "narration")
+        _write_source_text(pm, "episode_1.txt", "裴与出征后的第二年。")
+        _write_step1(pm, "narration", _narration_step1())
+
+        state = ScriptReviewService(pm).get_state("demo", 1)
+        assert state["status"] == "pending_review"
+
+        ep = script_review.find_episode(pm.load_project("demo"), 1)
+        assert ep is not None
+        assert ep["ledger_status"] == "unanchored"
+        assert ep["source_range"] is None
+
+    def test_confirm_self_heals_and_unblocks_step2(self, tmp_path):
+        """confirm（web 与 agent 工具共用同一 service）在空账本下不再 episode_not_found，且放行 step2。"""
+        pm = _make_manual_split_project(tmp_path, "drama")
+        _write_source_text(pm, "episode_1.txt", "任意派生内容")
+        _write_step1(pm, "drama", _drama_step1())
+
+        confirmed = ScriptReviewService(pm).confirm("demo", 1)
+        assert confirmed["status"] == "confirmed"
+
+        project_path = pm.get_project_path("demo")
+        assert script_review.gate_blocks_step2(project_path, pm.load_project("demo"), 1) is False
+
+    def test_self_heal_anchors_when_source_text_matches(self, tmp_path):
+        """派生文件内容能在原文中精确子串匹配 → 回填 source_range（而非 unanchored）。"""
+        pm = _make_manual_split_project(tmp_path, "narration")
+        original = "裴与出征后的第二年，送回一个襁褓中的婴儿。后续内容在此。"
+        _write_source_text(pm, "novel.txt", original)
+        _write_source_text(pm, "episode_1.txt", "裴与出征后的第二年，送回一个襁褓中的婴儿。")
+
+        ScriptReviewService(pm).get_state("demo", 1)
+
+        ep = script_review.find_episode(pm.load_project("demo"), 1)
+        assert ep is not None
+        assert ep["ledger_status"] in ("planned", "consumed")
+        assert ep["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": 21}
+
+    def test_self_heal_backfills_all_orphans_not_just_requested(self, tmp_path):
+        """自愈一次回填账本中所有孤儿集号的派生文件，不只是当前请求的那一集。"""
+        pm = _make_manual_split_project(tmp_path, "narration")
+        _write_source_text(pm, "episode_1.txt", "第一集内容")
+        _write_source_text(pm, "episode_2.txt", "第二集内容")
+
+        ScriptReviewService(pm).get_state("demo", 1)
+
+        project = pm.load_project("demo")
+        assert script_review.find_episode(project, 1) is not None
+        assert script_review.find_episode(project, 2) is not None
+
+    def test_self_heal_preserves_existing_ledger_status_entries(self, tmp_path):
+        """已带 ledger_status 的条目（规划工具写入）不因其他集号的自愈触发被改写。"""
+        pm = _make_manual_split_project(tmp_path, "narration")
+        pm.add_episode("demo", 1, "第一集", "scripts/episode_1.json")
+
+        def _mark_planned(p: dict) -> None:
+            ep = next(e for e in p["episodes"] if e["episode"] == 1)
+            ep["ledger_status"] = "planned"
+            ep["source_range"] = {"source_file": "source/novel.txt", "start": 0, "end": 5}
+
+        pm.update_project("demo", _mark_planned)
+        _write_source_text(pm, "episode_2.txt", "第二集派生内容")
+
+        # 触发对孤儿集（episode 2）的自愈请求，不涉及 episode 1。
+        ScriptReviewService(pm).get_state("demo", 2)
+
+        project = pm.load_project("demo")
+        ep1 = script_review.find_episode(project, 1)
+        assert ep1 is not None
+        assert ep1["ledger_status"] == "planned"
+        assert ep1["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": 5}
+        assert script_review.find_episode(project, 2) is not None
+
+    def test_self_heal_does_not_apply_when_derivative_file_missing(self, tmp_path):
+        """账本为空且该集派生文件也不存在（真正缺失的集号）→ 仍抛 episode_not_found，不自愈。"""
+        pm = _make_manual_split_project(tmp_path, "narration")
+        with pytest.raises(ScriptReviewError) as exc:
+            ScriptReviewService(pm).get_state("demo", 1)
+        assert exc.value.code == "episode_not_found"
+        assert pm.load_project("demo")["episodes"] == []
+
+    def test_self_heal_idempotent_no_duplicate_entries(self, tmp_path):
+        """重复触发自愈（同集反复读状态）不产生重复集号条目，也不重复改写已回填条目。"""
+        pm = _make_manual_split_project(tmp_path, "narration")
+        _write_source_text(pm, "episode_1.txt", "第一集派生内容")
+
+        svc = ScriptReviewService(pm)
+        svc.get_state("demo", 1)
+        first = script_review.find_episode(pm.load_project("demo"), 1)
+
+        svc.get_state("demo", 1)
+        svc.get_state("demo", 1)
+
+        project = pm.load_project("demo")
+        matches = [e for e in project["episodes"] if e.get("episode") == 1]
+        assert len(matches) == 1
+        assert matches[0] == first


### PR DESCRIPTION
Closes #1086

## 问题

手动预拆分场景（用户绕过分集规划器、自行上传 `source/episode_N.txt`，`project.json` 的 `episodes[]` 账本为空）下 step1 审核 gate 死锁：step2 生成被判 `pending_review` 阻塞，而 confirm 放行又因账本查不到条目抛 `episode_not_found`，两条放行路径互为前置，无任何运行时补救通道。

## 方案

`ScriptReviewService._require_episode`（`get_state` / `save_content` / `confirm` 三入口共用的条目存在性校验）在条目命空、且该集派生文件 `source/episode_N.txt` 实际存在时，先在项目锁内跑一次 `backfill_episode_ledger` 自愈补建账本并落盘，再重试校验；派生文件不存在（真正缺失的集号）仍抛 `episode_not_found`。

- 落盘走 `ProjectManager.update_project` 的锁内 read-modify-write，不绕锁直写 `project.json`
- `backfill_episode_ledger` 纯函数原样复用，语义未改；已带 `ledger_status` 的条目整条跳过，重复触发幂等
- 无可匹配原文 → 孤儿集补建为 `unanchored`（`source_range` 为 null），可被 confirm 命中；有原文可子串匹配 → 正常锚定 `source_range`

## 验证

- 新增 `TestManualSplitSelfHeal`（7 例）覆盖验收标准的状态组合：unanchored 自愈、confirm 放行 step2、原文锚定、全孤儿回填、保留既有 `ledger_status` 条目、派生文件缺失仍抛错、幂等无重复条目
- `uv run python -m pytest tests/test_script_review.py`：27 passed
- `uv run ruff check` / `ruff format --check` / `uv run basedpyright server/services/script_review.py`：全绿（0 error）

HTTP router (`server/routers/script_review.py`) 与 agent 侧 `confirm_script_review` MCP 工具均为 `ScriptReviewService` 的薄封装，自愈行为自动继承。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 当分集文件存在但登记信息缺失时，系统会自动补全分集记录，确保审核流程可继续。
  * 支持根据源文本匹配分集范围；无法匹配时仍会保留分集记录并标记为未锚定。
  * 自动补全不会覆盖已有分集状态或范围信息，重复触发也不会产生重复记录。

* **问题修复**
  * 分集文件确实缺失时，仍会正确提示“分集不存在”。
  * 修复了手动拆分场景下无法查看状态或确认审核的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->