### PR TITLE
fix(routers): 项目列表不再回传服务器内部路径，资源不存在响应统一收口

### DIFF
--- a/server/routers/_asset_router_factory.py
+++ b/server/routers/_asset_router_factory.py
@@ -20,6 +20,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict
 
+from lib.api_errors import NotFoundError
 from lib.asset_types import ASSET_SPECS, validate_asset_name
 from lib.i18n import Translator
 from lib.project_change_hints import project_change_source
@@ -123,8 +124,8 @@ def build_asset_router(
                 return {"success": True, result_key: data[spec.bucket_key][name]}
 
             return await asyncio.to_thread(_sync)
-        except FileNotFoundError:
-            raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+        except FileNotFoundError as exc:
+            raise NotFoundError("project_not_found", name=project_name) from exc
         except HTTPException:
             raise
         except Exception:
@@ -174,8 +175,8 @@ def build_asset_router(
             return await asyncio.to_thread(_sync)
         except KeyError:
             raise HTTPException(status_code=404, detail=_t(keys["not_found"], name=entry_name))
-        except FileNotFoundError:
-            raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+        except FileNotFoundError as exc:
+            raise NotFoundError("project_not_found", name=project_name) from exc
         except HTTPException:
             raise
         except Exception:
@@ -202,8 +203,8 @@ def build_asset_router(
             return await asyncio.to_thread(_sync)
         except KeyError:
             raise HTTPException(status_code=404, detail=_t(keys["not_found"], name=entry_name))
-        except FileNotFoundError:
-            raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+        except FileNotFoundError as exc:
+            raise NotFoundError("project_not_found", name=project_name) from exc
         except HTTPException:
             raise
         except Exception:

--- a/server/routers/agent_chat.py
+++ b/server/routers/agent_chat.py
@@ -10,7 +10,7 @@ import logging
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from lib.api_errors import BadRequestError, ConflictError, ServiceUnavailableError
+from lib.api_errors import BadRequestError, ConflictError, NotFoundError, ServiceUnavailableError
 from lib.i18n import Translator, get_locale
 from server.agent_runtime.models import Heartbeat, LiveMessage
 from server.agent_runtime.result_status import resolve_result_status
@@ -168,8 +168,8 @@ async def agent_chat(
     # 验证项目是否存在
     try:
         service.pm.get_project_path(body.project_name)
-    except (FileNotFoundError, KeyError):
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=body.project_name))
+    except (FileNotFoundError, KeyError) as exc:
+        raise NotFoundError("project_not_found", name=body.project_name) from exc
 
     # 若传入 session_id，先校验会话归属
     if body.session_id:

--- a/server/routers/assets.py
+++ b/server/routers/assets.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 
+from lib.api_errors import NotFoundError
 from lib.asset_types import BUCKET_KEY, GLOBAL_LIBRARY_ASSET_TYPES, SHEET_KEY, validate_asset_name
 from lib.db import async_session_factory
 from lib.db.repositories.asset_repo import AssetRepository
@@ -255,11 +256,8 @@ async def from_project(
     # 2) 加载项目
     try:
         project = get_project_manager().load_project(req.project_name)
-    except FileNotFoundError:
-        raise HTTPException(
-            status_code=404,
-            detail=_t("asset_target_project_not_found", project=req.project_name),
-        )
+    except FileNotFoundError as exc:
+        raise NotFoundError("asset_target_project_not_found", project=req.project_name) from exc
     except Exception:
         logger.exception("Failed to load project '%s' for from-project", req.project_name)
         raise HTTPException(status_code=500, detail=_t("asset_load_project_failed"))
@@ -390,11 +388,8 @@ async def apply_to_project(
     project_manager = get_project_manager()
     try:
         project = project_manager.load_project(req.target_project)
-    except FileNotFoundError:
-        raise HTTPException(
-            status_code=404,
-            detail=_t("asset_target_project_not_found", project=req.target_project),
-        )
+    except FileNotFoundError as exc:
+        raise NotFoundError("asset_target_project_not_found", project=req.target_project) from exc
 
     succeeded: list[dict] = []
     skipped: list[dict] = []

--- a/server/routers/assistant.py
+++ b/server/routers/assistant.py
@@ -13,7 +13,7 @@ from fastapi.sse import EventSourceResponse, ServerSentEvent
 from pydantic import BaseModel, Field
 
 from lib import PROJECT_ROOT
-from lib.api_errors import BadRequestError, ConflictError, ServiceUnavailableError
+from lib.api_errors import BadRequestError, ConflictError, NotFoundError, ServiceUnavailableError
 from lib.i18n import Translator, get_locale
 from server.agent_runtime.failure_observation import build_startup_failure_observation
 from server.agent_runtime.models import SessionMeta
@@ -108,8 +108,8 @@ async def send_message(
         return result
     except SessionCapacityError as exc:
         raise ServiceUnavailableError("session_capacity_exceeded") from exc
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("session_or_project_not_found"))
+    except FileNotFoundError as exc:
+        raise NotFoundError("session_or_project_not_found") from exc
     except TimeoutError:
         raise HTTPException(status_code=504, detail=_t("sdk_session_timeout"))
     except SessionBusyError as exc:
@@ -215,8 +215,8 @@ async def list_entries(
         return await service.list_session_entries(session_id, meta=meta, after_seq=after)
     except HTTPException:
         raise
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("session_not_found", session_id=session_id))
+    except FileNotFoundError as exc:
+        raise NotFoundError("session_not_found", session_id=session_id) from exc
     except Exception:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=_t("internal_server_error"))
@@ -273,8 +273,8 @@ async def interrupt_session(project_name: str, session_id: str, _user: CurrentUs
         return result
     except HTTPException:
         raise
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("session_not_found", session_id=session_id))
+    except FileNotFoundError as exc:
+        raise NotFoundError("session_not_found", session_id=session_id) from exc
     except ValueError as exc:
         logger.warning("会话中断请求非法: %s", exc)
         raise BadRequestError("request_invalid") from exc
@@ -306,8 +306,8 @@ async def answer_question(
         return result
     except HTTPException:
         raise
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("session_not_found", session_id=session_id))
+    except FileNotFoundError as exc:
+        raise NotFoundError("session_not_found", session_id=session_id) from exc
     except ValueError as exc:
         # 会话未运行或无待回答问题
         logger.warning("会话回答请求非法: %s", exc)
@@ -330,8 +330,8 @@ async def list_skills(project_name: str, _user: CurrentUser, _t: Translator):
     try:
         skills = get_assistant_service().list_available_skills(project_name=project_name)
         return {"skills": skills}
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
     except HTTPException:
         raise
     except Exception:

--- a/server/routers/cost_estimation.py
+++ b/server/routers/cost_estimation.py
@@ -7,6 +7,7 @@ import logging
 
 from fastapi import APIRouter, HTTPException
 
+from lib.api_errors import NotFoundError
 from lib.config.resolver import ConfigResolver
 from lib.db import async_session_factory
 from lib.i18n import Translator
@@ -29,8 +30,8 @@ async def get_cost_estimate(project_name: str, _user: CurrentUser, _t: Translato
 
         try:
             project_data = pm.load_project(project_name)
-        except FileNotFoundError:
-            raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+        except FileNotFoundError as exc:
+            raise NotFoundError("project_not_found", name=project_name) from exc
 
         # 加载所有剧本
         scripts: dict[str, dict] = {}

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 from fastapi import APIRouter, Body, File, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, PlainTextResponse
 
+from lib.api_errors import NotFoundError
 from lib.asset_types import GLOBAL_LIBRARY_ASSET_TYPES
 from lib.config.resolver import VisionCapabilityError
 from lib.episode_paths import (
@@ -92,8 +93,8 @@ async def serve_project_file(project_name: str, path: str, request: Request, _t:
             headers["Cache-Control"] = "public, max-age=31536000, immutable"
 
         return FileResponse(file_path, headers=headers)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
 
 
 @router.get("/global-assets/{asset_type}/{filename}")
@@ -342,8 +343,8 @@ async def upload_file(
 
         return await asyncio.to_thread(_sync)
 
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
     except HTTPException:
         raise
     except Exception:
@@ -363,8 +364,8 @@ async def _handle_source_upload(
 
     try:
         project_dir = get_project_manager().get_project_path(project_name)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
 
     source_dir = project_dir / "source"
     source_dir.mkdir(parents=True, exist_ok=True)
@@ -494,8 +495,8 @@ async def list_project_files(project_name: str, _user: CurrentUser, _t: Translat
 
         return await asyncio.to_thread(_sync)
 
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
     except HTTPException:
         raise
     except Exception:
@@ -525,8 +526,8 @@ async def get_source_file(project_name: str, filename: str, _user: CurrentUser, 
         content = await asyncio.to_thread(_sync)
         return PlainTextResponse(content)
 
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
     except UnicodeDecodeError:
         raise HTTPException(status_code=400, detail=_t("invalid_encoding"))
     except HTTPException:
@@ -563,8 +564,8 @@ async def update_source_file(
 
         return await asyncio.to_thread(_sync)
 
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
     except HTTPException:
         raise
     except Exception:
@@ -601,8 +602,8 @@ async def delete_source_file(project_name: str, filename: str, _user: CurrentUse
 
         return await asyncio.to_thread(_sync)
 
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
     except HTTPException:
         raise
     except Exception:
@@ -706,8 +707,8 @@ async def get_draft_content(project_name: str, episode: int, step_num: int, _use
         content = await asyncio.to_thread(_sync)
         return PlainTextResponse(content)
 
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
 
 
 @router.put("/projects/{project_name}/drafts/{episode}/step{step_num}")
@@ -786,8 +787,8 @@ async def update_draft_content(
 
         return await asyncio.to_thread(_sync)
 
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
 
 
 @router.delete("/projects/{project_name}/drafts/{episode}/step{step_num}")
@@ -814,8 +815,8 @@ async def delete_draft(project_name: str, episode: int, step_num: int, _user: Cu
 
         return await asyncio.to_thread(_sync)
 
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
 
 
 # ==================== 风格参考图管理 ====================
@@ -894,8 +895,8 @@ async def upload_style_image(project_name: str, _user: CurrentUser, _t: Translat
             "url": f"/api/v1/files/{project_name}/{style_filename}",
         }
 
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
     except HTTPException:
         raise
     except VisionCapabilityError as e:

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -29,7 +29,7 @@ from starlette.background import BackgroundTask
 
 logger = logging.getLogger(__name__)
 
-from lib.api_errors import ApiError, BadRequestError
+from lib.api_errors import ApiError, BadRequestError, NotFoundError
 from lib.asset_fingerprints import compute_asset_fingerprints
 from lib.config.resolver import ConfigResolver
 from lib.db import async_session_factory
@@ -284,8 +284,8 @@ async def export_project_archive(
             filename=download_name,
             background=BackgroundTask(_cleanup_temp_file, str(archive_path)),
         )
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=name) from exc
     except HTTPException:
         raise
     except Exception:
@@ -443,9 +443,7 @@ async def list_projects(_user: CurrentUser):
             except Exception as e:
                 # 出错时返回基本信息
                 logger.warning("加载项目 '%s' 元数据失败: %s", name, e)
-                projects.append(
-                    {"name": name, "title": "", "style": "", "thumbnail": None, "status": {}, "error": str(e)}
-                )
+                projects.append({"name": name, "title": "", "style": "", "thumbnail": None, "status": {}})
 
         return {"projects": projects}
 
@@ -575,7 +573,7 @@ async def get_video_capabilities(
     try:
         return await resolver.video_capabilities(name)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=name)) from exc
+        raise NotFoundError("project_not_found", name=name) from exc
     except ValueError as exc:
         raise HTTPException(
             status_code=422,
@@ -631,8 +629,8 @@ async def get_project(
             }
 
         return await asyncio.to_thread(_sync)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=name) from exc
     except HTTPException:
         raise
     except Exception:
@@ -806,8 +804,8 @@ async def update_project(name: str, req: UpdateProjectRequest, _user: CurrentUse
                 return {"success": True, "project": manager.update_project(name, _mutate)}
 
         return await asyncio.to_thread(_sync)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=name) from exc
     except HTTPException:
         raise
     except Exception:
@@ -825,8 +823,8 @@ async def delete_project(name: str, _user: CurrentUser, _t: Translator):
             return {"success": True, "message": _t("project_deleted", name=name)}
 
         return await asyncio.to_thread(_sync)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=name) from exc
     except HTTPException:
         raise
     except Exception:
@@ -840,8 +838,8 @@ async def get_script(name: str, script_file: str, _user: CurrentUser, _t: Transl
     try:
         script = await asyncio.to_thread(get_project_manager().load_script, name, script_file)
         return {"script": script}
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("script_not_found", name=script_file))
+    except FileNotFoundError as exc:
+        raise NotFoundError("script_not_found", name=script_file) from exc
     except HTTPException:
         raise
     except Exception:
@@ -897,8 +895,8 @@ async def update_scene(name: str, scene_id: str, req: UpdateSceneRequest, _user:
             return {"success": True, "scene": matched_scene}
 
         return await asyncio.to_thread(_sync)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("script_not_found", name=req.script_file))
+    except FileNotFoundError as exc:
+        raise NotFoundError("script_not_found", name=req.script_file) from exc
     except ValueError as exc:
         # 结构校验失败、集号错配、非法文件名都抛 ValueError（ScriptStructureValidationError
         # 即其子类）：统一转 422 客户端错误，避免落到下面的 500 兜底。
@@ -992,8 +990,8 @@ async def update_shot(name: str, shot_id: str, req: UpdateShotRequest, _user: Cu
             return {"success": True, "shot": matched_shot}
 
         return await asyncio.to_thread(_sync)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("script_not_found", name=req.script_file))
+    except FileNotFoundError as exc:
+        raise NotFoundError("script_not_found", name=req.script_file) from exc
     except ValueError as exc:
         # 结构校验失败、集号错配、非法文件名都抛 ValueError（ScriptStructureValidationError
         # 即其子类）：统一转 422 客户端错误，避免落到下面的 500 兜底。
@@ -1042,8 +1040,8 @@ async def reorder_shots(name: str, req: ReorderShotsRequest, _user: CurrentUser,
             return {"success": True, "shots": reordered}
 
         return await asyncio.to_thread(_sync)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("script_not_found", name=req.script_file))
+    except FileNotFoundError as exc:
+        raise NotFoundError("script_not_found", name=req.script_file) from exc
     except ValueError as exc:
         raise HTTPException(
             status_code=422,
@@ -1122,8 +1120,8 @@ async def update_segment(name: str, segment_id: str, req: UpdateSegmentRequest, 
             return {"success": True, "segment": matched_segment}
 
         return await asyncio.to_thread(_sync)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("script_not_found", name=req.script_file))
+    except FileNotFoundError as exc:
+        raise NotFoundError("script_not_found", name=req.script_file) from exc
     except ValueError as exc:
         # 结构校验失败、集号错配、非法文件名都抛 ValueError（ScriptStructureValidationError
         # 即其子类）：统一转 422 客户端错误，避免落到下面的 500 兜底。
@@ -1169,9 +1167,9 @@ async def update_episode(name: str, episode: int, req: UpdateEpisodeRequest, _us
                         script["title"] = title
                 except FileNotFoundError as exc:
                     if not manager.project_exists(name):
-                        raise HTTPException(status_code=404, detail=_t("project_not_found", name=name)) from exc
+                        raise NotFoundError("project_not_found", name=name) from exc
                     # project.json 指向的脚本文件已删除/移动（stale 绑定）
-                    raise HTTPException(status_code=404, detail=_t("ref_script_missing")) from exc
+                    raise NotFoundError("ref_script_missing") from exc
                 except EpisodeScriptReboundError as exc:
                     logger.info("episode script rebound during title update: %s", exc)
                     raise HTTPException(status_code=409, detail=_t("ref_script_rebound")) from exc
@@ -1187,8 +1185,8 @@ async def update_episode(name: str, episode: int, req: UpdateEpisodeRequest, _us
         return await asyncio.to_thread(_sync)
     except HTTPException:
         raise
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=name) from exc
     except Exception:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=_t("internal_server_error"))
@@ -1306,8 +1304,8 @@ async def generate_overview(name: str, _user: CurrentUser, _t: Translator):
         # 非法项目名（路径穿越等）先于生成流程拦截，避免落入下面 generate_overview()
         # 内部供应商解析链路的 except ValueError，被误判为「未配置供应商」
         raise BadRequestError("invalid_project_name", name=name) from e
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=name) from exc
     except (HTTPException, ApiError):
         raise
     except Exception:
@@ -1317,8 +1315,8 @@ async def generate_overview(name: str, _user: CurrentUser, _t: Translator):
         with project_change_source("webui"):
             overview = await get_project_manager().generate_overview(name)
         return {"success": True, "overview": overview}
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=name) from exc
     except PydanticValidationError:
         # 模型输出未通过 schema 校验（后端降级仍失守时的最后防线），
         # 裸 pydantic 错误串含模型原始输出片段，不透传给用户
@@ -1371,8 +1369,8 @@ async def update_overview(name: str, req: UpdateOverviewRequest, _user: CurrentU
             return {"success": True, "overview": captured["overview"]}
 
         return await asyncio.to_thread(_sync)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=name) from exc
     except HTTPException:
         raise
     except Exception:

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -1183,7 +1183,9 @@ async def update_episode(name: str, episode: int, req: UpdateEpisodeRequest, _us
             return {"success": True, "episode": {"episode": episode, "title": title}}
 
         return await asyncio.to_thread(_sync)
-    except HTTPException:
+    except (HTTPException, ApiError):
+        # ApiError 与 HTTPException 并列：_sync 内部抛出的 NotFoundError 不是
+        # HTTPException 子类，不并入这里会被下面的 except Exception 吞成 500
         raise
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=name) from exc

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -15,6 +15,7 @@ from typing import Any
 from fastapi import APIRouter, File, HTTPException, Response, UploadFile, status
 from pydantic import BaseModel, Field
 
+from lib.api_errors import NotFoundError
 from lib.asset_types import BUCKET_KEY
 from lib.generation_queue import get_generation_queue
 from lib.generation_queue_client import TaskSpec, TaskSpecValidationError
@@ -73,7 +74,7 @@ def _load_episode_script(project_name: str, episode: int, _t: Translator) -> tup
     try:
         project = get_project_manager().load_project(project_name)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name)) from exc
+        raise NotFoundError("project_not_found", name=project_name) from exc
     episodes = project.get("episodes") or []
     meta = next((e for e in episodes if e.get("episode") == episode), None)
     if meta is None or not meta.get("script_file"):
@@ -82,7 +83,7 @@ def _load_episode_script(project_name: str, episode: int, _t: Translator) -> tup
     try:
         script = get_project_manager().load_script(project_name, script_file)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=_t("script_not_found", name=script_file)) from exc
+        raise NotFoundError("script_not_found", name=script_file) from exc
     if effective_mode(project=project, episode=meta) != "reference_video":
         raise HTTPException(status_code=409, detail=_t("ref_not_reference_video_mode"))
     return project, script, script_file
@@ -136,8 +137,8 @@ def _locked_episode_script(project_name: str, resolver: Callable[[dict], str], _
     except FileNotFoundError as exc:
         # 区分「项目缺失」与「project.json 指向的脚本文件缺失（stale 绑定）」
         if not get_project_manager().project_exists(project_name):
-            raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name)) from exc
-        raise HTTPException(status_code=404, detail=_t("ref_script_missing")) from exc
+            raise NotFoundError("project_not_found", name=project_name) from exc
+        raise NotFoundError("ref_script_missing") from exc
     except EpisodeScriptReboundError as exc:
         logger.info("episode script rebound during write: %s", exc)
         raise HTTPException(status_code=409, detail=_t("ref_script_rebound")) from exc
@@ -535,7 +536,7 @@ async def upload_unit_video(
         raise HTTPException(status_code=exc.status_code, detail=_t(exc.key, **exc.params)) from exc
     except FileNotFoundError as exc:
         # 不回传 str(exc)：load_script 的异常信息含服务器绝对路径
-        raise HTTPException(status_code=404, detail=_t("ref_script_missing")) from exc
+        raise NotFoundError("ref_script_missing") from exc
     except KeyError as exc:
         # finalize 写回时 unit 已被并发删除（落盘后绑定重查到锁内写回之间的窄竞态）
         raise HTTPException(status_code=404, detail=_t("ref_unit_not_found", unit_id=unit_id)) from exc

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -15,7 +15,7 @@ from typing import Any
 from fastapi import APIRouter, File, HTTPException, Response, UploadFile, status
 from pydantic import BaseModel, Field
 
-from lib.api_errors import NotFoundError
+from lib.api_errors import ApiError, NotFoundError
 from lib.asset_types import BUCKET_KEY
 from lib.generation_queue import get_generation_queue
 from lib.generation_queue_client import TaskSpec, TaskSpecValidationError
@@ -542,7 +542,9 @@ async def upload_unit_video(
         raise HTTPException(status_code=404, detail=_t("ref_unit_not_found", unit_id=unit_id)) from exc
     except ScriptEditError as exc:
         raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=str(exc))) from exc
-    except HTTPException:
+    except (HTTPException, ApiError):
+        # ApiError 与 HTTPException 并列：_load_episode_script 抛出的 NotFoundError
+        # 不是 HTTPException 子类，不并入这里会被下面的 except Exception 吞成 500
         raise
     except Exception as exc:
         # 不回传 str(exc)：未预期异常的消息可能含服务器路径等内部细节，堆栈进日志即可

--- a/server/routers/script_review.py
+++ b/server/routers/script_review.py
@@ -10,6 +10,7 @@ import logging
 
 from fastapi import APIRouter, Body, HTTPException
 
+from lib.api_errors import NotFoundError
 from lib.i18n import Translator
 from lib.project_manager import get_project_manager
 from server.auth import CurrentUser
@@ -52,8 +53,8 @@ async def get_script_review(project_name: str, episode: int, _user: CurrentUser,
         return await asyncio.to_thread(service.get_state, project_name, episode)
     except ScriptReviewError as exc:
         _raise_review_error(exc, episode, _t)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
 
 
 @router.put("/projects/{project_name}/episodes/{episode}/script-review/content")
@@ -70,8 +71,8 @@ async def update_script_review_content(
         return await asyncio.to_thread(service.save_content, project_name, episode, content)
     except ScriptReviewError as exc:
         _raise_review_error(exc, episode, _t)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc
 
 
 @router.post("/projects/{project_name}/episodes/{episode}/script-review/confirm")
@@ -82,5 +83,5 @@ async def confirm_script_review(project_name: str, episode: int, _user: CurrentU
         return await asyncio.to_thread(service.confirm, project_name, episode)
     except ScriptReviewError as exc:
         _raise_review_error(exc, episode, _t)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=_t("project_not_found", name=project_name))
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=project_name) from exc

--- a/server/routers/shot_uploads.py
+++ b/server/routers/shot_uploads.py
@@ -16,6 +16,7 @@ from typing import Literal
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
 
+from lib.api_errors import NotFoundError
 from lib.i18n import Translator
 from lib.image_utils import normalize_storyboard_upload
 from lib.path_safety import PathTraversalError, safe_join
@@ -139,9 +140,9 @@ async def upload_shot_media(
 
     except UploadValidationError as e:
         raise HTTPException(status_code=e.status_code, detail=_t(e.key, **e.params))
-    except FileNotFoundError:
-        # 不回传 str(e)：load_script 的异常信息含服务器绝对路径
-        raise HTTPException(status_code=404, detail=_t("script_not_found", name=script_file))
+    except FileNotFoundError as exc:
+        # 不回传 str(exc)：load_script 的异常信息含服务器绝对路径
+        raise NotFoundError("script_not_found", name=script_file) from exc
     except KeyError:
         raise HTTPException(status_code=404, detail=_t("segment_not_found", id=shot_id))
     except ScriptEditError as e:

--- a/tests/server/test_reference_videos_router.py
+++ b/tests/server/test_reference_videos_router.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 
 
 @pytest.fixture
@@ -59,6 +60,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setattr(router_mod, "get_project_manager", lambda: custom_pm)
 
     app = FastAPI()
+    register_error_handlers(app)
     app.include_router(router_mod.router, prefix="/api/v1")
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="u1", sub="test", role="admin")
     return TestClient(app)

--- a/tests/server/test_reference_videos_router_ad.py
+++ b/tests/server/test_reference_videos_router_ad.py
@@ -15,6 +15,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 
 
 def _shot(shot_id: str, duration: int, **overrides) -> dict:
@@ -97,6 +98,7 @@ def ad_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setattr(router_mod, "get_generation_queue", lambda: fake_queue)
 
     app = FastAPI()
+    register_error_handlers(app)
     app.include_router(router_mod.router, prefix="/api/v1")
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="u1", sub="test", role="admin")
     client = TestClient(app)

--- a/tests/test_asset_router_factory.py
+++ b/tests/test_asset_router_factory.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 from server.routers import characters
 from tests.conftest import make_translator
 
@@ -47,6 +48,7 @@ def _client(monkeypatch):
     fake_pm = _FakePM()
     monkeypatch.setattr(characters, "get_project_manager", lambda: fake_pm)
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(characters.router, prefix="/api/v1")
     return TestClient(app), fake_pm
@@ -161,6 +163,7 @@ class TestAssetRouterNoLeak:
             lambda: (_ for _ in ()).throw(RuntimeError("LEAK_add")),
         )
         app = FastAPI()
+        register_error_handlers(app)
         app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
         app.include_router(characters.router, prefix="/api/v1")
         with TestClient(app) as client:
@@ -176,6 +179,7 @@ class TestAssetRouterNoLeak:
             lambda: (_ for _ in ()).throw(RuntimeError("LEAK_update")),
         )
         app = FastAPI()
+        register_error_handlers(app)
         app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
         app.include_router(characters.router, prefix="/api/v1")
         with TestClient(app) as client:
@@ -191,6 +195,7 @@ class TestAssetRouterNoLeak:
             lambda: (_ for _ in ()).throw(RuntimeError("LEAK_delete")),
         )
         app = FastAPI()
+        register_error_handlers(app)
         app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
         app.include_router(characters.router, prefix="/api/v1")
         with TestClient(app) as client:

--- a/tests/test_asset_router_factory.py
+++ b/tests/test_asset_router_factory.py
@@ -163,7 +163,6 @@ class TestAssetRouterNoLeak:
             lambda: (_ for _ in ()).throw(RuntimeError("LEAK_add")),
         )
         app = FastAPI()
-        register_error_handlers(app)
         app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
         app.include_router(characters.router, prefix="/api/v1")
         with TestClient(app) as client:
@@ -179,7 +178,6 @@ class TestAssetRouterNoLeak:
             lambda: (_ for _ in ()).throw(RuntimeError("LEAK_update")),
         )
         app = FastAPI()
-        register_error_handlers(app)
         app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
         app.include_router(characters.router, prefix="/api/v1")
         with TestClient(app) as client:
@@ -195,7 +193,6 @@ class TestAssetRouterNoLeak:
             lambda: (_ for _ in ()).throw(RuntimeError("LEAK_delete")),
         )
         app = FastAPI()
-        register_error_handlers(app)
         app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
         app.include_router(characters.router, prefix="/api/v1")
         with TestClient(app) as client:

--- a/tests/test_assets_router.py
+++ b/tests/test_assets_router.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from lib.db.base import Base
 from lib.project_manager import ProjectManager
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 from server.routers import assets
 
 
@@ -29,6 +30,7 @@ async def _assets_env(tmp_path, monkeypatch):
     monkeypatch.setattr(assets, "get_project_manager", lambda: pm)
 
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(assets.router, prefix="/api/v1")
 

--- a/tests/test_assistant_routes.py
+++ b/tests/test_assistant_routes.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 
 from lib.i18n import get_translator
 from server.auth import CurrentUserInfo, get_current_user, get_current_user_flexible
+from server.error_handlers import register_error_handlers
 from server.routers import assistant
 from tests.conftest import make_translator
 from tests.factories import make_session_meta
@@ -29,6 +30,7 @@ def _override_translator():
 
 def _build_client() -> TestClient:
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: _FAKE_USER
     app.dependency_overrides[get_current_user_flexible] = lambda: _FAKE_USER
     app.dependency_overrides[get_translator] = _override_translator

--- a/tests/test_characters_router.py
+++ b/tests/test_characters_router.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 from server.routers import characters
 
 
@@ -46,6 +47,7 @@ class _FakePM:
 def _client(monkeypatch, fake_pm):
     monkeypatch.setattr(characters, "get_project_manager", lambda: fake_pm)
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(characters.router, prefix="/api/v1")
     return TestClient(app)

--- a/tests/test_cost_estimation_router.py
+++ b/tests/test_cost_estimation_router.py
@@ -6,11 +6,13 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 from server.routers import cost_estimation
 
 
 def _make_app():
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(cost_estimation.router, prefix="/api/v1")
     return app
@@ -63,6 +65,7 @@ class TestCostEstimationRouter:
 
     def test_no_auth_returns_401(self):
         app = FastAPI()
+        register_error_handlers(app)
         # Do NOT override the auth dependency — real auth should reject
         app.include_router(cost_estimation.router, prefix="/api/v1")
         with TestClient(app, raise_server_exceptions=False) as client:

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -7,6 +7,7 @@ from PIL import Image
 
 from lib.project_manager import ProjectManager
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 from server.routers import files
 
 
@@ -52,6 +53,7 @@ def _client(monkeypatch, tmp_path):
     monkeypatch.setattr("lib.text_generator.create_text_backend_for_task", _fake_create_backend)
 
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(files.router, prefix="/api/v1")
     return TestClient(app), pm
@@ -835,6 +837,7 @@ def _client_with_pm_raising(monkeypatch, sentinel: str):
     monkeypatch.setattr(files, "get_project_manager", _raise)
 
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(files.router, prefix="/api/v1")
     return TestClient(app)

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1425,6 +1425,7 @@ class TestProjectsRouter:
         with client:
             resp = client.patch("/api/v1/projects/nope/episodes/1", json={"title": "x"})
             assert resp.status_code == 404
+            assert resp.json()["detail"] == zh_errors.MESSAGES["project_not_found"].format(name="nope")
 
     def test_update_episode_stale_script_binding_404(self, tmp_path, monkeypatch):
         """项目在但 project.json 指向的剧本文件已丢失（stale 绑定）→ 404 而非 500。"""
@@ -1435,6 +1436,7 @@ class TestProjectsRouter:
         with client:
             resp = client.patch("/api/v1/projects/ready/episodes/1", json={"title": "x"})
             assert resp.status_code == 404
+            assert resp.json()["detail"] == zh_errors.MESSAGES["ref_script_missing"]
 
 
 class TestGetVideoCapabilities:

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -259,7 +259,7 @@ class TestProjectsRouter:
             assert names == ["ready", "empty", "broken"]
             broken = [p for p in listed.json()["projects"] if p["name"] == "broken"][0]
             assert broken["status"] == {}
-            assert "error" in broken
+            assert "error" not in broken
 
             create_ok = client.post(
                 "/api/v1/projects",

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1415,6 +1415,27 @@ class TestProjectsRouter:
             resp = client.patch("/api/v1/projects/ready/episodes/99", json={"title": "x"})
             assert resp.status_code == 404
 
+    def test_update_episode_missing_project_404(self, tmp_path, monkeypatch):
+        """项目不存在 → 404，不退化成 500。
+
+        锁内抛出的 NotFoundError 不是 HTTPException 子类，外层 except 阶梯必须
+        同时放行 ApiError，否则被兜底分支吞成 internal_server_error。
+        """
+        client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
+        with client:
+            resp = client.patch("/api/v1/projects/nope/episodes/1", json={"title": "x"})
+            assert resp.status_code == 404
+
+    def test_update_episode_stale_script_binding_404(self, tmp_path, monkeypatch):
+        """项目在但 project.json 指向的剧本文件已丢失（stale 绑定）→ 404 而非 500。"""
+        fake_pm = _FakePM(tmp_path)
+        fake_pm.project_data["ready"]["episodes"][0]["script_file"] = "scripts/gone.json"
+
+        client = _client(monkeypatch, fake_pm, _FakeCalc())
+        with client:
+            resp = client.patch("/api/v1/projects/ready/episodes/1", json={"title": "x"})
+            assert resp.status_code == 404
+
 
 class TestGetVideoCapabilities:
     """GET /projects/{name}/video-capabilities"""

--- a/tests/test_props_router.py
+++ b/tests/test_props_router.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 from server.routers import props
 
 
@@ -41,6 +42,7 @@ class _FakePM:
 def _client(monkeypatch, fake_pm):
     monkeypatch.setattr(props, "get_project_manager", lambda: fake_pm)
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(props.router, prefix="/api/v1")
     return TestClient(app)

--- a/tests/test_scenes_router.py
+++ b/tests/test_scenes_router.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 from server.routers import scenes
 
 
@@ -41,6 +42,7 @@ class _FakePM:
 def _client(monkeypatch, fake_pm):
     monkeypatch.setattr(scenes, "get_project_manager", lambda: fake_pm)
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(scenes.router, prefix="/api/v1")
     return TestClient(app)
@@ -105,6 +107,7 @@ class TestScenesRouterDoesNotCollideWithProjects:
         monkeypatch.setattr(projects_router, "get_project_manager", lambda: fake_pm)
 
         app = FastAPI()
+        register_error_handlers(app)
         app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
         # 与 server/app.py 同序：projects 先 include
         app.include_router(projects_router.router, prefix="/api/v1")

--- a/tests/test_script_review_router.py
+++ b/tests/test_script_review_router.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from lib.json_io import atomic_write_json
 from lib.project_manager import ProjectManager
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 from server.routers import script_review as router_mod
 
 
@@ -59,6 +60,7 @@ def _client(monkeypatch, tmp_path: Path, *, generation_mode: str | None = None) 
     monkeypatch.setattr(router_mod, "get_project_manager", lambda: pm)
 
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(router_mod.router, prefix="/api/v1")
     return TestClient(app), pm

--- a/tests/test_shot_uploads_router.py
+++ b/tests/test_shot_uploads_router.py
@@ -13,6 +13,7 @@ from lib.project_change_hints import get_project_change_source
 from lib.project_manager import ProjectManager
 from lib.version_manager import VersionManager
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 from server.routers import reference_videos, shot_uploads
 from server.services import generation_tasks, reference_video_tasks, upload_finalize
 
@@ -64,6 +65,7 @@ def _client(monkeypatch, tmp_path):
     monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
 
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(shot_uploads.router, prefix="/api/v1")
     return TestClient(app), pm
@@ -358,6 +360,7 @@ def _ref_client(monkeypatch, tmp_path):
     monkeypatch.setattr(reference_video_tasks, "extract_video_thumbnail", _fake_thumbnail)
 
     app = FastAPI()
+    register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(reference_videos.router, prefix="/api/v1")
     return TestClient(app), pm

--- a/tests/test_shot_uploads_router.py
+++ b/tests/test_shot_uploads_router.py
@@ -417,6 +417,30 @@ class TestReferenceUnitVideoUpload:
             resp = _upload_unit(client, filename="clip.avi")
             assert resp.status_code == 400
 
+    def test_missing_project_404(self, tmp_path, monkeypatch):
+        """项目不存在 → 404，不退化成 500。
+
+        _load_episode_script 抛出的 NotFoundError 不是 HTTPException 子类，
+        端点的 except 阶梯必须同时放行 ApiError，否则被兜底分支吞成 500。
+        """
+        client, _ = _ref_client(monkeypatch, tmp_path)
+        with client:
+            resp = client.post(
+                "/api/v1/projects/nope/reference-videos/episodes/1/units/E1U1/upload-video",
+                files={"file": ("clip.mp4", BytesIO(b"\x00" * 256), "application/octet-stream")},
+            )
+            assert resp.status_code == 404
+
+    def test_stale_script_binding_404(self, tmp_path, monkeypatch):
+        """project.json 指向的剧本文件已丢失（stale 绑定）→ 404 而非 500。"""
+        client, pm = _ref_client(monkeypatch, tmp_path)
+        project = pm.load_project("demo")
+        project["episodes"][0]["script_file"] = "scripts/gone.json"
+        pm.save_project("demo", project)
+        with client:
+            resp = _upload_unit(client)
+            assert resp.status_code == 404
+
     def test_emit_uses_webui_source(self, tmp_path, monkeypatch):
         """emit 在 project_change_source("webui") 上下文内被调用（SSE source 由 contextvar 决定）。"""
         client, _ = _ref_client(monkeypatch, tmp_path)

--- a/tests/test_shot_uploads_router.py
+++ b/tests/test_shot_uploads_router.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from PIL import Image
 
+from lib.i18n.zh import errors as zh_errors
 from lib.project_change_hints import get_project_change_source
 from lib.project_manager import ProjectManager
 from lib.version_manager import VersionManager
@@ -430,6 +431,7 @@ class TestReferenceUnitVideoUpload:
                 files={"file": ("clip.mp4", BytesIO(b"\x00" * 256), "application/octet-stream")},
             )
             assert resp.status_code == 404
+            assert resp.json()["detail"] == zh_errors.MESSAGES["project_not_found"].format(name="nope")
 
     def test_stale_script_binding_404(self, tmp_path, monkeypatch):
         """project.json 指向的剧本文件已丢失（stale 绑定）→ 404 而非 500。"""
@@ -440,6 +442,7 @@ class TestReferenceUnitVideoUpload:
         with client:
             resp = _upload_unit(client)
             assert resp.status_code == 404
+            assert resp.json()["detail"] == zh_errors.MESSAGES["script_not_found"].format(name="scripts/gone.json")
 
     def test_emit_uses_webui_source(self, tmp_path, monkeypatch):
         """emit 在 project_change_source("webui") 上下文内被调用（SSE source 由 contextvar 决定）。"""


### PR DESCRIPTION
Closes #1263

## 范围 1：list_projects 路径泄漏

`list_projects` 加载单个项目元数据失败时，随 200 响应内嵌 `error: str(e)`，可能泄漏服务器绝对路径。前端 `ProjectSummary` 从未声明该字段、UI 无渲染点，属死载荷——直接删除，保留既有 `logger.warning`。用户可见行为零变化。

## 范围 2：FileNotFoundError 映射迁移到既有异常体系

router 层手写 `except FileNotFoundError → HTTPException(404)` 全量迁移到 `raise NotFoundError(既有 key, **params)`，由 `server/error_handlers.py` 的 app 级 handler 单点完成状态码映射、按 `Accept-Language` 翻译与脱敏。i18n key 与参数逐条沿用原值，响应文案与状态码不变。

origin/main 基线共 56 处捕获点 / 11 文件，处置如下：

- **47 处迁移**（`_asset_router_factory` / `assets` / `assistant` / `agent_chat` / `cost_estimation` / `files` / `projects` / `reference_videos` / `script_review` / `shot_uploads`）
- **1 处已在既有模式**（`project_events.py::_resolve_project`）
- **8 处保留**，均无 404 响应语义，不属本次迁移范围：
  - 幂等清理：`projects.py::_cleanup_temp_file`、`assets.py::_delete_global_asset_file`（捕获后 return/忽略）
  - 降级默认值：`files.py::_load_project_modes`、`cost_estimation.py` 剧集脚本预加载、`assets.py` sheet 路径查找、`projects.py::get_project` 脚本预加载（跳过或回退默认值，不抛异常）
  - `projects.py::export_jianying_draft`：裸重抛交 app 级 handler；同一 try 内有 sibling `except Exception` 兜底 500，删除该分支会使异常被吞成 500
  - `project_events.py` SSE 流：流已开始后无法再抛 HTTP 异常，捕获后关闭流

## 审查阶段修复的行为回归

`NotFoundError` 是 `ApiError(Exception)`，**不是** `HTTPException` 子类。两处端点的抛出点位于 `except` 阶梯的 try **体内**（而非 handler 内），迁移后不再命中 `except HTTPException: raise`，被兜底分支吞成 500：

| 端点 | 路径 | 迁移前 | 迁移后（未修） |
|---|---|---|---|
| `PATCH /projects/{name}/episodes/{ep}` | 项目不存在 / 剧本 stale 绑定 | 404 | 500 |
| `POST /projects/{name}/reference-videos/.../upload-video` | 项目不存在 / 剧本不存在 | 404 | 500 |

阶梯改为 `except (HTTPException, ApiError)`，与 `projects.py::generate_overview` 已有写法对齐。四条路径均补了回归测试（去掉修复后确认全部转红）。

## 验证

- `uv run ruff check . && uv run ruff format .` 通过
- `uv run basedpyright` 0 error
- `uv run python -m pytest` 6260 passed
- 终核 `grep -rn -A3 "except.*FileNotFoundError" server/routers/ | grep -B1 "HTTPException(status_code=404"` 无匹配

## 测试基础设施

5 + 7 个测试文件的裸 `FastAPI()` fixture 原先未调 `register_error_handlers(app)`。`HTTPException` 有 FastAPI 内置处理，`NotFoundError` 等自定义异常没有——不补注册，这些 app 上的 404 路径会以未处理异常向上抛。已统一补齐（Starlette `ServerErrorMiddleware` 在调用 `Exception` handler 后仍会 re-raise，TestClient 断言不被掩盖，无副作用）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 统一“资源不存在/项目不存在/会话不存在/脚本缺失”等场景的错误映射为一致的 404 返回，并保持本地化文案。
  * 修复部分缺失资源错误被错误转为 500 的情况（包含对参考视频、脚本评审、上传等端点）。
  * 调整项目列表加载失败时的输出，避免泄露内部错误信息。

* **Tests**
  * 在多处测试初始化中启用统一错误处理器注册。
  * 更新断言：移除 `broken` 项目 `error` 字段检查，并补齐 404 + `detail` 的本地化文案用例覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->