### PR TITLE
fix(video): 尾帧选图超限改用专属文案，非法剧本文件与选图超限统一返回 400

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -188,6 +188,7 @@ MESSAGES = {
     "invalid_resource_id": "Invalid resource ID: {resource_id}",
     "invalid_end_frame_source": "End frame source path is invalid or outside the project directory: {path}",
     "end_frame_source_not_found": "End frame source image not found: {path}",
+    "end_frame_source_too_large": "End frame image exceeds the size limit ({max_mb} MB): {path}",
     "end_frame_reference_video_unsupported": "Reference video mode has no start/end frame concept; setting an end frame is not supported",
     # Reference Video
     "ref_missing_asset": "Reference to {type} '{name}' is not in the project asset library, please generate it first",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -188,6 +188,7 @@ MESSAGES = {
     "invalid_resource_id": "ID tài nguyên không hợp lệ: {resource_id}",
     "invalid_end_frame_source": "Đường dẫn ảnh nguồn cho khung hình cuối không hợp lệ hoặc nằm ngoài thư mục dự án: {path}",
     "end_frame_source_not_found": "Không tìm thấy ảnh nguồn cho khung hình cuối: {path}",
+    "end_frame_source_too_large": "Ảnh khung hình cuối vượt quá giới hạn dung lượng ({max_mb} MB): {path}",
     "end_frame_reference_video_unsupported": "Chế độ video tham chiếu không có khái niệm khung hình đầu/cuối, không hỗ trợ đặt khung hình cuối",
     # Reference Video
     "ref_missing_asset": "Tham chiếu đến {type} '{name}' không có trong thư viện tài nguyên dự án, vui lòng tạo trước",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -178,6 +178,7 @@ MESSAGES = {
     "invalid_resource_id": "非法的资源 ID: {resource_id}",
     "invalid_end_frame_source": "尾帧来源路径非法或越出项目目录: {path}",
     "end_frame_source_not_found": "尾帧来源图片不存在: {path}",
+    "end_frame_source_too_large": "尾帧图超过大小上限（{max_mb} MB）: {path}",
     "end_frame_reference_video_unsupported": "参考生视频模式下镜头无首尾帧概念，不支持设置尾帧",
     # Reference Video
     "ref_missing_asset": "参考图引用的{type}「{name}」不在项目资产库中，请先生成",

--- a/lib/json_io.py
+++ b/lib/json_io.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +15,34 @@ def load_json(path: Path) -> Any:
     """严格加载 JSON。异常直接抛出，调用方按业务需要做 try/except。"""
     with open(path, encoding="utf-8") as handle:
         return json.load(handle)
+
+
+@contextmanager
+def domain_error_on_value_error(
+    factory: Callable[[ValueError], BaseException],
+    *,
+    on_json_decode_error: Callable[[json.JSONDecodeError], None] | None = None,
+    extra_passthrough: tuple[type[BaseException], ...] = (),
+) -> Iterator[None]:
+    """把业务解析调用抛出的 ``ValueError`` 转换为调用方指定的领域错误。
+
+    ``json.JSONDecodeError`` 是 ``ValueError`` 子类，须先于通用 ``ValueError`` 分支放行——
+    它代表 JSON 文件本身损坏（语法错误），与业务级非法值（如路径穿越、非法项目名）语义不同，
+    不能被误判为后者、进而返回一个误导性的 4xx。`on_json_decode_error` 用于放行前追加调用方
+    特有的副作用（如记录更具体的日志、直接改抛专属的 HTTP 响应）；不传则原样重新抛出。
+    `extra_passthrough` 追加调用方需要按同一理由豁免的其它 ``ValueError`` 子类（如读取非
+    UTF-8 剧本文件时的 ``UnicodeDecodeError``）。
+    """
+    try:
+        yield
+    except json.JSONDecodeError as exc:
+        if on_json_decode_error is not None:
+            on_json_decode_error(exc)
+        raise
+    except extra_passthrough:
+        raise
+    except ValueError as exc:
+        raise factory(exc) from exc
 
 
 def load_json_or_none(path: Path) -> Any | None:

--- a/lib/json_io.py
+++ b/lib/json_io.py
@@ -21,25 +21,19 @@ def load_json(path: Path) -> Any:
 def domain_error_on_value_error(
     factory: Callable[[ValueError], BaseException],
     *,
-    on_json_decode_error: Callable[[json.JSONDecodeError], None] | None = None,
     extra_passthrough: tuple[type[BaseException], ...] = (),
 ) -> Iterator[None]:
     """把业务解析调用抛出的 ``ValueError`` 转换为调用方指定的领域错误。
 
     ``json.JSONDecodeError`` 是 ``ValueError`` 子类，须先于通用 ``ValueError`` 分支放行——
     它代表 JSON 文件本身损坏（语法错误），与业务级非法值（如路径穿越、非法项目名）语义不同，
-    不能被误判为后者、进而返回一个误导性的 4xx。`on_json_decode_error` 用于放行前追加调用方
-    特有的副作用（如记录更具体的日志、直接改抛专属的 HTTP 响应）；不传则原样重新抛出。
+    不能被误判为后者、进而返回一个误导性的 4xx。放行后由调用方外层自行收口。
     `extra_passthrough` 追加调用方需要按同一理由豁免的其它 ``ValueError`` 子类（如读取非
-    UTF-8 剧本文件时的 ``UnicodeDecodeError``）。
+    UTF-8 剧本文件时的 ``UnicodeDecodeError``，或调用方另有专属分支处理的领域异常）。
     """
     try:
         yield
-    except json.JSONDecodeError as exc:
-        if on_json_decode_error is not None:
-            on_json_decode_error(exc)
-        raise
-    except extra_passthrough:
+    except (json.JSONDecodeError, *extra_passthrough):
         raise
     except ValueError as exc:
         raise factory(exc) from exc

--- a/server/routers/grids.py
+++ b/server/routers/grids.py
@@ -7,19 +7,19 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-from lib.api_errors import ApiError, BadRequestError, NotFoundError
+from lib.api_errors import BadRequestError, NotFoundError
 from lib.generation_queue import get_generation_queue
 from lib.grid.layout import calculate_grid_layout
 from lib.grid.models import GridGeneration
 from lib.grid.prompt_builder import build_grid_prompt
 from lib.grid_manager import GridManager
 from lib.i18n import Translator
+from lib.json_io import domain_error_on_value_error
 from lib.project_manager import get_project_manager
 from lib.storyboard_sequence import get_storyboard_items, group_scenes_by_segment_break
 from server.auth import CurrentUser
@@ -88,28 +88,18 @@ async def generate_grid(
 
     立即返回 grid_ids 和 task_ids。生成由 GenerationWorker 异步执行。
     """
-    try:
+    # 非法项目名（路径穿越等）是坏请求，不是「不存在」；project.json 损坏（JSONDecodeError）
+    # 不能被误判为非法项目名，交由 app 级 catch-all 收口为通用 500
+    with domain_error_on_value_error(lambda exc: BadRequestError("invalid_project_name", name=project_name)):
         project = get_project_manager().load_project(project_name)
-    except json.JSONDecodeError:
-        # JSONDecodeError 是 ValueError 子类，须先于下面的 except ValueError 拦截：
-        # project.json 损坏时不能误判为「非法项目名」，交由 app 级 catch-all 收口为通用 500
-        raise
-    except ValueError as exc:
-        # 非法项目名（路径穿越等）是坏请求，不是「不存在」
-        raise BadRequestError("invalid_project_name", name=project_name) from exc
     # 广告/短片项目不开放宫格生视频（宫格单格分辨率与产品高保真目标冲突），
     # 写入边界（create/PATCH 拒 generation_mode=grid）之外在动作端点再设一道防线
     if project.get("content_mode") == "ad":
         raise BadRequestError("ad_grid_not_supported")
-    try:
+    # 路径穿越等非法 script_file 是坏请求，400 而非落入下方 500 兜底；剧本文件损坏
+    # （JSONDecodeError）不能被误判为非法 script_file，交由 app 级 catch-all 收口为通用 500
+    with domain_error_on_value_error(lambda exc: BadRequestError("invalid_script_file", name=req.script_file)):
         script = get_project_manager().load_script(project_name, req.script_file)
-    except json.JSONDecodeError:
-        # JSONDecodeError 是 ValueError 子类，须先于下面的 except ValueError 拦截：
-        # 剧本文件损坏不能误判为「非法 script_file」，交由 app 级 catch-all 收口为通用 500
-        raise
-    except ValueError as exc:
-        # 路径穿越等非法 script_file 是坏请求，422 而非落入下方 500 兜底
-        raise ApiError("invalid_script_file", status_code=422, name=req.script_file) from exc
     project_path = get_project_manager().get_project_path(project_name)
 
     items, id_field, _, _, _ = get_storyboard_items(script)
@@ -274,14 +264,9 @@ async def get_grid(project_name: str, grid_id: str, _user: CurrentUser):
 @router.post("/grids/{grid_id}/regenerate")
 async def regenerate_grid(project_name: str, grid_id: str, _user: CurrentUser):
     """重置宫格图状态并重新入队生成任务。"""
-    try:
+    # project.json 损坏（JSONDecodeError）不能被误判为非法项目名，交由 app 级 catch-all 收口为通用 500
+    with domain_error_on_value_error(lambda exc: BadRequestError("invalid_project_name", name=project_name)):
         project = get_project_manager().load_project(project_name)
-    except json.JSONDecodeError:
-        # JSONDecodeError 是 ValueError 子类，须先于下面的 except ValueError 拦截：
-        # project.json 损坏时不能误判为「非法项目名」，交由 app 级 catch-all 收口为通用 500
-        raise
-    except ValueError as exc:
-        raise BadRequestError("invalid_project_name", name=project_name) from exc
     # 广告/短片项目不开放宫格生视频：首次提交端点已封禁，重生成端点同样设防,
     # 否则残留的历史 grid 记录仍可被重新入队
     if project.get("content_mode") == "ad":

--- a/server/routers/grids.py
+++ b/server/routers/grids.py
@@ -90,7 +90,7 @@ async def generate_grid(
     """
     # 非法项目名（路径穿越等）是坏请求，不是「不存在」；project.json 损坏（JSONDecodeError）
     # 不能被误判为非法项目名，交由 app 级 catch-all 收口为通用 500
-    with domain_error_on_value_error(lambda exc: BadRequestError("invalid_project_name", name=project_name)):
+    with domain_error_on_value_error(lambda _exc: BadRequestError("invalid_project_name", name=project_name)):
         project = get_project_manager().load_project(project_name)
     # 广告/短片项目不开放宫格生视频（宫格单格分辨率与产品高保真目标冲突），
     # 写入边界（create/PATCH 拒 generation_mode=grid）之外在动作端点再设一道防线
@@ -98,7 +98,7 @@ async def generate_grid(
         raise BadRequestError("ad_grid_not_supported")
     # 路径穿越等非法 script_file 是坏请求，400 而非落入下方 500 兜底；剧本文件损坏
     # （JSONDecodeError）不能被误判为非法 script_file，交由 app 级 catch-all 收口为通用 500
-    with domain_error_on_value_error(lambda exc: BadRequestError("invalid_script_file", name=req.script_file)):
+    with domain_error_on_value_error(lambda _exc: BadRequestError("invalid_script_file", name=req.script_file)):
         script = get_project_manager().load_script(project_name, req.script_file)
     project_path = get_project_manager().get_project_path(project_name)
 
@@ -265,7 +265,7 @@ async def get_grid(project_name: str, grid_id: str, _user: CurrentUser):
 async def regenerate_grid(project_name: str, grid_id: str, _user: CurrentUser):
     """重置宫格图状态并重新入队生成任务。"""
     # project.json 损坏（JSONDecodeError）不能被误判为非法项目名，交由 app 级 catch-all 收口为通用 500
-    with domain_error_on_value_error(lambda exc: BadRequestError("invalid_project_name", name=project_name)):
+    with domain_error_on_value_error(lambda _exc: BadRequestError("invalid_project_name", name=project_name)):
         project = get_project_manager().load_project(project_name)
     # 广告/短片项目不开放宫格生视频：首次提交端点已封禁，重生成端点同样设防,
     # 否则残留的历史 grid 记录仍可被重新入队

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -1320,18 +1320,12 @@ async def generate_overview(name: str, _user: CurrentUser, _t: Translator):
         logger.warning("生成概述配置错误: name=%s (%s)", name, exc)
         return BadRequestError("text_provider_not_configured")
 
-    def _project_corrupted(exc: json.JSONDecodeError) -> None:
-        # 供应商解析链路内部会重新 load_project，project.json 损坏时不能误判为「未配置供应商」
-        logger.exception("生成概述失败：项目数据损坏 name=%s", name)
-        raise HTTPException(status_code=500, detail=_t("internal_server_error")) from exc
-
     try:
         with project_change_source("webui"):
             # EmptySourceError / PydanticValidationError 都是 ValueError 子类，须放行给下方各自的
             # 专属 except 分支，不能被这里的通用 ValueError 处理误判为「未配置供应商」
             with domain_error_on_value_error(
                 _provider_not_configured,
-                on_json_decode_error=_project_corrupted,
                 extra_passthrough=(EmptySourceError, PydanticValidationError),
             ):
                 overview = await get_project_manager().generate_overview(name)
@@ -1346,6 +1340,10 @@ async def generate_overview(name: str, _user: CurrentUser, _t: Translator):
     except EmptySourceError as e:
         logger.warning("生成概述参数错误: name=%s (%s)", name, e)
         raise BadRequestError("overview_source_empty") from e
+    except json.JSONDecodeError:
+        # 供应商解析链路内部会重新 load_project，project.json 损坏时不能误判为「未配置供应商」
+        logger.exception("生成概述失败：项目数据损坏 name=%s", name)
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
     except (HTTPException, ApiError):
         raise
     except Exception:

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -34,6 +34,7 @@ from lib.asset_fingerprints import compute_asset_fingerprints
 from lib.config.resolver import ConfigResolver
 from lib.db import async_session_factory
 from lib.i18n import Translator
+from lib.json_io import domain_error_on_value_error
 from lib.profile_manifest import ContentMode
 from lib.project_change_hints import project_change_source
 from lib.project_manager import EmptySourceError, EpisodeScriptReboundError, SourceKind, get_project_manager
@@ -1313,9 +1314,27 @@ async def generate_overview(name: str, _user: CurrentUser, _t: Translator):
     except Exception:
         logger.exception("请求处理失败")
         raise HTTPException(status_code=500, detail=_t("internal_server_error"))
+
+    def _provider_not_configured(exc: ValueError) -> BadRequestError:
+        # 非法项目名已由上方预校验拦截，此处均来自供应商解析链路（未配置/无可用供应商）；str(exc) 只进日志
+        logger.warning("生成概述配置错误: name=%s (%s)", name, exc)
+        return BadRequestError("text_provider_not_configured")
+
+    def _project_corrupted(exc: json.JSONDecodeError) -> None:
+        # 供应商解析链路内部会重新 load_project，project.json 损坏时不能误判为「未配置供应商」
+        logger.exception("生成概述失败：项目数据损坏 name=%s", name)
+        raise HTTPException(status_code=500, detail=_t("internal_server_error")) from exc
+
     try:
         with project_change_source("webui"):
-            overview = await get_project_manager().generate_overview(name)
+            # EmptySourceError / PydanticValidationError 都是 ValueError 子类，须放行给下方各自的
+            # 专属 except 分支，不能被这里的通用 ValueError 处理误判为「未配置供应商」
+            with domain_error_on_value_error(
+                _provider_not_configured,
+                on_json_decode_error=_project_corrupted,
+                extra_passthrough=(EmptySourceError, PydanticValidationError),
+            ):
+                overview = await get_project_manager().generate_overview(name)
         return {"success": True, "overview": overview}
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=name) from exc
@@ -1327,15 +1346,6 @@ async def generate_overview(name: str, _user: CurrentUser, _t: Translator):
     except EmptySourceError as e:
         logger.warning("生成概述参数错误: name=%s (%s)", name, e)
         raise BadRequestError("overview_source_empty") from e
-    except json.JSONDecodeError:
-        # JSONDecodeError 是 ValueError 子类，须先于下面的 except ValueError 拦截：
-        # 供应商解析链路内部会重新 load_project，project.json 损坏时不能误判为「未配置供应商」
-        logger.exception("生成概述失败：项目数据损坏 name=%s", name)
-        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
-    except ValueError as e:
-        # 非法项目名已由上方预校验拦截，此处均来自供应商解析链路（未配置/无可用供应商）；str(e) 只进日志
-        logger.warning("生成概述配置错误: name=%s (%s)", name, e)
-        raise BadRequestError("text_provider_not_configured") from e
     except (HTTPException, ApiError):
         raise
     except Exception:

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -112,7 +112,7 @@ def _locate_shot(project_name: str, script_file: str, shot_id: str) -> Path:
     # 剧本文件损坏（JSON 语法错误或非 UTF-8 字节）不能误判为「非法 script_file」，
     # 交由 _translated_errors 的兜底分支收口为 500
     with domain_error_on_value_error(
-        lambda exc: EndFrameError("invalid_script_file", status_code=400, name=script_file),
+        lambda _exc: EndFrameError("invalid_script_file", status_code=400, name=script_file),
         extra_passthrough=(UnicodeDecodeError,),
     ):
         script = manager.load_script(project_name, script_file)

--- a/server/services/end_frame.py
+++ b/server/services/end_frame.py
@@ -44,18 +44,18 @@ mid-flight 被删除而失败时跳过整段写回，不留半截状态。
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import threading
 from pathlib import Path
 
 from lib.image_utils import normalize_storyboard_upload
+from lib.json_io import domain_error_on_value_error
 from lib.path_safety import PathTraversalError, safe_join
 from lib.project_change_hints import project_change_source
 from lib.project_manager import ProjectManager, get_project_manager, is_reference_video_episode
 from lib.resource_paths import END_FRAME_RESOURCE_TYPE, resource_relative_path
 from lib.storyboard_sequence import find_storyboard_item, get_storyboard_items
-from server.services.upload_finalize import UPLOAD_IMAGE_MAX_BYTES, UploadTooLargeError, write_bytes_atomic
+from server.services.upload_finalize import UPLOAD_IMAGE_MAX_BYTES, write_bytes_atomic
 
 logger = logging.getLogger(__name__)
 
@@ -109,15 +109,13 @@ def _locate_shot(project_name: str, script_file: str, shot_id: str) -> Path:
     except ValueError as exc:
         raise EndFrameError("invalid_project_name", status_code=400, name=project_name) from exc
 
-    try:
+    # 剧本文件损坏（JSON 语法错误或非 UTF-8 字节）不能误判为「非法 script_file」，
+    # 交由 _translated_errors 的兜底分支收口为 500
+    with domain_error_on_value_error(
+        lambda exc: EndFrameError("invalid_script_file", status_code=400, name=script_file),
+        extra_passthrough=(UnicodeDecodeError,),
+    ):
         script = manager.load_script(project_name, script_file)
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        # 二者都是 ValueError 子类，须先于下面的 except ValueError 拦截：
-        # 剧本文件损坏（JSON 语法错误或非 UTF-8 字节）不能误判为「非法 script_file」，
-        # 交由 _translated_errors 的兜底分支收口为 500
-        raise
-    except ValueError as exc:
-        raise EndFrameError("invalid_script_file", status_code=400, name=script_file) from exc
 
     try:
         project = manager.load_project(project_name)
@@ -288,7 +286,9 @@ def read_project_image(project_path: Path, source_path: str) -> bytes:
     with resolved.open("rb") as f:
         content = f.read(UPLOAD_IMAGE_MAX_BYTES + 1)
     if len(content) > UPLOAD_IMAGE_MAX_BYTES:
-        raise UploadTooLargeError(UPLOAD_IMAGE_MAX_BYTES)
+        raise EndFrameError(
+            "end_frame_source_too_large", max_mb=UPLOAD_IMAGE_MAX_BYTES // (1024 * 1024), path=normalized
+        )
     return content
 
 

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -175,13 +175,17 @@ class TestSelectChannel:
         assert _select(c, "storyboards/scene_E1S99.png").status_code == 404
 
     def test_oversized_source_image_rejected(self, client, monkeypatch):
-        """项目内选图源超过上传通道同一上限时须拒绝（见 read_project_image）。"""
+        """项目内选图源超过上传通道同一上限时须拒绝（见 read_project_image）。
+
+        专属文案 + 400：选图请求体只是路径字符串，413（请求体过大）语义不适用，
+        与上传通道自身的 413 + upload_too_large 分流（见 test_shot_uploads_router）。
+        """
         c, pm = client
         monkeypatch.setattr(end_frame_service, "UPLOAD_IMAGE_MAX_BYTES", 16)
         _write_source_image(pm, "storyboards/scene_E1S02.png", _img_bytes("PNG", size=(64, 64)))
 
         resp = _select(c, "storyboards/scene_E1S02.png")
-        assert resp.status_code == 413
+        assert resp.status_code == 400
         assert _segment(pm).get("end_frame_image") is None
 
     def test_source_image_read_is_bounded(self, client, monkeypatch):
@@ -210,7 +214,7 @@ class TestSelectChannel:
 
         monkeypatch.setattr(Path, "open", lambda self, *a, **kw: _SpyHandle(real_open(self, *a, **kw)))
 
-        with pytest.raises(upload_finalize.UploadTooLargeError):
+        with pytest.raises(end_frame_service.EndFrameError):
             end_frame_service.read_project_image(project_path, "storyboards/scene_E1S02.png")
 
         assert read_sizes == [17]

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -186,6 +186,10 @@ class TestSelectChannel:
 
         resp = _select(c, "storyboards/scene_E1S02.png")
         assert resp.status_code == 400
+        # max_mb 由字节上限整除 1 MB 得出，本例上限被压到 16 字节故为 0
+        assert resp.json()["detail"] == i18n_message(
+            "end_frame_source_too_large", max_mb=0, path="storyboards/scene_E1S02.png"
+        )
         assert _segment(pm).get("end_frame_image") is None
 
     def test_source_image_read_is_bounded(self, client, monkeypatch):

--- a/tests/test_grids_router.py
+++ b/tests/test_grids_router.py
@@ -271,7 +271,7 @@ class _FakePMInvalidScriptFile:
 
 
 def test_generate_grid_invalid_script_file(monkeypatch):
-    # 非法 script_file（路径穿越等）是坏请求，422 而非落入下方 500 兜底
+    # 非法 script_file（路径穿越等）是坏请求，400 而非落入下方 500 兜底
     client = _client(
         monkeypatch,
         get_project_manager=_FakePMInvalidScriptFile,
@@ -281,7 +281,7 @@ def test_generate_grid_invalid_script_file(monkeypatch):
             "/api/v1/projects/demo/generate/grid/1",
             json={"script_file": "../../etc/passwd"},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
 
 
 class _FakePMGenerate:

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -7,9 +7,18 @@ from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from pydantic import BaseModel
 
 from lib.i18n.zh import errors as zh_errors
 from lib.project_manager import EmptySourceError
+
+
+class _OverviewProbe(BaseModel):
+    """仅用于让 fake 生成器抛出真实的 pydantic ValidationError（也是 ValueError 子类）。"""
+
+    synopsis: str
+
+
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import projects
@@ -59,6 +68,7 @@ class _FakePM:
         (self.base / "bad").mkdir(parents=True, exist_ok=True)
         (self.base / "no-provider").mkdir(parents=True, exist_ok=True)
         (self.base / "corrupted").mkdir(parents=True, exist_ok=True)
+        (self.base / "bad-schema").mkdir(parents=True, exist_ok=True)
         # 上传后概览生成失败的软降级路径：项目存在，但 generate_overview 抛带路径异常
         (self.base / "leaky").mkdir(parents=True, exist_ok=True)
 
@@ -208,6 +218,10 @@ class _FakePM:
             # 模拟供应商解析链路内部重新 load_project 时命中损坏的 project.json：
             # JSONDecodeError 是 ValueError 子类，不该被误判为「未配置供应商」
             json.loads("{not valid json")
+        if name == "bad-schema":
+            # 模拟模型输出未通过 schema 校验：pydantic ValidationError 同样是 ValueError 子类，
+            # 不该被误判为「未配置供应商」
+            _OverviewProbe.model_validate({})
         raise EmptySourceError("source missing")
 
 
@@ -1713,6 +1727,15 @@ class TestUnexpectedErrorsDoNotLeak:
             resp = client.post("/api/v1/projects/corrupted/generate-overview")
             assert resp.status_code == 500
             assert "配置文本供应商" not in self._body(resp)
+
+    def test_generate_overview_schema_failure_maps_to_ai_response_invalid(self, tmp_path, monkeypatch):
+        # pydantic ValidationError 也是 ValueError 子类：模型输出不合 schema 时须命中
+        # 「AI 响应无效」专属分支，不能被通用 ValueError 处理误判为「未配置文本供应商」
+        client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
+        with client:
+            resp = client.post("/api/v1/projects/bad-schema/generate-overview")
+            assert resp.status_code == 400
+            assert resp.json()["detail"] == zh_errors.MESSAGES["overview_ai_response_invalid"]
 
     def test_generate_overview_invalid_project_name_maps_to_400_not_provider_error(self, tmp_path, monkeypatch):
         # get_project_path 抛出的非法项目名 ValueError（路径穿越等）不能被 generate_overview()


### PR DESCRIPTION
Closes #1356

## 改动

1. **尾帧「项目内选图」超限改用专属文案与 400**：`server/services/end_frame.py::read_project_image` 不再复用上传通道的 `UploadTooLargeError`（413 + `upload_too_large`），改抛 `EndFrameError`，新 i18n key `end_frame_source_too_large`（三语文案按 issue 定稿录入），状态码取尾帧领域错误默认的 400——选图请求体只是路径字符串，413 语义不适用。上传通道自身（`upload_end_frame` 内联超限检查、`upload_finalize`）未动，仍是 413 + `upload_too_large`。
2. **宫格 `invalid_script_file` 422 → 400**：`server/routers/grids.py` 唯一一处 `ApiError(..., status_code=422, ...)` 改为 `BadRequestError`，对齐同类非法输入错误（`invalid_project_name` 等）的 400 多数派口径。
3. **`JSONDecodeError` 守卫收编**：`grids.py`×3、`projects.py::generate_overview`×1、`end_frame.py::_locate_shot`×1 共 5 处重复的三段式 except 收编为 `lib/json_io.py::domain_error_on_value_error`——把 `ValueError` 转为调用方指定的领域错误，同时放行 `json.JSONDecodeError`（文件本身损坏，不是业务级非法值）与 `extra_passthrough` 声明的其它 `ValueError` 子类（如 `UnicodeDecodeError`、调用方另有专属分支处理的 `EmptySourceError`/pydantic `ValidationError`）。各处既有行为不变。

## 本地审查后的调整

- helper 去掉了 `on_json_decode_error` 回调参数：它只有一个调用点、且「声明返回 None 实则抛异常」的签名不诚实。`projects.py` 改回在函数尾部的 except 链里保留自己的 `except json.JSONDecodeError` 分支，行为等价而控制流直白。
- 补两条回归测试：概述生成的 pydantic `ValidationError` 透传（保护 `extra_passthrough` 清单不被静默降级为「未配置供应商」）、尾帧选图超限的 detail 文案断言（原先只断言状态码，key 写错也会绿）。
- 4 处未使用原异常的 factory lambda 参数改名 `_exc`。

## 验证

- `uv run ruff check .` + `ruff format --check` 通过
- `uv run basedpyright` 0 errors
- `uv run python -m pytest` 6529 passed（含 `tests/test_i18n_consistency.py`）
- 已 rebase 到最新 main（e36c1819）后重跑上述全部门禁

无前端改动（前端未按 status code / error key 分支处理该错误，统一渲染 detail 文案），未跑前端门。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **错误提示**
  - 新增中文、英文和越南文的尾帧源图片超大提示，包含文件路径及大小上限。
  - 尾帧源图片超限时统一返回 400，并提供更明确的错误详情。

- **错误处理**
  - 无效脚本文件和项目配置错误将返回更准确的客户端错误提示。
  - 项目概览生成失败时，可区分供应商未配置与 AI 响应格式无效等情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->