### PR TITLE
fix(validation): 剧集校验遇非法 content_mode 不再抛异常，改结构化错误

### DIFF
--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -1069,7 +1069,14 @@ class DataValidator:
         # 路径更换（见 docs/adr/0033），resolve_declared_kind 已内置该恒定映射。四个 validator
         # 函数及各自签名（products / reference_mode / language）保留，校验行为不变。
         gen_mode = effective_mode(project=project, episode=episode)
-        kind = resolve_declared_kind(content_mode, gen_mode)
+        try:
+            kind = resolve_declared_kind(content_mode, gen_mode)
+        except ValueError:
+            # content_mode 存在但非法（遗留/脏数据）：resolve_declared_kind 对此 fail-loud
+            # 抛错，但 validator 的契约是把脏数据报告成结构化错误而非让异常传播出去。跳过依赖
+            # 骨架种类的后续检查——没有合法 kind 就无从判断该读 segments/scenes/shots 中哪个。
+            errors.append(f"content_mode 值无效: '{content_mode}'，必须是 {self.VALID_CONTENT_MODES}")
+            return
         if kind == "video_units":
             self._validate_reference_video_script(
                 episode.get("video_units", []),

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -1242,6 +1242,83 @@ class TestSkeletonEntryTypeGuards:
         assert any(array_key in error and "数组" in error for error in result.errors), result.errors
 
 
+class TestInvalidContentModeEpisodeValidation:
+    """content_mode 存在但非法（遗留/脏数据）：resolve_declared_kind 对此 fail-loud 抛 ValueError，
+    但剧集级校验的契约是把脏数据报告成结构化错误，不让异常向外传播。"""
+
+    def test_validate_episode_reports_structured_error_not_crash(self, tmp_path):
+        project_dir = tmp_path / "projects" / "demo"
+        _write_json(project_dir / "project.json", _project_payload("bogus_legacy"))
+        _write_json(
+            project_dir / "scripts" / "episode_1.json",
+            {"episode": 1, "title": "第一集", "segments": []},
+        )
+
+        result = DataValidator(projects_root=str(tmp_path / "projects")).validate_episode("demo", "episode_1.json")
+
+        assert not result.valid
+        assert any("content_mode" in error for error in result.errors), result.errors
+
+    def test_validate_project_tree_reports_structured_error_not_crash(self, tmp_path):
+        payload = _project_payload("bogus_legacy")
+        payload["episodes"] = [{"episode": 1, "title": "x", "script_file": "scripts/episode_1.json"}]
+        project_dir = tmp_path / "projects" / "demo"
+        _write_json(project_dir / "project.json", payload)
+        _write_json(
+            project_dir / "scripts" / "episode_1.json",
+            {"episode": 1, "title": "第一集", "segments": []},
+        )
+
+        result = DataValidator(projects_root=str(tmp_path / "projects")).validate_project_tree(project_dir)
+
+        assert not result.valid
+        assert any("content_mode" in error for error in result.errors), result.errors
+
+    def test_episode_level_invalid_content_mode_also_reported(self, tmp_path):
+        # 项目级 content_mode 合法，但剧集自身声明的 content_mode 非法（覆盖项目级值）：
+        # 同样结构化报错，不抛异常。
+        project_dir = tmp_path / "projects" / "demo"
+        _write_json(project_dir / "project.json", _project_payload("narration"))
+        _write_json(
+            project_dir / "scripts" / "episode_1.json",
+            {"episode": 1, "title": "第一集", "content_mode": "bogus_legacy", "segments": []},
+        )
+
+        result = DataValidator(projects_root=str(tmp_path / "projects")).validate_episode("demo", "episode_1.json")
+
+        assert not result.valid
+        assert any("content_mode" in error for error in result.errors), result.errors
+
+    def test_missing_episode_content_mode_still_falls_back_to_project_value(self, tmp_path):
+        # 回归防线：剧集级 content_mode 完全缺失时仍应回落项目级值 / "narration"，不触发本次改动
+        # 新增的错误分支。
+        project_dir = tmp_path / "projects" / "demo"
+        _write_json(project_dir / "project.json", _project_payload("narration"))
+        _write_json(
+            project_dir / "scripts" / "episode_1.json",
+            {
+                "episode": 1,
+                "title": "第一集",
+                "segments": [
+                    {
+                        "segment_id": "E1S01",
+                        "novel_text": "原文",
+                        "characters_in_segment": ["姜月茴"],
+                        "scenes": ["古宅"],
+                        "props": ["玉佩"],
+                        "image_prompt": "img",
+                        "video_prompt": "vid",
+                        "duration_seconds": 3,
+                    }
+                ],
+            },
+        )
+
+        result = DataValidator(projects_root=str(tmp_path / "projects")).validate_episode("demo", "episode_1.json")
+
+        assert result.valid, result.errors
+
+
 # 骨架种类 → 触发该骨架的 (content_mode, generation_mode)，即 resolve_declared_kind 的逆。
 _KIND_TO_MODES = {
     "segments": ("narration", None),


### PR DESCRIPTION
Closes #1139

## 问题

`lib/data_validator.py::_validate_episode_payload` 调用 `resolve_declared_kind(content_mode, gen_mode)` 时无异常包裹。该函数对 `{"ad", "narration", "drama"}` 之外的 `content_mode` 有意 fail-loud 抛 `ValueError`，导致遗留/脏数据的非法 `content_mode` 不是被上报为校验错误，而是一路未捕获传播出 `validate_episode_file`。

## 改动

- 在 `_validate_episode_payload` 的 `resolve_declared_kind` 调用处包一层 `try/except ValueError`，捕获后追加与项目级同风格的结构化错误 `content_mode 值无效: '...'，必须是 {...}`，随后 `return` 跳过依赖骨架种类的后续检查（无合法 kind 无从判断该读 segments/scenes/shots 哪个数组）。
- `resolve_declared_kind` 本体零改动，fail-loud 契约保持不变（Out of scope）。

## 验证

- 新增 `TestInvalidContentModeEpisodeValidation`（4 个回归测试）：单集校验与 `validate_project_tree` 两条路径均结构化报错不崩溃；剧集级覆盖项目级非法值同样报错；剧集 `content_mode` 缺失仍回落项目级值不误触发新分支。
- `uv run ruff check` / `ruff format --check` / `basedpyright`（0 error）/ `pytest tests/test_data_validator.py`（107 passed）全绿。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 非法的内容模式现在会以结构化校验错误显示，不再导致验证过程崩溃。
  * 项目级和剧集级的非法内容模式均可被正确识别并报告。
  * 内容模式缺失时，仍会正确回退使用项目级配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->