### PR TITLE
fix(video): 设置了尾帧的镜头生成视频时带上尾帧，不可用时明确报错

### DIFF
--- a/lib/resource_paths.py
+++ b/lib/resource_paths.py
@@ -38,6 +38,11 @@ _PATTERNS: dict[str, ResourcePattern] = {
 
 RESOURCE_TYPES: tuple[str, ...] = tuple(_PATTERNS)
 
+# 尾帧快照的资源类型名，与 `_PATTERNS["end_frames"]` 同值。独立导出到这个无反向依赖的
+# 纯函数模块，供 server/services/end_frame.py（写侧）与 generation_tasks.py（读侧）共用，
+# 避免二者互相 import 对方所在的 server.services 包造成循环依赖。
+END_FRAME_RESOURCE_TYPE = "end_frames"
+
 
 def _pattern(resource_type: str) -> ResourcePattern:
     pattern = _PATTERNS.get(resource_type)

--- a/lib/resource_paths.py
+++ b/lib/resource_paths.py
@@ -22,10 +22,16 @@ class ResourcePattern:
     prefix: str = ""  # 文件名前缀：storyboards/videos 用 "scene_"，audio 用 "segment_"，其余空
 
 
+# 尾帧快照的资源类型名。独立导出到这个无反向依赖的纯函数模块，供
+# server/services/end_frame.py（写侧）与 generation_tasks.py（读侧）共用，避免二者互相
+# import 对方所在的 server.services 包造成循环依赖；同时作为 `_PATTERNS` 对应 key 的唯一
+# 来源，防止两处字面量各自维护后读写侧路径口径分叉。
+END_FRAME_RESOURCE_TYPE = "end_frames"
+
 _PATTERNS: dict[str, ResourcePattern] = {
     "storyboards": ResourcePattern("storyboards", ".png", prefix="scene_"),
     # 尾帧快照与分镜图、镜头视频同按镜头 id 命名，故共用 scene_ 前缀。
-    "end_frames": ResourcePattern("end_frames", ".png", prefix="scene_"),
+    END_FRAME_RESOURCE_TYPE: ResourcePattern(END_FRAME_RESOURCE_TYPE, ".png", prefix="scene_"),
     "videos": ResourcePattern("videos", ".mp4", prefix="scene_"),
     "characters": ResourcePattern("characters", ".png"),
     "scenes": ResourcePattern("scenes", ".png"),
@@ -37,11 +43,6 @@ _PATTERNS: dict[str, ResourcePattern] = {
 }
 
 RESOURCE_TYPES: tuple[str, ...] = tuple(_PATTERNS)
-
-# 尾帧快照的资源类型名，与 `_PATTERNS["end_frames"]` 同值。独立导出到这个无反向依赖的
-# 纯函数模块，供 server/services/end_frame.py（写侧）与 generation_tasks.py（读侧）共用，
-# 避免二者互相 import 对方所在的 server.services 包造成循环依赖。
-END_FRAME_RESOURCE_TYPE = "end_frames"
 
 
 def _pattern(resource_type: str) -> ResourcePattern:

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -52,13 +52,11 @@ from lib.image_utils import normalize_storyboard_upload
 from lib.path_safety import PathTraversalError, safe_join
 from lib.project_change_hints import project_change_source
 from lib.project_manager import ProjectManager, get_project_manager
-from lib.resource_paths import resource_relative_path
+from lib.resource_paths import END_FRAME_RESOURCE_TYPE, resource_relative_path
 from lib.storyboard_sequence import find_storyboard_item, get_storyboard_items
 from server.services.upload_finalize import write_bytes_atomic
 
 logger = logging.getLogger(__name__)
-
-END_FRAME_RESOURCE_TYPE = "end_frames"
 
 _ShotKey = tuple[str, str, str]
 _generation_lock = threading.Lock()

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -862,11 +862,18 @@ async def execute_video_task(
         end_frame_file = try_safe_join(project_path, candidate)
         expected_file = safe_join(project_path, expected_rel)
         # try_safe_join / safe_join 都走 realpath，会展开符号链接：若字段值恰是当前镜头的
-        # canonical 相对路径，但磁盘上那个位置被替换成指向别处（如另一镜头快照、分镜图）的
-        # 符号链接，两次解析会算出同一个被展开的真实目标，让下面的相等比较失去意义。这里额外
-        # 拒绝 canonical 位置本身是符号链接的情况——挡住"路径字符串正确但磁盘对象被调包"。
-        canonical_path_literal = project_path / expected_rel
-        if end_frame_file is None or end_frame_file != expected_file or canonical_path_literal.is_symlink():
+        # canonical 相对路径，但磁盘上那个位置（含 end_frames/ 目录本身等中间组件）被替换成
+        # 指向别处（如另一镜头快照、分镜图）的符号链接，两次解析会算出同一个被展开的真实目标，
+        # 让下面的相等比较失去意义。这里逐段检查 canonical 路径每个组件——文件名与父目录——
+        # 挡住"路径字符串正确但磁盘对象被调包"，不止查最终文件名那一段。
+        canonical_path_has_symlink = False
+        current = project_path
+        for component in Path(expected_rel).parts:
+            current = current / component
+            if current.is_symlink():
+                canonical_path_has_symlink = True
+                break
+        if end_frame_file is None or end_frame_file != expected_file or canonical_path_has_symlink:
             raise ValueError(f"invalid end frame snapshot path: {end_frame_rel!r}")
         if not end_frame_file.is_file():
             raise ValueError(f"end frame snapshot not found: {end_frame_file.name}")

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -837,7 +837,18 @@ async def execute_video_task(
     # 此处不预先 int() 截断，避免把非整数秒静默修正成「碰巧合法」的值。
     assert_duration_supported(duration_seconds, supported_durations)
 
-    end_image = None  # 宫格模式不再使用首尾帧，统一走普通图生视频
+    # end_frame_image 是镜头持久属性（见 server/services/end_frame.py），剧本每次加载都带出，
+    # 重新生成无需额外操作即可沿用。快照路径恒为服务层写出的 canonical 相对路径，直接拼接；
+    # 能力是否支持尾帧不在此处判断——generator.generate_video_async 内的 plan_frame_slots
+    # 已按已解析 backend 的实际能力统一 gating，不支持时硬失败（VideoCapabilityError），
+    # 不在这里重复一份判断逻辑。
+    end_frame_rel = item.get("end_frame_image") if isinstance(item, dict) else None
+    end_image: Path | None = None
+    if end_frame_rel:
+        end_frame_file = project_path / end_frame_rel
+        if not end_frame_file.exists():
+            raise ValueError(f"end frame snapshot not found: {end_frame_file.name}")
+        end_image = end_frame_file
 
     _, version, _, video_uri = await generator.generate_video_async(
         prompt=prompt_text,

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -865,15 +865,17 @@ async def execute_video_task(
         # canonical 相对路径，但磁盘上那个位置（含 end_frames/ 目录本身等中间组件）被替换成
         # 指向别处（如另一镜头快照、分镜图）的符号链接，两次解析会算出同一个被展开的真实目标，
         # 让下面的相等比较失去意义。这里逐段检查 canonical 路径每个组件——文件名与父目录——
-        # 挡住"路径字符串正确但磁盘对象被调包"，不止查最终文件名那一段。
-        canonical_path_has_symlink = False
+        # 挡住"路径字符串正确但磁盘对象被调包"，不止查最终文件名那一段。Windows 原生环境下
+        # 目录联接（junction）是独立于符号链接的 reparse point 类型，`is_symlink()` 识别不到，
+        # 须用 `is_junction()`（3.12+，POSIX 上恒为 False）单独检测。
+        canonical_path_tampered = False
         current = project_path
         for component in Path(expected_rel).parts:
             current = current / component
-            if current.is_symlink():
-                canonical_path_has_symlink = True
+            if current.is_symlink() or current.is_junction():
+                canonical_path_tampered = True
                 break
-        if end_frame_file is None or end_frame_file != expected_file or canonical_path_has_symlink:
+        if end_frame_file is None or end_frame_file != expected_file or canonical_path_tampered:
             raise ValueError(f"invalid end frame snapshot path: {end_frame_rel!r}")
         if not end_frame_file.is_file():
             raise ValueError(f"end frame snapshot not found: {end_frame_file.name}")

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -34,7 +34,7 @@ from lib.prompt_utils import (
     video_prompt_to_yaml,
 )
 from lib.reference_compression import ReferencePayloadFloorError
-from lib.resource_paths import resource_relative_path
+from lib.resource_paths import END_FRAME_RESOURCE_TYPE, resource_relative_path
 from lib.script_skeleton import SKELETON_ENTITY_TYPES, SKELETON_ITEM_NOUNS, resolve_script_kind
 from lib.storyboard_sequence import (
     build_previous_storyboard_reference,
@@ -45,7 +45,6 @@ from lib.storyboard_sequence import (
 )
 from lib.thumbnail import extract_video_thumbnail
 from lib.video_backends.base import VideoCapabilityError
-from server.services.end_frame import END_FRAME_RESOURCE_TYPE
 from server.services.generation_context import (
     AudioLaneRequest,
     ImageLaneRequest,
@@ -859,9 +858,15 @@ async def execute_video_task(
             raise ValueError(f"invalid end frame snapshot path: {end_frame_rel!r}")
         normalized = end_frame_rel.strip().replace("\\", "/")
         candidate = normalized if "/" in normalized else f"{END_FRAME_RESOURCE_TYPE}/{normalized}"
+        expected_rel = resource_relative_path(END_FRAME_RESOURCE_TYPE, resource_id)
         end_frame_file = try_safe_join(project_path, candidate)
-        expected_file = safe_join(project_path, resource_relative_path(END_FRAME_RESOURCE_TYPE, resource_id))
-        if end_frame_file is None or end_frame_file != expected_file:
+        expected_file = safe_join(project_path, expected_rel)
+        # try_safe_join / safe_join 都走 realpath，会展开符号链接：若字段值恰是当前镜头的
+        # canonical 相对路径，但磁盘上那个位置被替换成指向别处（如另一镜头快照、分镜图）的
+        # 符号链接，两次解析会算出同一个被展开的真实目标，让下面的相等比较失去意义。这里额外
+        # 拒绝 canonical 位置本身是符号链接的情况——挡住"路径字符串正确但磁盘对象被调包"。
+        canonical_path_literal = project_path / expected_rel
+        if end_frame_file is None or end_frame_file != expected_file or canonical_path_literal.is_symlink():
             raise ValueError(f"invalid end frame snapshot path: {end_frame_rel!r}")
         if not end_frame_file.is_file():
             raise ValueError(f"end frame snapshot not found: {end_frame_file.name}")

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -843,20 +843,25 @@ async def execute_video_task(
     # 按已解析 backend 统一 gating（不支持即 VideoCapabilityError），此处不重复一份判断。
     #
     # 剧本是磁盘上的 JSON，字段值不可直接信任（归档导入、外部编辑、脏数据都能落值）：绝对路径会
-    # 覆盖 `/` 的左操作数、`..` 会越出项目目录，把任意服务器文件送进视频请求上传给供应商。口径与
-    # 写侧 end_frame.py、校验侧 data_validator（confine_to_default_dir="end_frames"）一致：
-    # 只接受 end_frames/ 内的已存在快照，其余硬失败。
+    # 覆盖 `/` 的左操作数、`..` 会越出项目目录，把任意服务器文件送进视频请求上传给供应商。只接受
+    # 「当前镜头自己的」end_frames/ 快照——不是随便一个存在的 end_frames/ 内文件：字段被外部编辑
+    # 指向别的镜头（如 E1S01 引用 E1S02 的快照）会静默生成/扣费错镜头的尾帧，仅凭目录归属挡不住，
+    # 须与 resource_relative_path 算出的当前镜头 canonical 路径逐一比对。裸文件名（无路径分隔符）
+    # 按校验侧 data_validator._resolve_existing_path 的 default_dir 回退口径补 end_frames/ 前缀
+    # 重试，否则通过导入校验的值会在生成期无理由硬失败。
     end_frame_rel = item.get("end_frame_image") if isinstance(item, dict) else None
     end_image: Path | None = None
     # 只把 None / "" 视为「未设置」（与 data_validator 的 _resolve_existing_path 同口径）；
-    # 0 / False / [] / {} 等其余 falsy 脏数据必须继续走下面的 try_safe_join 硬失败，不能被
-    # Python 的真值判断静默吞成「未设置」进而无声跳过尾帧、照常生成扣费。
+    # 0 / False / [] / {} 等其余 falsy 脏数据必须继续走下面的硬失败，不能被 Python 的真值判断
+    # 静默吞成「未设置」进而无声跳过尾帧、照常生成扣费。
     if end_frame_rel not in (None, ""):
-        end_frames_dir = safe_join(project_path, END_FRAME_RESOURCE_TYPE)
-        # None 兜住越界 / 脏数据 / 解析失败；目录归属另判，挡住 `end_frames/../storyboards/x.png`
-        # 这类落在项目内却绕开快照目录的值。
-        end_frame_file = try_safe_join(project_path, end_frame_rel)
-        if end_frame_file is None or not end_frame_file.is_relative_to(end_frames_dir):
+        if not isinstance(end_frame_rel, str):
+            raise ValueError(f"invalid end frame snapshot path: {end_frame_rel!r}")
+        normalized = end_frame_rel.strip().replace("\\", "/")
+        candidate = normalized if "/" in normalized else f"{END_FRAME_RESOURCE_TYPE}/{normalized}"
+        end_frame_file = try_safe_join(project_path, candidate)
+        expected_file = safe_join(project_path, resource_relative_path(END_FRAME_RESOURCE_TYPE, resource_id))
+        if end_frame_file is None or end_frame_file != expected_file:
             raise ValueError(f"invalid end frame snapshot path: {end_frame_rel!r}")
         if not end_frame_file.is_file():
             raise ValueError(f"end frame snapshot not found: {end_frame_file.name}")

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -848,7 +848,10 @@ async def execute_video_task(
     # 只接受 end_frames/ 内的已存在快照，其余硬失败。
     end_frame_rel = item.get("end_frame_image") if isinstance(item, dict) else None
     end_image: Path | None = None
-    if end_frame_rel:
+    # 只把 None / "" 视为「未设置」（与 data_validator 的 _resolve_existing_path 同口径）；
+    # 0 / False / [] / {} 等其余 falsy 脏数据必须继续走下面的 try_safe_join 硬失败，不能被
+    # Python 的真值判断静默吞成「未设置」进而无声跳过尾帧、照常生成扣费。
+    if end_frame_rel not in (None, ""):
         end_frames_dir = safe_join(project_path, END_FRAME_RESOURCE_TYPE)
         # None 兜住越界 / 脏数据 / 解析失败；目录归属另判，挡住 `end_frames/../storyboards/x.png`
         # 这类落在项目内却绕开快照目录的值。

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -16,7 +16,7 @@ from lib.db.base import DEFAULT_USER_ID
 from lib.i18n import DEFAULT_LOCALE
 from lib.i18n import _ as i18n_translate
 from lib.image_backends.base import ImageCapabilityError
-from lib.path_safety import safe_exists, try_safe_join
+from lib.path_safety import safe_exists, safe_join, try_safe_join
 from lib.project_change_hints import emit_project_change_batch, project_change_source
 from lib.project_manager import get_project_manager
 from lib.prompt_builders import (
@@ -45,6 +45,7 @@ from lib.storyboard_sequence import (
 )
 from lib.thumbnail import extract_video_thumbnail
 from lib.video_backends.base import VideoCapabilityError
+from server.services.end_frame import END_FRAME_RESOURCE_TYPE
 from server.services.generation_context import (
     AudioLaneRequest,
     ImageLaneRequest,
@@ -838,15 +839,23 @@ async def execute_video_task(
     assert_duration_supported(duration_seconds, supported_durations)
 
     # end_frame_image 是镜头持久属性（见 server/services/end_frame.py），剧本每次加载都带出，
-    # 重新生成无需额外操作即可沿用。快照路径恒为服务层写出的 canonical 相对路径，直接拼接；
-    # 能力是否支持尾帧不在此处判断——generator.generate_video_async 内的 plan_frame_slots
-    # 已按已解析 backend 的实际能力统一 gating，不支持时硬失败（VideoCapabilityError），
-    # 不在这里重复一份判断逻辑。
+    # 重新生成无需额外操作即可沿用。能力是否支持尾帧由 generate_video_async 内的 plan_frame_slots
+    # 按已解析 backend 统一 gating（不支持即 VideoCapabilityError），此处不重复一份判断。
+    #
+    # 剧本是磁盘上的 JSON，字段值不可直接信任（归档导入、外部编辑、脏数据都能落值）：绝对路径会
+    # 覆盖 `/` 的左操作数、`..` 会越出项目目录，把任意服务器文件送进视频请求上传给供应商。口径与
+    # 写侧 end_frame.py、校验侧 data_validator（confine_to_default_dir="end_frames"）一致：
+    # 只接受 end_frames/ 内的已存在快照，其余硬失败。
     end_frame_rel = item.get("end_frame_image") if isinstance(item, dict) else None
     end_image: Path | None = None
     if end_frame_rel:
-        end_frame_file = project_path / end_frame_rel
-        if not end_frame_file.exists():
+        end_frames_dir = safe_join(project_path, END_FRAME_RESOURCE_TYPE)
+        # None 兜住越界 / 脏数据 / 解析失败；目录归属另判，挡住 `end_frames/../storyboards/x.png`
+        # 这类落在项目内却绕开快照目录的值。
+        end_frame_file = try_safe_join(project_path, end_frame_rel)
+        if end_frame_file is None or not end_frame_file.is_relative_to(end_frames_dir):
+            raise ValueError(f"invalid end frame snapshot path: {end_frame_rel!r}")
+        if not end_frame_file.is_file():
             raise ValueError(f"end frame snapshot not found: {end_frame_file.name}")
         end_image = end_frame_file
 

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -600,11 +600,14 @@ class TestGenerationTasks:
         assert fake_generator.video_calls[0]["end_image"] == end_frame_dir / "scene_E1S01.png"
 
     @pytest.mark.integration
-    async def test_execute_video_task_without_end_frame_image_passes_none(self, monkeypatch, tmp_path):
-        """未设置尾帧的镜头行为不变：end_image 恒为 None。"""
+    @pytest.mark.parametrize("missing", [True, False], ids=["field-absent", "empty-string"])
+    async def test_execute_video_task_without_end_frame_image_passes_none(self, monkeypatch, tmp_path, missing):
+        """未设置尾帧的镜头行为不变：字段缺失或显式空字符串，end_image 均为 None。"""
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = _FakeGenerator()
+        if not missing:
+            fake_pm.script["segments"][0]["end_frame_image"] = ""
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
@@ -652,6 +655,7 @@ class TestGenerationTasks:
             0,  # falsy 脏数据：真值判断不得把它当成「未设置」而静默跳过尾帧
             False,  # 同上
             [],  # 同上
+            {},  # 同上
         ],
     )
     @pytest.mark.integration

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -572,6 +572,137 @@ class TestGenerationTasks:
         assert result["resource_type"] == "videos"
         assert fake_generator.video_calls[0]["duration_seconds"] == 8
 
+    async def test_execute_video_task_end_frame_image_passed_to_generator(self, monkeypatch, tmp_path):
+        """镜头设置了 end_frame_image 时，生成视频请求携带 end_image；快照路径取自
+        镜头持久字段拼接的项目内固定相对路径。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+
+        end_frame_dir = project_path / "end_frames"
+        end_frame_dir.mkdir(parents=True, exist_ok=True)
+        (end_frame_dir / "scene_E1S01.png").write_bytes(b"png")
+        fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {"script_file": "episode_1.json", "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []}},
+        )
+
+        assert fake_generator.video_calls[0]["end_image"] == end_frame_dir / "scene_E1S01.png"
+
+    async def test_execute_video_task_without_end_frame_image_passes_none(self, monkeypatch, tmp_path):
+        """未设置尾帧的镜头行为不变：end_image 恒为 None。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {"script_file": "episode_1.json", "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []}},
+        )
+
+        assert fake_generator.video_calls[0]["end_image"] is None
+
+    async def test_execute_video_task_missing_end_frame_snapshot_fails_hard(self, monkeypatch, tmp_path):
+        """尾帧字段指向的快照文件缺失时硬失败，不调用后端生成。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+
+        with pytest.raises(ValueError, match="end frame snapshot not found"):
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                },
+            )
+        assert fake_generator.video_calls == []
+
+    async def test_execute_video_task_end_frame_capability_unsupported_propagates(self, monkeypatch, tmp_path):
+        """后端不支持尾帧能力时，generator 抛出的 VideoCapabilityError 原样上抛——不降级为
+        参考图、不静默丢帧。具体的能力 gating 由 lib/video_frame_slots.plan_frame_slots 负责
+        （见 tests/test_video_frame_slots.py），这里只验证 execute_video_task 把 end_image
+        接线进去后不吞掉/篡改该异常。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+
+        end_frame_dir = project_path / "end_frames"
+        end_frame_dir.mkdir(parents=True, exist_ok=True)
+        (end_frame_dir / "scene_E1S01.png").write_bytes(b"png")
+        fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
+
+        async def _raise_unsupported(**kwargs):
+            fake_generator.video_calls.append(kwargs)
+            if kwargs.get("end_image") is not None:
+                raise VideoCapabilityError("video_last_frame_unsupported", provider="ark", model="seedance")
+            raise AssertionError("expected end_image to be populated")
+
+        fake_generator.generate_video_async = _raise_unsupported
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+
+        with pytest.raises(VideoCapabilityError) as exc:
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                },
+            )
+        assert exc.value.code == "video_last_frame_unsupported"
+
+    async def test_execute_video_task_reuses_end_frame_on_regeneration(self, monkeypatch, tmp_path):
+        """视频重生成无需额外操作即自动沿用尾帧：字段是镜头持久属性，每次执行都从剧本重新加载。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+
+        end_frame_dir = project_path / "end_frames"
+        end_frame_dir.mkdir(parents=True, exist_ok=True)
+        (end_frame_dir / "scene_E1S01.png").write_bytes(b"png")
+        fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        for _ in range(2):
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                },
+            )
+
+        assert len(fake_generator.video_calls) == 2
+        for call in fake_generator.video_calls:
+            assert call["end_image"] == end_frame_dir / "scene_E1S01.png"
+
     async def test_execute_video_task_drama_dialogue_from_utterances(self, monkeypatch, tmp_path):
         """drama 口型台词从场景级 dialogue-kind utterances 取（覆盖 payload 已不带的
         video_prompt.dialogue）；voiceover-kind 不进视频 YAML。"""

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -746,6 +746,34 @@ class TestGenerationTasks:
         assert fake_generator.video_calls == []
 
     @pytest.mark.integration
+    async def test_execute_video_task_end_frame_parent_dir_symlink_fails_hard(self, monkeypatch, tmp_path):
+        """符号链接调包不止发生在文件名这一级：`end_frames/` 目录本身被替换成指向项目内
+        别的目录的符号链接时，最终文件名一致、realpath 展开后两侧路径也相等，仅检查文件名
+        这一段挡不住——须逐段检查 canonical 路径的每个组件（含父目录）。"""
+        project_path = _prepare_files(tmp_path)
+        real_dir = project_path / "storyboards_end_frames_swap"
+        real_dir.mkdir(parents=True, exist_ok=True)
+        (real_dir / "scene_E1S01.png").write_bytes(b"png")
+        (project_path / "end_frames").symlink_to(real_dir)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+
+        with pytest.raises(ValueError, match="invalid end frame snapshot path"):
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                },
+            )
+        assert fake_generator.video_calls == []
+
+    @pytest.mark.integration
     async def test_execute_video_task_end_frame_capability_unsupported_propagates(self, monkeypatch, tmp_path):
         """后端不支持尾帧能力时硬失败，不降级为参考图、不静默丢帧。
 

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -600,6 +600,35 @@ class TestGenerationTasks:
         assert fake_generator.video_calls[0]["end_image"] == end_frame_dir / "scene_E1S01.png"
 
     @pytest.mark.integration
+    async def test_execute_video_task_end_frame_image_bare_filename_resolves_via_default_dir(
+        self, monkeypatch, tmp_path
+    ):
+        """尾帧字段是裸文件名（无 `end_frames/` 前缀）时按校验侧
+        data_validator._resolve_existing_path 的 default_dir 回退口径解析——否则通过导入校验
+        （校验器对裸文件名会补目录重试）的值会在生成期无理由硬失败。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+
+        end_frame_dir = project_path / "end_frames"
+        end_frame_dir.mkdir(parents=True, exist_ok=True)
+        (end_frame_dir / "scene_E1S01.png").write_bytes(b"png")
+        fake_pm.script["segments"][0]["end_frame_image"] = "scene_E1S01.png"
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {"script_file": "episode_1.json", "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []}},
+        )
+
+        assert fake_generator.video_calls[0]["end_image"] == end_frame_dir / "scene_E1S01.png"
+
+    @pytest.mark.integration
     @pytest.mark.parametrize("missing", [True, False], ids=["field-absent", "empty-string"])
     async def test_execute_video_task_without_end_frame_image_passes_none(self, monkeypatch, tmp_path, missing):
         """未设置尾帧的镜头行为不变：字段缺失或显式空字符串，end_image 均为 None。"""
@@ -656,6 +685,7 @@ class TestGenerationTasks:
             False,  # 同上
             [],  # 同上
             {},  # 同上
+            "end_frames/scene_E1S02.png",  # 落在快照目录内、文件也存在，但属于别的镜头——跨镜头误引
         ],
     )
     @pytest.mark.integration
@@ -666,6 +696,9 @@ class TestGenerationTasks:
         不把任意服务器文件送进视频请求。约束与写侧 end_frame.py、校验侧 data_validator 同口径。"""
         project_path = _prepare_files(tmp_path)
         (tmp_path / "outside.png").write_bytes(b"png")
+        end_frame_dir = project_path / "end_frames"
+        end_frame_dir.mkdir(parents=True, exist_ok=True)
+        (end_frame_dir / "scene_E1S02.png").write_bytes(b"png")  # 别的镜头的快照，供跨镜头误引用例检查
         fake_pm = _FakePM(project_path)
         fake_generator = _FakeGenerator()
         fake_pm.script["segments"][0]["end_frame_image"] = end_frame_value

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -718,6 +718,34 @@ class TestGenerationTasks:
         assert fake_generator.video_calls == []
 
     @pytest.mark.integration
+    async def test_execute_video_task_end_frame_canonical_path_symlink_fails_hard(self, monkeypatch, tmp_path):
+        """尾帧字段值恰是当前镜头的 canonical 相对路径，但磁盘上那个位置被替换成指向别处
+        （另一镜头快照）的符号链接：try_safe_join / safe_join 都会展开符号链接把两侧解析到
+        同一真实目标，仅凭路径相等挡不住「路径字符串对、磁盘对象被调包」，须显式拒绝。"""
+        project_path = _prepare_files(tmp_path)
+        end_frame_dir = project_path / "end_frames"
+        end_frame_dir.mkdir(parents=True, exist_ok=True)
+        (end_frame_dir / "scene_E1S02.png").write_bytes(b"png")
+        (end_frame_dir / "scene_E1S01.png").symlink_to(end_frame_dir / "scene_E1S02.png")
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+
+        with pytest.raises(ValueError, match="invalid end frame snapshot path"):
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                },
+            )
+        assert fake_generator.video_calls == []
+
+    @pytest.mark.integration
     async def test_execute_video_task_end_frame_capability_unsupported_propagates(self, monkeypatch, tmp_path):
         """后端不支持尾帧能力时硬失败，不降级为参考图、不静默丢帧。
 

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -573,6 +573,7 @@ class TestGenerationTasks:
         assert result["resource_type"] == "videos"
         assert fake_generator.video_calls[0]["duration_seconds"] == 8
 
+    @pytest.mark.integration
     async def test_execute_video_task_end_frame_image_passed_to_generator(self, monkeypatch, tmp_path):
         """镜头设置了 end_frame_image 时，生成视频请求携带 end_image；快照路径取自
         镜头持久字段拼接的项目内固定相对路径。"""
@@ -598,6 +599,7 @@ class TestGenerationTasks:
 
         assert fake_generator.video_calls[0]["end_image"] == end_frame_dir / "scene_E1S01.png"
 
+    @pytest.mark.integration
     async def test_execute_video_task_without_end_frame_image_passes_none(self, monkeypatch, tmp_path):
         """未设置尾帧的镜头行为不变：end_image 恒为 None。"""
         project_path = _prepare_files(tmp_path)
@@ -617,6 +619,7 @@ class TestGenerationTasks:
 
         assert fake_generator.video_calls[0]["end_image"] is None
 
+    @pytest.mark.integration
     async def test_execute_video_task_missing_end_frame_snapshot_fails_hard(self, monkeypatch, tmp_path):
         """尾帧字段指向的快照文件缺失时硬失败，不调用后端生成。"""
         project_path = _prepare_files(tmp_path)
@@ -646,8 +649,12 @@ class TestGenerationTasks:
             "end_frames/../storyboards/scene_E1S01.png",  # 项目内但绕开快照目录，等于直接引用源图
             "storyboards/scene_E1S01.png",  # 同上：字段只接受 end_frames/ 内的快照
             123,  # 剧本 JSON 里的脏数据（非字符串）须给出可读失败，而非 TypeError
+            0,  # falsy 脏数据：真值判断不得把它当成「未设置」而静默跳过尾帧
+            False,  # 同上
+            [],  # 同上
         ],
     )
+    @pytest.mark.integration
     async def test_execute_video_task_end_frame_path_outside_snapshot_dir_fails_hard(
         self, monkeypatch, tmp_path, end_frame_value
     ):
@@ -673,6 +680,7 @@ class TestGenerationTasks:
             )
         assert fake_generator.video_calls == []
 
+    @pytest.mark.integration
     async def test_execute_video_task_end_frame_capability_unsupported_propagates(self, monkeypatch, tmp_path):
         """后端不支持尾帧能力时硬失败，不降级为参考图、不静默丢帧。
 
@@ -715,6 +723,7 @@ class TestGenerationTasks:
             )
         assert exc.value.code == "video_last_frame_unsupported"
 
+    @pytest.mark.integration
     async def test_execute_video_task_reuses_end_frame_on_regeneration(self, monkeypatch, tmp_path):
         """视频重生成无需额外操作即自动沿用尾帧：字段是镜头持久属性，每次执行都从剧本重新加载。"""
         project_path = _prepare_files(tmp_path)

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -774,6 +774,38 @@ class TestGenerationTasks:
         assert fake_generator.video_calls == []
 
     @pytest.mark.integration
+    async def test_execute_video_task_end_frame_parent_dir_junction_fails_hard(self, monkeypatch, tmp_path):
+        """Windows 原生环境下目录联接（junction）是独立于符号链接的 reparse point 类型，
+        `Path.is_symlink()` 识别不到；`end_frames/` 被联接到项目内别的目录时须靠 `is_junction()`
+        单独挡住。非 Windows 平台无法真实创建 junction，这里 monkeypatch `Path.is_junction()`
+        模拟该状态，验证逐段检查确实调用了它而非只查符号链接。"""
+        project_path = _prepare_files(tmp_path)
+        real_dir = project_path / "storyboards_end_frames_swap"
+        real_dir.mkdir(parents=True, exist_ok=True)
+        (real_dir / "scene_E1S01.png").write_bytes(b"png")
+        end_frames_dir = project_path / "end_frames"
+        end_frames_dir.mkdir(parents=True, exist_ok=True)
+        (end_frames_dir / "scene_E1S01.png").write_bytes(b"png")
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(Path, "is_junction", lambda self: self == end_frames_dir)
+
+        with pytest.raises(ValueError, match="invalid end frame snapshot path"):
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                },
+            )
+        assert fake_generator.video_calls == []
+
+    @pytest.mark.integration
     async def test_execute_video_task_end_frame_capability_unsupported_propagates(self, monkeypatch, tmp_path):
         """后端不支持尾帧能力时硬失败，不降级为参考图、不静默丢帧。
 

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -3,7 +3,8 @@ from pathlib import Path
 import pytest
 
 from lib.config.resolver import ProviderModel
-from lib.video_backends.base import VideoCapabilityError
+from lib.video_backends.base import VideoCapabilities, VideoCapabilityError
+from lib.video_frame_slots import plan_frame_slots
 from server.services import generation_tasks
 from server.services.generation_context import GenerationContext, ImageLaneResult, VideoLaneResult
 from server.services.generation_tasks import assert_duration_supported
@@ -637,11 +638,47 @@ class TestGenerationTasks:
             )
         assert fake_generator.video_calls == []
 
+    @pytest.mark.parametrize(
+        "end_frame_value",
+        [
+            "/etc/passwd",  # 绝对路径：裸 `/` 拼接会整体丢弃左操作数，读到项目外文件
+            "../../outside.png",  # `..` 穿越出项目目录
+            "end_frames/../storyboards/scene_E1S01.png",  # 项目内但绕开快照目录，等于直接引用源图
+            "storyboards/scene_E1S01.png",  # 同上：字段只接受 end_frames/ 内的快照
+            123,  # 剧本 JSON 里的脏数据（非字符串）须给出可读失败，而非 TypeError
+        ],
+    )
+    async def test_execute_video_task_end_frame_path_outside_snapshot_dir_fails_hard(
+        self, monkeypatch, tmp_path, end_frame_value
+    ):
+        """剧本是磁盘 JSON，尾帧字段不可信：越界 / 绕开 end_frames 快照目录 / 脏数据一律硬失败，
+        不把任意服务器文件送进视频请求。约束与写侧 end_frame.py、校验侧 data_validator 同口径。"""
+        project_path = _prepare_files(tmp_path)
+        (tmp_path / "outside.png").write_bytes(b"png")
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        fake_pm.script["segments"][0]["end_frame_image"] = end_frame_value
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+
+        with pytest.raises(ValueError, match="invalid end frame snapshot path"):
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                },
+            )
+        assert fake_generator.video_calls == []
+
     async def test_execute_video_task_end_frame_capability_unsupported_propagates(self, monkeypatch, tmp_path):
-        """后端不支持尾帧能力时，generator 抛出的 VideoCapabilityError 原样上抛——不降级为
-        参考图、不静默丢帧。具体的能力 gating 由 lib/video_frame_slots.plan_frame_slots 负责
-        （见 tests/test_video_frame_slots.py），这里只验证 execute_video_task 把 end_image
-        接线进去后不吞掉/篡改该异常。"""
+        """后端不支持尾帧能力时硬失败，不降级为参考图、不静默丢帧。
+
+        替身只替换 provider 调用，能力判定交给生产代码 plan_frame_slots 跑真值（caps
+        last_frame=False）——否则替身按自己的条件抛异常，验的是替身而非接线是否真能触达
+        gating。能力组合的各分支另见 tests/test_video_frame_slots.py。"""
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = _FakeGenerator()
@@ -651,13 +688,18 @@ class TestGenerationTasks:
         (end_frame_dir / "scene_E1S01.png").write_bytes(b"png")
         fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
 
-        async def _raise_unsupported(**kwargs):
+        async def _plan_with_real_gating(**kwargs):
             fake_generator.video_calls.append(kwargs)
-            if kwargs.get("end_image") is not None:
-                raise VideoCapabilityError("video_last_frame_unsupported", provider="ark", model="seedance")
-            raise AssertionError("expected end_image to be populated")
+            plan_frame_slots(
+                caps=VideoCapabilities(first_frame=True, last_frame=False),
+                provider="ark",
+                model="seedance",
+                start_image=kwargs.get("start_image"),
+                end_image=kwargs.get("end_image"),
+            )
+            raise AssertionError("plan_frame_slots 应在 end_image 非空且 caps.last_frame 为假时硬失败")
 
-        fake_generator.generate_video_async = _raise_unsupported
+        fake_generator.generate_video_async = _plan_with_real_gating
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))


### PR DESCRIPTION
Closes #1296

## 变更

已设置尾帧的镜头在生成/重新生成视频时，把尾帧快照接入视频请求；尾帧不可用时明确失败，不静默丢帧、不降级成参考图。

- `execute_video_task` 读取镜头持久字段 `end_frame_image`，解析出快照绝对路径填入 `end_image`（此前恒为空）。未设置尾帧的镜头行为不变。
- 快照路径经 `lib/path_safety` 收口，并要求落在项目的 `end_frames/` 快照目录内——口径与写侧 `server/services/end_frame.py`、校验侧 `lib/data_validator.py` 一致。剧本是磁盘上的 JSON，字段可能来自归档导入或外部编辑，裸拼接下绝对路径与 `..` 会把项目外的文件送进视频请求上传给供应商。越界 / 脏数据 / 文件缺失分别给出可读的硬失败。
- 后端不支持 `last_frame` 能力时的硬失败复用 `lib/video_frame_slots.py::plan_frame_slots` 既有 gating，编排层不重复一份能力判断。
- 视频重生成自动沿用尾帧（字段是镜头持久属性，剧本每次加载都带出，无需额外操作）。
- 范围仅普通图生视频路径；宫格生视频拆格后走同一函数天然沿用；参考生视频（`execute_reference_video_task`）与接续路径（`resume_executor.py`）未触碰。

## 验证

- `tests/test_generation_tasks_service.py` 新增 6 个用例（含 5 例参数化的越界/脏数据场景）：带尾帧时请求携带正确路径、未设尾帧恒为 `None`、快照缺失硬失败且不调用后端、路径越界或绕开快照目录硬失败、能力不支持时异常原样上抛、重生成两次均携带尾帧。能力不支持一例由生产代码 `plan_frame_slots` 跑真实 caps 判定，替身只替换 provider 调用。
- `uv run ruff check` / `ruff format`：全绿
- `uv run basedpyright`：0 error（872 warning 均为既有）
- `uv run python -m pytest --cov`：6485 passed，总覆盖率 92%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 视频生成现支持基于剧本配置的尾帧快照（`end_frame_image`）：支持完整路径或仅文件名，并将反斜杠规范化、按项目 `end_frames/` 规则解析为标准资源路径；同一镜头连续重生成可复用解析结果。
* **错误修复**
  * 对越界穿越、跨镜头/绝对路径、非字符串等不可信输入进行拒绝；缺失快照返回“not found”，不合法路径返回“invalid...”。同时校验符号链接/目录联接篡改；不支持尾帧时返回 `video_last_frame_unsupported` 且不发起生成。
* **测试**
  * 新增尾帧解析、安全校验、能力网关与重生成行为的集成覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->