### PR TITLE
fix(video): 剧本 generated_assets 损坏时视频入队不再整批中断

### DIFF
--- a/lib/storyboard_sequence.py
+++ b/lib/storyboard_sequence.py
@@ -66,6 +66,18 @@ def find_storyboard_item(
     return None
 
 
+def get_generated_assets(item: dict) -> dict:
+    """归一化访问 item 的 ``generated_assets`` 容器。
+
+    该字段来自磁盘上的剧本 JSON，不可信任：外部编辑可能把它损坏成非 dict（如
+    list/字符串）。归一化为空 dict 而非抛错，让调用方走各自「该资产未生成」的
+    既有分支（单条跳过 / 可读拒绝），不会在批量入队时因为一条脏数据抛未捕获
+    ``AttributeError`` 中断整批。
+    """
+    assets = item.get("generated_assets")
+    return assets if isinstance(assets, dict) else {}
+
+
 def resolve_storyboard_image_ref(project_path: Path, storyboard_rel: object) -> Path | None:
     """校验 ``generated_assets.storyboard_image`` 字段值，返回解析后落在 ``storyboards/``
     内的绝对路径；字段未设置（``None``/``""``）返回 ``None``，由调用方按各自默认路径回退。

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -467,7 +467,7 @@ async def _run_ad_reference_episode(
         ),
         # sync 把成员/参考集变化的 unit 重置为待生成；旧同名产物不可复用，
         # 仅 generated_assets 仍指向产物的 unit 才按磁盘文件跳过
-        reuse_existing=lambda u: bool((u.get("generated_assets") or {}).get("video_clip")),
+        reuse_existing=lambda u: bool(get_generated_assets(u).get("video_clip")),
     )
     header = f"参考直出生成完成，共 {len(paths)} 个 unit"
     return {"content": [{"type": "text", "text": "\n".join([header, *log])}]}
@@ -687,7 +687,7 @@ def generate_video_all_tool(ctx: ToolContext):
 
             items, id_field, _chars, _scenes, _props = get_storyboard_items(script)
             content_mode = script.get("content_mode", "narration")
-            pending = [it for it in items if not (it.get("generated_assets") or {}).get("video_clip")]
+            pending = [it for it in items if not get_generated_assets(it).get("video_clip")]
             if not pending:
                 return {"content": [{"type": "text", "text": "✨ 所有场景/片段的视频都已生成"}]}
 

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -26,7 +26,7 @@ from lib.reference_video.ad_units import (
     resolve_ad_unit_shots,
     sync_ad_reference_units,
 )
-from lib.storyboard_sequence import get_storyboard_items, resolve_storyboard_image_ref
+from lib.storyboard_sequence import get_generated_assets, get_storyboard_items, resolve_storyboard_image_ref
 from server.agent_runtime.sdk_tools._context import (
     ToolContext,
     tool_error,
@@ -124,7 +124,7 @@ def _build_video_specs(
         if item_id in skip_set:
             continue
 
-        storyboard_image = (item.get("generated_assets") or {}).get("storyboard_image")
+        storyboard_image = get_generated_assets(item).get("storyboard_image")
         # 字段值来自磁盘剧本 JSON，不可信任：非字符串脏数据/越界/绝对路径引用统一交给
         # resolve_storyboard_image_ref 校验（与路由入队预检、执行层读盘点共用同一份），
         # 批量场景下单个条目非法只跳过并记日志，不中断整批。
@@ -610,7 +610,7 @@ def generate_video_scene_tool(ctx: ToolContext):
             # checkpoint 扫描会找不到产物。
             item_id = str(item[id_field])
 
-            storyboard_image = item.get("generated_assets", {}).get("storyboard_image")
+            storyboard_image = get_generated_assets(item).get("storyboard_image")
             # 字段值来自磁盘剧本 JSON，不可信任：resolve_storyboard_image_ref 统一做类型检查 +
             # 越界 / 绝对路径拒绝（与路由入队预检、执行层读盘点共用同一份），异常经外层
             # except 转为可读的 tool_error，不再让非字符串脏数据抛未处理 TypeError。

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -331,8 +331,7 @@ async def generate_tts_batch(
         for item in items:
             if not _narration_text(item):
                 continue
-            assets = item.get("generated_assets") or {}
-            if isinstance(assets, dict) and assets.get("narration_audio"):
+            if get_generated_assets(item).get("narration_audio"):
                 continue
             seg_id = item.get(id_field)
             if seg_id:

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -24,6 +24,7 @@ from lib.path_safety import safe_exists
 from lib.project_manager import get_project_manager
 from lib.storyboard_sequence import (
     find_storyboard_item,
+    get_generated_assets,
     get_storyboard_items,
     resolve_storyboard_image_ref,
 )
@@ -160,15 +161,12 @@ async def generate_video(
         # fail-fast：不能 silently 降级走 default 路径——default 文件恰好存在时会让请求
         # 「先返回提交成功、worker 解析脚本时再确定失败」，撕裂用户预期。两者均由 app 级
         # handler 统一映射为脱敏响应（404 / 400）。
-        storyboard_rel: object = None
         script = pm_local.load_script(project_name, req.script_file)
         items, id_field, _, _, _ = get_storyboard_items(script)
         resolved = find_storyboard_item(items, id_field, segment_id)
         if resolved is None:
             raise NotFoundError("segment_not_found", id=segment_id)
-        assets = resolved[0].get("generated_assets") or {}
-        if isinstance(assets, dict):
-            storyboard_rel = assets.get("storyboard_image")
+        storyboard_rel = get_generated_assets(resolved[0]).get("storyboard_image")
 
         # 字段值来自磁盘剧本 JSON，不可信任：非字符串脏数据会让下面的路径拼接抛未处理
         # TypeError 变成通用 500；越界 / 绝对路径引用会把项目外任意文件当分镜图使用。

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -39,6 +39,7 @@ from lib.script_skeleton import SKELETON_ENTITY_TYPES, SKELETON_ITEM_NOUNS, reso
 from lib.storyboard_sequence import (
     build_previous_storyboard_reference,
     find_storyboard_item,
+    get_generated_assets,
     get_storyboard_items,
     group_scenes_by_segment_break,
     resolve_previous_storyboard_path,
@@ -792,8 +793,7 @@ async def execute_video_task(
 
     # 优先读取 generated_assets.storyboard_image，回退默认路径。校验口径见
     # resolve_storyboard_image_ref：与路由入队预检、SDK 工具入队预检共用同一份。
-    assets = item.get("generated_assets", {})
-    storyboard_rel = assets.get("storyboard_image") if isinstance(assets, dict) else None
+    storyboard_rel = get_generated_assets(item).get("storyboard_image")
     storyboard_file = resolve_storyboard_image_ref(project_path, storyboard_rel)
     if storyboard_file is None:
         storyboard_file = project_path / "storyboards" / f"scene_{resource_id}.png"

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1069,6 +1069,45 @@ def test_build_video_specs_skips_invalid_storyboard_image_without_aborting_batch
     assert any("S01" in line for line in log)
 
 
+def test_build_video_specs_skips_non_dict_generated_assets_without_aborting_batch(tmp_path: Path) -> None:
+    """generated_assets 容器本身被外部编辑损坏为非 dict（如 list）时按「没有分镜图」跳过，
+    不应让 `.get("storyboard_image")` 在非 dict 上抛未处理 AttributeError 中断整批。"""
+    from server.agent_runtime.sdk_tools.enqueue_videos import _build_video_specs
+
+    (tmp_path / "storyboards").mkdir()
+    (tmp_path / "storyboards" / "scene_S02.png").write_bytes(b"png")
+    items = [
+        {"segment_id": "S01", "video_prompt": "脏数据", "generated_assets": ["bad"]},
+        {
+            "segment_id": "S02",
+            "video_prompt": "合法引用",
+            "generated_assets": {"storyboard_image": "storyboards/scene_S02.png"},
+        },
+    ]
+    log: list[str] = []
+    specs, order_map = _build_video_specs(
+        items=items,
+        id_field="segment_id",
+        content_mode="narration",
+        script_filename="episode_1.json",
+        project_dir=tmp_path,
+        skip_ids=None,
+        log=log,
+    )
+    assert [s.resource_id for s in specs] == ["S02"]
+    assert any("S01" in line for line in log)
+
+
+async def test_generate_video_scene_generated_assets_non_dict_readable_rejection(fake_ctx: ToolContext) -> None:
+    """generated_assets 容器本身非 dict 时须走「没有分镜图」的可读拒绝分支，
+    不应在单条路径上抛未处理 AttributeError。"""
+    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = ["bad"]  # type: ignore[attr-defined]
+    tool_obj = generate_video_scene_tool(fake_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json", "scene_id": "E1S01"})
+    assert out.get("is_error") is True
+    assert "没有分镜图" in out["content"][0]["text"]
+
+
 def test_get_video_prompt_drama_sources_dialogue_from_utterances() -> None:
     """drama：_get_video_prompt 从场景级 dialogue-kind utterances 派生 video YAML 台词，
     voiceover-kind 不进；narration / ad（无 utterances 字段）原样渲染既有 video_prompt.dialogue。"""

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -855,6 +855,39 @@ async def test_generate_video_episode_happy(fake_ctx: ToolContext, monkeypatch) 
     assert out.get("is_error") is not True
 
 
+@pytest.mark.integration
+async def test_generate_video_episode_non_dict_generated_assets_does_not_abort_batch(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """整集入队先按 generated_assets.video_clip 过滤已完成条目。容器被外部编辑损坏为非 dict
+    时该过滤须按「未生成」处理，而不是在 pending 过滤阶段就抛未处理 AttributeError——那会
+    让整批在到达逐条跳过逻辑之前就中断。"""
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    project_dir = fake_ctx.pm.get_project_path("demo")
+    (project_dir / "storyboards" / "scene_E1S02.png").write_bytes(b"png")
+    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+        {"segment_id": "E1S01", "video_prompt": "脏数据", "generated_assets": ["bad"]},
+        {
+            "segment_id": "E1S02",
+            "video_prompt": "合法条目",
+            "generated_assets": {"storyboard_image": "storyboards/scene_E1S02.png"},
+        },
+    ]
+    enqueued: list[str] = []
+
+    async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
+        enqueued.extend(spec.resource_id for spec in specs)
+        return [], []
+
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+    tool_obj = generate_video_episode_tool(fake_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json"})
+
+    assert out.get("is_error") is not True
+    assert enqueued == ["E1S02"]
+
+
 async def test_generate_video_episode_error(fake_ctx: ToolContext) -> None:
     fake_ctx.pm.script_payload = {"content_mode": "narration", "segments": [], "episode": 1}  # type: ignore[attr-defined]
     tool_obj = generate_video_episode_tool(fake_ctx)
@@ -1069,6 +1102,7 @@ def test_build_video_specs_skips_invalid_storyboard_image_without_aborting_batch
     assert any("S01" in line for line in log)
 
 
+@pytest.mark.integration
 def test_build_video_specs_skips_non_dict_generated_assets_without_aborting_batch(tmp_path: Path) -> None:
     """generated_assets 容器本身被外部编辑损坏为非 dict（如 list）时按「没有分镜图」跳过，
     不应让 `.get("storyboard_image")` 在非 dict 上抛未处理 AttributeError 中断整批。"""
@@ -1098,6 +1132,7 @@ def test_build_video_specs_skips_non_dict_generated_assets_without_aborting_batc
     assert any("S01" in line for line in log)
 
 
+@pytest.mark.integration
 async def test_generate_video_scene_generated_assets_non_dict_readable_rejection(fake_ctx: ToolContext) -> None:
     """generated_assets 容器本身非 dict 时须走「没有分镜图」的可读拒绝分支，
     不应在单条路径上抛未处理 AttributeError。"""

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -213,6 +213,23 @@ class TestGenerateRouter:
             assert video.status_code == 200, video.text
             assert video.json()["success"] is True
 
+    def test_video_generated_assets_non_dict_falls_back_to_default(self, tmp_path, monkeypatch):
+        """generated_assets 容器本身被外部编辑损坏为非 dict（如 list）时按「未设置」处理、
+        回退默认路径，不抛未捕获 AttributeError（脏数据非 dict 上没有 .get()）。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_pm.script["segments"][0]["generated_assets"] = ["bad"]
+        fake_queue = _FakeQueue()
+        client = _client(monkeypatch, fake_pm, fake_queue)
+
+        with client:
+            video = client.post(
+                "/api/v1/projects/demo/generate/video/E1S01",
+                json={"script_file": "episode_1.json", "prompt": "x"},
+            )
+            assert video.status_code == 200, video.text
+            assert video.json()["success"] is True
+
     @pytest.mark.integration
     def test_video_storyboard_image_non_string_returns_400(self, tmp_path, monkeypatch):
         """storyboard_image 是剧本 JSON 里的脏数据（非字符串）时应 400 可读失败，

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -213,6 +213,7 @@ class TestGenerateRouter:
             assert video.status_code == 200, video.text
             assert video.json()["success"] is True
 
+    @pytest.mark.integration
     def test_video_generated_assets_non_dict_falls_back_to_default(self, tmp_path, monkeypatch):
         """generated_assets 容器本身被外部编辑损坏为非 dict（如 list）时按「未设置」处理、
         回退默认路径，不抛未捕获 AttributeError（脏数据非 dict 上没有 .get()）。"""

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -620,6 +620,28 @@ class TestGenerationTasks:
             )
         assert fake_generator.video_calls == []
 
+    @pytest.mark.integration
+    async def test_execute_video_task_generated_assets_non_dict_falls_back_to_default(self, monkeypatch, tmp_path):
+        """generated_assets 容器本身被外部编辑损坏为非 dict（如 list）时按「未设置」处理、
+        回退默认路径，不抛未捕获 AttributeError（`{"...": ...}.get()` 在非 dict 上不存在）。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        fake_pm.script["segments"][0]["generated_assets"] = ["bad"]
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {"script_file": "episode_1.json", "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []}},
+        )
+
+        assert fake_generator.video_calls[0]["start_image"] == project_path / "storyboards" / "scene_E1S01.png"
+
     @pytest.mark.parametrize(
         ("storyboard_value", "expected_message"),
         [

--- a/tests/test_storyboard_sequence.py
+++ b/tests/test_storyboard_sequence.py
@@ -10,6 +10,7 @@ from lib.storyboard_sequence import (
 )
 
 
+@pytest.mark.unit
 class TestGetGeneratedAssets:
     def test_returns_dict_container_unchanged(self):
         item = {"generated_assets": {"storyboard_image": "storyboards/scene_E1S01.png"}}

--- a/tests/test_storyboard_sequence.py
+++ b/tests/test_storyboard_sequence.py
@@ -4,9 +4,23 @@ import pytest
 
 from lib.storyboard_sequence import (
     build_storyboard_dependency_plan,
+    get_generated_assets,
     get_storyboard_items,
     resolve_previous_storyboard_path,
 )
+
+
+class TestGetGeneratedAssets:
+    def test_returns_dict_container_unchanged(self):
+        item = {"generated_assets": {"storyboard_image": "storyboards/scene_E1S01.png"}}
+        assert get_generated_assets(item) == {"storyboard_image": "storyboards/scene_E1S01.png"}
+
+    @pytest.mark.parametrize("dirty", [["bad"], "bad", 123, None, 0, False])
+    def test_normalizes_non_dict_container_to_empty_dict(self, dirty):
+        assert get_generated_assets({"generated_assets": dirty}) == {}
+
+    def test_missing_key_returns_empty_dict(self):
+        assert get_generated_assets({}) == {}
 
 
 class TestStoryboardSequence:


### PR DESCRIPTION
剧本 JSON 的 `generated_assets` 被外部编辑损坏成非 dict（如 list）时，视频入队路径会抛未捕获 `AttributeError`。原先四处调用点各自防御、且拷贝不齐——SDK 工具的两处完全无防御。

本 PR 把容器形状判断收敛到 `lib/storyboard_sequence.get_generated_assets()` 一处：非 dict 归一化为空 dict，调用方走各自「该资产未生成」的既有分支（单条跳过 / 可读拒绝），不中断整批。

收编的调用点：

- `server/routers/generate.py` — 视频入队预检、旁白配音批量的缺失扫描
- `server/services/generation_tasks.py` — 视频任务执行
- `server/agent_runtime/sdk_tools/enqueue_videos.py` — 逐条 spec 构建、单场景工具、整集入队的待办过滤、参考直出的复用判断

其中整集入队的待办过滤是本次审查新发现的缺口：它在逐条跳过逻辑之前执行，损坏数据会让整批在到达已修分支之前就失败。

## 验证

- 新增回归测试覆盖 helper 归一化（6 种脏值参数化）、以及路由入队 / 任务执行 / SDK 逐条构建 / SDK 单场景 / SDK 整集入队五条路径。整集入队与 SDK 两处的用例已用 revert 源码手法确认修复前为红（`'list' object has no attribute 'get'`，整批转为 tool_error）
- 新增测试按 CONTRIBUTING 的 markers 纪律打了 `unit` / `integration`
- `uv run ruff check .` 通过、`uv run basedpyright` 0 error、全量 pytest 6551 passed

Closes #1389


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 增强生成资产数据的容错能力，避免因资产字段格式异常导致视频、分镜图或配音批量任务中断。
  * 当分镜图资产不可用时，视频生成流程会自动回退到默认分镜图路径。
  * 异常数据现在会按未生成资产处理，并返回更清晰的错误提示。

* **Tests**
  * 新增对异常资产数据、批量生成、视频路由及默认回退行为的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->