### PR TITLE
refactor(ledger): 记账三通道落地并迁移全部生成路径记账调用点

### DIFF
--- a/lib/ledger.py
+++ b/lib/ledger.py
@@ -1,0 +1,223 @@
+"""记账账本（ledger）：三通道封装 API 调用记账落库。
+
+对外三个通道对应三种真实记账形态：
+
+1. **记账括号**（``record`` async context manager）—— image / audio / video / text 四条生成
+   路径用。进入即落 pending 行并在块内暴露 ``call_id``（视频路径先持久化 call_id 再调
+   backend）；成功以 ``call.success(result)`` 显式递交 backend 结果对象；``Exception`` 分支自动
+   翻 failed（错误信息截断）后原样重抛，且记账失败不吞原异常；``CancelledError`` 穿透不记账
+   （留 pending 供 resume 补账）；正常退出未声明成功抛 ``RuntimeError``。
+2. **resume 补账**（``resume_success`` / ``resume_failed``）—— 按 ``call_id`` 精准翻 pending，
+   幂等守卫（``WHERE status='pending'``）由仓储承担；finalize 自身异常不吞、直接冒泡（交
+   worker finally 兜底）。
+3. **事后补录**（``backfill``）—— agent 会话用量一次调用写入终态行（含 SDK 直报费用），对调用
+   方省掉需要自行管理的 pending 中间态。
+
+成功通道的 backend 结果对象 union 分发集中在 ``_settlement_from_result``：audio 合成字符数、
+video 实际计费时长两处语义转写在此单点完成，调用点成功分支不再有逐字段提取胶水。
+
+``session_factory`` 注入口保留：``Ledger(session_factory=...)`` 覆盖生产三处接线
+（MediaGenerator / TextGenerator / SessionManager）与测试内存库替换需求。写侧直连
+``UsageRepository``，不经用量透传层。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from lib.db import safe_session_factory
+from lib.db.base import DEFAULT_USER_ID
+from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
+from lib.providers import PROVIDER_GEMINI, CallType
+
+logger = logging.getLogger(__name__)
+
+
+def _settlement_from_result(call_type: CallType, result: Any, *, service_tier: str = "default") -> SettlementInput:
+    """成功通道 union 分发：按 call_type 从 backend 结果对象提取计费维度。
+
+    两处语义转写的唯一落点：
+    - audio 的 ``characters``（合成字符数）→ ``usage_tokens``（驱动 per-character 计费）；
+    - video 的 ``duration_seconds``（backend 回报的实际计费/生成时长）→
+      ``billed_duration_seconds``（覆盖 start_call 时的请求时长）。
+
+    四种 backend 结果对象结构独立、无共同基类，按调用点已知的 ``call_type`` 显式分发。
+    """
+    if call_type == "image":
+        return SettlementInput(
+            usage_tokens=result.usage_tokens,
+            quality=result.quality,
+            image_input_tokens=result.image_input_tokens,
+            image_output_tokens=result.image_output_tokens,
+            text_input_tokens=result.text_input_tokens,
+            text_output_tokens=result.text_output_tokens,
+        )
+    if call_type == "audio":
+        return SettlementInput(usage_tokens=result.characters)
+    if call_type == "video":
+        return SettlementInput(
+            usage_tokens=result.usage_tokens,
+            generate_audio=result.generate_audio,
+            billed_duration_seconds=result.duration_seconds,
+            service_tier=service_tier,
+        )
+    if call_type == "text":
+        return SettlementInput(
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
+        )
+    raise ValueError(f"unknown ledger channel: {call_type!r}")
+
+
+class LedgerCall:
+    """记账括号句柄：块内暴露 ``call_id``，``success(result)`` 递交 backend 结果对象。"""
+
+    def __init__(self, call_id: int, *, call_type: CallType, service_tier: str) -> None:
+        self.call_id = call_id
+        self._call_type: CallType = call_type
+        self._service_tier = service_tier
+        self._settlement: SettlementInput | None = None
+
+    def success(self, result: Any) -> None:
+        """声明成功并递交 backend 结果对象；union 分发在此完成，结算在括号退出时执行。"""
+        self._settlement = _settlement_from_result(self._call_type, result, service_tier=self._service_tier)
+
+
+class Ledger:
+    def __init__(self, *, session_factory=None):
+        self._session_factory = session_factory or safe_session_factory
+
+    @asynccontextmanager
+    async def record(
+        self,
+        *,
+        project_name: str,
+        call_type: CallType,
+        model: str,
+        provider: str = PROVIDER_GEMINI,
+        prompt: str | None = None,
+        resolution: str | None = None,
+        duration_seconds: int | None = None,
+        aspect_ratio: str | None = None,
+        generate_audio: bool = True,
+        user_id: str = DEFAULT_USER_ID,
+        segment_id: str | None = None,
+        service_tier: str = "default",
+        output_path: str | None = None,
+    ) -> AsyncIterator[LedgerCall]:
+        """记账括号：进入落 pending，块内 ``call.success(result)`` 声明成功。
+
+        退出语义：``CancelledError`` 穿透留 pending；``Exception`` 翻 failed 后原样重抛；正常
+        退出但未声明成功抛 ``RuntimeError``；声明成功则以 backend 结果对象结算翻 success。
+        """
+        call_id = await self._start_call(
+            project_name=project_name,
+            call_type=call_type,
+            model=model,
+            prompt=prompt,
+            resolution=resolution,
+            duration_seconds=duration_seconds,
+            aspect_ratio=aspect_ratio,
+            generate_audio=generate_audio,
+            provider=provider,
+            user_id=user_id,
+            segment_id=segment_id,
+        )
+        call = LedgerCall(call_id, call_type=call_type, service_tier=service_tier)
+        try:
+            yield call
+        except asyncio.CancelledError:
+            # 取消穿透：显式立约不记账，pending 行留待 resume 补账。
+            # （CancelledError 在 3.11+ 继承 BaseException 天然不进 except Exception，此处显式
+            #  声明为契约，而非依赖隐式继承副作用。）
+            raise
+        except Exception as exc:
+            # 自动翻 failed（错误信息截断由仓储承担）后原样重抛。
+            await self._finish_failed(call_id, exc)
+            raise
+        else:
+            if call._settlement is None:
+                raise RuntimeError(f"ledger.record(call_type={call_type!r}) 正常退出但未调用 call.success(result)")
+            await self._finish_success(call_id, call._settlement, output_path=output_path)
+
+    async def resume_success(self, *, call_id: int, result: Any, service_tier: str = "default") -> int:
+        """resume 成功补账：按 call_id 精准翻 pending → success，返回受影响行数（幂等 0/1）。
+
+        finalize 自身异常不吞、直接冒泡（交 worker finally 兜底），避免 ApiCall 永久卡 pending。
+        """
+        settlement = _settlement_from_result("video", result, service_tier=service_tier)
+        return await self._finalize(call_id=call_id, status="success", settlement=settlement)
+
+    async def resume_failed(self, *, call_id: int) -> int:
+        """resume 过期/失败补账：翻 pending → failed，零费用不重扣（幂等 0/1）。"""
+        return await self._finalize(call_id=call_id, status="failed", settlement=SettlementInput(cost_amount=0.0))
+
+    async def backfill(
+        self,
+        *,
+        project_name: str,
+        call_type: CallType,
+        model: str,
+        provider: str,
+        prompt: str | None,
+        user_id: str,
+        status: str,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        usage_tokens: int | None = None,
+        cost_amount: float | None = None,
+        currency: str | None = None,
+    ) -> None:
+        """事后补录：一次调用写入终态行（agent 会话用量含 SDK 直报费用）。
+
+        无 backend 结果对象 union —— 用量与 SDK 直报费用由调用方显式给出。内部经 start_call +
+        finish_call 复用结算口径（含 SQLite 跨 session 的 duration_ms 兜底语义），调用方不需自行
+        管理 pending 中间态。
+        """
+        settlement = SettlementInput(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            usage_tokens=usage_tokens,
+            cost_amount=cost_amount,
+            currency=currency,
+        )
+        call_id = await self._start_call(
+            project_name=project_name,
+            call_type=call_type,
+            model=model,
+            prompt=prompt,
+            provider=provider,
+            user_id=user_id,
+        )
+        async with self._session_factory() as session:
+            await UsageRepository(session).finish_call(call_id, status=status, settlement=settlement)
+
+    async def _start_call(self, **kwargs: Any) -> int:
+        async with self._session_factory() as session:
+            return await UsageRepository(session).start_call(**kwargs)
+
+    async def _finish_success(self, call_id: int, settlement: SettlementInput, *, output_path: str | None) -> None:
+        async with self._session_factory() as session:
+            await UsageRepository(session).finish_call(
+                call_id, status="success", settlement=settlement, output_path=output_path
+            )
+
+    async def _finish_failed(self, call_id: int, exc: BaseException) -> None:
+        # 记账失败不吞原异常：写入失败仅记日志，原异常继续冒泡。
+        try:
+            async with self._session_factory() as session:
+                await UsageRepository(session).finish_call(
+                    call_id, status="failed", settlement=SettlementInput(), error_message=str(exc)
+                )
+        except Exception:
+            logger.exception("ledger 失败分支记账写入自身失败 call_id=%s（原异常照常重抛）", call_id)
+
+    async def _finalize(self, *, call_id: int, status: str, settlement: SettlementInput) -> int:
+        async with self._session_factory() as session:
+            return await UsageRepository(session).finalize_pending_by_call_id(
+                call_id=call_id, status=status, settlement=settlement
+            )

--- a/lib/ledger.py
+++ b/lib/ledger.py
@@ -27,7 +27,7 @@ import asyncio
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Any, Literal
 
 from lib.db import safe_session_factory
 from lib.db.base import DEFAULT_USER_ID
@@ -142,7 +142,12 @@ class Ledger:
         else:
             if call._settlement is None:
                 raise RuntimeError(f"ledger.record(call_type={call_type!r}) 正常退出但未调用 call.success(result)")
-            await self._finish_success(call_id, call._settlement, output_path=output_path)
+            try:
+                await self._finish_success(call_id, call._settlement, output_path=output_path)
+            except Exception as exc:
+                # 成功结算写入本身失败：不留永久 pending，尝试翻 failed 后原样重抛。
+                await self._finish_failed(call_id, exc)
+                raise
 
     async def resume_success(self, *, call_id: int, result: Any, service_tier: str = "default") -> int:
         """resume 成功补账：按 call_id 精准翻 pending → success，返回受影响行数（幂等 0/1）。
@@ -165,7 +170,7 @@ class Ledger:
         provider: str,
         prompt: str | None,
         user_id: str,
-        status: str,
+        status: Literal["success", "failed"],
         input_tokens: int | None = None,
         output_tokens: int | None = None,
         usage_tokens: int | None = None,

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -29,8 +29,8 @@ if TYPE_CHECKING:
 
 from lib.db.base import DEFAULT_USER_ID
 from lib.gemini_shared import RateLimiter
+from lib.ledger import Ledger
 from lib.resource_paths import resource_relative_path
-from lib.usage_tracker import UsageTracker
 from lib.version_manager import VersionManager
 
 logger = logging.getLogger(__name__)
@@ -108,8 +108,8 @@ class MediaGenerator:
         self._video_provider_id = video_provider_id
         self.versions = VersionManager(project_path)
 
-        # 初始化 UsageTracker（使用全局 async session factory）
-        self.usage_tracker = UsageTracker()
+        # 初始化记账账本（使用全局 async session factory）
+        self.ledger = Ledger()
 
     @staticmethod
     def _sync(coro):
@@ -322,8 +322,9 @@ class MediaGenerator:
                 model=self._image_backend.model,
             )
 
-        # 2. 记录 API 调用开始
-        call_id = await self.usage_tracker.start_call(
+        # 2. 记账括号：进入落 pending，成功以 call.success(result) 递交 backend 结果对象，
+        #    Exception 自动翻 failed 后重抛，CancelledError 穿透留 pending。
+        async with self.ledger.record(
             project_name=self.project_name,
             call_type="image",
             model=self._image_backend.model,
@@ -333,9 +334,8 @@ class MediaGenerator:
             provider=self._image_backend.name,
             user_id=self._user_id,
             segment_id=resource_id if resource_type in ("storyboards", "videos", "grids") else None,
-        )
-
-        try:
+            output_path=str(output_path),
+        ) as call:
             from lib.reference_compression import ReferenceSpec, RefRole
 
             image_backend = self._image_backend
@@ -359,28 +359,7 @@ class MediaGenerator:
                 provider_id=self._image_provider_id,
                 build_and_call=_call_image,
             )
-
-            # 4. 记录调用成功
-            await self.usage_tracker.finish_call(
-                call_id=call_id,
-                status="success",
-                output_path=str(output_path),
-                usage_tokens=getattr(result, "usage_tokens", None),
-                quality=getattr(result, "quality", None),
-                image_input_tokens=getattr(result, "image_input_tokens", None),
-                image_output_tokens=getattr(result, "image_output_tokens", None),
-                text_input_tokens=getattr(result, "text_input_tokens", None),
-                text_output_tokens=getattr(result, "text_output_tokens", None),
-            )
-        except Exception as e:
-            # 记录调用失败
-            logger.exception("生成失败 (%s)", "image")
-            await self.usage_tracker.finish_call(
-                call_id=call_id,
-                status="failed",
-                error_message=str(e),
-            )
-            raise
+            call.success(result)
 
         # 5. 记录新版本
         new_version = self.versions.add_version(
@@ -438,7 +417,9 @@ class MediaGenerator:
         if self._audio_backend is None:
             raise RuntimeError("audio_backend not configured")
 
-        call_id = await self.usage_tracker.start_call(
+        # audio 合成字符数 → 计费 token 的语义转写已收进 ledger union 分发（_settlement_from_result），
+        # 此处仅把 backend 结果对象递交给 call.success。
+        async with self.ledger.record(
             project_name=self.project_name,
             call_type="audio",
             model=self._audio_backend.model,
@@ -446,9 +427,8 @@ class MediaGenerator:
             provider=self._audio_backend.name,
             user_id=self._user_id,
             segment_id=resource_id,
-        )
-
-        try:
+            output_path=str(output_path),
+        ) as call:
             request = AudioSynthesisRequest(
                 text=text,
                 output_path=output_path,
@@ -457,23 +437,7 @@ class MediaGenerator:
                 speed=speed,
             )
             result = await self._audio_backend.synthesize(request)
-
-            # audio 的 usage_tokens 承载合成字符数（非 LLM token），驱动 per_character 计费；
-            # finish_call 据此冻结 ApiCall.cost_amount 成本快照。
-            await self.usage_tracker.finish_call(
-                call_id=call_id,
-                status="success",
-                output_path=str(output_path),
-                usage_tokens=result.characters,
-            )
-        except Exception as e:
-            logger.exception("生成失败 (%s)", "audio")
-            await self.usage_tracker.finish_call(
-                call_id=call_id,
-                status="failed",
-                error_message=str(e),
-            )
-            raise
+            call.success(result)
 
         new_version = self.versions.add_version(
             resource_type=resource_type,
@@ -600,7 +564,11 @@ class MediaGenerator:
             configured_generate_audio = ConfigResolver._DEFAULT_VIDEO_GENERATE_AUDIO
         effective_generate_audio = version_metadata.get("generate_audio", configured_generate_audio)
 
-        call_id = await self.usage_tracker.start_call(
+        # video 实际计费时长（result.duration_seconds）覆盖请求时长的语义转写已收进 ledger union
+        # 分发（_settlement_from_result），此处仅递交 backend 结果对象。
+        video_ref = None
+        video_uri: str | None = None
+        async with self.ledger.record(
             project_name=self.project_name,
             call_type="video",
             model=model_name,
@@ -612,18 +580,17 @@ class MediaGenerator:
             provider=provider_name,
             user_id=self._user_id,
             segment_id=resource_id if resource_type in ("storyboards", "videos") else None,
-        )
-
-        try:
-            # start_call 拿到 call_id 后立即写入 task.payload["api_call_id"]，让 worker
-            # 崩溃重启后 resume 路径能精准翻这条 pending ApiCall 行（而不是按
-            # segment_id+LIMIT 1 模糊匹配）。fail-fast 抛异常会被本块 except 捕获，
-            # 走 finish_call(status="failed") 翻 pending → failed 后再 raise，避免
-            # 留下永久 pending 账目（ADR 0007）；放在 try 块内是必须的。
+            service_tier=version_metadata.get("service_tier", "default"),
+            output_path=str(output_path),
+        ) as call:
+            # 拿到 call_id 后立即写入 task.payload["api_call_id"]，让 worker 崩溃重启后 resume
+            # 路径能精准翻这条 pending ApiCall 行（而不是按 segment_id+LIMIT 1 模糊匹配）。
+            # fail-fast 抛异常会被记账括号翻 pending → failed 后再重抛，避免留下永久 pending
+            # 账目（ADR 0007）；放在 backend 调用前是必须的。
             if task_id is not None:
                 from lib.video_backends.base import persist_api_call_id
 
-                await persist_api_call_id(task_id, call_id)
+                await persist_api_call_id(task_id, call.call_id)
 
             from lib.video_backends.base import VideoGenerationRequest
 
@@ -704,30 +671,8 @@ class MediaGenerator:
                 provider_id=self._video_provider_id,
                 build_and_call=_call_video,
             )
-            video_ref = None
             video_uri = result.video_uri
-
-            # Track usage with provider info
-            # result.duration_seconds 是 backend 回报的实际计费/生成时长（如 DashScope
-            # usage.duration 含输入参考视频时长、vidu 为校正后的合法档位），缺省等于请求时长。
-            await self.usage_tracker.finish_call(
-                call_id=call_id,
-                status="success",
-                output_path=str(output_path),
-                usage_tokens=result.usage_tokens,
-                service_tier=version_metadata.get("service_tier", "default"),
-                generate_audio=result.generate_audio,
-                billed_duration_seconds=result.duration_seconds,
-            )
-        except Exception as e:
-            # 记录调用失败
-            logger.exception("生成失败 (%s)", "video")
-            await self.usage_tracker.finish_call(
-                call_id=call_id,
-                status="failed",
-                error_message=str(e),
-            )
-            raise
+            call.success(result)
 
         # 5. 记录新版本
         new_version = self.versions.add_version(
@@ -758,9 +703,9 @@ class MediaGenerator:
         """接续 provider 上已发起的 video job：调 backend.resume_video 而非 generate。
 
         与 generate_video_async 的差异：
-        - 不调 usage_tracker.start_call/finish_call —— 首次 submit 已记账；ResumeExpired
-          / crash window 都不应再写 ApiCall（防双重扣费）。caller 透传 ``api_call_id``
-          时按 call_id 精准翻 pending → success/failed；不透传则 logger.warning 不阻断。
+        - 不开记账括号（不落新 pending 行）—— 首次 submit 已记账；ResumeExpired / crash window
+          都不应再写 ApiCall（防双重扣费）。caller 透传 ``api_call_id`` 时经 ledger.resume_success
+          / resume_failed 按 call_id 精准翻 pending → success/failed；不透传则 logger.warning 不阻断。
         - resume 成功后总是 add_version 记录新版本：无论 versions.json 是否已有历史版本，
           backend.resume_video 都会下载新视频并覆盖 output_path，必须 bump 一个新版本号
           让 versions.json 与磁盘文件一致；否则会漏记本次重新生成的视频，回滚记录失真。
@@ -814,11 +759,7 @@ class MediaGenerator:
             # finalize 失败时不吞异常，让 worker finally 走 mark_failed 兜底，避免 ApiCall
             # 永久卡 pending 导致 usage 报表/补账缺口（与 persist_api_call_id 的 fail-fast 一致）。
             if api_call_id is not None:
-                await self.usage_tracker.finalize_pending_by_call_id(
-                    call_id=api_call_id,
-                    cost_amount=0.0,
-                    status="failed",
-                )
+                await self.ledger.resume_failed(call_id=api_call_id)
             raise
         except Exception:
             logger.exception("resume 失败 (video) task_id=%s job_id=%s", task_id, job_id)
@@ -827,27 +768,16 @@ class MediaGenerator:
         video_ref = None
         video_uri = result.video_uri
 
-        # Resume 成功：精准翻 pending → success。cost_amount=None 让 repo 按 ApiCall 行
-        # 字段（model/resolution/duration/generate_audio）调 cost_calculator 算实际 cost，
-        # 与 generate 路径 finish_call 自动算 cost 等价——避免视频已生成但账本永久漏记。
-        # service_tier 由 caller 透传（ApiCall 模型无该列），让非 default 档位按真实档计费。
-        # usage_tokens 同样透传：Ark video 按 token 计费，缺省 0 时 cost 永远为 0。
-        # generate_audio 从 backend 返回值透传：provider 在 submit 后可能降级/关闭音频，
-        # 与 generate 路径 finish_call(generate_audio=result.generate_audio) 等价，
-        # 避免按请求值误计费。
-        # billed_duration_seconds 同样从 backend 返回值透传：DashScope 的 resume 与 generate
-        # 走同一段 poll，会提取 usage.duration 实际计费时长；不透传则同一笔调用经 resume
-        # 完成时账本回落请求时长，与 generate 路径记账分叉。
-        # finalize 失败时不吞异常，让 worker finally 兜底处理（与 ResumeExpired 分支一致）。
-        # WHERE status='pending' 仍保护幂等性，已 success 行不会被 touch。
+        # Resume 成功：精准翻 pending → success。ledger.resume_success 收 backend 结果对象，
+        # 与视频通道成功分支同源做 union 分发（usage_tokens / generate_audio / 实际计费时长），
+        # cost 由 repo 按 ApiCall 行字段自动算——与 generate 路径记账等价，避免视频已生成但账本
+        # 永久漏记。service_tier 由 caller 透传（ApiCall 模型无该列），让非 default 档位按真实档
+        # 计费。finalize 自身异常不吞，交 worker finally 兜底；WHERE status='pending' 保护幂等性。
         if api_call_id is not None:
-            await self.usage_tracker.finalize_pending_by_call_id(
+            await self.ledger.resume_success(
                 call_id=api_call_id,
-                status="success",
+                result=result,
                 service_tier=version_metadata.get("service_tier", "default"),
-                usage_tokens=result.usage_tokens,
-                generate_audio=result.generate_audio,
-                billed_duration_seconds=result.duration_seconds,
             )
         else:
             logger.warning(

--- a/lib/text_generator.py
+++ b/lib/text_generator.py
@@ -1,7 +1,7 @@
-"""TextGenerator — 文本生成 + 用量追踪包装层。
+"""TextGenerator — 文本生成 + 记账包装层。
 
-类似 MediaGenerator，组合 TextBackend + UsageTracker，
-调用方无需关心 usage tracking 细节。
+类似 MediaGenerator，组合 TextBackend + Ledger，
+调用方无需关心记账细节。
 """
 
 from __future__ import annotations
@@ -9,13 +9,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from lib.ledger import Ledger
 from lib.text_backends.base import (
     TextGenerationRequest,
     TextGenerationResult,
     TextTaskType,
 )
 from lib.text_backends.factory import create_text_backend_for_task
-from lib.usage_tracker import UsageTracker
 
 if TYPE_CHECKING:
     from lib.text_backends.base import TextBackend
@@ -24,11 +24,11 @@ logger = logging.getLogger(__name__)
 
 
 class TextGenerator:
-    """组合 TextBackend + UsageTracker，统一封装文本生成 + 用量追踪。"""
+    """组合 TextBackend + Ledger，统一封装文本生成 + 记账。"""
 
-    def __init__(self, backend: TextBackend, usage_tracker: UsageTracker):
+    def __init__(self, backend: TextBackend, ledger: Ledger):
         self.backend = backend
-        self.usage_tracker = usage_tracker
+        self.ledger = ledger
 
     @property
     def model(self) -> str:
@@ -41,10 +41,9 @@ class TextGenerator:
         task_type: TextTaskType,
         project_name: str | None = None,
     ) -> TextGenerator:
-        """工厂方法：根据任务类型创建对应的 backend + usage_tracker。"""
+        """工厂方法：根据任务类型创建对应的 backend + ledger。"""
         backend = await create_text_backend_for_task(task_type, project_name)
-        usage_tracker = UsageTracker()
-        return cls(backend, usage_tracker)
+        return cls(backend, Ledger())
 
     async def generate(
         self,
@@ -52,26 +51,13 @@ class TextGenerator:
         project_name: str | None = None,
     ) -> TextGenerationResult:
         """生成文本并自动记录用量。"""
-        call_id = await self.usage_tracker.start_call(
+        async with self.ledger.record(
             project_name=project_name or "",
             call_type="text",
             model=self.backend.model,
             prompt=request.prompt[:500],
             provider=self.backend.name,
-        )
-        try:
+        ) as call:
             result = await self.backend.generate(request)
-            await self.usage_tracker.finish_call(
-                call_id,
-                status="success",
-                input_tokens=result.input_tokens,
-                output_tokens=result.output_tokens,
-            )
+            call.success(result)
             return result
-        except Exception as e:
-            await self.usage_tracker.finish_call(
-                call_id,
-                status="failed",
-                error_message=str(e)[:500],
-            )
-            raise

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -60,8 +60,8 @@ from claude_agent_sdk.types import (
 
 from lib.config.service import ConfigService
 from lib.db import async_session_factory
+from lib.ledger import Ledger
 from lib.providers import PROVIDER_ANTHROPIC
-from lib.usage_tracker import UsageTracker
 
 SDK_AVAILABLE = True
 
@@ -318,7 +318,7 @@ class SessionManager:
             in_docker=in_docker,
         )
         self._load_config()
-        self.usage_tracker = UsageTracker(session_factory=getattr(meta_store, "_session_factory", None))
+        self.ledger = Ledger(session_factory=getattr(meta_store, "_session_factory", None))
         # Options 装配器：持依赖、允许 I/O，异步 build 产出 SDK options。access_policy /
         # max_turns / session_factory / user_id 一律用 provider 回调现取——前两者
         # configure_sandbox_runtime / refresh_config 换新后对后续会话立即生效；后两者
@@ -1016,16 +1016,14 @@ class SessionManager:
         if input_tokens is None and output_tokens is None and total_cost_usd is None:
             return
 
-        call_id = await self.usage_tracker.start_call(
+        # 事后补录：一次调用写入终态行（省掉调用方管理的 pending 中间态）。
+        await self.ledger.backfill(
             project_name=managed.project_name,
             call_type="text",
             model=resolve_assistant_model(result_msg, managed.assistant_model),
             prompt=managed.last_user_prompt[:500] if managed.last_user_prompt else None,
             provider=PROVIDER_ANTHROPIC,
             user_id=getattr(self, "_user_id", DEFAULT_USER_ID),
-        )
-        await self.usage_tracker.finish_call(
-            call_id,
             status="success" if final_status == "completed" else "failed",
             input_tokens=input_tokens,
             output_tokens=output_tokens,

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -507,7 +507,7 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
     _wire_locked_script(fake_pm)
     monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
 
-    # 只 mock 最外层：VideoBackend（唯一的真外部依赖）+ UsageTracker/ConfigResolver
+    # 只 mock 最外层：VideoBackend（唯一的真外部依赖）+ Ledger/ConfigResolver
     # （这俩摸 DB，测试无 DB）。VersionManager 用真实实现 —— 这样 VersionManager
     # 自己的白名单（RESOURCE_TYPES / EXTENSIONS）也被这条路径守住，
     # 任何一处三张注册表漏登记都会在此爆 ValueError。
@@ -536,12 +536,16 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
                 generate_audio=False,
             )
 
-    class _FakeUsage:
-        async def start_call(self, **_kwargs):
-            return 1
+    class _FakeLedger:
+        @asynccontextmanager
+        async def record(self, **_kwargs):
+            class _Call:
+                call_id = 1
 
-        async def finish_call(self, **_kwargs):
-            pass
+                def success(self, _result):
+                    pass
+
+            yield _Call()
 
     class _FakeConfigResolver:
         async def video_generate_audio(self, _project_name=None):
@@ -555,7 +559,7 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
 
             return _DEFAULT_REFERENCE_TOTAL_MAX_BYTES, _DEFAULT_REFERENCE_SINGLE_MAX_BYTES
 
-    # object.__new__ 绕过 MediaGenerator.__init__（避开 __init__ 里的 UsageTracker 对 DB 的初始化）
+    # object.__new__ 绕过 MediaGenerator.__init__（避开 __init__ 里的 Ledger 对 DB 的初始化）
     real_gen = object.__new__(MediaGenerator)
     real_gen.project_path = proj_dir
     real_gen.project_name = "demo"
@@ -567,7 +571,7 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
     real_gen._image_provider_id = None
     real_gen._video_provider_id = None
     real_gen.versions = VersionManager(proj_dir)
-    real_gen.usage_tracker = _FakeUsage()
+    real_gen.ledger = _FakeLedger()
 
     _wire_context(monkeypatch, rvt, real_gen, backend_name="ark", backend_model="doubao-seedance-2-0-260128")
 

--- a/tests/test_accounting_characterization.py
+++ b/tests/test_accounting_characterization.py
@@ -1,7 +1,7 @@
 """记账特征化测试矩阵：六通道落库行为锁。
 
 以生成器公开方法驱动 + 假 backend（Protocol 实现，返回可控结果/抛可控异常）+ 真内存
-SQLite 落库 + 冻结时钟，把记账链路（UsageTracker → UsageRepository → 结算 →
+SQLite 落库 + 冻结时钟，把记账链路（Ledger → UsageRepository → 结算 →
 CostCalculator → 定价策略）的落库行为逐字段锁定：链路内部不 mock，断言 ApiCall 整行，
 任何记账落库行为的意外变化都会在此当场失败。
 
@@ -35,11 +35,12 @@ from lib.config.resolver import ConfigResolver
 from lib.db.base import Base
 from lib.db.models.api_call import ApiCall
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
+from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
 from lib.image_backends.base import ImageCapability, ImageGenerationRequest, ImageGenerationResult
+from lib.ledger import Ledger
 from lib.media_generator import MediaGenerator
 from lib.text_backends.base import TextCapability, TextGenerationRequest, TextGenerationResult
 from lib.text_generator import TextGenerator
-from lib.usage_tracker import UsageTracker
 from lib.video_backends.base import (
     ResumeExpiredError,
     VideoCapabilities,
@@ -90,7 +91,6 @@ def frozen_clock(monkeypatch: pytest.MonkeyPatch) -> _SteppingClock:
 class _AccountingDb:
     engine: AsyncEngine
     factory: async_sessionmaker
-    tracker: UsageTracker
 
     async def fetch_rows(self) -> list[dict[str, Any]]:
         """按 id 升序取全部 ApiCall 行，整行快照（表列全集）。
@@ -117,7 +117,7 @@ async def acct(frozen_clock: _SteppingClock) -> Any:
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     factory = async_sessionmaker(engine, expire_on_commit=False)
-    db = _AccountingDb(engine=engine, factory=factory, tracker=UsageTracker(session_factory=factory))
+    db = _AccountingDb(engine=engine, factory=factory)
     yield db
     await engine.dispose()
 
@@ -392,8 +392,8 @@ def _media_generator(
         audio_backend=audio_backend,
         config_resolver=cast(ConfigResolver, _FakeConfigResolver()),
     )
-    # 唯一的接线替换：把记账落点指到测试内存库。记账链路内部（tracker→repo→结算→定价）全真实。
-    gen.usage_tracker = UsageTracker(session_factory=db.factory)
+    # 唯一的接线替换：把记账落点指到测试内存库。记账链路内部（ledger→repo→结算→定价）全真实。
+    gen.ledger = Ledger(session_factory=db.factory)
     return gen
 
 
@@ -755,7 +755,7 @@ class TestTextChannel:
                 input_tokens=1_000_000,
                 output_tokens=1_000_000,
             ),
-            UsageTracker(session_factory=acct.factory),
+            Ledger(session_factory=acct.factory),
         )
 
         await gen.generate(TextGenerationRequest(prompt="文" * 700), project_name="demo")
@@ -776,7 +776,7 @@ class TestTextChannel:
     async def test_no_tokens_and_no_project_yields_zero_cost(self, acct: _AccountingDb) -> None:
         gen = TextGenerator(
             _FakeTextBackend(provider="gemini", model="gemini-3-flash-preview"),
-            UsageTracker(session_factory=acct.factory),
+            Ledger(session_factory=acct.factory),
         )
 
         await gen.generate(TextGenerationRequest(prompt="p"))
@@ -795,7 +795,7 @@ class TestTextChannel:
     async def test_failure_flips_failed_with_truncated_error(self, acct: _AccountingDb) -> None:
         gen = TextGenerator(
             _FakeTextBackend(provider="gemini", model="gemini-3-flash-preview", error=ValueError("t" * 600)),
-            UsageTracker(session_factory=acct.factory),
+            Ledger(session_factory=acct.factory),
         )
 
         with pytest.raises(ValueError):
@@ -844,7 +844,7 @@ class TestTextChannel:
                 input_tokens=1_000_000,
                 output_tokens=500_000,
             ),
-            UsageTracker(session_factory=acct.factory),
+            Ledger(session_factory=acct.factory),
         )
 
         await gen.generate(TextGenerationRequest(prompt="p"), project_name="demo")
@@ -871,19 +871,24 @@ class TestTextChannel:
 
 
 async def _pending_video_call(acct: _AccountingDb) -> int:
-    """模拟 submit 侧已记账的 pending 行（resume 的补账锚点）。"""
-    return await acct.tracker.start_call(
-        project_name="demo",
-        call_type="video",
-        model="veo-3.1-generate-preview",
-        prompt="p",
-        resolution="720p",
-        duration_seconds=8,
-        aspect_ratio="9:16",
-        generate_audio=True,
-        provider="gemini",
-        segment_id="E1S01",
-    )
+    """模拟 submit 侧已记账的 pending 行（resume 的补账锚点）。
+
+    直接经 UsageRepository 落 pending 行 —— submit 侧生产入口是记账括号的 start，此处仅需
+    锚点行，不必开括号。
+    """
+    async with acct.factory() as session:
+        return await UsageRepository(session).start_call(
+            project_name="demo",
+            call_type="video",
+            model="veo-3.1-generate-preview",
+            prompt="p",
+            resolution="720p",
+            duration_seconds=8,
+            aspect_ratio="9:16",
+            generate_audio=True,
+            provider="gemini",
+            segment_id="E1S01",
+        )
 
 
 async def _resume_video(gen: MediaGenerator, api_call_id: int | None) -> None:
@@ -978,14 +983,14 @@ class TestResumeChannel:
 
     async def test_pending_guard_never_touches_terminal_row(self, tmp_path: Path, acct: _AccountingDb) -> None:
         call_id = await _pending_video_call(acct)
-        await acct.tracker.finish_call(
-            call_id,
-            status="success",
-            output_path="/already/done.mp4",
-            usage_tokens=0,
-            generate_audio=True,
-            billed_duration_seconds=8,
-        )
+        # 预置一条已 success 的终态行（模拟 generate 已 finish），供 resume 幂等守卫验证。
+        async with acct.factory() as session:
+            await UsageRepository(session).finish_call(
+                call_id,
+                status="success",
+                settlement=SettlementInput(usage_tokens=0, generate_audio=True, billed_duration_seconds=8),
+                output_path="/already/done.mp4",
+            )
         terminal_snapshot = await acct.fetch_only_row()
 
         gen = _media_generator(tmp_path, acct, video_backend=_veo_backend(usage_tokens=0, duration_seconds=6))
@@ -1041,7 +1046,7 @@ class TestAgentBackfillChannel:
             project_root=tmp_path,
             meta_store=SessionMetaStore(session_factory=acct.factory),
         )
-        mgr.usage_tracker = UsageTracker(session_factory=acct.factory)
+        mgr.ledger = Ledger(session_factory=acct.factory)
         return mgr
 
     async def test_completed_turn_prefers_reported_cost(self, manager: SessionManager, acct: _AccountingDb) -> None:

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -143,9 +143,13 @@ class TestRecordBracket:
 
     async def test_cancellation_passes_through_leaving_pending(self, factory: async_sessionmaker) -> None:
         ledger = Ledger(session_factory=factory)
-        with pytest.raises(asyncio.CancelledError):
+        try:
             async with ledger.record(project_name="demo", call_type="text", model="m", provider="anthropic"):
                 raise asyncio.CancelledError()
+        except asyncio.CancelledError:
+            pass
+        else:
+            pytest.fail("expected CancelledError to propagate")
 
         # 穿透不记账：行停在 pending，不翻 failed
         row = await _only_row(factory)
@@ -179,6 +183,37 @@ class TestRecordBracket:
         with pytest.raises(ValueError, match="original"):
             async with ledger.record(project_name="demo", call_type="text", model="m", provider="anthropic"):
                 raise ValueError("original")
+
+    async def test_success_write_failure_flips_failed_and_reraises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """call.success() 已声明，但成功结算写入本身抛异常时，须尝试翻 failed 而非永久留 pending。"""
+
+        statuses: list[str] = []
+
+        class _BoomOnSuccessRepo:
+            def __init__(self, _session: Any) -> None:
+                pass
+
+            async def start_call(self, **_kwargs: Any) -> int:
+                return 1
+
+            async def finish_call(self, _call_id: int, *, status: str, **_kwargs: Any) -> None:
+                statuses.append(status)
+                if status == "success":
+                    raise RuntimeError("settlement write down")
+
+        monkeypatch.setattr("lib.ledger.UsageRepository", _BoomOnSuccessRepo)
+
+        @asynccontextmanager
+        async def _dummy_session() -> AsyncIterator[None]:
+            yield None
+
+        ledger = Ledger(session_factory=lambda: _dummy_session())
+
+        with pytest.raises(RuntimeError, match="settlement write down"):
+            async with ledger.record(project_name="demo", call_type="text", model="m", provider="anthropic") as call:
+                call.success(_TextResult(input_tokens=1, output_tokens=1))
+
+        assert statuses == ["success", "failed"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,255 @@
+"""ledger 直驱缝测试：直接驱动记账括号 / resume / backfill / union 分发。
+
+特征化矩阵（tests/test_accounting_characterization.py）从生成器公开方法端到端锁落库行为；
+本文件补齐矩阵覆盖不到的 CM 契约语义：块内 call_id 可用、漏调成功声明抛 RuntimeError、
+Exception 翻 failed 后重抛、记账失败不吞原异常、CancelledError 穿透留 pending。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from lib.db.base import Base
+from lib.db.models.api_call import ApiCall
+from lib.ledger import Ledger, _settlement_from_result
+
+
+@pytest.fixture
+async def factory() -> Any:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield async_sessionmaker(engine, expire_on_commit=False)
+    await engine.dispose()
+
+
+async def _only_row(factory: async_sessionmaker) -> ApiCall:
+    async with factory() as session:
+        rows = (await session.execute(select(ApiCall))).scalars().all()
+    assert len(rows) == 1, f"期望恰好 1 行，实际 {len(rows)}"
+    return rows[0]
+
+
+# ---------------------------------------------------------------------------
+# union 分发：两处语义转写的唯一落点
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ImgResult:
+    usage_tokens: int | None = 8
+    quality: str | None = "high"
+    image_input_tokens: int | None = None
+    image_output_tokens: int | None = None
+    text_input_tokens: int | None = None
+    text_output_tokens: int | None = None
+
+
+@dataclass
+class _AudioResult:
+    characters: int = 25_000
+
+
+@dataclass
+class _VideoResult:
+    usage_tokens: int | None = 0
+    generate_audio: bool | None = False
+    duration_seconds: int = 15
+
+
+@dataclass
+class _TextResult:
+    input_tokens: int | None = 100
+    output_tokens: int | None = 50
+
+
+class TestSettlementDispatch:
+    def test_image_extracts_token_and_quality_fields(self) -> None:
+        s = _settlement_from_result("image", _ImgResult(usage_tokens=8, quality="high"))
+        assert s.usage_tokens == 8
+        assert s.quality == "high"
+
+    def test_audio_transcribes_characters_to_usage_tokens(self) -> None:
+        # 语义转写①：合成字符数 → 计费 token
+        s = _settlement_from_result("audio", _AudioResult(characters=25_000))
+        assert s.usage_tokens == 25_000
+
+    def test_video_transcribes_duration_to_billed_and_carries_service_tier(self) -> None:
+        # 语义转写②：backend 实际计费时长 → billed_duration_seconds（覆盖请求时长）
+        s = _settlement_from_result(
+            "video", _VideoResult(duration_seconds=15, generate_audio=False), service_tier="pro"
+        )
+        assert s.billed_duration_seconds == 15
+        assert s.generate_audio is False
+        assert s.service_tier == "pro"
+
+    def test_text_extracts_input_output_tokens(self) -> None:
+        s = _settlement_from_result("text", _TextResult(input_tokens=100, output_tokens=50))
+        assert s.input_tokens == 100
+        assert s.output_tokens == 50
+
+    def test_unknown_channel_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown ledger channel"):
+            _settlement_from_result("bogus", object())  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 记账括号 CM 契约
+# ---------------------------------------------------------------------------
+
+
+class TestRecordBracket:
+    async def test_call_id_available_in_block_and_success_flips_row(self, factory: async_sessionmaker) -> None:
+        ledger = Ledger(session_factory=factory)
+        seen_call_id: int | None = None
+        async with ledger.record(project_name="demo", call_type="text", model="m", provider="anthropic") as call:
+            seen_call_id = call.call_id
+            call.success(_TextResult(input_tokens=100, output_tokens=50))
+
+        assert seen_call_id is not None and seen_call_id > 0
+        row = await _only_row(factory)
+        assert row.status == "success"
+        assert row.input_tokens == 100
+        assert row.output_tokens == 50
+
+    async def test_missing_success_declaration_raises_runtime_error(self, factory: async_sessionmaker) -> None:
+        ledger = Ledger(session_factory=factory)
+        with pytest.raises(RuntimeError, match="未调用 call.success"):
+            async with ledger.record(project_name="demo", call_type="text", model="m", provider="anthropic"):
+                pass  # 正常退出但未声明成功
+
+        # 未声明成功 → 未 finish，行停在 pending（不翻 success/failed）
+        row = await _only_row(factory)
+        assert row.status == "pending"
+
+    async def test_exception_flips_failed_and_reraises(self, factory: async_sessionmaker) -> None:
+        ledger = Ledger(session_factory=factory)
+        with pytest.raises(ValueError, match="boom"):
+            async with ledger.record(project_name="demo", call_type="text", model="m", provider="anthropic"):
+                raise ValueError("boom" * 200)
+
+        row = await _only_row(factory)
+        assert row.status == "failed"
+        assert row.error_message is not None
+        assert len(row.error_message) == 500  # 错误信息截断由仓储承担
+
+    async def test_cancellation_passes_through_leaving_pending(self, factory: async_sessionmaker) -> None:
+        ledger = Ledger(session_factory=factory)
+        with pytest.raises(asyncio.CancelledError):
+            async with ledger.record(project_name="demo", call_type="text", model="m", provider="anthropic"):
+                raise asyncio.CancelledError()
+
+        # 穿透不记账：行停在 pending，不翻 failed
+        row = await _only_row(factory)
+        assert row.status == "pending"
+
+    async def test_accounting_failure_does_not_swallow_original_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """失败分支记账写入自身抛异常时，必须让原异常照常冒泡（不被记账错误遮蔽）。"""
+
+        class _BoomOnFailRepo:
+            def __init__(self, _session: Any) -> None:
+                pass
+
+            async def start_call(self, **_kwargs: Any) -> int:
+                return 1
+
+            async def finish_call(self, _call_id: int, *, status: str, **_kwargs: Any) -> None:
+                if status == "failed":
+                    raise RuntimeError("ledger write down")
+
+        monkeypatch.setattr("lib.ledger.UsageRepository", _BoomOnFailRepo)
+
+        @asynccontextmanager
+        async def _dummy_session() -> AsyncIterator[None]:
+            yield None
+
+        ledger = Ledger(session_factory=lambda: _dummy_session())
+
+        # 原异常是 ValueError；记账失败分支的 RuntimeError 被吞（仅记日志），ValueError 冒泡
+        with pytest.raises(ValueError, match="original"):
+            async with ledger.record(project_name="demo", call_type="text", model="m", provider="anthropic"):
+                raise ValueError("original")
+
+
+# ---------------------------------------------------------------------------
+# resume 补账 / 事后补录：语义齐备的直驱确认（端到端计费口径见特征化矩阵）
+# ---------------------------------------------------------------------------
+
+
+class TestResumeAndBackfill:
+    async def _seed_pending_video(self, factory: async_sessionmaker) -> int:
+        from lib.db.repositories.usage_repo import UsageRepository
+
+        async with factory() as session:
+            return await UsageRepository(session).start_call(
+                project_name="demo",
+                call_type="video",
+                model="veo-3.1-generate-preview",
+                duration_seconds=8,
+                provider="gemini",
+            )
+
+    async def test_resume_success_flips_pending_by_call_id(self, factory: async_sessionmaker) -> None:
+        call_id = await self._seed_pending_video(factory)
+        ledger = Ledger(session_factory=factory)
+
+        affected = await ledger.resume_success(
+            call_id=call_id, result=_VideoResult(duration_seconds=6, generate_audio=False)
+        )
+        assert affected == 1
+
+        row = await _only_row(factory)
+        assert row.status == "success"
+        assert row.duration_seconds == 6  # backend 实际计费时长覆盖请求 8s
+
+    async def test_resume_failed_flips_pending_zero_cost(self, factory: async_sessionmaker) -> None:
+        call_id = await self._seed_pending_video(factory)
+        ledger = Ledger(session_factory=factory)
+
+        affected = await ledger.resume_failed(call_id=call_id)
+        assert affected == 1
+
+        row = await _only_row(factory)
+        assert row.status == "failed"
+        assert row.cost_amount == 0.0
+
+    async def test_resume_success_idempotent_on_terminal_row(self, factory: async_sessionmaker) -> None:
+        call_id = await self._seed_pending_video(factory)
+        ledger = Ledger(session_factory=factory)
+        await ledger.resume_success(call_id=call_id, result=_VideoResult())
+
+        # 二次 finalize 命中 0 行（WHERE status='pending' 幂等守卫），不抛异常
+        affected = await ledger.resume_success(call_id=call_id, result=_VideoResult())
+        assert affected == 0
+
+    async def test_backfill_writes_single_terminal_row(self, factory: async_sessionmaker) -> None:
+        ledger = Ledger(session_factory=factory)
+        await ledger.backfill(
+            project_name="demo",
+            call_type="text",
+            model="claude-sonnet-4",
+            provider="anthropic",
+            prompt="u",
+            user_id="default",
+            status="success",
+            input_tokens=1_000_000,
+            output_tokens=200_000,
+            usage_tokens=1_200_000,
+            cost_amount=0.123,
+            currency="USD",
+        )
+
+        row = await _only_row(factory)
+        assert row.status == "success"
+        assert row.cost_amount == pytest.approx(0.123)  # SDK 直报费用优先
+        assert row.usage_tokens == 1_200_000

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -143,13 +143,14 @@ class TestRecordBracket:
 
     async def test_cancellation_passes_through_leaving_pending(self, factory: async_sessionmaker) -> None:
         ledger = Ledger(session_factory=factory)
+        caught = False
         try:
             async with ledger.record(project_name="demo", call_type="text", model="m", provider="anthropic"):
                 raise asyncio.CancelledError()
         except asyncio.CancelledError:
-            pass
-        else:
-            pytest.fail("expected CancelledError to propagate")
+            caught = True
+
+        assert caught, "expected CancelledError to propagate"
 
         # 穿透不记账：行停在 pending，不翻 failed
         row = await _only_row(factory)

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -1,3 +1,5 @@
+import asyncio
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
@@ -77,17 +79,46 @@ class _FakeVersions:
         }
 
 
-class _FakeUsage:
+class _FakeLedgerCall:
+    def __init__(self, call_id):
+        self.call_id = call_id
+        self.declared = False
+        self.result = None
+
+    def success(self, result):
+        self.declared = True
+        self.result = result
+
+
+class _FakeLedger:
+    """记账账本假实现：捕获记账括号入参（started）与终态结果（outcomes）——新主缝。
+
+    括号语义与真 Ledger 一致：CancelledError 穿透、Exception 记 failed 后重抛、
+    正常退出未声明成功抛 RuntimeError。usage 字段的提取归属真 Ledger 的 union 分发，
+    此处只捕获调用点递交的 backend 结果对象。
+    """
+
     def __init__(self):
         self.started = []
-        self.finished = []
+        self.outcomes = []
+        self._n = 0
 
-    async def start_call(self, **kwargs):
+    @asynccontextmanager
+    async def record(self, **kwargs):
+        self._n += 1
         self.started.append(kwargs)
-        return len(self.started)
-
-    async def finish_call(self, **kwargs):
-        self.finished.append(kwargs)
+        call = _FakeLedgerCall(self._n)
+        try:
+            yield call
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.outcomes.append({"status": "failed", "error": exc})
+            raise
+        else:
+            if not call.declared:
+                raise RuntimeError("ledger.record exited without success()")
+            self.outcomes.append({"status": "success", "result": call.result})
 
 
 class _FakeConfigResolver:
@@ -122,7 +153,7 @@ def _build_generator(tmp_path: Path) -> MediaGenerator:
     gen._image_provider_id = None
     gen._video_provider_id = None
     gen.versions = _FakeVersions()
-    gen.usage_tracker = _FakeUsage()
+    gen.ledger = _FakeLedger()
     return gen
 
 
@@ -147,9 +178,10 @@ class TestMediaGenerator:
 
         assert output_path.name == "scene_E1S01.png"
         assert version == 1
-        assert gen.usage_tracker.started[0]["call_type"] == "image"
-        assert gen.usage_tracker.finished[0]["status"] == "success"
-        assert gen.usage_tracker.finished[0]["usage_tokens"] == 8
+        assert gen.ledger.started[0]["call_type"] == "image"
+        assert gen.ledger.outcomes[0]["status"] == "success"
+        # usage_tokens 提取归属真 Ledger union 分发；此处确认调用点递交了 backend 结果对象
+        assert gen.ledger.outcomes[0]["result"].usage_tokens == 8
 
         async def _raise(request):
             raise RuntimeError("boom")
@@ -158,7 +190,7 @@ class TestMediaGenerator:
         with pytest.raises(RuntimeError):
             gen.generate_image(prompt="p", resource_type="characters", resource_id="A")
 
-        assert any(item["status"] == "failed" for item in gen.usage_tracker.finished)
+        assert any(o["status"] == "failed" for o in gen.ledger.outcomes)
 
     @pytest.mark.asyncio
     async def test_generate_video_sync_and_async(self, tmp_path):
@@ -183,7 +215,7 @@ class TestMediaGenerator:
         )
         assert video_path2.name == "scene_E1S02.mp4"
         assert version2 == 2
-        assert gen.usage_tracker.started[-1]["call_type"] == "video"
+        assert gen.ledger.started[-1]["call_type"] == "video"
 
     @pytest.mark.asyncio
     async def test_video_billed_duration_passed_to_finish_call(self, tmp_path):
@@ -197,25 +229,27 @@ class TestMediaGenerator:
             resource_id="E1S10",
             duration_seconds="6",
         )
-        assert gen.usage_tracker.started[-1]["duration_seconds"] == 6
-        assert gen.usage_tracker.finished[-1]["billed_duration_seconds"] == 15
+        assert gen.ledger.started[-1]["duration_seconds"] == 6
+        # billed_duration_seconds 由真 Ledger union 分发从结果对象提取；此处确认递交了 duration=15 的结果
+        assert gen.ledger.outcomes[-1]["result"].duration_seconds == 15
 
     @pytest.mark.asyncio
     async def test_video_billed_duration_lands_in_ledger(self, tmp_path):
-        """端到端：backend 返回与请求不同的实际计费时长，ApiCall 账本记录 backend 值。"""
+        """端到端：真 Ledger 落库，backend 返回与请求不同的实际计费时长，ApiCall 账本记录 backend 值。"""
         from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
         from lib.db.base import Base
+        from lib.ledger import Ledger
         from lib.usage_tracker import UsageTracker
 
         engine = create_async_engine("sqlite+aiosqlite:///:memory:")
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
         try:
+            factory = async_sessionmaker(engine, expire_on_commit=False)
             gen = _build_generator(tmp_path)
             gen._video_backend = _FakeVideoBackend(result_duration_seconds=15)
-            tracker = UsageTracker(session_factory=async_sessionmaker(engine, expire_on_commit=False))
-            gen.usage_tracker = tracker
+            gen.ledger = Ledger(session_factory=factory)
 
             await gen.generate_video_async(
                 prompt="p",
@@ -224,7 +258,8 @@ class TestMediaGenerator:
                 duration_seconds="6",
             )
 
-            item = (await tracker.get_calls(project_name="demo"))["items"][0]
+            # 读侧仍走 UsageTracker（读侧未迁移）
+            item = (await UsageTracker(session_factory=factory).get_calls(project_name="demo"))["items"][0]
             assert item["status"] == "success"
             assert item["duration_seconds"] == 15
         finally:
@@ -242,7 +277,7 @@ class TestMediaGenerator:
             resource_id="E1S03",
         )
         # VideoBackend 路径尊重 ConfigResolver 返回的值
-        assert gen.usage_tracker.started[-1]["generate_audio"] is False
+        assert gen.ledger.started[-1]["generate_audio"] is False
 
     @pytest.mark.asyncio
     async def test_video_generate_audio_respects_config_true(self, tmp_path):
@@ -255,7 +290,7 @@ class TestMediaGenerator:
             resource_type="videos",
             resource_id="E1S04",
         )
-        assert gen.usage_tracker.started[-1]["generate_audio"] is True
+        assert gen.ledger.started[-1]["generate_audio"] is True
 
     @pytest.mark.asyncio
     async def test_video_generate_audio_defaults_true_when_config_none(self, tmp_path):
@@ -269,7 +304,7 @@ class TestMediaGenerator:
             resource_type="videos",
             resource_id="E1S05",
         )
-        assert gen.usage_tracker.started[-1]["generate_audio"] is True
+        assert gen.ledger.started[-1]["generate_audio"] is True
 
 
 # ── 咽喉层参考图压缩接线 ────────────────────────────────────────────────────
@@ -423,8 +458,8 @@ class TestReferenceCompressionSeam:
         # 一次 413 后降档重试成功：backend 被调两次
         assert len(backend.calls) == 2
         # 只记一条 success（413 内循环重试不额外记账）
-        assert len(gen.usage_tracker.finished) == 1
-        assert gen.usage_tracker.finished[0]["status"] == "success"
+        assert len(gen.ledger.outcomes) == 1
+        assert gen.ledger.outcomes[0]["status"] == "success"
 
     async def test_413_exhausted_raises_floor_records_failed(self, tmp_path):
         gen = _build_generator(tmp_path)
@@ -443,8 +478,8 @@ class TestReferenceCompressionSeam:
         # 走完梯子（基线 + LADDER_STEPS-1 档 + 地板）= LADDER_STEPS + 1 次调用后耗尽
         assert len(backend.calls) == LADDER_STEPS + 1
         # 耗尽冒泡到外层 except 记一条 failed
-        assert len(gen.usage_tracker.finished) == 1
-        assert gen.usage_tracker.finished[0]["status"] == "failed"
+        assert len(gen.ledger.outcomes) == 1
+        assert gen.ledger.outcomes[0]["status"] == "failed"
 
     async def test_t2i_no_refs_413_not_converted_to_floor(self, tmp_path):
         # 无参考图（T2I）的 413 与参考图无关，不应被误转成 floor、也不降档

--- a/tests/test_media_generator_resume.py
+++ b/tests/test_media_generator_resume.py
@@ -1,8 +1,8 @@
 """MediaGenerator.resume_video_async 单元测试。
 
 关注点：
-- resume 路径不写 ApiCall（不调 start_call / finish_call）
-- finalize_pending_by_call_id 按 api_call_id 精准翻 pending → success/failed
+- resume 路径不落新 pending 行（不开记账括号）
+- ledger.resume_success / resume_failed 按 api_call_id 精准翻 pending → success/failed
 - 版本管理用 add_version：resume 成功后总是 bump 新版本，让 versions.json 与磁盘文件一致
   （submit→poll 崩 → 登记 v1；已有 v_n 的覆盖式重新生成 → 登记 v_(n+1)）
 - ResumeExpiredError 沿调用链上抛，pending 翻 failed
@@ -10,6 +10,8 @@
 
 from __future__ import annotations
 
+import asyncio
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
@@ -85,23 +87,49 @@ class _ProbeVideoBackend(_FakeVideoBackend):
         return await super().resume_video(job_id, request)
 
 
-class _FakeUsage:
+class _FakeLedgerCall:
+    def __init__(self, call_id: int) -> None:
+        self.call_id = call_id
+        self.declared = False
+        self.result: Any = None
+
+    def success(self, result: Any) -> None:
+        self.declared = True
+        self.result = result
+
+
+class _FakeLedger:
+    """记账账本假实现：resume 路径只该走 resume_success/resume_failed，不开记账括号。
+
+    ``started`` 捕获误开的括号（应恒空）；``resumed`` 捕获 resume 补账入参（含递交的
+    backend 结果对象）——新主缝。
+    """
+
     def __init__(self) -> None:
         self.started: list[dict[str, Any]] = []
-        self.finished: list[dict[str, Any]] = []
-        self.finalized: list[dict[str, Any]] = []
-        self._finalize_affected = 1
+        self.resumed: list[dict[str, Any]] = []
+        self._n = 0
+        self._resume_affected = 1
 
-    async def start_call(self, **kwargs):
+    @asynccontextmanager
+    async def record(self, **kwargs):
+        self._n += 1
         self.started.append(kwargs)
-        return 999
+        call = _FakeLedgerCall(self._n)
+        try:
+            yield call
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            raise
 
-    async def finish_call(self, **kwargs):
-        self.finished.append(kwargs)
+    async def resume_success(self, *, call_id: int, result: Any, service_tier: str = "default") -> int:
+        self.resumed.append({"status": "success", "call_id": call_id, "result": result, "service_tier": service_tier})
+        return self._resume_affected
 
-    async def finalize_pending_by_call_id(self, **kwargs):
-        self.finalized.append(kwargs)
-        return self._finalize_affected
+    async def resume_failed(self, *, call_id: int) -> int:
+        self.resumed.append({"status": "failed", "call_id": call_id})
+        return self._resume_affected
 
 
 class _FakeConfigResolver:
@@ -120,12 +148,12 @@ def _build_generator(tmp_path: Path, *, initial_version: int = 0) -> MediaGenera
     gen._user_id = "default"
     gen._config = _FakeConfigResolver()
     gen.versions = _FakeVersions(initial_version=initial_version)
-    gen.usage_tracker = _FakeUsage()
+    gen.ledger = _FakeLedger()
     return gen
 
 
 @pytest.mark.asyncio
-async def test_resume_does_not_call_usage_tracker_start_or_finish(tmp_path):
+async def test_resume_does_not_open_record_bracket(tmp_path):
     gen = _build_generator(tmp_path)
 
     await gen.resume_video_async(
@@ -136,8 +164,8 @@ async def test_resume_does_not_call_usage_tracker_start_or_finish(tmp_path):
         api_call_id=42,
     )
 
-    assert gen.usage_tracker.started == [], "resume 不应调 start_call"
-    assert gen.usage_tracker.finished == [], "resume 不应调 finish_call"
+    # resume 不落新 pending 行：只走 resume_success/resume_failed 补账，不开记账括号
+    assert gen.ledger.started == [], "resume 不应开记账括号"
 
 
 @pytest.mark.asyncio
@@ -152,19 +180,19 @@ async def test_resume_success_flips_pending_apicall_by_call_id(tmp_path):
         api_call_id=42,
     )
 
-    assert len(gen.usage_tracker.finalized) == 1
-    call = gen.usage_tracker.finalized[0]
+    assert len(gen.ledger.resumed) == 1
+    call = gen.ledger.resumed[0]
     assert call["call_id"] == 42
     assert call["status"] == "success"
-    # success 路径不显式传 cost_amount，让 repo 按 ApiCall 行字段 auto-calc 算实际 cost
-    # （与 generate 路径 finish_call 等价记账），caller 端不再硬编码 0.0
-    assert "cost_amount" not in call or call["cost_amount"] is None
+    # 成功补账不显式传 cost_amount，让 repo 按 ApiCall 行字段 auto-calc 算实际 cost
+    # （与 generate 路径记账等价）；cost_amount 不进 resume_success 的补账入参
+    assert "cost_amount" not in call
 
 
 @pytest.mark.asyncio
 async def test_resume_idempotent_when_finalize_returns_zero(tmp_path, caplog):
     gen = _build_generator(tmp_path)
-    gen.usage_tracker._finalize_affected = 0  # 模拟「已 success」幂等场景
+    gen.ledger._resume_affected = 0  # 模拟「已 success」幂等场景
 
     output_path, version, _, _ = await gen.resume_video_async(
         job_id="provider-job-1",
@@ -177,7 +205,7 @@ async def test_resume_idempotent_when_finalize_returns_zero(tmp_path, caplog):
     assert output_path.exists()
     assert version == 1
     # 0 rows 不应抛异常，应当 logger.info 记录
-    assert len(gen.usage_tracker.finalized) == 1
+    assert len(gen.ledger.resumed) == 1
 
 
 @pytest.mark.asyncio
@@ -194,11 +222,11 @@ async def test_resume_expired_flips_pending_to_failed(tmp_path):
             api_call_id=42,
         )
 
-    assert len(gen.usage_tracker.finalized) == 1
-    call = gen.usage_tracker.finalized[0]
+    assert len(gen.ledger.resumed) == 1
+    call = gen.ledger.resumed[0]
     assert call["call_id"] == 42
     assert call["status"] == "failed"
-    assert call["cost_amount"] == 0.0
+    # 零费用不重扣的语义已收进 ledger.resume_failed 内部（cost_amount=0.0），补账入参不再显式承载
 
 
 @pytest.mark.asyncio
@@ -216,7 +244,7 @@ async def test_resume_other_exception_does_not_finalize(tmp_path):
             api_call_id=42,
         )
 
-    assert gen.usage_tracker.finalized == [], "非 ResumeExpired 不应 finalize pending"
+    assert gen.ledger.resumed == [], "非 ResumeExpired 不应 finalize pending"
 
 
 @pytest.mark.asyncio
@@ -349,11 +377,11 @@ async def test_resume_passes_usage_tokens_to_finalize(tmp_path):
         api_call_id=42,
     )
 
-    assert len(gen.usage_tracker.finalized) == 1
-    call = gen.usage_tracker.finalized[0]
+    assert len(gen.ledger.resumed) == 1
+    call = gen.ledger.resumed[0]
     assert call["call_id"] == 42
     assert call["status"] == "success"
-    assert call["usage_tokens"] == 12345, "usage_tokens 必须透传，否则 Ark cost 永远为 0"
+    assert call["result"].usage_tokens == 12345, "backend 结果对象必须递交，usage_tokens 由 ledger 分发透传"
 
 
 @pytest.mark.asyncio
@@ -371,18 +399,22 @@ async def test_resume_missing_api_call_id_warns_does_not_crash(tmp_path, caplog)
 
     assert output_path.exists()
     assert version == 1
-    assert gen.usage_tracker.finalized == [], "无 api_call_id 时不应 finalize"
+    assert gen.ledger.resumed == [], "无 api_call_id 时不应 finalize"
 
 
-class _FailingFinalizeUsage(_FakeUsage):
-    """模拟 finalize_pending_by_call_id 自身失败的场景。"""
+class _FailingResumeLedger(_FakeLedger):
+    """模拟 resume 补账（finalize）自身失败的场景。"""
 
     def __init__(self, *, exc: Exception) -> None:
         super().__init__()
         self._exc = exc
 
-    async def finalize_pending_by_call_id(self, **kwargs):
-        self.finalized.append(kwargs)
+    async def resume_success(self, *, call_id: int, result: Any, service_tier: str = "default") -> int:
+        self.resumed.append({"status": "success", "call_id": call_id})
+        raise self._exc
+
+    async def resume_failed(self, *, call_id: int) -> int:
+        self.resumed.append({"status": "failed", "call_id": call_id})
         raise self._exc
 
 
@@ -394,7 +426,7 @@ async def test_resume_success_propagates_finalize_exception(tmp_path):
     expired 分支又是终态），usage 报表和补账会出现永久缺口。fail-fast
     交给 worker finally 的 mark_failed 兜底。"""
     gen = _build_generator(tmp_path)
-    gen.usage_tracker = _FailingFinalizeUsage(exc=RuntimeError("db down"))
+    gen.ledger = _FailingResumeLedger(exc=RuntimeError("db down"))
 
     with pytest.raises(RuntimeError, match="db down"):
         await gen.resume_video_async(
@@ -406,7 +438,7 @@ async def test_resume_success_propagates_finalize_exception(tmp_path):
         )
 
     # finalize 被调过一次（看到异常上抛前的入参）
-    assert len(gen.usage_tracker.finalized) == 1
+    assert len(gen.ledger.resumed) == 1
 
 
 @pytest.mark.asyncio
@@ -415,7 +447,7 @@ async def test_resume_expired_propagates_finalize_exception(tmp_path):
     失败，避免 ApiCall 永远卡 pending。"""
     gen = _build_generator(tmp_path)
     gen._video_backend = _FakeVideoBackend(raises=ResumeExpiredError(job_id="provider-job-1", provider="openai"))
-    gen.usage_tracker = _FailingFinalizeUsage(exc=RuntimeError("db down"))
+    gen.ledger = _FailingResumeLedger(exc=RuntimeError("db down"))
 
     # finalize 抛 RuntimeError 应该覆盖原本要抛的 ResumeExpiredError 上抛
     with pytest.raises(RuntimeError, match="db down"):
@@ -427,7 +459,7 @@ async def test_resume_expired_propagates_finalize_exception(tmp_path):
             api_call_id=42,
         )
 
-    assert len(gen.usage_tracker.finalized) == 1
+    assert len(gen.ledger.resumed) == 1
 
 
 @pytest.mark.asyncio
@@ -470,9 +502,9 @@ async def test_resume_passes_generate_audio_to_finalize(tmp_path):
         api_call_id=42,
     )
 
-    assert len(gen.usage_tracker.finalized) == 1
-    call = gen.usage_tracker.finalized[0]
-    assert call["generate_audio"] is False, "generate_audio 必须透传 backend 返回的实际值"
+    assert len(gen.ledger.resumed) == 1
+    call = gen.ledger.resumed[0]
+    assert call["result"].generate_audio is False, "backend 结果对象必须递交，generate_audio 由 ledger 分发透传"
 
 
 @pytest.mark.asyncio
@@ -516,6 +548,6 @@ async def test_resume_passes_billed_duration_to_finalize(tmp_path):
         api_call_id=42,
     )
 
-    assert len(gen.usage_tracker.finalized) == 1
-    call = gen.usage_tracker.finalized[0]
-    assert call["billed_duration_seconds"] == 15, "实际计费时长必须透传，否则 resume 路径回落请求时长记账"
+    assert len(gen.ledger.resumed) == 1
+    call = gen.ledger.resumed[0]
+    assert call["result"].duration_seconds == 15, "backend 结果对象必须递交，实际计费时长由 ledger 分发透传"

--- a/tests/test_text_generator.py
+++ b/tests/test_text_generator.py
@@ -1,24 +1,33 @@
 """Tests for TextGenerator wrapper."""
 
+from dataclasses import dataclass
 from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.db.base import Base
+from lib.ledger import Ledger
 from lib.text_backends.base import TextGenerationRequest, TextGenerationResult
 from lib.text_generator import TextGenerator
 from lib.usage_tracker import UsageTracker
 
 
+@dataclass
+class _Wired:
+    """记账写侧注入 Ledger，读侧仍走 UsageTracker（读侧未迁移），共享同一内存库。"""
+
+    ledger: Ledger
+    reader: UsageTracker
+
+
 @pytest.fixture
-async def tracker():
+async def wired():
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     factory = async_sessionmaker(engine, expire_on_commit=False)
-    t = UsageTracker(session_factory=factory)
-    yield t
+    yield _Wired(ledger=Ledger(session_factory=factory), reader=UsageTracker(session_factory=factory))
     await engine.dispose()
 
 
@@ -39,9 +48,9 @@ def _make_backend(provider="gemini", model="gemini-3-flash-preview"):
 
 
 class TestTextGenerator:
-    async def test_generate_records_usage_on_success(self, tracker):
+    async def test_generate_records_usage_on_success(self, wired):
         backend = _make_backend()
-        gen = TextGenerator(backend, tracker)
+        gen = TextGenerator(backend, wired.ledger)
 
         result = await gen.generate(
             TextGenerationRequest(prompt="测试"),
@@ -52,7 +61,7 @@ class TestTextGenerator:
         assert result.input_tokens == 100
         assert result.output_tokens == 50
 
-        calls = await tracker.get_calls(project_name="demo")
+        calls = await wired.reader.get_calls(project_name="demo")
         assert calls["total"] == 1
         item = calls["items"][0]
         assert item["call_type"] == "text"
@@ -62,10 +71,10 @@ class TestTextGenerator:
         assert item["provider"] == "gemini"
         assert item["cost_amount"] == pytest.approx((100 * 0.50 + 50 * 3.00) / 1_000_000)
 
-    async def test_generate_records_usage_on_failure(self, tracker):
+    async def test_generate_records_usage_on_failure(self, wired):
         backend = _make_backend()
         backend.generate = AsyncMock(side_effect=RuntimeError("API 超时"))
-        gen = TextGenerator(backend, tracker)
+        gen = TextGenerator(backend, wired.ledger)
 
         with pytest.raises(RuntimeError, match="API 超时"):
             await gen.generate(
@@ -73,21 +82,21 @@ class TestTextGenerator:
                 project_name="demo",
             )
 
-        calls = await tracker.get_calls(project_name="demo")
+        calls = await wired.reader.get_calls(project_name="demo")
         assert calls["total"] == 1
         item = calls["items"][0]
         assert item["status"] == "failed"
         assert item["cost_amount"] == 0.0
         assert "API 超时" in item["error_message"]
 
-    async def test_generate_without_project_name(self, tracker):
+    async def test_generate_without_project_name(self, wired):
         backend = _make_backend()
-        gen = TextGenerator(backend, tracker)
+        gen = TextGenerator(backend, wired.ledger)
 
         result = await gen.generate(TextGenerationRequest(prompt="工具箱调用"))
 
         assert result.text == "生成的文本"
-        calls = await tracker.get_calls()
+        calls = await wired.reader.get_calls()
         assert calls["total"] == 1
         item = calls["items"][0]
         assert item["project_name"] == ""

--- a/tests/test_tts_skeleton.py
+++ b/tests/test_tts_skeleton.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
@@ -97,17 +98,41 @@ class _FakeVersions:
         return len(self.add_calls)
 
 
-class _FakeUsage:
+class _FakeLedgerCall:
+    def __init__(self, call_id):
+        self.call_id = call_id
+        self.declared = False
+        self.result = None
+
+    def success(self, result):
+        self.declared = True
+        self.result = result
+
+
+class _FakeLedger:
+    """记账账本假实现：捕获记账括号入参与递交的 backend 结果对象（新主缝）。"""
+
     def __init__(self):
         self.started = []
-        self.finished = []
+        self.outcomes = []
+        self._n = 0
 
-    async def start_call(self, **kwargs):
+    @asynccontextmanager
+    async def record(self, **kwargs):
+        self._n += 1
         self.started.append(kwargs)
-        return len(self.started)
-
-    async def finish_call(self, **kwargs):
-        self.finished.append(kwargs)
+        call = _FakeLedgerCall(self._n)
+        try:
+            yield call
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.outcomes.append({"status": "failed", "error": exc})
+            raise
+        else:
+            if not call.declared:
+                raise RuntimeError("ledger.record exited without success()")
+            self.outcomes.append({"status": "success", "result": call.result})
 
 
 def _build_generator(tmp_path: Path) -> MediaGenerator:
@@ -122,7 +147,7 @@ def _build_generator(tmp_path: Path) -> MediaGenerator:
     gen._user_id = "default"
     gen._config = None
     gen.versions = _FakeVersions()
-    gen.usage_tracker = _FakeUsage()
+    gen.ledger = _FakeLedger()
     return gen
 
 
@@ -133,11 +158,11 @@ class TestGenerateAudioAsync:
         assert output_path.name == "segment_E1S01.wav"
         assert output_path.read_bytes() == b"RIFFfakewav"
         assert version == 1
-        # start_call 用 call_type=audio + 字符数承载在 finish_call.usage_tokens
-        assert gen.usage_tracker.started[0]["call_type"] == "audio"
-        assert gen.usage_tracker.started[0]["model"] == "tts-model"
-        assert gen.usage_tracker.finished[0]["status"] == "success"
-        assert gen.usage_tracker.finished[0]["usage_tokens"] == len("你好世界")
+        # 记账括号用 call_type=audio；合成字符数由真 Ledger union 分发从 result.characters 转写
+        assert gen.ledger.started[0]["call_type"] == "audio"
+        assert gen.ledger.started[0]["model"] == "tts-model"
+        assert gen.ledger.outcomes[0]["status"] == "success"
+        assert gen.ledger.outcomes[0]["result"].characters == len("你好世界")
         assert gen.versions.add_calls[0]["resource_type"] == "audio"
 
     async def test_backend_failure_marks_failed(self, tmp_path: Path):
@@ -149,7 +174,7 @@ class TestGenerateAudioAsync:
         gen._audio_backend.synthesize = _raise
         with pytest.raises(RuntimeError):
             await gen.generate_audio_async(text="x", resource_id="E1S02", voice="Cherry")
-        assert gen.usage_tracker.finished[-1]["status"] == "failed"
+        assert gen.ledger.outcomes[-1]["status"] == "failed"
 
     async def test_no_backend_raises(self, tmp_path: Path):
         gen = _build_generator(tmp_path)


### PR DESCRIPTION
Closes #1181

## 变更

新建 `lib/ledger.py`，对外三通道对应三种真实记账形态，并迁移全部六个记账调用点：

1. **记账括号** `Ledger.record`（async CM）——image / audio / video / text 四条生成路径。进入落 pending 并块内暴露 `call.call_id`（video 先持久化 call_id 再调 backend，保留 resume 接续依赖）；成功以 `call.success(result)` 显式递交 backend 结果对象；退出语义显式立约：`Exception` 翻 failed 后原样重抛且记账失败不吞原异常、`CancelledError` 穿透留 pending、正常退出未声明成功抛 `RuntimeError`。
2. **resume 补账** `resume_success` / `resume_failed`——按 `call_id` 精准翻 pending，幂等守卫由仓储承担；finalize 自身异常不吞、直接冒泡交 worker finally 兜底。
3. **事后补录** `backfill`——agent 会话用量一次调用写终态行（含 SDK 直报费用），调用方不管理 pending 中间态。

成功通道 union 分发集中在 `_settlement_from_result`：audio 合成字符数→`usage_tokens`、video 实际计费时长→`billed_duration_seconds` 两处语义转写在此单点完成，调用点成功分支胶水清零。生产写侧对 `UsageTracker` 的调用点清零（读侧 `UsageTracker` 暂存，由 #1182 删除）。

## 验证

- 全量 `pytest`：**6147 passed**（含特征化矩阵 `test_accounting_characterization.py` 零期望值改动）
- `test_ledger.py` 直驱缝补齐矩阵覆盖不到的 CM 契约：块内 call_id 可用、漏声明成功抛 RuntimeError、Exception 翻 failed+截断+重抛、CancelledError 穿透、记账失败不吞原异常、resume 幂等、backfill 单终态行
- 捕获 kwargs 的旧假追踪器（`_FakeUsage`）断言改写到 ledger 主缝（`_FakeLedger`：`record` CM + `outcomes`/`resumed` 捕获）
- `ruff check` + `ruff format --check`：全绿
- `basedpyright`：**0 errors**（826 warnings 均既有第三方/tests mock 降级项）
- 已 rebase 到最新 main（`5d3f7d42`）

## Spec

[Spec #1171]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增统一记账账本模块：支持成功/失败写入、任务恢复补账与事后补录。
* **改进**
  * 媒体/文本生成改为使用统一账本落账；视频恢复通过调用标识精确幂等补账。
  * 优化 413 请求超限识别逻辑，增强异常/取消场景处理。
* **测试**
  * 更新与新增端到端记账与计费契约用例，覆盖恢复、补账与字段映射。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->