### PR TITLE
fix(frontend): 参考生视频与 TTS 完成事件补全为一等生成完成，刷新费用并显示正确文案

### DIFF
--- a/frontend/src/hooks/useProjectEventsSSE.test.tsx
+++ b/frontend/src/hooks/useProjectEventsSSE.test.tsx
@@ -6,6 +6,7 @@ import { API, type ProjectEventStreamOptions } from "@/api";
 import { useProjectEventsSSE } from "./useProjectEventsSSE";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
+import { useCostStore } from "@/stores/cost-store";
 
 function HookHarness({ projectName }: { projectName: string }) {
   useProjectEventsSSE(projectName);
@@ -267,6 +268,126 @@ describe("useProjectEventsSSE", () => {
     );
     expect(screen.getByTestId("location")).toHaveTextContent("/episodes/1");
     expect(useAppStore.getState().scrollTarget).toBeNull();
+  });
+
+  it.each([
+    {
+      action: "reference_video_ready" as const,
+      entityType: "reference_unit" as const,
+      entityId: "U01",
+      label: "参考视频「U01」",
+      expectedText: "参考视频「U01」已生成",
+    },
+    {
+      action: "tts_ready" as const,
+      entityType: "segment" as const,
+      entityId: "E1S01",
+      label: "旁白「E1S01」",
+      expectedText: "旁白「E1S01」已生成",
+    },
+  ])(
+    "shows a generation-completed toast and refreshes cost for $action, without navigation",
+    async ({ action, entityType, entityId, label, expectedText }) => {
+      let capturedOptions: ProjectEventStreamOptions | undefined;
+      vi.spyOn(API, "openProjectEventStream").mockImplementation((options) => {
+        capturedOptions = options;
+        return { close: vi.fn() } as unknown as EventSource;
+      });
+      const debouncedFetchSpy = vi.spyOn(useCostStore.getState(), "debouncedFetch");
+
+      renderHarness("/episodes/1");
+
+      act(() => {
+        capturedOptions?.onChanges?.(
+          {
+            project_name: "demo",
+            batch_id: "batch-completion",
+            fingerprint: "fp-completion",
+            generated_at: "2026-03-01T00:00:00Z",
+            source: "worker",
+            changes: [
+              {
+                entity_type: entityType,
+                action,
+                entity_id: entityId,
+                label,
+                episode: 1,
+                focus: null,
+                important: true,
+              },
+            ],
+          },
+          new MessageEvent("changes"),
+        );
+      });
+
+      await waitFor(() => {
+        expect(API.getProject).toHaveBeenCalledWith("demo");
+        expect(useAppStore.getState().toast?.text).toBe(expectedText);
+      });
+      expect(useAppStore.getState().toast?.tone).toBe("success");
+      expect(screen.getByTestId("location")).toHaveTextContent("/episodes/1");
+      expect(useAppStore.getState().scrollTarget).toBeNull();
+      expect(debouncedFetchSpy).toHaveBeenCalledWith("demo");
+    },
+  );
+
+  it("ranks reference_video_ready/tts_ready alongside existing completion events, above entity changes", async () => {
+    // CHANGE_PRIORITY 中 reference_video_ready/tts_ready 排在 storyboard_ready/video_ready/grid_ready
+    // 之后：同批次多组变更时，toast 状态被逐组覆写，最终展示的应是优先级数值最大（最后处理）的一组。
+    let capturedOptions: ProjectEventStreamOptions | undefined;
+    vi.spyOn(API, "openProjectEventStream").mockImplementation((options) => {
+      capturedOptions = options;
+      return { close: vi.fn() } as unknown as EventSource;
+    });
+
+    renderHarness("/episodes/1");
+
+    act(() => {
+      capturedOptions?.onChanges?.(
+        {
+          project_name: "demo",
+          batch_id: "batch-priority",
+          fingerprint: "fp-priority",
+          generated_at: "2026-03-01T00:00:00Z",
+          source: "worker",
+          changes: [
+            {
+              entity_type: "character",
+              action: "created",
+              entity_id: "hero",
+              label: "角色「hero」",
+              focus: null,
+              important: true,
+            },
+            {
+              entity_type: "reference_unit",
+              action: "reference_video_ready",
+              entity_id: "U01",
+              label: "参考视频「U01」",
+              episode: 1,
+              focus: null,
+              important: true,
+            },
+            {
+              entity_type: "segment",
+              action: "tts_ready",
+              entity_id: "E1S01",
+              label: "旁白「E1S01」",
+              episode: 1,
+              focus: null,
+              important: true,
+            },
+          ],
+        },
+        new MessageEvent("changes"),
+      );
+    });
+
+    await waitFor(() => {
+      expect(API.getProject).toHaveBeenCalledWith("demo");
+      expect(useAppStore.getState().toast?.text).toBe("旁白「E1S01」已生成");
+    });
   });
 
   it("groups remote changes by type and invalidates only the touched entity keys", async () => {

--- a/frontend/src/hooks/useProjectEventsSSE.ts
+++ b/frontend/src/hooks/useProjectEventsSSE.ts
@@ -37,17 +37,29 @@ const CHANGE_PRIORITY: Record<string, number> = {
   storyboard_ready: 7,
   video_ready: 8,
   grid_ready: 9,
+  reference_video_ready: 10,
+  tts_ready: 11,
 };
 
+// 完成事件（action 本身即通知类别，与 entity_type 无关）——优先级查表、导航行为均不按
+// entity_type 拆分，四类骨架/任务共用同一套判定。
+const COMPLETION_ACTIONS: ReadonlySet<ProjectChange["action"]> = new Set([
+  "storyboard_ready",
+  "video_ready",
+  "grid_ready",
+  "reference_video_ready",
+  "tts_ready",
+]);
+
 function getChangePriority(change: ProjectChange): number {
-  if (change.action === "storyboard_ready" || change.action === "video_ready" || change.action === "grid_ready") {
+  if (COMPLETION_ACTIONS.has(change.action)) {
     return CHANGE_PRIORITY[change.action] ?? Number.MAX_SAFE_INTEGER;
   }
   return CHANGE_PRIORITY[`${change.entity_type}:${change.action}`] ?? Number.MAX_SAFE_INTEGER;
 }
 
 function isNavigableChange(change: ProjectChange): boolean {
-  if (change.action === "storyboard_ready" || change.action === "video_ready" || change.action === "grid_ready") {
+  if (COMPLETION_ACTIONS.has(change.action)) {
     return false;
   }
   return Boolean(change.focus?.anchor_type && change.focus?.anchor_id);
@@ -316,7 +328,11 @@ export function useProjectEventsSSE(projectName?: string | null): void {
 
           // Refresh cost data when generation completes
           const hasGenerationEvent = payload.changes.some(
-            (c) => c.action === "storyboard_ready" || c.action === "video_ready",
+            (c) =>
+              c.action === "storyboard_ready" ||
+              c.action === "video_ready" ||
+              c.action === "reference_video_ready" ||
+              c.action === "tts_ready",
           );
           if (hasGenerationEvent && projectName) {
             useCostStore.getState().debouncedFetch(projectName);

--- a/frontend/src/hooks/useProjectEventsSSE.ts
+++ b/frontend/src/hooks/useProjectEventsSSE.ts
@@ -13,8 +13,10 @@ import type {
 } from "@/types";
 import {
   buildEntityRevisionKey,
+  COMPLETION_ACTIONS,
   formatGroupedDeferredText,
   formatGroupedNotificationText,
+  GENERATION_ACTIONS,
   groupChangesByType,
   type GroupedProjectChange,
 } from "@/utils/project-changes";
@@ -40,16 +42,6 @@ const CHANGE_PRIORITY: Record<string, number> = {
   reference_video_ready: 10,
   tts_ready: 11,
 };
-
-// 完成事件（action 本身即通知类别，与 entity_type 无关）——优先级查表、导航行为均不按
-// entity_type 拆分，四类骨架/任务共用同一套判定。
-const COMPLETION_ACTIONS: ReadonlySet<ProjectChange["action"]> = new Set([
-  "storyboard_ready",
-  "video_ready",
-  "grid_ready",
-  "reference_video_ready",
-  "tts_ready",
-]);
 
 function getChangePriority(change: ProjectChange): number {
   if (COMPLETION_ACTIONS.has(change.action)) {
@@ -327,12 +319,8 @@ export function useProjectEventsSSE(projectName?: string | null): void {
           void refreshProject();
 
           // Refresh cost data when generation completes
-          const hasGenerationEvent = payload.changes.some(
-            (c) =>
-              c.action === "storyboard_ready" ||
-              c.action === "video_ready" ||
-              c.action === "reference_video_ready" ||
-              c.action === "tts_ready",
+          const hasGenerationEvent = payload.changes.some((c) =>
+            GENERATION_ACTIONS.has(c.action),
           );
           if (hasGenerationEvent && projectName) {
             useCostStore.getState().debouncedFetch(projectName);

--- a/frontend/src/utils/project-changes.test.ts
+++ b/frontend/src/utils/project-changes.test.ts
@@ -122,8 +122,55 @@ describe("project-changes utils", () => {
     ]);
 
     expect(formatGroupedNotificationText(group)).toBe(
-      "更新了 2 个视频单元：U01、U02",
+      "已生成 2 个视频单元：U01、U02",
     );
     expect(formatGroupedNotificationText(group)).not.toContain("内容");
+  });
+
+  it("treats reference_video_ready/tts_ready as generation-completed, not the 更新了 fallback", () => {
+    const [singleReferenceVideo] = groupChangesByType([
+      makeChange({
+        entity_type: "reference_unit",
+        action: "reference_video_ready",
+        entity_id: "U01",
+        label: "参考视频「U01」",
+      }),
+    ]);
+    expect(formatGroupedNotificationText(singleReferenceVideo)).toBe(
+      "参考视频「U01」已生成",
+    );
+    expect(formatGroupedDeferredText(singleReferenceVideo)).toBe(
+      "参考视频「U01」 已生成",
+    );
+
+    const [singleTts] = groupChangesByType([
+      makeChange({
+        entity_type: "segment",
+        action: "tts_ready",
+        entity_id: "E1S01",
+        label: "旁白「E1S01」",
+      }),
+    ]);
+    expect(formatGroupedNotificationText(singleTts)).toBe("旁白「E1S01」已生成");
+    expect(formatGroupedDeferredText(singleTts)).toBe("旁白「E1S01」 已生成");
+
+    const [groupedTts] = groupChangesByType([
+      makeChange({
+        entity_type: "segment",
+        action: "tts_ready",
+        entity_id: "E1S01",
+        label: "旁白「E1S01」",
+      }),
+      makeChange({
+        entity_type: "segment",
+        action: "tts_ready",
+        entity_id: "E1S02",
+        label: "旁白「E1S02」",
+      }),
+    ]);
+    expect(formatGroupedNotificationText(groupedTts)).toBe(
+      "已生成 2 个旁白：E1S01、E1S02",
+    );
+    expect(formatGroupedNotificationText(groupedTts)).not.toContain("更新了");
   });
 });

--- a/frontend/src/utils/project-changes.ts
+++ b/frontend/src/utils/project-changes.ts
@@ -2,6 +2,21 @@ import type { ProjectChange } from "@/types";
 
 const GROUP_NAME_LIMIT = 5;
 
+// 生成事件（用于刷新费用等）——不含 grid_ready：宫格生成完成不触发费用刷新（既有行为）。
+export const GENERATION_ACTIONS: ReadonlySet<ProjectChange["action"]> = new Set([
+  "storyboard_ready",
+  "video_ready",
+  "reference_video_ready",
+  "tts_ready",
+]);
+
+// 完成事件（action 本身即通知类别，与 entity_type 无关）——优先级查表、导航行为、通知文案均不按
+// entity_type 拆分，五类骨架/任务共用同一套判定。
+export const COMPLETION_ACTIONS: ReadonlySet<ProjectChange["action"]> = new Set([
+  ...GENERATION_ACTIONS,
+  "grid_ready",
+]);
+
 const ENTITY_LABELS: Record<ProjectChange["entity_type"], string> = {
   project: "项目",
   character: "角色",
@@ -148,13 +163,7 @@ export function formatGroupedNotificationText(
   const entityLabel = getEntityLabel(group);
   const summary = summarizeGroupNames(group);
 
-  if (
-    group.action === "storyboard_ready" ||
-    group.action === "video_ready" ||
-    group.action === "grid_ready" ||
-    group.action === "reference_video_ready" ||
-    group.action === "tts_ready"
-  ) {
+  if (COMPLETION_ACTIONS.has(group.action)) {
     return `已生成 ${count} 个${entityLabel}：${summary}`;
   }
   if (group.action === "created") {
@@ -177,13 +186,7 @@ export function formatGroupedDeferredText(
   const entityLabel = getEntityLabel(group);
   const summary = summarizeGroupNames(group);
 
-  if (
-    group.action === "storyboard_ready" ||
-    group.action === "video_ready" ||
-    group.action === "grid_ready" ||
-    group.action === "reference_video_ready" ||
-    group.action === "tts_ready"
-  ) {
+  if (COMPLETION_ACTIONS.has(group.action)) {
     return `AI 刚生成了 ${count} 个${entityLabel}：${summary}，点击查看`;
   }
   if (group.action === "created") {

--- a/frontend/src/utils/project-changes.ts
+++ b/frontend/src/utils/project-changes.ts
@@ -64,6 +64,9 @@ function getEntityLabel(group: GroupedProjectChange): string {
   if (group.action === "grid_ready") {
     return "宫格";
   }
+  if (group.action === "tts_ready") {
+    return "旁白";
+  }
   return ENTITY_LABELS[group.entityType] ?? "内容";
 }
 
@@ -95,7 +98,11 @@ function formatSingleNotificationText(change: ProjectChange): string {
   if (change.action === "video_ready") {
     return `${change.label}的视频已生成`;
   }
-  if (change.action === "grid_ready") {
+  if (
+    change.action === "grid_ready" ||
+    change.action === "reference_video_ready" ||
+    change.action === "tts_ready"
+  ) {
     return `${change.label}已生成`;
   }
   if (change.action === "created") {
@@ -114,7 +121,11 @@ function formatSingleDeferredText(change: ProjectChange): string {
   if (change.action === "video_ready") {
     return `AI 刚生成了 ${change.label} 的视频，点击查看`;
   }
-  if (change.action === "grid_ready") {
+  if (
+    change.action === "grid_ready" ||
+    change.action === "reference_video_ready" ||
+    change.action === "tts_ready"
+  ) {
     return `${change.label} 已生成`;
   }
   if (change.action === "created") {
@@ -137,7 +148,13 @@ export function formatGroupedNotificationText(
   const entityLabel = getEntityLabel(group);
   const summary = summarizeGroupNames(group);
 
-  if (group.action === "storyboard_ready" || group.action === "video_ready" || group.action === "grid_ready") {
+  if (
+    group.action === "storyboard_ready" ||
+    group.action === "video_ready" ||
+    group.action === "grid_ready" ||
+    group.action === "reference_video_ready" ||
+    group.action === "tts_ready"
+  ) {
     return `已生成 ${count} 个${entityLabel}：${summary}`;
   }
   if (group.action === "created") {
@@ -160,7 +177,13 @@ export function formatGroupedDeferredText(
   const entityLabel = getEntityLabel(group);
   const summary = summarizeGroupNames(group);
 
-  if (group.action === "storyboard_ready" || group.action === "video_ready" || group.action === "grid_ready") {
+  if (
+    group.action === "storyboard_ready" ||
+    group.action === "video_ready" ||
+    group.action === "grid_ready" ||
+    group.action === "reference_video_ready" ||
+    group.action === "tts_ready"
+  ) {
     return `AI 刚生成了 ${count} 个${entityLabel}：${summary}，点击查看`;
   }
   if (group.action === "created") {


### PR DESCRIPTION
## 背景

后端任务完成会发送 `reference_video_ready`（参考生视频单元完成）与 `tts_ready`（TTS 完成）两个事件，#1122 已将二者补进 `ProjectChange["action"]` 联合类型。但前端消费端的运行时判定与文案分支仍只认 `storyboard_ready` / `video_ready` / `grid_ready`，导致这两类完成事件被降级为普通「更新」事件：费用面板不自动刷新，通知落「AI 刚更新了 XX」兜底文案。

## 改动

- **费用刷新**：`useProjectEventsSSE.ts` 的 `hasGenerationEvent` 纳入两个新 action，参考生视频 / TTS 完成后费用面板自动刷新，与分镜图 / 视频同待遇。
- **优先级与导航判定**：将 `getChangePriority` / `isNavigableChange` 原各自展开的完成事件条件收敛为共享的 `COMPLETION_ACTIONS` 集合；`CHANGE_PRIORITY` 新增 `reference_video_ready=10` / `tts_ready=11`，延续既有 `storyboard=7 / video=8 / grid=9` 的递增序列。
- **通知文案**：`project-changes.ts` 的单条与分组文案分支覆盖两个新 action，输出「生成完成」语义（`旁白「E1S01」已生成` / `已生成 2 个视频单元：…`），不再落「更新了」兜底。`tts_ready` 的分组标题名词专属映射为「旁白」，避免 `segment` 兜底成「分镜」而与分镜图生成语义混淆。
- **测试**：新增单条 / 分组文案、优先级排序、费用刷新与无导航的覆盖，并修正一处既有回归断言（`reference_video_ready` 分组文案由 bug 前的「更新了 2 个视频单元」改为「已生成 2 个视频单元」）。

## 验证

- `pnpm lint`：干净
- `pnpm check`（typecheck + vitest）：910 测试全绿
- 全仓核对：完成事件消费点仅 `useProjectEventsSSE.ts` 与 `project-changes.ts` 两处，均已覆盖；`COMPLETION_ACTIONS` 对 action 联合类型全部 5 个 `_ready` 值穷尽。

Closes #1123


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增对“参考视频生成完成”和“旁白生成完成”的事件处理：展示对应成功提示。
  - 生成完成后自动刷新成本信息，并同步更新相关通知文案（含单条与延迟/聚合文案）。

- **优化**
  - 统一生成完成事件的优先级与可导航性判断：当多类变更同时到达时，生成完成提示优先呈现，避免不必要的页面跳转。  

- **测试**
  - 扩展覆盖生成完成事件的单/成组场景与优先级行为，验证文案输出与导航状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->