### PR TITLE
fix(tasks): 统一任务活跃状态派生，重试任务不再被历史失败状态遮挡

### DIFF
--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useAppStore } from "@/stores/app-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
-import { useTasksStore } from "@/stores/tasks-store";
+import { useActiveResourceIds } from "@/stores/tasks-store";
 import { TimelineCanvas } from "./timeline/TimelineCanvas";
 import { OverviewCanvas } from "./OverviewCanvas";
 import { SourceFileViewer } from "./SourceFileViewer";
@@ -126,60 +126,11 @@ export function StudioCanvasRouter() {
 
   const durationOptions = localDurationOptions ?? resolvedDurationOptions;
 
-  // 从任务队列派生 loading 状态（替代本地 state）
-  const tasks = useTasksStore((s) => s.tasks);
-  const generatingCharacterNames = useMemo(() => {
-    const names = new Set<string>();
-    for (const t of tasks) {
-      if (
-        t.task_type === "character" &&
-        t.project_name === currentProjectName &&
-        (t.status === "queued" || t.status === "running")
-      ) {
-        names.add(t.resource_id);
-      }
-    }
-    return names;
-  }, [tasks, currentProjectName]);
-  const generatingSceneNames = useMemo(() => {
-    const names = new Set<string>();
-    for (const t of tasks) {
-      if (
-        t.task_type === "scene" &&
-        t.project_name === currentProjectName &&
-        (t.status === "queued" || t.status === "running")
-      ) {
-        names.add(t.resource_id);
-      }
-    }
-    return names;
-  }, [tasks, currentProjectName]);
-  const generatingPropNames = useMemo(() => {
-    const names = new Set<string>();
-    for (const t of tasks) {
-      if (
-        t.task_type === "prop" &&
-        t.project_name === currentProjectName &&
-        (t.status === "queued" || t.status === "running")
-      ) {
-        names.add(t.resource_id);
-      }
-    }
-    return names;
-  }, [tasks, currentProjectName]);
-  const generatingProductNames = useMemo(() => {
-    const names = new Set<string>();
-    for (const t of tasks) {
-      if (
-        t.task_type === "product" &&
-        t.project_name === currentProjectName &&
-        (t.status === "queued" || t.status === "running")
-      ) {
-        names.add(t.resource_id);
-      }
-    }
-    return names;
-  }, [tasks, currentProjectName]);
+  // 从任务队列派生 loading 状态（替代本地 state）：活跃 + 最新行胜出两条不变量下沉到 store selector
+  const generatingCharacterNames = useActiveResourceIds("character", currentProjectName);
+  const generatingSceneNames = useActiveResourceIds("scene", currentProjectName);
+  const generatingPropNames = useActiveResourceIds("prop", currentProjectName);
+  const generatingProductNames = useActiveResourceIds("product", currentProjectName);
 
   // 刷新项目数据；返回本地 store 是否已同步成功，供调用方决定是否推进依赖新顺序的 UI 状态
   const refreshProject = useCallback(async (invalidateKeys: string[] = []): Promise<boolean> => {

--- a/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
+++ b/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
@@ -7,7 +7,7 @@ import { ShotSplitView } from "../timeline/ShotSplitView";
 import { GridPreviewView } from "./GridPreviewView";
 import { useAppStore } from "@/stores/app-store";
 import { useCostStore } from "@/stores/cost-store";
-import { useTasksStore } from "@/stores/tasks-store";
+import { useActiveResourceIds } from "@/stores/tasks-store";
 import { getScriptItemId } from "@/utils/script-shape";
 import type {
   EpisodeScript,
@@ -119,29 +119,21 @@ export function GridImageToVideoCanvas({
     [contentMode, episodeScript, projectData],
   );
 
-  const tasks = useTasksStore((s) => s.tasks);
-  const isGenerating = useCallback(
-    (taskType: "storyboard" | "video" | "tts", segmentId: string): boolean =>
-      tasks.some(
-        (tk) =>
-          tk.task_type === taskType &&
-          tk.project_name === projectName &&
-          tk.resource_id === segmentId &&
-          (tk.status === "queued" || tk.status === "running"),
-      ),
-    [tasks, projectName],
-  );
+  // 任务派生 loading：活跃 + 最新行胜出下沉到 store selector（各 task_type 一组活跃 resource）
+  const storyboardBusyIds = useActiveResourceIds("storyboard", projectName);
+  const videoBusyIds = useActiveResourceIds("video", projectName);
+  const ttsBusyIds = useActiveResourceIds("tts", projectName);
   const generatingStoryboard = useCallback(
-    (segId: string) => isGenerating("storyboard", segId),
-    [isGenerating],
+    (segId: string) => storyboardBusyIds.has(segId),
+    [storyboardBusyIds],
   );
   const generatingVideo = useCallback(
-    (segId: string) => isGenerating("video", segId),
-    [isGenerating],
+    (segId: string) => videoBusyIds.has(segId),
+    [videoBusyIds],
   );
   const generatingNarration = useCallback(
-    (segId: string) => isGenerating("tts", segId),
-    [isGenerating],
+    (segId: string) => ttsBusyIds.has(segId),
+    [ttsBusyIds],
   );
   // 批量旁白进行中：当前分集还有未完结的 tts 任务时禁用批量按钮，避免重复入队
   const currentSegmentIds = useMemo(
@@ -149,15 +141,8 @@ export function GridImageToVideoCanvas({
     [segments, editorContentMode],
   );
   const narrationBatchBusy = useMemo(
-    () =>
-      tasks.some(
-        (tk) =>
-          tk.task_type === "tts" &&
-          tk.project_name === projectName &&
-          currentSegmentIds.has(tk.resource_id) &&
-          (tk.status === "queued" || tk.status === "running"),
-      ),
-    [tasks, projectName, currentSegmentIds],
+    () => [...currentSegmentIds].some((id) => ttsBusyIds.has(id)),
+    [ttsBusyIds, currentSegmentIds],
   );
 
   const invalidateGrids = useAppStore((s) => s.invalidateGrids);

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { useShallow } from "zustand/shallow";
 import { useTranslation } from "react-i18next";
 import {
   ChevronLeft,
@@ -22,7 +21,7 @@ import {
   useReferenceVideoStore,
   referenceVideoCacheKey,
 } from "@/stores/reference-video-store";
-import { useTasksStore } from "@/stores/tasks-store";
+import { useLatestTasksByResource } from "@/stores/tasks-store";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useCostStore } from "@/stores/cost-store";
@@ -91,13 +90,9 @@ export function ReferenceVideoCanvas({
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
 
-  const relevantTasks = useTasksStore(
-    useShallow((s) =>
-      s.tasks.filter(
-        (tk) => tk.project_name === projectName && tk.task_type === "reference_video",
-      ),
-    ),
-  );
+  // resource（=unit）→ 最新任务行。「最新行胜出」下沉到 store selector：
+  // store 不保证 tasks 顺序（SSE 原位 upsert），重试的新行不被旧失败行盖住。
+  const tasksByUnit = useLatestTasksByResource(projectName, "reference_video");
 
   useEffect(() => {
     void loadUnits(projectName, episode);
@@ -119,17 +114,6 @@ export function ReferenceVideoCanvas({
   const [optimisticUnitIds, setOptimisticUnitIds] = useState<Set<string>>(() => new Set());
 
   const [uploadingUnitIds, setUploadingUnitIds] = useState<Set<string>>(() => new Set());
-
-  const tasksByUnit = useMemo(() => {
-    const map = new Map<string, (typeof relevantTasks)[number]>();
-    // store 不保证顺序（SSE upsert 原位更新、初始列表排序属后端实现细节）：
-    // 显式取 updated_at 最新的任务行，重试时不被旧失败行盖住
-    for (const tk of relevantTasks) {
-      const prev = map.get(tk.resource_id);
-      if (!prev || tk.updated_at > prev.updated_at) map.set(tk.resource_id, tk);
-    }
-    return map;
-  }, [relevantTasks]);
 
   const statusMap = useMemo<Record<string, UnitStatus>>(() => {
     const map: Record<string, UnitStatus> = {};

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -21,7 +21,7 @@ import {
   useReferenceVideoStore,
   referenceVideoCacheKey,
 } from "@/stores/reference-video-store";
-import { useLatestTasksByResource } from "@/stores/tasks-store";
+import { isActiveStatus, useLatestTasksByResource } from "@/stores/tasks-store";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useCostStore } from "@/stores/cost-store";
@@ -123,7 +123,7 @@ export function ReferenceVideoCanvas({
       // 上传中的 unit 视为 running：批量生成按 statusMap 选 pending，
       // 否则上传期间会被再次入队，与生成回写同一个成片文件
       if (uploadingUnitIds.has(u.unit_id)) st = "running";
-      else if (queueRow?.status === "queued" || queueRow?.status === "running") st = "running";
+      else if (queueRow && isActiveStatus(queueRow.status)) st = "running";
       // 失败任务行 DB 持久化、不会过期：手动上传成片后单元已有可播放资产，
       // 不再让历史失败覆盖 ready（与 timeline/grid 画布用 toast 提示失败的语义对齐）
       else if (queueRow?.status === "failed" && !u.generated_assets.video_clip) st = "failed";

--- a/frontend/src/components/canvas/timeline/AdReferenceUnitsPanel.tsx
+++ b/frontend/src/components/canvas/timeline/AdReferenceUnitsPanel.tsx
@@ -8,10 +8,13 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useShallow } from "zustand/react/shallow";
 import { Layers, RefreshCw, Sparkles } from "lucide-react";
 import { API } from "@/api";
-import { useTasksStore } from "@/stores/tasks-store";
+import {
+  selectActiveResourceIds,
+  useActiveResourceIds,
+  useTasksStore,
+} from "@/stores/tasks-store";
 import type { AdReferenceUnit, AdShot } from "@/types";
 
 interface AdReferenceUnitsPanelProps {
@@ -51,20 +54,8 @@ export function AdReferenceUnitsPanel({ projectName, episode, shots }: AdReferen
 
   const shotById = useMemo(() => new Map(shots.map((s) => [s.shot_id, s])), [shots]);
 
-  const relevantTasks = useTasksStore(
-    useShallow((s) =>
-      s.tasks.filter((tk) => tk.project_name === projectName && tk.task_type === "reference_video"),
-    ),
-  );
-  const busyUnitIds = useMemo(
-    () =>
-      new Set(
-        relevantTasks
-          .filter((tk) => tk.status === "queued" || tk.status === "running")
-          .map((tk) => tk.resource_id),
-      ),
-    [relevantTasks],
-  );
+  // 活跃 + 最新行胜出下沉到 store selector：重试的新行不被同 unit 的旧失败行盖住。
+  const busyUnitIds = useActiveResourceIds("reference_video", projectName);
 
   const derive = async (): Promise<AdReferenceUnit[]> => {
     setDeriving(true);
@@ -94,17 +85,7 @@ export function AdReferenceUnitsPanel({ projectName, episode, shots }: AdReferen
   // 实时读 store 而非渲染期快照：串行 await 期间其他入口（如单 unit 按钮）
   // 可能已入队同一 unit
   const liveBusyUnitIds = () =>
-    new Set(
-      useTasksStore
-        .getState()
-        .tasks.filter(
-          (tk) =>
-            tk.project_name === projectName &&
-            tk.task_type === "reference_video" &&
-            (tk.status === "queued" || tk.status === "running"),
-        )
-        .map((tk) => tk.resource_id),
-    );
+    selectActiveResourceIds(useTasksStore.getState().tasks, "reference_video", projectName);
 
   const generateAll = async () => {
     // 先重新派生（保证索引与 shots 一致），再为未完成且空闲的 unit 入队

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -6,7 +6,7 @@ import { ShotSplitView } from "./ShotSplitView";
 import { EpisodeHeader } from "./EpisodeHeader";
 import { AdReferenceUnitsPanel } from "./AdReferenceUnitsPanel";
 import { useCostStore } from "@/stores/cost-store";
-import { useTasksStore } from "@/stores/tasks-store";
+import { useActiveResourceIds } from "@/stores/tasks-store";
 import { effectiveMode } from "@/utils/generation-mode";
 import { getScriptItemId } from "@/utils/script-shape";
 import type {
@@ -125,30 +125,21 @@ export function TimelineCanvas({
     [contentMode, episodeScript, projectData],
   );
 
-  // 任务派生 loading
-  const tasks = useTasksStore((s) => s.tasks);
-  const isGenerating = useCallback(
-    (taskType: "storyboard" | "video" | "tts", segmentId: string): boolean =>
-      tasks.some(
-        (t) =>
-          t.task_type === taskType &&
-          t.project_name === projectName &&
-          t.resource_id === segmentId &&
-          (t.status === "queued" || t.status === "running"),
-      ),
-    [tasks, projectName],
-  );
+  // 任务派生 loading：活跃 + 最新行胜出下沉到 store selector（各 task_type 一组活跃 resource）
+  const storyboardBusyIds = useActiveResourceIds("storyboard", projectName);
+  const videoBusyIds = useActiveResourceIds("video", projectName);
+  const ttsBusyIds = useActiveResourceIds("tts", projectName);
   const generatingStoryboard = useCallback(
-    (segId: string) => isGenerating("storyboard", segId),
-    [isGenerating],
+    (segId: string) => storyboardBusyIds.has(segId),
+    [storyboardBusyIds],
   );
   const generatingVideo = useCallback(
-    (segId: string) => isGenerating("video", segId),
-    [isGenerating],
+    (segId: string) => videoBusyIds.has(segId),
+    [videoBusyIds],
   );
   const generatingNarration = useCallback(
-    (segId: string) => isGenerating("tts", segId),
-    [isGenerating],
+    (segId: string) => ttsBusyIds.has(segId),
+    [ttsBusyIds],
   );
   // 批量旁白进行中：当前分集还有未完结的 tts 任务时禁用批量按钮，避免重复入队；
   // 按本集 segment 范围判定，不影响其他分集的批量入口
@@ -157,15 +148,8 @@ export function TimelineCanvas({
     [segments, editorContentMode],
   );
   const narrationBatchBusy = useMemo(
-    () =>
-      tasks.some(
-        (t) =>
-          t.task_type === "tts" &&
-          t.project_name === projectName &&
-          currentSegmentIds.has(t.resource_id) &&
-          (t.status === "queued" || t.status === "running"),
-      ),
-    [tasks, projectName, currentSegmentIds],
+    () => [...currentSegmentIds].some((id) => ttsBusyIds.has(id)),
+    [ttsBusyIds, currentSegmentIds],
   );
 
   if (!projectData || (!episodeScript && !hasDraft)) {

--- a/frontend/src/components/task-hud/TaskHud.tsx
+++ b/frontend/src/components/task-hud/TaskHud.tsx
@@ -16,7 +16,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { useEscapeClose } from "@/hooks/useEscapeClose";
 import { useAppStore } from "@/stores/app-store";
-import { useTasksStore } from "@/stores/tasks-store";
+import { isTerminalStatus, useTasksStore } from "@/stores/tasks-store";
 import { API } from "@/api";
 import type { TaskItem } from "@/types";
 import { GlassPopover } from "@/components/ui/GlassPopover";
@@ -371,12 +371,7 @@ function ChannelSection({
   );
   const queued = tasks.filter((task) => task.status === "queued");
   const recent = tasks
-    .filter(
-      (task) =>
-        task.status === "succeeded" ||
-        task.status === "failed" ||
-        task.status === "cancelled",
-    )
+    .filter((task) => isTerminalStatus(task.status))
     .filter((task) => !hiddenIds.has(task.task_id))
     .slice(0, 5);
 

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import {
+  isActiveStatus,
+  isTerminalStatus,
+  selectActiveResourceIds,
+  selectLatestTaskByResource,
+} from "./tasks-store";
+import type { TaskItem, TaskStatus } from "@/types";
+
+function task(overrides: Partial<TaskItem> & { task_id: string }): TaskItem {
+  return {
+    project_name: "proj",
+    task_type: "reference_video",
+    media_type: "video",
+    resource_id: "unit-1",
+    script_file: null,
+    payload: {},
+    status: "queued",
+    result: null,
+    error_message: null,
+    cancelled_by: null,
+    provider_id: null,
+    provider_job_id: null,
+    source: "webui",
+    queued_at: "2026-07-16T00:00:00Z",
+    started_at: null,
+    finished_at: null,
+    updated_at: "2026-07-16T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("isActiveStatus", () => {
+  it("counts queued and running as active", () => {
+    expect(isActiveStatus("queued")).toBe(true);
+    expect(isActiveStatus("running")).toBe(true);
+  });
+
+  it("counts every other status as inactive", () => {
+    const inactive: TaskStatus[] = ["cancelling", "succeeded", "failed", "cancelled"];
+    for (const status of inactive) expect(isActiveStatus(status)).toBe(false);
+  });
+});
+
+describe("isTerminalStatus", () => {
+  it("counts succeeded/failed/cancelled as terminal", () => {
+    expect(isTerminalStatus("succeeded")).toBe(true);
+    expect(isTerminalStatus("failed")).toBe(true);
+    expect(isTerminalStatus("cancelled")).toBe(true);
+  });
+
+  it("counts in-flight statuses as non-terminal", () => {
+    const live: TaskStatus[] = ["queued", "running", "cancelling"];
+    for (const status of live) expect(isTerminalStatus(status)).toBe(false);
+  });
+});
+
+describe("selectLatestTaskByResource", () => {
+  it("keeps the row with the newest updated_at per resource, ignoring array order", () => {
+    // 旧失败行排在新重试行之前：store 不保证顺序，须按 updated_at 归并
+    const tasks = [
+      task({ task_id: "old", resource_id: "unit-1", status: "failed", updated_at: "2026-07-16T00:00:00Z" }),
+      task({ task_id: "new", resource_id: "unit-1", status: "running", updated_at: "2026-07-16T01:00:00Z" }),
+    ];
+    const latest = selectLatestTaskByResource(tasks);
+    expect(latest.get("unit-1")?.task_id).toBe("new");
+    expect(latest.get("unit-1")?.status).toBe("running");
+  });
+
+  it("does not let a stale later-in-array row overwrite a newer one", () => {
+    const tasks = [
+      task({ task_id: "new", resource_id: "unit-1", updated_at: "2026-07-16T02:00:00Z" }),
+      task({ task_id: "old", resource_id: "unit-1", updated_at: "2026-07-16T00:00:00Z" }),
+    ];
+    expect(selectLatestTaskByResource(tasks).get("unit-1")?.task_id).toBe("new");
+  });
+
+  it("filters by projectName and taskType", () => {
+    const tasks = [
+      task({ task_id: "a", resource_id: "u1", project_name: "p1", task_type: "video" }),
+      task({ task_id: "b", resource_id: "u2", project_name: "p2", task_type: "video" }),
+      task({ task_id: "c", resource_id: "u3", project_name: "p1", task_type: "storyboard" }),
+    ];
+    const latest = selectLatestTaskByResource(tasks, { projectName: "p1", taskType: "video" });
+    expect([...latest.keys()]).toEqual(["u1"]);
+  });
+
+  it("groups distinct resources independently", () => {
+    const tasks = [
+      task({ task_id: "a", resource_id: "u1" }),
+      task({ task_id: "b", resource_id: "u2" }),
+    ];
+    expect(selectLatestTaskByResource(tasks).size).toBe(2);
+  });
+});
+
+describe("selectActiveResourceIds", () => {
+  it("returns resources whose latest row is active", () => {
+    const tasks = [
+      task({ task_id: "a", resource_id: "u1", status: "running" }),
+      task({ task_id: "b", resource_id: "u2", status: "queued" }),
+      task({ task_id: "c", resource_id: "u3", status: "succeeded" }),
+    ];
+    const ids = selectActiveResourceIds(tasks, "reference_video", "proj");
+    expect([...ids].sort()).toEqual(["u1", "u2"]);
+  });
+
+  it("does not report a resource active when its newest row is a terminal retry outcome", () => {
+    // 旧 running + 新 failed：最新行胜出 → 不活跃（朴素 some 会误判活跃）
+    const tasks = [
+      task({ task_id: "old", resource_id: "u1", status: "running", updated_at: "2026-07-16T00:00:00Z" }),
+      task({ task_id: "new", resource_id: "u1", status: "failed", updated_at: "2026-07-16T01:00:00Z" }),
+    ];
+    expect(selectActiveResourceIds(tasks, "reference_video", "proj").has("u1")).toBe(false);
+  });
+
+  it("reports a retry active when its newest row is running despite an older failed row", () => {
+    // 旧 failed + 新 running：重试不被旧失败行遮挡
+    const tasks = [
+      task({ task_id: "old", resource_id: "u1", status: "failed", updated_at: "2026-07-16T00:00:00Z" }),
+      task({ task_id: "new", resource_id: "u1", status: "running", updated_at: "2026-07-16T01:00:00Z" }),
+    ];
+    expect(selectActiveResourceIds(tasks, "reference_video", "proj").has("u1")).toBe(true);
+  });
+
+  it("scopes to the given taskType and projectName", () => {
+    const tasks = [
+      task({ task_id: "a", resource_id: "u1", status: "running", task_type: "video", project_name: "p1" }),
+      task({ task_id: "b", resource_id: "u2", status: "running", task_type: "storyboard", project_name: "p1" }),
+      task({ task_id: "c", resource_id: "u3", status: "running", task_type: "video", project_name: "p2" }),
+    ];
+    expect([...selectActiveResourceIds(tasks, "video", "p1")]).toEqual(["u1"]);
+  });
+});

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import type { TaskItem, TaskStats } from "@/types";
+import { useShallow } from "zustand/react/shallow";
+import type { TaskItem, TaskStats, TaskStatus } from "@/types";
 
 interface TasksState {
   tasks: TaskItem[];
@@ -36,3 +37,85 @@ export const useTasksStore = create<TasksState>((set) => ({
   setStats: (stats) => set({ stats }),
   setConnected: (connected) => set({ connected }),
 }));
+
+// ---------------------------------------------------------------------------
+// 派生 selector —— 任务队列两条不变量的单一真相源
+//
+// 消费点（画布 loading 派生、参考视频单元状态等）此前各自重写两条隐性契约：
+//   1.「什么算活跃」——排队或运行中的任务占用其 resource（isActiveStatus）。
+//   2.「最新行胜出」——同一 resource 可能有多条任务行：失败后重试是新的 task_id，
+//      store 按 task_id upsert（见 upsertTask）且不保证 tasks 顺序，故判定时须取
+//      updated_at 最新的一行，重试的新行不被旧失败行遮挡（selectLatestTaskByResource）。
+//
+// 纯函数版把两条不变量收敛于此、可直接用 vitest 测试；hook 版用 useShallow 比较
+// Set/Map 内容，保证内容不变时引用稳定，避免每次渲染返回新集合触发重渲染。
+// ---------------------------------------------------------------------------
+
+/** 不变量 1：排队或运行中的任务视为占用其 resource。 */
+export function isActiveStatus(status: TaskStatus): boolean {
+  return status === "queued" || status === "running";
+}
+
+/** 终态：任务生命周期末端，不再占用 resource。 */
+export function isTerminalStatus(status: TaskStatus): boolean {
+  return status === "succeeded" || status === "failed" || status === "cancelled";
+}
+
+/**
+ * 不变量 2：按 resource_id 归并任务，同一 resource 多行时取 updated_at 最新的一行。
+ * 可选按 projectName / taskType 预筛；store 不保证顺序，故显式比较 updated_at。
+ */
+export function selectLatestTaskByResource(
+  tasks: TaskItem[],
+  filter: { projectName?: string; taskType?: string } = {},
+): Map<string, TaskItem> {
+  const latest = new Map<string, TaskItem>();
+  for (const task of tasks) {
+    if (filter.projectName !== undefined && task.project_name !== filter.projectName) continue;
+    if (filter.taskType !== undefined && task.task_type !== filter.taskType) continue;
+    const prev = latest.get(task.resource_id);
+    if (!prev || task.updated_at > prev.updated_at) latest.set(task.resource_id, task);
+  }
+  return latest;
+}
+
+/**
+ * 命中 taskType + projectName 且「最新行」处于活跃态的 resource_id 集合。
+ * 「最新行胜出」下沉于此：重试的新 running/queued 行不被同 resource 的旧 failed 行盖住。
+ */
+export function selectActiveResourceIds(
+  tasks: TaskItem[],
+  taskType: string,
+  projectName: string,
+): Set<string> {
+  const ids = new Set<string>();
+  for (const task of selectLatestTaskByResource(tasks, { projectName, taskType }).values()) {
+    if (isActiveStatus(task.status)) ids.add(task.resource_id);
+  }
+  return ids;
+}
+
+// projectName 缺失时复用同一空集，保证 hook 引用稳定。
+const EMPTY_ACTIVE_IDS: Set<string> = new Set();
+
+/** hook 版 {@link selectActiveResourceIds}；projectName 缺失时返回稳定空集。 */
+export function useActiveResourceIds(
+  taskType: string,
+  projectName: string | undefined | null,
+): Set<string> {
+  return useTasksStore(
+    useShallow((s) =>
+      projectName ? selectActiveResourceIds(s.tasks, taskType, projectName) : EMPTY_ACTIVE_IDS,
+    ),
+  );
+}
+
+/** hook 版 {@link selectLatestTaskByResource}，按 project + type 预筛。 */
+export function useLatestTasksByResource(
+  projectName: string,
+  taskType: string,
+): Map<string, TaskItem> {
+  return useTasksStore(
+    useShallow((s) => selectLatestTaskByResource(s.tasks, { projectName, taskType })),
+  );
+}


### PR DESCRIPTION
Closes #1149

## 摘要

「什么算活跃」「同 resource 多任务行谁胜出」两条不变量此前由 6 个消费点各自重新发明，其中「最新行胜出」6 缺 5——只有 ReferenceVideoCanvas 一处实现了 latest-wins，其余 5 处对同一 resource 的多行任务用朴素 `.some(active)` 判定，重试任务可能被历史失败行遮挡。

本 PR 将两条不变量下沉到 `tasks-store`，导出纯函数（可直接 vitest）+ hook（`useShallow` 保引用稳定），6 个消费点全部改用 selector。

## 改动

- **`tasks-store.ts`** 新增：
  - `isActiveStatus(status)` — 不变量 1（queued||running）
  - `isTerminalStatus(status)` — 终态判定（供 TaskHud recent 过滤复用）
  - `selectLatestTaskByResource(tasks, {projectName?, taskType?})` — 不变量 2（按 resource_id 归并取 updated_at 最新行）
  - `selectActiveResourceIds(tasks, taskType, projectName)` — 两条不变量组合
  - hook：`useActiveResourceIds` / `useLatestTasksByResource`（均用 `useShallow`，内容不变时引用稳定）
- **6 个消费点迁移**：StudioCanvasRouter（4 段 useMemo）、TimelineCanvas、GridImageToVideoCanvas、ReferenceVideoCanvas、AdReferenceUnitsPanel、TaskHud。

## 行为变更

原 5 个消费点对同 resource 多行不做归并，现全部走 latest-wins。语义差异仅在「同 resource 同时存在活跃旧行 + 终态新行」时显现：旧 failed + 新 running（重试）→ 判活跃（此前被遮挡，即本 issue 的修复）；旧 running + 新 failed → 判不活跃。ReferenceVideoCanvas 本就是 latest-wins，改为直接调用 selector，行为不变。TaskHud 的展示分桶逻辑（running/cancelling 分桶、queued 单列等）语义与 resource 不变量不同，故仅迁移 recent 终态过滤。

## 验证

- `pnpm lint` 干净；`pnpm check`（tsc + eslint + vitest）通过：104 test files / 927 tests。
- 新增 `frontend/src/stores/tasks-store.test.ts`（15 例），覆盖 isActiveStatus / isTerminalStatus / selectLatestTaskByResource / selectActiveResourceIds，重点回归「重试不被旧失败行遮挡」正反两向。
- 纯前端改动，未触 Python。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化画布、时间线及参考视频中的生成状态显示，能更准确反映当前资源是否正在处理。
  - 改善任务重试后的状态判断，避免旧任务记录覆盖最新结果。
  - 批量生成和旁白操作会根据最新任务状态准确启用或禁用。
  - 任务面板对“进行中”和“已完成”状态的分类更加统一。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->