### PR TITLE
fix(script-generator): ad 剧本生成按项目语言折算口播语速与输出语言

### DIFF
--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -457,6 +457,9 @@ class ScriptGenerator:
             supported_durations=supported,
             episode=episode,
             aspect_ratio=self._resolve_aspect_ratio(),
+            # 输出语言与口播语速折算同取项目 source_language，与 drama/narration 同口径
+            # （见 build_ad_prompt 内 speech_rate_units_per_second/reading_unit_noun 调用）。
+            target_language=self.project_json.get("source_language") or "中文",
         )
 
     async def build_prompt(self, episode: int) -> str:

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -1209,6 +1209,25 @@ class TestAdScriptGeneration:
         # 不得落入参考视频 video_units prompt
         assert "video_units" not in prompt
 
+    async def test_build_prompt_uses_project_source_language(self, tmp_path):
+        """ad prompt 的口播语速折算与输出语言须取项目 source_language（与 drama/narration 同口径），非中文项目不得回落中文/zh 语速。"""
+        project_path = tmp_path / "demo"
+        _write_ad_project(project_path)
+        project_json_path = project_path / "project.json"
+        payload = json.loads(project_json_path.read_text(encoding="utf-8"))
+        payload["source_language"] = "en"
+        _write_json(project_json_path, payload)
+
+        generator = ScriptGenerator(project_path)
+        prompt = await generator.build_prompt(1)
+
+        # 口播语速折算按 en 口径（约 2.5 词/秒），不得回落默认 zh 口径（约 5 字/秒）
+        assert "约 2.5 词/秒" in prompt
+        assert "约 5 字/秒" not in prompt
+        # 输出语言规则锁定为项目 source_language，不回落默认中文
+        assert "所有字符串值必须使用 en" in prompt
+        assert "所有字符串值必须使用 中文" not in prompt
+
     async def test_build_prompt_tolerates_null_project_fields(self, tmp_path):
         """project.json 手工编辑后字段显式为 null：prompt 构建按空值归一化，不抛 AttributeError。"""
         project_path = tmp_path / "demo"


### PR DESCRIPTION
## 问题

`ScriptGenerator._build_ad_prompt` 调用 `build_ad_prompt` 时未传 `target_language`，恒用默认「中文」。导致非中文项目的 ad 剧本生成：口播语速折算恒回退 zh 口径（约 5 字/秒），输出语言规则恒中文——`lib/prompt_builders_ad.py` 已实现的「语速与量词随语言切换」在 ad 调用链上从未触发。

## 改动

- `_build_ad_prompt` 传入 `target_language=self.project_json.get("source_language") or "中文"`，与 drama/narration 三处接线同口径。
- 新增调用点级测试 `test_build_prompt_uses_project_source_language`：`source_language="en"` 时断言口播折算为「约 2.5 词/秒」、输出语言规则为项目语言，且不回落 zh/中文默认。

## 验证

- `uv run python -m pytest tests/test_script_generator.py -k "AdScript or source_language"` — 10 passed
- `uv run ruff check` / `ruff format --check` / `uv run basedpyright lib/script_generator.py` — 全部清洁
- `/code-review high` — 0 findings

## 行为

- 项目语言 en → 口播约 2.5 词/秒、输出 en
- 项目语言 zh 或未设置 → 行为不变（约 5 字/秒、中文）

Closes #1129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 广告和短片脚本现在会根据项目设置的源语言生成内容。
  * 未设置或语言无效时，默认使用中文。

* **测试**
  * 增加了对英文项目源语言及对应脚本输出规则的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->