### PR TITLE
feat(script): 剧本生成与逐镜头时长按当前分辨率、参考图模式过滤可选秒数

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -137,7 +137,7 @@ _Avoid_: 把 size 当比例或清晰度的同义词——它是二者派生的�
 _Avoid_: `VALID_DURATIONS` / 全局时长白名单（已删除的硬编码 `[4,6,8]`，与 per-model 概念相反）；把它当各家「官方时长能力表」（自定义供应商侧只是启发式预填、需用户 review）。
 
 **时长联动约束（duration_resolution_constraints / reference_image_durations）**：
-在 `supported_durations` 全集之上按上下文收窄的两个 per-model 声明：前者是 `{分辨率: 允许时长}`（如 Veo `{"1080p": [8], "4k": [8]}`），后者是走参考图路径时的允许时长（如 Veo `[8]`）。两条各自独立触发、可同时生效、取交集；与 `supported_durations` 同为 registry 单一真相源。后端唯一收窄入口是 `lib/config/resolver.constrain_durations`：剧本生成的 prompt 与动态 schema、SDK MCP 工具交给 LLM 的候选、执行期未显式指定时长时的取值，都在下传前经它收窄；前端时长选择器（项目级默认与逐镜头 pill）按同一份声明过滤候选。约束求值用的生效分辨率两侧口径不同：后端取「项目覆盖 → provider 兜底档位」（`_resolution_for_constraints`），前端只按项目已保存的分辨率，未保存时不过滤——那张兜底表是后端数据，镜像到前端会引入第二份真相源。已保存的越界时长一律给「警告 + 引导重选」，不静默改写。backend 侧另有模块级兜底常量，只在型号未登记于 registry 时生效（中转站、自定义供应商包装、已下线型号）。
+在 `supported_durations` 全集之上按上下文收窄的两个 per-model 声明：前者是 `{分辨率: 允许时长}`（如 Veo `{"1080p": [8], "4k": [8]}`），后者是走参考图路径时的允许时长（如 Veo `[8]`）。两条各自独立触发、可同时生效、取交集；与 `supported_durations` 同为 registry 单一真相源。后端唯一收窄入口是 `lib/config/resolver.constrain_durations`：剧本生成的 prompt 与动态 schema、SDK MCP 工具交给 LLM 的候选、执行期未显式指定时长时的取值，都在下传前经它收窄；前端时长选择器（项目级默认与逐镜头 pill）按同一份声明过滤候选。约束求值用的生效分辨率（`_resolution_for_constraints`）取项目已保存的档位，前后端同口径；未保存时不施加分辨率约束——普通视频路径此时省略 SDK 的 resolution 参数，供应商按自己的默认档位处理（Veo 是 720p），该档位下全集本就合法。参考视频路径例外：它执行期下发 `resolution_or_fallback`，故未保存时按 provider 兜底档位求值，与实际下发的档位保持同一集合。已保存的越界时长一律给「警告 + 引导重选」，不静默改写。backend 侧另有模块级兜底常量，只在型号未登记于 registry 时生效（中转站、自定义供应商包装、已下线型号）。
 _Avoid_: 把它当通用「条件→约束」DSL 的雏形去扩展——只表达已有官方明文的联动维度；在 backend 里另写一份与 registry 平行的约束表。
 
 **default_duration**：

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -137,7 +137,7 @@ _Avoid_: 把 size 当比例或清晰度的同义词——它是二者派生的�
 _Avoid_: `VALID_DURATIONS` / 全局时长白名单（已删除的硬编码 `[4,6,8]`，与 per-model 概念相反）；把它当各家「官方时长能力表」（自定义供应商侧只是启发式预填、需用户 review）。
 
 **时长联动约束（duration_resolution_constraints / reference_image_durations）**：
-在 `supported_durations` 全集之上按上下文收窄的两个 per-model 声明：前者是 `{分辨率: 允许时长}`（如 Veo `{"1080p": [8], "4k": [8]}`），后者是走参考图路径时的允许时长（如 Veo `[8]`）。两条各自独立触发、可同时生效、取交集；与 `supported_durations` 同为 registry 单一真相源，前端时长选择器与 backend 入口校验同源消费。backend 侧另有模块级兜底常量，只在型号未登记于 registry 时生效（中转站、自定义供应商包装、已下线型号）。
+在 `supported_durations` 全集之上按上下文收窄的两个 per-model 声明：前者是 `{分辨率: 允许时长}`（如 Veo `{"1080p": [8], "4k": [8]}`），后者是走参考图路径时的允许时长（如 Veo `[8]`）。两条各自独立触发、可同时生效、取交集；与 `supported_durations` 同为 registry 单一真相源。后端唯一收窄入口是 `lib/config/resolver.constrain_durations`：剧本生成的 prompt 与动态 schema、SDK MCP 工具交给 LLM 的候选、执行期未显式指定时长时的取值，都在下传前经它收窄；前端时长选择器（项目级默认与逐镜头 pill）按同一份声明过滤候选。约束求值用的生效分辨率两侧口径不同：后端取「项目覆盖 → provider 兜底档位」（`_resolution_for_constraints`），前端只按项目已保存的分辨率，未保存时不过滤——那张兜底表是后端数据，镜像到前端会引入第二份真相源。已保存的越界时长一律给「警告 + 引导重选」，不静默改写。backend 侧另有模块级兜底常量，只在型号未登记于 registry 时生效（中转站、自定义供应商包装、已下线型号）。
 _Avoid_: 把它当通用「条件→约束」DSL 的雏形去扩展——只表达已有官方明文的联动维度；在 backend 里另写一份与 registry 平行的约束表。
 
 **default_duration**：

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -585,6 +585,106 @@ describe("StudioCanvasRouter", () => {
     expect(providersSpy).not.toHaveBeenCalled();
   });
 
+  // 逐镜头时长候选须按项目分辨率与生效 generation_mode 收窄——用户在设置里选了 1080p 却仍能把
+  // 单个镜头改成 4 秒，入队时才被 backend 拒。
+  it("narrows the per-shot duration options by the project resolution", async () => {
+    const VEO = "gemini-aistudio/veo-3.1";
+    vi.spyOn(API, "getProviders").mockResolvedValue({
+      providers: [
+        {
+          id: "gemini-aistudio",
+          display_name: "Gemini",
+          description: "",
+          status: "ready",
+          media_types: ["video"],
+          capabilities: [],
+          configured_keys: [],
+          missing_keys: [],
+          models: {
+            "veo-3.1": {
+              display_name: "Veo 3.1",
+              media_type: "video",
+              capabilities: [],
+              default: true,
+              supported_durations: [4, 6, 8],
+              duration_resolution_constraints: { "1080p": [8] },
+              reference_image_durations: [8],
+              resolutions: ["720p", "1080p"],
+            },
+          },
+        },
+      ],
+    });
+    vi.spyOn(API, "listCustomProviders").mockResolvedValue({ providers: [] });
+    vi.spyOn(API, "getSystemConfig").mockResolvedValue({
+      settings: { default_video_backend: VEO },
+    } as Awaited<ReturnType<typeof API.getSystemConfig>>);
+
+    useProjectsStore.setState({
+      currentProjectName: "real-project",
+      currentProjectData: makeProjectData({
+        video_backend: VEO,
+        model_settings: { [VEO]: { resolution: "1080p" } },
+      }),
+      currentScripts: { "episode_1.json": makeScript() },
+    });
+
+    renderAtProjectRoute("real-project", "/episodes/1");
+    await waitFor(() => {
+      // 精确比对而非包含：全集 "4,6,8" 也含子串 "8"
+      expect(screen.getByTestId("timeline-duration-options").textContent).toBe("8");
+    });
+  });
+
+  // 未受约束的分辨率下行为与改动前一致：全集原样呈现，不因为接了收窄管线而误缩。
+  it("leaves the per-shot duration options untouched at an unconstrained resolution", async () => {
+    const VEO = "gemini-aistudio/veo-3.1";
+    vi.spyOn(API, "getProviders").mockResolvedValue({
+      providers: [
+        {
+          id: "gemini-aistudio",
+          display_name: "Gemini",
+          description: "",
+          status: "ready",
+          media_types: ["video"],
+          capabilities: [],
+          configured_keys: [],
+          missing_keys: [],
+          models: {
+            "veo-3.1": {
+              display_name: "Veo 3.1",
+              media_type: "video",
+              capabilities: [],
+              default: true,
+              supported_durations: [4, 6, 8],
+              duration_resolution_constraints: { "1080p": [8] },
+              reference_image_durations: [8],
+              resolutions: ["720p", "1080p"],
+            },
+          },
+        },
+      ],
+    });
+    vi.spyOn(API, "listCustomProviders").mockResolvedValue({ providers: [] });
+    vi.spyOn(API, "getSystemConfig").mockResolvedValue({
+      settings: { default_video_backend: VEO },
+    } as Awaited<ReturnType<typeof API.getSystemConfig>>);
+
+    useProjectsStore.setState({
+      currentProjectName: "real-project",
+      currentProjectData: makeProjectData({
+        video_backend: VEO,
+        model_settings: { [VEO]: { resolution: "720p" } },
+      }),
+      currentScripts: { "episode_1.json": makeScript() },
+    });
+
+    renderAtProjectRoute("real-project", "/episodes/1");
+    await waitFor(() => {
+      expect(screen.getByTestId("timeline-duration-options").textContent).toBe("4,6,8");
+    });
+  });
+
   // 反方向：同一实例从演示项目切到真实项目时，store 的 currentProjectName 仍滞留上一轮的
   // 演示项目名（StudioWorkspace 的 effect 还没写入新值）。demoMode 若仍以 store 值兜底会误判
   // 为演示态，延迟真实项目的三个 GET；路由参数存在时须直接采信它。

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -586,8 +586,12 @@ describe("StudioCanvasRouter", () => {
   });
 
   // 逐镜头时长候选须按项目分辨率与生效 generation_mode 收窄——用户在设置里选了 1080p 却仍能把
-  // 单个镜头改成 4 秒，入队时才被 backend 拒。
-  it("narrows the per-shot duration options by the project resolution", async () => {
+  // 单个镜头改成 4 秒，入队时才被 backend 拒。反向用例守住「未受约束的分辨率下与改动前一致」：
+  // 全集原样呈现，不因为接了收窄管线而误缩。
+  it.each([
+    ["1080p", "8"],
+    ["720p", "4,6,8"],
+  ])("narrows the per-shot duration options at %s", async (resolution, expected) => {
     const VEO = "gemini-aistudio/veo-3.1";
     vi.spyOn(API, "getProviders").mockResolvedValue({
       providers: [
@@ -624,7 +628,7 @@ describe("StudioCanvasRouter", () => {
       currentProjectName: "real-project",
       currentProjectData: makeProjectData({
         video_backend: VEO,
-        model_settings: { [VEO]: { resolution: "1080p" } },
+        model_settings: { [VEO]: { resolution } },
       }),
       currentScripts: { "episode_1.json": makeScript() },
     });
@@ -632,56 +636,7 @@ describe("StudioCanvasRouter", () => {
     renderAtProjectRoute("real-project", "/episodes/1");
     await waitFor(() => {
       // 精确比对而非包含：全集 "4,6,8" 也含子串 "8"
-      expect(screen.getByTestId("timeline-duration-options").textContent).toBe("8");
-    });
-  });
-
-  // 未受约束的分辨率下行为与改动前一致：全集原样呈现，不因为接了收窄管线而误缩。
-  it("leaves the per-shot duration options untouched at an unconstrained resolution", async () => {
-    const VEO = "gemini-aistudio/veo-3.1";
-    vi.spyOn(API, "getProviders").mockResolvedValue({
-      providers: [
-        {
-          id: "gemini-aistudio",
-          display_name: "Gemini",
-          description: "",
-          status: "ready",
-          media_types: ["video"],
-          capabilities: [],
-          configured_keys: [],
-          missing_keys: [],
-          models: {
-            "veo-3.1": {
-              display_name: "Veo 3.1",
-              media_type: "video",
-              capabilities: [],
-              default: true,
-              supported_durations: [4, 6, 8],
-              duration_resolution_constraints: { "1080p": [8] },
-              reference_image_durations: [8],
-              resolutions: ["720p", "1080p"],
-            },
-          },
-        },
-      ],
-    });
-    vi.spyOn(API, "listCustomProviders").mockResolvedValue({ providers: [] });
-    vi.spyOn(API, "getSystemConfig").mockResolvedValue({
-      settings: { default_video_backend: VEO },
-    } as Awaited<ReturnType<typeof API.getSystemConfig>>);
-
-    useProjectsStore.setState({
-      currentProjectName: "real-project",
-      currentProjectData: makeProjectData({
-        video_backend: VEO,
-        model_settings: { [VEO]: { resolution: "720p" } },
-      }),
-      currentScripts: { "episode_1.json": makeScript() },
-    });
-
-    renderAtProjectRoute("real-project", "/episodes/1");
-    await waitFor(() => {
-      expect(screen.getByTestId("timeline-duration-options").textContent).toBe("4,6,8");
+      expect(screen.getByTestId("timeline-duration-options").textContent).toBe(expected);
     });
   });
 

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -141,16 +141,22 @@ export function StudioCanvasRouter() {
   // 收窄放在下方按集的 Route 渲染里：generation_mode 可被单集覆盖，「是否走参考图路径」因此
   // 是按集的值，而能力查询只在组件顶层做一次。此处只取不随上下文变化的两项。
   const effectiveVideoBackend = currentProjectData?.video_backend || globalVideoBackend;
-  const { rawDurations, durationConstraints } = useModelCapabilities({
+  const { rawDurations, durationConstraints, resolvedVideoBackend } = useModelCapabilities({
     projectName: currentProjectName,
     videoBackend: effectiveVideoBackend,
     providers,
     customProviders,
     enabled: capabilitiesEnabled,
   });
-  // 用户未选分辨率时为 null：执行期会落到 provider 兜底档位，但那张兜底表是后端数据、
-  // 前端不镜像，故不替用户假定档位（不收窄，与项目设置页的时长选择器同口径）。
-  const videoResolution = lookupProjectVideoResolution(currentProjectData, effectiveVideoBackend);
+  // 分辨率按能力管线解析出的 `provider/model` 查，而非传入的原始值：后者可能是裸 provider
+  // （服务端补全默认视频模型）或留空跟随全局默认，直接拿去查 `model_settings` 会把 provider ID
+  // 当成 model ID、读不到用户实际保存的档位，于是该收窄的候选照旧呈现。
+  // 用户未选分辨率时为 null → 不收窄：执行期省略 resolution 参数、供应商按自己的默认档位处理，
+  // 该档位下全集本就合法。与后端约束求值、项目设置页的时长选择器同口径。
+  const videoResolution = lookupProjectVideoResolution(
+    currentProjectData,
+    resolvedVideoBackend || effectiveVideoBackend,
+  );
 
   // 从任务队列派生 loading 状态（替代本地 state）：活跃 + 最新行胜出两条不变量下沉到 store selector
   const generatingCharacterNames = useActiveResourceIds("character", currentProjectName);

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -45,8 +45,16 @@ import {
   enqueueVideo,
 } from "@/actions/generation";
 import { buildEntityRevisionKey } from "@/utils/project-changes";
-import { getProviderModels, getCustomProviderModels } from "@/utils/provider-models";
-import { useModelCapabilities } from "@/hooks/useModelCapabilities";
+import {
+  getProviderModels,
+  getCustomProviderModels,
+  lookupProjectVideoResolution,
+} from "@/utils/provider-models";
+import {
+  durationOutOfRangeReason,
+  narrowDurations,
+  useModelCapabilities,
+} from "@/hooks/useModelCapabilities";
 import { effectiveMode } from "@/utils/generation-mode";
 import type { Scene, Prop, Product, CustomProviderInfo, ProviderInfo } from "@/types";
 import type { EpisodeScript } from "@/types/script";
@@ -126,16 +134,23 @@ export function StudioCanvasRouter() {
   // currentProjectName 单独判一次兜住这一帧仍读到旧演示项目名的窗口。
   const capabilitiesEnabled = !demoMode && !isDemoProject(currentProjectName);
 
-  // 时长选项只用于「时长与后端不兼容」的橙色标记，取未经联动约束收窄的全集。
+  // 逐镜头时长编辑器的候选取经联动约束收窄后的集合，用户就选不到入队后必然被拒的组合；
+  // 已保存的越界值不改写，由 ShotDetail 按成因给警告并引导重选。
   // 后端未配置时能力管线退回服务端解析出的 model（与生成路径同一套规则，避免 FE/BE 漂移）。
-  const { rawDurations } = useModelCapabilities({
+  //
+  // 收窄放在下方按集的 Route 渲染里：generation_mode 可被单集覆盖，「是否走参考图路径」因此
+  // 是按集的值，而能力查询只在组件顶层做一次。此处只取不随上下文变化的两项。
+  const effectiveVideoBackend = currentProjectData?.video_backend || globalVideoBackend;
+  const { rawDurations, durationConstraints } = useModelCapabilities({
     projectName: currentProjectName,
-    videoBackend: currentProjectData?.video_backend || globalVideoBackend,
+    videoBackend: effectiveVideoBackend,
     providers,
     customProviders,
     enabled: capabilitiesEnabled,
   });
-  const durationOptions = rawDurations ?? undefined;
+  // 用户未选分辨率时为 null：执行期会落到 provider 兜底档位，但那张兜底表是后端数据、
+  // 前端不镜像，故不替用户假定档位（不收窄，与项目设置页的时长选择器同口径）。
+  const videoResolution = lookupProjectVideoResolution(currentProjectData, effectiveVideoBackend);
 
   // 从任务队列派生 loading 状态（替代本地 state）：活跃 + 最新行胜出两条不变量下沉到 store selector
   const generatingCharacterNames = useActiveResourceIds("character", currentProjectName);
@@ -634,6 +649,19 @@ export function StudioCanvasRouter() {
           const scriptFile = episode?.script_file?.replace(/^scripts\//, "");
           const script = scriptFile ? (currentScripts[scriptFile] ?? null) : null;
           const mode = effectiveMode(currentProjectData, episode);
+          // 本集生效模式决定是否走参考图路径，故时长候选按集收窄（见顶层能力查询处说明）。
+          const durationCtx = {
+            videoResolution,
+            usesReferenceImages: mode === "reference_video",
+          };
+          const durationOptions =
+            narrowDurations({ rawDurations, durationConstraints }, durationCtx) ?? undefined;
+          const durationWarningReason = (seconds: number) =>
+            durationOutOfRangeReason(
+              seconds,
+              { rawDurations, supportedDurations: durationOptions ?? null, durationConstraints },
+              durationCtx,
+            );
           const hasDraft =
             episode?.script_status === "segmented" || episode?.script_status === "generated";
           // ad 剧本骨架唯一（shots[]），但两条生成路径进不同画布：storyboard 走镜头
@@ -704,6 +732,7 @@ export function StudioCanvasRouter() {
                     scriptFile={scriptFile ?? undefined}
                     projectData={currentProjectData}
                     durationOptions={durationOptions}
+                    durationWarningReason={durationWarningReason}
                     onUpdatePrompt={awaitedUpdatePrompt}
                     onGenerateStoryboard={voidPromise(handleGenerateStoryboard)}
                     onGenerateVideo={voidPromise(handleGenerateVideo)}
@@ -730,6 +759,7 @@ export function StudioCanvasRouter() {
                     scriptFile={scriptFile ?? undefined}
                     projectData={currentProjectData}
                     durationOptions={durationOptions}
+                    durationWarningReason={durationWarningReason}
                     onUpdatePrompt={awaitedUpdatePrompt}
                     onMoveShot={isAd ? handleMoveShot : undefined}
                     onGenerateStoryboard={voidPromise(handleGenerateStoryboard)}

--- a/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
+++ b/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
@@ -9,6 +9,7 @@ import { useAppStore } from "@/stores/app-store";
 import { useCostStore } from "@/stores/cost-store";
 import { useActiveResourceIds, useHasActiveTaskForScriptFile } from "@/stores/tasks-store";
 import { getScriptItemId } from "@/utils/script-shape";
+import type { DurationOutOfRangeReason } from "@/hooks/useModelCapabilities";
 import type {
   EpisodeScript,
   NarrationEpisodeScript,
@@ -30,6 +31,8 @@ interface GridImageToVideoCanvasProps {
   scriptFile?: string;
   projectData: ProjectData | null;
   durationOptions?: number[];
+  /** 已保存时长越界的成因判定；缺省时 ShotDetail 退回不区分成因的通用警告文案。 */
+  durationWarningReason?: (seconds: number) => DurationOutOfRangeReason | null;
   onUpdatePrompt?: (
     segmentId: string,
     fieldOrPatch: string | Record<string, unknown>,
@@ -60,6 +63,7 @@ export function GridImageToVideoCanvas({
   scriptFile,
   projectData,
   durationOptions,
+  durationWarningReason,
   onUpdatePrompt,
   onGenerateStoryboard,
   onGenerateVideo,
@@ -342,6 +346,7 @@ export function GridImageToVideoCanvas({
             generatingVideo={generatingVideo}
             generatingNarration={generatingNarration}
             durationOptions={durationOptions}
+        durationWarningReason={durationWarningReason}
           />
         ) : null}
       </div>

--- a/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
+++ b/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
@@ -346,7 +346,7 @@ export function GridImageToVideoCanvas({
             generatingVideo={generatingVideo}
             generatingNarration={generatingNarration}
             durationOptions={durationOptions}
-        durationWarningReason={durationWarningReason}
+            durationWarningReason={durationWarningReason}
           />
         ) : null}
       </div>

--- a/frontend/src/components/canvas/timeline/ShotDetail.duration.test.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.duration.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ShotDetail } from "./ShotDetail";
+import type { DramaScene } from "@/types";
+
+/**
+ * 逐镜头时长编辑器：候选取经联动约束收窄后的集合，已保存的越界值不静默改写、
+ * 按成因给警告并引导重选。
+ */
+
+function makeScene(durationSeconds: number): DramaScene {
+  return {
+    scene_id: "E1S01",
+    duration_seconds: durationSeconds,
+    segment_break: false,
+    characters_in_scene: [],
+    scenes: [],
+    props: [],
+    image_prompt: {
+      scene: "重逢",
+      composition: { shot_type: "Medium Shot", lighting: "暖光", ambiance: "怀旧" },
+    },
+    video_prompt: { action: "推门而入", camera_motion: "Static", ambiance_audio: "", dialogue: [] },
+    utterances: [],
+    transition_to_next: "cut",
+  };
+}
+
+function renderDetail(props: Partial<Parameters<typeof ShotDetail>[0]> = {}, seconds = 4) {
+  return render(
+    <ShotDetail
+      segment={makeScene(seconds)}
+      segmentId="E1S01"
+      contentMode="drama"
+      aspectRatio="9:16"
+      projectName="demo"
+      scriptFile="episode_1.json"
+      selectedIndex={0}
+      totalCount={1}
+      onPrev={() => {}}
+      onNext={() => {}}
+      onUpdatePrompt={() => {}}
+      durationOptions={[8]}
+      {...props}
+    />,
+  );
+}
+
+/** 时长 pill 是唯一带秒数文案的按钮；越界时它带 aria-label 的 ⚠ 兄弟节点。 */
+function warningLabel(): string | null {
+  return screen.queryByText("⚠")?.getAttribute("aria-label") ?? null;
+}
+
+describe("ShotDetail 时长候选与越界提示", () => {
+  it("只呈现收窄后的候选，越界的已保存值仍原样显示、不被改写", () => {
+    const onUpdatePrompt = vi.fn();
+    renderDetail({ onUpdatePrompt });
+
+    // 存值 4 秒照常显示——静默改写会让用户在不知情下丢掉自己的设置
+    expect(screen.getByRole("button", { name: /4 秒/ })).toBeInTheDocument();
+    expect(onUpdatePrompt).not.toHaveBeenCalled();
+
+    // 展开后只有收窄后的 8 秒可选
+    fireEvent.click(screen.getByRole("button", { name: /4 秒/ }));
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(1);
+    expect(radios[0]).toHaveTextContent("8 秒");
+  });
+
+  it("重选写回选中的候选值", () => {
+    const onUpdatePrompt = vi.fn();
+    renderDetail({ onUpdatePrompt });
+    fireEvent.click(screen.getByRole("button", { name: /4 秒/ }));
+    fireEvent.click(screen.getByRole("radio", { name: /8 秒/ }));
+    expect(onUpdatePrompt).toHaveBeenCalledWith("E1S01", "duration_seconds", 8);
+  });
+
+  it("候选内的值不告警", () => {
+    renderDetail({}, 8);
+    expect(warningLabel()).toBeNull();
+  });
+
+  // 成因决定提示把用户引向哪里：分辨率 / 参考图两条改对应设置也能解决，
+  // 说成「模型不支持」会把用户引去换模型。
+  it("成因为分辨率时说清是分辨率，不说成模型不支持", () => {
+    renderDetail({ durationWarningReason: () => "resolution" });
+    expect(warningLabel()).toContain("当前分辨率");
+  });
+
+  it("成因为参考图路径时说清是该模式", () => {
+    renderDetail({ durationWarningReason: () => "reference" });
+    expect(warningLabel()).toContain("参考生视频");
+  });
+
+  it("成因为模型全集不含该值、或未传成因判定时用通用文案", () => {
+    const { unmount } = renderDetail({ durationWarningReason: () => "model" });
+    expect(warningLabel()).toContain("模型支持范围");
+    unmount();
+
+    // 未接线成因判定的调用点（如未来新增的画布）退回通用文案，而不是显示成 undefined key
+    renderDetail();
+    expect(warningLabel()).toContain("模型支持范围");
+  });
+});

--- a/frontend/src/components/canvas/timeline/ShotDetail.duration.test.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.duration.test.tsx
@@ -102,3 +102,62 @@ describe("ShotDetail 时长候选与越界提示", () => {
     expect(warningLabel()).toContain("模型支持范围");
   });
 });
+
+/**
+ * 占用感知型控件三项检查：在跑的任务已捕获旧时长，此时改时长会让任务产物与剧本存值不一致。
+ * 兄弟控件（重生成分镜 / 视频）本就按同一对占用态接线，此处覆盖打开时与提交时两道校验。
+ */
+describe("ShotDetail 时长编辑的占用态门控", () => {
+  it("该镜头生成中时禁用时长 pill 并说明原因", () => {
+    for (const busyProp of ["generatingStoryboard", "generatingVideo"] as const) {
+      const { unmount } = renderDetail({ [busyProp]: true }, 8);
+      const pill = screen.getByRole("button", { name: /8 秒/ });
+      expect(pill).toBeDisabled();
+      expect(pill).toHaveAttribute("title", "该镜头正在生成中，暂不能修改时长");
+      unmount();
+    }
+  });
+
+  it("面板打开后任务才启动时收起面板，且提交被拒不写回", () => {
+    const onUpdatePrompt = vi.fn();
+    const { rerender } = render(
+      <ShotDetail
+        segment={makeScene(4)}
+        segmentId="E1S01"
+        contentMode="drama"
+        aspectRatio="9:16"
+        projectName="demo"
+        scriptFile="episode_1.json"
+        selectedIndex={0}
+        totalCount={1}
+        onPrev={() => {}}
+        onNext={() => {}}
+        onUpdatePrompt={onUpdatePrompt}
+        durationOptions={[8]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /4 秒/ }));
+    expect(screen.getAllByRole("radio")).toHaveLength(1);
+
+    // 面板已打开，此刻该镜头的视频任务启动：只查打开时刻的实现会在这里放过写入
+    rerender(
+      <ShotDetail
+        segment={makeScene(4)}
+        segmentId="E1S01"
+        contentMode="drama"
+        aspectRatio="9:16"
+        projectName="demo"
+        scriptFile="episode_1.json"
+        selectedIndex={0}
+        totalCount={1}
+        onPrev={() => {}}
+        onNext={() => {}}
+        onUpdatePrompt={onUpdatePrompt}
+        durationOptions={[8]}
+        generatingVideo
+      />,
+    );
+    expect(screen.queryByRole("radio")).not.toBeInTheDocument();
+    expect(onUpdatePrompt).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/canvas/timeline/ShotDetail.duration.test.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.duration.test.tsx
@@ -202,4 +202,35 @@ describe("ShotDetail 时长编辑的占用态门控", () => {
     fireEvent.click(screen.getByRole("radio", { name: /8 秒/ }));
     expect(onUpdatePrompt).not.toHaveBeenCalled();
   });
+
+  it("任务结束后旧面板不自行重现", () => {
+    // 只派生可见性（open && !locked）会在 locked 回落时让旧面板连同未提交草稿一起回来。
+    // 转入锁定态必须真正清掉 open 与 draftSeconds。
+    const onUpdatePrompt = vi.fn();
+    const props = {
+      segment: makeScene(4),
+      segmentId: "E1S01",
+      contentMode: "drama" as const,
+      aspectRatio: "9:16" as const,
+      projectName: "demo",
+      scriptFile: "episode_1.json",
+      selectedIndex: 0,
+      totalCount: 1,
+      onPrev: () => {},
+      onNext: () => {},
+      onUpdatePrompt,
+      durationOptions: [8],
+    };
+    const { rerender } = render(<ShotDetail {...props} />);
+    fireEvent.click(screen.getByRole("button", { name: /4 秒/ }));
+    expect(screen.getAllByRole("radio")).toHaveLength(1);
+
+    rerender(<ShotDetail {...props} generatingVideo />);
+    expect(screen.queryByRole("radio")).not.toBeInTheDocument();
+
+    // 任务结束：面板须保持关闭，等用户自己再点开
+    rerender(<ShotDetail {...props} />);
+    expect(screen.queryByRole("radio")).not.toBeInTheDocument();
+    expect(onUpdatePrompt).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/canvas/timeline/ShotDetail.duration.test.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.duration.test.tsx
@@ -203,6 +203,43 @@ describe("ShotDetail 时长编辑的占用态门控", () => {
     expect(onUpdatePrompt).not.toHaveBeenCalled();
   });
 
+  it("同集宫格任务在跑时提交被拒（grid 按 scriptFile 判，归不进分镜粒度）", () => {
+    // grid 任务的 resource_id 是 grid_id，isResourceBusy 的分镜粒度判定看不到它；
+    // 而切割阶段会覆写本集多个分镜、与改时长并发写同一份剧本。
+    const onUpdatePrompt = vi.fn();
+    renderDetail({ onUpdatePrompt });
+    fireEvent.click(screen.getByRole("button", { name: /4 秒/ }));
+
+    useTasksStore.setState({
+      tasks: [
+        {
+          project_name: "demo",
+          task_type: "grid",
+          media_type: "image",
+          resource_id: "grid-1",
+          resource_type: null,
+          script_file: "episode_1.json",
+          payload: {},
+          task_id: "g1",
+          status: "running",
+          result: null,
+          error_message: null,
+          cancelled_by: null,
+          provider_id: null,
+          provider_job_id: null,
+          source: "webui",
+          queued_at: "2026-07-28T00:00:00Z",
+          started_at: null,
+          finished_at: null,
+          updated_at: "2026-07-28T00:00:00Z",
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: /8 秒/ }));
+    expect(onUpdatePrompt).not.toHaveBeenCalled();
+  });
+
   it("任务结束后旧面板不自行重现", () => {
     // 只派生可见性（open && !locked）会在 locked 回落时让旧面板连同未提交草稿一起回来。
     // 转入锁定态必须真正清掉 open 与 draftSeconds。

--- a/frontend/src/components/canvas/timeline/ShotDetail.duration.test.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.duration.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ShotDetail } from "./ShotDetail";
+import { useTasksStore } from "@/stores/tasks-store";
 import type { DramaScene } from "@/types";
 
 /**
@@ -108,6 +109,10 @@ describe("ShotDetail 时长候选与越界提示", () => {
  * 兄弟控件（重生成分镜 / 视频）本就按同一对占用态接线，此处覆盖打开时与提交时两道校验。
  */
 describe("ShotDetail 时长编辑的占用态门控", () => {
+  afterEach(() => {
+    useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
+  });
+
   it("该镜头生成中时禁用时长 pill 并说明原因", () => {
     for (const busyProp of ["generatingStoryboard", "generatingVideo"] as const) {
       const { unmount } = renderDetail({ [busyProp]: true }, 8);
@@ -158,6 +163,43 @@ describe("ShotDetail 时长编辑的占用态门控", () => {
       />,
     );
     expect(screen.queryByRole("radio")).not.toBeInTheDocument();
+    expect(onUpdatePrompt).not.toHaveBeenCalled();
+  });
+
+  it("prop 还没跟上、但 store 已记录该镜头在跑时，提交仍被拒", () => {
+    // 提交时刻复核的存在理由：prop 反映的是上次渲染，store 更新到重渲染提交之间用户仍可能
+    // 点下去。故走 tasks-store 的 isResourceBusy 新鲜读，而不是只看 busy prop。
+    const onUpdatePrompt = vi.fn();
+    renderDetail({ onUpdatePrompt });
+    fireEvent.click(screen.getByRole("button", { name: /4 秒/ }));
+
+    useTasksStore.setState({
+      tasks: [
+        {
+          project_name: "demo",
+          task_type: "video",
+          media_type: "video",
+          resource_id: "E1S01",
+          resource_type: null,
+          script_file: null,
+          payload: {},
+          task_id: "t1",
+          status: "running",
+          result: null,
+          error_message: null,
+          cancelled_by: null,
+          provider_id: null,
+          provider_job_id: null,
+          source: "webui",
+          queued_at: "2026-07-28T00:00:00Z",
+          started_at: null,
+          finished_at: null,
+          updated_at: "2026-07-28T00:00:00Z",
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: /8 秒/ }));
     expect(onUpdatePrompt).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/canvas/timeline/ShotDetail.duration.test.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.duration.test.tsx
@@ -240,6 +240,43 @@ describe("ShotDetail 时长编辑的占用态门控", () => {
     expect(onUpdatePrompt).not.toHaveBeenCalled();
   });
 
+  it("prop 还没跟上、但 store 已记录该镜头在跑时，面板打不开", () => {
+    // 打开时刻同样要新鲜复核：渲染完成到用户点击之间任务可能才启动，此时 busy prop
+    // 还停留在上次渲染，只看它会让面板照常展开。
+    const onUpdatePrompt = vi.fn();
+    renderDetail({ onUpdatePrompt });
+
+    useTasksStore.setState({
+      tasks: [
+        {
+          project_name: "demo",
+          task_type: "storyboard",
+          media_type: "image",
+          resource_id: "E1S01",
+          resource_type: null,
+          script_file: null,
+          payload: {},
+          task_id: "t2",
+          status: "running",
+          result: null,
+          error_message: null,
+          cancelled_by: null,
+          provider_id: null,
+          provider_job_id: null,
+          source: "webui",
+          queued_at: "2026-07-28T00:00:00Z",
+          started_at: null,
+          finished_at: null,
+          updated_at: "2026-07-28T00:00:00Z",
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /4 秒/ }));
+    expect(screen.queryByRole("radio")).not.toBeInTheDocument();
+    expect(onUpdatePrompt).not.toHaveBeenCalled();
+  });
+
   it("任务结束后旧面板不自行重现", () => {
     // 只派生可见性（open && !locked）会在 locked 回落时让旧面板连同未提交草稿一起回来。
     // 转入锁定态必须真正清掉 open 与 draftSeconds。

--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -155,6 +155,8 @@ interface DurationPillProps {
   durationOptions: number[];
   durationWarningReason?: ShotDetailProps["durationWarningReason"];
   onUpdatePrompt?: ShotDetailProps["onUpdatePrompt"];
+  /** 该镜头有分镜 / 视频任务在跑；置真时禁止改时长（在跑的任务已捕获旧值，改了两边就不一致）。 */
+  busy?: boolean;
 }
 
 function DurationPill({
@@ -163,6 +165,7 @@ function DurationPill({
   durationOptions,
   durationWarningReason,
   onUpdatePrompt,
+  busy = false,
 }: DurationPillProps) {
   const { t } = useTranslation("dashboard");
   const [open, setOpen] = useState(false);
@@ -171,17 +174,27 @@ function DurationPill({
   // 拖动 slider 期间用本地 state 跟随；松手 / 失焦 / 键盘抬起时再提交一次
   // 避免 onChange 每像素一次 onUpdatePrompt 产生并发写请求 + 乱序落库
   const [draftSeconds, setDraftSeconds] = useState<number | null>(null);
-  const displaySeconds = draftSeconds ?? seconds;
+  // 占用中一律回落到上游值：拖到一半任务才启动时，草稿不该继续顶替真实时长显示。
+  const displaySeconds = (busy ? null : draftSeconds) ?? seconds;
   const commitDraft = useCallback(() => {
     if (draftSeconds == null) return;
+    // 提交时刻复核占用态：面板打开后任务可能才启动，只查打开时刻会留一个竞态窗口。
+    if (busy) {
+      setDraftSeconds(null);
+      return;
+    }
     if (draftSeconds !== seconds) {
       void onUpdatePrompt?.(segmentId, "duration_seconds", draftSeconds);
     }
     setDraftSeconds(null);
-  }, [draftSeconds, seconds, segmentId, onUpdatePrompt]);
+  }, [draftSeconds, seconds, segmentId, onUpdatePrompt, busy]);
 
   const editable = !!onUpdatePrompt;
   const noOptions = durationOptions.length === 0;
+  const locked = noOptions || busy;
+  // 面板开合是派生态而非独立状态：打开后任务才启动时它自动收起，不必在 effect 里同步 setState。
+  // 少了这一道，面板会停在「可选」状态而提交被下面的 busy 复核静默丢弃。
+  const panelOpen = open && !locked;
   const isIncompatible =
     durationOptions.length > 0 && !durationOptions.includes(seconds);
   // 越界文案按成因分开：模型全集就不含该值才是「模型不支持」，被分辨率 / 参考图路径的联动约束
@@ -232,10 +245,16 @@ function DurationPill({
       <button
         ref={ref}
         type="button"
-        onClick={() => !noOptions && setOpen((o) => !o)}
-        disabled={noOptions}
-        aria-disabled={noOptions || undefined}
-        title={noOptions ? t("duration_no_options") : undefined}
+        onClick={() => !locked && setOpen((o) => !o)}
+        disabled={locked}
+        aria-disabled={locked || undefined}
+        title={
+          busy
+            ? t("duration_locked_generating")
+            : noOptions
+              ? t("duration_no_options")
+              : undefined
+        }
         className={`${baseClass} transition-colors disabled:cursor-not-allowed disabled:opacity-60`}
         style={baseStyle}
       >
@@ -250,7 +269,7 @@ function DurationPill({
         )}
       </button>
       <Popover
-        open={open}
+        open={panelOpen}
         onClose={() => setOpen(false)}
         anchorRef={ref}
         width="w-auto"
@@ -317,6 +336,11 @@ function DurationPill({
                   type="button"
                   aria-checked={checked}
                   onClick={() => {
+                    // 与 commitDraft 同口径：提交时刻再复核一次，不吃面板打开后才启动的任务。
+                    if (busy) {
+                      setOpen(false);
+                      return;
+                    }
                     void onUpdatePrompt(segmentId, "duration_seconds", d);
                     setOpen(false);
                   }}
@@ -958,6 +982,7 @@ export function ShotDetail({
           durationOptions={durationOptions}
           durationWarningReason={durationWarningReason}
           onUpdatePrompt={onUpdatePrompt}
+          busy={!!generatingStoryboard || !!generatingVideo}
         />
         <StatusBadge status={status} />
         <span className="flex-1" />

--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -177,8 +177,7 @@ function DurationPill({
   // 拖动 slider 期间用本地 state 跟随；松手 / 失焦 / 键盘抬起时再提交一次
   // 避免 onChange 每像素一次 onUpdatePrompt 产生并发写请求 + 乱序落库
   const [draftSeconds, setDraftSeconds] = useState<number | null>(null);
-  // 占用中一律回落到上游值：拖到一半任务才启动时，草稿不该继续顶替真实时长显示。
-  const displaySeconds = (busy ? null : draftSeconds) ?? seconds;
+  const displaySeconds = draftSeconds ?? seconds;
   // 提交时刻复核占用态：面板打开后任务可能才启动，只查打开/渲染时刻会留一个竞态窗口。
   // 走 tasks-store 的 isResourceBusy 新鲜读而非 busy prop——prop 反映的是上次渲染，
   // store 更新到重渲染提交之间用户仍可能点下去。命中则拒绝并给可见反馈（与立绘上传的
@@ -208,9 +207,19 @@ function DurationPill({
   const editable = !!onUpdatePrompt;
   const noOptions = durationOptions.length === 0;
   const locked = noOptions || busy;
-  // 面板开合是派生态而非独立状态：打开后任务才启动时它自动收起，不必在 effect 里同步 setState。
-  // 少了这一道，面板会停在「可选」状态而提交被下面的 busy 复核静默丢弃。
-  const panelOpen = open && !locked;
+
+  // 转入锁定态时真正清掉面板与草稿，而不只是遮蔽：只派生可见性的话，任务结束、locked 回到
+  // false 时旧面板会自行重现，未提交的 slider 草稿也一起回来、可能被误写回。
+  // 用「prop 变化时于渲染期调整 state」这一 React 官方模式，而不是 effect——后者多一个渲染
+  // 周期，且踩 react-hooks/set-state-in-effect。
+  const [prevLocked, setPrevLocked] = useState(locked);
+  if (locked !== prevLocked) {
+    setPrevLocked(locked);
+    if (locked) {
+      setOpen(false);
+      setDraftSeconds(null);
+    }
+  }
   const isIncompatible =
     durationOptions.length > 0 && !durationOptions.includes(seconds);
   // 越界文案按成因分开：模型全集就不含该值才是「模型不支持」，被分辨率 / 参考图路径的联动约束
@@ -285,7 +294,7 @@ function DurationPill({
         )}
       </button>
       <Popover
-        open={panelOpen}
+        open={open}
         onClose={() => setOpen(false)}
         anchorRef={ref}
         width="w-auto"

--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -36,6 +36,7 @@ import { StatusBadge, statusFromAssets } from "./StatusBadge";
 import { Popover } from "@/components/ui/Popover";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
+import { isResourceBusy } from "@/stores/tasks-store";
 import { useCostStore } from "@/stores/cost-store";
 import { useProjectsStore } from "@/stores/projects-store";
 import { errMsg } from "@/utils/async";
@@ -152,6 +153,7 @@ function draftSig(d: DraftState, isAd: boolean, isDrama: boolean): string {
 interface DurationPillProps {
   seconds: number;
   segmentId: string;
+  projectName: string;
   durationOptions: number[];
   durationWarningReason?: ShotDetailProps["durationWarningReason"];
   onUpdatePrompt?: ShotDetailProps["onUpdatePrompt"];
@@ -162,6 +164,7 @@ interface DurationPillProps {
 function DurationPill({
   seconds,
   segmentId,
+  projectName,
   durationOptions,
   durationWarningReason,
   onUpdatePrompt,
@@ -176,10 +179,23 @@ function DurationPill({
   const [draftSeconds, setDraftSeconds] = useState<number | null>(null);
   // 占用中一律回落到上游值：拖到一半任务才启动时，草稿不该继续顶替真实时长显示。
   const displaySeconds = (busy ? null : draftSeconds) ?? seconds;
+  // 提交时刻复核占用态：面板打开后任务可能才启动，只查打开/渲染时刻会留一个竞态窗口。
+  // 走 tasks-store 的 isResourceBusy 新鲜读而非 busy prop——prop 反映的是上次渲染，
+  // store 更新到重渲染提交之间用户仍可能点下去。命中则拒绝并给可见反馈（与立绘上传的
+  // rejectIfAssetBusy 同口径）。
+  const rejectIfBusy = useCallback(() => {
+    const stillBusy =
+      busy ||
+      isResourceBusy("storyboard", projectName, segmentId) ||
+      isResourceBusy("video", projectName, segmentId);
+    if (!stillBusy) return false;
+    useAppStore.getState().pushToast(t("duration_locked_generating"), "info");
+    return true;
+  }, [busy, projectName, segmentId, t]);
+
   const commitDraft = useCallback(() => {
     if (draftSeconds == null) return;
-    // 提交时刻复核占用态：面板打开后任务可能才启动，只查打开时刻会留一个竞态窗口。
-    if (busy) {
+    if (rejectIfBusy()) {
       setDraftSeconds(null);
       return;
     }
@@ -187,7 +203,7 @@ function DurationPill({
       void onUpdatePrompt?.(segmentId, "duration_seconds", draftSeconds);
     }
     setDraftSeconds(null);
-  }, [draftSeconds, seconds, segmentId, onUpdatePrompt, busy]);
+  }, [draftSeconds, seconds, segmentId, onUpdatePrompt, rejectIfBusy]);
 
   const editable = !!onUpdatePrompt;
   const noOptions = durationOptions.length === 0;
@@ -337,7 +353,7 @@ function DurationPill({
                   aria-checked={checked}
                   onClick={() => {
                     // 与 commitDraft 同口径：提交时刻再复核一次，不吃面板打开后才启动的任务。
-                    if (busy) {
+                    if (rejectIfBusy()) {
                       setOpen(false);
                       return;
                     }
@@ -979,6 +995,7 @@ export function ShotDetail({
         <DurationPill
           seconds={segment.duration_seconds ?? 0}
           segmentId={segmentId}
+          projectName={projectName}
           durationOptions={durationOptions}
           durationWarningReason={durationWarningReason}
           onUpdatePrompt={onUpdatePrompt}

--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -36,7 +36,7 @@ import { StatusBadge, statusFromAssets } from "./StatusBadge";
 import { Popover } from "@/components/ui/Popover";
 import { API } from "@/api";
 import { useAppStore } from "@/stores/app-store";
-import { isResourceBusy } from "@/stores/tasks-store";
+import { isResourceBusy, isScriptFileBusy } from "@/stores/tasks-store";
 import { useCostStore } from "@/stores/cost-store";
 import { useProjectsStore } from "@/stores/projects-store";
 import { errMsg } from "@/utils/async";
@@ -154,6 +154,8 @@ interface DurationPillProps {
   seconds: number;
   segmentId: string;
   projectName: string;
+  /** 本集剧本文件名；宫格任务按它做 scriptFile 粒度的占用判定。 */
+  scriptFile?: string;
   durationOptions: number[];
   durationWarningReason?: ShotDetailProps["durationWarningReason"];
   onUpdatePrompt?: ShotDetailProps["onUpdatePrompt"];
@@ -165,6 +167,7 @@ function DurationPill({
   seconds,
   segmentId,
   projectName,
+  scriptFile,
   durationOptions,
   durationWarningReason,
   onUpdatePrompt,
@@ -183,14 +186,17 @@ function DurationPill({
   // store 更新到重渲染提交之间用户仍可能点下去。命中则拒绝并给可见反馈（与立绘上传的
   // rejectIfAssetBusy 同口径）。
   const rejectIfBusy = useCallback(() => {
+    // 宫格任务另按 scriptFile 判：它的 resource_id 是 grid_id，归不进按分镜 resource_id 的
+    // 判定，而切割阶段会覆写本集内多个分镜、与改时长并发写同一份剧本。
     const stillBusy =
       busy ||
       isResourceBusy("storyboard", projectName, segmentId) ||
-      isResourceBusy("video", projectName, segmentId);
+      isResourceBusy("video", projectName, segmentId) ||
+      isScriptFileBusy("grid", scriptFile, projectName);
     if (!stillBusy) return false;
     useAppStore.getState().pushToast(t("duration_locked_generating"), "info");
     return true;
-  }, [busy, projectName, segmentId, t]);
+  }, [busy, projectName, segmentId, scriptFile, t]);
 
   const commitDraft = useCallback(() => {
     if (draftSeconds == null) return;
@@ -1005,6 +1011,7 @@ export function ShotDetail({
           seconds={segment.duration_seconds ?? 0}
           segmentId={segmentId}
           projectName={projectName}
+          scriptFile={scriptFile}
           durationOptions={durationOptions}
           durationWarningReason={durationWarningReason}
           onUpdatePrompt={onUpdatePrompt}

--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -11,6 +11,7 @@ import {
   Loader2,
   Undo2,
 } from "lucide-react";
+import type { DurationOutOfRangeReason } from "@/hooks/useModelCapabilities";
 import type {
   NarrationSegment,
   DramaScene,
@@ -81,6 +82,8 @@ interface ShotDetailProps {
   generatingVideo?: boolean;
   generatingNarration?: boolean;
   durationOptions?: number[];
+  /** 已保存时长越界的成因判定；缺省时退回不区分成因的通用警告文案。 */
+  durationWarningReason?: (seconds: number) => DurationOutOfRangeReason | null;
 }
 
 function getNovelText(seg: Segment, mode: DetailContentMode): string {
@@ -150,6 +153,7 @@ interface DurationPillProps {
   seconds: number;
   segmentId: string;
   durationOptions: number[];
+  durationWarningReason?: ShotDetailProps["durationWarningReason"];
   onUpdatePrompt?: ShotDetailProps["onUpdatePrompt"];
 }
 
@@ -157,6 +161,7 @@ function DurationPill({
   seconds,
   segmentId,
   durationOptions,
+  durationWarningReason,
   onUpdatePrompt,
 }: DurationPillProps) {
   const { t } = useTranslation("dashboard");
@@ -179,7 +184,15 @@ function DurationPill({
   const noOptions = durationOptions.length === 0;
   const isIncompatible =
     durationOptions.length > 0 && !durationOptions.includes(seconds);
-  const incompatibleLabel = t("duration_incompatible_warning", {
+  // 越界文案按成因分开：模型全集就不含该值才是「模型不支持」，被分辨率 / 参考图路径的联动约束
+  // 收窄掉时说清是哪一条——用户据此改对应设置，而不是被引去以为模型换不了这个时长。
+  // 与项目默认时长的三种提示同一套判定（见 useModelCapabilities.durationOutOfRangeReason）。
+  const incompatibleKey = {
+    model: "duration_incompatible_warning",
+    resolution: "duration_incompatible_resolution_warning",
+    reference: "duration_incompatible_reference_warning",
+  }[durationWarningReason?.(seconds) ?? "model"];
+  const incompatibleLabel = t(incompatibleKey, {
     value: seconds,
     supported: durationOptions.join(", "),
   });
@@ -359,6 +372,7 @@ export function ShotDetail({
   generatingVideo,
   generatingNarration,
   durationOptions = [],
+  durationWarningReason,
 }: ShotDetailProps) {
   const { t } = useTranslation("dashboard");
   const status = statusFromAssets(segment.generated_assets?.status);
@@ -942,6 +956,7 @@ export function ShotDetail({
           seconds={segment.duration_seconds ?? 0}
           segmentId={segmentId}
           durationOptions={durationOptions}
+          durationWarningReason={durationWarningReason}
           onUpdatePrompt={onUpdatePrompt}
         />
         <StatusBadge status={status} />

--- a/frontend/src/components/canvas/timeline/ShotDetail.tsx
+++ b/frontend/src/components/canvas/timeline/ShotDetail.tsx
@@ -276,7 +276,11 @@ function DurationPill({
       <button
         ref={ref}
         type="button"
-        onClick={() => !locked && setOpen((o) => !o)}
+        onClick={() => {
+          if (locked) return;
+          if (!open && rejectIfBusy()) return;
+          setOpen((o) => !o);
+        }}
         disabled={locked}
         aria-disabled={locked || undefined}
         title={

--- a/frontend/src/components/canvas/timeline/ShotSplitView.tsx
+++ b/frontend/src/components/canvas/timeline/ShotSplitView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import type { DurationOutOfRangeReason } from "@/hooks/useModelCapabilities";
 import type { NarrationSegment, DramaScene, AdShot } from "@/types";
 import { useAppStore } from "@/stores/app-store";
 import { getScriptItemId, type EditorContentMode } from "@/utils/script-shape";
@@ -31,6 +32,8 @@ interface ShotSplitViewProps {
   generatingVideo?: (segmentId: string) => boolean;
   generatingNarration?: (segmentId: string) => boolean;
   durationOptions?: number[];
+  /** 已保存时长越界的成因判定；缺省时 ShotDetail 退回不区分成因的通用警告文案。 */
+  durationWarningReason?: (seconds: number) => DurationOutOfRangeReason | null;
 }
 
 
@@ -55,6 +58,7 @@ export function ShotSplitView({
   generatingVideo,
   generatingNarration,
   durationOptions,
+  durationWarningReason,
 }: ShotSplitViewProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [collapsed, setCollapsed] = useState(
@@ -157,6 +161,7 @@ export function ShotSplitView({
         generatingVideo={generatingVideo?.(segmentId)}
         generatingNarration={generatingNarration?.(segmentId)}
         durationOptions={durationOptions}
+        durationWarningReason={durationWarningReason}
       />
     </div>
   );

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -357,7 +357,7 @@ export function TimelineCanvas(props: TimelineCanvasProps) {
                 generatingVideo={generatingVideo}
                 generatingNarration={generatingNarration}
                 durationOptions={durationOptions}
-        durationWarningReason={durationWarningReason}
+                durationWarningReason={durationWarningReason}
               />
             </div>
           </div>

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -9,6 +9,7 @@ import { useActiveResourceIds } from "@/stores/tasks-store";
 import { getScriptItemId } from "@/utils/script-shape";
 import { ONBOARDING_ANCHORS } from "@/onboarding/anchors";
 import { useDemoWorkbench } from "@/onboarding/use-demo-workbench";
+import type { DurationOutOfRangeReason } from "@/hooks/useModelCapabilities";
 import type {
   EpisodeScript,
   NarrationEpisodeScript,
@@ -43,6 +44,8 @@ interface TimelineCanvasProps {
   onGenerateNarration?: (segmentId: string, scriptFile?: string) => void;
   onGenerateEpisodeNarration?: (scriptFile?: string) => void;
   durationOptions?: number[];
+  /** 已保存时长越界的成因判定；缺省时 ShotDetail 退回不区分成因的通用警告文案。 */
+  durationWarningReason?: (seconds: number) => DurationOutOfRangeReason | null;
   onRestoreStoryboard?: () => Promise<void> | void;
   onRestoreVideo?: () => Promise<void> | void;
   onSaveTitle?: (next: string) => Promise<void>;
@@ -74,6 +77,7 @@ export function TimelineCanvas(props: TimelineCanvasProps) {
     scriptFile,
     projectData,
     durationOptions,
+    durationWarningReason,
     onUpdatePrompt,
     onMoveShot,
     onGenerateStoryboard,
@@ -353,6 +357,7 @@ export function TimelineCanvas(props: TimelineCanvasProps) {
                 generatingVideo={generatingVideo}
                 generatingNarration={generatingNarration}
                 durationOptions={durationOptions}
+        durationWarningReason={durationWarningReason}
               />
             </div>
           </div>

--- a/frontend/src/components/shared/ModelConfigSection.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.tsx
@@ -2,7 +2,11 @@ import { useEffect, useId, useMemo, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import { InlineWarning } from "@/components/ui/InlineWarning";
 import { ProviderModelSelect } from "@/components/ui/ProviderModelSelect";
-import { catalogDurations, useModelCapabilities } from "@/hooks/useModelCapabilities";
+import {
+  catalogDurations,
+  durationOutOfRangeReason,
+  useModelCapabilities,
+} from "@/hooks/useModelCapabilities";
 import { lookupResolutions } from "@/utils/provider-models";
 import { isContinuousIntegerRange } from "@/utils/duration_format";
 import { ResolutionPicker } from "./ResolutionPicker";
@@ -157,25 +161,25 @@ export function ModelConfigSection({
 
   // 已保存时长落在当前模型支持集之外（后端不变、支持集被外部缩小的挂载/重渲染场景）：
   // 不自动篡改存值，仅渲染提示并提供一键回退 auto，保留用户感知与重选机会。
-  const isDurationOutOfRange =
-    value.defaultDuration !== null &&
-    !!supportedDurations &&
-    !supportedDurations.includes(value.defaultDuration);
-
+  //
   // 提示文案按越界成因分开：模型全集就不含该值才是「模型不支持」，被联动约束收窄掉时说清
   // 是分辨率还是参考图路径——用户据此改对应设置，而不是被引去换模型。
   const durationNoticeKey = useMemo(() => {
-    const saved = value.defaultDuration;
-    if (!isDurationOutOfRange || saved === null) return null;
-    if (!rawDurations?.includes(saved)) return "duration_unsupported_notice";
-    const { withReferenceImages } = durationConstraints;
-    if (usesReferenceImages && withReferenceImages.length > 0 && !withReferenceImages.includes(saved))
-      return "duration_unsupported_reference_notice";
-    return "duration_unsupported_resolution_notice";
+    const reason = durationOutOfRangeReason(
+      value.defaultDuration,
+      { rawDurations, supportedDurations, durationConstraints },
+      { usesReferenceImages },
+    );
+    if (reason === null) return null;
+    return {
+      model: "duration_unsupported_notice",
+      reference: "duration_unsupported_reference_notice",
+      resolution: "duration_unsupported_resolution_notice",
+    }[reason];
   }, [
-    isDurationOutOfRange,
     value.defaultDuration,
     rawDurations,
+    supportedDurations,
     durationConstraints,
     usesReferenceImages,
   ]);

--- a/frontend/src/hooks/useModelCapabilities.test.tsx
+++ b/frontend/src/hooks/useModelCapabilities.test.tsx
@@ -1,7 +1,12 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { API } from "@/api";
-import { catalogDurations, useModelCapabilities } from "@/hooks/useModelCapabilities";
+import {
+  catalogDurations,
+  durationOutOfRangeReason,
+  narrowDurations,
+  useModelCapabilities,
+} from "@/hooks/useModelCapabilities";
 import { useCapabilitiesStore } from "@/stores/capabilities-store";
 import type { ProviderInfo, VideoCapabilities } from "@/types";
 
@@ -270,5 +275,71 @@ describe("catalogDurations", () => {
   it("目录查不到该模型时为 null", () => {
     expect(catalogDurations(provider(), [], "ark/unknown-model")).toBeNull();
     expect(catalogDurations(provider(), [], "")).toBeNull();
+  });
+});
+
+describe("narrowDurations", () => {
+  const CONSTRAINTS = { byResolution: { "1080p": [8] }, withReferenceImages: [8] };
+
+  // 上下文按集变化（generation_mode 可被单集覆盖），而能力查询只在组件顶层做一次；
+  // 收窄规则仍留在本模块，调用点不重新拼查表链路。
+  it("用已取到的能力对另一份上下文再算一次收窄", () => {
+    const capsIn = { rawDurations: [4, 6, 8], durationConstraints: CONSTRAINTS };
+    expect(narrowDurations(capsIn, { videoResolution: "1080p" })).toEqual([8]);
+    expect(narrowDurations(capsIn, { usesReferenceImages: true })).toEqual([8]);
+    expect(narrowDurations(capsIn, {})).toEqual([4, 6, 8]);
+    expect(narrowDurations(capsIn, { videoResolution: "720p" })).toEqual([4, 6, 8]);
+  });
+
+  it("能力未知时为 null（不谎报成空集合）", () => {
+    expect(narrowDurations({ rawDurations: null, durationConstraints: CONSTRAINTS }, {})).toBeNull();
+  });
+});
+
+describe("durationOutOfRangeReason", () => {
+  const CONSTRAINTS = { byResolution: { "1080p": [8] }, withReferenceImages: [8] };
+
+  it("全集就不含该值 → model", () => {
+    expect(
+      durationOutOfRangeReason(
+        5,
+        { rawDurations: [4, 6, 8], supportedDurations: [4, 6, 8], durationConstraints: CONSTRAINTS },
+        {},
+      ),
+    ).toBe("model");
+  });
+
+  // 成因决定提示把用户引向哪里：分辨率 / 参考图两条改对应设置也能解决，不该被引去换模型。
+  it("被分辨率约束收窄 → resolution", () => {
+    expect(
+      durationOutOfRangeReason(
+        4,
+        { rawDurations: [4, 6, 8], supportedDurations: [8], durationConstraints: CONSTRAINTS },
+        { videoResolution: "1080p" },
+      ),
+    ).toBe("resolution");
+  });
+
+  it("被参考图约束收窄 → reference", () => {
+    expect(
+      durationOutOfRangeReason(
+        4,
+        { rawDurations: [4, 6, 8], supportedDurations: [8], durationConstraints: CONSTRAINTS },
+        { usesReferenceImages: true },
+      ),
+    ).toBe("reference");
+  });
+
+  it("未越界 / 值缺失 / 能力未知一律 null", () => {
+    const capsIn = {
+      rawDurations: [4, 6, 8],
+      supportedDurations: [8],
+      durationConstraints: CONSTRAINTS,
+    };
+    expect(durationOutOfRangeReason(8, capsIn, {})).toBeNull();
+    expect(durationOutOfRangeReason(null, capsIn, {})).toBeNull();
+    expect(
+      durationOutOfRangeReason(4, { ...capsIn, supportedDurations: null }, {}),
+    ).toBeNull();
   });
 });

--- a/frontend/src/hooks/useModelCapabilities.test.tsx
+++ b/frontend/src/hooks/useModelCapabilities.test.tsx
@@ -134,6 +134,24 @@ describe("useModelCapabilities 时长维度", () => {
     expect(result.current.rawDurations).toEqual([5, 10]);
   });
 
+  it("裸 provider 后端下 resolvedVideoBackend 给出服务端补全的 provider/model", async () => {
+    // 裸 provider 是合法项目配置（服务端补全默认视频模型）。调用方按「项目为该后端保存了什么」
+    // 查配置时必须用这个已解析值，拿裸值去查会把 provider ID 当成 model ID、读不到实际档位。
+    vi.spyOn(API, "getVideoCapabilities").mockResolvedValue(caps());
+    const { result } = renderHook(() =>
+      useModelCapabilities({ projectName: PROJECT, videoBackend: "gemini", providers: provider() }),
+    );
+    await waitFor(() => expect(result.current.resolvedVideoBackend).toBe("gemini/veo-3"));
+  });
+
+  it("目录能解析时 resolvedVideoBackend 即传入的后端", () => {
+    vi.spyOn(API, "getVideoCapabilities").mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() =>
+      useModelCapabilities({ projectName: PROJECT, videoBackend: BACKEND, providers: provider() }),
+    );
+    expect(result.current.resolvedVideoBackend).toBe(BACKEND);
+  });
+
   it("unsavedBackend 时不采用服务端回退，时长按未知处理", async () => {
     // 表单里 backend 是未保存候选：服务端返回的仍是已保存模型的时长，采信会把它摆成新候选
     // 的选项，用户能存下新模型不支持的值。

--- a/frontend/src/hooks/useModelCapabilities.ts
+++ b/frontend/src/hooks/useModelCapabilities.ts
@@ -70,6 +70,14 @@ export interface ModelCapabilities {
   /** 经联动约束收窄并升序排列的时长候选；未知为 null。 */
   supportedDurations: number[] | null;
   durationConstraints: DurationConstraints;
+  /**
+   * 时长与约束实际查自哪个 `provider/model`；未知为 null。
+   *
+   * 传入的后端可能是裸 provider（`video_backend: "gemini-aistudio"`，服务端会补全默认视频模型）
+   * 或留空跟随全局默认，此时该值取服务端解析结果。凡按「项目为该后端保存了什么」查项目配置的
+   * 调用点都须用它，否则裸 provider 会被当成 model ID 去查 `model_settings`、读不到实际档位。
+   */
+  resolvedVideoBackend: string | null;
   /** 首帧 / 尾帧生效值（含用户覆盖）；尚未查到或查询失败时为 null（未知），不谎报不支持。 */
   firstFrame: boolean | null;
   lastFrame: boolean | null;
@@ -239,6 +247,7 @@ export function useModelCapabilities({
     rawDurations,
     supportedDurations,
     durationConstraints,
+    resolvedVideoBackend: durationSource?.backend ?? null,
     firstFrame: caps ? caps.first_frame : null,
     lastFrame: caps ? caps.last_frame : null,
     loading,

--- a/frontend/src/hooks/useModelCapabilities.ts
+++ b/frontend/src/hooks/useModelCapabilities.ts
@@ -103,6 +103,41 @@ function narrow(raw: readonly number[], constraints: DurationConstraints, ctx: D
 }
 
 /**
+ * 用 hook 已取到的能力，对另一份联动约束上下文再算一次收窄结果；未知为 null。
+ *
+ * 供上下文按集变化、而能力查询只能在组件顶层做一次的调用点使用——`rawDurations` 与
+ * `durationConstraints` 不随上下文变化，收窄规则仍收在本模块内，不在调用点重新拼一条查表链路。
+ */
+export function narrowDurations(
+  caps: Pick<ModelCapabilities, "rawDurations" | "durationConstraints">,
+  ctx: DurationContext,
+): number[] | null {
+  return caps.rawDurations ? narrow(caps.rawDurations, caps.durationConstraints, ctx) : null;
+}
+
+/**
+ * 已保存时长越界的成因；不越界为 null。
+ *
+ * 成因决定提示该把用户引向哪里：`model` 只能换时长或换模型，`resolution` / `reference` 则是
+ * 改对应设置也能解决。判定顺序即优先级——全集就不含该值时，联动约束是不是也排除它无关紧要。
+ */
+export type DurationOutOfRangeReason = "model" | "reference" | "resolution";
+
+export function durationOutOfRangeReason(
+  saved: number | null | undefined,
+  caps: Pick<ModelCapabilities, "rawDurations" | "supportedDurations" | "durationConstraints">,
+  ctx: DurationContext = {},
+): DurationOutOfRangeReason | null {
+  const { rawDurations, supportedDurations, durationConstraints } = caps;
+  if (saved == null || !supportedDurations || supportedDurations.includes(saved)) return null;
+  if (!rawDurations?.includes(saved)) return "model";
+  const { withReferenceImages } = durationConstraints;
+  if (ctx.usesReferenceImages && withReferenceImages.length > 0 && !withReferenceImages.includes(saved))
+    return "reference";
+  return "resolution";
+}
+
+/**
  * 服务端能力查询。
  *
  * 请求 key 只含「决定结果是否仍可用」的上下文：项目与后端。项目 / 后端一变必须立刻丢弃旧

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -837,6 +837,8 @@ export default {
   'cap_override_effective': 'In effect: {{effective}} (detected: {{detected}})',
   'cap_override_on_unavailable': 'This endpoint does not send end frames, so it cannot be forced on.',
   'duration_incompatible_warning': 'Selected {{value}}s not in model-supported [{{supported}}]',
+  'duration_incompatible_resolution_warning': 'Selected {{value}}s is unavailable at the current resolution — available: [{{supported}}]',
+  'duration_incompatible_reference_warning': 'Selected {{value}}s is unavailable in Reference-to-Video mode — available: [{{supported}}]',
   'duration_seconds_value_text': '{{value}}s',
   'duration_no_options': 'Current model has no configured durations — cannot change',
   'add_model_manually': 'Add model manually',

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -841,6 +841,7 @@ export default {
   'duration_incompatible_reference_warning': 'Selected {{value}}s is unavailable in Reference-to-Video mode — available: [{{supported}}]',
   'duration_seconds_value_text': '{{value}}s',
   'duration_no_options': 'Current model has no configured durations — cannot change',
+  'duration_locked_generating': 'This shot is generating — duration cannot be changed right now',
   'add_model_manually': 'Add model manually',
   'discover_or_add_hint': 'Click "Discover Models" to auto-discover, or',
   'test_connection': 'Test Connection',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -814,6 +814,8 @@ export default {
   'cap_override_effective': 'Giá trị áp dụng: {{effective}} (nhận định: {{detected}})',
   'cap_override_on_unavailable': 'Endpoint này không gửi khung cuối nên không thể buộc bật.',
   'duration_incompatible_warning': '{{value}}s đã chọn không nằm trong [{{supported}}] mà mô hình hỗ trợ',
+  'duration_incompatible_resolution_warning': '{{value}}s đã chọn không khả dụng ở độ phân giải hiện tại — khả dụng: [{{supported}}]',
+  'duration_incompatible_reference_warning': '{{value}}s đã chọn không khả dụng ở chế độ Reference-to-Video — khả dụng: [{{supported}}]',
   'duration_seconds_value_text': '{{value}}s',
   'duration_no_options': 'Mô hình hiện tại không có thời lượng cấu hình — không thể thay đổi',
   'add_model_manually': 'Thêm mô hình thủ công',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -818,6 +818,7 @@ export default {
   'duration_incompatible_reference_warning': '{{value}}s đã chọn không khả dụng ở chế độ Reference-to-Video — khả dụng: [{{supported}}]',
   'duration_seconds_value_text': '{{value}}s',
   'duration_no_options': 'Mô hình hiện tại không có thời lượng cấu hình — không thể thay đổi',
+  'duration_locked_generating': 'Cảnh này đang được tạo — hiện chưa thể thay đổi thời lượng',
   'add_model_manually': 'Thêm mô hình thủ công',
   'discover_or_add_hint': 'Nhấn "Phát hiện mô hình" để tự phát hiện, hoặc',
   'test_connection': 'Kiểm tra kết nối',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -841,6 +841,7 @@ export default {
   'duration_incompatible_reference_warning': '当前秒数 {{value}} 在参考生视频模式下不可用，可选 [{{supported}}]',
   'duration_seconds_value_text': '{{value}} 秒',
   'duration_no_options': '当前模型未配置可用时长，无法修改',
+  'duration_locked_generating': '该镜头正在生成中，暂不能修改时长',
   'add_model_manually': '手动添加模型',
   'discover_or_add_hint': '点击「获取模型列表」自动发现，或',
   'test_connection': '测试连接',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -837,6 +837,8 @@ export default {
   'cap_override_effective': '生效值：{{effective}}（判定：{{detected}}）',
   'cap_override_on_unavailable': '该接口不下传尾帧，无法强制开启。',
   'duration_incompatible_warning': '当前秒数 {{value}} 不在模型支持范围 [{{supported}}] 内',
+  'duration_incompatible_resolution_warning': '当前秒数 {{value}} 在当前分辨率下不可用，可选 [{{supported}}]',
+  'duration_incompatible_reference_warning': '当前秒数 {{value}} 在参考生视频模式下不可用，可选 [{{supported}}]',
   'duration_seconds_value_text': '{{value}} 秒',
   'duration_no_options': '当前模型未配置可用时长，无法修改',
   'add_model_manually': '手动添加模型',

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -6,6 +6,7 @@ import {
   isActiveStatus,
   isOccupyingStatus,
   isResourceBusy,
+  isScriptFileBusy,
   isTerminalStatus,
   selectActiveResourceIds,
   selectHasActiveTaskForScriptFile,
@@ -930,6 +931,43 @@ describe("isResourceBusy", () => {
     expect(isResourceBusy("video", "p1", "u1")).toBe(true);
     expect(isResourceBusy("storyboard", "p1", "u1")).toBe(false);
     expect(isResourceBusy("video", "p2", "u1")).toBe(false);
+  });
+});
+
+describe("isScriptFileBusy", () => {
+  beforeEach(() => {
+    useTasksStore.setState({ tasks: [], optimisticActiveScriptFile: new Set() });
+  });
+
+  it("reads the store snapshot at call time", () => {
+    // 与 isResourceBusy 同理：提交那一刻必须拿最新占用态，而非渲染期捕获的快照。
+    expect(isScriptFileBusy("grid", "episode_1.json", "proj")).toBe(false);
+    useTasksStore.setState({
+      tasks: [
+        task({ task_id: "g1", task_type: "grid", script_file: "episode_1.json", status: "running" }),
+      ],
+    });
+    expect(isScriptFileBusy("grid", "episode_1.json", "proj")).toBe(true);
+  });
+
+  it("normalizes the scripts/ prefix on both sides", () => {
+    // episode 元数据带 scripts/ 前缀、任务行不一定带，两边都要归一后再比。
+    useTasksStore.setState({
+      tasks: [
+        task({ task_id: "g1", task_type: "grid", script_file: "episode_1.json", status: "running" }),
+      ],
+    });
+    expect(isScriptFileBusy("grid", "scripts/episode_1.json", "proj")).toBe(true);
+  });
+
+  it("returns false when scriptFile or projectName is missing", () => {
+    useTasksStore.setState({
+      tasks: [
+        task({ task_id: "g1", task_type: "grid", script_file: "episode_1.json", status: "running" }),
+      ],
+    });
+    expect(isScriptFileBusy("grid", undefined, "proj")).toBe(false);
+    expect(isScriptFileBusy("grid", "episode_1.json", null)).toBe(false);
   });
 });
 

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -566,6 +566,30 @@ export function selectHasActiveTaskForScriptFile(
   return false;
 }
 
+/**
+ * scriptFile 粒度的提交时刻复核入口，与 {@link isResourceBusy} 同构（`getState()` 新鲜读）。
+ *
+ * 存在的理由与 resource 粒度那条相同——渲染时刻的 prop 反映的是上次渲染，store 更新到重渲染
+ * 提交之间用户仍可能点下去。粒度换成 scriptFile 是因为 grid 任务的 resource_id 是 grid_id、
+ * 归不进按分镜 resource_id 的判定（见 {@link selectHasActiveTaskForScriptFile}）。
+ * scriptFile/projectName 缺失时返回 false，与 hook 版同口径。
+ */
+export function isScriptFileBusy(
+  taskType: string,
+  scriptFile: string | undefined | null,
+  projectName: string | undefined | null,
+): boolean {
+  if (!scriptFile || !projectName) return false;
+  const { tasks, optimisticActiveScriptFile } = useTasksStore.getState();
+  return selectHasActiveTaskForScriptFile(
+    tasks,
+    taskType,
+    scriptFile,
+    projectName,
+    optimisticActiveScriptFile,
+  );
+}
+
 /** hook 版 {@link selectHasActiveTaskForScriptFile}；scriptFile/projectName 缺失时返回 false。 */
 export function useHasActiveTaskForScriptFile(
   taskType: string,

--- a/frontend/src/utils/provider-models.test.ts
+++ b/frontend/src/utils/provider-models.test.ts
@@ -157,8 +157,8 @@ describe("lookupProjectVideoResolution", () => {
     ).toBe("720p");
   });
 
-  // null 表示用户未选档位：执行期会落到 provider 兜底档位，但那张表是后端数据、前端不镜像，
-  // 故不替用户假定档位（返回 null → 不收窄）。
+  // null 表示用户未选档位：执行期省略 resolution 参数、供应商按自己的默认档位处理，
+  // 该档位下全集本就合法，故不替用户假定档位（返回 null → 不收窄）。
   it("未配置 / 缺项目 / 空后端一律 null", () => {
     expect(lookupProjectVideoResolution({}, BACKEND)).toBeNull();
     expect(lookupProjectVideoResolution({ model_settings: {} }, BACKEND)).toBeNull();
@@ -166,6 +166,20 @@ describe("lookupProjectVideoResolution", () => {
     expect(lookupProjectVideoResolution({ model_settings: { [BACKEND]: { resolution: "4K" } } }, "")).toBeNull();
     expect(
       lookupProjectVideoResolution({ model_settings: { [BACKEND]: { resolution: null } } }, BACKEND),
+    ).toBeNull();
+  });
+
+  // 新键存在且为 null 是「用户在新设置里清空了档位」，不是「没配过」——旧项目升级后残留的
+  // legacy 值不该把它顶回去，否则前端会按用户已经取消的档位收窄时长选项。
+  it("新键显式 null 时不回退 legacy", () => {
+    expect(
+      lookupProjectVideoResolution(
+        {
+          model_settings: { [BACKEND]: { resolution: null } },
+          video_model_settings: { "veo-3.1-generate-preview": { resolution: "1080p" } },
+        },
+        BACKEND,
+      ),
     ).toBeNull();
   });
 });

--- a/frontend/src/utils/provider-models.test.ts
+++ b/frontend/src/utils/provider-models.test.ts
@@ -183,4 +183,18 @@ describe("lookupProjectVideoResolution", () => {
       ),
     ).toBe("1080p");
   });
+
+  // 后端 `_resolution_from_project` 对新键与 legacy 两层都用真值判断，只归一新键会让
+  // 「空值按未配置处理」在 legacy 上失效。
+  it("legacy 侧的空串同样归一为 null", () => {
+    expect(
+      lookupProjectVideoResolution(
+        {
+          model_settings: { [BACKEND]: { resolution: null } },
+          video_model_settings: { "veo-3.1-generate-preview": { resolution: "" } },
+        },
+        BACKEND,
+      ),
+    ).toBeNull();
+  });
 });

--- a/frontend/src/utils/provider-models.test.ts
+++ b/frontend/src/utils/provider-models.test.ts
@@ -169,9 +169,10 @@ describe("lookupProjectVideoResolution", () => {
     ).toBeNull();
   });
 
-  // 新键存在且为 null 是「用户在新设置里清空了档位」，不是「没配过」——旧项目升级后残留的
-  // legacy 值不该把它顶回去，否则前端会按用户已经取消的档位收窄时长选项。
-  it("新键显式 null 时不回退 legacy", () => {
+  // 新键为空值按「未配置」处理并继续回退 legacy，与后端 `_resolution_from_project` 及保存期的
+  // legacy 迁移（`_migrate_legacy_resolution_on_save` 只在 resolution 有值时清理）同口径。
+  // 三处必须描述同一套语义，否则同一份 project.json 会让工作台呈现执行期实际不接受的时长。
+  it("新键为空值时回退 legacy，与后端读取口径一致", () => {
     expect(
       lookupProjectVideoResolution(
         {
@@ -180,6 +181,6 @@ describe("lookupProjectVideoResolution", () => {
         },
         BACKEND,
       ),
-    ).toBeNull();
+    ).toBe("1080p");
   });
 });

--- a/frontend/src/utils/provider-models.test.ts
+++ b/frontend/src/utils/provider-models.test.ts
@@ -6,6 +6,7 @@ import {
   getCustomProviderModels,
   getProviderModels,
   lookupDurationConstraints,
+  lookupProjectVideoResolution,
 } from "./provider-models";
 
 describe("provider-models fetchers", () => {
@@ -121,5 +122,50 @@ describe("constrainDurations", () => {
   it("keeps the original options when constraints would leave nothing selectable", () => {
     const contradictory = { byResolution: { "720p": [16] }, withReferenceImages: [] };
     expect(constrainDurations([4, 6, 8], contradictory, { resolution: "720p" })).toEqual([4, 6, 8]);
+  });
+});
+
+describe("lookupProjectVideoResolution", () => {
+  const BACKEND = "gemini-aistudio/veo-3.1-generate-preview";
+
+  it("读 model_settings 的 provider/model 复合键", () => {
+    expect(
+      lookupProjectVideoResolution({ model_settings: { [BACKEND]: { resolution: "4K" } } }, BACKEND),
+    ).toBe("4K");
+  });
+
+  // 旧项目的分辨率存在 video_model_settings 下、键是裸 model_id；不回退会让老项目的
+  // 时长候选按「未设分辨率」处理，选到该分辨率下必然被拒的时长。
+  it("回退 legacy video_model_settings 的裸 model_id 键", () => {
+    expect(
+      lookupProjectVideoResolution(
+        { video_model_settings: { "veo-3.1-generate-preview": { resolution: "1080p" } } },
+        BACKEND,
+      ),
+    ).toBe("1080p");
+  });
+
+  it("新键优先于 legacy", () => {
+    expect(
+      lookupProjectVideoResolution(
+        {
+          model_settings: { [BACKEND]: { resolution: "720p" } },
+          video_model_settings: { "veo-3.1-generate-preview": { resolution: "1080p" } },
+        },
+        BACKEND,
+      ),
+    ).toBe("720p");
+  });
+
+  // null 表示用户未选档位：执行期会落到 provider 兜底档位，但那张表是后端数据、前端不镜像，
+  // 故不替用户假定档位（返回 null → 不收窄）。
+  it("未配置 / 缺项目 / 空后端一律 null", () => {
+    expect(lookupProjectVideoResolution({}, BACKEND)).toBeNull();
+    expect(lookupProjectVideoResolution({ model_settings: {} }, BACKEND)).toBeNull();
+    expect(lookupProjectVideoResolution(null, BACKEND)).toBeNull();
+    expect(lookupProjectVideoResolution({ model_settings: { [BACKEND]: { resolution: "4K" } } }, "")).toBeNull();
+    expect(
+      lookupProjectVideoResolution({ model_settings: { [BACKEND]: { resolution: null } } }, BACKEND),
+    ).toBeNull();
   });
 });

--- a/frontend/src/utils/provider-models.ts
+++ b/frontend/src/utils/provider-models.ts
@@ -156,7 +156,9 @@ export function lookupProjectVideoResolution(
   if (fromModelSettings) return fromModelSettings;
   const slashIdx = backend.indexOf("/");
   const modelId = slashIdx === -1 ? backend : backend.slice(slashIdx + 1);
-  return project.video_model_settings?.[modelId]?.resolution ?? null;
+  // legacy 侧同样把空串归一为 null：后端 `_resolution_from_project` 对两层都用真值判断，
+  // 只归一新键会让「空值按未配置处理」在 legacy 上失效。
+  return project.video_model_settings?.[modelId]?.resolution || null;
 }
 
 /** 返回该 (provider, model) 下的分辨率候选 + 是否自定义供应商（决定 picker 模式）。

--- a/frontend/src/utils/provider-models.ts
+++ b/frontend/src/utils/provider-models.ts
@@ -149,10 +149,11 @@ export function lookupProjectVideoResolution(
   backend: string,
 ): string | null {
   if (!project || !backend) return null;
-  // 只在新键完全不存在时回退 legacy：显式 null 是「用户在新设置里清空了档位」，
-  // 旧项目升级后残留的 video_model_settings 值不该把它顶回去。
+  // 空值（null / 空串）按「未配置」处理并继续回退 legacy，与后端 `_resolution_from_project`
+  // 及保存期的 legacy 迁移同口径——这三处必须描述同一套语义，否则同一份 project.json 会让
+  // 工作台呈现执行期实际不接受的时长。
   const fromModelSettings = project.model_settings?.[backend]?.resolution;
-  if (fromModelSettings !== undefined) return fromModelSettings || null;
+  if (fromModelSettings) return fromModelSettings;
   const slashIdx = backend.indexOf("/");
   const modelId = slashIdx === -1 ? backend : backend.slice(slashIdx + 1);
   return project.video_model_settings?.[modelId]?.resolution ?? null;

--- a/frontend/src/utils/provider-models.ts
+++ b/frontend/src/utils/provider-models.ts
@@ -131,6 +131,30 @@ export function constrainDurations(
 export const IMAGE_STANDARD_RESOLUTIONS = ["512px", "1K", "2K", "4K"];
 export const VIDEO_STANDARD_RESOLUTIONS = ["480p", "720p", "1080p", "4K"];
 
+/** 项目里存了分辨率的两种形状：`model_settings` 以 `provider/model` 复合键，legacy 以裸 model_id。 */
+export interface ProjectResolutionSettings {
+  model_settings?: Record<string, { resolution?: string | null }> | null;
+  video_model_settings?: Record<string, { resolution?: string | null }> | null;
+}
+
+/**
+ * 读项目为该视频后端保存的分辨率：`model_settings` → legacy `video_model_settings` → null。
+ *
+ * `backend` 须是生效后端（项目覆盖 ‖ 全局默认），与写入侧同一口径。null 表示用户未选档位，
+ * 执行期会落到 provider 兜底档位——那张兜底表是后端数据，前端不镜像，故此处不替用户假定档位。
+ */
+export function lookupProjectVideoResolution(
+  project: ProjectResolutionSettings | null | undefined,
+  backend: string,
+): string | null {
+  if (!project || !backend) return null;
+  const fromModelSettings = project.model_settings?.[backend]?.resolution;
+  if (fromModelSettings) return fromModelSettings;
+  const slashIdx = backend.indexOf("/");
+  const modelId = slashIdx === -1 ? backend : backend.slice(slashIdx + 1);
+  return project.video_model_settings?.[modelId]?.resolution ?? null;
+}
+
 /** 返回该 (provider, model) 下的分辨率候选 + 是否自定义供应商（决定 picker 模式）。
  *  自定义 provider 路径需要从 endpoint 推 media_type 选标准分辨率集；该 map 由调用方
  *  从 endpoint-catalog-store 读出注入（保持本文件无 store 副作用）。 */

--- a/frontend/src/utils/provider-models.ts
+++ b/frontend/src/utils/provider-models.ts
@@ -140,16 +140,19 @@ export interface ProjectResolutionSettings {
 /**
  * 读项目为该视频后端保存的分辨率：`model_settings` → legacy `video_model_settings` → null。
  *
- * `backend` 须是生效后端（项目覆盖 ‖ 全局默认），与写入侧同一口径。null 表示用户未选档位，
- * 执行期会落到 provider 兜底档位——那张兜底表是后端数据，前端不镜像，故此处不替用户假定档位。
+ * `backend` 须是**已解析**的 `provider/model`（裸 provider 会被当成 model ID、读不到实际档位），
+ * 与写入侧同一口径。null 表示用户未选档位：执行期省略 resolution 参数、供应商按自己的默认档位
+ * 处理，故这里不替用户假定档位，与后端约束求值同口径。
  */
 export function lookupProjectVideoResolution(
   project: ProjectResolutionSettings | null | undefined,
   backend: string,
 ): string | null {
   if (!project || !backend) return null;
+  // 只在新键完全不存在时回退 legacy：显式 null 是「用户在新设置里清空了档位」，
+  // 旧项目升级后残留的 video_model_settings 值不该把它顶回去。
   const fromModelSettings = project.model_settings?.[backend]?.resolution;
-  if (fromModelSettings) return fromModelSettings;
+  if (fromModelSettings !== undefined) return fromModelSettings || null;
   const slashIdx = backend.indexOf("/");
   const modelId = slashIdx === -1 ? backend : backend.slice(slashIdx + 1);
   return project.video_model_settings?.[modelId]?.resolution ?? null;

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -244,20 +244,33 @@ def constrain_durations(
     return allowed or list(durations)
 
 
-def _resolution_for_constraints(project: dict, provider_id: str | None, model_id: str | None) -> str | None:
-    """约束求值用的生效分辨率：项目覆盖 → provider 兜底档位。
+def _resolution_for_constraints(
+    project: dict, provider_id: str | None, model_id: str | None, *, generation_mode: str | None
+) -> str | None:
+    """约束求值用的生效分辨率：项目已保存的档位，参考视频模式下补 provider 兜底。
 
-    与下传给 SDK 的 resolution 不同源。``None`` 的语义是「调用时不传 resolution 参数」
-    （见 ``docs/adr/0019``），执行期实际落在 provider 兜底档位上（见 ``get_provider_fallback``），
-    故约束求值必须按那个档位算——否则「用户没配分辨率」会被当成「不受约束」，而 Veo 恰好兜底
-    到 1080p、只接受 8 秒。自定义供应商的 DB 默认档位不在此解析：该类供应商不声明联动约束，
-    解析出来也不改变结果，不值得为此把纯函数变成 async。
+    联动约束必须按**执行期真正下发给供应商的那个档位**求值，而两条视频路径下发的值不同源：
+
+    - 普通图生视频路径下发 ``resolve_resolution()`` 的原始结果，``None`` 即「不传 resolution
+      参数」（见 ``docs/adr/0019``），供应商按自己的默认档位处理——Veo 省略时是 720p，4/6/8 全
+      合法。此时按兜底档位求值会凭空收窄：未配置分辨率的 Veo 项目剧本节奏会被锁死 8 秒，而
+      供应商本来就接受 4/6 秒。故未配置时返回 ``None``（不施加分辨率约束）。
+    - 参考视频路径是唯一需要非空档位的调用方，执行期取 ``resolution_or_fallback``（见
+      ``server/services/reference_video_tasks.py``），故这里同样补 ``get_provider_fallback``，
+      让约束与实际下发的档位描述同一件事。
+
+    ``get_provider_fallback`` 本身是费用估算与参考视频路径的内部口径，不是「用户没配分辨率时
+    的生效值」，不可当作后者施加到普通路径上。自定义供应商的 DB 默认档位不在此解析：该类
+    供应商不声明联动约束，解析出来也不改变结果，不值得为此把纯函数变成 async。
 
     返回值只用于约束求值，不得作为 SDK 的 resolution 参数下传。
     """
     if not provider_id or not model_id:
         return None
-    return _resolution_from_project(project, provider_id, model_id) or get_provider_fallback(provider_id)
+    saved = _resolution_from_project(project, provider_id, model_id)
+    if saved or generation_mode != "reference_video":
+        return saved
+    return get_provider_fallback(provider_id)
 
 
 def constrain_durations_for_project(
@@ -273,7 +286,7 @@ def constrain_durations_for_project(
         provider_id,
         model_id,
         durations,
-        resolution=_resolution_for_constraints(project, provider_id, model_id),
+        resolution=_resolution_for_constraints(project, provider_id, model_id, generation_mode=generation_mode),
         uses_reference_images=generation_mode == "reference_video",
     )
 

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lib.backend_assembly.specs import get_provider_spec
-from lib.config.registry import PROVIDER_REGISTRY, default_model_for_provider
+from lib.config.registry import PROVIDER_REGISTRY, default_model_for_provider, model_info_for
 from lib.config.service import (
     _DEFAULT_AUDIO_BACKEND,
     _DEFAULT_IMAGE_BACKEND,
@@ -204,6 +204,78 @@ def _resolution_from_project(project: dict, provider_id: str, model_id: str) -> 
     if legacy:
         return legacy
     return None
+
+
+# ---------------------------------------------------------------------------
+# 时长联动约束
+#
+# 时长并非只由 supported_durations 决定：部分型号（当前是 Veo 全系与 MiniMax 海螺）在高分辨率
+# 或参考图路径下把时长收窄到单一取值，声明在 registry 的 ModelInfo 上（单一真相源）。这里是
+# 后端唯一的消费入口——候选集合在交给 LLM、写进动态 schema、或作为默认值取首项之前都经此收窄，
+# 否则产出的时长在执行期必然被 backend 拒。
+# ---------------------------------------------------------------------------
+
+
+def constrain_durations(
+    provider_id: str | None,
+    model_id: str | None,
+    durations: list[int],
+    *,
+    resolution: str | None = None,
+    uses_reference_images: bool = False,
+) -> list[int]:
+    """按型号声明的「分辨率↔时长」「参考图↔时长」约束收窄候选。
+
+    两条约束各自独立触发、可同时生效，取交集。无声明、型号不在注册表（自定义供应商不表达
+    这类约束）、或交集为空时返回原候选——空集说明声明之间自相矛盾，清空候选会让上游拿不到
+    任何可用时长，而执行期仍有 backend 校验兜底。
+    """
+    if not durations:
+        return durations
+    model_info = model_info_for(provider_id, model_id) if provider_id and model_id else None
+    if model_info is None:
+        return durations
+    allowed = list(durations)
+    if uses_reference_images and model_info.reference_image_durations:
+        allowed = [d for d in allowed if d in model_info.reference_image_durations]
+    by_resolution = model_info.duration_resolution_constraints.get(resolution.strip().lower()) if resolution else None
+    if by_resolution:
+        allowed = [d for d in allowed if d in by_resolution]
+    return allowed or list(durations)
+
+
+def _resolution_for_constraints(project: dict, provider_id: str | None, model_id: str | None) -> str | None:
+    """约束求值用的生效分辨率：项目覆盖 → provider 兜底档位。
+
+    与下传给 SDK 的 resolution 不同源。``None`` 的语义是「调用时不传 resolution 参数」
+    （见 ``docs/adr/0019``），执行期实际落在 provider 兜底档位上（见 ``get_provider_fallback``），
+    故约束求值必须按那个档位算——否则「用户没配分辨率」会被当成「不受约束」，而 Veo 恰好兜底
+    到 1080p、只接受 8 秒。自定义供应商的 DB 默认档位不在此解析：该类供应商不声明联动约束，
+    解析出来也不改变结果，不值得为此把纯函数变成 async。
+
+    返回值只用于约束求值，不得作为 SDK 的 resolution 参数下传。
+    """
+    if not provider_id or not model_id:
+        return None
+    return _resolution_from_project(project, provider_id, model_id) or get_provider_fallback(provider_id)
+
+
+def constrain_durations_for_project(
+    project: dict,
+    durations: list[int],
+    *,
+    provider_id: str | None,
+    model_id: str | None,
+    generation_mode: str | None,
+) -> list[int]:
+    """按项目当前配置收窄时长候选：分辨率取生效档位，参考图约束按 ``generation_mode`` 判定。"""
+    return constrain_durations(
+        provider_id,
+        model_id,
+        durations,
+        resolution=_resolution_for_constraints(project, provider_id, model_id),
+        uses_reference_images=generation_mode == "reference_video",
+    )
 
 
 class VisionCapabilityError(ValueError):

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -280,14 +280,22 @@ def constrain_durations_for_project(
     provider_id: str | None,
     model_id: str | None,
     generation_mode: str | None,
+    uses_reference_images: bool | None = None,
 ) -> list[int]:
-    """按项目当前配置收窄时长候选：分辨率取生效档位，参考图约束按 ``generation_mode`` 判定。"""
+    """按项目当前配置收窄时长候选：分辨率取生效档位，参考图约束按是否真的带参考图判定。
+
+    ``uses_reference_images`` 缺省时退回「生成模式即参考视频」的近似判定。调用方能看到本次
+    实际的参考图情况时应显式传入：参考视频路径允许单元不带任何引用，执行层与 backend 都只在
+    ``reference_images`` 非空时施加该约束，按模式一刀切会把无引用单元本可申请的档位也收掉。
+    """
     return constrain_durations(
         provider_id,
         model_id,
         durations,
         resolution=_resolution_for_constraints(project, provider_id, model_id, generation_mode=generation_mode),
-        uses_reference_images=generation_mode == "reference_video",
+        uses_reference_images=(
+            generation_mode == "reference_video" if uses_reference_images is None else uses_reference_images
+        ),
     )
 
 

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -194,7 +194,7 @@ class ScriptGenerator:
         # 透传 utterances / source_text 等非视觉字段。reference_video 路径不入此分支（用 video_units）；
         # content_mode 非 narration（drama 或脏值）走 step2 drama 形状。
         if gen_mode != "reference_video" and self.content_mode != "narration":
-            return await self._generate_drama_step2(episode, output_filename)
+            return await self._generate_drama_step2(episode, output_filename, gen_mode=gen_mode)
 
         caps = await self._fetch_video_capabilities()
 
@@ -258,7 +258,7 @@ class ScriptGenerator:
 
         return await self._generate_and_save(prompt, schema, episode, output_filename, narration_step1=narration_step1)
 
-    async def _generate_drama_step2(self, episode: int, output_filename: str | None) -> Path:
+    async def _generate_drama_step2(self, episode: int, output_filename: str | None, *, gen_mode: str) -> Path:
         """drama 两段式 step2：读 step1 结构化内容 → LLM 仅出视觉层 → 按 scene_id 合并 → 落盘。
 
         非视觉字段（utterances / source_text / characters_in_scene / 时长 / 边界）一律取自 step1 内容、
@@ -269,6 +269,7 @@ class ScriptGenerator:
         content = self._load_drama_step1_content(episode)
         raw_scenes = content.get("scenes")
         content_scenes: list = raw_scenes if isinstance(raw_scenes, list) else []
+        await self._assert_drama_step1_durations(content_scenes, gen_mode=gen_mode)
 
         logger.info("正在生成第 %d 集剧本（drama step2 视觉层）...", episode)
         result = await self.generator.generate(
@@ -293,6 +294,30 @@ class ScriptGenerator:
         self._quality_probe(script_data, episode)
         logger.info("剧本已保存至 %s", output_path)
         return output_path
+
+    async def _assert_drama_step1_durations(self, content_scenes: list, *, gen_mode: str) -> None:
+        """校验 drama step1 已定场景时长在当前能力集合内，越界 fail-loud。
+
+        与 narration（``_load_narration_step1``）、reference_video（``_load_reference_step1``）
+        对称：drama 的时长同样由 step1 定稿、step2 只出视觉层并原样透传，而落盘前的静态校验只
+        要求正整数。缺这道校验时，step1 在某个分辨率下拆好、随后项目切到约束更严的分辨率再跑
+        step2，越界时长会一路存进剧本，直到视频入队才被拒。
+        """
+        supported = self._resolve_supported_durations(await self._fetch_video_capabilities(), gen_mode=gen_mode)
+        allowed = {int(d) for d in supported}
+        bad = sorted(
+            {
+                int(scene["duration_seconds"])
+                for scene in content_scenes
+                if isinstance(scene, dict) and isinstance(scene.get("duration_seconds"), int)
+            }
+            - allowed
+        )
+        if bad:
+            raise ValueError(
+                f"step1 已定场景时长非法（不在 {sorted(allowed)} 内）: {bad}；"
+                f"当前分辨率与型号下这些时长不可用，请重跑 normalize-drama-script 按当前能力规范化"
+            )
 
     def _build_drama_step2_prompt(self, content_scenes: list, episode: int) -> str:
         """构建 drama step2（视觉层）prompt：把 step1 内容渲染为输入，仅求 image_prompt / video_prompt。"""

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -333,9 +333,9 @@ class ScriptGenerator:
 
         取值按**最终 schema 的归一化口径**（``TypeAdapter(int)``，即 ``DramaSceneContent``
         的非 strict ``int`` 字段所用的那套）而非 ``isinstance(..., int)``：后者会把 ``"4"``
-        与 ``4.0`` 整个跳过，而它们会被归一成 4 存进剧本，等于给越界值开了一条绕路。缺键同理
-        取该字段的声明默认值——不填不代表不校验，落盘时补的正是这个默认值。归一化失败（如
-        ``"abc"``）不在此报错，交给落盘前的静态校验统一 fail-loud。
+        与 ``4.0`` 整个跳过，而它们会被归一成 4 存进剧本，等于给越界值开了一条绕路。缺键与显式
+        ``null`` 同取该字段的声明默认值——不填不代表不校验，落盘时补的正是这个默认值。归一化
+        失败（如 ``"abc"``）不在此报错，交给落盘前的静态校验统一 fail-loud。
         """
         supported = self._resolve_supported_durations(await self._fetch_video_capabilities(), gen_mode=gen_mode)
         allowed = {int(d) for d in supported}
@@ -343,8 +343,9 @@ class ScriptGenerator:
         for scene in content_scenes:
             if not isinstance(scene, dict):
                 continue
+            raw = scene.get("duration_seconds")
             try:
-                seen.add(_DURATION_ADAPTER.validate_python(scene.get("duration_seconds", _DRAMA_DEFAULT_DURATION)))
+                seen.add(_DURATION_ADAPTER.validate_python(_DRAMA_DEFAULT_DURATION if raw is None else raw))
             except ValidationError:
                 continue
         bad = sorted(seen - allowed)

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -12,7 +12,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Optional
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 
 from lib.config.registry import PROVIDER_REGISTRY
@@ -38,6 +38,7 @@ from lib.script_models import (
     AD_TARGET_DURATION_DRIFT_THRESHOLD,
     AdEpisodeScript,
     DramaEpisodeScript,
+    DramaSceneContent,
     DramaVisualScript,
     NarrationEpisodeScript,
     NarrationStep1Draft,
@@ -57,6 +58,11 @@ from lib.text_generator import TextGenerator
 from lib.text_utils import strip_json_code_fences
 
 logger = logging.getLogger(__name__)
+
+# drama step1 时长的归一化口径：与 DramaSceneContent.duration_seconds（非 strict int）同一套，
+# 避免校验侧与落盘侧对 "4" / 4.0 这类取值判断不一致。默认值也取字段声明，不另写字面量。
+_DURATION_ADAPTER = TypeAdapter(int)
+_DRAMA_DEFAULT_DURATION = DramaSceneContent.model_fields["duration_seconds"].default
 
 # 集号前缀正则：仅匹配 `E{数字}` + 紧随 S/U（segment/scene 用 S，video_unit 用 U），
 # 保留后缀（如 `E1S03_2` → `E2S03_2`）。设计契约见 lib/script_models.py。
@@ -302,17 +308,24 @@ class ScriptGenerator:
         对称：drama 的时长同样由 step1 定稿、step2 只出视觉层并原样透传，而落盘前的静态校验只
         要求正整数。缺这道校验时，step1 在某个分辨率下拆好、随后项目切到约束更严的分辨率再跑
         step2，越界时长会一路存进剧本，直到视频入队才被拒。
+
+        取值按**最终 schema 的归一化口径**（``TypeAdapter(int)``，即 ``DramaSceneContent``
+        的非 strict ``int`` 字段所用的那套）而非 ``isinstance(..., int)``：后者会把 ``"4"``
+        与 ``4.0`` 整个跳过，而它们会被归一成 4 存进剧本，等于给越界值开了一条绕路。缺键同理
+        取该字段的声明默认值——不填不代表不校验，落盘时补的正是这个默认值。归一化失败（如
+        ``"abc"``）不在此报错，交给落盘前的静态校验统一 fail-loud。
         """
         supported = self._resolve_supported_durations(await self._fetch_video_capabilities(), gen_mode=gen_mode)
         allowed = {int(d) for d in supported}
-        bad = sorted(
-            {
-                int(scene["duration_seconds"])
-                for scene in content_scenes
-                if isinstance(scene, dict) and isinstance(scene.get("duration_seconds"), int)
-            }
-            - allowed
-        )
+        seen: set[int] = set()
+        for scene in content_scenes:
+            if not isinstance(scene, dict):
+                continue
+            try:
+                seen.add(_DURATION_ADAPTER.validate_python(scene.get("duration_seconds", _DRAMA_DEFAULT_DURATION)))
+            except ValidationError:
+                continue
+        bad = sorted(seen - allowed)
         if bad:
             raise ValueError(
                 f"step1 已定场景时长非法（不在 {sorted(allowed)} 内）: {bad}；"

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 
 from lib.config.registry import PROVIDER_REGISTRY
-from lib.config.resolver import ConfigResolver
+from lib.config.resolver import ConfigResolver, constrain_durations_for_project
 from lib.db import async_session_factory
 from lib.episode_paths import (
     REFERENCE_VIDEO_STEP1_FILENAME,
@@ -207,14 +207,17 @@ class ScriptGenerator:
 
         # 解析一次时长能力：reference 据此构造 duration 枚举硬约束 schema；
         # narration 两段式用于校验 step1 各片段时长成员合法（step2 不再产出时长）。
-        supported_durations = self._resolve_supported_durations(caps)
+        supported_durations = self._resolve_supported_durations(caps, gen_mode=gen_mode)
 
         # narration 走两段式：step1 结构化片段透传内容层（novel_text 等），step2 仅产视觉层、
         # 按 segment_id 合并回 step1。非 narration 走单段（step1 markdown 直喂 LLM）。
         narration_step1: list[dict] | None = None
 
         if gen_mode == "reference_video":
-            step1_units = self._load_reference_step1(episode, supported_durations)
+            # 单 shot 时长按未收窄的全集校验：shot 是同一段 clip 内的时间编排、不单独发给供应商，
+            # 受联动约束的是它们的和（unit 总时长）。用收窄集合校验 shot 会连 clip 内的节奏一起
+            # 卡死（Veo 1080p 下每个 shot 都得是 8 秒，凑不出 4+4），而约束并不要求这一点。
+            step1_units = self._load_reference_step1(episode, self._resolve_raw_supported_durations(caps))
             prompt = build_reference_video_prompt(
                 project_overview=self.project_json.get("overview", {}),
                 style=self.project_json.get("style", ""),
@@ -225,7 +228,7 @@ class ScriptGenerator:
                 step1_units=step1_units,
                 supported_durations=supported_durations,
                 max_refs=self._resolve_max_refs(caps),
-                max_duration=self._resolve_max_duration(caps),
+                max_duration=self._resolve_max_duration(caps, gen_mode=gen_mode),
                 aspect_ratio=self._resolve_aspect_ratio(),
                 episode=episode,
             )
@@ -392,7 +395,7 @@ class ScriptGenerator:
             schema: type = build_ad_reference_episode_script_model()
         else:
             caps = await self._fetch_video_capabilities()
-            supported = self._resolve_supported_durations(caps)
+            supported = self._resolve_supported_durations(caps, gen_mode=gen_mode)
             schema = build_episode_script_model("ad", supported)
         return self._build_ad_prompt(episode, gen_mode, supported), schema
 
@@ -469,7 +472,7 @@ class ScriptGenerator:
         props = props if isinstance(props, dict) else {}
 
         if gen_mode == "reference_video":
-            supported_durations = self._resolve_supported_durations(caps)
+            supported_durations = self._resolve_supported_durations(caps, gen_mode=gen_mode)
             return build_reference_video_prompt(
                 project_overview=self.project_json.get("overview", {}),
                 style=self.project_json.get("style", ""),
@@ -477,10 +480,11 @@ class ScriptGenerator:
                 characters=characters,
                 scenes=scenes,
                 props=props,
-                step1_units=self._load_reference_step1(episode, supported_durations),
+                # 单 shot 按全集校验（见 generate() 同位置说明）。
+                step1_units=self._load_reference_step1(episode, self._resolve_raw_supported_durations(caps)),
                 supported_durations=supported_durations,
                 max_refs=self._resolve_max_refs(caps),
-                max_duration=self._resolve_max_duration(caps),
+                max_duration=self._resolve_max_duration(caps, gen_mode=gen_mode),
                 aspect_ratio=self._resolve_aspect_ratio(),
                 episode=episode,
             )
@@ -493,7 +497,9 @@ class ScriptGenerator:
             characters=characters,
             scenes=scenes,
             props=props,
-            step1_segments=self._load_narration_step1(episode, self._resolve_supported_durations(caps)),
+            step1_segments=self._load_narration_step1(
+                episode, self._resolve_supported_durations(caps, gen_mode=gen_mode)
+            ),
             aspect_ratio=self._resolve_aspect_ratio(),
             episode=episode,
             target_language=self.project_json.get("source_language") or "中文",
@@ -516,8 +522,40 @@ class ScriptGenerator:
             logger.info("video_capabilities 解析失败，将走 project.json fallback：%s", exc)
             return None
 
-    def _resolve_supported_durations(self, caps: dict | None = None) -> list[int]:
-        """从 caps → project.json → registry 三级解析；都拿不到抛 ValueError。"""
+    def _resolve_backend_ids(self, caps: dict | None) -> tuple[str | None, str | None]:
+        """当前视频模型身份：caps → project.json.video_backend；都拿不到为 (None, None)。
+
+        联动约束按型号声明查，故身份要与时长的来源同一个模型：caps 在手时以它为准
+        （后端留空走全局默认、或存值已不在注册表被 resolver 回退时，实际生效的是 caps 里的），
+        否则退到 project.json 自报的 ``video_backend``（与时长的 fallback 链同一层）。
+        """
+        if caps and caps.get("provider_id") and caps.get("model"):
+            return str(caps["provider_id"]), str(caps["model"])
+        video_backend = self.project_json.get("video_backend")
+        if video_backend and isinstance(video_backend, str) and "/" in video_backend:
+            provider_id, model_id = video_backend.split("/", 1)
+            return provider_id, model_id
+        return None, None
+
+    def _resolve_supported_durations(self, caps: dict | None = None, *, gen_mode: str) -> list[int]:
+        """从 caps → project.json → registry 三级解析，再按联动约束收窄；都拿不到抛 ValueError。
+
+        收窄发生在交给 prompt / 动态 schema 之前：``supported_durations`` 是型号的时长全集，
+        不含「分辨率↔时长」「参考图↔时长」两条联动约束。不收窄的话 Veo 项目（兜底分辨率即
+        1080p）的剧本会产出 4/6 秒镜头，到视频入队时才被 backend 拒，用户已无统一纠正入口。
+        """
+        raw = self._resolve_raw_supported_durations(caps)
+        provider_id, model_id = self._resolve_backend_ids(caps)
+        return constrain_durations_for_project(
+            self.project_json,
+            raw,
+            provider_id=provider_id,
+            model_id=model_id,
+            generation_mode=gen_mode,
+        )
+
+    def _resolve_raw_supported_durations(self, caps: dict | None) -> list[int]:
+        """收窄前的时长全集：caps → project.json → registry 三级解析；都拿不到抛 ValueError。"""
         if caps and caps.get("supported_durations"):
             return list(caps["supported_durations"])
         durations = self.project_json.get("_supported_durations")
@@ -535,12 +573,15 @@ class ScriptGenerator:
             f"supported_durations 无法解析：caps={bool(caps)}, video_backend={video_backend!r}；请确保 model 配置完整"
         )
 
-    def _resolve_max_duration(self, caps: dict | None = None) -> int | None:
-        """单次视频生成最长秒数；派生自 max(supported_durations)。"""
-        if caps and caps.get("max_duration") is not None:
-            return int(caps["max_duration"])
+    def _resolve_max_duration(self, caps: dict | None = None, *, gen_mode: str) -> int | None:
+        """单次视频生成最长秒数；派生自 max(收窄后的 supported_durations)。
+
+        取收窄后的集合而非 caps 自带的 ``max_duration``：该值是全集最大值，参考视频模式下
+        它是 unit 总时长上限，若不随联动约束收窄，step1 会拆出总时长超标的 unit，step2 的
+        枚举 schema 再把它判非法——上限与枚举必须描述同一个收窄后的集合。
+        """
         try:
-            durations = self._resolve_supported_durations(caps)
+            durations = self._resolve_supported_durations(caps, gen_mode=gen_mode)
         except ValueError:
             return None
         return max(durations)

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -92,6 +92,18 @@ _METADATA_COUNT_KEY: dict[str, str] = {
 }
 
 
+def _units_use_references(units: list[dict] | None) -> bool | None:
+    """本集 step1 是否存在带引用的 unit；``units`` 为 None（非参考视频路径）时返回 None。
+
+    None 的语义是「交给下游按生成模式近似判定」，与「确定不带参考图」的 False 区分开。
+    参考视频路径允许通用 unit 不带任何引用，执行层与 backend 都只在实际带图时施加
+    「参考图↔时长」约束——整集都无引用时按模式一刀切会收掉本可申请的档位。
+    """
+    if units is None:
+        return None
+    return any(u.get("references") for u in units if isinstance(u, dict))
+
+
 def _rewrite_episode_prefix(rid: object, ep: int) -> object:
     """把 ID 中的 `E\\d+` 前缀强制改写为 `E{ep}`；非字符串或无 E 前缀的原样返回。
 
@@ -211,19 +223,27 @@ class ScriptGenerator:
         props = self.project_json.get("props")
         props = props if isinstance(props, dict) else {}
 
+        # 参考视频路径先读 step1：本集是否真的带参考图决定要不要施加「参考图↔时长」约束。
+        # 单 shot 时长按未收窄的全集校验：shot 是同一段 clip 内的时间编排、不单独发给供应商，
+        # 受联动约束的是它们的和（unit 总时长）。用收窄集合校验 shot 会连 clip 内的节奏一起
+        # 卡死（Veo 1080p 下每个 shot 都得是 8 秒，凑不出 4+4），而约束并不要求这一点。
+        step1_units = (
+            self._load_reference_step1(episode, self._resolve_raw_supported_durations(caps))
+            if gen_mode == "reference_video"
+            else None
+        )
+
         # 解析一次时长能力：reference 据此构造 duration 枚举硬约束 schema；
         # narration 两段式用于校验 step1 各片段时长成员合法（step2 不再产出时长）。
-        supported_durations = self._resolve_supported_durations(caps, gen_mode=gen_mode)
+        supported_durations = self._resolve_supported_durations(
+            caps, gen_mode=gen_mode, uses_reference_images=_units_use_references(step1_units)
+        )
 
         # narration 走两段式：step1 结构化片段透传内容层（novel_text 等），step2 仅产视觉层、
         # 按 segment_id 合并回 step1。非 narration 走单段（step1 markdown 直喂 LLM）。
         narration_step1: list[dict] | None = None
 
-        if gen_mode == "reference_video":
-            # 单 shot 时长按未收窄的全集校验：shot 是同一段 clip 内的时间编排、不单独发给供应商，
-            # 受联动约束的是它们的和（unit 总时长）。用收窄集合校验 shot 会连 clip 内的节奏一起
-            # 卡死（Veo 1080p 下每个 shot 都得是 8 秒，凑不出 4+4），而约束并不要求这一点。
-            step1_units = self._load_reference_step1(episode, self._resolve_raw_supported_durations(caps))
+        if step1_units is not None:
             prompt = build_reference_video_prompt(
                 project_overview=self.project_json.get("overview", {}),
                 style=self.project_json.get("style", ""),
@@ -234,7 +254,9 @@ class ScriptGenerator:
                 step1_units=step1_units,
                 supported_durations=supported_durations,
                 max_refs=self._resolve_max_refs(caps),
-                max_duration=self._resolve_max_duration(caps, gen_mode=gen_mode),
+                max_duration=self._resolve_max_duration(
+                    caps, gen_mode=gen_mode, uses_reference_images=_units_use_references(step1_units)
+                ),
                 aspect_ratio=self._resolve_aspect_ratio(),
                 episode=episode,
             )
@@ -510,7 +532,12 @@ class ScriptGenerator:
         props = props if isinstance(props, dict) else {}
 
         if gen_mode == "reference_video":
-            supported_durations = self._resolve_supported_durations(caps, gen_mode=gen_mode)
+            # 单 shot 按全集校验、参考图约束按本集实际引用判定（见 generate() 同位置说明）。
+            step1_units = self._load_reference_step1(episode, self._resolve_raw_supported_durations(caps))
+            uses_refs = _units_use_references(step1_units)
+            supported_durations = self._resolve_supported_durations(
+                caps, gen_mode=gen_mode, uses_reference_images=uses_refs
+            )
             return build_reference_video_prompt(
                 project_overview=self.project_json.get("overview", {}),
                 style=self.project_json.get("style", ""),
@@ -518,11 +545,10 @@ class ScriptGenerator:
                 characters=characters,
                 scenes=scenes,
                 props=props,
-                # 单 shot 按全集校验（见 generate() 同位置说明）。
-                step1_units=self._load_reference_step1(episode, self._resolve_raw_supported_durations(caps)),
+                step1_units=step1_units,
                 supported_durations=supported_durations,
                 max_refs=self._resolve_max_refs(caps),
-                max_duration=self._resolve_max_duration(caps, gen_mode=gen_mode),
+                max_duration=self._resolve_max_duration(caps, gen_mode=gen_mode, uses_reference_images=uses_refs),
                 aspect_ratio=self._resolve_aspect_ratio(),
                 episode=episode,
             )
@@ -575,12 +601,17 @@ class ScriptGenerator:
             return provider_id, model_id
         return None, None
 
-    def _resolve_supported_durations(self, caps: dict | None = None, *, gen_mode: str) -> list[int]:
+    def _resolve_supported_durations(
+        self, caps: dict | None = None, *, gen_mode: str, uses_reference_images: bool | None = None
+    ) -> list[int]:
         """从 caps → project.json → registry 三级解析，再按联动约束收窄；都拿不到抛 ValueError。
 
         收窄发生在交给 prompt / 动态 schema 之前：``supported_durations`` 是型号的时长全集，
         不含「分辨率↔时长」「参考图↔时长」两条联动约束。不收窄的话 Veo 项目（兜底分辨率即
         1080p）的剧本会产出 4/6 秒镜头，到视频入队时才被 backend 拒，用户已无统一纠正入口。
+
+        ``uses_reference_images`` 由调用方按本集 step1 的实际引用情况传入；缺省退回按生成模式
+        判定（见 ``constrain_durations_for_project``）。
         """
         raw = self._resolve_raw_supported_durations(caps)
         provider_id, model_id = self._resolve_backend_ids(caps)
@@ -590,6 +621,7 @@ class ScriptGenerator:
             provider_id=provider_id,
             model_id=model_id,
             generation_mode=gen_mode,
+            uses_reference_images=uses_reference_images,
         )
 
     def _resolve_raw_supported_durations(self, caps: dict | None) -> list[int]:
@@ -611,7 +643,9 @@ class ScriptGenerator:
             f"supported_durations 无法解析：caps={bool(caps)}, video_backend={video_backend!r}；请确保 model 配置完整"
         )
 
-    def _resolve_max_duration(self, caps: dict | None = None, *, gen_mode: str) -> int | None:
+    def _resolve_max_duration(
+        self, caps: dict | None = None, *, gen_mode: str, uses_reference_images: bool | None = None
+    ) -> int | None:
         """单次视频生成最长秒数；派生自 max(收窄后的 supported_durations)。
 
         取收窄后的集合而非 caps 自带的 ``max_duration``：该值是全集最大值，参考视频模式下
@@ -619,7 +653,9 @@ class ScriptGenerator:
         枚举 schema 再把它判非法——上限与枚举必须描述同一个收窄后的集合。
         """
         try:
-            durations = self._resolve_supported_durations(caps, gen_mode=gen_mode)
+            durations = self._resolve_supported_durations(
+                caps, gen_mode=gen_mode, uses_reference_images=uses_reference_images
+            )
         except ValueError:
             return None
         return max(durations)

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -223,7 +223,10 @@ class ScriptGenerator:
             # 单 shot 时长按未收窄的全集校验：shot 是同一段 clip 内的时间编排、不单独发给供应商，
             # 受联动约束的是它们的和（unit 总时长）。用收窄集合校验 shot 会连 clip 内的节奏一起
             # 卡死（Veo 1080p 下每个 shot 都得是 8 秒，凑不出 4+4），而约束并不要求这一点。
-            step1_units = self._load_reference_step1(episode, self._resolve_raw_supported_durations(caps))
+            max_duration = self._resolve_max_duration(caps, gen_mode=gen_mode)
+            step1_units = self._load_reference_step1(
+                episode, self._resolve_raw_supported_durations(caps), max_duration=max_duration
+            )
             prompt = build_reference_video_prompt(
                 project_overview=self.project_json.get("overview", {}),
                 style=self.project_json.get("style", ""),
@@ -234,7 +237,7 @@ class ScriptGenerator:
                 step1_units=step1_units,
                 supported_durations=supported_durations,
                 max_refs=self._resolve_max_refs(caps),
-                max_duration=self._resolve_max_duration(caps, gen_mode=gen_mode),
+                max_duration=max_duration,
                 aspect_ratio=self._resolve_aspect_ratio(),
                 episode=episode,
             )
@@ -518,8 +521,12 @@ class ScriptGenerator:
                 characters=characters,
                 scenes=scenes,
                 props=props,
-                # 单 shot 按全集校验（见 generate() 同位置说明）。
-                step1_units=self._load_reference_step1(episode, self._resolve_raw_supported_durations(caps)),
+                # 单 shot 按全集校验成员、另按当前 unit 上限设天花板（见 generate() 同位置说明）。
+                step1_units=self._load_reference_step1(
+                    episode,
+                    self._resolve_raw_supported_durations(caps),
+                    max_duration=self._resolve_max_duration(caps, gen_mode=gen_mode),
+                ),
                 supported_durations=supported_durations,
                 max_refs=self._resolve_max_refs(caps),
                 max_duration=self._resolve_max_duration(caps, gen_mode=gen_mode),
@@ -681,14 +688,17 @@ class ScriptGenerator:
 
         return step1_path.read_text(encoding="utf-8")
 
-    def _load_reference_step1(self, episode: int, supported_durations: list[int]) -> list[dict]:
+    def _load_reference_step1(
+        self, episode: int, supported_durations: list[int], *, max_duration: int | None = None
+    ) -> list[dict]:
         """加载并校验 reference_video step1 结构化中间文件 ``step1_reference_units.json``。
 
         返回 unit dict 列表（unit_id / shots / references），供 step2 prompt 渲染
         （``render_reference_units_for_step2``）作唯一基底——step2 不解析自由文本。
         校验：结构合法（``ReferenceStep1Draft``）、units 非空、unit_id 唯一、
         shot ``duration`` ∈ ``supported_durations``（与拆分工具的 response_schema 同口径，
-        防手工编辑漂移出非法时长）。仅存在结构化前的旧 ``step1_reference_units.md`` 时给
+        防手工编辑漂移出非法时长）、且不超过 ``max_duration``（当前 unit 总时长上限，
+        None 表示未声明、跳过该层）。仅存在结构化前的旧 ``step1_reference_units.md`` 时给
         明确的「重跑拆分」报错——不写 md→json 迁移器（旧 md 产于结构化中间态引入前，
         与 narration 同决策）。
         """
@@ -737,6 +747,18 @@ class ScriptGenerator:
         bad = sorted({s["duration"] for u in units for s in u["shots"] if s["duration"] not in allowed})
         if bad:
             raise ValueError(f"step1_reference_units.json shot duration 非法（不在 {sorted(allowed)} 内）: {bad}")
+
+        # 单 shot 成员按全集判，但它仍不得超过当前 unit 总时长上限：shot 之和就是发给供应商的
+        # unit 总时长，单个 shot 超上限时总和必然超标。step1 在宽松分辨率下拆好、随后切到约束
+        # 更严的分辨率再跑 step2，越界 shot 会让 step2 要么静默改写已定的镜头节奏、要么凑不出
+        # 枚举 schema 要求的总时长而失败——与 narration / drama 的过期 step1 同样明确要求重拆。
+        if max_duration is not None:
+            over = sorted({s["duration"] for u in units for s in u["shots"] if s["duration"] > max_duration})
+            if over:
+                raise ValueError(
+                    f"step1_reference_units.json shot duration 超过当前 unit 总时长上限 {max_duration} 秒: {over}；"
+                    "当前分辨率与型号下拆分已过期，请重跑 split-reference-video-units 按当前能力重拆"
+                )
 
         return units
 

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -223,10 +223,7 @@ class ScriptGenerator:
             # 单 shot 时长按未收窄的全集校验：shot 是同一段 clip 内的时间编排、不单独发给供应商，
             # 受联动约束的是它们的和（unit 总时长）。用收窄集合校验 shot 会连 clip 内的节奏一起
             # 卡死（Veo 1080p 下每个 shot 都得是 8 秒，凑不出 4+4），而约束并不要求这一点。
-            max_duration = self._resolve_max_duration(caps, gen_mode=gen_mode)
-            step1_units = self._load_reference_step1(
-                episode, self._resolve_raw_supported_durations(caps), max_duration=max_duration
-            )
+            step1_units = self._load_reference_step1(episode, self._resolve_raw_supported_durations(caps))
             prompt = build_reference_video_prompt(
                 project_overview=self.project_json.get("overview", {}),
                 style=self.project_json.get("style", ""),
@@ -237,7 +234,7 @@ class ScriptGenerator:
                 step1_units=step1_units,
                 supported_durations=supported_durations,
                 max_refs=self._resolve_max_refs(caps),
-                max_duration=max_duration,
+                max_duration=self._resolve_max_duration(caps, gen_mode=gen_mode),
                 aspect_ratio=self._resolve_aspect_ratio(),
                 episode=episode,
             )
@@ -521,12 +518,8 @@ class ScriptGenerator:
                 characters=characters,
                 scenes=scenes,
                 props=props,
-                # 单 shot 按全集校验成员、另按当前 unit 上限设天花板（见 generate() 同位置说明）。
-                step1_units=self._load_reference_step1(
-                    episode,
-                    self._resolve_raw_supported_durations(caps),
-                    max_duration=self._resolve_max_duration(caps, gen_mode=gen_mode),
-                ),
+                # 单 shot 按全集校验（见 generate() 同位置说明）。
+                step1_units=self._load_reference_step1(episode, self._resolve_raw_supported_durations(caps)),
                 supported_durations=supported_durations,
                 max_refs=self._resolve_max_refs(caps),
                 max_duration=self._resolve_max_duration(caps, gen_mode=gen_mode),
@@ -688,17 +681,14 @@ class ScriptGenerator:
 
         return step1_path.read_text(encoding="utf-8")
 
-    def _load_reference_step1(
-        self, episode: int, supported_durations: list[int], *, max_duration: int | None = None
-    ) -> list[dict]:
+    def _load_reference_step1(self, episode: int, supported_durations: list[int]) -> list[dict]:
         """加载并校验 reference_video step1 结构化中间文件 ``step1_reference_units.json``。
 
         返回 unit dict 列表（unit_id / shots / references），供 step2 prompt 渲染
         （``render_reference_units_for_step2``）作唯一基底——step2 不解析自由文本。
         校验：结构合法（``ReferenceStep1Draft``）、units 非空、unit_id 唯一、
         shot ``duration`` ∈ ``supported_durations``（与拆分工具的 response_schema 同口径，
-        防手工编辑漂移出非法时长）、且不超过 ``max_duration``（当前 unit 总时长上限，
-        None 表示未声明、跳过该层）。仅存在结构化前的旧 ``step1_reference_units.md`` 时给
+        防手工编辑漂移出非法时长）。仅存在结构化前的旧 ``step1_reference_units.md`` 时给
         明确的「重跑拆分」报错——不写 md→json 迁移器（旧 md 产于结构化中间态引入前，
         与 narration 同决策）。
         """
@@ -747,18 +737,6 @@ class ScriptGenerator:
         bad = sorted({s["duration"] for u in units for s in u["shots"] if s["duration"] not in allowed})
         if bad:
             raise ValueError(f"step1_reference_units.json shot duration 非法（不在 {sorted(allowed)} 内）: {bad}")
-
-        # 单 shot 成员按全集判，但它仍不得超过当前 unit 总时长上限：shot 之和就是发给供应商的
-        # unit 总时长，单个 shot 超上限时总和必然超标。step1 在宽松分辨率下拆好、随后切到约束
-        # 更严的分辨率再跑 step2，越界 shot 会让 step2 要么静默改写已定的镜头节奏、要么凑不出
-        # 枚举 schema 要求的总时长而失败——与 narration / drama 的过期 step1 同样明确要求重拆。
-        if max_duration is not None:
-            over = sorted({s["duration"] for u in units for s in u["shots"] if s["duration"] > max_duration})
-            if over:
-                raise ValueError(
-                    f"step1_reference_units.json shot duration 超过当前 unit 总时长上限 {max_duration} 秒: {over}；"
-                    "当前分辨率与型号下拆分已过期，请重跑 split-reference-video-units 按当前能力重拆"
-                )
 
         return units
 

--- a/server/agent_runtime/sdk_tools/_context.py
+++ b/server/agent_runtime/sdk_tools/_context.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from lib.config.resolver import ConfigResolver
+from lib.config.resolver import ConfigResolver, constrain_durations_for_project
 from lib.db import async_session_factory
 from lib.project_manager import ProjectManager
 
@@ -36,17 +36,53 @@ def tool_error(name: str, exc: BaseException, log: list[str] | None = None) -> d
     return {"content": [{"type": "text", "text": text}], "is_error": True}
 
 
-async def fetch_video_caps(project: dict[str, Any]) -> tuple[int | None, list[int]]:
-    """Resolve ``(default_duration, supported_durations)`` for an MCP tool call.
+async def resolve_video_caps(project: dict[str, Any]) -> dict[str, Any]:
+    """Resolve the full video capability dict for an MCP tool call.
 
     Single source of truth for video model capability lookup across SDK MCP
-    tools (``enqueue_videos`` and ``text_generation`` both depend on this).
-    Returns the raw resolved durations; callers decide whether an empty result
-    is a hard error (video generation) or a soft fallback (script normalization).
+    tools. Callers that only need durations should use :func:`fetch_video_caps`;
+    this variant exposes the model identity so the caller can evaluate the
+    duration linkage constraints declared on it.
     """
     resolver = ConfigResolver(async_session_factory)
-    caps = await resolver.video_capabilities_for_project(project)
+    return await resolver.video_capabilities_for_project(project)
+
+
+def constrained_caps_durations(
+    project: dict[str, Any],
+    caps: dict[str, Any],
+    durations: list[int],
+    *,
+    generation_mode: str | None,
+) -> list[int]:
+    """按 caps 里的模型身份对 ``durations`` 施加时长联动约束（见 ``constrain_durations_for_project``）。
+
+    ``durations`` 单独传入而非从 caps 取：调用方对该集合做过自己的软回退 / 过滤，收窄要作用在
+    那个结果上，不能绕回 caps 的原始集合。
+    """
+    return constrain_durations_for_project(
+        project,
+        durations,
+        provider_id=caps.get("provider_id"),
+        model_id=caps.get("model"),
+        generation_mode=generation_mode,
+    )
+
+
+async def fetch_video_caps(
+    project: dict[str, Any], *, generation_mode: str | None = None
+) -> tuple[int | None, list[int]]:
+    """Resolve ``(default_duration, supported_durations)`` for an MCP tool call.
+
+    ``supported_durations`` 已按项目分辨率与 ``generation_mode`` 经时长联动约束收窄：型号声明的
+    全集不含「分辨率↔时长」「参考图↔时长」两条约束，未收窄的集合交给 LLM 会产出执行期必然被拒
+    的时长。``default_duration`` 是用户配置的原样值，成员性由调用方按各自口径判定。
+    Callers decide whether an empty result is a hard error (video generation) or
+    a soft fallback (script normalization).
+    """
+    caps = await resolve_video_caps(project)
     durations = [int(d) for d in caps.get("supported_durations") or []]
+    durations = constrained_caps_durations(project, caps, durations, generation_mode=generation_mode)
     default = caps.get("default_duration")
     default_int = int(default) if isinstance(default, int | float) else None
     return default_int, durations

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -474,9 +474,14 @@ async def _fetch_reference_caps_with_fallback(project: dict[str, Any]) -> tuple[
     （用户配置漂移）按 None 处理，避免 prompt 构建自相矛盾。
 
     ``max_duration`` 是 unit 总时长上限，也就是真正发给供应商的那个值，故取**经时长联动约束
-    收窄后**集合的最大值：不收窄的话（Veo 兜底 1080p 只接受 8 秒、海螺 1080p 只接受 6 秒）
-    step1 会按全集上限拆出总时长超标的 unit，step2 的枚举 schema 再把它判非法。单 shot 时长
-    维持全集：shot 是同一段 clip 内的时间编排、不单独发给供应商，受约束的是它们的和。
+    收窄后**集合的最大值：不收窄的话（海螺 1080p 只接受 6 秒）step1 会按全集上限拆出总时长
+    超标的 unit，step2 的枚举 schema 再把它判非法。
+
+    单 shot 时长**不按收窄后集合取成员**——shot 是同一段 clip 内的时间编排、不单独发给供应商，
+    受约束的是它们的和，按成员收窄会让合法编排（如总时长 8 = 4+4）凑不出来。但超过
+    ``max_duration`` 的候选必须剔除：单 shot 时长必然计入 unit 总和，海螺 1080p 下总时长上限为
+    6 而单 shot 枚举仍留 10，会让 prompt 同时要求「默认 10 秒」与「总时长不超过 6 秒」、schema
+    也放行 10，``_derive_and_validate_reference_units`` 再把含该值的 unit 全判非法。
     """
     try:
         caps = await resolve_video_caps(project)
@@ -491,7 +496,7 @@ async def _fetch_reference_caps_with_fallback(project: dict[str, Any]) -> tuple[
     raw_refs = caps.get("max_reference_images")
     max_refs = int(raw_refs) if isinstance(raw_refs, int | float) else None
     low, high = REFERENCE_SHOT_DURATION_RANGE
-    shot_durations = [d for d in durations if low <= d <= high]
+    shot_durations = [d for d in durations if low <= d <= min(high, max_duration)]
     raw_default = caps.get("default_duration")
     default = int(raw_default) if isinstance(raw_default, int | float) else None
     if default is not None and default not in shot_durations:

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -45,7 +45,13 @@ from lib.script_models import (
 from lib.text_backends.base import DEFAULT_MAX_OUTPUT_TOKENS, TextGenerationRequest, TextTaskType
 from lib.text_generator import TextGenerator
 from lib.text_utils import strip_json_code_fences
-from server.agent_runtime.sdk_tools._context import ToolContext, fetch_video_caps, tool_error
+from server.agent_runtime.sdk_tools._context import (
+    ToolContext,
+    constrained_caps_durations,
+    fetch_video_caps,
+    resolve_video_caps,
+    tool_error,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -316,9 +322,13 @@ async def _fetch_caps_with_fallback(project: dict[str, Any]) -> tuple[int | None
     Soft-fallbacks to ``duration_presets.DEFAULT_FALLBACK`` so the LLM still
     receives a usable duration constraint set if the resolver hiccups —— 与
     自定义供应商写入层的保守默认同一真相源，避免软回退口径含供应商未必支持的时长。
+
+    时长已按项目分辨率经联动约束收窄。参考图约束不在此施加：走参考生视频的项目 step1 用
+    ``split_reference_video_units``（见 ``_fetch_reference_caps_with_fallback``），本 helper
+    服务的 drama normalize / narration 拆分两个工具按分工不服务该路径。
     """
     try:
-        default_int, durations = await fetch_video_caps(project)
+        default_int, durations = await fetch_video_caps(project, generation_mode=None)
     except (FileNotFoundError, ValueError) as exc:
         logger.info("video_capabilities 不可解析，使用 fallback %s：%s", DEFAULT_FALLBACK, exc)
         return None, list(DEFAULT_FALLBACK)
@@ -450,24 +460,27 @@ async def _fetch_reference_caps_with_fallback(project: dict[str, Any]) -> tuple[
     """解析 rv 拆分所需的视频能力：``(default_duration, supported_durations, max_duration, max_refs)``。
 
     与 ``_fetch_caps_with_fallback`` 同口径 best-effort：resolver 故障时回退
-    ``duration_presets.DEFAULT_FALLBACK``、``max_duration`` 取集合最大值（用原始集合，不受下方单
-    shot 过滤影响）、``max_refs`` 视为未声明。返回的 ``supported_durations`` 已与
-    ``REFERENCE_SHOT_DURATION_RANGE`` 求交集——部分供应商（如 vidu/agnes）的单 shot 时长上限
-    超过该静态区间，未过滤会让 step1 产出的 shot 时长在 step2 读回校验（复用同一静态区间）时
-    fail-loud。``default_duration`` 非过滤后集合成员（用户配置漂移）按 None 处理，避免 prompt
-    构建自相矛盾。
+    ``duration_presets.DEFAULT_FALLBACK``、``max_refs`` 视为未声明。返回的
+    ``supported_durations`` 已与 ``REFERENCE_SHOT_DURATION_RANGE`` 求交集——部分供应商
+    （如 vidu/agnes）的单 shot 时长上限超过该静态区间，未过滤会让 step1 产出的 shot 时长在
+    step2 读回校验（复用同一静态区间）时 fail-loud。``default_duration`` 非过滤后集合成员
+    （用户配置漂移）按 None 处理，避免 prompt 构建自相矛盾。
+
+    ``max_duration`` 是 unit 总时长上限，也就是真正发给供应商的那个值，故取**经时长联动约束
+    收窄后**集合的最大值：不收窄的话（Veo 兜底 1080p 只接受 8 秒、海螺 1080p 只接受 6 秒）
+    step1 会按全集上限拆出总时长超标的 unit，step2 的枚举 schema 再把它判非法。单 shot 时长
+    维持全集：shot 是同一段 clip 内的时间编排、不单独发给供应商，受约束的是它们的和。
     """
     try:
-        resolver = ConfigResolver(async_session_factory)
-        caps = await resolver.video_capabilities_for_project(project)
+        caps = await resolve_video_caps(project)
     except Exception as exc:  # noqa: BLE001
         logger.warning("video_capabilities 查询异常，使用 fallback %s：%s", DEFAULT_FALLBACK, exc)
         caps = {}
     durations = [int(d) for d in caps.get("supported_durations") or []]
     if not durations:
         durations = list(DEFAULT_FALLBACK)
-    raw_max = caps.get("max_duration")
-    max_duration = int(raw_max) if isinstance(raw_max, int | float) else max(durations)
+    unit_durations = constrained_caps_durations(project, caps, durations, generation_mode="reference_video")
+    max_duration = max(unit_durations)
     raw_refs = caps.get("max_reference_images")
     max_refs = int(raw_refs) if isinstance(raw_refs, int | float) else None
     low, high = REFERENCE_SHOT_DURATION_RANGE

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -326,6 +326,11 @@ async def _fetch_caps_with_fallback(project: dict[str, Any]) -> tuple[int | None
     时长已按项目分辨率经联动约束收窄。参考图约束不在此施加：走参考生视频的项目 step1 用
     ``split_reference_video_units``（见 ``_fetch_reference_caps_with_fallback``），本 helper
     服务的 drama normalize / narration 拆分两个工具按分工不服务该路径。
+
+    ``default_duration`` 非返回集合成员时按 None 处理（即回到「auto」档，由模型按内容节奏选）：
+    项目存的是用户配置的原样值，收窄后（或软回退到 ``DEFAULT_FALLBACK`` 后）它可能落在集合外，
+    而 ``build_normalize_prompt`` 对非成员 default 是 fail-loud 的——不归 None 会把「已保存的
+    越界默认时长」变成整个工具的硬失败。与 ``_fetch_reference_caps_with_fallback`` 同口径。
     """
     try:
         default_int, durations = await fetch_video_caps(project, generation_mode=None)
@@ -336,7 +341,9 @@ async def _fetch_caps_with_fallback(project: dict[str, Any]) -> tuple[int | None
         logger.warning("video_capabilities 查询异常，使用 fallback %s：%s", DEFAULT_FALLBACK, exc)
         return None, list(DEFAULT_FALLBACK)
     if not durations:
-        return default_int, list(DEFAULT_FALLBACK)
+        durations = list(DEFAULT_FALLBACK)
+    if default_int is not None and default_int not in durations:
+        default_int = None
     return default_int, durations
 
 

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -11,7 +11,8 @@ from pathlib import Path
 from typing import Any
 
 from lib.asset_types import ASSET_SPECS
-from lib.config.registry import PROVIDER_REGISTRY, model_info_for
+from lib.config.registry import PROVIDER_REGISTRY
+from lib.config.resolver import constrain_durations
 from lib.db.base import DEFAULT_USER_ID
 from lib.path_safety import safe_exists, safe_join, try_safe_join
 from lib.project_change_hints import emit_project_change_batch, project_change_source
@@ -154,52 +155,6 @@ def _get_model_default_duration(provider_name: str, model_name: str | None) -> i
             return model_info.supported_durations[0]
     # 自定义供应商或 registry 中无此模型时 fallback
     return 4
-
-
-def constrain_durations_by_resolution(
-    provider_name: str, model_name: str | None, durations: list[int], resolution: str | None
-) -> list[int]:
-    """按型号声明的「分辨率↔时长」约束收窄候选；无声明或交集为空时返回原候选。
-
-    只服务于「未显式指定时长」时的取值：Veo 在 1080p/4k 下只接受 8 秒，而候选全集
-    ``supported_durations`` 首项是 4 秒，直接取首项会让默认设置必然撞上执行期拒绝。
-    显式指定的时长不经此收窄——其合法性仍由 :func:`assert_duration_supported` 与 backend
-    的执行期校验把关，拒绝行为不变。
-    """
-    if not durations or not resolution:
-        return durations
-    model_info = model_info_for(provider_name, model_name) if model_name else None
-    if model_info is None:
-        return durations
-    allowed = model_info.duration_resolution_constraints.get(resolution.strip().lower())
-    if not allowed:
-        return durations
-    narrowed = [d for d in durations if d in allowed]
-    return narrowed or durations
-
-
-def constrain_durations_by_reference_images(
-    provider_name: str, model_name: str | None, durations: list[int]
-) -> list[int]:
-    """按型号声明的「参考图↔时长」约束收窄候选；无声明或交集为空时返回原候选。
-
-    与 :func:`constrain_durations_by_resolution` 并列的第二条条件约束：Veo 3.1 全局支持
-    ``[4, 6, 8]``，但带参考图时只接受 8 秒（``ModelInfo.reference_image_durations``），
-    backend 在执行期对其余取值直接拒绝。带参考图的调用方按全集取值会必然撞上该拒绝。
-
-    空声明的语义是「参考图路径不额外约束时长」，与 backend 同口径——故只在声明非空时收窄，
-    不为未登记型号臆造约束。
-    """
-    if not durations:
-        return durations
-    model_info = model_info_for(provider_name, model_name) if model_name else None
-    if model_info is None:
-        return durations
-    allowed = model_info.reference_image_durations
-    if not allowed:
-        return durations
-    narrowed = [d for d in durations if d in allowed]
-    return narrowed or durations
 
 
 def assert_duration_supported(duration: int | float | str, supported_durations: list[int]) -> None:
@@ -874,10 +829,9 @@ async def execute_video_task(
     if not duration_seconds:
         # 取首项前先按当前分辨率的联动约束收窄：否则 Veo + 1080p/4k 的默认（Auto）设置会取到
         # 4 秒，被 backend 的「该分辨率必须 8 秒」拒绝——UI 已按同一份声明门控，此处不收窄
-        # 就等于默认配置必然失败。
-        candidates = constrain_durations_by_resolution(
-            registry_provider_id, model_name, supported_durations, resolution
-        )
+        # 就等于默认配置必然失败。显式指定的时长不经此收窄，其合法性由 assert_duration_supported
+        # 与 backend 的执行期校验把关。
+        candidates = constrain_durations(registry_provider_id, model_name, supported_durations, resolution=resolution)
         duration_seconds = (
             candidates[0] if candidates else _get_model_default_duration(registry_provider_id, model_name)
         )

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -14,7 +14,7 @@ from typing import Any
 from sqlalchemy.exc import SQLAlchemyError
 
 from lib.asset_types import ASSET_SPECS, BUCKET_KEY, SHEET_KEY
-from lib.config.resolver import ConfigResolver, get_provider_fallback
+from lib.config.resolver import ConfigResolver, constrain_durations, get_provider_fallback
 from lib.db import async_session_factory
 from lib.db.base import DEFAULT_USER_ID
 from lib.path_safety import safe_exists
@@ -34,8 +34,6 @@ from lib.version_manager import VersionManager
 from server.services.generation_context import VideoLaneRequest, resolve_generation_context
 from server.services.generation_tasks import (
     collect_product_references_for_names,
-    constrain_durations_by_reference_images,
-    constrain_durations_by_resolution,
     get_project_manager,
 )
 
@@ -189,13 +187,12 @@ def effective_reference_durations(
     套用它会把 720p 下本可申请的 4 秒错误抬到 8 秒。
 
     ``provider`` 必须是规范 registry provider id（backend 族名不是 registry key）。两条约束
-    都遵循「无声明或交集为空时不收窄」的降级口径（见各自实现），故本函数在能力声明缺位时
-    退化为原全集，不比收窄前更严。
+    都遵循「无声明或交集为空时不收窄」的降级口径（见 :func:`lib.config.resolver.constrain_durations`），
+    故本函数在能力声明缺位时退化为原全集，不比收窄前更严。
     """
-    narrowed = (
-        constrain_durations_by_reference_images(provider, model, durations) if with_reference_images else durations
+    return constrain_durations(
+        provider, model, durations, resolution=resolution, uses_reference_images=with_reference_images
     )
-    return constrain_durations_by_resolution(provider, model, narrowed, resolution)
 
 
 async def precheck_unit_duration_slot(project: dict, unit: dict, ad_shots: list[dict] | None) -> DurationSlot:

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1775,6 +1775,7 @@ async def test_fetch_caps_with_fallback_uses_write_layer_default(monkeypatch) ->
     assert durations == DEFAULT_FALLBACK
 
 
+@pytest.mark.unit
 async def test_fetch_caps_with_fallback_drops_out_of_range_default(monkeypatch) -> None:
     """收窄后落在集合外的已保存 default_duration 归 None（回到 auto 档），不拖垮整个工具。
 
@@ -1800,6 +1801,7 @@ async def test_fetch_caps_with_fallback_drops_out_of_range_default(monkeypatch) 
     assert durations == [4, 6, 8]
 
 
+@pytest.mark.unit
 async def test_fetch_video_caps_narrows_durations_by_constraints(monkeypatch) -> None:
     """交给 LLM 的时长集合已按项目分辨率经联动约束收窄。
 
@@ -2676,6 +2678,7 @@ async def test_fetch_reference_caps_with_fallback_clips_shot_durations_to_static
     assert max_refs is None
 
 
+@pytest.mark.unit
 async def test_fetch_reference_caps_with_fallback_narrows_unit_duration_cap(monkeypatch) -> None:
     """unit 总时长上限随联动约束收窄：海螺在 1080p 下只接受 6 秒，全集上限是 10 秒。
 
@@ -2702,6 +2705,7 @@ async def test_fetch_reference_caps_with_fallback_narrows_unit_duration_cap(monk
     assert max_duration == 6
 
 
+@pytest.mark.unit
 async def test_fetch_reference_caps_with_fallback_keeps_sub_cap_shot_durations(monkeypatch) -> None:
     """剔除超上限候选不等于按成员集收窄：Veo 1080p 下总时长须为 8，单 shot 仍保留 4/6。
 

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1766,13 +1766,46 @@ async def test_fetch_caps_with_fallback_uses_write_layer_default(monkeypatch) ->
     from lib.custom_provider.duration_presets import DEFAULT_FALLBACK
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def raising_caps(_p):
+    async def raising_caps(_p, *, generation_mode=None):
         raise ValueError("no provider configured")
 
     monkeypatch.setattr(mod, "fetch_video_caps", raising_caps)
     default, durations = await mod._fetch_caps_with_fallback({})
     assert default is None
     assert durations == DEFAULT_FALLBACK
+
+
+async def test_fetch_video_caps_narrows_durations_by_constraints(monkeypatch) -> None:
+    """交给 LLM 的时长集合已按项目分辨率经联动约束收窄。
+
+    Veo 项目不做任何分辨率配置时执行期落在 provider 兜底档位 1080p 上、只接受 8 秒；
+    不收窄的话 drama / narration 拆分会产出 4/6 秒镜头，视频入队时才被 backend 拒。
+    """
+    from server.agent_runtime.sdk_tools import _context as ctx_mod
+
+    async def _fake_caps(_project):
+        return {
+            "provider_id": "gemini-aistudio",
+            "model": "veo-3.1-generate-preview",
+            "supported_durations": [4, 6, 8],
+            "default_duration": 4,
+        }
+
+    monkeypatch.setattr(ctx_mod, "resolve_video_caps", _fake_caps)
+
+    default, durations = await ctx_mod.fetch_video_caps({})
+    assert durations == [8]
+    # default_duration 原样返回（用户配置值），成员性由调用方按各自口径判定
+    assert default == 4
+
+    # 项目显式选了无声明的分辨率：不收窄，与改动前一致
+    project = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}}}
+    _default, durations = await ctx_mod.fetch_video_caps(project)
+    assert durations == [4, 6, 8]
+
+    # 参考图路径：即便分辨率无声明也收窄
+    _default, durations = await ctx_mod.fetch_video_caps(project, generation_mode="reference_video")
+    assert durations == [8]
 
 
 async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext, monkeypatch) -> None:
@@ -2597,21 +2630,44 @@ async def test_fetch_reference_caps_with_fallback_clips_shot_durations_to_static
     的 shot 时长会在 step2 读回校验（复用同一静态区间的 Shot 模型）时 fail-loud。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    class _FakeResolver:
-        def __init__(self, _factory):
-            pass
+    async def _fake_caps(_project):
+        return {"supported_durations": [1, 8, 16, 18], "max_duration": 18, "default_duration": 16}
 
-        async def video_capabilities_for_project(self, _project):
-            return {"supported_durations": [1, 8, 16, 18], "max_duration": 18, "default_duration": 16}
-
-    monkeypatch.setattr(mod, "ConfigResolver", _FakeResolver)
+    monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
 
     default, durations, max_duration, max_refs = await mod._fetch_reference_caps_with_fallback({})
 
     assert durations == [1, 8]
-    assert max_duration == 18  # 单 unit 总时长上限沿用 resolver 原始声明，不受单 shot 过滤影响
+    # 单 unit 总时长上限取收窄后集合的最大值；该型号身份不可解析（无联动约束可查），
+    # 收窄是恒等变换，故仍是原始声明的 18，不受单 shot 过滤影响。
+    assert max_duration == 18
     assert default is None  # 16 已被过滤掉，非法 default 归 None
     assert max_refs is None
+
+
+async def test_fetch_reference_caps_with_fallback_narrows_unit_duration_cap(monkeypatch) -> None:
+    """unit 总时长上限随联动约束收窄：海螺在 1080p 下只接受 6 秒，全集上限是 10 秒。
+
+    不收窄的话 step1 会按 10 秒拆出 unit，step2 的枚举 schema 再把它判非法。
+    单 shot 时长仍是全集——shot 不单独发给供应商，受约束的是它们的和。
+    """
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    async def _fake_caps(_project):
+        return {
+            "provider_id": "minimax",
+            "model": "MiniMax-Hailuo-2.3",
+            "supported_durations": [6, 10],
+            "max_duration": 10,
+            "default_duration": None,
+        }
+
+    monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
+
+    project = {"model_settings": {"minimax/MiniMax-Hailuo-2.3": {"resolution": "1080p"}}}
+    _default, shot_durations, max_duration, _max_refs = await mod._fetch_reference_caps_with_fallback(project)
+    assert shot_durations == [6, 10]
+    assert max_duration == 6
 
 
 async def test_fetch_reference_caps_with_fallback_uses_write_layer_default(monkeypatch) -> None:
@@ -2619,14 +2675,10 @@ async def test_fetch_reference_caps_with_fallback_uses_write_layer_default(monke
     from lib.custom_provider.duration_presets import DEFAULT_FALLBACK
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    class _RaisingResolver:
-        def __init__(self, _factory):
-            pass
+    async def _raising_caps(_project):
+        raise ValueError("no provider configured")
 
-        async def video_capabilities_for_project(self, _project):
-            raise ValueError("no provider configured")
-
-    monkeypatch.setattr(mod, "ConfigResolver", _RaisingResolver)
+    monkeypatch.setattr(mod, "resolve_video_caps", _raising_caps)
     default, durations, max_duration, max_refs = await mod._fetch_reference_caps_with_fallback({})
     assert default is None
     assert durations == DEFAULT_FALLBACK

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1803,8 +1803,8 @@ async def test_fetch_caps_with_fallback_drops_out_of_range_default(monkeypatch) 
 async def test_fetch_video_caps_narrows_durations_by_constraints(monkeypatch) -> None:
     """交给 LLM 的时长集合已按项目分辨率经联动约束收窄。
 
-    Veo 项目不做任何分辨率配置时执行期落在 provider 兜底档位 1080p 上、只接受 8 秒；
-    不收窄的话 drama / narration 拆分会产出 4/6 秒镜头，视频入队时才被 backend 拒。
+    Veo 项目保存 1080p 时只接受 8 秒；不收窄的话 drama / narration 拆分会产出 4/6 秒镜头，
+    视频入队时才被 backend 拒。
     """
     from server.agent_runtime.sdk_tools import _context as ctx_mod
 
@@ -1818,10 +1818,16 @@ async def test_fetch_video_caps_narrows_durations_by_constraints(monkeypatch) ->
 
     monkeypatch.setattr(ctx_mod, "resolve_video_caps", _fake_caps)
 
-    default, durations = await ctx_mod.fetch_video_caps({})
+    project_1080p = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}}
+    default, durations = await ctx_mod.fetch_video_caps(project_1080p)
     assert durations == [8]
     # default_duration 原样返回（用户配置值），成员性由调用方按各自口径判定
     assert default == 4
+
+    # 未配置分辨率：普通路径省略 resolution 参数，供应商按自己的默认档位（Veo 720p）接受 4/6/8，
+    # 故不施加分辨率约束——按 provider 兜底档位收窄会凭空把剧本节奏锁死 8 秒。
+    _default, durations = await ctx_mod.fetch_video_caps({})
+    assert durations == [4, 6, 8]
 
     # 项目显式选了无声明的分辨率：不收窄，与改动前一致
     project = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}}}
@@ -2674,7 +2680,8 @@ async def test_fetch_reference_caps_with_fallback_narrows_unit_duration_cap(monk
     """unit 总时长上限随联动约束收窄：海螺在 1080p 下只接受 6 秒，全集上限是 10 秒。
 
     不收窄的话 step1 会按 10 秒拆出 unit，step2 的枚举 schema 再把它判非法。
-    单 shot 时长仍是全集——shot 不单独发给供应商，受约束的是它们的和。
+    单 shot 枚举同步剔除超过该上限的候选：shot 时长必然计入 unit 总和，留着 10 秒会让 prompt
+    同时要求「可选 10 秒」与「总时长不超过 6 秒」，schema 也放行必被后校验判非法的取值。
     """
     from server.agent_runtime.sdk_tools import text_generation as mod
 
@@ -2691,8 +2698,33 @@ async def test_fetch_reference_caps_with_fallback_narrows_unit_duration_cap(monk
 
     project = {"model_settings": {"minimax/MiniMax-Hailuo-2.3": {"resolution": "1080p"}}}
     _default, shot_durations, max_duration, _max_refs = await mod._fetch_reference_caps_with_fallback(project)
-    assert shot_durations == [6, 10]
+    assert shot_durations == [6]
     assert max_duration == 6
+
+
+async def test_fetch_reference_caps_with_fallback_keeps_sub_cap_shot_durations(monkeypatch) -> None:
+    """剔除超上限候选不等于按成员集收窄：Veo 1080p 下总时长须为 8，单 shot 仍保留 4/6。
+
+    否则每个 shot 都得是 8 秒，凑不出 4+4 这类合法编排，clip 内的节奏被一并卡死，而约束
+    只要求各 shot 之和落在支持集合内。
+    """
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    async def _fake_caps(_project):
+        return {
+            "provider_id": "gemini-aistudio",
+            "model": "veo-3.1-generate-preview",
+            "supported_durations": [4, 6, 8],
+            "max_duration": 8,
+            "default_duration": None,
+        }
+
+    monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
+
+    project = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}}
+    _default, shot_durations, max_duration, _max_refs = await mod._fetch_reference_caps_with_fallback(project)
+    assert shot_durations == [4, 6, 8]
+    assert max_duration == 8
 
 
 async def test_fetch_reference_caps_with_fallback_uses_write_layer_default(monkeypatch) -> None:

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1775,6 +1775,31 @@ async def test_fetch_caps_with_fallback_uses_write_layer_default(monkeypatch) ->
     assert durations == DEFAULT_FALLBACK
 
 
+async def test_fetch_caps_with_fallback_drops_out_of_range_default(monkeypatch) -> None:
+    """收窄后落在集合外的已保存 default_duration 归 None（回到 auto 档），不拖垮整个工具。
+
+    ``build_normalize_prompt`` 对非成员 default 是 fail-loud 的：用户在 720p 下存过 4 秒、
+    改到 1080p 后 Veo 收窄为 [8]，不归 None 会让 normalize_drama_script 直接抛 ValueError。
+    """
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    async def _narrowed_caps(_p, *, generation_mode=None):
+        return 4, [8]
+
+    monkeypatch.setattr(mod, "fetch_video_caps", _narrowed_caps)
+    default, durations = await mod._fetch_caps_with_fallback({})
+    assert default is None
+    assert durations == [8]
+
+    async def _in_range_caps(_p, *, generation_mode=None):
+        return 8, [4, 6, 8]
+
+    monkeypatch.setattr(mod, "fetch_video_caps", _in_range_caps)
+    default, durations = await mod._fetch_caps_with_fallback({})
+    assert default == 8
+    assert durations == [4, 6, 8]
+
+
 async def test_fetch_video_caps_narrows_durations_by_constraints(monkeypatch) -> None:
     """交给 LLM 的时长集合已按项目分辨率经联动约束收窄。
 

--- a/tests/test_config_resolver_resolution.py
+++ b/tests/test_config_resolver_resolution.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from lib.config.resolver import ConfigResolver, get_provider_fallback
+from lib.config.resolver import (
+    ConfigResolver,
+    constrain_durations,
+    constrain_durations_for_project,
+    get_provider_fallback,
+)
 from lib.custom_provider import make_provider_id
 from lib.db.base import Base
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
@@ -207,3 +212,86 @@ def test_get_provider_fallback(provider_id: str | None, expected: str):
 
 def test_get_provider_fallback_custom_default():
     assert get_provider_fallback("unknown", default="720p") == "720p"
+
+
+# ---------------------------------------------------------------------------
+# 时长联动约束
+# ---------------------------------------------------------------------------
+
+_VEO = ("gemini-aistudio", "veo-3.1-generate-preview")  # 声明 {1080p:[8], 4k:[8]} + 参考图 [8]
+_HAILUO = ("minimax", "MiniMax-Hailuo-2.3")  # 声明 {1080p:[6]}，无参考图声明
+
+
+def test_constrain_durations_by_resolution():
+    """已登记且有声明时按声明收窄，大小写不敏感。"""
+    assert constrain_durations(*_VEO, [4, 6, 8], resolution="4K") == [8]
+    assert constrain_durations(*_VEO, [4, 6, 8], resolution="1080p") == [8]
+
+
+def test_constrain_durations_by_reference_images():
+    """参考图约束独立于分辨率触发；未走参考图路径时不施加。"""
+    assert constrain_durations(*_VEO, [4, 6, 8], uses_reference_images=True) == [8]
+    assert constrain_durations(*_VEO, [4, 6, 8], uses_reference_images=False) == [4, 6, 8]
+    # 无参考图声明的型号：该维度不收窄
+    assert constrain_durations(*_HAILUO, [6, 10], uses_reference_images=True) == [6, 10]
+
+
+def test_constrain_durations_both_dimensions_intersect():
+    """两条约束同时生效时取交集。"""
+    assert constrain_durations(*_HAILUO, [6, 10], resolution="1080p", uses_reference_images=True) == [6]
+
+
+def test_constrain_durations_falls_back():
+    """无声明 / 未登记型号 / 交集为空 / 缺参数时返回原候选，不把候选清空。"""
+    # 该分辨率无声明
+    assert constrain_durations(*_VEO, [4, 6, 8], resolution="720p") == [4, 6, 8]
+    # 型号未登记（中转站 / 自定义供应商包装）
+    assert constrain_durations("gemini-aistudio", "veo-3.1-via-relay", [4, 6, 8], resolution="4k") == [4, 6, 8]
+    # 交集为空（声明自相矛盾，不该发生）：保留原候选而非清空。两维各自成立
+    assert constrain_durations(*_VEO, [4, 6], resolution="4k") == [4, 6]
+    assert constrain_durations(*_VEO, [4, 6], uses_reference_images=True) == [4, 6]
+    # resolution 缺失且不走参考图：两维都不触发
+    assert constrain_durations(*_VEO, [4, 6, 8]) == [4, 6, 8]
+    # 身份缺失（能力不可解析）
+    assert constrain_durations(None, None, [4, 6, 8], resolution="4k") == [4, 6, 8]
+    # 空候选原样返回
+    assert constrain_durations(*_VEO, [], resolution="4k") == []
+
+
+def test_constrain_durations_for_project_uses_project_resolution():
+    """项目已设分辨率优先于 provider 兜底档位。"""
+    project = {"model_settings": {f"{_VEO[0]}/{_VEO[1]}": {"resolution": "720p"}}}
+    assert constrain_durations_for_project(
+        project, [4, 6, 8], provider_id=_VEO[0], model_id=_VEO[1], generation_mode="storyboard"
+    ) == [4, 6, 8]
+
+
+def test_constrain_durations_for_project_falls_back_to_provider_resolution():
+    """项目未设分辨率时按 provider 兜底档位求值——执行期实际就落在该档位上。
+
+    这是 issue 描述的默认场景：用户不做任何配置，Veo 兜底 1080p，候选必须收窄到 8 秒，
+    否则剧本产出 4/6 秒镜头、入队时被 backend 拒。
+    """
+    assert constrain_durations_for_project(
+        {}, [4, 6, 8], provider_id=_VEO[0], model_id=_VEO[1], generation_mode="storyboard"
+    ) == [8]
+    # minimax 兜底 768p，该档位无声明 → 不收窄
+    assert constrain_durations_for_project(
+        {}, [6, 10], provider_id=_HAILUO[0], model_id=_HAILUO[1], generation_mode="storyboard"
+    ) == [6, 10]
+
+
+def test_constrain_durations_for_project_reference_mode():
+    """generation_mode=reference_video 触发参考图约束。"""
+    project = {"model_settings": {f"{_VEO[0]}/{_VEO[1]}": {"resolution": "720p"}}}
+    assert constrain_durations_for_project(
+        project, [4, 6, 8], provider_id=_VEO[0], model_id=_VEO[1], generation_mode="reference_video"
+    ) == [8]
+
+
+def test_constrain_durations_for_project_legacy_resolution_key():
+    """legacy video_model_settings（裸 model_id 键）同样参与求值。"""
+    project = {"video_model_settings": {_VEO[1]: {"resolution": "720p"}}}
+    assert constrain_durations_for_project(
+        project, [4, 6, 8], provider_id=_VEO[0], model_id=_VEO[1], generation_mode="storyboard"
+    ) == [4, 6, 8]

--- a/tests/test_config_resolver_resolution.py
+++ b/tests/test_config_resolver_resolution.py
@@ -266,18 +266,34 @@ def test_constrain_durations_for_project_uses_project_resolution():
     ) == [4, 6, 8]
 
 
-def test_constrain_durations_for_project_falls_back_to_provider_resolution():
-    """项目未设分辨率时按 provider 兜底档位求值——执行期实际就落在该档位上。
+def test_constrain_durations_for_project_unset_resolution_not_constrained():
+    """项目未设分辨率时不施加分辨率约束——普通视频路径此时不下发 resolution 参数。
 
-    这是 issue 描述的默认场景：用户不做任何配置，Veo 兜底 1080p，候选必须收窄到 8 秒，
-    否则剧本产出 4/6 秒镜头、入队时被 backend 拒。
+    执行期发给供应商的是 ``resolve_resolution()`` 的原始结果，``None`` 即省略该参数，供应商
+    按自己的默认档位处理（Veo 省略时是 720p，4/6/8 全合法）。按 provider 兜底档位收窄会凭空
+    把未配置项目的剧本节奏锁死 8 秒，而供应商本来就接受 4/6 秒。
     """
     assert constrain_durations_for_project(
         {}, [4, 6, 8], provider_id=_VEO[0], model_id=_VEO[1], generation_mode="storyboard"
-    ) == [8]
-    # minimax 兜底 768p，该档位无声明 → 不收窄
+    ) == [4, 6, 8]
     assert constrain_durations_for_project(
         {}, [6, 10], provider_id=_HAILUO[0], model_id=_HAILUO[1], generation_mode="storyboard"
+    ) == [6, 10]
+
+
+def test_constrain_durations_for_project_unset_resolution_reference_mode_uses_fallback():
+    """参考视频模式是唯一按 provider 兜底档位求值的路径——它执行期确实下发非空档位。
+
+    ``reference_video_tasks`` 取 ``resolution_or_fallback``，故未配置分辨率时约束也得按那个
+    档位算，否则 step1 会按全集上限拆 unit、step2 的枚举再判非法。Veo 兜底 1080p → 只剩 8 秒
+    （参考图约束在该模式下同样生效，二者指向同一结果）。
+    """
+    assert constrain_durations_for_project(
+        {}, [4, 6, 8], provider_id=_VEO[0], model_id=_VEO[1], generation_mode="reference_video"
+    ) == [8]
+    # minimax 兜底 768p，该档位无声明 → 分辨率维度不收窄
+    assert constrain_durations_for_project(
+        {}, [6, 10], provider_id=_HAILUO[0], model_id=_HAILUO[1], generation_mode="reference_video"
     ) == [6, 10]
 
 

--- a/tests/test_config_resolver_resolution.py
+++ b/tests/test_config_resolver_resolution.py
@@ -222,12 +222,14 @@ _VEO = ("gemini-aistudio", "veo-3.1-generate-preview")  # 声明 {1080p:[8], 4k:
 _HAILUO = ("minimax", "MiniMax-Hailuo-2.3")  # 声明 {1080p:[6]}，无参考图声明
 
 
+@pytest.mark.unit
 def test_constrain_durations_by_resolution():
     """已登记且有声明时按声明收窄，大小写不敏感。"""
     assert constrain_durations(*_VEO, [4, 6, 8], resolution="4K") == [8]
     assert constrain_durations(*_VEO, [4, 6, 8], resolution="1080p") == [8]
 
 
+@pytest.mark.unit
 def test_constrain_durations_by_reference_images():
     """参考图约束独立于分辨率触发；未走参考图路径时不施加。"""
     assert constrain_durations(*_VEO, [4, 6, 8], uses_reference_images=True) == [8]
@@ -236,11 +238,13 @@ def test_constrain_durations_by_reference_images():
     assert constrain_durations(*_HAILUO, [6, 10], uses_reference_images=True) == [6, 10]
 
 
+@pytest.mark.unit
 def test_constrain_durations_both_dimensions_intersect():
     """两条约束同时生效时取交集。"""
     assert constrain_durations(*_HAILUO, [6, 10], resolution="1080p", uses_reference_images=True) == [6]
 
 
+@pytest.mark.unit
 def test_constrain_durations_falls_back():
     """无声明 / 未登记型号 / 交集为空 / 缺参数时返回原候选，不把候选清空。"""
     # 该分辨率无声明
@@ -258,6 +262,7 @@ def test_constrain_durations_falls_back():
     assert constrain_durations(*_VEO, [], resolution="4k") == []
 
 
+@pytest.mark.unit
 def test_constrain_durations_for_project_uses_project_resolution():
     """项目已设分辨率优先于 provider 兜底档位。"""
     project = {"model_settings": {f"{_VEO[0]}/{_VEO[1]}": {"resolution": "720p"}}}
@@ -266,6 +271,7 @@ def test_constrain_durations_for_project_uses_project_resolution():
     ) == [4, 6, 8]
 
 
+@pytest.mark.unit
 def test_constrain_durations_for_project_unset_resolution_not_constrained():
     """项目未设分辨率时不施加分辨率约束——普通视频路径此时不下发 resolution 参数。
 
@@ -281,6 +287,7 @@ def test_constrain_durations_for_project_unset_resolution_not_constrained():
     ) == [6, 10]
 
 
+@pytest.mark.unit
 def test_constrain_durations_for_project_unset_resolution_reference_mode_uses_fallback():
     """参考视频模式是唯一按 provider 兜底档位求值的路径——它执行期确实下发非空档位。
 
@@ -297,6 +304,7 @@ def test_constrain_durations_for_project_unset_resolution_reference_mode_uses_fa
     ) == [6, 10]
 
 
+@pytest.mark.unit
 def test_constrain_durations_for_project_reference_mode():
     """generation_mode=reference_video 触发参考图约束。"""
     project = {"model_settings": {f"{_VEO[0]}/{_VEO[1]}": {"resolution": "720p"}}}
@@ -305,6 +313,7 @@ def test_constrain_durations_for_project_reference_mode():
     ) == [8]
 
 
+@pytest.mark.unit
 def test_constrain_durations_for_project_legacy_resolution_key():
     """legacy video_model_settings（裸 model_id 键）同样参与求值。"""
     project = {"video_model_settings": {_VEO[1]: {"resolution": "720p"}}}

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -1177,33 +1177,6 @@ class TestGenerationTasks:
         )
         assert fake_generator.video_calls[0]["duration_seconds"] == 8
 
-    async def test_constrain_durations_by_resolution_falls_back(self):
-        """无声明 / 未登记型号 / 交集为空时返回原候选，不把候选清空。"""
-        constrain = generation_tasks.constrain_durations_by_resolution
-        # 已登记且有声明：按声明收窄（大小写不敏感）
-        assert constrain("gemini-aistudio", "veo-3.1-generate-preview", [4, 6, 8], "4K") == [8]
-        # 该分辨率无声明
-        assert constrain("gemini-aistudio", "veo-3.1-generate-preview", [4, 6, 8], "720p") == [4, 6, 8]
-        # 型号未登记（中转站 / 自定义供应商包装）
-        assert constrain("gemini-aistudio", "veo-3.1-via-relay", [4, 6, 8], "4k") == [4, 6, 8]
-        # 交集为空（声明自相矛盾，不该发生）：保留原候选而非清空
-        assert constrain("gemini-aistudio", "veo-3.1-generate-preview", [4, 6], "4k") == [4, 6]
-        # resolution 缺失
-        assert constrain("gemini-aistudio", "veo-3.1-generate-preview", [4, 6, 8], None) == [4, 6, 8]
-
-    @pytest.mark.unit
-    async def test_constrain_durations_by_reference_images_falls_back(self):
-        """无声明 / 未登记型号 / 交集为空时返回原候选，不把候选清空。"""
-        constrain = generation_tasks.constrain_durations_by_reference_images
-        # 已登记且有声明：Veo 3.1 带参考图只接受 8 秒
-        assert constrain("gemini-aistudio", "veo-3.1-generate-preview", [4, 6, 8]) == [8]
-        # 型号未登记（中转站 / 自定义供应商包装）
-        assert constrain("gemini-aistudio", "veo-3.1-via-relay", [4, 6, 8]) == [4, 6, 8]
-        # 交集为空（声明自相矛盾，不该发生）：保留原候选而非清空
-        assert constrain("gemini-aistudio", "veo-3.1-generate-preview", [4, 6]) == [4, 6]
-        # 候选为空：原样透传（能力不可解析，空集放行口径）
-        assert constrain("gemini-aistudio", "veo-3.1-generate-preview", []) == []
-
     async def test_empty_supported_durations_guard_permissive(self, monkeypatch, tmp_path):
         """能力不可解析时 lane 交付空 supported_durations：守卫放行（不更坏），
         resolution 仍取自 lane 已解析出的值，不因能力缺失被改写。"""

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -1390,26 +1390,6 @@ class TestLoadReferenceStep1:
         with pytest.raises(ValueError):
             sg._load_reference_step1(1, [4, 6, 8])
 
-    @pytest.mark.unit
-    def test_shot_over_current_unit_cap_raises(self, tmp_path):
-        """shot 成员合法但超过当前 unit 总时长上限 → 要求重拆。
-
-        step1 在宽松分辨率下拆出 10 秒 shot，项目切到上限 6 秒的档位后，shot 之和必然超标：
-        step2 只能静默改写已定节奏或凑不出枚举 schema 的总时长，两条都不该静默发生。
-        """
-        sg = _bare_generator(tmp_path)
-        self._write(sg, 1, {"units": [self._unit("E1U01", duration=10)]})
-        with pytest.raises(ValueError, match="上限|重跑"):
-            sg._load_reference_step1(1, [4, 6, 8, 10], max_duration=6)
-
-    @pytest.mark.unit
-    def test_shot_within_cap_passes(self, tmp_path):
-        """上限内的 shot 不受影响；上限未声明（None）时跳过该层校验。"""
-        sg = _bare_generator(tmp_path)
-        self._write(sg, 1, {"units": [self._unit("E1U01", duration=4), self._unit("E1U02", duration=6)]})
-        assert len(sg._load_reference_step1(1, [4, 6, 8, 10], max_duration=6)) == 2
-        assert len(sg._load_reference_step1(1, [4, 6, 8, 10], max_duration=None)) == 2
-
 
 def _write_ad_project(project_path: Path, *, generation_mode: str = "storyboard", products: dict | None = None):
     payload = {

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -67,6 +67,31 @@ def _write_drama_ledger_project(project_path: Path, episodes: list[dict], charac
     )
 
 
+def _drama_project_with_backend(
+    tmp_path,
+    *,
+    backend: str,
+    resolution: str,
+    supported_durations: list[int] | None = None,
+):
+    """造一个指定视频后端 + 分辨率的最小 drama 项目，返回项目路径。
+
+    四个 step2 时长校验用例只在这三项上不同，其余装配逐字相同。
+    """
+    project_path = tmp_path / "demo"
+    _write_drama_ledger_project(
+        project_path,
+        [{"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"}],
+    )
+    project = json.loads((project_path / "project.json").read_text(encoding="utf-8"))
+    project["video_backend"] = backend
+    project["model_settings"] = {backend: {"resolution": resolution}}
+    if supported_durations is not None:
+        project["_supported_durations"] = supported_durations
+    _write_json(project_path / "project.json", project)
+    return project_path
+
+
 def _drama_step1_content() -> dict:
     """drama step1 结构化内容：含 utterances + source_text + scene_description（视觉改编）。"""
     return {
@@ -305,15 +330,9 @@ class TestScriptGenerator:
         step2 原样透传 step1 时长，落盘前的静态校验只要求正整数；缺这道校验时越界值会一路存进
         剧本，直到视频入队才被拒。与 narration / reference_video 的 step1 读回校验对称。
         """
-        project_path = tmp_path / "demo"
-        _write_drama_ledger_project(
-            project_path,
-            [{"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"}],
+        project_path = _drama_project_with_backend(
+            tmp_path, backend="gemini-aistudio/veo-3.1-generate-preview", resolution="1080p"
         )
-        project = json.loads((project_path / "project.json").read_text(encoding="utf-8"))
-        project["video_backend"] = "gemini-aistudio/veo-3.1-generate-preview"
-        project["model_settings"] = {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}
-        _write_json(project_path / "project.json", project)
 
         content = _drama_step1_content()
         content["scenes"][0]["duration_seconds"] = 4
@@ -332,15 +351,9 @@ class TestScriptGenerator:
 
         校验若按 `isinstance(..., int)` 判定就会整个跳过这两种形态，等于给越界值开一条绕路。
         """
-        project_path = tmp_path / "demo"
-        _write_drama_ledger_project(
-            project_path,
-            [{"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"}],
+        project_path = _drama_project_with_backend(
+            tmp_path, backend="gemini-aistudio/veo-3.1-generate-preview", resolution="1080p"
         )
-        project = json.loads((project_path / "project.json").read_text(encoding="utf-8"))
-        project["video_backend"] = "gemini-aistudio/veo-3.1-generate-preview"
-        project["model_settings"] = {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}
-        _write_json(project_path / "project.json", project)
 
         content = _drama_step1_content()
         content["scenes"][0]["duration_seconds"] = raw
@@ -354,16 +367,9 @@ class TestScriptGenerator:
 
         海螺 1080p 只接受 6 秒，而 DramaSceneContent 的默认是 8 秒，故该场景须被拦下。
         """
-        project_path = tmp_path / "demo"
-        _write_drama_ledger_project(
-            project_path,
-            [{"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"}],
+        project_path = _drama_project_with_backend(
+            tmp_path, backend="minimax/MiniMax-Hailuo-2.3", resolution="1080p", supported_durations=[6, 10]
         )
-        project = json.loads((project_path / "project.json").read_text(encoding="utf-8"))
-        project["video_backend"] = "minimax/MiniMax-Hailuo-2.3"
-        project["model_settings"] = {"minimax/MiniMax-Hailuo-2.3": {"resolution": "1080p"}}
-        project["_supported_durations"] = [6, 10]
-        _write_json(project_path / "project.json", project)
 
         content = _drama_step1_content()
         del content["scenes"][0]["duration_seconds"]
@@ -374,15 +380,9 @@ class TestScriptGenerator:
     @pytest.mark.integration
     async def test_drama_step2_accepts_step1_duration_within_constrained_set(self, tmp_path):
         """同一 1080p 项目下 8 秒仍合法——收窄后集合的成员不得被这道校验误拒。"""
-        project_path = tmp_path / "demo"
-        _write_drama_ledger_project(
-            project_path,
-            [{"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"}],
+        project_path = _drama_project_with_backend(
+            tmp_path, backend="gemini-aistudio/veo-3.1-generate-preview", resolution="1080p"
         )
-        project = json.loads((project_path / "project.json").read_text(encoding="utf-8"))
-        project["video_backend"] = "gemini-aistudio/veo-3.1-generate-preview"
-        project["model_settings"] = {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}
-        _write_json(project_path / "project.json", project)
 
         generator = ScriptGenerator(project_path)
         await generator._assert_drama_step1_durations(_drama_step1_content()["scenes"], gen_mode="storyboard")

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -378,6 +378,23 @@ class TestScriptGenerator:
             await generator._assert_drama_step1_durations(content["scenes"], gen_mode="storyboard")
 
     @pytest.mark.integration
+    async def test_drama_step2_checks_declared_default_when_duration_null(self, tmp_path):
+        """显式 null 与缺键同口径：都按声明默认值校验，不得绕过。
+
+        `dict.get` 的默认值只在缺键时生效，显式 null 会取到 None；不特判的话该场景跳过校验，
+        要等 step2 跑完、落盘时才被 Pydantic 拒，白耗一次完整的剧本生成调用。
+        """
+        project_path = _drama_project_with_backend(
+            tmp_path, backend="minimax/MiniMax-Hailuo-2.3", resolution="1080p", supported_durations=[6, 10]
+        )
+
+        content = _drama_step1_content()
+        content["scenes"][0]["duration_seconds"] = None
+        generator = ScriptGenerator(project_path)
+        with pytest.raises(ValueError, match="step1 已定场景时长非法"):
+            await generator._assert_drama_step1_durations(content["scenes"], gen_mode="storyboard")
+
+    @pytest.mark.integration
     async def test_drama_step2_accepts_step1_duration_within_constrained_set(self, tmp_path):
         """同一 1080p 项目下 8 秒仍合法——收窄后集合的成员不得被这道校验误拒。"""
         project_path = _drama_project_with_backend(

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -951,6 +951,14 @@ def test_resolve_max_duration_tracks_narrowed_set(tmp_path):
     # 1080p 下海螺只接受 6 秒：上限必须跟着降，否则 step1 会拆出 10 秒的 unit 而 step2 判非法
     assert hailuo._resolve_max_duration(hailuo_caps, gen_mode="storyboard") == 6
 
+    # rv 模式是 max_duration 真正当 unit 总时长上限用的分支：上限一旦退回 caps["max_duration"]
+    # （Veo 全集 8、海螺全集 10），step1 会按全集上限拆 unit、step2 的枚举再判非法。
+    # 两侧都钉死具体值，同时钉住「上限 == max(枚举集合)」这条不变量。
+    for sg_case, caps_case, expected in ((sg, caps, 8), (hailuo, hailuo_caps, 6)):
+        durations = sg_case._resolve_supported_durations(caps_case, gen_mode="reference_video")
+        assert durations == [expected]
+        assert sg_case._resolve_max_duration(caps_case, gen_mode="reference_video") == expected == max(durations)
+
 
 def _bare_generator(tmp_path: Path, project_extra: dict | None = None) -> ScriptGenerator:
     """构造跳过 backend 初始化的 narration ScriptGenerator（用于直接测内部方法）。"""

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -322,6 +322,56 @@ class TestScriptGenerator:
             await generator._assert_drama_step1_durations(content["scenes"], gen_mode="storyboard")
 
     @pytest.mark.integration
+    @pytest.mark.parametrize(
+        "raw",
+        ["4", 4.0],
+        ids=["numeric-string", "integral-float"],
+    )
+    async def test_drama_step2_rejects_out_of_range_duration_in_coercible_form(self, tmp_path, raw):
+        """手编的 `"4"` / `4.0` 同样拦下：它们会被最终 schema 归一成 4 落盘，不能绕过校验。
+
+        校验若按 `isinstance(..., int)` 判定就会整个跳过这两种形态，等于给越界值开一条绕路。
+        """
+        project_path = tmp_path / "demo"
+        _write_drama_ledger_project(
+            project_path,
+            [{"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"}],
+        )
+        project = json.loads((project_path / "project.json").read_text(encoding="utf-8"))
+        project["video_backend"] = "gemini-aistudio/veo-3.1-generate-preview"
+        project["model_settings"] = {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}
+        _write_json(project_path / "project.json", project)
+
+        content = _drama_step1_content()
+        content["scenes"][0]["duration_seconds"] = raw
+        generator = ScriptGenerator(project_path)
+        with pytest.raises(ValueError, match="step1 已定场景时长非法"):
+            await generator._assert_drama_step1_durations(content["scenes"], gen_mode="storyboard")
+
+    @pytest.mark.integration
+    async def test_drama_step2_checks_declared_default_when_duration_absent(self, tmp_path):
+        """缺 duration_seconds 键时按字段声明默认值校验——不填不代表不校验，落盘补的正是该默认值。
+
+        海螺 1080p 只接受 6 秒，而 DramaSceneContent 的默认是 8 秒，故该场景须被拦下。
+        """
+        project_path = tmp_path / "demo"
+        _write_drama_ledger_project(
+            project_path,
+            [{"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"}],
+        )
+        project = json.loads((project_path / "project.json").read_text(encoding="utf-8"))
+        project["video_backend"] = "minimax/MiniMax-Hailuo-2.3"
+        project["model_settings"] = {"minimax/MiniMax-Hailuo-2.3": {"resolution": "1080p"}}
+        project["_supported_durations"] = [6, 10]
+        _write_json(project_path / "project.json", project)
+
+        content = _drama_step1_content()
+        del content["scenes"][0]["duration_seconds"]
+        generator = ScriptGenerator(project_path)
+        with pytest.raises(ValueError, match="step1 已定场景时长非法"):
+            await generator._assert_drama_step1_durations(content["scenes"], gen_mode="storyboard")
+
+    @pytest.mark.integration
     async def test_drama_step2_accepts_step1_duration_within_constrained_set(self, tmp_path):
         """同一 1080p 项目下 8 秒仍合法——收窄后集合的成员不得被这道校验误拒。"""
         project_path = tmp_path / "demo"

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -298,6 +298,7 @@ class TestScriptGenerator:
         with pytest.raises(ValueError, match="改写到 episode=2 后重复"):
             generator._load_drama_step1_content(2)
 
+    @pytest.mark.integration
     async def test_drama_step2_rejects_step1_duration_out_of_constrained_set(self, tmp_path):
         """step1 在宽松分辨率下拆好、项目改到 Veo 1080p 后再跑 step2 → 越界时长 fail-loud。
 
@@ -320,6 +321,7 @@ class TestScriptGenerator:
         with pytest.raises(ValueError, match="step1 已定场景时长非法"):
             await generator._assert_drama_step1_durations(content["scenes"], gen_mode="storyboard")
 
+    @pytest.mark.integration
     async def test_drama_step2_accepts_step1_duration_within_constrained_set(self, tmp_path):
         """同一 1080p 项目下 8 秒仍合法——收窄后集合的成员不得被这道校验误拒。"""
         project_path = tmp_path / "demo"
@@ -863,6 +865,7 @@ _VEO_CAPS = {
 }
 
 
+@pytest.mark.integration
 def test_resolve_supported_durations_narrows_by_saved_resolution(tmp_path):
     """项目保存了 1080p 时收窄到该档位声明的集合——Veo 1080p 只接受 8 秒。
 
@@ -880,6 +883,7 @@ def test_resolve_supported_durations_narrows_by_saved_resolution(tmp_path):
     assert sg._resolve_raw_supported_durations(_VEO_CAPS) == [4, 6, 8]
 
 
+@pytest.mark.integration
 def test_resolve_supported_durations_unset_resolution_not_narrowed(tmp_path):
     """项目未配分辨率时不收窄：普通视频路径此时省略 resolution 参数，Veo 按默认 720p 接受 4/6/8。
 
@@ -889,6 +893,7 @@ def test_resolve_supported_durations_unset_resolution_not_narrowed(tmp_path):
     assert sg._resolve_supported_durations(_VEO_CAPS, gen_mode="storyboard") == [4, 6, 8]
 
 
+@pytest.mark.integration
 def test_resolve_supported_durations_respects_project_resolution(tmp_path):
     """项目显式配了无声明的分辨率时不收窄，行为与改动前一致。"""
     sg = _sg_with_project(
@@ -901,6 +906,7 @@ def test_resolve_supported_durations_respects_project_resolution(tmp_path):
     assert sg._resolve_supported_durations(_VEO_CAPS, gen_mode="storyboard") == [4, 6, 8]
 
 
+@pytest.mark.integration
 def test_resolve_supported_durations_narrows_by_reference_mode(tmp_path):
     """reference_video 模式触发「参考图↔时长」约束，即便分辨率本身无声明。"""
     sg = _sg_with_project(
@@ -913,6 +919,7 @@ def test_resolve_supported_durations_narrows_by_reference_mode(tmp_path):
     assert sg._resolve_supported_durations(_VEO_CAPS, gen_mode="reference_video") == [8]
 
 
+@pytest.mark.integration
 def test_resolve_supported_durations_unconstrained_model_unchanged(tmp_path):
     """已登记但无联动约束声明的型号：收窄是恒等变换，两种 gen_mode 都与全集一致。"""
     caps = {"provider_id": "ark", "model": "doubao-seedance-1-5-pro-251215", "supported_durations": [4, 5, 6]}
@@ -921,6 +928,7 @@ def test_resolve_supported_durations_unconstrained_model_unchanged(tmp_path):
     assert sg._resolve_supported_durations(caps, gen_mode="reference_video") == [4, 5, 6]
 
 
+@pytest.mark.integration
 def test_resolve_max_duration_tracks_narrowed_set(tmp_path):
     """max_duration 随收窄后的集合走：它在 rv 模式下是 unit 总时长上限，须与枚举同一集合。"""
     sg = _sg_with_project(tmp_path, {"video_backend": "gemini-aistudio/veo-3.1-generate-preview"})

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -298,6 +298,43 @@ class TestScriptGenerator:
         with pytest.raises(ValueError, match="改写到 episode=2 后重复"):
             generator._load_drama_step1_content(2)
 
+    async def test_drama_step2_rejects_step1_duration_out_of_constrained_set(self, tmp_path):
+        """step1 在宽松分辨率下拆好、项目改到 Veo 1080p 后再跑 step2 → 越界时长 fail-loud。
+
+        step2 原样透传 step1 时长，落盘前的静态校验只要求正整数；缺这道校验时越界值会一路存进
+        剧本，直到视频入队才被拒。与 narration / reference_video 的 step1 读回校验对称。
+        """
+        project_path = tmp_path / "demo"
+        _write_drama_ledger_project(
+            project_path,
+            [{"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"}],
+        )
+        project = json.loads((project_path / "project.json").read_text(encoding="utf-8"))
+        project["video_backend"] = "gemini-aistudio/veo-3.1-generate-preview"
+        project["model_settings"] = {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}
+        _write_json(project_path / "project.json", project)
+
+        content = _drama_step1_content()
+        content["scenes"][0]["duration_seconds"] = 4
+        generator = ScriptGenerator(project_path)
+        with pytest.raises(ValueError, match="step1 已定场景时长非法"):
+            await generator._assert_drama_step1_durations(content["scenes"], gen_mode="storyboard")
+
+    async def test_drama_step2_accepts_step1_duration_within_constrained_set(self, tmp_path):
+        """同一 1080p 项目下 8 秒仍合法——收窄后集合的成员不得被这道校验误拒。"""
+        project_path = tmp_path / "demo"
+        _write_drama_ledger_project(
+            project_path,
+            [{"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"}],
+        )
+        project = json.loads((project_path / "project.json").read_text(encoding="utf-8"))
+        project["video_backend"] = "gemini-aistudio/veo-3.1-generate-preview"
+        project["model_settings"] = {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}
+        _write_json(project_path / "project.json", project)
+
+        generator = ScriptGenerator(project_path)
+        await generator._assert_drama_step1_durations(_drama_step1_content()["scenes"], gen_mode="storyboard")
+
     async def test_drama_step2_build_prompt_renders_step1_content(self, tmp_path):
         """drama step2（视觉层）build_prompt 须把 step1 已定稿内容渲染入 prompt，仅求视觉字段。"""
         project_path = tmp_path / "demo"
@@ -826,15 +863,30 @@ _VEO_CAPS = {
 }
 
 
-def test_resolve_supported_durations_narrows_by_fallback_resolution(tmp_path):
-    """项目未配分辨率时按 provider 兜底档位收窄——Veo 兜底 1080p、只接受 8 秒。
+def test_resolve_supported_durations_narrows_by_saved_resolution(tmp_path):
+    """项目保存了 1080p 时收窄到该档位声明的集合——Veo 1080p 只接受 8 秒。
 
-    这是本票的默认场景：不收窄的话剧本产出 4/6 秒镜头，视频入队时才被 backend 拒。
+    这是验收标准第 1 条的正例：不收窄的话剧本产出 4/6 秒镜头，视频入队时才被 backend 拒。
     """
-    sg = _sg_with_project(tmp_path, {"video_backend": "gemini-aistudio/veo-3.1-generate-preview"})
+    sg = _sg_with_project(
+        tmp_path,
+        {
+            "video_backend": "gemini-aistudio/veo-3.1-generate-preview",
+            "model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}},
+        },
+    )
     assert sg._resolve_supported_durations(_VEO_CAPS, gen_mode="storyboard") == [8]
     # 全集仍可单独取到，供「shot 是 clip 内编排」这类不面向供应商的维度使用
     assert sg._resolve_raw_supported_durations(_VEO_CAPS) == [4, 6, 8]
+
+
+def test_resolve_supported_durations_unset_resolution_not_narrowed(tmp_path):
+    """项目未配分辨率时不收窄：普通视频路径此时省略 resolution 参数，Veo 按默认 720p 接受 4/6/8。
+
+    按 provider 兜底档位收窄会把未配置项目的剧本节奏凭空锁死 8 秒，而供应商本来就接受 4/6 秒。
+    """
+    sg = _sg_with_project(tmp_path, {"video_backend": "gemini-aistudio/veo-3.1-generate-preview"})
+    assert sg._resolve_supported_durations(_VEO_CAPS, gen_mode="storyboard") == [4, 6, 8]
 
 
 def test_resolve_supported_durations_respects_project_resolution(tmp_path):

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -806,7 +806,90 @@ def test_resolve_supported_durations_raises_when_unset(tmp_path):
     sg.project_json = {"video_backend": "nonexistent-provider/nonexistent-model"}
 
     with pytest.raises(ValueError, match="supported_durations"):
-        sg._resolve_supported_durations(None)
+        sg._resolve_supported_durations(None, gen_mode="storyboard")
+
+
+def _sg_with_project(tmp_path, project: dict) -> ScriptGenerator:
+    """只为 _resolve_* 系列造一个不走 __init__ 的 ScriptGenerator（不需要 TextGenerator）。"""
+    project_dir = tmp_path / "p"
+    project_dir.mkdir(exist_ok=True)
+    sg = ScriptGenerator.__new__(ScriptGenerator)
+    sg.project_path = project_dir
+    sg.project_json = project
+    return sg
+
+
+_VEO_CAPS = {
+    "provider_id": "gemini-aistudio",
+    "model": "veo-3.1-generate-preview",
+    "supported_durations": [4, 6, 8],
+}
+
+
+def test_resolve_supported_durations_narrows_by_fallback_resolution(tmp_path):
+    """项目未配分辨率时按 provider 兜底档位收窄——Veo 兜底 1080p、只接受 8 秒。
+
+    这是本票的默认场景：不收窄的话剧本产出 4/6 秒镜头，视频入队时才被 backend 拒。
+    """
+    sg = _sg_with_project(tmp_path, {"video_backend": "gemini-aistudio/veo-3.1-generate-preview"})
+    assert sg._resolve_supported_durations(_VEO_CAPS, gen_mode="storyboard") == [8]
+    # 全集仍可单独取到，供「shot 是 clip 内编排」这类不面向供应商的维度使用
+    assert sg._resolve_raw_supported_durations(_VEO_CAPS) == [4, 6, 8]
+
+
+def test_resolve_supported_durations_respects_project_resolution(tmp_path):
+    """项目显式配了无声明的分辨率时不收窄，行为与改动前一致。"""
+    sg = _sg_with_project(
+        tmp_path,
+        {
+            "video_backend": "gemini-aistudio/veo-3.1-generate-preview",
+            "model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}},
+        },
+    )
+    assert sg._resolve_supported_durations(_VEO_CAPS, gen_mode="storyboard") == [4, 6, 8]
+
+
+def test_resolve_supported_durations_narrows_by_reference_mode(tmp_path):
+    """reference_video 模式触发「参考图↔时长」约束，即便分辨率本身无声明。"""
+    sg = _sg_with_project(
+        tmp_path,
+        {
+            "video_backend": "gemini-aistudio/veo-3.1-generate-preview",
+            "model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}},
+        },
+    )
+    assert sg._resolve_supported_durations(_VEO_CAPS, gen_mode="reference_video") == [8]
+
+
+def test_resolve_supported_durations_unconstrained_model_unchanged(tmp_path):
+    """已登记但无联动约束声明的型号：收窄是恒等变换，两种 gen_mode 都与全集一致。"""
+    caps = {"provider_id": "ark", "model": "doubao-seedance-1-5-pro-251215", "supported_durations": [4, 5, 6]}
+    sg = _sg_with_project(tmp_path, {"video_backend": "ark/doubao-seedance-1-5-pro-251215"})
+    assert sg._resolve_supported_durations(caps, gen_mode="storyboard") == [4, 5, 6]
+    assert sg._resolve_supported_durations(caps, gen_mode="reference_video") == [4, 5, 6]
+
+
+def test_resolve_max_duration_tracks_narrowed_set(tmp_path):
+    """max_duration 随收窄后的集合走：它在 rv 模式下是 unit 总时长上限，须与枚举同一集合。"""
+    sg = _sg_with_project(tmp_path, {"video_backend": "gemini-aistudio/veo-3.1-generate-preview"})
+    caps = {**_VEO_CAPS, "max_duration": 8}
+    assert sg._resolve_max_duration(caps, gen_mode="storyboard") == 8
+
+    hailuo_caps = {
+        "provider_id": "minimax",
+        "model": "MiniMax-Hailuo-2.3",
+        "supported_durations": [6, 10],
+        "max_duration": 10,
+    }
+    hailuo = _sg_with_project(
+        tmp_path,
+        {
+            "video_backend": "minimax/MiniMax-Hailuo-2.3",
+            "model_settings": {"minimax/MiniMax-Hailuo-2.3": {"resolution": "1080p"}},
+        },
+    )
+    # 1080p 下海螺只接受 6 秒：上限必须跟着降，否则 step1 会拆出 10 秒的 unit 而 step2 判非法
+    assert hailuo._resolve_max_duration(hailuo_caps, gen_mode="storyboard") == 6
 
 
 def _bare_generator(tmp_path: Path, project_extra: dict | None = None) -> ScriptGenerator:

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -1390,6 +1390,26 @@ class TestLoadReferenceStep1:
         with pytest.raises(ValueError):
             sg._load_reference_step1(1, [4, 6, 8])
 
+    @pytest.mark.unit
+    def test_shot_over_current_unit_cap_raises(self, tmp_path):
+        """shot 成员合法但超过当前 unit 总时长上限 → 要求重拆。
+
+        step1 在宽松分辨率下拆出 10 秒 shot，项目切到上限 6 秒的档位后，shot 之和必然超标：
+        step2 只能静默改写已定节奏或凑不出枚举 schema 的总时长，两条都不该静默发生。
+        """
+        sg = _bare_generator(tmp_path)
+        self._write(sg, 1, {"units": [self._unit("E1U01", duration=10)]})
+        with pytest.raises(ValueError, match="上限|重跑"):
+            sg._load_reference_step1(1, [4, 6, 8, 10], max_duration=6)
+
+    @pytest.mark.unit
+    def test_shot_within_cap_passes(self, tmp_path):
+        """上限内的 shot 不受影响；上限未声明（None）时跳过该层校验。"""
+        sg = _bare_generator(tmp_path)
+        self._write(sg, 1, {"units": [self._unit("E1U01", duration=4), self._unit("E1U02", duration=6)]})
+        assert len(sg._load_reference_step1(1, [4, 6, 8, 10], max_duration=6)) == 2
+        assert len(sg._load_reference_step1(1, [4, 6, 8, 10], max_duration=None)) == 2
+
 
 def _write_ad_project(project_path: Path, *, generation_mode: str = "storyboard", products: dict | None = None):
     payload = {

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from lib.script_generator import ScriptGenerator
+from lib.script_generator import ScriptGenerator, _units_use_references
 from lib.script_structure_validator import ScriptStructureValidationError
 
 
@@ -967,6 +967,42 @@ def test_resolve_supported_durations_narrows_by_reference_mode(tmp_path):
         },
     )
     assert sg._resolve_supported_durations(_VEO_CAPS, gen_mode="reference_video") == [8]
+
+
+@pytest.mark.integration
+def test_resolve_supported_durations_reference_mode_without_refs_not_narrowed(tmp_path):
+    """参考视频模式但本集单元都不带引用时不施加参考图约束。
+
+    通用单元允许空 references，执行层与 backend 都只在实际带图时施加该约束；按模式一刀切
+    会把 720p 下本可申请的 4/6 秒收掉，改变无引用单元改动前的行为。
+    """
+    sg = _sg_with_project(
+        tmp_path,
+        {
+            "video_backend": "gemini-aistudio/veo-3.1-generate-preview",
+            "model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}},
+        },
+    )
+    assert sg._resolve_supported_durations(_VEO_CAPS, gen_mode="reference_video", uses_reference_images=False) == [
+        4,
+        6,
+        8,
+    ]
+    # 有引用的单元存在时照常收窄
+    assert sg._resolve_supported_durations(_VEO_CAPS, gen_mode="reference_video", uses_reference_images=True) == [8]
+
+
+@pytest.mark.unit
+def test_units_use_references_distinguishes_none_from_no_refs():
+    """None（非参考视频路径）与「确定不带引用」区分开，前者交由下游按模式近似判定。"""
+    assert _units_use_references(None) is None
+    assert _units_use_references([{"unit_id": "E1U01", "references": []}]) is False
+    assert (
+        _units_use_references(
+            [{"unit_id": "E1U01", "references": []}, {"unit_id": "E1U02", "references": [{"name": "甲"}]}]
+        )
+        is True
+    )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Closes #1425

「分辨率↔时长」「参考图↔时长」两条联动约束此前只在前端项目级选择器与 backend 入口校验上生效，剩余两个消费点仍取 `supported_durations` 全集。本 PR 把它们接线。

## 改了什么

**剧本生成**：`_resolve_supported_durations` 与 SDK MCP 文本工具在把候选交给 prompt / 动态 schema 之前先经收窄。接线前，项目保存了 1080p / 4k 的 Veo 项目，narration / drama / ad 三种内容模式都会产出 4/6 秒镜头、到视频入队时才被拒。

**逐镜头时长编辑器**：项目分辨率与本集生效的生成模式下传到 `ShotDetail`，候选按同一份声明过滤。已保存的越界值不静默改写，沿用既有的琥珀 pill 警告 + 点开重选；文案按成因分三档（模型不支持 / 当前分辨率下不可用 / 参考生视频模式下不可用），避免把「1080p 下不可用」说成「模型不支持」而把用户引去换模型。

后端的收窄逻辑收敛到 `lib/config/resolver.constrain_durations` 单一入口（执行层原有的 `constrain_durations_by_resolution` 全量收编并补上参考图一维）。执行层调用点仍只传分辨率，行为逐位不变。

## ad 模式的纠正出路：接线让产出天然合规，不恢复项目级时长控件

issue 前提需要一处校正：ad 模式隐藏的是**项目级**默认时长控件，逐镜头 pill 三种内容模式都无条件渲染。issue 的结论（ad 无统一纠正入口）成立。

论证：

1. ad 的镜头时长不是「默认值 + 逐个微调」模型，而是由 `target_duration` 与带货框架配比表逐镜头推导的。项目级「默认时长」在 ad 语义下没有对应物——这正是它当初被隐藏的原因，不是遗漏。
2. 接线后 ad-storyboard 路径的产出从源头合规，新生成的剧本不需要纠正。
3. 存量剧本确实需要纠正入口，逐镜头编辑器接线后正是它：候选已收窄、越界值按成因告警并就地重选。ad 的纠正本就该是逐镜头的——项目级批量重置会把配比压平、破坏 target_duration 贴合度，比现状更糟。
4. ad + 参考生视频路径的单 shot 时长是刻意的 1-15 自由整数：该路径发给供应商的是 unit 总时长（各 shot 之和），单 shot 不下发，不存在单 shot 越界。

## 参考视频模式：收窄落在 unit 总时长，单 shot 保持全集

该模式下 `supported_durations` 有两处语义不同的消费点：**unit 总时长**是真正发给供应商 API 的值，按成员收窄；**单 shot 时长**是同一段 clip 内的时间编排、不单独下发，不按成员收窄。若把单 shot 一并按成员收窄，Veo 1080p 下每个 shot 都得是 8 秒，凑不出 4+4 这类合法编排，clip 内的节奏被一并卡死，而约束并不要求这一点。

单 shot 枚举仍剔除超出 unit 总时长上限的候选：shot 时长必然计入 unit 总和，海螺 1080p 下总时长上限为 6 而枚举留着 10，会让 prompt 同时要求「可选 10 秒」与「总时长不超过 6 秒」，动态 schema 也放行必被后校验判非法的取值。

`_resolve_max_duration` 相应改为取收窄后集合的最大值：上限与枚举必须描述同一个集合，否则海螺 1080p 下 step1 会按 10 秒拆 unit、step2 的枚举再判非法。无约束型号下二者相等，行为不变。

## 约束求值用的生效分辨率：issue 背景的一处前提校正

issue 背景写「Veo 的兜底分辨率即 1080p，也就是说用户不做任何特殊配置……都可能产出 4/6 秒镜头，视频生成入队时被 backend 拒绝」。这个前提不成立，故未配置分辨率的场景不按兜底档位收窄：

- `lib/video_backends/gemini.py` 仅在 `request.resolution is not None` 时才写入 `config_params["resolution"]`，None 时省略该参数；同处的本地能力守卫拿空串去查 `duration_resolution_constraints` 也不匹配任何档位，不拒绝 4/6 秒。
- 仓库内的官方参数表 `docs/google-genai-docs/veo.md` 载明：省略 `resolution` 时 Veo 默认 **720p**，该档位下 4/6/8 全部合法。
- `get_provider_fallback` 的真实消费点只有费用估算与参考视频路径两处。普通图生视频路径下发的是 `ctx.video.resolution` 原始值——兜底档位是这两处的内部口径，不是「用户没配分辨率时的生效值」。

即未配置分辨率时不存在被拒场景，按兜底档位收窄反而会把这类项目的剧本节奏凭空锁死 8 秒。故约束求值取项目**已保存**的档位，未保存时不施加分辨率约束，**前后端同口径**。这也与验收第 1 条字面限定的「1080p / 4k 分辨率下」一致。

参考视频路径是唯一例外：它执行期取 `resolution_or_fallback`、确实下发非空档位，故未保存时仍按 provider 兜底档位求值，让约束与实际下发的档位描述同一集合。

口径已写进 `CONTEXT.md` 的术语条目。

## 本地审查发现并修复

- **drama 规范化工具硬失败**：`build_normalize_prompt` 对不在候选集内的 `default_duration` 是 fail-loud 的。收窄后，用户此前保存的默认时长可能落在集合外（720p 下存 4 秒 → 改 1080p 后 Veo 只剩 8 秒），会把「已保存的越界值」从 prompt 里的一个越界候选升级成整个工具抛 ValueError。改为按 None 处理回到 auto 档，与参考生视频、说书拆分两条路径同口径，补回归用例。
- CONTEXT.md 术语条目补齐新增消费点与生效分辨率口径；两处 JSX 属性缩进对齐。

## AI 审查发现并修复

- **参考视频单 shot 枚举未剔除超上限候选**：见上「参考视频模式」一节。海螺 1080p 下 unit 总时长上限 6、单 shot 枚举仍留 10，prompt 自相矛盾且后校验必拒。补两条用例：剔除超上限，以及「Veo 1080p 下 4/6 仍保留」的反向用例，守住 4+4 编排不被误收窄。
- **drama step2 不校验 step1 时长**：narration 与参考视频的 step1 读回都校验成员性，drama 缺这道检查。step1 在宽松分辨率下拆好、项目改到约束更严的分辨率再跑 step2 时，越界时长原样透传、落盘前的静态校验只要求正整数，会一路存进剧本。补对称校验，报错指向重跑规范化。取值按落盘同一套归一化（剧本 schema 的非 strict `int`）而非 `isinstance` 判定 —— 后者会跳过 `"4"` 与 `4.0`，而它们会被归一成 4 落盘；缺该键时按字段声明的默认值校验，落盘补的正是那个默认值。
- **逐镜头时长编辑器在裸 provider 配置下读不到分辨率**：`video_backend` 可以是裸 provider（服务端补全默认视频模型），原先把它直接当 `provider/model` 去查 `model_settings`，于是 provider ID 被当成 model ID、读不到用户实际保存的档位。同一 hook 内联动约束早已按服务端解析出的身份查表，分辨率查询没跟上。从 `useModelCapabilities` 导出已解析的 `provider/model`，两处同源。
- **镜头生成期间锁定时长编辑**：在跑的分镜 / 视频任务已捕获旧时长，此时改时长会让任务产物与剧本存值不一致。按占用感知型控件的三项检查接线 —— 打开时按占用态禁用并说明原因（新增 `duration_locked_generating`，三语齐备）；提交时刻经 `tasks-store` 的 `isResourceBusy` 新鲜读复核（`busy` prop 反映的是上次渲染，store 更新到重渲染提交之间用户仍可能点下去），命中则拒绝并 `pushToast` 可见反馈，与立绘上传的 `rejectIfAssetBusy` 同口径（该入口出自 #1446，rebase 后按它对齐）；同集宫格任务另按 scriptFile 粒度复核（grid 的 `resource_id` 是 `grid_id`、归不进分镜粒度，而切割阶段会覆写本集多个分镜、与改时长并发写同一份剧本），为此在 `tasks-store` 补了与 `isResourceBusy` 同构的 `isScriptFileBusy` 入口；同一镜头的兄弟控件本就按同一对占用态接线。转入锁定态时于渲染期清掉面板与未提交草稿（`prevLocked` 比较，不用 effect）——只派生可见性会让任务结束后旧面板与草稿一起重现。补三条用例，均做过证伪检查。
- **`model_settings` 空值仍回退 legacy，前后端与保存期迁移三处同口径**：一度改成「显式 `null` 不回退」，但这与仓库既有语义相悖 —— 后端 `_resolution_from_project` 按真值判断，`_migrate_legacy_resolution_on_save` 只在 resolution 有值时清理 legacy（有专门用例 `test_empty_resolution_in_new_does_not_migrate_legacy` 固定），单改前端会留下「新键显式 `null` + legacy 有值」这个前后端读数不同的状态，工作台呈现执行期实际不接受的时长。已还原为与两者一致，并把语义变更整体记为 follow-up。

## 验证

- 后端 `uv run python -m pytest`：6733 passed；`ruff check` / `ruff format --check` 干净；`basedpyright` 0 errors。
- 前端 `pnpm lint` 干净，`pnpm check`：132 文件 / 1433 用例通过。
- 本 PR 新增的 pytest 用例按 `CONTRIBUTING.md` 的 markers 纪律打标：纯函数与 monkeypatch 用例标 `unit`，用 tmp 文件系统的标 `integration`（`-m unit` / `-m integration` 选集已验证能选中）。
- 新增用例做过证伪检查：撤掉修复后 `test_fetch_caps_with_fallback_drops_out_of_range_default` 与 drama step2 时长校验用例分别转红，还原即绿；`StudioCanvasRouter` 的收窄用例把候选改回全集后同样转红。另补「未受约束的分辨率下候选与全集一致」的反向用例（验收第 3 条）。

## 已知薄弱点

- 参考生视频 step1 只被告知 unit 总时长上限、不被告知合法总时长集合，仍可能拆出总时长非成员的 unit，由 step2 枚举 fail-loud 拦下。是 fail-loud 而非产出越界值，验收第 1 条仍满足。
- ad + 参考生视频的 unit 总时长同构：`resolve_max_unit_duration` 取的是未收窄的 `caps["max_duration"]`，`derive_ad_reference_units` 也只校验总和不超上限、不校验成员性，越界总和到入队时由 `assert_duration_supported()` fail-loud 拦下。两条路径彻底闭合是同一件事——把收窄后的合法 unit 总时长集合传到派生/拆分层，并把「≤ 上限」收紧为成员校验，同时让该函数与 `_resolve_max_duration` 同口径。
- `constrain_durations` 在两条联动约束交集为空时静默回退全集：该分支只在 registry 对同一型号声明互斥约束时可达，属注册表数据错误。运行时 warning 拦截太晚（只在用户恰好用到该型号时才打日志），正解是一条覆盖 `PROVIDER_REGISTRY` 的一致性校验测试，让声明冲突在 PR 阶段就红。
- 约束目录取不到时不收窄：时长来自 `/video-capabilities`、约束来自 `/providers` 目录，后者失败则拿到空约束、展示未收窄的全集。属既有管线（#1434）的系统性属性，项目设置页的选择器同样如此，本次接线继承而非引入。正解是让 `/video-capabilities` 一并返回约束（见 follow-up），可同时消除两组并行请求的返回顺序窗口。
- `StudioCanvasRouter` 取 providers / 自定义供应商 / 系统配置的 `Promise.all(...).catch(() => {})` 是全成功或全丢弃，任一失败会连坐丢掉已取到的目录；应分别 settle、各自降级。属 #1434 引入代码的健壮性修复。
- ad + 参考生视频画布的 unit 总时长（各 shot 求和、只读展示）没有越界告警；该画布不是 issue 所指的逐镜头时长编辑器。
- 「新设置里清空分辨率」当前按「未配置」处理、继续回退 legacy 残留值，用户的清空动作因此不生效。改成「显式 `null` 即已清空」需要读取路径、保存期 legacy 迁移、前端查表三处一起动，并修订固定既有语义的用例，已列为 follow-up。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 逐镜头时长候选按项目已保存分辨率收窄；未保存则不施加分辨率约束。
  - Reference-to-Video 按对应口径收窄，并在越界时给出更精确的原因提示（多语言）。
  - 生成进行中时长编辑联动统一告警口径，前后各画布展示一致。
- **问题修复**
  - 越界处理由静默改写调整为警告并引导重选。
  - 任务占用时拒绝写回并锁定时长，避免竞态。
- **文档**
  - 更新“尺寸与比例/时长联动约束”前后端口径与生效范围说明。
- **测试**
  - 补强收窄、告警成因、占用态与越界校验等覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







