### PR TITLE
feat(onboarding): 首次进入自动弹出使用引导，设置页可随时重看

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -161,6 +161,7 @@ updates:
           - "@lobehub/*"
           - "@tanstack/react-virtual"
           - "streamdown"
+          - "driver.js"
         update-types:
           - "minor"
           - "patch"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@headlessui/react": "^2.2.10",
     "@lobehub/icons": "^5.10.0",
     "@tanstack/react-virtual": "^3.14.3",
+    "driver.js": "^1.8.0",
     "framer-motion": "^12.40.0",
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.14.3
         version: 3.14.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      driver.js:
+        specifier: ^1.8.0
+        version: 1.8.0
       framer-motion:
         specifier: ^12.40.0
         version: 12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2322,6 +2325,9 @@ packages:
 
   dompurify@3.4.8:
     resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+
+  driver.js@1.8.0:
+    resolution: {integrity: sha512-+8/IO7h1v14IzWh2GP60N7T3PFZweXwdn5e5POuxRSBoCYUojsBxzqawPeXh3YZIibRy7EehYNEyxe7slwwtdg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -7080,6 +7086,8 @@ snapshots:
   dompurify@3.4.8:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  driver.js@1.8.0: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -26,6 +26,7 @@ import type {
   ProjectDeletedPayload,
   GetSystemConfigResponse,
   GetSystemVersionResponse,
+  OnboardingStatus,
   SystemConfigPatch,
   ApiKeyInfo,
   CreateApiKeyResponse,
@@ -379,6 +380,18 @@ class API {
 
   static async getSystemVersion(): Promise<GetSystemVersionResponse> {
     return this.request("/system/version");
+  }
+
+  // ==================== 首次使用引导 ====================
+
+  static async getOnboardingStatus(
+    options: { signal?: AbortSignal } = {}
+  ): Promise<OnboardingStatus> {
+    return this.request("/onboarding/status", { signal: options.signal });
+  }
+
+  static async markOnboardingSeen(): Promise<OnboardingStatus> {
+    return this.request("/onboarding/seen", { method: "POST" });
   }
 
   static async downloadDiagnostics(): Promise<{ blob: Blob; filename: string }> {

--- a/frontend/src/app-routes.ts
+++ b/frontend/src/app-routes.ts
@@ -43,7 +43,10 @@ const WORKSPACE_STATIC_LEAF_ROUTES = [
  * `StudioCanvasRouter`（nest 路由）内层 `<Switch>` 实际注册的路由集合。
  * 内层没有兜底 404，未匹配的子路径只会渲染空白画布，因此不能整段
  * `/app/projects/` 前缀放行，需要按这份路由表精确匹配。
+ * wouter 底层 regexparam 编译路由时带 `i` 标志（大小写不敏感），这里同步加
+ * 上 `i`，否则大小写变体的合法路径会被本模式误判为未注册子路径。
  */
 export const APP_PROJECT_WORKSPACE_PATTERN = new RegExp(
   `^${ROUTE_APP_PROJECTS}/[^/]+(/(?:${WORKSPACE_STATIC_LEAF_ROUTES.join("|")}|${WORKSPACE_ROUTE_SOURCE}/[^/]+|${WORKSPACE_ROUTE_EPISODES}/[^/]+))?$`,
+  "i",
 );

--- a/frontend/src/app-routes.ts
+++ b/frontend/src/app-routes.ts
@@ -1,0 +1,12 @@
+/**
+ * 顶层应用路由常量 —— 唯一真相源，`router.tsx` 的 `<Switch>` 路由表与
+ * `OnboardingTour` 的主界面判断都从这里取值，避免两处字面量各自维护、悄悄漂移。
+ */
+
+export const ROUTE_APP = "/app";
+export const ROUTE_APP_PROJECTS = "/app/projects";
+export const ROUTE_APP_SETTINGS = "/app/settings";
+export const ROUTE_APP_ASSETS = "/app/assets";
+
+/** 无子路由的单页顶层路由——精确匹配，前缀不算数。 */
+export const APP_TOP_LEVEL_ROUTES = [ROUTE_APP, ROUTE_APP_PROJECTS, ROUTE_APP_SETTINGS, ROUTE_APP_ASSETS] as const;

--- a/frontend/src/app-routes.ts
+++ b/frontend/src/app-routes.ts
@@ -26,11 +26,13 @@ export const WORKSPACE_ROUTE_PROPS = "props";
 export const WORKSPACE_ROUTE_PRODUCTS = "products";
 export const WORKSPACE_ROUTE_EPISODES = "episodes";
 
-/** 无子路径、直接匹配的工作区叶子路由段。 */
+/** 无子路径、直接匹配的工作区叶子路由段。`source` 除了列表页本身还接受 `/:filename`，
+ *  在下面的正则里额外拼一条 `source/[^/]+` 分支覆盖后者。 */
 const WORKSPACE_STATIC_LEAF_ROUTES = [
   WORKSPACE_ROUTE_SETTINGS,
   WORKSPACE_ROUTE_LOREBOOK,
   WORKSPACE_ROUTE_CLUES,
+  WORKSPACE_ROUTE_SOURCE,
   WORKSPACE_ROUTE_CHARACTERS,
   WORKSPACE_ROUTE_SCENES,
   WORKSPACE_ROUTE_PROPS,

--- a/frontend/src/app-routes.ts
+++ b/frontend/src/app-routes.ts
@@ -12,6 +12,32 @@ export const ROUTE_APP_ASSETS = "/app/assets";
 export const APP_TOP_LEVEL_ROUTES = [ROUTE_APP, ROUTE_APP_PROJECTS, ROUTE_APP_SETTINGS, ROUTE_APP_ASSETS] as const;
 
 /**
+ * `/app/projects/:projectName` 下的路由段常量——`router.tsx`（项目设置页）与
+ * `StudioCanvasRouter`（内层 `<Switch>`）的 `<Route path>` 都从这里取值，
+ * `APP_PROJECT_WORKSPACE_PATTERN` 同样由它们拼出，新增/改名路由只需改这一处。
+ */
+export const WORKSPACE_ROUTE_SETTINGS = "settings";
+export const WORKSPACE_ROUTE_LOREBOOK = "lorebook";
+export const WORKSPACE_ROUTE_CLUES = "clues";
+export const WORKSPACE_ROUTE_SOURCE = "source";
+export const WORKSPACE_ROUTE_CHARACTERS = "characters";
+export const WORKSPACE_ROUTE_SCENES = "scenes";
+export const WORKSPACE_ROUTE_PROPS = "props";
+export const WORKSPACE_ROUTE_PRODUCTS = "products";
+export const WORKSPACE_ROUTE_EPISODES = "episodes";
+
+/** 无子路径、直接匹配的工作区叶子路由段。 */
+const WORKSPACE_STATIC_LEAF_ROUTES = [
+  WORKSPACE_ROUTE_SETTINGS,
+  WORKSPACE_ROUTE_LOREBOOK,
+  WORKSPACE_ROUTE_CLUES,
+  WORKSPACE_ROUTE_CHARACTERS,
+  WORKSPACE_ROUTE_SCENES,
+  WORKSPACE_ROUTE_PROPS,
+  WORKSPACE_ROUTE_PRODUCTS,
+] as const;
+
+/**
  * `/app/projects/:projectName` 下真正有路由承接的子路径——`.../settings`
  * 是 router.tsx 里独立注册的 `ProjectSettingsPage` 全屏路由；其余是
  * `StudioCanvasRouter`（nest 路由）内层 `<Switch>` 实际注册的路由集合。
@@ -19,5 +45,5 @@ export const APP_TOP_LEVEL_ROUTES = [ROUTE_APP, ROUTE_APP_PROJECTS, ROUTE_APP_SE
  * `/app/projects/` 前缀放行，需要按这份路由表精确匹配。
  */
 export const APP_PROJECT_WORKSPACE_PATTERN = new RegExp(
-  `^${ROUTE_APP_PROJECTS}/[^/]+(/(?:settings|lorebook|clues|source(?:/[^/]+)?|characters|scenes|props|products|episodes/[^/]+))?$`,
+  `^${ROUTE_APP_PROJECTS}/[^/]+(/(?:${WORKSPACE_STATIC_LEAF_ROUTES.join("|")}|${WORKSPACE_ROUTE_SOURCE}/[^/]+|${WORKSPACE_ROUTE_EPISODES}/[^/]+))?$`,
 );

--- a/frontend/src/app-routes.ts
+++ b/frontend/src/app-routes.ts
@@ -10,3 +10,14 @@ export const ROUTE_APP_ASSETS = "/app/assets";
 
 /** 无子路由的单页顶层路由——精确匹配，前缀不算数。 */
 export const APP_TOP_LEVEL_ROUTES = [ROUTE_APP, ROUTE_APP_PROJECTS, ROUTE_APP_SETTINGS, ROUTE_APP_ASSETS] as const;
+
+/**
+ * `/app/projects/:projectName` 下真正有路由承接的子路径——`.../settings`
+ * 是 router.tsx 里独立注册的 `ProjectSettingsPage` 全屏路由；其余是
+ * `StudioCanvasRouter`（nest 路由）内层 `<Switch>` 实际注册的路由集合。
+ * 内层没有兜底 404，未匹配的子路径只会渲染空白画布，因此不能整段
+ * `/app/projects/` 前缀放行，需要按这份路由表精确匹配。
+ */
+export const APP_PROJECT_WORKSPACE_PATTERN = new RegExp(
+  `^${ROUTE_APP_PROJECTS}/[^/]+(/(?:settings|lorebook|clues|source(?:/[^/]+)?|characters|scenes|props|products|episodes/[^/]+))?$`,
+);

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -1,6 +1,16 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { errMsg, voidPromise } from "@/utils/async";
 import { Route, Switch, Redirect } from "wouter";
+import {
+  WORKSPACE_ROUTE_LOREBOOK,
+  WORKSPACE_ROUTE_CLUES,
+  WORKSPACE_ROUTE_SOURCE,
+  WORKSPACE_ROUTE_CHARACTERS,
+  WORKSPACE_ROUTE_SCENES,
+  WORKSPACE_ROUTE_PROPS,
+  WORKSPACE_ROUTE_PRODUCTS,
+  WORKSPACE_ROUTE_EPISODES,
+} from "@/app-routes";
 import { useTranslation } from "react-i18next";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useAppStore } from "@/stores/app-store";
@@ -515,19 +525,19 @@ export function StudioCanvasRouter() {
         />
       </Route>
 
-      <Route path="/lorebook">
-        <Redirect to="/characters" />
+      <Route path={`/${WORKSPACE_ROUTE_LOREBOOK}`}>
+        <Redirect to={`/${WORKSPACE_ROUTE_CHARACTERS}`} />
       </Route>
 
-      <Route path="/clues">
-        <Redirect to="/scenes" />
+      <Route path={`/${WORKSPACE_ROUTE_CLUES}`}>
+        <Redirect to={`/${WORKSPACE_ROUTE_SCENES}`} />
       </Route>
 
-      <Route path="/source">
+      <Route path={`/${WORKSPACE_ROUTE_SOURCE}`}>
         <SourceFilesPage projectName={currentProjectName} />
       </Route>
 
-      <Route path="/characters">
+      <Route path={`/${WORKSPACE_ROUTE_CHARACTERS}`}>
         <CharactersPage
           projectName={currentProjectName}
           characters={currentProjectData?.characters ?? {}}
@@ -540,7 +550,7 @@ export function StudioCanvasRouter() {
         />
       </Route>
 
-      <Route path="/scenes">
+      <Route path={`/${WORKSPACE_ROUTE_SCENES}`}>
         <ScenesPage
           projectName={currentProjectName}
           scenes={currentProjectData?.scenes ?? {}}
@@ -553,7 +563,7 @@ export function StudioCanvasRouter() {
         />
       </Route>
 
-      <Route path="/props">
+      <Route path={`/${WORKSPACE_ROUTE_PROPS}`}>
         <PropsPage
           projectName={currentProjectName}
           props={currentProjectData?.props ?? {}}
@@ -566,7 +576,7 @@ export function StudioCanvasRouter() {
         />
       </Route>
 
-      <Route path="/products">
+      <Route path={`/${WORKSPACE_ROUTE_PRODUCTS}`}>
         <ProductsPage
           projectName={currentProjectName}
           products={currentProjectData?.products ?? {}}
@@ -579,7 +589,7 @@ export function StudioCanvasRouter() {
         />
       </Route>
 
-      <Route path="/source/:filename">
+      <Route path={`/${WORKSPACE_ROUTE_SOURCE}/:filename`}>
         {(params) => (
           <SourceFileViewer
             projectName={currentProjectName}
@@ -588,7 +598,7 @@ export function StudioCanvasRouter() {
         )}
       </Route>
 
-      <Route path="/episodes/:episodeId">
+      <Route path={`/${WORKSPACE_ROUTE_EPISODES}/:episodeId`}>
         {(params) => {
           const epNum = parseInt(params.episodeId, 10);
           const episode = currentProjectData?.episodes?.find((e) => e.episode === epNum);

--- a/frontend/src/components/pages/settings/AboutSection.tsx
+++ b/frontend/src/components/pages/settings/AboutSection.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { AlertTriangle, ExternalLink, Info, Loader2, RefreshCcw } from "lucide-react";
+import { AlertTriangle, ExternalLink, Info, Loader2, Play, RefreshCcw } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { API } from "@/api";
 import { StreamMarkdown } from "@/components/copilot/StreamMarkdown";
 import { CARD_STYLE, GHOST_BTN_LG_CLS } from "@/components/ui/darkroom-tokens";
+import { useOnboardingStore } from "@/stores/onboarding-store";
 import { formatDate } from "@/utils/date-format";
 import type { GetSystemVersionResponse } from "@/types";
 
@@ -17,6 +18,8 @@ const ABOUT_DATE_OPTS: Intl.DateTimeFormatOptions = {
 
 export function AboutSection() {
   const { t, i18n } = useTranslation("dashboard");
+  const { t: tOnboarding } = useTranslation("onboarding");
+  const startTour = useOnboardingStore((s) => s.start);
   const [data, setData] = useState<GetSystemVersionResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -241,6 +244,25 @@ export function AboutSection() {
         ) : (
           <p className="text-[12.5px] text-text-3">{t("about_release_notes_empty")}</p>
         )}
+      </div>
+
+      {/* 重看引导 —— 与首次自动弹出共用同一组件，重看不重置「已看过」标记 */}
+      <div
+        className="rounded-[12px] border border-hairline p-6"
+        style={CARD_STYLE}
+      >
+        <div className="mb-3 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-accent-2">
+          {tOnboarding("replay_title")}
+        </div>
+        <p className="text-[12.5px] text-text-3">{tOnboarding("replay_desc")}</p>
+        <button
+          type="button"
+          onClick={startTour}
+          className={`${GHOST_BTN_LG_CLS} mt-3`}
+        >
+          <Play className="h-3.5 w-3.5" aria-hidden />
+          {tOnboarding("replay_action")}
+        </button>
       </div>
 
       {/* Diagnostic logs */}

--- a/frontend/src/css/onboarding.css
+++ b/frontend/src/css/onboarding.css
@@ -211,4 +211,16 @@
     .arc-tour-filmstrip {
         width: 56px;
     }
+
+    /* 进度条 + 跳过 + 上一步/继续两组按钮，英/越文案比中文长得多，三者挤在一行
+     * 在窄屏（~320px）会溢出。这里让进度条独占一行，按钮组换到下一行。 */
+    .driver-popover.arc-tour .driver-popover-footer {
+        flex-wrap: wrap;
+        row-gap: 10px;
+    }
+
+    .driver-popover.arc-tour .driver-popover-progress-text {
+        flex-basis: 100%;
+        order: -1;
+    }
 }

--- a/frontend/src/css/onboarding.css
+++ b/frontend/src/css/onboarding.css
@@ -1,0 +1,214 @@
+/* === 首次使用引导 — driver.js 皮肤 ===
+ *
+ * driver.js 的 popover 用 `all: unset` 起手，所有观感都要在这里显式给出。皮肤刻意
+ * 复用工作台既有 token（玻璃面板、紫色 accent、文字四档、编辑体大标题），让引导读起来
+ * 是产品本身的一部分，而不是嵌进来的第三方控件。
+ *
+ * 作用域全部挂在 `.arc-tour` 上（driver 的 popoverClass），不改 driver 默认皮肤，
+ * 避免将来引入 hints 等其他 driver 形态时互相打架。
+ */
+
+/* 遮罩色不在这里 —— driver 把它写进 SVG 的 fill，取值见 tour.ts 的 OVERLAY_INK。 */
+
+/* ── 气泡本体 ─────────────────────────────────────────────── */
+
+.driver-popover.arc-tour {
+    /* 与 .arc-glass-panel 同源 */
+    background: linear-gradient(180deg, oklch(0.21 0.012 265 / 0.97), oklch(0.18 0.010 265 / 0.97));
+    border: 1px solid var(--color-hairline);
+    border-radius: 16px;
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    box-shadow:
+        0 24px 60px -12px oklch(0 0 0 / 0.6),
+        inset 0 1px 0 oklch(1 0 0 / 0.05);
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    min-width: 0;
+    max-width: min(92vw, 420px);
+    padding: 26px 26px 20px;
+}
+
+/* 顶部 accent hairline — 与 .arc-glass-hairline 一致 */
+.driver-popover.arc-tour::before {
+    content: "";
+    position: absolute;
+    inset-inline: 0;
+    top: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--color-accent-soft), transparent);
+    pointer-events: none;
+}
+
+.driver-popover.arc-tour .driver-popover-arrow {
+    border-color: transparent;
+}
+
+/* ── 文字 ─────────────────────────────────────────────────── */
+
+.driver-popover.arc-tour .driver-popover-title {
+    /* 编辑体大标题 —— 与项目大厅的电影感标题同一张脸 */
+    font-family: var(--font-editorial);
+    font-size: 27px;
+    font-weight: 400;
+    letter-spacing: -0.01em;
+    line-height: 1.2;
+    color: var(--color-text);
+    padding-right: 28px; /* 让开右上角的关闭按钮 */
+}
+
+.driver-popover.arc-tour .driver-popover-description {
+    margin-top: 10px;
+    font-size: 13.5px;
+    line-height: 1.75;
+    color: var(--color-text-2);
+}
+
+/* ── 关闭按钮 ─────────────────────────────────────────────── */
+
+.driver-popover.arc-tour .driver-popover-close-btn {
+    top: 14px;
+    right: 14px;
+    width: 26px;
+    height: 26px;
+    border-radius: 6px;
+    font-size: 17px;
+    line-height: 26px;
+    color: var(--color-text-4);
+    transition: color 150ms, background 150ms;
+}
+
+.driver-popover.arc-tour .driver-popover-close-btn:hover {
+    color: var(--color-text);
+    background: oklch(1 0 0 / 0.05);
+}
+
+/* ── 页脚 ─────────────────────────────────────────────────── */
+
+.driver-popover.arc-tour .driver-popover-footer {
+    margin-top: 22px;
+    gap: 16px;
+    align-items: center;
+}
+
+.driver-popover.arc-tour .driver-popover-navigation-btns {
+    gap: 8px;
+}
+
+.driver-popover.arc-tour .driver-popover-navigation-btns button + button {
+    margin-left: 0;
+}
+
+/* 进度：胶片齿孔 —— 轨道宽度恒定，格数随步数变化（2 步是两格宽条，11 步是细齿条）。
+ * 语义由页脚的 sr-only 文本承载，齿孔本身是装饰。 */
+.arc-tour-filmstrip {
+    display: flex;
+    gap: 3px;
+    width: 88px;
+    flex: none;
+}
+
+.arc-tour-filmstrip span {
+    flex: 1;
+    height: 4px;
+    border-radius: 1px;
+    background: var(--color-hairline);
+    transition: background 220ms;
+}
+
+.arc-tour-filmstrip span[data-on="1"] {
+    background: var(--color-accent);
+    box-shadow: 0 0 10px -2px var(--color-accent-glow);
+}
+
+.arc-tour-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}
+
+/* ── 按钮 ─────────────────────────────────────────────────── */
+
+.driver-popover.arc-tour .driver-popover-footer-btn {
+    border-radius: 8px;
+    padding: 7px 14px;
+    font-size: 12.5px;
+    font-weight: 500;
+    line-height: 1.3;
+    cursor: pointer;
+}
+
+.driver-popover.arc-tour .driver-popover-footer-btn:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}
+
+/* 次按钮：上一步 / 跳过 —— 与 .arc-btn-secondary 一致 */
+.driver-popover.arc-tour .driver-popover-prev-btn,
+.driver-popover.arc-tour .arc-tour-skip-btn {
+    color: var(--color-text-3);
+    border: 1px solid var(--color-hairline);
+    background: oklch(0.22 0.011 265 / 0.5);
+    transition: color 150ms, background 150ms, border-color 150ms;
+}
+
+.driver-popover.arc-tour .driver-popover-prev-btn:hover,
+.driver-popover.arc-tour .arc-tour-skip-btn:hover {
+    color: var(--color-text);
+    background: oklch(0.26 0.013 265 / 0.7);
+    border-color: var(--color-hairline-strong);
+}
+
+/* 跳过按钮无边框，压得比"上一步"更轻——它是退出路径，不是导航 */
+.driver-popover.arc-tour .arc-tour-skip-btn {
+    border-color: transparent;
+    background: transparent;
+    margin-right: auto;
+}
+
+/* 主按钮：继续 / 完成 —— 与 .arc-btn-primary 一致 */
+.driver-popover.arc-tour .driver-popover-next-btn,
+.driver-popover.arc-tour .driver-popover-done-btn {
+    color: oklch(0.14 0 0);
+    border: none;
+    font-weight: 600;
+    background: linear-gradient(135deg, var(--color-accent-2), var(--color-accent));
+    box-shadow:
+        inset 0 1px 0 oklch(1 0 0 / 0.35),
+        0 6px 18px -6px var(--color-accent-glow),
+        0 0 0 1px var(--color-accent-soft);
+    transition: transform 150ms;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .driver-popover.arc-tour .driver-popover-next-btn:hover,
+    .driver-popover.arc-tour .driver-popover-done-btn:hover {
+        transform: translateY(-1px);
+    }
+}
+
+.driver-popover.arc-tour .driver-popover-btn-disabled {
+    opacity: 0.4;
+}
+
+/* ── 窄屏 ─────────────────────────────────────────────────── */
+
+@media (max-width: 480px) {
+    .driver-popover.arc-tour {
+        padding: 20px 20px 16px;
+    }
+
+    .driver-popover.arc-tour .driver-popover-title {
+        font-size: 23px;
+    }
+
+    .arc-tour-filmstrip {
+        width: 56px;
+    }
+}

--- a/frontend/src/hooks/useEscapeClose.test.ts
+++ b/frontend/src/hooks/useEscapeClose.test.ts
@@ -1,0 +1,62 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startTour, type TourLabels, type TourStep } from "@/onboarding/tour";
+import { useEscapeClose } from "./useEscapeClose";
+
+const LABELS: TourLabels = {
+  next: "继续",
+  prev: "上一步",
+  done: "完成",
+  skip: "跳过",
+  close: "关闭引导",
+  progress: (current, total) => `第 ${current} 步，共 ${total} 步`,
+};
+
+const ONE_STEP: TourStep[] = [{ anchor: null, title: "欢迎", body: "开场" }];
+
+function pressEscape(): void {
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+}
+
+describe("useEscapeClose", () => {
+  afterEach(() => {
+    document.querySelector("#app-root")?.remove();
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    const onClose = vi.fn();
+    renderHook(() => useEscapeClose(onClose));
+
+    pressEscape();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing while disabled", () => {
+    const onClose = vi.fn();
+    renderHook(() => useEscapeClose(onClose, false));
+
+    pressEscape();
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("defers to the onboarding tour's own Esc handling while it is active", () => {
+    const appRoot = document.createElement("div");
+    appRoot.id = "app-root";
+    document.body.appendChild(appRoot);
+
+    const onClose = vi.fn();
+    renderHook(() => useEscapeClose(onClose));
+
+    const handle = startTour(ONE_STEP, LABELS, { onExit: vi.fn() });
+
+    pressEscape();
+    expect(onClose).not.toHaveBeenCalled();
+
+    handle.dispose();
+
+    pressEscape();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useEscapeClose.test.ts
+++ b/frontend/src/hooks/useEscapeClose.test.ts
@@ -15,7 +15,7 @@ const LABELS: TourLabels = {
 const ONE_STEP: TourStep[] = [{ anchor: null, title: "欢迎", body: "开场" }];
 
 function pressEscape(): void {
-  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+  document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
 }
 
 describe("useEscapeClose", () => {
@@ -41,7 +41,7 @@ describe("useEscapeClose", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("defers to the onboarding tour's own Esc handling while it is active", () => {
+  it("is suppressed by the onboarding tour's global keydown isolation while it is active", () => {
     const appRoot = document.createElement("div");
     appRoot.id = "app-root";
     document.body.appendChild(appRoot);

--- a/frontend/src/hooks/useEscapeClose.ts
+++ b/frontend/src/hooks/useEscapeClose.ts
@@ -1,10 +1,13 @@
 import { useEffect } from "react";
+import { isOnboardingTourActive } from "@/onboarding/tour";
 
 export function useEscapeClose(onClose: () => void, enabled = true) {
   useEffect(() => {
     if (!enabled) return;
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      // 引导期间 Esc 交给 driver 自己的退出流程处理，底层弹窗让位，
+      // 否则两边同时响应会把弹窗里尚未提交的内容一并关没。
+      if (e.key === "Escape" && !isOnboardingTourActive()) onClose();
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);

--- a/frontend/src/hooks/useEscapeClose.ts
+++ b/frontend/src/hooks/useEscapeClose.ts
@@ -1,13 +1,10 @@
 import { useEffect } from "react";
-import { isOnboardingTourActive } from "@/onboarding/tour";
 
 export function useEscapeClose(onClose: () => void, enabled = true) {
   useEffect(() => {
     if (!enabled) return;
     const handleKeyDown = (e: KeyboardEvent) => {
-      // 引导期间 Esc 交给 driver 自己的退出流程处理，底层弹窗让位，
-      // 否则两边同时响应会把弹窗里尚未提交的内容一并关没。
-      if (e.key === "Escape" && !isOnboardingTourActive()) onClose();
+      if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);

--- a/frontend/src/i18n/en/onboarding.ts
+++ b/frontend/src/i18n/en/onboarding.ts
@@ -1,0 +1,21 @@
+
+export default {
+  // Tour steps
+  'welcome_title': 'Welcome to [[brand]]',
+  'welcome_body': 'Hand it a novel and it breaks the story into shots, generates the frames, and cuts them into a short video. This tour only walks through the interface — it changes none of your data.',
+  'finish_title': 'Your turn',
+  'finish_body': 'Start by importing a novel, then take the rest one step at a time. To see this again, open Settings → About.',
+
+  // Tour controls
+  'next': 'Continue',
+  'prev': 'Back',
+  'done': 'Done',
+  'skip': 'Skip',
+  'close': 'Close the tour',
+  'progress': 'Step {{current}} of {{total}}',
+
+  // Settings → About entry
+  'replay_title': 'Product tour',
+  'replay_desc': 'Replay the first-run tour. It walks through the interface and changes no data.',
+  'replay_action': 'Replay tour',
+};

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -31,6 +31,7 @@ export const I18N_NAMESPACES = [
   'errors',
   'templates',
   'assets',
+  'onboarding',
 ] as const;
 
 // Replace every [[brand]] placeholder in a loaded namespace with the current

--- a/frontend/src/i18n/vi/onboarding.ts
+++ b/frontend/src/i18n/vi/onboarding.ts
@@ -1,0 +1,22 @@
+import type enOnboarding from '@/i18n/en/onboarding';
+
+export default {
+  // Các bước hướng dẫn
+  'welcome_title': 'Chào mừng đến với [[brand]]',
+  'welcome_body': 'Đưa vào một cuốn tiểu thuyết, hệ thống sẽ tách thành phân cảnh, tạo hình ảnh và dựng thành video ngắn. Phần hướng dẫn này chỉ giới thiệu giao diện, không thay đổi bất kỳ dữ liệu nào của bạn.',
+  'finish_title': 'Đến lượt bạn',
+  'finish_body': 'Hãy bắt đầu bằng cách nhập một cuốn tiểu thuyết, phần còn lại làm từng bước một. Muốn xem lại, hãy mở Cài đặt → Giới thiệu.',
+
+  // Điều khiển hướng dẫn
+  'next': 'Tiếp tục',
+  'prev': 'Quay lại',
+  'done': 'Hoàn tất',
+  'skip': 'Bỏ qua',
+  'close': 'Đóng hướng dẫn',
+  'progress': 'Bước {{current}} / {{total}}',
+
+  // Mục trong Cài đặt → Giới thiệu
+  'replay_title': 'Hướng dẫn sử dụng',
+  'replay_desc': 'Xem lại phần hướng dẫn lần đầu. Chỉ giới thiệu giao diện, không thay đổi dữ liệu.',
+  'replay_action': 'Xem lại hướng dẫn',
+} satisfies Record<keyof typeof enOnboarding, string>;

--- a/frontend/src/i18n/zh/onboarding.ts
+++ b/frontend/src/i18n/zh/onboarding.ts
@@ -1,4 +1,4 @@
-import type enOnboarding from '../en/onboarding';
+import type enOnboarding from '@/i18n/en/onboarding';
 
 export default {
   // 引导步骤

--- a/frontend/src/i18n/zh/onboarding.ts
+++ b/frontend/src/i18n/zh/onboarding.ts
@@ -1,0 +1,22 @@
+import type enOnboarding from '../en/onboarding';
+
+export default {
+  // 引导步骤
+  'welcome_title': '欢迎来到 [[brand]]',
+  'welcome_body': '把一本小说交给它，它会拆出分镜、生成画面、剪成短视频。这趟引导只讲解界面，不会改动你的任何数据。',
+  'finish_title': '轮到你了',
+  'finish_body': '从导入一本小说开始，剩下的一步步来。想再看一遍，去「设置 → 关于」打开这份引导。',
+
+  // 引导控件
+  'next': '继续',
+  'prev': '上一步',
+  'done': '完成',
+  'skip': '跳过',
+  'close': '关闭引导',
+  'progress': '第 {{current}} 步，共 {{total}} 步',
+
+  // 设置 → 关于 的入口
+  'replay_title': '使用引导',
+  'replay_desc': '重看首次使用引导。只讲解界面，不改动任何数据。',
+  'replay_action': '重看引导',
+} satisfies Record<keyof typeof enOnboarding, string>;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,10 +8,14 @@ import { useAuthStore } from "@/stores/auth-store";
 import { i18nReady } from "@/i18n";
 import { BRAND, BRAND_DOCUMENT_TITLE } from "@/branding";
 
+import "driver.js/dist/driver.css";
+
 import "./index.css";
 import "./css/styles.css";
 import "./css/app.css";
 import "./css/studio.css";
+// driver 默认皮肤之后加载，覆盖生效
+import "./css/onboarding.css";
 
 // 启动时按 BRAND 设置文档标题与 meta description（index.html 中的
 // <title> 与 <meta name="description"> 仅作为加载阶段的占位）。

--- a/frontend/src/onboarding/OnboardingTour.test.tsx
+++ b/frontend/src/onboarding/OnboardingTour.test.tsx
@@ -104,6 +104,31 @@ describe("OnboardingTour", () => {
     expect(popoverTitle()).toBeNull();
   });
 
+  it("does not run on an unregistered sub-path inside a project workspace", () => {
+    const status = vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    renderAt("/app/projects/my-novel/unknown");
+
+    expect(status).not.toHaveBeenCalled();
+    expect(popoverTitle()).toBeNull();
+  });
+
+  it("runs on a registered sub-path inside a project workspace", async () => {
+    const status = vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    renderAt("/app/projects/my-novel/characters");
+
+    await waitFor(() => expect(status).toHaveBeenCalled());
+  });
+
+  it("runs on the project settings page", async () => {
+    const status = vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    renderAt("/app/projects/my-novel/settings");
+
+    await waitFor(() => expect(status).toHaveBeenCalled());
+  });
+
   it("marks the tour as seen when it is closed, and does not reopen it", async () => {
     vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
 

--- a/frontend/src/onboarding/OnboardingTour.test.tsx
+++ b/frontend/src/onboarding/OnboardingTour.test.tsx
@@ -17,6 +17,16 @@ function renderAt(path: string) {
   );
 }
 
+function renderWithNavigation(path: string) {
+  const { hook, navigate } = memoryLocation({ path });
+  const view = render(
+    <Router hook={hook}>
+      <OnboardingTour />
+    </Router>,
+  );
+  return { ...view, navigate };
+}
+
 function popoverTitle(): string | null {
   return document.querySelector(".driver-popover-title")?.textContent ?? null;
 }
@@ -67,6 +77,15 @@ describe("OnboardingTour", () => {
     expect(status).not.toHaveBeenCalled();
   });
 
+  it("does not run on an unmatched route (404)", () => {
+    const status = vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    renderAt("/some/unknown/path");
+
+    expect(status).not.toHaveBeenCalled();
+    expect(popoverTitle()).toBeNull();
+  });
+
   it("marks the tour as seen when it is closed, and does not reopen it", async () => {
     vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
 
@@ -108,6 +127,18 @@ describe("OnboardingTour", () => {
     });
 
     await waitFor(() => expect(popoverTitle()).toBe("Your turn"));
+    expect(API.markOnboardingSeen).not.toHaveBeenCalled();
+  });
+
+  it("takes the tour down when the user navigates back to the login page mid-tour", async () => {
+    vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    const { navigate } = renderWithNavigation("/app/projects");
+    await waitFor(() => expect(popoverTitle()).toBe("欢迎来到 ArcReel"));
+
+    act(() => navigate("/login"));
+
+    expect(popoverTitle()).toBeNull();
     expect(API.markOnboardingSeen).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/onboarding/OnboardingTour.test.tsx
+++ b/frontend/src/onboarding/OnboardingTour.test.tsx
@@ -86,6 +86,15 @@ describe("OnboardingTour", () => {
     expect(popoverTitle()).toBeNull();
   });
 
+  it("does not run on an unmatched route that merely shares the /app prefix", () => {
+    const status = vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    renderAt("/application");
+
+    expect(status).not.toHaveBeenCalled();
+    expect(popoverTitle()).toBeNull();
+  });
+
   it("marks the tour as seen when it is closed, and does not reopen it", async () => {
     vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
 

--- a/frontend/src/onboarding/OnboardingTour.test.tsx
+++ b/frontend/src/onboarding/OnboardingTour.test.tsx
@@ -1,7 +1,8 @@
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import i18n from "@/i18n";
 import { API } from "@/api";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOnboardingStore } from "@/stores/onboarding-store";
@@ -25,6 +26,10 @@ describe("OnboardingTour", () => {
     useOnboardingStore.setState(useOnboardingStore.getInitialState(), true);
     useAuthStore.setState({ isAuthenticated: true });
     vi.spyOn(API, "markOnboardingSeen").mockResolvedValue({ seen: true });
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage("zh");
   });
 
   it("opens the tour on the first visit to the main interface", async () => {
@@ -87,6 +92,22 @@ describe("OnboardingTour", () => {
     document.querySelector<HTMLElement>(".driver-popover-close-btn")?.click();
 
     await waitFor(() => expect(popoverTitle()).toBeNull());
+    expect(API.markOnboardingSeen).not.toHaveBeenCalled();
+  });
+
+  it("keeps its place when the interface language changes mid-tour", async () => {
+    vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    renderAt("/app/projects");
+    await waitFor(() => expect(popoverTitle()).toBe("欢迎来到 ArcReel"));
+    document.querySelector<HTMLElement>(".driver-popover-next-btn")?.click();
+    expect(popoverTitle()).toBe("轮到你了");
+
+    await act(async () => {
+      await i18n.changeLanguage("en");
+    });
+
+    await waitFor(() => expect(popoverTitle()).toBe("Your turn"));
     expect(API.markOnboardingSeen).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/onboarding/OnboardingTour.test.tsx
+++ b/frontend/src/onboarding/OnboardingTour.test.tsx
@@ -95,6 +95,15 @@ describe("OnboardingTour", () => {
     expect(popoverTitle()).toBeNull();
   });
 
+  it("does not run on an unregistered sub-path under a single-page app route", () => {
+    const status = vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    renderAt("/app/settings/unknown");
+
+    expect(status).not.toHaveBeenCalled();
+    expect(popoverTitle()).toBeNull();
+  });
+
   it("marks the tour as seen when it is closed, and does not reopen it", async () => {
     vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
 

--- a/frontend/src/onboarding/OnboardingTour.test.tsx
+++ b/frontend/src/onboarding/OnboardingTour.test.tsx
@@ -121,6 +121,14 @@ describe("OnboardingTour", () => {
     await waitFor(() => expect(status).toHaveBeenCalled());
   });
 
+  it("runs on the source files list page, which has no filename segment", async () => {
+    const status = vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    renderAt("/app/projects/my-novel/source");
+
+    await waitFor(() => expect(status).toHaveBeenCalled());
+  });
+
   it("runs on the project settings page", async () => {
     const status = vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
 

--- a/frontend/src/onboarding/OnboardingTour.test.tsx
+++ b/frontend/src/onboarding/OnboardingTour.test.tsx
@@ -1,0 +1,104 @@
+import { render, waitFor } from "@testing-library/react";
+import { Router } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { API } from "@/api";
+import { useAuthStore } from "@/stores/auth-store";
+import { useOnboardingStore } from "@/stores/onboarding-store";
+import { OnboardingTour } from "./OnboardingTour";
+
+function renderAt(path: string) {
+  const { hook } = memoryLocation({ path });
+  return render(
+    <Router hook={hook}>
+      <OnboardingTour />
+    </Router>,
+  );
+}
+
+function popoverTitle(): string | null {
+  return document.querySelector(".driver-popover-title")?.textContent ?? null;
+}
+
+describe("OnboardingTour", () => {
+  beforeEach(() => {
+    useOnboardingStore.setState(useOnboardingStore.getInitialState(), true);
+    useAuthStore.setState({ isAuthenticated: true });
+    vi.spyOn(API, "markOnboardingSeen").mockResolvedValue({ seen: true });
+  });
+
+  it("opens the tour on the first visit to the main interface", async () => {
+    vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    renderAt("/app/projects");
+
+    await waitFor(() => expect(popoverTitle()).toBe("欢迎来到 ArcReel"));
+  });
+
+  it("stays out of the way once the tour has been seen", async () => {
+    const status = vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: true });
+
+    renderAt("/app/projects");
+
+    await waitFor(() => expect(status).toHaveBeenCalled());
+    expect(popoverTitle()).toBeNull();
+  });
+
+  it("does not run before the user reaches the main interface", () => {
+    const status = vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+    useAuthStore.setState({ isAuthenticated: false });
+
+    renderAt("/app/projects");
+
+    expect(status).not.toHaveBeenCalled();
+    expect(popoverTitle()).toBeNull();
+  });
+
+  it("does not run on the login page", () => {
+    const status = vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    renderAt("/login");
+
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it("marks the tour as seen when it is closed, and does not reopen it", async () => {
+    vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    renderAt("/app/projects");
+    await waitFor(() => expect(popoverTitle()).toBe("欢迎来到 ArcReel"));
+
+    document.querySelector<HTMLElement>(".driver-popover-close-btn")?.click();
+
+    await waitFor(() => expect(API.markOnboardingSeen).toHaveBeenCalledTimes(1));
+    expect(popoverTitle()).toBeNull();
+    expect(useOnboardingStore.getState().seen).toBe(true);
+  });
+
+  it("replays the tour on request without writing the flag again", async () => {
+    vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: true });
+
+    renderAt("/app/projects");
+    await waitFor(() => expect(API.getOnboardingStatus).toHaveBeenCalled());
+
+    useOnboardingStore.getState().start();
+
+    await waitFor(() => expect(popoverTitle()).toBe("欢迎来到 ArcReel"));
+    document.querySelector<HTMLElement>(".driver-popover-close-btn")?.click();
+
+    await waitFor(() => expect(popoverTitle()).toBeNull());
+    expect(API.markOnboardingSeen).not.toHaveBeenCalled();
+  });
+
+  it("takes the tour down when the mount point unmounts", async () => {
+    vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    const { unmount } = renderAt("/app/projects");
+    await waitFor(() => expect(popoverTitle()).toBe("欢迎来到 ArcReel"));
+
+    unmount();
+
+    expect(document.querySelector(".driver-popover")).toBeNull();
+    expect(API.markOnboardingSeen).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/onboarding/OnboardingTour.test.tsx
+++ b/frontend/src/onboarding/OnboardingTour.test.tsx
@@ -137,6 +137,14 @@ describe("OnboardingTour", () => {
     await waitFor(() => expect(status).toHaveBeenCalled());
   });
 
+  it("runs on a URL with a trailing slash that wouter itself matches", async () => {
+    const status = vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    renderAt("/app/settings/");
+
+    await waitFor(() => expect(status).toHaveBeenCalled());
+  });
+
   it("marks the tour as seen when it is closed, and does not reopen it", async () => {
     vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
 

--- a/frontend/src/onboarding/OnboardingTour.test.tsx
+++ b/frontend/src/onboarding/OnboardingTour.test.tsx
@@ -129,6 +129,14 @@ describe("OnboardingTour", () => {
     await waitFor(() => expect(status).toHaveBeenCalled());
   });
 
+  it("runs on a case-variant URL that wouter itself matches case-insensitively", async () => {
+    const status = vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+    renderAt("/APP/Projects/my-novel/Characters");
+
+    await waitFor(() => expect(status).toHaveBeenCalled());
+  });
+
   it("marks the tour as seen when it is closed, and does not reopen it", async () => {
     vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
 

--- a/frontend/src/onboarding/OnboardingTour.tsx
+++ b/frontend/src/onboarding/OnboardingTour.tsx
@@ -10,7 +10,7 @@
  *    组件本身不区分二者。
  */
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useLocation } from "wouter";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "@/stores/auth-store";
@@ -42,8 +42,15 @@ export function OnboardingTour() {
   }, [inMainUi, seen]);
 
   // 3. 驱动 driver.js
+  //
+  // 文案是构造时一次性交给 driver 的，切换界面语言（`t` 换身份）必须重建一遍才能生效。
+  // 重建走 `dispose()` —— 不记退出 —— 并把停留的步号带过去，讲到第几步就还在第几步。
+  const stepIndexRef = useRef(0);
   useEffect(() => {
-    if (!active) return;
+    if (!active) {
+      stepIndexRef.current = 0;
+      return;
+    }
     const labels: TourLabels = {
       next: t("next"),
       prev: t("prev"),
@@ -54,8 +61,12 @@ export function OnboardingTour() {
     };
     const handle = startTour(buildTourSteps(t), labels, {
       onExit: () => useOnboardingStore.getState().exit(),
+      startIndex: stepIndexRef.current,
     });
-    return () => handle.dispose();
+    return () => {
+      stepIndexRef.current = handle.currentIndex();
+      handle.dispose();
+    };
   }, [active, t]);
 
   return null;

--- a/frontend/src/onboarding/OnboardingTour.tsx
+++ b/frontend/src/onboarding/OnboardingTour.tsx
@@ -15,10 +15,9 @@ import { useLocation } from "wouter";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOnboardingStore } from "@/stores/onboarding-store";
+import { APP_TOP_LEVEL_ROUTES, ROUTE_APP_PROJECTS } from "@/app-routes";
 import { buildTourSteps } from "./steps";
 import { startTour, type TourLabels } from "./tour";
-
-const APP_TOP_LEVEL_ROUTES = ["/app", "/app/projects", "/app/settings", "/app/assets"];
 
 export function OnboardingTour() {
   const { t } = useTranslation("onboarding");
@@ -29,14 +28,13 @@ export function OnboardingTour() {
 
   // 只在已知应用路由内生效——未匹配路由（404）与 /login 一样不掺和，否则引导会
   // 在错链接 / 旧书签落地的 404 页自动弹出，且关闭时把全局 seen 标记写成已看过。
-  // 这份列表须跟 router.tsx 的顶层路由表保持一致：/app/settings、/app/assets 是无子路由
-  // 的单页，前缀匹配会把 /app/settings/unknown 这类 404 误判为主界面；只有
-  // /app/projects/:projectName 是 `nest` 路由，允许前缀匹配。
+  // /app/settings、/app/assets 是无子路由的单页，前缀匹配会把 /app/settings/unknown
+  // 这类 404 误判为主界面；只有 /app/projects/:projectName 是 `nest` 路由，允许前缀匹配。
   const inMainUi =
     isAuthenticated &&
     (location === "/" ||
-      APP_TOP_LEVEL_ROUTES.includes(location) ||
-      location.startsWith("/app/projects/"));
+      (APP_TOP_LEVEL_ROUTES as readonly string[]).includes(location) ||
+      location.startsWith(`${ROUTE_APP_PROJECTS}/`));
 
   // 1. 查询「是否已看过」
   useEffect(() => {

--- a/frontend/src/onboarding/OnboardingTour.tsx
+++ b/frontend/src/onboarding/OnboardingTour.tsx
@@ -31,9 +31,10 @@ export function OnboardingTour() {
   // /app/settings、/app/assets 是无子路由的单页，前缀匹配会把 /app/settings/unknown
   // 这类 404 误判为主界面；/app/projects/:projectName 下 StudioCanvasRouter 的内层
   // <Switch> 同样没有兜底路由，未注册的子路径按 APP_PROJECT_WORKSPACE_PATTERN 精确匹配。
-  // wouter 底层 regexparam 大小写不敏感，这里统一转小写后再比对，避免大小写变体的
+  // wouter 底层 regexparam 大小写不敏感、且非 loose 模式下末尾斜杠可选（pattern 以
+  // `\/?$` 收尾），这里统一转小写、去掉末尾斜杠后再比对，避免大小写变体或带尾斜杠的
   // 合法路径（wouter 能正常渲染）被本判断误判为不在主界面内。
-  const normalizedLocation = location.toLowerCase();
+  const normalizedLocation = location.toLowerCase().replace(/(.)\/$/, "$1");
   const inMainUi =
     isAuthenticated &&
     (normalizedLocation === "/" ||

--- a/frontend/src/onboarding/OnboardingTour.tsx
+++ b/frontend/src/onboarding/OnboardingTour.tsx
@@ -27,7 +27,8 @@ export function OnboardingTour() {
 
   // 只在已知应用路由内生效——未匹配路由（404）与 /login 一样不掺和，否则引导会
   // 在错链接 / 旧书签落地的 404 页自动弹出，且关闭时把全局 seen 标记写成已看过。
-  const inMainUi = isAuthenticated && (location === "/" || location.startsWith("/app"));
+  const inMainUi =
+    isAuthenticated && (location === "/" || location === "/app" || location.startsWith("/app/"));
 
   // 1. 查询「是否已看过」
   useEffect(() => {

--- a/frontend/src/onboarding/OnboardingTour.tsx
+++ b/frontend/src/onboarding/OnboardingTour.tsx
@@ -25,7 +25,9 @@ export function OnboardingTour() {
   const seen = useOnboardingStore((s) => s.seen);
   const active = useOnboardingStore((s) => s.active);
 
-  const inMainUi = isAuthenticated && location !== "/login";
+  // 只在已知应用路由内生效——未匹配路由（404）与 /login 一样不掺和，否则引导会
+  // 在错链接 / 旧书签落地的 404 页自动弹出，且关闭时把全局 seen 标记写成已看过。
+  const inMainUi = isAuthenticated && (location === "/" || location.startsWith("/app"));
 
   // 1. 查询「是否已看过」
   useEffect(() => {
@@ -47,8 +49,10 @@ export function OnboardingTour() {
   // 重建走 `dispose()` —— 不记退出 —— 并把停留的步号带过去，讲到第几步就还在第几步。
   const stepIndexRef = useRef(0);
   useEffect(() => {
-    if (!active) {
-      stepIndexRef.current = 0;
+    // 离开主界面（如运行期间浏览器后退回登录页）时收起正在运行的引导——不算一次
+    // 退出（不记 seen），保留步号，回到主界面后从原位继续。
+    if (!active || !inMainUi) {
+      if (!active) stepIndexRef.current = 0;
       return;
     }
     const labels: TourLabels = {
@@ -67,7 +71,7 @@ export function OnboardingTour() {
       stepIndexRef.current = handle.currentIndex();
       handle.dispose();
     };
-  }, [active, t]);
+  }, [active, inMainUi, t]);
 
   return null;
 }

--- a/frontend/src/onboarding/OnboardingTour.tsx
+++ b/frontend/src/onboarding/OnboardingTour.tsx
@@ -15,7 +15,7 @@ import { useLocation } from "wouter";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOnboardingStore } from "@/stores/onboarding-store";
-import { APP_TOP_LEVEL_ROUTES, ROUTE_APP_PROJECTS } from "@/app-routes";
+import { APP_PROJECT_WORKSPACE_PATTERN, APP_TOP_LEVEL_ROUTES } from "@/app-routes";
 import { buildTourSteps } from "./steps";
 import { startTour, type TourLabels } from "./tour";
 
@@ -29,12 +29,13 @@ export function OnboardingTour() {
   // 只在已知应用路由内生效——未匹配路由（404）与 /login 一样不掺和，否则引导会
   // 在错链接 / 旧书签落地的 404 页自动弹出，且关闭时把全局 seen 标记写成已看过。
   // /app/settings、/app/assets 是无子路由的单页，前缀匹配会把 /app/settings/unknown
-  // 这类 404 误判为主界面；只有 /app/projects/:projectName 是 `nest` 路由，允许前缀匹配。
+  // 这类 404 误判为主界面；/app/projects/:projectName 下 StudioCanvasRouter 的内层
+  // <Switch> 同样没有兜底路由，未注册的子路径按 APP_PROJECT_WORKSPACE_PATTERN 精确匹配。
   const inMainUi =
     isAuthenticated &&
     (location === "/" ||
       (APP_TOP_LEVEL_ROUTES as readonly string[]).includes(location) ||
-      location.startsWith(`${ROUTE_APP_PROJECTS}/`));
+      APP_PROJECT_WORKSPACE_PATTERN.test(location));
 
   // 1. 查询「是否已看过」
   useEffect(() => {

--- a/frontend/src/onboarding/OnboardingTour.tsx
+++ b/frontend/src/onboarding/OnboardingTour.tsx
@@ -1,0 +1,62 @@
+/**
+ * 引导挂载点 —— 挂在路由根，跨页面导航存活，自身不渲染任何 DOM（气泡与遮罩由
+ * driver.js 挂到 body 上）。
+ *
+ * 三件事：
+ * 1. 进入主界面后查一次「是否已看过」（auth 开启 = 登录成功后；匿名 = auth status 放行
+ *    后，两种情形都由 `isAuthenticated` 统一表达）。登录页不掺和。
+ * 2. 未看过则自动开一次。
+ * 3. store 里 active 为真时驱动 driver.js —— 自动首弹与设置页「重看引导」共用这条路径，
+ *    组件本身不区分二者。
+ */
+
+import { useEffect } from "react";
+import { useLocation } from "wouter";
+import { useTranslation } from "react-i18next";
+import { useAuthStore } from "@/stores/auth-store";
+import { useOnboardingStore } from "@/stores/onboarding-store";
+import { buildTourSteps } from "./steps";
+import { startTour, type TourLabels } from "./tour";
+
+export function OnboardingTour() {
+  const { t } = useTranslation("onboarding");
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const [location] = useLocation();
+  const seen = useOnboardingStore((s) => s.seen);
+  const active = useOnboardingStore((s) => s.active);
+
+  const inMainUi = isAuthenticated && location !== "/login";
+
+  // 1. 查询「是否已看过」
+  useEffect(() => {
+    if (!inMainUi) return;
+    const controller = new AbortController();
+    void useOnboardingStore.getState().loadStatus({ signal: controller.signal });
+    return () => controller.abort();
+  }, [inMainUi]);
+
+  // 2. 未看过 → 自动开一次（退出时 seen 置真，不会再开）
+  useEffect(() => {
+    if (!inMainUi || seen !== false) return;
+    useOnboardingStore.getState().start();
+  }, [inMainUi, seen]);
+
+  // 3. 驱动 driver.js
+  useEffect(() => {
+    if (!active) return;
+    const labels: TourLabels = {
+      next: t("next"),
+      prev: t("prev"),
+      done: t("done"),
+      skip: t("skip"),
+      close: t("close"),
+      progress: (current, total) => t("progress", { current, total }),
+    };
+    const handle = startTour(buildTourSteps(t), labels, {
+      onExit: () => useOnboardingStore.getState().exit(),
+    });
+    return () => handle.dispose();
+  }, [active, t]);
+
+  return null;
+}

--- a/frontend/src/onboarding/OnboardingTour.tsx
+++ b/frontend/src/onboarding/OnboardingTour.tsx
@@ -31,11 +31,14 @@ export function OnboardingTour() {
   // /app/settings、/app/assets 是无子路由的单页，前缀匹配会把 /app/settings/unknown
   // 这类 404 误判为主界面；/app/projects/:projectName 下 StudioCanvasRouter 的内层
   // <Switch> 同样没有兜底路由，未注册的子路径按 APP_PROJECT_WORKSPACE_PATTERN 精确匹配。
+  // wouter 底层 regexparam 大小写不敏感，这里统一转小写后再比对，避免大小写变体的
+  // 合法路径（wouter 能正常渲染）被本判断误判为不在主界面内。
+  const normalizedLocation = location.toLowerCase();
   const inMainUi =
     isAuthenticated &&
-    (location === "/" ||
-      (APP_TOP_LEVEL_ROUTES as readonly string[]).includes(location) ||
-      APP_PROJECT_WORKSPACE_PATTERN.test(location));
+    (normalizedLocation === "/" ||
+      (APP_TOP_LEVEL_ROUTES as readonly string[]).includes(normalizedLocation) ||
+      APP_PROJECT_WORKSPACE_PATTERN.test(normalizedLocation));
 
   // 1. 查询「是否已看过」
   useEffect(() => {

--- a/frontend/src/onboarding/OnboardingTour.tsx
+++ b/frontend/src/onboarding/OnboardingTour.tsx
@@ -18,6 +18,8 @@ import { useOnboardingStore } from "@/stores/onboarding-store";
 import { buildTourSteps } from "./steps";
 import { startTour, type TourLabels } from "./tour";
 
+const APP_TOP_LEVEL_ROUTES = ["/app", "/app/projects", "/app/settings", "/app/assets"];
+
 export function OnboardingTour() {
   const { t } = useTranslation("onboarding");
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
@@ -27,8 +29,14 @@ export function OnboardingTour() {
 
   // 只在已知应用路由内生效——未匹配路由（404）与 /login 一样不掺和，否则引导会
   // 在错链接 / 旧书签落地的 404 页自动弹出，且关闭时把全局 seen 标记写成已看过。
+  // 这份列表须跟 router.tsx 的顶层路由表保持一致：/app/settings、/app/assets 是无子路由
+  // 的单页，前缀匹配会把 /app/settings/unknown 这类 404 误判为主界面；只有
+  // /app/projects/:projectName 是 `nest` 路由，允许前缀匹配。
   const inMainUi =
-    isAuthenticated && (location === "/" || location === "/app" || location.startsWith("/app/"));
+    isAuthenticated &&
+    (location === "/" ||
+      APP_TOP_LEVEL_ROUTES.includes(location) ||
+      location.startsWith("/app/projects/"));
 
   // 1. 查询「是否已看过」
   useEffect(() => {

--- a/frontend/src/onboarding/steps.ts
+++ b/frontend/src/onboarding/steps.ts
@@ -1,0 +1,19 @@
+/**
+ * 首次使用引导的步骤大纲。
+ *
+ * 结构（顺序、锚点）写在这里，文案全部走 `onboarding` 命名空间的 i18n key —— 两者分离，
+ * 加语种不必碰结构，调顺序不必碰翻译。
+ *
+ * 当前是最小闭环：开场 + 收尾两步，都是居中气泡（`anchor: null`）。后续段落在中间插入
+ * 带锚点的步骤。
+ */
+
+import type { TFunction } from "i18next";
+import type { TourStep } from "./tour";
+
+export function buildTourSteps(t: TFunction<"onboarding">): TourStep[] {
+  return [
+    { anchor: null, title: t("welcome_title"), body: t("welcome_body") },
+    { anchor: null, title: t("finish_title"), body: t("finish_body") },
+  ];
+}

--- a/frontend/src/onboarding/tour.test.ts
+++ b/frontend/src/onboarding/tour.test.ts
@@ -154,4 +154,40 @@ describe("startTour", () => {
     expect(onExit).not.toHaveBeenCalled();
     expect(document.querySelector(".driver-popover")).toBeNull();
   });
+
+  describe("app root isolation", () => {
+    // driver.js 只挡 pointer-events + Tab 键，屏幕阅读器的虚拟光标仍能读到底层界面；
+    // #app-root 打 inert 把整棵子树从无障碍树摘除，才是真正的「全程只读」。
+    function withAppRoot(): HTMLElement {
+      const appRoot = document.createElement("div");
+      appRoot.id = "app-root";
+      document.body.appendChild(appRoot);
+      return appRoot;
+    }
+
+    it("marks #app-root inert while the tour is active, and clears it on close", () => {
+      const appRoot = withAppRoot();
+      const onExit = vi.fn();
+      startTour(TWO_STEPS, LABELS, { onExit });
+
+      expect(appRoot.inert).toBe(true);
+
+      click(".driver-popover-close-btn");
+
+      expect(appRoot.inert).toBe(false);
+      appRoot.remove();
+    });
+
+    it("clears #app-root inert when the caller disposes the tour", () => {
+      const appRoot = withAppRoot();
+      const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn() });
+
+      expect(appRoot.inert).toBe(true);
+
+      handle.dispose();
+
+      expect(appRoot.inert).toBe(false);
+      appRoot.remove();
+    });
+  });
 });

--- a/frontend/src/onboarding/tour.test.ts
+++ b/frontend/src/onboarding/tour.test.ts
@@ -155,9 +155,11 @@ describe("startTour", () => {
     expect(document.querySelector(".driver-popover")).toBeNull();
   });
 
-  describe("app root isolation", () => {
+  describe("peripheral isolation", () => {
     // driver.js 只挡 pointer-events + Tab 键，屏幕阅读器的虚拟光标仍能读到底层界面；
-    // #app-root 打 inert 把整棵子树从无障碍树摘除，才是真正的「全程只读」。
+    // body 的既有子节点（#app-root，以及 ModalShell/CreateProjectModal 这类直接
+    // createPortal 到 body、与 #app-root 是兄弟关系的对话框）打 inert 摘出无障碍树，
+    // 才是真正的「全程只读」。
     function withAppRoot(): HTMLElement {
       const appRoot = document.createElement("div");
       appRoot.id = "app-root";
@@ -188,6 +190,24 @@ describe("startTour", () => {
 
       expect(appRoot.inert).toBe(false);
       appRoot.remove();
+    });
+
+    it("also inerts a dialog already portaled to body when the tour starts, and clears it on dispose", () => {
+      const appRoot = withAppRoot();
+      // 模拟 ModalShell/CreateProjectModal 用 createPortal 挂到 body 的对话框——
+      // 是 #app-root 的兄弟节点，不在其子树内。
+      const modal = document.createElement("div");
+      document.body.appendChild(modal);
+
+      const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn() });
+
+      expect(modal.inert).toBe(true);
+
+      handle.dispose();
+
+      expect(modal.inert).toBe(false);
+      appRoot.remove();
+      modal.remove();
     });
   });
 });

--- a/frontend/src/onboarding/tour.test.ts
+++ b/frontend/src/onboarding/tour.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { anchorSelector, startTour, type TourLabels, type TourStep } from "./tour";
+import { anchorSelector, isOnboardingTourActive, startTour, type TourLabels, type TourStep } from "./tour";
 
 const LABELS: TourLabels = {
   next: "继续",
@@ -224,6 +224,19 @@ describe("startTour", () => {
       expect(modal.inert).toBe(false);
       appRoot.remove();
       modal.remove();
+    });
+
+    it("reports itself active only while the tour is up", () => {
+      const appRoot = withAppRoot();
+      expect(isOnboardingTourActive()).toBe(false);
+
+      const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn() });
+      expect(isOnboardingTourActive()).toBe(true);
+
+      handle.dispose();
+
+      expect(isOnboardingTourActive()).toBe(false);
+      appRoot.remove();
     });
   });
 });

--- a/frontend/src/onboarding/tour.test.ts
+++ b/frontend/src/onboarding/tour.test.ts
@@ -44,6 +44,23 @@ describe("startTour", () => {
     handle.dispose();
   });
 
+  it("opens at the requested step and reports where it stands", () => {
+    const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn(), startIndex: 1 });
+
+    expect(popover().querySelector(".driver-popover-title")?.textContent).toBe("轮到你了");
+    expect(handle.currentIndex()).toBe(1);
+
+    handle.dispose();
+  });
+
+  it("clamps an out-of-range start index onto the last step", () => {
+    const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn(), startIndex: 9 });
+
+    expect(handle.currentIndex()).toBe(1);
+
+    handle.dispose();
+  });
+
   it("uses the anchor's element when an anchor name is given", () => {
     const target = document.createElement("div");
     target.setAttribute("data-onboarding", "new-project");
@@ -135,6 +152,6 @@ describe("startTour", () => {
     handle.dispose();
 
     expect(onExit).not.toHaveBeenCalled();
-    expect(handle.isActive()).toBe(false);
+    expect(document.querySelector(".driver-popover")).toBeNull();
   });
 });

--- a/frontend/src/onboarding/tour.test.ts
+++ b/frontend/src/onboarding/tour.test.ts
@@ -192,6 +192,22 @@ describe("startTour", () => {
       appRoot.remove();
     });
 
+    it("restores a peripheral element's pre-existing inert state instead of forcing it false", () => {
+      const appRoot = withAppRoot();
+      const preInerted = document.createElement("div");
+      preInerted.inert = true;
+      document.body.appendChild(preInerted);
+
+      const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn() });
+      expect(preInerted.inert).toBe(true);
+
+      handle.dispose();
+
+      expect(preInerted.inert).toBe(true);
+      appRoot.remove();
+      preInerted.remove();
+    });
+
     it("also inerts a dialog already portaled to body when the tour starts, and clears it on dispose", () => {
       const appRoot = withAppRoot();
       // 模拟 ModalShell/CreateProjectModal 用 createPortal 挂到 body 的对话框——

--- a/frontend/src/onboarding/tour.test.ts
+++ b/frontend/src/onboarding/tour.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { anchorSelector, isOnboardingTourActive, startTour, type TourLabels, type TourStep } from "./tour";
+import { anchorSelector, startTour, type TourLabels, type TourStep } from "./tour";
 
 const LABELS: TourLabels = {
   next: "继续",
@@ -226,16 +226,37 @@ describe("startTour", () => {
       modal.remove();
     });
 
-    it("reports itself active only while the tour is up", () => {
+    it("suppresses a peripheral document keydown listener while the tour is active, and restores it on dispose", () => {
       const appRoot = withAppRoot();
-      expect(isOnboardingTourActive()).toBe(false);
+      const onKeyDown = vi.fn();
+      document.addEventListener("keydown", onKeyDown);
 
       const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn() });
-      expect(isOnboardingTourActive()).toBe(true);
+
+      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      expect(onKeyDown).not.toHaveBeenCalled();
 
       handle.dispose();
 
-      expect(isOnboardingTourActive()).toBe(false);
+      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+
+      document.removeEventListener("keydown", onKeyDown);
+      appRoot.remove();
+    });
+
+    it("does not suppress Tab so driver's own focus trap keeps working", () => {
+      const appRoot = withAppRoot();
+      const onKeyDown = vi.fn();
+      document.addEventListener("keydown", onKeyDown);
+
+      const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn() });
+
+      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+
+      handle.dispose();
+      document.removeEventListener("keydown", onKeyDown);
       appRoot.remove();
     });
   });

--- a/frontend/src/onboarding/tour.test.ts
+++ b/frontend/src/onboarding/tour.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import { anchorSelector, startTour, type TourLabels, type TourStep } from "./tour";
+
+const LABELS: TourLabels = {
+  next: "继续",
+  prev: "上一步",
+  done: "完成",
+  skip: "跳过",
+  close: "关闭引导",
+  progress: (current, total) => `第 ${current} 步，共 ${total} 步`,
+};
+
+const TWO_STEPS: TourStep[] = [
+  { anchor: null, title: "欢迎", body: "开场" },
+  { anchor: null, title: "轮到你了", body: "收尾" },
+];
+
+function popover(): HTMLElement {
+  const el = document.querySelector<HTMLElement>(".driver-popover");
+  if (!el) throw new Error("popover not rendered");
+  return el;
+}
+
+function click(selector: string): void {
+  const el = popover().querySelector<HTMLElement>(selector);
+  if (!el) throw new Error(`${selector} not found`);
+  el.click();
+}
+
+describe("anchorSelector", () => {
+  it("maps an anchor name to its data-onboarding selector", () => {
+    expect(anchorSelector("new-project")).toBe('[data-onboarding="new-project"]');
+  });
+});
+
+describe("startTour", () => {
+  it("renders a centered popover with no highlighted element for anchor: null", () => {
+    const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn() });
+
+    expect(popover().querySelector(".driver-popover-title")?.textContent).toBe("欢迎");
+    // 页面上没有任何真实元素被高亮 —— driver 顶上的是自己的占位元素，气泡因此居中
+    expect(document.querySelector(".driver-active-element")?.id).toBe("driver-dummy-element");
+
+    handle.dispose();
+  });
+
+  it("uses the anchor's element when an anchor name is given", () => {
+    const target = document.createElement("div");
+    target.setAttribute("data-onboarding", "new-project");
+    document.body.appendChild(target);
+
+    const handle = startTour([{ anchor: "new-project", title: "入口", body: "在这里新建" }], LABELS, {
+      onExit: vi.fn(),
+    });
+
+    expect(target.classList.contains("driver-active-element")).toBe(true);
+
+    handle.dispose();
+    target.remove();
+  });
+
+  it("renders one filmstrip cell per step, filled up to the current step", () => {
+    const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn() });
+
+    const cells = () => Array.from(popover().querySelectorAll<HTMLElement>(".arc-tour-filmstrip span"));
+    expect(cells().map((c) => c.dataset.on)).toEqual(["1", "0"]);
+
+    click(".driver-popover-next-btn");
+    expect(cells().map((c) => c.dataset.on)).toEqual(["1", "1"]);
+
+    handle.dispose();
+  });
+
+  it("states the step position in text for screen readers", () => {
+    const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn() });
+
+    expect(popover().querySelector(".arc-tour-sr-only")?.textContent).toBe("第 1 步，共 2 步");
+
+    handle.dispose();
+  });
+
+  it("labels the close button", () => {
+    const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn() });
+
+    expect(popover().querySelector(".driver-popover-close-btn")?.getAttribute("aria-label")).toBe("关闭引导");
+
+    handle.dispose();
+  });
+
+  it("offers skip on every step but the last", () => {
+    const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn() });
+
+    expect(popover().querySelector(".arc-tour-skip-btn")?.textContent).toBe("跳过");
+
+    click(".driver-popover-next-btn");
+    expect(popover().querySelector(".arc-tour-skip-btn")).toBeNull();
+
+    handle.dispose();
+  });
+
+  it("reports the exit once when the tour is skipped", () => {
+    const onExit = vi.fn();
+    startTour(TWO_STEPS, LABELS, { onExit });
+
+    click(".arc-tour-skip-btn");
+
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(document.querySelector(".driver-popover")).toBeNull();
+  });
+
+  it("reports the exit once when the tour is closed", () => {
+    const onExit = vi.fn();
+    startTour(TWO_STEPS, LABELS, { onExit });
+
+    click(".driver-popover-close-btn");
+
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the exit once when the tour is played to the end", () => {
+    const onExit = vi.fn();
+    startTour(TWO_STEPS, LABELS, { onExit });
+
+    click(".driver-popover-next-btn");
+    click(".driver-popover-next-btn");
+
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(document.querySelector(".driver-popover")).toBeNull();
+  });
+
+  it("does not report an exit when the caller disposes the tour", () => {
+    const onExit = vi.fn();
+    const handle = startTour(TWO_STEPS, LABELS, { onExit });
+
+    handle.dispose();
+
+    expect(onExit).not.toHaveBeenCalled();
+    expect(handle.isActive()).toBe(false);
+  });
+});

--- a/frontend/src/onboarding/tour.ts
+++ b/frontend/src/onboarding/tour.ts
@@ -55,20 +55,18 @@ export function anchorSelector(anchor: string): string {
  * （在随后的 `instance.drive()` 里才挂上），因此不会误伤 driver 自身。
  */
 let peripheralElements: Array<[element: HTMLElement, wasInert: boolean]> = [];
-let tourActive = false;
 
 /**
- * 引导是否正在进行中。`inert` 只摘除无障碍树，不注销底层弹窗自己挂在 `document`/
- * `window` 上的全局键盘监听（如 `useEscapeClose`）——那些监听不看谁在无障碍树里，
- * 照样会在按 Esc 时把弹窗关掉，和 driver 自己的 Esc 退出流程互相打架。这些全局
- * 处理器改为查询这里，引导期间让位。
+ * `inert` 摘不掉底层弹窗自己挂在 `document`/`window` 上的全局键盘监听——Esc 关闭、
+ * Enter 提交（如 `ApiKeysTab` 的「新建 API Key」弹窗）这类监听不看谁在无障碍树里，
+ * 引导期间照样会被触发，在遮罩后台悄悄关弹窗、甚至提交表单。逐个让每个监听器自行
+ * 判断引导状态属于挂一漏万，这里改为统一拦截：引导激活期间在 document 的捕获阶段
+ * 拦下所有 `keydown`（`Tab` 除外，放行给 driver 自己的焦点陷阱）。driver 自己的
+ * Esc/方向键处理挂在 `keyup` 而非 `keydown`，不受影响。
  */
-export function isOnboardingTourActive(): boolean {
-  return tourActive;
-}
+let suspendKeyboard: (() => void) | null = null;
 
-function setPeripheralInert(hidden: boolean): void {
-  tourActive = hidden;
+function setPeripheralIsolation(hidden: boolean): void {
   if (hidden) {
     peripheralElements = Array.from(document.body.children)
       .filter((el): el is HTMLElement => el instanceof HTMLElement)
@@ -76,11 +74,20 @@ function setPeripheralInert(hidden: boolean): void {
     peripheralElements.forEach(([el]) => {
       el.inert = true;
     });
+
+    const onKeyDownCapture = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") e.stopPropagation();
+    };
+    document.addEventListener("keydown", onKeyDownCapture, true);
+    suspendKeyboard = () => document.removeEventListener("keydown", onKeyDownCapture, true);
   } else {
     peripheralElements.forEach(([el, wasInert]) => {
       el.inert = wasInert;
     });
     peripheralElements = [];
+
+    suspendKeyboard?.();
+    suspendKeyboard = null;
   }
 }
 
@@ -166,18 +173,18 @@ export function startTour(
       exited = true;
       onExit();
     }
-    setPeripheralInert(false);
+    setPeripheralIsolation(false);
     instance.destroy();
   }
 
-  setPeripheralInert(true);
+  setPeripheralIsolation(true);
   instance.drive(Math.min(Math.max(startIndex, 0), total - 1));
 
   return {
     currentIndex: () => instance.getActiveIndex() ?? 0,
     dispose: () => {
       disposing = true;
-      setPeripheralInert(false);
+      setPeripheralIsolation(false);
       instance.destroy();
     },
   };

--- a/frontend/src/onboarding/tour.ts
+++ b/frontend/src/onboarding/tour.ts
@@ -55,8 +55,20 @@ export function anchorSelector(anchor: string): string {
  * （在随后的 `instance.drive()` 里才挂上），因此不会误伤 driver 自身。
  */
 let peripheralElements: Array<[element: HTMLElement, wasInert: boolean]> = [];
+let tourActive = false;
+
+/**
+ * 引导是否正在进行中。`inert` 只摘除无障碍树，不注销底层弹窗自己挂在 `document`/
+ * `window` 上的全局键盘监听（如 `useEscapeClose`）——那些监听不看谁在无障碍树里，
+ * 照样会在按 Esc 时把弹窗关掉，和 driver 自己的 Esc 退出流程互相打架。这些全局
+ * 处理器改为查询这里，引导期间让位。
+ */
+export function isOnboardingTourActive(): boolean {
+  return tourActive;
+}
 
 function setPeripheralInert(hidden: boolean): void {
+  tourActive = hidden;
   if (hidden) {
     peripheralElements = Array.from(document.body.children)
       .filter((el): el is HTMLElement => el instanceof HTMLElement)

--- a/frontend/src/onboarding/tour.ts
+++ b/frontend/src/onboarding/tour.ts
@@ -29,7 +29,8 @@ export interface TourLabels {
 }
 
 export interface TourHandle {
-  isActive: () => boolean;
+  /** 当前停在第几步（0 基）。用于重建时接着讲，而不是退回开头。 */
+  currentIndex: () => number;
   /** 主动收起（组件卸载等）。不触发 onExit。 */
   dispose: () => void;
 }
@@ -66,11 +67,12 @@ function renderProgress(progress: HTMLElement, current: number, total: number, l
  * 启动引导。
  *
  * @param onExit 任一退出路径（跳过 / 关闭 / 走完）都会调用一次；`dispose()` 不调用。
+ * @param startIndex 从第几步开始（0 基）。默认 0；重建时传入上一次的 `currentIndex()`。
  */
 export function startTour(
   steps: TourStep[],
   labels: TourLabels,
-  { onExit }: { onExit: () => void },
+  { onExit, startIndex = 0 }: { onExit: () => void; startIndex?: number },
 ): TourHandle {
   const total = steps.length;
   let exited = false;
@@ -125,10 +127,10 @@ export function startTour(
     instance.destroy();
   }
 
-  instance.drive();
+  instance.drive(Math.min(Math.max(startIndex, 0), total - 1));
 
   return {
-    isActive: () => instance.isActive(),
+    currentIndex: () => instance.getActiveIndex() ?? 0,
     dispose: () => {
       disposing = true;
       instance.destroy();

--- a/frontend/src/onboarding/tour.ts
+++ b/frontend/src/onboarding/tour.ts
@@ -45,13 +45,31 @@ export function anchorSelector(anchor: string): string {
 /**
  * driver.js 只用 `pointer-events: none` 和一个仅拦截 Tab 键的焦点陷阱隔离底层界面，
  * 不触及无障碍树——屏幕阅读器的虚拟光标导航能绕开这两者，在引导期间直接读到并激活
- * 底层工作台的控件。这里显式给 `#app-root`（挂载点见 main.tsx）打 `inert`，把整棵子树
- * 从无障碍树摘除，引导退出时复原。driver 自身的遮罩与气泡挂在 body 上、是 `#app-root`
- * 的兄弟节点，不受影响。
+ * 底层工作台的控件。这里显式给 body 的既有子节点打 `inert`，把它们从无障碍树摘除，
+ * 引导退出时复原。
+ *
+ * 不止 `#app-root`（挂载点见 main.tsx）：`ModalShell`/`CreateProjectModal` 等对话框
+ * 用 `createPortal` 直接挂到 `document.body`，是 `#app-root` 的兄弟节点而非子孙，只
+ * 打 `#app-root` 的 inert 罩不住"引导启动时已有弹窗开着"这种情形。这里改为在调用
+ * 时刻快照 body 的直接子节点、逐个打 inert——此刻 driver 自己的遮罩与气泡还没创建
+ * （在随后的 `instance.drive()` 里才挂上），因此不会误伤 driver 自身。
  */
-function setAppRootInert(hidden: boolean): void {
-  const appRoot = document.getElementById("app-root");
-  if (appRoot) appRoot.inert = hidden;
+let peripheralElements: HTMLElement[] = [];
+
+function setPeripheralInert(hidden: boolean): void {
+  if (hidden) {
+    peripheralElements = Array.from(document.body.children).filter(
+      (el): el is HTMLElement => el instanceof HTMLElement,
+    );
+    peripheralElements.forEach((el) => {
+      el.inert = true;
+    });
+  } else {
+    peripheralElements.forEach((el) => {
+      el.inert = false;
+    });
+    peripheralElements = [];
+  }
 }
 
 /** 进度齿孔轨道 —— 装饰，语义由同级的 sr-only 文本承载 */
@@ -136,18 +154,18 @@ export function startTour(
       exited = true;
       onExit();
     }
-    setAppRootInert(false);
+    setPeripheralInert(false);
     instance.destroy();
   }
 
-  setAppRootInert(true);
+  setPeripheralInert(true);
   instance.drive(Math.min(Math.max(startIndex, 0), total - 1));
 
   return {
     currentIndex: () => instance.getActiveIndex() ?? 0,
     dispose: () => {
       disposing = true;
-      setAppRootInert(false);
+      setPeripheralInert(false);
       instance.destroy();
     },
   };

--- a/frontend/src/onboarding/tour.ts
+++ b/frontend/src/onboarding/tour.ts
@@ -42,6 +42,18 @@ export function anchorSelector(anchor: string): string {
   return `[data-onboarding="${anchor}"]`;
 }
 
+/**
+ * driver.js 只用 `pointer-events: none` 和一个仅拦截 Tab 键的焦点陷阱隔离底层界面，
+ * 不触及无障碍树——屏幕阅读器的虚拟光标导航能绕开这两者，在引导期间直接读到并激活
+ * 底层工作台的控件。这里显式给 `#app-root`（挂载点见 main.tsx）打 `inert`，把整棵子树
+ * 从无障碍树摘除，引导退出时复原。driver 自身的遮罩与气泡挂在 body 上、是 `#app-root`
+ * 的兄弟节点，不受影响。
+ */
+function setAppRootInert(hidden: boolean): void {
+  const appRoot = document.getElementById("app-root");
+  if (appRoot) appRoot.inert = hidden;
+}
+
 /** 进度齿孔轨道 —— 装饰，语义由同级的 sr-only 文本承载 */
 function renderProgress(progress: HTMLElement, current: number, total: number, label: string): void {
   progress.replaceChildren();
@@ -124,15 +136,18 @@ export function startTour(
       exited = true;
       onExit();
     }
+    setAppRootInert(false);
     instance.destroy();
   }
 
+  setAppRootInert(true);
   instance.drive(Math.min(Math.max(startIndex, 0), total - 1));
 
   return {
     currentIndex: () => instance.getActiveIndex() ?? 0,
     dispose: () => {
       disposing = true;
+      setAppRootInert(false);
       instance.destroy();
     },
   };

--- a/frontend/src/onboarding/tour.ts
+++ b/frontend/src/onboarding/tour.ts
@@ -1,0 +1,150 @@
+/**
+ * driver.js 薄适配层。
+ *
+ * 存在的理由是把「引导步骤」这个业务概念与 driver.js 的 API 隔开：步骤只描述锚点名和
+ * 文案，锚点→选择器的映射、按钮文案、皮肤、退出路径收口都在这里一次性给定。后续段落
+ * 新增步骤时只写 TourStep，不碰 driver 配置。
+ *
+ * 锚点约定：`anchor` 为锚点名时映射到 `[data-onboarding="<名字>"]`；为 null 时该步不
+ * 高亮任何元素，driver 渲染居中气泡（开场与收尾用这个形态）。
+ */
+
+import { driver, type Driver, type DriveStep, type PopoverDOM } from "driver.js";
+
+export interface TourStep {
+  /** 锚点名 → `[data-onboarding="…"]`；null = 居中气泡，不高亮元素 */
+  anchor: string | null;
+  title: string;
+  body: string;
+}
+
+export interface TourLabels {
+  next: string;
+  prev: string;
+  done: string;
+  skip: string;
+  close: string;
+  /** 进度的无障碍文本，如「第 1 步，共 2 步」 */
+  progress: (current: number, total: number) => string;
+}
+
+export interface TourHandle {
+  isActive: () => boolean;
+  /** 主动收起（组件卸载等）。不触发 onExit。 */
+  dispose: () => void;
+}
+
+/** 遮罩墨色 —— body 背景同色系的冷紫墨，而不是 driver 默认纯黑 */
+const OVERLAY_INK = "oklch(0.10 0.012 265)";
+
+export function anchorSelector(anchor: string): string {
+  return `[data-onboarding="${anchor}"]`;
+}
+
+/** 进度齿孔轨道 —— 装饰，语义由同级的 sr-only 文本承载 */
+function renderProgress(progress: HTMLElement, current: number, total: number, label: string): void {
+  progress.replaceChildren();
+
+  const strip = document.createElement("span");
+  strip.className = "arc-tour-filmstrip";
+  strip.setAttribute("aria-hidden", "true");
+  for (let i = 0; i < total; i += 1) {
+    const cell = document.createElement("span");
+    cell.dataset.on = i <= current ? "1" : "0";
+    strip.appendChild(cell);
+  }
+
+  const sr = document.createElement("span");
+  sr.className = "arc-tour-sr-only";
+  sr.textContent = label;
+
+  progress.appendChild(strip);
+  progress.appendChild(sr);
+}
+
+/**
+ * 启动引导。
+ *
+ * @param onExit 任一退出路径（跳过 / 关闭 / 走完）都会调用一次；`dispose()` 不调用。
+ */
+export function startTour(
+  steps: TourStep[],
+  labels: TourLabels,
+  { onExit }: { onExit: () => void },
+): TourHandle {
+  const total = steps.length;
+  let exited = false;
+  let disposing = false;
+
+  const driveSteps: DriveStep[] = steps.map((step) => ({
+    ...(step.anchor === null ? {} : { element: anchorSelector(step.anchor) }),
+    popover: { title: step.title, description: step.body },
+  }));
+
+  const instance: Driver = driver({
+    steps: driveSteps,
+    popoverClass: "arc-tour",
+    overlayColor: OVERLAY_INK,
+    overlayOpacity: 0.78,
+    stagePadding: 8,
+    stageRadius: 10,
+    // 全程只读：driver 的 `.driver-active *{pointer-events:none}` 已经封死了底层界面，
+    // 这里再关掉高亮元素本身的交互，杜绝"讲到哪就能点到哪"意外触发生成动作。
+    disableActiveInteraction: true,
+    showProgress: true,
+    showButtons: ["next", "previous", "close"],
+    nextBtnText: labels.next,
+    prevBtnText: labels.prev,
+    doneBtnText: labels.done,
+    onPopoverRender: (popover: PopoverDOM) => {
+      const current = instance.getActiveIndex() ?? 0;
+      popover.closeButton.setAttribute("aria-label", labels.close);
+      renderProgress(popover.progress, current, total, labels.progress(current + 1, total));
+      decorateSkip(popover, instance.isLastStep(), labels.skip);
+    },
+    // 退出全部收口到这里，而不是 driver 的 onDestroyed。后者只在 driver 内部把高亮元素
+    // 写进 state 之后才会触发，而那次写入排在 requestAnimationFrame 里 —— 同步 destroy
+    // 与无 DOM 帧的环境下会静默漏掉回调。改走「按钮 + 主动收起」这两个我们自己掌握的
+    // 入口，退出必然被记一次。
+    onNextClick: () => {
+      if (instance.isLastStep()) finish();
+      else instance.moveNext();
+    },
+    onPrevClick: () => instance.movePrevious(),
+    onCloseClick: () => finish(),
+    // Esc 与点击遮罩走 driver 内部的收起流程，在真正拆掉之前回调这里。
+    onDestroyStarted: () => finish(),
+  });
+
+  /** 记一次退出并收起。重复调用只记一次。 */
+  function finish(): void {
+    if (!exited && !disposing) {
+      exited = true;
+      onExit();
+    }
+    instance.destroy();
+  }
+
+  instance.drive();
+
+  return {
+    isActive: () => instance.isActive(),
+    dispose: () => {
+      disposing = true;
+      instance.destroy();
+    },
+  };
+}
+
+/** 「跳过」按钮 —— 最后一步没有可跳过的内容，只留「完成」 */
+function decorateSkip(popover: PopoverDOM, isLastStep: boolean, label: string): void {
+  popover.footer.querySelector(".arc-tour-skip-btn")?.remove();
+  if (isLastStep) return;
+
+  const skip = document.createElement("button");
+  skip.type = "button";
+  skip.className = "driver-popover-footer-btn arc-tour-skip-btn";
+  skip.textContent = label;
+  skip.addEventListener("click", () => popover.closeButton.click());
+  popover.footer.insertBefore(skip, popover.footerButtons);
+}

--- a/frontend/src/onboarding/tour.ts
+++ b/frontend/src/onboarding/tour.ts
@@ -54,19 +54,19 @@ export function anchorSelector(anchor: string): string {
  * 时刻快照 body 的直接子节点、逐个打 inert——此刻 driver 自己的遮罩与气泡还没创建
  * （在随后的 `instance.drive()` 里才挂上），因此不会误伤 driver 自身。
  */
-let peripheralElements: HTMLElement[] = [];
+let peripheralElements: Array<[element: HTMLElement, wasInert: boolean]> = [];
 
 function setPeripheralInert(hidden: boolean): void {
   if (hidden) {
-    peripheralElements = Array.from(document.body.children).filter(
-      (el): el is HTMLElement => el instanceof HTMLElement,
-    );
-    peripheralElements.forEach((el) => {
+    peripheralElements = Array.from(document.body.children)
+      .filter((el): el is HTMLElement => el instanceof HTMLElement)
+      .map((el) => [el, Boolean(el.inert)]);
+    peripheralElements.forEach(([el]) => {
       el.inert = true;
     });
   } else {
-    peripheralElements.forEach((el) => {
-      el.inert = false;
+    peripheralElements.forEach(([el, wasInert]) => {
+      el.inert = wasInert;
     });
     peripheralElements = [];
   }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -19,7 +19,13 @@ import { useProjectsStore } from "@/stores/projects-store";
 import { useAssistantStore } from "@/stores/assistant-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
-import { ROUTE_APP, ROUTE_APP_ASSETS, ROUTE_APP_PROJECTS, ROUTE_APP_SETTINGS } from "@/app-routes";
+import {
+  ROUTE_APP,
+  ROUTE_APP_ASSETS,
+  ROUTE_APP_PROJECTS,
+  ROUTE_APP_SETTINGS,
+  WORKSPACE_ROUTE_SETTINGS,
+} from "@/app-routes";
 
 // ---------------------------------------------------------------------------
 // ConfigStatusLoader — 登录后集中拉取一次配置完整性状态
@@ -186,7 +192,7 @@ export function AppRoutes() {
         </Route>
 
         {/* Project settings — full-screen, must be before the nested workspace route */}
-        <Route path={`${ROUTE_APP_PROJECTS}/:projectName/settings`}>
+        <Route path={`${ROUTE_APP_PROJECTS}/:projectName/${WORKSPACE_ROUTE_SETTINGS}`}>
           <AuthGuard>
             <ProjectSettingsPage />
           </AuthGuard>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -19,6 +19,7 @@ import { useProjectsStore } from "@/stores/projects-store";
 import { useAssistantStore } from "@/stores/assistant-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
+import { ROUTE_APP, ROUTE_APP_ASSETS, ROUTE_APP_PROJECTS, ROUTE_APP_SETTINGS } from "@/app-routes";
 
 // ---------------------------------------------------------------------------
 // ConfigStatusLoader — 登录后集中拉取一次配置完整性状态
@@ -159,40 +160,40 @@ export function AppRoutes() {
         </Route>
 
         {/* /app and /app/ also redirect to projects list */}
-        <Route path="/app">
-          <Redirect to="/app/projects" />
+        <Route path={ROUTE_APP}>
+          <Redirect to={ROUTE_APP_PROJECTS} />
         </Route>
 
         {/* Projects list */}
-        <Route path="/app/projects">
+        <Route path={ROUTE_APP_PROJECTS}>
           <AuthGuard>
             <ProjectsPage />
           </AuthGuard>
         </Route>
 
         {/* System settings */}
-        <Route path="/app/settings">
+        <Route path={ROUTE_APP_SETTINGS}>
           <AuthGuard>
             <SystemConfigPage />
           </AuthGuard>
         </Route>
 
         {/* Asset library */}
-        <Route path="/app/assets">
+        <Route path={ROUTE_APP_ASSETS}>
           <AuthGuard>
             <AssetLibraryPage />
           </AuthGuard>
         </Route>
 
         {/* Project settings — full-screen, must be before the nested workspace route */}
-        <Route path="/app/projects/:projectName/settings">
+        <Route path={`${ROUTE_APP_PROJECTS}/:projectName/settings`}>
           <AuthGuard>
             <ProjectSettingsPage />
           </AuthGuard>
         </Route>
 
         {/* Studio workspace (three-column layout) */}
-        <Route path="/app/projects/:projectName" nest>
+        <Route path={`${ROUTE_APP_PROJECTS}/:projectName`} nest>
           <AuthGuard>
             <StudioWorkspace />
           </AuthGuard>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -13,6 +13,7 @@ import { AssetLibraryPage } from "@/components/pages/AssetLibraryPage";
 import { LoginPage } from "@/pages/LoginPage";
 import { NotFoundPage } from "@/pages/NotFoundPage";
 import { ToastOverlay } from "@/components/layout/ToastOverlay";
+import { OnboardingTour } from "@/onboarding/OnboardingTour";
 import { API } from "@/api";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useAssistantStore } from "@/stores/assistant-store";
@@ -147,6 +148,7 @@ export function AppRoutes() {
   return (
     <>
       <ConfigStatusLoader />
+      <OnboardingTour />
       <Switch>
         {/* Login page */}
         <Route path="/login" component={LoginPage} />

--- a/frontend/src/stores/onboarding-store.test.ts
+++ b/frontend/src/stores/onboarding-store.test.ts
@@ -37,6 +37,21 @@ describe("useOnboardingStore", () => {
       expect(useOnboardingStore.getState().seen).toBeNull();
     });
 
+    it("still writes the flag on replay when the earlier suppression was only a fetch failure", async () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      vi.spyOn(API, "getOnboardingStatus").mockRejectedValue(new Error("offline"));
+      const markSeen = vi.spyOn(API, "markOnboardingSeen").mockResolvedValue({ seen: true });
+
+      await useOnboardingStore.getState().loadStatus();
+      expect(useOnboardingStore.getState().seen).toBe(true);
+
+      // 后端此时可能已经恢复；本地 seen:true 只是本次会话的临时抑制，不是确认。
+      useOnboardingStore.getState().start();
+      useOnboardingStore.getState().exit();
+
+      await vi.waitFor(() => expect(markSeen).toHaveBeenCalledTimes(1));
+    });
+
     it("does not let a slow response undo an exit that already completed", async () => {
       let resolveStatus: (value: { seen: boolean }) => void;
       vi.spyOn(API, "getOnboardingStatus").mockReturnValue(
@@ -80,7 +95,7 @@ describe("useOnboardingStore", () => {
 
     it("writes nothing when the tour is replayed", async () => {
       const markSeen = vi.spyOn(API, "markOnboardingSeen").mockResolvedValue({ seen: true });
-      useOnboardingStore.setState({ seen: true });
+      useOnboardingStore.setState({ seen: true, seenConfirmed: true });
       useOnboardingStore.getState().start();
 
       useOnboardingStore.getState().exit();

--- a/frontend/src/stores/onboarding-store.test.ts
+++ b/frontend/src/stores/onboarding-store.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { API } from "@/api";
+import { useOnboardingStore } from "./onboarding-store";
+
+describe("useOnboardingStore", () => {
+  beforeEach(() => {
+    useOnboardingStore.setState(useOnboardingStore.getInitialState(), true);
+    vi.restoreAllMocks();
+  });
+
+  describe("loadStatus", () => {
+    it("records the flag returned by the backend", async () => {
+      vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+
+      await useOnboardingStore.getState().loadStatus();
+
+      expect(useOnboardingStore.getState().seen).toBe(false);
+    });
+
+    it("treats a failed lookup as already seen so nothing pops up", async () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      vi.spyOn(API, "getOnboardingStatus").mockRejectedValue(new Error("offline"));
+
+      await useOnboardingStore.getState().loadStatus();
+
+      expect(useOnboardingStore.getState().seen).toBe(true);
+    });
+
+    it("drops a response that arrives after its signal was aborted", async () => {
+      vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+      const controller = new AbortController();
+
+      const pending = useOnboardingStore.getState().loadStatus({ signal: controller.signal });
+      controller.abort();
+      await pending;
+
+      expect(useOnboardingStore.getState().seen).toBeNull();
+    });
+  });
+
+  describe("start", () => {
+    it("opens the tour", () => {
+      useOnboardingStore.getState().start();
+
+      expect(useOnboardingStore.getState().active).toBe(true);
+    });
+  });
+
+  describe("exit", () => {
+    it("marks the tour as seen on the first exit", async () => {
+      const markSeen = vi.spyOn(API, "markOnboardingSeen").mockResolvedValue({ seen: true });
+      useOnboardingStore.setState({ seen: false });
+      useOnboardingStore.getState().start();
+
+      useOnboardingStore.getState().exit();
+      await vi.waitFor(() => expect(markSeen).toHaveBeenCalledTimes(1));
+
+      expect(useOnboardingStore.getState()).toMatchObject({ active: false, seen: true });
+    });
+
+    it("writes nothing when the tour is replayed", async () => {
+      const markSeen = vi.spyOn(API, "markOnboardingSeen").mockResolvedValue({ seen: true });
+      useOnboardingStore.setState({ seen: true });
+      useOnboardingStore.getState().start();
+
+      useOnboardingStore.getState().exit();
+      await Promise.resolve();
+
+      expect(markSeen).not.toHaveBeenCalled();
+      expect(useOnboardingStore.getState().seen).toBe(true);
+    });
+
+    it("ignores an exit when no tour is running", () => {
+      const markSeen = vi.spyOn(API, "markOnboardingSeen").mockResolvedValue({ seen: true });
+      useOnboardingStore.setState({ seen: false });
+
+      useOnboardingStore.getState().exit();
+
+      expect(markSeen).not.toHaveBeenCalled();
+    });
+
+    it("keeps the tour closed when marking it seen fails", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      vi.spyOn(API, "markOnboardingSeen").mockRejectedValue(new Error("offline"));
+      useOnboardingStore.setState({ seen: false });
+      useOnboardingStore.getState().start();
+
+      useOnboardingStore.getState().exit();
+      await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+
+      expect(useOnboardingStore.getState().active).toBe(false);
+    });
+  });
+});

--- a/frontend/src/stores/onboarding-store.test.ts
+++ b/frontend/src/stores/onboarding-store.test.ts
@@ -36,6 +36,26 @@ describe("useOnboardingStore", () => {
 
       expect(useOnboardingStore.getState().seen).toBeNull();
     });
+
+    it("does not let a slow response undo an exit that already completed", async () => {
+      let resolveStatus: (value: { seen: boolean }) => void;
+      vi.spyOn(API, "getOnboardingStatus").mockReturnValue(
+        new Promise((resolve) => {
+          resolveStatus = resolve;
+        }),
+      );
+      vi.spyOn(API, "markOnboardingSeen").mockResolvedValue({ seen: true });
+
+      const pending = useOnboardingStore.getState().loadStatus();
+      // 查询飞行途中，用户从设置页启动重看并立即退出——本地已确立 seen: true。
+      useOnboardingStore.getState().start();
+      useOnboardingStore.getState().exit();
+
+      resolveStatus!({ seen: false });
+      await pending;
+
+      expect(useOnboardingStore.getState().seen).toBe(true);
+    });
   });
 
   describe("start", () => {

--- a/frontend/src/stores/onboarding-store.ts
+++ b/frontend/src/stores/onboarding-store.ts
@@ -4,6 +4,12 @@ import { API } from "@/api";
 interface OnboardingState {
   /** 后端「已看过」标记；null = 尚未查询 */
   seen: boolean | null;
+  /**
+   * `seen: true` 是否已被后端确认过(GET 返回过 true，或 POST 成功过)。
+   * 查询失败时也会把 `seen` 置真用于本次抑制自动弹出，但那不算确认——
+   * 靠这个字段把两种「true」的含义分开，避免 `exit()` 把前者误判成不必再写。
+   */
+  seenConfirmed: boolean;
   /** 引导是否正在运行 */
   active: boolean;
   /** 拉取「是否已看过」。失败时按已看过处置，宁可不弹也不误弹。 */
@@ -16,6 +22,7 @@ interface OnboardingState {
 
 export const useOnboardingStore = create<OnboardingState>((set, get) => ({
   seen: null,
+  seenConfirmed: false,
   active: false,
 
   loadStatus: async (options = {}) => {
@@ -23,12 +30,13 @@ export const useOnboardingStore = create<OnboardingState>((set, get) => ({
       const { seen } = await API.getOnboardingStatus({ signal: options.signal });
       if (options.signal?.aborted) return;
       // 迟到的查询结果不得回退已确立的「已看过」——用户可能在这次查询飞行途中
-      // 已经跑完并退出过一轮引导（本地 exit() 早已写入 seen: true）。
+      // 已经跑完并退出过一轮引导(本地 exit() 早已写入 seen: true)。
       if (get().seen === true) return;
-      set({ seen });
+      set({ seen, seenConfirmed: seen });
     } catch (err) {
       if (options.signal?.aborted) return;
-      // 后端抖动时不该给老用户重复弹引导。仅抑制本次会话，刷新后重新判定。
+      // 后端抖动时不该给老用户重复弹引导。仅抑制本次会话，刷新后重新判定；
+      // 不算后端确认，后续 exit() 仍要真正写一次。
       console.warn("[onboarding] status fetch failed; suppressing auto-start", err);
       set({ seen: true });
     }
@@ -40,14 +48,16 @@ export const useOnboardingStore = create<OnboardingState>((set, get) => ({
   },
 
   exit: () => {
-    const { active, seen } = get();
+    const { active, seenConfirmed } = get();
     if (!active) return;
     set({ active: false, seen: true });
-    // 重看路径上 flag 已是「已看过」，再写一次没有意义 —— 引导全程只允许这一个写操作，
-    // 能省则省。
-    if (seen === true) return;
-    void API.markOnboardingSeen().catch((err) => {
-      console.warn("[onboarding] failed to mark tour as seen", err);
-    });
+    // 后端已确认过「已看过」时再写一次没有意义 —— 引导全程只允许这一个写操作，
+    // 能省则省。查询失败导致的本地临时抑制不算确认，仍要写。
+    if (seenConfirmed) return;
+    void API.markOnboardingSeen()
+      .then(() => set({ seenConfirmed: true }))
+      .catch((err) => {
+        console.warn("[onboarding] failed to mark tour as seen", err);
+      });
   },
 }));

--- a/frontend/src/stores/onboarding-store.ts
+++ b/frontend/src/stores/onboarding-store.ts
@@ -1,0 +1,50 @@
+import { create } from "zustand";
+import { API } from "@/api";
+
+interface OnboardingState {
+  /** 后端「已看过」标记；null = 尚未查询 */
+  seen: boolean | null;
+  /** 引导是否正在运行 */
+  active: boolean;
+  /** 拉取「是否已看过」。失败时按已看过处置，宁可不弹也不误弹。 */
+  loadStatus: (options?: { signal?: AbortSignal }) => Promise<void>;
+  /** 打开引导。自动首弹与「重看引导」共用这一条路径。 */
+  start: () => void;
+  /** 任一退出路径（跳过 / 关闭 / 走完）。首次退出时标记已看；重看不重复写。 */
+  exit: () => void;
+}
+
+export const useOnboardingStore = create<OnboardingState>((set, get) => ({
+  seen: null,
+  active: false,
+
+  loadStatus: async (options = {}) => {
+    try {
+      const { seen } = await API.getOnboardingStatus({ signal: options.signal });
+      if (options.signal?.aborted) return;
+      set({ seen });
+    } catch (err) {
+      if (options.signal?.aborted) return;
+      // 后端抖动时不该给老用户重复弹引导。仅抑制本次会话，刷新后重新判定。
+      console.warn("[onboarding] status fetch failed; suppressing auto-start", err);
+      set({ seen: true });
+    }
+  },
+
+  start: () => {
+    if (get().active) return;
+    set({ active: true });
+  },
+
+  exit: () => {
+    const { active, seen } = get();
+    if (!active) return;
+    set({ active: false, seen: true });
+    // 重看路径上 flag 已是「已看过」，再写一次没有意义 —— 引导全程只允许这一个写操作，
+    // 能省则省。
+    if (seen === true) return;
+    void API.markOnboardingSeen().catch((err) => {
+      console.warn("[onboarding] failed to mark tour as seen", err);
+    });
+  },
+}));

--- a/frontend/src/stores/onboarding-store.ts
+++ b/frontend/src/stores/onboarding-store.ts
@@ -22,6 +22,9 @@ export const useOnboardingStore = create<OnboardingState>((set, get) => ({
     try {
       const { seen } = await API.getOnboardingStatus({ signal: options.signal });
       if (options.signal?.aborted) return;
+      // 迟到的查询结果不得回退已确立的「已看过」——用户可能在这次查询飞行途中
+      // 已经跑完并退出过一轮引导（本地 exit() 早已写入 seen: true）。
+      if (get().seen === true) return;
       set({ seen });
     } catch (err) {
       if (options.signal?.aborted) return;

--- a/frontend/src/types/system.ts
+++ b/frontend/src/types/system.ts
@@ -51,6 +51,11 @@ export interface GetSystemVersionResponse {
   update_check_error: string | null;
 }
 
+/** 首次使用引导的「已看过」状态 —— 实例级，未设置视为未看过。 */
+export interface OnboardingStatus {
+  seen: boolean;
+}
+
 export interface SystemConfigPatch {
   default_video_backend?: string;
   default_image_backend?: string;

--- a/server/app.py
+++ b/server/app.py
@@ -54,6 +54,7 @@ from server.routers import (
     files,
     generate,
     grids,
+    onboarding,
     products,
     project_events,
     projects,
@@ -583,6 +584,7 @@ app.include_router(cost_estimation.router, prefix="/api/v1", tags=["费用估算
 app.include_router(grids.router, prefix="/api/v1", tags=["宫格图"])
 app.include_router(reference_videos.router, prefix="/api/v1", tags=["参考生视频"])
 app.include_router(assets.router, prefix="/api/v1", tags=["全局资产库"])
+app.include_router(onboarding.router, prefix="/api/v1", tags=["首次使用引导"])
 
 
 def create_generation_worker() -> GenerationWorker:

--- a/server/routers/onboarding.py
+++ b/server/routers/onboarding.py
@@ -1,0 +1,55 @@
+"""Onboarding 引导状态 APIs.
+
+首次使用引导的「已看过」标记。刻意与 `/system/config` 分开：那条路由是配置面板的
+读写白名单，引导标记既不是用户可配置项，也不该被配置页的批量读写带上。
+
+作用域：端点按「当前用户的引导状态」语义设计，身份走 `get_current_user` 解析；
+标记本身今天落在实例级 `SystemSetting`（开源单用户形态）。将来引入多用户时，
+替换下面的读写后端即可，端点契约不变。
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lib.config.service import ConfigService
+from lib.db import get_async_session
+from server.auth import CurrentUser
+from server.dependencies import get_config_service
+
+router = APIRouter()
+
+ONBOARDING_SEEN_KEY = "onboarding_seen"
+
+
+class OnboardingStatusResponse(BaseModel):
+    seen: bool
+
+
+async def _read_seen(svc: ConfigService) -> bool:
+    return await svc.get_setting(ONBOARDING_SEEN_KEY) == "true"
+
+
+@router.get("/onboarding/status", response_model=OnboardingStatusResponse)
+async def get_onboarding_status(
+    _user: CurrentUser,
+    svc: Annotated[ConfigService, Depends(get_config_service)],
+) -> OnboardingStatusResponse:
+    """引导是否已看过。未设置视为未看过 —— 前端据此决定是否自动弹出。"""
+    return OnboardingStatusResponse(seen=await _read_seen(svc))
+
+
+@router.post("/onboarding/seen", response_model=OnboardingStatusResponse)
+async def mark_onboarding_seen(
+    _user: CurrentUser,
+    svc: Annotated[ConfigService, Depends(get_config_service)],
+    session: AsyncSession = Depends(get_async_session),
+) -> OnboardingStatusResponse:
+    """标记引导已看过。幂等 —— 跳过/看完/关闭三条退出路径都打到这里。"""
+    await svc.set_setting(ONBOARDING_SEEN_KEY, "true")
+    await session.commit()
+    return OnboardingStatusResponse(seen=True)

--- a/tests/test_onboarding_router.py
+++ b/tests/test_onboarding_router.py
@@ -1,0 +1,121 @@
+"""Onboarding 引导状态路由测试。"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from lib.config.service import ConfigService
+from lib.db import get_async_session
+from lib.db.base import Base
+from server.auth import CurrentUserInfo, get_current_user
+from server.routers import onboarding
+
+
+def _make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+
+    async def override_session():
+        async with session_factory() as session:
+            yield session
+            await session.commit()
+
+    app.dependency_overrides[get_async_session] = override_session
+    app.include_router(onboarding.router, prefix="/api/v1")
+    return app
+
+
+@pytest_asyncio.fixture
+async def _session_factory():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def authed_client(_session_factory):
+    app = _make_app(_session_factory)
+    app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def unauth_client(_session_factory):
+    """No dependency override → real auth applies → expects 401/403."""
+    app = _make_app(_session_factory)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_status_reports_not_seen_when_flag_missing(authed_client) -> None:
+    resp = await authed_client.get("/api/v1/onboarding/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"seen": False}
+
+
+@pytest.mark.asyncio
+async def test_mark_seen_then_status_reports_seen(authed_client) -> None:
+    marked = await authed_client.post("/api/v1/onboarding/seen")
+    assert marked.status_code == 200
+    assert marked.json() == {"seen": True}
+
+    resp = await authed_client.get("/api/v1/onboarding/status")
+    assert resp.json() == {"seen": True}
+
+
+@pytest.mark.asyncio
+async def test_mark_seen_is_idempotent(authed_client) -> None:
+    for _ in range(3):
+        resp = await authed_client.post("/api/v1/onboarding/seen")
+        assert resp.status_code == 200
+        assert resp.json() == {"seen": True}
+
+    assert (await authed_client.get("/api/v1/onboarding/status")).json() == {"seen": True}
+
+
+@pytest.mark.asyncio
+async def test_mark_seen_persists_flag_under_expected_key(authed_client, _session_factory) -> None:
+    """标记写在实例级 SystemSetting 的 `onboarding_seen` 上，不是内存态。"""
+    await authed_client.post("/api/v1/onboarding/seen")
+
+    async with _session_factory() as session:
+        stored = await ConfigService(session).get_setting(onboarding.ONBOARDING_SEEN_KEY)
+    assert stored == "true"
+
+
+@pytest.mark.asyncio
+async def test_mark_seen_writes_only_the_flag(authed_client, _session_factory) -> None:
+    """零副作用：标记引导只落一个 setting，不碰其他配置。"""
+    async with _session_factory() as session:
+        before = await ConfigService(session).get_all_settings()
+
+    await authed_client.post("/api/v1/onboarding/seen")
+
+    async with _session_factory() as session:
+        after = await ConfigService(session).get_all_settings()
+    assert set(after) - set(before) == {onboarding.ONBOARDING_SEEN_KEY}
+    assert {k: v for k, v in after.items() if k != onboarding.ONBOARDING_SEEN_KEY} == before
+
+
+@pytest.mark.asyncio
+async def test_status_rejects_unauthenticated(unauth_client, monkeypatch) -> None:
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    resp = await unauth_client.get("/api/v1/onboarding/status")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_mark_seen_rejects_unauthenticated(unauth_client, monkeypatch) -> None:
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    resp = await unauth_client.post("/api/v1/onboarding/seen")
+    assert resp.status_code == 401

--- a/tests/test_onboarding_router.py
+++ b/tests/test_onboarding_router.py
@@ -56,6 +56,7 @@ async def unauth_client(_session_factory):
         yield client
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_status_reports_not_seen_when_flag_missing(authed_client) -> None:
     resp = await authed_client.get("/api/v1/onboarding/status")
@@ -63,6 +64,7 @@ async def test_status_reports_not_seen_when_flag_missing(authed_client) -> None:
     assert resp.json() == {"seen": False}
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_mark_seen_then_status_reports_seen(authed_client) -> None:
     marked = await authed_client.post("/api/v1/onboarding/seen")
@@ -73,6 +75,7 @@ async def test_mark_seen_then_status_reports_seen(authed_client) -> None:
     assert resp.json() == {"seen": True}
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_mark_seen_is_idempotent(authed_client) -> None:
     for _ in range(3):
@@ -83,6 +86,7 @@ async def test_mark_seen_is_idempotent(authed_client) -> None:
     assert (await authed_client.get("/api/v1/onboarding/status")).json() == {"seen": True}
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_mark_seen_persists_flag_under_expected_key(authed_client, _session_factory) -> None:
     """标记写在实例级 SystemSetting 的 `onboarding_seen` 上，不是内存态。"""
@@ -93,6 +97,7 @@ async def test_mark_seen_persists_flag_under_expected_key(authed_client, _sessio
     assert stored == "true"
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_mark_seen_writes_only_the_flag(authed_client, _session_factory) -> None:
     """零副作用：标记引导只落一个 setting，不碰其他配置。"""
@@ -107,6 +112,7 @@ async def test_mark_seen_writes_only_the_flag(authed_client, _session_factory) -
     assert {k: v for k, v in after.items() if k != onboarding.ONBOARDING_SEEN_KEY} == before
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_status_rejects_unauthenticated(unauth_client, monkeypatch) -> None:
     monkeypatch.setenv("AUTH_ENABLED", "true")
@@ -114,6 +120,7 @@ async def test_status_rejects_unauthenticated(unauth_client, monkeypatch) -> Non
     assert resp.status_code == 401
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_mark_seen_rejects_unauthenticated(unauth_client, monkeypatch) -> None:
     monkeypatch.setenv("AUTH_ENABLED", "true")


### PR DESCRIPTION
Closes #1301

Spec #1299 实现顺序的第 1 步：后端 flag 端点 + 前端触发接线的最小闭环。

## 改动

**后端** — 新增 `server/routers/onboarding.py`：`GET /onboarding/status` 查询是否已看过、`POST /onboarding/seen` 标记已看（幂等）。身份走 `get_current_user`，标记落实例级 `SystemSetting`；刻意不进 `/system/config` 白名单——引导标记不是用户可配置项，也不该被配置页批量读写捎上。将来引入多用户只换读写后端，端点契约不动。

**前端** — `OnboardingTour` 挂在路由根，进入主界面后查一次状态，未看过则自动开一次；`AboutSection` 提供「重看引导」入口，与自动首弹共用同一条路径，重看不重复写 flag。driver.js 薄适配层 (`onboarding/tour.ts`) 把「引导步骤」与 driver 的 API 隔开，支持 `anchor: null` 居中气泡形态，为后续段落的锚点步骤铺路。新增 `onboarding` i18n 命名空间，zh/en/vi 全量。

**视觉** — 不新造品牌面，吃现有 Darkroom token；遮罩用应用自身的冷紫墨而非 driver 默认纯黑，进度用定宽胶片齿孔轨道（语义由同级 sr-only 文本承载）。

## 关键取舍

- 退出回调不走 driver 的 `onDestroyed`（该钩子被排在 `requestAnimationFrame` 里的 state 写入守卫，同步 destroy 或无渲染帧的环境下会静默漏调，「任一退出路径都标记已看过」会破）。改为接管 `onNextClick` / `onPrevClick` / `onCloseClick` + `onDestroyStarted`，退出必被记一次。
- 状态查询失败时前端 fail-closed（置「已看过」），只抑制本次页面加载、不落任何客户端持久化——后端抖动时宁可不弹，也不给老用户重复弹引导。

## 本地审查修复

- 切换界面语言会把进行中的引导重置回第 1 步：文案是构造时一次性交给 driver 的，`t` 换身份必须重建实例才生效，而重建走的是从头 `drive()`。改为重建时把停留步号带过去（`startIndex` / `currentIndex()`），并去掉无生产调用方的 `TourHandle.isActive`。已补回归测试。

## 验证

- `uv run python -m pytest`：6267 passed（含 `tests/test_onboarding_router.py` 新增 7 项，覆盖未设置/已设置/幂等/仅写该 flag/未认证拒绝）
- `pnpm lint && pnpm check`：绿，1071 tests / 116 files
- `uv run ruff check . && uv run ruff format --check .`：clean
- `uv run basedpyright`：0 errors

## 已知边界（Spec #1299 后续票范围）

锚点注册表与逐锚点渲染断言、锚点缺失的运行时降级、demo 数据与 11 步跨页流程均属后续票，本票只落 `anchorSelector()` 这一层映射。多标签页并发下 B 标签页已加载的 `seen: false` 不同步，可能多弹一次；单机单用户场景判定为可接受。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 已登录用户在主界面首次进入时自动启动引导流程（欢迎/完成、前进/返回、跳过与关闭），并在离开后持久化“已看过”状态。
  * “设置 → 关于”新增“重看引导”卡片，可再次播放引导。
* **改进**
  * 引导样式与交互升级，包含进度展示与无障碍文案；支持中文/英文/越南语，并优化窄屏显示。
  * 引导进行中按 Esc 不会误触关闭。
* **后端**
  * 新增引导状态查询与持久化接口，支持幂等。
* **测试**
  * 覆盖引导组件、状态机、路由挂载与接口（含未认证场景）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->