### PR TITLE
refactor(server): 参考视频与 resume 任务的 provider 解析收口到 GenerationContext

### DIFF
--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -29,10 +29,10 @@ from lib.script_editor import ScriptEditError
 from lib.script_models import ReferenceResource, ad_script_total_duration
 from lib.thumbnail import extract_video_thumbnail
 from lib.version_manager import VersionManager
+from server.services.generation_context import VideoLaneRequest, resolve_generation_context
 from server.services.generation_tasks import (
     assert_duration_supported,
     collect_product_references_for_names,
-    get_media_generator,
     get_project_manager,
 )
 
@@ -102,8 +102,8 @@ def _apply_provider_constraints(
 ) -> tuple[list[Path], int, list[dict]]:
     """按供应商上限裁剪 references / duration；回传 warnings（i18n key + 参数）。
 
-    `max_refs` / `max_duration` 由调用方从 `ConfigResolver.video_capabilities_for_project`
-    取得（model 粒度，单一真相源）；任意一项为 None 表示不做对应裁剪。
+    `max_refs` / `max_duration` 由调用方从 GenerationContext 的 video lane 取得（model 粒度，
+    单一真相源）；任意一项为 None 表示不做对应裁剪。
     """
     warnings: list[dict] = []
 
@@ -307,44 +307,26 @@ async def execute_reference_video_task(
     else:
         source_refs = _resolve_unit_references(project, project_path, unit.get("references") or [])
 
-    # 3. 构造 generator（拿到 video_backend 名字后才能做 provider 特判）
-    generator = await get_media_generator(project_name, payload=payload, user_id=user_id)
-    backend = getattr(generator, "_video_backend", None)
-    provider_name = getattr(backend, "name", "") if backend else ""
-    model_name = getattr(backend, "model", "") if backend else ""
+    # 3. 单次解析生成上下文（声明 video lane）：构造 generator 并按实际 backend 身份
+    #    查能力上限与 resolution。provider 身份解析收口于 GenerationContext
+    #    （docs/adr/0049）——executor 不再触碰 MediaGenerator 私有属性、不再手工重建
+    #    registry provider_id。
+    ctx = await resolve_generation_context(
+        project_name, payload, project=project, user_id=user_id, video=VideoLaneRequest()
+    )
+    generator = ctx.generator
+    video = ctx.video
+    provider_name = video.backend_name
+    model_name = video.backend_model
 
-    # 4. 解析 model 粒度能力上限（单一真相源：model.supported_durations）。
-    #    失败时 fallback 到 None（不裁剪，交由 backend 自行报错），与
-    #    ScriptGenerator._fetch_video_capabilities 的口径保持一致。
-    #
-    #    注意：caps 基于 `project.json.video_backend` 解析；但自定义 provider 的 model
-    #    被禁用时，`lib.custom_provider.loader.load_custom_backend` 会静默回退到默认启用
-    #    model。为避免"按旧模型 clamp、按新模型生成"
-    #    的错位，下面校验 caps.model 与 backend.model 是否一致；不一致就 skip clamp，
-    #    把决策推给 backend 自报错。根治需要 `VideoCapabilities` 协议暴露 `max_duration`，
-    #    本 PR 范围内先缓解。
-    max_refs: int | None = None
-    max_duration: int | None = None
-    supported_durations: list[int] = []
-    resolver = ConfigResolver(async_session_factory)
-    try:
-        caps = await resolver.video_capabilities_for_project(project)
-        caps_model = caps.get("model")
-        if model_name and caps_model and caps_model != model_name:
-            logger.warning(
-                "project.json video_backend model (%s) 与实际 backend model (%s) 不一致，"
-                "跳过 executor clamp 以避免按错误模型裁剪（常见于自定义模型禁用回退）。",
-                caps_model,
-                model_name,
-            )
-        else:
-            max_refs = caps.get("max_reference_images")
-            max_duration = caps.get("max_duration")
-            # caps 与实际 backend model 一致时才取 supported_durations 做 duration 能力守卫；
-            # 不一致（caps 不可信）时留空，守卫遇空集放行，把决策推给 backend（与 clamp 同口径）。
-            supported_durations = [int(d) for d in caps.get("supported_durations") or []]
-    except (ValueError, SQLAlchemyError) as exc:
-        logger.info("无法解析 video_capabilities，跳过 executor clamp：%s", exc)
+    # 4. model 粒度能力上限（单一真相源：model.supported_durations）。能力按实际 backend
+    #    身份（provider_id + backend.model）查得：自定义模型禁用回退时也直接命中活跃 model
+    #    的能力，不再出现"按旧模型裁剪、按新模型生成"的错位，原 caps.model 一致性防御分支
+    #    随之消解。查询失败时 lane 已把能力降级为空值/None——守卫遇空集放行、clamp 不施加
+    #    上限，把决策推给 backend，与 ScriptGenerator._fetch_video_capabilities 的口径一致。
+    max_refs = video.max_reference_images
+    max_duration = video.max_duration
+    supported_durations = list(video.supported_durations)
 
     # 5. Provider 特判：裁 refs + duration。ad 的参考裁剪走专用口径（产品 sheet
     #    跨产品稳定前置存活），时长裁剪与通用路径共用。
@@ -377,16 +359,9 @@ async def execute_reference_video_task(
     # 它不修正、会漏给 backend 报 400；这里与普通视频路径对称地本地拦下（VideoCapabilityError）。
     assert_duration_supported(effective_duration, supported_durations)
 
-    # resolver key 必须是 registry provider_id（project.video_backend 的 "/" 前半段），
-    # 而非 backend.name（如 "gemini"）——与 generation_tasks.execute_video_task 保持一致。
-    from lib.config.resolver import get_provider_fallback
-
-    video_backend_raw = project.get("video_backend") or ""
-    registry_provider_id = video_backend_raw.split("/", 1)[0] if "/" in video_backend_raw else provider_name
-
-    resolution = await resolver.resolve_resolution(project, registry_provider_id or provider_name, model_name or "")
-    if resolution is None:
-        resolution = get_provider_fallback(provider_name)
+    # 参考视频是唯一需要非空 resolution 档位的调用方：lane 已按 registry provider_id
+    # 兜底（resolution 命中空档位时取 provider fallback），executor 直接取非空档位。
+    resolution = video.resolution_or_fallback
 
     # 6. 渲染 prompt。ad：镜头文本 + 裁剪后参考的 [图N] 对照表 + 保真/反向尾词。
     #    narration/drama：@→[图N] 替换——必须按 `constrained_refs` 的长度裁

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -11,14 +11,13 @@ import asyncio
 import logging
 from typing import Any
 
-from lib.media_generator import MediaGenerator
 from lib.project_change_hints import project_change_source
+from server.services.generation_context import VideoLaneRequest, resolve_generation_context
 from server.services.generation_tasks import (
     DEFAULT_USER_ID,
     _finalize_video_task,
     emit_generation_success_batch,
     get_aspect_ratio,
-    get_media_generator,
     get_project_manager,
 )
 from server.services.reference_video_tasks import _finalize_reference_video_unit
@@ -53,14 +52,17 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
         )
     )
 
-    # require_image_backend=False：resume 路径用不到 image backend；若 image 配置在
-    # submit→重启之间被破坏，整段 resume 不该被无关检查弄失败（provider job 仍在跑）。
-    generator: MediaGenerator = await get_media_generator(
+    # 仅声明 video lane：resume 路径用不到 image backend，不声明 image lane 即不构造它——
+    # 若 image 配置在 submit→重启之间被破坏，整段 resume 不该被无关检查弄失败（provider
+    # job 仍在跑）。provider/backend 身份解析收口于 GenerationContext（docs/adr/0049）。
+    ctx = await resolve_generation_context(
         project_name,
-        payload=payload,
+        payload,
+        project=project,
         user_id=user_id,
-        require_image_backend=False,
+        video=VideoLaneRequest(),
     )
+    generator = ctx.generator
 
     aspect_ratio = get_aspect_ratio(project, "videos") if task_type == "video" else project.get("aspect_ratio", "9:16")
     # 浮点数字符串（如 "8.0"）直接 int() 会抛 ValueError；先 float 再 int 兜底脏数据

--- a/tests/integration/test_reference_video_e2e.py
+++ b/tests/integration/test_reference_video_e2e.py
@@ -158,17 +158,29 @@ async def test_e2e_three_bucket_mentions_with_multi_shot(three_bucket_client):
     fake_generator = MagicMock()
     fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
     fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-20T12:00:00"}]}
-    fake_video_backend = MagicMock()
-    fake_video_backend.name = "ark"
-    fake_video_backend.model = "doubao-seedance-2-0-260128"
-    fake_generator._video_backend = fake_video_backend
 
-    async def _fake_get_media_generator(*_a, **_k):
-        return fake_generator
-
+    from lib.config.resolver import ProviderModel
     from server.services import reference_video_tasks as rvt_mod
+    from server.services.generation_context import GenerationContext, VideoLaneResult
 
-    monkeypatch.setattr(rvt_mod, "get_media_generator", _fake_get_media_generator)
+    ctx = GenerationContext(
+        generator=fake_generator,
+        video_lane=VideoLaneResult(
+            provider_model=ProviderModel(provider_id="ark", model_id="doubao-seedance-2-0-260128"),
+            backend_name="ark",
+            backend_model="doubao-seedance-2-0-260128",
+            resolution=None,
+            resolution_or_fallback="1080p",
+            supported_durations=(),
+            max_duration=None,
+            max_reference_images=None,
+        ),
+    )
+
+    async def _fake_resolve(*_a, **_k):
+        return ctx
+
+    monkeypatch.setattr(rvt_mod, "resolve_generation_context", _fake_resolve)
 
     async def _fake_extract(*_a, **_k):
         return True

--- a/tests/server/test_ad_reference_video_tasks.py
+++ b/tests/server/test_ad_reference_video_tasks.py
@@ -99,8 +99,20 @@ def _write_ad_project(tmp_path: Path) -> Path:
     return proj_dir
 
 
-def _wire_executor(proj_dir: Path, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
-    """挂上 fake pm + fake generator，locked_script 写回磁盘以便断言 finalize 结果。"""
+def _wire_executor(
+    proj_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    max_refs: int | None = None,
+    max_duration: int | None = None,
+    supported_durations: tuple[int, ...] = (),
+) -> MagicMock:
+    """挂上 fake pm + fake generator，locked_script 写回磁盘以便断言 finalize 结果。
+
+    generator 与 video lane 值（backend 身份、能力上限、resolution）统一包成
+    GenerationContext，替换 `resolve_generation_context` 单点——executor 不再触碰
+    MediaGenerator 私有属性、不再自行解析 caps。
+    """
     from server.services import reference_video_tasks as rvt
 
     fake_pm = MagicMock()
@@ -137,15 +149,26 @@ def _wire_executor(proj_dir: Path, monkeypatch: pytest.MonkeyPatch) -> MagicMock
     fake_generator = MagicMock()
     fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
     fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-06-12T10:00:00"}]}
-    fake_backend = MagicMock()
-    fake_backend.name = "ark"
-    fake_backend.model = "seedance"
-    fake_generator._video_backend = fake_backend
 
-    async def _fake_get_media_generator(*_a, **_kw):
-        return fake_generator
+    from lib.config.resolver import ProviderModel
+    from server.services.generation_context import GenerationContext, VideoLaneResult
 
-    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+    lane = VideoLaneResult(
+        provider_model=ProviderModel(provider_id="ark", model_id="seedance"),
+        backend_name="ark",
+        backend_model="seedance",
+        resolution=None,
+        resolution_or_fallback="1080p",
+        supported_durations=supported_durations,
+        max_duration=max_duration,
+        max_reference_images=max_refs,
+    )
+    ctx = GenerationContext(generator=fake_generator, video_lane=lane)
+
+    async def _fake_resolve(*_a, **_kw):
+        return ctx
+
+    monkeypatch.setattr(rvt, "resolve_generation_context", _fake_resolve)
 
     async def _fake_extract(*_a, **_k):
         return True
@@ -262,17 +285,7 @@ async def test_ad_reference_clamp_keeps_product_sheets_alive(tmp_path: Path, mon
     ]
     (proj_dir / "scripts" / "episode_1.json").write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    fake_generator = _wire_executor(proj_dir, monkeypatch)
-
-    from server.services import reference_video_tasks as rvt_mod
-
-    async def _fake_caps(_project):
-        return {"model": "seedance", "max_reference_images": 3, "max_duration": None, "supported_durations": []}
-
-    fake_resolver = MagicMock()
-    fake_resolver.video_capabilities_for_project = AsyncMock(side_effect=_fake_caps)
-    fake_resolver.resolve_resolution = AsyncMock(return_value=None)
-    monkeypatch.setattr(rvt_mod, "ConfigResolver", lambda *_a, **_kw: fake_resolver)
+    fake_generator = _wire_executor(proj_dir, monkeypatch, max_refs=3)
 
     result = await rvt.execute_reference_video_task(
         "ad-demo",

--- a/tests/server/test_reference_video_e2e_backend.py
+++ b/tests/server/test_reference_video_e2e_backend.py
@@ -124,8 +124,10 @@ async def test_end_to_end_generate_unit_to_executor(
     assert captured_payload["task_type"] == "reference_video"
     assert captured_payload["resource_id"] == uid
 
-    # 3) Mock get_media_generator → 直接执行 executor
+    # 3) Mock resolve_generation_context → 直接执行 executor
+    from lib.config.resolver import ProviderModel
     from server.services import reference_video_tasks as rvt_mod
+    from server.services.generation_context import GenerationContext, VideoLaneResult
 
     async def _fake_generate_video_async(**kwargs):
         out = proj_dir / "reference_videos" / f"{uid}.mp4"
@@ -136,15 +138,25 @@ async def test_end_to_end_generate_unit_to_executor(
     fake_generator = MagicMock()
     fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
     fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-17T12:00:00"}]}
-    fake_video_backend = MagicMock()
-    fake_video_backend.name = "ark"
-    fake_video_backend.model = "doubao-seedance-2-0-260128"
-    fake_generator._video_backend = fake_video_backend
 
-    async def _fake_get_media_generator(*_a, **_k):
-        return fake_generator
+    ctx = GenerationContext(
+        generator=fake_generator,
+        video_lane=VideoLaneResult(
+            provider_model=ProviderModel(provider_id="ark", model_id="doubao-seedance-2-0-260128"),
+            backend_name="ark",
+            backend_model="doubao-seedance-2-0-260128",
+            resolution=None,
+            resolution_or_fallback="1080p",
+            supported_durations=(),
+            max_duration=None,
+            max_reference_images=None,
+        ),
+    )
 
-    monkeypatch.setattr(rvt_mod, "get_media_generator", _fake_get_media_generator)
+    async def _fake_resolve(*_a, **_k):
+        return ctx
+
+    monkeypatch.setattr(rvt_mod, "resolve_generation_context", _fake_resolve)
 
     async def _fake_extract(*_a, **_k):
         return True

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -82,6 +82,47 @@ def _write_project(tmp_path: Path) -> Path:
     return proj_dir
 
 
+def _wire_context(
+    monkeypatch: pytest.MonkeyPatch,
+    rvt,
+    fake_generator,
+    *,
+    backend_name: str,
+    backend_model: str,
+    resolution_or_fallback: str = "1080p",
+    resolution: str | None = None,
+    max_refs: int | None = None,
+    max_duration: int | None = None,
+    supported_durations: tuple[int, ...] = (),
+) -> None:
+    """把 fake generator + video lane 值包成 GenerationContext，替换 resolve_generation_context 单点。
+
+    executor 迁移后不再触碰 MediaGenerator 私有属性、不再手工重建 provider 身份——所有
+    provider/backend 身份、能力上限、resolution 均由 GenerationContext 的 video lane 提供。
+    能力上限与 resolution 的解析逻辑本身在 tests/server/test_generation_context.py 覆盖，此处
+    只需喂入 lane 值验证 executor 的下游 clamp / 守卫 / 透传行为。
+    """
+    from lib.config.resolver import ProviderModel
+    from server.services.generation_context import GenerationContext, VideoLaneResult
+
+    lane = VideoLaneResult(
+        provider_model=ProviderModel(provider_id=backend_name, model_id=backend_model),
+        backend_name=backend_name,
+        backend_model=backend_model,
+        resolution=resolution,
+        resolution_or_fallback=resolution_or_fallback,
+        supported_durations=supported_durations,
+        max_duration=max_duration,
+        max_reference_images=max_refs,
+    )
+    ctx = GenerationContext(generator=fake_generator, video_lane=lane)
+
+    async def _fake_resolve(*_args, **_kwargs):
+        return ctx
+
+    monkeypatch.setattr(rvt, "resolve_generation_context", _fake_resolve)
+
+
 def _wire_locked_script(fake_pm: MagicMock) -> None:
     """让 fake_pm.locked_script 产出磁盘上的真实剧本 dict。
 
@@ -159,7 +200,7 @@ def test_render_unit_prompt_replaces_mentions_in_order():
 
 
 def test_apply_provider_constraints_veo_clamps_duration_and_refs():
-    # caps 由调用方从 ConfigResolver.video_capabilities_for_project 取得；
+    # caps 由调用方从 GenerationContext 的 video lane 取得；
     # 这里直接提供 model 级上限模拟已 resolve 的结果。
     refs = [Path(f"/tmp/ref{i}.png") for i in range(5)]
     new_refs, new_duration, warnings = _apply_provider_constraints(
@@ -270,15 +311,7 @@ async def test_execute_reference_video_task_success(tmp_path: Path, monkeypatch:
     fake_generator = MagicMock()
     fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
     fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-17T10:00:00"}]}
-    fake_video_backend = MagicMock()
-    fake_video_backend.name = "ark"
-    fake_video_backend.model = "doubao-seedance-2-0-260128"
-    fake_generator._video_backend = fake_video_backend
-
-    async def _fake_get_media_generator(*_args, **_kwargs):
-        return fake_generator
-
-    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+    _wire_context(monkeypatch, rvt, fake_generator, backend_name="ark", backend_model="doubao-seedance-2-0-260128")
 
     # Patch thumbnail extractor → success
     async def _fake_extract(*_a, **_k):
@@ -340,15 +373,7 @@ async def test_execute_reference_video_task_clears_stale_video_uri_and_thumbnail
     fake_generator = MagicMock()
     fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
     fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-17T10:00:00"}]}
-    fake_video_backend = MagicMock()
-    fake_video_backend.name = "ark"
-    fake_video_backend.model = "doubao-seedance-2-0-260128"
-    fake_generator._video_backend = fake_video_backend
-
-    async def _fake_get_media_generator(*_a, **_kw):
-        return fake_generator
-
-    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+    _wire_context(monkeypatch, rvt, fake_generator, backend_name="ark", backend_model="doubao-seedance-2-0-260128")
 
     # 缩略图提取失败 → thumb_rel=None
     async def _fake_extract(*_a, **_k):
@@ -378,7 +403,9 @@ async def test_execute_reference_video_task_grok_uses_provider_default_resolutio
 ):
     """Regression: Grok 视频生成必须用 720p（xai_sdk 的 VideoResolutionMap 只接受 480p/720p；
     参考视频 executor 若回退到 MediaGenerator 默认 1080p，会在 SDK 抛 `Invalid video resolution 1080p`）。
-    Executor 必须与生产分镜视频流一致，按 `DEFAULT_VIDEO_RESOLUTION[grok]=720p` 解析。
+    executor 必须把 video lane 的 `resolution_or_fallback` 原样传给 generate_video_async——
+    档位的解析/兜底逻辑（provider fallback、model_settings 优先级）在
+    tests/server/test_generation_context.py 覆盖。
     """
     proj_dir = _write_project(tmp_path)
 
@@ -405,15 +432,14 @@ async def test_execute_reference_video_task_grok_uses_provider_default_resolutio
     fake_generator = MagicMock()
     fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
     fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-21T22:00:00"}]}
-    fake_video_backend = MagicMock()
-    fake_video_backend.name = "grok"
-    fake_video_backend.model = "grok-imagine-video"
-    fake_generator._video_backend = fake_video_backend
-
-    async def _fake_get_media_generator(*_a, **_kw):
-        return fake_generator
-
-    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+    _wire_context(
+        monkeypatch,
+        rvt,
+        fake_generator,
+        backend_name="grok",
+        backend_model="grok-imagine-video",
+        resolution_or_fallback="720p",
+    )
 
     async def _fake_extract(*_a, **_k):
         return True
@@ -431,67 +457,6 @@ async def test_execute_reference_video_task_grok_uses_provider_default_resolutio
         f"Grok executor 必须显式传 720p，否则 MediaGenerator 默认 1080p 会被 xai_sdk 拒绝。"
         f"实际收到: {captured.get('resolution')!r}"
     )
-
-
-@pytest.mark.asyncio
-async def test_execute_reference_video_task_respects_project_model_settings_resolution(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """project.video_model_settings[model].resolution 必须覆盖 provider 默认值，
-    与 generation_tasks.py 的分镜视频流保持一致的优先级。"""
-    proj_dir = _write_project(tmp_path)
-    project_path = proj_dir / "project.json"
-    project = json.loads(project_path.read_text(encoding="utf-8"))
-    project["video_model_settings"] = {"doubao-seedance-2-0-260128": {"resolution": "1080p"}}
-    project_path.write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
-
-    from server.services import reference_video_tasks as rvt
-
-    fake_pm = MagicMock()
-    fake_pm.load_project.return_value = json.loads(project_path.read_text(encoding="utf-8"))
-    fake_pm.get_project_path.return_value = proj_dir
-    fake_pm.load_script.side_effect = lambda *_a: json.loads(
-        (proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8")
-    )
-    _wire_locked_script(fake_pm)
-    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
-
-    captured: dict = {}
-
-    async def _fake_generate_video_async(**kwargs):
-        captured.update(kwargs)
-        out = proj_dir / "reference_videos" / "E1U1.mp4"
-        out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_bytes(b"\x00\x00\x00 ftypmp42")
-        return out, 1, None, None
-
-    fake_generator = MagicMock()
-    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
-    fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-21T22:00:00"}]}
-    fake_video_backend = MagicMock()
-    fake_video_backend.name = "ark"
-    fake_video_backend.model = "doubao-seedance-2-0-260128"
-    fake_generator._video_backend = fake_video_backend
-
-    async def _fake_get_media_generator(*_a, **_kw):
-        return fake_generator
-
-    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
-
-    async def _fake_extract(*_a, **_k):
-        return True
-
-    monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
-
-    await rvt.execute_reference_video_task(
-        "demo",
-        "E1U1",
-        {"script_file": "scripts/episode_1.json"},
-        user_id="u1",
-    )
-
-    assert captured.get("resolution") == "1080p"
 
 
 @pytest.mark.asyncio
@@ -604,10 +569,7 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
     real_gen.versions = VersionManager(proj_dir)
     real_gen.usage_tracker = _FakeUsage()
 
-    async def _fake_get_media_generator(*_a, **_kw):
-        return real_gen
-
-    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+    _wire_context(monkeypatch, rvt, real_gen, backend_name="ark", backend_model="doubao-seedance-2-0-260128")
 
     async def _fake_extract(*_a, **_k):
         return True
@@ -667,15 +629,7 @@ async def test_execute_reference_video_task_passes_source_refs(tmp_path: Path, m
     fake_generator = MagicMock()
     fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
     fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-17T10:00:00"}]}
-    fake_video_backend = MagicMock()
-    fake_video_backend.name = "grok"
-    fake_video_backend.model = "grok-imagine-video"
-    fake_generator._video_backend = fake_video_backend
-
-    async def _fake_get_media_generator(*_a, **_kw):
-        return fake_generator
-
-    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+    _wire_context(monkeypatch, rvt, fake_generator, backend_name="grok", backend_model="grok-imagine-video")
 
     async def _fake_extract(*_a, **_k):
         return True
@@ -701,16 +655,16 @@ async def test_execute_reference_video_task_passes_source_refs(tmp_path: Path, m
 
 
 @pytest.mark.asyncio
-async def test_execute_reference_video_task_clamps_via_resolver(
+async def test_execute_reference_video_task_clamps_via_lane_caps(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """回归守门：executor 的 duration/refs clamp 必须走 ConfigResolver 的 model 粒度 caps，
+    """回归守门：executor 的 duration/refs clamp 必须走 video lane 的 model 粒度 caps，
     不再走老的 PROVIDER_MAX_DURATION provider 级常量。
 
-    Monkeypatch `ConfigResolver.video_capabilities_for_project` 返自定义 caps
-    (max_duration=6, max_reference_images=1)，传入 duration_seconds=15 / 2 张 refs，
-    期望 generate_video_async 实际收到 duration=6 且 reference_images 只有 1 张。
+    lane 喂入自定义 caps (max_duration=6, max_reference_images=1)，传入
+    duration_seconds=15 / 2 张 refs，期望 generate_video_async 实际收到
+    duration=6 且 reference_images 只有 1 张。
     """
     proj_dir = _write_project(tmp_path)
 
@@ -742,39 +696,22 @@ async def test_execute_reference_video_task_clamps_via_resolver(
     fake_generator = MagicMock()
     fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
     fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-17T10:00:00"}]}
-    fake_video_backend = MagicMock()
-    fake_video_backend.name = "custom-openai"
-    fake_video_backend.model = "my-custom-video"
-    fake_generator._video_backend = fake_video_backend
-
-    async def _fake_get_media_generator(*_a, **_kw):
-        return fake_generator
-
-    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+    # lane 喂入假 caps —— 模拟 "supported_durations=[2,4,6]", max_reference_images=1 的 custom model
+    _wire_context(
+        monkeypatch,
+        rvt,
+        fake_generator,
+        backend_name="custom-openai",
+        backend_model="my-custom-video",
+        max_refs=1,
+        max_duration=6,
+        supported_durations=(2, 4, 6),
+    )
 
     async def _fake_extract(*_a, **_k):
         return True
 
     monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
-
-    # 注入假 caps —— 模拟 "supported_durations=[2,4,6]", max_reference_images=1
-    # 的 custom model。用 AsyncMock 直接替换实例方法。
-    from lib.config.resolver import ConfigResolver
-
-    async def _fake_caps(self, project):
-        return {
-            "provider_id": "custom-openai",
-            "model": "my-custom-video",
-            "supported_durations": [2, 4, 6],
-            "max_duration": 6,
-            "max_reference_images": 1,
-            "source": "custom",
-            "default_duration": None,
-            "content_mode": "narration",
-            "generation_mode": "reference_video",
-        }
-
-    monkeypatch.setattr(ConfigResolver, "video_capabilities_for_project", _fake_caps)
 
     await rvt.execute_reference_video_task(
         "demo",
@@ -844,38 +781,22 @@ async def test_execute_reference_video_task_prompt_matches_clipped_refs(
     fake_generator = MagicMock()
     fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
     fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-17T10:00:00"}]}
-    fake_video_backend = MagicMock()
-    fake_video_backend.name = "openai"
-    fake_video_backend.model = "sora-2"
-    fake_generator._video_backend = fake_video_backend
-
-    async def _fake_get_media_generator(*_a, **_kw):
-        return fake_generator
-
-    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
+    # Sora 上限 1 张（provider_id=openai, model=sora-2）
+    _wire_context(
+        monkeypatch,
+        rvt,
+        fake_generator,
+        backend_name="openai",
+        backend_model="sora-2",
+        max_refs=1,
+        max_duration=12,
+        supported_durations=(4, 8, 12),
+    )
 
     async def _fake_extract(*_a, **_k):
         return True
 
     monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
-
-    # Sora 上限 1 张（provider_id=openai, model=sora-2）
-    from lib.config.resolver import ConfigResolver
-
-    async def _fake_caps(self, project):
-        return {
-            "provider_id": "openai",
-            "model": "sora-2",
-            "supported_durations": [4, 8, 12],
-            "max_duration": 12,
-            "max_reference_images": 1,
-            "source": "registry",
-            "default_duration": None,
-            "content_mode": "narration",
-            "generation_mode": "reference_video",
-        }
-
-    monkeypatch.setattr(ConfigResolver, "video_capabilities_for_project", _fake_caps)
 
     await rvt.execute_reference_video_task(
         "demo",
@@ -892,168 +813,6 @@ async def test_execute_reference_video_task_prompt_matches_clipped_refs(
     assert "[图3]" not in prompt
     # 被裁掉的 @酒馆 / @瓶子 按 render_prompt_for_backend 的 "未注册保留原样" fallback 保留
     assert "@酒馆" in prompt or "@瓶子" in prompt
-
-
-@pytest.mark.asyncio
-async def test_gemini_model_settings_read_via_composite_key(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """C1 回归：当 project.video_backend = "gemini-aistudio/veo-3.1-generate-preview" 且
-    project.model_settings["gemini-aistudio/veo-3.1-generate-preview"].resolution = "720p" 时，
-    executor 必须用 "gemini-aistudio" 作为 resolver 的 provider_id（而非 backend.name="gemini"），
-    才能命中正确 composite key，实际传出 resolution="720p"。
-    """
-    proj_dir = _write_project(tmp_path)
-
-    # 在 project.json 写入 video_backend 和 model_settings（composite key 格式）
-    project_path = proj_dir / "project.json"
-    project = json.loads(project_path.read_text(encoding="utf-8"))
-    project["video_backend"] = "gemini-aistudio/veo-3.1-generate-preview"
-    project["model_settings"] = {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}}
-    project_path.write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
-
-    # video_backend 显式指向 veo（caps 命中 → duration 守卫生效）：unit 时长取 veo 支持成员，
-    # 避免触发能力守卫（本测试聚焦 resolution composite key）。
-    script_path = proj_dir / "scripts" / "episode_1.json"
-    script = json.loads(script_path.read_text(encoding="utf-8"))
-    script["video_units"][0]["duration_seconds"] = 8
-    script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
-
-    from server.services import reference_video_tasks as rvt
-
-    fake_pm = MagicMock()
-    fake_pm.load_project.return_value = json.loads(project_path.read_text(encoding="utf-8"))
-    fake_pm.get_project_path.return_value = proj_dir
-    fake_pm.load_script.side_effect = lambda *_a: json.loads(
-        (proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8")
-    )
-    _wire_locked_script(fake_pm)
-    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
-
-    captured: dict = {}
-
-    async def _fake_generate_video_async(**kwargs):
-        captured.update(kwargs)
-        out = proj_dir / "reference_videos" / "E1U1.mp4"
-        out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_bytes(b"\x00\x00\x00 ftypmp42")
-        return out, 1, None, None
-
-    fake_generator = MagicMock()
-    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
-    fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-23T10:00:00"}]}
-    fake_video_backend = MagicMock()
-    # backend.name 是短名 "gemini"，与 registry provider_id "gemini-aistudio" 不同
-    fake_video_backend.name = "gemini"
-    fake_video_backend.model = "veo-3.1-generate-preview"
-    fake_generator._video_backend = fake_video_backend
-
-    async def _fake_get_media_generator(*_a, **_kw):
-        return fake_generator
-
-    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
-
-    async def _fake_extract(*_a, **_k):
-        return True
-
-    monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
-
-    await rvt.execute_reference_video_task(
-        "demo",
-        "E1U1",
-        {"script_file": "scripts/episode_1.json"},
-        user_id="u1",
-    )
-
-    assert captured.get("resolution") == "720p", (
-        f"C1: executor 必须用 registry provider_id 'gemini-aistudio' 作为 resolver key，"
-        f"而非 backend.name 'gemini'，才能命中 model_settings composite key。"
-        f"实际收到: {captured.get('resolution')!r}"
-    )
-
-
-@pytest.mark.asyncio
-async def test_execute_reference_video_task_skips_clamp_when_backend_model_diverges(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """回归守门：caps 解析出的 model 与真实 backend.model 不一致时（自定义 provider
-    model 禁用回退的典型场景）必须 skip clamp，避免按错误模型的上限裁剪。
-    """
-    proj_dir = _write_project(tmp_path)
-
-    script_path = proj_dir / "scripts" / "episode_1.json"
-    script = json.loads(script_path.read_text(encoding="utf-8"))
-    script["video_units"][0]["duration_seconds"] = 20
-    script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
-
-    from server.services import reference_video_tasks as rvt
-
-    fake_pm = MagicMock()
-    fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
-    fake_pm.get_project_path.return_value = proj_dir
-    fake_pm.load_script.side_effect = lambda *_a: json.loads(script_path.read_text(encoding="utf-8"))
-    _wire_locked_script(fake_pm)
-    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
-
-    captured: dict = {}
-
-    async def _fake_generate_video_async(**kwargs):
-        captured.update(kwargs)
-        out = proj_dir / "reference_videos" / "E1U1.mp4"
-        out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_bytes(b"\x00")
-        return out, 1, None, None
-
-    fake_generator = MagicMock()
-    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
-    fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-17T10:00:00"}]}
-    fake_video_backend = MagicMock()
-    # 模拟 fallback：project.json 记录的是 "禁用模型"，backend 实际回退到 "默认模型"
-    fake_video_backend.name = "custom-openai"
-    fake_video_backend.model = "active-default-video"
-    fake_generator._video_backend = fake_video_backend
-
-    async def _fake_get_media_generator(*_a, **_kw):
-        return fake_generator
-
-    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
-
-    async def _fake_extract(*_a, **_k):
-        return True
-
-    monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
-
-    # caps 解析出来的 model 是 project.json 里那个（已禁用）的：与 backend.model 不一致
-    from lib.config.resolver import ConfigResolver
-
-    async def _fake_caps(self, project):
-        return {
-            "provider_id": "custom-openai",
-            "model": "disabled-old-video",  # ← 与 backend.model 不一致
-            "supported_durations": [2, 4],
-            "max_duration": 4,
-            "max_reference_images": 1,
-            "source": "custom",
-            "default_duration": None,
-            "content_mode": "narration",
-            "generation_mode": "reference_video",
-        }
-
-    monkeypatch.setattr(ConfigResolver, "video_capabilities_for_project", _fake_caps)
-
-    await rvt.execute_reference_video_task(
-        "demo",
-        "E1U1",
-        {"script_file": "scripts/episode_1.json"},
-        user_id="u1",
-    )
-
-    # skip clamp：duration 保持 20（未被 caps.max_duration=4 裁到 4）
-    assert captured["duration_seconds"] == 20
-    # refs 也保留原数（2 张，未被 caps.max_reference_images=1 裁到 1）
-    assert len(captured["reference_images"]) == 2
 
 
 @pytest.mark.asyncio
@@ -1091,32 +850,16 @@ async def test_execute_reference_video_task_rejects_unsupported_duration(
 
     fake_generator = MagicMock()
     fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
-    fake_video_backend = MagicMock()
-    fake_video_backend.name = "openai"
-    fake_video_backend.model = "sora-2"
-    fake_generator._video_backend = fake_video_backend
-
-    async def _fake_get_media_generator(*_a, **_kw):
-        return fake_generator
-
-    monkeypatch.setattr(rvt, "get_media_generator", _fake_get_media_generator)
-
-    from lib.config.resolver import ConfigResolver
-
-    async def _fake_caps(self, project):
-        return {
-            "provider_id": "openai",
-            "model": "sora-2",
-            "supported_durations": [4, 8, 12],
-            "max_duration": 12,
-            "max_reference_images": 9,
-            "source": "registry",
-            "default_duration": None,
-            "content_mode": "narration",
-            "generation_mode": "reference_video",
-        }
-
-    monkeypatch.setattr(ConfigResolver, "video_capabilities_for_project", _fake_caps)
+    _wire_context(
+        monkeypatch,
+        rvt,
+        fake_generator,
+        backend_name="openai",
+        backend_model="sora-2",
+        max_refs=9,
+        max_duration=12,
+        supported_durations=(4, 8, 12),
+    )
 
     with pytest.raises(VideoCapabilityError):
         await rvt.execute_reference_video_task(

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -79,12 +79,23 @@ def video_task() -> dict[str, Any]:
     }
 
 
+def _fake_video_context(fake_generator: _FakeGenerator):
+    """把 fake generator 包成 GenerationContext——resume 只取 ctx.generator，不读 video lane。"""
+    from server.services.generation_context import GenerationContext
+
+    return GenerationContext(generator=fake_generator)  # type: ignore[arg-type]
+
+
 def _patch_resume_executor_deps(monkeypatch, fake_pm: _FakeProjectManager, fake_generator: _FakeGenerator) -> None:
     """同时 patch resume_executor 的 pm/generator 来源——它从 generation_tasks 顶层 re-import。"""
     from server.services import resume_executor
 
     monkeypatch.setattr(resume_executor, "get_project_manager", lambda: fake_pm)
-    monkeypatch.setattr(resume_executor, "get_media_generator", AsyncMock(return_value=fake_generator))
+    monkeypatch.setattr(
+        resume_executor,
+        "resolve_generation_context",
+        AsyncMock(return_value=_fake_video_context(fake_generator)),
+    )
     # finalize helpers 内部也通过 generation_tasks/reference_video_tasks 的 get_project_manager
     monkeypatch.setattr("server.services.generation_tasks.get_project_manager", lambda: fake_pm)
     monkeypatch.setattr("server.services.reference_video_tasks.get_project_manager", lambda: fake_pm)
@@ -165,9 +176,11 @@ async def test_execute_resume_expired_propagates(monkeypatch, fake_pm, video_tas
 
 
 @pytest.mark.asyncio
-async def test_execute_resume_passes_require_image_backend_false(monkeypatch, fake_pm, video_task):
-    """resume_executor 应显式 require_image_backend=False —— image 配置坏不影响接续。"""
+async def test_execute_resume_declares_video_lane_only(monkeypatch, fake_pm, video_task):
+    """resume_executor 只声明 video lane、不声明 image lane —— 不构造 image backend，
+    image 配置坏不影响接续（等价于旧 require_image_backend=False 的意图）。"""
     from server.services import resume_executor
+    from server.services.generation_context import VideoLaneRequest
     from server.services.resume_executor import execute_resume_video_task
 
     fake_gen = _FakeGenerator()
@@ -183,15 +196,18 @@ async def test_execute_resume_passes_require_image_backend_false(monkeypatch, fa
 
     captured: dict[str, Any] = {}
 
-    async def _capturing_get_media_generator(*args: Any, **kwargs: Any) -> Any:
+    async def _capturing_resolve_context(*args: Any, **kwargs: Any) -> Any:
         captured["kwargs"] = kwargs
-        return fake_gen
+        return _fake_video_context(fake_gen)
 
-    monkeypatch.setattr(resume_executor, "get_media_generator", _capturing_get_media_generator)
+    monkeypatch.setattr(resume_executor, "resolve_generation_context", _capturing_resolve_context)
 
     await execute_resume_video_task(video_task, job_id="openai-job-1")
 
-    assert captured["kwargs"].get("require_image_backend") is False
+    # 只声明 video lane（VideoLaneRequest），image/audio lane 未声明 → 不构造对应 backend
+    assert isinstance(captured["kwargs"].get("video"), VideoLaneRequest)
+    assert captured["kwargs"].get("image") is None
+    assert captured["kwargs"].get("audio") is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 变更

`reference_video_tasks` 与 `resume_executor` 的 provider 解析收口到单次 `resolve_generation_context`（声明 video lane），对齐 GenerationContext 收口口径（docs/adr/0049）：

- 不再触碰 `MediaGenerator._video_backend` 私有属性，不再手工 split 项目 `video_backend` 字符串重建 registry provider_id
- 能力上限（`supported_durations` / `max_duration` / `max_reference_images`）与 resolution 按实际 backend 身份（`provider_id` + `backend.model`）查得；自定义模型禁用回退时直接命中活跃 model 的能力，「按旧模型裁剪、按新模型生成」的错位不再可能——原 `caps.model` 一致性防御分支成为死代码，随之删除
- resolution 经 video lane 的 `resolution_or_fallback` 取非空档位（参考视频是唯一需要非空兜底的调用方）
- `resume_executor` 仅声明 video lane（不构造 image backend），等价旧 `require_image_backend=False` 的意图

`resolve_max_unit_duration`（派生分组的纯能力查询）保留 ConfigResolver 直查——不构造 generator、不重建身份，不在本次收口范围。

## 测试

- 对应测试收敛为 `resolve_generation_context` 单点替换（新增 `_wire_context` helper），覆盖 `test_reference_video_tasks` / `test_ad_reference_video_tasks` / `test_reference_video_e2e_backend` / integration e2e / `test_resume_executor` 五个文件的旧接线
- 删除 3 个解析逻辑测试（model_settings resolution / composite key / caps.model 分歧 skip clamp）——其被测逻辑已随收口移入 GenerationContext 并在 `tests/server/test_generation_context.py` 落防；executor 侧仅保留「透传 lane resolution」回归

## 验证

- `ruff check` / `ruff format --check`：全绿
- `basedpyright`：0 error
- `pytest`（受影响 6 个测试文件，含 test_generation_context）：57 passed

Closes #1166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 统一视频生成与续作流程的能力解析，提升不同后端下的执行一致性。
  - 引用视频生成会根据当前配置自动应用引用图片数量、时长及分辨率限制。
  - 优化广告素材裁剪策略，优先保留关键产品图片，并确保提示词与实际引用素材保持对应。
  - 改进分辨率与支持时长校验，减少不符合后端能力的生成请求。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->