### PR TITLE
fix(frontend): 宫格生成完成后刷新费用面板

### DIFF
--- a/frontend/src/hooks/useProjectEventsSSE.test.tsx
+++ b/frontend/src/hooks/useProjectEventsSSE.test.tsx
@@ -272,6 +272,13 @@ describe("useProjectEventsSSE", () => {
 
   it.each([
     {
+      action: "grid_ready" as const,
+      entityType: "grid" as const,
+      entityId: "G01",
+      label: "宫格「G01」",
+      expectedText: "宫格「G01」已生成",
+    },
+    {
       action: "reference_video_ready" as const,
       entityType: "reference_unit" as const,
       entityId: "U01",

--- a/frontend/src/utils/project-changes.test.ts
+++ b/frontend/src/utils/project-changes.test.ts
@@ -3,6 +3,7 @@ import type { ProjectChange } from "@/types";
 import {
   formatGroupedDeferredText,
   formatGroupedNotificationText,
+  GENERATION_ACTIONS,
   groupChangesByType,
 } from "./project-changes";
 
@@ -19,6 +20,10 @@ function makeChange(overrides: Partial<ProjectChange> = {}): ProjectChange {
 }
 
 describe("project-changes utils", () => {
+  it("includes grid_ready in GENERATION_ACTIONS so grid completion refreshes cost", () => {
+    expect(GENERATION_ACTIONS.has("grid_ready")).toBe(true);
+  });
+
   it("groups changes by entity_type and action", () => {
     const groups = groupChangesByType([
       makeChange({ entity_id: "张三", label: "角色「张三」" }),

--- a/frontend/src/utils/project-changes.ts
+++ b/frontend/src/utils/project-changes.ts
@@ -2,20 +2,18 @@ import type { ProjectChange } from "@/types";
 
 const GROUP_NAME_LIMIT = 5;
 
-// 生成事件（用于刷新费用等）——不含 grid_ready：宫格生成完成不触发费用刷新（既有行为）。
+// 生成事件（用于刷新费用等）。
 export const GENERATION_ACTIONS: ReadonlySet<ProjectChange["action"]> = new Set([
   "storyboard_ready",
   "video_ready",
+  "grid_ready",
   "reference_video_ready",
   "tts_ready",
 ]);
 
 // 完成事件（action 本身即通知类别，与 entity_type 无关）——优先级查表、导航行为、通知文案均不按
 // entity_type 拆分，五类骨架/任务共用同一套判定。
-export const COMPLETION_ACTIONS: ReadonlySet<ProjectChange["action"]> = new Set([
-  ...GENERATION_ACTIONS,
-  "grid_ready",
-]);
+export const COMPLETION_ACTIONS: ReadonlySet<ProjectChange["action"]> = GENERATION_ACTIONS;
 
 const ENTITY_LABELS: Record<ProjectChange["entity_type"], string> = {
   project: "项目",


### PR DESCRIPTION
## 问题

`GENERATION_ACTIONS`（`frontend/src/utils/project-changes.ts`）判定 SSE 变更事件是否触发费用面板刷新（`useProjectEventsSSE.ts` 的 `hasGenerationEvent`）。`grid_ready` 此前不在集合中，且注释显式写明「宫格生成完成不触发费用刷新（既有行为）」。

但宫格生成走正常图片生成计费路径（`grid_image_unit_cost` + `usage_tracker` 记账），与分镜图/视频同样产生真实费用。宫格完成后费用面板不刷新是遗漏，而非有意取舍——与 #1123（参考生视频/TTS 不刷新）同类。

## 改动

- `GENERATION_ACTIONS` 纳入 `grid_ready`，宫格完成即触发 `debouncedFetch` 费用刷新
- 更新矛盾注释
- `COMPLETION_ACTIONS` 原为 `new Set([...GENERATION_ACTIONS, "grid_ready"])`，现两者集合内容完全等价，顺手简化为同一常量（行为不变）
- 回归测试：`project-changes.test.ts` 断言 `GENERATION_ACTIONS.has("grid_ready")`；`useProjectEventsSSE.test.tsx` 参数化用例新增 `grid_ready` 分支，验证 toast 文案与费用刷新被调用

## 验证

- `pnpm check`（typecheck + eslint + vitest）全绿，912 tests passed
- /code-review high 无发现

Closes #1133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持识别“宫格生成完成”事件，并在完成后刷新成本数据。

* **体验优化**
  * 宫格生成完成时显示对应提示，同时保持当前页面位置不变，不触发导航。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->