### PR TITLE
fix(frontend): 切换项目时不再误报页面数据刷新失败

### DIFF
--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -187,10 +187,15 @@ export function StudioCanvasRouter() {
 
   // 刷新项目数据；返回本地 store 是否已同步成功，供调用方决定是否推进依赖新顺序的 UI 状态。
   // 在途合并 + 失败留旧收敛于 projects-store 的 refreshProject，此处仅表达意图。
+  // "cancelled"（项目切换取消域轮换等）与 "failed" 在这里都不算已同步，统一按 false
+  // 处理——本地调用方只用这个值决定是否推进 UI 状态，不弹错误提示，故无需再细分。
   const refreshProject = useCallback(
     (invalidateKeys: string[] = []): Promise<boolean> =>
       currentProjectName
-        ? useProjectsStore.getState().refreshProject(currentProjectName, { invalidateKeys })
+        ? useProjectsStore
+            .getState()
+            .refreshProject(currentProjectName, { invalidateKeys })
+            .then((result) => result === "success")
         : Promise.resolve(false),
     [currentProjectName],
   );

--- a/frontend/src/components/canvas/timeline/EndFrameRow.test.tsx
+++ b/frontend/src/components/canvas/timeline/EndFrameRow.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
-import { useProjectsStore } from "@/stores/projects-store";
+import { type RefreshProjectResult, useProjectsStore } from "@/stores/projects-store";
 import { useTasksStore } from "@/stores/tasks-store";
 import type { TaskItem, VideoCapabilities } from "@/types";
 import { EndFrameRow } from "./EndFrameRow";
@@ -63,7 +63,9 @@ function renderRow(props: Partial<Parameters<typeof EndFrameRow>[0]> = {}) {
   );
 }
 
-const refreshProject = vi.fn().mockResolvedValue("success");
+// mock 的结果值用 satisfies 钉在 RefreshProjectResult 上：vi.fn() 本身不受 setState 的
+// 类型约束，联合成员改名时若不钉住，这里会静默停留在过期字面量上而测试照常通过。
+const refreshProject = vi.fn().mockResolvedValue("success" satisfies RefreshProjectResult);
 
 beforeEach(() => {
   vi.spyOn(API, "getVideoCapabilities").mockResolvedValue(caps(true));
@@ -249,7 +251,7 @@ describe("EndFrameRow 占用态", () => {
   });
 
   it("写入成功但刷新项目失败：提示刷新失败而非写入失败", async () => {
-    refreshProject.mockResolvedValueOnce("failed");
+    refreshProject.mockResolvedValueOnce("failed" satisfies RefreshProjectResult);
     vi
       .spyOn(API, "selectEndFrame")
       .mockResolvedValue({ success: true, end_frame_image: "end_frames/scene_E1S01.png" });
@@ -267,7 +269,7 @@ describe("EndFrameRow 占用态", () => {
   });
 
   it("写入成功但刷新恰好被项目切换取消：不误报刷新失败", async () => {
-    refreshProject.mockResolvedValueOnce("cancelled");
+    refreshProject.mockResolvedValueOnce("cancelled" satisfies RefreshProjectResult);
     vi
       .spyOn(API, "selectEndFrame")
       .mockResolvedValue({ success: true, end_frame_image: "end_frames/scene_E1S01.png" });

--- a/frontend/src/components/canvas/timeline/EndFrameRow.test.tsx
+++ b/frontend/src/components/canvas/timeline/EndFrameRow.test.tsx
@@ -63,7 +63,7 @@ function renderRow(props: Partial<Parameters<typeof EndFrameRow>[0]> = {}) {
   );
 }
 
-const refreshProject = vi.fn().mockResolvedValue(true);
+const refreshProject = vi.fn().mockResolvedValue("success");
 
 beforeEach(() => {
   vi.spyOn(API, "getVideoCapabilities").mockResolvedValue(caps(true));
@@ -249,7 +249,7 @@ describe("EndFrameRow 占用态", () => {
   });
 
   it("写入成功但刷新项目失败：提示刷新失败而非写入失败", async () => {
-    refreshProject.mockResolvedValueOnce(false);
+    refreshProject.mockResolvedValueOnce("failed");
     vi
       .spyOn(API, "selectEndFrame")
       .mockResolvedValue({ success: true, end_frame_image: "end_frames/scene_E1S01.png" });
@@ -264,6 +264,27 @@ describe("EndFrameRow 占用态", () => {
     await waitFor(() => {
       expect(useAppStore.getState().toast?.text).toMatch(/页面数据刷新失败/);
     });
+  });
+
+  it("写入成功但刷新恰好被项目切换取消：不误报刷新失败", async () => {
+    refreshProject.mockResolvedValueOnce("cancelled");
+    vi
+      .spyOn(API, "selectEndFrame")
+      .mockResolvedValue({ success: true, end_frame_image: "end_frames/scene_E1S01.png" });
+    const { getByRole, findByText, findByRole } = renderRow();
+    await findByText("未设置");
+
+    fireEvent.click(getByRole("button", { name: /尾帧/ }));
+    fireEvent.click(getByRole("button", { name: "选择图片" }));
+    fireEvent.click(await findByRole("button", { name: /镜头 E1S01/ }));
+    fireEvent.click(getByRole("button", { name: "设为尾帧" }));
+
+    await waitFor(() => {
+      expect(refreshProject).toHaveBeenCalledWith(PROJECT);
+    });
+    // 写入成功的提示保留，不被追加或覆盖为刷新失败提示。
+    expect(useAppStore.getState().toast?.text).not.toMatch(/页面数据刷新失败/);
+    expect(useAppStore.getState().toast?.tone).toBe("success");
   });
 
   it("提交在途状态经 onSubmittingChange 回传父级", async () => {

--- a/frontend/src/components/canvas/timeline/EndFrameRow.tsx
+++ b/frontend/src/components/canvas/timeline/EndFrameRow.tsx
@@ -149,9 +149,10 @@ export function EndFrameRow({
     useAppStore.getState().pushToast(t(successKey, { id: segmentId }), "success");
     // 快照路径固定、换图原地覆盖，须重取项目数据拿新的资产指纹才能 cache-bust。
     // refreshProject 内部吞掉请求错误、以返回值表达结果（从不 reject）：写入已经成功，
-    // 刷新失败要单独提示，不能把它误报成尾帧写入失败。
-    const refreshed = await useProjectsStore.getState().refreshProject(projectName);
-    if (!refreshed) {
+    // 刷新失败要单独提示，不能把它误报成尾帧写入失败；刷新被项目切换取消则不代表出错，
+    // 静默跳过，否则设置尾帧后立刻切项目会误报一条刷新失败。
+    const refreshResult = await useProjectsStore.getState().refreshProject(projectName);
+    if (refreshResult === "failed") {
       useAppStore.getState().pushToast(t("end_frame_refresh_failed"), "error");
     }
   };

--- a/frontend/src/stores/projects-store.test.ts
+++ b/frontend/src/stores/projects-store.test.ts
@@ -47,17 +47,17 @@ describe("projects-store refreshProject", () => {
     vi.restoreAllMocks();
   });
 
-  it("空 name 直接返回 false，不发请求", async () => {
+  it("空 name 直接返回 cancelled，不发请求", async () => {
     const spy = vi.spyOn(API, "getProject");
-    const ok = await useProjectsStore.getState().refreshProject("");
-    expect(ok).toBe(false);
+    const result = await useProjectsStore.getState().refreshProject("");
+    expect(result).toBe("cancelled");
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it("成功时写入 currentProject 并返回 true", async () => {
+  it("成功时写入 currentProject 并返回 success", async () => {
     vi.spyOn(API, "getProject").mockResolvedValue(makeResult("Demo", { "a.png": 1 }));
-    const ok = await useProjectsStore.getState().refreshProject("demo");
-    expect(ok).toBe(true);
+    const result = await useProjectsStore.getState().refreshProject("demo");
+    expect(result).toBe("success");
     const s = useProjectsStore.getState();
     expect(s.currentProjectName).toBe("demo");
     expect(s.currentProjectData?.title).toBe("Demo");
@@ -74,13 +74,13 @@ describe("projects-store refreshProject", () => {
     expect(app.getEntityRevision("character:hero")).toBe(1);
   });
 
-  it("失败留旧：不覆盖 currentProjectData，返回 false，onError 收到错误", async () => {
+  it("失败留旧：不覆盖 currentProjectData，返回 failed，onError 收到错误", async () => {
     useProjectsStore.getState().setCurrentProject("demo", makeProject("旧"), {}, {});
     const err = new Error("boom");
     vi.spyOn(API, "getProject").mockRejectedValue(err);
     const onError = vi.fn();
-    const ok = await useProjectsStore.getState().refreshProject("demo", { onError });
-    expect(ok).toBe(false);
+    const result = await useProjectsStore.getState().refreshProject("demo", { onError });
+    expect(result).toBe("failed");
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("旧");
     expect(onError).toHaveBeenCalledWith(err);
   });
@@ -107,7 +107,7 @@ describe("projects-store refreshProject", () => {
 
     d2.resolve(makeResult("R2"));
     const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
-    expect([r1, r2, r3]).toEqual([true, true, true]);
+    expect([r1, r2, r3]).toEqual(["success", "success", "success"]);
     // 3 个刷新意图合并为 2 次请求，store 落定在最新一轮
     expect(spy).toHaveBeenCalledTimes(2);
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("R2");
@@ -132,12 +132,12 @@ describe("projects-store refreshProject", () => {
     const [r1, r2] = await Promise.all([p1, p2]);
     // 首轮调用方拿到自己那一轮的真实结果（失败），不因排队轮后续成功被覆盖；
     // 排队轮调用方拿到自己那一轮的结果（成功）。
-    expect(r1).toBe(false);
-    expect(r2).toBe(true);
+    expect(r1).toBe("failed");
+    expect(r2).toBe("success");
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("新");
   });
 
-  it("首轮成功、排队轮失败时，首轮调用方仍返回 true（不被无关的后续轮次拖累）", async () => {
+  it("首轮成功、排队轮失败时，首轮调用方仍返回 success（不被无关的后续轮次拖累）", async () => {
     const d1 = deferred<GetProjectResult>();
     const d2 = deferred<GetProjectResult>();
     vi.spyOn(API, "getProject").mockReturnValueOnce(d1.promise).mockReturnValueOnce(d2.promise);
@@ -155,14 +155,14 @@ describe("projects-store refreshProject", () => {
 
     d2.reject(new Error("sse round fail"));
     const [okMoveShot, okSse] = await Promise.all([pMoveShot, pSse]);
-    // 首轮调用方拿到自己那一轮的真实结果（成功），不因排队轮后续失败被覆盖为 false。
-    expect(okMoveShot).toBe(true);
-    expect(okSse).toBe(false);
+    // 首轮调用方拿到自己那一轮的真实结果（成功），不因排队轮后续失败被覆盖。
+    expect(okMoveShot).toBe("success");
+    expect(okSse).toBe("failed");
     // 失败留旧：store 仍保留首轮写入的数据，不因排队轮失败被清空或回滚。
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("重排后");
   });
 
-  it("排队期间被更晚的不同项目请求取代：被取代的调用方立即收到 false，不与新项目的结果混同", async () => {
+  it("排队期间被更晚的不同项目请求取代：被取代的调用方立即收到 cancelled，不与新项目的结果混同", async () => {
     const dA = deferred<GetProjectResult>();
     const dC = deferred<GetProjectResult>();
     vi.spyOn(API, "getProject").mockReturnValueOnce(dA.promise).mockReturnValueOnce(dC.promise);
@@ -172,10 +172,10 @@ describe("projects-store refreshProject", () => {
     const pB = store.refreshProject("B"); // 排队 → queuedName = B
     const pC = store.refreshProject("C"); // 排队期间到达不同项目：B 被 C 取代
 
-    // B 的调用方无需等 A / C 落定，在被取代的一刻就立即收到 false——
+    // B 的调用方无需等 A / C 落定，在被取代的一刻就立即收到 cancelled——
     // 它请求的项目从未被真正拉取过，不能被并入 C 的结果。
     const okB = await pB;
-    expect(okB).toBe(false);
+    expect(okB).toBe("cancelled");
     // 只发起了 A 的请求；B 被取代时尚未轮到它，不产生任何请求。
     expect(API.getProject).toHaveBeenCalledTimes(1);
 
@@ -187,8 +187,8 @@ describe("projects-store refreshProject", () => {
 
     dC.resolve(makeResult("C-数据"));
     const [okA, okC] = await Promise.all([pA, pC]);
-    expect(okA).toBe(false);
-    expect(okC).toBe(true);
+    expect(okA).toBe("cancelled");
+    expect(okC).toBe("success");
     expect(useProjectsStore.getState().currentProjectName).toBe("C");
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("C-数据");
   });
@@ -211,8 +211,8 @@ describe("projects-store refreshProject", () => {
 
     dB.reject(new Error("B failed"));
     const [okA, okB] = await Promise.all([pA, pB]);
-    expect(okA).toBe(false);
-    expect(okB).toBe(false);
+    expect(okA).toBe("cancelled");
+    expect(okB).toBe("failed");
     // B 轮失败：留旧，仍是 B 的旧数据，绝不能变成 A 的数据
     expect(useProjectsStore.getState().currentProjectName).toBe("B");
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-旧");
@@ -272,7 +272,7 @@ describe("projects-store refreshProject", () => {
     d.resolve(makeResult("迟到的真实数据"));
     const ok = await p;
 
-    expect(ok).toBe(false);
+    expect(ok).toBe("cancelled");
     expect(useProjectsStore.getState().currentProjectName).toBe(DEMO_PROJECT_NAME);
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("演示");
   });
@@ -295,7 +295,7 @@ describe("projects-store refreshProject", () => {
     dA.resolve(makeResult("A-迟到数据"));
     const ok = await pA;
 
-    expect(ok).toBe(false);
+    expect(ok).toBe("cancelled");
     expect(useProjectsStore.getState().currentProjectName).toBe("B");
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
   });
@@ -316,7 +316,7 @@ describe("projects-store refreshProject", () => {
     dA.resolve(makeResult("A-迟到数据"));
     const ok = await pA;
 
-    expect(ok).toBe(false);
+    expect(ok).toBe("cancelled");
     expect(useProjectsStore.getState().currentProjectName).toBe(null);
     expect(useProjectsStore.getState().currentProjectData).toBe(null);
 
@@ -343,7 +343,7 @@ describe("projects-store refreshProject", () => {
     dC.resolve(makeResult("C-迟到数据"));
     const ok = await pC;
 
-    expect(ok).toBe(false);
+    expect(ok).toBe("cancelled");
     expect(useProjectsStore.getState().currentProjectName).toBe(null);
 
     useProjectsStore.getState().setCurrentProject("B", makeProject("B-数据"), {}, {});
@@ -365,7 +365,7 @@ describe("projects-store refreshProject", () => {
     dA.resolve(makeResult("A-迟到数据"));
     const ok = await pA;
 
-    expect(ok).toBe(false);
+    expect(ok).toBe("cancelled");
     expect(useProjectsStore.getState().currentProjectName).toBe("B");
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
   });
@@ -391,8 +391,8 @@ describe("projects-store refreshProject", () => {
     d2.resolve(makeResult("A-排队轮迟到"));
 
     const [ok1, ok2] = await Promise.all([p1, p2]);
-    expect(ok1).toBe(false);
-    expect(ok2).toBe(false);
+    expect(ok1).toBe("cancelled");
+    expect(ok2).toBe("cancelled");
     expect(useProjectsStore.getState().currentProjectName).toBe("B");
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
   });
@@ -418,7 +418,7 @@ describe("projects-store refreshProject", () => {
 
     const ok = await pA;
     expect(abortedSignal?.aborted).toBe(true);
-    expect(ok).toBe(false);
+    expect(ok).toBe("cancelled");
     // abort 是项目切换的正常结果，不是刷新失败：不该弹「项目同步失败」。
     expect(onError).not.toHaveBeenCalled();
     expect(useProjectsStore.getState().currentProjectName).toBe("B");
@@ -437,10 +437,10 @@ describe("projects-store refreshProject", () => {
 
     store.setCurrentProject("B", makeProject("B-数据"), {}, {});
     dA.resolve(makeResult("A-迟到数据"));
-    expect(await pA).toBe(false);
+    expect(await pA).toBe("cancelled");
 
     const okB = await useProjectsStore.getState().refreshProject("B");
-    expect(okB).toBe(true);
+    expect(okB).toBe("success");
     expect(useProjectsStore.getState().currentProjectName).toBe("B");
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-新数据");
   });

--- a/frontend/src/stores/projects-store.ts
+++ b/frontend/src/stores/projects-store.ts
@@ -4,6 +4,15 @@ import { API } from "@/api";
 import { isDemoProject } from "@/onboarding/demo-project";
 import { useAppStore } from "./app-store";
 
+/**
+ * {@link ProjectsState.refreshProject} 的结算结果：
+ * - `success` — store 已同步为最新数据
+ * - `failed` — 请求本身出错（网络 / 服务端错误），`onError` 会被调用
+ * - `cancelled` — 未同步但不代表出错：项目切换取消域轮换、被更晚的排队请求取代等。
+ *   调用方应静默处理，不弹错误提示
+ */
+export type RefreshProjectResult = "success" | "failed" | "cancelled";
+
 /** {@link ProjectsState.refreshProject} 的可选行为。 */
 interface RefreshProjectOptions {
   /** 刷新成功后要失效的实体版本 key（沿用 StudioCanvasRouter 旧变体语义）。 */
@@ -57,18 +66,18 @@ interface ProjectsState {
   updateAssetFingerprints: (fps: Record<string, number>) => void;
   getAssetFingerprint: (path: string) => number | null;
   /**
-   * 刷新当前项目数据到 store，返回 store 是否已同步成功。
+   * 刷新当前项目数据到 store，返回结果判别式联合（见 {@link RefreshProjectResult}）。
    *
    * 单一入口收敛此前各调用点分散的刷新语义，消除「两入口同时刷新时后完成者盖住
    * 先完成者」的竞态：
    * - **在途合并**：同一时刻只允许一个 getProject 在途；在途期间到达的刷新请求
    *   合并为「结束后再跑一轮」，取最新一次请求的 name / invalidateKeys。
-   * - **失败留旧**：getProject 失败时不覆盖 currentProjectData，返回 false 交调用方
-   *   决定是否提示（onError 亦会被调用）。
+   * - **失败留旧**：getProject 失败时不覆盖 currentProjectData，返回 `"failed"` 交
+   *   调用方决定是否提示（onError 亦会被调用）。
    * - **项目级取消域**：请求挂在随当前项目轮换的 AbortSignal 上，切换项目即作废前一个
-   *   项目的在途与迟到刷新，返回 false 且不视为失败（不触发 onError）。
+   *   项目的在途与迟到刷新，返回 `"cancelled"`，不视为失败（不触发 onError）。
    */
-  refreshProject: (name: string, options?: RefreshProjectOptions) => Promise<boolean>;
+  refreshProject: (name: string, options?: RefreshProjectOptions) => Promise<RefreshProjectResult>;
 }
 
 export const useProjectsStore = create<ProjectsState>((set, get) => {
@@ -80,7 +89,7 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
   let queuedOnErrors: Array<(err: unknown) => void> = [];
   // 排队轮调用方各自的 resolve——与 curResolvers 分开累积，避免"排队进同一批"
   // 被误解为"共享同一个最终结果"：每个调用方只对自己实际服务的那一轮结果负责。
-  let queuedResolvers: Array<(ok: boolean) => void> = [];
+  let queuedResolvers: Array<(result: RefreshProjectResult) => void> = [];
 
   // 项目级取消域：当前项目的数据请求都挂在这个 controller 上。切换项目时轮换（abort 旧的、
   // 换上新的），使前一个项目的在途请求当场取消、迟到响应无法写回 store。轮换后现役
@@ -101,7 +110,7 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
     name: string,
     keys: string[],
     onError: ((err: unknown) => void) | undefined,
-    resolvers: Array<(ok: boolean) => void>,
+    resolvers: Array<(result: RefreshProjectResult) => void>,
   ): Promise<void> => {
     let curName = name;
     let curKeys = keys;
@@ -110,7 +119,7 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
     let again = true;
     while (again) {
       again = false;
-      let ok = false;
+      let result: RefreshProjectResult = "cancelled";
       // 每轮取一次现役取消域：排队轮要挂在它自己发起时刻的域上，不复用上一轮的。
       const signal = projectScope.signal;
       try {
@@ -140,18 +149,22 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
           if (curKeys.length > 0) {
             useAppStore.getState().invalidateEntities(curKeys);
           }
-          ok = true;
+          result = "success";
         }
+        // 未写入但也未出错（superseded / aborted / 非当前项目）：结算为 "cancelled"，
+        // 调用方据此静默，不与真正的请求失败混淆。
       } catch (err) {
-        // 失败留旧：不覆盖 currentProjectData；调用方按返回值 / onError 决定提示。
-        ok = false;
-        // 取消域轮换导致的 abort 是项目切换的正常结果，不是刷新失败：按「未同步」结算
-        // 为 false，但不触发 onError，否则每次切项目都会弹一条同步失败提示。
-        if (!signal.aborted) {
+        // 取消域轮换导致的 abort 是项目切换的正常结果，不是刷新失败：结算为
+        // "cancelled"，不触发 onError，否则每次切项目都会弹一条同步失败提示。
+        // 失败留旧：两种结果都不覆盖 currentProjectData。
+        if (signal.aborted) {
+          result = "cancelled";
+        } else {
+          result = "failed";
           curOnErrors.forEach((cb) => cb(err));
         }
       }
-      curResolvers.forEach((resolve) => resolve(ok));
+      curResolvers.forEach((resolve) => resolve(result));
       if (refreshQueued) {
         refreshQueued = false;
         curName = queuedName ?? curName;
@@ -202,11 +215,11 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
     getAssetFingerprint: (path) => get().assetFingerprints[path] ?? null,
 
     refreshProject: (name, options) => {
-      if (!name) return Promise.resolve(false);
+      if (!name) return Promise.resolve("cancelled");
       // 引导演示项目的数据来自前端常量，没有可刷新的服务端状态
-      if (isDemoProject(name)) return Promise.resolve(true);
+      if (isDemoProject(name)) return Promise.resolve("success");
       const invalidateKeys = options?.invalidateKeys ?? [];
-      return new Promise<boolean>((resolve) => {
+      return new Promise<RefreshProjectResult>((resolve) => {
         if (refreshRunning) {
           // 已有刷新在途：合并为「结束后再跑一轮」，取最新 name，累积 invalidateKeys /
           // onError / resolve——排队轮次结束时需各自通知全部合并进来的调用方，
@@ -218,13 +231,13 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
           // 被接下来实际执行的那一轮命中；不提前结算就会被并入并共享本次这个新项目
           // 的结果，即便它们请求的从来不是这个项目（例如 B 排队后 C 覆盖，B 的调用方
           // 会在 C 成功后错误地收到 true，但 store 从未同步过 B 的数据）。按「未同步」
-          // 立即结算为 false，不视为请求出错，因此不触发 onError。
+          // 立即结算为 "cancelled"，不视为请求出错，因此不触发 onError。
           if (refreshQueued && queuedName !== null && queuedName !== name) {
             const supersededResolvers = queuedResolvers;
             queuedResolvers = [];
             queuedKeys = [];
             queuedOnErrors = [];
-            supersededResolvers.forEach((r) => r(false));
+            supersededResolvers.forEach((r) => r("cancelled"));
           }
           refreshQueued = true;
           queuedName = name;

--- a/frontend/src/stores/projects-store.ts
+++ b/frontend/src/stores/projects-store.ts
@@ -161,7 +161,13 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
           result = "cancelled";
         } else {
           result = "failed";
-          curOnErrors.forEach((cb) => cb(err));
+          curOnErrors.forEach((cb) => {
+            try {
+              cb(err);
+            } catch (callbackErr) {
+              console.error("refreshProject onError 回调失败", callbackErr);
+            }
+          });
         }
       }
       curResolvers.forEach((resolve) => resolve(result));


### PR DESCRIPTION
Closes #1365

## 问题

设置尾帧后立刻切换项目，会弹一条误导性的「页面数据刷新失败」。`refreshProject` 被项目切换的取消域 abort 后已经不再触发 `onError`，但仍然返回 `false`，与真实的请求失败无法区分；`EndFrameRow` 按这个布尔值弹错，于是把正常的项目切换报成了刷新失败。

## 改动

- `refreshProject` 的返回值从 `boolean` 改为判别式联合 `"success" | "failed" | "cancelled"`，取消（取消域轮换、被更晚的排队请求取代、迟到响应、非当前项目）与请求失败在结算层就分开，调用方无需自行补过期检查。
- 两处消费返回值的调用点各按自身语义适配：`EndFrameRow` 仅在 `"failed"` 时提示刷新失败，`"cancelled"` 静默；`StudioCanvasRouter` 的本地包装在边界映射回 `boolean`（该值只用于决定是否推进选中态，不弹提示）。
- 其余调用点（`OverviewCanvas`、`useProjectEventsSSE`、各 `onRefreshProject`）本就忽略返回值，未受影响。

## 验证

- `frontend/src/stores/projects-store.test.ts`：全部用例断言改写为三态，覆盖真实 abort 路径产出 `"cancelled"` 且不触发 `onError`、排队轮被取代立即结算 `"cancelled"`、首轮与排队轮各自结算不互相拖累。
- `frontend/src/components/canvas/timeline/EndFrameRow.test.tsx`：新增「刷新被项目切换取消 → 保留写入成功提示、不弹刷新失败」用例；既有「真实失败 → 仍弹错」用例改用 `"failed"`。mock 的结果值用 `satisfies RefreshProjectResult` 钉住，联合成员改名时 typecheck 会拦下。
- `pnpm check`（typecheck + lint + vitest）：128 文件 / 1269 测试全绿。后端零改动，未跑 pytest。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 项目刷新结果现区分为“成功”“失败”和“已取消”，并依据实际结果更新提示与判定。
  - 项目切换或在途请求被取消时，不再触发误报“刷新失败”或“尾帧写入失败”。
  - 尾帧写入流程仅在刷新明确失败时才显示对应错误提示。  
- **测试**
  - 更新并新增项目刷新、项目切换取消、以及尾帧写入刷新失败/不误报等场景的覆盖用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->