### PR TITLE
fix(video): 广告项目参考生视频模式下不再允许设置尾帧

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -184,6 +184,7 @@ MESSAGES = {
     "invalid_resource_id": "Invalid resource ID: {resource_id}",
     "invalid_end_frame_source": "End frame source path is invalid or outside the project directory: {path}",
     "end_frame_source_not_found": "End frame source image not found: {path}",
+    "end_frame_reference_video_unsupported": "Reference video mode has no start/end frame concept; setting an end frame is not supported",
     # Reference Video
     "ref_missing_asset": "Reference to {type} '{name}' is not in the project asset library, please generate it first",
     "ref_duration_exceeded": "Reference video unit duration {duration}s exceeds {model} limit of {max_duration}s, clamped",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -184,6 +184,7 @@ MESSAGES = {
     "invalid_resource_id": "ID tài nguyên không hợp lệ: {resource_id}",
     "invalid_end_frame_source": "Đường dẫn ảnh nguồn cho khung hình cuối không hợp lệ hoặc nằm ngoài thư mục dự án: {path}",
     "end_frame_source_not_found": "Không tìm thấy ảnh nguồn cho khung hình cuối: {path}",
+    "end_frame_reference_video_unsupported": "Chế độ video tham chiếu không có khái niệm khung hình đầu/cuối, không hỗ trợ đặt khung hình cuối",
     # Reference Video
     "ref_missing_asset": "Tham chiếu đến {type} '{name}' không có trong thư viện tài nguyên dự án, vui lòng tạo trước",
     "ref_duration_exceeded": "Thời lượng đơn vị video tham chiếu {duration}s vượt giới hạn {max_duration}s của {model}, đã cắt bớt",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -174,6 +174,7 @@ MESSAGES = {
     "invalid_resource_id": "非法的资源 ID: {resource_id}",
     "invalid_end_frame_source": "尾帧来源路径非法或越出项目目录: {path}",
     "end_frame_source_not_found": "尾帧来源图片不存在: {path}",
+    "end_frame_reference_video_unsupported": "参考生视频模式下镜头无首尾帧概念，不支持设置尾帧",
     # Reference Video
     "ref_missing_asset": "参考图引用的{type}「{name}」不在项目资产库中，请先生成",
     "ref_duration_exceeded": "参考视频单元时长 {duration}s 超出 {model} 上限 {max_duration}s，已裁剪",

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -84,6 +84,28 @@ def effective_mode(*, project: dict, episode: dict) -> str:
     return _DEFAULT_GENERATION_MODE
 
 
+def find_episode(project: dict[str, Any], episode: int | None) -> dict[str, Any] | None:
+    """返回 project.json ``episodes[]`` 中 ``episode == N`` 的条目，缺失则 None。
+
+    ``episode`` 为 None（集号未知）时不匹配任何条目，调用方据此回退到项目级配置。
+    """
+    if episode is None:
+        return None
+    for ep in project.get("episodes") or []:
+        if isinstance(ep, dict) and ep.get("episode") == episode:
+            return ep
+    return None
+
+
+def is_reference_video_episode(project: dict[str, Any], episode: int | None) -> bool:
+    """该集的生效 generation_mode 是否为 reference_video。
+
+    project.json 是该判定的唯一真相源：ad 内容模式的剧本骨架不携带剧本级
+    ``generation_mode`` 戳（见 ``script_generator``），只看剧本判不出参考生视频。
+    """
+    return effective_mode(project=project, episode=find_episode(project, episode) or {}) == "reference_video"
+
+
 def resolve_source_kind(project: Mapping[str, Any]) -> SourceKind:
     """项目源文件性质（novel / screenplay），缺失或非法值回退默认 novel，兼容脏数据。"""
     value = project.get("source_kind")

--- a/lib/script_review.py
+++ b/lib/script_review.py
@@ -29,7 +29,7 @@ from lib.episode_paths import (
     episode_drafts_dir,
     episode_script_relpath,
 )
-from lib.project_manager import effective_mode
+from lib.project_manager import find_episode, is_reference_video_episode
 
 #: 审核状态：not_applicable=该集不走 gate；no_step1=适用但 step1 未产出；
 #: pending_review=step1 已产出但未经确认（或确认后内容又变）→ 阻塞 step2；confirmed=已确认放行。
@@ -43,14 +43,6 @@ REVIEW_FIELD = "step1_review"
 Step1Kind = Literal["drama", "narration", "reference_video"]
 
 
-def find_episode(project: dict[str, Any], episode: int) -> dict[str, Any] | None:
-    """返回 project.json ``episodes[]`` 中 ``episode == N`` 的条目，缺失则 None。"""
-    for ep in project.get("episodes") or []:
-        if ep.get("episode") == episode:
-            return ep
-    return None
-
-
 def step1_kind(project: dict[str, Any], episode: int) -> Step1Kind | None:
     """该集 step1 变体；无结构化 step1 中间态（如 ad）时返回 None。
 
@@ -61,7 +53,7 @@ def step1_kind(project: dict[str, Any], episode: int) -> Step1Kind | None:
     content_mode = project.get("content_mode")
     if content_mode not in STEP1_FILENAMES:
         return None
-    if effective_mode(project=project, episode=find_episode(project, episode) or {}) == "reference_video":
+    if is_reference_video_episode(project, episode):
         return "reference_video"
     return content_mode  # "drama" | "narration"（STEP1_FILENAMES 成员）
 

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -18,7 +18,7 @@ from lib.generation_queue_client import (
     batch_enqueue_and_wait,
     enqueue_and_wait,
 )
-from lib.project_manager import ProjectManager, effective_mode
+from lib.project_manager import ProjectManager, is_reference_video_episode
 from lib.prompt_utils import is_structured_video_prompt, utterances_to_dialogue, video_prompt_to_yaml
 from lib.reference_video import assemble_shots_text
 from lib.reference_video.ad_units import (
@@ -65,12 +65,7 @@ def _is_ad_reference(ctx: ToolContext, script: dict[str, Any]) -> bool:
     project = ctx.pm.load_project(ctx.project_name)
     if project.get("content_mode") != "ad":
         return False
-    episode = script.get("episode")
-    meta = next(
-        (e for e in (project.get("episodes") or []) if isinstance(e, dict) and e.get("episode") == episode),
-        None,
-    )
-    return effective_mode(project=project, episode=meta or {}) == "reference_video"
+    return is_reference_video_episode(project, script.get("episode"))
 
 
 # Checkpoint helpers

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -52,8 +52,9 @@ from pathlib import Path
 from lib.image_utils import normalize_storyboard_upload
 from lib.path_safety import PathTraversalError, safe_join
 from lib.project_change_hints import project_change_source
-from lib.project_manager import ProjectManager, get_project_manager
+from lib.project_manager import ProjectManager, effective_mode, get_project_manager
 from lib.resource_paths import END_FRAME_RESOURCE_TYPE, resource_relative_path
+from lib.script_review import find_episode
 from lib.storyboard_sequence import find_storyboard_item, get_storyboard_items
 from server.services.upload_finalize import UPLOAD_IMAGE_MAX_BYTES, UploadTooLargeError, write_bytes_atomic
 
@@ -92,8 +93,12 @@ class EndFrameError(Exception):
 def _locate_shot(project_name: str, script_file: str, shot_id: str) -> Path:
     """确认镜头在剧本中存在，返回项目绝对路径；不存在时抛领域错误。
 
-    参考生视频剧本的 ``get_storyboard_items`` 返回空列表（该路径无首帧概念，
-    Spec 明确排除尾帧支持），故一并落到「镜头不存在」。
+    参考生视频路径无首帧概念（Spec 明确排除尾帧支持），按生效 generation_mode
+    （``effective_mode``，episode 覆盖 project）判定并拒绝——不能只看剧本级
+    ``generation_mode`` 戳：ad 内容模式的剧本骨架不携带该戳（见 ``script_generator``），
+    「ad + 项目/集级 reference_video」组合下剧本级判定会漏判，允许设置一个永不被
+    消费的尾帧。drama/narration 的参考生视频剧本仍会命中此处——两者判定口径统一，
+    不再依赖 ``get_storyboard_items`` 对未打戳剧本返回空列表的副作用。
     """
     manager = get_project_manager()
     try:
@@ -112,6 +117,13 @@ def _locate_shot(project_name: str, script_file: str, shot_id: str) -> Path:
         raise
     except ValueError as exc:
         raise EndFrameError("invalid_script_file", status_code=400, name=script_file) from exc
+
+    project = manager.load_project(project_name)
+    episode_num = ProjectManager.resolve_episode_from_script(script, script_file)
+    episode_entry = find_episode(project, episode_num) or {}
+    if effective_mode(project=project, episode=episode_entry) == "reference_video":
+        raise EndFrameError("end_frame_reference_video_unsupported")
+
     items, id_field, _, _, _ = get_storyboard_items(script)
     if find_storyboard_item(items, id_field, shot_id) is None:
         raise EndFrameError("segment_not_found", status_code=404, id=shot_id)

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -52,9 +52,8 @@ from pathlib import Path
 from lib.image_utils import normalize_storyboard_upload
 from lib.path_safety import PathTraversalError, safe_join
 from lib.project_change_hints import project_change_source
-from lib.project_manager import ProjectManager, effective_mode, get_project_manager
+from lib.project_manager import ProjectManager, get_project_manager, is_reference_video_episode
 from lib.resource_paths import END_FRAME_RESOURCE_TYPE, resource_relative_path
-from lib.script_review import find_episode
 from lib.storyboard_sequence import find_storyboard_item, get_storyboard_items
 from server.services.upload_finalize import UPLOAD_IMAGE_MAX_BYTES, UploadTooLargeError, write_bytes_atomic
 
@@ -91,14 +90,16 @@ class EndFrameError(Exception):
 
 
 def _locate_shot(project_name: str, script_file: str, shot_id: str) -> Path:
-    """确认镜头在剧本中存在，返回项目绝对路径；不存在时抛领域错误。
+    """校验该镜头可设尾帧，返回项目绝对路径；不可设时抛领域错误。
 
-    参考生视频路径无首帧概念（Spec 明确排除尾帧支持），按生效 generation_mode
-    （``effective_mode``，episode 覆盖 project）判定并拒绝——不能只看剧本级
-    ``generation_mode`` 戳：ad 内容模式的剧本骨架不携带该戳（见 ``script_generator``），
-    「ad + 项目/集级 reference_video」组合下剧本级判定会漏判，允许设置一个永不被
-    消费的尾帧。drama/narration 的参考生视频剧本仍会命中此处——两者判定口径统一，
-    不再依赖 ``get_storyboard_items`` 对未打戳剧本返回空列表的副作用。
+    参考生视频路径无首尾帧概念，一律拒绝。该判定按 project.json 的生效
+    generation_mode（``is_reference_video_episode``，集级覆盖项目级）作出，不看剧本级
+    ``generation_mode`` 戳——ad 内容模式的剧本骨架不携带该戳（见 ``script_generator``），
+    只看剧本会放过「ad + 项目/集级 reference_video」组合，让用户设下一个生成时永不被
+    消费的尾帧。各内容模式共用这一口径。
+
+    集号无法从剧本解析时按「无集级配置」处理，回退到项目级 generation_mode：拿不到集号
+    不构成拒绝理由，此处只做生成模式准入，剧本本身的合法性由上游校验负责。
     """
     manager = get_project_manager()
     try:
@@ -118,10 +119,15 @@ def _locate_shot(project_name: str, script_file: str, shot_id: str) -> Path:
     except ValueError as exc:
         raise EndFrameError("invalid_script_file", status_code=400, name=script_file) from exc
 
-    project = manager.load_project(project_name)
-    episode_num = ProjectManager.resolve_episode_from_script(script, script_file)
-    episode_entry = find_episode(project, episode_num) or {}
-    if effective_mode(project=project, episode=episode_entry) == "reference_video":
+    try:
+        project = manager.load_project(project_name)
+    except FileNotFoundError as exc:
+        raise EndFrameError("project_not_found", status_code=404, name=project_name) from exc
+    try:
+        episode_num = ProjectManager.resolve_episode_from_script(script, script_file)
+    except ValueError:
+        episode_num = None
+    if is_reference_video_episode(project, episode_num):
         raise EndFrameError("end_frame_reference_video_unsupported")
 
     items, id_field, _, _, _ = get_storyboard_items(script)

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -662,6 +662,129 @@ class TestErrorMapping:
         assert _upload(c, _img_bytes("PNG")).status_code == 500
 
 
+def _client_with_project(
+    tmp_path, monkeypatch, *, content_mode, script, project_generation_mode=None, episode_generation_mode=None
+):
+    """构造项目/集级 generation_mode 可控的测试 client，用于覆盖 effective_mode 判定。"""
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo", content_mode=content_mode)
+    pm.create_project_metadata("demo", "Demo", "Anime", content_mode)
+
+    project = pm.load_project("demo")
+    if project_generation_mode is not None:
+        project["generation_mode"] = project_generation_mode
+    episode_entry = {"episode": 1, "title": "E1", "script_file": "scripts/episode_1.json"}
+    if episode_generation_mode is not None:
+        episode_entry["generation_mode"] = episode_generation_mode
+    project["episodes"] = [episode_entry]
+    pm.save_project("demo", project)
+    pm.save_script("demo", script, "episode_1.json", validate=False)
+
+    monkeypatch.setattr(end_frame_service, "get_project_manager", lambda: pm)
+    app = FastAPI()
+    register_error_handlers(app)
+    app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+    app.include_router(end_frames.router, prefix="/api/v1")
+    return TestClient(app), pm
+
+
+def _ad_script(shot_id="E1S01") -> dict:
+    return {
+        "episode": 1,
+        "title": "E1",
+        "content_mode": "ad",
+        "shots": [
+            {
+                "shot_id": shot_id,
+                "section": "hook",
+                "duration_seconds": 4,
+                "voiceover_text": "t",
+                "characters_in_shot": [],
+                "image_prompt": "img",
+                "video_prompt": "vid",
+                "generated_assets": {"status": "pending"},
+            }
+        ],
+    }
+
+
+class TestReferenceVideoRejection:
+    """effective generation_mode（episode 覆盖 project）为 reference_video 时，尾帧三端点一律拒绝——
+    不管剧本本身是否打了 generation_mode 戳（ad 骨架从不打戳，见 script_generator）。
+    """
+
+    def test_ad_project_level_reference_video_rejects_all_three_endpoints(self, tmp_path, monkeypatch):
+        # ad 剧本骨架不携带 generation_mode 戳，只有项目级配置声明 reference_video——
+        # 这正是原缺陷未被剧本级判定拦下的组合。
+        c, pm = _client_with_project(
+            tmp_path, monkeypatch, content_mode="ad", script=_ad_script(), project_generation_mode="reference_video"
+        )
+
+        upload_resp = _upload(c, _img_bytes("PNG"), shot_id="E1S01")
+        assert upload_resp.status_code == 400, upload_resp.text
+        assert upload_resp.json()["detail"]
+
+        select_resp = _select(c, "storyboards/whatever.png", shot_id="E1S01")
+        assert select_resp.status_code == 400, select_resp.text
+
+        delete_resp = _delete(c, shot_id="E1S01")
+        assert delete_resp.status_code == 400, delete_resp.text
+
+        assert pm.load_script("demo", "episode_1.json")["shots"][0].get("end_frame_image") is None
+
+    def test_ad_episode_level_override_reference_video_rejected(self, tmp_path, monkeypatch):
+        # episode 覆盖 project：项目级未声明（回退 storyboard 默认），集级显式声明 reference_video。
+        c, _pm = _client_with_project(
+            tmp_path,
+            monkeypatch,
+            content_mode="ad",
+            script=_ad_script(),
+            episode_generation_mode="reference_video",
+        )
+        assert _upload(c, _img_bytes("PNG"), shot_id="E1S01").status_code == 400
+
+    def test_ad_episode_level_storyboard_overrides_project_reference_video(self, tmp_path, monkeypatch):
+        # episode 覆盖 project 的另一半：项目级 reference_video 被集级 storyboard 覆盖时须放行。
+        c, _pm = _client_with_project(
+            tmp_path,
+            monkeypatch,
+            content_mode="ad",
+            script=_ad_script(),
+            project_generation_mode="reference_video",
+            episode_generation_mode="storyboard",
+        )
+        assert _upload(c, _img_bytes("PNG"), shot_id="E1S01").status_code == 200
+
+    def test_drama_reference_video_script_still_rejected(self, tmp_path, monkeypatch):
+        # narration/drama 的参考生视频剧本本身打了戳，行为须保持不变（仍拒绝）。
+        script = {
+            "episode": 1,
+            "title": "E1",
+            "content_mode": "drama",
+            "generation_mode": "reference_video",
+            "video_units": [{"unit_id": "E1S01", "scenes": [], "props": []}],
+        }
+        c, _pm = _client_with_project(
+            tmp_path, monkeypatch, content_mode="drama", script=script, project_generation_mode="reference_video"
+        )
+        assert _upload(c, _img_bytes("PNG"), shot_id="E1S01").status_code == 400
+
+    def test_grid_mode_no_regression(self, tmp_path, monkeypatch):
+        # 常规宫格生视频路径不受影响，尾帧设置照常放行。
+        script = {
+            "episode": 1,
+            "title": "E1",
+            "content_mode": "narration",
+            "segments": [{"segment_id": "E1S01", "novel_text": "t", "duration_seconds": 5}],
+        }
+        c, pm = _client_with_project(
+            tmp_path, monkeypatch, content_mode="narration", script=script, project_generation_mode="grid"
+        )
+        resp = _upload(c, _img_bytes("PNG"), shot_id="E1S01")
+        assert resp.status_code == 200, resp.text
+        assert pm.load_script("demo", "episode_1.json")["segments"][0]["end_frame_image"] == END_FRAME_REL
+
+
 class TestValidatorAcceptsWrittenSnapshot:
     def test_written_project_passes_tree_validation(self, client):
         c, pm = client

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 from PIL import Image
 
 from lib.data_validator import DataValidator
+from lib.i18n import _ as i18n_message
 from lib.project_manager import ProjectManager
 from lib.script_editor import ScriptEditError
 from lib.version_manager import VersionManager
@@ -67,16 +68,21 @@ def _seed_project(tmp_path) -> ProjectManager:
     return pm
 
 
-@pytest.fixture
-def client(tmp_path, monkeypatch):
-    pm = _seed_project(tmp_path)
+def _build_client(pm: ProjectManager, monkeypatch) -> TestClient:
+    """把给定 ProjectManager 接到尾帧路由上，返回可发请求的 TestClient。"""
     monkeypatch.setattr(end_frame_service, "get_project_manager", lambda: pm)
 
     app = FastAPI()
     register_error_handlers(app)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(end_frames.router, prefix="/api/v1")
-    return TestClient(app), pm
+    return TestClient(app)
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    pm = _seed_project(tmp_path)
+    return _build_client(pm, monkeypatch), pm
 
 
 def _upload(client, content: bytes, filename="frame.jpg", shot_id="E1S01"):
@@ -665,7 +671,7 @@ class TestErrorMapping:
 def _client_with_project(
     tmp_path, monkeypatch, *, content_mode, script, project_generation_mode=None, episode_generation_mode=None
 ):
-    """构造项目/集级 generation_mode 可控的测试 client，用于覆盖 effective_mode 判定。"""
+    """构造项目/集级 generation_mode 可控的测试 client，用于覆盖生效 generation_mode 判定。"""
     pm = ProjectManager(tmp_path / "projects")
     pm.create_project("demo", content_mode=content_mode)
     pm.create_project_metadata("demo", "Demo", "Anime", content_mode)
@@ -680,12 +686,13 @@ def _client_with_project(
     pm.save_project("demo", project)
     pm.save_script("demo", script, "episode_1.json", validate=False)
 
-    monkeypatch.setattr(end_frame_service, "get_project_manager", lambda: pm)
-    app = FastAPI()
-    register_error_handlers(app)
-    app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
-    app.include_router(end_frames.router, prefix="/api/v1")
-    return TestClient(app), pm
+    return _build_client(pm, monkeypatch), pm
+
+
+def _assert_reference_video_rejected(resp) -> None:
+    """断言响应是参考生视频专属的拒绝，而非碰巧同为 400 的其他错误。"""
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"] == i18n_message("end_frame_reference_video_unsupported")
 
 
 def _ad_script(shot_id="E1S01") -> dict:
@@ -709,42 +716,42 @@ def _ad_script(shot_id="E1S01") -> dict:
 
 
 class TestReferenceVideoRejection:
-    """effective generation_mode（episode 覆盖 project）为 reference_video 时，尾帧三端点一律拒绝——
-    不管剧本本身是否打了 generation_mode 戳（ad 骨架从不打戳，见 script_generator）。
+    """生效 generation_mode（集级覆盖项目级）为 reference_video 时，尾帧三端点一律拒绝。
+
+    判定只看 project.json：ad 剧本骨架不携带剧本级 generation_mode 戳（见 script_generator），
+    各内容模式共用这一口径。
     """
 
     def test_ad_project_level_reference_video_rejects_all_three_endpoints(self, tmp_path, monkeypatch):
-        # ad 剧本骨架不携带 generation_mode 戳，只有项目级配置声明 reference_video——
-        # 这正是原缺陷未被剧本级判定拦下的组合。
+        # ad 剧本骨架不携带 generation_mode 戳，参考生视频只由项目级配置声明。
         c, pm = _client_with_project(
             tmp_path, monkeypatch, content_mode="ad", script=_ad_script(), project_generation_mode="reference_video"
         )
 
-        upload_resp = _upload(c, _img_bytes("PNG"), shot_id="E1S01")
-        assert upload_resp.status_code == 400, upload_resp.text
-        assert upload_resp.json()["detail"]
-
-        select_resp = _select(c, "storyboards/whatever.png", shot_id="E1S01")
-        assert select_resp.status_code == 400, select_resp.text
-
-        delete_resp = _delete(c, shot_id="E1S01")
-        assert delete_resp.status_code == 400, delete_resp.text
+        _assert_reference_video_rejected(_upload(c, _img_bytes("PNG"), shot_id="E1S01"))
+        _assert_reference_video_rejected(_select(c, "storyboards/whatever.png", shot_id="E1S01"))
+        _assert_reference_video_rejected(_delete(c, shot_id="E1S01"))
 
         assert pm.load_script("demo", "episode_1.json")["shots"][0].get("end_frame_image") is None
 
-    def test_ad_episode_level_override_reference_video_rejected(self, tmp_path, monkeypatch):
-        # episode 覆盖 project：项目级未声明（回退 storyboard 默认），集级显式声明 reference_video。
-        c, _pm = _client_with_project(
+    def test_ad_episode_level_override_reference_video_rejects_all_three_endpoints(self, tmp_path, monkeypatch):
+        # 集级覆盖项目级：项目级未声明（回退 storyboard 默认），集级显式声明 reference_video。
+        c, pm = _client_with_project(
             tmp_path,
             monkeypatch,
             content_mode="ad",
             script=_ad_script(),
             episode_generation_mode="reference_video",
         )
-        assert _upload(c, _img_bytes("PNG"), shot_id="E1S01").status_code == 400
+
+        _assert_reference_video_rejected(_upload(c, _img_bytes("PNG"), shot_id="E1S01"))
+        _assert_reference_video_rejected(_select(c, "storyboards/whatever.png", shot_id="E1S01"))
+        _assert_reference_video_rejected(_delete(c, shot_id="E1S01"))
+
+        assert pm.load_script("demo", "episode_1.json")["shots"][0].get("end_frame_image") is None
 
     def test_ad_episode_level_storyboard_overrides_project_reference_video(self, tmp_path, monkeypatch):
-        # episode 覆盖 project 的另一半：项目级 reference_video 被集级 storyboard 覆盖时须放行。
+        # 集级覆盖项目级的另一半：项目级 reference_video 被集级 storyboard 覆盖时须放行。
         c, _pm = _client_with_project(
             tmp_path,
             monkeypatch,
@@ -755,8 +762,8 @@ class TestReferenceVideoRejection:
         )
         assert _upload(c, _img_bytes("PNG"), shot_id="E1S01").status_code == 200
 
-    def test_drama_reference_video_script_still_rejected(self, tmp_path, monkeypatch):
-        # narration/drama 的参考生视频剧本本身打了戳，行为须保持不变（仍拒绝）。
+    def test_drama_reference_video_script_rejected(self, tmp_path, monkeypatch):
+        # drama/narration 的参考生视频剧本同样落到这条拒绝上。
         script = {
             "episode": 1,
             "title": "E1",
@@ -767,7 +774,7 @@ class TestReferenceVideoRejection:
         c, _pm = _client_with_project(
             tmp_path, monkeypatch, content_mode="drama", script=script, project_generation_mode="reference_video"
         )
-        assert _upload(c, _img_bytes("PNG"), shot_id="E1S01").status_code == 400
+        _assert_reference_video_rejected(_upload(c, _img_bytes("PNG"), shot_id="E1S01"))
 
     def test_grid_mode_no_regression(self, tmp_path, monkeypatch):
         # 常规宫格生视频路径不受影响，尾帧设置照常放行。
@@ -783,6 +790,24 @@ class TestReferenceVideoRejection:
         resp = _upload(c, _img_bytes("PNG"), shot_id="E1S01")
         assert resp.status_code == 200, resp.text
         assert pm.load_script("demo", "episode_1.json")["segments"][0]["end_frame_image"] == END_FRAME_REL
+
+    def test_unresolvable_episode_falls_back_to_project_mode(self, tmp_path, monkeypatch):
+        # 集号既不在剧本里也不在文件名里：回退项目级判定照常拒绝，不落到 500。
+        script = {
+            "title": "E1",
+            "content_mode": "narration",
+            "segments": [{"segment_id": "E1S01", "novel_text": "t", "duration_seconds": 5}],
+        }
+        c, pm = _client_with_project(
+            tmp_path, monkeypatch, content_mode="narration", script=script, project_generation_mode="reference_video"
+        )
+        pm.save_script("demo", script, "custom.json", validate=False)
+
+        resp = c.post(
+            "/api/v1/projects/demo/shots/E1S01/end-frame/upload?script_file=custom.json",
+            files={"file": ("frame.png", BytesIO(_img_bytes("PNG")), "application/octet-stream")},
+        )
+        _assert_reference_video_rejected(resp)
 
 
 class TestValidatorAcceptsWrittenSnapshot:


### PR DESCRIPTION
Closes #1354

## 问题

参考生视频路径的镜头没有首尾帧概念，尾帧端点本应拒绝。此前的拒绝依赖剧本里的
`generation_mode` 戳，而广告内容模式的剧本骨架不打这个戳，因此「广告 + 项目级（或集级）
参考生视频」组合下，尾帧的上传 / 选图 / 清除三个端点全部放行，用户能设下一个生成时
永不被消费的尾帧。

## 改动

- 尾帧服务的准入判定改看 `project.json` 的生效 generation_mode（集级覆盖项目级），
  各内容模式共用同一口径，拒绝时给出可读原因（新增错误文案，zh/en/vi 三语齐全）。
- 「该集是否参考生视频」的判定原先在三处各写一遍，收敛为 `lib/project_manager.py`
  的 `is_reference_video_episode`，尾帧服务、step1 审核 gate、视频入队工具统一调用；
  `find_episode` 一并移到 `project_manager`，尾帧服务不再反向依赖审核 gate 模块。
- 集号无法从剧本解析、或项目元数据缺失时，分别回退到项目级判定与 404 项目不存在，
  不会落成 500。

前端在该组合下本就不渲染尾帧入口（`StudioCanvasRouter` 不向 `ShotDetail` 传
`onGenerateVideo`），本次只堵 API 层，前端无改动。

## 验证

- `uv run python -m pytest` — 6508 passed
- `uv run ruff check . && uv run ruff format --check`、`uv run basedpyright` — 0 error
- 新增用例覆盖：广告 + 项目级参考生视频三端点均拒绝并校验错误文案、广告 + 集级参考生视频
  三端点均拒绝、集级 storyboard 覆盖项目级参考生视频时放行、drama 参考生视频剧本仍拒绝、
  宫格路径无回归、集号不可解析时回退项目级判定


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能优化**
  - 参考视频模式下设置、选择或清除尾帧时，系统会明确提示该模式不支持尾帧操作。
  - 支持根据项目及单集配置准确识别参考视频模式，相关提示已覆盖英文、中文和越南语。
  - 剧集级模式设置可正确覆盖项目级配置。
- **问题修复**
  - 非参考视频模式（如分镜、网格模式）的尾帧功能不受影响。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->