### PR TITLE
refactor(onboarding): 演示工作台的只读禁用统一由组件直读判定

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -68,7 +68,7 @@ import type {
   UpdateAgentCredentialRequest,
 } from "@/types/agent-credential";
 import { getToken, clearToken } from "@/utils/auth";
-import { DEMO_PROJECT_NAME } from "@/onboarding/demo-project";
+import { isDemoProject } from "@/onboarding/demo-project";
 import i18n from "./i18n";
 
 // ==================== Helper types ====================
@@ -363,7 +363,7 @@ function isReadOnlyGateBlocking(endpoint: string): boolean {
   if (!apiReadOnly) return false;
   if (READ_ONLY_GATE_EXEMPT_ENDPOINTS.has(endpoint)) return false;
   const projectName = extractProjectName(endpoint);
-  return projectName === null || projectName === DEMO_PROJECT_NAME;
+  return projectName === null || isDemoProject(projectName);
 }
 
 function withAuth(endpoint: string, options: RequestInit = {}): RequestInit {

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -388,6 +388,31 @@ describe("StudioCanvasRouter", () => {
     expect(systemConfigSpy).not.toHaveBeenCalled();
   });
 
+  // 上一条的正向对照：没有它，门控写成无条件 return 或整个 effect 被删都照样全绿
+  it("still performs the provider/system-config lookups outside the demo workbench", async () => {
+    const providersSpy = vi.spyOn(API, "getProviders").mockResolvedValue({ providers: [] });
+    const customProvidersSpy = vi
+      .spyOn(API, "listCustomProviders")
+      .mockResolvedValue({ providers: [] });
+    const systemConfigSpy = vi
+      .spyOn(API, "getSystemConfig")
+      .mockResolvedValue({ settings: {} } as Awaited<ReturnType<typeof API.getSystemConfig>>);
+
+    useProjectsStore.setState({
+      currentProjectName: "demo",
+      currentProjectData: makeProjectData(),
+      currentScripts: { "episode_1.json": makeScript() },
+    });
+
+    renderAt("/episodes/1");
+
+    await waitFor(() => {
+      expect(providersSpy).toHaveBeenCalled();
+    });
+    expect(customProvidersSpy).toHaveBeenCalled();
+    expect(systemConfigSpy).toHaveBeenCalled();
+  });
+
   it("shows EpisodeSourceReview instead of TimelineCanvas when an episode has no script and no draft", () => {
     useProjectsStore.setState({
       currentProjectName: "demo",

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -516,6 +516,41 @@ describe("StudioCanvasRouter", () => {
     expect(providersSpy).not.toHaveBeenCalled();
   });
 
+  // 反方向：同一实例从演示项目切到真实项目时，store 的 currentProjectName 仍滞留上一轮的
+  // 演示项目名（StudioWorkspace 的 effect 还没写入新值）。demoMode 若仍以 store 值兜底会误判
+  // 为演示态，延迟真实项目的三个 GET；路由参数存在时须直接采信它。
+  it("performs the provider/system-config lookups immediately after navigating from the demo route to a real project, before the store catches up", async () => {
+    const providersSpy = vi.spyOn(API, "getProviders").mockResolvedValue({ providers: [] });
+    const customProvidersSpy = vi
+      .spyOn(API, "listCustomProviders")
+      .mockResolvedValue({ providers: [] });
+    const systemConfigSpy = vi
+      .spyOn(API, "getSystemConfig")
+      .mockResolvedValue({ settings: {} } as Awaited<ReturnType<typeof API.getSystemConfig>>);
+
+    useProjectsStore.setState({
+      currentProjectName: DEMO_PROJECT_NAME,
+      currentProjectData: makeProjectData(),
+      currentScripts: { "episode_1.json": makeScript() },
+    });
+
+    const view = renderAtProjectRoute(DEMO_PROJECT_NAME, "/episodes/1");
+    await waitFor(() => {
+      expect(screen.getByTestId("timeline-canvas")).toBeInTheDocument();
+    });
+    expect(providersSpy).not.toHaveBeenCalled();
+
+    // 原地切换到真实项目：只挪路由，store 的 currentProjectName 刻意留在演示项目名，
+    // 复刻 StudioWorkspace 的 effect 尚未执行完成的时间窗。
+    view.navigate("/real-project/episodes/1");
+
+    await waitFor(() => {
+      expect(providersSpy).toHaveBeenCalled();
+    });
+    expect(customProvidersSpy).toHaveBeenCalled();
+    expect(systemConfigSpy).toHaveBeenCalled();
+  });
+
   it("shows EpisodeSourceReview instead of TimelineCanvas when an episode has no script and no draft", () => {
     useProjectsStore.setState({
       currentProjectName: "demo",

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Router } from "wouter";
+import { Route, Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
@@ -318,6 +318,22 @@ function renderAt(path: string) {
   );
 }
 
+// 复刻真实入口的路由结构：父路由 `/:projectName` nest 出 `projectName` 参数，
+// 供 StudioCanvasRouter 在 store 的 currentProjectName 还没同步时兜底判定演示态。
+// 返回 `navigate` 以便测试原地切换路由——不卸载组件，复刻同一 StudioCanvasRouter 实例
+// 从真实项目切到演示项目时的时序（wouter 路由参数变化不会重新挂载组件）。
+function renderAtProjectRoute(projectName: string, subPath: string) {
+  const { hook, navigate } = memoryLocation({ path: `/${projectName}${subPath}` });
+  const view = render(
+    <Router hook={hook}>
+      <Route path="/:projectName" nest>
+        <StudioCanvasRouter />
+      </Route>
+    </Router>,
+  );
+  return { ...view, navigate };
+}
+
 describe("StudioCanvasRouter", () => {
   beforeEach(() => {
     useProjectsStore.setState(useProjectsStore.getInitialState(), true);
@@ -411,6 +427,93 @@ describe("StudioCanvasRouter", () => {
     });
     expect(customProvidersSpy).toHaveBeenCalled();
     expect(systemConfigSpy).toHaveBeenCalled();
+  });
+
+  // 复刻真实入口时序：StudioWorkspace 要到自己的 effect 才把演示项目名写入 store，
+  // 子组件的首轮渲染此时读到的 currentProjectName 仍是旧值/空值。只靠 store 判定
+  // 会在首轮放行三个真实 GET；路由参数在渲染期即可用，必须兜底覆盖这段时间差。
+  it("skips the provider/system-config lookups on first render before the store's currentProjectName catches up with the demo route", async () => {
+    const providersSpy = vi.spyOn(API, "getProviders");
+    const customProvidersSpy = vi.spyOn(API, "listCustomProviders");
+    const systemConfigSpy = vi.spyOn(API, "getSystemConfig");
+
+    useProjectsStore.setState({
+      currentProjectName: null,
+      currentProjectData: null,
+      currentScripts: {},
+    });
+
+    renderAtProjectRoute(DEMO_PROJECT_NAME, "/episodes/1");
+
+    await waitFor(() => {
+      expect(screen.getByText("加载中...")).toBeInTheDocument();
+    });
+    expect(providersSpy).not.toHaveBeenCalled();
+    expect(customProvidersSpy).not.toHaveBeenCalled();
+    expect(systemConfigSpy).not.toHaveBeenCalled();
+  });
+
+  // 同一 StudioCanvasRouter 实例从真实项目切到演示项目（路由 nest 下 projectName 参数
+  // 变化，组件不会重新挂载）时，上一个真实项目遗留的时长能力缓存必须清空，否则真实后端的
+  // 时长限制会继续套用到演示的虚构时长上，重新触发「不兼容」误报。
+  it("clears cached provider/backend duration capabilities when switching from a real project into the demo route", async () => {
+    const providersSpy = vi.spyOn(API, "getProviders").mockResolvedValue({
+      providers: [
+        {
+          id: "real-backend",
+          display_name: "Real",
+          description: "",
+          status: "ready",
+          media_types: ["video"],
+          capabilities: [],
+          configured_keys: [],
+          missing_keys: [],
+          models: {
+            "model-1": {
+              display_name: "Model 1",
+              media_type: "video",
+              capabilities: [],
+              default: true,
+              supported_durations: [5, 10],
+              duration_resolution_constraints: {},
+              resolutions: [],
+            },
+          },
+        },
+      ],
+    });
+    vi.spyOn(API, "listCustomProviders").mockResolvedValue({ providers: [] });
+    vi.spyOn(API, "getSystemConfig").mockResolvedValue({
+      settings: { default_video_backend: "real-backend/model-1" },
+    } as Awaited<ReturnType<typeof API.getSystemConfig>>);
+
+    useProjectsStore.setState({
+      currentProjectName: "real-project",
+      currentProjectData: makeProjectData(),
+      currentScripts: { "episode_1.json": makeScript() },
+    });
+
+    const view = renderAtProjectRoute("real-project", "/episodes/1");
+    await waitFor(() => {
+      expect(screen.getByTestId("timeline-duration-options")).toHaveTextContent("5,10");
+    });
+
+    providersSpy.mockClear();
+
+    // 原地切换到演示项目：不卸载组件，复刻同一实例从真实项目切入演示态的时序，
+    // 与 StudioWorkspace 的 effect 同步写入 store 一致。
+    useProjectsStore.setState({
+      currentProjectName: DEMO_PROJECT_NAME,
+      currentProjectData: makeProjectData(),
+      currentScripts: { "episode_1.json": makeScript() },
+    });
+    view.navigate(`/${DEMO_PROJECT_NAME}/episodes/1`);
+
+    await waitFor(() => {
+      // 缓存已清空：真实项目遗留的 providers/backend 不再参与时长兼容性比对
+      expect(screen.getByTestId("timeline-duration-options")).toHaveTextContent("");
+    });
+    expect(providersSpy).not.toHaveBeenCalled();
   });
 
   it("shows EpisodeSourceReview instead of TimelineCanvas when an episode has no script and no draft", () => {

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -8,6 +8,7 @@ import { useConfigStatusStore } from "@/stores/config-status-store";
 import { useProjectsStore } from "@/stores/projects-store";
 import { selectActiveResourceIds, selectHasActiveTaskForScriptFile, useTasksStore } from "@/stores/tasks-store";
 import { StudioCanvasRouter } from "@/components/canvas/StudioCanvasRouter";
+import { DEMO_PROJECT_NAME } from "@/onboarding/demo-project";
 import type { AdEpisodeScript, EpisodeScript, ProjectData } from "@/types";
 
 vi.mock("./OverviewCanvas", () => ({
@@ -364,6 +365,27 @@ describe("StudioCanvasRouter", () => {
     await waitFor(() => {
       expect(screen.queryByText("加载中...")).not.toBeInTheDocument();
     });
+  });
+
+  it("skips the provider/system-config lookups in the demo workbench", async () => {
+    const providersSpy = vi.spyOn(API, "getProviders");
+    const customProvidersSpy = vi.spyOn(API, "listCustomProviders");
+    const systemConfigSpy = vi.spyOn(API, "getSystemConfig");
+
+    useProjectsStore.setState({
+      currentProjectName: DEMO_PROJECT_NAME,
+      currentProjectData: makeProjectData(),
+      currentScripts: { "episode_1.json": makeScript() },
+    });
+
+    renderAt("/episodes/1");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("timeline-canvas")).toBeInTheDocument();
+    });
+    expect(providersSpy).not.toHaveBeenCalled();
+    expect(customProvidersSpy).not.toHaveBeenCalled();
+    expect(systemConfigSpy).not.toHaveBeenCalled();
   });
 
   it("shows EpisodeSourceReview instead of TimelineCanvas when an episode has no script and no draft", () => {

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -551,6 +551,41 @@ describe("StudioCanvasRouter", () => {
     expect(systemConfigSpy).toHaveBeenCalled();
   });
 
+  // demo→真实项目切换后路由已让 demoMode 变为 false，但 store 的 currentProjectName 还滞留
+  // 演示项目名；只看 demoMode 会对着后端不存在的演示项目发一次必然失败的 /video-capabilities。
+  it("skips the video-capabilities lookup for the stale demo project name after navigating to a real project, before the store catches up", async () => {
+    const capabilitiesSpy = vi
+      .spyOn(API, "getVideoCapabilities")
+      .mockResolvedValue({ supported_durations: [5, 10] } as Awaited<
+        ReturnType<typeof API.getVideoCapabilities>
+      >);
+    vi.spyOn(API, "getProviders").mockResolvedValue({ providers: [] });
+    vi.spyOn(API, "listCustomProviders").mockResolvedValue({ providers: [] });
+    vi.spyOn(API, "getSystemConfig").mockResolvedValue({
+      settings: {},
+    } as Awaited<ReturnType<typeof API.getSystemConfig>>);
+
+    useProjectsStore.setState({
+      currentProjectName: DEMO_PROJECT_NAME,
+      currentProjectData: makeProjectData(),
+      currentScripts: { "episode_1.json": makeScript() },
+    });
+
+    const view = renderAtProjectRoute(DEMO_PROJECT_NAME, "/episodes/1");
+    await waitFor(() => {
+      expect(screen.getByTestId("timeline-canvas")).toBeInTheDocument();
+    });
+
+    // 原地切换到真实项目：只挪路由，store 的 currentProjectName 刻意留在演示项目名，
+    // 复刻 StudioWorkspace 的 effect 尚未执行完成的时间窗。
+    view.navigate("/real-project/episodes/1");
+
+    await waitFor(() => {
+      expect(API.getProviders).toHaveBeenCalled();
+    });
+    expect(capabilitiesSpy).not.toHaveBeenCalledWith(DEMO_PROJECT_NAME);
+  });
+
   it("shows EpisodeSourceReview instead of TimelineCanvas when an episode has no script and no draft", () => {
     useProjectsStore.setState({
       currentProjectName: "demo",

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { errMsg, voidPromise } from "@/utils/async";
-import { Route, Switch, Redirect } from "wouter";
+import { Route, Switch, Redirect, useParams } from "wouter";
 import {
   WORKSPACE_ROUTE_LOREBOOK,
   WORKSPACE_ROUTE_CLUES,
@@ -14,6 +14,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useDemoWorkbench } from "@/onboarding/use-demo-workbench";
+import { isDemoProject } from "@/onboarding/demo-project";
 import { DemoEpisodePlaceholder } from "@/onboarding/DemoEpisodePlaceholder";
 import { useAppStore } from "@/stores/app-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
@@ -90,7 +91,11 @@ export function StudioCanvasRouter() {
   const { currentProjectData, currentProjectName, currentScripts } =
     useProjectsStore();
   // 演示态：资产画布仍走 readOnly 透传，工作台时间线的只读则由组件自己直读同一判定
-  const demoMode = useDemoWorkbench();
+  // store 的 currentProjectName 由父组件 StudioWorkspace 在 effect 里异步写入，首轮渲染时
+  // （直接打开演示路由或刚从大厅进入）store 还没同步，仅靠它会在首轮判定为非演示态并放行三个
+  // 真实 GET；路由参数在渲染期即可用，兜底覆盖这段首轮时间差。
+  const routeParams = useParams<{ projectName?: string }>();
+  const demoMode = useDemoWorkbench() || isDemoProject(routeParams.projectName);
 
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [customProviders, setCustomProviders] = useState<CustomProviderInfo[]>([]);
@@ -119,10 +124,14 @@ export function StudioCanvasRouter() {
   // /video-capabilities，让 ConfigResolver 自动 fallback 到 PROVIDER_REGISTRY
   // 第一个 ready 的 default video model（与生成路径用同一套规则，避免 FE/BE 漂移）。
   const localDurationOptions = useMemo(() => {
+    // 演示态即便 state 里还留着上一个真实项目的 providers/backend（同一组件实例原地切入
+    // 演示路由，effect 提前 return 不会清掉旧值），也不参与比对——否则真实后端的时长限制
+    // 会继续套用到演示的虚构时长上，重新触发「不兼容」误报。
+    if (demoMode) return undefined;
     const backend = currentProjectData?.video_backend || globalVideoBackend;
     if (!backend) return undefined;
     return lookupSupportedDurations(providers, backend, customProviders);
-  }, [providers, customProviders, globalVideoBackend, currentProjectData?.video_backend]);
+  }, [demoMode, providers, customProviders, globalVideoBackend, currentProjectData?.video_backend]);
 
   useEffect(() => {
     // 依赖变化时清理旧的 resolved 选项；本地 lookup 有结果或缺项目名时同步清零，

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { errMsg, voidPromise } from "@/utils/async";
-import { Route, Switch, Redirect, useParams } from "wouter";
+import { Route, Switch, Redirect } from "wouter";
 import {
   WORKSPACE_ROUTE_LOREBOOK,
   WORKSPACE_ROUTE_CLUES,
@@ -90,15 +90,9 @@ export function StudioCanvasRouter() {
   tRef.current = t;
   const { currentProjectData, currentProjectName, currentScripts } =
     useProjectsStore();
-  // 演示态：资产画布仍走 readOnly 透传，工作台时间线的只读则由组件自己直读同一判定
-  // store 的 currentProjectName 由父组件 StudioWorkspace 在 effect 里异步写入，路由参数切换
-  // （含大厅进入演示路由、演示态与真实项目间切换，:projectName 变化不remount组件）后的首轮渲染
-  // store 都还没同步；路由参数在渲染期即可用，路由参数存在时以它为准，避免双向的一轮判定滞后。
-  const routeParams = useParams<{ projectName?: string }>();
-  const storeDemoMode = useDemoWorkbench();
-  const demoMode = routeParams.projectName
-    ? isDemoProject(routeParams.projectName)
-    : storeDemoMode;
+  // 演示态：资产画布仍走 readOnly 透传，工作台时间线的只读则由组件自己直读同一判定。
+  // useDemoWorkbench() 已把路由参数与 store 的判定滞后收口在单一来源，此处直接消费。
+  const demoMode = useDemoWorkbench();
 
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [customProviders, setCustomProviders] = useState<CustomProviderInfo[]>([]);

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -162,7 +162,10 @@ export function StudioCanvasRouter() {
     };
   }, [currentProjectName, localDurationOptions, demoMode]);
 
-  const durationOptions = localDurationOptions ?? resolvedDurationOptions;
+  // demoMode 翻转的同一渲染帧内 localDurationOptions 已同步归零，但 resolvedDurationOptions
+  // 是异步 effect 才清空的旧 state，真实项目切入演示路由的这一帧仍可能读到上一个项目的时长
+  // 能力；显式屏蔽 fallback，避免虚构时长被套用真实后端限制而误报「不兼容」。
+  const durationOptions = demoMode ? undefined : localDurationOptions ?? resolvedDurationOptions;
 
   // 从任务队列派生 loading 状态（替代本地 state）：活跃 + 最新行胜出两条不变量下沉到 store selector
   const generatingCharacterNames = useActiveResourceIds("character", currentProjectName);

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -172,8 +172,12 @@ export function StudioCanvasRouter() {
 
   // demoMode 翻转的同一渲染帧内 localDurationOptions 已同步归零，但 resolvedDurationOptions
   // 是异步 effect 才清空的旧 state，真实项目切入演示路由的这一帧仍可能读到上一个项目的时长
-  // 能力；显式屏蔽 fallback，避免虚构时长被套用真实后端限制而误报「不兼容」。
-  const durationOptions = demoMode ? undefined : localDurationOptions ?? resolvedDurationOptions;
+  // 能力；显式屏蔽 fallback，避免虚构时长被套用真实后端限制而误报「不兼容」。demoMode 演示→
+  // 真实切换时先于 store 变为 false，currentProjectName 单独判一次兜住同一滞后窗口。
+  const durationOptions =
+    demoMode || isDemoProject(currentProjectName)
+      ? undefined
+      : localDurationOptions ?? resolvedDurationOptions;
 
   // 从任务队列派生 loading 状态（替代本地 state）：活跃 + 最新行胜出两条不变量下沉到 store selector
   const generatingCharacterNames = useActiveResourceIds("character", currentProjectName);

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -123,12 +123,20 @@ export function StudioCanvasRouter() {
   const localDurationOptions = useMemo(() => {
     // 演示态即便 state 里还留着上一个真实项目的 providers/backend（同一组件实例原地切入
     // 演示路由，effect 提前 return 不会清掉旧值），也不参与比对——否则真实后端的时长限制
-    // 会继续套用到演示的虚构时长上，重新触发「不兼容」误报。
-    if (demoMode) return undefined;
+    // 会继续套用到演示的虚构时长上，重新触发「不兼容」误报。demoMode 演示→真实切换时先于
+    // store 变为 false，currentProjectName 单独判一次兜住这一帧仍读到旧演示项目名的窗口。
+    if (demoMode || isDemoProject(currentProjectName)) return undefined;
     const backend = currentProjectData?.video_backend || globalVideoBackend;
     if (!backend) return undefined;
     return lookupSupportedDurations(providers, backend, customProviders);
-  }, [demoMode, providers, customProviders, globalVideoBackend, currentProjectData?.video_backend]);
+  }, [
+    demoMode,
+    currentProjectName,
+    providers,
+    customProviders,
+    globalVideoBackend,
+    currentProjectData?.video_backend,
+  ]);
 
   useEffect(() => {
     // 依赖变化时清理旧的 resolved 选项；本地 lookup 有结果或缺项目名时同步清零，

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -144,8 +144,11 @@ export function StudioCanvasRouter() {
       setResolvedDurationOptions(undefined);
       return;
     }
-    // 演示项目查不到 /video-capabilities（后端无此项目），时长选项留空即可
-    if (!currentProjectName || demoMode) {
+    // 演示项目查不到 /video-capabilities（后端无此项目），时长选项留空即可。
+    // currentProjectName 单独判一次：demo→真实项目切换后路由已使 demoMode 为 false，
+    // 但 store 的 currentProjectName 还没同步完成时仍是演示项目名，只看 demoMode 会
+    // 对着不存在的演示项目发一次必然失败的请求。
+    if (!currentProjectName || demoMode || isDemoProject(currentProjectName)) {
       setResolvedDurationOptions(undefined);
       return;
     }

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -91,11 +91,14 @@ export function StudioCanvasRouter() {
   const { currentProjectData, currentProjectName, currentScripts } =
     useProjectsStore();
   // 演示态：资产画布仍走 readOnly 透传，工作台时间线的只读则由组件自己直读同一判定
-  // store 的 currentProjectName 由父组件 StudioWorkspace 在 effect 里异步写入，首轮渲染时
-  // （直接打开演示路由或刚从大厅进入）store 还没同步，仅靠它会在首轮判定为非演示态并放行三个
-  // 真实 GET；路由参数在渲染期即可用，兜底覆盖这段首轮时间差。
+  // store 的 currentProjectName 由父组件 StudioWorkspace 在 effect 里异步写入，路由参数切换
+  // （含大厅进入演示路由、演示态与真实项目间切换，:projectName 变化不remount组件）后的首轮渲染
+  // store 都还没同步；路由参数在渲染期即可用，路由参数存在时以它为准，避免双向的一轮判定滞后。
   const routeParams = useParams<{ projectName?: string }>();
-  const demoMode = useDemoWorkbench() || isDemoProject(routeParams.projectName);
+  const storeDemoMode = useDemoWorkbench();
+  const demoMode = routeParams.projectName
+    ? isDemoProject(routeParams.projectName)
+    : storeDemoMode;
 
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [customProviders, setCustomProviders] = useState<CustomProviderInfo[]>([]);

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -100,6 +100,8 @@ export function StudioCanvasRouter() {
   >(undefined);
 
   useEffect(() => {
+    // 这三份数据只服务视频时长选项；演示态时长选择器是静态展示，取回来也用不上
+    if (demoMode) return;
     let disposed = false;
     Promise.all([getProviderModels(), getCustomProviderModels(), API.getSystemConfig()]).then(
       ([provList, customList, configRes]) => {
@@ -110,7 +112,7 @@ export function StudioCanvasRouter() {
       },
     ).catch(() => {});
     return () => { disposed = true; };
-  }, []);
+  }, [demoMode]);
 
   // 已配置 backend 时本地 lookup 即可（同步、零延迟）；未配置时调后端
   // /video-capabilities，让 ConfigResolver 自动 fallback 到 PROVIDER_REGISTRY
@@ -700,32 +702,24 @@ export function StudioCanvasRouter() {
                     projectName={currentProjectName}
                     episode={epNum}
                     episodeTitle={episode?.title}
-                    onSaveTitle={
-                      demoMode ? undefined : (title) => handleUpdateEpisodeTitle(epNum, title)
-                    }
-                    canEditTitle={Boolean(episode?.script_file) && !demoMode}
+                    // 演示态的只读由 TimelineCanvas 直读判定收口，这里只表达非演示态的固有约束
+                    onSaveTitle={(title) => handleUpdateEpisodeTitle(epNum, title)}
+                    canEditTitle={Boolean(episode?.script_file)}
                     hasDraft={hasDraft}
                     episodeScript={script}
-                    // 演示态不给 scriptFile：分镜卡的上传入口以它为开关，缺省即整块不渲染
-                    scriptFile={demoMode ? undefined : (scriptFile ?? undefined)}
+                    scriptFile={scriptFile ?? undefined}
                     projectData={currentProjectData}
                     durationOptions={effectiveDurationOptions}
-                    onUpdatePrompt={demoMode ? undefined : handleUpdatePrompt}
-                    onMoveShot={isAd && !demoMode ? handleMoveShot : undefined}
+                    onUpdatePrompt={handleUpdatePrompt}
+                    onMoveShot={isAd ? handleMoveShot : undefined}
                     onGenerateStoryboard={
-                      adReference || demoMode ? undefined : voidPromise(handleGenerateStoryboard)
+                      adReference ? undefined : voidPromise(handleGenerateStoryboard)
                     }
-                    onGenerateVideo={
-                      adReference || demoMode ? undefined : voidPromise(handleGenerateVideo)
-                    }
-                    onGenerateNarration={
-                      demoMode ? undefined : voidPromise(handleGenerateNarration)
-                    }
-                    onGenerateEpisodeNarration={
-                      demoMode ? undefined : voidPromise(handleGenerateEpisodeNarration)
-                    }
-                    onRestoreStoryboard={demoMode ? undefined : handleRestoreAsset}
-                    onRestoreVideo={demoMode ? undefined : handleRestoreAsset}
+                    onGenerateVideo={adReference ? undefined : voidPromise(handleGenerateVideo)}
+                    onGenerateNarration={voidPromise(handleGenerateNarration)}
+                    onGenerateEpisodeNarration={voidPromise(handleGenerateEpisodeNarration)}
+                    onRestoreStoryboard={handleRestoreAsset}
+                    onRestoreVideo={handleRestoreAsset}
                   />
                 )}
               </div>

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -89,7 +89,7 @@ export function StudioCanvasRouter() {
   tRef.current = t;
   const { currentProjectData, currentProjectName, currentScripts } =
     useProjectsStore();
-  // 演示态：不传写回调，编辑 / 生成 / 上传 / 版本恢复的入口按既有惯例整块不渲染
+  // 演示态：资产画布仍走 readOnly 透传，工作台时间线的只读则由组件自己直读同一判定
   const demoMode = useDemoWorkbench();
 
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
@@ -100,7 +100,8 @@ export function StudioCanvasRouter() {
   >(undefined);
 
   useEffect(() => {
-    // 这三份数据只服务视频时长选项；演示态时长选择器是静态展示，取回来也用不上
+    // 这三份数据只服务视频时长选项。演示态的时长是虚构的静态展示，唯一还会用到选项的
+    // 是「时长与后端不兼容」的橙色标记——对虚构数据那是伪告警，不值得为它发三个全局请求。
     if (demoMode) return;
     let disposed = false;
     Promise.all([getProviderModels(), getCustomProviderModels(), API.getSystemConfig()]).then(

--- a/frontend/src/components/canvas/timeline/MediaCard.test.tsx
+++ b/frontend/src/components/canvas/timeline/MediaCard.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEMO_PROJECT_NAME } from "@/onboarding/demo-project";
+import { useProjectsStore } from "@/stores/projects-store";
 import { MediaCard } from "./MediaCard";
 
 function renderCard(props: Partial<Parameters<typeof MediaCard>[0]> = {}) {
@@ -63,5 +65,44 @@ describe("MediaCard upload", () => {
   it("disables the generate CTA when a sibling upload is in flight (uploadDisabled)", () => {
     const { getByRole } = renderCard({ onGenerate: vi.fn(), uploadDisabled: true });
     expect(getByRole("button", { name: /生成分镜/ })).toBeDisabled();
+  });
+});
+
+describe("MediaCard in the demo workbench", () => {
+  afterEach(() => {
+    useProjectsStore.setState(useProjectsStore.getInitialState(), true);
+  });
+
+  // 四个入口的回调/开关全部给足：只有演示态判定本身能把它们关掉
+  function renderCardWithAllEntries() {
+    return renderCard({
+      assetPath: "storyboards/E1S01_v1.png",
+      onUpload: vi.fn(),
+      onRestore: vi.fn(),
+      onGenerate: vi.fn(),
+      editScriptFile: "episode_1.json",
+    });
+  }
+
+  it("hides the write entries and the version entry from the same judgement", () => {
+    useProjectsStore.setState({ currentProjectName: DEMO_PROJECT_NAME });
+
+    const { container, queryByRole } = renderCardWithAllEntries();
+
+    expect(container.querySelector('input[type="file"]')).toBeNull();
+    expect(queryByRole("button", { name: /版本/ })).toBeNull();
+    expect(queryByRole("button", { name: /编辑/ })).toBeNull();
+    expect(queryByRole("button", { name: /重新生成分镜/ })).toBeNull();
+  });
+
+  it("keeps all four entries outside the demo workbench", () => {
+    useProjectsStore.setState({ currentProjectName: "demo" });
+
+    const { container, getByRole } = renderCardWithAllEntries();
+
+    expect(container.querySelector('input[type="file"]')).not.toBeNull();
+    expect(getByRole("button", { name: /版本/ })).toBeInTheDocument();
+    expect(getByRole("button", { name: /编辑/ })).toBeInTheDocument();
+    expect(getByRole("button", { name: /重新生成分镜/ })).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/canvas/timeline/MediaCard.tsx
+++ b/frontend/src/components/canvas/timeline/MediaCard.tsx
@@ -10,6 +10,7 @@ import {
   UPLOAD_VIDEO_ACCEPT,
   UploadIconButton,
 } from "@/components/ui/UploadIconButton";
+import { useDemoWorkbench } from "@/onboarding/use-demo-workbench";
 import { formatCost } from "@/utils/cost-format";
 import type { CostBreakdown } from "@/types";
 import { ImageEditButton } from "./ImageEditButton";
@@ -76,6 +77,9 @@ export function MediaCard({
   editScriptFile,
 }: MediaCardProps) {
   const { t } = useTranslation("dashboard");
+  // 演示态只读：卡片上的四个写入口（上传 / 编辑 / 版本恢复 / 生成）从同一处判定关闭，
+  // 不再各自靠「对应回调是否传入」推断——那让版本入口与其余入口分属两套机制。
+  const demoReadOnly = useDemoWorkbench();
 
   const assetFp = useProjectsStore((s) =>
     assetPath ? s.getAssetFingerprint(assetPath) : null,
@@ -117,7 +121,7 @@ export function MediaCard({
           {title}
         </span>
         <span className="flex-1" />
-        {onUpload && (
+        {onUpload && !demoReadOnly && (
           <UploadIconButton
             accept={UPLOAD_ACCEPT[kind]}
             label={
@@ -130,7 +134,7 @@ export function MediaCard({
             onSelect={(f) => void onUpload(f)}
           />
         )}
-        {kind === "storyboard" && editScriptFile && (
+        {kind === "storyboard" && editScriptFile && !demoReadOnly && (
           <ImageEditButton
             projectName={projectName}
             resourceType="storyboard"
@@ -140,7 +144,7 @@ export function MediaCard({
             busy={resourceBusy}
           />
         )}
-        {onRestore && (
+        {onRestore && !demoReadOnly && (
           <VersionTimeMachine
             projectName={projectName}
             resourceType={resourceType}
@@ -205,7 +209,7 @@ export function MediaCard({
       )}
 
       {/* Generate CTA */}
-      {!hideGenerateButton && onGenerate && (
+      {!hideGenerateButton && onGenerate && !demoReadOnly && (
         <button
           type="button"
           onClick={onGenerate}

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.test.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { API } from "@/api";
+import { DEMO_PROJECT_NAME } from "@/onboarding/demo-project";
 import { useCostStore } from "@/stores/cost-store";
+import { useProjectsStore } from "@/stores/projects-store";
 import { useTasksStore } from "@/stores/tasks-store";
 import { TimelineCanvas } from "./TimelineCanvas";
 import type { NarrationEpisodeScript, ProjectData } from "@/types";
@@ -10,10 +12,24 @@ vi.mock("./ScriptReviewGate", () => ({
   ScriptReviewGate: () => <div data-testid="script-review-gate" />,
 }));
 vi.mock("./ShotSplitView", () => ({
-  ShotSplitView: () => <div data-testid="shot-split-view" />,
+  ShotSplitView: ({
+    onUpdatePrompt,
+    onGenerateNarration,
+  }: {
+    onUpdatePrompt?: unknown;
+    onGenerateNarration?: unknown;
+  }) => (
+    <div
+      data-testid="shot-split-view"
+      data-can-update-prompt={onUpdatePrompt ? "yes" : "no"}
+      data-can-generate-narration={onGenerateNarration ? "yes" : "no"}
+    />
+  ),
 }));
 vi.mock("./EpisodeHeader", () => ({
-  EpisodeHeader: () => <div data-testid="episode-header" />,
+  EpisodeHeader: ({ canEditTitle }: { canEditTitle?: boolean }) => (
+    <div data-testid="episode-header" data-can-edit-title={canEditTitle ? "yes" : "no"} />
+  ),
 }));
 vi.mock("./AdReferenceUnitsPanel", () => ({
   AdReferenceUnitsPanel: () => <div data-testid="ad-reference-units-panel" />,
@@ -119,5 +135,55 @@ describe("TimelineCanvas", () => {
     );
 
     expect(screen.getByText("请在左侧选择剧集")).toBeInTheDocument();
+  });
+
+  describe("in the demo workbench", () => {
+    afterEach(() => {
+      useProjectsStore.setState(useProjectsStore.getInitialState(), true);
+    });
+
+    // 写回调一律给足：只有演示态判定本身能把它们作废
+    function renderWithAllWriteHandlers() {
+      return render(
+        <TimelineCanvas
+          projectName={DEMO_PROJECT_NAME}
+          episode={1}
+          hasDraft
+          episodeScript={makeScript()}
+          scriptFile="scripts/episode_1.json"
+          projectData={makeProjectData()}
+          onUpdatePrompt={vi.fn()}
+          onMoveShot={vi.fn()}
+          onGenerateNarration={vi.fn()}
+          onGenerateEpisodeNarration={vi.fn()}
+          onSaveTitle={vi.fn()}
+          canEditTitle
+        />,
+      );
+    }
+
+    it("passes no write handlers down and drops the batch narration entry", () => {
+      useProjectsStore.setState({ currentProjectName: DEMO_PROJECT_NAME });
+
+      renderWithAllWriteHandlers();
+
+      const shotView = screen.getByTestId("shot-split-view");
+      expect(shotView).toHaveAttribute("data-can-update-prompt", "no");
+      expect(shotView).toHaveAttribute("data-can-generate-narration", "no");
+      expect(screen.getByTestId("episode-header")).toHaveAttribute("data-can-edit-title", "no");
+      expect(screen.queryByRole("button", { name: /生成全集旁白/ })).toBeNull();
+    });
+
+    it("keeps the same write handlers outside the demo workbench", () => {
+      useProjectsStore.setState({ currentProjectName: "demo" });
+
+      renderWithAllWriteHandlers();
+
+      const shotView = screen.getByTestId("shot-split-view");
+      expect(shotView).toHaveAttribute("data-can-update-prompt", "yes");
+      expect(shotView).toHaveAttribute("data-can-generate-narration", "yes");
+      expect(screen.getByTestId("episode-header")).toHaveAttribute("data-can-edit-title", "yes");
+      expect(screen.getByRole("button", { name: /生成全集旁白/ })).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -10,6 +10,7 @@ import { useActiveResourceIds } from "@/stores/tasks-store";
 import { effectiveMode } from "@/utils/generation-mode";
 import { getScriptItemId } from "@/utils/script-shape";
 import { ONBOARDING_ANCHORS } from "@/onboarding/anchors";
+import { useDemoWorkbench } from "@/onboarding/use-demo-workbench";
 import type {
   EpisodeScript,
   NarrationEpisodeScript,
@@ -50,26 +51,43 @@ interface TimelineCanvasProps {
   canEditTitle?: boolean;
 }
 
-export function TimelineCanvas({
-  projectName,
-  episode,
-  episodeTitle,
-  hasDraft,
-  episodeScript,
-  scriptFile,
-  projectData,
-  durationOptions,
-  onUpdatePrompt,
-  onMoveShot,
-  onGenerateStoryboard,
-  onGenerateVideo,
-  onGenerateNarration,
-  onGenerateEpisodeNarration,
-  onRestoreStoryboard,
-  onRestoreVideo,
-  onSaveTitle,
-  canEditTitle,
-}: TimelineCanvasProps) {
+/**
+ * 演示态作废的入参。分镜卡自身的写入口（生成 / 上传 / 编辑 / 版本恢复）由 `MediaCard`
+ * 直读同一判定关闭，这里只列本画布额外承载的写能力，两处不重复兜同一个入口。
+ */
+const DEMO_READ_ONLY_PROPS = {
+  onUpdatePrompt: undefined,
+  onMoveShot: undefined,
+  onGenerateNarration: undefined,
+  onGenerateEpisodeNarration: undefined,
+  onSaveTitle: undefined,
+  canEditTitle: false,
+} as const satisfies Partial<TimelineCanvasProps>;
+
+export function TimelineCanvas(props: TimelineCanvasProps) {
+  // 演示态只读判定直读单一来源，不经父级逐个回调透传——漏接一个回调就是漏一个写入口
+  const demoReadOnly = useDemoWorkbench();
+  const {
+    projectName,
+    episode,
+    episodeTitle,
+    hasDraft,
+    episodeScript,
+    scriptFile,
+    projectData,
+    durationOptions,
+    onUpdatePrompt,
+    onMoveShot,
+    onGenerateStoryboard,
+    onGenerateVideo,
+    onGenerateNarration,
+    onGenerateEpisodeNarration,
+    onRestoreStoryboard,
+    onRestoreVideo,
+    onSaveTitle,
+    canEditTitle,
+  } = demoReadOnly ? { ...props, ...DEMO_READ_ONLY_PROPS } : props;
+
   const { t } = useTranslation("dashboard");
   const contentMode = projectData?.content_mode ?? "narration";
   // 分镜编辑子视图按剧本形状显式分派：narration（segments）/ drama（scenes）/ ad（shots）。

--- a/frontend/src/components/layout/AssetSidebar.tsx
+++ b/frontend/src/components/layout/AssetSidebar.tsx
@@ -19,6 +19,7 @@ import { useCostStore } from "@/stores/cost-store";
 import { useAppStore } from "@/stores/app-store";
 import { API } from "@/api";
 import { useDemoWorkbench } from "@/onboarding/use-demo-workbench";
+import { isDemoProject } from "@/onboarding/demo-project";
 import { EpisodeCard } from "./EpisodeCard";
 
 interface AssetSidebarProps {
@@ -66,7 +67,9 @@ export function AssetSidebar({ className }: AssetSidebarProps) {
   }, [currentProjectName, debouncedFetchCost]);
 
   useEffect(() => {
-    if (!currentProjectName || demoMode) return;
+    // demoMode 演示→真实切换时先于 store 变为 false，currentProjectName 单独判一次
+    // 兜住这一帧仍读到旧演示项目名的窗口，避免对不存在的演示项目发一次必然失败的请求。
+    if (!currentProjectName || demoMode || isDemoProject(currentProjectName)) return;
     let cancelled = false;
     API.listFiles(currentProjectName)
       .then((res) => {

--- a/frontend/src/components/layout/GlobalHeader.tsx
+++ b/frontend/src/components/layout/GlobalHeader.tsx
@@ -7,6 +7,7 @@ import { useAppStore } from "@/stores/app-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useDemoWorkbench } from "@/onboarding/use-demo-workbench";
+import { isDemoProject } from "@/onboarding/demo-project";
 import { useTasksStore } from "@/stores/tasks-store";
 import { useUsageStore, type UsageStats } from "@/stores/usage-store";
 import { TaskHud } from "@/components/task-hud/TaskHud";
@@ -69,9 +70,11 @@ export function GlobalHeader({ onNavigateBack }: GlobalHeaderProps) {
   const runningCount = stats.running + stats.queued;
   const unreadNotificationCount = workspaceNotifications.filter((item) => !item.read).length;
 
-  // 演示项目在后端没有用量记录，按项目查会 404；退回全局用量，顶栏费用仍有值可显示
+  // 演示项目在后端没有用量记录，按项目查会 404；退回全局用量，顶栏费用仍有值可显示。
+  // demoMode 演示→真实切换时先于 store 变为 false，currentProjectName 单独判一次
+  // 兜住这一帧仍读到旧演示项目名的窗口，避免按不存在的演示项目查用量而 404。
   const demoMode = useDemoWorkbench();
-  const usageProjectName = demoMode ? null : currentProjectName;
+  const usageProjectName = demoMode || isDemoProject(currentProjectName) ? null : currentProjectName;
 
   // 导出弹窗打开期间切到演示项目（如浏览器前进/后退复用同一路由实例）时随即关闭——
   // 触发按钮虽已按 demoMode 禁用，但已打开的弹窗不受影响，仍会展示可点击的导出/剪映草稿操作

--- a/frontend/src/components/layout/StudioLayout.tsx
+++ b/frontend/src/components/layout/StudioLayout.tsx
@@ -63,8 +63,11 @@ export function StudioLayout({ children }: StudioLayoutProps) {
 
   // demoMode 演示→真实切换时先于 store 变为 false，currentProjectName 单独判一次
   // 兜住这一帧仍读到旧演示项目名的窗口，避免对不存在的演示项目建一次必然失败的 SSE 连接。
-  const sseProjectName = demoMode || isDemoProject(currentProjectName) ? null : currentProjectName;
-  useTasksSSE(sseProjectName, !demoMode);
+  // useTasksSSE 的 projectName=null 语义是「不按项目过滤」而非「停用」，enabled 必须
+  // 同步这一判定，否则该帧会退化成对全局任务的轮询而非真正停用。
+  const isEffectivelyDemo = demoMode || isDemoProject(currentProjectName);
+  const sseProjectName = isEffectivelyDemo ? null : currentProjectName;
+  useTasksSSE(sseProjectName, !isEffectivelyDemo);
   useProjectEventsSSE(sseProjectName);
 
   const restoreBodyStyle = useCallback(() => {

--- a/frontend/src/components/layout/StudioLayout.tsx
+++ b/frontend/src/components/layout/StudioLayout.tsx
@@ -13,6 +13,7 @@ import { ScriptGenerationNoticeListener } from "./ScriptGenerationNoticeListener
 import { useProjectsStore } from "@/stores/projects-store";
 import { DemoReadOnlyBanner } from "@/onboarding/DemoReadOnlyBanner";
 import { useDemoWorkbench } from "@/onboarding/use-demo-workbench";
+import { isDemoProject } from "@/onboarding/demo-project";
 import {
   ASSISTANT_PANEL_DEFAULT_WIDTH,
   clampAssistantPanelWidth,
@@ -60,7 +61,9 @@ export function StudioLayout({ children }: StudioLayoutProps) {
     setDraftWidth(next);
   }, []);
 
-  const sseProjectName = demoMode ? null : currentProjectName;
+  // demoMode 演示→真实切换时先于 store 变为 false，currentProjectName 单独判一次
+  // 兜住这一帧仍读到旧演示项目名的窗口，避免对不存在的演示项目建一次必然失败的 SSE 连接。
+  const sseProjectName = demoMode || isDemoProject(currentProjectName) ? null : currentProjectName;
   useTasksSSE(sseProjectName, !demoMode);
   useProjectEventsSSE(sseProjectName);
 

--- a/frontend/src/onboarding/read-only-mode.test.ts
+++ b/frontend/src/onboarding/read-only-mode.test.ts
@@ -67,6 +67,18 @@ describe("read-only demo mode", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("blocks the demo project under any casing, matching isDemoProject", async () => {
+    // 闸门与 isDemoProject 必须同一口径：后者大小写不敏感，闸门若做精确比较，
+    // 大小写不同的演示项目名就会被判成「另一个真实项目」而放行写请求
+    await expect(
+      API.request(`/projects/${DEMO_PROJECT_NAME.toUpperCase()}/characters/hero`, {
+        method: "PATCH",
+        body: "{}",
+      }),
+    ).rejects.toThrow(ReadOnlyModeError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("does not treat a project literally named 'import' as project-less", async () => {
     // ProjectManager.normalize_project_name 允许 "import" 作为合法项目名，归档导入
     // 也会直接采用该名——只有精确的 /projects/import 静态归档端点本身该被排除，

--- a/frontend/src/onboarding/use-demo-workbench.test.tsx
+++ b/frontend/src/onboarding/use-demo-workbench.test.tsx
@@ -25,7 +25,7 @@ describe("useDemoWorkbench", () => {
     useProjectsStore.setState(useProjectsStore.getInitialState(), true);
   });
 
-  it("stays read-only immediately after navigating from the demo route to a real project, before the store catches up", () => {
+  it("switches out of demo mode immediately after navigating from the demo route to a real project, before the store catches up", () => {
     useProjectsStore.setState({ currentProjectName: DEMO_PROJECT_NAME });
     const { result, navigate } = renderAtProjectRoute(DEMO_PROJECT_NAME);
     expect(result.current).toBe(true);

--- a/frontend/src/onboarding/use-demo-workbench.test.tsx
+++ b/frontend/src/onboarding/use-demo-workbench.test.tsx
@@ -1,0 +1,56 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { Route, Router } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
+import { useProjectsStore } from "@/stores/projects-store";
+import { DEMO_PROJECT_NAME } from "./demo-project";
+import { useDemoWorkbench } from "./use-demo-workbench";
+
+function renderAtProjectRoute(projectName: string) {
+  const { hook, navigate } = memoryLocation({ path: `/${projectName}/episodes/1` });
+  const view = renderHook(() => useDemoWorkbench(), {
+    wrapper: ({ children }) => (
+      <Router hook={hook}>
+        <Route path="/:projectName" nest>
+          {children}
+        </Route>
+      </Router>
+    ),
+  });
+  return { ...view, navigate };
+}
+
+describe("useDemoWorkbench", () => {
+  beforeEach(() => {
+    useProjectsStore.setState(useProjectsStore.getInitialState(), true);
+  });
+
+  it("stays read-only immediately after navigating from the demo route to a real project, before the store catches up", () => {
+    useProjectsStore.setState({ currentProjectName: DEMO_PROJECT_NAME });
+    const { result, navigate } = renderAtProjectRoute(DEMO_PROJECT_NAME);
+    expect(result.current).toBe(true);
+
+    act(() => navigate("/real-project/episodes/1"));
+    // currentProjectName 仍是 store 里的 DEMO_PROJECT_NAME，模拟 StudioWorkspace 的 effect 还没追上路由。
+    expect(result.current).toBe(false);
+  });
+
+  it("goes read-only immediately after navigating from a real project to the demo route, before the store catches up", () => {
+    useProjectsStore.setState({ currentProjectName: "real-project" });
+    const { result, navigate } = renderAtProjectRoute("real-project");
+    expect(result.current).toBe(false);
+
+    act(() => navigate(`/${DEMO_PROJECT_NAME}/episodes/1`));
+    // currentProjectName 仍是 store 里的 "real-project"，同样模拟同一帧内的判定滞后窗口。
+    expect(result.current).toBe(true);
+  });
+
+  it("falls back to the store-derived value when no route param is available", () => {
+    useProjectsStore.setState({ currentProjectName: DEMO_PROJECT_NAME });
+    const { hook } = memoryLocation({ path: "/" });
+    const { result } = renderHook(() => useDemoWorkbench(), {
+      wrapper: ({ children }) => <Router hook={hook}>{children}</Router>,
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/frontend/src/onboarding/use-demo-workbench.ts
+++ b/frontend/src/onboarding/use-demo-workbench.ts
@@ -4,12 +4,20 @@
  * 工作台里绝大多数控件靠既有惯用法关掉（不传写回调 ⇒ 入口不渲染），少数需要跨层知道自己
  * 处在演示态的位置（布局要不要连 SSE、侧栏要不要拉文件列表、工具栏要不要给「新建」）用这个
  * hook 从 store 派生。判定只看当前项目名，离开演示项目即自动失效，不需要额外的开关状态。
+ *
+ * store 的 currentProjectName 由 StudioWorkspace 在 effect 里异步写入，路由参数切换
+ * （含大厅进入工作台、演示态与真实项目间切换，:projectName 变化不 remount 组件）后的首轮
+ * 渲染 store 都还没同步；路由参数在渲染期即可用，参数存在时以它为准，避免所有直读该 hook
+ * 的消费者各自重新踩一遍这段判定滞后。
  */
 
+import { useParams } from "wouter";
 import { useProjectsStore } from "@/stores/projects-store";
 import { isDemoProject } from "./demo-project";
 
 /** 当前工作台是否处在只读的演示态。 */
 export function useDemoWorkbench(): boolean {
-  return useProjectsStore((s) => isDemoProject(s.currentProjectName));
+  const routeProjectName = useParams<{ projectName?: string }>().projectName;
+  const storeDemoMode = useProjectsStore((s) => isDemoProject(s.currentProjectName));
+  return routeProjectName ? isDemoProject(routeProjectName) : storeDemoMode;
 }


### PR DESCRIPTION
Closes #1328

## 做了什么

演示工作台的只读态不再靠父级逐个回调置空手工接线，改由两处组件各自直读 `useDemoWorkbench()`：

- **MediaCard** 关掉自己承载的四个入口（上传 / 编辑 / 版本恢复 / 生成）。此前版本入口靠 `onRestore` 缺省关闭、其余靠 `readOnly` 透传，两套机制合一。
- **TimelineCanvas** 用 `DEMO_READ_ONLY_PROPS` 覆盖表作废本画布额外承载的写能力（提示词编辑 / 镜头移动 / 两个旁白生成 / 标题编辑），不重复兜 MediaCard 已关的入口。
- **StudioCanvasRouter** 相应删去 `demoMode ? undefined : x` 一串三元；`MediaCard` 深在四层之下，透传一个 `readOnly` prop 正是本票要消除的那种链。
- **api.ts** 只读闸门从 `=== DEMO_PROJECT_NAME` 改用 `isDemoProject()`，与后者的大小写不敏感口径统一。
- **演示态跳过三处全局 GET**（providers / custom providers / system config），它们只服务视频时长选项。

## 一处口径收窄

AC4 写「不发真实**项目** GET」，正文引用的五处却全是**全局**端点。项目级 GET 只剩 `getVideoCapabilities`，早已受门控。本 PR 门控 StudioCanvasRouter 的三处全局 GET，GlobalHeader 的两处有意不动：用量统计在演示态回落全局是既定设计，门控它会让顶栏费用显示为 0，与「不改变用户可见行为」冲突。

## 用户可见行为

演示态的入口渲染与改前逐一比对一致。唯一差异：时长胶囊上「与后端不兼容」的橙色标记在演示态不再出现——演示时长是虚构的，该标记本就是伪告警。

## 验证

- `pnpm lint` / `pnpm check` 全绿（124 文件 / 1211 用例）
- MediaCard、TimelineCanvas、StudioCanvasRouter 的演示态用例均配了同参数的非演示态对照，防「本来就没渲染」的假绿
- 对照用例做过变异验证：把门控改成无条件 `return` 后新增用例失败
- 后端零改动，未跑 pytest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 演示工作台只读体验完善：隐藏上传、脚本编辑、版本恢复与生成入口，并禁用标题/提示词/旁白等写入能力。
  * 演示项目识别更准确：基于运行时演示项目判断（支持大小写不敏感），相应调整闸门拦截与全局资源/接口查询。
  * 演示态切换更稳定：优先按路由参数判定只读，避免首次不同步与旧缓存导致的错误请求；演示/不存在场景不建立 SSE 连接。
* **测试**
  * 扩充演示态、路由切换时序、能力下放/作废及按钮可见性用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->