### PR TITLE
fix(dashboard): 任务 HUD 的 task_type 标签本地化（zh/en/vi）

### DIFF
--- a/frontend/src/components/task-hud/TaskHud.tsx
+++ b/frontend/src/components/task-hud/TaskHud.tsx
@@ -181,7 +181,7 @@ function TaskRow({
           className="flex-1 truncate"
           style={{ color: "var(--color-text-2)" }}
         >
-          {task.task_type}
+          {t(`task_type_${task.task_type}`, { defaultValue: task.task_type })}
         </span>
         <span
           className="text-[10.5px]"
@@ -679,7 +679,10 @@ export function TaskHud({ anchorRef }: { anchorRef: RefObject<HTMLElement | null
                 >
                   {cancelConfirm.preview.cascaded.map((task) => (
                     <li key={task.task_id}>
-                      {task.task_type} / {task.resource_id}
+                      {t(`task_type_${task.task_type}`, {
+                        defaultValue: task.task_type,
+                      })}{" "}
+                      / {task.resource_id}
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/components/task-hud/__tests__/TaskHud.taskType.test.tsx
+++ b/frontend/src/components/task-hud/__tests__/TaskHud.taskType.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useRef } from "react";
+import { TaskHud } from "@/components/task-hud/TaskHud";
+import { useAppStore } from "@/stores/app-store";
+import { useTasksStore } from "@/stores/tasks-store";
+import { makeTask } from "@/test/factories";
+import i18n from "@/i18n";
+
+// issue #1218：任务 HUD 的 task_type 标签本地化。已知类型经 i18n key 映射显示；
+// 词表外的未知类型机械兜底显示原始串（不做语义猜测映射）。
+
+function HostedTaskHud() {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  return (
+    <div>
+      <div ref={anchorRef} data-testid="anchor" />
+      <TaskHud anchorRef={anchorRef} />
+    </div>
+  );
+}
+
+function resetStores() {
+  useAppStore.setState({ taskHudOpen: true });
+  useTasksStore.setState({
+    tasks: [],
+    stats: { queued: 0, running: 0, cancelling: 0, succeeded: 0, failed: 0, cancelled: 0, total: 0 },
+  });
+}
+
+describe("TaskHud task_type label", () => {
+  afterEach(() => {
+    cleanup();
+    useAppStore.setState({ taskHudOpen: false });
+    useTasksStore.setState({
+      tasks: [],
+      stats: { queued: 0, running: 0, cancelling: 0, succeeded: 0, failed: 0, cancelled: 0, total: 0 },
+    });
+  });
+
+  it("renders localized label for a known task_type (zh)", async () => {
+    await i18n.changeLanguage("zh");
+    resetStores();
+    useTasksStore.setState({
+      tasks: [
+        makeTask({ task_id: "known-zh", task_type: "image_edit", media_type: "image" }),
+      ],
+    });
+
+    render(<HostedTaskHud />);
+    expect(await screen.findByText("图片编辑")).toBeInTheDocument();
+    expect(screen.queryByText("image_edit")).toBeNull();
+  });
+
+  it("renders localized label for a known task_type (en)", async () => {
+    await i18n.changeLanguage("en");
+    resetStores();
+    useTasksStore.setState({
+      tasks: [makeTask({ task_id: "known-en", task_type: "storyboard", media_type: "image" })],
+    });
+
+    render(<HostedTaskHud />);
+    expect(await screen.findByText("Storyboard")).toBeInTheDocument();
+    await i18n.changeLanguage("zh");
+  });
+
+  it("falls back to the raw string for an unknown task_type", async () => {
+    await i18n.changeLanguage("zh");
+    resetStores();
+    useTasksStore.setState({
+      tasks: [
+        makeTask({ task_id: "unknown-1", task_type: "some_future_type", media_type: "image" }),
+      ],
+    });
+
+    render(<HostedTaskHud />);
+    expect(await screen.findByText("some_future_type")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/task-hud/__tests__/TaskHud.taskType.test.tsx
+++ b/frontend/src/components/task-hud/__tests__/TaskHud.taskType.test.tsx
@@ -29,8 +29,9 @@ function resetStores() {
 }
 
 describe("TaskHud task_type label", () => {
-  afterEach(() => {
+  afterEach(async () => {
     cleanup();
+    await i18n.changeLanguage("zh");
     useAppStore.setState({ taskHudOpen: false });
     useTasksStore.setState({
       tasks: [],
@@ -61,7 +62,6 @@ describe("TaskHud task_type label", () => {
 
     render(<HostedTaskHud />);
     expect(await screen.findByText("Storyboard")).toBeInTheDocument();
-    await i18n.changeLanguage("zh");
   });
 
   it("falls back to the raw string for an unknown task_type", async () => {

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -386,6 +386,19 @@ export default {
   'cancelling': 'Cancelling...',
   'confirm_cancel': 'Confirm Cancel',
   'go_back': 'Back',
+  // task_type display names (backend task_type has no central enum — scattered
+  // literals at enqueue call sites + lib/asset_types.ASSET_SPECS keys; unknown
+  // values outside this table fall back to the raw string on the frontend)
+  'task_type_image_edit': 'Image Edit',
+  'task_type_storyboard': 'Storyboard',
+  'task_type_video': 'Video',
+  'task_type_reference_video': 'Reference Video',
+  'task_type_tts': 'Voiceover',
+  'task_type_grid': 'Grid',
+  'task_type_character': 'Character',
+  'task_type_scene': 'Scene',
+  'task_type_prop': 'Prop',
+  'task_type_product': 'Product',
 
   // AgentCopilot
   'new_session': 'New Session',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -376,6 +376,19 @@ export default {
   'cancelling': 'Đang hủy...',
   'confirm_cancel': 'Xác nhận hủy',
   'go_back': 'Quay lại',
+  // task_type display names (backend task_type không có enum tập trung — literal
+  // rải rác tại các điểm enqueue + key của lib/asset_types.ASSET_SPECS; giá trị
+  // ngoài bảng này sẽ hiển thị nguyên chuỗi gốc ở frontend)
+  'task_type_image_edit': 'Chỉnh sửa ảnh',
+  'task_type_storyboard': 'Storyboard',
+  'task_type_video': 'Video',
+  'task_type_reference_video': 'Video tham chiếu',
+  'task_type_tts': 'Giọng thuyết minh',
+  'task_type_grid': 'Lưới',
+  'task_type_character': 'Nhân vật',
+  'task_type_scene': 'Cảnh',
+  'task_type_prop': 'Đạo cụ',
+  'task_type_product': 'Sản phẩm',
 
   // AgentCopilot
   'new_session': 'Phiên mới',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -387,6 +387,18 @@ export default {
   'cancelling': '取消中...',
   'confirm_cancel': '确认取消',
   'go_back': '返回',
+  // task_type display names（后端 task_type 无集中枚举，散落在各入队调用点字面量 +
+  // lib/asset_types.ASSET_SPECS 的 key；词表外未知值前端兜底显示原始串）
+  'task_type_image_edit': '图片编辑',
+  'task_type_storyboard': '分镜图',
+  'task_type_video': '视频',
+  'task_type_reference_video': '参考视频',
+  'task_type_tts': '配音',
+  'task_type_grid': '宫格图',
+  'task_type_character': '角色',
+  'task_type_scene': '场景',
+  'task_type_prop': '道具',
+  'task_type_product': '产品',
 
   // AgentCopilot
   'new_session': '新会话',

--- a/tests/test_frontend_task_type_i18n.py
+++ b/tests/test_frontend_task_type_i18n.py
@@ -1,0 +1,77 @@
+"""Cross-check that every backend task_type has a frontend display name.
+
+``task_type`` has no centralized backend enum: it's a plain ``String`` column
+(``lib/db/models/task.py``) populated either by fixed literal call sites
+(``server/routers/generate.py``, ``server/routers/grids.py``,
+``server/routers/reference_videos.py``, ``server/agent_runtime/sdk_tools/enqueue_*.py``)
+or dynamically from :data:`ASSET_SPECS` keys (``lib/asset_types.py``) via
+``server/agent_runtime/sdk_tools/enqueue_assets.py``. The frontend Task HUD
+(``frontend/src/components/task-hud/TaskHud.tsx``) renders each task's type by
+looking up ``task_type_<type>`` in the ``dashboard`` i18n namespace; if a
+backend task_type ships without a corresponding ``task_type_<type>`` key in
+zh/en/vi, the label falls back to the raw task_type string. This test fails CI
+in that case so the gap is caught at PR time.
+
+The fixed literals below were enumerated by grepping every ``task_type="..."``
+and ``task_type=asset_type``/``task_type=spec.task_type`` call site in
+``server/`` and ``lib/`` (2026-07-17) — not from memory. Any new fixed literal
+task_type introduced by future backend changes must be added here alongside
+its zh/en/vi translations.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from lib.asset_types import ASSET_SPECS
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DASHBOARD_TS = "frontend/src/i18n/{locale}/dashboard.ts"
+LOCALES = ("zh", "en", "vi")
+
+FIXED_TASK_TYPES = frozenset(
+    {
+        "image_edit",
+        "storyboard",
+        "video",
+        "reference_video",
+        "tts",
+        "grid",
+    }
+)
+
+ALL_TASK_TYPES = FIXED_TASK_TYPES | frozenset(ASSET_SPECS.keys())
+
+_KEY_RE = re.compile(r"""['"](task_type_[a-z0-9_]+)['"]\s*:""")
+
+
+def _load_task_type_keys(locale: str) -> set[str]:
+    path = REPO_ROOT / DASHBOARD_TS.format(locale=locale)
+    text = path.read_text(encoding="utf-8")
+    return set(_KEY_RE.findall(text))
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+def test_every_task_type_has_frontend_display_name(locale: str) -> None:
+    keys = _load_task_type_keys(locale)
+    expected = {f"task_type_{t}" for t in ALL_TASK_TYPES}
+    missing = expected - keys
+    assert not missing, (
+        f"frontend/src/i18n/{locale}/dashboard.ts 缺少 task_type 显示名翻译: {sorted(missing)}。"
+        f" 固定字面量见本文件 FIXED_TASK_TYPES，动态部分单一真相源在 lib/asset_types.ASSET_SPECS。"
+    )
+
+
+def test_no_orphan_task_type_keys_in_any_locale() -> None:
+    """Frontend task_type_* keys 必须都对应已知 task_type —— 防止过时翻译堆积。"""
+    expected = {f"task_type_{t}" for t in ALL_TASK_TYPES}
+    for locale in LOCALES:
+        keys = _load_task_type_keys(locale)
+        orphans = keys - expected
+        assert not orphans, (
+            f"frontend/src/i18n/{locale}/dashboard.ts 存在与已知 task_type 不匹配的 task_type_* key: "
+            f"{sorted(orphans)}。请删除或更新本文件的 FIXED_TASK_TYPES。"
+        )


### PR DESCRIPTION
## 背景

任务 HUD 中每条任务的类型标签直接渲染 `task.task_type` 原始英文串（`image_edit`、`storyboard`、`character` 等），未经 i18n，属存量违例（面向用户的文本须有 zh/en/vi 三语）。

## 改动

- **`TaskHud.tsx` 两处渲染点**均改为 `t(\`task_type_${task.task_type}\`, { defaultValue: task.task_type })`：任务行主标签（`TaskRow`）+ 级联取消预览列表。复用仓库既有 `tool_name_`/`skill_name_` 的 key + defaultValue 兜底模式，未引入新范式。
- **三语补全**：`frontend/src/i18n/{zh,en,vi}/dashboard.ts` 各新增 10 个 `task_type_<type>` key，覆盖代码中现存全部 task_type。
  - 固定字面量 6 个：`image_edit` / `storyboard` / `video` / `reference_video` / `tts` / `grid`
  - `lib/asset_types.ASSET_SPECS` 派生 4 个：`character` / `scene` / `prop` / `product`
- **词表外未知 task_type**：defaultValue 机械兜底显示原始串，不做语义猜测映射。
- **仅改前端展示层与翻译文件**，未动任务数据结构与后端。

## task_type 全集核实

后端 `task_type` 无集中枚举（`lib/db/models/task.py` 为裸 `String` 列）。全集经逐一 grep 所有 `enqueue_task` 调用点核实：6 个固定字面量 + `ASSET_SPECS` 派生 4 个 = 10 个。`server/routers/shot_uploads.py` 的 `emit_generation_success_batch(task_type=kind)` 为项目事件非队列任务，且 `kind ∈ {storyboard, video}` 已覆盖。

## 验证

- 新增 `tests/test_frontend_task_type_i18n.py`：以 `ASSET_SPECS` 为动态部分单一真相源，双向校验三语（缺失 key / 孤儿 key），后端新增 task_type 漏补翻译时 CI 失败。
- 新增 `frontend/.../TaskHud.taskType.test.tsx`：已知类型渲染本地化文案、未知类型兜底原始串。
- 质量门全绿：`pnpm lint && pnpm check`（110 文件 / 993 测试）、`tests/test_frontend_task_type_i18n.py` + `tests/test_i18n_consistency.py`（16 passed）、`ruff` + `basedpyright`（0 error）。

## 范围外

任务 HUD 之外其他位置的 task_type 展示不在本票范围（issue 已明确排除）。

Closes #1218


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 任务 HUD 任务类型展示已切换为本地化文案（中文、英文、越南语），并在未配置翻译时自动回退为原始任务类型。
  - 取消确认弹层中的“级联取消预览”同步更新任务类型与显示格式。

- **测试**
  - 新增任务类型 i18n 展示与兜底行为的组件测试（覆盖已知与未知类型）。
  - 新增自动化校验，确保各语言的任务类型翻译键完整且无“孤儿”键，避免 CI 漏配。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->