### PR TITLE
fix(script-generator): 能力查询软回退时长与供应商保守默认收敛同源

### DIFF
--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, ValidationError
 
 from lib import script_review
 from lib.config.resolver import ConfigResolver
+from lib.custom_provider.duration_presets import DEFAULT_FALLBACK
 from lib.db import async_session_factory
 from lib.episode_ledger import episode_outline_context
 from lib.episode_paths import (
@@ -46,8 +47,6 @@ from lib.text_utils import strip_json_code_fences
 from server.agent_runtime.sdk_tools._context import ToolContext, fetch_video_caps, tool_error
 
 logger = logging.getLogger(__name__)
-
-_FALLBACK_SUPPORTED_DURATIONS: list[int] = [4, 6, 8]
 
 
 def _parse_step1_json(response_text: str, model: type[BaseModel], *, label: str, top_shape: str) -> dict:
@@ -312,19 +311,20 @@ def confirm_script_review_tool(ctx: ToolContext):
 async def _fetch_caps_with_fallback(project: dict[str, Any]) -> tuple[int | None, list[int]]:
     """Script normalization is best-effort: prompt生成 不该被能力查询失败堵住。
 
-    Soft-fallbacks to ``_FALLBACK_SUPPORTED_DURATIONS`` so the LLM still
-    receives a usable duration constraint set if the resolver hiccups.
+    Soft-fallbacks to ``duration_presets.DEFAULT_FALLBACK`` so the LLM still
+    receives a usable duration constraint set if the resolver hiccups —— 与
+    自定义供应商写入层的保守默认同一真相源，避免软回退口径含供应商未必支持的时长。
     """
     try:
         default_int, durations = await fetch_video_caps(project)
     except (FileNotFoundError, ValueError) as exc:
-        logger.info("video_capabilities 不可解析，使用 fallback [4,6,8]：%s", exc)
-        return None, list(_FALLBACK_SUPPORTED_DURATIONS)
+        logger.info("video_capabilities 不可解析，使用 fallback %s：%s", DEFAULT_FALLBACK, exc)
+        return None, list(DEFAULT_FALLBACK)
     except Exception as exc:  # noqa: BLE001
-        logger.warning("video_capabilities 查询异常，使用 fallback [4,6,8]：%s", exc)
-        return None, list(_FALLBACK_SUPPORTED_DURATIONS)
+        logger.warning("video_capabilities 查询异常，使用 fallback %s：%s", DEFAULT_FALLBACK, exc)
+        return None, list(DEFAULT_FALLBACK)
     if not durations:
-        return default_int, list(_FALLBACK_SUPPORTED_DURATIONS)
+        return default_int, list(DEFAULT_FALLBACK)
     return default_int, durations
 
 
@@ -448,7 +448,7 @@ async def _fetch_reference_caps_with_fallback(project: dict[str, Any]) -> tuple[
     """解析 rv 拆分所需的视频能力：``(default_duration, supported_durations, max_duration, max_refs)``。
 
     与 ``_fetch_caps_with_fallback`` 同口径 best-effort：resolver 故障时回退
-    ``_FALLBACK_SUPPORTED_DURATIONS``、``max_duration`` 取集合最大值（用原始集合，不受下方单
+    ``duration_presets.DEFAULT_FALLBACK``、``max_duration`` 取集合最大值（用原始集合，不受下方单
     shot 过滤影响）、``max_refs`` 视为未声明。返回的 ``supported_durations`` 已与
     ``REFERENCE_SHOT_DURATION_RANGE`` 求交集——部分供应商（如 vidu/agnes）的单 shot 时长上限
     超过该静态区间，未过滤会让 step1 产出的 shot 时长在 step2 读回校验（复用同一静态区间）时
@@ -459,11 +459,11 @@ async def _fetch_reference_caps_with_fallback(project: dict[str, Any]) -> tuple[
         resolver = ConfigResolver(async_session_factory)
         caps = await resolver.video_capabilities_for_project(project)
     except Exception as exc:  # noqa: BLE001
-        logger.warning("video_capabilities 查询异常，使用 fallback [4,6,8]：%s", exc)
+        logger.warning("video_capabilities 查询异常，使用 fallback %s：%s", DEFAULT_FALLBACK, exc)
         caps = {}
     durations = [int(d) for d in caps.get("supported_durations") or []]
     if not durations:
-        durations = list(_FALLBACK_SUPPORTED_DURATIONS)
+        durations = list(DEFAULT_FALLBACK)
     raw_max = caps.get("max_duration")
     max_duration = int(raw_max) if isinstance(raw_max, int | float) else max(durations)
     raw_refs = caps.get("max_reference_images")

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1253,6 +1253,21 @@ def test_parse_normalized_content_uses_dynamic_duration_schema() -> None:
         _parse_normalized_content(json.dumps({"title": "t", "scenes": [bad]}), model)
 
 
+async def test_fetch_caps_with_fallback_uses_write_layer_default(monkeypatch) -> None:
+    """resolver 失败时软回退须与自定义供应商写入层的保守默认（duration_presets.DEFAULT_FALLBACK）
+    同一真相源——独立维护第二套回退集会让 LLM 拿到供应商未必支持的时长。"""
+    from lib.custom_provider.duration_presets import DEFAULT_FALLBACK
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    async def raising_caps(_p):
+        raise ValueError("no provider configured")
+
+    monkeypatch.setattr(mod, "fetch_video_caps", raising_caps)
+    default, durations = await mod._fetch_caps_with_fallback({})
+    assert default is None
+    assert durations == DEFAULT_FALLBACK
+
+
 async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
@@ -2097,6 +2112,26 @@ async def test_fetch_reference_caps_with_fallback_clips_shot_durations_to_static
     assert durations == [1, 8]
     assert max_duration == 18  # 单 unit 总时长上限沿用 resolver 原始声明，不受单 shot 过滤影响
     assert default is None  # 16 已被过滤掉，非法 default 归 None
+    assert max_refs is None
+
+
+async def test_fetch_reference_caps_with_fallback_uses_write_layer_default(monkeypatch) -> None:
+    """rv 路径的软回退与 _fetch_caps_with_fallback 同口径，取 duration_presets.DEFAULT_FALLBACK。"""
+    from lib.custom_provider.duration_presets import DEFAULT_FALLBACK
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    class _RaisingResolver:
+        def __init__(self, _factory):
+            pass
+
+        async def video_capabilities_for_project(self, _project):
+            raise ValueError("no provider configured")
+
+    monkeypatch.setattr(mod, "ConfigResolver", _RaisingResolver)
+    default, durations, max_duration, max_refs = await mod._fetch_reference_caps_with_fallback({})
+    assert default is None
+    assert durations == DEFAULT_FALLBACK
+    assert max_duration == max(DEFAULT_FALLBACK)
     assert max_refs is None
 
 


### PR DESCRIPTION
## 摘要

视频时长能力此前存在两套保守默认：自定义供应商写入层 `duration_presets.DEFAULT_FALLBACK = [4, 8]`，与 SDK 工具层能力查询软回退 `_FALLBACK_SUPPORTED_DURATIONS = [4, 6, 8]`。后者含供应商未必支持的 6 秒——能力查询失败（最常见：项目/全局尚未配置供应商）时 LLM 按 `[4, 6, 8]` 产出的 6s 片段，等供应商配好后可能与其实际能力集不符。

收敛为单一真相源：工具层软回退（drama/narration 的 `_fetch_caps_with_fallback` 与 rv 的 `_fetch_reference_caps_with_fallback`）直接引用 `DEFAULT_FALLBACK`，删除独立常量；日志改为打印实际回退值。

## 验证

- 新增两个回归测试锚定回退值与写入层同源
- `tests/server/agent_runtime/test_sdk_tools.py` 128 passed；时长相关套件 38 passed
- ruff / basedpyright 0 error
- `[4, 8]` 与 rv 静态区间 `REFERENCE_SHOT_DURATION_RANGE (1, 15)` 交集非空，rv 单 shot 过滤不受影响

Closes #1243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 统一视频时长能力查询失败或缺少数据时的默认回退规则。
  * 改善视频生成与参考视频处理在异常情况下的稳定性，确保使用一致的默认时长范围。

* **Tests**
  * 新增异常回退场景测试，验证默认时长及最大时长处理符合预期。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->