### PR TITLE
fix(agent-runtime): task 通知条目补全 subagent 归属

### DIFF
--- a/server/agent_runtime/event_log.py
+++ b/server/agent_runtime/event_log.py
@@ -281,7 +281,7 @@ class SdkMessageNormalizer:
                 # 单条通知（绝大多数场景）保留原 uuid 不变；同一消息批了多条时才
                 # 加序号后缀区分，避免同 uuid 的多条系统条目在前端归并/查找时互相覆盖。
                 multiple = len(task_infos) > 1
-                return [
+                notification_entries = [
                     {
                         "type": ENTRY_TYPE_SYSTEM,
                         "subtype": ENTRY_SUBTYPE_TASK_NOTIFICATION,
@@ -297,6 +297,10 @@ class SdkMessageNormalizer:
                     }
                     for i, task_info in enumerate(task_infos)
                 ]
+                if parent:
+                    for notification_entry in notification_entries:
+                        notification_entry["parent_tool_use_id"] = parent
+                return notification_entries
 
         # tool_use_result 是消息级字段（CLI 单条 toolUseResult，非按 tool_use_id
         # 分片）：仅当本消息只批了一个待答复的 tool_result 时，才能确定该结构化

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -295,6 +295,37 @@ class TestNormalizeTaskNotificationXml:
         assert entries[0]["uuid"] != entries[1]["uuid"]
         assert all(e["uuid"] for e in entries)
 
+    def test_subagent_notification_carries_parent_tool_use_id(self):
+        """subagent 内产生的后台任务通知需带 parent_tool_use_id，前端时间线才能
+        把它路由进对应 subagent 卡片，而不是退化到顶层时间线。"""
+        entries = normalize_sdk_message_to_entries(
+            {"type": "user", "content": self.XML, "uuid": "n-sub", "parent_tool_use_id": "tu-parent"}
+        )
+        assert len(entries) == 1
+        assert entries[0]["parent_tool_use_id"] == "tu-parent"
+
+    def test_subagent_notification_parent_key_case_variants_normalized(self):
+        """归属键的大小写变体走既有归一化 helper，与其它分支同口径。"""
+        for key in ("parent_tool_use_id", "parentToolUseID", "parentToolUseId"):
+            entries = normalize_sdk_message_to_entries({"type": "user", "content": self.XML, key: "tu-p"})
+            assert entries[0]["parent_tool_use_id"] == "tu-p", key
+
+    def test_batched_notifications_all_carry_same_parent(self):
+        """同一消息批多条通知时，每条都带同一 parent。"""
+        xml2 = self.XML.replace("t9", "t10").replace("tu-9", "tu-10").replace("子任务完成", "另一子任务完成")
+        entries = normalize_sdk_message_to_entries(
+            {"type": "user", "content": self.XML + "\n" + xml2, "uuid": "n-multi", "parent_tool_use_id": "tu-parent"}
+        )
+        assert len(entries) == 2
+        assert all(e["parent_tool_use_id"] == "tu-parent" for e in entries)
+
+    def test_top_level_notification_has_no_parent_key(self):
+        """不带 parent 的消息归一化产出的 task_notification 条目不含该字段
+        （既有行为不回归）。"""
+        entries = normalize_sdk_message_to_entries({"type": "user", "content": self.XML, "uuid": "n-top"})
+        assert len(entries) == 1
+        assert "parent_tool_use_id" not in entries[0]
+
 
 class TestNormalizeQuestionAnswer:
     def _ask_assistant(self, normalizer: SdkMessageNormalizer) -> None:


### PR DESCRIPTION
## 背景

`server/agent_runtime/event_log.py` 的 `_normalize_user` 在函数开头提取了 `parent = _extract_parent(message)`，但 `task_notification` 分支（列表推导式为每条通知构造 dict）从未回填 `parent_tool_use_id`，是同一 normalizer 里唯一缺少该字段的分支。其结果是 subagent 内产生的后台任务通知在前端时间线上无法归属到对应 subagent 卡片，退化到顶层时间线。

## 改动

- `task_notification` 分支产出的每条条目在 `parent` 非空时补写 `parent_tool_use_id`，与 `system` / `qa_entry` / `tr_entry` / `user_entry` 分支同口径。
- 复用函数开头已提取的 `parent` 局部变量（而非逐条再调 `_copy_parent`→`_extract_parent`），效果与 `_copy_parent` 完全一致（同一份 `_extract_parent`），避免重复解析；大小写变体仍走既有归一化 helper。

## 验证

- 新增 4 条测试：单条带 parent、大小写变体归一化、批量多条共享同一 parent、不带 parent 时不产生该字段（既有行为不回归）。
- `uv run python -m pytest tests/agent_runtime/test_event_log.py` → 68 passed。
- `uv run ruff check` / `ruff format --check` / `uv run basedpyright server/agent_runtime/event_log.py` 均 0 error。

Closes #1140


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复子代理任务通知的归属信息未正确传递的问题。
  - 统一识别不同大小写形式的归属字段。
  - 批量任务通知现在都会正确继承相同的父工具调用标识。
  - 顶层任务通知继续保持原有行为，不附加归属信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->