### PR TITLE
fix(cost): AI Studio 视频费用预估按含音价计算，不采信 audio-off 开关

### DIFF
--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -71,6 +71,12 @@ class CostEstimationService:
                 generate_audio = await r.video_generate_audio(project_name)
             except Exception:
                 generate_audio = False
+            # AI Studio 的 Veo 请求不下发 generate_audio 参数（该开关仅存在于 Vertex 定价页，
+            # AI Studio 定价页无 audio-off 档），供应商恒按含音价出账；真实生成时
+            # GeminiVideoBackend 已按此结算实际用量（backend_type != "vertex" 强制 True，见
+            # lib/video_backends/gemini.py），此处对齐纯预估路径，避免二者口径分叉。
+            if video_provider == "gemini-aistudio":
+                generate_audio = True
 
             # 旁白配音（TTS）模型：project 覆盖 > 全局默认 > auto-resolve；
             # 未配置任何 audio 供应商时回落 unknown，该维度预估为空

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -576,11 +576,12 @@ class TestCostEstimationService:
         # compute() 不因 resolve_resolution 异常而中断，其余字段照常返回
         assert result["models"]["video"]["provider"] == "unknown"
 
+    @pytest.mark.integration
     @pytest.mark.parametrize(
         ("video_backend", "configured_generate_audio", "expected_usd"),
         [
             # AI Studio 无 audio-off 档，供应商恒按含音价出账：无论开关状态，预估都须落在
-            # veo-3.1-lite-generate-preview 1080p 的含音价 0.08 USD/s（issue #1426 的核心场景）。
+            # veo-3.1-lite-generate-preview 1080p 的含音价 0.08 USD/s。
             ("gemini-aistudio", True, 0.08),
             ("gemini-aistudio", False, 0.08),
             # Vertex 有独立的 audio-off 档，不受 AI Studio 修正影响，预估随开关走

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -576,6 +576,49 @@ class TestCostEstimationService:
         # compute() 不因 resolve_resolution 异常而中断，其余字段照常返回
         assert result["models"]["video"]["provider"] == "unknown"
 
+    @pytest.mark.parametrize(
+        ("video_backend", "configured_generate_audio", "expected_usd"),
+        [
+            # AI Studio 无 audio-off 档，供应商恒按含音价出账：无论开关状态，预估都须落在
+            # veo-3.1-lite-generate-preview 1080p 的含音价 0.08 USD/s（issue #1426 的核心场景）。
+            ("gemini-aistudio", True, 0.08),
+            ("gemini-aistudio", False, 0.08),
+            # Vertex 有独立的 audio-off 档，不受 AI Studio 修正影响，预估随开关走
+            # （veo-3.1-fast-generate-001 1080p：含音 0.12 / 无音 0.10 USD/s）。
+            ("gemini-vertex", True, 0.12),
+            ("gemini-vertex", False, 0.10),
+        ],
+    )
+    async def test_video_estimate_generate_audio_by_provider(
+        self, db_factory, monkeypatch, video_backend, configured_generate_audio, expected_usd
+    ):
+        """费用预估在所有 (provider, audio 开关) 组合下与供应商实际出账口径一致。
+
+        经 ``ConfigResolver.video_generate_audio`` 直接 monkeypatch 配置开关的解析结果，
+        绕开该方法内部对项目文件是否存在于磁盘的依赖（预估路径本不该受此约束）。
+        """
+
+        async def _fake_video_generate_audio(self, project_name=None):
+            return configured_generate_audio
+
+        monkeypatch.setattr(ConfigResolver, "video_generate_audio", _fake_video_generate_audio)
+
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "video_backend": video_backend,
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_script(1, ["E1S001"], [1])}
+
+        result = await service.compute(project_data, scripts, project_name="test")
+
+        seg = result["episodes"][0]["segments"][0]
+        assert seg["estimate"]["video"]["USD"] == pytest.approx(expected_usd)
+
     async def test_custom_provider_estimates_use_db_prices(self, db_factory):
         """自定义供应商预估：image/video/audio 单价来自 DB（与实际记账同源），估值按配置价格非零。"""
         from lib.db.repositories.custom_provider_repo import CustomProviderRepository


### PR DESCRIPTION
Closes #1426

## 实现形态与论证

计价侧按 provider 分支判断，而非给 AI Studio 型号单列 with-audio-only 费率表。

- **只改预估侧**：实际记账侧已由既有逻辑覆盖 —— `GeminiVideoBackend._poll_until_done` 在 `backend_type != "vertex"` 时把结果对象的 `generate_audio` 恒置为 `True`（`lib/video_backends/gemini.py:324`），`lib/ledger.py::_settlement_from_result` 消费的正是该结果对象，`usage_repo` 结算时以它覆盖请求时写入的行值。`generate` 与 `resume_video` 收敛到同一 `_poll_until_done`，resume 补账路径同样受覆盖。
- **不单列 with-audio-only 费率表**：`_per_second_matrix` 未命中 `(resolution, False)` 时会回落到固定 1080p 档，单列会掩盖分辨率差异。
- **不动 `lib/pricing/strategies.py`**：其 docstring 明确策略层「不含 provider 分支」。

## 费率核对

未改动任何费率数字。测试期望值对照官方定价页复核：

- AI Studio（<https://ai.google.dev/gemini-api/docs/pricing>）：Veo 3.1 Lite 1080p $0.08/s、Veo 3.1 Fast 1080p $0.12/s，页面标注为 "with audio price (default)"，**不存在独立的无音频档**，与 issue 前提一致。
- Vertex 侧 audio-off 档（Fast 1080p $0.10/s）为既有表值，本 PR 未改动；Google Cloud 定价页当前版本未在线列出 Veo 段落，故仅确认与仓库既有表一致，未做在线复核。

## 验证

- 新增参数化测试覆盖 (provider × audio 开关) 四组合：AI Studio 开/关均为含音价 $0.08，Vertex 随开关走 $0.12 / $0.10。
- 全量后端测试 6713 passed；`ruff check` / `ruff format --check` 干净；`basedpyright` 0 errors。
- 独立核验验收标准第 3 条：仅 Gemini Veo（`dimensions="resolution_audio"`）与 Ark（`PerTokenVideo` 按 `(service_tier, generate_audio)`）的费率吃 audio 维度。Ark backend 把请求值原样回报到结果对象（`lib/video_backends/ark.py:321`），记账与预估同源；其余供应商定价不吃该维度。预估与记账口径在所有 (provider, audio 开关) 组合下一致。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化 Gemini AI Studio 视频费用预估逻辑：当供应商为 Gemini AI Studio 时，按“包含音频”的计费口径计算，避免与实际结算因音频开关出现偏差。
- **测试**
  - 新增参数化集成用例，覆盖不同视频后端（Gemini AI Studio、Gemini Vertex）及音频配置组合，校验段级视频费用预估金额与预期一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->