### PR TITLE
fix(cost): 费用预估贯通自定义供应商价格，图片/Grid/视频/音频不再恒显 0

### DIFF
--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -61,7 +61,11 @@ class CostEstimationService:
         """
         if not is_custom_provider(provider):
             return _NO_CUSTOM_PRICE
-        price_model = await CustomProviderRepository(session).get_model_by_ids(parse_provider_id(provider), model or "")
+        try:
+            db_id = parse_provider_id(provider)
+        except ValueError:
+            return _NO_CUSTOM_PRICE
+        price_model = await CustomProviderRepository(session).get_model_by_ids(db_id, model or "")
         if price_model is None:
             return _NO_CUSTOM_PRICE
         return _CustomPrice(price_model.price_input, price_model.price_output, price_model.currency)

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -62,10 +62,12 @@ class CostEstimationService:
         if not is_custom_provider(provider):
             return _NO_CUSTOM_PRICE
         try:
-            db_id = parse_provider_id(provider)
-        except ValueError:
+            price_model = await CustomProviderRepository(session).get_model_by_ids(
+                parse_provider_id(provider), model or ""
+            )
+        except Exception:
+            logger.debug("自定义供应商价格查询失败 provider=%s model=%s", provider, model, exc_info=True)
             return _NO_CUSTOM_PRICE
-        price_model = await CustomProviderRepository(session).get_model_by_ids(db_id, model or "")
         if price_model is None:
             return _NO_CUSTOM_PRICE
         return _CustomPrice(price_model.price_input, price_model.price_output, price_model.currency)

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Any
+from typing import Any, NamedTuple
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from lib.config.resolver import ConfigResolver, get_provider_fallback
 from lib.cost_calculator import cost_calculator
+from lib.custom_provider import is_custom_provider, parse_provider_id
+from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.db.repositories.usage_repo import UsageRepository
 from lib.grid.layout import calculate_grid_layout
 from lib.pricing.strategies import PricingParams
@@ -20,6 +22,17 @@ from lib.storyboard_sequence import get_storyboard_items, group_scenes_by_segmen
 logger = logging.getLogger(__name__)
 
 CostBreakdown = dict[str, float]
+
+
+class _CustomPrice(NamedTuple):
+    """自定义供应商价格三元组，作为 ``calculate_cost`` 的 ``custom_price_*`` 入参来源。"""
+
+    price_input: float | None
+    price_output: float | None
+    currency: str | None
+
+
+_NO_CUSTOM_PRICE = _CustomPrice(None, None, None)
 
 
 def _add_cost(target: CostBreakdown, amount: float, currency: str) -> None:
@@ -39,6 +52,19 @@ class CostEstimationService:
     def __init__(self, resolver: ConfigResolver, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._resolver = resolver
         self._session_factory = session_factory
+
+    @staticmethod
+    async def _resolve_custom_price(session: AsyncSession, provider: str, model: str) -> _CustomPrice:
+        """自定义供应商价格取数（与实际记账链路 usage_repo 同源）。
+
+        预置供应商或查无价格模型时返回空价格；calculate_cost 对自定义供应商缺价时计为 0。
+        """
+        if not is_custom_provider(provider):
+            return _NO_CUSTOM_PRICE
+        price_model = await CustomProviderRepository(session).get_model_by_ids(parse_provider_id(provider), model or "")
+        if price_model is None:
+            return _NO_CUSTOM_PRICE
+        return _CustomPrice(price_model.price_input, price_model.price_output, price_model.currency)
 
     async def compute(
         self,
@@ -85,9 +111,12 @@ class CostEstimationService:
                 _resolved_resolution = None
         video_resolution = _resolved_resolution or get_provider_fallback(video_provider)
 
-        # Get actual costs
+        # Get actual costs + 自定义供应商价格（缺则预估恒为零，需与实际记账同源预查 DB 单价）
         async with self._session_factory() as session:
             actual_by_segment = await UsageRepository(session).get_actual_costs_by_segment(project_name)
+            image_price = await self._resolve_custom_price(session, image_provider, image_model)
+            video_price = await self._resolve_custom_price(session, video_provider, video_model)
+            audio_price = await self._resolve_custom_price(session, audio_provider, audio_model)
 
         generation_mode = project_data.get("generation_mode", "single")
         # 规范化 aspect_ratio：可能是 str 或 dict，复用生成任务的解析逻辑
@@ -107,6 +136,9 @@ class CostEstimationService:
             image_unit_cost = cost_calculator.calculate_cost(
                 image_provider,
                 PricingParams(call_type="image", model=image_model, resolution="1K"),
+                custom_price_input=image_price.price_input,
+                custom_price_output=image_price.price_output,
+                custom_currency=image_price.currency,
             )
         except Exception:
             logger.debug("无法计算 image 预估单价", exc_info=True)
@@ -116,6 +148,9 @@ class CostEstimationService:
                 grid_image_unit_cost = cost_calculator.calculate_cost(
                     image_provider,
                     PricingParams(call_type="image", model=image_model, resolution="2K"),
+                    custom_price_input=image_price.price_input,
+                    custom_price_output=image_price.price_output,
+                    custom_currency=image_price.currency,
                 )
             except Exception:
                 grid_image_unit_cost = image_unit_cost
@@ -212,6 +247,9 @@ class CostEstimationService:
                             duration_seconds=duration,
                             generate_audio=generate_audio,
                         ),
+                        custom_price_input=video_price.price_input,
+                        custom_price_output=video_price.price_output,
+                        custom_currency=video_price.currency,
                     )
                     _add_cost(est_video, vid_amount, vid_currency)
                 except Exception:
@@ -225,6 +263,9 @@ class CostEstimationService:
                         audio_amount, audio_currency = cost_calculator.calculate_cost(
                             audio_provider,
                             PricingParams(call_type="audio", model=audio_model, usage_tokens=narration_chars),
+                            custom_price_input=audio_price.price_input,
+                            custom_price_output=audio_price.price_output,
+                            custom_currency=audio_price.currency,
                         )
                         _add_cost(est_audio, audio_amount, audio_currency)
                     except Exception:

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -706,3 +706,21 @@ class TestCostEstimationService:
         # 缺价 → calculate_cost 返回 0，_add_cost 过滤，image 估值为空且未抛错
         seg = result["episodes"][0]["segments"][0]
         assert seg["estimate"]["image"] == {}
+
+    async def test_custom_provider_malformed_id_degrades_to_zero(self, db_factory):
+        """畸形 custom- provider id（非数字后缀）：parse_provider_id 的 ValueError 需降级为 0，不抛错。"""
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "image_provider_t2i": "custom-abc/ghost",  # 写入侧校验只查前缀，后缀非数字仍可能入库
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_script(1, ["E1S001"], [6])}
+
+        result = await service.compute(project_data, scripts, project_name="test-malformed-id")
+
+        seg = result["episodes"][0]["segments"][0]
+        assert seg["estimate"]["image"] == {}

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -703,6 +703,8 @@ class TestCostEstimationService:
 
         result = await service.compute(project_data, scripts, project_name="test-noprice")
 
+        # 断言解析到的仍是该自定义 provider/model，排除 resolver 回落 unknown 导致的同结果假阳性
+        assert result["models"]["image"] == {"provider": "custom-99", "model": "ghost"}
         # 缺价 → calculate_cost 返回 0，_add_cost 过滤，image 估值为空且未抛错
         seg = result["episodes"][0]["segments"][0]
         assert seg["estimate"]["image"] == {}
@@ -722,5 +724,7 @@ class TestCostEstimationService:
 
         result = await service.compute(project_data, scripts, project_name="test-malformed-id")
 
+        # 断言解析到的仍是该畸形 provider/model，排除 resolver 回落 unknown 导致的同结果假阳性
+        assert result["models"]["image"] == {"provider": "custom-abc", "model": "ghost"}
         seg = result["episodes"][0]["segments"][0]
         assert seg["estimate"]["image"] == {}

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -575,3 +575,134 @@ class TestCostEstimationService:
 
         # compute() 不因 resolve_resolution 异常而中断，其余字段照常返回
         assert result["models"]["video"]["provider"] == "unknown"
+
+    async def test_custom_provider_estimates_use_db_prices(self, db_factory):
+        """自定义供应商预估：image/video/audio 单价来自 DB（与实际记账同源），估值按配置价格非零。"""
+        from lib.db.repositories.custom_provider_repo import CustomProviderRepository
+
+        async with db_factory() as session:
+            await CustomProviderRepository(session).create_provider(
+                display_name="Custom",
+                discovery_format="openai",
+                base_url="https://api.example.com",
+                api_key="k",
+                models=[
+                    {
+                        "model_id": "img",
+                        "display_name": "Img",
+                        "endpoint": "openai-images",
+                        "price_unit": "image",
+                        "price_input": 0.05,
+                        "currency": "USD",
+                    },
+                    {
+                        "model_id": "vid",
+                        "display_name": "Vid",
+                        "endpoint": "openai-video",
+                        "price_unit": "second",
+                        "price_input": 0.10,
+                        "currency": "USD",
+                    },
+                    {
+                        "model_id": "aud",
+                        "display_name": "Aud",
+                        "endpoint": "openai-tts",
+                        "price_unit": "character",
+                        "price_input": 2.0,
+                        "currency": "CNY",
+                    },
+                ],
+            )
+            await session.commit()
+
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "image_provider_t2i": "custom-1/img",
+            "video_backend": "custom-1/vid",
+            "audio_backend": "custom-1/aud",
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        script = _make_script(1, ["E1S001"], [6])
+        script["segments"][0]["novel_text"] = "字" * 10000  # 1 万字符
+        scripts = {"ep1.json": script}
+
+        result = await service.compute(project_data, scripts, project_name="test-custom")
+
+        assert result["models"]["image"] == {"provider": "custom-1", "model": "img"}
+        seg = result["episodes"][0]["segments"][0]
+        # image：自定义供应商按张计费，flat 0.05 USD（不随 1K/2K 变化）
+        assert seg["estimate"]["image"]["USD"] == pytest.approx(0.05)
+        # video：时长 6s × 0.10 = 0.60 USD
+        assert seg["estimate"]["video"]["USD"] == pytest.approx(0.60)
+        # audio：10000 字符 / 10000 × 2.0 = 2.0 CNY
+        assert seg["estimate"]["audio"]["CNY"] == pytest.approx(2.0)
+        # 集/项目两级合计同步纳入
+        assert result["project_totals"]["estimate"]["video"]["USD"] == pytest.approx(0.60)
+
+    async def test_custom_provider_grid_estimate_uses_db_price(self, db_factory):
+        """grid 模式下自定义供应商图片单价同样贯通（2K grid 单价 = DB flat 价）。"""
+        from lib.db.repositories.custom_provider_repo import CustomProviderRepository
+
+        async with db_factory() as session:
+            await CustomProviderRepository(session).create_provider(
+                display_name="Custom",
+                discovery_format="openai",
+                base_url="https://api.example.com",
+                api_key="k",
+                models=[
+                    {
+                        "model_id": "img",
+                        "display_name": "Img",
+                        "endpoint": "openai-images",
+                        "price_unit": "image",
+                        "price_input": 0.09,
+                        "currency": "USD",
+                    },
+                ],
+            )
+            await session.commit()
+
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        seg_ids = [f"E1S{i:03d}" for i in range(1, 10)]  # 9 scenes → 1 张 grid_9
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "grid",
+            "image_provider_t2i": "custom-1/img",
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_script(1, seg_ids, [6] * 9)}
+
+        result = await service.compute(project_data, scripts, project_name="test-grid-custom")
+
+        # 9 格拼成 1 张 grid，flat 0.09 USD 摊到 9 格 → 每格 0.01 USD
+        segments = result["episodes"][0]["segments"]
+        for seg in segments:
+            assert seg["estimate"]["image"]["USD"] == pytest.approx(round(0.09 / 9, 6))
+        # 集合计 = 满张单价 0.09 USD
+        assert result["episodes"][0]["totals"]["estimate"]["image"]["USD"] == pytest.approx(0.09, abs=1e-4)
+
+    async def test_custom_provider_without_price_degrades_to_zero(self, db_factory):
+        """自定义供应商查无价格模型：预估降级为 0（记 debug 日志、不抛错），与现状降级口径一致。"""
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "image_provider_t2i": "custom-99/ghost",  # DB 无此供应商/模型
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_script(1, ["E1S001"], [6])}
+
+        result = await service.compute(project_data, scripts, project_name="test-noprice")
+
+        # 缺价 → calculate_cost 返回 0，_add_cost 过滤，image 估值为空且未抛错
+        seg = result["episodes"][0]["segments"][0]
+        assert seg["estimate"]["image"] == {}


### PR DESCRIPTION
## 背景

`server/services/cost_estimation.py` 中四处 `calculate_cost` 调用（image 单价、grid 单价、video、audio）未传 `custom_price_*`。`CostCalculator.calculate_cost` 对自定义供应商依赖调用方预先查询 DB 单价，缺省时预估恒为零——用户配置自定义供应商后，项目/单集/单镜头预估中图片、Grid、视频、音频金额显示 0。

## 改动

- 新增 `_resolve_custom_price(session, provider, model)`：与实际记账链路 `usage_repo.py:222-234` 同源取数——`is_custom_provider` 判定 → `CustomProviderRepository.get_model_by_ids(parse_provider_id(provider), model or "")` → 取 `price_input/price_output/currency`；预置供应商或查无模型返回空价格。
- 在既有 actual-costs 的 session 块内预查 image/video/audio 三个媒体维度的自定义价格（复用同一 session，不新开）。
- 四处 `calculate_cost` 调用点补传 `custom_price_input/output/currency`。
- 预置供应商注册表费率路径、缺价降级口径（`calculate_cost` 返回 0 + `except` debug 日志）零改动。

## 验证

- `uv run python -m pytest`：**6169 passed**
- 新增 3 个测试：自定义供应商 image/video/audio 按 DB 价非零、grid_9 摊分、缺价降级为 0 不抛错
- `ruff check` + `format --check` 干净、`basedpyright` 0 error

Closes #1210


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 成本预估现在支持从数据库读取自定义供应商/模型价格，用于图片、2K 网格图片、视频（按时长）与音频（按文本换算 tokens）单价计算；分段、剧集与项目汇总结果将同步反映自定义价格。

* **错误修复**
  * 当自定义供应商价格模型缺失或价格解析/查找失败时，不再中断；对应预估将退化为空结果（按零成本语义处理）。

* **测试**
  * 新增 4 条用例，覆盖自定义价格贯通、网格摊分、缺价降级以及畸形标识降级行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->