### PR TITLE
feat(video): 分集规划支持从指定集数起部分重置，保留在前剧集并续接编号

### DIFF
--- a/lib/episode_reset.py
+++ b/lib/episode_reset.py
@@ -278,15 +278,17 @@ def _resolve_partial_reset_cursor(
     任一不满足都会让「保留到哪、退回到哪」无法安全推算，抛 :class:`EpisodeResetError`
     并指引改用全量重置；调用方保证校验失败时账本不被改动：
 
-    - 账本形状必须干净（``episodes`` 是列表、条目均为对象、集号均可解析且不重复）——
-      部分重置与全量重置相反，不做「零前置校验」的损坏容忍，形状有问题直接指向
-      更彻底的全量重置
+    - 账本形状必须干净（``episodes`` 是列表、条目均为对象、集号均可解析、为正整数且
+      不重复）——部分重置与全量重置相反，不做「零前置校验」的损坏容忍，形状有问题
+      直接指向更彻底的全量重置
     - ``from_episode`` 必须是既有集号，且第 1..from_episode-1 集须连续存在（无缺口）
     - 第 from_episode-1 集（即 cursor 退回点）须带结构完整的 ``source_range``
     - 全部已记录源文指纹须与当前源文一致（``mismatched_source_fingerprints``，与
       ``EpisodePlanner`` 的提交门禁同一套逃生口）
-    - 保留段（1..from_episode-1）每一集若带 ``source_range``，须结构完整且落在
-      对应源文件当前长度界内（unanchored 保留集无坐标可越界，不参与本项检查）
+    - 保留段（1..from_episode-1）每一集若带 ``source_range``，须结构完整、落在
+      对应源文件当前长度界内、且与前一条锚定记录首尾相接（unanchored 保留集无坐标
+      可越界或可比较，不参与本项检查，但会切断与后续记录的连续性比较——它没有坐标
+      能证明后续记录确实紧接其后）
     """
     raw_episodes = project.get("episodes")
     if not isinstance(raw_episodes, list):
@@ -299,6 +301,10 @@ def _resolve_partial_reset_cursor(
         num = parse_episode_num(entry.get("episode"))
         if num is None:
             raise EpisodeResetError(f"账本存在无法解析集号的条目，无法安全推算部分重置边界，{_FULL_RESET_HINT}")
+        if num < 1:
+            raise EpisodeResetError(
+                f"账本存在非法集号 {num}（须为正整数），无法安全推算部分重置边界，{_FULL_RESET_HINT}"
+            )
         if num in entries_by_num:
             raise EpisodeResetError(f"账本存在重复集号 {num}，无法安全推算部分重置边界，{_FULL_RESET_HINT}")
         entries_by_num[num] = entry
@@ -331,10 +337,17 @@ def _resolve_partial_reset_cursor(
         )
 
     text_by_rel = {doc.rel_path: doc.text for doc in current_sources}
+    # EpisodePlanner 逐批规划时严格首尾相接写坐标（同一源文件内下一集 start 恒等于
+    # 上一集 end，切到下一源文件时 start 恒为 0，见 episode_planner.py 的 `prev = abs_end`
+    # 续接逻辑）——保留段任意两条锚定记录之间出现缺口或倒序，只能是账本被篡改或损坏，
+    # 若放行会让退回后的 planning_cursor 与真实已消费范围脱节，下次 plan 产出的内容
+    # 与已保留集重叠或遗漏
+    prev: tuple[str, int] | None = None
     for num in range(1, from_episode):
         entry = entries_by_num[num]
         if not isinstance(entry.get("source_range"), Mapping):
-            continue  # unanchored 保留集没有坐标可越界，物理文件本身即其最终记录
+            prev = None  # unanchored 保留集没有坐标可越界，物理文件本身即其最终记录
+            continue
         coords = _parse_source_range(entry)
         if coords is None:
             raise EpisodeResetError(f"第 {num} 集原文范围记录非法，无法安全部分重置，{_FULL_RESET_HINT}")
@@ -346,6 +359,15 @@ def _resolve_partial_reset_cursor(
                 f"第 {num} 集原文范围越界（源文件 {rel} 当前长度 {length}，记录范围 [{start}, {end})），"
                 f"无法安全部分重置，{_FULL_RESET_HINT}"
             )
+        if prev is not None:
+            prev_rel, prev_end = prev
+            expected_start = prev_end if rel == prev_rel else 0
+            if start != expected_start:
+                raise EpisodeResetError(
+                    f"第 {num} 集原文范围与前一集不连续（应从 {expected_start} 起，实际 {start}），"
+                    f"账本可能已损坏，无法安全部分重置，{_FULL_RESET_HINT}"
+                )
+        prev = (rel, end)
 
     return retain_rel, retain_end
 

--- a/lib/episode_reset.py
+++ b/lib/episode_reset.py
@@ -105,27 +105,41 @@ def _archive_path(path: Path) -> Path:
     return candidate
 
 
-def _has_recreatable_source_range(entry: Mapping[str, Any]) -> bool:
-    """entry 的 source_range 是否携带足以重造派生文件的坐标结构。
+_FULL_RESET_HINT = "请改用 from_episode=1 做全量重置"
+
+
+def _parse_source_range(entry: Mapping[str, Any]) -> tuple[str, int, int] | None:
+    """解析 entry 的 source_range 坐标，结构不完整时返回 None。
 
     只查字段类型（``source_file`` 是 str、``start``/``end`` 是非 bool 的 int），不校验
-    数值是否越界——重置零前置校验，不读源文、不做范围合法性判断，那是 plan/replan
-    的职责。空字典 ``{}`` 或缺字段的损坏映射满足 ``isinstance(..., Mapping)`` 但没有
-    可用坐标，仍会被误判为「可从账本重造」进而永久删除本应留底的文件。
+    数值是否越界——是否要求坐标落在源文界内由调用方按各自口径决定。空字典 ``{}`` 或缺
+    字段的损坏映射满足 ``isinstance(..., Mapping)`` 但没有可用坐标，一律按无坐标处理。
     """
     source_range = entry.get("source_range")
     if not isinstance(source_range, Mapping):
-        return False
+        return None
     rel = source_range.get("source_file")
     start = source_range.get("start")
     end = source_range.get("end")
-    return (
+    if (
         isinstance(rel, str)
         and isinstance(start, int)
         and not isinstance(start, bool)
         and isinstance(end, int)
         and not isinstance(end, bool)
-    )
+    ):
+        return rel, start, end
+    return None
+
+
+def _has_recreatable_source_range(entry: Mapping[str, Any]) -> bool:
+    """entry 的 source_range 是否携带足以重造派生文件的坐标结构。
+
+    只看坐标结构是否完整、不读源文校验数值是否越界——重置零前置校验，范围合法性判断
+    是 plan/replan 的职责。坐标结构不完整的损坏条目按「不可重造」处理，其集文件走留底
+    而非删除：删除不可逆，证据不足时偏保守。
+    """
+    return _parse_source_range(entry) is not None
 
 
 def _scan(project_dir: Path, project: Mapping[str, Any], *, from_episode: int = 1) -> _ResetPlan:
@@ -168,12 +182,22 @@ def _scan(project_dir: Path, project: Mapping[str, Any], *, from_episode: int = 
     consumed: list[int] = []
     deletes: list[Path] = []
     archives: list[Path] = []
+
+    def _in_scope(num: int) -> bool:
+        """该集号是否落在本次处置范围内。
+
+        全量重置（``from_episode == 1``）无条件放行，不比较集号：损坏账本可能写出 0 或
+        负数集号（``parse_episode_num`` 原样返回任意 int），拿它们与 1 比较会把这些条目
+        挡在扫描外、悄悄留在「已清空」的账本里，违反零前置校验的承诺。
+        """
+        return from_episode == 1 or num >= from_episode
+
     # 账本条目、磁盘派生文件、磁盘下游产物三者取并集：
     # - 孤儿集文件（账本无对应条目）同样要处置，否则重置后它会被回填重新补建成账本
     #   条目，账本清空的承诺落空
     # - 孤儿下游产物同样要纳入已消费判定，否则会绕过确认直接清空
     for num in sorted(set(entries) | set(episode_file_aliases) | product_nums):
-        if from_episode > 1 and num < from_episode:
+        if not _in_scope(num):
             continue
         dupes = entries_by_num.get(num) or [{}]
         # 已消费判定同样要聚合全部重复条目：损坏账本可能首条指向缺失的规范剧本路径、
@@ -196,7 +220,7 @@ def _scan(project_dir: Path, project: Mapping[str, Any], *, from_episode: int = 
         can_recreate = all(_has_recreatable_source_range(dupe) for dupe in dupes)
         target = deletes if can_recreate else archives
         target.extend(paths)
-    episode_nums = [num for num in sorted(entries) if not (from_episode > 1 and num < from_episode)]
+    episode_nums = [num for num in sorted(entries) if _in_scope(num)]
     return _ResetPlan(episode_nums=episode_nums, consumed=consumed, deletes=deletes, archives=archives)
 
 
@@ -245,7 +269,9 @@ def _rel(project_dir: Path, path: Path) -> str:
     return path.relative_to(project_dir).as_posix()
 
 
-def _validate_partial_reset(project_dir: Path, project: Mapping[str, Any], *, from_episode: int) -> tuple[str, int]:
+def _resolve_partial_reset_cursor(
+    project_dir: Path, project: Mapping[str, Any], *, from_episode: int
+) -> tuple[str, int]:
     """校验部分重置（``from_episode > 1``）的前置条件，返回重置后 planning_cursor
     的 ``(source_file, offset)``（第 from_episode-1 集原文范围末尾）。
 
@@ -256,7 +282,7 @@ def _validate_partial_reset(project_dir: Path, project: Mapping[str, Any], *, fr
       部分重置与全量重置相反，不做「零前置校验」的损坏容忍，形状有问题直接指向
       更彻底的全量重置
     - ``from_episode`` 必须是既有集号，且第 1..from_episode-1 集须连续存在（无缺口）
-    - 第 from_episode-1 集须带结构完整的 ``source_range``（regarding cursor 退回点）
+    - 第 from_episode-1 集（即 cursor 退回点）须带结构完整的 ``source_range``
     - 全部已记录源文指纹须与当前源文一致（``mismatched_source_fingerprints``，与
       ``EpisodePlanner`` 的提交门禁同一套逃生口）
     - 保留段（1..from_episode-1）每一集若带 ``source_range``，须结构完整且落在
@@ -264,25 +290,17 @@ def _validate_partial_reset(project_dir: Path, project: Mapping[str, Any], *, fr
     """
     raw_episodes = project.get("episodes")
     if not isinstance(raw_episodes, list):
-        raise EpisodeResetError(
-            "账本 episodes 字段形状异常，无法安全推算部分重置边界，请改用 from_episode=1 做全量重置"
-        )
+        raise EpisodeResetError(f"账本 episodes 字段形状异常，无法安全推算部分重置边界，{_FULL_RESET_HINT}")
 
     entries_by_num: dict[int, Mapping[str, Any]] = {}
     for entry in raw_episodes:
         if not isinstance(entry, Mapping):
-            raise EpisodeResetError(
-                "账本存在非法条目（非对象），无法安全推算部分重置边界，请改用 from_episode=1 做全量重置"
-            )
+            raise EpisodeResetError(f"账本存在非法条目（非对象），无法安全推算部分重置边界，{_FULL_RESET_HINT}")
         num = parse_episode_num(entry.get("episode"))
         if num is None:
-            raise EpisodeResetError(
-                "账本存在无法解析集号的条目，无法安全推算部分重置边界，请改用 from_episode=1 做全量重置"
-            )
+            raise EpisodeResetError(f"账本存在无法解析集号的条目，无法安全推算部分重置边界，{_FULL_RESET_HINT}")
         if num in entries_by_num:
-            raise EpisodeResetError(
-                f"账本存在重复集号 {num}，无法安全推算部分重置边界，请改用 from_episode=1 做全量重置"
-            )
+            raise EpisodeResetError(f"账本存在重复集号 {num}，无法安全推算部分重置边界，{_FULL_RESET_HINT}")
         entries_by_num[num] = entry
 
     if from_episode not in entries_by_num:
@@ -291,62 +309,42 @@ def _validate_partial_reset(project_dir: Path, project: Mapping[str, Any], *, fr
         )
     missing = [num for num in range(1, from_episode) if num not in entries_by_num]
     if missing:
-        raise EpisodeResetError(
-            f"账本缺少第 {missing} 集，保留段不连续，无法安全推算部分重置边界，请改用 from_episode=1 做全量重置"
-        )
+        raise EpisodeResetError(f"账本缺少第 {missing} 集，保留段不连续，无法安全推算部分重置边界，{_FULL_RESET_HINT}")
 
     retain_num = from_episode - 1
-    retain_range = entries_by_num[retain_num].get("source_range")
-    if not isinstance(retain_range, Mapping):
+    retain_entry = entries_by_num[retain_num]
+    if not isinstance(retain_entry.get("source_range"), Mapping):
         raise EpisodeResetError(
-            f"第 {retain_num} 集缺少原文范围记录（unanchored），无法确定部分重置后的规划起点，"
-            "请改用 from_episode=1 做全量重置"
+            f"第 {retain_num} 集缺少原文范围记录（unanchored），无法确定部分重置后的规划起点，{_FULL_RESET_HINT}"
         )
-    retain_rel = retain_range.get("source_file")
-    retain_start = retain_range.get("start")
-    retain_end = retain_range.get("end")
-    if (
-        not isinstance(retain_rel, str)
-        or not isinstance(retain_start, int)
-        or isinstance(retain_start, bool)
-        or not isinstance(retain_end, int)
-        or isinstance(retain_end, bool)
-        or retain_start > retain_end
-    ):
-        raise EpisodeResetError(
-            f"第 {retain_num} 集原文范围记录非法，无法确定部分重置后的规划起点，请改用 from_episode=1 做全量重置"
-        )
+    retain_coords = _parse_source_range(retain_entry)
+    if retain_coords is None or retain_coords[1] > retain_coords[2]:
+        raise EpisodeResetError(f"第 {retain_num} 集原文范围记录非法，无法确定部分重置后的规划起点，{_FULL_RESET_HINT}")
+    retain_rel, _, retain_end = retain_coords
 
     current_sources = discover_sources(project_dir)
     mismatched = mismatched_source_fingerprints(project.get(SOURCE_FINGERPRINTS_KEY), current_sources)
     if mismatched:
         raise EpisodeResetError(
             f"源文件已被修改或移除：{'、'.join(mismatched)}；账本坐标绑定的是修改前的原文内容，"
-            "无法安全部分重置，请改用 from_episode=1 做全量重置"
+            f"无法安全部分重置，{_FULL_RESET_HINT}"
         )
 
     text_by_rel = {doc.rel_path: doc.text for doc in current_sources}
     for num in range(1, from_episode):
-        source_range = entries_by_num[num].get("source_range")
-        if not isinstance(source_range, Mapping):
+        entry = entries_by_num[num]
+        if not isinstance(entry.get("source_range"), Mapping):
             continue  # unanchored 保留集没有坐标可越界，物理文件本身即其最终记录
-        rel = source_range.get("source_file")
-        start = source_range.get("start")
-        end = source_range.get("end")
-        if (
-            not isinstance(rel, str)
-            or not isinstance(start, int)
-            or isinstance(start, bool)
-            or not isinstance(end, int)
-            or isinstance(end, bool)
-        ):
-            raise EpisodeResetError(f"第 {num} 集原文范围记录非法，无法安全部分重置，请改用 from_episode=1 做全量重置")
+        coords = _parse_source_range(entry)
+        if coords is None:
+            raise EpisodeResetError(f"第 {num} 集原文范围记录非法，无法安全部分重置，{_FULL_RESET_HINT}")
+        rel, start, end = coords
         text = text_by_rel.get(rel)
         if text is None or not (0 <= start <= end <= len(text)):
             length = len(text) if text is not None else 0
             raise EpisodeResetError(
                 f"第 {num} 集原文范围越界（源文件 {rel} 当前长度 {length}，记录范围 [{start}, {end})），"
-                "无法安全部分重置，请改用 from_episode=1 做全量重置"
+                f"无法安全部分重置，{_FULL_RESET_HINT}"
             )
 
     return retain_rel, retain_end
@@ -362,7 +360,7 @@ def reset_episode_planning(
 
     ``from_episode=1``：全量重置，零前置校验，账本处于任何损坏状态都必须执行成功
     （见模块文档）。``from_episode > 1``：部分重置，保留第 1..from_episode-1 集，
-    见 :func:`_validate_partial_reset` 的前置校验；校验不通过时指名具体原因并指引
+    见 :func:`_resolve_partial_reset_cursor` 的前置校验；校验不通过时指名具体原因并指引
     改用全量重置，账本不被改动。
 
     两种模式都对波及已消费集（账本标 consumed 或磁盘已有剧本 / step1 产物）且未
@@ -385,7 +383,7 @@ def reset_episode_planning(
     # 不进锁、不碰文件
     project = pm.load_project(project_name)
     if from_episode > 1:
-        _validate_partial_reset(project_dir, project, from_episode=from_episode)
+        _resolve_partial_reset_cursor(project_dir, project, from_episode=from_episode)
     plan = _scan(project_dir, project, from_episode=from_episode)
     if plan.consumed and not confirm_consumed:
         return ResetConfirmationRequired(
@@ -400,7 +398,7 @@ def reset_episode_planning(
         nonlocal committed
         # 锁内重新校验/重新扫描：确认清单与前置校验都是锁外读取时刻的快照，期间源文件
         # 可能被外部改动、也可能出现清单之外的新消费集
-        cursor = _validate_partial_reset(project_dir, p, from_episode=from_episode) if from_episode > 1 else None
+        cursor = _resolve_partial_reset_cursor(project_dir, p, from_episode=from_episode) if from_episode > 1 else None
         current = _scan(project_dir, p, from_episode=from_episode)
         if any(num not in plan.consumed for num in current.consumed):
             raise EpisodeResetConflictError("重置期间出现新的已消费集，需重新确认后再执行")

--- a/lib/episode_reset.py
+++ b/lib/episode_reset.py
@@ -282,13 +282,17 @@ def _resolve_partial_reset_cursor(
       不重复）——部分重置与全量重置相反，不做「零前置校验」的损坏容忍，形状有问题
       直接指向更彻底的全量重置
     - ``from_episode`` 必须是既有集号，且第 1..from_episode-1 集须连续存在（无缺口）
-    - 第 from_episode-1 集（即 cursor 退回点）须带结构完整的 ``source_range``
+    - 第 from_episode-1 集（即 cursor 退回点）须带可信的 ``source_range``
     - 全部已记录源文指纹须与当前源文一致（``mismatched_source_fingerprints``，与
       ``EpisodePlanner`` 的提交门禁同一套逃生口）
-    - 保留段（1..from_episode-1）每一集若带 ``source_range``，须结构完整、落在
-      对应源文件当前长度界内、且与前一条锚定记录首尾相接（unanchored 保留集无坐标
-      可越界或可比较，不参与本项检查，但会切断与后续记录的连续性比较——它没有坐标
-      能证明后续记录确实紧接其后）
+    - 保留段（1..from_episode-1）每一集若带可信的 ``source_range``，须结构完整、
+      落在对应源文件当前长度界内；第 1 集须从排序后的首个源文件偏移 0 起；相邻两条
+      记录须首尾相接——同一源文件内后一条 ``start`` 须等于前一条 ``end``，跨源文件
+      时须切到排序中紧邻的下一个文件、起点为 0、且上一文件在切出点之后只剩空白
+      （``ledger_status == "unanchored"`` 的条目视为无坐标可信，不参与本项检查，
+      也会切断与后续记录的连续性比较——它没有可信坐标能证明后续记录确实紧接其后；
+      规划器同样不采信这类条目的 ``source_range``，见
+      ``EpisodePlanner._reconcile_derived_files``）
     """
     raw_episodes = project.get("episodes")
     if not isinstance(raw_episodes, list):
@@ -313,20 +317,19 @@ def _resolve_partial_reset_cursor(
         raise EpisodeResetError(
             f"第 {from_episode} 集不在账本中，无法从此处部分重置（当前已规划集号：{sorted(entries_by_num)}）"
         )
-    missing = [num for num in range(1, from_episode) if num not in entries_by_num]
-    if missing:
-        raise EpisodeResetError(f"账本缺少第 {missing} 集，保留段不连续，无法安全推算部分重置边界，{_FULL_RESET_HINT}")
+    # 只扫描已存在的条目找缺口，不物化 range(1, from_episode)：损坏账本可能把 from_episode
+    # 写成天文数字的集号，物化整段区间会让本应快速拒绝的逃生口自己先耗尽内存/长时间阻塞
+    expected = 1
+    for num in sorted(n for n in entries_by_num if n < from_episode):
+        if num != expected:
+            break
+        expected += 1
+    if expected != from_episode:
+        raise EpisodeResetError(
+            f"账本缺少第 {expected} 集起的条目，保留段不连续，无法安全推算部分重置边界，{_FULL_RESET_HINT}"
+        )
 
     retain_num = from_episode - 1
-    retain_entry = entries_by_num[retain_num]
-    if not isinstance(retain_entry.get("source_range"), Mapping):
-        raise EpisodeResetError(
-            f"第 {retain_num} 集缺少原文范围记录（unanchored），无法确定部分重置后的规划起点，{_FULL_RESET_HINT}"
-        )
-    retain_coords = _parse_source_range(retain_entry)
-    if retain_coords is None or retain_coords[1] > retain_coords[2]:
-        raise EpisodeResetError(f"第 {retain_num} 集原文范围记录非法，无法确定部分重置后的规划起点，{_FULL_RESET_HINT}")
-    retain_rel, _, retain_end = retain_coords
 
     current_sources = discover_sources(project_dir)
     mismatched = mismatched_source_fingerprints(project.get(SOURCE_FINGERPRINTS_KEY), current_sources)
@@ -337,16 +340,19 @@ def _resolve_partial_reset_cursor(
         )
 
     text_by_rel = {doc.rel_path: doc.text for doc in current_sources}
+    source_order = {doc.rel_path: idx for idx, doc in enumerate(current_sources)}
     # EpisodePlanner 逐批规划时严格首尾相接写坐标（同一源文件内下一集 start 恒等于
-    # 上一集 end，切到下一源文件时 start 恒为 0，见 episode_planner.py 的 `prev = abs_end`
-    # 续接逻辑）——保留段任意两条锚定记录之间出现缺口或倒序，只能是账本被篡改或损坏，
-    # 若放行会让退回后的 planning_cursor 与真实已消费范围脱节，下次 plan 产出的内容
-    # 与已保留集重叠或遗漏
+    # 上一集 end，切到下一源文件时 start 恒为 0 且上一文件必然只剩空白，见
+    # episode_planner.py 的 `prev = abs_end` 续接逻辑与 `_effective_start` 的耗尽推进）——
+    # 保留段任意两条锚定记录之间出现缺口、倒序或跳文件，只能是账本被篡改或损坏，若放行
+    # 会让退回后的 planning_cursor 与真实已消费范围脱节，下次 plan 产出的内容与已保留集
+    # 重叠或遗漏
     prev: tuple[str, int] | None = None
     for num in range(1, from_episode):
         entry = entries_by_num[num]
-        if not isinstance(entry.get("source_range"), Mapping):
-            prev = None  # unanchored 保留集没有坐标可越界，物理文件本身即其最终记录
+        has_range = isinstance(entry.get("source_range"), Mapping) and entry.get("ledger_status") != "unanchored"
+        if not has_range:
+            prev = None  # unanchored 保留集没有可信坐标，物理文件本身即其最终记录
             continue
         coords = _parse_source_range(entry)
         if coords is None:
@@ -359,9 +365,32 @@ def _resolve_partial_reset_cursor(
                 f"第 {num} 集原文范围越界（源文件 {rel} 当前长度 {length}，记录范围 [{start}, {end})），"
                 f"无法安全部分重置，{_FULL_RESET_HINT}"
             )
-        if prev is not None:
+        if prev is None:
+            if num == 1 and (source_order.get(rel) != 0 or start != 0):
+                raise EpisodeResetError(
+                    f"第 1 集原文范围未从首个源文件起点开始（记录范围 [{start}, {end}) @ {rel}），"
+                    f"账本可能已损坏，无法安全部分重置，{_FULL_RESET_HINT}"
+                )
+        else:
             prev_rel, prev_end = prev
-            expected_start = prev_end if rel == prev_rel else 0
+            if rel == prev_rel:
+                expected_start = prev_end
+            else:
+                prev_idx = source_order.get(prev_rel)
+                rel_idx = source_order.get(rel)
+                prev_text = text_by_rel.get(prev_rel)
+                if (
+                    prev_idx is None
+                    or rel_idx is None
+                    or rel_idx != prev_idx + 1
+                    or prev_text is None
+                    or prev_text[prev_end:].strip()
+                ):
+                    raise EpisodeResetError(
+                        f"第 {num} 集切换源文件不合法（应在 {prev_rel} 耗尽后顺序切到下一源文件），"
+                        f"账本可能已损坏，无法安全部分重置，{_FULL_RESET_HINT}"
+                    )
+                expected_start = 0
             if start != expected_start:
                 raise EpisodeResetError(
                     f"第 {num} 集原文范围与前一集不连续（应从 {expected_start} 起，实际 {start}），"
@@ -369,6 +398,11 @@ def _resolve_partial_reset_cursor(
                 )
         prev = (rel, end)
 
+    if prev is None:
+        raise EpisodeResetError(
+            f"第 {retain_num} 集缺少原文范围记录（unanchored），无法确定部分重置后的规划起点，{_FULL_RESET_HINT}"
+        )
+    retain_rel, retain_end = prev
     return retain_rel, retain_end
 
 

--- a/lib/episode_reset.py
+++ b/lib/episode_reset.py
@@ -286,12 +286,14 @@ def _resolve_partial_reset_cursor(
     - 全部已记录源文指纹须与当前源文一致（``mismatched_source_fingerprints``，与
       ``EpisodePlanner`` 的提交门禁同一套逃生口）
     - 保留段（1..from_episode-1）每一集若带可信的 ``source_range``，须结构完整、
-      落在对应源文件当前长度界内；第 1 集须从排序后的首个源文件偏移 0 起；相邻两条
-      记录须首尾相接——同一源文件内后一条 ``start`` 须等于前一条 ``end``，跨源文件
-      时须切到排序中紧邻的下一个文件、起点为 0、且上一文件在切出点之后只剩空白
-      （``ledger_status == "unanchored"`` 的条目视为无坐标可信，不参与本项检查，
-      也会切断与后续记录的连续性比较——它没有可信坐标能证明后续记录确实紧接其后；
-      规划器同样不采信这类条目的 ``source_range``，见
+      落在对应源文件当前长度界内；第 1 集起点须为 0，且排序中排在其源文件之前的
+      文件全部只剩空白（``EpisodePlanner`` 会自动跳过纯空白源文件，第 1 集因此可能
+      合法落在非首个文件）；相邻两条记录须首尾相接——同一源文件内后一条 ``start``
+      须等于前一条 ``end``，跨源文件时须切到排序中下一个仍有内容的文件、起点为 0、
+      且被跳过的中间文件（含切出点所在文件的剩余部分）全部只剩空白
+      （``ledger_status == "unanchored"`` 的条目视为无坐标可信，不参与坐标校验；
+      若这类条目出现在保留段中间，其后任何锚定记录都无法证明与已验证内容衔接，
+      直接拒绝——规划器同样不采信这类条目的 ``source_range``，见
       ``EpisodePlanner._reconcile_derived_files``）
     """
     raw_episodes = project.get("episodes")
@@ -366,10 +368,23 @@ def _resolve_partial_reset_cursor(
                 f"无法安全部分重置，{_FULL_RESET_HINT}"
             )
         if prev is None:
-            if num == 1 and (source_order.get(rel) != 0 or start != 0):
+            if num != 1:
+                # 保留段中间存在失锚条目切断了连续性：这条记录的坐标无法与任何可信的
+                # 前序位置比对，不能证明它确实紧接着已验证过的内容，只能拒绝——沉默
+                # 放行会让退回后的游标凭空重新起锚，中间那段源文既无法证明已覆盖，
+                # 也不会再被规划
                 raise EpisodeResetError(
-                    f"第 1 集原文范围未从首个源文件起点开始（记录范围 [{start}, {end}) @ {rel}），"
-                    f"账本可能已损坏，无法安全部分重置，{_FULL_RESET_HINT}"
+                    f"第 {num} 集之前存在失锚（unanchored）条目，无法确认原文范围是否与保留段"
+                    f"其余部分衔接，无法安全部分重置，{_FULL_RESET_HINT}"
+                )
+            rel_idx = source_order.get(rel)
+            # 排序中排在它之前的源文件必须全部只剩空白：EpisodePlanner 遇到纯空白源文件会
+            # 自动跳过（见 `_effective_start` 的耗尽推进），第 1 集因此可能合法落在非首个
+            # 源文件——只要求 rel_idx == 0 会把这种合法账本误判为损坏
+            if start != 0 or rel_idx is None or any(doc.text.strip() for doc in current_sources[:rel_idx]):
+                raise EpisodeResetError(
+                    f"第 1 集原文范围未从源文件起点开始（记录范围 [{start}, {end}) @ {rel}，"
+                    f"其前源文件仍有非空白内容），账本可能已损坏，无法安全部分重置，{_FULL_RESET_HINT}"
                 )
         else:
             prev_rel, prev_end = prev
@@ -379,16 +394,25 @@ def _resolve_partial_reset_cursor(
                 prev_idx = source_order.get(prev_rel)
                 rel_idx = source_order.get(rel)
                 prev_text = text_by_rel.get(prev_rel)
+                # 同理：中间被跳过的源文件（prev_idx 到 rel_idx 之间）必须全部只剩空白，
+                # 而非要求 rel_idx 恰为 prev_idx + 1——纯空白的中间源文件同样会被
+                # EpisodePlanner 自动跳过
+                skipped_have_content = (
+                    prev_idx is not None
+                    and rel_idx is not None
+                    and any(current_sources[i].text.strip() for i in range(prev_idx + 1, rel_idx))
+                )
                 if (
                     prev_idx is None
                     or rel_idx is None
-                    or rel_idx != prev_idx + 1
+                    or rel_idx <= prev_idx
                     or prev_text is None
                     or prev_text[prev_end:].strip()
+                    or skipped_have_content
                 ):
                     raise EpisodeResetError(
-                        f"第 {num} 集切换源文件不合法（应在 {prev_rel} 耗尽后顺序切到下一源文件），"
-                        f"账本可能已损坏，无法安全部分重置，{_FULL_RESET_HINT}"
+                        f"第 {num} 集切换源文件不合法（应在 {prev_rel} 及其间源文件耗尽后顺序切到"
+                        f"下一有内容的源文件），账本可能已损坏，无法安全部分重置，{_FULL_RESET_HINT}"
                     )
                 expected_start = 0
             if start != expected_start:

--- a/lib/episode_reset.py
+++ b/lib/episode_reset.py
@@ -286,15 +286,17 @@ def _resolve_partial_reset_cursor(
     - 全部已记录源文指纹须与当前源文一致（``mismatched_source_fingerprints``，与
       ``EpisodePlanner`` 的提交门禁同一套逃生口）
     - 保留段（1..from_episode-1）每一集若带可信的 ``source_range``，须结构完整、
-      落在对应源文件当前长度界内；第 1 集起点须为 0，且排序中排在其源文件之前的
+      落在对应源文件当前长度界内且非空（``start < end``，与 ``EpisodePlanner``
+      对重排范围的校验口径一致）；第 1 集起点须为 0，且排序中排在其源文件之前的
       文件全部只剩空白（``EpisodePlanner`` 会自动跳过纯空白源文件，第 1 集因此可能
       合法落在非首个文件）；相邻两条记录须首尾相接——同一源文件内后一条 ``start``
       须等于前一条 ``end``，跨源文件时须切到排序中下一个仍有内容的文件、起点为 0、
       且被跳过的中间文件（含切出点所在文件的剩余部分）全部只剩空白
-      （``ledger_status == "unanchored"`` 的条目视为无坐标可信，不参与坐标校验；
-      若这类条目出现在保留段中间，其后任何锚定记录都无法证明与已验证内容衔接，
-      直接拒绝——规划器同样不采信这类条目的 ``source_range``，见
-      ``EpisodePlanner._reconcile_derived_files``）
+      （``ledger_status`` 为 ``"unanchored"`` 或缺失（``None``，即待
+      ``backfill_episode_ledger`` 回填、当前坐标未必是最终结果）的条目均视为无
+      坐标可信，不参与坐标校验；若这类条目出现在保留段中间，其后任何锚定记录都
+      无法证明与已验证内容衔接，直接拒绝——规划器同样不采信 unanchored 条目的
+      ``source_range``，见 ``EpisodePlanner._reconcile_derived_files``）
     """
     raw_episodes = project.get("episodes")
     if not isinstance(raw_episodes, list):
@@ -352,19 +354,25 @@ def _resolve_partial_reset_cursor(
     prev: tuple[str, int] | None = None
     for num in range(1, from_episode):
         entry = entries_by_num[num]
-        has_range = isinstance(entry.get("source_range"), Mapping) and entry.get("ledger_status") != "unanchored"
+        # ledger_status 缺失（None）是 backfill_episode_ledger 眼中的「待回填」条目：
+        # 下一次 plan() 会按物理集文件重新核实/改写它的 source_range，此刻账本里存的
+        # 坐标未必是回填后的最终结果，与 unanchored 一样不可信，不能据此推算游标
+        has_range = isinstance(entry.get("source_range"), Mapping) and entry.get("ledger_status") not in (
+            None,
+            "unanchored",
+        )
         if not has_range:
-            prev = None  # unanchored 保留集没有可信坐标，物理文件本身即其最终记录
+            prev = None  # 无可信坐标，切断连续性比较
             continue
         coords = _parse_source_range(entry)
         if coords is None:
             raise EpisodeResetError(f"第 {num} 集原文范围记录非法，无法安全部分重置，{_FULL_RESET_HINT}")
         rel, start, end = coords
         text = text_by_rel.get(rel)
-        if text is None or not (0 <= start <= end <= len(text)):
+        if text is None or not (0 <= start < end <= len(text)):
             length = len(text) if text is not None else 0
             raise EpisodeResetError(
-                f"第 {num} 集原文范围越界（源文件 {rel} 当前长度 {length}，记录范围 [{start}, {end})），"
+                f"第 {num} 集原文范围无效（源文件 {rel} 当前长度 {length}，记录范围 [{start}, {end})），"
                 f"无法安全部分重置，{_FULL_RESET_HINT}"
             )
         if prev is None:
@@ -424,7 +432,8 @@ def _resolve_partial_reset_cursor(
 
     if prev is None:
         raise EpisodeResetError(
-            f"第 {retain_num} 集缺少原文范围记录（unanchored），无法确定部分重置后的规划起点，{_FULL_RESET_HINT}"
+            f"第 {retain_num} 集缺少可信的原文范围记录（unanchored 或待回填），"
+            f"无法确定部分重置后的规划起点，{_FULL_RESET_HINT}"
         )
     retain_rel, retain_end = prev
     return retain_rel, retain_end

--- a/lib/episode_reset.py
+++ b/lib/episode_reset.py
@@ -6,6 +6,13 @@
 执行后 ``episodes`` 清空、``planning_cursor`` 置 null、源文指纹清除，
 ``plan_episodes`` 可从头重新规划。
 
+部分重置（``from_episode > 1``）保留第 1..from_episode-1 集、只清除
+from_episode 起的条目，与全量重置相反，走**前置校验**：全部已记录源文指纹须与
+当前源文一致，且保留段每一集的 ``source_range`` 须结构完整、落在当前源文界内、
+且连续无缺口——任一不满足都无法安全推算「保留到哪、退回到哪」，直接拒绝执行
+（账本不改动）并指引改用全量重置。校验通过后 ``planning_cursor`` 退到第
+from_episode-1 集原文范围末尾，源文指纹字段保留不动（已验证与当前源文一致）。
+
 本模块刻意不依赖 :class:`lib.text_generator.TextGenerator`：重置不调模型，
 逃生口不能因供应商未配置而失效。写入与 ``EpisodePlanner`` 共用同一把项目锁
 （``ProjectManager.update_project``），提交纪律一致。
@@ -13,7 +20,8 @@
 派生集文件按「是否可从账本重造」分流：账本条目带 ``source_range`` 的
 ``source/episode_N.txt`` 是派生物，直接删除；无 ``source_range`` 的集文件可能是
 老项目原件（含手工内容，无坐标可重造），改名留底而非删除。下游产物（剧本 JSON、
-step1 中间文件、媒体）一律不删。
+step1 中间文件、媒体）一律不删。部分重置时上述处置只施于 from_episode 起的范围，
+保留段的派生文件与下游产物不受影响。
 """
 
 from __future__ import annotations
@@ -28,7 +36,9 @@ from lib.episode_ledger import (
     SOURCE_FINGERPRINTS_KEY,
     discover_episode_file_aliases,
     discover_product_episode_nums,
+    discover_sources,
     has_downstream_products,
+    mismatched_source_fingerprints,
     parse_episode_num,
 )
 from lib.project_manager import ProjectManager
@@ -118,11 +128,15 @@ def _has_recreatable_source_range(entry: Mapping[str, Any]) -> bool:
     )
 
 
-def _scan(project_dir: Path, project: Mapping[str, Any]) -> _ResetPlan:
+def _scan(project_dir: Path, project: Mapping[str, Any], *, from_episode: int = 1) -> _ResetPlan:
     """扫描账本与磁盘得出处置计划。纯读：不改入参、不动文件。
 
     已消费判定取账本状态与磁盘产物的并集——账本损坏时 ``ledger_status`` 未必可信，
     磁盘上的剧本 / step1 产物才是「这一集已经被消费过」的硬证据。
+
+    ``from_episode`` 限定处置范围（默认 1 即全量，与既有调用方行为逐字一致）：
+    集号小于它的账本条目、孤儿派生文件、孤儿下游产物均视为保留段，不参与本次
+    扫描——它们既不计入已消费判定，也不进入删除/留底候选。
     """
     raw_episodes = project.get("episodes")
     entries: dict[int, Mapping[str, Any]] = {}
@@ -159,6 +173,8 @@ def _scan(project_dir: Path, project: Mapping[str, Any]) -> _ResetPlan:
     #   条目，账本清空的承诺落空
     # - 孤儿下游产物同样要纳入已消费判定，否则会绕过确认直接清空
     for num in sorted(set(entries) | set(episode_file_aliases) | product_nums):
+        if from_episode > 1 and num < from_episode:
+            continue
         dupes = entries_by_num.get(num) or [{}]
         # 已消费判定同样要聚合全部重复条目：损坏账本可能首条指向缺失的规范剧本路径、
         # 后条的 script_file 指向实际存在的非规范路径（如 scripts/custom_name.json），
@@ -180,7 +196,8 @@ def _scan(project_dir: Path, project: Mapping[str, Any]) -> _ResetPlan:
         can_recreate = all(_has_recreatable_source_range(dupe) for dupe in dupes)
         target = deletes if can_recreate else archives
         target.extend(paths)
-    return _ResetPlan(episode_nums=sorted(entries), consumed=consumed, deletes=deletes, archives=archives)
+    episode_nums = [num for num in sorted(entries) if not (from_episode > 1 and num < from_episode)]
+    return _ResetPlan(episode_nums=episode_nums, consumed=consumed, deletes=deletes, archives=archives)
 
 
 def _apply_files(project_dir: Path, plan: _ResetPlan) -> tuple[list[str], list[tuple[str, str]]]:
@@ -228,35 +245,148 @@ def _rel(project_dir: Path, path: Path) -> str:
     return path.relative_to(project_dir).as_posix()
 
 
+def _validate_partial_reset(project_dir: Path, project: Mapping[str, Any], *, from_episode: int) -> tuple[str, int]:
+    """校验部分重置（``from_episode > 1``）的前置条件，返回重置后 planning_cursor
+    的 ``(source_file, offset)``（第 from_episode-1 集原文范围末尾）。
+
+    任一不满足都会让「保留到哪、退回到哪」无法安全推算，抛 :class:`EpisodeResetError`
+    并指引改用全量重置；调用方保证校验失败时账本不被改动：
+
+    - 账本形状必须干净（``episodes`` 是列表、条目均为对象、集号均可解析且不重复）——
+      部分重置与全量重置相反，不做「零前置校验」的损坏容忍，形状有问题直接指向
+      更彻底的全量重置
+    - ``from_episode`` 必须是既有集号，且第 1..from_episode-1 集须连续存在（无缺口）
+    - 第 from_episode-1 集须带结构完整的 ``source_range``（regarding cursor 退回点）
+    - 全部已记录源文指纹须与当前源文一致（``mismatched_source_fingerprints``，与
+      ``EpisodePlanner`` 的提交门禁同一套逃生口）
+    - 保留段（1..from_episode-1）每一集若带 ``source_range``，须结构完整且落在
+      对应源文件当前长度界内（unanchored 保留集无坐标可越界，不参与本项检查）
+    """
+    raw_episodes = project.get("episodes")
+    if not isinstance(raw_episodes, list):
+        raise EpisodeResetError(
+            "账本 episodes 字段形状异常，无法安全推算部分重置边界，请改用 from_episode=1 做全量重置"
+        )
+
+    entries_by_num: dict[int, Mapping[str, Any]] = {}
+    for entry in raw_episodes:
+        if not isinstance(entry, Mapping):
+            raise EpisodeResetError(
+                "账本存在非法条目（非对象），无法安全推算部分重置边界，请改用 from_episode=1 做全量重置"
+            )
+        num = parse_episode_num(entry.get("episode"))
+        if num is None:
+            raise EpisodeResetError(
+                "账本存在无法解析集号的条目，无法安全推算部分重置边界，请改用 from_episode=1 做全量重置"
+            )
+        if num in entries_by_num:
+            raise EpisodeResetError(
+                f"账本存在重复集号 {num}，无法安全推算部分重置边界，请改用 from_episode=1 做全量重置"
+            )
+        entries_by_num[num] = entry
+
+    if from_episode not in entries_by_num:
+        raise EpisodeResetError(
+            f"第 {from_episode} 集不在账本中，无法从此处部分重置（当前已规划集号：{sorted(entries_by_num)}）"
+        )
+    missing = [num for num in range(1, from_episode) if num not in entries_by_num]
+    if missing:
+        raise EpisodeResetError(
+            f"账本缺少第 {missing} 集，保留段不连续，无法安全推算部分重置边界，请改用 from_episode=1 做全量重置"
+        )
+
+    retain_num = from_episode - 1
+    retain_range = entries_by_num[retain_num].get("source_range")
+    if not isinstance(retain_range, Mapping):
+        raise EpisodeResetError(
+            f"第 {retain_num} 集缺少原文范围记录（unanchored），无法确定部分重置后的规划起点，"
+            "请改用 from_episode=1 做全量重置"
+        )
+    retain_rel = retain_range.get("source_file")
+    retain_start = retain_range.get("start")
+    retain_end = retain_range.get("end")
+    if (
+        not isinstance(retain_rel, str)
+        or not isinstance(retain_start, int)
+        or isinstance(retain_start, bool)
+        or not isinstance(retain_end, int)
+        or isinstance(retain_end, bool)
+        or retain_start > retain_end
+    ):
+        raise EpisodeResetError(
+            f"第 {retain_num} 集原文范围记录非法，无法确定部分重置后的规划起点，请改用 from_episode=1 做全量重置"
+        )
+
+    current_sources = discover_sources(project_dir)
+    mismatched = mismatched_source_fingerprints(project.get(SOURCE_FINGERPRINTS_KEY), current_sources)
+    if mismatched:
+        raise EpisodeResetError(
+            f"源文件已被修改或移除：{'、'.join(mismatched)}；账本坐标绑定的是修改前的原文内容，"
+            "无法安全部分重置，请改用 from_episode=1 做全量重置"
+        )
+
+    text_by_rel = {doc.rel_path: doc.text for doc in current_sources}
+    for num in range(1, from_episode):
+        source_range = entries_by_num[num].get("source_range")
+        if not isinstance(source_range, Mapping):
+            continue  # unanchored 保留集没有坐标可越界，物理文件本身即其最终记录
+        rel = source_range.get("source_file")
+        start = source_range.get("start")
+        end = source_range.get("end")
+        if (
+            not isinstance(rel, str)
+            or not isinstance(start, int)
+            or isinstance(start, bool)
+            or not isinstance(end, int)
+            or isinstance(end, bool)
+        ):
+            raise EpisodeResetError(f"第 {num} 集原文范围记录非法，无法安全部分重置，请改用 from_episode=1 做全量重置")
+        text = text_by_rel.get(rel)
+        if text is None or not (0 <= start <= end <= len(text)):
+            length = len(text) if text is not None else 0
+            raise EpisodeResetError(
+                f"第 {num} 集原文范围越界（源文件 {rel} 当前长度 {length}，记录范围 [{start}, {end})），"
+                "无法安全部分重置，请改用 from_episode=1 做全量重置"
+            )
+
+    return retain_rel, retain_end
+
+
 def reset_episode_planning(
     project_path: str | Path,
     *,
     from_episode: int = 1,
     confirm_consumed: bool = False,
 ) -> EpisodeResetResult | ResetConfirmationRequired:
-    """重置分集规划账本。当前仅支持 ``from_episode=1`` 的全量重置。
+    """重置分集规划账本。
 
-    波及已消费集（账本标 consumed 或磁盘已有剧本 / step1 产物）且未
+    ``from_episode=1``：全量重置，零前置校验，账本处于任何损坏状态都必须执行成功
+    （见模块文档）。``from_episode > 1``：部分重置，保留第 1..from_episode-1 集，
+    见 :func:`_validate_partial_reset` 的前置校验；校验不通过时指名具体原因并指引
+    改用全量重置，账本不被改动。
+
+    两种模式都对波及已消费集（账本标 consumed 或磁盘已有剧本 / step1 产物）且未
     ``confirm_consumed`` 时不执行，返回 :class:`ResetConfirmationRequired` 等待
     显式确认；确认后执行，下游产物一律保留。
 
     Raises:
-        EpisodeResetError: ``from_episode > 1``（部分重置尚未支持）或文件处置失败，
-            两种情形下账本均未被改动。
+        EpisodeResetError: ``from_episode`` 非正整数、部分重置前置校验未通过、或
+            文件处置失败，均保证账本未被改动。
         EpisodeResetConflictError: 重置期间出现确认清单之外的已消费集。
     """
-    if from_episode != 1:
-        raise EpisodeResetError(
-            f"暂不支持部分重置（from_episode={from_episode}）：当前只能用 from_episode=1 做全量重置"
-            "（清空整个账本后重新规划）。账本未做任何改动。"
-        )
+    if from_episode < 1:
+        raise EpisodeResetError(f"from_episode 必须是正整数，收到 {from_episode}")
 
     project_dir = Path(project_path)
     pm = ProjectManager(str(project_dir.parent))
     project_name = project_dir.name
 
-    # 锁外预扫描只为二段确认服务：需要确认时零写入返回，不进锁、不碰文件
-    plan = _scan(project_dir, pm.load_project(project_name))
+    # 锁外预扫描/前置校验只为二段确认与快速失败服务：校验不通过或需要确认时零写入返回，
+    # 不进锁、不碰文件
+    project = pm.load_project(project_name)
+    if from_episode > 1:
+        _validate_partial_reset(project_dir, project, from_episode=from_episode)
+    plan = _scan(project_dir, project, from_episode=from_episode)
     if plan.consumed and not confirm_consumed:
         return ResetConfirmationRequired(
             consumed_episodes=plan.consumed,
@@ -268,13 +398,25 @@ def reset_episode_planning(
 
     def _commit(p: dict[str, Any]) -> None:
         nonlocal committed
-        # 锁内重新扫描：确认清单是锁外读取时刻的快照，期间新消费的集不在用户确认范围内
-        current = _scan(project_dir, p)
+        # 锁内重新校验/重新扫描：确认清单与前置校验都是锁外读取时刻的快照，期间源文件
+        # 可能被外部改动、也可能出现清单之外的新消费集
+        cursor = _validate_partial_reset(project_dir, p, from_episode=from_episode) if from_episode > 1 else None
+        current = _scan(project_dir, p, from_episode=from_episode)
         if any(num not in plan.consumed for num in current.consumed):
             raise EpisodeResetConflictError("重置期间出现新的已消费集，需重新确认后再执行")
-        p["episodes"] = []
-        p["planning_cursor"] = None
-        p.pop(SOURCE_FINGERPRINTS_KEY, None)
+        if cursor is not None:
+            retained = [
+                entry
+                for entry in (p.get("episodes") or [])
+                if isinstance(entry, Mapping) and (parse_episode_num(entry.get("episode")) or 0) < from_episode
+            ]
+            retained.sort(key=lambda entry: parse_episode_num(entry.get("episode")) or 0)
+            p["episodes"] = retained
+            p["planning_cursor"] = {"source_file": cursor[0], "offset": cursor[1]}
+        else:
+            p["episodes"] = []
+            p["planning_cursor"] = None
+            p.pop(SOURCE_FINGERPRINTS_KEY, None)
         deleted, archived = _apply_files(project_dir, current)
         committed = EpisodeResetResult(
             removed_episodes=current.episode_nums,
@@ -287,7 +429,8 @@ def reset_episode_planning(
     if committed is None:  # pragma: no cover - update_project 必然调用 mutate_fn
         raise EpisodeResetError("重置未执行：账本更新回调未被调用")
     logger.info(
-        "分集规划已全量重置：项目 %s，清空 %d 集，删除派生文件 %d 个，留底 %d 个",
+        "分集规划已%s重置：项目 %s，清空 %d 集，删除派生文件 %d 个，留底 %d 个",
+        "全量" if from_episode == 1 else f"部分（从第 {from_episode} 集起）",
         project_name,
         len(committed.removed_episodes),
         len(committed.deleted_files),

--- a/server/agent_runtime/sdk_tools/episode_planning.py
+++ b/server/agent_runtime/sdk_tools/episode_planning.py
@@ -269,10 +269,14 @@ def reset_episode_planning_tool(ctx: ToolContext):
 
         if isinstance(result, ResetConfirmationRequired):
             episodes = "、".join(str(num) for num in result.consumed_episodes)
+            if from_episode == 1:
+                aftermath = "账本清空后这些集需要重新规划"
+            else:
+                aftermath = f"这些集的账本条目被清除后需要重新规划，第 1..{from_episode - 1} 集保留不动"
             lines = [
                 f"⚠️ 本次重置会波及已消费集（已有 step1/剧本/媒体产物）：第 {episodes} 集。尚未执行任何改动。",
                 "请把影响范围告知用户；用户确认后带 confirm_consumed=true 重新调用"
-                "（剧本与媒体产物不会被删除，但账本清空后这些集需要重新规划）。",
+                f"（剧本与媒体产物不会被删除，但{aftermath}）。",
             ]
             if result.archived_files:
                 lines.append(f"其中无原文范围记录的集文件会改名留底：{'、'.join(result.archived_files)}")

--- a/server/agent_runtime/sdk_tools/episode_planning.py
+++ b/server/agent_runtime/sdk_tools/episode_planning.py
@@ -222,20 +222,24 @@ def replan_episodes_tool(ctx: ToolContext):
 def reset_episode_planning_tool(ctx: ToolContext):
     @tool(
         "reset_episode_planning",
-        "重置分集规划：清空分集账本（episodes 与 planning_cursor），让 plan_episodes 可以从头重新规划。"
-        "这是账本损坏时的逃生口——源文被替换或删除重建后，规划会报「起点越界」「范围无效」等错误并"
-        "永久失败，此时用本工具重置即可恢复；不调用文本模型，不受供应商配置影响。"
-        "当前只支持 from_episode=1（全量重置），传更大的集号会被拒绝且账本不变。"
-        "波及已消费集（已有 step1/剧本/媒体产物）时不执行并返回受影响清单，须告知用户、确认后带 "
-        "confirm_consumed=true 重新调用。任何下游产物（剧本、媒体）都不会被删除；"
-        "可由账本重造的 source/episode_N.txt 会被删除，无原文范围记录的集文件改名留底（不会丢内容）。"
-        "重置后账本为空，需要重新调用 plan_episodes 规划，集号从第 1 集重新开始。",
+        "重置分集规划：把账本退回未规划状态的逃生口，不调用文本模型，不受供应商配置影响。"
+        "from_episode=1 是全量重置（清空整个账本与 planning_cursor），源文被替换或删除重建、"
+        "账本写坏导致规划报「起点越界」「范围无效」等错误并永久失败时用它恢复，零前置校验、"
+        "任何损坏状态都能执行成功。from_episode>1 是部分重置：保留第 1..from_episode-1 集，"
+        "只清除 from_episode 起的条目，游标退到第 from_episode-1 集原文范围末尾，下次 "
+        "plan_episodes 从第 from_episode 集续接编号；这条路径有前置校验（全部已记录源文指纹须"
+        "与当前源文一致，且保留段坐标须完整、连续、落在当前源文界内），任一不满足会拒绝执行并"
+        "指明具体原因，此时改用 from_episode=1 做全量重置。"
+        "两种模式都对波及已消费集（已有 step1/剧本/媒体产物）时不执行并返回受影响清单，须告知用户、"
+        "确认后带 confirm_consumed=true 重新调用。任何下游产物（剧本、媒体）都不会被删除；"
+        "重置范围内可由账本重造的 source/episode_N.txt 会被删除，无原文范围记录的集文件改名留底"
+        "（不会丢内容），保留段的派生文件不受影响。",
         {
             "type": "object",
             "properties": {
                 "from_episode": {
                     "type": "integer",
-                    "description": "重置起点集号；当前仅支持 1（全量重置）",
+                    "description": "重置起点集号；1 为全量重置，大于 1 为部分重置（保留其前的集）",
                 },
                 "confirm_consumed": {
                     "type": "boolean",
@@ -274,7 +278,13 @@ def reset_episode_planning_tool(ctx: ToolContext):
                 lines.append(f"其中无原文范围记录的集文件会改名留底：{'、'.join(result.archived_files)}")
             return {"content": [{"type": "text", "text": "\n".join(lines)}]}
 
-        lines = [f"✅ 已全量重置分集规划：清空 {len(result.removed_episodes)} 集，planning_cursor 已置空。"]
+        if from_episode == 1:
+            lines = [f"✅ 已全量重置分集规划：清空 {len(result.removed_episodes)} 集，planning_cursor 已置空。"]
+        else:
+            lines = [
+                f"✅ 已部分重置分集规划：清空第 {from_episode} 集起共 {len(result.removed_episodes)} 集，"
+                f"planning_cursor 已退到第 {from_episode - 1} 集原文范围末尾。"
+            ]
         if result.deleted_files:
             lines.append(f"已删除可重造的派生集文件 {len(result.deleted_files)} 个。")
         if result.archived_files:
@@ -283,7 +293,10 @@ def reset_episode_planning_tool(ctx: ToolContext):
         if result.consumed_episodes:
             consumed = "、".join(str(num) for num in result.consumed_episodes)
             lines.append(f"第 {consumed} 集的剧本 / 媒体产物仍在磁盘，未删除。")
-        lines.append("账本已空，请调用 plan_episodes 从头重新规划（集号从第 1 集起）。")
+        if from_episode == 1:
+            lines.append("账本已空，请调用 plan_episodes 从头重新规划（集号从第 1 集起）。")
+        else:
+            lines.append(f"请调用 plan_episodes 继续规划（新集号从第 {from_episode} 集起）。")
         return {"content": [{"type": "text", "text": "\n".join(lines)}]}
 
     return _handler

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -2077,17 +2077,39 @@ async def test_reset_episode_planning_forwards_confirm(fake_ctx: ToolContext, mo
 
 @pytest.mark.unit
 async def test_reset_episode_planning_partial_reset_error(fake_ctx: ToolContext, monkeypatch) -> None:
-    """暂不支持的部分重置按可读错误返回，不走通用异常兜底。"""
+    """部分重置前置校验未通过（如源文指纹不一致）按可读错误返回，不走通用异常兜底。"""
     from lib.episode_reset import EpisodeResetError
     from server.agent_runtime.sdk_tools import episode_planning as mod
 
     monkeypatch.setattr(
-        mod, "reset_episode_planning", _fake_reset(EpisodeResetError("暂不支持部分重置（from_episode=3）"))
+        mod, "reset_episode_planning", _fake_reset(EpisodeResetError("源文件已被修改或移除：source/novel.txt"))
     )
     out = await _call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 3})
 
     assert out.get("is_error") is True
-    assert "暂不支持部分重置" in out["content"][0]["text"]
+    assert "源文件已被修改或移除" in out["content"][0]["text"]
+
+
+@pytest.mark.unit
+async def test_reset_episode_planning_partial_reset_success_message(fake_ctx: ToolContext, monkeypatch) -> None:
+    """部分重置成功时的摘要区分于全量重置：报清空范围与新起点，而非「账本已空」。"""
+    from lib.episode_reset import EpisodeResetResult
+    from server.agent_runtime.sdk_tools import episode_planning as mod
+
+    result = EpisodeResetResult(
+        removed_episodes=[2, 3], deleted_files=["source/episode_2.txt"], archived_files=[], consumed_episodes=[]
+    )
+    monkeypatch.setattr(mod, "reset_episode_planning", _fake_reset(result))
+
+    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 2})
+
+    assert out.get("is_error") is not True
+    text = out["content"][0]["text"]
+    assert "部分重置" in text
+    assert "第 2 集起共 2 集" in text
+    assert "第 1 集原文范围末尾" in text
+    assert "新集号从第 2 集起" in text
+    assert "账本已空" not in text
 
 
 @pytest.mark.unit

--- a/tests/test_episode_planner.py
+++ b/tests/test_episode_planner.py
@@ -1132,6 +1132,40 @@ class TestSourceFingerprintGate:
         result2 = await EpisodePlanner(project_dir, generator=fake2).plan()
         assert result2.episodes[0].title == "t2"
 
+    async def test_partial_reset_retains_prefix_and_plan_continues_numbering(self, tmp_path: Path):
+        """规划 2 集后部分重置到第 2 集：账本保留第 1 集、游标退到其末尾，再次 plan 从第 2 集续接编号。"""
+        project_dir = _write_project(tmp_path)
+        fake = _FakeTextGenerator(
+            [
+                _plan_response(
+                    [
+                        {"title": "t1", "hook": "h1", "end_anchor": ANCHOR_EP1},
+                        {"title": "t2", "hook": "h2", "end_anchor": ANCHOR_EP2},
+                    ]
+                )
+            ]
+        )
+        await EpisodePlanner(project_dir, generator=fake).plan()
+        assert [e["episode"] for e in _load_project(project_dir)["episodes"]] == [1, 2]
+
+        result = reset_episode_planning(project_dir, from_episode=2)
+        assert isinstance(result, EpisodeResetResult)
+
+        project = _load_project(project_dir)
+        assert [e["episode"] for e in project["episodes"]] == [1]
+        # 游标退到第 1 集原文范围末尾，指纹字段保留（部分重置已验证其与当前源文一致）
+        assert project["planning_cursor"] == {"source_file": "source/novel.txt", "offset": _end_of(ANCHOR_EP1)}
+        assert SOURCE_FINGERPRINTS_KEY in project
+        # 保留段派生文件不动，重置范围内的派生文件已删除
+        assert (project_dir / "source" / "episode_1.txt").is_file()
+        assert not (project_dir / "source" / "episode_2.txt").exists()
+
+        fake2 = _FakeTextGenerator([_plan_response([{"title": "t2b", "hook": "h2b", "end_anchor": ANCHOR_EP2}])])
+        result2 = await EpisodePlanner(project_dir, generator=fake2).plan()
+
+        assert [ep.episode for ep in result2.episodes] == [2]
+        assert [e["episode"] for e in _load_project(project_dir)["episodes"]] == [1, 2]
+
     async def test_plan_rejects_when_source_changes_during_model_call_without_record(self, tmp_path: Path):
         """存量项目补记路径：模型调用期间源文被改动，提交时按文本复核拒绝，不落任何写入。"""
         project_dir = _write_project(tmp_path)

--- a/tests/test_episode_reset.py
+++ b/tests/test_episode_reset.py
@@ -726,6 +726,25 @@ def test_partial_reset_rejects_gap_before_from_episode(tmp_path: Path) -> None:
     assert _load_project(project_dir) == before
 
 
+def test_partial_reset_rejects_huge_from_episode_without_hanging(tmp_path: Path) -> None:
+    """账本只有少量条目、``from_episode`` 却是天文数字集号（损坏写出）时快速拒绝：
+    缺口扫描按已有条目而非 ``range(1, from_episode)`` 走，不物化整段区间。"""
+    huge = 100_000_000
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(huge, source_range={"source_file": "source/novel.txt", "start": 10, "end": 20}),
+        ],
+    )
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="不连续"):
+        reset_episode_planning(project_dir, from_episode=huge)
+
+    assert _load_project(project_dir) == before
+
+
 def test_partial_reset_rejects_when_retain_boundary_unanchored(tmp_path: Path) -> None:
     """第 from_episode-1 集（游标退回点）本身是 unanchored 时无法确定重置后的规划起点。"""
     project_dir = _write_project(
@@ -784,8 +803,8 @@ def test_partial_reset_rejects_non_contiguous_retained_ranges(tmp_path: Path) ->
     project_dir = _write_project(
         tmp_path,
         episodes=[
-            _entry(1, source_range={"source_file": "source/novel.txt", "start": 20, "end": 30}),
-            _entry(2, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": 30, "end": 40}),
             _entry(3, source_range={"source_file": "source/novel.txt", "start": 10, "end": 20}),
         ],
     )
@@ -793,6 +812,68 @@ def test_partial_reset_rejects_non_contiguous_retained_ranges(tmp_path: Path) ->
 
     with pytest.raises(EpisodeResetError, match="不连续"):
         reset_episode_planning(project_dir, from_episode=3)
+
+    assert _load_project(project_dir) == before
+
+
+def test_partial_reset_rejects_when_first_episode_not_at_source_start(tmp_path: Path) -> None:
+    """第 1 集范围本身未越界，但没有从首个源文件偏移 0 起：放行会让 [0, 该起点) 这段
+    源文既不在保留账本里、退回后的游标也不会再规划到它，永久遗漏。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 20, "end": 30}),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": 30, "end": 40}),
+        ],
+    )
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="未从首个源文件起点开始"):
+        reset_episode_planning(project_dir, from_episode=2)
+
+    assert _load_project(project_dir) == before
+
+
+def test_partial_reset_rejects_out_of_order_source_file_switch(tmp_path: Path) -> None:
+    """保留段跨源文件时必须切到排序中紧邻的下一个文件：这里第 1 集用完 a.txt 后跳过
+    b.txt 直接切到 c.txt，拒绝。"""
+    project_dir = _write_project(tmp_path)
+    (project_dir / "source" / "a.txt").write_text("A" * 10, encoding="utf-8")
+    (project_dir / "source" / "b.txt").write_text("B" * 10, encoding="utf-8")
+    (project_dir / "source" / "c.txt").write_text("C" * 10, encoding="utf-8")
+    project = _load_project(project_dir)
+    project["episodes"] = [
+        _entry(1, source_range={"source_file": "source/a.txt", "start": 0, "end": 10}),
+        _entry(2, source_range={"source_file": "source/c.txt", "start": 0, "end": 10}),
+        _entry(3, source_range={"source_file": "source/c.txt", "start": 10, "end": 10}),
+    ]
+    (project_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="切换源文件不合法"):
+        reset_episode_planning(project_dir, from_episode=3)
+
+    assert _load_project(project_dir) == before
+
+
+def test_partial_reset_rejects_unanchored_status_with_forged_source_range(tmp_path: Path) -> None:
+    """游标退回点标 unanchored 但仍带结构合法、坐标连续的 source_range：不采信该坐标——
+    规划器同样不认它，采信会让重置写出一个规划器自己都不承认的游标。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(
+                1,
+                source_range={"source_file": "source/novel.txt", "start": 0, "end": 10},
+                status="unanchored",
+            ),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": 10, "end": 20}),
+        ],
+    )
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="缺少原文范围记录"):
+        reset_episode_planning(project_dir, from_episode=2)
 
     assert _load_project(project_dir) == before
 

--- a/tests/test_episode_reset.py
+++ b/tests/test_episode_reset.py
@@ -828,7 +828,7 @@ def test_partial_reset_rejects_when_first_episode_not_at_source_start(tmp_path: 
     )
     before = _load_project(project_dir)
 
-    with pytest.raises(EpisodeResetError, match="未从首个源文件起点开始"):
+    with pytest.raises(EpisodeResetError, match="未从源文件起点开始"):
         reset_episode_planning(project_dir, from_episode=2)
 
     assert _load_project(project_dir) == before
@@ -852,6 +852,66 @@ def test_partial_reset_rejects_out_of_order_source_file_switch(tmp_path: Path) -
 
     with pytest.raises(EpisodeResetError, match="切换源文件不合法"):
         reset_episode_planning(project_dir, from_episode=3)
+
+    assert _load_project(project_dir) == before
+
+
+def test_partial_reset_allows_first_episode_after_blank_leading_source(tmp_path: Path) -> None:
+    """排序中排在第 1 集源文件之前的文件若只剩空白（EpisodePlanner 会自动跳过），
+    第 1 集合法落在非首个文件，不应被误判为账本损坏。"""
+    project_dir = _write_project(tmp_path)
+    (project_dir / "source" / "a.txt").write_text("   \n  ", encoding="utf-8")
+    (project_dir / "source" / "b.txt").write_text("B" * 10, encoding="utf-8")
+    project = _load_project(project_dir)
+    project["episodes"] = [
+        _entry(1, source_range={"source_file": "source/b.txt", "start": 0, "end": 10}),
+        _entry(2, source_range={"source_file": "source/b.txt", "start": 10, "end": 10}),
+    ]
+    (project_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=2)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert _load_project(project_dir)["planning_cursor"] == {"source_file": "source/b.txt", "offset": 10}
+
+
+def test_partial_reset_allows_skip_over_blank_middle_source(tmp_path: Path) -> None:
+    """相邻保留集跨源文件时，中间被跳过的文件若只剩空白同样合法，不要求恰为紧邻下一个
+    文件。"""
+    project_dir = _write_project(tmp_path)
+    (project_dir / "source" / "a.txt").write_text("A" * 10, encoding="utf-8")
+    (project_dir / "source" / "b.txt").write_text("   \n  ", encoding="utf-8")
+    (project_dir / "source" / "c.txt").write_text("C" * 10, encoding="utf-8")
+    project = _load_project(project_dir)
+    project["episodes"] = [
+        _entry(1, source_range={"source_file": "source/a.txt", "start": 0, "end": 10}),
+        _entry(2, source_range={"source_file": "source/c.txt", "start": 0, "end": 10}),
+        _entry(3, source_range={"source_file": "source/c.txt", "start": 10, "end": 10}),
+    ]
+    (project_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=3)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert _load_project(project_dir)["planning_cursor"] == {"source_file": "source/c.txt", "offset": 10}
+
+
+def test_partial_reset_rejects_mid_sequence_unanchored_entry(tmp_path: Path) -> None:
+    """保留段中间（非边界）出现失锚条目，其后又有锚定记录：该记录的坐标无法证明与
+    已验证内容衔接，中间那段源文可能被永久遗漏，拒绝而非凭空重新起锚。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(2, source_range=None, status="unanchored"),
+            _entry(3, source_range={"source_file": "source/novel.txt", "start": 20, "end": 30}),
+            _entry(4, source_range={"source_file": "source/novel.txt", "start": 30, "end": 40}),
+        ],
+    )
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="存在失锚（unanchored）条目"):
+        reset_episode_planning(project_dir, from_episode=4)
 
     assert _load_project(project_dir) == before
 

--- a/tests/test_episode_reset.py
+++ b/tests/test_episode_reset.py
@@ -778,6 +778,43 @@ def test_partial_reset_rejects_when_retained_range_out_of_bounds(tmp_path: Path)
     assert _load_project(project_dir) == before
 
 
+def test_partial_reset_rejects_non_contiguous_retained_ranges(tmp_path: Path) -> None:
+    """保留段相邻两集各自坐标均未越界，但首尾不相接（此处为倒序）时拒绝：放行会让退回
+    后的游标与真实已消费范围脱节，下次 plan 与已保留内容重叠。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 20, "end": 30}),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(3, source_range={"source_file": "source/novel.txt", "start": 10, "end": 20}),
+        ],
+    )
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="不连续"):
+        reset_episode_planning(project_dir, from_episode=3)
+
+    assert _load_project(project_dir) == before
+
+
+def test_partial_reset_rejects_non_positive_episode_numbers_in_ledger(tmp_path: Path) -> None:
+    """账本存在非正数集号（如损坏写出的 0）时拒绝：不能证明它属于保留段还是应被清除。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(0, source_range={"source_file": "source/novel.txt", "start": 0, "end": 0}),
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": 10, "end": 20}),
+        ],
+    )
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="非法集号"):
+        reset_episode_planning(project_dir, from_episode=2)
+
+    assert _load_project(project_dir) == before
+
+
 def test_partial_reset_rejects_duplicate_episode_numbers(tmp_path: Path) -> None:
     project_dir = _write_project(
         tmp_path,

--- a/tests/test_episode_reset.py
+++ b/tests/test_episode_reset.py
@@ -756,7 +756,7 @@ def test_partial_reset_rejects_when_retain_boundary_unanchored(tmp_path: Path) -
     )
     before = _load_project(project_dir)
 
-    with pytest.raises(EpisodeResetError, match="缺少原文范围记录"):
+    with pytest.raises(EpisodeResetError, match="缺少可信的原文范围记录"):
         reset_episode_planning(project_dir, from_episode=2)
 
     assert _load_project(project_dir) == before
@@ -791,7 +791,7 @@ def test_partial_reset_rejects_when_retained_range_out_of_bounds(tmp_path: Path)
     )
     before = _load_project(project_dir)
 
-    with pytest.raises(EpisodeResetError, match="越界"):
+    with pytest.raises(EpisodeResetError, match="原文范围无效"):
         reset_episode_planning(project_dir, from_episode=2)
 
     assert _load_project(project_dir) == before
@@ -916,6 +916,44 @@ def test_partial_reset_rejects_mid_sequence_unanchored_entry(tmp_path: Path) -> 
     assert _load_project(project_dir) == before
 
 
+def test_partial_reset_rejects_zero_length_retained_range(tmp_path: Path) -> None:
+    """保留段坐标 start == end（零长度）时拒绝：与 EpisodePlanner 重排校验的
+    ``start < end`` 口径一致，否则会保留一个空集并让游标退到起点，造成编号错位。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 0}),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+        ],
+    )
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="原文范围无效"):
+        reset_episode_planning(project_dir, from_episode=2)
+
+    assert _load_project(project_dir) == before
+
+
+def test_partial_reset_rejects_retain_boundary_pending_backfill(tmp_path: Path) -> None:
+    """游标退回点缺少 ledger_status（``backfill_episode_ledger`` 眼中待回填）：账本里
+    存的 source_range 未必是下一次 plan() 回填后的最终结果，不可信，拒绝而非直接采信。"""
+    project_dir = _write_project(tmp_path)
+    project = _load_project(project_dir)
+    entry = _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10})
+    del entry["ledger_status"]
+    project["episodes"] = [
+        entry,
+        _entry(2, source_range={"source_file": "source/novel.txt", "start": 10, "end": 20}),
+    ]
+    (project_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="缺少可信的原文范围记录"):
+        reset_episode_planning(project_dir, from_episode=2)
+
+    assert _load_project(project_dir) == before
+
+
 def test_partial_reset_rejects_unanchored_status_with_forged_source_range(tmp_path: Path) -> None:
     """游标退回点标 unanchored 但仍带结构合法、坐标连续的 source_range：不采信该坐标——
     规划器同样不认它，采信会让重置写出一个规划器自己都不承认的游标。"""
@@ -932,7 +970,7 @@ def test_partial_reset_rejects_unanchored_status_with_forged_source_range(tmp_pa
     )
     before = _load_project(project_dir)
 
-    with pytest.raises(EpisodeResetError, match="缺少原文范围记录"):
+    with pytest.raises(EpisodeResetError, match="缺少可信的原文范围记录"):
         reset_episode_planning(project_dir, from_episode=2)
 
     assert _load_project(project_dir) == before

--- a/tests/test_episode_reset.py
+++ b/tests/test_episode_reset.py
@@ -242,9 +242,9 @@ def test_conflict_when_new_consumed_episode_appears_during_commit(
     original_scan = episode_reset_module._scan
     calls = {"n": 0}
 
-    def _fake_scan(pd: Path, project: dict):
+    def _fake_scan(pd: Path, project: dict, *, from_episode: int = 1):
         calls["n"] += 1
-        result = original_scan(pd, project)
+        result = original_scan(pd, project, from_episode=from_episode)
         if calls["n"] == 2:  # 第二次调用发生在锁内（_commit 的复扫）
             result.consumed.append(1)
         return result
@@ -605,15 +605,268 @@ def test_reset_processes_all_padding_aliases_of_same_episode(tmp_path: Path) -> 
     assert discover_episode_files(project_dir) == {}
 
 
-def test_partial_reset_rejected_without_touching_ledger(tmp_path: Path) -> None:
+def test_reset_rejects_non_positive_from_episode(tmp_path: Path) -> None:
+    project_dir = _write_project(tmp_path)
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="正整数"):
+        reset_episode_planning(project_dir, from_episode=0)
+
+    assert _load_project(project_dir) == before
+
+
+# ---------------------------------------------------------------------------
+# 部分重置：成功路径
+# ---------------------------------------------------------------------------
+
+
+def test_partial_reset_keeps_retained_episodes_and_rewinds_cursor(tmp_path: Path) -> None:
+    """规划 3 集后部分重置到第 2 集：账本只保留第 1 集，游标退到第 1 集原文范围末尾，
+    再次规划的起点与集号自然从第 2 集续上。"""
+    end1 = 10
+    end2 = 20
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": end1}),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": end1, "end": end2}),
+            _entry(3, source_range={"source_file": "source/novel.txt", "start": end2, "end": end2 + 10}),
+        ],
+        planning_cursor={"source_file": "source/novel.txt", "offset": end2 + 10},
+    )
+    (project_dir / "source" / "episode_2.txt").write_text(SOURCE[end1:end2], encoding="utf-8")
+    (project_dir / "source" / "episode_3.txt").write_text(SOURCE[end2 : end2 + 10], encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=2)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert result.removed_episodes == [2, 3]
+    project = _load_project(project_dir)
+    assert [e["episode"] for e in project["episodes"]] == [1]
+    assert project["planning_cursor"] == {"source_file": "source/novel.txt", "offset": end1}
+    # 再次规划的起点（供 EpisodePlanner._effective_start 消费）与新集号自然从第 2 集续上
+    assert EpisodePlanner(project_dir)._effective_start(project) == ("source/novel.txt", end1)
+
+
+def test_partial_reset_deletes_derived_files_in_range_keeps_retained(tmp_path: Path) -> None:
+    """范围内（>= from_episode）有 source_range 的派生文件删除，保留段（< from_episode）
+    派生文件不受影响。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": 10, "end": 20}),
+        ],
+    )
+    retained_file = project_dir / "source" / "episode_1.txt"
+    retained_file.write_text(SOURCE[:10], encoding="utf-8")
+    reset_file = project_dir / "source" / "episode_2.txt"
+    reset_file.write_text(SOURCE[10:20], encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=2)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert result.deleted_files == ["source/episode_2.txt"]
+    assert not reset_file.exists()
+    assert retained_file.exists()  # 保留段派生文件不动
+
+
+def test_partial_reset_archives_unanchored_file_in_range(tmp_path: Path) -> None:
+    """范围内 unanchored（无 source_range）的集文件按无法重造处理，留底而非删除。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(2, source_range=None, status="unanchored"),
+        ],
+    )
+    (project_dir / "source" / "episode_1.txt").write_text(SOURCE[:10], encoding="utf-8")
+    legacy = project_dir / "source" / "episode_2.txt"
+    legacy.write_text("老项目手工内容", encoding="utf-8")
+
+    result = reset_episode_planning(project_dir, from_episode=2)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert result.archived_files == [("source/episode_2.txt", "source/_episode_2.txt.bak")]
+    assert not legacy.exists()
+
+
+# ---------------------------------------------------------------------------
+# 部分重置：前置校验拒绝（账本与文件均不被改动）
+# ---------------------------------------------------------------------------
+
+
+def test_partial_reset_rejects_when_from_episode_not_in_ledger(tmp_path: Path) -> None:
     project_dir = _write_project(
         tmp_path,
         episodes=[_entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10})],
-        planning_cursor={"source_file": "source/novel.txt", "offset": 10},
     )
     before = _load_project(project_dir)
 
-    with pytest.raises(EpisodeResetError, match="部分重置"):
+    with pytest.raises(EpisodeResetError, match="不在账本中"):
+        reset_episode_planning(project_dir, from_episode=5)
+
+    assert _load_project(project_dir) == before
+
+
+def test_partial_reset_rejects_gap_before_from_episode(tmp_path: Path) -> None:
+    """保留段（1..from_episode-1）存在缺口时拒绝：无法确定「保留到哪」。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(3, source_range={"source_file": "source/novel.txt", "start": 10, "end": 20}),
+        ],
+    )
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="不连续"):
+        reset_episode_planning(project_dir, from_episode=3)
+
+    assert _load_project(project_dir) == before
+
+
+def test_partial_reset_rejects_when_retain_boundary_unanchored(tmp_path: Path) -> None:
+    """第 from_episode-1 集（游标退回点）本身是 unanchored 时无法确定重置后的规划起点。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range=None, status="unanchored"),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": 10, "end": 20}),
+        ],
+    )
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="缺少原文范围记录"):
         reset_episode_planning(project_dir, from_episode=2)
 
     assert _load_project(project_dir) == before
+
+
+def test_partial_reset_rejects_on_fingerprint_mismatch(tmp_path: Path) -> None:
+    """已记录的源文指纹与当前源文不一致时拒绝，账本与文件均不被改动。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": 10, "end": 20}),
+        ],
+        extra={SOURCE_FINGERPRINTS_KEY: {"source/novel.txt": "0" * 64}},  # 与实际内容不一致的假指纹
+    )
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="已被修改或移除"):
+        reset_episode_planning(project_dir, from_episode=2)
+
+    assert _load_project(project_dir) == before
+
+
+def test_partial_reset_rejects_when_retained_range_out_of_bounds(tmp_path: Path) -> None:
+    """保留段坐标越出当前源文长度（源文已被替换为更短内容，指纹未记录故绕过指纹门禁）时拒绝。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 99999}),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": 99999, "end": 100010}),
+        ],
+    )
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="越界"):
+        reset_episode_planning(project_dir, from_episode=2)
+
+    assert _load_project(project_dir) == before
+
+
+def test_partial_reset_rejects_duplicate_episode_numbers(tmp_path: Path) -> None:
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": 10, "end": 20}),
+        ],
+    )
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="重复集号"):
+        reset_episode_planning(project_dir, from_episode=2)
+
+    assert _load_project(project_dir) == before
+
+
+def test_partial_reset_rejects_non_list_episodes(tmp_path: Path) -> None:
+    project_dir = _write_project(tmp_path, extra={"episodes": 1})
+    before = _load_project(project_dir)
+
+    with pytest.raises(EpisodeResetError, match="形状异常"):
+        reset_episode_planning(project_dir, from_episode=2)
+
+    assert _load_project(project_dir) == before
+
+
+# ---------------------------------------------------------------------------
+# 部分重置：已消费集的二段确认
+# ---------------------------------------------------------------------------
+
+
+def test_partial_reset_consumed_within_range_requires_confirmation(tmp_path: Path) -> None:
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(
+                2,
+                source_range={"source_file": "source/novel.txt", "start": 10, "end": 20},
+                status="consumed",
+            ),
+        ],
+    )
+    script = _write_script(project_dir, 2)
+    before = _load_project(project_dir)
+
+    result = reset_episode_planning(project_dir, from_episode=2)
+
+    assert isinstance(result, ResetConfirmationRequired)
+    assert result.consumed_episodes == [2]
+    assert _load_project(project_dir) == before
+    assert script.is_file()
+
+
+def test_partial_reset_consumed_before_range_not_flagged(tmp_path: Path) -> None:
+    """保留段（< from_episode）已消费不影响二段确认：确认只针对本次重置范围内的集。"""
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}, status="consumed"),
+            _entry(2, source_range={"source_file": "source/novel.txt", "start": 10, "end": 20}),
+        ],
+    )
+    _write_script(project_dir, 1)
+
+    result = reset_episode_planning(project_dir, from_episode=2)
+
+    assert isinstance(result, EpisodeResetResult)
+
+
+def test_partial_reset_confirmed_keeps_downstream_products(tmp_path: Path) -> None:
+    project_dir = _write_project(
+        tmp_path,
+        episodes=[
+            _entry(1, source_range={"source_file": "source/novel.txt", "start": 0, "end": 10}),
+            _entry(
+                2,
+                source_range={"source_file": "source/novel.txt", "start": 10, "end": 20},
+                status="consumed",
+            ),
+        ],
+    )
+    script = _write_script(project_dir, 2)
+
+    result = reset_episode_planning(project_dir, from_episode=2, confirm_consumed=True)
+
+    assert isinstance(result, EpisodeResetResult)
+    assert result.consumed_episodes == [2]
+    assert script.is_file()
+    project = _load_project(project_dir)
+    assert [e["episode"] for e in project["episodes"]] == [1]


### PR DESCRIPTION
## 变更

`reset_episode_planning` 支持 `from_episode > 1`：删除第 N 集起的账本条目，`planning_cursor` 退到第 N-1 集的源文末尾坐标，下次 `plan_episodes` 从第 N 集续接编号，第 1..N-1 集的账本条目与派生文件保持不动。

与零前置校验的全量重置相反，部分重置走前置校验：账本形状干净、保留段连续、退回点带完整 `source_range`、全部已记录源文指纹与当前源文一致、保留段坐标落在当前源文界内。任一不满足则指名具体原因并指引改用 `from_episode=1` 全量重置，账本与文件均不改动。校验在锁外预跑一次、锁内提交前再跑一次，覆盖用户确认往返期间源文被外部改动的 TOCTOU 窗口。

二段确认与文件处置沿用全量重置：波及已消费集时先返回清单，确认后执行且下游产物一律不删。

## 验证

- 验收标准逐条覆盖：`tests/test_episode_reset.py` 覆盖保留段/游标/拒绝路径零改动/二段确认/文件处置；`tests/test_episode_planner.py::test_partial_reset_retains_prefix_and_plan_continues_numbering` 端到端覆盖「plan → 部分重置 → 再 plan 从第 N 集续接编号」
- `uv run ruff check` / `ruff format --check` 全绿
- `uv run basedpyright` 全量扫描 0 errors
- `uv run python -m pytest` 6642 passed
- 未涉及前端改动

Closes #1370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持从指定集数开始的**部分重置**：保留更早集数的账本与规划进度，将起点回退后继续生成后续集。
  - 界面文案区分**全量**与**部分**重置：重置确认、成功摘要与下一步提示随之更新。

- **改进**
  - 部分重置增加更严格的前置校验与更清晰的失败原因提示，减少不一致回滚与误操作风险。
  - 锁内复扫与已消费集冲突处理按重置范围调整。

- **测试**
  - 扩展并细化部分重置成功/失败、提示摘要与账本变更快照用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->