### PR TITLE
feat(providers): 自定义供应商视频模型能力支持按模型覆盖

### DIFF
--- a/alembic/versions/b41d7c5e9a02_add_capability_overrides_to_custom_.py
+++ b/alembic/versions/b41d7c5e9a02_add_capability_overrides_to_custom_.py
@@ -1,0 +1,30 @@
+"""add capability_overrides to custom provider model
+
+Revision ID: b41d7c5e9a02
+Revises: e167b56a3e79
+Create Date: 2026-07-25 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b41d7c5e9a02"
+down_revision: str | Sequence[str] | None = "e167b56a3e79"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """加模型级能力覆盖列（稀疏 JSON，NULL = 全部跟随系统判定）。"""
+    with op.batch_alter_table("custom_provider_model", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("capability_overrides", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("custom_provider_model", schema=None) as batch_op:
+        batch_op.drop_column("capability_overrides")

--- a/lib/custom_provider/backends.py
+++ b/lib/custom_provider/backends.py
@@ -90,12 +90,34 @@ class CustomAudioBackend:
 
 
 class CustomVideoBackend:
-    """自定义供应商视频生成后端包装类。"""
+    """自定义供应商视频生成后端包装类。
 
-    def __init__(self, *, provider_id: str, delegate: VideoBackend, model: str) -> None:
+    ``video_capabilities`` 可被工厂注入生效能力（系统判定 ⊕ 用户覆盖），此时不再转发被包装
+    backend 的声明——后者只是系统判定的一个来源，用户覆盖必须能翻转执行层看到的能力。未注入
+    时（endpoint 闭包直接构造）回落到转发。
+    """
+
+    def __init__(
+        self,
+        *,
+        provider_id: str,
+        delegate: VideoBackend,
+        model: str,
+        video_capabilities: VideoCapabilities | None = None,
+    ) -> None:
         self._provider_id = provider_id
         self._delegate = delegate
         self._model = model
+        self._video_capabilities = video_capabilities
+
+    def with_video_capabilities(self, capabilities: VideoCapabilities) -> CustomVideoBackend:
+        """返回注入生效能力的新实例（不就地改写，包装器保持构造后不可变）。"""
+        return CustomVideoBackend(
+            provider_id=self._provider_id,
+            delegate=self._delegate,
+            model=self._model,
+            video_capabilities=capabilities,
+        )
 
     @property
     def name(self) -> str:
@@ -111,6 +133,8 @@ class CustomVideoBackend:
 
     @property
     def video_capabilities(self) -> VideoCapabilities:
+        if self._video_capabilities is not None:
+            return self._video_capabilities
         return self._delegate.video_capabilities
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:

--- a/lib/custom_provider/capabilities.py
+++ b/lib/custom_provider/capabilities.py
@@ -1,8 +1,9 @@
 """自定义供应商视频能力的唯一合成点：endpoint spec 系统判定 ⊕ 模型级用户覆盖。
 
-执行层（工厂构建 backend 时注入）与展示层都从这里取生效能力，两侧严格同源——避免
-「界面允许的操作在执行期反悔」。系统判定本身不落库，随注册表升级自动变化；用户覆盖是
-稀疏字典（`CustomProviderModel.capability_overrides`），键缺席即该维度跟随系统判定。
+合成语义只此一份：需要生效能力的调用方一律走这里，不得自行合并覆盖，否则「界面允许的
+操作在执行期反悔」。执行层由工厂构建 backend 时注入。系统判定本身不落库，随注册表升级
+自动变化；用户覆盖是稀疏字典（`CustomProviderModel.capability_overrides`），键缺席即该
+维度跟随系统判定。
 """
 
 from __future__ import annotations

--- a/lib/custom_provider/capabilities.py
+++ b/lib/custom_provider/capabilities.py
@@ -1,0 +1,124 @@
+"""自定义供应商视频能力的唯一合成点：endpoint spec 系统判定 ⊕ 模型级用户覆盖。
+
+执行层（工厂构建 backend 时注入）与展示层都从这里取生效能力，两侧严格同源——避免
+「界面允许的操作在执行期反悔」。系统判定本身不落库，随注册表升级自动变化；用户覆盖是
+稀疏字典（`CustomProviderModel.capability_overrides`），键缺席即该维度跟随系统判定。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import fields, replace
+from typing import get_type_hints
+
+from lib.custom_provider.endpoints import get_endpoint_spec
+from lib.video_backends.base import VideoCapabilities
+
+logger = logging.getLogger(__name__)
+
+
+# 覆盖键 → 值类型，直接从 VideoCapabilities dataclass 派生：新增能力维度自动进入覆盖
+# schema，无需 DB 迁移，也不存在手写副本与 dataclass 漂移的可能。
+# 走 get_type_hints 而非 field.type：base.py 启用 PEP 563，后者只给注解字符串。
+_CAPABILITY_TYPE_HINTS = get_type_hints(VideoCapabilities)
+CAPABILITY_OVERRIDE_FIELDS: dict[str, type] = {
+    f.name: _CAPABILITY_TYPE_HINTS[f.name] for f in fields(VideoCapabilities)
+}
+
+
+def system_video_capabilities(*, endpoint: str, model_id: str) -> VideoCapabilities:
+    """读 endpoint spec 得出系统对该模型视频能力的判定。
+
+    两条声明形式（注册表不变式保证恰填其一）：
+    - ``video_caps_for_model``：backend 的 per-model 纯函数，四字段全量由 backend 声明；
+    - ``video_max_reference_images``：endpoint 维度硬上限，参考图布尔位由上限推出（>0 即
+      支持），首帧/尾帧取 ``VideoCapabilities`` 默认。
+
+    不构造 SDK client、不查 DB，故 api_key 缺失也可调用。
+
+    Raises:
+        ValueError: endpoint 不存在、非 video 类、或两种声明都缺失 / 上限为负。
+    """
+    spec = get_endpoint_spec(endpoint)
+    if spec.media_type != "video":
+        raise ValueError(f"endpoint {endpoint!r} is {spec.media_type}, not video")
+
+    caps_fn = spec.video_caps_for_model
+    if caps_fn is not None:
+        caps = caps_fn(model_id)
+        if caps.max_reference_images < 0:
+            raise ValueError(
+                f"invalid backend max_reference_images: endpoint={endpoint!r} model={model_id!r} "
+                f"value={caps.max_reference_images!r}"
+            )
+        return caps
+
+    endpoint_cap = spec.video_max_reference_images
+    if endpoint_cap is None:
+        raise ValueError(
+            f"video endpoint {endpoint!r} declares neither video_max_reference_images nor video_caps_for_model"
+        )
+    if endpoint_cap < 0:
+        raise ValueError(f"invalid video_max_reference_images on endpoint {endpoint!r}: {endpoint_cap!r}")
+    return VideoCapabilities(reference_images=endpoint_cap > 0, max_reference_images=endpoint_cap)
+
+
+def synthesize_video_capabilities(
+    *,
+    endpoint: str,
+    model_id: str,
+    overrides: object | None,
+) -> VideoCapabilities:
+    """系统判定 ⊕ 用户覆盖 → 生效能力。
+
+    ``overrides`` 为 ``CustomProviderModel.capability_overrides`` 的原始值（DB 里可能是任何
+    形状）。不被识别的键、类型不符的值一律忽略并告警，降级为该维度跟随系统判定：合成是执行
+    链路的最后一道，一条脏配置不该让整个生成路径不可用。合法性由 API 层白名单在写入侧把关。
+
+    Raises:
+        ValueError: 系统判定本身不可得（见 :func:`system_video_capabilities`）。
+    """
+    caps = system_video_capabilities(endpoint=endpoint, model_id=model_id)
+    if overrides is None:
+        return caps
+    if not isinstance(overrides, dict):
+        logger.warning(
+            "忽略 %s/%s 的能力覆盖：期望字典，实际 %s",
+            endpoint,
+            model_id,
+            type(overrides).__name__,
+        )
+        return caps
+
+    applied: dict[str, object] = {}
+    for key, value in overrides.items():
+        expected = CAPABILITY_OVERRIDE_FIELDS.get(key)
+        if expected is None:
+            logger.warning("忽略 %s/%s 的未知能力覆盖键 %r", endpoint, model_id, key)
+            continue
+        if not _value_matches(value, expected):
+            logger.warning(
+                "忽略 %s/%s 的能力覆盖 %s=%r：期望 %s，该维度回退系统判定",
+                endpoint,
+                model_id,
+                key,
+                value,
+                expected.__name__,
+            )
+            continue
+        applied[key] = value
+
+    return replace(caps, **applied) if applied else caps
+
+
+def _value_matches(value: object, expected: type) -> bool:
+    """覆盖值是否可直接落入该能力维度。
+
+    bool 是 int 的子类，两个方向都要显式排除，否则 ``True`` 会被当成 1 张参考图上限、
+    ``1`` 会被当成布尔真——这类宽松真值是语义猜测，不做。数值维度另拒负数。
+    """
+    if expected is bool:
+        return isinstance(value, bool)
+    if expected is int:
+        return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+    return isinstance(value, expected)

--- a/lib/custom_provider/factory.py
+++ b/lib/custom_provider/factory.py
@@ -10,6 +10,7 @@ from lib.custom_provider.backends import (
     CustomTextBackend,
     CustomVideoBackend,
 )
+from lib.custom_provider.capabilities import synthesize_video_capabilities
 from lib.custom_provider.endpoints import get_endpoint_spec
 
 if TYPE_CHECKING:
@@ -21,16 +22,26 @@ def create_custom_backend(
     provider: CustomProvider,
     model_id: str,
     endpoint: str,
+    capability_overrides: object | None = None,
 ) -> CustomTextBackend | CustomImageBackend | CustomVideoBackend | CustomAudioBackend:
     """按 endpoint 查 ENDPOINT_REGISTRY 并构造 Backend。
+
+    视频后端额外注入生效能力（endpoint spec 系统判定 ⊕ 模型级用户覆盖），执行层据此门控，
+    不再直接读被包装 backend 的声明。
 
     Args:
         provider: 自定义供应商 ORM 对象（需 base_url / api_key / provider_id 属性）
         model_id: 该次调用使用的具体模型 id
         endpoint: ENDPOINT_REGISTRY 的键
+        capability_overrides: 该模型的 `capability_overrides` 原始值；None = 全部跟随系统判定
 
     Raises:
         ValueError: endpoint 不在 ENDPOINT_REGISTRY 中
     """
     spec = get_endpoint_spec(endpoint)
-    return spec.build_backend(provider, model_id)
+    backend = spec.build_backend(provider, model_id)
+    if isinstance(backend, CustomVideoBackend):
+        return backend.with_video_capabilities(
+            synthesize_video_capabilities(endpoint=endpoint, model_id=model_id, overrides=capability_overrides)
+        )
+    return backend

--- a/lib/custom_provider/loader.py
+++ b/lib/custom_provider/loader.py
@@ -80,4 +80,9 @@ async def load_custom_backend(
 
     if model_id is None:
         raise ValueError(f"自定义供应商 {provider_id} 解析后仍缺少 model_id")
-    return create_custom_backend(provider=provider, model_id=model_id, endpoint=model.endpoint)
+    return create_custom_backend(
+        provider=provider,
+        model_id=model_id,
+        endpoint=model.endpoint,
+        capability_overrides=model.capability_overrides,
+    )

--- a/lib/db/models/custom_provider.py
+++ b/lib/db/models/custom_provider.py
@@ -2,7 +2,18 @@
 
 from __future__ import annotations
 
-from sqlalchemy import Boolean, CheckConstraint, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    CheckConstraint,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from lib.db.base import Base, TimestampMixin
@@ -76,3 +87,7 @@ class CustomProviderModel(TimestampMixin, Base):
     resolution: Mapped[str | None] = mapped_column(
         String(64), nullable=True
     )  # standard token ("1080p"/"2K") or native "WxH"
+    # 模型级能力覆盖，稀疏字典，键名对齐 VideoCapabilities 字段名。NULL 或字典缺该键 =
+    # 跟随系统判定；写死的能力维度列表不进 schema，向新维度开放无需迁移。合成语义由
+    # lib.custom_provider.capabilities 唯一承载。
+    capability_overrides: Mapped[dict[str, object] | None] = mapped_column(JSON, nullable=True)

--- a/tests/test_alembic_custom_provider_capability_overrides.py
+++ b/tests/test_alembic_custom_provider_capability_overrides.py
@@ -35,7 +35,7 @@ def revisions() -> tuple[str, str]:
     versions_dir = repo_root / "alembic" / "versions"
     matches = list(versions_dir.glob("*_add_capability_overrides_to_custom_.py"))
     assert len(matches) == 1, f"找到 {len(matches)} 个加列迁移文件，期望 1"
-    text = matches[0].read_text()
+    text = matches[0].read_text(encoding="utf-8")
     revision: str | None = None
     down_revision: str | None = None
     for line in text.splitlines():

--- a/tests/test_alembic_custom_provider_capability_overrides.py
+++ b/tests/test_alembic_custom_provider_capability_overrides.py
@@ -1,0 +1,139 @@
+"""Alembic 迁移：custom_provider_model.capability_overrides 的 upgrade / downgrade。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.config import Config
+
+from alembic import command
+
+
+@pytest.fixture
+def alembic_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Config:
+    """指向项目 alembic 脚本，DB 用临时 sqlite（env.py 经 DATABASE_URL 读取）。
+
+    刻意不传 alembic.ini 路径：env.py 在 config_file_name 为 None 时跳过 fileConfig()，
+    避免 alembic.ini 的 logging section 在测试中重置 root logger。
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = Config()
+    cfg.set_main_option("script_location", str(repo_root / "alembic"))
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    cfg.attributes["_test_db_path"] = str(db_path)
+    return cfg
+
+
+@pytest.fixture
+def revisions() -> tuple[str, str]:
+    """读出加列迁移的 (revision, down_revision)。"""
+    repo_root = Path(__file__).resolve().parent.parent
+    versions_dir = repo_root / "alembic" / "versions"
+    matches = list(versions_dir.glob("*_add_capability_overrides_to_custom_.py"))
+    assert len(matches) == 1, f"找到 {len(matches)} 个加列迁移文件，期望 1"
+    text = matches[0].read_text()
+    revision: str | None = None
+    down_revision: str | None = None
+    for line in text.splitlines():
+        if line.startswith("revision: str ="):
+            revision = line.split("=")[1].strip().strip('"').strip("'")
+        elif line.startswith("down_revision:"):
+            down_revision = line.split("=")[1].strip().strip('"').strip("'")
+    if not revision or not down_revision:
+        raise RuntimeError("未在迁移文件中找到 revision / down_revision")
+    return revision, down_revision
+
+
+_COL = "capability_overrides"
+
+_INSERT_MODEL = (
+    "INSERT INTO custom_provider_model "
+    "(id, provider_id, model_id, display_name, endpoint, is_default, is_enabled, created_at, updated_at) "
+    "VALUES (1, 1, 'sora-2', 'Sora', 'openai-video', 0, 1, "
+    "'2026-07-25 00:00:00', '2026-07-25 00:00:00')"
+)
+
+_INSERT_PROVIDER = (
+    "INSERT INTO custom_provider "
+    "(id, display_name, discovery_format, base_url, api_key, created_at, updated_at) "
+    "VALUES (1, 'P', 'openai', 'https://x', 'k', '2026-07-25 00:00:00', '2026-07-25 00:00:00')"
+)
+
+
+def _columns(engine: sa.Engine) -> set[str]:
+    with engine.begin() as conn:
+        rows = conn.execute(sa.text("PRAGMA table_info(custom_provider_model)")).fetchall()
+    return {r[1] for r in rows}
+
+
+@pytest.mark.integration
+def test_upgrade_adds_column_existing_row_null(alembic_cfg: Config, revisions: tuple[str, str]):
+    """升到加列前插一行，升级后该列存在且存量行为 NULL —— 即全部跟随系统判定。"""
+    revision_id, parent_id = revisions
+    command.upgrade(alembic_cfg, parent_id)
+
+    db_path = alembic_cfg.attributes["_test_db_path"]
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        assert _COL not in _columns(engine), "加列前不应存在覆盖列"
+        with engine.begin() as conn:
+            conn.execute(sa.text(_INSERT_PROVIDER))
+            conn.execute(sa.text(_INSERT_MODEL))
+
+        command.upgrade(alembic_cfg, revision_id)
+
+        assert _COL in _columns(engine)
+        with engine.begin() as conn:
+            value = conn.execute(sa.text(f"SELECT {_COL} FROM custom_provider_model WHERE id = 1")).scalar_one()
+        assert value is None
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.integration
+def test_upgraded_column_round_trips_sparse_dict(alembic_cfg: Config, revisions: tuple[str, str]):
+    """稀疏覆盖字典可写入并原样读回（JSON 列，键集不受 schema 约束）。"""
+    revision_id, _ = revisions
+    command.upgrade(alembic_cfg, revision_id)
+
+    db_path = alembic_cfg.attributes["_test_db_path"]
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.begin() as conn:
+            conn.execute(sa.text(_INSERT_PROVIDER))
+            conn.execute(sa.text(_INSERT_MODEL))
+            conn.execute(
+                sa.text(f"UPDATE custom_provider_model SET {_COL} = :v WHERE id = 1"),
+                {"v": json.dumps({"last_frame": True})},
+            )
+            raw = conn.execute(sa.text(f"SELECT {_COL} FROM custom_provider_model WHERE id = 1")).scalar_one()
+        assert json.loads(raw) == {"last_frame": True}
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.integration
+def test_downgrade_drops_column(alembic_cfg: Config, revisions: tuple[str, str]):
+    """downgrade 回退后该列消失，同行其余数据保留。"""
+    revision_id, parent_id = revisions
+    command.upgrade(alembic_cfg, revision_id)
+
+    db_path = alembic_cfg.attributes["_test_db_path"]
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.begin() as conn:
+            conn.execute(sa.text(_INSERT_PROVIDER))
+            conn.execute(sa.text(_INSERT_MODEL))
+
+        command.downgrade(alembic_cfg, parent_id)
+
+        assert _COL not in _columns(engine)
+        with engine.begin() as conn:
+            model_id = conn.execute(sa.text("SELECT model_id FROM custom_provider_model WHERE id = 1")).scalar_one()
+        assert model_id == "sora-2"
+    finally:
+        engine.dispose()

--- a/tests/test_custom_provider_capabilities.py
+++ b/tests/test_custom_provider_capabilities.py
@@ -1,0 +1,167 @@
+"""自定义供应商视频能力合成函数（系统判定 ⊕ 用户覆盖）。"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lib.custom_provider.capabilities import (
+    CAPABILITY_OVERRIDE_FIELDS,
+    synthesize_video_capabilities,
+    system_video_capabilities,
+)
+from lib.video_backends.base import VideoCapabilities
+
+
+class TestOverrideFieldSchema:
+    @pytest.mark.unit
+    def test_schema_covers_every_video_capabilities_field(self):
+        """覆盖 schema 通用支持 VideoCapabilities 全部字段，键名严格对齐 dataclass。"""
+        assert set(CAPABILITY_OVERRIDE_FIELDS) == {
+            "first_frame",
+            "last_frame",
+            "reference_images",
+            "max_reference_images",
+        }
+        assert CAPABILITY_OVERRIDE_FIELDS["last_frame"] is bool
+        assert CAPABILITY_OVERRIDE_FIELDS["max_reference_images"] is int
+
+
+class TestSystemCapabilities:
+    @pytest.mark.unit
+    def test_endpoint_declaring_int_cap_rebuilds_capabilities(self):
+        """endpoint 维度声明硬上限时，参考图布尔位由上限推出（>0 即支持）。"""
+        caps = system_video_capabilities(endpoint="openai-video", model_id="sora-2")
+        assert caps == VideoCapabilities(
+            first_frame=True, last_frame=False, reference_images=True, max_reference_images=1
+        )
+
+    @pytest.mark.unit
+    def test_endpoint_declaring_zero_cap_yields_no_reference_images(self):
+        caps = system_video_capabilities(endpoint="newapi-video", model_id="whatever")
+        assert caps.reference_images is False
+        assert caps.max_reference_images == 0
+
+    @pytest.mark.unit
+    def test_endpoint_with_caps_fn_delegates_to_backend_declaration(self):
+        """endpoint 未声明硬上限时走 backend 的 per-model 纯函数，四字段全量取其声明。"""
+        from lib.video_backends.vidu import ViduVideoBackend
+
+        caps = system_video_capabilities(endpoint="vidu-video", model_id="viduq3")
+        assert caps == ViduVideoBackend.video_capabilities_for_model("viduq3")
+
+    @pytest.mark.unit
+    def test_non_video_endpoint_raises(self):
+        with pytest.raises(ValueError, match="not video"):
+            system_video_capabilities(endpoint="openai-chat", model_id="gpt-4o")
+
+    @pytest.mark.unit
+    def test_unknown_endpoint_raises(self):
+        with pytest.raises(ValueError):
+            system_video_capabilities(endpoint="no-such-endpoint", model_id="x")
+
+
+class TestSynthesize:
+    @pytest.mark.unit
+    @pytest.mark.parametrize("overrides", [None, {}])
+    def test_absent_overrides_follow_system(self, overrides: dict | None):
+        """列 NULL 与空字典都等价于「全部跟随系统判定」。"""
+        assert synthesize_video_capabilities(
+            endpoint="openai-video", model_id="sora-2", overrides=overrides
+        ) == system_video_capabilities(endpoint="openai-video", model_id="sora-2")
+
+    @pytest.mark.unit
+    def test_missing_key_follows_system(self):
+        """字典存在但缺某键 → 该维度跟随系统判定，其余键照常覆盖。"""
+        caps = synthesize_video_capabilities(endpoint="openai-video", model_id="sora-2", overrides={"last_frame": True})
+        assert caps.last_frame is True
+        assert caps.first_frame is True
+        assert caps.max_reference_images == 1
+
+    @pytest.mark.unit
+    def test_force_on(self):
+        caps = synthesize_video_capabilities(
+            endpoint="newapi-video", model_id="x", overrides={"last_frame": True, "reference_images": True}
+        )
+        assert caps.last_frame is True
+        assert caps.reference_images is True
+
+    @pytest.mark.unit
+    def test_force_off(self):
+        caps = synthesize_video_capabilities(
+            endpoint="openai-video", model_id="sora-2", overrides={"first_frame": False, "reference_images": False}
+        )
+        assert caps.first_frame is False
+        assert caps.reference_images is False
+        # 未覆盖的数值维度不受布尔覆盖牵连
+        assert caps.max_reference_images == 1
+
+    @pytest.mark.unit
+    def test_int_field_override(self):
+        caps = synthesize_video_capabilities(
+            endpoint="openai-video", model_id="sora-2", overrides={"max_reference_images": 3}
+        )
+        assert caps.max_reference_images == 3
+
+    @pytest.mark.unit
+    def test_system_capabilities_not_mutated_across_calls(self):
+        """合成返回新实例，不得就地改写系统判定（caps_fn 可能返回共享对象）。"""
+        first = synthesize_video_capabilities(
+            endpoint="openai-video", model_id="sora-2", overrides={"last_frame": True}
+        )
+        second = system_video_capabilities(endpoint="openai-video", model_id="sora-2")
+        assert first.last_frame is True
+        assert second.last_frame is False
+
+
+class TestTolerance:
+    """存量数据容错：合成函数是执行层的最后一道，坏数据降级为「跟随系统判定」而非抛错。
+
+    API 层白名单校验拒绝非法写入（另票），但存量行、手工 SQL、以及未来收窄的字段集都可能
+    让这里读到不认识的键，抛错会让整条生成链路因一条脏配置而不可用。
+    """
+
+    @pytest.mark.unit
+    def test_unknown_key_ignored_with_warning(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING, logger="lib.custom_provider.capabilities"):
+            caps = synthesize_video_capabilities(
+                endpoint="openai-video",
+                model_id="sora-2",
+                overrides={"last_frame": True, "audio_track": True},
+            )
+        assert caps.last_frame is True
+        assert caps == VideoCapabilities(
+            first_frame=True, last_frame=True, reference_images=True, max_reference_images=1
+        )
+        assert "audio_track" in caplog.text
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("bad", ["true", 1, None, [], {"x": 1}])
+    def test_non_bool_value_on_bool_field_ignored(self, bad: object, caplog: pytest.LogCaptureFixture):
+        """布尔维度只接受真 bool；1/"true" 等宽松真值不做语义映射，一律降级跟随。"""
+        with caplog.at_level(logging.WARNING, logger="lib.custom_provider.capabilities"):
+            caps = synthesize_video_capabilities(
+                endpoint="openai-video", model_id="sora-2", overrides={"last_frame": bad}
+            )
+        assert caps.last_frame is False
+        assert "last_frame" in caplog.text
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("bad", [True, -1, "2", 1.5, None])
+    def test_bad_value_on_int_field_ignored(self, bad: object, caplog: pytest.LogCaptureFixture):
+        """数值维度只接受非负 int；bool 是 int 子类，须被显式排除。"""
+        with caplog.at_level(logging.WARNING, logger="lib.custom_provider.capabilities"):
+            caps = synthesize_video_capabilities(
+                endpoint="openai-video", model_id="sora-2", overrides={"max_reference_images": bad}
+            )
+        assert caps.max_reference_images == 1
+        assert "max_reference_images" in caplog.text
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("bad", ["last_frame", ["last_frame"], 42])
+    def test_non_dict_overrides_ignored(self, bad: object, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING, logger="lib.custom_provider.capabilities"):
+            caps = synthesize_video_capabilities(endpoint="openai-video", model_id="sora-2", overrides=bad)
+        assert caps == system_video_capabilities(endpoint="openai-video", model_id="sora-2")
+        assert caplog.records

--- a/tests/test_custom_provider_capabilities.py
+++ b/tests/test_custom_provider_capabilities.py
@@ -98,6 +98,14 @@ class TestSynthesize:
         assert caps.max_reference_images == 1
 
     @pytest.mark.unit
+    def test_force_off_on_last_frame(self):
+        """last_frame 是首批开放的覆盖维度，单独验一遍「系统判定 True → 强制关」。"""
+        assert system_video_capabilities(endpoint="vidu-video", model_id="viduq3").last_frame is True
+        caps = synthesize_video_capabilities(endpoint="vidu-video", model_id="viduq3", overrides={"last_frame": False})
+        assert caps.last_frame is False
+        assert caps.first_frame is True
+
+    @pytest.mark.unit
     def test_int_field_override(self):
         caps = synthesize_video_capabilities(
             endpoint="openai-video", model_id="sora-2", overrides={"max_reference_images": 3}
@@ -118,8 +126,8 @@ class TestSynthesize:
 class TestTolerance:
     """存量数据容错：合成函数是执行层的最后一道，坏数据降级为「跟随系统判定」而非抛错。
 
-    API 层白名单校验拒绝非法写入（另票），但存量行、手工 SQL、以及未来收窄的字段集都可能
-    让这里读到不认识的键，抛错会让整条生成链路因一条脏配置而不可用。
+    合法性把关属于写入侧；存量行、手工 SQL、以及字段集收窄都可能让这里读到不认识的键，
+    抛错会让整条生成链路因一条脏配置而不可用。
     """
 
     @pytest.mark.unit

--- a/tests/test_custom_provider_loader.py
+++ b/tests/test_custom_provider_loader.py
@@ -104,6 +104,8 @@ class TestVideoCapabilityOverridesReachExecution:
                 }
             ],
         )
+        # 清 identity map，逼装载重新 SELECT：覆盖字典要真经过 JSON 编解码往返才算验到 DB 语义
+        session.expunge_all()
         return await load_custom_backend(session=session, provider_id=pid, model_id="sora-2", media_type="video")
 
     @pytest.mark.integration

--- a/tests/test_custom_provider_loader.py
+++ b/tests/test_custom_provider_loader.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.custom_provider import make_provider_id
 from lib.custom_provider.backends import CustomImageBackend
+from lib.custom_provider.capabilities import system_video_capabilities
 from lib.custom_provider.loader import load_custom_backend
 from lib.db.base import Base
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
@@ -84,3 +85,68 @@ class TestLoadCustomBackend:
         )
         with pytest.raises(ValueError, match="没有默认"):
             await load_custom_backend(session=session, provider_id=pid, model_id=None, media_type="video")
+
+
+class TestVideoCapabilityOverridesReachExecution:
+    """DB 的 capability_overrides 必须在装载出的 backend 上生效——执行层门控读的就是这里。"""
+
+    @staticmethod
+    async def _load_video_backend(session, *, overrides: object | None):
+        pid = await _seed(
+            session,
+            models=[
+                {
+                    "model_id": "sora-2",
+                    "endpoint": "openai-video",
+                    "is_enabled": True,
+                    "is_default": True,
+                    "capability_overrides": overrides,
+                }
+            ],
+        )
+        return await load_custom_backend(session=session, provider_id=pid, model_id="sora-2", media_type="video")
+
+    @pytest.mark.integration
+    @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
+    async def test_null_overrides_follow_system_judgement(self, _mock_cls, session):
+        backend = await self._load_video_backend(session, overrides=None)
+        assert backend.video_capabilities == system_video_capabilities(endpoint="openai-video", model_id="sora-2")
+
+    @pytest.mark.integration
+    @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
+    async def test_override_forces_capability_on(self, _mock_cls, session):
+        # 系统判定 last_frame=False；覆盖强制开启后执行层看到 True，且不再转发被包装 backend
+        backend = await self._load_video_backend(session, overrides={"last_frame": True})
+        assert backend.video_capabilities.last_frame is True
+        assert backend.video_capabilities.max_reference_images == 1
+
+    @pytest.mark.integration
+    @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
+    async def test_override_forces_capability_off(self, _mock_cls, session):
+        backend = await self._load_video_backend(session, overrides={"reference_images": False})
+        assert backend.video_capabilities.reference_images is False
+        assert backend.video_capabilities.first_frame is True
+
+    @pytest.mark.integration
+    @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
+    async def test_unknown_key_in_stored_overrides_does_not_break_loading(self, _mock_cls, session):
+        # 存量行可能带已下线的键，装载不得失败，该维度按系统判定走
+        backend = await self._load_video_backend(session, overrides={"retired_dimension": True, "last_frame": True})
+        assert backend.video_capabilities.last_frame is True
+
+    @pytest.mark.integration
+    @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
+    async def test_non_video_backend_untouched_by_overrides(self, _mock_cls, session):
+        pid = await _seed(
+            session,
+            models=[
+                {
+                    "model_id": "dall-e-3",
+                    "endpoint": "openai-images",
+                    "is_enabled": True,
+                    "capability_overrides": {"last_frame": True},
+                }
+            ],
+        )
+        result = await load_custom_backend(session=session, provider_id=pid, model_id="dall-e-3", media_type="image")
+        assert isinstance(result, CustomImageBackend)

--- a/tests/test_custom_provider_models.py
+++ b/tests/test_custom_provider_models.py
@@ -114,6 +114,7 @@ class TestCustomProviderModelTable:
             "currency",
             "supported_durations",
             "resolution",
+            "capability_overrides",
             "created_at",
             "updated_at",
         }


### PR DESCRIPTION
Closes #1292

Spec #1288 的执行层落地：自定义供应商视频模型的能力覆盖数据落库，并在生成链路上真正生效。

## 改动

- `CustomProviderModel` 新增 nullable JSON 列 `capability_overrides`（稀疏字典，键名对齐 `VideoCapabilities` 字段名）；列 NULL 或字典缺该键 = 跟随系统判定。一次 additive 加列迁移，此后向新能力维度开放零迁移。
- `lib/custom_provider/capabilities.py` 建立唯一合成点：`system_video_capabilities()`（endpoint spec 系统判定）与 `synthesize_video_capabilities()`（系统判定 ⊕ 用户覆盖 → 生效能力）。覆盖 schema 从 `VideoCapabilities` dataclass 派生，不存在手写副本漂移。
- 工厂构建自定义视频后端时注入生效能力，`CustomVideoBackend.video_capabilities` 不再纯转发被包装 backend——执行层门控自动见到覆盖。

容错方向为「忽略 + warn」而非抛错：合成处在执行链路末端，一条脏配置不应让整个生成路径不可用；合法性把关属于写入侧。布尔维度只认真 bool、数值维度显式排除 bool 子类并拒负数，不做 `1`→True 这类语义映射。

## 验证

- `tests/test_custom_provider_capabilities.py` — 合成函数：无覆盖跟随系统判定、缺键跟随、强制开、强制关（含 tracer-bullet 维度 `last_frame`）、int 维度覆盖、不就地改写系统判定；容错：未知键 / 类型不符 / 非字典整体降级并告警。
- `tests/test_custom_provider_loader.py` — 工厂注入：DB 写入覆盖后清 identity map 重新 SELECT，装载出的 backend `video_capabilities` 反映生效值；非视频后端不受覆盖影响。
- `tests/test_alembic_custom_provider_capability_overrides.py` — 迁移 upgrade/downgrade、存量行加列后为 NULL、稀疏字典 JSON 往返。
- 质量门：ruff check/format 通过、basedpyright 0 error、pytest 6292 passed、覆盖率 91%。

## 范围说明

本票不动 API 与前端。`ConfigResolver._resolve_video_caps_for_model` 的自定义分支未收编到合成函数（Spec #1288 决策 4 的展示层同源部分），由 #1293 承载；在此之前 int 分支判定逻辑在合成函数与 resolver 各存一份，合成函数是设计上的唯一权威。

覆盖列目前无写入入口（`ModelInput.to_db_dict()` 不含该键），API 票需注意 `replace_models` 是整体替换语义。

DB schema 选型（通用 JSON 列而非定型列）与 ADR 0042「字段集已知且稳定时优先定型列」方向相邻但不冲突：本列的字段集刻意开放（验收标准要求向新维度开放零迁移），正落在该 ADR 为动态场景保留的例外内。架构落定后可考虑补一条 ADR 记录。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为自定义视频模型新增“能力覆盖”配置，可按字段调整并支持强制开启/关闭。
  * 在模型加载时自动合成最终生效视频能力；未知或格式不正确的覆盖项会被忽略并回退到系统判断。
  * 覆盖仅影响视频模型，不影响非视频模型。
* **数据库**
  * 新增模型字段 `capability_overrides`（JSON），支持迁移升级与回滚。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->