### PR TITLE
refactor(usage): 记账结算收口为结算值对象与共享结算函数，费用计算器改收 PricingParams

### DIFF
--- a/lib/cost_calculator.py
+++ b/lib/cost_calculator.py
@@ -7,11 +7,12 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from lib.custom_provider import is_custom_provider
 from lib.pricing.lookup import lookup_pricing
 from lib.pricing.strategies import PricingParams, calculate_pricing
 from lib.pricing.types import CHARACTERS_PER_PRICING_UNIT, PerSecondMatrix, PerSecondTiered, PerTokenVideo
-from lib.providers import CallType
 
 
 class CostCalculator:
@@ -27,70 +28,38 @@ class CostCalculator:
     def calculate_cost(
         self,
         provider: str,
-        call_type: CallType,
+        params: PricingParams,
         *,
-        model: str | None = None,
-        resolution: str | None = None,
-        aspect_ratio: str | None = None,
-        duration_seconds: int | None = None,
-        generate_audio: bool = True,
-        usage_tokens: int | None = None,
-        service_tier: str = "default",
-        input_tokens: int | None = None,
-        output_tokens: int | None = None,
-        quality: str | None = None,
-        size: str | None = None,
-        image_input_tokens: int | None = None,
-        image_output_tokens: int | None = None,
-        text_input_tokens: int | None = None,
-        text_output_tokens: int | None = None,
         custom_price_input: float | None = None,
         custom_price_output: float | None = None,
         custom_currency: str | None = None,
     ) -> tuple[float, str]:
-        """统一费用计算入口。返回 ``(amount, currency)``。
+        """统一费用计算入口。调用方直接构造 ``PricingParams`` 传入，返回 ``(amount, currency)``。
 
-        自定义供应商的价格信息通过 ``custom_price_*`` 参数传入（调用方需预先查询 DB）。
+        自定义供应商的价格信息通过 ``custom_price_*`` 参数传入（调用方需预先查询 DB）；
+        它们是 DB 侧的价格来源、非定价形状维度，故不并入 ``PricingParams``。
         """
         if is_custom_provider(provider):
             return self._calculate_custom_cost(
-                call_type,
+                params.call_type,
                 price_input=custom_price_input,
                 price_output=custom_price_output,
                 currency=custom_currency,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                duration_seconds=duration_seconds,
-                usage_tokens=usage_tokens,
+                input_tokens=params.input_tokens,
+                output_tokens=params.output_tokens,
+                duration_seconds=params.duration_seconds,
+                usage_tokens=params.usage_tokens,
             )
 
         # 文本无 token 数据时无从计费，保留早返回。
-        if call_type == "text" and input_tokens is None:
+        if params.call_type == "text" and params.input_tokens is None:
             return 0.0, "USD"
 
-        pricing = lookup_pricing(provider, model, call_type)
+        pricing = lookup_pricing(provider, params.model, params.call_type)
         # 按秒计费的视频：单次实时调用无/0 时长时按默认 8 秒计（历史行为）。参考模式聚合走
         # estimate_reference_video_cost，传真实累计时长（可为 0），不经此默认。
-        if isinstance(pricing, (PerSecondMatrix, PerSecondTiered)):
-            duration_seconds = duration_seconds or 8
-        params = PricingParams(
-            call_type=call_type,
-            model=model,
-            resolution=resolution,
-            aspect_ratio=aspect_ratio,
-            duration_seconds=duration_seconds,
-            generate_audio=generate_audio,
-            usage_tokens=usage_tokens,
-            service_tier=service_tier,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            quality=quality,
-            size=size,
-            image_input_tokens=image_input_tokens,
-            image_output_tokens=image_output_tokens,
-            text_input_tokens=text_input_tokens,
-            text_output_tokens=text_output_tokens,
-        )
+        if isinstance(pricing, (PerSecondMatrix, PerSecondTiered)) and not params.duration_seconds:
+            params = replace(params, duration_seconds=8)
         return calculate_pricing(pricing, params)
 
     def estimate_reference_video_cost(

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -12,12 +13,51 @@ from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.db.base import DEFAULT_USER_ID, dt_to_iso, utc_now
 from lib.db.models.api_call import ApiCall
 from lib.db.repositories.base import BaseRepository, rowcount
+from lib.pricing.strategies import PricingParams
 from lib.providers import PROVIDER_GEMINI, CallType
 
 # 计费时长合理上限（24 小时），语义单点定义：repo 写入层是全部 backend 落账的最后防线，
 # 超出上限的计费时长视同未提供、回落请求时长，防超大数值写入 DB Integer 列溢出；
 # 解析侧（grok / dashscope extractor）的 clamp 引用同一常量，保持口径一致。
 MAX_BILLED_DURATION_SECONDS = 86400
+
+
+@dataclass(frozen=True)
+class SettlementInput:
+    """仓储写侧的申报值对象：承载 caller 在快照时刻提交的原始计费维度。
+
+    这些是"申报时刻"的原始值——``billed_duration_seconds`` 可能非法/超限、显式
+    ``cost_amount`` 绕过自动计算——由 ``_settle`` 归一为生效定价（``PricingParams``）。
+    与 ``PricingParams``（结算后的生效定价输入）刻意分成两个对象，避免原始值与生效值
+    在同一结构里语义混淆。新增计费字段自此只扩本对象，不再穿仓储写侧散参。
+    """
+
+    cost_amount: float | None = None
+    currency: str | None = None
+    service_tier: str = "default"
+    generate_audio: bool | None = None
+    billed_duration_seconds: int | None = None
+    usage_tokens: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    quality: str | None = None
+    image_input_tokens: int | None = None
+    image_output_tokens: int | None = None
+    text_input_tokens: int | None = None
+    text_output_tokens: int | None = None
+
+
+@dataclass(frozen=True)
+class _SettledCall:
+    """``_settle`` 输出：两条快照路径共用的生效结算值，各自 UPDATE 直接取用。"""
+
+    duration_ms: int
+    effective_duration_seconds: int | None
+    effective_generate_audio: bool | None
+    input_tokens: int | None
+    output_tokens: int | None
+    cost_amount: float
+    currency: str
 
 
 def _classify_asset_output_path(output_path: str | None) -> str:
@@ -110,78 +150,71 @@ class UsageRepository(BaseRepository):
         await self.session.refresh(row)
         return row.id
 
-    async def finalize_pending_by_call_id(
+    async def _settle(
         self,
         *,
-        call_id: int,
-        cost_amount: float | None = None,
-        currency: str | None = None,
-        status: str = "success",
-        service_tier: str = "default",
-        usage_tokens: int | None = None,
-        generate_audio: bool | None = None,
-        billed_duration_seconds: int | None = None,
-    ) -> int:
-        """Resume 路径专用：按 call_id 精准翻 pending → success/failed。
+        row: ApiCall,
+        finished_at: datetime,
+        settlement: SettlementInput,
+        auto_calc: bool,
+        base_currency: str,
+    ) -> _SettledCall:
+        """两条快照路径共享的结算函数：输入 ApiCall 行与申报值，输出生效计费时长、
+        生效有声标志、duration_ms、费用与币种（含 OpenAI 图片 token 聚合列归一）。
 
-        Repo WHERE 子句包含 ``status='pending'`` —— 已 success 行不 touch
-        （防止 generate 已 finish_call 后崩、resume 反向把 success 行覆写）。
-        cost_amount/currency 行为对齐 finish_call：
-        - cost_amount=None + status='success' → 按 ApiCall 行字段调 cost_calculator
-          算实际 cost（与 generate 路径等价记账，避免视频已生成但 cost=0 永久漏记）
-        - cost_amount=None + status='failed' → 走 0.0/USD（失败不计费）
-        - 显式传 cost_amount → 直接用
-        service_tier 由 caller 从原 generate 上下文透传（ApiCall 模型无此列，
-        与 finish_call 同 caller-passed 模式），非 default 档位才能按真实档计费。
-        usage_tokens 同样由 caller 从 resume_video 返回的 VideoGenerationResult.usage_tokens
-        透传：Ark video 按 usage_tokens 计费，未传则 cost 永远为 0；其它 provider 不依赖该字段。
-        generate_audio 由 caller 从 backend 返回值透传：provider 在 submit 后可能降级/关闭音频，
-        与 finish_call 的 ``generate_audio is not None`` 覆盖语义对齐，避免按请求值误计费。
-        billed_duration_seconds 同样由 caller 从 backend 返回值透传：provider 回报的实际计费
-        时长覆盖请求时长（与 finish_call 同覆盖语义，非正值视同未提供），保证同一笔调用
-        无论经 generate 还是 resume 完成，账本时长与自动 cost 口径一致。
-        duration_ms 按 (finished_at - started_at) 回写，让 get_stats_grouped_by_provider
-        的时长汇总不会因 resume 完成的调用 duration_ms=NULL 而系统性压低。
-        provider 端已扣费的事实通过 status='pending' WHERE 保护——绝不触发再次扣费。
-        返回受影响行数（0=幂等无操作；1=正常翻一行）。
+        - duration_ms 按 ``finished_at - started_at`` 回写；SQLite 跨 session 的 aware−naive
+          相减抛 TypeError 时兜底为 0（既有行为）。
+        - 计费时长/有声标志覆盖：backend 回报值覆盖 start_call 时的请求值，非正或超出
+          ``MAX_BILLED_DURATION_SECONDS`` 的计费时长视同未提供、回落请求时长。
+        - 费用：显式 ``cost_amount`` 视作 provider 直报计费数据、优先于自动计算；否则在
+          ``auto_calc`` 为真时按行字段 + 申报值调 ``cost_calculator``（自定义供应商价格预查
+          避免 CostCalculator 内 sync-over-async）。
+        - ``base_currency`` 由 caller 传入承载各自的币种兜底口径（finish_call 兜底
+          ``row.currency``，resume 兜底 ``settlement.currency``），保持行为不分叉。
+
+        防重复计费的 pending 守卫由各 public 方法的 UPDATE WHERE 子句显式承担，不在此。
         """
-        finished_at = utc_now()
-
-        # 无条件 fetch row：既用于 auto-calc cost 路径，也用于 duration_ms 回写
-        # （即便 caller 显式传 cost_amount，duration_ms 计算仍需要 started_at）。
-        # row.status='pending' 守卫继续由下面的 UPDATE WHERE 子句保证幂等性。
-        select_result = await self.session.execute(select(ApiCall).where(ApiCall.id == call_id))
-        row = select_result.scalar_one_or_none()
-        if row is None:
-            return 0
-
-        duration_ms = 0
         try:
             duration_ms = int((finished_at - row.started_at).total_seconds() * 1000)
         except (ValueError, TypeError):
             duration_ms = 0
 
-        # backend 回写的实际 generate_audio 覆盖 start_call 时的请求值
-        # （与 finish_call 同语义；用于 cost_calculator 输入及 UPDATE 回写）
-        effective_generate_audio = generate_audio if generate_audio is not None else row.generate_audio
-
-        # provider 回报的实际计费时长覆盖请求时长（与 finish_call 同覆盖语义，非正或超出
-        # 合理上限视同未提供）。走局部变量 + UPDATE 列回写而非 ORM 属性赋值，让覆盖继续受
-        # WHERE status='pending' 幂等守卫保护，不被 autoflush 绕过。
-        effective_duration_seconds = (
-            billed_duration_seconds
-            if billed_duration_seconds is not None and 0 < billed_duration_seconds <= MAX_BILLED_DURATION_SECONDS
-            else row.duration_seconds
+        effective_generate_audio = (
+            settlement.generate_audio if settlement.generate_audio is not None else row.generate_audio
         )
 
-        final_cost_amount = 0.0
-        final_currency = currency or "USD"
+        billed = settlement.billed_duration_seconds
+        effective_duration_seconds = (
+            billed if billed is not None and 0 < billed <= MAX_BILLED_DURATION_SECONDS else row.duration_seconds
+        )
 
-        if cost_amount is not None:
-            final_cost_amount = cost_amount
-            final_currency = currency or "USD"
-        elif status == "success" and row.status == "pending":
+        # OpenAI 图片调用：input_tokens/output_tokens 列的"总和"语义
+        # = image_*_tokens + text_*_tokens（用于跨 call_type 聚合查询保持兼容）。
+        # resume 路径无图片 token，has_image_tokens 恒 False → 保持申报值原样。
+        input_tokens = settlement.input_tokens
+        output_tokens = settlement.output_tokens
+        has_image_tokens = any(
+            t is not None
+            for t in (
+                settlement.image_input_tokens,
+                settlement.image_output_tokens,
+                settlement.text_input_tokens,
+                settlement.text_output_tokens,
+            )
+        )
+        if has_image_tokens:
+            input_tokens = (settlement.image_input_tokens or 0) + (settlement.text_input_tokens or 0)
+            output_tokens = (settlement.image_output_tokens or 0) + (settlement.text_output_tokens or 0)
+
+        cost_amount = 0.0
+        currency = base_currency
+        if settlement.cost_amount is not None:
+            cost_amount = settlement.cost_amount
+            currency = settlement.currency or base_currency
+        elif auto_calc:
             effective_provider = row.provider or PROVIDER_GEMINI
+
+            # Pre-query custom provider pricing (avoids sync-over-async in CostCalculator)
             custom_price_input: float | None = None
             custom_price_output: float | None = None
             custom_currency: str | None = None
@@ -195,20 +228,73 @@ class UsageRepository(BaseRepository):
                     custom_price_output = price_model.price_output
                     custom_currency = price_model.currency
 
-            final_cost_amount, final_currency = cost_calculator.calculate_cost(
-                provider=effective_provider,
-                call_type=row.call_type,  # type: ignore[arg-type]
+            params = PricingParams(
+                call_type=row.call_type,  # pyright: ignore[reportArgumentType]
                 model=row.model,
                 resolution=row.resolution,
                 aspect_ratio=row.aspect_ratio,
                 duration_seconds=effective_duration_seconds,
                 generate_audio=bool(effective_generate_audio),
-                service_tier=service_tier,
-                usage_tokens=usage_tokens,
+                usage_tokens=settlement.usage_tokens,
+                service_tier=settlement.service_tier,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                quality=settlement.quality,
+                image_input_tokens=settlement.image_input_tokens,
+                image_output_tokens=settlement.image_output_tokens,
+                text_input_tokens=settlement.text_input_tokens,
+                text_output_tokens=settlement.text_output_tokens,
+            )
+            cost_amount, currency = cost_calculator.calculate_cost(
+                effective_provider,
+                params,
                 custom_price_input=custom_price_input,
                 custom_price_output=custom_price_output,
                 custom_currency=custom_currency,
             )
+
+        return _SettledCall(
+            duration_ms=duration_ms,
+            effective_duration_seconds=effective_duration_seconds,
+            effective_generate_audio=effective_generate_audio,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_amount=cost_amount,
+            currency=currency,
+        )
+
+    async def finalize_pending_by_call_id(
+        self,
+        *,
+        call_id: int,
+        settlement: SettlementInput,
+        status: str = "success",
+    ) -> int:
+        """Resume 路径专用：按 call_id 精准翻 pending → success/failed。
+
+        Repo WHERE 子句包含 ``status='pending'`` —— 已 success 行不 touch
+        （防止 generate 已 finish_call 后崩、resume 反向把 success 行覆写）；provider 端
+        已扣费的事实由此守卫，绝不触发再次扣费。结算逻辑（计费时长/有声覆盖、自动 cost、
+        duration_ms 回写）与 finish_call 共享 ``_settle``，唯币种兜底口径按 resume 语义
+        取 ``settlement.currency``。返回受影响行数（0=幂等无操作；1=正常翻一行）。
+        """
+        finished_at = utc_now()
+
+        # 无条件 fetch row：既用于 auto-calc cost 路径，也用于 duration_ms 回写
+        # （即便 caller 显式传 cost_amount，duration_ms 计算仍需要 started_at）。
+        # row.status='pending' 守卫继续由下面的 UPDATE WHERE 子句保证幂等性。
+        select_result = await self.session.execute(select(ApiCall).where(ApiCall.id == call_id))
+        row = select_result.scalar_one_or_none()
+        if row is None:
+            return 0
+
+        settled = await self._settle(
+            row=row,
+            finished_at=finished_at,
+            settlement=settlement,
+            auto_calc=status == "success" and row.status == "pending",
+            base_currency=settlement.currency or "USD",
+        )
 
         result = await self.session.execute(
             update(ApiCall)
@@ -216,12 +302,12 @@ class UsageRepository(BaseRepository):
             .values(
                 status=status,
                 finished_at=finished_at,
-                duration_ms=duration_ms,
-                duration_seconds=effective_duration_seconds,
-                cost_amount=final_cost_amount,
-                currency=final_currency,
-                usage_tokens=usage_tokens,
-                generate_audio=effective_generate_audio,
+                duration_ms=settled.duration_ms,
+                duration_seconds=settled.effective_duration_seconds,
+                cost_amount=settled.cost_amount,
+                currency=settled.currency,
+                usage_tokens=settlement.usage_tokens,
+                generate_audio=settled.effective_generate_audio,
             )
         )
         affected = rowcount(result)
@@ -234,22 +320,10 @@ class UsageRepository(BaseRepository):
         call_id: int,
         *,
         status: str,
+        settlement: SettlementInput,
         output_path: str | None = None,
         error_message: str | None = None,
         retry_count: int = 0,
-        usage_tokens: int | None = None,
-        service_tier: str = "default",
-        generate_audio: bool | None = None,
-        input_tokens: int | None = None,
-        output_tokens: int | None = None,
-        quality: str | None = None,
-        image_input_tokens: int | None = None,
-        image_output_tokens: int | None = None,
-        text_input_tokens: int | None = None,
-        text_output_tokens: int | None = None,
-        cost_amount: float | None = None,
-        currency: str | None = None,
-        billed_duration_seconds: int | None = None,
     ) -> None:
         finished_at = utc_now()
 
@@ -258,78 +332,13 @@ class UsageRepository(BaseRepository):
         if not row:
             return
 
-        # provider 回报的实际计费时长覆盖 start_call 时的请求时长（如 DashScope usage.duration
-        # 含输入参考视频时长）；非正或超出合理上限的值视同未提供，回落请求时长，不记 0 秒账。
-        # 显式 cost_amount 仍优先于按时长的自动计算，但实际计费时长照常回写账本。
-        # 走局部变量 + UPDATE 列回写而非 ORM 属性赋值，避免 autoflush 对同一行额外多发一条 UPDATE。
-        effective_duration_seconds = (
-            billed_duration_seconds
-            if billed_duration_seconds is not None and 0 < billed_duration_seconds <= MAX_BILLED_DURATION_SECONDS
-            else row.duration_seconds
+        settled = await self._settle(
+            row=row,
+            finished_at=finished_at,
+            settlement=settlement,
+            auto_calc=status == "success",
+            base_currency=row.currency or "USD",
         )
-
-        # 后端回写的实际 generate_audio 覆盖 start_call 时的请求值
-        effective_generate_audio = generate_audio if generate_audio is not None else row.generate_audio
-
-        # Calculate duration
-        try:
-            duration_ms = int((finished_at - row.started_at).total_seconds() * 1000)
-        except (ValueError, TypeError):
-            duration_ms = 0
-
-        # Calculate cost. Explicit cost input is treated as provider-reported billing data.
-        final_cost_amount = 0.0
-        final_currency = row.currency or "USD"
-        effective_provider = row.provider or PROVIDER_GEMINI
-
-        # Pre-query custom provider pricing (avoids sync-over-async in CostCalculator)
-        custom_price_input: float | None = None
-        custom_price_output: float | None = None
-        custom_currency: str | None = None
-        if status == "success" and is_custom_provider(effective_provider):
-            from lib.db.repositories.custom_provider_repo import CustomProviderRepository
-
-            repo = CustomProviderRepository(self.session)
-            price_model = await repo.get_model_by_ids(parse_provider_id(effective_provider), row.model or "")
-            if price_model:
-                custom_price_input = price_model.price_input
-                custom_price_output = price_model.price_output
-                custom_currency = price_model.currency
-
-        # OpenAI 图片调用：input_tokens/output_tokens 列的"总和"语义
-        # = image_*_tokens + text_*_tokens（用于跨 call_type 聚合查询保持兼容）
-        has_image_tokens = any(
-            t is not None for t in (image_input_tokens, image_output_tokens, text_input_tokens, text_output_tokens)
-        )
-        if has_image_tokens:
-            input_tokens = (image_input_tokens or 0) + (text_input_tokens or 0)
-            output_tokens = (image_output_tokens or 0) + (text_output_tokens or 0)
-
-        if cost_amount is not None:
-            final_cost_amount = cost_amount
-            final_currency = currency or row.currency or "USD"
-        elif status == "success":
-            final_cost_amount, final_currency = cost_calculator.calculate_cost(
-                provider=effective_provider,
-                call_type=row.call_type,  # type: ignore[arg-type]
-                model=row.model,
-                resolution=row.resolution,
-                aspect_ratio=row.aspect_ratio,
-                duration_seconds=effective_duration_seconds,
-                generate_audio=bool(effective_generate_audio),
-                usage_tokens=usage_tokens,
-                service_tier=service_tier,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                quality=quality,
-                image_input_tokens=image_input_tokens,
-                image_output_tokens=image_output_tokens,
-                text_input_tokens=text_input_tokens,
-                text_output_tokens=text_output_tokens,
-                custom_price_input=custom_price_input,
-                custom_price_output=custom_price_output,
-                custom_currency=custom_currency,
-            )
 
         error_truncated = error_message[:500] if error_message else None
 
@@ -339,19 +348,19 @@ class UsageRepository(BaseRepository):
             .values(
                 status=status,
                 finished_at=finished_at,
-                duration_ms=duration_ms,
-                duration_seconds=effective_duration_seconds,
-                generate_audio=effective_generate_audio,
+                duration_ms=settled.duration_ms,
+                duration_seconds=settled.effective_duration_seconds,
+                generate_audio=settled.effective_generate_audio,
                 retry_count=retry_count,
-                cost_amount=final_cost_amount,
-                currency=final_currency,
-                usage_tokens=usage_tokens,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                image_input_tokens=image_input_tokens,
-                image_output_tokens=image_output_tokens,
-                text_input_tokens=text_input_tokens,
-                text_output_tokens=text_output_tokens,
+                cost_amount=settled.cost_amount,
+                currency=settled.currency,
+                usage_tokens=settlement.usage_tokens,
+                input_tokens=settled.input_tokens,
+                output_tokens=settled.output_tokens,
+                image_input_tokens=settlement.image_input_tokens,
+                image_output_tokens=settlement.image_output_tokens,
+                text_input_tokens=settlement.text_input_tokens,
+                text_output_tokens=settlement.text_output_tokens,
                 output_path=output_path,
                 error_message=error_truncated,
             )

--- a/lib/usage_tracker.py
+++ b/lib/usage_tracker.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from lib.db import safe_session_factory
 from lib.db.base import DEFAULT_USER_ID
-from lib.db.repositories.usage_repo import UsageRepository
+from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
 from lib.providers import PROVIDER_GEMINI, CallType
 
 
@@ -68,13 +68,15 @@ class UsageTracker:
             repo = UsageRepository(session)
             return await repo.finalize_pending_by_call_id(
                 call_id=call_id,
-                cost_amount=cost_amount,
-                currency=currency,
                 status=status,
-                service_tier=service_tier,
-                usage_tokens=usage_tokens,
-                generate_audio=generate_audio,
-                billed_duration_seconds=billed_duration_seconds,
+                settlement=SettlementInput(
+                    cost_amount=cost_amount,
+                    currency=currency,
+                    service_tier=service_tier,
+                    usage_tokens=usage_tokens,
+                    generate_audio=generate_audio,
+                    billed_duration_seconds=billed_duration_seconds,
+                ),
             )
 
     async def finish_call(
@@ -104,22 +106,24 @@ class UsageTracker:
             await repo.finish_call(
                 call_id,
                 status=status,
+                settlement=SettlementInput(
+                    cost_amount=cost_amount,
+                    currency=currency,
+                    service_tier=service_tier,
+                    generate_audio=generate_audio,
+                    billed_duration_seconds=billed_duration_seconds,
+                    usage_tokens=usage_tokens,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    quality=quality,
+                    image_input_tokens=image_input_tokens,
+                    image_output_tokens=image_output_tokens,
+                    text_input_tokens=text_input_tokens,
+                    text_output_tokens=text_output_tokens,
+                ),
                 output_path=output_path,
                 error_message=error_message,
                 retry_count=retry_count,
-                usage_tokens=usage_tokens,
-                service_tier=service_tier,
-                generate_audio=generate_audio,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                quality=quality,
-                image_input_tokens=image_input_tokens,
-                image_output_tokens=image_output_tokens,
-                text_input_tokens=text_input_tokens,
-                text_output_tokens=text_output_tokens,
-                cost_amount=cost_amount,
-                currency=currency,
-                billed_duration_seconds=billed_duration_seconds,
             )
 
     async def get_stats(

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -9,6 +9,7 @@ from typing import Any
 from lib.config.resolver import ConfigResolver, get_provider_fallback
 from lib.cost_calculator import cost_calculator
 from lib.grid.layout import calculate_grid_layout
+from lib.pricing.strategies import PricingParams
 from lib.project_manager import effective_mode
 from lib.script_editor import ScriptEditError
 from lib.storyboard_sequence import get_storyboard_items, group_scenes_by_segment_break
@@ -120,10 +121,8 @@ class CostEstimationService:
         grid_image_unit_cost: tuple[float, str] | None = None
         try:
             image_unit_cost = cost_calculator.calculate_cost(
-                provider=image_provider,
-                call_type="image",
-                model=image_model,
-                resolution="1K",
+                image_provider,
+                PricingParams(call_type="image", model=image_model, resolution="1K"),
             )
         except Exception:
             logger.debug("无法计算 image 预估单价", exc_info=True)
@@ -131,10 +130,8 @@ class CostEstimationService:
         if generation_mode == "grid":
             try:
                 grid_image_unit_cost = cost_calculator.calculate_cost(
-                    provider=image_provider,
-                    call_type="image",
-                    model=image_model,
-                    resolution="2K",
+                    image_provider,
+                    PricingParams(call_type="image", model=image_model, resolution="2K"),
                 )
             except Exception:
                 grid_image_unit_cost = image_unit_cost
@@ -223,12 +220,14 @@ class CostEstimationService:
 
                 try:
                     vid_amount, vid_currency = cost_calculator.calculate_cost(
-                        provider=video_provider,
-                        call_type="video",
-                        model=video_model,
-                        resolution=video_resolution,
-                        duration_seconds=duration,
-                        generate_audio=generate_audio,
+                        video_provider,
+                        PricingParams(
+                            call_type="video",
+                            model=video_model,
+                            resolution=video_resolution,
+                            duration_seconds=duration,
+                            generate_audio=generate_audio,
+                        ),
                     )
                     _add_cost(est_video, vid_amount, vid_currency)
                 except Exception:
@@ -240,10 +239,8 @@ class CostEstimationService:
                 if narration_chars:
                     try:
                         audio_amount, audio_currency = cost_calculator.calculate_cost(
-                            provider=audio_provider,
-                            call_type="audio",
-                            model=audio_model,
-                            usage_tokens=narration_chars,
+                            audio_provider,
+                            PricingParams(call_type="audio", model=audio_model, usage_tokens=narration_chars),
                         )
                         _add_cost(est_audio, audio_amount, audio_currency)
                     except Exception:

--- a/tests/test_cost_calculator.py
+++ b/tests/test_cost_calculator.py
@@ -8,23 +8,28 @@ gemini-aistudio）。仅在底层暴露的形态（如按张 n、纯策略 fallb
 import pytest
 
 from lib.cost_calculator import CostCalculator, cost_calculator
+from lib.pricing.strategies import PricingParams
 from lib.providers import PROVIDER_ANTHROPIC
+
+
+def _cost(provider, call_type, **params):
+    """构造 ``PricingParams`` 并调统一入口——费用对拍只在意金额/币种，用薄封装免逐行铺展。"""
+    return cost_calculator.calculate_cost(provider, PricingParams(call_type=call_type, **params))
 
 
 class TestImageCost:
     def test_calculate_image_cost_known_and_default(self):
-        calc = CostCalculator()
         # 默认模型 (gemini-3.1-flash-image-preview)
-        assert calc.calculate_cost("gemini-aistudio", "image", resolution="1k") == (0.067, "USD")
-        assert calc.calculate_cost("gemini-aistudio", "image", resolution="2K") == (0.101, "USD")
-        assert calc.calculate_cost("gemini-aistudio", "image", resolution="4K") == (0.151, "USD")
-        assert calc.calculate_cost("gemini-aistudio", "image", resolution="unknown") == (0.067, "USD")
+        assert _cost("gemini-aistudio", "image", resolution="1k") == (0.067, "USD")
+        assert _cost("gemini-aistudio", "image", resolution="2K") == (0.101, "USD")
+        assert _cost("gemini-aistudio", "image", resolution="4K") == (0.151, "USD")
+        assert _cost("gemini-aistudio", "image", resolution="unknown") == (0.067, "USD")
         # 指定旧模型 (gemini-3-pro-image-preview)
-        assert calc.calculate_cost("gemini-aistudio", "image", resolution="1k", model="gemini-3-pro-image-preview") == (
+        assert _cost("gemini-aistudio", "image", resolution="1k", model="gemini-3-pro-image-preview") == (
             0.134,
             "USD",
         )
-        assert calc.calculate_cost("gemini-aistudio", "image", resolution="2K", model="gemini-3-pro-image-preview") == (
+        assert _cost("gemini-aistudio", "image", resolution="2K", model="gemini-3-pro-image-preview") == (
             0.134,
             "USD",
         )
@@ -32,10 +37,9 @@ class TestImageCost:
 
 class TestVideoCost:
     def test_calculate_video_cost_known_and_default(self):
-        calc = CostCalculator()
 
         def video(duration, resolution, audio, provider="gemini-aistudio", model=None):
-            amount, _ = calc.calculate_cost(
+            amount, _ = _cost(
                 provider,
                 "video",
                 duration_seconds=duration,
@@ -73,7 +77,7 @@ class TestVideoCost:
 
 class TestAnthropicTextCost:
     def test_calculate_anthropic_text_cost(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             PROVIDER_ANTHROPIC,
             "text",
             input_tokens=100_000,
@@ -84,7 +88,7 @@ class TestAnthropicTextCost:
         assert amount == pytest.approx(1.05)
 
     def test_unknown_anthropic_model_uses_default(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             PROVIDER_ANTHROPIC,
             "text",
             input_tokens=100_000,
@@ -95,7 +99,7 @@ class TestAnthropicTextCost:
         assert amount == pytest.approx(1.05)
 
     def test_calculate_anthropic_haiku_text_cost(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             PROVIDER_ANTHROPIC,
             "text",
             input_tokens=100_000,
@@ -110,14 +114,14 @@ class TestKlingVideoCost:
     """可灵 per_second_tiered 经统一入口 calculate_cost 的金额对拍（CNY）。"""
 
     def test_turbo_std_silent(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "kling", "video", model="kling-v2-5-turbo", service_tier="std", generate_audio=False, duration_seconds=5
         )
         assert currency == "CNY"
         assert amount == pytest.approx(0.6 * 5)
 
     def test_turbo_pro_with_audio(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "kling", "video", model="kling-v2-5-turbo", service_tier="pro", generate_audio=True, duration_seconds=5
         )
         assert currency == "CNY"
@@ -125,14 +129,12 @@ class TestKlingVideoCost:
 
     def test_turbo_default_tier_maps_to_std(self):
         # service_tier 缺省 "default" → std 无声
-        amount, _ = cost_calculator.calculate_cost(
-            "kling", "video", model="kling-v2-5-turbo", generate_audio=False, duration_seconds=10
-        )
+        amount, _ = _cost("kling", "video", model="kling-v2-5-turbo", generate_audio=False, duration_seconds=10)
         assert amount == pytest.approx(0.6 * 10)
 
     def test_unknown_kling_model_falls_back_to_turbo(self):
         # 未知 model 回落到 kling 默认视频模型（turbo）费率，不串到 Gemini 表
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "kling", "video", model="kling-mystery", service_tier="pro", generate_audio=False, duration_seconds=5
         )
         assert currency == "CNY"
@@ -141,7 +143,7 @@ class TestKlingVideoCost:
 
 class TestArkVideoCost:
     def test_online_with_audio(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "ark",
             "video",
             usage_tokens=246840,
@@ -153,7 +155,7 @@ class TestArkVideoCost:
         assert amount == pytest.approx(3.9494, rel=1e-3)
 
     def test_online_no_audio(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "ark",
             "video",
             usage_tokens=246840,
@@ -165,7 +167,7 @@ class TestArkVideoCost:
         assert amount == pytest.approx(1.9747, rel=1e-3)
 
     def test_flex_with_audio(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "ark",
             "video",
             usage_tokens=246840,
@@ -177,7 +179,7 @@ class TestArkVideoCost:
         assert amount == pytest.approx(1.9747, rel=1e-3)
 
     def test_flex_no_audio(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "ark",
             "video",
             usage_tokens=246840,
@@ -189,22 +191,20 @@ class TestArkVideoCost:
         assert amount == pytest.approx(0.9874, rel=1e-3)
 
     def test_zero_tokens(self):
-        amount, currency = cost_calculator.calculate_cost(
-            "ark", "video", usage_tokens=0, service_tier="default", generate_audio=True
-        )
+        amount, currency = _cost("ark", "video", usage_tokens=0, service_tier="default", generate_audio=True)
         assert amount == pytest.approx(0.0)
         assert currency == "CNY"
 
     def test_unknown_model_uses_default(self):
         # 未知模型回落到 ark 默认视频模型（mini）的费率
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "ark", "video", usage_tokens=1_000_000, service_tier="default", generate_audio=True, model="unknown-model"
         )
         assert currency == "CNY"
         assert amount == pytest.approx(23.0)
 
     def test_seedance_2_cost(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "ark",
             "video",
             usage_tokens=1_000_000,
@@ -216,7 +216,7 @@ class TestArkVideoCost:
         assert amount == pytest.approx(46.00)
 
     def test_seedance_2_cost_no_audio_same_price(self):
-        amount, _ = cost_calculator.calculate_cost(
+        amount, _ = _cost(
             "ark",
             "video",
             usage_tokens=1_000_000,
@@ -227,7 +227,7 @@ class TestArkVideoCost:
         assert amount == pytest.approx(46.00)
 
     def test_seedance_2_fast_cost(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "ark",
             "video",
             usage_tokens=1_000_000,
@@ -239,7 +239,7 @@ class TestArkVideoCost:
         assert amount == pytest.approx(37.00)
 
     def test_seedance_2_mini_cost(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "ark",
             "video",
             usage_tokens=1_000_000,
@@ -251,7 +251,7 @@ class TestArkVideoCost:
         assert amount == pytest.approx(23.00)
 
     def test_seedance_2_mini_cost_no_audio_same_price(self):
-        amount, _ = cost_calculator.calculate_cost(
+        amount, _ = _cost(
             "ark",
             "video",
             usage_tokens=1_000_000,
@@ -264,136 +264,124 @@ class TestArkVideoCost:
 
 class TestGrokVideoCost:
     def test_default_model_per_second(self):
-        cost, currency = cost_calculator.calculate_cost(
-            "grok", "video", duration_seconds=10, model="grok-imagine-video"
-        )
+        cost, currency = _cost("grok", "video", duration_seconds=10, model="grok-imagine-video")
         assert cost == pytest.approx(0.50)
         assert currency == "USD"
 
     def test_short_video(self):
-        cost, currency = cost_calculator.calculate_cost("grok", "video", duration_seconds=1, model="grok-imagine-video")
+        cost, currency = _cost("grok", "video", duration_seconds=1, model="grok-imagine-video")
         assert cost == pytest.approx(0.050)
         assert currency == "USD"
 
     def test_max_duration(self):
-        cost, _ = cost_calculator.calculate_cost("grok", "video", duration_seconds=15, model="grok-imagine-video")
+        cost, _ = _cost("grok", "video", duration_seconds=15, model="grok-imagine-video")
         assert cost == pytest.approx(0.75)
 
     def test_zero_duration_defaults_to_8s(self):
         # 统一入口把 0/缺省时长视为默认 8 秒（与历史 calculate_cost 行为一致）：8 × 0.050 = 0.40
-        cost, _ = cost_calculator.calculate_cost("grok", "video", duration_seconds=0, model="grok-imagine-video")
+        cost, _ = _cost("grok", "video", duration_seconds=0, model="grok-imagine-video")
         assert cost == pytest.approx(0.40)
 
     def test_unknown_model_uses_default(self):
-        cost, _ = cost_calculator.calculate_cost("grok", "video", duration_seconds=10, model="unknown-grok-model")
+        cost, _ = _cost("grok", "video", duration_seconds=10, model="unknown-grok-model")
         assert cost == pytest.approx(0.50)
 
 
 class TestArkImageCost:
     def test_ark_image_cost_default(self):
-        cost, currency = cost_calculator.calculate_cost("ark", "image")
+        cost, currency = _cost("ark", "image")
         assert currency == "CNY"
         assert cost == pytest.approx(0.22)
 
     def test_ark_image_cost_by_model(self):
-        cost, _ = cost_calculator.calculate_cost("ark", "image", model="doubao-seedream-4-5-251128")
+        cost, _ = _cost("ark", "image", model="doubao-seedream-4-5-251128")
         assert cost == pytest.approx(0.25)
 
     def test_ark_image_cost_unknown_model(self):
-        cost, currency = cost_calculator.calculate_cost("ark", "image", model="unknown-model")
+        cost, currency = _cost("ark", "image", model="unknown-model")
         assert currency == "CNY"
         assert cost == pytest.approx(0.22)
 
 
 class TestGrokImageCost:
     def test_grok_image_cost_default(self):
-        cost, currency = cost_calculator.calculate_cost("grok", "image")
+        cost, currency = _cost("grok", "image")
         assert cost == pytest.approx(0.02)
         assert currency == "USD"
 
     def test_grok_image_cost_pro(self):
-        cost, currency = cost_calculator.calculate_cost("grok", "image", model="grok-imagine-image-pro")
+        cost, currency = _cost("grok", "image", model="grok-imagine-image-pro")
         assert cost == pytest.approx(0.07)
         assert currency == "USD"
 
     def test_grok_image_cost_unknown_model(self):
-        cost, currency = cost_calculator.calculate_cost("grok", "image", model="unknown-model")
+        cost, currency = _cost("grok", "image", model="unknown-model")
         assert cost == pytest.approx(0.02)
         assert currency == "USD"
 
 
 class TestOpenAICost:
     def test_openai_text_cost(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "openai", "text", input_tokens=1_000_000, output_tokens=1_000_000, model="gpt-5.4-mini"
         )
         assert currency == "USD"
         assert amount == pytest.approx(0.75 + 4.50)
 
     def test_openai_text_cost_default_model(self):
-        amount, currency = cost_calculator.calculate_cost("openai", "text", input_tokens=1_000_000, output_tokens=0)
+        amount, currency = _cost("openai", "text", input_tokens=1_000_000, output_tokens=0)
         assert currency == "USD"
         assert amount == pytest.approx(0.75)
 
     def test_openai_image_cost_low(self):
-        amount, currency = cost_calculator.calculate_cost("openai", "image", model="gpt-image-2", quality="low")
+        amount, currency = _cost("openai", "image", model="gpt-image-2", quality="low")
         assert currency == "USD"
         assert amount == pytest.approx(0.006)  # 默认 1024x1024
 
     def test_openai_image_cost_landscape(self):
-        amount, currency = cost_calculator.calculate_cost(
-            "openai", "image", model="gpt-image-2", quality="high", size="1792x1024"
-        )
+        amount, currency = _cost("openai", "image", model="gpt-image-2", quality="high", size="1792x1024")
         assert currency == "USD"
         assert amount == pytest.approx(0.317)
 
     def test_openai_video_cost(self):
-        amount, currency = cost_calculator.calculate_cost("openai", "video", duration_seconds=8, model="sora-2")
+        amount, currency = _cost("openai", "video", duration_seconds=8, model="sora-2")
         assert currency == "USD"
         assert amount == pytest.approx(0.80)
 
     def test_openai_video_cost_pro(self):
-        amount, currency = cost_calculator.calculate_cost(
-            "openai", "video", duration_seconds=4, model="sora-2-pro", resolution="1080p"
-        )
+        amount, currency = _cost("openai", "video", duration_seconds=4, model="sora-2-pro", resolution="1080p")
         assert currency == "USD"
         assert amount == pytest.approx(2.80)
 
     def test_openai_text_cost_5_5(self):
-        amount, currency = cost_calculator.calculate_cost(
-            "openai", "text", input_tokens=1_000_000, output_tokens=1_000_000, model="gpt-5.5"
-        )
+        amount, currency = _cost("openai", "text", input_tokens=1_000_000, output_tokens=1_000_000, model="gpt-5.5")
         assert currency == "USD"
         assert amount == pytest.approx(5.00 + 30.00)
 
     def test_openai_image_cost_gpt_image_2_high_square(self):
-        amount, currency = cost_calculator.calculate_cost("openai", "image", model="gpt-image-2", quality="high")
+        amount, currency = _cost("openai", "image", model="gpt-image-2", quality="high")
         assert currency == "USD"
         assert amount == pytest.approx(0.211)
 
     def test_openai_image_cost_gpt_image_2_high_portrait(self):
-        amount, currency = cost_calculator.calculate_cost(
-            "openai", "image", model="gpt-image-2", quality="high", size="1024x1792"
-        )
+        amount, currency = _cost("openai", "image", model="gpt-image-2", quality="high", size="1024x1792")
         assert currency == "USD"
         assert amount == pytest.approx(0.317)
 
     def test_openai_image_cost_default_uses_gpt_image_2(self):
         # 不传 model → 回落 OpenAI 图片默认模型 gpt-image-2，medium 1024x1024 = 0.053
-        amount, currency = cost_calculator.calculate_cost("openai", "image", quality="medium")
+        amount, currency = _cost("openai", "image", quality="medium")
         assert currency == "USD"
         assert amount == pytest.approx(0.053)
 
     def test_unified_entry_openai(self):
-        amount, _ = cost_calculator.calculate_cost("openai", "text", input_tokens=500_000, output_tokens=100_000)
+        amount, _ = _cost("openai", "text", input_tokens=500_000, output_tokens=100_000)
         assert amount == pytest.approx(0.375 + 0.45)
-        amount, _ = cost_calculator.calculate_cost("openai", "image", model="gpt-image-2", quality="high")
+        amount, _ = _cost("openai", "image", model="gpt-image-2", quality="high")
         assert amount == pytest.approx(0.211)  # 默认 1024x1024
-        amount, _ = cost_calculator.calculate_cost(
-            "openai", "image", model="gpt-image-2", quality="high", size="1024x1792"
-        )
+        amount, _ = _cost("openai", "image", model="gpt-image-2", quality="high", size="1024x1792")
         assert amount == pytest.approx(0.317)
-        amount, _ = cost_calculator.calculate_cost("openai", "video", duration_seconds=12, model="sora-2")
+        amount, _ = _cost("openai", "video", duration_seconds=12, model="sora-2")
         assert amount == pytest.approx(1.20)
 
 
@@ -403,7 +391,7 @@ class TestOpenAIImageTokenCost:
 
     def test_token_cost_gpt_image_2(self):
         # image_in × 8 + image_out × 30 + text_in × 5 + text_out × 0
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "openai",
             "image",
             model="gpt-image-2",
@@ -417,7 +405,7 @@ class TestOpenAIImageTokenCost:
 
     def test_zero_tokens_still_uses_token_path(self):
         # 所有 token 至少有一个非 None 时走 token 主路径，即使全为 0。
-        amount, _ = cost_calculator.calculate_cost(
+        amount, _ = _cost(
             "openai",
             "image",
             model="gpt-image-2",
@@ -430,18 +418,16 @@ class TestOpenAIImageTokenCost:
 
     def test_fallback_no_size_uses_default_square(self):
         # 所有 token 入参 None 时走 fallback；无显式 size → 默认 1024x1024（不再反查 resolution+aspect）。
-        amount, _ = cost_calculator.calculate_cost(
-            "openai", "image", model="gpt-image-2", quality="high", resolution="1K", aspect_ratio="9:16"
-        )
+        amount, _ = _cost("openai", "image", model="gpt-image-2", quality="high", resolution="1K", aspect_ratio="9:16")
         # high + 1024x1024 → 0.211（旧反查会得 0.317，已废弃）
         assert amount == pytest.approx(0.211)
 
     def test_fallback_aspect_independent(self):
         # 计费与尺寸解耦：相同 quality 下不同 aspect_ratio 的兜底金额一致（均落默认 1024x1024）。
         common = {"model": "gpt-image-2", "quality": "high", "resolution": "1K"}
-        amount_1_1, _ = cost_calculator.calculate_cost("openai", "image", aspect_ratio="1:1", **common)
-        amount_9_16, _ = cost_calculator.calculate_cost("openai", "image", aspect_ratio="9:16", **common)
-        amount_16_9, _ = cost_calculator.calculate_cost("openai", "image", aspect_ratio="16:9", **common)
+        amount_1_1, _ = _cost("openai", "image", aspect_ratio="1:1", **common)
+        amount_9_16, _ = _cost("openai", "image", aspect_ratio="9:16", **common)
+        amount_16_9, _ = _cost("openai", "image", aspect_ratio="16:9", **common)
         assert amount_1_1 == pytest.approx(0.211)
         assert amount_9_16 == pytest.approx(0.211)
         assert amount_16_9 == pytest.approx(0.211)
@@ -449,7 +435,7 @@ class TestOpenAIImageTokenCost:
 
     def test_fallback_explicit_size_used(self):
         # 显式 size kwarg 仍被兜底计费采用（resolution/aspect_ratio 不参与）。
-        amount, _ = cost_calculator.calculate_cost(
+        amount, _ = _cost(
             "openai",
             "image",
             model="gpt-image-2",
@@ -461,7 +447,7 @@ class TestOpenAIImageTokenCost:
         assert amount == pytest.approx(0.106)  # gpt-image-2 medium 1024x1792
 
     def test_unified_entry_token_path(self):
-        amount, currency = cost_calculator.calculate_cost(
+        amount, currency = _cost(
             "openai",
             "image",
             model="gpt-image-2",
@@ -473,10 +459,10 @@ class TestOpenAIImageTokenCost:
 
     def test_unified_entry_fallback_aspect_independent(self):
         # 统一入口的兜底同样与 aspect 解耦：均落默认 1024x1024 档
-        amount_1_1, _ = cost_calculator.calculate_cost(
+        amount_1_1, _ = _cost(
             "openai", "image", model="gpt-image-2", quality="high", resolution="1K", aspect_ratio="1:1"
         )
-        amount_9_16, _ = cost_calculator.calculate_cost(
+        amount_9_16, _ = _cost(
             "openai", "image", model="gpt-image-2", quality="high", resolution="1K", aspect_ratio="9:16"
         )
         assert amount_1_1 == pytest.approx(0.211)

--- a/tests/test_cost_calculator_text.py
+++ b/tests/test_cost_calculator_text.py
@@ -1,4 +1,5 @@
 from lib.cost_calculator import CostCalculator
+from lib.pricing.strategies import PricingParams
 
 
 class TestTextCost:
@@ -6,7 +7,7 @@ class TestTextCost:
         self.calc = CostCalculator()
 
     def _text(self, provider: str):
-        return self.calc.calculate_cost(provider, "text", input_tokens=1000, output_tokens=500)
+        return self.calc.calculate_cost(provider, PricingParams(call_type="text", input_tokens=1000, output_tokens=500))
 
     def test_gemini_cost(self):
         amount, currency = self._text("gemini")

--- a/tests/test_custom_cost.py
+++ b/tests/test_custom_cost.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from lib.cost_calculator import CostCalculator
+from lib.pricing.strategies import PricingParams
 
 
 class TestCustomTextCost:
@@ -12,10 +13,7 @@ class TestCustomTextCost:
         calc = CostCalculator()
         amount, currency = calc.calculate_cost(
             "custom-3",
-            "text",
-            model="deepseek-v3",
-            input_tokens=1000,
-            output_tokens=500,
+            PricingParams(call_type="text", model="deepseek-v3", input_tokens=1000, output_tokens=500),
             custom_price_input=1.0,
             custom_price_output=2.0,
             custom_currency="USD",
@@ -28,10 +26,7 @@ class TestCustomTextCost:
         calc = CostCalculator()
         amount, currency = calc.calculate_cost(
             "custom-7",
-            "text",
-            model="qwen-turbo",
-            input_tokens=2000,
-            output_tokens=1000,
+            PricingParams(call_type="text", model="qwen-turbo", input_tokens=2000, output_tokens=1000),
             custom_price_input=0.5,
             custom_price_output=1.0,
             custom_currency="CNY",
@@ -48,8 +43,7 @@ class TestCustomImageCost:
         calc = CostCalculator()
         amount, currency = calc.calculate_cost(
             "custom-5",
-            "image",
-            model="dall-e-3",
+            PricingParams(call_type="image", model="dall-e-3"),
             custom_price_input=0.05,
             custom_currency="USD",
         )
@@ -60,8 +54,7 @@ class TestCustomImageCost:
         calc = CostCalculator()
         amount, currency = calc.calculate_cost(
             "custom-1",
-            "image",
-            model="seedream",
+            PricingParams(call_type="image", model="seedream"),
             custom_price_input=0.22,
             custom_currency="CNY",
         )
@@ -76,9 +69,7 @@ class TestCustomVideoCost:
         calc = CostCalculator()
         amount, currency = calc.calculate_cost(
             "custom-2",
-            "video",
-            model="sora-2",
-            duration_seconds=10,
+            PricingParams(call_type="video", model="sora-2", duration_seconds=10),
             custom_price_input=0.10,
             custom_currency="USD",
         )
@@ -90,8 +81,7 @@ class TestCustomVideoCost:
         calc = CostCalculator()
         amount, currency = calc.calculate_cost(
             "custom-4",
-            "video",
-            model="some-video-model",
+            PricingParams(call_type="video", model="some-video-model"),
             custom_price_input=0.05,
             custom_currency="USD",
         )
@@ -108,9 +98,7 @@ class TestCustomAudioCost:
         calc = CostCalculator()
         amount, currency = calc.calculate_cost(
             "custom-6",
-            "audio",
-            model="tts-1",
-            usage_tokens=5_000,
+            PricingParams(call_type="audio", model="tts-1", usage_tokens=5_000),
             custom_price_input=0.8,
             custom_currency="CNY",
         )
@@ -122,8 +110,7 @@ class TestCustomAudioCost:
         calc = CostCalculator()
         amount, currency = calc.calculate_cost(
             "custom-6",
-            "audio",
-            model="tts-1",
+            PricingParams(call_type="audio", model="tts-1"),
             custom_price_input=0.8,
             custom_currency="USD",
         )
@@ -134,9 +121,7 @@ class TestCustomAudioCost:
         calc = CostCalculator()
         amount, currency = calc.calculate_cost(
             "custom-6",
-            "audio",
-            model="tts-1",
-            usage_tokens=5_000,
+            PricingParams(call_type="audio", model="tts-1", usage_tokens=5_000),
         )
         assert amount == 0.0
         assert currency == "USD"
@@ -149,10 +134,7 @@ class TestCustomCostNullPrice:
         calc = CostCalculator()
         amount, currency = calc.calculate_cost(
             "custom-1",
-            "text",
-            model="some-model",
-            input_tokens=1000,
-            output_tokens=500,
+            PricingParams(call_type="text", model="some-model", input_tokens=1000, output_tokens=500),
             custom_price_input=None,
             custom_price_output=None,
             custom_currency=None,
@@ -164,10 +146,7 @@ class TestCustomCostNullPrice:
         calc = CostCalculator()
         amount, currency = calc.calculate_cost(
             "custom-99",
-            "text",
-            model="nonexistent",
-            input_tokens=1000,
-            output_tokens=500,
+            PricingParams(call_type="text", model="nonexistent", input_tokens=1000, output_tokens=500),
         )
         assert amount == 0.0
         assert currency == "USD"
@@ -176,10 +155,7 @@ class TestCustomCostNullPrice:
         calc = CostCalculator()
         amount, currency = calc.calculate_cost(
             "custom-1",
-            "text",
-            model="model",
-            input_tokens=1000,
-            output_tokens=500,
+            PricingParams(call_type="text", model="model", input_tokens=1000, output_tokens=500),
             custom_price_input=1.0,
             custom_price_output=2.0,
             custom_currency=None,

--- a/tests/test_quality_propagation.py
+++ b/tests/test_quality_propagation.py
@@ -171,7 +171,7 @@ class TestUsageTrackerQualityPropagation:
 
         mock_repo.finish_call.assert_awaited_once()
         call_kwargs = mock_repo.finish_call.call_args[1]
-        assert call_kwargs.get("quality") == "high"
+        assert call_kwargs["settlement"].quality == "high"
 
     async def test_finish_call_quality_defaults_none(self):
         """未传 quality 时，UsageTracker 应传 quality=None 给 repo。"""
@@ -192,7 +192,7 @@ class TestUsageTrackerQualityPropagation:
             await tracker.finish_call(call_id=1, status="success")
 
         call_kwargs = mock_repo.finish_call.call_args[1]
-        assert call_kwargs.get("quality") is None
+        assert call_kwargs["settlement"].quality is None
 
 
 # ---------------------------------------------------------------------------
@@ -228,18 +228,19 @@ class TestUsageRepositoryQualityToCostCalculator:
         with patch("lib.db.repositories.usage_repo.cost_calculator") as mock_calc:
             mock_calc.calculate_cost.return_value = (0.02, "USD")
 
-            from lib.db.repositories.usage_repo import UsageRepository
+            from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
 
             repo = UsageRepository(mock_session)
             await repo.finish_call(
                 1,
                 status="success",
-                quality="high",
+                settlement=SettlementInput(quality="high"),
             )
 
         mock_calc.calculate_cost.assert_called_once()
-        call_kwargs = mock_calc.calculate_cost.call_args[1]
-        assert call_kwargs.get("quality") == "high"
+        # calculate_cost(provider, params) —— quality 落在位置参数 params 上
+        params = mock_calc.calculate_cost.call_args[0][1]
+        assert params.quality == "high"
 
     async def test_quality_none_when_not_provided(self):
         """未传 quality 时，CostCalculator 应收到 quality=None。"""
@@ -268,10 +269,10 @@ class TestUsageRepositoryQualityToCostCalculator:
         with patch("lib.db.repositories.usage_repo.cost_calculator") as mock_calc:
             mock_calc.calculate_cost.return_value = (0.02, "USD")
 
-            from lib.db.repositories.usage_repo import UsageRepository
+            from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
 
             repo = UsageRepository(mock_session)
-            await repo.finish_call(1, status="success")
+            await repo.finish_call(1, status="success", settlement=SettlementInput())
 
-        call_kwargs = mock_calc.calculate_cost.call_args[1]
-        assert call_kwargs.get("quality") is None
+        params = mock_calc.calculate_cost.call_args[0][1]
+        assert params.quality is None

--- a/tests/test_tts_pricing.py
+++ b/tests/test_tts_pricing.py
@@ -65,14 +65,14 @@ class TestAudioLookupPinsPerCharacter:
 class TestBuiltinAudioCost:
     def test_dashscope_audio_non_zero_cny(self):
         amount, currency = cost_calculator.calculate_cost(
-            provider="dashscope", call_type="audio", model="qwen3-tts-flash", usage_tokens=1500
+            "dashscope", PricingParams(call_type="audio", model="qwen3-tts-flash", usage_tokens=1500)
         )
         assert currency == "CNY"
         assert amount == pytest.approx(0.12)
 
     def test_zero_chars_zero_cost(self):
         amount, currency = cost_calculator.calculate_cost(
-            provider="dashscope", call_type="audio", model="qwen3-tts-flash", usage_tokens=0
+            "dashscope", PricingParams(call_type="audio", model="qwen3-tts-flash", usage_tokens=0)
         )
         assert currency == "CNY"
         assert amount == pytest.approx(0.0)

--- a/tests/test_tts_skeleton.py
+++ b/tests/test_tts_skeleton.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from lib.audio_backends.base import AudioCapability, AudioSynthesisResult
 from lib.data_validator import DataValidator
 from lib.db.base import Base
-from lib.db.repositories.usage_repo import UsageRepository
+from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
 from lib.generation_worker import CapacityTable, GenerationWorker, SlotTable
 from lib.media_generator import MediaGenerator
 from lib.resource_paths import RESOURCE_TYPES, resource_extension, resource_relative_path
@@ -184,7 +184,7 @@ class TestUsageStatsAudioCount:
                 call_id = await repo.start_call(
                     project_name="demo", call_type="audio", model="qwen3-tts-flash", provider="dashscope"
                 )
-                await repo.finish_call(call_id, status="success", usage_tokens=1500)
+                await repo.finish_call(call_id, status="success", settlement=SettlementInput(usage_tokens=1500))
                 stats = await repo.get_stats(project_name="demo")
                 assert stats["audio_count"] == 1
                 # audio 按字符冻结成本快照（非 0）

--- a/tests/test_usage_repo.py
+++ b/tests/test_usage_repo.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.db.base import Base
 from lib.db.models.api_call import ApiCall
-from lib.db.repositories.usage_repo import UsageRepository
+from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
 
 
 @pytest.fixture
@@ -40,6 +40,7 @@ class TestUsageRepository:
         await repo.finish_call(
             call_id,
             status="success",
+            settlement=SettlementInput(),
             output_path="storyboards/test.png",
             retry_count=0,
         )
@@ -55,7 +56,7 @@ class TestUsageRepository:
             call_type="image",
             model="test-model",
         )
-        await repo.finish_call(call1, status="success")
+        await repo.finish_call(call1, status="success", settlement=SettlementInput())
 
         call2 = await repo.start_call(
             project_name="demo",
@@ -63,7 +64,7 @@ class TestUsageRepository:
             model="test-model",
             duration_seconds=8,
         )
-        await repo.finish_call(call2, status="failed", error_message="timeout")
+        await repo.finish_call(call2, status="failed", settlement=SettlementInput(), error_message="timeout")
 
         stats = await repo.get_stats(project_name="demo")
         assert stats["image_count"] == 1
@@ -111,7 +112,7 @@ class TestFinalizePendingByCallId:
         call_id = await repo.start_call(project_name="demo", call_type="video", model="m")
 
         # 显式 cost_amount=0.0 维持单元测试的确定性，绕过 auto-calc 路径
-        affected = await repo.finalize_pending_by_call_id(call_id=call_id, cost_amount=0.0)
+        affected = await repo.finalize_pending_by_call_id(call_id=call_id, settlement=SettlementInput(cost_amount=0.0))
         assert affected == 1
 
         calls = await repo.get_calls(project_name="demo")
@@ -132,7 +133,7 @@ class TestFinalizePendingByCallId:
             provider="gemini",
         )
 
-        affected = await repo.finalize_pending_by_call_id(call_id=call_id)
+        affected = await repo.finalize_pending_by_call_id(call_id=call_id, settlement=SettlementInput())
         assert affected == 1
 
         calls = await repo.get_calls(project_name="demo")
@@ -146,8 +147,8 @@ class TestFinalizePendingByCallId:
 
         captured: dict[str, str] = {}
 
-        def _spy_calculate_cost(**kwargs):
-            captured["service_tier"] = kwargs.get("service_tier", "MISSING")
+        def _spy_calculate_cost(provider, params, **kwargs):
+            captured["service_tier"] = params.service_tier
             return (1.5, "USD")
 
         monkeypatch.setattr(cc_module.cost_calculator, "calculate_cost", _spy_calculate_cost)
@@ -161,7 +162,9 @@ class TestFinalizePendingByCallId:
             provider="openai",
         )
 
-        affected = await repo.finalize_pending_by_call_id(call_id=call_id, service_tier="priority")
+        affected = await repo.finalize_pending_by_call_id(
+            call_id=call_id, settlement=SettlementInput(service_tier="priority")
+        )
         assert affected == 1
         assert captured["service_tier"] == "priority", "service_tier 必须从 caller 透传到 cost_calculator"
 
@@ -172,8 +175,8 @@ class TestFinalizePendingByCallId:
 
         captured: dict[str, object] = {}
 
-        def _spy_calculate_cost(**kwargs):
-            captured["usage_tokens"] = kwargs.get("usage_tokens", "MISSING")
+        def _spy_calculate_cost(provider, params, **kwargs):
+            captured["usage_tokens"] = params.usage_tokens
             return (3.2, "CNY")
 
         monkeypatch.setattr(cc_module.cost_calculator, "calculate_cost", _spy_calculate_cost)
@@ -187,7 +190,9 @@ class TestFinalizePendingByCallId:
             provider="ark",
         )
 
-        affected = await repo.finalize_pending_by_call_id(call_id=call_id, usage_tokens=12345)
+        affected = await repo.finalize_pending_by_call_id(
+            call_id=call_id, settlement=SettlementInput(usage_tokens=12345)
+        )
         assert affected == 1
         assert captured["usage_tokens"] == 12345, "usage_tokens 必须从 caller 透传到 cost_calculator"
 
@@ -203,8 +208,8 @@ class TestFinalizePendingByCallId:
 
         captured: dict[str, object] = {}
 
-        def _spy_calculate_cost(**kwargs):
-            captured["duration_seconds"] = kwargs.get("duration_seconds", "MISSING")
+        def _spy_calculate_cost(provider, params, **kwargs):
+            captured["duration_seconds"] = params.duration_seconds
             return (6.0, "CNY")
 
         monkeypatch.setattr(cc_module.cost_calculator, "calculate_cost", _spy_calculate_cost)
@@ -218,7 +223,9 @@ class TestFinalizePendingByCallId:
             provider="dashscope",
         )
 
-        affected = await repo.finalize_pending_by_call_id(call_id=call_id, billed_duration_seconds=15)
+        affected = await repo.finalize_pending_by_call_id(
+            call_id=call_id, settlement=SettlementInput(billed_duration_seconds=15)
+        )
         assert affected == 1
         assert captured["duration_seconds"] == 15, "实际计费时长必须从 caller 透传到 cost_calculator"
 
@@ -231,38 +238,8 @@ class TestFinalizePendingByCallId:
 
         captured: dict[str, object] = {}
 
-        def _spy_calculate_cost(**kwargs):
-            captured["duration_seconds"] = kwargs.get("duration_seconds", "MISSING")
-            return (2.4, "CNY")
-
-        monkeypatch.setattr(cc_module.cost_calculator, "calculate_cost", _spy_calculate_cost)
-
-        repo = UsageRepository(db_session)
-        call_id = await repo.start_call(
-            project_name="demo",
-            call_type="video",
-            model="wan2.7-r2v",
-            duration_seconds=6,
-            provider="dashscope",
-        )
-
-        affected = await repo.finalize_pending_by_call_id(call_id=call_id, billed_duration_seconds=0)
-        assert affected == 1
-        assert captured["duration_seconds"] == 6, "非正计费时长不得传给 cost_calculator，应回落请求时长"
-
-        calls = await repo.get_calls(project_name="demo")
-        assert calls["items"][0]["duration_seconds"] == 6, "非正计费时长不得写回账本，应保留请求时长"
-
-    async def test_billed_duration_over_limit_falls_back_to_request_duration(self, db_session, monkeypatch):
-        """超出合理上限（24h）的计费时长视同未提供：repo 写入层是全部 backend 的最后防线，
-        防超大数值写入 DB Integer 列溢出。"""
-        from lib import cost_calculator as cc_module
-        from lib.db.repositories.usage_repo import MAX_BILLED_DURATION_SECONDS
-
-        captured: dict[str, object] = {}
-
-        def _spy_calculate_cost(**kwargs):
-            captured["duration_seconds"] = kwargs.get("duration_seconds", "MISSING")
+        def _spy_calculate_cost(provider, params, **kwargs):
+            captured["duration_seconds"] = params.duration_seconds
             return (2.4, "CNY")
 
         monkeypatch.setattr(cc_module.cost_calculator, "calculate_cost", _spy_calculate_cost)
@@ -277,7 +254,39 @@ class TestFinalizePendingByCallId:
         )
 
         affected = await repo.finalize_pending_by_call_id(
-            call_id=call_id, billed_duration_seconds=MAX_BILLED_DURATION_SECONDS + 1
+            call_id=call_id, settlement=SettlementInput(billed_duration_seconds=0)
+        )
+        assert affected == 1
+        assert captured["duration_seconds"] == 6, "非正计费时长不得传给 cost_calculator，应回落请求时长"
+
+        calls = await repo.get_calls(project_name="demo")
+        assert calls["items"][0]["duration_seconds"] == 6, "非正计费时长不得写回账本，应保留请求时长"
+
+    async def test_billed_duration_over_limit_falls_back_to_request_duration(self, db_session, monkeypatch):
+        """超出合理上限（24h）的计费时长视同未提供：repo 写入层是全部 backend 的最后防线，
+        防超大数值写入 DB Integer 列溢出。"""
+        from lib import cost_calculator as cc_module
+        from lib.db.repositories.usage_repo import MAX_BILLED_DURATION_SECONDS
+
+        captured: dict[str, object] = {}
+
+        def _spy_calculate_cost(provider, params, **kwargs):
+            captured["duration_seconds"] = params.duration_seconds
+            return (2.4, "CNY")
+
+        monkeypatch.setattr(cc_module.cost_calculator, "calculate_cost", _spy_calculate_cost)
+
+        repo = UsageRepository(db_session)
+        call_id = await repo.start_call(
+            project_name="demo",
+            call_type="video",
+            model="wan2.7-r2v",
+            duration_seconds=6,
+            provider="dashscope",
+        )
+
+        affected = await repo.finalize_pending_by_call_id(
+            call_id=call_id, settlement=SettlementInput(billed_duration_seconds=MAX_BILLED_DURATION_SECONDS + 1)
         )
         assert affected == 1
         assert captured["duration_seconds"] == 6, "超限计费时长不得传给 cost_calculator，应回落请求时长"
@@ -290,7 +299,7 @@ class TestFinalizePendingByCallId:
         cid_a = await repo.start_call(project_name="demo", call_type="video", model="m", segment_id="E1S01")
         cid_b = await repo.start_call(project_name="demo", call_type="video", model="m", segment_id="E1S01")
 
-        affected = await repo.finalize_pending_by_call_id(call_id=cid_a, cost_amount=0.0)
+        affected = await repo.finalize_pending_by_call_id(call_id=cid_a, settlement=SettlementInput(cost_amount=0.0))
         assert affected == 1
 
         # 全量查询
@@ -302,9 +311,11 @@ class TestFinalizePendingByCallId:
     async def test_idempotent_when_already_success(self, db_session):
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(project_name="demo", call_type="video", model="m")
-        await repo.finish_call(call_id, status="success", cost_amount=5.0, currency="USD")
+        await repo.finish_call(call_id, status="success", settlement=SettlementInput(cost_amount=5.0, currency="USD"))
 
-        affected = await repo.finalize_pending_by_call_id(call_id=call_id, cost_amount=999.0)
+        affected = await repo.finalize_pending_by_call_id(
+            call_id=call_id, settlement=SettlementInput(cost_amount=999.0)
+        )
         assert affected == 0, "已 success 行应保持不变"
 
         calls = await repo.get_calls(project_name="demo")
@@ -314,7 +325,9 @@ class TestFinalizePendingByCallId:
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(project_name="demo", call_type="video", model="m")
 
-        affected = await repo.finalize_pending_by_call_id(call_id=call_id, status="failed")
+        affected = await repo.finalize_pending_by_call_id(
+            call_id=call_id, settlement=SettlementInput(), status="failed"
+        )
         assert affected == 1
 
         calls = await repo.get_calls(project_name="demo")
@@ -323,7 +336,7 @@ class TestFinalizePendingByCallId:
 
     async def test_unknown_call_id_returns_zero(self, db_session):
         repo = UsageRepository(db_session)
-        affected = await repo.finalize_pending_by_call_id(call_id=99999)
+        affected = await repo.finalize_pending_by_call_id(call_id=99999, settlement=SettlementInput())
         assert affected == 0
 
     async def test_writes_duration_ms(self, db_session):
@@ -332,7 +345,7 @@ class TestFinalizePendingByCallId:
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(project_name="demo", call_type="video", model="m")
 
-        affected = await repo.finalize_pending_by_call_id(call_id=call_id, cost_amount=0.0)
+        affected = await repo.finalize_pending_by_call_id(call_id=call_id, settlement=SettlementInput(cost_amount=0.0))
         assert affected == 1
 
         calls = await repo.get_calls(project_name="demo")
@@ -349,8 +362,8 @@ class TestFinalizePendingByCallId:
 
         captured: dict[str, object] = {}
 
-        def _spy_calculate_cost(**kwargs):
-            captured["generate_audio"] = kwargs.get("generate_audio", "MISSING")
+        def _spy_calculate_cost(provider, params, **kwargs):
+            captured["generate_audio"] = params.generate_audio
             return (1.5, "USD")
 
         monkeypatch.setattr(cc_module.cost_calculator, "calculate_cost", _spy_calculate_cost)
@@ -367,7 +380,9 @@ class TestFinalizePendingByCallId:
         )
 
         # provider 实际降级到关闭音频
-        affected = await repo.finalize_pending_by_call_id(call_id=call_id, generate_audio=False)
+        affected = await repo.finalize_pending_by_call_id(
+            call_id=call_id, settlement=SettlementInput(generate_audio=False)
+        )
         assert affected == 1
         assert captured["generate_audio"] is False, "generate_audio 透传必须覆盖到 cost_calculator"
 
@@ -393,8 +408,7 @@ class TestMultiProviderUsage:
         await repo.finish_call(
             call_id,
             status="success",
-            usage_tokens=246840,
-            service_tier="default",
+            settlement=SettlementInput(usage_tokens=246840, service_tier="default"),
         )
 
         calls = await repo.get_calls(project_name="demo")
@@ -414,7 +428,7 @@ class TestMultiProviderUsage:
             duration_seconds=8,
             generate_audio=True,
         )
-        await repo.finish_call(call_id, status="success")
+        await repo.finish_call(call_id, status="success", settlement=SettlementInput())
 
         calls = await repo.get_calls(project_name="demo")
         item = calls["items"][0]
@@ -434,7 +448,7 @@ class TestMultiProviderUsage:
             resolution="1080p",
             generate_audio=True,
         )
-        await repo.finish_call(c1, status="success")
+        await repo.finish_call(c1, status="success", settlement=SettlementInput())
 
         # Ark call
         c2 = await repo.start_call(
@@ -446,7 +460,9 @@ class TestMultiProviderUsage:
             generate_audio=True,
             provider="ark",
         )
-        await repo.finish_call(c2, status="success", usage_tokens=246840, service_tier="default")
+        await repo.finish_call(
+            c2, status="success", settlement=SettlementInput(usage_tokens=246840, service_tier="default")
+        )
 
         stats = await repo.get_stats(project_name="demo")
         assert stats["total_count"] == 2
@@ -466,7 +482,7 @@ class TestMultiProviderUsage:
             resolution="1080p",
             provider="vidu",
         )
-        await repo.finish_call(ok, status="success", usage_tokens=8)
+        await repo.finish_call(ok, status="success", settlement=SettlementInput(usage_tokens=8))
 
         failed = await repo.start_call(
             project_name="demo",
@@ -474,7 +490,7 @@ class TestMultiProviderUsage:
             model="claude-sonnet-4",
             provider="anthropic",
         )
-        await repo.finish_call(failed, status="failed", error_message="boom")
+        await repo.finish_call(failed, status="failed", settlement=SettlementInput(), error_message="boom")
         await db_session.execute(
             update(ApiCall)
             .where(ApiCall.id == failed)
@@ -489,7 +505,7 @@ class TestMultiProviderUsage:
             resolution="1080p",
             provider="vidu",
         )
-        await repo.finish_call(failed_unbilled, status="failed", error_message="boom")
+        await repo.finish_call(failed_unbilled, status="failed", settlement=SettlementInput(), error_message="boom")
 
         zero_cost = await repo.start_call(
             project_name="demo",
@@ -497,7 +513,7 @@ class TestMultiProviderUsage:
             model="gemini-3-flash-preview",
             provider="gemini",
         )
-        await repo.finish_call(zero_cost, status="success", input_tokens=0, output_tokens=0)
+        await repo.finish_call(zero_cost, status="success", settlement=SettlementInput(input_tokens=0, output_tokens=0))
 
         stats = await repo.get_stats(project_name="demo")
         # failed 即使有实付记录也不计入金额；零费用/未扣费记录也不计入金额。
@@ -518,7 +534,7 @@ class TestMultiProviderUsage:
             resolution="1K",
             provider="gemini",
         )
-        await repo.finish_call(gemini_id, status="success")
+        await repo.finish_call(gemini_id, status="success", settlement=SettlementInput())
 
         vidu_id = await repo.start_call(
             project_name="demo",
@@ -527,7 +543,7 @@ class TestMultiProviderUsage:
             resolution="1080p",
             provider="vidu",
         )
-        await repo.finish_call(vidu_id, status="success", usage_tokens=8)
+        await repo.finish_call(vidu_id, status="success", settlement=SettlementInput(usage_tokens=8))
 
         failed_vidu_id = await repo.start_call(
             project_name="demo",
@@ -536,7 +552,7 @@ class TestMultiProviderUsage:
             resolution="1080p",
             provider="vidu",
         )
-        await repo.finish_call(failed_vidu_id, status="failed", error_message="boom")
+        await repo.finish_call(failed_vidu_id, status="failed", settlement=SettlementInput(), error_message="boom")
 
         failed_anthropic_id = await repo.start_call(
             project_name="demo",
@@ -544,7 +560,7 @@ class TestMultiProviderUsage:
             model="claude-sonnet-4",
             provider="anthropic",
         )
-        await repo.finish_call(failed_anthropic_id, status="failed", error_message="boom")
+        await repo.finish_call(failed_anthropic_id, status="failed", settlement=SettlementInput(), error_message="boom")
         await db_session.execute(
             update(ApiCall)
             .where(ApiCall.id == failed_anthropic_id)
@@ -585,8 +601,7 @@ class TestMultiProviderUsage:
         await repo.finish_call(
             call_id,
             status="success",
-            input_tokens=1000,
-            output_tokens=500,
+            settlement=SettlementInput(input_tokens=1000, output_tokens=500),
         )
 
         calls = await repo.get_calls(project_name="demo")
@@ -611,8 +626,7 @@ class TestMultiProviderUsage:
         await repo.finish_call(
             call_id,
             status="success",
-            input_tokens=2000,
-            output_tokens=1000,
+            settlement=SettlementInput(input_tokens=2000, output_tokens=1000),
         )
 
         calls = await repo.get_calls(project_name="demo")
@@ -633,6 +647,7 @@ class TestMultiProviderUsage:
         await repo.finish_call(
             call_id,
             status="failed",
+            settlement=SettlementInput(),
             error_message="API error",
         )
 
@@ -643,13 +658,13 @@ class TestMultiProviderUsage:
     async def test_get_stats_includes_text_count(self, db_session):
         repo = UsageRepository(db_session)
         c1 = await repo.start_call(project_name="demo", call_type="image", model="m")
-        await repo.finish_call(c1, status="success")
+        await repo.finish_call(c1, status="success", settlement=SettlementInput())
 
         c2 = await repo.start_call(project_name="demo", call_type="video", model="m", duration_seconds=8)
-        await repo.finish_call(c2, status="failed", error_message="timeout")
+        await repo.finish_call(c2, status="failed", settlement=SettlementInput(), error_message="timeout")
 
         c3 = await repo.start_call(project_name="demo", call_type="text", model="m", provider="gemini")
-        await repo.finish_call(c3, status="success", input_tokens=100, output_tokens=50)
+        await repo.finish_call(c3, status="success", settlement=SettlementInput(input_tokens=100, output_tokens=50))
 
         stats = await repo.get_stats(project_name="demo")
         assert stats["image_count"] == 1


### PR DESCRIPTION
Closes #1180

## 变更概述

记账成本结算逻辑收敛为单份（expand 阶段）：常规完成（`finish_call`）与 resume 补账（`finalize_pending_by_call_id`）两条快照路径共享同一私有结算函数 `UsageRepository._settle`，输入 ApiCall 行与申报值，输出生效计费时长、生效有声标志、`duration_ms`、费用与币种。两个公开方法各自保留 UPDATE 语句与 pending 幂等守卫，防重复计费机制保持显式可见。

- **结算值对象**：新增 frozen `SettlementInput`（归属 `usage_repo.py`，不使仓储反向依赖上层），承载申报时刻原始值，穿过仓储写侧签名；新计费字段自此不再穿散参。
- **费用计算器统一入口**：`CostCalculator.calculate_cost` 改收 `(provider, params: PricingParams, *, custom_price_*)`；费用估算服务 4 个调用点跟随改写。
- **用量追踪层公开签名不变**：`UsageTracker.finish_call / finalize_pending_by_call_id` 参数列表原样保留，内部构造 `SettlementInput` 转调 repo（临时 expand 适配层，后续 contract 票拆除）。
- **两路径差异用参数吸收**：`auto_calc` 与 `base_currency` 两个参数承接币种兜底口径与 pending 前置守卫的历史差异，避免合并公式悄改 failed 分支行为。
- **custom 价格预查移进 auto_calc 分支**：仅在真正自动算价时查 DB，纯读无副作用，落库零差异并省一次无用 DB 读。

## 验证

- 特征化矩阵 `test_accounting_characterization.py` 零期望值改动、全绿（六通道落库逐字段锁定）
- 全量 `pytest`：6028 passed
- `ruff check` + `ruff format --check`：全绿
- `basedpyright`：0 errors
- 本地审查（/code-review high）：移除 `_settle` 未使用的 `status` 死参数（纯签名清理，行为零变化）

基于最新 `main`（含 #1192）rebase。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 统一费用计算与结算参数，支持更一致地处理文本、图片、视频、音频及自定义供应商费用。
  - 支持直接使用预先提供的费用与币种信息，减少重复计算并提升结算灵活性。
- **错误修复**
  - 优化视频默认计费时长处理，未提供时将采用合理默认值。
  - 限制计费时长上限，避免异常数据导致费用过高。
  - 改进令牌计费与图片费用回退逻辑，提升金额和币种计算准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->