### PR TITLE
feat(agent): 智能体可一键重置分集规划，从损坏的分集账本中恢复

### DIFF
--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1289,6 +1289,7 @@ export default {
   'tool_name_get_video_capabilities': 'Query video model capabilities',
   'tool_name_plan_episodes': 'Plan episodes',
   'tool_name_replan_episodes': 'Replan episodes',
+  'tool_name_reset_episode_planning': 'Reset episode planning',
   'tool_name_patch_episode_script': 'Edit shot field',
   'tool_name_patch_episode_meta': 'Edit episode title',
   'tool_name_insert_segment': 'Insert shot',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1409,6 +1409,7 @@ export default {
   'tool_name_get_video_capabilities': 'Truy vấn năng lực mô hình video',
   'tool_name_plan_episodes': 'Lập kế hoạch chia tập',
   'tool_name_replan_episodes': 'Sắp xếp lại các tập',
+  'tool_name_reset_episode_planning': 'Đặt lại kế hoạch chia tập',
   'tool_name_patch_episode_script': 'Sửa trường phân cảnh',
   'tool_name_patch_episode_meta': 'Sửa tiêu đề tập',
   'tool_name_insert_segment': 'Chèn phân cảnh',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1289,6 +1289,7 @@ export default {
   'tool_name_get_video_capabilities': '查询视频模型能力',
   'tool_name_plan_episodes': '分集规划',
   'tool_name_replan_episodes': '分集重排',
+  'tool_name_reset_episode_planning': '重置分集规划',
   'tool_name_patch_episode_script': '编辑分镜字段',
   'tool_name_patch_episode_meta': '编辑分集标题',
   'tool_name_insert_segment': '插入分镜',

--- a/lib/episode_ledger.py
+++ b/lib/episode_ledger.py
@@ -174,11 +174,20 @@ def _read_text_or_none(path: Path) -> str | None:
 
 def parse_episode_num(value: Any) -> int | None:
     """宽松解析条目集号：int（排除 bool——True 会与第 1 集同键碰撞）或纯数字
-    字符串（历史手编数据），其余返回 None（条目原样保留，不参与回填）。"""
+    字符串（历史手编数据），其余返回 None（条目原样保留，不参与回填）。
+
+    ``str.isdigit()`` 认可的字符集比 ``int()`` 能转换的更宽（如上标 ``²``、
+    带圈数字 ``①``），损坏账本写入这类字符会让 ``isdigit()`` 放行但 ``int()`` 抛
+    ``ValueError``；两者不一致时同样返回 None，不能让调用方（含零前置校验的重置
+    逃生口）因此崩溃。
+    """
     if isinstance(value, int) and not isinstance(value, bool):
         return value
     if isinstance(value, str) and value.isdigit():
-        return int(value)
+        try:
+            return int(value)
+        except ValueError:
+            return None
     return None
 
 
@@ -211,6 +220,12 @@ def discover_episode_file_aliases(project_dir: Path) -> dict[int, list[Path]]:
     同一集号可能因命名 padding 不同（``episode_1.txt`` / ``episode_01.txt``）产生多个
     别名文件。大多数调用方只需其中一个代表路径（见 ``discover_episode_files``）；需要
     完整处置某集号全部派生文件的场景（如重置清理）用本函数取全部。
+
+    悬空符号链接（目标不存在）同样纳入：``Path.is_file()`` 会因链接目标缺失而返回
+    False，导致这类文件对发现逻辑完全不可见——处置类调用方（如重置）因此漏清它，
+    残留的悬空链接会在下一次派生文件写入时被 ``EpisodePlanner`` 的符号链接校验硬
+    拦截。``unlink()``/``rename()`` 只作用于链接条目本身、不跟随最终一段的链接目标，
+    纳入悬空链接不会引入跟随写入的风险。
     """
     source_dir = project_dir / "source"
     if not source_dir.is_dir():
@@ -218,7 +233,7 @@ def discover_episode_file_aliases(project_dir: Path) -> dict[int, list[Path]]:
     result: dict[int, list[Path]] = {}
     for path in sorted(source_dir.iterdir()):
         match = _EPISODE_FILE_RE.fullmatch(path.name)
-        if match and path.is_file():
+        if match and (path.is_file() or path.is_symlink()):
             result.setdefault(int(match.group(1)), []).append(path)
     return result
 

--- a/lib/episode_ledger.py
+++ b/lib/episode_ledger.py
@@ -36,6 +36,8 @@ LEDGER_STATUSES: tuple[str, ...] = get_args(LedgerStatus)
 
 # 仅 ASCII 数字：\d 会放行全角等 Unicode 数字，把非流水线产物误判为派生集文件
 _EPISODE_FILE_RE = re.compile(r"episode_([0-9]+)\.txt")
+_SCRIPT_FILE_RE = re.compile(r"episode_([0-9]+)\.json")
+_DRAFT_DIR_RE = re.compile(r"episode_([0-9]+)")
 
 # 「什么后缀算源文本文件」的唯一定义，候选枚举与其他源文读取方共用
 SOURCE_TEXT_SUFFIXES = {".txt", ".md"}
@@ -203,17 +205,50 @@ def discover_sources(project_dir: Path) -> list[SourceDoc]:
     return docs
 
 
-def discover_episode_files(project_dir: Path) -> dict[int, Path]:
-    """枚举派生集文件 source/episode_N.txt → {集号: 路径}。"""
+def discover_episode_file_aliases(project_dir: Path) -> dict[int, list[Path]]:
+    """枚举派生集文件的全部别名 source/episode_N.txt → {集号: [路径, ...]}（按文件名排序）。
+
+    同一集号可能因命名 padding 不同（``episode_1.txt`` / ``episode_01.txt``）产生多个
+    别名文件。大多数调用方只需其中一个代表路径（见 ``discover_episode_files``）；需要
+    完整处置某集号全部派生文件的场景（如重置清理）用本函数取全部。
+    """
     source_dir = project_dir / "source"
     if not source_dir.is_dir():
         return {}
-    result: dict[int, Path] = {}
+    result: dict[int, list[Path]] = {}
     for path in sorted(source_dir.iterdir()):
         match = _EPISODE_FILE_RE.fullmatch(path.name)
         if match and path.is_file():
-            result.setdefault(int(match.group(1)), path)
+            result.setdefault(int(match.group(1)), []).append(path)
     return result
+
+
+def discover_episode_files(project_dir: Path) -> dict[int, Path]:
+    """枚举派生集文件 source/episode_N.txt → {集号: 路径}（每号取排序后首个别名）。"""
+    return {num: paths[0] for num, paths in discover_episode_file_aliases(project_dir).items()}
+
+
+def discover_product_episode_nums(project_dir: Path) -> set[int]:
+    """枚举磁盘上有下游产物（剧本 JSON / step1 草稿目录）的集号，不依赖账本条目。
+
+    账本丢失条目（写坏/手工误删）但 ``scripts/episode_N.json`` 或
+    ``drafts/episode_N/`` 仍在磁盘时，仅从账本条目与 ``source/episode_N.txt`` 取候选
+    集号会漏掉这类孤儿产物，使其消费状态判定被跳过。
+    """
+    nums: set[int] = set()
+    scripts_dir = project_dir / "scripts"
+    if scripts_dir.is_dir():
+        for path in scripts_dir.iterdir():
+            match = _SCRIPT_FILE_RE.fullmatch(path.name)
+            if match and path.is_file():
+                nums.add(int(match.group(1)))
+    drafts_dir = project_dir / "drafts"
+    if drafts_dir.is_dir():
+        for path in drafts_dir.iterdir():
+            match = _DRAFT_DIR_RE.fullmatch(path.name)
+            if match and path.is_dir():
+                nums.add(int(match.group(1)))
+    return nums
 
 
 def _find_in_sources(

--- a/lib/episode_ledger.py
+++ b/lib/episode_ledger.py
@@ -239,8 +239,18 @@ def discover_episode_file_aliases(project_dir: Path) -> dict[int, list[Path]]:
 
 
 def discover_episode_files(project_dir: Path) -> dict[int, Path]:
-    """枚举派生集文件 source/episode_N.txt → {集号: 路径}（每号取排序后首个别名）。"""
-    return {num: paths[0] for num, paths in discover_episode_file_aliases(project_dir).items()}
+    """枚举派生集文件 source/episode_N.txt → {集号: 路径}（每号取一个代表路径）。
+
+    代表路径优先选可读的普通文件；该集号全部别名都是悬空符号链接时才退而取排序
+    后的首个。``discover_episode_file_aliases`` 按文件名排序、不区分悬空与否，若
+    悬空别名（如 ``episode_01.txt``）恰好排在有效文件（``episode_1.txt``）之前，
+    直接取首个会让 ``backfill_episode_ledger`` 等按内容匹配 ``source_range`` 的
+    调用方读到悬空链接而误判该集 unanchored，白白丢失本可从有效文件恢复的坐标。
+    """
+    result: dict[int, Path] = {}
+    for num, paths in discover_episode_file_aliases(project_dir).items():
+        result[num] = next((p for p in paths if p.is_file()), paths[0])
+    return result
 
 
 def discover_product_episode_nums(project_dir: Path) -> set[int]:
@@ -261,7 +271,10 @@ def discover_product_episode_nums(project_dir: Path) -> set[int]:
     if drafts_dir.is_dir():
         for path in drafts_dir.iterdir():
             match = _DRAFT_DIR_RE.fullmatch(path.name)
-            if match and path.is_dir():
+            # 目录存在不等于有产物：files.py::update_draft_content 会在校验草稿内容前
+            # 先建目录，一次被拒绝的无效保存就会留下空目录；只有真正落了 step1_* 才算
+            # 下游产物，与 has_downstream_products() 的口径保持一致
+            if match and path.is_dir() and any(path.glob("step1_*")):
                 nums.add(int(match.group(1)))
     return nums
 

--- a/lib/episode_ledger.py
+++ b/lib/episode_ledger.py
@@ -239,17 +239,21 @@ def discover_episode_file_aliases(project_dir: Path) -> dict[int, list[Path]]:
 
 
 def discover_episode_files(project_dir: Path) -> dict[int, Path]:
-    """枚举派生集文件 source/episode_N.txt → {集号: 路径}（每号取一个代表路径）。
+    """枚举派生集文件 source/episode_N.txt → {集号: 路径}（每号取一个可读的代表路径）。
 
-    代表路径优先选可读的普通文件；该集号全部别名都是悬空符号链接时才退而取排序
-    后的首个。``discover_episode_file_aliases`` 按文件名排序、不区分悬空与否，若
-    悬空别名（如 ``episode_01.txt``）恰好排在有效文件（``episode_1.txt``）之前，
-    直接取首个会让 ``backfill_episode_ledger`` 等按内容匹配 ``source_range`` 的
-    调用方读到悬空链接而误判该集 unanchored，白白丢失本可从有效文件恢复的坐标。
+    代表路径只从该集号别名中选可读的普通文件；全部别名都是悬空符号链接（无真实
+    内容）时该集号整体不出现在结果里，而不是退而返回一个读不到内容的路径——
+    ``discover_episode_file_aliases`` 按文件名排序、不区分悬空与否，若悬空别名
+    （如 ``episode_01.txt``）恰好排在有效文件（``episode_1.txt``）之前，直接取
+    排序首个会让 ``backfill_episode_ledger`` 等按内容匹配 ``source_range`` 的调用
+    方读到悬空链接：内容为空既会误判本可从有效别名恢复坐标的集为 unanchored，也
+    会给纯悬空、毫无真实内容的集号凭空补建一个 unanchored 幽灵条目。
     """
     result: dict[int, Path] = {}
     for num, paths in discover_episode_file_aliases(project_dir).items():
-        result[num] = next((p for p in paths if p.is_file()), paths[0])
+        readable = next((p for p in paths if p.is_file()), None)
+        if readable is not None:
+            result[num] = readable
     return result
 
 

--- a/lib/episode_ledger.py
+++ b/lib/episode_ledger.py
@@ -40,6 +40,10 @@ _EPISODE_FILE_RE = re.compile(r"episode_([0-9]+)\.txt")
 # 「什么后缀算源文本文件」的唯一定义，候选枚举与其他源文读取方共用
 SOURCE_TEXT_SUFFIXES = {".txt", ".md"}
 
+# project.json 顶层源文指纹字段（源文相对路径 → 归一化文本 sha256）。账本坐标绑定
+# 具体源文内容，指纹是「原文未变」的证据；全量重置把账本清空，指纹随之失效清除。
+SOURCE_FINGERPRINTS_KEY = "source_fingerprints"
+
 
 def _validate_rel_posix_path(value: str) -> str:
     """``source_file`` 的路径语义：项目根相对 POSIX 路径，拒绝绝对路径 / ``..`` / 反斜杠。
@@ -234,8 +238,11 @@ def _find_in_sources(
     return None
 
 
-def _has_downstream(project_dir: Path, episode_num: int, entry: Mapping[str, Any]) -> bool:
-    """该集是否已有下游产物（剧本 JSON / step1 中间文件；媒体必经剧本，剧本存在即覆盖）。"""
+def has_downstream_products(project_dir: Path, episode_num: int, entry: Mapping[str, Any]) -> bool:
+    """该集是否已有下游产物（剧本 JSON / step1 中间文件；媒体必经剧本，剧本存在即覆盖）。
+
+    磁盘证据优先于账本状态：账本损坏（状态缺失/错乱）时仍能判定该集是否已被消费。
+    """
     script_file = entry.get("script_file")
     if isinstance(script_file, str) and safe_exists(project_dir, script_file):
         return True
@@ -352,7 +359,7 @@ def backfill_episode_ledger(project_dir: Path, project: Mapping[str, Any]) -> di
 
         doc, start, end = anchored
         entry["source_range"] = {"source_file": doc.rel_path, "start": start, "end": end}
-        entry["ledger_status"] = "consumed" if _has_downstream(project_dir, num, entry) else "planned"
+        entry["ledger_status"] = "consumed" if has_downstream_products(project_dir, num, entry) else "planned"
         # 直接赋值（允许回退）：全文退化命中早于游标说明用户重切过，后续集跟随新布局
         doc.cursor = end
         last_doc = doc

--- a/lib/episode_reset.py
+++ b/lib/episode_reset.py
@@ -1,0 +1,238 @@
+"""分集规划重置：把账本退回未规划状态的逃生口。
+
+账本坐标绑定具体源文内容，源文被替换或账本被写坏后，规划入口会因坐标越界 /
+范围无效而永久失败。全量重置（``from_episode=1``）是这种局面的唯一出路：
+**零前置校验**——不读旧坐标、不解析范围，账本处于任何损坏状态都必须执行成功，
+执行后 ``episodes`` 清空、``planning_cursor`` 置 null、源文指纹清除，
+``plan_episodes`` 可从头重新规划。
+
+本模块刻意不依赖 :class:`lib.text_generator.TextGenerator`：重置不调模型，
+逃生口不能因供应商未配置而失效。写入与 ``EpisodePlanner`` 共用同一把项目锁
+（``ProjectManager.update_project``），提交纪律一致。
+
+派生集文件按「是否可从账本重造」分流：账本条目带 ``source_range`` 的
+``source/episode_N.txt`` 是派生物，直接删除；无 ``source_range`` 的集文件可能是
+老项目原件（含手工内容，无坐标可重造），改名留底而非删除。下游产物（剧本 JSON、
+step1 中间文件、媒体）一律不删。
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from lib.episode_ledger import (
+    SOURCE_FINGERPRINTS_KEY,
+    discover_episode_files,
+    has_downstream_products,
+    parse_episode_num,
+)
+from lib.project_manager import ProjectManager
+
+logger = logging.getLogger(__name__)
+
+
+class EpisodeResetError(RuntimeError):
+    """分集规划重置失败。"""
+
+
+class EpisodeResetConflictError(EpisodeResetError):
+    """重置期间账本被并发修改（出现确认清单之外的已消费集），提交被拒绝。"""
+
+
+@dataclass
+class ResetConfirmationRequired:
+    """重置波及已消费集，需显式确认（``confirm_consumed=True``）后才执行。
+
+    返回本对象时未发生任何写入，``archived_files`` 供调用方向用户交代留底去向。
+    """
+
+    consumed_episodes: list[int]
+    archived_files: list[str] = field(default_factory=list)
+
+
+@dataclass
+class EpisodeResetResult:
+    """重置执行结果：清掉的集号与文件处置去向（相对项目根的 POSIX 路径）。"""
+
+    removed_episodes: list[int]
+    deleted_files: list[str]
+    archived_files: list[tuple[str, str]]  # (原路径, 留底路径)
+    consumed_episodes: list[int]
+
+
+@dataclass
+class _ResetPlan:
+    """一次扫描得出的处置计划：受影响集号、已消费集号、文件删除/留底清单。"""
+
+    episode_nums: list[int]
+    consumed: list[int]
+    deletes: list[Path]
+    archives: list[Path]
+
+
+def _archive_path(path: Path) -> Path:
+    """派生集文件的留底路径：下划线前缀 + ``.bak`` 尾缀，同名时追加序号。
+
+    两处改动缺一不可地把文件挡在发现逻辑之外：下划线前缀让 ``discover_sources``
+    跳过（不会被当成新源文），``.bak`` 后缀既不属于源文后缀白名单、也让
+    ``discover_episode_files`` 的 ``episode_N.txt`` 全匹配落空（不会被当成派生集文件
+    重新补建账本条目）。
+    """
+    base = f"_{path.name}"
+    candidate = path.with_name(f"{base}.bak")
+    index = 1
+    while candidate.exists():
+        candidate = path.with_name(f"{base}.{index}.bak")
+        index += 1
+    return candidate
+
+
+def _scan(project_dir: Path, project: Mapping[str, Any]) -> _ResetPlan:
+    """扫描账本与磁盘得出处置计划。纯读：不改入参、不动文件。
+
+    已消费判定取账本状态与磁盘产物的并集——账本损坏时 ``ledger_status`` 未必可信，
+    磁盘上的剧本 / step1 产物才是「这一集已经被消费过」的硬证据。
+    """
+    entries: dict[int, Mapping[str, Any]] = {}
+    for entry in project.get("episodes") or []:
+        if not isinstance(entry, Mapping):
+            continue
+        num = parse_episode_num(entry.get("episode"))
+        if num is not None:
+            entries.setdefault(num, entry)
+
+    episode_files = discover_episode_files(project_dir)
+    consumed: list[int] = []
+    deletes: list[Path] = []
+    archives: list[Path] = []
+    # 账本条目与磁盘派生文件取并集：孤儿集文件（账本无对应条目）同样要处置，
+    # 否则重置后它会被回填重新补建成账本条目，账本清空的承诺落空
+    for num in sorted(set(entries) | set(episode_files)):
+        entry = entries.get(num) or {}
+        if entry.get("ledger_status") == "consumed" or has_downstream_products(project_dir, num, entry):
+            consumed.append(num)
+        path = episode_files.get(num)
+        if path is None:
+            continue
+        if isinstance(entry.get("source_range"), Mapping):
+            deletes.append(path)
+        else:
+            archives.append(path)
+    return _ResetPlan(episode_nums=sorted(entries), consumed=consumed, deletes=deletes, archives=archives)
+
+
+def _apply_files(project_dir: Path, plan: _ResetPlan) -> tuple[list[str], list[tuple[str, str]]]:
+    """落盘文件处置：删派生集文件、留底非派生集文件、清理余文文件。
+
+    失败一律抛错中止提交（账本写回随之回滚）：残留的集文件会被回填重新认领成账本
+    条目，「重置后账本为空」的承诺会被悄悄推翻，宁可整体失败让调用方重试。重置本身
+    幂等，重跑即可自愈已完成的部分。
+    """
+    deleted: list[str] = []
+    archived: list[tuple[str, str]] = []
+    for path in plan.deletes:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            raise EpisodeResetError(f"派生集文件删除失败，重置已中止：{path.name}: {exc}") from exc
+        deleted.append(_rel(project_dir, path))
+    for path in plan.archives:
+        target = _archive_path(path)
+        try:
+            path.rename(target)
+        except OSError as exc:
+            raise EpisodeResetError(f"集文件留底改名失败，重置已中止：{path.name}: {exc}") from exc
+        archived.append((_rel(project_dir, path), _rel(project_dir, target)))
+    # 余文文件是旧流程的进度指针，留着会在下次规划的回填中被换算成 planning_cursor，
+    # 让「从头规划」变成从余文起点续规划
+    remaining = project_dir / "source" / "_remaining.txt"
+    if remaining.is_file():
+        try:
+            remaining.unlink()
+        except OSError as exc:
+            raise EpisodeResetError(f"余文文件清理失败，重置已中止：{remaining.name}: {exc}") from exc
+    return deleted, archived
+
+
+def _rel(project_dir: Path, path: Path) -> str:
+    return path.relative_to(project_dir).as_posix()
+
+
+def reset_episode_planning(
+    project_path: str | Path,
+    *,
+    from_episode: int = 1,
+    confirm_consumed: bool = False,
+) -> EpisodeResetResult | ResetConfirmationRequired:
+    """重置分集规划账本。当前仅支持 ``from_episode=1`` 的全量重置。
+
+    波及已消费集（账本标 consumed 或磁盘已有剧本 / step1 产物）且未
+    ``confirm_consumed`` 时不执行，返回 :class:`ResetConfirmationRequired` 等待
+    显式确认；确认后执行，下游产物一律保留。
+
+    Raises:
+        EpisodeResetError: ``from_episode > 1``（部分重置尚未支持）或文件处置失败，
+            两种情形下账本均未被改动。
+        EpisodeResetConflictError: 重置期间出现确认清单之外的已消费集。
+    """
+    if from_episode != 1:
+        raise EpisodeResetError(
+            f"暂不支持部分重置（from_episode={from_episode}）：当前只能用 from_episode=1 做全量重置"
+            "（清空整个账本后重新规划）。账本未做任何改动。"
+        )
+
+    project_dir = Path(project_path)
+    pm = ProjectManager(str(project_dir.parent))
+    project_name = project_dir.name
+
+    # 锁外预扫描只为二段确认服务：需要确认时零写入返回，不进锁、不碰文件
+    plan = _scan(project_dir, pm.load_project(project_name))
+    if plan.consumed and not confirm_consumed:
+        return ResetConfirmationRequired(
+            consumed_episodes=plan.consumed,
+            archived_files=[_rel(project_dir, path) for path in plan.archives],
+        )
+
+    committed: dict[str, Any] = {}
+
+    def _commit(p: dict[str, Any]) -> None:
+        # 锁内重新扫描：确认清单是锁外读取时刻的快照，期间新消费的集不在用户确认范围内
+        current = _scan(project_dir, p)
+        if any(num not in plan.consumed for num in current.consumed):
+            raise EpisodeResetConflictError("重置期间出现新的已消费集，需重新确认后再执行")
+        p["episodes"] = []
+        p["planning_cursor"] = None
+        p.pop(SOURCE_FINGERPRINTS_KEY, None)
+        deleted, archived = _apply_files(project_dir, current)
+        committed["removed"] = current.episode_nums
+        committed["consumed"] = current.consumed
+        committed["deleted"] = deleted
+        committed["archived"] = archived
+
+    pm.update_project(project_name, _commit)
+    logger.info(
+        "分集规划已全量重置：项目 %s，清空 %d 集，删除派生文件 %d 个，留底 %d 个",
+        project_name,
+        len(committed["removed"]),
+        len(committed["deleted"]),
+        len(committed["archived"]),
+    )
+    return EpisodeResetResult(
+        removed_episodes=committed["removed"],
+        deleted_files=committed["deleted"],
+        archived_files=committed["archived"],
+        consumed_episodes=committed["consumed"],
+    )
+
+
+__all__ = [
+    "EpisodeResetConflictError",
+    "EpisodeResetError",
+    "EpisodeResetResult",
+    "ResetConfirmationRequired",
+    "reset_episode_planning",
+]

--- a/lib/episode_reset.py
+++ b/lib/episode_reset.py
@@ -86,7 +86,10 @@ def _archive_path(path: Path) -> Path:
     base = f"_{path.name}"
     candidate = path.with_name(f"{base}.bak")
     index = 1
-    while candidate.exists():
+    # exists() 对悬空符号链接返回 False（它会解引用到不存在的目标）：上一次重置把悬空
+    # episode_N.txt 留底后，candidate 本身可能就是这样一个悬空链接，仅查 exists() 会漏判
+    # 占用，导致 rename() 静默覆盖上一次的留底，违反本函数「同名时追加序号」的承诺
+    while candidate.exists() or candidate.is_symlink():
         candidate = path.with_name(f"{base}.{index}.bak")
         index += 1
     return candidate
@@ -100,9 +103,11 @@ def _scan(project_dir: Path, project: Mapping[str, Any]) -> _ResetPlan:
     """
     raw_episodes = project.get("episodes")
     entries: dict[int, Mapping[str, Any]] = {}
-    # 损坏账本可能对同一集号写出多条条目（如首条 planned、后条 consumed）：只取首条会
-    # 丢失后条携带的已消费证据，故已消费判定按集号聚合全部条目，而非只看被 setdefault
-    # 留下的那一条
+    # 损坏账本可能对同一集号写出多条条目（如首条 planned、后条 consumed，或首条带
+    # source_range、后条不带）：只取首条会丢失后条携带的证据，故已消费判定与
+    # 「文件是否可从账本重造」判定都按集号聚合全部条目，而非只看被 setdefault 留下的
+    # 那一条
+    entries_by_num: dict[int, list[Mapping[str, Any]]] = {}
     consumed_by_ledger_status: set[int] = set()
     # episodes 容器本身可能被写坏成非列表值（如 truthy 标量）：重置承诺零前置校验，
     # 这种情形按空账本处理而非抛错，不能让逃生口本身崩溃
@@ -115,6 +120,7 @@ def _scan(project_dir: Path, project: Mapping[str, Any]) -> _ResetPlan:
         if entry.get("ledger_status") == "consumed":
             consumed_by_ledger_status.add(num)
         entries.setdefault(num, entry)
+        entries_by_num.setdefault(num, []).append(entry)
 
     episode_file_aliases = discover_episode_file_aliases(project_dir)
     # 孤儿下游产物候选集号（账本无条目、无 source/episode_N.txt，但 scripts/ 或 drafts/
@@ -137,8 +143,12 @@ def _scan(project_dir: Path, project: Mapping[str, Any]) -> _ResetPlan:
         if not paths:
             continue
         # 同一集号可能存在多个 padding 别名（episode_1.txt / episode_01.txt），
-        # 全部按同一处置口径处理，否则未处理的别名会在下次回填中重新补建账本条目
-        target = deletes if isinstance(entry.get("source_range"), Mapping) else archives
+        # 全部按同一处置口径处理，否则未处理的别名会在下次回填中重新补建账本条目。
+        # 判定是否可删除取该集号全部重复条目的 source_range 交集：任一条目无法证明
+        # 文件可从账本重造，都按无法重造处理——删除是不可逆操作，证据冲突时偏保守
+        dupes = entries_by_num.get(num) or [entry]
+        can_recreate = all(isinstance(dupe.get("source_range"), Mapping) for dupe in dupes)
+        target = deletes if can_recreate else archives
         target.extend(paths)
     return _ResetPlan(episode_nums=sorted(entries), consumed=consumed, deletes=deletes, archives=archives)
 

--- a/lib/episode_reset.py
+++ b/lib/episode_reset.py
@@ -26,7 +26,8 @@ from typing import Any
 
 from lib.episode_ledger import (
     SOURCE_FINGERPRINTS_KEY,
-    discover_episode_files,
+    discover_episode_file_aliases,
+    discover_product_episode_nums,
     has_downstream_products,
     parse_episode_num,
 )
@@ -97,31 +98,37 @@ def _scan(project_dir: Path, project: Mapping[str, Any]) -> _ResetPlan:
     已消费判定取账本状态与磁盘产物的并集——账本损坏时 ``ledger_status`` 未必可信，
     磁盘上的剧本 / step1 产物才是「这一集已经被消费过」的硬证据。
     """
+    raw_episodes = project.get("episodes")
     entries: dict[int, Mapping[str, Any]] = {}
-    for entry in project.get("episodes") or []:
+    # episodes 容器本身可能被写坏成非列表值（如 truthy 标量）：重置承诺零前置校验，
+    # 这种情形按空账本处理而非抛错，不能让逃生口本身崩溃
+    for entry in raw_episodes if isinstance(raw_episodes, list) else []:
         if not isinstance(entry, Mapping):
             continue
         num = parse_episode_num(entry.get("episode"))
         if num is not None:
             entries.setdefault(num, entry)
 
-    episode_files = discover_episode_files(project_dir)
+    episode_file_aliases = discover_episode_file_aliases(project_dir)
     consumed: list[int] = []
     deletes: list[Path] = []
     archives: list[Path] = []
-    # 账本条目与磁盘派生文件取并集：孤儿集文件（账本无对应条目）同样要处置，
-    # 否则重置后它会被回填重新补建成账本条目，账本清空的承诺落空
-    for num in sorted(set(entries) | set(episode_files)):
+    # 账本条目、磁盘派生文件、磁盘下游产物三者取并集：
+    # - 孤儿集文件（账本无对应条目）同样要处置，否则重置后它会被回填重新补建成账本
+    #   条目，账本清空的承诺落空
+    # - 孤儿下游产物（账本无条目、无 source/episode_N.txt，但 scripts/ 或 drafts/ 仍有
+    #   该集产物）同样要纳入已消费判定，否则会绕过确认直接清空
+    for num in sorted(set(entries) | set(episode_file_aliases) | discover_product_episode_nums(project_dir)):
         entry = entries.get(num) or {}
         if entry.get("ledger_status") == "consumed" or has_downstream_products(project_dir, num, entry):
             consumed.append(num)
-        path = episode_files.get(num)
-        if path is None:
+        paths = episode_file_aliases.get(num) or []
+        if not paths:
             continue
-        if isinstance(entry.get("source_range"), Mapping):
-            deletes.append(path)
-        else:
-            archives.append(path)
+        # 同一集号可能存在多个 padding 别名（episode_1.txt / episode_01.txt），
+        # 全部按同一处置口径处理，否则未处理的别名会在下次回填中重新补建账本条目
+        target = deletes if isinstance(entry.get("source_range"), Mapping) else archives
+        target.extend(paths)
     return _ResetPlan(episode_nums=sorted(entries), consumed=consumed, deletes=deletes, archives=archives)
 
 
@@ -132,15 +139,24 @@ def _apply_files(project_dir: Path, plan: _ResetPlan) -> tuple[list[str], list[t
     条目，「重置后账本为空」的承诺会被悄悄推翻，宁可整体失败让调用方重试。重置本身
     幂等，重跑即可自愈已完成的部分。
     """
+    source_dir = project_dir / "source"
+    # source/ 是符号链接时拒绝处置：unlink/rename 会作用到链接目标（可能在项目外），
+    # 与 EpisodePlanner._reconcile_derived_files 的同类校验保持一致
+    if source_dir.is_symlink():
+        raise EpisodeResetError("source/ 不能是符号链接，拒绝处置派生集文件")
     deleted: list[str] = []
     archived: list[tuple[str, str]] = []
     for path in plan.deletes:
+        if path.is_symlink():
+            raise EpisodeResetError(f"派生集文件是符号链接，拒绝删除：{path.name}")
         try:
             path.unlink(missing_ok=True)
         except OSError as exc:
             raise EpisodeResetError(f"派生集文件删除失败，重置已中止：{path.name}: {exc}") from exc
         deleted.append(_rel(project_dir, path))
     for path in plan.archives:
+        if path.is_symlink():
+            raise EpisodeResetError(f"集文件是符号链接，拒绝留底改名：{path.name}")
         target = _archive_path(path)
         try:
             path.rename(target)

--- a/lib/episode_reset.py
+++ b/lib/episode_reset.py
@@ -197,9 +197,11 @@ def reset_episode_planning(
             archived_files=[_rel(project_dir, path) for path in plan.archives],
         )
 
-    committed: dict[str, Any] = {}
+    # 结果只能在锁内（按锁内复扫的实际处置）拼出，用闭包变量带回锁外
+    committed: EpisodeResetResult | None = None
 
     def _commit(p: dict[str, Any]) -> None:
+        nonlocal committed
         # 锁内重新扫描：确认清单是锁外读取时刻的快照，期间新消费的集不在用户确认范围内
         current = _scan(project_dir, p)
         if any(num not in plan.consumed for num in current.consumed):
@@ -208,25 +210,24 @@ def reset_episode_planning(
         p["planning_cursor"] = None
         p.pop(SOURCE_FINGERPRINTS_KEY, None)
         deleted, archived = _apply_files(project_dir, current)
-        committed["removed"] = current.episode_nums
-        committed["consumed"] = current.consumed
-        committed["deleted"] = deleted
-        committed["archived"] = archived
+        committed = EpisodeResetResult(
+            removed_episodes=current.episode_nums,
+            deleted_files=deleted,
+            archived_files=archived,
+            consumed_episodes=current.consumed,
+        )
 
     pm.update_project(project_name, _commit)
+    if committed is None:  # pragma: no cover - update_project 必然调用 mutate_fn
+        raise EpisodeResetError("重置未执行：账本更新回调未被调用")
     logger.info(
         "分集规划已全量重置：项目 %s，清空 %d 集，删除派生文件 %d 个，留底 %d 个",
         project_name,
-        len(committed["removed"]),
-        len(committed["deleted"]),
-        len(committed["archived"]),
+        len(committed.removed_episodes),
+        len(committed.deleted_files),
+        len(committed.archived_files),
     )
-    return EpisodeResetResult(
-        removed_episodes=committed["removed"],
-        deleted_files=committed["deleted"],
-        archived_files=committed["archived"],
-        consumed_episodes=committed["consumed"],
-    )
+    return committed
 
 
 __all__ = [

--- a/lib/episode_reset.py
+++ b/lib/episode_reset.py
@@ -95,6 +95,29 @@ def _archive_path(path: Path) -> Path:
     return candidate
 
 
+def _has_recreatable_source_range(entry: Mapping[str, Any]) -> bool:
+    """entry 的 source_range 是否携带足以重造派生文件的坐标结构。
+
+    只查字段类型（``source_file`` 是 str、``start``/``end`` 是非 bool 的 int），不校验
+    数值是否越界——重置零前置校验，不读源文、不做范围合法性判断，那是 plan/replan
+    的职责。空字典 ``{}`` 或缺字段的损坏映射满足 ``isinstance(..., Mapping)`` 但没有
+    可用坐标，仍会被误判为「可从账本重造」进而永久删除本应留底的文件。
+    """
+    source_range = entry.get("source_range")
+    if not isinstance(source_range, Mapping):
+        return False
+    rel = source_range.get("source_file")
+    start = source_range.get("start")
+    end = source_range.get("end")
+    return (
+        isinstance(rel, str)
+        and isinstance(start, int)
+        and not isinstance(start, bool)
+        and isinstance(end, int)
+        and not isinstance(end, bool)
+    )
+
+
 def _scan(project_dir: Path, project: Mapping[str, Any]) -> _ResetPlan:
     """扫描账本与磁盘得出处置计划。纯读：不改入参、不动文件。
 
@@ -136,18 +159,25 @@ def _scan(project_dir: Path, project: Mapping[str, Any]) -> _ResetPlan:
     #   条目，账本清空的承诺落空
     # - 孤儿下游产物同样要纳入已消费判定，否则会绕过确认直接清空
     for num in sorted(set(entries) | set(episode_file_aliases) | product_nums):
-        entry = entries.get(num) or {}
-        if num in consumed_by_ledger_status or num in product_nums or has_downstream_products(project_dir, num, entry):
+        dupes = entries_by_num.get(num) or [{}]
+        # 已消费判定同样要聚合全部重复条目：损坏账本可能首条指向缺失的规范剧本路径、
+        # 后条的 script_file 指向实际存在的非规范路径（如 scripts/custom_name.json），
+        # 只传被 setdefault 留下的首条给 has_downstream_products 会漏判
+        is_consumed = (
+            num in consumed_by_ledger_status
+            or num in product_nums
+            or any(has_downstream_products(project_dir, num, dupe) for dupe in dupes)
+        )
+        if is_consumed:
             consumed.append(num)
         paths = episode_file_aliases.get(num) or []
         if not paths:
             continue
         # 同一集号可能存在多个 padding 别名（episode_1.txt / episode_01.txt），
         # 全部按同一处置口径处理，否则未处理的别名会在下次回填中重新补建账本条目。
-        # 判定是否可删除取该集号全部重复条目的 source_range 交集：任一条目无法证明
-        # 文件可从账本重造，都按无法重造处理——删除是不可逆操作，证据冲突时偏保守
-        dupes = entries_by_num.get(num) or [entry]
-        can_recreate = all(isinstance(dupe.get("source_range"), Mapping) for dupe in dupes)
+        # 判定是否可删除取该集号全部重复条目的可重造性交集：任一条目无法证明文件可
+        # 从账本重造，都按无法重造处理——删除是不可逆操作，证据冲突时偏保守
+        can_recreate = all(_has_recreatable_source_range(dupe) for dupe in dupes)
         target = deletes if can_recreate else archives
         target.extend(paths)
     return _ResetPlan(episode_nums=sorted(entries), consumed=consumed, deletes=deletes, archives=archives)

--- a/lib/episode_reset.py
+++ b/lib/episode_reset.py
@@ -100,27 +100,38 @@ def _scan(project_dir: Path, project: Mapping[str, Any]) -> _ResetPlan:
     """
     raw_episodes = project.get("episodes")
     entries: dict[int, Mapping[str, Any]] = {}
+    # 损坏账本可能对同一集号写出多条条目（如首条 planned、后条 consumed）：只取首条会
+    # 丢失后条携带的已消费证据，故已消费判定按集号聚合全部条目，而非只看被 setdefault
+    # 留下的那一条
+    consumed_by_ledger_status: set[int] = set()
     # episodes 容器本身可能被写坏成非列表值（如 truthy 标量）：重置承诺零前置校验，
     # 这种情形按空账本处理而非抛错，不能让逃生口本身崩溃
     for entry in raw_episodes if isinstance(raw_episodes, list) else []:
         if not isinstance(entry, Mapping):
             continue
         num = parse_episode_num(entry.get("episode"))
-        if num is not None:
-            entries.setdefault(num, entry)
+        if num is None:
+            continue
+        if entry.get("ledger_status") == "consumed":
+            consumed_by_ledger_status.add(num)
+        entries.setdefault(num, entry)
 
     episode_file_aliases = discover_episode_file_aliases(project_dir)
+    # 孤儿下游产物候选集号（账本无条目、无 source/episode_N.txt，但 scripts/ 或 drafts/
+    # 仍有该集产物）本身就是「该集已消费」的直接证据：has_downstream_products 只认
+    # episode_script_relpath 算出的规范路径，无法识别 discover_product_episode_nums 已
+    # 靠正则宽松匹配到的 padding 别名文件名（如 episode_01.json），必须单独纳入判定
+    product_nums = discover_product_episode_nums(project_dir)
     consumed: list[int] = []
     deletes: list[Path] = []
     archives: list[Path] = []
     # 账本条目、磁盘派生文件、磁盘下游产物三者取并集：
     # - 孤儿集文件（账本无对应条目）同样要处置，否则重置后它会被回填重新补建成账本
     #   条目，账本清空的承诺落空
-    # - 孤儿下游产物（账本无条目、无 source/episode_N.txt，但 scripts/ 或 drafts/ 仍有
-    #   该集产物）同样要纳入已消费判定，否则会绕过确认直接清空
-    for num in sorted(set(entries) | set(episode_file_aliases) | discover_product_episode_nums(project_dir)):
+    # - 孤儿下游产物同样要纳入已消费判定，否则会绕过确认直接清空
+    for num in sorted(set(entries) | set(episode_file_aliases) | product_nums):
         entry = entries.get(num) or {}
-        if entry.get("ledger_status") == "consumed" or has_downstream_products(project_dir, num, entry):
+        if num in consumed_by_ledger_status or num in product_nums or has_downstream_products(project_dir, num, entry):
             consumed.append(num)
         paths = episode_file_aliases.get(num) or []
         if not paths:
@@ -140,23 +151,22 @@ def _apply_files(project_dir: Path, plan: _ResetPlan) -> tuple[list[str], list[t
     幂等，重跑即可自愈已完成的部分。
     """
     source_dir = project_dir / "source"
-    # source/ 是符号链接时拒绝处置：unlink/rename 会作用到链接目标（可能在项目外），
-    # 与 EpisodePlanner._reconcile_derived_files 的同类校验保持一致
-    if source_dir.is_symlink():
-        raise EpisodeResetError("source/ 不能是符号链接，拒绝处置派生集文件")
+    # source/ 是符号链接或（Windows 原生）目录联接时拒绝处置：这类 reparse point 会让
+    # source_dir 之下的路径解析穿透到项目外目录，unlink/rename 因此可能作用到外部文件；
+    # is_junction() 3.12+ 可用、POSIX 上恒为 False，与 EpisodePlanner._reconcile_derived_files
+    # 的同类校验保持一致。派生集文件自身是符号链接则不受影响——unlink/rename 操作的是链接
+    # 条目本身、不跟随最终一段的链接目标，悬空链接同样能被安全清理
+    if source_dir.is_symlink() or source_dir.is_junction():
+        raise EpisodeResetError("source/ 不能是符号链接或目录联接，拒绝处置派生集文件")
     deleted: list[str] = []
     archived: list[tuple[str, str]] = []
     for path in plan.deletes:
-        if path.is_symlink():
-            raise EpisodeResetError(f"派生集文件是符号链接，拒绝删除：{path.name}")
         try:
             path.unlink(missing_ok=True)
         except OSError as exc:
             raise EpisodeResetError(f"派生集文件删除失败，重置已中止：{path.name}: {exc}") from exc
         deleted.append(_rel(project_dir, path))
     for path in plan.archives:
-        if path.is_symlink():
-            raise EpisodeResetError(f"集文件是符号链接，拒绝留底改名：{path.name}")
         target = _archive_path(path)
         try:
             path.rename(target)

--- a/server/agent_runtime/sdk_tools/__init__.py
+++ b/server/agent_runtime/sdk_tools/__init__.py
@@ -34,6 +34,7 @@ from server.agent_runtime.sdk_tools.enqueue_videos import (
 from server.agent_runtime.sdk_tools.episode_planning import (
     plan_episodes_tool,
     replan_episodes_tool,
+    reset_episode_planning_tool,
 )
 from server.agent_runtime.sdk_tools.patch_episode_meta import patch_episode_meta_tool
 from server.agent_runtime.sdk_tools.patch_project import patch_project_tool
@@ -80,6 +81,7 @@ ARCREEL_MCP_TOOL_IDS: tuple[str, ...] = (
     "get_video_capabilities",
     "plan_episodes",
     "replan_episodes",
+    "reset_episode_planning",
     "patch_episode_script",
     "patch_episode_meta",
     "insert_segment",
@@ -114,6 +116,7 @@ def build_arcreel_mcp_server(*, project_name: str, projects_root: Path) -> Any:
             get_video_capabilities_tool(ctx),
             plan_episodes_tool(ctx),
             replan_episodes_tool(ctx),
+            reset_episode_planning_tool(ctx),
             patch_episode_script_tool(ctx),
             patch_episode_meta_tool(ctx),
             insert_segment_tool(ctx),

--- a/server/agent_runtime/sdk_tools/episode_planning.py
+++ b/server/agent_runtime/sdk_tools/episode_planning.py
@@ -1,7 +1,8 @@
-"""SDK MCP tools for episode planning (plan / replan).
+"""SDK MCP tools for episode planning (plan / replan / reset).
 
 主 agent 单次调用、只收账本摘要；窗口读取、文本模型调用、机械校验重试与
-同锁提交全部在 :class:`lib.episode_planner.EpisodePlanner` 内完成。
+同锁提交全部在 :class:`lib.episode_planner.EpisodePlanner` 内完成。重置走
+:mod:`lib.episode_reset`，不经文本模型。
 """
 
 from __future__ import annotations
@@ -16,6 +17,11 @@ from lib.episode_planner import (
     LedgerStats,
     PlanResult,
     ReplanConfirmationRequired,
+)
+from lib.episode_reset import (
+    EpisodeResetError,
+    ResetConfirmationRequired,
+    reset_episode_planning,
 )
 from server.agent_runtime.sdk_tools._context import ToolContext, tool_error
 
@@ -201,4 +207,80 @@ def replan_episodes_tool(ctx: ToolContext):
     return _handler
 
 
-__all__ = ["plan_episodes_tool", "replan_episodes_tool"]
+def reset_episode_planning_tool(ctx: ToolContext):
+    @tool(
+        "reset_episode_planning",
+        "重置分集规划：清空分集账本（episodes 与 planning_cursor），让 plan_episodes 可以从头重新规划。"
+        "这是账本损坏时的逃生口——源文被替换或删除重建后，规划会报「起点越界」「范围无效」等错误并"
+        "永久失败，此时用本工具重置即可恢复；不调用文本模型，不受供应商配置影响。"
+        "当前只支持 from_episode=1（全量重置），传更大的集号会被拒绝且账本不变。"
+        "波及已消费集（已有 step1/剧本/媒体产物）时不执行并返回受影响清单，须告知用户、确认后带 "
+        "confirm_consumed=true 重新调用。任何下游产物（剧本、媒体）都不会被删除；"
+        "可由账本重造的 source/episode_N.txt 会被删除，无原文范围记录的集文件改名留底（不会丢内容）。"
+        "重置后账本为空，需要重新调用 plan_episodes 规划，集号从第 1 集重新开始。",
+        {
+            "type": "object",
+            "properties": {
+                "from_episode": {
+                    "type": "integer",
+                    "description": "重置起点集号；当前仅支持 1（全量重置）",
+                },
+                "confirm_consumed": {
+                    "type": "boolean",
+                    "description": "已向用户确认波及的已消费集后置 true",
+                },
+            },
+            "required": ["from_episode"],
+        },
+    )
+    async def _handler(args: dict[str, Any]) -> dict[str, Any]:
+        try:
+            raw_from_episode = args["from_episode"]
+            if not isinstance(raw_from_episode, int) or isinstance(raw_from_episode, bool) or raw_from_episode < 1:
+                raise ValueError(f"from_episode 必须是正整数，收到 {raw_from_episode!r}")
+            from_episode = raw_from_episode
+            raw_confirm = args.get("confirm_consumed", False)
+            if not isinstance(raw_confirm, bool):
+                raise ValueError(f"confirm_consumed 必须是布尔值（JSON true/false），收到 {raw_confirm!r}")
+            confirm_consumed = raw_confirm
+        except (KeyError, ValueError) as exc:
+            return {"content": [{"type": "text", "text": f"❌ 参数错误：{exc}"}], "is_error": True}
+
+        try:
+            result = reset_episode_planning(
+                ctx.project_path,
+                from_episode=from_episode,
+                confirm_consumed=confirm_consumed,
+            )
+        except (EpisodeResetError, FileNotFoundError) as exc:
+            return {"content": [{"type": "text", "text": f"❌ 分集规划重置失败：{exc}"}], "is_error": True}
+        except Exception as exc:  # noqa: BLE001
+            return tool_error("reset_episode_planning", exc)
+
+        if isinstance(result, ResetConfirmationRequired):
+            episodes = "、".join(str(num) for num in result.consumed_episodes)
+            lines = [
+                f"⚠️ 本次重置会波及已消费集（已有 step1/剧本/媒体产物）：第 {episodes} 集。尚未执行任何改动。",
+                "请把影响范围告知用户；用户确认后带 confirm_consumed=true 重新调用"
+                "（剧本与媒体产物不会被删除，但账本清空后这些集需要重新规划）。",
+            ]
+            if result.archived_files:
+                lines.append(f"其中无原文范围记录的集文件会改名留底：{'、'.join(result.archived_files)}")
+            return {"content": [{"type": "text", "text": "\n".join(lines)}]}
+
+        lines = [f"✅ 已全量重置分集规划：清空 {len(result.removed_episodes)} 集，planning_cursor 已置空。"]
+        if result.deleted_files:
+            lines.append(f"已删除可重造的派生集文件 {len(result.deleted_files)} 个。")
+        if result.archived_files:
+            archived = "、".join(f"{src} → {dst}" for src, dst in result.archived_files)
+            lines.append(f"无原文范围记录的集文件已改名留底（内容保留）：{archived}")
+        if result.consumed_episodes:
+            consumed = "、".join(str(num) for num in result.consumed_episodes)
+            lines.append(f"第 {consumed} 集的剧本 / 媒体产物仍在磁盘，未删除。")
+        lines.append("账本已空，请调用 plan_episodes 从头重新规划（集号从第 1 集起）。")
+        return {"content": [{"type": "text", "text": "\n".join(lines)}]}
+
+    return _handler
+
+
+__all__ = ["plan_episodes_tool", "replan_episodes_tool", "reset_episode_planning_tool"]

--- a/server/agent_runtime/sdk_tools/episode_planning.py
+++ b/server/agent_runtime/sdk_tools/episode_planning.py
@@ -30,6 +30,22 @@ from server.agent_runtime.sdk_tools._context import ToolContext, tool_error
 _MAX_INSTRUCTIONS_LEN = 4000
 
 
+def _require_positive_int(args: dict[str, Any], key: str) -> int:
+    """取必填正整数入参。``bool`` 是 ``int`` 子类，须单独排除以免 ``true`` 被当成 1。"""
+    value = args[key]
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ValueError(f"{key} 必须是正整数，收到 {value!r}")
+    return value
+
+
+def _optional_bool(args: dict[str, Any], key: str) -> bool:
+    """取可选布尔入参，缺省为 False。确认类开关不做真值化，非布尔一律拒绝。"""
+    value = args.get(key, False)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} 必须是布尔值（JSON true/false），收到 {value!r}")
+    return value
+
+
 def _render_ledger_stats(stats: LedgerStats) -> list[str]:
     """全局核对材料：累计集数、最小体量集、中位数、目标体量，附一句面向主 agent 的核对指令。"""
     lines = [f"累计总集数：{stats.total_episodes}"]
@@ -156,10 +172,7 @@ def replan_episodes_tool(ctx: ToolContext):
         # 参数校验与 planner 调用分属两个 try：校验阶段的 KeyError/ValueError 才算参数错误，
         # planner 内部（如供应商未配置）抛出的 ValueError 走 tool_error 通用路径，不被误标。
         try:
-            raw_from_episode = args["from_episode"]
-            if not isinstance(raw_from_episode, int) or isinstance(raw_from_episode, bool) or raw_from_episode < 1:
-                raise ValueError(f"from_episode 必须是正整数，收到 {raw_from_episode!r}")
-            from_episode = raw_from_episode
+            from_episode = _require_positive_int(args, "from_episode")
             raw_instructions = args["instructions"]
             if not isinstance(raw_instructions, str):
                 raise ValueError(f"instructions 必须是字符串，收到 {type(raw_instructions).__name__}")
@@ -170,10 +183,7 @@ def replan_episodes_tool(ctx: ToolContext):
                 raise ValueError(
                     f"instructions 过长（{len(raw_instructions)} 字符，上限 {_MAX_INSTRUCTIONS_LEN}），请精简后重试"
                 )
-            raw_confirm = args.get("confirm_consumed", False)
-            if not isinstance(raw_confirm, bool):
-                raise ValueError(f"confirm_consumed 必须是布尔值（JSON true/false），收到 {raw_confirm!r}")
-            confirm_consumed = raw_confirm
+            confirm_consumed = _optional_bool(args, "confirm_consumed")
         except (KeyError, ValueError) as exc:
             return {"content": [{"type": "text", "text": f"❌ 参数错误：{exc}"}], "is_error": True}
 
@@ -235,14 +245,8 @@ def reset_episode_planning_tool(ctx: ToolContext):
     )
     async def _handler(args: dict[str, Any]) -> dict[str, Any]:
         try:
-            raw_from_episode = args["from_episode"]
-            if not isinstance(raw_from_episode, int) or isinstance(raw_from_episode, bool) or raw_from_episode < 1:
-                raise ValueError(f"from_episode 必须是正整数，收到 {raw_from_episode!r}")
-            from_episode = raw_from_episode
-            raw_confirm = args.get("confirm_consumed", False)
-            if not isinstance(raw_confirm, bool):
-                raise ValueError(f"confirm_consumed 必须是布尔值（JSON true/false），收到 {raw_confirm!r}")
-            confirm_consumed = raw_confirm
+            from_episode = _require_positive_int(args, "from_episode")
+            confirm_consumed = _optional_bool(args, "confirm_consumed")
         except (KeyError, ValueError) as exc:
             return {"content": [{"type": "text", "text": f"❌ 参数错误：{exc}"}], "is_error": True}
 

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1881,6 +1881,7 @@ def _fake_reset(result: Any, captured: dict[str, Any] | None = None):
     return _reset
 
 
+@pytest.mark.unit
 async def test_reset_episode_planning_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from lib.episode_reset import EpisodeResetResult
     from server.agent_runtime.sdk_tools import episode_planning as mod
@@ -1904,6 +1905,7 @@ async def test_reset_episode_planning_happy(fake_ctx: ToolContext, monkeypatch) 
     assert "plan_episodes" in text  # 指路后续动作
 
 
+@pytest.mark.unit
 async def test_reset_episode_planning_confirmation_required(fake_ctx: ToolContext, monkeypatch) -> None:
     from lib.episode_reset import ResetConfirmationRequired
     from server.agent_runtime.sdk_tools import episode_planning as mod
@@ -1920,6 +1922,7 @@ async def test_reset_episode_planning_confirmation_required(fake_ctx: ToolContex
     assert "已消费" in text and "confirm_consumed" in text
 
 
+@pytest.mark.unit
 async def test_reset_episode_planning_forwards_confirm(fake_ctx: ToolContext, monkeypatch) -> None:
     from lib.episode_reset import EpisodeResetResult
     from server.agent_runtime.sdk_tools import episode_planning as mod
@@ -1934,6 +1937,7 @@ async def test_reset_episode_planning_forwards_confirm(fake_ctx: ToolContext, mo
     assert "未删除" in out["content"][0]["text"]  # 产物保留须对主 agent 说明
 
 
+@pytest.mark.unit
 async def test_reset_episode_planning_partial_reset_error(fake_ctx: ToolContext, monkeypatch) -> None:
     """暂不支持的部分重置按可读错误返回，不走通用异常兜底。"""
     from lib.episode_reset import EpisodeResetError
@@ -1948,6 +1952,7 @@ async def test_reset_episode_planning_partial_reset_error(fake_ctx: ToolContext,
     assert "暂不支持部分重置" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_reset_episode_planning_rejects_string_confirm_consumed(fake_ctx: ToolContext) -> None:
     """confirm_consumed 是确认安全边界：非布尔值必须拒绝而非真值化。"""
     from server.agent_runtime.sdk_tools import episode_planning as mod
@@ -1960,6 +1965,7 @@ async def test_reset_episode_planning_rejects_string_confirm_consumed(fake_ctx: 
     assert "confirm_consumed" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("bad", [0, -1, "1", True, None])
 async def test_reset_episode_planning_rejects_bad_from_episode(fake_ctx: ToolContext, bad: Any) -> None:
     from server.agent_runtime.sdk_tools import episode_planning as mod
@@ -1969,6 +1975,7 @@ async def test_reset_episode_planning_rejects_bad_from_episode(fake_ctx: ToolCon
     assert "from_episode" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_reset_episode_planning_requires_from_episode(fake_ctx: ToolContext) -> None:
     from server.agent_runtime.sdk_tools import episode_planning as mod
 

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1866,6 +1866,117 @@ async def test_replan_episodes_planner_value_error_not_mislabeled_as_param_error
 
 
 # ---------------------------------------------------------------------------
+# episode_planning — reset_episode_planning 薄包装
+# ---------------------------------------------------------------------------
+
+
+def _fake_reset(result: Any, captured: dict[str, Any] | None = None):
+    def _reset(project_path, *, from_episode, confirm_consumed):
+        if captured is not None:
+            captured["args"] = (project_path, from_episode, confirm_consumed)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    return _reset
+
+
+async def test_reset_episode_planning_happy(fake_ctx: ToolContext, monkeypatch) -> None:
+    from lib.episode_reset import EpisodeResetResult
+    from server.agent_runtime.sdk_tools import episode_planning as mod
+
+    captured: dict[str, Any] = {}
+    result = EpisodeResetResult(
+        removed_episodes=[1, 2],
+        deleted_files=["source/episode_1.txt"],
+        archived_files=[("source/episode_2.txt", "source/_episode_2.txt.bak")],
+        consumed_episodes=[],
+    )
+    monkeypatch.setattr(mod, "reset_episode_planning", _fake_reset(result, captured))
+
+    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 1})
+
+    assert out.get("is_error") is not True
+    assert captured["args"][1:] == (1, False)
+    text = out["content"][0]["text"]
+    assert "清空 2 集" in text
+    assert "source/_episode_2.txt.bak" in text
+    assert "plan_episodes" in text  # 指路后续动作
+
+
+async def test_reset_episode_planning_confirmation_required(fake_ctx: ToolContext, monkeypatch) -> None:
+    from lib.episode_reset import ResetConfirmationRequired
+    from server.agent_runtime.sdk_tools import episode_planning as mod
+
+    monkeypatch.setattr(
+        mod,
+        "reset_episode_planning",
+        _fake_reset(ResetConfirmationRequired(consumed_episodes=[1, 3], archived_files=[])),
+    )
+    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 1})
+
+    assert out.get("is_error") is not True  # 预期内的流程出口，不是错误
+    text = out["content"][0]["text"]
+    assert "已消费" in text and "confirm_consumed" in text
+
+
+async def test_reset_episode_planning_forwards_confirm(fake_ctx: ToolContext, monkeypatch) -> None:
+    from lib.episode_reset import EpisodeResetResult
+    from server.agent_runtime.sdk_tools import episode_planning as mod
+
+    captured: dict[str, Any] = {}
+    result = EpisodeResetResult(removed_episodes=[1], deleted_files=[], archived_files=[], consumed_episodes=[1])
+    monkeypatch.setattr(mod, "reset_episode_planning", _fake_reset(result, captured))
+
+    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 1, "confirm_consumed": True})
+
+    assert captured["args"][1:] == (1, True)
+    assert "未删除" in out["content"][0]["text"]  # 产物保留须对主 agent 说明
+
+
+async def test_reset_episode_planning_partial_reset_error(fake_ctx: ToolContext, monkeypatch) -> None:
+    """暂不支持的部分重置按可读错误返回，不走通用异常兜底。"""
+    from lib.episode_reset import EpisodeResetError
+    from server.agent_runtime.sdk_tools import episode_planning as mod
+
+    monkeypatch.setattr(
+        mod, "reset_episode_planning", _fake_reset(EpisodeResetError("暂不支持部分重置（from_episode=3）"))
+    )
+    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 3})
+
+    assert out.get("is_error") is True
+    assert "暂不支持部分重置" in out["content"][0]["text"]
+
+
+async def test_reset_episode_planning_rejects_string_confirm_consumed(fake_ctx: ToolContext) -> None:
+    """confirm_consumed 是确认安全边界：非布尔值必须拒绝而非真值化。"""
+    from server.agent_runtime.sdk_tools import episode_planning as mod
+
+    out = await _call(
+        mod.reset_episode_planning_tool(fake_ctx),
+        {"from_episode": 1, "confirm_consumed": "true"},
+    )
+    assert out.get("is_error") is True
+    assert "confirm_consumed" in out["content"][0]["text"]
+
+
+@pytest.mark.parametrize("bad", [0, -1, "1", True, None])
+async def test_reset_episode_planning_rejects_bad_from_episode(fake_ctx: ToolContext, bad: Any) -> None:
+    from server.agent_runtime.sdk_tools import episode_planning as mod
+
+    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": bad})
+    assert out.get("is_error") is True
+    assert "from_episode" in out["content"][0]["text"]
+
+
+async def test_reset_episode_planning_requires_from_episode(fake_ctx: ToolContext) -> None:
+    from server.agent_runtime.sdk_tools import episode_planning as mod
+
+    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {})
+    assert out.get("is_error") is True
+
+
+# ---------------------------------------------------------------------------
 # enqueue_videos — ad + reference_video（派生分组直出）
 # ---------------------------------------------------------------------------
 

--- a/tests/test_episode_reset.py
+++ b/tests/test_episode_reset.py
@@ -200,6 +200,27 @@ def test_orphan_episode_file_archived(tmp_path: Path) -> None:
     assert discover_episode_files(project_dir) == {}
 
 
+def test_file_failure_aborts_and_leaves_ledger_intact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """文件处置失败硬失败：账本写回随之回滚，避免留下「账本已空但残留文件会被重新认领」的中间态。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[_entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10})],
+        planning_cursor={"source_file": "source/novel.txt", "offset": 10},
+    )
+    (project_dir / "source" / "episode_1.txt").write_text(SOURCE[:10], encoding="utf-8")
+    before = _load_project(project_dir)
+
+    def _boom(self: Path, missing_ok: bool = False) -> None:
+        raise OSError("device busy")
+
+    monkeypatch.setattr(Path, "unlink", _boom)
+
+    with pytest.raises(EpisodeResetError, match="派生集文件删除失败"):
+        reset_episode_planning(project_dir, from_episode=1)
+
+    assert _load_project(project_dir) == before
+
+
 # ---------------------------------------------------------------------------
 # 已消费集的二段确认
 # ---------------------------------------------------------------------------

--- a/tests/test_episode_reset.py
+++ b/tests/test_episode_reset.py
@@ -1,0 +1,283 @@
+"""分集规划全量重置的行为测试（真实文件系统，不触 LLM）。
+
+只断言对外行为：账本状态、文件去向、二段确认出口与错误路径。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lib.episode_ledger import (
+    SOURCE_FINGERPRINTS_KEY,
+    discover_episode_files,
+    discover_sources,
+)
+from lib.episode_planner import EpisodePlanner
+from lib.episode_reset import (
+    EpisodeResetError,
+    EpisodeResetResult,
+    ResetConfirmationRequired,
+    reset_episode_planning,
+)
+
+SOURCE = "第一章 山村少年。李恒在山村长大。第二章 下山。李恒辞别师父。第三章 风波。少女身份成谜。"
+
+
+def _write_project(
+    tmp_path: Path,
+    *,
+    episodes: list | None = None,
+    planning_cursor: dict | None = None,
+    extra: dict | None = None,
+    source_text: str = SOURCE,
+) -> Path:
+    project_dir = tmp_path / "demo-proj"
+    (project_dir / "source").mkdir(parents=True)
+    project = {
+        "schema_version": 3,
+        "title": "测试项目",
+        "content_mode": "narration",
+        "generation_mode": "storyboard",
+        "style": "国漫",
+        "characters": {},
+        "scenes": {},
+        "props": {},
+        "episodes": episodes or [],
+        "planning_cursor": planning_cursor,
+    }
+    if extra:
+        project.update(extra)
+    (project_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
+    (project_dir / "source" / "novel.txt").write_text(source_text, encoding="utf-8")
+    return project_dir
+
+
+def _load_project(project_dir: Path) -> dict:
+    return json.loads((project_dir / "project.json").read_text(encoding="utf-8"))
+
+
+def _entry(num: int, *, source_range: dict | None, status: str = "planned") -> dict:
+    return {
+        "episode": num,
+        "title": f"第 {num} 集",
+        "script_file": f"scripts/episode_{num}.json",
+        "source_range": source_range,
+        "ledger_status": status,
+    }
+
+
+def _write_script(project_dir: Path, num: int) -> Path:
+    scripts = project_dir / "scripts"
+    scripts.mkdir(exist_ok=True)
+    path = scripts / f"episode_{num}.json"
+    path.write_text("{}", encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# 全量重置：账本任意损坏都必须成功
+# ---------------------------------------------------------------------------
+
+
+def test_reset_on_corrupted_ledger_clears_everything(tmp_path: Path) -> None:
+    """cursor 越界 + 条目坐标越界 + 账本与磁盘不一致：全量重置仍成功，随后可从头规划。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 99999}),
+            _entry(2, source_range={"source_file": "source/gone.txt", "start": 500, "end": 900}),
+        ],
+        planning_cursor={"source_file": "source/gone.txt", "offset": 99999},
+    )
+    (project_dir / "source" / "episode_1.txt").write_text("旧内容", encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert result.removed_episodes == [1, 2]
+    project = _load_project(project_dir)
+    assert project["episodes"] == []
+    assert project["planning_cursor"] is None
+    # 重置后规划起点回到第一个源文件开头（plan 可正常从头规划）
+    assert EpisodePlanner(project_dir)._effective_start(project) == ("source/novel.txt", 0)
+
+
+def test_reset_clears_source_fingerprints(tmp_path: Path) -> None:
+    """源文指纹随账本一并失效：字段存在时被清除，不存在时不报错。"""
+    project_dir = _write_project(
+        tmp_path,
+        extra={SOURCE_FINGERPRINTS_KEY: {"source/novel.txt": "deadbeef"}},
+    )
+
+    reset_episode_planning(project_dir, from_episode=1)
+
+    assert SOURCE_FINGERPRINTS_KEY not in _load_project(project_dir)
+
+
+def test_reset_removes_remaining_file(tmp_path: Path) -> None:
+    """余文文件被清理：留着会在下次规划的回填中被换算成游标，让「从头规划」变成续规划。"""
+    project_dir = _write_project(tmp_path)
+    remaining = project_dir / "source" / "_remaining.txt"
+    remaining.write_text("第三章 风波。少女身份成谜。", encoding="utf-8")
+
+    reset_episode_planning(project_dir, from_episode=1)
+
+    assert not remaining.exists()
+    project = _load_project(project_dir)
+    assert EpisodePlanner(project_dir)._effective_start(project) == ("source/novel.txt", 0)
+
+
+# ---------------------------------------------------------------------------
+# 文件处置：派生的删、非派生的留底
+# ---------------------------------------------------------------------------
+
+
+def test_derived_files_deleted_and_legacy_files_archived(tmp_path: Path) -> None:
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(2, source_range=None, status="unanchored"),
+        ],
+    )
+    derived = project_dir / "source" / "episode_1.txt"
+    derived.write_text(SOURCE[:10], encoding="utf-8")
+    legacy = project_dir / "source" / "episode_2.txt"
+    legacy.write_text("老项目手工内容", encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert not derived.exists()
+    assert result.deleted_files == ["source/episode_1.txt"]
+    assert not legacy.exists()
+    archived = project_dir / "source" / "_episode_2.txt.bak"
+    assert archived.read_text(encoding="utf-8") == "老项目手工内容"
+    assert result.archived_files == [("source/episode_2.txt", "source/_episode_2.txt.bak")]
+
+
+def test_archived_file_left_out_of_discovery(tmp_path: Path) -> None:
+    """留底文件既不进源文候选，也不被当成派生集文件重新认领。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[_entry(2, source_range=None, status="unanchored")],
+    )
+    (project_dir / "source" / "episode_2.txt").write_text("老项目手工内容", encoding="utf-8")
+
+    reset_episode_planning(project_dir, from_episode=1)
+
+    assert discover_episode_files(project_dir) == {}
+    assert [doc.rel_path for doc in discover_sources(project_dir)] == ["source/novel.txt"]
+
+
+def test_archive_does_not_overwrite_existing_backup(tmp_path: Path) -> None:
+    """重复重置不覆盖上一次的留底：同名时追加序号。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[_entry(2, source_range=None, status="unanchored")],
+    )
+    (project_dir / "source" / "_episode_2.txt.bak").write_text("上一次的留底", encoding="utf-8")
+    (project_dir / "source" / "episode_2.txt").write_text("这一次的内容", encoding="utf-8")
+
+    reset_episode_planning(project_dir, from_episode=1)
+
+    assert (project_dir / "source" / "_episode_2.txt.bak").read_text(encoding="utf-8") == "上一次的留底"
+    assert (project_dir / "source" / "_episode_2.txt.1.bak").read_text(encoding="utf-8") == "这一次的内容"
+
+
+def test_orphan_episode_file_archived(tmp_path: Path) -> None:
+    """账本无对应条目的孤儿集文件按无坐标处理：留底而非删除，避免回填重新补建条目。"""
+    project_dir = _write_project(tmp_path)
+    (project_dir / "source" / "episode_7.txt").write_text("孤儿内容", encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert result.archived_files == [("source/episode_7.txt", "source/_episode_7.txt.bak")]
+    assert discover_episode_files(project_dir) == {}
+
+
+# ---------------------------------------------------------------------------
+# 已消费集的二段确认
+# ---------------------------------------------------------------------------
+
+
+def test_consumed_requires_confirmation_and_writes_nothing(tmp_path: Path) -> None:
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}, status="consumed"),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": 10, "end": 20}),
+        ],
+        planning_cursor={"source_file": "source/novel.txt", "offset": 20},
+    )
+    derived = project_dir / "source" / "episode_1.txt"
+    derived.write_text("已消费集", encoding="utf-8")
+    before = _load_project(project_dir)
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, ResetConfirmationRequired)
+    assert result.consumed_episodes == [1]
+    assert _load_project(project_dir) == before
+    assert derived.exists()
+
+
+def test_consumed_detected_from_disk_when_ledger_status_missing(tmp_path: Path) -> None:
+    """账本状态不可信时以磁盘产物为准：条目无 ledger_status 但剧本已存在，仍要确认。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[{"episode": 1, "title": "第 1 集", "script_file": "scripts/episode_1.json"}],
+    )
+    _write_script(project_dir, 1)
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, ResetConfirmationRequired)
+    assert result.consumed_episodes == [1]
+
+
+def test_confirmed_reset_keeps_downstream_products(tmp_path: Path) -> None:
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}, status="consumed"),
+        ],
+    )
+    script = _write_script(project_dir, 1)
+    drafts = project_dir / "drafts" / "episode_1"
+    drafts.mkdir(parents=True)
+    step1 = drafts / "step1_segments.json"
+    step1.write_text("{}", encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=1, confirm_consumed=True)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert result.consumed_episodes == [1]
+    assert script.is_file()
+    assert step1.is_file()
+    project = _load_project(project_dir)
+    assert project["episodes"] == []
+    assert project["planning_cursor"] is None
+
+
+# ---------------------------------------------------------------------------
+# 部分重置尚未支持
+# ---------------------------------------------------------------------------
+
+
+def test_partial_reset_rejected_without_touching_ledger(tmp_path: Path) -> None:
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[_entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10})],
+        planning_cursor={"source_file": "source/novel.txt", "offset": 10},
+    )
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="部分重置"):
+        reset_episode_planning(project_dir, from_episode=2)
+
+    assert _load_project(project_dir) == before

--- a/tests/test_episode_reset.py
+++ b/tests/test_episode_reset.py
@@ -14,6 +14,7 @@ import pytest
 
 from lib.episode_ledger import (
     SOURCE_FINGERPRINTS_KEY,
+    discover_episode_file_aliases,
     discover_episode_files,
     discover_sources,
 )
@@ -415,6 +416,45 @@ def test_reset_aggregates_consumed_status_across_duplicate_episode_entries(tmp_p
     assert result.consumed_episodes == [1]
 
 
+def test_reset_aggregates_downstream_products_across_duplicate_entries(tmp_path: Path) -> None:
+    """损坏账本同一集号出现多条条目，首条指向缺失的规范剧本路径、后条的 script_file
+    指向实际存在的非规范路径（如 scripts/custom_name.json）时，已消费判定仍要命中——
+    不能只把 setdefault 留下的首条传给 has_downstream_products。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            {"episode": 1, "title": "首条", "script_file": "scripts/episode_1.json"},
+            {"episode": 1, "title": "后条", "script_file": "scripts/custom_name.json"},
+        ],
+    )
+    scripts = project_dir / "scripts"
+    scripts.mkdir()
+    (scripts / "custom_name.json").write_text("{}", encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, ResetConfirmationRequired)
+    assert result.consumed_episodes == [1]
+
+
+def test_reset_archives_when_source_range_is_structurally_incomplete(tmp_path: Path) -> None:
+    """source_range 是空字典或缺字段的损坏映射时，虽满足 isinstance(Mapping) 但没有
+    可用坐标，仍按无法从账本重造处理（留底而非删除）。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[_entry(1, source_range={})],
+    )
+    derived = project_dir / "source" / "episode_1.txt"
+    derived.write_text(SOURCE[:10], encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert result.deleted_files == []
+    assert result.archived_files
+    assert not derived.exists()
+
+
 def test_reset_archives_when_any_duplicate_entry_lacks_source_range(tmp_path: Path) -> None:
     """损坏账本同一集号出现多条条目，首条带 source_range、后条不带时，按无法证明可
     重造处理（留底而非删除）——删除不可逆，证据冲突时偏保守。"""
@@ -467,6 +507,18 @@ def test_discover_episode_files_prefers_readable_over_dangling_alias(tmp_path: P
     dangling.symlink_to(project_dir / "source" / "does_not_exist.txt")
 
     assert discover_episode_files(project_dir)[1] == valid
+
+
+def test_discover_episode_files_skips_episode_with_only_dangling_alias(tmp_path: Path) -> None:
+    """某集号全部别名都是悬空符号链接（无真实内容）时，代表路径映射里不出现该集号，
+    而不是返回一个读不到内容的路径——否则 backfill 会为纯悬空、无真实内容的集号
+    凭空补建一个 unanchored 幽灵条目。"""
+    project_dir = _write_project(tmp_path)
+    dangling = project_dir / "source" / "episode_9.txt"
+    dangling.symlink_to(project_dir / "source" / "does_not_exist.txt")
+
+    assert 9 not in discover_episode_files(project_dir)
+    assert discover_episode_file_aliases(project_dir)[9] == [dangling]
 
 
 def test_empty_drafts_dir_does_not_require_confirmation(tmp_path: Path) -> None:

--- a/tests/test_episode_reset.py
+++ b/tests/test_episode_reset.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -288,6 +289,102 @@ def test_confirmed_reset_keeps_downstream_products(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # 部分重置尚未支持
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# 损坏边界：非列表 episodes / 符号链接 / 磁盘孤儿产物 / 同集号别名文件
+# ---------------------------------------------------------------------------
+
+
+def test_reset_tolerates_non_list_episodes(tmp_path: Path) -> None:
+    """episodes 被写坏成 truthy 非列表值（如手工误编辑成整数）时按空账本处理，不崩溃。"""
+    project_dir = _write_project(tmp_path, extra={"episodes": 1})
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert result.removed_episodes == []
+    assert _load_project(project_dir)["episodes"] == []
+
+
+def test_reset_rejects_symlinked_source_dir(tmp_path: Path) -> None:
+    """source/ 是指向项目外目录的符号链接时拒绝处置，避免删除/改名外部目录中的文件。"""
+    project_dir = _write_project(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "episode_1.txt").write_text("外部文件", encoding="utf-8")
+    source_dir = project_dir / "source"
+    shutil.rmtree(source_dir)
+    source_dir.symlink_to(outside, target_is_directory=True)
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="符号链接"):
+        reset_episode_planning(project_dir, from_episode=1)
+
+    assert (outside / "episode_1.txt").exists()
+    assert _load_project(project_dir) == before
+
+
+def test_reset_rejects_symlinked_episode_file(tmp_path: Path) -> None:
+    """单个派生集文件是符号链接时拒绝处置，避免跟随链接删除/改名外部文件。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[_entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10})],
+    )
+    outside_target = tmp_path / "outside_episode_1.txt"
+    outside_target.write_text("外部文件", encoding="utf-8")
+    (project_dir / "source" / "episode_1.txt").symlink_to(outside_target)
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="符号链接"):
+        reset_episode_planning(project_dir, from_episode=1)
+
+    assert outside_target.exists()
+    assert _load_project(project_dir) == before
+
+
+def test_orphan_disk_product_requires_confirmation(tmp_path: Path) -> None:
+    """账本丢失条目、无对应 source/episode_N.txt，但 scripts/ 下仍有产物时仍要求确认。"""
+    project_dir = _write_project(tmp_path)
+    _write_script(project_dir, 1)
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, ResetConfirmationRequired)
+    assert result.consumed_episodes == [1]
+
+
+def test_orphan_draft_dir_requires_confirmation(tmp_path: Path) -> None:
+    """账本丢失条目、无对应 source/episode_N.txt，但 drafts/ 下仍有 step1 产物时仍要求确认。"""
+    project_dir = _write_project(tmp_path)
+    drafts = project_dir / "drafts" / "episode_1"
+    drafts.mkdir(parents=True)
+    (drafts / "step1_segments.json").write_text("{}", encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, ResetConfirmationRequired)
+    assert result.consumed_episodes == [1]
+
+
+def test_reset_processes_all_padding_aliases_of_same_episode(tmp_path: Path) -> None:
+    """同一集号的多个 padding 别名（episode_1.txt / episode_01.txt）全部被处置，
+    否则未处理的别名会在下次回填中重新补建账本条目。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[_entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10})],
+    )
+    alias_a = project_dir / "source" / "episode_1.txt"
+    alias_a.write_text(SOURCE[:10], encoding="utf-8")
+    alias_b = project_dir / "source" / "episode_01.txt"
+    alias_b.write_text(SOURCE[:10], encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert not alias_a.exists()
+    assert not alias_b.exists()
+    assert discover_episode_files(project_dir) == {}
 
 
 def test_partial_reset_rejected_without_touching_ledger(tmp_path: Path) -> None:

--- a/tests/test_episode_reset.py
+++ b/tests/test_episode_reset.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import sys
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,7 @@ from lib.episode_ledger import (
 )
 from lib.episode_planner import EpisodePlanner
 from lib.episode_reset import (
+    EpisodeResetConflictError,
     EpisodeResetError,
     EpisodeResetResult,
     ResetConfirmationRequired,
@@ -231,23 +233,24 @@ def test_conflict_when_new_consumed_episode_appears_during_commit(
 ) -> None:
     """锁内复扫发现确认清单之外的新消费集时拒绝提交、账本不被改动：这是防止「确认时看到的
     清单」与「实际提交时的账本状态」不一致的关键安全网，用 monkeypatch 模拟该竞态窗口。"""
-    import lib.episode_reset as reset_mod
-
+    # 通过 sys.modules 取模块对象供 monkeypatch 使用，不再新增一种 import 风格
+    # （lib.episode_reset 已在文件顶部用 from-import 引入）
+    episode_reset_module = sys.modules["lib.episode_reset"]
     project_dir = _write_project(tmp_path)
     before = _load_project(project_dir)
-    original_scan = reset_mod._scan
+    original_scan = episode_reset_module._scan
     calls = {"n": 0}
 
-    def _fake_scan(pd: Path, project: dict) -> reset_mod._ResetPlan:
+    def _fake_scan(pd: Path, project: dict):
         calls["n"] += 1
         result = original_scan(pd, project)
         if calls["n"] == 2:  # 第二次调用发生在锁内（_commit 的复扫）
             result.consumed.append(1)
         return result
 
-    monkeypatch.setattr(reset_mod, "_scan", _fake_scan)
+    monkeypatch.setattr(episode_reset_module, "_scan", _fake_scan)
 
-    with pytest.raises(reset_mod.EpisodeResetConflictError):
+    with pytest.raises(EpisodeResetConflictError):
         reset_episode_planning(project_dir, from_episode=1)
 
     assert _load_project(project_dir) == before
@@ -410,6 +413,71 @@ def test_reset_aggregates_consumed_status_across_duplicate_episode_entries(tmp_p
 
     assert isinstance(result, ResetConfirmationRequired)
     assert result.consumed_episodes == [1]
+
+
+def test_reset_archives_when_any_duplicate_entry_lacks_source_range(tmp_path: Path) -> None:
+    """损坏账本同一集号出现多条条目，首条带 source_range、后条不带时，按无法证明可
+    重造处理（留底而非删除）——删除不可逆，证据冲突时偏保守。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(1, source_range=None, status="unanchored"),
+        ],
+    )
+    derived = project_dir / "source" / "episode_1.txt"
+    derived.write_text(SOURCE[:10], encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert result.deleted_files == []
+    assert result.archived_files
+    assert not derived.exists()
+
+
+def test_archive_path_increments_past_dangling_symlink_collision(tmp_path: Path) -> None:
+    """留底目标名恰好被上一次遗留的悬空符号链接占用时仍按占用处理并追加序号：
+    exists() 对悬空链接返回 False，只查 exists() 会让 rename() 静默覆盖旧留底。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[_entry(2, source_range=None, status="unanchored")],
+    )
+    stale_backup = project_dir / "source" / "_episode_2.txt.bak"
+    stale_backup.symlink_to(project_dir / "source" / "does_not_exist_either.txt")
+    legacy = project_dir / "source" / "episode_2.txt"
+    legacy.write_text("这一次的内容", encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert stale_backup.is_symlink()  # 旧留底（悬空链接）未被覆盖
+    new_backup = project_dir / "source" / "_episode_2.txt.1.bak"
+    assert new_backup.read_text(encoding="utf-8") == "这一次的内容"
+    assert result.archived_files == [("source/episode_2.txt", "source/_episode_2.txt.1.bak")]
+
+
+def test_discover_episode_files_prefers_readable_over_dangling_alias(tmp_path: Path) -> None:
+    """代表路径在悬空别名恰好排序在前时仍优先选可读文件，避免 backfill 等按内容匹配
+    source_range 的调用方读到悬空链接而误判该集 unanchored。"""
+    project_dir = _write_project(tmp_path)
+    valid = project_dir / "source" / "episode_1.txt"
+    valid.write_text(SOURCE[:10], encoding="utf-8")
+    dangling = project_dir / "source" / "episode_01.txt"  # 排序早于 episode_1.txt
+    dangling.symlink_to(project_dir / "source" / "does_not_exist.txt")
+
+    assert discover_episode_files(project_dir)[1] == valid
+
+
+def test_empty_drafts_dir_does_not_require_confirmation(tmp_path: Path) -> None:
+    """drafts/episode_N/ 目录存在但为空（如一次被拒绝的草稿保存留下的空目录）时不计入
+    已消费产物，不能因为目录存在就误报需要确认。"""
+    project_dir = _write_project(tmp_path)
+    (project_dir / "drafts" / "episode_1").mkdir(parents=True)
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, EpisodeResetResult)
 
 
 def test_reset_tolerates_unconvertible_digit_episode_num(tmp_path: Path) -> None:

--- a/tests/test_episode_reset.py
+++ b/tests/test_episode_reset.py
@@ -24,6 +24,10 @@ from lib.episode_reset import (
     reset_episode_planning,
 )
 
+# 全部用例跨 EpisodeReset / ProjectManager / EpisodePlanner 协作，用真实 tmp_path 文件系统，
+# 不 mock 被测模块的公共入口——按 CONTRIBUTING.md 的 marker 纪律归类为 integration。
+pytestmark = pytest.mark.integration
+
 SOURCE = "第一章 山村少年。李恒在山村长大。第二章 下山。李恒辞别师父。第三章 风波。少女身份成谜。"
 
 
@@ -222,6 +226,33 @@ def test_file_failure_aborts_and_leaves_ledger_intact(tmp_path: Path, monkeypatc
     assert _load_project(project_dir) == before
 
 
+def test_conflict_when_new_consumed_episode_appears_during_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """锁内复扫发现确认清单之外的新消费集时拒绝提交、账本不被改动：这是防止「确认时看到的
+    清单」与「实际提交时的账本状态」不一致的关键安全网，用 monkeypatch 模拟该竞态窗口。"""
+    import lib.episode_reset as reset_mod
+
+    project_dir = _write_project(tmp_path)
+    before = _load_project(project_dir)
+    original_scan = reset_mod._scan
+    calls = {"n": 0}
+
+    def _fake_scan(pd: Path, project: dict) -> reset_mod._ResetPlan:
+        calls["n"] += 1
+        result = original_scan(pd, project)
+        if calls["n"] == 2:  # 第二次调用发生在锁内（_commit 的复扫）
+            result.consumed.append(1)
+        return result
+
+    monkeypatch.setattr(reset_mod, "_scan", _fake_scan)
+
+    with pytest.raises(reset_mod.EpisodeResetConflictError):
+        reset_episode_planning(project_dir, from_episode=1)
+
+    assert _load_project(project_dir) == before
+
+
 # ---------------------------------------------------------------------------
 # 已消费集的二段确认
 # ---------------------------------------------------------------------------
@@ -325,22 +356,89 @@ def test_reset_rejects_symlinked_source_dir(tmp_path: Path) -> None:
     assert _load_project(project_dir) == before
 
 
-def test_reset_rejects_symlinked_episode_file(tmp_path: Path) -> None:
-    """单个派生集文件是符号链接时拒绝处置，避免跟随链接删除/改名外部文件。"""
+def test_reset_deletes_symlinked_episode_file_without_touching_target(tmp_path: Path) -> None:
+    """单个派生集文件是符号链接时按计划正常处置：unlink/rename 只作用于链接条目本身、
+    不跟随最终一段的链接目标，外部文件不受影响（与 source/ 本身是符号链接的风险不同）。"""
     project_dir = _write_project(
         tmp_path,
         episodes=[_entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10})],
     )
     outside_target = tmp_path / "outside_episode_1.txt"
     outside_target.write_text("外部文件", encoding="utf-8")
-    (project_dir / "source" / "episode_1.txt").symlink_to(outside_target)
-    before = _load_project(project_dir)
+    link = project_dir / "source" / "episode_1.txt"
+    link.symlink_to(outside_target)
 
-    with pytest.raises(EpisodeResetError, match="符号链接"):
-        reset_episode_planning(project_dir, from_episode=1)
+    result = reset_episode_planning(project_dir, from_episode=1)
 
+    assert isinstance(result, EpisodeResetResult)
+    assert not link.exists()
     assert outside_target.exists()
-    assert _load_project(project_dir) == before
+    assert outside_target.read_text(encoding="utf-8") == "外部文件"
+
+
+def test_reset_clears_dangling_symlinked_episode_file(tmp_path: Path) -> None:
+    """目标不存在的悬空符号链接同样被发现并清理，否则残留链接会在下次 plan_episodes
+    写派生文件时被 EpisodePlanner 的符号链接校验硬拦截，重置的"可继续规划"承诺落空。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[_entry(2, source_range=None, status="unanchored")],
+    )
+    link = project_dir / "source" / "episode_2.txt"
+    link.symlink_to(project_dir / "source" / "does_not_exist.txt")
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert not link.exists()
+    assert result.archived_files
+    archived_target = project_dir / result.archived_files[0][1]
+    assert archived_target.is_symlink()
+
+
+def test_reset_aggregates_consumed_status_across_duplicate_episode_entries(tmp_path: Path) -> None:
+    """损坏账本同一集号出现多条条目（首条 planned、后条 consumed）时，已消费判定按
+    集号聚合全部条目，不能只看被去重逻辑留下的首条而漏判。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}, status="planned"),
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}, status="consumed"),
+        ],
+    )
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, ResetConfirmationRequired)
+    assert result.consumed_episodes == [1]
+
+
+def test_reset_tolerates_unconvertible_digit_episode_num(tmp_path: Path) -> None:
+    """episode 字段是 str.isdigit() 认可但 int() 无法转换的字符（如上标 ²）时不崩溃，
+    该条目按无法识别集号处理（原样跳过），不阻断重置这个逃生口本身。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[{"episode": "²", "title": "损坏集号"}],
+    )
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert result.removed_episodes == []
+
+
+def test_orphan_disk_product_with_padded_filename_requires_confirmation(tmp_path: Path) -> None:
+    """账本丢失条目、产物文件名 padding 与规范路径不一致（episode_01.json 而非
+    episode_1.json）时，仍要求确认——不能因为 has_downstream_products 只认规范路径
+    就漏判已消费。"""
+    project_dir = _write_project(tmp_path)
+    scripts = project_dir / "scripts"
+    scripts.mkdir()
+    (scripts / "episode_01.json").write_text("{}", encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=1)
+
+    assert isinstance(result, ResetConfirmationRequired)
+    assert result.consumed_episodes == [1]
 
 
 def test_orphan_disk_product_requires_confirmation(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1368

## 做了什么

新增 SDK 工具 `reset_episode_planning(from_episode, confirm_consumed)`，本票只落地 `from_episode=1` 的全量重置。账本坐标绑定源文内容，源文被替换或账本写坏后规划入口会永久失败；重置是这种局面的逃生口：**零前置校验**——不解析 `source_range`、不校验 cursor，账本处于任何损坏状态都能执行成功。

- 重置逻辑落在独立模块 `lib/episode_reset.py`，不挂 `EpisodePlanner`：后者的 `create()` 会先构造 `TextGenerator`，逃生口不能因供应商未配置而失效。写入仍走 `ProjectManager.update_project`，与规划共用同一把项目锁。
- 已消费判定取账本状态与磁盘产物的并集：账本损坏时 `ledger_status` 未必可信，磁盘上的剧本 / step1 才是硬证据。偏保守，只会多要一次确认。
- 派生文件按「能否从账本重造」分流：带 `source_range` 的 `source/episode_N.txt` 删除；无 `source_range` 的集文件改名留底（`_` 前缀 + `.bak` 尾缀，同名追加序号），内容保留。下游产物一律不删。
- 一并清理 `source/_remaining.txt`：留着会在下次规划的回填中被换算成 `planning_cursor`，让「从头规划」变成从余文续规划。
- `from_episode > 1` 返回明确的暂不支持错误，账本不动。

## 验证

- `uv run python -m pytest`：6552 passed
- `uv run basedpyright`：0 errors
- `uv run ruff check . && uv run ruff format`：通过
- `pnpm lint && pnpm check`：128 files / 1269 tests 通过
- 六条验收标准逐条核实：损坏账本（cursor 越界 + 条目坐标越界 + 账本磁盘不一致）重置后 `_effective_start` 回到源文起点；consumed 集首次调用零写入返回清单、确认后执行且剧本 / step1 保留；留底文件实测同时逃出 `discover_sources`（`_` 前缀跳过）与 `discover_episode_files`（`episode_N.txt` 全匹配落空）；部分重置拒绝且账本逐字不变；三语 `tool_name_reset_episode_planning` 补齐。

## 本地审查后的改动

- 抽出 `_require_positive_int` / `_optional_bool`，消除 replan 与 reset 两个 handler 间逐字重复的入参校验。
- 锁内闭包的 `dict[str, Any]` 信箱换成类型化的 `EpisodeResetResult`，恢复该段的类型检查覆盖。
- 补测文件处置失败时硬失败并回滚账本写入——这是本模块与 `_reconcile_derived_files`（仅告警）分叉的关键决策，此前无覆盖。

## 范围说明

Agent 侧文档（`CLAUDE.*.md` / SKILL）对新工具的指引收口在 #1371，ADR 0031/0032 与 CONTEXT.md 词条收口在 #1373；`source_fingerprints` 字段本票只做清除，生产者是 #1369。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“重置分集规划”工具：可将规划账本回滚到未规划状态；若检测到可能已消费的集数，将先请求二段确认以避免误删已生成产物。
  * 新增英文/中文/越南语界面文案（工具名称）。
* **改进**
  * 更可靠地识别分集文件及其别名派生产物，并在重置过程中加强一致性校验、冲突检测与安全的文件删除/归档策略。
* **测试**
  * 补充重置工具的集成与 SDK 工具测试，覆盖成功、确认、冲突回滚及多类边界参数场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->