### PR TITLE
fix(custom-provider): 能力覆盖回显与保存的键集合保持一致

### DIFF
--- a/lib/custom_provider/capabilities.py
+++ b/lib/custom_provider/capabilities.py
@@ -73,9 +73,10 @@ def filter_valid_overrides(*, endpoint: str, model_id: str, overrides: object | 
 
     :func:`synthesize_video_capabilities` 与 API 响应边界（``server/routers/custom_providers.py``
     的 ``_model_to_response``）共用此过滤：后者据此裁剪回显给客户端的 ``capability_overrides``，
-    保证"界面显示的覆盖"与"执行层实际采用的覆盖"不漂移——否则存量脏数据会被界面呈现为已生效，
-    而实际执行时静默忽略。不校验 endpoint / media_type 合法性，调用方已各自处理（见
-    :func:`system_video_capabilities` 与 ``_system_capabilities_for``）。
+    存量脏数据因此不会被界面呈现为已生效、而执行时静默忽略。回显侧在此之上再按开放白名单收窄
+    一道，故回显是执行层采用集合的子集：未开放维度的键只能由手工改库产生，界面既无入口呈现也
+    无入口删除，回显隐去它以保证 GET 与写入落库的键集合一致。不校验 endpoint / media_type
+    合法性，调用方已各自处理（见 :func:`system_video_capabilities` 与 ``_system_capabilities_for``）。
     """
     if overrides is None:
         return {}

--- a/lib/db/repositories/custom_provider_repo.py
+++ b/lib/db/repositories/custom_provider_repo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import NamedTuple
 
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, select
 
 from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
@@ -116,22 +116,6 @@ class CustomProviderRepository(BaseRepository):
             new_models.append(model)
         await self.session.flush()
         return new_models
-
-    async def update_model(self, model_id: int, **kwargs) -> CustomProviderModel | None:
-        """按主键原子更新模型字段，返回更新后的对象，行不存在（含更新前一刻被删除）时返回 None。
-
-        用 ``UPDATE ... WHERE id = :model_id RETURNING *`` 而非「先 SELECT 再 setattr」：
-        后者的 SELECT 与后续 flush 之间存在窗口，调用方按旧主键整表删除重建（同一业务 model_id
-        新行）可在此间隙发生而不被发现。原子语句把「行是否还在」与「更新」并成一步，无中间态。
-        """
-        stmt = (
-            update(CustomProviderModel)
-            .where(CustomProviderModel.id == model_id)
-            .values(**kwargs)
-            .returning(CustomProviderModel)
-        )
-        result = await self.session.execute(stmt)
-        return result.scalar_one_or_none()
 
     async def delete_model(self, model_id: int) -> None:
         """删除单个模型。"""

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -294,13 +294,18 @@ def _system_capabilities_for(endpoint: str, model_id: str) -> dict[str, object] 
 def _effective_overrides_for_response(
     endpoint: str, model_id: str, overrides: object | None
 ) -> dict[str, object] | None:
-    """回显前按写入侧同一判定过滤，剔除执行层不会采用的键值。
+    """回显前按写入侧同一判定过滤，剔除执行层不会采用的键值，并收窄至开放白名单。
 
     存量行 / 非 API 写入可能留下已不兼容的覆盖（如 endpoint 不再 end_image_capable 后的
     last_frame=True）：原样回显会让界面显示"覆盖已生效"，但执行层其实静默忽略；且客户端
     普通保存时把它原样回传，会被写入侧白名单拒为 422，堵住与该覆盖无关的编辑。
+
+    再按 ``CAPABILITY_OVERRIDE_ALLOWLIST`` 收窄：DB 遗留的白名单外键（同样只能来自手工改库）
+    在被保存剔除前会原样回显，与写入落库的键集合不一致，调用方需要额外知道"回显可能含脏键
+    但写回会被剔除"。这里与写入侧共用同一白名单常量，两处集合保持一致。
     """
     filtered = filter_valid_overrides(endpoint=endpoint, model_id=model_id, overrides=overrides)
+    filtered = {k: v for k, v in filtered.items() if k in CAPABILITY_OVERRIDE_ALLOWLIST}
     return filtered or None
 
 

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -68,6 +68,12 @@ if not CAPABILITY_OVERRIDE_ALLOWLIST <= CAPABILITY_OVERRIDE_FIELDS.keys():
         f"{sorted(CAPABILITY_OVERRIDE_ALLOWLIST - set(CAPABILITY_OVERRIDE_FIELDS))}"
     )
 
+
+def _narrow_to_allowlist(overrides: dict[str, object]) -> dict[str, object]:
+    """收窄至开放白名单。写入侧与回显侧共用，两处键集合同源而非各自推导后靠注释约定一致。"""
+    return {k: v for k, v in overrides.items() if k in CAPABILITY_OVERRIDE_ALLOWLIST}
+
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/custom-providers", tags=["Custom Providers"])
@@ -131,7 +137,7 @@ class ModelInput(BaseModel):
         """
         if not value:
             return None
-        kept = {k: v for k, v in value.items() if k in CAPABILITY_OVERRIDE_ALLOWLIST}
+        kept = _narrow_to_allowlist(value)
         if dropped := sorted(value.keys() - kept.keys()):
             logger.warning("能力覆盖含未开放键，保存时已剔除: %s", ", ".join(dropped))
         return kept or None
@@ -300,12 +306,11 @@ def _effective_overrides_for_response(
     last_frame=True）：原样回显会让界面显示"覆盖已生效"，但执行层其实静默忽略；且客户端
     普通保存时把它原样回传，会被写入侧白名单拒为 422，堵住与该覆盖无关的编辑。
 
-    再按 ``CAPABILITY_OVERRIDE_ALLOWLIST`` 收窄：DB 遗留的白名单外键（同样只能来自手工改库）
-    在被保存剔除前会原样回显，与写入落库的键集合不一致，调用方需要额外知道"回显可能含脏键
-    但写回会被剔除"。这里与写入侧共用同一白名单常量，两处集合保持一致。
+    再经 :func:`_narrow_to_allowlist` 收窄：DB 遗留的白名单外键（同样只能来自手工改库）若原样
+    回显，与写入落库的键集合不一致，调用方需要额外知道"回显可能含脏键但写回会被剔除"。收窄与
+    写入侧走同一个函数，两处集合同源。
     """
-    filtered = filter_valid_overrides(endpoint=endpoint, model_id=model_id, overrides=overrides)
-    filtered = {k: v for k, v in filtered.items() if k in CAPABILITY_OVERRIDE_ALLOWLIST}
+    filtered = _narrow_to_allowlist(filter_valid_overrides(endpoint=endpoint, model_id=model_id, overrides=overrides))
     return filtered or None
 
 

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -250,6 +250,49 @@ class TestModelListExposesCapabilities:
         assert resp.status_code == 200
         assert resp.json()["models"][0]["capability_overrides"] is None
 
+    @pytest.mark.integration
+    async def test_unallowlisted_key_dropped_from_response(self, client: TestClient, session_factory):
+        """DB 遗留的白名单外键（如 first_frame，语义合法但未开放给用户覆盖）不该在回显中
+        原样带出：否则界面呈现"覆盖已生效"，而写入侧一保存这条键就会被剔除——GET 与 PUT
+        的键集合必须一致，调用方不该额外知道"回显可能含脏键但写回会被剔除"这条隐藏知识。"""
+        pid = await _seed_provider_with_raw_models(
+            session_factory,
+            [
+                {
+                    "model_id": VIDEO_MODEL,
+                    "display_name": "Sora 2",
+                    "endpoint": VIDEO_ENDPOINT,
+                    "is_enabled": True,
+                    "is_default": True,
+                    "capability_overrides": {"first_frame": False},
+                }
+            ],
+        )
+
+        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        assert models[0]["capability_overrides"] is None
+
+    @pytest.mark.integration
+    async def test_allowlisted_key_kept_when_mixed_with_unallowlisted(self, client: TestClient, session_factory):
+        """混合了白名单内外键的存量行：白名单内键（last_frame）回显不变，白名单外键
+        （first_frame）被剔除，回显集合与写入落库集合一致。"""
+        pid = await _seed_provider_with_raw_models(
+            session_factory,
+            [
+                {
+                    "model_id": LAST_FRAME_MODEL,
+                    "display_name": "Seedance",
+                    "endpoint": LAST_FRAME_ENDPOINT,
+                    "is_enabled": True,
+                    "is_default": True,
+                    "capability_overrides": {"last_frame": True, "first_frame": False},
+                }
+            ],
+        )
+
+        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        assert models[0]["capability_overrides"] == {"last_frame": True}
+
 
 class TestSaveDropsUnlistedOverrides:
     """白名单外的键随保存被静默剔除——这是它们唯一的出口。

--- a/tests/test_custom_provider_repo.py
+++ b/tests/test_custom_provider_repo.py
@@ -301,43 +301,6 @@ class TestModelManagement:
 
         assert await repo.list_models(p.id) == []
 
-    async def test_update_model(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
-        p = await repo.create_provider(
-            display_name="TestProvider",
-            discovery_format="openai",
-            base_url="https://example.com",
-            api_key="key",
-            models=[
-                {
-                    "model_id": "gpt-4o",
-                    "display_name": "GPT-4o",
-                    "endpoint": "openai-chat",
-                    "price_unit": "token",
-                    "price_input": 0.01,
-                    "price_output": 0.03,
-                    "currency": "USD",
-                },
-            ],
-        )
-        await session.flush()
-
-        models = await repo.list_models(p.id)
-        model = models[0]
-
-        await repo.update_model(model.id, price_input=0.005, price_output=0.015)
-        await session.flush()
-
-        updated_models = await repo.list_models(p.id)
-        assert updated_models[0].price_input == 0.005
-        assert updated_models[0].price_output == 0.015
-        assert updated_models[0].display_name == "GPT-4o"  # unchanged
-
-    async def test_update_model_nonexistent(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
-        result = await repo.update_model(999, display_name="Nope")
-        assert result is None
-
     async def test_delete_model(self, session: AsyncSession):
         repo = CustomProviderRepository(session)
         p = await repo.create_provider(


### PR DESCRIPTION
Closes #1393

## 改动

覆盖写入机制收敛删除单模型 PATCH 端点后遗留的两处残余：

1. **`CustomProviderRepository.update_model` 死码清理** — 该方法的并发谓词已随 PATCH 端点删除，此后无生产调用方，仅剩 repo 层单测在调用。删除方法本体、两条对应单测，以及因此变得多余的 `update` 导入。
2. **回显收窄至开放白名单** — `_effective_overrides_for_response` 此前只走 `filter_valid_overrides`，不按开放白名单过滤。DB 遗留的白名单外键在被保存剔除前会原样回显一轮，GET 与 PUT 的键集合不一致，调用方需额外知道「回显可能含脏键但写回会被剔除」这条隐藏知识。现在回显与写入落库的键集合一致。

白名单收窄抽为 `_narrow_to_allowlist`，写入侧与回显侧共用，键集合同源由代码保证而非靠注释互相承诺。`filter_valid_overrides` 的 docstring 原先声明回显与执行层共用同一过滤、两者不漂移；回显侧收窄后回显是执行层采用集合的子集，文档同步为实际语义。

## 验证

三条验收标准逐条核验：

1. **全仓无 `update_model` 引用** — `lib/` `server/` `tests/` `frontend/` 全量 grep 为空（`docs/superpowers/` 下历史设计文档的归档记录保留）。
2. **白名单外键不再回显** — 新增两条 integration 测试：纯白名单外键（`first_frame`）回显收敛为 `None`；白名单内外混合时白名单内键（`last_frame`）回显不变、外键被剔除。两条测试做过证伪验证——还原生产代码到 main 后均失败，失败原因正是 `first_frame` 被原样带出，确认非恒真断言。
3. **写入侧行为不变** — 剔除 + `logger.warning` 语义未变，既有 `TestSaveDropsUnlistedOverrides` 套件覆盖。

质量门：`ruff check` / `ruff format --check` 通过，`basedpyright` 0 errors，`pytest` 全量 6551 passed。已 rebase 至最新 main（无冲突）后重跑上述全部检查。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复能力覆盖项回显问题：仅展示允许的配置项，自动过滤无效或历史遗留字段。
  * 当覆盖数据全部无效时，接口将返回空值，避免界面误显示为已生效。
  * 统一配置写入与接口回显的允许字段范围。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->