### PR TITLE
chore(skills): pr-ai-review-loop 复盘三则修入 skill

### DIFF
--- a/.agents/skills/pr-ai-review-loop/references/reviewers.md
+++ b/.agents/skills/pr-ai-review-loop/references/reviewers.md
@@ -36,6 +36,8 @@
 - 本轮 inline 均为 `is_ack == true`
 - 本轮 inline 均为 nit 级(`cr_markers` 仅含 nit 级 token,无 actionable token)
 
+**outside diff range 意见**:CodeRabbit 对 diff 之外代码的建议内嵌在 review body(`coderabbit.reviews` 一行,source `coderabbit_review`)里,没有独立 inline comment id。索引只给出这条 review 的存在与 `is_new`、不含正文,`unacked coderabbitai[bot]` 兜底只扫 `inline_*_by_user`,同样看不见它——只靠 inline 口径会漏。发现靠 `query.sh <PR> history`(按 400 字 head 扫出该 review),全文用 `query.sh <PR> details <该 review 的 id>` 取;因无 inline 锚点,回复只能走 PR 顶层评论,不能回 inline。
+
 ## Gemini Code Assist
 
 **触发**(按 `pr_created_at` 与 `gemini.reviews` 判别,均受触发去重约束):
@@ -49,7 +51,7 @@
 **actionable**(两条路径,任一命中即算):
 
 - **inline 路径**:`inline_new_by_user["gemini-code-assist[bot]"]` 中 `severity_alt` 为 `high` / `medium` / `critical`;`low` / `nit` / `style` 不算
-- **summary 路径**:最新一条 `gemini.reviews` 的 `has_pass_marker == false`(通过标记词表见 poll.sh)
+- **summary 路径**:最新一条 `gemini.reviews` 的 `has_pass_marker == false`(通过判定见 poll.sh header——按 summary 的 "no feedback" 语法结构判,未命中即视为仍有 actionable)
 
 **通过**:前置条件——已审当前 HEAD(避免误用上一轮的通过标记)。前置之上需**同时**满足:
 
@@ -99,7 +101,7 @@ PR reaction 是当前审查状态:新 push 启动审查时,Codex 会把上一轮
 **退出门槛**(代替"通过",在准备宣布循环结束时核对):
 
 1. **分析完成且成功**:`codeql_checks.all_ok == true`(要求 total > 0 且无 pending、无 failing;失败态集合定义见 poll.sh header `checks_failing` 条,同名重跑已由 poll.sh 归一为每名最新一条)。`total == 0` 只说明分析未注册(继续等待)或仓库未接入(见下),不是通过;`failing` 非空时 alerts 数据停留在上次成功分析,直接核对门槛 2 会漏报新告警——归入故障类暂停。分析超过 25 分钟未完成同样归入故障类暂停
-2. **security 无遗留**:`security_alerts.open_introduced` 为空(poll.sh 已做 base 分支差集,排除存量告警)。`available == false` 时降级:把 `unavailable_hint` 贴给用户,说明无法核对 alerts API(权限或 merge ref 原因),请人工确认后再退出
+2. **security 无遗留**:`security_alerts.open_introduced` 为空(poll.sh 已做 base 分支差集,排除存量告警)。**勿采信 CodeQL check-run 标题里的 "N new alerts" 计数**——该数字按 merge-ref 全量统计,存量场景会把 main 上的旧告警一并计入,`N` 虚高会误导判定;口径一律以 `open_introduced`(已做 base 差集)为准。`available == false` 时降级:把 `unavailable_hint` 贴给用户,说明无法核对 alerts API(权限或 merge ref 原因),请人工确认后再退出
 3. **quality 无遗留**:终核时跑 `query.sh quality-all` 取 `github-code-quality[bot]` 的**全量** inline 评论(不限本轮)逐条核对——对应代码已修改,或已有 pushback 记录(PR 评论说明)。quality 没有可查的告警列表 API(实测 404),全量评论 + 代码现状就是完整事实,以本次查询结果为准而非对话记忆(压缩后无法重建)。常规 PR 该量级是个位数;若全量达数十条,向用户说明数量并商定抽查口径
 
 **仓库未接入 code scanning 的判定**:`codeql_checks.total` 全程为 0 + `security_alerts.available == false`(两端 alerts API 均不可用)+ PR 上从无两家 bot 评论 → 疑似未接入。跳过该门槛前必须先向用户确认一次——GitHub 对无权限的资源同样返回 404,权限不足(如 token 缺 `security_events` scope)会伪装成与未接入相同的三信号,静默跳过等于放行未核对的安全告警。判别辅助:读 `unavailable_hint`,含 403 / permission / "must be enabled"(Advanced Security 未开)字样 → 权限或配置问题,按故障类暂停处理;含 404 + "not enabled" / "no analysis found" → 未接入佐证。经用户确认跳过后,在退出汇报中注明"code scanning 未接入(经用户确认),该门槛未核对"

--- a/.agents/skills/pr-ai-review-loop/scripts/poll.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/poll.sh
@@ -102,9 +102,11 @@
 #                            verification    "_💡 Verification agent"  trivial   "_🔵 Trivial"
 #                            nitpick         "_🧹 Nitpick"             low_value "_💤 Low value"
 #   severity_alt           Gemini severity or Codex "Pn Badge" from the inline badge image alt text
-#   has_pass_marker        Gemini review summary carries an explicit pass marker: "LGTM" / "no issues found" /
-#                          "no feedback to provide" (any case) / word "approved" (any case), or body is empty
-#                          aside from the "## Code Review" heading (any case)
+#   has_pass_marker        Gemini review summary carries no actionable opinion: "LGTM" / "no issues found" /
+#                          a "no [adjective] feedback" clause (covers "no feedback to provide", "no additional
+#                          feedback", "no feedback is provided"; any case) / word "approved" (any case), or body
+#                          is empty aside from the "## Code Review" heading (any case). Gemini-only; an unmatched
+#                          summary is treated as still actionable (safe default — no silent pass).
 #   has_started            Codex has posted eyes on the PR or an @codex review trigger comment
 #   preview                first 120 chars of body after stripping HTML comments and markdown images, whitespace
 #                          collapsed — the eyeball safety net for flag misparses (flag vs preview conflict => fetch
@@ -376,10 +378,17 @@ jq -n \
     | map(select(.[1] as $pat | $h | contains($pat)) | .[0]);
 
   def has_pass_marker_body:
+    # A Gemini review summary is one paragraph: it either describes the feedback it gave, or
+    # states there is none. The "no feedback" clause is that pass signal, so match the grammar
+    # mechanically instead of enumerating exact phrasings — "\\bno(\\s+\\w+)?\\s+feedback\\b"
+    # tolerates an inserted adjective ("no additional feedback") and passive voice ("no
+    # feedback is provided"), both of which broke the old fixed-substring match. An unmatched
+    # summary stays actionable (has_pass_marker=false) — the safe default keeps the loop polling
+    # rather than declaring a silent pass. Gemini-only; other bots use their own pass paths.
     (. // "")
     | ((test("\\bLGTM\\b"))
        or (test("no issues found"; "i"))
-       or (test("no feedback to provide"; "i"))
+       or (test("\\bno(\\s+\\w+)?\\s+feedback\\b"; "i"))
        or (test("\\bapproved\\b"; "i"))
        or ((gsub("\\s+"; "") | ascii_downcase) as $bare | ($bare == "" or $bare == "##codereview")));
 

--- a/.agents/skills/pr-ai-review-loop/scripts/test_pass_marker.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_pass_marker.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# test_pass_marker.sh — regression test for poll.sh's has_pass_marker_body (Gemini review
+# summary pass detection).
+#
+# USAGE
+#   bash test_pass_marker.sh
+#
+# Extracts the `has_pass_marker_body` jq def verbatim out of poll.sh (so this test always
+# exercises the function actually shipped, not a copy that can drift) and runs it against
+# real Gemini review bodies captured from source PRs in testdata/:
+#   - gemini_pass_additional_feedback_pr1249.txt: "I have no additional feedback to provide."
+#     — an adjective sits between "no" and "feedback", which broke the old fixed-substring
+#     match ("no feedback to provide"). This is one of the two silent-stuck regressions the
+#     structural match guards against.
+#   - gemini_pass_passive_provided_pr1250.txt: "...so no feedback is provided on reviewer
+#     comments." — passive voice, also missed by the old substring. The other regression.
+#   - gemini_pass_plain_pr1252.txt: "I have no feedback to provide." — already passed under
+#     the old rule; proves the generalization doesn't regress the common phrasing.
+#   - gemini_actionable_pr1244.txt: a real body describing a concrete reviewer suggestion —
+#     the reverse case, must NOT be read as a pass.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POLL_SH="$SCRIPT_DIR/poll.sh"
+TESTDATA="$SCRIPT_DIR/testdata"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq not found on PATH" >&2
+  exit 3
+fi
+
+# Pull the def verbatim: from `def has_pass_marker_body:` through the first following line
+# that ends in a semicolon (the def's closing line). Comment lines inside the def carry no
+# trailing `;`, so they don't trip the exit early.
+PASS_DEF=$(awk '/^[[:space:]]*def has_pass_marker_body:/{flag=1} flag{print; if (/;[[:space:]]*$/) exit}' "$POLL_SH")
+if [[ -z "$PASS_DEF" ]]; then
+  echo "could not extract has_pass_marker_body def from $POLL_SH" >&2
+  exit 4
+fi
+
+# fixture : expect (true/false)
+CASES=(
+  "gemini_pass_additional_feedback_pr1249.txt:true"
+  "gemini_pass_passive_provided_pr1250.txt:true"
+  "gemini_pass_plain_pr1252.txt:true"
+  "gemini_actionable_pr1244.txt:false"
+)
+
+fail=0
+for tc in "${CASES[@]}"; do
+  IFS=":" read -r file expect <<<"$tc"
+  body_file="$TESTDATA/$file"
+  if [[ ! -f "$body_file" ]]; then
+    echo "FAIL $file: fixture missing at $body_file" >&2
+    fail=1
+    continue
+  fi
+
+  got=$(jq -n \
+    --rawfile body "$body_file" \
+    "
+    $PASS_DEF
+    (\$body | has_pass_marker_body)
+    ")
+
+  if [[ "$got" == "$expect" ]]; then
+    echo "PASS $file (has_pass_marker=$got)"
+  else
+    echo "FAIL $file: expected has_pass_marker=$expect, got=$got" >&2
+    fail=1
+  fi
+done
+
+exit "$fail"

--- a/.agents/skills/pr-ai-review-loop/scripts/testdata/gemini_actionable_pr1244.txt
+++ b/.agents/skills/pr-ai-review-loop/scripts/testdata/gemini_actionable_pr1244.txt
@@ -1,0 +1,7 @@
+## Code Review
+
+This pull request replaces the hardcoded fallback video durations with a single source of truth, `DEFAULT_FALLBACK`, imported from `lib.custom_provider.duration_presets` across the text generation SDK tools and adds corresponding unit tests. The reviewer suggested moving the `durations` parsing logic inside the `try-except` block in `_fetch_reference_caps_with_fallback` to prevent unhandled `ValueError` exceptions when processing invalid capability data, ensuring the fallback mechanism remains robust.
+
+> [!IMPORTANT]
+> The [consumer version of Gemini Code Assist on GitHub](https://developers.google.com/gemini-code-assist/docs/review-repo-code) is being sunset. Starting **June 18, 2026**, new organization installations will be blocked, and all code review activity will officially cease on **July 17, 2026**.
+> For more details on the timeline and next steps, please review the [Help Documentation](https://developers.google.com/gemini-code-assist/docs/deprecations/consumer-code-review).

--- a/.agents/skills/pr-ai-review-loop/scripts/testdata/gemini_pass_additional_feedback_pr1249.txt
+++ b/.agents/skills/pr-ai-review-loop/scripts/testdata/gemini_pass_additional_feedback_pr1249.txt
@@ -1,0 +1,7 @@
+## Code Review
+
+This pull request implements asynchronous race condition protection and atomic state updates in the assistant session management. Specifically, it updates `useAssistantSession` to check for stale requests (due to project switching or concurrent actions) before updating the store or establishing SSE connections. It also introduces `loadSessionSnapshot` in `useAssistantStore` to batch state updates atomically, preventing intermediate UI flashes. Comprehensive unit tests have been added to verify these race condition protections. I have no additional feedback to provide.
+
+> [!IMPORTANT]
+> The [consumer version of Gemini Code Assist on GitHub](https://developers.google.com/gemini-code-assist/docs/review-repo-code) is being sunset. Starting **June 18, 2026**, new organization installations will be blocked, and all code review activity will officially cease on **July 17, 2026**.
+> For more details on the timeline and next steps, please review the [Help Documentation](https://developers.google.com/gemini-code-assist/docs/deprecations/consumer-code-review).

--- a/.agents/skills/pr-ai-review-loop/scripts/testdata/gemini_pass_passive_provided_pr1250.txt
+++ b/.agents/skills/pr-ai-review-loop/scripts/testdata/gemini_pass_passive_provided_pr1250.txt
@@ -1,0 +1,7 @@
+## Code Review
+
+This pull request refactors and enhances the API's error handling by introducing domain-specific exceptions (such as ConflictError, ServiceUnavailableError, UnsupportedDiscoveryFormatError, EmptySourceError, SessionBusyError, and NoCompletedSegmentsError) to replace generic ValueErrors and HTTPExceptions. This allows the routing layer to map errors to precise HTTP status codes (e.g., 400, 409, 422, 503) and return localized error messages without leaking internal system paths. Additionally, deprecated code was cleaned up, and comprehensive unit tests were added to validate the new error propagation logic. There are no review comments to assess, so no feedback is provided on reviewer comments.
+
+> [!IMPORTANT]
+> The [consumer version of Gemini Code Assist on GitHub](https://developers.google.com/gemini-code-assist/docs/review-repo-code) is being sunset. Starting **June 18, 2026**, new organization installations will be blocked, and all code review activity will officially cease on **July 17, 2026**.
+> For more details on the timeline and next steps, please review the [Help Documentation](https://developers.google.com/gemini-code-assist/docs/deprecations/consumer-code-review).

--- a/.agents/skills/pr-ai-review-loop/scripts/testdata/gemini_pass_plain_pr1252.txt
+++ b/.agents/skills/pr-ai-review-loop/scripts/testdata/gemini_pass_plain_pr1252.txt
@@ -1,0 +1,7 @@
+## Code Review
+
+This pull request introduces a new translation key `overview_generation_failed` across English, Vietnamese, and Chinese locales, and updates the project router to return this generic error message instead of raw exception strings when overview generation fails. This prevents potential leaks of internal server paths. Additionally, a unit test has been added to verify that path leakage is prevented and the correct error message is returned. I have no feedback to provide.
+
+> [!IMPORTANT]
+> The [consumer version of Gemini Code Assist on GitHub](https://developers.google.com/gemini-code-assist/docs/review-repo-code) is being sunset. Starting **June 18, 2026**, new organization installations will be blocked, and all code review activity will officially cease on **July 17, 2026**.
+> For more details on the timeline and next steps, please review the [Help Documentation](https://developers.google.com/gemini-code-assist/docs/deprecations/consumer-code-review).


### PR DESCRIPTION
## 背景
pr-ai-review-loop 编排循环运行中暴露的三则实测经验复盘，固化进 skill（`.agents/skills/pr-ai-review-loop/`，非产品代码）。无 backing issue，工作边界为 afk 批次 batch-20260719 内联 brief。

## 改动
1. **Gemini 通过判定（poll.sh `has_pass_marker_body`）**：从固定子串 `"no feedback to provide"` 改为 Oniguruma 语法匹配 `\bno(\s+\w+)?\s+feedback\b`，容忍两种此前会漏判导致循环静默卡住的真实措辞——形容词插入（"no additional feedback"）与被动语态（"no feedback is provided"）。保留 LGTM / no issues found / approved / 空 body 既有分支。未命中即降级为 actionable（安全默认，绝不静默宣布通过）。仅影响 Gemini 口径，Codex/CodeRabbit 走各自路径互不干扰。
2. **reviewers.md — CodeRabbit outside-diff-range 意见**：补处理路径。此类建议内嵌在 review body（source `coderabbit_review`），无独立 inline id，`unacked` 兜底只扫 inline 看不见，靠 `query.sh history` 发现、`details` 取全文，回复只能走顶层评论。
3. **reviewers.md — CodeQL 退出门槛**：补「勿采信 check-run 标题 'N new alerts' 计数」——该数字按 merge-ref 全量统计会把 main 存量告警计入，一律以 `open_introduced`（已做 base 差集）为准。

## 测试
- 新增 `scripts/test_pass_marker.sh`：awk 逐行抽出 poll.sh 出厂的 `has_pass_marker_body` 原文跑，测的是真函数不是副本。
- 4 个真实 fixture（`scripts/testdata/`）：additional_feedback/passive_provided/plain → true，actionable → false（反向护栏）。
- `test_pass_marker.sh` 4/4 PASS、`test_quota_alerts.sh` 4/4 未回归、全部 5 个 `.sh` `bash -n` 干净。shellcheck 环境未安装，shell 质量门降级为 `bash -n`。

## 审查说明
本地审查重点评估了 item 1 正则的「误判为通过」面：`\bno(\s+\w+)?\s+feedback\b` 对合成的混合措辞（如 "no actionable feedback found but consider..."）确会误判为 pass，但风险判定为可接受——(a) 该判定仅覆盖 summary 路径，inline high/medium/critical 意见由独立路径捕获；(b) 实测语料中 Gemini 通过 body 均为句末独立 "no [X] feedback" 陈述、actionable body 均以肯定句描述建议且不含该子句，两者干净可分，混合措辞无观测样本；(c) 稳健修复需语义 actionable 动词表，违反容错层「不做语义映射」纪律，正则为机械语法匹配合规；(d) 安全默认（未命中→actionable）经验证保留。三则文档字段引用（`coderabbit_review`/`is_new`/`history` 400 字 head/`unacked` inline-only/`open_introduced`）均已对照 query.sh/poll.sh 核实为真。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 更新 AI 代码审查结果的判定规则，覆盖差异外反馈、摘要通过条件及安全告警统计口径。
  - 明确无法获取安全告警数据时的降级提示，并避免使用可能不准确的告警总数。

- **测试**
  - 新增 Gemini 代码审查结果判定的回归测试，覆盖多种“无反馈”和可操作反馈场景。
  - 强化未识别摘要时的安全默认行为，避免误判为审查通过。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->