### PR TITLE
fix(skills): PR 审查轮询能识别 CodeRabbit 限流评论，避免漏审假通过

### DIFF
--- a/.agents/skills/pr-ai-review-loop/scripts/poll.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/poll.sh
@@ -373,11 +373,17 @@ jq -n \
     # bot reply happens to discuss quota as a topic (e.g. a PR description that mentions quota).
     # Real alerts always pair a keyword with a verb like "exceeded" / "reached" / "exhausted",
     # or use a fixed phrase like "You have / You\x27ve reached your ... limit".
+    # CodeRabbit additionally always wraps its rate-limit banner in a dedicated
+    # HTML marker ("rate limited by coderabbit.ai"); matching that marker directly
+    # is CodeRabbit-authored and unambiguous, so this check is not restricted to
+    # the body head — a preceding change-stack link banner can otherwise push
+    # the phrase itself past the 500-char window and cause a silent miss.
     [$sub_a[]
      | select(.user.login | test("(gemini-code-assist|coderabbitai)\\[bot\\]$"))
      | (.body // "") as $qb
      | select(
-         ($qb[0:500] | test("you(\\x27ve|\\x{2019}ve|\\s+have)\\s+reached your[^\\n]*?limit"; "i"))
+         ($qb | test("<!--\\s*This is an auto-generated comment:\\s*rate limited by coderabbit\\.ai\\s*-->"))
+         or ($qb[0:500] | test("you(\\x27ve|\\x{2019}ve|\\s+have)\\s+reached your[^\\n]*?limit"; "i"))
          or ($qb[0:500] | test("(usage|rate|api|daily|monthly)\\s+limit[^\\n]*?(exceeded|reached|hit|reset)"; "i"))
          or ($qb[0:500] | test("quota[^\\n]*?(exceeded|exhausted|reached|reset|limit hit)"; "i"))
          or ($qb[0:500] | test("(http\\s*)?429\\b|too many requests"; "i"))

--- a/.agents/skills/pr-ai-review-loop/scripts/test_quota_alerts.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_quota_alerts.sh
@@ -34,7 +34,7 @@ fi
 
 # Pull the def verbatim: from `def quota_alerts:` through the line ending `];`
 # that closes it.
-QUOTA_DEF=$(awk '/^  def quota_alerts:/{flag=1} flag{print; if (/\];$/) exit}' "$POLL_SH")
+QUOTA_DEF=$(awk '/^[[:space:]]*def quota_alerts:/{flag=1} flag{print; if (/\];[[:space:]]*$/) exit}' "$POLL_SH")
 if [[ -z "$QUOTA_DEF" ]]; then
   echo "could not extract quota_alerts def from $POLL_SH" >&2
   exit 4
@@ -49,8 +49,8 @@ CASES=(
 )
 
 fail=0
-for case in "${CASES[@]}"; do
-  IFS=":" read -r file login expect <<<"$case"
+for tc in "${CASES[@]}"; do
+  IFS=":" read -r file login expect <<<"$tc"
   body_file="$TESTDATA/$file"
   if [[ ! -f "$body_file" ]]; then
     echo "FAIL $file: fixture missing at $body_file" >&2

--- a/.agents/skills/pr-ai-review-loop/scripts/test_quota_alerts.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_quota_alerts.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# test_quota_alerts.sh — regression test for poll.sh's quota_alerts detection.
+#
+# USAGE
+#   bash test_quota_alerts.sh
+#
+# Extracts the `quota_alerts` jq def verbatim out of poll.sh (so this test always
+# exercises the function actually shipped, not a copy that can drift) and runs it
+# against fixture comment bodies in testdata/:
+#   - quota_alert_pr1115_no_stack.txt / quota_alert_pr1115_review_stack.txt: real
+#     CodeRabbit rate-limit banners captured from PR #1115's walkthrough comment
+#     edit history (GraphQL userContentEdits — the live GitHub body has since been
+#     overwritten by CodeRabbit's own later edits, so this is the only way to
+#     recover the exact bytes). *_review_stack carries the change-stack link
+#     banner that pushes the alert phrase past the old 500-char scan window —
+#     this is the exact regression from issue #1124.
+#   - no_actionable_pr1115.txt: the same PR's final (non-alert) walkthrough body,
+#     also real, sharing the same change-stack banner prefix — proves the fix
+#     doesn't start matching on the banner alone.
+#   - synthetic_non_alert_mentions_limit.txt: constructed (not captured from a
+#     real PR) edge case where the body merely discusses rate limiting as a
+#     topic, to check bare keyword mentions still don't trigger.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POLL_SH="$SCRIPT_DIR/poll.sh"
+TESTDATA="$SCRIPT_DIR/testdata"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq not found on PATH" >&2
+  exit 3
+fi
+
+# Pull the def verbatim: from `def quota_alerts:` through the line ending `];`
+# that closes it.
+QUOTA_DEF=$(awk '/^  def quota_alerts:/{flag=1} flag{print; if (/\];$/) exit}' "$POLL_SH")
+if [[ -z "$QUOTA_DEF" ]]; then
+  echo "could not extract quota_alerts def from $POLL_SH" >&2
+  exit 4
+fi
+
+# name : user login : expect (true/false)
+CASES=(
+  "quota_alert_pr1115_no_stack.txt:coderabbitai[bot]:true"
+  "quota_alert_pr1115_review_stack.txt:coderabbitai[bot]:true"
+  "no_actionable_pr1115.txt:coderabbitai[bot]:false"
+  "synthetic_non_alert_mentions_limit.txt:coderabbitai[bot]:false"
+)
+
+fail=0
+for case in "${CASES[@]}"; do
+  IFS=":" read -r file login expect <<<"$case"
+  body_file="$TESTDATA/$file"
+  if [[ ! -f "$body_file" ]]; then
+    echo "FAIL $file: fixture missing at $body_file" >&2
+    fail=1
+    continue
+  fi
+
+  got=$(jq -n \
+    --rawfile body "$body_file" \
+    --arg login "$login" \
+    "
+    [{user: {login: \$login}, created_at: \"2026-07-13T00:00:00Z\", body: \$body}] as \$sub_a
+    | $QUOTA_DEF
+      (quota_alerts | length) > 0
+    ")
+
+  if [[ "$got" == "$expect" ]]; then
+    echo "PASS $file (quota_alerts triggered=$got)"
+  else
+    echo "FAIL $file: expected triggered=$expect, got=$got" >&2
+    fail=1
+  fi
+done
+
+exit "$fail"

--- a/.agents/skills/pr-ai-review-loop/scripts/test_quota_alerts.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_quota_alerts.sh
@@ -8,12 +8,12 @@
 # exercises the function actually shipped, not a copy that can drift) and runs it
 # against fixture comment bodies in testdata/:
 #   - quota_alert_pr1115_no_stack.txt / quota_alert_pr1115_review_stack.txt: real
-#     CodeRabbit rate-limit banners captured from PR #1115's walkthrough comment
-#     edit history (GraphQL userContentEdits — the live GitHub body has since been
-#     overwritten by CodeRabbit's own later edits, so this is the only way to
-#     recover the exact bytes). *_review_stack carries the change-stack link
-#     banner that pushes the alert phrase past the old 500-char scan window —
-#     this is the exact regression from issue #1124.
+#     CodeRabbit rate-limit banners captured from the source PR's walkthrough
+#     comment edit history (GraphQL userContentEdits — the live GitHub body has
+#     since been overwritten by CodeRabbit's own later edits, so this is the only
+#     way to recover the exact bytes). *_review_stack carries the change-stack
+#     link banner that pushes the alert phrase past the old 500-char scan window —
+#     this is the exact silent-miss regression this test guards against.
 #   - no_actionable_pr1115.txt: the same PR's final (non-alert) walkthrough body,
 #     also real, sharing the same change-stack banner prefix — proves the fix
 #     doesn't start matching on the banner alone.

--- a/.agents/skills/pr-ai-review-loop/scripts/testdata/no_actionable_pr1115.txt
+++ b/.agents/skills/pr-ai-review-loop/scripts/testdata/no_actionable_pr1115.txt
@@ -1,0 +1,140 @@
+<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
+<!-- review_stack_entry_start -->
+
+[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/1115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)
+
+<!-- review_stack_entry_end -->
+No actionable comments were generated in the recent review. 🎉
+
+<details>
+<summary>ℹ️ Recent review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Organization UI
+
+**Review profile**: ASSERTIVE
+
+**Plan**: Pro Plus
+
+**Run ID**: `e82c03d5-8695-42b4-864a-6470071ae5f4`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 0310cbb50228987e370eb76982dcf5c8d00c625c and f879673332d10feae5817f1c188f1e3fccd6c352.
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (1)</summary>
+
+* `frontend/src/components/pages/settings/AboutSection.tsx`
+
+</details>
+
+</details>
+
+---
+<!-- walkthrough_start -->
+
+<details>
+<summary>📝 Walkthrough</summary>
+
+## Walkthrough
+
+设置页诊断日志下载改为点击后延迟回收 Blob URL，并新增测试验证回收时序、ObjectURL 创建次数及下载文件名。
+
+### Changes
+
+**诊断日志下载**
+
+|Layer / File(s)|Summary|
+|---|---|
+|**延迟回收 Blob URL 与下载验证** <br> `frontend/src/components/pages/settings/AboutSection.tsx`, `frontend/src/components/pages/settings/AboutSection.test.tsx`|`URL.revokeObjectURL` 延迟至下一个宏任务执行；测试覆盖非同步回收、ObjectURL 创建次数及返回文件名对应的下载属性。|
+
+**Estimated code review effort:** 2 (Simple) | ~10 minutes
+
+**Poem**
+
+> 小兔轻点下载键，  
+> Blob 月亮暂不眠。  
+> 定时器响再归还，  
+> 文件名稳稳落地面。  
+> 测试胡萝卜，咔嚓甜！
+
+</details>
+
+<!-- walkthrough_end -->
+<!-- pre_merge_checks_walkthrough_start -->
+
+<details>
+<summary>🚥 Pre-merge checks | ✅ 4 | ❌ 1</summary>
+
+### ❌ Failed checks (1 warning)
+
+|     Check name     | Status     | Explanation                                                                          | Resolution                                                                         |
+| :----------------: | :--------- | :----------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------- |
+| Docstring Coverage | ⚠️ Warning | Docstring coverage is 0.00% which is insufficient. The required threshold is 80.00%. | Write docstrings for the functions missing them to satisfy the coverage threshold. |
+
+<details>
+<summary>✅ Passed checks (4 passed)</summary>
+
+|         Check name         | Status   | Explanation                                              |
+| :------------------------: | :------- | :------------------------------------------------------- |
+|         Title check        | ✅ Passed | 标题简洁且准确概括了诊断日志下载因过早回收 Blob 而失败的修复。                       |
+|      Description check     | ✅ Passed | 包含问题背景、主要改动、验证结果和已知限制，但未按模板提供“范围”、“验收清单”与“已知 defer”分节。   |
+|     Linked Issues check    | ✅ Passed | 代码修改与 `#1040` 目标一致：延迟 revokeObjectURL 并补充测试，解决部分浏览器下载静默失败。 |
+| Out of Scope Changes check | ✅ Passed | 未见明显超出 `#1040` 范围的改动，新增测试和异常回收逻辑都与诊断日志下载修复直接相关。            |
+
+</details>
+
+</details>
+
+<!-- pre_merge_checks_walkthrough_end -->
+<!-- finishing_touch_checkbox_start -->
+
+<details>
+<summary>✨ Finishing Touches</summary>
+
+<details>
+<summary>📝 Generate docstrings</summary>
+
+- [ ] <!-- {"checkboxId": "7962f53c-55bc-4827-bfbf-6a18da830691"} --> Create stacked PR
+- [ ] <!-- {"checkboxId": "3e1879ae-f29b-4d0d-8e06-d12b7ba33d98"} --> Commit on current branch
+
+</details>
+<details>
+<summary>🧪 Generate unit tests (beta)</summary>
+
+- [ ] <!-- {"checkboxId": "f47ac10b-58cc-4372-a567-0e02b2c3d479", "radioGroupId": "utg-output-choice-group-4955791502"} -->   Create PR with unit tests
+- [ ] <!-- {"checkboxId": "6ba7b810-9dad-11d1-80b4-00c04fd430c8", "radioGroupId": "utg-output-choice-group-4955791502"} -->   Commit unit tests in branch `issue/1040`
+
+</details>
+
+</details>
+
+<!-- finishing_touch_checkbox_end -->
+<!-- tips_start -->
+
+---
+
+Thanks for using [CodeRabbit](https://coderabbit.ai?utm_source=oss&utm_medium=github&utm_campaign=ArcReel/ArcReel&utm_content=1115)! It's free for OSS, and your support helps us grow. If you like it, consider giving us a shout-out.
+
+<details>
+<summary>❤️ Share</summary>
+
+- [X](https://twitter.com/intent/tweet?text=I%20just%20used%20%40coderabbitai%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20the%20proprietary%20code.%20Check%20it%20out%3A&url=https%3A//coderabbit.ai)
+- [Mastodon](https://mastodon.social/share?text=I%20just%20used%20%40coderabbitai%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20the%20proprietary%20code.%20Check%20it%20out%3A%20https%3A%2F%2Fcoderabbit.ai)
+- [Reddit](https://www.reddit.com/submit?title=Great%20tool%20for%20code%20review%20-%20CodeRabbit&text=I%20just%20used%20CodeRabbit%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20proprietary%20code.%20Check%20it%20out%3A%20https%3A//coderabbit.ai)
+- [LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fcoderabbit.ai&mini=true&title=Great%20tool%20for%20code%20review%20-%20CodeRabbit&summary=I%20just%20used%20CodeRabbit%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20proprietary%20code)
+
+</details>
+
+
+<sub>Comment `@coderabbitai help` to get the list of available commands.</sub>
+
+<!-- tips_end -->

--- a/.agents/skills/pr-ai-review-loop/scripts/testdata/quota_alert_pr1115_no_stack.txt
+++ b/.agents/skills/pr-ai-review-loop/scripts/testdata/quota_alert_pr1115_no_stack.txt
@@ -1,0 +1,105 @@
+<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
+<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->
+
+> [!WARNING]
+> ## Review limit reached
+> 
+> `@Pollo3470`, you've reached your PR review limit, so we couldn't start this review.
+> 
+> **Next review available in:** **6 minutes**
+> 
+> Enable **[usage-based reviews](https://app.coderabbit.ai/settings/billing?tab=usage&orgId=cdbd6e0c-9edd-4eb5-a978-65c2225c23e9)** in Billing to review now. Otherwise, wait until the next included review is available.
+> You're only billed for reviews past your plan's rate limits ($0.25/file).
+> 
+> <details>
+> <summary>How can I continue?</summary>
+> 
+> After more reviews become available, a review can be triggered using the `@coderabbitai review` command as a PR comment. Alternatively, push new commits to this PR.
+> 
+> To avoid repeated limits, reduce automatic review volume by pausing incremental auto-reviews earlier, using label-based review opt-in, excluding WIP or generated PR titles, or requesting reviews manually when the PR is ready. If your team needs uninterrupted high-volume reviews, an organization admin can enable usage-based reviews.
+> 
+> </details>
+> 
+> 
+> <details>
+> <summary>How do review limits work?</summary>
+> 
+> CodeRabbit enforces per-developer PR review limits for each organization. Most developers receive the normal plan review availability.
+> 
+> For paid Pro and Pro+ PR reviews, CodeRabbit uses adaptive limits for sustained high-volume activity. When a developer's recent PR review activity reaches the 95th percentile or higher among CodeRabbit users, additional reviews become available more gradually as earlier reviews age out of the rolling window.
+> 
+> Please refer [docs](https://docs.coderabbit.ai/management/plans#rate-limits) for additional details.
+> 
+> </details>
+> 
+> <details>
+> <summary>Review details</summary>
+> 
+> <details>
+> <summary>⚙️ Run configuration</summary>
+> 
+> **Configuration used**: Organization UI
+> 
+> **Review profile**: ASSERTIVE
+> 
+> **Plan**: Pro Plus
+> 
+> **Run ID**: `c752d3b5-7793-4634-99e2-c6af42f9756f`
+> 
+> </details>
+> 
+> <details>
+> <summary>📥 Commits</summary>
+> 
+> Reviewing files that changed from the base of the PR and between 0bfb6ee4e22c8bdb2a3d1fd715aa46dddb791754 and 5ba769cda2f3b4c4ab7fd9ed85c4a224f3eb5887.
+> 
+> </details>
+> 
+> <details>
+> <summary>📒 Files selected for processing (2)</summary>
+> 
+> * `frontend/src/components/pages/settings/AboutSection.test.tsx`
+> * `frontend/src/components/pages/settings/AboutSection.tsx`
+> 
+> </details>
+> 
+> </details>
+
+<!-- end of auto-generated comment: rate limited by coderabbit.ai -->
+
+<!-- finishing_touch_checkbox_start -->
+
+<details>
+<summary>✨ Finishing Touches</summary>
+
+<details>
+<summary>🧪 Generate unit tests (beta)</summary>
+
+- [ ] <!-- {"checkboxId": "f47ac10b-58cc-4372-a567-0e02b2c3d479", "radioGroupId": "utg-output-choice-group-unknown_comment_id"} -->   Create PR with unit tests
+- [ ] <!-- {"checkboxId": "6ba7b810-9dad-11d1-80b4-00c04fd430c8", "radioGroupId": "utg-output-choice-group-unknown_comment_id"} -->   Commit unit tests in branch `issue/1040`
+
+</details>
+
+</details>
+
+<!-- finishing_touch_checkbox_end -->
+<!-- tips_start -->
+
+---
+
+Thanks for using [CodeRabbit](https://coderabbit.ai?utm_source=oss&utm_medium=github&utm_campaign=ArcReel/ArcReel&utm_content=1115)! It's free for OSS, and your support helps us grow. If you like it, consider giving us a shout-out.
+
+<details>
+<summary>❤️ Share</summary>
+
+- [X](https://twitter.com/intent/tweet?text=I%20just%20used%20%40coderabbitai%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20the%20proprietary%20code.%20Check%20it%20out%3A&url=https%3A//coderabbit.ai)
+- [Mastodon](https://mastodon.social/share?text=I%20just%20used%20%40coderabbitai%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20the%20proprietary%20code.%20Check%20it%20out%3A%20https%3A%2F%2Fcoderabbit.ai)
+- [Reddit](https://www.reddit.com/submit?title=Great%20tool%20for%20code%20review%20-%20CodeRabbit&text=I%20just%20used%20CodeRabbit%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20proprietary%20code.%20Check%20it%20out%3A%20https%3A//coderabbit.ai)
+- [LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fcoderabbit.ai&mini=true&title=Great%20tool%20for%20code%20review%20-%20CodeRabbit&summary=I%20just%20used%20CodeRabbit%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20proprietary%20code)
+
+</details>
+
+
+<sub>Comment `@coderabbitai help` to get the list of available commands.</sub>
+
+<!-- tips_end -->

--- a/.agents/skills/pr-ai-review-loop/scripts/testdata/quota_alert_pr1115_review_stack.txt
+++ b/.agents/skills/pr-ai-review-loop/scripts/testdata/quota_alert_pr1115_review_stack.txt
@@ -1,0 +1,165 @@
+<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
+<!-- review_stack_entry_start -->
+
+[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcReel/ArcReel/pull/1115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)
+
+<!-- review_stack_entry_end -->
+<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->
+
+> [!WARNING]
+> ## Review limit reached
+> 
+> `@Pollo3470`, you've reached your PR review limit, so we couldn't start this review.
+> 
+> **Next review available in:** **38 seconds**
+> 
+> Enable **[usage-based reviews](https://app.coderabbit.ai/settings/billing?tab=usage&orgId=cdbd6e0c-9edd-4eb5-a978-65c2225c23e9)** in Billing to review now. Otherwise, wait until the next included review is available.
+> You're only billed for reviews past your plan's rate limits ($0.25/file).
+> 
+> <details>
+> <summary>How can I continue?</summary>
+> 
+> After more reviews become available, a review can be triggered using the `@coderabbitai review` command as a PR comment. Alternatively, push new commits to this PR.
+> 
+> To avoid repeated limits, reduce automatic review volume by pausing incremental auto-reviews earlier, using label-based review opt-in, excluding WIP or generated PR titles, or requesting reviews manually when the PR is ready. If your team needs uninterrupted high-volume reviews, an organization admin can enable usage-based reviews.
+> 
+> </details>
+> 
+> 
+> <details>
+> <summary>How do review limits work?</summary>
+> 
+> CodeRabbit enforces per-developer PR review limits for each organization. Most developers receive the normal plan review availability.
+> 
+> For paid Pro and Pro+ PR reviews, CodeRabbit uses adaptive limits for sustained high-volume activity. When a developer's recent PR review activity reaches the 95th percentile or higher among CodeRabbit users, additional reviews become available more gradually as earlier reviews age out of the rolling window.
+> 
+> Please refer [docs](https://docs.coderabbit.ai/management/plans#rate-limits) for additional details.
+> 
+> </details>
+> 
+> <details>
+> <summary>Review details</summary>
+> 
+> <details>
+> <summary>⚙️ Run configuration</summary>
+> 
+> **Configuration used**: Organization UI
+> 
+> **Review profile**: ASSERTIVE
+> 
+> **Plan**: Pro Plus
+> 
+> **Run ID**: `9bbad795-5959-4dcd-8af7-60a870f94bdf`
+> 
+> </details>
+> 
+> <details>
+> <summary>📥 Commits</summary>
+> 
+> Reviewing files that changed from the base of the PR and between 0310cbb50228987e370eb76982dcf5c8d00c625c and f879673332d10feae5817f1c188f1e3fccd6c352.
+> 
+> </details>
+> 
+> <details>
+> <summary>📒 Files selected for processing (1)</summary>
+> 
+> * `frontend/src/components/pages/settings/AboutSection.tsx`
+> 
+> </details>
+> 
+> </details>
+
+<!-- end of auto-generated comment: rate limited by coderabbit.ai -->
+
+<!-- walkthrough_start -->
+
+<details>
+<summary>📝 Walkthrough</summary>
+
+## Walkthrough
+
+设置页诊断日志下载改为点击后延迟回收 Blob URL，并新增测试验证回收时序、ObjectURL 创建次数及下载文件名。
+
+### Changes
+
+**诊断日志下载**
+
+|Layer / File(s)|Summary|
+|---|---|
+|**延迟回收 Blob URL 与下载验证** <br> `frontend/src/components/pages/settings/AboutSection.tsx`, `frontend/src/components/pages/settings/AboutSection.test.tsx`|`URL.revokeObjectURL` 延迟至下一个宏任务执行；测试覆盖非同步回收、ObjectURL 创建次数及返回文件名对应的下载属性。|
+
+**Estimated code review effort:** 2 (Simple) | ~10 minutes
+
+**Poem**
+
+> 小兔轻点下载键，  
+> Blob 月亮暂不眠。  
+> 定时器响再归还，  
+> 文件名稳稳落地面。  
+> 测试胡萝卜，咔嚓甜！
+
+</details>
+
+<!-- walkthrough_end -->
+<!-- pre_merge_checks_walkthrough_start -->
+
+<details>
+<summary>🚥 Pre-merge checks | ✅ 3 | ❌ 2</summary>
+
+### ❌ Failed checks (2 warnings)
+
+|     Check name     | Status     | Explanation                                                                          | Resolution                                                                         |
+| :----------------: | :--------- | :----------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------- |
+|  Description check | ⚠️ Warning | 内容覆盖了问题、改动、验证和限制，但未按模板提供“范围/变更/验收清单/已知 defer”结构。                                     | 请补齐模板中的“范围”“变更”“验收清单”“已知 defer”四部分，并填写相关勾选项或注明“无”。                                 |
+| Docstring Coverage | ⚠️ Warning | Docstring coverage is 0.00% which is insufficient. The required threshold is 80.00%. | Write docstrings for the functions missing them to satisfy the coverage threshold. |
+
+<details>
+<summary>✅ Passed checks (3 passed)</summary>
+
+|         Check name         | Status   | Explanation                                           |
+| :------------------------: | :------- | :---------------------------------------------------- |
+|         Title check        | ✅ Passed | 标题准确概括了主变更：修复 Firefox/Safari 中诊断日志下载因过早回收 Blob 导致的失败。 |
+|     Linked Issues check    | ✅ Passed | 改动已按 `#1040` 修复同步 revoke 问题，并补充延迟回收、异常回收和下载文件名测试。       |
+| Out of Scope Changes check | ✅ Passed | 改动集中在 AboutSection 下载路径及其测试，没有明显引入与目标无关的变更。           |
+
+</details>
+
+</details>
+
+<!-- pre_merge_checks_walkthrough_end -->
+<!-- finishing_touch_checkbox_start -->
+
+<details>
+<summary>✨ Finishing Touches</summary>
+
+<details>
+<summary>🧪 Generate unit tests (beta)</summary>
+
+- [ ] <!-- {"checkboxId": "f47ac10b-58cc-4372-a567-0e02b2c3d479", "radioGroupId": "utg-output-choice-group-unknown_comment_id"} -->   Create PR with unit tests
+- [ ] <!-- {"checkboxId": "6ba7b810-9dad-11d1-80b4-00c04fd430c8", "radioGroupId": "utg-output-choice-group-unknown_comment_id"} -->   Commit unit tests in branch `issue/1040`
+
+</details>
+
+</details>
+
+<!-- finishing_touch_checkbox_end -->
+<!-- tips_start -->
+
+---
+
+Thanks for using [CodeRabbit](https://coderabbit.ai?utm_source=oss&utm_medium=github&utm_campaign=ArcReel/ArcReel&utm_content=1115)! It's free for OSS, and your support helps us grow. If you like it, consider giving us a shout-out.
+
+<details>
+<summary>❤️ Share</summary>
+
+- [X](https://twitter.com/intent/tweet?text=I%20just%20used%20%40coderabbitai%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20the%20proprietary%20code.%20Check%20it%20out%3A&url=https%3A//coderabbit.ai)
+- [Mastodon](https://mastodon.social/share?text=I%20just%20used%20%40coderabbitai%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20the%20proprietary%20code.%20Check%20it%20out%3A%20https%3A%2F%2Fcoderabbit.ai)
+- [Reddit](https://www.reddit.com/submit?title=Great%20tool%20for%20code%20review%20-%20CodeRabbit&text=I%20just%20used%20CodeRabbit%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20proprietary%20code.%20Check%20it%20out%3A%20https%3A//coderabbit.ai)
+- [LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fcoderabbit.ai&mini=true&title=Great%20tool%20for%20code%20review%20-%20CodeRabbit&summary=I%20just%20used%20CodeRabbit%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20proprietary%20code)
+
+</details>
+
+
+<sub>Comment `@coderabbitai help` to get the list of available commands.</sub>
+
+<!-- tips_end -->

--- a/.agents/skills/pr-ai-review-loop/scripts/testdata/synthetic_non_alert_mentions_limit.txt
+++ b/.agents/skills/pr-ai-review-loop/scripts/testdata/synthetic_non_alert_mentions_limit.txt
@@ -1,0 +1,7 @@
+<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
+
+## Walkthrough
+
+新增每用户限流(rate limiting)中间件，quota 配置存于 Redis，rate 字段用于每分钟计数。
+
+**Estimated code review effort:** 2 (Simple)


### PR DESCRIPTION
## 问题

`pr-ai-review-loop` 的 `poll.sh` 用 `quota_alerts` 扫描 reviewer 评论正文的**前 500 字符**探测限流/配额告警。CodeRabbit 限流评论正文前缀固定携带一段「变更堆栈」HTML 注释 + 链接横幅，把关键句「you've reached your PR review limit」挤出窗口，导致 `quota_alerts` 为空。叠加该评论 `is_ok: false`、`actionable_count: null`，机械判读会误读为「已审查、无 actionable」——实际最后两笔 commit 从未被审查，险些按达标合并（PR #1115 实证）。

## 方案

`quota_alerts` 新增一条补充判定分支：全文匹配 CodeRabbit 限流横幅固定携带的 HTML 标记 `<!-- ... rate limited by coderabbit.ai -->`。该标记由 CodeRabbit 自身发出、结构性且不受横幅长度影响，无歧义。原有基于短语的 500 字符窗口匹配不变，继续覆盖 Gemini 等其他 bot。

放弃的替代方案：扩大/后移扫描窗口（横幅长度不固定，扩多大都可能被再挤出）；短语去窗口全文匹配（扩大误报面，普通评论讨论 limit 话题时易命中）。

## 验证

- 新增 `scripts/test_quota_alerts.sh`：从 `poll.sh` 动态摘取 `quota_alerts` def 源码后跑 4 组用例（含变更堆栈横幅的真实限流评论正例、无横幅正例、真实终版负例、构造的「仅讨论限流话题」负例），4/4 PASS。
- 回归有效性：临时撤销修复后重跑，恰好含横幅的真实样本 FAIL、其余 3 例仍 PASS，确认测试捕获的是本 issue 描述的原始漏审 bug。
- `bash -n poll.sh` / `shellcheck poll.sh`（对比修复前无新增告警）通过。
- SKILL.md / references 仅描述 `quota_alerts` 非空时的处置动作，未描述扫描窗口机制，无需同步。

## 本地审查

`/code-review xhigh` 复核核心 jq/正则逻辑、转义、误报面、awk 提取边界均正确。修复一处约定违规：回归测试注释中的 issue/PR 追踪编号已移除（改指 fixture 文件名 + 保留数据复原方法）。

Closes #1124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 改进配额/限流提示识别，能够直接识别平台自动生成的“rate limited”标记。
  * 避免因评论内容格式变化导致配额警报误判或漏报。
* **测试**
  * 新增回归测试，覆盖配额警报触发与非触发场景，并新增多组真实评论示例以验证识别准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->