### PR TITLE
fix(video): 尾帧选图器移除角色与场景分组

### DIFF
--- a/frontend/src/components/canvas/timeline/EndFramePicker.test.tsx
+++ b/frontend/src/components/canvas/timeline/EndFramePicker.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { API } from "@/api";
 import { useProjectsStore } from "@/stores/projects-store";
-import type { EpisodeScript } from "@/types";
+import type { EpisodeScript, ProjectData } from "@/types";
 import type { GridGeneration } from "@/types/grid";
 import { EndFramePicker } from "./EndFramePicker";
 
@@ -89,6 +89,10 @@ beforeEach(() => {
   useProjectsStore.setState({
     currentProjectName: PROJECT,
     currentScripts: { [SCRIPT]: script },
+    currentProjectData: {
+      characters: { 张三: { description: "", character_sheet: "characters/zhangsan.png" } },
+      scenes: { 客厅: { description: "", scene_sheet: "scenes/living_room.png" } },
+    } as unknown as ProjectData,
   });
 });
 
@@ -99,13 +103,17 @@ afterEach(() => {
 
 describe("EndFramePicker 项目内通道", () => {
   it("按来源分组：本集分镜图 / 本集宫格切图", async () => {
-    const { findByText, getByText, queryByRole } = renderPicker();
+    const { findByText, getByText, queryByRole, queryByText } = renderPicker();
 
     await findByText("本集宫格切图");
     expect(getByText("本集分镜图")).toBeInTheDocument();
 
     // 无分镜图的镜头不出现
     expect(queryByRole("button", { name: /镜头 E1S02/ })).toBeNull();
+
+    // 角色/场景分组已移除：即使 currentProjectData 里有对应素材也不展示
+    expect(queryByText("角色")).toBeNull();
+    expect(queryByText("场景")).toBeNull();
   });
 
   it("宫格切图只取本集、且跳过未切出图的格子", async () => {

--- a/frontend/src/components/canvas/timeline/EndFramePicker.test.tsx
+++ b/frontend/src/components/canvas/timeline/EndFramePicker.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { API } from "@/api";
 import { useProjectsStore } from "@/stores/projects-store";
-import type { EpisodeScript, ProjectData } from "@/types";
+import type { EpisodeScript } from "@/types";
 import type { GridGeneration } from "@/types/grid";
 import { EndFramePicker } from "./EndFramePicker";
 
@@ -24,12 +24,6 @@ const script = {
     { segment_id: "E1S02", novel_text: "", image_prompt: "", video_prompt: "" },
   ],
 } as unknown as EpisodeScript;
-
-const projectData = {
-  characters: { 阿澈: { character_sheet: "characters/achr.png" } },
-  scenes: { 长街: { scene_sheet: "scenes/street.png" } },
-  props: { 铜镜: { prop_sheet: "props/mirror.png" } },
-} as unknown as ProjectData;
 
 function grid(scriptFile: string, cellPath: string): GridGeneration {
   return {
@@ -94,7 +88,6 @@ beforeEach(() => {
   ]);
   useProjectsStore.setState({
     currentProjectName: PROJECT,
-    currentProjectData: projectData,
     currentScripts: { [SCRIPT]: script },
   });
 });
@@ -105,13 +98,11 @@ afterEach(() => {
 });
 
 describe("EndFramePicker 项目内通道", () => {
-  it("按来源分组：本集分镜图 / 角色 / 场景 / 本集宫格切图", async () => {
+  it("按来源分组：本集分镜图 / 本集宫格切图", async () => {
     const { findByText, getByText, queryByRole } = renderPicker();
 
     await findByText("本集宫格切图");
     expect(getByText("本集分镜图")).toBeInTheDocument();
-    expect(getByText("角色")).toBeInTheDocument();
-    expect(getByText("场景")).toBeInTheDocument();
 
     // 无分镜图的镜头不出现
     expect(queryByRole("button", { name: /镜头 E1S02/ })).toBeNull();

--- a/frontend/src/components/canvas/timeline/EndFramePicker.tsx
+++ b/frontend/src/components/canvas/timeline/EndFramePicker.tsx
@@ -9,7 +9,6 @@ import { PrimaryButton } from "@/components/ui/PrimaryButton";
 import { SecondaryButton } from "@/components/ui/SecondaryButton";
 import { UPLOAD_IMAGE_ACCEPT } from "@/components/ui/UploadIconButton";
 import { useProjectsStore } from "@/stores/projects-store";
-import { SHEET_FIELD } from "@/types/reference-video";
 import { getScriptItems, getScriptItemId, type EditorContentMode } from "@/utils/script-shape";
 import { stripScriptsPrefix } from "@/utils/task-target";
 
@@ -44,7 +43,7 @@ interface EndFramePickerProps {
 /**
  * 尾帧选图器：单选，两条通道同一落点。
  *
- * 通道一是项目内图片按来源分组平铺（本集分镜图 / 角色 / 场景 / 本集宫格切图），
+ * 通道一是项目内图片按来源分组平铺（本集分镜图 / 本集宫格切图），
  * 选定后走 `/end-frame/select` 按相对路径快照复制；通道二是 header 的上传入口，
  * 走 `/end-frame/upload`。两者都不建立对源图的引用，源图后续变动不影响尾帧。
  */
@@ -66,7 +65,6 @@ export function EndFramePicker({
   const fileRef = useRef<HTMLInputElement>(null);
 
   const script = useProjectsStore((s) => s.currentScripts[scriptFile]);
-  const projectData = useProjectsStore((s) => s.currentProjectData);
   const [gridImages, setGridImages] = useState<PickableImage[]>([]);
 
   // 宫格切图不在 store 里，弹窗打开时拉一次。取消走 AbortSignal：
@@ -115,35 +113,11 @@ export function EndFramePicker({
         };
       });
 
-    const assetGroup = (
-      kind: "character" | "scene",
-      dict: Record<string, Record<string, unknown>> | undefined,
-    ): PickableImage[] =>
-      Object.entries(dict ?? {})
-        .map(([name, asset]) => ({ name, sheet: asset[SHEET_FIELD[kind]] }))
-        .filter((row): row is { name: string; sheet: string } => typeof row.sheet === "string")
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map((row) => ({ path: row.sheet, label: row.name }));
-
     return [
       { title: t("end_frame_picker_group_storyboards"), images: storyboards },
-      {
-        title: t("end_frame_picker_group_characters"),
-        images: assetGroup(
-          "character",
-          projectData?.characters as Record<string, Record<string, unknown>> | undefined,
-        ),
-      },
-      {
-        title: t("end_frame_picker_group_scenes"),
-        images: assetGroup(
-          "scene",
-          projectData?.scenes as Record<string, Record<string, unknown>> | undefined,
-        ),
-      },
       { title: t("end_frame_picker_group_grid_cells"), images: gridImages },
     ].filter((g) => g.images.length > 0);
-  }, [script, contentMode, projectData, gridImages, t]);
+  }, [script, contentMode, gridImages, t]);
 
   return (
     <GlassModal

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1526,7 +1526,7 @@ export default {
   'end_frame_picker_submitting': 'Setting\u2026',
   'end_frame_picker_hint': 'Pick an image from this project, or upload your own.',
   'end_frame_picker_selected': 'Selected: {{label}}',
-  'end_frame_picker_empty': 'No images in this project yet. Upload one instead.',
+  'end_frame_picker_empty': 'No storyboard or grid images for this episode yet. Upload one instead.',
   'end_frame_picker_group_storyboards': 'Storyboards in this episode',
   'end_frame_picker_group_grid_cells': 'Grid cells in this episode',
   'end_frame_picker_storyboard_label': 'Shot {{id}}',

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1528,8 +1528,6 @@ export default {
   'end_frame_picker_selected': 'Selected: {{label}}',
   'end_frame_picker_empty': 'No images in this project yet. Upload one instead.',
   'end_frame_picker_group_storyboards': 'Storyboards in this episode',
-  'end_frame_picker_group_characters': 'Characters',
-  'end_frame_picker_group_scenes': 'Scenes',
   'end_frame_picker_group_grid_cells': 'Grid cells in this episode',
   'end_frame_picker_storyboard_label': 'Shot {{id}}',
   'end_frame_picker_grid_cell_label': '{{grid}} cell {{index}}',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1522,7 +1522,7 @@ export default {
   'end_frame_picker_submitting': 'Đang đặt\u2026',
   'end_frame_picker_hint': 'Chọn một ảnh trong dự án này, hoặc tải ảnh của bạn lên.',
   'end_frame_picker_selected': 'Đã chọn: {{label}}',
-  'end_frame_picker_empty': 'Dự án này chưa có ảnh nào. Bạn có thể tải lên một ảnh.',
+  'end_frame_picker_empty': 'Tập này chưa có ảnh phân cảnh hoặc ảnh cắt lưới nào. Bạn có thể tải lên một ảnh.',
   'end_frame_picker_group_storyboards': 'Ảnh storyboard của tập này',
   'end_frame_picker_group_grid_cells': 'Ô lưới của tập này',
   'end_frame_picker_storyboard_label': 'Cảnh {{id}}',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1524,8 +1524,6 @@ export default {
   'end_frame_picker_selected': 'Đã chọn: {{label}}',
   'end_frame_picker_empty': 'Dự án này chưa có ảnh nào. Bạn có thể tải lên một ảnh.',
   'end_frame_picker_group_storyboards': 'Ảnh storyboard của tập này',
-  'end_frame_picker_group_characters': 'Nhân vật',
-  'end_frame_picker_group_scenes': 'Bối cảnh',
   'end_frame_picker_group_grid_cells': 'Ô lưới của tập này',
   'end_frame_picker_storyboard_label': 'Cảnh {{id}}',
   'end_frame_picker_grid_cell_label': '{{grid}} ô {{index}}',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1528,8 +1528,6 @@ export default {
   'end_frame_picker_selected': '已选：{{label}}',
   'end_frame_picker_empty': '本项目还没有图片，可以直接上传一张。',
   'end_frame_picker_group_storyboards': '本集分镜图',
-  'end_frame_picker_group_characters': '角色',
-  'end_frame_picker_group_scenes': '场景',
   'end_frame_picker_group_grid_cells': '本集宫格切图',
   'end_frame_picker_storyboard_label': '镜头 {{id}}',
   'end_frame_picker_grid_cell_label': '{{grid}} 第 {{index}} 格',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1526,7 +1526,7 @@ export default {
   'end_frame_picker_submitting': '设置中\u2026',
   'end_frame_picker_hint': '从本项目中选一张图片，或上传自己的图片。',
   'end_frame_picker_selected': '已选：{{label}}',
-  'end_frame_picker_empty': '本项目还没有图片，可以直接上传一张。',
+  'end_frame_picker_empty': '本集暂无可选的分镜图或宫格切图，可以直接上传一张。',
   'end_frame_picker_group_storyboards': '本集分镜图',
   'end_frame_picker_group_grid_cells': '本集宫格切图',
   'end_frame_picker_storyboard_label': '镜头 {{id}}',


### PR DESCRIPTION
Closes #1357

尾帧选图器的项目内来源收窄为镜头画面类图片：只保留「本集分镜图」与「本集宫格切图」两组，移除「角色」「场景」两组。角色/场景的资产定妆图不是镜头画面，作为视频尾帧无实际意义。上传通道不变，用户仍可上传任意图片作尾帧。

## 改动范围

- `EndFramePicker.tsx`：移除 `assetGroup` 辅助函数、`SHEET_FIELD` 导入与 `currentProjectData` store 订阅（三者仅为角色/场景两组服务），`useMemo` 依赖数组同步收缩；组件 docstring 更新为新的分组列表
- `frontend/src/i18n/{zh,en,vi}/dashboard.ts`：删除 `end_frame_picker_group_characters` / `end_frame_picker_group_scenes` 两个 key
- `EndFramePicker.test.tsx`：移除角色/场景分组的 mock 数据与断言，其余行为断言保留

## 验证

- `pnpm lint`、`pnpm check`（typecheck + lint + vitest）全绿：128 个测试文件 / 1254 个测试通过
- 孤儿 key 核对：两个被删 key 全仓零引用；剩余 12 个 `end_frame_picker_*` key 逐条确认仍有使用点；三语 key 集合无漂移
- 悬空引用核对：`SHEET_FIELD` 与 `currentProjectData` 在其他组件仍在使用，本次仅移除本文件的引用，未误删定义
- 上传通道核对：`fileRef` / `onPickUpload` / `UPLOAD_IMAGE_ACCEPT` 及 header 上传入口均未进入 diff，行为不变

## 本地审查

`/code-review origin/main` 两轴（Standards / Spec）各零 finding，未做修复性改动。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 尾帧选择器现按“本集分镜图”和“本集宫格切图”分组展示素材。
  - 新增宫格切图分组及对应的来源标签。

- **改进**
  - 移除角色与场景素材分组，简化素材选择界面。
  - 同步更新英文、中文和越南文界面文案。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->