### PR TITLE
feat(server): 新增 GenerationContext 单次解析入口模块 [Spec #1161]

### DIFF
--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -345,7 +345,7 @@ def _check_unique_defaults(models: list[ModelInput], _t: Callable[..., str]) -> 
 
 async def _invalidate_caches(request: Request) -> None:
     """清空 backend 实例缓存 + 刷新 worker 限流配置。"""
-    from server.services.generation_tasks import invalidate_backend_cache
+    from server.services.generation_context import invalidate_backend_cache
 
     invalidate_backend_cache()
     worker = getattr(request.app.state, "generation_worker", None)

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -283,7 +283,7 @@ def _cred_to_response(cred: ProviderCredential) -> CredentialResponse:
 
 
 async def _invalidate_caches(request: Request) -> None:
-    from server.services.generation_tasks import invalidate_backend_cache
+    from server.services.generation_context import invalidate_backend_cache
 
     invalidate_backend_cache()
     worker = getattr(request.app.state, "generation_worker", None)

--- a/server/services/generation_context.py
+++ b/server/services/generation_context.py
@@ -284,17 +284,16 @@ async def resolve_generation_context(
             max_reference_images: int | None = None
             try:
                 caps = await r.video_capabilities_for_model(resolved.provider_id, actual_model, project)
-            except ValueError as exc:
+                supported_durations = tuple(int(d) for d in caps.get("supported_durations") or [])
+                max_duration = caps.get("max_duration")
+                max_reference_images = caps.get("max_reference_images")
+            except Exception as exc:
                 logger.info(
                     "无法解析 video capabilities（%s/%s），能力值降级为空：%s",
                     resolved.provider_id,
                     actual_model,
                     exc,
                 )
-            else:
-                supported_durations = tuple(int(d) for d in caps.get("supported_durations") or [])
-                max_duration = caps.get("max_duration")
-                max_reference_images = caps.get("max_reference_images")
             video_result = VideoLaneResult(
                 provider_model=resolved,
                 backend_name=video_backend.name,

--- a/server/services/generation_context.py
+++ b/server/services/generation_context.py
@@ -1,0 +1,341 @@
+"""GenerationContext —— 生成任务 provider 解析产物的单次收口入口（见 ``docs/adr/0049``）。
+
+``resolve_generation_context`` 在单个 ConfigResolver session 内完成全部声明 lane 的解析与
+backend 构造，返回不可变的 :class:`GenerationContext`（MediaGenerator + 各 lane 结果值对象）。
+每条 lane 固定求解顺序：解析 ProviderModel → 经 ``assemble_backend``（``docs/adr/0039``）构造
+backend → 按实际身份查 resolution 与能力。
+
+查询身份 =（规范 registry provider_id, backend 实际 model）：provider 在构造缝中不可能漂移，
+而族别名 provider（如 ark-agent-plan 复用 Ark backend）的 ``backend.name`` 是族名、非 registry
+key，不能用作查询键；model 是唯一真实漂移轴（自定义供应商目标 model 被禁用时 loader 静默回退），
+故取 backend 实际 ``.model``。lane 结果同时暴露 ``provider_model``（规范 registry 身份）与
+``backend_name`` / ``backend_model``（backend 报告的实际身份）两组字段。
+
+backend 实例缓存随本模块承载：缓存是 server 执行层关切（``docs/adr/0039``「缓存留在调用方」），
+供应商配置变更路由经 ``invalidate_backend_cache()`` 统一失效。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from lib.backend_assembly import assemble_backend
+from lib.config.resolver import ConfigResolver, get_provider_fallback
+from lib.db.base import DEFAULT_USER_ID
+from lib.gemini_shared import get_shared_rate_limiter
+from lib.media_generator import MediaGenerator
+from lib.project_manager import get_project_manager
+
+if TYPE_CHECKING:
+    from lib.config.resolver import ProviderModel
+
+logger = logging.getLogger(__name__)
+
+rate_limiter = get_shared_rate_limiter()
+
+# 按 (channel, provider_name, model) 缓存 Backend 实例，避免每次任务重建 API 客户端
+_backend_cache: dict[tuple[str, str, str | None], Any] = {}
+
+
+def invalidate_backend_cache() -> None:
+    """清空 Backend 实例缓存。在供应商配置变更后调用。"""
+    _backend_cache.clear()
+
+
+async def _get_or_create_video_backend(
+    provider_name: str,
+    provider_settings: dict,
+    resolver: ConfigResolver,
+    *,
+    default_video_model: str | None = None,
+):
+    """获取或创建 VideoBackend 实例（带缓存）。
+
+    provider_name 可以是旧格式（gemini/seedance/grok）或新格式（gemini-aistudio/gemini-vertex）。
+    通过 resolver 按需加载供应商配置。
+    default_video_model: 全局默认视频模型，当 provider_settings 中无 model 时作为 fallback。
+    """
+    effective_model = provider_settings.get("model") or default_video_model or None
+    cache_key = ("video", provider_name, effective_model)
+    if cache_key in _backend_cache:
+        return _backend_cache[cache_key]
+
+    backend = await assemble_backend(
+        provider_id=provider_name,
+        media_type="video",
+        model_id=effective_model,
+        resolver=resolver,
+        rate_limiter=rate_limiter,
+    )
+    _backend_cache[cache_key] = backend
+    return backend
+
+
+async def _get_or_create_image_backend(
+    provider_name: str,
+    provider_settings: dict,
+    resolver: ConfigResolver,
+    *,
+    default_image_model: str | None = None,
+):
+    """获取或创建 ImageBackend 实例（带缓存）。"""
+    effective_model = provider_settings.get("model") or default_image_model or None
+    cache_key = ("image", provider_name, effective_model)
+    if cache_key in _backend_cache:
+        return _backend_cache[cache_key]
+
+    backend = await assemble_backend(
+        provider_id=provider_name,
+        media_type="image",
+        model_id=effective_model,
+        resolver=resolver,
+        rate_limiter=rate_limiter,
+    )
+    _backend_cache[cache_key] = backend
+    return backend
+
+
+async def _get_or_create_audio_backend(
+    provider_name: str,
+    provider_settings: dict,
+    resolver: ConfigResolver,
+    *,
+    default_audio_model: str | None = None,
+):
+    """获取或创建 AudioBackend 实例（带缓存）。"""
+    effective_model = provider_settings.get("model") or default_audio_model or None
+    cache_key = ("audio", provider_name, effective_model)
+    if cache_key in _backend_cache:
+        return _backend_cache[cache_key]
+
+    # audio 无 gemini/kling 媒体特例：自定义 + 简单族统一经构造缝
+    backend = await assemble_backend(
+        provider_id=provider_name,
+        media_type="audio",
+        model_id=effective_model,
+        resolver=resolver,
+        rate_limiter=rate_limiter,
+    )
+    _backend_cache[cache_key] = backend
+    return backend
+
+
+@dataclass(frozen=True)
+class ImageLaneRequest:
+    """声明本次任务需要 image lane。capability 决定 t2i / i2i 默认槽（``docs/adr/0001``）。"""
+
+    capability: Literal["t2i", "i2i"] = "t2i"
+
+
+@dataclass(frozen=True)
+class VideoLaneRequest:
+    """声明本次任务需要 video lane。"""
+
+
+@dataclass(frozen=True)
+class AudioLaneRequest:
+    """声明本次任务需要 audio lane（旁白 TTS）。"""
+
+
+@dataclass(frozen=True)
+class ImageLaneResult:
+    """image lane 解析产物。
+
+    ``provider_model`` 是规范 registry 身份；``backend_name`` / ``backend_model`` 是构造后
+    backend 报告的实际身份——自定义供应商目标 model 被禁用回退时 ``backend_model`` 可能与
+    ``provider_model.model_id`` 不同。``resolution`` 为 None 表示调用时不传 SDK 参数
+    （``docs/adr/0019``）。
+    """
+
+    provider_model: ProviderModel
+    backend_name: str
+    backend_model: str
+    resolution: str | None
+
+
+@dataclass(frozen=True)
+class VideoLaneResult:
+    """video lane 解析产物。
+
+    能力字段（``supported_durations`` / ``max_duration`` / ``max_reference_images``）在能力
+    查询失败时降级为空值（空元组 / None）放行：能力是已选定 provider/model 的元数据，缺失
+    不代表不可调用，守卫遇空值不施加限制、把决策推给 backend。``resolution_or_fallback``
+    供需要非空档位的调用方（参考视频路径），其余语义同 :class:`ImageLaneResult`。
+    """
+
+    provider_model: ProviderModel
+    backend_name: str
+    backend_model: str
+    resolution: str | None
+    resolution_or_fallback: str
+    supported_durations: tuple[int, ...]
+    max_duration: int | None
+    max_reference_images: int | None
+
+
+@dataclass(frozen=True)
+class AudioLaneResult:
+    """audio lane 解析产物。narration voice/speed 与 backend 解析在同一 session 内交付。"""
+
+    provider_model: ProviderModel
+    backend_name: str
+    backend_model: str
+    narration_voice: str
+    narration_speed: float | None
+
+
+def _lane_not_declared(lane: str, request_hint: str) -> RuntimeError:
+    return RuntimeError(
+        f"{lane} lane 未声明：调用 resolve_generation_context 时传入 {request_hint} 才能访问该 lane 的解析产物"
+    )
+
+
+@dataclass(frozen=True)
+class GenerationContext:
+    """单次解析交付的全部产物：MediaGenerator + 各声明 lane 的结果值对象。
+
+    lane 字段为 None 表示该 lane 未声明；经同名 property 访问未声明 lane 直接抛
+    RuntimeError（fail-loud，返回类型非 Optional）。测试可用本 dataclass 直接拼装假 context。
+    """
+
+    generator: MediaGenerator
+    image_lane: ImageLaneResult | None = None
+    video_lane: VideoLaneResult | None = None
+    audio_lane: AudioLaneResult | None = None
+
+    @property
+    def image(self) -> ImageLaneResult:
+        if self.image_lane is None:
+            raise _lane_not_declared("image", "image=ImageLaneRequest(...)")
+        return self.image_lane
+
+    @property
+    def video(self) -> VideoLaneResult:
+        if self.video_lane is None:
+            raise _lane_not_declared("video", "video=VideoLaneRequest()")
+        return self.video_lane
+
+    @property
+    def audio(self) -> AudioLaneResult:
+        if self.audio_lane is None:
+            raise _lane_not_declared("audio", "audio=AudioLaneRequest()")
+        return self.audio_lane
+
+
+async def resolve_generation_context(
+    project_name: str,
+    payload: dict | None,
+    *,
+    project: dict,
+    user_id: str = DEFAULT_USER_ID,
+    image: ImageLaneRequest | None = None,
+    video: VideoLaneRequest | None = None,
+    audio: AudioLaneRequest | None = None,
+) -> GenerationContext:
+    """在单个 ConfigResolver session 内解析全部声明 lane、构造 backend 并组装 MediaGenerator。
+
+    lane 传即声明、None 跳过，任务只为用到的 lane 付出配置要求与构造成本。任一声明 lane
+    的解析或构造失败即原样上抛、整次调用失败——无部分结果、无跨 provider 兜底；仅能力
+    查询失败降级空值放行。``project`` 是调用方已加载的项目快照，本函数不读盘。
+    """
+    from lib.db import async_session_factory
+
+    project_path = await asyncio.to_thread(get_project_manager().get_project_path, project_name)
+    resolver = ConfigResolver(async_session_factory)
+
+    image_result: ImageLaneResult | None = None
+    video_result: VideoLaneResult | None = None
+    audio_result: AudioLaneResult | None = None
+    image_backend: Any = None
+    video_backend: Any = None
+    audio_backend: Any = None
+
+    async with resolver.session() as r:
+        if image is not None:
+            resolved = await r.resolve_image_backend(project, payload, capability=image.capability)
+            image_backend = await _get_or_create_image_backend(
+                resolved.provider_id,
+                {},
+                r,
+                default_image_model=resolved.model_id or None,
+            )
+            image_result = ImageLaneResult(
+                provider_model=resolved,
+                backend_name=image_backend.name,
+                backend_model=image_backend.model,
+                resolution=await r.resolve_resolution(project, resolved.provider_id, image_backend.model),
+            )
+
+        if video is not None:
+            resolved = await r.resolve_video_backend(project, payload)
+            video_backend = await _get_or_create_video_backend(
+                resolved.provider_id,
+                {},
+                r,
+                default_video_model=resolved.model_id or None,
+            )
+            actual_model = video_backend.model
+            resolution = await r.resolve_resolution(project, resolved.provider_id, actual_model)
+            supported_durations: tuple[int, ...] = ()
+            max_duration: int | None = None
+            max_reference_images: int | None = None
+            try:
+                caps = await r.video_capabilities_for_model(resolved.provider_id, actual_model, project)
+            except ValueError as exc:
+                logger.info(
+                    "无法解析 video capabilities（%s/%s），能力值降级为空：%s",
+                    resolved.provider_id,
+                    actual_model,
+                    exc,
+                )
+            else:
+                supported_durations = tuple(int(d) for d in caps.get("supported_durations") or [])
+                max_duration = caps.get("max_duration")
+                max_reference_images = caps.get("max_reference_images")
+            video_result = VideoLaneResult(
+                provider_model=resolved,
+                backend_name=video_backend.name,
+                backend_model=actual_model,
+                resolution=resolution,
+                resolution_or_fallback=resolution or get_provider_fallback(resolved.provider_id),
+                supported_durations=supported_durations,
+                max_duration=max_duration,
+                max_reference_images=max_reference_images,
+            )
+
+        if audio is not None:
+            resolved = await r.resolve_audio_backend(project, payload)
+            audio_backend = await _get_or_create_audio_backend(
+                resolved.provider_id,
+                {},
+                r,
+                default_audio_model=resolved.model_id or None,
+            )
+            audio_result = AudioLaneResult(
+                provider_model=resolved,
+                backend_name=audio_backend.name,
+                backend_model=audio_backend.model,
+                narration_voice=await r.resolve_narration_voice(project),
+                narration_speed=await r.resolve_narration_speed(project),
+            )
+
+    generator = MediaGenerator(
+        project_path,
+        rate_limiter=rate_limiter,
+        image_backend=image_backend,
+        video_backend=video_backend,
+        audio_backend=audio_backend,
+        config_resolver=resolver,
+        user_id=user_id,
+        image_provider_id=image_result.provider_model.provider_id if image_result else None,
+        video_provider_id=video_result.provider_model.provider_id if video_result else None,
+    )
+    return GenerationContext(
+        generator=generator,
+        image_lane=image_result,
+        video_lane=video_result,
+        audio_lane=audio_result,
+    )

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from lib.config.resolver import ConfigResolver, ProviderModel
 
 from lib.asset_types import ASSET_SPECS
-from lib.backend_assembly import assemble_backend
 from lib.config.registry import PROVIDER_REGISTRY
 from lib.db.base import DEFAULT_USER_ID
 from lib.gemini_shared import get_shared_rate_limiter
@@ -51,17 +50,14 @@ from lib.storyboard_sequence import (
 )
 from lib.thumbnail import extract_video_thumbnail
 from lib.video_backends.base import VideoCapabilityError
+from server.services.generation_context import (
+    _get_or_create_audio_backend,
+    _get_or_create_image_backend,
+    _get_or_create_video_backend,
+)
 
 rate_limiter = get_shared_rate_limiter()
 logger = logging.getLogger(__name__)
-
-# 按 (channel, provider_name, model) 缓存 Backend 实例，避免每次任务重建 API 客户端
-_backend_cache: dict[tuple[str, str, str | None], Any] = {}
-
-
-def invalidate_backend_cache() -> None:
-    """清空 VideoBackend 实例缓存。在配置变更后调用。"""
-    _backend_cache.clear()
 
 
 async def _resolve_effective_image_backend(
@@ -95,84 +91,6 @@ async def _resolve_resolution(project: dict, provider_id: str, model_id: str) ->
 
     resolver = ConfigResolver(async_session_factory)
     return await resolver.resolve_resolution(project, provider_id, model_id)
-
-
-async def _get_or_create_video_backend(
-    provider_name: str,
-    provider_settings: dict,
-    resolver: ConfigResolver,
-    *,
-    default_video_model: str | None = None,
-):
-    """获取或创建 VideoBackend 实例（带缓存）。
-
-    provider_name 可以是旧格式（gemini/seedance/grok）或新格式（gemini-aistudio/gemini-vertex）。
-    通过 resolver 按需加载供应商配置。
-    default_video_model: 全局默认视频模型，当 provider_settings 中无 model 时作为 fallback。
-    """
-    effective_model = provider_settings.get("model") or default_video_model or None
-    cache_key = ("video", provider_name, effective_model)
-    if cache_key in _backend_cache:
-        return _backend_cache[cache_key]
-
-    backend = await assemble_backend(
-        provider_id=provider_name,
-        media_type="video",
-        model_id=effective_model,
-        resolver=resolver,
-        rate_limiter=rate_limiter,
-    )
-    _backend_cache[cache_key] = backend
-    return backend
-
-
-async def _get_or_create_image_backend(
-    provider_name: str,
-    provider_settings: dict,
-    resolver: ConfigResolver,
-    *,
-    default_image_model: str | None = None,
-):
-    """获取或创建 ImageBackend 实例（带缓存）。"""
-    effective_model = provider_settings.get("model") or default_image_model or None
-    cache_key = ("image", provider_name, effective_model)
-    if cache_key in _backend_cache:
-        return _backend_cache[cache_key]
-
-    backend = await assemble_backend(
-        provider_id=provider_name,
-        media_type="image",
-        model_id=effective_model,
-        resolver=resolver,
-        rate_limiter=rate_limiter,
-    )
-    _backend_cache[cache_key] = backend
-    return backend
-
-
-async def _get_or_create_audio_backend(
-    provider_name: str,
-    provider_settings: dict,
-    resolver: ConfigResolver,
-    *,
-    default_audio_model: str | None = None,
-):
-    """获取或创建 AudioBackend 实例（带缓存）。"""
-    effective_model = provider_settings.get("model") or default_audio_model or None
-    cache_key = ("audio", provider_name, effective_model)
-    if cache_key in _backend_cache:
-        return _backend_cache[cache_key]
-
-    # audio 无 gemini/kling 媒体特例：自定义 + 简单族统一经构造缝
-    backend = await assemble_backend(
-        provider_id=provider_name,
-        media_type="audio",
-        model_id=effective_model,
-        resolver=resolver,
-        rate_limiter=rate_limiter,
-    )
-    _backend_cache[cache_key] = backend
-    return backend
 
 
 async def _resolve_video_backend(

--- a/tests/server/test_generation_context.py
+++ b/tests/server/test_generation_context.py
@@ -1,0 +1,347 @@
+"""resolve_generation_context 公开接口测试：lane 声明与跳过 / fail-loud property /
+按实际身份查 resolution 与能力 / 能力查询降级空值 / 原子失败 / backend 缓存与失效。
+
+按 ADR 0049 的测试口径：真实内存 DB + tmp_path 真 ProjectManager + fake backend
+（仅替换 assemble_backend 构造缝），不 mock ConfigResolver / ProjectManager，不断言私有属性。
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from lib.config.registry import PROVIDER_REGISTRY
+from lib.config.resolver import ProviderModel, get_provider_fallback
+from lib.custom_provider import make_provider_id
+from lib.db.base import Base
+from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
+from lib.media_generator import MediaGenerator
+from lib.project_manager import ProjectManager
+from server.services import generation_context
+from server.services.generation_context import (
+    AudioLaneRequest,
+    AudioLaneResult,
+    GenerationContext,
+    ImageLaneRequest,
+    ImageLaneResult,
+    VideoLaneRequest,
+    VideoLaneResult,
+    resolve_generation_context,
+)
+
+
+def _registry_video_model(provider_id: str) -> str:
+    """从 registry 取该 provider 的任一视频 model id，避免硬编码供应商数据。"""
+    meta = PROVIDER_REGISTRY[provider_id]
+    return next(mid for mid, mi in meta.models.items() if mi.media_type == "video")
+
+
+@dataclass
+class _FakeBackend:
+    name: str
+    model: str
+
+
+@pytest.fixture
+async def session_factory(monkeypatch):
+    """真实内存 DB：建全部 ORM 表，并把 lib.db.async_session_factory 指向它。"""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr("lib.db.async_session_factory", factory)
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def project_env(monkeypatch, tmp_path: Path):
+    """tmp_path 下的真 ProjectManager + 已存在的项目目录。"""
+    pm = ProjectManager(tmp_path / "projects")
+    (tmp_path / "projects" / "demo").mkdir(parents=True)
+    monkeypatch.setattr(generation_context, "get_project_manager", lambda: pm)
+    return pm
+
+
+@pytest.fixture(autouse=True)
+def _clean_backend_cache():
+    generation_context.invalidate_backend_cache()
+    yield
+    generation_context.invalidate_backend_cache()
+
+
+@pytest.fixture
+def fake_assemble(monkeypatch):
+    """替换 backend 构造缝：默认按请求原样回声身份，记录每次构造。"""
+    calls: list[tuple[str, str, str | None]] = []
+
+    async def _assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
+        calls.append((provider_id, media_type, model_id))
+        return _FakeBackend(name=provider_id, model=model_id or "default-model")
+
+    monkeypatch.setattr(generation_context, "assemble_backend", _assemble)
+    return calls
+
+
+async def _seed_custom_video_provider(session_factory) -> str:
+    """种一个自定义供应商：目标 model 已禁用、默认 model 存活（带 resolution 与时长表）。"""
+    async with session_factory() as session:
+        provider = CustomProvider(
+            display_name="Prov",
+            discovery_format="openai",
+            base_url="https://api.example.com",
+            api_key="k",
+        )
+        session.add(provider)
+        await session.flush()
+        session.add(
+            CustomProviderModel(
+                provider_id=provider.id,
+                model_id="m-dead",
+                display_name="Dead",
+                endpoint="newapi-video",
+                is_default=False,
+                is_enabled=False,
+            )
+        )
+        session.add(
+            CustomProviderModel(
+                provider_id=provider.id,
+                model_id="m-live",
+                display_name="Live",
+                endpoint="newapi-video",
+                is_default=True,
+                is_enabled=True,
+                resolution="540p",
+                supported_durations=json.dumps([4, 6, 8]),
+            )
+        )
+        await session.commit()
+        return make_provider_id(provider.id)
+
+
+class TestLaneDeclaration:
+    async def test_only_declared_lanes_are_constructed(self, session_factory, project_env, fake_assemble):
+        """只声明 image lane：不解析、不构造 video/audio，视频供应商缺配置不影响图片任务。"""
+        project = {"image_provider_t2i": "ark/img-model-x"}
+        ctx = await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest())
+
+        assert [media for _, media, _ in fake_assemble] == ["image"]
+        assert ctx.image.provider_model == ProviderModel("ark", "img-model-x")
+        assert ctx.image.backend_name == "ark"
+        assert ctx.image.backend_model == "img-model-x"
+        with pytest.raises(RuntimeError, match="video lane 未声明"):
+            _ = ctx.video
+        with pytest.raises(RuntimeError, match="audio lane 未声明"):
+            _ = ctx.audio
+
+    async def test_no_lane_declared_still_returns_generator(self, session_factory, project_env, fake_assemble):
+        ctx = await resolve_generation_context("demo", None, project={})
+        assert isinstance(ctx.generator, MediaGenerator)
+        assert fake_assemble == []
+        with pytest.raises(RuntimeError, match="image lane 未声明"):
+            _ = ctx.image
+
+    async def test_i2i_capability_selects_i2i_slot(self, session_factory, project_env, fake_assemble):
+        project = {
+            "image_provider_t2i": "ark/img-t2i",
+            "image_provider_i2i": "ark/img-i2i",
+        }
+        ctx = await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest(capability="i2i"))
+        assert ctx.image.provider_model == ProviderModel("ark", "img-i2i")
+
+    async def test_all_three_lanes(self, session_factory, project_env, fake_assemble):
+        video_model = _registry_video_model("ark")
+        project = {
+            "image_provider_t2i": "ark/img-model-x",
+            "video_backend": f"ark/{video_model}",
+            "audio_backend": "dashscope/tts-model-x",
+        }
+        ctx = await resolve_generation_context(
+            "demo",
+            None,
+            project=project,
+            image=ImageLaneRequest(),
+            video=VideoLaneRequest(),
+            audio=AudioLaneRequest(),
+        )
+        assert sorted(media for _, media, _ in fake_assemble) == ["audio", "image", "video"]
+        assert ctx.video.provider_model == ProviderModel("ark", video_model)
+        assert ctx.audio.provider_model == ProviderModel("dashscope", "tts-model-x")
+
+
+class TestVideoLane:
+    async def test_registry_capabilities_and_fallback_resolution(self, session_factory, project_env, fake_assemble):
+        video_model = _registry_video_model("ark")
+        expected = PROVIDER_REGISTRY["ark"].models[video_model]
+        ctx = await resolve_generation_context(
+            "demo", None, project={"video_backend": f"ark/{video_model}"}, video=VideoLaneRequest()
+        )
+
+        assert ctx.video.supported_durations == tuple(expected.supported_durations or [])
+        assert ctx.video.max_duration == max(expected.supported_durations or [0])
+        assert ctx.video.max_reference_images == expected.max_reference_images
+        assert ctx.video.resolution is None
+        assert ctx.video.resolution_or_fallback == get_provider_fallback("ark")
+
+    async def test_resolution_from_model_settings(self, session_factory, project_env, fake_assemble):
+        video_model = _registry_video_model("ark")
+        project = {
+            "video_backend": f"ark/{video_model}",
+            "model_settings": {f"ark/{video_model}": {"resolution": "480p"}},
+        }
+        ctx = await resolve_generation_context("demo", None, project=project, video=VideoLaneRequest())
+        assert ctx.video.resolution == "480p"
+        assert ctx.video.resolution_or_fallback == "480p"
+
+    async def test_capability_query_failure_degrades_to_empty(self, session_factory, project_env, monkeypatch):
+        """fake backend 报告 registry 之外的 model：能力查询失败降级空值，整次调用照常成功。"""
+
+        async def _assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
+            return _FakeBackend(name=provider_id, model="mystery-model")
+
+        monkeypatch.setattr(generation_context, "assemble_backend", _assemble)
+        video_model = _registry_video_model("ark")
+        ctx = await resolve_generation_context(
+            "demo", None, project={"video_backend": f"ark/{video_model}"}, video=VideoLaneRequest()
+        )
+        assert ctx.video.supported_durations == ()
+        assert ctx.video.max_duration is None
+        assert ctx.video.max_reference_images is None
+        assert ctx.video.backend_model == "mystery-model"
+
+    async def test_payload_overrides_project(self, session_factory, project_env, fake_assemble):
+        """payload > project：历史任务携带的 video_provider 决定实际解析身份。"""
+        ark_model = _registry_video_model("ark")
+        grok_model = _registry_video_model("grok")
+        ctx = await resolve_generation_context(
+            "demo",
+            {"video_provider": "grok", "video_model": grok_model},
+            project={"video_backend": f"ark/{ark_model}"},
+            video=VideoLaneRequest(),
+        )
+        assert ctx.video.provider_model == ProviderModel("grok", grok_model)
+
+
+class TestActualIdentityQueries:
+    async def test_custom_model_fallback_queries_by_actual_model(self, session_factory, project_env, monkeypatch):
+        """自定义供应商目标 model 被禁用回退：resolution 与能力按 backend 实际 model 查询。"""
+        provider_id = await _seed_custom_video_provider(session_factory)
+
+        async def _assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
+            # 模拟 load_custom_backend 的回退：请求 m-dead，实际构造出默认启用的 m-live
+            return _FakeBackend(name=provider_id, model="m-live")
+
+        monkeypatch.setattr(generation_context, "assemble_backend", _assemble)
+        ctx = await resolve_generation_context(
+            "demo", None, project={"video_backend": f"{provider_id}/m-dead"}, video=VideoLaneRequest()
+        )
+
+        assert ctx.video.provider_model == ProviderModel(provider_id, "m-dead")
+        assert ctx.video.backend_model == "m-live"
+        # resolution 命中 m-live（实际身份）的 DB 默认，而非按解析意图 m-dead 落空
+        assert ctx.video.resolution == "540p"
+        # 能力同样按 m-live 查询
+        assert ctx.video.supported_durations == (4, 6, 8)
+        assert ctx.video.max_duration == 8
+        assert ctx.video.max_reference_images == 0
+
+
+class TestAudioLane:
+    async def test_narration_voice_and_speed_from_project(self, session_factory, project_env, fake_assemble):
+        project = {
+            "audio_backend": "dashscope/tts-model-x",
+            "narration_voice": "Cherry",
+            "narration_speed": 1.25,
+        }
+        ctx = await resolve_generation_context("demo", None, project=project, audio=AudioLaneRequest())
+        assert ctx.audio.narration_voice == "Cherry"
+        assert ctx.audio.narration_speed == 1.25
+        assert ctx.audio.backend_name == "dashscope"
+        assert ctx.audio.backend_model == "tts-model-x"
+
+    async def test_narration_defaults_when_unset(self, session_factory, project_env, fake_assemble):
+        project = {"audio_backend": "dashscope/tts-model-x"}
+        ctx = await resolve_generation_context("demo", None, project=project, audio=AudioLaneRequest())
+        assert isinstance(ctx.audio.narration_voice, str) and ctx.audio.narration_voice
+        assert ctx.audio.narration_speed is None
+
+
+class TestAtomicFailure:
+    async def test_declared_lane_construction_failure_fails_whole_call(self, session_factory, project_env, monkeypatch):
+        """image 成功后 video 构造失败：整次调用原样上抛，无部分结果。"""
+
+        async def _assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
+            if media_type == "video":
+                raise ValueError("video backend 构造失败")
+            return _FakeBackend(name=provider_id, model=model_id or "default-model")
+
+        monkeypatch.setattr(generation_context, "assemble_backend", _assemble)
+        video_model = _registry_video_model("ark")
+        with pytest.raises(ValueError, match="video backend 构造失败"):
+            await resolve_generation_context(
+                "demo",
+                None,
+                project={"image_provider_t2i": "ark/img-model-x", "video_backend": f"ark/{video_model}"},
+                image=ImageLaneRequest(),
+                video=VideoLaneRequest(),
+            )
+
+    async def test_missing_project_dir_raises(self, session_factory, project_env, fake_assemble):
+        with pytest.raises(FileNotFoundError):
+            await resolve_generation_context("nope", None, project={}, image=ImageLaneRequest())
+
+
+class TestBackendCache:
+    async def test_backend_reused_until_invalidated(self, session_factory, project_env, fake_assemble):
+        project = {"image_provider_t2i": "ark/img-model-x"}
+        await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest())
+        await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest())
+        assert len(fake_assemble) == 1, "第二次调用须命中缓存，不再重建 backend"
+
+        generation_context.invalidate_backend_cache()
+        await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest())
+        assert len(fake_assemble) == 2, "失效后须重建 backend"
+
+
+class TestValueObjectAssembly:
+    def test_fake_context_assembles_from_frozen_dataclasses(self, tmp_path: Path):
+        """消费方测试的拼装路径：frozen dataclass 直接构造假 context，property 原样返回。"""
+        lane = VideoLaneResult(
+            provider_model=ProviderModel("ark", "m"),
+            backend_name="ark",
+            backend_model="m",
+            resolution=None,
+            resolution_or_fallback="720p",
+            supported_durations=(4, 8),
+            max_duration=8,
+            max_reference_images=9,
+        )
+        ctx = GenerationContext(generator=MediaGenerator(tmp_path / "p"), video_lane=lane)
+        assert ctx.video is lane
+        with pytest.raises(RuntimeError, match="image lane 未声明"):
+            _ = ctx.image
+
+    def test_lane_results_are_frozen(self):
+        lane = ImageLaneResult(
+            provider_model=ProviderModel("ark", "m"),
+            backend_name="ark",
+            backend_model="m",
+            resolution=None,
+        )
+        with pytest.raises(AttributeError):
+            lane.resolution = "720p"  # type: ignore[misc]
+
+    def test_audio_lane_result_shape(self):
+        lane = AudioLaneResult(
+            provider_model=ProviderModel("dashscope", "tts"),
+            backend_name="dashscope",
+            backend_model="tts",
+            narration_voice="Cherry",
+            narration_speed=None,
+        )
+        assert lane.narration_voice == "Cherry"

--- a/tests/test_execute_tts_task.py
+++ b/tests/test_execute_tts_task.py
@@ -11,7 +11,7 @@ from typing import cast
 import pytest
 
 from lib.config.resolver import ConfigResolver, ProviderModel
-from server.services import generation_tasks
+from server.services import generation_context, generation_tasks
 
 
 def _async_return(value):
@@ -140,12 +140,12 @@ class TestGetOrCreateAudioBackend:
             calls.append((provider_id, media_type, model_id))
             return sentinel
 
-        monkeypatch.setattr(generation_tasks, "assemble_backend", _fake_assemble)
-        monkeypatch.setattr(generation_tasks, "_backend_cache", {})
+        monkeypatch.setattr(generation_context, "assemble_backend", _fake_assemble)
+        monkeypatch.setattr(generation_context, "_backend_cache", {})
 
         resolver = cast(ConfigResolver, None)
-        b1 = await generation_tasks._get_or_create_audio_backend("custom-3", {"model": "tts-1"}, resolver)
-        b2 = await generation_tasks._get_or_create_audio_backend("custom-3", {"model": "tts-1"}, resolver)
+        b1 = await generation_context._get_or_create_audio_backend("custom-3", {"model": "tts-1"}, resolver)
+        b2 = await generation_context._get_or_create_audio_backend("custom-3", {"model": "tts-1"}, resolver)
 
         assert b1 is sentinel and b2 is sentinel
         assert calls == [("custom-3", "audio", "tts-1")], "第二次调用须命中缓存，不再重建 backend"
@@ -158,14 +158,14 @@ class TestGetOrCreateAudioBackend:
             created.append((provider_id, media_type, model_id))
             return sentinel
 
-        monkeypatch.setattr(generation_tasks, "assemble_backend", _fake_assemble)
-        monkeypatch.setattr(generation_tasks, "_backend_cache", {})
+        monkeypatch.setattr(generation_context, "assemble_backend", _fake_assemble)
+        monkeypatch.setattr(generation_context, "_backend_cache", {})
 
         resolver = cast(ConfigResolver, None)
-        b1 = await generation_tasks._get_or_create_audio_backend(
+        b1 = await generation_context._get_or_create_audio_backend(
             "dashscope", {}, resolver, default_audio_model="qwen3-tts-flash"
         )
-        b2 = await generation_tasks._get_or_create_audio_backend(
+        b2 = await generation_context._get_or_create_audio_backend(
             "dashscope", {}, resolver, default_audio_model="qwen3-tts-flash"
         )
         assert b1 is sentinel and b2 is sentinel
@@ -178,10 +178,10 @@ class TestGetOrCreateAudioBackend:
             calls.append(model_id)
             return object()
 
-        monkeypatch.setattr(generation_tasks, "assemble_backend", _fake_assemble)
-        monkeypatch.setattr(generation_tasks, "_backend_cache", {})
+        monkeypatch.setattr(generation_context, "assemble_backend", _fake_assemble)
+        monkeypatch.setattr(generation_context, "_backend_cache", {})
 
-        await generation_tasks._get_or_create_audio_backend(
+        await generation_context._get_or_create_audio_backend(
             "dashscope",
             {"model": "explicit-model"},
             cast(ConfigResolver, None),


### PR DESCRIPTION
## 概述

新增深模块 `server/services/generation_context.py`，暴露唯一入口 `resolve_generation_context(project_name, payload, *, project, user_id, image=, video=, audio=)`：在单个 ConfigResolver session 内完成全部声明 lane 的解析与 backend 构造（经 `assemble_backend`），返回不可变的 `GenerationContext`（`generator` + 各 lane 结果值对象）。落地 ADR 0049 的收口决策。本 ticket 不迁移任何消费方，`get_media_generator` 及其调用方保持现状，随后续 tickets 逐个切换。

## 改动要点

- **一次解析**：单 session 内解析全部声明 lane；lane 传即声明、None 跳过；未声明 lane 经同名 property 访问抛 `RuntimeError`（fail-loud，返回类型非 Optional）。
- **frozen dataclass 值对象**：`ImageLaneResult` / `VideoLaneResult` / `AudioLaneResult` 不暴露 backend 实例；同时携带 `provider_model`（规范 registry 身份）与 `backend_name` / `backend_model`（backend 实际身份）。video lane 另供 `resolution_or_fallback`（非空）；audio lane 携带 `narration_voice` / `narration_speed`。
- **按实际身份取值**：固定求解顺序——解析 ProviderModel → 构造 backend → 按 backend 实际 model 查 resolution 与能力。查询键 =（`provider_model.provider_id`, `backend.model`）：provider 在构造缝中不漂移，model 是唯一真实漂移轴（自定义供应商目标 model 被禁用时 loader 静默回退）；族别名 provider（ark-agent-plan 复用 Ark backend）的 `backend.name` 恒为族名，不能作查询键。
- **错误语义（ADR 0049）**：lane 解析或构造失败整次调用失败、无部分结果、无跨 provider 兜底；仅能力查询失败降级空值放行。
- **backend 缓存迁移**：`_backend_cache` / `invalidate_backend_cache()` 与三个构造辅助自 `generation_tasks` 迁入本模块；`providers.py` / `custom_providers.py` 两处失效调用改导入新落点。

## 验证

- ruff check/format 通过
- basedpyright 0 error（5 warning 为 generation_tasks 既有 reportUnnecessaryIsInstance）
- 全量 pytest 5991 passed；新模块 `tests/server/test_generation_context.py` 覆盖 lane 声明与跳过 / fail-loud property / 按实际身份查值 / 能力降级 / 原子失败 / backend 缓存与失效，用真实内存 DB + tmp_path 真 ProjectManager + fake backend 走公开接口断言

Closes #1164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增统一的媒体生成配置解析能力，支持图片、视频和音频任务。
  - 改进后端实例缓存复用，并支持配置变更后的缓存刷新。
  - 补充视频能力、分辨率、时长及音频旁白参数的自动解析与默认回退。

- **错误修复**
  - 优化供应商配置变更后的后端限制重新加载，确保最新配置及时生效。

- **测试**
  - 新增并完善图片、视频、音频配置解析、缓存、失败回退及参数覆盖场景测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->