### PR TITLE
fix(settings): 用量筛选下拉显示供应商名称而非内部 provider id

### DIFF
--- a/frontend/src/components/pages/settings/UsageStatsSection.test.tsx
+++ b/frontend/src/components/pages/settings/UsageStatsSection.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { API } from "@/api";
+import { UsageStatsSection } from "./UsageStatsSection";
+import type { UsageStatsResponse } from "@/types";
+
+const STATS_RESPONSE: UsageStatsResponse = {
+  stats: [
+    {
+      provider: "custom-1",
+      display_name: "我的自定义供应商",
+      call_type: "image",
+      total_calls: 10,
+      success_calls: 9,
+      total_cost_usd: 1.2,
+      cost_by_currency: { USD: 1.2 },
+    },
+    {
+      provider: "gemini",
+      display_name: "Gemini",
+      call_type: "video",
+      total_calls: 5,
+      success_calls: 5,
+      total_cost_usd: 0.5,
+      cost_by_currency: { USD: 0.5 },
+    },
+  ],
+  period: { start: "2026-07-01", end: "2026-07-16" },
+};
+
+describe("UsageStatsSection provider filter dropdown (issue #1179)", () => {
+  it("renders provider options by display_name while keeping provider id as value", async () => {
+    vi.spyOn(API, "getUsageStatsGrouped").mockResolvedValue(STATS_RESPONSE);
+
+    render(<UsageStatsSection />);
+    await waitFor(() => expect(API.getUsageStatsGrouped).toHaveBeenCalled());
+
+    const select = await screen.findByRole("combobox", { name: "按供应商筛选" });
+    const options = Array.from(select.querySelectorAll("option"));
+    const byValue = Object.fromEntries(options.map((o) => [o.value, o.textContent]));
+
+    // 自定义供应商显示用户配置的名称，而不是内部 custom-1 id
+    expect(byValue["custom-1"]).toBe("我的自定义供应商");
+    // 内置供应商显示注册表名称
+    expect(byValue["gemini"]).toBe("Gemini");
+    // value 保持 provider 原值，筛选行为不受影响
+    expect(Object.keys(byValue).sort()).toEqual(["", "custom-1", "gemini"]);
+  });
+
+  it("falls back to the raw provider id when display_name is missing", async () => {
+    vi.spyOn(API, "getUsageStatsGrouped").mockResolvedValue({
+      stats: [
+        {
+          provider: "legacy-provider",
+          call_type: "image",
+          total_calls: 1,
+          success_calls: 1,
+          total_cost_usd: 0.1,
+          cost_by_currency: { USD: 0.1 },
+        },
+      ],
+      period: { start: "2026-07-01", end: "2026-07-16" },
+    });
+
+    render(<UsageStatsSection />);
+    await waitFor(() => expect(API.getUsageStatsGrouped).toHaveBeenCalled());
+
+    const select = await screen.findByRole("combobox", { name: "按供应商筛选" });
+    const option = select.querySelector('option[value="legacy-provider"]');
+    expect(option?.textContent).toBe("legacy-provider");
+  });
+});

--- a/frontend/src/components/pages/settings/UsageStatsSection.test.tsx
+++ b/frontend/src/components/pages/settings/UsageStatsSection.test.tsx
@@ -35,7 +35,7 @@ describe("UsageStatsSection provider filter dropdown (issue #1179)", () => {
     render(<UsageStatsSection />);
     await waitFor(() => expect(API.getUsageStatsGrouped).toHaveBeenCalled());
 
-    const select = await screen.findByRole("combobox", { name: "按供应商筛选" });
+    const select = await screen.findByRole("combobox");
     const options = Array.from(select.querySelectorAll("option"));
     const byValue = Object.fromEntries(options.map((o) => [o.value, o.textContent]));
 
@@ -65,7 +65,7 @@ describe("UsageStatsSection provider filter dropdown (issue #1179)", () => {
     render(<UsageStatsSection />);
     await waitFor(() => expect(API.getUsageStatsGrouped).toHaveBeenCalled());
 
-    const select = await screen.findByRole("combobox", { name: "按供应商筛选" });
+    const select = await screen.findByRole("combobox");
     const option = select.querySelector('option[value="legacy-provider"]');
     expect(option?.textContent).toBe("legacy-provider");
   });

--- a/frontend/src/components/pages/settings/UsageStatsSection.tsx
+++ b/frontend/src/components/pages/settings/UsageStatsSection.tsx
@@ -81,10 +81,15 @@ export function UsageStatsSection() {
     void fetchStats();
   }, [fetchStats]);
 
-  const providers = useMemo(
-    () => Array.from(new Set(stats.map((s) => s.provider))).sort(),
-    [stats],
-  );
+  const providers = useMemo(() => {
+    const byProvider = new Map<string, string | undefined>();
+    for (const s of stats) {
+      if (!byProvider.has(s.provider)) byProvider.set(s.provider, s.display_name);
+    }
+    return Array.from(byProvider.entries())
+      .map(([provider, displayName]) => ({ provider, displayName }))
+      .sort((a, b) => a.provider.localeCompare(b.provider));
+  }, [stats]);
 
   // Aggregate totals — used for the editorial header summary card.
   // 这里只是求和：用 Object.entries 直接遍历，避免 costEntries 的排序/过滤开销
@@ -180,9 +185,9 @@ export function UsageStatsSection() {
             className="rounded-[7px] border border-hairline-soft bg-bg-grad-a/45 px-3 py-1.5 text-[12px] text-text-2 transition-colors hover:border-hairline focus:border-accent/55 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           >
             <option value="">{t("all_providers")}</option>
-            {providers.map((p) => (
-              <option key={p} value={p}>
-                {p}
+            {providers.map(({ provider, displayName }) => (
+              <option key={provider} value={provider}>
+                {displayName ?? provider}
               </option>
             ))}
           </select>

--- a/frontend/src/components/pages/settings/UsageStatsSection.tsx
+++ b/frontend/src/components/pages/settings/UsageStatsSection.tsx
@@ -88,7 +88,7 @@ export function UsageStatsSection() {
     }
     return Array.from(byProvider.entries())
       .map(([provider, displayName]) => ({ provider, displayName }))
-      .sort((a, b) => a.provider.localeCompare(b.provider));
+      .sort((a, b) => (a.displayName ?? a.provider).localeCompare(b.displayName ?? b.provider));
   }, [stats]);
 
   // Aggregate totals — used for the editorial header summary card.

--- a/frontend/src/components/pages/settings/UsageStatsSection.tsx
+++ b/frontend/src/components/pages/settings/UsageStatsSection.tsx
@@ -82,14 +82,15 @@ export function UsageStatsSection() {
   }, [fetchStats]);
 
   const providers = useMemo(() => {
+    const locale = i18n.language;
     const byProvider = new Map<string, string | undefined>();
     for (const s of stats) {
       if (!byProvider.has(s.provider)) byProvider.set(s.provider, s.display_name);
     }
     return Array.from(byProvider.entries())
       .map(([provider, displayName]) => ({ provider, displayName }))
-      .sort((a, b) => (a.displayName ?? a.provider).localeCompare(b.displayName ?? b.provider));
-  }, [stats]);
+      .sort((a, b) => (a.displayName ?? a.provider).localeCompare(b.displayName ?? b.provider, locale));
+  }, [stats, i18n.language]);
 
   // Aggregate totals — used for the editorial header summary card.
   // 这里只是求和：用 Object.entries 直接遍历，避免 costEntries 的排序/过滤开销

--- a/frontend/src/components/pages/settings/UsageStatsSection.tsx
+++ b/frontend/src/components/pages/settings/UsageStatsSection.tsx
@@ -89,7 +89,7 @@ export function UsageStatsSection() {
     }
     return Array.from(byProvider.entries())
       .map(([provider, displayName]) => ({ provider, displayName }))
-      .sort((a, b) => (a.displayName ?? a.provider).localeCompare(b.displayName ?? b.provider, locale));
+      .sort((a, b) => (a.displayName || a.provider).localeCompare(b.displayName || b.provider, locale));
   }, [stats, i18n.language]);
 
   // Aggregate totals — used for the editorial header summary card.
@@ -188,7 +188,7 @@ export function UsageStatsSection() {
             <option value="">{t("all_providers")}</option>
             {providers.map(({ provider, displayName }) => (
               <option key={provider} value={provider}>
-                {displayName ?? provider}
+                {displayName || provider}
               </option>
             ))}
           </select>


### PR DESCRIPTION
Closes #1179

## 变更

用量统计的供应商筛选下拉向用户显示供应商名称（display_name）而非内部 provider id：自定义供应商显示用户配置的名称，内置供应商显示注册表名称。分组统计接口已返回 display_name 富化数据，本次为纯前端改动。

- `providers` 由「去重 provider 字符串数组」改为去重后保留 `{provider, displayName}` 的对象数组，以 provider 为 key 取首次出现的 display_name
- 下拉 `<option>` 的 `value` 保持 provider 原值不变，仅 label 改为 `displayName ?? provider`，筛选请求参数与行为不受影响
- 下拉按可见的 display_name 排序（回退 provider），避免出现「按隐藏内部 id 排序」的视觉错位

## 验证

- 新增组件测试 `UsageStatsSection.test.tsx`：断言下拉选项 label 渲染 display_name、value 保持 provider 原值，并覆盖 display_name 缺失时回退 provider id 的路径
- 前端质量门全绿：`pnpm typecheck` / `pnpm lint` / `vitest`（105 files / 930 tests 通过）
- `/code-review high --fix`：仅一处低严重度 UX 发现（排序键与展示不一致），已就地修复

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 使用量统计的“供应商”筛选下拉选项现优先展示供应商名称（display_name）；当名称不可用时自动回退为供应商标识。
  * 筛选所选项的底层值仍保持原始供应商标识，确保筛选逻辑一致可靠。
* **测试**
  * 新增测试覆盖供应商名称展示与缺失回退两种渲染场景，断言选项文本及对应 value（含空值选项）正确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->