### PR TITLE
fix(video): 后端不支持尾帧时拒绝生成而非静默丢帧

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -236,6 +236,7 @@ MESSAGES = {
     "video_end_image_unreadable": "The last-frame image for model {model} is unreadable; generation aborted: {name}; check the last-frame image path",
     "video_end_image_requires_start_image": "Model {model} does not support a standalone last frame; also provide a first frame (first+last keyframes) or remove the last frame",
     "video_last_frame_requires_pro": "{provider}/{model} only supports first+last frame at the pro tier; switch to the pro tier or remove the last frame",
+    "video_last_frame_unsupported": "{provider}/{model} does not support a last frame; generation aborted. Remove the shot's last frame or switch to a model that supports it",
     # Agent credentials
     "agent_preset_unknown": "Unknown preset provider: {preset_id}",
     "agent_base_url_required_custom": "base_url is required for custom configuration",

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -236,7 +236,7 @@ MESSAGES = {
     "video_end_image_unreadable": "The last-frame image for model {model} is unreadable; generation aborted: {name}; check the last-frame image path",
     "video_end_image_requires_start_image": "Model {model} does not support a standalone last frame; also provide a first frame (first+last keyframes) or remove the last frame",
     "video_last_frame_requires_pro": "{provider}/{model} only supports first+last frame at the pro tier; switch to the pro tier or remove the last frame",
-    "video_last_frame_unsupported": "{provider}/{model} does not support a last frame; generation aborted. Remove the shot's last frame or switch to a model that supports it",
+    "video_last_frame_unsupported": "{provider}/{model} does not support a last frame under the current configuration; generation aborted. Remove the shot's last frame, or switch to a model or tier that supports it",
     # Agent credentials
     "agent_preset_unknown": "Unknown preset provider: {preset_id}",
     "agent_base_url_required_custom": "base_url is required for custom configuration",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -236,6 +236,7 @@ MESSAGES = {
     "video_end_image_unreadable": "Ảnh khung hình cuối của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình cuối",
     "video_end_image_requires_start_image": "Mô hình {model} không hỗ trợ khung hình cuối độc lập; hãy cung cấp thêm khung hình đầu (chế độ khung đầu+cuối) hoặc bỏ khung hình cuối",
     "video_last_frame_requires_pro": "{provider}/{model} chỉ hỗ trợ khung đầu+cuối ở gói pro; hãy chuyển sang gói pro hoặc bỏ khung hình cuối",
+    "video_last_frame_unsupported": "{provider}/{model} không hỗ trợ khung hình cuối; đã hủy tạo. Hãy bỏ khung hình cuối của cảnh quay này hoặc chuyển sang mô hình có hỗ trợ",
     # Agent credentials
     "agent_preset_unknown": "Nhà cung cấp đặt sẵn không xác định: {preset_id}",
     "agent_base_url_required_custom": "Cấu hình tuỳ chỉnh yêu cầu base_url",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -236,7 +236,7 @@ MESSAGES = {
     "video_end_image_unreadable": "Ảnh khung hình cuối của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình cuối",
     "video_end_image_requires_start_image": "Mô hình {model} không hỗ trợ khung hình cuối độc lập; hãy cung cấp thêm khung hình đầu (chế độ khung đầu+cuối) hoặc bỏ khung hình cuối",
     "video_last_frame_requires_pro": "{provider}/{model} chỉ hỗ trợ khung đầu+cuối ở gói pro; hãy chuyển sang gói pro hoặc bỏ khung hình cuối",
-    "video_last_frame_unsupported": "{provider}/{model} không hỗ trợ khung hình cuối; đã hủy tạo. Hãy bỏ khung hình cuối của cảnh quay này hoặc chuyển sang mô hình có hỗ trợ",
+    "video_last_frame_unsupported": "{provider}/{model} không hỗ trợ khung hình cuối với cấu hình hiện tại; đã hủy tạo. Hãy bỏ khung hình cuối của cảnh quay này, hoặc chuyển sang mô hình hoặc gói có hỗ trợ",
     # Agent credentials
     "agent_preset_unknown": "Nhà cung cấp đặt sẵn không xác định: {preset_id}",
     "agent_base_url_required_custom": "Cấu hình tuỳ chỉnh yêu cầu base_url",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -226,7 +226,7 @@ MESSAGES = {
     "video_end_image_unreadable": "模型 {model} 的尾帧图无法读取，已中止生成：{name}；请检查尾帧图路径",
     "video_end_image_requires_start_image": "模型 {model} 不支持单独的尾帧；请同时提供首帧（首尾帧模式），或移除尾帧",
     "video_last_frame_requires_pro": "{provider}/{model} 的首尾帧仅在 pro 档生效；请切换到 pro 档，或移除尾帧",
-    "video_last_frame_unsupported": "{provider}/{model} 不支持尾帧，已中止生成；请移除该镜头的尾帧，或改用支持尾帧的模型",
+    "video_last_frame_unsupported": "{provider}/{model} 当前配置不支持尾帧，已中止生成；请移除该镜头的尾帧，或改用支持尾帧的模型/档位",
     # Agent credentials
     "agent_preset_unknown": "未知预设供应商: {preset_id}",
     "agent_base_url_required_custom": "自定义配置需要填写 base_url",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -226,6 +226,7 @@ MESSAGES = {
     "video_end_image_unreadable": "模型 {model} 的尾帧图无法读取，已中止生成：{name}；请检查尾帧图路径",
     "video_end_image_requires_start_image": "模型 {model} 不支持单独的尾帧；请同时提供首帧（首尾帧模式），或移除尾帧",
     "video_last_frame_requires_pro": "{provider}/{model} 的首尾帧仅在 pro 档生效；请切换到 pro 档，或移除尾帧",
+    "video_last_frame_unsupported": "{provider}/{model} 不支持尾帧，已中止生成；请移除该镜头的尾帧，或改用支持尾帧的模型",
     # Agent credentials
     "agent_preset_unknown": "未知预设供应商: {preset_id}",
     "agent_base_url_required_custom": "自定义配置需要填写 base_url",

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -568,11 +568,10 @@ class MediaGenerator:
 
         # 能力 gating 与槽位组装先于记账括号：尾帧不被支持时硬失败要"不扣费"，
         # 在括号内抛虽也不结算，却会留一条 failed ApiCall 行；纯函数无副作用，前置最干净。
-        from lib.video_backends.base import VideoCapabilities
         from lib.video_frame_slots import plan_frame_slots, resolve_video_capabilities
 
-        # 能力查询保持惰性：不带尾帧的请求不触发 gating，任何能力声明都等价，
-        # 无谓查询只会给无尾帧路径新增一层后端属性依赖。
+        # 能力查询保持惰性：不带尾帧的请求不触发 gating，无谓查询只会给无尾帧路径
+        # 新增一层后端属性依赖；未查询即传 None，不伪造一份占位能力声明。
         video_caps = (
             resolve_video_capabilities(
                 self._video_backend,
@@ -580,7 +579,7 @@ class MediaGenerator:
                 resolution=resolution,
             )
             if end_image is not None
-            else VideoCapabilities()
+            else None
         )
         slot_plan = plan_frame_slots(
             caps=video_caps,

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -564,6 +564,13 @@ class MediaGenerator:
         if self._video_backend is None:
             raise RuntimeError("video_backend not configured")
 
+        # 空串 end_image 归一为 None：遗留/直接 Python 调用者可能以 "" 表示无尾帧
+        # （kling _build_payload 的真值判断锁定了这个兼容语义，见
+        # tests/test_kling_video_backend.py::test_image2video_empty_end_frame_is_omitted）。
+        # 下方 gating 用 is not None 判空，"" 若不归一会被误判成真尾帧。
+        if not end_image:
+            end_image = None
+
         model_name = self._video_backend.model
 
         # 能力 gating 与槽位组装先于记账括号：尾帧不被支持时硬失败要"不扣费"，

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -565,6 +565,32 @@ class MediaGenerator:
             raise RuntimeError("video_backend not configured")
 
         model_name = self._video_backend.model
+
+        # 能力 gating 与槽位组装先于记账括号：尾帧不被支持时硬失败要"不扣费"，
+        # 在括号内抛虽也不结算，却会留一条 failed ApiCall 行；纯函数无副作用，前置最干净。
+        from lib.video_backends.base import VideoCapabilities
+        from lib.video_frame_slots import plan_frame_slots, resolve_video_capabilities
+
+        # 能力查询保持惰性：不带尾帧的请求不触发 gating，任何能力声明都等价，
+        # 无谓查询只会给无尾帧路径新增一层后端属性依赖。
+        video_caps = (
+            resolve_video_capabilities(
+                self._video_backend,
+                service_tier=version_metadata.get("service_tier", "default"),
+                resolution=resolution,
+            )
+            if end_image is not None
+            else VideoCapabilities()
+        )
+        slot_plan = plan_frame_slots(
+            caps=video_caps,
+            provider=self._video_backend.name,
+            model=model_name,
+            start_image=start_image,
+            end_image=end_image,
+            reference_images=reference_images,
+        )
+
         if self._config is not None:
             configured_generate_audio = await self._config.video_generate_audio(self.project_name)
         else:
@@ -604,49 +630,13 @@ class MediaGenerator:
 
             from lib.video_backends.base import VideoGenerationRequest
 
-            # 尾帧只在后端声明 last_frame 时下发：参考图是与首帧互斥的独立路径，
-            # 把尾帧转投参考图会丢掉首帧语义，故不支持尾帧的后端直接忽略该槽位。
-            #
-            # 优先取 video_capabilities_for_tier（若后端实现）：某些后端（如 Kling）的
-            # last_frame 仅在特定 service_tier 生效，无请求上下文的 video_capabilities 属性
-            # 只能保守声明，会让合法档位的请求在这里被误判不支持而静默丢帧。
-            actual_end_image = None
-
-            if end_image and self._video_backend:
-                tier_aware_caps = getattr(self._video_backend, "video_capabilities_for_tier", None)
-                caps = (
-                    tier_aware_caps(version_metadata.get("service_tier", "default"), resolution=resolution)
-                    if tier_aware_caps is not None
-                    else self._video_backend.video_capabilities
-                )
-                if caps.last_frame:
-                    actual_end_image = end_image  # first_last mode
-                else:
-                    logger.warning(
-                        "Video backend %s does not support last_frame, end_image will be ignored",
-                        self._video_backend.name,
-                    )
-
-            from lib.reference_compression import ReferenceSpec, RefRole
-
             video_backend = self._video_backend
             # FRAME（start/end 帧，永不缩尺寸）+ ARRAY（参考数组，完整梯子）按已知序位组织成
-            # specs，压缩后按 index 还原回三个请求字段。start_image 沿用现有 path 门控：仅 str/Path
-            # 文件源作 FRAME，PIL.Image / None 不入压缩器（维持原行为 request.start_image=None）。
-            specs: list[ReferenceSpec] = []
-            start_spec_idx: int | None = None
-            end_spec_idx: int | None = None
-            ref_start_idx: int | None = None
-
-            if isinstance(start_image, (str, Path)):
-                start_spec_idx = len(specs)
-                specs.append(ReferenceSpec(source=Path(start_image), label="", role=RefRole.FRAME))
-            if actual_end_image is not None:
-                end_spec_idx = len(specs)
-                specs.append(ReferenceSpec(source=Path(actual_end_image), label="", role=RefRole.FRAME))
-            if reference_images:
-                ref_start_idx = len(specs)
-                specs.extend(ReferenceSpec(source=Path(r), label="", role=RefRole.ARRAY) for r in reference_images)
+            # specs（见 lib/video_frame_slots.py），压缩后按 index 还原回三个请求字段。
+            specs = slot_plan.specs
+            start_spec_idx = slot_plan.start_index
+            end_spec_idx = slot_plan.end_index
+            ref_start_idx = slot_plan.reference_start_index
 
             def _call_video(compressed: "list[CompressedRef]"):
                 start_arg = compressed[start_spec_idx].path if start_spec_idx is not None else None

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
@@ -102,6 +103,20 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
         "seedance-1-0-lite-t2v",
         "seedance-1.0-lite-t2v",
     )
+    # 白名单命中后要求剩余部分为空或纯数字日期戳（如 "-251215"）——单纯 `in` 子串匹配会让
+    # "doubao-seedance-1-5-pro-future" 这类未上表的未知变体因包含 "seedance-1-5-pro" 而
+    # 被误判为继承已验证型号的尾帧能力，绕过本模块新增的硬拒绝。
+    _KNOWN_MODEL_SUFFIX_RE = re.compile(r"^(-\d+)?$")
+
+    @staticmethod
+    def _matches_known_model(model_lower: str, prefixes: tuple[str, ...]) -> bool:
+        for prefix in prefixes:
+            idx = model_lower.find(prefix)
+            if idx == -1:
+                continue
+            if ArkVideoBackend._KNOWN_MODEL_SUFFIX_RE.match(model_lower[idx + len(prefix) :]):
+                return True
+        return False
 
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
@@ -121,7 +136,9 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
         # 未命中白名单的一律 last_frame=False（含未来新增/自定义供应商的未知型号）。
         model_lower = model.lower()
         no_first_frame = any(sub in model_lower for sub in ArkVideoBackend._NO_FIRST_FRAME_SUBSTRINGS)
-        allowed_last_frame = any(sub in model_lower for sub in ArkVideoBackend._LAST_FRAME_ALLOW_SUBSTRINGS)
+        allowed_last_frame = ArkVideoBackend._matches_known_model(
+            model_lower, ArkVideoBackend._LAST_FRAME_ALLOW_SUBSTRINGS
+        )
         denied_last_frame = any(sub in model_lower for sub in ArkVideoBackend._NO_LAST_FRAME_SUBSTRINGS)
         return VideoCapabilities(
             first_frame=not no_first_frame, last_frame=allowed_last_frame and not denied_last_frame

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -80,6 +80,10 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
         model_lower = model.lower()
         return "seedance-2-0" in model_lower or "seedance-2.0" in model_lower
 
+    # docs/ark-docs/seedance2.0.md 能力表中「图生视频-首尾帧」标 "-" 的两个 1.0 系列型号：
+    # 1.0 pro fast 未开放首尾帧；1.0 lite t2v 是纯文生视频，不接受任何图片输入。
+    _NO_LAST_FRAME_SUBSTRINGS = ("seedance-1-0-pro-fast", "seedance-1-0-lite-t2v")
+
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
         """按 model_id 纯计算参考图等 caps —— 不构造 SDK client（无需 api_key）。
@@ -92,7 +96,12 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
             # cannot be mixed with reference media content，实测）——参考图是与首尾帧互斥的
             # 参考生视频模式，故不声明首帧叠加参考能力；若上游后续放开混合可重新开启。
             return VideoCapabilities(last_frame=True, reference_images=True, max_reference_images=9)
-        return VideoCapabilities()
+        # 非 2.0 系列：能力表除 1.0 pro fast / 1.0 lite t2v 外均支持首尾帧（含 DEFAULT_MODEL
+        # 1.5 pro），此前统一按 VideoCapabilities() 默认 last_frame=False 处理是误判——见
+        # test_first_last_frame_role_fields，1.5 pro 实测正常下发 role="last_frame"。
+        model_lower = model.lower()
+        no_last_frame = any(sub in model_lower for sub in ArkVideoBackend._NO_LAST_FRAME_SUBSTRINGS)
+        return VideoCapabilities(last_frame=not no_last_frame)
 
     @property
     def video_capabilities(self) -> VideoCapabilities:

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -80,12 +80,22 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
         model_lower = model.lower()
         return "seedance-2-0" in model_lower or "seedance-2.0" in model_lower
 
-    # docs/ark-docs/seedance2.0.md 能力表中「图生视频-首帧」「图生视频-首尾帧」标 "-" 的两个
-    # 1.0 系列型号：1.0 pro fast 支持首帧但未开放尾帧；1.0 lite t2v 是纯文生视频，首帧/尾帧均
-    # 不支持。子串同时收录连字符与点号两种版本号写法（如 "1-0" / "1.0"）——上游命名不统一，
-    # docs/ark-docs/火山方舟费用参考.md 中 doubao-seedance-1.0-pro-fast 即用点号，
-    # 自定义供应商配置也可能沿用该写法。
+    # docs/ark-docs/seedance2.0.md 能力表中，非 seedance-2.0 系列里明确支持首尾帧的仅这三个
+    # 1.x 型号（1.0 pro fast 与 1.0 lite t2v 标 "-"，其余未上表的型号未经验证）。改用白名单
+    # 而非黑名单：自定义供应商配置或上游新增的未知型号一律保守判定为不支持尾帧，避免错误声明
+    # 支持而绕过本模块新增的硬拒绝——一旦放行，真实不支持的型号会照样产生供应商侧调用与扣费，
+    # 与本 issue 的验收标准直接相悖。子串同时收录连字符与点号两种版本号写法（如 "1-0" /
+    # "1.0"）——上游命名不统一，docs/ark-docs/火山方舟费用参考.md 中 doubao-seedance-1.0-pro-fast
+    # 即用点号。
     _NO_FIRST_FRAME_SUBSTRINGS = ("seedance-1-0-lite-t2v", "seedance-1.0-lite-t2v")
+    _LAST_FRAME_ALLOW_SUBSTRINGS = (
+        "seedance-1-5-pro",
+        "seedance-1.5-pro",
+        "seedance-1-0-pro",
+        "seedance-1.0-pro",
+        "seedance-1-0-lite-i2v",
+        "seedance-1.0-lite-i2v",
+    )
     _NO_LAST_FRAME_SUBSTRINGS = (
         "seedance-1-0-pro-fast",
         "seedance-1.0-pro-fast",
@@ -105,13 +115,17 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
             # cannot be mixed with reference media content，实测）——参考图是与首尾帧互斥的
             # 参考生视频模式，故不声明首帧叠加参考能力；若上游后续放开混合可重新开启。
             return VideoCapabilities(last_frame=True, reference_images=True, max_reference_images=9)
-        # 非 2.0 系列：能力表除 1.0 pro fast / 1.0 lite t2v 外均支持首尾帧（含 DEFAULT_MODEL
-        # 1.5 pro），此前统一按 VideoCapabilities() 默认 last_frame=False 处理是误判——见
-        # test_first_last_frame_role_fields，1.5 pro 实测正常下发 role="last_frame"。
+        # 非 2.0 系列：DEFAULT_MODEL 1.5 pro 实测正常下发 role="last_frame"（见
+        # test_first_last_frame_role_fields），此前统一按 VideoCapabilities() 默认
+        # last_frame=False 处理是误判；白名单覆盖能力表已验证支持首尾帧的三个型号，
+        # 未命中白名单的一律 last_frame=False（含未来新增/自定义供应商的未知型号）。
         model_lower = model.lower()
         no_first_frame = any(sub in model_lower for sub in ArkVideoBackend._NO_FIRST_FRAME_SUBSTRINGS)
-        no_last_frame = any(sub in model_lower for sub in ArkVideoBackend._NO_LAST_FRAME_SUBSTRINGS)
-        return VideoCapabilities(first_frame=not no_first_frame, last_frame=not no_last_frame)
+        allowed_last_frame = any(sub in model_lower for sub in ArkVideoBackend._LAST_FRAME_ALLOW_SUBSTRINGS)
+        denied_last_frame = any(sub in model_lower for sub in ArkVideoBackend._NO_LAST_FRAME_SUBSTRINGS)
+        return VideoCapabilities(
+            first_frame=not no_first_frame, last_frame=allowed_last_frame and not denied_last_frame
+        )
 
     @property
     def video_capabilities(self) -> VideoCapabilities:

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -80,9 +80,18 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
         model_lower = model.lower()
         return "seedance-2-0" in model_lower or "seedance-2.0" in model_lower
 
-    # docs/ark-docs/seedance2.0.md 能力表中「图生视频-首尾帧」标 "-" 的两个 1.0 系列型号：
-    # 1.0 pro fast 未开放首尾帧；1.0 lite t2v 是纯文生视频，不接受任何图片输入。
-    _NO_LAST_FRAME_SUBSTRINGS = ("seedance-1-0-pro-fast", "seedance-1-0-lite-t2v")
+    # docs/ark-docs/seedance2.0.md 能力表中「图生视频-首帧」「图生视频-首尾帧」标 "-" 的两个
+    # 1.0 系列型号：1.0 pro fast 支持首帧但未开放尾帧；1.0 lite t2v 是纯文生视频，首帧/尾帧均
+    # 不支持。子串同时收录连字符与点号两种版本号写法（如 "1-0" / "1.0"）——上游命名不统一，
+    # docs/ark-docs/火山方舟费用参考.md 中 doubao-seedance-1.0-pro-fast 即用点号，
+    # 自定义供应商配置也可能沿用该写法。
+    _NO_FIRST_FRAME_SUBSTRINGS = ("seedance-1-0-lite-t2v", "seedance-1.0-lite-t2v")
+    _NO_LAST_FRAME_SUBSTRINGS = (
+        "seedance-1-0-pro-fast",
+        "seedance-1.0-pro-fast",
+        "seedance-1-0-lite-t2v",
+        "seedance-1.0-lite-t2v",
+    )
 
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
@@ -100,8 +109,9 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
         # 1.5 pro），此前统一按 VideoCapabilities() 默认 last_frame=False 处理是误判——见
         # test_first_last_frame_role_fields，1.5 pro 实测正常下发 role="last_frame"。
         model_lower = model.lower()
+        no_first_frame = any(sub in model_lower for sub in ArkVideoBackend._NO_FIRST_FRAME_SUBSTRINGS)
         no_last_frame = any(sub in model_lower for sub in ArkVideoBackend._NO_LAST_FRAME_SUBSTRINGS)
-        return VideoCapabilities(last_frame=not no_last_frame)
+        return VideoCapabilities(first_frame=not no_first_frame, last_frame=not no_last_frame)
 
     @property
     def video_capabilities(self) -> VideoCapabilities:

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -108,6 +108,19 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
     # 被误判为继承已验证型号的尾帧能力，绕过本模块新增的硬拒绝。
     _KNOWN_MODEL_SUFFIX_RE = re.compile(r"^(-\d+)?$")
 
+    # Seedance 2.0 系列已验证支持首尾帧的三个变体（lib/config/registry.py 内建型号：
+    # doubao-seedance-2-0-260128 / -2-0-fast-260128 / -2-0-mini-260615，及无日期戳的
+    # doubao-seedance-2.0 / -2.0-fast / -2.0-mini）。同样走边界匹配，未知后缀（如
+    # "doubao-seedance-2-0-future"）不得因子串包含 "seedance-2-0" 而继承尾帧能力。
+    _SEEDANCE_2_LAST_FRAME_ALLOW_SUBSTRINGS = (
+        "seedance-2-0-fast",
+        "seedance-2.0-fast",
+        "seedance-2-0-mini",
+        "seedance-2.0-mini",
+        "seedance-2-0",
+        "seedance-2.0",
+    )
+
     @staticmethod
     def _matches_known_model(model_lower: str, prefixes: tuple[str, ...]) -> bool:
         for prefix in prefixes:
@@ -129,7 +142,12 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
             # API 拒绝首帧/尾帧与参考素材混合请求（InvalidParameter: first/last frame content
             # cannot be mixed with reference media content，实测）——参考图是与首尾帧互斥的
             # 参考生视频模式，故不声明首帧叠加参考能力；若上游后续放开混合可重新开启。
-            return VideoCapabilities(last_frame=True, reference_images=True, max_reference_images=9)
+            # last_frame 单独走边界校验的已验证型号白名单：_is_seedance_2 本身只做宽松族群
+            # 识别（供 FLEX_TIER 剔除复用），未验证的 2.0 系列未来变体不应继承尾帧能力。
+            verified_last_frame = ArkVideoBackend._matches_known_model(
+                model.lower(), ArkVideoBackend._SEEDANCE_2_LAST_FRAME_ALLOW_SUBSTRINGS
+            )
+            return VideoCapabilities(last_frame=verified_last_frame, reference_images=True, max_reference_images=9)
         # 非 2.0 系列：DEFAULT_MODEL 1.5 pro 实测正常下发 role="last_frame"（见
         # test_first_last_frame_role_fields），此前统一按 VideoCapabilities() 默认
         # last_frame=False 处理是误判；白名单覆盖能力表已验证支持首尾帧的三个型号，

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -236,9 +236,11 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         #
         # last_frame_requires_pro 为真的 model（kling-v2-5-turbo、kling-v2-6）：该位不按 service_tier
         # 分档——service_tier 是逐请求字段（generation_tasks 入队时选定），本函数只按 model 声明、
-        # 无从得知调用方将选哪档。std/4k 档提交尾帧会被 _build_payload 的 fail-loud 护栏拒绝，declare
-        # 一个仅在少数档位成立的 True 会让 media_generator 按此位放行 end_image、多数请求撞 guard 硬失败；
-        # 保守声明 False 更贴近默认档的真实执行结果，与未登记 model 回落保守默认同一原则。
+        # 无从得知调用方将选哪档。std/4k 档提交尾帧会被拒绝——有 tier 上下文的调用方走
+        # video_capabilities_for_tier 在 media_generator 处拒，能力被用户覆盖放行时由
+        # _build_payload 的 fail-loud 护栏兜底。declare 一个仅在少数档位成立的 True 会让无 tier
+        # 上下文的调用方按此位放行 end_image、多数请求撞硬失败；保守声明 False 更贴近默认档的
+        # 真实执行结果，与未登记 model 回落保守默认同一原则。
         caps = _lookup_video_caps(model)
         return VideoCapabilities(
             first_frame=True,

--- a/lib/video_frame_slots.py
+++ b/lib/video_frame_slots.py
@@ -1,0 +1,102 @@
+"""视频生成的帧槽位规划：能力 gating + 参考图槽位组装。
+
+从 ``MediaGenerator.generate_video_async`` 抽出的纯函数，不触碰记账、版本管理与
+provider 调用，可独立导入并直接单测各能力组合分支。
+
+槽位序位是与 ``lib.reference_compression`` 的契约：压缩器按 index 原样返回压缩后的
+路径列表，调用方据 ``FrameSlotPlan`` 上的三个索引还原回 ``VideoGenerationRequest``
+的 ``start_image`` / ``end_image`` / ``reference_images`` 三个字段。数组参考图恒排在
+首/尾帧之后，故用一个起始索引即可切出全部数组项。
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from lib.video_backends.base import VideoCapabilities, VideoCapabilityError
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+    from lib.reference_compression import ReferenceSpec
+
+__all__ = ["FrameSlotPlan", "plan_frame_slots", "resolve_video_capabilities"]
+
+
+def resolve_video_capabilities(
+    backend: Any,
+    *,
+    service_tier: str = "default",
+    resolution: str | None = None,
+) -> VideoCapabilities:
+    """解析后端在本次请求档位下的视频能力。
+
+    优先取 ``video_capabilities_for_tier``（若后端实现）：某些后端（如 Kling）的
+    ``last_frame`` 仅在特定 ``service_tier`` 生效，无请求上下文的 ``video_capabilities``
+    属性只能保守声明，会让合法档位的请求被误判为不支持。
+    """
+    tier_aware = getattr(backend, "video_capabilities_for_tier", None)
+    if tier_aware is not None:
+        return tier_aware(service_tier, resolution=resolution)
+    return backend.video_capabilities
+
+
+@dataclass(frozen=True)
+class FrameSlotPlan:
+    """压缩器输入 specs 及各请求字段在其中的序位。
+
+    ``start_index`` / ``end_index`` 为 None 表示该槽位本次不下发；
+    ``reference_start_index`` 为 None 表示无可压缩的数组参考项，调用方回落原
+    ``reference_images``（保留 None / [] 语义）。
+    """
+
+    specs: "list[ReferenceSpec]"
+    start_index: int | None = None
+    end_index: int | None = None
+    reference_start_index: int | None = None
+
+
+def plan_frame_slots(
+    *,
+    caps: VideoCapabilities,
+    provider: str,
+    model: str,
+    start_image: "str | Path | Image.Image | None" = None,
+    end_image: Path | None = None,
+    reference_images: "list[Path] | None" = None,
+) -> FrameSlotPlan:
+    """按后端能力组装帧/参考图槽位，能力不支持尾帧时硬失败。
+
+    尾帧不做降级：参考图是与首帧互斥的独立路径，把尾帧转投参考图会丢掉首帧语义；
+    静默丢弃尾帧则会照常生成并扣费、产出与用户意图不符的视频。故 ``caps.last_frame``
+    为假而请求携带尾帧时抛 ``VideoCapabilityError``，由上层渲染成用户可读错误。
+
+    ``start_image`` 仅 ``str`` / ``Path`` 文件源进压缩器；``PIL.Image`` 与 None 不入
+    specs（对应请求字段保持 None），维持原有行为。
+    """
+    if end_image is not None and not caps.last_frame:
+        raise VideoCapabilityError("video_last_frame_unsupported", provider=provider, model=model)
+
+    from lib.reference_compression import ReferenceSpec, RefRole
+
+    specs: list[ReferenceSpec] = []
+    start_index: int | None = None
+    end_index: int | None = None
+    reference_start_index: int | None = None
+
+    if isinstance(start_image, (str, Path)):
+        start_index = len(specs)
+        specs.append(ReferenceSpec(source=Path(start_image), label="", role=RefRole.FRAME))
+    if end_image is not None:
+        end_index = len(specs)
+        specs.append(ReferenceSpec(source=Path(end_image), label="", role=RefRole.FRAME))
+    if reference_images:
+        reference_start_index = len(specs)
+        specs.extend(ReferenceSpec(source=Path(r), label="", role=RefRole.ARRAY) for r in reference_images)
+
+    return FrameSlotPlan(
+        specs=specs,
+        start_index=start_index,
+        end_index=end_index,
+        reference_start_index=reference_start_index,
+    )

--- a/lib/video_frame_slots.py
+++ b/lib/video_frame_slots.py
@@ -11,7 +11,7 @@ provider 调用，可独立导入并直接单测各能力组合分支。
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Protocol
 
 from lib.video_backends.base import VideoCapabilities, VideoCapabilityError
 
@@ -20,11 +20,23 @@ if TYPE_CHECKING:
 
     from lib.reference_compression import ReferenceSpec
 
-__all__ = ["FrameSlotPlan", "plan_frame_slots", "resolve_video_capabilities"]
+__all__ = ["FrameSlotPlan", "VideoCapabilityProbe", "plan_frame_slots", "resolve_video_capabilities"]
+
+
+class VideoCapabilityProbe(Protocol):
+    """能力查询实际需要的最小后端接口：只读能力声明，不碰 generate / resume。
+
+    比 ``VideoBackend`` 窄是有意的——收窄到用得着的那一个成员，调用方与测试替身都不必
+    为一次能力查询实现整个生成协议。档位感知的 ``video_capabilities_for_tier`` 不在此列，
+    它是可选成员，由 ``resolve_video_capabilities`` 探测。
+    """
+
+    @property
+    def video_capabilities(self) -> VideoCapabilities: ...
 
 
 def resolve_video_capabilities(
-    backend: Any,
+    backend: VideoCapabilityProbe,
     *,
     service_tier: str = "default",
     resolution: str | None = None,
@@ -58,7 +70,7 @@ class FrameSlotPlan:
 
 def plan_frame_slots(
     *,
-    caps: VideoCapabilities,
+    caps: VideoCapabilities | None,
     provider: str,
     model: str,
     start_image: "str | Path | Image.Image | None" = None,
@@ -71,10 +83,14 @@ def plan_frame_slots(
     静默丢弃尾帧则会照常生成并扣费、产出与用户意图不符的视频。故 ``caps.last_frame``
     为假而请求携带尾帧时抛 ``VideoCapabilityError``，由上层渲染成用户可读错误。
 
+    ``caps`` 为 None 表示调用方未查询后端能力——无尾帧诉求时能力声明不影响任何槽位，
+    调用方可省去这次查询。传 None 却带尾帧一律按不支持拒绝，而不是放行：占位一份
+    "支持尾帧"的假能力会让未经能力核实的尾帧下发出去，正是本函数要堵的降级。
+
     ``start_image`` 仅 ``str`` / ``Path`` 文件源进压缩器；``PIL.Image`` 与 None 不入
     specs（对应请求字段保持 None），维持原有行为。
     """
-    if end_image is not None and not caps.last_frame:
+    if end_image is not None and (caps is None or not caps.last_frame):
         raise VideoCapabilityError("video_last_frame_unsupported", provider=provider, model=model)
 
     from lib.reference_compression import ReferenceSpec, RefRole

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -31,9 +31,11 @@ VIDEO_MODEL = "sora-2"
 
 # openai-video 的 delegate 不序列化 end_image（见 _check_capability_overrides 的
 # end_image_capable 门槛），last_frame 覆盖为 True 的用例须换一个真正支持尾帧的 endpoint。
-# ark-seedance 非 seedance-2 系列模型系统判定同样是 last_frame=False，可类比断言覆盖前后差异。
+# ark-seedance 的 1.0 pro fast 系统判定 last_frame=False（docs/ark-docs/seedance2.0.md
+# 能力表标 "-"），可类比断言覆盖前后差异；不用 seedance-2 系列是因为那两系模型系统判定
+# 本身就是 True，无法体现覆盖生效前后的差异。
 LAST_FRAME_ENDPOINT = "ark-seedance"
-LAST_FRAME_MODEL = "seedance-1-pro"
+LAST_FRAME_MODEL = "doubao-seedance-1-0-pro-fast-251015"
 
 
 @pytest.fixture()

--- a/tests/test_custom_provider_capabilities.py
+++ b/tests/test_custom_provider_capabilities.py
@@ -76,7 +76,7 @@ class TestSynthesize:
     def test_missing_key_follows_system(self):
         """字典存在但缺某键 → 该维度跟随系统判定，其余键照常覆盖。"""
         caps = synthesize_video_capabilities(
-            endpoint="ark-seedance", model_id="seedance-1-pro", overrides={"last_frame": True}
+            endpoint="ark-seedance", model_id="doubao-seedance-1-0-pro-fast-251015", overrides={"last_frame": True}
         )
         assert caps.last_frame is True
         assert caps.first_frame is True
@@ -85,7 +85,9 @@ class TestSynthesize:
     @pytest.mark.unit
     def test_force_on(self):
         caps = synthesize_video_capabilities(
-            endpoint="ark-seedance", model_id="seedance-1-pro", overrides={"last_frame": True, "reference_images": True}
+            endpoint="ark-seedance",
+            model_id="doubao-seedance-1-0-pro-fast-251015",
+            overrides={"last_frame": True, "reference_images": True},
         )
         assert caps.last_frame is True
         assert caps.reference_images is True
@@ -125,9 +127,9 @@ class TestSynthesize:
     def test_system_capabilities_not_mutated_across_calls(self):
         """合成返回新实例，不得就地改写系统判定（caps_fn 可能返回共享对象）。"""
         first = synthesize_video_capabilities(
-            endpoint="ark-seedance", model_id="seedance-1-pro", overrides={"last_frame": True}
+            endpoint="ark-seedance", model_id="doubao-seedance-1-0-pro-fast-251015", overrides={"last_frame": True}
         )
-        second = system_video_capabilities(endpoint="ark-seedance", model_id="seedance-1-pro")
+        second = system_video_capabilities(endpoint="ark-seedance", model_id="doubao-seedance-1-0-pro-fast-251015")
         assert first.last_frame is True
         assert second.last_frame is False
 
@@ -144,7 +146,7 @@ class TestTolerance:
         with caplog.at_level(logging.WARNING, logger="lib.custom_provider.capabilities"):
             caps = synthesize_video_capabilities(
                 endpoint="ark-seedance",
-                model_id="seedance-1-pro",
+                model_id="doubao-seedance-1-0-pro-fast-251015",
                 overrides={"last_frame": True, "audio_track": True},
             )
         assert caps.last_frame is True

--- a/tests/test_custom_provider_capabilities.py
+++ b/tests/test_custom_provider_capabilities.py
@@ -76,10 +76,10 @@ class TestSynthesize:
     def test_missing_key_follows_system(self):
         """字典存在但缺某键 → 该维度跟随系统判定，其余键照常覆盖。"""
         caps = synthesize_video_capabilities(
-            endpoint="ark-seedance", model_id="doubao-seedance-1-0-pro-fast-251015", overrides={"last_frame": True}
+            endpoint="ark-seedance", model_id="doubao-seedance-1-0-pro-fast-251015", overrides={"first_frame": False}
         )
-        assert caps.last_frame is True
-        assert caps.first_frame is True
+        assert caps.first_frame is False
+        assert caps.last_frame is False
         assert caps.max_reference_images == 0
 
     @pytest.mark.unit

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -310,24 +310,27 @@ class TestMediaGenerator:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
-    async def test_end_image_ignored_when_backend_lacks_last_frame(self, tmp_path):
-        """后端 last_frame=False 时忽略 end_image 并告警，不降级为参考图。"""
-        from lib.video_backends.base import VideoCapabilities
+    async def test_end_image_rejected_when_backend_lacks_last_frame(self, tmp_path):
+        """后端 last_frame=False 时硬失败：不下发供应商调用、不开记账，也不降级为参考图。"""
+        from lib.video_backends.base import VideoCapabilities, VideoCapabilityError
 
         gen = _build_generator(tmp_path)
         gen._video_backend = _FakeVideoBackend(video_capabilities=VideoCapabilities(last_frame=False))
         end_image = tmp_path / "end.png"
         end_image.write_bytes(b"fake-end-image")
+        started_before = len(gen.ledger.started)
 
-        await gen.generate_video_async(
-            prompt="p",
-            resource_type="videos",
-            resource_id="E1S06",
-            end_image=end_image,
-        )
-        call = gen._video_backend.calls[0]
-        assert call.end_image is None
-        assert call.reference_images is None
+        with pytest.raises(VideoCapabilityError) as exc:
+            await gen.generate_video_async(
+                prompt="p",
+                resource_type="videos",
+                resource_id="E1S06",
+                end_image=end_image,
+            )
+
+        assert exc.value.code == "video_last_frame_unsupported"
+        assert gen._video_backend.calls == []
+        assert len(gen.ledger.started) == started_before
 
     @pytest.mark.integration
     @pytest.mark.asyncio
@@ -362,9 +365,9 @@ class TestMediaGenerator:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
-    async def test_end_image_ignored_when_tier_aware_backend_reports_std_tier(self, tmp_path):
-        """同一后端，std 档时仍按能力收窄拒绝转发——覆盖 pro/std 两条分支。"""
-        from lib.video_backends.base import VideoCapabilities
+    async def test_end_image_rejected_when_tier_aware_backend_reports_std_tier(self, tmp_path):
+        """同一后端，std 档时仍按能力收窄硬失败——覆盖 pro/std 两条分支。"""
+        from lib.video_backends.base import VideoCapabilities, VideoCapabilityError
 
         class _TierAwareVideoBackend(_FakeVideoBackend):
             def __init__(self):
@@ -379,16 +382,20 @@ class TestMediaGenerator:
         gen._video_backend = _TierAwareVideoBackend()
         end_image = tmp_path / "end.png"
         end_image.write_bytes(b"fake-end-image")
+        started_before = len(gen.ledger.started)
 
-        await gen.generate_video_async(
-            prompt="p",
-            resource_type="videos",
-            resource_id="E1S08",
-            end_image=end_image,
-            service_tier="std",
-        )
-        call = gen._video_backend.calls[0]
-        assert call.end_image is None
+        with pytest.raises(VideoCapabilityError) as exc:
+            await gen.generate_video_async(
+                prompt="p",
+                resource_type="videos",
+                resource_id="E1S08",
+                end_image=end_image,
+                service_tier="std",
+            )
+
+        assert exc.value.code == "video_last_frame_unsupported"
+        assert gen._video_backend.calls == []
+        assert len(gen.ledger.started) == started_before
 
 
 # ── 咽喉层参考图压缩接线 ────────────────────────────────────────────────────

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -397,6 +397,26 @@ class TestMediaGenerator:
         assert gen._video_backend.calls == []
         assert len(gen.ledger.started) == started_before
 
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_empty_string_end_image_normalized_to_no_end_frame(self, tmp_path):
+        """遗留/直接调用者以 end_image="" 表示无尾帧：即便后端不支持 last_frame 也应正常放行，
+        不误判为携带尾帧而硬失败（与 kling _build_payload 的真值判断兼容语义对齐）。"""
+        from lib.video_backends.base import VideoCapabilities
+
+        gen = _build_generator(tmp_path)
+        gen._video_backend = _FakeVideoBackend(video_capabilities=VideoCapabilities(last_frame=False))
+
+        await gen.generate_video_async(
+            prompt="p",
+            resource_type="videos",
+            resource_id="E1S09",
+            end_image="",
+        )
+
+        call = gen._video_backend.calls[0]
+        assert call.end_image is None
+
 
 # ── 咽喉层参考图压缩接线 ────────────────────────────────────────────────────
 

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -421,6 +421,20 @@ class TestArkModelCapabilities:
         assert caps.last_frame is False
 
     @pytest.mark.unit
+    def test_seedance_1_0_pro_non_fast_supports_last_frame(self):
+        """能力表标首尾帧 ✅；型号名含 "seedance-1-0-pro" 是 "seedance-1-0-pro-fast" 的前缀子串，
+        验证白名单与黑名单的先后顺序不会把非 fast 型号误判为不支持。"""
+        caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-0-pro-250528")
+        assert caps.last_frame is True
+
+    @pytest.mark.unit
+    def test_unknown_model_defaults_to_no_last_frame(self):
+        """白名单而非黑名单：能力表之外的未知型号（自定义供应商新配置、上游未来新增）一律保守
+        判定为不支持尾帧，避免错误声明支持而绕过硬拒绝、产生真实供应商调用与扣费。"""
+        caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-9-9-ultra-future")
+        assert caps.last_frame is False
+
+    @pytest.mark.unit
     def test_seedance_1_0_lite_t2v_no_last_frame(self):
         """纯文生视频型号，能力表「图生视频-首帧」「图生视频-首尾帧」均标 "-"，不接受任何图片输入。"""
         caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-0-lite-t2v-250428")

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -401,6 +401,26 @@ class TestArkModelCapabilities:
         caps = b.capabilities
         assert VideoCapability.FLEX_TIER in caps
 
+    def test_seedance_1_5_pro_default_model_supports_last_frame(self):
+        """DEFAULT_MODEL：能力表标首尾帧 ✅，实测 generate() 正常下发 role=last_frame。"""
+        caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-5-pro-251215")
+        assert caps.last_frame is True
+
+    def test_seedance_1_0_pro_fast_no_last_frame(self):
+        """能力表「图生视频-首尾帧」列该型号标 "-"。"""
+        caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-0-pro-fast-251015")
+        assert caps.last_frame is False
+
+    def test_seedance_1_0_lite_t2v_no_last_frame(self):
+        """纯文生视频型号，不接受任何图片输入。"""
+        caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-0-lite-t2v-250428")
+        assert caps.last_frame is False
+
+    def test_seedance_1_0_lite_i2v_supports_last_frame(self):
+        """能力表标首尾帧 ✅，且型号名含 "lite-t2v" 判定串的邻近变体，验证不误命中。"""
+        caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-0-lite-i2v-250428")
+        assert caps.last_frame is True
+
     def test_seedance_2_dot_format_no_flex_tier(self):
         """ark-agent-plan 用 dot 命名（doubao-seedance-2.0），同样不该带 FLEX_TIER。"""
         with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -455,6 +455,29 @@ class TestArkModelCapabilities:
         assert caps.first_frame is True
         assert caps.last_frame is True
 
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "doubao-seedance-2-0-260128",
+            "doubao-seedance-2-0-fast-260128",
+            "doubao-seedance-2-0-mini-260615",
+            "doubao-seedance-2.0",
+            "doubao-seedance-2.0-fast",
+            "doubao-seedance-2.0-mini",
+        ],
+    )
+    def test_seedance_2_known_variants_support_last_frame(self, model: str):
+        caps = ArkVideoBackend.video_capabilities_for_model(model)
+        assert caps.last_frame is True
+
+    @pytest.mark.unit
+    def test_seedance_2_unknown_suffix_does_not_inherit_last_frame(self):
+        """白名单命中要求边界匹配：型号名包含已验证前缀 "seedance-2-0" 但带未知后缀
+        （非已验证的 fast/mini/日期戳形态）时，不能因子串包含关系继承 2.0 系列的尾帧能力。"""
+        caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-2-0-future")
+        assert caps.last_frame is False
+
     def test_seedance_2_dot_format_no_flex_tier(self):
         """ark-agent-plan 用 dot 命名（doubao-seedance-2.0），同样不该带 FLEX_TIER。"""
         with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -435,6 +435,13 @@ class TestArkModelCapabilities:
         assert caps.last_frame is False
 
     @pytest.mark.unit
+    def test_unknown_suffix_on_known_prefix_does_not_inherit_last_frame(self):
+        """白名单命中要求边界匹配：型号名包含已验证前缀 "seedance-1-5-pro" 但带未知后缀
+        （非纯数字日期戳）时，不能因子串包含关系继承该前缀型号的尾帧能力。"""
+        caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-5-pro-future")
+        assert caps.last_frame is False
+
+    @pytest.mark.unit
     def test_seedance_1_0_lite_t2v_no_last_frame(self):
         """纯文生视频型号，能力表「图生视频-首帧」「图生视频-首尾帧」均标 "-"，不接受任何图片输入。"""
         caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-0-lite-t2v-250428")

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -401,24 +401,37 @@ class TestArkModelCapabilities:
         caps = b.capabilities
         assert VideoCapability.FLEX_TIER in caps
 
+    @pytest.mark.unit
     def test_seedance_1_5_pro_default_model_supports_last_frame(self):
         """DEFAULT_MODEL：能力表标首尾帧 ✅，实测 generate() 正常下发 role=last_frame。"""
         caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-5-pro-251215")
         assert caps.last_frame is True
 
+    @pytest.mark.unit
     def test_seedance_1_0_pro_fast_no_last_frame(self):
-        """能力表「图生视频-首尾帧」列该型号标 "-"。"""
+        """能力表「图生视频-首尾帧」列该型号标 "-"，但「图生视频-首帧」列仍是 ✅。"""
         caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-0-pro-fast-251015")
+        assert caps.first_frame is True
         assert caps.last_frame is False
 
+    @pytest.mark.unit
+    def test_seedance_1_0_pro_fast_dot_naming_no_last_frame(self):
+        """上游命名不统一：费用文档用点号 "1.0" 而非连字符 "1-0"，判定须同时兼容两种写法。"""
+        caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1.0-pro-fast")
+        assert caps.last_frame is False
+
+    @pytest.mark.unit
     def test_seedance_1_0_lite_t2v_no_last_frame(self):
-        """纯文生视频型号，不接受任何图片输入。"""
+        """纯文生视频型号，能力表「图生视频-首帧」「图生视频-首尾帧」均标 "-"，不接受任何图片输入。"""
         caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-0-lite-t2v-250428")
+        assert caps.first_frame is False
         assert caps.last_frame is False
 
+    @pytest.mark.unit
     def test_seedance_1_0_lite_i2v_supports_last_frame(self):
         """能力表标首尾帧 ✅，且型号名含 "lite-t2v" 判定串的邻近变体，验证不误命中。"""
         caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-0-lite-i2v-250428")
+        assert caps.first_frame is True
         assert caps.last_frame is True
 
     def test_seedance_2_dot_format_no_flex_tier(self):

--- a/tests/test_video_frame_slots.py
+++ b/tests/test_video_frame_slots.py
@@ -1,0 +1,129 @@
+"""帧槽位规划纯函数的直接单测：能力 gating × 槽位组装各组合分支。"""
+
+from pathlib import Path
+
+import pytest
+
+from lib.reference_compression import RefRole
+from lib.video_backends.base import VideoCapabilities, VideoCapabilityError
+from lib.video_frame_slots import plan_frame_slots, resolve_video_capabilities
+
+CAPS_WITH_LAST_FRAME = VideoCapabilities(
+    first_frame=True, last_frame=True, reference_images=True, max_reference_images=4
+)
+CAPS_NO_LAST_FRAME = VideoCapabilities(
+    first_frame=True, last_frame=False, reference_images=True, max_reference_images=4
+)
+
+
+def _plan(caps: VideoCapabilities, **kwargs):
+    return plan_frame_slots(caps=caps, provider="acme", model="acme-v1", **kwargs)
+
+
+class TestLastFrameGating:
+    def test_unsupported_last_frame_with_end_image_raises(self):
+        """不支持尾帧 × 携带尾帧：硬失败，不静默降级。"""
+        with pytest.raises(VideoCapabilityError) as exc:
+            _plan(CAPS_NO_LAST_FRAME, start_image=Path("start.png"), end_image=Path("end.png"))
+
+        assert exc.value.code == "video_last_frame_unsupported"
+        assert exc.value.params == {"provider": "acme", "model": "acme-v1"}
+
+    def test_unsupported_last_frame_without_end_image_passes(self):
+        """不支持尾帧 × 不携带尾帧：正常放行，无尾帧槽位。"""
+        plan = _plan(CAPS_NO_LAST_FRAME, start_image=Path("start.png"))
+
+        assert plan.end_index is None
+        assert [s.source for s in plan.specs] == [Path("start.png")]
+
+    def test_supported_last_frame_with_end_image_passes(self):
+        """支持尾帧 × 携带尾帧：尾帧进入槽位（first_last 模式）。"""
+        plan = _plan(CAPS_WITH_LAST_FRAME, start_image=Path("start.png"), end_image=Path("end.png"))
+
+        assert plan.start_index == 0
+        assert plan.end_index == 1
+        assert [s.role for s in plan.specs] == [RefRole.FRAME, RefRole.FRAME]
+
+    def test_supported_last_frame_without_end_image_passes(self):
+        plan = _plan(CAPS_WITH_LAST_FRAME, start_image=Path("start.png"))
+
+        assert plan.end_index is None
+        assert plan.start_index == 0
+
+    def test_end_image_without_start_image_still_gated(self):
+        """尾帧单独出现同样受 gating——不因缺首帧而绕过。"""
+        with pytest.raises(VideoCapabilityError):
+            _plan(CAPS_NO_LAST_FRAME, end_image=Path("end.png"))
+
+    def test_end_image_only_takes_first_slot_when_supported(self):
+        plan = _plan(CAPS_WITH_LAST_FRAME, end_image=Path("end.png"))
+
+        assert plan.start_index is None
+        assert plan.end_index == 0
+
+
+class TestSlotAssembly:
+    def test_no_inputs_yields_empty_plan(self):
+        plan = _plan(CAPS_WITH_LAST_FRAME)
+
+        assert plan.specs == []
+        assert (plan.start_index, plan.end_index, plan.reference_start_index) == (None, None, None)
+
+    def test_reference_images_follow_frames(self):
+        """数组参考图恒排在首/尾帧之后，调用方按起始索引切片还原。"""
+        plan = _plan(
+            CAPS_WITH_LAST_FRAME,
+            start_image=Path("start.png"),
+            end_image=Path("end.png"),
+            reference_images=[Path("r1.png"), Path("r2.png")],
+        )
+
+        assert (plan.start_index, plan.end_index, plan.reference_start_index) == (0, 1, 2)
+        assert [s.role for s in plan.specs] == [RefRole.FRAME, RefRole.FRAME, RefRole.ARRAY, RefRole.ARRAY]
+        assert [s.source for s in plan.specs[plan.reference_start_index :]] == [Path("r1.png"), Path("r2.png")]
+
+    def test_empty_reference_list_yields_no_reference_index(self):
+        """空列表与 None 同义：不设起始索引，调用方回落原字段保留 [] / None 语义。"""
+        plan = _plan(CAPS_WITH_LAST_FRAME, start_image=Path("start.png"), reference_images=[])
+
+        assert plan.reference_start_index is None
+        assert len(plan.specs) == 1
+
+    def test_str_start_image_normalized_to_path(self):
+        plan = _plan(CAPS_WITH_LAST_FRAME, start_image="start.png")
+
+        assert plan.specs[0].source == Path("start.png")
+
+    def test_pil_start_image_skips_compression(self):
+        """PIL.Image 首帧不入压缩器，维持 request.start_image=None 的原行为。"""
+        from PIL import Image
+
+        plan = _plan(CAPS_WITH_LAST_FRAME, start_image=Image.new("RGB", (2, 2)), end_image=Path("end.png"))
+
+        assert plan.start_index is None
+        assert plan.end_index == 0
+
+
+class TestResolveVideoCapabilities:
+    def test_prefers_tier_aware_query(self):
+        """后端实现 video_capabilities_for_tier 时按实际档位收窄，而非读保守属性。"""
+        seen: dict[str, object] = {}
+
+        class TierAwareBackend:
+            video_capabilities = CAPS_NO_LAST_FRAME
+
+            def video_capabilities_for_tier(self, service_tier: str, resolution: str | None = None):
+                seen["service_tier"] = service_tier
+                seen["resolution"] = resolution
+                return CAPS_WITH_LAST_FRAME
+
+        caps = resolve_video_capabilities(TierAwareBackend(), service_tier="pro", resolution="1080p")
+
+        assert caps.last_frame is True
+        assert seen == {"service_tier": "pro", "resolution": "1080p"}
+
+    def test_falls_back_to_static_property(self):
+        class PlainBackend:
+            video_capabilities = CAPS_NO_LAST_FRAME
+
+        assert resolve_video_capabilities(PlainBackend()).last_frame is False

--- a/tests/test_video_frame_slots.py
+++ b/tests/test_video_frame_slots.py
@@ -16,7 +16,7 @@ CAPS_NO_LAST_FRAME = VideoCapabilities(
 )
 
 
-def _plan(caps: VideoCapabilities, **kwargs):
+def _plan(caps: VideoCapabilities | None, **kwargs):
     return plan_frame_slots(caps=caps, provider="acme", model="acme-v1", **kwargs)
 
 
@@ -60,6 +60,19 @@ class TestLastFrameGating:
 
         assert plan.start_index is None
         assert plan.end_index == 0
+
+    def test_uncharted_caps_without_end_image_passes(self):
+        """caps=None（调用方未查询能力）× 不携带尾帧：能力不影响任何槽位，正常放行。"""
+        plan = _plan(None, start_image=Path("start.png"), reference_images=[Path("r1.png")])
+
+        assert (plan.start_index, plan.end_index, plan.reference_start_index) == (0, None, 1)
+
+    def test_uncharted_caps_with_end_image_raises(self):
+        """caps=None × 携带尾帧：未经能力核实的尾帧一律拒绝，不按"支持"放行。"""
+        with pytest.raises(VideoCapabilityError) as exc:
+            _plan(None, start_image=Path("start.png"), end_image=Path("end.png"))
+
+        assert exc.value.code == "video_last_frame_unsupported"
 
 
 class TestSlotAssembly:

--- a/tests/test_video_frame_slots.py
+++ b/tests/test_video_frame_slots.py
@@ -8,6 +8,8 @@ from lib.reference_compression import RefRole
 from lib.video_backends.base import VideoCapabilities, VideoCapabilityError
 from lib.video_frame_slots import plan_frame_slots, resolve_video_capabilities
 
+pytestmark = pytest.mark.unit
+
 CAPS_WITH_LAST_FRAME = VideoCapabilities(
     first_frame=True, last_frame=True, reference_images=True, max_reference_images=4
 )


### PR DESCRIPTION
Closes #1332

## 变更

后端能力不支持 `last_frame` 而请求携带尾帧时，原先 `logger.warning` 后丢弃尾帧槽位、照常生成并扣费——用户拿到一段不符合意图的视频，还付了钱。改为硬失败：拒绝生成、不产生供应商侧调用与扣费，返回三语可读错误。

尾帧/参考图的槽位组装与能力 gating 从 `generate_video_async` 抽出为 `lib/video_frame_slots.py` 的纯函数，各能力组合分支得到直接单测覆盖（此前只能靠上层集成测试间接覆盖）。

## 实现要点

- gating 前置到 `ledger.record` 括号**之前**：括号内抛虽也不结算费用，却会留一条 failed ApiCall 行。
- 能力查询保持惰性：仅 `end_image is not None` 时才查询后端能力，不给无尾帧路径新增后端属性依赖；未查询时传 `caps=None`，带尾帧时按不支持拒绝。
- 新错误 code `video_last_frame_unsupported`，与既有 `video_reference_images_unsupported` 同构。文案同时指出「换模型」与「换档位」两条出路——Kling 部分模型的首尾帧仅 pro 档生效，这类请求在 gating 处即被拒，只提换模型会误导。

## 验证

- `uv run python -m pytest`：6385 passed
- `uv run ruff check . && uv run ruff format .`：clean
- `uv run basedpyright`：0 errors（`lib/video_frame_slots.py` 与其测试 0 warnings）
- 行为等价性（验收标准 3）：`plan_frame_slots` 与原内联逻辑逐分支比对——`start_image` 的 str/Path→FRAME 与 PIL/None 不入 specs、`reference_images` 的 None/`[]` 同义回落、specs 序位与三个索引的还原路径一一对应。
- 不扣费（验收标准 1）：集成测试断言硬失败时 `backend.calls == []` 且 ledger 未开新行；错误经 `execute_generation_task` 的 dispatch catch 渲染进 `task.error_message`。

## 已知边界

- 前端未做对称拦截：用户仍可在不支持尾帧的后端上给镜头设尾帧，到入队执行才拿到错误。本 issue 验收标准只覆盖后端硬失败。
- CONTEXT.md 尾帧词条另一半「快照文件缺失时硬失败」未实现，不在本 issue 验收标准内。
- 「档位可切换」与「模型不支持」目前靠文案兼容两种情形，未在错误码上精确区分——精确区分需要第二个 `getattr` 鸭子类型探测或把 `video_capabilities_for_tier` 升为 Protocol 正式成员，后者是 issue 明示不作为验收项的重构线索。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增视频帧槽位规划：依据所选模型/档位能力自动确定起始帧、尾帧与参考图提交方式。
* **错误修复**
  * 当所选模型/档位不支持尾帧且提供了尾帧，生成将中止并报错 `video_last_frame_unsupported`。
  * 兼容将 `end_image=""` 视为未提供尾帧，不触发尾帧能力校验失败。
  * Ark 后端的首/尾帧能力判定更精确。
  * 新增/补全多语言错误文案 `video_last_frame_unsupported`。
* **测试**
  * 强化尾帧能力校验：错误时不调用视频后端、不写入开始账单；补充帧槽位规划与能力解析单测。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->