### PR TITLE
fix(api): 上传后概览生成失败不再回传服务器路径

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -2,6 +2,7 @@ MESSAGES = {
     "project_not_found": "Project '{name}' does not exist or is not initialized",
     "resource_not_found": "The requested resource does not exist",
     "overview_ai_response_invalid": "The AI response could not be parsed into a project overview. Please retry or switch to a different model/provider",
+    "overview_generation_failed": "Overview generation failed. Please retry later or switch to a different model/provider",
     "video_capabilities_unresolved": "Cannot resolve video model capabilities for project '{name}': {reason}",
     "scope_invalid": "scope must be full or current",
     "download_expired": "Download link expired, please re-export",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -2,6 +2,7 @@ MESSAGES = {
     "project_not_found": "Dự án '{name}' không tồn tại hoặc chưa được khởi tạo",
     "resource_not_found": "Tài nguyên được yêu cầu không tồn tại",
     "overview_ai_response_invalid": "Không thể phân tích phản hồi của AI thành tổng quan dự án, vui lòng thử lại hoặc đổi mô hình/nhà cung cấp",
+    "overview_generation_failed": "Tạo tổng quan thất bại, vui lòng thử lại sau hoặc đổi mô hình/nhà cung cấp",
     "video_capabilities_unresolved": "Không xác định được khả năng mô hình video cho dự án '{name}': {reason}",
     "scope_invalid": "scope phải là full hoặc current",
     "download_expired": "Liên kết tải xuống đã hết hạn, vui lòng xuất lại",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -2,6 +2,7 @@ MESSAGES = {
     "project_not_found": "项目 '{name}' 不存在或未初始化",
     "resource_not_found": "请求的资源不存在",
     "overview_ai_response_invalid": "AI 返回内容无法解析为项目概述，请重试或更换模型/供应商",
+    "overview_generation_failed": "概述生成失败，请稍后重试或更换模型/供应商",
     "video_capabilities_unresolved": "无法解析项目 '{name}' 的视频模型能力：{reason}",
     "scope_invalid": "scope 必须为 full 或 current",
     "download_expired": "下载链接已过期，请重新导出",

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -1273,9 +1273,14 @@ async def set_project_source(
                     overview = await manager.generate_overview(name)
                 result["overview"] = overview
             except Exception as ov_err:
+                # 概览生成是上传的可选后续步骤，失败仅降级回传提示、不影响上传成功。
+                # 裸 str(ov_err) 可能携带服务器路径等内部细节，回传翻译后的通用文案。
+                logger.exception("上传后概览生成失败")
                 result["overview"] = None
                 result["overview_error"] = (
-                    _t("overview_ai_response_invalid") if isinstance(ov_err, PydanticValidationError) else str(ov_err)
+                    _t("overview_ai_response_invalid")
+                    if isinstance(ov_err, PydanticValidationError)
+                    else _t("overview_generation_failed")
                 )
 
         return result

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from lib.i18n.zh import errors as zh_errors
 from lib.project_manager import EmptySourceError
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
@@ -58,12 +59,14 @@ class _FakePM:
         (self.base / "bad").mkdir(parents=True, exist_ok=True)
         (self.base / "no-provider").mkdir(parents=True, exist_ok=True)
         (self.base / "corrupted").mkdir(parents=True, exist_ok=True)
+        # 上传后概览生成失败的软降级路径：项目存在，但 generate_overview 抛带路径异常
+        (self.base / "leaky").mkdir(parents=True, exist_ok=True)
 
     def list_projects(self):
         return ["ready", "empty", "broken"]
 
     def project_exists(self, name):
-        return name in {"ready", "broken"}
+        return name in {"ready", "broken", "leaky"}
 
     def load_project(self, name):
         if name == "broken":
@@ -195,6 +198,10 @@ class _FakePM:
     async def generate_overview(self, name):
         if name == "ready":
             return {"synopsis": "generated"}
+        if name == "leaky":
+            # 模拟底层异常文本携带服务器绝对路径（如文件读写失败），
+            # 上传端点的软降级分支不得把裸 str(e) 透传给客户端。
+            raise RuntimeError("open failed: /Users/secret/projects/leaky/source/novel.txt")
         if name == "no-provider":
             raise ValueError("未找到可用的 text 供应商")
         if name == "corrupted":
@@ -1644,6 +1651,27 @@ class TestUnexpectedErrorsDoNotLeak:
             )
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
+
+    def test_set_project_source_overview_error_does_not_leak_path(self, tmp_path, monkeypatch):
+        # 概览生成是上传的可选后续：失败时上传仍成功（200），错误只降级回传 overview_error。
+        # 底层异常文本可能携带服务器绝对路径，该分支不得把裸 str(e) 透传给客户端。
+        client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
+        with client:
+            resp = client.post(
+                "/api/v1/projects/leaky/source",
+                data={"content": "正文", "generate_overview": "true"},
+            )
+            assert resp.status_code == 200
+            payload = resp.json()
+            assert payload["success"] is True
+            assert payload["overview"] is None
+            # 上传成功后合法回传的 filename 是 novel.txt，不在泄漏范畴；
+            # 泄漏关注的是异常文本携带的服务器绝对路径片段。
+            assert "/Users" not in resp.text
+            assert "/var" not in resp.text
+            assert "/secret/" not in resp.text
+            # 回传的是翻译后的通用文案，而非裸异常串
+            assert payload["overview_error"] == zh_errors.MESSAGES["overview_generation_failed"]
 
     def test_generate_overview_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_generate_overview"


### PR DESCRIPTION
Closes #1251

## 背景

PR #1250 完成路由错误处理迁移后，文件上传端点的内联概览生成错误分支仍残留 `str(ov_err)` 写入错误响应，异常文本可能携带服务器绝对路径回传客户端（CodeQL alert #317，py/stack-trace-exposure）。该路径不在 PR #1250 的 diff 内，属漏网点。

## 改动

- `server/routers/projects.py`：上传后概览生成失败分支改为 `logger.exception` 记录 + 回传新增的 `overview_generation_failed` 通用文案，不再透传裸 `str(ov_err)`。保留 `PydanticValidationError → overview_ai_response_invalid` 特例分支（提示更具体）。
- 该分支语义为**软降级**——概览是上传的可选后续，失败时上传本身仍返回 200，错误只降级填入 `result["overview_error"]`，故走「日志 + 通用文案」而非改抛领域异常，以保持既有语义。
- 新增 `overview_generation_failed` 三语文案（zh/en/vi）。
- 新增回归用例：模拟 `generate_overview` 抛携带 `/Users/secret/...` 路径的异常，断言响应仍 200、`overview` 为 None、响应体不含 `/Users`/`/var`/`/secret/` 片段、`overview_error` 等值于通用文案。

## 验证

- `ruff check` + `ruff format --check`：干净
- `basedpyright server/routers/projects.py`：0 error
- `pytest tests/test_projects_router.py tests/test_i18n_consistency.py`：83 passed
- 全量 `pytest`（实现阶段）：6216 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误处理**
  * 优化项目概述生成失败时的提示，统一显示本地化的通用错误信息。
  * 概述生成失败不会影响项目源文件上传，系统将返回空概述并建议稍后重试或更换模型/供应商。
  * 避免向界面暴露服务器内部路径等敏感错误细节。

* **本地化**
  * 新增中文、英文和越南语错误提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->