### PR TITLE
fix(pricing): update MiniMax M3 text rates

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -1086,7 +1086,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 media_type="text",
                 capabilities=["text_generation", "structured_output"],
                 default=True,
-                pricing=_minimax_text_pricing("MiniMax-M3", 2.1, 8.4),
+                pricing=_minimax_text_pricing("MiniMax-M3", 4.2, 16.8),
             ),
             "MiniMax-M2.7": ModelInfo(
                 display_name="MiniMax M2.7",

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -113,6 +113,16 @@ class TestFactoryWiring:
 
 
 class TestLookupPricing:
+    def test_m3_text_cny_per_token(self):
+        p = lookup_pricing(PROVIDER_MINIMAX, "MiniMax-M3", "text")
+        amount, cur = calculate_pricing(
+            p,
+            PricingParams(call_type="text", model="MiniMax-M3", input_tokens=1_000_000, output_tokens=1_000_000),
+        )
+        assert cur == "CNY"
+        # ¥4.2 input + ¥16.8 output
+        assert amount == pytest.approx(21.0)
+
     def test_text_cny_per_token(self):
         p = lookup_pricing(PROVIDER_MINIMAX, "MiniMax-M2.7", "text")
         amount, cur = calculate_pricing(


### PR DESCRIPTION
Reason: Refresh MiniMax text pricing to match current target parameters and preserve Anthropic-compatible endpoint coverage.

Updated the MiniMax M3 text pricing rates in the provider registry and added a regression test covering the revised input and output rates. Existing global and China Anthropic-compatible endpoints already match the target configuration.

Checks: `uv run ruff check lib/config/registry.py tests/test_minimax_integration.py`; `uv run ruff format --check lib/config/registry.py tests/test_minimax_integration.py`; `uv run python -m pytest tests/test_minimax_integration.py -q`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **计费调整**
  * 更新 MiniMax-M3 文本模型的输入和输出计费标准。
  * 输入价格调整为每百万 tokens ¥4.2，输出价格调整为每百万 tokens ¥16.8。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->