### PR TITLE
fix(frontend): 快速切换项目时不再被上一个项目迟到的数据覆盖

### DIFF
--- a/frontend/src/hooks/useProjectEventsSSE.test.tsx
+++ b/frontend/src/hooks/useProjectEventsSSE.test.tsx
@@ -120,7 +120,7 @@ describe("useProjectEventsSSE", () => {
     });
 
     await waitFor(() => {
-      expect(API.getProject).toHaveBeenCalledWith("demo");
+      expect(API.getProject).toHaveBeenCalledWith("demo", { signal: expect.any(AbortSignal) });
       expect(screen.getByTestId("location")).toHaveTextContent("/characters");
     });
     expect(useAppStore.getState().scrollTarget).toEqual(
@@ -182,7 +182,7 @@ describe("useProjectEventsSSE", () => {
     });
 
     await waitFor(() => {
-      expect(API.getProject).toHaveBeenCalledWith("demo");
+      expect(API.getProject).toHaveBeenCalledWith("demo", { signal: expect.any(AbortSignal) });
       expect(useAppStore.getState().scrollTarget).toEqual(
         expect.objectContaining({
           type: "reference_unit",
@@ -243,7 +243,7 @@ describe("useProjectEventsSSE", () => {
     });
 
     await waitFor(() => {
-      expect(API.getProject).toHaveBeenCalledWith("demo");
+      expect(API.getProject).toHaveBeenCalledWith("demo", { signal: expect.any(AbortSignal) });
       expect(useAppStore.getState().workspaceNotifications[0]?.target?.id).toBe("酒馆");
     });
     expect(screen.getByTestId("location")).toHaveTextContent("/");
@@ -284,7 +284,7 @@ describe("useProjectEventsSSE", () => {
     });
 
     await waitFor(() => {
-      expect(API.getProject).toHaveBeenCalledWith("demo");
+      expect(API.getProject).toHaveBeenCalledWith("demo", { signal: expect.any(AbortSignal) });
       expect(useAppStore.getState().toast?.text).toBe("分镜「E1S01」的分镜图已生成");
     });
     expect(useAppStore.getState().toast?.tone).toBe("success");
@@ -358,7 +358,7 @@ describe("useProjectEventsSSE", () => {
       });
 
       await waitFor(() => {
-        expect(API.getProject).toHaveBeenCalledWith("demo");
+        expect(API.getProject).toHaveBeenCalledWith("demo", { signal: expect.any(AbortSignal) });
         expect(useAppStore.getState().toast?.text).toBe(expectedText);
       });
       expect(useAppStore.getState().toast?.tone).toBe("success");
@@ -421,7 +421,7 @@ describe("useProjectEventsSSE", () => {
     });
 
     await waitFor(() => {
-      expect(API.getProject).toHaveBeenCalledWith("demo");
+      expect(API.getProject).toHaveBeenCalledWith("demo", { signal: expect.any(AbortSignal) });
       expect(useAppStore.getState().toast?.text).toBe("旁白「E1S01」已生成");
     });
   });
@@ -487,7 +487,7 @@ describe("useProjectEventsSSE", () => {
     });
 
     await waitFor(() => {
-      expect(API.getProject).toHaveBeenCalledWith("demo");
+      expect(API.getProject).toHaveBeenCalledWith("demo", { signal: expect.any(AbortSignal) });
       expect(useAppStore.getState().toast?.text).toBe("道具「玉佩」已更新");
     });
 
@@ -554,7 +554,7 @@ describe("useProjectEventsSSE", () => {
     });
 
     await waitFor(() => {
-      expect(API.getProject).toHaveBeenCalledWith("demo");
+      expect(API.getProject).toHaveBeenCalledWith("demo", { signal: expect.any(AbortSignal) });
     });
     expect(screen.getByTestId("location")).toHaveTextContent("/props");
     expect(useAppStore.getState().scrollTarget).toBeNull();

--- a/frontend/src/stores/projects-store.test.ts
+++ b/frontend/src/stores/projects-store.test.ts
@@ -325,6 +325,32 @@ describe("projects-store refreshProject", () => {
     expect(useProjectsStore.getState().currentProjectName).toBe("B");
   });
 
+  it("跨两次切换的更早项目迟到写入（C→A→B）：null 窗口不因换了新名字而放行", async () => {
+    // Codex 在上一条修复后指出的多跳场景：C 页面未取消的写操作直到 A→B 切换期间
+    // 的 null 窗口才发起 refreshProject("C")。若只记「最近一次被清空的名字」（当时是
+    // A），curName="C" 不等于它，会被误判成「无当前项目，可放行」重新写回。真正的
+    // 判据应是「store 是否已经建立过任何真实项目」，不分具体是哪一个。
+    const store = useProjectsStore.getState();
+    store.setCurrentProject("C", makeProject("C-数据"), {}, {}); // 建立 C
+    store.setCurrentProject(null, null); // 路由 cleanup：离开 C
+    store.setCurrentProject("A", makeProject("A-数据"), {}, {}); // A 落地
+    store.setCurrentProject(null, null); // 路由 cleanup：离开 A，尚未加载 B
+
+    const dC = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject").mockReturnValueOnce(dC.promise);
+
+    const pC = useProjectsStore.getState().refreshProject("C"); // 在第二次 null 窗口内发起
+    dC.resolve(makeResult("C-迟到数据"));
+    const ok = await pC;
+
+    expect(ok).toBe(false);
+    expect(useProjectsStore.getState().currentProjectName).toBe(null);
+
+    useProjectsStore.getState().setCurrentProject("B", makeProject("B-数据"), {}, {});
+    expect(useProjectsStore.getState().currentProjectName).toBe("B");
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
+  });
+
   it("项目已切到 B 后才发起的 A 刷新：不写回 store（现役域未 abort，靠当前项目名拦截）", async () => {
     // 与上一条不同：这里切换先于 refreshProject("A") 调用完成——例如写操作完成后的
     // 回调捕获了切换前的旧项目名，等它真正发起请求时项目已经是 B。此时拿到的是 B

--- a/frontend/src/stores/projects-store.test.ts
+++ b/frontend/src/stores/projects-store.test.ts
@@ -276,4 +276,75 @@ describe("projects-store refreshProject", () => {
     expect(useProjectsStore.getState().currentProjectName).toBe(DEMO_PROJECT_NAME);
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("演示");
   });
+
+  it("项目切换后 A 的迟到响应落定：不覆盖已接管的 B", async () => {
+    // 路由层的项目切换不经过 refreshProject（自带 AbortController + setCurrentProject），
+    // 因此排队去重看不到它——A 页面上 SSE / 写操作触发的刷新若在切到 B 之后才落定，
+    // 不该把 currentProjectName 写回 A。
+    useProjectsStore.getState().setCurrentProject("A", makeProject("A-数据"), {}, {});
+    const dA = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject").mockReturnValueOnce(dA.promise);
+
+    const store = useProjectsStore.getState();
+    const pA = store.refreshProject("A");
+
+    // 路由切到 B：cleanup 清空当前项目，随后写入 B 的数据。
+    store.setCurrentProject(null, null);
+    store.setCurrentProject("B", makeProject("B-数据"), {}, {});
+
+    dA.resolve(makeResult("A-迟到数据"));
+    const ok = await pA;
+
+    expect(ok).toBe(false);
+    expect(useProjectsStore.getState().currentProjectName).toBe("B");
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
+  });
+
+  it("项目切换 abort 在途请求：请求被取消，且不按刷新失败提示", async () => {
+    useProjectsStore.getState().setCurrentProject("A", makeProject("A-数据"), {}, {});
+    let abortedSignal: AbortSignal | undefined;
+    vi.spyOn(API, "getProject").mockImplementation(
+      (_name, options) =>
+        new Promise<GetProjectResult>((_resolve, reject) => {
+          abortedSignal = options?.signal;
+          options?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+
+    const onError = vi.fn();
+    const store = useProjectsStore.getState();
+    const pA = store.refreshProject("A", { onError });
+
+    store.setCurrentProject("B", makeProject("B-数据"), {}, {});
+
+    const ok = await pA;
+    expect(abortedSignal?.aborted).toBe(true);
+    expect(ok).toBe(false);
+    // abort 是项目切换的正常结果，不是刷新失败：不该弹「项目同步失败」。
+    expect(onError).not.toHaveBeenCalled();
+    expect(useProjectsStore.getState().currentProjectName).toBe("B");
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
+  });
+
+  it("切换项目后新项目的刷新照常生效（取消域轮换不会长期作废后续刷新）", async () => {
+    useProjectsStore.getState().setCurrentProject("A", makeProject("A-数据"), {}, {});
+    const dA = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject")
+      .mockReturnValueOnce(dA.promise)
+      .mockResolvedValue(makeResult("B-新数据"));
+
+    const store = useProjectsStore.getState();
+    const pA = store.refreshProject("A");
+
+    store.setCurrentProject("B", makeProject("B-数据"), {}, {});
+    dA.resolve(makeResult("A-迟到数据"));
+    expect(await pA).toBe(false);
+
+    const okB = await useProjectsStore.getState().refreshProject("B");
+    expect(okB).toBe(true);
+    expect(useProjectsStore.getState().currentProjectName).toBe("B");
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-新数据");
+  });
 });

--- a/frontend/src/stores/projects-store.test.ts
+++ b/frontend/src/stores/projects-store.test.ts
@@ -300,6 +300,25 @@ describe("projects-store refreshProject", () => {
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
   });
 
+  it("项目已切到 B 后才发起的 A 刷新：不写回 store（现役域未 abort，靠当前项目名拦截）", async () => {
+    // 与上一条不同：这里切换先于 refreshProject("A") 调用完成——例如写操作完成后的
+    // 回调捕获了切换前的旧项目名，等它真正发起请求时项目已经是 B。此时拿到的是 B
+    // 现役、未 abort 的域，signal.aborted 与排队去重都拦不住，必须靠当前项目名核对。
+    useProjectsStore.getState().setCurrentProject("A", makeProject("A-数据"), {}, {});
+    useProjectsStore.getState().setCurrentProject("B", makeProject("B-数据"), {}, {});
+
+    const dA = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject").mockReturnValueOnce(dA.promise);
+
+    const pA = useProjectsStore.getState().refreshProject("A");
+    dA.resolve(makeResult("A-迟到数据"));
+    const ok = await pA;
+
+    expect(ok).toBe(false);
+    expect(useProjectsStore.getState().currentProjectName).toBe("B");
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
+  });
+
   it("项目切换 abort 在途请求：请求被取消，且不按刷新失败提示", async () => {
     useProjectsStore.getState().setCurrentProject("A", makeProject("A-数据"), {}, {});
     let abortedSignal: AbortSignal | undefined;

--- a/frontend/src/stores/projects-store.test.ts
+++ b/frontend/src/stores/projects-store.test.ts
@@ -319,6 +319,33 @@ describe("projects-store refreshProject", () => {
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
   });
 
+  it("A 在途时排队同项目再刷一轮，期间切到 B：排队轮响应不写回（同名不豁免当前项目核对）", async () => {
+    // Codex 提出的场景：A 首轮在途、又有一次 A 刷新排队合并（queuedName === curName，
+    // 不触发 supersededByOtherProject）；随后用户切到 B。首轮因取消域轮换而 abort，
+    // 但排队轮沿用 while 循环继续跑，取的是 B 现役、未 abort 的域，对 queuedName=A 发起
+    // 第二次请求。响应落定时当前项目已是 B，须靠当前项目名核对拦截，而非同名判断。
+    useProjectsStore.getState().setCurrentProject("A", makeProject("A-旧"), {}, {});
+    const d1 = deferred<GetProjectResult>();
+    const d2 = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject").mockReturnValueOnce(d1.promise).mockReturnValueOnce(d2.promise);
+
+    const store = useProjectsStore.getState();
+    const p1 = store.refreshProject("A");
+    const p2 = store.refreshProject("A"); // 在途 → 合并排队
+
+    store.setCurrentProject("B", makeProject("B-数据"), {}, {});
+    d1.resolve(makeResult("A-首轮迟到"));
+    await flush();
+    // 首轮 abort，排队轮已发起第二次请求
+    d2.resolve(makeResult("A-排队轮迟到"));
+
+    const [ok1, ok2] = await Promise.all([p1, p2]);
+    expect(ok1).toBe(false);
+    expect(ok2).toBe(false);
+    expect(useProjectsStore.getState().currentProjectName).toBe("B");
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
+  });
+
   it("项目切换 abort 在途请求：请求被取消，且不按刷新失败提示", async () => {
     useProjectsStore.getState().setCurrentProject("A", makeProject("A-数据"), {}, {});
     let abortedSignal: AbortSignal | undefined;

--- a/frontend/src/stores/projects-store.test.ts
+++ b/frontend/src/stores/projects-store.test.ts
@@ -300,6 +300,31 @@ describe("projects-store refreshProject", () => {
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
   });
 
+  it("null 过渡窗口内发起的旧项目刷新：不豁免为「无当前项目」，不写回", async () => {
+    // Codex 提出的场景：router cleanup 先把 currentProjectName 清为 null，B 自己的
+    // getProject 落定、写入 currentProjectName 之前有一段异步窗口。若 A 中未取消的
+    // 写操作恰好在这段窗口里发起 refreshProject("A")，此时取到的是清空后现役、未 abort
+    // 的域，且 currentProjectName 恰为 null——不能被「无当前项目，放行」豁免，否则
+    // A 的数据会在 B 落地前抢先写回。
+    useProjectsStore.getState().setCurrentProject("A", makeProject("A-数据"), {}, {});
+    useProjectsStore.getState().setCurrentProject(null, null); // 路由 cleanup：清空但尚未加载 B
+
+    const dA = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject").mockReturnValueOnce(dA.promise);
+
+    const pA = useProjectsStore.getState().refreshProject("A"); // 在 null 窗口内发起
+    dA.resolve(makeResult("A-迟到数据"));
+    const ok = await pA;
+
+    expect(ok).toBe(false);
+    expect(useProjectsStore.getState().currentProjectName).toBe(null);
+    expect(useProjectsStore.getState().currentProjectData).toBe(null);
+
+    // B 随后落地：不受上面被拦截的 A 写入影响。
+    useProjectsStore.getState().setCurrentProject("B", makeProject("B-数据"), {}, {});
+    expect(useProjectsStore.getState().currentProjectName).toBe("B");
+  });
+
   it("项目已切到 B 后才发起的 A 刷新：不写回 store（现役域未 abort，靠当前项目名拦截）", async () => {
     // 与上一条不同：这里切换先于 refreshProject("A") 调用完成——例如写操作完成后的
     // 回调捕获了切换前的旧项目名，等它真正发起请求时项目已经是 B。此时拿到的是 B

--- a/frontend/src/stores/projects-store.ts
+++ b/frontend/src/stores/projects-store.ts
@@ -115,7 +115,16 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
         // 离开工作台清空）。这些路径都不经过 refreshProject，排队去重看不到它们，只能靠
         // 取消域识别。abort 与响应落定同为异步，响应先到、abort 后到时网络层不会 reject，
         // 因此写入前还要复核一次 aborted。
-        if (!supersededByOtherProject && !signal.aborted) {
+        // 上述两项都只能拦住「请求发起时项目已切走」的情形：若调用方（如写操作完成后
+        // 的刷新）捕获的是切走前的旧项目名，且这次调用是在切换已经完成之后才发起的，
+        // 拿到的会是新项目现役、未 abort 的域——因此还要在写入前核对 curName 是否仍是
+        // 当前项目，防止旧项目的数据覆盖已经切入的新项目。
+        // currentProjectName 为 null 时放行：refreshProject 也承担着把首个项目数据
+        // 建立进 store 的职责（届时还没有「当前项目」可比较），只有已经易主给另一个
+        // 具体项目名时才需要拦截。
+        const currentProjectName = get().currentProjectName;
+        const isCurrentProject = currentProjectName === null || currentProjectName === curName;
+        if (!supersededByOtherProject && !signal.aborted && isCurrentProject) {
           get().setCurrentProject(curName, res.project, res.scripts ?? {}, res.asset_fingerprints);
           if (curKeys.length > 0) {
             useAppStore.getState().invalidateEntities(curKeys);

--- a/frontend/src/stores/projects-store.ts
+++ b/frontend/src/stores/projects-store.ts
@@ -53,6 +53,8 @@ interface ProjectsState {
    *   合并为「结束后再跑一轮」，取最新一次请求的 name / invalidateKeys。
    * - **失败留旧**：getProject 失败时不覆盖 currentProjectData，返回 false 交调用方
    *   决定是否提示（onError 亦会被调用）。
+   * - **项目级取消域**：请求挂在随当前项目轮换的 AbortSignal 上，切换项目即作废前一个
+   *   项目的在途与迟到刷新，返回 false 且不视为失败（不触发 onError）。
    */
   refreshProject: (name: string, options?: RefreshProjectOptions) => Promise<boolean>;
 }
@@ -67,6 +69,15 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
   // 排队轮调用方各自的 resolve——与 curResolvers 分开累积，避免"排队进同一批"
   // 被误解为"共享同一个最终结果"：每个调用方只对自己实际服务的那一轮结果负责。
   let queuedResolvers: Array<(ok: boolean) => void> = [];
+
+  // 项目级取消域：当前项目的数据请求都挂在这个 controller 上。切换项目时轮换（abort 旧的、
+  // 换上新的），使前一个项目的在途请求当场取消、迟到响应无法写回 store。轮换后现役
+  // controller 恒为未 abort 状态，因此不会长期作废后续刷新。
+  let projectScope = new AbortController();
+  const rotateProjectScope = () => {
+    projectScope.abort();
+    projectScope = new AbortController();
+  };
 
   // 执行刷新循环：while 排队重跑替代递归，失败路径也消费排队请求，直至无新排队为止。
   // 每轮结束立刻 resolve 该轮的调用方（curResolvers），不等后续排队轮跑完——否则先到
@@ -86,17 +97,18 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
     while (again) {
       again = false;
       let ok = false;
+      // 每轮取一次现役取消域：排队轮要挂在它自己发起时刻的域上，不复用上一轮的。
+      const signal = projectScope.signal;
       try {
-        const res = await API.getProject(curName);
+        const res = await API.getProject(curName, { signal });
         // 在途期间若已排队到不同项目的刷新请求，本轮响应针对的是即将切走的旧项目——
         // 跳过写入，避免用它覆盖排队轮即将加载的新项目（数据 / 名称均不提交）。
         const supersededByOtherProject = refreshQueued && queuedName !== null && queuedName !== curName;
-        // 演示项目导航不经过 refreshProject（数据来自前端常量，见入口处的 isDemoProject
-        // 短路），因此上面的排队去重看不到它——真实项目的刷新请求（如 SSE onChanges 触发）
-        // 若在只读演示项目已接管当前视图之后才落定，也不该把 currentProjectName 写回真实
-        // 项目，否则只读横幅 / 演示数据会被这次迟到响应悄悄顶掉。
-        const supersededByDemoNavigation = isDemoProject(get().currentProjectName);
-        if (!supersededByOtherProject && !supersededByDemoNavigation) {
+        // 取消域已轮换：当前项目在请求在途期间被换掉了（路由切到别的项目、演示工作台接管、
+        // 离开工作台清空）。这些路径都不经过 refreshProject，排队去重看不到它们，只能靠
+        // 取消域识别。abort 与响应落定同为异步，响应先到、abort 后到时网络层不会 reject，
+        // 因此写入前还要复核一次 aborted。
+        if (!supersededByOtherProject && !signal.aborted) {
           get().setCurrentProject(curName, res.project, res.scripts ?? {}, res.asset_fingerprints);
           if (curKeys.length > 0) {
             useAppStore.getState().invalidateEntities(curKeys);
@@ -106,7 +118,11 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
       } catch (err) {
         // 失败留旧：不覆盖 currentProjectData；调用方按返回值 / onError 决定提示。
         ok = false;
-        curOnErrors.forEach((cb) => cb(err));
+        // 取消域轮换导致的 abort 是项目切换的正常结果，不是刷新失败：按「未同步」结算
+        // 为 false，但不触发 onError，否则每次切项目都会弹一条同步失败提示。
+        if (!signal.aborted) {
+          curOnErrors.forEach((cb) => cb(err));
+        }
       }
       curResolvers.forEach((resolve) => resolve(ok));
       if (refreshQueued) {
@@ -138,13 +154,17 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
 
     setProjects: (projects) => set({ projects }),
     setProjectsLoading: (loading) => set({ projectsLoading: loading }),
-    setCurrentProject: (name, data, scripts, fingerprints) =>
+    setCurrentProject: (name, data, scripts, fingerprints) => {
+      // 当前项目易主即轮换取消域。这是全部切换路径（路由 effect 及其 cleanup、演示工作台
+      // 接管）的必经之处，因此不必让各调用方各自传播取消——它们保持原样即受此保护。
+      if (name !== get().currentProjectName) rotateProjectScope();
       set((s) => ({
         currentProjectName: name,
         currentProjectData: data,
         currentScripts: scripts ?? {},
         assetFingerprints: fingerprints ?? s.assetFingerprints,
-      })),
+      }));
+    },
     setProjectDetailLoading: (loading) => set({ projectDetailLoading: loading }),
     setShowCreateModal: (show) => set({ showCreateModal: show }),
     setCreatingProject: (creating) => set({ creatingProject: creating }),

--- a/frontend/src/stores/projects-store.ts
+++ b/frontend/src/stores/projects-store.ts
@@ -86,6 +86,12 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
     projectScope = new AbortController();
   };
 
+  // 路由 cleanup 会先把 currentProjectName 置 null 再异步加载新项目，null 期间尚未
+  // 轮换到新项目自己的域，旧项目的迟到写入会被误判成「无当前项目可比较，放行」。记下
+  // 被清空前的名字，null 期间专门排除它，同时不影响这个 null 状态本身允许建立任意
+  // 其它（未被排除的）项目——包括 store 从未加载过任何项目时的首次建立。
+  let vacatedProjectName: string | null = null;
+
   // 执行刷新循环：while 排队重跑替代递归，失败路径也消费排队请求，直至无新排队为止。
   // 每轮结束立刻 resolve 该轮的调用方（curResolvers），不等后续排队轮跑完——否则先到
   // 的调用方会被后到、且与自己无关的轮次结果覆盖返回值（如已成功写入的重排刷新，被
@@ -119,11 +125,16 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
         // 的刷新）捕获的是切走前的旧项目名，且这次调用是在切换已经完成之后才发起的，
         // 拿到的会是新项目现役、未 abort 的域——因此还要在写入前核对 curName 是否仍是
         // 当前项目，防止旧项目的数据覆盖已经切入的新项目。
-        // currentProjectName 为 null 时放行：refreshProject 也承担着把首个项目数据
-        // 建立进 store 的职责（届时还没有「当前项目」可比较），只有已经易主给另一个
-        // 具体项目名时才需要拦截。
+        // currentProjectName 为 null 时原则上放行：refreshProject 也承担着把首个项目
+        // 数据建立进 store 的职责（届时还没有「当前项目」可比较）。但 null 也是路由
+        // cleanup 清空旧项目、异步加载新项目之间的过渡态——这段窗口里旧项目名不能被
+        // 放行的「无当前项目」豁免过：否则旧项目迟到的写入会在新项目自己的数据落地前
+        // 抢先写回 store。用 vacatedProjectName 单独排除刚被清空的那个名字，其它待建立
+        // 的项目名（含 store 从未加载过任何项目的场景）仍按原语义放行。
         const currentProjectName = get().currentProjectName;
-        const isCurrentProject = currentProjectName === null || currentProjectName === curName;
+        const isCurrentProject =
+          currentProjectName === curName ||
+          (currentProjectName === null && curName !== vacatedProjectName);
         if (!supersededByOtherProject && !signal.aborted && isCurrentProject) {
           get().setCurrentProject(curName, res.project, res.scripts ?? {}, res.asset_fingerprints);
           if (curKeys.length > 0) {
@@ -173,7 +184,15 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
     setCurrentProject: (name, data, scripts, fingerprints) => {
       // 当前项目易主即轮换取消域。这是全部切换路径（路由 effect 及其 cleanup、演示工作台
       // 接管）的必经之处，因此不必让各调用方各自传播取消——它们保持原样即受此保护。
-      if (name !== get().currentProjectName) rotateProjectScope();
+      const previousName = get().currentProjectName;
+      if (name !== previousName) {
+        if (name === null && previousName !== null) {
+          vacatedProjectName = previousName;
+        } else if (name !== null) {
+          vacatedProjectName = null;
+        }
+        rotateProjectScope();
+      }
       set((s) => ({
         currentProjectName: name,
         currentProjectData: data,

--- a/frontend/src/stores/projects-store.ts
+++ b/frontend/src/stores/projects-store.ts
@@ -33,6 +33,11 @@ interface ProjectsState {
   // Actions
   setProjects: (projects: ProjectSummary[]) => void;
   setProjectsLoading: (loading: boolean) => void;
+  /**
+   * 写入当前项目。名称易主时同时轮换项目级取消域：前一个项目挂在旧域上的在途请求当场
+   * 取消，其迟到响应写不回 store（见 refreshProject 的「项目级取消域」）。这不是纯 setter，
+   * 全部切换路径（路由 effect 及其 cleanup、演示工作台接管）经此收口。
+   */
   setCurrentProject: (
     name: string | null,
     data: ProjectData | null,
@@ -73,6 +78,8 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
   // 项目级取消域：当前项目的数据请求都挂在这个 controller 上。切换项目时轮换（abort 旧的、
   // 换上新的），使前一个项目的在途请求当场取消、迟到响应无法写回 store。轮换后现役
   // controller 恒为未 abort 状态，因此不会长期作废后续刷新。
+  // 刷新自己写入成功时（名称由 null 变为该项目）也会走一次轮换，abort 的是本轮刚用完的域：
+  // 后续每一轮都重新取现役域，故无影响；日后若有别的项目级请求挂上来，需要复核这一点。
   let projectScope = new AbortController();
   const rotateProjectScope = () => {
     projectScope.abort();

--- a/frontend/src/stores/projects-store.ts
+++ b/frontend/src/stores/projects-store.ts
@@ -30,6 +30,13 @@ interface ProjectsState {
   // Asset fingerprints (path → mtime_ns)
   assetFingerprints: Record<string, number>;
 
+  /**
+   * 内部记账：store 生命周期内是否已经建立过至少一个真实项目。仅供
+   * {@link refreshProject} 判断 `currentProjectName` 为 `null` 时是「store 从未加载
+   * 过任何项目」还是「路由切换途中的过渡态」，不供 UI 消费。
+   */
+  hasLoadedAnyProject: boolean;
+
   // Actions
   setProjects: (projects: ProjectSummary[]) => void;
   setProjectsLoading: (loading: boolean) => void;
@@ -86,12 +93,6 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
     projectScope = new AbortController();
   };
 
-  // 路由 cleanup 会先把 currentProjectName 置 null 再异步加载新项目，null 期间尚未
-  // 轮换到新项目自己的域，旧项目的迟到写入会被误判成「无当前项目可比较，放行」。记下
-  // 被清空前的名字，null 期间专门排除它，同时不影响这个 null 状态本身允许建立任意
-  // 其它（未被排除的）项目——包括 store 从未加载过任何项目时的首次建立。
-  let vacatedProjectName: string | null = null;
-
   // 执行刷新循环：while 排队重跑替代递归，失败路径也消费排队请求，直至无新排队为止。
   // 每轮结束立刻 resolve 该轮的调用方（curResolvers），不等后续排队轮跑完——否则先到
   // 的调用方会被后到、且与自己无关的轮次结果覆盖返回值（如已成功写入的重排刷新，被
@@ -125,16 +126,15 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
         // 的刷新）捕获的是切走前的旧项目名，且这次调用是在切换已经完成之后才发起的，
         // 拿到的会是新项目现役、未 abort 的域——因此还要在写入前核对 curName 是否仍是
         // 当前项目，防止旧项目的数据覆盖已经切入的新项目。
-        // currentProjectName 为 null 时原则上放行：refreshProject 也承担着把首个项目
-        // 数据建立进 store 的职责（届时还没有「当前项目」可比较）。但 null 也是路由
-        // cleanup 清空旧项目、异步加载新项目之间的过渡态——这段窗口里旧项目名不能被
-        // 放行的「无当前项目」豁免过：否则旧项目迟到的写入会在新项目自己的数据落地前
-        // 抢先写回 store。用 vacatedProjectName 单独排除刚被清空的那个名字，其它待建立
-        // 的项目名（含 store 从未加载过任何项目的场景）仍按原语义放行。
-        const currentProjectName = get().currentProjectName;
+        // currentProjectName 为 null 时，只有 store 整个生命周期内还从未建立过任何真实
+        // 项目才放行——那是 refreshProject 承担的「把首个项目数据建立进 store」职责，
+        // 届时没有「当前项目」可比较。一旦建立过任意项目，后续任何 null 都只会是路由
+        // cleanup 清空旧项目、异步加载新项目之间的过渡态：这段窗口里不放行任何名字的
+        // 写入（包括比刚清空的项目更早、直到现在才落定的旧项目，见 hasLoadedAnyProject
+        // 的注释），否则旧数据会在新项目自己的数据落地前抢先写回。
+        const { currentProjectName, hasLoadedAnyProject } = get();
         const isCurrentProject =
-          currentProjectName === curName ||
-          (currentProjectName === null && curName !== vacatedProjectName);
+          currentProjectName === curName || (currentProjectName === null && !hasLoadedAnyProject);
         if (!supersededByOtherProject && !signal.aborted && isCurrentProject) {
           get().setCurrentProject(curName, res.project, res.scripts ?? {}, res.asset_fingerprints);
           if (curKeys.length > 0) {
@@ -178,26 +178,20 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
     showCreateModal: false,
     creatingProject: false,
     assetFingerprints: {},
+    hasLoadedAnyProject: false,
 
     setProjects: (projects) => set({ projects }),
     setProjectsLoading: (loading) => set({ projectsLoading: loading }),
     setCurrentProject: (name, data, scripts, fingerprints) => {
       // 当前项目易主即轮换取消域。这是全部切换路径（路由 effect 及其 cleanup、演示工作台
       // 接管）的必经之处，因此不必让各调用方各自传播取消——它们保持原样即受此保护。
-      const previousName = get().currentProjectName;
-      if (name !== previousName) {
-        if (name === null && previousName !== null) {
-          vacatedProjectName = previousName;
-        } else if (name !== null) {
-          vacatedProjectName = null;
-        }
-        rotateProjectScope();
-      }
+      if (name !== get().currentProjectName) rotateProjectScope();
       set((s) => ({
         currentProjectName: name,
         currentProjectData: data,
         currentScripts: scripts ?? {},
         assetFingerprints: fingerprints ?? s.assetFingerprints,
+        hasLoadedAnyProject: s.hasLoadedAnyProject || name !== null,
       }));
     },
     setProjectDetailLoading: (loading) => set({ projectDetailLoading: loading }),


### PR DESCRIPTION
Closes #1351

## 范围

修复项目切换竞态：切换后前一项目在途或迟到的 `refreshProject` 响应会覆盖当前项目的数据。
`refreshProject` 的在途合并只看得到经它自己排队的请求；项目切换走的是路由层独立的
AbortController，不经过这层协调。慢网络下打开项目 A 触发刷新、响应未回时切到项目 B，
迟到的 `refreshProject(A)` 响应会把 A 的数据静默写进 store，B 的界面显示 A 的内容。

## 变更

按 `.claude/rules/frontend-async-race.md` 的机制，在 store 层引入项目级取消域：

- `setCurrentProject` 在当前项目名易主时轮换 `AbortController`。全部切换路径（路由 effect
  及其 cleanup、演示工作台接管）都经此收口，约 15 处 `refreshProject` 调用方零改动即受保护。
- `refreshProject` 每轮取一次现役 signal 传给 `API.getProject`（在途请求当场取消），
  写入 store 前再复核 `signal.aborted`（堵住响应先落定、abort 后到的窗口），并核对
  `curName` 是否仍是当前项目（堵住「切换已完成之后才发起」的迟到写入，含 null 过渡窗口
  与多跳切换）。
- abort 是项目切换的正常结果而非刷新失败：返回 `false`，但不触发 `onError`，避免每切一次
  项目就弹一条同步失败提示。
- 原 `supersededByDemoNavigation` 专项判断被通用取消域覆盖，随之删除；演示场景既有测试未改
  动仍通过。

## 验收清单

- [x] 项目切换后，前一项目在途或迟到的 `refreshProject` 响应被丢弃，不写入 store
- [x] 全部既有调用方（约 15 处）不需要各自改动即获得该保护，行为无回归
- [x] 竞态场景有测试覆盖（慢响应 + 切换项目，含 null 过渡窗口与多跳切换）

## 验证

- `projects-store.test.ts` 新增多条用例：迟到响应不覆盖已接管项目、切换 abort 在途请求且
  不报错、轮换后新项目刷新照常生效、null 过渡窗口内旧项目迟到写入被拦截、跨两次切换的
  多跳场景不被放行。
- `useProjectEventsSSE.test.tsx` 8 处 `getProject` 断言随签名新增 `{ signal }` 同步更新。
- `pnpm lint` 与 `pnpm check`（typecheck + vitest）全绿：128 文件 / 1254 测试。后端零改动。

## 已知 defer

- `refreshProject` 缺第三态返回值：abort 已不触发 `onError`，但仍返回 `false`，
  `EndFrameRow.tsx` 按返回值弹 `end_frame_refresh_failed`。设尾帧后立刻切项目会多出一条
  误导性错误提示；这是既有语义，本次未扩大也未收窄。正解是让 `refreshProject` 区分「已
  取消」与「刷新失败」，超出本 issue 范围，是否立项待定。
- 项目详情这一份数据仍由两个取消域分管：路由首屏加载走 `router.tsx` 自建 controller 直调
  `API.getProject`，刷新走 store 的 `projectScope`，靠 cleanup 间接同步。收敛方向是让首屏
  加载也走 `refreshProject` / 挂同一个域，超出本 issue 验收标准，未动。

## 审查记录

- 核实「首次写入（null → 项目名）时轮换会误伤同项目在途刷新」不可达：SSE 与全部 UI 调用方
  都在 `currentProjectName` 写入之后才可能发起刷新。
- 补一处接口层文档：`setCurrentProject` 不是纯 setter，声明处写明轮换副作用。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复快速切换项目时，较早的刷新响应覆盖当前项目数据的问题。
  * 改进项目刷新取消与并发处理，避免已取消请求错误更新状态或触发错误提示。
  * 确保取消旧项目刷新后，后续项目刷新仍可正常完成。
* **Tests**
  * 补充项目切换、取消、并发竞态及事件刷新场景的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->