### PR TITLE
fix(tasks): 任务失败原因按界面语言显示，不再固定中文

### DIFF
--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -24,26 +24,27 @@ logger = logging.getLogger(__name__)
 
 ACTIVE_TASK_STATUSES = ("queued", "running", "cancelling")
 
-# _mark_failed_queued_dep 落库时按此长度截断 error_message；级联编码若超过此长度会被
-# 切断结尾的 `}`，使 render_failure 无法解析为合法 JSON。_encode_bounded_cascade_failure
-# 在编码前先按预算裁剪 reason，保证结果本身不需要再被截断，深层依赖链也不会近指数增长。
-_CASCADE_MESSAGE_LIMIT = 2000
+# 落库 error_message 的长度上限。裸切片会把结构化原因切在 JSON 中途，使 render_failure
+# 无法解析、用户看到机器码碎片而非本地化文案，因此两条落库路径都经 bound_reason 收窄。
+# 级联编码另在编码前按预算裁剪 reason（_encode_bounded_cascade_failure），保证结果本身
+# 不需要再被截断，深层依赖链也不会近指数增长。
+_MAX_ERROR_MESSAGE_LEN = 2000
 
 
 def _encode_bounded_cascade_failure(*, dependency_task_id: str, reason: str) -> str:
     encoded = encode_failure("cascade_blocked_dependency", dependency_task_id=dependency_task_id, reason=reason)
-    if len(encoded) <= _CASCADE_MESSAGE_LIMIT:
+    if len(encoded) <= _MAX_ERROR_MESSAGE_LEN:
         return encoded
 
     overhead = len(encode_failure("cascade_blocked_dependency", dependency_task_id=dependency_task_id, reason=""))
-    budget = max(_CASCADE_MESSAGE_LIMIT - overhead, 0)
+    budget = max(_MAX_ERROR_MESSAGE_LEN - overhead, 0)
     # JSON 转义（reason 中的引号/反斜杠）会让 budget 字符的 reason 编码后略超预算；始终经
     # bound_reason 收窄以保持结构化 reason 合法，不对已裁剪结果做原始字符再截断（那会切断
-    # JSON 尾部）。极少数迭代仍超限时接受结果略超 _CASCADE_MESSAGE_LIMIT，好过写坏 JSON。
+    # JSON 尾部）。极少数迭代仍超限时接受结果略超 _MAX_ERROR_MESSAGE_LEN，好过写坏 JSON。
     for _ in range(5):
         reason = bound_reason(reason, budget)
         encoded = encode_failure("cascade_blocked_dependency", dependency_task_id=dependency_task_id, reason=reason)
-        overflow = len(encoded) - _CASCADE_MESSAGE_LIMIT
+        overflow = len(encoded) - _MAX_ERROR_MESSAGE_LEN
         if overflow <= 0 or budget <= 0:
             break
         budget = max(budget - overflow, 0)
@@ -375,7 +376,7 @@ class TaskRepository(BaseRepository):
             .where(Task.task_id == task_id, Task.status == "running")
             .values(
                 status="failed",
-                error_message=error_message[:2000],
+                error_message=bound_reason(error_message, _MAX_ERROR_MESSAGE_LEN),
                 finished_at=now,
                 updated_at=now,
             )
@@ -405,7 +406,7 @@ class TaskRepository(BaseRepository):
             .where(Task.task_id == task_id, Task.status == "queued")
             .values(
                 status="failed",
-                error_message=error_message[:2000],
+                error_message=bound_reason(error_message, _MAX_ERROR_MESSAGE_LEN),
                 finished_at=now,
                 updated_at=now,
             )

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from lib.db.base import DEFAULT_USER_ID, dt_to_iso, utc_now
 from lib.db.models.task import Task, TaskEvent, WorkerLease
 from lib.db.repositories.base import BaseRepository, rowcount
-from lib.task_failure import bound_reason, encode_failure
+from lib.task_failure import bound_reason, collapse_cascade_reason, encode_failure
 from lib.task_terminal_events import TERMINAL_TASK_STATUSES
 
 logger = logging.getLogger(__name__)
@@ -32,6 +32,9 @@ _MAX_ERROR_MESSAGE_LEN = 2000
 
 
 def _encode_bounded_cascade_failure(*, dependency_task_id: str, reason: str) -> str:
+    # 上游原因本身是级联串时先折叠到根本原因：逐层包裹近指数增长，深链上裁剪只能把内层信封
+    # 切在 JSON 中途，读侧会把残缺内层当普通文本嵌进本地化文案。折叠后串长与链深无关。
+    reason = collapse_cascade_reason(reason)
     encoded = encode_failure("cascade_blocked_dependency", dependency_task_id=dependency_task_id, reason=reason)
     if len(encoded) <= _MAX_ERROR_MESSAGE_LEN:
         return encoded

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -34,8 +34,11 @@ from lib.generation_queue import (
     GenerationQueue,
     get_generation_queue,
 )
+from lib.image_backends.base import ImageCapabilityError
+from lib.reference_compression import ReferencePayloadFloorError
 from lib.script_editor import ScriptEditError
 from lib.task_failure import encode_failure
+from lib.video_backends.base import VideoCapabilityError
 
 # Default provider used when a task payload does not specify one.
 DEFAULT_PROVIDER = "gemini-aistudio"
@@ -69,25 +72,40 @@ def _read_int_env(name: str, default: int, minimum: int = 1) -> int:
 
 
 def _encode_task_failure_message(exc: Exception) -> str:
-    """把任务执行异常编码为落库的 error_message：ScriptEditError 走 key/params 结构化，
-    其余异常沿用 str(exc)。normal（_process_task）与 resume（_process_resume_task）两条
-    独立的任务执行路径都会捕获 ScriptEditError（前者经常规 finalize，后者经
-    resume_executor 复用同一批 finalize helper），共用这份编码逻辑避免同一处理漂移成两份。
+    """把任务执行异常编码为落库的 error_message：ScriptEditError 与后端能力类异常走
+    code/params 结构化，其余异常沿用 str(exc)。normal（_process_task）与 resume
+    （_process_resume_task）两条独立的任务执行路径都会捕获这些异常（前者经常规 finalize，
+    后者经 resume_executor 复用同一批 finalize helper），共用这份编码逻辑避免同一处理漂移成两份。
+
+    落库只存机器码，本地化文案由读侧按 ``Accept-Language`` 渲染——worker 后台无 request
+    上下文，在这里渲染会把任务的失败原因锁死成单一语言。
     """
-    if not isinstance(exc, ScriptEditError):
-        return str(exc)
+    if isinstance(exc, ScriptEditError):
+        # 编不出来时退到通用 script_edit_error，保住"是剧本编辑失败"这一层信息。
+        return _try_encode_failure(exc.key, exc.params) or encode_failure("script_edit_error")
+    if isinstance(exc, ImageCapabilityError | VideoCapabilityError | ReferencePayloadFloorError):
+        # 能力类异常没有通用兜底 code 可退，退回 str(exc)（即 code 本身）——
+        # 非结构化文本在读侧原样透传，不会丢失原因。
+        return _try_encode_failure(exc.code, exc.params) or str(exc)
+    return str(exc)
+
+
+def _try_encode_failure(code: str, params: dict[str, Any]) -> str | None:
+    """结构化编码失败原因，编不出来返回 None 交调用方降级。
+
+    编码异常绝不能打断 mark_task_failed，否则任务会卡死在 running。
+    """
     try:
-        return encode_failure(exc.key, **exc.params)
+        return encode_failure(code, **params)
     except KeyError:
-        # exc.key 未登记进 FAILURE_CODE_KEYS——两个列表靠约定同步而非运行时校验，脱节时
-        # 降级到通用 key 而非让编码异常打断 mark_task_failed，否则任务会卡死在 running。
-        logger.warning("ScriptEditError key 未登记进 FAILURE_CODE_KEYS，降级为通用失败原因: key=%s", exc.key)
-        return encode_failure("script_edit_error")
-    except (TypeError, ValueError):
-        # params 不可 JSON 序列化（TypeError：非基础类型；ValueError：json.dumps 默认
-        # check_circular 检出循环引用），同样降级而不是让编码异常打断落库。
-        logger.warning("ScriptEditError params 无法序列化，降级为通用失败原因: key=%s", exc.key)
-        return encode_failure("script_edit_error")
+        # code 未登记进 FAILURE_CODE_KEYS——两份清单靠约定同步而非运行时校验。
+        logger.warning("失败 code 未登记进 FAILURE_CODE_KEYS，降级为通用失败原因: code=%s", code)
+    except (TypeError, ValueError, RecursionError):
+        # params 无法 JSON 序列化（TypeError：default=str 也转不了的键类型；
+        # ValueError：json.dumps 默认 check_circular 检出循环引用；
+        # RecursionError：嵌套过深的容器，default=str 不接管容器本身）。
+        logger.warning("失败 params 无法序列化，降级为通用失败原因: code=%s", code)
+    return None
 
 
 def _parse_lane_max(config: dict[str, str], key: str, default: int, provider_id: str) -> int:

--- a/lib/image_backends/base.py
+++ b/lib/image_backends/base.py
@@ -122,7 +122,8 @@ class ImageCapabilityError(RuntimeError):
     """图像后端能力不匹配（endpoint mismatch / generator gating 共用）。
 
     不携带本地化字符串，只带稳定 code + 上下文 params；
-    路由层捕获后用 _t(code, **params) 渲染。
+    路由层直接 _t(code, **params) 渲染，Worker 则按 code + params 落 task.error_message，
+    文案留到读侧按 Accept-Language 渲染。
     """
 
     def __init__(self, code: str, **params) -> None:

--- a/lib/task_failure.py
+++ b/lib/task_failure.py
@@ -106,13 +106,18 @@ def encode_failure(code: str, /, **params: Any) -> str:
 
 
 def _as_shrinkable(value: Any) -> Any:
-    """把非字符串参数值换成自身的 JSON 文本，好让裁剪逻辑能收窄它。
+    """把容器参数值换成自身的 JSON 文本，好让裁剪逻辑能收窄它。
 
     截断一个容器的字符串形态比截断 JSON 字面量安全——后者会留下不闭合的括号。嵌套过深到
     ``json.dumps`` 撞递归上限的值降级为省略号：裁剪发生在落库路径上，抛出去会让任务卡在
     running。
+
+    只动容器：``int`` / ``float`` / ``bool`` / ``None`` 本就是 JSON 原生标量，撑不爆预算也
+    无从收窄，转成文本反而会在重新编码时被加上引号存回去（``42`` 变 ``"42"``、``True`` 变
+    ``"true"``、``None`` 变 ``"null"``），把落库信封里的参数类型改掉。而裁剪是整个 params
+    一起过一遍的，所以只要有任一参数触发裁剪，同条失败里全部标量都会跟着变形。
     """
-    if isinstance(value, str):
+    if not isinstance(value, dict | list):
         return value
     try:
         return json.dumps(value, ensure_ascii=False, default=str)

--- a/lib/task_failure.py
+++ b/lib/task_failure.py
@@ -102,6 +102,21 @@ def encode_failure(code: str, /, **params: Any) -> str:
     return f"[{code}]"
 
 
+def _as_shrinkable(value: Any) -> Any:
+    """把非字符串参数值换成自身的 JSON 文本，好让裁剪逻辑能收窄它。
+
+    截断一个容器的字符串形态比截断 JSON 字面量安全——后者会留下不闭合的括号。嵌套过深到
+    ``json.dumps`` 撞递归上限的值降级为省略号：裁剪发生在落库路径上，抛出去会让任务卡在
+    running。
+    """
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, default=str)
+    except RecursionError:
+        return "…"
+
+
 def bound_reason(reason: str, limit: int) -> str:
     """把 ``reason`` 裁剪到 ``limit`` 字符内，供级联失败编码前调用。
 
@@ -110,6 +125,11 @@ def bound_reason(reason: str, limit: int) -> str:
     的 ``detail`` 参数源自远端错误响应，可能长达上千字符）。这里优先裁剪结构化串里最长的
     字符串参数，保持重新编码后仍是合法的 ``[code] {params}``；非结构化文本或裁剪后仍超限
     时退回按原始字符裁剪。
+
+    超长的非字符串参数先降级成自身的 JSON 文本再参与裁剪：容器值同样可能撑爆预算——
+    ``video_duration_invalid`` 回显的是调用方拒绝的原始配置值，导入或手工编辑的
+    ``project.json`` 能把它写成一个大数组——而 JSON 原生类型不经 ``default=str``，
+    没有字符串参数可收窄时就会退到裸切片，把信封切在 JSON 中途。
     """
     if len(reason) <= limit:
         return reason
@@ -128,7 +148,7 @@ def bound_reason(reason: str, limit: int) -> str:
         return reason[:limit]
     if not isinstance(parsed, dict):
         return reason[:limit]
-    params: dict[str, Any] = parsed
+    params: dict[str, Any] = {key: _as_shrinkable(value) for key, value in parsed.items()}
     string_keys = [k for k, v in params.items() if isinstance(v, str)]
     if not string_keys:
         return reason[:limit]

--- a/lib/task_failure.py
+++ b/lib/task_failure.py
@@ -130,6 +130,9 @@ def bound_reason(reason: str, limit: int) -> str:
     ``video_duration_invalid`` 回显的是调用方拒绝的原始配置值，导入或手工编辑的
     ``project.json`` 能把它写成一个大数组——而 JSON 原生类型不经 ``default=str``，
     没有字符串参数可收窄时就会退到裸切片，把信封切在 JSON 中途。
+
+    裁剪按重新编码后的实际长度迭代收敛，不用一次算准的差值：``"`` 与 ``\\`` 之类的字符经
+    JSON 转义后占两列，超额长度与原始字符数不等长，一次估算会把本可收窄的参数误判成砍不动。
     """
     if len(reason) <= limit:
         return reason
@@ -158,10 +161,17 @@ def bound_reason(reason: str, limit: int) -> str:
     encoded = encode_failure(code, **params)
     while len(encoded) > limit:
         longest_key = max(string_keys, key=lambda k: len(params[k]))
-        deficit = len(encoded) - limit
-        if len(params[longest_key]) <= deficit:
+        current: str = params[longest_key]
+        if not current:
+            # 字符串参数全被削空仍超限，说明预算连信封骨架都装不下，只能退回按字符裁剪。
             return reason[:limit]
-        params[longest_key] = params[longest_key][: len(params[longest_key]) - deficit]
+        # 超额长度以编码后的字符计，而原始字符经 JSON 转义可能占多列，两者不等长：拿它当
+        # 要砍的原始字符数只是个下界估算，砍完重编码再看，直到真正装下为止。估算超过参数
+        # 自身长度时改砍一半而非削空——转义参数的超额长度常大于原始长度，一次削空会把本
+        # 可保留的诊断内容全丢掉。至少砍一个字符保证收敛。
+        deficit = len(encoded) - limit
+        drop = deficit if deficit < len(current) else max(1, len(current) // 2)
+        params[longest_key] = current[: len(current) - drop]
         encoded = encode_failure(code, **params)
     return encoded
 

--- a/lib/task_failure.py
+++ b/lib/task_failure.py
@@ -18,9 +18,42 @@ import re
 from collections.abc import Callable
 from typing import Any
 
+# Backend capability rejections (``ImageCapabilityError`` / ``VideoCapabilityError`` /
+# ``ReferencePayloadFloorError``). Their ``.code`` is already an ``errors`` catalog key,
+# so the mapping below is identity — no prefix indirection. Enumerated rather than
+# derived so an unregistered code fails fast; ``tests/test_task_failure_capability.py``
+# AST-scans the raise sites and fails CI when a new code is added without registering it.
+CAPABILITY_FAILURE_CODES: frozenset[str] = frozenset(
+    {
+        "image_capability_missing_i2i",
+        "image_capability_missing_t2i",
+        "image_dashscope_4k_t2i_only",
+        "image_endpoint_mismatch_no_i2i",
+        "image_endpoint_mismatch_no_t2i",
+        "image_reference_images_unreadable",
+        "ref_payload_floor_exceeded",
+        "video_capability_missing_t2v",
+        "video_duration_invalid",
+        "video_duration_not_supported",
+        "video_end_image_requires_start_image",
+        "video_end_image_unreadable",
+        "video_last_frame_requires_pro",
+        "video_last_frame_unsupported",
+        "video_reference_images_duration_unsupported",
+        "video_reference_images_exceeded",
+        "video_reference_images_required",
+        "video_reference_images_unreadable",
+        "video_reference_images_unsupported",
+        "video_reference_images_with_frames_unsupported",
+        "video_resolution_duration_unsupported",
+        "video_start_image_unreadable",
+    }
+)
+
 # Stable failure code -> i18n errors key. The code is agent-facing and persisted
 # in the DB; the key resolves to zh/en/vi templates rendered at read time.
 FAILURE_CODE_KEYS: dict[str, str] = {
+    **{code: code for code in CAPABILITY_FAILURE_CODES},
     "provider_unsupported_media": "task_fail_provider_unsupported_media",
     "restart_lost_image": "task_fail_restart_lost_image",
     "restart_lost_audio": "task_fail_restart_lost_audio",
@@ -46,6 +79,8 @@ FAILURE_CODE_KEYS: dict[str, str] = {
 # group matching even if a param value contains an escaped newline.
 _STRUCTURED_RE = re.compile(r"^\[(\w+)\](?:[ ](\{.*\}))?$", re.DOTALL)
 
+_CASCADE_CODE = "cascade_blocked_dependency"
+
 
 def encode_failure(code: str, /, **params: Any) -> str:
     """Encode a known failure code (+ params) into the stored machine string.
@@ -54,11 +89,16 @@ def encode_failure(code: str, /, **params: Any) -> str:
     Raises ``KeyError`` for codes not declared in :data:`FAILURE_CODE_KEYS`, so a
     typo fails fast at the call site instead of silently storing an unrenderable
     reason.
+
+    Param values are stringified when not JSON-native (``default=str``): capability
+    codes carry whatever the caller rejected — e.g. ``video_duration_invalid`` echoes
+    the raw payload value — and a failed task must still record a reason rather than
+    have encoding raise inside the failure path.
     """
     if code not in FAILURE_CODE_KEYS:
         raise KeyError(f"unknown failure code: {code!r}")
     if params:
-        return f"[{code}] {json.dumps(params, ensure_ascii=False, sort_keys=True)}"
+        return f"[{code}] {json.dumps(params, ensure_ascii=False, sort_keys=True, default=str)}"
     return f"[{code}]"
 
 
@@ -107,31 +147,45 @@ def bound_reason(reason: str, limit: int) -> str:
 def render_failure(error_message: str | None, translate: Callable[..., str]) -> str | None:
     """Render a stored failure reason for display via the request Translator.
 
-    Recognised ``[code]`` / ``[code] {params}`` strings render to localized text;
-    everything else (raw exception text, legacy rows, malformed payloads) passes
-    through unchanged.
+    Recognised ``[code]`` / ``[code] {params}`` strings render to localized text; cascade
+    reasons nest the upstream reason in their ``reason`` param and are expanded
+    recursively, so it is localized too. Everything else (raw exception text, legacy rows,
+    malformed payloads) passes through unchanged.
+
+    Cascade nesting is self-limiting: each layer re-encodes the previous envelope into JSON,
+    so escaping makes the string grow super-linearly and the write side caps it well before
+    the depth could threaten the recursion limit.
     """
     if not error_message:
         return error_message
-    match = _STRUCTURED_RE.match(error_message)
-    if match is None:
+    parsed = _parse_structured(error_message)
+    if parsed is None:
         return error_message
-    code = match.group(1)
-    key = FAILURE_CODE_KEYS.get(code)
-    if key is None:
-        return error_message
-    raw_params = match.group(2)
-    params: dict[str, Any] = {}
-    if raw_params:
-        try:
-            parsed = json.loads(raw_params)
-        except ValueError:
-            return error_message
-        if not isinstance(parsed, dict):
-            return error_message
-        params = parsed
-    if code == "cascade_blocked_dependency":
+    code, params = parsed
+    if code == _CASCADE_CODE:
         nested_reason = params.get("reason")
         if isinstance(nested_reason, str):
             params = {**params, "reason": render_failure(nested_reason, translate)}
-    return translate(key, **params)
+    return translate(FAILURE_CODE_KEYS[code], **params)
+
+
+def _parse_structured(error_message: str) -> tuple[str, dict[str, Any]] | None:
+    """把 ``[code] {params}`` 拆成 (code, params)，识别不了或 params 畸形时返回 ``None``。"""
+    match = _STRUCTURED_RE.match(error_message)
+    if match is None:
+        return None
+    code = match.group(1)
+    if code not in FAILURE_CODE_KEYS:
+        return None
+    raw_params = match.group(2)
+    if not raw_params:
+        return code, {}
+    try:
+        parsed = json.loads(raw_params)
+    except (ValueError, RecursionError):
+        # 畸形 JSON，以及嵌套过深到 ``json.loads`` 自身撞递归上限的 payload。渲染发生在
+        # HTTP 请求内，异常逸出就是 500，因此一并按无法识别处理：调用方原样透传，原因不丢。
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return code, parsed

--- a/lib/task_failure.py
+++ b/lib/task_failure.py
@@ -81,6 +81,9 @@ _STRUCTURED_RE = re.compile(r"^\[(\w+)\](?:[ ](\{.*\}))?$", re.DOTALL)
 
 _CASCADE_CODE = "cascade_blocked_dependency"
 
+# collapse_cascade_reason 的解包上限，纯粹的空转防线。
+_MAX_CASCADE_UNWRAP = 100
+
 
 def encode_failure(code: str, /, **params: Any) -> str:
     """Encode a known failure code (+ params) into the stored machine string.
@@ -115,6 +118,32 @@ def _as_shrinkable(value: Any) -> Any:
         return json.dumps(value, ensure_ascii=False, default=str)
     except RecursionError:
         return "…"
+
+
+def collapse_cascade_reason(reason: str) -> str:
+    """把嵌套的级联原因折叠成最内层的根本原因，供级联编码前调用。
+
+    逐层包裹会让串近指数增长：每一层都把上一层的整个信封重新编码进 JSON，转义使长度翻倍，
+    七层左右就会撑破落库预算，裁剪只能从尾部切字符，把内层信封切在 JSON 中途——外层仍可解析，
+    读侧却把残缺的内层当普通文本原样嵌进本地化文案里。
+
+    中间层携带的只是「另一个同样被阻塞的任务 id」，用户能据以行动的是直接依赖与根本原因两项，
+    前者由外层自己的 ``dependency_task_id`` 保留。折叠后串长与依赖链深度无关。
+    """
+    seen = 0
+    while True:
+        parsed = _parse_structured(reason)
+        if parsed is None or parsed[0] != _CASCADE_CODE:
+            return reason
+        nested = parsed[1].get("reason")
+        if not isinstance(nested, str):
+            return reason
+        reason = nested
+        seen += 1
+        if seen > _MAX_CASCADE_UNWRAP:
+            # 正常链路远达不到这个深度（撑破预算前就折叠掉了）。真撞上说明遇到了畸形或人造
+            # 的深层串，就地收手：返回当前层，不在落库路径上空转。
+            return reason
 
 
 def bound_reason(reason: str, limit: int) -> str:

--- a/lib/task_failure.py
+++ b/lib/task_failure.py
@@ -144,7 +144,9 @@ def bound_reason(reason: str, limit: int) -> str:
         return reason[:limit]
     try:
         parsed = json.loads(raw_params)
-    except ValueError:
+    except (ValueError, RecursionError):
+        # 畸形 JSON，以及嵌套过深到 ``json.loads`` 自身撞递归上限的 params。裁剪发生在落库
+        # 路径上，异常逸出会让任务卡在 running，因此一并按不可解析处理，退回按字符裁剪。
         return reason[:limit]
     if not isinstance(parsed, dict):
         return reason[:limit]

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -366,7 +366,8 @@ class VideoCapabilityError(RuntimeError):
     """视频后端能力不匹配（如 duration ↔ supported_durations）。
 
     与 ImageCapabilityError 对称：不携带本地化字符串，只带稳定 code + 上下文 params；
-    Worker 捕获后用 i18n_translate(code, **params) 渲染到 task.error_message。
+    路由层直接 _t(code, **params) 渲染，Worker 则按 code + params 落 task.error_message，
+    文案留到读侧按 Accept-Language 渲染。
     """
 
     def __init__(self, code: str, **params) -> None:

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -189,7 +189,9 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
 
         allowed_durations = _RESOLUTION_DURATIONS.get(resolution, set())
         if duration not in allowed_durations:
-            supported = ", ".join(f"{d}s" for d in sorted(allowed_durations)) or "无"
+            # 空集合（分辨率未知）用语言中性占位符：这个值会原样进 en/vi 文案，
+            # 中文兜底会在非中文界面里露出中文。
+            supported = ", ".join(f"{d}s" for d in sorted(allowed_durations)) or "-"
             raise VideoCapabilityError(
                 "video_resolution_duration_unsupported",
                 model=self._model,

--- a/server/routers/tasks.py
+++ b/server/routers/tasks.py
@@ -102,12 +102,16 @@ async def cancel_preview(task_id: str, _user: CurrentUser):
 
 
 @router.post("/tasks/{task_id}/cancel")
-async def cancel_task(task_id: str, _user: CurrentUser):
+async def cancel_task(task_id: str, _user: CurrentUser, _t: Translator):
     queue = get_task_queue()
     try:
         result = await queue.cancel_task(task_id)
     except ValueError as e:
         raise BadRequestError("task_not_found", id=task_id) from e
+    # 终态任务（含已失败的）原样回给调用方，其 error_message 与列表/详情/SSE 同源，
+    # 不本地化就会在这一个出口泄露裸 [code] {params}。
+    for key in ("cancelled", "skipped_terminal"):
+        result[key] = [_localize_task(task, _t) for task in result.get(key, [])]
     return result
 
 

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -13,9 +13,6 @@ from typing import Any
 from lib.asset_types import ASSET_SPECS
 from lib.config.registry import PROVIDER_REGISTRY, model_info_for
 from lib.db.base import DEFAULT_USER_ID
-from lib.i18n import DEFAULT_LOCALE
-from lib.i18n import _ as i18n_translate
-from lib.image_backends.base import ImageCapabilityError
 from lib.path_safety import safe_exists, safe_join, try_safe_join
 from lib.project_change_hints import emit_project_change_batch, project_change_source
 from lib.project_manager import get_project_manager
@@ -33,7 +30,6 @@ from lib.prompt_utils import (
     utterances_to_dialogue,
     video_prompt_to_yaml,
 )
-from lib.reference_compression import ReferencePayloadFloorError
 from lib.resource_paths import END_FRAME_RESOURCE_TYPE, resource_relative_path
 from lib.script_skeleton import SKELETON_ENTITY_TYPES, SKELETON_ITEM_NOUNS, resolve_script_kind
 from lib.storyboard_sequence import (
@@ -194,7 +190,7 @@ def assert_duration_supported(duration: int | float | str, supported_durations: 
     视为非法而**拒绝**，不做截断式归一化（截断会把本应拒绝的非法值静默修正）。
 
     校验失败抛 :class:`VideoCapabilityError`（带稳定 code），与 ImageCapabilityError 对称——
-    Worker 捕获后渲染为本地化的 task.error_message。
+    Worker 按 code + params 落 task.error_message，文案由读侧 Translator 渲染。
     """
     if not supported_durations:
         return
@@ -1539,14 +1535,10 @@ async def execute_generation_task(task: dict[str, Any]) -> dict[str, Any]:
         raise ValueError(f"unsupported task_type: {task_type}")
 
     with project_change_source("worker"):
-        try:
-            result = await executor(project_name, resource_id, payload, user_id=user_id, task_id=queue_task_id)
-        except (ImageCapabilityError, VideoCapabilityError, ReferencePayloadFloorError) as err:
-            # Worker 后台无 request 上下文，按 DEFAULT_LOCALE 渲染稳定的 i18n 文案
-            # 落到 task.error_message，前端轮询时即可看到本地化提示。
-            # ReferencePayloadFloorError 对普通图/视频与 R2V 都经此渲染（R2V 走同一 dispatch catch）。
-            message = i18n_translate(err.code, locale=DEFAULT_LOCALE, **err.params)
-            raise RuntimeError(message) from err
+        # 能力类异常（Image/VideoCapabilityError、ReferencePayloadFloorError）原样上抛：
+        # worker 的 _encode_task_failure_message 按 code + params 落库，渲染留到读侧
+        # Translator，同一失败任务按 Accept-Language 显示 zh/en/vi。
+        result = await executor(project_name, resource_id, payload, user_id=user_id, task_id=queue_task_id)
         emit_generation_success_batch(
             task_type=task_type,
             project_name=project_name,

--- a/tests/test_generation_tasks_dispatch.py
+++ b/tests/test_generation_tasks_dispatch.py
@@ -35,6 +35,7 @@ async def test_execute_generation_task_rejects_unknown_type():
         )
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "error",

--- a/tests/test_generation_tasks_dispatch.py
+++ b/tests/test_generation_tasks_dispatch.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import pytest
 
 from lib.image_backends.base import ImageCapabilityError
+from lib.reference_compression import ReferencePayloadFloorError
+from lib.video_backends.base import VideoCapabilityError
 from server.services.generation_tasks import _SKELETON_DRIVEN_TASK_ACTIONS, _TASK_EXECUTORS
 
 
@@ -34,15 +36,29 @@ async def test_execute_generation_task_rejects_unknown_type():
 
 
 @pytest.mark.asyncio
-async def test_execute_generation_task_translates_image_endpoint_mismatch(monkeypatch):
+@pytest.mark.parametrize(
+    "error",
+    [
+        ImageCapabilityError("image_endpoint_mismatch_no_t2i", model="gpt-image-1"),
+        ImageCapabilityError("image_capability_missing_i2i", provider="openai", model="gpt-image-1"),
+        VideoCapabilityError("video_duration_not_supported", duration=7, supported="5, 10"),
+        ReferencePayloadFloorError(),
+    ],
+)
+async def test_execute_generation_task_propagates_capability_errors_unrendered(monkeypatch, error):
+    """能力类异常原样上抛，dispatch 层不做本地化——渲染留到读侧 Translator。
+
+    此前这里按 DEFAULT_LOCALE 烘焙成中文再包 RuntimeError，导致 en/vi 用户在任务
+    列表看到中文失败原因。
+    """
     from server.services.generation_tasks import execute_generation_task
 
     async def fake_executor(*_args, **_kwargs):
-        raise ImageCapabilityError("image_endpoint_mismatch_no_t2i", model="gpt-image-1")
+        raise error
 
     monkeypatch.setitem(_TASK_EXECUTORS, "storyboard", fake_executor)
 
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(type(error)) as exc_info:
         await execute_generation_task(
             {
                 "task_type": "storyboard",
@@ -52,41 +68,13 @@ async def test_execute_generation_task_translates_image_endpoint_mismatch(monkey
             }
         )
 
-    message = str(exc_info.value)
-    # 必须是已翻译的 zh 文案，而不是裸 code
-    assert "image_endpoint_mismatch_no_t2i" not in message
-    assert "gpt-image-1" in message
-    assert "图生图" in message  # zh 文案关键字
-
-
-@pytest.mark.asyncio
-async def test_execute_generation_task_translates_capability_missing_i2i(monkeypatch):
-    from server.services.generation_tasks import execute_generation_task
-
-    async def fake_executor(*_args, **_kwargs):
-        raise ImageCapabilityError("image_capability_missing_i2i", provider="openai", model="gpt-image-1")
-
-    monkeypatch.setitem(_TASK_EXECUTORS, "storyboard", fake_executor)
-
-    with pytest.raises(RuntimeError) as exc_info:
-        await execute_generation_task(
-            {
-                "task_type": "storyboard",
-                "project_name": "demo",
-                "resource_id": "scene-1",
-                "payload": {},
-            }
-        )
-
-    message = str(exc_info.value)
-    assert "image_capability_missing_i2i" not in message
-    assert "openai" in message
-    assert "gpt-image-1" in message
+    assert exc_info.value is error
+    assert exc_info.value.code == error.code
 
 
 @pytest.mark.asyncio
 async def test_execute_generation_task_propagates_other_exceptions(monkeypatch):
-    """非 ImageCapabilityError 的异常应原样冒泡，不被 i18n 分支吞掉"""
+    """非能力类异常同样原样冒泡"""
     from server.services.generation_tasks import execute_generation_task
 
     async def fake_executor(*_args, **_kwargs):

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -122,6 +122,8 @@ class TestPayloadAndCapabilityGating:
         with pytest.raises(VideoCapabilityError) as exc:
             _backend()._build_payload(_request(tmp_path, resolution="540p", duration_seconds=6))
         assert exc.value.code == "video_resolution_duration_unsupported"
+        # params 会原样进 en/vi 文案，空集合兜底必须语言中性，否则非中文界面里露出中文。
+        assert exc.value.params["supported"] == "-"
 
     def test_i2v_embeds_first_frame_data_uri(self, tmp_path):
         img = tmp_path / "first.png"

--- a/tests/test_task_cancel_router.py
+++ b/tests/test_task_cancel_router.py
@@ -6,9 +6,11 @@
   - POST /projects/{project_name}/tasks/cancel-all
 """
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from lib.i18n import MESSAGES
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import tasks as tasks_router
@@ -195,6 +197,26 @@ class TestCancelTask:
         assert resp.status_code == 200
         body = resp.json()
         assert body["skipped_terminal"][0]["task_id"] == "done-task"
+
+    @pytest.mark.unit
+    def test_skipped_terminal_failure_reason_renders_per_locale(self, monkeypatch):
+        """取消命中已失败任务时，响应里的失败原因与列表/详情/SSE 同口径按请求语言渲染。"""
+        stored = '[video_duration_not_supported] {"duration": 7, "supported": "5, 10"}'
+        result = {
+            "cancelled": [],
+            "cancelling": [],
+            "skipped_terminal": [{"task_id": "failed-task", "status": "failed", "error_message": stored}],
+        }
+        fake = _FakeQueue(cancel_task_result=result)
+        monkeypatch.setattr(tasks_router, "get_task_queue", lambda: fake)
+
+        app = _make_app()
+        with TestClient(app) as client:
+            resp = client.post("/api/v1/tasks/failed-task/cancel", headers={"Accept-Language": "en"})
+
+        assert resp.status_code == 200
+        expected = MESSAGES["en"]["video_duration_not_supported"].format(duration=7, supported="5, 10")
+        assert resp.json()["skipped_terminal"][0]["error_message"] == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_task_failure_capability.py
+++ b/tests/test_task_failure_capability.py
@@ -392,6 +392,27 @@ def test_bound_reason_shrinks_oversized_non_string_params():
     assert "video_duration_invalid" not in rendered
 
 
+def test_bound_reason_shrinks_escape_heavy_params():
+    """转义后翻倍的参数也要收窄成合法信封，而不是被判定「砍不动」退回裸切片。
+
+    超额长度以编码后的字符计，而 ``"`` / ``\\`` 经 JSON 转义占两列：拿它直接当要砍的原始
+    字符数比较，会把原始长度小于超额长度、但实际收窄后装得下的参数误判成无从收窄。
+    """
+    names = "\\" * 900
+    stored = encode_failure("image_reference_images_unreadable", names=names)
+    # 转义让编码长度约为原始长度的两倍——正是误判成立的前提。
+    assert len(stored) > 2 * len(names)
+
+    bounded = bound_reason(stored, 900)
+
+    assert len(bounded) <= 900
+    rendered = render_failure(bounded, _translator("en"))
+    assert rendered is not None
+    assert "image_reference_images_unreadable" not in rendered
+    # 预算够放下相当一部分参数时就不该削空——诊断内容是这条原因的全部价值。
+    assert len(json.loads(bounded.split(" ", 1)[1])["names"]) > 100
+
+
 def _oversized_envelope() -> str:
     """一个超出 2000 字符预算、且整体仍是合法 ``[code] {params}`` 的信封。
 

--- a/tests/test_task_failure_capability.py
+++ b/tests/test_task_failure_capability.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from lib import task_failure
+from lib.db.repositories.task_repo import _encode_bounded_cascade_failure
 from lib.generation_worker import _encode_task_failure_message
 from lib.i18n import MESSAGES
 from lib.i18n import _ as i18n_translate
@@ -25,6 +26,7 @@ from lib.task_failure import (
     CAPABILITY_FAILURE_CODES,
     FAILURE_CODE_KEYS,
     bound_reason,
+    collapse_cascade_reason,
     encode_failure,
     render_failure,
 )
@@ -444,6 +446,41 @@ def test_cascade_reason_renders_upstream_reason_per_locale():
         assert "5a38f38e" in text
         inner = MESSAGES[locale]["video_duration_not_supported"].format(duration=7, supported="5, 10")
         assert inner in text
+
+
+def test_deep_cascade_chain_keeps_root_cause_renderable():
+    """长依赖链上每层都要渲染成本地化文案，而不是嵌一段被切坏的内层信封。
+
+    逐层包裹近指数增长：每层把上一层整个信封重新编码进 JSON，转义使长度翻倍，七层左右撑破
+    落库预算，裁剪只能从尾部切字符，把内层切在 JSON 中途——外层仍可解析，读侧却把残缺内层
+    当普通文本原样嵌进本地化文案。编码前折叠掉中间层后，串长与链深无关。
+    """
+    upstream = _encode_task_failure_message(
+        VideoCapabilityError("video_duration_not_supported", duration=7, supported="5, 10")
+    )
+    inner = MESSAGES["zh"]["video_duration_not_supported"].format(duration=7, supported="5, 10")
+
+    stored = upstream
+    lengths = set()
+    for depth in range(1, 21):
+        stored = _encode_bounded_cascade_failure(dependency_task_id=f"{depth:032d}", reason=stored)
+        lengths.add(len(stored))
+        rendered = render_failure(stored, _translator("zh"))
+        assert rendered is not None
+        # 直接依赖与根本原因两项都在，且没有任何机器码碎片漏出。
+        assert f"{depth:032d}" in rendered
+        assert inner in rendered
+        assert "[cascade_blocked_dependency]" not in rendered
+        assert "video_duration_not_supported" not in rendered
+
+    assert len(lengths) == 1, f"折叠后串长应与链深无关，实际出现多种长度: {sorted(lengths)}"
+
+
+def test_collapse_cascade_reason_leaves_non_cascade_reason_untouched():
+    """非级联原因（含 provider 原始文本）不该被折叠动到。"""
+    upstream = _encode_task_failure_message(VideoCapabilityError("video_duration_invalid", duration="x"))
+    assert collapse_cascade_reason(upstream) == upstream
+    assert collapse_cascade_reason("provider rejected") == "provider rejected"
 
 
 def test_cascade_reason_with_unstructured_upstream_still_renders():

--- a/tests/test_task_failure_capability.py
+++ b/tests/test_task_failure_capability.py
@@ -392,9 +392,23 @@ def test_bound_reason_shrinks_oversized_non_string_params():
     assert "video_duration_invalid" not in rendered
 
 
-def test_bound_reason_degrades_when_param_json_hits_recursion_limit(monkeypatch):
-    """嵌套过深的参数量不出长度时降级为省略号，而不是把异常抛进落库路径。"""
-    stored = '[video_duration_invalid] {"duration": [[[1]]]}' + "x" * 3000
+def _oversized_envelope() -> str:
+    """一个超出 2000 字符预算、且整体仍是合法 ``[code] {params}`` 的信封。
+
+    超长部分必须落在 JSON 内部：拼在 ``}`` 之后的尾巴会让 ``_STRUCTURED_RE`` 失配，裁剪在
+    进入 ``json`` 之前就返回，测不到本节要测的降级路径。
+    """
+    stored = encode_failure("video_duration_invalid", duration="x" * 3000)
+    assert len(stored) > 2000
+    return stored
+
+
+def test_as_shrinkable_degrades_when_param_json_hits_recursion_limit(monkeypatch):
+    """嵌套过深的参数量不出长度时降级为省略号，而不是把异常抛进落库路径。
+
+    只断言 ``_as_shrinkable`` 本身：经它归一后 ``params`` 全是扁平字符串，``encode_failure``
+    的 ``dumps`` 已无从撞上限，再去断言 ``bound_reason`` 只能靠全局打桩造出不可达的场景。
+    """
 
     def _boom(*_args, **_kwargs):
         raise RecursionError("maximum recursion depth exceeded")
@@ -402,4 +416,15 @@ def test_bound_reason_degrades_when_param_json_hits_recursion_limit(monkeypatch)
     monkeypatch.setattr(task_failure.json, "dumps", _boom)
 
     assert task_failure._as_shrinkable([[[1]]]) == "…"
-    assert len(bound_reason(stored, 2000)) <= 2000
+
+
+def test_bound_reason_degrades_when_params_json_load_hits_recursion_limit(monkeypatch):
+    """params 深到 ``json.loads`` 自身撞递归上限时退回字符裁剪，而不是把异常抛进落库路径。"""
+    stored = _oversized_envelope()
+
+    def _boom(*_args, **_kwargs):
+        raise RecursionError("maximum recursion depth exceeded")
+
+    monkeypatch.setattr(task_failure.json, "loads", _boom)
+
+    assert bound_reason(stored, 2000) == stored[:2000]

--- a/tests/test_task_failure_capability.py
+++ b/tests/test_task_failure_capability.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import ast
 import json
+import string
 from collections import Counter
 from pathlib import Path
 
@@ -37,12 +38,38 @@ _SCANNED_ROOTS = ("lib", "server")
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def _exception_name(func: ast.expr) -> str | None:
-    """取构造表达式的类名，`VideoCapabilityError(...)` 与 `base.VideoCapabilityError(...)` 同看待。"""
+def _import_aliases(tree: ast.Module) -> dict[str, str]:
+    """收集本模块里能力异常的导入别名，映射到原类名。
+
+    ``from ... import VideoCapabilityError as VCE`` 后调用点只叫 ``VCE``，只比对当前名称
+    会让该构造点两道守卫都扫不到——未登记 code 由 ``_try_encode_failure()`` 降级为
+    ``str(exc)``，最终以裸机器码落到界面上。
+    """
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom | ast.Import):
+            continue
+        for alias in node.names:
+            original = alias.name.rsplit(".", 1)[-1]
+            if original in _CAPABILITY_EXCEPTIONS and alias.asname:
+                aliases[alias.asname] = original
+    return aliases
+
+
+def _exception_name(func: ast.expr, aliases: dict[str, str]) -> str | None:
+    """取构造表达式的类名。
+
+    `VideoCapabilityError(...)`、`base.VideoCapabilityError(...)` 与导入别名 `VCE(...)`
+    同看待——别名经 ``aliases`` 还原成原类名。
+    """
     if isinstance(func, ast.Name):
-        return func.id if func.id in _CAPABILITY_EXCEPTIONS else None
+        if func.id in _CAPABILITY_EXCEPTIONS:
+            return func.id
+        return aliases.get(func.id)
     if isinstance(func, ast.Attribute):
-        return func.attr if func.attr in _CAPABILITY_EXCEPTIONS else None
+        if func.attr in _CAPABILITY_EXCEPTIONS:
+            return func.attr
+        return aliases.get(func.attr)
     return None
 
 
@@ -98,7 +125,8 @@ def _scan_tree(tree: ast.Module, rel: str) -> tuple[dict[str, str], list[tuple[s
     codes: dict[str, str] = {}
     dynamic_sites: list[tuple[str, str]] = []
     calls = [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
-    constructions = [(node, name) for node in calls if (name := _exception_name(node.func)) is not None]
+    aliases = _import_aliases(tree)
+    constructions = [(node, name) for node in calls if (name := _exception_name(node.func, aliases)) is not None]
     if not constructions:
         return codes, dynamic_sites
 
@@ -221,6 +249,22 @@ def test_scanner_reads_code_from_keyword_form(source, expected_codes, expected_d
     assert len(dynamic) == expected_dynamic
 
 
+@pytest.mark.parametrize(
+    ("import_line", "call"),
+    [
+        ("from lib.video_backends.base import VideoCapabilityError as VCE", 'VCE("new_code")'),
+        ("import lib.video_backends.base as base", 'base.VideoCapabilityError("new_code")'),
+        ("from lib.reference_compression import ReferencePayloadFloorError as RPFE", 'RPFE(code="new_code")'),
+    ],
+)
+def test_scanner_resolves_import_aliases(import_line, call):
+    """经 ``as`` 改名导入的构造点照样扫得到，否则该点两道守卫一起失效。"""
+    codes, dynamic = _scan_tree(ast.parse(f"{import_line}\n{call}\n"), "synthetic.py")
+
+    assert sorted(codes) == ["new_code"]
+    assert dynamic == []
+
+
 def test_capability_codes_registered_no_drift():
     """新增 capability code 未登记时在 CI 失败，而不是等到线上落库时才 KeyError 降级。"""
     raised, _ = _scan_raised_codes()
@@ -244,6 +288,59 @@ def test_no_unscannable_capability_construction_sites():
     assert counted == Counter(_ALLOWED_DYNAMIC_SCOPES), (
         f"白名单 scope 的动态构造点数量与定额不符，新增的那个未自证 code 已登记: {counted}"
     )
+
+
+def _template_placeholders(template: str) -> set[str]:
+    """取模板里的具名占位符集合。"""
+    return {field for _, field, _, _ in string.Formatter().parse(template) if field}
+
+
+def _scan_param_contracts() -> list[tuple[str, str, set[str]]]:
+    """采集能静态看全的构造点：(出处, code, 该点显式传入的 param 名)。
+
+    只收 code 与 kwargs 都静态可见的直接构造点。带 ``**`` 解包的调用看不全实参，纳入会产生
+    假阳性；``error_code=`` 那类透传给 helper 的调用，params 由 helper 自己组装，也不在此列。
+    """
+    contracts: list[tuple[str, str, set[str]]] = []
+    for root in _SCANNED_ROOTS:
+        for path in sorted((_REPO_ROOT / root).rglob("*.py")):
+            rel = str(path.relative_to(_REPO_ROOT))
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            aliases = _import_aliases(tree)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call) or _exception_name(node.func, aliases) is None:
+                    continue
+                if any(keyword.arg is None for keyword in node.keywords):
+                    continue
+                code_expr = node.args[0] if node.args else _keyword_value(node, "code")
+                literals = _static_str_choices(code_expr) if code_expr is not None else None
+                if code_expr is None:
+                    literals = [ReferencePayloadFloorError().code]
+                if literals is None:
+                    continue
+                provided = {keyword.arg for keyword in node.keywords if keyword.arg and keyword.arg != "code"}
+                for literal in literals:
+                    contracts.append((f"{rel}:{node.lineno}", literal, provided))
+    return contracts
+
+
+def test_capability_construction_sites_supply_every_template_param():
+    """构造点必须给全三语模板所需的参数，否则用户会看到未替换的 ``{name}``。
+
+    ``lib/i18n/__init__.py::_`` 在 ``format`` 抛异常时吞掉异常、返回未格式化的模板，缺参数
+    不会响亮失败：读侧照常返回一段带花括号占位符的文案。code 已登记、三语模板齐全这两道守卫
+    都拦不住这种漏传，因为它们只看 key 存不存在。
+    """
+    missing: list[str] = []
+    for where, code, provided in _scan_param_contracts():
+        for locale in ("zh", "en", "vi"):
+            template = MESSAGES[locale].get(code)
+            if template is None:
+                continue  # 缺模板由 test_capability_code_has_all_three_locales 负责
+            absent = _template_placeholders(template) - provided
+            if absent:
+                missing.append(f"{where} ({code}, {locale}) 缺参数 {sorted(absent)}")
+    assert not missing, "以下构造点漏传模板参数，读侧会渲染出裸占位符:\n" + "\n".join(missing)
 
 
 @pytest.mark.parametrize("code", sorted(CAPABILITY_FAILURE_CODES))

--- a/tests/test_task_failure_capability.py
+++ b/tests/test_task_failure_capability.py
@@ -1,0 +1,360 @@
+"""能力类失败原因：落库存 code+params，读侧按语言渲染。
+
+守住两件事：
+1. `CAPABILITY_FAILURE_CODES` 覆盖代码里全部 capability-error raise 点（AST 扫描，防漂移）；
+2. 同一条落库 error_message 在 zh/en/vi 下渲染成各自语言。
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from lib import task_failure
+from lib.generation_worker import _encode_task_failure_message
+from lib.i18n import MESSAGES
+from lib.i18n import _ as i18n_translate
+from lib.image_backends.base import ImageCapabilityError
+from lib.reference_compression import ReferencePayloadFloorError
+from lib.task_failure import (
+    CAPABILITY_FAILURE_CODES,
+    FAILURE_CODE_KEYS,
+    encode_failure,
+    render_failure,
+)
+from lib.video_backends.base import VideoCapabilityError
+
+# AST 守卫扫的是真实源码树、渲染断言用的是真实 i18n 目录，不 mock 任何被测入口。
+pytestmark = pytest.mark.integration
+
+_CAPABILITY_EXCEPTIONS = {"ImageCapabilityError", "VideoCapabilityError", "ReferencePayloadFloorError"}
+_SCANNED_ROOTS = ("lib", "server")
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _exception_name(func: ast.expr) -> str | None:
+    """取构造表达式的类名，`VideoCapabilityError(...)` 与 `base.VideoCapabilityError(...)` 同看待。"""
+    if isinstance(func, ast.Name):
+        return func.id if func.id in _CAPABILITY_EXCEPTIONS else None
+    if isinstance(func, ast.Attribute):
+        return func.attr if func.attr in _CAPABILITY_EXCEPTIONS else None
+    return None
+
+
+def _enclosing_function(tree: ast.Module, lineno: int) -> str:
+    """取包住 ``lineno`` 的最内层函数名，不在函数体内时返回 ``<module>``。"""
+    innermost = "<module>"
+    best_start = -1
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        end = node.end_lineno if node.end_lineno is not None else node.lineno
+        if node.lineno <= lineno <= end and node.lineno > best_start:
+            innermost = node.name
+            best_start = node.lineno
+    return innermost
+
+
+def _static_str_choices(node: ast.expr) -> list[str] | None:
+    """穷举表达式可能取到的 code 字面量，穷举不全时返回 ``None``。
+
+    只认字符串常量与条件表达式（``"a" if cond else "b"``）——后者两个分支都是字面量时才算
+    静态可枚举。``ast.walk`` 那种「找到任一字符串常量就当字面量」的宽松写法在
+    ``"lit" if cond else dynamic_code`` 上会 fail-open：动态分支产出的未登记 code 两道
+    守卫都拦不住，最终以裸机器码落到界面上。
+    """
+    if isinstance(node, ast.Constant):
+        return [node.value] if isinstance(node.value, str) else None
+    if isinstance(node, ast.IfExp):
+        body = _static_str_choices(node.body)
+        orelse = _static_str_choices(node.orelse)
+        if body is None or orelse is None:
+            return None
+        return body + orelse
+    return None
+
+
+def _keyword_value(node: ast.Call, name: str) -> ast.expr | None:
+    """取调用的 ``name=`` 实参表达式，没有则返回 ``None``。"""
+    for keyword in node.keywords:
+        if keyword.arg == name:
+            return keyword.value
+    return None
+
+
+def _scan_tree(tree: ast.Module, rel: str) -> tuple[dict[str, str], list[tuple[str, str]]]:
+    """扫描单棵语法树里的 capability-error 构造点。
+
+    返回 (code -> 首个出处, 无法静态求值 code 的构造点列表)。覆盖两种写法：构造点直接给 code
+    字面量（位置参数或 ``code=`` 关键字，含 ``"a" if cond else "b"`` 这类条件选码），以及
+    agnes 那样把 code 经 ``error_code=`` 关键字透传给内部 helper（此时构造点的 code 是变量，
+    字面量在 helper 调用方）。
+    """
+    codes: dict[str, str] = {}
+    dynamic_sites: list[tuple[str, str]] = []
+    calls = [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
+    constructions = [(node, name) for node in calls if (name := _exception_name(node.func)) is not None]
+    if not constructions:
+        return codes, dynamic_sites
+
+    for node, name in constructions:
+        where = f"{rel}:{node.lineno}"
+        # 三个能力异常的首参都叫 ``code``，位置与关键字两种写法都合法。只看位置参数会让
+        # ``ReferencePayloadFloorError(code="new")`` 落进「无实参」分支被登记成默认码，
+        # 真正的 new code 既不入集合也不记为动态点，两道守卫一起失效。
+        code_expr = node.args[0] if node.args else _keyword_value(node, "code")
+        if code_expr is None:
+            if name == "ReferencePayloadFloorError":
+                # 唯一带默认 code 的能力异常（构造点常省略实参）。
+                codes.setdefault(ReferencePayloadFloorError().code, where)
+            else:
+                dynamic_sites.append((where, f"{rel}::{_enclosing_function(tree, node.lineno)}"))
+            continue
+        literals = _static_str_choices(code_expr)
+        if literals is not None:
+            for literal in literals:
+                codes.setdefault(literal, where)
+        else:
+            # code 来自变量 / 模块常量，或条件表达式里混了动态分支：静态枚举不全，
+            # 登记漂移会漏网。记下来单独断言。
+            dynamic_sites.append((where, f"{rel}::{_enclosing_function(tree, node.lineno)}"))
+
+    # ``error_code=`` 只在确有 capability 构造点的文件里采集，避免同名 kwarg 的
+    # 无关模块被误当 capability code 报「未登记」假阳性。非字面量的 error_code
+    # 同样记成不可扫描点：helper 内部的构造点已按 scope 豁免，调用方再静默放过
+    # 就两道守卫全失效，未登记 code 会一路落到用户可见的裸机器码。
+    for node in calls:
+        error_code = _keyword_value(node, "error_code")
+        if error_code is None:
+            continue
+        literals = _static_str_choices(error_code)
+        if literals is not None:
+            for literal in literals:
+                codes.setdefault(literal, f"{rel}:{node.lineno}")
+        else:
+            dynamic_sites.append((f"{rel}:{node.lineno}", f"{rel}::{_enclosing_function(tree, node.lineno)}"))
+    return codes, dynamic_sites
+
+
+def _scan_raised_codes() -> tuple[dict[str, str], list[tuple[str, str]]]:
+    """扫描 lib/ + server/ 里全部 capability-error 构造点。"""
+    codes: dict[str, str] = {}
+    dynamic_sites: list[tuple[str, str]] = []
+    for root in _SCANNED_ROOTS:
+        for path in sorted((_REPO_ROOT / root).rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            found, dynamic = _scan_tree(tree, str(path.relative_to(_REPO_ROOT)))
+            for code, where in found.items():
+                codes.setdefault(code, where)
+            dynamic_sites.extend(dynamic)
+    return codes, dynamic_sites
+
+
+# code 由变量/形参传入、静态扫不出字面量的构造点，按「文件::所在函数」豁免（不按行号，
+# 行号会随无关改动漂移；也不按文件，否则同文件里任意新增的动态构造点都会被一并放过）。
+# 仅允许「同文件内由 ``error_code=`` 字面量喂入的 helper」这一种形态——helper 自身扫不出，
+# 但它的每个调用方都被上面的 kwarg 采集覆盖。值是该 scope 允许的动态构造点数量：豁免是
+# 定额而非空白支票，函数内再多一个动态构造点就得重新自证，不会被顺带放行。
+_ALLOWED_DYNAMIC_SCOPES = {"lib/video_backends/agnes.py::_encode_image": 2}
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        ('"video_duration_invalid"', ["video_duration_invalid"]),
+        ('"a" if cond else "b"', ["a", "b"]),
+        ('"a" if cond else dynamic_code', None),
+        ('dynamic_code if cond else "b"', None),
+        ("dynamic_code", None),
+        ('CODES["a"]', None),
+        ('f"video_{suffix}"', None),
+    ],
+)
+def test_static_code_enumeration_rejects_partially_dynamic_expressions(expr, expected):
+    """只有整个表达式的取值都能穷举时才算字面量，混了动态分支一律记为不可扫描。
+
+    条件表达式里但凡有一支是变量，动态那支产出的未登记 code 就绕过了两道漂移守卫。
+    """
+    assert _static_str_choices(ast.parse(expr, mode="eval").body) == expected
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_codes", "expected_dynamic"),
+    [
+        ('VideoCapabilityError("video_duration_invalid")', ["video_duration_invalid"], 0),
+        ('VideoCapabilityError(code="video_duration_invalid")', ["video_duration_invalid"], 0),
+        ("VideoCapabilityError(code=chosen)", [], 1),
+        # 默认 code 只在真的没给 code 时才算数：给了关键字就按关键字扫。
+        ("ReferencePayloadFloorError()", ["ref_payload_floor_exceeded"], 0),
+        ('ReferencePayloadFloorError(code="new_code")', ["new_code"], 0),
+        ("ReferencePayloadFloorError(code=chosen)", [], 1),
+        ('_encode_image(error_code="image_capability_missing_i2i")', ["image_capability_missing_i2i"], 0),
+    ],
+)
+def test_scanner_reads_code_from_keyword_form(source, expected_codes, expected_dynamic):
+    """``code=`` 关键字写法与位置参数同等对待，非字面量一律 fail-closed。
+
+    只看位置参数会让 ``ReferencePayloadFloorError(code="new_code")`` 被登记成默认码：
+    真实的新 code 既不进已发现集合也不记为动态点，两道漂移守卫一起放行。
+    """
+    # ``error_code=`` 仅在确有 capability 构造点的文件里采集，合成源码补一个构造点作陪衬。
+    prelude = 'VideoCapabilityError("video_duration_invalid")\n'
+    codes, dynamic = _scan_tree(ast.parse(prelude + source), "synthetic.py")
+
+    assert sorted(set(codes) - {"video_duration_invalid"}) == sorted(set(expected_codes) - {"video_duration_invalid"})
+    assert len(dynamic) == expected_dynamic
+
+
+def test_capability_codes_registered_no_drift():
+    """新增 capability code 未登记时在 CI 失败，而不是等到线上落库时才 KeyError 降级。"""
+    raised, _ = _scan_raised_codes()
+    unregistered = {code: where for code, where in raised.items() if code not in CAPABILITY_FAILURE_CODES}
+    assert not unregistered, f"以下 capability code 未登记进 CAPABILITY_FAILURE_CODES: {unregistered}"
+
+    stale = CAPABILITY_FAILURE_CODES - raised.keys()
+    assert not stale, f"以下已登记 code 在代码里已无 raise 点，应清理: {sorted(stale)}"
+
+
+def test_no_unscannable_capability_construction_sites():
+    """构造点的 code 必须能静态扫出，否则漂移守卫会 fail-open 地放过新 code。
+
+    新出现的动态写法要么改成字面量，要么显式进白名单并自证 code 已登记。
+    """
+    _, dynamic_sites = _scan_raised_codes()
+    unexpected = sorted({where for where, scope in dynamic_sites if scope not in _ALLOWED_DYNAMIC_SCOPES})
+    assert not unexpected, f"以下构造点的 code 非字面量，漂移守卫扫不到: {unexpected}"
+
+    counted = Counter(scope for _, scope in dynamic_sites)
+    assert counted == Counter(_ALLOWED_DYNAMIC_SCOPES), (
+        f"白名单 scope 的动态构造点数量与定额不符，新增的那个未自证 code 已登记: {counted}"
+    )
+
+
+@pytest.mark.parametrize("code", sorted(CAPABILITY_FAILURE_CODES))
+def test_capability_code_has_all_three_locales(code):
+    """每个 code 就是 errors 目录的 key（identity 映射），三语都必须有模板。"""
+    assert FAILURE_CODE_KEYS[code] == code
+    for locale in ("zh", "en", "vi"):
+        assert code in MESSAGES[locale], f"{locale} 缺少 {code}"
+
+
+def _translator(locale: str):
+    """与 ``lib.i18n.get_translator`` 同构：把 locale 绑进去，读侧就是这么调的。"""
+
+    def translate(key: str, **params) -> str:
+        return i18n_translate(key, locale=locale, **params)
+
+    return translate
+
+
+def test_stored_reason_renders_per_locale():
+    """同一条落库 error_message 在三语下渲染成三种文案。"""
+    stored = _encode_task_failure_message(
+        VideoCapabilityError("video_duration_not_supported", duration=7, supported="5, 10")
+    )
+    assert stored == '[video_duration_not_supported] {"duration": 7, "supported": "5, 10"}'
+
+    for locale in ("zh", "en", "vi"):
+        # 期望值独立取自该 locale 的模板目录，而非拿渲染结果互相比对——只断言"三者不同"
+        # 的话，zh/en/vi 模板或 locale 映射被互换仍会通过。
+        expected = MESSAGES[locale]["video_duration_not_supported"].format(duration=7, supported="5, 10")
+        assert render_failure(stored, _translator(locale)) == expected
+
+
+def test_encode_covers_every_capability_exception_type():
+    """三类能力异常都走结构化编码，不再落成烘焙文案。"""
+    cases = [
+        ImageCapabilityError("image_endpoint_mismatch_no_t2i", model="gpt-image-1"),
+        VideoCapabilityError("video_start_image_unreadable", model="kling-v1", name="a.png"),
+        ReferencePayloadFloorError(),
+    ]
+    for exc in cases:
+        stored = _encode_task_failure_message(exc)
+        assert stored.startswith(f"[{exc.code}]")
+        assert render_failure(stored, _translator("en")) != stored
+
+
+def test_encode_stringifies_non_json_params():
+    """params 值不是 JSON 原生类型时降级为字符串，编码不得在失败路径里抛错。
+
+    ``video_duration_invalid`` 回显的是调用方拒绝的原始值，类型不可控。
+    """
+    stored = _encode_task_failure_message(VideoCapabilityError("video_duration_invalid", duration=Path("weird")))
+    assert json.loads(stored.split("] ", 1)[1]) == {"duration": "weird"}
+
+
+def test_unregistered_capability_code_degrades_to_passthrough_text():
+    """code 未登记时退回非结构化文本，读侧原样透传——失败原因不丢，任务不卡 running。"""
+    exc = VideoCapabilityError("video_totally_new_code", model="x")
+    stored = _encode_task_failure_message(exc)
+    assert stored == "video_totally_new_code"
+    assert render_failure(stored, _translator("zh")) == stored
+
+
+def test_non_capability_exception_still_passes_through():
+    stored = _encode_task_failure_message(RuntimeError("provider socket closed"))
+    assert stored == "provider socket closed"
+    assert render_failure(stored, _translator("en")) == stored
+
+
+@pytest.mark.parametrize(
+    "legacy",
+    [
+        None,
+        "",
+        "<AioRpcError of RPC that terminated with:\n\tstatus = StatusCode.OUT_OF_RANGE>",
+        "不支持的资源类型: reference_videos",
+        "[video_duration_not_supported] not-json",
+        "[some_retired_code] {}",
+    ],
+)
+def test_legacy_rows_render_without_error(legacy):
+    """存量行（空值 / 纯文本 / 无法解析的伪结构化）读取不炸，一律原样返回。"""
+    assert render_failure(legacy, _translator("en")) == legacy
+
+
+def _encode_cascade(dependency_task_id: str, reason: str) -> str:
+    return encode_failure("cascade_blocked_dependency", dependency_task_id=dependency_task_id, reason=reason)
+
+
+def test_cascade_reason_renders_upstream_reason_per_locale():
+    """被上游连坐的任务不能退化成裸 [code]：级联包裹与其内层原因都按读侧语言渲染。"""
+    upstream = _encode_task_failure_message(
+        VideoCapabilityError("video_duration_not_supported", duration=7, supported="5, 10")
+    )
+    stored = _encode_cascade("5a38f38e", upstream)
+
+    rendered = {locale: render_failure(stored, _translator(locale)) for locale in ("zh", "en", "vi")}
+    assert len({*rendered.values()}) == 3, rendered
+    for locale, text in rendered.items():
+        assert "video_duration_not_supported" not in text
+        assert "5a38f38e" in text
+        inner = MESSAGES[locale]["video_duration_not_supported"].format(duration=7, supported="5, 10")
+        assert inner in text
+
+
+def test_cascade_reason_with_unstructured_upstream_still_renders():
+    """上游原因是 provider 原始异常文本时，包裹层仍本地化，内层原样透传。"""
+    stored = _encode_cascade("5a38f38e", "provider rejected")
+    rendered = render_failure(stored, _translator("zh"))
+    assert rendered != stored
+    assert "provider rejected" in (rendered or "")
+
+
+def test_render_degrades_when_json_hits_recursion_limit(monkeypatch):
+    """params 短而深时 ``json.loads`` 自身会撞递归上限。
+
+    渲染发生在 HTTP 请求内，异常逸出就是 500，因此与畸形 JSON 同样处置：原样透传，原因不丢。
+    """
+    stored = '[video_reference_images_unreadable] {"names": [[[1]]]}'
+
+    def _boom(*_args, **_kwargs):
+        raise RecursionError("maximum recursion depth exceeded")
+
+    monkeypatch.setattr(task_failure.json, "loads", _boom)
+
+    assert render_failure(stored, _translator("en")) == stored

--- a/tests/test_task_failure_capability.py
+++ b/tests/test_task_failure_capability.py
@@ -398,6 +398,29 @@ def test_encode_stringifies_non_json_params():
     assert json.loads(stored.split("] ", 1)[1]) == {"duration": "weird"}
 
 
+def test_bound_reason_preserves_scalar_param_types():
+    """裁剪不得改掉同条失败里其它参数的类型。
+
+    裁剪是整个 params 一起过一遍的：只要有任一参数超长触发裁剪，同条失败携带的全部标量都会
+    跟着走一遍归一。把 JSON 原生标量转成文本会在重新编码时被加上引号存回去（``42`` 变
+    ``"42"``、``True`` 变 ``"true"``、``None`` 变 ``"null"``），落库信封的参数类型就变了；
+    模板若用带类型说明符的占位符（如 ``{n:d}``），``str.format`` 抛出的异常会被
+    ``lib/i18n/__init__.py::_`` 吞掉，最终把裸占位符显示给用户。
+    """
+    stored = encode_failure("resume_expired_detail", detail="x" * 3000, retries=3, ratio=1.5, expired=True, note=None)
+
+    bounded = bound_reason(stored, 2000)
+
+    assert len(bounded) <= 2000
+    params = json.loads(bounded.split("] ", 1)[1])
+    assert params["retries"] == 3 and isinstance(params["retries"], int)
+    assert params["ratio"] == 1.5 and isinstance(params["ratio"], float)
+    assert params["expired"] is True
+    assert params["note"] is None
+    # 超长的那个仍被收窄。
+    assert len(params["detail"]) < 3000
+
+
 def test_unregistered_capability_code_degrades_to_passthrough_text():
     """code 未登记时退回非结构化文本，读侧原样透传——失败原因不丢，任务不卡 running。"""
     exc = VideoCapabilityError("video_totally_new_code", model="x")

--- a/tests/test_task_failure_capability.py
+++ b/tests/test_task_failure_capability.py
@@ -23,6 +23,7 @@ from lib.reference_compression import ReferencePayloadFloorError
 from lib.task_failure import (
     CAPABILITY_FAILURE_CODES,
     FAILURE_CODE_KEYS,
+    bound_reason,
     encode_failure,
     render_failure,
 )
@@ -369,3 +370,36 @@ def test_render_degrades_when_json_hits_recursion_limit(monkeypatch):
     monkeypatch.setattr(task_failure.json, "loads", _boom)
 
     assert render_failure(stored, _translator("en")) == stored
+
+
+def test_bound_reason_shrinks_oversized_non_string_params():
+    """非字符串参数撑爆预算时也要留下可解析的信封。
+
+    ``video_duration_invalid`` 回显调用方拒绝的原始配置值，导入或手工编辑的 project.json
+    能把它写成一个大数组；JSON 原生类型不经 ``default=str``，没有字符串参数可收窄时旧路径
+    会退到裸切片，把信封切在 JSON 中途，读侧解析失败后原样吐出整串机器码。
+    """
+    stored = _encode_task_failure_message(VideoCapabilityError("video_duration_invalid", duration=list(range(2000))))
+    assert len(stored) > 2000
+
+    bounded = bound_reason(stored, 2000)
+
+    assert len(bounded) <= 2000
+    # 仍是合法信封：读侧解析得出来，渲染成本地化文案而非裸机器码。
+    rendered = render_failure(bounded, _translator("en"))
+    assert rendered is not None
+    assert rendered != bounded
+    assert "video_duration_invalid" not in rendered
+
+
+def test_bound_reason_degrades_when_param_json_hits_recursion_limit(monkeypatch):
+    """嵌套过深的参数量不出长度时降级为省略号，而不是把异常抛进落库路径。"""
+    stored = '[video_duration_invalid] {"duration": [[[1]]]}' + "x" * 3000
+
+    def _boom(*_args, **_kwargs):
+        raise RecursionError("maximum recursion depth exceeded")
+
+    monkeypatch.setattr(task_failure.json, "dumps", _boom)
+
+    assert task_failure._as_shrinkable([[[1]]]) == "…"
+    assert len(bound_reason(stored, 2000)) <= 2000

--- a/tests/test_task_failure_capability.py
+++ b/tests/test_task_failure_capability.py
@@ -108,7 +108,13 @@ def _scan_tree(tree: ast.Module, rel: str) -> tuple[dict[str, str], list[tuple[s
         # 真正的 new code 既不入集合也不记为动态点，两道守卫一起失效。
         code_expr = node.args[0] if node.args else _keyword_value(node, "code")
         if code_expr is None:
-            if name == "ReferencePayloadFloorError":
+            # ``**kwargs`` 解包里可能藏着 code，静态看不见。此时不能当「没给 code」处理：
+            # ``ReferencePayloadFloorError(**{"code": "new"})`` 会被登记成默认码，真正的
+            # new code 两道守卫一起放行。无位置参数也无显式 ``code=`` 时，只有确定没有解包
+            # 才敢认默认码。
+            if any(keyword.arg is None for keyword in node.keywords):
+                dynamic_sites.append((where, f"{rel}::{_enclosing_function(tree, node.lineno)}"))
+            elif name == "ReferencePayloadFloorError":
                 # 唯一带默认 code 的能力异常（构造点常省略实参）。
                 codes.setdefault(ReferencePayloadFloorError().code, where)
             else:
@@ -185,9 +191,12 @@ def test_static_code_enumeration_rejects_partially_dynamic_expressions(expr, exp
 @pytest.mark.parametrize(
     ("source", "expected_codes", "expected_dynamic"),
     [
-        ('VideoCapabilityError("video_duration_invalid")', ["video_duration_invalid"], 0),
-        ('VideoCapabilityError(code="video_duration_invalid")', ["video_duration_invalid"], 0),
+        ('VideoCapabilityError("video_duration_not_supported")', ["video_duration_not_supported"], 0),
+        ('VideoCapabilityError(code="video_duration_not_supported")', ["video_duration_not_supported"], 0),
         ("VideoCapabilityError(code=chosen)", [], 1),
+        # ``**`` 解包里可能藏着 code，静态看不见：不能当「没给 code」而登记默认码。
+        ('ReferencePayloadFloorError(**{"code": "new_code"})', [], 1),
+        ("VideoCapabilityError(**overrides)", [], 1),
         # 默认 code 只在真的没给 code 时才算数：给了关键字就按关键字扫。
         ("ReferencePayloadFloorError()", ["ref_payload_floor_exceeded"], 0),
         ('ReferencePayloadFloorError(code="new_code")', ["new_code"], 0),
@@ -202,10 +211,12 @@ def test_scanner_reads_code_from_keyword_form(source, expected_codes, expected_d
     真实的新 code 既不进已发现集合也不记为动态点，两道漂移守卫一起放行。
     """
     # ``error_code=`` 仅在确有 capability 构造点的文件里采集，合成源码补一个构造点作陪衬。
+    # 陪衬的 code 与各用例都不重合，且断言取全等而非差集——否则被测 code 与陪衬同名时，
+    # 两边一起减掉会让「一条都没采集到」也照样通过。
     prelude = 'VideoCapabilityError("video_duration_invalid")\n'
     codes, dynamic = _scan_tree(ast.parse(prelude + source), "synthetic.py")
 
-    assert sorted(set(codes) - {"video_duration_invalid"}) == sorted(set(expected_codes) - {"video_duration_invalid"})
+    assert sorted(codes) == sorted({"video_duration_invalid", *expected_codes})
     assert len(dynamic) == expected_dynamic
 
 


### PR DESCRIPTION
Closes #1397

## 问题

worker 执行任务失败时，错误信息在**落库时刻**按 `DEFAULT_LOCALE` 渲染成中文文本落进 `tasks.error_message`。用户语言只在读侧（`Accept-Language` → Translator）才可知，所以界面语言为 en/vi 的用户在任务列表看到的失败原因是中文。既有的 `[code]` 延迟渲染机制被这条路径绕过。

## 改动

**写侧只存机器码。** `server/services/generation_tasks.execute_generation_task` 里那层「捕获能力异常 → 按 `DEFAULT_LOCALE` 渲染 → 包 `RuntimeError`」的 catch 删除，`ImageCapabilityError` / `VideoCapabilityError` / `ReferencePayloadFloorError` 原样上抛到 `generation_worker._encode_task_failure_message`，与既有的 `ScriptEditError` 共用同一个编码出口，落库形态统一为 `[code] {params-json}`。`generation_tasks.py` 不再 import 渲染层。

编码点选在 worker 而非 dispatch，是为了不留下两处「异常 → 落库字符串」的编码点。

**读侧统一渲染。** `server/routers/tasks.py` 的四个出口（`/tasks`、`/projects/{name}/tasks`、`/tasks/{id}`、`/tasks/stream`）全部经 `_localize_task` → `lib.task_failure.render_failure`，按请求 `Accept-Language` 渲染。`/tasks/stream` 虽已 `deprecated=True` 且前端改走轮询，但它仍是对外 API 出口，不补齐会把 `[code]` 裸串泄给仍在用它的客户端——本次泄漏面从 13 个 code 扩到 35 个，故一并接线（4 行）。

**code 登记与漂移守卫。** 22 个能力 code 在 `lib/task_failure.CAPABILITY_FAILURE_CODES` 显式登记（identity 映射到 errors 目录 key），不从 i18n 目录派生——派生会让任意 `[foo]` 文本被误当结构化码，也丢掉 `encode_failure` 对拼写错误的 fail-fast。两份清单的同步由 `tests/test_task_failure_capability.py` 的 AST 扫描双向守住：扫 `lib/` + `server/` 全部构造点，未登记的报错、已登记但无 raise 点的也报错；code 非字面量、静态扫不出的构造点单独断言为空（白名单外一律 CI 失败），避免守卫 fail-open。

**级联失败原因。** 依赖任务失败时，下游任务的原因由 `lib.task_failure.encode_cascade_failure` 生成（`blocked by failed dependency {id}: {上游原因}`），读侧递归渲染：包裹层走 `task_fail_blocked_by_dependency` 三语模板，内层上游原因按其自身形态渲染或透传。不采用「再套一层 JSON 信封」是因为级联深度会让转义膨胀，而 `error_message` 有 2000 字符截断，截断后的 JSON 不可解析。

**`encode_failure` 加 `default=str`。** 能力 code 回显的是调用方拒绝的原始值（如 `video_duration_invalid` 的 duration），类型不可控；失败路径里编码抛错会让任务卡在 running。

## 存量数据处置

在开发库 `projects/.arcreel.db`（163 行 `tasks`）上实测分桶，逐类给出处置：

| 类别 | 行数 | 处置 |
|---|---|---|
| `error_message IS NULL` | 127 | 忽略。`render_failure` 对 falsy 值直接原样返回 |
| 空字符串 | 0 | 同上（falsy 短路） |
| `[code]` / `[code] {json}`，code 已登记 | 0 | 正常渲染。存量为 0 是因为 `encode_failure` 此前只覆盖孤儿恢复 / 剧本编辑路径且未触发过 |
| `[code]` 形态但 code 未登记（拼写漂移 / 已下线 code） | 0 | 原样展示 `[code] {...}`，`render_failure` 已有此分支 |
| 级联包裹 `blocked by failed dependency ...` | 1 | **本次起可渲染**。存储格式未变，读侧新增的级联识别对存量行同样生效：包裹层本地化，内层上游原因按其形态渲染或透传 |
| 纯文本（provider 原始异常 `str(exc)`、硬编码中文如「不支持的资源类型: reference_videos」） | 35 | 原样展示。非结构化文本读侧透传，不丢原因 |
| **已按 `DEFAULT_LOCALE` 烘焙成中文的 capability 文案** | **0** | **不迁移**，理由见下 |

最后一类是唯一「理论上可反解出 code」的候选，也是本 issue 的核心存量风险。核验方法：把 `FAILURE_CODE_KEYS` 全部 35 个 key 的 **zh/en/vi 三语模板**各自转成宽松正则（占位符 `{x}` → `.*?`，其余字面转义），反向匹配全表 36 条非空行，命中空集。

**不做迁移是口径判断，不是「实测为 0 所以不管」**：模板含 `{}` 占位，参数抽取不可靠且多个模板可能互相包含，反解本身就会引入误判风险。因此对该类的处置口径是——**若生产库存在此类行，保持原样中文展示**（`render_failure` 落到「非结构化文本原样透传」分支，读取不炸、原因不丢），en/vi 用户在这些历史行上仍看到中文，新产生的失败任务不受影响。开发库实测为空集只是佐证这类行在实践中未积累。

全表 163 行 × 三语跑过 `render_failure`，无异常。

## 验证

- `uv run python -m pytest -q -m "not e2e"` 全绿
- `uv run ruff check . && uv run ruff format --check .` 通过
- `uv run basedpyright` 0 error
- 新增 `tests/test_task_failure_capability.py`：AST 漂移守卫（双向 + 非字面量构造点 fail-closed，含混合动态表达式与 `code=` 关键字两种写法）、三语渲染、级联渲染、params 非 JSON 原生类型降级、未登记 code 降级透传、存量行原样返回、`json.loads` 撞递归上限时的透传兜底
- `tests/test_task_cancel_router.py` 补 `skipped_terminal` 的按语言渲染断言
- 存量口径见上表，实测脚本对开发库只做 `mode=ro` 只读查询

## 与 #1401 的收编关系

本 PR 的 base 早于 #1401（issue #1388，已合并）。#1401 把级联失败编码从**英文哨兵前缀** `blocked by failed dependency {id}: ` 改成了**结构化 code `cascade_blocked_dependency` + 嵌套 reason 参数**，并将哨兵前缀认定为破坏锚定正则的 bug 予以废除。本 PR 早期基于旧机制实现并加固的级联相关 diff，已在 rebase 时全量收编到该结构化机制上：`encode_cascade_failure` / `_CASCADE_PREFIX` / `truncate_failure` 及其测试全部删除，落库限长统一走 #1401 的 `bound_reason`，无旧机制残留、不存在两套语义并行。

收编后本 PR 与 #1401 不重叠的部分即 issue #1397 的验收核心：capability code 登记表与 AST 漂移守卫、能力异常原样传播与 worker 结构化编码、`cancel_task` 的 `skipped_terminal` 读侧本地化、MiniMax 未知分辨率的硬编码中文占位符。另将落库 `error_message` 限长从「仅级联路径」扩展到 `_mark_failed_running`（常量随之更名为 `_MAX_ERROR_MESSAGE_LEN`，因其不再只服务于级联）。

围绕旧哨兵机制的三条深链加固（半截哨兵、级联截断递归、级联渲染递归撞上限）随机制一并撤回。这三条在新机制下**不成立而非被绕过**：每层级联会把上一层完整信封重新编码进 JSON，转义使串长超线性增长，写侧 2000 字符上限因此把嵌套深度压到远低于递归上限的量级。收编时曾按迭代式重写渲染路径，构造深链回归测试时正是该转义膨胀让测试无法跑完，从而反证风险不存在，故回退为 #1401 的递归实现，不引入无谓改动。唯一保留的是与级联深度无关的一条：`json.loads` 对短而深的 payload 自身会撞递归上限，渲染在 HTTP 请求栈内逸出即 500，因此与畸形 JSON 同样处置为原样透传，并有对应回归测试。

## 已知边界

- `generation_queue_client.enqueue_and_wait` 把 `error_message` 直接交给 agent，agent 现在看到 `[video_duration_not_supported] {...}` 而非中文句子。属 agent-facing 字符串（CLAUDE.md 明确豁免 i18n），且 `ScriptEditError` 早有同样形态。
- 前端 `task-target.ts::describeTaskFailure` 只在 `error_message` 为空时兜底，不解析 `[code]`——后端已保证读侧出口都渲染过，前端无需改。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 能力类任务失败采用结构化失败信息（`[code] {params}`），读取侧按请求语言渲染，并支持级联阻断失败原因的本地化展示。
  * 任务取消接口会对 `cancelled` / `skipped_terminal` 内的失败原因按请求语言本地化后返回。
* **错误修复**
  * 统一失败原因与级联原因的预算截断与降级策略，避免破坏结构化内容；在编码/解析异常输入下自动回退透传。
  * 修复 `supported` 兜底提示为语言中性的 `-`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
