### PR TITLE
refactor(accounting): 自定义供应商价格解析抽为仓储共享方法，预估与记账口径一致

### DIFF
--- a/lib/db/repositories/custom_provider_repo.py
+++ b/lib/db/repositories/custom_provider_repo.py
@@ -207,7 +207,10 @@ class CustomProviderRepository(BaseRepository):
         if not is_custom_provider(provider):
             return _NO_PRICE
         try:
-            price_model = await self.get_model_by_ids(parse_provider_id(provider), model or "")
+            # SAVEPOINT 隔离：查询异常只回滚到此处，不污染调用方（如 usage_repo._settle）
+            # 随后在同一 session 上执行的结算 UPDATE/commit。
+            async with self.session.begin_nested():
+                price_model = await self.get_model_by_ids(parse_provider_id(provider), model or "")
         except Exception:
             logger.debug("自定义供应商价格查询失败 provider=%s model=%s", provider, model, exc_info=True)
             return _NO_PRICE

--- a/lib/db/repositories/custom_provider_repo.py
+++ b/lib/db/repositories/custom_provider_repo.py
@@ -2,10 +2,31 @@
 
 from __future__ import annotations
 
+import logging
+from typing import NamedTuple
+
 from sqlalchemy import delete, select
 
+from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 from lib.db.repositories.base import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+
+class CustomProviderPrice(NamedTuple):
+    """自定义供应商价格三元组，作为 ``calculate_cost`` 的 ``custom_price_*`` 入参来源。
+
+    三字段全 ``None`` 表示无自定义价格：预置供应商 / 畸形 provider id / 查询异常 / 查无模型
+    均归为此语义，``calculate_cost`` 据此对自定义供应商缺价时计为 0。
+    """
+
+    price_input: float | None = None
+    price_output: float | None = None
+    currency: str | None = None
+
+
+_NO_PRICE = CustomProviderPrice()
 
 
 class CustomProviderRepository(BaseRepository):
@@ -170,6 +191,29 @@ class CustomProviderRepository(BaseRepository):
         )
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
+
+    async def resolve_price(self, provider: str, model: str) -> CustomProviderPrice:
+        """解析自定义供应商的声明价格，供记账与预估两侧共用，杜绝同源复刻的口径漂移。
+
+        非自定义供应商 / 畸形 provider id / 查询异常 / 查无模型均降级为无价（三字段 ``None``），
+        绝不抛错——调用方以此驱动 ``calculate_cost`` 的 ``custom_price_*``，缺价时费用计为 0。
+
+        刻意不做 enabled / media_type 校验（区别于 ``lib/custom_provider/loader.load_custom_backend``
+        的模型解析回退）：记账须按实际调用的那个模型的声明价计费，与该模型当前是否启用无关——
+        在此过滤 ``is_enabled`` 会让对"事后被停用模型"的历史调用丢价、错计为 0；预估侧同理，
+        停用模型应回落到执行期实际使用的默认模型价，而非 0。enabled / media_type 回退属模型解析层
+        （loader）职责、在价格取数上游发生，两侧共用同一"按声明取价、不过滤"口径以保持一致。
+        """
+        if not is_custom_provider(provider):
+            return _NO_PRICE
+        try:
+            price_model = await self.get_model_by_ids(parse_provider_id(provider), model or "")
+        except Exception:
+            logger.debug("自定义供应商价格查询失败 provider=%s model=%s", provider, model, exc_info=True)
+            return _NO_PRICE
+        if price_model is None:
+            return _NO_PRICE
+        return CustomProviderPrice(price_model.price_input, price_model.price_output, price_model.currency)
 
     async def get_default_model(self, provider_id: int, media_type: str) -> CustomProviderModel | None:
         """获取指定供应商 + 媒体类型的默认已启用模型。

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -13,6 +13,7 @@ from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.db.base import DEFAULT_USER_ID, dt_to_iso, utc_now
 from lib.db.models.api_call import ApiCall
 from lib.db.repositories.base import BaseRepository, rowcount
+from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.pricing.strategies import PricingParams
 from lib.providers import PROVIDER_GEMINI, CallType
 
@@ -224,19 +225,11 @@ class UsageRepository(BaseRepository):
         elif auto_calc:
             effective_provider = row.provider or PROVIDER_GEMINI
 
-            # Pre-query custom provider pricing (avoids sync-over-async in CostCalculator)
-            custom_price_input: float | None = None
-            custom_price_output: float | None = None
-            custom_currency: str | None = None
-            if is_custom_provider(effective_provider):
-                from lib.db.repositories.custom_provider_repo import CustomProviderRepository
-
-                repo = CustomProviderRepository(self.session)
-                price_model = await repo.get_model_by_ids(parse_provider_id(effective_provider), row.model or "")
-                if price_model:
-                    custom_price_input = price_model.price_input
-                    custom_price_output = price_model.price_output
-                    custom_currency = price_model.currency
+            # 自定义供应商价格预查（避免 CostCalculator 内 sync-over-async）；与费用预估链路共用
+            # CustomProviderRepository.resolve_price，非自定义 / 畸形 id / 查询异常 / 缺价统一降级为无价。
+            custom_price = await CustomProviderRepository(self.session).resolve_price(
+                effective_provider, row.model or ""
+            )
 
             params = PricingParams(
                 call_type=row.call_type,  # pyright: ignore[reportArgumentType]
@@ -258,9 +251,9 @@ class UsageRepository(BaseRepository):
             cost_amount, currency = cost_calculator.calculate_cost(
                 effective_provider,
                 params,
-                custom_price_input=custom_price_input,
-                custom_price_output=custom_price_output,
-                custom_currency=custom_currency,
+                custom_price_input=custom_price.price_input,
+                custom_price_output=custom_price.price_output,
+                custom_currency=custom_price.currency,
             )
 
         return _SettledCall(

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Any, NamedTuple
+from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from lib.config.resolver import ConfigResolver, get_provider_fallback
 from lib.cost_calculator import cost_calculator
-from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.db.repositories.usage_repo import UsageRepository
 from lib.grid.layout import calculate_grid_layout
@@ -22,17 +21,6 @@ from lib.storyboard_sequence import get_storyboard_items, group_scenes_by_segmen
 logger = logging.getLogger(__name__)
 
 CostBreakdown = dict[str, float]
-
-
-class _CustomPrice(NamedTuple):
-    """自定义供应商价格三元组，作为 ``calculate_cost`` 的 ``custom_price_*`` 入参来源。"""
-
-    price_input: float | None
-    price_output: float | None
-    currency: str | None
-
-
-_NO_CUSTOM_PRICE = _CustomPrice(None, None, None)
 
 
 def _add_cost(target: CostBreakdown, amount: float, currency: str) -> None:
@@ -52,25 +40,6 @@ class CostEstimationService:
     def __init__(self, resolver: ConfigResolver, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._resolver = resolver
         self._session_factory = session_factory
-
-    @staticmethod
-    async def _resolve_custom_price(session: AsyncSession, provider: str, model: str) -> _CustomPrice:
-        """自定义供应商价格取数（与实际记账链路 usage_repo 同源）。
-
-        预置供应商或查无价格模型时返回空价格；calculate_cost 对自定义供应商缺价时计为 0。
-        """
-        if not is_custom_provider(provider):
-            return _NO_CUSTOM_PRICE
-        try:
-            price_model = await CustomProviderRepository(session).get_model_by_ids(
-                parse_provider_id(provider), model or ""
-            )
-        except Exception:
-            logger.debug("自定义供应商价格查询失败 provider=%s model=%s", provider, model, exc_info=True)
-            return _NO_CUSTOM_PRICE
-        if price_model is None:
-            return _NO_CUSTOM_PRICE
-        return _CustomPrice(price_model.price_input, price_model.price_output, price_model.currency)
 
     async def compute(
         self,
@@ -120,9 +89,10 @@ class CostEstimationService:
         # Get actual costs + 自定义供应商价格（缺则预估恒为零，需与实际记账同源预查 DB 单价）
         async with self._session_factory() as session:
             actual_by_segment = await UsageRepository(session).get_actual_costs_by_segment(project_name)
-            image_price = await self._resolve_custom_price(session, image_provider, image_model)
-            video_price = await self._resolve_custom_price(session, video_provider, video_model)
-            audio_price = await self._resolve_custom_price(session, audio_provider, audio_model)
+            custom_repo = CustomProviderRepository(session)
+            image_price = await custom_repo.resolve_price(image_provider, image_model)
+            video_price = await custom_repo.resolve_price(video_provider, video_model)
+            audio_price = await custom_repo.resolve_price(audio_provider, audio_model)
 
         generation_mode = project_data.get("generation_mode", "single")
         # 规范化 aspect_ratio：可能是 str 或 dict，复用生成任务的解析逻辑

--- a/tests/test_custom_provider_repo.py
+++ b/tests/test_custom_provider_repo.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from lib.db.base import Base
-from lib.db.repositories.custom_provider_repo import CustomProviderRepository
+from lib.db.repositories.custom_provider_repo import CustomProviderPrice, CustomProviderRepository
 
 
 @pytest.fixture
@@ -494,6 +494,68 @@ class TestModelManagement:
     async def test_get_default_model_nonexistent_provider(self, session: AsyncSession):
         repo = CustomProviderRepository(session)
         assert await repo.get_default_model(999, "text") is None
+
+
+class TestResolvePrice:
+    """resolve_price：记账与预估共用的价格取数，全部降级路径归为无价、绝不抛错。"""
+
+    async def _provider_with_model(self, repo: CustomProviderRepository, session: AsyncSession, **model_over) -> str:
+        model = {
+            "model_id": "m1",
+            "display_name": "M1",
+            "endpoint": "openai-chat",
+            "is_enabled": True,
+            "price_unit": "token",
+            "price_input": 2.0,
+            "price_output": 4.0,
+            "currency": "CNY",
+        }
+        model.update(model_over)
+        p = await repo.create_provider(
+            display_name="P",
+            discovery_format="openai",
+            base_url="https://x",
+            api_key="k",
+            models=[model],
+        )
+        await session.flush()
+        return f"custom-{p.id}"
+
+    async def test_non_custom_provider_returns_no_price(self, session: AsyncSession):
+        repo = CustomProviderRepository(session)
+        assert await repo.resolve_price("gemini-aistudio", "gemini-3-flash-preview") == CustomProviderPrice()
+
+    async def test_valid_custom_provider_returns_declared_price(self, session: AsyncSession):
+        repo = CustomProviderRepository(session)
+        provider = await self._provider_with_model(repo, session)
+        assert await repo.resolve_price(provider, "m1") == CustomProviderPrice(2.0, 4.0, "CNY")
+
+    async def test_missing_model_returns_no_price(self, session: AsyncSession):
+        repo = CustomProviderRepository(session)
+        provider = await self._provider_with_model(repo, session)
+        assert await repo.resolve_price(provider, "ghost") == CustomProviderPrice()
+
+    async def test_malformed_id_degrades_to_no_price(self, session: AsyncSession):
+        """畸形 custom- id（parse_provider_id 抛 ValueError）降级为无价，不抛错。"""
+        repo = CustomProviderRepository(session)
+        assert await repo.resolve_price("custom-abc/ghost", "m1") == CustomProviderPrice()
+
+    async def test_query_exception_degrades_to_no_price(self, session: AsyncSession, monkeypatch: pytest.MonkeyPatch):
+        """底层查询异常（如 DB 瞬时不可用）降级为无价，不冒泡。"""
+        repo = CustomProviderRepository(session)
+        provider = await self._provider_with_model(repo, session)
+
+        async def _boom(*_args, **_kwargs):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(repo, "get_model_by_ids", _boom)
+        assert await repo.resolve_price(provider, "m1") == CustomProviderPrice()
+
+    async def test_disabled_model_still_priced(self, session: AsyncSession):
+        """刻意豁免 enabled 校验：停用模型仍按其声明价取价（记账按实际调用的模型计费）。"""
+        repo = CustomProviderRepository(session)
+        provider = await self._provider_with_model(repo, session, is_enabled=False)
+        assert await repo.resolve_price(provider, "m1") == CustomProviderPrice(2.0, 4.0, "CNY")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 摘要

自定义供应商的价格取数逻辑此前在记账（`usage_repo._settle`）与预估（`cost_estimation`）两处同源复刻，存在口径漂移风险。本 PR 将其抽为 `CustomProviderRepository.resolve_price` 共享方法，两侧调用点改为复用，唯一真相源落在仓储层。

## 改动

- `custom_provider_repo.py`：新增 `CustomProviderPrice`（价格三元组 NamedTuple）+ `_NO_PRICE` sentinel + `resolve_price(provider, model)` 共享方法
- `usage_repo.py`：结算路径内联价格预查块替换为 `resolve_price` 调用
- `cost_estimation.py`：删除本地 `_resolve_custom_price` staticmethod，改调 `resolve_price`
- `tests/test_custom_provider_repo.py`：新增 `TestResolvePrice`（6 例）锁定共享方法契约

## 降级语义（统一）

非自定义供应商 / 畸形 provider id（`parse_provider_id` 抛 ValueError）/ 查询异常 / 查无模型 一律返回无价（三字段 None），绝不抛错；缺价时 `calculate_cost` 计为 0。

## enabled / media_type 校验：明确豁免

`resolve_price` 刻意不做 `is_enabled` / `media_type` 校验：记账须按实际被调用模型的声明价计费，与其当前是否启用无关（过滤会让停用模型的历史调用丢价）；enabled / media_type 回退属模型解析层（loader）职责，发生在取价上游。两侧共用同一「按声明取价、不过滤」口径即达成账口一致。

## 结算行为 delta

`tests/test_accounting_characterization.py`（结算行为锁）未修改，全绿。记账侧唯一语义变化是「畸形 id / 查询异常」由抛错 → 降级为无价（票面明确要求），happy-path 逐行一致。

## 验证

- `pytest`（repo / 结算锁 / 预估 / 用量 相关套件）：全绿
- `ruff check` + `format --check`（改动 4 文件）：passed
- `basedpyright`：0 errors
- 已 rebase 到最新 main（#1223）后重验绿

Closes #1222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增统一的自定义供应商模型价格解析能力：同时支持输入价、输出价与币种的取数逻辑。
  * 费用结算与费用估算在相关场景下改为使用该解析结果，保持口径一致。
* **问题修复**
  * 当供应商/模型缺失、ID 格式异常或数据库查询失败时，费用计算自动安全降级为“无价格”，不会中断处理。
  * 模型即便未启用，仍按其声明价格参与计算与预估。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->