### PR TITLE
fix(server): drama/ad 项目生成完成通知按骨架显示正确名词，不再一律标「分镜」

### DIFF
--- a/frontend/src/utils/project-changes.test.ts
+++ b/frontend/src/utils/project-changes.test.ts
@@ -101,4 +101,32 @@ describe("project-changes utils", () => {
       );
     }
   });
+
+  it("labels reference_unit notifications as 视频单元, not the 内容 fallback", () => {
+    // 回归 issue #1036：后端曾把参考生视频任务完成事件的 entity_type 发成前端不认识的
+    // "reference_video_unit"，落 ENTITY_LABELS 兜底显示「内容」。修复后 entity_type 与前端
+    // 联合类型的 "reference_unit" 对齐，分组标题应显示「视频单元」。action 用 "updated"：
+    // 生产中该通知实际带 "reference_video_ready"（不在 ProjectChange["action"] 联合类型内，
+    // 类型收窄不在本 issue 范围），但 getEntityLabel 对非 storyboard/video/grid_ready 的
+    // action 走同一条 ENTITY_LABELS 兜底分支，"updated" 足以复现并锁定这条修复路径。
+    const [group] = groupChangesByType([
+      makeChange({
+        entity_type: "reference_unit",
+        action: "updated",
+        entity_id: "U01",
+        label: "参考视频「U01」",
+      }),
+      makeChange({
+        entity_type: "reference_unit",
+        action: "updated",
+        entity_id: "U02",
+        label: "参考视频「U02」",
+      }),
+    ]);
+
+    expect(formatGroupedNotificationText(group)).toBe(
+      "更新了 2 个视频单元：U01、U02",
+    );
+    expect(formatGroupedNotificationText(group)).not.toContain("内容");
+  });
 });

--- a/frontend/src/utils/project-changes.test.ts
+++ b/frontend/src/utils/project-changes.test.ts
@@ -103,11 +103,11 @@ describe("project-changes utils", () => {
   });
 
   it("labels reference_unit notifications as 视频单元, not the 内容 fallback", () => {
-    // 回归 issue #1036：后端曾把参考生视频任务完成事件的 entity_type 发成前端不认识的
+    // 回归：后端曾把参考生视频任务完成事件的 entity_type 发成前端不认识的
     // "reference_video_unit"，落 ENTITY_LABELS 兜底显示「内容」。修复后 entity_type 与前端
     // 联合类型的 "reference_unit" 对齐，分组标题应显示「视频单元」。action 用 "updated"：
     // 生产中该通知实际带 "reference_video_ready"（不在 ProjectChange["action"] 联合类型内，
-    // 类型收窄不在本 issue 范围），但 getEntityLabel 对非 storyboard/video/grid_ready 的
+    // 类型收窄属独立缺口），但 getEntityLabel 对非 storyboard/video/grid_ready 的
     // action 走同一条 ENTITY_LABELS 兜底分支，"updated" 足以复现并锁定这条修复路径。
     const [group] = groupChangesByType([
       makeChange({

--- a/lib/script_skeleton.py
+++ b/lib/script_skeleton.py
@@ -45,6 +45,36 @@ SKELETONS: dict[str, Skeleton] = {
     "video_units": Skeleton("unit_id", None),
 }
 
+# 条目名词按骨架种类硬编码——驱动分镜级事件与任务完成事件共用的通知文案（如「镜头「E1S01」」）。
+# 名词 i18n 化是独立议题（与 ``_diff_named_entities`` 的「角色」/「线索」同为既有硬编码形态），
+# 不在此处收敛。两套事件路径必须读同一张表，不各自维护一份（见 issue #1036）。
+SKELETON_ITEM_NOUNS: dict[str, str] = {
+    "segments": "分镜",
+    "scenes": "场景",
+    "shots": "镜头",
+    "video_units": "视频单元",
+}
+
+# 事件的实体类型按骨架种类推导，与 ``SKELETON_ITEM_NOUNS`` 同源。驱动前端分组标签映射
+# （``ENTITY_LABELS``），使四种骨架各显分镜/场景/镜头/视频单元，而非恒为「分镜」。取值与既有
+# ``entity_type`` 枚举不冲突（drama 用 ``drama_scene`` 避免与命名实体 ``scene`` 撞组）。
+SKELETON_ENTITY_TYPES: dict[str, str] = {
+    "segments": "segment",
+    "scenes": "drama_scene",
+    "shots": "shot",
+    "video_units": "reference_unit",
+}
+
+# 事件的锚点类型按骨架种类推导，取值与前端各画布的滚动目标类型守卫对齐：video_units 归
+# ``reference_unit``（参考生视频画布按此选中并高亮对应视频单元），其余归 ``segment``
+# （narration/drama/ad 共用时间线镜头拆分视图，按 id 选中条目）。
+SKELETON_ANCHOR_TYPES: dict[str, str] = {
+    "segments": "segment",
+    "scenes": "segment",
+    "shots": "segment",
+    "video_units": "reference_unit",
+}
+
 
 def _validate_registry() -> None:
     """import 期表自洽校验：四骨架齐全、字段合法。失败即启动炸（同 ``docs/adr/0039`` 手法）。"""
@@ -57,6 +87,13 @@ def _validate_registry() -> None:
         # chars_field 为 None 合法（video_units 显式缺位）；空串非法。
         if skeleton.chars_field is not None and not skeleton.chars_field:
             raise RuntimeError(f"SKELETONS[{kind!r}].chars_field 非法：{skeleton.chars_field!r}")
+    for name, table in (
+        ("SKELETON_ITEM_NOUNS", SKELETON_ITEM_NOUNS),
+        ("SKELETON_ENTITY_TYPES", SKELETON_ENTITY_TYPES),
+        ("SKELETON_ANCHOR_TYPES", SKELETON_ANCHOR_TYPES),
+    ):
+        if set(table) != expected:
+            raise RuntimeError(f"{name} 骨架种类不齐：期望 {expected}，实际 {set(table)}")
 
 
 _validate_registry()

--- a/lib/script_skeleton.py
+++ b/lib/script_skeleton.py
@@ -47,7 +47,7 @@ SKELETONS: dict[str, Skeleton] = {
 
 # 条目名词按骨架种类硬编码——驱动分镜级事件与任务完成事件共用的通知文案（如「镜头「E1S01」」）。
 # 名词 i18n 化是独立议题（与 ``_diff_named_entities`` 的「角色」/「线索」同为既有硬编码形态），
-# 不在此处收敛。两套事件路径必须读同一张表，不各自维护一份（见 issue #1036）。
+# 不在此处收敛。两套事件路径必须读同一张表，不各自维护一份。
 SKELETON_ITEM_NOUNS: dict[str, str] = {
     "segments": "分镜",
     "scenes": "场景",

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -587,7 +587,7 @@ def _product_references_for_video(generator: Any, project: dict, project_path: P
 
 
 def _episode_from_script(script: dict[str, Any] | None) -> int | None:
-    if script is None:
+    if not isinstance(script, dict):
         return None
     episode = script.get("episode")
     if isinstance(episode, int):
@@ -767,7 +767,14 @@ def emit_generation_success_batch(
 
     action = _SKELETON_DRIVEN_TASK_ACTIONS.get(task_type)
     if action is not None:
-        kind = resolve_script_kind(script) if script is not None else "segments"
+        if task_type == "reference_video":
+            # ad 剧本骨架恒为 shots[]（reference_video 路径只是把镜头派生分组为
+            # video_unit 索引，二者持久于同一份剧本 JSON），resolve_script_kind
+            # 的数据形状优先判别会因 shots 键仍在而退回 content_mode==ad→shots，
+            # 与该任务实际对应 video_unit 资源不符——直接固定 kind，不经骨架判别。
+            kind = "video_units"
+        else:
+            kind = resolve_script_kind(script) if isinstance(script, dict) else "segments"
         entity_type = SKELETON_ENTITY_TYPES.get(kind, "segment")
         noun = _SKELETON_TASK_LABEL_NOUNS.get(task_type) or SKELETON_ITEM_NOUNS.get(kind, "分镜")
         label_tpl = f"{noun}「{{}}」"

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -42,6 +42,7 @@ from lib.prompt_utils import (
 )
 from lib.reference_compression import ReferencePayloadFloorError
 from lib.resource_paths import resource_relative_path
+from lib.script_skeleton import SKELETON_ENTITY_TYPES, SKELETON_ITEM_NOUNS, resolve_script_kind
 from lib.storyboard_sequence import (
     build_previous_storyboard_reference,
     find_storyboard_item,
@@ -715,14 +716,44 @@ def compute_affected_fingerprints(project_name: str, task_type: str, resource_id
 
 # (entity_type, action, label_tpl, include_script_episode)
 # 三类项目级资产（character / scene / prop）的 spec 由 lib.asset_types.ASSET_SPECS 派生。
+# storyboard / video / reference_video 不在此表——三者按剧本骨架种类（segments/scenes/shots/
+# video_units）动态派生 entity_type 与条目名词，见 _SKELETON_DRIVEN_TASK_ACTIONS，避免恒发
+# ``segment``/「分镜」而与分镜级事件（project_events.py）名词不一致（issue #1036）。
 _TASK_CHANGE_SPECS: dict[str, tuple] = {
-    "storyboard": ("segment", "storyboard_ready", "分镜「{}」", True),
-    "video": ("segment", "video_ready", "分镜「{}」", True),
     "tts": ("segment", "tts_ready", "旁白「{}」", True),
     "grid": ("grid", "grid_ready", "宫格「{}」", True),
-    "reference_video": ("reference_video_unit", "reference_video_ready", "参考视频「{}」", True),
     **{atype: (atype, "updated", f"{spec.label_zh}「{{}}」设计图", False) for atype, spec in ASSET_SPECS.items()},
 }
+
+# 骨架驱动的任务类型 → 完成事件 action。entity_type/条目名词按项目剧本当前骨架种类
+# （resolve_script_kind，与分镜级事件同一判定）动态解析，不按 task_type 恒定硬编码。
+_SKELETON_DRIVEN_TASK_ACTIONS: dict[str, str] = {
+    "storyboard": "storyboard_ready",
+    "video": "video_ready",
+    "reference_video": "reference_video_ready",
+}
+
+# reference_video 的条目标签沿用「参考视频」措辞（区别于分镜级事件的骨架名词「视频单元」，
+# 两者服务不同场景：此为任务完成通知的条目文案，不在本 issue 收敛）；storyboard/video 未列出，
+# 回退到骨架名词本身（分镜/场景/镜头），与同项目分镜级事件同口径。
+_SKELETON_TASK_LABEL_NOUNS: dict[str, str] = {
+    "reference_video": "参考视频",
+}
+
+
+def _resolve_skeleton_kind_for_task(project_name: str, script_file: str | None) -> str:
+    """任务完成事件复用分镜级事件的骨架判定（``resolve_script_kind``），不独立维护第二套。
+
+    加载失败（脚本缺失/损坏）时回退 ``"segments"``，与既有 ``SKELETON_ENTITY_TYPES.get(kind,
+    "segment")`` 兜底口径一致，不让通知发送因骨架判定失败而中断。
+    """
+    if not script_file:
+        return "segments"
+    try:
+        script = get_project_manager().load_script(project_name, script_file)
+    except Exception:
+        return "segments"
+    return resolve_script_kind(script)
 
 
 def emit_generation_success_batch(
@@ -736,11 +767,21 @@ def emit_generation_success_batch(
 
     事件 source 由 project_change_source contextvar 决定（worker / webui 调用方各自包裹）。
     """
-    spec = _TASK_CHANGE_SPECS.get(task_type)
-    if spec is None:
-        return {}
+    script_file = str(payload.get("script_file") or "") or None
 
-    entity_type, action, label_tpl, include_script_episode = spec
+    action = _SKELETON_DRIVEN_TASK_ACTIONS.get(task_type)
+    if action is not None:
+        kind = _resolve_skeleton_kind_for_task(project_name, script_file)
+        entity_type = SKELETON_ENTITY_TYPES.get(kind, "segment")
+        noun = _SKELETON_TASK_LABEL_NOUNS.get(task_type) or SKELETON_ITEM_NOUNS.get(kind, "分镜")
+        label_tpl = f"{noun}「{{}}」"
+        include_script_episode = True
+    else:
+        spec = _TASK_CHANGE_SPECS.get(task_type)
+        if spec is None:
+            return {}
+        entity_type, action, label_tpl, include_script_episode = spec
+
     asset_fingerprints = compute_affected_fingerprints(project_name, task_type, resource_id)
 
     change: dict[str, Any] = {
@@ -753,7 +794,6 @@ def emit_generation_success_batch(
         "asset_fingerprints": asset_fingerprints,
     }
     if include_script_episode:
-        script_file = str(payload.get("script_file") or "") or None
         change["script_file"] = script_file
         change["episode"] = _resolve_script_episode(project_name, script_file)
 

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -586,14 +586,9 @@ def _product_references_for_video(generator: Any, project: dict, project_path: P
     return references
 
 
-def _resolve_script_episode(project_name: str, script_file: str | None) -> int | None:
-    if not script_file:
+def _episode_from_script(script: dict[str, Any] | None) -> int | None:
+    if script is None:
         return None
-    try:
-        script = get_project_manager().load_script(project_name, script_file)
-    except Exception:
-        return None
-
     episode = script.get("episode")
     if isinstance(episode, int):
         return episode
@@ -718,7 +713,7 @@ def compute_affected_fingerprints(project_name: str, task_type: str, resource_id
 # 三类项目级资产（character / scene / prop）的 spec 由 lib.asset_types.ASSET_SPECS 派生。
 # storyboard / video / reference_video 不在此表——三者按剧本骨架种类（segments/scenes/shots/
 # video_units）动态派生 entity_type 与条目名词，见 _SKELETON_DRIVEN_TASK_ACTIONS，避免恒发
-# ``segment``/「分镜」而与分镜级事件（project_events.py）名词不一致（issue #1036）。
+# ``segment``/「分镜」而与分镜级事件（project_events.py）名词不一致。
 _TASK_CHANGE_SPECS: dict[str, tuple] = {
     "tts": ("segment", "tts_ready", "旁白「{}」", True),
     "grid": ("grid", "grid_ready", "宫格「{}」", True),
@@ -734,26 +729,25 @@ _SKELETON_DRIVEN_TASK_ACTIONS: dict[str, str] = {
 }
 
 # reference_video 的条目标签沿用「参考视频」措辞（区别于分镜级事件的骨架名词「视频单元」，
-# 两者服务不同场景：此为任务完成通知的条目文案，不在本 issue 收敛）；storyboard/video 未列出，
+# 两者服务不同场景：此为任务完成通知的条目文案，不随骨架名词收敛）；storyboard/video 未列出，
 # 回退到骨架名词本身（分镜/场景/镜头），与同项目分镜级事件同口径。
 _SKELETON_TASK_LABEL_NOUNS: dict[str, str] = {
     "reference_video": "参考视频",
 }
 
 
-def _resolve_skeleton_kind_for_task(project_name: str, script_file: str | None) -> str:
-    """任务完成事件复用分镜级事件的骨架判定（``resolve_script_kind``），不独立维护第二套。
+def _load_event_script(project_name: str, script_file: str | None) -> dict[str, Any] | None:
+    """加载完成事件所属剧本一次，供骨架种类与 episode 共用；缺失/损坏时返回 None。
 
-    加载失败（脚本缺失/损坏）时回退 ``"segments"``，与既有 ``SKELETON_ENTITY_TYPES.get(kind,
-    "segment")`` 兜底口径一致，不让通知发送因骨架判定失败而中断。
+    调用方对 None 各自兜底（骨架种类回退 ``"segments"``、episode 回退 ``None``），
+    不让剧本加载失败导致通知发送中断。
     """
     if not script_file:
-        return "segments"
+        return None
     try:
-        script = get_project_manager().load_script(project_name, script_file)
+        return get_project_manager().load_script(project_name, script_file)
     except Exception:
-        return "segments"
-    return resolve_script_kind(script)
+        return None
 
 
 def emit_generation_success_batch(
@@ -768,10 +762,12 @@ def emit_generation_success_batch(
     事件 source 由 project_change_source contextvar 决定（worker / webui 调用方各自包裹）。
     """
     script_file = str(payload.get("script_file") or "") or None
+    # 单次加载剧本，骨架种类与 episode 共用，避免同一 script_file 双解析。
+    script = _load_event_script(project_name, script_file)
 
     action = _SKELETON_DRIVEN_TASK_ACTIONS.get(task_type)
     if action is not None:
-        kind = _resolve_skeleton_kind_for_task(project_name, script_file)
+        kind = resolve_script_kind(script) if script is not None else "segments"
         entity_type = SKELETON_ENTITY_TYPES.get(kind, "segment")
         noun = _SKELETON_TASK_LABEL_NOUNS.get(task_type) or SKELETON_ITEM_NOUNS.get(kind, "分镜")
         label_tpl = f"{noun}「{{}}」"
@@ -795,7 +791,7 @@ def emit_generation_success_batch(
     }
     if include_script_episode:
         change["script_file"] = script_file
-        change["episode"] = _resolve_script_episode(project_name, script_file)
+        change["episode"] = _episode_from_script(script)
 
     try:
         emit_project_change_batch(project_name, [change])

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -25,7 +25,13 @@ from lib.project_change_hints import (
     register_project_change_listener,
 )
 from lib.project_manager import ProjectManager, effective_mode
-from lib.script_skeleton import SKELETONS, resolve_script_kind
+from lib.script_skeleton import (
+    SKELETON_ANCHOR_TYPES,
+    SKELETON_ENTITY_TYPES,
+    SKELETON_ITEM_NOUNS,
+    SKELETONS,
+    resolve_script_kind,
+)
 from server.sse_channel import IDLE, DropSubscriber, SseChannel
 
 logger = logging.getLogger(__name__)
@@ -34,36 +40,6 @@ PROJECT_EVENTS_POLL_SECONDS = 0.5
 
 # 项目目录被删除后向订阅者广播的终止事件名——流在其后正常结束（见 stream_events._iter）。
 PROJECT_DELETED_EVENT = "project_deleted"
-
-
-# 条目名词按骨架种类硬编码——用于分镜级事件标签（如「镜头「E1S01」」）。名词 i18n 化是
-# 独立议题（与 ``_diff_named_entities`` 的「角色」/「线索」同为既有硬编码形态），不在此处收敛。
-_SKELETON_ITEM_NOUNS: dict[str, str] = {
-    "segments": "分镜",
-    "scenes": "场景",
-    "shots": "镜头",
-    "video_units": "视频单元",
-}
-
-# 分镜级事件的实体类型按骨架种类推导，与 ``_SKELETON_ITEM_NOUNS`` 同源。驱动前端分组标签映射
-# （``ENTITY_LABELS``），使四种骨架各显分镜/场景/镜头/视频单元，而非恒为「分镜」。取值与既有
-# ``entity_type`` 枚举不冲突（drama 用 ``drama_scene`` 避免与命名实体 ``scene`` 撞组）。
-_SKELETON_ENTITY_TYPES: dict[str, str] = {
-    "segments": "segment",
-    "scenes": "drama_scene",
-    "shots": "shot",
-    "video_units": "reference_unit",
-}
-
-# 分镜级事件的锚点类型按骨架种类推导，取值与前端各画布的滚动目标类型守卫对齐：video_units 归
-# ``reference_unit``（参考生视频画布按此选中并高亮对应视频单元），其余归 ``segment``
-# （narration/drama/ad 共用时间线镜头拆分视图，按 id 选中条目）。
-_SKELETON_ANCHOR_TYPES: dict[str, str] = {
-    "segments": "segment",
-    "scenes": "segment",
-    "shots": "segment",
-    "video_units": "reference_unit",
-}
 
 
 def _utc_now_iso() -> str:
@@ -1087,11 +1063,11 @@ class ProjectEventService:
 
     @staticmethod
     def _script_item_entity_type(script_meta: dict[str, Any]) -> str:
-        return _SKELETON_ENTITY_TYPES.get(ProjectEventService._script_kind(script_meta), "segment")
+        return SKELETON_ENTITY_TYPES.get(ProjectEventService._script_kind(script_meta), "segment")
 
     @staticmethod
     def _script_item_anchor_type(script_meta: dict[str, Any]) -> str:
-        return _SKELETON_ANCHOR_TYPES.get(ProjectEventService._script_kind(script_meta), "segment")
+        return SKELETON_ANCHOR_TYPES.get(ProjectEventService._script_kind(script_meta), "segment")
 
     @staticmethod
     def _build_script_item_focus(
@@ -1107,7 +1083,7 @@ class ProjectEventService:
 
     @staticmethod
     def _build_script_item_label(item_id: str, script_meta: dict[str, Any]) -> str:
-        noun = _SKELETON_ITEM_NOUNS.get(ProjectEventService._script_kind(script_meta), "分镜")
+        noun = SKELETON_ITEM_NOUNS.get(ProjectEventService._script_kind(script_meta), "分镜")
         return f"{noun}「{item_id}」"
 
     def _build_script_item_change(

--- a/tests/test_generation_tasks_dispatch.py
+++ b/tests/test_generation_tasks_dispatch.py
@@ -14,7 +14,7 @@ def test_task_change_action_registered_for_reference_video():
     # entity_type 不再是静态 spec：按剧本骨架种类动态解析（见
     # test_generation_tasks_service.py 里对 emit_generation_success_batch 的骨架覆盖用例），
     # 与前端 ProjectChange["entity_type"] 联合类型的 "reference_unit" 对齐，不再是仅本侧
-    # 认识的 "reference_video_unit"（issue #1036）。
+    # 认识的 "reference_video_unit"。
     assert _SKELETON_DRIVEN_TASK_ACTIONS.get("reference_video") == "reference_video_ready"
 
 

--- a/tests/test_generation_tasks_dispatch.py
+++ b/tests/test_generation_tasks_dispatch.py
@@ -3,20 +3,19 @@ from __future__ import annotations
 import pytest
 
 from lib.image_backends.base import ImageCapabilityError
-from server.services.generation_tasks import _TASK_CHANGE_SPECS, _TASK_EXECUTORS
+from server.services.generation_tasks import _SKELETON_DRIVEN_TASK_ACTIONS, _TASK_EXECUTORS
 
 
 def test_task_executors_registered_for_reference_video():
     assert "reference_video" in _TASK_EXECUTORS
 
 
-def test_task_change_specs_registered_for_reference_video():
-    spec = _TASK_CHANGE_SPECS.get("reference_video")
-    assert spec is not None
-    entity_type, action, _label_tpl, include_script_episode = spec
-    assert entity_type == "reference_video_unit"
-    assert action == "reference_video_ready"
-    assert include_script_episode is True
+def test_task_change_action_registered_for_reference_video():
+    # entity_type 不再是静态 spec：按剧本骨架种类动态解析（见
+    # test_generation_tasks_service.py 里对 emit_generation_success_batch 的骨架覆盖用例），
+    # 与前端 ProjectChange["entity_type"] 联合类型的 "reference_unit" 对齐，不再是仅本侧
+    # 认识的 "reference_video_unit"（issue #1036）。
+    assert _SKELETON_DRIVEN_TASK_ACTIONS.get("reference_video") == "reference_video_ready"
 
 
 @pytest.mark.asyncio

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -856,6 +856,41 @@ class TestGenerationTasks:
         assert change["action"] == "reference_video_ready"
         assert change["label"] == "参考视频「U01」"
 
+    def test_emit_success_batch_reference_video_ad_entity_type_not_shot(self, monkeypatch, tmp_path):
+        """ad 剧本骨架恒为 shots[]，reference_video 路径派生的 video_unit 索引与 shots
+        同存于一份剧本 JSON——resolve_script_kind 的数据形状判别会因 shots 键仍在而落回
+        content_mode==ad→shots，与该任务实际对应 video_unit 资源不符，故需固定解析，
+        不随骨架判别漂到 "shot"。"""
+        captured = []
+        monkeypatch.setattr(
+            generation_tasks,
+            "emit_project_change_batch",
+            lambda project_name, changes: captured.append(changes),
+        )
+
+        project_path = tmp_path / "demo"
+        project_path.mkdir()
+        fake_pm = _FakePM(project_path)
+        fake_pm.script = {
+            "content_mode": "ad",
+            "shots": [{"shot_id": "E1S01"}],
+            "video_units": [{"unit_id": "U01", "shot_ids": ["E1S01"]}],
+        }
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+
+        generation_tasks.emit_generation_success_batch(
+            task_type="reference_video",
+            project_name="demo",
+            resource_id="U01",
+            payload={"script_file": "episode_1.json"},
+        )
+
+        assert len(captured) == 1
+        change = captured[0][0]
+        assert change["entity_type"] == "reference_unit"
+        assert change["action"] == "reference_video_ready"
+        assert change["label"] == "参考视频「U01」"
+
     def test_emit_success_batch_falls_back_to_segments_when_script_load_fails(self, monkeypatch, tmp_path):
         """骨架判定拿不到剧本（脚本缺失/损坏）时兜底 segments/「分镜」，不让通知发送中断。"""
         captured = []
@@ -880,6 +915,34 @@ class TestGenerationTasks:
             project_name="demo",
             resource_id="E1S01",
             payload={"script_file": "missing.json"},
+        )
+
+        assert len(captured) == 1
+        change = captured[0][0]
+        assert change["entity_type"] == "segment"
+        assert change["label"] == "分镜「E1S01」"
+
+    def test_emit_success_batch_falls_back_to_segments_when_script_not_a_dict(self, monkeypatch, tmp_path):
+        """剧本文件内容损坏成非 dict（如顶层数组）时兜底 segments/「分镜」，不让
+        resolve_script_kind 内部的 .get() 调用抛 AttributeError 中断通知发送。"""
+        captured = []
+        monkeypatch.setattr(
+            generation_tasks,
+            "emit_project_change_batch",
+            lambda project_name, changes: captured.append(changes),
+        )
+
+        project_path = tmp_path / "demo"
+        project_path.mkdir()
+        fake_pm = _FakePM(project_path)
+        fake_pm.script = ["not", "a", "dict"]
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+
+        generation_tasks.emit_generation_success_batch(
+            task_type="storyboard",
+            project_name="demo",
+            resource_id="E1S01",
+            payload={"script_file": "corrupted.json"},
         )
 
         assert len(captured) == 1

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -798,7 +798,7 @@ class TestGenerationTasks:
         self, monkeypatch, tmp_path, script, expected_entity_type, expected_label
     ):
         """storyboard/video 任务完成通知与分镜级事件同口径：实体类型与名词按项目剧本骨架
-        种类解析，不恒为 narration 的 segment/「分镜」（issue #1036）。"""
+        种类解析，不恒为 narration 的 segment/「分镜」。"""
         captured = []
         monkeypatch.setattr(
             generation_tasks,
@@ -829,7 +829,7 @@ class TestGenerationTasks:
     def test_emit_success_batch_reference_video_entity_type_aligns_with_frontend(self, monkeypatch, tmp_path):
         """参考生视频任务完成通知的 entity_type 需为前端联合类型认识的 "reference_unit"
         （而非仅本侧认识的 "reference_video_unit"），分组标题才能落「视频单元」而非「内容」
-        兜底；条目文案仍沿用「参考视频」措辞，不随骨架名词改动（issue #1036）。"""
+        兜底；条目文案仍沿用「参考视频」措辞，不随骨架名词改动。"""
         captured = []
         monkeypatch.setattr(
             generation_tasks,
@@ -886,6 +886,35 @@ class TestGenerationTasks:
         change = captured[0][0]
         assert change["entity_type"] == "segment"
         assert change["label"] == "分镜「E1S01」"
+
+    def test_emit_success_batch_attaches_script_file_and_episode(self, monkeypatch, tmp_path):
+        """骨架驱动的完成事件须挂 script_file 与 episode（供 episode 作用域消费方使用）——
+        锁死这条挂载，防将来改动 emit 时静默丢字段。"""
+        captured = []
+        monkeypatch.setattr(
+            generation_tasks,
+            "emit_project_change_batch",
+            lambda project_name, changes: captured.append(changes),
+        )
+
+        project_path = tmp_path / "demo"
+        project_path.mkdir()
+        fake_pm = _FakePM(project_path)
+        fake_pm.script = {"content_mode": "narration", "episode": 3, "segments": [{"segment_id": "E3S01"}]}
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+
+        for task_type in ("storyboard", "video", "reference_video"):
+            captured.clear()
+            generation_tasks.emit_generation_success_batch(
+                task_type=task_type,
+                project_name="demo",
+                resource_id="E3S01",
+                payload={"script_file": "ep03.json"},
+            )
+            assert len(captured) == 1
+            change = captured[0][0]
+            assert change["script_file"] == "ep03.json"
+            assert change["episode"] == 3
 
     def test_grid_fingerprints_include_split_cells(self, monkeypatch, tmp_path):
         """宫格指纹应包含切割覆写的 canonical 分镜图（cache-bust），但拒绝越出项目目录的路径"""

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -771,6 +771,122 @@ class TestGenerationTasks:
         assert "storyboards/scene_E1S01.png" in change["asset_fingerprints"]
         assert isinstance(change["asset_fingerprints"]["storyboards/scene_E1S01.png"], int)
 
+    @pytest.mark.parametrize(
+        ("script", "expected_entity_type", "expected_label"),
+        [
+            pytest.param(
+                {"content_mode": "drama", "scenes": [{"scene_id": "E1S01"}]},
+                "drama_scene",
+                "场景「E1S01」",
+                id="drama-scenes",
+            ),
+            pytest.param(
+                {"content_mode": "ad", "shots": [{"shot_id": "E1S01"}]},
+                "shot",
+                "镜头「E1S01」",
+                id="ad-shots",
+            ),
+            pytest.param(
+                {"content_mode": "narration", "segments": [{"segment_id": "E1S01"}]},
+                "segment",
+                "分镜「E1S01」",
+                id="narration-segments",
+            ),
+        ],
+    )
+    def test_emit_success_batch_storyboard_entity_type_follows_skeleton(
+        self, monkeypatch, tmp_path, script, expected_entity_type, expected_label
+    ):
+        """storyboard/video 任务完成通知与分镜级事件同口径：实体类型与名词按项目剧本骨架
+        种类解析，不恒为 narration 的 segment/「分镜」（issue #1036）。"""
+        captured = []
+        monkeypatch.setattr(
+            generation_tasks,
+            "emit_project_change_batch",
+            lambda project_name, changes: captured.append(changes),
+        )
+
+        project_path = tmp_path / "demo"
+        project_path.mkdir()
+        fake_pm = _FakePM(project_path)
+        fake_pm.script = script
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+
+        for task_type, action in (("storyboard", "storyboard_ready"), ("video", "video_ready")):
+            captured.clear()
+            generation_tasks.emit_generation_success_batch(
+                task_type=task_type,
+                project_name="demo",
+                resource_id="E1S01",
+                payload={"script_file": "ep01.json"},
+            )
+            assert len(captured) == 1
+            change = captured[0][0]
+            assert change["entity_type"] == expected_entity_type
+            assert change["action"] == action
+            assert change["label"] == expected_label
+
+    def test_emit_success_batch_reference_video_entity_type_aligns_with_frontend(self, monkeypatch, tmp_path):
+        """参考生视频任务完成通知的 entity_type 需为前端联合类型认识的 "reference_unit"
+        （而非仅本侧认识的 "reference_video_unit"），分组标题才能落「视频单元」而非「内容」
+        兜底；条目文案仍沿用「参考视频」措辞，不随骨架名词改动（issue #1036）。"""
+        captured = []
+        monkeypatch.setattr(
+            generation_tasks,
+            "emit_project_change_batch",
+            lambda project_name, changes: captured.append(changes),
+        )
+
+        project_path = tmp_path / "demo"
+        project_path.mkdir()
+        fake_pm = _FakePM(project_path)
+        fake_pm.script = {"content_mode": "narration", "video_units": [{"unit_id": "U01"}]}
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+
+        generation_tasks.emit_generation_success_batch(
+            task_type="reference_video",
+            project_name="demo",
+            resource_id="U01",
+            payload={"script_file": "ep01.json"},
+        )
+
+        assert len(captured) == 1
+        change = captured[0][0]
+        assert change["entity_type"] == "reference_unit"
+        assert change["action"] == "reference_video_ready"
+        assert change["label"] == "参考视频「U01」"
+
+    def test_emit_success_batch_falls_back_to_segments_when_script_load_fails(self, monkeypatch, tmp_path):
+        """骨架判定拿不到剧本（脚本缺失/损坏）时兜底 segments/「分镜」，不让通知发送中断。"""
+        captured = []
+        monkeypatch.setattr(
+            generation_tasks,
+            "emit_project_change_batch",
+            lambda project_name, changes: captured.append(changes),
+        )
+
+        project_path = tmp_path / "demo"
+        project_path.mkdir()
+        fake_pm = _FakePM(project_path)
+
+        def _raise_load_script(project_name, script_file):
+            raise FileNotFoundError(script_file)
+
+        fake_pm.load_script = _raise_load_script
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+
+        generation_tasks.emit_generation_success_batch(
+            task_type="storyboard",
+            project_name="demo",
+            resource_id="E1S01",
+            payload={"script_file": "missing.json"},
+        )
+
+        assert len(captured) == 1
+        change = captured[0][0]
+        assert change["entity_type"] == "segment"
+        assert change["label"] == "分镜「E1S01」"
+
     def test_grid_fingerprints_include_split_cells(self, monkeypatch, tmp_path):
         """宫格指纹应包含切割覆写的 canonical 分镜图（cache-bust），但拒绝越出项目目录的路径"""
         from lib.grid.models import FrameCell, GridGeneration

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -6,11 +6,13 @@ import pytest
 
 from lib.project_change_hints import emit_project_change_batch, project_change_source
 from lib.project_manager import ProjectManager
-from lib.script_skeleton import SKELETONS
+from lib.script_skeleton import (
+    SKELETON_ANCHOR_TYPES,
+    SKELETON_ENTITY_TYPES,
+    SKELETON_ITEM_NOUNS,
+    SKELETONS,
+)
 from server.services.project_events import (
-    _SKELETON_ANCHOR_TYPES,
-    _SKELETON_ENTITY_TYPES,
-    _SKELETON_ITEM_NOUNS,
     PROJECT_DELETED_EVENT,
     ProjectEventService,
 )
@@ -700,12 +702,12 @@ class TestProjectEventService:
 
     def test_every_skeleton_kind_has_label_noun(self):
         """标签名词表覆盖全部骨架种类——第五种骨架出现时此处失败，逼出名词补全。"""
-        assert set(_SKELETON_ITEM_NOUNS) == set(SKELETONS)
+        assert set(SKELETON_ITEM_NOUNS) == set(SKELETONS)
 
     def test_every_skeleton_kind_has_entity_and_anchor_type(self):
         """实体/锚点类型表覆盖全部骨架种类——第五种骨架出现时此处失败，逼出补全。"""
-        assert set(_SKELETON_ENTITY_TYPES) == set(SKELETONS)
-        assert set(_SKELETON_ANCHOR_TYPES) == set(SKELETONS)
+        assert set(SKELETON_ENTITY_TYPES) == set(SKELETONS)
+        assert set(SKELETON_ANCHOR_TYPES) == set(SKELETONS)
 
     @pytest.mark.parametrize(
         ("kind", "content_mode", "generation_mode", "entity_type", "anchor_type"),


### PR DESCRIPTION
Closes #1036

## 背景

worker 任务完成通知（focus 为 None、不可导航的那批）此前对 storyboard/video 恒发实体类型 `segment` 与「分镜「{}」」标签，不区分项目剧本骨架；同一 drama/ad 项目的分镜级事件已按骨架显示「场景」「镜头」，两条事件路径名词不一致。

## 改动

- storyboard/video 完成通知的**条目名词按项目剧本骨架种类**（narration→分镜 / drama→场景 / ad→镜头）动态派生，复用分镜级事件已有的 `resolve_script_kind` 判定与 `lib/script_skeleton.py` 的公共骨架映射表（自 `project_events.py` 私有表提升，纳入既有 import 期自洽校验），不新造第二套。
- reference_video 完成事件的 `entity_type` 由前端联合类型不认识的 `reference_video_unit` 改为 `reference_unit`，与 `frontend/src/types/workspace.ts` 对齐（防御性消除仅单侧认识的取值）。
- 完成事件对同一 `script_file` 只加载解析一次，骨架种类与 episode 共用，消除双解析。

## 范围诚实说明

issue 提到「参考生视频任务分组标签退化为『内容』」——经核实，**该分组标题场景不适用于单条完成事件**：任务完成事件每次只 emit 单条 change，前端对单条走 `formatSingleNotificationText(change.label)`，不查 `ENTITY_LABELS`/`entity_type`，分组标题（「内容」兜底所在）仅在同批多条时才渲染。因此本 PR 对 reference_video **通知文案未做改变**（仍为「参考视频「U01」」），`entity_type` 对齐属防御性一致，对用户可见文案无影响。真正落地的用户可见修复是 storyboard/video 在 drama/ad 项目的名词修正。

## Follow-up 候选（未立项）

- 若要让 reference_video 完成通知真正露出「视频单元」，需改 `label`（非 `entity_type`），且涉及 ad 内容 reference_video 命名取向（骨架为 `shots`，与同项目分镜级事件一致显示「镜头」 vs 强制「视频单元」）——属 UI 文案与业务取舍。
- 前端 `ProjectChange["action"]` 联合类型未含实际会发的 `reference_video_ready`/`tts_ready`；骨架名词表为中文硬编码常量，未来 i18n 一并处理。

## 验证

- 后端：`ruff check`/`ruff format` 干净；`basedpyright` 0 error；`pytest`（generation_tasks_service / dispatch / project_events）全绿，新增骨架种类覆盖、script_file/episode 挂载、加载失败兜底用例。
- 前端：`pnpm lint` + `pnpm check`（typecheck + vitest 904 passed）全绿。
- 已 rebase 到最新 main。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能优化**
  * 生成完成通知会根据剧本骨架类型动态显示更准确的实体类型与条目名称（如“场景”“镜头”“视频单元”）。
  * 视频/分镜相关任务完成通知将附带剧本文件与集数信息（如适用）。
* **问题修复**
  * 修复“视频单元”变更通知标题错误回退为“内容”的问题。
  * 脚本加载失败或脚本文案异常时，仍会正常发送完成通知并使用合理默认文案。
* **测试**
  * 新增与更新回归及通知语义断言，覆盖多种骨架与兜底场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->