### PR TITLE
fix(script): 剧本资产字段损坏时场景状态计算不再中断

### DIFF
--- a/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
+++ b/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
@@ -36,6 +36,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from lib.project_manager import ProjectManager
+from lib.script_models import get_generated_assets
 
 FFMPEG_TOOLS_HINT = "需要 ffmpeg 和 ffprobe 同时可用，并且都在 PATH 中"
 
@@ -626,7 +627,7 @@ def compose_video(
     transitions = []
 
     for scene in script["scenes"]:
-        video_clip = scene.get("generated_assets", {}).get("video_clip")
+        video_clip = get_generated_assets(scene).get("video_clip")
         if not video_clip:
             raise ValueError(f"场景 {scene['scene_id']} 缺少视频片段")
 

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -1007,13 +1007,14 @@ class ProjectManager:
                     scene["audio"][key] = template["audio"][key]
 
         # 补全 generated_assets 字段
-        if "generated_assets" not in scene:
-            scene["generated_assets"] = self.create_generated_assets()
-        else:
-            assets_template = self.create_generated_assets()
-            for key in assets_template:
-                if key not in scene["generated_assets"]:
-                    scene["generated_assets"][key] = assets_template[key]
+        # generated_assets 来自磁盘剧本 JSON，外部编辑可能损坏成非 dict（None/字符串等）；
+        # 先经 get_generated_assets 归一化，避免下面的成员检查/赋值抛 TypeError。
+        assets = get_generated_assets(scene)
+        assets_template = self.create_generated_assets()
+        for key in assets_template:
+            if key not in assets:
+                assets[key] = assets_template[key]
+        scene["generated_assets"] = assets
 
         # 补全其他顶层字段
         top_level_defaults = {

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -44,7 +44,7 @@ from lib.profile_manifest import (
 )
 from lib.project_change_hints import emit_project_change_hint
 from lib.script_editor import ScriptEditError, resolve_items
-from lib.script_models import script_duration_total
+from lib.script_models import get_generated_assets, script_duration_total
 from lib.style_templates import LEGACY_STYLE_MAP, resolve_template_prompt
 
 logger = logging.getLogger(__name__)
@@ -1049,7 +1049,9 @@ class ProjectManager:
         Returns:
             更新后的状态值
         """
-        assets = scene.get("generated_assets", {})
+        # generated_assets 来自磁盘剧本 JSON，外部编辑可能损坏成非 dict（None/字符串等）；
+        # get_generated_assets 归一化为空 dict 按「未生成」处理，避免 .get() 链式访问抛 AttributeError。
+        assets = get_generated_assets(scene)
 
         has_image = bool(assets.get("storyboard_image"))
         has_video = bool(assets.get("video_clip"))
@@ -1062,6 +1064,7 @@ class ProjectManager:
             status = "pending"
 
         assets["status"] = status
+        scene["generated_assets"] = assets
         return status
 
     # ==================== 场景管理 ====================

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -189,6 +189,18 @@ class GeneratedAssets(BaseModel):
     status: Literal["pending", "storyboard_ready", "completed"] = Field(default="pending", description="生成状态")
 
 
+def get_generated_assets(item: dict) -> dict:
+    """归一化访问 item 的 ``generated_assets`` 容器。
+
+    该字段来自磁盘上的剧本 JSON，不可信任：外部编辑可能把它损坏成非 dict（如
+    list/字符串）。归一化为空 dict 而非抛错，让调用方走各自「该资产未生成」的
+    既有分支（单条跳过 / 可读拒绝），不会在批量入队时因为一条脏数据抛未捕获
+    ``AttributeError`` 中断整批。
+    """
+    assets = item.get("generated_assets")
+    return assets if isinstance(assets, dict) else {}
+
+
 # ============ 说书模式（Narration） ============
 
 

--- a/lib/status_calculator.py
+++ b/lib/status_calculator.py
@@ -15,9 +15,8 @@ from lib.episode_paths import (
 )
 from lib.path_safety import safe_exists
 from lib.project_manager import effective_mode
-from lib.script_models import ad_script_total_duration, script_duration_total
+from lib.script_models import ad_script_total_duration, get_generated_assets, script_duration_total
 from lib.script_skeleton import SKELETONS, resolve_declared_kind
-from lib.storyboard_sequence import get_generated_assets
 
 logger = logging.getLogger(__name__)
 

--- a/lib/storyboard_sequence.py
+++ b/lib/storyboard_sequence.py
@@ -66,18 +66,6 @@ def find_storyboard_item(
     return None
 
 
-def get_generated_assets(item: dict) -> dict:
-    """归一化访问 item 的 ``generated_assets`` 容器。
-
-    该字段来自磁盘上的剧本 JSON，不可信任：外部编辑可能把它损坏成非 dict（如
-    list/字符串）。归一化为空 dict 而非抛错，让调用方走各自「该资产未生成」的
-    既有分支（单条跳过 / 可读拒绝），不会在批量入队时因为一条脏数据抛未捕获
-    ``AttributeError`` 中断整批。
-    """
-    assets = item.get("generated_assets")
-    return assets if isinstance(assets, dict) else {}
-
-
 def resolve_storyboard_image_ref(project_path: Path, storyboard_rel: object) -> Path | None:
     """校验 ``generated_assets.storyboard_image`` 字段值，返回解析后落在 ``storyboards/``
     内的绝对路径；字段未设置（``None``/``""``）返回 ``None``，由调用方按各自默认路径回退。

--- a/server/agent_runtime/sdk_tools/enqueue_narration_audio.py
+++ b/server/agent_runtime/sdk_tools/enqueue_narration_audio.py
@@ -15,7 +15,8 @@ from lib.generation_queue_client import (
     batch_enqueue_and_wait,
 )
 from lib.resource_paths import resource_relative_path
-from lib.storyboard_sequence import get_generated_assets, get_storyboard_items
+from lib.script_models import get_generated_assets
+from lib.storyboard_sequence import get_storyboard_items
 from server.agent_runtime.sdk_tools._context import ToolContext, tool_error, validate_script_filename
 
 

--- a/server/agent_runtime/sdk_tools/enqueue_storyboards.py
+++ b/server/agent_runtime/sdk_tools/enqueue_storyboards.py
@@ -16,10 +16,10 @@ from lib.generation_queue_client import (
     batch_enqueue_and_wait,
 )
 from lib.prompt_utils import image_prompt_to_yaml, is_structured_image_prompt, normalize_style
+from lib.script_models import get_generated_assets
 from lib.storyboard_sequence import (
     StoryboardTaskPlan,
     build_storyboard_dependency_plan,
-    get_generated_assets,
     get_storyboard_items,
 )
 from server.agent_runtime.sdk_tools._context import ToolContext, tool_error, validate_script_filename

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -26,7 +26,8 @@ from lib.reference_video.ad_units import (
     resolve_ad_unit_shots,
     sync_ad_reference_units,
 )
-from lib.storyboard_sequence import get_generated_assets, get_storyboard_items, resolve_storyboard_image_ref
+from lib.script_models import get_generated_assets
+from lib.storyboard_sequence import get_storyboard_items, resolve_storyboard_image_ref
 from server.agent_runtime.sdk_tools._context import (
     ToolContext,
     tool_error,

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -22,9 +22,9 @@ from lib.generation_queue_client import TaskSpec
 from lib.i18n import Translator
 from lib.path_safety import safe_exists
 from lib.project_manager import get_project_manager
+from lib.script_models import get_generated_assets
 from lib.storyboard_sequence import (
     find_storyboard_item,
-    get_generated_assets,
     get_storyboard_items,
     resolve_storyboard_image_ref,
 )

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -31,11 +31,11 @@ from lib.prompt_utils import (
     video_prompt_to_yaml,
 )
 from lib.resource_paths import END_FRAME_RESOURCE_TYPE, resource_relative_path
+from lib.script_models import get_generated_assets
 from lib.script_skeleton import SKELETON_ENTITY_TYPES, SKELETON_ITEM_NOUNS, resolve_script_kind
 from lib.storyboard_sequence import (
     build_previous_storyboard_reference,
     find_storyboard_item,
-    get_generated_assets,
     get_storyboard_items,
     group_scenes_by_segment_break,
     resolve_previous_storyboard_path,

--- a/server/services/jianying_draft_service.py
+++ b/server/services/jianying_draft_service.py
@@ -52,10 +52,9 @@ _SPAN_SUBTITLE_MODES: frozenset[str] = frozenset({"drama"})
 from lib.path_safety import PathTraversalError, safe_join, safe_resolve
 from lib.project_manager import ProjectManager, effective_mode
 from lib.reference_video.ad_units import ad_shots_by_id
-from lib.script_models import ad_shot_duration_seconds
+from lib.script_models import ad_shot_duration_seconds, get_generated_assets
 from lib.script_skeleton import SKELETONS, resolve_declared_kind
 from lib.speech_rate import estimate_spoken_seconds
-from lib.storyboard_sequence import get_generated_assets
 
 logger = logging.getLogger(__name__)
 

--- a/server/services/project_cover.py
+++ b/server/services/project_cover.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from lib.storyboard_sequence import get_generated_assets
+from lib.script_models import get_generated_assets
 
 if TYPE_CHECKING:
     from lib.project_manager import ProjectManager

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -25,6 +25,7 @@ from lib.project_change_hints import (
     register_project_change_listener,
 )
 from lib.project_manager import ProjectManager, effective_mode
+from lib.script_models import get_generated_assets
 from lib.script_skeleton import (
     SKELETON_ANCHOR_TYPES,
     SKELETON_ENTITY_TYPES,
@@ -963,8 +964,8 @@ class ProjectEventService:
                 focus = self._build_script_item_focus(item_id, current_meta)
                 label = self._build_script_item_label(item_id, current_meta)
                 if self._became_truthy(
-                    previous_item["generated_assets"].get("storyboard_image"),
-                    current_item["generated_assets"].get("storyboard_image"),
+                    get_generated_assets(previous_item).get("storyboard_image"),
+                    get_generated_assets(current_item).get("storyboard_image"),
                 ):
                     changes.append(
                         self._build_entity_change(
@@ -979,8 +980,8 @@ class ProjectEventService:
                         )
                     )
                 if self._became_truthy(
-                    previous_item["generated_assets"].get("video_clip"),
-                    current_item["generated_assets"].get("video_clip"),
+                    get_generated_assets(previous_item).get("video_clip"),
+                    get_generated_assets(current_item).get("video_clip"),
                 ):
                     changes.append(
                         self._build_entity_change(

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -655,9 +655,7 @@ class ProjectEventService:
             item_id = str(item.get(skeleton.id_field) or "")
             if not item_id:
                 continue
-            assets = item.get("generated_assets")
-            if not isinstance(assets, dict):
-                assets = {}
+            assets = get_generated_assets(item)
             characters, scenes, props = self._item_entities(item, skeleton.chars_field)
             items[item_id] = {
                 "duration_seconds": item.get("duration_seconds"),
@@ -711,9 +709,7 @@ class ProjectEventService:
             unit_id = str(unit.get("unit_id") or "")
             if not unit_id:
                 continue
-            assets = unit.get("generated_assets")
-            if not isinstance(assets, dict):
-                assets = {}
+            assets = get_generated_assets(unit)
             units[unit_id] = {"video_clip": str(assets.get("video_clip") or "")}
         return units
 

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -472,6 +472,7 @@ class TestProjectManagerMore:
         assert pm.update_scene_status({"generated_assets": {"storyboard_image": "s.png"}}) == "storyboard_ready"
         assert pm.update_scene_status({"generated_assets": {}}) == "pending"
 
+    @pytest.mark.integration
     @pytest.mark.parametrize("dirty", [None, "bad", ["bad"], 123, False])
     def test_update_scene_status_recovers_from_corrupted_generated_assets(self, tmp_path, dirty):
         """外部编辑把 generated_assets 损坏成非 dict 形态时按无资产处理，不抛 AttributeError。"""
@@ -480,6 +481,17 @@ class TestProjectManagerMore:
 
         assert pm.update_scene_status(scene) == "pending"
         assert scene["generated_assets"] == {"status": "pending"}
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("dirty", [None, "bad", ["bad"], 123, False])
+    def test_normalize_scene_recovers_from_corrupted_generated_assets(self, tmp_path, dirty):
+        """normalize_scene 是 update_scene_status 之前的公共入口，同样需容错损坏的 generated_assets。"""
+        pm = ProjectManager(tmp_path / "projects")
+        scene = {"scene_id": "S1", "generated_assets": dirty}
+
+        normalized = pm.normalize_scene(scene)
+
+        assert normalized["generated_assets"]["status"] == "pending"
 
     def test_entity_and_batch_management_and_paths(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -472,6 +472,15 @@ class TestProjectManagerMore:
         assert pm.update_scene_status({"generated_assets": {"storyboard_image": "s.png"}}) == "storyboard_ready"
         assert pm.update_scene_status({"generated_assets": {}}) == "pending"
 
+    @pytest.mark.parametrize("dirty", [None, "bad", ["bad"], 123, False])
+    def test_update_scene_status_recovers_from_corrupted_generated_assets(self, tmp_path, dirty):
+        """外部编辑把 generated_assets 损坏成非 dict 形态时按无资产处理，不抛 AttributeError。"""
+        pm = ProjectManager(tmp_path / "projects")
+        scene = {"scene_id": "S1", "generated_assets": dirty}
+
+        assert pm.update_scene_status(scene) == "pending"
+        assert scene["generated_assets"] == {"status": "pending"}
+
     def test_entity_and_batch_management_and_paths(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")

--- a/tests/test_script_models.py
+++ b/tests/test_script_models.py
@@ -15,9 +15,24 @@ from lib.script_models import (
     NarrationSegment,
     Utterance,
     VideoPrompt,
+    get_generated_assets,
     item_duration,
     script_duration_total,
 )
+
+
+@pytest.mark.unit
+class TestGetGeneratedAssets:
+    def test_returns_dict_container_unchanged(self):
+        item = {"generated_assets": {"storyboard_image": "storyboards/scene_E1S01.png"}}
+        assert get_generated_assets(item) == {"storyboard_image": "storyboards/scene_E1S01.png"}
+
+    @pytest.mark.parametrize("dirty", [["bad"], "bad", 123, None, 0, False])
+    def test_normalizes_non_dict_container_to_empty_dict(self, dirty):
+        assert get_generated_assets({"generated_assets": dirty}) == {}
+
+    def test_missing_key_returns_empty_dict(self):
+        assert get_generated_assets({}) == {}
 
 
 def _image_prompt() -> ImagePrompt:

--- a/tests/test_storyboard_sequence.py
+++ b/tests/test_storyboard_sequence.py
@@ -4,24 +4,9 @@ import pytest
 
 from lib.storyboard_sequence import (
     build_storyboard_dependency_plan,
-    get_generated_assets,
     get_storyboard_items,
     resolve_previous_storyboard_path,
 )
-
-
-@pytest.mark.unit
-class TestGetGeneratedAssets:
-    def test_returns_dict_container_unchanged(self):
-        item = {"generated_assets": {"storyboard_image": "storyboards/scene_E1S01.png"}}
-        assert get_generated_assets(item) == {"storyboard_image": "storyboards/scene_E1S01.png"}
-
-    @pytest.mark.parametrize("dirty", [["bad"], "bad", 123, None, 0, False])
-    def test_normalizes_non_dict_container_to_empty_dict(self, dirty):
-        assert get_generated_assets({"generated_assets": dirty}) == {}
-
-    def test_missing_key_returns_empty_dict(self):
-        assert get_generated_assets({}) == {}
 
 
 class TestStoryboardSequence:


### PR DESCRIPTION
Closes #1437

## 改动

1. **场景状态更新路径的损坏数据容错**。`ProjectManager.update_scene_status` 原先用 `scene.get("generated_assets", {})`——default 只在 key 缺失时生效，字段存在但值为 `None`/字符串等损坏形态时后续链式访问抛 `AttributeError`。改为调用共享 helper `get_generated_assets` 归一化，按「无资产」处理；归一化结果写回 `scene["generated_assets"]`，否则损坏形态下推导出的 status 会写在临时 dict 上被丢弃、字段仍留损坏值。
2. **helper 迁址**。`get_generated_assets` 从 `lib/storyboard_sequence.py` 迁至领域真相源 `lib/script_models.py`（多数调用方与分镜排序无关），13 个调用文件同步改为从新位置导入，函数体与签名逐字不变；旧位置不保留 re-export。
3. 顺带收编另两处同类不安全访问：`agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py` 的 `scene.get("generated_assets", {}).get(...)`、`server/services/project_events.py` 的 `previous_item["generated_assets"].get(...)` 下标直取（后者还会在字段缺失时抛 `KeyError`）。

## 验证

- 验收标准 1：`tests/test_project_manager_more.py` 新增参数化回归（`None` / 字符串 / list / int / bool 五种脏值），断言状态为 `pending` 且不抛错。
- 验收标准 2：全仓库（tests 除外）逐点核查 `generated_assets` 的全部取值处，剩余站点均有 `isinstance` 或等价守卫（`lib/status_calculator.py` 经 `_wellformed` 预过滤），无「取值后直接链式访问」写法。
- 验收标准 3：全仓库 0 处从旧位置导入；helper 的既有单测随实现从 `tests/test_storyboard_sequence.py` 平移到 `tests/test_script_models.py`，断言未改。
- 本地质量门：`pytest` 6718 passed、`ruff check` + `ruff format --check` 全绿、`basedpyright` 0 errors。无前端改动。

## 本地审查发现与处置

- 采纳：`server/services/project_events.py` 另有两处与 helper 函数体逐字相同的内联归一化未收编，同一文件里一半迁一半留。已一并换成 helper（第二个 commit），行为不变。
- 未采纳：剩余若干处手写 `isinstance` 归一化（`lib/project_manager.py` 的写入路径需要自行回写、`cost_estimation.py` / `image_edit_tasks.py` / `jianying_draft_service.py` 的谓词形态）均已安全，收编它们超出本票范围，记为 follow-up 候选。
- 未采纳：helper 更名建议（如 `generated_assets_or_empty`）——验收标准 3 明确要求签名不变。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 提升对损坏或非预期格式的生成资产数据容错能力，避免因单条脏数据导致处理中断。
  * 统一生成资产的读取与状态判断逻辑，使场景/视频/项目事件展示更稳定（视频与分镜就绪状态判定更一致）。
* **测试**
  * 新增并完善生成资产异常场景的单元与集成测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->