### PR TITLE
fix(assistant): 新会话幂等查找按项目隔离，消除切换项目后会话串号

### DIFF
--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -438,6 +438,41 @@ describe("useAssistantSession", () => {
     expect(sendSpy.mock.calls[1][4]).not.toBe(sendSpy.mock.calls[0][4]);
   });
 
+  it("uses a fresh idempotency key after switching projects (signature includes project)", async () => {
+    // 面板为长生命周期单例，切换项目不卸载：项目 A 的失败缓存（clientKey + 签名）
+    // 会跨项目存活。签名含项目维度后，切到 B 重发同内容应生成新键、不复用 A 的键。
+    mockIdleSession();
+    const sendSpy = vi
+      .spyOn(API, "sendAssistantMessage")
+      .mockRejectedValueOnce(new Error("发送失败")) // 项目 A：失败并缓存 clientKey
+      .mockResolvedValueOnce({ session_id: "session-1", status: "accepted", entry: userEntry(0, "hello") });
+
+    const { result, rerender } = renderHook(({ p }) => useAssistantSession(p), {
+      initialProps: { p: "proj_a" },
+    });
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    // 切换项目（同一 hook 实例，失败缓存的 ref 存活）
+    rerender({ p: "proj_b" });
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+    // 跨项目同内容重发：签名含项目维度 → 生成新键，不复用旧项目缓存的 clientKey
+    expect(sendSpy.mock.calls[1][4]).not.toBe(sendSpy.mock.calls[0][4]);
+  });
+
   it("ignores delayed send completions after switching sessions", async () => {
     vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
       sessions: [

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -321,8 +321,11 @@ export function useAssistantSession(projectName: string | null) {
         media_type: img.mimeType,
       }));
 
-      // 请求侧幂等键：同一内容失败重试复用同键，服务端按键去重不产生重复
-      const signature = JSON.stringify([sessionId, content.trim(), imagePayload ?? []]);
+      // 请求侧幂等键：同一内容失败重试复用同键，服务端按键去重不产生重复。
+      // 签名纳入 projectName：面板为长生命周期单例，切换项目不卸载，失败缓存
+      // （clientKey + 签名）跨项目存活；含项目维度后旧项目缓存的 clientKey 自然
+      // 失效，不再被其他项目的同内容重发复用。
+      const signature = JSON.stringify([projectName, sessionId, content.trim(), imagePayload ?? []]);
       const clientKey =
         failedSendRef.current?.signature === signature
           ? failedSendRef.current.clientKey

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -261,7 +261,7 @@ class AssistantService:
             if not client_key:
                 return await self._create_new_session(project_name, content, images, locale, client_key)
 
-            existing = await self._find_accepted_new_session(client_key)
+            existing = await self._find_accepted_new_session(client_key, project_name)
             if existing is not None:
                 return existing
 
@@ -270,22 +270,37 @@ class AssistantService:
             lock = self._new_session_locks.lock_for(client_key)
             async with lock:
                 # 双重检查：等锁期间先行者可能已完成同一 client_key 的建会话。
-                existing = await self._find_accepted_new_session(client_key)
+                existing = await self._find_accepted_new_session(client_key, project_name)
                 if existing is not None:
                     return existing
                 result = await self._create_new_session(project_name, content, images, locale, client_key)
                 self._record_new_session_client_key(client_key, result["session_id"])
                 return result
 
-    async def _find_accepted_new_session(self, client_key: str) -> dict[str, Any] | None:
+    async def _find_accepted_new_session(self, client_key: str, project_name: str) -> dict[str, Any] | None:
         """按幂等键定位已受理的新会话：进程内映射为快路径，事件日志跨会话
         查询兜底——进程重启 / LRU 淘汰后映射丢失，受理已落库的重试仍须命中
-        既有会话而非重复建会话（重复执行同一 prompt、重复计费）。"""
+        既有会话而非重复建会话（重复执行同一 prompt、重复计费）。
+
+        命中会话的项目归属须与调用方 ``project_name`` 一致：不一致则视为未命中
+        （返回 None，由调用方在当前项目新建会话），不抛错——用户未指名任何
+        会话，跨项目复用同一 client_key 时新会话意图应落在当前项目。两条查找
+        路径口径一致，均在返回前做归属校验。"""
         mapped_session_id = self._new_session_client_keys.get(client_key)
         if mapped_session_id is not None:
             # 幂等重试：首次受理已建会话并投递，返回同一会话的权威条目。
             entry = await self.event_log_store.find_by_client_key(mapped_session_id, client_key)
-            if entry is not None:
+            if entry is None:
+                # 映射指向的会话条目已不存在（如会话已被删除）：映射已失效，
+                # 清掉后继续向下探测，避免返回指向已删除会话的幽灵 "accepted"
+                # 响应——调用方会据此连接一个不存在的会话，消息静默丢失。上一行
+                # await 期间该 key 可能已被其他并发请求写入更新的映射；仅当当前
+                # 值仍是本次读到的旧值时才清，避免清掉并发写入的新映射（DB 兜底
+                # 查询本身按 client_key 定位一定命中同一权威会话，误删只是白跑
+                # 一次查询，但仍以精确条件避免这层不必要的抖动）。
+                if self._new_session_client_keys.get(client_key) == mapped_session_id:
+                    self._new_session_client_keys.pop(client_key, None)
+            elif await self._new_session_matches_project(mapped_session_id, project_name):
                 # 命中即刷新 LRU 位置：否则被频繁重试命中的 key 仍按插入
                 # 顺序（而非访问顺序）淘汰，退化成 FIFO。上一行 await 期间
                 # 该 key 可能已被其他并发请求的淘汰逻辑移除，直接
@@ -294,25 +309,29 @@ class AssistantService:
                 # 存在则原地更新）再显式挪到最近使用端，两种情形都安全。
                 self._record_new_session_client_key(client_key, mapped_session_id)
                 return {"status": "accepted", "session_id": mapped_session_id, "entry": entry}
-            # 映射指向的会话条目已不存在（如会话已被删除）：映射已失效，
-            # 清掉后继续向下探测，避免返回指向已删除会话的幽灵 "accepted"
-            # 响应——调用方会据此连接一个不存在的会话，消息静默丢失。上一行
-            # await 期间该 key 可能已被其他并发请求写入更新的映射；仅当当前
-            # 值仍是本次读到的旧值时才清，避免清掉并发写入的新映射（DB 兜底
-            # 查询本身按 client_key 定位一定命中同一权威会话，误删只是白跑
-            # 一次查询，但仍以精确条件避免这层不必要的抖动）。
-            if self._new_session_client_keys.get(client_key) == mapped_session_id:
-                self._new_session_client_keys.pop(client_key, None)
+            # else：映射命中的会话属于其他项目 → 视为未命中，落到 DB 兜底 / 新建
+            # 路径。不清映射：它对原项目仍有效；后续在当前项目新建会话时由
+            # _record_new_session_client_key 以本项目 session 覆盖同一 client_key。
         recovered = await self.event_log_store.find_new_session_by_client_key(client_key)
         if recovered is None:
             return None
         session_id, entry = recovered
+        if not await self._new_session_matches_project(session_id, project_name):
+            # 兜底命中的会话属于其他项目 → 视为未命中，走当前项目新建路径。
+            return None
         # 上一行 await 期间该 key 可能已被其他并发请求记入新映射；仅当当前
         # 无映射或已是同一 session_id 时才写入，避免用本次查到的（较旧）
         # session_id 覆盖并发写入的映射。
         if self._new_session_client_keys.get(client_key) in (None, session_id):
             self._record_new_session_client_key(client_key, session_id)
         return {"status": "accepted", "session_id": session_id, "entry": entry}
+
+    async def _new_session_matches_project(self, session_id: str, project_name: str) -> bool:
+        """幂等命中的新会话是否属于当前调用项目。校验依据为会话 meta 的
+        ``project_name``；meta 不存在（异常 / 已删）时不阻断命中，保持既有幂等
+        语义——跨项目串号的前提是命中会话 meta 存在且项目不同。"""
+        meta = await self.meta_store.get(session_id)
+        return meta is None or meta.project_name == project_name
 
     def _record_new_session_client_key(self, client_key: str, session_id: str) -> None:
         self._new_session_client_keys[client_key] = session_id

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -21,6 +21,18 @@ class _FakePM:
         return Path("/tmp") / project_name
 
 
+class _MultiProjectPM:
+    """接受多个合法项目名的 PM，用于跨项目会话隔离测试。"""
+
+    def __init__(self, valid_projects):
+        self.valid_projects = set(valid_projects)
+
+    def get_project_path(self, project_name):
+        if project_name not in self.valid_projects:
+            raise FileNotFoundError(project_name)
+        return Path("/tmp") / project_name
+
+
 class _FakeMetaStore:
     def __init__(self, metas=None):
         self.metas = {m.id: m for m in (metas or [])}
@@ -359,6 +371,119 @@ class TestAssistantServiceMore:
 
         await engine.dispose()
 
+    @staticmethod
+    def _make_project_scoped_service(tmp_path, store, sm, meta_store):
+        """装配一个跨项目 send_new_session 会落地 meta + 事件日志的 service。"""
+        service = AssistantService(project_root=tmp_path)
+        service.pm = _MultiProjectPM({"proj_a", "proj_b"})
+        service.session_manager = sm
+        service.meta_store = meta_store
+        service.event_log = _FakeEventLogService()
+        service.event_log_store = store
+
+        async def send_new_session(project_name, prompt, *, user_entry=None, client_key=None, **kwargs):
+            sid = f"sdk-{len(sm.new_sessions)}"
+            sm.new_sessions.append((project_name, prompt))
+            meta_store.metas[sid] = make_session_meta(id=sid, project_name=project_name)
+            if user_entry is not None:
+                await store.append_user_entry(sid, user_entry, client_key=client_key)
+            return sid
+
+        sm.send_new_session = send_new_session
+        return service
+
+    @pytest.mark.asyncio
+    async def test_new_session_client_key_project_scoped_via_map_hit(self, tmp_path):
+        """项目 A 已受理的新会话 client_key，用相同 client_key 对项目 B 调
+        send_or_create（无 session_id）→ 返回项目 B 下新建的会话，而非静默接回 A
+        的会话。覆盖进程内映射命中的快路径。"""
+        from server.agent_runtime.event_log import EventLogStore
+
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        store = EventLogStore(session_factory=factory)
+
+        sm = _FakeSessionManager()
+        meta_store = _FakeMetaStore([])
+        service = self._make_project_scoped_service(tmp_path, store, sm, meta_store)
+
+        first = await service.send_or_create("proj_a", "hello", client_key="ck-shared")
+        assert first["session_id"] == "sdk-0"
+        # 映射已就绪：项目 B 的调用会先走进程内映射命中的快路径
+        assert service._new_session_client_keys["ck-shared"] == "sdk-0"
+
+        second = await service.send_or_create("proj_b", "hello", client_key="ck-shared")
+
+        assert second["session_id"] == "sdk-1"  # 项目 B 新建，非接回 A
+        assert meta_store.metas["sdk-1"].project_name == "proj_b"
+        assert sm.new_sessions == [("proj_a", "hello"), ("proj_b", "hello")]
+        # 映射被本项目会话覆盖，后续同项目重试命中 B
+        assert service._new_session_client_keys["ck-shared"] == "sdk-1"
+
+        await engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_new_session_client_key_project_scoped_via_db_fallback(self, tmp_path):
+        """清空进程内映射（模拟重启）后，DB 兜底恢复路径同样按项目隔离：
+        项目 A 的 client_key 对项目 B 恢复时视为未命中，在 B 下新建会话。"""
+        from server.agent_runtime.event_log import EventLogStore
+
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        store = EventLogStore(session_factory=factory)
+
+        sm = _FakeSessionManager()
+        meta_store = _FakeMetaStore([])
+        service = self._make_project_scoped_service(tmp_path, store, sm, meta_store)
+
+        first = await service.send_or_create("proj_a", "hello", client_key="ck-shared")
+        assert first["session_id"] == "sdk-0"
+        service._new_session_client_keys.clear()  # 模拟重启：进程内映射丢失
+
+        second = await service.send_or_create("proj_b", "hello", client_key="ck-shared")
+
+        assert second["session_id"] == "sdk-1"  # DB 兜底命中 A 会话但项目不符 → 新建 B
+        assert meta_store.metas["sdk-1"].project_name == "proj_b"
+        assert sm.new_sessions == [("proj_a", "hello"), ("proj_b", "hello")]
+
+        await engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_new_session_client_key_same_project_retry_still_idempotent(self, tmp_path):
+        """同项目内幂等语义不回归：相同 client_key 在同一项目重发，仍命中原会话、
+        不重复建会话（分别经映射快路径与 DB 兜底路径）。"""
+        from server.agent_runtime.event_log import EventLogStore
+
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        store = EventLogStore(session_factory=factory)
+
+        sm = _FakeSessionManager()
+        meta_store = _FakeMetaStore([])
+        service = self._make_project_scoped_service(tmp_path, store, sm, meta_store)
+
+        first = await service.send_or_create("proj_a", "hello", client_key="ck-same")
+        assert first["session_id"] == "sdk-0"
+
+        # 映射快路径命中
+        hit = await service.send_or_create("proj_a", "hello", client_key="ck-same")
+        assert hit["session_id"] == "sdk-0"
+        assert len(sm.new_sessions) == 1
+
+        # 清空映射后 DB 兜底路径同样命中原会话
+        service._new_session_client_keys.clear()
+        recovered = await service.send_or_create("proj_a", "hello", client_key="ck-same")
+        assert recovered["session_id"] == "sdk-0"
+        assert len(sm.new_sessions) == 1  # 全程未重复建会话
+
+        await engine.dispose()
+
     @pytest.mark.asyncio
     async def test_send_or_create_hit_refreshes_lru_position(self, tmp_path):
         """命中进程内映射时刷新 LRU 位置：被频繁重试命中的 key 不因插入顺序
@@ -516,7 +641,7 @@ class TestAssistantServiceMore:
         )
         service._new_session_client_keys["ck-a"] = "sdk-deleted"
 
-        result = await service._find_accepted_new_session("ck-a")  # pyright: ignore[reportPrivateUsage]
+        result = await service._find_accepted_new_session("ck-a", "demo")  # pyright: ignore[reportPrivateUsage]
 
         assert result is None  # 本测试的兜底查询返回 None，不影响本次断言重点
         assert service._new_session_client_keys["ck-a"] == "sdk-fresh"  # 未被误删
@@ -545,7 +670,7 @@ class TestAssistantServiceMore:
             find_new_session_by_client_key=find_new_session_by_client_key,
         )
 
-        result = await service._find_accepted_new_session("ck-b")  # pyright: ignore[reportPrivateUsage]
+        result = await service._find_accepted_new_session("ck-b", "demo")  # pyright: ignore[reportPrivateUsage]
 
         assert result is not None
         assert result["session_id"] == "sdk-old"  # 本次调用仍返回自己查到的权威条目

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -1,4 +1,5 @@
 import asyncio
+import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -30,7 +31,7 @@ class _MultiProjectPM:
     def get_project_path(self, project_name):
         if project_name not in self.valid_projects:
             raise FileNotFoundError(project_name)
-        return Path("/tmp") / project_name
+        return Path(tempfile.gettempdir()) / project_name
 
 
 class _FakeMetaStore:


### PR DESCRIPTION
## 背景

新会话的 `client_key` 幂等查找此前只按键匹配，不校验命中会话的项目归属——与既有会话分支（校验 `meta.project_name` 不符则拒绝）不对称。助手面板为长生命周期单例，切换项目不卸载：在项目 A 触发新会话 `send` 后（服务端已受理但客户端视为失败），切到项目 B 重发相同内容会命中并静默接回 A 的会话，造成跨项目会话串号。

Closes #1138

## 改动

- **后端** `server/agent_runtime/service.py`：`_find_accepted_new_session` 新增 `project_name` 参数，命中后经 `_new_session_matches_project` 校验会话 meta 的项目归属。进程内映射快路径与 DB 兜底两条路径口径一致；不符时视为未命中、在当前项目正常新建（不抛错）。fast-path 陈旧映射清理显式收进 `entry is None` 分支，避免误清对原项目仍有效的映射。
- **前端** `frontend/src/hooks/useAssistantSession.ts`：失败重试的幂等键签名由 `[sessionId, content, images]` 改为 `[projectName, sessionId, content, images]`，切换项目后旧项目缓存的 `clientKey` 自然失效。
- **meta 缺失宽松放行**：`_new_session_matches_project` 在 `meta is None`（异常/已删）时不阻断命中——串号前提是命中会话 meta 存在且项目不同，None 场景无项目归属可泄露，保持既有幂等语义。

同项目内幂等语义不变：受理后的重试仍命中同一会话、不重复建会话。

## 验证

- 后端 `pytest tests/test_assistant_service_more.py`：20 passed（新增 3 例：映射快路径跨项目→新建 B / 清空映射走 DB 兜底跨项目→新建 B / 同项目两路径仍幂等）
- 前端 `pnpm check`：928 tests passed（新增 1 例：rerender 切项目后同内容重发生成新 clientKey）
- `ruff check` / `ruff format --check` / `basedpyright`（0 error）/ `pnpm lint` 全绿
- 已 rebase 到最新 `origin/main`（b13a4237），无重叠冲突


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 调整客户端失败重试的幂等键计算：同内容切换到不同项目时不再复用旧幂等键，避免跨项目错误接续。
  - 调整服务端“创建/复用会话”的幂等查找：跨项目场景下不再命中他项目的已受理会话，需独立新建会话。
- **测试**
  - 新增跨项目会话隔离、缓存/兜底恢复与同项目重试的用例，覆盖进程内命中与数据库兜底两类路径。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->