### PR TITLE
fix(script): 统一剧本条目时长兜底口径，修脏 duration_seconds 致项目列表 5xx

### DIFF
--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -41,6 +41,7 @@ from lib.profile_manifest import (
 )
 from lib.project_change_hints import emit_project_change_hint
 from lib.script_editor import ScriptEditError, resolve_items
+from lib.script_models import script_duration_total
 from lib.style_templates import LEGACY_STYLE_MAP, resolve_template_prompt
 
 logger = logging.getLogger(__name__)
@@ -631,25 +632,10 @@ class ProjectManager:
             # estimated_duration_seconds 会被垃圾元素按 default 时长撑大，与各路径不一致。
             scene_items = [item for item in items if isinstance(item, dict)]
             metadata["total_scenes"] = len(scene_items)
-            # 计算总时长：按当前选中的数据结构决定回退值，避免 content_mode 缺失时误判。
-            # ``.get(k, default)`` 仅在键缺失时返回 default，键存在但值为 None（脏数据）会
-            # 返回 None 让 sum() 抛 TypeError——显式判 None 视为缺失，与同函数前面对 metadata
-            # 缺字段时按 setdefault 兜底的语义一致：脏值不阻塞 metadata 重算，但若 default 也
-            # 失真（如 reference 模式未填 duration_seconds），下游 estimated 字段仍是近似值。
-            # shots（ad）无单镜头默认时长偏好，缺失按 0 计（与 StatusCalculator 口径一致）；
-            # 未知 kind 沿用历史兜底 8。
-            default_duration = {"segments": 4, "scenes": 8, "shots": 0}.get(kind, 8)
-
-            def _duration(item: dict) -> int:
-                value = item.get("duration_seconds")
-                # bool 是 int 子类,排除避免 duration_seconds=True 被算成 1 秒、=False 算成 0 秒
-                if isinstance(value, bool):
-                    return default_duration
-                if isinstance(value, (int, float)):
-                    return int(value)
-                return default_duration
-
-            metadata["estimated_duration_seconds"] = sum(_duration(item) for item in scene_items)
+            # 总时长走 script_duration_total 单一真相源：脏值（None/bool/负数/字符串）按骨架
+            # 兜底时长归一、不抛（见 lib/script_models.py）。与 StatusCalculator 读时计算、
+            # ScriptGenerator 落盘估算共用同一兜底表与守卫，避免三处口径漂移。
+            metadata["estimated_duration_seconds"] = script_duration_total(kind, scene_items)
 
         # 原子写（含路径遍历防护，output_path 已在守卫前解析），避免并发 PATCH 导致 JSON 损坏
         atomic_write_json(output_path, script)

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -47,6 +47,7 @@ from lib.script_models import (
     build_episode_script_model,
     build_reference_video_script_model,
     merge_drama_visual_into_scenes,
+    script_duration_total,
 )
 from lib.script_skeleton import SKELETONS, resolve_declared_kind
 from lib.text_backends.base import DEFAULT_MAX_OUTPUT_TOKENS, TextGenerationRequest, TextTaskType
@@ -82,15 +83,6 @@ _METADATA_COUNT_KEY: dict[str, str] = {
     "video_units": "total_units",
 }
 
-# 骨架种类 → 缺 duration_seconds 时的兜底时长（秒）。业务附着值：segments/scenes 沿用
-# 历史默认，video_units 缺失按 0 计。shots（ad）无单镜头默认时长、改走 ad_script_total_duration
-# 稳健求和，故不在此表——第五种非 ad 骨架未登记即在 _add_metadata 处 KeyError 报红。
-_METADATA_FALLBACK_DURATION: dict[str, int] = {
-    "segments": 4,
-    "scenes": 8,
-    "video_units": 0,
-}
-
 
 def _rewrite_episode_prefix(rid: object, ep: int) -> object:
     """把 ID 中的 `E\\d+` 前缀强制改写为 `E{ep}`；非字符串或无 E 前缀的原样返回。
@@ -103,25 +95,6 @@ def _rewrite_episode_prefix(rid: object, ep: int) -> object:
     if n and new_rid != rid:
         logger.warning("episode prefix rewritten: %s → %s", rid, new_rid)
     return new_rid
-
-
-def _coerce_duration(item: object, fallback: int) -> int:
-    """降级保存路径按稳健口径取单条时长:校验失败时保存的原始 dict 里数组可能含脏条目，
-    直接 ``int(item.get(...))`` 会在非 dict 或 duration_seconds 非数字时崩溃。
-
-    非 dict 条目无时长语义、记 0；dict 内 duration_seconds 缺失、非数字（None / 布尔 /
-    非数字字符串）或非正数（校验器亦按 ``duration <= 0`` 判无效）回退 ``fallback``。
-    """
-    if not isinstance(item, dict):
-        return 0
-    value = item.get("duration_seconds", fallback)
-    if isinstance(value, bool):
-        return fallback
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        return fallback
-    return parsed if parsed > 0 else fallback
 
 
 class ScriptGenerator:
@@ -896,17 +869,13 @@ class ScriptGenerator:
         script_data["metadata"]["generator"] = self.generator.model if self.generator else "unknown"
 
         # 计算统计信息（episode 级角色/场景/道具聚合由 StatusCalculator 读时计算）。
-        # 数组键经上方规范解析所得 kind 查表；计数键名与兜底时长为业务附着、随 kind 显式保留。
-        # 校验失败降级保存的原始 dict 里数组可能为 null / 含脏条目，isinstance 守卫走稳健口径。
+        # 数组键经上方规范解析所得 kind 查表；计数键名为业务附着、随 kind 显式保留。
+        # 校验失败降级保存的原始 dict 里数组可能为 null / 含脏条目：len(items) 计入全部条目
+        # （既有口径），时长走 script_duration_total 单一真相源逐条兜底（脏值归一、不抛）。
         raw_items = script_data.get(kind)
         items = raw_items if isinstance(raw_items, list) else []
         script_data["metadata"][_METADATA_COUNT_KEY[kind]] = len(items)
-        if kind == "shots":
-            # ad 逐镜头按 target_duration 预算规划、无单镜头默认时长，走 ad_script_total_duration。
-            script_data["duration_seconds"] = ad_script_total_duration(items)
-        else:
-            fallback = _METADATA_FALLBACK_DURATION[kind]
-            script_data["duration_seconds"] = sum(_coerce_duration(i, fallback) for i in items)
+        script_data["duration_seconds"] = script_duration_total(kind, items)
 
         # 剥离废弃的 episode 级聚合字段（改为读时计算）
         script_data.pop("characters_in_episode", None)

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -771,6 +771,40 @@ def ad_script_total_duration(shots: object) -> int:
     return sum(ad_shot_duration_seconds(shot) for shot in shots)
 
 
+#: 缺 duration_seconds 时按骨架种类取的兜底时长（秒）——剧本条目时长的单一真相源。
+#: segments/scenes 沿用历史默认；shots（ad）与 video_units（参考直出）无单镜头默认时长
+#: 偏好（按 target/预算逐条规划），缺失按 0 计，避免杜撰值污染与目标总时长的对照。
+#: 三个消费方（StatusCalculator 读时计算、ProjectManager 写盘重算、ScriptGenerator
+#: 落盘估算）共用此表，四种骨架全登记；第五种骨架加入即在 ``item_duration`` 查表 KeyError。
+_ITEM_FALLBACK_DURATIONS: dict[str, int] = {"segments": 4, "scenes": 8, "shots": 0, "video_units": 0}
+
+
+def item_duration(kind: str, item: object) -> int:
+    """单条剧本条目时长（秒）的脏数据归一口径——沿 ``ad_shot_duration_seconds`` 先例推广到四骨架。
+
+    非 dict 条目无时长语义按 0 计；dict 内 ``duration_seconds`` 缺失，或为脏值
+    （None / 布尔 / 非正整数 / 浮点 / 字符串）一律回退按 ``kind`` 查 ``_ITEM_FALLBACK_DURATIONS``
+    的兜底时长。只认真正的正整数（bool 按 int 子类排除），与校验器「``duration <= 0`` 判无效」一致。
+    """
+    if not isinstance(item, dict):
+        return 0
+    value = item.get("duration_seconds")
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return _ITEM_FALLBACK_DURATIONS[kind]
+
+
+def script_duration_total(kind: str, items: object) -> int:
+    """按骨架种类求剧本条目总时长（秒）——脏数据稳健、不抛（见 ``item_duration``）。
+
+    ``items`` 非 list（含 null 这类降级保存的脏值）按空处理返回 0。读时计算与写盘重算
+    共用此单一真相源，避免三处各自维护同一兜底表与守卫。
+    """
+    if not isinstance(items, list):
+        return 0
+    return sum(item_duration(kind, item) for item in items)
+
+
 class Shot(BaseModel):
     """参考视频单元内的一个镜头。"""
 

--- a/lib/status_calculator.py
+++ b/lib/status_calculator.py
@@ -10,15 +10,10 @@ import logging
 from lib.episode_paths import STEP1_FILENAMES, STEP1_LEGACY_FILENAMES, episode_drafts_dir
 from lib.path_safety import safe_exists
 from lib.project_manager import effective_mode
-from lib.script_models import ad_script_total_duration
+from lib.script_models import ad_script_total_duration, script_duration_total
 from lib.script_skeleton import SKELETONS, resolve_declared_kind
 
 logger = logging.getLogger(__name__)
-
-# 缺 duration_seconds 时按骨架种类取的兜底时长（秒）。
-# segments/scenes 沿用历史默认；shots（ad）没有单镜头时长偏好（按 target_duration 预算
-# 逐镜头规划），缺失按 0 计入，避免杜撰值污染与目标总时长的对照。
-_FALLBACK_ITEM_DURATIONS: dict[str, int] = {"segments": 4, "scenes": 8, "shots": 0}
 
 # 缺 content_mode 声明的老脚本：按主结构鸭子类型兜底探测的骨架种类，顺序固定
 # segments > scenes > shots（video_units 不参与——按声明分派，不嗅探残留派生索引）。
@@ -107,7 +102,6 @@ class StatusCalculator:
         if kind == "shots" and generation_mode == "reference_video":
             return self._calculate_ad_reference_stats(script, items)
 
-        default_duration = _FALLBACK_ITEM_DURATIONS[kind]
         storyboard_done = sum(1 for i in items if i.get("generated_assets", {}).get("storyboard_image"))
         video_done = sum(1 for i in items if i.get("generated_assets", {}).get("video_clip"))
         total = len(items)
@@ -122,7 +116,7 @@ class StatusCalculator:
         return {
             "scenes_count": total,
             "status": status,
-            "duration_seconds": sum(i.get("duration_seconds", default_duration) for i in items),
+            "duration_seconds": script_duration_total(kind, items),
             "storyboards": {"total": total, "completed": storyboard_done},
             "videos": {"total": total, "completed": video_done},
         }
@@ -195,7 +189,7 @@ class StatusCalculator:
             "scenes_count": total,
             "units_count": total,
             "status": status,
-            "duration_seconds": sum(u.get("duration_seconds", 0) for u in units),
+            "duration_seconds": script_duration_total("video_units", units),
             "storyboards": {"total": total, "completed": 0},
             "videos": {"total": total, "completed": video_done},
         }
@@ -458,10 +452,7 @@ class StatusCalculator:
             注入计算字段后的剧本数据
         """
         kind, items = self._select_kind_and_items(script)
-        # video_units 骨架不在时长表内，沿用历史 else 兜底值 8
-        default_duration = _FALLBACK_ITEM_DURATIONS.get(kind, 8)
-
-        total_duration = sum(i.get("duration_seconds", default_duration) for i in items)
+        total_duration = script_duration_total(kind, items)
 
         # 注入 metadata 计算字段
         if "metadata" not in script:

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -848,12 +848,13 @@ class TestScriptGeneratorSkeletonExhaustiveness:
 
         assert set(_METADATA_COUNT_KEY) == set(SKELETONS)
 
-    def test_metadata_fallback_duration_covers_non_shots_kinds(self):
-        # shots（ad）走 ad_script_total_duration、不进兜底时长表；其余骨架均须登记。
-        from lib.script_generator import _METADATA_FALLBACK_DURATION
+    def test_item_fallback_duration_covers_every_skeleton_kind(self):
+        # 时长兜底表单点化到 script_models，四骨架全登记（含 shots/video_units→0）；
+        # 第五种骨架加入 SKELETONS 而未登记即在 item_duration 查表 KeyError 报红。
+        from lib.script_models import _ITEM_FALLBACK_DURATIONS
         from lib.script_skeleton import SKELETONS
 
-        assert set(_METADATA_FALLBACK_DURATION) == set(SKELETONS) - {"shots"}
+        assert set(_ITEM_FALLBACK_DURATIONS) == set(SKELETONS)
 
     @pytest.mark.parametrize("kind", list(_KIND_TO_MODES))
     def test_add_metadata_handles_every_skeleton_kind(self, kind: str, tmp_path: Path):

--- a/tests/test_script_models.py
+++ b/tests/test_script_models.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from lib.script_models import (
+    _ITEM_FALLBACK_DURATIONS,
     AdEpisodeScript,
     AdShot,
     Composition,
@@ -14,6 +15,8 @@ from lib.script_models import (
     NarrationSegment,
     Utterance,
     VideoPrompt,
+    item_duration,
+    script_duration_total,
 )
 
 
@@ -355,6 +358,69 @@ class TestAdScriptModels:
                     "hallucinated_field": "x",
                 }
             )
+
+
+class TestItemDurationCoercion:
+    """剧本条目时长的脏数据归一——单一真相源，读时计算/写盘重算/落盘估算三处共用。
+
+    校验失败降级保存的原始 dict 会把 None/bool/负数/字符串/缺失等脏值带到读路径，
+    历史上三份兜底表 + 三套守卫互异（StatusCalculator 缺 None 守卫致 sum() TypeError、
+    项目列表 API 5xx）。此处穷举脏值矩阵 × 四骨架，钉住单点化后的统一口径。
+    """
+
+    def test_fallback_table_covers_four_skeletons(self):
+        assert _ITEM_FALLBACK_DURATIONS == {"segments": 4, "scenes": 8, "shots": 0, "video_units": 0}
+
+    @pytest.mark.parametrize("kind", ["segments", "scenes", "shots", "video_units"])
+    def test_valid_positive_int_passes_through(self, kind: str):
+        assert item_duration(kind, {"duration_seconds": 7}) == 7
+
+    @pytest.mark.parametrize("kind", ["segments", "scenes", "shots", "video_units"])
+    @pytest.mark.parametrize(
+        "dirty",
+        [
+            {},  # 缺失
+            {"duration_seconds": None},  # None
+            {"duration_seconds": True},  # bool（int 子类，须排除）
+            {"duration_seconds": False},
+            {"duration_seconds": 0},  # 非正数
+            {"duration_seconds": -5},  # 负数
+            {"duration_seconds": "6"},  # 数字字符串
+            {"duration_seconds": "six"},  # 非数字字符串
+            {"duration_seconds": 4.5},  # 浮点
+        ],
+    )
+    def test_dirty_values_fall_back_by_kind(self, kind: str, dirty: dict):
+        # 缺失与所有脏值一律回退到骨架兜底时长（shots/video_units 兜底为 0）。
+        assert item_duration(kind, dirty) == _ITEM_FALLBACK_DURATIONS[kind]
+
+    @pytest.mark.parametrize("kind", ["segments", "scenes", "shots", "video_units"])
+    def test_non_dict_item_counts_zero(self, kind: str):
+        # 非 dict 条目无时长语义，恒按 0 计，不挪用骨架兜底。
+        for junk in ("junk", 5, None, ["x"]):
+            assert item_duration(kind, junk) == 0
+
+    def test_script_total_sums_mixed_dirty_items(self):
+        # 混合脏条目求和不抛：5(有效) + 0(非 dict) + 4(缺失) + 4(None) + 4(负数) = 17。
+        items = [
+            {"duration_seconds": 5},
+            "junk_not_a_dict",
+            {},
+            {"duration_seconds": None},
+            {"duration_seconds": -5},
+        ]
+        assert script_duration_total("segments", items) == 17
+
+    def test_script_total_video_units_missing_is_zero(self):
+        # 口径拍板：video_units 缺时长统一按 0 计（不再沿历史 8 秒 else 兜底）。
+        assert script_duration_total("video_units", [{}, {"duration_seconds": None}]) == 0
+        assert script_duration_total("video_units", [{"duration_seconds": 6}, {}]) == 6
+
+    @pytest.mark.parametrize("kind", ["segments", "scenes", "shots", "video_units"])
+    def test_script_total_non_list_is_zero(self, kind: str):
+        # items 为 null / 真值标量（降级保存脏值）按空处理返回 0、不抛。
+        for junk in (None, "segments", 5, {"a": 1}):
+            assert script_duration_total(kind, junk) == 0
 
 
 class TestEnumDriftNormalization:

--- a/tests/test_status_calculator.py
+++ b/tests/test_status_calculator.py
@@ -646,7 +646,8 @@ _KIND_TO_MODES = {
 class TestStatusCalculatorSkeletonExhaustiveness:
     """穷尽性断言：calculate_episode_stats 的按 kind 分派覆盖 SKELETONS 全部键。
 
-    第五种骨架加入 SKELETONS（+ 规范解析映射）时，_FALLBACK_ITEM_DURATIONS 查表 KeyError，逐个报红。
+    第五种骨架加入 SKELETONS（+ 规范解析映射）时，script_duration_total 查 _ITEM_FALLBACK_DURATIONS
+    KeyError，逐个报红。
     """
 
     @pytest.mark.parametrize("kind", list(_KIND_TO_MODES))


### PR DESCRIPTION
## 摘要

剧本条目「缺失/脏 `duration_seconds` 按几秒计」原有三份互异兜底表 + 三套守卫（StatusCalculator 读时计算、ProjectManager 写盘重算、ScriptGenerator 落盘估算），同一脏值在不同路径算出不同结果；其中 StatusCalculator 缺 `None` 守卫，`duration_seconds: null` 时 `sum()` 抛 TypeError、沿 `calculate_project_status` 冒泡致**项目列表 API 5xx**。

沿 `ad_script_total_duration` 先例，在 `lib/script_models.py` 收口 `item_duration(kind, item)` + `script_duration_total(kind, items)` 单一真相源：兜底表只留一份（四骨架全登记），`None`/bool/负数/浮点/字符串/缺失一套守卫按骨架兜底归一、不抛。三个消费方改调用，旧三份表与三套守卫移除。

口径统一（用户拍板）：**video_units 缺时长按 0 计**——修正 StatusCalculator `enrich_script` 原 else 兜底 8、ProjectManager 未登记落 8 两处历史不一致，与 `_calculate_reference_video_stats` 既有 0 对齐。

## 变更

- `lib/script_models.py` — 新增 `_ITEM_FALLBACK_DURATIONS` + `item_duration` + `script_duration_total`（严格正整数口径，与既有 `ad_shot_duration_seconds` 一致）
- `lib/status_calculator.py` — 三处（`calculate_episode_stats` 通用分支、`_calculate_reference_video_stats`、`enrich_script`）改调用，删除本地 `_FALLBACK_ITEM_DURATIONS`
- `lib/project_manager.py` — `save_script` metadata 重算改调用，删除内联 `_duration` + `default_duration`
- `lib/script_generator.py` — `_add_metadata` 改调用（shots 特例折叠，与 `ad_script_total_duration` 等价），删除 `_METADATA_FALLBACK_DURATION` + `_coerce_duration`

## 验证

- `pytest` 全量 5935 passed（实现阶段）；审查阶段 rebase 到最新 main 后复验四个相关测试模块 220 passed
- 新增 `tests/test_script_models.py::TestItemDurationCoercion`：脏值矩阵（缺失/None/bool/负数/0/数字字符串/非数字字符串/浮点）× 四骨架，断言统一回退口径；非 dict→0；混合脏条目求和；video_units 缺时长→0；items 非 list→0
- `ruff check`/`format` 全绿；`basedpyright` 0 errors
- /code-review high：0 确认缺陷

Closes #1147


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 统一脚本条目的时长估算规则，支持对缺失、无效或异常时长使用合理默认值。
  * 生成脚本、写入元数据和状态统计中的总时长计算保持一致。
  * 提升对不完整或异常数据的容错能力，避免时长统计因脏数据出错。

* **测试**
  * 增加对不同脚本类型、异常时长值及无效输入的覆盖，确保时长统计稳定可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->