### PR TITLE
feat(frontend): 前端入队动作层收拢乐观占用打标，并透出取消窗口期的去重反馈

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ ConfigService（`service.py`）→ Repository（持久化 + 密钥脱敏）→ R
 - Vite 代理：`/api` → `http://127.0.0.1:1241`
 - i18n：`i18next` + `react-i18next`，翻译文件在 `frontend/src/i18n/{zh,en,vi}/`，命名空间 `common`/`dashboard`/`auth`/`errors`/`assets`/`templates`
 - **占用感知型控件接线** — 编辑/重生成/上传/入库/版本恢复等随资源占用态禁用的控件，新增或改动时通过三项检查：弹窗/面板打开时校验当前占用态；提交时刻复核最新占用态（打开后状态可能已变化，仅查打开时刻会留竞态窗口）；同一资源卡片上的兄弟控件同步接线禁用
+- **入队走动作层** — 生成类入队操作一律经 `frontend/src/actions/` 的动作函数（内部统一封装 API 调用、乐观占用打标与去重提示），组件不直调入队类 API 方法；新增入队类 API 方法时同步登记 `frontend/eslint.config.js` 中 no-restricted-syntax 的方法名清单
 
 ## 关键设计模式
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -95,4 +95,24 @@ export default tseslint.config(
       "react-hooks/incompatible-library": "error",
     },
   },
+
+  // 入队类 API 方法只能经 src/actions/ 的入队动作层调用——乐观占用打标、
+  // 去重提示与返回值归一化由动作层统一封装，组件直调会绕过这些副作用。
+  // 新增入队类 API 方法时同步把方法名登记进下方 selector 的清单。
+  // src/api.test.ts 豁免：它测试的是 API 层本体的端点路径与请求体。
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: ["src/actions/**", "src/api.test.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "CallExpression[callee.object.name='API'][callee.property.name=/^(generateStoryboard|generateVideo|generateNarrationAudio|generateEpisodeNarrationAudio|generateCharacter|generateProjectScene|generateProjectProp|generateProjectProduct|editImage|generateGrid|regenerateGrid|generateReferenceVideoUnit)$/]",
+          message:
+            "入队类 API 方法只能经 src/actions/ 的入队动作层调用（统一封装乐观占用打标与去重提示）。",
+        },
+      ],
+    },
+  },
 );

--- a/frontend/src/actions/generation.test.ts
+++ b/frontend/src/actions/generation.test.ts
@@ -1,0 +1,256 @@
+/**
+ * 入队动作层测试：spy API 静态方法 + 真实 zustand store，
+ * 验证「API 调用 → 乐观打标 → toast → 返回值归一化」的固定封装，
+ * 以及 deduped=true 统一 info 提示与失败上抛不打标。
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { API } from "@/api";
+import i18n from "@/i18n";
+import { useAppStore } from "@/stores/app-store";
+import { useTasksStore } from "@/stores/tasks-store";
+import {
+  enqueueCharacter,
+  enqueueEpisodeNarration,
+  enqueueGrid,
+  enqueueGridRegenerate,
+  enqueueImageEdit,
+  enqueueNarration,
+  enqueueProduct,
+  enqueueProp,
+  enqueueReferenceVideoUnit,
+  enqueueScene,
+  enqueueStoryboard,
+  enqueueVideo,
+} from "@/actions/generation";
+
+const SINGLE_OK = { success: true, task_id: "t1", deduped: false, message: "ok" };
+
+function optimisticKeys(): string[] {
+  return Array.from(useTasksStore.getState().optimisticActive);
+}
+
+function optimisticScriptFileKeys(): string[] {
+  return Array.from(useTasksStore.getState().optimisticActiveScriptFile);
+}
+
+beforeEach(() => {
+  useTasksStore.setState({
+    tasks: [],
+    optimisticActive: new Set(),
+    optimisticActiveScriptFile: new Set(),
+  });
+  useAppStore.setState({ toast: null });
+});
+
+describe("enqueueStoryboard", () => {
+  it("成功时调 API、打乐观标记、弹成功 toast 并归一化返回值", async () => {
+    const spy = vi.spyOn(API, "generateStoryboard").mockResolvedValue(SINGLE_OK);
+
+    const res = await enqueueStoryboard("demo", "seg-1", "img prompt", "episode_1.json");
+
+    expect(spy).toHaveBeenCalledWith("demo", "seg-1", "img prompt", "episode_1.json");
+    expect(optimisticKeys()).toEqual(["demo\0storyboard\0seg-1\0storyboard\0"]);
+    const toast = useAppStore.getState().toast;
+    expect(toast?.text).toBe(i18n.t("dashboard:storyboard_task_submitted_toast", { id: "seg-1" }));
+    expect(toast?.tone).toBe("success");
+    expect(res).toEqual({ taskIds: ["t1"], deduped: false });
+  });
+
+  it("deduped=true 时改弹统一 info 提示，仍打标并透出 deduped", async () => {
+    vi.spyOn(API, "generateStoryboard").mockResolvedValue({ ...SINGLE_OK, deduped: true });
+
+    const res = await enqueueStoryboard("demo", "seg-1", "img prompt", "episode_1.json");
+
+    const toast = useAppStore.getState().toast;
+    expect(toast?.text).toBe(i18n.t("dashboard:enqueue_deduped_toast"));
+    expect(toast?.tone).toBe("info");
+    expect(optimisticKeys()).toHaveLength(1);
+    expect(res.deduped).toBe(true);
+  });
+
+  it("API 失败时向上抛，不打标也不弹 toast", async () => {
+    vi.spyOn(API, "generateStoryboard").mockRejectedValue(new Error("boom"));
+
+    await expect(enqueueStoryboard("demo", "seg-1", "p", "episode_1.json")).rejects.toThrow("boom");
+
+    expect(optimisticKeys()).toEqual([]);
+    expect(useAppStore.getState().toast).toBeNull();
+  });
+});
+
+describe("单资源入队动作的乐观标记 kind / taskType", () => {
+  it.each([
+    {
+      label: "video",
+      run: () => enqueueVideo("demo", "seg-1", "p", "episode_1.json", 4),
+      method: "generateVideo" as const,
+      key: "demo\0video\0seg-1\0video\0",
+    },
+    {
+      label: "tts",
+      run: () => enqueueNarration("demo", "seg-1", "episode_1.json"),
+      method: "generateNarrationAudio" as const,
+      key: "demo\0tts\0seg-1\0tts\0",
+    },
+    {
+      label: "character",
+      run: () => enqueueCharacter("demo", "Hero", "p"),
+      method: "generateCharacter" as const,
+      key: "demo\0character\0Hero\0character\0",
+    },
+    {
+      label: "scene",
+      run: () => enqueueScene("demo", "Temple", "p"),
+      method: "generateProjectScene" as const,
+      key: "demo\0scene\0Temple\0scene\0",
+    },
+    {
+      label: "prop",
+      run: () => enqueueProp("demo", "Sword", "p"),
+      method: "generateProjectProp" as const,
+      key: "demo\0prop\0Sword\0prop\0",
+    },
+    {
+      label: "product",
+      run: () => enqueueProduct("demo", "Phone", "p"),
+      method: "generateProjectProduct" as const,
+      key: "demo\0product\0Phone\0product\0",
+    },
+  ])("$label：成功后按资源类型打标并归一化 task_id", async ({ run, method, key }) => {
+    vi.spyOn(API, method).mockResolvedValue(SINGLE_OK);
+
+    const res = await run();
+
+    expect(optimisticKeys()).toEqual([key]);
+    expect(res).toEqual({ taskIds: ["t1"], deduped: false });
+  });
+});
+
+describe("enqueueEpisodeNarration", () => {
+  it("有缺失片段时弹批量提交 toast，不打乐观标记", async () => {
+    vi.spyOn(API, "generateEpisodeNarrationAudio").mockResolvedValue({
+      success: true,
+      task_ids: ["t1", "t2"],
+      deduped: false,
+      message: "ok",
+    });
+
+    const res = await enqueueEpisodeNarration("demo", "episode_1.json");
+
+    expect(useAppStore.getState().toast?.text).toBe(
+      i18n.t("dashboard:narration_batch_submitted_toast", { count: 2 }),
+    );
+    expect(optimisticKeys()).toEqual([]);
+    expect(optimisticScriptFileKeys()).toEqual([]);
+    expect(res).toEqual({ taskIds: ["t1", "t2"], deduped: false });
+  });
+
+  it("无缺失片段（task_ids 为空）时弹无缺失提示", async () => {
+    vi.spyOn(API, "generateEpisodeNarrationAudio").mockResolvedValue({
+      success: true,
+      task_ids: [],
+      deduped: false,
+      message: "ok",
+    });
+
+    await enqueueEpisodeNarration("demo", "episode_1.json");
+
+    expect(useAppStore.getState().toast?.text).toBe(
+      i18n.t("dashboard:narration_batch_none_missing_toast"),
+    );
+  });
+});
+
+describe("enqueueImageEdit", () => {
+  it("按被编辑资源类型归槽打标，taskType 固定 image_edit，toast 用后端 message", async () => {
+    vi.spyOn(API, "editImage").mockResolvedValue({ ...SINGLE_OK, message: "已提交图片编辑" });
+
+    const res = await enqueueImageEdit("demo", {
+      resourceType: "storyboard",
+      resourceId: "seg-1",
+      instruction: "去掉水印",
+      scriptFile: "episode_1.json",
+    });
+
+    expect(optimisticKeys()).toEqual(["demo\0storyboard\0seg-1\0image_edit\0"]);
+    expect(useAppStore.getState().toast?.text).toBe("已提交图片编辑");
+    expect(res).toEqual({ taskIds: ["t1"], deduped: false });
+  });
+});
+
+describe("enqueueGrid", () => {
+  it("task_ids 非空时按 scriptFile 粒度打标，toast 用后端 message", async () => {
+    vi.spyOn(API, "generateGrid").mockResolvedValue({
+      success: true,
+      grid_ids: ["g1"],
+      task_ids: ["t1"],
+      deduped: false,
+      message: "已入队 1 个宫格",
+    });
+
+    const res = await enqueueGrid("demo", 1, "episode_1.json");
+
+    expect(optimisticScriptFileKeys()).toEqual(["demo\0grid\0episode_1.json\0"]);
+    expect(useAppStore.getState().toast?.text).toBe("已入队 1 个宫格");
+    expect(res).toEqual({ taskIds: ["t1"], deduped: false });
+  });
+
+  it("task_ids 为空时不打标（无任务落库，标记会永久残留）", async () => {
+    vi.spyOn(API, "generateGrid").mockResolvedValue({
+      success: true,
+      grid_ids: [],
+      task_ids: [],
+      deduped: false,
+      message: "无匹配分组",
+    });
+
+    await enqueueGrid("demo", 1, "episode_1.json", ["S9"]);
+
+    expect(optimisticScriptFileKeys()).toEqual([]);
+  });
+});
+
+describe("enqueueGridRegenerate", () => {
+  it("成功时静默（面板内已有状态反馈），有 scriptFile 则打标", async () => {
+    vi.spyOn(API, "regenerateGrid").mockResolvedValue({ success: true, task_id: "t1", deduped: false });
+
+    const res = await enqueueGridRegenerate("demo", "grid-1", "episode_1.json");
+
+    expect(optimisticScriptFileKeys()).toEqual(["demo\0grid\0episode_1.json\0"]);
+    expect(useAppStore.getState().toast).toBeNull();
+    expect(res).toEqual({ taskIds: ["t1"], deduped: false });
+  });
+
+  it("scriptFile 为 null 时不打标；deduped=true 仍弹统一 info 提示", async () => {
+    vi.spyOn(API, "regenerateGrid").mockResolvedValue({ success: true, task_id: "t1", deduped: true });
+
+    await enqueueGridRegenerate("demo", "grid-1", null);
+
+    expect(optimisticScriptFileKeys()).toEqual([]);
+    const toast = useAppStore.getState().toast;
+    expect(toast?.text).toBe(i18n.t("dashboard:enqueue_deduped_toast"));
+    expect(toast?.tone).toBe("info");
+  });
+});
+
+describe("enqueueReferenceVideoUnit", () => {
+  it("成功时打标并弹入队 info 提示", async () => {
+    vi.spyOn(API, "generateReferenceVideoUnit").mockResolvedValue({ task_id: "t1", deduped: false });
+
+    const res = await enqueueReferenceVideoUnit("demo", 1, "E1U1");
+
+    expect(optimisticKeys()).toEqual(["demo\0reference_video\0E1U1\0reference_video\0"]);
+    const toast = useAppStore.getState().toast;
+    expect(toast?.text).toBe(i18n.t("dashboard:reference_generate_queued"));
+    expect(toast?.tone).toBe("info");
+    expect(res).toEqual({ taskIds: ["t1"], deduped: false });
+  });
+
+  it("deduped=true 时改弹统一去重提示", async () => {
+    vi.spyOn(API, "generateReferenceVideoUnit").mockResolvedValue({ task_id: "t1", deduped: true });
+
+    await enqueueReferenceVideoUnit("demo", 1, "E1U1");
+
+    expect(useAppStore.getState().toast?.text).toBe(i18n.t("dashboard:enqueue_deduped_toast"));
+  });
+});

--- a/frontend/src/actions/generation.ts
+++ b/frontend/src/actions/generation.ts
@@ -1,0 +1,195 @@
+/**
+ * 入队动作层：所有生成类入队操作的唯一入口。
+ *
+ * 每个动作内部固定封装三件事：
+ * 1. 调用对应 API 入队端点；
+ * 2. 成功后在 tasks-store 打乐观占用标记（入队成功到 SSE 轮询把真实任务行
+ *    写进 store 之间有 ~3s 空窗，期间同资源的其它入口会误判为空闲）；
+ * 3. 弹提示：后端 deduped=true（同资源任务已在处理中，本次未新建）时统一
+ *    弹 info 提示，否则沿用各操作原有的成功文案。
+ *
+ * 失败一律向上抛，由调用方决定错误提示与回滚副作用。返回值统一归一化为
+ * EnqueueResult，屏蔽各端点 task_id / task_ids 的形状差异。
+ *
+ * 组件禁止绕过本层直调入队类 API 方法（ESLint no-restricted-syntax 强制）。
+ */
+import { API } from "@/api";
+import i18n from "@/i18n";
+import { useAppStore } from "@/stores/app-store";
+import { useTasksStore } from "@/stores/tasks-store";
+
+export interface EnqueueResult {
+  taskIds: string[];
+  deduped: boolean;
+}
+
+/**
+ * deduped 时弹统一 info 提示；否则弹该操作自己的成功文案
+ * （successText 为 null 表示该操作成功时本就静默，维持静默）。
+ */
+function notifyEnqueued(
+  deduped: boolean,
+  successText: string | null,
+  successTone: "success" | "info" = "success",
+): void {
+  const { pushToast } = useAppStore.getState();
+  if (deduped) {
+    pushToast(i18n.t("dashboard:enqueue_deduped_toast"), "info");
+  } else if (successText !== null) {
+    pushToast(successText, successTone);
+  }
+}
+
+export async function enqueueStoryboard(
+  projectName: string,
+  segmentId: string,
+  prompt: string | Record<string, unknown>,
+  scriptFile: string,
+): Promise<EnqueueResult> {
+  const res = await API.generateStoryboard(projectName, segmentId, prompt, scriptFile);
+  useTasksStore.getState().markOptimisticActive(projectName, "storyboard", segmentId, "storyboard");
+  notifyEnqueued(res.deduped, i18n.t("dashboard:storyboard_task_submitted_toast", { id: segmentId }));
+  return { taskIds: [res.task_id], deduped: res.deduped };
+}
+
+export async function enqueueVideo(
+  projectName: string,
+  segmentId: string,
+  prompt: string | Record<string, unknown>,
+  scriptFile: string,
+  durationSeconds?: number,
+): Promise<EnqueueResult> {
+  const res = await API.generateVideo(projectName, segmentId, prompt, scriptFile, durationSeconds);
+  useTasksStore.getState().markOptimisticActive(projectName, "video", segmentId, "video");
+  notifyEnqueued(res.deduped, i18n.t("dashboard:video_task_submitted_toast", { id: segmentId }));
+  return { taskIds: [res.task_id], deduped: res.deduped };
+}
+
+export async function enqueueNarration(
+  projectName: string,
+  segmentId: string,
+  scriptFile: string,
+): Promise<EnqueueResult> {
+  const res = await API.generateNarrationAudio(projectName, segmentId, scriptFile);
+  useTasksStore.getState().markOptimisticActive(projectName, "tts", segmentId, "tts");
+  notifyEnqueued(res.deduped, i18n.t("dashboard:narration_task_submitted_toast", { id: segmentId }));
+  return { taskIds: [res.task_id], deduped: res.deduped };
+}
+
+export async function enqueueEpisodeNarration(
+  projectName: string,
+  scriptFile: string,
+): Promise<EnqueueResult> {
+  const res = await API.generateEpisodeNarrationAudio(projectName, scriptFile);
+  // 批量响应不含各段 segment_id，无法逐段打乐观标记；批量入口本身没有
+  // 逐段占用消费方，空窗期由 SSE 轮询写回真实任务行兜住。
+  notifyEnqueued(
+    res.deduped,
+    res.task_ids.length > 0
+      ? i18n.t("dashboard:narration_batch_submitted_toast", { count: res.task_ids.length })
+      : i18n.t("dashboard:narration_batch_none_missing_toast"),
+  );
+  return { taskIds: res.task_ids, deduped: res.deduped };
+}
+
+export async function enqueueCharacter(
+  projectName: string,
+  name: string,
+  prompt: string,
+): Promise<EnqueueResult> {
+  const res = await API.generateCharacter(projectName, name, prompt);
+  useTasksStore.getState().markOptimisticActive(projectName, "character", name, "character");
+  notifyEnqueued(res.deduped, i18n.t("dashboard:character_task_submitted_toast", { name }));
+  return { taskIds: [res.task_id], deduped: res.deduped };
+}
+
+export async function enqueueScene(
+  projectName: string,
+  name: string,
+  prompt: string,
+): Promise<EnqueueResult> {
+  const res = await API.generateProjectScene(projectName, name, prompt);
+  useTasksStore.getState().markOptimisticActive(projectName, "scene", name, "scene");
+  notifyEnqueued(res.deduped, i18n.t("dashboard:scene_task_submitted_toast", { name }));
+  return { taskIds: [res.task_id], deduped: res.deduped };
+}
+
+export async function enqueueProp(
+  projectName: string,
+  name: string,
+  prompt: string,
+): Promise<EnqueueResult> {
+  const res = await API.generateProjectProp(projectName, name, prompt);
+  useTasksStore.getState().markOptimisticActive(projectName, "prop", name, "prop");
+  notifyEnqueued(res.deduped, i18n.t("dashboard:prop_task_submitted_toast", { name }));
+  return { taskIds: [res.task_id], deduped: res.deduped };
+}
+
+export async function enqueueProduct(
+  projectName: string,
+  name: string,
+  prompt: string,
+): Promise<EnqueueResult> {
+  const res = await API.generateProjectProduct(projectName, name, prompt);
+  useTasksStore.getState().markOptimisticActive(projectName, "product", name, "product");
+  notifyEnqueued(res.deduped, i18n.t("dashboard:product_task_submitted_toast", { name }));
+  return { taskIds: [res.task_id], deduped: res.deduped };
+}
+
+export async function enqueueImageEdit(
+  projectName: string,
+  params: {
+    resourceType: "character" | "scene" | "prop" | "product" | "storyboard";
+    resourceId: string;
+    instruction: string;
+    scriptFile?: string | null;
+  },
+): Promise<EnqueueResult> {
+  const res = await API.editImage(projectName, params);
+  // image_edit 与生成任务共享同一资源槽位：kind 按被编辑资源类型归槽，
+  // pendingTaskType 固定 image_edit，与 taskResourceKind 的归一化保持一致。
+  useTasksStore.getState().markOptimisticActive(projectName, params.resourceType, params.resourceId, "image_edit");
+  notifyEnqueued(res.deduped, res.message);
+  return { taskIds: [res.task_id], deduped: res.deduped };
+}
+
+export async function enqueueGrid(
+  projectName: string,
+  episode: number,
+  scriptFile: string,
+  sceneIds?: string[],
+): Promise<EnqueueResult> {
+  const res = await API.generateGrid(projectName, episode, scriptFile, sceneIds);
+  // task_ids 可能为空数组（如 scene_ids 过滤后无匹配分组）：此时后端不会产生
+  // 任何任务行，乐观标记将永远等不到真实任务落库来解除，需在打标前排除。
+  if (res.task_ids.length > 0) {
+    useTasksStore.getState().markOptimisticActiveForScriptFile(projectName, "grid", scriptFile);
+  }
+  notifyEnqueued(res.deduped, res.message);
+  return { taskIds: res.task_ids, deduped: res.deduped };
+}
+
+export async function enqueueGridRegenerate(
+  projectName: string,
+  gridId: string,
+  scriptFile: string | null,
+): Promise<EnqueueResult> {
+  const res = await API.regenerateGrid(projectName, gridId);
+  if (scriptFile) {
+    useTasksStore.getState().markOptimisticActiveForScriptFile(projectName, "grid", scriptFile);
+  }
+  // 重生成入口成功时静默（面板内已有状态反馈），仅 deduped 时弹提示。
+  notifyEnqueued(res.deduped, null);
+  return { taskIds: [res.task_id], deduped: res.deduped };
+}
+
+export async function enqueueReferenceVideoUnit(
+  projectName: string,
+  episode: number,
+  unitId: string,
+): Promise<EnqueueResult> {
+  const res = await API.generateReferenceVideoUnit(projectName, episode, unitId);
+  useTasksStore.getState().markOptimisticActive(projectName, "reference_video", unitId, "reference_video");
+  notifyEnqueued(res.deduped, i18n.t("dashboard:reference_generate_queued"), "info");
+  return { taskIds: [res.task_id], deduped: res.deduped };
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1113,7 +1113,7 @@ class API {
     segmentId: string,
     prompt: string | Record<string, unknown>,
     scriptFile: string
-  ): Promise<{ success: boolean; task_id: string; message: string }> {
+  ): Promise<{ success: boolean; task_id: string; deduped: boolean; message: string }> {
     return this.request(
       `/projects/${encodeURIComponent(projectName)}/generate/storyboard/${encodeURIComponent(segmentId)}`,
       {
@@ -1137,7 +1137,7 @@ class API {
     prompt: string | Record<string, unknown>,
     scriptFile: string,
     durationSeconds: number = 4
-  ): Promise<{ success: boolean; task_id: string; message: string }> {
+  ): Promise<{ success: boolean; task_id: string; deduped: boolean; message: string }> {
     return this.request(
       `/projects/${encodeURIComponent(projectName)}/generate/video/${encodeURIComponent(segmentId)}`,
       {
@@ -1161,7 +1161,7 @@ class API {
     projectName: string,
     segmentId: string,
     scriptFile: string
-  ): Promise<{ success: boolean; task_id: string; message: string }> {
+  ): Promise<{ success: boolean; task_id: string; deduped: boolean; message: string }> {
     return this.request(
       `/projects/${encodeURIComponent(projectName)}/generate/tts/${encodeURIComponent(segmentId)}`,
       {
@@ -1179,7 +1179,7 @@ class API {
   static async generateEpisodeNarrationAudio(
     projectName: string,
     scriptFile: string
-  ): Promise<{ success: boolean; task_ids: string[]; message: string }> {
+  ): Promise<{ success: boolean; task_ids: string[]; deduped: boolean; message: string }> {
     return this.request(
       `/projects/${encodeURIComponent(projectName)}/generate/tts`,
       {
@@ -1202,6 +1202,7 @@ class API {
   ): Promise<{
     success: boolean;
     task_id: string;
+    deduped: boolean;
     message: string;
   }> {
     return this.request(
@@ -1226,6 +1227,7 @@ class API {
   ): Promise<{
     success: boolean;
     task_id: string;
+    deduped: boolean;
     message: string;
   }> {
     return this.request(
@@ -1250,6 +1252,7 @@ class API {
   ): Promise<{
     success: boolean;
     task_id: string;
+    deduped: boolean;
     message: string;
   }> {
     return this.request(
@@ -1274,6 +1277,7 @@ class API {
   ): Promise<{
     success: boolean;
     task_id: string;
+    deduped: boolean;
     message: string;
   }> {
     return this.request(
@@ -1300,6 +1304,7 @@ class API {
   ): Promise<{
     success: boolean;
     task_id: string;
+    deduped: boolean;
     message: string;
   }> {
     return this.request(
@@ -1938,7 +1943,7 @@ class API {
     episode: number,
     scriptFile: string,
     sceneIds?: string[]
-  ): Promise<{ success: boolean; grid_ids: string[]; task_ids: string[]; message: string }> {
+  ): Promise<{ success: boolean; grid_ids: string[]; task_ids: string[]; deduped: boolean; message: string }> {
     return this.request(
       `/projects/${encodeURIComponent(projectName)}/generate/grid/${episode}`,
       { method: "POST", body: JSON.stringify({ script_file: scriptFile, scene_ids: sceneIds }) }
@@ -1970,7 +1975,7 @@ class API {
   static async regenerateGrid(
     projectName: string,
     gridId: string
-  ): Promise<{ success: boolean; task_id: string }> {
+  ): Promise<{ success: boolean; task_id: string; deduped: boolean }> {
     return this.request(
       `/projects/${encodeURIComponent(projectName)}/grids/${encodeURIComponent(gridId)}/regenerate`,
       { method: "POST" }

--- a/frontend/src/components/canvas/AdInitCanvas.test.tsx
+++ b/frontend/src/components/canvas/AdInitCanvas.test.tsx
@@ -33,6 +33,7 @@ describe("AdInitCanvas", () => {
     vi.spyOn(API, "generateProjectProduct").mockResolvedValue({
       success: true,
       task_id: "t1",
+      deduped: false,
       message: "ok",
     });
 

--- a/frontend/src/components/canvas/AdInitCanvas.tsx
+++ b/frontend/src/components/canvas/AdInitCanvas.tsx
@@ -2,6 +2,7 @@ import { useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ImagePlus, ShoppingBag, Sparkles, X } from "lucide-react";
 import { API } from "@/api";
+import { enqueueProduct } from "@/actions/generation";
 import { useAppStore } from "@/stores/app-store";
 import { errMsg } from "@/utils/async";
 
@@ -73,7 +74,7 @@ export function AdInitCanvas({ projectName, onDone }: AdInitCanvasProps) {
         await API.updateProject(projectName, { brief: brief.trim() });
       }
       if (generateSheet && hasProduct) {
-        await API.generateProjectProduct(projectName, name, desc);
+        await enqueueProduct(projectName, name, desc);
       }
       useAppStore.getState().pushToast(t("dashboard:ad_init_success_toast"), "success");
       await onDone();

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -410,7 +410,7 @@ describe("StudioCanvasRouter", () => {
     });
     vi.spyOn(API, "updateCharacter").mockResolvedValue({ success: true });
     vi.spyOn(API, "uploadFile").mockResolvedValue({ success: true, path: "x", url: "y" });
-    vi.spyOn(API, "generateCharacter").mockResolvedValue({ success: true, task_id: "t-1", message: "已提交" });
+    vi.spyOn(API, "generateCharacter").mockResolvedValue({ success: true, task_id: "t-1", deduped: false, message: "已提交" });
     vi.spyOn(API, "addCharacter").mockResolvedValue({ success: true });
 
     renderAt("/characters");
@@ -526,7 +526,7 @@ describe("StudioCanvasRouter", () => {
       project: makeProjectData(),
       scripts: { "episode_1.json": makeScript() },
     });
-    vi.spyOn(API, "generateProjectScene").mockResolvedValue({ success: true, task_id: "t-1", message: "已提交" });
+    vi.spyOn(API, "generateProjectScene").mockResolvedValue({ success: true, task_id: "t-1", deduped: false, message: "已提交" });
 
     renderAt("/scenes");
     fireEvent.click(screen.getByText("generate-scene"));
@@ -548,7 +548,7 @@ describe("StudioCanvasRouter", () => {
       project: makeProjectData(),
       scripts: { "episode_1.json": makeScript() },
     });
-    vi.spyOn(API, "generateProjectProp").mockResolvedValue({ success: true, task_id: "t-1", message: "已提交" });
+    vi.spyOn(API, "generateProjectProp").mockResolvedValue({ success: true, task_id: "t-1", deduped: false, message: "已提交" });
 
     renderAt("/props");
     fireEvent.click(screen.getByText("generate-prop"));
@@ -576,7 +576,7 @@ describe("StudioCanvasRouter", () => {
     const updateSpy = vi.spyOn(API, "updateProjectProduct").mockResolvedValue({ success: true });
     const generateSpy = vi
       .spyOn(API, "generateProjectProduct")
-      .mockResolvedValue({ success: true, task_id: "t-1", message: "已提交" });
+      .mockResolvedValue({ success: true, task_id: "t-1", deduped: false, message: "已提交" });
     const addSpy = vi.spyOn(API, "addProjectProduct").mockResolvedValue({ success: true });
 
     renderAt("/products");
@@ -712,11 +712,13 @@ describe("StudioCanvasRouter", () => {
     vi.spyOn(API, "generateStoryboard").mockResolvedValue({
       success: true,
       task_id: "t-sb",
+      deduped: false,
       message: "已提交",
     });
     vi.spyOn(API, "generateVideo").mockResolvedValue({
       success: true,
       task_id: "t-v",
+      deduped: false,
       message: "已提交",
     });
 
@@ -907,6 +909,7 @@ describe("StudioCanvasRouter", () => {
     vi.spyOn(API, "generateStoryboard").mockResolvedValue({
       success: true,
       task_id: "t-sb",
+      deduped: false,
       message: "已提交",
     });
 
@@ -1012,6 +1015,7 @@ describe("StudioCanvasRouter", () => {
     vi.spyOn(API, "generateNarrationAudio").mockResolvedValue({
       success: true,
       task_id: "t-1",
+      deduped: false,
       message: "已提交",
     });
 
@@ -1061,6 +1065,7 @@ describe("StudioCanvasRouter", () => {
     vi.spyOn(API, "generateEpisodeNarrationAudio").mockResolvedValue({
       success: true,
       task_ids: ["t-1", "t-2"],
+      deduped: false,
       message: "已提交",
     });
 
@@ -1088,6 +1093,7 @@ describe("StudioCanvasRouter", () => {
     vi.spyOn(API, "generateEpisodeNarrationAudio").mockResolvedValue({
       success: true,
       task_ids: [],
+      deduped: false,
       message: "无需补缺",
     });
 
@@ -1165,6 +1171,7 @@ describe("StudioCanvasRouter", () => {
       success: true,
       grid_ids: ["grid-1"],
       task_ids: ["t-1"],
+      deduped: false,
       message: "已提交",
     });
 
@@ -1195,6 +1202,7 @@ describe("StudioCanvasRouter", () => {
       success: true,
       grid_ids: [],
       task_ids: [],
+      deduped: false,
       message: "已提交 0 个宫格生成任务",
     });
 

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useAppStore } from "@/stores/app-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
-import { useActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
+import { useActiveResourceIds } from "@/stores/tasks-store";
 import { TimelineCanvas } from "./timeline/TimelineCanvas";
 import { OverviewCanvas } from "./OverviewCanvas";
 import { SourceFileViewer } from "./SourceFileViewer";
@@ -18,6 +18,17 @@ import { ReferenceVideoCanvas } from "./reference/ReferenceVideoCanvas";
 import { GridImageToVideoCanvas } from "./grid/GridImageToVideoCanvas";
 import { EpisodeSourceReview } from "./EpisodeSourceReview";
 import { API } from "@/api";
+import {
+  enqueueCharacter,
+  enqueueEpisodeNarration,
+  enqueueGrid,
+  enqueueNarration,
+  enqueueProduct,
+  enqueueProp,
+  enqueueScene,
+  enqueueStoryboard,
+  enqueueVideo,
+} from "@/actions/generation";
 import { buildEntityRevisionKey } from "@/utils/project-changes";
 import { getProviderModels, getCustomProviderModels, lookupSupportedDurations } from "@/utils/provider-models";
 import { effectiveMode } from "@/utils/generation-mode";
@@ -215,17 +226,12 @@ export function StudioCanvasRouter() {
     const resolved = resolveSegmentPrompt(currentScripts, segmentId, "image_prompt", scriptFile);
     if (!resolved) return;
     try {
-      await API.generateStoryboard(
+      await enqueueStoryboard(
         currentProjectName,
         segmentId,
         resolved.prompt as string | Record<string, unknown>,
         resolved.resolvedFile,
       );
-      // 乐观占用：入队成功到 SSE 下一次轮询把新任务行写进 store 之间有 ~3s 空窗，
-      // 期间同资源的 ImageEditButton 会误判为空闲，可并发提交 image_edit 与本次
-      // 重新生成竞争同一张 current 图（两者 task_type 不同，后端 dedupe 索引不拦）。
-      useTasksStore.getState().markOptimisticActive(currentProjectName, "storyboard", segmentId, "storyboard");
-      useAppStore.getState().pushToast(tRef.current("storyboard_task_submitted_toast", { id: segmentId }), "success");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("generate_storyboard_failed", { message: errMsg(err) }), "error");
     }
@@ -236,14 +242,13 @@ export function StudioCanvasRouter() {
     const resolved = resolveSegmentPrompt(currentScripts, segmentId, "video_prompt", scriptFile);
     if (!resolved) return;
     try {
-      await API.generateVideo(
+      await enqueueVideo(
         currentProjectName,
         segmentId,
         resolved.prompt as string | Record<string, unknown>,
         resolved.resolvedFile,
         resolved.duration,
       );
-      useAppStore.getState().pushToast(tRef.current("video_task_submitted_toast", { id: segmentId }), "success");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("generate_video_failed", { message: errMsg(err) }), "error");
     }
@@ -265,8 +270,7 @@ export function StudioCanvasRouter() {
     const resolvedFile = scriptFile ?? Object.keys(currentScripts)[0];
     if (!resolvedFile) return;
     try {
-      await API.generateNarrationAudio(currentProjectName, segmentId, resolvedFile);
-      useAppStore.getState().pushToast(tRef.current("narration_task_submitted_toast", { id: segmentId }), "success");
+      await enqueueNarration(currentProjectName, segmentId, resolvedFile);
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("generate_narration_failed", { message: errMsg(err) }), "error");
     }
@@ -278,12 +282,7 @@ export function StudioCanvasRouter() {
     const resolvedFile = scriptFile ?? Object.keys(currentScripts)[0];
     if (!resolvedFile) return;
     try {
-      const res = await API.generateEpisodeNarrationAudio(currentProjectName, resolvedFile);
-      const message =
-        res.task_ids.length > 0
-          ? tRef.current("narration_batch_submitted_toast", { count: res.task_ids.length })
-          : tRef.current("narration_batch_none_missing_toast");
-      useAppStore.getState().pushToast(message, "success");
+      await enqueueEpisodeNarration(currentProjectName, resolvedFile);
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("generate_narration_failed", { message: errMsg(err) }), "error");
     }
@@ -328,16 +327,11 @@ export function StudioCanvasRouter() {
   const handleGenerateCharacter = useCallback(async (name: string) => {
     if (!currentProjectName) return;
     try {
-      await API.generateCharacter(
+      await enqueueCharacter(
         currentProjectName,
         name,
         currentProjectData?.characters?.[name]?.description ?? "",
       );
-      // 乐观占用：见 handleGenerateStoryboard 同类注释。
-      useTasksStore.getState().markOptimisticActive(currentProjectName, "character", name, "character");
-      useAppStore
-        .getState()
-        .pushToast(tRef.current("character_task_submitted_toast", { name }), "success");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("submit_failed", { message: errMsg(err) }), "error");
     }
@@ -383,10 +377,7 @@ export function StudioCanvasRouter() {
   const handleGenerateScene = useCallback(async (name: string) => {
     if (!currentProjectName) return;
     try {
-      await API.generateProjectScene(currentProjectName, name, currentProjectData?.scenes?.[name]?.description ?? "");
-      // 乐观占用：见 handleGenerateStoryboard 同类注释。
-      useTasksStore.getState().markOptimisticActive(currentProjectName, "scene", name, "scene");
-      useAppStore.getState().pushToast(tRef.current("scene_task_submitted_toast", { name }), "success");
+      await enqueueScene(currentProjectName, name, currentProjectData?.scenes?.[name]?.description ?? "");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("submit_failed", { message: errMsg(err) }), "error");
     }
@@ -418,10 +409,7 @@ export function StudioCanvasRouter() {
   const handleGenerateProp = useCallback(async (name: string) => {
     if (!currentProjectName) return;
     try {
-      await API.generateProjectProp(currentProjectName, name, currentProjectData?.props?.[name]?.description ?? "");
-      // 乐观占用：见 handleGenerateStoryboard 同类注释。
-      useTasksStore.getState().markOptimisticActive(currentProjectName, "prop", name, "prop");
-      useAppStore.getState().pushToast(tRef.current("prop_task_submitted_toast", { name }), "success");
+      await enqueueProp(currentProjectName, name, currentProjectData?.props?.[name]?.description ?? "");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("submit_failed", { message: errMsg(err) }), "error");
     }
@@ -453,14 +441,11 @@ export function StudioCanvasRouter() {
   const handleGenerateProduct = useCallback(async (name: string) => {
     if (!currentProjectName) return;
     try {
-      await API.generateProjectProduct(
+      await enqueueProduct(
         currentProjectName,
         name,
         currentProjectData?.products?.[name]?.description ?? "",
       );
-      // 乐观占用：见 handleGenerateStoryboard 同类注释。
-      useTasksStore.getState().markOptimisticActive(currentProjectName, "product", name, "product");
-      useAppStore.getState().pushToast(tRef.current("product_task_submitted_toast", { name }), "success");
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("submit_failed", { message: errMsg(err) }), "error");
     }
@@ -481,16 +466,7 @@ export function StudioCanvasRouter() {
   const handleGenerateGrid = useCallback(async (episode: number, scriptFile: string, sceneIds?: string[]) => {
     if (!currentProjectName) return;
     try {
-      const result = await API.generateGrid(currentProjectName, episode, scriptFile, sceneIds);
-      // 乐观占用：入队成功到下一次轮询把新 grid 任务行写进 store 之间有 ~3s 空窗，期间本集
-      // 分镜编辑入口会误判为空闲，与随后的切割阶段并发写同一张 storyboard current 图，
-      // 见 tasks-store.ts::selectHasActiveTaskForScriptFile 的乐观占用小节。
-      // task_ids 可能为空数组（如 scene_ids 过滤后无匹配分组）：此时后端不会产生任何任务行，
-      // 乐观标记将永远等不到真实任务落库来解除，需在打标前排除这种空提交。
-      if (result.task_ids.length > 0) {
-        useTasksStore.getState().markOptimisticActiveForScriptFile(currentProjectName, "grid", scriptFile);
-      }
-      useAppStore.getState().pushToast(result.message, "success");
+      await enqueueGrid(currentProjectName, episode, scriptFile, sceneIds);
     } catch (err) {
       useAppStore.getState().pushToast(tRef.current("grid_generation_failed", { message: errMsg(err) }), "error");
     }

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
@@ -44,7 +44,13 @@ describe("ReferenceVideoCanvas", () => {
   beforeEach(() => {
     useReferenceVideoStore.setState({ unitsByEpisode: {}, selectedUnitId: null, loading: false, error: null });
     useProjectsStore.setState({ currentProjectName: "proj", currentProjectData: STUB_PROJECT });
-    useTasksStore.setState({ tasks: [], connected: false });
+    // 乐观标记由入队动作层写入且跨测试共享同一 store 实例，须一并重置
+    useTasksStore.setState({
+      tasks: [],
+      connected: false,
+      optimisticActive: new Set(),
+      optimisticActiveScriptFile: new Set(),
+    });
     useAppStore.setState({ toast: null });
   });
   afterEach(() => vi.restoreAllMocks());
@@ -219,11 +225,11 @@ describe("ReferenceVideoCanvas", () => {
     // 点击前 tasks store 为空，按钮启用
     expect(btn).not.toBeDisabled();
     fireEvent.click(btn);
-    // 立刻：按钮 disabled，显示 "Generating…/生成中"
-    await waitFor(() => expect(screen.getByRole("button", { name: /Generating|生成中/ })).toBeDisabled());
-    // 收尾：让 generate promise 完成 + info toast 冒出
-    resolveGen({ task_id: "t1", deduped: false });
     await waitFor(() => expect(genSpy).toHaveBeenCalled());
+    // 入队成功（202 返回）后、任务轮询写回前：动作层打乐观标记，按钮立即
+    // busy 并显示 "Generating…/生成中"；请求飞行中的双击由后端去重索引兜底
+    resolveGen({ task_id: "t1", deduped: false });
+    await waitFor(() => expect(screen.getByRole("button", { name: /Generating|生成中/ })).toBeDisabled());
     await waitFor(() => {
       expect(useAppStore.getState().toast?.text).toMatch(/Queued for generation|已加入生成队列/);
     });

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -17,11 +17,12 @@ import { ReferencePanel } from "./ReferencePanel";
 import { EpisodeHeader } from "./EpisodeHeader";
 import { ScriptReviewGate } from "@/components/canvas/timeline/ScriptReviewGate";
 import { API } from "@/api";
+import { enqueueReferenceVideoUnit } from "@/actions/generation";
 import {
   useReferenceVideoStore,
   referenceVideoCacheKey,
 } from "@/stores/reference-video-store";
-import { isActiveStatus, useLatestTasksByResource } from "@/stores/tasks-store";
+import { isActiveStatus, useActiveResourceIds, useLatestTasksByResource } from "@/stores/tasks-store";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useCostStore } from "@/stores/cost-store";
@@ -78,7 +79,6 @@ export function ReferenceVideoCanvas({
   const loadUnits = useReferenceVideoStore((s) => s.loadUnits);
   const addUnit = useReferenceVideoStore((s) => s.addUnit);
   const patchUnit = useReferenceVideoStore((s) => s.patchUnit);
-  const generate = useReferenceVideoStore((s) => s.generate);
   const select = useReferenceVideoStore((s) => s.select);
 
   const units =
@@ -116,8 +116,8 @@ export function ReferenceVideoCanvas({
     }
   }, [units, selected, select]);
 
-  // Optimistic UI: POST 前置位 → 队列接力 → 队列窗口换出后失效。
-  const [optimisticUnitIds, setOptimisticUnitIds] = useState<Set<string>>(() => new Set());
+  // 乐观占用来自 tasks-store：入队动作层在 API 成功后打标，真实任务行落库后让位。
+  const busyUnitIds = useActiveResourceIds("reference_video", projectName);
 
   const [uploadingUnitIds, setUploadingUnitIds] = useState<Set<string>>(() => new Set());
 
@@ -133,11 +133,13 @@ export function ReferenceVideoCanvas({
       // 失败任务行 DB 持久化、不会过期：手动上传成片后单元已有可播放资产，
       // 不再让历史失败覆盖 ready（与 timeline/grid 画布用 toast 提示失败的语义对齐）
       else if (queueRow?.status === "failed" && !u.generated_assets.video_clip) st = "failed";
-      else if (optimisticUnitIds.has(u.unit_id) && !queueRow) st = "running";
+      // 乐观窗口：真实任务行尚未落库时按占用集显示 running。已有任务行时不走
+      // 这个分支——显示语义仍由 isActiveStatus 决定（cancelling 不显示为 running）。
+      else if (!queueRow && busyUnitIds.has(u.unit_id)) st = "running";
       map[u.unit_id] = st;
     }
     return map;
-  }, [units, tasksByUnit, optimisticUnitIds, uploadingUnitIds]);
+  }, [units, tasksByUnit, busyUnitIds, uploadingUnitIds]);
 
   const generating = !!(selected && statusMap[selected.unit_id] === "running");
 
@@ -168,32 +170,15 @@ export function ReferenceVideoCanvas({
 
   const handleGenerate = useCallback(
     async (unitId: string) => {
-      setOptimisticUnitIds((s) => {
-        if (s.has(unitId)) return s;
-        const next = new Set(s);
-        next.add(unitId);
-        return next;
-      });
       setStackTab("preview");
       try {
-        const { deduped } = await generate(projectName, episode, unitId);
-        useAppStore
-          .getState()
-          .pushToast(
-            t(deduped ? "reference_generate_deduped" : "reference_generate_queued"),
-            "info",
-          );
+        // 入队成功的乐观打标与 queued/deduped 提示都在动作层内完成
+        await enqueueReferenceVideoUnit(projectName, episode, unitId);
       } catch (e) {
-        setOptimisticUnitIds((s) => {
-          if (!s.has(unitId)) return s;
-          const next = new Set(s);
-          next.delete(unitId);
-          return next;
-        });
         toastError(e, (msg) => t("reference_generate_request_failed", { error: msg }));
       }
     },
-    [generate, projectName, episode, t],
+    [projectName, episode, t],
   );
 
   const handleUploadVideo = useCallback(

--- a/frontend/src/components/canvas/timeline/AdReferenceUnitsPanel.test.tsx
+++ b/frontend/src/components/canvas/timeline/AdReferenceUnitsPanel.test.tsx
@@ -50,7 +50,12 @@ function renderPanel() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  useTasksStore.setState({ tasks: [] });
+  // 乐观标记由入队动作层写入且跨测试共享同一 store 实例，须一并重置
+  useTasksStore.setState({
+    tasks: [],
+    optimisticActive: new Set(),
+    optimisticActiveScriptFile: new Set(),
+  });
 });
 
 describe("AdReferenceUnitsPanel", () => {

--- a/frontend/src/components/canvas/timeline/AdReferenceUnitsPanel.tsx
+++ b/frontend/src/components/canvas/timeline/AdReferenceUnitsPanel.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Layers, RefreshCw, Sparkles } from "lucide-react";
 import { API } from "@/api";
+import { enqueueReferenceVideoUnit } from "@/actions/generation";
 import {
   selectActiveResourceIds,
   useActiveResourceIds,
@@ -76,16 +77,18 @@ export function AdReferenceUnitsPanel({ projectName, episode, shots }: AdReferen
   // 后一个 unit 的调用抹掉前一个 unit 的失败信息
   const generateUnit = async (unitId: string) => {
     try {
-      await API.generateReferenceVideoUnit(projectName, episode, unitId);
+      await enqueueReferenceVideoUnit(projectName, episode, unitId);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     }
   };
 
   // 实时读 store 而非渲染期快照：串行 await 期间其他入口（如单 unit 按钮）
-  // 可能已入队同一 unit
-  const liveBusyUnitIds = () =>
-    selectActiveResourceIds(useTasksStore.getState().tasks, "reference_video", projectName);
+  // 可能已入队同一 unit；乐观标记集也要带上，动作层刚打的标记才能被循环看到
+  const liveBusyUnitIds = () => {
+    const { tasks, optimisticActive } = useTasksStore.getState();
+    return selectActiveResourceIds(tasks, "reference_video", projectName, optimisticActive);
+  };
 
   const generateAll = async () => {
     // 先重新派生（保证索引与 shots 一致），再为未完成且空闲的 unit 入队

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.test.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.test.tsx
@@ -31,7 +31,7 @@ describe("GridPreviewPanel regenerate", () => {
   it("marks the grid's scriptFile as optimistically active after a successful regenerate submit", async () => {
     useTasksStore.setState({ tasks: [], optimisticActiveScriptFile: new Set() });
     vi.spyOn(API, "getGrid").mockResolvedValue(makeGrid());
-    vi.spyOn(API, "regenerateGrid").mockResolvedValue({ success: true, task_id: "t-1" });
+    vi.spyOn(API, "regenerateGrid").mockResolvedValue({ success: true, task_id: "t-1", deduped: false });
 
     render(<GridPreviewPanel projectName="demo" gridIds={["grid-1"]} defaultExpanded />);
 

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -15,10 +15,10 @@ import {
 import { motion, AnimatePresence } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { API } from "@/api";
+import { enqueueGridRegenerate } from "@/actions/generation";
 import { errMsg } from "@/utils/async";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useAppStore } from "@/stores/app-store";
-import { useTasksStore } from "@/stores/tasks-store";
 import type { GridGeneration, ReferenceImage } from "@/types/grid";
 
 // ---------------------------------------------------------------------------
@@ -342,17 +342,9 @@ export function GridPreviewPanel({
                       onClick={() => {
                         if (!selectedGridId || regenerating || isInProgress) return;
                         setRegenerating(true);
-                        API.regenerateGrid(projectName, selectedGridId)
+                        enqueueGridRegenerate(projectName, selectedGridId, grid?.script_file ?? null)
                           .then(() => {
                             setGrid((prev) => prev ? { ...prev, status: "pending" } : prev);
-                            // 乐观占用：重生成入队成功到轮询把刷新后的 grid 任务行写进 store 之间
-                            // 有空窗，期间同集的分镜编辑入口会误判为空闲，见
-                            // tasks-store.ts::selectHasActiveTaskForScriptFile 的乐观占用小节。
-                            if (grid?.script_file) {
-                              useTasksStore
-                                .getState()
-                                .markOptimisticActiveForScriptFile(projectName, "grid", grid.script_file);
-                            }
                             onRegenerated?.();
                           })
                           .catch((err: unknown) => {

--- a/frontend/src/components/canvas/timeline/ImageEditButton.tsx
+++ b/frontend/src/components/canvas/timeline/ImageEditButton.tsx
@@ -1,10 +1,9 @@
 import { useId, useState, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import { Wand2 } from "lucide-react";
-import { API } from "@/api";
+import { enqueueImageEdit } from "@/actions/generation";
 import { GlassModal } from "@/components/ui/GlassModal";
 import { useAppStore } from "@/stores/app-store";
-import { useTasksStore } from "@/stores/tasks-store";
 import { errMsg } from "@/utils/async";
 
 export type ImageEditResourceType =
@@ -71,18 +70,12 @@ export function ImageEditButton({
     if (!trimmed || submitting || disabled) return;
     setSubmitting(true);
     try {
-      const res = await API.editImage(projectName, {
+      await enqueueImageEdit(projectName, {
         resourceType,
         resourceId,
         instruction: trimmed,
         scriptFile: resourceType === "storyboard" ? scriptFile ?? null : null,
       });
-      // 乐观占用：入队成功到 SSE 下一次轮询把新 image_edit 任务行写进 store 之间有
-      // ~3s 空窗；期间该资源在 store 里尚无任务行，同资源的常规生成/上传按钮会误判为
-      // 空闲——两者的 task_type 不同，后端 dedupe 索引不拦这种跨 task_type 并发，会
-      // 并发写同一 current 图。此处立即标记占用，直到真实任务行出现再让位。
-      useTasksStore.getState().markOptimisticActive(projectName, resourceType, resourceId, "image_edit");
-      useAppStore.getState().pushToast(res.message, "success");
       setInstruction("");
       setOpen(false);
     } catch (err) {

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -643,7 +643,7 @@ export default {
   'reference_status_ready': 'Ready',
   'reference_status_failed': 'Failed',
   'reference_generate_queued': 'Queued for generation',
-  'reference_generate_deduped': 'Already in the queue',
+  'enqueue_deduped_toast': 'A task for this resource is already in progress; no new task was created.',
   'reference_generate_request_failed': 'Generation request failed: {{error}}; please try again.',
   'reference_generation_task_failed': 'Unit {{unitId}} generation failed: {{reason}}; please try again.',
   'storyboard_task_failed': 'Storyboard "{{id}}" generation failed: {{reason}}',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -620,7 +620,7 @@ export default {
   'reference_status_ready': 'Sẵn sàng',
   'reference_status_failed': 'Thất bại',
   'reference_generate_queued': 'Đã đưa vào hàng đợi tạo',
-  'reference_generate_deduped': 'Đã có trong hàng đợi',
+  'enqueue_deduped_toast': 'Đã có tác vụ cho tài nguyên này đang xử lý; không tạo tác vụ mới.',
   'reference_generate_request_failed': 'Yêu cầu tạo thất bại: {{error}}; vui lòng thử lại.',
   'reference_generation_task_failed': 'Tạo đơn vị {{unitId}} thất bại: {{reason}}; vui lòng thử lại.',
   'storyboard_task_failed': 'Tạo phân cảnh "{{id}}" thất bại: {{reason}}',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -643,7 +643,7 @@ export default {
   'reference_status_ready': '已就绪',
   'reference_status_failed': '失败',
   'reference_generate_queued': '已加入生成队列',
-  'reference_generate_deduped': '该 Unit 已在队列中',
+  'enqueue_deduped_toast': '已有同资源任务在处理中，本次未新建任务',
   'reference_generate_request_failed': '生成请求失败：{{error}}，请稍后重试',
   'reference_generation_task_failed': 'Unit {{unitId}} 生成失败：{{reason}}，请稍后重试',
   'storyboard_task_failed': '分镜 "{{id}}" 生成失败：{{reason}}',

--- a/frontend/src/stores/reference-video-store.ts
+++ b/frontend/src/stores/reference-video-store.ts
@@ -38,7 +38,6 @@ interface ReferenceVideoStore {
   patchUnit: (projectName: string, episode: number, unitId: string, patch: PatchUnitPayload) => Promise<ReferenceVideoUnit>;
   deleteUnit: (projectName: string, episode: number, unitId: string) => Promise<void>;
   reorderUnits: (projectName: string, episode: number, unitIds: string[]) => Promise<void>;
-  generate: (projectName: string, episode: number, unitId: string) => Promise<{ task_id: string; deduped: boolean }>;
   select: (unitId: string | null) => void;
 }
 
@@ -106,10 +105,6 @@ export const useReferenceVideoStore = create<ReferenceVideoStore>((set) => ({
     set((s) => ({
       unitsByEpisode: { ...s.unitsByEpisode, [referenceVideoCacheKey(projectName, episode)]: units },
     }));
-  },
-
-  generate: async (projectName, episode, unitId) => {
-    return API.generateReferenceVideoUnit(projectName, episode, unitId);
   },
 
   select: (unitId) => set({ selectedUnitId: unitId }),

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isActiveStatus,
+  isOccupyingStatus,
   isTerminalStatus,
   selectActiveResourceIds,
   selectHasActiveTaskForScriptFile,
@@ -43,6 +44,21 @@ describe("isActiveStatus", () => {
   it("counts every other status as inactive", () => {
     const inactive: TaskStatus[] = ["cancelling", "succeeded", "failed", "cancelled"];
     for (const status of inactive) expect(isActiveStatus(status)).toBe(false);
+  });
+});
+
+describe("isOccupyingStatus", () => {
+  it("counts queued/running/cancelling as occupying", () => {
+    // 占用谓词与后端 ACTIVE_TASK_STATUSES 对齐：cancelling 期间 worker 仍可能写资源，
+    // 且后端 dedupe 索引会把重复提交去重到既有任务上
+    expect(isOccupyingStatus("queued")).toBe(true);
+    expect(isOccupyingStatus("running")).toBe(true);
+    expect(isOccupyingStatus("cancelling")).toBe(true);
+  });
+
+  it("counts terminal statuses as not occupying", () => {
+    const free: TaskStatus[] = ["succeeded", "failed", "cancelled"];
+    for (const status of free) expect(isOccupyingStatus(status)).toBe(false);
   });
 });
 
@@ -601,5 +617,27 @@ describe("selectActiveResourceIds", () => {
       task({ task_id: "c", resource_id: "u3", status: "running", task_type: "video", project_name: "p2" }),
     ];
     expect([...selectActiveResourceIds(tasks, "video", "p1")]).toEqual(["u1"]);
+  });
+
+  it("keeps a cancelling task in the occupancy set", () => {
+    // 取消窗口期资源仍被占用：按钮须保持禁用，否则重提交会撞后端 dedupe 索引
+    // 返回既有任务、造成「提交成功却没有新任务」的谎报
+    const tasks = [task({ task_id: "a", resource_id: "u1", status: "cancelling" })];
+    expect(selectActiveResourceIds(tasks, "reference_video", "proj").has("u1")).toBe(true);
+  });
+});
+
+describe("selectHasActiveTaskForScriptFile with cancelling", () => {
+  it("counts a cancelling grid task as occupying the scriptFile", () => {
+    const tasks = [
+      task({
+        task_id: "grid-1",
+        task_type: "grid",
+        resource_id: "grid-abc",
+        script_file: "episode_1.json",
+        status: "cancelling",
+      }),
+    ];
+    expect(selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "proj")).toBe(true);
   });
 });

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -161,7 +161,9 @@ export const useTasksStore = create<TasksState>((set) => ({
 // 派生 selector —— 任务队列两条不变量的单一真相源
 //
 // 消费点（画布 loading 派生、参考视频单元状态等）此前各自重写两条隐性契约：
-//   1.「什么算活跃」——排队或运行中的任务占用其 resource（isActiveStatus）。
+//   1.「什么算活跃」——占用与显示是两个谓词：占用判定（isOccupyingStatus）计入
+//      cancelling，与后端 dedupe 索引的 ACTIVE_TASK_STATUSES 对齐；显示判定
+//      （isActiveStatus）不计 cancelling——取消中的任务不显示为进行中。
 //   2.「最新行胜出」——同一 resource 可能有多条任务行：失败后重试是新的 task_id，
 //      tasks 由服务端列表整体写入、顺序不保证，故判定时须取 updated_at 最新的一行，
 //      重试的新行不被旧失败行遮挡（selectLatestTaskByResource）。
@@ -170,9 +172,19 @@ export const useTasksStore = create<TasksState>((set) => ({
 // Set/Map 内容，保证内容不变时引用稳定，避免每次渲染返回新集合触发重渲染。
 // ---------------------------------------------------------------------------
 
-/** 不变量 1：排队或运行中的任务视为占用其 resource。 */
+/** 显示谓词：排队或运行中的任务显示为进行中；cancelling 是收尾中间态，不显示为进行中。 */
 export function isActiveStatus(status: TaskStatus): boolean {
   return status === "queued" || status === "running";
+}
+
+/**
+ * 占用谓词：该状态的任务仍占用其 resource（按钮禁用、占用集判定）。与后端 dedupe
+ * 索引的 ACTIVE_TASK_STATUSES 对齐——cancelling 期间 worker 仍可能在写资源文件，
+ * 且后端会把同资源的重复提交去重到既有任务上；若前端此时判定空闲，会出现「按钮
+ * 可点、提交后没有新任务」的谎报。
+ */
+export function isOccupyingStatus(status: TaskStatus): boolean {
+  return status === "queued" || status === "running" || status === "cancelling";
 }
 
 /** 终态：任务生命周期末端，不再占用 resource。 */
@@ -246,7 +258,7 @@ export function selectActiveResourceIds(
   }
   const ids = new Set<string>();
   for (const task of latestByResourceAndTaskType.values()) {
-    if (isActiveStatus(task.status)) ids.add(task.resource_id);
+    if (isOccupyingStatus(task.status)) ids.add(task.resource_id);
   }
   for (const key of optimisticActive) {
     const [kProject, kResourceKind, kResourceId, kPendingTaskType, kBaseline = ""] = key.split("\0");
@@ -300,7 +312,7 @@ export function selectHasActiveTaskForScriptFile(
       task.task_type === taskType &&
       task.script_file != null &&
       stripScriptsPrefix(task.script_file) === normalized &&
-      isActiveStatus(task.status),
+      isOccupyingStatus(task.status),
   );
   if (hasRealActive) return true;
 

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -126,6 +126,7 @@ async def generate_storyboard(
     return {
         "success": True,
         "task_id": result["task_id"],
+        "deduped": result.get("deduped", False),
         "message": _t("storyboard_task_submitted", segment_id=segment_id),
     }
 
@@ -205,6 +206,7 @@ async def generate_video(
     return {
         "success": True,
         "task_id": result["task_id"],
+        "deduped": result.get("deduped", False),
         "message": _t("video_task_submitted", segment_id=segment_id),
     }
 
@@ -303,6 +305,7 @@ async def generate_tts(
     return {
         "success": True,
         "task_id": result["task_id"],
+        "deduped": result.get("deduped", False),
         "message": _t("tts_task_submitted", segment_id=segment_id),
     }
 
@@ -336,11 +339,12 @@ async def generate_tts_batch(
     project, missing_ids = await asyncio.to_thread(_sync)
 
     if not missing_ids:
-        return {"success": True, "task_ids": [], "message": _t("tts_batch_none_missing")}
+        return {"success": True, "task_ids": [], "deduped": False, "message": _t("tts_batch_none_missing")}
 
     provider_id = await _require_audio_provider_configured(project)
 
     task_ids: list[str] = []
+    deduped_flags: list[bool] = []
     for seg_id in missing_ids:
         result = await _enqueue_tts_segment(
             project_name=project_name,
@@ -350,9 +354,16 @@ async def generate_tts_batch(
             provider_id=provider_id,
         )
         task_ids.append(result["task_id"])
+        deduped_flags.append(bool(result.get("deduped", False)))
 
     message = _t("tts_batch_submitted", count=len(task_ids)) if task_ids else _t("tts_batch_none_missing")
-    return {"success": True, "task_ids": task_ids, "message": message}
+    # 批量语义：全部入队都命中既有任务（本次一个新任务都没建）才算 deduped
+    return {
+        "success": True,
+        "task_ids": task_ids,
+        "deduped": bool(task_ids) and all(deduped_flags),
+        "message": message,
+    }
 
 
 # ==================== 资产设计图生成（character / scene / prop / product 共用） ====================
@@ -408,6 +419,7 @@ async def _enqueue_asset_generation(
     return {
         "success": True,
         "task_id": result["task_id"],
+        "deduped": result.get("deduped", False),
         "message": _t(keys["submitted"], name=resource_name),
     }
 
@@ -577,5 +589,6 @@ async def edit_image(
     return {
         "success": True,
         "task_id": result["task_id"],
+        "deduped": result.get("deduped", False),
         "message": _t("image_edit_task_submitted", id=req.resource_id),
     }

--- a/server/routers/grids.py
+++ b/server/routers/grids.py
@@ -68,6 +68,8 @@ class GenerateGridResponse(BaseModel):
     success: bool
     grid_ids: list[str]
     task_ids: list[str]
+    # 批量语义：全部入队都命中既有任务（本次一个新任务都没建）才为 True
+    deduped: bool
     message: str
 
 
@@ -109,6 +111,7 @@ async def generate_grid(
 
         grid_ids: list[str] = []
         task_ids: list[str] = []
+        deduped_flags: list[bool] = []
         queue = get_generation_queue()
         gm = GridManager(project_path)
 
@@ -197,11 +200,13 @@ async def generate_grid(
                 )
                 grid_ids.append(grid.id)
                 task_ids.append(task["task_id"])
+                deduped_flags.append(bool(task.get("deduped", False)))
 
         return GenerateGridResponse(
             success=True,
             grid_ids=grid_ids,
             task_ids=task_ids,
+            deduped=bool(task_ids) and all(deduped_flags),
             message=f"已提交 {len(grid_ids)} 个宫格生成任务",
         )
 
@@ -306,7 +311,7 @@ async def regenerate_grid(project_name: str, grid_id: str, _user: CurrentUser, _
             user_id=_user.id,
         )
 
-        return {"success": True, "task_id": task["task_id"]}
+        return {"success": True, "task_id": task["task_id"], "deduped": task.get("deduped", False)}
 
     except HTTPException:
         raise

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -733,3 +733,59 @@ class TestNoServerPathLeak:
             assert resp.status_code == 500, resp.text
             assert "boom" not in resp.text
             self._assert_no_path(resp)
+
+
+class _FakeDedupeHitQueue(_FakeQueue):
+    """模拟 dedupe 索引命中：返回既有任务行而非新建。"""
+
+    async def enqueue_task(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"task_id": "task-existing", "deduped": True, "existing_task_id": "task-existing"}
+
+
+class TestDedupedPassthrough:
+    """入队响应透出队列层的 deduped 事实，供前端识别「本次未新建任务」。"""
+
+    def test_fresh_enqueue_reports_deduped_false(self, tmp_path, monkeypatch):
+        project_path = _prepare_files(tmp_path)
+        client = _client(monkeypatch, _FakePM(project_path), _FakeQueue())
+
+        with client:
+            resp = client.post(
+                "/api/v1/projects/demo/generate/storyboard/E1S01",
+                json={
+                    "script_file": "episode_1.json",
+                    "prompt": {"scene": "雨夜", "composition": {"shot_type": "Medium Shot"}},
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["deduped"] is False
+
+    def test_dedupe_hit_reports_deduped_true_with_existing_task_id(self, tmp_path, monkeypatch):
+        project_path = _prepare_files(tmp_path)
+        client = _client(monkeypatch, _FakePM(project_path), _FakeDedupeHitQueue())
+
+        with client:
+            resp = client.post(
+                "/api/v1/projects/demo/generate/storyboard/E1S01",
+                json={
+                    "script_file": "episode_1.json",
+                    "prompt": {"scene": "雨夜", "composition": {"shot_type": "Medium Shot"}},
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["deduped"] is True
+            assert body["task_id"] == "task-existing"
+
+    def test_asset_generation_exposes_deduped(self, tmp_path, monkeypatch):
+        project_path = _prepare_files(tmp_path)
+        client = _client(monkeypatch, _FakePM(project_path), _FakeDedupeHitQueue())
+
+        with client:
+            resp = client.post(
+                "/api/v1/projects/demo/generate/character/Alice",
+                json={"prompt": "hero"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["deduped"] is True

--- a/tests/test_generate_router_tts.py
+++ b/tests/test_generate_router_tts.py
@@ -235,3 +235,78 @@ class TestGenerateTtsBatch:
             assert body["success"] is True
             assert body["task_ids"] == []
             assert fake_queue.calls == []
+
+
+class _FakeDedupeHitQueue(_FakeQueue):
+    """模拟 dedupe 索引全部命中。"""
+
+    async def enqueue_task(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"task_id": f"task-{len(self.calls)}", "deduped": True, "existing_task_id": f"task-{len(self.calls)}"}
+
+
+class _FakeFirstHitQueue(_FakeQueue):
+    """模拟部分命中：第一次入队命中既有任务，其余新建。"""
+
+    async def enqueue_task(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"task_id": f"task-{len(self.calls)}", "deduped": len(self.calls) == 1}
+
+
+class TestTtsDedupedPassthrough:
+    def test_single_exposes_deduped(self, tmp_path, monkeypatch):
+        fake_pm = _FakePM(tmp_path / "projects" / "demo")
+        client = _client(monkeypatch, fake_pm, _FakeDedupeHitQueue())
+
+        with client:
+            res = client.post(
+                "/api/v1/projects/demo/generate/tts/E1S01",
+                json={"script_file": "episode_1.json"},
+            )
+            assert res.status_code == 200, res.text
+            assert res.json()["deduped"] is True
+
+    def test_batch_all_hits_reports_deduped_true(self, tmp_path, monkeypatch):
+        fake_pm = _FakePM(tmp_path / "projects" / "demo")
+        client = _client(monkeypatch, fake_pm, _FakeDedupeHitQueue())
+
+        with client:
+            res = client.post(
+                "/api/v1/projects/demo/generate/tts",
+                json={"script_file": "episode_1.json"},
+            )
+            assert res.status_code == 200, res.text
+            body = res.json()
+            assert body["task_ids"] == ["task-1"]
+            assert body["deduped"] is True
+
+    def test_batch_partial_hit_reports_deduped_false(self, tmp_path, monkeypatch):
+        fake_pm = _FakePM(tmp_path / "projects" / "demo")
+        # 让 E1S02 也缺旁白：两段入队，其中一段命中既有任务 → 仍新建了任务，不算 deduped
+        fake_pm.script["segments"][1]["generated_assets"] = {}
+        client = _client(monkeypatch, fake_pm, _FakeFirstHitQueue())
+
+        with client:
+            res = client.post(
+                "/api/v1/projects/demo/generate/tts",
+                json={"script_file": "episode_1.json"},
+            )
+            assert res.status_code == 200, res.text
+            body = res.json()
+            assert len(body["task_ids"]) == 2
+            assert body["deduped"] is False
+
+    def test_batch_none_missing_reports_deduped_false(self, tmp_path, monkeypatch):
+        fake_pm = _FakePM(tmp_path / "projects" / "demo")
+        fake_pm.script["segments"][0]["generated_assets"] = {"narration_audio": "audio/segment_E1S01.wav"}
+        client = _client(monkeypatch, fake_pm, _FakeQueue())
+
+        with client:
+            res = client.post(
+                "/api/v1/projects/demo/generate/tts",
+                json={"script_file": "episode_1.json"},
+            )
+            assert res.status_code == 200, res.text
+            body = res.json()
+            assert body["task_ids"] == []
+            assert body["deduped"] is False


### PR DESCRIPTION
Closes #1226

## 变更概述

将散布在各调用点的「入队 + 乐观占用打标 + 返回值归一化 + 提示」收拢进新建的前端入队动作层，并把取消窗口期（cancelling）纳入占用语义，消除「按钮可点、提交后没有新任务却谎报成功」的静默吞没。

### 前端

- 新建 `frontend/src/actions/generation.ts`：12 个入队动作函数，内部统一封装 API 调用、mark-after-success 乐观占用打标、返回值归一化（`EnqueueResult`）与 toast；`deduped=true` 弹统一 i18n info 提示（zh/en/vi），不再弹成功 toast。
- 全部调用点迁移至动作层：StudioCanvasRouter、ImageEditButton、GridPreviewPanel、AdInitCanvas、AdReferenceUnitsPanel、ReferenceVideoCanvas；参考视频入口弃用组件局部提交状态，改走 store 占用体系。
- 占用谓词与显示谓词拆分：占用判定（`isOccupyingStatus`，`selectActiveResourceIds` 一族）计入 cancelling，对齐后端 dedupe 索引；显示判定（`isActiveStatus`）维持现状，cancelling 不显示为进行中。
- ESLint `no-restricted-syntax`：动作层外禁止直调 12 个入队类 API 方法，`src/actions/` 与 `src/api.test.ts` 豁免。

### 后端

- 各入队端点响应统一透出 `deduped` 字段（事实来源是入队路径既有的去重判定）；批量端点（tts 批量 / 宫格）语义为「全部入队都命中既有任务才为 True」。未改去重索引与取消状态机。

## 验证

- 前端：`pnpm lint`（含新规则自证）+ `pnpm check`（typecheck + 1015 测试）全绿。
- 后端：`ruff check` / `ruff format --check` / `basedpyright` 0 error / `pytest` 6193 全过（含 i18n 三语一致性）。
- 本地审查（/code-review high）：无正确性缺陷；三项迁移行为变化（AdInit 额外 toast 被 success toast 同步覆盖、AdRef 批量单槽 toast 无风暴、ReferenceVideoCanvas 飞行中双击由后端去重兜底）核实为迁移必然且可接受。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 统一生成、编辑与重生成任务的提交流程。
  * 新增重复任务检测提示，已有进行中任务时不会重复创建。
  * 提交后即时显示资源处理中状态，提升操作反馈一致性。
  * 任务状态在取消期间仍会正确保持资源占用。

* **错误修复**
  * 优化批量旁白、宫格生成及参考视频任务的状态与提示处理。
  * 统一各类任务返回结果，改善任务状态展示与异常反馈。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->