### PR TITLE
fix(studio): 并发刷新项目时不再相互覆盖，编辑与实时事件同时刷新不再丢失更新

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,6 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { API, ConflictError } from "@/api";
-import type { TaskItem } from "@/types";
 
 type JsonResponseOptions = {
   ok?: boolean;
@@ -36,52 +35,6 @@ function mockResponse(options: JsonResponseOptions = {}): Response {
     text: vi.fn().mockResolvedValue(textData),
     blob: vi.fn().mockResolvedValue(blobData),
   } as unknown as Response;
-}
-
-function makeTask(overrides: Partial<TaskItem> = {}): TaskItem {
-  return {
-    task_id: "task-1",
-    project_name: "demo",
-    task_type: "storyboard",
-    media_type: "image",
-    resource_id: "segment-1",
-    script_file: null,
-    payload: {},
-    status: "queued",
-    result: null,
-    error_message: null,
-    cancelled_by: null,
-    provider_id: null,
-    provider_job_id: null,
-    source: "webui",
-    queued_at: "2026-02-01T00:00:00Z",
-    started_at: null,
-    finished_at: null,
-    updated_at: "2026-02-01T00:00:00Z",
-    ...overrides,
-  };
-}
-
-class MockEventSource {
-  onerror: ((event: Event) => void) | null = null;
-  close = vi.fn();
-  private readonly listeners = new Map<string, Array<(event: Event) => void>>();
-
-  constructor(public readonly url: string) {}
-
-  addEventListener(type: string, cb: (event: Event) => void): void {
-    const list = this.listeners.get(type) ?? [];
-    list.push(cb);
-    this.listeners.set(type, list);
-  }
-
-  emit(type: string, data: string): void {
-    const event = { data } as MessageEvent;
-    const listeners = this.listeners.get(type) ?? [];
-    for (const listener of listeners) {
-      listener(event as unknown as Event);
-    }
-  }
 }
 
 describe("API", () => {
@@ -850,77 +803,6 @@ describe("API", () => {
 
         await expect(API.downloadDiagnostics()).rejects.toThrow();
       });
-    });
-  });
-
-  describe("openTaskStream", () => {
-    it("builds stream URL, dispatches events and forwards onError", () => {
-      const instances: MockEventSource[] = [];
-      class EventSourceMock extends MockEventSource {
-        constructor(url: string) {
-          super(url);
-          instances.push(this);
-        }
-      }
-      vi.stubGlobal("EventSource", EventSourceMock as unknown as typeof EventSource);
-
-      const onSnapshot = vi.fn();
-      const onTask = vi.fn();
-      const onError = vi.fn();
-      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-
-      const source = API.openTaskStream({
-        projectName: "demo",
-        lastEventId: "42",
-        onSnapshot,
-        onTask,
-        onError,
-      });
-
-      expect(instances[0].url).toBe(
-        "/api/v1/tasks/stream?project_name=demo&last_event_id=42",
-      );
-
-      const es = instances[0];
-      es.emit(
-        "snapshot",
-        JSON.stringify({
-          tasks: [makeTask()],
-          stats: { queued: 1, running: 0, succeeded: 0, failed: 0, total: 1 },
-        }),
-      );
-      es.emit(
-        "task",
-        JSON.stringify({
-          action: "updated",
-          task: makeTask({ status: "running" }),
-          stats: { queued: 0, running: 1, succeeded: 0, failed: 0, total: 1 },
-        }),
-      );
-      es.emit("snapshot", "{invalid json");
-
-      expect(onSnapshot).toHaveBeenCalledTimes(1);
-      expect(onTask).toHaveBeenCalledTimes(1);
-      expect(consoleError).toHaveBeenCalled();
-
-      const errEvent = new Event("error");
-      es.onerror?.(errEvent);
-      expect(onError).toHaveBeenCalledWith(errEvent);
-      expect(source).toBe(es as unknown as EventSource);
-    });
-
-    it("ignores invalid lastEventId", () => {
-      const instances: MockEventSource[] = [];
-      class EventSourceMock extends MockEventSource {
-        constructor(url: string) {
-          super(url);
-          instances.push(this);
-        }
-      }
-      vi.stubGlobal("EventSource", EventSourceMock as unknown as typeof EventSource);
-
-      API.openTaskStream({ projectName: "demo", lastEventId: "0" });
-      expect(instances[0].url).toBe("/api/v1/tasks/stream?project_name=demo");
     });
   });
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -127,26 +127,6 @@ export interface ShotUploadResult {
   asset_fingerprints: Record<string, number>;
 }
 
-/** Options for {@link API.openTaskStream}. */
-export interface TaskStreamOptions {
-  projectName?: string;
-  lastEventId?: number | string;
-  onSnapshot?: (payload: TaskStreamSnapshotPayload, event: MessageEvent) => void;
-  onTask?: (payload: TaskStreamTaskPayload, event: MessageEvent) => void;
-  onError?: (event: Event) => void;
-}
-
-export interface TaskStreamSnapshotPayload {
-  tasks: TaskItem[];
-  stats: TaskStats;
-}
-
-export interface TaskStreamTaskPayload {
-  action: "created" | "updated";
-  task: TaskItem;
-  stats: TaskStats;
-}
-
 export interface ProjectEventStreamOptions {
   projectName: string;
   onSnapshot?: (payload: ProjectEventSnapshotPayload, event: MessageEvent) => void;
@@ -1406,57 +1386,6 @@ class API {
       `/projects/${encodeURIComponent(projectName)}/tasks/cancel-all`,
       { method: "POST" }
     );
-  }
-
-  static openTaskStream(options: TaskStreamOptions = {}): EventSource {
-    const params = new URLSearchParams();
-    if (options.projectName)
-      params.append("project_name", options.projectName);
-    const parsedLastEventId = Number(options.lastEventId);
-    if (Number.isFinite(parsedLastEventId) && parsedLastEventId > 0) {
-      params.append("last_event_id", String(parsedLastEventId));
-    }
-
-    const query = params.toString();
-    const url = withAuthQuery(`${API_BASE}/tasks/stream${query ? "?" + query : ""}`);
-    const source = new EventSource(url);
-
-    const parsePayload = (event: MessageEvent): unknown => {
-      try {
-        return JSON.parse((event.data as string) || "{}");
-      } catch (err) {
-        console.error("解析 SSE 数据失败:", err, event.data);
-        return null;
-      }
-    };
-
-    source.addEventListener("snapshot", (event) => {
-      const payload = parsePayload(event);
-      if (payload && typeof options.onSnapshot === "function") {
-        options.onSnapshot(
-          payload as TaskStreamSnapshotPayload,
-          event
-        );
-      }
-    });
-
-    source.addEventListener("task", (event) => {
-      const payload = parsePayload(event);
-      if (payload && typeof options.onTask === "function") {
-        options.onTask(
-          payload as TaskStreamTaskPayload,
-          event
-        );
-      }
-    });
-
-    source.onerror = (event: Event) => {
-      if (typeof options.onError === "function") {
-        options.onError(event);
-      }
-    };
-
-    return source;
   }
 
   static openProjectEventStream(options: ProjectEventStreamOptions): EventSource {

--- a/frontend/src/components/canvas/OverviewCanvas.tsx
+++ b/frontend/src/components/canvas/OverviewCanvas.tsx
@@ -78,15 +78,10 @@ export function OverviewCanvas({ projectName, projectData }: OverviewCanvasProps
     wasWelcomeRef.current = isWelcome;
   }, [projectData]);
 
+  // 在途合并 + 失败留旧收敛于 projects-store；此处仅表达刷新意图，忽略返回值。
   const refreshProject = useCallback(
     async () => {
-      const res = await API.getProject(projectName);
-      useProjectsStore.getState().setCurrentProject(
-        projectName,
-        res.project,
-        res.scripts ?? {},
-        res.asset_fingerprints,
-      );
+      await useProjectsStore.getState().refreshProject(projectName);
     },
     [projectName],
   );

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -132,26 +132,15 @@ export function StudioCanvasRouter() {
   const generatingPropNames = useActiveResourceIds("prop", currentProjectName);
   const generatingProductNames = useActiveResourceIds("product", currentProjectName);
 
-  // 刷新项目数据；返回本地 store 是否已同步成功，供调用方决定是否推进依赖新顺序的 UI 状态
-  const refreshProject = useCallback(async (invalidateKeys: string[] = []): Promise<boolean> => {
-    if (!currentProjectName) return false;
-    try {
-      const res = await API.getProject(currentProjectName);
-      useProjectsStore.getState().setCurrentProject(
-        currentProjectName,
-        res.project,
-        res.scripts ?? {},
-        res.asset_fingerprints,
-      );
-      if (invalidateKeys.length > 0) {
-        useAppStore.getState().invalidateEntities(invalidateKeys);
-      }
-      return true;
-    } catch {
-      // 静默失败：多数调用方只做尽力刷新，由返回值交调用方自行判断
-      return false;
-    }
-  }, [currentProjectName]);
+  // 刷新项目数据；返回本地 store 是否已同步成功，供调用方决定是否推进依赖新顺序的 UI 状态。
+  // 在途合并 + 失败留旧收敛于 projects-store 的 refreshProject，此处仅表达意图。
+  const refreshProject = useCallback(
+    (invalidateKeys: string[] = []): Promise<boolean> =>
+      currentProjectName
+        ? useProjectsStore.getState().refreshProject(currentProjectName, { invalidateKeys })
+        : Promise.resolve(false),
+    [currentProjectName],
+  );
 
   // ---- Timeline action callbacks ----
   // These receive scriptFile from TimelineCanvas so they always use the active episode's script.

--- a/frontend/src/hooks/useProjectEventsSSE.test.tsx
+++ b/frontend/src/hooks/useProjectEventsSSE.test.tsx
@@ -23,6 +23,35 @@ function renderHarness(path = "/") {
   );
 }
 
+type GetProjectResult = Awaited<ReturnType<typeof API.getProject>>;
+
+// 手动可控的 deferred promise，用于把 getProject 卡在「在途」状态精确编排两批
+// onChanges 的重叠时序（对齐 projects-store.test.ts 的既有模式）。
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeGetProjectResult(title: string): GetProjectResult {
+  return {
+    project: {
+      title,
+      content_mode: "narration",
+      style: "Anime",
+      episodes: [],
+      characters: { hero: { description: "勇者" } },
+      scenes: { 酒馆: { description: "小镇酒馆" } },
+      props: {},
+    },
+    scripts: {},
+  };
+}
+
 describe("useProjectEventsSSE", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -576,6 +605,96 @@ describe("useProjectEventsSSE", () => {
     });
     expect(screen.getByTestId("location")).toHaveTextContent("/characters");
     expect(useAppStore.getState().scrollTarget).toBeNull();
+  });
+
+  it("does not navigate to a stale focus target once a later SSE batch has queued a newer one", async () => {
+    // 复现:两批 onChanges 重叠到达,第一批的 refreshProject 仍在途(getProject 未落定)时
+    // 第二批已到达并把 queuedFocusRef 改写为自己的目标。第一批落定后不应消费已被取代的
+    // ref 值提前导航;要等第二批自己那一轮落定才导航到第二批的目标。
+    let capturedOptions: ProjectEventStreamOptions | undefined;
+    vi.spyOn(API, "openProjectEventStream").mockImplementation((options) => {
+      capturedOptions = options;
+      return { close: vi.fn() } as unknown as EventSource;
+    });
+
+    const d1 = deferred<GetProjectResult>();
+    const d2 = deferred<GetProjectResult>();
+    const getProjectSpy = vi
+      .spyOn(API, "getProject")
+      .mockReturnValueOnce(d1.promise)
+      .mockReturnValueOnce(d2.promise);
+
+    renderHarness("/");
+
+    // 第一批:聚焦角色 hero → /characters。发起后 getProject 卡在在途(d1 未 resolve)。
+    act(() => {
+      capturedOptions?.onChanges?.(
+        {
+          project_name: "demo",
+          batch_id: "batch-stale",
+          fingerprint: "fp-stale-1",
+          generated_at: "2026-03-01T00:00:00Z",
+          source: "filesystem",
+          changes: [
+            {
+              entity_type: "character",
+              action: "created",
+              entity_id: "hero",
+              label: "角色「hero」",
+              focus: { pane: "characters", anchor_type: "character", anchor_id: "hero" },
+              important: true,
+            },
+          ],
+        },
+        new MessageEvent("changes"),
+      );
+    });
+    expect(getProjectSpy).toHaveBeenCalledTimes(1);
+
+    // 第二批在第一批仍在途时到达:聚焦场景 酒馆 → /scenes，覆盖 queuedFocusRef。
+    act(() => {
+      capturedOptions?.onChanges?.(
+        {
+          project_name: "demo",
+          batch_id: "batch-stale-2",
+          fingerprint: "fp-stale-2",
+          generated_at: "2026-03-01T00:00:00Z",
+          source: "filesystem",
+          changes: [
+            {
+              entity_type: "scene",
+              action: "updated",
+              entity_id: "酒馆",
+              label: "场景「酒馆」",
+              focus: { pane: "scenes", anchor_type: "scene", anchor_id: "酒馆" },
+              important: true,
+            },
+          ],
+        },
+        new MessageEvent("changes"),
+      );
+    });
+    // 在途合并:第二批只是排队，不会立即多发一次请求。
+    expect(getProjectSpy).toHaveBeenCalledTimes(1);
+
+    // 第一轮落定：不应提前导航到已被取代的第一批目标（/characters）。
+    await act(async () => {
+      d1.resolve(makeGetProjectResult("R1"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("location")).toHaveTextContent("/");
+
+    // 排队轮（第二批）落定：导航到第二批真正的目标（/scenes），且只发了这一次补充请求。
+    await act(async () => {
+      d2.resolve(makeGetProjectResult("R2"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/scenes");
+    });
+    expect(getProjectSpy).toHaveBeenCalledTimes(2);
   });
 
   it("extracts asset_fingerprints from SSE changes and updates store", async () => {

--- a/frontend/src/hooks/useProjectEventsSSE.test.tsx
+++ b/frontend/src/hooks/useProjectEventsSSE.test.tsx
@@ -607,6 +607,91 @@ describe("useProjectEventsSSE", () => {
     expect(useAppStore.getState().scrollTarget).toBeNull();
   });
 
+  it("一次不带聚焦目标的刷新（如 onSnapshot）落定时，不应抢先消费更晚一批 onChanges 排队的目标", async () => {
+    // onSnapshot 触发的 refreshProject() 不设置新的聚焦目标，落定后按旧逻辑会
+    // 无条件 flushQueuedFocus()。若它在途期间，一批带真实目标的 onChanges 已经
+    // 到达并排队（改写了 queuedFocusRef，但数据要等它自己那一轮 getProject 完成
+    // 才落库），onSnapshot 落定时若仍无条件消费 ref，会拿着尚未落库的目标提前
+    // 导航，且清空 ref 后 onChanges 那一批之后不再触发导航。
+    let capturedOptions: ProjectEventStreamOptions | undefined;
+    vi.spyOn(API, "openProjectEventStream").mockImplementation((options) => {
+      capturedOptions = options;
+      return { close: vi.fn() } as unknown as EventSource;
+    });
+
+    const d1 = deferred<GetProjectResult>();
+    const d2 = deferred<GetProjectResult>();
+    const getProjectSpy = vi
+      .spyOn(API, "getProject")
+      .mockReturnValueOnce(d1.promise)
+      .mockReturnValueOnce(d2.promise);
+
+    renderHarness("/");
+
+    // 建立初始 fingerprint 基线（首次 onSnapshot 不触发刷新）。
+    act(() => {
+      capturedOptions?.onSnapshot?.(
+        { project_name: "demo", fingerprint: "fp-a", generated_at: "2026-03-01T00:00:00Z" },
+        new MessageEvent("snapshot"),
+      );
+    });
+    expect(getProjectSpy).not.toHaveBeenCalled();
+
+    // fingerprint 变化触发一次不带聚焦目标的刷新，getProject 卡在在途（d1 未 resolve）。
+    act(() => {
+      capturedOptions?.onSnapshot?.(
+        { project_name: "demo", fingerprint: "fp-b", generated_at: "2026-03-01T00:00:01Z" },
+        new MessageEvent("snapshot"),
+      );
+    });
+    expect(getProjectSpy).toHaveBeenCalledTimes(1);
+
+    // 在途期间，一批带真实聚焦目标的 onChanges 到达并排队。
+    act(() => {
+      capturedOptions?.onChanges?.(
+        {
+          project_name: "demo",
+          batch_id: "batch-race",
+          fingerprint: "fp-race",
+          generated_at: "2026-03-01T00:00:00Z",
+          source: "filesystem",
+          changes: [
+            {
+              entity_type: "character",
+              action: "created",
+              entity_id: "hero",
+              label: "角色「hero」",
+              focus: { pane: "characters", anchor_type: "character", anchor_id: "hero" },
+              important: true,
+            },
+          ],
+        },
+        new MessageEvent("changes"),
+      );
+    });
+    // 在途合并：这批只是排队，不会立即多发一次请求。
+    expect(getProjectSpy).toHaveBeenCalledTimes(1);
+
+    // onSnapshot 那一轮落定：不应提前导航到 onChanges 排队的目标（/characters）。
+    await act(async () => {
+      d1.resolve(makeGetProjectResult("R1"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("location")).toHaveTextContent("/");
+
+    // onChanges 排队的那一轮落定：导航到它真正的目标，且只补发了这一次请求。
+    await act(async () => {
+      d2.resolve(makeGetProjectResult("R2"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/characters");
+    });
+    expect(getProjectSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("does not navigate to a stale focus target once a later SSE batch has queued a newer one", async () => {
     // 复现:两批 onChanges 重叠到达,第一批的 refreshProject 仍在途(getProject 未落定)时
     // 第二批已到达并把 queuedFocusRef 改写为自己的目标。第一批落定后不应消费已被取代的

--- a/frontend/src/hooks/useProjectEventsSSE.ts
+++ b/frontend/src/hooks/useProjectEventsSSE.ts
@@ -174,29 +174,31 @@ export function useProjectEventsSSE(projectName?: string | null): void {
     executeFocus(target);
   }, [executeFocus]);
 
-  const refreshProject = useCallback(
-    async (ownFocusTarget?: WorkspaceNotificationTarget | null) => {
-      if (!projectName) return;
-      // 在途合并逻辑（单飞 + 排队再跑一轮 + 失败留旧）已下沉到 projects-store.refreshProject；
-      // 此处只保留 SSE 专属包装：失败时告警、刷新落定后消费排队的聚焦目标。
-      //
-      // refreshProject 现在按轮次各自 resolve（见 projects-store），因此本次调用可能在
-      // 更晚一批 changes 已把 queuedFocusRef 改写为它自己的目标之后才落定——那个新目标
-      // 对应的数据要等它自己那一轮 getProject 完成才会写入 store。此时若仍消费 ref 里的
-      // 值，会拿着尚未落库的目标提前导航/滚动，且消费后 ref 被清空，那一批之后也不会
-      // 再重试。带 ownFocusTarget 时，只在 ref 仍是自己设置的那个值时才消费；已被更晚一批
-      // 取代则跳过——由那一批自己的调用在其对应轮次落定后消费。
-      await useProjectsStore.getState().refreshProject(projectName, {
-        onError: (err) =>
-          pushNotification(tRef.current("project_sync_failed", { message: errMsg(err) }), "warning"),
-      });
-      if (ownFocusTarget !== undefined && queuedFocusRef.current !== ownFocusTarget) {
-        return;
-      }
-      flushQueuedFocus();
-    },
-    [flushQueuedFocus, projectName, pushNotification],
-  );
+  const refreshProject = useCallback(async () => {
+    if (!projectName) return;
+    // 在途合并逻辑（单飞 + 排队再跑一轮 + 失败留旧）已下沉到 projects-store.refreshProject；
+    // 此处只保留 SSE 专属包装：失败时告警、刷新落定后消费排队的聚焦目标。
+    //
+    // refreshProject 现在按轮次各自 resolve（见 projects-store），因此本次调用落定时，
+    // 可能已有更晚一批 onChanges 把 queuedFocusRef 改写为它自己的目标——那个新目标
+    // 对应的数据要等它自己那一轮 getProject 完成才会写入 store。无条件消费 ref 会拿着
+    // 尚未落库的目标提前导航/滚动，且消费后 ref 被清空，那一批之后也不会再重试；这个
+    // 风险不局限于「本次调用自己设置了新目标」的场景——不设置新目标的调用（onSnapshot、
+    // webui 来源、draftHandled 分支）同样可能在等待落定期间被别的调用改写 ref。
+    //
+    // 因此改为在发起请求前对 ref 拍快照，落定后只在 ref 仍等于快照时才消费——说明这段
+    // 等待期间没有别的调用改写过它，可以放心视为「跟自己这一轮对应」；ref 已变则跳过，
+    // 交由改写它的那次调用在自己对应轮次落定后消费。
+    const focusSnapshot = queuedFocusRef.current;
+    await useProjectsStore.getState().refreshProject(projectName, {
+      onError: (err) =>
+        pushNotification(tRef.current("project_sync_failed", { message: errMsg(err) }), "warning"),
+    });
+    if (queuedFocusRef.current !== focusSnapshot) {
+      return;
+    }
+    flushQueuedFocus();
+  }, [flushQueuedFocus, projectName, pushNotification]);
 
   useEffect(() => {
     lastFingerprintRef.current = null;
@@ -265,12 +267,6 @@ export function useProjectEventsSSE(projectName?: string | null): void {
             }
           }
 
-          // 本批 changes 若设置了新的聚焦目标，记入本地变量随本次 refreshProject 一并
-          // 传递——用于落定后核对 queuedFocusRef 是否仍是本批设置的那个值（未被更晚一批
-          // 覆盖），而不是无条件消费 ref 当前值。未设置新目标（如 draftHandled）时保持
-          // undefined，refreshProject 退回旧的「落定即消费」行为。
-          let ownFocusTarget: WorkspaceNotificationTarget | null | undefined;
-
           if (payload.source !== "webui") {
             // Draft 事件 — 自动导航到剧集预处理 Tab
             let draftHandled = false;
@@ -305,12 +301,11 @@ export function useProjectEventsSSE(projectName?: string | null): void {
                   })
                   .find(Boolean) ?? null;
 
-              ownFocusTarget = isWorkspaceEditing() ? null : nextFocusTarget;
-              queuedFocusRef.current = ownFocusTarget;
+              queuedFocusRef.current = isWorkspaceEditing() ? null : nextFocusTarget;
             }
           }
 
-          void refreshProject(ownFocusTarget);
+          void refreshProject();
 
           // Refresh cost data when generation completes
           const hasGenerationEvent = payload.changes.some((c) =>

--- a/frontend/src/hooks/useProjectEventsSSE.ts
+++ b/frontend/src/hooks/useProjectEventsSSE.ts
@@ -131,7 +131,6 @@ export function useProjectEventsSSE(projectName?: string | null): void {
     tRef.current = t;
   }, [t]);
   const [, setLocation] = useLocation();
-  const setCurrentProject = useProjectsStore((s) => s.setCurrentProject);
   const invalidateEntities = useAppStore((s) => s.invalidateEntities);
   const triggerScrollTo = useAppStore((s) => s.triggerScrollTo);
   const clearScrollTarget = useAppStore((s) => s.clearScrollTarget);
@@ -145,8 +144,6 @@ export function useProjectEventsSSE(projectName?: string | null): void {
   const sourceRef = useRef<EventSource | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastFingerprintRef = useRef<string | null>(null);
-  const refreshingRef = useRef(false);
-  const needsRefreshRef = useRef(false);
   const queuedFocusRef = useRef<WorkspaceNotificationTarget | null>(null);
   // 项目已被删除（收到终止事件）：停止断线重连循环，不再对已删项目周期性发起请求。
   const terminatedRef = useRef(false);
@@ -179,41 +176,18 @@ export function useProjectEventsSSE(projectName?: string | null): void {
 
   const refreshProject = useCallback(async () => {
     if (!projectName) return;
-    if (refreshingRef.current) {
-      needsRefreshRef.current = true;
-      return;
-    }
-
-    refreshingRef.current = true;
-    try {
-      // while 循环替代递归自调用，规避 react-hooks/immutability 的自引用限制。
-      // API 异常单独捕获，确保失败路径也消费排队中的 needsRefreshRef
-      // （与旧递归实现的"成功或失败都会再跑一轮"语义一致）。
-      let again = true;
-      while (again) {
-        again = false;
-        try {
-          const res = await API.getProject(projectName);
-          setCurrentProject(projectName, res.project, res.scripts ?? {}, res.asset_fingerprints);
-        } catch (err) {
-          pushNotification(tRef.current("project_sync_failed", { message: errMsg(err) }), "warning");
-        }
-        if (needsRefreshRef.current) {
-          needsRefreshRef.current = false;
-          again = true;
-        }
-      }
-    } finally {
-      refreshingRef.current = false;
-    }
+    // 在途合并逻辑（单飞 + 排队再跑一轮 + 失败留旧）已下沉到 projects-store.refreshProject；
+    // 此处只保留 SSE 专属包装：失败时告警、刷新落定后消费排队的聚焦目标。
+    await useProjectsStore.getState().refreshProject(projectName, {
+      onError: (err) =>
+        pushNotification(tRef.current("project_sync_failed", { message: errMsg(err) }), "warning"),
+    });
     flushQueuedFocus();
-  }, [flushQueuedFocus, projectName, pushNotification, setCurrentProject]);
+  }, [flushQueuedFocus, projectName, pushNotification]);
 
   useEffect(() => {
     lastFingerprintRef.current = null;
     queuedFocusRef.current = null;
-    needsRefreshRef.current = false;
-    refreshingRef.current = false;
     terminatedRef.current = false;
     clearScrollTarget();
     clearWorkspaceNotifications();

--- a/frontend/src/hooks/useProjectEventsSSE.ts
+++ b/frontend/src/hooks/useProjectEventsSSE.ts
@@ -174,16 +174,29 @@ export function useProjectEventsSSE(projectName?: string | null): void {
     executeFocus(target);
   }, [executeFocus]);
 
-  const refreshProject = useCallback(async () => {
-    if (!projectName) return;
-    // 在途合并逻辑（单飞 + 排队再跑一轮 + 失败留旧）已下沉到 projects-store.refreshProject；
-    // 此处只保留 SSE 专属包装：失败时告警、刷新落定后消费排队的聚焦目标。
-    await useProjectsStore.getState().refreshProject(projectName, {
-      onError: (err) =>
-        pushNotification(tRef.current("project_sync_failed", { message: errMsg(err) }), "warning"),
-    });
-    flushQueuedFocus();
-  }, [flushQueuedFocus, projectName, pushNotification]);
+  const refreshProject = useCallback(
+    async (ownFocusTarget?: WorkspaceNotificationTarget | null) => {
+      if (!projectName) return;
+      // 在途合并逻辑（单飞 + 排队再跑一轮 + 失败留旧）已下沉到 projects-store.refreshProject；
+      // 此处只保留 SSE 专属包装：失败时告警、刷新落定后消费排队的聚焦目标。
+      //
+      // refreshProject 现在按轮次各自 resolve（见 projects-store），因此本次调用可能在
+      // 更晚一批 changes 已把 queuedFocusRef 改写为它自己的目标之后才落定——那个新目标
+      // 对应的数据要等它自己那一轮 getProject 完成才会写入 store。此时若仍消费 ref 里的
+      // 值，会拿着尚未落库的目标提前导航/滚动，且消费后 ref 被清空，那一批之后也不会
+      // 再重试。带 ownFocusTarget 时，只在 ref 仍是自己设置的那个值时才消费；已被更晚一批
+      // 取代则跳过——由那一批自己的调用在其对应轮次落定后消费。
+      await useProjectsStore.getState().refreshProject(projectName, {
+        onError: (err) =>
+          pushNotification(tRef.current("project_sync_failed", { message: errMsg(err) }), "warning"),
+      });
+      if (ownFocusTarget !== undefined && queuedFocusRef.current !== ownFocusTarget) {
+        return;
+      }
+      flushQueuedFocus();
+    },
+    [flushQueuedFocus, projectName, pushNotification],
+  );
 
   useEffect(() => {
     lastFingerprintRef.current = null;
@@ -252,6 +265,12 @@ export function useProjectEventsSSE(projectName?: string | null): void {
             }
           }
 
+          // 本批 changes 若设置了新的聚焦目标，记入本地变量随本次 refreshProject 一并
+          // 传递——用于落定后核对 queuedFocusRef 是否仍是本批设置的那个值（未被更晚一批
+          // 覆盖），而不是无条件消费 ref 当前值。未设置新目标（如 draftHandled）时保持
+          // undefined，refreshProject 退回旧的「落定即消费」行为。
+          let ownFocusTarget: WorkspaceNotificationTarget | null | undefined;
+
           if (payload.source !== "webui") {
             // Draft 事件 — 自动导航到剧集预处理 Tab
             let draftHandled = false;
@@ -286,11 +305,12 @@ export function useProjectEventsSSE(projectName?: string | null): void {
                   })
                   .find(Boolean) ?? null;
 
-              queuedFocusRef.current = isWorkspaceEditing() ? null : nextFocusTarget;
+              ownFocusTarget = isWorkspaceEditing() ? null : nextFocusTarget;
+              queuedFocusRef.current = ownFocusTarget;
             }
           }
 
-          void refreshProject();
+          void refreshProject(ownFocusTarget);
 
           // Refresh cost data when generation completes
           const hasGenerationEvent = payload.changes.some((c) =>

--- a/frontend/src/stores/projects-store.test.ts
+++ b/frontend/src/stores/projects-store.test.ts
@@ -161,6 +161,37 @@ describe("projects-store refreshProject", () => {
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("重排后");
   });
 
+  it("排队期间被更晚的不同项目请求取代：被取代的调用方立即收到 false，不与新项目的结果混同", async () => {
+    const dA = deferred<GetProjectResult>();
+    const dC = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject").mockReturnValueOnce(dA.promise).mockReturnValueOnce(dC.promise);
+
+    const store = useProjectsStore.getState();
+    const pA = store.refreshProject("A"); // 发起中
+    const pB = store.refreshProject("B"); // 排队 → queuedName = B
+    const pC = store.refreshProject("C"); // 排队期间到达不同项目：B 被 C 取代
+
+    // B 的调用方无需等 A / C 落定，在被取代的一刻就立即收到 false——
+    // 它请求的项目从未被真正拉取过，不能被并入 C 的结果。
+    const okB = await pB;
+    expect(okB).toBe(false);
+    // 只发起了 A 的请求；B 被取代时尚未轮到它，不产生任何请求。
+    expect(API.getProject).toHaveBeenCalledTimes(1);
+
+    dA.resolve(makeResult("A-数据"));
+    await flush();
+    // A 的响应到达，但排队目标已是 C：不提交（既有行为），且已发起 C 的请求。
+    expect(useProjectsStore.getState().currentProjectData?.title).not.toBe("A-数据");
+    expect(API.getProject).toHaveBeenCalledTimes(2);
+
+    dC.resolve(makeResult("C-数据"));
+    const [okA, okC] = await Promise.all([pA, pC]);
+    expect(okA).toBe(false);
+    expect(okC).toBe(true);
+    expect(useProjectsStore.getState().currentProjectName).toBe("C");
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("C-数据");
+  });
+
   it("跨项目合并：A 在途时排队刷新 B，A 的响应不写入 store（避免覆盖排队中的 B）", async () => {
     useProjectsStore.getState().setCurrentProject("B", makeProject("B-旧"), {}, {});
     const dA = deferred<GetProjectResult>();

--- a/frontend/src/stores/projects-store.test.ts
+++ b/frontend/src/stores/projects-store.test.ts
@@ -112,7 +112,7 @@ describe("projects-store refreshProject", () => {
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("R2");
   });
 
-  it("首轮失败、排队轮成功时用新值替换旧值并返回 true", async () => {
+  it("首轮失败、排队轮成功时用新值替换旧值；各调用方返回自己那一轮的结果", async () => {
     useProjectsStore.getState().setCurrentProject("demo", makeProject("旧"), {}, {});
     const d1 = deferred<GetProjectResult>();
     const d2 = deferred<GetProjectResult>();
@@ -129,9 +129,36 @@ describe("projects-store refreshProject", () => {
 
     d2.resolve(makeResult("新"));
     const [r1, r2] = await Promise.all([p1, p2]);
-    // 返回最后一轮结果（成功）
-    expect([r1, r2]).toEqual([true, true]);
+    // 首轮调用方拿到自己那一轮的真实结果（失败），不因排队轮后续成功被覆盖；
+    // 排队轮调用方拿到自己那一轮的结果（成功）。
+    expect(r1).toBe(false);
+    expect(r2).toBe(true);
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("新");
+  });
+
+  it("首轮成功、排队轮失败时，首轮调用方仍返回 true（不被无关的后续轮次拖累）", async () => {
+    const d1 = deferred<GetProjectResult>();
+    const d2 = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject").mockReturnValueOnce(d1.promise).mockReturnValueOnce(d2.promise);
+
+    const store = useProjectsStore.getState();
+    // 例如 handleMoveShot：重排后发起刷新，依赖返回值推进选中态。
+    const pMoveShot = store.refreshProject("demo");
+    // 合并期间到达的另一意图（如 SSE 刷新），随后失败。
+    const pSse = store.refreshProject("demo");
+
+    d1.resolve(makeResult("重排后"));
+    await flush();
+    // 首轮已成功写入
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("重排后");
+
+    d2.reject(new Error("sse round fail"));
+    const [okMoveShot, okSse] = await Promise.all([pMoveShot, pSse]);
+    // 首轮调用方拿到自己那一轮的真实结果（成功），不因排队轮后续失败被覆盖为 false。
+    expect(okMoveShot).toBe(true);
+    expect(okSse).toBe(false);
+    // 失败留旧：store 仍保留首轮写入的数据，不因排队轮失败被清空或回滚。
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("重排后");
   });
 
   it("跨项目合并：A 在途时排队刷新 B，A 的响应不写入 store（避免覆盖排队中的 B）", async () => {

--- a/frontend/src/stores/projects-store.test.ts
+++ b/frontend/src/stores/projects-store.test.ts
@@ -134,6 +134,49 @@ describe("projects-store refreshProject", () => {
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("新");
   });
 
+  it("跨项目合并：A 在途时排队刷新 B，A 的响应不写入 store（避免覆盖排队中的 B）", async () => {
+    useProjectsStore.getState().setCurrentProject("B", makeProject("B-旧"), {}, {});
+    const dA = deferred<GetProjectResult>();
+    const dB = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject").mockReturnValueOnce(dA.promise).mockReturnValueOnce(dB.promise);
+
+    const store = useProjectsStore.getState();
+    const pA = store.refreshProject("A");
+    const pB = store.refreshProject("B"); // 合并 → 排队到不同名称
+
+    dA.resolve(makeResult("A-数据"));
+    await flush();
+    // A 的响应到达，但排队目标已是不同项目 B：不提交，store 仍是 B 的旧数据
+    expect(useProjectsStore.getState().currentProjectName).toBe("B");
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-旧");
+
+    dB.reject(new Error("B failed"));
+    const [okA, okB] = await Promise.all([pA, pB]);
+    expect(okA).toBe(false);
+    expect(okB).toBe(false);
+    // B 轮失败：留旧，仍是 B 的旧数据，绝不能变成 A 的数据
+    expect(useProjectsStore.getState().currentProjectName).toBe("B");
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-旧");
+  });
+
+  it("排队轮 onError：首轮无回调、排队轮有回调且失败时通知排队轮回调", async () => {
+    const d1 = deferred<GetProjectResult>();
+    const d2 = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject").mockReturnValueOnce(d1.promise).mockReturnValueOnce(d2.promise);
+    const onError2 = vi.fn();
+
+    const store = useProjectsStore.getState();
+    const p1 = store.refreshProject("demo"); // 首轮无 onError
+    const p2 = store.refreshProject("demo", { onError: onError2 }); // 排队轮带 onError
+
+    d1.resolve(makeResult("R1"));
+    await flush();
+    const err = new Error("round2 fail");
+    d2.reject(err);
+    await Promise.all([p1, p2]);
+    expect(onError2).toHaveBeenCalledWith(err);
+  });
+
   it("合并期间累积 invalidateKeys：排队轮成功后一并失效", async () => {
     const d1 = deferred<GetProjectResult>();
     const d2 = deferred<GetProjectResult>();

--- a/frontend/src/stores/projects-store.test.ts
+++ b/frontend/src/stores/projects-store.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { API } from "@/api";
+import { useAppStore } from "@/stores/app-store";
+import { useProjectsStore } from "@/stores/projects-store";
+import type { ProjectData } from "@/types";
+
+type GetProjectResult = Awaited<ReturnType<typeof API.getProject>>;
+
+function makeProject(title: string): ProjectData {
+  return {
+    title,
+    content_mode: "narration",
+    style: "Anime",
+    episodes: [],
+    characters: {},
+    scenes: {},
+    props: {},
+  };
+}
+
+function makeResult(title: string, fingerprints: Record<string, number> = {}): GetProjectResult {
+  return { project: makeProject(title), scripts: {}, asset_fingerprints: fingerprints };
+}
+
+// 手动可控的 deferred promise，用于把 getProject 卡在「在途」状态精确编排合并时序。
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// 冲刷 microtask + timer 队列，让在途刷新的续跑推进到下一次 await。
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("projects-store refreshProject", () => {
+  beforeEach(() => {
+    useProjectsStore.setState(useProjectsStore.getInitialState(), true);
+    useAppStore.setState(useAppStore.getInitialState(), true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("空 name 直接返回 false，不发请求", async () => {
+    const spy = vi.spyOn(API, "getProject");
+    const ok = await useProjectsStore.getState().refreshProject("");
+    expect(ok).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("成功时写入 currentProject 并返回 true", async () => {
+    vi.spyOn(API, "getProject").mockResolvedValue(makeResult("Demo", { "a.png": 1 }));
+    const ok = await useProjectsStore.getState().refreshProject("demo");
+    expect(ok).toBe(true);
+    const s = useProjectsStore.getState();
+    expect(s.currentProjectName).toBe("demo");
+    expect(s.currentProjectData?.title).toBe("Demo");
+    expect(s.getAssetFingerprint("a.png")).toBe(1);
+  });
+
+  it("成功后按 invalidateKeys 失效实体版本", async () => {
+    vi.spyOn(API, "getProject").mockResolvedValue(makeResult("Demo"));
+    await useProjectsStore
+      .getState()
+      .refreshProject("demo", { invalidateKeys: ["segment:S1", "character:hero"] });
+    const app = useAppStore.getState();
+    expect(app.getEntityRevision("segment:S1")).toBe(1);
+    expect(app.getEntityRevision("character:hero")).toBe(1);
+  });
+
+  it("失败留旧：不覆盖 currentProjectData，返回 false，onError 收到错误", async () => {
+    useProjectsStore.getState().setCurrentProject("demo", makeProject("旧"), {}, {});
+    const err = new Error("boom");
+    vi.spyOn(API, "getProject").mockRejectedValue(err);
+    const onError = vi.fn();
+    const ok = await useProjectsStore.getState().refreshProject("demo", { onError });
+    expect(ok).toBe(false);
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("旧");
+    expect(onError).toHaveBeenCalledWith(err);
+  });
+
+  it("在途合并：在途期间的多次请求只多触发一次 getProject，最终反映最新一轮", async () => {
+    const d1 = deferred<GetProjectResult>();
+    const d2 = deferred<GetProjectResult>();
+    const spy = vi
+      .spyOn(API, "getProject")
+      .mockReturnValueOnce(d1.promise)
+      .mockReturnValueOnce(d2.promise);
+
+    const store = useProjectsStore.getState();
+    const p1 = store.refreshProject("demo"); // owner：发起第一轮
+    const p2 = store.refreshProject("demo"); // 在途 → 合并
+    const p3 = store.refreshProject("demo"); // 在途 → 合并
+    // 合并期间只发起了第一轮请求
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    d1.resolve(makeResult("R1"));
+    await flush();
+    // 排队请求收敛为「结束后再跑一轮」，此刻第二轮已发起
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    d2.resolve(makeResult("R2"));
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+    expect([r1, r2, r3]).toEqual([true, true, true]);
+    // 3 个刷新意图合并为 2 次请求，store 落定在最新一轮
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("R2");
+  });
+
+  it("首轮失败、排队轮成功时用新值替换旧值并返回 true", async () => {
+    useProjectsStore.getState().setCurrentProject("demo", makeProject("旧"), {}, {});
+    const d1 = deferred<GetProjectResult>();
+    const d2 = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject").mockReturnValueOnce(d1.promise).mockReturnValueOnce(d2.promise);
+
+    const store = useProjectsStore.getState();
+    const p1 = store.refreshProject("demo");
+    const p2 = store.refreshProject("demo"); // 合并 → 结束后再跑一轮
+
+    d1.reject(new Error("first fail"));
+    await flush();
+    // 第一轮失败：留旧
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("旧");
+
+    d2.resolve(makeResult("新"));
+    const [r1, r2] = await Promise.all([p1, p2]);
+    // 返回最后一轮结果（成功）
+    expect([r1, r2]).toEqual([true, true]);
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("新");
+  });
+
+  it("合并期间累积 invalidateKeys：排队轮成功后一并失效", async () => {
+    const d1 = deferred<GetProjectResult>();
+    const d2 = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject").mockReturnValueOnce(d1.promise).mockReturnValueOnce(d2.promise);
+
+    const store = useProjectsStore.getState();
+    const p1 = store.refreshProject("demo", { invalidateKeys: ["segment:S1"] });
+    const p2 = store.refreshProject("demo", { invalidateKeys: ["segment:S2"] });
+
+    d1.resolve(makeResult("R1"));
+    await flush();
+    d2.resolve(makeResult("R2"));
+    await Promise.all([p1, p2]);
+
+    const app = useAppStore.getState();
+    // 第一轮失效 S1；排队轮把 S2 带上（S1 不重复计入排队轮）
+    expect(app.getEntityRevision("segment:S1")).toBe(1);
+    expect(app.getEntityRevision("segment:S2")).toBe(1);
+  });
+});

--- a/frontend/src/stores/projects-store.ts
+++ b/frontend/src/stores/projects-store.ts
@@ -154,6 +154,21 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
           // 已有刷新在途：合并为「结束后再跑一轮」，取最新 name，累积 invalidateKeys /
           // onError / resolve——排队轮次结束时需各自通知全部合并进来的调用方，
           // 而非共享首轮或末轮的单一结果。
+          //
+          // 排队期间到达的请求若指向和当前排队目标不同的项目，说明上一批排队请求
+          // 即将被本次覆盖——设计上只保留「结束后再跑一轮」这一个名额，取最新
+          // name，不会再为被覆盖的项目单独多跑一轮。因此上一批排队的调用方注定不会
+          // 被接下来实际执行的那一轮命中；不提前结算就会被并入并共享本次这个新项目
+          // 的结果，即便它们请求的从来不是这个项目（例如 B 排队后 C 覆盖，B 的调用方
+          // 会在 C 成功后错误地收到 true，但 store 从未同步过 B 的数据）。按「未同步」
+          // 立即结算为 false，不视为请求出错，因此不触发 onError。
+          if (refreshQueued && queuedName !== null && queuedName !== name) {
+            const supersededResolvers = queuedResolvers;
+            queuedResolvers = [];
+            queuedKeys = [];
+            queuedOnErrors = [];
+            supersededResolvers.forEach((r) => r(false));
+          }
           refreshQueued = true;
           queuedName = name;
           queuedKeys = [...queuedKeys, ...invalidateKeys];

--- a/frontend/src/stores/projects-store.ts
+++ b/frontend/src/stores/projects-store.ts
@@ -1,5 +1,15 @@
 import { create } from "zustand";
 import type { ProjectData, ProjectSummary, EpisodeScript } from "@/types";
+import { API } from "@/api";
+import { useAppStore } from "./app-store";
+
+/** {@link ProjectsState.refreshProject} 的可选行为。 */
+interface RefreshProjectOptions {
+  /** 刷新成功后要失效的实体版本 key（沿用 StudioCanvasRouter 旧变体语义）。 */
+  invalidateKeys?: string[];
+  /** 每次 getProject 失败时回调（附错误对象），供调用方按需提示；不影响留旧语义。 */
+  onError?: (err: unknown) => void;
+}
 
 interface ProjectsState {
   // List
@@ -33,32 +43,105 @@ interface ProjectsState {
   setCreatingProject: (creating: boolean) => void;
   updateAssetFingerprints: (fps: Record<string, number>) => void;
   getAssetFingerprint: (path: string) => number | null;
+  /**
+   * 刷新当前项目数据到 store，返回 store 是否已同步成功。
+   *
+   * 单一入口收敛此前各调用点分散的刷新语义，消除「两入口同时刷新时后完成者盖住
+   * 先完成者」的竞态：
+   * - **在途合并**：同一时刻只允许一个 getProject 在途；在途期间到达的刷新请求
+   *   合并为「结束后再跑一轮」，取最新一次请求的 name / invalidateKeys。
+   * - **失败留旧**：getProject 失败时不覆盖 currentProjectData，返回 false 交调用方
+   *   决定是否提示（onError 亦会被调用）。
+   */
+  refreshProject: (name: string, options?: RefreshProjectOptions) => Promise<boolean>;
 }
 
-export const useProjectsStore = create<ProjectsState>((set, get) => ({
-  projects: [],
-  projectsLoading: false,
-  currentProjectName: null,
-  currentProjectData: null,
-  currentScripts: {},
-  projectDetailLoading: false,
-  showCreateModal: false,
-  creatingProject: false,
-  assetFingerprints: {},
+export const useProjectsStore = create<ProjectsState>((set, get) => {
+  // 刷新的在途合并协调状态（非响应式单例，不进 store state，避免触发订阅重渲染）。
+  let refreshInFlight: Promise<boolean> | null = null;
+  let refreshQueued = false;
+  let queuedName: string | null = null;
+  let queuedKeys: string[] = [];
 
-  setProjects: (projects) => set({ projects }),
-  setProjectsLoading: (loading) => set({ projectsLoading: loading }),
-  setCurrentProject: (name, data, scripts, fingerprints) =>
-    set((s) => ({
-      currentProjectName: name,
-      currentProjectData: data,
-      currentScripts: scripts ?? {},
-      assetFingerprints: fingerprints ?? s.assetFingerprints,
-    })),
-  setProjectDetailLoading: (loading) => set({ projectDetailLoading: loading }),
-  setShowCreateModal: (show) => set({ showCreateModal: show }),
-  setCreatingProject: (creating) => set({ creatingProject: creating }),
-  updateAssetFingerprints: (fps) =>
-    set((s) => ({ assetFingerprints: { ...s.assetFingerprints, ...fps } })),
-  getAssetFingerprint: (path) => get().assetFingerprints[path] ?? null,
-}));
+  // 执行刷新循环：while 排队重跑替代递归，失败路径也消费排队请求，
+  // 直至无新排队为止；返回最后一轮是否成功。
+  const runRefresh = async (
+    name: string,
+    keys: string[],
+    onError?: (err: unknown) => void,
+  ): Promise<boolean> => {
+    let curName = name;
+    let curKeys = keys;
+    let ok = false;
+    let again = true;
+    while (again) {
+      again = false;
+      try {
+        const res = await API.getProject(curName);
+        get().setCurrentProject(curName, res.project, res.scripts ?? {}, res.asset_fingerprints);
+        if (curKeys.length > 0) {
+          useAppStore.getState().invalidateEntities(curKeys);
+        }
+        ok = true;
+      } catch (err) {
+        // 失败留旧：不覆盖 currentProjectData；调用方按返回值 / onError 决定提示。
+        ok = false;
+        onError?.(err);
+      }
+      if (refreshQueued) {
+        refreshQueued = false;
+        curName = queuedName ?? curName;
+        curKeys = queuedKeys;
+        queuedName = null;
+        queuedKeys = [];
+        again = true;
+      }
+    }
+    return ok;
+  };
+
+  return {
+    projects: [],
+    projectsLoading: false,
+    currentProjectName: null,
+    currentProjectData: null,
+    currentScripts: {},
+    projectDetailLoading: false,
+    showCreateModal: false,
+    creatingProject: false,
+    assetFingerprints: {},
+
+    setProjects: (projects) => set({ projects }),
+    setProjectsLoading: (loading) => set({ projectsLoading: loading }),
+    setCurrentProject: (name, data, scripts, fingerprints) =>
+      set((s) => ({
+        currentProjectName: name,
+        currentProjectData: data,
+        currentScripts: scripts ?? {},
+        assetFingerprints: fingerprints ?? s.assetFingerprints,
+      })),
+    setProjectDetailLoading: (loading) => set({ projectDetailLoading: loading }),
+    setShowCreateModal: (show) => set({ showCreateModal: show }),
+    setCreatingProject: (creating) => set({ creatingProject: creating }),
+    updateAssetFingerprints: (fps) =>
+      set((s) => ({ assetFingerprints: { ...s.assetFingerprints, ...fps } })),
+    getAssetFingerprint: (path) => get().assetFingerprints[path] ?? null,
+
+    refreshProject: (name, options) => {
+      if (!name) return Promise.resolve(false);
+      const invalidateKeys = options?.invalidateKeys ?? [];
+      if (refreshInFlight) {
+        // 已有刷新在途：合并为「结束后再跑一轮」，取最新 name，累积 invalidateKeys。
+        refreshQueued = true;
+        queuedName = name;
+        queuedKeys = [...queuedKeys, ...invalidateKeys];
+        return refreshInFlight;
+      }
+      const p = runRefresh(name, invalidateKeys, options?.onError).finally(() => {
+        refreshInFlight = null;
+      });
+      refreshInFlight = p;
+      return p;
+    },
+  };
+});

--- a/frontend/src/stores/projects-store.ts
+++ b/frontend/src/stores/projects-store.ts
@@ -62,6 +62,7 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
   let refreshQueued = false;
   let queuedName: string | null = null;
   let queuedKeys: string[] = [];
+  let queuedOnErrors: Array<(err: unknown) => void> = [];
 
   // 执行刷新循环：while 排队重跑替代递归，失败路径也消费排队请求，
   // 直至无新排队为止；返回最后一轮是否成功。
@@ -72,28 +73,36 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
   ): Promise<boolean> => {
     let curName = name;
     let curKeys = keys;
+    let curOnErrors = onError ? [onError] : [];
     let ok = false;
     let again = true;
     while (again) {
       again = false;
       try {
         const res = await API.getProject(curName);
-        get().setCurrentProject(curName, res.project, res.scripts ?? {}, res.asset_fingerprints);
-        if (curKeys.length > 0) {
-          useAppStore.getState().invalidateEntities(curKeys);
+        // 在途期间若已排队到不同项目的刷新请求，本轮响应针对的是即将切走的旧项目——
+        // 跳过写入，避免用它覆盖排队轮即将加载的新项目（数据 / 名称均不提交）。
+        const supersededByOtherProject = refreshQueued && queuedName !== null && queuedName !== curName;
+        if (!supersededByOtherProject) {
+          get().setCurrentProject(curName, res.project, res.scripts ?? {}, res.asset_fingerprints);
+          if (curKeys.length > 0) {
+            useAppStore.getState().invalidateEntities(curKeys);
+          }
+          ok = true;
         }
-        ok = true;
       } catch (err) {
         // 失败留旧：不覆盖 currentProjectData；调用方按返回值 / onError 决定提示。
         ok = false;
-        onError?.(err);
+        curOnErrors.forEach((cb) => cb(err));
       }
       if (refreshQueued) {
         refreshQueued = false;
         curName = queuedName ?? curName;
         curKeys = queuedKeys;
+        curOnErrors = queuedOnErrors;
         queuedName = null;
         queuedKeys = [];
+        queuedOnErrors = [];
         again = true;
       }
     }
@@ -131,10 +140,14 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
       if (!name) return Promise.resolve(false);
       const invalidateKeys = options?.invalidateKeys ?? [];
       if (refreshInFlight) {
-        // 已有刷新在途：合并为「结束后再跑一轮」，取最新 name，累积 invalidateKeys。
+        // 已有刷新在途：合并为「结束后再跑一轮」，取最新 name，累积 invalidateKeys /
+        // onError——排队轮次失败时需通知全部合并进来的调用方，不能只保留首轮回调。
         refreshQueued = true;
         queuedName = name;
         queuedKeys = [...queuedKeys, ...invalidateKeys];
+        if (options?.onError) {
+          queuedOnErrors = [...queuedOnErrors, options.onError];
+        }
         return refreshInFlight;
       }
       const p = runRefresh(name, invalidateKeys, options?.onError).finally(() => {

--- a/frontend/src/stores/projects-store.ts
+++ b/frontend/src/stores/projects-store.ts
@@ -58,26 +58,33 @@ interface ProjectsState {
 
 export const useProjectsStore = create<ProjectsState>((set, get) => {
   // 刷新的在途合并协调状态（非响应式单例，不进 store state，避免触发订阅重渲染）。
-  let refreshInFlight: Promise<boolean> | null = null;
+  let refreshRunning = false;
   let refreshQueued = false;
   let queuedName: string | null = null;
   let queuedKeys: string[] = [];
   let queuedOnErrors: Array<(err: unknown) => void> = [];
+  // 排队轮调用方各自的 resolve——与 curResolvers 分开累积，避免"排队进同一批"
+  // 被误解为"共享同一个最终结果"：每个调用方只对自己实际服务的那一轮结果负责。
+  let queuedResolvers: Array<(ok: boolean) => void> = [];
 
-  // 执行刷新循环：while 排队重跑替代递归，失败路径也消费排队请求，
-  // 直至无新排队为止；返回最后一轮是否成功。
+  // 执行刷新循环：while 排队重跑替代递归，失败路径也消费排队请求，直至无新排队为止。
+  // 每轮结束立刻 resolve 该轮的调用方（curResolvers），不等后续排队轮跑完——否则先到
+  // 的调用方会被后到、且与自己无关的轮次结果覆盖返回值（如已成功写入的重排刷新，被
+  // 随后排队、失败的 SSE 刷新拖累成 false，UI 无法据此推进选中态）。
   const runRefresh = async (
     name: string,
     keys: string[],
-    onError?: (err: unknown) => void,
-  ): Promise<boolean> => {
+    onError: ((err: unknown) => void) | undefined,
+    resolvers: Array<(ok: boolean) => void>,
+  ): Promise<void> => {
     let curName = name;
     let curKeys = keys;
     let curOnErrors = onError ? [onError] : [];
-    let ok = false;
+    let curResolvers = resolvers;
     let again = true;
     while (again) {
       again = false;
+      let ok = false;
       try {
         const res = await API.getProject(curName);
         // 在途期间若已排队到不同项目的刷新请求，本轮响应针对的是即将切走的旧项目——
@@ -95,18 +102,21 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
         ok = false;
         curOnErrors.forEach((cb) => cb(err));
       }
+      curResolvers.forEach((resolve) => resolve(ok));
       if (refreshQueued) {
         refreshQueued = false;
         curName = queuedName ?? curName;
         curKeys = queuedKeys;
         curOnErrors = queuedOnErrors;
+        curResolvers = queuedResolvers;
         queuedName = null;
         queuedKeys = [];
         queuedOnErrors = [];
+        queuedResolvers = [];
         again = true;
       }
     }
-    return ok;
+    refreshRunning = false;
   };
 
   return {
@@ -139,22 +149,23 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
     refreshProject: (name, options) => {
       if (!name) return Promise.resolve(false);
       const invalidateKeys = options?.invalidateKeys ?? [];
-      if (refreshInFlight) {
-        // 已有刷新在途：合并为「结束后再跑一轮」，取最新 name，累积 invalidateKeys /
-        // onError——排队轮次失败时需通知全部合并进来的调用方，不能只保留首轮回调。
-        refreshQueued = true;
-        queuedName = name;
-        queuedKeys = [...queuedKeys, ...invalidateKeys];
-        if (options?.onError) {
-          queuedOnErrors = [...queuedOnErrors, options.onError];
+      return new Promise<boolean>((resolve) => {
+        if (refreshRunning) {
+          // 已有刷新在途：合并为「结束后再跑一轮」，取最新 name，累积 invalidateKeys /
+          // onError / resolve——排队轮次结束时需各自通知全部合并进来的调用方，
+          // 而非共享首轮或末轮的单一结果。
+          refreshQueued = true;
+          queuedName = name;
+          queuedKeys = [...queuedKeys, ...invalidateKeys];
+          if (options?.onError) {
+            queuedOnErrors = [...queuedOnErrors, options.onError];
+          }
+          queuedResolvers = [...queuedResolvers, resolve];
+          return;
         }
-        return refreshInFlight;
-      }
-      const p = runRefresh(name, invalidateKeys, options?.onError).finally(() => {
-        refreshInFlight = null;
+        refreshRunning = true;
+        void runRefresh(name, invalidateKeys, options?.onError, [resolve]);
       });
-      refreshInFlight = p;
-      return p;
     },
   };
 });

--- a/frontend/src/stores/stores.test.ts
+++ b/frontend/src/stores/stores.test.ts
@@ -138,21 +138,20 @@ describe("stores", () => {
     expect(app.getEntityRevision("clue:missing")).toBe(1);
   });
 
-  it("upserts tasks by task_id and updates task stats", () => {
+  it("replaces tasks via setTasks and updates task stats", () => {
     const tasks = useTasksStore.getState();
     const first = makeTask();
-    const updated = makeTask({ status: "running", updated_at: "2026-02-01T00:01:00Z" });
-    const second = makeTask({ task_id: "task-2" });
+    const second = makeTask({
+      task_id: "task-2",
+      status: "running",
+      updated_at: "2026-02-01T00:01:00Z",
+    });
 
-    tasks.upsertTask(first);
+    tasks.setTasks([first]);
     expect(useTasksStore.getState().tasks).toHaveLength(1);
     expect(useTasksStore.getState().tasks[0].status).toBe("queued");
 
-    tasks.upsertTask(updated);
-    expect(useTasksStore.getState().tasks).toHaveLength(1);
-    expect(useTasksStore.getState().tasks[0].status).toBe("running");
-
-    tasks.upsertTask(second);
+    tasks.setTasks([second, first]);
     expect(useTasksStore.getState().tasks).toHaveLength(2);
     expect(useTasksStore.getState().tasks[0].task_id).toBe("task-2");
 

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -9,7 +9,6 @@ interface TasksState {
 
   // Actions
   setTasks: (tasks: TaskItem[]) => void;
-  upsertTask: (task: TaskItem) => void;
   setStats: (stats: TaskStats) => void;
   setConnected: (connected: boolean) => void;
 }
@@ -24,16 +23,6 @@ export const useTasksStore = create<TasksState>((set) => ({
   connected: false,
 
   setTasks: (tasks) => set({ tasks }),
-  upsertTask: (task) =>
-    set((s) => {
-      const idx = s.tasks.findIndex((t) => t.task_id === task.task_id);
-      if (idx >= 0) {
-        const updated = [...s.tasks];
-        updated[idx] = task;
-        return { tasks: updated };
-      }
-      return { tasks: [task, ...s.tasks] };
-    }),
   setStats: (stats) => set({ stats }),
   setConnected: (connected) => set({ connected }),
 }));
@@ -44,8 +33,8 @@ export const useTasksStore = create<TasksState>((set) => ({
 // 消费点（画布 loading 派生、参考视频单元状态等）此前各自重写两条隐性契约：
 //   1.「什么算活跃」——排队或运行中的任务占用其 resource（isActiveStatus）。
 //   2.「最新行胜出」——同一 resource 可能有多条任务行：失败后重试是新的 task_id，
-//      store 按 task_id upsert（见 upsertTask）且不保证 tasks 顺序，故判定时须取
-//      updated_at 最新的一行，重试的新行不被旧失败行遮挡（selectLatestTaskByResource）。
+//      tasks 由服务端列表整体写入、顺序不保证，故判定时须取 updated_at 最新的一行，
+//      重试的新行不被旧失败行遮挡（selectLatestTaskByResource）。
 //
 // 纯函数版把两条不变量收敛于此、可直接用 vitest 测试；hook 版用 useShallow 比较
 // Set/Map 内容，保证内容不变时引用稳定，避免每次渲染返回新集合触发重渲染。


### PR DESCRIPTION
## 摘要

「刷新当前项目」原先 5 处调用点各写一套并发/失败语义，只有 SSE 那份防了重复请求与乱序覆盖，其余入口在两个入口同时刷新时后完成者会盖住先完成者。本 PR 把在途合并 + 失败留旧收敛进 `projects-store` 的单一 action `refreshProject(name, options?)`，调用点只表达刷新意图。

Closes #1150

## 核心改动（`c0e28163`）

新增 `projects-store.refreshProject(name, { invalidateKeys?, onError? }): Promise<boolean>`：

- **在途合并**：闭包级非响应式单例（`refreshInFlight`/`refreshQueued`/`queuedName`/`queuedKeys`，不进 store state 以免触发订阅重渲染）。同一时刻只允许一个 `getProject` 在途；在途期间到达的请求合并为「结束后再跑一轮」，取最新 name、累积 `invalidateKeys`。while 循环替代递归，失败路径也消费排队。
- **失败留旧**：`getProject` 失败时不覆盖 `currentProjectData`，返回 `false`；每次失败调 `onError(err)`。
- **成功副作用**：`setCurrentProject(...)` + 仅成功后 `invalidateEntities(invalidateKeys)`（保留 StudioCanvasRouter 旧变体语义）。

## 5 处调用点处置对照

| 调用点 | 处置 | 说明 |
|--------|------|------|
| `StudioCanvasRouter.tsx:185-200` | **收编** | `refreshProject(keys)` → `store.refreshProject(name, { invalidateKeys })`，保留对外 `(keys) => Promise<boolean>` 接口（十余个 handler 依赖 bool 推进 UI，如 handleMoveShot 选中态跟随）。 |
| `OverviewCanvas.tsx:83-84` | **收编** | `refreshProject()` → `store.refreshProject(name)`，保留 `() => Promise<void>` 形状。失败语义由「抛出」统一为「留旧静默」；handleRegenerate 的 try/catch 仍捕获 generateOverview 自身失败。 |
| `useProjectEventsSSE.ts:170-200` | **收编（逻辑本体）** | 在途合并本体下沉到 store，SSE 侧只保留专属包装：`onError` 复用 `project_sync_failed` 告警、刷新落定后 `flushQueuedFocus()`。移除已无用的 `refreshingRef`/`needsRefreshRef`/`setCurrentProject` 订阅。 |
| `router.tsx:95-133` | **排除** | StudioWorkspace 挂载**初次加载**语义：切 `projectDetailLoading`、失败置 `null`（展示空态而非留旧）、卸载 `setCurrentProject(null,null)` + cancelled 守卫。折进会丢 loading 指示并改失败语义，非本 issue 竞态范畴。经 team-lead 裁决排除。 |
| `ProjectSettingsPage.tsx:162/363` | **排除** | `getProject` 结果读进**组件本地 state**（setOptions/setStyleValue），从不写共享 `currentProject` store，不参与并发覆盖竞态；且需返回 project 对象派生表单，bool 返回值用不上。经 team-lead 裁决排除。 |

## 顺手清理（独立 commit `25646197`）

删除死表面 `api.ts` 的 `openTaskStream` + `TaskStream*` 类型、`tasks-store` 的 `upsertTask`——唯一消费者是各自单测（任务队列走 `useTasksSSE` 的 `listTasks` 轮询 + `setTasks` 整体写入）。已核实无生产调用点，`upsertTask` 在 #1149 合入后仍为死表面。同步清理相关单测脚手架（改测 `setTasks`，保留 setStats/setConnected 覆盖）与 selector 注释引用。

## 验证

- 新增 `projects-store.test.ts`（7 例纯逻辑 vitest，`vi.spyOn(API,"getProject")` + deferred promise 精确编排合并时序）：空 name 短路、成功写入、invalidateKeys 成功后失效、失败留旧 + onError、在途合并（3 意图 → 2 请求、落定最新一轮）、首轮失败排队轮成功替换、合并期累积 invalidateKeys（不重复计入）。
- 本地审查阶段 rebase 至最新 `origin/main`（纳入 #1169 时长口径修复，无冲突）后重跑 `pnpm check`（tsc + eslint + vitest）全绿：**105 test files / 932 tests passed**。
- 纯前端改动，未触 Python。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增项目刷新能力，支持错误提示、实体失效处理及并发刷新合并。
  - 项目数据刷新流程更加统一，刷新后可同步更新项目、脚本和资源指纹信息。

- **改进**
  - 优化项目事件同步与画布刷新体验，减少重复请求并确保最新数据生效。
  - 任务列表改为整体更新方式，移除旧的单任务更新接口。

- **移除**
  - 移除独立任务流接口及其相关事件处理能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->