### PR TITLE
fix(frontend): ProjectChange action 联合类型补全 reference_video_ready/tts_ready

### DIFF
--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -32,7 +32,9 @@ export interface ProjectChange {
     | "deleted"
     | "storyboard_ready"
     | "video_ready"
-    | "grid_ready";
+    | "grid_ready"
+    | "reference_video_ready"
+    | "tts_ready";
   entity_id: string;
   label: string;
   script_file?: string;

--- a/frontend/src/utils/project-changes.test.ts
+++ b/frontend/src/utils/project-changes.test.ts
@@ -105,20 +105,17 @@ describe("project-changes utils", () => {
   it("labels reference_unit notifications as 视频单元, not the 内容 fallback", () => {
     // 回归：后端曾把参考生视频任务完成事件的 entity_type 发成前端不认识的
     // "reference_video_unit"，落 ENTITY_LABELS 兜底显示「内容」。修复后 entity_type 与前端
-    // 联合类型的 "reference_unit" 对齐，分组标题应显示「视频单元」。action 用 "updated"：
-    // 生产中该通知实际带 "reference_video_ready"（不在 ProjectChange["action"] 联合类型内，
-    // 类型收窄属独立缺口），但 getEntityLabel 对非 storyboard/video/grid_ready 的
-    // action 走同一条 ENTITY_LABELS 兜底分支，"updated" 足以复现并锁定这条修复路径。
+    // 联合类型的 "reference_unit" 对齐，分组标题应显示「视频单元」。
     const [group] = groupChangesByType([
       makeChange({
         entity_type: "reference_unit",
-        action: "updated",
+        action: "reference_video_ready",
         entity_id: "U01",
         label: "参考视频「U01」",
       }),
       makeChange({
         entity_type: "reference_unit",
-        action: "updated",
+        action: "reference_video_ready",
         entity_id: "U02",
         label: "参考视频「U02」",
       }),


### PR DESCRIPTION
## 背景

`ProjectChange["action"]` 联合类型此前只列 `created`/`updated`/`deleted`/`storyboard_ready`/`video_ready`/`grid_ready`,但后端任务完成事件实际还会发射 `reference_video_ready`(参考生视频单元完成)与 `tts_ready`(旁白 TTS 完成)。类型与运行时不符,使依赖该联合类型的 exhaustiveness 保障失效。

## 改动

- `ProjectChange["action"]` 补全 `reference_video_ready` 与 `tts_ready` 两个字面量。
- `project-changes.test.ts` 中原用 `updated` 绕行断言 `reference_unit` 分组标题的回归测试,改回真实的 `reference_video_ready` 字面量,并删去解释绕行缘由的注释。

## 后端全集独立核对

以后端实际发射值为准逐点核对,联合类型不多不少:

- `server/services/project_events.py` 直接发射:`created` / `updated` / `deleted` / `storyboard_ready` / `video_ready`
- `server/services/generation_tasks.py` 经 spec 表派生:`_TASK_CHANGE_SPECS` → `tts_ready` / `grid_ready`(+资产 `updated`);`_SKELETON_DRIVEN_TASK_ACTIONS` → `storyboard_ready` / `video_ready` / `reference_video_ready`

并集恰为 8 个,与补全后的联合类型完全一致。参考生视频的路由/worker/resume 三条路径均经 `emit_generation_success_batch` 发射,无绕过入口。

## 验证

- `pnpm lint` 通过
- `pnpm check`(typecheck + lint + vitest)通过,906 测试全绿
- 已 rebase 到最新 main(0418d7a7)后复跑质量门仍全绿

## 范围说明

严格限于类型对齐 + 测试字面量还原。通知 UI 展示文案映射(`project-changes.ts`)与后端事件发射逻辑均未触碰(issue 明确范围外)。xhigh code review 另发现两处**既有**下游消费者缺口(展示文案兜底、费用刷新触发集未纳入新 action),均在本 diff 之外且属 issue 范围外,已记入 follow-up 候选,不在本 PR 处理。

Closes #1120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修正视频单元变更事件的识别，使通知分组标题正确显示为“视频单元”，而非“内容”。
  * 支持“参考视频已就绪”这一新的变更状态，确保相关通知文案准确展示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->