### PR TITLE
refactor(frontend): 占用判定的提交时刻复核统一走 tasks-store 的 isResourceBusy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ ConfigService（`service.py`）→ Repository（持久化 + 密钥脱敏）→ R
 - 路径别名：`@/` → `frontend/src/`
 - Vite 代理：`/api` → `http://127.0.0.1:1241`
 - i18n：`i18next` + `react-i18next`，翻译文件在 `frontend/src/i18n/{zh,en,vi}/`，命名空间 `common`/`dashboard`/`auth`/`errors`/`assets`/`templates`
-- **占用感知型控件接线** — 编辑/重生成/上传/入库/版本恢复等随资源占用态禁用的控件，新增或改动时通过三项检查：弹窗/面板打开时校验当前占用态；提交时刻复核最新占用态（打开后状态可能已变化，仅查打开时刻会留竞态窗口）；同一资源卡片上的兄弟控件同步接线禁用
+- **占用感知型控件接线** — 编辑/重生成/上传/入库/版本恢复等随资源占用态禁用的控件，新增或改动时通过三项检查：弹窗/面板打开时校验当前占用态；提交时刻用 `frontend/src/stores/tasks-store.ts` 导出的 `isResourceBusy(kind, projectName, resourceId)` 复核最新占用态（打开后状态可能已变化，仅查打开时刻会留竞态窗口）；同一资源卡片上的兄弟控件同步接线禁用
 - **入队走动作层** — 生成类入队操作一律经 `frontend/src/actions/` 的动作函数（内部统一封装 API 调用、乐观占用打标与去重提示），组件不直调入队类 API 方法；新增入队类 API 方法时同步登记 `frontend/eslint.config.js` 中 no-restricted-syntax 的方法名清单
 
 ## 关键设计模式

--- a/frontend/src/components/canvas/lorebook/assetBusyGuard.ts
+++ b/frontend/src/components/canvas/lorebook/assetBusyGuard.ts
@@ -6,7 +6,7 @@ import { isResourceBusy } from "@/stores/tasks-store";
  * 立绘上传的提交时刻复核：从点击上传按钮到文件选完之间，该资源可能已被别处（另一标签页、
  * Agent、image_edit）入队占用，只查渲染时刻会留一个竞态窗口。命中则拒绝并给出可见反馈。
  *
- * `kind` 取 `isResourceBusy` 的资源种类口径，与 `StudioCanvasRouter` 算各卡片
+ * `kind` 取 `taskResourceKind` 的资源种类口径，与 `StudioCanvasRouter` 算各卡片
  * `generating` 的口径同源，不另立判据。
  */
 export function rejectIfAssetBusy(

--- a/frontend/src/components/canvas/lorebook/assetBusyGuard.ts
+++ b/frontend/src/components/canvas/lorebook/assetBusyGuard.ts
@@ -1,12 +1,12 @@
 import type { TFunction } from "i18next";
 import { useAppStore } from "@/stores/app-store";
-import { selectActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
+import { isResourceBusy } from "@/stores/tasks-store";
 
 /**
  * 立绘上传的提交时刻复核：从点击上传按钮到文件选完之间，该资源可能已被别处（另一标签页、
  * Agent、image_edit）入队占用，只查渲染时刻会留一个竞态窗口。命中则拒绝并给出可见反馈。
  *
- * `kind` 取 `selectActiveResourceIds` 的资源种类口径，与 `StudioCanvasRouter` 算各卡片
+ * `kind` 取 `isResourceBusy` 的资源种类口径，与 `StudioCanvasRouter` 算各卡片
  * `generating` 的口径同源，不另立判据。
  */
 export function rejectIfAssetBusy(
@@ -15,8 +15,7 @@ export function rejectIfAssetBusy(
   name: string,
   t: TFunction,
 ): boolean {
-  const { tasks, optimisticActive } = useTasksStore.getState();
-  if (!selectActiveResourceIds(tasks, kind, projectName, optimisticActive).has(name)) return false;
+  if (!isResourceBusy(kind, projectName, name)) return false;
   useAppStore.getState().pushToast(t("assets:upload_sheet_busy_hint"), "info");
   return true;
 }

--- a/frontend/src/components/canvas/reference/AdReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/AdReferenceVideoCanvas.tsx
@@ -16,10 +16,9 @@ import { enqueueReferenceVideoUnit } from "@/actions/generation";
 import { EpisodeHeader } from "./EpisodeHeader";
 import { StatusBadge, deriveUnitStatus } from "./unit-status";
 import {
-  selectActiveResourceIds,
+  isResourceBusy,
   useActiveResourceIds,
   useLatestTasksByResource,
-  useTasksStore,
 } from "@/stores/tasks-store";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
@@ -94,7 +93,7 @@ export function AdReferenceVideoCanvas({
   // 该 unit 存在未落库的镜头字段写入时，阻止同 unit 的生成入队——PATCH 与生成请求
   // 并发时后端可能仍按写入前的旧值处理，成片与用户刚编辑的时长/文案对不上。
   // ref 与 state 同步维护：state 供渲染（禁用态展示），ref 供 liveSavingUnitIds()
-  // 在异步函数体内新鲜读——与 liveBusyUnitIds() 同一动机，闭包捕获的 state 在
+  // 在异步函数体内新鲜读——与 isUnitBusy() 同一动机，闭包捕获的 state 在
   // await 跨越的时间窗口里可能已经过期（如 generateAll 的 derive() 之后的循环）。
   const savingUnitIdsRef = useRef<Set<string>>(new Set());
   const [savingUnitIds, setSavingUnitIdsState] = useState<Set<string>>(new Set());
@@ -183,17 +182,16 @@ export function AdReferenceVideoCanvas({
   // 提交时刻的占用集新鲜读：渲染期捕获的 busy 快照未必反映最新占用态（批量生成循环、
   // Agent 入队、SSE 落库都可能在渲染之后、点击之前占用同一 unit），故各写入口一律在
   // 提交那一刻重读 store 而非用渲染期的值。乐观标记集一并计入，动作层刚打的标记才能被看到。
-  const liveBusyUnitIds = useCallback(() => {
-    const { tasks, optimisticActive } = useTasksStore.getState();
-    return selectActiveResourceIds(tasks, "reference_video", projectName, optimisticActive);
-  }, [projectName]);
+  const isUnitBusy = useCallback(
+    (unitId: string) => isResourceBusy("reference_video", projectName, unitId),
+    [projectName],
+  );
 
   const derive = useCallback(async (): Promise<AdReferenceUnit[]> => {
     // 命中即中止——避免把仍在跑的旧任务对应的成员重新绑定到派生后的新分组；
     // 有镜头字段写入未落库时同样中止，避免派生与该 PATCH 的落库顺序不确定。
-    const live = liveBusyUnitIds();
     const saving = liveSavingUnitIds();
-    if (hydrated.some(({ unit }) => live.has(unit.unit_id) || saving.has(unit.unit_id))) {
+    if (hydrated.some(({ unit }) => isUnitBusy(unit.unit_id) || saving.has(unit.unit_id))) {
       useAppStore.getState().pushToast(t("ad_ref_rederive_busy"), "error");
       return [];
     }
@@ -211,13 +209,13 @@ export function AdReferenceVideoCanvas({
     } finally {
       setDeriving(false);
     }
-  }, [projectName, episode, hydrated, liveBusyUnitIds, liveSavingUnitIds, t]);
+  }, [projectName, episode, hydrated, isUnitBusy, liveSavingUnitIds, t]);
 
   // 错误清空只在触发入口做：generateUnit 自身不清，避免批量循环中
   // 后一个 unit 的调用抹掉前一个 unit 的失败信息
   const generateUnit = useCallback(
     async (unitId: string) => {
-      if (liveBusyUnitIds().has(unitId) || liveSavingUnitIds().has(unitId)) {
+      if (isUnitBusy(unitId) || liveSavingUnitIds().has(unitId)) {
         useAppStore.getState().pushToast(t("ad_ref_busy"), "error");
         return;
       }
@@ -227,7 +225,7 @@ export function AdReferenceVideoCanvas({
         setError(errMsg(err));
       }
     },
-    [projectName, episode, liveBusyUnitIds, liveSavingUnitIds, t],
+    [projectName, episode, isUnitBusy, liveSavingUnitIds, t],
   );
 
   // 编辑期间该 unit 若已被其他入口占用，放弃这次写入而非与生成中的任务乱序落库
@@ -236,7 +234,7 @@ export function AdReferenceVideoCanvas({
   const commitShotField = useCallback(
     async (unitId: string, shotId: string, patch: Record<string, unknown>): Promise<boolean> => {
       if (!onUpdatePrompt) return false;
-      if (deriving || liveBusyUnitIds().has(unitId) || liveSavingUnitIds().has(unitId)) {
+      if (deriving || isUnitBusy(unitId) || liveSavingUnitIds().has(unitId)) {
         useAppStore.getState().pushToast(t("ad_ref_busy"), "error");
         return false;
       }
@@ -258,7 +256,7 @@ export function AdReferenceVideoCanvas({
         });
       }
     },
-    [onUpdatePrompt, deriving, liveBusyUnitIds, liveSavingUnitIds, setSavingUnitIds, scriptFile, t],
+    [onUpdatePrompt, deriving, isUnitBusy, liveSavingUnitIds, setSavingUnitIds, scriptFile, t],
   );
 
   const generateAll = useCallback(async () => {
@@ -270,13 +268,13 @@ export function AdReferenceVideoCanvas({
       // 已经落库，闭包捕获的 savingUnitIds 会让该 unit 被永久跳过、这批不再补入队。
       if (
         unit.generated_assets?.video_clip ||
-        liveBusyUnitIds().has(unit.unit_id) ||
+        isUnitBusy(unit.unit_id) ||
         liveSavingUnitIds().has(unit.unit_id)
       )
         continue;
       await generateUnit(unit.unit_id);
     }
-  }, [derive, generateUnit, liveBusyUnitIds, liveSavingUnitIds]);
+  }, [derive, generateUnit, isUnitBusy, liveSavingUnitIds]);
 
   const hasUnits = hydrated.length > 0;
   // 任一分组仍有活跃任务（含取消中）或镜头字段写入未落库时禁止重新派生：派生会按

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -24,10 +24,9 @@ import {
   referenceVideoCacheKey,
 } from "@/stores/reference-video-store";
 import {
-  selectActiveResourceIds,
+  isResourceBusy,
   useActiveResourceIds,
   useLatestTasksByResource,
-  useTasksStore,
 } from "@/stores/tasks-store";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
@@ -97,8 +96,7 @@ function toastError(e: unknown, format?: (msg: string) => string): void {
  * 入队动作层在请求发出前就打乐观标记，因此同一 tick 内的连点也会被这一读拦下。
  */
 function isUnitBusy(projectName: string, unitId: string): boolean {
-  const { tasks, optimisticActive } = useTasksStore.getState();
-  return selectActiveResourceIds(tasks, "reference_video", projectName, optimisticActive).has(unitId);
+  return isResourceBusy("reference_video", projectName, unitId);
 }
 
 export function ReferenceVideoCanvas({

--- a/frontend/src/components/canvas/timeline/EndFrameRow.tsx
+++ b/frontend/src/components/canvas/timeline/EndFrameRow.tsx
@@ -8,11 +8,7 @@ import { useModelCapabilities } from "@/hooks/useModelCapabilities";
 import { useDemoWorkbench } from "@/onboarding/use-demo-workbench";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
-import {
-  selectActiveResourceIds,
-  useActiveResourceIds,
-  useTasksStore,
-} from "@/stores/tasks-store";
+import { isResourceBusy, useActiveResourceIds } from "@/stores/tasks-store";
 import type { EditorContentMode } from "@/utils/script-shape";
 import { errMsg } from "@/utils/async";
 import { EndFramePicker } from "./EndFramePicker";
@@ -97,9 +93,7 @@ export function EndFrameRow({
       useAppStore.getState().pushToast(t("end_frame_busy_hint"), "info");
       return true;
     }
-    const { tasks, optimisticActive } = useTasksStore.getState();
-    const active = selectActiveResourceIds(tasks, "video", projectName, optimisticActive);
-    if (!active.has(segmentId)) return false;
+    if (!isResourceBusy("video", projectName, segmentId)) return false;
     useAppStore.getState().pushToast(t("end_frame_busy_hint"), "info");
     return true;
   };

--- a/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
+++ b/frontend/src/components/canvas/timeline/GridPreviewPanel.tsx
@@ -19,7 +19,7 @@ import { enqueueGridRegenerate } from "@/actions/generation";
 import { errMsg } from "@/utils/async";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useAppStore } from "@/stores/app-store";
-import { selectActiveResourceIds, useActiveResourceIds, useTasksStore } from "@/stores/tasks-store";
+import { isResourceBusy, useActiveResourceIds } from "@/stores/tasks-store";
 import type { GridGeneration, ReferenceImage } from "@/types/grid";
 
 // ---------------------------------------------------------------------------
@@ -346,8 +346,7 @@ export function GridPreviewPanel({
                         if (!selectedGridId || regenerating || isInProgress) return;
                         // 提交前用 getState() 新鲜读复核：面板停留期间占用状态可能
                         // 已变化，渲染期捕获的 isInProgress 未必反映最新状态。
-                        const { tasks, optimisticActive } = useTasksStore.getState();
-                        if (selectActiveResourceIds(tasks, "grid", projectName, optimisticActive).has(selectedGridId)) {
+                        if (isResourceBusy("grid", projectName, selectedGridId)) {
                           // 用 toast 而非 setError：error 是面板的整体错误态，会把宫格图、
                           // 批次切换与本按钮一并替换掉，直到下次 refetch 才恢复；占用拒绝是
                           // 瞬态提示，不该毁掉当前视图。

--- a/frontend/src/components/canvas/timeline/ImageEditButton.tsx
+++ b/frontend/src/components/canvas/timeline/ImageEditButton.tsx
@@ -4,7 +4,7 @@ import { Wand2 } from "lucide-react";
 import { enqueueImageEdit } from "@/actions/generation";
 import { GlassModal } from "@/components/ui/GlassModal";
 import { useAppStore } from "@/stores/app-store";
-import { selectActiveResourceIds, selectHasActiveTaskForScriptFile, useTasksStore } from "@/stores/tasks-store";
+import { isResourceBusy, selectHasActiveTaskForScriptFile, useTasksStore } from "@/stores/tasks-store";
 import { errMsg } from "@/utils/async";
 
 export type ImageEditResourceType =
@@ -74,11 +74,11 @@ export function ImageEditButton({
     // 再用 getState() 新鲜读复核：弹窗停留期间响应式 busy prop 的更新依赖父组件
     // 重渲染，存在感知延迟；这里直接读 store 当前值，与 resourceType/resourceId
     // 命中同一占用槽（taskResourceKind 对 image_edit 按 resource_type 归槽）。
-    const { tasks, optimisticActive, optimisticActiveScriptFile } = useTasksStore.getState();
-    if (selectActiveResourceIds(tasks, resourceType, projectName, optimisticActive).has(resourceId)) {
+    if (isResourceBusy(resourceType, projectName, resourceId)) {
       useAppStore.getState().pushToast(t("image_edit_resource_busy"), "error");
       return;
     }
+    const { tasks, optimisticActiveScriptFile } = useTasksStore.getState();
     // storyboard 资源占用集查不到 grid 任务（其 resource_id 是 grid_id）；宫格模式下
     // 本集有切割任务在跑时需按 scriptFile 复核，否则新鲜读会漏过 busy prop 尚未追上
     // 的这一维度，见 selectHasActiveTaskForScriptFile 与 GridImageToVideoCanvas 的

--- a/frontend/src/stores/tasks-store.test.ts
+++ b/frontend/src/stores/tasks-store.test.ts
@@ -5,6 +5,7 @@ import {
   defaultTaskStats,
   isActiveStatus,
   isOccupyingStatus,
+  isResourceBusy,
   isTerminalStatus,
   selectActiveResourceIds,
   selectHasActiveTaskForScriptFile,
@@ -900,6 +901,35 @@ describe("selectActiveResourceIds", () => {
     // 返回既有任务、造成「提交成功却没有新任务」的谎报
     const tasks = [task({ task_id: "a", resource_id: "u1", status: "cancelling" })];
     expect(selectActiveResourceIds(tasks, "reference_video", "proj").has("u1")).toBe(true);
+  });
+});
+
+describe("isResourceBusy", () => {
+  beforeEach(() => {
+    useTasksStore.setState({ tasks: [], optimisticActive: new Set() });
+  });
+
+  it("reads the store snapshot at call time rather than a captured one", () => {
+    // 该函数存在的全部理由：调用方在提交那一刻拿到的必须是最新占用态，
+    // 而非渲染期（或上一次调用时）捕获的快照。
+    expect(isResourceBusy("reference_video", "proj", "u1")).toBe(false);
+    useTasksStore.setState({ tasks: [task({ task_id: "a", resource_id: "u1", status: "running" })] });
+    expect(isResourceBusy("reference_video", "proj", "u1")).toBe(true);
+  });
+
+  it("counts the optimistic in-flight markers held in the store", () => {
+    // 入队动作层在请求发出前打的标记也要被看到，否则同 tick 内的连点会漏过
+    useTasksStore.setState({ optimisticActive: new Set([pendingKey("character", "A", "image_edit")]) });
+    expect(isResourceBusy("character", "proj", "A")).toBe(true);
+  });
+
+  it("scopes to the given kind and projectName", () => {
+    useTasksStore.setState({
+      tasks: [task({ task_id: "a", resource_id: "u1", status: "running", task_type: "video", project_name: "p1" })],
+    });
+    expect(isResourceBusy("video", "p1", "u1")).toBe(true);
+    expect(isResourceBusy("storyboard", "p1", "u1")).toBe(false);
+    expect(isResourceBusy("video", "p2", "u1")).toBe(false);
   });
 });
 

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -510,6 +510,15 @@ export function selectActiveResourceIds(
 
 const EMPTY_OPTIMISTIC: ReadonlySet<string> = new Set();
 
+/**
+ * 提交时刻复核占用态的统一入口：封装 `getState()` 新鲜读 + {@link selectActiveResourceIds} +
+ * key 拼装，供各写入控件在提交那一刻直接判定，不必各自重复这三步。
+ */
+export function isResourceBusy(kind: string, projectName: string, resourceId: string): boolean {
+  const { tasks, optimisticActive } = useTasksStore.getState();
+  return selectActiveResourceIds(tasks, kind, projectName, optimisticActive).has(resourceId);
+}
+
 // 与 task-target.ts 的 stripScriptsPrefix 同一归一化规则：episode 元数据的 script_file
 // 固定带 `scripts/` 前缀（见 ProjectManager._apply_episode_sync），但任务行的 script_file
 // 由各入队调用方各自传入——router 直传 webui 表单值，Agent/SDK 工具经 validate_script_filename


### PR DESCRIPTION
Closes #1436

## 改动

「提交时刻用 `getState()` 新鲜读复核资源占用态」此前在仓库中有三份同形实现（6 处手写调用点 + `AdReferenceVideoCanvas.liveBusyUnitIds` / `assetBusyGuard.rejectIfAssetBusy` 两个局部 helper）。本 PR 将判定收敛为 `tasks-store` 导出的 `isResourceBusy(kind, projectName, resourceId)`，内部封装 `getState()` 新鲜读与 `selectActiveResourceIds`（含乐观占用标记）。

- 6 处生产调用点（`EndFrameRow` / `ImageEditButton` / `GridPreviewPanel` / `ReferenceVideoCanvas` / `AdReferenceVideoCanvas` / `assetBusyGuard`）全部改为调用该函数
- `AdReferenceVideoCanvas` 的 `liveBusyUnitIds()`（返回 `Set`，调用方一律 `.has(id)`）改为按单 id 判定的 `isUnitBusy(unitId)`；两个局部 helper 各自仅保留组件语境职责（ref 镜像、toast 提示）
- `ImageEditButton` 的 scriptFile 级判定（`selectHasActiveTaskForScriptFile`）是另一套判据（按剧集而非资源 id），不在收编范围，保留原样
- AGENTS.md「占用感知型控件接线」一节的提交时刻复核描述改为指向该函数

纯收编，不改变判定口径与任何行为。

## 验证

- 既有占用相关测试断言未作任何修改，全部通过
- 新增 `isResourceBusy` 三条最小用例：调用时刻读 store 快照（而非捕获的旧快照）、乐观在途标记计入、kind 与 projectName 作用域
- `pnpm lint` + `pnpm check`（typecheck + vitest）全绿：131 文件 / 1415 例通过
- `grep selectActiveResourceIds` 确认生产代码已无绕开统一函数的手写判定点（残留仅在测试文件的断言 helper 中，与生产实现解耦是有意为之）

## 审查中修复

- `assetBusyGuard.ts` 的注释一度改为「`kind` 取 `isResourceBusy` 的口径」，但 `isResourceBusy` 只是转发、不定义 kind 口径，指路空转一层；改为指向真正定义口径的 `taskResourceKind`

后端未触及（纯前端 + 文档改动）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能优化**
  - 优化资源占用状态校验，提交、上传、生成及编辑操作会读取最新状态。
  - 资源被占用时，相关控件会及时禁用并显示提示，减少并发操作冲突。
  - 保持同一资源卡片中关联控件的同步禁用行为。

- **测试**
  - 新增占用状态校验测试，覆盖实时任务状态、乐观进行中状态及项目与资源类型匹配场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->