### PR TITLE
feat(audio): expose MiniMax speech-2.8-hd model and add t2a_v2 audio backend

### DIFF
--- a/lib/audio_backends/__init__.py
+++ b/lib/audio_backends/__init__.py
@@ -20,6 +20,8 @@ __all__ = [
 
 # Backend auto-registration
 from lib.audio_backends.dashscope import DashScopeAudioBackend
-from lib.providers import PROVIDER_DASHSCOPE
+from lib.audio_backends.minimax import MiniMaxAudioBackend
+from lib.providers import PROVIDER_DASHSCOPE, PROVIDER_MINIMAX
 
 register_backend(PROVIDER_DASHSCOPE, DashScopeAudioBackend)
+register_backend(PROVIDER_MINIMAX, MiniMaxAudioBackend)

--- a/lib/audio_backends/minimax.py
+++ b/lib/audio_backends/minimax.py
@@ -1,0 +1,193 @@
+"""MiniMaxAudioBackend — MiniMax (海螺) speech synthesis backend (synchronous /v1/t2a_v2).
+
+Native text-to-audio endpoint: a single POST returns a download URL (24h valid) when
+``output_format="url"`` is requested, then an HTTP GET downloads the audio bytes to
+disk. Billing is per character (``extra_info.usage_characters``), mirrored from the
+synthesis request length by the AudioSynthesisResult. Schema per the official MiniMax
+speech-t2a-http API reference: required fields ``model`` / ``text``; voice carried in
+``voice_setting.voice_id``; audio container chosen via ``audio_setting.format``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import httpx
+
+from lib.audio_backends.base import (
+    AudioCapability,
+    AudioSynthesisRequest,
+    AudioSynthesisResult,
+)
+from lib.minimax_shared import (
+    minimax_headers,
+    minimax_text_base_url,
+    resolve_minimax_api_key,
+)
+from lib.providers import PROVIDER_MINIMAX
+from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
+from lib.video_backends.base import should_retry_download, should_retry_submit, submit_post
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "speech-2.8-hd"
+
+_TTS_ENDPOINT = "/t2a_v2"
+
+# t2a_v2 audio_setting.format 接受的容器（与 audio_formats 参考一致）。
+_SUPPORTED_AUDIO_FORMATS = frozenset({"mp3", "wav", "flac", "pcm"})
+_FALLBACK_AUDIO_FORMAT = "wav"
+
+
+def _audio_format_for(output_path: Path) -> str:
+    """按落盘扩展名选输出容器，保证文件内容与扩展名一致（资源路径约定 .wav）。"""
+    suffix = output_path.suffix.lstrip(".").lower()
+    return suffix if suffix in _SUPPORTED_AUDIO_FORMATS else _FALLBACK_AUDIO_FORMAT
+
+
+def _as_dict(value: object) -> dict:
+    """把任意值归一化为 dict（与 minimax_shared 同口径），避免非 dict 真值调 .get。"""
+    return value if isinstance(value, dict) else {}
+
+
+def _tts_failure_reason(payload: dict) -> str | None:
+    """base_resp.status_code 非零时返回错误描述；成功（0）或缺失 base_resp 返回 None。
+
+    MiniMax 业务错误以 HTTP 200 + base_resp.status_code 非零承载，故同步响应须先查
+    base_resp 再取音频 URL（与图像 / 视频响应同构）。
+    """
+    base = _as_dict(_as_dict(payload).get("base_resp"))
+    status = base.get("status_code")
+    if status is not None and status != 0:
+        msg = base.get("status_msg") or ""
+        return f"MiniMax 语音合成失败 status_code={status}: {msg}".strip()
+    return None
+
+
+class _EmptyDownloadError(RuntimeError):
+    """200 但空响应体（瞬时代理/CDN 异常），视为瞬态触发下载重试。"""
+
+
+class MiniMaxAudioBackend:
+    """MiniMax 语音合成后端（同步 t2a_v2 端点）。"""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        http_timeout: float = 60.0,
+    ) -> None:
+        self._api_key = resolve_minimax_api_key(api_key)
+        self._base_url = minimax_text_base_url(base_url)
+        self._model = model or DEFAULT_MODEL
+        self._http_timeout = http_timeout
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_MINIMAX
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def capabilities(self) -> set[AudioCapability]:
+        return {AudioCapability.TEXT_TO_SPEECH}
+
+    async def synthesize(self, request: AudioSynthesisRequest) -> AudioSynthesisResult:
+        # 合成（计费）与下载分两段独立重试：下载瞬时失败只重试 GET，绝不回头重跑会再次计费的
+        # 合成 POST（与 DashScopeAudioBackend 及 lib.retry.DOWNLOAD_* 语义一致）。
+        url = await self._request_synthesis(request)
+        await self._download_audio(url, request.output_path)
+        logger.info("MiniMax 语音合成完成: %s", request.output_path)
+        return AudioSynthesisResult(
+            provider=PROVIDER_MINIMAX,
+            model=self._model,
+            characters=len(request.text),
+            output_path=request.output_path,
+        )
+
+    @with_retry_async(retry_if=should_retry_submit)
+    async def _request_synthesis(self, request: AudioSynthesisRequest) -> str:
+        """提交合成请求（计费段），返回 data.audio 下载 URL。"""
+        voice_setting: dict[str, object] = {"voice_id": request.voice}
+        if request.speed is not None:
+            voice_setting["speed"] = request.speed
+        payload: dict = {
+            "model": self._model,
+            "text": request.text,
+            "output_format": "url",
+            "voice_setting": voice_setting,
+            "audio_setting": {"format": _audio_format_for(request.output_path)},
+        }
+        if request.language_type:
+            payload["language_boost"] = request.language_type
+
+        # 日志只带白名单标量 + 文本长度，不展开合成文本（CodeQL clear-text-logging 约束）。
+        logger.info(
+            "调用 %s 语音合成 API model=%s voice=%s language=%s format=%s chars=%d",
+            self.name,
+            self._model,
+            request.voice,
+            request.language_type,
+            payload["audio_setting"]["format"],
+            len(request.text),
+        )
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            # 合成是非幂等的「计费」POST：submit_post 把歧义传输错误转 AmbiguousSubmitError
+            # 终态失败避免重复计费；>=400 落 body 日志 + 抛 HTTPStatusError（保留 status_code），
+            # 交 should_retry_submit 按状态码分流——4xx fail-fast、5xx/429 重试。
+            resp = await submit_post(
+                lambda: client.post(
+                    f"{self._base_url}{_TTS_ENDPOINT}",
+                    json=payload,
+                    headers=minimax_headers(self._api_key),
+                ),
+                provider=PROVIDER_MINIMAX,
+            )
+            data = resp.json()
+
+        reason = _tts_failure_reason(data)
+        if reason:
+            # 不嵌完整响应体进异常消息：body 里的 "503"/"timeout" 子串会被默认 _should_retry
+            # 误判为可重试（仓库已确立按状态码而非字符串判重试）。
+            logger.error("MiniMax 语音合成业务错误: %s", reason)
+            raise RuntimeError(reason)
+
+        url = _as_dict(_as_dict(data).get("data")).get("audio")
+        if not isinstance(url, str) or not url:
+            logger.error("MiniMax 语音合成响应缺少 data.audio URL: %s", data)
+            raise RuntimeError("MiniMax 语音合成响应缺少 data.audio URL")
+        return url
+
+    @with_retry_async(
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
+        # 下载是幂等 GET：HTTPStatusError 按 status_code 闸门（should_retry_download，4xx 含 404 一律
+        # fail-fast——结果 URL 的 4xx 是确定性错误），5xx/传输/网络错误重试，业务错误 fail-fast；
+        # 200-空体（_EmptyDownloadError）属瞬态另行重试。
+        retry_if=lambda e: isinstance(e, _EmptyDownloadError) or should_retry_download(e),
+    )
+    async def _download_audio(self, url: str, output_path: Path) -> None:
+        """下载合成音频（非计费段，可独立多次重试）。"""
+        # 日志与异常只带去掉 query 的 URL：结果 URL 在有效期内等同下载凭证。
+        safe_url = url.split("?", 1)[0]
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            resp = await client.get(url)
+            if resp.status_code >= 400:
+                logger.warning("MiniMax 音频下载返回 %s: %s", resp.status_code, safe_url)
+                # 不用 raise_for_status：它生成的异常文本携带完整结果 URL；
+                # 手动构造保留异常类型与 .response.status_code，消息只带脱敏 URL。
+                raise httpx.HTTPStatusError(
+                    f"MiniMax 音频下载返回 {resp.status_code}: {safe_url}",
+                    request=resp.request,
+                    response=resp,
+                )
+            if not resp.content:
+                # 200 但空体：不写 0 字节音频
+                raise _EmptyDownloadError(f"MiniMax 音频下载返回空内容: {safe_url}")
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(resp.content)

--- a/lib/backend_assembly/specs.py
+++ b/lib/backend_assembly/specs.py
@@ -320,13 +320,14 @@ def _text_openai_compat_spec(
 # 构造形态分三类登记（简单文本 / gemini 文本 / OpenAI-compat 文本，见各闭包），其中 dashscope/minimax 文本
 # 映射到 "openai" registry backend，别名映射并入 spec.registry_backend 字段。每对显式登记一行，fail-loud
 # （未登记的 provider × media 抛 ValueError，不「缺席即默认」造静默错误 backend）。只登记今天确有注册 backend
-# 的对：image/video 简单族七家齐全，audio 仅 dashscope，text 八家（六 provider，gemini 两 id）。
+# 的对：image/video 简单族七家齐全，audio 含 dashscope 与 minimax，text 八家（六 provider，gemini 两 id）。
 
 _SIMPLE_IMAGE_VIDEO_PROVIDERS = ("ark", "ark-agent-plan", "grok", "openai", "vidu", "dashscope", "minimax")
 _SIMPLE_MEDIA_PAIRS: list[tuple[str, str]] = [
     *((p, "image") for p in _SIMPLE_IMAGE_VIDEO_PROVIDERS),
     *((p, "video") for p in _SIMPLE_IMAGE_VIDEO_PROVIDERS),
     ("dashscope", "audio"),
+    ("minimax", "audio"),
 ]
 
 # gemini 两个 provider_id → backend_type，每个 × image/video 登记一行。

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -1100,9 +1100,9 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
     ),
     "minimax": ProviderMeta(
         display_name="MiniMax",
-        description="MiniMax（海螺）多模态平台，提供文本、图片、视频生成。默认连接国内站，海外可将 base_url 切换到国际站。",
+        description="MiniMax（海螺）多模态平台，提供文本、图片、视频与语音合成。默认连接国内站，海外可将 base_url 切换到国际站。",
         required_keys=["api_key"],
-        optional_keys=["base_url", "image_max_workers", "video_max_workers"],
+        optional_keys=["base_url", "image_max_workers", "video_max_workers", "audio_max_workers"],
         secret_keys=["api_key"],
         models={
             # --- text ---
@@ -1173,6 +1173,52 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 resolutions=["768p"],
                 max_reference_images=1,
                 pricing=_minimax_video_pricing("S2V-01", {("768p", 6): 3.0}),
+            ),
+            # --- audio ---
+            # MiniMax speech-2.x / speech-0x 系列：同步 /v1/t2a_v2 端点，按字符计费。
+            # 官方未公布稳定的按字符公开费率（见 docs/research/arcreel-tts-narration-research.md
+            # 中 MiniMax 计费档「被否决」0-3），故 pricing 暂不声明，回落到默认模型再回落 Gemini
+            # 通用费率；待官方费率核实后在此补 PerCharacter 声明。speech-2.8-hd 为当前默认型号。
+            "speech-2.8-hd": ModelInfo(
+                display_name="MiniMax Speech 2.8 HD",
+                media_type="audio",
+                capabilities=["text_to_speech"],
+                default=True,
+            ),
+            "speech-2.8-turbo": ModelInfo(
+                display_name="MiniMax Speech 2.8 Turbo",
+                media_type="audio",
+                capabilities=["text_to_speech"],
+            ),
+            "speech-2.6-hd": ModelInfo(
+                display_name="MiniMax Speech 2.6 HD",
+                media_type="audio",
+                capabilities=["text_to_speech"],
+            ),
+            "speech-2.6-turbo": ModelInfo(
+                display_name="MiniMax Speech 2.6 Turbo",
+                media_type="audio",
+                capabilities=["text_to_speech"],
+            ),
+            "speech-02-hd": ModelInfo(
+                display_name="MiniMax Speech 02 HD",
+                media_type="audio",
+                capabilities=["text_to_speech"],
+            ),
+            "speech-02-turbo": ModelInfo(
+                display_name="MiniMax Speech 02 Turbo",
+                media_type="audio",
+                capabilities=["text_to_speech"],
+            ),
+            "speech-01-hd": ModelInfo(
+                display_name="MiniMax Speech 01 HD",
+                media_type="audio",
+                capabilities=["text_to_speech"],
+            ),
+            "speech-01-turbo": ModelInfo(
+                display_name="MiniMax Speech 01 Turbo",
+                media_type="audio",
+                capabilities=["text_to_speech"],
             ),
         },
         default_base_url=MINIMAX_BASE_URL,

--- a/tests/test_audio_backends.py
+++ b/tests/test_audio_backends.py
@@ -30,6 +30,18 @@ class TestRegistry:
         backend = create_backend(PROVIDER_DASHSCOPE, api_key="sk")
         assert isinstance(backend, DashScopeAudioBackend)
 
+    def test_minimax_auto_registered(self):
+        from lib.providers import PROVIDER_MINIMAX
+
+        assert PROVIDER_MINIMAX in get_registered_backends()
+
+    def test_create_minimax(self):
+        from lib.audio_backends.minimax import MiniMaxAudioBackend
+        from lib.providers import PROVIDER_MINIMAX
+
+        backend = create_backend(PROVIDER_MINIMAX, api_key="sk")
+        assert isinstance(backend, MiniMaxAudioBackend)
+
     def test_unknown_backend_raises(self):
         with pytest.raises(ValueError, match="Unknown audio backend"):
             create_backend("nope")

--- a/tests/test_backend_assembly_specs.py
+++ b/tests/test_backend_assembly_specs.py
@@ -108,6 +108,16 @@ class TestMediaRegistryRouting:
             "dashscope", api_key="sk-test", model="qwen3-tts-flash", base_url="https://dashscope.aliyuncs.com"
         )
 
+    @patch("lib.audio_backends.registry.create_backend")
+    def test_minimax_audio_uses_audio_registry(self, mock_create):
+        spec = get_provider_spec("minimax", "audio")
+        config = _loaded(credentials={"api_key": "sk-test"}, provider_id="minimax")
+        spec.build_backend(config, "speech-2.8-hd")
+        # 用户未配 base_url → 回落 registry default（国内站 /v1）
+        mock_create.assert_called_once_with(
+            "minimax", api_key="sk-test", model="speech-2.8-hd", base_url="https://api.minimaxi.com/v1"
+        )
+
 
 class TestGeminiSpec:
     """gemini 特例族：backend_type 按 provider_id 分叉（aistudio/vertex 各一行），image/video 对等透传
@@ -504,9 +514,9 @@ class TestRegistryShape:
         with pytest.raises(ValueError, match="no builtin ProviderSpec"):
             get_provider_spec("ark", "audio")  # ark 无 audio backend，未登记
 
-    def test_audio_only_dashscope_registered(self):
+    def test_audio_only_dashscope_and_minimax_registered(self):
         audio_keys = {k for k in PROVIDER_SPEC_REGISTRY if k[1] == "audio"}
-        assert audio_keys == {("dashscope", "audio")}
+        assert audio_keys == {("dashscope", "audio"), ("minimax", "audio")}
 
     def test_simple_family_image_video_complete(self):
         for provider in ("ark", "ark-agent-plan", "grok", "openai", "vidu", "dashscope", "minimax"):

--- a/tests/test_minimax_audio_backend.py
+++ b/tests/test_minimax_audio_backend.py
@@ -1,0 +1,294 @@
+"""MiniMaxAudioBackend tests: registry registration + /v1/t2a_v2 request/response
++ download retry isolation + base_resp business error + audio format/voice mapping.
+
+Mirrors TestDashScopeAudioBackend patterns: mock httpx.AsyncClient, assert the
+non-idempotent synthesis POST is never retried when the idempotent download GET fails.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from lib.audio_backends import (
+    AudioCapability,
+    AudioSynthesisRequest,
+    create_backend,
+    get_registered_backends,
+)
+from lib.providers import PROVIDER_MINIMAX
+
+
+class TestRegistry:
+    def test_minimax_auto_registered(self):
+        assert PROVIDER_MINIMAX in get_registered_backends()
+
+    def test_create_minimax(self):
+        from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+        backend = create_backend(PROVIDER_MINIMAX, api_key="sk")
+        assert isinstance(backend, MiniMaxAudioBackend)
+
+    def test_default_model_is_speech_2_8_hd(self):
+        from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+        assert MiniMaxAudioBackend(api_key="sk").model == "speech-2.8-hd"
+
+
+class TestRegistryModels:
+    def test_minimax_exposes_speech_models(self):
+        from lib.config.registry import PROVIDER_REGISTRY, default_model_for_provider
+
+        meta = PROVIDER_REGISTRY[PROVIDER_MINIMAX]
+        assert "audio" in meta.media_types
+        for model_id in (
+            "speech-2.8-hd",
+            "speech-2.8-turbo",
+            "speech-2.6-hd",
+            "speech-2.6-turbo",
+            "speech-02-hd",
+            "speech-02-turbo",
+            "speech-01-hd",
+            "speech-01-turbo",
+        ):
+            info = meta.models[model_id]
+            assert info.media_type == "audio"
+            assert "text_to_speech" in info.capabilities
+        assert default_model_for_provider(PROVIDER_MINIMAX, "audio") == "speech-2.8-hd"
+
+
+def _synth_response(url: str = "https://x/out.wav") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "data": {"audio": url, "status": 2},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    return resp
+
+
+def _download_response(content: bytes = b"RIFFfakewav") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.content = content
+    return resp
+
+
+def _mock_client(post_resp: httpx.Response | MagicMock, get_resp: httpx.Response | MagicMock) -> AsyncMock:
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=post_resp)
+    client.get = AsyncMock(return_value=get_resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+class TestMiniMaxAudioBackend:
+    def test_metadata(self):
+        from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+        b = MiniMaxAudioBackend(api_key="sk", model="speech-2.8-hd")
+        assert b.name == PROVIDER_MINIMAX
+        assert b.model == "speech-2.8-hd"
+        assert b.capabilities == {AudioCapability.TEXT_TO_SPEECH}
+
+    def test_default_model(self):
+        from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+        assert MiniMaxAudioBackend(api_key="sk").model == "speech-2.8-hd"
+
+    async def test_synthesize_request_and_download(self, tmp_path: Path):
+        client = _mock_client(_synth_response(), _download_response(b"RIFFwavbytes"))
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk", model="speech-2.8-hd", base_url="https://api.minimaxi.com")
+            out = tmp_path / "o.wav"
+            result = await b.synthesize(
+                AudioSynthesisRequest(text="你好世界", output_path=out, voice="male-qn-qingse", language_type="Chinese")
+            )
+
+        body = client.post.call_args.kwargs["json"]
+        assert body["model"] == "speech-2.8-hd"
+        assert body["text"] == "你好世界"
+        assert body["output_format"] == "url"
+        assert body["voice_setting"] == {"voice_id": "male-qn-qingse"}
+        assert body["audio_setting"]["format"] == "wav"
+        assert body["language_boost"] == "Chinese"
+        # 鉴权头 + 端点
+        headers = client.post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer sk"
+        assert client.post.call_args.args[0].endswith("/v1/t2a_v2")
+        # 下载 URL 命中响应里的 data.audio
+        assert client.get.call_args.args[0] == "https://x/out.wav"
+        # 字节落盘 + 结果字段
+        assert out.read_bytes() == b"RIFFwavbytes"
+        assert result.provider == PROVIDER_MINIMAX
+        assert result.model == "speech-2.8-hd"
+        assert result.characters == len("你好世界")
+        assert result.output_path == out
+
+    async def test_speed_passthrough_into_voice_setting(self, tmp_path: Path):
+        client = _mock_client(_synth_response(), _download_response())
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            await b.synthesize(AudioSynthesisRequest(text="hi", output_path=tmp_path / "s.wav", voice="v", speed=1.5))
+        body = client.post.call_args.kwargs["json"]
+        assert body["voice_setting"]["speed"] == 1.5
+
+    async def test_speed_omitted_when_none(self, tmp_path: Path):
+        client = _mock_client(_synth_response(), _download_response())
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            await b.synthesize(AudioSynthesisRequest(text="hi", output_path=tmp_path / "s.wav", voice="v"))
+        body = client.post.call_args.kwargs["json"]
+        assert "speed" not in body["voice_setting"]
+
+    async def test_audio_format_follows_extension(self, tmp_path: Path):
+        client = _mock_client(_synth_response(), _download_response())
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            await b.synthesize(AudioSynthesisRequest(text="hi", output_path=tmp_path / "o.mp3", voice="v"))
+        assert client.post.call_args.kwargs["json"]["audio_setting"]["format"] == "mp3"
+
+    async def test_unknown_suffix_falls_back_to_wav(self, tmp_path: Path):
+        client = _mock_client(_synth_response(), _download_response())
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            await b.synthesize(AudioSynthesisRequest(text="hi", output_path=tmp_path / "x.bin", voice="v"))
+        assert client.post.call_args.kwargs["json"]["audio_setting"]["format"] == "wav"
+
+    async def test_base_resp_error_raises(self, tmp_path: Path):
+        # 200 + base_resp.status_code != 0 → 业务错误，不取音频、不下载
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"data": {}, "base_resp": {"status_code": 1001, "status_msg": "bad voice"}}
+        client = _mock_client(resp, _download_response())
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            with pytest.raises(RuntimeError, match="语音合成失败"):
+                await b.synthesize(AudioSynthesisRequest(text="x", output_path=tmp_path / "e.wav", voice="v"))
+        # 业务错误不触发下载
+        client.get.assert_not_called()
+
+    async def test_missing_audio_url_raises(self, tmp_path: Path):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"data": {}, "base_resp": {"status_code": 0, "status_msg": "success"}}
+        client = _mock_client(resp, _download_response())
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            with pytest.raises(RuntimeError, match="data.audio"):
+                await b.synthesize(AudioSynthesisRequest(text="x", output_path=tmp_path / "e.wav", voice="v"))
+        client.get.assert_not_called()
+
+    async def test_http_error_raises(self, tmp_path: Path):
+        # 4xx 透出 httpx.HTTPStatusError；计费的合成 POST 只发一次、不连带触发下载
+        err_resp = httpx.Response(400, text="bad request", request=httpx.Request("POST", "https://x"))
+        client = _mock_client(err_resp, _download_response())
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            with pytest.raises(httpx.HTTPStatusError):
+                await b.synthesize(AudioSynthesisRequest(text="x", output_path=tmp_path / "e.wav", voice="v"))
+        assert client.post.call_count == 1
+        client.get.assert_not_called()
+
+    async def test_download_failure_does_not_rebill_synthesis(self, tmp_path: Path, monkeypatch):
+        # 下载瞬时失败只重试 GET，绝不回头重跑会再次计费的合成 POST。
+        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=_synth_response())
+        client.get = AsyncMock(side_effect=[httpx.ConnectError("transient"), _download_response(b"ok")])
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            out = tmp_path / "d.wav"
+            await b.synthesize(AudioSynthesisRequest(text="hi", output_path=out, voice="v"))
+
+        # 合成 POST 只发一次（未被下载重试连带重跑 → 不重复计费），下载 GET 重试到第 2 次成功
+        assert client.post.call_count == 1
+        assert client.get.call_count == 2
+        assert out.read_bytes() == b"ok"
+
+    async def test_empty_download_retried_then_rejected_no_file(self, tmp_path: Path, monkeypatch):
+        # 200 但空体视为瞬态：重试到下载上限后失败，不写 0 字节音频，合成 POST 不被重跑。
+        from lib.retry import DOWNLOAD_MAX_ATTEMPTS
+
+        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=_synth_response())
+        client.get = AsyncMock(return_value=_download_response(b""))
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            out = tmp_path / "empty.wav"
+            with pytest.raises(RuntimeError, match="空内容"):
+                await b.synthesize(AudioSynthesisRequest(text="hi", output_path=out, voice="v"))
+
+        assert client.post.call_count == 1
+        assert client.get.call_count == DOWNLOAD_MAX_ATTEMPTS
+        assert not out.exists()
+
+    async def test_empty_download_transient_recovers(self, tmp_path: Path, monkeypatch):
+        # 空体一次后恢复：重试拿到字节落盘，合成 POST 不被重跑
+        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=_synth_response())
+        client.get = AsyncMock(side_effect=[_download_response(b""), _download_response(b"ok")])
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            out = tmp_path / "recover.wav"
+            await b.synthesize(AudioSynthesisRequest(text="hi", output_path=out, voice="v"))
+
+        assert client.post.call_count == 1
+        assert client.get.call_count == 2
+        assert out.read_bytes() == b"ok"
+
+    async def test_download_http_error_raises(self, tmp_path: Path, monkeypatch):
+        # 下载 4xx：透出 httpx.HTTPStatusError 且不写文件、不被误判可重试、合成 POST 不被重跑；
+        # 异常文本不携带结果 URL query（有效期内等同下载凭证）
+        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
+        signed_url = "https://x/out.wav?Expires=1&Signature=topsecret"
+        err_resp = httpx.Response(404, request=httpx.Request("GET", signed_url))
+        client = _mock_client(_synth_response(signed_url), err_resp)
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.audio_backends.minimax import MiniMaxAudioBackend
+
+            b = MiniMaxAudioBackend(api_key="sk")
+            out = tmp_path / "err.wav"
+            with pytest.raises(httpx.HTTPStatusError) as excinfo:
+                await b.synthesize(AudioSynthesisRequest(text="hi", output_path=out, voice="v"))
+
+        assert "Signature" not in str(excinfo.value)
+        assert "https://x/out.wav" in str(excinfo.value)
+        assert excinfo.value.response.status_code == 404
+        assert client.post.call_count == 1
+        assert client.get.call_count == 1, "4xx 不可重试，下载 GET 不应被重试"
+        assert not out.exists()


### PR DESCRIPTION
Reason: Expose the MiniMax speech-2.8-hd model family in the built-in MiniMax registry and wire the TTS pipeline to the native t2a_v2 endpoint.

## Changes

- **`lib/config/registry.py`**: Register the MiniMax speech model family (`speech-2.8-hd` as default, plus `speech-2.8-turbo`, `speech-2.6-hd`, `speech-2.6-turbo`, `speech-02-hd`, `speech-02-turbo`, `speech-01-hd`, `speech-01-turbo`) under the `minimax` provider with `media_type="audio"` and `text_to_speech` capability, and add `audio_max_workers` to its optional keys. No pricing is declared because the official per-character rate is not yet verified (falls back to the default-model path); a `PerCharacter` declaration can be added once the rate is confirmed.
- **`lib/audio_backends/minimax.py`** (new): `MiniMaxAudioBackend` drives the synchronous `POST /v1/t2a_v2` endpoint with Bearer auth, requesting `output_format="url"` and downloading the returned audio. Synthesis (billed) and download (idempotent GET) use isolated retry scopes so a transient download failure never re-runs the billed synthesis POST. The audio container (`mp3`/`wav`/`flac`/`pcm`) follows the output path extension; `voice_setting.voice_id`, `speed`, and `language_boost` are mapped from the generic request.
- **`lib/audio_backends/__init__.py`**: Auto-register the `MiniMaxAudioBackend` under `PROVIDER_MINIMAX`.
- **`lib/backend_assembly/specs.py`**: Register the `("minimax", "audio")` provider spec so backend assembly routes the audio lane to the new backend.

## Tests

- **`tests/test_minimax_audio_backend.py`** (new): registry registration, default model, `/v1/t2a_v2` request body/headers/endpoint, voice/speed/format mapping, `base_resp` business error, missing `data.audio`, HTTP 4xx fail-fast, download retry isolation (no rebilling), empty-body transient recovery.
- **`tests/test_audio_backends.py`**: assert MiniMax is auto-registered and instantiable via `create_backend`.
- **`tests/test_backend_assembly_specs.py`**: assert `("minimax", "audio")` is registered and routes to the audio registry with the registry default base URL.

## Verification

- `ruff check` and `ruff format --check` pass on all changed files.
- `pytest tests/test_minimax_audio_backend.py tests/test_audio_backends.py tests/test_backend_assembly_specs.py` — 86 passed.
- `pytest tests/test_tts_pricing.py tests/test_tts_resolver.py tests/test_tts_skeleton.py tests/test_pricing_lookup.py tests/test_pricing_strategies.py tests/test_minimax_shared.py tests/test_agent_provider_catalog.py tests/test_backend_assembly_loader.py tests/test_minimax_video_backend.py tests/test_minimax_image_backend.py` — 255 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 MiniMax 语音合成功能，支持多种 `speech-*` 音频模型。
  * 支持将合成音频下载并保存至指定路径。
  * MiniMax 音频服务已纳入自动注册与媒体路由。
  * 支持音频格式映射、语音速度设置及请求失败重试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->