### PR TITLE
fix(script): 剧本资产字段损坏时不再中断进度统计、入队与导出

### DIFF
--- a/lib/status_calculator.py
+++ b/lib/status_calculator.py
@@ -17,6 +17,7 @@ from lib.path_safety import safe_exists
 from lib.project_manager import effective_mode
 from lib.script_models import ad_script_total_duration, script_duration_total
 from lib.script_skeleton import SKELETONS, resolve_declared_kind
+from lib.storyboard_sequence import get_generated_assets
 
 logger = logging.getLogger(__name__)
 
@@ -116,8 +117,8 @@ class StatusCalculator:
         if kind == "shots" and generation_mode == "reference_video":
             return self._calculate_ad_reference_stats(script, items)
 
-        storyboard_done = sum(1 for i in items if i.get("generated_assets", {}).get("storyboard_image"))
-        video_done = sum(1 for i in items if i.get("generated_assets", {}).get("video_clip"))
+        storyboard_done = sum(1 for i in items if get_generated_assets(i).get("storyboard_image"))
+        video_done = sum(1 for i in items if get_generated_assets(i).get("video_clip"))
         total = len(items)
 
         if video_done == total and total > 0:
@@ -188,7 +189,7 @@ class StatusCalculator:
     def _calculate_reference_video_stats(units: list[dict]) -> dict:
         """Reference-video scripts are scored by video_units[].generated_assets.video_clip."""
         total = len(units)
-        video_done = sum(1 for u in units if u.get("generated_assets", {}).get("video_clip"))
+        video_done = sum(1 for u in units if get_generated_assets(u).get("video_clip"))
 
         if total == 0:
             status = "draft"

--- a/server/agent_runtime/sdk_tools/enqueue_narration_audio.py
+++ b/server/agent_runtime/sdk_tools/enqueue_narration_audio.py
@@ -15,7 +15,7 @@ from lib.generation_queue_client import (
     batch_enqueue_and_wait,
 )
 from lib.resource_paths import resource_relative_path
-from lib.storyboard_sequence import get_storyboard_items
+from lib.storyboard_sequence import get_generated_assets, get_storyboard_items
 from server.agent_runtime.sdk_tools._context import ToolContext, tool_error, validate_script_filename
 
 
@@ -30,7 +30,7 @@ def _select_items(items: list[dict[str, Any]], id_field: str, segment_ids: list[
     if segment_ids is not None:
         wanted = {str(s) for s in segment_ids}
         return [item for item in items if str(item.get(id_field)) in wanted]
-    return [item for item in items if not (item.get("generated_assets") or {}).get("narration_audio")]
+    return [item for item in items if not get_generated_assets(item).get("narration_audio")]
 
 
 def generate_narration_audio_tool(ctx: ToolContext):

--- a/server/agent_runtime/sdk_tools/enqueue_storyboards.py
+++ b/server/agent_runtime/sdk_tools/enqueue_storyboards.py
@@ -19,6 +19,7 @@ from lib.prompt_utils import image_prompt_to_yaml, is_structured_image_prompt, n
 from lib.storyboard_sequence import (
     StoryboardTaskPlan,
     build_storyboard_dependency_plan,
+    get_generated_assets,
     get_storyboard_items,
 )
 from server.agent_runtime.sdk_tools._context import ToolContext, tool_error, validate_script_filename
@@ -93,7 +94,7 @@ def _select_items(items: list[dict[str, Any]], id_field: str, segment_ids: list[
     if segment_ids is not None:
         wanted = {str(s) for s in segment_ids}
         return [item for item in items if str(item.get(id_field)) in wanted]
-    return [item for item in items if not item.get("generated_assets", {}).get("storyboard_image")]
+    return [item for item in items if not get_generated_assets(item).get("storyboard_image")]
 
 
 def _build_specs(

--- a/server/services/jianying_draft_service.py
+++ b/server/services/jianying_draft_service.py
@@ -55,6 +55,7 @@ from lib.reference_video.ad_units import ad_shots_by_id
 from lib.script_models import ad_shot_duration_seconds
 from lib.script_skeleton import SKELETONS, resolve_declared_kind
 from lib.speech_rate import estimate_spoken_seconds
+from lib.storyboard_sequence import get_generated_assets
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +164,7 @@ class JianyingDraftService:
 
         clips = []
         for item in items:
-            assets = item.get("generated_assets") or {}
+            assets = get_generated_assets(item)
             video_clip = assets.get("video_clip")
             if not video_clip:
                 continue

--- a/server/services/project_cover.py
+++ b/server/services/project_cover.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from lib.storyboard_sequence import get_generated_assets
+
 if TYPE_CHECKING:
     from lib.project_manager import ProjectManager
 
@@ -86,14 +88,14 @@ def resolve_project_cover(
 
     for script in scripts:
         for item in _iter_items(script):
-            ga = (item or {}).get("generated_assets") or {}
+            ga = get_generated_assets(item or {})
             thumb = ga.get("video_thumbnail")
             if thumb:
                 return _url(thumb)
 
     for script in scripts:
         for item in _iter_items(script):
-            ga = (item or {}).get("generated_assets") or {}
+            ga = get_generated_assets(item or {})
             sb = ga.get("storyboard_image")
             if sb:
                 return _url(sb)

--- a/tests/lib/test_status_calculator_reference.py
+++ b/tests/lib/test_status_calculator_reference.py
@@ -77,6 +77,18 @@ def test_calculate_episode_stats_reference_video_empty_draft(pm: ProjectManager)
     assert stats["duration_seconds"] == 0
 
 
+def test_calculate_episode_stats_reference_video_tolerates_corrupt_generated_assets(
+    pm: ProjectManager,
+) -> None:
+    """generated_assets 为非 dict 脏数据（如字符串）时按缺失处理，不抛 AttributeError。"""
+    calc = StatusCalculator(pm)
+    script = _mk_reference_script(units_total=2, units_done=1)
+    script["video_units"][0]["generated_assets"] = "corrupt"
+    stats = calc.calculate_episode_stats("proj", script)
+    assert stats["status"] == "draft"
+    assert stats["videos"] == {"total": 2, "completed": 0}
+
+
 def test_enrich_script_reference_video_aggregates_references(pm: ProjectManager) -> None:
     """enrich_script must collect @character/@scene/@prop references from units."""
     calc = StatusCalculator(pm)

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -569,9 +569,12 @@ async def test_generate_storyboards_selects_item_with_corrupt_generated_assets(
     """generated_assets 为非 dict 脏数据（如字符串）时按缺失处理，不抛 AttributeError。"""
     from server.agent_runtime.sdk_tools import enqueue_storyboards as mod
 
+    captured: list[Any] = []
+
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
         from lib.generation_queue_client import BatchTaskResult
 
+        captured.extend(specs)
         succ = [
             BatchTaskResult(
                 resource_id=s.resource_id,
@@ -588,6 +591,7 @@ async def test_generate_storyboards_selects_item_with_corrupt_generated_assets(
     tool_obj = generate_storyboards_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True, out
+    assert [s.resource_id for s in captured] == ["E1S01"]
 
 
 async def test_generate_storyboards_error(fake_ctx: ToolContext, monkeypatch) -> None:

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -293,6 +293,40 @@ async def test_generate_narration_audio_enqueues_missing_segments(fake_ctx: Tool
     assert "audio/segment_E1S01.wav" in text
 
 
+async def test_generate_narration_audio_selects_item_with_corrupt_generated_assets(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """generated_assets 为非 dict 脏数据（如字符串）时按缺失处理，不抛 AttributeError。"""
+    from server.agent_runtime.sdk_tools import enqueue_narration_audio as mod
+
+    script = _narration_audio_script()
+    script["segments"][0]["generated_assets"] = "corrupt"
+    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    captured: list[Any] = []
+
+    async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
+        from lib.generation_queue_client import BatchTaskResult
+
+        captured.extend(specs)
+        succ = [
+            BatchTaskResult(
+                resource_id=s.resource_id,
+                task_id="t1",
+                status="succeeded",
+                result={"file_path": f"audio/segment_{s.resource_id}.wav"},
+            )
+            for s in specs
+        ]
+        return succ, []
+
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+    tool_obj = mod.generate_narration_audio_tool(fake_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json"})
+
+    assert out.get("is_error") is not True, out
+    assert [s.resource_id for s in captured] == ["E1S01"]
+
+
 async def test_generate_narration_audio_explicit_ids_regenerate(fake_ctx: ToolContext, monkeypatch) -> None:
     """传 segment_ids → 即使该段已有 narration_audio 也重新入队（批量范围/单段重生语义）。"""
     from server.agent_runtime.sdk_tools import enqueue_narration_audio as mod
@@ -527,6 +561,33 @@ async def test_generate_storyboards_happy(fake_ctx: ToolContext, monkeypatch) ->
     tool_obj = generate_storyboards_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True
+
+
+async def test_generate_storyboards_selects_item_with_corrupt_generated_assets(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """generated_assets 为非 dict 脏数据（如字符串）时按缺失处理，不抛 AttributeError。"""
+    from server.agent_runtime.sdk_tools import enqueue_storyboards as mod
+
+    async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
+        from lib.generation_queue_client import BatchTaskResult
+
+        succ = [
+            BatchTaskResult(
+                resource_id=s.resource_id,
+                task_id="t1",
+                status="succeeded",
+                result={"file_path": f"storyboards/scene_{s.resource_id}.png"},
+            )
+            for s in specs
+        ]
+        return succ, []
+
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = "corrupt"  # type: ignore[attr-defined]
+    tool_obj = generate_storyboards_tool(fake_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json"})
+    assert out.get("is_error") is not True, out
 
 
 async def test_generate_storyboards_error(fake_ctx: ToolContext, monkeypatch) -> None:

--- a/tests/server/test_project_cover.py
+++ b/tests/server/test_project_cover.py
@@ -100,6 +100,17 @@ def test_reference_mode_without_generated_assets_falls_back_to_scene_sheet():
     assert url == "/api/v1/files/proj/scenes/酒馆.png"
 
 
+def test_tolerates_corrupt_generated_assets():
+    """generated_assets 为非 dict 脏数据（如字符串）时按缺失处理，回退到 scene_sheet，不抛异常。"""
+    project = {
+        "episodes": [{"script_file": "scripts/episode_1.json"}],
+        "scenes": {"酒馆": {"scene_sheet": "scenes/酒馆.png"}},
+    }
+    scripts = {"scripts/episode_1.json": {"video_units": [{"generated_assets": "corrupt"}]}}
+    url = resolve_project_cover(_mk_manager(scripts), "proj", project)
+    assert url == "/api/v1/files/proj/scenes/酒馆.png"
+
+
 def test_falls_back_to_character_sheet_when_no_scenes():
     project = {
         "episodes": [],

--- a/tests/test_jianying_draft_service.py
+++ b/tests/test_jianying_draft_service.py
@@ -230,6 +230,30 @@ class TestCollectVideoClips:
         assert clips[1]["id"] == "E1S2"
         assert clips[1]["subtitle_text"] == "点击下方链接立即下单"
 
+    def test_tolerates_corrupt_generated_assets(self, tmp_path):
+        """generated_assets 为非 dict 脏数据（如字符串）时按缺失处理，不抛 AttributeError"""
+        from server.services.jianying_draft_service import JianyingDraftService
+
+        project_dir = tmp_path / "projects" / "demo"
+        project_dir.mkdir(parents=True)
+
+        script = {
+            "content_mode": "narration",
+            "segments": [
+                {
+                    "segment_id": "S1",
+                    "duration_seconds": 8,
+                    "novel_text": "从前有座山",
+                    "generated_assets": "corrupt",
+                },
+            ],
+        }
+
+        svc = JianyingDraftService.__new__(JianyingDraftService)
+        clips = svc._collect_video_clips(script, project_dir)
+
+        assert len(clips) == 0
+
     def test_skips_missing_video_files(self, tmp_path):
         """script 中有记录但文件不存在时跳过"""
         from server.services.jianying_draft_service import JianyingDraftService

--- a/tests/test_status_calculator.py
+++ b/tests/test_status_calculator.py
@@ -80,6 +80,23 @@ class TestStatusCalculator:
         assert completed["storyboards"] == {"total": 1, "completed": 0}
         assert completed["videos"] == {"total": 1, "completed": 1}
 
+    def test_calculate_episode_stats_tolerates_corrupt_generated_assets(self, tmp_path):
+        """generated_assets 为非 dict 脏数据（如字符串）时按缺失处理，不抛 AttributeError。"""
+        calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
+
+        stats = calc.calculate_episode_stats(
+            "demo",
+            {
+                "content_mode": "narration",
+                "segments": [
+                    {"generated_assets": "corrupt", "duration_seconds": 4},
+                    {"generated_assets": {"storyboard_image": "a.png"}, "duration_seconds": 4},
+                ],
+            },
+        )
+        assert stats["storyboards"] == {"total": 2, "completed": 1}
+        assert stats["videos"] == {"total": 2, "completed": 0}
+
     def test_load_episode_script(self, tmp_path):
         project_root = tmp_path / "projects"
         project_path = project_root / "demo"


### PR DESCRIPTION
剧本 JSON 的 `generated_assets` 字段被外部编辑损坏成非 dict（如字符串）时，进度统计、分镜/配音入队、剪映导出、项目封面这几条读取路径会抛 `AttributeError` 中断，而非按「该资产未生成」跳过。原因是这些调用点沿用 `(x or {}).get(...)` / `.get("generated_assets", {})` 手写形态——`or {}` 只兜 falsy，兜不住非空非 dict 的真值；`.get(key, default)` 的 default 也只在 key 缺失时生效。

本次把这些访问点统一收编进共享 helper `get_generated_assets`（非 dict 归一化为空 dict），损坏数据降级为「未生成」，不再中断整批处理。

## 改动的访问点

- `lib/status_calculator.py` — `calculate_episode_stats` 主路径 storyboard_done / video_done 两处，`_calculate_reference_video_stats` 一处
- `server/agent_runtime/sdk_tools/enqueue_storyboards.py` — `_select_items`
- `server/agent_runtime/sdk_tools/enqueue_narration_audio.py` — `_select_items`
- `server/services/jianying_draft_service.py` — `_collect_video_clips` 主分支
- `server/services/project_cover.py` — `_iter_items` 后 video_thumbnail / storyboard_image 两处

## 核查结论：已有等价防御、保持原样的访问点

issue 点名的 7 个文件已逐一 grep 全量核查，以下访问点在非 dict 脏数据下不会抛错，按验收标准保持原样：

- `lib/status_calculator.py:166`（`_calculate_ad_reference_stats`）——上游 `_wellformed()` 在 `units = raw_units` 前逐 unit 断言 `ga is None or isinstance(ga, dict)`，且要求全体通过才采纳索引；执行到此处类型已保证安全。此处若改用 helper 反而会把损坏索引变成部分计数，与「坏索引不伪装成真实进度」的既有语义冲突
- `server/services/jianying_draft_service.py:211-212`（`_collect_ad_reference_unit_clips`）——取值后 `isinstance(assets, dict)` 三元兜底
- `server/services/cost_estimation.py:179-181`——取值后 `isinstance` 校验 + `continue` 短路
- `server/services/image_edit_tasks.py:62-63`——取值后 `isinstance(assets, dict)` 三元兜底

`server/agent_runtime/sdk_tools/enqueue_videos.py` 的 `reuse_existing` lambda（:470）与批量过滤 pending 分支（:690）——issue 正文点名的两处，核查发现已在 #1398 完成收编，当前已是 helper 形态，本次无需改动。该文件全量 grep 无残留手写点。

## 验证

- 每处改动配一条注入 `generated_assets: "corrupt"` 的回归测试，共 5 条（`tests/test_status_calculator.py`、`tests/lib/test_status_calculator_reference.py`、`tests/server/agent_runtime/test_sdk_tools.py` ×2、`tests/server/test_project_cover.py`、`tests/test_jianying_draft_service.py`）。已验证：把 5 个生产文件回退到 main 版本后，这 5 条测试全部以 `AttributeError` 失败，非恒真断言
- `uv run python -m pytest`：6742 passed
- `uv run ruff check .` / `ruff format --check`：全绿
- `uv run basedpyright`：0 errors

Closes #1417


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 增强对生成资源数据异常（如 `generated_assets` 非字典）的容错：状态统计、旁白/分镜入队选择、草稿导出资源汇总与封面解析均可继续执行。
  * 统一通过新的资源读取方式判断各类资源是否已生成，异常或缺失将按“未生成”处理，并保证返回结果结构与流程稳定。
* **测试**
  * 新增多项覆盖用例，验证损坏生成数据下的统计容错、入队筛选、草稿导出与封面回退行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->