### PR TITLE
fix(server): 生成端点错误响应不再泄露服务器路径，异常统一由 app 级处理器映射

### DIFF
--- a/lib/api_errors.py
+++ b/lib/api_errors.py
@@ -1,0 +1,34 @@
+"""携带 (status_code, i18n key, params) 的领域异常。
+
+约定：
+- lib / service 层抛出时只带 i18n key 与 params，不带成品文案；
+- server 注册的 app 级 exception handler（``server/error_handlers.py``）单点完成
+  状态码映射、按请求 Accept-Language 翻译与脱敏，路由函数体只保留 happy path；
+- ``str(exc)`` 只进服务端日志，永不面向客户端输出。
+"""
+
+from __future__ import annotations
+
+
+class ApiError(Exception):
+    """领域异常基类：由 app 级 exception handler 统一翻译为 ``{"detail": ...}`` 响应。"""
+
+    def __init__(self, key: str, *, status_code: int, **params: object) -> None:
+        super().__init__(key)
+        self.key = key
+        self.status_code = status_code
+        self.params = params
+
+
+class BadRequestError(ApiError):
+    """客户端请求错误（HTTP 400）。"""
+
+    def __init__(self, key: str, **params: object) -> None:
+        super().__init__(key, status_code=400, **params)
+
+
+class NotFoundError(ApiError):
+    """请求的资源不存在（HTTP 404）。"""
+
+    def __init__(self, key: str, **params: object) -> None:
+        super().__init__(key, status_code=404, **params)

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -1,5 +1,6 @@
 MESSAGES = {
     "project_not_found": "Project '{name}' does not exist or is not initialized",
+    "resource_not_found": "The requested resource does not exist",
     "overview_ai_response_invalid": "The AI response could not be parsed into a project overview. Please retry or switch to a different model/provider",
     "video_capabilities_unresolved": "Cannot resolve video model capabilities for project '{name}': {reason}",
     "scope_invalid": "scope must be full or current",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -1,5 +1,6 @@
 MESSAGES = {
     "project_not_found": "Dự án '{name}' không tồn tại hoặc chưa được khởi tạo",
+    "resource_not_found": "Tài nguyên được yêu cầu không tồn tại",
     "overview_ai_response_invalid": "Không thể phân tích phản hồi của AI thành tổng quan dự án, vui lòng thử lại hoặc đổi mô hình/nhà cung cấp",
     "video_capabilities_unresolved": "Không xác định được khả năng mô hình video cho dự án '{name}': {reason}",
     "scope_invalid": "scope phải là full hoặc current",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -1,5 +1,6 @@
 MESSAGES = {
     "project_not_found": "项目 '{name}' 不存在或未初始化",
+    "resource_not_found": "请求的资源不存在",
     "overview_ai_response_invalid": "AI 返回内容无法解析为项目概述，请重试或更换模型/供应商",
     "video_capabilities_unresolved": "无法解析项目 '{name}' 的视频模型能力：{reason}",
     "scope_invalid": "scope 必须为 full 或 current",

--- a/server/app.py
+++ b/server/app.py
@@ -455,13 +455,14 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# app 级异常处理器：异常→状态码→detail 映射的单点（见 server/error_handlers.py）
-register_error_handlers(app)
-
 # CORS 配置（env 驱动）：
 #   - CORS_ORIGINS 未设置 / 空 / 包含 "*" → 通配 origins，credentials 强制关闭
 #     （CORS spec 不允许通配 + credentials 组合；Starlette 在初始化时会 RuntimeError）
 #   - 否则按逗号分隔解析为白名单，credentials 打开供前端附带 cookie / Authorization 跨域
+#
+# 须在 register_error_handlers(app) 之前算出：未预期异常的 500 由
+# ServerErrorMiddleware 兜底发送，绕过 CORSMiddleware（见
+# server/error_handlers.py::_cors_headers_for），handler 需要这份配置手工补 CORS 头。
 _cors_raw = os.environ.get("CORS_ORIGINS", "*").strip()
 _allow_origins: list[str] = [o.strip() for o in _cors_raw.split(",") if o.strip()]
 if not _allow_origins or "*" in _allow_origins:
@@ -469,6 +470,9 @@ if not _allow_origins or "*" in _allow_origins:
     _allow_credentials = False
 else:
     _allow_credentials = True
+
+# app 级异常处理器：异常→状态码→detail 映射的单点（见 server/error_handlers.py）
+register_error_handlers(app, cors_allow_origins=_allow_origins, cors_allow_credentials=_allow_credentials)
 
 app.add_middleware(
     CORSMiddleware,

--- a/server/app.py
+++ b/server/app.py
@@ -40,6 +40,7 @@ from lib.logging_config import attach_file_handler, migrate_legacy_log_dir, setu
 from lib.project_migrations import cleanup_stale_backups, run_project_migrations
 from lib.source_loader.migration import migrate_project_source_encoding
 from server.auth import ensure_auth_password
+from server.error_handlers import register_error_handlers
 from server.routers import (
     agent_chat,
     agent_config,
@@ -453,6 +454,9 @@ app = FastAPI(
     version="1.0.0",
     lifespan=lifespan,
 )
+
+# app 级异常处理器：异常→状态码→detail 映射的单点（见 server/error_handlers.py）
+register_error_handlers(app)
 
 # CORS 配置（env 驱动）：
 #   - CORS_ORIGINS 未设置 / 空 / 包含 "*" → 通配 origins，credentials 强制关闭

--- a/server/error_handlers.py
+++ b/server/error_handlers.py
@@ -1,0 +1,59 @@
+"""app 级异常处理器：异常→状态码→detail 映射的单点。
+
+路由函数体只保留 happy path，领域异常与 lib 层异常在此统一完成：
+
+- 状态码映射（``ApiError`` 自带；lib 异常按类型固定）
+- 按请求 ``Accept-Language`` 翻译（复用 ``get_translator``）
+- 脱敏：除 i18n key 显式声明的 params 外，异常消息一律不回传客户端——
+  ``FileNotFoundError`` / 未预期异常的 ``str(exc)`` 可能含服务器绝对路径，只进日志
+
+渐进迁移：仍自行 try/except 的路由不受影响（异常不会传播到这里）；
+迁移一个端点 = 删掉它的 except 阶梯，让异常自然传播。
+"""
+
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from lib.api_errors import ApiError
+from lib.generation_queue_client import TaskSpecValidationError
+from lib.i18n import get_translator
+from lib.script_editor import ScriptEditError
+
+logger = logging.getLogger(__name__)
+
+
+def register_error_handlers(app: FastAPI) -> None:
+    """注册全部 app 级异常处理器。测试中对 bare ``FastAPI()`` 同样适用。"""
+
+    @app.exception_handler(ApiError)
+    async def _handle_api_error(request: Request, exc: ApiError) -> JSONResponse:
+        _t = get_translator(request)
+        return JSONResponse(status_code=exc.status_code, content={"detail": _t(exc.key, **exc.params)})
+
+    @app.exception_handler(TaskSpecValidationError)
+    async def _handle_task_spec_error(request: Request, exc: TaskSpecValidationError) -> JSONResponse:
+        _t = get_translator(request)
+        return JSONResponse(status_code=400, content={"detail": _t(exc.code, **exc.params)})
+
+    @app.exception_handler(ScriptEditError)
+    async def _handle_script_edit_error(request: Request, exc: ScriptEditError) -> JSONResponse:
+        # 脏脚本（分镜数组键损坏等）→ 4xx 客户端错误；reason 是结构性描述，不含服务器路径
+        _t = get_translator(request)
+        return JSONResponse(status_code=400, content={"detail": _t("script_data_corrupted", reason=str(exc))})
+
+    @app.exception_handler(FileNotFoundError)
+    async def _handle_file_not_found(request: Request, exc: FileNotFoundError) -> JSONResponse:
+        # 不回传 str(exc)：load_script 等异常消息含服务器绝对路径，只进日志
+        logger.warning("资源不存在: %s %s (%s)", request.method, request.url.path, exc)
+        _t = get_translator(request)
+        return JSONResponse(status_code=404, content={"detail": _t("resource_not_found")})
+
+    @app.exception_handler(Exception)
+    async def _handle_unexpected(request: Request, exc: Exception) -> JSONResponse:
+        # 未预期异常的消息可能含服务器路径等内部细节，一律通用 500。
+        # Starlette 发送本响应后会 re-raise，堆栈由 request_logging_middleware /
+        # uvicorn 记录，此处不重复打印。
+        _t = get_translator(request)
+        return JSONResponse(status_code=500, content={"detail": _t("internal_server_error")})

--- a/server/error_handlers.py
+++ b/server/error_handlers.py
@@ -12,6 +12,7 @@
 """
 
 import logging
+from collections.abc import Sequence
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
@@ -24,8 +25,54 @@ from lib.script_editor import ScriptEditError
 logger = logging.getLogger(__name__)
 
 
-def register_error_handlers(app: FastAPI) -> None:
-    """注册全部 app 级异常处理器。测试中对 bare ``FastAPI()`` 同样适用。"""
+def _cors_headers_for(
+    request: Request,
+    *,
+    allow_origins: Sequence[str],
+    allow_credentials: bool,
+) -> dict[str, str]:
+    """为兜底 500 响应手工补 CORS 头，逻辑对齐 Starlette ``CORSMiddleware.send()``。
+
+    ``ServerErrorMiddleware`` 发送未预期异常的 500 响应时用的是最外层原始
+    ``send``（闭包参数），绕过所有内层中间件的 send 包装——包括注册在更内层的
+    ``CORSMiddleware``。跨域前端因此只会看到 network error，看不到真正的
+    500 body。调整中间件注册顺序无效（``Exception``/500 恒定路由到
+    ``ServerErrorMiddleware``），只能在 handler 内按与 app 一致的 CORS 配置
+    手工计算并附加响应头。
+    """
+    origin = request.headers.get("origin")
+    if origin is None:
+        return {}
+
+    allow_all_origins = "*" in allow_origins
+    headers: dict[str, str] = {}
+    if allow_all_origins:
+        headers["Access-Control-Allow-Origin"] = "*"
+    if allow_credentials:
+        headers["Access-Control-Allow-Credentials"] = "true"
+
+    if allow_all_origins and allow_credentials:
+        headers["Access-Control-Allow-Origin"] = origin
+        headers["Vary"] = "Origin"
+    elif not allow_all_origins and origin in allow_origins:
+        headers["Access-Control-Allow-Origin"] = origin
+        headers["Vary"] = "Origin"
+
+    return headers
+
+
+def register_error_handlers(
+    app: FastAPI,
+    *,
+    cors_allow_origins: Sequence[str] = ("*",),
+    cors_allow_credentials: bool = False,
+) -> None:
+    """注册全部 app 级异常处理器。测试中对 bare ``FastAPI()`` 同样适用。
+
+    ``cors_allow_origins``/``cors_allow_credentials`` 须与 app 上实际注册的
+    ``CORSMiddleware`` 配置一致（见 ``_handle_unexpected`` 内的说明与
+    ``server/app.py`` 调用处），默认值对应「未配置 CORS」的保守场景。
+    """
 
     @app.exception_handler(ApiError)
     async def _handle_api_error(request: Request, exc: ApiError) -> JSONResponse:
@@ -55,5 +102,14 @@ def register_error_handlers(app: FastAPI) -> None:
         # 未预期异常的消息可能含服务器路径等内部细节，一律通用 500。
         # Starlette 发送本响应后会 re-raise，堆栈由 request_logging_middleware /
         # uvicorn 记录，此处不重复打印。
+        #
+        # ServerErrorMiddleware 恒定用最外层原始 send 发送本响应，绕过
+        # CORSMiddleware（见 _cors_headers_for 文档）——手工补上 CORS 头，
+        # 否则跨域前端会把这个 500 当成 network error。
         _t = get_translator(request)
-        return JSONResponse(status_code=500, content={"detail": _t("internal_server_error")})
+        headers = _cors_headers_for(
+            request,
+            allow_origins=cors_allow_origins,
+            allow_credentials=cors_allow_credentials,
+        )
+        return JSONResponse(status_code=500, content={"detail": _t("internal_server_error")}, headers=headers)

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -3,24 +3,25 @@
 
 处理分镜图、视频、角色图、线索图的生成请求。
 所有生成请求入队到 GenerationQueue，由 GenerationWorker 异步执行。
+
+错误处理：路由函数体只保留 happy path。领域异常（``lib.api_errors``）与 lib 层异常
+（``FileNotFoundError`` / ``ScriptEditError`` / ``TaskSpecValidationError`` / 未预期异常）
+由 app 级 exception handler 统一映射为 HTTP 响应并脱敏（见 ``server/error_handlers.py``）。
 """
 
 import asyncio
-import logging
 
-logger = logging.getLogger(__name__)
-
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from pydantic import BaseModel
 
+from lib.api_errors import BadRequestError, NotFoundError
 from lib.app_data_dir import app_data_dir
 from lib.asset_types import ASSET_SPECS
 from lib.config.resolver import ConfigResolver
 from lib.generation_queue import get_generation_queue
-from lib.generation_queue_client import TaskSpec, TaskSpecValidationError
+from lib.generation_queue_client import TaskSpec
 from lib.i18n import Translator
 from lib.project_manager import ProjectManager
-from lib.script_editor import ScriptEditError
 from lib.storyboard_sequence import (
     find_storyboard_item,
     get_storyboard_items,
@@ -88,59 +89,45 @@ async def generate_storyboard(
 
     生成由 GenerationWorker 异步执行，状态通过 SSE 推送。
     """
-    try:
 
-        def _sync():
-            get_project_manager().load_project(project_name)
-            script = get_project_manager().load_script(project_name, req.script_file)
-            items, id_field, _, _, _ = get_storyboard_items(script)
-            resolved = find_storyboard_item(items, id_field, segment_id)
-            if resolved is None:
-                raise HTTPException(status_code=404, detail=_t("segment_not_found", id=segment_id))
+    def _sync():
+        get_project_manager().load_project(project_name)
+        script = get_project_manager().load_script(project_name, req.script_file)
+        items, id_field, _, _, _ = get_storyboard_items(script)
+        resolved = find_storyboard_item(items, id_field, segment_id)
+        if resolved is None:
+            raise NotFoundError("segment_not_found", id=segment_id)
 
-        await asyncio.to_thread(_sync)
+    await asyncio.to_thread(_sync)
 
-        # 结构校验 + 构造经单一守卫点（与 SDK 入队同源，规则不分叉）
-        try:
-            spec = TaskSpec.from_request(
-                task_type="storyboard",
-                media_type="image",
-                resource_id=segment_id,
-                prompt=req.prompt,
-                script_file=req.script_file,
-            )
-        except TaskSpecValidationError as e:
-            raise HTTPException(status_code=400, detail=_t(e.code, **e.params))
+    # 结构校验 + 构造经单一守卫点（与 SDK 入队同源，规则不分叉）；
+    # 校验失败抛 TaskSpecValidationError，由 app 级 handler 映射为 400
+    spec = TaskSpec.from_request(
+        task_type="storyboard",
+        media_type="image",
+        resource_id=segment_id,
+        prompt=req.prompt,
+        script_file=req.script_file,
+    )
 
-        # 入队
-        queue = get_generation_queue()
-        result = await queue.enqueue_task(
-            project_name=project_name,
-            task_type=spec.task_type,
-            media_type=spec.media_type,
-            resource_id=spec.resource_id,
-            script_file=spec.script_file,
-            payload=spec.payload,
-            source="webui",
-            user_id=_user.id,
-        )
+    # 入队
+    queue = get_generation_queue()
+    result = await queue.enqueue_task(
+        project_name=project_name,
+        task_type=spec.task_type,
+        media_type=spec.media_type,
+        resource_id=spec.resource_id,
+        script_file=spec.script_file,
+        payload=spec.payload,
+        source="webui",
+        user_id=_user.id,
+    )
 
-        return {
-            "success": True,
-            "task_id": result["task_id"],
-            "message": _t("storyboard_task_submitted", segment_id=segment_id),
-        }
-
-    except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except HTTPException:
-        raise
-    except ScriptEditError as e:
-        # 脏脚本(分镜数组键损坏)→ 4xx 客户端错误而非 5xx,detail 走 i18n 不直接暴露 str(e)
-        raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=str(e)))
-    except Exception:
-        logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
+    return {
+        "success": True,
+        "task_id": result["task_id"],
+        "message": _t("storyboard_task_submitted", segment_id=segment_id),
+    }
 
 
 # ==================== 视频生成 ====================
@@ -159,93 +146,75 @@ async def generate_video(
 
     需要先有分镜图作为起始帧。生成由 GenerationWorker 异步执行。
     """
-    try:
 
-        def _sync():
-            pm_local = get_project_manager()
-            pm_local.load_project(project_name)
-            project_path = pm_local.get_project_path(project_name)
+    def _sync():
+        pm_local = get_project_manager()
+        pm_local.load_project(project_name)
+        project_path = pm_local.get_project_path(project_name)
 
-            # 与 worker 一致：优先读取 generated_assets.storyboard_image，回退默认路径。
-            # 旧宫格项目 storyboard_image 指向 scene_{id}_first.png，仍可正常解析。
-            storyboard_rel: str | None = None
-            try:
-                script = pm_local.load_script(project_name, req.script_file)
-                items, id_field, _, _, _ = get_storyboard_items(script)
-                resolved = find_storyboard_item(items, id_field, segment_id)
-                if resolved:
-                    assets = resolved[0].get("generated_assets") or {}
-                    if isinstance(assets, dict):
-                        storyboard_rel = assets.get("storyboard_image")
-            except FileNotFoundError:
-                # 脚本不存在交由后续流程报错；此处只负责存在性检查
-                pass
-            except ScriptEditError as exc:
-                # 脏脚本(分镜数组键损坏)→ fail-fast 4xx,与 storyboard endpoint 对齐。
-                # 不再 silently pass 降级走 default 路径:default 文件恰好存在时会让请求
-                # 「先返回提交成功、worker 解析脚本时再确定失败」,撕裂用户预期;脚本损坏是
-                # 路由层就能识别的客户端错误,提前 4xx 比让 worker 后置失败更准确。
-                raise HTTPException(
-                    status_code=400,
-                    detail=_t("script_data_corrupted", reason=str(exc)),
-                )
-
-            storyboard_file = (
-                project_path / storyboard_rel
-                if storyboard_rel
-                else project_path / "storyboards" / f"scene_{segment_id}.png"
-            )
-            if not storyboard_file.exists():
-                raise HTTPException(status_code=400, detail=_t("generate_storyboard_first", segment_id=segment_id))
-
-        await asyncio.to_thread(_sync)
-
-        # 结构校验 + 构造经单一守卫点（与 SDK 入队同源，规则不分叉）。
-        # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）。
+        # 与 worker 一致：优先读取 generated_assets.storyboard_image，回退默认路径。
+        # 旧宫格项目 storyboard_image 指向 scene_{id}_first.png，仍可正常解析。
+        # 脏脚本（分镜数组键损坏）抛 ScriptEditError → fail-fast 4xx，与 storyboard
+        # endpoint 对齐：不能 silently 降级走 default 路径——default 文件恰好存在时会让
+        # 请求「先返回提交成功、worker 解析脚本时再确定失败」，撕裂用户预期。
+        storyboard_rel: str | None = None
         try:
-            spec = TaskSpec.from_request(
-                task_type="video",
-                media_type="video",
-                resource_id=segment_id,
-                prompt=req.prompt,
-                script_file=req.script_file,
-                extra_payload={"duration_seconds": req.duration_seconds, "seed": req.seed},
-            )
-        except TaskSpecValidationError as e:
-            raise HTTPException(status_code=400, detail=_t(e.code, **e.params))
+            script = pm_local.load_script(project_name, req.script_file)
+            items, id_field, _, _, _ = get_storyboard_items(script)
+            resolved = find_storyboard_item(items, id_field, segment_id)
+            if resolved:
+                assets = resolved[0].get("generated_assets") or {}
+                if isinstance(assets, dict):
+                    storyboard_rel = assets.get("storyboard_image")
+        except FileNotFoundError:
+            # 脚本不存在交由后续流程报错；此处只负责存在性检查
+            pass
 
-        # 入队（provider 由服务层根据配置自动解析，调用方无需传递）
-        queue = get_generation_queue()
-        result = await queue.enqueue_task(
-            project_name=project_name,
-            task_type=spec.task_type,
-            media_type=spec.media_type,
-            resource_id=spec.resource_id,
-            script_file=spec.script_file,
-            payload=spec.payload,
-            source="webui",
-            user_id=_user.id,
+        storyboard_file = (
+            project_path / storyboard_rel
+            if storyboard_rel
+            else project_path / "storyboards" / f"scene_{segment_id}.png"
         )
+        if not storyboard_file.exists():
+            raise BadRequestError("generate_storyboard_first", segment_id=segment_id)
 
-        return {
-            "success": True,
-            "task_id": result["task_id"],
-            "message": _t("video_task_submitted", segment_id=segment_id),
-        }
+    await asyncio.to_thread(_sync)
 
-    except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except HTTPException:
-        raise
-    except Exception:
-        logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
+    # 结构校验 + 构造经单一守卫点（与 SDK 入队同源，规则不分叉）。
+    # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）。
+    spec = TaskSpec.from_request(
+        task_type="video",
+        media_type="video",
+        resource_id=segment_id,
+        prompt=req.prompt,
+        script_file=req.script_file,
+        extra_payload={"duration_seconds": req.duration_seconds, "seed": req.seed},
+    )
+
+    # 入队（provider 由服务层根据配置自动解析，调用方无需传递）
+    queue = get_generation_queue()
+    result = await queue.enqueue_task(
+        project_name=project_name,
+        task_type=spec.task_type,
+        media_type=spec.media_type,
+        resource_id=spec.resource_id,
+        script_file=spec.script_file,
+        payload=spec.payload,
+        source="webui",
+        user_id=_user.id,
+    )
+
+    return {
+        "success": True,
+        "task_id": result["task_id"],
+        "message": _t("video_task_submitted", segment_id=segment_id),
+    }
 
 
 # ==================== 旁白配音（TTS）生成 ====================
 
 
-async def _require_audio_provider_configured(project: dict, _t: Translator) -> str:
+async def _require_audio_provider_configured(project: dict) -> str:
     """未配置任何 audio 供应商时直接 400，让用户在生成入口就看到清晰提示。
 
     解析失败（无全局默认且 auto-resolve 找不到 ready 的 audio 供应商）即视为未配置；
@@ -257,7 +226,7 @@ async def _require_audio_provider_configured(project: dict, _t: Translator) -> s
     try:
         resolved = await ConfigResolver(async_session_factory).resolve_audio_backend(project, None)
     except ValueError:
-        raise HTTPException(status_code=400, detail=_t("audio_provider_not_configured"))
+        raise BadRequestError("audio_provider_not_configured")
     return resolved.provider_id
 
 
@@ -273,17 +242,13 @@ async def _enqueue_tts_segment(
     script_file: str,
     user_id: str,
     provider_id: str | None,
-    _t: Translator,
 ) -> dict:
-    try:
-        spec = TaskSpec.from_request(
-            task_type="tts",
-            media_type="audio",
-            resource_id=segment_id,
-            script_file=script_file,
-        )
-    except TaskSpecValidationError as e:
-        raise HTTPException(status_code=400, detail=_t(e.code, **e.params))
+    spec = TaskSpec.from_request(
+        task_type="tts",
+        media_type="audio",
+        resource_id=segment_id,
+        script_file=script_file,
+    )
 
     queue = get_generation_queue()
     return await queue.enqueue_task(
@@ -311,49 +276,37 @@ async def generate_tts(
 
     文本由执行层从剧本 segment 的 novel_text 读取；已有旁白的段允许重生成。
     """
-    try:
 
-        def _sync() -> tuple[dict, dict]:
-            pm_local = get_project_manager()
-            _project = pm_local.load_project(project_name)
-            script = pm_local.load_script(project_name, req.script_file)
-            items, id_field, _, _, _ = get_storyboard_items(script)
-            resolved = find_storyboard_item(items, id_field, segment_id)
-            if resolved is None:
-                raise HTTPException(status_code=404, detail=_t("segment_not_found", id=segment_id))
-            return _project, resolved[0]
+    def _sync() -> tuple[dict, dict]:
+        pm_local = get_project_manager()
+        _project = pm_local.load_project(project_name)
+        script = pm_local.load_script(project_name, req.script_file)
+        items, id_field, _, _, _ = get_storyboard_items(script)
+        resolved = find_storyboard_item(items, id_field, segment_id)
+        if resolved is None:
+            raise NotFoundError("segment_not_found", id=segment_id)
+        return _project, resolved[0]
 
-        project, segment = await asyncio.to_thread(_sync)
+    project, segment = await asyncio.to_thread(_sync)
 
-        if not _narration_text(segment):
-            raise HTTPException(status_code=400, detail=_t("tts_novel_text_missing", segment_id=segment_id))
+    if not _narration_text(segment):
+        raise BadRequestError("tts_novel_text_missing", segment_id=segment_id)
 
-        provider_id = await _require_audio_provider_configured(project, _t)
+    provider_id = await _require_audio_provider_configured(project)
 
-        result = await _enqueue_tts_segment(
-            project_name=project_name,
-            segment_id=segment_id,
-            script_file=req.script_file,
-            user_id=_user.id,
-            provider_id=provider_id,
-            _t=_t,
-        )
+    result = await _enqueue_tts_segment(
+        project_name=project_name,
+        segment_id=segment_id,
+        script_file=req.script_file,
+        user_id=_user.id,
+        provider_id=provider_id,
+    )
 
-        return {
-            "success": True,
-            "task_id": result["task_id"],
-            "message": _t("tts_task_submitted", segment_id=segment_id),
-        }
-
-    except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except HTTPException:
-        raise
-    except ScriptEditError as e:
-        raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=str(e)))
-    except Exception:
-        logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
+    return {
+        "success": True,
+        "task_id": result["task_id"],
+        "message": _t("tts_task_submitted", segment_id=segment_id),
+    }
 
 
 @router.post("/projects/{project_name}/generate/tts")
@@ -364,56 +317,44 @@ async def generate_tts_batch(
     _t: Translator,
 ):
     """批量提交旁白配音任务：只入队缺少 narration_audio 且有小说原文的段（断点补缺）。"""
-    try:
 
-        def _sync() -> tuple[dict, list[str]]:
-            pm_local = get_project_manager()
-            _project = pm_local.load_project(project_name)
-            script = pm_local.load_script(project_name, req.script_file)
-            items, id_field, _, _, _ = get_storyboard_items(script)
-            missing: list[str] = []
-            for item in items:
-                if not _narration_text(item):
-                    continue
-                assets = item.get("generated_assets") or {}
-                if isinstance(assets, dict) and assets.get("narration_audio"):
-                    continue
-                seg_id = item.get(id_field)
-                if seg_id:
-                    missing.append(str(seg_id))
-            return _project, missing
+    def _sync() -> tuple[dict, list[str]]:
+        pm_local = get_project_manager()
+        _project = pm_local.load_project(project_name)
+        script = pm_local.load_script(project_name, req.script_file)
+        items, id_field, _, _, _ = get_storyboard_items(script)
+        missing: list[str] = []
+        for item in items:
+            if not _narration_text(item):
+                continue
+            assets = item.get("generated_assets") or {}
+            if isinstance(assets, dict) and assets.get("narration_audio"):
+                continue
+            seg_id = item.get(id_field)
+            if seg_id:
+                missing.append(str(seg_id))
+        return _project, missing
 
-        project, missing_ids = await asyncio.to_thread(_sync)
+    project, missing_ids = await asyncio.to_thread(_sync)
 
-        if not missing_ids:
-            return {"success": True, "task_ids": [], "message": _t("tts_batch_none_missing")}
+    if not missing_ids:
+        return {"success": True, "task_ids": [], "message": _t("tts_batch_none_missing")}
 
-        provider_id = await _require_audio_provider_configured(project, _t)
+    provider_id = await _require_audio_provider_configured(project)
 
-        task_ids: list[str] = []
-        for seg_id in missing_ids:
-            result = await _enqueue_tts_segment(
-                project_name=project_name,
-                segment_id=seg_id,
-                script_file=req.script_file,
-                user_id=_user.id,
-                provider_id=provider_id,
-                _t=_t,
-            )
-            task_ids.append(result["task_id"])
+    task_ids: list[str] = []
+    for seg_id in missing_ids:
+        result = await _enqueue_tts_segment(
+            project_name=project_name,
+            segment_id=seg_id,
+            script_file=req.script_file,
+            user_id=_user.id,
+            provider_id=provider_id,
+        )
+        task_ids.append(result["task_id"])
 
-        message = _t("tts_batch_submitted", count=len(task_ids)) if task_ids else _t("tts_batch_none_missing")
-        return {"success": True, "task_ids": task_ids, "message": message}
-
-    except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except HTTPException:
-        raise
-    except ScriptEditError as e:
-        raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=str(e)))
-    except Exception:
-        logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
+    message = _t("tts_batch_submitted", count=len(task_ids)) if task_ids else _t("tts_batch_none_missing")
+    return {"success": True, "task_ids": task_ids, "message": message}
 
 
 # ==================== 资产设计图生成（character / scene / prop / product 共用） ====================
@@ -444,19 +385,16 @@ async def _enqueue_asset_generation(
     def _sync():
         project = get_project_manager().load_project(project_name)
         if resource_name not in project.get(spec.bucket_key, {}):
-            raise HTTPException(status_code=404, detail=_t(keys["not_found"], name=resource_name))
+            raise NotFoundError(keys["not_found"], name=resource_name)
 
     await asyncio.to_thread(_sync)
 
-    try:
-        task_spec = TaskSpec.from_request(
-            task_type=asset_type,
-            media_type="image",
-            resource_id=resource_name,
-            prompt=prompt,
-        )
-    except TaskSpecValidationError as e:
-        raise HTTPException(status_code=400, detail=_t(e.code, **e.params))
+    task_spec = TaskSpec.from_request(
+        task_type=asset_type,
+        media_type="image",
+        resource_id=resource_name,
+        prompt=prompt,
+    )
 
     queue = get_generation_queue()
     result = await queue.enqueue_task(
@@ -485,22 +423,14 @@ async def generate_character(
     _t: Translator,
 ):
     """提交角色设计图生成任务到队列，立即返回 task_id。"""
-    try:
-        return await _enqueue_asset_generation(
-            asset_type="character",
-            project_name=project_name,
-            resource_name=char_name,
-            prompt=req.prompt,
-            user_id=_user.id,
-            _t=_t,
-        )
-    except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except HTTPException:
-        raise
-    except Exception:
-        logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
+    return await _enqueue_asset_generation(
+        asset_type="character",
+        project_name=project_name,
+        resource_name=char_name,
+        prompt=req.prompt,
+        user_id=_user.id,
+        _t=_t,
+    )
 
 
 @router.post("/projects/{project_name}/generate/scene/{scene_name}")
@@ -512,22 +442,14 @@ async def generate_scene(
     _t: Translator,
 ):
     """提交场景设计图生成任务到队列，立即返回 task_id。"""
-    try:
-        return await _enqueue_asset_generation(
-            asset_type="scene",
-            project_name=project_name,
-            resource_name=scene_name,
-            prompt=req.prompt,
-            user_id=_user.id,
-            _t=_t,
-        )
-    except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except HTTPException:
-        raise
-    except Exception:
-        logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
+    return await _enqueue_asset_generation(
+        asset_type="scene",
+        project_name=project_name,
+        resource_name=scene_name,
+        prompt=req.prompt,
+        user_id=_user.id,
+        _t=_t,
+    )
 
 
 @router.post("/projects/{project_name}/generate/prop/{prop_name}")
@@ -539,22 +461,14 @@ async def generate_prop(
     _t: Translator,
 ):
     """提交道具设计图生成任务到队列，立即返回 task_id。"""
-    try:
-        return await _enqueue_asset_generation(
-            asset_type="prop",
-            project_name=project_name,
-            resource_name=prop_name,
-            prompt=req.prompt,
-            user_id=_user.id,
-            _t=_t,
-        )
-    except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except HTTPException:
-        raise
-    except Exception:
-        logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
+    return await _enqueue_asset_generation(
+        asset_type="prop",
+        project_name=project_name,
+        resource_name=prop_name,
+        prompt=req.prompt,
+        user_id=_user.id,
+        _t=_t,
+    )
 
 
 @router.post("/projects/{project_name}/generate/product/{product_name}")
@@ -566,19 +480,11 @@ async def generate_product(
     _t: Translator,
 ):
     """提交产品标准参考图（product sheet）生成任务到队列，立即返回 task_id。"""
-    try:
-        return await _enqueue_asset_generation(
-            asset_type="product",
-            project_name=project_name,
-            resource_name=product_name,
-            prompt=req.prompt,
-            user_id=_user.id,
-            _t=_t,
-        )
-    except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except HTTPException:
-        raise
-    except Exception:
-        logger.exception("请求处理失败")
-        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
+    return await _enqueue_asset_generation(
+        asset_type="product",
+        project_name=project_name,
+        resource_name=product_name,
+        prompt=req.prompt,
+        user_id=_user.id,
+        _t=_t,
+    )

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -154,28 +154,25 @@ async def generate_video(
 
         # 与 worker 一致：优先读取 generated_assets.storyboard_image，回退默认路径。
         # 旧宫格项目 storyboard_image 指向 scene_{id}_first.png，仍可正常解析。
-        # 脏脚本（分镜数组键损坏）抛 ScriptEditError → fail-fast 4xx，与 storyboard
-        # endpoint 对齐：不能 silently 降级走 default 路径——default 文件恰好存在时会让
-        # 请求「先返回提交成功、worker 解析脚本时再确定失败」，撕裂用户预期。
+        # 脚本缺失（FileNotFoundError）/ 脏脚本（分镜数组键损坏，ScriptEditError）均
+        # fail-fast：不能 silently 降级走 default 路径——default 文件恰好存在时会让请求
+        # 「先返回提交成功、worker 解析脚本时再确定失败」，撕裂用户预期。两者均由 app 级
+        # handler 统一映射为脱敏响应（404 / 400）。
         storyboard_rel: str | None = None
-        try:
-            script = pm_local.load_script(project_name, req.script_file)
-            items, id_field, _, _, _ = get_storyboard_items(script)
-            resolved = find_storyboard_item(items, id_field, segment_id)
-            if resolved:
-                assets = resolved[0].get("generated_assets") or {}
-                if isinstance(assets, dict):
-                    storyboard_rel = assets.get("storyboard_image")
-        except FileNotFoundError:
-            # 脚本不存在交由后续流程报错；此处只负责存在性检查
-            pass
+        script = pm_local.load_script(project_name, req.script_file)
+        items, id_field, _, _, _ = get_storyboard_items(script)
+        resolved = find_storyboard_item(items, id_field, segment_id)
+        if resolved:
+            assets = resolved[0].get("generated_assets") or {}
+            if isinstance(assets, dict):
+                storyboard_rel = assets.get("storyboard_image")
 
         storyboard_file = (
             project_path / storyboard_rel
             if storyboard_rel
             else project_path / "storyboards" / f"scene_{segment_id}.png"
         )
-        if not storyboard_file.exists():
+        if not storyboard_file.is_file():
             raise BadRequestError("generate_storyboard_first", segment_id=segment_id)
 
     await asyncio.to_thread(_sync)

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -162,10 +162,11 @@ async def generate_video(
         script = pm_local.load_script(project_name, req.script_file)
         items, id_field, _, _, _ = get_storyboard_items(script)
         resolved = find_storyboard_item(items, id_field, segment_id)
-        if resolved:
-            assets = resolved[0].get("generated_assets") or {}
-            if isinstance(assets, dict):
-                storyboard_rel = assets.get("storyboard_image")
+        if resolved is None:
+            raise NotFoundError("segment_not_found", id=segment_id)
+        assets = resolved[0].get("generated_assets") or {}
+        if isinstance(assets, dict):
+            storyboard_rel = assets.get("storyboard_image")
 
         storyboard_file = (
             project_path / storyboard_rel

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -1,5 +1,8 @@
 """app 级异常处理器测试：状态码映射、Accept-Language 翻译、脱敏。"""
 
+import tempfile
+from pathlib import Path
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -8,7 +11,8 @@ from lib.generation_queue_client import TaskSpecValidationError
 from lib.script_editor import ScriptEditError
 from server.error_handlers import register_error_handlers
 
-_SERVER_PATH = "/Users/someone/projects/demo/episode_1.json"
+# 运行时基于系统 tmp 目录构造，不提交机器特定的绝对路径。
+_SERVER_PATH = str(Path(tempfile.gettempdir()) / "projects" / "demo" / "episode_1.json")
 
 
 def _make_client() -> TestClient:
@@ -96,7 +100,7 @@ class TestLibExceptionHandlers:
         resp = client.get("/file-not-found")
         assert resp.status_code == 404
         assert resp.json()["detail"] == "请求的资源不存在"
-        assert "/Users" not in resp.text
+        assert _SERVER_PATH not in resp.text
 
     def test_unexpected_exception_500_hides_details(self):
         client = _make_client()
@@ -104,7 +108,7 @@ class TestLibExceptionHandlers:
         assert resp.status_code == 500
         assert resp.json()["detail"] == "服务器内部错误，请稍后重试"
         assert "boom" not in resp.text
-        assert "/Users" not in resp.text
+        assert _SERVER_PATH not in resp.text
 
 
 class TestRealAppRegistration:
@@ -113,3 +117,60 @@ class TestRealAppRegistration:
 
         for exc_type in (ApiError, TaskSpecValidationError, ScriptEditError, FileNotFoundError, Exception):
             assert exc_type in real_app.exception_handlers, f"{exc_type} 未注册 app 级 handler"
+
+
+def _make_cors_client(allow_origins, allow_credentials) -> TestClient:
+    app = FastAPI()
+    register_error_handlers(app, cors_allow_origins=allow_origins, cors_allow_credentials=allow_credentials)
+
+    @app.get("/unexpected")
+    async def _unexpected():
+        raise RuntimeError("boom")
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestUnexpectedErrorCorsHeaders:
+    """ServerErrorMiddleware 兜底发 500 时绕过 CORSMiddleware（走最外层原始 send），
+    handler 需手工补齐 CORS 头，否则跨域前端把 500 当成 network error。"""
+
+    def test_wildcard_origin_gets_wildcard_header(self):
+        client = _make_cors_client(["*"], False)
+        resp = client.get("/unexpected", headers={"Origin": "https://example.com"})
+        assert resp.status_code == 500
+        assert resp.headers.get("access-control-allow-origin") == "*"
+        assert "access-control-allow-credentials" not in resp.headers
+
+    def test_allowlisted_origin_with_credentials_gets_explicit_origin(self):
+        client = _make_cors_client(["https://example.com"], True)
+        resp = client.get("/unexpected", headers={"Origin": "https://example.com"})
+        assert resp.status_code == 500
+        assert resp.headers.get("access-control-allow-origin") == "https://example.com"
+        assert resp.headers.get("access-control-allow-credentials") == "true"
+        assert resp.headers.get("vary") == "Origin"
+
+    def test_disallowed_origin_gets_no_allow_origin_header(self):
+        client = _make_cors_client(["https://allowed.example.com"], True)
+        resp = client.get("/unexpected", headers={"Origin": "https://evil.example.com"})
+        assert resp.status_code == 500
+        assert "access-control-allow-origin" not in resp.headers
+
+    def test_no_origin_header_means_no_cors_headers(self):
+        client = _make_cors_client(["*"], False)
+        resp = client.get("/unexpected")
+        assert resp.status_code == 500
+        assert "access-control-allow-origin" not in resp.headers
+
+    def test_default_kwargs_fall_back_to_wildcard(self):
+        # register_error_handlers 不传 cors 参数时的保守默认值：通配 origins，不开 credentials。
+        app = FastAPI()
+        register_error_handlers(app)
+
+        @app.get("/unexpected")
+        async def _unexpected():
+            raise RuntimeError("boom")
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/unexpected", headers={"Origin": "https://example.com"})
+        assert resp.status_code == 500
+        assert resp.headers.get("access-control-allow-origin") == "*"

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -1,0 +1,115 @@
+"""app 级异常处理器测试：状态码映射、Accept-Language 翻译、脱敏。"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from lib.api_errors import ApiError, BadRequestError, NotFoundError
+from lib.generation_queue_client import TaskSpecValidationError
+from lib.script_editor import ScriptEditError
+from server.error_handlers import register_error_handlers
+
+_SERVER_PATH = "/Users/someone/projects/demo/episode_1.json"
+
+
+def _make_client() -> TestClient:
+    app = FastAPI()
+    register_error_handlers(app)
+
+    @app.get("/api-error-404")
+    async def _api_error_404():
+        raise NotFoundError("segment_not_found", id="E1S01")
+
+    @app.get("/api-error-400")
+    async def _api_error_400():
+        raise BadRequestError("audio_provider_not_configured")
+
+    @app.get("/api-error-custom-status")
+    async def _api_error_custom():
+        raise ApiError("internal_server_error", status_code=503)
+
+    @app.get("/task-spec-error")
+    async def _task_spec_error():
+        raise TaskSpecValidationError("prompt_text_empty")
+
+    @app.get("/script-edit-error")
+    async def _script_edit_error():
+        raise ScriptEditError("segments 必须是列表，当前为 NoneType")
+
+    @app.get("/file-not-found")
+    async def _file_not_found():
+        raise FileNotFoundError(f"剧本文件不存在: {_SERVER_PATH}")
+
+    @app.get("/unexpected")
+    async def _unexpected():
+        raise RuntimeError(f"boom at {_SERVER_PATH}")
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestApiErrorHandler:
+    def test_not_found_translated_zh_default(self):
+        client = _make_client()
+        resp = client.get("/api-error-404")
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "片段 'E1S01' 不存在"
+
+    def test_bad_request_400(self):
+        client = _make_client()
+        resp = client.get("/api-error-400")
+        assert resp.status_code == 400
+        assert "音频" in resp.json()["detail"]
+
+    def test_accept_language_en(self):
+        client = _make_client()
+        resp = client.get("/api-error-404", headers={"Accept-Language": "en-US,en;q=0.9"})
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Segment 'E1S01' does not exist"
+
+    def test_accept_language_vi(self):
+        client = _make_client()
+        resp = client.get("/api-error-404", headers={"Accept-Language": "vi"})
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Đoạn 'E1S01' không tồn tại"
+
+    def test_custom_status_code(self):
+        client = _make_client()
+        resp = client.get("/api-error-custom-status")
+        assert resp.status_code == 503
+
+
+class TestLibExceptionHandlers:
+    def test_task_spec_validation_error_400(self):
+        client = _make_client()
+        resp = client.get("/task-spec-error")
+        assert resp.status_code == 400
+        # detail 是翻译后的成品文案，不是裸 code
+        assert resp.json()["detail"] != "prompt_text_empty"
+
+    def test_script_edit_error_400(self):
+        client = _make_client()
+        resp = client.get("/script-edit-error")
+        assert resp.status_code == 400
+        assert "损坏" in resp.json()["detail"]
+
+    def test_file_not_found_404_hides_server_path(self):
+        client = _make_client()
+        resp = client.get("/file-not-found")
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "请求的资源不存在"
+        assert "/Users" not in resp.text
+
+    def test_unexpected_exception_500_hides_details(self):
+        client = _make_client()
+        resp = client.get("/unexpected")
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "服务器内部错误，请稍后重试"
+        assert "boom" not in resp.text
+        assert "/Users" not in resp.text
+
+
+class TestRealAppRegistration:
+    def test_server_app_registers_all_handlers(self):
+        from server.app import app as real_app
+
+        for exc_type in (ApiError, TaskSpecValidationError, ScriptEditError, FileNotFoundError, Exception):
+            assert exc_type in real_app.exception_handlers, f"{exc_type} 未注册 app 级 handler"

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 from server.routers import generate
 
 
@@ -117,9 +118,12 @@ def _client(monkeypatch, fake_pm, fake_queue):
     monkeypatch.setattr(generate, "get_generation_queue", lambda: fake_queue)
 
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(generate.router, prefix="/api/v1")
-    return TestClient(app)
+    # raise_server_exceptions=False：500 由 app 级 Exception handler 生成响应后
+    # Starlette 会 re-raise，默认配置会把它抛进测试而非返回响应
+    return TestClient(app, raise_server_exceptions=False)
 
 
 class TestGenerateRouter:
@@ -424,10 +428,10 @@ class TestGenerateRouter:
 class TestUnexpectedErrorMapsTo500:
     """未预期异常 → 通用 500 且不泄露内部异常细节。
 
-    每个端点 try 块内最早调用 get_project_manager()（storyboard/video/tts 在 _sync 内，
+    每个端点最早调用 get_project_manager()（storyboard/video/tts 在 _sync 内，
     character/scene/prop/product 经 _enqueue_asset_generation 的 _sync 内），将其 monkeypatch
-    成抛 RuntimeError。RuntimeError 绕过前置的 FileNotFoundError/HTTPException/ScriptEditError
-    处理器，落到 except Exception，断言 500 且哨兵串不出现在响应体。
+    成抛 RuntimeError。RuntimeError 绕过 FileNotFoundError/ScriptEditError 等专属处理器，
+    落到 app 级 Exception handler，断言 500 且哨兵串不出现在响应体。
     """
 
     def _client_with_leak(self, monkeypatch, sentinel: str) -> TestClient:
@@ -436,9 +440,10 @@ class TestUnexpectedErrorMapsTo500:
 
         monkeypatch.setattr(generate, "get_project_manager", _boom)
         app = FastAPI()
+        register_error_handlers(app)
         app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
         app.include_router(generate.router, prefix="/api/v1")
-        return TestClient(app)
+        return TestClient(app, raise_server_exceptions=False)
 
     def test_storyboard_unexpected_error_maps_to_500(self, monkeypatch):
         client = self._client_with_leak(monkeypatch, "LEAK_storyboard")
@@ -574,3 +579,99 @@ class TestAdStoryboardRegeneration:
                 json={"script_file": "episode_1.json", "prompt": "产品特写"},
             )
             assert resp.status_code == 404
+
+
+class TestNoServerPathLeak:
+    """404/400/500 响应形状回归：detail 不得含服务器绝对路径片段。
+
+    lib 层 FileNotFoundError 的消息携带绝对路径（如 load_script 的
+    「剧本文件不存在: /abs/path」），app 级 handler 必须脱敏为通用 404 文案。
+    """
+
+    _PATH_SENTINELS = ("/Users", "/var", "/private", "\\Users")
+
+    def _assert_no_path(self, resp) -> None:
+        detail = resp.json()["detail"]
+        assert isinstance(detail, str) and detail
+        for sentinel in self._PATH_SENTINELS:
+            assert sentinel not in detail, f"detail 泄露路径片段 {sentinel!r}: {detail}"
+
+    def _client_project_missing(self, tmp_path, monkeypatch) -> TestClient:
+        """load_project 抛携带服务器绝对路径的 FileNotFoundError（各端点第一步都会触发）。"""
+        fake_pm = _FakePM(tmp_path / "projects" / "demo")
+
+        def _raise(*args, **kwargs):
+            raise FileNotFoundError("项目元数据文件不存在: /Users/someone/projects/demo/project.json")
+
+        fake_pm.load_project = _raise  # type: ignore[method-assign]
+        return _client(monkeypatch, fake_pm, _FakeQueue())
+
+    def test_file_not_found_404_hides_path_for_all_endpoints(self, tmp_path, monkeypatch):
+        client = self._client_project_missing(tmp_path, monkeypatch)
+        requests = [
+            ("/api/v1/projects/demo/generate/storyboard/E1S01", {"script_file": "episode_1.json", "prompt": "x"}),
+            ("/api/v1/projects/demo/generate/video/E1S01", {"script_file": "episode_1.json", "prompt": "x"}),
+            ("/api/v1/projects/demo/generate/tts/E1S01", {"script_file": "episode_1.json"}),
+            ("/api/v1/projects/demo/generate/tts", {"script_file": "episode_1.json"}),
+            ("/api/v1/projects/demo/generate/character/Alice", {"prompt": "x"}),
+            ("/api/v1/projects/demo/generate/scene/祠堂", {"prompt": "x"}),
+            ("/api/v1/projects/demo/generate/prop/玉佩", {"prompt": "x"}),
+            ("/api/v1/projects/demo/generate/product/保温杯", {"prompt": "x"}),
+        ]
+        with client:
+            for url, payload in requests:
+                resp = client.post(url, json=payload)
+                assert resp.status_code == 404, f"{url}: {resp.status_code} {resp.text}"
+                assert "/Users" not in resp.text, f"{url} 泄露路径: {resp.text}"
+                self._assert_no_path(resp)
+
+    def test_script_file_not_found_404_hides_path(self, tmp_path, monkeypatch):
+        """load_script 的 FileNotFoundError 是原始泄漏源（消息含绝对路径）。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+
+        def _raise(*args, **kwargs):
+            raise FileNotFoundError("剧本文件不存在: /Users/someone/projects/demo/scripts/episode_1.json")
+
+        fake_pm.load_script = _raise  # type: ignore[method-assign]
+        client = _client(monkeypatch, fake_pm, _FakeQueue())
+
+        with client:
+            resp = client.post(
+                "/api/v1/projects/demo/generate/storyboard/E1S01",
+                json={"script_file": "episode_1.json", "prompt": "x"},
+            )
+            assert resp.status_code == 404, resp.text
+            self._assert_no_path(resp)
+
+    def test_bad_prompt_400_shape(self, tmp_path, monkeypatch):
+        """TaskSpecValidationError → app 级 handler 翻译为 400，无路径片段。"""
+        project_path = _prepare_files(tmp_path)
+        client = _client(monkeypatch, _FakePM(project_path), _FakeQueue())
+
+        with client:
+            resp = client.post(
+                "/api/v1/projects/demo/generate/storyboard/E1S02",
+                json={"script_file": "episode_1.json", "prompt": ""},
+            )
+            assert resp.status_code == 400, resp.text
+            self._assert_no_path(resp)
+
+    def test_unexpected_error_500_hides_path(self, tmp_path, monkeypatch):
+        """未预期异常消息含路径时，500 响应仍为通用文案。"""
+        fake_pm = _FakePM(tmp_path / "projects" / "demo")
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("boom at /Users/someone/projects/demo/project.json")
+
+        fake_pm.load_project = _raise  # type: ignore[method-assign]
+        client = _client(monkeypatch, fake_pm, _FakeQueue())
+
+        with client:
+            resp = client.post(
+                "/api/v1/projects/demo/generate/storyboard/E1S01",
+                json={"script_file": "episode_1.json", "prompt": "x"},
+            )
+            assert resp.status_code == 500, resp.text
+            assert "boom" not in resp.text
+            self._assert_no_path(resp)

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -251,6 +251,39 @@ class TestGenerateRouter:
             # 任务未入队
             assert fake_queue.calls == []
 
+    def test_video_missing_script_fail_fast_404(self, tmp_path, monkeypatch):
+        """剧本文件缺失（FileNotFoundError）时,/generate/video 应 404 fail-fast,
+        而不是 silently 走 default storyboard 路径继续 enqueue —— 后者会让用户
+        先收到「提交成功」,worker 解析脚本时再确定失败,撕裂提交-执行预期。
+
+        本测试保 default `storyboards/scene_E1S01.png` 存在（旧宫格项目遗留场景），
+        验证即使 default 文件恰好存在，脚本缺失也不能被悄悄放过。
+        """
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        missing_script_path = project_path / "scripts" / "episode_1.json"
+
+        def _raise_missing(*args, **kwargs):
+            raise FileNotFoundError(f"剧本文件不存在: {missing_script_path}")
+
+        fake_pm.load_script = _raise_missing  # type: ignore[method-assign]
+        fake_queue = _FakeQueue()
+        client = _client(monkeypatch, fake_pm, fake_queue)
+
+        with client:
+            video = client.post(
+                "/api/v1/projects/demo/generate/video/E1S01",
+                json={
+                    "script_file": "episode_1.json",
+                    "duration_seconds": 5,
+                    "prompt": "fail fast",
+                },
+            )
+            assert video.status_code == 404, video.text
+            assert str(missing_script_path) not in video.text
+            # 任务未入队
+            assert fake_queue.calls == []
+
     def test_character_enqueue_success(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -601,7 +634,7 @@ class TestNoServerPathLeak:
         fake_pm = _FakePM(tmp_path / "projects" / "demo")
 
         def _raise(*args, **kwargs):
-            raise FileNotFoundError("项目元数据文件不存在: /Users/someone/projects/demo/project.json")
+            raise FileNotFoundError(f"项目元数据文件不存在: {tmp_path / 'projects' / 'demo' / 'project.json'}")
 
         fake_pm.load_project = _raise  # type: ignore[method-assign]
         return _client(monkeypatch, fake_pm, _FakeQueue())
@@ -631,7 +664,7 @@ class TestNoServerPathLeak:
         fake_pm = _FakePM(project_path)
 
         def _raise(*args, **kwargs):
-            raise FileNotFoundError("剧本文件不存在: /Users/someone/projects/demo/scripts/episode_1.json")
+            raise FileNotFoundError(f"剧本文件不存在: {project_path / 'scripts' / 'episode_1.json'}")
 
         fake_pm.load_script = _raise  # type: ignore[method-assign]
         client = _client(monkeypatch, fake_pm, _FakeQueue())
@@ -662,7 +695,7 @@ class TestNoServerPathLeak:
         fake_pm = _FakePM(tmp_path / "projects" / "demo")
 
         def _raise(*args, **kwargs):
-            raise RuntimeError("boom at /Users/someone/projects/demo/project.json")
+            raise RuntimeError(f"boom at {tmp_path / 'projects' / 'demo' / 'project.json'}")
 
         fake_pm.load_project = _raise  # type: ignore[method-assign]
         client = _client(monkeypatch, fake_pm, _FakeQueue())

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -284,6 +284,31 @@ class TestGenerateRouter:
             # 任务未入队
             assert fake_queue.calls == []
 
+    def test_video_missing_segment_404(self, tmp_path, monkeypatch):
+        """segment_id 在脚本中根本不存在时,/generate/video 应 404,而不是
+        悄悄走 default storyboard 路径——即使 default 文件恰好存在(如与旧
+        数据撞名),也不能把不存在的 segment 当成校验通过而入队。
+        """
+        project_path = _prepare_files(tmp_path)
+        # default 路径恰好存在的场景：撞上一个不存在 segment 的默认文件名
+        (project_path / "storyboards" / "scene_E1S99.png").write_bytes(b"png")
+        fake_pm = _FakePM(project_path)
+        fake_queue = _FakeQueue()
+        client = _client(monkeypatch, fake_pm, fake_queue)
+
+        with client:
+            video = client.post(
+                "/api/v1/projects/demo/generate/video/E1S99",
+                json={
+                    "script_file": "episode_1.json",
+                    "duration_seconds": 5,
+                    "prompt": "fail fast",
+                },
+            )
+            assert video.status_code == 404, video.text
+            # 任务未入队
+            assert fake_queue.calls == []
+
     def test_character_enqueue_success(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)

--- a/tests/test_generate_router_tts.py
+++ b/tests/test_generate_router_tts.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 
 from lib.config.resolver import ConfigResolver, ProviderModel
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 from server.routers import generate
 
 
@@ -71,9 +72,10 @@ def _client(monkeypatch, fake_pm, fake_queue, *, audio_provider_ready=True):
     monkeypatch.setattr(ConfigResolver, "resolve_audio_backend", _resolve)
 
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(generate.router, prefix="/api/v1")
-    return TestClient(app)
+    return TestClient(app, raise_server_exceptions=False)
 
 
 class TestGenerateTtsSingle:


### PR DESCRIPTION
Closes #1148

## 背景

`generate.py` 的 8 处 404 通过 `HTTPException(404, detail=str(e))` 把含**服务器绝对路径**的异常文本回传客户端，与 `reference_videos.py` 刻意脱敏的行为并存分叉，构成路径泄漏安全问题。

## 方案

引入 app 级异常处理器作为「异常→状态码→detail」映射的单点：

- **领域异常** `lib/api_errors.py`：`ApiError` / `BadRequestError`(400) / `NotFoundError`(404)，只携带 `(status_code, i18n key, params)`，不带成品文案。
- **app 级 handler** `server/error_handlers.py`：注册五类处理器，按请求 `Accept-Language` 翻译并脱敏——
  - `ApiError` → 自带 status + 翻译 key
  - `TaskSpecValidationError` → 400
  - `ScriptEditError` → 400（`reason` 为结构性描述，不含路径）
  - `FileNotFoundError` → 404 通用 `resource_not_found`（`str(exc)` 只进日志）
  - `Exception` 兜底 → 500 通用文案
- **generate.py** 迁移：删除 7 处 try/except 阶梯与全部 `detail=str(e)`，路由函数体只剩 happy path。

渐进迁移：仍自行 try/except 的其余路由零影响（异常到不了 handler）；后续迁移一个端点 = 删它的 except 阶梯。本 PR 只做 handler 基建 + generate.py。

## 脱敏机制

机制上 `str(e)` 不可能再直达客户端：未预期异常统一走 `Exception` 兜底 handler 返回通用 500；`FileNotFoundError` 消息（含绝对路径）仅进服务端日志。未预期异常的堆栈由 `request_logging_middleware` 记录（发送响应后 Starlette re-raise），handler 不重复打日志。

## i18n

新增 `resource_not_found`，zh/en/vi 三语齐全；其余 key 复用既有。

## 验证

- `tests/test_error_handlers.py`（新增 55 断言）：五类 handler 的状态码映射、`Accept-Language` zh/en/vi 翻译、路径哨兵脱敏。
- `tests/test_generate_router.py` 新增 `TestNoServerPathLeak`：对 generate.py 各端点 404/400/500 响应形状回归——`detail` 不含 `/Users` `/var` `/private` 等路径片段。
- 全量 `pytest` 5893 passed；`ruff check/format`、`basedpyright` 0 error；`test_i18n_consistency` 通过。

## 已知薄弱点与后续

- `script_data_corrupted` 的 `reason=str(exc)` 沿袭既有行为回传 `ScriptEditError` 原文（当前消息为结构性描述、不含路径）。
- follow-up：其余 router（agent_chat / assistant / projects / versions / grids 等）分批迁移；`ProjectManager` 改抛领域异常以恢复 404 具体文案并消除 lib 层 `FileNotFoundError` 依赖。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 集中化 API 错误处理，按请求语言返回本地化提示。
  * 新增“请求资源不存在”多语言文案（中文/英文/越南文）。
  * 统一 400、404、500 的错误响应格式与内容边界。
* **改进**
  * 生成、视频、TTS 及资产相关接口采用一致的错误响应；缺失资源将更早以 404/400 失败返回。
  * 保护敏感信息：不回传异常文本/服务器路径；500 场景补齐跨域响应头，避免前端网络错误。
* **测试**
  * 新增与更新多语言、状态码映射、脱敏与 CORS 头的回归覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->