### PR TITLE
refactor(agent_runtime): 移除 data_dir 三级构造透传与 .agent_data 空目录创建

### DIFF
--- a/server/agent_runtime/options_assembler.py
+++ b/server/agent_runtime/options_assembler.py
@@ -75,7 +75,7 @@ _PERSONA_PROMPT = """\
 class OptionsAssembler:
     """把开会话时现场收集的依赖装配成 ClaudeAgentOptions。
 
-    构造参数分两类：静态依赖（``data_dir`` / ``projects_root`` / ``allowed_tools`` /
+    构造参数分两类：静态依赖（``projects_root`` / ``allowed_tools`` /
     ``setting_sources``）在实例化时锁定；随运行时变化的依赖用 provider 回调每次 build
     时现取——``access_policy_provider``（``configure_sandbox_runtime`` 会整体换新）与
     ``max_turns_provider``（``refresh_config`` 会改写）。``resolve_project_cwd`` 由
@@ -90,7 +90,6 @@ class OptionsAssembler:
     def __init__(
         self,
         *,
-        data_dir: Path,
         projects_root: Path,
         allowed_tools: Sequence[str],
         setting_sources: Sequence[str],
@@ -101,7 +100,6 @@ class OptionsAssembler:
         session_factory_provider: Callable[[], Any] | None = None,
         user_id_provider: Callable[[], str] | None = None,
     ) -> None:
-        self.data_dir = Path(data_dir)
         self.projects_root = Path(projects_root)
         self._allowed_tools = list(allowed_tools)
         self._setting_sources = list(setting_sources)

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -47,8 +47,6 @@ class AssistantService:
     def __init__(self, project_root: Path):
         self.project_root = Path(project_root)
         self.projects_root = app_data_dir()
-        self.data_dir = self.projects_root / ".agent_data"
-        self.data_dir.mkdir(parents=True, exist_ok=True)
 
         self.pm = ProjectManager(self.projects_root)
         self.meta_store = SessionMetaStore()
@@ -57,7 +55,6 @@ class AssistantService:
         self.event_log_store = EventLogStore()
         self.session_manager = SessionManager(
             project_root=self.project_root,
-            data_dir=self.data_dir,
             meta_store=self.meta_store,
             projects_root=self.projects_root,
             event_log_store=self.event_log_store,

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -272,7 +272,6 @@ class SessionManager:
     def __init__(
         self,
         project_root: Path,
-        data_dir: Path,
         meta_store: SessionMetaStore,
         projects_root: Path | None = None,
         in_docker: bool = False,
@@ -281,7 +280,6 @@ class SessionManager:
     ):
         self.event_log_store = event_log_store or EventLogStore()
         self.project_root = Path(project_root)
-        self.data_dir = Path(data_dir)
         # Tests construct SessionManager directly without going through
         # AssistantService, so we fall back to the legacy ``project_root/projects``
         # convention. Production passes the configured app_data_dir() explicitly.
@@ -328,7 +326,6 @@ class SessionManager:
         # 同源，避免 store 与用量落到不同 per-user 命名空间。_resolve_project_cwd
         # （项目名校验/作用域）留在会话管理侧，作为依赖注入。
         self._options_assembler = OptionsAssembler(
-            data_dir=self.data_dir,
             projects_root=self.projects_root,
             allowed_tools=self.DEFAULT_ALLOWED_TOOLS,
             setting_sources=self.DEFAULT_SETTING_SOURCES,

--- a/tests/agent_runtime/test_agent_startup_error.py
+++ b/tests/agent_runtime/test_agent_startup_error.py
@@ -53,10 +53,8 @@ def session_manager(tmp_path: Path) -> SessionManager:
     proj_dir.mkdir()
     (proj_dir / "project.json").write_text('{"title": "t"}', encoding="utf-8")
 
-    data_dir = tmp_path / "data"
-    data_dir.mkdir()
     meta_store = SessionMetaStore()
-    return SessionManager(project_root, data_dir, meta_store)
+    return SessionManager(project_root, meta_store)
 
 
 @pytest.mark.asyncio

--- a/tests/agent_runtime/test_event_log_session_flow.py
+++ b/tests/agent_runtime/test_event_log_session_flow.py
@@ -48,7 +48,6 @@ async def db_factory(tmp_path):
 async def manager(tmp_path, db_factory):
     return SessionManager(
         project_root=tmp_path,
-        data_dir=tmp_path / "data",
         meta_store=SessionMetaStore(session_factory=db_factory),
         event_log_store=EventLogStore(session_factory=db_factory),
     )

--- a/tests/agent_runtime/test_options_assembler.py
+++ b/tests/agent_runtime/test_options_assembler.py
@@ -45,7 +45,6 @@ def _make_assembler(
     (projects_root / "demo").mkdir(exist_ok=True)
     resolved_policy = policy or _make_policy(tmp_path)
     return OptionsAssembler(
-        data_dir=tmp_path / "data",
         projects_root=projects_root,
         allowed_tools=_ALLOWED_TOOLS,
         setting_sources=_SETTING_SOURCES,

--- a/tests/agent_runtime/test_sdk_0_1_76_features.py
+++ b/tests/agent_runtime/test_sdk_0_1_76_features.py
@@ -121,11 +121,8 @@ class TestCanUseToolDecisionReason:
         from server.agent_runtime.session_manager import SessionManager
         from server.agent_runtime.session_store import SessionMetaStore
 
-        data_dir = tmp_path / "data"
-        data_dir.mkdir(parents=True, exist_ok=True)
         sm = SessionManager(
             project_root=tmp_path,
-            data_dir=data_dir,
             meta_store=SessionMetaStore(),
         )
         callback = await sm._build_can_use_tool_callback(session_id="sess-x")
@@ -140,11 +137,8 @@ class TestCanUseToolDecisionReason:
         from server.agent_runtime.session_manager import SessionManager
         from server.agent_runtime.session_store import SessionMetaStore
 
-        data_dir = tmp_path / "data"
-        data_dir.mkdir(parents=True, exist_ok=True)
         sm = SessionManager(
             project_root=tmp_path,
-            data_dir=data_dir,
             meta_store=SessionMetaStore(),
         )
         callback = await sm._build_can_use_tool_callback(session_id="sess-y")

--- a/tests/agent_runtime/test_session_manager_sandbox.py
+++ b/tests/agent_runtime/test_session_manager_sandbox.py
@@ -20,10 +20,8 @@ def session_manager(tmp_path: Path) -> SessionManager:
     project_root = tmp_path / "repo"
     project_root.mkdir()
     (project_root / "projects").mkdir()
-    data_dir = tmp_path / "data"
-    data_dir.mkdir()
     meta_store = SessionMetaStore()
-    return SessionManager(project_root, data_dir, meta_store)
+    return SessionManager(project_root, meta_store)
 
 
 @pytest.mark.asyncio
@@ -76,7 +74,7 @@ def test_session_manager_wires_env_resolved_roots_into_policy(tmp_path: Path, mo
     monkeypatch.setenv("ARCREEL_LOG_DIR", str(external_logs))
     monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(external_profile))
 
-    sm = SessionManager(repo, tmp_path / "data", SessionMetaStore(), projects_root=external_data)
+    sm = SessionManager(repo, SessionMetaStore(), projects_root=external_data)
     policy = sm.access_policy
 
     assert policy.log_dir == external_logs.resolve()
@@ -159,11 +157,8 @@ def _make_session_manager(tmp_path: Path, *, sandbox_enabled: bool) -> SessionMa
     project_root = tmp_path / "repo"
     project_root.mkdir(exist_ok=True)
     (project_root / "projects").mkdir(exist_ok=True)
-    data_dir = tmp_path / "data"
-    data_dir.mkdir(exist_ok=True)
     return SessionManager(
         project_root,
-        data_dir,
         SessionMetaStore(),
         sandbox_enabled=sandbox_enabled,
     )

--- a/tests/agent_runtime/test_session_manager_store_injection.py
+++ b/tests/agent_runtime/test_session_manager_store_injection.py
@@ -30,7 +30,6 @@ def _build_sm(tmp_path: Path) -> SessionManager:
 
     return SessionManager(
         project_root=tmp_path,
-        data_dir=tmp_path / "data",
         meta_store=_NullMetaStore(),
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,7 +165,6 @@ async def session_manager(tmp_path: Path, meta_store: SessionMetaStore) -> Sessi
     """Create a SessionManager wired to *tmp_path* and *meta_store*."""
     return SessionManager(
         project_root=tmp_path,
-        data_dir=tmp_path,
         meta_store=meta_store,
     )
 

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -22,7 +22,6 @@ def _make_manager(tmp_path: Path) -> SessionManager:
     """Create a SessionManager with a real MetaStore for testing."""
     return SessionManager(
         project_root=tmp_path,
-        data_dir=tmp_path / "data",
         meta_store=SessionMetaStore(),
     )
 

--- a/tests/test_session_manager_more.py
+++ b/tests/test_session_manager_more.py
@@ -459,7 +459,6 @@ class TestSessionManagerMore:
 
         mgr = sm_mod.SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=meta_store,
         )
 
@@ -507,7 +506,6 @@ class TestSessionManagerMore:
 
         mgr = sm_mod.SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=meta_store,
         )
 
@@ -545,7 +543,6 @@ class TestSessionManagerMore:
 
         mgr = sm_mod.SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=meta_store,
         )
 
@@ -579,7 +576,6 @@ class TestSessionManagerMore:
 
         mgr = sm_mod.SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=meta_store,
         )
 
@@ -671,7 +667,6 @@ class TestSessionManagerMore:
 
         mgr = sm_mod.SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=meta_store,
         )
 
@@ -704,7 +699,6 @@ class TestSessionManagerMore:
 
         mgr = sm_mod.SessionManager(
             project_root=app_root,
-            data_dir=app_root,
             meta_store=meta_store,
         )
         # SDK 会话数据基准目录是 policy 的构造参数：换新 policy 即注入测试位置
@@ -827,7 +821,6 @@ class TestJsonValidationHook:
 
         return SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path / "data",
             meta_store=SessionMetaStore(),
         )
 
@@ -1071,7 +1064,6 @@ class TestJsonPostValidationHook:
 
         return SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path / "data",
             meta_store=SessionMetaStore(),
         )
 

--- a/tests/test_session_manager_project_scope.py
+++ b/tests/test_session_manager_project_scope.py
@@ -45,7 +45,6 @@ class TestSessionManagerProjectScope:
         store, engine = await _make_store()
         manager = SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=store,
         )
         monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
@@ -66,7 +65,6 @@ class TestSessionManagerProjectScope:
         store, engine = await _make_store()
         manager = SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=store,
         )
         monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
@@ -89,7 +87,6 @@ class TestSessionManagerProjectScope:
         store, engine = await _make_store()
         manager = SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=store,
         )
         monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
@@ -123,7 +120,6 @@ class TestSessionManagerProjectScope:
         store, engine = await _make_store()
         manager = SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=store,
         )
         monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
@@ -182,7 +178,6 @@ class TestSessionManagerProjectScope:
         store, engine = await _make_store()
         manager = SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=store,
         )
 
@@ -232,7 +227,6 @@ class TestSessionManagerProjectScope:
         store, engine = await _make_store()
         manager = SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=store,
         )
 
@@ -252,7 +246,6 @@ class TestAllowedToolsAndConstants:
         store, engine = await _make_store()
         manager = SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=store,
         )
         tools = manager.DEFAULT_ALLOWED_TOOLS
@@ -275,7 +268,6 @@ class TestAllowedToolsAndConstants:
         store, engine = await _make_store()
         manager = SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=store,
         )
         assert "LS" not in manager.access_policy.PATH_TOOLS
@@ -292,7 +284,6 @@ class TestSystemPromptProjectContext:
         store, engine = await _make_store()
         manager = SessionManager(
             project_root=tmp_path,
-            data_dir=tmp_path,
             meta_store=store,
         )
 


### PR DESCRIPTION
## 背景

`server/agent_runtime/` 中 `data_dir` 沿 `service.py` → `session_manager.py` → `options_assembler.py` 三级构造函数透传，但相关消费者删除后全仓已无读者；`service.py` 仍在创建 `.agent_data` 目录，该目录创建后再无用途，属死代码链，徒增构造签名噪音并在项目目录残留空目录。

## 改动

- 删除 `data_dir` 参数在 `OptionsAssembler` / `SessionManager` / `AssistantService` 三级构造函数中的透传与存储
- 移除 `service.py` 中 `.agent_data` 空目录的创建逻辑
- `OptionsAssembler` 文档字符串「静态依赖」枚举同步移除 `data_dir`
- 相关测试同步调整（含位置参数调用点按新签名逐一核对）

## 验证

- 动手前全仓 grep 复核 `.agent_data` / `data_dir` 引用，确认无其他真实读者：
  - `scripts/migrate_sqlite_to_orm.py` 读取的是遗留 `.agent_data/sessions.db`，靠 `.exists()` 守卫优雅跳过，`service.py` 从不写入该文件，删除不影响一次性存量迁移脚本
  - `server/app.py` 的 `migrate_local_transcripts_to_store(..., data_dir=...)` 是同名但独立的参数（marker 落在 `projects_root`），与被删路径无关
  - session store 现走 SQLAlchemy ORM（`AgentSession` 表），旧的 `.agent_data` 独立存储方案已未采用，无写入者
- `pytest`（相关套件 395 passed）/ `ruff` / `basedpyright`（0 error）全绿
- `docs/superpowers/plans` 与 `specs` 下历史设计文档提及 `.agent_data` 按仓库惯例保留，不随实现改写

Closes #1125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **变更**
  * 简化会话与选项装配相关接口，移除不再需要的数据目录配置。
  * 会话管理继续使用项目根目录处理路径与运行时配置。

* **测试**
  * 更新相关测试以适配新的初始化方式。
  * 保持会话生命周期、沙箱策略、事件日志及工具权限等行为验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->