### PR TITLE
feat(frontend): 图片卡片编辑入口——指令弹窗、占用互斥、版本编辑标记

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -272,6 +272,51 @@ describe("API", () => {
       });
     });
 
+    it("editImage posts instruction with singular resource_type; script_file null for non-storyboard", async () => {
+      const requestSpy = vi
+        .spyOn(API, "request")
+        .mockResolvedValue({ success: true, task_id: "t1", message: "ok" } as never);
+
+      await API.editImage("demo", {
+        resourceType: "character",
+        resourceId: "Hero",
+        instruction: "把头发改成红色",
+      });
+
+      expect(requestSpy).toHaveBeenCalledWith("/projects/demo/edit/image", {
+        method: "POST",
+        body: JSON.stringify({
+          resource_type: "character",
+          resource_id: "Hero",
+          instruction: "把头发改成红色",
+          script_file: null,
+        }),
+      });
+    });
+
+    it("editImage forwards script_file for storyboard edits and encodes the project name", async () => {
+      const requestSpy = vi
+        .spyOn(API, "request")
+        .mockResolvedValue({ success: true, task_id: "t2", message: "ok" } as never);
+
+      await API.editImage("a b", {
+        resourceType: "storyboard",
+        resourceId: "E1S01",
+        instruction: "去掉背景路人",
+        scriptFile: "episode_1.json",
+      });
+
+      expect(requestSpy).toHaveBeenCalledWith("/projects/a%20b/edit/image", {
+        method: "POST",
+        body: JSON.stringify({
+          resource_type: "storyboard",
+          resource_id: "E1S01",
+          instruction: "去掉背景路人",
+          script_file: "episode_1.json",
+        }),
+      });
+    });
+
     it("rejects unsupported project mode updates before sending the request", async () => {
       const requestSpy = vi
         .spyOn(API, "request")

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1303,6 +1303,37 @@ class API {
     );
   }
 
+  /**
+   * 提交图片指令式编辑任务：以当前图为唯一底图、指令为唯一 prompt 走 i2i，
+   * 新图覆盖 current、旧图进版本历史。分镜（resourceType="storyboard"）须带 scriptFile。
+   */
+  static async editImage(
+    projectName: string,
+    params: {
+      resourceType: "character" | "scene" | "prop" | "product" | "storyboard";
+      resourceId: string;
+      instruction: string;
+      scriptFile?: string | null;
+    }
+  ): Promise<{
+    success: boolean;
+    task_id: string;
+    message: string;
+  }> {
+    return this.request(
+      `/projects/${encodeURIComponent(projectName)}/edit/image`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          resource_type: params.resourceType,
+          resource_id: params.resourceId,
+          instruction: params.instruction,
+          script_file: params.scriptFile ?? null,
+        }),
+      }
+    );
+  }
+
   // ==================== 任务队列 API ====================
 
   static async getTask(taskId: string): Promise<TaskItem> {

--- a/frontend/src/components/assets/AddToLibraryButton.test.tsx
+++ b/frontend/src/components/assets/AddToLibraryButton.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { API } from "@/api";
+import { useAppStore } from "@/stores/app-store";
+import { AddToLibraryButton } from "./AddToLibraryButton";
+
+describe("AddToLibraryButton", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState(), true);
+    vi.spyOn(API, "listAssets").mockResolvedValue({ items: [] });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects submit if the resource becomes busy while the import modal is open (issue #1159 round-11 Codex finding)", async () => {
+    const addSpy = vi.spyOn(API, "addAssetFromProject").mockResolvedValue({} as never);
+
+    const { rerender } = render(
+      <AddToLibraryButton
+        resourceType="character"
+        resourceId="Hero"
+        projectName="demo"
+        initialDescription="hero desc"
+        busy={false}
+      />,
+    );
+
+    // 打开时资源未占用，弹窗正常打开
+    fireEvent.click(screen.getByRole("button", { name: "加入资产库" }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "确认入库" })).toBeInTheDocument();
+    });
+
+    // 弹窗打开期间，资源通过 SSE/另一个标签页进入生成或 image_edit 占用态
+    rerender(
+      <AddToLibraryButton
+        resourceType="character"
+        resourceId="Hero"
+        projectName="demo"
+        initialDescription="hero desc"
+        busy
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "确认入库" }));
+
+    await waitFor(() => {
+      expect(useAppStore.getState().toast?.tone).toBe("error");
+    });
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows submit when the resource stays idle throughout", async () => {
+    const addSpy = vi.spyOn(API, "addAssetFromProject").mockResolvedValue({} as never);
+
+    render(
+      <AddToLibraryButton
+        resourceType="character"
+        resourceId="Hero"
+        projectName="demo"
+        initialDescription="hero desc"
+        busy={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "加入资产库" }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "确认入库" })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "确认入库" }));
+
+    await waitFor(() => {
+      expect(addSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ project_name: "demo", resource_type: "character", resource_id: "Hero" }),
+      );
+    });
+  });
+});

--- a/frontend/src/components/assets/AddToLibraryButton.tsx
+++ b/frontend/src/components/assets/AddToLibraryButton.tsx
@@ -51,6 +51,12 @@ export function AddToLibraryButton({
   };
 
   const handleSubmit = async (payload: { name: string; description: string; voice_style: string; overwrite?: boolean }) => {
+    // 弹窗打开后资源可能通过 SSE / 其他标签页 / Agent 进入生成或 image_edit 占用态，
+    // 提交时须复核最新 busy 值，避免把占用期间的旧图复制进全局资产库
+    if (busy) {
+      useAppStore.getState().pushToast(t("add_to_library_busy_hint"), "error");
+      return;
+    }
     try {
       await API.addAssetFromProject({
         project_name: projectName,

--- a/frontend/src/components/assets/AddToLibraryButton.tsx
+++ b/frontend/src/components/assets/AddToLibraryButton.tsx
@@ -17,6 +17,8 @@ interface Props {
   sheetPath?: string | null;
   className?: string;
   showLabel?: boolean;
+  /** 资源被生成/编辑任务占用：禁用入库，避免把编辑前的旧图复制进全局资产库 */
+  busy?: boolean;
 }
 
 export function AddToLibraryButton({
@@ -28,6 +30,7 @@ export function AddToLibraryButton({
   sheetPath = null,
   className,
   showLabel = false,
+  busy = false,
 }: Props) {
   const { t } = useTranslation("assets");
   const [modal, setModal] = useState<{ conflictWith?: Asset } | null>(null);
@@ -37,6 +40,7 @@ export function AddToLibraryButton({
   const previewUrl = sheetPath ? API.getFileUrl(projectName, sheetPath, sheetFp) : undefined;
 
   const openPreview = async () => {
+    if (busy) return;
     try {
       const res = await API.listAssets({ type: resourceType, q: resourceId });
       const exact = res.items.find((a) => a.name === resourceId);
@@ -69,8 +73,9 @@ export function AddToLibraryButton({
   return (
     <>
       <button type="button" onClick={() => void openPreview()}
+        disabled={busy}
         aria-label={t("add_to_library")}
-        title={t("add_to_library")}
+        title={busy ? t("add_to_library_busy_hint") : t("add_to_library")}
         className={className ?? defaultClass}
         style={className ? undefined : { color: "var(--color-text-3)" }}>
         <Package className="h-3 w-3" />

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -1179,4 +1179,36 @@ describe("StudioCanvasRouter", () => {
       ).toBe(true);
     });
   });
+
+  it("does not mark optimistic occupancy when grid generation returns no task_ids", async () => {
+    useProjectsStore.setState({
+      currentProjectName: "demo",
+      currentProjectData: makeProjectData({ generation_mode: "grid" }),
+      currentScripts: { "episode_1.json": makeScript() },
+    });
+
+    vi.spyOn(API, "getProject").mockResolvedValue({
+      project: makeProjectData({ generation_mode: "grid" }),
+      scripts: { "episode_1.json": makeScript() },
+    });
+    vi.spyOn(API, "generateGrid").mockResolvedValue({
+      success: true,
+      grid_ids: [],
+      task_ids: [],
+      message: "已提交 0 个宫格生成任务",
+    });
+
+    renderAt("/episodes/1");
+
+    fireEvent.click(await screen.findByText("generate-grid"));
+    await waitFor(() => {
+      expect(API.generateGrid).toHaveBeenCalledWith("demo", 1, "episode_1.json", undefined);
+      expect(useAppStore.getState().toast?.text).toBe("已提交 0 个宫格生成任务");
+    });
+
+    const { tasks, optimisticActiveScriptFile } = useTasksStore.getState();
+    expect(
+      selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "demo", optimisticActiveScriptFile),
+    ).toBe(false);
+  });
 });

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -6,6 +6,7 @@ import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
 import { useProjectsStore } from "@/stores/projects-store";
+import { selectActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
 import { StudioCanvasRouter } from "@/components/canvas/StudioCanvasRouter";
 import type { AdEpisodeScript, EpisodeScript, ProjectData } from "@/types";
 
@@ -321,6 +322,7 @@ describe("StudioCanvasRouter", () => {
     useProjectsStore.setState(useProjectsStore.getInitialState(), true);
     useAppStore.setState(useAppStore.getInitialState(), true);
     useConfigStatusStore.setState(useConfigStatusStore.getInitialState(), true);
+    useTasksStore.setState(useTasksStore.getInitialState(), true);
     vi.restoreAllMocks();
   });
 
@@ -438,6 +440,10 @@ describe("StudioCanvasRouter", () => {
       );
       expect(useAppStore.getState().toast?.text).toContain("生成任务已提交");
       expect(useAppStore.getState().toast?.tone).toBe("success");
+      // 入队成功后应立即乐观占用该角色，避免 SSE 轮询落地前的空窗被误判为空闲
+      // 而并发触发 image_edit（见 tasks-store.ts 乐观占用小节）。
+      const { tasks, optimisticActive } = useTasksStore.getState();
+      expect(selectActiveResourceIds(tasks, "character", "demo", optimisticActive).has("Hero")).toBe(true);
     });
 
     // Test add character flow: click "add" button is not directly accessible in CharacterCard mock;
@@ -509,6 +515,50 @@ describe("StudioCanvasRouter", () => {
     });
   });
 
+  it("marks scene generation as optimistically active on submit success", async () => {
+    useProjectsStore.setState({
+      currentProjectName: "demo",
+      currentProjectData: makeProjectData(),
+      currentScripts: { "episode_1.json": makeScript() },
+    });
+
+    vi.spyOn(API, "getProject").mockResolvedValue({
+      project: makeProjectData(),
+      scripts: { "episode_1.json": makeScript() },
+    });
+    vi.spyOn(API, "generateProjectScene").mockResolvedValue({ success: true, task_id: "t-1", message: "已提交" });
+
+    renderAt("/scenes");
+    fireEvent.click(screen.getByText("generate-scene"));
+    await waitFor(() => {
+      expect(API.generateProjectScene).toHaveBeenCalledWith("demo", "Temple", "ancient temple");
+      const { tasks, optimisticActive } = useTasksStore.getState();
+      expect(selectActiveResourceIds(tasks, "scene", "demo", optimisticActive).has("Temple")).toBe(true);
+    });
+  });
+
+  it("marks prop generation as optimistically active on submit success", async () => {
+    useProjectsStore.setState({
+      currentProjectName: "demo",
+      currentProjectData: makeProjectData(),
+      currentScripts: { "episode_1.json": makeScript() },
+    });
+
+    vi.spyOn(API, "getProject").mockResolvedValue({
+      project: makeProjectData(),
+      scripts: { "episode_1.json": makeScript() },
+    });
+    vi.spyOn(API, "generateProjectProp").mockResolvedValue({ success: true, task_id: "t-1", message: "已提交" });
+
+    renderAt("/props");
+    fireEvent.click(screen.getByText("generate-prop"));
+    await waitFor(() => {
+      expect(API.generateProjectProp).toHaveBeenCalledWith("demo", "Sword", "rusty sword");
+      const { tasks, optimisticActive } = useTasksStore.getState();
+      expect(selectActiveResourceIds(tasks, "prop", "demo", optimisticActive).has("Sword")).toBe(true);
+    });
+  });
+
   it("runs product callbacks and reports API failures with toast", async () => {
     const projectData = makeProjectData({
       products: { Phone: { description: "sleek phone" } },
@@ -545,6 +595,8 @@ describe("StudioCanvasRouter", () => {
       expect(generateSpy).toHaveBeenCalledWith("demo", "Phone", "sleek phone");
       expect(useAppStore.getState().toast?.text).toContain("标准参考图生成任务已提交");
       expect(useAppStore.getState().toast?.tone).toBe("success");
+      const { tasks, optimisticActive } = useTasksStore.getState();
+      expect(selectActiveResourceIds(tasks, "product", "demo", optimisticActive).has("Phone")).toBe(true);
     });
 
     fireEvent.click(screen.getByText("add-product"));
@@ -868,6 +920,8 @@ describe("StudioCanvasRouter", () => {
         "drama image prompt",
         "episode_1.json",
       );
+      const { tasks, optimisticActive } = useTasksStore.getState();
+      expect(selectActiveResourceIds(tasks, "storyboard", "demo", optimisticActive).has("SEG-1")).toBe(true);
     });
   });
 

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -6,7 +6,7 @@ import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
 import { useProjectsStore } from "@/stores/projects-store";
-import { selectActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
+import { selectActiveResourceIds, selectHasActiveTaskForScriptFile, useTasksStore } from "@/stores/tasks-store";
 import { StudioCanvasRouter } from "@/components/canvas/StudioCanvasRouter";
 import type { AdEpisodeScript, EpisodeScript, ProjectData } from "@/types";
 
@@ -1147,6 +1147,36 @@ describe("StudioCanvasRouter", () => {
       expect(API.generateGrid).toHaveBeenCalledWith("demo", 1, "episode_1.json", undefined);
       expect(useAppStore.getState().toast?.text).toContain("宫格生成失败");
       expect(useAppStore.getState().toast?.tone).toBe("error");
+    });
+  });
+
+  it("marks the scriptFile as optimistically active on grid generation submit success", async () => {
+    useProjectsStore.setState({
+      currentProjectName: "demo",
+      currentProjectData: makeProjectData({ generation_mode: "grid" }),
+      currentScripts: { "episode_1.json": makeScript() },
+    });
+
+    vi.spyOn(API, "getProject").mockResolvedValue({
+      project: makeProjectData({ generation_mode: "grid" }),
+      scripts: { "episode_1.json": makeScript() },
+    });
+    vi.spyOn(API, "generateGrid").mockResolvedValue({
+      success: true,
+      grid_ids: ["grid-1"],
+      task_ids: ["t-1"],
+      message: "已提交",
+    });
+
+    renderAt("/episodes/1");
+
+    fireEvent.click(await screen.findByText("generate-grid"));
+    await waitFor(() => {
+      expect(API.generateGrid).toHaveBeenCalledWith("demo", 1, "episode_1.json", undefined);
+      const { tasks, optimisticActiveScriptFile } = useTasksStore.getState();
+      expect(
+        selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "demo", optimisticActiveScriptFile),
+      ).toBe(true);
     });
   });
 });

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -485,7 +485,11 @@ export function StudioCanvasRouter() {
       // 乐观占用：入队成功到下一次轮询把新 grid 任务行写进 store 之间有 ~3s 空窗，期间本集
       // 分镜编辑入口会误判为空闲，与随后的切割阶段并发写同一张 storyboard current 图，
       // 见 tasks-store.ts::selectHasActiveTaskForScriptFile 的乐观占用小节。
-      useTasksStore.getState().markOptimisticActiveForScriptFile(currentProjectName, "grid", scriptFile);
+      // task_ids 可能为空数组（如 scene_ids 过滤后无匹配分组）：此时后端不会产生任何任务行，
+      // 乐观标记将永远等不到真实任务落库来解除，需在打标前排除这种空提交。
+      if (result.task_ids.length > 0) {
+        useTasksStore.getState().markOptimisticActiveForScriptFile(currentProjectName, "grid", scriptFile);
+      }
       useAppStore.getState().pushToast(result.message, "success");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("grid_generation_failed", { message: errMsg(err) }), "error");

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -482,6 +482,10 @@ export function StudioCanvasRouter() {
     if (!currentProjectName) return;
     try {
       const result = await API.generateGrid(currentProjectName, episode, scriptFile, sceneIds);
+      // 乐观占用：入队成功到下一次轮询把新 grid 任务行写进 store 之间有 ~3s 空窗，期间本集
+      // 分镜编辑入口会误判为空闲，与随后的切割阶段并发写同一张 storyboard current 图，
+      // 见 tasks-store.ts::selectHasActiveTaskForScriptFile 的乐观占用小节。
+      useTasksStore.getState().markOptimisticActiveForScriptFile(currentProjectName, "grid", scriptFile);
       useAppStore.getState().pushToast(result.message, "success");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("grid_generation_failed", { message: errMsg(err) }), "error");

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useAppStore } from "@/stores/app-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
-import { useActiveResourceIds } from "@/stores/tasks-store";
+import { useActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
 import { TimelineCanvas } from "./timeline/TimelineCanvas";
 import { OverviewCanvas } from "./OverviewCanvas";
 import { SourceFileViewer } from "./SourceFileViewer";
@@ -221,6 +221,10 @@ export function StudioCanvasRouter() {
         resolved.prompt as string | Record<string, unknown>,
         resolved.resolvedFile,
       );
+      // 乐观占用：入队成功到 SSE 下一次轮询把新任务行写进 store 之间有 ~3s 空窗，
+      // 期间同资源的 ImageEditButton 会误判为空闲，可并发提交 image_edit 与本次
+      // 重新生成竞争同一张 current 图（两者 task_type 不同，后端 dedupe 索引不拦）。
+      useTasksStore.getState().markOptimisticActive(currentProjectName, "storyboard", segmentId, "storyboard");
       useAppStore.getState().pushToast(tRef.current("storyboard_task_submitted_toast", { id: segmentId }), "success");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("generate_storyboard_failed", { message: errMsg(err) }), "error");
@@ -329,6 +333,8 @@ export function StudioCanvasRouter() {
         name,
         currentProjectData?.characters?.[name]?.description ?? "",
       );
+      // 乐观占用：见 handleGenerateStoryboard 同类注释。
+      useTasksStore.getState().markOptimisticActive(currentProjectName, "character", name, "character");
       useAppStore
         .getState()
         .pushToast(tRef.current("character_task_submitted_toast", { name }), "success");
@@ -378,6 +384,8 @@ export function StudioCanvasRouter() {
     if (!currentProjectName) return;
     try {
       await API.generateProjectScene(currentProjectName, name, currentProjectData?.scenes?.[name]?.description ?? "");
+      // 乐观占用：见 handleGenerateStoryboard 同类注释。
+      useTasksStore.getState().markOptimisticActive(currentProjectName, "scene", name, "scene");
       useAppStore.getState().pushToast(tRef.current("scene_task_submitted_toast", { name }), "success");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("submit_failed", { message: errMsg(err) }), "error");
@@ -411,6 +419,8 @@ export function StudioCanvasRouter() {
     if (!currentProjectName) return;
     try {
       await API.generateProjectProp(currentProjectName, name, currentProjectData?.props?.[name]?.description ?? "");
+      // 乐观占用：见 handleGenerateStoryboard 同类注释。
+      useTasksStore.getState().markOptimisticActive(currentProjectName, "prop", name, "prop");
       useAppStore.getState().pushToast(tRef.current("prop_task_submitted_toast", { name }), "success");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("submit_failed", { message: errMsg(err) }), "error");
@@ -448,6 +458,8 @@ export function StudioCanvasRouter() {
         name,
         currentProjectData?.products?.[name]?.description ?? "",
       );
+      // 乐观占用：见 handleGenerateStoryboard 同类注释。
+      useTasksStore.getState().markOptimisticActive(currentProjectName, "product", name, "product");
       useAppStore.getState().pushToast(tRef.current("product_task_submitted_toast", { name }), "success");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("submit_failed", { message: errMsg(err) }), "error");

--- a/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
+++ b/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
@@ -7,7 +7,7 @@ import { ShotSplitView } from "../timeline/ShotSplitView";
 import { GridPreviewView } from "./GridPreviewView";
 import { useAppStore } from "@/stores/app-store";
 import { useCostStore } from "@/stores/cost-store";
-import { useActiveResourceIds } from "@/stores/tasks-store";
+import { useActiveResourceIds, useHasActiveTaskForScriptFile } from "@/stores/tasks-store";
 import { getScriptItemId } from "@/utils/script-shape";
 import type {
   EpisodeScript,
@@ -123,9 +123,13 @@ export function GridImageToVideoCanvas({
   const storyboardBusyIds = useActiveResourceIds("storyboard", projectName);
   const videoBusyIds = useActiveResourceIds("video", projectName);
   const ttsBusyIds = useActiveResourceIds("tts", projectName);
+  // 本集有宫格任务在跑：切割阶段会覆写本集内多个分镜的 storyboard 文件，grid 任务的
+  // resource_id 是 grid_id、无法归入按分镜 resource_id 判定的 storyboardBusyIds，
+  // 故按 scriptFile 粗粒度判定，禁用宫格模式下的分镜编辑入口，避免并发写同一文件。
+  const gridActiveForEpisode = useHasActiveTaskForScriptFile("grid", scriptFile, projectName);
   const generatingStoryboard = useCallback(
-    (segId: string) => storyboardBusyIds.has(segId),
-    [storyboardBusyIds],
+    (segId: string) => storyboardBusyIds.has(segId) || gridActiveForEpisode,
+    [storyboardBusyIds, gridActiveForEpisode],
   );
   const generatingVideo = useCallback(
     (segId: string) => videoBusyIds.has(segId),

--- a/frontend/src/components/canvas/lorebook/CharacterCard.test.tsx
+++ b/frontend/src/components/canvas/lorebook/CharacterCard.test.tsx
@@ -73,6 +73,23 @@ describe("CharacterCard", () => {
     });
   });
 
+  it("disables add-to-library while an image_edit/generation task is in flight", () => {
+    render(
+      <CharacterCard
+        name="Hero"
+        character={{ description: "hero desc", voice_style: "warm" }}
+        projectName="demo"
+        onSave={vi.fn()}
+        onGenerate={vi.fn()}
+        generating
+      />,
+    );
+
+    const addButton = screen.getByRole("button", { name: "加入资产库" });
+    expect(addButton).toBeDisabled();
+    expect(addButton).toHaveAttribute("title", "生成或编辑进行中，暂无法加入资产库");
+  });
+
   it("auto-resizes the description textarea as content grows", async () => {
     render(
       <CharacterCard

--- a/frontend/src/components/canvas/lorebook/CharacterCard.tsx
+++ b/frontend/src/components/canvas/lorebook/CharacterCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { ImagePlus, Upload, User } from "lucide-react";
 import { API } from "@/api";
 import { AddToLibraryButton } from "@/components/assets/AddToLibraryButton";
+import { ImageEditButton } from "@/components/canvas/timeline/ImageEditButton";
 import { VersionTimeMachine } from "@/components/canvas/timeline/VersionTimeMachine";
 import { AspectFrame } from "@/components/ui/AspectFrame";
 import { GenerateButton } from "@/components/ui/GenerateButton";
@@ -234,10 +235,10 @@ export function CharacterCard({
           <button
             type="button"
             onClick={() => sheetInputRef.current?.click()}
-            disabled={uploadingSheet}
+            disabled={uploadingSheet || generating}
             title={t("assets:upload_sheet")}
             aria-label={t("assets:upload_sheet")}
-            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:opacity-40"
+            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:cursor-not-allowed disabled:opacity-40"
             style={{ color: "var(--color-text-3)" }}
           >
             <Upload className="h-3.5 w-3.5" />
@@ -249,6 +250,13 @@ export function CharacterCard({
             aria-label={t("assets:upload_sheet")}
             className="hidden"
             onChange={(e) => void handleSheetUpload(e)}
+          />
+          <ImageEditButton
+            projectName={projectName}
+            resourceType="character"
+            resourceId={name}
+            hasImage={Boolean(character.character_sheet)}
+            busy={generating}
           />
           <AddToLibraryButton
             resourceType="character"

--- a/frontend/src/components/canvas/lorebook/CharacterCard.tsx
+++ b/frontend/src/components/canvas/lorebook/CharacterCard.tsx
@@ -273,6 +273,7 @@ export function CharacterCard({
             resourceId={name}
             onRestore={onRestoreVersion}
             iconOnly
+            busy={generating || uploadingSheet}
           />
         </div>
       </div>

--- a/frontend/src/components/canvas/lorebook/CharacterCard.tsx
+++ b/frontend/src/components/canvas/lorebook/CharacterCard.tsx
@@ -265,7 +265,8 @@ export function CharacterCard({
             initialDescription={character.description}
             initialVoiceStyle={character.voice_style ?? ""}
             sheetPath={character.character_sheet}
-            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--color-text-3)] transition-colors hover:bg-[oklch(1_0_0_/_0.05)]"
+            busy={generating || uploadingSheet}
+            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--color-text-3)] transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:cursor-not-allowed disabled:opacity-40"
           />
           <VersionTimeMachine
             projectName={projectName}

--- a/frontend/src/components/canvas/lorebook/CharacterCard.tsx
+++ b/frontend/src/components/canvas/lorebook/CharacterCard.tsx
@@ -256,7 +256,7 @@ export function CharacterCard({
             resourceType="character"
             resourceId={name}
             hasImage={Boolean(character.character_sheet)}
-            busy={generating}
+            busy={generating || uploadingSheet}
           />
           <AddToLibraryButton
             resourceType="character"

--- a/frontend/src/components/canvas/lorebook/ProductCard.tsx
+++ b/frontend/src/components/canvas/lorebook/ProductCard.tsx
@@ -236,7 +236,7 @@ export function ProductCard({
             resourceType="product"
             resourceId={name}
             hasImage={Boolean(product.product_sheet)}
-            busy={generating}
+            busy={generating || uploadingSheet}
           />
           <VersionTimeMachine
             projectName={projectName}

--- a/frontend/src/components/canvas/lorebook/ProductCard.tsx
+++ b/frontend/src/components/canvas/lorebook/ProductCard.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback, useId } from "react";
 import { useTranslation } from "react-i18next";
 import { ImagePlus, ShoppingBag, Upload } from "lucide-react";
 import { API } from "@/api";
+import { ImageEditButton } from "@/components/canvas/timeline/ImageEditButton";
 import { VersionTimeMachine } from "@/components/canvas/timeline/VersionTimeMachine";
 import { AspectFrame } from "@/components/ui/AspectFrame";
 import { GenerateButton } from "@/components/ui/GenerateButton";
@@ -214,10 +215,10 @@ export function ProductCard({
           <button
             type="button"
             onClick={() => sheetInputRef.current?.click()}
-            disabled={uploadingSheet}
+            disabled={uploadingSheet || generating}
             title={t("assets:upload_sheet")}
             aria-label={t("assets:upload_sheet")}
-            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:opacity-40"
+            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:cursor-not-allowed disabled:opacity-40"
             style={{ color: "var(--color-text-3)" }}
           >
             <Upload className="h-3.5 w-3.5" />
@@ -229,6 +230,13 @@ export function ProductCard({
             aria-label={t("assets:upload_sheet")}
             className="hidden"
             onChange={(e) => void handleSheetUpload(e)}
+          />
+          <ImageEditButton
+            projectName={projectName}
+            resourceType="product"
+            resourceId={name}
+            hasImage={Boolean(product.product_sheet)}
+            busy={generating}
           />
           <VersionTimeMachine
             projectName={projectName}

--- a/frontend/src/components/canvas/lorebook/ProductCard.tsx
+++ b/frontend/src/components/canvas/lorebook/ProductCard.tsx
@@ -244,6 +244,7 @@ export function ProductCard({
             resourceId={name}
             onRestore={onRestoreVersion}
             iconOnly
+            busy={generating || uploadingSheet}
           />
         </div>
       </div>

--- a/frontend/src/components/canvas/lorebook/PropCard.tsx
+++ b/frontend/src/components/canvas/lorebook/PropCard.tsx
@@ -195,7 +195,8 @@ export function PropCard({
             projectName={projectName}
             initialDescription={prop.description}
             sheetPath={prop.prop_sheet}
-            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--color-text-3)] transition-colors hover:bg-[oklch(1_0_0_/_0.05)]"
+            busy={generating || uploadingSheet}
+            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--color-text-3)] transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:cursor-not-allowed disabled:opacity-40"
           />
           <VersionTimeMachine
             projectName={projectName}

--- a/frontend/src/components/canvas/lorebook/PropCard.tsx
+++ b/frontend/src/components/canvas/lorebook/PropCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Package, Upload } from "lucide-react";
 import { API } from "@/api";
 import { AddToLibraryButton } from "@/components/assets/AddToLibraryButton";
+import { ImageEditButton } from "@/components/canvas/timeline/ImageEditButton";
 import { VersionTimeMachine } from "@/components/canvas/timeline/VersionTimeMachine";
 import { AspectFrame } from "@/components/ui/AspectFrame";
 import { GenerateButton } from "@/components/ui/GenerateButton";
@@ -165,10 +166,10 @@ export function PropCard({
           <button
             type="button"
             onClick={() => sheetInputRef.current?.click()}
-            disabled={uploadingSheet}
+            disabled={uploadingSheet || generating}
             title={t("assets:upload_sheet")}
             aria-label={t("assets:upload_sheet")}
-            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:opacity-40"
+            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:cursor-not-allowed disabled:opacity-40"
             style={{ color: "var(--color-text-3)" }}
           >
             <Upload className="h-3.5 w-3.5" />
@@ -180,6 +181,13 @@ export function PropCard({
             aria-label={t("assets:upload_sheet")}
             className="hidden"
             onChange={(e) => void handleSheetUpload(e)}
+          />
+          <ImageEditButton
+            projectName={projectName}
+            resourceType="prop"
+            resourceId={name}
+            hasImage={Boolean(prop.prop_sheet)}
+            busy={generating}
           />
           <AddToLibraryButton
             resourceType="prop"

--- a/frontend/src/components/canvas/lorebook/PropCard.tsx
+++ b/frontend/src/components/canvas/lorebook/PropCard.tsx
@@ -203,6 +203,7 @@ export function PropCard({
             resourceId={name}
             onRestore={onRestoreVersion}
             iconOnly
+            busy={generating || uploadingSheet}
           />
         </div>
       </div>

--- a/frontend/src/components/canvas/lorebook/PropCard.tsx
+++ b/frontend/src/components/canvas/lorebook/PropCard.tsx
@@ -187,7 +187,7 @@ export function PropCard({
             resourceType="prop"
             resourceId={name}
             hasImage={Boolean(prop.prop_sheet)}
-            busy={generating}
+            busy={generating || uploadingSheet}
           />
           <AddToLibraryButton
             resourceType="prop"

--- a/frontend/src/components/canvas/lorebook/SceneCard.tsx
+++ b/frontend/src/components/canvas/lorebook/SceneCard.tsx
@@ -203,6 +203,7 @@ export function SceneCard({
             resourceId={name}
             onRestore={onRestoreVersion}
             iconOnly
+            busy={generating || uploadingSheet}
           />
         </div>
       </div>

--- a/frontend/src/components/canvas/lorebook/SceneCard.tsx
+++ b/frontend/src/components/canvas/lorebook/SceneCard.tsx
@@ -195,7 +195,8 @@ export function SceneCard({
             projectName={projectName}
             initialDescription={scene.description}
             sheetPath={scene.scene_sheet}
-            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--color-text-3)] transition-colors hover:bg-[oklch(1_0_0_/_0.05)]"
+            busy={generating || uploadingSheet}
+            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--color-text-3)] transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:cursor-not-allowed disabled:opacity-40"
           />
           <VersionTimeMachine
             projectName={projectName}

--- a/frontend/src/components/canvas/lorebook/SceneCard.tsx
+++ b/frontend/src/components/canvas/lorebook/SceneCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Landmark, Upload } from "lucide-react";
 import { API } from "@/api";
 import { AddToLibraryButton } from "@/components/assets/AddToLibraryButton";
+import { ImageEditButton } from "@/components/canvas/timeline/ImageEditButton";
 import { VersionTimeMachine } from "@/components/canvas/timeline/VersionTimeMachine";
 import { AspectFrame } from "@/components/ui/AspectFrame";
 import { GenerateButton } from "@/components/ui/GenerateButton";
@@ -165,10 +166,10 @@ export function SceneCard({
           <button
             type="button"
             onClick={() => sheetInputRef.current?.click()}
-            disabled={uploadingSheet}
+            disabled={uploadingSheet || generating}
             title={t("assets:upload_sheet")}
             aria-label={t("assets:upload_sheet")}
-            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:opacity-40"
+            className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:cursor-not-allowed disabled:opacity-40"
             style={{ color: "var(--color-text-3)" }}
           >
             <Upload className="h-3.5 w-3.5" />
@@ -180,6 +181,13 @@ export function SceneCard({
             aria-label={t("assets:upload_sheet")}
             className="hidden"
             onChange={(e) => void handleSheetUpload(e)}
+          />
+          <ImageEditButton
+            projectName={projectName}
+            resourceType="scene"
+            resourceId={name}
+            hasImage={Boolean(scene.scene_sheet)}
+            busy={generating}
           />
           <AddToLibraryButton
             resourceType="scene"

--- a/frontend/src/components/canvas/lorebook/SceneCard.tsx
+++ b/frontend/src/components/canvas/lorebook/SceneCard.tsx
@@ -187,7 +187,7 @@ export function SceneCard({
             resourceType="scene"
             resourceId={name}
             hasImage={Boolean(scene.scene_sheet)}
-            busy={generating}
+            busy={generating || uploadingSheet}
           />
           <AddToLibraryButton
             resourceType="scene"

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.test.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { API } from "@/api";
+import { useTasksStore, selectHasActiveTaskForScriptFile } from "@/stores/tasks-store";
+import type { GridGeneration } from "@/types/grid";
+import { GridPreviewPanel } from "./GridPreviewPanel";
+
+function makeGrid(overrides: Partial<GridGeneration> = {}): GridGeneration {
+  return {
+    id: "grid-1",
+    episode: 1,
+    script_file: "episode_1.json",
+    scene_ids: ["SCN-1"],
+    grid_image_path: "grids/grid-1.png",
+    rows: 2,
+    cols: 2,
+    cell_count: 4,
+    frame_chain: [],
+    status: "completed",
+    prompt: null,
+    provider: "gemini",
+    model: "gemini-image",
+    grid_size: "2x2",
+    created_at: "2026-07-16T00:00:00Z",
+    error_message: null,
+    ...overrides,
+  };
+}
+
+describe("GridPreviewPanel regenerate", () => {
+  it("marks the grid's scriptFile as optimistically active after a successful regenerate submit", async () => {
+    useTasksStore.setState({ tasks: [], optimisticActiveScriptFile: new Set() });
+    vi.spyOn(API, "getGrid").mockResolvedValue(makeGrid());
+    vi.spyOn(API, "regenerateGrid").mockResolvedValue({ success: true, task_id: "t-1" });
+
+    render(<GridPreviewPanel projectName="demo" gridIds={["grid-1"]} defaultExpanded />);
+
+    const regenBtn = await screen.findByText("重新生成");
+    fireEvent.click(regenBtn);
+
+    await waitFor(() => {
+      expect(API.regenerateGrid).toHaveBeenCalledWith("demo", "grid-1");
+      const { tasks, optimisticActiveScriptFile } = useTasksStore.getState();
+      expect(
+        selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "demo", optimisticActiveScriptFile),
+      ).toBe(true);
+    });
+  });
+
+  it("does not mark occupancy when the regenerate request fails", async () => {
+    useTasksStore.setState({ tasks: [], optimisticActiveScriptFile: new Set() });
+    vi.spyOn(API, "getGrid").mockResolvedValue(makeGrid());
+    vi.spyOn(API, "regenerateGrid").mockRejectedValue(new Error("regen failed"));
+
+    render(<GridPreviewPanel projectName="demo" gridIds={["grid-1"]} defaultExpanded />);
+
+    const regenBtn = await screen.findByText("重新生成");
+    fireEvent.click(regenBtn);
+
+    await waitFor(() => {
+      expect(API.regenerateGrid).toHaveBeenCalledWith("demo", "grid-1");
+    });
+    const { tasks, optimisticActiveScriptFile } = useTasksStore.getState();
+    expect(
+      selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "demo", optimisticActiveScriptFile),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -18,6 +18,7 @@ import { API } from "@/api";
 import { errMsg } from "@/utils/async";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useAppStore } from "@/stores/app-store";
+import { useTasksStore } from "@/stores/tasks-store";
 import type { GridGeneration, ReferenceImage } from "@/types/grid";
 
 // ---------------------------------------------------------------------------
@@ -344,6 +345,14 @@ export function GridPreviewPanel({
                         API.regenerateGrid(projectName, selectedGridId)
                           .then(() => {
                             setGrid((prev) => prev ? { ...prev, status: "pending" } : prev);
+                            // 乐观占用：重生成入队成功到轮询把刷新后的 grid 任务行写进 store 之间
+                            // 有空窗，期间同集的分镜编辑入口会误判为空闲，见
+                            // tasks-store.ts::selectHasActiveTaskForScriptFile 的乐观占用小节。
+                            if (grid?.script_file) {
+                              useTasksStore
+                                .getState()
+                                .markOptimisticActiveForScriptFile(projectName, "grid", grid.script_file);
+                            }
                             onRegenerated?.();
                           })
                           .catch((err: unknown) => {

--- a/frontend/src/components/canvas/timeline/ImageEditButton.tsx
+++ b/frontend/src/components/canvas/timeline/ImageEditButton.tsx
@@ -4,6 +4,7 @@ import { Wand2 } from "lucide-react";
 import { API } from "@/api";
 import { GlassModal } from "@/components/ui/GlassModal";
 import { useAppStore } from "@/stores/app-store";
+import { useTasksStore } from "@/stores/tasks-store";
 import { errMsg } from "@/utils/async";
 
 export type ImageEditResourceType =
@@ -76,6 +77,11 @@ export function ImageEditButton({
         instruction: trimmed,
         scriptFile: resourceType === "storyboard" ? scriptFile ?? null : null,
       });
+      // 乐观占用：入队成功到 SSE 下一次轮询把新 image_edit 任务行写进 store 之间有
+      // ~3s 空窗；期间该资源在 store 里尚无任务行，同资源的常规生成/上传按钮会误判为
+      // 空闲——两者的 task_type 不同，后端 dedupe 索引不拦这种跨 task_type 并发，会
+      // 并发写同一 current 图。此处立即标记占用，直到真实任务行出现再让位。
+      useTasksStore.getState().markOptimisticActive(projectName, resourceType, resourceId, "image_edit");
       useAppStore.getState().pushToast(res.message, "success");
       setInstruction("");
       setOpen(false);

--- a/frontend/src/components/canvas/timeline/ImageEditButton.tsx
+++ b/frontend/src/components/canvas/timeline/ImageEditButton.tsx
@@ -65,7 +65,9 @@ export function ImageEditButton({
 
   const handleSubmit = async () => {
     const trimmed = instruction.trim();
-    if (!trimmed || submitting) return;
+    // disabled 是响应式的 busy||!hasImage：弹窗打开期间资源转为占用中时随之更新，
+    // 这里兜底防止禁用态生效前的一次点击仍发出请求。
+    if (!trimmed || submitting || disabled) return;
     setSubmitting(true);
     try {
       const res = await API.editImage(projectName, {
@@ -161,7 +163,7 @@ export function ImageEditButton({
             <button
               type="button"
               onClick={() => void handleSubmit()}
-              disabled={submitting || instruction.trim().length === 0}
+              disabled={submitting || instruction.trim().length === 0 || disabled}
               className="focus-ring inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[12px] font-medium transition-transform disabled:cursor-not-allowed disabled:opacity-50"
               style={{
                 color: "oklch(0.14 0 0)",

--- a/frontend/src/components/canvas/timeline/ImageEditButton.tsx
+++ b/frontend/src/components/canvas/timeline/ImageEditButton.tsx
@@ -1,0 +1,182 @@
+import { useId, useState, type CSSProperties } from "react";
+import { useTranslation } from "react-i18next";
+import { Wand2 } from "lucide-react";
+import { API } from "@/api";
+import { GlassModal } from "@/components/ui/GlassModal";
+import { useAppStore } from "@/stores/app-store";
+import { errMsg } from "@/utils/async";
+
+export type ImageEditResourceType =
+  | "character"
+  | "scene"
+  | "prop"
+  | "product"
+  | "storyboard";
+
+interface ImageEditButtonProps {
+  projectName: string;
+  resourceType: ImageEditResourceType;
+  resourceId: string;
+  /** 分镜编辑必带的剧集文件；其余资产类型忽略 */
+  scriptFile?: string | null;
+  /** 是否存在可编辑的当前图；无图时禁用并提示先生成/上传 */
+  hasImage: boolean;
+  /** 资源被生成/编辑任务占用：禁用编辑入口 */
+  busy?: boolean;
+}
+
+const FIELD_STYLE: CSSProperties = {
+  background:
+    "linear-gradient(180deg, oklch(0.20 0.011 265 / 0.6), oklch(0.18 0.010 265 / 0.45))",
+  border: "1px solid var(--color-hairline)",
+  color: "var(--color-text)",
+  boxShadow: "inset 0 1px 2px oklch(0 0 0 / 0.2)",
+};
+
+/**
+ * 图片卡片头部的图标式编辑入口：7x7 图标按钮 + 指令输入弹窗。
+ * 提交即以当前图为底图、指令为 prompt 入队 i2i 编辑；完成后经 SSE fingerprint 自动刷新。
+ */
+export function ImageEditButton({
+  projectName,
+  resourceType,
+  resourceId,
+  scriptFile,
+  hasImage,
+  busy = false,
+}: ImageEditButtonProps) {
+  const { t } = useTranslation("dashboard");
+  const [open, setOpen] = useState(false);
+  const [instruction, setInstruction] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const titleId = useId();
+  const descId = useId();
+  const fieldId = useId();
+
+  const disabled = busy || !hasImage;
+  const triggerTitle = hasImage
+    ? t("image_edit_action")
+    : t("image_edit_no_image_hint");
+
+  const close = () => {
+    if (submitting) return;
+    setOpen(false);
+  };
+
+  const handleSubmit = async () => {
+    const trimmed = instruction.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    try {
+      const res = await API.editImage(projectName, {
+        resourceType,
+        resourceId,
+        instruction: trimmed,
+        scriptFile: resourceType === "storyboard" ? scriptFile ?? null : null,
+      });
+      useAppStore.getState().pushToast(res.message, "success");
+      setInstruction("");
+      setOpen(false);
+    } catch (err) {
+      useAppStore.getState().pushToast(errMsg(err), "error");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={disabled}
+        title={triggerTitle}
+        aria-label={t("image_edit_action")}
+        className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:cursor-not-allowed disabled:opacity-40"
+        style={{ color: "var(--color-text-3)" }}
+      >
+        <Wand2 className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+
+      <GlassModal
+        open={open}
+        onClose={close}
+        labelledBy={titleId}
+        describedBy={descId}
+        closeOnBackdrop={!submitting}
+        closeOnEscape={!submitting}
+      >
+        <div className="p-5">
+          <h2
+            id={titleId}
+            className="display-serif text-[17px] font-semibold tracking-tight"
+            style={{ color: "var(--color-text)" }}
+          >
+            {t("image_edit_modal_title")}
+          </h2>
+          <p
+            id={descId}
+            className="mt-1.5 text-[12.5px] leading-[1.55]"
+            style={{ color: "var(--color-text-3)" }}
+          >
+            {t("image_edit_modal_desc", { name: resourceId })}
+          </p>
+
+          <label
+            htmlFor={fieldId}
+            className="mt-4 block text-[10px] font-semibold uppercase tracking-[0.12em]"
+            style={{ color: "var(--color-text-4)" }}
+          >
+            {t("image_edit_instruction_label")}
+          </label>
+          <textarea
+            id={fieldId}
+            value={instruction}
+            onChange={(e) => setInstruction(e.target.value)}
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                e.preventDefault();
+                void handleSubmit();
+              }
+            }}
+            rows={3}
+            // 弹窗打开即聚焦指令输入，符合"点开就写"的心智
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            placeholder={t("image_edit_instruction_placeholder")}
+            className="focus-ring mt-1.5 w-full resize-none rounded-lg px-3 py-2 text-[13px] leading-[1.55] outline-none transition-[border-color,box-shadow]"
+            style={FIELD_STYLE}
+          />
+
+          <div className="mt-4 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={close}
+              disabled={submitting}
+              className="focus-ring rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors hover:bg-[oklch(1_0_0_/_0.05)] disabled:cursor-not-allowed disabled:opacity-50"
+              style={{ color: "var(--color-text-2)" }}
+            >
+              {t("common:cancel")}
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleSubmit()}
+              disabled={submitting || instruction.trim().length === 0}
+              className="focus-ring inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[12px] font-medium transition-transform disabled:cursor-not-allowed disabled:opacity-50"
+              style={{
+                color: "oklch(0.14 0 0)",
+                background:
+                  "linear-gradient(135deg, var(--color-accent-2), var(--color-accent))",
+                boxShadow:
+                  "inset 0 1px 0 oklch(1 0 0 / 0.35), 0 6px 18px -4px var(--color-accent-glow), 0 0 0 1px var(--color-accent-soft)",
+              }}
+            >
+              <Wand2 className="h-3.5 w-3.5" aria-hidden="true" />
+              {submitting ? t("image_edit_submitting") : t("image_edit_submit")}
+            </button>
+          </div>
+        </div>
+      </GlassModal>
+    </>
+  );
+}

--- a/frontend/src/components/canvas/timeline/MediaCard.tsx
+++ b/frontend/src/components/canvas/timeline/MediaCard.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/UploadIconButton";
 import { formatCost } from "@/utils/cost-format";
 import type { CostBreakdown } from "@/types";
+import { ImageEditButton } from "./ImageEditButton";
 import { VersionTimeMachine } from "./VersionTimeMachine";
 
 type MediaKind = "storyboard" | "video";
@@ -46,6 +47,8 @@ interface MediaCardProps {
   uploading?: boolean;
   /** 其他上传进行中等需要互斥的场景：禁用上传入口但不显示 spinner */
   uploadDisabled?: boolean;
+  /** 分镜编辑所需的剧集文件；提供时（且 kind=storyboard、已有图）显示编辑入口 */
+  editScriptFile?: string | null;
 }
 
 const UPLOAD_ACCEPT: Record<MediaKind, string> = {
@@ -70,6 +73,7 @@ export function MediaCard({
   onUpload,
   uploading,
   uploadDisabled,
+  editScriptFile,
 }: MediaCardProps) {
   const { t } = useTranslation("dashboard");
 
@@ -121,6 +125,16 @@ export function MediaCard({
             busy={uploading}
             disabled={generating || uploadDisabled}
             onSelect={(f) => void onUpload(f)}
+          />
+        )}
+        {kind === "storyboard" && editScriptFile && (
+          <ImageEditButton
+            projectName={projectName}
+            resourceType="storyboard"
+            resourceId={segmentId}
+            scriptFile={editScriptFile}
+            hasImage={Boolean(assetPath)}
+            busy={generating}
           />
         )}
         <VersionTimeMachine

--- a/frontend/src/components/canvas/timeline/MediaCard.tsx
+++ b/frontend/src/components/canvas/timeline/MediaCard.tsx
@@ -134,7 +134,7 @@ export function MediaCard({
             resourceId={segmentId}
             scriptFile={editScriptFile}
             hasImage={Boolean(assetPath)}
-            busy={generating}
+            busy={generating || uploading}
           />
         )}
         <VersionTimeMachine

--- a/frontend/src/components/canvas/timeline/MediaCard.tsx
+++ b/frontend/src/components/canvas/timeline/MediaCard.tsx
@@ -142,6 +142,7 @@ export function MediaCard({
           resourceType={resourceType}
           resourceId={segmentId}
           onRestore={onRestore}
+          busy={kind === "storyboard" ? generating || uploading : undefined}
         />
       </div>
 

--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -841,6 +841,7 @@ export function ShotDetail({
         onUpload={scriptFile ? (file) => handleUpload("storyboard", file) : undefined}
         uploading={uploadingKind === "storyboard"}
         uploadDisabled={uploadingKind !== null}
+        editScriptFile={scriptFile}
         generateDisabled={dirty || saving}
         generateDisabledHint={dirty ? dirtyHint : undefined}
       />

--- a/frontend/src/components/canvas/timeline/VersionTimeMachine.test.tsx
+++ b/frontend/src/components/canvas/timeline/VersionTimeMachine.test.tsx
@@ -143,4 +143,52 @@ describe("VersionTimeMachine", () => {
     expect(previewImage).toHaveClass("object-contain");
     expect(previewImage.parentElement).toHaveClass("h-80");
   });
+
+  it("disables version restore while the resource is busy (image_edit in flight)", async () => {
+    vi.spyOn(API, "getVersions").mockResolvedValue({
+      resource_type: "storyboards",
+      resource_id: "SEG-1",
+      current_version: 2,
+      versions: [
+        {
+          version: 1,
+          filename: "v1.png",
+          created_at: "2026-02-01T00:00:00Z",
+          file_size: 10,
+          is_current: false,
+          prompt: "old prompt",
+          file_url: "/api/v1/files/demo/versions/storyboards/v1.png",
+        },
+        {
+          version: 2,
+          filename: "v2.png",
+          created_at: "2026-02-01T01:00:00Z",
+          file_size: 12,
+          is_current: true,
+          file_url: "/api/v1/files/demo/versions/storyboards/v2.png",
+        },
+      ],
+    });
+    const restoreSpy = vi.spyOn(API, "restoreVersion").mockResolvedValue({ success: true });
+
+    render(
+      <VersionTimeMachine
+        projectName="demo"
+        resourceType="storyboards"
+        resourceId="SEG-1"
+        busy
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /版本/ }));
+    expect(await screen.findByRole("button", { name: "v1" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "v1" }));
+
+    const restoreButton = await screen.findByRole("button", { name: /切换到此版本/ });
+    expect(restoreButton).toBeDisabled();
+    expect(restoreButton).toHaveAttribute("title", "生成或编辑进行中，暂无法切换版本");
+
+    fireEvent.click(restoreButton);
+    expect(restoreSpy).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
+++ b/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
@@ -295,9 +295,14 @@ export function VersionTimeMachine({
                 {selectedInfo && (
                   <div className="rounded-xl border border-gray-700 bg-gray-950/80 p-2.5">
                     <div className="mb-2 flex items-center justify-between gap-2">
-                      <span className="text-[11px] font-medium text-gray-200">
+                      <span className="flex items-center gap-1.5 text-[11px] font-medium text-gray-200">
                         v{selectedInfo.version}
-                        <span className="ml-1.5 text-[10px] font-normal text-gray-500">
+                        {selectedInfo.source === "image_edit" && (
+                          <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-medium text-amber-200">
+                            {t("version_image_edit_badge")}
+                          </span>
+                        )}
+                        <span className="text-[10px] font-normal text-gray-500">
                           {selectedInfo.created_at}
                         </span>
                       </span>

--- a/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
+++ b/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
@@ -14,6 +14,12 @@ interface VersionTimeMachineProps {
   onRestore?: (version: number) => void | Promise<void>;
   /** Icon-only trigger button: hides label and chevron for narrow card headers. */
   iconOnly?: boolean;
+  /**
+   * 同资源正被生成/编辑占用（含 image_edit 乐观占用）：禁用版本恢复。
+   * image_edit 任务完成时会无条件把 current 覆盖为编辑结果，占用期间恢复旧版本会
+   * 显示成功但随后被编辑任务覆盖，用户最后一次选择丢失。
+   */
+  busy?: boolean;
 }
 
 function getImagePreviewHeightClass(
@@ -42,6 +48,7 @@ export function VersionTimeMachine({
   resourceId,
   onRestore,
   iconOnly = false,
+  busy = false,
 }: VersionTimeMachineProps) {
   const { t } = useTranslation("dashboard");
   const resourcePath =
@@ -100,6 +107,9 @@ export function VersionTimeMachine({
   }
 
   async function handleRestore(version: number) {
+    // disabled 是响应式的 restoringVersion/busy：面板打开期间资源转为占用中时随之更新，
+    // 这里兜底防止禁用态生效前的一次点击仍发出恢复请求。
+    if (busy || restoringVersion !== null) return;
     setRestoringVersion(version);
     try {
       const result = await API.restoreVersion(projectName, resourceType, resourceId, version);
@@ -313,8 +323,9 @@ export function VersionTimeMachine({
                       ) : (
                         <button
                           type="button"
-                          disabled={restoringVersion !== null}
+                          disabled={restoringVersion !== null || busy}
                           onClick={() => void handleRestore(selectedInfo.version)}
+                          title={busy ? t("version_restore_busy_hint") : undefined}
                           className="shrink-0 rounded-full bg-indigo-600 px-2.5 py-0.5 text-[10px] font-medium text-white transition-colors hover:bg-indigo-500 disabled:opacity-50"
                         >
                           {restoringVersion === selectedInfo.version ? t("switching_version") : t("switch_to_version")}

--- a/frontend/src/hooks/useTaskFailureNotifications.test.tsx
+++ b/frontend/src/hooks/useTaskFailureNotifications.test.tsx
@@ -18,6 +18,7 @@ function task(overrides: Partial<TaskItem>): TaskItem {
     task_type: "storyboard",
     media_type: "image",
     resource_id: "E1S01",
+    resource_type: null,
     script_file: "ep1.json",
     payload: {},
     status: "running",

--- a/frontend/src/hooks/useTaskFailureNotifications.ts
+++ b/frontend/src/hooks/useTaskFailureNotifications.ts
@@ -11,7 +11,7 @@ import type { TaskStatus } from "@/types";
  * 通知。这是后台任务失败的唯一通知来源——用户可能已离开出错的页面，因此用
  * pushNotification 而非瞬时 toast（入队同步失败仍由调用点用 toast 反馈，那类任务
  * 从未进入队列，不会被这里捕获）。覆盖 storyboard/video/character/scene/prop/grid/
- * reference_video。
+ * reference_video/image_edit。
  *
  * 任务队列是 3 秒轮询（useTasksSSE）。两类情况推送：
  * 1. 观察到非 failed → failed 的状态转换；

--- a/frontend/src/hooks/useTasksSSE.test.tsx
+++ b/frontend/src/hooks/useTasksSSE.test.tsx
@@ -12,6 +12,7 @@ function makeTask(overrides: Partial<TaskItem> = {}): TaskItem {
     task_type: "storyboard",
     media_type: "image",
     resource_id: "segment-1",
+    resource_type: null,
     script_file: null,
     payload: {},
     status: "queued",

--- a/frontend/src/i18n/en/assets.ts
+++ b/frontend/src/i18n/en/assets.ts
@@ -45,6 +45,7 @@ export default {
   "add_to_library": "Add to Library",
   "add_to_library_short": "Library",
   "add_to_library_success": "\"{{name}}\" added to library",
+  "add_to_library_busy_hint": "Generation or editing in progress — cannot add to library",
   "upload_sheet_short": "Upload",
   "edit": "Edit",
   "delete": "Delete",

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1128,6 +1128,7 @@ export default {
   'current_version_badge': 'Current',
   'switching_version': 'Switching...',
   'switch_to_version': 'Switch to this version',
+  'version_restore_busy_hint': 'Generation or editing in progress — version switching is unavailable',
   'version_preview_alt': 'Version v{{version}} preview',
   'version_no_notes': 'No additional notes recorded for this version.',
   'version_manual_upload': 'Manually uploaded by the user.',

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -642,6 +642,7 @@ export default {
   'scene_task_failed': 'Scene "{{id}}" generation failed: {{reason}}',
   'prop_task_failed': 'Prop "{{id}}" generation failed: {{reason}}',
   'grid_task_failed': 'Grid generation failed: {{reason}}',
+  'image_edit_task_failed': 'Edit for "{{id}}" failed: {{reason}}',
   'episode_mode_switcher_label': 'Episode generation mode',
   'episode_mode_inherit_from_project': 'Inherit from project',
   'episode_mode_switch_keep_data': "Switching mode won't remove existing units / scenes — you can switch back anytime.",

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -224,6 +224,16 @@ export default {
   'voice_style_example': 'e.g., Gentle but authoritative',
   'generate_design': 'Generate Design',
   'regenerate_design': 'Regenerate Design',
+
+  // Instruction-based image editing
+  'image_edit_action': 'Edit image',
+  'image_edit_no_image_hint': 'Generate or upload an image first, then edit',
+  'image_edit_modal_title': 'Edit image',
+  'image_edit_modal_desc': 'Describe in one line what to change on "{{name}}". Only that part is adjusted; everything else stays the same.',
+  'image_edit_instruction_label': 'Edit instruction',
+  'image_edit_instruction_placeholder': 'e.g. change the hair to red, remove the passerby in the background',
+  'image_edit_submit': 'Submit edit',
+  'image_edit_submitting': 'Submitting…',
   'characters_count': 'Characters ({{count}})',
   'scenes': 'Scenes',
   'props': 'Props',
@@ -1120,6 +1130,7 @@ export default {
   'version_preview_alt': 'Version v{{version}} preview',
   'version_no_notes': 'No additional notes recorded for this version.',
   'version_manual_upload': 'Manually uploaded by the user.',
+  'version_image_edit_badge': 'Edited',
 
   // ProjectCard - more actions
   'more_actions': 'More Actions',

--- a/frontend/src/i18n/vi/assets.ts
+++ b/frontend/src/i18n/vi/assets.ts
@@ -47,6 +47,7 @@ export default {
   "add_to_library": "Thêm vào thư viện",
   "add_to_library_short": "Thư viện",
   "add_to_library_success": "Đã thêm \"{{name}}\" vào thư viện",
+  "add_to_library_busy_hint": "Đang tạo hoặc chỉnh sửa, chưa thể thêm vào thư viện",
   "upload_sheet_short": "Tải lên",
   "edit": "Chỉnh sửa",
   "delete": "Xóa",

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1099,6 +1099,7 @@ export default {
   'current_version_badge': 'Hiện tại',
   'switching_version': 'Đang chuyển...',
   'switch_to_version': 'Chuyển sang phiên bản này',
+  'version_restore_busy_hint': 'Đang tạo hoặc chỉnh sửa, chưa thể chuyển phiên bản',
   'version_preview_alt': 'Xem trước phiên bản v{{version}}',
   'version_no_notes': 'Phiên bản này không có ghi chú bổ sung.',
   'version_manual_upload': 'Phiên bản do người dùng tải lên thủ công.',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -619,6 +619,7 @@ export default {
   'scene_task_failed': 'Tạo cảnh "{{id}}" thất bại: {{reason}}',
   'prop_task_failed': 'Tạo đạo cụ "{{id}}" thất bại: {{reason}}',
   'grid_task_failed': 'Tạo lưới thất bại: {{reason}}',
+  'image_edit_task_failed': 'Chỉnh sửa "{{id}}" thất bại: {{reason}}',
   'episode_mode_switcher_label': 'Chế độ tạo của tập',
   'episode_mode_inherit_from_project': 'Kế thừa từ dự án',
   'episode_mode_switch_keep_data': "Chuyển chế độ sẽ không xóa các đơn vị / cảnh hiện có — bạn có thể chuyển lại bất cứ lúc nào.",

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -225,6 +225,16 @@ export default {
   'voice_style_example': 'Ví dụ: Dịu dàng nhưng uy nghiêm',
   'generate_design': 'Tạo thiết kế',
   'regenerate_design': 'Tạo lại thiết kế',
+
+  // Chỉnh sửa ảnh theo chỉ dẫn
+  'image_edit_action': 'Chỉnh sửa ảnh',
+  'image_edit_no_image_hint': 'Hãy tạo hoặc tải ảnh lên trước rồi mới chỉnh sửa',
+  'image_edit_modal_title': 'Chỉnh sửa ảnh',
+  'image_edit_modal_desc': 'Mô tả trong một câu điều cần thay đổi ở "{{name}}". Chỉ phần đó được điều chỉnh; mọi thứ khác giữ nguyên.',
+  'image_edit_instruction_label': 'Chỉ dẫn chỉnh sửa',
+  'image_edit_instruction_placeholder': 'ví dụ: đổi tóc thành màu đỏ, xóa người qua đường ở hậu cảnh',
+  'image_edit_submit': 'Gửi chỉnh sửa',
+  'image_edit_submitting': 'Đang gửi…',
   'characters_count': 'Nhân vật ({{count}})',
   'scenes': 'Cảnh',
   'props': 'Đạo cụ',
@@ -1091,6 +1101,7 @@ export default {
   'version_preview_alt': 'Xem trước phiên bản v{{version}}',
   'version_no_notes': 'Phiên bản này không có ghi chú bổ sung.',
   'version_manual_upload': 'Phiên bản do người dùng tải lên thủ công.',
+  'version_image_edit_badge': 'Đã chỉnh sửa',
 
   // ProjectCard - more actions
   'more_actions': 'Thao tác khác',

--- a/frontend/src/i18n/zh/assets.ts
+++ b/frontend/src/i18n/zh/assets.ts
@@ -47,6 +47,7 @@ export default {
   "add_to_library": "加入资产库",
   "add_to_library_short": "入库",
   "add_to_library_success": "「{{name}}」已加入资产库",
+  "add_to_library_busy_hint": "生成或编辑进行中，暂无法加入资产库",
   "upload_sheet_short": "上传",
   "edit": "编辑",
   "delete": "删除",

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -225,6 +225,16 @@ export default {
   'voice_style_example': '例如：温柔但有威严',
   'generate_design': '生成设计图',
   'regenerate_design': '重新生成设计图',
+
+  // 图片指令式编辑
+  'image_edit_action': '编辑图片',
+  'image_edit_no_image_hint': '先生成或上传图片后再编辑',
+  'image_edit_modal_title': '编辑图片',
+  'image_edit_modal_desc': '用一句话描述「{{name}}」要修改的地方，只调整这一处，其余保持不变。',
+  'image_edit_instruction_label': '编辑指令',
+  'image_edit_instruction_placeholder': '例如：把头发改成红色、去掉背景里的路人',
+  'image_edit_submit': '提交编辑',
+  'image_edit_submitting': '提交中…',
   'characters_count': '角色 ({{count}})',
   'scenes': '场景',
   'props': '道具',
@@ -1121,6 +1131,7 @@ export default {
   'version_preview_alt': '版本 v{{version}} 预览',
   'version_no_notes': '该版本没有记录额外说明。',
   'version_manual_upload': '用户手动上传的版本。',
+  'version_image_edit_badge': '编辑',
 
   // ProjectCard - more actions
   'more_actions': '更多操作',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -643,6 +643,7 @@ export default {
   'scene_task_failed': '场景 "{{id}}" 生成失败：{{reason}}',
   'prop_task_failed': '道具 "{{id}}" 生成失败：{{reason}}',
   'grid_task_failed': '宫格生成失败：{{reason}}',
+  'image_edit_task_failed': '"{{id}}" 编辑失败：{{reason}}',
   'episode_mode_switcher_label': '集级生成模式',
   'episode_mode_inherit_from_project': '继承项目设置',
   'episode_mode_switch_keep_data': '切换模式不会删除已生成的 units / scenes，可随时切回原模式继续。',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1129,6 +1129,7 @@ export default {
   'current_version_badge': '当前',
   'switching_version': '切换中...',
   'switch_to_version': '切换到此版本',
+  'version_restore_busy_hint': '生成或编辑进行中，暂无法切换版本',
   'version_preview_alt': '版本 v{{version}} 预览',
   'version_no_notes': '该版本没有记录额外说明。',
   'version_manual_upload': '用户手动上传的版本。',

--- a/frontend/src/stores/stores.test.ts
+++ b/frontend/src/stores/stores.test.ts
@@ -23,6 +23,7 @@ function makeTask(overrides: Partial<TaskItem> = {}): TaskItem {
     task_type: "storyboard",
     media_type: "image",
     resource_id: "segment-1",
+    resource_type: null,
     script_file: null,
     payload: {},
     status: "queued",

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -162,16 +162,16 @@ describe("selectActiveResourceIds with image_edit", () => {
 
 describe("selectActiveResourceIds optimistic occupancy", () => {
   it("counts a resource active via an optimistic marker when no real task row exists yet", () => {
-    // 提交成功但 SSE 尚未把任务行写进 store 的空窗：仅凭乐观标记也应判定占用
-    const key = "proj\0character\0A\0image_edit";
+    // 提交成功但 SSE 尚未把任务行写进 store 的空窗：仅凭乐观标记也应判定占用（空 baseline）
+    const key = "proj\0character\0A\0image_edit\0";
     expect(selectActiveResourceIds([], "character", "proj", new Set([key])).has("A")).toBe(true);
   });
 
-  it("lets the real task row supersede the optimistic marker regardless of its status", () => {
+  it("lets a real task row newer than the baseline supersede the optimistic marker regardless of its status", () => {
     // 真实任务行一旦出现（哪怕已是终态），不再依赖乐观标记——但此时该行本身若是活跃态，
     // 仍会通过 selectActiveResourceIds 主逻辑判定占用；这里验证的是"不因乐观标记残留而
     // 对已完结的真实行仍强制判占用"
-    const key = "proj\0character\0A\0image_edit";
+    const key = "proj\0character\0A\0image_edit\0";
     const tasks = [
       task({
         task_id: "edit-A",
@@ -184,10 +184,43 @@ describe("selectActiveResourceIds optimistic occupancy", () => {
     expect(selectActiveResourceIds(tasks, "character", "proj", new Set([key])).has("A")).toBe(false);
   });
 
+  it("does not let a stale task row predating the baseline supersede a marker for a repeat edit", () => {
+    // 同一资源被反复编辑：本次标记的 baseline 取自上一次编辑遗留的终态行 updated_at，
+    // 该旧行本身不该被当作"本次"标记等待的真实行，否则二次编辑期间会误判空闲
+    const key = `proj\0character\0A\0image_edit\0${"2026-07-16T00:00:00Z"}`;
+    const tasks = [
+      task({
+        task_id: "edit-A-first",
+        task_type: "image_edit",
+        resource_type: "character",
+        resource_id: "A",
+        status: "succeeded",
+        updated_at: "2026-07-16T00:00:00Z",
+      }),
+    ];
+    expect(selectActiveResourceIds(tasks, "character", "proj", new Set([key])).has("A")).toBe(true);
+  });
+
   it("ignores an optimistic marker scoped to a different project or resource kind", () => {
-    const key = "proj\0character\0A\0image_edit";
+    const key = "proj\0character\0A\0image_edit\0";
     expect(selectActiveResourceIds([], "storyboard", "proj", new Set([key])).has("A")).toBe(false);
     expect(selectActiveResourceIds([], "character", "other-proj", new Set([key])).has("A")).toBe(false);
+  });
+
+  it("does not let a same-resource_id task of a different resource kind supersede the marker", () => {
+    // character "A" 与 scene "A" 偶然同名(resource_id 相同)：scene 的真实行不该
+    // 让 character 的乐观标记失效
+    const key = "proj\0character\0A\0image_edit\0";
+    const tasks = [
+      task({
+        task_id: "edit-scene-A",
+        task_type: "image_edit",
+        resource_type: "scene",
+        resource_id: "A",
+        status: "succeeded",
+      }),
+    ];
+    expect(selectActiveResourceIds(tasks, "character", "proj", new Set([key])).has("A")).toBe(true);
   });
 });
 
@@ -201,16 +234,43 @@ describe("useTasksStore.markOptimisticActive", () => {
           resource_type: "character",
           resource_id: "A",
           status: "succeeded",
+          updated_at: "2026-07-16T00:00:00Z",
         }),
       ],
-      optimisticActive: new Set(["proj\0character\0A\0image_edit"]),
+      optimisticActive: new Set([`proj\0character\0A\0image_edit\0${"2025-01-01T00:00:00Z"}`]),
     });
 
-    // 标记一个新资源 B 的同时，A 的旧标记已被上面的真实终态行取代，应被顺带清理
+    // 标记一个新资源 B 的同时，A 的旧标记（baseline 早于真实终态行）已被取代，应被顺带清理
     useTasksStore.getState().markOptimisticActive("proj", "character", "B", "image_edit");
 
     const keys = [...useTasksStore.getState().optimisticActive];
-    expect(keys).toEqual(["proj\0character\0B\0image_edit"]);
+    expect(keys).toEqual(["proj\0character\0B\0image_edit\0"]);
+  });
+
+  it("uses the latest matching real row's updated_at as baseline so a repeat edit isn't superseded by the old row", () => {
+    // A 已有一条旧终态行；对 A 发起新一轮编辑时，baseline 应取该旧行的 updated_at，
+    // 使得新标记不会被这条旧行自己判定为"已超越"
+    useTasksStore.setState({
+      tasks: [
+        task({
+          task_id: "edit-A-first",
+          task_type: "image_edit",
+          resource_type: "character",
+          resource_id: "A",
+          status: "succeeded",
+          updated_at: "2026-07-16T00:00:00Z",
+        }),
+      ],
+      optimisticActive: new Set(),
+    });
+
+    useTasksStore.getState().markOptimisticActive("proj", "character", "A", "image_edit");
+
+    const keys = [...useTasksStore.getState().optimisticActive];
+    expect(keys).toEqual([`proj\0character\0A\0image_edit\0${"2026-07-16T00:00:00Z"}`]);
+
+    const { tasks, optimisticActive } = useTasksStore.getState();
+    expect(selectActiveResourceIds(tasks, "character", "proj", optimisticActive).has("A")).toBe(true);
   });
 });
 

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -3,6 +3,7 @@ import {
   isActiveStatus,
   isTerminalStatus,
   selectActiveResourceIds,
+  selectHasActiveTaskForScriptFile,
   selectLatestTaskByResource,
   taskResourceKind,
 } from "./tasks-store";
@@ -155,6 +156,62 @@ describe("selectActiveResourceIds with image_edit", () => {
       }),
     ];
     expect(selectActiveResourceIds(tasks, "character", "proj").has("A")).toBe(true);
+  });
+});
+
+describe("selectHasActiveTaskForScriptFile", () => {
+  it("returns true when a grid task for the scriptFile is queued or running", () => {
+    const tasks = [
+      task({
+        task_id: "grid-1",
+        task_type: "grid",
+        resource_id: "grid-abc",
+        script_file: "episode_1.json",
+        status: "running",
+      }),
+    ];
+    expect(selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "proj")).toBe(true);
+  });
+
+  it("ignores tasks for a different scriptFile, project, or task_type", () => {
+    const tasks = [
+      task({
+        task_id: "grid-other-file",
+        task_type: "grid",
+        resource_id: "grid-a",
+        script_file: "episode_2.json",
+        status: "running",
+      }),
+      task({
+        task_id: "grid-other-project",
+        task_type: "grid",
+        resource_id: "grid-b",
+        script_file: "episode_1.json",
+        project_name: "other-proj",
+        status: "running",
+      }),
+      task({
+        task_id: "non-grid",
+        task_type: "storyboard",
+        resource_id: "seg-1",
+        script_file: "episode_1.json",
+        status: "running",
+      }),
+    ];
+    expect(selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "proj")).toBe(false);
+  });
+
+  it("does not merge to a latest row — a terminal grid task for the scriptFile stays inactive", () => {
+    const tasks = [
+      task({
+        task_id: "grid-done",
+        task_type: "grid",
+        resource_id: "grid-abc",
+        script_file: "episode_1.json",
+        status: "succeeded",
+      }),
+    ];
+    expect(selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "proj")).toBe(false);
   });
 });
 

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -201,6 +201,37 @@ describe("selectHasActiveTaskForScriptFile", () => {
     expect(selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "proj")).toBe(false);
   });
 
+  it("normalizes an optional scripts/ prefix before comparing, either side", () => {
+    // router 入队路径可能传入带 scripts/ 前缀的 script_file，Agent/SDK 工具路径经
+    // validate_script_filename 强制裸文件名；两种任务行格式都要能被两种调用方式
+    // 传入的 scriptFile（带或不带前缀）匹配到，不依赖调用方预先裁剪。
+    const prefixedTaskTasks = [
+      task({
+        task_id: "grid-prefixed",
+        task_type: "grid",
+        resource_id: "grid-abc",
+        script_file: "scripts/episode_1.json",
+        status: "running",
+      }),
+    ];
+    expect(selectHasActiveTaskForScriptFile(prefixedTaskTasks, "grid", "episode_1.json", "proj")).toBe(
+      true,
+    );
+
+    const bareTaskTasks = [
+      task({
+        task_id: "grid-bare",
+        task_type: "grid",
+        resource_id: "grid-abc",
+        script_file: "episode_1.json",
+        status: "running",
+      }),
+    ];
+    expect(
+      selectHasActiveTaskForScriptFile(bareTaskTasks, "grid", "scripts/episode_1.json", "proj"),
+    ).toBe(true);
+  });
+
   it("does not merge to a latest row — a terminal grid task for the scriptFile stays inactive", () => {
     const tasks = [
       task({

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -6,6 +6,7 @@ import {
   selectHasActiveTaskForScriptFile,
   selectLatestTaskByResource,
   taskResourceKind,
+  useTasksStore,
 } from "./tasks-store";
 import type { TaskItem, TaskStatus } from "@/types";
 
@@ -156,6 +157,60 @@ describe("selectActiveResourceIds with image_edit", () => {
       }),
     ];
     expect(selectActiveResourceIds(tasks, "character", "proj").has("A")).toBe(true);
+  });
+});
+
+describe("selectActiveResourceIds optimistic occupancy", () => {
+  it("counts a resource active via an optimistic marker when no real task row exists yet", () => {
+    // 提交成功但 SSE 尚未把任务行写进 store 的空窗：仅凭乐观标记也应判定占用
+    const key = "proj\0character\0A\0image_edit";
+    expect(selectActiveResourceIds([], "character", "proj", new Set([key])).has("A")).toBe(true);
+  });
+
+  it("lets the real task row supersede the optimistic marker regardless of its status", () => {
+    // 真实任务行一旦出现（哪怕已是终态），不再依赖乐观标记——但此时该行本身若是活跃态，
+    // 仍会通过 selectActiveResourceIds 主逻辑判定占用；这里验证的是"不因乐观标记残留而
+    // 对已完结的真实行仍强制判占用"
+    const key = "proj\0character\0A\0image_edit";
+    const tasks = [
+      task({
+        task_id: "edit-A",
+        task_type: "image_edit",
+        resource_type: "character",
+        resource_id: "A",
+        status: "succeeded",
+      }),
+    ];
+    expect(selectActiveResourceIds(tasks, "character", "proj", new Set([key])).has("A")).toBe(false);
+  });
+
+  it("ignores an optimistic marker scoped to a different project or resource kind", () => {
+    const key = "proj\0character\0A\0image_edit";
+    expect(selectActiveResourceIds([], "storyboard", "proj", new Set([key])).has("A")).toBe(false);
+    expect(selectActiveResourceIds([], "character", "other-proj", new Set([key])).has("A")).toBe(false);
+  });
+});
+
+describe("useTasksStore.markOptimisticActive", () => {
+  it("marks a resource optimistically active and prunes markers already superseded by a real row", () => {
+    useTasksStore.setState({
+      tasks: [
+        task({
+          task_id: "edit-A",
+          task_type: "image_edit",
+          resource_type: "character",
+          resource_id: "A",
+          status: "succeeded",
+        }),
+      ],
+      optimisticActive: new Set(["proj\0character\0A\0image_edit"]),
+    });
+
+    // 标记一个新资源 B 的同时，A 的旧标记已被上面的真实终态行取代，应被顺带清理
+    useTasksStore.getState().markOptimisticActive("proj", "character", "B", "image_edit");
+
+    const keys = [...useTasksStore.getState().optimisticActive];
+    expect(keys).toEqual(["proj\0character\0B\0image_edit"]);
   });
 });
 

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -4,6 +4,7 @@ import {
   isTerminalStatus,
   selectActiveResourceIds,
   selectLatestTaskByResource,
+  taskResourceKind,
 } from "./tasks-store";
 import type { TaskItem, TaskStatus } from "@/types";
 
@@ -13,6 +14,7 @@ function task(overrides: Partial<TaskItem> & { task_id: string }): TaskItem {
     task_type: "reference_video",
     media_type: "video",
     resource_id: "unit-1",
+    resource_type: null,
     script_file: null,
     payload: {},
     status: "queued",
@@ -52,6 +54,62 @@ describe("isTerminalStatus", () => {
   it("counts in-flight statuses as non-terminal", () => {
     const live: TaskStatus[] = ["queued", "running", "cancelling"];
     for (const status of live) expect(isTerminalStatus(status)).toBe(false);
+  });
+});
+
+describe("taskResourceKind", () => {
+  it("returns task_type for non-edit tasks", () => {
+    expect(taskResourceKind(task({ task_id: "a", task_type: "storyboard" }))).toBe("storyboard");
+    expect(taskResourceKind(task({ task_id: "b", task_type: "character" }))).toBe("character");
+  });
+
+  it("returns resource_type for image_edit tasks so edits land in the target resource slot", () => {
+    expect(
+      taskResourceKind(task({ task_id: "a", task_type: "image_edit", resource_type: "character" })),
+    ).toBe("character");
+    expect(
+      taskResourceKind(task({ task_id: "b", task_type: "image_edit", resource_type: "storyboard" })),
+    ).toBe("storyboard");
+  });
+
+  it("falls back to empty string when an image_edit task has no resource_type", () => {
+    expect(taskResourceKind(task({ task_id: "a", task_type: "image_edit", resource_type: null }))).toBe("");
+  });
+});
+
+describe("selectActiveResourceIds with image_edit", () => {
+  it("counts an in-flight edit toward its resource kind's occupancy set", () => {
+    // 角色 A 有一条运行中的编辑任务：应落入 character 占用集，与生成任务同槽互斥
+    const tasks = [
+      task({
+        task_id: "edit-A",
+        task_type: "image_edit",
+        media_type: "image",
+        resource_id: "A",
+        resource_type: "character",
+        status: "running",
+      }),
+      task({
+        task_id: "gen-B",
+        task_type: "character",
+        media_type: "image",
+        resource_id: "B",
+        status: "queued",
+      }),
+    ];
+    expect([...selectActiveResourceIds(tasks, "character", "proj")].sort()).toEqual(["A", "B"]);
+    // 分镜编辑不串到 character 槽
+    const sbEdit = [
+      task({
+        task_id: "edit-S",
+        task_type: "image_edit",
+        resource_id: "S",
+        resource_type: "storyboard",
+        status: "running",
+      }),
+    ];
+    expect(selectActiveResourceIds(sbEdit, "character", "proj").has("S")).toBe(false);
+    expect(selectActiveResourceIds(sbEdit, "storyboard", "proj").has("S")).toBe(true);
   });
 });
 

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -111,6 +111,51 @@ describe("selectActiveResourceIds with image_edit", () => {
     expect(selectActiveResourceIds(sbEdit, "character", "proj").has("S")).toBe(false);
     expect(selectActiveResourceIds(sbEdit, "storyboard", "proj").has("S")).toBe(true);
   });
+
+  it("does not let a newer terminal edit hide a still-running generation task for the same resource", () => {
+    // 生成任务 running（较旧 updated_at）+ 编辑任务 failed（较新 updated_at）：
+    // 二者 task_type 不同，各自取最新行后按「任一活跃」判定，生成任务仍应算占用中
+    const tasks = [
+      task({
+        task_id: "gen-A",
+        task_type: "character",
+        resource_id: "A",
+        status: "running",
+        updated_at: "2026-07-16T00:00:00Z",
+      }),
+      task({
+        task_id: "edit-A",
+        task_type: "image_edit",
+        resource_type: "character",
+        resource_id: "A",
+        status: "failed",
+        updated_at: "2026-07-16T01:00:00Z",
+      }),
+    ];
+    expect(selectActiveResourceIds(tasks, "character", "proj").has("A")).toBe(true);
+  });
+
+  it("does not let a newer terminal generation hide a still-running edit task for the same resource", () => {
+    // 反向对称场景：编辑任务 running（较旧）+ 生成任务 succeeded（较新），编辑仍占用中
+    const tasks = [
+      task({
+        task_id: "edit-A",
+        task_type: "image_edit",
+        resource_type: "character",
+        resource_id: "A",
+        status: "running",
+        updated_at: "2026-07-16T00:00:00Z",
+      }),
+      task({
+        task_id: "gen-A",
+        task_type: "character",
+        resource_id: "A",
+        status: "succeeded",
+        updated_at: "2026-07-16T01:00:00Z",
+      }),
+    ];
+    expect(selectActiveResourceIds(tasks, "character", "proj").has("A")).toBe(true);
+  });
 });
 
 describe("selectLatestTaskByResource", () => {

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -274,6 +274,46 @@ describe("useTasksStore.markOptimisticActive", () => {
   });
 });
 
+describe("useTasksStore.setTasks prunes stale optimistic markers", () => {
+  it("removes a marker superseded by a real row even without a new markOptimisticActive call", () => {
+    // store 只保留最近 200 条任务：真实行落地后若被更晚的大量新任务挤出该窗口，
+    // 仅靠 markOptimisticActive 内的顺带清理不会再触发——轮询写回本身也要清理，
+    // 否则这条已完结的旧标记会永久残留，把资源误判为占用中直到页面刷新。
+    useTasksStore.setState({
+      tasks: [],
+      optimisticActive: new Set([`proj\0character\0A\0image_edit\0${"2025-01-01T00:00:00Z"}`]),
+    });
+
+    useTasksStore.getState().setTasks([
+      task({
+        task_id: "edit-A",
+        task_type: "image_edit",
+        resource_type: "character",
+        resource_id: "A",
+        status: "succeeded",
+        updated_at: "2026-07-16T00:00:00Z",
+      }),
+    ]);
+
+    expect([...useTasksStore.getState().optimisticActive]).toEqual([]);
+  });
+
+  it("keeps a marker whose real row has not landed yet", () => {
+    useTasksStore.setState({
+      tasks: [],
+      optimisticActive: new Set([`proj\0character\0A\0image_edit\0`]),
+    });
+
+    useTasksStore.getState().setTasks([
+      task({ task_id: "unrelated", resource_id: "B", task_type: "character" }),
+    ]);
+
+    expect([...useTasksStore.getState().optimisticActive]).toEqual([
+      `proj\0character\0A\0image_edit\0`,
+    ]);
+  });
+});
+
 describe("selectHasActiveTaskForScriptFile", () => {
   it("returns true when a grid task for the scriptFile is queued or running", () => {
     const tasks = [
@@ -358,6 +398,131 @@ describe("selectHasActiveTaskForScriptFile", () => {
       }),
     ];
     expect(selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "proj")).toBe(false);
+  });
+
+  describe("optimistic occupancy", () => {
+    it("counts the scriptFile active via an optimistic marker when no real grid row exists yet", () => {
+      // 宫格入队成功到轮询写回新 grid 任务行之间的空窗：仅凭乐观标记也应判定本集占用中
+      const key = "proj\0grid\0episode_1.json\0";
+      expect(
+        selectHasActiveTaskForScriptFile([], "grid", "episode_1.json", "proj", new Set([key])),
+      ).toBe(true);
+    });
+
+    it("lets a real grid row newer than the baseline supersede the marker regardless of its status", () => {
+      const key = "proj\0grid\0episode_1.json\0";
+      const tasks = [
+        task({
+          task_id: "grid-1",
+          task_type: "grid",
+          resource_id: "grid-abc",
+          script_file: "episode_1.json",
+          status: "succeeded",
+        }),
+      ];
+      expect(
+        selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "proj", new Set([key])),
+      ).toBe(false);
+    });
+
+    it("does not let a stale row predating the baseline supersede a marker for a repeat submission", () => {
+      const key = `proj\0grid\0episode_1.json\0${"2026-07-16T00:00:00Z"}`;
+      const tasks = [
+        task({
+          task_id: "grid-old",
+          task_type: "grid",
+          resource_id: "grid-abc",
+          script_file: "episode_1.json",
+          status: "succeeded",
+          updated_at: "2026-07-16T00:00:00Z",
+        }),
+      ];
+      expect(
+        selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "proj", new Set([key])),
+      ).toBe(true);
+    });
+
+    it("ignores a marker scoped to a different project, task type, or scriptFile", () => {
+      const key = "proj\0grid\0episode_1.json\0";
+      expect(
+        selectHasActiveTaskForScriptFile([], "storyboard", "episode_1.json", "proj", new Set([key])),
+      ).toBe(false);
+      expect(
+        selectHasActiveTaskForScriptFile([], "grid", "episode_1.json", "other-proj", new Set([key])),
+      ).toBe(false);
+      expect(
+        selectHasActiveTaskForScriptFile([], "grid", "episode_2.json", "proj", new Set([key])),
+      ).toBe(false);
+    });
+  });
+});
+
+describe("useTasksStore.markOptimisticActiveForScriptFile", () => {
+  it("marks a scriptFile optimistically active for the given taskType", () => {
+    useTasksStore.setState({ tasks: [], optimisticActiveScriptFile: new Set() });
+
+    useTasksStore.getState().markOptimisticActiveForScriptFile("proj", "grid", "episode_1.json");
+
+    const keys = [...useTasksStore.getState().optimisticActiveScriptFile];
+    expect(keys).toEqual(["proj\0grid\0episode_1.json\0"]);
+
+    const { tasks, optimisticActiveScriptFile } = useTasksStore.getState();
+    expect(
+      selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "proj", optimisticActiveScriptFile),
+    ).toBe(true);
+  });
+
+  it("normalizes a scripts/ prefix in the scriptFile before storing the key", () => {
+    useTasksStore.setState({ tasks: [], optimisticActiveScriptFile: new Set() });
+
+    useTasksStore.getState().markOptimisticActiveForScriptFile("proj", "grid", "scripts/episode_1.json");
+
+    expect([...useTasksStore.getState().optimisticActiveScriptFile]).toEqual([
+      "proj\0grid\0episode_1.json\0",
+    ]);
+  });
+
+  it("prunes markers already superseded by a real row when marking a different scriptFile", () => {
+    useTasksStore.setState({
+      tasks: [
+        task({
+          task_id: "grid-1",
+          task_type: "grid",
+          resource_id: "grid-abc",
+          script_file: "episode_1.json",
+          status: "succeeded",
+          updated_at: "2026-07-16T00:00:00Z",
+        }),
+      ],
+      optimisticActiveScriptFile: new Set([`proj\0grid\0episode_1.json\0${"2025-01-01T00:00:00Z"}`]),
+    });
+
+    useTasksStore.getState().markOptimisticActiveForScriptFile("proj", "grid", "episode_2.json");
+
+    const keys = [...useTasksStore.getState().optimisticActiveScriptFile];
+    expect(keys).toEqual(["proj\0grid\0episode_2.json\0"]);
+  });
+});
+
+describe("useTasksStore.setTasks prunes stale optimisticActiveScriptFile markers", () => {
+  it("removes a scriptFile marker superseded by a real row without a new mark call", () => {
+    useTasksStore.setState({
+      tasks: [],
+      optimisticActiveScriptFile: new Set([`proj\0grid\0episode_1.json\0${"2025-01-01T00:00:00Z"}`]),
+    });
+
+    useTasksStore.getState().setTasks([
+      task({
+        task_id: "grid-1",
+        task_type: "grid",
+        resource_id: "grid-abc",
+        script_file: "episode_1.json",
+        status: "succeeded",
+        updated_at: "2026-07-16T00:00:00Z",
+      }),
+    ]);
+
+    expect([...useTasksStore.getState().optimisticActiveScriptFile]).toEqual([]);
   });
 });
 

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -25,13 +25,18 @@ const defaultStats: TaskStats = {
   queued: 0, running: 0, cancelling: 0, succeeded: 0, failed: 0, cancelled: 0, total: 0,
 };
 
+// 标记发起时尚未有真实行，baseline 取空串——空串小于任何 ISO 时间戳，故首次判定
+// 一律视为"尚无真实行"，语义与之前一致；同资源之后再次编辑时 baseline 取当时最新
+// 真实行的 updated_at，只有新落地的行（updated_at 大于 baseline）才能让位，旧终态
+// 行不会误判为"当前这次"的真实行。
 function optimisticKey(
   projectName: string,
   resourceKind: string,
   resourceId: string,
   pendingTaskType: string,
+  baselineUpdatedAt: string,
 ): string {
-  return `${projectName}\0${resourceKind}\0${resourceId}\0${pendingTaskType}`;
+  return `${projectName}\0${resourceKind}\0${resourceId}\0${pendingTaskType}\0${baselineUpdatedAt}`;
 }
 
 export const useTasksStore = create<TasksState>((set) => ({
@@ -45,17 +50,34 @@ export const useTasksStore = create<TasksState>((set) => ({
   setConnected: (connected) => set({ connected }),
   markOptimisticActive: (projectName, resourceKind, resourceId, pendingTaskType) =>
     set((s) => {
+      let baseline = "";
+      for (const t of s.tasks) {
+        if (
+          t.project_name === projectName &&
+          t.task_type === pendingTaskType &&
+          t.resource_id === resourceId &&
+          taskResourceKind(t) === resourceKind &&
+          t.updated_at > baseline
+        ) {
+          baseline = t.updated_at;
+        }
+      }
+
       // 顺带清理已被真实任务行取代的旧标记，避免 Set 在会话周期内无界增长。
       const next = new Set<string>();
       for (const key of s.optimisticActive) {
-        const [kProject, , kResourceId, kPendingTaskType] = key.split("\0");
+        const [kProject, kResourceKind, kResourceId, kPendingTaskType, kBaseline = ""] = key.split("\0");
         const superseded = s.tasks.some(
           (t) =>
-            t.project_name === kProject && t.task_type === kPendingTaskType && t.resource_id === kResourceId,
+            t.project_name === kProject &&
+            t.task_type === kPendingTaskType &&
+            t.resource_id === kResourceId &&
+            taskResourceKind(t) === kResourceKind &&
+            t.updated_at > kBaseline,
         );
         if (!superseded) next.add(key);
       }
-      next.add(optimisticKey(projectName, resourceKind, resourceId, pendingTaskType));
+      next.add(optimisticKey(projectName, resourceKind, resourceId, pendingTaskType, baseline));
       return { optimisticActive: next };
     }),
 }));
@@ -126,7 +148,12 @@ export function selectLatestTaskByResource(
  * `idx_tasks_dedupe_active`，但该索引以 task_type 为键的一部分，不拦跨 task_type 并发）。
  * `optimisticActive` 由提交方（如 ImageEditButton）在提交成功后立即标记，此处按
  * (projectName, taskType) 过滤后并入占用集，直到标记所等待的真实任务行出现为止
- * （比对不看状态，出现即让位给真实数据）。
+ * （比对不看状态，出现即让位给真实数据）。标记内嵌 baseline（标记发起时刻该资源
+ * 已有的最新同类真实行 updated_at）与 resourceKind：同一资源被反复编辑时，若不比对
+ * baseline，本次标记会被上一次编辑遗留的旧终态行误判为"已有真实行"而立即失效；
+ * 若不比对 resourceKind，不同资源种类之间偶然的 resource_id 相同（如同名角色与场景）
+ * 会互相让位。故只有 updated_at 大于 baseline 且 resourceKind 匹配的行才视为"本次
+ * 标记等待的真实行"。
  */
 export function selectActiveResourceIds(
   tasks: TaskItem[],
@@ -147,10 +174,15 @@ export function selectActiveResourceIds(
     if (isActiveStatus(task.status)) ids.add(task.resource_id);
   }
   for (const key of optimisticActive) {
-    const [kProject, kResourceKind, kResourceId, kPendingTaskType] = key.split("\0");
+    const [kProject, kResourceKind, kResourceId, kPendingTaskType, kBaseline = ""] = key.split("\0");
     if (kProject !== projectName || kResourceKind !== taskType) continue;
     const hasPendingRow = tasks.some(
-      (t) => t.project_name === kProject && t.task_type === kPendingTaskType && t.resource_id === kResourceId,
+      (t) =>
+        t.project_name === kProject &&
+        t.task_type === kPendingTaskType &&
+        t.resource_id === kResourceId &&
+        taskResourceKind(t) === kResourceKind &&
+        t.updated_at > kBaseline,
     );
     if (!hasPendingRow) ids.add(kResourceId);
   }

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -51,6 +51,15 @@ export function isTerminalStatus(status: TaskStatus): boolean {
 }
 
 /**
+ * 任务占用的「资源种类」。除 image_edit 外，task_type 本身即资源种类；image_edit 跨
+ * character/scene/prop/product/storyboard 共用一个 task_type，真正的种类在 resource_type，
+ * 故按 resource_type 归槽——编辑任务与同资源的生成任务落入同一占用集、彼此互斥。
+ */
+export function taskResourceKind(task: TaskItem): string {
+  return task.task_type === "image_edit" ? (task.resource_type ?? "") : task.task_type;
+}
+
+/**
  * 不变量 2：按 resource_id 归并任务，同一 resource 多行时取 updated_at 最新的一行。
  * 可选按 projectName / taskType 预筛；store 不保证顺序，故显式比较 updated_at。
  */
@@ -61,7 +70,7 @@ export function selectLatestTaskByResource(
   const latest = new Map<string, TaskItem>();
   for (const task of tasks) {
     if (filter.projectName !== undefined && task.project_name !== filter.projectName) continue;
-    if (filter.taskType !== undefined && task.task_type !== filter.taskType) continue;
+    if (filter.taskType !== undefined && taskResourceKind(task) !== filter.taskType) continue;
     const prev = latest.get(task.resource_id);
     if (!prev || task.updated_at > prev.updated_at) latest.set(task.resource_id, task);
   }

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -8,6 +8,8 @@ interface TasksState {
   connected: boolean;
   /** 乐观占用标记，见下方 {@link selectActiveResourceIds} 的乐观占用小节。 */
   optimisticActive: Set<string>;
+  /** 乐观占用标记（scriptFile 粒度），见下方 {@link selectHasActiveTaskForScriptFile} 的乐观占用小节。 */
+  optimisticActiveScriptFile: Set<string>;
 
   // Actions
   setTasks: (tasks: TaskItem[]) => void;
@@ -18,6 +20,11 @@ interface TasksState {
     resourceKind: string,
     resourceId: string,
     pendingTaskType: string,
+  ) => void;
+  markOptimisticActiveForScriptFile: (
+    projectName: string,
+    taskType: string,
+    scriptFile: string,
   ) => void;
 }
 
@@ -39,13 +46,73 @@ function optimisticKey(
   return `${projectName}\0${resourceKind}\0${resourceId}\0${pendingTaskType}\0${baselineUpdatedAt}`;
 }
 
+// 按当前 tasks 修剪已被真实行取代的乐观占用标记（不新增标记，仅清理）。除标记时机的顺带
+// 清理外，也要在每次 setTasks（轮询写回）时执行——store 只保留最近 200 条任务，若真实行
+// 落地后被更晚的大量新任务挤出该窗口，仅在“下次再有新标记”时才清理会让这条已完结的旧
+// 标记永久残留、误判资源占用中，必须让轮询本身也承担清理职责。
+function pruneSupersededOptimisticActive(
+  tasks: TaskItem[],
+  optimisticActive: ReadonlySet<string>,
+): Set<string> {
+  const next = new Set<string>();
+  for (const key of optimisticActive) {
+    const [kProject, kResourceKind, kResourceId, kPendingTaskType, kBaseline = ""] = key.split("\0");
+    const superseded = tasks.some(
+      (t) =>
+        t.project_name === kProject &&
+        t.task_type === kPendingTaskType &&
+        t.resource_id === kResourceId &&
+        taskResourceKind(t) === kResourceKind &&
+        t.updated_at > kBaseline,
+    );
+    if (!superseded) next.add(key);
+  }
+  return next;
+}
+
+function optimisticScriptFileKey(
+  projectName: string,
+  taskType: string,
+  scriptFile: string,
+  baselineUpdatedAt: string,
+): string {
+  return `${projectName}\0${taskType}\0${stripScriptsPrefix(scriptFile)}\0${baselineUpdatedAt}`;
+}
+
+// scriptFile 粒度乐观标记的同类修剪，见 {@link pruneSupersededOptimisticActive}。
+function pruneSupersededOptimisticActiveScriptFile(
+  tasks: TaskItem[],
+  optimisticActiveScriptFile: ReadonlySet<string>,
+): Set<string> {
+  const next = new Set<string>();
+  for (const key of optimisticActiveScriptFile) {
+    const [kProject, kTaskType, kScriptFile, kBaseline = ""] = key.split("\0");
+    const superseded = tasks.some(
+      (t) =>
+        t.project_name === kProject &&
+        t.task_type === kTaskType &&
+        t.script_file != null &&
+        stripScriptsPrefix(t.script_file) === kScriptFile &&
+        t.updated_at > kBaseline,
+    );
+    if (!superseded) next.add(key);
+  }
+  return next;
+}
+
 export const useTasksStore = create<TasksState>((set) => ({
   tasks: [],
   stats: defaultStats,
   connected: false,
   optimisticActive: new Set(),
+  optimisticActiveScriptFile: new Set(),
 
-  setTasks: (tasks) => set({ tasks }),
+  setTasks: (tasks) =>
+    set((s) => ({
+      tasks,
+      optimisticActive: pruneSupersededOptimisticActive(tasks, s.optimisticActive),
+      optimisticActiveScriptFile: pruneSupersededOptimisticActiveScriptFile(tasks, s.optimisticActiveScriptFile),
+    })),
   setStats: (stats) => set({ stats }),
   setConnected: (connected) => set({ connected }),
   markOptimisticActive: (projectName, resourceKind, resourceId, pendingTaskType) =>
@@ -64,21 +131,29 @@ export const useTasksStore = create<TasksState>((set) => ({
       }
 
       // 顺带清理已被真实任务行取代的旧标记，避免 Set 在会话周期内无界增长。
-      const next = new Set<string>();
-      for (const key of s.optimisticActive) {
-        const [kProject, kResourceKind, kResourceId, kPendingTaskType, kBaseline = ""] = key.split("\0");
-        const superseded = s.tasks.some(
-          (t) =>
-            t.project_name === kProject &&
-            t.task_type === kPendingTaskType &&
-            t.resource_id === kResourceId &&
-            taskResourceKind(t) === kResourceKind &&
-            t.updated_at > kBaseline,
-        );
-        if (!superseded) next.add(key);
-      }
+      const next = pruneSupersededOptimisticActive(s.tasks, s.optimisticActive);
       next.add(optimisticKey(projectName, resourceKind, resourceId, pendingTaskType, baseline));
       return { optimisticActive: next };
+    }),
+  markOptimisticActiveForScriptFile: (projectName, taskType, scriptFile) =>
+    set((s) => {
+      const normalized = stripScriptsPrefix(scriptFile);
+      let baseline = "";
+      for (const t of s.tasks) {
+        if (
+          t.project_name === projectName &&
+          t.task_type === taskType &&
+          t.script_file != null &&
+          stripScriptsPrefix(t.script_file) === normalized &&
+          t.updated_at > baseline
+        ) {
+          baseline = t.updated_at;
+        }
+      }
+
+      const next = pruneSupersededOptimisticActiveScriptFile(s.tasks, s.optimisticActiveScriptFile);
+      next.add(optimisticScriptFileKey(projectName, taskType, scriptFile, baseline));
+      return { optimisticActiveScriptFile: next };
     }),
 }));
 
@@ -205,15 +280,21 @@ function stripScriptsPrefix(path: string): string {
  * 分镜 segment_id，无法归入 selectActiveResourceIds 的按资源判定；但 grid 切割阶段
  * 会覆写本集内多个分镜的 storyboard 文件，故按 scriptFile 判定「本集是否有宫格任务
  * 在跑」，用于禁用宫格模式下的分镜编辑入口，避免编辑与切割并发写同一文件。
+ *
+ * 乐观占用：宫格入队请求成功返回到下一次轮询把新 grid 任务行写进 store 之间有 ~3s 空窗，
+ * 期间本集在 store 里尚无对应 grid 任务行，分镜编辑入口会误判为空闲、与随后的切割阶段
+ * 并发写同一张 storyboard current 图。语义与 {@link selectActiveResourceIds} 的乐观占用
+ * 小节一致，但归组键换成 scriptFile（grid 任务无法按 resource_id 归组，见上）。
  */
 export function selectHasActiveTaskForScriptFile(
   tasks: TaskItem[],
   taskType: string,
   scriptFile: string,
   projectName: string,
+  optimisticActiveScriptFile: ReadonlySet<string> = EMPTY_OPTIMISTIC,
 ): boolean {
   const normalized = stripScriptsPrefix(scriptFile);
-  return tasks.some(
+  const hasRealActive = tasks.some(
     (task) =>
       task.project_name === projectName &&
       task.task_type === taskType &&
@@ -221,6 +302,22 @@ export function selectHasActiveTaskForScriptFile(
       stripScriptsPrefix(task.script_file) === normalized &&
       isActiveStatus(task.status),
   );
+  if (hasRealActive) return true;
+
+  for (const key of optimisticActiveScriptFile) {
+    const [kProject, kTaskType, kScriptFile, kBaseline = ""] = key.split("\0");
+    if (kProject !== projectName || kTaskType !== taskType || kScriptFile !== normalized) continue;
+    const hasPendingRow = tasks.some(
+      (t) =>
+        t.project_name === kProject &&
+        t.task_type === kTaskType &&
+        t.script_file != null &&
+        stripScriptsPrefix(t.script_file) === kScriptFile &&
+        t.updated_at > kBaseline,
+    );
+    if (!hasPendingRow) return true;
+  }
+  return false;
 }
 
 /** hook 版 {@link selectHasActiveTaskForScriptFile}；scriptFile/projectName 缺失时返回 false。 */
@@ -231,7 +328,13 @@ export function useHasActiveTaskForScriptFile(
 ): boolean {
   return useTasksStore((s) =>
     scriptFile && projectName
-      ? selectHasActiveTaskForScriptFile(s.tasks, taskType, scriptFile, projectName)
+      ? selectHasActiveTaskForScriptFile(
+          s.tasks,
+          taskType,
+          scriptFile,
+          projectName,
+          s.optimisticActiveScriptFile,
+        )
       : false,
   );
 }

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -79,15 +79,28 @@ export function selectLatestTaskByResource(
 
 /**
  * 命中 taskType + projectName 且「最新行」处于活跃态的 resource_id 集合。
- * 「最新行胜出」下沉于此：重试的新 running/queued 行不被同 resource 的旧 failed 行盖住。
+ * 「最新行胜出」按 (resource_id, task.task_type) 二级键分别归并——同一原生 task_type
+ * 内，重试的新 running/queued 行不被同 resource 的旧 failed 行盖住；但 image_edit 与
+ * 其目标资源的生成任务是两个独立 task_type（仅通过 taskResourceKind 共享同一占用槽），
+ * 后端并无互斥保证，二者可能真实并存。若仍按单一「最新行」判定，较新落地的编辑终态
+ * （成功/失败）会掩盖仍在运行的生成任务（或反之），导致资源被误判为空闲。故按各自
+ * task_type 分别取最新行，再在任一 task_type 的最新行活跃时即计入占用。
  */
 export function selectActiveResourceIds(
   tasks: TaskItem[],
   taskType: string,
   projectName: string,
 ): Set<string> {
+  const latestByResourceAndTaskType = new Map<string, TaskItem>();
+  for (const task of tasks) {
+    if (task.project_name !== projectName) continue;
+    if (taskResourceKind(task) !== taskType) continue;
+    const key = `${task.resource_id}\0${task.task_type}`;
+    const prev = latestByResourceAndTaskType.get(key);
+    if (!prev || task.updated_at > prev.updated_at) latestByResourceAndTaskType.set(key, task);
+  }
   const ids = new Set<string>();
-  for (const task of selectLatestTaskByResource(tasks, { projectName, taskType }).values()) {
+  for (const task of latestByResourceAndTaskType.values()) {
     if (isActiveStatus(task.status)) ids.add(task.resource_id);
   }
   return ids;

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -106,6 +106,41 @@ export function selectActiveResourceIds(
   return ids;
 }
 
+/**
+ * 是否存在指定 scriptFile 下、taskType 类型的活跃任务。不做「最新行胜出」归并——
+ * 存在即算，用于粗粒度剧集级占用判定：grid 任务的 resource_id 是 grid_id 而非
+ * 分镜 segment_id，无法归入 selectActiveResourceIds 的按资源判定；但 grid 切割阶段
+ * 会覆写本集内多个分镜的 storyboard 文件，故按 scriptFile 判定「本集是否有宫格任务
+ * 在跑」，用于禁用宫格模式下的分镜编辑入口，避免编辑与切割并发写同一文件。
+ */
+export function selectHasActiveTaskForScriptFile(
+  tasks: TaskItem[],
+  taskType: string,
+  scriptFile: string,
+  projectName: string,
+): boolean {
+  return tasks.some(
+    (task) =>
+      task.project_name === projectName &&
+      task.task_type === taskType &&
+      task.script_file === scriptFile &&
+      isActiveStatus(task.status),
+  );
+}
+
+/** hook 版 {@link selectHasActiveTaskForScriptFile}；scriptFile/projectName 缺失时返回 false。 */
+export function useHasActiveTaskForScriptFile(
+  taskType: string,
+  scriptFile: string | undefined | null,
+  projectName: string | undefined | null,
+): boolean {
+  return useTasksStore((s) =>
+    scriptFile && projectName
+      ? selectHasActiveTaskForScriptFile(s.tasks, taskType, scriptFile, projectName)
+      : false,
+  );
+}
+
 // projectName 缺失时复用同一空集，保证 hook 引用稳定。
 const EMPTY_ACTIVE_IDS: Set<string> = new Set();
 

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -6,25 +6,58 @@ interface TasksState {
   tasks: TaskItem[];
   stats: TaskStats;
   connected: boolean;
+  /** 乐观占用标记，见下方 {@link selectActiveResourceIds} 的乐观占用小节。 */
+  optimisticActive: Set<string>;
 
   // Actions
   setTasks: (tasks: TaskItem[]) => void;
   setStats: (stats: TaskStats) => void;
   setConnected: (connected: boolean) => void;
+  markOptimisticActive: (
+    projectName: string,
+    resourceKind: string,
+    resourceId: string,
+    pendingTaskType: string,
+  ) => void;
 }
 
 const defaultStats: TaskStats = {
   queued: 0, running: 0, cancelling: 0, succeeded: 0, failed: 0, cancelled: 0, total: 0,
 };
 
+function optimisticKey(
+  projectName: string,
+  resourceKind: string,
+  resourceId: string,
+  pendingTaskType: string,
+): string {
+  return `${projectName}\0${resourceKind}\0${resourceId}\0${pendingTaskType}`;
+}
+
 export const useTasksStore = create<TasksState>((set) => ({
   tasks: [],
   stats: defaultStats,
   connected: false,
+  optimisticActive: new Set(),
 
   setTasks: (tasks) => set({ tasks }),
   setStats: (stats) => set({ stats }),
   setConnected: (connected) => set({ connected }),
+  markOptimisticActive: (projectName, resourceKind, resourceId, pendingTaskType) =>
+    set((s) => {
+      // 顺带清理已被真实任务行取代的旧标记，避免 Set 在会话周期内无界增长。
+      const next = new Set<string>();
+      for (const key of s.optimisticActive) {
+        const [kProject, , kResourceId, kPendingTaskType] = key.split("\0");
+        const superseded = s.tasks.some(
+          (t) =>
+            t.project_name === kProject && t.task_type === kPendingTaskType && t.resource_id === kResourceId,
+        );
+        if (!superseded) next.add(key);
+      }
+      next.add(optimisticKey(projectName, resourceKind, resourceId, pendingTaskType));
+      return { optimisticActive: next };
+    }),
 }));
 
 // ---------------------------------------------------------------------------
@@ -85,11 +118,21 @@ export function selectLatestTaskByResource(
  * 后端并无互斥保证，二者可能真实并存。若仍按单一「最新行」判定，较新落地的编辑终态
  * （成功/失败）会掩盖仍在运行的生成任务（或反之），导致资源被误判为空闲。故按各自
  * task_type 分别取最新行，再在任一 task_type 的最新行活跃时即计入占用。
+ *
+ * 乐观占用：入队请求成功返回到 `useTasksSSE` 下一次轮询把新任务行写进 store 之间有
+ * ~3s 空窗（轮询间隔），期间该 resource 在 store 里还没有对应任务行、判定为空闲。
+ * image_edit 与其目标资源共用占用槽，是第一个会在此空窗内与「本资源另一 task_type」
+ * 并发提交的场景（同 task_type 的并发提交已被后端 dedupe 索引拦下，见
+ * `idx_tasks_dedupe_active`，但该索引以 task_type 为键的一部分，不拦跨 task_type 并发）。
+ * `optimisticActive` 由提交方（如 ImageEditButton）在提交成功后立即标记，此处按
+ * (projectName, taskType) 过滤后并入占用集，直到标记所等待的真实任务行出现为止
+ * （比对不看状态，出现即让位给真实数据）。
  */
 export function selectActiveResourceIds(
   tasks: TaskItem[],
   taskType: string,
   projectName: string,
+  optimisticActive: ReadonlySet<string> = EMPTY_OPTIMISTIC,
 ): Set<string> {
   const latestByResourceAndTaskType = new Map<string, TaskItem>();
   for (const task of tasks) {
@@ -103,8 +146,18 @@ export function selectActiveResourceIds(
   for (const task of latestByResourceAndTaskType.values()) {
     if (isActiveStatus(task.status)) ids.add(task.resource_id);
   }
+  for (const key of optimisticActive) {
+    const [kProject, kResourceKind, kResourceId, kPendingTaskType] = key.split("\0");
+    if (kProject !== projectName || kResourceKind !== taskType) continue;
+    const hasPendingRow = tasks.some(
+      (t) => t.project_name === kProject && t.task_type === kPendingTaskType && t.resource_id === kResourceId,
+    );
+    if (!hasPendingRow) ids.add(kResourceId);
+  }
   return ids;
 }
+
+const EMPTY_OPTIMISTIC: ReadonlySet<string> = new Set();
 
 // 与 task-target.ts 的 stripScriptsPrefix 同一归一化规则：episode 元数据的 script_file
 // 固定带 `scripts/` 前缀（见 ProjectManager._apply_episode_sync），但任务行的 script_file
@@ -161,7 +214,9 @@ export function useActiveResourceIds(
 ): Set<string> {
   return useTasksStore(
     useShallow((s) =>
-      projectName ? selectActiveResourceIds(s.tasks, taskType, projectName) : EMPTY_ACTIVE_IDS,
+      projectName
+        ? selectActiveResourceIds(s.tasks, taskType, projectName, s.optimisticActive)
+        : EMPTY_ACTIVE_IDS,
     ),
   );
 }

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -106,6 +106,14 @@ export function selectActiveResourceIds(
   return ids;
 }
 
+// 与 task-target.ts 的 stripScriptsPrefix 同一归一化规则：episode 元数据的 script_file
+// 固定带 `scripts/` 前缀（见 ProjectManager._apply_episode_sync），但任务行的 script_file
+// 由各入队调用方各自传入——router 直传 webui 表单值，Agent/SDK 工具经 validate_script_filename
+// 强制裸文件名，两者格式不保证一致。此处不依赖调用方预先裁剪，自行归一化后再比较。
+function stripScriptsPrefix(path: string): string {
+  return path.replace(/^scripts\//, "");
+}
+
 /**
  * 是否存在指定 scriptFile 下、taskType 类型的活跃任务。不做「最新行胜出」归并——
  * 存在即算，用于粗粒度剧集级占用判定：grid 任务的 resource_id 是 grid_id 而非
@@ -119,11 +127,13 @@ export function selectHasActiveTaskForScriptFile(
   scriptFile: string,
   projectName: string,
 ): boolean {
+  const normalized = stripScriptsPrefix(scriptFile);
   return tasks.some(
     (task) =>
       task.project_name === projectName &&
       task.task_type === taskType &&
-      task.script_file === scriptFile &&
+      task.script_file != null &&
+      stripScriptsPrefix(task.script_file) === normalized &&
       isActiveStatus(task.status),
   );
 }

--- a/frontend/src/test/factories.ts
+++ b/frontend/src/test/factories.ts
@@ -9,6 +9,7 @@ export function makeTask(overrides: Partial<TaskItem> = {}): TaskItem {
     task_type: "reference_video",
     media_type: "video",
     resource_id: "E1U1",
+    resource_type: null,
     script_file: null,
     payload: {},
     status: "queued",

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -21,6 +21,12 @@ export interface TaskItem {
   task_type: string;
   media_type: TaskMediaType;
   resource_id: string;
+  /**
+   * 资源种类。仅 image_edit 任务写入（character/scene/prop/product/storyboard）——
+   * 其余任务类型 task_type 本身已按资源种类区分，故为 null。占用匹配据此把编辑任务
+   * 归入对应资源槽（见 tasks-store 的 taskResourceKind）。
+   */
+  resource_type: string | null;
   script_file: string | null;
   /** Parsed from payload_json in the SQLite row */
   payload: Record<string, unknown>;

--- a/frontend/src/utils/task-target.test.ts
+++ b/frontend/src/utils/task-target.test.ts
@@ -93,6 +93,40 @@ describe("buildTaskFailureTarget", () => {
   it("returns null for unknown task types", () => {
     expect(buildTaskFailureTarget(makeTask({ task_type: "unknown" }), projectData)).toBeNull();
   });
+
+  it("dispatches image_edit to the resource_type's own route", () => {
+    expect(
+      buildTaskFailureTarget(
+        makeTask({ task_type: "image_edit", resource_type: "character", resource_id: "Hero" }),
+        null,
+      ),
+    ).toEqual({ type: "character", id: "Hero", route: "/characters", highlight_style: "flash" });
+
+    const storyboardTarget = buildTaskFailureTarget(
+      makeTask({
+        task_type: "image_edit",
+        resource_type: "storyboard",
+        resource_id: "E1S01",
+        script_file: "ep1.json",
+      }),
+      projectData,
+    );
+    expect(storyboardTarget).toEqual({
+      type: "segment",
+      id: "E1S01",
+      route: "/episodes/1",
+      highlight_style: "flash",
+    });
+  });
+
+  it("returns null for image_edit on a product (no route defined)", () => {
+    expect(
+      buildTaskFailureTarget(
+        makeTask({ task_type: "image_edit", resource_type: "product", resource_id: "Bag" }),
+        null,
+      ),
+    ).toBeNull();
+  });
 });
 
 describe("describeTaskFailure", () => {
@@ -116,5 +150,14 @@ describe("describeTaskFailure", () => {
 
   it("returns null for unknown task types", () => {
     expect(describeTaskFailure(t, makeTask({ task_type: "unknown" }))).toBeNull();
+  });
+
+  it("uses the image_edit key regardless of resource_type", () => {
+    expect(
+      describeTaskFailure(
+        t,
+        makeTask({ task_type: "image_edit", resource_type: "prop", resource_id: "Sword" }),
+      ),
+    ).toBe("image_edit_task_failed|Sword|boom");
   });
 });

--- a/frontend/src/utils/task-target.test.ts
+++ b/frontend/src/utils/task-target.test.ts
@@ -10,6 +10,7 @@ function makeTask(overrides: Partial<TaskItem>): TaskItem {
     task_type: "storyboard",
     media_type: "image",
     resource_id: "E1S01",
+    resource_type: null,
     script_file: "ep1.json",
     payload: {},
     status: "failed",

--- a/frontend/src/utils/task-target.ts
+++ b/frontend/src/utils/task-target.ts
@@ -9,6 +9,8 @@ import type { ProjectData, TaskItem, WorkspaceNotificationTarget } from "@/types
  * - storyboard/video → 对应剧集的分镜（ShotSplitView 按 segment id 选中）
  * - grid → 对应剧集的宫格画布（导航即回跳，无 DOM 锚点）
  * - reference_video → 对应剧集的参考单元（ReferenceVideoCanvas 选中 unit）
+ * - image_edit → 按 resource_type 转发到上述对应路由；product 暂无路由（与既有
+ *   product 生成任务缺口一致），仅推送文案不可点击
  *
  * 剧集路由由 task.script_file 反查 projectData.episodes 得到；查不到时返回
  * null，让通知仍然推送、仅不可点击（优雅降级）。
@@ -30,6 +32,7 @@ const FAILURE_TEXT_KEYS: Partial<
   prop: { key: "prop_task_failed", idParam: "id" },
   grid: { key: "grid_task_failed", idParam: "id" },
   reference_video: { key: "reference_generation_task_failed", idParam: "unitId" },
+  image_edit: { key: "image_edit_task_failed", idParam: "id" },
 };
 
 function stripScriptsPrefix(path: string): string {
@@ -76,6 +79,30 @@ export function buildTaskFailureTarget(
     case "reference_video": {
       const route = resolveEpisodeRoute(projectData, task.script_file);
       return route ? { type: "reference_unit", id: task.resource_id, route } : null;
+    }
+    case "image_edit": {
+      // image_edit 跨 character/scene/prop/product/storyboard 共用 task_type，真正
+      // 的资源种类在 resource_type；product 目前无对应 WorkspaceFocusTarget 路由
+      // （与既有 product 生成任务的通知目标缺口一致），优雅降级为不可点击。
+      switch (task.resource_type) {
+        case "character":
+        case "scene":
+        case "prop":
+          return {
+            type: task.resource_type,
+            id: task.resource_id,
+            route: ASSET_ROUTES[task.resource_type],
+            highlight_style: "flash",
+          };
+        case "storyboard": {
+          const route = resolveEpisodeRoute(projectData, task.script_file);
+          return route
+            ? { type: "segment", id: task.resource_id, route, highlight_style: "flash" }
+            : null;
+        }
+        default:
+          return null;
+      }
     }
     default:
       return null;

--- a/lib/asset_fingerprints.py
+++ b/lib/asset_fingerprints.py
@@ -10,6 +10,7 @@ _MEDIA_SUBDIRS = (
     "characters",
     "scenes",
     "props",
+    "products",
     "grids",
     "reference_videos",
 )

--- a/tests/test_asset_fingerprints.py
+++ b/tests/test_asset_fingerprints.py
@@ -28,6 +28,7 @@ class TestComputeAssetFingerprints:
             ("characters", "Alice.png"),
             ("scenes", "庙宇.png"),
             ("props", "玉佩.png"),
+            ("products", "手镯.png"),
         ]:
             (tmp_path / subdir).mkdir()
             (tmp_path / subdir / name).write_bytes(b"x")
@@ -37,6 +38,7 @@ class TestComputeAssetFingerprints:
         assert "characters/Alice.png" in result
         assert "scenes/庙宇.png" in result
         assert "props/玉佩.png" in result
+        assert "products/手镯.png" in result
 
     def test_includes_root_level_assets(self, tmp_path):
         (tmp_path / "style_reference.png").write_bytes(b"style")


### PR DESCRIPTION
Closes #1159

## 概述

为角色/场景/道具/产品设计图与分镜图卡片新增「编辑」入口：点击弹出指令输入弹窗，提交后入队 `image_edit` 任务，以当前图为底图、指令为 prompt 走 i2i；新图覆盖 current、旧图进版本历史。

## 变更要点

- **五卡片编辑入口**：`ImageEditButton`（图标按钮 + `GlassModal` 指令弹窗）接入 Character/Scene/Prop/Product/MediaCard(storyboard)；分镜仅图片形态（`kind === "storyboard"`）显示。
- **占用互斥**：`taskResourceKind(task)` 将 `image_edit` 任务按 `resource_type` 归入目标资源槽，`selectLatestTaskByResource` 改用该函数过滤——编辑任务与同资源的生成任务落入同一占用集。编辑进行中卡片编辑/重生成/上传全部禁用；其他生成进行中时编辑按钮同样禁用。
- **版本编辑标记**：`VersionTimeMachine` 对 `source === "image_edit"` 版本显示「编辑」badge，指令经既有 `selectedInfo.prompt` 区渲染，回滚复用既有 restore。
- **错误透传**：i2i 不可用时服务端 fail-fast 错误经 `API.editImage` 非 2xx throw → catch → toast。
- **类型契约**：`TaskItem.resource_type: string | null`（required-nullable，沿用 `script_file` 约定）；后端 `_task_to_dict` 无条件序列化该列，前端 `?? ""` 兜底，存量任务行无崩溃风险。
- **i18n**：新增 9 个文案 key，zh/en/vi 三语齐全。

## 验证

- `pnpm lint` 绿
- `pnpm check`（typecheck + vitest）绿：**947/947** 通过
- 占用匹配纯函数（`taskResourceKind` / `selectActiveResourceIds`）单测覆盖
- `API.editImage` 请求形状单测覆盖（本地审查补齐：非分镜 `script_file=null`、分镜透传 + 项目名编码）
- 已 rebase 至最新 `main`（新增提交均为后端，与前端零文件交集）

## 审查说明

本地审查（/code-review high）无 correctness 发现。审查阶段补齐了 `API.editImage` 请求形状测试以满足验收标准「API client 请求形状有测试」。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增图片指令式编辑入口，覆盖角色、场景、道具、产品与分镜；分镜可关联脚本文件，并提交后触发任务。
- **体验优化**
  - 上传/生成/编辑进行中自动禁用相关入口，包含分镜与宫格场景的并发遮蔽。
  - 引入乐观占用与更精确的占用判定，失败后可跳转到对应资源并展示错误提示。
- **测试**
  - 扩展接口、任务资源归类、乐观占用与失败跳转等用例，并补齐任务夹具字段。
- **文案**
  - 补充图片编辑多语言文案及“版本图片编辑”徽标、错误提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->