### PR TITLE
refactor(generation): 图片编辑改用生成上下文单点解析并清理旧解析入口

### DIFF
--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -8,19 +8,14 @@ import asyncio
 import logging
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from lib.config.resolver import ConfigResolver, ProviderModel
+from typing import Any
 
 from lib.asset_types import ASSET_SPECS
 from lib.config.registry import PROVIDER_REGISTRY
 from lib.db.base import DEFAULT_USER_ID
-from lib.gemini_shared import get_shared_rate_limiter
 from lib.i18n import DEFAULT_LOCALE
 from lib.i18n import _ as i18n_translate
 from lib.image_backends.base import ImageCapabilityError
-from lib.media_generator import MediaGenerator
 from lib.path_safety import safe_exists
 from lib.project_change_hints import emit_project_change_batch, project_change_source
 from lib.project_manager import get_project_manager
@@ -54,151 +49,10 @@ from server.services.generation_context import (
     AudioLaneRequest,
     ImageLaneRequest,
     VideoLaneRequest,
-    _get_or_create_audio_backend,
-    _get_or_create_image_backend,
-    _get_or_create_video_backend,
     resolve_generation_context,
 )
 
-rate_limiter = get_shared_rate_limiter()
 logger = logging.getLogger(__name__)
-
-
-async def _resolve_effective_image_backend(
-    project: dict,
-    payload: dict | None,
-    *,
-    needs_i2i: bool = False,
-) -> ProviderModel:
-    """图片 provider 解析的薄投影：委托 ``ConfigResolver.resolve_image_backend``。
-
-    capability 仅在执行层确定（见 ``docs/adr/0001``）：``needs_i2i`` → i2i 槽，否则 t2i 槽。
-    与 ``_resolve_video_backend`` 一致不吞解析异常——未配置供应商时让 ``ConfigResolver`` 抛出的
-    清晰 ``ValueError``（"未找到可用的 image 供应商..."）直接透传，而非掩盖成空 backend 的通用错误。
-    """
-    from lib.config.resolver import ConfigResolver
-    from lib.db import async_session_factory
-
-    resolver = ConfigResolver(async_session_factory)
-    capability = "i2i" if needs_i2i else "t2i"
-    return await resolver.resolve_image_backend(project, payload, capability=capability)
-
-
-async def _resolve_resolution(project: dict, provider_id: str, model_id: str) -> str | None:
-    """resolution 解析的薄投影：委托 ``ConfigResolver.resolve_resolution``。
-
-    project.model_settings > legacy > 自定义供应商默认 > None（None＝不传 SDK 参数，见
-    ``docs/adr/0019``）。
-    """
-    from lib.config.resolver import ConfigResolver
-    from lib.db import async_session_factory
-
-    resolver = ConfigResolver(async_session_factory)
-    return await resolver.resolve_resolution(project, provider_id, model_id)
-
-
-async def _resolve_video_backend(
-    project_name: str,
-    resolver: ConfigResolver,
-    payload: dict | None,
-) -> tuple[Any | None, str | None]:
-    """解析并构造视频后端，返回 (video_backend, provider_id)。
-
-    provider/model 的**解析**是 ``resolver.resolve_video_backend`` 的薄投影；backend **构造**
-    （``_get_or_create_video_backend``）留在原地。仅在 payload 存在时创建 VideoBackend，避免
-    图片任务因视频配置缺失而报错。provider_id 是 registry id（参考图压缩按它查 per-provider 上限）。
-    """
-    project = await asyncio.to_thread(get_project_manager().load_project, project_name) if payload else None
-    resolved = await resolver.resolve_video_backend(project, payload)
-
-    video_backend = None
-    if payload:
-        provider_settings: dict = {"model": resolved.model_id} if resolved.model_id else {}
-        video_backend = await _get_or_create_video_backend(
-            resolved.provider_id,
-            provider_settings,
-            resolver,
-            default_video_model=resolved.model_id or None,
-        )
-
-    # provider_id 与 backend 成对返回：无 payload 时不构造 video_backend，此时 provider_id 无
-    # 消费者（压缩上限与记账都只在视频真实调用时用），返回 None 以满足 MediaGenerator 的成对不变量。
-    return video_backend, (resolved.provider_id if video_backend is not None else None)
-
-
-async def get_media_generator(
-    project_name: str,
-    payload: dict | None = None,
-    *,
-    user_id: str = DEFAULT_USER_ID,
-    require_image_backend: bool = True,
-    needs_i2i: bool = False,
-    needs_audio: bool = False,
-) -> MediaGenerator:
-    """创建 MediaGenerator。仅按调用场景初始化所需的 backend。
-
-    needs_i2i: 若调用方知晓本次任务带参考图，传 True 以选 I2I 默认 backend；否则用 T2I。
-    needs_audio: TTS 任务传 True，只构造 audio backend，跳过 image/video（语音任务不需要二者，
-        且强行构造视频 backend 会因视频供应商缺配置而误失败）。
-    """
-    from lib.config.resolver import ConfigResolver
-    from lib.db import async_session_factory
-
-    project_path = await asyncio.to_thread(get_project_manager().get_project_path, project_name)
-    resolver = ConfigResolver(async_session_factory)
-
-    # provider_id 须在 async with 之前初始化：纯视频任务（require_image_backend=False）取不到
-    # image provider，纯图任务也要拿到 video provider，两个分支各自赋值后传给 MediaGenerator。
-    image_provider_id: str | None = None
-    video_provider_id: str | None = None
-    audio_provider_id: str | None = None
-    async with resolver.session() as r:
-        image_backend = None
-        video_backend = None
-        audio_backend = None
-
-        if needs_audio:
-            project = await asyncio.to_thread(get_project_manager().load_project, project_name)
-            resolved_audio = await r.resolve_audio_backend(project, payload)
-            audio_provider_id = resolved_audio.provider_id
-            audio_backend = await _get_or_create_audio_backend(
-                resolved_audio.provider_id,
-                {},
-                r,
-                default_audio_model=resolved_audio.model_id or None,
-            )
-        else:
-            if require_image_backend:
-                project = await asyncio.to_thread(get_project_manager().load_project, project_name)
-                resolved_image = await _resolve_effective_image_backend(project, payload, needs_i2i=needs_i2i)
-                # 解析失败 → provider_id 为空，让 _get_or_create_image_backend 抛出清晰错误
-                image_provider_id = resolved_image.provider_id
-                image_backend = await _get_or_create_image_backend(
-                    resolved_image.provider_id,
-                    {},
-                    r,
-                    default_image_model=resolved_image.model_id or None,
-                )
-
-            # 解析 video backend（保持现有逻辑）
-            video_backend, video_provider_id = await _resolve_video_backend(
-                project_name,
-                r,
-                payload,
-            )
-
-    return MediaGenerator(
-        project_path,
-        rate_limiter=rate_limiter,
-        image_backend=image_backend,
-        video_backend=video_backend,
-        audio_backend=audio_backend,
-        config_resolver=resolver,
-        user_id=user_id,
-        image_provider_id=image_provider_id,
-        video_provider_id=video_provider_id,
-        audio_provider_id=audio_provider_id,
-    )
 
 
 def get_aspect_ratio(project: dict, resource_type: str) -> str:

--- a/server/services/image_edit_tasks.py
+++ b/server/services/image_edit_tasks.py
@@ -20,11 +20,9 @@ from lib.db.base import DEFAULT_USER_ID
 from lib.path_safety import safe_exists
 from lib.resource_paths import resource_relative_path
 from lib.storyboard_sequence import find_storyboard_item, get_storyboard_items
+from server.services.generation_context import ImageLaneRequest, resolve_generation_context
 from server.services.generation_tasks import (
-    _resolve_effective_image_backend,
-    _resolve_resolution,
     get_aspect_ratio,
-    get_media_generator,
     get_project_manager,
 )
 
@@ -86,8 +84,8 @@ async def execute_image_edit_task(
 ) -> dict[str, Any]:
     """执行图片编辑任务：读 current 图 → i2i → 新版本覆盖 current → 按资源类型写回。
 
-    编辑必然 i2i（唯一入队即知 capability 的图片任务，见 ``docs/adr/0001``），故
-    ``needs_i2i=True`` 恒定走 i2i 槽；backend 调用失败时 current 图指针与资源写回
+    编辑必然 i2i（唯一入队即知 capability 的图片任务，见 ``docs/adr/0001``），故声明
+    ``ImageLaneRequest(capability="i2i")`` 恒定走 i2i 槽；backend 调用失败时 current 图指针与资源写回
     不被触碰（MediaGenerator 仅在成功后覆盖 output 并登记新版本，写回也不会发生）。
     旧图基线登记（见下方 ``ensure_current_tracked`` 调用）先于 backend 调用发生，与
     backend 成败无关、失败时不回滚——保证编辑前的旧图始终可回滚，不属于本次生成
@@ -120,7 +118,15 @@ async def execute_image_edit_task(
 
     project, current_image = await asyncio.to_thread(_prepare)
 
-    generator = await get_media_generator(project_name, payload=payload, user_id=user_id, needs_i2i=True)
+    # 编辑必然 i2i：单次解析拿到 generator 与 image lane 产物（provider / backend / resolution）。
+    ctx = await resolve_generation_context(
+        project_name,
+        payload,
+        project=project,
+        user_id=user_id,
+        image=ImageLaneRequest(capability="i2i"),
+    )
+    generator = ctx.generator
 
     # 旧图若尚无版本记录（如旧宫格项目 current 指向非 canonical 路径），先以中性元数据补登，
     # 保证编辑前的旧图可回滚；也避免 generate_image_async 内部的 ensure_current_tracked
@@ -134,8 +140,7 @@ async def execute_image_edit_task(
     )
 
     aspect_ratio = get_aspect_ratio(project, version_resource_type)
-    resolved_image = await _resolve_effective_image_backend(project, payload, needs_i2i=True)
-    image_size = await _resolve_resolution(project, resolved_image.provider_id, resolved_image.model_id)
+    image_size = ctx.image.resolution
 
     # 参考图仅当前图一张、prompt 仅编辑指令（不拼原 image_prompt / 不追加生成路径的
     # 自动参考图收集）；新版本 prompt 字段即编辑指令，source 标记编辑版本。

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -1072,51 +1072,6 @@ class TestGenerationTasks:
             await generation_tasks.execute_prop_task("demo", "玉佩", {"prompt": ""})
 
 
-from server.services.generation_tasks import _resolve_effective_image_backend
-
-
-@pytest.mark.asyncio
-async def test_resolve_picks_t2i_from_payload_when_no_refs():
-    payload = {
-        "image_provider_t2i": "openai/gen-1",
-        "image_provider_i2i": "openai/edit-1",
-    }
-    resolved = await _resolve_effective_image_backend({}, payload, needs_i2i=False)
-    assert (resolved.provider_id, resolved.model_id) == ("openai", "gen-1")
-
-
-@pytest.mark.asyncio
-async def test_resolve_picks_i2i_from_payload_when_refs():
-    payload = {
-        "image_provider_t2i": "openai/gen-1",
-        "image_provider_i2i": "openai/edit-1",
-    }
-    resolved = await _resolve_effective_image_backend({}, payload, needs_i2i=True)
-    assert (resolved.provider_id, resolved.model_id) == ("openai", "edit-1")
-
-
-@pytest.mark.asyncio
-async def test_resolve_falls_back_to_legacy_payload_image_provider():
-    """payload 仅有旧 image_provider/image_model（历史任务）时两槽都用此值。"""
-    payload = {"image_provider": "openai", "image_model": "legacy"}
-    t2i = await _resolve_effective_image_backend({}, payload, needs_i2i=False)
-    i2i = await _resolve_effective_image_backend({}, payload, needs_i2i=True)
-    assert (t2i.provider_id, t2i.model_id) == ("openai", "legacy")
-    assert (i2i.provider_id, i2i.model_id) == ("openai", "legacy")
-
-
-@pytest.mark.asyncio
-async def test_resolve_reads_project_split_fields():
-    project = {
-        "image_provider_t2i": "openai/proj-gen",
-        "image_provider_i2i": "openai/proj-edit",
-    }
-    t2i = await _resolve_effective_image_backend(project, {}, needs_i2i=False)
-    i2i = await _resolve_effective_image_backend(project, {}, needs_i2i=True)
-    assert (t2i.provider_id, t2i.model_id) == ("openai", "proj-gen")
-    assert (i2i.provider_id, i2i.model_id) == ("openai", "proj-edit")
-
-
 class TestGetAspectRatio:
     def test_reads_top_level_aspect_ratio(self):
         project = {"aspect_ratio": "16:9", "content_mode": "narration"}

--- a/tests/test_image_edit_executor.py
+++ b/tests/test_image_edit_executor.py
@@ -1,14 +1,23 @@
 """image_edit executor 的编辑独有语义：底图即当前图且是唯一参考图、prompt 即指令、
-按资源类型写回、版本带编辑标记、失败不写回。"""
+按资源类型写回、版本带编辑标记、失败不写回；image_size 解析迁移前后同源。"""
 
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from lib.config.resolver import ConfigResolver, ProviderModel
 from lib.db.base import Base
-from server.services import image_edit_tasks
+from lib.project_manager import ProjectManager
+from server.services import generation_context, image_edit_tasks
+from server.services.generation_context import (
+    GenerationContext,
+    ImageLaneRequest,
+    ImageLaneResult,
+    resolve_generation_context,
+)
 from server.services.image_edit_tasks import (
     IMAGE_EDIT_VERSION_SOURCE,
     execute_image_edit_task,
@@ -16,19 +25,12 @@ from server.services.image_edit_tasks import (
 )
 
 
-def _async_return(value):
-    async def _inner(*args, **kwargs):
-        return value
-
-    return _inner
-
-
 @pytest.fixture
 async def session_factory(monkeypatch):
     """真实内存 DB：建全部 ORM 表，把 lib.db.async_session_factory 指向它。
 
-    编辑任务的 image provider / resolution 解析走真实 ConfigResolver，仅 backend/generator
-    构造经 get_media_generator 单缝替换，不再拼装 resolve 侧 monkeypatch。
+    供 image_size 解析等价用例的真实 ConfigResolver 使用（预置供应商无 DB 行，自定义供应商
+    默认 resolution 才落 DB）。
     """
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -106,10 +108,22 @@ def _prepare_files(tmp_path: Path) -> Path:
     return project_path
 
 
-def _patch_common(monkeypatch, fake_pm, fake_generator):
-    """仅替换项目管理器与 generator 构造缝；image provider / resolution 走真实 ConfigResolver。"""
+def _patch_common(monkeypatch, fake_pm, fake_generator, *, resolution=None):
+    """替换项目管理器与 generation context 解析缝：ctx.generator 即 fake_generator，
+    image lane 携带指定 resolution。断言编辑恒声明 i2i 槽（capability == "i2i"）。"""
     monkeypatch.setattr(image_edit_tasks, "get_project_manager", lambda: fake_pm)
-    monkeypatch.setattr(image_edit_tasks, "get_media_generator", _async_return(fake_generator))
+
+    async def _fake_resolve(project_name, payload, *, project, image=None, **_kwargs):
+        assert image is not None and image.capability == "i2i"
+        lane = ImageLaneResult(
+            provider_model=ProviderModel("gemini-aistudio", "gemini-image"),
+            backend_name="gemini-aistudio",
+            backend_model="gemini-image",
+            resolution=resolution,
+        )
+        return GenerationContext(generator=fake_generator, image_lane=lane)
+
+    monkeypatch.setattr(image_edit_tasks, "resolve_generation_context", _fake_resolve)
 
 
 class TestResolveCurrentImageRel:
@@ -135,7 +149,7 @@ class TestResolveCurrentImageRel:
 
 
 class TestExecuteImageEditTask:
-    async def test_character_edit_uses_current_image_as_sole_reference(self, tmp_path, monkeypatch, session_factory):
+    async def test_character_edit_uses_current_image_as_sole_reference(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = _FakeGenerator()
@@ -166,7 +180,7 @@ class TestExecuteImageEditTask:
         assert result["version"] == 2
         assert result["file_path"] == "characters/Alice.png"
 
-    async def test_storyboard_edit_reads_pointer_writes_canonical(self, tmp_path, monkeypatch, session_factory):
+    async def test_storyboard_edit_reads_pointer_writes_canonical(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = _FakeGenerator()
@@ -204,7 +218,7 @@ class TestExecuteImageEditTask:
         assert fake_generator.image_calls == []
         assert fake_pm.sheet_updates == []
 
-    async def test_backend_failure_skips_writeback(self, tmp_path, monkeypatch, session_factory):
+    async def test_backend_failure_skips_writeback(self, tmp_path, monkeypatch):
         """失败零损失：backend 抛错时不写回资源字段（current 图指针由 MediaGenerator 保证不触碰）。
         旧图基线登记先于 backend 调用发生，与成败无关、不因失败回滚，不在本用例断言范围。
         """
@@ -230,6 +244,63 @@ class TestExecuteImageEditTask:
             await execute_image_edit_task("demo", "Alice", {"resource_type": "character", "prompt": "   "})
         with pytest.raises(ValueError, match="script_file"):
             await execute_image_edit_task("demo", "E1S01", {"resource_type": "storyboard", "prompt": "x"})
+
+
+@dataclass
+class _EchoBackend:
+    """回声 backend：model 原样反映请求 model_id（无自定义回退，与 registry 身份一致）。"""
+
+    name: str
+    model: str
+
+
+class TestImageSizeResolutionEquivalence:
+    """image_size 同源：``ctx.image.resolution`` 等于「先 resolve_image_backend(i2i) 得
+    provider/model、再按 model_id 查 resolution」这一独立两步口径的结果。
+
+    编辑走 i2i 槽、预置供应商 backend.model 与 registry model_id 一致（无自定义回退），
+    故新路径「按 backend 实际 model 查」与两步口径「按 registry model_id 查」恒等。
+    """
+
+    @pytest.fixture
+    def _ctx_env(self, monkeypatch, tmp_path):
+        """真 ProjectManager（demo 项目目录）+ 回声 assemble 缝，避免 backend 构造触网。"""
+        pm = ProjectManager(tmp_path / "projects")
+        (tmp_path / "projects" / "demo").mkdir(parents=True)
+        monkeypatch.setattr(generation_context, "get_project_manager", lambda: pm)
+
+        async def _assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
+            return _EchoBackend(name=provider_id, model=model_id or "default-model")
+
+        monkeypatch.setattr(generation_context, "assemble_backend", _assemble)
+        generation_context.invalidate_backend_cache()
+        yield
+        generation_context.invalidate_backend_cache()
+
+    @staticmethod
+    async def _old_image_size(session_factory, project, payload):
+        """旧执行层口径：resolve_image_backend(i2i) 得 provider/model，再按 model_id 查 resolution。"""
+        resolver = ConfigResolver(session_factory)
+        async with resolver.session() as r:
+            resolved = await r.resolve_image_backend(project, payload, capability="i2i")
+            return await r.resolve_resolution(project, resolved.provider_id, resolved.model_id)
+
+    async def test_model_settings_override(self, session_factory, _ctx_env):
+        project = {
+            "image_provider_i2i": "gemini-aistudio/gemini-image",
+            "model_settings": {"gemini-aistudio/gemini-image": {"resolution": "2048x2048"}},
+        }
+        old = await self._old_image_size(session_factory, project, None)
+        ctx = await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest(capability="i2i"))
+        assert old == "2048x2048"
+        assert ctx.image.resolution == old
+
+    async def test_default_falls_back_to_none(self, session_factory, _ctx_env):
+        project = {"image_provider_i2i": "gemini-aistudio/gemini-image"}
+        old = await self._old_image_size(session_factory, project, None)
+        ctx = await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest(capability="i2i"))
+        assert old is None
+        assert ctx.image.resolution == old
 
 
 class TestImageEditEventMapping:


### PR DESCRIPTION
Closes #1216

## 变更

ADR 0049「消费方一次调用拿全」的最后一块收口：`execute_image_edit_task` 从 `get_media_generator` 旧入口迁到 `resolve_generation_context` 单点，声明 `image=ImageLaneRequest(capability="i2i")`（编辑恒 i2i），由 image lane 单次交付 generator、backend 与 resolution（`image_size = ctx.image.resolution`）。

随迁移删除全死的旧入口与其独占喂养的三个 helper（均 `generation_tasks` 侧）：
- `get_media_generator`
- `_resolve_effective_image_backend`
- `_resolve_resolution`
- `_resolve_video_backend`

保留：`lib/config/resolver.py` 的同名 `_resolve_video_backend` / `_resolve_video_backend_from_project` 是 `ConfigResolver` 私有方法、不同符号，不在删除范围。

顺带清理 `generation_tasks.py` 随删除产生的未用 import 与模块级 rate_limiter。

## image_size 等价性

新路径按 backend 实际 model 查 resolution，旧两步按 registry `model_id` 查；预置供应商二者恒等，差异仅在自定义供应商目标 model 被禁用回退时出现——此时「按实际身份查」是 ADR 0049 的有意更正。新增 `TestImageSizeResolutionEquivalence` 两场景（项目级覆盖 → `2048x2048`；默认回退 → `None`）显式断言两式相等。删除的 4 条 `_resolve_effective_image_backend` 薄投影测试其槽位选择覆盖已由 `test_config_resolver.py::TestResolveImageBackend` 承接。

## 验证

- `uv run ruff check` / `ruff format --check`：全绿
- `uv run basedpyright`（改动文件）：0 errors（5 warnings 均为既有 `reportUnnecessaryIsInstance`）
- `uv run python -m pytest -m "not e2e" --cov=lib --cov=server --cov-fail-under=80`：6186 passed，总覆盖率 90.93%
- 全库 grep 确认四个删除符号零残留（`resolver.py` 同名方法为 ConfigResolver 私有符号，不在范围）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 图片编辑任务统一通过图像到图像（i2i）流程执行，提升编辑生成链路的一致性。
  - 图片分辨率将依据当前生成配置自动解析，并正确应用模型设置中的分辨率覆盖项。
  - 未配置分辨率时将保持默认行为，避免影响现有编辑任务。
- **稳定性**
  - 保留编辑失败时不写回结果，以及当前图片和历史版本的回滚保护。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->