### PR TITLE
fix(server): 多凭证组供应商切换鉴权方式后旧凭证自动清除，切换立即生效

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 
 from lib.agnes_shared import AGNES_BASE_URL
@@ -107,6 +108,14 @@ class ProviderMeta:
     @property
     def capabilities(self) -> list[str]:
         return sorted(set(c for m in self.models.values() for c in m.capabilities))
+
+    def fully_covered_credential_groups(self, values: Mapping[str, str | None]) -> list[list[str]]:
+        """返回本次提交「完整覆盖」的凭证组（组内所有 key 在 values 中均非空）。
+
+        驱动凭证创建/更新端点的切组判定（issue #1084）：未声明 credential_groups 的 provider
+        （绝大多数）该列表恒为空，调用方据此保持"不做切组处理"的原语义不变。
+        """
+        return [group for group in self.credential_groups if all(values.get(k) for k in group)]
 
 
 # Gemini 文本费率（美元/百万 token），Standard paid tier、prompt ≤200K 区间。

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -112,7 +112,7 @@ class ProviderMeta:
     def fully_covered_credential_groups(self, values: Mapping[str, str | None]) -> list[list[str]]:
         """返回本次提交「完整覆盖」的凭证组（组内所有 key 在 values 中均非空）。
 
-        驱动凭证创建/更新端点的切组判定（issue #1084）：未声明 credential_groups 的 provider
+        驱动凭证创建/更新端点的切组判定：未声明 credential_groups 的 provider
         （绝大多数）该列表恒为空，调用方据此保持"不做切组处理"的原语义不变。
         """
         return [group for group in self.credential_groups if all(values.get(k) for k in group)]

--- a/lib/db/repositories/credential_repository.py
+++ b/lib/db/repositories/credential_repository.py
@@ -93,7 +93,7 @@ class CredentialRepository(BaseRepository):
     ) -> None:
         """更新凭证字段。省略参数（保持 _UNSET）表示不修改；api_key/base_url/access_key/
         secret_key 显式传 None 会清空该字段——凭证切组时用于清空另一组的旧值（见
-        ``ProviderMeta.credential_groups`` / issue #1084）。name/credentials_path 无清空语义，
+        ``ProviderMeta.credential_groups``）。name/credentials_path 无清空语义，
         传 None 等同不修改。
         """
         cred = await self.get_by_id(cred_id)

--- a/lib/db/repositories/credential_repository.py
+++ b/lib/db/repositories/credential_repository.py
@@ -85,28 +85,32 @@ class CredentialRepository(BaseRepository):
         cred_id: int,
         *,
         name: str | None = None,
-        api_key: str | None = None,
+        api_key: str | None | object = _UNSET,
         credentials_path: str | None = None,
         base_url: str | None | object = _UNSET,
-        access_key: str | None = None,
-        secret_key: str | None = None,
+        access_key: str | None | object = _UNSET,
+        secret_key: str | None | object = _UNSET,
     ) -> None:
-        """更新凭证字段。仅更新非 None 参数（base_url 用 _UNSET 表示未传入）。"""
+        """更新凭证字段。省略参数（保持 _UNSET）表示不修改；api_key/base_url/access_key/
+        secret_key 显式传 None 会清空该字段——凭证切组时用于清空另一组的旧值（见
+        ``ProviderMeta.credential_groups`` / issue #1084）。name/credentials_path 无清空语义，
+        传 None 等同不修改。
+        """
         cred = await self.get_by_id(cred_id)
         if cred is None:
             return
         if name is not None:
             cred.name = name
-        if api_key is not None:
-            cred.api_key = api_key
+        if api_key is not _UNSET:
+            cred.api_key = api_key  # type: ignore[assignment]
         if credentials_path is not None:
             cred.credentials_path = credentials_path
         if base_url is not _UNSET:
             cred.base_url = normalize_base_url(base_url)  # type: ignore[arg-type]
-        if access_key is not None:
-            cred.access_key = access_key
-        if secret_key is not None:
-            cred.secret_key = secret_key
+        if access_key is not _UNSET:
+            cred.access_key = access_key  # type: ignore[assignment]
+        if secret_key is not _UNSET:
+            cred.secret_key = secret_key  # type: ignore[assignment]
 
     async def delete(self, cred_id: int) -> None:
         """删除凭证。若删除的是活跃凭证，自动将最早的另一条设为活跃。"""

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -103,6 +103,10 @@ MESSAGES = {
     "connection_failed": "Connection failed: {err_msg}",
     "unsupported_test": "Provider {provider_id} does not support connection testing yet",
     "missing_credentials": "Missing credential configuration, please add a key first",
+    "credential_group_ambiguous": (
+        "This submission fully covers more than one credential group, so the switch target is "
+        "ambiguous. Please submit only one group."
+    ),
     # Assistant
     "session_not_found": "Session '{session_id}' does not exist",
     "session_or_project_not_found": "Session or project does not exist",

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -104,8 +104,8 @@ MESSAGES = {
     "unsupported_test": "Provider {provider_id} does not support connection testing yet",
     "missing_credentials": "Missing credential configuration, please add a key first",
     "credential_group_ambiguous": (
-        "This submission fully covers more than one credential group, so the switch target is "
-        "ambiguous. Please submit only one group."
+        "This submission mixes fields from more than one mutually exclusive credential group, so the "
+        "switch target is ambiguous. Please fill in only one group."
     ),
     # Assistant
     "session_not_found": "Session '{session_id}' does not exist",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -104,8 +104,8 @@ MESSAGES = {
     "unsupported_test": "Nhà cung cấp {provider_id} hiện chưa hỗ trợ kiểm tra kết nối",
     "missing_credentials": "Thiếu cấu hình thông tin xác thực, vui lòng thêm khóa trước",
     "credential_group_ambiguous": (
-        "Lần gửi này đã điền đầy đủ nhiều nhóm thông tin xác thực cùng lúc, không thể xác định "
-        "muốn chuyển sang nhóm nào. Vui lòng chỉ gửi một nhóm."
+        "Lần gửi này chứa các trường thuộc nhiều nhóm thông tin xác thực loại trừ lẫn nhau, không "
+        "thể xác định muốn chuyển sang nhóm nào. Vui lòng chỉ điền một nhóm."
     ),
     # Assistant
     "session_not_found": "Phiên '{session_id}' không tồn tại",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -103,6 +103,10 @@ MESSAGES = {
     "connection_failed": "Kết nối thất bại: {err_msg}",
     "unsupported_test": "Nhà cung cấp {provider_id} hiện chưa hỗ trợ kiểm tra kết nối",
     "missing_credentials": "Thiếu cấu hình thông tin xác thực, vui lòng thêm khóa trước",
+    "credential_group_ambiguous": (
+        "Lần gửi này đã điền đầy đủ nhiều nhóm thông tin xác thực cùng lúc, không thể xác định "
+        "muốn chuyển sang nhóm nào. Vui lòng chỉ gửi một nhóm."
+    ),
     # Assistant
     "session_not_found": "Phiên '{session_id}' không tồn tại",
     "session_or_project_not_found": "Phiên hoặc dự án không tồn tại",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -103,6 +103,7 @@ MESSAGES = {
     "connection_failed": "连接失败: {err_msg}",
     "unsupported_test": "供应商 {provider_id} 暂不支持连接测试",
     "missing_credentials": "缺少凭证配置，请先添加密钥",
+    "credential_group_ambiguous": "本次提交同时完整覆盖了多组凭证，无法判断切换方向，请仅提交其中一组",
     # Assistant
     "session_not_found": "会话 '{session_id}' 不存在",
     "session_or_project_not_found": "会话或项目不存在",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -103,7 +103,7 @@ MESSAGES = {
     "connection_failed": "连接失败: {err_msg}",
     "unsupported_test": "供应商 {provider_id} 暂不支持连接测试",
     "missing_credentials": "缺少凭证配置，请先添加密钥",
-    "credential_group_ambiguous": "本次提交同时完整覆盖了多组凭证，无法判断切换方向，请仅提交其中一组",
+    "credential_group_ambiguous": "本次提交包含多组互斥凭证的字段，无法判断切换方向，请仅填写其中一组",
     # Assistant
     "session_not_found": "会话 '{session_id}' 不存在",
     "session_or_project_not_found": "会话或项目不存在",

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -201,9 +201,16 @@ def _validate_provider(provider_id: str, _t: Callable[..., str]) -> None:
         raise HTTPException(status_code=404, detail=_t("unknown_provider", provider_id=provider_id))
 
 
+_NON_SECRET_FIELDS = frozenset({"name", "base_url"})
+
+
 def _submitted_secret_values(body: CreateCredentialRequest | UpdateCredentialRequest) -> dict[str, str | None]:
-    """从请求体取出参与凭证组切换判定的密钥字段，供 create/update 共用以保持字段集一致。"""
-    return {"api_key": body.api_key, "access_key": body.access_key, "secret_key": body.secret_key}
+    """从请求体取出参与凭证组切换判定的密钥字段，供 create/update 共用以保持字段集一致。
+
+    动态排除非密钥字段而非硬编码字段名列表，新增供应商凭证字段（并纳入某个
+    credential_groups）时无需同步修改此处。
+    """
+    return {k: v for k, v in body.model_dump().items() if k not in _NON_SECRET_FIELDS}
 
 
 def _resolve_credential_group_switch(
@@ -490,10 +497,11 @@ async def update_credential(
     repo = CredentialRepository(session)
     # 先确认凭证存在（404 优先于后续切组歧义的 422），再用库内原值参与「切入」判定。
     cred = await _get_credential_or_404(repo, provider_id, cred_id, _t)
+    submitted = _submitted_secret_values(body)
     clear_keys = _resolve_credential_group_switch(
         provider_id,
-        _submitted_secret_values(body),
-        {"api_key": cred.api_key, "access_key": cred.access_key, "secret_key": cred.secret_key},
+        submitted,
+        {k: getattr(cred, k, None) for k in submitted},
         _t,
     )
     kwargs: dict = {}

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -201,6 +201,28 @@ def _validate_provider(provider_id: str, _t: Callable[..., str]) -> None:
         raise HTTPException(status_code=404, detail=_t("unknown_provider", provider_id=provider_id))
 
 
+def _resolve_credential_group_switch(
+    provider_id: str,
+    submitted: dict[str, str | None],
+    _t: Callable[..., str],
+) -> set[str]:
+    """判定本次提交是否触发凭证切组，返回需清空的其它组字段集合。
+
+    切组由 ``ProviderMeta.credential_groups`` 声明驱动（issue #1084）：本次提交完整覆盖
+    （非空）某一组时，视为切向该组，返回其它已声明组的全部字段供调用方清空；同时完整覆盖
+    多组时无法判断切向哪组，报错拒绝；未完整覆盖任何组（含未声明 credential_groups 的绝大多数
+    provider）时返回空集合，维持现有 PATCH/创建的保留语义不变。
+    """
+    meta = PROVIDER_REGISTRY[provider_id]
+    matched = meta.fully_covered_credential_groups(submitted)
+    if len(matched) > 1:
+        raise HTTPException(status_code=422, detail=_t("credential_group_ambiguous"))
+    if len(matched) == 1:
+        covered = set(matched[0])
+        return {k for group in meta.credential_groups for k in group if k not in covered}
+    return set()
+
+
 async def _get_credential_or_404(
     repo: CredentialRepository,
     provider_id: str,
@@ -417,6 +439,12 @@ async def create_credential(
     session: AsyncSession = Depends(get_async_session),
 ) -> CredentialResponse:
     _validate_provider(provider_id, _t)
+    # 创建是全新行，无需清空——同时完整覆盖多组仍歧义，一律拒绝（新行不落盘）。
+    _resolve_credential_group_switch(
+        provider_id,
+        {"api_key": body.api_key, "access_key": body.access_key, "secret_key": body.secret_key},
+        _t,
+    )
     repo = CredentialRepository(session)
     cred = await repo.create(
         provider=provider_id,
@@ -441,6 +469,13 @@ async def update_credential(
     session: AsyncSession = Depends(get_async_session),
 ) -> Response:
     _validate_provider(provider_id, _t)
+    # 切组判定须用本次提交的原始值（而非与库内旧值合并后的结果）：只有当次提交本身完整覆盖
+    # 某一组，才视为用户主动切组；否则维持现有「未提交字段保留原值」的部分更新语义。
+    clear_keys = _resolve_credential_group_switch(
+        provider_id,
+        {"api_key": body.api_key, "access_key": body.access_key, "secret_key": body.secret_key},
+        _t,
+    )
     repo = CredentialRepository(session)
     cred = await _get_credential_or_404(repo, provider_id, cred_id, _t)
     kwargs: dict = {}
@@ -454,6 +489,9 @@ async def update_credential(
         kwargs["access_key"] = body.access_key
     if body.secret_key is not None:
         kwargs["secret_key"] = body.secret_key
+    # 切组命中：清空其它已声明组的字段，消除"静默沿用旧模式"（issue #1084）。
+    for key in clear_keys:
+        kwargs[key] = None
     if kwargs:
         await repo.update(cred_id, **kwargs)
         await session.commit()

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any
 
@@ -201,26 +201,48 @@ def _validate_provider(provider_id: str, _t: Callable[..., str]) -> None:
         raise HTTPException(status_code=404, detail=_t("unknown_provider", provider_id=provider_id))
 
 
+def _submitted_secret_values(body: CreateCredentialRequest | UpdateCredentialRequest) -> dict[str, str | None]:
+    """从请求体取出参与凭证组切换判定的密钥字段，供 create/update 共用以保持字段集一致。"""
+    return {"api_key": body.api_key, "access_key": body.access_key, "secret_key": body.secret_key}
+
+
 def _resolve_credential_group_switch(
     provider_id: str,
-    submitted: dict[str, str | None],
+    submitted: Mapping[str, str | None],
+    current: Mapping[str, str | None] | None,
     _t: Callable[..., str],
 ) -> set[str]:
     """判定本次提交是否触发凭证切组，返回需清空的其它组字段集合。
 
-    切组由 ``ProviderMeta.credential_groups`` 声明驱动（issue #1084）：本次提交完整覆盖
-    （非空）某一组时，视为切向该组，返回其它已声明组的全部字段供调用方清空；同时完整覆盖
-    多组时无法判断切向哪组，报错拒绝；未完整覆盖任何组（含未声明 credential_groups 的绝大多数
-    provider）时返回空集合，维持现有 PATCH/创建的保留语义不变。
+    切组由 ``ProviderMeta.credential_groups`` 声明驱动：
+    - 单次提交的非空字段横跨多个互斥组时无法判断意图，报错拒绝（避免静默丢弃用户填入的值）；
+    - 完整覆盖某一组、且该组在库内原值中原本未完整存在时，视为「切入」该组，返回其它已声明组
+      的全部字段供调用方清空——消除旧组残留导致的静默沿用旧模式；
+    - 完整覆盖的组在库内原本就已完整存在（存量共存行上例行轮换该组），则不算切组、不清空另一组，
+      避免清掉用户未触碰的休眠凭证；
+    - 未完整覆盖任何组（含未声明 credential_groups 的绝大多数 provider）时返回空集合，维持部分
+      更新的保留语义。
+
+    ``current`` 传入库内原值用于上述「切入」判定；创建端点无原值传 None（新行无可清空项，仅复用
+    本函数的横跨多组拒绝校验）。
     """
     meta = PROVIDER_REGISTRY[provider_id]
-    matched = meta.fully_covered_credential_groups(submitted)
-    if len(matched) > 1:
+    groups = meta.credential_groups
+    if not groups:
+        return set()
+    touched = [g for g in groups if any(submitted.get(k) for k in g)]
+    if len(touched) > 1:
         raise HTTPException(status_code=422, detail=_t("credential_group_ambiguous"))
-    if len(matched) == 1:
-        covered = set(matched[0])
-        return {k for group in meta.credential_groups for k in group if k not in covered}
-    return set()
+    covered = meta.fully_covered_credential_groups(submitted)
+    if not covered:
+        return set()
+    target = covered[0]
+    if current is not None:
+        pre_covered = {frozenset(g) for g in meta.fully_covered_credential_groups(current)}
+        if frozenset(target) in pre_covered:
+            return set()
+    target_keys = set(target)
+    return {k for group in groups for k in group if k not in target_keys}
 
 
 async def _get_credential_or_404(
@@ -439,12 +461,8 @@ async def create_credential(
     session: AsyncSession = Depends(get_async_session),
 ) -> CredentialResponse:
     _validate_provider(provider_id, _t)
-    # 创建是全新行，无需清空——同时完整覆盖多组仍歧义，一律拒绝（新行不落盘）。
-    _resolve_credential_group_switch(
-        provider_id,
-        {"api_key": body.api_key, "access_key": body.access_key, "secret_key": body.secret_key},
-        _t,
-    )
+    # 创建是全新行，无可清空——仅复用横跨多组的歧义校验拒绝矛盾提交（新行不落盘）。
+    _resolve_credential_group_switch(provider_id, _submitted_secret_values(body), None, _t)
     repo = CredentialRepository(session)
     cred = await repo.create(
         provider=provider_id,
@@ -469,15 +487,15 @@ async def update_credential(
     session: AsyncSession = Depends(get_async_session),
 ) -> Response:
     _validate_provider(provider_id, _t)
-    # 切组判定须用本次提交的原始值（而非与库内旧值合并后的结果）：只有当次提交本身完整覆盖
-    # 某一组，才视为用户主动切组；否则维持现有「未提交字段保留原值」的部分更新语义。
+    repo = CredentialRepository(session)
+    # 先确认凭证存在（404 优先于后续切组歧义的 422），再用库内原值参与「切入」判定。
+    cred = await _get_credential_or_404(repo, provider_id, cred_id, _t)
     clear_keys = _resolve_credential_group_switch(
         provider_id,
-        {"api_key": body.api_key, "access_key": body.access_key, "secret_key": body.secret_key},
+        _submitted_secret_values(body),
+        {"api_key": cred.api_key, "access_key": cred.access_key, "secret_key": cred.secret_key},
         _t,
     )
-    repo = CredentialRepository(session)
-    cred = await _get_credential_or_404(repo, provider_id, cred_id, _t)
     kwargs: dict = {}
     if body.name is not None:
         kwargs["name"] = body.name
@@ -489,7 +507,8 @@ async def update_credential(
         kwargs["access_key"] = body.access_key
     if body.secret_key is not None:
         kwargs["secret_key"] = body.secret_key
-    # 切组命中：清空其它已声明组的字段，消除"静默沿用旧模式"（issue #1084）。
+    # 切入某组：清空其它已声明组的字段，消除"静默沿用旧模式"。切入判定已排除本次提交触及的组，
+    # 故不会覆盖用户本次填入的值。
     for key in clear_keys:
         kwargs[key] = None
     if kwargs:

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -207,7 +207,9 @@ def _submitted_secret_values(
     """从请求体取出参与凭证组切换判定的密钥字段，供 create/update 共用以保持字段集一致。
 
     按 provider 在 `PROVIDER_REGISTRY` 中声明的 `secret_keys` 动态过滤，而非硬编码排除列表，
-    与 `credential_groups` 同源、同步声明驱动：新增供应商凭证字段时只需在注册表登记。
+    与 `credential_groups` 同源、同步声明驱动。注：新增凭证字段时，除在注册表登记 `secret_keys`
+    外，仍需同步给 `CreateCredentialRequest`/`UpdateCredentialRequest` 加对应字段——未加字段的
+    key 会被 `hasattr` 过滤静默忽略。
     """
     meta = PROVIDER_REGISTRY[provider_id]
     return {k: getattr(body, k, None) for k in meta.secret_keys if hasattr(body, k)}

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -201,16 +201,16 @@ def _validate_provider(provider_id: str, _t: Callable[..., str]) -> None:
         raise HTTPException(status_code=404, detail=_t("unknown_provider", provider_id=provider_id))
 
 
-_NON_SECRET_FIELDS = frozenset({"name", "base_url"})
-
-
-def _submitted_secret_values(body: CreateCredentialRequest | UpdateCredentialRequest) -> dict[str, str | None]:
+def _submitted_secret_values(
+    provider_id: str, body: CreateCredentialRequest | UpdateCredentialRequest
+) -> dict[str, str | None]:
     """从请求体取出参与凭证组切换判定的密钥字段，供 create/update 共用以保持字段集一致。
 
-    动态排除非密钥字段而非硬编码字段名列表，新增供应商凭证字段（并纳入某个
-    credential_groups）时无需同步修改此处。
+    按 provider 在 `PROVIDER_REGISTRY` 中声明的 `secret_keys` 动态过滤，而非硬编码排除列表，
+    与 `credential_groups` 同源、同步声明驱动：新增供应商凭证字段时只需在注册表登记。
     """
-    return {k: v for k, v in body.model_dump().items() if k not in _NON_SECRET_FIELDS}
+    meta = PROVIDER_REGISTRY[provider_id]
+    return {k: getattr(body, k, None) for k in meta.secret_keys if hasattr(body, k)}
 
 
 def _resolve_credential_group_switch(
@@ -469,7 +469,7 @@ async def create_credential(
 ) -> CredentialResponse:
     _validate_provider(provider_id, _t)
     # 创建是全新行，无可清空——仅复用横跨多组的歧义校验拒绝矛盾提交（新行不落盘）。
-    _resolve_credential_group_switch(provider_id, _submitted_secret_values(body), None, _t)
+    _resolve_credential_group_switch(provider_id, _submitted_secret_values(provider_id, body), None, _t)
     repo = CredentialRepository(session)
     cred = await repo.create(
         provider=provider_id,
@@ -497,7 +497,7 @@ async def update_credential(
     repo = CredentialRepository(session)
     # 先确认凭证存在（404 优先于后续切组歧义的 422），再用库内原值参与「切入」判定。
     cred = await _get_credential_or_404(repo, provider_id, cred_id, _t)
-    submitted = _submitted_secret_values(body)
+    submitted = _submitted_secret_values(provider_id, body)
     clear_keys = _resolve_credential_group_switch(
         provider_id,
         submitted,

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -507,13 +507,13 @@ async def update_credential(
     kwargs: dict = {}
     if body.name is not None:
         kwargs["name"] = body.name
-    if body.api_key is not None:
+    if "api_key" in body.model_fields_set:
         kwargs["api_key"] = body.api_key
     if "base_url" in body.model_fields_set:
         kwargs["base_url"] = body.base_url
-    if body.access_key is not None:
+    if "access_key" in body.model_fields_set:
         kwargs["access_key"] = body.access_key
-    if body.secret_key is not None:
+    if "secret_key" in body.model_fields_set:
         kwargs["secret_key"] = body.secret_key
     # 切入某组：清空其它已声明组的字段，消除"静默沿用旧模式"。切入判定已排除本次提交触及的组，
     # 故不会覆盖用户本次填入的值。

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -168,7 +168,7 @@ class TestCredentialGroups:
 
 
 class TestFullyCoveredCredentialGroups:
-    """ProviderMeta.fully_covered_credential_groups —— 切组判定的核心真值表（issue #1084）。"""
+    """ProviderMeta.fully_covered_credential_groups —— 切组判定的核心真值表。"""
 
     def _kling_meta(self) -> ProviderMeta:
         return ProviderMeta(

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -165,3 +165,55 @@ class TestCredentialGroups:
                 secret_keys=["api_key", "access_key", "secret_key"],
                 credential_groups=[["api_key"]],
             )
+
+
+class TestFullyCoveredCredentialGroups:
+    """ProviderMeta.fully_covered_credential_groups —— 切组判定的核心真值表（issue #1084）。"""
+
+    def _kling_meta(self) -> ProviderMeta:
+        return ProviderMeta(
+            display_name="t",
+            description="t",
+            required_keys=["api_key", "access_key", "secret_key"],
+            secret_keys=["api_key", "access_key", "secret_key"],
+            credential_groups=[["api_key"], ["access_key", "secret_key"]],
+        )
+
+    def test_no_groups_declared_always_empty(self):
+        meta = ProviderMeta(display_name="t", description="t", required_keys=["api_key"], secret_keys=["api_key"])
+        assert meta.fully_covered_credential_groups({"api_key": "k"}) == []
+
+    def test_single_group_fully_submitted(self):
+        meta = self._kling_meta()
+        assert meta.fully_covered_credential_groups({"api_key": "k"}) == [["api_key"]]
+
+    def test_dual_key_group_fully_submitted(self):
+        meta = self._kling_meta()
+        assert meta.fully_covered_credential_groups({"access_key": "ak", "secret_key": "sk"}) == [
+            ["access_key", "secret_key"]
+        ]
+
+    def test_dual_key_group_partially_submitted_not_matched(self):
+        """只提交组内一个 key（如仅轮换 secret_key）不算完整覆盖该组。"""
+        meta = self._kling_meta()
+        assert meta.fully_covered_credential_groups({"secret_key": "sk"}) == []
+
+    def test_both_groups_fully_submitted(self):
+        meta = self._kling_meta()
+        assert meta.fully_covered_credential_groups({"api_key": "k", "access_key": "ak", "secret_key": "sk"}) == [
+            ["api_key"],
+            ["access_key", "secret_key"],
+        ]
+
+    def test_empty_string_not_counted_as_covering(self):
+        """空字符串视同未提交，不满足组覆盖。"""
+        meta = self._kling_meta()
+        assert meta.fully_covered_credential_groups({"api_key": ""}) == []
+
+    def test_none_not_counted_as_covering(self):
+        meta = self._kling_meta()
+        assert meta.fully_covered_credential_groups({"api_key": None}) == []
+
+    def test_nothing_submitted(self):
+        meta = self._kling_meta()
+        assert meta.fully_covered_credential_groups({}) == []

--- a/tests/test_credential_api.py
+++ b/tests/test_credential_api.py
@@ -99,13 +99,14 @@ class TestCreateCredential:
 
 def _fake_kling_cred(
     id: int = 1,
-    access_key: str = "AKfake12345678",
-    secret_key: str = "SKsecret87654321",
+    access_key: str | None = "AKfake12345678",
+    secret_key: str | None = "SKsecret87654321",
+    api_key: str | None = None,
 ) -> ProviderCredential:
     cred = ProviderCredential(
         provider="kling",
         name="可灵账号",
-        api_key=None,
+        api_key=api_key,
         access_key=access_key,
         secret_key=secret_key,
         is_active=True,
@@ -202,7 +203,7 @@ class TestKlingTwoSecretCredential:
 
 
 class TestCredentialGroupSwitch:
-    """凭证切组自动清空（issue #1084）：完整覆盖某组即视为切组，自动清空其它组字段。"""
+    """凭证切组自动清空：完整覆盖某组即视为切组，自动清空其它组字段。"""
 
     def test_update_switch_to_dual_secret_clears_api_key(self):
         """先存 api_key，再完整提交 access_key+secret_key → api_key 被清空。"""
@@ -318,6 +319,71 @@ class TestCredentialGroupSwitch:
         assert resp.status_code == 204
         kwargs = mock_repo.update.await_args.kwargs
         assert kwargs == {"api_key": "AIza-new"}
+
+    def test_update_rotate_active_group_on_coexistence_row_preserves_other(self):
+        """存量共存行（两组凭证并存）上例行轮换 api_key：不视为切组，另一组休眠凭证不被清空。"""
+        app, _ = _make_app()
+        mock_repo = MagicMock(spec=CredentialRepository)
+        # 本功能上线前可创建的共存行：api_key 与 access_key/secret_key 同时留存
+        mock_repo.get_by_id = AsyncMock(
+            return_value=_fake_kling_cred(api_key="AK-old", access_key="AK-legacy", secret_key="SK-legacy")
+        )
+        mock_repo.update = AsyncMock()
+        with patch("server.routers.providers.CredentialRepository", return_value=mock_repo):
+            with TestClient(app) as client:
+                resp = client.patch(
+                    "/api/v1/providers/kling/credentials/1",
+                    json={"api_key": "AK-rotated"},
+                )
+        assert resp.status_code == 204
+        kwargs = mock_repo.update.await_args.kwargs
+        assert kwargs["api_key"] == "AK-rotated"
+        assert "access_key" not in kwargs
+        assert "secret_key" not in kwargs
+
+    def test_update_mixed_group_fields_rejected(self):
+        """一次提交横跨两组（api_key + secret_key）：拒绝，不静默丢弃已填字段，凭证行不变。"""
+        app, _ = _make_app()
+        mock_repo = MagicMock(spec=CredentialRepository)
+        mock_repo.get_by_id = AsyncMock(return_value=_fake_kling_cred())
+        mock_repo.update = AsyncMock()
+        with patch("server.routers.providers.CredentialRepository", return_value=mock_repo):
+            with TestClient(app) as client:
+                resp = client.patch(
+                    "/api/v1/providers/kling/credentials/1",
+                    json={"api_key": "AK-bearer", "secret_key": "SK-stray"},
+                )
+        assert resp.status_code == 422
+        mock_repo.update.assert_not_awaited()
+
+    def test_create_mixed_group_fields_rejected(self):
+        """创建端点同样拒绝横跨多组的提交（api_key + access_key），且不落盘。"""
+        app, _ = _make_app()
+        mock_repo = MagicMock(spec=CredentialRepository)
+        mock_repo.create = AsyncMock(return_value=_fake_kling_cred())
+        with patch("server.routers.providers.CredentialRepository", return_value=mock_repo):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/api/v1/providers/kling/credentials",
+                    json={"name": "可灵账号", "api_key": "AK-bearer", "access_key": "AK-stray"},
+                )
+        assert resp.status_code == 422
+        mock_repo.create.assert_not_awaited()
+
+    def test_update_nonexistent_credential_returns_404_before_ambiguity(self):
+        """凭证不存在时优先返回 404，而非切组歧义的 422。"""
+        app, _ = _make_app()
+        mock_repo = MagicMock(spec=CredentialRepository)
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+        mock_repo.update = AsyncMock()
+        with patch("server.routers.providers.CredentialRepository", return_value=mock_repo):
+            with TestClient(app) as client:
+                resp = client.patch(
+                    "/api/v1/providers/kling/credentials/999",
+                    json={"api_key": "AK-bearer", "access_key": "AK-new", "secret_key": "SK-new"},
+                )
+        assert resp.status_code == 404
+        mock_repo.update.assert_not_awaited()
 
 
 class TestActivateCredential:

--- a/tests/test_credential_api.py
+++ b/tests/test_credential_api.py
@@ -201,6 +201,125 @@ class TestKlingTwoSecretCredential:
         assert "access_key" not in kwargs
 
 
+class TestCredentialGroupSwitch:
+    """凭证切组自动清空（issue #1084）：完整覆盖某组即视为切组，自动清空其它组字段。"""
+
+    def test_update_switch_to_dual_secret_clears_api_key(self):
+        """先存 api_key，再完整提交 access_key+secret_key → api_key 被清空。"""
+        app, _ = _make_app()
+        mock_repo = MagicMock(spec=CredentialRepository)
+        mock_repo.get_by_id = AsyncMock(return_value=_fake_cred(provider="kling", api_key="AK-old"))
+        mock_repo.update = AsyncMock()
+        with patch("server.routers.providers.CredentialRepository", return_value=mock_repo):
+            with TestClient(app) as client:
+                resp = client.patch(
+                    "/api/v1/providers/kling/credentials/1",
+                    json={"access_key": "AK-new", "secret_key": "SK-new"},
+                )
+        assert resp.status_code == 204
+        kwargs = mock_repo.update.await_args.kwargs
+        assert kwargs["access_key"] == "AK-new"
+        assert kwargs["secret_key"] == "SK-new"
+        assert kwargs["api_key"] is None
+
+    def test_update_switch_to_api_key_clears_dual_secret(self):
+        """反向切换：完整提交 api_key → access_key/secret_key 被清空。"""
+        app, _ = _make_app()
+        mock_repo = MagicMock(spec=CredentialRepository)
+        mock_repo.get_by_id = AsyncMock(return_value=_fake_kling_cred())
+        mock_repo.update = AsyncMock()
+        with patch("server.routers.providers.CredentialRepository", return_value=mock_repo):
+            with TestClient(app) as client:
+                resp = client.patch(
+                    "/api/v1/providers/kling/credentials/1",
+                    json={"api_key": "AK-bearer"},
+                )
+        assert resp.status_code == 204
+        kwargs = mock_repo.update.await_args.kwargs
+        assert kwargs["api_key"] == "AK-bearer"
+        assert kwargs["access_key"] is None
+        assert kwargs["secret_key"] is None
+
+    def test_update_both_groups_submitted_rejected(self):
+        """一次提交同时完整覆盖两组：拒绝，凭证行不变。"""
+        app, _ = _make_app()
+        mock_repo = MagicMock(spec=CredentialRepository)
+        mock_repo.get_by_id = AsyncMock(return_value=_fake_kling_cred())
+        mock_repo.update = AsyncMock()
+        with patch("server.routers.providers.CredentialRepository", return_value=mock_repo):
+            with TestClient(app) as client:
+                resp = client.patch(
+                    "/api/v1/providers/kling/credentials/1",
+                    json={"api_key": "AK-bearer", "access_key": "AK-new", "secret_key": "SK-new"},
+                )
+        assert resp.status_code == 422
+        mock_repo.update.assert_not_awaited()
+
+    def test_update_partial_submission_does_not_clear(self):
+        """未完整覆盖任何组（仅轮换 secret_key）：不触发清空，其余字段保持原值。"""
+        app, _ = _make_app()
+        mock_repo = MagicMock(spec=CredentialRepository)
+        mock_repo.get_by_id = AsyncMock(return_value=_fake_kling_cred())
+        mock_repo.update = AsyncMock()
+        with patch("server.routers.providers.CredentialRepository", return_value=mock_repo):
+            with TestClient(app) as client:
+                resp = client.patch(
+                    "/api/v1/providers/kling/credentials/1",
+                    json={"secret_key": "SK-rotated"},
+                )
+        assert resp.status_code == 204
+        kwargs = mock_repo.update.await_args.kwargs
+        assert kwargs["secret_key"] == "SK-rotated"
+        assert "api_key" not in kwargs
+        assert "access_key" not in kwargs
+
+    def test_update_name_only_does_not_clear(self):
+        """存量两组并存的凭证行：仅改名/改 base_url 不触发清空，两组字段都不动。"""
+        app, _ = _make_app()
+        mock_repo = MagicMock(spec=CredentialRepository)
+        mock_repo.get_by_id = AsyncMock(return_value=_fake_kling_cred())
+        mock_repo.update = AsyncMock()
+        with patch("server.routers.providers.CredentialRepository", return_value=mock_repo):
+            with TestClient(app) as client:
+                resp = client.patch(
+                    "/api/v1/providers/kling/credentials/1",
+                    json={"name": "改名"},
+                )
+        assert resp.status_code == 204
+        kwargs = mock_repo.update.await_args.kwargs
+        assert kwargs == {"name": "改名"}
+
+    def test_create_both_groups_submitted_rejected(self):
+        """创建端点同样拒绝一次提交同时完整覆盖两组，且不落盘。"""
+        app, _ = _make_app()
+        mock_repo = MagicMock(spec=CredentialRepository)
+        mock_repo.create = AsyncMock(return_value=_fake_kling_cred())
+        with patch("server.routers.providers.CredentialRepository", return_value=mock_repo):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/api/v1/providers/kling/credentials",
+                    json={"name": "可灵账号", "api_key": "AK-bearer", "access_key": "AK-new", "secret_key": "SK-new"},
+                )
+        assert resp.status_code == 422
+        mock_repo.create.assert_not_awaited()
+
+    def test_provider_without_credential_groups_unaffected(self):
+        """未声明 credential_groups 的 provider（回归）：更新 api_key 不触发任何清空逻辑。"""
+        app, _ = _make_app()
+        mock_repo = MagicMock(spec=CredentialRepository)
+        mock_repo.get_by_id = AsyncMock(return_value=_fake_cred(provider="gemini-aistudio"))
+        mock_repo.update = AsyncMock()
+        with patch("server.routers.providers.CredentialRepository", return_value=mock_repo):
+            with TestClient(app) as client:
+                resp = client.patch(
+                    "/api/v1/providers/gemini-aistudio/credentials/1",
+                    json={"api_key": "AIza-new"},
+                )
+        assert resp.status_code == 204
+        kwargs = mock_repo.update.await_args.kwargs
+        assert kwargs == {"api_key": "AIza-new"}
+
+
 class TestActivateCredential:
     def test_returns_204(self):
         app, _ = _make_app()

--- a/tests/test_credential_repository.py
+++ b/tests/test_credential_repository.py
@@ -162,6 +162,35 @@ class TestCredentialRepository:
         assert config["secret_key"] == "SK-1"
         assert "api_key" not in config
 
+    async def test_update_can_explicitly_clear_secret_fields(self, session: AsyncSession):
+        """显式传 None 清空 api_key/access_key/secret_key/base_url；省略参数（默认）不动它们。"""
+        repo = CredentialRepository(session)
+        c = await repo.create(
+            provider="kling",
+            name="可灵账号",
+            api_key="AK-legacy",
+            base_url="https://proxy.example.com/v1",
+        )
+        await session.flush()
+
+        # 省略 access_key/secret_key：保持未设置，不受影响
+        await repo.update(c.id, name="改名")
+        await session.flush()
+        untouched = await repo.get_by_id(c.id)
+        assert untouched is not None
+        assert untouched.api_key == "AK-legacy"
+        assert untouched.name == "改名"
+
+        # 显式传 None：清空该字段
+        await repo.update(c.id, api_key=None, base_url=None, access_key="AK-new", secret_key="SK-new")
+        await session.flush()
+        switched = await repo.get_by_id(c.id)
+        assert switched is not None
+        assert switched.api_key is None
+        assert switched.base_url is None
+        assert switched.access_key == "AK-new"
+        assert switched.secret_key == "SK-new"
+
     async def test_base_url_normalized_on_create(self, session: AsyncSession):
         repo = CredentialRepository(session)
         c = await repo.create(


### PR DESCRIPTION
## 概述

多凭证组供应商（如可灵的 API Key 单密钥 / Access Key+Secret Key 双密钥二选一）切换鉴权方式时，旧组凭证未被清除，后端按优先级静默沿用旧模式、忽略新填凭证且不报错。本 PR 在创建/更新凭证端点引入「切入」判定：完整提交某一组即视为切向该组，自动清空其它已声明组的字段，使切换立即生效。

Closes #1084

## 改动

- **`lib/config/registry.py`**：`ProviderMeta.fully_covered_credential_groups()` —— 声明驱动的凭证组覆盖判定，未声明 `credential_groups` 的供应商恒返回空、行为不变。
- **`server/routers/providers.py`**：
  - 创建/更新端点判定切组，切入某组时清空其它组字段。
  - 「切入」采用库内原值参与判定：仅当完整覆盖的组在原值中原本未完整存在时才清空另一组 —— 存量共存行上的例行密钥轮换不会误删未触碰的休眠凭证。
  - 单次提交的非空字段横跨多个互斥组时返回 422 拒绝，不再静默把用户填入的另一组字段写成 NULL。
  - `update` 先做 404 存在性检查再判切组歧义。
- **`lib/db/repositories/credential_repository.py`**：`update()` 的 `api_key`/`access_key`/`secret_key` 改用 `_UNSET` 哨兵（省略=不改，显式 None=清空），支撑切组清空。
- **i18n**：新增 `credential_group_ambiguous`（zh/en/vi）。

## 验证

- `uv run python -m pytest tests/test_config_registry.py tests/test_credential_api.py tests/test_credential_repository.py tests/test_providers_api.py tests/test_i18n_consistency.py` 全绿（新增覆盖：切入清空、共存行轮换保留、横跨多组拒绝、404 先于 422）。
- `uv run ruff check` / `uv run basedpyright`（改动文件）零告警。

## 已知 follow-up 候选（本 PR 未处理）

- 可灵由 Bearer 切到 JWT 时，非凭证组字段 `base_url`（自定义 Bearer 代理）不在清空范围内，若代理不接受官方 JWT 鉴权会在生成时报错。`base_url` 是否随切组清空取决于代理是否同时服务两种鉴权模式，属独立设计/供应商能力决策，不在本 issue 范围内。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 凭证创建/更新支持“凭证组切换”：当一次提交完整覆盖某一互斥凭证组时，会自动清空其它不再适用的字段。
- **错误修复**
  - 提交同时触及多个互斥凭证组时，返回歧义提示并拒绝请求（HTTP 422）。
  - 凭证不存在时，更新优先返回“未找到”（404），避免触发切组校验。
- **变更说明**
  - 更新接口区分“未提交”与“显式清空”：API Key / Base URL / 访问与密钥等字段可通过传入空值清空。
- **测试**
  - 扩展覆盖切组判定、清空联动与拒绝/优先级场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->