### PR TITLE
feat(providers): 视频模型能力覆盖可在设置中读写并即时生效

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -455,6 +455,9 @@ class API {
     supported_durations: number[];
     max_duration: number;
     max_reference_images: number;
+    /** 生效值（系统判定 ⊕ 用户覆盖），与执行层注入 backend 的能力同源。 */
+    first_frame: boolean;
+    last_frame: boolean;
     source: "registry" | "custom";
     default_duration?: number | null;
     content_mode?: string | null;

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -684,11 +684,17 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
                           const nextId = e.target.value;
                           updateModel(m.key, {
                             model_id: nextId,
-                            // capability_overrides 是模型级配置，能力判定本身依赖 model_id：
-                            // 对齐加载时的 original_model_id 而非上一次中间态——否则临时改动
-                            // 又逐字符改回原值时，第一次改动已清空覆盖，改回原值也无法找回。
+                            // capability_overrides 是模型级配置，能力判定本身依赖 model_id 与
+                            // endpoint 二者共同决定的 (endpoint, model_id) 组合：对齐加载时的
+                            // original_model_id 而非上一次中间态——否则临时改动又逐字符改回原值
+                            // 时，第一次改动已清空覆盖，改回原值也无法找回。同时要求 endpoint 仍
+                            // 等于加载时的 original_endpoint 才恢复——否则「先改 model_id、再切换
+                            // endpoint 又切回」会把只对原 (endpoint, model_id) 组合成立的覆盖，
+                            // 错配到已变更的 model_id 上。
                             capability_overrides:
-                              nextId === m.original_model_id ? m.original_capability_overrides : null,
+                              nextId === m.original_model_id && m.endpoint === m.original_endpoint
+                                ? m.original_capability_overrides
+                                : null,
                           });
                         }}
                         placeholder="model-id…"
@@ -709,7 +715,13 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
                             // 否则隐藏字段原样提交可能被后端因白名单/兼容性拒绝，用户无法保存。对齐
                             // 加载时的 original_endpoint 而非上一次中间态——弹层里重新点选当前已选中
                             // 项、或切到别的 endpoint 后又切回原值，都不应清空用户尚未改动的原有覆盖。
-                            capability_overrides: next === m.original_endpoint ? m.original_capability_overrides : null,
+                            // 同时要求 model_id 仍等于 original_model_id 才恢复——否则「先切 endpoint、
+                            // 再改 model_id、又切回原 endpoint」会把只对原 (endpoint, model_id) 组合
+                            // 成立的覆盖，错配到已变更的 model_id 上。
+                            capability_overrides:
+                              next === m.original_endpoint && m.model_id === m.original_model_id
+                                ? m.original_capability_overrides
+                                : null,
                           })
                         }
                         ariaLabel={t("endpoint_label")}

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -683,9 +683,11 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
                             is_default: false,
                             // 表单没有覆盖编辑控件（专门的 PATCH 端点承载，见 issue #1294），且覆盖的
                             // 合法性本身随 endpoint 变化（如 last_frame 要求目标 endpoint 支持尾帧）：
-                            // 前端拿不到判定所需的 end_image_capable 数据，任何 endpoint 切换一律清空，
-                            // 否则隐藏字段原样提交可能被后端因白名单/兼容性拒绝，用户无法保存。
-                            capability_overrides: null,
+                            // 前端拿不到判定所需的 end_image_capable 数据，endpoint 实际切换时一律清空，
+                            // 否则隐藏字段原样提交可能被后端因白名单/兼容性拒绝，用户无法保存。仅在
+                            // next !== m.endpoint 时清空——弹层里重新点选当前已选中项也会触发 onChange，
+                            // 此时无条件清空会把用户尚未改动的已有覆盖静默删掉。
+                            capability_overrides: next === m.endpoint ? m.capability_overrides : null,
                           })
                         }
                         ariaLabel={t("endpoint_label")}

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -668,7 +668,16 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
                       <input
                         type="text"
                         value={m.model_id}
-                        onChange={(e) => updateModel(m.key, { model_id: e.target.value })}
+                        onChange={(e) => {
+                          const nextId = e.target.value;
+                          updateModel(m.key, {
+                            model_id: nextId,
+                            // capability_overrides 是模型级配置，能力判定本身依赖 model_id：
+                            // model_id 实际变化时随之清空，否则旧模型的覆盖（如 last_frame）
+                            // 会静默带到 endpoint 相同但能力不同的新模型上。
+                            capability_overrides: nextId === m.model_id ? m.capability_overrides : null,
+                          });
+                        }}
                         placeholder="model-id…"
                         aria-label={t("model_id_label")}
                         className={`${COMPACT_INPUT_CLS} flex-1`}

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -681,9 +681,11 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
                           updateModel(m.key, {
                             endpoint: next,
                             is_default: false,
-                            // 覆盖字段只对 video endpoint 有意义；切到非 video 时随表单一并清除，
-                            // 否则隐藏字段原样提交会被后端因 media_type 不符拒绝，用户无法保存。
-                            capability_overrides: endpointToMediaType[next] === "video" ? m.capability_overrides : null,
+                            // 表单没有覆盖编辑控件（专门的 PATCH 端点承载，见 issue #1294），且覆盖的
+                            // 合法性本身随 endpoint 变化（如 last_frame 要求目标 endpoint 支持尾帧）：
+                            // 前端拿不到判定所需的 end_image_capable 数据，任何 endpoint 切换一律清空，
+                            // 否则隐藏字段原样提交可能被后端因白名单/兼容性拒绝，用户无法保存。
+                            capability_overrides: null,
                           })
                         }
                         ariaLabel={t("endpoint_label")}

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -70,14 +70,20 @@ interface ModelRow {
   supported_durations_text: string; // 用户原始文本，提交前 parse；空串 = 让后端按 preset 兜底
   // 本表单不编辑能力覆盖，仅原样携带：保存是整体替换语义，不回传会清空已写入的覆盖。
   capability_overrides: CapabilityOverrides | null;
+  // 行创建时的快照，之后不再变化：model_id/endpoint 的清除判断须对齐这份原始值而非上一次
+  // 的中间态——逐字符编辑 model_id 时若拿"上一次的值"作基准，第一次改动即清空覆盖，之后就
+  // 算把输入改回原值也已丢失、无法通过继续编辑恢复；改回原值时应从这份快照原样取回覆盖。
+  original_model_id: string;
+  original_endpoint: EndpointKey;
+  original_capability_overrides: CapabilityOverrides | null;
 }
 
 function newModelRow(partial?: Partial<ModelRow>): ModelRow {
-  return {
+  const base = {
     key: uid(),
     model_id: "",
     display_name: "",
-    endpoint: "openai-chat",
+    endpoint: "openai-chat" as EndpointKey,
     is_default: false,
     is_enabled: true,
     price_unit: "",
@@ -88,6 +94,12 @@ function newModelRow(partial?: Partial<ModelRow>): ModelRow {
     supported_durations_text: "",
     capability_overrides: null,
     ...partial,
+  };
+  return {
+    ...base,
+    original_model_id: base.model_id,
+    original_endpoint: base.endpoint,
+    original_capability_overrides: base.capability_overrides,
   };
 }
 
@@ -673,9 +685,10 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
                           updateModel(m.key, {
                             model_id: nextId,
                             // capability_overrides 是模型级配置，能力判定本身依赖 model_id：
-                            // model_id 实际变化时随之清空，否则旧模型的覆盖（如 last_frame）
-                            // 会静默带到 endpoint 相同但能力不同的新模型上。
-                            capability_overrides: nextId === m.model_id ? m.capability_overrides : null,
+                            // 对齐加载时的 original_model_id 而非上一次中间态——否则临时改动
+                            // 又逐字符改回原值时，第一次改动已清空覆盖，改回原值也无法找回。
+                            capability_overrides:
+                              nextId === m.original_model_id ? m.original_capability_overrides : null,
                           });
                         }}
                         placeholder="model-id…"
@@ -693,10 +706,10 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
                             // 表单没有覆盖编辑控件（专门的 PATCH 端点承载，见 issue #1294），且覆盖的
                             // 合法性本身随 endpoint 变化（如 last_frame 要求目标 endpoint 支持尾帧）：
                             // 前端拿不到判定所需的 end_image_capable 数据，endpoint 实际切换时一律清空，
-                            // 否则隐藏字段原样提交可能被后端因白名单/兼容性拒绝，用户无法保存。仅在
-                            // next !== m.endpoint 时清空——弹层里重新点选当前已选中项也会触发 onChange，
-                            // 此时无条件清空会把用户尚未改动的已有覆盖静默删掉。
-                            capability_overrides: next === m.endpoint ? m.capability_overrides : null,
+                            // 否则隐藏字段原样提交可能被后端因白名单/兼容性拒绝，用户无法保存。对齐
+                            // 加载时的 original_endpoint 而非上一次中间态——弹层里重新点选当前已选中
+                            // 项、或切到别的 endpoint 后又切回原值，都不应清空用户尚未改动的原有覆盖。
+                            capability_overrides: next === m.original_endpoint ? m.original_capability_overrides : null,
                           })
                         }
                         ariaLabel={t("endpoint_label")}

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -677,7 +677,15 @@ export function CustomProviderForm({ existing, onSaved, onCancel }: CustomProvid
                       {/* Endpoint select (custom dropdown showing real API path) */}
                       <EndpointSelect
                         value={m.endpoint}
-                        onChange={(next) => updateModel(m.key, { endpoint: next, is_default: false })}
+                        onChange={(next) =>
+                          updateModel(m.key, {
+                            endpoint: next,
+                            is_default: false,
+                            // 覆盖字段只对 video endpoint 有意义；切到非 video 时随表单一并清除，
+                            // 否则隐藏字段原样提交会被后端因 media_type 不符拒绝，用户无法保存。
+                            capability_overrides: endpointToMediaType[next] === "video" ? m.capability_overrides : null,
+                          })
+                        }
                         ariaLabel={t("endpoint_label")}
                       />
 

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -7,6 +7,7 @@ import { useEndpointCatalogStore } from "@/stores/endpoint-catalog-store";
 import { uid } from "@/utils/id";
 import { errMsg } from "@/utils/async";
 import type {
+  CapabilityOverrides,
   CustomProviderInfo,
   CustomProviderModelInput,
   DiscoveredModel,
@@ -67,6 +68,8 @@ interface ModelRow {
   currency: string;
   resolution: string; // 空串 = null
   supported_durations_text: string; // 用户原始文本，提交前 parse；空串 = 让后端按 preset 兜底
+  // 本表单不编辑能力覆盖，仅原样携带：保存是整体替换语义，不回传会清空已写入的覆盖。
+  capability_overrides: CapabilityOverrides | null;
 }
 
 function newModelRow(partial?: Partial<ModelRow>): ModelRow {
@@ -83,6 +86,7 @@ function newModelRow(partial?: Partial<ModelRow>): ModelRow {
     currency: "USD",
     resolution: "",
     supported_durations_text: "",
+    capability_overrides: null,
     ...partial,
   };
 }
@@ -110,6 +114,7 @@ function existingToRow(m: CustomProviderInfo["models"][number]): ModelRow {
     currency: m.currency ?? "",
     resolution: m.resolution ?? "",
     supported_durations_text: m.supported_durations ? compactRangeFormat(m.supported_durations) : "",
+    capability_overrides: m.capability_overrides,
   });
 }
 
@@ -131,6 +136,7 @@ function rowToInput(r: ModelRow): CustomProviderModelInput {
     ...(r.currency ? { currency: r.currency } : {}),
     ...(r.resolution ? { resolution: r.resolution } : { resolution: null }),
     ...(supported_durations ? { supported_durations } : { supported_durations: null }),
+    capability_overrides: r.capability_overrides,
   };
 }
 

--- a/frontend/src/components/shared/ImageModelDualSelect.test.tsx
+++ b/frontend/src/components/shared/ImageModelDualSelect.test.tsx
@@ -63,6 +63,8 @@ const CUSTOM_PROVIDERS: CustomProviderInfo[] = [
         currency: null,
         supported_durations: null,
         resolution: null,
+        system_capabilities: null,
+        capability_overrides: null,
       },
       {
         id: 2,
@@ -77,6 +79,8 @@ const CUSTOM_PROVIDERS: CustomProviderInfo[] = [
         currency: null,
         supported_durations: null,
         resolution: null,
+        system_capabilities: null,
+        capability_overrides: null,
       },
       {
         id: 3,
@@ -91,6 +95,8 @@ const CUSTOM_PROVIDERS: CustomProviderInfo[] = [
         currency: null,
         supported_durations: null,
         resolution: null,
+        system_capabilities: null,
+        capability_overrides: null,
       },
     ],
   },

--- a/frontend/src/stores/config-status-store.test.ts
+++ b/frontend/src/stores/config-status-store.test.ts
@@ -183,6 +183,8 @@ describe("config-status-store", () => {
               currency: null,
               supported_durations: null,
               resolution: null,
+              system_capabilities: null,
+              capability_overrides: null,
             },
           ],
         },

--- a/frontend/src/types/custom-provider.ts
+++ b/frontend/src/types/custom-provider.ts
@@ -45,7 +45,22 @@ export interface CustomProviderModelInfo {
   currency: string | null;
   supported_durations: number[] | null;
   resolution: string | null;
+  /** 系统判定的视频能力（四字段全量）；非视频模型为 null。 */
+  system_capabilities: VideoCapabilityFlags | null;
+  /** 用户覆盖（稀疏），与 system_capabilities 合并即为生效值；无覆盖为 null。 */
+  capability_overrides: CapabilityOverrides | null;
 }
+
+/** 与后端 VideoCapabilities 字段对齐。 */
+export interface VideoCapabilityFlags {
+  first_frame: boolean;
+  last_frame: boolean;
+  reference_images: boolean;
+  max_reference_images: number;
+}
+
+/** 稀疏覆盖字典：键缺席 = 跟随系统判定。当前后端只开放 last_frame。 */
+export type CapabilityOverrides = Partial<VideoCapabilityFlags>;
 
 export interface DiscoveredModel {
   model_id: string;
@@ -91,6 +106,8 @@ export interface CustomProviderModelInput {
   currency?: string;
   supported_durations?: number[] | null;
   resolution?: string | null;
+  /** 保存模型列表是整体替换语义：省略该字段会清空已有覆盖，编辑既有模型时必须原样回传。 */
+  capability_overrides?: CapabilityOverrides | null;
 }
 
 export interface CustomProviderCredentials {

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -675,8 +675,18 @@ class ConfigResolver:
                 raise ValueError(f"invalid custom provider_id: {provider_id}") from exc
             repo = CustomProviderRepository(session)
             model = await repo.get_model_by_ids(db_pid, model_id)
+            if model is not None and not model.is_enabled:
+                # 与 loader.load_custom_backend 同一条回退规则：请求 model 已禁用时执行层改派
+                # 默认启用 model，展示的能力必须与执行层一致，否则能力位仍按已禁用 model 合成，
+                # 会宣称执行层实际不会兑现的 first_frame/last_frame。
+                logger.warning("自定义模型 %s/%s 已禁用，能力解析回退到默认模型", provider_id, model_id)
+                model = None
             if model is None:
-                raise ValueError(f"custom model not found: {provider_id}/{model_id}")
+                default_model = await repo.get_default_model(db_pid, "video")
+                if default_model is None:
+                    raise ValueError(f"custom model not found: {provider_id}/{model_id}")
+                model = default_model
+                model_id = default_model.model_id
 
             # 生效能力（系统判定 ⊕ 用户覆盖）只此一个合成点：工厂给执行层注入的也是它的返回值，
             # 展示层与执行层因此严格同源，不在此处自行合并覆盖或重算系统判定。纯函数不查

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -421,7 +421,9 @@ class ConfigResolver:
               "model": str,
               "supported_durations": list[int],    # 来自 model (单一真相源)
               "max_duration": int,                 # max(supported_durations) 派生
-              "max_reference_images": int,         # registry: model.max_reference_images；custom: endpoint.video_max_reference_images
+              "max_reference_images": int,         # registry: model.max_reference_images；custom: 合成后的生效值
+              "first_frame": bool,                 # 生效值（系统判定 ⊕ 用户覆盖），与执行层同源
+              "last_frame": bool,                  # 同上
               "source": "registry" | "custom",
               "default_duration": int | None,      # 用户在 project.json 里设置的偏好
               "content_mode": str | None,

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lib.backend_assembly.specs import get_provider_spec
 from lib.config.registry import PROVIDER_REGISTRY, default_model_for_provider
 from lib.config.service import (
     _DEFAULT_AUDIO_BACKEND,
@@ -31,11 +32,12 @@ from lib.config.service import (
     ConfigService,
 )
 from lib.custom_provider import is_custom_provider, parse_provider_id
-from lib.custom_provider.endpoints import get_endpoint_spec
+from lib.custom_provider.capabilities import synthesize_video_capabilities
 from lib.db.repositories.credential_repository import CredentialRepository
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.project_manager import get_project_manager
 from lib.text_backends.base import TEXT_TASK_TIERS, VISION_REQUIRED_TASKS, TextTaskTier, TextTaskType
+from lib.video_backends.registry import video_capabilities_for_model as builtin_video_capabilities_for_model
 
 logger = logging.getLogger(__name__)
 
@@ -674,33 +676,21 @@ class ConfigResolver:
             if model is None:
                 raise ValueError(f"custom model not found: {provider_id}/{model_id}")
 
-            endpoint_spec = get_endpoint_spec(model.endpoint)
-            if endpoint_spec.media_type != "video":
-                raise ValueError(
-                    f"endpoint media_type mismatch: {provider_id}/{model_id} endpoint={model.endpoint!r} "
-                    f"is {endpoint_spec.media_type}, not video"
+            # 生效能力（系统判定 ⊕ 用户覆盖）只此一个合成点：工厂给执行层注入的也是它的返回值，
+            # 展示层与执行层因此严格同源，不在此处自行合并覆盖或重算系统判定。纯函数不查
+            # provider 行、不构造 SDK client，故每镜头解析无 DB/网络/client 构造副作用
+            # （也不因 api_key 缺失而抛）。
+            try:
+                caps = synthesize_video_capabilities(
+                    endpoint=model.endpoint,
+                    model_id=model_id,
+                    overrides=model.capability_overrides,
                 )
-            endpoint_cap = endpoint_spec.video_max_reference_images
-            if endpoint_cap is not None:
-                max_reference_images = endpoint_cap
-            else:
-                # endpoint cap 未声明（多 model 共享端点、容量随 model 变）→ 用 endpoint 绑定的纯
-                # caps 函数按 model_id 读 backend 声明的上限。纯函数不查 provider 行、不构造 SDK
-                # client，故每镜头解析无 DB/网络/client 构造副作用（也不因 api_key 缺失而抛）。
-                caps_fn = endpoint_spec.video_caps_for_model
-                if caps_fn is None:
-                    raise ValueError(
-                        f"video endpoint {model.endpoint!r} declares neither video_max_reference_images "
-                        f"nor video_caps_for_model: {provider_id}/{model_id}"
-                    )
-                max_reference_images = caps_fn(model_id).max_reference_images
-                if max_reference_images < 0:
-                    # backend caps 是这条链路的真相源，负数直接抛错，不静默下传——
-                    # 否则 reference_video_tasks 会按坏值跳过裁剪。
-                    raise ValueError(
-                        f"invalid backend max_reference_images: {provider_id}/{model_id} "
-                        f"endpoint={model.endpoint!r} value={max_reference_images!r}"
-                    )
+            except ValueError as exc:
+                raise ValueError(f"cannot resolve video capabilities for {provider_id}/{model_id}: {exc}") from exc
+            max_reference_images = caps.max_reference_images
+            first_frame = caps.first_frame
+            last_frame = caps.last_frame
             raw_durations = model.supported_durations
             supported_durations: list[int] = []
             if raw_durations:
@@ -722,6 +712,15 @@ class ConfigResolver:
                 raise ValueError(f"model not found in registry: {provider_id}/{model_id}")
             supported_durations = list(model_info.supported_durations or [])
             max_reference_images = model_info.max_reference_images
+            # 布尔能力位读 backend 声明，不复制进 ModelInfo：backend 是这几位的唯一真相源。
+            # max_reference_images 维持读 ModelInfo（注册表按 model 分档，backend 侧不区分）。
+            try:
+                spec = get_provider_spec(provider_id, "video")
+                builtin_caps = builtin_video_capabilities_for_model(spec.registry_backend, model_id)
+            except ValueError as exc:
+                raise ValueError(f"cannot resolve video capabilities for {provider_id}/{model_id}: {exc}") from exc
+            first_frame = builtin_caps.first_frame
+            last_frame = builtin_caps.last_frame
 
         if not supported_durations:
             raise ValueError(f"supported_durations is empty for {provider_id}/{model_id}; cannot derive capabilities")
@@ -750,6 +749,8 @@ class ConfigResolver:
             "supported_durations": supported_durations,
             "max_duration": max_duration,
             "max_reference_images": max_reference_images,
+            "first_frame": first_frame,
+            "last_frame": last_frame,
             "source": source,
             "default_duration": default_duration,
             "content_mode": content_mode,

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -33,6 +33,7 @@ from lib.config.service import (
 )
 from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.custom_provider.capabilities import synthesize_video_capabilities
+from lib.custom_provider.endpoints import endpoint_to_media_type
 from lib.db.repositories.credential_repository import CredentialRepository
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.project_manager import get_project_manager
@@ -675,11 +676,12 @@ class ConfigResolver:
                 raise ValueError(f"invalid custom provider_id: {provider_id}") from exc
             repo = CustomProviderRepository(session)
             model = await repo.get_model_by_ids(db_pid, model_id)
-            if model is not None and not model.is_enabled:
-                # 与 loader.load_custom_backend 同一条回退规则：请求 model 已禁用时执行层改派
-                # 默认启用 model，展示的能力必须与执行层一致，否则能力位仍按已禁用 model 合成，
-                # 会宣称执行层实际不会兑现的 first_frame/last_frame。
-                logger.warning("自定义模型 %s/%s 已禁用，能力解析回退到默认模型", provider_id, model_id)
+            if model is not None and (not model.is_enabled or endpoint_to_media_type(model.endpoint) != "video"):
+                # 与 loader.load_custom_backend 同一条回退规则：请求 model 已禁用或 endpoint 媒体
+                # 类型不再是 video（用户在设置里改了该模型的 endpoint）时执行层改派默认启用 model，
+                # 展示的能力必须与执行层一致，否则这里要么按已失效的 model 合成能力，要么直接报错，
+                # 而执行层其实静默回退成功了。
+                logger.warning("自定义模型 %s/%s 已禁用或媒体类型不符，能力解析回退到默认模型", provider_id, model_id)
                 model = None
             if model is None:
                 default_model = await repo.get_default_model(db_pid, "video")

--- a/lib/custom_provider/backends.py
+++ b/lib/custom_provider/backends.py
@@ -137,6 +137,21 @@ class CustomVideoBackend:
             return self._video_capabilities
         return self._delegate.video_capabilities
 
+    def video_capabilities_for_tier(self, service_tier: str, resolution: str | None = None) -> VideoCapabilities:
+        """按请求档位收窄能力，转发给被包装 backend（如 Kling）——与 `video_capabilities`
+        同一优先级：注入生效能力（用户覆盖）存在时优先返回它，否则查被包装 backend 是否实现
+        tier-aware 查询（`getattr` 探测，与 `media_generator` 的探测方式一致），未实现则回落
+        `video_capabilities`。缺失本方法时 `media_generator` 会回落到无请求上下文的保守声明，
+        让 Pro 档本可接受的尾帧被静默丢弃（`KlingVideoBackend.video_capabilities_for_tier` 的
+        docstring 详述了该保守声明的由来）。
+        """
+        if self._video_capabilities is not None:
+            return self._video_capabilities
+        tier_aware = getattr(self._delegate, "video_capabilities_for_tier", None)
+        if tier_aware is not None:
+            return tier_aware(service_tier, resolution=resolution)
+        return self._delegate.video_capabilities
+
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         return await self._delegate.generate(request)
 

--- a/lib/custom_provider/backends.py
+++ b/lib/custom_provider/backends.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from lib.audio_backends.base import AudioBackend, AudioCapability, AudioSynthesisRequest, AudioSynthesisResult
 from lib.image_backends.base import ImageBackend, ImageCapability, ImageGenerationRequest, ImageGenerationResult
 from lib.text_backends.base import TextBackend, TextCapability, TextGenerationRequest, TextGenerationResult
@@ -104,19 +106,30 @@ class CustomVideoBackend:
         delegate: VideoBackend,
         model: str,
         video_capabilities: VideoCapabilities | None = None,
+        capability_overrides: dict[str, object] | None = None,
     ) -> None:
         self._provider_id = provider_id
         self._delegate = delegate
         self._model = model
         self._video_capabilities = video_capabilities
+        self._capability_overrides = capability_overrides or {}
 
-    def with_video_capabilities(self, capabilities: VideoCapabilities) -> CustomVideoBackend:
-        """返回注入生效能力的新实例（不就地改写，包装器保持构造后不可变）。"""
+    def with_video_capabilities(
+        self, capabilities: VideoCapabilities, *, overrides: dict[str, object] | None = None
+    ) -> CustomVideoBackend:
+        """返回注入生效能力的新实例（不就地改写，包装器保持构造后不可变）。
+
+        ``overrides`` 是过滤后的稀疏用户覆盖（`filter_valid_overrides` 的返回值），供
+        `video_capabilities_for_tier` 叠加到档位感知基底上；与 ``capabilities``（系统判定 ⊕
+        覆盖的完整合成结果，供 context-free 的 `video_capabilities` 属性使用）分开传递——
+        两者不能合一，否则档位查询会短路回完整合成结果，见 `video_capabilities_for_tier`。
+        """
         return CustomVideoBackend(
             provider_id=self._provider_id,
             delegate=self._delegate,
             model=self._model,
             video_capabilities=capabilities,
+            capability_overrides=overrides,
         )
 
     @property
@@ -138,19 +151,24 @@ class CustomVideoBackend:
         return self._delegate.video_capabilities
 
     def video_capabilities_for_tier(self, service_tier: str, resolution: str | None = None) -> VideoCapabilities:
-        """按请求档位收窄能力，转发给被包装 backend（如 Kling）——与 `video_capabilities`
-        同一优先级：注入生效能力（用户覆盖）存在时优先返回它，否则查被包装 backend 是否实现
-        tier-aware 查询（`getattr` 探测，与 `media_generator` 的探测方式一致），未实现则回落
-        `video_capabilities`。缺失本方法时 `media_generator` 会回落到无请求上下文的保守声明，
-        让 Pro 档本可接受的尾帧被静默丢弃（`KlingVideoBackend.video_capabilities_for_tier` 的
-        docstring 详述了该保守声明的由来）。
+        """按请求档位收窄能力：以被包装 backend（如 Kling）的档位感知查询为基底——
+        `getattr` 探测是否实现（与 `media_generator` 的探测方式一致），未实现则回落其
+        context-free `video_capabilities`——再叠加稀疏用户覆盖（未覆盖字段跟随基底）。
+
+        不能直接短路返回工厂注入的完整合成结果（`self._video_capabilities`）：那是用
+        context-free 的系统判定算出的（对 Kling 等档位敏感 backend 而言是保守声明），工厂
+        路径下该字段永远非 None，短路会让本方法在生产环境等价于未实现档位感知，
+        Pro 档本可接受的尾帧被静默丢弃。
         """
-        if self._video_capabilities is not None:
-            return self._video_capabilities
         tier_aware = getattr(self._delegate, "video_capabilities_for_tier", None)
-        if tier_aware is not None:
-            return tier_aware(service_tier, resolution=resolution)
-        return self._delegate.video_capabilities
+        base = (
+            tier_aware(service_tier, resolution=resolution)
+            if tier_aware is not None
+            else self._delegate.video_capabilities
+        )
+        if self._capability_overrides:
+            return replace(base, **self._capability_overrides)
+        return base
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         return await self._delegate.generate(request)

--- a/lib/custom_provider/capabilities.py
+++ b/lib/custom_provider/capabilities.py
@@ -64,24 +64,21 @@ def system_video_capabilities(*, endpoint: str, model_id: str) -> VideoCapabilit
     return VideoCapabilities(reference_images=endpoint_cap > 0, max_reference_images=endpoint_cap)
 
 
-def synthesize_video_capabilities(
-    *,
-    endpoint: str,
-    model_id: str,
-    overrides: object | None,
-) -> VideoCapabilities:
-    """系统判定 ⊕ 用户覆盖 → 生效能力。
+def filter_valid_overrides(*, endpoint: str, model_id: str, overrides: object | None) -> dict[str, object]:
+    """按写入侧同一判定过滤 overrides，丢弃执行层不会采用的键值，返回真正生效的子集。
 
     ``overrides`` 为 ``CustomProviderModel.capability_overrides`` 的原始值（DB 里可能是任何
-    形状）。不被识别的键、类型不符的值一律忽略并告警，降级为该维度跟随系统判定：合成是执行
-    链路的最后一道，一条脏配置不该让整个生成路径不可用。合法性由 API 层白名单在写入侧把关。
+    形状）。不被识别的键、类型不符的值一律忽略并告警：合成是执行链路的最后一道，一条脏配置
+    不该让整个生成路径不可用。合法性由 API 层白名单在写入侧把关。
 
-    Raises:
-        ValueError: 系统判定本身不可得（见 :func:`system_video_capabilities`）。
+    :func:`synthesize_video_capabilities` 与 API 响应边界（``server/routers/custom_providers.py``
+    的 ``_model_to_response``）共用此过滤：后者据此裁剪回显给客户端的 ``capability_overrides``，
+    保证"界面显示的覆盖"与"执行层实际采用的覆盖"不漂移——否则存量脏数据会被界面呈现为已生效，
+    而实际执行时静默忽略。不校验 endpoint / media_type 合法性，调用方已各自处理（见
+    :func:`system_video_capabilities` 与 ``_system_capabilities_for``）。
     """
-    caps = system_video_capabilities(endpoint=endpoint, model_id=model_id)
     if overrides is None:
-        return caps
+        return {}
     if not isinstance(overrides, dict):
         logger.warning(
             "忽略 %s/%s 的能力覆盖：期望字典，实际 %s",
@@ -89,7 +86,7 @@ def synthesize_video_capabilities(
             model_id,
             type(overrides).__name__,
         )
-        return caps
+        return {}
 
     applied: dict[str, object] = {}
     for key, value in overrides.items():
@@ -119,6 +116,22 @@ def synthesize_video_capabilities(
             continue
         applied[key] = value
 
+    return applied
+
+
+def synthesize_video_capabilities(
+    *,
+    endpoint: str,
+    model_id: str,
+    overrides: object | None,
+) -> VideoCapabilities:
+    """系统判定 ⊕ 用户覆盖 → 生效能力。
+
+    Raises:
+        ValueError: 系统判定本身不可得（见 :func:`system_video_capabilities`）。
+    """
+    caps = system_video_capabilities(endpoint=endpoint, model_id=model_id)
+    applied = filter_valid_overrides(endpoint=endpoint, model_id=model_id, overrides=overrides)
     return replace(caps, **applied) if applied else caps
 
 

--- a/lib/custom_provider/capabilities.py
+++ b/lib/custom_provider/capabilities.py
@@ -107,13 +107,20 @@ def filter_valid_overrides(*, endpoint: str, model_id: str, overrides: object | 
         # 与写入侧同一判定（见 server/routers/custom_providers.py::_check_capability_overrides）：
         # last_frame=True 但 endpoint 的 delegate 不下传 end_image 时，覆盖只会让合成层宣称
         # 支持、执行层仍静默丢帧。写入侧已挡住新配置，这里再挡一遍存量行 / 非 API 写入路径。
-        if key == "last_frame" and value is True and not get_endpoint_spec(endpoint).end_image_capable:
-            logger.warning(
-                "忽略 %s/%s 的能力覆盖 last_frame=True：endpoint 不支持尾帧生成，该维度回退系统判定",
-                endpoint,
-                model_id,
-            )
-            continue
+        # endpoint 本身可能已从注册表下线（升级移除）：get_endpoint_spec 此时抛 ValueError，
+        # 视同不支持尾帧处理——存量脏配置不该让响应过滤这道最后防线也跟着炸。
+        if key == "last_frame" and value is True:
+            try:
+                end_image_capable = get_endpoint_spec(endpoint).end_image_capable
+            except ValueError:
+                end_image_capable = False
+            if not end_image_capable:
+                logger.warning(
+                    "忽略 %s/%s 的能力覆盖 last_frame=True：endpoint 不支持尾帧生成，该维度回退系统判定",
+                    endpoint,
+                    model_id,
+                )
+                continue
         applied[key] = value
 
     return applied

--- a/lib/custom_provider/capabilities.py
+++ b/lib/custom_provider/capabilities.py
@@ -97,7 +97,7 @@ def synthesize_video_capabilities(
         if expected is None:
             logger.warning("忽略 %s/%s 的未知能力覆盖键 %r", endpoint, model_id, key)
             continue
-        if not _value_matches(value, expected):
+        if not capability_value_matches(value, expected):
             logger.warning(
                 "忽略 %s/%s 的能力覆盖 %s=%r：期望 %s，该维度回退系统判定",
                 endpoint,
@@ -112,11 +112,14 @@ def synthesize_video_capabilities(
     return replace(caps, **applied) if applied else caps
 
 
-def _value_matches(value: object, expected: type) -> bool:
+def capability_value_matches(value: object, expected: type) -> bool:
     """覆盖值是否可直接落入该能力维度。
 
     bool 是 int 的子类，两个方向都要显式排除，否则 ``True`` 会被当成 1 张参考图上限、
     ``1`` 会被当成布尔真——这类宽松真值是语义猜测，不做。数值维度另拒负数。
+
+    写入侧校验（API 层白名单）与此处的合成必须用同一判定：两边一旦漂移，写入放行的值会被
+    合成静默忽略，正是本模块要消灭的「界面允许、执行反悔」。故此函数公开供 API 层复用。
     """
     if expected is bool:
         return isinstance(value, bool)

--- a/lib/custom_provider/capabilities.py
+++ b/lib/custom_provider/capabilities.py
@@ -137,9 +137,33 @@ def synthesize_video_capabilities(
     Raises:
         ValueError: 系统判定本身不可得（见 :func:`system_video_capabilities`）。
     """
+    caps, _applied = synthesize_video_capabilities_with_overrides(
+        endpoint=endpoint, model_id=model_id, overrides=overrides
+    )
+    return caps
+
+
+def synthesize_video_capabilities_with_overrides(
+    *,
+    endpoint: str,
+    model_id: str,
+    overrides: object | None,
+) -> tuple[VideoCapabilities, dict[str, object]]:
+    """同 :func:`synthesize_video_capabilities`，额外返回过滤后的稀疏覆盖字典。
+
+    工厂需要这份稀疏覆盖单独下传给请求期档位查询（见
+    ``CustomVideoBackend.video_capabilities_for_tier``）：该查询以被包装 backend 的档位感知
+    结果为基底，只应叠加真正被用户覆盖的字段，不能整体替换为本函数合并出的完整对象——那是
+    context-free 的系统判定（对 Kling 等档位敏感 backend 而言是保守声明），会让档位查询短路
+    回到未实现档位感知时的效果。
+
+    Raises:
+        ValueError: 系统判定本身不可得（见 :func:`system_video_capabilities`）。
+    """
     caps = system_video_capabilities(endpoint=endpoint, model_id=model_id)
     applied = filter_valid_overrides(endpoint=endpoint, model_id=model_id, overrides=overrides)
-    return replace(caps, **applied) if applied else caps
+    merged = replace(caps, **applied) if applied else caps
+    return merged, applied
 
 
 def capability_value_matches(value: object, expected: type) -> bool:

--- a/lib/custom_provider/capabilities.py
+++ b/lib/custom_provider/capabilities.py
@@ -107,6 +107,16 @@ def synthesize_video_capabilities(
                 expected.__name__,
             )
             continue
+        # 与写入侧同一判定（见 server/routers/custom_providers.py::_check_capability_overrides）：
+        # last_frame=True 但 endpoint 的 delegate 不下传 end_image 时，覆盖只会让合成层宣称
+        # 支持、执行层仍静默丢帧。写入侧已挡住新配置，这里再挡一遍存量行 / 非 API 写入路径。
+        if key == "last_frame" and value is True and not get_endpoint_spec(endpoint).end_image_capable:
+            logger.warning(
+                "忽略 %s/%s 的能力覆盖 last_frame=True：endpoint 不支持尾帧生成，该维度回退系统判定",
+                endpoint,
+                model_id,
+            )
+            continue
         applied[key] = value
 
     return replace(caps, **applied) if applied else caps

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -71,6 +71,10 @@ class EndpointSpec:
     # caps —— 不构造 SDK client、不查 provider 行。video_max_reference_images 为 int 时此字段应为
     # None（endpoint 维度已能给出硬上限）。二者对每个 video endpoint 恰填其一（见注册表末尾不变式）。
     video_caps_for_model: Callable[[str], VideoCapabilities] | None = None
+    # 该 endpoint 的 delegate.generate() 是否真的读取 VideoGenerationRequest.end_image 并下传
+    # 尾帧约束。仅 video 类有意义；False 时即便系统判定或用户覆盖把 last_frame 置为 True，执行层
+    # 也会静默丢弃尾帧、按无约束生成——写入侧 last_frame 覆盖据此收窄可开启的 endpoint 范围。
+    end_image_capable: bool = False
 
 
 # ── 各 endpoint 的 build_backend 闭包 ──────────────────────────────
@@ -317,6 +321,7 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         build_backend=_build_v2_video_generations,
         # 多 model 共享端点、容量不同 → endpoint 维度不声明，按 model 读 backend caps（不构造 client）
         video_caps_for_model=V2VideoGenerationsBackend.video_capabilities_for_model,
+        end_image_capable=True,
     ),
     "ark-seedance": EndpointSpec(
         key="ark-seedance",
@@ -327,6 +332,7 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         request_path_template="/api/v3/contents/generations/tasks",
         build_backend=_build_ark_seedance,
         video_caps_for_model=ArkVideoBackend.video_capabilities_for_model,
+        end_image_capable=True,
     ),
     "vidu-video": EndpointSpec(
         key="vidu-video",
@@ -337,6 +343,7 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         request_path_template="/ent/v2/img2video",
         build_backend=_build_vidu_video,
         video_caps_for_model=ViduVideoBackend.video_capabilities_for_model,
+        end_image_capable=True,
     ),
     "dashscope-image": EndpointSpec(
         key="dashscope-image",
@@ -413,6 +420,7 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         # 参考图上限随 model 异质（v3-omni / video-o1 多图主体 R2V max=4，其余首尾帧无参考为 0）→ 不在
         # endpoint 维度声明 int cap，按 model 读 backend 纯 caps 函数（与 minimax-video 同构）。
         video_caps_for_model=KlingVideoBackend.video_capabilities_for_model,
+        end_image_capable=True,
     ),
 }
 

--- a/lib/custom_provider/factory.py
+++ b/lib/custom_provider/factory.py
@@ -10,7 +10,7 @@ from lib.custom_provider.backends import (
     CustomTextBackend,
     CustomVideoBackend,
 )
-from lib.custom_provider.capabilities import synthesize_video_capabilities
+from lib.custom_provider.capabilities import synthesize_video_capabilities_with_overrides
 from lib.custom_provider.endpoints import get_endpoint_spec
 
 if TYPE_CHECKING:
@@ -41,7 +41,8 @@ def create_custom_backend(
     spec = get_endpoint_spec(endpoint)
     backend = spec.build_backend(provider, model_id)
     if isinstance(backend, CustomVideoBackend):
-        return backend.with_video_capabilities(
-            synthesize_video_capabilities(endpoint=endpoint, model_id=model_id, overrides=capability_overrides)
+        merged, applied = synthesize_video_capabilities_with_overrides(
+            endpoint=endpoint, model_id=model_id, overrides=capability_overrides
         )
+        return backend.with_video_capabilities(merged, overrides=applied)
     return backend

--- a/lib/db/repositories/custom_provider_repo.py
+++ b/lib/db/repositories/custom_provider_repo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import NamedTuple
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 
 from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
@@ -118,15 +118,20 @@ class CustomProviderRepository(BaseRepository):
         return new_models
 
     async def update_model(self, model_id: int, **kwargs) -> CustomProviderModel | None:
-        """更新模型字段。返回更新后的对象，若不存在返回 None。"""
-        stmt = select(CustomProviderModel).where(CustomProviderModel.id == model_id)
+        """按主键原子更新模型字段，返回更新后的对象，行不存在（含更新前一刻被删除）时返回 None。
+
+        用 ``UPDATE ... WHERE id = :model_id RETURNING *`` 而非「先 SELECT 再 setattr」：
+        后者的 SELECT 与后续 flush 之间存在窗口，调用方按旧主键整表删除重建（同一 model_id
+        新行）可在此间隙发生而不被发现。原子语句把「行是否还在」与「更新」并成一步，无中间态。
+        """
+        stmt = (
+            update(CustomProviderModel)
+            .where(CustomProviderModel.id == model_id)
+            .values(**kwargs)
+            .returning(CustomProviderModel)
+        )
         result = await self.session.execute(stmt)
-        model = result.scalar_one_or_none()
-        if model is None:
-            return None
-        for key, value in kwargs.items():
-            setattr(model, key, value)
-        return model
+        return result.scalar_one_or_none()
 
     async def delete_model(self, model_id: int) -> None:
         """删除单个模型。"""

--- a/lib/db/repositories/custom_provider_repo.py
+++ b/lib/db/repositories/custom_provider_repo.py
@@ -123,6 +123,7 @@ class CustomProviderRepository(BaseRepository):
         *,
         expect_provider_id: int | None = None,
         expect_model_id: str | None = None,
+        expect_endpoint: str | None = None,
         **kwargs,
     ) -> CustomProviderModel | None:
         """按主键原子更新模型字段，返回更新后的对象，行不存在（含更新前一刻被删除）时返回 None。
@@ -135,12 +136,20 @@ class CustomProviderRepository(BaseRepository):
         复用已释放的 ``INTEGER PRIMARY KEY``（表清空后新插入从最小可用值起），仅按主键匹配可能
         命中业务上完全不同的新行，把覆盖写错模型且不会返回 None（真实故障因此被吞掉）。业务标识
         一并校验后，主键复用但业务身份不符时谓词不命中，仍正确返回 None 触发调用方的 409。
+
+        ``expect_endpoint`` 传入时同样入谓词：业务身份（provider_id/model_id）不变、但并发整表
+        PUT 把该模型换到了另一个 endpoint 时，仅按业务身份匹配仍会命中——调用方对旧 endpoint
+        校验过的覆盖字段（如仅特定 endpoint 支持的 ``last_frame``）会被写入新 endpoint 的行，
+        校验结果与写入目标不一致。传入调用方读到旧行时的 endpoint 后，行已被换到别的 endpoint
+        时谓词不命中，正确返回 None 触发调用方的 409，而非静默写入一个校验时并不针对的 endpoint。
         """
         predicate = [CustomProviderModel.id == model_id]
         if expect_provider_id is not None:
             predicate.append(CustomProviderModel.provider_id == expect_provider_id)
         if expect_model_id is not None:
             predicate.append(CustomProviderModel.model_id == expect_model_id)
+        if expect_endpoint is not None:
+            predicate.append(CustomProviderModel.endpoint == expect_endpoint)
         stmt = update(CustomProviderModel).where(*predicate).values(**kwargs).returning(CustomProviderModel)
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()

--- a/lib/db/repositories/custom_provider_repo.py
+++ b/lib/db/repositories/custom_provider_repo.py
@@ -117,19 +117,31 @@ class CustomProviderRepository(BaseRepository):
         await self.session.flush()
         return new_models
 
-    async def update_model(self, model_id: int, **kwargs) -> CustomProviderModel | None:
+    async def update_model(
+        self,
+        model_id: int,
+        *,
+        expect_provider_id: int | None = None,
+        expect_model_id: str | None = None,
+        **kwargs,
+    ) -> CustomProviderModel | None:
         """按主键原子更新模型字段，返回更新后的对象，行不存在（含更新前一刻被删除）时返回 None。
 
         用 ``UPDATE ... WHERE id = :model_id RETURNING *`` 而非「先 SELECT 再 setattr」：
-        后者的 SELECT 与后续 flush 之间存在窗口，调用方按旧主键整表删除重建（同一 model_id
+        后者的 SELECT 与后续 flush 之间存在窗口，调用方按旧主键整表删除重建（同一业务 model_id
         新行）可在此间隙发生而不被发现。原子语句把「行是否还在」与「更新」并成一步，无中间态。
+
+        ``expect_provider_id``/``expect_model_id`` 传入时一并入谓词：SQLite 整表删除重建时会
+        复用已释放的 ``INTEGER PRIMARY KEY``（表清空后新插入从最小可用值起），仅按主键匹配可能
+        命中业务上完全不同的新行，把覆盖写错模型且不会返回 None（真实故障因此被吞掉）。业务标识
+        一并校验后，主键复用但业务身份不符时谓词不命中，仍正确返回 None 触发调用方的 409。
         """
-        stmt = (
-            update(CustomProviderModel)
-            .where(CustomProviderModel.id == model_id)
-            .values(**kwargs)
-            .returning(CustomProviderModel)
-        )
+        predicate = [CustomProviderModel.id == model_id]
+        if expect_provider_id is not None:
+            predicate.append(CustomProviderModel.provider_id == expect_provider_id)
+        if expect_model_id is not None:
+            predicate.append(CustomProviderModel.model_id == expect_model_id)
+        stmt = update(CustomProviderModel).where(*predicate).values(**kwargs).returning(CustomProviderModel)
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
 

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -145,6 +145,11 @@ MESSAGES = {
     "capability_override_invalid_value": (
         "Capability {capability} of model {model_id} has an invalid value type; expected {expected}"
     ),
+    "capability_override_last_frame_unsupported": (
+        "Endpoint {endpoint} of model {model_id} does not support last-frame generation; "
+        "last_frame cannot be overridden to true"
+    ),
+    "custom_model_concurrent_update": "Model {model_id} was modified concurrently; please refresh and retry",
     # Projects
     "unknown_style_template": "Unknown style template: {template_id}",
     "ad_only_field": "{field} is only available for ad/short-video projects (content_mode=ad)",

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -241,6 +241,7 @@ MESSAGES = {
     "video_start_image_unreadable": "The first-frame image for model {model} is unreadable; generation aborted: {name}; check the first-frame image path",
     "video_end_image_unreadable": "The last-frame image for model {model} is unreadable; generation aborted: {name}; check the last-frame image path",
     "video_end_image_requires_start_image": "Model {model} does not support a standalone last frame; also provide a first frame (first+last keyframes) or remove the last frame",
+    "video_last_frame_requires_pro": "{provider}/{model} only supports first+last frame at the pro tier; switch to the pro tier or remove the last frame",
     # Agent credentials
     "agent_preset_unknown": "Unknown preset provider: {preset_id}",
     "agent_base_url_required_custom": "base_url is required for custom configuration",

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -134,6 +134,17 @@ MESSAGES = {
     "endpoint_media_type_mismatch": "Endpoint media_type mismatch: {detail}",
     "backend_creation_failed": "Backend creation failed: {err_msg}",
     "unsupported_discovery_format": "Connection test not supported for {discovery_format}",
+    "custom_model_not_found": "Model not found: {model_id}",
+    "capability_overrides_video_only": (
+        "Endpoint {endpoint} of model {model_id} is not a video endpoint; capability overrides are not supported"
+    ),
+    "capability_override_unknown_key": "Capability overrides of model {model_id} contain an unknown capability: {capability}",
+    "capability_override_not_open": (
+        "Capability {capability} of model {model_id} is not open for override; currently overridable: {allowed}"
+    ),
+    "capability_override_invalid_value": (
+        "Capability {capability} of model {model_id} has an invalid value type; expected {expected}"
+    ),
     # Projects
     "unknown_style_template": "Unknown style template: {template_id}",
     "ad_only_field": "{field} is only available for ad/short-video projects (content_mode=ad)",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -241,6 +241,7 @@ MESSAGES = {
     "video_start_image_unreadable": "Ảnh khung hình đầu của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình đầu",
     "video_end_image_unreadable": "Ảnh khung hình cuối của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình cuối",
     "video_end_image_requires_start_image": "Mô hình {model} không hỗ trợ khung hình cuối độc lập; hãy cung cấp thêm khung hình đầu (chế độ khung đầu+cuối) hoặc bỏ khung hình cuối",
+    "video_last_frame_requires_pro": "{provider}/{model} chỉ hỗ trợ khung đầu+cuối ở gói pro; hãy chuyển sang gói pro hoặc bỏ khung hình cuối",
     # Agent credentials
     "agent_preset_unknown": "Nhà cung cấp đặt sẵn không xác định: {preset_id}",
     "agent_base_url_required_custom": "Cấu hình tuỳ chỉnh yêu cầu base_url",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -145,6 +145,11 @@ MESSAGES = {
     "capability_override_invalid_value": (
         "Năng lực {capability} của mô hình {model_id} có kiểu giá trị không hợp lệ; cần {expected}"
     ),
+    "capability_override_last_frame_unsupported": (
+        "Endpoint {endpoint} của mô hình {model_id} không hỗ trợ tạo khung hình cuối; "
+        "không thể ghi đè last_frame thành true"
+    ),
+    "custom_model_concurrent_update": "Mô hình {model_id} đã bị sửa đổi đồng thời; vui lòng làm mới và thử lại",
     # Projects
     "unknown_style_template": "Mẫu phong cách không xác định: {template_id}",
     "ad_only_field": "{field} chỉ khả dụng cho dự án quảng cáo/video ngắn (content_mode=ad)",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -134,6 +134,17 @@ MESSAGES = {
     "endpoint_media_type_mismatch": "media_type của endpoint không khớp: {detail}",
     "backend_creation_failed": "Tạo backend thất bại: {err_msg}",
     "unsupported_discovery_format": "Kiểm tra kết nối không hỗ trợ với {discovery_format}",
+    "custom_model_not_found": "Không tìm thấy mô hình: {model_id}",
+    "capability_overrides_video_only": (
+        "Endpoint {endpoint} của mô hình {model_id} không phải loại video; không hỗ trợ ghi đè năng lực"
+    ),
+    "capability_override_unknown_key": "Ghi đè năng lực của mô hình {model_id} chứa năng lực không xác định: {capability}",
+    "capability_override_not_open": (
+        "Năng lực {capability} của mô hình {model_id} chưa mở cho ghi đè; hiện có thể ghi đè: {allowed}"
+    ),
+    "capability_override_invalid_value": (
+        "Năng lực {capability} của mô hình {model_id} có kiểu giá trị không hợp lệ; cần {expected}"
+    ),
     # Projects
     "unknown_style_template": "Mẫu phong cách không xác định: {template_id}",
     "ad_only_field": "{field} chỉ khả dụng cho dự án quảng cáo/video ngắn (content_mode=ad)",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -131,6 +131,11 @@ MESSAGES = {
     "endpoint_media_type_mismatch": "模型 endpoint 与媒体类型不一致: {detail}",
     "backend_creation_failed": "Backend 创建失败: {err_msg}",
     "unsupported_discovery_format": "供应商 {discovery_format} 暂不支持连接测试",
+    "custom_model_not_found": "模型不存在: {model_id}",
+    "capability_overrides_video_only": "模型 {model_id} 的 endpoint {endpoint} 不是视频类，不支持能力覆盖",
+    "capability_override_unknown_key": "模型 {model_id} 的能力覆盖包含未知能力项: {capability}",
+    "capability_override_not_open": "模型 {model_id} 的能力项 {capability} 暂不开放覆盖，当前可覆盖: {allowed}",
+    "capability_override_invalid_value": "模型 {model_id} 的能力项 {capability} 取值类型不正确，应为 {expected}",
     # Projects
     "unknown_style_template": "未知的风格模版: {template_id}",
     "ad_only_field": "{field} 仅广告/短片项目（content_mode=ad）可用",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -136,6 +136,8 @@ MESSAGES = {
     "capability_override_unknown_key": "模型 {model_id} 的能力覆盖包含未知能力项: {capability}",
     "capability_override_not_open": "模型 {model_id} 的能力项 {capability} 暂不开放覆盖，当前可覆盖: {allowed}",
     "capability_override_invalid_value": "模型 {model_id} 的能力项 {capability} 取值类型不正确，应为 {expected}",
+    "capability_override_last_frame_unsupported": "模型 {model_id} 的 endpoint {endpoint} 不支持尾帧生成，无法覆盖 last_frame 为开启",
+    "custom_model_concurrent_update": "模型 {model_id} 已被并发修改，请刷新后重试",
     # Projects
     "unknown_style_template": "未知的风格模版: {template_id}",
     "ad_only_field": "{field} 仅广告/短片项目（content_mode=ad）可用",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -229,6 +229,7 @@ MESSAGES = {
     "video_start_image_unreadable": "模型 {model} 的首帧图无法读取，已中止生成：{name}；请检查首帧图路径",
     "video_end_image_unreadable": "模型 {model} 的尾帧图无法读取，已中止生成：{name}；请检查尾帧图路径",
     "video_end_image_requires_start_image": "模型 {model} 不支持单独的尾帧；请同时提供首帧（首尾帧模式），或移除尾帧",
+    "video_last_frame_requires_pro": "{provider}/{model} 的首尾帧仅在 pro 档生效；请切换到 pro 档，或移除尾帧",
     # Agent credentials
     "agent_preset_unknown": "未知预设供应商: {preset_id}",
     "agent_base_url_required_custom": "自定义配置需要填写 base_url",

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -615,7 +615,7 @@ class MediaGenerator:
             if end_image and self._video_backend:
                 tier_aware_caps = getattr(self._video_backend, "video_capabilities_for_tier", None)
                 caps = (
-                    tier_aware_caps(version_metadata.get("service_tier", "default"))
+                    tier_aware_caps(version_metadata.get("service_tier", "default"), resolution=resolution)
                     if tier_aware_caps is not None
                     else self._video_backend.video_capabilities
                 )

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -606,10 +606,20 @@ class MediaGenerator:
 
             # 尾帧只在后端声明 last_frame 时下发：参考图是与首帧互斥的独立路径，
             # 把尾帧转投参考图会丢掉首帧语义，故不支持尾帧的后端直接忽略该槽位。
+            #
+            # 优先取 video_capabilities_for_tier（若后端实现）：某些后端（如 Kling）的
+            # last_frame 仅在特定 service_tier 生效，无请求上下文的 video_capabilities 属性
+            # 只能保守声明，会让合法档位的请求在这里被误判不支持而静默丢帧。
             actual_end_image = None
 
             if end_image and self._video_backend:
-                if self._video_backend.video_capabilities.last_frame:
+                tier_aware_caps = getattr(self._video_backend, "video_capabilities_for_tier", None)
+                caps = (
+                    tier_aware_caps(version_metadata.get("service_tier", "default"))
+                    if tier_aware_caps is not None
+                    else self._video_backend.video_capabilities
+                )
+                if caps.last_frame:
                     actual_end_image = end_image  # first_last mode
                 else:
                     logger.warning(

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -221,15 +221,24 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
     def capabilities(self) -> set[VideoCapability]:
         return self._capabilities
 
-    @property
-    def video_capabilities(self) -> VideoCapabilities:
-        # 首帧 + 尾帧（首尾关键帧）+ 多图主体参考；参考图不与首帧叠加（单通道 + mode 不可叠加）。
+    @staticmethod
+    def video_capabilities_for_model(model: str) -> VideoCapabilities:
+        """按 model_id 纯计算 caps —— 不构造 SDK client（无需 api_key）。
+
+        首帧 + 尾帧（首尾关键帧）+ 多图主体参考；参考图不与首帧叠加（单通道 + mode 不可叠加）。
+        当前全系模型能力一致，不按 model_id 分支；instance property 委托至此，
+        保持 backend 为单一真相源。
+        """
         return VideoCapabilities(
             first_frame=True,
             last_frame=True,
             reference_images=True,
             max_reference_images=_MAX_REFERENCE_IMAGES,
         )
+
+    @property
+    def video_capabilities(self) -> VideoCapabilities:
+        return self.video_capabilities_for_model(self._model)
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         # 读盘 + base64 编码（首尾帧最多 2 张、参考图最多 4 张，可能数 MB）offload 到线程，

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -105,11 +105,19 @@ class GeminiVideoBackend(ProviderJobIdPersistenceMixin):
     def capabilities(self) -> set[VideoCapability]:
         return self._capabilities
 
+    @staticmethod
+    def video_capabilities_for_model(model: str) -> VideoCapabilities:
+        """按 model_id 纯计算 caps —— 不构造 SDK client（无需 api_key）。
+
+        Veo 文档（docs/google-genai-docs/veo.md）把 Image-to-video 与 Reference images
+        列为并列模式，带参考图时 durationSeconds 必须为 8。当前全系模型能力一致，不按
+        model_id 分支；instance property 委托至此，保持 backend 为单一真相源。
+        """
+        return VideoCapabilities(last_frame=True, reference_images=True, max_reference_images=3)
+
     @property
     def video_capabilities(self) -> VideoCapabilities:
-        # Veo 文档（docs/google-genai-docs/veo.md）把 Image-to-video 与 Reference images
-        # 列为并列模式，带参考图时 durationSeconds 必须为 8。
-        return VideoCapabilities(last_frame=True, reference_images=True, max_reference_images=3)
+        return self.video_capabilities_for_model(self._video_model)
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         """生成视频。任务创建和轮询阶段分离重试，避免瞬态错误导致重建任务。"""

--- a/lib/video_backends/grok.py
+++ b/lib/video_backends/grok.py
@@ -55,9 +55,18 @@ class GrokVideoBackend:
     def capabilities(self) -> set[VideoCapability]:
         return self._capabilities
 
+    @staticmethod
+    def video_capabilities_for_model(model: str) -> VideoCapabilities:
+        """按 model_id 纯计算 caps —— 不构造 SDK client（无需 api_key）。
+
+        当前全系模型能力一致，不按 model_id 分支；instance property 委托至此，
+        保持 backend 为单一真相源。
+        """
+        return VideoCapabilities(reference_images=True, max_reference_images=7)
+
     @property
     def video_capabilities(self) -> VideoCapabilities:
-        return VideoCapabilities(reference_images=True, max_reference_images=7)
+        return self.video_capabilities_for_model(self._model)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
         # Grok 同步型 API，无 job_id 可接续；orphan handler 据 NotImplementedError 标 [resume_unsupported]

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -251,6 +251,25 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
     def video_capabilities(self) -> VideoCapabilities:
         return self.video_capabilities_for_model(self._model)
 
+    def video_capabilities_for_tier(self, service_tier: str) -> VideoCapabilities:
+        """按实际请求档位收窄的 last_frame 声明，供有请求上下文的调用方使用。
+
+        `video_capabilities_for_model(model)` 是无请求上下文的纯函数，对
+        `last_frame_requires_pro` 的 model 只能保守声明 `last_frame=False`（供
+        `/video-capabilities`、custom provider resolver 等无 tier 信息的调用方）。而
+        `media_generator` 转发 `end_image` 前已知 `service_tier`——按此处收窄，pro 档放行、
+        std/4k 档仍保守拒绝，与 `_build_payload` 的 fail-loud 护栏放行条件对齐，避免 pro 档
+        请求被上层静默丢帧（该请求实际会被 `_build_payload` 接受）。
+        """
+        caps = _lookup_video_caps(self._model)
+        last_frame = caps.last_frame and (not caps.last_frame_requires_pro or (service_tier or "").lower() == "pro")
+        return VideoCapabilities(
+            first_frame=True,
+            last_frame=last_frame,
+            reference_images=caps.reference_images,
+            max_reference_images=caps.max_reference_images,
+        )
+
     # ── request building ────────────────────────────────────────────────
 
     def _resolve_mode(self, request: VideoGenerationRequest) -> str:

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -251,18 +251,21 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
     def video_capabilities(self) -> VideoCapabilities:
         return self.video_capabilities_for_model(self._model)
 
-    def video_capabilities_for_tier(self, service_tier: str) -> VideoCapabilities:
+    def video_capabilities_for_tier(self, service_tier: str, resolution: str | None = None) -> VideoCapabilities:
         """按实际请求档位收窄的 last_frame 声明，供有请求上下文的调用方使用。
 
         `video_capabilities_for_model(model)` 是无请求上下文的纯函数，对
         `last_frame_requires_pro` 的 model 只能保守声明 `last_frame=False`（供
         `/video-capabilities`、custom provider resolver 等无 tier 信息的调用方）。而
-        `media_generator` 转发 `end_image` 前已知 `service_tier`——按此处收窄，pro 档放行、
-        std/4k 档仍保守拒绝，与 `_build_payload` 的 fail-loud 护栏放行条件对齐，避免 pro 档
-        请求被上层静默丢帧（该请求实际会被 `_build_payload` 接受）。
+        `media_generator` 转发 `end_image` 前已知 `service_tier`/`resolution`——按此处收窄，
+        实际解析出的 mode（复用 `_resolve_mode_from` 同一派生规则，`resolution="4k"` 优先于
+        `service_tier`）为 pro 才放行、std/4k 档仍保守拒绝，与 `_build_payload` 的 fail-loud
+        护栏放行条件对齐，避免 pro 档请求被上层静默丢帧（该请求实际会被 `_build_payload` 接受），
+        也避免 4k+pro 组合被误判放行（`_resolve_mode` 对该组合解出 ``"4k"`` 而非 ``"pro"``）。
         """
         caps = _lookup_video_caps(self._model)
-        last_frame = caps.last_frame and (not caps.last_frame_requires_pro or (service_tier or "").lower() == "pro")
+        mode = self._resolve_mode_from(resolution, service_tier)
+        last_frame = caps.last_frame and (not caps.last_frame_requires_pro or mode == "pro")
         return VideoCapabilities(
             first_frame=True,
             last_frame=last_frame,
@@ -272,14 +275,20 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
 
     # ── request building ────────────────────────────────────────────────
 
-    def _resolve_mode(self, request: VideoGenerationRequest) -> str:
+    @staticmethod
+    def _resolve_mode_from(resolution: str | None, service_tier: str | None) -> str:
         """质量档 → mode：resolution=4k 独立成 ``4k`` 档（仅 v3/v3-omni 可达），否则 service_tier→std/pro。
 
         与 per_second_tiered 定价的档位派生一致（4k 优先于 std/pro），保证请求档与计费档同源。
+        `_resolve_mode` 与 `video_capabilities_for_tier` 共用此同一派生规则，避免两处独立实现
+        对同一请求解出不同 mode（曾因此让 tier-aware 能力查询对 4k+pro 组合误判 last_frame=True）。
         """
-        if (request.resolution or "").lower() == "4k":
+        if (resolution or "").lower() == "4k":
             return "4k"
-        return "pro" if (request.service_tier or "").lower() == "pro" else "std"
+        return "pro" if (service_tier or "").lower() == "pro" else "std"
+
+    def _resolve_mode(self, request: VideoGenerationRequest) -> str:
+        return self._resolve_mode_from(request.resolution, request.service_tier)
 
     def _effective_audio(self, request: VideoGenerationRequest) -> bool:
         """实际是否产出视频内人声：请求要 + model 有 generate_audio 能力 + pro 档（官方仅 v2-6 pro ✅）。

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -233,10 +233,16 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         # max_reference_images 同时声明于 registry ModelInfo（编排层裁剪读它）与此处（生成时防御），取保守
         # 值、待 app.klingai.com 控制台核对。纯函数（不构造 client / 不需 api_key），供 custom endpoint
         # resolver 按 model_id 读上限复用。
+        #
+        # last_frame_requires_pro 为真的 model（kling-v2-5-turbo、kling-v2-6）：该位不按 service_tier
+        # 分档——service_tier 是逐请求字段（generation_tasks 入队时选定），本函数只按 model 声明、
+        # 无从得知调用方将选哪档。std/4k 档提交尾帧会被 _build_payload 的 fail-loud 护栏拒绝，declare
+        # 一个仅在少数档位成立的 True 会让 media_generator 按此位放行 end_image、多数请求撞 guard 硬失败；
+        # 保守声明 False 更贴近默认档的真实执行结果，与未登记 model 回落保守默认同一原则。
         caps = _lookup_video_caps(model)
         return VideoCapabilities(
             first_frame=True,
-            last_frame=caps.last_frame,
+            last_frame=caps.last_frame and not caps.last_frame_requires_pro,
             reference_images=caps.reference_images,
             max_reference_images=caps.max_reference_images,
         )

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -69,6 +69,11 @@ class _KlingVideoModelCaps:
     text_to_video: bool
     image_to_video: bool
     last_frame: bool
+    # last_frame=True 但仅 pro 档可用（官方一手：kling-v2-5-turbo、kling-v2-6 首尾帧均标"仅 pro"，
+    # 出处 docs/research/arcreel-vendor-integration-research.md）；std 档提交 image_tail 请求体虽会
+    # 被受理，尾帧约束却不生效——_build_payload 按此位在 std 档拒绝 image_tail，而非放行一个
+    # 调用方以为已生效实则被忽略的请求。
+    last_frame_requires_pro: bool
     reference_images: bool
     max_reference_images: int
     generate_audio: bool  # 能产出视频内人声；官方仅 v2-6（pro 档）标 ✅
@@ -80,6 +85,7 @@ _DEFAULT_VIDEO_CAPS = _KlingVideoModelCaps(
     text_to_video=True,
     image_to_video=True,
     last_frame=True,
+    last_frame_requires_pro=True,
     reference_images=False,
     max_reference_images=0,
     generate_audio=False,
@@ -92,6 +98,7 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
         text_to_video=True,
         image_to_video=True,
         last_frame=True,
+        last_frame_requires_pro=False,
         reference_images=False,
         max_reference_images=0,
         generate_audio=False,
@@ -101,6 +108,7 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
         text_to_video=True,
         image_to_video=True,
         last_frame=True,
+        last_frame_requires_pro=False,
         reference_images=True,
         max_reference_images=_R2V_MAX_REFERENCE_IMAGES,
         generate_audio=False,
@@ -110,6 +118,7 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
         text_to_video=True,
         image_to_video=True,
         last_frame=True,
+        last_frame_requires_pro=True,
         reference_images=False,
         max_reference_images=0,
         generate_audio=True,
@@ -119,6 +128,7 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
         text_to_video=False,
         image_to_video=True,
         last_frame=True,
+        last_frame_requires_pro=False,
         reference_images=True,
         max_reference_images=_R2V_MAX_REFERENCE_IMAGES,
         generate_audio=False,
@@ -301,6 +311,10 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
             payload["image"] = self._encode_frame(Path(start_image))
             end_image = request.end_image
             if isinstance(end_image, (str, Path)) and str(end_image):
+                # 该 model 的首尾帧仅 pro 档生效时，std/4k 档提交 image_tail 虽会被官方接口受理，
+                # 尾帧约束却不生效——fail loud 拒绝而非放行一个调用方以为已生效实则被忽略的请求。
+                if self._caps.last_frame_requires_pro and self._resolve_mode(request) != "pro":
+                    raise VideoCapabilityError("video_last_frame_requires_pro", provider=self.name, model=self._model)
                 payload["image_tail"] = self._encode_frame(Path(end_image))
             subpath = _IMAGE2VIDEO
 

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -94,9 +94,18 @@ class NewAPIVideoBackend(ProviderJobIdPersistenceMixin):
     def capabilities(self) -> set[VideoCapability]:
         return self._capabilities
 
+    @staticmethod
+    def video_capabilities_for_model(model: str) -> VideoCapabilities:
+        """按 model_id 纯计算 caps —— 不构造 SDK client（无需 api_key）。
+
+        中转端点不接受参考图；当前全系模型能力一致，不按 model_id 分支。
+        instance property 委托至此，保持 backend 为单一真相源。
+        """
+        return VideoCapabilities(reference_images=False, max_reference_images=0)
+
     @property
     def video_capabilities(self) -> VideoCapabilities:
-        return VideoCapabilities(reference_images=False, max_reference_images=0)
+        return self.video_capabilities_for_model(self._model)
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         width, height = _resolve_size(request.resolution, request.aspect_ratio)

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -111,10 +111,19 @@ class OpenAIVideoBackend(ProviderJobIdPersistenceMixin):
     def capabilities(self) -> set[VideoCapability]:
         return self._capabilities
 
+    @staticmethod
+    def video_capabilities_for_model(model: str) -> VideoCapabilities:
+        """按 model_id 纯计算 caps —— 不构造 SDK client（无需 api_key）。
+
+        Sora input_reference 为单张首帧图，参考图上限为 1；首帧与参考共享该单槽位。
+        当前全系模型能力一致，不按 model_id 分支；instance property 委托至此，
+        保持 backend 为单一真相源。
+        """
+        return VideoCapabilities(reference_images=True, max_reference_images=1)
+
     @property
     def video_capabilities(self) -> VideoCapabilities:
-        # Sora input_reference 为单张首帧图，参考图上限为 1；首帧与参考共享该单槽位。
-        return VideoCapabilities(reference_images=True, max_reference_images=1)
+        return self.video_capabilities_for_model(self._model)
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         kwargs: dict = {

--- a/lib/video_backends/registry.py
+++ b/lib/video_backends/registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from lib.video_backends.base import VideoBackend
+from lib.video_backends.base import VideoBackend, VideoCapabilities
 
 _BACKEND_FACTORIES: dict[str, Callable[..., VideoBackend]] = {}
 
@@ -25,3 +25,22 @@ def create_backend(name: str, **kwargs: Any) -> VideoBackend:
 def get_registered_backends() -> list[str]:
     """返回所有已注册的后端名称。"""
     return list(_BACKEND_FACTORIES.keys())
+
+
+def video_capabilities_for_model(name: str, model_id: str) -> VideoCapabilities:
+    """读某后端对某 model 声明的视频能力 —— 纯查表，不构造实例（无需 api_key）。
+
+    ``name`` 是 registry 名（内置侧由 ``ProviderSpec.registry_backend`` 给出，与 provider_id
+    不必相同：gemini-aistudio / gemini-vertex 同映射到 ``gemini``）。展示层解析内置模型的
+    布尔能力位走这里，使 backend 保持唯一真相源，不在注册表复制第二份能力声明。
+    """
+    factory = _BACKEND_FACTORIES.get(name)
+    if factory is None:
+        raise ValueError(f"Unknown video backend: {name}")
+    caps_fn = getattr(factory, "video_capabilities_for_model", None)
+    if caps_fn is None:
+        raise ValueError(f"video backend {name!r} does not declare video_capabilities_for_model")
+    caps = caps_fn(model_id)
+    if not isinstance(caps, VideoCapabilities):
+        raise ValueError(f"video backend {name!r} video_capabilities_for_model returned {type(caps).__name__}")
+    return caps

--- a/lib/video_backends/vidu.py
+++ b/lib/video_backends/vidu.py
@@ -185,16 +185,20 @@ class ViduVideoBackend:
 
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
-        """按 model_id 纯计算 caps —— 不构造 client。保留 `model` 形参仅为跨 backend 接口统一，
-        Vidu 容量当前不随 model 变（恒为 `_MAX_REFERENCE_IMAGES`）。
+        """按 model_id 纯计算 caps —— 不构造 client。first_frame/last_frame/reference_images
+        直接查 `_ENDPOINT_MODELS` 的端点白名单，与 `_select_endpoint`/`_build_request` 实际能否
+        派发到 /img2video、/start-end2video、/reference2video 同源：例如 `viduq3` 不在
+        /img2video、/start-end2video 白名单内（只支持 /reference2video），若恒为 True，
+        调用方按声明提交首帧/尾帧会在 `_build_request` 抛 RuntimeError。容量上限
+        （max_reference_images）不随 model 变，恒为 `_MAX_REFERENCE_IMAGES`。
         """
         return VideoCapabilities(
-            first_frame=True,
-            last_frame=True,
-            reference_images=True,
+            first_frame=model in _ENDPOINT_MODELS["/img2video"],
+            last_frame=model in _ENDPOINT_MODELS["/start-end2video"],
+            reference_images=model in _ENDPOINT_MODELS["/reference2video"],
             max_reference_images=_MAX_REFERENCE_IMAGES,
             # 参考图与首帧在 Vidu 上是互斥模式：_select_endpoint 见参考图即切 /reference2video，
-            # start_image 不进请求体（首帧被丢弃），且多数型号不在该端点白名单内会直接 RuntimeError。
+            # start_image 不进请求体（首帧被丢弃）。
         )
 
     @property

--- a/lib/video_backends/vidu.py
+++ b/lib/video_backends/vidu.py
@@ -189,14 +189,17 @@ class ViduVideoBackend:
         直接查 `_ENDPOINT_MODELS` 的端点白名单，与 `_select_endpoint`/`_build_request` 实际能否
         派发到 /img2video、/start-end2video、/reference2video 同源：例如 `viduq3` 不在
         /img2video、/start-end2video 白名单内（只支持 /reference2video），若恒为 True，
-        调用方按声明提交首帧/尾帧会在 `_build_request` 抛 RuntimeError。容量上限
-        （max_reference_images）不随 model 变，恒为 `_MAX_REFERENCE_IMAGES`。
+        调用方按声明提交首帧/尾帧会在 `_build_request` 抛 RuntimeError。`max_reference_images`
+        随 `reference_images` 联动归零（与 `kling.py` 同一实现约定一致）：不在 /reference2video
+        白名单的 model 不可能提交参考图，声明非零容量会误导展示层（如自定义供应商的
+        `/video-capabilities`）。
         """
+        reference_images = model in _ENDPOINT_MODELS["/reference2video"]
         return VideoCapabilities(
             first_frame=model in _ENDPOINT_MODELS["/img2video"],
             last_frame=model in _ENDPOINT_MODELS["/start-end2video"],
-            reference_images=model in _ENDPOINT_MODELS["/reference2video"],
-            max_reference_images=_MAX_REFERENCE_IMAGES,
+            reference_images=reference_images,
+            max_reference_images=_MAX_REFERENCE_IMAGES if reference_images else 0,
             # 参考图与首帧在 Vidu 上是互斥模式：_select_endpoint 见参考图即切 /reference2video，
             # start_image 不进请求体（首帧被丢弃）。
         )

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -769,8 +769,18 @@ async def update_model_capability_overrides(
     # 空字典与 None 都表示"全部跟随"，统一落 NULL，避免 DB 里出现两种等价表示。
     # 按行首查到的旧主键（model.id）更新：并发的整表 PUT（replace_models）会先删后按同一
     # model_id 重建新行，旧主键随之失效。update_model 返回 None 即命中该竞态——此时旧主键已
-    # 不存在，写入根本没有落到任何行，须回 409 而非静默按更新成功处理。
-    if await repo.update_model(model.id, capability_overrides=overrides or None) is None:
+    # 不存在，写入根本没有落到任何行，须回 409 而非静默按更新成功处理。一并传入业务标识
+    # （provider_id/model_id）：SQLite 整表删除重建会复用释放出的主键，仅按主键匹配可能命中
+    # 业务上无关的新行，一并校验业务标识可挡住这类静默写错模型。
+    if (
+        await repo.update_model(
+            model.id,
+            expect_provider_id=provider_id,
+            expect_model_id=model_id,
+            capability_overrides=overrides or None,
+        )
+        is None
+    ):
         raise HTTPException(status_code=409, detail=_t("custom_model_concurrent_update", model_id=model_id))
     await session.commit()
     await _invalidate_caches(request)

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -23,6 +23,7 @@ from lib.custom_provider import make_provider_id
 from lib.custom_provider.capabilities import (
     CAPABILITY_OVERRIDE_FIELDS,
     capability_value_matches,
+    filter_valid_overrides,
     system_video_capabilities,
 )
 from lib.custom_provider.endpoints import (
@@ -272,11 +273,24 @@ def _system_capabilities_for(endpoint: str, model_id: str) -> dict[str, object] 
         return None
 
 
+def _effective_overrides_for_response(
+    endpoint: str, model_id: str, overrides: object | None
+) -> dict[str, object] | None:
+    """回显前按写入侧同一判定过滤，剔除执行层不会采用的键值。
+
+    存量行 / 非 API 写入可能留下已不兼容的覆盖（如 endpoint 不再 end_image_capable 后的
+    last_frame=True）：原样回显会让界面显示"覆盖已生效"，但执行层其实静默忽略；且客户端
+    普通保存时把它原样回传，会被写入侧白名单拒为 422，堵住与该覆盖无关的编辑。
+    """
+    filtered = filter_valid_overrides(endpoint=endpoint, model_id=model_id, overrides=overrides)
+    return filtered or None
+
+
 def _model_to_response(m) -> ModelResponse:
     durations = json.loads(m.supported_durations) if m.supported_durations else None
     return ModelResponse(
         system_capabilities=_system_capabilities_for(m.endpoint, m.model_id),
-        capability_overrides=m.capability_overrides,
+        capability_overrides=_effective_overrides_for_response(m.endpoint, m.model_id, m.capability_overrides),
         id=m.id,
         model_id=m.model_id,
         display_name=m.display_name,

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -771,12 +771,15 @@ async def update_model_capability_overrides(
     # model_id 重建新行，旧主键随之失效。update_model 返回 None 即命中该竞态——此时旧主键已
     # 不存在，写入根本没有落到任何行，须回 409 而非静默按更新成功处理。一并传入业务标识
     # （provider_id/model_id）：SQLite 整表删除重建会复用释放出的主键，仅按主键匹配可能命中
-    # 业务上无关的新行，一并校验业务标识可挡住这类静默写错模型。
+    # 业务上无关的新行，一并校验业务标识可挡住这类静默写错模型。再传入校验时读到的旧 endpoint
+    # （model.endpoint）：业务身份不变但并发 PUT 把模型换到了另一个 endpoint 时，上面的校验是
+    # 针对旧 endpoint 做的，若不核对 endpoint 是否仍一致，写入会落到一个校验结果并不适用的行。
     if (
         await repo.update_model(
             model.id,
             expect_provider_id=provider_id,
             expect_model_id=model_id,
+            expect_endpoint=model.endpoint,
             capability_overrides=overrides or None,
         )
         is None

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Callable
+from dataclasses import asdict
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -19,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from lib.api_errors import BadRequestError
 from lib.config.repository import mask_secret
 from lib.custom_provider import make_provider_id
+from lib.custom_provider.capabilities import CAPABILITY_OVERRIDE_FIELDS, system_video_capabilities
 from lib.custom_provider.endpoints import (
     ENDPOINT_REGISTRY,
     endpoint_spec_to_dict,
@@ -47,6 +49,10 @@ DiscoveryFormatLiteral = Literal["openai", "google"]
 
 # 并发上限定型字段：可空正整数（≥1）；None = 未设置 → 容量装载回退全局默认。
 MaxWorkers = Annotated[int | None, Field(default=None, ge=1)]
+
+# 开放给用户覆盖的能力维度。DB 列与合成函数对 VideoCapabilities 全字段通用，写入侧在此收窄：
+# 未列入的维度即便是合法字段名也拒收，扩容只需往这里加键名，无需 DB 迁移或改合成语义。
+CAPABILITY_OVERRIDE_ALLOWLIST = frozenset({"last_frame"})
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +101,9 @@ class ModelInput(BaseModel):
     currency: str | None = None
     supported_durations: list[int] | None = None
     resolution: str | None = None
+    # 稀疏覆盖字典，键名对齐 VideoCapabilities 字段名；None 或键缺席 = 跟随系统判定。
+    # 保存模型列表是整体替换语义，本字段必须随列表回传，否则存量覆盖被清空。
+    capability_overrides: dict[str, object] | None = None
 
     def to_db_dict(self) -> dict:
         """返回适合写入数据库的字典（supported_durations 序列化为 JSON 字符串）。
@@ -173,6 +182,16 @@ class ModelResponse(BaseModel):
     currency: str | None = None
     supported_durations: list[int] | None = None
     resolution: str | None = None
+    # 系统判定值（四字段全量），video endpoint 才有；非 video 或 endpoint 声明异常时为 None。
+    system_capabilities: dict[str, object] | None = None
+    # 用户覆盖（稀疏字典），与 system_capabilities 平凡合并即为生效值。
+    capability_overrides: dict[str, object] | None = None
+
+
+class CapabilityOverridesRequest(BaseModel):
+    """单模型能力覆盖写入体：携带完整覆盖字典，整体替换存量（非逐键 merge）。"""
+
+    capability_overrides: dict[str, object] | None = None
 
 
 class ProviderResponse(BaseModel):
@@ -229,9 +248,26 @@ class EndpointCatalogResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+def _system_capabilities_for(endpoint: str, model_id: str) -> dict[str, object] | None:
+    """读该 model 的系统判定能力（四字段全量）；非 video endpoint 返回 None。
+
+    判定失败（endpoint 已下线、注册表声明异常）时降级为 None 而非 500：列表端点要能把
+    其余模型正常呈现出来，单行判定不出来只是设置页少一段"判定值"提示。
+    """
+    try:
+        if endpoint_to_media_type(endpoint) != "video":
+            return None
+        return asdict(system_video_capabilities(endpoint=endpoint, model_id=model_id))
+    except ValueError:
+        logger.warning("无法判定系统能力: endpoint=%r model_id=%r", endpoint, model_id)
+        return None
+
+
 def _model_to_response(m) -> ModelResponse:
     durations = json.loads(m.supported_durations) if m.supported_durations else None
     return ModelResponse(
+        system_capabilities=_system_capabilities_for(m.endpoint, m.model_id),
+        capability_overrides=m.capability_overrides,
         id=m.id,
         model_id=m.model_id,
         display_name=m.display_name,
@@ -295,6 +331,66 @@ def _check_duplicate_model_ids(models: list[ModelInput], _t: Callable[..., str])
             raise HTTPException(status_code=422, detail=_t("duplicate_model_id", model_id=m.model_id))
         if m.model_id:
             seen.add(m.model_id)
+
+
+def _check_capability_overrides(
+    overrides: dict[str, object] | None,
+    endpoint: str,
+    model_id: str,
+    _t: Callable[..., str],
+) -> None:
+    """写入侧白名单校验：合成函数对脏值只降级不抛，合法性把关全在这里。
+
+    None 与空字典都表示"全部跟随系统判定"，一律放行。非空字典要求 endpoint 为 video 类，
+    且每个键都是 VideoCapabilities 字段、在开放白名单内、值类型与该字段一致。
+    """
+    if not overrides:
+        return
+    if endpoint_to_media_type(endpoint) != "video":
+        raise HTTPException(
+            status_code=422,
+            detail=_t("capability_overrides_video_only", model_id=model_id, endpoint=endpoint),
+        )
+    for key, value in overrides.items():
+        expected = CAPABILITY_OVERRIDE_FIELDS.get(key)
+        if expected is None:
+            raise HTTPException(
+                status_code=422,
+                detail=_t("capability_override_unknown_key", model_id=model_id, capability=key),
+            )
+        if key not in CAPABILITY_OVERRIDE_ALLOWLIST:
+            raise HTTPException(
+                status_code=422,
+                detail=_t(
+                    "capability_override_not_open",
+                    model_id=model_id,
+                    capability=key,
+                    allowed=", ".join(sorted(CAPABILITY_OVERRIDE_ALLOWLIST)),
+                ),
+            )
+        # bool 是 int 子类，两个方向都要显式排除，否则 True 会被当作 int 覆盖放行。
+        if expected is bool:
+            ok = isinstance(value, bool)
+        elif expected is int:
+            ok = isinstance(value, int) and not isinstance(value, bool) and value >= 0
+        else:
+            ok = isinstance(value, expected)
+        if not ok:
+            raise HTTPException(
+                status_code=422,
+                detail=_t(
+                    "capability_override_invalid_value",
+                    model_id=model_id,
+                    capability=key,
+                    expected=expected.__name__,
+                ),
+            )
+
+
+def _check_model_capability_overrides(models: list[ModelInput], _t: Callable[..., str]) -> None:
+    """对整批模型逐个跑覆盖白名单校验（保存模型列表的写入路径）。"""
+    for m in models:
+        _check_capability_overrides(m.capability_overrides, m.endpoint, m.model_id, _t)
 
 
 def _check_unique_defaults(models: list[ModelInput], _t: Callable[..., str]) -> None:
@@ -390,6 +486,7 @@ async def create_provider(
     if body.models:
         _check_duplicate_model_ids(body.models, _t)
         _check_unique_defaults(body.models, _t)
+        _check_model_capability_overrides(body.models, _t)
     repo = CustomProviderRepository(session)
     model_dicts = [m.to_db_dict() for m in body.models] if body.models else None
     provider = await repo.create_provider(
@@ -492,6 +589,7 @@ async def full_update_provider(
     """原子更新供应商元数据 + 模型列表（单一事务）。"""
     _check_duplicate_model_ids(body.models, _t)
     _check_unique_defaults(body.models, _t)
+    _check_model_capability_overrides(body.models, _t)
     repo = CustomProviderRepository(session)
     kwargs: dict = {
         "display_name": body.display_name,
@@ -561,6 +659,7 @@ async def replace_models(
     """替换供应商的整个模型列表。"""
     _check_duplicate_model_ids(body.models, _t)
     _check_unique_defaults(body.models, _t)
+    _check_model_capability_overrides(body.models, _t)
     repo = CustomProviderRepository(session)
     provider = await repo.get_provider(provider_id)
     if provider is None:
@@ -590,6 +689,41 @@ async def replace_models(
     await session.commit()
     await _invalidate_caches(request)
     return [_model_to_response(m) for m in new_models]
+
+
+@router.patch("/{provider_id}/models/{model_id:path}/capability-overrides", response_model=ModelResponse)
+async def update_model_capability_overrides(
+    provider_id: int,
+    model_id: str,
+    body: CapabilityOverridesRequest,
+    request: Request,
+    _user: CurrentUser,
+    _t: Translator,
+    session: AsyncSession = Depends(get_async_session),
+) -> ModelResponse:
+    """整体替换单个模型的能力覆盖字典。
+
+    请求体携带完整覆盖字典（不是逐键 patch）：省略某键即该维度回到跟随系统判定，传 None 或
+    空字典即清空全部覆盖。走单模型端点而非重发整张模型列表，设置页切一个三态控件不必回传
+    其余模型，也不触碰列表的整体替换语义。
+    """
+    repo = CustomProviderRepository(session)
+    model = await repo.get_model_by_ids(provider_id, model_id)
+    if model is None:
+        raise HTTPException(status_code=404, detail=_t("custom_model_not_found", model_id=model_id))
+
+    overrides = body.capability_overrides
+    _check_capability_overrides(overrides, model.endpoint, model_id, _t)
+    # 空字典与 None 都表示"全部跟随"，统一落 NULL，避免 DB 里出现两种等价表示。
+    await repo.update_model(model.id, capability_overrides=overrides or None)
+    await session.commit()
+    await _invalidate_caches(request)
+
+    updated = await repo.get_model_by_ids(provider_id, model_id)
+    # 刚更新成功，行必然存在；理论上并发删除可致 None，此时按 404 语义回报而非 500。
+    if updated is None:
+        raise HTTPException(status_code=404, detail=_t("custom_model_not_found", model_id=model_id))
+    return _model_to_response(updated)
 
 
 # ---------------------------------------------------------------------------

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -20,7 +20,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from lib.api_errors import BadRequestError
 from lib.config.repository import mask_secret
 from lib.custom_provider import make_provider_id
-from lib.custom_provider.capabilities import CAPABILITY_OVERRIDE_FIELDS, system_video_capabilities
+from lib.custom_provider.capabilities import (
+    CAPABILITY_OVERRIDE_FIELDS,
+    capability_value_matches,
+    system_video_capabilities,
+)
 from lib.custom_provider.endpoints import (
     ENDPOINT_REGISTRY,
     endpoint_spec_to_dict,
@@ -368,14 +372,9 @@ def _check_capability_overrides(
                     allowed=", ".join(sorted(CAPABILITY_OVERRIDE_ALLOWLIST)),
                 ),
             )
-        # bool 是 int 子类，两个方向都要显式排除，否则 True 会被当作 int 覆盖放行。
-        if expected is bool:
-            ok = isinstance(value, bool)
-        elif expected is int:
-            ok = isinstance(value, int) and not isinstance(value, bool) and value >= 0
-        else:
-            ok = isinstance(value, expected)
-        if not ok:
+        # 值类型判定复用合成层的同一函数：两边各写一份会漂移，届时写入侧放行的值被合成
+        # 静默忽略，正是本能力覆盖链路要消灭的「界面允许、执行反悔」。
+        if not capability_value_matches(value, expected):
             raise HTTPException(
                 status_code=422,
                 detail=_t(

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -30,6 +30,7 @@ from lib.custom_provider.endpoints import (
     endpoint_spec_to_dict,
     endpoint_to_image_capabilities,
     endpoint_to_media_type,
+    get_endpoint_spec,
 )
 from lib.db import get_async_session
 from lib.db.base import dt_to_iso
@@ -193,9 +194,13 @@ class ModelResponse(BaseModel):
 
 
 class CapabilityOverridesRequest(BaseModel):
-    """单模型能力覆盖写入体：携带完整覆盖字典，整体替换存量（非逐键 merge）。"""
+    """单模型能力覆盖写入体：携带完整覆盖字典，整体替换存量（非逐键 merge）。
 
-    capability_overrides: dict[str, object] | None = None
+    字段无默认值——必须显式传 null 或字典才表示"整体替换"；请求体缺失该键（如拼写错误、
+    序列化遗漏）会被 Pydantic 拒为 422，而不是静默当作 null 把已有覆盖清空。
+    """
+
+    capability_overrides: dict[str, object] | None
 
 
 class ProviderResponse(BaseModel):
@@ -382,6 +387,17 @@ def _check_capability_overrides(
                     model_id=model_id,
                     capability=key,
                     expected=expected.__name__,
+                ),
+            )
+        # last_frame 覆盖为 True 时，endpoint 的 delegate.generate() 必须真的会读取
+        # end_image 下传尾帧约束——否则覆盖只是让合成层宣称支持，执行层仍静默生成无约束视频。
+        if key == "last_frame" and value is True and not get_endpoint_spec(endpoint).end_image_capable:
+            raise HTTPException(
+                status_code=422,
+                detail=_t(
+                    "capability_override_last_frame_unsupported",
+                    model_id=model_id,
+                    endpoint=endpoint,
                 ),
             )
 
@@ -714,7 +730,11 @@ async def update_model_capability_overrides(
     overrides = body.capability_overrides
     _check_capability_overrides(overrides, model.endpoint, model_id, _t)
     # 空字典与 None 都表示"全部跟随"，统一落 NULL，避免 DB 里出现两种等价表示。
-    await repo.update_model(model.id, capability_overrides=overrides or None)
+    # 按行首查到的旧主键（model.id）更新：并发的整表 PUT（replace_models）会先删后按同一
+    # model_id 重建新行，旧主键随之失效。update_model 返回 None 即命中该竞态——此时旧主键已
+    # 不存在，写入根本没有落到任何行，须回 409 而非静默按更新成功处理。
+    if await repo.update_model(model.id, capability_overrides=overrides or None) is None:
+        raise HTTPException(status_code=409, detail=_t("custom_model_concurrent_update", model_id=model_id))
     await session.commit()
     await _invalidate_caches(request)
 

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import asdict
 from typing import Annotated, Literal
 
@@ -416,9 +416,25 @@ def _check_capability_overrides(
             )
 
 
-def _check_model_capability_overrides(models: list[ModelInput], _t: Callable[..., str]) -> None:
-    """对整批模型逐个跑覆盖白名单校验（保存模型列表的写入路径）。"""
+def _check_model_capability_overrides(
+    models: list[ModelInput],
+    _t: Callable[..., str],
+    *,
+    stored_overrides: Mapping[str, object | None] | None = None,
+) -> None:
+    """对整批模型逐个跑覆盖白名单校验（保存模型列表的写入路径）。
+
+    ``stored_overrides`` 传入时按 model_id 对照当前落库值：与落库值相同则跳过白名单校验。
+    这条端点承载的是模型基础字段（名称/价格/是否启用等）的整表写入，覆盖内容的编辑走专门的
+    PATCH 端点（``update_model_capability_overrides``），白名单收紧只在那里把关。否则前端把
+    GET 回显（``filter_valid_overrides`` 只做结构性校验，不过滤白名单）原样带回本端点时，历史
+    行 / 非 API 写入产生的、已不在开放白名单内但结构合法的覆盖值会让用户连改个显示名都被拒绝，
+    且没有入口能清掉它。
+    """
+    stored_overrides = stored_overrides or {}
     for m in models:
+        if m.model_id in stored_overrides and m.capability_overrides == stored_overrides[m.model_id]:
+            continue
         _check_capability_overrides(m.capability_overrides, m.endpoint, m.model_id, _t)
 
 
@@ -618,8 +634,10 @@ async def full_update_provider(
     """原子更新供应商元数据 + 模型列表（单一事务）。"""
     _check_duplicate_model_ids(body.models, _t)
     _check_unique_defaults(body.models, _t)
-    _check_model_capability_overrides(body.models, _t)
     repo = CustomProviderRepository(session)
+    old_models = await repo.list_models(provider_id)
+    stored_overrides = {m.model_id: m.capability_overrides for m in old_models}
+    _check_model_capability_overrides(body.models, _t, stored_overrides=stored_overrides)
     kwargs: dict = {
         "display_name": body.display_name,
         "base_url": body.base_url,
@@ -688,14 +706,15 @@ async def replace_models(
     """替换供应商的整个模型列表。"""
     _check_duplicate_model_ids(body.models, _t)
     _check_unique_defaults(body.models, _t)
-    _check_model_capability_overrides(body.models, _t)
     repo = CustomProviderRepository(session)
     provider = await repo.get_provider(provider_id)
     if provider is None:
         raise HTTPException(status_code=404, detail=_t("provider_not_found"))
-    # 记录旧模型 ID，用于清理悬空引用
+    # 记录旧模型 ID，用于清理悬空引用；同时对照旧覆盖值判定白名单校验是否可跳过
     old_models = await repo.list_models(provider_id)
     old_model_ids = {m.model_id for m in old_models}
+    stored_overrides = {m.model_id: m.capability_overrides for m in old_models}
+    _check_model_capability_overrides(body.models, _t, stored_overrides=stored_overrides)
     new_model_ids = {m.model_id for m in body.models}
     deleted_model_ids = old_model_ids - new_model_ids
 

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -420,20 +420,24 @@ def _check_model_capability_overrides(
     models: list[ModelInput],
     _t: Callable[..., str],
     *,
-    stored_overrides: Mapping[str, object | None] | None = None,
+    stored_state: Mapping[str, tuple[str, object | None]] | None = None,
 ) -> None:
     """对整批模型逐个跑覆盖白名单校验（保存模型列表的写入路径）。
 
-    ``stored_overrides`` 传入时按 model_id 对照当前落库值：与落库值相同则跳过白名单校验。
-    这条端点承载的是模型基础字段（名称/价格/是否启用等）的整表写入，覆盖内容的编辑走专门的
-    PATCH 端点（``update_model_capability_overrides``），白名单收紧只在那里把关。否则前端把
-    GET 回显（``filter_valid_overrides`` 只做结构性校验，不过滤白名单）原样带回本端点时，历史
-    行 / 非 API 写入产生的、已不在开放白名单内但结构合法的覆盖值会让用户连改个显示名都被拒绝，
-    且没有入口能清掉它。
+    ``stored_state`` 传入时按 model_id 对照当前落库的 ``(endpoint, capability_overrides)``：
+    两者都未变更才跳过白名单校验——校验结果本就是 endpoint 相关的（白名单本身不区分 endpoint，
+    但 last_frame=True 还要求 endpoint 的 end_image_capable；non-video endpoint 直接拒绝非空
+    覆盖），只比对覆盖值而不比对 endpoint 会让「model_id 不变、覆盖字典不变、endpoint 悄悄换了」
+    的整表 PUT 绕过针对新 endpoint 的校验。这条端点承载的是模型基础字段（名称/价格/是否启用等）
+    的整表写入，覆盖内容的编辑走专门的 PATCH 端点（``update_model_capability_overrides``），白
+    名单收紧只在那里把关。否则前端把 GET 回显（``filter_valid_overrides`` 只做结构性校验，不过
+    滤白名单）原样带回本端点时，历史行 / 非 API 写入产生的、已不在开放白名单内但结构合法的覆盖
+    值会让用户连改个显示名都被拒绝，且没有入口能清掉它。
     """
-    stored_overrides = stored_overrides or {}
+    stored_state = stored_state or {}
     for m in models:
-        if m.model_id in stored_overrides and m.capability_overrides == stored_overrides[m.model_id]:
+        stored = stored_state.get(m.model_id)
+        if stored is not None and stored == (m.endpoint, m.capability_overrides):
             continue
         _check_capability_overrides(m.capability_overrides, m.endpoint, m.model_id, _t)
 
@@ -636,8 +640,8 @@ async def full_update_provider(
     _check_unique_defaults(body.models, _t)
     repo = CustomProviderRepository(session)
     old_models = await repo.list_models(provider_id)
-    stored_overrides = {m.model_id: m.capability_overrides for m in old_models}
-    _check_model_capability_overrides(body.models, _t, stored_overrides=stored_overrides)
+    stored_state = {m.model_id: (m.endpoint, m.capability_overrides) for m in old_models}
+    _check_model_capability_overrides(body.models, _t, stored_state=stored_state)
     kwargs: dict = {
         "display_name": body.display_name,
         "base_url": body.base_url,
@@ -710,11 +714,11 @@ async def replace_models(
     provider = await repo.get_provider(provider_id)
     if provider is None:
         raise HTTPException(status_code=404, detail=_t("provider_not_found"))
-    # 记录旧模型 ID，用于清理悬空引用；同时对照旧覆盖值判定白名单校验是否可跳过
+    # 记录旧模型 ID，用于清理悬空引用；同时对照旧 (endpoint, 覆盖值) 判定白名单校验是否可跳过
     old_models = await repo.list_models(provider_id)
     old_model_ids = {m.model_id for m in old_models}
-    stored_overrides = {m.model_id: m.capability_overrides for m in old_models}
-    _check_model_capability_overrides(body.models, _t, stored_overrides=stored_overrides)
+    stored_state = {m.model_id: (m.endpoint, m.capability_overrides) for m in old_models}
+    _check_model_capability_overrides(body.models, _t, stored_state=stored_state)
     new_model_ids = {m.model_id for m in body.models}
     deleted_model_ids = old_model_ids - new_model_ids
 

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -190,6 +190,66 @@ class TestModelListExposesCapabilities:
         models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["capability_overrides"] is None
 
+    @pytest.mark.integration
+    async def test_corrupted_non_dict_override_does_not_500_response(self, client: TestClient, session_factory):
+        """存量行 / 手工 SQL 可能让 JSON 列存了非字典值（字符串、列表等）：执行层的
+        synthesize_video_capabilities 按容错设计忽略它，响应边界须同样容错，不能把原值
+        直接塞进只接受 dict | None 的 ModelResponse 触发 Pydantic 校验错误，让整个列表/详情
+        请求 500——用户也就无法进入设置页清理这条坏值。"""
+        async with session_factory() as session:
+            repo = CustomProviderRepository(session)
+            provider = await repo.create_provider(
+                display_name="Relay",
+                discovery_format="openai",
+                base_url="https://relay.test/v1",
+                api_key="sk-relay",
+                models=[
+                    {
+                        "model_id": VIDEO_MODEL,
+                        "display_name": "Sora 2",
+                        "endpoint": VIDEO_ENDPOINT,
+                        "is_enabled": True,
+                        "is_default": True,
+                        "capability_overrides": "last_frame",
+                    }
+                ],
+            )
+            await session.commit()
+            pid = provider.id
+
+        resp = client.get(f"/api/v1/custom-providers/{pid}")
+        assert resp.status_code == 200
+        assert resp.json()["models"][0]["capability_overrides"] is None
+
+    @pytest.mark.integration
+    async def test_retired_endpoint_override_does_not_500_response(self, client: TestClient, session_factory):
+        """endpoint 已从注册表下线（升级移除）时，get_endpoint_spec 会抛 ValueError；响应边界
+        过滤 last_frame 覆盖时须容错这条查表失败，不能让存量脏配置把列表/详情请求也炸成 500。"""
+        async with session_factory() as session:
+            repo = CustomProviderRepository(session)
+            provider = await repo.create_provider(
+                display_name="Relay",
+                discovery_format="openai",
+                base_url="https://relay.test/v1",
+                api_key="sk-relay",
+                models=[
+                    {
+                        "model_id": "retired-model",
+                        "display_name": "Retired",
+                        "endpoint": "no-such-retired-endpoint",
+                        "is_enabled": True,
+                        "is_default": True,
+                        "capability_overrides": {"last_frame": True},
+                    }
+                ],
+            )
+            await session.commit()
+            pid = provider.id
+
+        resp = client.get(f"/api/v1/custom-providers/{pid}")
+        assert resp.status_code == 200
+        assert resp.json()["models"][0]["capability_overrides"] is None
+
 
 class TestPatchCapabilityOverrides:
     """PATCH 携带完整覆盖字典，整体替换存量。"""

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -397,3 +397,53 @@ class TestBuiltinBackendsDeclareCapabilityFunction:
 
         with pytest.raises(ValueError, match="Unknown video backend"):
             video_capabilities_for_model("no-such-backend", "m")
+
+
+class TestVideoCapabilitiesEndpoint:
+    """GET /projects/{name}/video-capabilities 的响应形状与覆盖联动。
+
+    其余同源测试打在 resolver 私有方法上，这里补住 HTTP 这一层：新增的两个布尔位真的
+    出现在接口响应里，且写入覆盖后接口返回值随之变化（不只是 resolver 内部变了）。
+    """
+
+    @staticmethod
+    def _client(monkeypatch, session_factory, provider_id: str) -> TestClient:
+        from fastapi import FastAPI
+
+        from lib.config import resolver as resolver_mod
+        from server.routers import projects as projects_mod
+
+        class _FakePM:
+            def load_project(self, name: str) -> dict:
+                return {"name": name, "video_backend": f"{provider_id}/{VIDEO_MODEL}"}
+
+        monkeypatch.setattr(projects_mod, "async_session_factory", session_factory)
+        monkeypatch.setattr(resolver_mod, "get_project_manager", lambda: _FakePM())
+
+        app = FastAPI()
+        app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="t", sub="t", role="admin")
+        app.include_router(projects_mod.router, prefix="/api/v1")
+        register_error_handlers(app)
+        return TestClient(app)
+
+    async def test_endpoint_returns_effective_boolean_caps(self, session_factory, monkeypatch):
+        async with session_factory() as session:
+            pid = await TestResolverReturnsEffectiveCapabilities._seed(session, overrides=None)
+
+        with self._client(monkeypatch, session_factory, pid) as client:
+            body = client.get("/api/v1/projects/demo/video-capabilities").json()
+
+        system = system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL)
+        assert body["first_frame"] is system.first_frame
+        assert body["last_frame"] is system.last_frame is False
+
+    async def test_endpoint_follows_written_override(self, session_factory, monkeypatch):
+        """AC：对自定义模型写入覆盖后，该接口返回值随之变化。"""
+        async with session_factory() as session:
+            pid = await TestResolverReturnsEffectiveCapabilities._seed(session, overrides={"last_frame": True})
+
+        with self._client(monkeypatch, session_factory, pid) as client:
+            body = client.get("/api/v1/projects/demo/video-capabilities").json()
+
+        assert system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL).last_frame is False
+        assert body["last_frame"] is True

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -368,7 +368,9 @@ class TestResolverReturnsEffectiveCapabilities:
     """/video-capabilities 走的 resolver 必须回生效能力，且与执行层同源。"""
 
     @staticmethod
-    async def _seed(session: AsyncSession, *, overrides: object | None) -> str:
+    async def _seed(
+        session: AsyncSession, *, overrides: object | None, endpoint: str = VIDEO_ENDPOINT, model_id: str = VIDEO_MODEL
+    ) -> str:
         repo = CustomProviderRepository(session)
         provider = await repo.create_provider(
             display_name="Relay",
@@ -377,9 +379,9 @@ class TestResolverReturnsEffectiveCapabilities:
             api_key="sk-relay",
             models=[
                 {
-                    "model_id": VIDEO_MODEL,
+                    "model_id": model_id,
                     "display_name": "Sora 2",
-                    "endpoint": VIDEO_ENDPOINT,
+                    "endpoint": endpoint,
                     "is_enabled": True,
                     "is_default": True,
                     "supported_durations": "[5, 10]",
@@ -391,14 +393,14 @@ class TestResolverReturnsEffectiveCapabilities:
         return make_provider_id(provider.id)
 
     @staticmethod
-    async def _resolve(session: AsyncSession, provider_id: str) -> dict:
+    async def _resolve(session: AsyncSession, provider_id: str, model_id: str = VIDEO_MODEL) -> dict:
         from lib.config.resolver import ConfigResolver
         from lib.config.service import ConfigService
 
         factory = async_sessionmaker(bind=session.get_bind(), class_=AsyncSession, expire_on_commit=False)  # type: ignore[call-overload]
         resolver = ConfigResolver(factory, _bound_session=session)
         return await resolver._resolve_video_caps_for_model(
-            ConfigService(session), session, provider_id, VIDEO_MODEL, None
+            ConfigService(session), session, provider_id, model_id, None
         )
 
     async def test_custom_model_without_overrides_follows_system(self, session: AsyncSession):
@@ -412,21 +414,35 @@ class TestResolverReturnsEffectiveCapabilities:
 
     async def test_override_changes_resolver_output(self, session: AsyncSession):
         """AC：对自定义模型写入覆盖后，该接口返回值随之变化。"""
-        pid = await self._seed(session, overrides={"last_frame": True})
+        pid = await self._seed(
+            session, overrides={"last_frame": True}, endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL
+        )
 
-        caps = await self._resolve(session, pid)
-        assert system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL).last_frame is False
+        caps = await self._resolve(session, pid, model_id=LAST_FRAME_MODEL)
+        assert system_video_capabilities(endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL).last_frame is False
         assert caps["last_frame"] is True
 
-    @pytest.mark.integration
-    @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
-    async def test_resolver_matches_execution_layer(self, _mock_cls, session: AsyncSession):
-        """展示层与执行层出自同一合成函数：逐字段比对 resolver 与装载出的 backend。"""
+    async def test_override_ignored_when_endpoint_lacks_end_image_support(self, session: AsyncSession):
+        """openai-video 的 delegate 不下传 end_image：即便存量行/非 API 写入把 last_frame 写成 True，
+        resolver 也须回退系统判定，而不是把「合成层宣称支持、执行层静默丢帧」的错误状态当作生效。"""
         pid = await self._seed(session, overrides={"last_frame": True})
 
         caps = await self._resolve(session, pid)
+        assert caps["last_frame"] is False
+
+    @pytest.mark.integration
+    @patch("lib.custom_provider.endpoints.ArkVideoBackend")
+    async def test_resolver_matches_execution_layer(self, _mock_cls, session: AsyncSession):
+        """展示层与执行层出自同一合成函数：逐字段比对 resolver 与装载出的 backend。"""
+        pid = await self._seed(
+            session, overrides={"last_frame": True}, endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL
+        )
+
+        caps = await self._resolve(session, pid, model_id=LAST_FRAME_MODEL)
         session.expunge_all()
-        backend = await load_custom_backend(session=session, provider_id=pid, model_id=VIDEO_MODEL, media_type="video")
+        backend = await load_custom_backend(
+            session=session, provider_id=pid, model_id=LAST_FRAME_MODEL, media_type="video"
+        )
 
         executed = backend.video_capabilities
         assert caps["first_frame"] is executed.first_frame
@@ -434,7 +450,7 @@ class TestResolverReturnsEffectiveCapabilities:
         assert caps["max_reference_images"] == executed.max_reference_images
         # 同源的判据：两侧都等于合成函数在同一输入下的返回值
         expected = synthesize_video_capabilities(
-            endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL, overrides={"last_frame": True}
+            endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL, overrides={"last_frame": True}
         )
         assert executed == expected
 
@@ -489,7 +505,7 @@ class TestVideoCapabilitiesEndpoint:
     """
 
     @staticmethod
-    def _client(monkeypatch, session_factory, provider_id: str) -> TestClient:
+    def _client(monkeypatch, session_factory, provider_id: str, model_id: str = VIDEO_MODEL) -> TestClient:
         from fastapi import FastAPI
 
         from lib.config import resolver as resolver_mod
@@ -497,7 +513,7 @@ class TestVideoCapabilitiesEndpoint:
 
         class _FakePM:
             def load_project(self, name: str) -> dict:
-                return {"name": name, "video_backend": f"{provider_id}/{VIDEO_MODEL}"}
+                return {"name": name, "video_backend": f"{provider_id}/{model_id}"}
 
         monkeypatch.setattr(projects_mod, "async_session_factory", session_factory)
         monkeypatch.setattr(resolver_mod, "get_project_manager", lambda: _FakePM())
@@ -522,10 +538,12 @@ class TestVideoCapabilitiesEndpoint:
     async def test_endpoint_follows_written_override(self, session_factory, monkeypatch):
         """AC：对自定义模型写入覆盖后，该接口返回值随之变化。"""
         async with session_factory() as session:
-            pid = await TestResolverReturnsEffectiveCapabilities._seed(session, overrides={"last_frame": True})
+            pid = await TestResolverReturnsEffectiveCapabilities._seed(
+                session, overrides={"last_frame": True}, endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL
+            )
 
-        with self._client(monkeypatch, session_factory, pid) as client:
+        with self._client(monkeypatch, session_factory, pid, model_id=LAST_FRAME_MODEL) as client:
             body = client.get("/api/v1/projects/demo/video-capabilities").json()
 
-        assert system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL).last_frame is False
+        assert system_video_capabilities(endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL).last_frame is False
         assert body["last_frame"] is True

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -537,6 +537,49 @@ class TestReplaceModelsOverrideSemantics:
         assert resp.status_code == 422
 
     @pytest.mark.integration
+    async def test_endpoint_change_still_validated_even_when_override_dict_unchanged(
+        self, client: TestClient, session_factory
+    ):
+        """未变更豁免比对的是 (endpoint, 覆盖值) 二元组，不能只比对覆盖值：model_id 与覆盖字典
+        原样不动、只切 endpoint 时，校验结果天然随新 endpoint 变化（last_frame=True 是否合法
+        依赖 endpoint 的 end_image_capable），必须照常针对新 endpoint 校验。"""
+        async with session_factory() as session:
+            repo = CustomProviderRepository(session)
+            provider = await repo.create_provider(
+                display_name="Relay",
+                discovery_format="openai",
+                base_url="https://relay.test/v1",
+                api_key="sk-relay",
+                models=[
+                    {
+                        "model_id": LAST_FRAME_MODEL,
+                        "display_name": "Seedance",
+                        "endpoint": LAST_FRAME_ENDPOINT,
+                        "is_enabled": True,
+                        "is_default": True,
+                        "capability_overrides": {"last_frame": True},
+                    }
+                ],
+            )
+            await session.commit()
+            pid = provider.id
+
+        resp = client.put(
+            f"/api/v1/custom-providers/{pid}/models",
+            json={
+                "models": [
+                    _video_model(
+                        model_id=LAST_FRAME_MODEL,
+                        # endpoint 悄悄换成 openai-video（不 end_image_capable），覆盖字典原样不动
+                        endpoint=VIDEO_ENDPOINT,
+                        capability_overrides={"last_frame": True},
+                    )
+                ]
+            },
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.integration
     async def test_unchanged_unallowlisted_override_does_not_block_full_update(
         self, client: TestClient, session_factory
     ):

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -472,6 +472,109 @@ class TestReplaceModelsOverrideSemantics:
         )
         assert resp.status_code == 422
 
+    @pytest.mark.integration
+    async def test_unchanged_unallowlisted_override_does_not_block_replace(self, client: TestClient, session_factory):
+        """first_frame 不在开放白名单内，但结构合法：filter_valid_overrides 不按白名单过滤
+        （见 test_stale_incompatible_override_filtered_from_response 同类容忍），GET 会原样
+        回显；表单据此把它原样带回整表 PUT。若整表写入对未变更的覆盖仍跑白名单校验，用户会
+        连改个无关字段都被 422 拒绝，且没有入口能清掉这条历史值——未变更时须放行。"""
+        async with session_factory() as session:
+            repo = CustomProviderRepository(session)
+            provider = await repo.create_provider(
+                display_name="Relay",
+                discovery_format="openai",
+                base_url="https://relay.test/v1",
+                api_key="sk-relay",
+                models=[
+                    {
+                        "model_id": VIDEO_MODEL,
+                        "display_name": "Sora 2",
+                        "endpoint": VIDEO_ENDPOINT,
+                        "is_enabled": True,
+                        "is_default": True,
+                        "capability_overrides": {"first_frame": False},
+                    }
+                ],
+            )
+            await session.commit()
+            pid = provider.id
+
+        resp = client.put(
+            f"/api/v1/custom-providers/{pid}/models",
+            json={"models": [_video_model(capability_overrides={"first_frame": False})]},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()[0]["capability_overrides"] == {"first_frame": False}
+
+    @pytest.mark.integration
+    async def test_changed_unallowlisted_override_still_rejected_on_replace(self, client: TestClient, session_factory):
+        """未变更才豁免白名单校验；把历史值改成另一个值仍须照常拒绝，白名单不能被整表端点绕过。"""
+        async with session_factory() as session:
+            repo = CustomProviderRepository(session)
+            provider = await repo.create_provider(
+                display_name="Relay",
+                discovery_format="openai",
+                base_url="https://relay.test/v1",
+                api_key="sk-relay",
+                models=[
+                    {
+                        "model_id": VIDEO_MODEL,
+                        "display_name": "Sora 2",
+                        "endpoint": VIDEO_ENDPOINT,
+                        "is_enabled": True,
+                        "is_default": True,
+                        "capability_overrides": {"first_frame": False},
+                    }
+                ],
+            )
+            await session.commit()
+            pid = provider.id
+
+        resp = client.put(
+            f"/api/v1/custom-providers/{pid}/models",
+            json={"models": [_video_model(capability_overrides={"first_frame": True})]},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.integration
+    async def test_unchanged_unallowlisted_override_does_not_block_full_update(
+        self, client: TestClient, session_factory
+    ):
+        """同上，覆盖 PUT /{provider_id}（原子更新 provider 元数据 + 模型列表）这条写入路径。"""
+        async with session_factory() as session:
+            repo = CustomProviderRepository(session)
+            provider = await repo.create_provider(
+                display_name="Relay",
+                discovery_format="openai",
+                base_url="https://relay.test/v1",
+                api_key="sk-relay",
+                models=[
+                    {
+                        "model_id": VIDEO_MODEL,
+                        "display_name": "Sora 2",
+                        "endpoint": VIDEO_ENDPOINT,
+                        "is_enabled": True,
+                        "is_default": True,
+                        "capability_overrides": {"first_frame": False},
+                    }
+                ],
+            )
+            await session.commit()
+            pid = provider.id
+
+        resp = client.put(
+            f"/api/v1/custom-providers/{pid}",
+            json={
+                # 只改 display_name，验证「与该覆盖无关的编辑」不会被历史脏值挡住
+                "display_name": "Relay Renamed",
+                "base_url": "https://relay.test/v1",
+                "models": [_video_model(capability_overrides={"first_frame": False})],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["display_name"] == "Relay Renamed"
+        assert resp.json()["models"][0]["capability_overrides"] == {"first_frame": False}
+
 
 class TestResolverReturnsEffectiveCapabilities:
     """/video-capabilities 走的 resolver 必须回生效能力，且与执行层同源。"""

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -1,0 +1,399 @@
+"""能力覆盖的 API 面与展示层同源。
+
+覆盖三件事：配置 API 读写覆盖（含白名单 4xx 与整体替换语义）、resolver 返回生效能力、
+展示层与执行层出自同一个合成函数。API 侧沿用 test_custom_providers_api.py 的内存 SQLite +
+TestClient 范式，同源侧沿用 test_custom_provider_loader.py 的真 repo 装载范式。
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Generator
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from lib.custom_provider import make_provider_id
+from lib.custom_provider.capabilities import synthesize_video_capabilities, system_video_capabilities
+from lib.custom_provider.loader import load_custom_backend
+from lib.db import get_async_session
+from lib.db.base import Base
+from lib.db.repositories.custom_provider_repo import CustomProviderRepository
+from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
+from server.routers import custom_providers
+
+# 系统判定 last_frame=False、reference_images=True/max=1 —— 覆盖前后差异可断言
+VIDEO_ENDPOINT = "openai-video"
+VIDEO_MODEL = "sora-2"
+
+
+@pytest.fixture()
+async def db_engine():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture()
+async def session_factory(db_engine):
+    return async_sessionmaker(db_engine, expire_on_commit=False)
+
+
+@pytest.fixture()
+def app(session_factory) -> FastAPI:
+    _app = FastAPI()
+
+    async def _override_session():
+        async with session_factory() as session:
+            yield session
+
+    _app.dependency_overrides[get_async_session] = _override_session
+    _app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="test", sub="test", role="admin")
+    _app.include_router(custom_providers.router, prefix="/api/v1")
+    register_error_handlers(_app)
+    return _app
+
+
+@pytest.fixture()
+async def session(session_factory) -> AsyncGenerator[AsyncSession, None]:
+    async with session_factory() as s:
+        yield s
+
+
+@pytest.fixture()
+def client(app) -> Generator[TestClient, None, None]:
+    with TestClient(app) as c:
+        yield c
+
+
+def _create_provider(client: TestClient, models: list[dict]) -> int:
+    resp = client.post(
+        "/api/v1/custom-providers",
+        json={
+            "display_name": "Relay",
+            "discovery_format": "openai",
+            "base_url": "https://relay.test/v1",
+            "api_key": "sk-relay",
+            "models": models,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _video_model(**overrides) -> dict:
+    model = {
+        "model_id": VIDEO_MODEL,
+        "display_name": "Sora 2",
+        "endpoint": VIDEO_ENDPOINT,
+        "is_default": True,
+        "is_enabled": True,
+    }
+    model.update(overrides)
+    return model
+
+
+class TestModelListExposesCapabilities:
+    """models 列表同时给出系统判定与用户覆盖，设置页平凡合并即可展示。"""
+
+    def test_video_model_reports_system_capabilities(self, client: TestClient):
+        pid = _create_provider(client, [_video_model()])
+
+        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        assert models[0]["system_capabilities"] == {
+            "first_frame": True,
+            "last_frame": False,
+            "reference_images": True,
+            "max_reference_images": 1,
+        }
+        assert models[0]["capability_overrides"] is None
+
+    def test_system_capabilities_matches_synthesis_source(self, client: TestClient):
+        """判定值不是 API 里另写一份，而是合成函数的系统判定分支。"""
+        pid = _create_provider(client, [_video_model()])
+
+        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        expected = system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL)
+        assert models[0]["system_capabilities"] == {
+            "first_frame": expected.first_frame,
+            "last_frame": expected.last_frame,
+            "reference_images": expected.reference_images,
+            "max_reference_images": expected.max_reference_images,
+        }
+
+    def test_non_video_model_has_no_system_capabilities(self, client: TestClient):
+        pid = _create_provider(
+            client,
+            [{"model_id": "dall-e-3", "display_name": "D3", "endpoint": "openai-images", "is_enabled": True}],
+        )
+
+        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        assert models[0]["system_capabilities"] is None
+
+    def test_overrides_round_trip_through_create(self, client: TestClient):
+        pid = _create_provider(client, [_video_model(capability_overrides={"last_frame": True})])
+
+        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        assert models[0]["capability_overrides"] == {"last_frame": True}
+        # 判定值不受覆盖影响：设置页要能同时显示"判定 False / 生效 True"
+        assert models[0]["system_capabilities"]["last_frame"] is False
+
+
+class TestPatchCapabilityOverrides:
+    """PATCH 携带完整覆盖字典，整体替换存量。"""
+
+    @staticmethod
+    def _patch(client: TestClient, pid: int, payload: dict, model_id: str = VIDEO_MODEL):
+        return client.patch(
+            f"/api/v1/custom-providers/{pid}/models/{model_id}/capability-overrides",
+            json=payload,
+        )
+
+    def test_write_override_and_read_back(self, client: TestClient):
+        pid = _create_provider(client, [_video_model()])
+
+        resp = self._patch(client, pid, {"capability_overrides": {"last_frame": True}})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["capability_overrides"] == {"last_frame": True}
+
+        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        assert models[0]["capability_overrides"] == {"last_frame": True}
+
+    def test_empty_dict_clears_existing_overrides(self, client: TestClient):
+        """整体替换而非逐键 merge：空字典即回到全部跟随系统判定。"""
+        pid = _create_provider(client, [_video_model(capability_overrides={"last_frame": True})])
+
+        resp = self._patch(client, pid, {"capability_overrides": {}})
+        assert resp.status_code == 200
+        assert resp.json()["capability_overrides"] is None
+
+    def test_null_clears_existing_overrides(self, client: TestClient):
+        pid = _create_provider(client, [_video_model(capability_overrides={"last_frame": True})])
+
+        resp = self._patch(client, pid, {"capability_overrides": None})
+        assert resp.status_code == 200
+        assert resp.json()["capability_overrides"] is None
+
+    def test_unknown_key_rejected(self, client: TestClient):
+        pid = _create_provider(client, [_video_model()])
+
+        resp = self._patch(client, pid, {"capability_overrides": {"no_such_capability": True}})
+        assert resp.status_code == 422
+        assert "no_such_capability" in resp.json()["detail"]
+
+    def test_known_but_unallowlisted_key_rejected(self, client: TestClient):
+        """first_frame 是合法 VideoCapabilities 字段，但首批未开放覆盖。"""
+        pid = _create_provider(client, [_video_model()])
+
+        resp = self._patch(client, pid, {"capability_overrides": {"first_frame": False}})
+        assert resp.status_code == 422
+        assert "first_frame" in resp.json()["detail"]
+
+    @pytest.mark.parametrize("bad_value", ["true", 1, 0, None, [], {}])
+    def test_wrong_value_type_rejected(self, client: TestClient, bad_value):
+        pid = _create_provider(client, [_video_model()])
+
+        resp = self._patch(client, pid, {"capability_overrides": {"last_frame": bad_value}})
+        assert resp.status_code == 422
+
+    def test_non_video_endpoint_rejected(self, client: TestClient):
+        pid = _create_provider(
+            client,
+            [{"model_id": "dall-e-3", "display_name": "D3", "endpoint": "openai-images", "is_enabled": True}],
+        )
+
+        resp = self._patch(client, pid, {"capability_overrides": {"last_frame": True}}, model_id="dall-e-3")
+        assert resp.status_code == 422
+
+    def test_missing_model_returns_404(self, client: TestClient):
+        pid = _create_provider(client, [_video_model()])
+
+        resp = self._patch(client, pid, {"capability_overrides": {"last_frame": True}}, model_id="ghost")
+        assert resp.status_code == 404
+
+    def test_rejected_write_leaves_stored_overrides_intact(self, client: TestClient):
+        pid = _create_provider(client, [_video_model(capability_overrides={"last_frame": True})])
+
+        assert self._patch(client, pid, {"capability_overrides": {"first_frame": False}}).status_code == 422
+
+        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        assert models[0]["capability_overrides"] == {"last_frame": True}
+
+
+class TestReplaceModelsOverrideSemantics:
+    """保存模型列表是整体替换：覆盖必须随列表回传，否则被清空。"""
+
+    def test_overrides_survive_when_resubmitted(self, client: TestClient):
+        pid = _create_provider(client, [_video_model(capability_overrides={"last_frame": True})])
+
+        resp = client.put(
+            f"/api/v1/custom-providers/{pid}/models",
+            json={"models": [_video_model(capability_overrides={"last_frame": True})]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()[0]["capability_overrides"] == {"last_frame": True}
+
+    def test_overrides_dropped_when_omitted(self, client: TestClient):
+        """整体替换语义的直接后果，前端保存模型列表时必须回传覆盖字段。"""
+        pid = _create_provider(client, [_video_model(capability_overrides={"last_frame": True})])
+
+        resp = client.put(f"/api/v1/custom-providers/{pid}/models", json={"models": [_video_model()]})
+        assert resp.status_code == 200
+        assert resp.json()[0]["capability_overrides"] is None
+
+    def test_invalid_override_rejected_on_replace(self, client: TestClient):
+        pid = _create_provider(client, [_video_model()])
+
+        resp = client.put(
+            f"/api/v1/custom-providers/{pid}/models",
+            json={"models": [_video_model(capability_overrides={"first_frame": False})]},
+        )
+        assert resp.status_code == 422
+
+    def test_invalid_override_rejected_on_create(self, client: TestClient):
+        resp = client.post(
+            "/api/v1/custom-providers",
+            json={
+                "display_name": "Relay",
+                "discovery_format": "openai",
+                "base_url": "https://relay.test/v1",
+                "api_key": "sk-relay",
+                "models": [_video_model(capability_overrides={"nope": True})],
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_invalid_override_rejected_on_full_update(self, client: TestClient):
+        pid = _create_provider(client, [_video_model()])
+
+        resp = client.put(
+            f"/api/v1/custom-providers/{pid}",
+            json={
+                "display_name": "Relay",
+                "base_url": "https://relay.test/v1",
+                "models": [_video_model(capability_overrides={"last_frame": "yes"})],
+            },
+        )
+        assert resp.status_code == 422
+
+
+class TestResolverReturnsEffectiveCapabilities:
+    """/video-capabilities 走的 resolver 必须回生效能力，且与执行层同源。"""
+
+    @staticmethod
+    async def _seed(session: AsyncSession, *, overrides: object | None) -> str:
+        repo = CustomProviderRepository(session)
+        provider = await repo.create_provider(
+            display_name="Relay",
+            discovery_format="openai",
+            base_url="https://relay.test/v1",
+            api_key="sk-relay",
+            models=[
+                {
+                    "model_id": VIDEO_MODEL,
+                    "display_name": "Sora 2",
+                    "endpoint": VIDEO_ENDPOINT,
+                    "is_enabled": True,
+                    "is_default": True,
+                    "supported_durations": "[5, 10]",
+                    "capability_overrides": overrides,
+                }
+            ],
+        )
+        await session.commit()
+        return make_provider_id(provider.id)
+
+    @staticmethod
+    async def _resolve(session: AsyncSession, provider_id: str) -> dict:
+        from lib.config.resolver import ConfigResolver
+        from lib.config.service import ConfigService
+
+        factory = async_sessionmaker(bind=session.get_bind(), class_=AsyncSession, expire_on_commit=False)  # type: ignore[call-overload]
+        resolver = ConfigResolver(factory, _bound_session=session)
+        return await resolver._resolve_video_caps_for_model(
+            ConfigService(session), session, provider_id, VIDEO_MODEL, None
+        )
+
+    async def test_custom_model_without_overrides_follows_system(self, session: AsyncSession):
+        pid = await self._seed(session, overrides=None)
+
+        caps = await self._resolve(session, pid)
+        system = system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL)
+        assert caps["last_frame"] is system.last_frame
+        assert caps["first_frame"] is system.first_frame
+        assert caps["max_reference_images"] == system.max_reference_images
+
+    async def test_override_changes_resolver_output(self, session: AsyncSession):
+        """AC：对自定义模型写入覆盖后，该接口返回值随之变化。"""
+        pid = await self._seed(session, overrides={"last_frame": True})
+
+        caps = await self._resolve(session, pid)
+        assert system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL).last_frame is False
+        assert caps["last_frame"] is True
+
+    @pytest.mark.integration
+    @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
+    async def test_resolver_matches_execution_layer(self, _mock_cls, session: AsyncSession):
+        """展示层与执行层出自同一合成函数：逐字段比对 resolver 与装载出的 backend。"""
+        pid = await self._seed(session, overrides={"last_frame": True})
+
+        caps = await self._resolve(session, pid)
+        session.expunge_all()
+        backend = await load_custom_backend(session=session, provider_id=pid, model_id=VIDEO_MODEL, media_type="video")
+
+        executed = backend.video_capabilities
+        assert caps["first_frame"] is executed.first_frame
+        assert caps["last_frame"] is executed.last_frame
+        assert caps["max_reference_images"] == executed.max_reference_images
+        # 同源的判据：两侧都等于合成函数在同一输入下的返回值
+        expected = synthesize_video_capabilities(
+            endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL, overrides={"last_frame": True}
+        )
+        assert executed == expected
+
+    async def test_builtin_boolean_caps_come_from_backend(self, session: AsyncSession):
+        """内置分支的布尔位来自 backend 纯函数，注册表不存第二份。"""
+        from lib.backend_assembly.specs import get_provider_spec
+        from lib.config.resolver import ConfigResolver
+        from lib.config.service import ConfigService
+        from lib.video_backends.registry import video_capabilities_for_model
+
+        factory = async_sessionmaker(bind=session.get_bind(), class_=AsyncSession, expire_on_commit=False)  # type: ignore[call-overload]
+        resolver = ConfigResolver(factory, _bound_session=session)
+        caps = await resolver._resolve_video_caps_for_model(ConfigService(session), session, "openai", "sora-2", None)
+
+        spec = get_provider_spec("openai", "video")
+        backend_caps = video_capabilities_for_model(spec.registry_backend, "sora-2")
+        assert caps["source"] == "registry"
+        assert caps["first_frame"] is backend_caps.first_frame
+        assert caps["last_frame"] is backend_caps.last_frame
+
+
+class TestBuiltinBackendsDeclareCapabilityFunction:
+    """每个能承载视频模型的内置 provider 都要能被纯函数问出布尔能力位。"""
+
+    def test_every_builtin_video_provider_resolvable(self):
+        from lib.backend_assembly.specs import get_provider_spec
+        from lib.config.registry import PROVIDER_REGISTRY
+        from lib.video_backends.base import VideoCapabilities
+        from lib.video_backends.registry import video_capabilities_for_model
+
+        for provider_id, meta in PROVIDER_REGISTRY.items():
+            video_models = [mid for mid, mi in meta.models.items() if mi.media_type == "video"]
+            if not video_models:
+                continue
+            spec = get_provider_spec(provider_id, "video")
+            for model_id in video_models:
+                caps = video_capabilities_for_model(spec.registry_backend, model_id)
+                assert isinstance(caps, VideoCapabilities), f"{provider_id}/{model_id}"
+
+    def test_unknown_backend_name_fails_loud(self):
+        from lib.video_backends.registry import video_capabilities_for_model
+
+        with pytest.raises(ValueError, match="Unknown video backend"):
+            video_capabilities_for_model("no-such-backend", "m")

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -107,6 +107,7 @@ def _video_model(**overrides) -> dict:
 class TestModelListExposesCapabilities:
     """models 列表同时给出系统判定与用户覆盖，设置页平凡合并即可展示。"""
 
+    @pytest.mark.integration
     def test_video_model_reports_system_capabilities(self, client: TestClient):
         pid = _create_provider(client, [_video_model()])
 
@@ -119,6 +120,7 @@ class TestModelListExposesCapabilities:
         }
         assert models[0]["capability_overrides"] is None
 
+    @pytest.mark.integration
     def test_system_capabilities_matches_synthesis_source(self, client: TestClient):
         """判定值不是 API 里另写一份，而是合成函数的系统判定分支。"""
         pid = _create_provider(client, [_video_model()])
@@ -132,6 +134,7 @@ class TestModelListExposesCapabilities:
             "max_reference_images": expected.max_reference_images,
         }
 
+    @pytest.mark.integration
     def test_non_video_model_has_no_system_capabilities(self, client: TestClient):
         pid = _create_provider(
             client,
@@ -141,6 +144,7 @@ class TestModelListExposesCapabilities:
         models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["system_capabilities"] is None
 
+    @pytest.mark.integration
     def test_overrides_round_trip_through_create(self, client: TestClient):
         pid = _create_provider(
             client,
@@ -156,6 +160,36 @@ class TestModelListExposesCapabilities:
         # 判定值不受覆盖影响：设置页要能同时显示"判定 False / 生效 True"
         assert models[0]["system_capabilities"]["last_frame"] is False
 
+    @pytest.mark.integration
+    async def test_stale_incompatible_override_filtered_from_response(self, client: TestClient, session_factory):
+        """存量行 / 非 API 写入可能留下已不兼容的覆盖（如 openai-video 上的 last_frame=True，
+        endpoint 不 end_image_capable）：写入侧白名单挡不住这条已落库的数据，回显前须过滤，
+        不能让界面呈现"覆盖已生效"而执行层其实静默忽略——原样回显还会让下次普通保存被
+        写入校验拒为 422，堵住与该覆盖无关的编辑。"""
+        async with session_factory() as session:
+            repo = CustomProviderRepository(session)
+            provider = await repo.create_provider(
+                display_name="Relay",
+                discovery_format="openai",
+                base_url="https://relay.test/v1",
+                api_key="sk-relay",
+                models=[
+                    {
+                        "model_id": VIDEO_MODEL,
+                        "display_name": "Sora 2",
+                        "endpoint": VIDEO_ENDPOINT,
+                        "is_enabled": True,
+                        "is_default": True,
+                        "capability_overrides": {"last_frame": True},
+                    }
+                ],
+            )
+            await session.commit()
+            pid = provider.id
+
+        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        assert models[0]["capability_overrides"] is None
+
 
 class TestPatchCapabilityOverrides:
     """PATCH 携带完整覆盖字典，整体替换存量。"""
@@ -167,6 +201,7 @@ class TestPatchCapabilityOverrides:
             json=payload,
         )
 
+    @pytest.mark.integration
     def test_write_override_and_read_back(self, client: TestClient):
         pid = _create_provider(client, [_video_model(endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL)])
 
@@ -177,6 +212,7 @@ class TestPatchCapabilityOverrides:
         models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["capability_overrides"] == {"last_frame": True}
 
+    @pytest.mark.integration
     def test_empty_dict_clears_existing_overrides(self, client: TestClient):
         """整体替换而非逐键 merge：空字典即回到全部跟随系统判定。"""
         pid = _create_provider(
@@ -194,6 +230,7 @@ class TestPatchCapabilityOverrides:
         assert resp.status_code == 200
         assert resp.json()["capability_overrides"] is None
 
+    @pytest.mark.integration
     def test_null_clears_existing_overrides(self, client: TestClient):
         pid = _create_provider(
             client,
@@ -210,6 +247,7 @@ class TestPatchCapabilityOverrides:
         assert resp.status_code == 200
         assert resp.json()["capability_overrides"] is None
 
+    @pytest.mark.integration
     def test_unknown_key_rejected(self, client: TestClient):
         pid = _create_provider(client, [_video_model()])
 
@@ -217,6 +255,7 @@ class TestPatchCapabilityOverrides:
         assert resp.status_code == 422
         assert "no_such_capability" in resp.json()["detail"]
 
+    @pytest.mark.integration
     def test_known_but_unallowlisted_key_rejected(self, client: TestClient):
         """first_frame 是合法 VideoCapabilities 字段，但首批未开放覆盖。"""
         pid = _create_provider(client, [_video_model()])
@@ -225,6 +264,7 @@ class TestPatchCapabilityOverrides:
         assert resp.status_code == 422
         assert "first_frame" in resp.json()["detail"]
 
+    @pytest.mark.integration
     @pytest.mark.parametrize("bad_value", ["true", 1, 0, None, [], {}])
     def test_wrong_value_type_rejected(self, client: TestClient, bad_value):
         pid = _create_provider(client, [_video_model()])
@@ -232,6 +272,7 @@ class TestPatchCapabilityOverrides:
         resp = self._patch(client, pid, {"capability_overrides": {"last_frame": bad_value}})
         assert resp.status_code == 422
 
+    @pytest.mark.integration
     def test_last_frame_rejected_on_endpoint_without_end_image_support(self, client: TestClient):
         """openai-video 的 delegate 不下传 end_image：开启覆盖只会让 UI 宣称支持、执行层仍静默丢帧。"""
         pid = _create_provider(client, [_video_model()])
@@ -240,6 +281,7 @@ class TestPatchCapabilityOverrides:
         assert resp.status_code == 422
         assert "last_frame" in resp.json()["detail"]
 
+    @pytest.mark.integration
     def test_non_video_endpoint_rejected(self, client: TestClient):
         pid = _create_provider(
             client,
@@ -249,12 +291,14 @@ class TestPatchCapabilityOverrides:
         resp = self._patch(client, pid, {"capability_overrides": {"last_frame": True}}, model_id="dall-e-3")
         assert resp.status_code == 422
 
+    @pytest.mark.integration
     def test_missing_model_returns_404(self, client: TestClient):
         pid = _create_provider(client, [_video_model()])
 
         resp = self._patch(client, pid, {"capability_overrides": {"last_frame": True}}, model_id="ghost")
         assert resp.status_code == 404
 
+    @pytest.mark.integration
     def test_rejected_write_leaves_stored_overrides_intact(self, client: TestClient):
         pid = _create_provider(
             client,
@@ -281,6 +325,7 @@ class TestPatchCapabilityOverrides:
 class TestReplaceModelsOverrideSemantics:
     """保存模型列表是整体替换：覆盖必须随列表回传，否则被清空。"""
 
+    @pytest.mark.integration
     def test_overrides_survive_when_resubmitted(self, client: TestClient):
         pid = _create_provider(
             client,
@@ -308,6 +353,7 @@ class TestReplaceModelsOverrideSemantics:
         assert resp.status_code == 200
         assert resp.json()[0]["capability_overrides"] == {"last_frame": True}
 
+    @pytest.mark.integration
     def test_overrides_dropped_when_omitted(self, client: TestClient):
         """整体替换语义的直接后果，前端保存模型列表时必须回传覆盖字段。"""
         pid = _create_provider(
@@ -328,6 +374,7 @@ class TestReplaceModelsOverrideSemantics:
         assert resp.status_code == 200
         assert resp.json()[0]["capability_overrides"] is None
 
+    @pytest.mark.integration
     def test_invalid_override_rejected_on_replace(self, client: TestClient):
         pid = _create_provider(client, [_video_model()])
 
@@ -337,6 +384,7 @@ class TestReplaceModelsOverrideSemantics:
         )
         assert resp.status_code == 422
 
+    @pytest.mark.integration
     def test_invalid_override_rejected_on_create(self, client: TestClient):
         resp = client.post(
             "/api/v1/custom-providers",
@@ -350,6 +398,7 @@ class TestReplaceModelsOverrideSemantics:
         )
         assert resp.status_code == 422
 
+    @pytest.mark.integration
     def test_invalid_override_rejected_on_full_update(self, client: TestClient):
         pid = _create_provider(client, [_video_model()])
 
@@ -403,6 +452,7 @@ class TestResolverReturnsEffectiveCapabilities:
             ConfigService(session), session, provider_id, model_id, None
         )
 
+    @pytest.mark.integration
     async def test_custom_model_without_overrides_follows_system(self, session: AsyncSession):
         pid = await self._seed(session, overrides=None)
 
@@ -412,6 +462,7 @@ class TestResolverReturnsEffectiveCapabilities:
         assert caps["first_frame"] is system.first_frame
         assert caps["max_reference_images"] == system.max_reference_images
 
+    @pytest.mark.integration
     async def test_override_changes_resolver_output(self, session: AsyncSession):
         """AC：对自定义模型写入覆盖后，该接口返回值随之变化。"""
         pid = await self._seed(
@@ -422,6 +473,7 @@ class TestResolverReturnsEffectiveCapabilities:
         assert system_video_capabilities(endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL).last_frame is False
         assert caps["last_frame"] is True
 
+    @pytest.mark.integration
     async def test_override_ignored_when_endpoint_lacks_end_image_support(self, session: AsyncSession):
         """openai-video 的 delegate 不下传 end_image：即便存量行/非 API 写入把 last_frame 写成 True，
         resolver 也须回退系统判定，而不是把「合成层宣称支持、执行层静默丢帧」的错误状态当作生效。"""
@@ -454,6 +506,7 @@ class TestResolverReturnsEffectiveCapabilities:
         )
         assert executed == expected
 
+    @pytest.mark.integration
     async def test_builtin_boolean_caps_come_from_backend(self, session: AsyncSession):
         """内置分支的布尔位来自 backend 纯函数，注册表不存第二份。"""
         from lib.backend_assembly.specs import get_provider_spec
@@ -475,6 +528,7 @@ class TestResolverReturnsEffectiveCapabilities:
 class TestBuiltinBackendsDeclareCapabilityFunction:
     """每个能承载视频模型的内置 provider 都要能被纯函数问出布尔能力位。"""
 
+    @pytest.mark.unit
     def test_every_builtin_video_provider_resolvable(self):
         from lib.backend_assembly.specs import get_provider_spec
         from lib.config.registry import PROVIDER_REGISTRY
@@ -490,6 +544,7 @@ class TestBuiltinBackendsDeclareCapabilityFunction:
                 caps = video_capabilities_for_model(spec.registry_backend, model_id)
                 assert isinstance(caps, VideoCapabilities), f"{provider_id}/{model_id}"
 
+    @pytest.mark.unit
     def test_unknown_backend_name_fails_loud(self):
         from lib.video_backends.registry import video_capabilities_for_model
 
@@ -524,6 +579,7 @@ class TestVideoCapabilitiesEndpoint:
         register_error_handlers(app)
         return TestClient(app)
 
+    @pytest.mark.integration
     async def test_endpoint_returns_effective_boolean_caps(self, session_factory, monkeypatch):
         async with session_factory() as session:
             pid = await TestResolverReturnsEffectiveCapabilities._seed(session, overrides=None)
@@ -535,6 +591,7 @@ class TestVideoCapabilitiesEndpoint:
         assert body["first_frame"] is system.first_frame
         assert body["last_frame"] is system.last_frame is False
 
+    @pytest.mark.integration
     async def test_endpoint_follows_written_override(self, session_factory, monkeypatch):
         """AC：对自定义模型写入覆盖后，该接口返回值随之变化。"""
         async with session_factory() as session:

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -713,6 +713,87 @@ class TestResolverReturnsEffectiveCapabilities:
         assert executed == expected
 
     @pytest.mark.integration
+    async def test_disabled_model_falls_back_to_default_model(self, session: AsyncSession):
+        """请求的 model 被禁用时,与执行层同一条回退规则:改用该 provider 的默认启用 video
+        model,而不是报错——否则 /video-capabilities 会 4xx,而实际生成请求会静默用默认模型
+        成功,展示层与执行层因此漂移。"""
+        repo = CustomProviderRepository(session)
+        provider = await repo.create_provider(
+            display_name="Relay",
+            discovery_format="openai",
+            base_url="https://relay.test/v1",
+            api_key="sk-relay",
+            models=[
+                {
+                    "model_id": "disabled-model",
+                    "display_name": "Disabled",
+                    "endpoint": VIDEO_ENDPOINT,
+                    "is_enabled": False,
+                    "is_default": False,
+                    "supported_durations": "[5, 10]",
+                    "capability_overrides": None,
+                },
+                {
+                    "model_id": VIDEO_MODEL,
+                    "display_name": "Sora 2",
+                    "endpoint": VIDEO_ENDPOINT,
+                    "is_enabled": True,
+                    "is_default": True,
+                    "supported_durations": "[5, 10]",
+                    "capability_overrides": None,
+                },
+            ],
+        )
+        await session.commit()
+        pid = make_provider_id(provider.id)
+
+        caps = await self._resolve(session, pid, model_id="disabled-model")
+        system = system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL)
+        assert caps["last_frame"] is system.last_frame
+        assert caps["first_frame"] is system.first_frame
+
+    @pytest.mark.integration
+    async def test_media_type_mismatch_falls_back_to_default_model(self, session: AsyncSession):
+        """请求的 model 仍启用,但用户已把该模型的 endpoint 改成非 video 类型时,与执行层同一条
+        回退规则:改用该 provider 的默认启用 video model。此前这里只检查 is_enabled,遗漏 endpoint
+        媒体类型不符会让本方法直接抛错(响应层 422),而 loader.load_custom_backend 会静默回退
+        成功,展示层与执行层因此漂移。"""
+        repo = CustomProviderRepository(session)
+        provider = await repo.create_provider(
+            display_name="Relay",
+            discovery_format="openai",
+            base_url="https://relay.test/v1",
+            api_key="sk-relay",
+            models=[
+                {
+                    "model_id": "repurposed-model",
+                    "display_name": "Repurposed",
+                    "endpoint": "openai-images",
+                    "is_enabled": True,
+                    "is_default": False,
+                    "supported_durations": "[5, 10]",
+                    "capability_overrides": None,
+                },
+                {
+                    "model_id": VIDEO_MODEL,
+                    "display_name": "Sora 2",
+                    "endpoint": VIDEO_ENDPOINT,
+                    "is_enabled": True,
+                    "is_default": True,
+                    "supported_durations": "[5, 10]",
+                    "capability_overrides": None,
+                },
+            ],
+        )
+        await session.commit()
+        pid = make_provider_id(provider.id)
+
+        caps = await self._resolve(session, pid, model_id="repurposed-model")
+        system = system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL)
+        assert caps["last_frame"] is system.last_frame
+        assert caps["first_frame"] is system.first_frame
+
+    @pytest.mark.integration
     async def test_builtin_boolean_caps_come_from_backend(self, session: AsyncSession):
         """内置分支的布尔位来自 backend 纯函数，注册表不存第二份。"""
         from lib.backend_assembly.specs import get_provider_spec

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -29,6 +29,12 @@ from server.routers import custom_providers
 VIDEO_ENDPOINT = "openai-video"
 VIDEO_MODEL = "sora-2"
 
+# openai-video 的 delegate 不序列化 end_image（见 _check_capability_overrides 的
+# end_image_capable 门槛），last_frame 覆盖为 True 的用例须换一个真正支持尾帧的 endpoint。
+# ark-seedance 非 seedance-2 系列模型系统判定同样是 last_frame=False，可类比断言覆盖前后差异。
+LAST_FRAME_ENDPOINT = "ark-seedance"
+LAST_FRAME_MODEL = "seedance-1-pro"
+
 
 @pytest.fixture()
 async def db_engine():
@@ -136,7 +142,14 @@ class TestModelListExposesCapabilities:
         assert models[0]["system_capabilities"] is None
 
     def test_overrides_round_trip_through_create(self, client: TestClient):
-        pid = _create_provider(client, [_video_model(capability_overrides={"last_frame": True})])
+        pid = _create_provider(
+            client,
+            [
+                _video_model(
+                    capability_overrides={"last_frame": True}, endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL
+                )
+            ],
+        )
 
         models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["capability_overrides"] == {"last_frame": True}
@@ -155,9 +168,9 @@ class TestPatchCapabilityOverrides:
         )
 
     def test_write_override_and_read_back(self, client: TestClient):
-        pid = _create_provider(client, [_video_model()])
+        pid = _create_provider(client, [_video_model(endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL)])
 
-        resp = self._patch(client, pid, {"capability_overrides": {"last_frame": True}})
+        resp = self._patch(client, pid, {"capability_overrides": {"last_frame": True}}, model_id=LAST_FRAME_MODEL)
         assert resp.status_code == 200, resp.text
         assert resp.json()["capability_overrides"] == {"last_frame": True}
 
@@ -166,16 +179,34 @@ class TestPatchCapabilityOverrides:
 
     def test_empty_dict_clears_existing_overrides(self, client: TestClient):
         """整体替换而非逐键 merge：空字典即回到全部跟随系统判定。"""
-        pid = _create_provider(client, [_video_model(capability_overrides={"last_frame": True})])
+        pid = _create_provider(
+            client,
+            [
+                _video_model(
+                    capability_overrides={"last_frame": True},
+                    endpoint=LAST_FRAME_ENDPOINT,
+                    model_id=LAST_FRAME_MODEL,
+                )
+            ],
+        )
 
-        resp = self._patch(client, pid, {"capability_overrides": {}})
+        resp = self._patch(client, pid, {"capability_overrides": {}}, model_id=LAST_FRAME_MODEL)
         assert resp.status_code == 200
         assert resp.json()["capability_overrides"] is None
 
     def test_null_clears_existing_overrides(self, client: TestClient):
-        pid = _create_provider(client, [_video_model(capability_overrides={"last_frame": True})])
+        pid = _create_provider(
+            client,
+            [
+                _video_model(
+                    capability_overrides={"last_frame": True},
+                    endpoint=LAST_FRAME_ENDPOINT,
+                    model_id=LAST_FRAME_MODEL,
+                )
+            ],
+        )
 
-        resp = self._patch(client, pid, {"capability_overrides": None})
+        resp = self._patch(client, pid, {"capability_overrides": None}, model_id=LAST_FRAME_MODEL)
         assert resp.status_code == 200
         assert resp.json()["capability_overrides"] is None
 
@@ -201,6 +232,14 @@ class TestPatchCapabilityOverrides:
         resp = self._patch(client, pid, {"capability_overrides": {"last_frame": bad_value}})
         assert resp.status_code == 422
 
+    def test_last_frame_rejected_on_endpoint_without_end_image_support(self, client: TestClient):
+        """openai-video 的 delegate 不下传 end_image：开启覆盖只会让 UI 宣称支持、执行层仍静默丢帧。"""
+        pid = _create_provider(client, [_video_model()])
+
+        resp = self._patch(client, pid, {"capability_overrides": {"last_frame": True}})
+        assert resp.status_code == 422
+        assert "last_frame" in resp.json()["detail"]
+
     def test_non_video_endpoint_rejected(self, client: TestClient):
         pid = _create_provider(
             client,
@@ -217,9 +256,23 @@ class TestPatchCapabilityOverrides:
         assert resp.status_code == 404
 
     def test_rejected_write_leaves_stored_overrides_intact(self, client: TestClient):
-        pid = _create_provider(client, [_video_model(capability_overrides={"last_frame": True})])
+        pid = _create_provider(
+            client,
+            [
+                _video_model(
+                    capability_overrides={"last_frame": True},
+                    endpoint=LAST_FRAME_ENDPOINT,
+                    model_id=LAST_FRAME_MODEL,
+                )
+            ],
+        )
 
-        assert self._patch(client, pid, {"capability_overrides": {"first_frame": False}}).status_code == 422
+        assert (
+            self._patch(
+                client, pid, {"capability_overrides": {"first_frame": False}}, model_id=LAST_FRAME_MODEL
+            ).status_code
+            == 422
+        )
 
         models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["capability_overrides"] == {"last_frame": True}
@@ -229,20 +282,49 @@ class TestReplaceModelsOverrideSemantics:
     """保存模型列表是整体替换：覆盖必须随列表回传，否则被清空。"""
 
     def test_overrides_survive_when_resubmitted(self, client: TestClient):
-        pid = _create_provider(client, [_video_model(capability_overrides={"last_frame": True})])
+        pid = _create_provider(
+            client,
+            [
+                _video_model(
+                    capability_overrides={"last_frame": True},
+                    endpoint=LAST_FRAME_ENDPOINT,
+                    model_id=LAST_FRAME_MODEL,
+                )
+            ],
+        )
 
         resp = client.put(
             f"/api/v1/custom-providers/{pid}/models",
-            json={"models": [_video_model(capability_overrides={"last_frame": True})]},
+            json={
+                "models": [
+                    _video_model(
+                        capability_overrides={"last_frame": True},
+                        endpoint=LAST_FRAME_ENDPOINT,
+                        model_id=LAST_FRAME_MODEL,
+                    )
+                ]
+            },
         )
         assert resp.status_code == 200
         assert resp.json()[0]["capability_overrides"] == {"last_frame": True}
 
     def test_overrides_dropped_when_omitted(self, client: TestClient):
         """整体替换语义的直接后果，前端保存模型列表时必须回传覆盖字段。"""
-        pid = _create_provider(client, [_video_model(capability_overrides={"last_frame": True})])
+        pid = _create_provider(
+            client,
+            [
+                _video_model(
+                    capability_overrides={"last_frame": True},
+                    endpoint=LAST_FRAME_ENDPOINT,
+                    model_id=LAST_FRAME_MODEL,
+                )
+            ],
+        )
 
-        resp = client.put(f"/api/v1/custom-providers/{pid}/models", json={"models": [_video_model()]})
+        resp = client.put(
+            f"/api/v1/custom-providers/{pid}/models",
+            json={"models": [_video_model(endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL)]},
+        )
         assert resp.status_code == 200
         assert resp.json()[0]["capability_overrides"] is None
 

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -714,6 +714,58 @@ class TestVideoCapabilities:
         assert caps["source"] == "custom"
         assert caps["max_reference_images"] == 1
 
+    async def test_custom_disabled_model_falls_back_to_default_like_execution_layer(self):
+        """project 仍指向已禁用的 model 时，能力解析须与 loader.load_custom_backend 同一条回退
+        规则改读默认启用 model——否则会宣称执行层实际不会兑现的 first_frame/last_frame。"""
+        from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
+
+        resolver = ConfigResolver.__new__(ConfigResolver)
+        fake_svc = _FakeConfigService(settings={})
+        factory, engine = await _make_session()
+        try:
+            async with factory() as session:
+                provider = CustomProvider(
+                    display_name="Custom Fallback",
+                    discovery_format="openai",
+                    base_url="https://example.com",
+                    api_key="xxx",
+                )
+                session.add(provider)
+                await session.flush()
+                disabled = CustomProviderModel(
+                    provider_id=provider.id,
+                    model_id="disabled-model",
+                    display_name="Disabled",
+                    endpoint="ark-seedance",
+                    is_enabled=False,
+                    supported_durations="[5]",
+                    capability_overrides={"last_frame": True},
+                )
+                default = CustomProviderModel(
+                    provider_id=provider.id,
+                    model_id="default-model",
+                    display_name="Default",
+                    endpoint="newapi-video",
+                    is_enabled=True,
+                    is_default=True,
+                    supported_durations="[5, 10]",
+                )
+                session.add_all([disabled, default])
+                await session.flush()
+
+                project_backend = f"custom-{provider.id}/disabled-model"
+                with patch("lib.config.resolver.get_project_manager") as mock_pm:
+                    mock_pm.return_value.load_project.return_value = {
+                        "video_backend": project_backend,
+                    }
+                    caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
+        finally:
+            await engine.dispose()
+        assert caps["model"] == "default-model"
+        assert caps["supported_durations"] == [5, 10]
+        # newapi-video 不接受尾帧覆盖；已禁用 model 的 last_frame=True 覆盖不应残留
+        assert caps["last_frame"] is False
+
 
 class TestResolveImageBackend:
     """resolve_image_backend：payload > project > 全局默认，capability=t2i/i2i 各覆盖。"""

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -714,6 +714,7 @@ class TestVideoCapabilities:
         assert caps["source"] == "custom"
         assert caps["max_reference_images"] == 1
 
+    @pytest.mark.integration
     async def test_custom_disabled_model_falls_back_to_default_like_execution_layer(self):
         """project 仍指向已禁用的 model 时，能力解析须与 loader.load_custom_backend 同一条回退
         规则改读默认启用 model——否则会宣称执行层实际不会兑现的 first_frame/last_frame。"""

--- a/tests/test_custom_backends.py
+++ b/tests/test_custom_backends.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from lib.audio_backends.base import AudioCapability, AudioSynthesisRequest, AudioSynthesisResult
 from lib.custom_provider.backends import (
@@ -14,7 +14,12 @@ from lib.custom_provider.backends import (
 )
 from lib.image_backends.base import ImageCapability, ImageGenerationRequest, ImageGenerationResult
 from lib.text_backends.base import TextCapability, TextGenerationRequest, TextGenerationResult
-from lib.video_backends.base import VideoCapability, VideoGenerationRequest, VideoGenerationResult
+from lib.video_backends.base import (
+    VideoCapabilities,
+    VideoCapability,
+    VideoGenerationRequest,
+    VideoGenerationResult,
+)
 
 # ---------------------------------------------------------------------------
 # CustomTextBackend
@@ -195,6 +200,48 @@ class TestCustomVideoBackend:
         backend = CustomVideoBackend(provider_id="full-provider", delegate=delegate, model="veo-3")
 
         assert backend.capabilities == all_caps
+
+    def test_video_capabilities_for_tier_delegates_when_delegate_supports_it(self):
+        """delegate 实现 tier-aware 查询（如 Kling）时，按请求档位透传其结果，而不是回落
+        context-free 的 video_capabilities——否则 media_generator 的 getattr 探测会命中一个
+        总是保守拒绝的空壳方法,起不到收窄效果。"""
+        pro_caps = VideoCapabilities(first_frame=True, last_frame=True, reference_images=False)
+        delegate = AsyncMock()
+        delegate.video_capabilities_for_tier = MagicMock(return_value=pro_caps)
+        backend = CustomVideoBackend(provider_id="vid-provider", delegate=delegate, model="kling-v2-5-turbo")
+
+        result = backend.video_capabilities_for_tier("pro", resolution="1080p")
+
+        assert result is pro_caps
+        delegate.video_capabilities_for_tier.assert_called_once_with("pro", resolution="1080p")
+
+    def test_video_capabilities_for_tier_falls_back_without_tier_support(self):
+        """delegate 未实现 tier-aware 查询时,回落到 context-free 的 video_capabilities。"""
+        static_caps = VideoCapabilities(first_frame=True, last_frame=False, reference_images=False)
+        delegate = AsyncMock(spec=["video_capabilities", "capabilities"])
+        delegate.video_capabilities = static_caps
+        backend = CustomVideoBackend(provider_id="vid-provider", delegate=delegate, model="wan-pro")
+
+        result = backend.video_capabilities_for_tier("pro")
+
+        assert result is static_caps
+
+    def test_video_capabilities_for_tier_prefers_injected_override(self):
+        """注入生效能力（用户覆盖）存在时优先返回它，不查 delegate——与 `video_capabilities`
+        属性同一优先级,覆盖必须能翻转执行层看到的能力。"""
+        override_caps = VideoCapabilities(first_frame=True, last_frame=True, reference_images=False)
+        delegate = AsyncMock()
+        delegate.video_capabilities_for_tier = MagicMock(
+            return_value=VideoCapabilities(first_frame=True, last_frame=False, reference_images=False)
+        )
+        backend = CustomVideoBackend(
+            provider_id="vid-provider", delegate=delegate, model="kling-v2-5-turbo", video_capabilities=override_caps
+        )
+
+        result = backend.video_capabilities_for_tier("std")
+
+        assert result is override_caps
+        delegate.video_capabilities_for_tier.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_custom_backends.py
+++ b/tests/test_custom_backends.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from lib.audio_backends.base import AudioCapability, AudioSynthesisRequest, AudioSynthesisResult
 from lib.custom_provider.backends import (
     CustomAudioBackend,
@@ -201,6 +203,7 @@ class TestCustomVideoBackend:
 
         assert backend.capabilities == all_caps
 
+    @pytest.mark.unit
     def test_video_capabilities_for_tier_delegates_when_delegate_supports_it(self):
         """delegate 实现 tier-aware 查询（如 Kling）时，按请求档位透传其结果，而不是回落
         context-free 的 video_capabilities——否则 media_generator 的 getattr 探测会命中一个
@@ -215,6 +218,7 @@ class TestCustomVideoBackend:
         assert result is pro_caps
         delegate.video_capabilities_for_tier.assert_called_once_with("pro", resolution="1080p")
 
+    @pytest.mark.unit
     def test_video_capabilities_for_tier_falls_back_without_tier_support(self):
         """delegate 未实现 tier-aware 查询时,回落到 context-free 的 video_capabilities。"""
         static_caps = VideoCapabilities(first_frame=True, last_frame=False, reference_images=False)
@@ -226,6 +230,7 @@ class TestCustomVideoBackend:
 
         assert result is static_caps
 
+    @pytest.mark.unit
     def test_video_capabilities_for_tier_prefers_injected_override(self):
         """注入生效能力（用户覆盖）存在时优先返回它，不查 delegate——与 `video_capabilities`
         属性同一优先级,覆盖必须能翻转执行层看到的能力。"""

--- a/tests/test_custom_backends.py
+++ b/tests/test_custom_backends.py
@@ -231,22 +231,41 @@ class TestCustomVideoBackend:
         assert result is static_caps
 
     @pytest.mark.unit
-    def test_video_capabilities_for_tier_prefers_injected_override(self):
-        """注入生效能力（用户覆盖）存在时优先返回它，不查 delegate——与 `video_capabilities`
-        属性同一优先级,覆盖必须能翻转执行层看到的能力。"""
-        override_caps = VideoCapabilities(first_frame=True, last_frame=True, reference_images=False)
+    def test_video_capabilities_for_tier_ignores_full_injected_capabilities(self):
+        """工厂注入的完整合成能力（`with_video_capabilities` 不带 overrides,如 factory.py 未
+        配置用户覆盖时的调用形状）不得短路档位查询——那是 context-free 的系统判定,对 Kling 等
+        档位敏感 backend 是保守声明;短路会让本方法在生产环境等价于未实现档位感知。"""
+        static_merged = VideoCapabilities(first_frame=True, last_frame=False, reference_images=False)
+        pro_caps = VideoCapabilities(first_frame=True, last_frame=True, reference_images=False)
         delegate = AsyncMock()
-        delegate.video_capabilities_for_tier = MagicMock(
-            return_value=VideoCapabilities(first_frame=True, last_frame=False, reference_images=False)
-        )
+        delegate.video_capabilities_for_tier = MagicMock(return_value=pro_caps)
         backend = CustomVideoBackend(
-            provider_id="vid-provider", delegate=delegate, model="kling-v2-5-turbo", video_capabilities=override_caps
-        )
+            provider_id="vid-provider", delegate=delegate, model="kling-v2-5-turbo"
+        ).with_video_capabilities(static_merged)
 
-        result = backend.video_capabilities_for_tier("std")
+        result = backend.video_capabilities_for_tier("pro", resolution="1080p")
 
-        assert result is override_caps
-        delegate.video_capabilities_for_tier.assert_not_called()
+        assert result is pro_caps
+        delegate.video_capabilities_for_tier.assert_called_once_with("pro", resolution="1080p")
+
+    @pytest.mark.unit
+    def test_video_capabilities_for_tier_merges_sparse_override_onto_delegate_base(self):
+        """稀疏用户覆盖（`with_video_capabilities` 的 `overrides` 参数）叠加到 delegate 的档位
+        感知基底上,未覆盖字段跟随基底——覆盖必须能翻转执行层看到的能力,但不能整体替换基底,
+        否则档位切换时未覆盖字段会冻结在覆盖注入时刻的值。"""
+        base_caps = VideoCapabilities(first_frame=True, last_frame=False, reference_images=False)
+        delegate = AsyncMock()
+        delegate.video_capabilities_for_tier = MagicMock(return_value=base_caps)
+        backend = CustomVideoBackend(
+            provider_id="vid-provider", delegate=delegate, model="kling-v2-5-turbo"
+        ).with_video_capabilities(base_caps, overrides={"last_frame": True})
+
+        result = backend.video_capabilities_for_tier("pro")
+
+        assert result.first_frame is True
+        assert result.last_frame is True
+        assert result.reference_images is False
+        delegate.video_capabilities_for_tier.assert_called_once_with("pro", resolution=None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_custom_provider_capabilities.py
+++ b/tests/test_custom_provider_capabilities.py
@@ -8,6 +8,7 @@ import pytest
 
 from lib.custom_provider.capabilities import (
     CAPABILITY_OVERRIDE_FIELDS,
+    filter_valid_overrides,
     synthesize_video_capabilities,
     system_video_capabilities,
 )
@@ -185,3 +186,14 @@ class TestTolerance:
             caps = synthesize_video_capabilities(endpoint="openai-video", model_id="sora-2", overrides=bad)
         assert caps == system_video_capabilities(endpoint="openai-video", model_id="sora-2")
         assert caplog.records
+
+    @pytest.mark.unit
+    def test_last_frame_override_on_retired_endpoint_does_not_raise(self, caplog: pytest.LogCaptureFixture):
+        """endpoint 已从注册表下线（升级移除）时，get_endpoint_spec 抛 ValueError；filter_valid_overrides
+        是 API 响应过滤边界的最后一道，不得让存量脏配置把这里也炸穿——须降级丢弃并告警，而非抛错。"""
+        with caplog.at_level(logging.WARNING, logger="lib.custom_provider.capabilities"):
+            applied = filter_valid_overrides(
+                endpoint="no-such-retired-endpoint", model_id="whatever", overrides={"last_frame": True}
+            )
+        assert applied == {}
+        assert "last_frame" in caplog.text

--- a/tests/test_custom_provider_capabilities.py
+++ b/tests/test_custom_provider_capabilities.py
@@ -74,15 +74,17 @@ class TestSynthesize:
     @pytest.mark.unit
     def test_missing_key_follows_system(self):
         """字典存在但缺某键 → 该维度跟随系统判定，其余键照常覆盖。"""
-        caps = synthesize_video_capabilities(endpoint="openai-video", model_id="sora-2", overrides={"last_frame": True})
+        caps = synthesize_video_capabilities(
+            endpoint="ark-seedance", model_id="seedance-1-pro", overrides={"last_frame": True}
+        )
         assert caps.last_frame is True
         assert caps.first_frame is True
-        assert caps.max_reference_images == 1
+        assert caps.max_reference_images == 0
 
     @pytest.mark.unit
     def test_force_on(self):
         caps = synthesize_video_capabilities(
-            endpoint="newapi-video", model_id="x", overrides={"last_frame": True, "reference_images": True}
+            endpoint="ark-seedance", model_id="seedance-1-pro", overrides={"last_frame": True, "reference_images": True}
         )
         assert caps.last_frame is True
         assert caps.reference_images is True
@@ -116,9 +118,9 @@ class TestSynthesize:
     def test_system_capabilities_not_mutated_across_calls(self):
         """合成返回新实例，不得就地改写系统判定（caps_fn 可能返回共享对象）。"""
         first = synthesize_video_capabilities(
-            endpoint="openai-video", model_id="sora-2", overrides={"last_frame": True}
+            endpoint="ark-seedance", model_id="seedance-1-pro", overrides={"last_frame": True}
         )
-        second = system_video_capabilities(endpoint="openai-video", model_id="sora-2")
+        second = system_video_capabilities(endpoint="ark-seedance", model_id="seedance-1-pro")
         assert first.last_frame is True
         assert second.last_frame is False
 
@@ -134,15 +136,25 @@ class TestTolerance:
     def test_unknown_key_ignored_with_warning(self, caplog: pytest.LogCaptureFixture):
         with caplog.at_level(logging.WARNING, logger="lib.custom_provider.capabilities"):
             caps = synthesize_video_capabilities(
-                endpoint="openai-video",
-                model_id="sora-2",
+                endpoint="ark-seedance",
+                model_id="seedance-1-pro",
                 overrides={"last_frame": True, "audio_track": True},
             )
         assert caps.last_frame is True
         assert caps == VideoCapabilities(
-            first_frame=True, last_frame=True, reference_images=True, max_reference_images=1
+            first_frame=True, last_frame=True, reference_images=False, max_reference_images=0
         )
         assert "audio_track" in caplog.text
+
+    @pytest.mark.unit
+    def test_last_frame_override_ignored_when_endpoint_lacks_end_image_support(self, caplog: pytest.LogCaptureFixture):
+        """openai-video 的 delegate 不下传 end_image：覆盖只会让合成层宣称支持、执行层仍静默丢帧，须降级跟随系统判定。"""
+        with caplog.at_level(logging.WARNING, logger="lib.custom_provider.capabilities"):
+            caps = synthesize_video_capabilities(
+                endpoint="openai-video", model_id="sora-2", overrides={"last_frame": True}
+            )
+        assert caps.last_frame is False
+        assert "last_frame" in caplog.text
 
     @pytest.mark.unit
     @pytest.mark.parametrize("bad", ["true", 1, None, [], {"x": 1}])

--- a/tests/test_custom_provider_capabilities.py
+++ b/tests/test_custom_provider_capabilities.py
@@ -102,9 +102,15 @@ class TestSynthesize:
 
     @pytest.mark.unit
     def test_force_off_on_last_frame(self):
-        """last_frame 是首批开放的覆盖维度，单独验一遍「系统判定 True → 强制关」。"""
-        assert system_video_capabilities(endpoint="vidu-video", model_id="viduq3").last_frame is True
-        caps = synthesize_video_capabilities(endpoint="vidu-video", model_id="viduq3", overrides={"last_frame": False})
+        """last_frame 是首批开放的覆盖维度，单独验一遍「系统判定 True → 强制关」。
+
+        用 viduq3-turbo 而非 viduq3：后者不在 /start-end2video、/img2video 白名单内
+        （只支持 /reference2video），系统判定本身就是 False，验不出"强制关"的效果。
+        """
+        assert system_video_capabilities(endpoint="vidu-video", model_id="viduq3-turbo").last_frame is True
+        caps = synthesize_video_capabilities(
+            endpoint="vidu-video", model_id="viduq3-turbo", overrides={"last_frame": False}
+        )
         assert caps.last_frame is False
         assert caps.first_frame is True
 

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -61,6 +61,7 @@ class TestRegistry:
             "image_capabilities": None,
             # 未声明的 endpoint cap 序列化为 None（resolver fallthrough 到 backend caps）
             "video_max_reference_images": None,
+            "end_image_capable": False,
         }
 
     def test_new_video_endpoints_have_unset_cap(self):

--- a/tests/test_custom_provider_loader.py
+++ b/tests/test_custom_provider_loader.py
@@ -91,13 +91,15 @@ class TestVideoCapabilityOverridesReachExecution:
     """DB 的 capability_overrides 必须在装载出的 backend 上生效——执行层门控读的就是这里。"""
 
     @staticmethod
-    async def _load_video_backend(session, *, overrides: object | None):
+    async def _load_video_backend(
+        session, *, overrides: object | None, endpoint: str = "openai-video", model_id: str = "sora-2"
+    ):
         pid = await _seed(
             session,
             models=[
                 {
-                    "model_id": "sora-2",
-                    "endpoint": "openai-video",
+                    "model_id": model_id,
+                    "endpoint": endpoint,
                     "is_enabled": True,
                     "is_default": True,
                     "capability_overrides": overrides,
@@ -106,7 +108,7 @@ class TestVideoCapabilityOverridesReachExecution:
         )
         # 清 identity map，逼装载重新 SELECT：覆盖字典要真经过 JSON 编解码往返才算验到 DB 语义
         session.expunge_all()
-        return await load_custom_backend(session=session, provider_id=pid, model_id="sora-2", media_type="video")
+        return await load_custom_backend(session=session, provider_id=pid, model_id=model_id, media_type="video")
 
     @pytest.mark.integration
     @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
@@ -115,12 +117,15 @@ class TestVideoCapabilityOverridesReachExecution:
         assert backend.video_capabilities == system_video_capabilities(endpoint="openai-video", model_id="sora-2")
 
     @pytest.mark.integration
-    @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
+    @patch("lib.custom_provider.endpoints.ArkVideoBackend")
     async def test_override_forces_capability_on(self, _mock_cls, session):
         # 系统判定 last_frame=False；覆盖强制开启后执行层看到 True，且不再转发被包装 backend
-        backend = await self._load_video_backend(session, overrides={"last_frame": True})
+        # endpoint 须支持尾帧（end_image_capable）覆盖才会生效，openai-video 不满足此前提
+        backend = await self._load_video_backend(
+            session, overrides={"last_frame": True}, endpoint="ark-seedance", model_id="seedance-1-pro"
+        )
         assert backend.video_capabilities.last_frame is True
-        assert backend.video_capabilities.max_reference_images == 1
+        assert backend.video_capabilities.max_reference_images == 0
 
     @pytest.mark.integration
     @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
@@ -130,10 +135,15 @@ class TestVideoCapabilityOverridesReachExecution:
         assert backend.video_capabilities.first_frame is True
 
     @pytest.mark.integration
-    @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
+    @patch("lib.custom_provider.endpoints.ArkVideoBackend")
     async def test_unknown_key_in_stored_overrides_does_not_break_loading(self, _mock_cls, session):
         # 存量行可能带已下线的键，装载不得失败，该维度按系统判定走
-        backend = await self._load_video_backend(session, overrides={"retired_dimension": True, "last_frame": True})
+        backend = await self._load_video_backend(
+            session,
+            overrides={"retired_dimension": True, "last_frame": True},
+            endpoint="ark-seedance",
+            model_id="seedance-1-pro",
+        )
         assert backend.video_capabilities.last_frame is True
 
     @pytest.mark.integration

--- a/tests/test_custom_provider_repo.py
+++ b/tests/test_custom_provider_repo.py
@@ -338,6 +338,46 @@ class TestModelManagement:
         result = await repo.update_model(999, display_name="Nope")
         assert result is None
 
+    async def test_update_model_rejects_pk_reused_by_unrelated_row(self, session: AsyncSession):
+        """SQLite 整表删除重建会复用释放出的主键：模拟并发 PUT 用同一主键插入了一个业务上
+        完全不同的新模型，若只按主键匹配，更新会静默命中并污染这条无关的行；一并校验业务标识
+        （provider_id/model_id）后谓词应落空，正确返回 None 而不是误报更新成功。"""
+        from sqlalchemy import insert
+
+        from lib.db.models.custom_provider import CustomProviderModel
+
+        repo = CustomProviderRepository(session)
+        p = await repo.create_provider(
+            display_name="TestProvider",
+            discovery_format="openai",
+            base_url="https://example.com",
+            api_key="key",
+            models=[{"model_id": "gpt-4o", "display_name": "GPT-4o", "endpoint": "openai-chat"}],
+        )
+        await session.flush()
+        stale_id = (await repo.list_models(p.id))[0].id
+
+        # 模拟并发整表 PUT：删除旧行，用同一主键插入一个业务上无关的新模型
+        await repo.replace_models(p.id, [])
+        await session.execute(
+            insert(CustomProviderModel).values(
+                id=stale_id,
+                provider_id=p.id,
+                model_id="unrelated-model",
+                display_name="Unrelated",
+                endpoint="openai-chat",
+            )
+        )
+        await session.flush()
+
+        result = await repo.update_model(
+            stale_id, expect_provider_id=p.id, expect_model_id="gpt-4o", display_name="Hijacked"
+        )
+        assert result is None
+
+        untouched = (await repo.list_models(p.id))[0]
+        assert untouched.display_name == "Unrelated"
+
     async def test_delete_model(self, session: AsyncSession):
         repo = CustomProviderRepository(session)
         p = await repo.create_provider(

--- a/tests/test_custom_provider_repo.py
+++ b/tests/test_custom_provider_repo.py
@@ -338,6 +338,7 @@ class TestModelManagement:
         result = await repo.update_model(999, display_name="Nope")
         assert result is None
 
+    @pytest.mark.integration
     async def test_update_model_rejects_pk_reused_by_unrelated_row(self, session: AsyncSession):
         """SQLite 整表删除重建会复用释放出的主键：模拟并发 PUT 用同一主键插入了一个业务上
         完全不同的新模型，若只按主键匹配，更新会静默命中并污染这条无关的行；一并校验业务标识
@@ -378,6 +379,7 @@ class TestModelManagement:
         untouched = (await repo.list_models(p.id))[0]
         assert untouched.display_name == "Unrelated"
 
+    @pytest.mark.integration
     async def test_update_model_rejects_endpoint_changed_by_concurrent_replace(self, session: AsyncSession):
         """业务身份（provider_id/model_id）不变，但并发整表 PUT 把模型换到了另一个 endpoint：
         仅按业务身份匹配仍会命中，调用方对旧 endpoint 校验过的字段会被写入新 endpoint 的行；

--- a/tests/test_custom_provider_repo.py
+++ b/tests/test_custom_provider_repo.py
@@ -378,6 +378,52 @@ class TestModelManagement:
         untouched = (await repo.list_models(p.id))[0]
         assert untouched.display_name == "Unrelated"
 
+    async def test_update_model_rejects_endpoint_changed_by_concurrent_replace(self, session: AsyncSession):
+        """业务身份（provider_id/model_id）不变，但并发整表 PUT 把模型换到了另一个 endpoint：
+        仅按业务身份匹配仍会命中，调用方对旧 endpoint 校验过的字段会被写入新 endpoint 的行；
+        一并校验 expect_endpoint 后谓词应落空，正确返回 None 而不是把校验结果写错目标行。"""
+        from sqlalchemy import insert
+
+        from lib.db.models.custom_provider import CustomProviderModel
+
+        repo = CustomProviderRepository(session)
+        p = await repo.create_provider(
+            display_name="TestProvider",
+            discovery_format="openai",
+            base_url="https://example.com",
+            api_key="key",
+            models=[{"model_id": "seedance", "display_name": "Seedance", "endpoint": "ark-seedance"}],
+        )
+        await session.flush()
+        stale_id = (await repo.list_models(p.id))[0].id
+
+        # 模拟并发整表 PUT：删除旧行，用同一主键 + 同一业务 model_id 重建，但换到了
+        # 不支持覆盖字段的 endpoint（业务身份不变，只有 endpoint 变了）
+        await repo.replace_models(p.id, [])
+        await session.execute(
+            insert(CustomProviderModel).values(
+                id=stale_id,
+                provider_id=p.id,
+                model_id="seedance",
+                display_name="Seedance",
+                endpoint="openai-video",
+            )
+        )
+        await session.flush()
+
+        result = await repo.update_model(
+            stale_id,
+            expect_provider_id=p.id,
+            expect_model_id="seedance",
+            expect_endpoint="ark-seedance",
+            capability_overrides={"last_frame": True},
+        )
+        assert result is None
+
+        untouched = (await repo.list_models(p.id))[0]
+        assert untouched.endpoint == "openai-video"
+        assert untouched.capability_overrides is None
+
     async def test_delete_model(self, session: AsyncSession):
         repo = CustomProviderRepository(session)
         p = await repo.create_provider(

--- a/tests/test_custom_provider_resolution.py
+++ b/tests/test_custom_provider_resolution.py
@@ -147,7 +147,7 @@ async def test_video_capabilities_endpoint_mismatch_raises(db_session: AsyncSess
     svc = ConfigService(db_session)
     resolver = ConfigResolver(factory, _bound_session=db_session)
 
-    with pytest.raises(ValueError, match="endpoint media_type mismatch"):
+    with pytest.raises(ValueError, match="is text, not video"):
         await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
 
 

--- a/tests/test_custom_provider_resolution.py
+++ b/tests/test_custom_provider_resolution.py
@@ -110,7 +110,11 @@ async def test_endpoint_field_stores_gemini_image(db_session: AsyncSession):
 
 @pytest.mark.asyncio
 async def test_video_capabilities_endpoint_mismatch_raises(db_session: AsyncSession):
-    """配 endpoint=openai-chat 但被当作 video_backend 使用 → ValueError。"""
+    """配 endpoint=openai-chat 但被当作 video_backend 使用，且该 provider 没有任何默认启用的
+    video model 可回退 → ValueError。与 loader.load_custom_backend 同一条回退规则：media_type
+    不符视为该 model 失效，先尝试回退默认 video model，回退也找不到才报错——不是原样报
+    「media_type 不符」（那会让展示层与仍能静默回退成功的执行层不一致，见 resolver.py 中
+    is_enabled/media_type 回退分支的注释）。"""
     from lib.config.resolver import ConfigResolver
 
     provider = CustomProvider(
@@ -147,7 +151,7 @@ async def test_video_capabilities_endpoint_mismatch_raises(db_session: AsyncSess
     svc = ConfigService(db_session)
     resolver = ConfigResolver(factory, _bound_session=db_session)
 
-    with pytest.raises(ValueError, match="is text, not video"):
+    with pytest.raises(ValueError, match="custom model not found"):
         await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
 
 

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -104,28 +104,34 @@ class TestConstructionAndCapabilities:
 class TestVideoCapabilitiesForTier:
     """有请求上下文（service_tier）时的 last_frame 收窄——供 media_generator 转发 end_image 前调用。"""
 
+    @pytest.mark.unit
     def test_pro_tier_allows_last_frame_for_gated_model(self):
         caps = _jwt_backend().video_capabilities_for_tier("pro")
         assert caps.last_frame is True
 
+    @pytest.mark.unit
     def test_std_tier_still_conservative(self):
         caps = _jwt_backend().video_capabilities_for_tier("std")
         assert caps.last_frame is False
 
+    @pytest.mark.unit
     def test_pro_tier_case_insensitive(self):
         caps = _jwt_backend().video_capabilities_for_tier("PRO")
         assert caps.last_frame is True
 
+    @pytest.mark.unit
     def test_ungated_model_last_frame_unaffected_by_tier(self):
         # kling-v3 的 last_frame 各档皆真，不受 last_frame_requires_pro 收窄影响
         b = _jwt_backend("kling-v3")
         assert b.video_capabilities_for_tier("std").last_frame is True
         assert b.video_capabilities_for_tier("pro").last_frame is True
 
+    @pytest.mark.unit
     def test_4k_tier_still_conservative(self):
         caps = _jwt_backend().video_capabilities_for_tier("std", resolution="4k")
         assert caps.last_frame is False
 
+    @pytest.mark.unit
     def test_4k_overrides_pro_tier_stays_conservative(self):
         # resolution=4k 优先于 service_tier（与 _resolve_mode 同一派生规则）：即使 tier=pro，
         # 4k 请求解出的 mode 是 "4k" 而非 "pro"，last_frame 仍须保守拒绝，否则会与
@@ -377,6 +383,7 @@ class TestPayloadBuilding:
         )
         assert "image" in payload and "image_tail" in payload
 
+    @pytest.mark.integration
     def test_image2video_end_frame_rejected_at_std_tier(self, tmp_path):
         # kling-v2-5-turbo 首尾帧仅 pro 档生效：std（含未显式指定 service_tier 的默认档）提交
         # image_tail 虽会被官方接口受理，尾帧约束却不生效，须 fail loud 而非静默发出无效请求。
@@ -388,6 +395,7 @@ class TestPayloadBuilding:
             _jwt_backend()._build_payload(_request(tmp_path, start_image=first, end_image=last))
         assert exc.value.code == "video_last_frame_requires_pro"
 
+    @pytest.mark.integration
     def test_image2video_end_frame_allowed_at_std_tier_for_v3(self, tmp_path):
         # kling-v3 首尾帧未标"仅 pro"（官方能力表未附此限制），std 档应正常放行。
         first = tmp_path / "first.png"

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -332,11 +332,34 @@ class TestPayloadBuilding:
         assert "image_tail" not in payload
 
     def test_image2video_with_end_frame(self, tmp_path):
+        # kling-v2-5-turbo 首尾帧仅 pro 档生效，须显式带 service_tier="pro" 才会放行 image_tail。
         first = tmp_path / "first.png"
         last = tmp_path / "last.png"
         first.write_bytes(b"\x89PNG\r\n1")
         last.write_bytes(b"\x89PNG\r\n2")
-        _, payload = _jwt_backend()._build_payload(_request(tmp_path, start_image=first, end_image=last))
+        _, payload = _jwt_backend()._build_payload(
+            _request(tmp_path, start_image=first, end_image=last, service_tier="pro")
+        )
+        assert "image" in payload and "image_tail" in payload
+
+    def test_image2video_end_frame_rejected_at_std_tier(self, tmp_path):
+        # kling-v2-5-turbo 首尾帧仅 pro 档生效：std（含未显式指定 service_tier 的默认档）提交
+        # image_tail 虽会被官方接口受理，尾帧约束却不生效，须 fail loud 而非静默发出无效请求。
+        first = tmp_path / "first.png"
+        last = tmp_path / "last.png"
+        first.write_bytes(b"\x89PNG\r\n1")
+        last.write_bytes(b"\x89PNG\r\n2")
+        with pytest.raises(VideoCapabilityError) as exc:
+            _jwt_backend()._build_payload(_request(tmp_path, start_image=first, end_image=last))
+        assert exc.value.code == "video_last_frame_requires_pro"
+
+    def test_image2video_end_frame_allowed_at_std_tier_for_v3(self, tmp_path):
+        # kling-v3 首尾帧未标"仅 pro"（官方能力表未附此限制），std 档应正常放行。
+        first = tmp_path / "first.png"
+        last = tmp_path / "last.png"
+        first.write_bytes(b"\x89PNG\r\n1")
+        last.write_bytes(b"\x89PNG\r\n2")
+        _, payload = _jwt_backend("kling-v3")._build_payload(_request(tmp_path, start_image=first, end_image=last))
         assert "image" in payload and "image_tail" in payload
 
     def test_image2video_empty_end_frame_is_omitted(self, tmp_path):

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -94,7 +94,8 @@ class TestConstructionAndCapabilities:
     def test_video_capabilities_first_and_last_frame(self):
         caps = _jwt_backend().video_capabilities
         assert caps.first_frame is True
-        assert caps.last_frame is True
+        # turbo 尾帧仅 pro 档生效，声明按默认档保守为 False（std 档提交会被 _build_payload 拒绝）
+        assert caps.last_frame is False
         # turbo 不建模参考图（多图主体留 v3-omni/o1）
         assert caps.reference_images is False
         assert caps.max_reference_images == 0
@@ -130,11 +131,12 @@ class TestPerModelCapabilities:
         assert vc.reference_images is True and vc.max_reference_images == 4
 
     def test_unknown_model_falls_back_to_default_caps(self):
-        # bearer 透传原生 model_name：未登记 → 保守默认（t2v+i2v、首尾帧、无音频/参考）
+        # bearer 透传原生 model_name：未登记 → 保守默认（t2v+i2v、尾帧仅 pro 档，声明按 std 档保守
+        # 为 False；无音频/参考）
         b = _bearer_backend("kling-some-passthrough")
         assert b.capabilities == {VideoCapability.TEXT_TO_VIDEO, VideoCapability.IMAGE_TO_VIDEO}
         vc = b.video_capabilities
-        assert vc.last_frame is True
+        assert vc.last_frame is False
         assert vc.reference_images is False and vc.max_reference_images == 0
 
     def test_prefixed_and_cased_model_normalizes_to_registered_caps(self):

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -101,6 +101,28 @@ class TestConstructionAndCapabilities:
         assert caps.max_reference_images == 0
 
 
+class TestVideoCapabilitiesForTier:
+    """有请求上下文（service_tier）时的 last_frame 收窄——供 media_generator 转发 end_image 前调用。"""
+
+    def test_pro_tier_allows_last_frame_for_gated_model(self):
+        caps = _jwt_backend().video_capabilities_for_tier("pro")
+        assert caps.last_frame is True
+
+    def test_std_tier_still_conservative(self):
+        caps = _jwt_backend().video_capabilities_for_tier("std")
+        assert caps.last_frame is False
+
+    def test_pro_tier_case_insensitive(self):
+        caps = _jwt_backend().video_capabilities_for_tier("PRO")
+        assert caps.last_frame is True
+
+    def test_ungated_model_last_frame_unaffected_by_tier(self):
+        # kling-v3 的 last_frame 各档皆真，不受 last_frame_requires_pro 收窄影响
+        b = _jwt_backend("kling-v3")
+        assert b.video_capabilities_for_tier("std").last_frame is True
+        assert b.video_capabilities_for_tier("pro").last_frame is True
+
+
 class TestPerModelCapabilities:
     def test_v3_t2v_i2v_no_audio_no_reference(self):
         b = _jwt_backend("kling-v3")

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -122,6 +122,17 @@ class TestVideoCapabilitiesForTier:
         assert b.video_capabilities_for_tier("std").last_frame is True
         assert b.video_capabilities_for_tier("pro").last_frame is True
 
+    def test_4k_tier_still_conservative(self):
+        caps = _jwt_backend().video_capabilities_for_tier("std", resolution="4k")
+        assert caps.last_frame is False
+
+    def test_4k_overrides_pro_tier_stays_conservative(self):
+        # resolution=4k 优先于 service_tier（与 _resolve_mode 同一派生规则）：即使 tier=pro，
+        # 4k 请求解出的 mode 是 "4k" 而非 "pro"，last_frame 仍须保守拒绝，否则会与
+        # _build_payload 的 fail-loud 护栏（按 _resolve_mode 判定）不一致。
+        caps = _jwt_backend().video_capabilities_for_tier("pro", resolution="4k")
+        assert caps.last_frame is False
+
 
 class TestPerModelCapabilities:
     def test_v3_t2v_i2v_no_audio_no_reference(self):

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -329,6 +329,63 @@ class TestMediaGenerator:
         assert call.end_image is None
         assert call.reference_images is None
 
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_end_image_forwarded_when_backend_reports_tier_aware_last_frame(self, tmp_path):
+        """后端实现 video_capabilities_for_tier 时按实际 service_tier 收窄决定是否转发
+        end_image：pro 档放行——无请求上下文的 video_capabilities 恒 False 也不应误判丢帧。"""
+        from lib.video_backends.base import VideoCapabilities
+
+        class _TierAwareVideoBackend(_FakeVideoBackend):
+            def __init__(self):
+                super().__init__(video_capabilities=VideoCapabilities(last_frame=False))
+
+            def video_capabilities_for_tier(self, service_tier: str) -> VideoCapabilities:
+                return VideoCapabilities(last_frame=(service_tier or "").lower() == "pro")
+
+        gen = _build_generator(tmp_path)
+        gen._video_backend = _TierAwareVideoBackend()
+        end_image = tmp_path / "end.png"
+        end_image.write_bytes(b"fake-end-image")
+
+        await gen.generate_video_async(
+            prompt="p",
+            resource_type="videos",
+            resource_id="E1S07",
+            end_image=end_image,
+            service_tier="pro",
+        )
+        call = gen._video_backend.calls[0]
+        assert call.end_image == end_image
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_end_image_ignored_when_tier_aware_backend_reports_std_tier(self, tmp_path):
+        """同一后端，std 档时仍按能力收窄拒绝转发——覆盖 pro/std 两条分支。"""
+        from lib.video_backends.base import VideoCapabilities
+
+        class _TierAwareVideoBackend(_FakeVideoBackend):
+            def __init__(self):
+                super().__init__(video_capabilities=VideoCapabilities(last_frame=False))
+
+            def video_capabilities_for_tier(self, service_tier: str) -> VideoCapabilities:
+                return VideoCapabilities(last_frame=(service_tier or "").lower() == "pro")
+
+        gen = _build_generator(tmp_path)
+        gen._video_backend = _TierAwareVideoBackend()
+        end_image = tmp_path / "end.png"
+        end_image.write_bytes(b"fake-end-image")
+
+        await gen.generate_video_async(
+            prompt="p",
+            resource_type="videos",
+            resource_id="E1S08",
+            end_image=end_image,
+            service_tier="std",
+        )
+        call = gen._video_backend.calls[0]
+        assert call.end_image is None
+
 
 # ── 咽喉层参考图压缩接线 ────────────────────────────────────────────────────
 

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -340,7 +340,9 @@ class TestMediaGenerator:
             def __init__(self):
                 super().__init__(video_capabilities=VideoCapabilities(last_frame=False))
 
-            def video_capabilities_for_tier(self, service_tier: str) -> VideoCapabilities:
+            def video_capabilities_for_tier(
+                self, service_tier: str, resolution: str | None = None
+            ) -> VideoCapabilities:
                 return VideoCapabilities(last_frame=(service_tier or "").lower() == "pro")
 
         gen = _build_generator(tmp_path)
@@ -368,7 +370,9 @@ class TestMediaGenerator:
             def __init__(self):
                 super().__init__(video_capabilities=VideoCapabilities(last_frame=False))
 
-            def video_capabilities_for_tier(self, service_tier: str) -> VideoCapabilities:
+            def video_capabilities_for_tier(
+                self, service_tier: str, resolution: str | None = None
+            ) -> VideoCapabilities:
                 return VideoCapabilities(last_frame=(service_tier or "").lower() == "pro")
 
         gen = _build_generator(tmp_path)

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -49,12 +49,20 @@ class TestBackendBasics:
         assert backend.video_capabilities.max_reference_images == 7
 
     def test_max_reference_images_zero_for_non_reference2video_model(self):
-        # viduq3-pro-fast 支持 /img2video、/start-end2video，但不在 /reference2video 白名单内——
-        # 与 reference_images=False 联动归零，避免展示层声称支持参考图但生成期必然 RuntimeError。
+        # viduq3-pro-fast 支持 /img2video，但不在 /start-end2video、/reference2video 白名单内——
+        # last_frame/reference_images 应为 False，max_reference_images 随 reference_images 归零，
+        # 避免展示层声称支持尾帧/参考图但生成期必然 RuntimeError。
         backend = ViduVideoBackend(api_key="test-key", model="viduq3-pro-fast")
         caps = backend.video_capabilities
+        assert caps.first_frame is True
+        assert caps.last_frame is False
         assert caps.reference_images is False
         assert caps.max_reference_images == 0
+
+    def test_last_frame_true_for_start_end2video_model(self):
+        # viduq3-turbo 在 /start-end2video 白名单内，last_frame 应为 True。
+        backend = ViduVideoBackend(api_key="test-key", model="viduq3-turbo")
+        assert backend.video_capabilities.last_frame is True
 
 
 class TestEndpointSelection:

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -48,6 +48,14 @@ class TestBackendBasics:
         backend = ViduVideoBackend(api_key="test-key")
         assert backend.video_capabilities.max_reference_images == 7
 
+    def test_max_reference_images_zero_for_non_reference2video_model(self):
+        # viduq3-pro-fast 支持 /img2video、/start-end2video，但不在 /reference2video 白名单内——
+        # 与 reference_images=False 联动归零，避免展示层声称支持参考图但生成期必然 RuntimeError。
+        backend = ViduVideoBackend(api_key="test-key", model="viduq3-pro-fast")
+        caps = backend.video_capabilities
+        assert caps.reference_images is False
+        assert caps.max_reference_images == 0
+
 
 class TestEndpointSelection:
     def _backend(self, model: str = "viduq3-turbo") -> ViduVideoBackend:

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -48,6 +48,7 @@ class TestBackendBasics:
         backend = ViduVideoBackend(api_key="test-key")
         assert backend.video_capabilities.max_reference_images == 7
 
+    @pytest.mark.unit
     def test_max_reference_images_zero_for_non_reference2video_model(self):
         # viduq3-pro-fast 支持 /img2video，但不在 /start-end2video、/reference2video 白名单内——
         # last_frame/reference_images 应为 False，max_reference_images 随 reference_images 归零，
@@ -59,6 +60,7 @@ class TestBackendBasics:
         assert caps.reference_images is False
         assert caps.max_reference_images == 0
 
+    @pytest.mark.unit
     def test_last_frame_true_for_start_end2video_model(self):
         # viduq3-turbo 在 /start-end2video 白名单内，last_frame 应为 True。
         backend = ViduVideoBackend(api_key="test-key", model="viduq3-turbo")


### PR DESCRIPTION
Closes #1293

## 变更

把系统判定与用户覆盖推到 API 面，并让展示层与执行层严格同源。

**配置 API（自定义供应商 models）**
- models 列表响应每个 model 新增 `system_capabilities`（系统判定，四字段全量）与 `capability_overrides`（稀疏覆盖），设置页可平凡合并展示
- 新增 `PATCH /custom-providers/{provider_id}/models/{model_id}/capability-overrides`：携带完整覆盖字典整体替换存量
- API 层白名单校验：首批仅开放 `last_frame`。未知键 / 已知但未开放 / 值类型不符各返回独立的 422 文案，zh/en/vi 三语齐全
- `ModelInput` 增 `capability_overrides` 字段，闭合「保存模型列表（整体替换语义）会清空已写入覆盖」的坑；前端 `CustomProviderForm` 相应原样回传该字段（不编辑，无新增 UI 控件）

**展示层同源（resolver）**
- 自定义分支改调与执行层同一个合成函数 `synthesize_video_capabilities`，不再自行合并覆盖或重算系统判定
- 内置分支的布尔能力位改调 `video_backends.registry.video_capabilities_for_model(backend, model_id)` 纯函数读 backend 声明，不复制进 `ModelInfo`；`max_reference_images` 按 issue 维持读 `ModelInfo`（注册表按 model 分档，backend 侧不区分）
- 为此给 gemini / grok / openai / newapi / agnes 五个 video backend 补静态 `video_capabilities_for_model`，原 instance property 委托至此，避免第二真相源与构造 SDK client 的开销
- `/video-capabilities` 响应新增 `first_frame` / `last_frame` 生效值，生成 UI 门控不必自行合并覆盖

## 验证

- 后端：`ruff check` / `ruff format --check` 全绿；`basedpyright` 0 error；`pytest` 6323 passed，覆盖率 91%（门槛 80%）
- 前端：`pnpm lint` 通过；`pnpm check` 113 files / 1042 tests 全过
- 新增 `tests/test_capability_overrides_api.py`（31 条）：白名单三类 422、整体替换语义、resolver 生效值随覆盖变化、resolver 与工厂注入执行层逐字段同源、内置 provider 布尔位全部可由纯函数问出
- `/video-capabilities` 补 HTTP 层端到端回归（真 router + 真 resolver + 真 DB），并经变异测试确认护栏有效

## 审查阶段修复

- 写入侧白名单校验原自带一份 bool/int 判定，与合成层 `_value_matches` 逐字同构；漂移即产生「写入放行、执行静默忽略」，已改为复用公开的 `capability_value_matches`
- 补 `/video-capabilities` 的 HTTP 层护栏（此前测试全打在 resolver 私有方法上，projects router 测试又把 resolver 整个 mock 掉）
- 订正 `resolver.video_capabilities` 文档：补上两个新键，并修掉仍描述已被替换的 `endpoint.video_max_reference_images` 旧路径的那行

## 后续（不在本票）

- 设置页能力覆盖的三态控件与 `system_capabilities` 展示（Spec #1288 决策 6）：本票已把两组字段送到前端类型层
- 白名单扩容到 `first_frame` / `reference_images` / `max_reference_images` 时需一并处理跨字段一致性
- 整套覆盖架构落定后补 ADR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 视频能力新增展示 **首帧/尾帧**（`first_frame/last_frame`），并支持自定义模型的 **能力覆盖**（整体替换、清空、以及单模型增量更新）。
  - 尾帧生成现按 **档位与端点能力** 校验，`end_image` 将随能力与档位生效/失效（`pro` 才支持首尾组合中的尾帧限制）。

- **错误修复**
  - 能力覆盖校验更严格：仅允许合规的字段与类型；不支持尾帧时自动丢弃覆盖并回退到系统判定，同时补充冲突提示。

- **测试**
  - 更新并新增 API、解析一致性、回显语义、端点/档位回退与尾帧约束相关测试用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->