### PR TITLE
refactor(generation-tasks): 五类生成任务收口 GenerationContext 单次解析

### DIFF
--- a/server/routers/grids.py
+++ b/server/routers/grids.py
@@ -150,8 +150,8 @@ async def generate_grid(
                 if chunk_layout is None:
                     continue
 
-                # provider/model 由 execute_grid_task 在 _resolve_effective_image_backend
-                # 之后回填，因为只有 task 层能根据 reference_images 判断走 T2I 还是 I2I 槽
+                # provider/model 由 execute_grid_task 在 image lane 解析之后回填，
+                # 因为只有 task 层能根据 reference_images 判断走 T2I 还是 I2I 槽
                 grid = GridGeneration.create(
                     episode=episode,
                     script_file=req.script_file,

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -51,9 +51,13 @@ from lib.storyboard_sequence import (
 from lib.thumbnail import extract_video_thumbnail
 from lib.video_backends.base import VideoCapabilityError
 from server.services.generation_context import (
+    AudioLaneRequest,
+    ImageLaneRequest,
+    VideoLaneRequest,
     _get_or_create_audio_backend,
     _get_or_create_image_backend,
     _get_or_create_video_backend,
+    resolve_generation_context,
 )
 
 rate_limiter = get_shared_rate_limiter()
@@ -810,16 +814,16 @@ async def execute_storyboard_task(
     project, project_path, prompt_text, reference_images = await asyncio.to_thread(_prepare)
     _needs_i2i = bool(reference_images)
 
-    generator = await get_media_generator(
+    ctx = await resolve_generation_context(
         project_name,
-        payload=payload,
+        payload,
+        project=project,
         user_id=user_id,
-        needs_i2i=_needs_i2i,
+        image=ImageLaneRequest(capability="i2i" if _needs_i2i else "t2i"),
     )
+    generator = ctx.generator
     aspect_ratio = get_aspect_ratio(project, "storyboards")
-
-    resolved_image = await _resolve_effective_image_backend(project, payload, needs_i2i=_needs_i2i)
-    image_size = await _resolve_resolution(project, resolved_image.provider_id, resolved_image.model_id)
+    image_size = ctx.image.resolution
 
     _, version = await generator.generate_image_async(
         prompt=prompt_text,
@@ -885,20 +889,16 @@ async def execute_tts_task(
 
     project, text = await asyncio.to_thread(_prepare)
 
-    generator = await get_media_generator(
+    ctx = await resolve_generation_context(
         project_name,
-        payload=payload,
+        payload,
+        project=project,
         user_id=user_id,
-        require_image_backend=False,
-        needs_audio=True,
+        audio=AudioLaneRequest(),
     )
-
-    from lib.config.resolver import ConfigResolver
-    from lib.db import async_session_factory
-
-    resolver = ConfigResolver(async_session_factory)
-    voice = await resolver.resolve_narration_voice(project)
-    speed = await resolver.resolve_narration_speed(project)
+    generator = ctx.generator
+    voice = ctx.audio.narration_voice
+    speed = ctx.audio.narration_speed
 
     _, version = await generator.generate_audio_async(
         text=text,
@@ -958,7 +958,14 @@ async def execute_video_task(
         return _project, _project_path, _item
 
     project, project_path, item = await asyncio.to_thread(_load)
-    generator = await get_media_generator(project_name, payload=payload, user_id=user_id)
+    ctx = await resolve_generation_context(
+        project_name,
+        payload,
+        project=project,
+        user_id=user_id,
+        video=VideoLaneRequest(),
+    )
+    generator = ctx.generator
 
     # 优先读取 generated_assets.storyboard_image，回退默认路径。
     # 旧宫格项目 storyboard_image 指向 scene_{id}_first.png，仍可正常解析。
@@ -990,36 +997,16 @@ async def execute_video_task(
     if product_reference_images:
         prompt_text = append_product_fidelity_tail(prompt_text, _product_names_in_references(_gated_product_refs))
 
-    # 解析 provider / model（薄投影），供 duration fallback 和分辨率查找共用。
-    # 与执行层 backend 构造同走 resolve_video_backend，确保限流/分辨率与实际调用对齐。
-    from lib.config.resolver import ConfigResolver
-    from lib.db import async_session_factory
-
-    _resolver = ConfigResolver(async_session_factory)
-    try:
-        resolved_video = await _resolver.resolve_video_backend(project, payload)
-        registry_provider_id = resolved_video.provider_id
-        model_name = resolved_video.model_id or None
-    except Exception:
-        registry_provider_id, model_name = "gemini-aistudio", "veo-3.1-lite-generate-preview"
-
-    # supported_durations 按上面已解析出的 provider/model 取（而非按 project 二次解析），
-    # 确保 duration 守卫所依据的能力与实际要调用的 model 一致——历史任务 payload 携带
-    # provider 覆盖时，二者不一致会用「项目默认 model 的能力」误判「payload 解析出的 model」。
-    # caps 失败不得丢弃已解析出的 provider/model，否则 resolution 与默认 duration
-    # 会错配。能力不可解析时留空，守卫遇空列表放行（不更坏，见 ADR-0002）。
-    supported_durations: list[int] = []
-    try:
-        caps = await _resolver.video_capabilities_for_model(registry_provider_id, model_name or "", project)
-        supported_durations = [int(d) for d in caps.get("supported_durations") or []]
-    except Exception:
-        supported_durations = []
-
-    resolution = await _resolve_resolution(
-        project,
-        registry_provider_id,
-        model_name or "",
-    )
+    # provider / model / 能力 / 分辨率均取自单次解析的 video lane：能力按 backend 实际身份
+    # （registry provider_id + backend.model）查询，与实际要调用的 model 对齐——历史任务 payload
+    # 携带 provider 覆盖、或自定义供应商目标 model 被禁用回退时，二者一致避免 duration 守卫误判
+    # （用「项目默认 model 的能力」误判「实际调用的 model」）。能力不可解析时 supported_durations
+    # 留空，守卫遇空列表放行（不更坏，见 ADR-0002）。解析/构造失败已在 resolve_generation_context
+    # 内原样上抛整次任务失败，不再有硬编码 provider/model 静默兜底。
+    registry_provider_id = ctx.video.provider_model.provider_id
+    model_name = ctx.video.backend_model
+    supported_durations: list[int] = list(ctx.video.supported_durations)
+    resolution = ctx.video.resolution
 
     # duration 解析收口于执行层：payload > project.default_duration > caps 默认。
     # 用 ``is not None`` 而非 ``or`` 取 payload 值，避免显式 falsy 值被当作未设置。
@@ -1155,11 +1142,16 @@ async def execute_character_task(
     project, full_prompt, reference_images = await asyncio.to_thread(_prepare_char)
     _needs_i2i = bool(reference_images)
 
-    generator = await get_media_generator(project_name, payload=payload, user_id=user_id, needs_i2i=_needs_i2i)
+    ctx = await resolve_generation_context(
+        project_name,
+        payload,
+        project=project,
+        user_id=user_id,
+        image=ImageLaneRequest(capability="i2i" if _needs_i2i else "t2i"),
+    )
+    generator = ctx.generator
     aspect_ratio = get_aspect_ratio(project, "characters")
-
-    resolved_image = await _resolve_effective_image_backend(project, payload, needs_i2i=_needs_i2i)
-    image_size = await _resolve_resolution(project, resolved_image.provider_id, resolved_image.model_id)
+    image_size = ctx.image.resolution
 
     _, version = await generator.generate_image_async(
         prompt=full_prompt,
@@ -1254,11 +1246,16 @@ async def execute_design_task(
     project, full_prompt, reference_images = await asyncio.to_thread(_prepare)
     needs_i2i = bool(reference_images)
 
-    generator = await get_media_generator(project_name, payload=payload, user_id=user_id, needs_i2i=needs_i2i)
+    ctx = await resolve_generation_context(
+        project_name,
+        payload,
+        project=project,
+        user_id=user_id,
+        image=ImageLaneRequest(capability="i2i" if needs_i2i else "t2i"),
+    )
+    generator = ctx.generator
     aspect_ratio = get_aspect_ratio(project, bucket_key)
-
-    resolved_image = await _resolve_effective_image_backend(project, payload, needs_i2i=needs_i2i)
-    image_size = await _resolve_resolution(project, resolved_image.provider_id, resolved_image.model_id)
+    image_size = ctx.image.resolution
 
     _, version = await generator.generate_image_async(
         prompt=full_prompt,
@@ -1467,24 +1464,24 @@ async def execute_grid_task(
             raise ValueError("prompt is required for grid task")
 
         _needs_i2i = bool(reference_images)
-        generator = await get_media_generator(
-            project_name,
-            payload=payload,
-            user_id=user_id,
-            needs_i2i=_needs_i2i,
-        )
-
         project = await asyncio.to_thread(get_project_manager().load_project, project_name)
+        ctx = await resolve_generation_context(
+            project_name,
+            payload,
+            project=project,
+            user_id=user_id,
+            image=ImageLaneRequest(capability="i2i" if _needs_i2i else "t2i"),
+        )
+        generator = ctx.generator
         aspect_ratio = payload.get("grid_aspect_ratio") or get_aspect_ratio(project, "storyboards")
 
-        resolved_image = await _resolve_effective_image_backend(project, payload, needs_i2i=_needs_i2i)
-        # 回填 grid metadata：route 层创建/重建时无法预知 needs_i2i，由此处补齐
-        grid.provider = resolved_image.provider_id
-        grid.model = resolved_image.model_id
+        # 回填 grid metadata：route 层创建/重建时无法预知 needs_i2i，由此处补齐。
+        # provider 记 registry 身份（供后续重解析定位供应商），model 记 backend 实际身份
+        # （自定义供应商目标 model 被禁用回退时，实际调用的 model 与解析出的 model_id 不同）。
+        grid.provider = ctx.image.provider_model.provider_id
+        grid.model = ctx.image.backend_model
         grid_manager.save(grid)
-        image_size = (
-            await _resolve_resolution(project, resolved_image.provider_id, resolved_image.model_id) or "2K"
-        )  # 宫格图保底高分辨率
+        image_size = ctx.image.resolution or "2K"  # 宫格图保底高分辨率
 
         image_path, version = await generator.generate_image_async(
             prompt=prompt_text,

--- a/tests/test_execute_tts_task.py
+++ b/tests/test_execute_tts_task.py
@@ -12,6 +12,7 @@ import pytest
 
 from lib.config.resolver import ConfigResolver, ProviderModel
 from server.services import generation_context, generation_tasks
+from server.services.generation_context import AudioLaneResult, GenerationContext
 
 
 def _async_return(value):
@@ -19,6 +20,25 @@ def _async_return(value):
         return value
 
     return _inner
+
+
+def _audio_ctx(generator, *, voice="Cherry", speed=None):
+    """把 audio lane 解析产物拼成假 GenerationContext，替换 resolve_generation_context 单点。"""
+    ctx = GenerationContext(
+        generator=generator,
+        audio_lane=AudioLaneResult(
+            provider_model=ProviderModel("dashscope", "qwen3-tts-flash"),
+            backend_name="dashscope",
+            backend_model="qwen3-tts-flash",
+            narration_voice=voice,
+            narration_speed=speed,
+        ),
+    )
+
+    async def _resolve(*args, **kwargs):
+        return ctx
+
+    return _resolve
 
 
 class _FakePM:
@@ -65,9 +85,7 @@ def tts_env(monkeypatch, tmp_path):
     pm = _FakePM(tmp_path / "projects" / "demo")
     gen = _FakeAudioGenerator()
     monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
-    monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(gen))
-    monkeypatch.setattr(ConfigResolver, "resolve_narration_voice", _async_return("Cherry"))
-    monkeypatch.setattr(ConfigResolver, "resolve_narration_speed", _async_return(None))
+    monkeypatch.setattr(generation_tasks, "resolve_generation_context", _audio_ctx(gen))
     return pm, gen
 
 
@@ -101,7 +119,7 @@ class TestExecuteTtsTask:
 
     async def test_narration_speed_passed_to_generator(self, tts_env, monkeypatch):
         pm, gen = tts_env
-        monkeypatch.setattr(ConfigResolver, "resolve_narration_speed", _async_return(1.5))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _audio_ctx(gen, speed=1.5))
         await generation_tasks.execute_tts_task("demo", "E1S01", {"text": "你好"})
         assert gen.audio_calls[0]["speed"] == 1.5
 

--- a/tests/test_execute_tts_task.py
+++ b/tests/test_execute_tts_task.py
@@ -36,6 +36,9 @@ def _audio_ctx(generator, *, voice="Cherry", speed=None):
     )
 
     async def _resolve(*args, **kwargs):
+        assert kwargs.get("audio") is not None
+        assert kwargs.get("image") is None
+        assert kwargs.get("video") is None
         return ctx
 
     return _resolve

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -3,8 +3,10 @@ from pathlib import Path
 
 import pytest
 
+from lib.config.resolver import ProviderModel
 from lib.video_backends.base import VideoCapabilities, VideoCapabilityError
 from server.services import generation_tasks
+from server.services.generation_context import GenerationContext, ImageLaneResult, VideoLaneResult
 from server.services.generation_tasks import assert_duration_supported
 
 
@@ -79,6 +81,52 @@ def _async_return(value):
         return value
 
     return _inner
+
+
+def _fake_resolve_ctx(
+    generator,
+    *,
+    image_provider=("openai", "gpt-image-2"),
+    image_resolution=None,
+    video_provider=("ark", "seedance"),
+    video_resolution="720p",
+    supported_durations=(4, 6, 8),
+    seen_lane_requests=None,
+):
+    """lane 感知的假 resolve_generation_context：按调用方声明的 lane 拼装 frozen dataclass 产物。
+
+    ``seen_lane_requests`` 传入 list 时记录每次调用声明的 lane 请求，供断言任务只声明
+    自己用到的 lane。
+    """
+
+    async def _resolve(project_name, payload, *, project, user_id="default", image=None, video=None, audio=None):
+        if seen_lane_requests is not None:
+            seen_lane_requests.append({"image": image, "video": video, "audio": audio})
+        image_lane = None
+        if image is not None:
+            provider, model = image_provider
+            image_lane = ImageLaneResult(
+                provider_model=ProviderModel(provider, model),
+                backend_name=provider,
+                backend_model=model,
+                resolution=image_resolution,
+            )
+        video_lane = None
+        if video is not None:
+            provider, model = video_provider
+            video_lane = VideoLaneResult(
+                provider_model=ProviderModel(provider, model),
+                backend_name=provider,
+                backend_model=model,
+                resolution=video_resolution,
+                resolution_or_fallback=video_resolution or "720p",
+                supported_durations=tuple(supported_durations),
+                max_duration=None,
+                max_reference_images=None,
+            )
+        return GenerationContext(generator=generator, image_lane=image_lane, video_lane=video_lane)
+
+    return _resolve
 
 
 from lib.storyboard_sequence import (
@@ -281,15 +329,8 @@ class TestGenerationTasks:
         fake_generator = _FakeGenerator()
         emitted_batches = []
 
-        from lib.config.resolver import ProviderModel
-
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
-        # get_media_generator 已 mock；storyboard 路径仍直接调 _resolve_effective_image_backend
-        # 推导 image_size（DB 无 provider 配置），此处 stub 掉解析——解析逻辑由 TestResolveImageBackend 覆盖。
-        monkeypatch.setattr(
-            generation_tasks, "_resolve_effective_image_backend", _async_return(ProviderModel("openai", "gpt-image-2"))
-        )
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
         monkeypatch.setattr(
             generation_tasks,
             "emit_project_change_batch",
@@ -395,13 +436,8 @@ class TestGenerationTasks:
         fake_pm = _FakePM(project_path)
         fake_generator = _FakeGenerator()
 
-        from lib.config.resolver import ProviderModel
-
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
-        monkeypatch.setattr(
-            generation_tasks, "_resolve_effective_image_backend", _async_return(ProviderModel("openai", "gpt-image-2"))
-        )
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
 
         result = await generation_tasks.execute_product_task(
             "demo",
@@ -423,13 +459,8 @@ class TestGenerationTasks:
         fake_pm.project["products"]["保温杯"]["reference_images"] = []
         fake_generator = _FakeGenerator()
 
-        from lib.config.resolver import ProviderModel
-
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
-        monkeypatch.setattr(
-            generation_tasks, "_resolve_effective_image_backend", _async_return(ProviderModel("openai", "gpt-image-2"))
-        )
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
 
         await generation_tasks.execute_product_task("demo", "保温杯", {"prompt": "保温杯"})
         assert fake_generator.image_calls[0]["reference_images"] is None
@@ -480,7 +511,7 @@ class TestGenerationTasks:
             return out_path
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
         monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", fake_extract)
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
@@ -502,20 +533,8 @@ class TestGenerationTasks:
         fake_pm = _FakePM(project_path)
         fake_generator = _FakeGenerator()
 
-        from lib.config import resolver as resolver_mod
-        from lib.config.resolver import ProviderModel
-
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
-        monkeypatch.setattr(generation_tasks, "_resolve_resolution", _async_return("720p"))
-        monkeypatch.setattr(
-            resolver_mod.ConfigResolver, "resolve_video_backend", _async_return(ProviderModel("ark", "seedance"))
-        )
-        monkeypatch.setattr(
-            resolver_mod.ConfigResolver,
-            "video_capabilities_for_model",
-            _async_return({"supported_durations": [4, 6, 8], "default_duration": None}),
-        )
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
 
         with pytest.raises(VideoCapabilityError) as exc:
             await generation_tasks.execute_video_task(
@@ -537,22 +556,10 @@ class TestGenerationTasks:
         fake_pm = _FakePM(project_path)
         fake_generator = _FakeGenerator()
 
-        from lib.config import resolver as resolver_mod
-        from lib.config.resolver import ProviderModel
-
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
-        monkeypatch.setattr(generation_tasks, "_resolve_resolution", _async_return("720p"))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
         monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
-        monkeypatch.setattr(
-            resolver_mod.ConfigResolver, "resolve_video_backend", _async_return(ProviderModel("ark", "seedance"))
-        )
-        monkeypatch.setattr(
-            resolver_mod.ConfigResolver,
-            "video_capabilities_for_model",
-            _async_return({"supported_durations": [4, 6, 8], "default_duration": None}),
-        )
 
         result = await generation_tasks.execute_video_task(
             "demo",
@@ -594,22 +601,10 @@ class TestGenerationTasks:
             ],
         }
 
-        from lib.config import resolver as resolver_mod
-        from lib.config.resolver import ProviderModel
-
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
-        monkeypatch.setattr(generation_tasks, "_resolve_resolution", _async_return("720p"))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
         monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
-        monkeypatch.setattr(
-            resolver_mod.ConfigResolver, "resolve_video_backend", _async_return(ProviderModel("ark", "seedance"))
-        )
-        monkeypatch.setattr(
-            resolver_mod.ConfigResolver,
-            "video_capabilities_for_model",
-            _async_return({"supported_durations": [4, 6, 8], "default_duration": None}),
-        )
 
         # payload 的 video_prompt 不带 dialogue（drama 新结构）
         await generation_tasks.execute_video_task(
@@ -634,22 +629,14 @@ class TestGenerationTasks:
         fake_pm = _FakePM(project_path)
         fake_generator = _FakeGenerator()
 
-        from lib.config import resolver as resolver_mod
-        from lib.config.resolver import ProviderModel
-
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
-        monkeypatch.setattr(generation_tasks, "_resolve_resolution", _async_return("720p"))
+        monkeypatch.setattr(
+            generation_tasks,
+            "resolve_generation_context",
+            _fake_resolve_ctx(fake_generator, supported_durations=(6, 10)),
+        )
         monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
-        monkeypatch.setattr(
-            resolver_mod.ConfigResolver, "resolve_video_backend", _async_return(ProviderModel("ark", "seedance"))
-        )
-        monkeypatch.setattr(
-            resolver_mod.ConfigResolver,
-            "video_capabilities_for_model",
-            _async_return({"supported_durations": [6, 10], "default_duration": None}),
-        )
         # 项目默认 duration 也置空，强制走 caps 默认。
         fake_pm.project.pop("default_duration", None)
 
@@ -661,32 +648,21 @@ class TestGenerationTasks:
         assert result["resource_type"] == "videos"
         assert fake_generator.video_calls[0]["duration_seconds"] == 6
 
-    async def test_caps_failure_preserves_resolved_provider(self, monkeypatch, tmp_path):
-        """caps 解析失败不得丢弃已解析的 provider/model：resolution 仍按真实 provider。"""
+    async def test_empty_supported_durations_guard_permissive(self, monkeypatch, tmp_path):
+        """能力不可解析时 lane 交付空 supported_durations：守卫放行（不更坏），
+        resolution 仍取自 lane 已解析出的值，不因能力缺失被改写。"""
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = _FakeGenerator()
-        seen_resolution_args: list[tuple] = []
-
-        async def fake_resolution(project, provider, model):
-            seen_resolution_args.append((provider, model))
-            return "720p"
-
-        from lib.config import resolver as resolver_mod
-        from lib.config.resolver import ProviderModel
-
-        async def boom_caps(self, provider_id, model_id, project=None):
-            raise ValueError("supported_durations is empty for ark/seedance")
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
-        monkeypatch.setattr(generation_tasks, "_resolve_resolution", fake_resolution)
+        monkeypatch.setattr(
+            generation_tasks,
+            "resolve_generation_context",
+            _fake_resolve_ctx(fake_generator, supported_durations=()),
+        )
         monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
-        monkeypatch.setattr(
-            resolver_mod.ConfigResolver, "resolve_video_backend", _async_return(ProviderModel("ark", "seedance"))
-        )
-        monkeypatch.setattr(resolver_mod.ConfigResolver, "video_capabilities_for_model", boom_caps)
 
         result = await generation_tasks.execute_video_task(
             "demo",
@@ -698,34 +674,63 @@ class TestGenerationTasks:
             },
         )
         assert result["resource_type"] == "videos"
-        # caps 失败时 supported_durations 留空 → 守卫放行（不更坏），但 provider 不被改写。
-        assert seen_resolution_args == [("ark", "seedance")]
+        assert fake_generator.video_calls[0]["duration_seconds"] == 9
+        assert fake_generator.video_calls[0]["resolution"] == "720p"
 
-    async def test_caps_resolved_for_payload_provider_model(self, monkeypatch, tmp_path):
-        """caps 按已解析（含 payload 覆盖）的 provider/model 取，而非按 project 二次解析。"""
+    async def test_video_resolve_failure_fails_task_without_fallback(self, monkeypatch, tmp_path):
+        """视频解析失败即任务失败：异常原样上抛留痕，无硬编码 provider/model 兜底，后端不被调用。"""
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = _FakeGenerator()
-        seen_caps_args: list[tuple] = []
 
-        from lib.config import resolver as resolver_mod
-        from lib.config.resolver import ProviderModel
-
-        async def capture_caps(self, provider_id, model_id, project=None):
-            seen_caps_args.append((provider_id, model_id))
-            return {"supported_durations": [4, 6, 8], "default_duration": None}
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("video provider unconfigured")
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(fake_generator))
-        monkeypatch.setattr(generation_tasks, "_resolve_resolution", _async_return("720p"))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _boom)
+
+        with pytest.raises(RuntimeError, match="video provider unconfigured"):
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                },
+            )
+        assert fake_generator.video_calls == []
+
+    async def test_tasks_declare_only_needed_lanes(self, monkeypatch, tmp_path):
+        """任务只声明自己用到的 lane：图片类任务不声明 video/audio（只配置图片供应商的项目
+        不因视频供应商缺配置失败，未声明 lane 不解析见 tests/server/test_generation_context.py），
+        视频任务只声明 video；带参考图时 image lane 请求 i2i 能力。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        seen: list[dict] = []
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(
+            generation_tasks,
+            "resolve_generation_context",
+            _fake_resolve_ctx(fake_generator, seen_lane_requests=seen),
+        )
         monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
-        # 模拟历史任务 payload 覆盖：resolve_video_backend 解析出 ark/seedance。
-        monkeypatch.setattr(
-            resolver_mod.ConfigResolver, "resolve_video_backend", _async_return(ProviderModel("ark", "seedance"))
-        )
-        monkeypatch.setattr(resolver_mod.ConfigResolver, "video_capabilities_for_model", capture_caps)
 
+        # E1S02 引用角色/场景/道具 sheet → 带参考图 → i2i；character 带 reference_image → i2i
+        await generation_tasks.execute_storyboard_task(
+            "demo", "E1S02", {"script_file": "episode_1.json", "prompt": "画面"}
+        )
+        await generation_tasks.execute_character_task("demo", "Alice", {"prompt": "角色描述"})
+        await generation_tasks.execute_scene_task("demo", "祠堂", {"prompt": "场景描述"})
+        for req in seen:
+            assert req["image"] is not None
+            assert req["video"] is None
+            assert req["audio"] is None
+        assert seen[0]["image"].capability == "i2i"
+
+        seen.clear()
         await generation_tasks.execute_video_task(
             "demo",
             "E1S01",
@@ -735,8 +740,10 @@ class TestGenerationTasks:
                 "duration_seconds": 8,
             },
         )
-        # caps 用解析后的 model 而非 project 默认取，二者一致。
-        assert seen_caps_args == [("ark", "seedance")]
+        assert len(seen) == 1
+        assert seen[0]["video"] is not None
+        assert seen[0]["image"] is None
+        assert seen[0]["audio"] is None
 
     async def test_get_media_generator_skips_image_backend_for_video_tasks(self, monkeypatch, tmp_path):
         """视频任务只应初始化视频 backend，避免图片配置缺失导致提前失败。"""
@@ -1086,7 +1093,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(_FakeGenerator()))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(_FakeGenerator()))
 
         with pytest.raises(ValueError):
             await generation_tasks.execute_storyboard_task("demo", "E1S01", {"prompt": "x"})
@@ -1222,13 +1229,8 @@ class TestAdProductFidelityStoryboard:
     """产品保真注入二元化——分镜层。"""
 
     def _patch(self, monkeypatch, pm, generator):
-        from lib.config.resolver import ProviderModel
-
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
-        monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(generator))
-        monkeypatch.setattr(
-            generation_tasks, "_resolve_effective_image_backend", _async_return(ProviderModel("openai", "gpt-image-2"))
-        )
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(generator))
 
     async def test_product_shot_injects_sheet_then_originals_before_other_sheets(self, tmp_path, monkeypatch):
         """有确认 sheet 的产品镜头：注入集为「sheet 多角度 + 原图压阵」，排序绝对优先于角色/场景 sheet。"""
@@ -1346,22 +1348,10 @@ class _FakeVideoBackend:
 
 
 def _patch_video_path(monkeypatch, pm, generator):
-    from lib.config import resolver as resolver_mod
-    from lib.config.resolver import ProviderModel
-
     monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
-    monkeypatch.setattr(generation_tasks, "get_media_generator", _async_return(generator))
-    monkeypatch.setattr(generation_tasks, "_resolve_resolution", _async_return("720p"))
+    monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(generator))
     monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
     monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
-    monkeypatch.setattr(
-        resolver_mod.ConfigResolver, "resolve_video_backend", _async_return(ProviderModel("ark", "seedance"))
-    )
-    monkeypatch.setattr(
-        resolver_mod.ConfigResolver,
-        "video_capabilities_for_model",
-        _async_return({"supported_durations": [4, 6, 8], "default_duration": None}),
-    )
 
 
 class TestAdProductFidelityVideo:

--- a/tests/test_grid_executor.py
+++ b/tests/test_grid_executor.py
@@ -7,6 +7,29 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from lib.config.resolver import ProviderModel
+from server.services.generation_context import GenerationContext, ImageLaneResult
+
+
+def _image_ctx(generator, *, provider="openai", model="gpt-image-2", resolution="2K", backend_model=None):
+    """把 image lane 解析产物拼成假 GenerationContext，替换 resolve_generation_context 单点。
+
+    backend_model 可与 model 发散，模拟自定义供应商目标 model 被禁用回退时 backend
+    实际身份与解析 model_id 不同的场景。
+    """
+    ctx = GenerationContext(
+        generator=generator,
+        image_lane=ImageLaneResult(
+            provider_model=ProviderModel(provider, model),
+            backend_name=provider,
+            backend_model=backend_model if backend_model is not None else model,
+            resolution=resolution,
+        ),
+    )
+
+    async def _resolve(*args, **kwargs):
+        return ctx
+
+    return _resolve
 
 
 @pytest.fixture
@@ -199,10 +222,9 @@ class TestExecuteGridTask:
 
         with (
             patch("server.services.generation_tasks.get_project_manager") as mock_pm_fn,
-            patch("server.services.generation_tasks.get_media_generator", new_callable=AsyncMock) as mock_get_gen,
             patch(
-                "server.services.generation_tasks._resolve_effective_image_backend",
-                new=AsyncMock(return_value=ProviderModel("openai", "gpt-image-2")),
+                "server.services.generation_tasks.resolve_generation_context",
+                new=_image_ctx(mock_generator),
             ),
         ):
             mock_pm = MagicMock()
@@ -213,7 +235,6 @@ class TestExecuteGridTask:
             )
             mock_pm.update_scene_asset.return_value = {}
             mock_pm_fn.return_value = mock_pm
-            mock_get_gen.return_value = mock_generator
 
             result = await execute_grid_task(
                 "test-project",
@@ -258,10 +279,9 @@ class TestExecuteGridTask:
 
         with (
             patch("server.services.generation_tasks.get_project_manager") as mock_pm_fn,
-            patch("server.services.generation_tasks.get_media_generator", new_callable=AsyncMock) as mock_get_gen,
             patch(
-                "server.services.generation_tasks._resolve_effective_image_backend",
-                new=AsyncMock(return_value=ProviderModel("openai", "gpt-image-2")),
+                "server.services.generation_tasks.resolve_generation_context",
+                new=_image_ctx(mock_generator),
             ),
         ):
             mock_pm = MagicMock()
@@ -271,7 +291,6 @@ class TestExecuteGridTask:
                 (project_with_script / "scripts" / "episode_1.json").read_text()
             )
             mock_pm_fn.return_value = mock_pm
-            mock_get_gen.return_value = mock_generator
 
             await execute_grid_task(
                 "test-project",
@@ -325,10 +344,9 @@ class TestExecuteGridTask:
 
         with (
             patch("server.services.generation_tasks.get_project_manager") as mock_pm_fn,
-            patch("server.services.generation_tasks.get_media_generator", new_callable=AsyncMock) as mock_get_gen,
             patch(
-                "server.services.generation_tasks._resolve_effective_image_backend",
-                new=AsyncMock(return_value=ProviderModel("openai", "gpt-image-2")),
+                "server.services.generation_tasks.resolve_generation_context",
+                new=_image_ctx(mock_generator),
             ),
         ):
             mock_pm = MagicMock()
@@ -336,7 +354,6 @@ class TestExecuteGridTask:
             mock_pm.load_project.return_value = json.loads((project_with_script / "project.json").read_text())
             mock_pm.load_script.return_value = script_data
             mock_pm_fn.return_value = mock_pm
-            mock_get_gen.return_value = mock_generator
 
             with caplog.at_level(logging.WARNING, logger="server.services.generation_tasks"):
                 await execute_grid_task(
@@ -417,7 +434,7 @@ class TestGridMetadataT2II2ISlotSelection:
         grid_path.write_text(json.dumps(grid.to_dict(), ensure_ascii=False, indent=2))
         return grid
 
-    async def _run_grid_task(self, project_with_script, grid, payload):
+    async def _run_grid_task(self, project_with_script, grid, payload, resolve_override=None):
         """Helper：mock 掉 generator 与 project manager，运行 execute_grid_task。"""
         from PIL import Image
 
@@ -430,9 +447,25 @@ class TestGridMetadataT2II2ISlotSelection:
         mock_generator = MagicMock()
         mock_generator.generate_image_async = AsyncMock(return_value=(grid_image_path, 1))
 
+        async def _cap_aware_resolve(project_name, req_payload, *, image, **kwargs):
+            # capability-aware：grid 任务按 reference_images 是否非空选 t2i/i2i 槽，
+            # 假解析回显对应 payload 槽的 provider/model，锁定「槽选择 → 元数据回填」契约。
+            provider, model = req_payload[f"image_provider_{image.capability}"].split("/")
+            return GenerationContext(
+                generator=mock_generator,
+                image_lane=ImageLaneResult(
+                    provider_model=ProviderModel(provider, model),
+                    backend_name=provider,
+                    backend_model=model,
+                    resolution="2K",
+                ),
+            )
+
+        fake_resolve = resolve_override(mock_generator) if resolve_override is not None else _cap_aware_resolve
+
         with (
             patch("server.services.generation_tasks.get_project_manager") as mock_pm_fn,
-            patch("server.services.generation_tasks.get_media_generator", new_callable=AsyncMock) as mock_get_gen,
+            patch("server.services.generation_tasks.resolve_generation_context", new=fake_resolve),
         ):
             mock_pm = MagicMock()
             mock_pm.get_project_path.return_value = project_with_script
@@ -442,7 +475,6 @@ class TestGridMetadataT2II2ISlotSelection:
             )
             mock_pm.update_scene_asset.return_value = {}
             mock_pm_fn.return_value = mock_pm
-            mock_get_gen.return_value = mock_generator
 
             await execute_grid_task("test-project", grid.id, payload, user_id="test-user")
 
@@ -487,3 +519,22 @@ class TestGridMetadataT2II2ISlotSelection:
         updated = json.loads((project_with_script / "grids" / f"{grid.id}.json").read_text())
         assert updated["provider"] == "openai"
         assert updated["model"] == "gpt-image-i2i"
+
+    async def test_metadata_records_backend_actual_model_on_divergence(
+        self, project_with_script, grid_with_empty_metadata
+    ):
+        """自定义供应商目标 model 被禁用回退时，backend 实际身份与解析 model_id 发散：
+        grid 元数据 provider 记 registry 身份、model 记 backend 实际调用的 model。"""
+        grid = grid_with_empty_metadata
+        payload = {"prompt": "test grid prompt", "script_file": "episode_1.json"}
+
+        await self._run_grid_task(
+            project_with_script,
+            grid,
+            payload,
+            resolve_override=lambda gen: _image_ctx(gen, provider="custom-1", model="m-dead", backend_model="m-live"),
+        )
+
+        updated = json.loads((project_with_script / "grids" / f"{grid.id}.json").read_text())
+        assert updated["provider"] == "custom-1"
+        assert updated["model"] == "m-live"


### PR DESCRIPTION
## 摘要

generation_tasks 五个消费站点（storyboard / character / design / grid / video）改为单次调用 `resolve_generation_context`，按需声明 lane，删除「拿到 generator 后重开 ConfigResolver 重解析」的模式。行为修正随迁移交付。

## 改动

- **图片类任务只声明 image lane**：只配置图片供应商的项目可完成图片类任务，不再因视频供应商解析失败整体报错
- **video 任务删除硬编码兜底**：解析失败即任务失败、留痕可查，不再静默落 `gemini-aistudio`/`veo-*`
- **能力/分辨率按 backend 实际身份查询**：修复自定义供应商目标 model 被禁用回退时的能力错配（查询键 = registry provider_id + backend 实际 model）
- **TTS narration voice/speed 经 audio lane 取值**：语音路径的第二个 ConfigResolver session 消失
- **grid 落盘元数据**：provider 记 registry 身份、model 记 backend 实际身份

旧 helper（`get_media_generator` / `_resolve_effective_image_backend` / `_resolve_resolution` / `_resolve_video_backend`）保留未删：仍被 image_edit_tasks / resume_executor / reference_video_tasks 消费，不在本 issue 五站点范围。

## 测试

对应测试收敛为 `resolve_generation_context` 单点替换，以 frozen dataclass 拼装假 context。新增三类回归：
- 任务只声明用到的 lane（图片类不声明 video/audio；带参考图请求 i2i）
- 视频解析失败原样上抛、后端不被调用
- grid 元数据在 backend 实际身份与解析 model 发散时记实际身份

## 验证

- `pytest tests/test_generation_tasks_service.py tests/test_grid_executor.py tests/test_execute_tts_task.py tests/server/test_generation_context.py` — 98 passed
- `ruff check` / `ruff format --check` — clean
- `basedpyright` — 0 errors

Closes #1165


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 统一图片、音频和视频生成任务的配置解析，确保生成时使用正确的模型、后端、分辨率、语音参数及视频时长能力。
  * 图片任务可根据参考图自动选择对应的生成模式。
  * 网格生成结果中的模型与后端信息记录更加准确，便于查看实际使用情况。

* **Bug 修复**
  * 修正视频能力校验及分辨率处理逻辑，避免错误回退或参数被意外修改。
  * 改进生成任务异常传递，解析失败时可及时反馈。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->