### PR TITLE
feat(onboarding): 新手引导延伸到设置页，带你配好供应商与 Agent

### DIFF
--- a/frontend/src/components/pages/SystemConfigPage.tsx
+++ b/frontend/src/components/pages/SystemConfigPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useConfigStatusStore } from "@/stores/config-status-store";
+import { ONBOARDING_ANCHORS } from "@/onboarding/anchors";
 import { AgentConfigTab } from "./AgentConfigTab";
 import { ApiKeysTab } from "./ApiKeysTab";
 import { AboutSection } from "./settings/AboutSection";
@@ -34,6 +35,12 @@ import {
 // ---------------------------------------------------------------------------
 
 type SettingsSection = "agent" | "providers" | "media" | "usage" | "api-keys" | "about";
+
+/** 引导第 5/6 步指向的侧栏入口——只有这两项挂锚点，其余小节不在当前引导覆盖范围内。 */
+const SECTION_ONBOARDING_ANCHORS: Partial<Record<SettingsSection, string>> = {
+  providers: ONBOARDING_ANCHORS.settingsProviders,
+  agent: ONBOARDING_ANCHORS.settingsAgent,
+};
 
 interface SectionDef {
   id: SettingsSection;
@@ -210,6 +217,7 @@ export function SystemConfigPage() {
                     key={id}
                     type="button"
                     onClick={() => setActiveSection(id)}
+                    data-onboarding={SECTION_ONBOARDING_ANCHORS[id]}
                     aria-current={isActive ? "page" : undefined}
                     aria-pressed={isActive}
                     className={

--- a/frontend/src/i18n/en/onboarding.ts
+++ b/frontend/src/i18n/en/onboarding.ts
@@ -9,6 +9,10 @@ export default {
   'lobby_demo_body': 'This card is a sample, not one of your projects. The badge shows the current phase, and the counters below track characters, scenes, props, and episodes as production fills them in.',
   'lobby_settings_title': 'Providers live in Settings',
   'lobby_settings_body': 'Image, video, and text generation each run on a provider you choose. A red dot on this button means something required is still missing — open Settings and it points you at the gap.',
+  'settings_providers_title': 'Set up a media provider',
+  'settings_providers_body': 'Configure at least one provider here — enter its API key and run the connection test before generating anything.',
+  'settings_agent_title': 'Connect the agent',
+  'settings_agent_body': 'The assistant needs an Anthropic credential to generate overviews, scripts, and chat replies. Add it here.',
   'finish_title': 'Your turn',
   'finish_body': 'Start by importing a novel, then take the rest one step at a time. To see this again, open Settings → About.',
 

--- a/frontend/src/i18n/vi/onboarding.ts
+++ b/frontend/src/i18n/vi/onboarding.ts
@@ -10,6 +10,10 @@ export default {
   'lobby_demo_body': 'Đây là thẻ ví dụ, không phải dự án của bạn. Nhãn hiển thị giai đoạn hiện tại, các số liệu bên dưới theo dõi tiến độ của nhân vật, bối cảnh, đạo cụ và các tập.',
   'lobby_settings_title': 'Cấu hình nhà cung cấp nằm trong Cài đặt',
   'lobby_settings_body': 'Tạo hình ảnh, video và văn bản đều chạy trên nhà cung cấp do bạn chọn. Chấm đỏ trên nút này nghĩa là còn mục bắt buộc chưa được cấu hình — mở Cài đặt sẽ thấy ngay phần còn thiếu.',
+  'settings_providers_title': 'Cấu hình một nhà cung cấp',
+  'settings_providers_body': 'Cấu hình ít nhất một nhà cung cấp ở đây — nhập API Key và chạy thử kết nối trước khi bắt đầu tạo nội dung.',
+  'settings_agent_title': 'Kết nối Agent',
+  'settings_agent_body': 'Tạo tổng quan, kịch bản và trả lời trò chuyện đều cần thông tin xác thực Anthropic — hãy thêm vào đây.',
   'finish_title': 'Đến lượt bạn',
   'finish_body': 'Hãy bắt đầu bằng cách nhập một cuốn tiểu thuyết, phần còn lại làm từng bước một. Muốn xem lại, hãy mở Cài đặt → Giới thiệu.',
 

--- a/frontend/src/i18n/zh/onboarding.ts
+++ b/frontend/src/i18n/zh/onboarding.ts
@@ -10,6 +10,10 @@ export default {
   'lobby_demo_body': '这是一张示例卡片，不是你的项目。角标显示当前阶段，下方计数随制作进度记录角色、场景、道具和分集的完成情况。',
   'lobby_settings_title': '供应商配置在设置里',
   'lobby_settings_body': '图像、视频、文本三类生成各自跑在你选定的供应商上。按钮上的红点表示还有必填项没配齐，进设置页会直接指出缺口。',
+  'settings_providers_title': '配置一个媒体供应商',
+  'settings_providers_body': '在这里至少配好一个供应商——填入 API Key 并跑一次连接测试，再开始生成。',
+  'settings_agent_title': '接入 Agent',
+  'settings_agent_body': '生成概述、剧本和对话回复都依赖 Anthropic 凭证，在这里添加。',
   'finish_title': '轮到你了',
   'finish_body': '从导入一本小说开始，剩下的一步步来。想再看一遍，去「设置 → 关于」打开这份引导。',
 

--- a/frontend/src/onboarding/OnboardingTour.test.tsx
+++ b/frontend/src/onboarding/OnboardingTour.test.tsx
@@ -224,6 +224,109 @@ describe("OnboardingTour", () => {
     expect(history.at(-1)).toBe("/app/projects");
   });
 
+  /** 大厅三步的锚点。没有大厅页面可渲染，手动补上元素，测的是跳页而不是锚点降级。 */
+  function mountLobbyAnchors(): HTMLElement[] {
+    const names = [
+      ONBOARDING_ANCHORS.lobbyCreateProject,
+      ONBOARDING_ANCHORS.lobbyDemoCard,
+      ONBOARDING_ANCHORS.lobbySettings,
+    ];
+    return names.map((name) => {
+      const el = document.createElement("button");
+      el.setAttribute("data-onboarding", name);
+      document.body.appendChild(el);
+      return el;
+    });
+  }
+
+  function click(selector: string): void {
+    document.querySelector<HTMLElement>(selector)?.click();
+  }
+
+  it("crosses from the lobby into settings when the tour reaches the provider step", async () => {
+    vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+    const lobbyAnchors = mountLobbyAnchors();
+    const settingsAnchor = document.createElement("button");
+    settingsAnchor.setAttribute("data-onboarding", ONBOARDING_ANCHORS.settingsProviders);
+    document.body.appendChild(settingsAnchor);
+
+    const { hook, history } = memoryLocation({ path: "/app/projects", record: true });
+    render(
+      <Router hook={hook}>
+        <OnboardingTour />
+      </Router>,
+    );
+    await waitFor(() => expect(popoverTitle()).toBe("欢迎来到 ArcReel"));
+
+    click(".driver-popover-next-btn"); // → 新建项目入口
+    click(".driver-popover-next-btn"); // → 演示卡
+    click(".driver-popover-next-btn"); // → 设置入口（仍在大厅）
+    click(".driver-popover-next-btn"); // → 媒体供应商（跨页到设置）
+
+    await waitFor(() => expect(popoverTitle()).toBe("配置一个媒体供应商"));
+    expect(history.at(-1)).toBe("/app/settings");
+    expect(API.markOnboardingSeen).not.toHaveBeenCalled();
+    [...lobbyAnchors, settingsAnchor].forEach((el) => el.remove());
+  });
+
+  it("degrades to a centered popover when the settings-step anchor never mounts", async () => {
+    vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const lobbyAnchors = mountLobbyAnchors();
+
+    const { hook } = memoryLocation({ path: "/app/projects" });
+    render(
+      <Router hook={hook}>
+        <OnboardingTour />
+      </Router>,
+    );
+    await waitFor(() => expect(popoverTitle()).toBe("欢迎来到 ArcReel"));
+
+    click(".driver-popover-next-btn");
+    click(".driver-popover-next-btn");
+    click(".driver-popover-next-btn");
+    click(".driver-popover-next-btn"); // 没有渲染设置页，锚点不存在——等待超时后应当降级为居中气泡而不是卡住
+
+    await waitFor(() => expect(popoverTitle()).toBe("配置一个媒体供应商"), { timeout: 3000 });
+    // 讲解照常进行，丢的只是高亮——driver 顶上自己的占位元素，气泡回到屏幕中央。
+    expect(document.getElementById("driver-dummy-element")?.classList.contains("driver-active-element")).toBe(
+      true,
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(ONBOARDING_ANCHORS.settingsProviders));
+
+    warn.mockRestore();
+    lobbyAnchors.forEach((el) => el.remove());
+  });
+
+  it("still marks the tour as seen when skipped mid-way through the settings steps", async () => {
+    vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+    const lobbyAnchors = mountLobbyAnchors();
+    const settingsAnchor = document.createElement("button");
+    settingsAnchor.setAttribute("data-onboarding", ONBOARDING_ANCHORS.settingsProviders);
+    document.body.appendChild(settingsAnchor);
+
+    const { hook } = memoryLocation({ path: "/app/projects" });
+    render(
+      <Router hook={hook}>
+        <OnboardingTour />
+      </Router>,
+    );
+    await waitFor(() => expect(popoverTitle()).toBe("欢迎来到 ArcReel"));
+
+    click(".driver-popover-next-btn");
+    click(".driver-popover-next-btn");
+    click(".driver-popover-next-btn");
+    click(".driver-popover-next-btn");
+    await waitFor(() => expect(popoverTitle()).toBe("配置一个媒体供应商"));
+
+    click(".arc-tour-skip-btn");
+
+    await waitFor(() => expect(API.markOnboardingSeen).toHaveBeenCalledTimes(1));
+    expect(popoverTitle()).toBeNull();
+    expect(useOnboardingStore.getState().seen).toBe(true);
+    [...lobbyAnchors, settingsAnchor].forEach((el) => el.remove());
+  });
+
   it("takes the tour down when the user navigates back to the login page mid-tour", async () => {
     vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
 

--- a/frontend/src/onboarding/OnboardingTour.test.tsx
+++ b/frontend/src/onboarding/OnboardingTour.test.tsx
@@ -269,6 +269,36 @@ describe("OnboardingTour", () => {
     [...lobbyAnchors, settingsAnchor].forEach((el) => el.remove());
   });
 
+  it("crosses back into the lobby when the tour steps backwards out of settings", async () => {
+    vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
+    const lobbyAnchors = mountLobbyAnchors();
+    const settingsAnchor = document.createElement("button");
+    settingsAnchor.setAttribute("data-onboarding", ONBOARDING_ANCHORS.settingsProviders);
+    document.body.appendChild(settingsAnchor);
+
+    const { hook, history } = memoryLocation({ path: "/app/projects", record: true });
+    render(
+      <Router hook={hook}>
+        <OnboardingTour />
+      </Router>,
+    );
+    await waitFor(() => expect(popoverTitle()).toBe("欢迎来到 ArcReel"));
+
+    click(".driver-popover-next-btn");
+    click(".driver-popover-next-btn");
+    click(".driver-popover-next-btn");
+    click(".driver-popover-next-btn"); // → 媒体供应商（跨页到设置）
+    await waitFor(() => expect(popoverTitle()).toBe("配置一个媒体供应商"));
+    expect(history.at(-1)).toBe("/app/settings");
+
+    click(".driver-popover-prev-btn"); // ← 设置入口（跨页回大厅）
+
+    await waitFor(() => expect(popoverTitle()).toBe("供应商配置在设置里"));
+    expect(history.at(-1)).toBe("/app/projects");
+    expect(API.markOnboardingSeen).not.toHaveBeenCalled();
+    [...lobbyAnchors, settingsAnchor].forEach((el) => el.remove());
+  });
+
   it("degrades to a centered popover when the settings-step anchor never mounts", async () => {
     vi.spyOn(API, "getOnboardingStatus").mockResolvedValue({ seen: false });
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/frontend/src/onboarding/OnboardingTour.tsx
+++ b/frontend/src/onboarding/OnboardingTour.tsx
@@ -17,22 +17,14 @@
  * 切换高亮之前把即将停靠的步号同步上报，本组件据此提前导航，驱动效果本身不重启。
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation } from "wouter";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOnboardingStore } from "@/stores/onboarding-store";
-import {
-  APP_PROJECT_WORKSPACE_PATTERN,
-  APP_TOP_LEVEL_ROUTES,
-  ROUTE_APP_PROJECTS,
-  ROUTE_APP_SETTINGS,
-} from "@/app-routes";
+import { APP_PROJECT_WORKSPACE_PATTERN, APP_TOP_LEVEL_ROUTES } from "@/app-routes";
 import { buildTourSteps } from "./steps";
 import { startTour, type TourLabels } from "./tour";
-
-/** 引导步骤大纲当下覆盖的路由集合——驱动效果据此判断「是否还在引导范围内」。 */
-const TOUR_ROUTES: readonly string[] = [ROUTE_APP_PROJECTS, ROUTE_APP_SETTINGS];
 
 export function OnboardingTour() {
   const { t } = useTranslation("onboarding");
@@ -55,9 +47,15 @@ export function OnboardingTour() {
     (normalizedLocation === "/" ||
       (APP_TOP_LEVEL_ROUTES as readonly string[]).includes(normalizedLocation) ||
       APP_PROJECT_WORKSPACE_PATTERN.test(normalizedLocation));
-  // 当前所在路由是否是引导覆盖的路由之一（大厅或设置页）——驱动效果（4）以此为准，
-  // 而不是逐步比对，这样大厅↔设置页之间的跨页步骤切换不会拆重建 driver 实例。
-  const onTourRoute = TOUR_ROUTES.includes(normalizedLocation);
+
+  // 步骤大纲只随界面语言重建，渲染期与两个效果共用同一份，避免每次渲染重跑一遍翻译。
+  const steps = useMemo(() => buildTourSteps(t), [t]);
+  // 引导覆盖的路由集合，从大纲自身派生而非另写一份常量——后续段落在新页面加步骤时
+  // 只需给那一步写 `route`，这里自动跟上，不存在「忘了同步」的维护缺口。
+  const tourRoutes = useMemo(
+    () => new Set(steps.map((s) => s.route).filter((route): route is string => Boolean(route))),
+    [steps],
+  );
 
   // 停在第几步（0 基）。用 ref 给驱动效果读取初始值又不把它列进依赖（步骤切换不该
   // 重启驱动效果），state 给下面的路由判定效果做响应式依赖。两者总是同步写入。
@@ -68,7 +66,10 @@ export function OnboardingTour() {
     setStepIndex(index);
   };
 
-  const requiredRoute = buildTourSteps(t)[stepIndex]?.route ?? null;
+  // 当前所在路由是否是引导覆盖的路由之一（大厅或设置页）——驱动效果（4）以此为准，
+  // 而不是逐步比对，这样大厅↔设置页之间的跨页步骤切换不会拆重建 driver 实例。
+  const onTourRoute = tourRoutes.has(normalizedLocation);
+  const requiredRoute = steps[stepIndex]?.route ?? null;
 
   // 0. 引导开启但当前路由不是本步所需的路由——先导航过去，锚点才能挂载。跨页步骤
   //    切换（见 tour.ts 的 onStepChange）与「重看引导」从非首步路由触发都走这里。
@@ -111,7 +112,7 @@ export function OnboardingTour() {
       close: t("close"),
       progress: (current, total) => t("progress", { current, total }),
     };
-    const handle = startTour(buildTourSteps(t), labels, {
+    const handle = startTour(steps, labels, {
       onExit: () => useOnboardingStore.getState().exit(),
       startIndex: stepIndexRef.current,
       onStepChange: setStep,
@@ -122,7 +123,7 @@ export function OnboardingTour() {
     };
     // 步骤号有意不进依赖（stepIndexRef 是 ref，读取本就不受 lint 约束）——步骤号变化
     // 不该重启这个效果，否则每次「下一步」都会拆重建 driver 实例。
-  }, [active, onTourRoute, t]);
+  }, [active, onTourRoute, steps, t]);
 
   return null;
 }

--- a/frontend/src/onboarding/OnboardingTour.tsx
+++ b/frontend/src/onboarding/OnboardingTour.tsx
@@ -6,20 +6,33 @@
  * 1. 进入主界面后查一次「是否已看过」（auth 开启 = 登录成功后；匿名 = auth status 放行
  *    后，两种情形都由 `isAuthenticated` 统一表达）。登录页不掺和。
  * 2. 未看过则自动开一次。
- * 3. 开启但当前不在大厅（如设置页点「重看引导」、或深链接直落其它主界面路由）时先
- *    导航到大厅——当前步骤大纲的锚点全部落在大厅，其它页面上没有可高亮的目标。
- * 4. store 里 active 为真且已在大厅时驱动 driver.js —— 自动首弹与设置页「重看引导」
- *    共用这条路径，组件本身不区分二者。
+ * 3. 开启但当前所在路由不是当前步骤所需的路由（如设置页点「重看引导」回到第 1 步、
+ *    或跨页步骤切到下一段）时先导航过去，锚点才能挂载。
+ * 4. store 里 active 为真、且当前路由是引导覆盖的路由之一时驱动 driver.js —— 自动
+ *    首弹与设置页「重看引导」共用这条路径，组件本身不区分二者。
+ *
+ * 步骤大纲现在跨大厅、设置两个页面。driver.js 实例挂在 `document.body` 上、在
+ * React 树之外，只要第 3 点里的路由判定在这两页之间保持同一个真值，实例就不会被
+ * effect 4 拆重建——「下一步」跨页时靠 `tour.ts` 的 `onStepChange` 在 driver 真正
+ * 切换高亮之前把即将停靠的步号同步上报，本组件据此提前导航，驱动效果本身不重启。
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocation } from "wouter";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOnboardingStore } from "@/stores/onboarding-store";
-import { APP_PROJECT_WORKSPACE_PATTERN, APP_TOP_LEVEL_ROUTES, ROUTE_APP_PROJECTS } from "@/app-routes";
+import {
+  APP_PROJECT_WORKSPACE_PATTERN,
+  APP_TOP_LEVEL_ROUTES,
+  ROUTE_APP_PROJECTS,
+  ROUTE_APP_SETTINGS,
+} from "@/app-routes";
 import { buildTourSteps } from "./steps";
 import { startTour, type TourLabels } from "./tour";
+
+/** 引导步骤大纲当下覆盖的路由集合——驱动效果据此判断「是否还在引导范围内」。 */
+const TOUR_ROUTES: readonly string[] = [ROUTE_APP_PROJECTS, ROUTE_APP_SETTINGS];
 
 export function OnboardingTour() {
   const { t } = useTranslation("onboarding");
@@ -42,16 +55,27 @@ export function OnboardingTour() {
     (normalizedLocation === "/" ||
       (APP_TOP_LEVEL_ROUTES as readonly string[]).includes(normalizedLocation) ||
       APP_PROJECT_WORKSPACE_PATTERN.test(normalizedLocation));
-  // 当前步骤大纲的锚点全部落在大厅（ROUTE_APP_PROJECTS）——「重看引导」在设置页
-  // 等其它主界面路由触发时，driver.js 找不到锚点只会退化居中，不会自动跳转。
-  // 后续段落若在设置页/工作台新增带锚点的步骤，需按步骤索引扩展这里的路由判定。
-  const atLobby = normalizedLocation === ROUTE_APP_PROJECTS;
+  // 当前所在路由是否是引导覆盖的路由之一（大厅或设置页）——驱动效果（4）以此为准，
+  // 而不是逐步比对，这样大厅↔设置页之间的跨页步骤切换不会拆重建 driver 实例。
+  const onTourRoute = TOUR_ROUTES.includes(normalizedLocation);
 
-  // 0. 引导开启但不在大厅——先导航过去，锚点才能挂载
+  // 停在第几步（0 基）。用 ref 给驱动效果读取初始值又不把它列进依赖（步骤切换不该
+  // 重启驱动效果），state 给下面的路由判定效果做响应式依赖。两者总是同步写入。
+  const stepIndexRef = useRef(0);
+  const [stepIndex, setStepIndex] = useState(0);
+  const setStep = (index: number) => {
+    stepIndexRef.current = index;
+    setStepIndex(index);
+  };
+
+  const requiredRoute = buildTourSteps(t)[stepIndex]?.route ?? null;
+
+  // 0. 引导开启但当前路由不是本步所需的路由——先导航过去，锚点才能挂载。跨页步骤
+  //    切换（见 tour.ts 的 onStepChange）与「重看引导」从非首步路由触发都走这里。
   useEffect(() => {
-    if (!active || atLobby || !inMainUi) return;
-    navigate(ROUTE_APP_PROJECTS);
-  }, [active, atLobby, inMainUi, navigate]);
+    if (!active || !inMainUi || !requiredRoute || normalizedLocation === requiredRoute) return;
+    navigate(requiredRoute);
+  }, [active, inMainUi, requiredRoute, normalizedLocation, navigate]);
 
   // 1. 查询「是否已看过」
   useEffect(() => {
@@ -71,12 +95,12 @@ export function OnboardingTour() {
   //
   // 文案是构造时一次性交给 driver 的，切换界面语言（`t` 换身份）必须重建一遍才能生效。
   // 重建走 `dispose()` —— 不记退出 —— 并把停留的步号带过去，讲到第几步就还在第几步。
-  const stepIndexRef = useRef(0);
   useEffect(() => {
-    // 离开主界面（如运行期间浏览器后退回登录页）或尚未导航到大厅时收起正在运行的
-    // 引导——不算一次退出（不记 seen），保留步号，回到大厅后从原位继续。
-    if (!active || !atLobby) {
-      if (!active) stepIndexRef.current = 0;
+    // 离开引导覆盖的路由（如运行期间浏览器后退回登录页）或尚未导航过去时收起正在
+    // 运行的引导——不算一次退出（不记 seen），保留步号，回到范围内后从原位继续。
+    if (!active || !onTourRoute) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- 引导退出时把步号复位到起点，是有意的受控重置，下次开启从头开始
+      if (!active) setStep(0);
       return;
     }
     const labels: TourLabels = {
@@ -90,12 +114,15 @@ export function OnboardingTour() {
     const handle = startTour(buildTourSteps(t), labels, {
       onExit: () => useOnboardingStore.getState().exit(),
       startIndex: stepIndexRef.current,
+      onStepChange: setStep,
     });
     return () => {
-      stepIndexRef.current = handle.currentIndex();
+      setStep(handle.currentIndex());
       handle.dispose();
     };
-  }, [active, atLobby, t]);
+    // 步骤号有意不进依赖（stepIndexRef 是 ref，读取本就不受 lint 约束）——步骤号变化
+    // 不该重启这个效果，否则每次「下一步」都会拆重建 driver 实例。
+  }, [active, onTourRoute, t]);
 
   return null;
 }

--- a/frontend/src/onboarding/anchors.test.tsx
+++ b/frontend/src/onboarding/anchors.test.tsx
@@ -11,6 +11,7 @@ import { Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
 import { API } from "@/api";
 import { ProjectsPage } from "@/components/pages/ProjectsPage";
+import { SystemConfigPage } from "@/components/pages/SystemConfigPage";
 import { useAppStore } from "@/stores/app-store";
 import { useOnboardingStore } from "@/stores/onboarding-store";
 import { useProjectsStore } from "@/stores/projects-store";
@@ -30,6 +31,15 @@ function renderLobby() {
   );
 }
 
+function renderSettings() {
+  const { hook } = memoryLocation({ path: "/app/settings" });
+  render(
+    <Router hook={hook}>
+      <SystemConfigPage />
+    </Router>,
+  );
+}
+
 /** 每个锚点挂载它所在的界面。断言统一在下面的用例里做。 */
 const RENDERERS: Record<OnboardingAnchor, () => void> = {
   [ONBOARDING_ANCHORS.lobbyCreateProject]: renderLobby,
@@ -39,6 +49,8 @@ const RENDERERS: Record<OnboardingAnchor, () => void> = {
     useOnboardingStore.setState({ active: true });
     renderLobby();
   },
+  [ONBOARDING_ANCHORS.settingsProviders]: renderSettings,
+  [ONBOARDING_ANCHORS.settingsAgent]: renderSettings,
 };
 
 describe("onboarding anchors", () => {

--- a/frontend/src/onboarding/anchors.ts
+++ b/frontend/src/onboarding/anchors.ts
@@ -10,14 +10,18 @@
  * | `lobby-create-project` | 大厅 2 | 项目大厅顶栏的「新建项目」按钮 |
  * | `lobby-demo-card` | 大厅 3 | 引导期间注入大厅的演示项目卡 |
  * | `lobby-settings` | 大厅 4 | 项目大厅顶栏的设置图标（未配置齐全时带红点） |
+ * | `settings-providers` | 设置 5 | 设置页侧栏「媒体供应商」入口 |
+ * | `settings-agent` | 设置 6 | 设置页侧栏「Agent 配置」入口 |
  *
- * 大厅第 1 步是居中的欢迎气泡，不挂锚点。
+ * 大厅第 1 步与收尾步是居中的气泡，不挂锚点。
  */
 
 export const ONBOARDING_ANCHORS = {
   lobbyCreateProject: "lobby-create-project",
   lobbyDemoCard: "lobby-demo-card",
   lobbySettings: "lobby-settings",
+  settingsProviders: "settings-providers",
+  settingsAgent: "settings-agent",
 } as const;
 
 export type OnboardingAnchor = (typeof ONBOARDING_ANCHORS)[keyof typeof ONBOARDING_ANCHORS];

--- a/frontend/src/onboarding/steps.test.ts
+++ b/frontend/src/onboarding/steps.test.ts
@@ -1,12 +1,14 @@
 /**
- * 步骤大纲的形状：大厅四步（欢迎 + 三个带锚点的入口）后面接收尾气泡。
+ * 步骤大纲的形状：大厅四步（欢迎 + 三个带锚点的入口）跨页进入设置页两步，后面接收尾气泡。
  *
  * 锚点名漂移由类型拦，步骤被顺手删掉只有这里拦 —— 收尾气泡里带着「重看引导」的去处，
- * 中间任何一段落地时都不该把它挤掉。
+ * 中间任何一段落地时都不该把它挤掉。`route` 一并断言，跨页步骤的导航目标写错也会在
+ * 这里被抓到，而不必等到跑 `OnboardingTour` 的集成测试才发现。
  */
 
 import { describe, expect, it } from "vitest";
 import type { TFunction } from "i18next";
+import { ROUTE_APP_PROJECTS, ROUTE_APP_SETTINGS } from "@/app-routes";
 import { ONBOARDING_ANCHORS } from "./anchors";
 import { buildTourSteps } from "./steps";
 
@@ -14,13 +16,15 @@ import { buildTourSteps } from "./steps";
 const t = ((key: string) => key) as unknown as TFunction<"onboarding">;
 
 describe("buildTourSteps", () => {
-  it("walks the lobby and ends on a centered wrap-up bubble", () => {
-    expect(buildTourSteps(t).map((s) => [s.anchor, s.title])).toEqual([
-      [null, "welcome_title"],
-      [ONBOARDING_ANCHORS.lobbyCreateProject, "lobby_create_title"],
-      [ONBOARDING_ANCHORS.lobbyDemoCard, "lobby_demo_title"],
-      [ONBOARDING_ANCHORS.lobbySettings, "lobby_settings_title"],
-      [null, "finish_title"],
+  it("walks the lobby, crosses into settings, and ends on a centered wrap-up bubble", () => {
+    expect(buildTourSteps(t).map((s) => [s.anchor, s.title, s.route])).toEqual([
+      [null, "welcome_title", ROUTE_APP_PROJECTS],
+      [ONBOARDING_ANCHORS.lobbyCreateProject, "lobby_create_title", ROUTE_APP_PROJECTS],
+      [ONBOARDING_ANCHORS.lobbyDemoCard, "lobby_demo_title", ROUTE_APP_PROJECTS],
+      [ONBOARDING_ANCHORS.lobbySettings, "lobby_settings_title", ROUTE_APP_PROJECTS],
+      [ONBOARDING_ANCHORS.settingsProviders, "settings_providers_title", ROUTE_APP_SETTINGS],
+      [ONBOARDING_ANCHORS.settingsAgent, "settings_agent_title", ROUTE_APP_SETTINGS],
+      [null, "finish_title", undefined],
     ]);
   });
 });

--- a/frontend/src/onboarding/steps.ts
+++ b/frontend/src/onboarding/steps.ts
@@ -1,34 +1,52 @@
 /**
  * 首次使用引导的步骤大纲。
  *
- * 结构（顺序、锚点）写在这里，文案全部走 `onboarding` 命名空间的 i18n key —— 两者分离，
- * 加语种不必碰结构，调顺序不必碰翻译。锚点一律引用 `anchors.ts` 的注册表，不写字面量。
+ * 结构（顺序、锚点、路由）写在这里，文案全部走 `onboarding` 命名空间的 i18n key —— 两者
+ * 分离，加语种不必碰结构，调顺序不必碰翻译。锚点一律引用 `anchors.ts` 的注册表，不写
+ * 字面量。`route` 是该步所需落地的页面（`OnboardingTour` 据此在步骤切换前先行导航），
+ * 省略表示不要求特定路由。
  *
- * 当前覆盖大厅段：欢迎（居中气泡）→ 新建项目入口 → 演示卡 → 设置入口，末尾接收尾气泡。
- * 设置页段与工作台段的步骤插在设置入口与收尾之间。
+ * 覆盖大厅段（欢迎 → 新建项目入口 → 演示卡 → 设置入口）与设置页段（媒体供应商 → Agent
+ * 配置），末尾接收尾气泡。工作台段的步骤留待后续段落插在设置页段与收尾之间。
  */
 
 import type { TFunction } from "i18next";
+import { ROUTE_APP_PROJECTS, ROUTE_APP_SETTINGS } from "@/app-routes";
 import { ONBOARDING_ANCHORS } from "./anchors";
 import type { TourStep } from "./tour";
 
 export function buildTourSteps(t: TFunction<"onboarding">): TourStep[] {
   return [
-    { anchor: null, title: t("welcome_title"), body: t("welcome_body") },
+    { anchor: null, title: t("welcome_title"), body: t("welcome_body"), route: ROUTE_APP_PROJECTS },
     {
       anchor: ONBOARDING_ANCHORS.lobbyCreateProject,
       title: t("lobby_create_title"),
       body: t("lobby_create_body"),
+      route: ROUTE_APP_PROJECTS,
     },
     {
       anchor: ONBOARDING_ANCHORS.lobbyDemoCard,
       title: t("lobby_demo_title"),
       body: t("lobby_demo_body"),
+      route: ROUTE_APP_PROJECTS,
     },
     {
       anchor: ONBOARDING_ANCHORS.lobbySettings,
       title: t("lobby_settings_title"),
       body: t("lobby_settings_body"),
+      route: ROUTE_APP_PROJECTS,
+    },
+    {
+      anchor: ONBOARDING_ANCHORS.settingsProviders,
+      title: t("settings_providers_title"),
+      body: t("settings_providers_body"),
+      route: ROUTE_APP_SETTINGS,
+    },
+    {
+      anchor: ONBOARDING_ANCHORS.settingsAgent,
+      title: t("settings_agent_title"),
+      body: t("settings_agent_body"),
+      route: ROUTE_APP_SETTINGS,
     },
     { anchor: null, title: t("finish_title"), body: t("finish_body") },
   ];

--- a/frontend/src/onboarding/tour.test.ts
+++ b/frontend/src/onboarding/tour.test.ts
@@ -208,6 +208,24 @@ describe("startTour", () => {
       handle.dispose();
     });
 
+    it("ignores ArrowLeft on the first step instead of exiting the tour", () => {
+      // driver 的「上一步」按钮在首步会被禁用，click() 不会触发；但键盘路径没有这层禁用
+      // 态——不挡住的话 movePrevious() 在 driver.js 内部找不到上一步会直接把引导销毁掉，
+      // 表现为用户什么都没做（没跳过/没关闭/没走完）却提前退出了引导。
+      const onExit = vi.fn();
+      const onStepChange = vi.fn();
+      const handle = startTour(TWO_STEPS, LABELS, { onExit, onStepChange });
+
+      window.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowLeft" }));
+
+      expect(onStepChange).not.toHaveBeenCalled();
+      expect(onExit).not.toHaveBeenCalled();
+      expect(handle.currentIndex()).toBe(0);
+      expect(document.querySelector(".driver-popover")).not.toBeNull();
+
+      handle.dispose();
+    });
+
     it("reports the exit once on Escape", () => {
       const onExit = vi.fn();
       startTour(TWO_STEPS, LABELS, { onExit });

--- a/frontend/src/onboarding/tour.test.ts
+++ b/frontend/src/onboarding/tour.test.ts
@@ -180,6 +180,55 @@ describe("startTour", () => {
     expect(document.querySelector(".driver-popover")).toBeNull();
   });
 
+  describe("keyboard navigation", () => {
+    // driver 自带的方向键处理绕过 onNextClick/onPrevClick、不会触发 onStepChange 上报
+    // （跨页导航因此失效）——startTour 关闭了它，自己接管 Esc/方向键，这里断言键盘路径
+    // 与按钮点击走的是同一条上报逻辑。
+    it("advances and reports onStepChange on ArrowRight, same as clicking next", () => {
+      const onStepChange = vi.fn();
+      const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn(), onStepChange });
+
+      window.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowRight" }));
+
+      expect(onStepChange).toHaveBeenCalledWith(1);
+      expect(handle.currentIndex()).toBe(1);
+
+      handle.dispose();
+    });
+
+    it("moves back and reports onStepChange on ArrowLeft", () => {
+      const onStepChange = vi.fn();
+      const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn(), startIndex: 1, onStepChange });
+
+      window.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowLeft" }));
+
+      expect(onStepChange).toHaveBeenCalledWith(0);
+      expect(handle.currentIndex()).toBe(0);
+
+      handle.dispose();
+    });
+
+    it("reports the exit once on Escape", () => {
+      const onExit = vi.fn();
+      startTour(TWO_STEPS, LABELS, { onExit });
+
+      window.dispatchEvent(new KeyboardEvent("keyup", { key: "Escape" }));
+
+      expect(onExit).toHaveBeenCalledTimes(1);
+      expect(document.querySelector(".driver-popover")).toBeNull();
+    });
+
+    it("stops handling arrow keys after the caller disposes the tour", () => {
+      const onStepChange = vi.fn();
+      const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn(), onStepChange });
+
+      handle.dispose();
+      window.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowRight" }));
+
+      expect(onStepChange).not.toHaveBeenCalled();
+    });
+  });
+
   describe("peripheral isolation", () => {
     // driver.js 只挡 pointer-events + Tab 键，屏幕阅读器的虚拟光标仍能读到底层界面；
     // body 的既有子节点（#app-root，以及 ModalShell/CreateProjectModal 这类直接

--- a/frontend/src/onboarding/tour.test.ts
+++ b/frontend/src/onboarding/tour.test.ts
@@ -196,6 +196,18 @@ describe("startTour", () => {
       handle.dispose();
     });
 
+    it("finishes the tour on ArrowRight at the last step, same as clicking next", () => {
+      const onExit = vi.fn();
+      const onStepChange = vi.fn();
+      startTour(TWO_STEPS, LABELS, { onExit, startIndex: 1, onStepChange });
+
+      window.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowRight" }));
+
+      expect(onStepChange).not.toHaveBeenCalled();
+      expect(onExit).toHaveBeenCalledTimes(1);
+      expect(document.querySelector(".driver-popover")).toBeNull();
+    });
+
     it("moves back and reports onStepChange on ArrowLeft", () => {
       const onStepChange = vi.fn();
       const handle = startTour(TWO_STEPS, LABELS, { onExit: vi.fn(), startIndex: 1, onStepChange });

--- a/frontend/src/onboarding/tour.ts
+++ b/frontend/src/onboarding/tour.ts
@@ -19,6 +19,12 @@ export interface TourStep {
   anchor: OnboardingAnchor | null;
   title: string;
   body: string;
+  /**
+   * 该步所需的路由，调用方自行定义、这里不解释语义——纯粹原样透传，供调用方在
+   * `onStepChange` 里比对是否需要导航。省略 = 不要求特定路由，留在当前页继续讲
+   * （开场欢迎气泡以外的居中步通常这样用）。
+   */
+  route?: string;
 }
 
 export interface TourLabels {
@@ -128,6 +134,10 @@ function renderProgress(progress: HTMLElement, current: number, total: number, l
  * @param onExit 任一退出路径（跳过 / 关闭 / 走完）都会调用一次；`dispose()` 不调用。
  * @param startIndex 从第几步开始（0 基）。默认 0；重建时传入上一次的 `currentIndex()`。
  * @param anchorWaitMs 锚点缺席时的等待上限，默认 `ANCHOR_WAIT_MS`。
+ * @param onStepChange 「下一步/上一步」被触发时（按钮点击与方向键都走同一条内部回调，
+ *   见 `onNextClick`/`onPrevClick`）、在 driver 实际切换高亮之前，同步上报即将停靠的
+ *   步号。调用方可以据此在 driver 尝试高亮新步骤的锚点之前先行导航——两者天然存在的
+ *   时间差由 driver 自己的 `waitForElement` 轮询吸收，不需要额外的等待逻辑。
  */
 export function startTour(
   steps: TourStep[],
@@ -136,7 +146,13 @@ export function startTour(
     onExit,
     startIndex = 0,
     anchorWaitMs = ANCHOR_WAIT_MS,
-  }: { onExit: () => void; startIndex?: number; anchorWaitMs?: number },
+    onStepChange,
+  }: {
+    onExit: () => void;
+    startIndex?: number;
+    anchorWaitMs?: number;
+    onStepChange?: (index: number) => void;
+  },
 ): TourHandle {
   const total = steps.length;
   let exited = false;
@@ -185,10 +201,17 @@ export function startTour(
     // 与无 DOM 帧的环境下会静默漏掉回调。改走「按钮 + 主动收起」这两个我们自己掌握的
     // 入口，退出必然被记一次。
     onNextClick: () => {
-      if (instance.isLastStep()) finish();
-      else instance.moveNext();
+      if (instance.isLastStep()) {
+        finish();
+        return;
+      }
+      onStepChange?.((instance.getActiveIndex() ?? 0) + 1);
+      instance.moveNext();
     },
-    onPrevClick: () => instance.movePrevious(),
+    onPrevClick: () => {
+      onStepChange?.(Math.max((instance.getActiveIndex() ?? 0) - 1, 0));
+      instance.movePrevious();
+    },
     onCloseClick: () => finish(),
     // Esc 与点击遮罩走 driver 内部的收起流程，在真正拆掉之前回调这里。
     onDestroyStarted: () => finish(),

--- a/frontend/src/onboarding/tour.ts
+++ b/frontend/src/onboarding/tour.ts
@@ -222,9 +222,14 @@ export function startTour(
     instance.moveNext();
   }
 
-  /** 上一步：按钮点击与 `ArrowLeft` 键共用，保证跨页上报一致。 */
+  /**
+   * 上一步：按钮点击与 `ArrowLeft` 键共用，保证跨页上报一致。首步无上一步可退——
+   * 按钮此时被 driver 禁用不会触发，但键盘路径没有这层禁用态，不挡住的话
+   * `instance.movePrevious()` 会在 driver.js 内部找不到上一步时把整个引导销毁掉。
+   */
   function handlePrev(): void {
-    onStepChange?.(Math.max((instance.getActiveIndex() ?? 0) - 1, 0));
+    if (instance.isFirstStep()) return;
+    onStepChange?.((instance.getActiveIndex() ?? 0) - 1);
     instance.movePrevious();
   }
 

--- a/frontend/src/onboarding/tour.ts
+++ b/frontend/src/onboarding/tour.ts
@@ -179,6 +179,11 @@ export function startTour(
     // 讲解本身仍然成立，丢的只是高亮，driver 会退回自己的占位元素、把气泡摆到屏幕中央。
     waitForElement: anchorWaitMs,
     skipMissingElement: false,
+    // driver 自带的方向键切步直接调 moveNext()/movePrevious()，不经过下面的
+    // onNextClick/onPrevClick——跨页导航的 onStepChange 上报会被绕过。这里关闭它，
+    // 改由本文件末尾的 keyup 监听统一接管 Esc/方向键，确保键盘路径与按钮路径走同一条
+    // 上报逻辑。
+    allowKeyboardControl: false,
     nextBtnText: labels.next,
     prevBtnText: labels.prev,
     doneBtnText: labels.done,
@@ -200,22 +205,28 @@ export function startTour(
     // 写进 state 之后才会触发，而那次写入排在 requestAnimationFrame 里 —— 同步 destroy
     // 与无 DOM 帧的环境下会静默漏掉回调。改走「按钮 + 主动收起」这两个我们自己掌握的
     // 入口，退出必然被记一次。
-    onNextClick: () => {
-      if (instance.isLastStep()) {
-        finish();
-        return;
-      }
-      onStepChange?.((instance.getActiveIndex() ?? 0) + 1);
-      instance.moveNext();
-    },
-    onPrevClick: () => {
-      onStepChange?.(Math.max((instance.getActiveIndex() ?? 0) - 1, 0));
-      instance.movePrevious();
-    },
+    onNextClick: () => handleNext(),
+    onPrevClick: () => handlePrev(),
     onCloseClick: () => finish(),
     // Esc 与点击遮罩走 driver 内部的收起流程，在真正拆掉之前回调这里。
     onDestroyStarted: () => finish(),
   });
+
+  /** 下一步：按钮点击与 `ArrowRight` 键共用，保证跨页上报一致。 */
+  function handleNext(): void {
+    if (instance.isLastStep()) {
+      finish();
+      return;
+    }
+    onStepChange?.((instance.getActiveIndex() ?? 0) + 1);
+    instance.moveNext();
+  }
+
+  /** 上一步：按钮点击与 `ArrowLeft` 键共用，保证跨页上报一致。 */
+  function handlePrev(): void {
+    onStepChange?.(Math.max((instance.getActiveIndex() ?? 0) - 1, 0));
+    instance.movePrevious();
+  }
 
   /** 记一次退出并收起。重复调用只记一次。 */
   function finish(): void {
@@ -223,17 +234,33 @@ export function startTour(
       exited = true;
       onExit();
     }
+    window.removeEventListener("keyup", onKeyUp);
     setPeripheralIsolation(false);
     instance.destroy();
   }
 
+  // allowKeyboardControl 关闭后 driver 不再自行处理 Esc/方向键，这里接管：Esc 走 finish()
+  // （与 driver 默认的 allowClose 行为一致，本文件未覆盖该配置，其默认值即为 true）；
+  // 方向键复用 handleNext/handlePrev，与按钮点击走同一条上报路径。
+  function onKeyUp(e: KeyboardEvent): void {
+    if (e.key === "Escape") {
+      finish();
+    } else if (e.key === "ArrowRight") {
+      handleNext();
+    } else if (e.key === "ArrowLeft") {
+      handlePrev();
+    }
+  }
+
   setPeripheralIsolation(true);
+  window.addEventListener("keyup", onKeyUp);
   instance.drive(Math.min(Math.max(startIndex, 0), total - 1));
 
   return {
     currentIndex: () => instance.getActiveIndex() ?? 0,
     dispose: () => {
       disposing = true;
+      window.removeEventListener("keyup", onKeyUp);
       setPeripheralIsolation(false);
       instance.destroy();
     },


### PR DESCRIPTION
Closes #1303

首次使用引导从项目大厅延伸到设置页：讲完大厅四步后自动跳转设置页，依次高亮「媒体供应商」与「Agent 配置」两个入口，再回到收尾气泡。中途「跳过」「关闭」照常标记已看；跨页后目标尚未渲染时沿用锚点等待轮询，超时降级为居中气泡继续讲，不中断也不跳步。设置页未配齐的红点提醒机制零改动。

## 实现要点

- `TourStep` 新增可选 `route`，由 `OnboardingTour` 解释：`tour.ts` 的 `onStepChange` 在 driver 切换高亮之前同步上报即将停靠的步号，组件据此抢先导航，时间差交给 driver 自身的 `waitForElement` 吸收
- 「当前路由是否属于引导覆盖范围」与「当前步该落在哪条路由」拆成两层判定，前者门控 driver 实例存活、后者门控主动导航，大厅↔设置页往返不拆重建实例
- 引导覆盖的路由集合从步骤大纲派生，后续段落在新页面加步骤只需给那一步写 `route`，无需同步维护第二份常量

## 验证

- `pnpm lint && pnpm check` 全绿：119 files / 1106 tests
- 新增集成用例：跨页命中真实锚点、跨页回退（「上一步」从设置页退回大厅）、跨页途中跳过仍记 seen、锚点缺席降级居中气泡；每条锚点断言与三语文案同步补齐
- 后端零改动


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 首次使用引导新增“媒体供应商”和“Agent 配置”步骤，并支持在工作台与系统设置页间跨页定位。
- **改进**
  - 完善前进/后退/跳过及键盘（方向键、Esc）下的引导状态同步与退出行为。
  - 引导文案已补充并覆盖英文、越南文与中文。
- **问题修复**
  - 当系统设置页关键锚点暂未出现时，将超时降级为居中气泡并提示告警。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->