### PR TITLE
fix(accounting): 记账 provider 取解析层身份，Gemini 文本与图像视频调用合组显示

### DIFF
--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -21,6 +21,11 @@ from lib.providers import PROVIDER_GEMINI, CallType
 # 解析侧（grok / dashscope extractor）的 clamp 引用同一常量，保持口径一致。
 MAX_BILLED_DURATION_SECONDS = 86400
 
+# 存量裸 provider 值的报表显示兜底：身份反转前，文本 gemini 调用以 backend.name 落账为裸
+# "gemini"（图像/视频侧已是 "gemini-aistudio"）。这些历史行不迁移，仅在分组报表按此表补一个
+# 友好显示名；registry 只登记新格式 key（gemini-aistudio / gemini-vertex），故裸值查不到 meta。
+_LEGACY_PROVIDER_DISPLAY_NAMES = {PROVIDER_GEMINI: "Gemini"}
+
 
 @dataclass(frozen=True)
 class SettlementInput:
@@ -573,7 +578,10 @@ class UsageRepository(BaseRepository):
                     stat["display_name"] = provider_str
             else:
                 meta = PROVIDER_REGISTRY.get(provider_str or "")
-                stat["display_name"] = meta.display_name if meta else provider_str
+                if meta:
+                    stat["display_name"] = meta.display_name
+                else:
+                    stat["display_name"] = _LEGACY_PROVIDER_DISPLAY_NAMES.get(provider_str or "", provider_str)
 
         period_start: str | None = None
         period_end: str | None = None

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -17,7 +17,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from PIL import Image
 
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 from lib.db.base import DEFAULT_USER_ID
 from lib.gemini_shared import RateLimiter
 from lib.ledger import Ledger
+from lib.providers import require_provider_pair
 from lib.resource_paths import resource_relative_path
 from lib.version_manager import VersionManager
 
@@ -80,6 +81,7 @@ class MediaGenerator:
         user_id: str = DEFAULT_USER_ID,
         image_provider_id: str | None = None,
         video_provider_id: str | None = None,
+        audio_provider_id: str | None = None,
     ):
         """
         初始化 MediaGenerator
@@ -92,10 +94,16 @@ class MediaGenerator:
             audio_backend: 可选的 AudioBackend 实例（用于语音合成）
             config_resolver: ConfigResolver 实例，用于运行时读取配置
             user_id: 用户 ID
-            image_provider_id: 图像 registry provider_id（解析参考图压缩 per-provider 上限用；
-                None 时走保守通用上限）。须为 registry id（如 "gemini-aistudio"），非 backend.name
-            video_provider_id: 视频 registry provider_id（同上，I2V/R2V 用）
+            image_provider_id: 图像 registry provider_id。既是解析参考图压缩 per-provider 上限的
+                依据，也是该 lane 记账 provider 的单一真相源。须为 registry id（如 "gemini-aistudio"），
+                非 backend.name；与 image_backend 成对提供，缺一即抛
+            video_provider_id: 视频 registry provider_id（同上，I2V/R2V 与视频记账用）
+            audio_provider_id: 音频 registry provider_id（旁白 TTS 记账用），与 audio_backend 成对
         """
+        require_provider_pair("image", image_backend, image_provider_id)
+        require_provider_pair("video", video_backend, video_provider_id)
+        require_provider_pair("audio", audio_backend, audio_provider_id)
+
         self.project_path = Path(project_path)
         self.project_name = self.project_path.name
         self._rate_limiter = rate_limiter
@@ -106,6 +114,7 @@ class MediaGenerator:
         self._user_id = user_id
         self._image_provider_id = image_provider_id
         self._video_provider_id = video_provider_id
+        self._audio_provider_id = audio_provider_id
         self.versions = VersionManager(project_path)
 
         # 初始化记账账本（使用全局 async session factory）
@@ -331,7 +340,8 @@ class MediaGenerator:
             prompt=prompt,
             resolution=image_size,
             aspect_ratio=aspect_ratio,
-            provider=self._image_backend.name,
+            # 记账 provider 取解析层 provider_id；成对不变量保证 backend 非 None 时 provider_id 亦非 None。
+            provider=cast(str, self._image_provider_id),
             user_id=self._user_id,
             segment_id=resource_id if resource_type in ("storyboards", "videos", "grids") else None,
             output_path=str(output_path),
@@ -424,7 +434,8 @@ class MediaGenerator:
             call_type="audio",
             model=self._audio_backend.model,
             prompt=text,
-            provider=self._audio_backend.name,
+            # 记账 provider 取解析层 provider_id；成对不变量保证 backend 非 None 时 provider_id 亦非 None。
+            provider=cast(str, self._audio_provider_id),
             user_id=self._user_id,
             segment_id=resource_id,
             output_path=str(output_path),
@@ -555,7 +566,6 @@ class MediaGenerator:
             raise RuntimeError("video_backend not configured")
 
         model_name = self._video_backend.model
-        provider_name = self._video_backend.name
         if self._config is not None:
             configured_generate_audio = await self._config.video_generate_audio(self.project_name)
         else:
@@ -577,7 +587,8 @@ class MediaGenerator:
             duration_seconds=duration_int,
             aspect_ratio=aspect_ratio,
             generate_audio=effective_generate_audio,
-            provider=provider_name,
+            # 记账 provider 取解析层 provider_id；成对不变量保证 backend 非 None 时 provider_id 亦非 None。
+            provider=cast(str, self._video_provider_id),
             user_id=self._user_id,
             segment_id=resource_id if resource_type in ("storyboards", "videos") else None,
             service_tier=version_metadata.get("service_tier", "default"),

--- a/lib/providers.py
+++ b/lib/providers.py
@@ -20,3 +20,18 @@ CALL_TYPE_IMAGE: CallType = "image"
 CALL_TYPE_VIDEO: CallType = "video"
 CALL_TYPE_TEXT: CallType = "text"
 CALL_TYPE_AUDIO: CallType = "audio"
+
+
+def require_provider_pair(kind: str, backend: object | None, provider_id: str | None) -> None:
+    """构造期成对不变量：媒体/文本 backend 与其解析层 registry provider_id 必须同在同缺。
+
+    记账 provider 一律取解析层 provider_id（单一真相源），backend 仅承担生成调用与日志/错误
+    上下文。二者缺一即为装配错误：backend 有而 provider_id 无 → 记账失去身份来源；provider_id
+    有而 backend 无 → 声明了该 lane 却没有可用 backend。此处一次性拦截，调用期不再逐次校验、
+    也不设豁免名单。
+    """
+    if (backend is None) != (provider_id is None):
+        raise ValueError(
+            f"{kind} backend 与 provider_id 必须成对提供："
+            f"backend={'set' if backend is not None else 'None'}, provider_id={provider_id!r}"
+        )

--- a/lib/text_backends/factory.py
+++ b/lib/text_backends/factory.py
@@ -16,8 +16,12 @@ from lib.text_backends.base import TextBackend, TextTaskType
 async def create_text_backend_for_task(
     task_type: TextTaskType,
     project_name: str | None = None,
-) -> TextBackend:
-    """从 DB 配置创建文本 backend。"""
+) -> tuple[TextBackend, str]:
+    """从 DB 配置创建文本 backend，随 backend 返回解析层 registry provider_id。
+
+    provider_id 是记账 provider 的单一真相源，与 backend 成对交付；调用方（TextGenerator）
+    据此记账，backend.name 不再作为记账输入。
+    """
     resolver = ConfigResolver(async_session_factory)
 
     async with resolver.session() as r:
@@ -28,4 +32,4 @@ async def create_text_backend_for_task(
             model_id=model_id,
             resolver=r,
         )
-    return backend
+    return backend, provider_id

--- a/lib/text_generator.py
+++ b/lib/text_generator.py
@@ -10,6 +10,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from lib.ledger import Ledger
+from lib.providers import require_provider_pair
 from lib.text_backends.base import (
     TextGenerationRequest,
     TextGenerationResult,
@@ -26,9 +27,11 @@ logger = logging.getLogger(__name__)
 class TextGenerator:
     """组合 TextBackend + Ledger，统一封装文本生成 + 记账。"""
 
-    def __init__(self, backend: TextBackend, ledger: Ledger):
+    def __init__(self, backend: TextBackend, ledger: Ledger, provider_id: str):
+        require_provider_pair("text", backend, provider_id)
         self.backend = backend
         self.ledger = ledger
+        self._provider_id = provider_id
 
     @property
     def model(self) -> str:
@@ -42,8 +45,8 @@ class TextGenerator:
         project_name: str | None = None,
     ) -> TextGenerator:
         """工厂方法：根据任务类型创建对应的 backend + ledger。"""
-        backend = await create_text_backend_for_task(task_type, project_name)
-        return cls(backend, Ledger())
+        backend, provider_id = await create_text_backend_for_task(task_type, project_name)
+        return cls(backend, Ledger(), provider_id)
 
     async def generate(
         self,
@@ -56,7 +59,7 @@ class TextGenerator:
             call_type="text",
             model=self.backend.model,
             prompt=request.prompt[:500],
-            provider=self.backend.name,
+            provider=self._provider_id,
         ) as call:
             result = await self.backend.generate(request)
             call.success(result)

--- a/server/services/generation_context.py
+++ b/server/services/generation_context.py
@@ -331,6 +331,7 @@ async def resolve_generation_context(
         user_id=user_id,
         image_provider_id=image_result.provider_model.provider_id if image_result else None,
         video_provider_id=video_result.provider_model.provider_id if video_result else None,
+        audio_provider_id=audio_result.provider_model.provider_id if audio_result else None,
     )
     return GenerationContext(
         generator=generator,

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -101,7 +101,7 @@ async def _resolve_video_backend(
     project_name: str,
     resolver: ConfigResolver,
     payload: dict | None,
-) -> tuple[Any | None, str]:
+) -> tuple[Any | None, str | None]:
     """解析并构造视频后端，返回 (video_backend, provider_id)。
 
     provider/model 的**解析**是 ``resolver.resolve_video_backend`` 的薄投影；backend **构造**
@@ -121,7 +121,9 @@ async def _resolve_video_backend(
             default_video_model=resolved.model_id or None,
         )
 
-    return video_backend, resolved.provider_id
+    # provider_id 与 backend 成对返回：无 payload 时不构造 video_backend，此时 provider_id 无
+    # 消费者（压缩上限与记账都只在视频真实调用时用），返回 None 以满足 MediaGenerator 的成对不变量。
+    return video_backend, (resolved.provider_id if video_backend is not None else None)
 
 
 async def get_media_generator(
@@ -149,6 +151,7 @@ async def get_media_generator(
     # image provider，纯图任务也要拿到 video provider，两个分支各自赋值后传给 MediaGenerator。
     image_provider_id: str | None = None
     video_provider_id: str | None = None
+    audio_provider_id: str | None = None
     async with resolver.session() as r:
         image_backend = None
         video_backend = None
@@ -157,6 +160,7 @@ async def get_media_generator(
         if needs_audio:
             project = await asyncio.to_thread(get_project_manager().load_project, project_name)
             resolved_audio = await r.resolve_audio_backend(project, payload)
+            audio_provider_id = resolved_audio.provider_id
             audio_backend = await _get_or_create_audio_backend(
                 resolved_audio.provider_id,
                 {},
@@ -193,6 +197,7 @@ async def get_media_generator(
         user_id=user_id,
         image_provider_id=image_provider_id,
         video_provider_id=video_provider_id,
+        audio_provider_id=audio_provider_id,
     )
 
 

--- a/tests/test_accounting_characterization.py
+++ b/tests/test_accounting_characterization.py
@@ -382,15 +382,24 @@ def _media_generator(
     image_backend: _FakeImageBackend | None = None,
     video_backend: _FakeVideoBackend | None = None,
     audio_backend: _FakeAudioBackend | None = None,
+    image_provider_id: str | None = None,
+    video_provider_id: str | None = None,
+    audio_provider_id: str | None = None,
 ) -> MediaGenerator:
     project_path = tmp_path / "projects" / "demo"
     project_path.mkdir(parents=True, exist_ok=True)
+    # 成对不变量要求：backend 在则 provider_id 在。媒体侧真实 backend.name 与解析层 id 同值
+    # （gemini-aistudio/ark/dashscope），故默认取 backend.name 保持矩阵零改动；反转锁测试显式传
+    # 不同值证明记账取 provider_id 而非 name。
     gen = MediaGenerator(
         project_path,
         image_backend=image_backend,
         video_backend=video_backend,
         audio_backend=audio_backend,
         config_resolver=cast(ConfigResolver, _FakeConfigResolver()),
+        image_provider_id=image_provider_id or (image_backend.name if image_backend else None),
+        video_provider_id=video_provider_id or (video_backend.name if video_backend else None),
+        audio_provider_id=audio_provider_id or (audio_backend.name if audio_backend else None),
     )
     # 唯一的接线替换：把记账落点指到测试内存库。记账链路内部（ledger→repo→结算→定价）全真实。
     gen.ledger = Ledger(session_factory=db.factory)
@@ -756,11 +765,12 @@ class TestTextChannel:
                 output_tokens=1_000_000,
             ),
             Ledger(session_factory=acct.factory),
+            "gemini-aistudio",
         )
 
         await gen.generate(TextGenerationRequest(prompt="文" * 700), project_name="demo")
 
-        # 0.50 + 3.00 USD/百万 token
+        # 0.50 + 3.00 USD/百万 token；记账 provider 取解析层 id（gemini-aistudio），非 backend.name（gemini）
         _assert_full_row(
             await acct.fetch_only_row(),
             _expected_row(
@@ -768,6 +778,7 @@ class TestTextChannel:
                 model="gemini-3-flash-preview",
                 prompt="文" * 500,
                 cost_amount=pytest.approx(3.5),
+                provider="gemini-aistudio",
                 input_tokens=1_000_000,
                 output_tokens=1_000_000,
             ),
@@ -777,6 +788,7 @@ class TestTextChannel:
         gen = TextGenerator(
             _FakeTextBackend(provider="gemini", model="gemini-3-flash-preview"),
             Ledger(session_factory=acct.factory),
+            "gemini-aistudio",
         )
 
         await gen.generate(TextGenerationRequest(prompt="p"))
@@ -789,6 +801,7 @@ class TestTextChannel:
                 model="gemini-3-flash-preview",
                 project_name="",
                 prompt="p",
+                provider="gemini-aistudio",
             ),
         )
 
@@ -796,6 +809,7 @@ class TestTextChannel:
         gen = TextGenerator(
             _FakeTextBackend(provider="gemini", model="gemini-3-flash-preview", error=ValueError("t" * 600)),
             Ledger(session_factory=acct.factory),
+            "gemini-aistudio",
         )
 
         with pytest.raises(ValueError):
@@ -809,6 +823,7 @@ class TestTextChannel:
                 prompt="p",
                 status="failed",
                 error_message="t" * 500,
+                provider="gemini-aistudio",
             ),
         )
 
@@ -845,6 +860,7 @@ class TestTextChannel:
                 output_tokens=500_000,
             ),
             Ledger(session_factory=acct.factory),
+            provider_key,
         )
 
         await gen.generate(TextGenerationRequest(prompt="p"), project_name="demo")
@@ -863,6 +879,52 @@ class TestTextChannel:
                 output_tokens=500_000,
             ),
         )
+
+
+# ---------------------------------------------------------------------------
+# 身份不变量：记账 provider 取解析层 provider_id，构造期成对不变量
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityInvariant:
+    async def test_media_records_resolver_provider_id_not_backend_name(
+        self, tmp_path: Path, acct: _AccountingDb
+    ) -> None:
+        # backend.name 报裸 "gemini"，解析层 id 为 "gemini-aistudio"：记账须落解析层 id。
+        gen = _media_generator(
+            tmp_path,
+            acct,
+            image_backend=_FakeImageBackend(provider="gemini", model="gemini-3-pro-image-preview"),
+            image_provider_id="gemini-aistudio",
+        )
+
+        await gen.generate_image_async(prompt="p", resource_type="characters", resource_id="婉儿", image_size="2K")
+
+        row = await acct.fetch_only_row()
+        assert row["provider"] == "gemini-aistudio"
+
+    def test_media_backend_without_provider_id_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError):
+            MediaGenerator(
+                tmp_path / "projects" / "demo",
+                image_backend=_FakeImageBackend(provider="gemini", model="m"),
+                image_provider_id=None,
+            )
+
+    def test_media_provider_id_without_backend_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError):
+            MediaGenerator(
+                tmp_path / "projects" / "demo",
+                video_provider_id="gemini-aistudio",
+            )
+
+    def test_text_missing_provider_id_raises(self, acct: _AccountingDb) -> None:
+        with pytest.raises(ValueError):
+            TextGenerator(
+                _FakeTextBackend(provider="gemini", model="m"),
+                Ledger(session_factory=acct.factory),
+                cast(str, None),
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -30,7 +30,7 @@ class _FakeTextBackend:
 
 
 async def _fake_create_backend(*args, **kwargs):
-    return _FakeTextBackend()
+    return _FakeTextBackend(), "fake"
 
 
 def _img_bytes(fmt="JPEG"):

--- a/tests/test_media_generator_image_capability.py
+++ b/tests/test_media_generator_image_capability.py
@@ -24,6 +24,7 @@ async def test_t2i_call_with_i2i_only_backend_raises(tmp_path):
     g = MediaGenerator(
         project_path=tmp_path,
         image_backend=backend,
+        image_provider_id="fake",
     )
     with pytest.raises(ImageCapabilityError) as excinfo:
         await g.generate_image_async(
@@ -45,6 +46,7 @@ async def test_i2i_call_with_t2i_only_backend_raises(tmp_path):
     g = MediaGenerator(
         project_path=tmp_path,
         image_backend=backend,
+        image_provider_id="fake",
     )
     ref = tmp_path / "ref.png"
     ref.write_bytes(b"\x89PNG")

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -586,7 +586,7 @@ class TestProjectManagerMore:
         assert "1.txt" in content
 
         async def _fake_create_backend(*args, **kwargs):
-            return _FakeTextBackend()
+            return _FakeTextBackend(), "gemini-aistudio"
 
         monkeypatch.setattr("lib.text_generator.create_text_backend_for_task", _fake_create_backend)
         overview = await pm.generate_overview("demo")
@@ -617,7 +617,7 @@ class TestProjectManagerMore:
         _write(pm.get_project_path("demo") / "source" / "1.txt", "source body")
 
         async def _fake_create_backend(*args, **kwargs):
-            return _FakeTextBackend(language=lang)
+            return _FakeTextBackend(language=lang), "gemini-aistudio"
 
         monkeypatch.setattr("lib.text_generator.create_text_backend_for_task", _fake_create_backend)
         overview = await pm.generate_overview("demo")
@@ -635,7 +635,7 @@ class TestProjectManagerMore:
         _write(pm.get_project_path("demo") / "source" / "1.txt", "source body")
 
         async def _fake_create_backend(*args, **kwargs):
-            return _FakeTextBackend(language="chinese")  # 非枚举值
+            return _FakeTextBackend(language="chinese"), "gemini-aistudio"  # 非枚举值
 
         monkeypatch.setattr("lib.text_generator.create_text_backend_for_task", _fake_create_backend)
         with pytest.raises(ValidationError):
@@ -657,7 +657,7 @@ class TestProjectManagerMore:
         backend = _FakeTextBackend()
 
         async def _fake_create_backend(*args, **kwargs):
-            return backend
+            return backend, "gemini-aistudio"
 
         monkeypatch.setattr("lib.text_generator.create_text_backend_for_task", _fake_create_backend)
         await pm.generate_overview("demo")
@@ -685,7 +685,7 @@ class TestProjectManagerMore:
         backend = _FakeTextBackend()
 
         async def _fake_create_backend(*args, **kwargs):
-            return backend
+            return backend, "gemini-aistudio"
 
         monkeypatch.setattr("lib.text_generator.create_text_backend_for_task", _fake_create_backend)
         await pm.generate_overview("demo")
@@ -714,7 +714,7 @@ class TestProjectManagerMore:
         backend = _FakeTextBackend()
 
         async def _fake_create_backend(*args, **kwargs):
-            return backend
+            return backend, "gemini-aistudio"
 
         monkeypatch.setattr("lib.text_generator.create_text_backend_for_task", _fake_create_backend)
         await pm.generate_overview("demo")

--- a/tests/test_text_backends/test_factory.py
+++ b/tests/test_text_backends/test_factory.py
@@ -39,7 +39,7 @@ async def test_creates_gemini_aistudio_backend():
         mock_backend = MagicMock()
         mock_create.return_value = mock_backend
 
-        result = await create_text_backend_for_task(TextTaskType.SCRIPT)
+        backend, provider_id = await create_text_backend_for_task(TextTaskType.SCRIPT)
 
         # aistudio：base_url 无条件透传用户值（含空串），由 backend 内部处理
         mock_create.assert_called_once_with(
@@ -48,7 +48,9 @@ async def test_creates_gemini_aistudio_backend():
             api_key="test-key",
             base_url="",
         )
-        assert result is mock_backend
+        assert backend is mock_backend
+        # 工厂随 backend 返回解析层 provider_id（记账单一真相源）
+        assert provider_id == "gemini-aistudio"
 
 
 async def test_creates_ark_backend():
@@ -64,7 +66,7 @@ async def test_creates_ark_backend():
         mock_backend = MagicMock()
         mock_create.return_value = mock_backend
 
-        result = await create_text_backend_for_task(TextTaskType.OVERVIEW, "my-project")
+        backend, provider_id = await create_text_backend_for_task(TextTaskType.OVERVIEW, "my-project")
 
         # ark：用户未配 base_url → 回落 registry default
         mock_create.assert_called_once_with(
@@ -73,7 +75,8 @@ async def test_creates_ark_backend():
             api_key="ark-key",
             base_url="https://ark.cn-beijing.volces.com/api/v3",
         )
-        assert result is mock_backend
+        assert backend is mock_backend
+        assert provider_id == "ark"
 
 
 async def test_creates_ark_agent_plan_backend_uses_plan_endpoint():
@@ -91,7 +94,7 @@ async def test_creates_ark_agent_plan_backend_uses_plan_endpoint():
         mock_backend = MagicMock()
         mock_create.return_value = mock_backend
 
-        await create_text_backend_for_task(TextTaskType.OVERVIEW, "my-project")
+        backend, provider_id = await create_text_backend_for_task(TextTaskType.OVERVIEW, "my-project")
 
         mock_create.assert_called_once_with(
             "ark-agent-plan",
@@ -99,6 +102,9 @@ async def test_creates_ark_agent_plan_backend_uses_plan_endpoint():
             api_key="ark-plan-key",
             base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
         )
+        assert backend is mock_backend
+        # ark-agent-plan 复用 ArkTextBackend（name 报 "ark"），记账须取解析层 id "ark-agent-plan"
+        assert provider_id == "ark-agent-plan"
 
 
 async def test_user_base_url_overrides_default_for_ark_agent_plan():
@@ -128,7 +134,7 @@ async def test_creates_vertex_backend():
         mock_backend = MagicMock()
         mock_create.return_value = mock_backend
 
-        result = await create_text_backend_for_task(TextTaskType.STYLE_ANALYSIS)
+        backend, provider_id = await create_text_backend_for_task(TextTaskType.STYLE_ANALYSIS)
 
         mock_create.assert_called_once_with(
             "gemini",
@@ -136,7 +142,8 @@ async def test_creates_vertex_backend():
             backend="vertex",
             gcs_bucket="my-bucket",
         )
-        assert result is mock_backend
+        assert backend is mock_backend
+        assert provider_id == "gemini-vertex"
 
 
 async def test_creates_grok_backend_omits_base_url_when_unset():

--- a/tests/test_text_generator.py
+++ b/tests/test_text_generator.py
@@ -53,8 +53,9 @@ def _make_backend(provider="gemini", model="gemini-3-flash-preview"):
 
 class TestTextGenerator:
     async def test_generate_records_usage_on_success(self, wired):
+        # backend.name 为裸 "gemini"，记账须取解析层 provider_id（"gemini-aistudio"）。
         backend = _make_backend()
-        gen = TextGenerator(backend, wired.ledger)
+        gen = TextGenerator(backend, wired.ledger, "gemini-aistudio")
 
         result = await gen.generate(
             TextGenerationRequest(prompt="测试"),
@@ -72,13 +73,13 @@ class TestTextGenerator:
         assert item["status"] == "success"
         assert item["input_tokens"] == 100
         assert item["output_tokens"] == 50
-        assert item["provider"] == "gemini"
+        assert item["provider"] == "gemini-aistudio"
         assert item["cost_amount"] == pytest.approx((100 * 0.50 + 50 * 3.00) / 1_000_000)
 
     async def test_generate_records_usage_on_failure(self, wired):
         backend = _make_backend()
         backend.generate = AsyncMock(side_effect=RuntimeError("API 超时"))
-        gen = TextGenerator(backend, wired.ledger)
+        gen = TextGenerator(backend, wired.ledger, "gemini-aistudio")
 
         with pytest.raises(RuntimeError, match="API 超时"):
             await gen.generate(
@@ -95,7 +96,7 @@ class TestTextGenerator:
 
     async def test_generate_without_project_name(self, wired):
         backend = _make_backend()
-        gen = TextGenerator(backend, wired.ledger)
+        gen = TextGenerator(backend, wired.ledger, "gemini-aistudio")
 
         result = await gen.generate(TextGenerationRequest(prompt="工具箱调用"))
 

--- a/tests/test_tts_skeleton.py
+++ b/tests/test_tts_skeleton.py
@@ -144,6 +144,7 @@ def _build_generator(tmp_path: Path) -> MediaGenerator:
     gen._image_backend = None
     gen._video_backend = None
     gen._audio_backend = _FakeAudioBackend()
+    gen._audio_provider_id = "fake-audio"
     gen._user_id = "default"
     gen._config = None
     gen.versions = _FakeVersions()


### PR DESCRIPTION
Closes #1183

## 变更

记账 provider 身份的单一真相源从 `backend.name` 反转为配置解析层的 registry `provider_id`。`backend.name` 退出记账链路，仅保留生成调用与日志/错误上下文用途。用户可感知效果：Gemini 文本调用与图像/视频调用自新调用起按同一供应商身份（`gemini-aistudio`）合组显示。

- **构造期成对不变量** `lib/providers.py::require_provider_pair`：媒体三 lane（image/video/audio）与文本在构造期各校验一次，backend 与 provider_id 缺一即抛 `ValueError`；不引入调用期逐次校验、不设豁免名单。
- **贯通改动**：文本工厂随 backend 返回 `provider_id`（返回类型 `TextBackend` → `tuple[TextBackend, str]`）；`TextGenerator` 构造增 `provider_id`；`MediaGenerator` 补 `audio_provider_id`，三条 lane 记账改取对应 `_X_provider_id`；两处生产构造点补 audio 贯通。
- **报表存量兜底**：`usage_repo` 对历史裸 `gemini` 行按 `_LEGACY_PROVIDER_DISPLAY_NAMES` 补友好显示名，不迁移历史落账值。

## 身份 delta 白名单（解析 id vs 现状 name）

仅两处语义变更，均为 issue 验收意图内：
- 文本 gemini（aistudio）：裸 `gemini` → `gemini-aistudio`（本票核心修复）
- 文本 ark-agent-plan（复用 ArkTextBackend）：`ark` → `ark-agent-plan`

OpenAI 兼容族（openai/dashscope/minimax）、媒体 gemini、custom-N、agent 会话回填等其余 backend 的 `name` 恒等于解析 id，零 delta；特征化矩阵除上述身份字段外零改动。

## 审查修复（本地审查阶段追加）

- 补 `test_factory.py` 对 ark-agent-plan 的 `provider_id == "ark-agent-plan"` 断言，锁定白名单第二条 delta（原缺测试覆盖）。
- `generation_tasks.py::_resolve_video_backend`：无 payload 时不构造 video_backend，同步返回 `provider_id=None`，使返回值与新成对不变量一致，规避未来空/None payload 调用在构造期误抛。

## 验证

- `uv run python -m pytest`：6159 passed
- `uv run ruff check .` / `ruff format .`：全过
- `uv run basedpyright`：0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 优化文本、图片、视频和音频生成的供应商标识记录，账单与用量统计显示更准确。
  - 为历史数据补充更友好的供应商名称展示，例如将旧版 Gemini 标识显示为“Gemini”。

- **问题修复**
  - 增强生成服务配置校验，避免供应商信息不完整导致运行时异常或错误记账。
  - 修复自定义供应商名称与实际账单归属不一致的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->