### PR TITLE
refactor(cost-estimation): 费用预估图片/视频解析改直调 ConfigResolver

### DIFF
--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -48,14 +48,18 @@ class CostEstimationService:
 
         # Resolve current model config（共享单一 session）。估价以 T2I 为准（T2I/I2I 是正交能力槽，
         # T2I 缺失不应回落 I2I —— 那会拿错误能力的价目算费用）。
+        # image/video 的项目覆盖优先级由 ConfigResolver 统一解析，与执行路径共用同一套
+        # payload>project>全局默认 链路，此处 payload 传 None（预估无历史任务 payload 可排空）。
         async with self._resolver.session() as r:
             try:
-                image_provider, image_model = await r.default_image_backend_t2i()
+                resolved_image = await r.resolve_image_backend(project_data, None, capability="t2i")
+                image_provider, image_model = resolved_image.provider_id, resolved_image.model_id
             except Exception:
                 image_provider, image_model = "unknown", "unknown"
 
             try:
-                video_provider, video_model = await r.default_video_backend()
+                resolved_video = await r.resolve_video_backend(project_data, None)
+                video_provider, video_model = resolved_video.provider_id, resolved_video.model_id
             except Exception:
                 video_provider, video_model = "unknown", "unknown"
 
@@ -72,33 +76,7 @@ class CostEstimationService:
             except Exception:
                 audio_provider, audio_model = "unknown", "unknown"
 
-        # 项目级视频配置覆盖
-        # 优先读新格式 video_backend（"provider_id/model_id"），兼容旧 video_provider 字段
-        project_video_backend = project_data.get("video_backend") or ""
-        registry_video_provider_id: str | None = None
-        if project_video_backend and "/" in project_video_backend:
-            _vb_provider, _vb_model = project_video_backend.split("/", 1)
-            registry_video_provider_id = _vb_provider
-            video_provider = _vb_provider
-            video_model = _vb_model
-        else:
-            project_video_provider = project_data.get("video_provider")
-            if project_video_provider:
-                video_provider = project_video_provider
-                registry_video_provider_id = project_video_provider
-                # 项目级可能有自己的模型设置
-                project_video_settings = project_data.get("video_provider_settings", {}).get(project_video_provider, {})
-                if project_video_settings.get("model"):
-                    video_model = project_video_settings["model"]
-
-        # 项目级图片配置覆盖：按 T2I 槽估算（ProjectManager.load_project 已将旧 image_backend
-        # 字段 lazy 升级到 image_provider_t2i/i2i，所以这里只读新 T2I 槽）
-        project_image_pair = project_data.get("image_provider_t2i")
-        if isinstance(project_image_pair, str) and "/" in project_image_pair:
-            image_provider, image_model = project_image_pair.split("/", 1)
-
-        _resolve_pid = registry_video_provider_id or video_provider
-        _resolved_resolution = await self._resolver.resolve_resolution(project_data, _resolve_pid, video_model or "")
+        _resolved_resolution = await self._resolver.resolve_resolution(project_data, video_provider, video_model or "")
         video_resolution = _resolved_resolution or get_provider_fallback(video_provider)
 
         # Get actual costs

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -76,7 +76,10 @@ class CostEstimationService:
             except Exception:
                 audio_provider, audio_model = "unknown", "unknown"
 
-            _resolved_resolution = await r.resolve_resolution(project_data, video_provider, video_model or "")
+            try:
+                _resolved_resolution = await r.resolve_resolution(project_data, video_provider, video_model or "")
+            except Exception:
+                _resolved_resolution = None
         video_resolution = _resolved_resolution or get_provider_fallback(video_provider)
 
         # Get actual costs

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -76,7 +76,7 @@ class CostEstimationService:
             except Exception:
                 audio_provider, audio_model = "unknown", "unknown"
 
-        _resolved_resolution = await self._resolver.resolve_resolution(project_data, video_provider, video_model or "")
+            _resolved_resolution = await r.resolve_resolution(project_data, video_provider, video_model or "")
         video_resolution = _resolved_resolution or get_provider_fallback(video_provider)
 
         # Get actual costs

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -503,3 +503,25 @@ class TestCostEstimationService:
         # 这个契约同时排除掉 i2i 槽（gpt-image-1-edit）和 legacy（gemini-2.0-...）。
         assert result["models"]["image"]["provider"] == "unknown"
         assert result["models"]["image"]["model"] == "unknown"
+
+    async def test_cost_estimation_resolve_resolution_exception_degrades_gracefully(self, db_factory, monkeypatch):
+        """resolve_resolution 抛异常时预估整体降级而非中断，与 image/video/audio 三处 except 兜底同构。"""
+        resolver = ConfigResolver(db_factory)
+        tracker = UsageTracker(session_factory=db_factory)
+        service = CostEstimationService(resolver, tracker)
+
+        async def _raise(self, project, provider_id, model_id):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(ConfigResolver, "resolve_resolution", _raise)
+
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "episodes": [],
+        }
+
+        result = await service.compute(project_data, {}, project_name="test_resolution_exc")
+
+        # compute() 不因 resolve_resolution 异常而中断，其余字段照常返回
+        assert result["models"]["video"]["provider"] == "unknown"


### PR DESCRIPTION
## 背景

`CostEstimationService.compute()` 里手工重演了 image/video 的「项目覆盖 > 全局默认」优先级，与执行路径各写一套，是漂移风险源。本次收口为直调 `ConfigResolver`。

## 改动

- image 解析改 `resolver.resolve_image_backend(project_data, None, capability="t2i")`、video 改 `resolver.resolve_video_backend(project_data, None)`，与既有 `resolve_audio_backend(project_data, None)` 用法对齐，共用同一套 `payload>project>全局默认` 解析链。
- `resolve_resolution` 的 provider_id 参数由 `registry_video_provider_id or video_provider` 简化为解析后的规范 `video_provider`（`resolve_video_backend` 已返回规范 id）。
- 删除对 project.json 顶层遗留字段 `video_provider` / `video_provider_settings` 的手工兼容读取——全库检索确认这两个字段仅本文件当作 project.json 数据消费，其余引用（`generation_worker`、`resolver` payload 层、`generation_tasks`、`resume_executor`）均为**历史任务 payload** 上下文，非 project.json。`ConfigResolver` 只认新格式 `video_backend`，与代码库其余部分口径一致。

## 语义保持

- 「解析失败降级 `unknown`」展示语义不变：image/video/audio 三处 `except Exception` 兜底 `("unknown", "unknown")` 保留。逐组合核验（有/无 project 覆盖 × 全局是否抛异常），改动前后取值一致。
- project 覆盖存在时 `resolve_*_backend` 纯 dict 解析、无 DB、不抛，直接返回规范对；无覆盖时回落全局默认，与旧代码等价。

## 验证

- `uv run ruff check` + `ruff format --check`：通过
- `uv run basedpyright`（全量）：0 errors
- `uv run python -m pytest`（全量）：5974 passed

Closes #1167


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **错误修复**
  - 优化图像/视频后端识别流程：在同一会话内解析图像与视频后端信息，解析失败时将提供方与模型信息安全回退为“unknown”，避免影响整体成本预估。
  - 改进分辨率解析：更直接基于已解析的提供方与模型计算分辨率；异常时将降级为可继续完成计算的结果。
- **测试**
  - 新增异常场景用例，验证分辨率解析失败时仍能稳定返回可用模型信息并不中断流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->