### PR TITLE
feat(video): 镜头尾帧支持上传或从项目内选图，快照留存不随源图变动

### DIFF
--- a/lib/asset_fingerprints.py
+++ b/lib/asset_fingerprints.py
@@ -5,6 +5,7 @@ from pathlib import Path
 # 扫描的媒体子目录
 _MEDIA_SUBDIRS = (
     "storyboards",
+    "end_frames",
     "videos",
     "thumbnails",
     "characters",

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -93,6 +93,7 @@ class DataValidator:
         "products",
         "reference_videos",
         "storyboards",
+        "end_frames",
         "videos",
         "audio",
         "thumbnails",
@@ -504,6 +505,25 @@ class DataValidator:
             default_dir="audio",
         )
 
+    def _validate_end_frame_image(
+        self,
+        project_dir: Path,
+        prefix: str,
+        item: dict[str, Any],
+        errors: list[str],
+    ) -> None:
+        """校验镜头条目的尾帧快照路径：越界与缺失均报 error（缺失即悬空引用，不容忍）。
+
+        与 generated_assets 内的路径字段同口径，但字段在条目顶层（用户意图而非运行时产出）。
+        """
+        self._validate_local_reference(
+            project_dir,
+            item.get("end_frame_image"),
+            errors,
+            f"{prefix}.end_frame_image",
+            default_dir="end_frames",
+        )
+
     def _validate_segments(
         self,
         segments: list[dict[str, Any]] | Any,
@@ -585,6 +605,7 @@ class DataValidator:
                     segment.get("generated_assets"),
                     errors,
                 )
+                self._validate_end_frame_image(project_dir, prefix, segment, errors)
 
     def _validate_scenes(
         self,
@@ -684,6 +705,7 @@ class DataValidator:
                     scene.get("generated_assets"),
                     errors,
                 )
+                self._validate_end_frame_image(project_dir, prefix, scene, errors)
 
     @staticmethod
     def _validate_utterances(utterances: Any, prefix: str, errors: list[str]) -> None:
@@ -864,6 +886,7 @@ class DataValidator:
                     shot.get("generated_assets"),
                     errors,
                 )
+                self._validate_end_frame_image(project_dir, prefix, shot, errors)
 
     @staticmethod
     def _warn_ad_target_duration_drift(

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -128,6 +128,7 @@ class DataValidator:
         *,
         default_dir: str | None = None,
         missing_ok: bool = False,
+        confine_to_default_dir: bool = False,
     ) -> tuple[str | None, str | None]:
         normalized = str(raw_path).strip().replace("\\", "/")
         if not normalized:
@@ -137,7 +138,12 @@ class DataValidator:
         if default_dir and len(candidate_paths[0].parts) == 1:
             candidate_paths.append(Path(default_dir) / candidate_paths[0])
 
+        confine_root = (
+            safe_join(project_dir, default_dir, allow_base=True) if confine_to_default_dir and default_dir else None
+        )
+
         seen: set[str] = set()
+        saw_out_of_confine = False
         for candidate in candidate_paths:
             candidate_key = candidate.as_posix()
             if candidate_key in seen:
@@ -149,9 +155,18 @@ class DataValidator:
             except PathTraversalError:
                 return None, f"引用路径越界: {normalized}"
 
+            if confine_root is not None:
+                try:
+                    resolved.relative_to(confine_root)
+                except ValueError:
+                    saw_out_of_confine = True
+                    continue
+
             if resolved.exists():
                 return candidate.as_posix(), None
 
+        if saw_out_of_confine:
+            return None, f"引用路径必须位于 {default_dir}/ 目录下: {normalized}"
         if missing_ok:
             return None, None
         return None, f"引用的文件不存在: {normalized}"
@@ -166,6 +181,7 @@ class DataValidator:
         default_dir: str | None = None,
         allow_external: bool = False,
         missing_ok: bool = False,
+        confine_to_default_dir: bool = False,
     ) -> str | None:
         if value in (None, ""):
             return None
@@ -188,6 +204,7 @@ class DataValidator:
             raw_value,
             default_dir=default_dir,
             missing_ok=missing_ok,
+            confine_to_default_dir=confine_to_default_dir,
         )
         if error:
             errors.append(f"{field_name}: {error}")
@@ -512,9 +529,11 @@ class DataValidator:
         item: dict[str, Any],
         errors: list[str],
     ) -> None:
-        """校验镜头条目的尾帧快照路径：越界与缺失均报 error（缺失即悬空引用，不容忍）。
+        """校验镜头条目的尾帧快照路径：越界、缺失、目录外均报 error（缺失即悬空引用，不容忍）。
 
-        与 generated_assets 内的路径字段同口径，但字段在条目顶层（用户意图而非运行时产出）。
+        与 generated_assets 内的路径字段不同：尾帧字段只接受服务层写出的 `end_frames/`
+        快照路径（`confine_to_default_dir`），不接受指向 storyboards/scripts 等其它目录
+        内恰好存在的文件——否则字段等于绕过快照复制直接引用源图，废掉解耦设计。
         """
         self._validate_local_reference(
             project_dir,
@@ -522,6 +541,7 @@ class DataValidator:
             errors,
             f"{prefix}.end_frame_image",
             default_dir="end_frames",
+            confine_to_default_dir=True,
         )
 
     def _validate_segments(

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -162,7 +162,7 @@ class DataValidator:
                     saw_out_of_confine = True
                     continue
 
-            if resolved.exists():
+            if resolved.is_file():
                 return candidate.as_posix(), None
 
         if saw_out_of_confine:

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -182,6 +182,8 @@ MESSAGES = {
     # Versions
     "unsupported_resource_type": "Unsupported resource type: {resource_type}",
     "invalid_resource_id": "Invalid resource ID: {resource_id}",
+    "invalid_end_frame_source": "End frame source path is invalid or outside the project directory: {path}",
+    "end_frame_source_not_found": "End frame source image not found: {path}",
     # Reference Video
     "ref_missing_asset": "Reference to {type} '{name}' is not in the project asset library, please generate it first",
     "ref_duration_exceeded": "Reference video unit duration {duration}s exceeds {model} limit of {max_duration}s, clamped",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -182,6 +182,8 @@ MESSAGES = {
     # Versions
     "unsupported_resource_type": "Loại tài nguyên không hỗ trợ: {resource_type}",
     "invalid_resource_id": "ID tài nguyên không hợp lệ: {resource_id}",
+    "invalid_end_frame_source": "Đường dẫn ảnh nguồn cho khung hình cuối không hợp lệ hoặc nằm ngoài thư mục dự án: {path}",
+    "end_frame_source_not_found": "Không tìm thấy ảnh nguồn cho khung hình cuối: {path}",
     # Reference Video
     "ref_missing_asset": "Tham chiếu đến {type} '{name}' không có trong thư viện tài nguyên dự án, vui lòng tạo trước",
     "ref_duration_exceeded": "Thời lượng đơn vị video tham chiếu {duration}s vượt giới hạn {max_duration}s của {model}, đã cắt bớt",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -172,6 +172,8 @@ MESSAGES = {
     # Versions
     "unsupported_resource_type": "不支持的资源类型: {resource_type}",
     "invalid_resource_id": "非法的资源 ID: {resource_id}",
+    "invalid_end_frame_source": "尾帧来源路径非法或越出项目目录: {path}",
+    "end_frame_source_not_found": "尾帧来源图片不存在: {path}",
     # Reference Video
     "ref_missing_asset": "参考图引用的{type}「{name}」不在项目资产库中，请先生成",
     "ref_duration_exceeded": "参考视频单元时长 {duration}s 超出 {model} 上限 {max_duration}s，已裁剪",

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -553,8 +553,8 @@ class ProjectManager:
         Returns:
             保存的文件路径
         """
-        if filename is not None and filename.startswith("scripts/"):
-            filename = filename[len("scripts/") :]
+        if filename is not None:
+            filename = self.normalize_script_filename(filename)
 
         if filename is None:
             chapter = script["novel"].get("chapter", "chapter_01")
@@ -710,12 +710,12 @@ class ProjectManager:
         若加锁前后绑定指向了不同脚本（并发改绑），抛 `EpisodeScriptReboundError` 让调用方重试。
         """
         candidate = resolve_script_file(self.load_project(project_name))
-        norm = candidate[len("scripts/") :] if candidate.startswith("scripts/") else candidate
+        norm = self.normalize_script_filename(candidate)
         with self._script_lock(project_name, norm):
             with self._project_lock(project_name):
                 project = self._read_project_raw_unlocked(project_name)
                 current = resolve_script_file(project)
-                cur_norm = current[len("scripts/") :] if current.startswith("scripts/") else current
+                cur_norm = self.normalize_script_filename(current)
                 if cur_norm != norm:
                     raise EpisodeScriptReboundError(f"episode script binding changed: {norm} -> {cur_norm}")
                 script = self.load_script(project_name, norm)
@@ -739,7 +739,7 @@ class ProjectManager:
 
         filename 缺集号模式或脚本内无 `episode` int 时静默放行（兼容旧数据）。
         """
-        base_name = script_filename[len("scripts/") :] if script_filename.startswith("scripts/") else script_filename
+        base_name = ProjectManager.normalize_script_filename(script_filename)
         filename_match = re.search(r"episode[-_\s]*(\d+)", base_name, re.IGNORECASE)
         if filename_match is None:
             return
@@ -825,7 +825,7 @@ class ProjectManager:
         供 `sync_episode_from_script`（在 `update_project` 锁内）与 `locked_episode_script`
         （在已持 `_project_lock` 的临界区内）共用，避免重复实现集元数据同步逻辑。
         """
-        base_name = script_filename[len("scripts/") :] if script_filename.startswith("scripts/") else script_filename
+        base_name = self.normalize_script_filename(script_filename)
         # 防御纵深：SSE 扫描路径直接调用此函数（不经 save_script），同样需要校验
         self._require_filename_episode_consistency(script, base_name)
 
@@ -863,8 +863,7 @@ class ProjectManager:
             剧本字典
         """
         project_dir = self.get_project_path(project_name)
-        if filename.startswith("scripts/"):
-            filename = filename[len("scripts/") :]
+        filename = self.normalize_script_filename(filename)
         real = Path(self._safe_subpath(project_dir / "scripts", filename))
 
         if not real.exists():
@@ -1351,8 +1350,7 @@ class ProjectManager:
         """
         scripts_dir = self.get_project_path(project_name) / "scripts"
         scripts_dir.mkdir(parents=True, exist_ok=True)
-        if script_filename.startswith("scripts/"):
-            script_filename = script_filename[len("scripts/") :]
+        script_filename = self.normalize_script_filename(script_filename)
         real = Path(self._safe_subpath(scripts_dir, script_filename))
         lock_path = real.parent / f".{real.name}.lock"
         lock_path.parent.mkdir(parents=True, exist_ok=True)

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -661,13 +661,15 @@ class ProjectManager:
     def normalize_script_filename(script_filename: str) -> str:
         """剥离 `scripts/` 前缀并折叠 `./` 片段，归一到与 `_script_lock`/`_safe_subpath` 一致的身份。
 
-        `episode_1.json`、`scripts/episode_1.json`、`./episode_1.json` 是指向同一剧本的合法
-        别名——`_safe_subpath` 底层按真实路径解析，三者共享同一把文件锁；调用方需要跨调用比较
-        或做 key（如按剧本分组的并发标记）时应先过这里，避免几种写法各自生成一份身份、互相看
-        不见对方。保留 `..` 片段原样交给 `_safe_subpath` 拒绝，这里不做越界判断。
+        `episode_1.json`、`scripts/episode_1.json`、`./episode_1.json`、`./scripts/episode_1.json`
+        是指向同一剧本的合法别名——`_safe_subpath` 底层按真实路径解析，均共享同一把文件锁；调用方
+        需要跨调用比较或做 key（如按剧本分组的并发标记）时应先过这里，避免几种写法各自生成一份
+        身份、互相看不见对方。须先折叠路径片段再剥前缀——顺序反过来的话，`./scripts/x.json` 先剥
+        前缀不命中（前缀前面还有 `./`），折叠后才变回 `scripts/x.json`，会被 `load_script`/
+        `_script_lock` 当成不含前缀的裸文件名再次拼接 `scripts/` 目录，产生 `scripts/scripts/x.json`
+        双重前缀。保留 `..` 片段原样交给 `_safe_subpath` 拒绝，这里不做越界判断。
         """
-        normalized = script_filename.removeprefix("scripts/")
-        normalized = posixpath.normpath(normalized)
+        normalized = posixpath.normpath(script_filename).removeprefix("scripts/")
         return "" if normalized == "." else normalized
 
     @contextmanager

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -656,6 +656,16 @@ class ProjectManager:
 
         return output_path
 
+    @staticmethod
+    def normalize_script_filename(script_filename: str) -> str:
+        """剥离 `scripts/` 前缀，把剧本文件名归一到与内部锁键/存储路径一致的形式。
+
+        `episode_1.json` 与 `scripts/episode_1.json` 是指向同一剧本的合法别名；调用方需要
+        跨调用比较或做 key（如按剧本分组的并发标记）时应先过这里，避免两种写法各自生成一份
+        身份、互相看不见对方。
+        """
+        return script_filename[len("scripts/") :] if script_filename.startswith("scripts/") else script_filename
+
     @contextmanager
     def locked_script(self, project_name: str, script_filename: str, *, validate: bool = True):
         """在单一 `_script_lock` 内完成剧本的 load → mutate → save 读-改-写。
@@ -667,7 +677,7 @@ class ProjectManager:
         `validate=True`（默认）时在 yield 前快照「改前」剧本，写回走「不更坏」结构校验（零额外
         读盘）。只动 `generated_assets` 的资产回写热路径传 `validate=False` 整体豁免。
         """
-        norm = script_filename[len("scripts/") :] if script_filename.startswith("scripts/") else script_filename
+        norm = self.normalize_script_filename(script_filename)
         with self._script_lock(project_name, norm):
             script = self.load_script(project_name, norm)
             before = copy.deepcopy(script) if validate else None

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -9,6 +9,7 @@ import errno
 import json
 import logging
 import os
+import posixpath
 import re
 import secrets
 import shutil
@@ -658,13 +659,16 @@ class ProjectManager:
 
     @staticmethod
     def normalize_script_filename(script_filename: str) -> str:
-        """剥离 `scripts/` 前缀，把剧本文件名归一到与内部锁键/存储路径一致的形式。
+        """剥离 `scripts/` 前缀并折叠 `./` 片段，归一到与 `_script_lock`/`_safe_subpath` 一致的身份。
 
-        `episode_1.json` 与 `scripts/episode_1.json` 是指向同一剧本的合法别名；调用方需要
-        跨调用比较或做 key（如按剧本分组的并发标记）时应先过这里，避免两种写法各自生成一份
-        身份、互相看不见对方。
+        `episode_1.json`、`scripts/episode_1.json`、`./episode_1.json` 是指向同一剧本的合法
+        别名——`_safe_subpath` 底层按真实路径解析，三者共享同一把文件锁；调用方需要跨调用比较
+        或做 key（如按剧本分组的并发标记）时应先过这里，避免几种写法各自生成一份身份、互相看
+        不见对方。保留 `..` 片段原样交给 `_safe_subpath` 拒绝，这里不做越界判断。
         """
-        return script_filename[len("scripts/") :] if script_filename.startswith("scripts/") else script_filename
+        normalized = script_filename.removeprefix("scripts/")
+        normalized = posixpath.normpath(normalized)
+        return "" if normalized == "." else normalized
 
     @contextmanager
     def locked_script(self, project_name: str, script_filename: str, *, validate: bool = True):

--- a/lib/resource_paths.py
+++ b/lib/resource_paths.py
@@ -1,7 +1,7 @@
 """资源路径解析器 — 「资源类型 → 项目内相对路径」的唯一真相源。
 
 纯函数，不读盘、不持有项目状态。独家拥有各资源类型的子目录、文件名模板、
-扩展名，以及 storyboards/videos（``scene_``）、audio（``segment_``）的文件名前缀。
+扩展名，以及 storyboards/end_frames/videos（``scene_``）、audio（``segment_``）的文件名前缀。
 
 写侧（MediaGenerator）、版本回溯（versions 路由）、导入修复（project_archive）、
 版本管理（VersionManager）都从这里取形状，避免副本各自漂移。越界校验不在此处，
@@ -24,6 +24,8 @@ class ResourcePattern:
 
 _PATTERNS: dict[str, ResourcePattern] = {
     "storyboards": ResourcePattern("storyboards", ".png", prefix="scene_"),
+    # 尾帧快照与分镜图、镜头视频同按镜头 id 命名，故共用 scene_ 前缀。
+    "end_frames": ResourcePattern("end_frames", ".png", prefix="scene_"),
     "videos": ResourcePattern("videos", ".mp4", prefix="scene_"),
     "characters": ResourcePattern("characters", ".png"),
     "scenes": ResourcePattern("scenes", ".png"),
@@ -47,7 +49,7 @@ def _pattern(resource_type: str) -> ResourcePattern:
 def resource_relative_path(resource_type: str, resource_id: str) -> str:
     """返回资源在项目内的相对路径（posix，正斜杠）。
 
-    storyboards/videos 形如 ``storyboards/scene_{id}.png``、audio 形如 ``audio/segment_{id}.wav``；
+    storyboards/end_frames/videos 形如 ``storyboards/scene_{id}.png``、audio 形如 ``audio/segment_{id}.wav``；
     其余 ``{subdir}/{id}{ext}``。未知类型抛 ``ValueError``。
     """
     pattern = _pattern(resource_type)

--- a/lib/script_editor.py
+++ b/lib/script_editor.py
@@ -81,6 +81,10 @@ def _set_nested(obj: dict[str, Any], field_path: str, value: Any) -> None:
     if parts[0] == "generated_assets":
         # patch 是纯字段 setter，资产生命周期与剧本编辑解耦（见 ADR-0003）。
         raise ScriptEditError("patch_episode_script 不可改 generated_assets；资产的生成/重生是独立的显式动作")
+    if parts[0] == "end_frame_image":
+        # 尾帧字段的值是本服务写出的快照相对路径，只由尾帧设置/清除端点写入。放行 patch
+        # 会让原样写入的任意字符串绕过快照复制，重新引入悬空引用与越界路径。
+        raise ScriptEditError("patch_episode_script 不可改 end_frame_image；尾帧的设置/清除是独立的显式动作")
     if parts[0] in {"segment_id", "scene_id", "unit_id", "shot_id"}:
         # patch 不可改分镜 id：id 由 insert/split 从锚点派生，结构校验不查 id 唯一性，
         # agent 改 id 后会让其他依赖 id 定位的 helper（update_scene_asset 等）回写到错误分镜
@@ -119,8 +123,8 @@ def patch_field(script: dict[str, Any], item_id: str, field_path: str, value: An
 def insert_segment(script: dict[str, Any], after_id: str, new_item: dict[str, Any]) -> dict[str, Any]:
     """在 ``after_id`` 之后插入一个新分镜，分配派生自锚点 id 的稳定新 id。
 
-    新分镜的 id 字段被强制改写为 ``{after_id}_{k}``（唯一），``generated_assets`` 清空。
-    其余字段由 agent 提供，结构是否合法由写盘统一入口校验。
+    新分镜的 id 字段被强制改写为 ``{after_id}_{k}``（唯一），``generated_assets`` 与
+    ``end_frame_image`` 清空。其余字段由 agent 提供，结构是否合法由写盘统一入口校验。
     """
     if not isinstance(new_item, dict):
         raise ScriptEditError("new_item 必须是对象")
@@ -129,6 +133,8 @@ def insert_segment(script: dict[str, Any], after_id: str, new_item: dict[str, An
     item = deepcopy(new_item)
     item[id_field] = _next_suffixed_id(str(after_id), _existing_ids(items, id_field))
     item["generated_assets"] = {}
+    # 尾帧快照按镜头 id 命名，新 id 名下还没有快照；agent 自带的值只会指向别人的快照或空路径。
+    item.pop("end_frame_image", None)
     items.insert(idx + 1, item)
     return script
 
@@ -144,10 +150,10 @@ def remove_segment(script: dict[str, Any], item_id: str) -> dict[str, Any]:
 def split_segment(script: dict[str, Any], item_id: str, parts: list[dict[str, Any]]) -> dict[str, Any]:
     """把 ``item_id`` 分镜按 agent 提供的各部分内容拆成多个。
 
-    首个部分保留原 id 且**保留** ``generated_assets`` 不清空——视为"锚点延续",与
-    ``insert_segment`` 的锚点资产不动语义对齐(同族结构操作,资产作废粒度统一)。其余 parts
-    取 ``{item_id}_{k}`` 后缀的新 id 且清空 ``generated_assets``(身份变化,旧资产无归属,
-    退回 pending 待重生)。agent 想微调原分镜内容请用 ``patch_episode_script`` 改字段,
+    首个部分保留原 id 且**保留** ``generated_assets`` 与 ``end_frame_image`` 不清空——视为
+    "锚点延续",与 ``insert_segment`` 的锚点资产不动语义对齐(同族结构操作,资产作废粒度统一)。
+    其余 parts 取 ``{item_id}_{k}`` 后缀的新 id 且清空 ``generated_assets`` 与
+    ``end_frame_image``(身份变化,旧资产无归属,退回 pending 待重生)。agent 想微调原分镜内容请用 ``patch_episode_script`` 改字段,
     用 split 时锚点资产被保留是为了避免误用一次 split 把已生成的图/视频全部失效。
 
     reference 模式下各 unit 的 ``duration_seconds`` 须与其 ``shots`` 总时长一致——由写盘
@@ -160,6 +166,7 @@ def split_segment(script: dict[str, Any], item_id: str, parts: list[dict[str, An
     items, id_field, _ = resolve_items(script)
     idx = _find_index(items, id_field, item_id)
     anchor_assets = items[idx].get("generated_assets")
+    anchor_end_frame = items[idx].get("end_frame_image")
 
     taken = _existing_ids(items, id_field)
     new_parts: list[dict[str, Any]] = []
@@ -183,11 +190,18 @@ def split_segment(script: dict[str, Any], item_id: str, parts: list[dict[str, An
                         type(anchor_assets).__name__,
                     )
                 part["generated_assets"] = {}
+            # 尾帧同锚点延续：以原分镜实际值为准，不让 agent 在 parts[0] 凭空改写快照路径。
+            if anchor_end_frame is None:
+                part.pop("end_frame_image", None)
+            else:
+                part["end_frame_image"] = anchor_end_frame
         else:
             new_id = _next_suffixed_id(str(item_id), taken)
             taken.add(new_id)
             part[id_field] = new_id
             part["generated_assets"] = {}
+            # 新 id 名下没有快照，agent 自带的值只会指向锚点的快照。
+            part.pop("end_frame_image", None)
         new_parts.append(part)
 
     items[idx : idx + 1] = new_parts

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -232,6 +232,10 @@ class NarrationSegment(BaseModel):
     # 以下字段对 LLM 隐藏（SkipJsonSchema）：note 是人工备注、generated_assets 是 post-LLM 运行时状态。
     # 仍保留在 Pydantic 模型里以便存储 / 校验，但不出现在 response_schema 中，避免 LLM 填污染数据。
     note: SkipJsonSchema[str | None] = Field(default=None, description="用户备注（不参与生成）")
+    # 尾帧快照的项目内相对路径（``end_frames/scene_{id}.png``）。用户意图而非运行时产出，
+    # 故不进 generated_assets；只由尾帧设置/清除端点写入（通用 PATCH 白名单不含此字段，
+    # 避免绕过快照复制写出悬空引用或越界路径），整集剧本重生成不保留（同 note 口径）。
+    end_frame_image: SkipJsonSchema[str | None] = Field(default=None, description="尾帧快照路径（项目内相对路径）")
     generated_assets: SkipJsonSchema[GeneratedAssets] = Field(
         default_factory=GeneratedAssets, description="生成资源状态"
     )
@@ -478,6 +482,7 @@ class DramaScene(BaseModel):
     transition_to_next: SkipJsonSchema[TransitionType] = Field(default="cut", description="转场类型")
     # 见 NarrationSegment 同名字段说明。
     note: SkipJsonSchema[str | None] = Field(default=None, description="用户备注（不参与生成）")
+    end_frame_image: SkipJsonSchema[str | None] = Field(default=None, description="尾帧快照路径（项目内相对路径）")
     generated_assets: SkipJsonSchema[GeneratedAssets] = Field(
         default_factory=GeneratedAssets, description="生成资源状态"
     )
@@ -671,6 +676,7 @@ class AdShot(BaseModel):
     transition_to_next: SkipJsonSchema[TransitionType] = Field(default="cut", description="转场类型")
     # 见 NarrationSegment 同名字段说明。
     note: SkipJsonSchema[str | None] = Field(default=None, description="用户备注（不参与生成）")
+    end_frame_image: SkipJsonSchema[str | None] = Field(default=None, description="尾帧快照路径（项目内相对路径）")
     generated_assets: SkipJsonSchema[GeneratedAssets] = Field(
         default_factory=GeneratedAssets, description="生成资源状态"
     )

--- a/server/app.py
+++ b/server/app.py
@@ -51,6 +51,7 @@ from server.routers import (
     characters,
     cost_estimation,
     custom_providers,
+    end_frames,
     files,
     generate,
     grids,
@@ -568,6 +569,7 @@ app.include_router(files.router, prefix="/api/v1", tags=["文件管理"])
 app.include_router(generate.router, prefix="/api/v1", tags=["生成"])
 app.include_router(script_review.router, prefix="/api/v1", tags=["剧本审核 gate"])
 app.include_router(shot_uploads.router, prefix="/api/v1", tags=["镜头上传"])
+app.include_router(end_frames.router, prefix="/api/v1", tags=["镜头尾帧"])
 app.include_router(versions.router, prefix="/api/v1", tags=["版本管理"])
 app.include_router(usage.router, prefix="/api/v1", tags=["费用统计"])
 app.include_router(assistant.router, prefix="/api/v1/projects/{project_name}/assistant", tags=["助手会话"])

--- a/server/routers/end_frames.py
+++ b/server/routers/end_frames.py
@@ -1,0 +1,122 @@
+"""镜头尾帧设置/清除路由。
+
+设置有两条通道、同一落点：``/end-frame/upload`` 收 multipart 上传，``/end-frame/select``
+按项目内相对路径选已有图片；两者都归一为 PNG 快照写到 ``end_frames/scene_{id}.png``。
+``DELETE /end-frame`` 清除（删快照 + 字段置空）。
+
+字段 ``end_frame_image`` 只由这里写入：通用剧本 PATCH 白名单刻意不含它，避免原样写值
+绕过快照复制、重新引入悬空引用与越界路径。
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from pydantic import BaseModel
+
+from lib.api_errors import ApiError, NotFoundError
+from lib.i18n import Translator
+from lib.script_editor import ScriptEditError
+from server.auth import CurrentUser
+from server.services.end_frame import (
+    EndFrameError,
+    clear_end_frame,
+    set_end_frame_from_bytes,
+    set_end_frame_from_project_image,
+)
+from server.services.upload_finalize import (
+    UploadTooLargeError,
+    UploadValidationError,
+    validate_upload,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class SelectEndFrameRequest(BaseModel):
+    script_file: str
+    source_path: str
+
+
+@contextmanager
+def _translated_errors(script_file: str, _t: Translator) -> Iterator[None]:
+    """三个端点共用的领域错误 → HTTP 映射。"""
+    try:
+        yield
+    except (EndFrameError, UploadValidationError) as e:
+        raise HTTPException(status_code=e.status_code, detail=_t(e.key, **e.params))
+    except FileNotFoundError as exc:
+        # 不回传 str(exc)：load_script 的异常信息含服务器绝对路径
+        raise NotFoundError("script_not_found", name=script_file) from exc
+    except ScriptEditError as e:
+        raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=str(e)))
+    except (HTTPException, ApiError):
+        raise
+    except Exception as e:
+        # 不回传 str(e)：未预期异常的消息可能含服务器路径等内部细节，堆栈进日志即可
+        logger.exception("请求处理失败")
+        raise HTTPException(status_code=500, detail=_t("internal_server_error")) from e
+
+
+@router.post("/projects/{project_name}/shots/{shot_id}/end-frame/upload")
+async def upload_end_frame(
+    project_name: str,
+    shot_id: str,
+    script_file: str,
+    _user: CurrentUser,
+    _t: Translator,
+    file: UploadFile = File(...),
+):
+    """上传任意图片作为该镜头的尾帧。"""
+    with _translated_errors(script_file, _t):
+        max_bytes = validate_upload(file.filename, file.size, kind="image")
+        # 限定读入内存的字节数：Content-Length 缺失/被绕过时不至于 OOM
+        content = await file.read(max_bytes + 1)
+        if len(content) > max_bytes:
+            raise UploadTooLargeError(max_bytes)
+
+        relative = await set_end_frame_from_bytes(
+            project_name=project_name,
+            script_file=script_file,
+            shot_id=shot_id,
+            content=content,
+        )
+        return {"success": True, "end_frame_image": relative}
+
+
+@router.post("/projects/{project_name}/shots/{shot_id}/end-frame/select")
+async def select_end_frame(
+    project_name: str,
+    shot_id: str,
+    req: SelectEndFrameRequest,
+    _user: CurrentUser,
+    _t: Translator,
+):
+    """指定项目内已有图片的相对路径作为该镜头的尾帧（快照复制，不建立引用）。"""
+    with _translated_errors(req.script_file, _t):
+        relative = await set_end_frame_from_project_image(
+            project_name=project_name,
+            script_file=req.script_file,
+            shot_id=shot_id,
+            source_path=req.source_path,
+        )
+        return {"success": True, "end_frame_image": relative}
+
+
+@router.delete("/projects/{project_name}/shots/{shot_id}/end-frame")
+async def delete_end_frame(
+    project_name: str,
+    shot_id: str,
+    script_file: str,
+    _user: CurrentUser,
+    _t: Translator,
+):
+    """清除该镜头的尾帧：删快照文件并把字段置空。"""
+    with _translated_errors(script_file, _t):
+        await clear_end_frame(project_name=project_name, script_file=script_file, shot_id=shot_id)
+        return {"success": True}

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -13,16 +13,21 @@ mid-flight 被删除而失败时跳过整段写回，不留半截状态。
 
 `locked_script` 在锁内完成剧本持久化，校验/落盘异常向调用方传出前锁已释放，故文件
 系统副作用（写快照 / 删快照）不能靠锁外的 try/except 直接回滚——那样回滚本身会跟同
-一间隙内另一个成功落盘的并发请求打架。补偿改为重新过锁并按「文件内容是否仍是失败前
-留下的状态」做条件回滚（见 `_restore_after_persist_failure`），只撤销自己的效果、不
-覆盖旁人已落盘的成果。孤儿快照文件（如进程在文件写完、锁释放前被杀）仍可能残留，
-无害，与 storyboards 现状一致，不做清理机制。
+一间隙内另一个成功落盘的并发请求打架。补偿改为重新过锁并按「本镜头的操作代次是否仍是
+失败前那一次」做条件回滚（见 `_restore_after_persist_failure`），只撤销自己的效果、不
+覆盖旁人已落盘的成果。代次而非文件内容——内容比对有退化值问题：并发的另一次清除同样会
+让文件落到「不存在」，与「无人接手」的期望内容（None）无法区分，会把并发清除的结果误判
+为无人接手，回滚出不该存在的孤儿文件。代次在临界区内随每次进入自增，无论那次操作最终
+成功与否，只要有人在本次失败到回滚重新过锁之间进入过临界区，代次必然前移，据此可靠判定
+是否跳过。孤儿快照文件（如进程在文件写完、锁释放前被杀）仍可能残留，无害，与 storyboards
+现状一致，不做清理机制。
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from pathlib import Path
 
 from lib.image_utils import normalize_storyboard_upload
@@ -36,6 +41,25 @@ from server.services.upload_finalize import write_bytes_atomic
 logger = logging.getLogger(__name__)
 
 END_FRAME_RESOURCE_TYPE = "end_frames"
+
+_ShotKey = tuple[str, str, str]
+_generation_lock = threading.Lock()
+_shot_generations: dict[_ShotKey, int] = {}
+
+
+def _current_shot_generation(key: _ShotKey) -> int:
+    with _generation_lock:
+        return _shot_generations.get(key, 0)
+
+
+def _advance_shot_generation(key: _ShotKey) -> int:
+    """推进该镜头的操作代次，返回新值。在临界区内、mutation 之前调用——无论后续
+    是否失败，都代表「一次操作进入过临界区」，供失败一方的补偿回滚据此判断有无被接手。
+    """
+    with _generation_lock:
+        generation = _shot_generations.get(key, 0) + 1
+        _shot_generations[key] = generation
+        return generation
 
 
 class EndFrameError(Exception):
@@ -83,26 +107,26 @@ def _restore_after_persist_failure(
     script_file: str,
     target: Path,
     old_bytes: bytes | None,
-    expected_current: bytes | None,
+    key: _ShotKey,
+    expected_generation: int,
 ) -> None:
     """剧本持久化失败后的补偿：在新的一次剧本锁临界区内条件回滚快照文件。
 
     补偿本身必须重新过锁——`locked_script` 在锁内完成持久化，异常向上传播前锁已释放，
     若在锁外直接按调用方持有的旧字节回写，会跟同一间隙内另一个成功落盘的并发请求打架。
-    回滚前用 `expected_current` 复核文件当前内容是否仍是本次失败前留下的状态：仍是则说明这段时间无人接手，安全回滚；
-    已不是则说明并发操作已经用它自己的一次原子写快照+写字段接管，当前状态已自洽，
-    回滚只会用陈旧字节覆盖它的成果，直接跳过。
+    回滚前用 `expected_generation` 复核该镜头的操作代次是否仍是本次失败前那一次：仍是
+    则说明这段时间无人进入过临界区，安全回滚；已前移则说明并发操作已经接管（不论其
+    自身成败），当前状态可能已自洽，回滚只会用陈旧字节覆盖它的成果，直接跳过。
     """
     try:
         with manager.locked_script(project_name, script_file):
-            current = target.read_bytes() if target.exists() else None
-            if current != expected_current:
+            if _current_shot_generation(key) != expected_generation:
                 return
             if old_bytes is not None:
                 write_bytes_atomic(old_bytes, target)
             else:
                 target.unlink(missing_ok=True)
-    except BaseException:
+    except Exception:
         logger.exception(
             "尾帧快照回滚失败：project=%s script=%s target=%s（原持久化异常见上一条 traceback）",
             project_name,
@@ -125,10 +149,13 @@ def _write_snapshot_and_field(
     虽被回滚，快照文件的旧内容已被静默替换，调用方收到失败响应却看不出内容已丢失。
     """
     manager = get_project_manager()
+    key = (project_name, script_file, shot_id)
     old_bytes = target.read_bytes() if target.exists() else None
+    generation = _current_shot_generation(key)
     try:
         with project_change_source("webui"):
             with manager.locked_script(project_name, script_file) as script:
+                generation = _advance_shot_generation(key)
                 items, id_field, _, _, _ = get_storyboard_items(script)
                 matched = find_storyboard_item(items, id_field, shot_id)
                 if matched is None:
@@ -138,7 +165,7 @@ def _write_snapshot_and_field(
     except EndFrameError:
         raise
     except BaseException:
-        _restore_after_persist_failure(manager, project_name, script_file, target, old_bytes, png_bytes)
+        _restore_after_persist_failure(manager, project_name, script_file, target, old_bytes, key, generation)
         raise
 
 
@@ -149,10 +176,13 @@ def _clear_snapshot_and_field(project_name: str, script_file: str, shot_id: str,
     快照文件已被删除，重新落回悬空引用。
     """
     manager = get_project_manager()
+    key = (project_name, script_file, shot_id)
     old_bytes = target.read_bytes() if target.exists() else None
+    generation = _current_shot_generation(key)
     try:
         with project_change_source("webui"):
             with manager.locked_script(project_name, script_file) as script:
+                generation = _advance_shot_generation(key)
                 items, id_field, _, _, _ = get_storyboard_items(script)
                 matched = find_storyboard_item(items, id_field, shot_id)
                 if matched is None:
@@ -162,7 +192,7 @@ def _clear_snapshot_and_field(project_name: str, script_file: str, shot_id: str,
     except EndFrameError:
         raise
     except BaseException:
-        _restore_after_persist_failure(manager, project_name, script_file, target, old_bytes, expected_current=None)
+        _restore_after_persist_failure(manager, project_name, script_file, target, old_bytes, key, generation)
         raise
 
 

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -1,0 +1,168 @@
+"""镜头尾帧快照的设置与清除服务层。
+
+尾帧是镜头的用户意图持久属性（``end_frame_image``），不是运行时产出，故不进
+``generated_assets``。设置的两条通道（上传任意图片 / 指定项目内已有图片的相对路径）
+在这里汇成同一落点：归一为 PNG 后快照复制到 ``end_frames/scene_{id}.png``，剧本条目
+只存该固定相对路径。源图与快照就此彻底解耦——源图重生成、版本回滚、删除都动不到
+已定尾帧，结构上不存在悬空引用。
+
+写入顺序遵循「先落文件、后写字段」（清除时反向），任一步失败都不会留下指向缺失
+文件的字段值；残留的孤儿快照文件无害，与 storyboards 现状一致，不做清理机制。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from lib.image_utils import normalize_storyboard_upload
+from lib.path_safety import PathTraversalError, safe_join
+from lib.project_change_hints import project_change_source
+from lib.project_manager import get_project_manager
+from lib.resource_paths import resource_relative_path
+from lib.storyboard_sequence import find_storyboard_item, get_storyboard_items
+from server.services.upload_finalize import save_uploaded_bytes
+
+END_FRAME_RESOURCE_TYPE = "end_frames"
+
+
+class EndFrameError(Exception):
+    """尾帧操作的领域错误。路由层按 (status_code, key, params) 翻译为 HTTP 响应。"""
+
+    def __init__(self, key: str, *, status_code: int = 400, **params: object):
+        super().__init__(key)
+        self.key = key
+        self.status_code = status_code
+        self.params = params
+
+
+def _locate_shot(project_name: str, script_file: str, shot_id: str) -> Path:
+    """确认镜头在剧本中存在，返回项目绝对路径；不存在时抛领域错误。
+
+    参考生视频剧本的 ``get_storyboard_items`` 返回空列表（该路径无首帧概念，
+    Spec 明确排除尾帧支持），故一并落到「镜头不存在」。
+    """
+    manager = get_project_manager()
+    try:
+        project_path = manager.get_project_path(project_name)
+    except FileNotFoundError as exc:
+        raise EndFrameError("project_not_found", status_code=404, name=project_name) from exc
+
+    script = manager.load_script(project_name, script_file)
+    items, id_field, _, _, _ = get_storyboard_items(script)
+    if find_storyboard_item(items, id_field, shot_id) is None:
+        raise EndFrameError("segment_not_found", status_code=404, id=shot_id)
+    return project_path
+
+
+def _snapshot_target(project_path: Path, shot_id: str) -> tuple[Path, str]:
+    """返回尾帧快照的 (绝对路径, 项目内相对路径)；shot_id 拼出的路径越界时抛领域错误。"""
+    relative = resource_relative_path(END_FRAME_RESOURCE_TYPE, shot_id)
+    try:
+        target = safe_join(project_path, relative)
+    except PathTraversalError as exc:
+        raise EndFrameError("invalid_resource_id", resource_id=shot_id) from exc
+    return target, relative
+
+
+def _write_end_frame_field(project_name: str, script_file: str, shot_id: str, value: str | None) -> None:
+    """在剧本锁内把镜头条目的 ``end_frame_image`` 写成 value（``None`` 即清除）。"""
+    manager = get_project_manager()
+    with project_change_source("webui"):
+        with manager.locked_script(project_name, script_file) as script:
+            items, id_field, _, _, _ = get_storyboard_items(script)
+            matched = find_storyboard_item(items, id_field, shot_id)
+            if matched is None:
+                raise EndFrameError("segment_not_found", status_code=404, id=shot_id)
+            matched[0]["end_frame_image"] = value
+
+
+def read_project_image(project_path: Path, source_path: str) -> bytes:
+    """读取项目内已有图片的字节；路径越界或文件缺失时抛领域错误。
+
+    不限定来源子目录——分镜图 / 角色 / 场景 / 宫格切图都可直接选用，越界防护
+    由 ``safe_join`` 统一负责（与 data_validator 的路径字段校验同口径）。
+    """
+    normalized = source_path.strip().replace("\\", "/")
+    if not normalized:
+        raise EndFrameError("invalid_end_frame_source", path=source_path)
+    try:
+        resolved = safe_join(project_path, normalized)
+    except PathTraversalError as exc:
+        raise EndFrameError("invalid_end_frame_source", path=source_path) from exc
+    if not resolved.is_file():
+        raise EndFrameError("end_frame_source_not_found", status_code=404, path=normalized)
+    return resolved.read_bytes()
+
+
+async def _apply_snapshot(
+    *,
+    project_path: Path,
+    project_name: str,
+    script_file: str,
+    shot_id: str,
+    content: bytes,
+) -> str:
+    """两条设置通道的共同落点：归一为 PNG → 写固定路径 → 写回字段，返回相对路径。
+
+    换图即原地覆盖同一路径：字段值不变，前端靠资产指纹 cache-bust。
+    """
+    target, relative = _snapshot_target(project_path, shot_id)
+
+    try:
+        png_bytes = await asyncio.to_thread(normalize_storyboard_upload, content)
+    except ValueError as exc:
+        raise EndFrameError("invalid_image_file") from exc
+
+    await save_uploaded_bytes(png_bytes, target)
+    await asyncio.to_thread(_write_end_frame_field, project_name, script_file, shot_id, relative)
+    return relative
+
+
+async def set_end_frame_from_bytes(
+    *,
+    project_name: str,
+    script_file: str,
+    shot_id: str,
+    content: bytes,
+) -> str:
+    """上传通道：把上传的图片字节落成该镜头的尾帧快照。"""
+    project_path = await asyncio.to_thread(_locate_shot, project_name, script_file, shot_id)
+    return await _apply_snapshot(
+        project_path=project_path,
+        project_name=project_name,
+        script_file=script_file,
+        shot_id=shot_id,
+        content=content,
+    )
+
+
+async def set_end_frame_from_project_image(
+    *,
+    project_name: str,
+    script_file: str,
+    shot_id: str,
+    source_path: str,
+) -> str:
+    """项目内选图通道：读源图字节后走与上传完全相同的归一 + 快照落点。"""
+    project_path = await asyncio.to_thread(_locate_shot, project_name, script_file, shot_id)
+    content = await asyncio.to_thread(read_project_image, project_path, source_path)
+    return await _apply_snapshot(
+        project_path=project_path,
+        project_name=project_name,
+        script_file=script_file,
+        shot_id=shot_id,
+        content=content,
+    )
+
+
+async def clear_end_frame(*, project_name: str, script_file: str, shot_id: str) -> None:
+    """清除镜头尾帧：先把字段置空，再删快照文件。
+
+    先置空字段可保证删文件失败时不留下指向缺失文件的引用（data_validator 会判 error）；
+    反之残留的快照文件无害。
+    """
+    project_path = await asyncio.to_thread(_locate_shot, project_name, script_file, shot_id)
+    target, _ = _snapshot_target(project_path, shot_id)
+    await asyncio.to_thread(_write_end_frame_field, project_name, script_file, shot_id, None)
+    await asyncio.to_thread(target.unlink, missing_ok=True)

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -34,6 +34,11 @@ mid-flight 被删除而失败时跳过整段写回，不留半截状态。
 标记"可补偿"（`entered`）须在基线读取*成功之后*才置位，不能在读之前——读之前置位的话，
 读基线本身失败（权限 / 临时 IO 错误）时 `old_bytes` 仍是初始的 `None`，补偿会把"读失败"
 误判成"目标文件原本不存在"，进而 unlink 一个从未被本次操作触碰过的既有快照。
+
+操作代次的推进（`_advance_shot_generation`）须放在镜头匹配成功、紧邻首次文件 mutation
+之前，不能在此之前就推进——提前推进的话，一次因镜头未找到而空手退出的请求也会让代次
+前移，导致同一时间段内另一个真正持久化失败、正在等待重新过锁补偿的请求，把这次空手
+退出误判成"已被接管、自身状态自洽"而跳过回滚，把它自己失败前的半截效果留在磁盘上。
 """
 
 from __future__ import annotations
@@ -186,13 +191,13 @@ def _write_snapshot_and_field(
     try:
         with project_change_source("webui"):
             with manager.locked_script(project_name, script_file) as script:
-                generation = _advance_shot_generation(key)
                 old_bytes = target.read_bytes() if target.exists() else None
-                entered = True
                 items, id_field, _, _, _ = get_storyboard_items(script)
                 matched = find_storyboard_item(items, id_field, shot_id)
                 if matched is None:
                     raise EndFrameError("segment_not_found", status_code=404, id=shot_id)
+                generation = _advance_shot_generation(key)
+                entered = True
                 write_bytes_atomic(png_bytes, target)
                 matched[0]["end_frame_image"] = relative
     except EndFrameError:
@@ -218,13 +223,13 @@ def _clear_snapshot_and_field(project_name: str, script_file: str, shot_id: str,
     try:
         with project_change_source("webui"):
             with manager.locked_script(project_name, script_file) as script:
-                generation = _advance_shot_generation(key)
                 old_bytes = target.read_bytes() if target.exists() else None
-                entered = True
                 items, id_field, _, _, _ = get_storyboard_items(script)
                 matched = find_storyboard_item(items, id_field, shot_id)
                 if matched is None:
                     raise EndFrameError("segment_not_found", status_code=404, id=shot_id)
+                generation = _advance_shot_generation(key)
+                entered = True
                 matched[0]["end_frame_image"] = None
                 target.unlink(missing_ok=True)
     except EndFrameError:

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -76,29 +76,51 @@ def _write_snapshot_and_field(
     png_bytes: bytes,
     relative: str,
 ) -> None:
-    """在剧本锁临界区内完成「写快照文件 + 写字段」，与清除操作互斥。"""
+    """在剧本锁临界区内完成「写快照文件 + 写字段」，与清除操作互斥。
+
+    剧本持久化失败（校验/落盘异常）时把快照文件还原成操作前状态——否则字段写入
+    虽被回滚，快照文件的旧内容已被静默替换，调用方收到失败响应却看不出内容已丢失。
+    """
     manager = get_project_manager()
-    with project_change_source("webui"):
-        with manager.locked_script(project_name, script_file) as script:
-            items, id_field, _, _, _ = get_storyboard_items(script)
-            matched = find_storyboard_item(items, id_field, shot_id)
-            if matched is None:
-                raise EndFrameError("segment_not_found", status_code=404, id=shot_id)
-            write_bytes_atomic(png_bytes, target)
-            matched[0]["end_frame_image"] = relative
+    old_bytes = target.read_bytes() if target.exists() else None
+    try:
+        with project_change_source("webui"):
+            with manager.locked_script(project_name, script_file) as script:
+                items, id_field, _, _, _ = get_storyboard_items(script)
+                matched = find_storyboard_item(items, id_field, shot_id)
+                if matched is None:
+                    raise EndFrameError("segment_not_found", status_code=404, id=shot_id)
+                write_bytes_atomic(png_bytes, target)
+                matched[0]["end_frame_image"] = relative
+    except BaseException:
+        if old_bytes is not None:
+            write_bytes_atomic(old_bytes, target)
+        else:
+            target.unlink(missing_ok=True)
+        raise
 
 
 def _clear_snapshot_and_field(project_name: str, script_file: str, shot_id: str, target: Path) -> None:
-    """在剧本锁临界区内完成「置空字段 + 删快照文件」，与设置操作互斥。"""
+    """在剧本锁临界区内完成「置空字段 + 删快照文件」，与设置操作互斥。
+
+    剧本持久化失败时把已删除的快照文件恢复——否则字段清空虽被回滚（仍指向原路径），
+    快照文件已被删除，重新落回悬空引用。
+    """
     manager = get_project_manager()
-    with project_change_source("webui"):
-        with manager.locked_script(project_name, script_file) as script:
-            items, id_field, _, _, _ = get_storyboard_items(script)
-            matched = find_storyboard_item(items, id_field, shot_id)
-            if matched is None:
-                raise EndFrameError("segment_not_found", status_code=404, id=shot_id)
-            matched[0]["end_frame_image"] = None
-            target.unlink(missing_ok=True)
+    old_bytes = target.read_bytes() if target.exists() else None
+    try:
+        with project_change_source("webui"):
+            with manager.locked_script(project_name, script_file) as script:
+                items, id_field, _, _, _ = get_storyboard_items(script)
+                matched = find_storyboard_item(items, id_field, shot_id)
+                if matched is None:
+                    raise EndFrameError("segment_not_found", status_code=404, id=shot_id)
+                matched[0]["end_frame_image"] = None
+                target.unlink(missing_ok=True)
+    except BaseException:
+        if old_bytes is not None:
+            write_bytes_atomic(old_bytes, target)
+        raise
 
 
 def read_project_image(project_path: Path, source_path: str) -> bytes:

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -8,23 +8,32 @@
 
 设置写快照文件 + 写字段、清除删快照文件 + 置空字段，各自整段落在同一把剧本锁
 （`ProjectManager.locked_script`）临界区内完成，与对方互斥——不会出现一方写完文件、
-对方抢在字段写回前把文件删掉的交错，结构上杜绝悬空引用。临界区内失败（如目标镜头
-mid-flight 被删除）会跳过整段写回，不留半截状态；孤儿快照文件（如进程在文件写完、
-锁释放前被杀）仍可能残留，无害，与 storyboards 现状一致，不做清理机制。
+对方抢在字段写回前把文件删掉的交错，结构上杜绝悬空引用。临界区内因目标镜头
+mid-flight 被删除而失败时跳过整段写回，不留半截状态。
+
+`locked_script` 在锁内完成剧本持久化，校验/落盘异常向调用方传出前锁已释放，故文件
+系统副作用（写快照 / 删快照）不能靠锁外的 try/except 直接回滚——那样回滚本身会跟同
+一间隙内另一个成功落盘的并发请求打架。补偿改为重新过锁并按「文件内容是否仍是失败前
+留下的状态」做条件回滚（见 `_restore_after_persist_failure`），只撤销自己的效果、不
+覆盖旁人已落盘的成果。孤儿快照文件（如进程在文件写完、锁释放前被杀）仍可能残留，
+无害，与 storyboards 现状一致，不做清理机制。
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 
 from lib.image_utils import normalize_storyboard_upload
 from lib.path_safety import PathTraversalError, safe_join
 from lib.project_change_hints import project_change_source
-from lib.project_manager import get_project_manager
+from lib.project_manager import ProjectManager, get_project_manager
 from lib.resource_paths import resource_relative_path
 from lib.storyboard_sequence import find_storyboard_item, get_storyboard_items
 from server.services.upload_finalize import write_bytes_atomic
+
+logger = logging.getLogger(__name__)
 
 END_FRAME_RESOURCE_TYPE = "end_frames"
 
@@ -68,6 +77,40 @@ def _snapshot_target(project_path: Path, shot_id: str) -> tuple[Path, str]:
     return target, relative
 
 
+def _restore_after_persist_failure(
+    manager: ProjectManager,
+    project_name: str,
+    script_file: str,
+    target: Path,
+    old_bytes: bytes | None,
+    expected_current: bytes | None,
+) -> None:
+    """剧本持久化失败后的补偿：在新的一次剧本锁临界区内条件回滚快照文件。
+
+    补偿本身必须重新过锁——`locked_script` 在锁内完成持久化，异常向上传播前锁已释放，
+    若在锁外直接按调用方持有的旧字节回写，会跟同一间隙内另一个成功落盘的并发请求打架。
+    回滚前用 `expected_current` 复核文件当前内容是否仍是本次失败前留下的状态：仍是则说明这段时间无人接手，安全回滚；
+    已不是则说明并发操作已经用它自己的一次原子写快照+写字段接管，当前状态已自洽，
+    回滚只会用陈旧字节覆盖它的成果，直接跳过。
+    """
+    try:
+        with manager.locked_script(project_name, script_file):
+            current = target.read_bytes() if target.exists() else None
+            if current != expected_current:
+                return
+            if old_bytes is not None:
+                write_bytes_atomic(old_bytes, target)
+            else:
+                target.unlink(missing_ok=True)
+    except BaseException:
+        logger.exception(
+            "尾帧快照回滚失败：project=%s script=%s target=%s（原持久化异常见上一条 traceback）",
+            project_name,
+            script_file,
+            target,
+        )
+
+
 def _write_snapshot_and_field(
     project_name: str,
     script_file: str,
@@ -92,11 +135,10 @@ def _write_snapshot_and_field(
                     raise EndFrameError("segment_not_found", status_code=404, id=shot_id)
                 write_bytes_atomic(png_bytes, target)
                 matched[0]["end_frame_image"] = relative
+    except EndFrameError:
+        raise
     except BaseException:
-        if old_bytes is not None:
-            write_bytes_atomic(old_bytes, target)
-        else:
-            target.unlink(missing_ok=True)
+        _restore_after_persist_failure(manager, project_name, script_file, target, old_bytes, png_bytes)
         raise
 
 
@@ -117,9 +159,10 @@ def _clear_snapshot_and_field(project_name: str, script_file: str, shot_id: str,
                     raise EndFrameError("segment_not_found", status_code=404, id=shot_id)
                 matched[0]["end_frame_image"] = None
                 target.unlink(missing_ok=True)
+    except EndFrameError:
+        raise
     except BaseException:
-        if old_bytes is not None:
-            write_bytes_atomic(old_bytes, target)
+        _restore_after_persist_failure(manager, project_name, script_file, target, old_bytes, expected_current=None)
         raise
 
 

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -22,12 +22,14 @@ mid-flight 被删除而失败时跳过整段写回，不留半截状态。
 是否跳过。孤儿快照文件（如进程在文件写完、锁释放前被杀）仍可能残留，无害，与 storyboards
 现状一致，不做清理机制。
 
-代次键须按 `ProjectManager` 内部同款规则归一化剧本文件名（见 `_normalize_script_file`）——
-`episode_1.json` 与 `scripts/episode_1.json` 是同一剧本的合法别名，不归一的话两个别名各自
-生成一把代次键，用不同别名操作同一镜头的并发请求就互相看不见。回滚基线（`old_bytes`）须在
-取得剧本锁之后、mutation 之前读取，不能在锁外预读——锁外预读的话，若本次操作前还有一次
-并发写入抢先成功落盘，读到的就是比"操作前"更早的陈旧内容，失败时会用它覆盖那次已成功的
-写入，即便代次判定本身没有问题。
+代次键须按 `ProjectManager.normalize_script_filename` 归一化剧本文件名——`episode_1.json`
+与 `scripts/episode_1.json` 是同一剧本的合法别名，不归一的话两个别名各自生成一把代次键，
+用不同别名操作同一镜头的并发请求就互相看不见。归一化调用 `ProjectManager` 的公开入口而非
+在本文件复刻其内部规则，避免上游改动（如支持新别名形式）时两处静默漂移、代次键重新分裂。
+
+回滚基线（`old_bytes`）须在取得剧本锁之后、mutation 之前读取，不能在锁外预读——锁外预读的话，
+若本次操作前还有一次并发写入抢先成功落盘，读到的就是比"操作前"更早的陈旧内容，失败时会用
+它覆盖那次已成功的写入，即便代次判定本身没有问题。
 """
 
 from __future__ import annotations
@@ -67,17 +69,6 @@ def _advance_shot_generation(key: _ShotKey) -> int:
         generation = _shot_generations.get(key, 0) + 1
         _shot_generations[key] = generation
         return generation
-
-
-def _normalize_script_file(script_file: str) -> str:
-    """按 `ProjectManager.locked_script`/`_script_lock` 同款规则归一化剧本文件名。
-
-    `episode_1.json` 与 `scripts/episode_1.json` 是指向同一剧本的合法别名，
-    `ProjectManager` 内部按此规则归一到同一把文件锁；代次键若直接用调用方传入的原始
-    字符串，两个别名会各自生成一把代次键，互相看不见对方——两个并发请求分别用不同别名
-    操作同一镜头时，失败一方的补偿据此误判「无人接手」，用旧字节覆盖对方已成功落盘的内容。
-    """
-    return script_file[len("scripts/") :] if script_file.startswith("scripts/") else script_file
 
 
 class EndFrameError(Exception):
@@ -170,7 +161,7 @@ def _write_snapshot_and_field(
     已成功的写入覆盖掉。
     """
     manager = get_project_manager()
-    key = (project_name, _normalize_script_file(script_file), shot_id)
+    key = (project_name, ProjectManager.normalize_script_filename(script_file), shot_id)
     generation = 0
     old_bytes: bytes | None = None
     entered = False
@@ -202,7 +193,7 @@ def _clear_snapshot_and_field(project_name: str, script_file: str, shot_id: str,
     同 `_write_snapshot_and_field`。
     """
     manager = get_project_manager()
-    key = (project_name, _normalize_script_file(script_file), shot_id)
+    key = (project_name, ProjectManager.normalize_script_filename(script_file), shot_id)
     generation = 0
     old_bytes: bytes | None = None
     entered = False

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -21,6 +21,13 @@ mid-flight 被删除而失败时跳过整段写回，不留半截状态。
 成功与否，只要有人在本次失败到回滚重新过锁之间进入过临界区，代次必然前移，据此可靠判定
 是否跳过。孤儿快照文件（如进程在文件写完、锁释放前被杀）仍可能残留，无害，与 storyboards
 现状一致，不做清理机制。
+
+代次键须按 `ProjectManager` 内部同款规则归一化剧本文件名（见 `_normalize_script_file`）——
+`episode_1.json` 与 `scripts/episode_1.json` 是同一剧本的合法别名，不归一的话两个别名各自
+生成一把代次键，用不同别名操作同一镜头的并发请求就互相看不见。回滚基线（`old_bytes`）须在
+取得剧本锁之后、mutation 之前读取，不能在锁外预读——锁外预读的话，若本次操作前还有一次
+并发写入抢先成功落盘，读到的就是比"操作前"更早的陈旧内容，失败时会用它覆盖那次已成功的
+写入，即便代次判定本身没有问题。
 """
 
 from __future__ import annotations
@@ -60,6 +67,17 @@ def _advance_shot_generation(key: _ShotKey) -> int:
         generation = _shot_generations.get(key, 0) + 1
         _shot_generations[key] = generation
         return generation
+
+
+def _normalize_script_file(script_file: str) -> str:
+    """按 `ProjectManager.locked_script`/`_script_lock` 同款规则归一化剧本文件名。
+
+    `episode_1.json` 与 `scripts/episode_1.json` 是指向同一剧本的合法别名，
+    `ProjectManager` 内部按此规则归一到同一把文件锁；代次键若直接用调用方传入的原始
+    字符串，两个别名会各自生成一把代次键，互相看不见对方——两个并发请求分别用不同别名
+    操作同一镜头时，失败一方的补偿据此误判「无人接手」，用旧字节覆盖对方已成功落盘的内容。
+    """
+    return script_file[len("scripts/") :] if script_file.startswith("scripts/") else script_file
 
 
 class EndFrameError(Exception):
@@ -147,15 +165,21 @@ def _write_snapshot_and_field(
 
     剧本持久化失败（校验/落盘异常）时把快照文件还原成操作前状态——否则字段写入
     虽被回滚，快照文件的旧内容已被静默替换，调用方收到失败响应却看不出内容已丢失。
+    读旧字节须在取得剧本锁之后、写入之前——锁外预读的话，若排在本次操作之前还有一次
+    并发写入抢先成功落盘，预读到的就是比"操作前"更早的陈旧内容，失败时会用它把那次
+    已成功的写入覆盖掉。
     """
     manager = get_project_manager()
-    key = (project_name, script_file, shot_id)
-    old_bytes = target.read_bytes() if target.exists() else None
-    generation = _current_shot_generation(key)
+    key = (project_name, _normalize_script_file(script_file), shot_id)
+    generation = 0
+    old_bytes: bytes | None = None
+    entered = False
     try:
         with project_change_source("webui"):
             with manager.locked_script(project_name, script_file) as script:
                 generation = _advance_shot_generation(key)
+                entered = True
+                old_bytes = target.read_bytes() if target.exists() else None
                 items, id_field, _, _, _ = get_storyboard_items(script)
                 matched = find_storyboard_item(items, id_field, shot_id)
                 if matched is None:
@@ -165,7 +189,8 @@ def _write_snapshot_and_field(
     except EndFrameError:
         raise
     except BaseException:
-        _restore_after_persist_failure(manager, project_name, script_file, target, old_bytes, key, generation)
+        if entered:
+            _restore_after_persist_failure(manager, project_name, script_file, target, old_bytes, key, generation)
         raise
 
 
@@ -173,16 +198,20 @@ def _clear_snapshot_and_field(project_name: str, script_file: str, shot_id: str,
     """在剧本锁临界区内完成「置空字段 + 删快照文件」，与设置操作互斥。
 
     剧本持久化失败时把已删除的快照文件恢复——否则字段清空虽被回滚（仍指向原路径），
-    快照文件已被删除，重新落回悬空引用。
+    快照文件已被删除，重新落回悬空引用。读旧字节须在取得剧本锁之后、删除之前，理由
+    同 `_write_snapshot_and_field`。
     """
     manager = get_project_manager()
-    key = (project_name, script_file, shot_id)
-    old_bytes = target.read_bytes() if target.exists() else None
-    generation = _current_shot_generation(key)
+    key = (project_name, _normalize_script_file(script_file), shot_id)
+    generation = 0
+    old_bytes: bytes | None = None
+    entered = False
     try:
         with project_change_source("webui"):
             with manager.locked_script(project_name, script_file) as script:
                 generation = _advance_shot_generation(key)
+                entered = True
+                old_bytes = target.read_bytes() if target.exists() else None
                 items, id_field, _, _, _ = get_storyboard_items(script)
                 matched = find_storyboard_item(items, id_field, shot_id)
                 if matched is None:
@@ -192,7 +221,8 @@ def _clear_snapshot_and_field(project_name: str, script_file: str, shot_id: str,
     except EndFrameError:
         raise
     except BaseException:
-        _restore_after_persist_failure(manager, project_name, script_file, target, old_bytes, key, generation)
+        if entered:
+            _restore_after_persist_failure(manager, project_name, script_file, target, old_bytes, key, generation)
         raise
 
 

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -6,8 +6,11 @@
 只存该固定相对路径。源图与快照就此彻底解耦——源图重生成、版本回滚、删除都动不到
 已定尾帧，结构上不存在悬空引用。
 
-写入顺序遵循「先落文件、后写字段」（清除时反向），任一步失败都不会留下指向缺失
-文件的字段值；残留的孤儿快照文件无害，与 storyboards 现状一致，不做清理机制。
+设置写快照文件 + 写字段、清除删快照文件 + 置空字段，各自整段落在同一把剧本锁
+（`ProjectManager.locked_script`）临界区内完成，与对方互斥——不会出现一方写完文件、
+对方抢在字段写回前把文件删掉的交错，结构上杜绝悬空引用。临界区内失败（如目标镜头
+mid-flight 被删除）会跳过整段写回，不留半截状态；孤儿快照文件（如进程在文件写完、
+锁释放前被杀）仍可能残留，无害，与 storyboards 现状一致，不做清理机制。
 """
 
 from __future__ import annotations
@@ -21,7 +24,7 @@ from lib.project_change_hints import project_change_source
 from lib.project_manager import get_project_manager
 from lib.resource_paths import resource_relative_path
 from lib.storyboard_sequence import find_storyboard_item, get_storyboard_items
-from server.services.upload_finalize import save_uploaded_bytes
+from server.services.upload_finalize import write_bytes_atomic
 
 END_FRAME_RESOURCE_TYPE = "end_frames"
 
@@ -65,8 +68,15 @@ def _snapshot_target(project_path: Path, shot_id: str) -> tuple[Path, str]:
     return target, relative
 
 
-def _write_end_frame_field(project_name: str, script_file: str, shot_id: str, value: str | None) -> None:
-    """在剧本锁内把镜头条目的 ``end_frame_image`` 写成 value（``None`` 即清除）。"""
+def _write_snapshot_and_field(
+    project_name: str,
+    script_file: str,
+    shot_id: str,
+    target: Path,
+    png_bytes: bytes,
+    relative: str,
+) -> None:
+    """在剧本锁临界区内完成「写快照文件 + 写字段」，与清除操作互斥。"""
     manager = get_project_manager()
     with project_change_source("webui"):
         with manager.locked_script(project_name, script_file) as script:
@@ -74,7 +84,21 @@ def _write_end_frame_field(project_name: str, script_file: str, shot_id: str, va
             matched = find_storyboard_item(items, id_field, shot_id)
             if matched is None:
                 raise EndFrameError("segment_not_found", status_code=404, id=shot_id)
-            matched[0]["end_frame_image"] = value
+            write_bytes_atomic(png_bytes, target)
+            matched[0]["end_frame_image"] = relative
+
+
+def _clear_snapshot_and_field(project_name: str, script_file: str, shot_id: str, target: Path) -> None:
+    """在剧本锁临界区内完成「置空字段 + 删快照文件」，与设置操作互斥。"""
+    manager = get_project_manager()
+    with project_change_source("webui"):
+        with manager.locked_script(project_name, script_file) as script:
+            items, id_field, _, _, _ = get_storyboard_items(script)
+            matched = find_storyboard_item(items, id_field, shot_id)
+            if matched is None:
+                raise EndFrameError("segment_not_found", status_code=404, id=shot_id)
+            matched[0]["end_frame_image"] = None
+            target.unlink(missing_ok=True)
 
 
 def read_project_image(project_path: Path, source_path: str) -> bytes:
@@ -114,8 +138,7 @@ async def _apply_snapshot(
     except ValueError as exc:
         raise EndFrameError("invalid_image_file") from exc
 
-    await save_uploaded_bytes(png_bytes, target)
-    await asyncio.to_thread(_write_end_frame_field, project_name, script_file, shot_id, relative)
+    await asyncio.to_thread(_write_snapshot_and_field, project_name, script_file, shot_id, target, png_bytes, relative)
     return relative
 
 
@@ -157,12 +180,7 @@ async def set_end_frame_from_project_image(
 
 
 async def clear_end_frame(*, project_name: str, script_file: str, shot_id: str) -> None:
-    """清除镜头尾帧：先把字段置空，再删快照文件。
-
-    先置空字段可保证删文件失败时不留下指向缺失文件的引用（data_validator 会判 error）；
-    反之残留的快照文件无害。
-    """
+    """清除镜头尾帧：在同一剧本锁临界区内把字段置空并删快照文件，与设置操作互斥。"""
     project_path = await asyncio.to_thread(_locate_shot, project_name, script_file, shot_id)
     target, _ = _snapshot_target(project_path, shot_id)
-    await asyncio.to_thread(_write_end_frame_field, project_name, script_file, shot_id, None)
-    await asyncio.to_thread(target.unlink, missing_ok=True)
+    await asyncio.to_thread(_clear_snapshot_and_field, project_name, script_file, shot_id, target)

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -30,6 +30,10 @@ mid-flight 被删除而失败时跳过整段写回，不留半截状态。
 回滚基线（`old_bytes`）须在取得剧本锁之后、mutation 之前读取，不能在锁外预读——锁外预读的话，
 若本次操作前还有一次并发写入抢先成功落盘，读到的就是比"操作前"更早的陈旧内容，失败时会用
 它覆盖那次已成功的写入，即便代次判定本身没有问题。
+
+标记"可补偿"（`entered`）须在基线读取*成功之后*才置位，不能在读之前——读之前置位的话，
+读基线本身失败（权限 / 临时 IO 错误）时 `old_bytes` 仍是初始的 `None`，补偿会把"读失败"
+误判成"目标文件原本不存在"，进而 unlink 一个从未被本次操作触碰过的既有快照。
 """
 
 from __future__ import annotations
@@ -110,6 +114,17 @@ def _snapshot_target(project_path: Path, shot_id: str) -> tuple[Path, str]:
     return target, relative
 
 
+class _RollbackDone(Exception):
+    """哨兵：标记补偿分支已跑完，用于跳过 `locked_script` 退出时的正常剧本写回。
+
+    `locked_script` 基于 `@contextmanager`：`with` 体内无论正常落出还是 `return`，生成器都
+    会在 `yield` 之后继续跑 `_write_script_unlocked`。补偿只改快照文件，从不读改 `script`，
+    正常落出会触发一次多余落盘（附带更新 `metadata["updated_at"]`、触发项目同步与变更事件，
+    失败时还会被这里的 `except Exception` 误记成"回滚失败"）。抛这个哨兵异常换生成器在
+    `yield` 处直接重新抛出，绕过写回；下面的 `except _RollbackDone: pass` 吞掉它。
+    """
+
+
 def _restore_after_persist_failure(
     manager: ProjectManager,
     project_name: str,
@@ -130,11 +145,14 @@ def _restore_after_persist_failure(
     try:
         with manager.locked_script(project_name, script_file):
             if _current_shot_generation(key) != expected_generation:
-                return
+                raise _RollbackDone
             if old_bytes is not None:
                 write_bytes_atomic(old_bytes, target)
             else:
                 target.unlink(missing_ok=True)
+            raise _RollbackDone
+    except _RollbackDone:
+        pass
     except Exception:
         logger.exception(
             "尾帧快照回滚失败：project=%s script=%s target=%s（原持久化异常见上一条 traceback）",
@@ -169,8 +187,8 @@ def _write_snapshot_and_field(
         with project_change_source("webui"):
             with manager.locked_script(project_name, script_file) as script:
                 generation = _advance_shot_generation(key)
-                entered = True
                 old_bytes = target.read_bytes() if target.exists() else None
+                entered = True
                 items, id_field, _, _, _ = get_storyboard_items(script)
                 matched = find_storyboard_item(items, id_field, shot_id)
                 if matched is None:
@@ -201,8 +219,8 @@ def _clear_snapshot_and_field(project_name: str, script_file: str, shot_id: str,
         with project_change_source("webui"):
             with manager.locked_script(project_name, script_file) as script:
                 generation = _advance_shot_generation(key)
-                entered = True
                 old_bytes = target.read_bytes() if target.exists() else None
+                entered = True
                 items, id_field, _, _, _ = get_storyboard_items(script)
                 matched = find_storyboard_item(items, id_field, shot_id)
                 if matched is None:

--- a/server/services/upload_finalize.py
+++ b/server/services/upload_finalize.py
@@ -104,20 +104,25 @@ async def save_uploaded_video_stream(src: BinaryIO, target: Path, *, max_bytes: 
         raise
 
 
+def write_bytes_atomic(content: bytes, target: Path) -> None:
+    """同步版本：把内存中的内容原子写入 target（同 dot-tmp + replace + 失败清理）。
+
+    阻塞 I/O，供调用方自行决定线程化时机——需要与其它阻塞操作（如剧本锁）共享
+    同一临界区时（见 `server/services/end_frame.py`），不能各自套一层 `asyncio.to_thread`。
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = _upload_tmp_path(target)
+    try:
+        tmp_path.write_bytes(content)
+        tmp_path.replace(target)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
 async def save_uploaded_bytes(content: bytes, target: Path) -> None:
     """把内存中的上传内容原子写入 target（同 dot-tmp + replace + 失败清理）。"""
-
-    def _write() -> None:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = _upload_tmp_path(target)
-        try:
-            tmp_path.write_bytes(content)
-            tmp_path.replace(target)
-        except BaseException:
-            tmp_path.unlink(missing_ok=True)
-            raise
-
-    await asyncio.to_thread(_write)
+    await asyncio.to_thread(write_bytes_atomic, content, target)
 
 
 def record_upload_version(

--- a/tests/test_end_frame_model.py
+++ b/tests/test_end_frame_model.py
@@ -1,0 +1,205 @@
+"""``end_frame_image`` 的数据模型、PATCH 白名单与 data_validator 校验测试。
+
+三骨架（narration 片段 / drama 场景 / ad 镜头）同构持有该字段：默认空、参与
+Python 端序列化与校验、对 LLM 隐藏。写入通道只有尾帧专用端点——通用剧本 PATCH
+刻意不放行该字段，否则原样写值会绕过快照复制、重开悬空引用与越界路径的口子。
+"""
+
+from io import BytesIO
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from lib.data_validator import DataValidator
+from lib.project_manager import ProjectManager
+from lib.script_models import (
+    AdShot,
+    Composition,
+    DramaScene,
+    DramaVideoPrompt,
+    ImagePrompt,
+    NarrationSegment,
+    VideoPrompt,
+)
+from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
+from server.routers import projects as projects_router
+
+END_FRAME_REL = "end_frames/scene_E1S01.png"
+
+
+def _image_prompt() -> ImagePrompt:
+    return ImagePrompt(
+        scene="场景",
+        composition=Composition(shot_type="Medium Shot", lighting="暖光", ambiance="薄雾"),
+    )
+
+
+def _narration_segment(**overrides) -> NarrationSegment:
+    return NarrationSegment(
+        segment_id="E1S01",
+        duration_seconds=4,
+        novel_text="原文",
+        characters_in_segment=[],
+        image_prompt=_image_prompt(),
+        video_prompt=VideoPrompt(action="转身", camera_motion="Static", ambiance_audio="风声"),
+        **overrides,
+    )
+
+
+def _drama_scene(**overrides) -> DramaScene:
+    return DramaScene(
+        scene_id="E1S01",
+        characters_in_scene=[],
+        image_prompt=_image_prompt(),
+        video_prompt=DramaVideoPrompt(action="转身", camera_motion="Static", ambiance_audio="风声"),
+        **overrides,
+    )
+
+
+def _ad_shot(**overrides) -> AdShot:
+    return AdShot(
+        shot_id="E1S01",
+        section="hook",
+        duration_seconds=3,
+        voiceover_text="开场口播",
+        image_prompt=_image_prompt(),
+        video_prompt=VideoPrompt(action="转身", camera_motion="Static", ambiance_audio="风声"),
+        **overrides,
+    )
+
+
+_BUILDERS = pytest.mark.parametrize(
+    "build", [_narration_segment, _drama_scene, _ad_shot], ids=["narration", "drama", "ad"]
+)
+
+
+class TestEndFrameImageField:
+    @_BUILDERS
+    def test_defaults_to_none(self, build) -> None:
+        assert build().end_frame_image is None
+
+    @_BUILDERS
+    def test_round_trips_through_serialization(self, build) -> None:
+        item = build(end_frame_image=END_FRAME_REL)
+        dumped = item.model_dump()
+        assert dumped["end_frame_image"] == END_FRAME_REL
+        assert type(item).model_validate(dumped).end_frame_image == END_FRAME_REL
+
+    @_BUILDERS
+    def test_absent_key_loads_as_none(self, build) -> None:
+        """存量剧本没有该键：extra=forbid 下仍须放行并落回默认空。"""
+        model = type(build())
+        payload = build().model_dump()
+        payload.pop("end_frame_image")
+        assert model.model_validate(payload).end_frame_image is None
+
+
+def _seed_project(tmp_path, content_mode: str) -> ProjectManager:
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Demo", "Anime", content_mode)
+    if content_mode == "narration":
+        script = {"segments": [{"segment_id": "E1S01", "novel_text": "t", "duration_seconds": 5}]}
+    elif content_mode == "drama":
+        script = {"scenes": [{"scene_id": "E1S01", "duration_seconds": 5}]}
+    else:
+        script = {"shots": [{"shot_id": "E1S01", "section": "hook", "voiceover_text": "v", "duration_seconds": 3}]}
+    pm.save_script(
+        "demo",
+        {"episode": 1, "title": "E1", "content_mode": content_mode, **script},
+        "episode_1.json",
+        validate=False,
+    )
+    return pm
+
+
+def _projects_client(pm: ProjectManager, monkeypatch) -> TestClient:
+    monkeypatch.setattr(projects_router, "get_project_manager", lambda: pm)
+    app = FastAPI()
+    register_error_handlers(app)
+    app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+    app.include_router(projects_router.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+class TestGenericPatchIgnoresEndFrame:
+    """通用剧本 PATCH 白名单不含 end_frame_image：设置尾帧只能走专用端点。"""
+
+    @pytest.mark.parametrize(
+        ("content_mode", "path", "items_key", "id_key", "flat_body"),
+        [
+            # narration 走显式 Pydantic 请求体（字段级白名单），drama/ad 走 updates 字典白名单
+            ("narration", "segments", "segments", "segment_id", True),
+            ("drama", "script-scenes", "scenes", "scene_id", False),
+            ("ad", "script-shots", "shots", "shot_id", False),
+        ],
+    )
+    def test_patch_does_not_write_end_frame_image(
+        self, tmp_path, monkeypatch, content_mode, path, items_key, id_key, flat_body
+    ):
+        pm = _seed_project(tmp_path, content_mode)
+        client = _projects_client(pm, monkeypatch)
+
+        # 白名单内的 note 一并提交：它生效即证明 PATCH 确实执行了，end_frame_image 是被单独忽略
+        updates = {"end_frame_image": "../../../etc/passwd", "note": "备注"}
+        body = (
+            {"script_file": "episode_1.json", **updates}
+            if flat_body
+            else {
+                "script_file": "episode_1.json",
+                "updates": updates,
+            }
+        )
+        resp = client.patch(f"/api/v1/projects/demo/{path}/E1S01", json=body)
+        assert resp.status_code == 200, resp.text
+
+        item = pm.load_script("demo", "episode_1.json")[items_key][0]
+        assert item[id_key] == "E1S01"
+        assert item["note"] == "备注"
+        assert item.get("end_frame_image") is None
+
+
+def _write_png(path, size=(8, 8)) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    buf = BytesIO()
+    Image.new("RGB", size, (255, 0, 0)).save(buf, format="PNG")
+    path.write_bytes(buf.getvalue())
+
+
+class TestDataValidatorEndFramePath:
+    @pytest.fixture
+    def project(self, tmp_path):
+        pm = _seed_project(tmp_path, "narration")
+        return pm, DataValidator(projects_root=str(pm.projects_root))
+
+    def _validate_with(self, pm, validator, end_frame_value):
+        script = pm.load_script("demo", "episode_1.json")
+        script["segments"][0]["end_frame_image"] = end_frame_value
+        pm.save_script("demo", script, "episode_1.json", validate=False)
+        return validator.validate_episode("demo", "episode_1.json")
+
+    def test_existing_snapshot_passes(self, project):
+        pm, validator = project
+        _write_png(pm.get_project_path("demo") / END_FRAME_REL)
+        result = self._validate_with(pm, validator, END_FRAME_REL)
+        assert not [e for e in result.errors if "end_frame_image" in e]
+
+    def test_missing_snapshot_is_error(self, project):
+        pm, validator = project
+        result = self._validate_with(pm, validator, END_FRAME_REL)
+        assert [e for e in result.errors if "end_frame_image" in e]
+        assert not result.valid
+
+    def test_traversal_path_is_error(self, project):
+        pm, validator = project
+        result = self._validate_with(pm, validator, "../../../etc/passwd")
+        assert [e for e in result.errors if "end_frame_image" in e and "越界" in e]
+        assert not result.valid
+
+    def test_null_is_accepted(self, project):
+        pm, validator = project
+        result = self._validate_with(pm, validator, None)
+        assert not [e for e in result.errors if "end_frame_image" in e]

--- a/tests/test_end_frame_model.py
+++ b/tests/test_end_frame_model.py
@@ -220,3 +220,11 @@ class TestDataValidatorEndFramePath:
         result = self._validate_with(pm, validator, "end_frames/../storyboards/scene_E1S02.png")
         assert [e for e in result.errors if "end_frame_image" in e]
         assert not result.valid
+
+    def test_directory_reference_is_error(self, project):
+        """指向 end_frames/ 下确实存在的目录须拒绝——校验只认普通文件，不认目录。"""
+        pm, validator = project
+        (pm.get_project_path("demo") / "end_frames" / "scene_E1S01.png").mkdir(parents=True)
+        result = self._validate_with(pm, validator, END_FRAME_REL)
+        assert [e for e in result.errors if "end_frame_image" in e]
+        assert not result.valid

--- a/tests/test_end_frame_model.py
+++ b/tests/test_end_frame_model.py
@@ -203,3 +203,20 @@ class TestDataValidatorEndFramePath:
         pm, validator = project
         result = self._validate_with(pm, validator, None)
         assert not [e for e in result.errors if "end_frame_image" in e]
+
+    def test_path_outside_end_frames_dir_is_error(self, project):
+        """指向 end_frames/ 之外目录内确实存在的文件也须拒绝——字段只认服务层写出的快照路径，
+        否则等于绕过快照复制直接引用源图，重新引入源图耦合。"""
+        pm, validator = project
+        _write_png(pm.get_project_path("demo") / "storyboards/scene_E1S02.png")
+        result = self._validate_with(pm, validator, "storyboards/scene_E1S02.png")
+        assert [e for e in result.errors if "end_frame_image" in e]
+        assert not result.valid
+
+    def test_dot_dot_escaping_end_frames_prefix_is_error(self, project):
+        """`end_frames/../storyboards/x.png` 表面以 end_frames 前缀开头，实际逃出该目录，同样拒绝。"""
+        pm, validator = project
+        _write_png(pm.get_project_path("demo") / "storyboards/scene_E1S02.png")
+        result = self._validate_with(pm, validator, "end_frames/../storyboards/scene_E1S02.png")
+        assert [e for e in result.errors if "end_frame_image" in e]
+        assert not result.valid

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -287,6 +287,63 @@ class TestConcurrentSetClear:
             # 清除赢：字段置空，文件可能已删或残留孤儿（无害），但不检验其存在性
 
 
+class TestPersistFailureRestoresSnapshot:
+    """剧本持久化在临界区内失败时，快照文件须回滚到操作前状态，不留悬空引用或静默丢失。"""
+
+    @pytest.mark.integration
+    def test_set_failure_restores_previous_snapshot_bytes(self, client, monkeypatch):
+        c, pm = client
+        _upload(c, _img_bytes("PNG", size=(8, 8)))
+        snapshot = pm.get_project_path("demo") / END_FRAME_REL
+        before = snapshot.read_bytes()
+
+        def _boom(*_a, **_k):
+            raise ValueError("simulated persist failure")
+
+        monkeypatch.setattr(ProjectManager, "_write_script_unlocked", _boom)
+        resp = _upload(c, _img_bytes("PNG", size=(16, 16)))
+        assert resp.status_code == 500
+
+        # 字段未变（写回被跳过），快照文件也须还原成写前内容——不能是被换图覆盖后的新内容
+        assert _segment(pm)["end_frame_image"] == END_FRAME_REL
+        assert snapshot.read_bytes() == before
+
+    @pytest.mark.integration
+    def test_set_failure_on_first_write_removes_snapshot(self, client, monkeypatch):
+        """此前未设置过尾帧时失败：快照文件此前不存在，须整段撤回而非留下孤儿文件。"""
+        c, pm = client
+        snapshot = pm.get_project_path("demo") / END_FRAME_REL
+
+        def _boom(*_a, **_k):
+            raise ValueError("simulated persist failure")
+
+        monkeypatch.setattr(ProjectManager, "_write_script_unlocked", _boom)
+        resp = _upload(c, _img_bytes("PNG"))
+        assert resp.status_code == 500
+
+        assert _segment(pm).get("end_frame_image") is None
+        assert not snapshot.exists()
+
+    @pytest.mark.integration
+    def test_clear_failure_restores_deleted_snapshot(self, client, monkeypatch):
+        c, pm = client
+        _upload(c, _img_bytes("PNG"))
+        snapshot = pm.get_project_path("demo") / END_FRAME_REL
+        before = snapshot.read_bytes()
+
+        def _boom(*_a, **_k):
+            raise ValueError("simulated persist failure")
+
+        monkeypatch.setattr(ProjectManager, "_write_script_unlocked", _boom)
+        resp = _delete(c)
+        assert resp.status_code == 500
+
+        # 字段未变（仍指向原路径），快照文件须恢复——否则字段回滚后指向的是已删除的文件
+        assert _segment(pm)["end_frame_image"] == END_FRAME_REL
+        assert snapshot.exists()
+        assert snapshot.read_bytes() == before
+
+
 class TestErrorMapping:
     """领域错误到 HTTP 的映射：三个端点行为一致，不泄漏服务器路径。"""
 

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -306,11 +306,15 @@ def _fail_first_persist(monkeypatch):
     monkeypatch.setattr(ProjectManager, "_write_script_unlocked", _boom)
 
 
-def _inject_concurrent_write_before_nth_load(monkeypatch, target: Path, content: bytes, n: int):
-    """模拟「回滚重新过锁前，另一个并发请求已抢先完成自己的一次成功落盘」。
+def _inject_concurrent_takeover_before_nth_load(monkeypatch, key, target: Path, content: bytes | None, n: int):
+    """模拟「回滚重新过锁前，另一个并发请求已抢先完整地执行完自己的一次操作」。
+
+    回滚判定的是「操作代次」而非文件内容（见 end_frame.py 模块 docstring 的退化值说明），
+    所以这里不能只改文件字节，还要推进该镜头的代次，否则复现不出代次判定要拦截的场景。
+    `content=None` 表示并发的那一次是清除（文件被删）；否则表示并发的那一次是设置。
 
     补偿回滚会再发起一次 `locked_script`，其 `load_script` 调用即回滚临界区的起点——在其
-    第 n 次被调用时把 target 改写为 content，相当于并发请求恰好在回滚拿到锁之前完成。
+    第 n 次被调用时执行这次「并发接管」，相当于恰好在回滚拿到锁之前完成。
     """
     original = ProjectManager.load_script
     calls = {"n": 0}
@@ -318,7 +322,11 @@ def _inject_concurrent_write_before_nth_load(monkeypatch, target: Path, content:
     def _load_with_race(self, *args, **kwargs):
         calls["n"] += 1
         if calls["n"] == n:
-            target.write_bytes(content)
+            end_frame_service._advance_shot_generation(key)
+            if content is None:
+                target.unlink(missing_ok=True)
+            else:
+                target.write_bytes(content)
         return original(self, *args, **kwargs)
 
     monkeypatch.setattr(ProjectManager, "load_script", _load_with_race)
@@ -373,15 +381,16 @@ class TestPersistFailureRestoresSnapshot:
 
     @pytest.mark.integration
     def test_set_failure_skips_restore_when_concurrent_write_supersedes(self, client, monkeypatch):
-        """回滚重新过锁时若文件内容已不是本次失败前写入的字节，说明并发请求已经接管，
+        """回滚重新过锁时若该镜头的操作代次已前移，说明并发请求已经接管，
         必须跳过回滚——否则会用陈旧字节覆盖对方刚成功落盘的内容。"""
         c, pm = client
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
+        key = ("demo", "episode_1.json", "E1S01")
         concurrent_bytes = _img_bytes("PNG", size=(32, 32))
 
         _fail_first_persist(monkeypatch)
         # load 序列：_locate_shot(1) → 本次失败的 locked_script(2) → 回滚的 locked_script(3)
-        _inject_concurrent_write_before_nth_load(monkeypatch, snapshot, concurrent_bytes, n=3)
+        _inject_concurrent_takeover_before_nth_load(monkeypatch, key, snapshot, concurrent_bytes, n=3)
 
         resp = _upload(c, _img_bytes("PNG", size=(16, 16)))
         assert resp.status_code == 500
@@ -393,10 +402,11 @@ class TestPersistFailureRestoresSnapshot:
         c, pm = client
         _upload(c, _img_bytes("PNG"))
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
+        key = ("demo", "episode_1.json", "E1S01")
         concurrent_bytes = _img_bytes("PNG", size=(40, 40))
 
         _fail_first_persist(monkeypatch)
-        _inject_concurrent_write_before_nth_load(monkeypatch, snapshot, concurrent_bytes, n=3)
+        _inject_concurrent_takeover_before_nth_load(monkeypatch, key, snapshot, concurrent_bytes, n=3)
 
         resp = _delete(c)
         assert resp.status_code == 500
@@ -404,6 +414,26 @@ class TestPersistFailureRestoresSnapshot:
         # 回滚跳过：文件保留并发请求写入的新内容，没有被「删除态」覆盖
         assert snapshot.exists()
         assert snapshot.read_bytes() == concurrent_bytes
+
+    @pytest.mark.integration
+    def test_clear_failure_skips_restore_when_concurrent_clear_wins(self, client, monkeypatch):
+        """CodeRabbit 指出的退化值场景：清除失败后文件已被删（期望内容与「无人接手」的
+        期望值同为 None），并发的另一次清除随后也成功完成，结果同样是文件不存在——若
+        仅比对文件内容将无法区分两者，误判为无人接手并把旧快照字节回滚出孤儿文件。
+        代次判定下，并发清除会推进代次，回滚据此正确跳过。"""
+        c, pm = client
+        _upload(c, _img_bytes("PNG"))
+        snapshot = pm.get_project_path("demo") / END_FRAME_REL
+        key = ("demo", "episode_1.json", "E1S01")
+
+        _fail_first_persist(monkeypatch)
+        _inject_concurrent_takeover_before_nth_load(monkeypatch, key, snapshot, None, n=3)
+
+        resp = _delete(c)
+        assert resp.status_code == 500
+
+        # 回滚跳过：文件保持并发清除后的「已删除」结果，没有被旧字节重新写回制造孤儿文件
+        assert not snapshot.exists()
 
 
 class TestErrorMapping:

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -1,0 +1,317 @@
+"""镜头尾帧设置/清除端点测试。
+
+覆盖两条设置通道（上传 / 项目内选图）落到同一快照路径、换图原地覆盖、清除语义、
+越界与缺失拒绝，以及快照与源图的解耦（源图被改写/删除不影响已定尾帧）。
+"""
+
+import asyncio
+from io import BytesIO
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from lib.data_validator import DataValidator
+from lib.project_manager import ProjectManager
+from lib.script_editor import ScriptEditError
+from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
+from server.routers import end_frames
+from server.services import end_frame as end_frame_service
+from server.services import upload_finalize
+
+END_FRAME_REL = "end_frames/scene_E1S01.png"
+
+
+def _img_bytes(fmt="JPEG", size=(8, 8), color=(255, 0, 0)):
+    image = Image.new("RGB", size, color)
+    buf = BytesIO()
+    image.save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def _seed_project(tmp_path) -> ProjectManager:
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+    pm.save_script(
+        "demo",
+        {
+            "episode": 1,
+            "title": "E1",
+            "content_mode": "narration",
+            "segments": [
+                {
+                    "segment_id": "E1S01",
+                    "novel_text": "t",
+                    "duration_seconds": 5,
+                    "generated_assets": {"status": "pending"},
+                },
+                {
+                    "segment_id": "E1S02",
+                    "novel_text": "t2",
+                    "duration_seconds": 5,
+                    "generated_assets": {"status": "pending"},
+                },
+            ],
+        },
+        "episode_1.json",
+        validate=False,
+    )
+    return pm
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    pm = _seed_project(tmp_path)
+    monkeypatch.setattr(end_frame_service, "get_project_manager", lambda: pm)
+
+    app = FastAPI()
+    register_error_handlers(app)
+    app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+    app.include_router(end_frames.router, prefix="/api/v1")
+    return TestClient(app), pm
+
+
+def _upload(client, content: bytes, filename="frame.jpg", shot_id="E1S01"):
+    return client.post(
+        f"/api/v1/projects/demo/shots/{shot_id}/end-frame/upload?script_file=episode_1.json",
+        files={"file": (filename, BytesIO(content), "application/octet-stream")},
+    )
+
+
+def _select(client, source_path: str, shot_id="E1S01"):
+    return client.post(
+        f"/api/v1/projects/demo/shots/{shot_id}/end-frame/select",
+        json={"script_file": "episode_1.json", "source_path": source_path},
+    )
+
+
+def _delete(client, shot_id="E1S01"):
+    return client.delete(f"/api/v1/projects/demo/shots/{shot_id}/end-frame?script_file=episode_1.json")
+
+
+def _segment(pm: ProjectManager, index: int = 0) -> dict:
+    return pm.load_script("demo", "episode_1.json")["segments"][index]
+
+
+def _write_source_image(pm: ProjectManager, rel: str, content: bytes) -> None:
+    target = pm.get_project_path("demo") / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+
+
+class TestUploadChannel:
+    def test_upload_writes_normalized_png_snapshot_and_field(self, client):
+        c, pm = client
+        resp = _upload(c, _img_bytes("JPEG"))
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["end_frame_image"] == END_FRAME_REL
+
+        assert _segment(pm)["end_frame_image"] == END_FRAME_REL
+        # JPEG 入参统一归一为 PNG（与分镜图上传同口径）
+        with Image.open(pm.get_project_path("demo") / END_FRAME_REL) as img:
+            assert img.format == "PNG"
+
+    def test_replacing_overwrites_in_place(self, client):
+        c, pm = client
+        _upload(c, _img_bytes("JPEG", size=(8, 8)))
+        resp = _upload(c, _img_bytes("PNG", size=(16, 16)))
+        assert resp.status_code == 200, resp.text
+        # 路径固定，字段值不变；文件内容被换掉
+        assert _segment(pm)["end_frame_image"] == END_FRAME_REL
+        with Image.open(pm.get_project_path("demo") / END_FRAME_REL) as img:
+            assert img.size == (16, 16)
+
+    def test_undecodable_bytes_rejected(self, client):
+        c, pm = client
+        resp = _upload(c, b"not an image", filename="frame.png")
+        assert resp.status_code == 400
+        assert _segment(pm).get("end_frame_image") is None
+
+    def test_unsupported_extension_rejected(self, client):
+        c, _pm = client
+        assert _upload(c, _img_bytes("PNG"), filename="frame.gif").status_code == 400
+
+    def test_unknown_shot_returns_404(self, client):
+        c, _pm = client
+        assert _upload(c, _img_bytes("PNG"), shot_id="E9S99").status_code == 404
+
+
+class TestSelectChannel:
+    def test_select_project_image_snapshots_to_end_frames(self, client):
+        c, pm = client
+        _write_source_image(pm, "storyboards/scene_E1S02.png", _img_bytes("PNG", size=(12, 12)))
+
+        resp = _select(c, "storyboards/scene_E1S02.png")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["end_frame_image"] == END_FRAME_REL
+        # 字段存的是快照路径，不是源图路径 —— 引用关系从结构上就不存在
+        assert _segment(pm)["end_frame_image"] == END_FRAME_REL
+        with Image.open(pm.get_project_path("demo") / END_FRAME_REL) as img:
+            assert img.format == "PNG"
+            assert img.size == (12, 12)
+
+    def test_traversal_path_rejected(self, client):
+        c, pm = client
+        resp = _select(c, "../../../etc/passwd")
+        assert resp.status_code == 400
+        assert _segment(pm).get("end_frame_image") is None
+
+    def test_missing_source_returns_404(self, client):
+        c, _pm = client
+        assert _select(c, "storyboards/scene_E1S99.png").status_code == 404
+
+
+class TestClear:
+    def test_clear_deletes_snapshot_and_nulls_field(self, client):
+        c, pm = client
+        _upload(c, _img_bytes("PNG"))
+        snapshot = pm.get_project_path("demo") / END_FRAME_REL
+        assert snapshot.exists()
+
+        resp = _delete(c)
+        assert resp.status_code == 200, resp.text
+        assert _segment(pm)["end_frame_image"] is None
+        assert not snapshot.exists()
+
+    def test_clear_without_end_frame_is_idempotent(self, client):
+        c, pm = client
+        assert _delete(c).status_code == 200
+        assert _segment(pm)["end_frame_image"] is None
+
+    def test_clear_unknown_shot_returns_404(self, client):
+        c, _pm = client
+        assert _delete(c, shot_id="E9S99").status_code == 404
+
+
+class TestSnapshotDecoupling:
+    """快照与源图彻底解耦：源图后续被改写或删除都动不到已定尾帧。"""
+
+    def test_source_rewrite_and_delete_leave_end_frame_intact(self, client):
+        c, pm = client
+        source_rel = "storyboards/scene_E1S02.png"
+        _write_source_image(pm, source_rel, _img_bytes("PNG", size=(12, 12), color=(255, 0, 0)))
+        _select(c, source_rel)
+
+        snapshot = pm.get_project_path("demo") / END_FRAME_REL
+        before = snapshot.read_bytes()
+
+        # 源图重生成（内容与尺寸都变）后再删除，模拟版本回滚 / 资源清理
+        _write_source_image(pm, source_rel, _img_bytes("PNG", size=(24, 24), color=(0, 0, 255)))
+        (pm.get_project_path("demo") / source_rel).unlink()
+
+        assert snapshot.read_bytes() == before
+        assert _segment(pm)["end_frame_image"] == END_FRAME_REL
+
+    def test_per_shot_snapshots_are_independent(self, client):
+        c, pm = client
+        _upload(c, _img_bytes("PNG", size=(8, 8)), shot_id="E1S01")
+        _upload(c, _img_bytes("PNG", size=(16, 16)), shot_id="E1S02")
+
+        assert _segment(pm, 0)["end_frame_image"] == "end_frames/scene_E1S01.png"
+        assert _segment(pm, 1)["end_frame_image"] == "end_frames/scene_E1S02.png"
+
+        # 清一个不影响另一个
+        _delete(c, shot_id="E1S01")
+        assert _segment(pm, 0)["end_frame_image"] is None
+        assert _segment(pm, 1)["end_frame_image"] == "end_frames/scene_E1S02.png"
+        assert (pm.get_project_path("demo") / "end_frames/scene_E1S02.png").exists()
+
+
+class TestErrorMapping:
+    """领域错误到 HTTP 的映射：三个端点行为一致，不泄漏服务器路径。"""
+
+    def test_unknown_script_file_returns_404(self, client):
+        c, _pm = client
+        assert (
+            c.post(
+                "/api/v1/projects/demo/shots/E1S01/end-frame/upload?script_file=missing.json",
+                files={"file": ("f.png", BytesIO(_img_bytes("PNG")), "application/octet-stream")},
+            ).status_code
+            == 404
+        )
+        assert (
+            c.post(
+                "/api/v1/projects/demo/shots/E1S01/end-frame/select",
+                json={"script_file": "missing.json", "source_path": "storyboards/x.png"},
+            ).status_code
+            == 404
+        )
+        assert c.delete("/api/v1/projects/demo/shots/E1S01/end-frame?script_file=missing.json").status_code == 404
+
+    def test_unknown_project_returns_404(self, client):
+        c, _pm = client
+        resp = c.post(
+            "/api/v1/projects/nope/shots/E1S01/end-frame/upload?script_file=episode_1.json",
+            files={"file": ("f.png", BytesIO(_img_bytes("PNG")), "application/octet-stream")},
+        )
+        assert resp.status_code == 404
+
+    def test_empty_source_path_rejected(self, client):
+        c, pm = client
+        assert _select(c, "   ").status_code == 400
+        assert _segment(pm).get("end_frame_image") is None
+
+    def test_oversized_upload_rejected(self, client, monkeypatch):
+        c, pm = client
+        monkeypatch.setattr(upload_finalize, "UPLOAD_IMAGE_MAX_BYTES", 16)
+        resp = _upload(c, _img_bytes("PNG", size=(64, 64)))
+        assert resp.status_code == 413
+        assert _segment(pm).get("end_frame_image") is None
+
+    def test_traversal_shot_id_rejected_before_write(self, client):
+        """剧本里存在越界形状的镜头 id 时，快照路径解析必须拒绝而非写出项目目录。"""
+        _c, pm = client
+        script = pm.load_script("demo", "episode_1.json")
+        script["segments"][0]["segment_id"] = "../../../../evil"
+        pm.save_script("demo", script, "episode_1.json", validate=False)
+
+        with pytest.raises(end_frame_service.EndFrameError) as exc:
+            asyncio.run(
+                end_frame_service.set_end_frame_from_bytes(
+                    project_name="demo",
+                    script_file="episode_1.json",
+                    shot_id="../../../../evil",
+                    content=_img_bytes("PNG"),
+                )
+            )
+        assert exc.value.key == "invalid_resource_id"
+
+    def test_body_exceeding_limit_rejected_after_read(self, client, monkeypatch):
+        """Content-Length 缺失/被绕过时，按实际读入字节数兜底拒绝。"""
+        c, pm = client
+        monkeypatch.setattr(end_frames, "validate_upload", lambda *a, **k: 16)
+        assert _upload(c, _img_bytes("PNG", size=(64, 64))).status_code == 413
+        assert _segment(pm).get("end_frame_image") is None
+
+    def test_script_edit_error_maps_to_400(self, client, monkeypatch):
+        c, _pm = client
+
+        async def _boom(**_kwargs):
+            raise ScriptEditError("坏掉的剧本结构")
+
+        monkeypatch.setattr(end_frames, "set_end_frame_from_bytes", _boom)
+        assert _upload(c, _img_bytes("PNG")).status_code == 400
+
+    def test_unexpected_error_maps_to_500_without_internals(self, client, monkeypatch):
+        c, _pm = client
+
+        async def _boom(**_kwargs):
+            raise RuntimeError("/absolute/server/path/leaked")
+
+        monkeypatch.setattr(end_frames, "set_end_frame_from_bytes", _boom)
+        resp = _upload(c, _img_bytes("PNG"))
+        assert resp.status_code == 500
+        assert "leaked" not in resp.text
+
+
+class TestValidatorAcceptsWrittenSnapshot:
+    def test_written_project_passes_tree_validation(self, client):
+        c, pm = client
+        _upload(c, _img_bytes("PNG"))
+        # end_frames 已登记为允许的项目根目录条目，不被判为未知目录
+        assert "end_frames" in DataValidator.ALLOWED_ROOT_ENTRIES
+        result = DataValidator(projects_root=str(pm.projects_root)).validate_project_tree("demo")
+        assert not [e for e in result.errors if "end_frames" in e]

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -5,6 +5,7 @@
 """
 
 import asyncio
+import threading
 from io import BytesIO
 
 import pytest
@@ -243,6 +244,39 @@ class TestSnapshotDecoupling:
         assert (pm.get_project_path("demo") / "end_frames/scene_E1S02.png").exists()
 
 
+class TestConcurrentSetClear:
+    """设置与清除并发交错时，字段与快照文件必须同进同退，不留悬空引用。"""
+
+    def test_interleaved_set_and_clear_never_dangles(self, client):
+        c, pm = client
+        snapshot = pm.get_project_path("demo") / END_FRAME_REL
+
+        for _ in range(20):
+            barrier = threading.Barrier(2)
+
+            def _do_set():
+                barrier.wait()
+                _upload(c, _img_bytes("PNG"))
+
+            def _do_clear():
+                barrier.wait()
+                _delete(c)
+
+            t_set = threading.Thread(target=_do_set)
+            t_clear = threading.Thread(target=_do_clear)
+            t_set.start()
+            t_clear.start()
+            t_set.join()
+            t_clear.join()
+
+            end_frame_image = _segment(pm).get("end_frame_image")
+            # 设置赢：字段非空则快照文件必须存在——不允许指向缺失文件的引用
+            if end_frame_image is not None:
+                assert end_frame_image == END_FRAME_REL
+                assert snapshot.exists()
+            # 清除赢：字段置空，文件可能已删或残留孤儿（无害），但不检验其存在性
+
+
 class TestErrorMapping:
     """领域错误到 HTTP 的映射：三个端点行为一致，不泄漏服务器路径。"""
 
@@ -262,7 +296,8 @@ class TestErrorMapping:
             ).status_code
             == 404
         )
-        assert c.delete("/api/v1/projects/demo/shots/E1S01/end-frame?script_file=missing.json").status_code == 404
+        resp = c.delete("/api/v1/projects/demo/shots/E1S01/end-frame?script_file=missing.json")
+        assert resp.status_code == 404
 
     def test_unknown_project_returns_404(self, client):
         c, _pm = client

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -435,6 +435,60 @@ class TestPersistFailureRestoresSnapshot:
         # 回滚跳过：文件保持并发清除后的「已删除」结果，没有被旧字节重新写回制造孤儿文件
         assert not snapshot.exists()
 
+    @pytest.mark.integration
+    def test_set_failure_skips_restore_when_concurrent_takeover_uses_other_alias(self, client, monkeypatch):
+        """Codex 指出的别名归一问题：本次失败操作用 `scripts/episode_1.json` 这个别名，
+        代次键若不归一化会与并发接管（用 `episode_1.json` 归一后的键）各自生成一把代次，
+        互相看不见——回滚会误判「无人接手」，用旧字节覆盖对方已成功落盘的内容。"""
+        c, pm = client
+        snapshot = pm.get_project_path("demo") / END_FRAME_REL
+        normalized_key = ("demo", "episode_1.json", "E1S01")
+        concurrent_bytes = _img_bytes("PNG", size=(48, 48))
+
+        _fail_first_persist(monkeypatch)
+        _inject_concurrent_takeover_before_nth_load(monkeypatch, normalized_key, snapshot, concurrent_bytes, n=3)
+
+        resp = c.post(
+            "/api/v1/projects/demo/shots/E1S01/end-frame/upload?script_file=scripts/episode_1.json",
+            files={"file": ("f.png", BytesIO(_img_bytes("PNG", size=(16, 16))), "application/octet-stream")},
+        )
+        assert resp.status_code == 500
+
+        # 未归一化则代次键不同，回滚会看不到接管、用旧字节覆盖并发写入的新内容
+        assert snapshot.read_bytes() == concurrent_bytes
+
+    @pytest.mark.integration
+    def test_set_failure_restore_uses_bytes_read_inside_critical_section(self, client, monkeypatch):
+        """Codex 指出的陈旧基线问题：`old_bytes` 若在取得剧本锁之前预读，读到的是「进入
+        临界区之前」而非「进入临界区那一刻」的文件内容。这里不推进代次，只在本次操作
+        自己的 `load_script` 调用（进入临界区的时点）直接改写文件——代次检查不会拦截
+        （因为没有别的操作声称接管），能否回滚出这份改写后的内容，才真正区分基线是在
+        锁内读还是锁外预读：锁外预读会读到改写前的旧内容，回滚会把改写后的内容覆盖掉。"""
+        c, pm = client
+        _upload(c, _img_bytes("PNG", size=(8, 8)))
+        snapshot = pm.get_project_path("demo") / END_FRAME_REL
+
+        original_load_script = ProjectManager.load_script
+        calls = {"n": 0}
+        content_at_critical_section_entry = _img_bytes("PNG", size=(56, 56))
+
+        def _load_with_rewrite(self, *args, **kwargs):
+            calls["n"] += 1
+            # load 序列：_locate_shot(1) → 本次失败操作自己的 locked_script(2)
+            if calls["n"] == 2:
+                snapshot.write_bytes(content_at_critical_section_entry)
+            return original_load_script(self, *args, **kwargs)
+
+        monkeypatch.setattr(ProjectManager, "load_script", _load_with_rewrite)
+        _fail_first_persist(monkeypatch)
+
+        resp = _upload(c, _img_bytes("PNG", size=(16, 16)))
+        assert resp.status_code == 500
+
+        # 基线在临界区内读取，读到的就是这份改写后的内容，回滚据此还原；
+        # 若基线在锁外预读，读到的是改写前的旧内容，回滚会把这份改写覆盖掉
+        assert snapshot.read_bytes() == content_at_critical_section_entry
+
 
 class TestErrorMapping:
     """领域错误到 HTTP 的映射：三个端点行为一致，不泄漏服务器路径。"""

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -7,6 +7,7 @@
 import asyncio
 import threading
 from io import BytesIO
+from pathlib import Path
 
 import pytest
 from fastapi import FastAPI
@@ -287,6 +288,42 @@ class TestConcurrentSetClear:
             # 清除赢：字段置空，文件可能已删或残留孤儿（无害），但不检验其存在性
 
 
+def _fail_first_persist(monkeypatch):
+    """让下一次剧本持久化失败一次，随后（补偿回滚重新过锁触发的第二次）恢复原实现。
+
+    补偿回滚本身也要走一次 `locked_script`（读快照现状、必要时改写、重新持久化），若一律
+    拦截会连回滚自身的持久化也打断，所以只失败第一次。
+    """
+    original = ProjectManager._write_script_unlocked
+    calls = {"n": 0}
+
+    def _boom(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ValueError("simulated persist failure")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(ProjectManager, "_write_script_unlocked", _boom)
+
+
+def _inject_concurrent_write_before_nth_load(monkeypatch, target: Path, content: bytes, n: int):
+    """模拟「回滚重新过锁前，另一个并发请求已抢先完成自己的一次成功落盘」。
+
+    补偿回滚会再发起一次 `locked_script`，其 `load_script` 调用即回滚临界区的起点——在其
+    第 n 次被调用时把 target 改写为 content，相当于并发请求恰好在回滚拿到锁之前完成。
+    """
+    original = ProjectManager.load_script
+    calls = {"n": 0}
+
+    def _load_with_race(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == n:
+            target.write_bytes(content)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(ProjectManager, "load_script", _load_with_race)
+
+
 class TestPersistFailureRestoresSnapshot:
     """剧本持久化在临界区内失败时，快照文件须回滚到操作前状态，不留悬空引用或静默丢失。"""
 
@@ -297,10 +334,7 @@ class TestPersistFailureRestoresSnapshot:
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         before = snapshot.read_bytes()
 
-        def _boom(*_a, **_k):
-            raise ValueError("simulated persist failure")
-
-        monkeypatch.setattr(ProjectManager, "_write_script_unlocked", _boom)
+        _fail_first_persist(monkeypatch)
         resp = _upload(c, _img_bytes("PNG", size=(16, 16)))
         assert resp.status_code == 500
 
@@ -314,10 +348,7 @@ class TestPersistFailureRestoresSnapshot:
         c, pm = client
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
 
-        def _boom(*_a, **_k):
-            raise ValueError("simulated persist failure")
-
-        monkeypatch.setattr(ProjectManager, "_write_script_unlocked", _boom)
+        _fail_first_persist(monkeypatch)
         resp = _upload(c, _img_bytes("PNG"))
         assert resp.status_code == 500
 
@@ -331,10 +362,7 @@ class TestPersistFailureRestoresSnapshot:
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         before = snapshot.read_bytes()
 
-        def _boom(*_a, **_k):
-            raise ValueError("simulated persist failure")
-
-        monkeypatch.setattr(ProjectManager, "_write_script_unlocked", _boom)
+        _fail_first_persist(monkeypatch)
         resp = _delete(c)
         assert resp.status_code == 500
 
@@ -342,6 +370,40 @@ class TestPersistFailureRestoresSnapshot:
         assert _segment(pm)["end_frame_image"] == END_FRAME_REL
         assert snapshot.exists()
         assert snapshot.read_bytes() == before
+
+    @pytest.mark.integration
+    def test_set_failure_skips_restore_when_concurrent_write_supersedes(self, client, monkeypatch):
+        """回滚重新过锁时若文件内容已不是本次失败前写入的字节，说明并发请求已经接管，
+        必须跳过回滚——否则会用陈旧字节覆盖对方刚成功落盘的内容。"""
+        c, pm = client
+        snapshot = pm.get_project_path("demo") / END_FRAME_REL
+        concurrent_bytes = _img_bytes("PNG", size=(32, 32))
+
+        _fail_first_persist(monkeypatch)
+        # load 序列：_locate_shot(1) → 本次失败的 locked_script(2) → 回滚的 locked_script(3)
+        _inject_concurrent_write_before_nth_load(monkeypatch, snapshot, concurrent_bytes, n=3)
+
+        resp = _upload(c, _img_bytes("PNG", size=(16, 16)))
+        assert resp.status_code == 500
+
+        assert snapshot.read_bytes() == concurrent_bytes
+
+    @pytest.mark.integration
+    def test_clear_failure_skips_restore_when_concurrent_write_recreates_snapshot(self, client, monkeypatch):
+        c, pm = client
+        _upload(c, _img_bytes("PNG"))
+        snapshot = pm.get_project_path("demo") / END_FRAME_REL
+        concurrent_bytes = _img_bytes("PNG", size=(40, 40))
+
+        _fail_first_persist(monkeypatch)
+        _inject_concurrent_write_before_nth_load(monkeypatch, snapshot, concurrent_bytes, n=3)
+
+        resp = _delete(c)
+        assert resp.status_code == 500
+
+        # 回滚跳过：文件保留并发请求写入的新内容，没有被「删除态」覆盖
+        assert snapshot.exists()
+        assert snapshot.read_bytes() == concurrent_bytes
 
 
 class TestErrorMapping:

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -15,6 +15,7 @@ from PIL import Image
 from lib.data_validator import DataValidator
 from lib.project_manager import ProjectManager
 from lib.script_editor import ScriptEditError
+from lib.version_manager import VersionManager
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import end_frames
@@ -201,6 +202,28 @@ class TestSnapshotDecoupling:
         # 源图重生成（内容与尺寸都变）后再删除，模拟版本回滚 / 资源清理
         _write_source_image(pm, source_rel, _img_bytes("PNG", size=(24, 24), color=(0, 0, 255)))
         (pm.get_project_path("demo") / source_rel).unlink()
+
+        assert snapshot.read_bytes() == before
+        assert _segment(pm)["end_frame_image"] == END_FRAME_REL
+
+    def test_source_version_rollback_leaves_end_frame_intact(self, client):
+        """源图回滚到旧版本后已定尾帧不变——尾帧存的是快照路径，与源图的版本轴无关。"""
+        c, pm = client
+        source_rel = "storyboards/scene_E1S02.png"
+        source_abs = pm.get_project_path("demo") / source_rel
+        vm = VersionManager(pm.get_project_path("demo"))
+
+        _write_source_image(pm, source_rel, _img_bytes("PNG", size=(12, 12), color=(255, 0, 0)))
+        vm.add_version("storyboards", "E1S02", "v1", source_file=source_abs)
+        _select(c, source_rel)
+
+        snapshot = pm.get_project_path("demo") / END_FRAME_REL
+        before = snapshot.read_bytes()
+
+        # 源图重生成为 v2，再回滚到 v1
+        _write_source_image(pm, source_rel, _img_bytes("PNG", size=(24, 24), color=(0, 0, 255)))
+        vm.add_version("storyboards", "E1S02", "v2", source_file=source_abs)
+        vm.restore_version("storyboards", "E1S02", 1, source_abs)
 
         assert snapshot.read_bytes() == before
         assert _segment(pm)["end_frame_image"] == END_FRAME_REL

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -253,14 +253,21 @@ class TestConcurrentSetClear:
 
         for _ in range(20):
             barrier = threading.Barrier(2)
+            results: dict[str, object] = {}
 
             def _do_set():
                 barrier.wait()
-                _upload(c, _img_bytes("PNG"))
+                try:
+                    results["set"] = _upload(c, _img_bytes("PNG")).status_code
+                except Exception as exc:  # noqa: BLE001 - 捕获后由主线程断言失败
+                    results["set"] = exc
 
             def _do_clear():
                 barrier.wait()
-                _delete(c)
+                try:
+                    results["clear"] = _delete(c).status_code
+                except Exception as exc:  # noqa: BLE001
+                    results["clear"] = exc
 
             t_set = threading.Thread(target=_do_set)
             t_clear = threading.Thread(target=_do_clear)
@@ -268,6 +275,9 @@ class TestConcurrentSetClear:
             t_clear.start()
             t_set.join()
             t_clear.join()
+
+            assert results["set"] == 200, results["set"]
+            assert results["clear"] == 200, results["clear"]
 
             end_frame_image = _segment(pm).get("end_frame_image")
             # 设置赢：字段非空则快照文件必须存在——不允许指向缺失文件的引用

--- a/tests/test_project_archive_service.py
+++ b/tests/test_project_archive_service.py
@@ -196,6 +196,7 @@ class TestProjectArchiveService:
             assert "demo/.DS_Store" not in names
             assert "demo/.hidden/secret.txt" not in names
 
+    @pytest.mark.integration
     @pytest.mark.parametrize("scope", ["full", "current"])
     def test_export_includes_end_frame_snapshots(self, tmp_path, scope):
         """end_frames 登记为允许的根目录条目后，两种 scope 的导出都自动带上尾帧快照。"""

--- a/tests/test_project_archive_service.py
+++ b/tests/test_project_archive_service.py
@@ -196,6 +196,20 @@ class TestProjectArchiveService:
             assert "demo/.DS_Store" not in names
             assert "demo/.hidden/secret.txt" not in names
 
+    @pytest.mark.parametrize("scope", ["full", "current"])
+    def test_export_includes_end_frame_snapshots(self, tmp_path, scope):
+        """end_frames 登记为允许的根目录条目后，两种 scope 的导出都自动带上尾帧快照。"""
+        pm = ProjectManager(tmp_path / "projects")
+        project_dir = _create_project(pm)
+        _write_bytes(project_dir / "end_frames" / "scene_E1S01.png", b"png")
+        payload = json.loads((project_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8"))
+        payload["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
+        _write_json(project_dir / "scripts" / "episode_1.json", payload)
+
+        archive_path, _ = ProjectArchiveService(pm).export_project("demo", scope=scope)
+        with zipfile.ZipFile(archive_path) as archive:
+            assert "demo/end_frames/scene_E1S01.png" in set(archive.namelist())
+
     def test_export_excludes_agent_runtime_symlinks(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)

--- a/tests/test_resource_paths.py
+++ b/tests/test_resource_paths.py
@@ -22,6 +22,7 @@ class TestResourceRelativePath:
         [
             # storyboards / videos 带 scene_ 前缀特例
             ("storyboards", "E1S01", "storyboards/scene_E1S01.png"),
+            ("end_frames", "E1S01", "end_frames/scene_E1S01.png"),
             ("videos", "E1S01", "videos/scene_E1S01.mp4"),
             # audio 带 segment_ 前缀特例
             ("audio", "E1S01", "audio/segment_E1S01.wav"),
@@ -36,8 +37,8 @@ class TestResourceRelativePath:
     def test_canonical_paths(self, resource_type: str, resource_id: str, expected: str) -> None:
         assert resource_relative_path(resource_type, resource_id) == expected
 
-    def test_only_storyboards_and_videos_get_scene_prefix(self) -> None:
-        # 反向断言：非 storyboards/videos 不得带 scene_ 前缀（audio 用 segment_ 前缀，单独验证）
+    def test_only_shot_keyed_types_get_scene_prefix(self) -> None:
+        # 反向断言：非按镜头 id 命名的类型不得带 scene_ 前缀（audio 用 segment_ 前缀，单独验证）
         for rt in ("characters", "scenes", "props", "grids", "reference_videos"):
             assert "scene_" not in resource_relative_path(rt, "X")
         assert resource_relative_path("audio", "X").startswith("audio/segment_")
@@ -57,6 +58,7 @@ class TestResourceExtension:
         ("resource_type", "expected"),
         [
             ("storyboards", ".png"),
+            ("end_frames", ".png"),
             ("videos", ".mp4"),
             ("characters", ".png"),
             ("scenes", ".png"),
@@ -79,6 +81,7 @@ class TestResourceTypes:
     def test_covers_canonical_types(self) -> None:
         assert set(RESOURCE_TYPES) == {
             "storyboards",
+            "end_frames",
             "videos",
             "audio",
             "characters",

--- a/tests/test_script_editor.py
+++ b/tests/test_script_editor.py
@@ -179,6 +179,7 @@ class TestPatchField:
         with pytest.raises(ScriptEditError, match="不可改分镜 id"):
             patch_field(_narration(), "E1S01", id_field, "X")
 
+    @pytest.mark.unit
     def test_patch_end_frame_image_rejected(self):
         # 尾帧字段只由尾帧设置/清除端点写入：patch 放行等于让 agent 原样写任意字符串，
         # 绕过快照复制并重新引入悬空引用与越界路径。
@@ -204,6 +205,7 @@ class TestInsertSegment:
         script = insert_segment(_narration(), "E1S01", _segment("X"))
         assert script["segments"][1]["generated_assets"] == {}
 
+    @pytest.mark.unit
     def test_insert_drops_end_frame_image(self):
         # 新 id 名下还没有快照，agent 自带的值只会指向锚点的快照或不存在的路径。
         new_item = _segment("X") | {"end_frame_image": "end_frames/scene_E1S01.png"}
@@ -265,6 +267,7 @@ class TestSplitSegment:
         assert script["segments"][0]["generated_assets"] == anchor_assets
         assert script["segments"][1]["generated_assets"] == {}
 
+    @pytest.mark.unit
     def test_split_keeps_anchor_end_frame_clears_new_parts(self):
         # 尾帧快照按镜头 id 命名：锚点保留原 id 故快照仍归它；新派生 id 名下没有快照，
         # 且以原分镜实际值为准，不让 agent 在 parts[0] 凭空改写快照路径。
@@ -275,6 +278,7 @@ class TestSplitSegment:
         assert script["segments"][0]["end_frame_image"] == "end_frames/scene_E1S01.png"
         assert script["segments"][1].get("end_frame_image") is None
 
+    @pytest.mark.unit
     def test_split_anchor_without_end_frame_drops_agent_supplied_value(self):
         parts = [_segment("a") | {"end_frame_image": "end_frames/forged.png"}, _segment("b")]
         script = split_segment(_narration(), "E1S01", parts)

--- a/tests/test_script_editor.py
+++ b/tests/test_script_editor.py
@@ -179,6 +179,12 @@ class TestPatchField:
         with pytest.raises(ScriptEditError, match="不可改分镜 id"):
             patch_field(_narration(), "E1S01", id_field, "X")
 
+    def test_patch_end_frame_image_rejected(self):
+        # 尾帧字段只由尾帧设置/清除端点写入：patch 放行等于让 agent 原样写任意字符串，
+        # 绕过快照复制并重新引入悬空引用与越界路径。
+        with pytest.raises(ScriptEditError, match="不可改 end_frame_image"):
+            patch_field(_narration(), "E1S01", "end_frame_image", "../../../etc/passwd")
+
     def test_patch_does_not_touch_generated_assets(self):
         script = patch_field(_narration(), "E1S01", "duration_seconds", 7)
         assert script["segments"][0]["generated_assets"]["status"] == "completed"
@@ -197,6 +203,12 @@ class TestInsertSegment:
     def test_insert_clears_generated_assets(self):
         script = insert_segment(_narration(), "E1S01", _segment("X"))
         assert script["segments"][1]["generated_assets"] == {}
+
+    def test_insert_drops_end_frame_image(self):
+        # 新 id 名下还没有快照，agent 自带的值只会指向锚点的快照或不存在的路径。
+        new_item = _segment("X") | {"end_frame_image": "end_frames/scene_E1S01.png"}
+        script = insert_segment(_narration(), "E1S01", new_item)
+        assert script["segments"][1].get("end_frame_image") is None
 
     def test_insert_id_avoids_collision(self):
         seg = _segment("E1S01_1")
@@ -252,6 +264,21 @@ class TestSplitSegment:
         script = split_segment(_narration(), "E1S01", [_segment("a"), _segment("b")])
         assert script["segments"][0]["generated_assets"] == anchor_assets
         assert script["segments"][1]["generated_assets"] == {}
+
+    def test_split_keeps_anchor_end_frame_clears_new_parts(self):
+        # 尾帧快照按镜头 id 命名：锚点保留原 id 故快照仍归它；新派生 id 名下没有快照，
+        # 且以原分镜实际值为准，不让 agent 在 parts[0] 凭空改写快照路径。
+        script_in = _narration()
+        script_in["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
+        parts = [_segment("a") | {"end_frame_image": "end_frames/forged.png"}, _segment("b")]
+        script = split_segment(script_in, "E1S01", parts)
+        assert script["segments"][0]["end_frame_image"] == "end_frames/scene_E1S01.png"
+        assert script["segments"][1].get("end_frame_image") is None
+
+    def test_split_anchor_without_end_frame_drops_agent_supplied_value(self):
+        parts = [_segment("a") | {"end_frame_image": "end_frames/forged.png"}, _segment("b")]
+        script = split_segment(_narration(), "E1S01", parts)
+        assert script["segments"][0].get("end_frame_image") is None
 
     def test_split_requires_at_least_two_parts(self):
         with pytest.raises(ScriptEditError):

--- a/tests/test_script_models.py
+++ b/tests/test_script_models.py
@@ -561,7 +561,7 @@ class TestLLMSchemaExclusion:
         from lib.script_models import NarrationEpisodeScript
 
         keys = self._all_keys(NarrationEpisodeScript.model_json_schema())
-        for forbidden in ("note", "generated_assets"):
+        for forbidden in ("note", "generated_assets", "end_frame_image"):
             assert forbidden not in keys, f"{forbidden} 不应出现在 LLM schema 中"
         # 顶层 duration_seconds 由 caller 重算
         assert "duration_seconds" not in NarrationEpisodeScript.model_json_schema()["properties"]
@@ -570,12 +570,19 @@ class TestLLMSchemaExclusion:
         from lib.script_models import DramaEpisodeScript
 
         keys = self._all_keys(DramaEpisodeScript.model_json_schema())
-        for forbidden in ("note", "generated_assets"):
+        for forbidden in ("note", "generated_assets", "end_frame_image"):
             assert forbidden not in keys
         assert "duration_seconds" not in DramaEpisodeScript.model_json_schema()["properties"]
         # utterances 是 LLM 可见的一等字段（drama 口播序列的落点），取代旧 voiceover
         assert "utterances" in keys
         assert "voiceover" not in keys
+
+    def test_ad_schema_excludes_runtime_fields(self):
+        from lib.script_models import AdEpisodeScript
+
+        keys = self._all_keys(AdEpisodeScript.model_json_schema())
+        for forbidden in ("note", "generated_assets", "end_frame_image"):
+            assert forbidden not in keys
 
     def test_reference_video_schema_excludes_runtime_fields(self):
         from lib.script_models import ReferenceVideoScript

--- a/tests/test_script_models.py
+++ b/tests/test_script_models.py
@@ -577,6 +577,7 @@ class TestLLMSchemaExclusion:
         assert "utterances" in keys
         assert "voiceover" not in keys
 
+    @pytest.mark.unit
     def test_ad_schema_excludes_runtime_fields(self):
         from lib.script_models import AdEpisodeScript
 


### PR DESCRIPTION
Closes #1295

## 做了什么

创作者可通过 API 为任一镜头设置/清除尾帧，设定持久落进剧集 JSON 并随项目归档导出。

- 三骨架（narration 片段 / drama 场景 / ad 镜头）同构新增顶层可选字段 `end_frame_image`，默认空、对 LLM 隐藏、不进 `generated_assets`
- 设置双通道同一落点：上传任意图片，或指定项目内已有图片的相对路径；统一归一为 PNG（EXIF 摆正 + 长边封顶，不裁切比例）后快照复制到 `end_frames/scene_{id}.png`，换图原地覆盖
- 清除：字段置空 + 删快照文件
- `end_frames` 登记进资源类型注册表与项目根目录白名单，归档两种 scope 自动包含导出；本次不接 VersionManager
- `end_frame_image` 进 data_validator 路径字段校验（越界 + 缺失均报 error）

快照与源图彻底解耦：字段存的是快照路径而非源图路径，源图重生成、版本回滚、删除都动不到已定尾帧，悬空引用在结构上不存在。

## 写入通道收敛

`end_frame_image` **不**进通用剧本 PATCH 白名单（team-lead 拍板方案 A），专用 set/clear 端点是唯一写入通道。通用 PATCH 端点不做路径校验，放行后客户端可原样写任意字符串，会从正门废掉「快照复制、结构上消灭悬空引用」的设计目标，还开一个越界写路径的口子。

本地审查阶段发现该封堵此前只覆盖了 HTTP PATCH，agent 侧的剧本编辑工具是敞开的，已一并收口：

- `patch_episode_script` 拒绝改 `end_frame_image`，与 `generated_assets` 同口径
- `insert_segment` 清空新分镜的该字段；`split_segment` 锚点延续原值、新派生分镜清空——尾帧快照按镜头 id 命名，新 id 名下没有快照，agent 自带的值只会指向别人的快照
- `end_frames` 登记进资产指纹扫描目录，让「换图原地覆盖后靠指纹 cache-bust」这一自述机制真正成立

## 验证

- `uv run ruff check . && uv run ruff format .` — 全绿
- `uv run basedpyright` — 0 errors
- `uv run python -m pytest --cov` — 6463 passed，总覆盖率 92%，`server/services/end_frame.py` 99%
- 新增测试覆盖：三骨架字段序列化与 SkipJsonSchema、通用 PATCH 忽略该字段、双通道快照落点、换图原地覆盖、清除幂等、越界路径与越界 shot_id 拒绝、超限上传兜底、错误映射不泄漏服务器路径、源图重写/删除/**版本回滚**后尾帧不变、归档目录树校验

## 范围外（follow-up 候选）

- 前端未接线（本票只交付 API）：设置/清除入口、占用态禁用需另票
- 尾帧无版本历史与回滚（未接 VersionManager，按 Spec 拆分为刻意选择）
- 设置/清除未推送项目事件，其他客户端不会实时刷新——事件类型取决于前端消费方式，随前端接线票一并定


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增镜头尾帧快照管理：支持上传、从项目图片生成快照并可清除；适配说书/剧集/广告等脚本类型。
  - 快照自动归一为 PNG，保存并在项目导出（不同导出范围）中随资源一并包含。
- **错误修复**
  - 强化尾帧来源校验：防止越界与目录引用，缺失源图/无效路径会给出本地化提示。
  - 脚本编辑规则已适配尾帧：插入/分割按策略保留或清空；不允许通过通用 PATCH 直接改写尾帧字段，避免悬空引用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->