### PR TITLE
fix(video): 视频生成拒收越界或非法的分镜图路径，失败原因可读

### DIFF
--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -801,8 +801,10 @@ async def execute_video_task(
             raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}")
         # try_safe_join 的越界校验只挡「解析结果落在项目外」；`os.path.join` 遇到绝对路径会
         # 丢弃 base，若该绝对路径恰好落在项目 storyboards/ 内仍会通过越界检查。issue 验收标准
-        # 要求绝对路径本身一律拒绝（与是否越界无关），须在解析前显式挡掉。
-        if Path(storyboard_rel).is_absolute():
+        # 要求绝对路径本身一律拒绝（与是否越界无关），须在解析前显式挡掉。Windows 原生运行时
+        # 无盘符的「根路径」（如 `\Users\...`）对 `Path.is_absolute()` 不算绝对，但 os.path.join
+        # 遇到它同样会丢弃 base（仅保留 base 的盘符），需按正斜杠归一化后再查是否以根分隔符开头。
+        if Path(storyboard_rel).is_absolute() or storyboard_rel.replace("\\", "/").startswith("/"):
             raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}")
         storyboards_root = safe_join(project_path, "storyboards", allow_base=True)
         storyboard_file = try_safe_join(project_path, storyboard_rel)
@@ -816,7 +818,9 @@ async def execute_video_task(
             raise ValueError(f"storyboard image path must stay under storyboards/: {storyboard_rel!r}") from None
     else:
         storyboard_file = project_path / "storyboards" / f"scene_{resource_id}.png"
-    if not storyboard_file.exists():
+    # is_file 而非 exists：字段被外部编辑指向目录（如 "storyboards" 本身）时 exists() 仍为
+    # True，目录会被当作 start_image 传给视频后端，在编码阶段才失败且原因不可读。
+    if not storyboard_file.is_file():
         raise ValueError(f"storyboard not found: {storyboard_file.name}")
 
     # drama 口型台词单一真相源在场景级有序 utterances：从 dialogue-kind 条目取台词注入 video YAML

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -799,6 +799,11 @@ async def execute_video_task(
     if storyboard_rel not in (None, ""):
         if not isinstance(storyboard_rel, str):
             raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}")
+        # try_safe_join 的越界校验只挡「解析结果落在项目外」；`os.path.join` 遇到绝对路径会
+        # 丢弃 base，若该绝对路径恰好落在项目 storyboards/ 内仍会通过越界检查。issue 验收标准
+        # 要求绝对路径本身一律拒绝（与是否越界无关），须在解析前显式挡掉。
+        if Path(storyboard_rel).is_absolute():
+            raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}")
         storyboards_root = safe_join(project_path, "storyboards", allow_base=True)
         storyboard_file = try_safe_join(project_path, storyboard_rel)
         if storyboard_file is None:

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -790,11 +790,23 @@ async def execute_video_task(
     generator = ctx.generator
 
     # 优先读取 generated_assets.storyboard_image，回退默认路径。
-    # 旧宫格项目 storyboard_image 指向 scene_{id}_first.png，仍可正常解析。
+    # 旧宫格项目 storyboard_image 指向 scene_{id}_first.png，仍可正常解析——这点与 end_frame_image
+    # 不同，不能要求与 canonical 路径逐一比对，只做目录归属校验：剧本是磁盘上的 JSON，字段值不可
+    # 信任（归档导入、外部编辑、脏数据都能落值），绝对路径 / `..` 会把项目外任意文件送进视频请求
+    # 上传给供应商，须先用 try_safe_join 解析并确认结果落在 storyboards/ 目录内，否则可读硬失败。
     assets = item.get("generated_assets", {})
     storyboard_rel = assets.get("storyboard_image") if isinstance(assets, dict) else None
-    if storyboard_rel:
-        storyboard_file = project_path / storyboard_rel
+    if storyboard_rel not in (None, ""):
+        if not isinstance(storyboard_rel, str):
+            raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}")
+        storyboards_root = safe_join(project_path, "storyboards", allow_base=True)
+        storyboard_file = try_safe_join(project_path, storyboard_rel)
+        if storyboard_file is None:
+            raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}")
+        try:
+            storyboard_file.relative_to(storyboards_root)
+        except ValueError:
+            raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}") from None
     else:
         storyboard_file = project_path / "storyboards" / f"scene_{resource_id}.png"
     if not storyboard_file.exists():

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -806,7 +806,9 @@ async def execute_video_task(
         try:
             storyboard_file.relative_to(storyboards_root)
         except ValueError:
-            raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}") from None
+            # 与越界/脏数据分开措辞：这一支是「项目内但不在 storyboards/」，唯一能自然落进来的
+            # 是外部编辑过的剧本，运维需要从失败原因直接看出是目录归属而非路径越界。
+            raise ValueError(f"storyboard image path must stay under storyboards/: {storyboard_rel!r}") from None
     else:
         storyboard_file = project_path / "storyboards" / f"scene_{resource_id}.png"
     if not storyboard_file.exists():

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import pytest
@@ -620,22 +621,24 @@ class TestGenerationTasks:
         assert fake_generator.video_calls == []
 
     @pytest.mark.parametrize(
-        "storyboard_value",
+        ("storyboard_value", "expected_message"),
         [
-            "/etc/passwd",  # 绝对路径：裸 `/` 拼接会整体丢弃左操作数，读到项目外文件
-            "../../outside.png",  # `..` 穿越出项目目录
-            "storyboards/../end_frames/scene_E1S01.png",  # 项目内但绕开 storyboards 目录
-            "end_frames/scene_E1S01.png",  # 落在项目内合法目录，但不是 storyboards/
-            123,  # 剧本 JSON 里的脏数据（非字符串）须给出可读失败，而非 TypeError
-            0,  # falsy 脏数据：真值判断不得把它当成「未设置」而静默回退默认路径
-            False,  # 同上
-            [],  # 同上
-            {},  # 同上
+            # 越界与脏数据：统称非法路径
+            ("/etc/passwd", "invalid storyboard image path"),  # 绝对路径：裸 `/` 拼接会整体丢弃左操作数
+            ("../../outside.png", "invalid storyboard image path"),  # `..` 穿越出项目目录
+            (123, "invalid storyboard image path"),  # 剧本 JSON 里的脏数据（非字符串）须可读失败而非 TypeError
+            (0, "invalid storyboard image path"),  # falsy 脏数据：真值判断不得当成「未设置」而静默回退默认路径
+            (False, "invalid storyboard image path"),  # 同上
+            ([], "invalid storyboard image path"),  # 同上
+            ({}, "invalid storyboard image path"),  # 同上
+            # 目录归属：项目内但不在 storyboards/，措辞需与越界区分，便于定位外部编辑过的剧本
+            ("storyboards/../end_frames/scene_E1S01.png", "must stay under storyboards/"),
+            ("end_frames/scene_E1S01.png", "must stay under storyboards/"),
         ],
     )
     @pytest.mark.integration
     async def test_execute_video_task_storyboard_image_outside_dir_fails_hard(
-        self, monkeypatch, tmp_path, storyboard_value
+        self, monkeypatch, tmp_path, storyboard_value, expected_message
     ):
         """剧本是磁盘 JSON，storyboard_image 字段不可信：越界 / 绕开 storyboards 目录 / 脏数据
         一律硬失败，不把任意服务器文件送进视频请求上传给供应商。"""
@@ -651,7 +654,7 @@ class TestGenerationTasks:
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
 
-        with pytest.raises(ValueError, match="invalid storyboard image path"):
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
             await generation_tasks.execute_video_task(
                 "demo",
                 "E1S01",

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -574,6 +574,95 @@ class TestGenerationTasks:
         assert fake_generator.video_calls[0]["duration_seconds"] == 8
 
     @pytest.mark.integration
+    async def test_execute_video_task_storyboard_image_legacy_grid_filename_resolves(self, monkeypatch, tmp_path):
+        """旧宫格项目 storyboard_image 指向 scene_{id}_first.png（非 canonical 文件名），只要落在
+        storyboards/ 目录内就正常解析——与 end_frame_image 不同，这里不要求文件名与 canonical
+        路径逐一比对。"""
+        project_path = _prepare_files(tmp_path)
+        (project_path / "storyboards" / "scene_E1S01_first.png").write_bytes(b"png")
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01_first.png"}
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {"script_file": "episode_1.json", "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []}},
+        )
+
+        assert fake_generator.video_calls[0]["start_image"] == project_path / "storyboards" / "scene_E1S01_first.png"
+
+    @pytest.mark.integration
+    async def test_execute_video_task_missing_storyboard_image_fails_hard(self, monkeypatch, tmp_path):
+        """storyboard_image 字段指向的文件缺失时硬失败，不调用后端生成。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_missing.png"}
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+
+        with pytest.raises(ValueError, match="storyboard not found"):
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                },
+            )
+        assert fake_generator.video_calls == []
+
+    @pytest.mark.parametrize(
+        "storyboard_value",
+        [
+            "/etc/passwd",  # 绝对路径：裸 `/` 拼接会整体丢弃左操作数，读到项目外文件
+            "../../outside.png",  # `..` 穿越出项目目录
+            "storyboards/../end_frames/scene_E1S01.png",  # 项目内但绕开 storyboards 目录
+            "end_frames/scene_E1S01.png",  # 落在项目内合法目录，但不是 storyboards/
+            123,  # 剧本 JSON 里的脏数据（非字符串）须给出可读失败，而非 TypeError
+            0,  # falsy 脏数据：真值判断不得把它当成「未设置」而静默回退默认路径
+            False,  # 同上
+            [],  # 同上
+            {},  # 同上
+        ],
+    )
+    @pytest.mark.integration
+    async def test_execute_video_task_storyboard_image_outside_dir_fails_hard(
+        self, monkeypatch, tmp_path, storyboard_value
+    ):
+        """剧本是磁盘 JSON，storyboard_image 字段不可信：越界 / 绕开 storyboards 目录 / 脏数据
+        一律硬失败，不把任意服务器文件送进视频请求上传给供应商。"""
+        project_path = _prepare_files(tmp_path)
+        (tmp_path / "outside.png").write_bytes(b"png")
+        end_frame_dir = project_path / "end_frames"
+        end_frame_dir.mkdir(parents=True, exist_ok=True)
+        (end_frame_dir / "scene_E1S01.png").write_bytes(b"png")
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": storyboard_value}
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+
+        with pytest.raises(ValueError, match="invalid storyboard image path"):
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                },
+            )
+        assert fake_generator.video_calls == []
+
+    @pytest.mark.integration
     async def test_execute_video_task_end_frame_image_passed_to_generator(self, monkeypatch, tmp_path):
         """镜头设置了 end_frame_image 时，生成视频请求携带 end_image；快照路径取自
         镜头持久字段拼接的项目内固定相对路径。"""

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -666,6 +666,34 @@ class TestGenerationTasks:
         assert fake_generator.video_calls == []
 
     @pytest.mark.integration
+    async def test_execute_video_task_storyboard_image_absolute_path_inside_project_fails_hard(
+        self, monkeypatch, tmp_path
+    ):
+        """storyboard_image 是项目 storyboards/ 内的绝对路径时同样硬失败：`os.path.join` 遇绝对
+        路径会丢弃项目根，越界校验只看结果是否落在项目内，光靠目录归属挡不住这类值，须显式拒绝
+        绝对路径本身。"""
+        project_path = _prepare_files(tmp_path)
+        (project_path / "storyboards" / "scene_E1S01.png").write_bytes(b"png")
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        absolute_value = str(project_path / "storyboards" / "scene_E1S01.png")
+        fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": absolute_value}
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+
+        with pytest.raises(ValueError, match="invalid storyboard image path"):
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                },
+            )
+        assert fake_generator.video_calls == []
+
+    @pytest.mark.integration
     async def test_execute_video_task_end_frame_image_passed_to_generator(self, monkeypatch, tmp_path):
         """镜头设置了 end_frame_image 时，生成视频请求携带 end_image；快照路径取自
         镜头持久字段拼接的项目内固定相对路径。"""

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -694,6 +694,56 @@ class TestGenerationTasks:
         assert fake_generator.video_calls == []
 
     @pytest.mark.integration
+    async def test_execute_video_task_storyboard_image_rooted_no_drive_path_fails_hard(self, monkeypatch, tmp_path):
+        """storyboard_image 是无盘符的根路径（如 `\\Users\\...`）时同样硬失败：`Path.is_absolute()`
+        在 Windows 原生运行时对这类值返回 False，但 `os.path.join` 遇到根路径仍会丢弃项目根（仅
+        保留 base 的盘符），须按正斜杠归一化后单独判断根分隔符开头。"""
+        project_path = _prepare_files(tmp_path)
+        (project_path / "storyboards" / "scene_E1S01.png").write_bytes(b"png")
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "\\Users\\Alice\\scene.png"}
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+
+        with pytest.raises(ValueError, match="invalid storyboard image path"):
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                },
+            )
+        assert fake_generator.video_calls == []
+
+    @pytest.mark.integration
+    async def test_execute_video_task_storyboard_image_pointing_to_directory_fails_hard(self, monkeypatch, tmp_path):
+        """storyboard_image 指向 storyboards/ 内一个存在的目录（而非文件）时硬失败：目录同样
+        通过 `exists()`，若不显式要求是文件，目录会被当作 start_image 传给视频后端，在编码阶段
+        才失败且原因不可读。"""
+        project_path = _prepare_files(tmp_path)
+        (project_path / "storyboards" / "subdir").mkdir(parents=True)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/subdir"}
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+
+        with pytest.raises(ValueError, match="storyboard not found"):
+            await generation_tasks.execute_video_task(
+                "demo",
+                "E1S01",
+                {
+                    "script_file": "episode_1.json",
+                    "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+                },
+            )
+        assert fake_generator.video_calls == []
+
+    @pytest.mark.integration
     async def test_execute_video_task_end_frame_image_passed_to_generator(self, monkeypatch, tmp_path):
         """镜头设置了 end_frame_image 时，生成视频请求携带 end_image；快照路径取自
         镜头持久字段拼接的项目内固定相对路径。"""


### PR DESCRIPTION
Closes #1352

## 改动

常规视频生成任务读取镜头分镜图（`generated_assets.storyboard_image`）时，先经路径安全校验再读盘：绝对路径、`../` 越界、非字符串脏数据在生成前被拒绝，任务失败原因可读，不再把项目外的任意文件拼接读盘后上传给视频供应商。

该读取点是尾帧路径收口（#1343）之后同函数内仅存的「直接信任磁盘 JSON 内路径字符串」的读盘点。剧本 JSON 可经归档导入或外部编辑落入任意值，威胁模型与尾帧一致。

与尾帧侧的口径差异：尾帧要求与 canonical 路径逐一比对，分镜图不能照抄——旧宫格项目的 `storyboard_image` 合法地指向 `scene_{id}_first.png`，故只做目录归属校验（解析结果须落在 `storyboards/` 内）。

失败原因分两类措辞：路径越界与脏数据统称非法路径；「项目内但不在 `storyboards/`」单独措辞，这一支只可能来自外部编辑过的剧本，运维需要直接看出是目录归属问题而非越界。

## 验证

- `uv run pytest` 全量 6513 passed
- `uv run ruff check` / `ruff format --check` 改动文件通过
- `uv run basedpyright` 改动文件 0 error
- 新增测试：旧宫格 `scene_{id}_first.png` 文件名正常解析（无回归）、引用文件缺失硬失败、9 组非法值参数化（绝对路径 / `..` 越界 / 绕开 `storyboards/` / 项目内他目录 / 非字符串脏数据含 `0`、`False`、`[]`、`{}` 等 falsy 值），非法值一律不进后端调用


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **安全性改进**
  * 加强分镜图片路径校验，拒绝绝对路径、路径穿越、非字符串/脏数据，并确保解析结果仅落在项目 `storyboards/` 下；拒绝将目录当作文件使用。
* **错误处理**
  * 分镜图片缺失或不合法时将直接报错，并阻止继续调用视频生成服务。
  * 未提供分镜图片时继续使用默认分镜图片路径。
* **兼容性**
  * 兼容 `storyboards/` 内旧命名但仍可正确解析的文件。
* **测试**
  * 新增/扩展集成级用例，覆盖正常解析、缺失文件与多类硬失败断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->