### PR TITLE
refactor: 收编散装 ProjectManager 构造为统一懒加载单例

### DIFF
--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from lib.app_data_dir import app_data_dir
 from lib.config.registry import PROVIDER_REGISTRY, default_model_for_provider
 from lib.config.service import (
     _DEFAULT_AUDIO_BACKEND,
@@ -35,19 +34,8 @@ from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.custom_provider.endpoints import get_endpoint_spec
 from lib.db.repositories.credential_repository import CredentialRepository
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
-from lib.project_manager import ProjectManager
+from lib.project_manager import get_project_manager
 from lib.text_backends.base import TextTaskType
-
-_project_manager: ProjectManager | None = None
-
-
-def get_project_manager() -> ProjectManager:
-    """返回共享的 ProjectManager 单例（使用标准项目根目录）。"""
-    global _project_manager
-    if _project_manager is None:
-        _project_manager = ProjectManager(app_data_dir())
-    return _project_manager
-
 
 logger = logging.getLogger(__name__)
 

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -24,6 +24,7 @@ import portalocker
 from pydantic import BaseModel, Field
 
 from lib.agent_profile import agent_profile_dir
+from lib.app_data_dir import app_data_dir
 from lib.asset_types import ASSET_SPECS, validate_asset_name
 from lib.episode_ledger import SOURCE_TEXT_SUFFIXES
 from lib.episode_paths import episode_script_relpath
@@ -2276,3 +2277,20 @@ class ProjectManager:
 
         logger.info("项目概述已生成并保存")
         return overview_dict
+
+
+_project_manager: ProjectManager | None = None
+
+
+def get_project_manager() -> ProjectManager:
+    """返回懒加载的全局 ProjectManager 单例（标准项目根目录）。"""
+    global _project_manager
+    if _project_manager is None:
+        _project_manager = ProjectManager(app_data_dir())
+    return _project_manager
+
+
+def _reset_project_manager_for_tests() -> None:
+    """清空缓存的单例，供测试在不同 app_data_dir 场景间重置。"""
+    global _project_manager
+    _project_manager = None

--- a/server/app.py
+++ b/server/app.py
@@ -389,9 +389,9 @@ async def lifespan(app: FastAPI):
         logger.warning("JSON→DB config migration failed (non-fatal): %s", exc)
 
     # 把 agent_runtime_profile 同步到存量项目（manifest 物化，同步文件 I/O → worker 线程）
-    from lib.project_manager import ProjectManager
+    from lib.project_manager import get_project_manager
 
-    _pm = ProjectManager(app_data_dir())
+    _pm = get_project_manager()
     _profile_sync_stats = await asyncio.to_thread(_pm.sync_all_agent_profiles)
     _log_profile_sync_outcome(_profile_sync_stats)
 

--- a/server/routers/assets.py
+++ b/server/routers/assets.py
@@ -12,25 +12,16 @@ from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 
-from lib.app_data_dir import app_data_dir
 from lib.asset_types import BUCKET_KEY, GLOBAL_LIBRARY_ASSET_TYPES, SHEET_KEY, validate_asset_name
 from lib.db import async_session_factory
 from lib.db.repositories.asset_repo import AssetRepository
 from lib.i18n import Translator
-from lib.project_manager import ProjectManager
+from lib.project_manager import ProjectManager, get_project_manager
 from server.auth import CurrentUser
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/assets", tags=["全局资产库"])
-
-# Module-level PM; overridable via monkeypatch in tests
-pm = ProjectManager(app_data_dir())
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
-
 
 MAX_UPLOAD_BYTES = 5 * 1024 * 1024
 ALLOWED_EXTS = {".png", ".jpg", ".jpeg", ".webp"}

--- a/server/routers/characters.py
+++ b/server/routers/characters.py
@@ -1,15 +1,7 @@
 """角色管理路由（CRUD 由 _asset_router_factory 统一生成）。"""
 
-from lib.app_data_dir import app_data_dir
-from lib.project_manager import ProjectManager
+from lib.project_manager import get_project_manager
 from server.routers._asset_router_factory import build_asset_router
-
-pm = ProjectManager(app_data_dir())
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
-
 
 # late-binding 必需：测试通过 monkeypatch.setattr(characters, "get_project_manager", ...) 替换模块属性
 router = build_asset_router(asset_type="character", pm_getter=lambda: get_project_manager())  # noqa: PLW0108

--- a/server/routers/cost_estimation.py
+++ b/server/routers/cost_estimation.py
@@ -7,18 +7,16 @@ import logging
 
 from fastapi import APIRouter, HTTPException
 
-from lib.app_data_dir import app_data_dir
 from lib.config.resolver import ConfigResolver
 from lib.db import async_session_factory
 from lib.i18n import Translator
-from lib.project_manager import ProjectManager
+from lib.project_manager import get_project_manager
 from lib.usage_tracker import UsageTracker
 from server.auth import CurrentUser
 from server.services.cost_estimation import CostEstimationService
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-pm = ProjectManager(app_data_dir())
 
 
 @router.get("/projects/{project_name}/cost-estimate")
@@ -26,6 +24,7 @@ async def get_cost_estimate(project_name: str, _user: CurrentUser, _t: Translato
     """获取项目费用估算（预估 + 实际）。"""
 
     def _sync():
+        pm = get_project_manager()
         if not pm.project_exists(project_name):
             raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
 

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 from fastapi import APIRouter, Body, File, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, PlainTextResponse
 
-from lib.app_data_dir import app_data_dir
 from lib.asset_types import GLOBAL_LIBRARY_ASSET_TYPES
 from lib.episode_paths import (
     REFERENCE_VIDEO_STEP1_FILENAME,
@@ -28,7 +27,7 @@ from lib.episode_paths import (
 from lib.i18n import Translator
 from lib.image_utils import normalize_uploaded_image, validate_image_bytes
 from lib.project_change_hints import emit_project_change_batch, project_change_source
-from lib.project_manager import ProjectManager, effective_mode
+from lib.project_manager import effective_mode, get_project_manager
 from lib.source_loader import (
     ConflictError,
     CorruptFileError,
@@ -42,13 +41,6 @@ from lib.source_loader import (
 from server.auth import CurrentUser
 
 router = APIRouter()
-
-# 初始化项目管理器
-pm = ProjectManager(app_data_dir())
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
 
 
 def _require_filename(file: UploadFile, _t: Callable[..., str]) -> str:

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -15,13 +15,12 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 
 from lib.api_errors import BadRequestError, NotFoundError
-from lib.app_data_dir import app_data_dir
 from lib.asset_types import ASSET_SPECS
 from lib.config.resolver import ConfigResolver
 from lib.generation_queue import get_generation_queue
 from lib.generation_queue_client import TaskSpec
 from lib.i18n import Translator
-from lib.project_manager import ProjectManager
+from lib.project_manager import get_project_manager
 from lib.storyboard_sequence import (
     find_storyboard_item,
     get_storyboard_items,
@@ -29,14 +28,6 @@ from lib.storyboard_sequence import (
 from server.auth import CurrentUser
 
 router = APIRouter()
-
-# 初始化管理器
-pm = ProjectManager(app_data_dir())
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
-
 
 # ==================== 请求模型 ====================
 

--- a/server/routers/grids.py
+++ b/server/routers/grids.py
@@ -14,26 +14,18 @@ logger = logging.getLogger(__name__)
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from lib.app_data_dir import app_data_dir
 from lib.generation_queue import get_generation_queue
 from lib.grid.layout import calculate_grid_layout
 from lib.grid.models import GridGeneration
 from lib.grid.prompt_builder import build_grid_prompt
 from lib.grid_manager import GridManager
 from lib.i18n import Translator
-from lib.project_manager import ProjectManager
+from lib.project_manager import get_project_manager
 from lib.script_editor import ScriptEditError
 from lib.storyboard_sequence import get_storyboard_items, group_scenes_by_segment_break
 from server.auth import CurrentUser
 
 router = APIRouter(prefix="/projects/{project_name}", tags=["grids"])
-
-# 初始化管理器
-pm = ProjectManager(app_data_dir())
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
 
 
 def _build_grid_task_payload(

--- a/server/routers/products.py
+++ b/server/routers/products.py
@@ -1,15 +1,7 @@
 """产品管理路由（CRUD 由 _asset_router_factory 统一生成）。"""
 
-from lib.app_data_dir import app_data_dir
-from lib.project_manager import ProjectManager
+from lib.project_manager import get_project_manager
 from server.routers._asset_router_factory import build_asset_router
-
-pm = ProjectManager(app_data_dir())
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
-
 
 # late-binding 必需：测试通过 monkeypatch.setattr(products, "get_project_manager", ...) 替换模块属性
 router = build_asset_router(asset_type="product", pm_getter=lambda: get_project_manager())  # noqa: PLW0108

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -29,14 +29,13 @@ from starlette.background import BackgroundTask
 
 logger = logging.getLogger(__name__)
 
-from lib.app_data_dir import app_data_dir
 from lib.asset_fingerprints import compute_asset_fingerprints
 from lib.config.resolver import ConfigResolver
 from lib.db import async_session_factory
 from lib.i18n import Translator
 from lib.profile_manifest import ContentMode
 from lib.project_change_hints import project_change_source
-from lib.project_manager import EpisodeScriptReboundError, ProjectManager, SourceKind
+from lib.project_manager import EpisodeScriptReboundError, SourceKind, get_project_manager
 from lib.status_calculator import StatusCalculator
 from lib.style_templates import is_known_template, resolve_template_prompt
 from server.auth import CurrentUser, create_download_token, verify_download_token
@@ -50,19 +49,14 @@ from server.services.project_cover import resolve_project_cover
 
 router = APIRouter()
 
-# 初始化项目管理器和状态计算器
-pm = ProjectManager(app_data_dir())
-calc = StatusCalculator(pm)
+# 状态计算器
+calc = StatusCalculator(get_project_manager())
 
 # episode 字段白名单：只允许持久化合法的 on-disk 字段。
 # StatusCalculator 注入的统计字段（scenes_count / status / storyboards / videos 等）
 # 是读时计算值，禁止写回 project.json。title 不在白名单：它以剧本顶层 title 为唯一真相源，
 # 经 _apply_episode_sync 单向同步进 episodes[].title，专用端点 PATCH /episodes/{episode} 写入。
 EPISODE_PERSIST_FIELDS = {"script_file", "generation_mode"}
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
 
 
 def get_status_calculator() -> StatusCalculator:

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -49,9 +49,6 @@ from server.services.project_cover import resolve_project_cover
 
 router = APIRouter()
 
-# 状态计算器
-calc = StatusCalculator(get_project_manager())
-
 # episode 字段白名单：只允许持久化合法的 on-disk 字段。
 # StatusCalculator 注入的统计字段（scenes_count / status / storyboards / videos 等）
 # 是读时计算值，禁止写回 project.json。title 不在白名单：它以剧本顶层 title 为唯一真相源，
@@ -60,7 +57,7 @@ EPISODE_PERSIST_FIELDS = {"script_file", "generation_mode"}
 
 
 def get_status_calculator() -> StatusCalculator:
-    return calc
+    return StatusCalculator(get_project_manager())
 
 
 def get_archive_service() -> ProjectArchiveService:

--- a/server/routers/props.py
+++ b/server/routers/props.py
@@ -1,15 +1,7 @@
 """道具管理路由（CRUD 由 _asset_router_factory 统一生成）。"""
 
-from lib.app_data_dir import app_data_dir
-from lib.project_manager import ProjectManager
+from lib.project_manager import get_project_manager
 from server.routers._asset_router_factory import build_asset_router
-
-pm = ProjectManager(app_data_dir())
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
-
 
 # late-binding 必需：测试通过 monkeypatch.setattr(props, "get_project_manager", ...) 替换模块属性
 router = build_asset_router(asset_type="prop", pm_getter=lambda: get_project_manager())  # noqa: PLW0108

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -15,13 +15,12 @@ from typing import Any
 from fastapi import APIRouter, File, HTTPException, Response, UploadFile, status
 from pydantic import BaseModel, Field
 
-from lib.app_data_dir import app_data_dir
 from lib.asset_types import BUCKET_KEY
 from lib.generation_queue import get_generation_queue
 from lib.generation_queue_client import TaskSpec, TaskSpecValidationError
 from lib.i18n import Translator
 from lib.project_change_hints import project_change_source
-from lib.project_manager import EpisodeScriptReboundError, ProjectManager, effective_mode
+from lib.project_manager import EpisodeScriptReboundError, effective_mode, get_project_manager
 from lib.reference_video import assemble_shots_text, parse_prompt
 from lib.reference_video.ad_units import (
     render_ad_unit_prompt,
@@ -48,13 +47,6 @@ router = APIRouter(
     prefix="/projects/{project_name}/reference-videos",
     tags=["reference-videos"],
 )
-
-pm = ProjectManager(app_data_dir())
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
-
 
 # ============ 请求模型 ============
 

--- a/server/routers/scenes.py
+++ b/server/routers/scenes.py
@@ -1,15 +1,7 @@
 """场景管理路由（CRUD 由 _asset_router_factory 统一生成）。"""
 
-from lib.app_data_dir import app_data_dir
-from lib.project_manager import ProjectManager
+from lib.project_manager import get_project_manager
 from server.routers._asset_router_factory import build_asset_router
-
-pm = ProjectManager(app_data_dir())
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
-
 
 # late-binding 必需：测试通过 monkeypatch.setattr(scenes, "get_project_manager", ...) 替换模块属性
 router = build_asset_router(asset_type="scene", pm_getter=lambda: get_project_manager())  # noqa: PLW0108

--- a/server/routers/script_review.py
+++ b/server/routers/script_review.py
@@ -10,22 +10,14 @@ import logging
 
 from fastapi import APIRouter, Body, HTTPException
 
-from lib.app_data_dir import app_data_dir
 from lib.i18n import Translator
-from lib.project_manager import ProjectManager
+from lib.project_manager import get_project_manager
 from server.auth import CurrentUser
 from server.services.script_review import ScriptReviewError, ScriptReviewService
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-pm = ProjectManager(app_data_dir())
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
-
 
 # gate 领域错误码 → (HTTP 状态, i18n key)。invalid_content / episode_not_found 带参数另行注入。
 _ERROR_STATUS: dict[str, int] = {

--- a/server/routers/shot_uploads.py
+++ b/server/routers/shot_uploads.py
@@ -16,11 +16,10 @@ from typing import Literal
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
 
-from lib.app_data_dir import app_data_dir
 from lib.i18n import Translator
 from lib.image_utils import normalize_storyboard_upload
 from lib.project_change_hints import project_change_source
-from lib.project_manager import ProjectManager
+from lib.project_manager import get_project_manager
 from lib.resource_paths import resource_relative_path
 from lib.script_editor import ScriptEditError
 from lib.storyboard_sequence import find_storyboard_item, get_storyboard_items
@@ -41,12 +40,6 @@ from server.services.upload_finalize import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-pm = ProjectManager(app_data_dir())
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
 
 
 @router.post("/projects/{project_name}/shots/{shot_id}/upload/{kind}")

--- a/server/routers/versions.py
+++ b/server/routers/versions.py
@@ -13,10 +13,9 @@ from fastapi import APIRouter, HTTPException
 
 logger = logging.getLogger(__name__)
 
-from lib.app_data_dir import app_data_dir
 from lib.i18n import Translator
 from lib.project_change_hints import project_change_source
-from lib.project_manager import ProjectManager
+from lib.project_manager import get_project_manager
 from lib.resource_paths import resource_relative_path
 from lib.script_editor import ScriptEditError
 from lib.version_manager import VersionManager
@@ -25,18 +24,11 @@ from server.services.reference_video_tasks import apply_unit_video_assets
 
 router = APIRouter()
 
-# 初始化项目管理器
-pm = ProjectManager(app_data_dir())
-
 # 经此路由可还原的资源类型（API 面策略）。路径形状委托 lib.resource_paths，但本路由
 # 仅放行有还原后元数据同步分支的这几类；grids 的还原是独立议题。
 _RESTORABLE_RESOURCE_TYPES = frozenset(
     {"storyboards", "videos", "characters", "scenes", "props", "products", "reference_videos"}
 )
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
 
 
 def get_version_manager(project_name: str) -> VersionManager:

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from lib.config.resolver import ConfigResolver, ProviderModel
 
-from lib.app_data_dir import app_data_dir
 from lib.asset_types import ASSET_SPECS
 from lib.backend_assembly import assemble_backend
 from lib.config.registry import PROVIDER_REGISTRY
@@ -25,7 +24,7 @@ from lib.image_backends.base import ImageCapabilityError
 from lib.media_generator import MediaGenerator
 from lib.path_safety import safe_exists
 from lib.project_change_hints import emit_project_change_batch, project_change_source
-from lib.project_manager import ProjectManager
+from lib.project_manager import get_project_manager
 from lib.prompt_builders import (
     append_product_fidelity_tail,
     build_character_prompt,
@@ -54,16 +53,11 @@ from lib.thumbnail import extract_video_thumbnail
 from lib.video_backends.base import VideoCapabilityError
 from server.services.resolution_resolver import resolve_resolution
 
-pm = ProjectManager(app_data_dir())
 rate_limiter = get_shared_rate_limiter()
 logger = logging.getLogger(__name__)
 
 # 按 (channel, provider_name, model) 缓存 Backend 实例，避免每次任务重建 API 客户端
 _backend_cache: dict[tuple[str, str, str | None], Any] = {}
-
-
-def get_project_manager() -> ProjectManager:
-    return pm
 
 
 def invalidate_backend_cache() -> None:

--- a/tests/integration/test_reference_video_e2e.py
+++ b/tests/integration/test_reference_video_e2e.py
@@ -86,9 +86,7 @@ def three_bucket_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     from server.services import reference_video_tasks as rvt_mod
 
     custom_pm = ProjectManager(projects_root)
-    monkeypatch.setattr(router_mod, "pm", custom_pm)
     monkeypatch.setattr(router_mod, "get_project_manager", lambda: custom_pm)
-    monkeypatch.setattr(gt_mod, "pm", custom_pm, raising=False)
     monkeypatch.setattr(gt_mod, "get_project_manager", lambda: custom_pm)
     monkeypatch.setattr(rvt_mod, "get_project_manager", lambda: custom_pm)
 

--- a/tests/server/test_reference_video_e2e_backend.py
+++ b/tests/server/test_reference_video_e2e_backend.py
@@ -72,13 +72,11 @@ def seeded_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Test
     from server.routers import reference_videos as router_mod
 
     custom_pm = ProjectManager(projects_root)
-    monkeypatch.setattr(router_mod, "pm", custom_pm)
     monkeypatch.setattr(router_mod, "get_project_manager", lambda: custom_pm)
 
     from server.services import generation_tasks as gt_mod
     from server.services import reference_video_tasks as rvt_mod
 
-    monkeypatch.setattr(gt_mod, "pm", custom_pm, raising=False)
     monkeypatch.setattr(gt_mod, "get_project_manager", lambda: custom_pm)
     monkeypatch.setattr(rvt_mod, "get_project_manager", lambda: custom_pm)
 

--- a/tests/server/test_reference_videos_router.py
+++ b/tests/server/test_reference_videos_router.py
@@ -56,7 +56,6 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     from server.routers import reference_videos as router_mod
 
     custom_pm = ProjectManager(projects_root)
-    monkeypatch.setattr(router_mod, "pm", custom_pm)
     monkeypatch.setattr(router_mod, "get_project_manager", lambda: custom_pm)
 
     app = FastAPI()

--- a/tests/server/test_reference_videos_router_ad.py
+++ b/tests/server/test_reference_videos_router_ad.py
@@ -88,7 +88,6 @@ def ad_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     from server.routers import reference_videos as router_mod
 
     custom_pm = ProjectManager(projects_root)
-    monkeypatch.setattr(router_mod, "pm", custom_pm)
     monkeypatch.setattr(router_mod, "get_project_manager", lambda: custom_pm)
 
     # 供应商时长上限解析与队列都打桩：路由测试只看入参与持久化结果

--- a/tests/test_assets_router.py
+++ b/tests/test_assets_router.py
@@ -26,7 +26,7 @@ async def _assets_env(tmp_path, monkeypatch):
 
     # 3) monkeypatch symbols used inside assets router
     monkeypatch.setattr(assets, "async_session_factory", factory)
-    monkeypatch.setattr(assets, "pm", pm)
+    monkeypatch.setattr(assets, "get_project_manager", lambda: pm)
 
     app = FastAPI()
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")

--- a/tests/test_cost_estimation_router.py
+++ b/tests/test_cost_estimation_router.py
@@ -17,7 +17,7 @@ def _make_app():
 
 
 def _mock_pm(**overrides):
-    """Create a mock to replace the module-level ``pm`` singleton."""
+    """Create a mock to replace the ``get_project_manager()`` singleton getter."""
     mock = MagicMock()
     for k, v in overrides.items():
         setattr(mock, k, MagicMock(return_value=v))
@@ -26,7 +26,7 @@ def _mock_pm(**overrides):
 
 class TestCostEstimationRouter:
     def test_project_not_found_returns_404(self):
-        with patch.object(cost_estimation, "pm", _mock_pm(project_exists=False)):
+        with patch.object(cost_estimation, "get_project_manager", lambda: _mock_pm(project_exists=False)):
             with TestClient(_make_app()) as client:
                 resp = client.get("/api/v1/projects/nonexistent/cost-estimate")
         assert resp.status_code == 404
@@ -46,7 +46,7 @@ class TestCostEstimationRouter:
         mock_pm = _mock_pm(project_exists=True, load_project={"episodes": []})
 
         with (
-            patch.object(cost_estimation, "pm", mock_pm),
+            patch.object(cost_estimation, "get_project_manager", lambda: mock_pm),
             patch.object(cost_estimation, "CostEstimationService") as MockService,
         ):
             MockService.return_value.compute = AsyncMock(return_value=fake_result)

--- a/tests/test_jianying_draft_routes.py
+++ b/tests/test_jianying_draft_routes.py
@@ -57,7 +57,7 @@ def _client(monkeypatch, pm: ProjectManager) -> TestClient:
     """创建绑定到指定 ProjectManager 的 TestClient"""
     from server.routers import projects as proj_mod
 
-    monkeypatch.setattr(proj_mod, "pm", pm)
+    monkeypatch.setattr(proj_mod, "get_project_manager", lambda: pm)
 
     from server.app import app
 

--- a/tests/test_upload_restore_png.py
+++ b/tests/test_upload_restore_png.py
@@ -40,7 +40,7 @@ class TestUploadRestorePng:
         pm.save_project(project_name, project)
 
         # Patch router project manager to the temp projects root.
-        monkeypatch.setattr(versions_router, "pm", pm)
+        monkeypatch.setattr(versions_router, "get_project_manager", lambda: pm)
 
         # Switch back to v1 without creating a synthetic new version.
         result = await versions_router.restore_version(


### PR DESCRIPTION
## 背景

Spec #1161 收口工作的一环。全库此前散落约 15 处 `ProjectManager(app_data_dir())` 直接构造（13 个 router + `generation_tasks` + `lib/config/resolver` + `server/app` 启动流程），各自持有独立实例，无单一权威落点。

## 改动

- `lib/project_manager.py` 新增模块级懒加载单例 `get_project_manager()`（内部 `ProjectManager(app_data_dir())`）+ 配套 `_reset_project_manager_for_tests()`，作为唯一权威构造落点。
- 全部散装构造站点改为经该函数取用；改后全库仅 `lib/project_manager.py` 内部保留一处真实构造（`grep -rn "ProjectManager(app_data_dir())"` 复核仅剩该处）。传入自定义项目路径的构造（script_generator/episode_planner/agent_runtime/project_events）不在本次收编范围，保持不变。
- 保留各 router 既有 late-binding 约定：模块内以 `from lib.project_manager import get_project_manager` 引入后于请求期调用，测试沿用 `monkeypatch.setattr(module, "get_project_manager", ...)`，约 30+ 既有 router 测试零改动。
- `cost_estimation.py` / `assets.py` 及 6 个参考视频/剪映/上传相关测试原先直接打桩模块级 `pm` 变量（其中 2 处以 `raising=False` 掩盖 `pm` 已不存在），一并收敛到 `get_project_manager` late-binding，删除冗余打桩行。

纯收编重构，行为等价；无 API / 数据 / 用户可见变更。

## 验证

- `ruff check .` 全绿；`ruff format --check .` 668 files already formatted
- `basedpyright` 0 errors（829 warnings 均既有、与本改动无关）
- 全量 `pytest --cov` 5956 passed，总覆盖率 90%
- 已 rebase 至最新 main（含 #1169）

Closes #1163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 统一项目管理器的获取方式，确保各项项目、资源及生成相关功能使用一致的项目数据。
  * 优化应用启动时的项目配置同步流程。
* **稳定性**
  * 改进测试环境下项目管理器的替换与隔离，提升相关功能的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->