### PR TITLE
fix(assets): 资产卡片立绘上传补提交时刻占用复核

### DIFF
--- a/frontend/src/components/canvas/lorebook/CharacterCard.test.tsx
+++ b/frontend/src/components/canvas/lorebook/CharacterCard.test.tsx
@@ -1,11 +1,38 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CharacterCard } from "./CharacterCard";
+import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
+import { useTasksStore } from "@/stores/tasks-store";
+import type { TaskItem } from "@/types";
 
 vi.mock("@/components/canvas/timeline/VersionTimeMachine", () => ({
   VersionTimeMachine: () => <div data-testid="version-time-machine">versions</div>,
 }));
+
+function characterTask(status: TaskItem["status"]): TaskItem {
+  return {
+    task_id: "t1",
+    project_name: "demo",
+    task_type: "character",
+    media_type: "image",
+    resource_id: "Hero",
+    resource_type: null,
+    script_file: null,
+    payload: {},
+    status,
+    result: null,
+    error_message: null,
+    cancelled_by: null,
+    provider_id: null,
+    provider_job_id: null,
+    source: "webui",
+    queued_at: "2026-01-01T00:00:00Z",
+    started_at: null,
+    finished_at: null,
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
 
 describe("CharacterCard", () => {
   beforeEach(() => {
@@ -19,6 +46,10 @@ describe("CharacterCard", () => {
       writable: true,
       value: vi.fn(),
     });
+  });
+
+  afterEach(() => {
+    useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
   });
 
   it("renders existing saved reference image", () => {
@@ -88,6 +119,32 @@ describe("CharacterCard", () => {
     const addButton = screen.getByRole("button", { name: "加入资产库" });
     expect(addButton).toBeDisabled();
     expect(addButton).toHaveAttribute("title", "生成或编辑进行中，暂无法加入资产库");
+  });
+
+  it("rejects sheet upload submitted after the resource became busy post-open", async () => {
+    const uploadFile = vi.spyOn(API, "uploadFile").mockResolvedValue({ path: "x" } as never);
+    const pushToast = vi.spyOn(useAppStore.getState(), "pushToast");
+    render(
+      <CharacterCard
+        name="Hero"
+        character={{ description: "hero desc", voice_style: "warm" }}
+        projectName="demo"
+        onSave={vi.fn()}
+        onGenerate={vi.fn()}
+      />,
+    );
+
+    const sheetInput = screen.getByLabelText("上传设计图", { selector: "input" });
+    // 面板打开（点击上传按钮）之后、选完文件之前，该角色被别处入队占用。
+    useTasksStore.setState({ tasks: [characterTask("running")] });
+
+    const file = new File(["sheet"], "hero-sheet.png", { type: "image/png" });
+    fireEvent.change(sheetInput as HTMLInputElement, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(pushToast).toHaveBeenCalledWith("生成或编辑进行中，暂无法上传设计图", "info");
+    });
+    expect(uploadFile).not.toHaveBeenCalled();
   });
 
   it("auto-resizes the description textarea as content grows", async () => {

--- a/frontend/src/components/canvas/lorebook/CharacterCard.test.tsx
+++ b/frontend/src/components/canvas/lorebook/CharacterCard.test.tsx
@@ -4,40 +4,16 @@ import { CharacterCard } from "./CharacterCard";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
 import { useTasksStore } from "@/stores/tasks-store";
-import type { TaskItem } from "@/types";
+import { makeTask } from "@/test/factories";
 
 vi.mock("@/components/canvas/timeline/VersionTimeMachine", () => ({
   VersionTimeMachine: () => <div data-testid="version-time-machine">versions</div>,
 }));
 
-function characterTask(status: TaskItem["status"]): TaskItem {
-  return {
-    task_id: "t1",
-    project_name: "demo",
-    task_type: "character",
-    media_type: "image",
-    resource_id: "Hero",
-    resource_type: null,
-    script_file: null,
-    payload: {},
-    status,
-    result: null,
-    error_message: null,
-    cancelled_by: null,
-    provider_id: null,
-    provider_job_id: null,
-    source: "webui",
-    queued_at: "2026-01-01T00:00:00Z",
-    started_at: null,
-    finished_at: null,
-    updated_at: "2026-01-01T00:00:00Z",
-  };
-}
 
 describe("CharacterCard", () => {
   beforeEach(() => {
     useAppStore.setState(useAppStore.getInitialState(), true);
-    vi.restoreAllMocks();
     Object.defineProperty(globalThis.URL, "createObjectURL", {
       writable: true,
       value: vi.fn(() => "blob:character-ref"),
@@ -136,7 +112,17 @@ describe("CharacterCard", () => {
 
     const sheetInput = screen.getByLabelText("上传设计图", { selector: "input" });
     // 面板打开（点击上传按钮）之后、选完文件之前，该角色被别处入队占用。
-    useTasksStore.setState({ tasks: [characterTask("running")] });
+    useTasksStore.setState({
+      tasks: [
+        makeTask({
+          project_name: "demo",
+          task_type: "character",
+          media_type: "image",
+          resource_id: "Hero",
+          status: "running",
+        }),
+      ],
+    });
 
     const file = new File(["sheet"], "hero-sheet.png", { type: "image/png" });
     fireEvent.change(sheetInput as HTMLInputElement, { target: { files: [file] } });

--- a/frontend/src/components/canvas/lorebook/CharacterCard.tsx
+++ b/frontend/src/components/canvas/lorebook/CharacterCard.tsx
@@ -11,6 +11,7 @@ import { ImageFlipReveal } from "@/components/ui/ImageFlipReveal";
 import { PreviewableImageFrame } from "@/components/ui/PreviewableImageFrame";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
+import { selectActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
 import { errMsg } from "@/utils/async";
 import type { Character } from "@/types";
 
@@ -77,6 +78,12 @@ export function CharacterCard({
     const file = e.target.files?.[0];
     e.target.value = "";
     if (!file) return;
+    // 提交时刻复核最新占用态：弹窗打开到文件选完之间可能已被别处入队占用。
+    const { tasks, optimisticActive } = useTasksStore.getState();
+    if (selectActiveResourceIds(tasks, "character", projectName, optimisticActive).has(name)) {
+      useAppStore.getState().pushToast(t("assets:upload_sheet_busy_hint"), "info");
+      return;
+    }
     setUploadingSheet(true);
     try {
       await API.uploadFile(projectName, "character", file, name);

--- a/frontend/src/components/canvas/lorebook/CharacterCard.tsx
+++ b/frontend/src/components/canvas/lorebook/CharacterCard.tsx
@@ -11,8 +11,8 @@ import { ImageFlipReveal } from "@/components/ui/ImageFlipReveal";
 import { PreviewableImageFrame } from "@/components/ui/PreviewableImageFrame";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
-import { selectActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
 import { errMsg } from "@/utils/async";
+import { rejectIfAssetBusy } from "./assetBusyGuard";
 import type { Character } from "@/types";
 
 interface CharacterSavePayload {
@@ -78,12 +78,7 @@ export function CharacterCard({
     const file = e.target.files?.[0];
     e.target.value = "";
     if (!file) return;
-    // 提交时刻复核最新占用态：弹窗打开到文件选完之间可能已被别处入队占用。
-    const { tasks, optimisticActive } = useTasksStore.getState();
-    if (selectActiveResourceIds(tasks, "character", projectName, optimisticActive).has(name)) {
-      useAppStore.getState().pushToast(t("assets:upload_sheet_busy_hint"), "info");
-      return;
-    }
+    if (rejectIfAssetBusy("character", projectName, name, t)) return;
     setUploadingSheet(true);
     try {
       await API.uploadFile(projectName, "character", file, name);

--- a/frontend/src/components/canvas/lorebook/ProductCard.test.tsx
+++ b/frontend/src/components/canvas/lorebook/ProductCard.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProductCard } from "./ProductCard";
+import { API } from "@/api";
+import { useAppStore } from "@/stores/app-store";
+import { useTasksStore } from "@/stores/tasks-store";
+import type { TaskItem } from "@/types";
+
+vi.mock("@/components/canvas/timeline/VersionTimeMachine", () => ({
+  VersionTimeMachine: () => <div data-testid="version-time-machine">versions</div>,
+}));
+
+function productTask(status: TaskItem["status"]): TaskItem {
+  return {
+    task_id: "t1",
+    project_name: "demo",
+    task_type: "product",
+    media_type: "image",
+    resource_id: "A",
+    resource_type: null,
+    script_file: null,
+    payload: {},
+    status,
+    result: null,
+    error_message: null,
+    cancelled_by: null,
+    provider_id: null,
+    provider_job_id: null,
+    source: "webui",
+    queued_at: "2026-01-01T00:00:00Z",
+    started_at: null,
+    finished_at: null,
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("ProductCard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
+  });
+
+  const product = { description: "限量款背包" };
+
+  it("renders name and description", () => {
+    render(
+      <ProductCard
+        name="A"
+        product={product}
+        projectName="demo"
+        onUpdate={vi.fn()}
+        onGenerate={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("限量款背包")).toBeInTheDocument();
+  });
+
+  it("rejects sheet upload submitted after the resource became busy post-open", async () => {
+    const uploadFile = vi.spyOn(API, "uploadFile").mockResolvedValue({ path: "x" } as never);
+    const pushToast = vi.spyOn(useAppStore.getState(), "pushToast");
+    render(
+      <ProductCard
+        name="A"
+        product={product}
+        projectName="demo"
+        onUpdate={vi.fn()}
+        onGenerate={vi.fn()}
+      />,
+    );
+
+    const sheetInput = screen.getByLabelText("上传设计图", { selector: "input" });
+    // 面板打开（点击上传按钮）之后、选完文件之前，该商品被别处入队占用。
+    useTasksStore.setState({ tasks: [productTask("running")] });
+
+    const file = new File(["sheet"], "product-sheet.png", { type: "image/png" });
+    fireEvent.change(sheetInput as HTMLInputElement, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(pushToast).toHaveBeenCalledWith("生成或编辑进行中，暂无法上传设计图", "info");
+    });
+    expect(uploadFile).not.toHaveBeenCalled();
+  });
+
+  it("renders no write entries when read-only", () => {
+    render(
+      <ProductCard
+        name="A"
+        product={product}
+        projectName="demo"
+        onUpdate={vi.fn()}
+        onGenerate={vi.fn()}
+        readOnly
+      />,
+    );
+
+    expect(screen.getByDisplayValue("限量款背包")).toHaveAttribute("readonly");
+    expect(screen.queryByTestId("version-time-machine")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});

--- a/frontend/src/components/canvas/lorebook/ProductCard.test.tsx
+++ b/frontend/src/components/canvas/lorebook/ProductCard.test.tsx
@@ -4,39 +4,15 @@ import { ProductCard } from "./ProductCard";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
 import { useTasksStore } from "@/stores/tasks-store";
-import type { TaskItem } from "@/types";
+import { makeTask } from "@/test/factories";
 
 vi.mock("@/components/canvas/timeline/VersionTimeMachine", () => ({
   VersionTimeMachine: () => <div data-testid="version-time-machine">versions</div>,
 }));
 
-function productTask(status: TaskItem["status"]): TaskItem {
-  return {
-    task_id: "t1",
-    project_name: "demo",
-    task_type: "product",
-    media_type: "image",
-    resource_id: "A",
-    resource_type: null,
-    script_file: null,
-    payload: {},
-    status,
-    result: null,
-    error_message: null,
-    cancelled_by: null,
-    provider_id: null,
-    provider_job_id: null,
-    source: "webui",
-    queued_at: "2026-01-01T00:00:00Z",
-    started_at: null,
-    finished_at: null,
-    updated_at: "2026-01-01T00:00:00Z",
-  };
-}
 
 describe("ProductCard", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
     useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
   });
 
@@ -71,7 +47,17 @@ describe("ProductCard", () => {
 
     const sheetInput = screen.getByLabelText("上传设计图", { selector: "input" });
     // 面板打开（点击上传按钮）之后、选完文件之前，该商品被别处入队占用。
-    useTasksStore.setState({ tasks: [productTask("running")] });
+    useTasksStore.setState({
+      tasks: [
+        makeTask({
+          project_name: "demo",
+          task_type: "product",
+          media_type: "image",
+          resource_id: "A",
+          status: "running",
+        }),
+      ],
+    });
 
     const file = new File(["sheet"], "product-sheet.png", { type: "image/png" });
     fireEvent.change(sheetInput as HTMLInputElement, { target: { files: [file] } });

--- a/frontend/src/components/canvas/lorebook/ProductCard.tsx
+++ b/frontend/src/components/canvas/lorebook/ProductCard.tsx
@@ -9,6 +9,7 @@ import { GenerateButton } from "@/components/ui/GenerateButton";
 import { PreviewableImageFrame } from "@/components/ui/PreviewableImageFrame";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
+import { selectActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
 import { errMsg } from "@/utils/async";
 import type { Product } from "@/types";
 
@@ -74,6 +75,12 @@ export function ProductCard({
     const file = e.target.files?.[0];
     e.target.value = "";
     if (!file) return;
+    // 提交时刻复核最新占用态：弹窗打开到文件选完之间可能已被别处入队占用。
+    const { tasks, optimisticActive } = useTasksStore.getState();
+    if (selectActiveResourceIds(tasks, "product", projectName, optimisticActive).has(name)) {
+      useAppStore.getState().pushToast(t("assets:upload_sheet_busy_hint"), "info");
+      return;
+    }
     setUploadingSheet(true);
     try {
       await API.uploadFile(projectName, "product", file, name);

--- a/frontend/src/components/canvas/lorebook/ProductCard.tsx
+++ b/frontend/src/components/canvas/lorebook/ProductCard.tsx
@@ -9,8 +9,8 @@ import { GenerateButton } from "@/components/ui/GenerateButton";
 import { PreviewableImageFrame } from "@/components/ui/PreviewableImageFrame";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
-import { selectActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
 import { errMsg } from "@/utils/async";
+import { rejectIfAssetBusy } from "./assetBusyGuard";
 import type { Product } from "@/types";
 
 // ---------------------------------------------------------------------------
@@ -75,12 +75,7 @@ export function ProductCard({
     const file = e.target.files?.[0];
     e.target.value = "";
     if (!file) return;
-    // 提交时刻复核最新占用态：弹窗打开到文件选完之间可能已被别处入队占用。
-    const { tasks, optimisticActive } = useTasksStore.getState();
-    if (selectActiveResourceIds(tasks, "product", projectName, optimisticActive).has(name)) {
-      useAppStore.getState().pushToast(t("assets:upload_sheet_busy_hint"), "info");
-      return;
-    }
+    if (rejectIfAssetBusy("product", projectName, name, t)) return;
     setUploadingSheet(true);
     try {
       await API.uploadFile(projectName, "product", file, name);

--- a/frontend/src/components/canvas/lorebook/PropCard.test.tsx
+++ b/frontend/src/components/canvas/lorebook/PropCard.test.tsx
@@ -4,39 +4,15 @@ import { PropCard } from "./PropCard";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
 import { useTasksStore } from "@/stores/tasks-store";
-import type { TaskItem } from "@/types";
+import { makeTask } from "@/test/factories";
 
 vi.mock("@/components/canvas/timeline/VersionTimeMachine", () => ({
   VersionTimeMachine: () => <div data-testid="version-time-machine">versions</div>,
 }));
 
-function propTask(status: TaskItem["status"]): TaskItem {
-  return {
-    task_id: "t1",
-    project_name: "demo",
-    task_type: "prop",
-    media_type: "image",
-    resource_id: "A",
-    resource_type: null,
-    script_file: null,
-    payload: {},
-    status,
-    result: null,
-    error_message: null,
-    cancelled_by: null,
-    provider_id: null,
-    provider_job_id: null,
-    source: "webui",
-    queued_at: "2026-01-01T00:00:00Z",
-    started_at: null,
-    finished_at: null,
-    updated_at: "2026-01-01T00:00:00Z",
-  };
-}
 
 describe("PropCard", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
     useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
   });
 
@@ -121,7 +97,17 @@ describe("PropCard", () => {
 
     const sheetInput = screen.getByLabelText("上传设计图", { selector: "input" });
     // 面板打开（点击上传按钮）之后、选完文件之前，该道具被别处入队占用。
-    useTasksStore.setState({ tasks: [propTask("running")] });
+    useTasksStore.setState({
+      tasks: [
+        makeTask({
+          project_name: "demo",
+          task_type: "prop",
+          media_type: "image",
+          resource_id: "A",
+          status: "running",
+        }),
+      ],
+    });
 
     const file = new File(["sheet"], "prop-sheet.png", { type: "image/png" });
     fireEvent.change(sheetInput as HTMLInputElement, { target: { files: [file] } });

--- a/frontend/src/components/canvas/lorebook/PropCard.test.tsx
+++ b/frontend/src/components/canvas/lorebook/PropCard.test.tsx
@@ -1,12 +1,45 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { PropCard } from "./PropCard";
+import { API } from "@/api";
+import { useAppStore } from "@/stores/app-store";
+import { useTasksStore } from "@/stores/tasks-store";
+import type { TaskItem } from "@/types";
 
 vi.mock("@/components/canvas/timeline/VersionTimeMachine", () => ({
   VersionTimeMachine: () => <div data-testid="version-time-machine">versions</div>,
 }));
 
+function propTask(status: TaskItem["status"]): TaskItem {
+  return {
+    task_id: "t1",
+    project_name: "demo",
+    task_type: "prop",
+    media_type: "image",
+    resource_id: "A",
+    resource_type: null,
+    script_file: null,
+    payload: {},
+    status,
+    result: null,
+    error_message: null,
+    cancelled_by: null,
+    provider_id: null,
+    provider_job_id: null,
+    source: "webui",
+    queued_at: "2026-01-01T00:00:00Z",
+    started_at: null,
+    finished_at: null,
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
 describe("PropCard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
+  });
+
   const prop = { description: "古铜色钥匙" };
 
   it("renders name and description", () => {
@@ -71,6 +104,32 @@ describe("PropCard", () => {
     fireEvent.change(textarea, { target: { value: "新描述" } });
     fireEvent.click(screen.getByRole("button", { name: /保存/ }));
     expect(onUpdate).toHaveBeenCalledWith("A", { description: "新描述" });
+  });
+
+  it("rejects sheet upload submitted after the resource became busy post-open", async () => {
+    const uploadFile = vi.spyOn(API, "uploadFile").mockResolvedValue({ path: "x" } as never);
+    const pushToast = vi.spyOn(useAppStore.getState(), "pushToast");
+    render(
+      <PropCard
+        name="A"
+        prop={prop}
+        projectName="demo"
+        onUpdate={vi.fn()}
+        onGenerate={vi.fn()}
+      />,
+    );
+
+    const sheetInput = screen.getByLabelText("上传设计图", { selector: "input" });
+    // 面板打开（点击上传按钮）之后、选完文件之前，该道具被别处入队占用。
+    useTasksStore.setState({ tasks: [propTask("running")] });
+
+    const file = new File(["sheet"], "prop-sheet.png", { type: "image/png" });
+    fireEvent.change(sheetInput as HTMLInputElement, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(pushToast).toHaveBeenCalledWith("生成或编辑进行中，暂无法上传设计图", "info");
+    });
+    expect(uploadFile).not.toHaveBeenCalled();
   });
 
   it("renders VersionTimeMachine", () => {

--- a/frontend/src/components/canvas/lorebook/PropCard.tsx
+++ b/frontend/src/components/canvas/lorebook/PropCard.tsx
@@ -10,6 +10,7 @@ import { GenerateButton } from "@/components/ui/GenerateButton";
 import { PreviewableImageFrame } from "@/components/ui/PreviewableImageFrame";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
+import { selectActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
 import { errMsg } from "@/utils/async";
 import type { Prop } from "@/types";
 
@@ -67,6 +68,12 @@ export function PropCard({
     const file = e.target.files?.[0];
     e.target.value = "";
     if (!file) return;
+    // 提交时刻复核最新占用态：弹窗打开到文件选完之间可能已被别处入队占用。
+    const { tasks, optimisticActive } = useTasksStore.getState();
+    if (selectActiveResourceIds(tasks, "prop", projectName, optimisticActive).has(name)) {
+      useAppStore.getState().pushToast(t("assets:upload_sheet_busy_hint"), "info");
+      return;
+    }
     setUploadingSheet(true);
     try {
       await API.uploadFile(projectName, "prop", file, name);

--- a/frontend/src/components/canvas/lorebook/PropCard.tsx
+++ b/frontend/src/components/canvas/lorebook/PropCard.tsx
@@ -10,8 +10,8 @@ import { GenerateButton } from "@/components/ui/GenerateButton";
 import { PreviewableImageFrame } from "@/components/ui/PreviewableImageFrame";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
-import { selectActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
 import { errMsg } from "@/utils/async";
+import { rejectIfAssetBusy } from "./assetBusyGuard";
 import type { Prop } from "@/types";
 
 // ---------------------------------------------------------------------------
@@ -68,12 +68,7 @@ export function PropCard({
     const file = e.target.files?.[0];
     e.target.value = "";
     if (!file) return;
-    // 提交时刻复核最新占用态：弹窗打开到文件选完之间可能已被别处入队占用。
-    const { tasks, optimisticActive } = useTasksStore.getState();
-    if (selectActiveResourceIds(tasks, "prop", projectName, optimisticActive).has(name)) {
-      useAppStore.getState().pushToast(t("assets:upload_sheet_busy_hint"), "info");
-      return;
-    }
+    if (rejectIfAssetBusy("prop", projectName, name, t)) return;
     setUploadingSheet(true);
     try {
       await API.uploadFile(projectName, "prop", file, name);

--- a/frontend/src/components/canvas/lorebook/SceneCard.test.tsx
+++ b/frontend/src/components/canvas/lorebook/SceneCard.test.tsx
@@ -4,39 +4,15 @@ import { SceneCard } from "./SceneCard";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
 import { useTasksStore } from "@/stores/tasks-store";
-import type { TaskItem } from "@/types";
+import { makeTask } from "@/test/factories";
 
 vi.mock("@/components/canvas/timeline/VersionTimeMachine", () => ({
   VersionTimeMachine: () => <div data-testid="version-time-machine">versions</div>,
 }));
 
-function sceneTask(status: TaskItem["status"]): TaskItem {
-  return {
-    task_id: "t1",
-    project_name: "demo",
-    task_type: "scene",
-    media_type: "image",
-    resource_id: "A",
-    resource_type: null,
-    script_file: null,
-    payload: {},
-    status,
-    result: null,
-    error_message: null,
-    cancelled_by: null,
-    provider_id: null,
-    provider_job_id: null,
-    source: "webui",
-    queued_at: "2026-01-01T00:00:00Z",
-    started_at: null,
-    finished_at: null,
-    updated_at: "2026-01-01T00:00:00Z",
-  };
-}
 
 describe("SceneCard", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
     useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
   });
 
@@ -121,7 +97,17 @@ describe("SceneCard", () => {
 
     const sheetInput = screen.getByLabelText("上传设计图", { selector: "input" });
     // 面板打开（点击上传按钮）之后、选完文件之前，该场景被别处入队占用。
-    useTasksStore.setState({ tasks: [sceneTask("running")] });
+    useTasksStore.setState({
+      tasks: [
+        makeTask({
+          project_name: "demo",
+          task_type: "scene",
+          media_type: "image",
+          resource_id: "A",
+          status: "running",
+        }),
+      ],
+    });
 
     const file = new File(["sheet"], "scene-sheet.png", { type: "image/png" });
     fireEvent.change(sheetInput as HTMLInputElement, { target: { files: [file] } });

--- a/frontend/src/components/canvas/lorebook/SceneCard.test.tsx
+++ b/frontend/src/components/canvas/lorebook/SceneCard.test.tsx
@@ -1,12 +1,45 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { SceneCard } from "./SceneCard";
+import { API } from "@/api";
+import { useAppStore } from "@/stores/app-store";
+import { useTasksStore } from "@/stores/tasks-store";
+import type { TaskItem } from "@/types";
 
 vi.mock("@/components/canvas/timeline/VersionTimeMachine", () => ({
   VersionTimeMachine: () => <div data-testid="version-time-machine">versions</div>,
 }));
 
+function sceneTask(status: TaskItem["status"]): TaskItem {
+  return {
+    task_id: "t1",
+    project_name: "demo",
+    task_type: "scene",
+    media_type: "image",
+    resource_id: "A",
+    resource_type: null,
+    script_file: null,
+    payload: {},
+    status,
+    result: null,
+    error_message: null,
+    cancelled_by: null,
+    provider_id: null,
+    provider_job_id: null,
+    source: "webui",
+    queued_at: "2026-01-01T00:00:00Z",
+    started_at: null,
+    finished_at: null,
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
 describe("SceneCard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
+  });
+
   const scene = { description: "阴森古朴" };
 
   it("renders name and description", () => {
@@ -71,6 +104,32 @@ describe("SceneCard", () => {
     fireEvent.change(textarea, { target: { value: "新描述" } });
     fireEvent.click(screen.getByRole("button", { name: /保存/ }));
     expect(onUpdate).toHaveBeenCalledWith("A", { description: "新描述" });
+  });
+
+  it("rejects sheet upload submitted after the resource became busy post-open", async () => {
+    const uploadFile = vi.spyOn(API, "uploadFile").mockResolvedValue({ path: "x" } as never);
+    const pushToast = vi.spyOn(useAppStore.getState(), "pushToast");
+    render(
+      <SceneCard
+        name="A"
+        scene={scene}
+        projectName="demo"
+        onUpdate={vi.fn()}
+        onGenerate={vi.fn()}
+      />,
+    );
+
+    const sheetInput = screen.getByLabelText("上传设计图", { selector: "input" });
+    // 面板打开（点击上传按钮）之后、选完文件之前，该场景被别处入队占用。
+    useTasksStore.setState({ tasks: [sceneTask("running")] });
+
+    const file = new File(["sheet"], "scene-sheet.png", { type: "image/png" });
+    fireEvent.change(sheetInput as HTMLInputElement, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(pushToast).toHaveBeenCalledWith("生成或编辑进行中，暂无法上传设计图", "info");
+    });
+    expect(uploadFile).not.toHaveBeenCalled();
   });
 
   it("renders VersionTimeMachine", () => {

--- a/frontend/src/components/canvas/lorebook/SceneCard.tsx
+++ b/frontend/src/components/canvas/lorebook/SceneCard.tsx
@@ -10,8 +10,8 @@ import { GenerateButton } from "@/components/ui/GenerateButton";
 import { PreviewableImageFrame } from "@/components/ui/PreviewableImageFrame";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
-import { selectActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
 import { errMsg } from "@/utils/async";
+import { rejectIfAssetBusy } from "./assetBusyGuard";
 import type { Scene } from "@/types";
 
 // ---------------------------------------------------------------------------
@@ -68,12 +68,7 @@ export function SceneCard({
     const file = e.target.files?.[0];
     e.target.value = "";
     if (!file) return;
-    // 提交时刻复核最新占用态：弹窗打开到文件选完之间可能已被别处入队占用。
-    const { tasks, optimisticActive } = useTasksStore.getState();
-    if (selectActiveResourceIds(tasks, "scene", projectName, optimisticActive).has(name)) {
-      useAppStore.getState().pushToast(t("assets:upload_sheet_busy_hint"), "info");
-      return;
-    }
+    if (rejectIfAssetBusy("scene", projectName, name, t)) return;
     setUploadingSheet(true);
     try {
       await API.uploadFile(projectName, "scene", file, name);

--- a/frontend/src/components/canvas/lorebook/SceneCard.tsx
+++ b/frontend/src/components/canvas/lorebook/SceneCard.tsx
@@ -10,6 +10,7 @@ import { GenerateButton } from "@/components/ui/GenerateButton";
 import { PreviewableImageFrame } from "@/components/ui/PreviewableImageFrame";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
+import { selectActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
 import { errMsg } from "@/utils/async";
 import type { Scene } from "@/types";
 
@@ -67,6 +68,12 @@ export function SceneCard({
     const file = e.target.files?.[0];
     e.target.value = "";
     if (!file) return;
+    // 提交时刻复核最新占用态：弹窗打开到文件选完之间可能已被别处入队占用。
+    const { tasks, optimisticActive } = useTasksStore.getState();
+    if (selectActiveResourceIds(tasks, "scene", projectName, optimisticActive).has(name)) {
+      useAppStore.getState().pushToast(t("assets:upload_sheet_busy_hint"), "info");
+      return;
+    }
     setUploadingSheet(true);
     try {
       await API.uploadFile(projectName, "scene", file, name);

--- a/frontend/src/components/canvas/lorebook/assetBusyGuard.ts
+++ b/frontend/src/components/canvas/lorebook/assetBusyGuard.ts
@@ -1,0 +1,22 @@
+import type { TFunction } from "i18next";
+import { useAppStore } from "@/stores/app-store";
+import { selectActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
+
+/**
+ * 立绘上传的提交时刻复核：从点击上传按钮到文件选完之间，该资源可能已被别处（另一标签页、
+ * Agent、image_edit）入队占用，只查渲染时刻会留一个竞态窗口。命中则拒绝并给出可见反馈。
+ *
+ * `kind` 取 `selectActiveResourceIds` 的资源种类口径，与 `StudioCanvasRouter` 算各卡片
+ * `generating` 的口径同源，不另立判据。
+ */
+export function rejectIfAssetBusy(
+  kind: string,
+  projectName: string,
+  name: string,
+  t: TFunction,
+): boolean {
+  const { tasks, optimisticActive } = useTasksStore.getState();
+  if (!selectActiveResourceIds(tasks, kind, projectName, optimisticActive).has(name)) return false;
+  useAppStore.getState().pushToast(t("assets:upload_sheet_busy_hint"), "info");
+  return true;
+}

--- a/frontend/src/i18n/en/assets.ts
+++ b/frontend/src/i18n/en/assets.ts
@@ -46,6 +46,7 @@ export default {
   "add_to_library_short": "Library",
   "add_to_library_success": "\"{{name}}\" added to library",
   "add_to_library_busy_hint": "Generation or editing in progress — cannot add to library",
+  "upload_sheet_busy_hint": "Generation or editing in progress — cannot upload a design sheet",
   "upload_sheet_short": "Upload",
   "edit": "Edit",
   "delete": "Delete",

--- a/frontend/src/i18n/vi/assets.ts
+++ b/frontend/src/i18n/vi/assets.ts
@@ -48,6 +48,7 @@ export default {
   "add_to_library_short": "Thư viện",
   "add_to_library_success": "Đã thêm \"{{name}}\" vào thư viện",
   "add_to_library_busy_hint": "Đang tạo hoặc chỉnh sửa, chưa thể thêm vào thư viện",
+  "upload_sheet_busy_hint": "Đang tạo hoặc chỉnh sửa, chưa thể tải lên bảng thiết kế",
   "upload_sheet_short": "Tải lên",
   "edit": "Chỉnh sửa",
   "delete": "Xóa",

--- a/frontend/src/i18n/zh/assets.ts
+++ b/frontend/src/i18n/zh/assets.ts
@@ -48,6 +48,7 @@ export default {
   "add_to_library_short": "入库",
   "add_to_library_success": "「{{name}}」已加入资产库",
   "add_to_library_busy_hint": "生成或编辑进行中，暂无法加入资产库",
+  "upload_sheet_busy_hint": "生成或编辑进行中，暂无法上传设计图",
   "upload_sheet_short": "上传",
   "edit": "编辑",
   "delete": "删除",


### PR DESCRIPTION
Closes #1418

## 改动

`CharacterCard` / `SceneCard` / `PropCard` / `ProductCard` 的立绘上传此前只靠渲染时刻的 `generating` prop 与本地 `uploadingSheet` 标志门控：文件对话框打开到用户选完文件之间，该资源可能已被别处（另一标签页、Agent、`image_edit`）入队占用，此时提交会覆盖正在生成的结果。

- 四张卡片的 `handleSheetUpload` 入口补提交时刻占用复核，命中则 toast 提示并中止，不再往下调 `API.uploadFile`。判据取 `selectActiveResourceIds(tasks, <kind>, projectName, optimisticActive)`，与 `StudioCanvasRouter` 计算各卡片 `generating` 的口径同源，未新造判定维度；形状对齐既有先例 `EndFrameRow.rejectIfDisabled`
- 复核逻辑收敛到 `lorebook/assetBusyGuard.ts` 的 `rejectIfAssetBusy`，避免同一块判据在四张卡片里逐字重复、后续调整需散改四处
- 新增 i18n key `assets:upload_sheet_busy_hint`，措辞对齐同文件既有的 `add_to_library_busy_hint`，zh/en/vi 三语齐备

同卡片上随占用态禁用的兄弟控件（`ImageEditButton` / `AddToLibraryButton` / `VersionTimeMachine`）本就统一读 `generating || uploadingSheet`，渲染时刻的接线无需改动。

issue 中「`tasks-store` 失真的空窗注释」一项已由先前合并的 #1410 完成——当前 `tasks-store.ts` 中已无 `~3s` 表述，`selectActiveResourceIds` 的注释与 `selectNeedsFastPolling` 的实际档位切换一致，本 PR 未再改动。

## 验证

- 四张卡片各补一条回归用例：渲染后经 `useTasksStore.setState` 注入占用任务，再触发文件选择，断言 toast 被推送且 `API.uploadFile` 未被调用。变异验证：临时让守卫恒返回 `false` 后四条用例全部转红，非恒真断言
- `pnpm lint`、`pnpm check` 全绿（129 files / 1387 tests），已 rebase 到最新 main 后复跑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 当角色、产品、道具或场景资源正在生成或编辑时，上传设计图会被阻止。
  * 系统将显示提示信息，避免重复上传或覆盖处理中资源。
  * 支持中文、英文和越南语提示。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->