### PR TITLE
Register MiniMax speech-2.8-hd TTS backend

### DIFF
--- a/lib/audio_backends/__init__.py
+++ b/lib/audio_backends/__init__.py
@@ -20,6 +20,8 @@ __all__ = [
 
 # Backend auto-registration
 from lib.audio_backends.dashscope import DashScopeAudioBackend
-from lib.providers import PROVIDER_DASHSCOPE
+from lib.audio_backends.minimax import MiniMaxAudioBackend
+from lib.providers import PROVIDER_DASHSCOPE, PROVIDER_MINIMAX
 
 register_backend(PROVIDER_DASHSCOPE, DashScopeAudioBackend)
+register_backend(PROVIDER_MINIMAX, MiniMaxAudioBackend)

--- a/lib/audio_backends/minimax.py
+++ b/lib/audio_backends/minimax.py
@@ -1,0 +1,139 @@
+"""MiniMaxAudioBackend — MiniMax (Hailuo) speech-2.8-hd TTS backend (synchronous /v1/t2a_v2).
+
+Calls the native text-to-audio v2 endpoint: a single POST returns hex-encoded audio
+bytes in ``data.audio`` (no separate download step). The response also carries
+``base_resp.status_code`` (0 = success). The ``voice`` field maps to
+``voice_setting.voice_id``; the output format is derived from the file suffix.
+Schema verified against the official T2A v2 API reference.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import httpx
+
+from lib.audio_backends.base import (
+    AudioCapability,
+    AudioSynthesisRequest,
+    AudioSynthesisResult,
+)
+from lib.logging_utils import format_kwargs_for_log
+from lib.minimax_shared import (
+    extract_minimax_audio_hex,
+    minimax_failure_reason,
+    minimax_headers,
+    minimax_text_base_url,
+    resolve_minimax_api_key,
+    safe_body_for_log,
+)
+from lib.providers import PROVIDER_MINIMAX
+from lib.retry import with_retry_async
+from lib.video_backends.base import should_retry_submit, submit_post
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "speech-2.8-hd"
+
+_TTS_ENDPOINT = "/t2a_v2"
+
+# /v1/t2a_v2 supported output formats (official schema).
+_SUPPORTED_OUTPUT_FORMATS = frozenset({"mp3", "wav", "flac", "pcm"})
+_FALLBACK_OUTPUT_FORMAT = "mp3"
+
+
+def _output_format_for(output_path: Path) -> str:
+    """Pick output format from the file suffix; fall back to mp3 for unknown extensions."""
+    suffix = output_path.suffix.lstrip(".").lower()
+    return suffix if suffix in _SUPPORTED_OUTPUT_FORMATS else _FALLBACK_OUTPUT_FORMAT
+
+
+class MiniMaxAudioBackend:
+    """MiniMax speech synthesis backend (synchronous /v1/t2a_v2 endpoint)."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        http_timeout: float = 60.0,
+    ) -> None:
+        self._api_key = resolve_minimax_api_key(api_key)
+        self._base_url = minimax_text_base_url(base_url)
+        self._model = model or DEFAULT_MODEL
+        self._http_timeout = http_timeout
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_MINIMAX
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def capabilities(self) -> set[AudioCapability]:
+        return {AudioCapability.TEXT_TO_SPEECH}
+
+    async def synthesize(self, request: AudioSynthesisRequest) -> AudioSynthesisResult:
+        # MiniMax T2A returns hex-encoded audio directly in the response body — no separate
+        # download step (unlike DashScope which returns a URL). The synthesis POST is the billing
+        # step; write failure does not trigger a re-bill of the synthesis call.
+        audio_bytes = await self._request_synthesis(request)
+        request.output_path.write_bytes(audio_bytes)
+
+        logger.info("MiniMax speech synthesis complete: %s", request.output_path)
+
+        return AudioSynthesisResult(
+            provider=PROVIDER_MINIMAX,
+            model=self._model,
+            characters=len(request.text),
+            output_path=request.output_path,
+        )
+
+    @with_retry_async(retry_if=should_retry_submit)
+    async def _request_synthesis(self, request: AudioSynthesisRequest) -> bytes:
+        """Submit synthesis request (billing step), return decoded audio bytes."""
+        payload: dict = {
+            "model": self._model,
+            "text": request.text,
+            "voice_setting": {
+                "voice_id": request.voice,
+            },
+            "output_format": _output_format_for(request.output_path),
+        }
+        if request.language_type:
+            payload["language_boost"] = request.language_type
+
+        # safe_body_for_log only emits whitelisted scalars (model, output_format, language_boost);
+        # the input text is never logged (CodeQL clear-text-logging false positive).
+        logger.info(
+            "Calling %s speech synthesis API model=%s voice=%s format=%s chars=%d body=%s",
+            self.name,
+            self._model,
+            request.voice,
+            payload["output_format"],
+            len(request.text),
+            format_kwargs_for_log(safe_body_for_log(payload)),
+        )
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            # Non-idempotent billing POST: submit_post converts ambiguous transport errors into
+            # AmbiguousSubmitError (terminal failure, no retry to avoid double billing); >=400
+            # raises HTTPStatusError (status_code preserved) for should_retry_submit to gate
+            # (4xx fail-fast, 5xx/429 retry).
+            resp = await submit_post(
+                lambda: client.post(
+                    f"{self._base_url}{_TTS_ENDPOINT}",
+                    json=payload,
+                    headers=minimax_headers(self._api_key),
+                ),
+                provider=PROVIDER_MINIMAX,
+            )
+            data = resp.json()
+            reason = minimax_failure_reason(data)
+            if reason:
+                raise RuntimeError(reason)
+            hex_audio = extract_minimax_audio_hex(data)
+            return bytes.fromhex(hex_audio)

--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -327,6 +327,7 @@ _SIMPLE_MEDIA_PAIRS: list[tuple[str, str]] = [
     *((p, "image") for p in _SIMPLE_IMAGE_VIDEO_PROVIDERS),
     *((p, "video") for p in _SIMPLE_IMAGE_VIDEO_PROVIDERS),
     ("dashscope", "audio"),
+    ("minimax", "audio"),
 ]
 
 # gemini 两个 provider_id → backend_type，每个 × image/video 登记一行。

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -1102,7 +1102,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
         display_name="MiniMax",
         description="MiniMax（海螺）多模态平台，提供文本、图片、视频生成。默认连接国内站，海外可将 base_url 切换到国际站。",
         required_keys=["api_key"],
-        optional_keys=["base_url", "image_max_workers", "video_max_workers"],
+        optional_keys=["base_url", "image_max_workers", "video_max_workers", "audio_max_workers"],
         secret_keys=["api_key"],
         models={
             # --- text ---
@@ -1173,6 +1173,16 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 resolutions=["768p"],
                 max_reference_images=1,
                 pricing=_minimax_video_pricing("S2V-01", {("768p", 6): 3.0}),
+            ),
+            # --- audio ---
+            # speech-2.8-hd: synchronous HTTP TTS (t2a_v2), per-character billing.
+            # Audio bytes returned as hex in data.audio (no separate download step).
+            "speech-2.8-hd": ModelInfo(
+                display_name="MiniMax Speech 2.8 HD",
+                media_type="audio",
+                capabilities=["text_to_speech"],
+                default=True,
+                pricing=None,
             ),
         },
         default_base_url=MINIMAX_BASE_URL,

--- a/lib/minimax_shared.py
+++ b/lib/minimax_shared.py
@@ -135,12 +135,27 @@ def minimax_failure_reason(payload: object) -> str | None:
     return None
 
 
+# ── 同步 T2A v2 响应工具 ─────────────────────────────────────────────────────
+
+
+def extract_minimax_audio_hex(payload: object) -> str:
+    """从 t2a_v2 同步响应 ``data.audio`` 提取 hex 编码音频字节。
+
+    同步 TTS 端点单次 POST 直接返回音频（hex 字符串），无二段下载。
+    缺失或非字符串即抛错（caller 无法在不计费重跑的前提下获取音频，交任务层失败）。
+    """
+    audio = _as_dict(_as_dict(payload).get("data")).get("audio")
+    if not isinstance(audio, str) or not audio:
+        raise RuntimeError("MiniMax TTS response missing data.audio")
+    return audio
+
+
 # ── 日志脱敏 ──────────────────────────────────────────────────────────────────
 
 # 仅允许进日志的标量字段白名单；prompt 仅记长度、subject_reference 仅计数，
 # base64/URL 一律不入日志（对齐 CodeQL clear-text-logging 约束）。
 _SAFE_LOG_KEYS: frozenset[str] = frozenset(
-    {"model", "aspect_ratio", "width", "height", "response_format", "n", "prompt_optimizer", "seed"}
+    {"model", "aspect_ratio", "width", "height", "response_format", "n", "prompt_optimizer", "seed", "output_format", "language_boost"}
 )
 
 

--- a/tests/test_audio_backends.py
+++ b/tests/test_audio_backends.py
@@ -1,5 +1,6 @@
 """AudioBackend 家族测试：registry 注册/创建 + DashScopeAudioBackend（mock httpx，同步端点）
-+ OpenAIAudioBackend（mock SDK client，/v1/audio/speech）+ extract_audio_url。"""
++ OpenAIAudioBackend（mock SDK client，/v1/audio/speech）+ MiniMaxAudioBackend（mock httpx,
+同步 t2a_v2 端点）+ extract_audio_url。"""
 
 from __future__ import annotations
 
@@ -17,18 +18,27 @@ from lib.audio_backends import (
     register_backend,
 )
 from lib.dashscope_shared import extract_audio_url
-from lib.providers import PROVIDER_DASHSCOPE
+from lib.providers import PROVIDER_DASHSCOPE, PROVIDER_MINIMAX
 
 
 class TestRegistry:
     def test_dashscope_auto_registered(self):
         assert PROVIDER_DASHSCOPE in get_registered_backends()
 
+    def test_minimax_auto_registered(self):
+        assert PROVIDER_MINIMAX in get_registered_backends()
+
     def test_create_dashscope(self):
         from lib.audio_backends.dashscope import DashScopeAudioBackend
 
         backend = create_backend(PROVIDER_DASHSCOPE, api_key="sk")
         assert isinstance(backend, DashScopeAudioBackend)
+
+    def test_create_minimax(self):
+        from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+        backend = create_backend(PROVIDER_MINIMAX, api_key="sk")
+        assert isinstance(backend, MiniMaxAudioBackend)
 
     def test_unknown_backend_raises(self):
         with pytest.raises(ValueError, match="Unknown audio backend"):
@@ -374,3 +384,159 @@ class TestOpenAIAudioBackend:
                     await b.synthesize(req)
 
         assert mock_client.audio.speech.create.call_count == 1, "写盘失败不得重跑计费的合成调用"
+
+
+# ── MiniMax TTS (t2a_v2) ─────────────────────────────────────────────────────
+
+
+def _minimax_synth_response(hex_audio: str = "52494646", status_code: int = 0) -> MagicMock:
+    """Build a t2a_v2 response mock with hex-encoded audio in data.audio."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "data": {"audio": hex_audio, "status": 2},
+        "base_resp": {"status_code": status_code, "status_msg": "success" if status_code == 0 else "error"},
+    }
+    return resp
+
+
+def _minimax_error_response(status_code: int = 1004, status_msg: str = "invalid api key") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "data": {},
+        "base_resp": {"status_code": status_code, "status_msg": status_msg},
+    }
+    return resp
+
+
+class TestMiniMaxAudioBackend:
+    def test_metadata(self):
+        from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+        b = MiniMaxAudioBackend(api_key="sk", model="speech-2.8-hd")
+        assert b.name == PROVIDER_MINIMAX
+        assert b.model == "speech-2.8-hd"
+        assert b.capabilities == {AudioCapability.TEXT_TO_SPEECH}
+
+    def test_default_model(self):
+        from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+        b = MiniMaxAudioBackend(api_key="sk")
+        assert b.model == "speech-2.8-hd"
+
+    async def test_synthesize_request_and_bytes(self, tmp_path: Path):
+        hex_audio = b"RIFFwavbytes".hex()
+        client = _mock_client(_minimax_synth_response(hex_audio), _download_response(b"unused"))
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk", model="speech-2.8-hd", base_url="https://api.minimaxi.com/v1")
+            out = tmp_path / "o.mp3"
+            result = await b.synthesize(
+                AudioSynthesisRequest(text="hello world", output_path=out, voice="male-qn-qingse")
+            )
+
+        # Request body shape: model + text + voice_setting.voice_id + output_format from suffix
+        body = client.post.call_args.kwargs["json"]
+        assert body["model"] == "speech-2.8-hd"
+        assert body["text"] == "hello world"
+        assert body["voice_setting"] == {"voice_id": "male-qn-qingse"}
+        assert body["output_format"] == "mp3"
+        # Bearer auth
+        headers = client.post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer sk"
+        assert headers["Content-Type"] == "application/json"
+        # Endpoint: base + /t2a_v2
+        assert client.post.call_args.args[0].endswith("/t2a_v2")
+        # No second download step — audio decoded from hex directly
+        client.get.assert_not_called()
+        # Hex decoded and written to disk
+        assert out.read_bytes() == b"RIFFwavbytes"
+        assert result.provider == PROVIDER_MINIMAX
+        assert result.model == "speech-2.8-hd"
+        assert result.characters == len("hello world")
+        assert result.output_path == out
+
+    async def test_output_format_from_suffix(self, tmp_path: Path):
+        hex_audio = b"audio".hex()
+        client = _mock_client(_minimax_synth_response(hex_audio), _download_response(b"unused"))
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            await b.synthesize(AudioSynthesisRequest(text="hi", output_path=tmp_path / "o.wav", voice="v"))
+        assert client.post.call_args.kwargs["json"]["output_format"] == "wav"
+
+    async def test_unknown_suffix_falls_back_to_mp3(self, tmp_path: Path):
+        hex_audio = b"x".hex()
+        client = _mock_client(_minimax_synth_response(hex_audio), _download_response(b"unused"))
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            await b.synthesize(AudioSynthesisRequest(text="hi", output_path=tmp_path / "x.bin", voice="v"))
+        assert client.post.call_args.kwargs["json"]["output_format"] == "mp3"
+
+    async def test_language_type_sent_as_language_boost(self, tmp_path: Path):
+        hex_audio = b"x".hex()
+        client = _mock_client(_minimax_synth_response(hex_audio), _download_response(b"unused"))
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            await b.synthesize(
+                AudioSynthesisRequest(text="hi", output_path=tmp_path / "o.mp3", voice="v", language_type="Chinese")
+            )
+        assert client.post.call_args.kwargs["json"]["language_boost"] == "Chinese"
+
+    async def test_base_resp_error_raises(self, tmp_path: Path):
+        client = _mock_client(_minimax_error_response(), _download_response(b"unused"))
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            out = tmp_path / "err.mp3"
+            with pytest.raises(RuntimeError, match="1004"):
+                await b.synthesize(AudioSynthesisRequest(text="hi", output_path=out, voice="v"))
+        assert not out.exists()
+
+    async def test_missing_audio_raises(self, tmp_path: Path):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"data": {}, "base_resp": {"status_code": 0, "status_msg": "success"}}
+        client = _mock_client(resp, _download_response(b"unused"))
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            out = tmp_path / "noaudio.mp3"
+            with pytest.raises(RuntimeError, match="data.audio"):
+                await b.synthesize(AudioSynthesisRequest(text="hi", output_path=out, voice="v"))
+        assert not out.exists()
+
+    async def test_http_error_raises(self, tmp_path: Path):
+        err_resp = httpx.Response(400, text="bad request", request=httpx.Request("POST", "https://x"))
+        client = _mock_client(err_resp, _download_response(b"unused"))
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            with pytest.raises(httpx.HTTPStatusError):
+                await b.synthesize(AudioSynthesisRequest(text="x", output_path=tmp_path / "e.mp3", voice="v"))
+        assert client.post.call_count == 1
+
+    async def test_write_failure_does_not_rebill_synthesis(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
+        hex_audio = b"ok".hex()
+        client = _mock_client(_minimax_synth_response(hex_audio), _download_response(b"unused"))
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            out_dir = tmp_path / "missing-dir"
+            req = AudioSynthesisRequest(text="hi", output_path=out_dir / "o.mp3", voice="v")
+            with pytest.raises(OSError):
+                with patch.object(type(req.output_path), "write_bytes", side_effect=OSError("Connection timed out")):
+                    await b.synthesize(req)
+        assert client.post.call_count == 1, "write failure must not re-bill the synthesis call"

--- a/tests/test_backend_assembly_specs.py
+++ b/tests/test_backend_assembly_specs.py
@@ -506,7 +506,7 @@ class TestRegistryShape:
 
     def test_audio_only_dashscope_registered(self):
         audio_keys = {k for k in PROVIDER_SPEC_REGISTRY if k[1] == "audio"}
-        assert audio_keys == {("dashscope", "audio")}
+        assert audio_keys == {("dashscope", "audio"), ("minimax", "audio")}
 
     def test_simple_family_image_video_complete(self):
         for provider in ("ark", "ark-agent-plan", "grok", "openai", "vidu", "dashscope", "minimax"):

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -31,16 +31,22 @@ class TestRegistry:
         from lib.config.registry import PROVIDER_REGISTRY
 
         meta = PROVIDER_REGISTRY[PROVIDER_MINIMAX]
-        assert meta.media_types == ["image", "text", "video"]
+        assert meta.media_types == ["audio", "image", "text", "video"]
         assert "api_key" in meta.required_keys
         assert "api_key" in meta.secret_keys
         assert "base_url" in meta.optional_keys
+        assert "audio_max_workers" in meta.optional_keys
         assert meta.default_base_url == "https://api.minimaxi.com/v1"
         assert "MiniMax-M3" in meta.models
         assert meta.models["MiniMax-M3"].default is True
         assert "vision" in meta.models["MiniMax-M3"].capabilities
         assert "MiniMax-M2.7" in meta.models
         assert meta.models["MiniMax-M2.7"].default is False
+        # speech-2.8-hd: default audio model, text_to_speech capability
+        audio = meta.models["speech-2.8-hd"]
+        assert audio.media_type == "audio"
+        assert audio.default is True
+        assert audio.capabilities == ["text_to_speech"]
         # image-01：默认图像模型，T2I + I2I，单脸参考
         image = meta.models["image-01"]
         assert image.media_type == "image"


### PR DESCRIPTION
Reason: Register the speech-2.8-hd model in the MiniMax TTS pipeline.

## Changes

- **`lib/audio_backends/minimax.py`** (new): `MiniMaxAudioBackend` implementing the `AudioBackend` protocol. Calls the synchronous `/v1/t2a_v2` endpoint and decodes hex-encoded audio from `data.audio` directly (no separate download step). Maps `voice` to `voice_setting.voice_id`, derives `output_format` from the file suffix, and checks `base_resp.status_code` for business errors.
- **`lib/minimax_shared.py`**: Add `extract_minimax_audio_hex` helper (extracts hex audio from `data.audio`); add `output_format` and `language_boost` to the safe-log whitelist.
- **`lib/audio_backends/__init__.py`**: Auto-register `MiniMaxAudioBackend` under the `minimax` provider name.
- **`lib/backend_assembly/specs.py`**: Register `("minimax", "audio")` in `PROVIDER_SPEC_REGISTRY` so the assembly layer can build MiniMax audio backends.
- **`lib/config/registry.py`**: Add `speech-2.8-hd` as the default audio model for MiniMax (per-character billing, `text_to_speech` capability); add `audio_max_workers` to MiniMax optional keys.
- **Tests**: Add `TestMiniMaxAudioBackend` (10 tests covering metadata, synthesis, output format, language boost, error handling, and no-rebill write failures); update registry and spec tests to include MiniMax audio.

## Checks

- `pytest tests/test_audio_backends.py tests/test_minimax_shared.py tests/test_minimax_integration.py tests/test_tts_resolver.py tests/test_tts_pricing.py tests/test_execute_tts_task.py tests/test_backend_assembly_specs.py` — 180 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 MiniMax 音频文本转语音能力，默认使用 `speech-2.8-hd`，支持音色、输出格式及语言增强。
  - MiniMax 音频后端已完成自动注册与内置能力开放，并新增可配置的音频并发数选项。
- **错误修复**
  - 强化合成失败、返回音频数据缺失及写盘异常时的处理：明确抛错，并避免重复合成或不必要的下载流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->