### PR TITLE
fix(routers): 上传接口项目缺失时报准确的项目不存在文案

### DIFF
--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -391,6 +391,10 @@ async def _handle_source_upload(
 
     try:
         result = await asyncio.to_thread(_sync)
+    except FileNotFoundError as exc:
+        # 竞态窗口：get_project_path 通过后项目目录被并发删除，SourceLoader 写入时才炸。
+        # 不映射会落到 app 级兜底的泛化 resource_not_found，丢失项目语义
+        raise NotFoundError("project_not_found", name=project_name) from exc
     except UnsupportedFormatError as exc:
         raise HTTPException(
             status_code=400,

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -393,7 +393,10 @@ async def _handle_source_upload(
         result = await asyncio.to_thread(_sync)
     except FileNotFoundError as exc:
         # 竞态窗口：get_project_path 通过后项目目录被并发删除，SourceLoader 写入时才炸。
-        # 不映射会落到 app 级兜底的泛化 resource_not_found，丢失项目语义
+        # 不映射会落到 app 级兜底的泛化 resource_not_found，丢失项目语义。
+        # 仅在项目目录确实消失时转换：tmp 文件/加载器内部的文件缺失不是项目问题，继续上抛
+        if project_dir.exists():
+            raise
         raise NotFoundError("project_not_found", name=project_name) from exc
     except UnsupportedFormatError as exc:
         raise HTTPException(

--- a/server/routers/shot_uploads.py
+++ b/server/routers/shot_uploads.py
@@ -16,7 +16,7 @@ from typing import Literal
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
 
-from lib.api_errors import NotFoundError
+from lib.api_errors import ApiError, NotFoundError
 from lib.i18n import Translator
 from lib.image_utils import normalize_storyboard_upload
 from lib.path_safety import PathTraversalError, safe_join
@@ -66,7 +66,11 @@ async def upload_shot_media(
         relative_path = resource_relative_path(resource_type, shot_id)
 
         def _validate_shot() -> tuple[Path, VersionManager]:
-            project_path = get_project_manager().get_project_path(project_name)
+            # 项目缺失单独映射：落到外层 except FileNotFoundError 会误报「剧本不存在」
+            try:
+                project_path = get_project_manager().get_project_path(project_name)
+            except FileNotFoundError as exc:
+                raise NotFoundError("project_not_found", name=project_name) from exc
             script = get_project_manager().load_script(project_name, script_file)
             # reference_video 剧本返回空列表 → 404，该模式的视频上传走 reference-videos 路由
             items, id_field, _, _, _ = get_storyboard_items(script)
@@ -147,7 +151,7 @@ async def upload_shot_media(
         raise HTTPException(status_code=404, detail=_t("segment_not_found", id=shot_id))
     except ScriptEditError as e:
         raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=str(e)))
-    except HTTPException:
+    except (HTTPException, ApiError):
         raise
     except Exception as e:
         # 不回传 str(e)：未预期异常的消息可能含服务器路径等内部细节，堆栈进日志即可

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -123,7 +123,7 @@ class TestFilesRouter:
         class _BrokenLoader:
             @staticmethod
             def load(*args, **kwargs):
-                raise FileNotFoundError("/tmp/upload-tmp gone")
+                raise FileNotFoundError("upload-tmp gone")
 
         monkeypatch.setattr(files, "SourceLoader", _BrokenLoader)
         with client:

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 from io import BytesIO
 
 from fastapi import FastAPI
@@ -104,6 +105,7 @@ class TestFilesRouter:
         class _RaceLoader:
             @staticmethod
             def load(*args, **kwargs):
+                shutil.rmtree(tmp_path / "projects" / "demo")
                 raise FileNotFoundError("/server/projects/demo/source gone")
 
         monkeypatch.setattr(files, "SourceLoader", _RaceLoader)
@@ -114,6 +116,23 @@ class TestFilesRouter:
             )
             assert resp.status_code == 404
             assert resp.json()["detail"] == zh_errors.MESSAGES["project_not_found"].format(name="demo")
+
+    def test_source_upload_loader_file_missing_with_project_intact_stays_generic(self, tmp_path, monkeypatch):
+        client, _ = _client(monkeypatch, tmp_path)
+
+        class _BrokenLoader:
+            @staticmethod
+            def load(*args, **kwargs):
+                raise FileNotFoundError("/tmp/upload-tmp gone")
+
+        monkeypatch.setattr(files, "SourceLoader", _BrokenLoader)
+        with client:
+            resp = client.post(
+                "/api/v1/projects/demo/upload/source",
+                files={"file": ("chapter.txt", BytesIO(b"hello"), "text/plain")},
+            )
+            assert resp.status_code == 404
+            assert resp.json()["detail"] == zh_errors.MESSAGES["resource_not_found"]
 
     def test_upload_assets_and_drafts(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from PIL import Image
 
+from lib.i18n.zh import errors as zh_errors
 from lib.project_manager import ProjectManager
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
@@ -96,6 +97,23 @@ class TestFilesRouter:
 
             missing = client.get("/api/v1/projects/demo/source/missing.txt")
             assert missing.status_code == 404
+
+    def test_source_upload_race_project_deleted_reports_project_not_found(self, tmp_path, monkeypatch):
+        client, _ = _client(monkeypatch, tmp_path)
+
+        class _RaceLoader:
+            @staticmethod
+            def load(*args, **kwargs):
+                raise FileNotFoundError("/server/projects/demo/source gone")
+
+        monkeypatch.setattr(files, "SourceLoader", _RaceLoader)
+        with client:
+            resp = client.post(
+                "/api/v1/projects/demo/upload/source",
+                files={"file": ("chapter.txt", BytesIO(b"hello"), "text/plain")},
+            )
+            assert resp.status_code == 404
+            assert resp.json()["detail"] == zh_errors.MESSAGES["project_not_found"].format(name="demo")
 
     def test_upload_assets_and_drafts(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)

--- a/tests/test_shot_uploads_router.py
+++ b/tests/test_shot_uploads_router.py
@@ -219,6 +219,16 @@ class TestShotStoryboardUpload:
             assert resp.status_code == 404
             assert str(tmp_path) not in resp.json()["detail"]
 
+    def test_missing_project_404_reports_project_not_found(self, tmp_path, monkeypatch):
+        client, _ = _client(monkeypatch, tmp_path)
+        with client:
+            resp = client.post(
+                "/api/v1/projects/nope/shots/E1S01/upload/storyboard?script_file=episode_1.json",
+                files={"file": ("x.png", BytesIO(_img_bytes("PNG")), "application/octet-stream")},
+            )
+            assert resp.status_code == 404
+            assert resp.json()["detail"] == zh_errors.MESSAGES["project_not_found"].format(name="nope")
+
 
 class TestShotVideoUpload:
     def test_upload_finalizes_and_clears_stale_video_uri(self, tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #1324

## 改动

1. **`shot_uploads.py`**：`_validate_shot` 内 `get_project_path` 单独映射 `NotFoundError("project_not_found")`——此前项目缺失与剧本缺失共用外层 `except FileNotFoundError`，误报「剧本不存在」。抛出点落在路由 except 阶梯的 try 体内，阶梯同步补 `(HTTPException, ApiError)` 直通（#1263 判据：否则被 `except Exception` 吞成 500）。
2. **`files.py::_handle_source_upload`**：`_sync`（SourceLoader 写入）的异常阶梯补 `FileNotFoundError` → `NotFoundError("project_not_found")`，覆盖「`get_project_path` 通过后项目被并发删除」的竞态窗口——此前落到 app 级兜底的泛化 `resource_not_found` 文案。

## 测试

- 两处各一条回归测试，均验证「去掉修复即转红」；断言 `zh_errors.MESSAGES[...]` 文案防 i18n key/参数误用
- `ruff check/format` 通过；`basedpyright` 0 error；受影响测试文件 73 passed

https://claude.ai/code/session_019Jg3TctYKu8RWm3zR1L4xU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 源文件上传在项目目录并发删除导致找不到时，返回明确“项目不存在”（404），并区分项目已消失/仍存在的竞态结果。
  - 镜头上传校验对项目路径缺失进行专门映射为“项目不存在”（404），同时避免服务端路径信息泄露。
  - 上传接口异常处理范围更精确，已识别错误不再被错误转换为 500。
- **测试**
  - 新增源文件上传竞态/缺失场景回归用例，断言中文 i18n 错误文案。
  - 新增镜头 storyboard 上传缺失项目回归用例（校验返回 detail）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->