### PR TITLE
test(episode-planner): 补分集规划并发冲突分支的专属测试

### DIFF
--- a/tests/test_episode_planner.py
+++ b/tests/test_episode_planner.py
@@ -591,9 +591,11 @@ class TestPlan:
         assert (project_dir / "project.json").read_text(encoding="utf-8") == before
         assert not list((project_dir / "source").glob("episode_*.txt"))
 
+    @pytest.mark.integration
     async def test_plan_raises_planning_conflict_when_ledger_advances_during_call(self, tmp_path: Path):
         """请求在途时账本被另一次调用抢先提交、有效起点前移：锁内复核发现不一致，整批作废，账本与磁盘均无写入。"""
         project_dir = _write_project(tmp_path)
+        after_concurrent_commit: list[str] = []
 
         class _ConcurrentCommitGenerator(_FakeTextGenerator):
             async def generate(self, request, project_name=None):
@@ -602,6 +604,7 @@ class TestPlan:
                 project["episodes"] = [_entry(1, 0, _end_of(ANCHOR_EP1))]
                 project["planning_cursor"] = {"source_file": "source/novel.txt", "offset": _end_of(ANCHOR_EP1)}
                 (project_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
+                after_concurrent_commit.append((project_dir / "project.json").read_text(encoding="utf-8"))
                 return await super().generate(request, project_name)
 
         fake = _ConcurrentCommitGenerator(
@@ -611,11 +614,9 @@ class TestPlan:
         with pytest.raises(PlanningConflictError, match="并发"):
             await EpisodePlanner(project_dir, generator=fake).plan()
 
-        project = _load_project(project_dir)
-        assert [e["episode"] for e in project["episodes"]] == [1]
-        assert project["episodes"][0]["title"] == "第1集"  # 并发提交的版本保留，本次调用的结果未覆盖
-        assert project["planning_cursor"] == {"source_file": "source/novel.txt", "offset": _end_of(ANCHOR_EP1)}
-        assert not (project_dir / "source" / "episode_1.txt").exists()  # 本次调用未走到派生文件写入
+        # 账本逐字停留在并发提交后的状态：本次调用的集条目、游标与源文指纹一个字节都没落盘
+        assert (project_dir / "project.json").read_text(encoding="utf-8") == after_concurrent_commit[0]
+        assert not list((project_dir / "source").glob("episode_*.txt"))
 
     async def test_plan_truncation_short_circuits_retry_and_hints_leverage(self, tmp_path: Path):
         """结构化输出被截断时不重试，直接冒泡 EpisodePlanningError 并附带调小窗口/集数的提示（见 docs/adr/0044）。"""

--- a/tests/test_episode_planner.py
+++ b/tests/test_episode_planner.py
@@ -18,6 +18,7 @@ from lib.episode_ledger import discover_sources as _real_discover_sources
 from lib.episode_planner import (
     EpisodePlanner,
     EpisodePlanningError,
+    PlanningConflictError,
     _find_all_overlapping,
 )
 from lib.episode_reset import EpisodeResetResult, reset_episode_planning
@@ -589,6 +590,32 @@ class TestPlan:
 
         assert (project_dir / "project.json").read_text(encoding="utf-8") == before
         assert not list((project_dir / "source").glob("episode_*.txt"))
+
+    async def test_plan_raises_planning_conflict_when_ledger_advances_during_call(self, tmp_path: Path):
+        """请求在途时账本被另一次调用抢先提交、有效起点前移：锁内复核发现不一致，整批作废，账本与磁盘均无写入。"""
+        project_dir = _write_project(tmp_path)
+
+        class _ConcurrentCommitGenerator(_FakeTextGenerator):
+            async def generate(self, request, project_name=None):
+                # 模拟另一次 plan() 调用在本次锁外快照之后、锁内复核之前抢先提交了第 1 集
+                project = _load_project(project_dir)
+                project["episodes"] = [_entry(1, 0, _end_of(ANCHOR_EP1))]
+                project["planning_cursor"] = {"source_file": "source/novel.txt", "offset": _end_of(ANCHOR_EP1)}
+                (project_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
+                return await super().generate(request, project_name)
+
+        fake = _ConcurrentCommitGenerator(
+            [_plan_response([{"title": "古玉藏诀", "hook": "玉中剑诀来历成谜", "end_anchor": ANCHOR_EP1}])]
+        )
+
+        with pytest.raises(PlanningConflictError, match="并发"):
+            await EpisodePlanner(project_dir, generator=fake).plan()
+
+        project = _load_project(project_dir)
+        assert [e["episode"] for e in project["episodes"]] == [1]
+        assert project["episodes"][0]["title"] == "第1集"  # 并发提交的版本保留，本次调用的结果未覆盖
+        assert project["planning_cursor"] == {"source_file": "source/novel.txt", "offset": _end_of(ANCHOR_EP1)}
+        assert not (project_dir / "source" / "episode_1.txt").exists()  # 本次调用未走到派生文件写入
 
     async def test_plan_truncation_short_circuits_retry_and_hints_leverage(self, tmp_path: Path):
         """结构化输出被截断时不重试，直接冒泡 EpisodePlanningError 并附带调小窗口/集数的提示（见 docs/adr/0044）。"""


### PR DESCRIPTION
Closes #1423

## 背景

`#1416` 删除 `TestReplan` 后，`EpisodePlanner.plan()` 提交阶段锁内复核抛 `PlanningConflictError` 的分支失去了唯一的间接覆盖，plan() 自身此前从未有过专属用例。本 PR 只补测试，不改生产代码。

## 改动

新增 `TestPlan::test_plan_raises_planning_conflict_when_ledger_advances_during_call`：用 `_FakeTextGenerator` 子类在 `generate()` 内写盘，模拟另一次 `plan()` 调用在本次锁外快照之后、锁内复核之前抢先提交第 1 集，使有效起点前移，触发锁内复核不一致。

## 验证

- **分支归属**：临时把 `lib/episode_planner.py` 的 `if self._effective_start(p) != start_ref:` 改成 `if False:`，用例转红（DID NOT RAISE），还原后转绿；覆盖率 term-missing 显示中止于该行、其后的指纹复核与提交逻辑均未执行，确认不是被更早的分支（孤儿登记 / source_ranges / 指纹）拦下。
- **「账本与磁盘均无写入」断言强度**：同样在禁用该分支的前提下去掉 `pytest.raises` 包裹，`project.json` 逐字比对断言转红，确认它真能拦住误提交（而非恒真）。
- **门禁**：`ruff check` + `ruff format --check` 通过；`basedpyright` 0 errors；`pytest -m "not e2e"` 6710 passed。

## 备注

用例按 CONTRIBUTING「Pytest markers 纪律」标 `@pytest.mark.integration`（走 tmp 真实文件系统 + 真实 `plan()` 全链路，只替换文本后端依赖，未 mock 被测入口）。所在的 `TestPlan` 类属存量未打标测试，按「现存测试不强制回溯打标」未一并回溯。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **错误修复**
  - 改进了剧集规划过程中的并发冲突处理。
  - 当检测到其他提交在规划期间更新账本时，系统会安全终止本次规划并提示并发冲突。
  - 冲突发生后不会产生部分写入，项目数据及派生文件均保持一致，避免出现不完整结果。

- **测试**
  - 新增并发提交场景的集成测试，验证冲突检测与数据完整性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->