### PR TITLE
fix(video): Veo 参考图与 1080p/4K 下时长不合规时给出可读拒绝

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -227,6 +227,7 @@ MESSAGES = {
     "video_duration_not_supported": "Video duration {duration}s is not within the durations supported by this model ({supported})",
     "video_capability_missing_t2v": "{provider}/{model} does not support text-to-video; provide a first-frame image or switch to a model that supports text-to-video",
     "video_resolution_duration_unsupported": "Model {model} does not support {duration}s at {resolution} resolution (only {supported}); adjust the resolution or duration",
+    "video_reference_images_duration_unsupported": "Model {model} does not support {duration}s with reference images (only {supported}); change the duration to {supported} or remove the reference images",
     "video_reference_images_required": "Model {model} requires at least one reference image; please provide reference images",
     "video_reference_images_unreadable": "Model {model} has reference images that are missing or unreadable; generation aborted: {names}; check the reference image paths",
     "video_reference_images_unsupported": "Model {model} does not support multi-subject reference images; remove the reference images or switch to a model that supports reference-to-video",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -227,6 +227,7 @@ MESSAGES = {
     "video_duration_not_supported": "Thời lượng video {duration}s không nằm trong các thời lượng mà mô hình này hỗ trợ ({supported})",
     "video_capability_missing_t2v": "{provider}/{model} không hỗ trợ text-to-video; hãy cung cấp ảnh khung hình đầu hoặc chuyển sang mô hình có hỗ trợ text-to-video",
     "video_resolution_duration_unsupported": "Mô hình {model} không hỗ trợ {duration}s ở độ phân giải {resolution} (chỉ {supported}); hãy điều chỉnh độ phân giải hoặc thời lượng",
+    "video_reference_images_duration_unsupported": "Mô hình {model} không hỗ trợ {duration}s khi dùng ảnh tham chiếu (chỉ {supported}); hãy đổi thời lượng sang {supported} hoặc bỏ ảnh tham chiếu",
     "video_reference_images_required": "Mô hình {model} cần ít nhất một ảnh tham chiếu; hãy cung cấp ảnh tham chiếu",
     "video_reference_images_unreadable": "Mô hình {model} có ảnh tham chiếu bị thiếu hoặc không đọc được; đã hủy tạo: {names}; hãy kiểm tra đường dẫn ảnh tham chiếu",
     "video_reference_images_unsupported": "Mô hình {model} không hỗ trợ ảnh tham chiếu đa chủ thể; hãy bỏ ảnh tham chiếu hoặc chuyển sang mô hình có hỗ trợ tạo video từ ảnh tham chiếu",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -217,6 +217,7 @@ MESSAGES = {
     "video_duration_not_supported": "视频时长 {duration}s 不在该模型支持的时长（{supported}）内",
     "video_capability_missing_t2v": "{provider}/{model} 不支持文生视频；请提供首帧图，或换一个支持文生视频的模型",
     "video_resolution_duration_unsupported": "模型 {model} 在 {resolution} 分辨率下不支持 {duration}s（仅支持 {supported}）；请调整分辨率或时长",
+    "video_reference_images_duration_unsupported": "模型 {model} 使用参考图时不支持 {duration}s（仅支持 {supported}）；请把时长改为 {supported}，或移除参考图",
     "video_reference_images_required": "模型 {model} 需要至少一张参考图；请提供参考图",
     "video_reference_images_unreadable": "模型 {model} 有参考图缺失或无法读取，已中止生成：{names}；请检查参考图路径",
     "video_reference_images_unsupported": "模型 {model} 不支持多图主体参考；请移除参考图，或换一个支持参考生视频的模型",

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 
 # Veo 的 durationSeconds 取值为 4/6/8，但参考图路径与 1080p/4k 分辨率下只接受 8 秒。
 # 两条路径各自独立触发，与首帧/尾帧无关。
-_LOCKED_DURATION_SECONDS = 8
-_LOCKED_DURATION_RESOLUTIONS = frozenset({"1080p", "4k"})
+_REQUIRED_DURATION_SECONDS = 8
+_DURATION_CONSTRAINED_RESOLUTIONS = frozenset({"1080p", "4k"})
 
 
 class GeminiVideoBackend(ProviderJobIdPersistenceMixin):
@@ -127,6 +127,8 @@ class GeminiVideoBackend(ProviderJobIdPersistenceMixin):
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         """生成视频。任务创建和轮询阶段分离重试，避免瞬态错误导致重建任务。"""
+        # 能力校验放在重试装饰器之外：约束违规必然复现，重试只是重复失败
+        self._validate_duration_constraints(request)
         operation = await self._create_task(request)
         op_name = getattr(operation, "name", None)
         if not op_name:
@@ -166,10 +168,10 @@ class GeminiVideoBackend(ProviderJobIdPersistenceMixin):
         fail-loud 换成可读拒绝，也省掉一次必然失败的调用。首帧（image）与尾帧
         （last_frame）不在约束内，4/6 秒照常下发。
         """
-        if request.duration_seconds == _LOCKED_DURATION_SECONDS:
+        if request.duration_seconds == _REQUIRED_DURATION_SECONDS:
             return
 
-        supported = f"{_LOCKED_DURATION_SECONDS}s"
+        supported = f"{_REQUIRED_DURATION_SECONDS}s"
         if request.reference_images:
             raise VideoCapabilityError(
                 "video_reference_images_duration_unsupported",
@@ -179,7 +181,7 @@ class GeminiVideoBackend(ProviderJobIdPersistenceMixin):
             )
 
         resolution = (request.resolution or "").strip().lower()
-        if resolution in _LOCKED_DURATION_RESOLUTIONS:
+        if resolution in _DURATION_CONSTRAINED_RESOLUTIONS:
             raise VideoCapabilityError(
                 "video_resolution_duration_unsupported",
                 model=self._video_model,
@@ -191,9 +193,6 @@ class GeminiVideoBackend(ProviderJobIdPersistenceMixin):
     @with_retry_async()
     async def _create_task(self, request: VideoGenerationRequest) -> Any:
         """创建 Gemini 视频生成任务（带重试保护）。"""
-        # 0. 能力校验：不合法组合在限流与 SDK 调用之前拒绝
-        self._validate_duration_constraints(request)
-
         # 1. 限流
         if self._rate_limiter:
             await self._rate_limiter.acquire_async(self._video_model)

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -21,12 +21,18 @@ from lib.video_backends.base import (
     ResumeExpiredError,
     VideoCapabilities,
     VideoCapability,
+    VideoCapabilityError,
     VideoGenerationRequest,
     VideoGenerationResult,
     poll_with_retry,
 )
 
 logger = logging.getLogger(__name__)
+
+# Veo 的 durationSeconds 取值为 4/6/8，但参考图路径与 1080p/4k 分辨率下只接受 8 秒。
+# 两条路径各自独立触发，与首帧/尾帧无关。
+_LOCKED_DURATION_SECONDS = 8
+_LOCKED_DURATION_RESOLUTIONS = frozenset({"1080p", "4k"})
 
 
 class GeminiVideoBackend(ProviderJobIdPersistenceMixin):
@@ -153,9 +159,41 @@ class GeminiVideoBackend(ProviderJobIdPersistenceMixin):
                 raise ResumeExpiredError(job_id=job_id, provider=PROVIDER_GEMINI) from exc
             raise
 
+    def _validate_duration_constraints(self, request: VideoGenerationRequest) -> None:
+        """参考图 / 1080p·4k 两条路径强制 8 秒，违反即拒绝。
+
+        供应商侧对这两种组合直接报错，透传过去用户拿到的是原始报文；在构建请求前
+        fail-loud 换成可读拒绝，也省掉一次必然失败的调用。首帧（image）与尾帧
+        （last_frame）不在约束内，4/6 秒照常下发。
+        """
+        if request.duration_seconds == _LOCKED_DURATION_SECONDS:
+            return
+
+        supported = f"{_LOCKED_DURATION_SECONDS}s"
+        if request.reference_images:
+            raise VideoCapabilityError(
+                "video_reference_images_duration_unsupported",
+                model=self._video_model,
+                duration=request.duration_seconds,
+                supported=supported,
+            )
+
+        resolution = (request.resolution or "").strip().lower()
+        if resolution in _LOCKED_DURATION_RESOLUTIONS:
+            raise VideoCapabilityError(
+                "video_resolution_duration_unsupported",
+                model=self._video_model,
+                resolution=resolution.upper(),
+                duration=request.duration_seconds,
+                supported=supported,
+            )
+
     @with_retry_async()
     async def _create_task(self, request: VideoGenerationRequest) -> Any:
         """创建 Gemini 视频生成任务（带重试保护）。"""
+        # 0. 能力校验：不合法组合在限流与 SDK 调用之前拒绝
+        self._validate_duration_constraints(request)
+
         # 1. 限流
         if self._rate_limiter:
             await self._rate_limiter.acquire_async(self._video_model)

--- a/tests/test_gemini_video_resolution.py
+++ b/tests/test_gemini_video_resolution.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from lib.retry import _should_retry
 from lib.video_backends.base import VideoCapabilityError, VideoGenerationRequest
 from lib.video_backends.gemini import GeminiVideoBackend
 
@@ -82,6 +81,9 @@ def _frame(tmp_path, name="frame.png"):
     return p
 
 
+# 统一走 generate()：校验在重试装饰器之外，只有从这个入口进才覆盖真实调用顺序。
+
+
 @pytest.mark.parametrize("seconds", [4, 6])
 @pytest.mark.asyncio
 async def test_reference_images_reject_non_8s(tmp_path, seconds):
@@ -93,7 +95,7 @@ async def test_reference_images_reject_non_8s(tmp_path, seconds):
         reference_images=[_frame(tmp_path, "ref.png")],
     )
     with pytest.raises(VideoCapabilityError) as exc:
-        await backend._create_task(req)
+        await backend.generate(req)
 
     assert exc.value.code == "video_reference_images_duration_unsupported"
     assert exc.value.params["duration"] == seconds
@@ -101,29 +103,24 @@ async def test_reference_images_reject_non_8s(tmp_path, seconds):
     backend._client.aio.models.generate_videos.assert_not_awaited()
 
 
+@pytest.mark.parametrize("seconds", [4, 6])
 @pytest.mark.parametrize("resolution", ["1080p", "1080P", "4k", "4K"])
 @pytest.mark.asyncio
-async def test_high_resolution_rejects_non_8s(tmp_path, resolution):
+async def test_high_resolution_rejects_non_8s(tmp_path, resolution, seconds):
     backend = _make_backend()
     req = VideoGenerationRequest(
         prompt="x",
         output_path=tmp_path / "o.mp4",
-        duration_seconds=6,
+        duration_seconds=seconds,
         resolution=resolution,
     )
     with pytest.raises(VideoCapabilityError) as exc:
-        await backend._create_task(req)
+        await backend.generate(req)
 
     assert exc.value.code == "video_resolution_duration_unsupported"
     assert exc.value.params["resolution"] == resolution.upper()
+    assert exc.value.params["duration"] == seconds
     backend._client.aio.models.generate_videos.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_capability_error_is_not_retried():
-    """约束违规必然复现，重试只会重复失败——确认它不落入瞬态重试。"""
-    assert not _should_retry(VideoCapabilityError("video_resolution_duration_unsupported"), ())
-    assert not _should_retry(VideoCapabilityError("video_reference_images_duration_unsupported"), ())
 
 
 @pytest.mark.parametrize("seconds", [4, 6])
@@ -140,30 +137,24 @@ async def test_start_and_last_frame_keep_short_durations(tmp_path, seconds):
         end_image=_frame(tmp_path, "end.png"),
     )
     with pytest.raises(RuntimeError):  # SDK mock 的 stop 哨兵，说明已走到调用点
-        await backend._create_task(req)
+        await backend.generate(req)
 
     backend._client.aio.models.generate_videos.assert_awaited_once()
     assert backend._types.GenerateVideosConfig.call_args.kwargs["duration_seconds"] == str(seconds)
 
 
-@pytest.mark.parametrize(
-    "extra",
-    [
-        {"resolution": "1080p"},
-        {"resolution": "4k"},
-    ],
-)
+@pytest.mark.parametrize("resolution", ["1080p", "4k"])
 @pytest.mark.asyncio
-async def test_8s_passes_through(tmp_path, extra):
+async def test_8s_passes_through(tmp_path, resolution):
     backend = _make_backend()
     req = VideoGenerationRequest(
         prompt="x",
         output_path=tmp_path / "o.mp4",
         duration_seconds=8,
+        resolution=resolution,
         reference_images=[_frame(tmp_path, "ref.png")],
-        **extra,
     )
     with pytest.raises(RuntimeError):
-        await backend._create_task(req)
+        await backend.generate(req)
 
     backend._client.aio.models.generate_videos.assert_awaited_once()

--- a/tests/test_gemini_video_resolution.py
+++ b/tests/test_gemini_video_resolution.py
@@ -1,10 +1,11 @@
-"""测试 GeminiVideoBackend 对 resolution=None 的处理。"""
+"""测试 GeminiVideoBackend 对 resolution 的处理与 duration 联动约束。"""
 
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from lib.video_backends.base import VideoGenerationRequest
+from lib.retry import _should_retry
+from lib.video_backends.base import VideoCapabilityError, VideoGenerationRequest
 from lib.video_backends.gemini import GeminiVideoBackend
 
 
@@ -70,3 +71,99 @@ async def test_duration_passthrough_str(tmp_path, seconds):
 
     cfg_call = backend._types.GenerateVideosConfig.call_args
     assert cfg_call.kwargs["duration_seconds"] == str(seconds)
+
+
+# ── duration 联动约束：参考图 / 1080p·4k 强制 8 秒 ──────────────────
+
+
+def _frame(tmp_path, name="frame.png"):
+    p = tmp_path / name
+    p.write_bytes(b"fake-png-data")
+    return p
+
+
+@pytest.mark.parametrize("seconds", [4, 6])
+@pytest.mark.asyncio
+async def test_reference_images_reject_non_8s(tmp_path, seconds):
+    backend = _make_backend()
+    req = VideoGenerationRequest(
+        prompt="x",
+        output_path=tmp_path / "o.mp4",
+        duration_seconds=seconds,
+        reference_images=[_frame(tmp_path, "ref.png")],
+    )
+    with pytest.raises(VideoCapabilityError) as exc:
+        await backend._create_task(req)
+
+    assert exc.value.code == "video_reference_images_duration_unsupported"
+    assert exc.value.params["duration"] == seconds
+    assert exc.value.params["supported"] == "8s"
+    backend._client.aio.models.generate_videos.assert_not_awaited()
+
+
+@pytest.mark.parametrize("resolution", ["1080p", "1080P", "4k", "4K"])
+@pytest.mark.asyncio
+async def test_high_resolution_rejects_non_8s(tmp_path, resolution):
+    backend = _make_backend()
+    req = VideoGenerationRequest(
+        prompt="x",
+        output_path=tmp_path / "o.mp4",
+        duration_seconds=6,
+        resolution=resolution,
+    )
+    with pytest.raises(VideoCapabilityError) as exc:
+        await backend._create_task(req)
+
+    assert exc.value.code == "video_resolution_duration_unsupported"
+    assert exc.value.params["resolution"] == resolution.upper()
+    backend._client.aio.models.generate_videos.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_capability_error_is_not_retried():
+    """约束违规必然复现，重试只会重复失败——确认它不落入瞬态重试。"""
+    assert not _should_retry(VideoCapabilityError("video_resolution_duration_unsupported"), ())
+    assert not _should_retry(VideoCapabilityError("video_reference_images_duration_unsupported"), ())
+
+
+@pytest.mark.parametrize("seconds", [4, 6])
+@pytest.mark.asyncio
+async def test_start_and_last_frame_keep_short_durations(tmp_path, seconds):
+    """image / lastFrame 路径不受约束，720p 下 4/6 秒照常下发。"""
+    backend = _make_backend()
+    req = VideoGenerationRequest(
+        prompt="x",
+        output_path=tmp_path / "o.mp4",
+        duration_seconds=seconds,
+        resolution="720p",
+        start_image=_frame(tmp_path, "start.png"),
+        end_image=_frame(tmp_path, "end.png"),
+    )
+    with pytest.raises(RuntimeError):  # SDK mock 的 stop 哨兵，说明已走到调用点
+        await backend._create_task(req)
+
+    backend._client.aio.models.generate_videos.assert_awaited_once()
+    assert backend._types.GenerateVideosConfig.call_args.kwargs["duration_seconds"] == str(seconds)
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"resolution": "1080p"},
+        {"resolution": "4k"},
+    ],
+)
+@pytest.mark.asyncio
+async def test_8s_passes_through(tmp_path, extra):
+    backend = _make_backend()
+    req = VideoGenerationRequest(
+        prompt="x",
+        output_path=tmp_path / "o.mp4",
+        duration_seconds=8,
+        reference_images=[_frame(tmp_path, "ref.png")],
+        **extra,
+    )
+    with pytest.raises(RuntimeError):
+        await backend._create_task(req)
+
+    backend._client.aio.models.generate_videos.assert_awaited_once()


### PR DESCRIPTION
Closes #1333

## 问题

Veo 的 `durationSeconds` 在使用参考图或 1080p/4k 分辨率时只接受 8 秒，但 gemini 后端此前对 duration 与 resolution 双透传，没有联动校验。用户提交 4/6 秒 + 参考图（或 1080p/4k）时，拿到的是供应商返回的原始报错，而不是本系统的可读拒绝。

## 改动

在 `GeminiVideoBackend.generate()` 里、发起供应商调用之前校验两条约束，违反即 fail-loud 抛 `VideoCapabilityError`：

- 参考图路径 + duration ≠ 8 → 新增 i18n key `video_reference_images_duration_unsupported`（zh/en/vi）
- 1080p/4k + duration ≠ 8 → 复用既有的 `video_resolution_duration_unsupported`（MiniMax 已在用，参数形状一致）

分辨率匹配做 `strip().lower()` 归一（`1080P`/`4K` 同样命中），错误信息回显 `.upper()`。

按 issue 已裁决的边界，首帧（`image`）与尾帧（`lastFrame`）路径不受此约束，4/6 秒行为不变；vendor 文档未更新。

## 验证

- `tests/test_gemini_video_resolution.py` 覆盖四条验收标准：参考图 4/6 秒被拒、1080p/4k × 4/6 秒被拒（含大小写变体）、首帧+尾帧 720p 4/6 秒照常下发、duration=8 时上述路径均正常提交。拒绝路径以 `assert_not_awaited()` 证实无供应商调用。
- 测试统一从 `generate()` 入口驱动，覆盖真实调用顺序。
- 全量质量门：`pytest` 6384 passed、`ruff check` clean、`basedpyright` 0 errors。
- 未做端到端验证（无 Veo 凭证）。

## 审查阶段的调整

- 校验点从 `_create_task`（带 `@with_retry_async`）上提到 `generate()`，不再依赖「`VideoCapabilityError` 的 code 恰好不命中重试模式」这一隐式前提，与 MiniMax/Kling 把能力校验放在重试之外的先例一致。
- 1080p/4k 拒绝用例补 `duration=4`，此前只覆盖 6。
- 常量改名 `_REQUIRED_DURATION_SECONDS` / `_DURATION_CONSTRAINED_RESOLUTIONS`。

## 已知限制

`lib/config/registry.py` 中 veo 模型已声明 `duration_resolution_constraints={"1080p": [8]}` 供前端门控，但参考图↔时长这条约束在 `ModelInfo` 上无处表达，前端无法门控，只能靠后端兜底拒绝。registry 的 `resolutions` 也不含 4k（本次按 issue 描述把 4k 一并纳入 backend 约束）。两者是否收敛到统一真相源，留作后续。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误提示**
  * 新增视频生成时长不受支持时的提示信息，支持英文、越南文和中文。
  * 提示会说明模型、请求时长及可用时长，并建议调整时长或移除参考图片。

* **功能改进**
  * 在提交视频生成请求前校验参考图片、高分辨率与时长的兼容性。
  * 不兼容的请求将及时返回明确错误，避免无效任务提交。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->