### PR TITLE
fix(assistant): 切换项目后重置助手时间线，消除跨项目条目混排

### DIFF
--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -579,4 +579,115 @@ describe("useAssistantSession", () => {
       expect(sendResult).toBe(false);
     });
   });
+
+  it("resets timeline on project switch so a running session's SSE cold cursor is not polluted by the previous project's residual entries", async () => {
+    vi.spyOn(API, "listAssistantSessions").mockImplementation(async (projectName) => ({
+      sessions: [makeSession(projectName === "project-a" ? "session-a" : "session-b", "running")],
+    }));
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (_projectName, sessionId) => ({
+      session: makeSession(sessionId, "running"),
+    }));
+
+    const { rerender } = renderHook(({ projectName }) => useAssistantSession(projectName), {
+      initialProps: { projectName: "project-a" as string | null },
+    });
+
+    // 项目 A：running 会话冷订阅建流，灌入残留条目
+    await waitFor(() => {
+      expect(MockEventSource.instances).toHaveLength(1);
+    });
+    act(() => {
+      MockEventSource.instances[0].emit("entry", userEntry(0, "A-0"));
+      MockEventSource.instances[0].emit("entry", {
+        seq: 1,
+        type: "assistant",
+        content: [{ type: "text", text: "A-1" }],
+        uuid: "a-1",
+      });
+    });
+    expect(useAssistantStore.getState().entries.map((e) => e.seq)).toEqual([0, 1]);
+
+    // 切到项目 B（其会话亦为 running）
+    rerender({ projectName: "project-b" });
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-b");
+    });
+    await waitFor(() => {
+      expect(MockEventSource.instances).toHaveLength(2);
+    });
+
+    // 冷订阅游标由重置后的空 entries 推导（after=-1，等效从头订阅，URL 不带 after 参数），
+    // 不被 A 的残留最大 seq 污染
+    expect(MockEventSource.instances[1].url).not.toContain("after=");
+    // 时间线不含 A 的条目
+    expect(useAssistantStore.getState().entries).toEqual([]);
+    expect(useAssistantStore.getState().turns).toEqual([]);
+  });
+
+  it("resets timeline when switching to a project that has no sessions", async () => {
+    vi.spyOn(API, "listAssistantSessions").mockImplementation(async (projectName) => ({
+      sessions: projectName === "project-a" ? [makeSession("session-a", "idle")] : [],
+    }));
+    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-a", "idle") });
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(
+      makeEntriesResponse({ entries: [userEntry(0, "A-0")] }),
+    );
+
+    const { rerender } = renderHook(({ projectName }) => useAssistantSession(projectName), {
+      initialProps: { projectName: "project-a" as string | null },
+    });
+
+    // 项目 A：idle 会话冷读出一条历史条目
+    await waitFor(() => {
+      expect(useAssistantStore.getState().turns).toHaveLength(1);
+    });
+
+    // 切到无会话项目：初始化路径「无会话」分支同样重置时间线
+    rerender({ projectName: "project-b" });
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBeNull();
+    });
+    expect(useAssistantStore.getState().entries).toEqual([]);
+    expect(useAssistantStore.getState().turns).toEqual([]);
+  });
+
+  it("keeps the resume cursor at the last seq when reconnecting a dropped stream within the same session", async () => {
+    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+      sessions: [makeSession("session-1", "running")],
+    });
+    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "running") });
+
+    renderHook(() => useAssistantSession("demo"));
+
+    await waitFor(() => {
+      expect(MockEventSource.instances).toHaveLength(1);
+    });
+    // 首帧冷订阅从头开始（entries 为空，URL 不带 after 参数）
+    expect(MockEventSource.instances[0].url).not.toContain("after=");
+
+    act(() => {
+      MockEventSource.instances[0].emit("entry", userEntry(0, "hello"));
+      MockEventSource.instances[0].emit("entry", {
+        seq: 1,
+        type: "assistant",
+        content: [{ type: "text", text: "hi" }],
+        uuid: "a-1",
+      });
+    });
+
+    // 同会话断线：连接被判死且运行中，兜底重连（3s 后）
+    vi.useFakeTimers();
+    act(() => {
+      MockEventSource.instances[0].readyState = MockEventSource.CLOSED;
+      MockEventSource.instances[0].onerror?.(new Event("error"));
+      vi.advanceTimersByTime(3000);
+    });
+    vi.useRealTimers();
+
+    // 续传游标停在最后 seq（after=1），不因本 issue 的项目切换重置而回退到从头
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(MockEventSource.instances[1].url).toContain("after=1");
+  });
 });

--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -679,12 +679,15 @@ describe("useAssistantSession", () => {
 
     // 同会话断线：连接被判死且运行中，兜底重连（3s 后）
     vi.useFakeTimers();
-    act(() => {
-      MockEventSource.instances[0].readyState = MockEventSource.CLOSED;
-      MockEventSource.instances[0].onerror?.(new Event("error"));
-      vi.advanceTimersByTime(3000);
-    });
-    vi.useRealTimers();
+    try {
+      act(() => {
+        MockEventSource.instances[0].readyState = MockEventSource.CLOSED;
+        MockEventSource.instances[0].onerror?.(new Event("error"));
+        vi.advanceTimersByTime(3000);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
 
     // 续传游标停在最后 seq（after=1），不因本 issue 的项目切换重置而回退到从头
     expect(MockEventSource.instances).toHaveLength(2);

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -253,6 +253,7 @@ export function useAssistantSession(projectName: string | null) {
       try {
         // 获取会话列表
         const res = await API.listAssistantSessions(projectName!);
+        if (cancelled) return;
         const sessions = res.sessions ?? [];
         store.getState().setSessions(sessions);
 

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -245,6 +245,11 @@ export function useAssistantSession(projectName: string | null) {
 
     async function init() {
       store.getState().setMessagesLoading(true);
+      // 切项目先重置时间线（与新建/切换/删除三条会话路径同口径），使有会话/
+      // 无会话两个分支都从干净状态出发：running 会话的 SSE 冷订阅游标由重置后
+      // 的空 entries 推导（等效从头订阅），不被上一个项目的残留条目污染，也不会
+      // 把旧项目条目混排进新会话时间线。
+      store.getState().resetTimeline();
       try {
         // 获取会话列表
         const res = await API.listAssistantSessions(projectName!);


### PR DESCRIPTION
## 问题

切换项目时若上一项目的助手会话正处于 `running` 且已累积时间线条目，项目切换 effect 的 `init()` 缺少 `resetTimeline()`（其余三条会话切换路径都有），导致：

- 新项目 running 会话的 SSE 冷订阅游标由残留 `entries` 的最大 seq 推导，服务端据此游标过滤会跳过新会话早期条目
- 新会话时间线在被整帧替换前，短暂混排上一项目的残留条目

## 改动

在项目切换 effect 的 `init()` 开头（`setMessagesLoading(true)` 之后、拉取会话列表的 `await` 之前）补一次 `store.getState().resetTimeline()`。一处调用同时覆盖「有会话」「无会话」两个分支，与新建/切换/删除三条路径同口径。放在 `await` 之前保证建流时 `entries` 恒为空，冷订阅游标等效从头订阅（URL 不带 `after`）。

## 验证

- 新增 3 例测试：跨项目 running 切换冷订阅不带 `after` 且时间线不含旧条目；切到无会话项目时间线清空；同会话断线重连续传游标 = `after=1`（回归守卫，锁定不误伤续传）
- `pnpm lint` / `pnpm typecheck` 清洁；`vitest run` 103 文件 915 测试全过
- `/code-review high` 无发现

Closes #1141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 切换项目/会话或进入会话前，会先重置时间线为干净起点，避免旧条目残留影响回放与续传推导（包括运行中会话相关场景）。
  * 切换到无会话的项目时，会走“无会话”初始化流程，正确清空会话条目并重置当前会话标识。
  * SSE 断线后重连会保持续传位置，避免重复或从头订阅导致的错位。
* **Tests**
  * 新增切项目重置、无会话初始化、断线重连续传的用例覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->