### PR TITLE
ci(codeql): 加载 AlertSuppression 查询，使行内抑制注释生效

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -2,3 +2,12 @@ name: "ArcReel CodeQL Config"
 
 paths-ignore:
   - alembic/versions
+
+# AlertSuppression 不在默认套件：不加载则行内 `# codeql[rule-id]` 抑制注释不会写入
+# SARIF suppressions[]，误报只能走 GitHub API dismiss（alert 编号还会随行号漂移）。
+# 语言键 javascript 覆盖 JS/TS；默认查询套件不受 packs 影响、照常运行。
+packs:
+  python:
+    - codeql/python-queries:AlertSuppression.ql
+  javascript:
+    - codeql/javascript-queries:AlertSuppression.ql


### PR DESCRIPTION
Closes #1325

## 改动

`.github/codeql/codeql-config.yml` 按语言追加官方查询包内的 `AlertSuppression.ql`（`py/alert-suppression` / `js/alert-suppression`，`@kind alert-suppression`）。此后行内 `# codeql[rule-id]` 抑制注释（独占一行、紧邻被抑制行上方）会写入 SARIF `suppressions[]`，对应 alert 自动进入 dismissed 状态，误报不再需要走 API dismiss + alert 编号同源核对。

## 核实记录（不凭印象）

- `codeql/python-queries` 与 `codeql/javascript-queries` 均自带 `AlertSuppression.ql`（github/codeql 仓库实查）
- `scope/pack:path` 单查询限定与按语言分组的 `packs` 写法出自 GitHub 官方 code scanning 配置文档；语言键 `javascript` 覆盖 JS/TS；默认查询套件不受 `packs` 影响照常运行
- 曾候选的 `advanced-security/${language}-alert-suppression` 在 GHCR 上不存在（404）；实际发布名 `advanced-security-demo/*` 是钉死旧依赖的 0.0.1 PoC 包，弃用，改用随引擎同步维护的官方包

## 验收

- 两个语言的 CodeQL analyze job 全绿、默认告警集无变化（看本 PR 的 CodeQL check）
- 行内抑制的实际生效验证留待下一次真实误报出现时进行（本 PR 不人为制造告警）

https://claude.ai/code/session_019Jg3TctYKu8RWm3zR1L4xU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化代码安全分析配置，增强对 Python、JavaScript 和 TypeScript 项目的扫描支持。
  * 改进安全告警抑制规则的处理，帮助减少误报并提升扫描结果的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->