### PR TITLE
chore(api): 移除无消费方的草稿列表端点

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -159,7 +159,6 @@ describe("API", () => {
       await API.getSystemVersion();
       await API.updateSystemConfig({ default_image_backend: "vertex" });
       await API.listFiles("demo");
-      await API.listDrafts("demo");
       await API.deleteDraft("demo", 1, 2);
       await API.generateOverview("demo");
       await API.updateOverview("demo", { synopsis: "new" });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -209,14 +209,6 @@ export interface CreateProjectPayload {
   model_settings?: Record<string, { resolution?: string | null }>;
 }
 
-/** Draft metadata returned by listDrafts. */
-export interface DraftInfo {
-  episode: number;
-  step: number;
-  filename: string;
-  modified_at: string;
-}
-
 function normalizeDiagnosticsBucket(value: unknown): { code: string; message: string; location?: string }[] {
   if (!Array.isArray(value)) {
     return [];
@@ -1023,17 +1015,6 @@ class API {
   }
 
   // ==================== 草稿文件管理 ====================
-
-  /**
-   * 获取项目的所有草稿
-   */
-  static async listDrafts(
-    projectName: string
-  ): Promise<{ drafts: DraftInfo[] }> {
-    return this.request(
-      `/projects/${encodeURIComponent(projectName)}/drafts`
-    );
-  }
 
   /**
    * 获取草稿内容

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -616,48 +616,6 @@ async def delete_source_file(project_name: str, filename: str, _user: CurrentUse
 # ==================== 草稿文件管理 ====================
 
 
-@router.get("/projects/{project_name}/drafts")
-async def list_drafts(project_name: str, _user: CurrentUser, _t: Translator):
-    """列出项目的所有草稿目录和文件"""
-    try:
-
-        def _sync():
-            project_dir = get_project_manager().get_project_path(project_name)
-            drafts_dir = project_dir / "drafts"
-
-            result = {}
-            if drafts_dir.exists():
-                for episode_dir in sorted(drafts_dir.iterdir()):
-                    if episode_dir.is_dir() and episode_dir.name.startswith("episode_"):
-                        episode_num = episode_dir.name.replace("episode_", "")
-                        files = []
-                        for f in sorted(episode_dir.glob("*.md")):
-                            files.append(
-                                {
-                                    "name": f.name,
-                                    "step": _extract_step_number(f.name),
-                                    "title": _get_step_title(f.name, _t),
-                                    "size": f.stat().st_size,
-                                    "modified": f.stat().st_mtime,
-                                }
-                            )
-                        result[episode_num] = files
-
-            return {"drafts": result}
-
-        return await asyncio.to_thread(_sync)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
-
-
-def _extract_step_number(filename: str) -> int:
-    """从文件名提取步骤编号"""
-    import re
-
-    match = re.search(r"step(\d+)", filename)
-    return int(match.group(1)) if match else 0
-
-
 def _get_step_files(content_mode: str, generation_mode: str | None = None) -> dict:
     """根据 generation_mode / content_mode 获取步骤文件名映射
 
@@ -691,18 +649,6 @@ _STEP1_PROBE_ORDER = [REFERENCE_VIDEO_STEP1_FILENAME, STEP1_FILENAMES["narration
 _STEP1_CANDIDATES = list(
     dict.fromkeys(name for key in [*_STEP1_PROBE_ORDER, *_STEP1_FAMILY] for name in _STEP1_FAMILY[key])
 )
-
-
-def _get_step_title(filename: str, _t: Callable[..., str]) -> str:
-    """获取步骤标题：每种 step1（含旧 .md 别名）映射到其展示名 i18n key。"""
-    titles: dict[str, str] = {}
-    for name in step1_read_candidates("drama"):
-        titles[name] = _t("normalized_script")
-    for name in step1_read_candidates("narration"):
-        titles[name] = _t("segment_splitting")
-    titles[REFERENCE_VIDEO_STEP1_FILENAME] = _t("segment_splitting")
-    titles[REFERENCE_VIDEO_STEP1_LEGACY_FILENAME] = _t("segment_splitting")
-    return titles.get(filename, filename)
 
 
 def _load_project_modes(project_name: str, episode: int) -> tuple[str, str | None]:

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -154,10 +154,6 @@ class TestFilesRouter:
             )
             assert update_draft.status_code == 200
 
-            list_drafts = client.get("/api/v1/projects/demo/drafts")
-            assert list_drafts.status_code == 200
-            assert "1" in list_drafts.json()["drafts"]
-
             get_draft = client.get("/api/v1/projects/demo/drafts/1/step1")
             assert get_draft.status_code == 200
             assert "draft content" in get_draft.text
@@ -476,11 +472,6 @@ class TestFilesRouter:
             assert "immutable" not in resp.headers.get("cache-control", "")
 
     def test_files_helper_functions(self, tmp_path):
-        from tests.conftest import make_translator
-
-        _t = make_translator()
-        assert files._extract_step_number("step12_x.md") == 12
-        assert files._extract_step_number("not-match.md") == 0
         assert files._get_step_files("narration") == {1: "step1_segments.json"}
         assert files._get_step_files("drama") == {1: "step1_normalized_script.json"}
         # reference_video 走独立的结构化 step1 文件
@@ -488,15 +479,6 @@ class TestFilesRouter:
         assert files._get_step_files("narration", "reference_video") == {1: "step1_reference_units.json"}
         # 其他 generation_mode 回落到 content_mode
         assert files._get_step_files("narration", "storyboard") == {1: "step1_segments.json"}
-        assert files._get_step_title("step1_segments.json", _t) == "片段拆分"
-        # 旧 step1_segments.md 仍保留标题映射，便于存量在制品浏览
-        assert files._get_step_title("step1_segments.md", _t) == "片段拆分"
-        assert files._get_step_title("step1_normalized_script.json", _t) == "规范化剧本"
-        assert files._get_step_title("step1_normalized_script.md", _t) == "规范化剧本"
-        assert files._get_step_title("step1_reference_units.json", _t) == "片段拆分"
-        # 旧 step1_reference_units.md 仍保留标题映射，便于存量在制品浏览
-        assert files._get_step_title("step1_reference_units.md", _t) == "片段拆分"
-        assert files._get_step_title("unknown.md", _t) == "unknown.md"
 
     def test_resolve_step1_path_narration_prefers_own_legacy_md(self, tmp_path):
         """narration step1 缺 .json 时优先回落自家旧 .md，不被跨模式遗留 reference_units.md 抢占。"""


### PR DESCRIPTION
## 摘要

移除 `GET /api/v1/projects/{project_name}/drafts`（`list_drafts`）端点及其前端封装。该端点 glob 写死 `*.md`，三种结构化 step1 `.json` 中间稿均不可见，且核查全仓无生产消费方（web 剧本工作区走 script_review / units 专用端点），属沉睡的 API 层不一致，采废弃方向直接清理。

## 变更

- 后端：删除 `list_drafts` 端点与专用 helper `_extract_step_number` / `_get_step_title`；保留另有使用点的 i18n key（`normalized_script` / `segment_splitting`）与共享 import
- 前端：删除 `API.listDrafts` 与 `DraftInfo` interface 及对应测试引用
- 测试：删除 `list_drafts` 集成断言与两个 helper 的单测；`_get_step_files` 断言保留
- `getDraftContent` / `saveDraft` 等草稿内容端点不受影响

## 验证

- `tests/test_files_router.py` 45 passed（`test_style_image_endpoints` 本地环境性失败，基线复现，与本改动无关）
- ruff / basedpyright 0 error；前端 eslint + vitest 993 passed
- 全仓 `list_drafts` / `listDrafts` / `DraftInfo` 无残留引用

Closes #1227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **变更**
  * 移除项目草稿列表接口及对应的前端调用。
  * 优化草稿步骤文件的识别与读取，支持不同内容和生成模式。
  * 改进特殊视频模式及模式回退下的步骤文件映射。
* **测试**
  * 更新文件与草稿相关测试，改为直接验证具体步骤内容。
  * 保留并完善不同模式下步骤文件解析的覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->