### PR TITLE
fix(i18n): 剧本编辑类错误响应按界面语言呈现，不再混入中文原文

### DIFF
--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -671,7 +671,16 @@ class GenerationWorker:
             raise
         except Exception as exc:
             logger.exception("任务失败 %s (type=%s, provider=%s)", task_id, task_type, provider_id)
-            message = encode_failure(exc.key, **exc.params) if isinstance(exc, ScriptEditError) else str(exc)
+            message = str(exc)
+            if isinstance(exc, ScriptEditError):
+                try:
+                    message = encode_failure(exc.key, **exc.params)
+                except (KeyError, TypeError):
+                    # exc.key 未登记进 FAILURE_CODE_KEYS，或 params 不可 JSON 序列化——两个列表
+                    # 靠约定同步而非运行时校验，脱节时降级到通用 key 而非让编码异常打断
+                    # mark_task_failed，否则任务会卡死在 running 终态之外。
+                    logger.warning("ScriptEditError key 未登记，降级为通用失败原因: key=%s", exc.key)
+                    message = encode_failure("script_edit_error")
             rows = await asyncio.shield(self.queue.mark_task_failed(task_id, message))
             if rows == 0:
                 # 外部已抢先翻 cancelling → 落地 cancelled 终态

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -34,6 +34,7 @@ from lib.generation_queue import (
     GenerationQueue,
     get_generation_queue,
 )
+from lib.script_editor import ScriptEditError
 from lib.task_failure import encode_failure
 
 # Default provider used when a task payload does not specify one.
@@ -670,7 +671,8 @@ class GenerationWorker:
             raise
         except Exception as exc:
             logger.exception("任务失败 %s (type=%s, provider=%s)", task_id, task_type, provider_id)
-            rows = await asyncio.shield(self.queue.mark_task_failed(task_id, str(exc)))
+            message = encode_failure(exc.key, **exc.params) if isinstance(exc, ScriptEditError) else str(exc)
+            rows = await asyncio.shield(self.queue.mark_task_failed(task_id, message))
             if rows == 0:
                 # 外部已抢先翻 cancelling → 落地 cancelled 终态
                 await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -68,6 +68,28 @@ def _read_int_env(name: str, default: int, minimum: int = 1) -> int:
     return max(minimum, value)
 
 
+def _encode_task_failure_message(exc: Exception) -> str:
+    """把任务执行异常编码为落库的 error_message：ScriptEditError 走 key/params 结构化，
+    其余异常沿用 str(exc)。normal（_process_task）与 resume（_process_resume_task）两条
+    独立的任务执行路径都会捕获 ScriptEditError（前者经常规 finalize，后者经
+    resume_executor 复用同一批 finalize helper），共用这份编码逻辑避免同一处理漂移成两份。
+    """
+    if not isinstance(exc, ScriptEditError):
+        return str(exc)
+    try:
+        return encode_failure(exc.key, **exc.params)
+    except KeyError:
+        # exc.key 未登记进 FAILURE_CODE_KEYS——两个列表靠约定同步而非运行时校验，脱节时
+        # 降级到通用 key 而非让编码异常打断 mark_task_failed，否则任务会卡死在 running。
+        logger.warning("ScriptEditError key 未登记进 FAILURE_CODE_KEYS，降级为通用失败原因: key=%s", exc.key)
+        return encode_failure("script_edit_error")
+    except (TypeError, ValueError):
+        # params 不可 JSON 序列化（TypeError：非基础类型；ValueError：json.dumps 默认
+        # check_circular 检出循环引用），同样降级而不是让编码异常打断落库。
+        logger.warning("ScriptEditError params 无法序列化，降级为通用失败原因: key=%s", exc.key)
+        return encode_failure("script_edit_error")
+
+
 def _parse_lane_max(config: dict[str, str], key: str, default: int, provider_id: str) -> int:
     """逐 key 容错解析单条 lane 的并发上限。
 
@@ -671,18 +693,7 @@ class GenerationWorker:
             raise
         except Exception as exc:
             logger.exception("任务失败 %s (type=%s, provider=%s)", task_id, task_type, provider_id)
-            message = str(exc)
-            if isinstance(exc, ScriptEditError):
-                try:
-                    message = encode_failure(exc.key, **exc.params)
-                except (KeyError, TypeError, ValueError):
-                    # exc.key 未登记进 FAILURE_CODE_KEYS，或 params 不可 JSON 序列化（TypeError：
-                    # 非基础类型；ValueError：json.dumps 默认 check_circular 检出循环引用）——
-                    # 两个列表靠约定同步而非运行时校验，脱节时降级到通用 key 而非让编码异常打断
-                    # mark_task_failed，否则任务会卡死在 running 终态之外。
-                    logger.warning("ScriptEditError key 未登记，降级为通用失败原因: key=%s", exc.key)
-                    message = encode_failure("script_edit_error")
-            rows = await asyncio.shield(self.queue.mark_task_failed(task_id, message))
+            rows = await asyncio.shield(self.queue.mark_task_failed(task_id, _encode_task_failure_message(exc)))
             if rows == 0:
                 # 外部已抢先翻 cancelling → 落地 cancelled 终态
                 await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
@@ -775,7 +786,7 @@ class GenerationWorker:
             return
         except Exception as exc:
             logger.exception("resume 失败 %s (type=%s, provider=%s)", task_id, task_type, provider_id)
-            rows = await asyncio.shield(self.queue.mark_task_failed(task_id, str(exc)))
+            rows = await asyncio.shield(self.queue.mark_task_failed(task_id, _encode_task_failure_message(exc)))
             if rows == 0:
                 await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
             return

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -675,9 +675,10 @@ class GenerationWorker:
             if isinstance(exc, ScriptEditError):
                 try:
                     message = encode_failure(exc.key, **exc.params)
-                except (KeyError, TypeError):
-                    # exc.key 未登记进 FAILURE_CODE_KEYS，或 params 不可 JSON 序列化——两个列表
-                    # 靠约定同步而非运行时校验，脱节时降级到通用 key 而非让编码异常打断
+                except (KeyError, TypeError, ValueError):
+                    # exc.key 未登记进 FAILURE_CODE_KEYS，或 params 不可 JSON 序列化（TypeError：
+                    # 非基础类型；ValueError：json.dumps 默认 check_circular 检出循环引用）——
+                    # 两个列表靠约定同步而非运行时校验，脱节时降级到通用 key 而非让编码异常打断
                     # mark_task_failed，否则任务会卡死在 running 终态之外。
                     logger.warning("ScriptEditError key 未登记，降级为通用失败原因: key=%s", exc.key)
                     message = encode_failure("script_edit_error")

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -20,6 +20,8 @@ MESSAGES = {
     "script_missing": "Script does not exist",
     "script_validation_failed": "Script structure validation failed: {details}",
     "script_data_corrupted": "Script data is corrupted: {reason}",
+    "script_edit_error": "Segment edit validation failed",
+    "script_edit_items_not_list": "{kind} must be a list, but got {type_name}",
     "narration_mode_required": "This script is not in narration mode, please use the scene update interface",
     "ad_mode_required": "This script is not in ad/short-video mode, please use the update interface for its mode",
     "shot_not_found": "Shot '{id}' does not exist",

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -22,6 +22,8 @@ MESSAGES = {
     "script_data_corrupted": "Script data is corrupted: {reason}",
     "script_edit_error": "Segment edit validation failed",
     "script_edit_items_not_list": "{kind} must be a list, but got {type_name}",
+    "script_edit_unit_lists_invalid": "video_units / reference_units must be a list",
+    "script_edit_generated_assets_invalid": "generated_assets must be a dictionary",
     "narration_mode_required": "This script is not in narration mode, please use the scene update interface",
     "ad_mode_required": "This script is not in ad/short-video mode, please use the update interface for its mode",
     "shot_not_found": "Shot '{id}' does not exist",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -22,6 +22,8 @@ MESSAGES = {
     "script_data_corrupted": "Dữ liệu kịch bản bị hỏng: {reason}",
     "script_edit_error": "Xác thực chỉnh sửa kịch bản thất bại",
     "script_edit_items_not_list": "{kind} phải là một danh sách, nhưng nhận được {type_name}",
+    "script_edit_unit_lists_invalid": "video_units / reference_units phải là một danh sách",
+    "script_edit_generated_assets_invalid": "generated_assets phải là một từ điển",
     "narration_mode_required": "Kịch bản này không ở chế độ thuyết minh, vui lòng dùng API cập nhật cảnh",
     "ad_mode_required": "Kịch bản này không ở chế độ quảng cáo/video ngắn, vui lòng dùng API cập nhật của chế độ tương ứng",
     "shot_not_found": "Cảnh quay '{id}' không tồn tại",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -20,6 +20,8 @@ MESSAGES = {
     "script_missing": "Kịch bản không tồn tại",
     "script_validation_failed": "Xác thực cấu trúc kịch bản thất bại: {details}",
     "script_data_corrupted": "Dữ liệu kịch bản bị hỏng: {reason}",
+    "script_edit_error": "Xác thực chỉnh sửa kịch bản thất bại",
+    "script_edit_items_not_list": "{kind} phải là một danh sách, nhưng nhận được {type_name}",
     "narration_mode_required": "Kịch bản này không ở chế độ thuyết minh, vui lòng dùng API cập nhật cảnh",
     "ad_mode_required": "Kịch bản này không ở chế độ quảng cáo/video ngắn, vui lòng dùng API cập nhật của chế độ tương ứng",
     "shot_not_found": "Cảnh quay '{id}' không tồn tại",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -22,6 +22,8 @@ MESSAGES = {
     "script_data_corrupted": "剧本数据损坏：{reason}",
     "script_edit_error": "剧本编辑操作校验失败",
     "script_edit_items_not_list": "{kind} 必须是列表，当前为 {type_name}",
+    "script_edit_unit_lists_invalid": "video_units / reference_units 必须是列表",
+    "script_edit_generated_assets_invalid": "generated_assets 必须是字典",
     "narration_mode_required": "该剧本不是说书模式，请使用场景更新接口",
     "ad_mode_required": "该剧本不是广告/短片模式，请使用对应模式的更新接口",
     "shot_not_found": "镜头 '{id}' 不存在",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -20,6 +20,8 @@ MESSAGES = {
     "script_missing": "剧本不存在",
     "script_validation_failed": "剧本结构校验失败：{details}",
     "script_data_corrupted": "剧本数据损坏：{reason}",
+    "script_edit_error": "剧本编辑操作校验失败",
+    "script_edit_items_not_list": "{kind} 必须是列表，当前为 {type_name}",
     "narration_mode_required": "该剧本不是说书模式，请使用场景更新接口",
     "ad_mode_required": "该剧本不是广告/短片模式，请使用对应模式的更新接口",
     "shot_not_found": "镜头 '{id}' 不存在",

--- a/lib/script_editor.py
+++ b/lib/script_editor.py
@@ -23,7 +23,20 @@ logger = logging.getLogger(__name__)
 
 
 class ScriptEditError(ValueError):
-    """剧本编辑操作非法（id 未命中、数组越界、拆分份数不足、字段路径不存在等）。"""
+    """剧本编辑操作非法（id 未命中、数组越界、拆分份数不足、字段路径不存在等）。
+
+    多数 raise 点只被 MCP 工具（`server/agent_runtime/sdk_tools/patch_script.py`）消费,
+    str(self) 的中文文案是 agent-facing、按 CLAUDE.md 豁免 i18n。唯一会经 HTTP 路由回传
+    给终端用户的是 `resolve_items` 的"数组键损坏"错误（`server/error_handlers.py` /
+    `end_frames.py` / `shot_uploads.py` / `reference_videos.py` 统一按 `Accept-Language`
+    翻译该场景），故只有它显式传 ``key``/``params``；其余 raise 点沿用默认 key，
+    翻译为通用兜底文案而非把中文 str(self) 直接嵌进已翻译的响应模板。
+    """
+
+    def __init__(self, message: str, *, key: str = "script_edit_error", **params: Any) -> None:
+        super().__init__(message)
+        self.key = key
+        self.params = params
 
 
 def resolve_items(script: dict[str, Any]) -> tuple[list[dict[str, Any]], str, str]:
@@ -41,7 +54,13 @@ def resolve_items(script: dict[str, Any]) -> tuple[list[dict[str, Any]], str, st
         return [], id_field, kind
     items = script[kind]
     if not isinstance(items, list):
-        raise ScriptEditError(f"{kind} 必须是列表，当前为 {type(items).__name__}")
+        type_name = type(items).__name__
+        raise ScriptEditError(
+            f"{kind} 必须是列表，当前为 {type_name}",
+            key="script_edit_items_not_list",
+            kind=kind,
+            type_name=type_name,
+        )
     return items, id_field, kind
 
 

--- a/lib/script_editor.py
+++ b/lib/script_editor.py
@@ -25,12 +25,10 @@ logger = logging.getLogger(__name__)
 class ScriptEditError(ValueError):
     """剧本编辑操作非法（id 未命中、数组越界、拆分份数不足、字段路径不存在等）。
 
-    多数 raise 点只被 MCP 工具（`server/agent_runtime/sdk_tools/patch_script.py`）消费,
-    str(self) 的中文文案是 agent-facing、按 CLAUDE.md 豁免 i18n。唯一会经 HTTP 路由回传
-    给终端用户的是 `resolve_items` 的"数组键损坏"错误（`server/error_handlers.py` /
-    `end_frames.py` / `shot_uploads.py` / `reference_videos.py` 统一按 `Accept-Language`
-    翻译该场景），故只有它显式传 ``key``/``params``；其余 raise 点沿用默认 key，
-    翻译为通用兜底文案而非把中文 str(self) 直接嵌进已翻译的响应模板。
+    ``key``/``params`` 是给用户可见路径准备的翻译坐标：会经 HTTP 路由回传终端用户的 raise 点
+    必须显式传具体 ``key``，服务端按请求 ``Accept-Language`` 渲染，而不是把固定中文的
+    ``str(self)`` 嵌进已翻译的响应模板。只被 MCP 工具与日志消费的 raise 点是 agent-facing、
+    按 CLAUDE.md 豁免 i18n，沿用默认 key 即可（渲染为通用兜底文案）。
     """
 
     def __init__(self, message: str, *, key: str = "script_edit_error", **params: Any) -> None:

--- a/lib/task_failure.py
+++ b/lib/task_failure.py
@@ -32,6 +32,7 @@ FAILURE_CODE_KEYS: dict[str, str] = {
     "resume_expired_detail": "task_fail_resume_expired_detail",
     # ScriptEditError.key 本身就是 errors.py 的 key（见 lib/script_editor.py），无需前缀间接层。
     "script_edit_error": "script_edit_error",
+    "script_edit_items_not_list": "script_edit_items_not_list",
     "script_edit_unit_lists_invalid": "script_edit_unit_lists_invalid",
     "script_edit_generated_assets_invalid": "script_edit_generated_assets_invalid",
 }

--- a/lib/task_failure.py
+++ b/lib/task_failure.py
@@ -30,6 +30,10 @@ FAILURE_CODE_KEYS: dict[str, str] = {
     "resume_unsupported_capacity_zero": "task_fail_resume_unsupported_capacity_zero",
     "resume_unsupported_detail": "task_fail_resume_unsupported_detail",
     "resume_expired_detail": "task_fail_resume_expired_detail",
+    # ScriptEditError.key 本身就是 errors.py 的 key（见 lib/script_editor.py），无需前缀间接层。
+    "script_edit_error": "script_edit_error",
+    "script_edit_unit_lists_invalid": "script_edit_unit_lists_invalid",
+    "script_edit_generated_assets_invalid": "script_edit_generated_assets_invalid",
 }
 
 # A structured reason is ``[code]`` optionally followed by a single space and a

--- a/server/error_handlers.py
+++ b/server/error_handlers.py
@@ -86,9 +86,11 @@ def register_error_handlers(
 
     @app.exception_handler(ScriptEditError)
     async def _handle_script_edit_error(request: Request, exc: ScriptEditError) -> JSONResponse:
-        # 脏脚本（分镜数组键损坏等）→ 4xx 客户端错误；reason 是结构性描述，不含服务器路径
+        # 脏脚本（分镜数组键损坏等）→ 4xx 客户端错误；reason 经 exc.key/exc.params 按请求语言
+        # 翻译，不直接嵌 str(exc)（其文案固定中文，会在 en/vi 响应里混入中文原文）
         _t = get_translator(request)
-        return JSONResponse(status_code=400, content={"detail": _t("script_data_corrupted", reason=str(exc))})
+        reason = _t(exc.key, **exc.params)
+        return JSONResponse(status_code=400, content={"detail": _t("script_data_corrupted", reason=reason)})
 
     @app.exception_handler(FileNotFoundError)
     async def _handle_file_not_found(request: Request, exc: FileNotFoundError) -> JSONResponse:

--- a/server/error_handlers.py
+++ b/server/error_handlers.py
@@ -12,7 +12,7 @@
 """
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
@@ -23,6 +23,16 @@ from lib.i18n import get_translator
 from lib.script_editor import ScriptEditError
 
 logger = logging.getLogger(__name__)
+
+
+def script_edit_detail(exc: ScriptEditError, _t: Callable[..., str]) -> str:
+    """``ScriptEditError`` → 用户可见 detail 的单点映射。
+
+    reason 走 ``exc.key``/``exc.params`` 按请求语言翻译，不嵌 ``str(exc)``——后者文案固定
+    中文，会在 en/vi 响应里混入中文原文。仍自行 ``except ScriptEditError`` 的路由与本模块
+    的全局 handler 共用本函数，避免同一表达式散落多处各自演化。
+    """
+    return _t("script_data_corrupted", reason=_t(exc.key, **exc.params))
 
 
 def _cors_headers_for(
@@ -86,11 +96,9 @@ def register_error_handlers(
 
     @app.exception_handler(ScriptEditError)
     async def _handle_script_edit_error(request: Request, exc: ScriptEditError) -> JSONResponse:
-        # 脏脚本（分镜数组键损坏等）→ 4xx 客户端错误；reason 经 exc.key/exc.params 按请求语言
-        # 翻译，不直接嵌 str(exc)（其文案固定中文，会在 en/vi 响应里混入中文原文）
+        # 脏脚本（分镜数组键损坏等）→ 4xx 客户端错误
         _t = get_translator(request)
-        reason = _t(exc.key, **exc.params)
-        return JSONResponse(status_code=400, content={"detail": _t("script_data_corrupted", reason=reason)})
+        return JSONResponse(status_code=400, content={"detail": script_edit_detail(exc, _t)})
 
     @app.exception_handler(FileNotFoundError)
     async def _handle_file_not_found(request: Request, exc: FileNotFoundError) -> JSONResponse:

--- a/server/routers/end_frames.py
+++ b/server/routers/end_frames.py
@@ -54,7 +54,8 @@ def _translated_errors(script_file: str, _t: Translator) -> Iterator[None]:
         # 不回传 str(exc)：load_script 的异常信息含服务器绝对路径
         raise NotFoundError("script_not_found", name=script_file) from exc
     except ScriptEditError as e:
-        raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=str(e)))
+        # reason 经 e.key/e.params 按请求语言翻译，不直接嵌 str(e)（固定中文，会混入 en/vi 响应）
+        raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=_t(e.key, **e.params)))
     except (HTTPException, ApiError):
         raise
     except Exception as e:

--- a/server/routers/end_frames.py
+++ b/server/routers/end_frames.py
@@ -21,6 +21,7 @@ from lib.api_errors import ApiError, NotFoundError
 from lib.i18n import Translator
 from lib.script_editor import ScriptEditError
 from server.auth import CurrentUser
+from server.error_handlers import script_edit_detail
 from server.services.end_frame import (
     EndFrameError,
     clear_end_frame,
@@ -54,8 +55,7 @@ def _translated_errors(script_file: str, _t: Translator) -> Iterator[None]:
         # 不回传 str(exc)：load_script 的异常信息含服务器绝对路径
         raise NotFoundError("script_not_found", name=script_file) from exc
     except ScriptEditError as e:
-        # reason 经 e.key/e.params 按请求语言翻译，不直接嵌 str(e)（固定中文，会混入 en/vi 响应）
-        raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=_t(e.key, **e.params)))
+        raise HTTPException(status_code=400, detail=script_edit_detail(e, _t))
     except (HTTPException, ApiError):
         raise
     except Exception as e:

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -33,6 +33,7 @@ from lib.resource_paths import resource_relative_path
 from lib.script_editor import ScriptEditError
 from lib.version_manager import VersionManager
 from server.auth import CurrentUser
+from server.error_handlers import script_edit_detail
 from server.routers._reorder import full_permutation_error
 from server.services.generation_tasks import emit_generation_success_batch
 from server.services.reference_video_tasks import _finalize_reference_video_unit, resolve_max_unit_duration
@@ -541,10 +542,7 @@ async def upload_unit_video(
         # finalize 写回时 unit 已被并发删除（落盘后绑定重查到锁内写回之间的窄竞态）
         raise HTTPException(status_code=404, detail=_t("ref_unit_not_found", unit_id=unit_id)) from exc
     except ScriptEditError as exc:
-        # reason 经 exc.key/exc.params 按请求语言翻译，不直接嵌 str(exc)（固定中文，会混入 en/vi 响应）
-        raise HTTPException(
-            status_code=400, detail=_t("script_data_corrupted", reason=_t(exc.key, **exc.params))
-        ) from exc
+        raise HTTPException(status_code=400, detail=script_edit_detail(exc, _t)) from exc
     except (HTTPException, ApiError):
         # ApiError 与 HTTPException 并列：_load_episode_script 抛出的 NotFoundError
         # 不是 HTTPException 子类，不并入这里会被下面的 except Exception 吞成 500

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -541,7 +541,10 @@ async def upload_unit_video(
         # finalize 写回时 unit 已被并发删除（落盘后绑定重查到锁内写回之间的窄竞态）
         raise HTTPException(status_code=404, detail=_t("ref_unit_not_found", unit_id=unit_id)) from exc
     except ScriptEditError as exc:
-        raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=str(exc))) from exc
+        # reason 经 exc.key/exc.params 按请求语言翻译，不直接嵌 str(exc)（固定中文，会混入 en/vi 响应）
+        raise HTTPException(
+            status_code=400, detail=_t("script_data_corrupted", reason=_t(exc.key, **exc.params))
+        ) from exc
     except (HTTPException, ApiError):
         # ApiError 与 HTTPException 并列：_load_episode_script 抛出的 NotFoundError
         # 不是 HTTPException 子类，不并入这里会被下面的 except Exception 吞成 500

--- a/server/routers/shot_uploads.py
+++ b/server/routers/shot_uploads.py
@@ -150,7 +150,8 @@ async def upload_shot_media(
     except KeyError:
         raise HTTPException(status_code=404, detail=_t("segment_not_found", id=shot_id))
     except ScriptEditError as e:
-        raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=str(e)))
+        # reason 经 e.key/e.params 按请求语言翻译，不直接嵌 str(e)（固定中文，会混入 en/vi 响应）
+        raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=_t(e.key, **e.params)))
     except (HTTPException, ApiError):
         raise
     except Exception as e:

--- a/server/routers/shot_uploads.py
+++ b/server/routers/shot_uploads.py
@@ -27,6 +27,7 @@ from lib.script_editor import ScriptEditError
 from lib.storyboard_sequence import find_storyboard_item, get_storyboard_items
 from lib.version_manager import VersionManager
 from server.auth import CurrentUser
+from server.error_handlers import script_edit_detail
 from server.services.generation_tasks import emit_generation_success_batch
 from server.services.upload_finalize import (
     UploadTooLargeError,
@@ -150,8 +151,7 @@ async def upload_shot_media(
     except KeyError:
         raise HTTPException(status_code=404, detail=_t("segment_not_found", id=shot_id))
     except ScriptEditError as e:
-        # reason 经 e.key/e.params 按请求语言翻译，不直接嵌 str(e)（固定中文，会混入 en/vi 响应）
-        raise HTTPException(status_code=400, detail=_t("script_data_corrupted", reason=_t(e.key, **e.params)))
+        raise HTTPException(status_code=400, detail=script_edit_detail(e, _t))
     except (HTTPException, ApiError):
         raise
     except Exception as e:

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -421,14 +421,14 @@ def apply_unit_video_assets(script: dict, resource_id: str, *, video_uri: str | 
     unit_lists = [script.get(key) for key in ("video_units", "reference_units")]
     candidates = [units for units in unit_lists if isinstance(units, list)]
     if not candidates:
-        raise ScriptEditError("video_units / reference_units 必须是 list")
+        raise ScriptEditError("video_units / reference_units 必须是 list", key="script_edit_unit_lists_invalid")
     for units in candidates:
         for u in units:
             if not isinstance(u, dict) or u.get("unit_id") != resource_id:
                 continue
             ga = u.setdefault("generated_assets", {})
             if not isinstance(ga, dict):
-                raise ScriptEditError("generated_assets 必须是 dict")
+                raise ScriptEditError("generated_assets 必须是 dict", key="script_edit_generated_assets_invalid")
             ga["video_clip"] = f"reference_videos/{resource_id}.mp4"
             if video_uri:
                 ga["video_uri"] = video_uri

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -877,21 +877,28 @@ async def test_execute_reference_video_task_rejects_unsupported_duration(
 
 
 def test_apply_unit_video_assets_distinguishes_failures():
-    """结构损坏与 unit 不存在抛不同异常：还原侧据此区分「脏脚本告警」与「正常跳过」。"""
+    """结构损坏与 unit 不存在抛不同异常：还原侧据此区分「脏脚本告警」与「正常跳过」。
+
+    结构损坏的两类异常会经 upload_unit_video 路由回传终端用户，故须带具体 i18n key
+    （默认兜底 key 会让 en/vi 用户只看到无信息的通用句）。
+    """
     from lib.script_editor import ScriptEditError
     from server.services.reference_video_tasks import apply_unit_video_assets
 
-    with pytest.raises(ScriptEditError):
+    with pytest.raises(ScriptEditError) as unit_lists_broken:
         apply_unit_video_assets({"video_units": "broken"}, "E1U1", video_uri=None, thumb_rel=None)
-    with pytest.raises(ScriptEditError):
+    assert unit_lists_broken.value.key == "script_edit_unit_lists_invalid"
+    with pytest.raises(ScriptEditError) as unit_lists_missing:
         apply_unit_video_assets({}, "E1U1", video_uri=None, thumb_rel=None)
-    with pytest.raises(ScriptEditError):
+    assert unit_lists_missing.value.key == "script_edit_unit_lists_invalid"
+    with pytest.raises(ScriptEditError) as assets_broken:
         apply_unit_video_assets(
             {"video_units": [{"unit_id": "E1U1", "generated_assets": "broken"}]},
             "E1U1",
             video_uri=None,
             thumb_rel=None,
         )
+    assert assets_broken.value.key == "script_edit_generated_assets_invalid"
     with pytest.raises(KeyError):
         apply_unit_video_assets({"video_units": []}, "E1U1", video_uri=None, thumb_rel=None)
 

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -39,6 +39,15 @@ def _make_client() -> TestClient:
     async def _script_edit_error():
         raise ScriptEditError("segments 必须是列表，当前为 NoneType")
 
+    @app.get("/script-edit-error-keyed")
+    async def _script_edit_error_keyed():
+        raise ScriptEditError(
+            "segments 必须是列表，当前为 NoneType",
+            key="script_edit_items_not_list",
+            kind="segments",
+            type_name="NoneType",
+        )
+
     @app.get("/file-not-found")
     async def _file_not_found():
         raise FileNotFoundError(f"剧本文件不存在: {_SERVER_PATH}")
@@ -94,6 +103,24 @@ class TestLibExceptionHandlers:
         resp = client.get("/script-edit-error")
         assert resp.status_code == 400
         assert "损坏" in resp.json()["detail"]
+
+    def test_script_edit_error_keyed_reason_translated_en(self):
+        """带 key/params 的 ScriptEditError（如 resolve_items 抛出的那种）en 请求下，
+        reason 须按英文翻译，不得混入中文原文（issue #1353）。"""
+        client = _make_client()
+        resp = client.get("/script-edit-error-keyed", headers={"Accept-Language": "en"})
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert detail == "Script data is corrupted: segments must be a list, but got NoneType"
+        assert not any("一" <= ch <= "鿿" for ch in detail)
+
+    def test_script_edit_error_keyed_reason_translated_vi(self):
+        client = _make_client()
+        resp = client.get("/script-edit-error-keyed", headers={"Accept-Language": "vi"})
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert detail == "Dữ liệu kịch bản bị hỏng: segments phải là một danh sách, nhưng nhận được NoneType"
+        assert not any("一" <= ch <= "鿿" for ch in detail)
 
     def test_file_not_found_404_hides_server_path(self):
         client = _make_client()

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -106,7 +106,7 @@ class TestLibExceptionHandlers:
 
     def test_script_edit_error_keyed_reason_translated_en(self):
         """带 key/params 的 ScriptEditError（如 resolve_items 抛出的那种）en 请求下，
-        reason 须按英文翻译，不得混入中文原文（issue #1353）。"""
+        reason 须按英文翻译，不得混入中文原文。"""
         client = _make_client()
         resp = client.get("/script-edit-error-keyed", headers={"Accept-Language": "en"})
         assert resp.status_code == 400

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -3,6 +3,7 @@
 import tempfile
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -104,6 +105,7 @@ class TestLibExceptionHandlers:
         assert resp.status_code == 400
         assert "损坏" in resp.json()["detail"]
 
+    @pytest.mark.integration
     def test_script_edit_error_keyed_reason_translated_en(self):
         """带 key/params 的 ScriptEditError（如 resolve_items 抛出的那种）en 请求下，
         reason 须按英文翻译，不得混入中文原文。"""
@@ -114,6 +116,7 @@ class TestLibExceptionHandlers:
         assert detail == "Script data is corrupted: segments must be a list, but got NoneType"
         assert not any("一" <= ch <= "鿿" for ch in detail)
 
+    @pytest.mark.integration
     def test_script_edit_error_keyed_reason_translated_vi(self):
         client = _make_client()
         resp = client.get("/script-edit-error-keyed", headers={"Accept-Language": "vi"})

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -543,22 +543,49 @@ class TestGenerationWorker:
         assert queue.failed and queue.failed[0][0] == "t2"
 
     @pytest.mark.asyncio
-    async def test_process_task_script_edit_error_encodes_key_not_chinese_str(self, monkeypatch):
+    async def test_process_task_script_edit_error_encodes_key_and_params(self, monkeypatch):
         """apply_unit_video_assets 经异步任务队列（非 upload_unit_video 同步路由）抛出时，
-        error_message 落成可翻译的 [key] 结构而非 str(exc) 的固定中文，任务状态接口按
-        Accept-Language 渲染时才不会给 en/vi 用户漏出中文。"""
+        error_message 落成可翻译的 [key] {params} 结构而非 str(exc) 的固定中文，任务状态
+        接口按 Accept-Language 渲染时才不会给 en/vi 用户漏出中文；params 一并落库才能在
+        渲染侧还原成完整的翻译占位符替换（如 resolve_items 的 kind/type_name）。"""
         queue = _FakeQueue()
         worker = GenerationWorker(queue=queue)
 
         async def _raise_script_edit_error(_task):
-            raise ScriptEditError("generated_assets 必须是 dict", key="script_edit_generated_assets_invalid")
+            raise ScriptEditError(
+                "segments 必须是列表，当前为 dict",
+                key="script_edit_items_not_list",
+                kind="segments",
+                type_name="dict",
+            )
 
         monkeypatch.setattr(
             "server.services.generation_tasks.execute_generation_task",
             _raise_script_edit_error,
         )
         await worker._process_task({"task_id": "t_script_edit"})
-        assert queue.failed and queue.failed[0] == ("t_script_edit", "[script_edit_generated_assets_invalid]")
+        assert queue.failed and queue.failed[0] == (
+            "t_script_edit",
+            '[script_edit_items_not_list] {"kind": "segments", "type_name": "dict"}',
+        )
+
+    @pytest.mark.asyncio
+    async def test_process_task_script_edit_error_unregistered_key_falls_back(self, monkeypatch):
+        """两份登记（errors.py 的翻译 key、task_failure.FAILURE_CODE_KEYS 的 worker 编码表）
+        靠约定同步，非运行时校验——新 raise 点忘了同步登记时，encode_failure 对未登记 key
+        抛 KeyError 不能打断 mark_task_failed，否则任务会卡在 running 而非落终态。"""
+        queue = _FakeQueue()
+        worker = GenerationWorker(queue=queue)
+
+        async def _raise_unregistered(_task):
+            raise ScriptEditError("尚未登记的错误", key="script_edit_not_yet_registered")
+
+        monkeypatch.setattr(
+            "server.services.generation_tasks.execute_generation_task",
+            _raise_unregistered,
+        )
+        await worker._process_task({"task_id": "t_unregistered"})
+        assert queue.failed and queue.failed[0] == ("t_unregistered", "[script_edit_error]")
 
     @pytest.mark.asyncio
     async def test_process_task_cancelled_error_marks_cancelled(self, monkeypatch):

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -1512,6 +1512,33 @@ class TestGenerationWorker:
         assert not queue.failed[0][1].startswith("[resume_")
 
     @pytest.mark.asyncio
+    async def test_process_resume_task_script_edit_error_encodes_key(self, monkeypatch):
+        """resume_executor 复用 _finalize_reference_video_unit 等 finalize helper，同样会抛
+        ScriptEditError；resume 路径与常规 _process_task 走同一份 _encode_task_failure_message，
+        不能因为是重启自愈这条独立调用链就退回 str(exc) 的固定中文。"""
+        queue = _FakeQueue()
+        worker = GenerationWorker(queue=queue)
+
+        async def _raise_script_edit_error(_task, *, job_id):
+            raise ScriptEditError("generated_assets 必须是 dict", key="script_edit_generated_assets_invalid")
+
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _raise_script_edit_error)
+        task = {
+            "task_id": "resume_script_edit",
+            "task_type": "reference_video",
+            "media_type": "video",
+            "provider_id": "ark",
+            "provider_job_id": "x",
+            "payload": {},
+            "project_name": "demo",
+        }
+        await worker._process_resume_task(task)
+        assert queue.failed and queue.failed[0] == (
+            "resume_script_edit",
+            "[script_edit_generated_assets_invalid]",
+        )
+
+    @pytest.mark.asyncio
     async def test_process_resume_task_cancelled_error(self, monkeypatch):
         """CancelledError → mark_cancelled + 重新抛出。"""
         queue = _FakeQueue()

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -14,6 +14,7 @@ from lib.generation_worker import (
     _extract_provider,
     _read_int_env,
 )
+from lib.script_editor import ScriptEditError
 
 
 def _cap(limits: dict[str, dict[str, int]] | None = None, *, image: int = 5, video: int = 3) -> CapacityTable:
@@ -540,6 +541,24 @@ class TestGenerationWorker:
         monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _raise)
         await worker._process_task({"task_id": "t2"})
         assert queue.failed and queue.failed[0][0] == "t2"
+
+    @pytest.mark.asyncio
+    async def test_process_task_script_edit_error_encodes_key_not_chinese_str(self, monkeypatch):
+        """apply_unit_video_assets 经异步任务队列（非 upload_unit_video 同步路由）抛出时，
+        error_message 落成可翻译的 [key] 结构而非 str(exc) 的固定中文，任务状态接口按
+        Accept-Language 渲染时才不会给 en/vi 用户漏出中文。"""
+        queue = _FakeQueue()
+        worker = GenerationWorker(queue=queue)
+
+        async def _raise_script_edit_error(_task):
+            raise ScriptEditError("generated_assets 必须是 dict", key="script_edit_generated_assets_invalid")
+
+        monkeypatch.setattr(
+            "server.services.generation_tasks.execute_generation_task",
+            _raise_script_edit_error,
+        )
+        await worker._process_task({"task_id": "t_script_edit"})
+        assert queue.failed and queue.failed[0] == ("t_script_edit", "[script_edit_generated_assets_invalid]")
 
     @pytest.mark.asyncio
     async def test_process_task_cancelled_error_marks_cancelled(self, monkeypatch):

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -588,6 +588,29 @@ class TestGenerationWorker:
         assert queue.failed and queue.failed[0] == ("t_unregistered", "[script_edit_error]")
 
     @pytest.mark.asyncio
+    async def test_process_task_script_edit_error_circular_params_falls_back(self, monkeypatch):
+        """params 含循环引用时 json.dumps 抛 ValueError（而非 TypeError）——同一条降级路径
+        也要接住这个分支，否则序列化失败照样打断 mark_task_failed，任务卡在 running。"""
+        queue = _FakeQueue()
+        worker = GenerationWorker(queue=queue)
+
+        async def _raise_circular_params(_task):
+            circular: dict[str, Any] = {}
+            circular["self"] = circular
+            raise ScriptEditError(
+                "generated_assets 必须是 dict",
+                key="script_edit_generated_assets_invalid",
+                circular=circular,
+            )
+
+        monkeypatch.setattr(
+            "server.services.generation_tasks.execute_generation_task",
+            _raise_circular_params,
+        )
+        await worker._process_task({"task_id": "t_circular"})
+        assert queue.failed and queue.failed[0] == ("t_circular", "[script_edit_error]")
+
+    @pytest.mark.asyncio
     async def test_process_task_cancelled_error_marks_cancelled(self, monkeypatch):
         """ADR 0006: asyncio.CancelledError 走 finally → mark_cancelled。"""
         queue = _FakeQueue()

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -542,6 +542,7 @@ class TestGenerationWorker:
         await worker._process_task({"task_id": "t2"})
         assert queue.failed and queue.failed[0][0] == "t2"
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_process_task_script_edit_error_encodes_key_and_params(self, monkeypatch):
         """apply_unit_video_assets 经异步任务队列（非 upload_unit_video 同步路由）抛出时，
@@ -569,6 +570,7 @@ class TestGenerationWorker:
             '[script_edit_items_not_list] {"kind": "segments", "type_name": "dict"}',
         )
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_process_task_script_edit_error_unregistered_key_falls_back(self, monkeypatch):
         """两份登记（errors.py 的翻译 key、task_failure.FAILURE_CODE_KEYS 的 worker 编码表）
@@ -587,6 +589,7 @@ class TestGenerationWorker:
         await worker._process_task({"task_id": "t_unregistered"})
         assert queue.failed and queue.failed[0] == ("t_unregistered", "[script_edit_error]")
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_process_task_script_edit_error_circular_params_falls_back(self, monkeypatch):
         """params 含循环引用时 json.dumps 抛 ValueError（而非 TypeError）——同一条降级路径
@@ -1511,6 +1514,7 @@ class TestGenerationWorker:
         # 无 [resume_*] 前缀
         assert not queue.failed[0][1].startswith("[resume_")
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_process_resume_task_script_edit_error_encodes_key(self, monkeypatch):
         """resume_executor 复用 _finalize_reference_video_unit 等 finalize helper，同样会抛


### PR DESCRIPTION
Closes #1353

## 变更

`ScriptEditError` 改为携带 i18n key 与参数，用户可达的抛出点各带具体 key，由服务端按请求 `Accept-Language` 渲染，不再把固定中文的 `str(exc)` 嵌进已翻译的响应模板。

- `lib/script_editor.py` — `ScriptEditError` 增加 `key`/`params`；`resolve_items` 的「分镜数组键损坏」带 `script_edit_items_not_list` + `kind`/`type_name`
- `server/services/reference_video_tasks.py` — `apply_unit_video_assets` 的两处结构损坏（unit 列表非 list、`generated_assets` 非 dict）也经 `upload_unit_video` 路由回传用户，各带专属 key
- `lib/i18n/{zh,en,vi}/errors.py` — 补四个 key（一个通用兜底 + 三个具体场景），三语齐全
- `server/error_handlers.py` — 新增 `script_edit_detail(exc, _t)`，全局 handler 与三个自捕获路由（`end_frames` / `shot_uploads` / `reference_videos`）共用这一处映射

仅被 MCP 工具与日志消费的抛出点（`patch_field` / `insert_segment` / `remove_segment` / `split_segment` 及 `sdk_tools/patch_script.py`）沿用默认 key，按 CLAUDE.md 的 agent-facing 豁免边界不接翻译。该边界经逐个抛出点核对调用链确认：这些函数无任何 HTTP 路由入口。

## 验证

- 新增 `tests/test_error_handlers.py` 两条用例：en / vi 请求下响应逐字匹配目标语言且断言无中文字符
- `tests/server/test_reference_video_tasks.py` 补断言：结构损坏的两类异常各带对应 key
- `uv run ruff check .` 通过；`uv run basedpyright` 0 error；`uv run python -m pytest` 6524 passed（含 `tests/test_i18n_consistency.py` 三语一致性）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误提示**
  * 优化剧本编辑校验失败报错：新增结构化错误分类（如输入类型/单位列表/生成资产结构不符合预期），并补齐英文、越南文与中文本地化文案。
* **错误处理**
  * 统一将脚本编辑类错误转换为可翻译、带参数的返回详情；任务失败编码根据已登记错误码渲染本地化内容，失败时支持回退策略。
* **测试**
  * 扩展多语言与脚本数据异常场景断言，校验错误 key 及翻译后的 detail/失败消息格式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->