### PR TITLE
fix(config): 自定义供应商模块可任意顺序独立导入

### DIFF
--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -32,8 +32,6 @@ from lib.config.service import (
     ConfigService,
 )
 from lib.custom_provider import is_custom_provider, parse_provider_id
-from lib.custom_provider.capabilities import synthesize_video_capabilities
-from lib.custom_provider.endpoints import endpoint_to_media_type
 from lib.db.repositories.credential_repository import CredentialRepository
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.project_manager import get_project_manager
@@ -668,6 +666,12 @@ class ConfigResolver:
         model_id: str,
         project: dict | None,
     ) -> dict:
+        # 延迟导入：``lib.custom_provider.{capabilities,endpoints}`` 依赖全部媒体 backend，而
+        # backend 又依赖 ``lib.config``，模块级导入会让 ``lib.config`` 反向依赖上层的自定义供应商
+        # 装配层。分层方向以 ``lib.config`` 为下层，故这条向上的边只在调用期建立。
+        from lib.custom_provider.capabilities import synthesize_video_capabilities
+        from lib.custom_provider.endpoints import endpoint_to_media_type
+
         if is_custom_provider(provider_id):
             source = "custom"
             try:

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -666,13 +666,14 @@ class ConfigResolver:
         model_id: str,
         project: dict | None,
     ) -> dict:
-        # 延迟导入：``lib.custom_provider.{capabilities,endpoints}`` 依赖全部媒体 backend，而
-        # backend 又依赖 ``lib.config``，模块级导入会让 ``lib.config`` 反向依赖上层的自定义供应商
-        # 装配层。分层方向以 ``lib.config`` 为下层，故这条向上的边只在调用期建立。
-        from lib.custom_provider.capabilities import synthesize_video_capabilities
-        from lib.custom_provider.endpoints import endpoint_to_media_type
-
         if is_custom_provider(provider_id):
+            # 延迟导入：``lib.custom_provider.{capabilities,endpoints}`` 依赖全部媒体 backend，而
+            # backend 又依赖 ``lib.config``，模块级导入会让 ``lib.config`` 反向依赖上层的自定义供应商
+            # 装配层。分层方向以 ``lib.config`` 为下层，故这条向上的边只在调用期建立；注册表分支
+            # 不用这两个符号，也就不必为它拉起整个装配层。
+            from lib.custom_provider.capabilities import synthesize_video_capabilities
+            from lib.custom_provider.endpoints import endpoint_to_media_type
+
             source = "custom"
             try:
                 db_pid = parse_provider_id(provider_id)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -3,9 +3,7 @@
 参数化遍历 lib/ 与 server/ 下核心子模块，每个 importlib.import_module 一次。
 任何循环依赖、缺失依赖、顶层副作用崩溃都会在此红。
 
-同进程遍历只能发现"任何顺序都炸"的环；只在特定模块作为首个导入时才触发的环，会被先前
-用例留在 ``sys.modules`` 里的缓存掩盖。故另有 :func:`test_module_imports_first_in_fresh_process`
-在全新解释器里逐个验证首位导入。
+同进程遍历有其盲区，:func:`test_module_imports_first_in_fresh_process` 补上，理由见该函数。
 """
 
 from __future__ import annotations
@@ -21,6 +19,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # 核心子模块白名单。新增包时请在此追加（而不是用 pkgutil.walk_packages，
 # 以避免意外拉起 lib.i18n.zh/en 的翻译数据包和 alembic.versions 迁移脚本）。
+# 参与 lib.config ↔ lib.custom_provider 互引的模块另需登记 FIRST_IMPORT_MODULES。
 MODULES = [
     # lib 顶层单文件模块
     "lib.ark_shared",
@@ -74,8 +73,7 @@ MODULES = [
 ]
 
 
-# 首位导入必须成立的模块：``lib.config`` ↔ ``lib.custom_provider`` ↔ 各媒体 backend 三者
-# 相互引用，环只在特定模块打头时才显形，故逐个在全新解释器里验证。
+# 首位导入必须成立的模块，逐个在全新解释器里验证（理由见用例 docstring）。
 FIRST_IMPORT_MODULES = [
     "lib.config",
     "lib.config.resolver",
@@ -94,7 +92,7 @@ def test_module_imports_cleanly(module_name: str) -> None:
     importlib.import_module(module_name)
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 @pytest.mark.parametrize("module_name", FIRST_IMPORT_MODULES)
 def test_module_imports_first_in_fresh_process(module_name: str) -> None:
     """该模块作为解释器里第一个被导入的项目模块时也能成功。
@@ -104,11 +102,17 @@ def test_module_imports_first_in_fresh_process(module_name: str) -> None:
     冒烟遍历因 ``sys.modules`` 已被前序用例填热而看不见。全新子进程是唯一能钉住"任意顺序
     均可独立导入"的手段。
     """
-    result = subprocess.run(
-        [sys.executable, "-c", f"import {module_name}"],
-        cwd=str(_REPO_ROOT),
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", f"import {module_name}"],
+            cwd=str(_REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        # 导入期的阻塞式副作用（网络、锁等待）正是本用例要拦的形态之一，超时须显式转红，
+        # 而不是把 CI job 挂满时限。
+        pytest.fail(f"{module_name} 首位导入超时，疑似存在阻塞式顶层副作用")
     assert result.returncode == 0, f"{module_name} 无法作为首个导入：\n{result.stderr}"

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -2,13 +2,22 @@
 
 参数化遍历 lib/ 与 server/ 下核心子模块，每个 importlib.import_module 一次。
 任何循环依赖、缺失依赖、顶层副作用崩溃都会在此红。
+
+同进程遍历只能发现"任何顺序都炸"的环；只在特定模块作为首个导入时才触发的环，会被先前
+用例留在 ``sys.modules`` 里的缓存掩盖。故另有 :func:`test_module_imports_first_in_fresh_process`
+在全新解释器里逐个验证首位导入。
 """
 
 from __future__ import annotations
 
 import importlib
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # 核心子模块白名单。新增包时请在此追加（而不是用 pkgutil.walk_packages，
 # 以避免意外拉起 lib.i18n.zh/en 的翻译数据包和 alembic.versions 迁移脚本）。
@@ -65,7 +74,41 @@ MODULES = [
 ]
 
 
+# 首位导入必须成立的模块：``lib.config`` ↔ ``lib.custom_provider`` ↔ 各媒体 backend 三者
+# 相互引用，环只在特定模块打头时才显形，故逐个在全新解释器里验证。
+FIRST_IMPORT_MODULES = [
+    "lib.config",
+    "lib.config.resolver",
+    "lib.custom_provider.backends",
+    "lib.custom_provider.capabilities",
+    "lib.custom_provider.discovery",
+    "lib.custom_provider.endpoints",
+    "lib.custom_provider.factory",
+    "lib.custom_provider.loader",
+]
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize("module_name", MODULES)
 def test_module_imports_cleanly(module_name: str) -> None:
     importlib.import_module(module_name)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name", FIRST_IMPORT_MODULES)
+def test_module_imports_first_in_fresh_process(module_name: str) -> None:
+    """该模块作为解释器里第一个被导入的项目模块时也能成功。
+
+    ``lib.config`` 与 ``lib.custom_provider`` 互相引用（后者装配 backend、backend 又读前者的
+    URL 工具），一旦某条边退回模块级导入就会成环——而环只在特定模块打头时才炸，同进程的
+    冒烟遍历因 ``sys.modules`` 已被前序用例填热而看不见。全新子进程是唯一能钉住"任意顺序
+    均可独立导入"的手段。
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {module_name}"],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"{module_name} 无法作为首个导入：\n{result.stderr}"


### PR DESCRIPTION
Closes #1334

## 问题

`lib.custom_provider.endpoints` 作为进程首个导入时抛 `ImportError: cannot import name 'get_endpoint_spec' from partially initialized module`。环的实际形状比 issue 描述长一圈：

```
lib.custom_provider.endpoints → lib.audio_backends → lib.video_backends
  → lib.config（包 __init__ 转出 ConfigResolver）→ lib.config.resolver
  → lib.custom_provider.capabilities → 回到 endpoints
```

崩点在 `capabilities.py` 的 `get_endpoint_spec`，但可切的边不在 `custom_provider` 内部。

## 拆环方向：依赖反转

切点选 `lib/config/resolver.py` 对 `lib.custom_provider.{capabilities,endpoints}` 的两个模块级导入，改为函数内延迟导入。

理由是分层方向：`lib.custom_provider` 装配各媒体 backend，backend 又反过来读 `lib.config` 的 URL 工具，故 `lib.config` 是下层。resolver 反向引用上层是这个环里唯一方向错误的边，切它是修分层而不是挑软柿子。两个符号只在 `_resolve_video_caps_for_model` 的自定义供应商分支使用，导入语句就放在该分支内——注册表分支不用这两个符号，也不必为它拉起整个装配层。同文件 `_pick_default_provider_model` 已有同包函数内导入的先例。

**放弃的替代方案**

- *抽底层公共模块*：`capabilities` 需要完整 `EndpointSpec`（`video_caps_for_model` / `end_image_capable`），而 spec 的字段就是各 backend 的 delegate 工厂，抽不出不依赖 backend 的子集，切不断这条边。
- *改 `lib/config/__init__.py` 不再转出 `ConfigResolver`*：这才是环的机械根因，且全仓无一处 `from lib.config import ConfigResolver`。但它改动公开导出面，与验收标准 3 冲突，转为 follow-up 候选。

## 回归测试

`tests/test_imports.py` 新增 `test_module_imports_first_in_fresh_process`，在**全新子进程**里逐个验证首位导入，覆盖 8 个模块（`lib.config`、`lib.config.resolver` + `lib/custom_provider/` 全部 6 个子模块）。

同文件既有的同进程遍历正是漏掉这个环的原因——前序用例已把 `lib.config` 填进 `sys.modules`，首位导入的顺序效应彻底消失。子进程是唯一能钉住"任意顺序均可独立导入"的手段。选择逐模块参数化而非合并成一条：合并只省进程启动、不省导入开销，却丢掉"哪个模块打头会炸"的定位信息。用例打 `integration` marker（起真实子进程，非 `unit` 的"不碰真实 I/O"），并设 120s 超时——阻塞式顶层副作用正是它要拦的形态之一，须显式转红而不是挂满 CI job 时限。

## 验证

- 三个模块（及另外 5 个）各自作首位导入均成功；反向把 resolver 改动 stash 掉后，新增用例 5 条转红（backends / capabilities / endpoints / factory / loader），恢复后全绿。
- 公共 API 不变：全仓无 `from lib.config.resolver import synthesize_video_capabilities|endpoint_to_media_type` 的转口导入，也无对这两个 resolver 模块属性的 monkeypatch。
- 质量门：`ruff check .` 全绿、`basedpyright` 0 error、`pytest -m "not e2e"` 6370 passed。

## 已知限制

- 延迟导入把首次调用的开销从进程启动挪到首次解析。server 进程里 `server/routers/custom_providers.py` 仍在模块级导入 `endpoints`，`sys.modules` 恒为热态，故只在未导入该路由的独立进程首调用时产生一次性冷加载；CPython 的 per-module import lock 使并发调用安全。
- `endpoints.py` 的模块级不变式校验 `_validate_video_caps_declarations()` 在非 server 入口下由进程启动推迟到首次视频能力解析。server 启动路径照旧 fail-fast。
- 新增用例只钉住"能否作为首个导入"，不阻止新的模块级反向依赖被加回去（只要不成环就照样绿）。真正的分层护栏需要 import-linter 一类的依赖方向静态检查，本次未引入，列为 follow-up。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 改善视频能力解析模块的导入流程，避免特定导入顺序导致的循环依赖问题。
  * 提升自定义供应商相关功能的加载稳定性。

* **测试**
  * 增加全新进程中的模块导入检查，更全面地捕获导入失败和启动异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->