### PR TITLE
fix(generation): 修复供应商配置变更期间的 backend 缓存竞态与并发构造泄漏

### DIFF
--- a/server/services/generation_context.py
+++ b/server/services/generation_context.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -36,13 +37,72 @@ logger = logging.getLogger(__name__)
 
 rate_limiter = get_shared_rate_limiter()
 
-# 按 (channel, provider_name, model) 缓存 Backend 实例，避免每次任务重建 API 客户端
-_backend_cache: dict[tuple[str, str, str | None], Any] = {}
+_CacheKey = tuple[str, str, str | None]
+
+
+class _BackendCache:
+    """Backend 实例缓存：按 (media_type, provider_name, model) 复用实例，避免每次任务重建 API 客户端。
+
+    缓存查询/构造/写回/失效在此单点实现，两条并发纪律藏在实现内、不扩大接口：
+
+    - **代际 invariant**：``invalidate()`` 时代数 +1；构造前记录代数，构造完成后代数未变才写回。
+      代数已变（构造期间发生配置变更）则该实例用完即弃——该笔任务按入队时配置快照跑完，
+      不把旧配置实例写回缓存遮蔽新配置。
+    - **per-key single-flight**：同 key 并发 miss 经 per-key 锁串行化，只构造一次、各调用方
+      拿到同一实例，避免并发构造出无人持有的多余 SDK client（全库无 backend 关闭协议）。
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[_CacheKey, Any] = {}
+        self._locks: dict[_CacheKey, asyncio.Lock] = {}
+        self._generation = 0
+
+    async def get_or_create(self, key: _CacheKey, factory: Callable[[], Awaitable[Any]]) -> Any:
+        if key in self._entries:
+            return self._entries[key]
+        lock = self._locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            if key in self._entries:
+                return self._entries[key]
+            generation = self._generation
+            backend = await factory()
+            if self._generation == generation:
+                self._entries[key] = backend
+            return backend
+
+    def invalidate(self) -> None:
+        self._generation += 1
+        self._entries.clear()
+
+
+_backend_cache = _BackendCache()
 
 
 def invalidate_backend_cache() -> None:
     """清空 Backend 实例缓存。在供应商配置变更后调用。"""
-    _backend_cache.clear()
+    _backend_cache.invalidate()
+
+
+async def _get_or_create_backend(
+    media_type: str,
+    provider_name: str,
+    provider_settings: dict,
+    resolver: ConfigResolver,
+    default_model: str | None,
+) -> Any:
+    """组 key + 提供 factory closure，缓存纪律统一委托 :class:`_BackendCache`。"""
+    effective_model = provider_settings.get("model") or default_model or None
+
+    async def _factory() -> Any:
+        return await assemble_backend(
+            provider_id=provider_name,
+            media_type=media_type,
+            model_id=effective_model,
+            resolver=resolver,
+            rate_limiter=rate_limiter,
+        )
+
+    return await _backend_cache.get_or_create((media_type, provider_name, effective_model), _factory)
 
 
 async def _get_or_create_video_backend(
@@ -58,20 +118,7 @@ async def _get_or_create_video_backend(
     通过 resolver 按需加载供应商配置。
     default_video_model: 全局默认视频模型，当 provider_settings 中无 model 时作为 fallback。
     """
-    effective_model = provider_settings.get("model") or default_video_model or None
-    cache_key = ("video", provider_name, effective_model)
-    if cache_key in _backend_cache:
-        return _backend_cache[cache_key]
-
-    backend = await assemble_backend(
-        provider_id=provider_name,
-        media_type="video",
-        model_id=effective_model,
-        resolver=resolver,
-        rate_limiter=rate_limiter,
-    )
-    _backend_cache[cache_key] = backend
-    return backend
+    return await _get_or_create_backend("video", provider_name, provider_settings, resolver, default_video_model)
 
 
 async def _get_or_create_image_backend(
@@ -82,20 +129,7 @@ async def _get_or_create_image_backend(
     default_image_model: str | None = None,
 ):
     """获取或创建 ImageBackend 实例（带缓存）。"""
-    effective_model = provider_settings.get("model") or default_image_model or None
-    cache_key = ("image", provider_name, effective_model)
-    if cache_key in _backend_cache:
-        return _backend_cache[cache_key]
-
-    backend = await assemble_backend(
-        provider_id=provider_name,
-        media_type="image",
-        model_id=effective_model,
-        resolver=resolver,
-        rate_limiter=rate_limiter,
-    )
-    _backend_cache[cache_key] = backend
-    return backend
+    return await _get_or_create_backend("image", provider_name, provider_settings, resolver, default_image_model)
 
 
 async def _get_or_create_audio_backend(
@@ -105,22 +139,8 @@ async def _get_or_create_audio_backend(
     *,
     default_audio_model: str | None = None,
 ):
-    """获取或创建 AudioBackend 实例（带缓存）。"""
-    effective_model = provider_settings.get("model") or default_audio_model or None
-    cache_key = ("audio", provider_name, effective_model)
-    if cache_key in _backend_cache:
-        return _backend_cache[cache_key]
-
-    # audio 无 gemini/kling 媒体特例：自定义 + 简单族统一经构造缝
-    backend = await assemble_backend(
-        provider_id=provider_name,
-        media_type="audio",
-        model_id=effective_model,
-        resolver=resolver,
-        rate_limiter=rate_limiter,
-    )
-    _backend_cache[cache_key] = backend
-    return backend
+    """获取或创建 AudioBackend 实例（带缓存）。audio 无媒体特例：自定义 + 简单族统一经构造缝。"""
+    return await _get_or_create_backend("audio", provider_name, provider_settings, resolver, default_audio_model)
 
 
 @dataclass(frozen=True)

--- a/server/services/generation_context.py
+++ b/server/services/generation_context.py
@@ -45,9 +45,10 @@ class _BackendCache:
 
     缓存查询/构造/写回/失效在此单点实现，两条并发纪律藏在实现内、不扩大接口：
 
-    - **代际 invariant**：``invalidate()`` 时代数 +1；构造前记录代数，构造完成后代数未变才写回。
-      代数已变（构造期间发生配置变更）则该实例用完即弃——该笔任务按入队时配置快照跑完，
-      不把旧配置实例写回缓存遮蔽新配置。
+    - **代际 invariant**：``invalidate()`` 时代数 +1；代数须在等锁前（而非取得锁后）捕获，
+      构造完成后代数未变才写回。代数已变——无论是本请求持锁构造期间发生失效，还是本请求在
+      失效边界前排队等锁、失效后才拿到锁——该实例用完即弃，不写回缓存遮蔽新配置；该笔任务
+      仍按入队时配置快照跑完。
     - **per-key single-flight**：同 key 并发 miss 经 per-key 锁串行化，只构造一次、各调用方
       拿到同一实例，避免并发构造出无人持有的多余 SDK client（全库无 backend 关闭协议）。
     """
@@ -60,11 +61,13 @@ class _BackendCache:
     async def get_or_create(self, key: _CacheKey, factory: Callable[[], Awaitable[Any]]) -> Any:
         if key in self._entries:
             return self._entries[key]
+        # 代数须在等锁前捕获：若在失效边界前排队等锁，即使失效后才拿到锁，也要按排队时的
+        # 旧代数与失效后的当前代数不符处理，避免用旧 resolver 构造的实例污染新代际缓存。
+        generation = self._generation
         lock = self._locks.setdefault(key, asyncio.Lock())
         async with lock:
             if key in self._entries:
                 return self._entries[key]
-            generation = self._generation
             backend = await factory()
             if self._generation == generation:
                 self._entries[key] = backend

--- a/tests/server/test_generation_context.py
+++ b/tests/server/test_generation_context.py
@@ -7,15 +7,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from lib.config.registry import PROVIDER_REGISTRY
-from lib.config.resolver import ProviderModel, get_provider_fallback
+from lib.config.resolver import ConfigResolver, ProviderModel, get_provider_fallback
 from lib.custom_provider import make_provider_id
 from lib.db.base import Base
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
@@ -306,6 +308,62 @@ class TestBackendCache:
         generation_context.invalidate_backend_cache()
         await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest())
         assert len(fake_assemble) == 2, "失效后须重建 backend"
+
+    async def test_invalidate_during_construction_discards_instance(self, monkeypatch):
+        """构造中途（assemble_backend await 挂起期间）触发 invalidate：完成的实例不写回缓存。"""
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        built: list[_FakeBackend] = []
+
+        async def _assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
+            backend = _FakeBackend(name=provider_id, model=model_id or "default-model")
+            built.append(backend)
+            if len(built) == 1:
+                entered.set()
+                await release.wait()
+            return backend
+
+        monkeypatch.setattr(generation_context, "assemble_backend", _assemble)
+        resolver = cast(ConfigResolver, None)
+
+        task = asyncio.create_task(generation_context._get_or_create_video_backend("ark", {"model": "m"}, resolver))
+        await entered.wait()
+        generation_context.invalidate_backend_cache()
+        release.set()
+        stale = await task
+
+        fresh = await generation_context._get_or_create_video_backend("ark", {"model": "m"}, resolver)
+        assert len(built) == 2, "缓存中不得残留失效期间构造的实例，后续访问须重新构造"
+        assert stale is built[0] and fresh is built[1]
+        assert fresh is not stale
+
+    async def test_concurrent_same_key_constructs_once(self, monkeypatch):
+        """同 key 并发两次 get_or_create：只构造一次，两调用方拿到同一实例。"""
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        construct_count = 0
+
+        async def _assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
+            nonlocal construct_count
+            construct_count += 1
+            entered.set()
+            await release.wait()
+            return _FakeBackend(name=provider_id, model=model_id or "default-model")
+
+        monkeypatch.setattr(generation_context, "assemble_backend", _assemble)
+        resolver = cast(ConfigResolver, None)
+
+        t1 = asyncio.create_task(generation_context._get_or_create_video_backend("ark", {"model": "m"}, resolver))
+        t2 = asyncio.create_task(generation_context._get_or_create_video_backend("ark", {"model": "m"}, resolver))
+        await entered.wait()
+        # 让 t2 在 t1 构造挂起期间也进入 get_or_create（并发 miss 而非先后命中）
+        for _ in range(3):
+            await asyncio.sleep(0)
+        release.set()
+        b1, b2 = await asyncio.gather(t1, t2)
+
+        assert construct_count == 1, "同 key 并发 miss 须 single-flight，只构造一次"
+        assert b1 is b2
 
 
 class TestValueObjectAssembly:

--- a/tests/server/test_generation_context.py
+++ b/tests/server/test_generation_context.py
@@ -71,9 +71,21 @@ def project_env(monkeypatch, tmp_path: Path):
 
 @pytest.fixture(autouse=True)
 def _clean_backend_cache():
+    """除清空缓存条目外，同时清空 per-key 锁。
+
+    ``invalidate_backend_cache()`` 按设计只清条目、不清 ``_locks``（生产环境同一事件循环
+    贯穿进程生命周期，key 空间有界，不清理无泄漏风险，见 ``_BackendCache`` 类文档）。但
+    pytest-asyncio 按测试函数切换独立事件循环，跨测试复用同一缓存 key 时，若前一个测试
+    已触发过锁竞争（``asyncio.Lock`` 首次竞争时会绑定到当时的事件循环），该 Lock 实例会
+    永久绑定在已关闭的旧循环上，后续测试里再次发生竞争即抛
+    ``RuntimeError: ... is bound to a different event loop``。测试隔离清空 locks 不影响
+    被测生产行为。
+    """
     generation_context.invalidate_backend_cache()
+    generation_context._backend_cache._locks.clear()
     yield
     generation_context.invalidate_backend_cache()
+    generation_context._backend_cache._locks.clear()
 
 
 @pytest.fixture
@@ -364,6 +376,51 @@ class TestBackendCache:
 
         assert construct_count == 1, "同 key 并发 miss 须 single-flight，只构造一次"
         assert b1 is b2
+
+    async def test_follower_queued_before_invalidate_discards_instance(self, monkeypatch):
+        """失效边界前已排队等锁的旧代际请求（follower）：跨越失效后拿到锁，仍不得写回缓存。
+
+        leader 持锁构造中途被打断（已有测试覆盖）之外的第三种交错：follower 在 leader 构造期间、
+        invalidate() 之前就已进入 get_or_create 并排队等锁，只有在 invalidate() 之后才轮到它拿锁。
+        它的调用参数（factory 闭包）仍是失效前的旧配置，因此即使拿锁时看到的是新代数，也必须按
+        「进入时（等锁前）捕获的旧代数」判定为过期，不写回缓存——否则旧配置构造的 backend 会被
+        误标为新代际有效实例，污染后续同 key 请求。
+        """
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        built: list[_FakeBackend] = []
+
+        async def _assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
+            backend = _FakeBackend(name=provider_id, model=model_id or "default-model")
+            built.append(backend)
+            if len(built) == 1:
+                entered.set()
+                await release.wait()
+            return backend
+
+        monkeypatch.setattr(generation_context, "assemble_backend", _assemble)
+        resolver = cast(ConfigResolver, None)
+
+        leader = asyncio.create_task(generation_context._get_or_create_video_backend("ark", {"model": "m"}, resolver))
+        await entered.wait()  # leader 已持锁，正在构造中途挂起
+
+        follower = asyncio.create_task(generation_context._get_or_create_video_backend("ark", {"model": "m"}, resolver))
+        # 让 follower 跑到「捕获代数 + 排队等锁」这一步（尚未轮到它拿锁）
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        generation_context.invalidate_backend_cache()  # 失效边界：此时 follower 已排队，代数已翻篇
+        release.set()  # 放行 leader，完成构造
+        stale = await leader
+        stale_from_follower = await follower
+
+        assert stale is built[0] and stale_from_follower is built[1]
+        assert stale is not stale_from_follower
+
+        fresh = await generation_context._get_or_create_video_backend("ark", {"model": "m"}, resolver)
+        assert len(built) == 3, "leader 与 follower 的旧代际实例均不得写回，后续访问须重新构造"
+        assert fresh is built[2]
+        assert fresh is not stale and fresh is not stale_from_follower
 
 
 class TestValueObjectAssembly:

--- a/tests/test_execute_tts_task.py
+++ b/tests/test_execute_tts_task.py
@@ -154,7 +154,7 @@ class TestGetOrCreateAudioBackend:
             return sentinel
 
         monkeypatch.setattr(generation_context, "assemble_backend", _fake_assemble)
-        monkeypatch.setattr(generation_context, "_backend_cache", {})
+        monkeypatch.setattr(generation_context, "_backend_cache", generation_context._BackendCache())
 
         resolver = cast(ConfigResolver, None)
         b1 = await generation_context._get_or_create_audio_backend("custom-3", {"model": "tts-1"}, resolver)
@@ -172,7 +172,7 @@ class TestGetOrCreateAudioBackend:
             return sentinel
 
         monkeypatch.setattr(generation_context, "assemble_backend", _fake_assemble)
-        monkeypatch.setattr(generation_context, "_backend_cache", {})
+        monkeypatch.setattr(generation_context, "_backend_cache", generation_context._BackendCache())
 
         resolver = cast(ConfigResolver, None)
         b1 = await generation_context._get_or_create_audio_backend(
@@ -192,7 +192,7 @@ class TestGetOrCreateAudioBackend:
             return object()
 
         monkeypatch.setattr(generation_context, "assemble_backend", _fake_assemble)
-        monkeypatch.setattr(generation_context, "_backend_cache", {})
+        monkeypatch.setattr(generation_context, "_backend_cache", generation_context._BackendCache())
 
         await generation_context._get_or_create_audio_backend(
             "dashscope",


### PR DESCRIPTION
## 背景

`server/services/generation_context.py` 的 backend 缓存原为模块级裸 dict，「查缓存 → miss 则 assemble → 写回」逻辑在三个 lane helper 内联三份，写回缺乏并发纪律，存在两个同根隐患：

1. **代际竞态（写回污染）**：任务 miss 后 `await assemble_backend(...)` 期间用户改配置触发 `invalidate_backend_cache()` 全量 clear，构造完成后旧配置实例仍写回缓存。key 仅含 (media_type, provider, model)，改 API key/endpoint 这类「key 不变、构造参数变」的修改会被污染条目长期遮蔽，任务持续用旧配置失败直至重启，无自愈路径。
2. **并发构造泄漏**：无 per-key 去重，两任务同时 miss 同 key 会并发构造两个 SDK client，后写回者顶替先写回者，被顶替的 client 无人持有，连接泄漏（全库无 backend 关闭协议）。

## 改动

缓存收口为 `generation_context` 内的 `_BackendCache` 单一小类，接口仅 `get_or_create(key, factory)` 与 `invalidate()`：

- **代际 invariant**（藏进实现）：`invalidate()` 时代数 +1；构造前记录代数，构造完成后代数未变才写回，变了则该实例用完即弃（该笔任务按入队时配置快照跑完）——不再遮蔽新配置。
- **per-key single-flight**（内部细节）：同 key 并发 miss 经 per-key `asyncio.Lock` 串行化，只构造一次、各调用方拿到同一实例。
- 三个 `_get_or_create_*_backend` 退化为「组 key + factory closure」的薄包装；`invalidate_backend_cache()` 对外签名与调用方（配置变更路由）不变。

缓存边界不动（ADR 0039/0049 两次确认「缓存留在调用方」），仅收口实现。

## 验证

- 新增编排测试：构造中途触发 invalidate → 完成实例不写回、后续访问重新构造；同 key 并发两次 → single-flight 只构造一次、两调用方同一实例（均用 `asyncio.Event` 精确编排时序）。
- `uv run ruff check` / `ruff format --check` / `basedpyright`：全绿（0 error/warning）。
- `pytest tests/server/test_generation_context.py tests/test_execute_tts_task.py`：31 passed，`generation_context.py` 覆盖率 99%。

Closes #1217


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化视频、图片和音频的后端实例复用：按媒体类型、提供方与有效模型精细化缓存，降低并发下的重复构建。
  * 引入代际失效与并发单飞：配置变更期间避免在失效后回写旧实例，队列等待的请求也会按最新代际重新获取。
* **Tests**
  * 增加缓存失效边界、构建中触发失效不回写、同 key 并发仅构建一次，以及队列 follower 交错等用例覆盖。
  * 更新音频后端相关测试使用新的缓存实现类型。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->