### PR TITLE
fix(frontend): 诊断日志下载在 Firefox/Safari 不再因过早回收 Blob 而静默失败

### DIFF
--- a/frontend/src/components/pages/settings/AboutSection.test.tsx
+++ b/frontend/src/components/pages/settings/AboutSection.test.tsx
@@ -76,7 +76,9 @@ describe("AboutSection diagnostics download (issue #1040)", () => {
     const button = await screen.findByRole("button", { name: "下载诊断日志" });
     await user.click(button);
 
-    await waitFor(() => expect(anchorRef.current).not.toBeNull());
-    expect(anchorRef.current?.download).toBe("custom-diagnostics.zip");
+    // 直接对下载锚点的 download 断言轮询：组件恒渲染的 GitHub 署名锚点会先被
+    // createElement spy 捕获（download 为空），若只断言 anchorRef 非空会立即命中
+    // 署名锚点而非下载锚点。断言 download 值可确保轮询到 click 后创建的下载锚点。
+    await waitFor(() => expect(anchorRef.current?.download).toBe("custom-diagnostics.zip"));
   });
 });

--- a/frontend/src/components/pages/settings/AboutSection.test.tsx
+++ b/frontend/src/components/pages/settings/AboutSection.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { API } from "@/api";
+import { AboutSection } from "./AboutSection";
+import type { GetSystemVersionResponse } from "@/types/system";
+
+globalThis.URL.createObjectURL ??= vi.fn();
+globalThis.URL.revokeObjectURL ??= vi.fn();
+
+const VERSION_RESPONSE: GetSystemVersionResponse = {
+  current: { version: "1.0.0" },
+  latest: null,
+  has_update: false,
+  checked_at: "2026-07-13T00:00:00Z",
+  update_check_error: null,
+};
+
+describe("AboutSection diagnostics download (issue #1040)", () => {
+  beforeEach(() => {
+    vi.spyOn(API, "getSystemVersion").mockResolvedValue(VERSION_RESPONSE);
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-diagnostics");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+  });
+
+  it("defers URL.revokeObjectURL past the click, still revokes after the deferred timer fires", async () => {
+    vi.spyOn(API, "downloadDiagnostics").mockResolvedValue({
+      blob: new Blob(["zip-bytes"]),
+      filename: "arcreel-diagnostics.zip",
+    });
+
+    // 先用真实定时器渲染完成，避免 findByRole/waitFor 的内部轮询与 fake timers 相互卡死
+    render(<AboutSection />);
+    await waitFor(() => expect(API.getSystemVersion).toHaveBeenCalled());
+    const button = screen.getByRole("button", { name: "下载诊断日志" });
+
+    // 切换到 fake timers 后再点击：click() 是同步调度，异步延续只在微任务
+    // 中运行，可精确区分「微任务已跑完」与「宏任务（setTimeout）已触发」两个时间点
+    vi.useFakeTimers();
+    try {
+      fireEvent.click(button);
+      // 仅推进微任务队列，不推进定时器：让 handleDownloadDiagnostics 的
+      // await 之后的逻辑（createObjectURL / click / setTimeout 调度）跑完
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+      }
+
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+      // click() 触发下载后不应同步回收，否则部分浏览器下载会静默失败
+      expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-diagnostics");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the download filename unchanged", async () => {
+    vi.spyOn(API, "downloadDiagnostics").mockResolvedValue({
+      blob: new Blob(["zip-bytes"]),
+      filename: "custom-diagnostics.zip",
+    });
+    const user = userEvent.setup();
+    const anchorRef: { current: HTMLAnchorElement | null } = { current: null };
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      const el = originalCreateElement(tagName);
+      if (tagName === "a") anchorRef.current = el as HTMLAnchorElement;
+      return el;
+    });
+
+    render(<AboutSection />);
+    await waitFor(() => expect(API.getSystemVersion).toHaveBeenCalled());
+
+    const button = await screen.findByRole("button", { name: "下载诊断日志" });
+    await user.click(button);
+
+    await waitFor(() => expect(anchorRef.current).not.toBeNull());
+    expect(anchorRef.current?.download).toBe("custom-diagnostics.zip");
+  });
+});

--- a/frontend/src/components/pages/settings/AboutSection.test.tsx
+++ b/frontend/src/components/pages/settings/AboutSection.test.tsx
@@ -62,11 +62,11 @@ describe("AboutSection diagnostics download (issue #1040)", () => {
       filename: "custom-diagnostics.zip",
     });
     const user = userEvent.setup();
-    const anchorRef: { current: HTMLAnchorElement | null } = { current: null };
+    const createdAnchors: HTMLAnchorElement[] = [];
     const originalCreateElement = document.createElement.bind(document);
     vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
       const el = originalCreateElement(tagName);
-      if (tagName === "a") anchorRef.current = el as HTMLAnchorElement;
+      if (tagName === "a") createdAnchors.push(el as HTMLAnchorElement);
       return el;
     });
 
@@ -76,9 +76,12 @@ describe("AboutSection diagnostics download (issue #1040)", () => {
     const button = await screen.findByRole("button", { name: "下载诊断日志" });
     await user.click(button);
 
-    // 直接对下载锚点的 download 断言轮询：组件恒渲染的 GitHub 署名锚点会先被
-    // createElement spy 捕获（download 为空），若只断言 anchorRef 非空会立即命中
-    // 署名锚点而非下载锚点。断言 download 值可确保轮询到 click 后创建的下载锚点。
-    await waitFor(() => expect(anchorRef.current?.download).toBe("custom-diagnostics.zip"));
+    // 遍历全部被创建的 <a> 标签查找下载锚点，不依赖「单一可变引用最后一次写入即为目标」
+    // 的假设——组件恒渲染的 GitHub 署名锚点先于下载锚点创建；用数组可避免未来若有更多
+    // <a> 创建（例如重渲染顺序变化）时单一引用被覆盖导致测试失真。
+    await waitFor(() => {
+      const target = createdAnchors.find((a) => a.download === "custom-diagnostics.zip");
+      expect(target).toBeDefined();
+    });
   });
 });

--- a/frontend/src/components/pages/settings/AboutSection.tsx
+++ b/frontend/src/components/pages/settings/AboutSection.tsx
@@ -39,17 +39,18 @@ export function AboutSection() {
     try {
       const { blob, filename } = await API.downloadDiagnostics();
       const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
       try {
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = filename;
         document.body.appendChild(a);
         a.click();
         a.remove();
       } finally {
         // Firefox / Safari 在下载任务尚未开始读取 Blob 前同步 revoke 会导致下载静默失败；
-        // 推迟到下一个宏任务再回收，确保下载已启动读取。DOM 操作本身若抛错也不能跳过
-        // revoke，否则 Blob URL 永久泄漏，故用 finally 兜底
+        // 推迟到下一个宏任务再回收，确保下载已启动读取。createElement / 属性赋值 /
+        // DOM 操作任一环节抛错都不能跳过 revoke，否则 Blob URL 永久泄漏，故 try 从
+        // createObjectURL 之后即开始覆盖，用 finally 兜底
         setTimeout(() => URL.revokeObjectURL(url), 0);
       }
     } catch (err) {

--- a/frontend/src/components/pages/settings/AboutSection.tsx
+++ b/frontend/src/components/pages/settings/AboutSection.tsx
@@ -42,12 +42,16 @@ export function AboutSection() {
       const a = document.createElement("a");
       a.href = url;
       a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      // Firefox / Safari 在下载任务尚未开始读取 Blob 前同步 revoke 会导致下载静默失败；
-      // 推迟到下一个宏任务再回收，确保下载已启动读取
-      setTimeout(() => URL.revokeObjectURL(url), 0);
+      try {
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+      } finally {
+        // Firefox / Safari 在下载任务尚未开始读取 Blob 前同步 revoke 会导致下载静默失败；
+        // 推迟到下一个宏任务再回收，确保下载已启动读取。DOM 操作本身若抛错也不能跳过
+        // revoke，否则 Blob URL 永久泄漏，故用 finally 兜底
+        setTimeout(() => URL.revokeObjectURL(url), 0);
+      }
     } catch (err) {
       if (!mountedRef.current) return;
       setDownloadError(err instanceof Error ? err.message : String(err));

--- a/frontend/src/components/pages/settings/AboutSection.tsx
+++ b/frontend/src/components/pages/settings/AboutSection.tsx
@@ -45,7 +45,9 @@ export function AboutSection() {
       document.body.appendChild(a);
       a.click();
       a.remove();
-      URL.revokeObjectURL(url);
+      // Firefox / Safari 在下载任务尚未开始读取 Blob 前同步 revoke 会导致下载静默失败；
+      // 推迟到下一个宏任务再回收，确保下载已启动读取
+      setTimeout(() => URL.revokeObjectURL(url), 0);
     } catch (err) {
       if (!mountedRef.current) return;
       setDownloadError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
Closes #1040

## 问题

设置-关于页的诊断日志下载在 `a.click()` 后**同步**调用 `URL.revokeObjectURL(url)`。Firefox/Safari 的下载任务异步开始读取 Blob，同步回收会在读取前移除 Blob URL，导致下载静默失败（点击后无文件落地、无错误提示），诊断包越大窗口期越明显。

## 改动

- `AboutSection.tsx`：将 `URL.revokeObjectURL(url)` 从同步调用改为 `setTimeout(() => URL.revokeObjectURL(url), 0)`，推迟到下一个宏任务再回收，让下载任务先启动读取；回收不受 `mountedRef` 门控（组件卸载也需回收，避免 Blob URL 泄漏，为有意行为）。
- 新增 `AboutSection.test.tsx`（此前该组件无测试）：用 fake timers 断言 `revokeObjectURL` 在 click 后**未同步**回收、在 `setTimeout(0)` 宏任务触发后才回收；另断言下载文件名保持不变。

## 本地审查修复

对下载文件名测试，原 `waitFor` 只断言 `anchorRef` 非空，会被组件恒渲染的 GitHub 署名锚点立即命中，无法真正等待 click 后创建的下载锚点（xhigh code-review 经探针实测确认）。已改为直接对 `download` 属性值轮询。

## 验证

- `pnpm lint` ✅
- `pnpm check`（typecheck + lint + vitest）✅ — 103 文件 / 904 测试全绿，含新增用例
- 分支基于最新 origin/main，无需 rebase

## 已知限制

固定延迟为 0ms（一个宏任务），未在真实 Firefox/Safari 浏览器手动验证下载启动读取所需的确切时机余量；仅经 jsdom + fake timers 断言时序。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复“下载诊断日志”在部分浏览器中可能静默失败的问题。
  * 调整对象 URL 清理时机：改为延迟回收，并使用兜底逻辑确保即使中途发生异常也能最终回收，同时保持下载文件名不变。
* **Tests**
  * 新增测试用例，覆盖延迟回收 ObjectURL 的调用时机与参数校验，并验证下载锚点的文件名与预期一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->