### PR TITLE
fix(video): 视频入队对非法分镜图引用给出可读拒绝原因，不再返回通用 500

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -53,6 +53,7 @@ MESSAGES = {
     "prompt_text_empty": "prompt must not be empty",
     "storyboard_task_submitted": "Storyboard generation task for '{segment_id}' submitted",
     "generate_storyboard_first": "Please generate storyboard scene_{segment_id}.png first",
+    "invalid_storyboard_image_path": "Segment '{segment_id}' has an invalid storyboard image reference; please regenerate the storyboard",
     "video_prompt_must_be_string_or_action_object": "prompt must be a string or an object containing action/camera_motion",
     "video_prompt_action_empty": "prompt.action cannot be empty",
     "video_prompt_dialogue_array": "prompt.dialogue must be an array",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -53,6 +53,7 @@ MESSAGES = {
     "prompt_text_empty": "prompt không được để trống",
     "storyboard_task_submitted": "Đã gửi tác vụ tạo phân cảnh cho '{segment_id}'",
     "generate_storyboard_first": "Vui lòng tạo phân cảnh scene_{segment_id}.png trước",
+    "invalid_storyboard_image_path": "Đoạn '{segment_id}' có tham chiếu ảnh phân cảnh không hợp lệ, vui lòng tạo lại phân cảnh",
     "video_prompt_must_be_string_or_action_object": "prompt phải là chuỗi hoặc đối tượng chứa action/camera_motion",
     "video_prompt_action_empty": "prompt.action không được để trống",
     "video_prompt_dialogue_array": "prompt.dialogue phải là mảng",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -53,6 +53,7 @@ MESSAGES = {
     "prompt_text_empty": "prompt 不能为空",
     "storyboard_task_submitted": "分镜「{segment_id}」生成任务已提交",
     "generate_storyboard_first": "请先生成分镜图 scene_{segment_id}.png",
+    "invalid_storyboard_image_path": "片段「{segment_id}」的分镜图引用无效，请重新生成分镜图",
     "video_prompt_must_be_string_or_action_object": "prompt 必须是字符串或包含 action/camera_motion 的对象",
     "video_prompt_action_empty": "prompt.action 不能为空",
     "video_prompt_dialogue_array": "prompt.dialogue 必须是数组",

--- a/lib/storyboard_sequence.py
+++ b/lib/storyboard_sequence.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from lib.path_safety import safe_join, try_safe_join
 from lib.script_editor import resolve_items
 from lib.script_skeleton import SKELETONS
 
@@ -63,6 +64,43 @@ def find_storyboard_item(
         if str(item.get(id_field)) == str(resource_id):
             return item, index
     return None
+
+
+def resolve_storyboard_image_ref(project_path: Path, storyboard_rel: object) -> Path | None:
+    """校验 ``generated_assets.storyboard_image`` 字段值，返回解析后落在 ``storyboards/``
+    内的绝对路径；字段未设置（``None``/``""``）返回 ``None``，由调用方按各自默认路径回退。
+
+    该字段来自磁盘上的 project.json / 剧本 JSON，不可信任（归档导入、外部编辑、脏数据都能
+    落值）：绝对路径 / ``..`` 会把项目外任意文件当作分镜图使用，须先做类型检查、显式拒绝
+    绝对路径（含 Windows 无盘符根路径），再用 ``try_safe_join`` 解析并确认结果落在
+    ``storyboards/`` 目录内。旧宫格项目 ``storyboard_image`` 指向非 canonical 文件名
+    （``scene_{id}_first.png``）仍需正常解析，故只做目录归属校验，不与 canonical 路径逐一
+    比对（这点与 ``end_frame_image`` 不同）。
+
+    Raises:
+        ValueError: 字段值非字符串、是绝对路径、越界、或解析结果不在 ``storyboards/`` 内。
+    """
+    if storyboard_rel in (None, ""):
+        return None
+    if not isinstance(storyboard_rel, str):
+        raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}")
+    # `os.path.join` 遇到绝对路径会丢弃 base，若该绝对路径恰好落在项目 storyboards/ 内仍会
+    # 通过越界检查，须在解析前显式挡掉。Windows 原生运行时无盘符的「根路径」（如 `\Users\...`）
+    # 对 `Path.is_absolute()` 不算绝对，但 os.path.join 遇到它同样会丢弃 base（仅保留 base 的
+    # 盘符），需按正斜杠归一化后再查是否以根分隔符开头。
+    if Path(storyboard_rel).is_absolute() or storyboard_rel.replace("\\", "/").startswith("/"):
+        raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}")
+    storyboards_root = safe_join(project_path, "storyboards", allow_base=True)
+    storyboard_file = try_safe_join(project_path, storyboard_rel)
+    if storyboard_file is None:
+        raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}")
+    try:
+        storyboard_file.relative_to(storyboards_root)
+    except ValueError:
+        # 与越界/脏数据分开措辞：这一支是「项目内但不在 storyboards/」，唯一能自然落进来的
+        # 是外部编辑过的剧本，运维需要从失败原因直接看出是目录归属而非路径越界。
+        raise ValueError(f"storyboard image path must stay under storyboards/: {storyboard_rel!r}") from None
+    return storyboard_file
 
 
 def resolve_previous_storyboard_path(

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -26,7 +26,7 @@ from lib.reference_video.ad_units import (
     resolve_ad_unit_shots,
     sync_ad_reference_units,
 )
-from lib.storyboard_sequence import get_storyboard_items
+from lib.storyboard_sequence import get_storyboard_items, resolve_storyboard_image_ref
 from server.agent_runtime.sdk_tools._context import (
     ToolContext,
     tool_error,
@@ -125,11 +125,18 @@ def _build_video_specs(
             continue
 
         storyboard_image = (item.get("generated_assets") or {}).get("storyboard_image")
-        if not storyboard_image:
+        # 字段值来自磁盘剧本 JSON，不可信任：非字符串脏数据/越界/绝对路径引用统一交给
+        # resolve_storyboard_image_ref 校验（与路由入队预检、执行层读盘点共用同一份），
+        # 批量场景下单个条目非法只跳过并记日志，不中断整批。
+        try:
+            storyboard_path = resolve_storyboard_image_ref(project_dir, storyboard_image)
+        except ValueError as exc:
+            log.append(f"⚠️  {item_type} {item_id} 的分镜图引用无效，跳过: {exc}")
+            continue
+        if storyboard_path is None:
             log.append(f"⚠️  {item_type} {item_id} 没有分镜图，跳过")
             continue
-        storyboard_path = project_dir / storyboard_image
-        if not storyboard_path.exists():
+        if not storyboard_path.is_file():
             log.append(f"⚠️  分镜图不存在: {storyboard_path}，跳过")
             continue
 
@@ -604,10 +611,14 @@ def generate_video_scene_tool(ctx: ToolContext):
             item_id = str(item[id_field])
 
             storyboard_image = item.get("generated_assets", {}).get("storyboard_image")
-            if not storyboard_image:
+            # 字段值来自磁盘剧本 JSON，不可信任：resolve_storyboard_image_ref 统一做类型检查 +
+            # 越界 / 绝对路径拒绝（与路由入队预检、执行层读盘点共用同一份），异常经外层
+            # except 转为可读的 tool_error，不再让非字符串脏数据抛未处理 TypeError。
+            storyboard_path = resolve_storyboard_image_ref(project_dir, storyboard_image)
+            if storyboard_path is None:
                 raise ValueError(f"场景/片段 '{item_id}' 没有分镜图，请先运行 generate_storyboards")
-            if not (project_dir / storyboard_image).exists():
-                raise FileNotFoundError(f"分镜图不存在: {project_dir / storyboard_image}")
+            if not storyboard_path.is_file():
+                raise FileNotFoundError(f"分镜图不存在: {storyboard_path}")
 
             prompt = _get_video_prompt(item)
             # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -25,6 +25,7 @@ from lib.project_manager import get_project_manager
 from lib.storyboard_sequence import (
     find_storyboard_item,
     get_storyboard_items,
+    resolve_storyboard_image_ref,
 )
 from server.auth import CurrentUser
 from server.services.image_edit_tasks import EDITABLE_RESOURCE_TYPES, resolve_current_image_rel
@@ -159,7 +160,7 @@ async def generate_video(
         # fail-fast：不能 silently 降级走 default 路径——default 文件恰好存在时会让请求
         # 「先返回提交成功、worker 解析脚本时再确定失败」，撕裂用户预期。两者均由 app 级
         # handler 统一映射为脱敏响应（404 / 400）。
-        storyboard_rel: str | None = None
+        storyboard_rel: object = None
         script = pm_local.load_script(project_name, req.script_file)
         items, id_field, _, _, _ = get_storyboard_items(script)
         resolved = find_storyboard_item(items, id_field, segment_id)
@@ -169,11 +170,15 @@ async def generate_video(
         if isinstance(assets, dict):
             storyboard_rel = assets.get("storyboard_image")
 
-        storyboard_file = (
-            project_path / storyboard_rel
-            if storyboard_rel
-            else project_path / "storyboards" / f"scene_{segment_id}.png"
-        )
+        # 字段值来自磁盘剧本 JSON，不可信任：非字符串脏数据会让下面的路径拼接抛未处理
+        # TypeError 变成通用 500；越界 / 绝对路径引用会把项目外任意文件当分镜图使用。
+        # 校验口径与 execute_video_task / SDK 工具入队预检共用同一份（resolve_storyboard_image_ref）。
+        try:
+            storyboard_file = resolve_storyboard_image_ref(project_path, storyboard_rel)
+        except ValueError:
+            raise BadRequestError("invalid_storyboard_image_path", segment_id=segment_id) from None
+        if storyboard_file is None:
+            storyboard_file = project_path / "storyboards" / f"scene_{segment_id}.png"
         if not storyboard_file.is_file():
             raise BadRequestError("generate_storyboard_first", segment_id=segment_id)
 

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -42,6 +42,7 @@ from lib.storyboard_sequence import (
     get_storyboard_items,
     group_scenes_by_segment_break,
     resolve_previous_storyboard_path,
+    resolve_storyboard_image_ref,
 )
 from lib.thumbnail import extract_video_thumbnail
 from lib.video_backends.base import VideoCapabilityError
@@ -789,34 +790,12 @@ async def execute_video_task(
     )
     generator = ctx.generator
 
-    # 优先读取 generated_assets.storyboard_image，回退默认路径。
-    # 旧宫格项目 storyboard_image 指向 scene_{id}_first.png，仍可正常解析——这点与 end_frame_image
-    # 不同，不能要求与 canonical 路径逐一比对，只做目录归属校验：剧本是磁盘上的 JSON，字段值不可
-    # 信任（归档导入、外部编辑、脏数据都能落值），绝对路径 / `..` 会把项目外任意文件送进视频请求
-    # 上传给供应商，须先用 try_safe_join 解析并确认结果落在 storyboards/ 目录内，否则可读硬失败。
+    # 优先读取 generated_assets.storyboard_image，回退默认路径。校验口径见
+    # resolve_storyboard_image_ref：与路由入队预检、SDK 工具入队预检共用同一份。
     assets = item.get("generated_assets", {})
     storyboard_rel = assets.get("storyboard_image") if isinstance(assets, dict) else None
-    if storyboard_rel not in (None, ""):
-        if not isinstance(storyboard_rel, str):
-            raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}")
-        # try_safe_join 的越界校验只挡「解析结果落在项目外」；`os.path.join` 遇到绝对路径会
-        # 丢弃 base，若该绝对路径恰好落在项目 storyboards/ 内仍会通过越界检查。issue 验收标准
-        # 要求绝对路径本身一律拒绝（与是否越界无关），须在解析前显式挡掉。Windows 原生运行时
-        # 无盘符的「根路径」（如 `\Users\...`）对 `Path.is_absolute()` 不算绝对，但 os.path.join
-        # 遇到它同样会丢弃 base（仅保留 base 的盘符），需按正斜杠归一化后再查是否以根分隔符开头。
-        if Path(storyboard_rel).is_absolute() or storyboard_rel.replace("\\", "/").startswith("/"):
-            raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}")
-        storyboards_root = safe_join(project_path, "storyboards", allow_base=True)
-        storyboard_file = try_safe_join(project_path, storyboard_rel)
-        if storyboard_file is None:
-            raise ValueError(f"invalid storyboard image path: {storyboard_rel!r}")
-        try:
-            storyboard_file.relative_to(storyboards_root)
-        except ValueError:
-            # 与越界/脏数据分开措辞：这一支是「项目内但不在 storyboards/」，唯一能自然落进来的
-            # 是外部编辑过的剧本，运维需要从失败原因直接看出是目录归属而非路径越界。
-            raise ValueError(f"storyboard image path must stay under storyboards/: {storyboard_rel!r}") from None
-    else:
+    storyboard_file = resolve_storyboard_image_ref(project_path, storyboard_rel)
+    if storyboard_file is None:
         storyboard_file = project_path / "storyboards" / f"scene_{resource_id}.png"
     # is_file 而非 exists：字段被外部编辑指向目录（如 "storyboards" 本身）时 exists() 仍为
     # True，目录会被当作 start_image 传给视频后端，在编码阶段才失败且原因不可读。

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -880,6 +880,23 @@ async def test_generate_video_scene_missing(fake_ctx: ToolContext) -> None:
     assert out.get("is_error") is True
 
 
+@pytest.mark.parametrize(
+    "storyboard_value",
+    [
+        123,  # 剧本 JSON 里的脏数据（非字符串）须可读失败而非未处理 TypeError
+        "/etc/passwd",  # 绝对路径：越权引用项目外文件
+        "../../outside.png",  # `..` 穿越出项目目录
+    ],
+)
+async def test_generate_video_scene_rejects_invalid_storyboard_image(
+    fake_ctx: ToolContext, storyboard_value: object
+) -> None:
+    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {"storyboard_image": storyboard_value}  # type: ignore[attr-defined]
+    tool_obj = generate_video_scene_tool(fake_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json", "scene_id": "E1S01"})
+    assert out.get("is_error") is True
+
+
 async def test_generate_video_all_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
 
@@ -1003,6 +1020,49 @@ def test_build_video_specs_does_not_validate_duration_at_enqueue(tmp_path) -> No
         log=[],
     )
     assert "duration_seconds" not in specs2[0].payload
+
+
+@pytest.mark.parametrize(
+    "storyboard_value",
+    [
+        123,  # 剧本 JSON 里的脏数据（非字符串）
+        "/etc/passwd",  # 绝对路径
+        "../../outside.png",  # `..` 穿越出项目目录
+    ],
+)
+def test_build_video_specs_skips_invalid_storyboard_image_without_aborting_batch(
+    tmp_path: Path, storyboard_value: object
+) -> None:
+    """批量入队场景下，单个条目 storyboard_image 非法（脏数据/越界/绝对路径）只跳过并记日志，
+    不应让 `project_dir / storyboard_image` 抛未处理异常中断整批。"""
+    from server.agent_runtime.sdk_tools.enqueue_videos import _build_video_specs
+
+    (tmp_path / "storyboards").mkdir()
+    (tmp_path / "storyboards" / "scene_S02.png").write_bytes(b"png")
+    items = [
+        {
+            "segment_id": "S01",
+            "video_prompt": "非法引用",
+            "generated_assets": {"storyboard_image": storyboard_value},
+        },
+        {
+            "segment_id": "S02",
+            "video_prompt": "合法引用",
+            "generated_assets": {"storyboard_image": "storyboards/scene_S02.png"},
+        },
+    ]
+    log: list[str] = []
+    specs, order_map = _build_video_specs(
+        items=items,
+        id_field="segment_id",
+        content_mode="narration",
+        script_filename="episode_1.json",
+        project_dir=tmp_path,
+        skip_ids=None,
+        log=log,
+    )
+    assert [s.resource_id for s in specs] == ["S02"]
+    assert any("S01" in line for line in log)
 
 
 def test_get_video_prompt_drama_sources_dialogue_from_utterances() -> None:

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -880,6 +880,7 @@ async def test_generate_video_scene_missing(fake_ctx: ToolContext) -> None:
     assert out.get("is_error") is True
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "storyboard_value",
     [
@@ -1022,6 +1023,7 @@ def test_build_video_specs_does_not_validate_duration_at_enqueue(tmp_path) -> No
     assert "duration_seconds" not in specs2[0].payload
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "storyboard_value",
     [

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -896,9 +896,8 @@ async def test_generate_video_scene_rejects_invalid_storyboard_image(
     tool_obj = generate_video_scene_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json", "scene_id": "E1S01"})
     assert out.get("is_error") is True
-    # tool_error 文本须带 storyboard image path 相关提示，不是通用失败信息
-    text = out["content"][0]["text"]
-    assert "storyboard image path" in text
+    # 锁定 resolve_storyboard_image_ref 抛出的 canonical 消息，而不是模糊子串或通用失败文本
+    assert f"invalid storyboard image path: {storyboard_value!r}" in out["content"][0]["text"]
 
 
 async def test_generate_video_all_happy(fake_ctx: ToolContext, monkeypatch) -> None:

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -896,6 +896,9 @@ async def test_generate_video_scene_rejects_invalid_storyboard_image(
     tool_obj = generate_video_scene_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json", "scene_id": "E1S01"})
     assert out.get("is_error") is True
+    # tool_error 文本须带 storyboard image path 相关提示，不是通用失败信息
+    text = out["content"][0]["text"]
+    assert "storyboard image path" in text
 
 
 async def test_generate_video_all_happy(fake_ctx: ToolContext, monkeypatch) -> None:

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -228,6 +228,8 @@ class TestGenerateRouter:
                 json={"script_file": "episode_1.json", "prompt": "x"},
             )
             assert video.status_code == 400, video.text
+            # detail 走 invalid_storyboard_image_path 这条可读文案，不是通用 500/内部错误
+            assert "E1S01" in video.json()["detail"]
             assert fake_queue.calls == []
 
     @pytest.mark.integration
@@ -245,6 +247,7 @@ class TestGenerateRouter:
                 json={"script_file": "episode_1.json", "prompt": "x"},
             )
             assert video.status_code == 400, video.text
+            assert "E1S01" in video.json()["detail"]
             assert fake_queue.calls == []
 
     @pytest.mark.integration
@@ -262,6 +265,7 @@ class TestGenerateRouter:
                 json={"script_file": "episode_1.json", "prompt": "x"},
             )
             assert video.status_code == 400, video.text
+            assert "E1S01" in video.json()["detail"]
             assert fake_queue.calls == []
 
     def test_video_dirty_script_fail_fast_400(self, tmp_path, monkeypatch):

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -211,6 +212,7 @@ class TestGenerateRouter:
             assert video.status_code == 200, video.text
             assert video.json()["success"] is True
 
+    @pytest.mark.integration
     def test_video_storyboard_image_non_string_returns_400(self, tmp_path, monkeypatch):
         """storyboard_image 是剧本 JSON 里的脏数据（非字符串）时应 400 可读失败，
         而不是让 `project_path / storyboard_rel` 抛未处理 TypeError 变成 500。"""
@@ -228,6 +230,7 @@ class TestGenerateRouter:
             assert video.status_code == 400, video.text
             assert fake_queue.calls == []
 
+    @pytest.mark.integration
     def test_video_storyboard_image_absolute_path_returns_400(self, tmp_path, monkeypatch):
         """storyboard_image 是绝对路径时应 400 可读失败，不越权引用项目外文件。"""
         project_path = _prepare_files(tmp_path)
@@ -244,6 +247,7 @@ class TestGenerateRouter:
             assert video.status_code == 400, video.text
             assert fake_queue.calls == []
 
+    @pytest.mark.integration
     def test_video_storyboard_image_path_traversal_returns_400(self, tmp_path, monkeypatch):
         """storyboard_image 含 `..` 越出项目目录时应 400 可读失败，不越权引用项目外文件。"""
         project_path = _prepare_files(tmp_path)

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from lib.i18n import _ as i18n_message
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import generate
@@ -228,8 +229,7 @@ class TestGenerateRouter:
                 json={"script_file": "episode_1.json", "prompt": "x"},
             )
             assert video.status_code == 400, video.text
-            # detail 走 invalid_storyboard_image_path 这条可读文案，不是通用 500/内部错误
-            assert "E1S01" in video.json()["detail"]
+            assert video.json()["detail"] == i18n_message("invalid_storyboard_image_path", segment_id="E1S01")
             assert fake_queue.calls == []
 
     @pytest.mark.integration
@@ -247,7 +247,7 @@ class TestGenerateRouter:
                 json={"script_file": "episode_1.json", "prompt": "x"},
             )
             assert video.status_code == 400, video.text
-            assert "E1S01" in video.json()["detail"]
+            assert video.json()["detail"] == i18n_message("invalid_storyboard_image_path", segment_id="E1S01")
             assert fake_queue.calls == []
 
     @pytest.mark.integration
@@ -265,7 +265,7 @@ class TestGenerateRouter:
                 json={"script_file": "episode_1.json", "prompt": "x"},
             )
             assert video.status_code == 400, video.text
-            assert "E1S01" in video.json()["detail"]
+            assert video.json()["detail"] == i18n_message("invalid_storyboard_image_path", segment_id="E1S01")
             assert fake_queue.calls == []
 
     def test_video_dirty_script_fail_fast_400(self, tmp_path, monkeypatch):

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -211,6 +211,55 @@ class TestGenerateRouter:
             assert video.status_code == 200, video.text
             assert video.json()["success"] is True
 
+    def test_video_storyboard_image_non_string_returns_400(self, tmp_path, monkeypatch):
+        """storyboard_image 是剧本 JSON 里的脏数据（非字符串）时应 400 可读失败，
+        而不是让 `project_path / storyboard_rel` 抛未处理 TypeError 变成 500。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": 123}
+        fake_queue = _FakeQueue()
+        client = _client(monkeypatch, fake_pm, fake_queue)
+
+        with client:
+            video = client.post(
+                "/api/v1/projects/demo/generate/video/E1S01",
+                json={"script_file": "episode_1.json", "prompt": "x"},
+            )
+            assert video.status_code == 400, video.text
+            assert fake_queue.calls == []
+
+    def test_video_storyboard_image_absolute_path_returns_400(self, tmp_path, monkeypatch):
+        """storyboard_image 是绝对路径时应 400 可读失败，不越权引用项目外文件。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "/etc/passwd"}
+        fake_queue = _FakeQueue()
+        client = _client(monkeypatch, fake_pm, fake_queue)
+
+        with client:
+            video = client.post(
+                "/api/v1/projects/demo/generate/video/E1S01",
+                json={"script_file": "episode_1.json", "prompt": "x"},
+            )
+            assert video.status_code == 400, video.text
+            assert fake_queue.calls == []
+
+    def test_video_storyboard_image_path_traversal_returns_400(self, tmp_path, monkeypatch):
+        """storyboard_image 含 `..` 越出项目目录时应 400 可读失败，不越权引用项目外文件。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "../../outside.png"}
+        fake_queue = _FakeQueue()
+        client = _client(monkeypatch, fake_pm, fake_queue)
+
+        with client:
+            video = client.post(
+                "/api/v1/projects/demo/generate/video/E1S01",
+                json={"script_file": "episode_1.json", "prompt": "x"},
+            )
+            assert video.status_code == 400, video.text
+            assert fake_queue.calls == []
+
     def test_video_dirty_script_fail_fast_400(self, tmp_path, monkeypatch):
         """脏脚本(分镜数组键损坏)时,/generate/video 应在路由层 4xx 失败,
         而不是 silently 走 default storyboard 路径继续 enqueue —— 后者会让用户


### PR DESCRIPTION
Closes #1366

## 问题

视频入队前的分镜图存在性预检直接拼接 `project_path / storyboard_image`：剧本 JSON 里的字段值非字符串时先抛 TypeError 退化成通用 500，绝对路径 / `..` 引用则未经校验。涉及路由侧单条入队与 SDK 工具侧的批量、单条两个入口。

## 改动

- `lib/storyboard_sequence.py` 新增 `resolve_storyboard_image_ref`：把执行层已有的校验口径（类型检查 + 显式拒绝绝对路径（含 Windows 无盘符根路径）+ `try_safe_join` 越界校验 + `storyboards/` 目录归属）提取为单一实现。字段未设置返回 `None`，由调用方按各自默认路径回退；非法值抛 `ValueError`，两支失败文案区分「非法路径」与「不在 storyboards/ 内」。
- 四个调用点改为共用该函数：执行层 `execute_video_task`（原内联逻辑逐项等价搬迁，行为不变）、路由 `generate_video`（`ValueError` → 400 `invalid_storyboard_image_path`，新增三语文案）、SDK 工具 `generate_video_scene_tool`（上抛，由外层转为可读的工具错误文本）、SDK 工具 `_build_video_specs`（批量扫描下单条非法只记日志并跳过，不中断整批，沿用该循环既有的跳过语义）。
- 两处 SDK 预检的存在性检查由 `exists()` 收紧为 `is_file()`，与执行层口径一致：字段被外部编辑指向目录时 `exists()` 仍为真，目录会被当作分镜图继续往下走，直到编码阶段才以不可读的原因失败。

旧宫格项目的 `scene_{id}_first.png` 仍走目录归属校验而非与 canonical 路径逐一比对，因此不受影响。

## 验证

- 新增回归测试覆盖非字符串、绝对路径、`..` 越界三类非法输入，分别落在路由侧（400）与 SDK 工具侧的批量、单条两个入口：`tests/test_generate_router.py`、`tests/server/agent_runtime/test_sdk_tools.py`
- `uv run ruff check . && uv run ruff format --check .` 通过
- `uv run basedpyright` 0 error
- `uv run python -m pytest` 全量 6538 passed（含 `tests/test_i18n_consistency.py` 三语一致性）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **安全性**
  - 更严格校验分镜图片引用：拒绝非字符串、绝对路径、目录穿越及越界目录归属，避免不可信输入导致的越权读取与异常。
- **错误提示**
  - 新增多语言错误码 `invalid_storyboard_image_path`：当分镜图引用无效时提示重新生成对应分镜图。
- **稳定性**
  - 批量生成遇到无效引用自动跳过对应条目；视频生成接口对非法输入返回明确的 400。
- **测试**
  - 补充路由与视频生成工具的防御性回归用例，覆盖非字符串/绝对路径/目录穿越，确保不入队且不终止整批任务。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->