### PR TITLE
fix(video): 参考生视频重试与重新生成时生成按钮全程禁用，不会重复入队

### DIFF
--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
@@ -290,11 +290,15 @@ describe("ReferenceVideoCanvas", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /Generating|生成中/ })).toBeDisabled();
     });
+    // 旧任务行仍是 failed，statusMap 未变；预览区不能同时叠出「生成中」占位与
+    // 旧失败覆盖层——inFlight 应压过 failed 的展示（回归 Codex P2）。
+    expect(screen.queryByText(/Generation failed|生成失败/)).not.toBeInTheDocument();
     resolveGen({ task_id: "t2", deduped: false });
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /Generating|生成中/ })).toBeDisabled();
     });
+    expect(screen.queryByText(/Generation failed|生成失败/)).not.toBeInTheDocument();
   });
 
   // 重新生成路径：旧成功行始终在，statusMap 的乐观分支不生效，同样需要按占用集

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
@@ -3,11 +3,30 @@ import { render, screen, waitFor, fireEvent, act } from "@testing-library/react"
 import { ReferenceVideoCanvas } from "./ReferenceVideoCanvas";
 import { useReferenceVideoStore } from "@/stores/reference-video-store";
 import { useProjectsStore } from "@/stores/projects-store";
-import { useTasksStore } from "@/stores/tasks-store";
+import { useActiveResourceIds, useLatestTasksByResource, useTasksStore } from "@/stores/tasks-store";
 import { useAppStore } from "@/stores/app-store";
 import { API } from "@/api";
 import type { ReferenceVideoUnit } from "@/types";
 import type { ProjectData } from "@/types";
+
+// useActiveResourceIds / useLatestTasksByResource 默认包裹真实实现，仅在个别用例里
+// 冻结返回值模拟「响应式信号尚未追上真实 store」的场景，验证提交 handler 不依赖它们、
+// 独立用 getState() 新鲜读 store。
+const mockHolder = vi.hoisted(() => ({
+  realActiveResourceIds: undefined as unknown as typeof import("@/stores/tasks-store").useActiveResourceIds,
+  realLatestTasksByResource:
+    undefined as unknown as typeof import("@/stores/tasks-store").useLatestTasksByResource,
+}));
+vi.mock("@/stores/tasks-store", async () => {
+  const actual = await vi.importActual<typeof import("@/stores/tasks-store")>("@/stores/tasks-store");
+  mockHolder.realActiveResourceIds = actual.useActiveResourceIds;
+  mockHolder.realLatestTasksByResource = actual.useLatestTasksByResource;
+  return {
+    ...actual,
+    useActiveResourceIds: vi.fn(actual.useActiveResourceIds),
+    useLatestTasksByResource: vi.fn(actual.useLatestTasksByResource),
+  };
+});
 
 function mkUnit(id: string, shotText = "x"): ReferenceVideoUnit {
   return {
@@ -42,6 +61,8 @@ const STUB_PROJECT: ProjectData = {
 
 describe("ReferenceVideoCanvas", () => {
   beforeEach(() => {
+    vi.mocked(useActiveResourceIds).mockImplementation(mockHolder.realActiveResourceIds);
+    vi.mocked(useLatestTasksByResource).mockImplementation(mockHolder.realLatestTasksByResource);
     useReferenceVideoStore.setState({ unitsByEpisode: {}, selectedUnitId: null, loading: false, error: null });
     useProjectsStore.setState({ currentProjectName: "proj", currentProjectData: STUB_PROJECT });
     // 乐观标记由入队动作层写入且跨测试共享同一 store 实例，须一并重置
@@ -263,6 +284,12 @@ describe("ReferenceVideoCanvas", () => {
     const retry = await screen.findByRole("button", { name: /Retry generation|重试生成/ });
     fireEvent.click(retry);
     await waitFor(() => expect(genSpy).toHaveBeenCalled());
+
+    // 请求在途（响应未回、动作层乐观打标尚未落）时按钮就必须已禁用——AC 要求的
+    // 窗口起点是「请求发出」，不是「响应返回」。
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Generating|生成中/ })).toBeDisabled();
+    });
     resolveGen({ task_id: "t2", deduped: false });
 
     await waitFor(() => {
@@ -299,11 +326,54 @@ describe("ReferenceVideoCanvas", () => {
     const regenerate = await screen.findByRole("button", { name: /Regenerate video|重新生成视频/ });
     fireEvent.click(regenerate);
     await waitFor(() => expect(genSpy).toHaveBeenCalled());
+
+    // 同上：请求往返期间即须禁用，而非等响应回来才禁用。
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Generating|生成中/ })).toBeDisabled();
+    });
     resolveGen({ task_id: "t2", deduped: false });
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /Generating|生成中/ })).toBeDisabled();
     });
+  });
+
+  // 提交时刻复核：渲染期捕获的占用信号已过期（真实 store 里该 unit 已被别的入口占用），
+  // 点击须被 getState() 新鲜读拦下并提示，不得静默再发一次入队请求。
+  it("响应式占用信号尚未追上真实 store 时，生成提交仍被 getState() 新鲜读拦截", async () => {
+    vi.spyOn(API, "listReferenceVideoUnits").mockResolvedValue({ units: [mkUnit("E1U1")] });
+    const genSpy = vi
+      .spyOn(API, "generateReferenceVideoUnit")
+      .mockResolvedValue({ task_id: "t1", deduped: false } as never);
+    const pushToast = vi.spyOn(useAppStore.getState(), "pushToast");
+    // 冻结两个响应式 hook——模拟面板渲染期捕获的 busy/status 未能反映随后落库的任务行
+    vi.mocked(useActiveResourceIds).mockReturnValue(new Set());
+    vi.mocked(useLatestTasksByResource).mockReturnValue(new Map());
+
+    render(<ReferenceVideoCanvas projectName="proj" episode={1} />);
+
+    const generate = await screen.findByRole("button", { name: /Generate video|生成视频/ });
+    expect(generate).not.toBeDisabled();
+
+    // 渲染之后、点击之前，另一入口（Agent 入队 / SSE 落库）已占用同一 unit
+    act(() => {
+      useTasksStore.setState({
+        tasks: [
+          {
+            task_id: "t1",
+            project_name: "proj",
+            task_type: "reference_video",
+            resource_id: "E1U1",
+            status: "running",
+            updated_at: "2026-06-12T10:00:00Z",
+          },
+        ] as never,
+      });
+    });
+
+    fireEvent.click(generate);
+    await waitFor(() => expect(pushToast).toHaveBeenCalled());
+    expect(genSpy).not.toHaveBeenCalled();
   });
 
   // 后台任务失败通知已统一迁移到全局 useTaskFailureNotifications hook（转变驱动 /

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
@@ -235,6 +235,77 @@ describe("ReferenceVideoCanvas", () => {
     });
   });
 
+  // 重试路径：旧失败行始终在，statusMap 的乐观分支（!queueRow）不生效，禁用须
+  // 直接取占用集，否则入队到任务行落库之间的窗口内按钮可重复点击。
+  it("重试失败 unit 后在真实任务行落库前即禁用按钮", async () => {
+    vi.spyOn(API, "listReferenceVideoUnits").mockResolvedValue({ units: [mkUnit("E1U1")] });
+    useTasksStore.setState({
+      tasks: [
+        {
+          task_id: "t1",
+          project_name: "proj",
+          task_type: "reference_video",
+          resource_id: "E1U1",
+          status: "failed",
+          error_message: "供应商拒绝",
+          updated_at: "2026-06-12T10:00:00Z",
+        },
+      ] as never,
+    });
+    let resolveGen: (v: { task_id: string; deduped: boolean }) => void = () => {};
+    const genSpy = vi.spyOn(API, "generateReferenceVideoUnit").mockReturnValue(
+      new Promise((resolve) => {
+        resolveGen = resolve;
+      }),
+    );
+    render(<ReferenceVideoCanvas projectName="proj" episode={1} />);
+
+    const retry = await screen.findByRole("button", { name: /Retry generation|重试生成/ });
+    fireEvent.click(retry);
+    await waitFor(() => expect(genSpy).toHaveBeenCalled());
+    resolveGen({ task_id: "t2", deduped: false });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Generating|生成中/ })).toBeDisabled();
+    });
+  });
+
+  // 重新生成路径：旧成功行始终在，statusMap 的乐观分支不生效，同样需要按占用集
+  // 独立禁用，不能仅靠 statusMap 派生的 status。
+  it("重新生成已完成 unit 后在真实任务行落库前即禁用按钮", async () => {
+    const unit = mkUnit("E1U1");
+    unit.generated_assets.video_clip = "videos/E1U1.mp4";
+    vi.spyOn(API, "listReferenceVideoUnits").mockResolvedValue({ units: [unit] });
+    useTasksStore.setState({
+      tasks: [
+        {
+          task_id: "t1",
+          project_name: "proj",
+          task_type: "reference_video",
+          resource_id: "E1U1",
+          status: "succeeded",
+          updated_at: "2026-06-12T10:00:00Z",
+        },
+      ] as never,
+    });
+    let resolveGen: (v: { task_id: string; deduped: boolean }) => void = () => {};
+    const genSpy = vi.spyOn(API, "generateReferenceVideoUnit").mockReturnValue(
+      new Promise((resolve) => {
+        resolveGen = resolve;
+      }),
+    );
+    render(<ReferenceVideoCanvas projectName="proj" episode={1} />);
+
+    const regenerate = await screen.findByRole("button", { name: /Regenerate video|重新生成视频/ });
+    fireEvent.click(regenerate);
+    await waitFor(() => expect(genSpy).toHaveBeenCalled());
+    resolveGen({ task_id: "t2", deduped: false });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Generating|生成中/ })).toBeDisabled();
+    });
+  });
+
   // 后台任务失败通知已统一迁移到全局 useTaskFailureNotifications hook（转变驱动 /
   // 历史失败不重报 / 同一失败只报一次回归均在那里覆盖），见
   // hooks/useTaskFailureNotifications.test.tsx。此处只验证回跳消费。

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -143,6 +143,12 @@ export function ReferenceVideoCanvas({
 
   const generating = !!(selected && statusMap[selected.unit_id] === "running");
 
+  // 独立于 statusMap 传给 UnitPreviewPanel：重试（旧失败行在）与重新生成（旧成功行在）
+  // 两条路径上 queueRow 始终非空，statusMap 的乐观分支不生效，仅看 status 会在入队到
+  // 任务行落库之间的窗口内漏禁用生成按钮。
+  const selectedBusy = !!(selected && busyUnitIds.has(selected.unit_id));
+  const selectedCancelling = !!(selected && tasksByUnit.get(selected.unit_id)?.status === "cancelling");
+
   const failureMessage = useMemo(() => {
     if (!selected) return null;
     if (statusMap[selected.unit_id] !== "failed") return null;
@@ -760,6 +766,8 @@ export function ReferenceVideoCanvas({
                           projectName={projectName}
                           status={statusMap[selected.unit_id]}
                           errorMessage={failureMessage}
+                          busy={selectedBusy}
+                          cancelling={selectedCancelling}
                           estimatedCost={estimatedCost}
                           actualCost={actualCost}
                           onGenerate={onGenerateVoid}
@@ -786,6 +794,8 @@ export function ReferenceVideoCanvas({
                   projectName={projectName}
                   status={selected ? statusMap[selected.unit_id] : undefined}
                   errorMessage={failureMessage}
+                  busy={selectedBusy}
+                  cancelling={selectedCancelling}
                   estimatedCost={estimatedCost}
                   actualCost={actualCost}
                   onGenerate={onGenerateVoid}

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -22,7 +22,13 @@ import {
   useReferenceVideoStore,
   referenceVideoCacheKey,
 } from "@/stores/reference-video-store";
-import { isActiveStatus, useActiveResourceIds, useLatestTasksByResource } from "@/stores/tasks-store";
+import {
+  isActiveStatus,
+  selectActiveResourceIds,
+  useActiveResourceIds,
+  useLatestTasksByResource,
+  useTasksStore,
+} from "@/stores/tasks-store";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useCostStore } from "@/stores/cost-store";
@@ -121,6 +127,13 @@ export function ReferenceVideoCanvas({
 
   const [uploadingUnitIds, setUploadingUnitIds] = useState<Set<string>>(() => new Set());
 
+  // 入队请求自身在途的 unit：动作层的乐观打标要等 API 响应回来才落，这段往返里
+  // busyUnitIds 仍是空的，只靠它禁用会在「请求已发出、响应未回」的窗口内漏禁用。
+  // ref 是提交时刻复核的同步真相源（同一 tick 内连点时 state 尚未提交到闭包），
+  // state 仅用于驱动禁用态重渲染。
+  const submittingRef = useRef<Set<string>>(new Set());
+  const [submittingUnitIds, setSubmittingUnitIds] = useState<Set<string>>(() => new Set());
+
   const statusMap = useMemo<Record<string, UnitStatus>>(() => {
     const map: Record<string, UnitStatus> = {};
     for (const u of units) {
@@ -145,8 +158,12 @@ export function ReferenceVideoCanvas({
 
   // 独立于 statusMap 传给 UnitPreviewPanel：重试（旧失败行在）与重新生成（旧成功行在）
   // 两条路径上 queueRow 始终非空，statusMap 的乐观分支不生效，仅看 status 会在入队到
-  // 任务行落库之间的窗口内漏禁用生成按钮。
-  const selectedBusy = !!(selected && busyUnitIds.has(selected.unit_id));
+  // 任务行落库之间的窗口内漏禁用生成按钮。submittingUnitIds 补上请求往返那一段，
+  // 合起来覆盖「请求发出 → 乐观打标 → 真实任务行落库」全程。
+  const selectedBusy = !!(
+    selected &&
+    (busyUnitIds.has(selected.unit_id) || submittingUnitIds.has(selected.unit_id))
+  );
   const selectedCancelling = !!(selected && tasksByUnit.get(selected.unit_id)?.status === "cancelling");
 
   const failureMessage = useMemo(() => {
@@ -177,11 +194,25 @@ export function ReferenceVideoCanvas({
   const handleGenerate = useCallback(
     async (unitId: string) => {
       setStackTab("preview");
+      // 提交前用 getState() 新鲜读复核：按钮渲染期捕获的占用态未必是最新的
+      // （批量循环、Agent 入队、SSE 落库都可能在渲染之后、点击之前占用同一 unit）。
+      const { tasks, optimisticActive } = useTasksStore.getState();
+      const live = selectActiveResourceIds(tasks, "reference_video", projectName, optimisticActive);
+      if (live.has(unitId) || submittingRef.current.has(unitId)) {
+        useAppStore.getState().pushToast(t("reference_generate_busy"), "error");
+        return;
+      }
+      submittingRef.current.add(unitId);
+      setSubmittingUnitIds(new Set(submittingRef.current));
       try {
         // 入队成功的乐观打标与 queued/deduped 提示都在动作层内完成
         await enqueueReferenceVideoUnit(projectName, episode, unitId);
       } catch (e) {
         toastError(e, (msg) => t("reference_generate_request_failed", { error: msg }));
+      } finally {
+        // 打标已由动作层完成（失败时无标可解），此处只交还请求在途标记
+        submittingRef.current.delete(unitId);
+        setSubmittingUnitIds(new Set(submittingRef.current));
       }
     },
     [projectName, episode, t],

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
@@ -98,12 +98,14 @@ export function UnitPreviewPanel({
           {t("reference_preview_label")}
         </span>
         <span className="flex-1" />
+        {/* 上传是同一 unit 上的兄弟控件，与主 CTA 同步接线禁用：cancelling 期间
+            inFlight 为假但占用仍在，上传会与在跑的生成回写同一个成片文件 */}
         {onUploadVideo && (
           <UploadIconButton
             accept={UPLOAD_VIDEO_ACCEPT}
             label={t("media_upload_video")}
             busy={uploadingVideo}
-            disabled={inFlight}
+            disabled={inFlight || busy}
             onSelect={(f) => void onUploadVideo(unit.unit_id, f)}
           />
         )}

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
@@ -16,6 +16,14 @@ export interface UnitPreviewPanelProps {
   status?: UnitStatus;
   /** Latest task error message (if any) for the failed state. */
   errorMessage?: string | null;
+  /**
+   * 占用集（含入队后真实任务行落库前的乐观标记）命中与否，独立于 status：
+   * status 的乐观分支只在无任务行时生效（保持 cancelling 不显示为生成中），
+   * 重试与重新生成这两条路径上旧任务行始终在，仅看 status 会在乐观窗口内漏禁用。
+   */
+  busy?: boolean;
+  /** 最新任务行是否处于取消中——占用集会计入 cancelling，但不应展示为「生成中」。 */
+  cancelling?: boolean;
   /** Estimated cost for this unit (optional; rendered next to the CTA). */
   estimatedCost?: CostBreakdown;
   /** Actual already-spent cost; rendered in the metadata block. */
@@ -40,6 +48,8 @@ export function UnitPreviewPanel({
   projectName,
   status,
   errorMessage,
+  busy = false,
+  cancelling = false,
   estimatedCost,
   actualCost,
   onGenerate,
@@ -67,8 +77,12 @@ export function UnitPreviewPanel({
   // 还为 null —— 这种情况下走 inFlight 占位避免空白面板。
   const ready = effectiveStatus === "ready" && Boolean(videoUrl);
   const failed = effectiveStatus === "failed";
+  // busy 一并计入，使重试/重新生成在乐观窗口内也占位；但 cancelling 时排除在外——
+  // 取消中不是「生成中」，展示层沿用取消前的状态，仅按钮仍需保持禁用（见下方 disabled）。
   const inFlight =
-    effectiveStatus === "running" || (effectiveStatus === "ready" && !videoUrl);
+    (busy && !cancelling) ||
+    effectiveStatus === "running" ||
+    (effectiveStatus === "ready" && !videoUrl);
 
   const ctaLabel = ready
     ? t("reference_preview_regenerate")
@@ -184,9 +198,9 @@ export function UnitPreviewPanel({
         <button
           type="button"
           onClick={() => onGenerate(unit.unit_id)}
-          disabled={inFlight}
+          disabled={inFlight || busy}
           className={`focus-ring inline-flex items-center justify-center gap-2 rounded-lg px-3.5 py-2.5 text-sm font-semibold transition-colors ${
-            inFlight
+            inFlight || busy
               ? "cursor-not-allowed border border-[var(--color-hairline)] bg-[oklch(0.22_0.011_265_/_0.6)] text-[var(--color-text-3)]"
               : "text-[oklch(0.14_0_0)] [background:linear-gradient(180deg,var(--color-accent-2),var(--color-accent))] shadow-[inset_0_1px_0_oklch(1_0_0_/_0.3),0_4px_14px_-4px_var(--color-accent-glow)]"
           }`}

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
@@ -165,7 +165,7 @@ export function UnitPreviewPanel({
           </div>
         )}
 
-        {failed && (
+        {failed && !inFlight && (
           <div className="absolute inset-0 grid place-items-center p-5">
             <div className="max-w-[280px] text-center">
               <div className="mx-auto mb-2.5 grid h-9 w-9 place-items-center rounded-full border border-red-400/60 bg-red-500/15 text-red-300">

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -982,6 +982,7 @@ export default {
   'reference_tab_preprocess': 'Splitting preprocess',
   'reference_batch_generate': 'Batch generate videos',
   'reference_batch_nothing_to_do': 'All units are already generated or in flight',
+  'reference_generate_busy': 'This unit is generating, try again later',
   'reference_episode_header_units_one': '{{count}} unit',
   'reference_episode_header_units_other': '{{count}} units',
   'reference_episode_header_ready': 'Ready',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -953,6 +953,7 @@ export default {
   'reference_tab_preprocess': 'Tiền xử lý tách',
   'reference_batch_generate': 'Tạo hàng loạt',
   'reference_batch_nothing_to_do': 'Tất cả đơn vị đã được tạo hoặc đang xử lý',
+  'reference_generate_busy': 'Đơn vị này đang được tạo, vui lòng thử lại sau',
   'reference_episode_header_units_one': '{{count}} đơn vị',
   'reference_episode_header_units_other': '{{count}} đơn vị',
   'reference_episode_header_ready': 'Sẵn sàng',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -982,6 +982,7 @@ export default {
   'reference_tab_preprocess': '拆分预处理',
   'reference_batch_generate': '批量生成视频',
   'reference_batch_nothing_to_do': '所有 Unit 都已生成或正在生成中',
+  'reference_generate_busy': '该 Unit 正在生成中，请稍后再试',
   'reference_episode_header_units_one': '{{count}} 单元',
   'reference_episode_header_units_other': '{{count}} 单元',
   'reference_episode_header_ready': '就绪',


### PR DESCRIPTION
Closes #1367

## 问题

drama/narration 参考生视频画布的分组生成按钮，禁用判定取自 `statusMap`，而 `statusMap` 的乐观分支带 `!queueRow` 前置条件。重试（旧失败行在）与重新生成（旧成功行在）两条路径上 `queueRow` 始终非空、乐观分支不触发，入队在途期间按钮仍可点击，可重复入队同一 unit。

## 改动

- **禁用判定改走独立入参**：`UnitPreviewPanel` 新增 `busy` / `cancelling` 两个入参承担禁用判定，`statusMap` 本身不动——`cancelling` 不显示为「生成中」的展示语义保持原样，但按钮在取消中仍维持禁用。与已合并的 `AdUnitCard` 同款修法。
- **覆盖窗口全程**：入队动作层的乐观打标要等 API 响应返回才落，请求往返那一段占用集仍为空。新增请求在途标记补上这段，与乐观打标、真实任务行接力，覆盖「请求发出 → 乐观打标 → 任务行落库」全程。
- **提交时刻复核占用态**：`handleGenerate` 提交前用 `getState()` 新鲜读复核，拦下渲染之后、点击之前由其他入口（批量循环 / Agent 入队 / SSE 落库）产生的占用，命中即提示并中止。
- **兄弟控件同步禁用**：预览面板的视频上传按钮与主 CTA 同步接线，避免取消中占用仍在时上传与在跑的生成回写同一个成片文件。
- 新增 `reference_generate_busy` 三语文案。

## 验证

- 5 条回归测试覆盖重试 / 重新生成两条路径的请求在途禁用、响应返回后禁用，以及响应式占用信号过期时提交被新鲜读拦截。逐项做过红绿验证：移除请求在途标记 → 2 条失败；移除 `getState()` 复核 → 1 条失败；移除独立 `busy` 入参 → 2 条失败。
- `pnpm lint` 通过；`pnpm check`（typecheck + 全量 vitest）通过，128 文件 / 1271 测试全绿。
- 未做真机浏览器验证，仅 vitest + jsdom 覆盖。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复参考视频生成从点击到任务落库前短暂未禁用的问题，通过“提交中”占用态补齐拦截。
  * 防止同一单元在落库前重复提交，并在占用时展示 `reference_generate_busy` 提示（中/英/越南语）。
  * 取消相关流程期间保持一致的禁用表现，避免生成中显示错误覆盖层。
* **Tests**
  * 补充失败重试、成功后重新生成及占用复核拦截的场景用例，并增强响应式 hook 的可控模拟。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->