### PR TITLE
fix(frontend): 对话行编辑器用稳定 key，删除中间行不再串行内容

### DIFF
--- a/frontend/src/components/canvas/timeline/DialogueListEditor.test.tsx
+++ b/frontend/src/components/canvas/timeline/DialogueListEditor.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { DialogueListEditor } from "./DialogueListEditor";
@@ -73,5 +74,36 @@ describe("DialogueListEditor", () => {
     render(<DialogueListEditor dialogue={dialogue} onChange={onChange} />);
     fireEvent.click(screen.getByRole("button", { name: "dialogue_remove" }));
     expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("keeps each remaining row's own DOM node and content after removing a middle row", () => {
+    // Stateful wrapper: onChange feeds back into dialogue so React actually
+    // reconciles the list, which is what exposes index-key DOM reuse bugs.
+    function Wrapper() {
+      const [items, setItems] = useState<Dialogue[]>([
+        { speaker: "甲", line: "第一行" },
+        { speaker: "乙", line: "第二行" },
+        { speaker: "丙", line: "第三行" },
+      ]);
+      return <DialogueListEditor dialogue={items} onChange={setItems} />;
+    }
+    render(<Wrapper />);
+
+    const firstLineNode = screen.getByDisplayValue("第一行");
+    const thirdLineNode = screen.getByDisplayValue("第三行");
+
+    // Delete the middle row (乙/第二行).
+    const removeButtons = screen.getAllByRole("button", { name: "dialogue_remove" });
+    fireEvent.click(removeButtons[1]);
+
+    // With a stable per-row key, the surviving rows keep their own DOM nodes
+    // (and thus focus/content) instead of the third row's node being silently
+    // rebound to the first row's data via reused index-based DOM.
+    expect(screen.getByDisplayValue("第一行")).toBe(firstLineNode);
+    expect(screen.getByDisplayValue("第三行")).toBe(thirdLineNode);
+    expect(screen.queryByDisplayValue("第二行")).toBeNull();
+    expect(screen.getByDisplayValue("甲")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("丙")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("乙")).toBeNull();
   });
 });

--- a/frontend/src/components/canvas/timeline/DialogueListEditor.tsx
+++ b/frontend/src/components/canvas/timeline/DialogueListEditor.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Plus, X } from "lucide-react";
 import type { Dialogue } from "@/types";
@@ -60,12 +61,33 @@ function DialogueRow({ value, onUpdate, onRemove }: DialogueRowProps) {
   );
 }
 
+/** 下一个稳定 key：取现有 key 数字后缀最大值 +1；空序列从 d0 起，与初始化命名对齐。
+ *  纯函数，StrictMode 双调用幂等。 */
+function nextKey(keys: string[]): string {
+  if (keys.length === 0) return "d0";
+  const max = keys.reduce((m, k) => Math.max(m, Number(k.slice(1)) || 0), 0);
+  return `d${max + 1}`;
+}
+
 /** Editable list of speaker/line dialogue pairs. */
 export function DialogueListEditor({
   dialogue,
   onChange,
 }: DialogueListEditorProps) {
   const { t } = useTranslation("dashboard");
+
+  // 数据模型无 id：在编辑态派生与条目一一绑定的稳定 key，增删时同步搬运，使受控输入
+  // 节点按条目（而非按位置）复用，避免删除中间行后焦点跳行、编辑内容串到相邻行。
+  const [keys, setKeys] = useState<string[]>(() => dialogue.map((_, i) => `d${i}`));
+
+  // 外部整体替换（挂载后 adopt / revision 静默刷新）导致条目数与 key 数漂移时对齐：按位复用
+  // 已有 key、尾部补新 key、裁掉多余。本地增删已同步搬运 key，长度恒等，不触发此分支。
+  let renderKeys = keys;
+  if (keys.length !== dialogue.length) {
+    renderKeys = keys.slice(0, dialogue.length);
+    while (renderKeys.length < dialogue.length) renderKeys.push(nextKey(renderKeys));
+    setKeys(renderKeys);
+  }
 
   const update = (index: number, patch: Partial<Dialogue>) => {
     const next = dialogue.map((d, i) =>
@@ -76,17 +98,19 @@ export function DialogueListEditor({
 
   const remove = (index: number) => {
     onChange(dialogue.filter((_, i) => i !== index));
+    setKeys((prev) => prev.filter((_, i) => i !== index));
   };
 
   const add = () => {
     onChange([...dialogue, { speaker: "", line: "" }]);
+    setKeys((prev) => [...prev, nextKey(prev)]);
   };
 
   return (
     <div className="flex flex-col gap-1.5">
       {dialogue.map((d, i) => (
         <DialogueRow
-          key={i}
+          key={renderKeys[i]}
           value={d}
           onUpdate={(patch) => update(i, patch)}
           onRemove={() => remove(i)}


### PR DESCRIPTION
Closes #924

## 问题

`DialogueListEditor` 以数组下标作对话行 React key，删除某行后下标整体前移，React 按位置复用受控输入 DOM 节点：光标停在被复用行时内容悄然串到相邻行，或聚焦末行删除后输入丢失（latent、低危、删除路径触发、浏览器相关）。

## 改动

- 编辑态派生与条目一一绑定的稳定 key（`d{n}`，取现有 key 数字后缀最大值 +1），本地增删同步搬运 key 数组，使受控输入节点按条目而非按位置复用。
- 沿用同目录 `UtteranceListEditor.tsx` 已有的「派生稳定 key + 增删同步 + 长度协调」方案，保持编辑器族实现一致，未引入新模式。
- 数据模型无持久化 id，未落库；组件内自增序列即满足需求且无需 mock 即可测试。

## 验证

- 新增单测：状态化 wrapper 让 React 真正 reconcile，断言删除中间行后剩余两行 DOM 节点引用不变、内容与数据仍一一对应（旧下标 key 实现下该断言失败）。
- `pnpm lint` 通过；`pnpm check`（typecheck + 903 vitest）全绿。
- xhigh code-review：本地增删路径已正确修复；对外部整体替换（非尾部插入 / 同长度重排）的键位协调为镜像方案的既有限制，与 `UtteranceListEditor` 一致、非本次回归，其彻底修复需引入稳定唯一标识（issue 明确列为超范围）。详见 follow-up 候选。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复删除对话列表中间行后，其他行内容或编辑状态发生错位的问题。
  * 确保剩余行保持原有内容和编辑节点，避免出现内容串行或错误复用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->