### PR TITLE
fix(frontend): 助手切换项目或会话时旧请求即时中止，杜绝迟到响应误建 SSE 连接

### DIFF
--- a/.claude/rules/frontend-async-race.md
+++ b/.claude/rules/frontend-async-race.md
@@ -1,0 +1,27 @@
+---
+globs:
+  - "frontend/**"
+---
+
+# 前端异步竞态防护
+
+「await 后须检查过期」这条纪律不靠人肉复制闭包标志传播，按场景收敛到两种机制。
+
+## 跨函数边界的异步链取消：AbortSignal
+
+调用链跨出单个函数边界（effect 调用异步函数、异步函数内再发请求）时，取消一律用 AbortSignal 传播：
+
+- API 层方法接受 `options?: { signal?: AbortSignal }` 并透传给 `fetch`。网络 await 断点被 abort 后自动 reject，过期检查由平台原语代劳，不再每处手写
+- 非网络断点（写 store、建 SSE 连接等副作用）前复核 `signal.aborted`，拦截 abort 发生在响应已 resolve 之后的窗口
+- 接管方轮换 controller：新一轮加载先 `abort()` 前任再新建。取消域按数据生命周期划分，不共用——项目级数据（如会话列表、技能列表）只随项目切换作废，会话级加载随任何会话操作作废，二者混用会把慢响应的项目级数据误判过期丢弃
+- 被 abort 方的收尾（如 loading 复位）让位给接管方：`finally` 中先查 `signal.aborted`，已作废则不动共享状态，否则会踩到接管方正在进行的加载
+
+首例范式：`frontend/src/hooks/useAssistantSession.ts`（init 自动选择 + `loadSession` 加载链）。
+
+`cancelled` closure flag 是历史写法：只拦截所在函数自身的 await 断点，不传播到被调函数，不再新增；改动涉及处顺带迁移到 AbortSignal。
+
+## 跨入口共享的刷新：store action 在途合并
+
+同一份数据有多个入口触发刷新时，刷新逻辑收敛为单个 store action，在 action 内做在途合并（已有刷新在途则排队合并为「结束后再跑一轮」，各调用方分别结算），调用方不各自发请求。先例：`frontend/src/stores/projects-store.ts` 的 `refreshProject`。
+
+适用边界：这是「多入口写同一份数据」的互斥问题，与上节的「过期响应作废」互补——前者保证并发刷新不交错，后者保证已离开的上下文不回写。取消一份数据的加载用 AbortSignal；合并多入口对同一份数据的刷新用 store action。

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -441,11 +441,13 @@ describe("API", () => {
       expect(requestSpy).toHaveBeenCalledWith("/tasks/stats?project_name=demo");
       expect(requestSpy).toHaveBeenCalledWith(
         "/projects/demo/assistant/sessions?status=running",
+        { signal: undefined },
       );
       expect(requestSpy).toHaveBeenCalledWith(
         "/projects/demo/assistant/sessions/session-1/entries?after=5",
+        { signal: undefined },
       );
-      expect(requestSpy).toHaveBeenCalledWith("/projects/demo/assistant/skills");
+      expect(requestSpy).toHaveBeenCalledWith("/projects/demo/assistant/skills", { signal: undefined });
       expect(requestSpy).toHaveBeenCalledWith(
         "/usage/stats?project_name=demo&start_date=2026-01-01&end_date=2026-02-01",
       );

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1568,22 +1568,26 @@ class API {
 
   static async listAssistantSessions(
     projectName: string,
-    status: string | null = null
+    status: string | null = null,
+    options: { signal?: AbortSignal } = {}
   ): Promise<{ sessions: SessionMeta[] }> {
     const params = new URLSearchParams();
     if (status) params.append("status", status);
     const query = params.toString();
     return this.request(
-      `${this.assistantBase(projectName)}/sessions${query ? "?" + query : ""}`
+      `${this.assistantBase(projectName)}/sessions${query ? "?" + query : ""}`,
+      { signal: options.signal }
     );
   }
 
   static async getAssistantSession(
     projectName: string,
-    sessionId: string
+    sessionId: string,
+    options: { signal?: AbortSignal } = {}
   ): Promise<{ session: SessionMeta }> {
     return this.request(
-      `${this.assistantBase(projectName)}/sessions/${encodeURIComponent(sessionId)}`
+      `${this.assistantBase(projectName)}/sessions/${encodeURIComponent(sessionId)}`,
+      { signal: options.signal }
     );
   }
 
@@ -1591,11 +1595,13 @@ class API {
   static async listAssistantEntries(
     projectName: string,
     sessionId: string,
-    after: number = -1
+    after: number = -1,
+    options: { signal?: AbortSignal } = {}
   ): Promise<EntriesResponse> {
     const query = after >= 0 ? `?after=${after}` : "";
     return this.request(
-      `${this.assistantBase(projectName)}/sessions/${encodeURIComponent(sessionId)}/entries${query}`
+      `${this.assistantBase(projectName)}/sessions/${encodeURIComponent(sessionId)}/entries${query}`,
+      { signal: options.signal }
     );
   }
 
@@ -1656,10 +1662,12 @@ class API {
   }
 
   static async listAssistantSkills(
-    projectName: string
+    projectName: string,
+    options: { signal?: AbortSignal } = {}
   ): Promise<{ skills: SkillInfo[] }> {
     return this.request(
-      `${this.assistantBase(projectName)}/skills`
+      `${this.assistantBase(projectName)}/skills`,
+      { signal: options.signal }
     );
   }
 

--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -1179,4 +1179,70 @@ describe("useAssistantSession", () => {
     expect(useAssistantStore.getState().sessions.map((s) => s.id)).toEqual(["session-b1"]);
     expect(MockEventSource.instances).toHaveLength(0);
   });
+
+  it("does not let a delayed session-list response overwrite the new project's list after project switch", async () => {
+    // 项目 A 的 listAssistantSessions 挂起期间切到项目 B；A 的响应在 abort() 之后
+    // 才 resolve（fetch 不会因此 reject），此时不得把 A 的会话列表写入已切到 B 的
+    // store（写入前须复核 projectAbort.signal.aborted）。
+    const deferredA = createDeferred<{ sessions: SessionMeta[] }>();
+    vi.spyOn(API, "listAssistantSessions").mockImplementation((projectName) => {
+      if (projectName === "project-a") return deferredA.promise;
+      return Promise.resolve({ sessions: [makeSession("session-b1", "idle")] });
+    });
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (_projectName, sessionId) => ({
+      session: makeSession(sessionId, "idle"),
+    }));
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+
+    const { rerender } = renderHook(({ projectName }) => useAssistantSession(projectName), {
+      initialProps: { projectName: "project-a" as string | null },
+    });
+
+    // 切到项目 B：其会话列表正常落地
+    rerender({ projectName: "project-b" });
+    await waitFor(() => {
+      expect(useAssistantStore.getState().sessions.map((s) => s.id)).toEqual(["session-b1"]);
+    });
+
+    // 迟到：A 的会话列表此刻才返回，signal 已 abort，不得覆盖 B 的列表
+    await act(async () => {
+      deferredA.resolve({ sessions: [makeSession("session-a1", "idle")] });
+      await deferredA.promise;
+    });
+
+    expect(useAssistantStore.getState().sessions.map((s) => s.id)).toEqual(["session-b1"]);
+  });
+
+  it("does not let a delayed skills response overwrite the new project's skills after project switch", async () => {
+    // 同上，针对技能列表：A 的响应在离开 A 之后才 resolve，不得写入 B 的 skills。
+    const deferredA = createDeferred<{ skills: SkillInfo[] }>();
+    vi.spyOn(API, "listAssistantSkills").mockImplementation((projectName) => {
+      if (projectName === "project-a") return deferredA.promise;
+      return Promise.resolve({
+        skills: [{ name: "b-skill", description: "d", scope: "project", path: "/p" }],
+      });
+    });
+    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+      sessions: [makeSession("session-1", "idle")],
+    });
+    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "idle") });
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+
+    const { rerender } = renderHook(({ projectName }) => useAssistantSession(projectName), {
+      initialProps: { projectName: "project-a" as string | null },
+    });
+
+    rerender({ projectName: "project-b" });
+    await waitFor(() => {
+      expect(useAssistantStore.getState().skills.map((s) => s.name)).toEqual(["b-skill"]);
+    });
+
+    // 迟到：A 的技能列表此刻才返回，不得覆盖 B 的技能列表
+    await act(async () => {
+      deferredA.resolve({ skills: [{ name: "a-skill", description: "d", scope: "project", path: "/p" }] });
+      await deferredA.promise;
+    });
+
+    expect(useAssistantStore.getState().skills.map((s) => s.name)).toEqual(["b-skill"]);
+  });
 });

--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentFailureError, API } from "@/api";
 import { useAssistantStore } from "@/stores/assistant-store";
-import type { EntriesResponse, PendingQuestion, SessionMeta, TimelineEntry } from "@/types";
+import type { EntriesResponse, PendingQuestion, SessionMeta, SkillInfo, TimelineEntry } from "@/types";
 import { useAssistantSession } from "./useAssistantSession";
 
 class MockEventSource {
@@ -763,5 +763,420 @@ describe("useAssistantSession", () => {
     // 续传游标停在最后 seq（after=1），不因本 issue 的项目切换重置而回退到从头
     expect(MockEventSource.instances).toHaveLength(2);
     expect(MockEventSource.instances[1].url).toContain("after=1");
+  });
+
+  it("ignores a delayed loadSession response after switching projects (no SSE leak, no state write)", async () => {
+    // 项目 A 的 running 会话：loadSession 卡在 getAssistantSession；切到 B 后 A 的
+    // 迟到响应不得建 SSE 连接、不得回写任何 store 状态（否则为已离开的项目建立
+    // 无人消费的 SSE 订阅，服务端订阅者堆积泄漏）。
+    const deferredA = createDeferred<{ session: SessionMeta }>();
+    vi.spyOn(API, "listAssistantSessions").mockImplementation(async (projectName) => ({
+      sessions: [
+        makeSession(
+          projectName === "project-a" ? "session-a" : "session-b",
+          projectName === "project-a" ? "running" : "idle",
+        ),
+      ],
+    }));
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (projectName, sessionId) => {
+      if (projectName === "project-a") return deferredA.promise;
+      return { session: makeSession(sessionId, "idle") };
+    });
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(
+      makeEntriesResponse({ session_id: "session-b", entries: [userEntry(0, "B-0")] }),
+    );
+
+    const { rerender } = renderHook(({ projectName }) => useAssistantSession(projectName), {
+      initialProps: { projectName: "project-a" as string | null },
+    });
+
+    // 项目 A：loadSession 卡在 getAssistantSession（deferredA 未 resolve）
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-a");
+    });
+
+    // 切到项目 B（其 idle 会话冷读一条条目）
+    rerender({ projectName: "project-b" });
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-b");
+      expect(useAssistantStore.getState().turns).toHaveLength(1);
+    });
+
+    // 迟到：A 的 getAssistantSession 此刻才返回 running；signal 已被 cleanup abort，短路
+    await act(async () => {
+      deferredA.resolve({ session: makeSession("session-a", "running") });
+      await deferredA.promise;
+    });
+
+    // 不为已离开的项目 A 建 SSE 连接；状态与时间线保持项目 B
+    expect(MockEventSource.instances).toHaveLength(0);
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-b");
+    expect(useAssistantStore.getState().sessionStatus).toBe("idle");
+    expect(useAssistantStore.getState().turns).toHaveLength(1);
+    expect(useAssistantStore.getState().turns[0].content[0].text).toBe("B-0");
+  });
+
+  it("aborts the previous loadSession on rapid session switching (no interleaved writes)", async () => {
+    // 快速连续切会话：前一次切换的冷读挂起期间发起下一次切换，前任加载链被
+    // abort，迟到的 entries 不得覆盖新会话时间线。
+    const deferred2 = createDeferred<EntriesResponse>();
+    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+      sessions: [
+        makeSession("session-1", "idle"),
+        makeSession("session-2", "idle"),
+        makeSession("session-3", "idle"),
+      ],
+    });
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (_projectName, sessionId) => ({
+      session: makeSession(sessionId, "idle"),
+    }));
+    vi.spyOn(API, "listAssistantEntries").mockImplementation((_projectName, sessionId) => {
+      if (sessionId === "session-2") return deferred2.promise;
+      return Promise.resolve(makeEntriesResponse({
+        session_id: sessionId,
+        entries: sessionId === "session-3" ? [userEntry(0, "S3-0")] : [],
+      }));
+    });
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    // 切到 session-2：冷读挂起；随即切到 session-3：正常完成
+    act(() => {
+      void result.current.switchSession("session-2");
+    });
+    await act(async () => {
+      await result.current.switchSession("session-3");
+    });
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-3");
+    expect(useAssistantStore.getState().turns).toHaveLength(1);
+    expect(useAssistantStore.getState().messagesLoading).toBe(false);
+
+    // 迟到：session-2 的冷读此刻才返回，不得覆盖 session-3 的时间线
+    await act(async () => {
+      deferred2.resolve(makeEntriesResponse({ session_id: "session-2", entries: [userEntry(0, "S2-0")] }));
+      await deferred2.promise;
+    });
+
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-3");
+    expect(useAssistantStore.getState().turns).toHaveLength(1);
+    expect(useAssistantStore.getState().turns[0].content[0].text).toBe("S3-0");
+  });
+
+  it("does not let a delayed idle cold-read overwrite state set by a concurrent sendMessage", async () => {
+    // 冷读 listAssistantEntries 挂起期间，用户在同一会话内发送消息：sendMessage
+    // 受理后作废在途加载链。冷读迟到完成后携带的是发消息前的旧快照，不得据此
+    // 覆盖 running 状态与已追加的权威条目。
+    const deferredEntries = createDeferred<EntriesResponse>();
+    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+      sessions: [makeSession("session-1", "idle")],
+    });
+    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "idle") });
+    vi.spyOn(API, "listAssistantEntries").mockReturnValue(deferredEntries.promise);
+    vi.spyOn(API, "sendAssistantMessage").mockResolvedValue({
+      session_id: "session-1",
+      status: "accepted",
+      entry: userEntry(0, "hello"),
+    });
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    let accepted = false;
+    await act(async () => {
+      accepted = await result.current.sendMessage("hello");
+    });
+    expect(accepted).toBe(true);
+    expect(useAssistantStore.getState().sessionStatus).toBe("running");
+    expect(useAssistantStore.getState().messagesLoading).toBe(false);
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    await act(async () => {
+      deferredEntries.resolve(makeEntriesResponse({ entries: [] }));
+      await deferredEntries.promise;
+    });
+
+    // running 状态与已发送的条目保留，不被冷读前捕获的旧 idle 快照回退
+    expect(useAssistantStore.getState().sessionStatus).toBe("running");
+    expect(useAssistantStore.getState().entries.map((e) => e.seq)).toEqual([0]);
+  });
+
+  it("no-ops switchSession when projectName is null (stale session list with no project selected)", async () => {
+    // 面板为长生命周期单例，切项目为 null 后 sessions 列表不清空（见初始化
+    // effect 的前置 guard）；SessionSelector 据此仍可能渲染出旧项目的会话项。
+    // 点击它们不得以 null projectName 发起请求。
+    const getSessionSpy = vi.spyOn(API, "getAssistantSession");
+    const listEntriesSpy = vi.spyOn(API, "listAssistantEntries");
+    const listSessionsSpy = vi.spyOn(API, "listAssistantSessions");
+
+    act(() => {
+      useAssistantStore.getState().setSessions([makeSession("stale-session", "idle")]);
+    });
+
+    const { result } = renderHook(() => useAssistantSession(null));
+
+    await act(async () => {
+      await result.current.switchSession("stale-session");
+    });
+
+    expect(getSessionSpy).not.toHaveBeenCalled();
+    expect(listEntriesSpy).not.toHaveBeenCalled();
+    expect(listSessionsSpy).not.toHaveBeenCalled();
+    expect(useAssistantStore.getState().currentSessionId).toBeNull();
+  });
+
+  it("ignores a delayed switchSession response after leaving the project (currentSessionId unchanged, no SSE leak)", async () => {
+    // switchSession 同步把 currentSessionId 设为目标 sessionId，随后用户离开项目
+    // （projectName -> null，不重置 currentSessionId）。effect cleanup abort 加载链，
+    // 迟到响应短路，不用旧闭包的 projectName 为已离开的项目建 SSE 连接。
+    const deferredSwitch = createDeferred<{ session: SessionMeta }>();
+    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+      sessions: [makeSession("session-1", "idle")],
+    });
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (_projectName, sessionId) => {
+      if (sessionId === "session-2") return deferredSwitch.promise;
+      return { session: makeSession(sessionId, "idle") };
+    });
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+
+    const { result, rerender } = renderHook(({ projectName }) => useAssistantSession(projectName), {
+      initialProps: { projectName: "project-a" as string | null },
+    });
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    await act(async () => {
+      void result.current.switchSession("session-2");
+    });
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-2");
+    expect(useAssistantStore.getState().sessionStatus).toBe("idle");
+
+    // 离开项目：projectName 置空，currentSessionId 不受影响，仍是 "session-2"
+    rerender({ projectName: null });
+
+    // 迟到：switchSession 发起的 getAssistantSession 此刻才返回 running
+    await act(async () => {
+      deferredSwitch.resolve({ session: makeSession("session-2", "running") });
+      await deferredSwitch.promise;
+    });
+
+    expect(MockEventSource.instances).toHaveLength(0);
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-2");
+    expect(useAssistantStore.getState().sessionStatus).toBe("idle");
+  });
+
+  it("ignores a delayed init auto-selection after createNewSession", async () => {
+    // init 的 listAssistantSessions 挂起期间用户新建会话：迟到响应不得把
+    // currentSessionId 覆盖回旧会话并为其重建 SSE 连接。
+    const deferredSessions = createDeferred<{ sessions: SessionMeta[] }>();
+    vi.spyOn(API, "listAssistantSessions").mockReturnValue(deferredSessions.promise);
+    const getSessionSpy = vi
+      .spyOn(API, "getAssistantSession")
+      .mockResolvedValue({ session: makeSession("session-1", "running") });
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    await act(async () => {
+      result.current.createNewSession();
+    });
+    expect(useAssistantStore.getState().currentSessionId).toBeNull();
+    expect(useAssistantStore.getState().isDraftSession).toBe(true);
+    expect(useAssistantStore.getState().messagesLoading).toBe(false);
+
+    // 迟到：init 的会话列表此刻才返回，携带一个 running 会话
+    await act(async () => {
+      deferredSessions.resolve({ sessions: [makeSession("session-1", "running")] });
+      await deferredSessions.promise;
+    });
+
+    // 列表（项目级数据）照常落地；自动选择让位于用户操作，不重建 SSE
+    expect(useAssistantStore.getState().sessions.map((s) => s.id)).toEqual(["session-1"]);
+    expect(useAssistantStore.getState().currentSessionId).toBeNull();
+    expect(useAssistantStore.getState().isDraftSession).toBe(true);
+    expect(getSessionSpy).not.toHaveBeenCalled();
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it("ignores a delayed init auto-selection after switchSession", async () => {
+    // 同上，换成挂起期间用户直接切到另一会话（如通过历史记录/深链接跳转）。
+    const deferredSessions = createDeferred<{ sessions: SessionMeta[] }>();
+    vi.spyOn(API, "listAssistantSessions").mockReturnValue(deferredSessions.promise);
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (_projectName, sessionId) => ({
+      session: makeSession(sessionId, "idle"),
+    }));
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    await act(async () => {
+      await result.current.switchSession("session-2");
+    });
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-2");
+
+    // 迟到：init 的会话列表此刻才返回，携带一个 running 会话
+    await act(async () => {
+      deferredSessions.resolve({ sessions: [makeSession("session-1", "running")] });
+      await deferredSessions.promise;
+    });
+
+    // 不覆盖用户已切到的会话，不为已放弃的会话建 SSE 连接
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-2");
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it("ignores a delayed init auto-selection after deleteSession clears the current session", async () => {
+    // 同上，换成挂起期间用户删除当前会话且无其它会话可切（清空到无会话）。
+    const deferredSessions = createDeferred<{ sessions: SessionMeta[] }>();
+    vi.spyOn(API, "listAssistantSessions").mockReturnValue(deferredSessions.promise);
+    vi.spyOn(API, "getAssistantSession").mockResolvedValue({ session: makeSession("session-1", "running") });
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+    vi.spyOn(API, "deleteAssistantSession").mockResolvedValue({ success: true });
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    // 模拟用户此前已选中会话（挂起期间 store 中已有当前会话可删）
+    act(() => {
+      useAssistantStore.getState().setCurrentSessionId("session-1");
+      useAssistantStore.getState().setSessions([makeSession("session-1", "idle")]);
+    });
+
+    await act(async () => {
+      await result.current.deleteSession("session-1");
+    });
+    expect(useAssistantStore.getState().currentSessionId).toBeNull();
+    expect(useAssistantStore.getState().messagesLoading).toBe(false);
+
+    // 迟到：init 的会话列表此刻才返回，携带一个 running 会话
+    await act(async () => {
+      deferredSessions.resolve({ sessions: [makeSession("session-1", "running")] });
+      await deferredSessions.promise;
+    });
+
+    // 不覆盖用户的删除操作，不为已删除的会话建 SSE 连接
+    expect(useAssistantStore.getState().currentSessionId).toBeNull();
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it("ignores a delayed init auto-selection after sendMessage creates a session from draft", async () => {
+    // init 的 listAssistantSessions 挂起期间用户从草稿直接发送首条消息建会话：
+    // 迟到的初始化响应不得把 currentSessionId 覆盖回列表里的旧会话。
+    const deferredSessions = createDeferred<{ sessions: SessionMeta[] }>();
+    vi.spyOn(API, "listAssistantSessions").mockReturnValue(deferredSessions.promise);
+    const getSessionSpy = vi
+      .spyOn(API, "getAssistantSession")
+      .mockResolvedValue({ session: makeSession("session-1", "running") });
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+    vi.spyOn(API, "sendAssistantMessage").mockResolvedValue({
+      session_id: "session-new",
+      status: "accepted",
+      entry: userEntry(0, "hello"),
+    });
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    let accepted = false;
+    await act(async () => {
+      accepted = await result.current.sendMessage("hello");
+    });
+    expect(accepted).toBe(true);
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-new");
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    // 迟到：init 的会话列表此刻才返回
+    await act(async () => {
+      deferredSessions.resolve({ sessions: [makeSession("session-1", "running")] });
+      await deferredSessions.promise;
+    });
+
+    // 不覆盖发送建立的新会话，不为列表里的旧会话另建 SSE 连接
+    expect(useAssistantStore.getState().currentSessionId).toBe("session-new");
+    expect(getSessionSpy).not.toHaveBeenCalled();
+    expect(MockEventSource.instances).toHaveLength(1);
+  });
+
+  it("keeps a slow skills response after a session operation (skills are project-level data)", async () => {
+    // 技能列表是项目级数据：挂起期间的会话操作不作废它，慢响应照常落地，
+    // 否则 / 技能命令在该项目内持续不可用直到重进项目。
+    const deferredSkills = createDeferred<{ skills: SkillInfo[] }>();
+    vi.spyOn(API, "listAssistantSkills").mockReturnValue(deferredSkills.promise);
+    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+      sessions: [makeSession("session-1", "idle")],
+    });
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (_projectName, sessionId) => ({
+      session: makeSession(sessionId, "idle"),
+    }));
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    // 技能响应挂起期间发生会话操作
+    await act(async () => {
+      await result.current.switchSession("session-2");
+    });
+
+    await act(async () => {
+      deferredSkills.resolve({
+        skills: [{ name: "demo-skill", description: "d", scope: "project", path: "/p" }],
+      });
+      await deferredSkills.promise;
+    });
+
+    expect(useAssistantStore.getState().skills.map((s) => s.name)).toEqual(["demo-skill"]);
+  });
+
+  it("keeps the new project's session list when a stale session click races the init", async () => {
+    // 项目切换后 B 的 listAssistantSessions 未返回前，面板仍渲染 A 的残留会话
+    // 列表；点击陈旧项触发 switchSession（请求以 404 静默失败），不得作废 B 的
+    // 会话列表落地——列表是项目级数据，走独立于会话加载链的取消域。
+    const deferredB = createDeferred<{ sessions: SessionMeta[] }>();
+    vi.spyOn(API, "listAssistantSessions").mockImplementation((projectName) => {
+      if (projectName === "project-b") return deferredB.promise;
+      return Promise.resolve({
+        sessions: [makeSession("session-a1", "idle"), makeSession("session-a2", "idle")],
+      });
+    });
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (projectName, sessionId) => {
+      if (projectName === "project-b" && sessionId === "session-a2") {
+        throw new Error("会话不存在");
+      }
+      return { session: makeSession(sessionId, "idle") };
+    });
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+
+    const { result, rerender } = renderHook(({ projectName }) => useAssistantSession(projectName), {
+      initialProps: { projectName: "project-a" as string | null },
+    });
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-a1");
+    });
+
+    // 切到项目 B：其会话列表挂起；点击残留的 A 会话项（在 B 上 404 静默失败）
+    rerender({ projectName: "project-b" });
+    await act(async () => {
+      await result.current.switchSession("session-a2");
+    });
+
+    await act(async () => {
+      deferredB.resolve({ sessions: [makeSession("session-b1", "idle")] });
+      await deferredB.promise;
+    });
+
+    // B 的会话列表照常落地，供用户重新选择；不为任何会话建 SSE 连接
+    expect(useAssistantStore.getState().sessions.map((s) => s.id)).toEqual(["session-b1"]);
+    expect(MockEventSource.instances).toHaveLength(0);
   });
 });

--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -1245,4 +1245,95 @@ describe("useAssistantSession", () => {
 
     expect(useAssistantStore.getState().skills.map((s) => s.name)).toEqual(["b-skill"]);
   });
+
+  it("does not let a delayed turn-end session-list refresh overwrite the new project's list after project switch", async () => {
+    // 项目 A 的 running 会话终态触发 listAssistantSessions 刷新（获取 SDK summary
+    // 标题）；响应挂起期间切到项目 B，A 的迟到响应不得覆盖 B 的会话列表——终态
+    // 刷新纳入项目级取消域，与 init/switchSession 的写入同口径。
+    const deferredRefresh = createDeferred<{ sessions: SessionMeta[] }>();
+    let projectACalls = 0;
+    vi.spyOn(API, "listAssistantSessions").mockImplementation((projectName) => {
+      if (projectName === "project-a") {
+        projectACalls += 1;
+        if (projectACalls === 1) {
+          return Promise.resolve({ sessions: [makeSession("session-a", "running")] });
+        }
+        return deferredRefresh.promise;
+      }
+      return Promise.resolve({ sessions: [makeSession("session-b1", "idle")] });
+    });
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (projectName, sessionId) => ({
+      session: makeSession(sessionId, projectName === "project-a" ? "running" : "idle"),
+    }));
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+
+    const { rerender } = renderHook(({ projectName }) => useAssistantSession(projectName), {
+      initialProps: { projectName: "project-a" as string | null },
+    });
+
+    await waitFor(() => {
+      expect(MockEventSource.instances).toHaveLength(1);
+    });
+
+    // running 会话终态：触发刷新，挂起在 deferredRefresh
+    act(() => {
+      MockEventSource.instances[0].emit("status", { status: "completed" });
+    });
+
+    // 切到项目 B：其会话列表正常落地
+    rerender({ projectName: "project-b" });
+    await waitFor(() => {
+      expect(useAssistantStore.getState().sessions.map((s) => s.id)).toEqual(["session-b1"]);
+    });
+
+    // 迟到：A 的终态刷新此刻才返回，signal 已 abort，不得覆盖 B 的列表
+    await act(async () => {
+      deferredRefresh.resolve({ sessions: [makeSession("session-a-refreshed", "idle")] });
+      await deferredRefresh.promise;
+    });
+
+    expect(useAssistantStore.getState().sessions.map((s) => s.id)).toEqual(["session-b1"]);
+  });
+
+  it("resets stuck loading when leaving the project while a load is in flight (no successor to take over)", async () => {
+    // switchSession 的 loadSession 挂起期间离开项目（projectName 变为 null）：
+    // cleanup abort 了 loadSignal，但没有新项目的 init 接管收尾——effect 需在
+    // 离开分支显式复位 messagesLoading，否则永久卡在 true。
+    const deferredEntry = createDeferred<{ session: SessionMeta }>();
+    vi.spyOn(API, "listAssistantSessions").mockResolvedValue({
+      sessions: [makeSession("session-1", "idle"), makeSession("session-2", "idle")],
+    });
+    vi.spyOn(API, "getAssistantSession").mockImplementation(async (_projectName, sessionId) => {
+      if (sessionId === "session-2") return deferredEntry.promise;
+      return { session: makeSession(sessionId, "idle") };
+    });
+    vi.spyOn(API, "listAssistantEntries").mockResolvedValue(makeEntriesResponse({ entries: [] }));
+
+    const { result, rerender } = renderHook(({ projectName }) => useAssistantSession(projectName), {
+      initialProps: { projectName: "demo" as string | null },
+    });
+
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    act(() => {
+      void result.current.switchSession("session-2");
+    });
+    await waitFor(() => {
+      expect(useAssistantStore.getState().messagesLoading).toBe(true);
+    });
+
+    // 离开项目：switchSession 的加载链被 abort，但没有后续加载链接管
+    rerender({ projectName: null });
+
+    expect(useAssistantStore.getState().messagesLoading).toBe(false);
+
+    // 迟到的 getAssistantSession 不再产生任何写入（signal 已 abort）
+    await act(async () => {
+      deferredEntry.resolve({ session: makeSession("session-2", "idle") });
+      await deferredEntry.promise;
+    });
+    expect(useAssistantStore.getState().messagesLoading).toBe(false);
+  });
 });

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -100,6 +100,9 @@ export function useAssistantSession(projectName: string | null) {
   // controller。任何接管会话选择权的入口（切会话/新建/删除/发送建会话/项目切换）
   // 先作废在途链，迟到响应经 signal 短路，不写 store、不建 SSE 连接。
   const loadAbortRef = useRef<AbortController | null>(null);
+  // 项目级取消域的当前 controller：跨 useCallback 边界（connectStream 的终态刷新）
+  // 复用同一 signal，随项目切换/卸载 abort。
+  const projectAbortRef = useRef<AbortController | null>(null);
 
   const abortSessionLoad = useCallback(() => {
     loadAbortRef.current?.abort();
@@ -193,12 +196,17 @@ export function useAssistantSession(projectName: string | null) {
           }
           closeStream();
 
-          // Turn 结束后刷新会话列表，获取 SDK summary 标题
+          // Turn 结束后刷新会话列表，获取 SDK summary 标题；纳入项目级取消域，
+          // 挂起期间切换项目时迟到响应不得覆盖已切到的新项目会话列表
           if (projectName) {
-            API.listAssistantSessions(projectName).then((res) => {
-              const fresh = res.sessions ?? [];
-              if (fresh.length > 0) store.getState().setSessions(fresh);
-            }).catch(() => {/* 静默失败 */});
+            const signal = projectAbortRef.current?.signal;
+            if (signal) {
+              API.listAssistantSessions(projectName, null, { signal }).then((res) => {
+                if (signal.aborted) return;
+                const fresh = res.sessions ?? [];
+                if (fresh.length > 0) store.getState().setSessions(fresh);
+              }).catch(() => {/* 静默失败 */});
+            }
           }
         }
       });
@@ -261,11 +269,17 @@ export function useAssistantSession(projectName: string | null) {
 
   // 加载会话
   useEffect(() => {
-    if (!projectName) return;
+    if (!projectName) {
+      // 离开项目：上一个 projectName 的 cleanup 已 abort 在途加载链，但没有
+      // 后续加载链接管收尾——显式清掉可能遗留的 loading，避免卡死为 true
+      store.getState().setMessagesLoading(false);
+      return;
+    }
     // 项目级取消域：只随项目切换/卸载 abort。会话列表与技能列表是项目级数据，
     // 挂起期间的会话操作（新建/切换/删除）不应作废它们——否则慢响应下技能列表
     // 会被误判过期丢弃、新项目的会话列表被陈旧会话点击作废且无重试。
     const projectAbort = new AbortController();
+    projectAbortRef.current = projectAbort;
 
     async function init() {
       // 会话自动选择占据加载链：后续任何用户会话操作接管选择权时作废
@@ -320,6 +334,7 @@ export function useAssistantSession(projectName: string | null) {
 
     return () => {
       projectAbort.abort();
+      if (projectAbortRef.current === projectAbort) projectAbortRef.current = null;
       abortSessionLoad();
       invalidatePendingSend();
       closeStream();

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -96,6 +96,23 @@ export function useAssistantSession(projectName: string | null) {
     store.getState().setSending(false);
   }, [store]);
 
+  // 会话加载链取消域：init 的会话自动选择与 loadSession（冷读/建流）共用一个
+  // controller。任何接管会话选择权的入口（切会话/新建/删除/发送建会话/项目切换）
+  // 先作废在途链，迟到响应经 signal 短路，不写 store、不建 SSE 连接。
+  const loadAbortRef = useRef<AbortController | null>(null);
+
+  const abortSessionLoad = useCallback(() => {
+    loadAbortRef.current?.abort();
+    loadAbortRef.current = null;
+  }, []);
+
+  const beginSessionLoad = useCallback(() => {
+    abortSessionLoad();
+    const controller = new AbortController();
+    loadAbortRef.current = controller;
+    return controller.signal;
+  }, [abortSessionLoad]);
+
   // 关闭流
   const closeStream = useCallback(() => {
     if (reconnectRef.current) {
@@ -216,9 +233,13 @@ export function useAssistantSession(projectName: string | null) {
     [clearPendingQuestion, projectName, closeStream, store, syncPendingQuestion],
   );
 
-  // 加载指定会话时间线：非 running 冷读日志；running 交给 entry 流回放
-  const loadSession = useCallback(async (sessionId: string) => {
-    const res = await API.getAssistantSession(projectName!, sessionId);
+  // 加载指定会话时间线：非 running 冷读日志；running 交给 entry 流回放。
+  // signal 被 abort 时网络 await 断点由 fetch 自动 reject；写 store 与建流前
+  // 复核 aborted，拦截「abort 发生在响应已 resolve 之后」的窗口。
+  const loadSession = useCallback(async (sessionId: string, options: { signal: AbortSignal }) => {
+    const { signal } = options;
+    const res = await API.getAssistantSession(projectName!, sessionId, { signal });
+    if (signal.aborted) return;
     const raw = res as Record<string, unknown>;
     const sessionObj = (raw.session ?? raw) as Record<string, unknown>;
     const status = (sessionObj.status as string) ?? "idle";
@@ -231,8 +252,8 @@ export function useAssistantSession(projectName: string | null) {
     if (status === "running") {
       connectStream(sessionId);
     } else {
-      const data = await API.listAssistantEntries(projectName!, sessionId);
-      if (store.getState().currentSessionId !== sessionId) return;
+      const data = await API.listAssistantEntries(projectName!, sessionId, -1, { signal });
+      if (signal.aborted) return;
       store.getState().setEntries(data.entries ?? []);
       store.getState().setDraftSnapshot(data.draft ?? null, data.draft_rev ?? 0);
     }
@@ -241,9 +262,14 @@ export function useAssistantSession(projectName: string | null) {
   // 加载会话
   useEffect(() => {
     if (!projectName) return;
-    let cancelled = false;
+    // 项目级取消域：只随项目切换/卸载 abort。会话列表与技能列表是项目级数据，
+    // 挂起期间的会话操作（新建/切换/删除）不应作废它们——否则慢响应下技能列表
+    // 会被误判过期丢弃、新项目的会话列表被陈旧会话点击作废且无重试。
+    const projectAbort = new AbortController();
 
     async function init() {
+      // 会话自动选择占据加载链：后续任何用户会话操作接管选择权时作废
+      const loadSignal = beginSessionLoad();
       store.getState().setMessagesLoading(true);
       // 切项目先重置时间线（与新建/切换/删除三条会话路径同口径），使有会话/
       // 无会话两个分支都从干净状态出发：running 会话的 SSE 冷订阅游标由重置后
@@ -251,11 +277,11 @@ export function useAssistantSession(projectName: string | null) {
       // 把旧项目条目混排进新会话时间线。
       store.getState().resetTimeline();
       try {
-        // 获取会话列表
-        const res = await API.listAssistantSessions(projectName!);
-        if (cancelled) return;
+        // 获取会话列表（项目级数据：即便自动选择已被用户操作作废，列表照常落地）
+        const res = await API.listAssistantSessions(projectName!, null, { signal: projectAbort.signal });
         const sessions = res.sessions ?? [];
         store.getState().setSessions(sessions);
+        if (loadSignal.aborted) return;
 
         // 优先使用上次选择的会话（如果仍存在于列表中）
         const lastId = getLastSessionId(projectName!);
@@ -268,33 +294,38 @@ export function useAssistantSession(projectName: string | null) {
           store.getState().setMessagesLoading(false);
           return;
         }
-        if (cancelled) return;
 
         store.getState().setCurrentSessionId(sessionId);
-        await loadSession(sessionId);
+        await loadSession(sessionId, { signal: loadSignal });
       } catch {
-        // 静默失败
+        // 静默失败（含被 abort 中止的请求）
       } finally {
-        if (!cancelled) store.getState().setMessagesLoading(false);
+        // 被作废时 loading 归接管方管理（switchSession 自开自收、
+        // createNewSession / deleteSession / sendMessage 显式复位），
+        // 此处复位会踩到接管方正在进行的加载
+        if (!loadSignal.aborted) store.getState().setMessagesLoading(false);
       }
     }
 
     // 加载技能列表
-    API.listAssistantSkills(projectName)
+    API.listAssistantSkills(projectName, { signal: projectAbort.signal })
       .then((res) => {
-        if (!cancelled) store.getState().setSkills(res.skills ?? []);
+        store.getState().setSkills(res.skills ?? []);
       })
       .catch(() => {});
 
     voidCall(init());
 
     return () => {
-      cancelled = true;
+      projectAbort.abort();
+      abortSessionLoad();
       invalidatePendingSend();
       closeStream();
     };
   }, [
     projectName,
+    abortSessionLoad,
+    beginSessionLoad,
     clearPendingQuestion,
     closeStream,
     invalidatePendingSend,
@@ -343,6 +374,11 @@ export function useAssistantSession(projectName: string | null) {
 
         if (pendingSendVersionRef.current !== sendVersion) return false;
         failedSendRef.current = null;
+        // 发送已受理：用户以发送行为接管会话选择权与时间线，作废在途加载链
+        // （init 自动选择不再覆盖 currentSessionId，挂起的冷读不再覆写时间线），
+        // 并复位其遗留的 loading
+        abortSessionLoad();
+        store.getState().setMessagesLoading(false);
 
         const returnedSessionId = result.session_id;
 
@@ -388,7 +424,8 @@ export function useAssistantSession(projectName: string | null) {
         return true;
       } catch (err) {
         if (pendingSendVersionRef.current !== sendVersion) return false;
-        // 失败：无本地合成消息可回滚，仅记录幂等键供重试复用
+        // 失败：无本地合成消息可回滚，仅记录幂等键供重试复用；
+        // 在途加载链未被作废，挂起的冷读继续正常落地
         failedSendRef.current = { clientKey, signature };
         if (err instanceof AgentFailureError) {
           store.getState().setStartupFailure(err.failure);
@@ -399,7 +436,7 @@ export function useAssistantSession(projectName: string | null) {
         return false;
       }
     },
-    [projectName, connectStream, store],
+    [projectName, abortSessionLoad, connectStream, store],
   );
 
   const answerQuestion = useCallback(
@@ -440,6 +477,7 @@ export function useAssistantSession(projectName: string | null) {
   const createNewSession = useCallback(() => {
     if (!projectName) return;
 
+    abortSessionLoad();
     invalidatePendingSend();
     closeStream();
     store.getState().resetTimeline();
@@ -447,13 +485,19 @@ export function useAssistantSession(projectName: string | null) {
     clearPendingQuestion();
     store.getState().setCurrentSessionId(null);
     store.getState().setIsDraftSession(true);
+    // 草稿会话无加载过程，复位被作废加载链遗留的 loading
+    store.getState().setMessagesLoading(false);
     statusRef.current = "idle";
-  }, [projectName, clearPendingQuestion, closeStream, invalidatePendingSend, store]);
+  }, [projectName, abortSessionLoad, clearPendingQuestion, closeStream, invalidatePendingSend, store]);
 
   // 切换到指定会话
   const switchSession = useCallback(async (sessionId: string) => {
+    // 面板为长生命周期单例：切项目为 null 后 sessions 列表不清空，仍可能渲染出
+    // 旧项目的会话项，点击不得以 null projectName 发起请求
+    if (!projectName) return;
     if (store.getState().currentSessionId === sessionId) return;
 
+    const signal = beginSessionLoad();
     invalidatePendingSend();
     closeStream();
     store.getState().setCurrentSessionId(sessionId);
@@ -463,16 +507,17 @@ export function useAssistantSession(projectName: string | null) {
     store.getState().setMessagesLoading(true);
 
     // 记住选择
-    if (projectName) saveLastSessionId(projectName, sessionId);
+    saveLastSessionId(projectName, sessionId);
 
     try {
-      await loadSession(sessionId);
+      await loadSession(sessionId, { signal });
     } catch {
-      // 静默失败
+      // 静默失败（含被后续切换 abort）
     } finally {
-      store.getState().setMessagesLoading(false);
+      // 被作废时 loading 归接管方管理，此处复位会踩到其正在进行的加载
+      if (!signal.aborted) store.getState().setMessagesLoading(false);
     }
-  }, [projectName, clearPendingQuestion, closeStream, invalidatePendingSend, loadSession, store]);
+  }, [projectName, beginSessionLoad, clearPendingQuestion, closeStream, invalidatePendingSend, loadSession, store]);
 
   // 删除会话
   const deleteSession = useCallback(async (sessionId: string) => {
@@ -487,19 +532,22 @@ export function useAssistantSession(projectName: string | null) {
         if (sessions.length > 0) {
           await switchSession(sessions[0].id);
         } else {
+          abortSessionLoad();
           invalidatePendingSend();
           closeStream();
           store.getState().setCurrentSessionId(null);
           store.getState().resetTimeline();
           store.getState().setSessionStatus(null);
           clearPendingQuestion();
+          // 清空到无会话后无加载过程，复位被作废加载链遗留的 loading
+          store.getState().setMessagesLoading(false);
           statusRef.current = "idle";
         }
       }
     } catch {
       // 静默失败
     }
-  }, [projectName, clearPendingQuestion, closeStream, invalidatePendingSend, switchSession, store]);
+  }, [projectName, abortSessionLoad, clearPendingQuestion, closeStream, invalidatePendingSend, switchSession, store]);
 
   return { sendMessage, answerQuestion, interrupt, createNewSession, switchSession, deleteSession };
 }

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -279,6 +279,7 @@ export function useAssistantSession(projectName: string | null) {
       try {
         // 获取会话列表（项目级数据：即便自动选择已被用户操作作废，列表照常落地）
         const res = await API.listAssistantSessions(projectName!, null, { signal: projectAbort.signal });
+        if (projectAbort.signal.aborted) return;
         const sessions = res.sessions ?? [];
         store.getState().setSessions(sessions);
         if (loadSignal.aborted) return;
@@ -310,6 +311,7 @@ export function useAssistantSession(projectName: string | null) {
     // 加载技能列表
     API.listAssistantSkills(projectName, { signal: projectAbort.signal })
       .then((res) => {
+        if (projectAbort.signal.aborted) return;
         store.getState().setSkills(res.skills ?? []);
       })
       .catch(() => {});


### PR DESCRIPTION
Closes #1245

## 背景

`useAssistantSession` 的 `loadSession` 内部异步请求不感知取消：外层 `init()` effect 的 `cancelled` 闭包标志只拦截 effect 自身的 await 断点，`loadSession` 拿到旧项目迟到响应后仍会 `connectStream`，为已离开的项目建立无人消费的 SSE 连接（服务端订阅者堆积），并把旧项目会话状态写入全局 store。快速切换项目即可触发。

## 方案（issue #1245 拍板：AbortSignal 全链路）

- **API 层**：`getAssistantSession` / `listAssistantEntries` / `listAssistantSessions` / `listAssistantSkills` 增加 `options?: { signal }` 并透传 `fetch`，网络 await 断点被 abort 后自动 reject。
- **双取消域按数据生命周期二分**：项目级 `projectAbort`（会话列表 + 技能列表，仅随项目切换/卸载作废）与会话级 `loadAbortRef`（init 自动选择与 `loadSession` 共用，任何会话操作轮换/作废）。避免慢响应下项目级数据被会话操作误判过期丢弃。
- **接管方轮换 controller**：`beginSessionLoad()` 先 abort 前任再新建，被 switch/create/delete/send/init 统一复用，结构性消除 `switchSession` 与 init 判据不一致。
- **非网络副作用前复核** `signal.aborted`（写 store、建 SSE 连接），拦截 abort 发生在响应已 resolve 之后的窗口。
- **loading 归属**：被 abort 方 `finally` 查 `aborted` 后让位，由接管方管理复位。
- 删除全部 `cancelled` 闭包标志与手工 `currentSessionId` 比对，收敛到 signal 单判据。
- 附带：`switchSession` 补 `projectName` 判空守卫；新增 `.claude/rules/frontend-async-race.md` 固化前端异步竞态防护约定。

## 验证

- `cd frontend && pnpm lint && pnpm check` 全绿（typecheck + eslint + vitest 1038 用例通过）。
- 新增 vitest 用例锁定 4 个验收场景：迟到 `loadSession` 响应不建 SSE / 不写 store、快速切会话不交错写、发送消息接管在途加载、null projectName 守卫。
- PR #1152 的 3 例回归测试保留未回退（冷订阅 URL 不带 after、切换后时间线不含旧项目条目、同会话重连续传游标）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 助手会话相关接口支持可选取消信号；切换/离开等场景会自动中止不再需要的异步请求，减少过期数据回写。
* **Bug Fixes**
  * 修复会话冷读、自动会话选择与时间线更新的竞态问题：迟到响应不再覆盖当前会话/项目状态，并避免 SSE 连接泄漏与 loading 卡死。
* **测试**
  * 新增并扩展竞态取消、迟到不回写、离开项目不污染、技能与会话刷新一致性等用例。
* **文档**
  * 补充前端异步竞态防护规则说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->