### PR TITLE
chore: 忽略 TypeScript 增量编译产物 tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ CLAUDE.local.md
 frontend/node_modules/
 frontend/dist/
 frontend/.vite/
+*.tsbuildinfo
 
 # Git backup
 .git.backup


### PR DESCRIPTION
开发态偶发生成的 `*.tsbuildinfo` 加入 `.gitignore`，避免误提交。来源：Spec #1299 收尾转呈候选，用户批准顺手处理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新版本控制忽略规则，避免提交 TypeScript 构建信息文件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->