### PR TITLE
fix(video): 生成入队从点击那一刻起就占用资源，请求失败自动解除

### DIFF
--- a/frontend/src/actions/generation.test.ts
+++ b/frontend/src/actions/generation.test.ts
@@ -1,13 +1,19 @@
 /**
  * 入队动作层测试：spy API 静态方法 + 真实 zustand store，
- * 验证「API 调用 → 乐观打标 → toast → 返回值归一化」的固定封装，
- * 以及 deduped=true 统一 info 提示与失败上抛不打标。
+ * 验证「乐观打标（请求发出前）→ API 调用 → 兑现/回滚 → toast → 返回值归一化」的固定封装，
+ * 以及 deduped=true 统一 info 提示与失败回滚。
+ *
+ * 占用一律按 selector 断言而非比对标记 key 的字面量——key 编码是 store 内部实现。
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { API } from "@/api";
 import i18n from "@/i18n";
 import { useAppStore } from "@/stores/app-store";
-import { useTasksStore } from "@/stores/tasks-store";
+import {
+  selectActiveResourceIds,
+  selectHasActiveTaskForScriptFile,
+  useTasksStore,
+} from "@/stores/tasks-store";
 import {
   enqueueCharacter,
   enqueueEpisodeNarration,
@@ -25,12 +31,27 @@ import {
 
 const SINGLE_OK = { success: true, task_id: "t1", deduped: false, message: "ok" };
 
-function optimisticKeys(): string[] {
-  return Array.from(useTasksStore.getState().optimisticActive);
+/** 该资源是否被占用（真实任务行或乐观标记）。 */
+function occupied(projectName: string, resourceKind: string, resourceId: string): boolean {
+  const { tasks, optimisticActive } = useTasksStore.getState();
+  return selectActiveResourceIds(tasks, resourceKind, projectName, optimisticActive).has(resourceId);
 }
 
-function optimisticScriptFileKeys(): string[] {
-  return Array.from(useTasksStore.getState().optimisticActiveScriptFile);
+/** 该剧集在指定 taskType 下是否被占用。 */
+function scriptFileOccupied(projectName: string, taskType: string, scriptFile: string): boolean {
+  const { tasks, optimisticActiveScriptFile } = useTasksStore.getState();
+  return selectHasActiveTaskForScriptFile(
+    tasks,
+    taskType,
+    scriptFile,
+    projectName,
+    optimisticActiveScriptFile,
+  );
+}
+
+function markCounts(): { resource: number; scriptFile: number } {
+  const s = useTasksStore.getState();
+  return { resource: s.optimisticActive.size, scriptFile: s.optimisticActiveScriptFile.size };
 }
 
 beforeEach(() => {
@@ -49,11 +70,28 @@ describe("enqueueStoryboard", () => {
     const res = await enqueueStoryboard("demo", "seg-1", "img prompt", "episode_1.json");
 
     expect(spy).toHaveBeenCalledWith("demo", "seg-1", "img prompt", "episode_1.json");
-    expect(optimisticKeys()).toEqual(["demo\0storyboard\0seg-1\0storyboard\0"]);
+    expect(occupied("demo", "storyboard", "seg-1")).toBe(true);
     const toast = useAppStore.getState().toast;
     expect(toast?.text).toBe(i18n.t("dashboard:storyboard_task_submitted_toast", { id: "seg-1" }));
     expect(toast?.tone).toBe("success");
     expect(res).toEqual({ taskIds: ["t1"], deduped: false });
+  });
+
+  it("请求发出前就完成打标，往返窗口内资源即被判为占用", async () => {
+    // 打标若等到 API 返回才落，这段往返里资源判定为空闲，各调用方就得自备在途 ref
+    let release: (v: typeof SINGLE_OK) => void = () => {};
+    vi.spyOn(API, "generateStoryboard").mockReturnValue(
+      new Promise<typeof SINGLE_OK>((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    const pending = enqueueStoryboard("demo", "seg-1", "p", "episode_1.json");
+    expect(occupied("demo", "storyboard", "seg-1")).toBe(true);
+
+    release(SINGLE_OK);
+    await pending;
+    expect(occupied("demo", "storyboard", "seg-1")).toBe(true);
   });
 
   it("deduped=true 时改弹统一 info 提示，仍打标并透出 deduped", async () => {
@@ -64,16 +102,17 @@ describe("enqueueStoryboard", () => {
     const toast = useAppStore.getState().toast;
     expect(toast?.text).toBe(i18n.t("dashboard:enqueue_deduped_toast"));
     expect(toast?.tone).toBe("info");
-    expect(optimisticKeys()).toHaveLength(1);
+    expect(occupied("demo", "storyboard", "seg-1")).toBe(true);
     expect(res.deduped).toBe(true);
   });
 
-  it("API 失败时向上抛，不打标也不弹 toast", async () => {
+  it("API 失败时向上抛并回滚乐观标记，不弹 toast", async () => {
     vi.spyOn(API, "generateStoryboard").mockRejectedValue(new Error("boom"));
 
     await expect(enqueueStoryboard("demo", "seg-1", "p", "episode_1.json")).rejects.toThrow("boom");
 
-    expect(optimisticKeys()).toEqual([]);
+    expect(occupied("demo", "storyboard", "seg-1")).toBe(false);
+    expect(markCounts().resource).toBe(0);
     expect(useAppStore.getState().toast).toBeNull();
   });
 });
@@ -84,45 +123,63 @@ describe("单资源入队动作的乐观标记 kind / taskType", () => {
       label: "video",
       run: () => enqueueVideo("demo", "seg-1", "p", "episode_1.json", 4),
       method: "generateVideo" as const,
-      key: "demo\0video\0seg-1\0video\0",
+      kind: "video",
+      resourceId: "seg-1",
     },
     {
       label: "tts",
       run: () => enqueueNarration("demo", "seg-1", "episode_1.json"),
       method: "generateNarrationAudio" as const,
-      key: "demo\0tts\0seg-1\0tts\0",
+      kind: "tts",
+      resourceId: "seg-1",
     },
     {
       label: "character",
       run: () => enqueueCharacter("demo", "Hero", "p"),
       method: "generateCharacter" as const,
-      key: "demo\0character\0Hero\0character\0",
+      kind: "character",
+      resourceId: "Hero",
     },
     {
       label: "scene",
       run: () => enqueueScene("demo", "Temple", "p"),
       method: "generateProjectScene" as const,
-      key: "demo\0scene\0Temple\0scene\0",
+      kind: "scene",
+      resourceId: "Temple",
     },
     {
       label: "prop",
       run: () => enqueueProp("demo", "Sword", "p"),
       method: "generateProjectProp" as const,
-      key: "demo\0prop\0Sword\0prop\0",
+      kind: "prop",
+      resourceId: "Sword",
     },
     {
       label: "product",
       run: () => enqueueProduct("demo", "Phone", "p"),
       method: "generateProjectProduct" as const,
-      key: "demo\0product\0Phone\0product\0",
+      kind: "product",
+      resourceId: "Phone",
     },
-  ])("$label：成功后按资源类型打标并归一化 task_id", async ({ run, method, key }) => {
+  ])("$label：成功后按资源类型打标并归一化 task_id", async ({ run, method, kind, resourceId }) => {
     vi.spyOn(API, method).mockResolvedValue(SINGLE_OK);
 
     const res = await run();
 
-    expect(optimisticKeys()).toEqual([key]);
+    expect(occupied("demo", kind, resourceId)).toBe(true);
+    expect(markCounts().resource).toBe(1);
     expect(res).toEqual({ taskIds: ["t1"], deduped: false });
+  });
+
+  it.each([
+    { label: "video", run: () => enqueueVideo("demo", "seg-1", "p", "episode_1.json", 4), method: "generateVideo" as const },
+    { label: "character", run: () => enqueueCharacter("demo", "Hero", "p"), method: "generateCharacter" as const },
+  ])("$label：请求失败时回滚，不留下占用", async ({ run, method }) => {
+    vi.spyOn(API, method).mockRejectedValue(new Error("boom"));
+
+    await expect(run()).rejects.toThrow("boom");
+
+    expect(markCounts()).toEqual({ resource: 0, scriptFile: 0 });
   });
 });
 
@@ -140,8 +197,7 @@ describe("enqueueEpisodeNarration", () => {
     expect(useAppStore.getState().toast?.text).toBe(
       i18n.t("dashboard:narration_batch_submitted_toast", { count: 2 }),
     );
-    expect(optimisticKeys()).toEqual([]);
-    expect(optimisticScriptFileKeys()).toEqual([]);
+    expect(markCounts()).toEqual({ resource: 0, scriptFile: 0 });
     expect(res).toEqual({ taskIds: ["t1", "t2"], deduped: false });
   });
 
@@ -172,7 +228,8 @@ describe("enqueueImageEdit", () => {
       scriptFile: "episode_1.json",
     });
 
-    expect(optimisticKeys()).toEqual(["demo\0storyboard\0seg-1\0image_edit\0"]);
+    // 编辑任务与目标资源的生成任务同槽：按 storyboard 归槽而非 image_edit
+    expect(occupied("demo", "storyboard", "seg-1")).toBe(true);
     expect(useAppStore.getState().toast?.text).toBe("已提交图片编辑");
     expect(res).toEqual({ taskIds: ["t1"], deduped: false });
   });
@@ -190,12 +247,12 @@ describe("enqueueGrid", () => {
 
     const res = await enqueueGrid("demo", 1, "episode_1.json");
 
-    expect(optimisticScriptFileKeys()).toEqual(["demo\0grid\0episode_1.json\0"]);
+    expect(scriptFileOccupied("demo", "grid", "episode_1.json")).toBe(true);
     expect(useAppStore.getState().toast?.text).toBe("已入队 1 个宫格");
     expect(res).toEqual({ taskIds: ["t1"], deduped: false });
   });
 
-  it("task_ids 为空时不打标（无任务落库，标记会永久残留）", async () => {
+  it("task_ids 为空时回滚标记（无任务落库，标记会永久残留）", async () => {
     vi.spyOn(API, "generateGrid").mockResolvedValue({
       success: true,
       grid_ids: [],
@@ -206,30 +263,40 @@ describe("enqueueGrid", () => {
 
     await enqueueGrid("demo", 1, "episode_1.json", ["S9"]);
 
-    expect(optimisticScriptFileKeys()).toEqual([]);
+    expect(markCounts().scriptFile).toBe(0);
+    expect(scriptFileOccupied("demo", "grid", "episode_1.json")).toBe(false);
   });
 });
 
 describe("enqueueGridRegenerate", () => {
-  it("成功时静默（面板内已有状态反馈），有 scriptFile 则打标", async () => {
+  it("成功时静默（面板内已有状态反馈），宫格与所属剧集同时打标", async () => {
     vi.spyOn(API, "regenerateGrid").mockResolvedValue({ success: true, task_id: "t1", deduped: false });
 
     const res = await enqueueGridRegenerate("demo", "grid-1", "episode_1.json");
 
-    expect(optimisticScriptFileKeys()).toEqual(["demo\0grid\0episode_1.json\0"]);
+    expect(occupied("demo", "grid", "grid-1")).toBe(true);
+    expect(scriptFileOccupied("demo", "grid", "episode_1.json")).toBe(true);
     expect(useAppStore.getState().toast).toBeNull();
     expect(res).toEqual({ taskIds: ["t1"], deduped: false });
   });
 
-  it("scriptFile 为 null 时不打标；deduped=true 仍弹统一 info 提示", async () => {
+  it("scriptFile 为 null 时只打宫格粒度标记；deduped=true 仍弹统一 info 提示", async () => {
     vi.spyOn(API, "regenerateGrid").mockResolvedValue({ success: true, task_id: "t1", deduped: true });
 
     await enqueueGridRegenerate("demo", "grid-1", null);
 
-    expect(optimisticScriptFileKeys()).toEqual([]);
+    expect(markCounts()).toEqual({ resource: 1, scriptFile: 0 });
     const toast = useAppStore.getState().toast;
     expect(toast?.text).toBe(i18n.t("dashboard:enqueue_deduped_toast"));
     expect(toast?.tone).toBe("info");
+  });
+
+  it("请求失败时两个粒度的标记一起回滚", async () => {
+    vi.spyOn(API, "regenerateGrid").mockRejectedValue(new Error("boom"));
+
+    await expect(enqueueGridRegenerate("demo", "grid-1", "episode_1.json")).rejects.toThrow("boom");
+
+    expect(markCounts()).toEqual({ resource: 0, scriptFile: 0 });
   });
 });
 
@@ -239,7 +306,7 @@ describe("enqueueReferenceVideoUnit", () => {
 
     const res = await enqueueReferenceVideoUnit("demo", 1, "E1U1");
 
-    expect(optimisticKeys()).toEqual(["demo\0reference_video\0E1U1\0reference_video\0"]);
+    expect(occupied("demo", "reference_video", "E1U1")).toBe(true);
     const toast = useAppStore.getState().toast;
     expect(toast?.text).toBe(i18n.t("dashboard:reference_generate_queued"));
     expect(toast?.tone).toBe("info");

--- a/frontend/src/actions/generation.test.ts
+++ b/frontend/src/actions/generation.test.ts
@@ -115,6 +115,19 @@ describe("enqueueStoryboard", () => {
     expect(markCounts().resource).toBe(0);
     expect(useAppStore.getState().toast).toBeNull();
   });
+
+  it("响应体形状意外时同样回滚，不留下永不清除的在途标记", async () => {
+    // 在途标记不被任何轮询写回清除，故兑现前的异常路径（如 204 让 API.request 返回
+    // undefined、随后取 task_id 抛 TypeError）也必须回滚，否则资源锁死到刷新为止。
+    vi.spyOn(API, "generateStoryboard").mockResolvedValue(
+      undefined as unknown as Awaited<ReturnType<typeof API.generateStoryboard>>,
+    );
+
+    await expect(enqueueStoryboard("demo", "seg-1", "p", "episode_1.json")).rejects.toThrow();
+
+    expect(occupied("demo", "storyboard", "seg-1")).toBe(false);
+    expect(markCounts().resource).toBe(0);
+  });
 });
 
 describe("单资源入队动作的乐观标记 kind / taskType", () => {

--- a/frontend/src/actions/generation.ts
+++ b/frontend/src/actions/generation.ts
@@ -2,21 +2,22 @@
  * 入队动作层：所有生成类入队操作的唯一入口。
  *
  * 每个动作内部固定封装三件事：
- * 1. 调用对应 API 入队端点；
- * 2. 成功后在 tasks-store 打乐观占用标记（入队成功到 SSE 轮询把真实任务行
- *    写进 store 之间有 ~3s 空窗，期间同资源的其它入口会误判为空闲）；
+ * 1. 在**请求发出前**于 tasks-store 打乐观占用标记，请求失败即回滚，成功则用后端
+ *    返回的 task_id 兑现（见 {@link submit}）——占用态因此从点击那一刻起就成立，
+ *    调用方无须自备「请求在途」标记来覆盖网络往返窗口；
+ * 2. 调用对应 API 入队端点；
  * 3. 弹提示：后端 deduped=true（同资源任务已在处理中，本次未新建）时统一
  *    弹 info 提示，否则沿用各操作原有的成功文案。
  *
- * 失败一律向上抛，由调用方决定错误提示与回滚副作用。返回值统一归一化为
- * EnqueueResult，屏蔽各端点 task_id / task_ids 的形状差异。
+ * 失败一律向上抛，由调用方决定错误提示。返回值统一归一化为 EnqueueResult，
+ * 屏蔽各端点 task_id / task_ids 的形状差异。
  *
  * 组件禁止绕过本层直调入队类 API 方法（ESLint no-restricted-syntax 强制）。
  */
 import { API } from "@/api";
 import i18n from "@/i18n";
 import { useAppStore } from "@/stores/app-store";
-import { useTasksStore } from "@/stores/tasks-store";
+import { useTasksStore, type OptimisticHandle } from "@/stores/tasks-store";
 
 export interface EnqueueResult {
   taskIds: string[];
@@ -40,14 +41,64 @@ function notifyEnqueued(
   }
 }
 
+/** 资源粒度乐观标记的简写（请求发出前调用）。 */
+function markResource(
+  projectName: string,
+  resourceKind: string,
+  resourceId: string,
+  pendingTaskType: string,
+): OptimisticHandle {
+  return useTasksStore
+    .getState()
+    .beginOptimisticActive(projectName, resourceKind, resourceId, pendingTaskType);
+}
+
+/** scriptFile 粒度乐观标记的简写（请求发出前调用）。 */
+function markScriptFile(projectName: string, taskType: string, scriptFile: string): OptimisticHandle {
+  return useTasksStore.getState().beginOptimisticActiveForScriptFile(projectName, taskType, scriptFile);
+}
+
+/**
+ * 入队请求的统一骨架：标记已在 `marks` 里打好，此处只负责发请求并按结果兑现——
+ * 失败全部回滚后原样抛出，成功用 `taskIdsOf` 取出的 task_id 兑现（为空即回滚，
+ * 后端没建任务行时标记永远等不到真实行）。
+ */
+async function submit<T>(
+  marks: readonly OptimisticHandle[],
+  request: () => Promise<T>,
+  taskIdsOf: (res: T) => string[],
+): Promise<T> {
+  let res: T;
+  try {
+    res = await request();
+  } catch (e) {
+    for (const m of marks) m.rollback();
+    throw e;
+  }
+  const taskIds = taskIdsOf(res);
+  for (const m of marks) m.settle(taskIds);
+  return res;
+}
+
+function oneTaskId(res: { task_id: string }): string[] {
+  return [res.task_id];
+}
+
+function manyTaskIds(res: { task_ids: string[] }): string[] {
+  return res.task_ids;
+}
+
 export async function enqueueStoryboard(
   projectName: string,
   segmentId: string,
   prompt: string | Record<string, unknown>,
   scriptFile: string,
 ): Promise<EnqueueResult> {
-  const res = await API.generateStoryboard(projectName, segmentId, prompt, scriptFile);
-  useTasksStore.getState().markOptimisticActive(projectName, "storyboard", segmentId, "storyboard");
+  const res = await submit(
+    [markResource(projectName, "storyboard", segmentId, "storyboard")],
+    () => API.generateStoryboard(projectName, segmentId, prompt, scriptFile),
+    oneTaskId,
+  );
   notifyEnqueued(res.deduped, i18n.t("dashboard:storyboard_task_submitted_toast", { id: segmentId }));
   return { taskIds: [res.task_id], deduped: res.deduped };
 }
@@ -59,8 +110,11 @@ export async function enqueueVideo(
   scriptFile: string,
   durationSeconds?: number,
 ): Promise<EnqueueResult> {
-  const res = await API.generateVideo(projectName, segmentId, prompt, scriptFile, durationSeconds);
-  useTasksStore.getState().markOptimisticActive(projectName, "video", segmentId, "video");
+  const res = await submit(
+    [markResource(projectName, "video", segmentId, "video")],
+    () => API.generateVideo(projectName, segmentId, prompt, scriptFile, durationSeconds),
+    oneTaskId,
+  );
   notifyEnqueued(res.deduped, i18n.t("dashboard:video_task_submitted_toast", { id: segmentId }));
   return { taskIds: [res.task_id], deduped: res.deduped };
 }
@@ -70,8 +124,11 @@ export async function enqueueNarration(
   segmentId: string,
   scriptFile: string,
 ): Promise<EnqueueResult> {
-  const res = await API.generateNarrationAudio(projectName, segmentId, scriptFile);
-  useTasksStore.getState().markOptimisticActive(projectName, "tts", segmentId, "tts");
+  const res = await submit(
+    [markResource(projectName, "tts", segmentId, "tts")],
+    () => API.generateNarrationAudio(projectName, segmentId, scriptFile),
+    oneTaskId,
+  );
   notifyEnqueued(res.deduped, i18n.t("dashboard:narration_task_submitted_toast", { id: segmentId }));
   return { taskIds: [res.task_id], deduped: res.deduped };
 }
@@ -97,8 +154,11 @@ export async function enqueueCharacter(
   name: string,
   prompt: string,
 ): Promise<EnqueueResult> {
-  const res = await API.generateCharacter(projectName, name, prompt);
-  useTasksStore.getState().markOptimisticActive(projectName, "character", name, "character");
+  const res = await submit(
+    [markResource(projectName, "character", name, "character")],
+    () => API.generateCharacter(projectName, name, prompt),
+    oneTaskId,
+  );
   notifyEnqueued(res.deduped, i18n.t("dashboard:character_task_submitted_toast", { name }));
   return { taskIds: [res.task_id], deduped: res.deduped };
 }
@@ -108,8 +168,11 @@ export async function enqueueScene(
   name: string,
   prompt: string,
 ): Promise<EnqueueResult> {
-  const res = await API.generateProjectScene(projectName, name, prompt);
-  useTasksStore.getState().markOptimisticActive(projectName, "scene", name, "scene");
+  const res = await submit(
+    [markResource(projectName, "scene", name, "scene")],
+    () => API.generateProjectScene(projectName, name, prompt),
+    oneTaskId,
+  );
   notifyEnqueued(res.deduped, i18n.t("dashboard:scene_task_submitted_toast", { name }));
   return { taskIds: [res.task_id], deduped: res.deduped };
 }
@@ -119,8 +182,11 @@ export async function enqueueProp(
   name: string,
   prompt: string,
 ): Promise<EnqueueResult> {
-  const res = await API.generateProjectProp(projectName, name, prompt);
-  useTasksStore.getState().markOptimisticActive(projectName, "prop", name, "prop");
+  const res = await submit(
+    [markResource(projectName, "prop", name, "prop")],
+    () => API.generateProjectProp(projectName, name, prompt),
+    oneTaskId,
+  );
   notifyEnqueued(res.deduped, i18n.t("dashboard:prop_task_submitted_toast", { name }));
   return { taskIds: [res.task_id], deduped: res.deduped };
 }
@@ -130,8 +196,11 @@ export async function enqueueProduct(
   name: string,
   prompt: string,
 ): Promise<EnqueueResult> {
-  const res = await API.generateProjectProduct(projectName, name, prompt);
-  useTasksStore.getState().markOptimisticActive(projectName, "product", name, "product");
+  const res = await submit(
+    [markResource(projectName, "product", name, "product")],
+    () => API.generateProjectProduct(projectName, name, prompt),
+    oneTaskId,
+  );
   notifyEnqueued(res.deduped, i18n.t("dashboard:product_task_submitted_toast", { name }));
   return { taskIds: [res.task_id], deduped: res.deduped };
 }
@@ -145,10 +214,13 @@ export async function enqueueImageEdit(
     scriptFile?: string | null;
   },
 ): Promise<EnqueueResult> {
-  const res = await API.editImage(projectName, params);
   // image_edit 与生成任务共享同一资源槽位：kind 按被编辑资源类型归槽，
   // pendingTaskType 固定 image_edit，与 taskResourceKind 的归一化保持一致。
-  useTasksStore.getState().markOptimisticActive(projectName, params.resourceType, params.resourceId, "image_edit");
+  const res = await submit(
+    [markResource(projectName, params.resourceType, params.resourceId, "image_edit")],
+    () => API.editImage(projectName, params),
+    oneTaskId,
+  );
   notifyEnqueued(res.deduped, res.message);
   return { taskIds: [res.task_id], deduped: res.deduped };
 }
@@ -159,12 +231,13 @@ export async function enqueueGrid(
   scriptFile: string,
   sceneIds?: string[],
 ): Promise<EnqueueResult> {
-  const res = await API.generateGrid(projectName, episode, scriptFile, sceneIds);
-  // task_ids 可能为空数组（如 scene_ids 过滤后无匹配分组）：此时后端不会产生
-  // 任何任务行，乐观标记将永远等不到真实任务落库来解除，需在打标前排除。
-  if (res.task_ids.length > 0) {
-    useTasksStore.getState().markOptimisticActiveForScriptFile(projectName, "grid", scriptFile);
-  }
+  // task_ids 可能为空数组（如 scene_ids 过滤后无匹配分组）：此时后端不产生任何任务行，
+  // settle([]) 会把标记回滚掉，不留下永远等不到真实行的残留。
+  const res = await submit(
+    [markScriptFile(projectName, "grid", scriptFile)],
+    () => API.generateGrid(projectName, episode, scriptFile, sceneIds),
+    manyTaskIds,
+  );
   notifyEnqueued(res.deduped, res.message);
   return { taskIds: res.task_ids, deduped: res.deduped };
 }
@@ -174,11 +247,14 @@ export async function enqueueGridRegenerate(
   gridId: string,
   scriptFile: string | null,
 ): Promise<EnqueueResult> {
-  const res = await API.regenerateGrid(projectName, gridId);
-  useTasksStore.getState().markOptimisticActive(projectName, "grid", gridId, "grid");
-  if (scriptFile) {
-    useTasksStore.getState().markOptimisticActiveForScriptFile(projectName, "grid", scriptFile);
-  }
+  const res = await submit(
+    [
+      markResource(projectName, "grid", gridId, "grid"),
+      ...(scriptFile ? [markScriptFile(projectName, "grid", scriptFile)] : []),
+    ],
+    () => API.regenerateGrid(projectName, gridId),
+    oneTaskId,
+  );
   // 重生成入口成功时静默（面板内已有状态反馈），仅 deduped 时弹提示。
   notifyEnqueued(res.deduped, null);
   return { taskIds: [res.task_id], deduped: res.deduped };
@@ -189,8 +265,11 @@ export async function enqueueReferenceVideoUnit(
   episode: number,
   unitId: string,
 ): Promise<EnqueueResult> {
-  const res = await API.generateReferenceVideoUnit(projectName, episode, unitId);
-  useTasksStore.getState().markOptimisticActive(projectName, "reference_video", unitId, "reference_video");
+  const res = await submit(
+    [markResource(projectName, "reference_video", unitId, "reference_video")],
+    () => API.generateReferenceVideoUnit(projectName, episode, unitId),
+    oneTaskId,
+  );
   notifyEnqueued(res.deduped, i18n.t("dashboard:reference_generate_queued"), "info");
   return { taskIds: [res.task_id], deduped: res.deduped };
 }

--- a/frontend/src/actions/generation.ts
+++ b/frontend/src/actions/generation.ts
@@ -62,22 +62,24 @@ function markScriptFile(projectName: string, taskType: string, scriptFile: strin
  * 入队请求的统一骨架：标记已在 `marks` 里打好，此处只负责发请求并按结果兑现——
  * 失败全部回滚后原样抛出，成功用 `taskIdsOf` 取出的 task_id 兑现（为空即回滚，
  * 后端没建任务行时标记永远等不到真实行）。
+ *
+ * 响应解析（`taskIdsOf`）与兑现同在 try 内：在途标记不被任何轮询写回清除，因此
+ * 兑现前的任何异常路径都必须回滚，否则标记会残留到页面刷新为止。
  */
 async function submit<T>(
   marks: readonly OptimisticHandle[],
   request: () => Promise<T>,
   taskIdsOf: (res: T) => string[],
 ): Promise<T> {
-  let res: T;
   try {
-    res = await request();
+    const res = await request();
+    const taskIds = taskIdsOf(res);
+    for (const m of marks) m.settle(taskIds);
+    return res;
   } catch (e) {
     for (const m of marks) m.rollback();
     throw e;
   }
-  const taskIds = taskIdsOf(res);
-  for (const m of marks) m.settle(taskIds);
-  return res;
 }
 
 function oneTaskId(res: { task_id: string }): string[] {

--- a/frontend/src/components/canvas/reference/AdReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/AdReferenceVideoCanvas.tsx
@@ -14,9 +14,8 @@ import { Clock, Layers, RefreshCw, Scissors, Sparkles } from "lucide-react";
 import { API } from "@/api";
 import { enqueueReferenceVideoUnit } from "@/actions/generation";
 import { EpisodeHeader } from "./EpisodeHeader";
-import { StatusBadge } from "./unit-status";
+import { StatusBadge, deriveUnitStatus } from "./unit-status";
 import {
-  isActiveStatus,
   selectActiveResourceIds,
   useActiveResourceIds,
   useLatestTasksByResource,
@@ -108,16 +107,14 @@ export function AdReferenceVideoCanvas({
   const statusMap = useMemo<Record<string, UnitStatus>>(() => {
     const map: Record<string, UnitStatus> = {};
     for (const { unit } of hydrated) {
-      const clip = unit.generated_assets?.video_clip ?? null;
-      let st: UnitStatus = clip ? "ready" : "pending";
-      const queueRow = tasksByUnit.get(unit.unit_id);
-      if (queueRow && isActiveStatus(queueRow.status)) st = "running";
-      // 「最新行胜出」已保证 queueRow 是该 unit 最新一次生成尝试：重新生成失败时
-      // 最新行必然是这次失败，不能被旧成片压成 ready，否则失败原因无处可见。
-      else if (queueRow?.status === "failed") st = "failed";
-      // 乐观窗口：真实任务行尚未落库时按占用集显示 running。
-      else if (!queueRow && busyUnitIds.has(unit.unit_id)) st = "running";
-      map[unit.unit_id] = st;
+      map[unit.unit_id] = deriveUnitStatus({
+        hasClip: Boolean(unit.generated_assets?.video_clip),
+        queueRow: tasksByUnit.get(unit.unit_id),
+        busy: busyUnitIds.has(unit.unit_id),
+        // 本画布不提供成片上传入口（ADR 0033 的参考直出路径）：成片只能来自生成，
+        // 最新行失败即本次尝试失败，不能被旧成片压成 ready。
+        supportsManualUpload: false,
+      });
     }
     return map;
   }, [hydrated, tasksByUnit, busyUnitIds]);

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
@@ -436,6 +436,34 @@ describe("ReferenceVideoCanvas", () => {
     expect(uploadSpy).not.toHaveBeenCalled();
   });
 
+  // 上传不产生任务行，进不了 tasks-store 占用集，故由画布自记。它必须进入提交时刻的
+  // 复核口径：否则上传在途期间批量生成仍会入队同一 unit，两条路径并发写同一个成片文件。
+  it("批量生成跳过上传在途的 unit", async () => {
+    vi.spyOn(API, "listReferenceVideoUnits").mockResolvedValue({
+      units: [mkUnit("E1U1"), mkUnit("E1U2")],
+    });
+    // 上传挂起不 resolve，模拟「请求已发出、尚未落盘」的窗口
+    vi.spyOn(API, "uploadReferenceUnitVideo").mockReturnValue(new Promise(() => {}) as never);
+    const genSpy = vi
+      .spyOn(API, "generateReferenceVideoUnit")
+      .mockResolvedValue({ task_id: "t9", deduped: false } as never);
+    vi.mocked(useActiveResourceIds).mockReturnValue(new Set());
+    vi.mocked(useLatestTasksByResource).mockReturnValue(new Map());
+
+    const { container } = render(<ReferenceVideoCanvas projectName="proj" episode={1} />);
+    const batch = await screen.findByRole("button", { name: /Batch generate videos|批量生成视频/ });
+    await waitFor(() => expect(batch).not.toBeDisabled());
+
+    // 选中项默认是 E1U1，其预览面板的上传入口即针对该 unit
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).not.toBeNull();
+    fireEvent.change(input!, { target: { files: [new File(["x"], "clip.mp4", { type: "video/mp4" })] } });
+
+    fireEvent.click(batch);
+    await waitFor(() => expect(genSpy).toHaveBeenCalledTimes(1));
+    expect(genSpy).toHaveBeenCalledWith("proj", 1, "E1U2");
+  });
+
   it("没有待生成 unit 时批量生成按钮禁用", async () => {
     // 唯一的 unit 已有成片：statusMap 为 ready，批量入口无作用对象
     const ready = mkUnit("E1U1");

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
@@ -49,6 +49,21 @@ function mkUnit(id: string, shotText = "x"): ReferenceVideoUnit {
   };
 }
 
+// 单元预览面板的生成 CTA。锚定行首把批量入口「批量生成视频」排除在外——两者都含
+// 「生成视频」，不锚定会按 DOM 顺序先匹配到批量按钮，测到的就不是这条提交路径。
+const UNIT_GENERATE_CTA = /^(Generate video|生成视频)/;
+
+function runningTask(unitId: string) {
+  return {
+    task_id: `task-${unitId}`,
+    project_name: "proj",
+    task_type: "reference_video",
+    resource_id: unitId,
+    status: "running",
+    updated_at: "2026-06-12T10:00:00Z",
+  };
+}
+
 const STUB_PROJECT: ProjectData = {
   title: "p",
   content_mode: "narration",
@@ -356,28 +371,81 @@ describe("ReferenceVideoCanvas", () => {
 
     render(<ReferenceVideoCanvas projectName="proj" episode={1} />);
 
-    const generate = await screen.findByRole("button", { name: /Generate video|生成视频/ });
+    // 锚定行首，避免匹配到批量入口「批量生成视频」——它是另一条提交路径（见下一个用例）
+    const generate = await screen.findByRole("button", { name: UNIT_GENERATE_CTA });
     expect(generate).not.toBeDisabled();
 
     // 渲染之后、点击之前，另一入口（Agent 入队 / SSE 落库）已占用同一 unit
     act(() => {
-      useTasksStore.setState({
-        tasks: [
-          {
-            task_id: "t1",
-            project_name: "proj",
-            task_type: "reference_video",
-            resource_id: "E1U1",
-            status: "running",
-            updated_at: "2026-06-12T10:00:00Z",
-          },
-        ] as never,
-      });
+      useTasksStore.setState({ tasks: [runningTask("E1U1")] as never });
     });
 
     fireEvent.click(generate);
     await waitFor(() => expect(pushToast).toHaveBeenCalled());
     expect(genSpy).not.toHaveBeenCalled();
+  });
+
+  // 批量入口的保护对象是「全部待生成 unit」：占用的 unit 静默跳过（逐个报错只会刷屏），
+  // 没有待生成 unit 时按钮直接禁用——此前禁用条件只看当前选中 unit，与保护对象无关。
+  it("批量生成跳过提交时刻已被占用的 unit，不重复入队", async () => {
+    vi.spyOn(API, "listReferenceVideoUnits").mockResolvedValue({
+      units: [mkUnit("E1U1"), mkUnit("E1U2")],
+    });
+    const genSpy = vi
+      .spyOn(API, "generateReferenceVideoUnit")
+      .mockResolvedValue({ task_id: "t9", deduped: false } as never);
+    vi.mocked(useActiveResourceIds).mockReturnValue(new Set());
+    vi.mocked(useLatestTasksByResource).mockReturnValue(new Map());
+
+    render(<ReferenceVideoCanvas projectName="proj" episode={1} />);
+    const batch = await screen.findByRole("button", { name: /Batch generate videos|批量生成视频/ });
+    await waitFor(() => expect(batch).not.toBeDisabled());
+
+    // 渲染之后、点击之前，E1U1 已被别的入口占用；E1U2 仍空闲
+    act(() => {
+      useTasksStore.setState({ tasks: [runningTask("E1U1")] as never });
+    });
+
+    fireEvent.click(batch);
+    await waitFor(() => expect(genSpy).toHaveBeenCalledTimes(1));
+    expect(genSpy).toHaveBeenCalledWith("proj", 1, "E1U2");
+  });
+
+  // 上传与生成回写同一个成片文件：文件选择对话框打开期间同一 unit 可能已被占用，
+  // 按钮渲染期的禁用态挡不住这段窗口，提交时刻须再用 getState() 新鲜读复核一次。
+  it("上传确认时刻复核占用态，命中即拒绝并提示", async () => {
+    vi.spyOn(API, "listReferenceVideoUnits").mockResolvedValue({ units: [mkUnit("E1U1")] });
+    const uploadSpy = vi.spyOn(API, "uploadReferenceUnitVideo");
+    const pushToast = vi.spyOn(useAppStore.getState(), "pushToast");
+    vi.mocked(useActiveResourceIds).mockReturnValue(new Set());
+    vi.mocked(useLatestTasksByResource).mockReturnValue(new Map());
+
+    const { container } = render(<ReferenceVideoCanvas projectName="proj" episode={1} />);
+    await screen.findByRole("button", { name: UNIT_GENERATE_CTA });
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).not.toBeNull();
+
+    // 选择文件之后、确认之前，该 unit 已被别的入口占用
+    act(() => {
+      useTasksStore.setState({ tasks: [runningTask("E1U1")] as never });
+    });
+
+    fireEvent.change(input!, { target: { files: [new File(["x"], "clip.mp4", { type: "video/mp4" })] } });
+
+    await waitFor(() => expect(pushToast).toHaveBeenCalled());
+    expect(uploadSpy).not.toHaveBeenCalled();
+  });
+
+  it("没有待生成 unit 时批量生成按钮禁用", async () => {
+    // 唯一的 unit 已有成片：statusMap 为 ready，批量入口无作用对象
+    const ready = mkUnit("E1U1");
+    ready.generated_assets.video_clip = "videos/E1U1.mp4";
+    vi.spyOn(API, "listReferenceVideoUnits").mockResolvedValue({ units: [ready] });
+
+    render(<ReferenceVideoCanvas projectName="proj" episode={1} />);
+
+    const batch = await screen.findByRole("button", { name: /Batch generate videos|批量生成视频/ });
+    await waitFor(() => expect(batch).toBeDisabled());
   });
 
   // 后台任务失败通知已统一迁移到全局 useTaskFailureNotifications hook（转变驱动 /

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -137,6 +137,28 @@ export function ReferenceVideoCanvas({
   const busyUnitIds = useActiveResourceIds("reference_video", projectName);
 
   const [uploadingUnitIds, setUploadingUnitIds] = useState<Set<string>>(() => new Set());
+  // 版本恢复不产生任务行，进不了 tasks-store 占用集，故在画布层按 unit 记录。存在这里
+  // 而非 UnitPreviewPanel 内：该面板有窄屏 sub-tab 与宽屏右栏两处挂载点，切换子页或跨越
+  // STACK_PREVIEW_BREAKPOINT 都会卸载它（在途的恢复请求不会因此取消），且它随选中项切换
+  // 复用，面板内的单个布尔量还会把 A 的恢复态串到 B 上。
+  const [restoringUnitIds, setRestoringUnitIds] = useState<Set<string>>(() => new Set());
+  // 渲染用上面的 state，提交时刻复核用这个镜像：state 要等 render 冲刷才可见，而
+  // 「点击发生在状态已变、渲染未到」的窗口正是复核要挡的（与 isUnitBusy 的新鲜读同理）。
+  const restoringRef = useRef<Set<string>>(new Set());
+
+  const handleRestoringChange = useCallback((unitId: string, restoring: boolean) => {
+    const next = new Set(restoringRef.current);
+    if (restoring) next.add(unitId);
+    else next.delete(unitId);
+    restoringRef.current = next;
+    setRestoringUnitIds(next);
+  }, []);
+
+  /** 该 unit 是否被任一写入路径占用：生成/上传（tasks-store 占用集）或版本恢复。 */
+  const isUnitLocked = useCallback(
+    (unitId: string) => isUnitBusy(projectName, unitId) || restoringRef.current.has(unitId),
+    [projectName],
+  );
 
   const statusMap = useMemo<Record<string, UnitStatus>>(() => {
     const map: Record<string, UnitStatus> = {};
@@ -190,7 +212,7 @@ export function ReferenceVideoCanvas({
       setStackTab("preview");
       // 提交前用 getState() 新鲜读复核：按钮渲染期捕获的占用态未必是最新的
       // （批量循环、Agent 入队、SSE 落库都可能在渲染之后、点击之前占用同一 unit）。
-      if (isUnitBusy(projectName, unitId)) {
+      if (isUnitLocked(unitId)) {
         useAppStore.getState().pushToast(t("reference_generate_busy"), "error");
         return;
       }
@@ -201,14 +223,14 @@ export function ReferenceVideoCanvas({
         toastError(e, (msg) => t("reference_generate_request_failed", { error: msg }));
       }
     },
-    [projectName, episode, t],
+    [projectName, episode, isUnitLocked, t],
   );
 
   const handleUploadVideo = useCallback(
     async (unitId: string, file: File) => {
       // 上传与生成回写同一个成片文件，故与生成入口同一套占用判定：文件选择对话框
       // 打开期间同一 unit 可能已被占用，按钮渲染期的禁用态挡不住这段窗口。
-      if (isUnitBusy(projectName, unitId)) {
+      if (isUnitLocked(unitId)) {
         useAppStore.getState().pushToast(t("reference_generate_busy"), "error");
         return;
       }
@@ -240,7 +262,7 @@ export function ReferenceVideoCanvas({
         });
       }
     },
-    [projectName, episode, loadUnits, t],
+    [projectName, episode, loadUnits, isUnitLocked, t],
   );
 
   const handleUnitsRefresh = useCallback(
@@ -265,11 +287,11 @@ export function ReferenceVideoCanvas({
       // 实时复核而非用渲染期快照：串行 await 期间其它入口（单元按钮、Agent 入队、
       // SSE 落库）可能已占用同一 unit。命中即跳过，不当作错误提示——批量入口的语义
       // 是「把还能生成的都排上」，逐个报错只会刷屏。
-      if (isUnitBusy(projectName, u.unit_id)) continue;
+      if (isUnitLocked(u.unit_id)) continue;
       // 串行 enqueue —— 让前端依次触发后端 dedup 检查；后端实际仍按 worker 并发跑。
       await handleGenerate(u.unit_id);
     }
-  }, [batchTargets, handleGenerate, projectName, t]);
+  }, [batchTargets, handleGenerate, isUnitLocked, t]);
 
   const onAdd = useCallback(() => void handleAdd(), [handleAdd]);
   const onGenerateVoid = useCallback((id: string) => void handleGenerate(id), [handleGenerate]);
@@ -807,6 +829,8 @@ export function ReferenceVideoCanvas({
                           onGenerate={onGenerateVoid}
                           onUploadVideo={handleUploadVideo}
                           uploadingVideo={uploadingUnitIds.has(selected.unit_id)}
+                          restoring={restoringUnitIds.has(selected.unit_id)}
+                          onRestoringChange={handleRestoringChange}
                           onRestored={handleUnitsRefresh}
                         />
                       </div>
@@ -835,6 +859,8 @@ export function ReferenceVideoCanvas({
                   onGenerate={onGenerateVoid}
                   onUploadVideo={handleUploadVideo}
                   uploadingVideo={selected ? uploadingUnitIds.has(selected.unit_id) : false}
+                  restoring={selected ? restoringUnitIds.has(selected.unit_id) : false}
+                  onRestoringChange={handleRestoringChange}
                   onRestored={handleUnitsRefresh}
                 />
               </div>

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -837,6 +837,7 @@ export function ReferenceVideoCanvas({
                           uploadingVideo={uploading.ids.has(selected.unit_id)}
                           restoring={restoring.ids.has(selected.unit_id)}
                           onRestoringChange={handleRestoringChange}
+                          checkBusy={isUnitLocked}
                           onRestored={handleUnitsRefresh}
                         />
                       </div>
@@ -867,6 +868,7 @@ export function ReferenceVideoCanvas({
                   uploadingVideo={selected ? uploading.ids.has(selected.unit_id) : false}
                   restoring={selected ? restoring.ids.has(selected.unit_id) : false}
                   onRestoringChange={handleRestoringChange}
+                  checkBusy={isUnitLocked}
                   onRestored={handleUnitsRefresh}
                 />
               </div>

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -13,6 +13,7 @@ import { UnitList } from "./UnitList";
 import { UnitRail } from "./UnitRail";
 import { UnitPreviewPanel } from "./UnitPreviewPanel";
 import { ReferenceVideoCard, unitPromptText } from "./ReferenceVideoCard";
+import { deriveUnitStatus } from "./unit-status";
 import { ReferencePanel } from "./ReferencePanel";
 import { EpisodeHeader } from "./EpisodeHeader";
 import { ScriptReviewGate } from "@/components/canvas/timeline/ScriptReviewGate";
@@ -23,7 +24,6 @@ import {
   referenceVideoCacheKey,
 } from "@/stores/reference-video-store";
 import {
-  isActiveStatus,
   selectActiveResourceIds,
   useActiveResourceIds,
   useLatestTasksByResource,
@@ -70,6 +70,16 @@ function draftKey(projectName: string, episode: number, unitId: string): string 
 function toastError(e: unknown, format?: (msg: string) => string): void {
   const msg = errMsg(e);
   useAppStore.getState().pushToast(format ? format(msg) : msg, "error");
+}
+
+/**
+ * 提交时刻的占用复核：按钮渲染期捕获的占用态未必是最新的（批量循环、Agent 入队、
+ * SSE 落库都可能在渲染之后、点击之前占用同一 unit），故一律用 getState() 新鲜读。
+ * 入队动作层在请求发出前就打乐观标记，因此同一 tick 内的连点也会被这一读拦下。
+ */
+function isUnitBusy(projectName: string, unitId: string): boolean {
+  const { tasks, optimisticActive } = useTasksStore.getState();
+  return selectActiveResourceIds(tasks, "reference_video", projectName, optimisticActive).has(unitId);
 }
 
 export function ReferenceVideoCanvas({
@@ -122,48 +132,32 @@ export function ReferenceVideoCanvas({
     }
   }, [units, selected, select]);
 
-  // 乐观占用来自 tasks-store：入队动作层在 API 成功后打标，真实任务行落库后让位。
+  // 乐观占用来自 tasks-store：入队动作层在请求发出前打标、失败回滚，真实任务行落库后
+  // 让位，故「请求发出 → 任务行落库」全程都被覆盖，画布无须自备请求在途标记。
   const busyUnitIds = useActiveResourceIds("reference_video", projectName);
 
   const [uploadingUnitIds, setUploadingUnitIds] = useState<Set<string>>(() => new Set());
 
-  // 入队请求自身在途的 unit：动作层的乐观打标要等 API 响应回来才落，这段往返里
-  // busyUnitIds 仍是空的，只靠它禁用会在「请求已发出、响应未回」的窗口内漏禁用。
-  // ref 是提交时刻复核的同步真相源（同一 tick 内连点时 state 尚未提交到闭包），
-  // state 仅用于驱动禁用态重渲染。
-  const submittingRef = useRef<Set<string>>(new Set());
-  const [submittingUnitIds, setSubmittingUnitIds] = useState<Set<string>>(() => new Set());
-
   const statusMap = useMemo<Record<string, UnitStatus>>(() => {
     const map: Record<string, UnitStatus> = {};
     for (const u of units) {
-      let st: UnitStatus = u.generated_assets.video_clip ? "ready" : "pending";
-      const queueRow = tasksByUnit.get(u.unit_id);
-      // 上传中的 unit 视为 running：批量生成按 statusMap 选 pending，
-      // 否则上传期间会被再次入队，与生成回写同一个成片文件
-      if (uploadingUnitIds.has(u.unit_id)) st = "running";
-      else if (queueRow && isActiveStatus(queueRow.status)) st = "running";
-      // 失败任务行 DB 持久化、不会过期：手动上传成片后单元已有可播放资产，
-      // 不再让历史失败覆盖 ready（与 timeline/grid 画布用 toast 提示失败的语义对齐）
-      else if (queueRow?.status === "failed" && !u.generated_assets.video_clip) st = "failed";
-      // 乐观窗口：真实任务行尚未落库时按占用集显示 running。已有任务行时不走
-      // 这个分支——显示语义仍由 isActiveStatus 决定（cancelling 不显示为 running）。
-      else if (!queueRow && busyUnitIds.has(u.unit_id)) st = "running";
-      map[u.unit_id] = st;
+      map[u.unit_id] = deriveUnitStatus({
+        hasClip: Boolean(u.generated_assets.video_clip),
+        queueRow: tasksByUnit.get(u.unit_id),
+        busy: busyUnitIds.has(u.unit_id),
+        uploading: uploadingUnitIds.has(u.unit_id),
+        // 本画布提供成片上传入口：上传后单元已有可播放资产，历史失败不再覆盖 ready
+        // （与 timeline/grid 画布用 toast 提示失败的语义对齐）。
+        supportsManualUpload: true,
+      });
     }
     return map;
   }, [units, tasksByUnit, busyUnitIds, uploadingUnitIds]);
 
-  const generating = !!(selected && statusMap[selected.unit_id] === "running");
-
   // 独立于 statusMap 传给 UnitPreviewPanel：重试（旧失败行在）与重新生成（旧成功行在）
   // 两条路径上 queueRow 始终非空，statusMap 的乐观分支不生效，仅看 status 会在入队到
-  // 任务行落库之间的窗口内漏禁用生成按钮。submittingUnitIds 补上请求往返那一段，
-  // 合起来覆盖「请求发出 → 乐观打标 → 真实任务行落库」全程。
-  const selectedBusy = !!(
-    selected &&
-    (busyUnitIds.has(selected.unit_id) || submittingUnitIds.has(selected.unit_id))
-  );
+  // 任务行落库之间的窗口内漏禁用生成按钮。
+  const selectedBusy = !!(selected && busyUnitIds.has(selected.unit_id));
   const selectedCancelling = !!(selected && tasksByUnit.get(selected.unit_id)?.status === "cancelling");
 
   const failureMessage = useMemo(() => {
@@ -196,23 +190,15 @@ export function ReferenceVideoCanvas({
       setStackTab("preview");
       // 提交前用 getState() 新鲜读复核：按钮渲染期捕获的占用态未必是最新的
       // （批量循环、Agent 入队、SSE 落库都可能在渲染之后、点击之前占用同一 unit）。
-      const { tasks, optimisticActive } = useTasksStore.getState();
-      const live = selectActiveResourceIds(tasks, "reference_video", projectName, optimisticActive);
-      if (live.has(unitId) || submittingRef.current.has(unitId)) {
+      if (isUnitBusy(projectName, unitId)) {
         useAppStore.getState().pushToast(t("reference_generate_busy"), "error");
         return;
       }
-      submittingRef.current.add(unitId);
-      setSubmittingUnitIds(new Set(submittingRef.current));
       try {
-        // 入队成功的乐观打标与 queued/deduped 提示都在动作层内完成
+        // 乐观打标（请求发出前）、失败回滚与 queued/deduped 提示都在动作层内完成
         await enqueueReferenceVideoUnit(projectName, episode, unitId);
       } catch (e) {
         toastError(e, (msg) => t("reference_generate_request_failed", { error: msg }));
-      } finally {
-        // 打标已由动作层完成（失败时无标可解），此处只交还请求在途标记
-        submittingRef.current.delete(unitId);
-        setSubmittingUnitIds(new Set(submittingRef.current));
       }
     },
     [projectName, episode, t],
@@ -220,6 +206,12 @@ export function ReferenceVideoCanvas({
 
   const handleUploadVideo = useCallback(
     async (unitId: string, file: File) => {
+      // 上传与生成回写同一个成片文件，故与生成入口同一套占用判定：文件选择对话框
+      // 打开期间同一 unit 可能已被占用，按钮渲染期的禁用态挡不住这段窗口。
+      if (isUnitBusy(projectName, unitId)) {
+        useAppStore.getState().pushToast(t("reference_generate_busy"), "error");
+        return;
+      }
       setUploadingUnitIds((s) => {
         const next = new Set(s);
         next.add(unitId);
@@ -256,17 +248,28 @@ export function ReferenceVideoCanvas({
     [loadUnits, projectName, episode],
   );
 
+  // 批量生成的作用对象：全部待生成 unit。按钮禁用与它同一口径——此前只看当前选中
+  // unit 是否在跑，与作用对象无关，选中项空闲时按钮会在没有任何待生成 unit 的情况下
+  // 仍可点击，选中项在跑时又会挡住其余 unit 的批量生成。
+  const batchTargets = useMemo(
+    () => units.filter((u) => statusMap[u.unit_id] === "pending"),
+    [units, statusMap],
+  );
+
   const handleBatchGenerate = useCallback(async () => {
-    const targets = units.filter((u) => statusMap[u.unit_id] === "pending");
-    if (targets.length === 0) {
+    if (batchTargets.length === 0) {
       useAppStore.getState().pushToast(t("reference_batch_nothing_to_do"), "info");
       return;
     }
-    for (const u of targets) {
+    for (const u of batchTargets) {
+      // 实时复核而非用渲染期快照：串行 await 期间其它入口（单元按钮、Agent 入队、
+      // SSE 落库）可能已占用同一 unit。命中即跳过，不当作错误提示——批量入口的语义
+      // 是「把还能生成的都排上」，逐个报错只会刷屏。
+      if (isUnitBusy(projectName, u.unit_id)) continue;
       // 串行 enqueue —— 让前端依次触发后端 dedup 检查；后端实际仍按 worker 并发跑。
       await handleGenerate(u.unit_id);
     }
-  }, [units, statusMap, handleGenerate, t]);
+  }, [batchTargets, handleGenerate, projectName, t]);
 
   const onAdd = useCallback(() => void handleAdd(), [handleAdd]);
   const onGenerateVoid = useCallback((id: string) => void handleGenerate(id), [handleGenerate]);
@@ -558,7 +561,7 @@ export function ReferenceVideoCanvas({
           <button
             type="button"
             onClick={() => void handleBatchGenerate()}
-            disabled={units.length === 0 || generating}
+            disabled={batchTargets.length === 0}
             className="focus-ring inline-flex items-center gap-1.5 rounded-md border border-[var(--color-hairline)] bg-[oklch(0.22_0.011_265_/_0.5)] px-2.5 py-1 text-[11.5px] text-[var(--color-text-2)] transition-colors hover:bg-[oklch(0.26_0.013_265_/_0.7)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-60"
           >
             <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -52,6 +52,25 @@ export interface ReferenceVideoCanvasProps {
 
 const EMPTY_UNITS: readonly ReferenceVideoUnit[] = Object.freeze([]);
 
+/**
+ * 画布层自记的按 unit 占用位（不产生任务行、进不了 tasks-store 占用集的那些写入路径）。
+ *
+ * `ids` 供渲染，`ref` 供提交时刻新鲜读：state 要等 render 冲刷才可见，而「点击发生在状态
+ * 已变、渲染未到」的窗口正是提交时复核要挡的（与 isUnitBusy 的新鲜读同理）。
+ */
+function useUnitFlagSet() {
+  const [ids, setIds] = useState<Set<string>>(() => new Set());
+  const ref = useRef<Set<string>>(new Set());
+  const set = useCallback((unitId: string, on: boolean) => {
+    const next = new Set(ref.current);
+    if (on) next.add(unitId);
+    else next.delete(unitId);
+    ref.current = next;
+    setIds(next);
+  }, []);
+  return useMemo(() => ({ ids, ref, set }), [ids, set]);
+}
+
 // 容器宽度断点（px，对应设计稿的响应式行为）。
 //   < LIST_RAIL_BREAKPOINT — 左侧 UnitList 收成 56px rail（带 flyout 触发）
 //   < STACK_PREVIEW_BREAKPOINT — 中右合栏，预览叠成 sub-tab
@@ -136,28 +155,23 @@ export function ReferenceVideoCanvas({
   // 让位，故「请求发出 → 任务行落库」全程都被覆盖，画布无须自备请求在途标记。
   const busyUnitIds = useActiveResourceIds("reference_video", projectName);
 
-  const [uploadingUnitIds, setUploadingUnitIds] = useState<Set<string>>(() => new Set());
-  // 版本恢复不产生任务行，进不了 tasks-store 占用集，故在画布层按 unit 记录。存在这里
-  // 而非 UnitPreviewPanel 内：该面板有窄屏 sub-tab 与宽屏右栏两处挂载点，切换子页或跨越
-  // STACK_PREVIEW_BREAKPOINT 都会卸载它（在途的恢复请求不会因此取消），且它随选中项切换
-  // 复用，面板内的单个布尔量还会把 A 的恢复态串到 B 上。
-  const [restoringUnitIds, setRestoringUnitIds] = useState<Set<string>>(() => new Set());
-  // 渲染用上面的 state，提交时刻复核用这个镜像：state 要等 render 冲刷才可见，而
-  // 「点击发生在状态已变、渲染未到」的窗口正是复核要挡的（与 isUnitBusy 的新鲜读同理）。
-  const restoringRef = useRef<Set<string>>(new Set());
+  // 成片上传与版本恢复都不产生任务行，进不了 tasks-store 占用集，故在画布层按 unit 记录。
+  // 存在这里而非 UnitPreviewPanel 内：该面板有窄屏 sub-tab 与宽屏右栏两处挂载点，切换子页
+  // 或跨越 STACK_PREVIEW_BREAKPOINT 都会卸载它（在途请求不会因此取消），且它随选中项切换
+  // 复用，面板内的单个布尔量还会把 A 的占用态串到 B 上。
+  const uploading = useUnitFlagSet();
+  const restoring = useUnitFlagSet();
 
-  const handleRestoringChange = useCallback((unitId: string, restoring: boolean) => {
-    const next = new Set(restoringRef.current);
-    if (restoring) next.add(unitId);
-    else next.delete(unitId);
-    restoringRef.current = next;
-    setRestoringUnitIds(next);
-  }, []);
+  const setUploading = uploading.set;
+  const handleRestoringChange = restoring.set;
 
-  /** 该 unit 是否被任一写入路径占用：生成/上传（tasks-store 占用集）或版本恢复。 */
+  /** 该 unit 是否被任一写入路径占用：生成（tasks-store 占用集）、成片上传或版本恢复。 */
   const isUnitLocked = useCallback(
-    (unitId: string) => isUnitBusy(projectName, unitId) || restoringRef.current.has(unitId),
-    [projectName],
+    (unitId: string) =>
+      isUnitBusy(projectName, unitId) ||
+      uploading.ref.current.has(unitId) ||
+      restoring.ref.current.has(unitId),
+    [projectName, uploading.ref, restoring.ref],
   );
 
   const statusMap = useMemo<Record<string, UnitStatus>>(() => {
@@ -167,14 +181,14 @@ export function ReferenceVideoCanvas({
         hasClip: Boolean(u.generated_assets.video_clip),
         queueRow: tasksByUnit.get(u.unit_id),
         busy: busyUnitIds.has(u.unit_id),
-        uploading: uploadingUnitIds.has(u.unit_id),
+        uploading: uploading.ids.has(u.unit_id),
         // 本画布提供成片上传入口：上传后单元已有可播放资产，历史失败不再覆盖 ready
         // （与 timeline/grid 画布用 toast 提示失败的语义对齐）。
         supportsManualUpload: true,
       });
     }
     return map;
-  }, [units, tasksByUnit, busyUnitIds, uploadingUnitIds]);
+  }, [units, tasksByUnit, busyUnitIds, uploading.ids]);
 
   // 独立于 statusMap 传给 UnitPreviewPanel：重试（旧失败行在）与重新生成（旧成功行在）
   // 两条路径上 queueRow 始终非空，statusMap 的乐观分支不生效，仅看 status 会在入队到
@@ -234,11 +248,7 @@ export function ReferenceVideoCanvas({
         useAppStore.getState().pushToast(t("reference_generate_busy"), "error");
         return;
       }
-      setUploadingUnitIds((s) => {
-        const next = new Set(s);
-        next.add(unitId);
-        return next;
-      });
+      setUploading(unitId, true);
       try {
         try {
           const result = await API.uploadReferenceUnitVideo(projectName, episode, unitId, file);
@@ -255,14 +265,10 @@ export function ReferenceVideoCanvas({
           toastError(e, (msg) => t("media_refresh_failed", { message: msg }));
         }
       } finally {
-        setUploadingUnitIds((s) => {
-          const next = new Set(s);
-          next.delete(unitId);
-          return next;
-        });
+        setUploading(unitId, false);
       }
     },
-    [projectName, episode, loadUnits, isUnitLocked, t],
+    [projectName, episode, loadUnits, isUnitLocked, setUploading, t],
   );
 
   const handleUnitsRefresh = useCallback(
@@ -828,8 +834,8 @@ export function ReferenceVideoCanvas({
                           actualCost={actualCost}
                           onGenerate={onGenerateVoid}
                           onUploadVideo={handleUploadVideo}
-                          uploadingVideo={uploadingUnitIds.has(selected.unit_id)}
-                          restoring={restoringUnitIds.has(selected.unit_id)}
+                          uploadingVideo={uploading.ids.has(selected.unit_id)}
+                          restoring={restoring.ids.has(selected.unit_id)}
                           onRestoringChange={handleRestoringChange}
                           onRestored={handleUnitsRefresh}
                         />
@@ -858,8 +864,8 @@ export function ReferenceVideoCanvas({
                   actualCost={actualCost}
                   onGenerate={onGenerateVoid}
                   onUploadVideo={handleUploadVideo}
-                  uploadingVideo={selected ? uploadingUnitIds.has(selected.unit_id) : false}
-                  restoring={selected ? restoringUnitIds.has(selected.unit_id) : false}
+                  uploadingVideo={selected ? uploading.ids.has(selected.unit_id) : false}
+                  restoring={selected ? restoring.ids.has(selected.unit_id) : false}
                   onRestoringChange={handleRestoringChange}
                   onRestored={handleUnitsRefresh}
                 />

--- a/frontend/src/components/canvas/reference/UnitList.tsx
+++ b/frontend/src/components/canvas/reference/UnitList.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Plus, Scissors, Search } from "lucide-react";
 import { assetColor } from "./asset-colors";
-import { StatusBadge, deriveUnitStatus } from "./unit-status";
+import { StatusBadge, resolveUnitStatus } from "./unit-status";
 import type { ReferenceVideoUnit, UnitStatus } from "@/types";
 
 export interface UnitListProps {
@@ -85,7 +85,7 @@ export function UnitList({ units, selectedId, onSelect, onAdd, dirtyMap, statusM
           className="min-h-0 flex-1 overflow-y-auto px-2 pb-2"
         >
           {filtered.map((u) => {
-            const status = deriveUnitStatus(u, statusMap);
+            const status = resolveUnitStatus(u, statusMap);
             const selected = u.unit_id === selectedId;
             const dirty = !!dirtyMap?.[u.unit_id];
             return (

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.test.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.test.tsx
@@ -131,30 +131,42 @@ describe("UnitPreviewPanel", () => {
     });
 
     it("恢复在途反向禁用同一 unit 的生成与上传", () => {
-      // 恢复不产生任务行，占用只存在于组件树内：若不回传父级，恢复返回前生成/上传
-      // 仍可点，两个请求并发写同一个 reference_videos/{unit_id}.mp4，后完成者覆盖
-      // 前者且双方都提示成功。
+      // 恢复与生成、上传写同一个 reference_videos/{unit_id}.mp4：恢复返回前若这两个
+      // 入口仍可点，两个请求并发落盘，后完成者覆盖前者且双方都提示成功。
       const { container } = render(
         <UnitPreviewPanel
           unit={mkUnit()}
           projectName="proj"
           onGenerate={vi.fn()}
           onUploadVideo={vi.fn()}
+          restoring
         />,
       );
-      const uploadButton = () =>
-        container.querySelector<HTMLInputElement>('input[type="file"]')
-          ?.nextElementSibling as HTMLButtonElement;
-      const generateButton = () =>
-        [...container.querySelectorAll("button")].find((b) => b.textContent?.trim());
+      const uploadButton = container.querySelector<HTMLInputElement>('input[type="file"]')
+        ?.nextElementSibling as HTMLButtonElement;
+      const generateButton = [...container.querySelectorAll("button")].find((b) =>
+        b.textContent?.trim(),
+      );
 
-      expect(uploadButton()).not.toBeDisabled();
-      expect(generateButton()).not.toBeDisabled();
+      expect(uploadButton).toBeDisabled();
+      expect(generateButton).toBeDisabled();
+    });
+
+    it("恢复态上报带 unitId，供画布层按 unit 记录", () => {
+      // 恢复态必须存在面板之外：本面板有窄屏 sub-tab / 宽屏右栏两处挂载点，切换会卸载
+      // 它而在途请求不取消；且它随选中项复用，面板内的单个布尔量会串到别的 unit 上。
+      const onRestoringChange = vi.fn();
+      render(
+        <UnitPreviewPanel
+          unit={mkUnit({ unit_id: "E1U2" })}
+          projectName="proj"
+          onRestoringChange={onRestoringChange}
+        />,
+      );
 
       fireEvent.click(screen.getByTestId("start-restore"));
 
-      expect(uploadButton()).toBeDisabled();
-      expect(generateButton()).toBeDisabled();
+      expect(onRestoringChange).toHaveBeenCalledWith("E1U2", true);
     });
   });
 });

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.test.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.test.tsx
@@ -6,8 +6,17 @@ import type { ReferenceVideoUnit } from "@/types";
 // VersionTimeMachine 的 busy 只关面板内的恢复按钮，触发按钮的可用性不变；替身把这个
 // 入参渲染成可断言的属性，避免为了读它去展开面板、加载版本列表。
 vi.mock("@/components/canvas/timeline/VersionTimeMachine", () => ({
-  VersionTimeMachine: ({ busy }: { busy?: boolean }) => (
-    <div data-testid="version-time-machine" data-busy={String(Boolean(busy))} />
+  VersionTimeMachine: ({
+    busy,
+    onRestoringChange,
+  }: {
+    busy?: boolean;
+    onRestoringChange?: (restoring: boolean) => void;
+  }) => (
+    <div data-testid="version-time-machine" data-busy={String(Boolean(busy))}>
+      {/* 替身把恢复态回传口暴露成一个按钮，供断言兄弟控件的反向互斥 */}
+      <button type="button" data-testid="start-restore" onClick={() => onRestoringChange?.(true)} />
+    </div>
   ),
 }));
 
@@ -119,6 +128,33 @@ describe("UnitPreviewPanel", () => {
         <UnitPreviewPanel unit={mkUnit()} projectName="proj" onUploadVideo={vi.fn()} uploadingVideo />,
       );
       expect(versionMachineBusy()).toBe(true);
+    });
+
+    it("恢复在途反向禁用同一 unit 的生成与上传", () => {
+      // 恢复不产生任务行，占用只存在于组件树内：若不回传父级，恢复返回前生成/上传
+      // 仍可点，两个请求并发写同一个 reference_videos/{unit_id}.mp4，后完成者覆盖
+      // 前者且双方都提示成功。
+      const { container } = render(
+        <UnitPreviewPanel
+          unit={mkUnit()}
+          projectName="proj"
+          onGenerate={vi.fn()}
+          onUploadVideo={vi.fn()}
+        />,
+      );
+      const uploadButton = () =>
+        container.querySelector<HTMLInputElement>('input[type="file"]')
+          ?.nextElementSibling as HTMLButtonElement;
+      const generateButton = () =>
+        [...container.querySelectorAll("button")].find((b) => b.textContent?.trim());
+
+      expect(uploadButton()).not.toBeDisabled();
+      expect(generateButton()).not.toBeDisabled();
+
+      fireEvent.click(screen.getByTestId("start-restore"));
+
+      expect(uploadButton()).toBeDisabled();
+      expect(generateButton()).toBeDisabled();
     });
   });
 });

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.test.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.test.tsx
@@ -152,6 +152,13 @@ describe("UnitPreviewPanel", () => {
       expect(generateButton).toBeDisabled();
     });
 
+    it("外部恢复态同样置 busy——重挂载后不放行第二次恢复", () => {
+      // 面板在窄屏 sub-tab / 宽屏右栏之间切换时会重挂载，VersionTimeMachine 自身的
+      // 恢复中状态随之丢失；父级仍记录该 unit 恢复在途，此时放行会并发写同一成片文件。
+      render(<UnitPreviewPanel unit={mkUnit()} projectName="proj" restoring />);
+      expect(versionMachineBusy()).toBe(true);
+    });
+
     it("恢复态上报带 unitId，供画布层按 unit 记录", () => {
       // 恢复态必须存在面板之外：本面板有窄屏 sub-tab / 宽屏右栏两处挂载点，切换会卸载
       // 它而在途请求不取消；且它随选中项复用，面板内的单个布尔量会串到别的 unit 上。

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.test.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.test.tsx
@@ -3,6 +3,18 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { UnitPreviewPanel } from "./UnitPreviewPanel";
 import type { ReferenceVideoUnit } from "@/types";
 
+// VersionTimeMachine 的 busy 只关面板内的恢复按钮，触发按钮的可用性不变；替身把这个
+// 入参渲染成可断言的属性，避免为了读它去展开面板、加载版本列表。
+vi.mock("@/components/canvas/timeline/VersionTimeMachine", () => ({
+  VersionTimeMachine: ({ busy }: { busy?: boolean }) => (
+    <div data-testid="version-time-machine" data-busy={String(Boolean(busy))} />
+  ),
+}));
+
+function versionMachineBusy(): boolean {
+  return screen.getByTestId("version-time-machine").dataset.busy === "true";
+}
+
 function mkUnit(overrides: Partial<ReferenceVideoUnit> = {}): ReferenceVideoUnit {
   return {
     unit_id: "E1U1",
@@ -79,5 +91,34 @@ describe("UnitPreviewPanel", () => {
     const input = container.querySelector<HTMLInputElement>('input[type="file"]');
     const button = input?.nextElementSibling as HTMLButtonElement;
     expect(button).toBeDisabled();
+  });
+
+  // 版本恢复与生成回写同一个成片文件：占用期间恢复旧版本会显示成功、随后被在跑的
+  // 生成任务覆盖。VersionTimeMachine 的 busy 关掉的是面板内的恢复按钮（触发按钮照常
+  // 可开，只读浏览不受影响），故这里断言接线本身。
+  describe("版本恢复的占用接线", () => {
+    it("空闲时不置 busy", () => {
+      render(<UnitPreviewPanel unit={mkUnit()} projectName="proj" />);
+      expect(versionMachineBusy()).toBe(false);
+    });
+
+    it("生成中置 busy", () => {
+      render(<UnitPreviewPanel unit={mkUnit()} projectName="proj" status="running" />);
+      expect(versionMachineBusy()).toBe(true);
+    });
+
+    it("取消中置 busy——占用比 running 状态活得更久", () => {
+      // cancelling 期间不展示为生成中（status 不是 running），但 worker 仍可能在写
+      // 成片文件，占用判定仍成立；仅看 status 会漏禁用
+      render(<UnitPreviewPanel unit={mkUnit()} projectName="proj" busy cancelling />);
+      expect(versionMachineBusy()).toBe(true);
+    });
+
+    it("成片上传在途置 busy", () => {
+      render(
+        <UnitPreviewPanel unit={mkUnit()} projectName="proj" onUploadVideo={vi.fn()} uploadingVideo />,
+      );
+      expect(versionMachineBusy()).toBe(true);
+    });
   });
 });

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
@@ -5,7 +5,7 @@ import { useProjectsStore } from "@/stores/projects-store";
 import { VersionTimeMachine } from "@/components/canvas/timeline/VersionTimeMachine";
 import { UPLOAD_VIDEO_ACCEPT, UploadIconButton } from "@/components/ui/UploadIconButton";
 import { formatCost } from "@/utils/cost-format";
-import { StatusBadge, deriveUnitStatus } from "./unit-status";
+import { StatusBadge, resolveUnitStatus } from "./unit-status";
 import type { CostBreakdown, ReferenceVideoUnit, UnitStatus } from "@/types";
 
 export interface UnitPreviewPanelProps {
@@ -70,7 +70,7 @@ export function UnitPreviewPanel({
     );
   }
 
-  const effectiveStatus = status ?? deriveUnitStatus(unit);
+  const effectiveStatus = status ?? resolveUnitStatus(unit);
   const videoUrl = clip && projectName ? API.getFileUrl(projectName, clip, clipFp) : null;
 
   // 状态先于 video_clip 落库的窗口里，effectiveStatus==="ready" 但 videoUrl
@@ -109,12 +109,15 @@ export function UnitPreviewPanel({
             onSelect={(f) => void onUploadVideo(unit.unit_id, f)}
           />
         )}
+        {/* 版本恢复同样写这个 unit 的成片文件，与上传、主 CTA 同步接线禁用：
+            占用期间恢复旧版本会显示成功、随后被在跑的生成任务覆盖 */}
         {projectName && (
           <VersionTimeMachine
             projectName={projectName}
             resourceType="reference_videos"
             resourceId={unit.unit_id}
             onRestore={onRestored}
+            busy={inFlight || busy || Boolean(uploadingVideo)}
             iconOnly
           />
         )}

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Film, Loader2, Sparkles, RotateCcw, AlertTriangle } from "lucide-react";
 import { API } from "@/api";
@@ -34,6 +33,14 @@ export interface UnitPreviewPanelProps {
   onUploadVideo?: (unitId: string, file: File) => void | Promise<void>;
   /** 上传进行中 */
   uploadingVideo?: boolean;
+  /**
+   * 该 unit 的版本恢复请求在途。恢复不产生任务行、进不了 tasks-store 占用集，状态由
+   * {@link VersionTimeMachine} 经 `onRestoringChange` 上报，但必须存在**本面板之外**：
+   * 本面板在窄屏 sub-tab 与宽屏右栏是两处挂载点，切换子页或跨越断点都会卸载它，而在途
+   * 的恢复请求不会因此取消；且同一面板会随选中项切换复用，状态存在这里还会串到别的 unit。
+   */
+  restoring?: boolean;
+  onRestoringChange?: (unitId: string, restoring: boolean) => void;
   /** 版本恢复后的刷新回调（重新拉取 units） */
   onRestored?: () => void | Promise<void>;
 }
@@ -56,15 +63,14 @@ export function UnitPreviewPanel({
   onGenerate,
   onUploadVideo,
   uploadingVideo,
+  restoring = false,
+  onRestoringChange,
   onRestored,
 }: UnitPreviewPanelProps) {
   const { t } = useTranslation("dashboard");
   const clip = unit?.generated_assets.video_clip ?? null;
   // 上传/还原后路径不变，靠 fingerprint cache-bust 让 <video> 重新拉取
   const clipFp = useProjectsStore((s) => (clip ? s.getAssetFingerprint(clip) : null));
-  // 版本恢复不产生任务行，占用只存在于组件树内：由 VersionTimeMachine 回传，
-  // 供同 unit 的生成 / 上传按钮反向互斥（三者写同一个 reference_videos/{unit_id}.mp4）。
-  const [restoring, setRestoring] = useState(false);
 
   if (!unit) {
     return (
@@ -122,7 +128,7 @@ export function UnitPreviewPanel({
             resourceId={unit.unit_id}
             onRestore={onRestored}
             busy={inFlight || busy || Boolean(uploadingVideo)}
-            onRestoringChange={setRestoring}
+            onRestoringChange={(r) => onRestoringChange?.(unit.unit_id, r)}
             iconOnly
           />
         )}

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
@@ -127,7 +127,7 @@ export function UnitPreviewPanel({
             resourceType="reference_videos"
             resourceId={unit.unit_id}
             onRestore={onRestored}
-            busy={inFlight || busy || Boolean(uploadingVideo)}
+            busy={inFlight || busy || Boolean(uploadingVideo) || restoring}
             onRestoringChange={(r) => onRestoringChange?.(unit.unit_id, r)}
             iconOnly
           />

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Film, Loader2, Sparkles, RotateCcw, AlertTriangle } from "lucide-react";
 import { API } from "@/api";
@@ -61,6 +62,9 @@ export function UnitPreviewPanel({
   const clip = unit?.generated_assets.video_clip ?? null;
   // 上传/还原后路径不变，靠 fingerprint cache-bust 让 <video> 重新拉取
   const clipFp = useProjectsStore((s) => (clip ? s.getAssetFingerprint(clip) : null));
+  // 版本恢复不产生任务行，占用只存在于组件树内：由 VersionTimeMachine 回传，
+  // 供同 unit 的生成 / 上传按钮反向互斥（三者写同一个 reference_videos/{unit_id}.mp4）。
+  const [restoring, setRestoring] = useState(false);
 
   if (!unit) {
     return (
@@ -105,7 +109,7 @@ export function UnitPreviewPanel({
             accept={UPLOAD_VIDEO_ACCEPT}
             label={t("media_upload_video")}
             busy={uploadingVideo}
-            disabled={inFlight || busy}
+            disabled={inFlight || busy || restoring}
             onSelect={(f) => void onUploadVideo(unit.unit_id, f)}
           />
         )}
@@ -118,6 +122,7 @@ export function UnitPreviewPanel({
             resourceId={unit.unit_id}
             onRestore={onRestored}
             busy={inFlight || busy || Boolean(uploadingVideo)}
+            onRestoringChange={setRestoring}
             iconOnly
           />
         )}
@@ -203,9 +208,9 @@ export function UnitPreviewPanel({
         <button
           type="button"
           onClick={() => onGenerate(unit.unit_id)}
-          disabled={inFlight || busy}
+          disabled={inFlight || busy || restoring}
           className={`focus-ring inline-flex items-center justify-center gap-2 rounded-lg px-3.5 py-2.5 text-sm font-semibold transition-colors ${
-            inFlight || busy
+            inFlight || busy || restoring
               ? "cursor-not-allowed border border-[var(--color-hairline)] bg-[oklch(0.22_0.011_265_/_0.6)] text-[var(--color-text-3)]"
               : "text-[oklch(0.14_0_0)] [background:linear-gradient(180deg,var(--color-accent-2),var(--color-accent))] shadow-[inset_0_1px_0_oklch(1_0_0_/_0.3),0_4px_14px_-4px_var(--color-accent-glow)]"
           }`}

--- a/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/UnitPreviewPanel.tsx
@@ -41,6 +41,11 @@ export interface UnitPreviewPanelProps {
    */
   restoring?: boolean;
   onRestoringChange?: (unitId: string, restoring: boolean) => void;
+  /**
+   * 恢复提交时刻的占用复核（新鲜读）：面板打开着而 Agent、批量入口或轮询随后占用该 unit
+   * 时，`restoring`/`busy` 这类渲染快照要等 render 冲刷才生效，其间的点击仍会发出恢复请求。
+   */
+  checkBusy?: (unitId: string) => boolean;
   /** 版本恢复后的刷新回调（重新拉取 units） */
   onRestored?: () => void | Promise<void>;
 }
@@ -65,6 +70,7 @@ export function UnitPreviewPanel({
   uploadingVideo,
   restoring = false,
   onRestoringChange,
+  checkBusy,
   onRestored,
 }: UnitPreviewPanelProps) {
   const { t } = useTranslation("dashboard");
@@ -129,6 +135,7 @@ export function UnitPreviewPanel({
             onRestore={onRestored}
             busy={inFlight || busy || Boolean(uploadingVideo) || restoring}
             onRestoringChange={(r) => onRestoringChange?.(unit.unit_id, r)}
+            checkBusy={checkBusy ? () => checkBusy(unit.unit_id) : undefined}
             iconOnly
           />
         )}

--- a/frontend/src/components/canvas/reference/UnitRail.tsx
+++ b/frontend/src/components/canvas/reference/UnitRail.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { LayoutGrid } from "lucide-react";
-import { STATUS_CONF, deriveUnitStatus } from "./unit-status";
+import { STATUS_CONF, resolveUnitStatus } from "./unit-status";
 import type { ReferenceVideoUnit, UnitStatus } from "@/types";
 
 export interface UnitRailProps {
@@ -35,7 +35,7 @@ export function UnitRail({ units, selectedId, onSelect, onExpand, dirtyMap, stat
         {units.map((u) => {
           const sel = u.unit_id === selectedId;
           const dirty = !!dirtyMap?.[u.unit_id];
-          const status = deriveUnitStatus(u, statusMap);
+          const status = resolveUnitStatus(u, statusMap);
           const conf = STATUS_CONF[status];
           // Strip the leading E{episode} from the unit id so the rail shows just `U{n}`.
           const shortId = u.unit_id.replace(/^E\d+/, "");

--- a/frontend/src/components/canvas/reference/unit-status.tsx
+++ b/frontend/src/components/canvas/reference/unit-status.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
-import type { ReferenceVideoUnit, UnitStatus } from "@/types";
+import { isActiveStatus } from "@/stores/tasks-store";
+import type { ReferenceVideoUnit, TaskItem, UnitStatus } from "@/types";
 
 export interface UnitStatusConf {
   i18nKey: string;
@@ -40,11 +41,58 @@ export const STATUS_CONF: Record<UnitStatus, UnitStatusConf> = {
   },
 };
 
-export function deriveUnitStatus(
+/** 从画布传下来的 statusMap 取该单元状态；未提供时按有无成片退化为 ready/pending。 */
+export function resolveUnitStatus(
   unit: ReferenceVideoUnit,
   statusMap?: Record<string, UnitStatus>,
 ): UnitStatus {
   return statusMap?.[unit.unit_id] ?? (unit.generated_assets.video_clip ? "ready" : "pending");
+}
+
+export interface UnitStatusInput {
+  /** 该单元是否已有成片资产。 */
+  hasClip: boolean;
+  /** 该单元的最新任务行；「最新行胜出」由 selectLatestTaskByResource 保证。 */
+  queueRow: TaskItem | undefined;
+  /** 占用集命中——真实任务行占用或入队动作层的乐观标记，含 cancelling。 */
+  busy: boolean;
+  /** 该单元正在上传成片。 */
+  uploading?: boolean;
+  /**
+   * 本画布是否提供手动上传成片入口。提供时成片可能来自上传而非生成，历史失败行不该
+   * 覆盖已有的可播放资产；不提供时成片只能来自生成，最新行失败即本次尝试失败，必须
+   * 展示失败而不能被旧成片压成 ready，否则失败原因无处可见。
+   */
+  supportsManualUpload?: boolean;
+}
+
+/**
+ * 参考生视频单元的展示状态：两个参考视频画布共用的单一推导口径。
+ *
+ * 判定按优先级依次落位——上传中 → 队列行活跃 → 队列行失败 → 乐观占用窗口。
+ * 展示语义用 isActiveStatus（cancelling 不显示为生成中），与占用语义
+ * （isOccupyingStatus，用于禁用控件）是两个谓词，不要合并：取消中的单元不显示为
+ * 「生成中」，但按钮仍须禁用，故 `busy` 独立于本函数的返回值另行接线。
+ *
+ * 乐观分支要求 `!queueRow`：有任务行时状态一律由该行决定，否则 cancelling 会被
+ * 乐观占用重新显示成生成中。重试与重新生成这两条路径上任务行始终在，乐观窗口内的
+ * 禁用因此不能只看本函数返回值——见 `busy` 的说明。
+ */
+export function deriveUnitStatus({
+  hasClip,
+  queueRow,
+  busy,
+  uploading = false,
+  supportsManualUpload = false,
+}: UnitStatusInput): UnitStatus {
+  // 上传中视为 running：批量生成按状态挑 pending 目标，否则上传期间会被再次入队，
+  // 与生成回写同一个成片文件。
+  if (uploading) return "running";
+  if (queueRow && isActiveStatus(queueRow.status)) return "running";
+  // 失败任务行 DB 持久化、不会过期，故成片是否压过失败取决于成片能否来自上传。
+  if (queueRow?.status === "failed" && !(supportsManualUpload && hasClip)) return "failed";
+  if (!queueRow && busy) return "running";
+  return hasClip ? "ready" : "pending";
 }
 
 export interface StatusBadgeProps {

--- a/frontend/src/components/canvas/timeline/VersionTimeMachine.test.tsx
+++ b/frontend/src/components/canvas/timeline/VersionTimeMachine.test.tsx
@@ -191,4 +191,60 @@ describe("VersionTimeMachine", () => {
     fireEvent.click(restoreButton);
     expect(restoreSpy).not.toHaveBeenCalled();
   });
+
+  // busy 是渲染快照：版本面板打开着的这段时间里 Agent 入队、批量入口或轮询落库都可能
+  // 占用该资源，新 prop 冲刷到按钮之前的一次点击仍会发出恢复请求，与在跑的任务并发写
+  // 同一个资源文件。故提交处理器里再做一次新鲜读。
+  it("恢复提交时刻复核占用态，命中即拒绝并提示", async () => {
+    vi.spyOn(API, "getVersions").mockResolvedValue({
+      resource_type: "storyboards",
+      resource_id: "SEG-1",
+      current_version: 2,
+      versions: [
+        {
+          version: 1,
+          filename: "v1.png",
+          created_at: "2026-02-01T00:00:00Z",
+          file_size: 10,
+          is_current: false,
+          prompt: "old prompt",
+          file_url: "/api/v1/files/demo/versions/storyboards/v1.png",
+        },
+        {
+          version: 2,
+          filename: "v2.png",
+          created_at: "2026-02-01T01:00:00Z",
+          file_size: 12,
+          is_current: true,
+          file_url: "/api/v1/files/demo/versions/storyboards/v2.png",
+        },
+      ],
+    });
+    const restoreSpy = vi.spyOn(API, "restoreVersion").mockResolvedValue({ success: true });
+    // 渲染期空闲（busy 缺省为 false，按钮可点），提交时刻已被别的入口占用
+    const checkBusy = vi.fn().mockReturnValue(true);
+
+    render(
+      <VersionTimeMachine
+        projectName="demo"
+        resourceType="storyboards"
+        resourceId="SEG-1"
+        checkBusy={checkBusy}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /版本/ }));
+    expect(await screen.findByRole("button", { name: "v1" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "v1" }));
+
+    const restoreButton = await screen.findByRole("button", { name: /切换到此版本/ });
+    expect(restoreButton).not.toBeDisabled();
+
+    fireEvent.click(restoreButton);
+
+    expect(restoreSpy).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(useAppStore.getState().toast?.text).toBe("生成或编辑进行中，暂无法切换版本"),
+    );
+  });
 });

--- a/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
+++ b/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
@@ -20,6 +20,12 @@ interface VersionTimeMachineProps {
    * 显示成功但随后被编辑任务覆盖，用户最后一次选择丢失。
    */
   busy?: boolean;
+  /**
+   * 恢复请求在途状态回传父级：`busy` 只做「外部占用 → 禁恢复」这一向，兄弟控件
+   * （生成、上传）还需反向知道恢复正在写同一个资源文件，否则恢复返回前它们仍可点，
+   * 两个请求并发写同一路径、后完成者覆盖前者且双方都提示成功。
+   */
+  onRestoringChange?: (restoring: boolean) => void;
 }
 
 function getImagePreviewHeightClass(
@@ -49,6 +55,7 @@ export function VersionTimeMachine({
   onRestore,
   iconOnly = false,
   busy = false,
+  onRestoringChange,
 }: VersionTimeMachineProps) {
   const { t } = useTranslation("dashboard");
   const resourcePath =
@@ -111,6 +118,7 @@ export function VersionTimeMachine({
     // 这里兜底防止禁用态生效前的一次点击仍发出恢复请求。
     if (busy || restoringVersion !== null) return;
     setRestoringVersion(version);
+    onRestoringChange?.(true);
     try {
       const result = await API.restoreVersion(projectName, resourceType, resourceId, version);
       if (result.asset_fingerprints) {
@@ -126,6 +134,7 @@ export function VersionTimeMachine({
         .pushToast(t("switch_version_failed", { message: errMsg(err) }), "error");
     } finally {
       setRestoringVersion(null);
+      onRestoringChange?.(false);
     }
   }
 

--- a/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
+++ b/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
@@ -26,6 +26,12 @@ interface VersionTimeMachineProps {
    * 两个请求并发写同一路径、后完成者覆盖前者且双方都提示成功。
    */
   onRestoringChange?: (restoring: boolean) => void;
+  /**
+   * 提交时刻的占用复核（新鲜读）：`busy` 是最近一次渲染的快照，版本面板打开期间
+   * Agent 入队、批量入口或轮询落库都可能占用该资源，新 prop 冲刷到按钮之前的点击
+   * 仍会发出恢复请求，与在跑的任务并发写同一个资源文件。返回 true 即拒绝本次恢复。
+   */
+  checkBusy?: () => boolean;
 }
 
 function getImagePreviewHeightClass(
@@ -56,6 +62,7 @@ export function VersionTimeMachine({
   iconOnly = false,
   busy = false,
   onRestoringChange,
+  checkBusy,
 }: VersionTimeMachineProps) {
   const { t } = useTranslation("dashboard");
   const resourcePath =
@@ -117,6 +124,11 @@ export function VersionTimeMachine({
     // disabled 是响应式的 restoringVersion/busy：面板打开期间资源转为占用中时随之更新，
     // 这里兜底防止禁用态生效前的一次点击仍发出恢复请求。
     if (busy || restoringVersion !== null) return;
+    // 渲染快照之外再做一次新鲜读：状态已变、渲染未到的窗口里按钮仍可点。
+    if (checkBusy?.()) {
+      useAppStore.getState().pushToast(t("version_restore_busy_hint"), "error");
+      return;
+    }
     setRestoringVersion(version);
     onRestoringChange?.(true);
     try {

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -35,6 +35,50 @@ function task(overrides: Partial<TaskItem> & { task_id: string }): TaskItem {
   };
 }
 
+// 乐观标记 key 的构造（与 tasks-store 内部编码一致）。seq 只用于区分同资源上的并发
+// 标记，单条标记的测试取固定值即可。
+const TASK_ID_SEP = "\u0001";
+
+/** 在途标记：请求已发出、后端 task_id 未知。 */
+function pendingKey(
+  resourceKind: string,
+  resourceId: string,
+  pendingTaskType: string,
+  opts: { projectName?: string; seq?: number } = {},
+): string {
+  const { projectName = "proj", seq = 1 } = opts;
+  return `${projectName}\0${resourceKind}\0${resourceId}\0${pendingTaskType}\0${seq}\0`;
+}
+
+/** 已兑现标记：等待这些 task_id 的真实行落库。 */
+function settledKey(
+  resourceKind: string,
+  resourceId: string,
+  pendingTaskType: string,
+  taskIds: string[],
+  opts: { projectName?: string; seq?: number } = {},
+): string {
+  return pendingKey(resourceKind, resourceId, pendingTaskType, opts) + taskIds.join(TASK_ID_SEP);
+}
+
+function pendingScriptFileKey(
+  taskType: string,
+  scriptFile: string,
+  opts: { projectName?: string; seq?: number } = {},
+): string {
+  const { projectName = "proj", seq = 1 } = opts;
+  return `${projectName}\0${taskType}\0${scriptFile}\0${seq}\0`;
+}
+
+function settledScriptFileKey(
+  taskType: string,
+  scriptFile: string,
+  taskIds: string[],
+  opts: { projectName?: string; seq?: number } = {},
+): string {
+  return pendingScriptFileKey(taskType, scriptFile, opts) + taskIds.join(TASK_ID_SEP);
+}
+
 describe("isActiveStatus", () => {
   it("counts queued and running as active", () => {
     expect(isActiveStatus("queued")).toBe(true);
@@ -177,17 +221,15 @@ describe("selectActiveResourceIds with image_edit", () => {
 });
 
 describe("selectActiveResourceIds optimistic occupancy", () => {
-  it("counts a resource active via an optimistic marker when no real task row exists yet", () => {
-    // 提交成功但 SSE 尚未把任务行写进 store 的空窗：仅凭乐观标记也应判定占用（空 baseline）
-    const key = "proj\0character\0A\0image_edit\0";
+  it("counts a resource active via an in-flight marker when no real task row exists yet", () => {
+    // 请求已发出、后端 task_id 未知的往返窗口：仅凭在途标记也应判定占用
+    const key = pendingKey("character", "A", "image_edit");
     expect(selectActiveResourceIds([], "character", "proj", new Set([key])).has("A")).toBe(true);
   });
 
-  it("lets a real task row newer than the baseline supersede the optimistic marker regardless of its status", () => {
-    // 真实任务行一旦出现（哪怕已是终态），不再依赖乐观标记——但此时该行本身若是活跃态，
-    // 仍会通过 selectActiveResourceIds 主逻辑判定占用；这里验证的是"不因乐观标记残留而
-    // 对已完结的真实行仍强制判占用"
-    const key = "proj\0character\0A\0image_edit\0";
+  it("lets the marker's own task row supersede it regardless of that row's status", () => {
+    // 本次提交的任务行一旦出现（哪怕已是终态），占用判定就交回真实数据
+    const key = settledKey("character", "A", "image_edit", ["edit-A"]);
     const tasks = [
       task({
         task_id: "edit-A",
@@ -200,10 +242,10 @@ describe("selectActiveResourceIds optimistic occupancy", () => {
     expect(selectActiveResourceIds(tasks, "character", "proj", new Set([key])).has("A")).toBe(false);
   });
 
-  it("does not let a stale task row predating the baseline supersede a marker for a repeat edit", () => {
-    // 同一资源被反复编辑：本次标记的 baseline 取自上一次编辑遗留的终态行 updated_at，
-    // 该旧行本身不该被当作"本次"标记等待的真实行，否则二次编辑期间会误判空闲
-    const key = `proj\0character\0A\0image_edit\0${"2026-07-16T00:00:00Z"}`;
+  it("does not let another task row of the same resource supersede the marker", () => {
+    // 同一资源被反复编辑：上一次编辑遗留的终态行不是本次标记等待的行，
+    // 否则二次编辑期间会误判空闲
+    const key = settledKey("character", "A", "image_edit", ["edit-A-second"]);
     const tasks = [
       task({
         task_id: "edit-A-first",
@@ -217,8 +259,25 @@ describe("selectActiveResourceIds optimistic occupancy", () => {
     expect(selectActiveResourceIds(tasks, "character", "proj", new Set([key])).has("A")).toBe(true);
   });
 
+  it("keeps an in-flight marker alive no matter what rows the poll brings back", () => {
+    // 晚到的旧轮询快照里不会有本次提交的任务行；在途标记更不该被它清掉，
+    // 否则请求往返窗口内资源会被误判为空闲、可重复入队
+    const key = pendingKey("character", "A", "image_edit");
+    const stale = [
+      task({
+        task_id: "edit-A-first",
+        task_type: "image_edit",
+        resource_type: "character",
+        resource_id: "A",
+        status: "failed",
+        updated_at: "2999-01-01T00:00:00Z",
+      }),
+    ];
+    expect(selectActiveResourceIds(stale, "character", "proj", new Set([key])).has("A")).toBe(true);
+  });
+
   it("ignores an optimistic marker scoped to a different project or resource kind", () => {
-    const key = "proj\0character\0A\0image_edit\0";
+    const key = pendingKey("character", "A", "image_edit");
     expect(selectActiveResourceIds([], "storyboard", "proj", new Set([key])).has("A")).toBe(false);
     expect(selectActiveResourceIds([], "character", "other-proj", new Set([key])).has("A")).toBe(false);
   });
@@ -226,7 +285,7 @@ describe("selectActiveResourceIds optimistic occupancy", () => {
   it("does not let a same-resource_id task of a different resource kind supersede the marker", () => {
     // character "A" 与 scene "A" 偶然同名(resource_id 相同)：scene 的真实行不该
     // 让 character 的乐观标记失效
-    const key = "proj\0character\0A\0image_edit\0";
+    const key = settledKey("character", "A", "image_edit", ["edit-char-A"]);
     const tasks = [
       task({
         task_id: "edit-scene-A",
@@ -240,8 +299,65 @@ describe("selectActiveResourceIds optimistic occupancy", () => {
   });
 });
 
-describe("useTasksStore.markOptimisticActive", () => {
-  it("marks a resource optimistically active and prunes markers already superseded by a real row", () => {
+describe("useTasksStore.beginOptimisticActive", () => {
+  function activeIds(): Set<string> {
+    const { tasks, optimisticActive } = useTasksStore.getState();
+    return selectActiveResourceIds(tasks, "character", "proj", optimisticActive);
+  }
+
+  it("occupies the resource from the moment the mark is taken, before any task id is known", () => {
+    useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
+
+    useTasksStore.getState().beginOptimisticActive("proj", "character", "A", "image_edit");
+
+    expect(activeIds().has("A")).toBe(true);
+  });
+
+  it("releases the resource on rollback so a failed request leaves no residue", () => {
+    useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
+
+    const mark = useTasksStore.getState().beginOptimisticActive("proj", "character", "A", "image_edit");
+    mark.rollback();
+
+    expect([...useTasksStore.getState().optimisticActive]).toEqual([]);
+    expect(activeIds().has("A")).toBe(false);
+  });
+
+  it("treats settling with no task ids as a rollback", () => {
+    // 后端没建任何任务行（如宫格按 scene_ids 过滤后无匹配分组）：标记若留下就永远
+    // 等不到真实行，资源被误判为永久占用
+    useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
+
+    const mark = useTasksStore.getState().beginOptimisticActive("proj", "character", "A", "image_edit");
+    mark.settle([]);
+
+    expect([...useTasksStore.getState().optimisticActive]).toEqual([]);
+  });
+
+  it("keeps occupying until the settled task row lands", () => {
+    useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
+
+    const mark = useTasksStore.getState().beginOptimisticActive("proj", "character", "A", "image_edit");
+    mark.settle(["edit-A"]);
+    expect(activeIds().has("A")).toBe(true);
+
+    useTasksStore.getState().setTasks([
+      task({
+        task_id: "edit-A",
+        task_type: "image_edit",
+        resource_type: "character",
+        resource_id: "A",
+        status: "succeeded",
+      }),
+    ]);
+    expect([...useTasksStore.getState().optimisticActive]).toEqual([]);
+    expect(activeIds().has("A")).toBe(false);
+  });
+
+  it("releases immediately when the settled task row is already a terminal row in the store", () => {
+    // 去重命中既有任务：后端返回的是那条既有行的 task_id，它已在 store 里且已终态。
+    // 标记必须当场让位——按时间戳基线比较时这条行永远「不比基线新」，标记会永久残留、
+    // 把资源锁死到页面刷新为止。
     useTasksStore.setState({
       tasks: [
         task({
@@ -253,51 +369,57 @@ describe("useTasksStore.markOptimisticActive", () => {
           updated_at: "2026-07-16T00:00:00Z",
         }),
       ],
-      optimisticActive: new Set([`proj\0character\0A\0image_edit\0${"2025-01-01T00:00:00Z"}`]),
+      optimisticActive: new Set(),
     });
 
-    // 标记一个新资源 B 的同时，A 的旧标记（baseline 早于真实终态行）已被取代，应被顺带清理
-    useTasksStore.getState().markOptimisticActive("proj", "character", "B", "image_edit");
+    const mark = useTasksStore.getState().beginOptimisticActive("proj", "character", "A", "image_edit");
+    mark.settle(["edit-A"]);
 
-    const keys = [...useTasksStore.getState().optimisticActive];
-    expect(keys).toEqual(["proj\0character\0B\0image_edit\0"]);
+    expect([...useTasksStore.getState().optimisticActive]).toEqual([]);
+    expect(activeIds().has("A")).toBe(false);
   });
 
-  it("uses the latest matching real row's updated_at as baseline so a repeat edit isn't superseded by the old row", () => {
-    // A 已有一条旧终态行；对 A 发起新一轮编辑时，baseline 应取该旧行的 updated_at，
-    // 使得新标记不会被这条旧行自己判定为"已超越"
+  it("rolls back only its own mark when two submissions overlap on the same resource", () => {
+    useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
+
+    const first = useTasksStore.getState().beginOptimisticActive("proj", "character", "A", "image_edit");
+    useTasksStore.getState().beginOptimisticActive("proj", "character", "A", "image_edit");
+    first.rollback();
+
+    expect(useTasksStore.getState().optimisticActive.size).toBe(1);
+    expect(activeIds().has("A")).toBe(true);
+  });
+
+  it("prunes markers already released by their task row when taking a new mark", () => {
     useTasksStore.setState({
       tasks: [
         task({
-          task_id: "edit-A-first",
+          task_id: "edit-A",
           task_type: "image_edit",
           resource_type: "character",
           resource_id: "A",
           status: "succeeded",
-          updated_at: "2026-07-16T00:00:00Z",
         }),
       ],
-      optimisticActive: new Set(),
+      optimisticActive: new Set([settledKey("character", "A", "image_edit", ["edit-A"])]),
     });
 
-    useTasksStore.getState().markOptimisticActive("proj", "character", "A", "image_edit");
+    useTasksStore.getState().beginOptimisticActive("proj", "character", "B", "image_edit");
 
     const keys = [...useTasksStore.getState().optimisticActive];
-    expect(keys).toEqual([`proj\0character\0A\0image_edit\0${"2026-07-16T00:00:00Z"}`]);
-
-    const { tasks, optimisticActive } = useTasksStore.getState();
-    expect(selectActiveResourceIds(tasks, "character", "proj", optimisticActive).has("A")).toBe(true);
+    expect(keys).toHaveLength(1);
+    expect(keys[0].startsWith("proj\0character\0B\0image_edit\0")).toBe(true);
   });
 });
 
 describe("useTasksStore.setTasks prunes stale optimistic markers", () => {
-  it("removes a marker superseded by a real row even without a new markOptimisticActive call", () => {
+  it("removes a marker released by its task row even without a new mark call", () => {
     // store 只保留最近 200 条任务：真实行落地后若被更晚的大量新任务挤出该窗口，
-    // 仅靠 markOptimisticActive 内的顺带清理不会再触发——轮询写回本身也要清理，
-    // 否则这条已完结的旧标记会永久残留，把资源误判为占用中直到页面刷新。
+    // 仅靠打标时的顺带清理不会再触发——轮询写回本身也要清理，否则这条已完结的旧
+    // 标记会永久残留，把资源误判为占用中直到页面刷新。
     useTasksStore.setState({
       tasks: [],
-      optimisticActive: new Set([`proj\0character\0A\0image_edit\0${"2025-01-01T00:00:00Z"}`]),
+      optimisticActive: new Set([settledKey("character", "A", "image_edit", ["edit-A"])]),
     });
 
     useTasksStore.getState().setTasks([
@@ -314,19 +436,34 @@ describe("useTasksStore.setTasks prunes stale optimistic markers", () => {
     expect([...useTasksStore.getState().optimisticActive]).toEqual([]);
   });
 
-  it("keeps a marker whose real row has not landed yet", () => {
-    useTasksStore.setState({
-      tasks: [],
-      optimisticActive: new Set([`proj\0character\0A\0image_edit\0`]),
-    });
+  it("keeps a marker whose task row has not landed yet", () => {
+    const key = settledKey("character", "A", "image_edit", ["edit-A"]);
+    useTasksStore.setState({ tasks: [], optimisticActive: new Set([key]) });
 
     useTasksStore.getState().setTasks([
       task({ task_id: "unrelated", resource_id: "B", task_type: "character" }),
     ]);
 
-    expect([...useTasksStore.getState().optimisticActive]).toEqual([
-      `proj\0character\0A\0image_edit\0`,
+    expect([...useTasksStore.getState().optimisticActive]).toEqual([key]);
+  });
+
+  it("never drops an in-flight marker, even on a poll that carries newer unrelated rows", () => {
+    // 晚到轮询不覆盖较新的乐观标记：请求往返期间任何写回都不足以判定资源已空闲
+    const key = pendingKey("character", "A", "image_edit");
+    useTasksStore.setState({ tasks: [], optimisticActive: new Set([key]) });
+
+    useTasksStore.getState().setTasks([
+      task({
+        task_id: "edit-A-first",
+        task_type: "image_edit",
+        resource_type: "character",
+        resource_id: "A",
+        status: "failed",
+        updated_at: "2999-01-01T00:00:00Z",
+      }),
     ]);
+
+    expect([...useTasksStore.getState().optimisticActive]).toEqual([key]);
   });
 });
 
@@ -417,16 +554,16 @@ describe("selectHasActiveTaskForScriptFile", () => {
   });
 
   describe("optimistic occupancy", () => {
-    it("counts the scriptFile active via an optimistic marker when no real grid row exists yet", () => {
-      // 宫格入队成功到轮询写回新 grid 任务行之间的空窗：仅凭乐观标记也应判定本集占用中
-      const key = "proj\0grid\0episode_1.json\0";
+    it("counts the scriptFile active via an in-flight marker when no real grid row exists yet", () => {
+      // 宫格请求发出到轮询写回新 grid 任务行之间的空窗：仅凭乐观标记也应判定本集占用中
+      const key = pendingScriptFileKey("grid", "episode_1.json");
       expect(
         selectHasActiveTaskForScriptFile([], "grid", "episode_1.json", "proj", new Set([key])),
       ).toBe(true);
     });
 
-    it("lets a real grid row newer than the baseline supersede the marker regardless of its status", () => {
-      const key = "proj\0grid\0episode_1.json\0";
+    it("lets the marker's own grid row supersede it regardless of that row's status", () => {
+      const key = settledScriptFileKey("grid", "episode_1.json", ["grid-1"]);
       const tasks = [
         task({
           task_id: "grid-1",
@@ -441,8 +578,34 @@ describe("selectHasActiveTaskForScriptFile", () => {
       ).toBe(false);
     });
 
-    it("does not let a stale row predating the baseline supersede a marker for a repeat submission", () => {
-      const key = `proj\0grid\0episode_1.json\0${"2026-07-16T00:00:00Z"}`;
+    it("releases as soon as any of the marker's rows lands", () => {
+      // 一次宫格入队会建多条任务行；只要其中一条落库，占用判定就交回真实数据
+      const key = settledScriptFileKey("grid", "episode_1.json", ["grid-1", "grid-2"]);
+      const tasks = [
+        task({
+          task_id: "grid-2",
+          task_type: "grid",
+          resource_id: "grid-def",
+          script_file: "episode_1.json",
+          status: "queued",
+        }),
+      ];
+      expect(
+        selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "proj", new Set([key])),
+      ).toBe(true); // 该行本身活跃
+      expect(
+        selectHasActiveTaskForScriptFile(
+          [{ ...tasks[0], status: "succeeded" }],
+          "grid",
+          "episode_1.json",
+          "proj",
+          new Set([key]),
+        ),
+      ).toBe(false); // 行已终态且标记已让位
+    });
+
+    it("does not let another submission's grid row supersede the marker", () => {
+      const key = settledScriptFileKey("grid", "episode_1.json", ["grid-new"]);
       const tasks = [
         task({
           task_id: "grid-old",
@@ -459,7 +622,7 @@ describe("selectHasActiveTaskForScriptFile", () => {
     });
 
     it("ignores a marker scoped to a different project, task type, or scriptFile", () => {
-      const key = "proj\0grid\0episode_1.json\0";
+      const key = pendingScriptFileKey("grid", "episode_1.json");
       expect(
         selectHasActiveTaskForScriptFile([], "storyboard", "episode_1.json", "proj", new Set([key])),
       ).toBe(false);
@@ -473,32 +636,51 @@ describe("selectHasActiveTaskForScriptFile", () => {
   });
 });
 
-describe("useTasksStore.markOptimisticActiveForScriptFile", () => {
-  it("marks a scriptFile optimistically active for the given taskType", () => {
+describe("useTasksStore.beginOptimisticActiveForScriptFile", () => {
+  function scriptFileActive(scriptFile = "episode_1.json"): boolean {
+    const { tasks, optimisticActiveScriptFile } = useTasksStore.getState();
+    return selectHasActiveTaskForScriptFile(tasks, "grid", scriptFile, "proj", optimisticActiveScriptFile);
+  }
+
+  it("occupies the scriptFile from the moment the mark is taken", () => {
     useTasksStore.setState({ tasks: [], optimisticActiveScriptFile: new Set() });
 
-    useTasksStore.getState().markOptimisticActiveForScriptFile("proj", "grid", "episode_1.json");
+    useTasksStore.getState().beginOptimisticActiveForScriptFile("proj", "grid", "episode_1.json");
 
-    const keys = [...useTasksStore.getState().optimisticActiveScriptFile];
-    expect(keys).toEqual(["proj\0grid\0episode_1.json\0"]);
-
-    const { tasks, optimisticActiveScriptFile } = useTasksStore.getState();
-    expect(
-      selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "proj", optimisticActiveScriptFile),
-    ).toBe(true);
+    expect(scriptFileActive()).toBe(true);
   });
 
   it("normalizes a scripts/ prefix in the scriptFile before storing the key", () => {
     useTasksStore.setState({ tasks: [], optimisticActiveScriptFile: new Set() });
 
-    useTasksStore.getState().markOptimisticActiveForScriptFile("proj", "grid", "scripts/episode_1.json");
+    useTasksStore.getState().beginOptimisticActiveForScriptFile("proj", "grid", "scripts/episode_1.json");
 
-    expect([...useTasksStore.getState().optimisticActiveScriptFile]).toEqual([
-      "proj\0grid\0episode_1.json\0",
-    ]);
+    // 带前缀打的标记，用裸文件名查询也要命中
+    expect(scriptFileActive("episode_1.json")).toBe(true);
   });
 
-  it("prunes markers already superseded by a real row when marking a different scriptFile", () => {
+  it("releases the scriptFile on rollback", () => {
+    useTasksStore.setState({ tasks: [], optimisticActiveScriptFile: new Set() });
+
+    const mark = useTasksStore.getState().beginOptimisticActiveForScriptFile("proj", "grid", "episode_1.json");
+    mark.rollback();
+
+    expect([...useTasksStore.getState().optimisticActiveScriptFile]).toEqual([]);
+    expect(scriptFileActive()).toBe(false);
+  });
+
+  it("treats settling with no task ids as a rollback", () => {
+    // 宫格按 scene_ids 过滤后无匹配分组时后端不建任务行，标记不能留下
+    useTasksStore.setState({ tasks: [], optimisticActiveScriptFile: new Set() });
+
+    const mark = useTasksStore.getState().beginOptimisticActiveForScriptFile("proj", "grid", "episode_1.json");
+    mark.settle([]);
+
+    expect([...useTasksStore.getState().optimisticActiveScriptFile]).toEqual([]);
+    expect(scriptFileActive()).toBe(false);
+  });
+
+  it("prunes markers already released by their task row when taking a new mark", () => {
     useTasksStore.setState({
       tasks: [
         task({
@@ -510,21 +692,22 @@ describe("useTasksStore.markOptimisticActiveForScriptFile", () => {
           updated_at: "2026-07-16T00:00:00Z",
         }),
       ],
-      optimisticActiveScriptFile: new Set([`proj\0grid\0episode_1.json\0${"2025-01-01T00:00:00Z"}`]),
+      optimisticActiveScriptFile: new Set([settledScriptFileKey("grid", "episode_1.json", ["grid-1"])]),
     });
 
-    useTasksStore.getState().markOptimisticActiveForScriptFile("proj", "grid", "episode_2.json");
+    useTasksStore.getState().beginOptimisticActiveForScriptFile("proj", "grid", "episode_2.json");
 
     const keys = [...useTasksStore.getState().optimisticActiveScriptFile];
-    expect(keys).toEqual(["proj\0grid\0episode_2.json\0"]);
+    expect(keys).toHaveLength(1);
+    expect(keys[0].startsWith("proj\0grid\0episode_2.json\0")).toBe(true);
   });
 });
 
 describe("useTasksStore.setTasks prunes stale optimisticActiveScriptFile markers", () => {
-  it("removes a scriptFile marker superseded by a real row without a new mark call", () => {
+  it("removes a scriptFile marker released by its task row without a new mark call", () => {
     useTasksStore.setState({
       tasks: [],
-      optimisticActiveScriptFile: new Set([`proj\0grid\0episode_1.json\0${"2025-01-01T00:00:00Z"}`]),
+      optimisticActiveScriptFile: new Set([settledScriptFileKey("grid", "episode_1.json", ["grid-1"])]),
     });
 
     useTasksStore.getState().setTasks([

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -730,6 +730,41 @@ describe("useTasksStore.setTasks prunes stale optimisticActiveScriptFile markers
     expect([...useTasksStore.getState().optimisticActiveScriptFile]).toEqual([]);
   });
 
+  it("多条任务行分两轮落地也让位，不要求同一快照里同时出现", () => {
+    // 轮询每次只取最新 200 行，单次入队产生的任务行数没有上限：若要求所有 task_id
+    // 在同一快照里同时出现，超出窗口的批次会永久残留、锁死分镜编辑直到刷新页面。
+    const key = settledScriptFileKey("grid", "episode_1.json", ["grid-1", "grid-2"]);
+    useTasksStore.setState({ tasks: [], optimisticActiveScriptFile: new Set([key]) });
+
+    const row = (taskId: string, resourceId: string) =>
+      task({
+        task_id: taskId,
+        task_type: "grid",
+        resource_id: resourceId,
+        script_file: "episode_1.json",
+        status: "succeeded",
+        updated_at: "2026-07-16T00:00:00Z",
+      });
+
+    // 第一轮只看得到 grid-1：扣除它，标记继续守住 grid-2
+    useTasksStore.getState().setTasks([row("grid-1", "grid-abc")]);
+    const afterFirst = [...useTasksStore.getState().optimisticActiveScriptFile];
+    expect(afterFirst).toHaveLength(1);
+    expect(
+      selectHasActiveTaskForScriptFile(
+        useTasksStore.getState().tasks,
+        "grid",
+        "episode_1.json",
+        "proj",
+        useTasksStore.getState().optimisticActiveScriptFile,
+      ),
+    ).toBe(true);
+
+    // 第二轮 grid-1 已被挤出窗口、只剩 grid-2：扣完，标记让位
+    useTasksStore.getState().setTasks([row("grid-2", "grid-def")]);
+    expect([...useTasksStore.getState().optimisticActiveScriptFile]).toEqual([]);
+  });
+
   it("一次提交建多条任务行时，只落地其中一条不让位", () => {
     // 宫格按分组逐条入队：首条已快速失败、其余尚未进入快照的窗口里，若按「任一落地」
     // 让位，scriptFile 既无乐观标记也无活跃真实行，分镜编辑会短暂解禁并与后续切割竞争。
@@ -746,7 +781,16 @@ describe("useTasksStore.setTasks prunes stale optimisticActiveScriptFile markers
         updated_at: "2026-07-16T00:00:00Z",
       }),
     ]);
-    expect([...useTasksStore.getState().optimisticActiveScriptFile]).toEqual([key]);
+    // 已落地的 grid-1 被扣除，标记仍在等 grid-2——占用按 selector 断言，不比对 key 字面量
+    expect(
+      selectHasActiveTaskForScriptFile(
+        useTasksStore.getState().tasks,
+        "grid",
+        "episode_1.json",
+        "proj",
+        useTasksStore.getState().optimisticActiveScriptFile,
+      ),
+    ).toBe(true);
 
     useTasksStore.getState().setTasks([
       task({

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -578,30 +578,36 @@ describe("selectHasActiveTaskForScriptFile", () => {
       ).toBe(false);
     });
 
-    it("releases as soon as any of the marker's rows lands", () => {
-      // 一次宫格入队会建多条任务行；只要其中一条落库，占用判定就交回真实数据
+    it("releases only after all of the marker's rows land", () => {
+      // 一次宫格入队会建多条任务行；只落地一条就交回真实数据的话，「首条已终态、
+      // 其余尚未进入快照」的窗口里 scriptFile 会被误判为空闲。
       const key = settledScriptFileKey("grid", "episode_1.json", ["grid-1", "grid-2"]);
-      const tasks = [
+      const landedOne = [
         task({
           task_id: "grid-2",
           task_type: "grid",
           resource_id: "grid-def",
           script_file: "episode_1.json",
-          status: "queued",
+          status: "succeeded",
         }),
       ];
       expect(
-        selectHasActiveTaskForScriptFile(tasks, "grid", "episode_1.json", "proj", new Set([key])),
-      ).toBe(true); // 该行本身活跃
+        selectHasActiveTaskForScriptFile(landedOne, "grid", "episode_1.json", "proj", new Set([key])),
+      ).toBe(true); // 仅一条落地且已终态，标记继续守住剩余那条
+
+      const landedAll = [
+        ...landedOne,
+        task({
+          task_id: "grid-1",
+          task_type: "grid",
+          resource_id: "grid-abc",
+          script_file: "episode_1.json",
+          status: "succeeded",
+        }),
+      ];
       expect(
-        selectHasActiveTaskForScriptFile(
-          [{ ...tasks[0], status: "succeeded" }],
-          "grid",
-          "episode_1.json",
-          "proj",
-          new Set([key]),
-        ),
-      ).toBe(false); // 行已终态且标记已让位
+        selectHasActiveTaskForScriptFile(landedAll, "grid", "episode_1.json", "proj", new Set([key])),
+      ).toBe(false); // 全部落地且均已终态，标记让位
     });
 
     it("does not let another submission's grid row supersede the marker", () => {
@@ -721,6 +727,45 @@ describe("useTasksStore.setTasks prunes stale optimisticActiveScriptFile markers
       }),
     ]);
 
+    expect([...useTasksStore.getState().optimisticActiveScriptFile]).toEqual([]);
+  });
+
+  it("一次提交建多条任务行时，只落地其中一条不让位", () => {
+    // 宫格按分组逐条入队：首条已快速失败、其余尚未进入快照的窗口里，若按「任一落地」
+    // 让位，scriptFile 既无乐观标记也无活跃真实行，分镜编辑会短暂解禁并与后续切割竞争。
+    const key = settledScriptFileKey("grid", "episode_1.json", ["grid-1", "grid-2"]);
+    useTasksStore.setState({ tasks: [], optimisticActiveScriptFile: new Set([key]) });
+
+    useTasksStore.getState().setTasks([
+      task({
+        task_id: "grid-1",
+        task_type: "grid",
+        resource_id: "grid-abc",
+        script_file: "episode_1.json",
+        status: "failed",
+        updated_at: "2026-07-16T00:00:00Z",
+      }),
+    ]);
+    expect([...useTasksStore.getState().optimisticActiveScriptFile]).toEqual([key]);
+
+    useTasksStore.getState().setTasks([
+      task({
+        task_id: "grid-1",
+        task_type: "grid",
+        resource_id: "grid-abc",
+        script_file: "episode_1.json",
+        status: "failed",
+        updated_at: "2026-07-16T00:00:00Z",
+      }),
+      task({
+        task_id: "grid-2",
+        task_type: "grid",
+        resource_id: "grid-def",
+        script_file: "episode_1.json",
+        status: "running",
+        updated_at: "2026-07-16T00:00:01Z",
+      }),
+    ]);
     expect([...useTasksStore.getState().optimisticActiveScriptFile]).toEqual([]);
   });
 });

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -56,7 +56,8 @@ export const defaultTaskStats: TaskStats = {
 //   scriptFile project \0 taskType \0 scriptFile \0 seq \0 taskIds
 //
 // seq 让同一资源上的两次并发提交各自可独立回滚；taskIds 为空串即「在途」——请求已发出、
-// 后端任务 id 未知，此时标记不可被任何轮询写回清除。
+// 后端任务 id 未知，此时标记不可被任何轮询写回清除。两种粒度的字段数不同，但 taskIds
+// 一律是最后一段，故让位判定只需 {@link markTaskIds} 一个解析口径，加字段不会错位。
 //
 // 让位判定看 task_id 而非时间戳：只有本次提交自己的任务行出现在 tasks 里，标记才交还给
 // 真实数据。这条判据同时堵住两个时序洞：
@@ -75,8 +76,9 @@ function encodeTaskIds(taskIds: readonly string[]): string {
   return taskIds.join(TASK_ID_SEP);
 }
 
-/** 取 key 尾部的 taskIds 段；在途标记返回空数组。 */
-function decodeTaskIds(encoded: string | undefined): string[] {
+/** 取标记 key 末段的 taskIds；在途标记（末段为空串）返回空数组。 */
+function markTaskIds(key: string): string[] {
+  const encoded = key.split("\0").at(-1);
   return encoded ? encoded.split(TASK_ID_SEP) : [];
 }
 
@@ -113,22 +115,13 @@ function isMarkSuperseded(taskIds: readonly string[], tasks: TaskItem[]): boolea
 // 按当前 tasks 修剪已让位的乐观占用标记（不新增标记，仅清理）。除兑现时机的顺带清理外，
 // 也要在每次 setTasks（轮询写回）时执行——真实任务行是经轮询进入 store 的，标记只能在
 // 那一刻发现自己该让位。
-function pruneSupersededOptimistic(
-  tasks: TaskItem[],
-  marks: ReadonlySet<string>,
-  taskIdsAt: number,
-): Set<string> {
+function pruneSupersededOptimistic(tasks: TaskItem[], marks: ReadonlySet<string>): Set<string> {
   const next = new Set<string>();
   for (const key of marks) {
-    if (!isMarkSuperseded(decodeTaskIds(key.split("\0")[taskIdsAt]), tasks)) next.add(key);
+    if (!isMarkSuperseded(markTaskIds(key), tasks)) next.add(key);
   }
   return next;
 }
-
-/** 资源粒度 key 中 taskIds 段的下标。 */
-const RESOURCE_TASK_IDS_AT = 5;
-/** scriptFile 粒度 key 中 taskIds 段的下标。 */
-const SCRIPT_FILE_TASK_IDS_AT = 4;
 
 export const useTasksStore = create<TasksState>((set, get) => {
   /**
@@ -137,13 +130,12 @@ export const useTasksStore = create<TasksState>((set, get) => {
    */
   function beginMark(
     field: "optimisticActive" | "optimisticActiveScriptFile",
-    taskIdsAt: number,
     keyOf: (taskIds: readonly string[]) => string,
   ): OptimisticHandle {
     const pendingKey = keyOf([]);
     set((s) => {
       // 顺带清理已让位的旧标记，避免 Set 在会话周期内无界增长。
-      const next = pruneSupersededOptimistic(s.tasks, s[field], taskIdsAt);
+      const next = pruneSupersededOptimistic(s.tasks, s[field]);
       next.add(pendingKey);
       return { [field]: next };
     });
@@ -154,7 +146,7 @@ export const useTasksStore = create<TasksState>((set, get) => {
         const next = new Set(s[field]);
         next.delete(pendingKey);
         // 去重命中既有任务时该行往往已在 store 里，此刻即判定让位，不必等下一轮轮询。
-        if (replacement !== null && !isMarkSuperseded(decodeTaskIds(replacement.split("\0")[taskIdsAt]), s.tasks)) {
+        if (replacement !== null && !isMarkSuperseded(markTaskIds(replacement), s.tasks)) {
           next.add(replacement);
         }
         return { [field]: next };
@@ -177,24 +169,20 @@ export const useTasksStore = create<TasksState>((set, get) => {
     setTasks: (tasks) =>
       set((s) => ({
         tasks,
-        optimisticActive: pruneSupersededOptimistic(tasks, s.optimisticActive, RESOURCE_TASK_IDS_AT),
-        optimisticActiveScriptFile: pruneSupersededOptimistic(
-          tasks,
-          s.optimisticActiveScriptFile,
-          SCRIPT_FILE_TASK_IDS_AT,
-        ),
+        optimisticActive: pruneSupersededOptimistic(tasks, s.optimisticActive),
+        optimisticActiveScriptFile: pruneSupersededOptimistic(tasks, s.optimisticActiveScriptFile),
       })),
     setStats: (stats) => set({ stats }),
     setConnected: (connected) => set({ connected }),
     beginOptimisticActive: (projectName, resourceKind, resourceId, pendingTaskType) => {
       const seq = ++optimisticSeq;
-      return beginMark("optimisticActive", RESOURCE_TASK_IDS_AT, (taskIds) =>
+      return beginMark("optimisticActive", (taskIds) =>
         optimisticKey(projectName, resourceKind, resourceId, pendingTaskType, seq, taskIds),
       );
     },
     beginOptimisticActiveForScriptFile: (projectName, taskType, scriptFile) => {
       const seq = ++optimisticSeq;
-      return beginMark("optimisticActiveScriptFile", SCRIPT_FILE_TASK_IDS_AT, (taskIds) =>
+      return beginMark("optimisticActiveScriptFile", (taskIds) =>
         optimisticScriptFileKey(projectName, taskType, scriptFile, seq, taskIds),
       );
     },
@@ -304,10 +292,9 @@ export function selectActiveResourceIds(
     if (isOccupyingStatus(task.status)) ids.add(task.resource_id);
   }
   for (const key of optimisticActive) {
-    const parts = key.split("\0");
-    const [kProject, kResourceKind, kResourceId] = parts;
+    const [kProject, kResourceKind, kResourceId] = key.split("\0");
     if (kProject !== projectName || kResourceKind !== taskType) continue;
-    if (!isMarkSuperseded(decodeTaskIds(parts[RESOURCE_TASK_IDS_AT]), tasks)) ids.add(kResourceId);
+    if (!isMarkSuperseded(markTaskIds(key), tasks)) ids.add(kResourceId);
   }
   return ids;
 }
@@ -353,10 +340,9 @@ export function selectHasActiveTaskForScriptFile(
   if (hasRealActive) return true;
 
   for (const key of optimisticActiveScriptFile) {
-    const parts = key.split("\0");
-    const [kProject, kTaskType, kScriptFile] = parts;
+    const [kProject, kTaskType, kScriptFile] = key.split("\0");
     if (kProject !== projectName || kTaskType !== taskType || kScriptFile !== normalized) continue;
-    if (!isMarkSuperseded(decodeTaskIds(parts[SCRIPT_FILE_TASK_IDS_AT]), tasks)) return true;
+    if (!isMarkSuperseded(markTaskIds(key), tasks)) return true;
   }
   return false;
 }

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -106,10 +106,14 @@ function optimisticScriptFileKey(
 /**
  * 标记是否已被自己等待的真实任务行取代。在途标记（taskIds 为空）永不成立——请求
  * 往返期间没有任何依据可以判定资源已空闲。
+ *
+ * 一次提交建多条任务行时（宫格按分组逐条入队），要**全部**出现才让位：只等到其中
+ * 一条就交还，会在「首条已终态、其余尚未进入快照」的窗口里把资源误判为空闲。
  */
 function isMarkSuperseded(taskIds: readonly string[], tasks: TaskItem[]): boolean {
   if (taskIds.length === 0) return false;
-  return tasks.some((t) => taskIds.includes(t.task_id));
+  const landed = new Set(tasks.map((t) => t.task_id));
+  return taskIds.every((id) => landed.has(id));
 }
 
 // 按当前 tasks 修剪已让位的乐观占用标记（不新增标记，仅清理）。除兑现时机的顺带清理外，

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -59,8 +59,9 @@ export const defaultTaskStats: TaskStats = {
 // 后端任务 id 未知，此时标记不可被任何轮询写回清除。两种粒度的字段数不同，但 taskIds
 // 一律是最后一段，故让位判定只需 {@link markTaskIds} 一个解析口径，加字段不会错位。
 //
-// 让位判定看 task_id 而非时间戳：只有本次提交自己的任务行出现在 tasks 里，标记才交还给
-// 真实数据。这条判据同时堵住两个时序洞：
+// 让位判定看 task_id 而非时间戳：只有本次提交自己的任务行**全部**出现在 tasks 里，标记
+// 才交还给真实数据；已落库的 id 逐轮从 key 里扣除，故不要求它们在同一个快照里同时出现。
+// 这条判据同时堵住两个时序洞：
 //   1. 终态先到不再永久残留——去重命中既有任务时后端返回的是那条既有行的 task_id，
 //      它已在（或即将在）tasks 里，标记随即让位；按时间戳比较则会因该行 updated_at
 //      不大于标记发起时的基线而永不让位。
@@ -103,26 +104,43 @@ function optimisticScriptFileKey(
   return `${projectName}\0${taskType}\0${stripScriptsPrefix(scriptFile)}\0${seq}\0${encodeTaskIds(taskIds)}`;
 }
 
-/**
- * 标记是否已被自己等待的真实任务行取代。在途标记（taskIds 为空）永不成立——请求
- * 往返期间没有任何依据可以判定资源已空闲。
- *
- * 一次提交建多条任务行时（宫格按分组逐条入队），要**全部**出现才让位：只等到其中
- * 一条就交还，会在「首条已终态、其余尚未进入快照」的窗口里把资源误判为空闲。
- */
-function isMarkSuperseded(taskIds: readonly string[], tasks: TaskItem[]): boolean {
-  if (taskIds.length === 0) return false;
-  const landed = new Set(tasks.map((t) => t.task_id));
-  return taskIds.every((id) => landed.has(id));
+/** 把 key 末段的 taskIds 换成 `taskIds`，其余字段原样保留。 */
+function withTaskIds(key: string, taskIds: readonly string[]): string {
+  return key.slice(0, key.lastIndexOf("\0") + 1) + encodeTaskIds(taskIds);
 }
 
-// 按当前 tasks 修剪已让位的乐观占用标记（不新增标记，仅清理）。除兑现时机的顺带清理外，
-// 也要在每次 setTasks（轮询写回）时执行——真实任务行是经轮询进入 store 的，标记只能在
-// 那一刻发现自己该让位。
+/** 本次快照里已落库的 task_id。 */
+function landedTaskIds(tasks: TaskItem[]): Set<string> {
+  return new Set(tasks.map((t) => t.task_id));
+}
+
+/**
+ * 该标记经本次快照后应以什么形态留下：已扣完（等待的 task_id 全部落库）返回 null
+ * 表示让位，否则返回扣除后的 key（无变化时原样返回，避免无谓的 Set 抖动）。
+ *
+ * 在途标记（taskIds 为空）原样留下、永不让位——请求往返期间没有任何依据可以判定
+ * 资源已空闲。一次提交建多条任务行时（宫格按分组逐条入队），要**全部**落库才让位：
+ * 只等到其中一条就交还，会在「首条已终态、其余尚未进入快照」的窗口里把资源误判为
+ * 空闲。扣除逐轮累计，不要求所有 task_id 在同一个快照里同时出现——轮询每次只取最新
+ * 200 行，而单次入队产生的任务行数没有上限。
+ */
+function keepMark(key: string, landed: ReadonlySet<string>): string | null {
+  const taskIds = markTaskIds(key);
+  if (taskIds.length === 0) return key; // 在途标记
+  const remaining = taskIds.filter((id) => !landed.has(id));
+  if (remaining.length === 0) return null;
+  return remaining.length === taskIds.length ? key : withTaskIds(key, remaining);
+}
+
+// 按当前 tasks 修剪乐观占用标记（不新增标记，仅扣除已落库的 task_id 并清理已让位者）。
+// 除兑现时机的顺带清理外，也要在每次 setTasks（轮询写回）时执行——真实任务行是经轮询
+// 进入 store 的，标记只能在那一刻发现自己的行已落库。
 function pruneSupersededOptimistic(tasks: TaskItem[], marks: ReadonlySet<string>): Set<string> {
+  const landed = landedTaskIds(tasks);
   const next = new Set<string>();
   for (const key of marks) {
-    if (!isMarkSuperseded(markTaskIds(key), tasks)) next.add(key);
+    const kept = keepMark(key, landed);
+    if (kept !== null) next.add(kept);
   }
   return next;
 }
@@ -149,9 +167,11 @@ export const useTasksStore = create<TasksState>((set, get) => {
       set((s) => {
         const next = new Set(s[field]);
         next.delete(pendingKey);
-        // 去重命中既有任务时该行往往已在 store 里，此刻即判定让位，不必等下一轮轮询。
-        if (replacement !== null && !isMarkSuperseded(markTaskIds(replacement), s.tasks)) {
-          next.add(replacement);
+        if (replacement !== null) {
+          // 去重命中既有任务时该行往往已在 store 里，此刻即扣除，不必等下一轮轮询；
+          // 全部扣完即当场让位。
+          const kept = keepMark(replacement, landedTaskIds(s.tasks));
+          if (kept !== null) next.add(kept);
         }
         return { [field]: next };
       });
@@ -295,10 +315,12 @@ export function selectActiveResourceIds(
   for (const task of latestByResourceAndTaskType.values()) {
     if (isOccupyingStatus(task.status)) ids.add(task.resource_id);
   }
+  // 修剪发生在 setTasks 时，selector 可能先于它看到新快照，故这里按同一判据现算。
+  const landed = landedTaskIds(tasks);
   for (const key of optimisticActive) {
     const [kProject, kResourceKind, kResourceId] = key.split("\0");
     if (kProject !== projectName || kResourceKind !== taskType) continue;
-    if (!isMarkSuperseded(markTaskIds(key), tasks)) ids.add(kResourceId);
+    if (keepMark(key, landed) !== null) ids.add(kResourceId);
   }
   return ids;
 }
@@ -343,10 +365,11 @@ export function selectHasActiveTaskForScriptFile(
   );
   if (hasRealActive) return true;
 
+  const landed = landedTaskIds(tasks);
   for (const key of optimisticActiveScriptFile) {
     const [kProject, kTaskType, kScriptFile] = key.split("\0");
     if (kProject !== projectName || kTaskType !== taskType || kScriptFile !== normalized) continue;
-    if (!isMarkSuperseded(markTaskIds(key), tasks)) return true;
+    if (keepMark(key, landed) !== null) return true;
   }
   return false;
 }

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -2,6 +2,21 @@ import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
 import type { TaskItem, TaskStats, TaskStatus } from "@/types";
 
+/**
+ * 一次入队提交的乐观占用句柄。由入队动作层在**请求发出前**取得，请求结束时二选一兑现：
+ *
+ * - `settle(taskIds)` —— 后端已建（或去重命中）任务行，标记转为等待这些 task_id 落库；
+ *   传空数组表示本次没有产生任何任务行，等同 `rollback()`（否则标记永远等不到真实行）。
+ * - `rollback()` —— 请求失败，撤销标记。
+ *
+ * 未兑现前标记处于「在途」态，不被任何轮询写回清除——这段正是请求往返窗口，
+ * 各调用方过去要自备 in-flight ref 才能覆盖。
+ */
+export interface OptimisticHandle {
+  settle: (taskIds: string[]) => void;
+  rollback: () => void;
+}
+
 interface TasksState {
   tasks: TaskItem[];
   stats: TaskStats;
@@ -15,147 +30,176 @@ interface TasksState {
   setTasks: (tasks: TaskItem[]) => void;
   setStats: (stats: TaskStats) => void;
   setConnected: (connected: boolean) => void;
-  markOptimisticActive: (
+  beginOptimisticActive: (
     projectName: string,
     resourceKind: string,
     resourceId: string,
     pendingTaskType: string,
-  ) => void;
-  markOptimisticActiveForScriptFile: (
+  ) => OptimisticHandle;
+  beginOptimisticActiveForScriptFile: (
     projectName: string,
     taskType: string,
     scriptFile: string,
-  ) => void;
+  ) => OptimisticHandle;
 }
 
 export const defaultTaskStats: TaskStats = {
   queued: 0, running: 0, cancelling: 0, succeeded: 0, failed: 0, cancelled: 0, total: 0,
 };
 
-// 标记发起时尚未有真实行，baseline 取空串——空串小于任何 ISO 时间戳，故首次判定
-// 一律视为"尚无真实行"，语义与之前一致；同资源之后再次编辑时 baseline 取当时最新
-// 真实行的 updated_at，只有新落地的行（updated_at 大于 baseline）才能让位，旧终态
-// 行不会误判为"当前这次"的真实行。
+// ---------------------------------------------------------------------------
+// 乐观占用标记的编码与让位判定
+//
+// 标记以字符串 key 存于 Set，尾部两段是「标记序号」与「已兑现的 task_id 列表」：
+//
+//   资源粒度   project \0 resourceKind \0 resourceId \0 pendingTaskType \0 seq \0 taskIds
+//   scriptFile project \0 taskType \0 scriptFile \0 seq \0 taskIds
+//
+// seq 让同一资源上的两次并发提交各自可独立回滚；taskIds 为空串即「在途」——请求已发出、
+// 后端任务 id 未知，此时标记不可被任何轮询写回清除。
+//
+// 让位判定看 task_id 而非时间戳：只有本次提交自己的任务行出现在 tasks 里，标记才交还给
+// 真实数据。这条判据同时堵住两个时序洞：
+//   1. 终态先到不再永久残留——去重命中既有任务时后端返回的是那条既有行的 task_id，
+//      它已在（或即将在）tasks 里，标记随即让位；按时间戳比较则会因该行 updated_at
+//      不大于标记发起时的基线而永不让位。
+//   2. 晚到的旧轮询结果不再覆盖较新的标记——旧快照里没有本次的 task_id，判定不成立。
+// ---------------------------------------------------------------------------
+
+/** 已兑现 task_id 之间的分隔符；与字段分隔符 \0 区分开，便于解析。 */
+const TASK_ID_SEP = "\u0001";
+
+let optimisticSeq = 0;
+
+function encodeTaskIds(taskIds: readonly string[]): string {
+  return taskIds.join(TASK_ID_SEP);
+}
+
+/** 取 key 尾部的 taskIds 段；在途标记返回空数组。 */
+function decodeTaskIds(encoded: string | undefined): string[] {
+  return encoded ? encoded.split(TASK_ID_SEP) : [];
+}
+
 function optimisticKey(
   projectName: string,
   resourceKind: string,
   resourceId: string,
   pendingTaskType: string,
-  baselineUpdatedAt: string,
+  seq: number,
+  taskIds: readonly string[],
 ): string {
-  return `${projectName}\0${resourceKind}\0${resourceId}\0${pendingTaskType}\0${baselineUpdatedAt}`;
-}
-
-// 按当前 tasks 修剪已被真实行取代的乐观占用标记（不新增标记，仅清理）。除标记时机的顺带
-// 清理外，也要在每次 setTasks（轮询写回）时执行——store 只保留最近 200 条任务，若真实行
-// 落地后被更晚的大量新任务挤出该窗口，仅在“下次再有新标记”时才清理会让这条已完结的旧
-// 标记永久残留、误判资源占用中，必须让轮询本身也承担清理职责。
-function pruneSupersededOptimisticActive(
-  tasks: TaskItem[],
-  optimisticActive: ReadonlySet<string>,
-): Set<string> {
-  const next = new Set<string>();
-  for (const key of optimisticActive) {
-    const [kProject, kResourceKind, kResourceId, kPendingTaskType, kBaseline = ""] = key.split("\0");
-    const superseded = tasks.some(
-      (t) =>
-        t.project_name === kProject &&
-        t.task_type === kPendingTaskType &&
-        t.resource_id === kResourceId &&
-        taskResourceKind(t) === kResourceKind &&
-        t.updated_at > kBaseline,
-    );
-    if (!superseded) next.add(key);
-  }
-  return next;
+  return `${projectName}\0${resourceKind}\0${resourceId}\0${pendingTaskType}\0${seq}\0${encodeTaskIds(taskIds)}`;
 }
 
 function optimisticScriptFileKey(
   projectName: string,
   taskType: string,
   scriptFile: string,
-  baselineUpdatedAt: string,
+  seq: number,
+  taskIds: readonly string[],
 ): string {
-  return `${projectName}\0${taskType}\0${stripScriptsPrefix(scriptFile)}\0${baselineUpdatedAt}`;
+  return `${projectName}\0${taskType}\0${stripScriptsPrefix(scriptFile)}\0${seq}\0${encodeTaskIds(taskIds)}`;
 }
 
-// scriptFile 粒度乐观标记的同类修剪，见 {@link pruneSupersededOptimisticActive}。
-function pruneSupersededOptimisticActiveScriptFile(
+/**
+ * 标记是否已被自己等待的真实任务行取代。在途标记（taskIds 为空）永不成立——请求
+ * 往返期间没有任何依据可以判定资源已空闲。
+ */
+function isMarkSuperseded(taskIds: readonly string[], tasks: TaskItem[]): boolean {
+  if (taskIds.length === 0) return false;
+  return tasks.some((t) => taskIds.includes(t.task_id));
+}
+
+// 按当前 tasks 修剪已让位的乐观占用标记（不新增标记，仅清理）。除兑现时机的顺带清理外，
+// 也要在每次 setTasks（轮询写回）时执行——真实任务行是经轮询进入 store 的，标记只能在
+// 那一刻发现自己该让位。
+function pruneSupersededOptimistic(
   tasks: TaskItem[],
-  optimisticActiveScriptFile: ReadonlySet<string>,
+  marks: ReadonlySet<string>,
+  taskIdsAt: number,
 ): Set<string> {
   const next = new Set<string>();
-  for (const key of optimisticActiveScriptFile) {
-    const [kProject, kTaskType, kScriptFile, kBaseline = ""] = key.split("\0");
-    const superseded = tasks.some(
-      (t) =>
-        t.project_name === kProject &&
-        t.task_type === kTaskType &&
-        t.script_file != null &&
-        stripScriptsPrefix(t.script_file) === kScriptFile &&
-        t.updated_at > kBaseline,
-    );
-    if (!superseded) next.add(key);
+  for (const key of marks) {
+    if (!isMarkSuperseded(decodeTaskIds(key.split("\0")[taskIdsAt]), tasks)) next.add(key);
   }
   return next;
 }
 
-export const useTasksStore = create<TasksState>((set) => ({
-  tasks: [],
-  stats: defaultTaskStats,
-  connected: false,
-  optimisticActive: new Set(),
-  optimisticActiveScriptFile: new Set(),
+/** 资源粒度 key 中 taskIds 段的下标。 */
+const RESOURCE_TASK_IDS_AT = 5;
+/** scriptFile 粒度 key 中 taskIds 段的下标。 */
+const SCRIPT_FILE_TASK_IDS_AT = 4;
 
-  setTasks: (tasks) =>
-    set((s) => ({
-      tasks,
-      optimisticActive: pruneSupersededOptimisticActive(tasks, s.optimisticActive),
-      optimisticActiveScriptFile: pruneSupersededOptimisticActiveScriptFile(tasks, s.optimisticActiveScriptFile),
-    })),
-  setStats: (stats) => set({ stats }),
-  setConnected: (connected) => set({ connected }),
-  markOptimisticActive: (projectName, resourceKind, resourceId, pendingTaskType) =>
+export const useTasksStore = create<TasksState>((set, get) => {
+  /**
+   * begin/settle/rollback 三态的公共骨架：两种粒度只在 key 编码与落到哪个 Set 上不同。
+   * `field` 选定 Set，`keyOf(taskIds)` 按已兑现的 task_id 编码出 key（空数组即在途 key）。
+   */
+  function beginMark(
+    field: "optimisticActive" | "optimisticActiveScriptFile",
+    taskIdsAt: number,
+    keyOf: (taskIds: readonly string[]) => string,
+  ): OptimisticHandle {
+    const pendingKey = keyOf([]);
     set((s) => {
-      let baseline = "";
-      for (const t of s.tasks) {
-        if (
-          t.project_name === projectName &&
-          t.task_type === pendingTaskType &&
-          t.resource_id === resourceId &&
-          taskResourceKind(t) === resourceKind &&
-          t.updated_at > baseline
-        ) {
-          baseline = t.updated_at;
-        }
-      }
+      // 顺带清理已让位的旧标记，避免 Set 在会话周期内无界增长。
+      const next = pruneSupersededOptimistic(s.tasks, s[field], taskIdsAt);
+      next.add(pendingKey);
+      return { [field]: next };
+    });
 
-      // 顺带清理已被真实任务行取代的旧标记，避免 Set 在会话周期内无界增长。
-      const next = pruneSupersededOptimisticActive(s.tasks, s.optimisticActive);
-      next.add(optimisticKey(projectName, resourceKind, resourceId, pendingTaskType, baseline));
-      return { optimisticActive: next };
-    }),
-  markOptimisticActiveForScriptFile: (projectName, taskType, scriptFile) =>
-    set((s) => {
-      const normalized = stripScriptsPrefix(scriptFile);
-      let baseline = "";
-      for (const t of s.tasks) {
-        if (
-          t.project_name === projectName &&
-          t.task_type === taskType &&
-          t.script_file != null &&
-          stripScriptsPrefix(t.script_file) === normalized &&
-          t.updated_at > baseline
-        ) {
-          baseline = t.updated_at;
+    const drop = (replacement: string | null): void => {
+      if (!get()[field].has(pendingKey)) return; // 已被回滚或被 store 重置
+      set((s) => {
+        const next = new Set(s[field]);
+        next.delete(pendingKey);
+        // 去重命中既有任务时该行往往已在 store 里，此刻即判定让位，不必等下一轮轮询。
+        if (replacement !== null && !isMarkSuperseded(decodeTaskIds(replacement.split("\0")[taskIdsAt]), s.tasks)) {
+          next.add(replacement);
         }
-      }
+        return { [field]: next };
+      });
+    };
 
-      const next = pruneSupersededOptimisticActiveScriptFile(s.tasks, s.optimisticActiveScriptFile);
-      next.add(optimisticScriptFileKey(projectName, taskType, scriptFile, baseline));
-      return { optimisticActiveScriptFile: next };
-    }),
-}));
+    return {
+      settle: (taskIds) => drop(taskIds.length > 0 ? keyOf(taskIds) : null),
+      rollback: () => drop(null),
+    };
+  }
+
+  return {
+    tasks: [],
+    stats: defaultTaskStats,
+    connected: false,
+    optimisticActive: new Set(),
+    optimisticActiveScriptFile: new Set(),
+
+    setTasks: (tasks) =>
+      set((s) => ({
+        tasks,
+        optimisticActive: pruneSupersededOptimistic(tasks, s.optimisticActive, RESOURCE_TASK_IDS_AT),
+        optimisticActiveScriptFile: pruneSupersededOptimistic(
+          tasks,
+          s.optimisticActiveScriptFile,
+          SCRIPT_FILE_TASK_IDS_AT,
+        ),
+      })),
+    setStats: (stats) => set({ stats }),
+    setConnected: (connected) => set({ connected }),
+    beginOptimisticActive: (projectName, resourceKind, resourceId, pendingTaskType) => {
+      const seq = ++optimisticSeq;
+      return beginMark("optimisticActive", RESOURCE_TASK_IDS_AT, (taskIds) =>
+        optimisticKey(projectName, resourceKind, resourceId, pendingTaskType, seq, taskIds),
+      );
+    },
+    beginOptimisticActiveForScriptFile: (projectName, taskType, scriptFile) => {
+      const seq = ++optimisticSeq;
+      return beginMark("optimisticActiveScriptFile", SCRIPT_FILE_TASK_IDS_AT, (taskIds) =>
+        optimisticScriptFileKey(projectName, taskType, scriptFile, seq, taskIds),
+      );
+    },
+  };
+});
 
 // ---------------------------------------------------------------------------
 // 派生 selector —— 任务队列两条不变量的单一真相源
@@ -228,19 +272,18 @@ export function selectLatestTaskByResource(
  * （成功/失败）会掩盖仍在运行的生成任务（或反之），导致资源被误判为空闲。故按各自
  * task_type 分别取最新行，再在任一 task_type 的最新行活跃时即计入占用。
  *
- * 乐观占用：入队请求成功返回到 `useTasksSSE` 下一次轮询把新任务行写进 store 之间有
- * ~3s 空窗（轮询间隔），期间该 resource 在 store 里还没有对应任务行、判定为空闲。
- * image_edit 与其目标资源共用占用槽，是第一个会在此空窗内与「本资源另一 task_type」
- * 并发提交的场景（同 task_type 的并发提交已被后端 dedupe 索引拦下，见
- * `idx_tasks_dedupe_active`，但该索引以 task_type 为键的一部分，不拦跨 task_type 并发）。
- * `optimisticActive` 由提交方（如 ImageEditButton）在提交成功后立即标记，此处按
- * (projectName, taskType) 过滤后并入占用集，直到标记所等待的真实任务行出现为止
- * （比对不看状态，出现即让位给真实数据）。标记内嵌 baseline（标记发起时刻该资源
- * 已有的最新同类真实行 updated_at）与 resourceKind：同一资源被反复编辑时，若不比对
- * baseline，本次标记会被上一次编辑遗留的旧终态行误判为"已有真实行"而立即失效；
- * 若不比对 resourceKind，不同资源种类之间偶然的 resource_id 相同（如同名角色与场景）
- * 会互相让位。故只有 updated_at 大于 baseline 且 resourceKind 匹配的行才视为"本次
- * 标记等待的真实行"。
+ * 乐观占用：从入队请求发出到 `useTasksSSE` 下一次轮询把新任务行写进 store 之间，
+ * 该 resource 在 store 里还没有对应任务行、判定为空闲。这个空窗跨越请求往返与一个
+ * 轮询间隔（~3s），期间同资源的其它入口会误判可提交——image_edit 与其目标资源共用
+ * 占用槽，是第一个会在此空窗内与「本资源另一 task_type」并发提交的场景（同 task_type
+ * 的并发提交已被后端 dedupe 索引拦下，见 `idx_tasks_dedupe_active`，但该索引以
+ * task_type 为键的一部分，不拦跨 task_type 并发）。
+ *
+ * `optimisticActive` 由入队动作层在**请求发出前**用 {@link OptimisticHandle} 标记、
+ * 请求失败时回滚，故整个空窗都被覆盖；此处按 (projectName, resourceKind) 过滤后并入
+ * 占用集，直到标记所等待的真实任务行出现为止（比对不看状态，出现即让位给真实数据）。
+ * 标记按 task_id 认领自己的真实行，判据与残留风险见文件上方「乐观占用标记的编码与
+ * 让位判定」。
  */
 export function selectActiveResourceIds(
   tasks: TaskItem[],
@@ -261,17 +304,10 @@ export function selectActiveResourceIds(
     if (isOccupyingStatus(task.status)) ids.add(task.resource_id);
   }
   for (const key of optimisticActive) {
-    const [kProject, kResourceKind, kResourceId, kPendingTaskType, kBaseline = ""] = key.split("\0");
+    const parts = key.split("\0");
+    const [kProject, kResourceKind, kResourceId] = parts;
     if (kProject !== projectName || kResourceKind !== taskType) continue;
-    const hasPendingRow = tasks.some(
-      (t) =>
-        t.project_name === kProject &&
-        t.task_type === kPendingTaskType &&
-        t.resource_id === kResourceId &&
-        taskResourceKind(t) === kResourceKind &&
-        t.updated_at > kBaseline,
-    );
-    if (!hasPendingRow) ids.add(kResourceId);
+    if (!isMarkSuperseded(decodeTaskIds(parts[RESOURCE_TASK_IDS_AT]), tasks)) ids.add(kResourceId);
   }
   return ids;
 }
@@ -293,8 +329,8 @@ function stripScriptsPrefix(path: string): string {
  * 会覆写本集内多个分镜的 storyboard 文件，故按 scriptFile 判定「本集是否有宫格任务
  * 在跑」，用于禁用宫格模式下的分镜编辑入口，避免编辑与切割并发写同一文件。
  *
- * 乐观占用：宫格入队请求成功返回到下一次轮询把新 grid 任务行写进 store 之间有 ~3s 空窗，
- * 期间本集在 store 里尚无对应 grid 任务行，分镜编辑入口会误判为空闲、与随后的切割阶段
+ * 乐观占用：宫格入队请求发出到下一次轮询把新 grid 任务行写进 store 之间是空窗，期间
+ * 本集在 store 里尚无对应 grid 任务行，分镜编辑入口会误判为空闲、与随后的切割阶段
  * 并发写同一张 storyboard current 图。语义与 {@link selectActiveResourceIds} 的乐观占用
  * 小节一致，但归组键换成 scriptFile（grid 任务无法按 resource_id 归组，见上）。
  */
@@ -317,17 +353,10 @@ export function selectHasActiveTaskForScriptFile(
   if (hasRealActive) return true;
 
   for (const key of optimisticActiveScriptFile) {
-    const [kProject, kTaskType, kScriptFile, kBaseline = ""] = key.split("\0");
+    const parts = key.split("\0");
+    const [kProject, kTaskType, kScriptFile] = parts;
     if (kProject !== projectName || kTaskType !== taskType || kScriptFile !== normalized) continue;
-    const hasPendingRow = tasks.some(
-      (t) =>
-        t.project_name === kProject &&
-        t.task_type === kTaskType &&
-        t.script_file != null &&
-        stripScriptsPrefix(t.script_file) === kScriptFile &&
-        t.updated_at > kBaseline,
-    );
-    if (!hasPendingRow) return true;
+    if (!isMarkSuperseded(decodeTaskIds(parts[SCRIPT_FILE_TASK_IDS_AT]), tasks)) return true;
   }
   return false;
 }


### PR DESCRIPTION
Closes #1387

## 范围

只动前端占用（busy）判定这一条线：`frontend/src/actions/generation.ts`（入队动作层）、`frontend/src/stores/tasks-store.ts`（乐观占用标记）、两个参考视频画布的状态推导与占用接线、`VersionTimeMachine`（版本恢复）。

不动：后端入队接口与任务队列语义、轮询与 SSE 的传输机制、任何生成流程本身。

## 变更

- **乐观打标从「API 返回后」提前到「请求发出前」**，请求失败自动回滚，由 `frontend/src/actions/` 统一承担；调用方不再自备「请求在途」ref 去覆盖网络往返窗口（各画布自备的在途 ref 全部删除）。
- **让位判据从时间戳基线换成任务号认领。** 标记先处于「在途」态（不可被任何轮询清除），拿到后端返回的 task_id 后只认自己那几个 id 落库。堵掉两个时序洞：去重命中已终态任务时标记不再永久残留（旧判据下该行 `updated_at` 恒等于基线、永不满足「更新」）；晚到的旧轮询结果也不再冲掉刚打上的新标记。一次提交产生多条任务行时逐轮扣除，不要求它们出现在同一份快照里。
- **`markOptimisticActive` 改为返回句柄的 `beginOptimisticActive`**，`settle(taskIds)` / `rollback()` 二选一兑现。标记带自增序号，同资源两次并发提交互不影响；`settle([])` 等同回滚。响应体解析也移入 try，形状意外时同样回滚，不留永不清除的在途标记。
- **两个参考视频画布近乎逐字重复的 `statusMap` 四分支推导收敛为共享 `deriveUnitStatus`**，两画布唯一真实差异（成片能否来自手动上传）由 `supportsManualUpload` 表达。
- **`VersionTimeMachine`（版本恢复）接入占用判定** —— 此前完全未接，生成在途时可点恢复，与生成写回竞争同一个成片文件。恢复在途状态回传父级，反向禁用同一 unit 的生成与上传；新增可选的 `checkBusy` 钩子，在提交时刻做一次新鲜读复核。
- **成片上传与版本恢复的占用位提升到画布层按 unit 记录**（收敛为 `useUnitFlagSet`，state 供渲染、ref 供提交时刻新鲜读）。两者都不产生任务行、进不了 tasks-store 占用集，且预览面板有窄屏 sub-tab 与宽屏右栏两处挂载点，切换会卸载它而在途请求不取消。
- **批量生成的禁用条件改看「全部待生成 unit」**，与它的保护对象对齐；提交时刻逐个复核统一的占用判定，命中的 unit 静默跳过。

## 验收清单

- [x] 本地已跑相关测试：`pnpm lint`、`pnpm check`（typecheck + eslint + vitest）全绿，128 个测试文件 / 1301 个用例通过
- [ ] 手动验证了改动所声称的行为 —— 未做浏览器手动验证，行为由上述回归测试覆盖
- [x] 新增面向用户文案已加 zh/en 翻译（如适用）——本 PR 未新增文案 key，版本恢复的占用提示复用既有 `version_restore_busy_hint`（zh/en/vi 齐备）
- [x] 无新增 ESLint disable
- [x] CODEOWNERS 要求的 review 已请求（无额外 CODEOWNERS 要求）

两个时序洞各有回归测试锚定语义（按 selector 断言占用与否，不比对标记 key 的字面量）：终态先到当场让位、在途标记在任何轮询写回下都不被清除。两画布状态推导逐分支代入核对与改前等价。版本恢复的占用接线与提交时刻复核、批量路径的跳过语义与按钮禁用、上传确认的提交时刻复核各有用例覆盖。

## 已知 defer

- **批量入队端点缺少逐项 task_id 交接。** 单次入队产生的任务行数超过轮询窗口（`pageSize: 200`）时，早期行可能在响应返回前就被挤出快照；批量入队中途失败时，已提交的任务行也无法在回滚后被认领。两者同根因，残留窗口均为一个轮询周期（3s）后由真实任务行恢复占用。修法（端点返回已提交的 task_ids / 原子入队 / 批次标识）均属接口契约变更，超出本 PR 验收范围。Follow-up：ArcReel/ArcReel#1411
- **`setTasks` 全表覆盖缺少过期保护。** 轮询写回不校验快照新鲜度，这是既有行为，本 PR 未改变。Follow-up：ArcReel/ArcReel#1412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能 / 体验优化**
  * 生成、编辑、网格、参考视频等任务在请求发出前即显示占用；完成后自动按返回结果兑现并更新状态。
  * 批量生成与上传/版本恢复期间，若检测到占用则静默跳过冲突单元，并同步禁用相关按钮。
* **问题修复**
  * 失败或未创建任务会自动释放占用，避免资源长期“忙碌”。
  * 参考视频画布的单元状态/忙碌判定在并发、延迟返回与状态切换下更一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

