### PR TITLE
fix(project): 快速切换项目时详情不再卡在加载中或残留上一个项目的数据

### DIFF
--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -370,6 +370,22 @@ describe("StudioCanvasRouter", () => {
     expect(screen.getByText("加载中...")).toBeInTheDocument();
   });
 
+  it("keeps showing loading state on a deep link while the project detail request is still in flight", () => {
+    // 首屏加载先落地 currentProjectName（数据置空）再等 refreshProject 结算（见
+    // router.tsx）：currentProjectName 非空不代表详情已到达。直接打开 /characters 这类
+    // 深链时,若只看 currentProjectName 会把空集合渲染成可交互的「空项目」页面。
+    useProjectsStore.setState({
+      currentProjectName: "demo",
+      currentProjectData: null,
+      projectDetailLoading: true,
+    });
+
+    renderAt("/characters");
+
+    expect(screen.getByText("加载中...")).toBeInTheDocument();
+    expect(screen.queryByTestId("character-card")).not.toBeInTheDocument();
+  });
+
   it("routes characters/scenes/props/source/episodes views correctly", async () => {
     useProjectsStore.setState({
       currentProjectName: "demo",

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -88,7 +88,7 @@ export function StudioCanvasRouter() {
   const tRef = useRef(t);
   // eslint-disable-next-line react-hooks/refs -- tRef 是稳定 event-handler ref 模式，用于在回调中获取最新 t 而不触发无限 useCallback 重建
   tRef.current = t;
-  const { currentProjectData, currentProjectName, currentScripts } =
+  const { currentProjectData, currentProjectName, currentScripts, projectDetailLoading } =
     useProjectsStore();
   // 演示态：资产画布仍走 readOnly 透传，工作台时间线的只读则由组件自己直读同一判定。
   // useDemoWorkbench() 已把路由参数与 store 的判定滞后收口在单一来源，此处直接消费。
@@ -545,7 +545,10 @@ export function StudioCanvasRouter() {
     void handleGenerateProduct(...args).catch(console.error);
   }, [handleGenerateProduct]);
 
-  if (!currentProjectName) {
+  // `currentProjectName` 在详情到达前就已落地（见 router.tsx 首屏加载的注释），
+  // 仅查它会在深链（/characters 等）直接打开或详情较慢时把空集合渲染成可交互的
+  // 「空项目」页面；`projectDetailLoading` 才是详情是否已到达的信号。
+  if (!currentProjectName || projectDetailLoading) {
     return (
       <div className="flex h-full items-center justify-center text-gray-500">
         {t("loading_placeholder")}

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -199,6 +199,7 @@ export default {
   'overview_gen_desc': 'A project overview will be generated, then you can start creating scripts and storyboards',
   'project_overview_regenerated': 'Project overview regenerated',
   'project_sync_failed': 'Failed to sync project changes: {{message}}',
+  'project_load_failed': 'Failed to load project: {{message}}',
   'synopsis': 'Synopsis',
   'genre': 'Genre',
   'theme': 'Theme',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -200,6 +200,7 @@ export default {
   'overview_gen_desc': 'Tổng quan dự án sẽ được tạo, sau đó bạn có thể bắt đầu viết kịch bản và phân cảnh',
   'project_overview_regenerated': 'Đã tạo lại tổng quan dự án',
   'project_sync_failed': 'Đồng bộ thay đổi dự án thất bại: {{message}}',
+  'project_load_failed': 'Tải dự án thất bại: {{message}}',
   'synopsis': 'Tóm tắt',
   'genre': 'Thể loại',
   'theme': 'Chủ đề',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -200,6 +200,7 @@ export default {
   'overview_gen_desc': '自动生成项目概述，然后您可以开始创建剧本和分镜',
   'project_overview_regenerated': '项目概述已重新生成',
   'project_sync_failed': '同步项目变更失败: {{message}}',
+  'project_load_failed': '加载项目失败: {{message}}',
   'synopsis': '故事梗概',
   'genre': '题材',
   'theme': '主题',

--- a/frontend/src/router.test.tsx
+++ b/frontend/src/router.test.tsx
@@ -211,6 +211,55 @@ describe("AppRoutes", () => {
     expect(capturedSignal?.aborted).toBe(true);
   });
 
+  it("快速切换项目：旧项目的迟到响应不覆盖新项目的首屏数据", async () => {
+    // 回归：首屏加载收编进 refreshProject 的取消域后，A → B 快速切换时 A 的响应可能
+    // 在切换完成之后才落定（abort 与响应落定同为异步，响应先到时网络层不会 reject）。
+    // 它既不该写回 currentProject，也不该让 B 自己的首屏加载失踪或停在加载态。
+    let resolveA!: (value: Awaited<ReturnType<typeof API.getProject>>) => void;
+    const pendingA = new Promise<Awaited<ReturnType<typeof API.getProject>>>((res) => {
+      resolveA = res;
+    });
+    vi.spyOn(API, "getProject").mockImplementation((name) =>
+      name === "A"
+        ? pendingA
+        : Promise.resolve({ project: { title: "B-数据" } as never, scripts: {} }),
+    );
+
+    // 只看最终态不足以证伪「迟到覆盖」——A 的数据即便写进去了，也会被随后跑完的 B 盖回
+    // 去。订阅整段过程，断言 A 的数据一次都没有落进 store。
+    const seenTitles: Array<string | undefined> = [];
+    const unsubscribe = useProjectsStore.subscribe((s) =>
+      seenTitles.push(s.currentProjectData?.title),
+    );
+
+    const { hook, navigate } = memoryLocation({ path: "/app/projects/A" });
+    render(
+      <Router hook={hook}>
+        <AppRoutes />
+      </Router>,
+    );
+    await waitFor(() => {
+      expect(API.getProject).toHaveBeenCalledWith("A", { signal: expect.any(AbortSignal) });
+    });
+
+    act(() => navigate("/app/projects/B"));
+    // 切换完成后 A 的响应才落定
+    await act(async () => {
+      resolveA({ project: { title: "A-迟到数据" } as never, scripts: {} });
+      await pendingA;
+    });
+
+    await waitFor(() => {
+      const s = useProjectsStore.getState();
+      expect(s.currentProjectName).toBe("B");
+      expect(s.currentProjectData?.title).toBe("B-数据");
+      // B 的首屏加载正常收口，不因 A 占着在途/排队名额而停在加载态
+      expect(s.projectDetailLoading).toBe(false);
+    });
+    unsubscribe();
+    expect(seenTitles).not.toContain("A-迟到数据");
+  });
+
   it("keeps project name when loading project details fails", async () => {
     vi.spyOn(API, "getProject").mockRejectedValue(new Error("network"));
 

--- a/frontend/src/router.test.tsx
+++ b/frontend/src/router.test.tsx
@@ -192,12 +192,16 @@ describe("AppRoutes", () => {
 
   it("离开项目会中止在途的详情请求", async () => {
     let capturedSignal: AbortSignal | undefined;
-    vi.spyOn(API, "getProject").mockImplementation((_name, options) => {
-      capturedSignal = options?.signal;
-      return new Promise(() => {
-        // 永不 settle：模拟一条还挂在网络上的请求
-      });
-    });
+    vi.spyOn(API, "getProject").mockImplementation(
+      (_name, options) =>
+        new Promise((_resolve, reject) => {
+          capturedSignal = options?.signal;
+          // 模拟真实 fetch + AbortSignal 语义：abort 后 reject，而不是永久悬挂——
+          // 否则 refreshProject 的共享「在途」标志会被这条请求永久卡住，污染同一
+          // 文件里排在后面的用例（它们的 refreshProject 调用会被无限期排队）。
+          options?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+        }),
+    );
 
     const view = renderAt("/app/projects/demo");
     await waitFor(() => expect(capturedSignal).toBeDefined());

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -20,7 +20,7 @@ import {
   DEMO_PROJECT_NAME,
   isDemoProject,
 } from "@/onboarding/demo-project";
-import { API, setApiReadOnly } from "@/api";
+import { setApiReadOnly } from "@/api";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useAssistantStore } from "@/stores/assistant-store";
 import { useAuthStore } from "@/stores/auth-store";
@@ -139,24 +139,22 @@ function StudioWorkspace() {
     // 进真实项目一律解锁，不让上一次演示的闸门残留下来
     setApiReadOnly(false);
     setProjectDetailLoading(true);
-    const controller = new AbortController();
-    API.getProject(projectName, { signal: controller.signal })
-      .then((res) => {
-        if (controller.signal.aborted) return;
-        setCurrentProject(projectName, res.project, res.scripts ?? {}, res.asset_fingerprints);
-      })
-      .catch(() => {
-        // Still set the project name so the UI shows something
-        if (controller.signal.aborted) return;
-        setCurrentProject(projectName, null);
-      })
-      .finally(() => {
-        // 已被接管方作废时不动共享状态，否则会踩到新一轮加载
-        if (!controller.signal.aborted) setProjectDetailLoading(false);
+    // 先落地项目名（数据置空）：refreshProject 的写入门槛要求 currentProjectName 已等于
+    // 目标项目，否则响应落地时会被判成「非当前项目」而丢弃（见 projects-store.ts
+    // isCurrentProject 的注释）。这一步同时轮换取消域，上一个项目的在途请求随之作废，
+    // 首屏加载与 refreshProject 的其余调用方共用同一取消域。
+    setCurrentProject(projectName, null);
+    void useProjectsStore
+      .getState()
+      .refreshProject(projectName)
+      .then((result) => {
+        // "cancelled" 代表本轮未同步（项目已被切走、取消域已轮换），loading 状态交由
+        // 接管的新一轮自行结算，此处不动共享状态。
+        if (result === "cancelled") return;
+        setProjectDetailLoading(false);
       });
 
     return () => {
-      controller.abort();
       setCurrentProject(null, null);
     };
   }, [projectName, setCurrentProject, setProjectDetailLoading]);

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,6 +1,6 @@
 // router.tsx — Route definitions for the studio layout
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Route, Switch, Redirect, useParams } from "wouter";
 import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
@@ -22,9 +22,11 @@ import {
 } from "@/onboarding/demo-project";
 import { setApiReadOnly } from "@/api";
 import { useProjectsStore } from "@/stores/projects-store";
+import { useAppStore } from "@/stores/app-store";
 import { useAssistantStore } from "@/stores/assistant-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
+import { errMsg } from "@/utils/async";
 import {
   ROUTE_APP,
   ROUTE_APP_ASSETS,
@@ -111,6 +113,12 @@ function StudioWorkspace() {
   const projectName = params.projectName ?? null;
   const { setCurrentProject, setProjectDetailLoading } = useProjectsStore();
   const { t } = useTranslation("onboarding");
+  // 把 t 通过 ref 暴露给首屏加载的 onError 回调，避免切语言触发 t 重建 → effect
+  // 依赖跟着重建 → 真实项目整条加载重跑（下方 effect 依赖里刻意不含 t，理由见下）。
+  const tRef = useRef(t);
+  useEffect(() => {
+    tRef.current = t;
+  }, [t]);
 
   // 项目生命周期：清空上一个项目的 assistant 状态，再按项目类型取数据。
   // 依赖里不含 `t` —— 界面语言变化只该重灌演示常量（见下一个 effect），不该让真实项目
@@ -146,7 +154,10 @@ function StudioWorkspace() {
     setCurrentProject(projectName, null);
     void useProjectsStore
       .getState()
-      .refreshProject(projectName)
+      .refreshProject(projectName, {
+        onError: (err) =>
+          useAppStore.getState().pushToast(tRef.current("dashboard:project_load_failed", { message: errMsg(err) }), "error"),
+      })
       .then((result) => {
         // "cancelled" 代表本轮未同步（项目已被切走、取消域已轮换），loading 状态交由
         // 接管的新一轮自行结算，此处不动共享状态。

--- a/frontend/src/stores/projects-store.test.ts
+++ b/frontend/src/stores/projects-store.test.ts
@@ -444,4 +444,59 @@ describe("projects-store refreshProject", () => {
     expect(useProjectsStore.getState().currentProjectName).toBe("B");
     expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-新数据");
   });
+
+  it("在途轮是当前项目、排队的却是旧项目名：在途轮照常写入，不为排队者让位", async () => {
+    // 首屏加载收编进来之后，「排队里有别的项目」不再必然意味着本轮即将被取代：路由切换
+    // 会先落名再刷新，因此真正要取代本轮的项目此刻已是当前项目；而持旧项目名的调用方
+    // （写操作完成后的刷新、SSE）排进来时，当前项目并未易主。此时若仍为它让位，本轮
+    // 就是当前项目自己的首屏数据，丢掉后没有任何人会再加载它。
+    useProjectsStore.getState().setCurrentProject("B", null);
+    const dB = deferred<GetProjectResult>();
+    const dStale = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject").mockImplementation((name) =>
+      name === "B" ? dB.promise : dStale.promise,
+    );
+
+    const store = useProjectsStore.getState();
+    const pB = store.refreshProject("B"); // 当前项目 B 的首屏轮，在途
+    const pStale = store.refreshProject("A"); // 持旧项目名的调用方排队
+
+    dB.resolve(makeResult("B-数据"));
+    expect(await pB).toBe("success");
+    expect(useProjectsStore.getState().currentProjectName).toBe("B");
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
+
+    // 排队轮跑的是旧项目 A：它本就写不进去（非当前项目），结算为 cancelled 即可。
+    dStale.resolve(makeResult("A-迟到数据"));
+    expect(await pStale).toBe("cancelled");
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
+  });
+
+  it("当前项目的刷新在排队时，持旧项目名的调用方不夺走唯一的排队名额", async () => {
+    // 排队只有一个名额，且设计上「取最新 name」。收编首屏加载后，被挤掉的那个可能正是
+    // 当前项目自己的首屏刷新——而挤进来的旧项目名注定写不进 store，于是当前项目的数据
+    // 一轮都不会被拉取，projectDetailLoading 也永远回落不了。
+    useProjectsStore.getState().setCurrentProject("A", makeProject("A-数据"), {}, {});
+    const dSseA = deferred<GetProjectResult>();
+    const dB = deferred<GetProjectResult>();
+    vi.spyOn(API, "getProject").mockImplementation((name) =>
+      name === "B" ? dB.promise : dSseA.promise,
+    );
+
+    const store = useProjectsStore.getState();
+    const pSseA = store.refreshProject("A"); // A 页面上的 SSE 刷新，在途
+    store.setCurrentProject("B", null); // 路由切到 B：先落名，取消域随之轮换
+    const pFirstScreenB = store.refreshProject("B"); // B 的首屏刷新 → 排队
+    const pStaleA = store.refreshProject("A"); // 持旧项目名的调用方，不该挤掉 B
+
+    dSseA.resolve(makeResult("A-迟到数据"));
+    await flush();
+    dB.resolve(makeResult("B-数据"));
+
+    expect(await pFirstScreenB).toBe("success");
+    expect(useProjectsStore.getState().currentProjectName).toBe("B");
+    expect(useProjectsStore.getState().currentProjectData?.title).toBe("B-数据");
+    expect(await pSseA).toBe("cancelled");
+    expect(await pStaleA).toBe("cancelled");
+  });
 });

--- a/frontend/src/stores/projects-store.ts
+++ b/frontend/src/stores/projects-store.ts
@@ -124,9 +124,25 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
       const signal = projectScope.signal;
       try {
         const res = await API.getProject(curName, { signal });
-        // 在途期间若已排队到不同项目的刷新请求，本轮响应针对的是即将切走的旧项目——
-        // 跳过写入，避免用它覆盖排队轮即将加载的新项目（数据 / 名称均不提交）。
-        const supersededByOtherProject = refreshQueued && queuedName !== null && queuedName !== curName;
+        // currentProjectName 为 null 时，只有 store 整个生命周期内还从未建立过任何真实
+        // 项目才放行——那是 refreshProject 承担的「把首个项目数据建立进 store」职责，
+        // 届时没有「当前项目」可比较。一旦建立过任意项目，后续任何 null 都只会是路由
+        // cleanup 清空旧项目、异步加载新项目之间的过渡态：这段窗口里不放行任何名字的
+        // 写入（包括比刚清空的项目更早、直到现在才落定的旧项目，见 hasLoadedAnyProject
+        // 的注释），否则旧数据会在新项目自己的数据落地前抢先写回。
+        const { currentProjectName, hasLoadedAnyProject } = get();
+        // 在途期间若已排队到「更有资格写入」的另一个项目，本轮响应针对的就是即将被取代
+        // 的旧项目——跳过写入，避免覆盖排队轮即将加载的新项目（数据 / 名称均不提交）。
+        // 「更有资格」有两种：排队的那个项目已经是当前项目（路由切换先落名再发起刷新，
+        // 切换此刻已经完成），或 store 还没有当前项目（尚未建立任何项目，排队里的最新
+        // 意图就是目标）。反过来，排队者若是持切走前旧项目名的调用方（写操作完成后的
+        // 刷新、SSE），它注定过不了下面的当前项目核对、一个字节也写不进 store，本轮
+        // 不能为它让位——本轮才是当前项目自己的数据，丢掉后没有任何人会再加载它。
+        const supersededByOtherProject =
+          refreshQueued &&
+          queuedName !== null &&
+          queuedName !== curName &&
+          (currentProjectName === null || queuedName === currentProjectName);
         // 取消域已轮换：当前项目在请求在途期间被换掉了（路由切到别的项目、演示工作台接管、
         // 离开工作台清空）。这些路径都不经过 refreshProject，排队去重看不到它们，只能靠
         // 取消域识别。abort 与响应落定同为异步，响应先到、abort 后到时网络层不会 reject，
@@ -135,13 +151,6 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
         // 的刷新）捕获的是切走前的旧项目名，且这次调用是在切换已经完成之后才发起的，
         // 拿到的会是新项目现役、未 abort 的域——因此还要在写入前核对 curName 是否仍是
         // 当前项目，防止旧项目的数据覆盖已经切入的新项目。
-        // currentProjectName 为 null 时，只有 store 整个生命周期内还从未建立过任何真实
-        // 项目才放行——那是 refreshProject 承担的「把首个项目数据建立进 store」职责，
-        // 届时没有「当前项目」可比较。一旦建立过任意项目，后续任何 null 都只会是路由
-        // cleanup 清空旧项目、异步加载新项目之间的过渡态：这段窗口里不放行任何名字的
-        // 写入（包括比刚清空的项目更早、直到现在才落定的旧项目，见 hasLoadedAnyProject
-        // 的注释），否则旧数据会在新项目自己的数据落地前抢先写回。
-        const { currentProjectName, hasLoadedAnyProject } = get();
         const isCurrentProject =
           currentProjectName === curName || (currentProjectName === null && !hasLoadedAnyProject);
         if (!supersededByOtherProject && !signal.aborted && isCurrentProject) {
@@ -239,6 +248,16 @@ export const useProjectsStore = create<ProjectsState>((set, get) => {
           // 会在 C 成功后错误地收到 true，但 store 从未同步过 B 的数据）。按「未同步」
           // 立即结算为 "cancelled"，不视为请求出错，因此不触发 onError。
           if (refreshQueued && queuedName !== null && queuedName !== name) {
+            // 名额上已经是当前项目的刷新（通常就是路由切换后的首屏加载），而本次带来的
+            // 是别的项目名——调用方持有的是切走前的旧项目名。这一轮就算跑起来也过不了
+            // 当前项目核对，写不进任何东西：立即结算为 "cancelled"，不占用名额。否则
+            // 当前项目自己的刷新会被挤掉，而设计上只保留一个名额、不会为它补跑，当前
+            // 项目的数据一轮都不会被拉取（首屏则永远停在加载态）。
+            const { currentProjectName } = get();
+            if (currentProjectName !== null && queuedName === currentProjectName && name !== currentProjectName) {
+              resolve("cancelled");
+              return;
+            }
             const supersededResolvers = queuedResolvers;
             queuedResolvers = [];
             queuedKeys = [];


### PR DESCRIPTION
Closes #1390

## 改动

项目详情这一份数据此前由两个取消域分管：首屏加载在 `router.tsx` 自建 `AbortController` 直调 `API.getProject`，刷新走 `projects-store.ts` 的 `projectScope`。本 PR 把首屏加载收编进 `refreshProject`，`router.tsx` 不再自建 controller，与 `.claude/rules/frontend-async-race.md` 的目标模式（同一份数据一个取消域 + store action 在途合并）对齐。

首屏 effect 改为先 `setCurrentProject(projectName, null)` 落名（同时轮换取消域），再调 `refreshProject`；按返回的判别式联合结算 loading，`"cancelled"` 时不动共享状态。

## 本地审查发现与修复

收编到共享的单槽排队通道后暴露出两条会让首屏数据永久加载不出来的路径——持切走前旧项目名的调用方（写操作完成后的刷新、SSE，`projects-store.ts` 注释中已记载这类调用方真实存在）会干掉当前项目自己的那一轮，而它自己又必然过不了当前项目核对、写不进任何数据：

1. **顶替在途轮**：当前项目 B 的首屏轮在途时，旧项目名 A 排队 → B 的响应被 `supersededByOtherProject` 判为「即将被取代」而丢弃。
2. **夺走排队名额**：B 的首屏刷新正在排队时，旧项目名 A 到达 → 排队只有一个名额且「取最新 name」，B 被立即结算为 `"cancelled"` 且不会补跑。

两者结果相同：新项目的详情一轮都不会被拉取，`projectDetailLoading` 永远回落不了。修法是按「谁真的有资格写入」裁决让位与排队名额——排队者只有在它已是当前项目，或 store 尚未建立任何项目（bootstrap，取最新意图）时才更有资格。两条路径均先补回归测试复现、再修复。

另外补充了 issue 验收标准第 2 条要求的路由层快速切换回归测试：A → B 切换后 A 的响应才落定，通过订阅 store 断言 A 的数据一次都没有落进去（只断言最终态无法证伪迟到覆盖——A 的数据即便写进去也会被随后跑完的 B 盖回去）。

## 验证

- `pnpm lint`、`pnpm check`（typecheck + 128 文件 / 1283 用例）全绿，已 rebase 到最新 main 后重跑。
- 19 条既有 `projects-store` 用例与 13 条既有 `router` 用例全部**未经修改**保持绿，修复未放宽任何既有断言。
- 新增的快速切换用例做过突变验证：临时去掉 store 写入门槛后该用例转红。
- `router.test.tsx` 中「离开项目会中止在途的详情请求」的 mock 由「永不 settle」改为「abort 时 reject」，还原真实 `fetch` + `AbortSignal` 语义。已实测：沿用旧 mock 会让共享的在途标志被永久卡死，导致同文件后一条用例的 `projectDetailLoading` 停在 `true` 而失败。该用例自身断言（`aborted` 由 false 变 true）未改动。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化快速切换项目时的数据加载，避免旧项目的迟到响应覆盖新项目首屏数据。
  * 修复离开项目后在途详情请求无法正确取消、导致加载状态卡住的问题。
  * 改善项目详情加载的并发/队列让位逻辑，防止过期请求影响当前项目数据。
  * 直达深链时保持“加载中”占位，避免详情未就绪时渲染可交互的空内容。
* **新增功能**
  * 新增“加载项目失败”提示文案（支持消息占位），提升加载失败可见性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->