### PR TITLE
fix(video): 尾帧选图拒收超大源文件，非法项目名或剧本路径返回可读错误

### DIFF
--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -44,6 +44,7 @@ mid-flight 被删除而失败时跳过整段写回，不留半截状态。
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import threading
 from pathlib import Path
@@ -54,7 +55,7 @@ from lib.project_change_hints import project_change_source
 from lib.project_manager import ProjectManager, get_project_manager
 from lib.resource_paths import END_FRAME_RESOURCE_TYPE, resource_relative_path
 from lib.storyboard_sequence import find_storyboard_item, get_storyboard_items
-from server.services.upload_finalize import write_bytes_atomic
+from server.services.upload_finalize import UPLOAD_IMAGE_MAX_BYTES, UploadTooLargeError, write_bytes_atomic
 
 logger = logging.getLogger(__name__)
 
@@ -99,8 +100,17 @@ def _locate_shot(project_name: str, script_file: str, shot_id: str) -> Path:
         project_path = manager.get_project_path(project_name)
     except FileNotFoundError as exc:
         raise EndFrameError("project_not_found", status_code=404, name=project_name) from exc
+    except ValueError as exc:
+        raise EndFrameError("invalid_project_name", status_code=400, name=project_name) from exc
 
-    script = manager.load_script(project_name, script_file)
+    try:
+        script = manager.load_script(project_name, script_file)
+    except json.JSONDecodeError:
+        # JSONDecodeError 是 ValueError 子类，须先于下面的 except ValueError 拦截：
+        # 剧本文件损坏不能误判为「非法 script_file」，交由 _translated_errors 的兜底分支收口为 500
+        raise
+    except ValueError as exc:
+        raise EndFrameError("invalid_script_file", status_code=400, name=script_file) from exc
     items, id_field, _, _, _ = get_storyboard_items(script)
     if find_storyboard_item(items, id_field, shot_id) is None:
         raise EndFrameError("segment_not_found", status_code=404, id=shot_id)
@@ -239,10 +249,13 @@ def _clear_snapshot_and_field(project_name: str, script_file: str, shot_id: str,
 
 
 def read_project_image(project_path: Path, source_path: str) -> bytes:
-    """读取项目内已有图片的字节；路径越界或文件缺失时抛领域错误。
+    """读取项目内已有图片的字节；路径越界、文件缺失或超限时抛领域错误。
 
     不限定来源子目录——分镜图 / 角色 / 场景 / 宫格切图都可直接选用，越界防护
     由 ``safe_join`` 统一负责（与 data_validator 的路径字段校验同口径）。
+
+    读取按上传通道同一 30 MiB 上限有界读取，不整读入内存——项目内合法存在的
+    大文件（如视频）被当作选图源时不至于无界内存占用。
     """
     normalized = source_path.strip().replace("\\", "/")
     if not normalized:
@@ -253,7 +266,11 @@ def read_project_image(project_path: Path, source_path: str) -> bytes:
         raise EndFrameError("invalid_end_frame_source", path=source_path) from exc
     if not resolved.is_file():
         raise EndFrameError("end_frame_source_not_found", status_code=404, path=normalized)
-    return resolved.read_bytes()
+    with resolved.open("rb") as f:
+        content = f.read(UPLOAD_IMAGE_MAX_BYTES + 1)
+    if len(content) > UPLOAD_IMAGE_MAX_BYTES:
+        raise UploadTooLargeError(UPLOAD_IMAGE_MAX_BYTES)
+    return content
 
 
 async def _apply_snapshot(

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -105,9 +105,10 @@ def _locate_shot(project_name: str, script_file: str, shot_id: str) -> Path:
 
     try:
         script = manager.load_script(project_name, script_file)
-    except json.JSONDecodeError:
-        # JSONDecodeError 是 ValueError 子类，须先于下面的 except ValueError 拦截：
-        # 剧本文件损坏不能误判为「非法 script_file」，交由 _translated_errors 的兜底分支收口为 500
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        # 二者都是 ValueError 子类，须先于下面的 except ValueError 拦截：
+        # 剧本文件损坏（JSON 语法错误或非 UTF-8 字节）不能误判为「非法 script_file」，
+        # 交由 _translated_errors 的兜底分支收口为 500
         raise
     except ValueError as exc:
         raise EndFrameError("invalid_script_file", status_code=400, name=script_file) from exc

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -254,8 +254,8 @@ def read_project_image(project_path: Path, source_path: str) -> bytes:
     不限定来源子目录——分镜图 / 角色 / 场景 / 宫格切图都可直接选用，越界防护
     由 ``safe_join`` 统一负责（与 data_validator 的路径字段校验同口径）。
 
-    读取按上传通道同一 30 MiB 上限有界读取，不整读入内存——项目内合法存在的
-    大文件（如视频）被当作选图源时不至于无界内存占用。
+    读取按上传通道同一上限（``UPLOAD_IMAGE_MAX_BYTES``）有界读取，不整读入内存——
+    项目内合法存在的大文件（如视频）被当作选图源时不至于无界内存占用。
     """
     normalized = source_path.strip().replace("\\", "/")
     if not normalized:

--- a/tests/test_end_frame_model.py
+++ b/tests/test_end_frame_model.py
@@ -76,6 +76,7 @@ _BUILDERS = pytest.mark.parametrize(
 )
 
 
+@pytest.mark.unit
 class TestEndFrameImageField:
     @_BUILDERS
     def test_defaults_to_none(self, build) -> None:
@@ -125,6 +126,7 @@ def _projects_client(pm: ProjectManager, monkeypatch) -> TestClient:
     return TestClient(app)
 
 
+@pytest.mark.integration
 class TestGenericPatchIgnoresEndFrame:
     """通用剧本 PATCH 白名单不含 end_frame_image：设置尾帧只能走专用端点。"""
 
@@ -169,6 +171,7 @@ def _write_png(path, size=(8, 8)) -> None:
     path.write_bytes(buf.getvalue())
 
 
+@pytest.mark.integration
 class TestDataValidatorEndFramePath:
     @pytest.fixture
     def project(self, tmp_path):

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -24,6 +24,8 @@ from server.routers import end_frames
 from server.services import end_frame as end_frame_service
 from server.services import upload_finalize
 
+pytestmark = pytest.mark.integration
+
 END_FRAME_REL = "end_frames/scene_E1S01.png"
 
 
@@ -165,6 +167,16 @@ class TestSelectChannel:
     def test_missing_source_returns_404(self, client):
         c, _pm = client
         assert _select(c, "storyboards/scene_E1S99.png").status_code == 404
+
+    def test_oversized_source_image_rejected_without_full_read(self, client, monkeypatch):
+        """项目内选图源超过上传通道同一上限时须拒绝，不整读入内存（见 read_project_image）。"""
+        c, pm = client
+        monkeypatch.setattr(end_frame_service, "UPLOAD_IMAGE_MAX_BYTES", 16)
+        _write_source_image(pm, "storyboards/scene_E1S02.png", _img_bytes("PNG", size=(64, 64)))
+
+        resp = _select(c, "storyboards/scene_E1S02.png")
+        assert resp.status_code == 413
+        assert _segment(pm).get("end_frame_image") is None
 
 
 class TestClear:
@@ -335,7 +347,6 @@ def _inject_concurrent_takeover_before_nth_load(monkeypatch, key, target: Path, 
 class TestPersistFailureRestoresSnapshot:
     """剧本持久化在临界区内失败时，快照文件须回滚到操作前状态，不留悬空引用或静默丢失。"""
 
-    @pytest.mark.integration
     def test_set_failure_restores_previous_snapshot_bytes(self, client, monkeypatch):
         c, pm = client
         _upload(c, _img_bytes("PNG", size=(8, 8)))
@@ -350,7 +361,6 @@ class TestPersistFailureRestoresSnapshot:
         assert _segment(pm)["end_frame_image"] == END_FRAME_REL
         assert snapshot.read_bytes() == before
 
-    @pytest.mark.integration
     def test_set_failure_on_first_write_removes_snapshot(self, client, monkeypatch):
         """此前未设置过尾帧时失败：快照文件此前不存在，须整段撤回而非留下孤儿文件。"""
         c, pm = client
@@ -363,7 +373,6 @@ class TestPersistFailureRestoresSnapshot:
         assert _segment(pm).get("end_frame_image") is None
         assert not snapshot.exists()
 
-    @pytest.mark.integration
     def test_clear_failure_restores_deleted_snapshot(self, client, monkeypatch):
         c, pm = client
         _upload(c, _img_bytes("PNG"))
@@ -379,7 +388,6 @@ class TestPersistFailureRestoresSnapshot:
         assert snapshot.exists()
         assert snapshot.read_bytes() == before
 
-    @pytest.mark.integration
     def test_set_failure_skips_restore_when_concurrent_write_supersedes(self, client, monkeypatch):
         """回滚重新过锁时若该镜头的操作代次已前移，说明并发请求已经接管，
         必须跳过回滚——否则会用陈旧字节覆盖对方刚成功落盘的内容。"""
@@ -397,7 +405,6 @@ class TestPersistFailureRestoresSnapshot:
 
         assert snapshot.read_bytes() == concurrent_bytes
 
-    @pytest.mark.integration
     def test_clear_failure_skips_restore_when_concurrent_write_recreates_snapshot(self, client, monkeypatch):
         c, pm = client
         _upload(c, _img_bytes("PNG"))
@@ -415,7 +422,6 @@ class TestPersistFailureRestoresSnapshot:
         assert snapshot.exists()
         assert snapshot.read_bytes() == concurrent_bytes
 
-    @pytest.mark.integration
     def test_clear_failure_skips_restore_when_concurrent_clear_wins(self, client, monkeypatch):
         """CodeRabbit 指出的退化值场景：清除失败后文件已被删（期望内容与「无人接手」的
         期望值同为 None），并发的另一次清除随后也成功完成，结果同样是文件不存在——若
@@ -435,7 +441,6 @@ class TestPersistFailureRestoresSnapshot:
         # 回滚跳过：文件保持并发清除后的「已删除」结果，没有被旧字节重新写回制造孤儿文件
         assert not snapshot.exists()
 
-    @pytest.mark.integration
     def test_set_failure_skips_restore_when_concurrent_takeover_uses_other_alias(self, client, monkeypatch):
         """Codex 指出的别名归一问题：本次失败操作用 `scripts/episode_1.json` 这个别名，
         代次键若不归一化会与并发接管（用 `episode_1.json` 归一后的键）各自生成一把代次，
@@ -457,7 +462,6 @@ class TestPersistFailureRestoresSnapshot:
         # 未归一化则代次键不同，回滚会看不到接管、用旧字节覆盖并发写入的新内容
         assert snapshot.read_bytes() == concurrent_bytes
 
-    @pytest.mark.integration
     def test_set_failure_restore_uses_bytes_read_inside_critical_section(self, client, monkeypatch):
         """Codex 指出的陈旧基线问题：`old_bytes` 若在取得剧本锁之前预读，读到的是「进入
         临界区之前」而非「进入临界区那一刻」的文件内容。这里不推进代次，只在本次操作
@@ -576,6 +580,25 @@ class TestErrorMapping:
         resp = _upload(c, _img_bytes("PNG"))
         assert resp.status_code == 500
         assert "leaked" not in resp.text
+
+    def test_illegal_project_name_returns_400(self, client):
+        """`get_project_path` 对非法项目名（正则不匹配）抛 ValueError，须映射为 400 而非落 500 兜底。"""
+        c, _pm = client
+        resp = c.post(
+            "/api/v1/projects/demo.evil/shots/E1S01/end-frame/upload?script_file=episode_1.json",
+            files={"file": ("f.png", BytesIO(_img_bytes("PNG")), "application/octet-stream")},
+        )
+        assert resp.status_code == 400
+
+    def test_illegal_script_file_returns_400(self, client):
+        """`load_script` 底层 `_safe_subpath` 对越界 script_file 抛 ValueError，须映射为 400。"""
+        c, pm = client
+        resp = c.post(
+            "/api/v1/projects/demo/shots/E1S01/end-frame/upload?script_file=../../../../etc/passwd",
+            files={"file": ("f.png", BytesIO(_img_bytes("PNG")), "application/octet-stream")},
+        )
+        assert resp.status_code == 400
+        assert _segment(pm).get("end_frame_image") is None
 
 
 class TestValidatorAcceptsWrittenSnapshot:

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -168,8 +168,8 @@ class TestSelectChannel:
         c, _pm = client
         assert _select(c, "storyboards/scene_E1S99.png").status_code == 404
 
-    def test_oversized_source_image_rejected_without_full_read(self, client, monkeypatch):
-        """项目内选图源超过上传通道同一上限时须拒绝，不整读入内存（见 read_project_image）。"""
+    def test_oversized_source_image_rejected(self, client, monkeypatch):
+        """项目内选图源超过上传通道同一上限时须拒绝（见 read_project_image）。"""
         c, pm = client
         monkeypatch.setattr(end_frame_service, "UPLOAD_IMAGE_MAX_BYTES", 16)
         _write_source_image(pm, "storyboards/scene_E1S02.png", _img_bytes("PNG", size=(64, 64)))
@@ -177,6 +177,37 @@ class TestSelectChannel:
         resp = _select(c, "storyboards/scene_E1S02.png")
         assert resp.status_code == 413
         assert _segment(pm).get("end_frame_image") is None
+
+    def test_source_image_read_is_bounded(self, client, monkeypatch):
+        """超限源图不得整读入内存：单次 read 请求的字节数以上限 +1 为界，够判超限即止。"""
+        _c, pm = client
+        _write_source_image(pm, "storyboards/scene_E1S02.png", _img_bytes("PNG", size=(64, 64)))
+        project_path = pm.get_project_path("demo")
+        monkeypatch.setattr(end_frame_service, "UPLOAD_IMAGE_MAX_BYTES", 16)
+
+        read_sizes: list[int] = []
+        real_open = Path.open
+
+        class _SpyHandle:
+            def __init__(self, handle) -> None:
+                self._handle = handle
+
+            def read(self, size: int = -1) -> bytes:
+                read_sizes.append(size)
+                return self._handle.read(size)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info):
+                return self._handle.__exit__(*exc_info)
+
+        monkeypatch.setattr(Path, "open", lambda self, *a, **kw: _SpyHandle(real_open(self, *a, **kw)))
+
+        with pytest.raises(upload_finalize.UploadTooLargeError):
+            end_frame_service.read_project_image(project_path, "storyboards/scene_E1S02.png")
+
+        assert read_sizes == [17]
 
 
 class TestClear:
@@ -599,6 +630,28 @@ class TestErrorMapping:
         )
         assert resp.status_code == 400
         assert _segment(pm).get("end_frame_image") is None
+
+    def test_illegal_path_returns_400_on_select_and_clear(self, client):
+        """三个端点共用 `_locate_shot`，选图与清除通道同样须落 400 而非 500。"""
+        c, _pm = client
+        select_resp = c.post(
+            "/api/v1/projects/demo.evil/shots/E1S01/end-frame/select",
+            json={"script_file": "episode_1.json", "source_path": "storyboards/scene_E1S01.png"},
+        )
+        assert select_resp.status_code == 400
+
+        clear_resp = c.delete(
+            "/api/v1/projects/demo/shots/E1S01/end-frame?script_file=../../../../etc/passwd",
+        )
+        assert clear_resp.status_code == 400
+
+    def test_corrupt_script_still_maps_to_500(self, client):
+        """`JSONDecodeError` 是 `ValueError` 子类：剧本文件损坏须落 500 兜底，
+        不能被非法 script_file 的 400 分支吞掉，否则错误原因对排查完全失真。"""
+        c, pm = client
+        (pm.get_project_path("demo") / "scripts" / "episode_1.json").write_text("{ not json", encoding="utf-8")
+
+        assert _upload(c, _img_bytes("PNG")).status_code == 500
 
 
 class TestValidatorAcceptsWrittenSnapshot:

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -653,6 +653,14 @@ class TestErrorMapping:
 
         assert _upload(c, _img_bytes("PNG")).status_code == 500
 
+    def test_non_utf8_script_still_maps_to_500(self, client):
+        """`UnicodeDecodeError` 同样是 `ValueError` 子类：剧本文件含非法 UTF-8 字节须落 500 兜底，
+        不能被非法 script_file 的 400 分支吞掉。"""
+        c, pm = client
+        (pm.get_project_path("demo") / "scripts" / "episode_1.json").write_bytes(b"\xff\xfe not utf-8")
+
+        assert _upload(c, _img_bytes("PNG")).status_code == 500
+
 
 class TestValidatorAcceptsWrittenSnapshot:
     def test_written_project_passes_tree_validation(self, client):


### PR DESCRIPTION
Closes #1345

## 变更

PR #1344（尾帧数据模型与 API）审查循环中经核实成立、因时序未在原 PR 内修复的三处缺陷，同属 `end_frames` 改动域，合为一票收口。

1. **项目内选图不再无界读取源文件** — `read_project_image()` 此前仅判断文件存在即整读字节，项目内合法存在的大文件（如视频）被当作选图源时会无界占用内存。改为复用上传通道同一上限（`UPLOAD_IMAGE_MAX_BYTES`，30 MiB）做一次性有界读取（`read(max + 1)` 后判长），超限抛既有的大小超限错误。用有界读取而非先 `stat()` 再整读，是为了避开 stat 通过后源文件被换成更大文件的 TOCTOU 窗口。
2. **非法项目名与越界剧本路径返回可读错误而非服务器错误** — `get_project_path` / `_safe_subpath` 抛的 `ValueError` 此前未被单独捕获，落入兜底分支返回 500 并产生日志噪音。在 `_locate_shot` 内分别映射为既有的 `invalid_project_name` / `invalid_script_file`（三语翻译已存在，未新增 key）。`json.JSONDecodeError` 是 `ValueError` 子类，先行重新抛出，避免把「剧本文件损坏」误判成「非法 script_file」——与 `server/routers/grids.py` 的既有先例同形。
3. **两个尾帧测试文件补 marker** — `test_end_frames_router.py` 全文件走真实 `TestClient` + `ProjectManager`，用模块级 `pytestmark = pytest.mark.integration` 统一覆盖（并删掉此前零散的 8 处方法级重复标注）；`test_end_frame_model.py` 按类拆分，纯 Pydantic 往返标 `unit`，触真实文件系统的两类标 `integration`。

## 验证

- `uv run python -m pytest` — 6501 passed
- `uv run ruff check . && uv run ruff format --check` — 全绿
- `uv run basedpyright` — 0 errors
- `pytest -m "not unit and not integration"` 对两个尾帧测试文件收集到 0 个用例（57 个全部被 marker 选中）

## 新增回归测试

- 选图源超限返回大小超限错误；并单独断言单次读取字节数以上限 +1 为界（守住「不整读入内存」本身，而非只守拒绝结果）
- 非法项目名 / 越界 script_file 在上传、选图、清除三个端点均返回 400
- 剧本文件损坏仍落 500，守住 `JSONDecodeError` 不被 400 分支吞掉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **漏洞修复**
  * 尾帧“项目内选图”改为有界读取：按图片上限进行读取，超出上限将被拒绝，避免过量内存占用。
  * 改进错误映射：非法项目名、剧本文件及相关路径在选图/清除场景下返回明确的 400。
  * 损坏剧本仍按预期返回 500（包含坏 JSON 与非 UTF-8 情况），不被错误分支错误吞掉。
* **测试**
  * 新增/调整集成与单元标记，并补齐超限拒绝、有界读取边界及多种错误映射断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->