### PR TITLE
fix(providers): Declare MiniMax M3 vision capability

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -1084,7 +1084,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "MiniMax-M3": ModelInfo(
                 display_name="MiniMax M3",
                 media_type="text",
-                capabilities=["text_generation", "structured_output"],
+                capabilities=["text_generation", "structured_output", "vision"],
                 default=True,
                 pricing=_minimax_text_pricing("MiniMax-M3", 2.1, 8.4),
             ),

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -38,6 +38,7 @@ class TestRegistry:
         assert meta.default_base_url == "https://api.minimaxi.com/v1"
         assert "MiniMax-M3" in meta.models
         assert meta.models["MiniMax-M3"].default is True
+        assert "vision" in meta.models["MiniMax-M3"].capabilities
         assert "MiniMax-M2.7" in meta.models
         assert meta.models["MiniMax-M2.7"].default is False
         # image-01：默认图像模型，T2I + I2I，单脸参考


### PR DESCRIPTION
Reason: Declare the existing image-input support for MiniMax M3 in the model registry.

This adds the `vision` capability to the MiniMax M3 model metadata and extends the provider integration test to prevent regressions. The existing generic text backend already builds image message parts; this change makes model selection recognize that supported path.

Checks:
- `uv run pytest tests/test_minimax_integration.py tests/test_config_registry_models.py -q`
- `uv run ruff check lib/config/registry.py tests/test_minimax_integration.py`
- `uv run ruff format --check lib/config/registry.py tests/test_minimax_integration.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * MiniMax-M3 现支持视觉能力，可用于相关图像理解功能及智能路由场景。

* **测试**
  * 增加了对 MiniMax-M3 视觉能力支持的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->