### PR TITLE
fix(frontend): 助手切项目时旧项目迟到响应不再建 SSE 连接

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ ConfigService（`service.py`）→ Repository（持久化 + 密钥脱敏）→ R
 - i18n：`i18next` + `react-i18next`，翻译文件在 `frontend/src/i18n/{zh,en,vi}/`，命名空间 `common`/`dashboard`/`auth`/`errors`/`assets`/`templates`
 - **占用感知型控件接线** — 编辑/重生成/上传/入库/版本恢复等随资源占用态禁用的控件，新增或改动时通过三项检查：弹窗/面板打开时校验当前占用态；提交时刻复核最新占用态（打开后状态可能已变化，仅查打开时刻会留竞态窗口）；同一资源卡片上的兄弟控件同步接线禁用
 - **入队走动作层** — 生成类入队操作一律经 `frontend/src/actions/` 的动作函数（内部统一封装 API 调用、乐观占用打标与去重提示），组件不直调入队类 API 方法；新增入队类 API 方法时同步登记 `frontend/eslint.config.js` 中 no-restricted-syntax 的方法名清单
+- **异步竞态防护** — 异步操作完成后写共享 state（store / 建流）前须复核过期，迟到响应不得写入或建立连接。effect 内的一次性请求用 `cancelled` closure flag，并把它传入被 effect 调用的异步函数（这类函数须自身感知取消，effect 的 flag 不会自动拦截其内部 await 断点）；跨入口复用的刷新收敛为 store action 做在途合并（先例 `projects-store.refreshProject`）
 
 ## 关键设计模式
 

--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -819,4 +819,28 @@ describe("useAssistantSession", () => {
     expect(useAssistantStore.getState().sessionStatus).toBe("running");
     expect(useAssistantStore.getState().entries.map((e) => e.seq)).toEqual([0]);
   });
+
+  it("no-ops switchSession when projectName is null (stale session list with no project selected)", async () => {
+    // 面板为长生命周期单例，切项目为 null 后 sessions 列表不清空（见初始化
+    // effect 的前置 guard）；SessionSelector 据此仍可能渲染出旧项目的会话项。
+    // 点击它们不得以 null projectName 发起请求。
+    const getSessionSpy = vi.spyOn(API, "getAssistantSession");
+    const listEntriesSpy = vi.spyOn(API, "listAssistantEntries");
+    const listSessionsSpy = vi.spyOn(API, "listAssistantSessions");
+
+    act(() => {
+      useAssistantStore.getState().setSessions([makeSession("stale-session", "idle")]);
+    });
+
+    const { result } = renderHook(() => useAssistantSession(null));
+
+    await act(async () => {
+      await result.current.switchSession("stale-session");
+    });
+
+    expect(getSessionSpy).not.toHaveBeenCalled();
+    expect(listEntriesSpy).not.toHaveBeenCalled();
+    expect(listSessionsSpy).not.toHaveBeenCalled();
+    expect(useAssistantStore.getState().currentSessionId).toBeNull();
+  });
 });

--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -779,4 +779,44 @@ describe("useAssistantSession", () => {
     expect(useAssistantStore.getState().turns).toHaveLength(1);
     expect(useAssistantStore.getState().turns[0].content[0].text).toBe("B-0");
   });
+
+  it("does not let a delayed idle cold-read overwrite sessionStatus set by a concurrent sendMessage", async () => {
+    // 冷读 listAssistantEntries 挂起期间，用户在同一会话内发送消息：sendMessage
+    // 把 sessionStatus 改写为 running 并建流。冷读迟到完成后携带的仍是发消息前
+    // 捕获的 idle 状态，不得据此覆盖回去（否则 UI 误判会话已空闲、隐藏停止按钮）。
+    const deferredEntries = createDeferred<EntriesResponse>();
+    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+      sessions: [makeSession("session-1", "idle")],
+    });
+    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "idle") });
+    vi.spyOn(API, "listAssistantEntries").mockReturnValue(deferredEntries.promise);
+    vi.spyOn(API, "sendAssistantMessage").mockResolvedValue({
+      session_id: "session-1",
+      status: "accepted",
+      entry: userEntry(0, "hello"),
+    });
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    let accepted = false;
+    await act(async () => {
+      accepted = await result.current.sendMessage("hello");
+    });
+    expect(accepted).toBe(true);
+    expect(useAssistantStore.getState().sessionStatus).toBe("running");
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    await act(async () => {
+      deferredEntries.resolve(makeEntriesResponse({ entries: [] }));
+      await deferredEntries.promise;
+    });
+
+    // running 状态与已发送的条目保留，不被冷读前捕获的旧 idle 状态回退
+    expect(useAssistantStore.getState().sessionStatus).toBe("running");
+    expect(useAssistantStore.getState().entries.map((e) => e.seq)).toEqual([0]);
+  });
 });

--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -728,4 +728,55 @@ describe("useAssistantSession", () => {
     expect(MockEventSource.instances).toHaveLength(2);
     expect(MockEventSource.instances[1].url).toContain("after=1");
   });
+
+  it("ignores a delayed loadSession response after switching projects (no SSE leak, no state write)", async () => {
+    // 项目 A 的 running 会话：loadSession 卡在 getAssistantSession；切到 B 后 A 的
+    // 迟到响应不得建 SSE 连接、不得回写任何 store 状态（否则为已离开的项目建立
+    // 无人消费的 SSE 订阅，服务端订阅者堆积泄漏）。
+    const deferredA = createDeferred<{ session: SessionMeta }>();
+    vi.spyOn(API, "listAssistantSessions").mockImplementation(async (projectName) => ({
+      sessions: [
+        makeSession(
+          projectName === "project-a" ? "session-a" : "session-b",
+          projectName === "project-a" ? "running" : "idle",
+        ),
+      ],
+    }));
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (projectName, sessionId) => {
+      if (projectName === "project-a") return deferredA.promise;
+      return { session: makeSession(sessionId, "idle") };
+    });
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(
+      makeEntriesResponse({ session_id: "session-b", entries: [userEntry(0, "B-0")] }),
+    );
+
+    const { rerender } = renderHook(({ projectName }) => useAssistantSession(projectName), {
+      initialProps: { projectName: "project-a" as string | null },
+    });
+
+    // 项目 A：loadSession 卡在 getAssistantSession（deferredA 未 resolve）
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-a");
+    });
+
+    // 切到项目 B（其 idle 会话冷读一条条目）
+    rerender({ projectName: "project-b" });
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-b");
+      expect(useAssistantStore.getState().turns).toHaveLength(1);
+    });
+
+    // 迟到：A 的 getAssistantSession 此刻才返回 running；loadSession 据 cancelled 短路
+    await act(async () => {
+      deferredA.resolve({ session: makeSession("session-a", "running") });
+      await deferredA.promise;
+    });
+
+    // 不为已离开的项目 A 建 SSE 连接；状态与时间线保持项目 B
+    expect(MockEventSource.instances).toHaveLength(0);
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-b");
+    expect(useAssistantStore.getState().sessionStatus).toBe("idle");
+    expect(useAssistantStore.getState().turns).toHaveLength(1);
+    expect(useAssistantStore.getState().turns[0].content[0].text).toBe("B-0");
+  });
 });

--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -886,4 +886,92 @@ describe("useAssistantSession", () => {
     expect(useAssistantStore.getState().currentSessionId).toBe("session-2");
     expect(useAssistantStore.getState().sessionStatus).toBe("idle");
   });
+
+  it("ignores a delayed init session-list response after createNewSession (session-op generation)", async () => {
+    // init effect 的 listAssistantSessions 挂起期间用户新建会话：迟到响应若不
+    // 感知这一操作，会把 currentSessionId 覆盖回旧会话并重新 loadSession，为
+    // 已被放弃的会话重建 SSE 连接，覆盖用户刚完成的新建会话操作。
+    const deferredSessions = createDeferred<{ sessions: SessionMeta[] }>();
+    vi.spyOn(API, "listAssistantSessions").mockReturnValue(deferredSessions.promise);
+    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "running") });
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    await act(async () => {
+      result.current.createNewSession();
+    });
+    expect(useAssistantStore.getState().currentSessionId).toBeNull();
+    expect(useAssistantStore.getState().isDraftSession).toBe(true);
+
+    // 迟到：init 的会话列表此刻才返回，携带一个 running 会话
+    await act(async () => {
+      deferredSessions.resolve({ sessions: [makeSession("session-1", "running")] });
+      await deferredSessions.promise;
+    });
+
+    // 不覆盖用户的新建会话操作，不为已放弃的会话重建 SSE 连接
+    expect(useAssistantStore.getState().currentSessionId).toBeNull();
+    expect(useAssistantStore.getState().isDraftSession).toBe(true);
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it("ignores a delayed init session-list response after switchSession (session-op generation)", async () => {
+    // 同上，换成挂起期间用户直接切到另一会话（如通过历史记录/深链接跳转）。
+    const deferredSessions = createDeferred<{ sessions: SessionMeta[] }>();
+    vi.spyOn(API, "listAssistantSessions").mockReturnValue(deferredSessions.promise);
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (_projectName, sessionId) => ({
+      session: makeSession(sessionId, "idle"),
+    }));
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    await act(async () => {
+      await result.current.switchSession("session-2");
+    });
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-2");
+
+    // 迟到：init 的会话列表此刻才返回，携带一个 running 会话
+    await act(async () => {
+      deferredSessions.resolve({ sessions: [makeSession("session-1", "running")] });
+      await deferredSessions.promise;
+    });
+
+    // 不覆盖用户已切到的会话，不为已放弃的会话重建 SSE 连接
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-2");
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it("ignores a delayed init session-list response after deleteSession clears the current session (session-op generation)", async () => {
+    // 同上，换成挂起期间用户删除当前会话且无其它会话可切（清空到无会话）。
+    const deferredSessions = createDeferred<{ sessions: SessionMeta[] }>();
+    vi.spyOn(API, "listAssistantSessions").mockReturnValue(deferredSessions.promise);
+    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "running") });
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+    vi.spyOn(API, "deleteAssistantSession").mockResolvedValue({ success: true });
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    // 模拟用户此前已选中会话（挂起期间 store 中已有当前会话可删）
+    act(() => {
+      useAssistantStore.getState().setCurrentSessionId("session-1");
+      useAssistantStore.getState().setSessions([makeSession("session-1", "idle")]);
+    });
+
+    await act(async () => {
+      await result.current.deleteSession("session-1");
+    });
+    expect(useAssistantStore.getState().currentSessionId).toBeNull();
+
+    // 迟到：init 的会话列表此刻才返回，携带一个 running 会话
+    await act(async () => {
+      deferredSessions.resolve({ sessions: [makeSession("session-1", "running")] });
+      await deferredSessions.promise;
+    });
+
+    // 不覆盖用户的删除操作，不为已放弃的会话重建 SSE 连接
+    expect(useAssistantStore.getState().currentSessionId).toBeNull();
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
 });

--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -843,4 +843,47 @@ describe("useAssistantSession", () => {
     expect(listSessionsSpy).not.toHaveBeenCalled();
     expect(useAssistantStore.getState().currentSessionId).toBeNull();
   });
+
+  it("ignores a delayed switchSession response after leaving the project (currentSessionId unchanged, no SSE leak)", async () => {
+    // switchSession 同步把 currentSessionId 设为目标 sessionId，若随后用户离开
+    // 项目（projectName -> null，不会重置 currentSessionId），loadSession 的
+    // currentSessionId 比对无法识破——两者仍相等。必须靠项目代次判定短路，
+    // 否则会用旧闭包的 projectName 为已离开的项目建 SSE 连接（连接泄漏）。
+    const deferredSwitch = createDeferred<{ session: SessionMeta }>();
+    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+      sessions: [makeSession("session-1", "idle")],
+    });
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (_projectName, sessionId) => {
+      if (sessionId === "session-2") return deferredSwitch.promise;
+      return { session: makeSession(sessionId, "idle") };
+    });
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+
+    const { result, rerender } = renderHook(({ projectName }) => useAssistantSession(projectName), {
+      initialProps: { projectName: "project-a" as string | null },
+    });
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    await act(async () => {
+      void result.current.switchSession("session-2");
+    });
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-2");
+    expect(useAssistantStore.getState().sessionStatus).toBe("idle");
+
+    // 离开项目：projectName 置空，currentSessionId 不受影响，仍是 "session-2"
+    rerender({ projectName: null });
+
+    // 迟到：switchSession 发起的 getAssistantSession 此刻才返回 running
+    await act(async () => {
+      deferredSwitch.resolve({ session: makeSession("session-2", "running") });
+      await deferredSwitch.promise;
+    });
+
+    expect(MockEventSource.instances).toHaveLength(0);
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-2");
+    expect(useAssistantStore.getState().sessionStatus).toBe("idle");
+  });
 });

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -8,6 +8,7 @@ import type {
   DraftState,
   PendingQuestion,
   SessionMeta,
+  SessionStatus,
   TimelineEntry,
 } from "@/types";
 
@@ -216,27 +217,36 @@ export function useAssistantSession(projectName: string | null) {
     [clearPendingQuestion, projectName, closeStream, store, syncPendingQuestion],
   );
 
-  // 加载指定会话时间线：非 running 冷读日志；running 交给 entry 流回放
-  const loadSession = useCallback(async (sessionId: string) => {
+  // 加载指定会话时间线：非 running 冷读日志；running 交给 entry 流回放。
+  // 内部异步请求感知取消：每个 await 断点后、connectStream 建流前与写 store 前
+  // 均复核过期，旧项目/旧会话的迟到响应不建 SSE 连接、不写入任何状态。
+  const loadSession = useCallback(async (sessionId: string, isStale?: () => boolean) => {
+    // 过期判定：外层 effect 的 cancelled closure flag（拦截项目切换后的迟到响应）
+    // 叠加 currentSessionId 身份比对（switchSession 等同步改写路径的第二道防线）。
+    const isStaleLoad = () => (isStale?.() ?? false) || store.getState().currentSessionId !== sessionId;
+
     const res = await API.getAssistantSession(projectName!, sessionId);
+    if (isStaleLoad()) return;
     const raw = res as Record<string, unknown>;
     const sessionObj = (raw.session ?? raw) as Record<string, unknown>;
     const status = (sessionObj.status as string) ?? "idle";
     statusRef.current = status;
-    store.getState().setSessionStatus(status as "idle");
     // 清掉跨挂载残留的过期问题（zustand 全局 store 在组件卸载后仍保留）；
     // running 会话的未决问题由 entry 流的 question 事件重新投递。
-    clearPendingQuestion();
 
     if (status === "running") {
+      store.getState().loadSessionSnapshot(status);
       connectStream(sessionId);
     } else {
       const data = await API.listAssistantEntries(projectName!, sessionId);
-      if (store.getState().currentSessionId !== sessionId) return;
-      store.getState().setEntries(data.entries ?? []);
-      store.getState().setDraftSnapshot(data.draft ?? null, data.draft_rev ?? 0);
+      if (isStaleLoad()) return;
+      store.getState().loadSessionSnapshot(status as SessionStatus, {
+        entries: data.entries ?? [],
+        draft: data.draft ?? null,
+        rev: data.draft_rev ?? 0,
+      });
     }
-  }, [projectName, clearPendingQuestion, connectStream, store]);
+  }, [projectName, connectStream, store]);
 
   // 加载会话
   useEffect(() => {
@@ -271,7 +281,9 @@ export function useAssistantSession(projectName: string | null) {
         if (cancelled) return;
 
         store.getState().setCurrentSessionId(sessionId);
-        await loadSession(sessionId);
+        // 传入取消判定：项目切换后 cleanup 置 cancelled，loadSession 的迟到
+        // 响应据此短路，不为已离开的项目建 SSE 连接、不写入陈旧状态。
+        await loadSession(sessionId, () => cancelled);
       } catch {
         // 静默失败
       } finally {

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -95,6 +95,17 @@ export function useAssistantSession(projectName: string | null) {
     projectGenRef.current += 1;
   }, [projectName]);
 
+  // 会话操作代次：switchSession/createNewSession/删除当前会话到无会话时
+  // 同步递增，供 init effect 内挂起的 listAssistantSessions 请求感知“同
+  // 项目内会话已被用户操作变更”。与 projectGenRef 正交——项目代次感知
+  // “项目已切换”，此代次感知“同项目内会话已被操作”：init 的
+  // listAssistantSessions 挂起期间若用户新建/切换/删除会话，cancelled 和
+  // projectGenRef 均不变（effect 未 cleanup、projectName 未变），迟到响应
+  // 会把 currentSessionId 覆盖回旧会话并重新 loadSession，覆盖用户刚完成
+  // 的操作。三处操作均由用户交互同步调用（非渲染期、无微任务竞速窗口），
+  // 直接写 ref 即可，无需 layout effect 的时序保证。
+  const sessionOpGenRef = useRef(0);
+
   const syncPendingQuestion = useCallback((question: PendingQuestion | null) => {
     store.getState().setPendingQuestion(question);
     store.getState().setAnsweringQuestion(false);
@@ -277,15 +288,20 @@ export function useAssistantSession(projectName: string | null) {
     // 本次 commit 时 projectGenRef 已由同一轮的 layout effect 同步递增完毕
     // （layout effect 先于 passive effect 运行），此处读到的即当前项目代次。
     const gen = projectGenRef.current;
+    // 会话操作代次同一时刻捕获：挂起期间 switchSession/createNewSession/
+    // 删除当前会话到无会话会同步递增它，感知“同项目内会话已被操作”。
+    const sessionOpGen = sessionOpGenRef.current;
 
-    // 取消判定统一叠加两道信号：cancelled 由本 effect cleanup 同步置位，
+    // 取消判定统一叠加三道信号：cancelled 由本 effect cleanup 同步置位，
     // 但 cleanup 本身也是 passive effect、经宏任务调度；projectGenRef 由
     // layout effect 同步递增，弥补 cleanup 尚未运行时的迟到响应（fetch 续行
-    // 是微任务，可能抢在 cleanup 的宏任务之前执行）。凡是本 effect 内任何异步
-    // 续行要写 store，都须先过这道判定——单独判 loadSession 的迟到响应不够，
-    // listAssistantSessions/listAssistantSkills 的迟到响应同样可能在项目已
-    // 切走后把旧项目数据写进当前 store。
-    const isStale = () => cancelled || projectGenRef.current !== gen;
+    // 是微任务，可能抢在 cleanup 的宏任务之前执行）；sessionOpGenRef 弥补
+    // 项目未切换、但同项目内会话已被操作的场景——前两道信号均无法拦截。
+    // 凡是本 effect 内任何异步续行要写 store，都须先过这道判定——单独判
+    // loadSession 的迟到响应不够，listAssistantSessions/listAssistantSkills
+    // 的迟到响应同样可能覆盖用户已完成的项目切换或会话操作。
+    const isStale = () =>
+      cancelled || projectGenRef.current !== gen || sessionOpGenRef.current !== sessionOpGen;
 
     async function init() {
       store.getState().setMessagesLoading(true);
@@ -485,6 +501,9 @@ export function useAssistantSession(projectName: string | null) {
   const createNewSession = useCallback(() => {
     if (!projectName) return;
 
+    // 使同项目内挂起的 init listAssistantSessions 迟到响应失效，防止其
+    // 覆盖本次新建会话（见 sessionOpGenRef 定义处的竞态说明）。
+    sessionOpGenRef.current += 1;
     invalidatePendingSend();
     closeStream();
     store.getState().resetTimeline();
@@ -507,6 +526,9 @@ export function useAssistantSession(projectName: string | null) {
     // 捕获当前项目代次：调用期间项目被切走（即便 currentSessionId 未变，
     // 见 loadSession 的第二道防线注释）时据此短路，不为已离开的项目建流。
     const gen = projectGenRef.current;
+    // 使同项目内挂起的 init listAssistantSessions 迟到响应失效，防止其
+    // 覆盖本次切换（见 sessionOpGenRef 定义处的竞态说明）。
+    sessionOpGenRef.current += 1;
 
     invalidatePendingSend();
     closeStream();
@@ -545,6 +567,9 @@ export function useAssistantSession(projectName: string | null) {
         if (sessions.length > 0) {
           await switchSession(sessions[0].id);
         } else {
+          // 使同项目内挂起的 init listAssistantSessions 迟到响应失效，防止
+          // 其覆盖本次删除（见 sessionOpGenRef 定义处的竞态说明）。
+          sessionOpGenRef.current += 1;
           invalidatePendingSend();
           closeStream();
           store.getState().setCurrentSessionId(null);

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -243,7 +243,14 @@ export function useAssistantSession(projectName: string | null) {
       store.getState().loadSessionSnapshot(status as SessionStatus);
       const data = await API.listAssistantEntries(projectName!, sessionId);
       if (isStaleLoad()) return;
-      store.getState().loadSessionSnapshot(status as SessionStatus, {
+      if (store.getState().sessionStatus !== status) {
+        // 冷读期间 sessionStatus 已被并发操作（如同会话内 sendMessage）改写，
+        // 说明会话已进入新状态：不再用冷读前捕获的旧 status/draft 覆盖回去，
+        // 仅按 seq 并入历史 entries，状态与 draft 交由并发写入方与后续 SSE 流接管。
+        store.getState().setEntries(data.entries ?? []);
+        return;
+      }
+      store.getState().loadSessionSnapshot(status, {
         entries: data.entries ?? [],
         draft: data.draft ?? null,
         rev: data.draft_rev ?? 0,

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -278,6 +278,15 @@ export function useAssistantSession(projectName: string | null) {
     // （layout effect 先于 passive effect 运行），此处读到的即当前项目代次。
     const gen = projectGenRef.current;
 
+    // 取消判定统一叠加两道信号：cancelled 由本 effect cleanup 同步置位，
+    // 但 cleanup 本身也是 passive effect、经宏任务调度；projectGenRef 由
+    // layout effect 同步递增，弥补 cleanup 尚未运行时的迟到响应（fetch 续行
+    // 是微任务，可能抢在 cleanup 的宏任务之前执行）。凡是本 effect 内任何异步
+    // 续行要写 store，都须先过这道判定——单独判 loadSession 的迟到响应不够，
+    // listAssistantSessions/listAssistantSkills 的迟到响应同样可能在项目已
+    // 切走后把旧项目数据写进当前 store。
+    const isStale = () => cancelled || projectGenRef.current !== gen;
+
     async function init() {
       store.getState().setMessagesLoading(true);
       // 切项目先重置时间线（与新建/切换/删除三条会话路径同口径），使有会话/
@@ -285,10 +294,14 @@ export function useAssistantSession(projectName: string | null) {
       // 的空 entries 推导（等效从头订阅），不被上一个项目的残留条目污染，也不会
       // 把旧项目条目混排进新会话时间线。
       store.getState().resetTimeline();
+      // 目标会话 id 提升到 try 外部：finally 里据此复核 currentSessionId 是否
+      // 仍等于本次请求的目标，防止本次切项目未过期、但用户在同一项目内并发
+      // 切换到另一会话时，被本次 init 的 finally 误关新会话的 loading 态。
+      let targetSessionId: string | null = null;
       try {
         // 获取会话列表
         const res = await API.listAssistantSessions(projectName!);
-        if (cancelled) return;
+        if (isStale()) return;
         const sessions = res.sessions ?? [];
         store.getState().setSessions(sessions);
 
@@ -296,32 +309,30 @@ export function useAssistantSession(projectName: string | null) {
         const lastId = getLastSessionId(projectName!);
         const sessionId = (lastId && sessions.some((s: SessionMeta) => s.id === lastId))
           ? lastId
-          : sessions[0]?.id;
+          : (sessions[0]?.id ?? null);
+        targetSessionId = sessionId;
         if (!sessionId) {
           store.getState().setCurrentSessionId(null);
           clearPendingQuestion();
-          store.getState().setMessagesLoading(false);
           return;
         }
-        if (cancelled) return;
+        if (isStale()) return;
 
         store.getState().setCurrentSessionId(sessionId);
-        // 取消判定叠加两道信号：cancelled 由本 effect cleanup 同步置位，
-        // 但 cleanup 本身也是 passive effect、经宏任务调度；projectGenRef
-        // 由 layout effect 同步递增，弥补 cleanup 尚未运行时的迟到响应
-        // （fetch 续行是微任务，可能抢在 cleanup 的宏任务之前执行）。
-        await loadSession(sessionId, () => cancelled || projectGenRef.current !== gen);
+        await loadSession(sessionId, isStale);
       } catch {
         // 静默失败
       } finally {
-        if (!cancelled) store.getState().setMessagesLoading(false);
+        if (!isStale() && store.getState().currentSessionId === targetSessionId) {
+          store.getState().setMessagesLoading(false);
+        }
       }
     }
 
     // 加载技能列表
     API.listAssistantSkills(projectName)
       .then((res) => {
-        if (!cancelled) store.getState().setSkills(res.skills ?? []);
+        if (!isStale()) store.getState().setSkills(res.skills ?? []);
       })
       .catch(() => {});
 
@@ -509,7 +520,11 @@ export function useAssistantSession(projectName: string | null) {
     } catch {
       // 静默失败
     } finally {
-      store.getState().setMessagesLoading(false);
+      // 与 init effect 同一套代次 + 目标身份复核：避免本次调用挂起期间用户
+      // 已再次切换会话/项目，迟到的 finally 误关新会话的 loading 态。
+      if (projectGenRef.current === gen && store.getState().currentSessionId === sessionId) {
+        store.getState().setMessagesLoading(false);
+      }
     }
   }, [projectName, clearPendingQuestion, closeStream, invalidatePendingSend, loadSession, store]);
 

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -492,6 +492,10 @@ export function useAssistantSession(projectName: string | null) {
     clearPendingQuestion();
     store.getState().setCurrentSessionId(null);
     store.getState().setIsDraftSession(true);
+    // 放弃当前加载：若此时有 switchSession 的 loadSession 正在挂起，其
+    // finally 会因 currentSessionId 已变为 null 而判定过期、跳过收尾，
+    // 此处需替其显式清理，否则 messagesLoading 永久卡 true。
+    store.getState().setMessagesLoading(false);
     statusRef.current = "idle";
   }, [projectName, clearPendingQuestion, closeStream, invalidatePendingSend, store]);
 
@@ -547,6 +551,9 @@ export function useAssistantSession(projectName: string | null) {
           store.getState().resetTimeline();
           store.getState().setSessionStatus(null);
           clearPendingQuestion();
+          // 同 createNewSession：放弃当前加载时若有旧 switchSession 的
+          // loadSession 挂起中，需替其显式清理 messagesLoading。
+          store.getState().setMessagesLoading(false);
           statusRef.current = "idle";
         }
       }

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -83,6 +83,16 @@ export function useAssistantSession(projectName: string | null) {
   // 失败重试复用同一幂等键（同内容签名），成功后清除
   const failedSendRef = useRef<{ clientKey: string; signature: string } | null>(null);
 
+  // 项目代次：projectName 变化后递增，供 switchSession 等 imperatively 发起
+  // 的异步调用感知“项目已切换”，弥补它不像 init effect 那样天然拥有按
+  // projectName 重建的 cancelled closure flag。effect 在 commit 后运行，
+  // switchSession 只能由用户交互触发（不会与本次渲染同步执行），故此处的
+  // 一帧延迟不构成竞态窗口。
+  const projectGenRef = useRef(0);
+  useEffect(() => {
+    projectGenRef.current += 1;
+  }, [projectName]);
+
   const syncPendingQuestion = useCallback((question: PendingQuestion | null) => {
     store.getState().setPendingQuestion(question);
     store.getState().setAnsweringQuestion(false);
@@ -472,6 +482,10 @@ export function useAssistantSession(projectName: string | null) {
     if (!projectName) return;
     if (store.getState().currentSessionId === sessionId) return;
 
+    // 捕获当前项目代次：调用期间项目被切走（即便 currentSessionId 未变，
+    // 见 loadSession 的第二道防线注释）时据此短路，不为已离开的项目建流。
+    const gen = projectGenRef.current;
+
     invalidatePendingSend();
     closeStream();
     store.getState().setCurrentSessionId(sessionId);
@@ -484,7 +498,7 @@ export function useAssistantSession(projectName: string | null) {
     if (projectName) saveLastSessionId(projectName, sessionId);
 
     try {
-      await loadSession(sessionId);
+      await loadSession(sessionId, () => projectGenRef.current !== gen);
     } catch {
       // 静默失败
     } finally {

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -469,6 +469,7 @@ export function useAssistantSession(projectName: string | null) {
 
   // 切换到指定会话
   const switchSession = useCallback(async (sessionId: string) => {
+    if (!projectName) return;
     if (store.getState().currentSessionId === sessionId) return;
 
     invalidatePendingSend();

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -238,6 +238,9 @@ export function useAssistantSession(projectName: string | null) {
       store.getState().loadSessionSnapshot(status);
       connectStream(sessionId);
     } else {
+      // 先落状态 + 清残留问题，再冷读时间线：entries 较慢或失败时，旧会话的
+      // running/pendingQuestion 状态不会滞留——新会话已正确落为 idle/completed。
+      store.getState().loadSessionSnapshot(status as SessionStatus);
       const data = await API.listAssistantEntries(projectName!, sessionId);
       if (isStaleLoad()) return;
       store.getState().loadSessionSnapshot(status as SessionStatus, {

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { errMsg, voidCall } from "@/utils/async";
 import { API } from "@/api";
 import { uid } from "@/utils/id";
@@ -83,13 +83,15 @@ export function useAssistantSession(projectName: string | null) {
   // 失败重试复用同一幂等键（同内容签名），成功后清除
   const failedSendRef = useRef<{ clientKey: string; signature: string } | null>(null);
 
-  // 项目代次：projectName 变化后递增，供 switchSession 等 imperatively 发起
-  // 的异步调用感知“项目已切换”，弥补它不像 init effect 那样天然拥有按
-  // projectName 重建的 cancelled closure flag。effect 在 commit 后运行，
-  // switchSession 只能由用户交互触发（不会与本次渲染同步执行），故此处的
-  // 一帧延迟不构成竞态窗口。
+  // 项目代次：projectName 变化后递增，供 switchSession/init 等异步调用感知
+  // “项目已切换”。必须用 useLayoutEffect 而非 useEffect：passive effect 由
+  // 浏览器宏任务（MessageChannel）调度，而被守护的 fetch 续行是微任务——若
+  // 用 useEffect，微任务可能抢在宏任务化的递增之前执行，造成迟到响应把
+  // isStale 误判为 false 的竞态窗口。layout effect 在 commit 阶段同步运行，
+  // 保证在任何后续微任务/宏任务执行前完成递增，彻底关闭该窗口。写 ref 仍
+  // 发生在 effect 回调内（非渲染期），不违反 react-hooks/refs 规则。
   const projectGenRef = useRef(0);
-  useEffect(() => {
+  useLayoutEffect(() => {
     projectGenRef.current += 1;
   }, [projectName]);
 
@@ -272,6 +274,9 @@ export function useAssistantSession(projectName: string | null) {
   useEffect(() => {
     if (!projectName) return;
     let cancelled = false;
+    // 本次 commit 时 projectGenRef 已由同一轮的 layout effect 同步递增完毕
+    // （layout effect 先于 passive effect 运行），此处读到的即当前项目代次。
+    const gen = projectGenRef.current;
 
     async function init() {
       store.getState().setMessagesLoading(true);
@@ -301,9 +306,11 @@ export function useAssistantSession(projectName: string | null) {
         if (cancelled) return;
 
         store.getState().setCurrentSessionId(sessionId);
-        // 传入取消判定：项目切换后 cleanup 置 cancelled，loadSession 的迟到
-        // 响应据此短路，不为已离开的项目建 SSE 连接、不写入陈旧状态。
-        await loadSession(sessionId, () => cancelled);
+        // 取消判定叠加两道信号：cancelled 由本 effect cleanup 同步置位，
+        // 但 cleanup 本身也是 passive effect、经宏任务调度；projectGenRef
+        // 由 layout effect 同步递增，弥补 cleanup 尚未运行时的迟到响应
+        // （fetch 续行是微任务，可能抢在 cleanup 的宏任务之前执行）。
+        await loadSession(sessionId, () => cancelled || projectGenRef.current !== gen);
       } catch {
         // 静默失败
       } finally {

--- a/frontend/src/stores/assistant-store.ts
+++ b/frontend/src/stores/assistant-store.ts
@@ -70,6 +70,15 @@ interface AssistantState {
   setDraftSnapshot: (draft: DraftState | null, rev: number) => void;
   /** 应用一条流式 delta；rev 未超过门槛时忽略。 */
   applyDelta: (payload: DraftDeltaPayload) => void;
+  /**
+   * 载入会话首帧：会话状态 + 清残留问题合并为单次原子更新；冷读非 running
+   * 会话时一并落时间线（entries + draft），把状态、问题、时间线的多次写归并
+   * 到一次 set，消除加载过程中的中间态闪现。
+   */
+  loadSessionSnapshot: (
+    status: SessionStatus | null,
+    timeline?: { entries: TimelineEntry[]; draft: DraftState | null; rev: number },
+  ) => void;
   clearDraft: () => void;
   /** 清空时间线（项目切换 / 新会话）。 */
   resetTimeline: () => void;
@@ -212,6 +221,36 @@ export const useAssistantStore = create<AssistantState>((set, get) => {
         draft: next,
         draftRev: payload.rev,
         draftTurn: buildDraftTurn(next, isDraftReplaced(next, committedFor(get().entries))),
+      });
+    },
+    loadSessionSnapshot: (status, timeline) => {
+      // running 分支：时间线交给 entry 流回放，仅落状态 + 清残留问题
+      if (!timeline) {
+        set({ sessionStatus: status, pendingQuestion: null, answeringQuestion: false });
+        return;
+      }
+      // 非 running 冷读：与 setEntries / setDraftSnapshot 同口径构造投影，
+      // 但状态、问题、entries、draft 一次 set 落地，避免中间态多帧渲染。
+      const prevEntries = get().entries;
+      const merged = mergeEntriesBySeq(prevEntries, timeline.entries);
+      const mirror: DraftMirror | null = timeline.draft
+        ? {
+            ...timeline.draft,
+            content: [...(timeline.draft.content ?? [])],
+            toolJson: { ...(timeline.draft.tool_json ?? {}) },
+          }
+        : null;
+      committedIds = collectCommittedMessageIds(merged);
+      committedSource = merged;
+      set({
+        sessionStatus: status,
+        pendingQuestion: null,
+        answeringQuestion: false,
+        entries: merged,
+        turns: projectEntries(prevEntries, merged),
+        draft: mirror,
+        draftRev: timeline.rev,
+        draftTurn: buildDraftTurn(mirror, isDraftReplaced(mirror, committedIds)),
       });
     },
     clearDraft: () => set({ draft: null, draftTurn: null }),


### PR DESCRIPTION
## 摘要

`useAssistantSession` 的 `loadSession` 内部异步请求（`getAssistantSession` / `listAssistantEntries`）此前不感知取消：外层 `init()` effect 的 `cancelled` closure flag 只拦截 effect 自身的 await 断点，`loadSession` 拿到旧项目的迟到响应后仍会调用 `connectStream`——为用户已离开的项目建立无人消费、无人关闭的 SSE 连接（服务端订阅者堆积泄漏）。

## 改动

- `loadSession(sessionId, isStale?)` 感知取消：过期判定 = 传入的 `cancelled` closure flag（拦截项目切换后的迟到响应）**叠加** `currentSessionId` 身份比对（`switchSession` 等同步改写路径的第二道防线）。每个 await 断点后、`connectStream` 建流前、写 store 前均复核过期。
- 顺带将冷读非 running 会话的「状态 + 清残留问题 + 时间线（entries + draft）」多次 `set` 合并为单次 store 原子 action `loadSessionSnapshot`，消除加载中间态闪现；投影口径（mergeEntriesBySeq / committedIds / draft mirror / draftTurn）与原 `setEntries` + `setDraftSnapshot` 完全一致，最终态不变。
- CLAUDE.md（经 `AGENTS.md` 符号链接）前端节新增「异步竞态防护」约定，含 `cancelled` flag 传入被调异步函数、跨入口刷新收敛为 store action 在途合并两种场景的适用边界。

## 验证

- `pnpm lint` 干净；`pnpm check`（typecheck + vitest）1016 passed（111 文件），含新增回归用例 `ignores a delayed loadSession response after switching projects`：项目 A running 会话 loadSession 卡在 `getAssistantSession`，切到 B 后 A 迟到响应 resolve——断言不建 SSE 连接、状态与时间线保持 B。
- PR #1152 锁定的 3 例回归全绿：冷订阅游标（切项目后 `after=` 不带）、续传游标（同会话重连 `after=1` 不回退）、无会话项目重置。

Closes #1245


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复切换项目/会话后迟到请求可能建立连接、回写旧会话或覆盖时间线/条目的竞态问题。
  * 优化会话装载：区分进行中与冷读首帧恢复，并在并发冷读/发送冲突时避免状态回退。
  * 防止切换或放弃加载时加载状态长时间卡住、误关闭新会话的 loading。
* **New Features**
  * 新增会话快照装载能力：支持首帧状态恢复，并在适用场景下合并条目与草稿，减少中间态闪现。
* **Documentation**
  * 新增前端工程规范：异步竞态防护与跨入口刷新请求合并策略。
* **Tests**
  * 扩展并发时序覆盖：迟到响应忽略、离开项目短路、冷读挂起并发发送等关键场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->