### PR TITLE
fix(grids): 宫格生成成功文案改走多语言，英越用户不再收到中文提示

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -53,6 +53,7 @@ MESSAGES = {
     "video_prompt_action_empty": "prompt.action cannot be empty",
     "video_prompt_dialogue_array": "prompt.dialogue must be an array",
     "video_task_submitted": "Video generation task for '{segment_id}' submitted",
+    "grid_task_submitted": "Submitted {count} grid generation tasks",
     "tts_prompt_must_be_string_or_null": "tts task prompt must be a non-empty string or omitted",
     "tts_task_submitted": "Narration audio task for '{segment_id}' submitted",
     "tts_batch_submitted": "Submitted {count} narration audio tasks",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -53,6 +53,7 @@ MESSAGES = {
     "video_prompt_action_empty": "prompt.action không được để trống",
     "video_prompt_dialogue_array": "prompt.dialogue phải là mảng",
     "video_task_submitted": "Đã gửi tác vụ tạo video cho '{segment_id}'",
+    "grid_task_submitted": "Đã gửi {count} tác vụ tạo lưới",
     "tts_prompt_must_be_string_or_null": "prompt của tác vụ tts phải là chuỗi không rỗng hoặc để trống",
     "tts_task_submitted": "Đã gửi tác vụ tạo thuyết minh cho '{segment_id}'",
     "tts_batch_submitted": "Đã gửi {count} tác vụ tạo thuyết minh",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -53,6 +53,7 @@ MESSAGES = {
     "video_prompt_action_empty": "prompt.action 不能为空",
     "video_prompt_dialogue_array": "prompt.dialogue 必须是数组",
     "video_task_submitted": "视频「{segment_id}」生成任务已提交",
+    "grid_task_submitted": "已提交 {count} 个宫格生成任务",
     "tts_prompt_must_be_string_or_null": "tts 任务的 prompt 必须是非空字符串或留空",
     "tts_task_submitted": "旁白「{segment_id}」生成任务已提交",
     "tts_batch_submitted": "已提交 {count} 个旁白生成任务",

--- a/server/routers/grids.py
+++ b/server/routers/grids.py
@@ -18,6 +18,7 @@ from lib.grid.layout import calculate_grid_layout
 from lib.grid.models import GridGeneration
 from lib.grid.prompt_builder import build_grid_prompt
 from lib.grid_manager import GridManager
+from lib.i18n import Translator
 from lib.project_manager import get_project_manager
 from lib.storyboard_sequence import get_storyboard_items, group_scenes_by_segment_break
 from server.auth import CurrentUser
@@ -79,6 +80,7 @@ async def generate_grid(
     episode: int,
     req: GenerateGridRequest,
     _user: CurrentUser,
+    _t: Translator,
 ):
     """
     提交宫格图生成任务到队列，按分段分组，每组 N>=4 个场景生成一个宫格图。
@@ -222,7 +224,7 @@ async def generate_grid(
         grid_ids=grid_ids,
         task_ids=task_ids,
         deduped=bool(task_ids) and all(deduped_flags),
-        message=f"已提交 {len(grid_ids)} 个宫格生成任务",
+        message=_t("grid_task_submitted", count=len(grid_ids)),
     )
 
 

--- a/tests/test_grids_router.py
+++ b/tests/test_grids_router.py
@@ -318,9 +318,30 @@ def test_generate_grid_success(monkeypatch, tmp_path):
         assert len(body["grid_ids"]) == 1
         assert len(body["task_ids"]) == 1
         assert body["deduped"] is False
+        # message 走 i18n（默认中文），不再硬编码
+        assert body["message"] == "已提交 1 个宫格生成任务"
     assert len(fake_queue.calls) == 1
     saved = json.loads((tmp_path / "grids" / f"{body['grid_ids'][0]}.json").read_text(encoding="utf-8"))
     assert saved["scene_ids"] == ["E1S01", "E1S02", "E1S03", "E1S04"]
+
+
+def test_generate_grid_success_message_localized_en(monkeypatch, tmp_path):
+    # Accept-Language=en 时 message 按英文渲染，验证成功文案已接入 Translator
+    fake_queue = _FakeQueue()
+    client = _client(
+        monkeypatch,
+        get_project_manager=lambda: _FakePMGenerate(tmp_path),
+        get_generation_queue=lambda: fake_queue,
+    )
+    with client:
+        resp = client.post(
+            "/api/v1/projects/demo/generate/grid/1",
+            json={"script_file": "episode_1.json"},
+            headers={"Accept-Language": "en"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["message"] == "Submitted 1 grid generation tasks"
 
 
 class _FakePMPath:


### PR DESCRIPTION
Closes #1265

## 问题
宫格生成端点响应体 `message` 硬编码中文（`f"已提交 {len(grid_ids)} 个宫格生成任务"`），`grids.py` 未接 `Translator` 依赖，en/vi 用户提交宫格生成会收到中文文案。

## 修复
- `generate_grid` 端点新增 `_t: Translator` 依赖（参照 `server/routers/generate.py` 的 `storyboard_task_submitted` 范式）
- `lib/i18n/{zh,en,vi}/errors.py` 各新增 `grid_task_submitted`（带 `count` 参数，紧邻 `video_task_submitted`）
- 响应改为 `message=_t("grid_task_submitted", count=len(grid_ids))`
- 范围仅此一处；285 行 `error_message = None` 为内部赋值、非面向用户，未动

## 验证
- `pytest tests/test_grids_router.py tests/test_i18n_consistency.py` → 30 passed（含默认中文断言 + 新增 `Accept-Language: en` 本地化断言）
- `ruff check` / `ruff format --check` 干净
- `basedpyright server/routers/grids.py` 0 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 网格生成任务提交成功提示支持国际化。
  * 新增英语、越南语和简体中文提示文案，并动态显示已提交的任务数量。
  * 根据用户语言偏好返回对应的成功消息。

* **测试**
  * 增加默认中文和英语环境下的提示文案验证，确保本地化结果正确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->