### PR TITLE
fix(text): Gemini 经代理网关的结构化输出恢复枚举约束，剧本生成不再连续失败

### DIFF
--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -719,6 +719,13 @@ class ScriptGenerator:
         except json.JSONDecodeError as e:
             raise ValueError(f"JSON 解析失败: {e}")
 
+        # title 缺失/空白兜底：非约束解码通道下模型可能整字段漏写。title 仅展示用、
+        # 用户可改，不值得让整集生成失败；与 _merge_narration_visual 的兜底同口径。
+        if isinstance(data, dict):
+            title = data.get("title")
+            if not (isinstance(title, str) and title.strip()):
+                data["title"] = f"第{episode}集"
+
         # 校验模型经规范解析定骨架种类（ad→shots 骨架唯一，reference→video_units），
         # kind→模型映射留本地（模型属上层依赖，不进 SKELETONS 窄表）。
         kind = resolve_declared_kind(self.content_mode, self._effective_generation_mode(episode))

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -6,9 +6,10 @@ script_models.py - 剧本数据模型
 2. 输出验证
 """
 
-from typing import Annotated, ClassVar, Literal
+import logging
+from typing import Annotated, ClassVar, Literal, get_args
 
-from pydantic import BaseModel, ConfigDict, Field, create_model, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, create_model, model_validator
 from pydantic.json_schema import SkipJsonSchema
 
 from lib.script_skeleton import resolve_declared_kind
@@ -54,6 +55,51 @@ TransitionType = Literal[
     "dissolve",
 ]
 
+logger = logging.getLogger(__name__)
+
+
+def _canon_enum_key(value: str) -> str:
+    """枚举漂移归一键：下划线/连字符折叠为空格、多空格合一、casefold。"""
+    return " ".join(value.replace("_", " ").replace("-", " ").split()).casefold()
+
+
+# schema 的 enum 只有在供应商执行约束解码时才是硬约束；代理网关/OpenAI 兼容通道丢弃
+# wire 级结构化参数时，模型会把枚举写成大写/小写蛇形（MEDIUM_SHOT / medium_shot）
+# 甚至词表外值（wide_shot / dolly_in / orbit，均为线上实测值）。机械归一（大小写/
+# 分隔符）把风格漂移拉回词表；词表外值不做语义近义映射（语义映射永远穷举不全），
+# 一律降级为中性默认值并 warn——这两个字段下游只作生成 prompt 的文本插值，
+# 单镜头词汇漂移不值得让整集剧本生成失败。
+_DEFAULT_SHOT_TYPE: ShotType = "Medium Shot"
+_DEFAULT_CAMERA_MOTION: CameraMotion = "Static"
+
+_SHOT_TYPE_BY_KEY: dict[str, str] = {_canon_enum_key(v): v for v in get_args(ShotType)}
+_CAMERA_MOTION_BY_KEY: dict[str, str] = {_canon_enum_key(v): v for v in get_args(CameraMotion)}
+
+
+def _normalize_shot_type(value: object) -> object:
+    if not isinstance(value, str):
+        return value
+    hit = _SHOT_TYPE_BY_KEY.get(_canon_enum_key(value))
+    if hit is not None:
+        return hit
+    logger.warning("shot_type 枚举漂移无法归一，降级为 %s: %r", _DEFAULT_SHOT_TYPE, value)
+    return _DEFAULT_SHOT_TYPE
+
+
+def _normalize_camera_motion(value: object) -> object:
+    if not isinstance(value, str):
+        return value
+    hit = _CAMERA_MOTION_BY_KEY.get(_canon_enum_key(value))
+    if hit is not None:
+        return hit
+    logger.warning("camera_motion 枚举漂移无法归一，降级为 %s: %r", _DEFAULT_CAMERA_MOTION, value)
+    return _DEFAULT_CAMERA_MOTION
+
+
+def _none_to_empty_list(value: object) -> object:
+    """漂移容错：非约束解码通道可能把可选列表字段写成 null 而非省略。"""
+    return [] if value is None else value
+
 
 class Dialogue(BaseModel):
     """对话条目"""
@@ -69,7 +115,7 @@ class Composition(BaseModel):
 
     model_config = _STRICT_CONFIG
 
-    shot_type: ShotType = Field(description="镜头类型")
+    shot_type: Annotated[ShotType, BeforeValidator(_normalize_shot_type)] = Field(description="镜头类型")
     lighting: str = Field(description="光线描述：光源、方向、色温；避免抽象词")
     ambiance: str = Field(description="整体氛围：可观察的环境效果；避免抽象情绪词")
 
@@ -89,7 +135,7 @@ class _VideoPromptCore(BaseModel):
     model_config = _STRICT_CONFIG
 
     action: str = Field(description="动作描述：仅描述物理可观察动作，避免内心动词（如 陷入/回忆/意识到）")
-    camera_motion: CameraMotion = Field(description="镜头运动")
+    camera_motion: Annotated[CameraMotion, BeforeValidator(_normalize_camera_motion)] = Field(description="镜头运动")
     ambiance_audio: str = Field(description="环境音效：仅描述场景内的声音，禁止 BGM")
 
 
@@ -100,7 +146,9 @@ class VideoPrompt(_VideoPromptCore):
     ``DramaVideoPrompt`` 变体（见 ADR 0040）。
     """
 
-    dialogue: list[Dialogue] = Field(default_factory=list, description="对话列表，仅当原文有引号对话时填写")
+    dialogue: Annotated[list[Dialogue], BeforeValidator(_none_to_empty_list)] = Field(
+        default_factory=list, description="对话列表，仅当原文有引号对话时填写"
+    )
 
 
 class DramaVideoPrompt(_VideoPromptCore):
@@ -799,8 +847,20 @@ class ReferenceVideoScript(BaseModel):
 # ============ duration 枚举硬约束（按视频模型能力动态构造剧本 schema） ============
 
 
+def _coerce_digit_string(value: object) -> object:
+    """机械强转：纯数字字符串 → int，其余原样透传交给 ``Literal`` 校验。
+
+    Gemini ``responseSchema`` 通道的 ``enum`` 仅支持字符串，整数时长枚举在 wire 层转为
+    字符串枚举（``["4","6","8"]``，见 ``lib/text_backends/gemini.py``），约束解码下模型
+    输出 ``"4"``；此处恢复 int，使复验与解析两侧的 ``Literal[4,6,8]`` 照常命中。
+    """
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return value
+
+
 def _duration_literal(supported_durations: list[int]) -> object:
-    """把 supported_durations 去重排序后构造成 ``Literal[...]``。
+    """把 supported_durations 去重排序后构造成数字字符串可强转的 ``Literal[...]``。
 
     多值在 ``model_json_schema()`` 里渲染为 JSON-schema ``enum``、单值渲染为 ``const``，两者都是硬约束。
     与 ``ConfigResolver`` 同口径用 ``int(d)`` 归一（见 ``lib/config/resolver.py`` custom 分支）。空集抛 ValueError。
@@ -808,7 +868,7 @@ def _duration_literal(supported_durations: list[int]) -> object:
     values = tuple(sorted({int(d) for d in supported_durations}))
     if not values:
         raise ValueError("supported_durations 为空，无法构造 duration 枚举约束")
-    return Literal[values]
+    return Annotated[Literal[values], BeforeValidator(_coerce_digit_string)]
 
 
 def _constrained_duration_item(item_base: type[BaseModel], duration_type: object, description: str) -> type[BaseModel]:

--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -131,7 +131,7 @@ class ArkTextBackend:
                 return await self._structured_fallback(request, messages)
 
             # 成功路径复验：HTTP 200 后校验返回是否真满足 schema，违例（非 JSON / 违反 schema）则降级。
-            # 不严格强制 schema 的模型/中转会返回违例 JSON，若直接放行会一路漏到下游校验才报错。
+            # 不严格强制 schema 的模型/代理网关会返回违例 JSON，若直接放行会一路漏到下游校验才报错。
             # ark 原生 response_format 未声明 strict，复验同样用 strict=False，避免对可强转值误判违例。
             fallback_reason = structured_fallback_reason(native.text, request.response_schema, strict=False)
             if fallback_reason:

--- a/lib/text_backends/base.py
+++ b/lib/text_backends/base.py
@@ -227,7 +227,7 @@ def structured_fallback_reason(text: str, response_schema: dict | type | None, *
     （用于日志）；None 表示原生输出可直接采用。两类触发场景：
 
     1. 返回非 JSON：供应商静默忽略结构化输出参数，吐出纯文本/markdown。
-    2. 返回违反 schema 的合法 JSON：供应商接受结构化输出参数却不真正强制 schema（国内中转 /
+    2. 返回违反 schema 的合法 JSON：供应商接受结构化输出参数却不真正强制 schema（代理网关 /
        非原厂模型常见），枚举值非法或缺必填字段。此类违例 JSON 若直接放行，会一路漏到下游
        Pydantic 校验或渲染处才抛裸 ValidationError。
 

--- a/lib/text_backends/gemini.py
+++ b/lib/text_backends/gemini.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL = "gemini-3-flash-preview"
 
 # prompt 注入降级的最大调用次数：首次注入 schema + 一次带校验错误反馈的重试。
-# 每次都是计费调用；schema 注入后仍两连败的模型/中转，再多重试收益趋零。
+# 每次都是计费调用；schema 注入后仍两连败的模型/代理网关，再多重试收益趋零。
 _FALLBACK_MAX_ATTEMPTS = 2
 
 
@@ -43,11 +43,14 @@ _INSTANCE_KEYWORDS = frozenset({"const", "enum", "default", "examples"})
 
 
 def _const_to_enum(node: object, *, in_subschema_map: bool = False) -> object:
-    """把 schema 里「值为标量」的 ``const: X`` 归一为 ``enum: [X]``（语义等价）。
+    """归一 schema 的枚举形约束为 ``responseSchema`` 通道可表达的形态。
 
-    单值 ``Literal`` 在 ``model_json_schema()`` 里渲染为 ``const``，而 ``const`` 不在 Gemini
-    ``response_json_schema`` 的受支持特性内（``enum`` 在）。归一后单值约束落到受支持的 ``enum``，
-    保留生成层硬约束。
+    两步归一（同一次位置感知遍历完成）：
+    1. 「值为标量」的 ``const: X`` → ``enum: [X]``（语义等价）。单值 ``Literal`` 在
+       ``model_json_schema()`` 里渲染为 ``const``，而 ``types.Schema`` 无 ``const`` 字段。
+    2. 含非字符串成员的 ``enum`` → 字符串枚举 + ``type: string``。``types.Schema`` 的
+       ``enum`` 仅支持字符串（proto 定义如此），整数时长枚举 ``[4,6,8]`` 转为 ``["4","6","8"]``
+       后精确集合的约束解码依然成立；解析侧 ``_duration_literal`` 的机械强转恢复 int。
 
     ``const`` 出现的位置有三种，须区分对待（这是正确性的不可约最小状态机）：
     - **schema 关键字**：归一（仅标量，对齐本仓库唯一的 const 形态——单值时长 Literal）；
@@ -70,17 +73,21 @@ def _const_to_enum(node: object, *, in_subschema_map: bool = False) -> object:
             out[k] = _const_to_enum(v, in_subschema_map=k in _SUBSCHEMA_MAP_KEYS)
     if "const" in out and (out["const"] is None or isinstance(out["const"], (str, int, float, bool))):
         out["enum"] = [out.pop("const")]
+    if "enum" in out and isinstance(out["enum"], list) and any(not isinstance(x, str) for x in out["enum"]):
+        out["enum"] = [str(x) for x in out["enum"]]
+        out["type"] = "string"
     return out
 
 
-def _to_response_json_schema(schema: dict | type) -> dict:
-    """把 response_schema 统一转成 Gemini ``response_json_schema`` 可消费的 JSON Schema dict。
+def _to_response_schema(schema: dict | type) -> dict:
+    """把 response_schema 统一转成 Gemini ``response_schema``（``types.Schema``）可消费的 dict。
 
-    Gemini 有两条结构化输出通道：``response_schema``（``types.Schema``，OpenAPI 子集，``enum``
-    仅支持字符串）与 ``response_json_schema``（标准 JSON Schema，``enum`` 支持字符串与数字）。
-    ``build_episode_script_model`` 把 ``duration_seconds`` 收紧为 ``Literal[*supported_durations]``
-    的整数 enum，走前者会在 SDK schema 转换时抛 "Input should be a valid string"，故统一走后者：
-    先 ``resolve_schema`` 内联 ``$ref``，再把单值 ``const`` 归一为 ``enum``。
+    Gemini 有两条结构化输出通道：``response_schema``（wire 字段 ``responseSchema``，OpenAPI 子集，
+    上线已久，代理网关普遍能透传给真实上游执行约束解码）与 ``response_json_schema``（wire 字段
+    ``responseJsonSchema``，较新，多数代理网关的请求解析结构体不认识、会静默丢弃——丢弃后上游按
+    无 schema 的纯 JSON 模式自由生成，枚举/必填约束全部失效，线上大面积复现）。统一走前者：
+    先 ``resolve_schema`` 内联 ``$ref``，再经 ``_const_to_enum`` 把 ``const`` 与非字符串 ``enum``
+    归一为 ``types.Schema`` 可表达的字符串枚举。
     """
     normalized = _const_to_enum(resolve_schema(schema))
     assert isinstance(normalized, dict)  # resolve_schema 必返回 dict
@@ -169,7 +176,7 @@ class GeminiTextBackend:
         config: dict = {}
         if response_schema:
             config["response_mime_type"] = "application/json"
-            config["response_json_schema"] = _to_response_json_schema(response_schema)
+            config["response_schema"] = _to_response_schema(response_schema)
         if system_prompt:
             config["system_instruction"] = system_prompt
         if max_output_tokens is not None:
@@ -202,13 +209,13 @@ class GeminiTextBackend:
         native = await self._generate_native(request, structured=bool(request.response_schema))
 
         if request.response_schema:
-            # 成功路径复验：HTTP 200 后校验返回是否真满足 schema。中转/代理可能静默忽略
-            # response_json_schema 返回散文或违例 JSON，直接放行会一路漏到下游 Pydantic
+            # 成功路径复验：HTTP 200 后校验返回是否真满足 schema。代理网关可能静默忽略
+            # response_schema 返回散文或违例 JSON，直接放行会一路漏到下游 Pydantic
             # 校验才抛裸 ValidationError。Gemini 原生请求无 strict 声明，复验用 strict=False，
             # 容忍可强转值，避免对供应商已接受的合法响应触发多余的计费降级调用。
             fallback_reason = structured_fallback_reason(native.text, request.response_schema, strict=False)
             if fallback_reason:
-                logger.warning("原生 response_json_schema %s，降级到 prompt 注入路径", fallback_reason)
+                logger.warning("原生 response_schema %s，降级到 prompt 注入路径", fallback_reason)
                 result = await self._prompt_json_fallback(request)
                 # 这次原生 200 调用已被计费，把它的 token 并入降级结果，否则会系统性漏记。
                 # 仅在至少一侧有计量时相加；两侧皆 None（未追踪）保持 None，不塌成字面 0 token。
@@ -277,9 +284,9 @@ class GeminiTextBackend:
     async def _prompt_json_fallback(self, request: TextGenerationRequest) -> TextGenerationResult:
         """Prompt 注入降级：schema 写进 prompt 重发纯文本调用，剥栅栏后校验，失败带反馈重试。
 
-        触发场景是中转/代理静默忽略 wire 级结构化参数（response_json_schema），此时任何
+        触发场景是代理网关静默忽略 wire 级结构化参数（responseSchema），此时任何
         wire 级通道（含 instructor genai 集成的 JSON/TOOLS 模式，同样落在 response_schema /
-        function calling 参数上）都会被同一中转忽略，把 schema 约束写进 prompt 是唯一不依赖
+        function calling 参数上）都会被同一代理网关忽略，把 schema 约束写进 prompt 是唯一不依赖
         wire 参数的手段。校验通过后返回规范化 JSON（model_dump_json），下游解析必定成功。
         """
         assert request.response_schema is not None  # 调用方（generate 复验分支）保证

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -380,7 +380,8 @@ class TestScriptGenerator:
 
         generator = ScriptGenerator(project_path)
         parsed = generator._parse_response('{"foo": "bar"}', 1)
-        assert parsed == {"foo": "bar"}
+        # 校验失败降级返回原始数据；title 兜底在校验前注入，故降级结果也携带
+        assert parsed == {"foo": "bar", "title": "第1集"}
 
     async def test_generate_writes_script_and_metadata(self, tmp_path):
         project_path = tmp_path / "demo"
@@ -1335,6 +1336,71 @@ class TestAdScriptGeneration:
         output_path = await generator.generate(1)
         saved = json.loads(output_path.read_text(encoding="utf-8"))
         assert saved["shots"][0]["shot_id"] == "E1S01"
+
+
+class TestAdParseResponseDriftRecovery:
+    """代理网关不执行约束解码时的输出容错：枚举风格漂移归一 + title 缺失兜底。
+
+    复刻 2026-07-13 诊断日志捕获的失败形态：gemini 代理网关输出大写/小写蛇形枚举
+    （MEDIUM_SHOT / dolly_in）、dialogue 为 null、顶层 title 缺失，三次生成全部
+    折在 save_script 结构校验上。_parse_response 须把这类可挽救漂移归一后放行。
+    """
+
+    @staticmethod
+    def _drifted_shot(shot_id: str, shot_type: str, camera_motion: str) -> dict:
+        return {
+            "shot_id": shot_id,
+            "section": "hook",
+            "duration_seconds": 3,
+            "voiceover_text": "开场口播",
+            "image_prompt": {
+                "scene": "老伴在广场中央起舞",
+                "composition": {"shot_type": shot_type, "lighting": "夕阳侧光", "ambiance": "人群环绕"},
+            },
+            "video_prompt": {
+                "action": "旋转舞动",
+                "camera_motion": camera_motion,
+                "ambiance_audio": "广场音乐",
+                "dialogue": None,
+            },
+        }
+
+    def test_parse_response_recovers_drifted_payload_without_title(self, tmp_path):
+        project_path = tmp_path / "demo"
+        _write_ad_project(project_path)
+        generator = ScriptGenerator(project_path)
+
+        llm_response = json.dumps(
+            {
+                "shots": [
+                    self._drifted_shot("E1S01", "MEDIUM_SHOT", "ZOOM_OUT"),
+                    self._drifted_shot("E1S02", "wide_shot", "dolly_in"),
+                ]
+            },
+            ensure_ascii=False,
+        )
+        parsed = generator._parse_response(llm_response, 1)
+
+        assert parsed["title"] == "第1集"
+        first, second = parsed["shots"]
+        assert first["image_prompt"]["composition"]["shot_type"] == "Medium Shot"
+        assert first["video_prompt"]["camera_motion"] == "Zoom Out"
+        assert first["video_prompt"]["dialogue"] == []
+        # 词表外值（wide_shot / dolly_in）不做语义映射，降级为中性默认值
+        assert second["image_prompt"]["composition"]["shot_type"] == "Medium Shot"
+        assert second["video_prompt"]["camera_motion"] == "Static"
+
+    def test_parse_response_keeps_model_title_when_present(self, tmp_path):
+        project_path = tmp_path / "demo"
+        _write_ad_project(project_path)
+        generator = ScriptGenerator(project_path)
+
+        llm_response = json.dumps(
+            {"title": "速干杯广场舞", "shots": [self._drifted_shot("E1S01", "Medium Shot", "Static")]},
+            ensure_ascii=False,
+        )
+        parsed = generator._parse_response(llm_response, 1)
+        assert parsed["title"] == "速干杯广场舞"
 
 
 class TestAdQualityProbe:

--- a/tests/test_script_models.py
+++ b/tests/test_script_models.py
@@ -357,6 +357,110 @@ class TestAdScriptModels:
             )
 
 
+class TestEnumDriftNormalization:
+    """非约束解码通道（代理网关等）下的枚举风格漂移归一。
+
+    schema 的 enum 只有在供应商执行约束解码时才是硬约束；代理网关/兼容通道放任模型
+    自由发挥时，枚举值会漂移成大写/小写蛇形（MEDIUM_SHOT / medium_shot）甚至
+    词表外近义词（wide_shot / dolly_in / orbit）。校验层做机械归一 + 别名映射 +
+    未知值降级默认，避免可挽救的风格漂移让整集剧本生成失败。
+    """
+
+    @staticmethod
+    def _composition(shot_type: str) -> dict:
+        return {"shot_type": shot_type, "lighting": "夕阳侧光", "ambiance": "广场人群环绕"}
+
+    @staticmethod
+    def _video_prompt(camera_motion: str, **extra: object) -> dict:
+        return {"action": "旋转舞动", "camera_motion": camera_motion, "ambiance_audio": "广场音乐", **extra}
+
+    @pytest.mark.parametrize(
+        ("drifted", "expected"),
+        [
+            ("MEDIUM_SHOT", "Medium Shot"),
+            ("medium_shot", "Medium Shot"),
+            ("CLOSE_UP", "Close-up"),
+            ("MEDIUM_CLOSE_UP", "Medium Close-up"),
+            ("medium_long_shot", "Medium Long Shot"),
+            ("extreme  close-up", "Extreme Close-up"),
+        ],
+    )
+    def test_shot_type_normalizes_case_and_separators(self, drifted: str, expected: str):
+        comp = Composition.model_validate(self._composition(drifted))
+        assert comp.shot_type == expected
+
+    @pytest.mark.parametrize(
+        ("drifted", "expected"),
+        [
+            ("ZOOM_OUT", "Zoom Out"),
+            ("static", "Static"),
+            ("TILT_UP", "Tilt Up"),
+            ("pan_right", "Pan Right"),
+            ("tracking shot", "Tracking Shot"),
+        ],
+    )
+    def test_camera_motion_normalizes_case_and_separators(self, drifted: str, expected: str):
+        vp = VideoPrompt.model_validate(self._video_prompt(drifted))
+        assert vp.camera_motion == expected
+
+    @pytest.mark.parametrize("drifted", ["WIDE_SHOT", "第一视角特写"])
+    def test_out_of_vocab_shot_type_falls_back_to_default_with_warning(self, caplog, drifted: str):
+        """词表外值不做语义近义映射（穷举不全），一律降级默认并 warn 保留原值。"""
+        with caplog.at_level("WARNING", logger="lib.script_models"):
+            comp = Composition.model_validate(self._composition(drifted))
+        assert comp.shot_type == "Medium Shot"
+        assert drifted in caplog.text
+
+    @pytest.mark.parametrize("drifted", ["dolly_in", "orbit", "crane_up_spiral"])
+    def test_out_of_vocab_camera_motion_falls_back_to_default_with_warning(self, caplog, drifted: str):
+        with caplog.at_level("WARNING", logger="lib.script_models"):
+            vp = VideoPrompt.model_validate(self._video_prompt(drifted))
+        assert vp.camera_motion == "Static"
+        assert drifted in caplog.text
+
+    def test_canonical_values_pass_through_unchanged(self):
+        comp = Composition.model_validate(self._composition("Over-the-shoulder"))
+        assert comp.shot_type == "Over-the-shoulder"
+        vp = VideoPrompt.model_validate(self._video_prompt("Pan Left"))
+        assert vp.camera_motion == "Pan Left"
+
+    def test_non_string_enum_still_rejected(self):
+        with pytest.raises(ValidationError):
+            Composition.model_validate(self._composition(123))  # type: ignore[arg-type]
+        with pytest.raises(ValidationError):
+            VideoPrompt.model_validate(self._video_prompt(None))  # type: ignore[arg-type]
+
+    def test_dialogue_null_coerces_to_empty_list(self):
+        vp = VideoPrompt.model_validate(self._video_prompt("Static", dialogue=None))
+        assert vp.dialogue == []
+
+    def test_llm_schema_still_declares_enum(self):
+        """BeforeValidator 不得改变 LLM 侧 schema：enum 仍是约束解码通道的硬约束。"""
+        comp_schema = Composition.model_json_schema()
+        assert comp_schema["properties"]["shot_type"]["enum"] == [
+            "Extreme Close-up",
+            "Close-up",
+            "Medium Close-up",
+            "Medium Shot",
+            "Medium Long Shot",
+            "Long Shot",
+            "Extreme Long Shot",
+            "Over-the-shoulder",
+            "Point-of-view",
+        ]
+        vp_schema = VideoPrompt.model_json_schema()
+        assert vp_schema["properties"]["camera_motion"]["enum"] == [
+            "Static",
+            "Pan Left",
+            "Pan Right",
+            "Tilt Up",
+            "Tilt Down",
+            "Zoom In",
+            "Zoom Out",
+            "Tracking Shot",
+        ]
+
+
 class TestLLMSchemaExclusion:
     """LLM 看到的 JSON schema 必须排除 note / generated_assets / duration_override / 顶层 duration_seconds。"""
 

--- a/tests/test_script_models_duration_enum.py
+++ b/tests/test_script_models_duration_enum.py
@@ -102,6 +102,30 @@ class TestConstrainedValidation:
         with pytest.raises(ValidationError):
             model.model_validate(self._narration_payload(5))
 
+    def test_digit_string_duration_coerced_to_int(self):
+        """Gemini responseSchema 通道的 enum 仅支持字符串，时长枚举 wire 层转为字符串枚举，
+        约束解码下模型输出 "6"——解析/复验侧机械强转恢复 int 并命中 Literal。"""
+        model = build_episode_script_model("narration", [4, 6, 8])
+        payload = self._narration_payload(6)
+        payload["segments"][0]["duration_seconds"] = "6"
+        validated = model.model_validate(payload)
+        assert validated.segments[0].duration_seconds == 6
+
+    def test_out_of_set_digit_string_rejected(self):
+        """强转仅是类型恢复，不放宽成员约束：字符串 "5" 强转后仍被枚举拒绝。"""
+        model = build_episode_script_model("narration", [4, 6, 8])
+        payload = self._narration_payload(6)
+        payload["segments"][0]["duration_seconds"] = "5"
+        with pytest.raises(ValidationError):
+            model.model_validate(payload)
+
+    def test_non_digit_string_rejected(self):
+        model = build_episode_script_model("narration", [4, 6, 8])
+        payload = self._narration_payload(6)
+        payload["segments"][0]["duration_seconds"] = "six"
+        with pytest.raises(ValidationError):
+            model.model_validate(payload)
+
     def test_drama_out_of_set_duration_rejected(self):
         model = build_episode_script_model("drama", [4, 6, 8])
         payload = {

--- a/tests/test_text_backends/test_gemini.py
+++ b/tests/test_text_backends/test_gemini.py
@@ -84,7 +84,8 @@ class TestGenerate:
         call_kwargs = backend._test_client.aio.models.generate_content.call_args
         config = call_kwargs.kwargs.get("config")
         assert config["response_mime_type"] == "application/json"
-        assert config["response_json_schema"] == schema
+        assert config["response_schema"] == schema
+        assert "response_json_schema" not in config
 
     async def test_structured_truncation_raises(self, backend):
         """结构化输出被 MAX_TOKENS 截断时抛 TextOutputTruncatedError（见 docs/adr/0044）。"""
@@ -120,12 +121,12 @@ class TestGenerate:
         assert result.text == "partial"
         assert any("被截断" in r.message for r in caplog.records)
 
-    async def test_structured_output_pydantic_class_resolved_to_json_schema(self, backend):
-        """传入 Pydantic 类时解析为 JSON Schema dict 走 response_json_schema。
+    async def test_structured_output_pydantic_class_resolved_to_response_schema(self, backend):
+        """传入 Pydantic 类时解析为 dict 走 response_schema（wire 字段 responseSchema）。
 
-        google-genai 的 response_schema(types.Schema) 是 OpenAPI 子集，enum 仅支持字符串，
-        整数/数字 enum 会在 SDK schema 转换时抛 "Input should be a valid string"。统一走
-        response_json_schema（标准 JSON Schema，官方支持数字 enum），与 dict 入参同口径。
+        responseSchema 上线已久、代理网关普遍能透传给真实上游执行约束解码；较新的
+        responseJsonSchema 多数代理网关的请求解析结构体不认识、会静默丢弃，导致上游
+        按无 schema 的纯 JSON 模式自由生成。故统一走 responseSchema，与 dict 入参同口径。
         """
         from pydantic import BaseModel
 
@@ -143,36 +144,38 @@ class TestGenerate:
         call_kwargs = backend._test_client.aio.models.generate_content.call_args
         config = call_kwargs.kwargs.get("config")
         assert config["response_mime_type"] == "application/json"
-        assert "response_schema" not in config
-        js = config["response_json_schema"]
+        assert "response_json_schema" not in config
+        js = config["response_schema"]
         assert js["type"] == "object"
         assert js["properties"]["name"]["type"] == "string"
         assert js["required"] == ["name"]
 
-    def test_episode_script_integer_enum_routes_to_json_schema(self, backend):
-        """回归：duration_seconds 整数 enum 的剧本 schema 必须走 response_json_schema。
+    def test_episode_script_integer_enum_stringified(self, backend):
+        """回归：duration_seconds 整数 enum 在 responseSchema 通道转为字符串枚举。
 
-        build_episode_script_model 把 duration_seconds 收紧为 Literal[*supported_durations]
-        （整数 enum）。若退回 response_schema(types.Schema, enum: list[str]) 会在真实 SDK
-        转换时抛 "Input should be a valid string"，整集生成直接失败。
+        types.Schema 的 enum 仅支持字符串，整数枚举原样发出会在真实 SDK 转换时抛
+        "Input should be a valid string"。转为字符串枚举后精确集合的约束解码依然成立，
+        解析侧 _duration_literal 的机械强转恢复 int。
         """
         from lib.script_models import build_episode_script_model
 
         config = backend._build_config(build_episode_script_model("narration", [4, 6, 8]), None)
 
-        assert "response_schema" not in config
-        seg_props = config["response_json_schema"]["properties"]["segments"]["items"]["properties"]
-        assert seg_props["duration_seconds"]["enum"] == [4, 6, 8]
+        assert "response_json_schema" not in config
+        seg_props = config["response_schema"]["properties"]["segments"]["items"]["properties"]
+        assert seg_props["duration_seconds"]["enum"] == ["4", "6", "8"]
+        assert seg_props["duration_seconds"]["type"] == "string"
 
     def test_single_value_duration_const_normalized_to_enum(self, backend):
-        """单值 supported_durations 渲染为 const（不在 response_json_schema 支持特性内），
-        归一为单元素 enum 以保留生成层硬约束。"""
+        """单值 supported_durations 渲染为 const（types.Schema 无此字段），
+        归一为单元素字符串 enum 以保留生成层硬约束。"""
         from lib.script_models import build_episode_script_model
 
         config = backend._build_config(build_episode_script_model("narration", [8]), None)
-        ds = config["response_json_schema"]["properties"]["segments"]["items"]["properties"]["duration_seconds"]
+        ds = config["response_schema"]["properties"]["segments"]["items"]["properties"]["duration_seconds"]
         assert "const" not in ds
-        assert ds["enum"] == [8]
+        assert ds["enum"] == ["8"]
+        assert ds["type"] == "string"
 
     def test_const_to_enum_distinguishes_keyword_field_name_and_data(self, backend):
         """区分 const 出现的三种位置：schema 关键字（归一）、字段名（值仍是子 schema）、实例数据（不动）。
@@ -190,28 +193,44 @@ class TestGenerate:
                 "obj_const": {"const": {"const": 5}},  # 非标量 const → 不动
             },
         }
-        props = backend._build_config(schema, None)["response_json_schema"]["properties"]
-        assert props["duration_seconds"] == {"type": "integer", "enum": [8]}
+        props = backend._build_config(schema, None)["response_schema"]["properties"]
+        assert props["duration_seconds"] == {"type": "string", "enum": ["8"]}
         assert props["const"] == {"type": "string"}
-        assert props["default"] == {"type": "integer", "enum": [6]}
+        assert props["default"] == {"type": "string", "enum": ["6"]}
         assert props["with_default"]["default"] == {"const": 42}
         assert props["obj_const"] == {"const": {"const": 5}}
 
-    def test_episode_script_schema_accepted_by_google_genai_jsonschema(self, backend):
-        """集成回归：剧本 schema 经 _build_config 产出后必须被 google-genai 真实 JSONSchema 接受。
+    def test_all_script_schemas_accepted_by_google_genai_schema(self, backend):
+        """集成回归：全部剧本 schema 工厂经 _build_config 产出后必须被真实 types.Schema 接受。
 
-        mock 掉 generate_content 会让 SDK 的 schema 转换不执行，掩盖整数 enum 与 Gemini
-        response_schema 的不兼容。这里直接过真实 SDK 类型校验，堵住该盲区。
+        mock 掉 generate_content 会让 SDK 的 schema 转换不执行，掩盖整数 enum / const 与
+        types.Schema 的不兼容（"Input should be a valid string" 在请求发出前即抛，整集生成
+        直接失败）。这里直接过真实 SDK 类型校验，堵住该盲区。
         """
         from google.genai import types as gtypes
 
-        from lib.script_models import build_episode_script_model
+        from lib.script_models import (
+            build_ad_reference_episode_script_model,
+            build_drama_normalized_script_model,
+            build_episode_script_model,
+            build_reference_video_script_model,
+        )
 
-        for content_mode in ("narration", "drama", "ad"):
-            for durations in ([4, 6, 8], [8]):
-                config = backend._build_config(build_episode_script_model(content_mode, durations), None)
-                # 不抛 = 整数 enum / 归一后单值被 google-genai 的 JSONSchema(enum: list[Any]) 接受
-                gtypes.JSONSchema.model_validate(config["response_json_schema"])
+        schemas = [
+            build_episode_script_model(mode, durations)
+            for mode in ("narration", "drama", "ad")
+            for durations in ([4, 6, 8], [8])
+        ]
+        schemas += [
+            build_ad_reference_episode_script_model(),
+            build_drama_normalized_script_model([4, 6, 8]),
+            build_drama_normalized_script_model([8]),
+            build_reference_video_script_model([4, 6, 8]),
+        ]
+        for schema in schemas:
+            config = backend._build_config(schema, None)
+            # 不抛 = 转换后的 dict（字符串枚举、无 const）被 google-genai types.Schema 接受
+            gtypes.Schema.model_validate(config["response_schema"])
 
     async def test_system_prompt(self, backend):
         mock_resp = SimpleNamespace(
@@ -278,7 +297,7 @@ _VALID_JSON = '{"genre": "都市", "theme": "逆袭"}'
 
 
 class TestStructuredFallback:
-    """中转 HTTP 200 但不强制 response_json_schema（返回散文/违例 JSON）时的降级路径。"""
+    """代理网关 HTTP 200 但不强制 response_schema（返回散文/违例 JSON）时的降级路径。"""
 
     @pytest.fixture
     def backend(self, mock_genai):
@@ -297,7 +316,11 @@ class TestStructuredFallback:
 
         assert gc.call_count == 2
         fb_config = gc.call_args_list[1].kwargs.get("config")
-        assert fb_config is None or ("response_json_schema" not in fb_config and "response_mime_type" not in fb_config)
+        assert fb_config is None or (
+            "response_schema" not in fb_config
+            and "response_json_schema" not in fb_config
+            and "response_mime_type" not in fb_config
+        )
         fb_prompt = gc.call_args_list[1].kwargs["contents"][-1]
         assert "分析剧本" in fb_prompt
         assert "JSON Schema" in fb_prompt


### PR DESCRIPTION
## 问题

多个用户反馈经代理网关使用 Gemini 文本模型时剧本生成连续失败，且影响所有结构化输出的文本生成（概述、分集规划、drama step1 等共用同一后端路径）。

诊断日志证据链：三次生成输出中出现枚举表外值（`WIDE_SHOT`/`dolly_in`/`orbit`），说明上游未执行约束解码——`responseJsonSchema` 是较新的 wire 字段，多数代理网关的请求解析结构体不认识、静默丢弃，上游退化为无 schema 的纯 JSON 模式；模型枚举风格漂移（`MEDIUM_SHOT`/`medium_shot`）、`dialogue: null`、`title` 缺失，卡死在保存前结构校验，重试全败。

## 修复

**统一回到已验证的 `responseSchema` 通道**（官方与代理网关同一条路径，不按端点分流）：

- `lib/text_backends/gemini.py` — `_build_config` 改发 `response_schema`；转换器在 `$ref` 内联、`const→enum` 之外新增非字符串枚举 → 字符串枚举（`types.Schema` 的 enum 仅支持字符串，这是当初切走该通道的唯一动因），精确集合的约束解码依然成立
- `lib/script_models.py` — 时长枚举解析/复验侧机械强转（`"4"→4`），成员约束不放宽（`"5"` 仍拒）；所有持久化路径均经 Pydantic 往返，无字符串泄漏
- 解析层枚举漂移容错（兜住连 `responseSchema` 都不透传的网关）：`shot_type`/`camera_motion` 大小写与分隔符机械归一；词表外值不做语义映射，降级中性默认值并 warn 保留原值；`dialogue: null→[]`；`title` 缺失兜底「第N集」
- 既有复验 + prompt 注入降级保留，纯风格漂移经归一化直接通过复验，不再触发额外计费的降级调用

## 测试

- wire 断言反转：`response_schema` 在、`response_json_schema` 不在
- 全部 10 个剧本 schema 工厂变体（narration/drama/ad × 多值/单值 + ad-reference + drama-step1 + reference-video）过真实 `google-genai types.Schema` 校验
- 时长强转三例（命中/超集拒/非数字拒）；枚举漂移归一回放诊断日志捕获的真实失败形态
- 相关测试 273 过，ruff 干净，basedpyright 0 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 增强结构化剧本解析的容错能力，自动补全缺失标题。
  * 兼容不同格式的镜头类型、运镜方式及对话字段，异常值将安全回退。
  * 支持将数字字符串正确识别为时长，并继续执行严格校验。
  * 优化 Gemini 结构化输出兼容性，减少因格式差异导致的解析失败。

* **测试**
  * 新增并完善多种字段漂移、默认值补全及结构化输出场景的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->