### PR TITLE
refactor(tasks): 删除任务事件表的只写不读死代码链

### DIFF
--- a/alembic/versions/3649100774fa_drop_task_events_table.py
+++ b/alembic/versions/3649100774fa_drop_task_events_table.py
@@ -1,0 +1,40 @@
+"""drop task_events table
+
+Revision ID: 3649100774fa
+Revises: b41d7c5e9a02
+Create Date: 2026-07-28 15:08:39.065681
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3649100774fa"
+down_revision: str | Sequence[str] | None = "b41d7c5e9a02"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """`/tasks/stream` 端点已随 #1388 移除，task_events 只写不读，事件属短生命周期数据，存量直接丢弃。"""
+    op.drop_index("idx_task_events_project_id", table_name="task_events")
+    op.drop_table("task_events")
+
+
+def downgrade() -> None:
+    """重建表结构（含 #1388 后新增的 tasks FK），历史事件数据无法恢复。"""
+    op.create_table(
+        "task_events",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True, nullable=False),
+        sa.Column("task_id", sa.String(), sa.ForeignKey("tasks.task_id", ondelete="CASCADE"), nullable=False),
+        sa.Column("project_name", sa.String(), nullable=False),
+        sa.Column("event_type", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("data_json", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("idx_task_events_project_id", "task_events", ["project_name", "id"])

--- a/alembic/versions/3649100774fa_drop_task_events_table.py
+++ b/alembic/versions/3649100774fa_drop_task_events_table.py
@@ -20,21 +20,31 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    """`/tasks/stream` 端点已随 #1388 移除，task_events 只写不读，事件属短生命周期数据，存量直接丢弃。"""
+    """`/tasks/stream` 端点已移除，task_events 只写不读，事件属短生命周期数据，存量直接丢弃。"""
     op.drop_index("idx_task_events_project_id", table_name="task_events")
     op.drop_table("task_events")
 
 
 def downgrade() -> None:
-    """重建表结构（含 #1388 后新增的 tasks FK），历史事件数据无法恢复。"""
+    """重建表结构（含指向 tasks 的具名 FK），历史事件数据无法恢复。
+
+    FK 必须与建表迁移同名（``fk_task_events_task_id``），否则更早一级迁移的 downgrade
+    在 drop_constraint 时找不到约束、整条下行链断在此处。
+    """
     op.create_table(
         "task_events",
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True, nullable=False),
-        sa.Column("task_id", sa.String(), sa.ForeignKey("tasks.task_id", ondelete="CASCADE"), nullable=False),
+        sa.Column("task_id", sa.String(), nullable=False),
         sa.Column("project_name", sa.String(), nullable=False),
         sa.Column("event_type", sa.String(), nullable=False),
         sa.Column("status", sa.String(), nullable=False),
         sa.Column("data_json", sa.Text(), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["task_id"],
+            ["tasks.task_id"],
+            name="fk_task_events_task_id",
+            ondelete="CASCADE",
+        ),
     )
     op.create_index("idx_task_events_project_id", "task_events", ["project_name", "id"])

--- a/alembic/versions/e167b56a3e79_add_resource_type_column_to_tasks_for_.py
+++ b/alembic/versions/e167b56a3e79_add_resource_type_column_to_tasks_for_.py
@@ -34,8 +34,8 @@ def _collapse_duplicate_active_tasks_for_downgrade() -> None:
 
     升级后不同资产类型同名（如角色和道具都叫「玉佩」）的活动 image_edit 任务可以并存；
     降级恢复不含 resource_type 的窄索引前，这些合并后撞键的分组只保留最早入队的一条，
-    其余按既有 cancel 语义（见 ``TaskRepository.cancel_task``）软取消——不落 task_events，
-    降级路径不依赖事件流回放；保留行、仅摘除其终态外的活动任务，不做硬删除。
+    其余按既有 cancel 语义（见 ``TaskRepository.cancel_task``）软取消——直接改状态、不发终态事件，
+    降级路径不依赖事件通知；保留行、仅摘除其终态外的活动任务，不做硬删除。
     """
     op.execute(
         sa.text(

--- a/lib/db/models/__init__.py
+++ b/lib/db/models/__init__.py
@@ -9,12 +9,11 @@ from lib.db.models.credential import ProviderCredential
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 from lib.db.models.session import AgentSession
 from lib.db.models.session_event import AgentSessionEventLogEntry
-from lib.db.models.task import Task, TaskEvent, WorkerLease
+from lib.db.models.task import Task, WorkerLease
 from lib.db.models.user import User
 
 __all__ = [
     "Task",
-    "TaskEvent",
     "WorkerLease",
     "ApiCall",
     "AgentSession",

--- a/lib/db/models/task.py
+++ b/lib/db/models/task.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, String, Text, text
+from sqlalchemy import DateTime, Float, Index, Integer, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from lib.db.base import Base, UserOwnedMixin
@@ -55,20 +55,6 @@ class Task(UserOwnedMixin, Base):
             postgresql_where=text("status IN ('queued', 'running', 'cancelling')"),
         ),
     )
-
-
-class TaskEvent(Base):
-    __tablename__ = "task_events"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    task_id: Mapped[str] = mapped_column(String, ForeignKey("tasks.task_id", ondelete="CASCADE"), nullable=False)
-    project_name: Mapped[str] = mapped_column(String, nullable=False)
-    event_type: Mapped[str] = mapped_column(String, nullable=False)
-    status: Mapped[str] = mapped_column(String, nullable=False)
-    data_json: Mapped[str | None] = mapped_column(Text)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-
-    __table_args__ = (Index("idx_task_events_project_id", "project_name", "id"),)
 
 
 class WorkerLease(Base):

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -15,7 +15,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lib.db.base import DEFAULT_USER_ID, dt_to_iso, utc_now
-from lib.db.models.task import Task, TaskEvent, WorkerLease
+from lib.db.models.task import Task, WorkerLease
 from lib.db.repositories.base import BaseRepository, rowcount
 from lib.task_failure import bound_reason, collapse_cascade_reason, encode_failure
 from lib.task_terminal_events import TERMINAL_TASK_STATUSES
@@ -95,35 +95,22 @@ def _task_to_dict(row: Task) -> dict[str, Any]:
     }
 
 
-def _event_to_dict(row: TaskEvent) -> dict[str, Any]:
-    return {
-        "id": row.id,
-        "task_id": row.task_id,
-        "project_name": row.project_name,
-        "event_type": row.event_type,
-        "status": row.status,
-        "data": _json_loads(row.data_json, {}),
-        "created_at": dt_to_iso(row.created_at),
-    }
-
-
 class TaskRepository(BaseRepository):
     def __init__(self, session: AsyncSession):
         super().__init__(session)
         # 本次会话内落地的任务终态，供上层（GenerationQueue）在事务提交后发布项目事件。
         # 在此收集而非各终态方法各自记账：所有终态迁移（含级联失败/级联取消、批量取消
-        # 队列）都经 _append_event 收口，一处挂钩即全覆盖。
+        # 队列）都经 _record_terminal_event 收口，一处挂钩即全覆盖。
         self.terminal_events: list[dict[str, Any]] = []
 
-    async def _append_event(
+    def _record_terminal_event(
         self,
         *,
         task_id: str,
         project_name: str,
-        event_type: str,
         status: str,
         data: dict | None = None,
-    ) -> int:
+    ) -> None:
         if status in TERMINAL_TASK_STATUSES:
             self.terminal_events.append(
                 {
@@ -133,18 +120,6 @@ class TaskRepository(BaseRepository):
                     "task_type": (data or {}).get("task_type"),
                 }
             )
-        now = utc_now()
-        event = TaskEvent(
-            task_id=task_id,
-            project_name=project_name,
-            event_type=event_type,
-            status=status,
-            data_json=_json_dumps(data or {}),
-            created_at=now,
-        )
-        self.session.add(event)
-        await self.session.flush()
-        return event.id
 
     async def enqueue(
         self,
@@ -217,10 +192,9 @@ class TaskRepository(BaseRepository):
             raise
 
         task_data = _task_to_dict(task)
-        await self._append_event(
+        self._record_terminal_event(
             task_id=task_id,
             project_name=project_name,
-            event_type="queued",
             status="queued",
             data=task_data,
         )
@@ -309,10 +283,9 @@ class TaskRepository(BaseRepository):
         running_task = result.scalar_one()
         task_data = _task_to_dict(running_task)
 
-        await self._append_event(
+        self._record_terminal_event(
             task_id=target_task_id,
             project_name=running_task.project_name,
-            event_type="running",
             status="running",
             data=task_data,
         )
@@ -347,10 +320,9 @@ class TaskRepository(BaseRepository):
         res = await self.session.execute(select(Task).where(Task.task_id == task_id))
         done_task = res.scalar_one()
         task_data = _task_to_dict(done_task)
-        await self._append_event(
+        self._record_terminal_event(
             task_id=task_id,
             project_name=done_task.project_name,
-            event_type="succeeded",
             status="succeeded",
             data=task_data,
         )
@@ -392,10 +364,9 @@ class TaskRepository(BaseRepository):
         res = await self.session.execute(select(Task).where(Task.task_id == task_id))
         failed_task = res.scalar_one()
         task_data = _task_to_dict(failed_task)
-        await self._append_event(
+        self._record_terminal_event(
             task_id=task_id,
             project_name=failed_task.project_name,
-            event_type="failed",
             status="failed",
             data=task_data,
         )
@@ -422,10 +393,9 @@ class TaskRepository(BaseRepository):
         res = await self.session.execute(select(Task).where(Task.task_id == task_id))
         failed_task = res.scalar_one()
         task_data = _task_to_dict(failed_task)
-        await self._append_event(
+        self._record_terminal_event(
             task_id=task_id,
             project_name=failed_task.project_name,
-            event_type="failed",
             status="failed",
             data=task_data,
         )
@@ -630,10 +600,9 @@ class TaskRepository(BaseRepository):
         res = await self.session.execute(select(Task).where(Task.task_id == task_id))
         cancelled_task = res.scalar_one()
         task_data = _task_to_dict(cancelled_task)
-        await self._append_event(
+        self._record_terminal_event(
             task_id=task_id,
             project_name=cancelled_task.project_name,
-            event_type="cancelled",
             status="cancelled",
             data=task_data,
         )
@@ -673,10 +642,9 @@ class TaskRepository(BaseRepository):
         res = await self.session.execute(select(Task).where(Task.task_id == task_id))
         cancelling_task = res.scalar_one()
         task_data = _task_to_dict(cancelling_task)
-        await self._append_event(
+        self._record_terminal_event(
             task_id=task_id,
             project_name=cancelling_task.project_name,
-            event_type="cancelling",
             status="cancelling",
             data=task_data,
         )
@@ -822,10 +790,9 @@ class TaskRepository(BaseRepository):
             )
             for updated_task in refreshed.scalars().all():
                 task_data = _task_to_dict(updated_task)
-                await self._append_event(
+                self._record_terminal_event(
                     task_id=updated_task.task_id,
                     project_name=project_name,
-                    event_type="cancelled",
                     status="cancelled",
                     data=task_data,
                 )
@@ -873,20 +840,6 @@ class TaskRepository(BaseRepository):
         rows = await self.session.execute(select(Task).where(Task.task_id.in_(task_ids), Task.status == "queued"))
         requeued_tasks = rows.scalars().all()
 
-        # Step 4: bulk-insert all requeue events
-        event_now = utc_now()
-        events = [
-            TaskEvent(
-                task_id=t.task_id,
-                project_name=t.project_name,
-                event_type="requeued",
-                status="queued",
-                data_json=_json_dumps(_task_to_dict(t)),
-                created_at=event_now,
-            )
-            for t in requeued_tasks
-        ]
-        self.session.add_all(events)
         await self.session.commit()
         return len(requeued_tasks)
 
@@ -970,47 +923,6 @@ class TaskRepository(BaseRepository):
             total += cnt
         stats["total"] = total
         return stats
-
-    async def get_recent_tasks_snapshot(
-        self,
-        *,
-        project_name: str | None = None,
-        limit: int = 200,
-    ) -> list[dict[str, Any]]:
-        limit = max(1, min(1000, limit))
-        stmt = select(Task)
-        if project_name:
-            stmt = stmt.where(Task.project_name == project_name)
-        stmt = stmt.order_by(Task.updated_at.desc()).limit(limit)
-        stmt = self._scope_query(stmt, Task)
-
-        result = await self.session.execute(stmt)
-        return [_task_to_dict(t) for t in result.scalars().all()]
-
-    # NOTE: In multi-user mode, override this method to filter by user via JOIN Task
-    async def get_events_since(
-        self,
-        *,
-        last_event_id: int,
-        project_name: str | None = None,
-        limit: int = 200,
-    ) -> list[dict[str, Any]]:
-        limit = max(1, min(1000, limit))
-        stmt = select(TaskEvent).where(TaskEvent.id > last_event_id)
-        if project_name:
-            stmt = stmt.where(TaskEvent.project_name == project_name)
-        stmt = stmt.order_by(TaskEvent.id.asc()).limit(limit)
-
-        result = await self.session.execute(stmt)
-        return [_event_to_dict(e) for e in result.scalars().all()]
-
-    # NOTE: In multi-user mode, override this method to filter by user via JOIN Task
-    async def get_latest_event_id(self, *, project_name: str | None = None) -> int:
-        stmt = select(func.max(TaskEvent.id))
-        if project_name:
-            stmt = stmt.where(TaskEvent.project_name == project_name)
-        result = await self.session.execute(stmt)
-        return result.scalar() or 0
 
     # ---- Worker Lease ----
 

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -109,15 +109,16 @@ class TaskRepository(BaseRepository):
         task_id: str,
         project_name: str,
         status: str,
-        data: dict | None = None,
+        task_type: str | None = None,
     ) -> None:
+        """非终态调用是空操作：状态守卫兜住未来新增的非终态调用点，避免发出无对应动作的事件。"""
         if status in TERMINAL_TASK_STATUSES:
             self.terminal_events.append(
                 {
                     "task_id": task_id,
                     "project_name": project_name,
                     "status": status,
-                    "task_type": (data or {}).get("task_type"),
+                    "task_type": task_type,
                 }
             )
 
@@ -191,13 +192,6 @@ class TaskRepository(BaseRepository):
                 }
             raise
 
-        task_data = _task_to_dict(task)
-        self._record_terminal_event(
-            task_id=task_id,
-            project_name=project_name,
-            status="queued",
-            data=task_data,
-        )
         await self.session.commit()
 
         return {
@@ -282,13 +276,6 @@ class TaskRepository(BaseRepository):
         result = await self.session.execute(select(Task).where(Task.task_id == target_task_id))
         running_task = result.scalar_one()
         task_data = _task_to_dict(running_task)
-
-        self._record_terminal_event(
-            task_id=target_task_id,
-            project_name=running_task.project_name,
-            status="running",
-            data=task_data,
-        )
         await self.session.commit()
         return task_data
 
@@ -319,12 +306,11 @@ class TaskRepository(BaseRepository):
         await self.session.flush()
         res = await self.session.execute(select(Task).where(Task.task_id == task_id))
         done_task = res.scalar_one()
-        task_data = _task_to_dict(done_task)
         self._record_terminal_event(
             task_id=task_id,
             project_name=done_task.project_name,
             status="succeeded",
-            data=task_data,
+            task_type=done_task.task_type,
         )
         await self.session.commit()
         return affected
@@ -363,12 +349,11 @@ class TaskRepository(BaseRepository):
         await self.session.flush()
         res = await self.session.execute(select(Task).where(Task.task_id == task_id))
         failed_task = res.scalar_one()
-        task_data = _task_to_dict(failed_task)
         self._record_terminal_event(
             task_id=task_id,
             project_name=failed_task.project_name,
             status="failed",
-            data=task_data,
+            task_type=failed_task.task_type,
         )
         return affected
 
@@ -392,12 +377,11 @@ class TaskRepository(BaseRepository):
         await self.session.flush()
         res = await self.session.execute(select(Task).where(Task.task_id == task_id))
         failed_task = res.scalar_one()
-        task_data = _task_to_dict(failed_task)
         self._record_terminal_event(
             task_id=task_id,
             project_name=failed_task.project_name,
             status="failed",
-            data=task_data,
+            task_type=failed_task.task_type,
         )
         return affected
 
@@ -604,7 +588,7 @@ class TaskRepository(BaseRepository):
             task_id=task_id,
             project_name=cancelled_task.project_name,
             status="cancelled",
-            data=task_data,
+            task_type=cancelled_task.task_type,
         )
 
         # 先把自身入 cancelled 列表，再级联——保证 cancel_task 响应体里父先于子。
@@ -634,21 +618,7 @@ class TaskRepository(BaseRepository):
             .values(status="cancelling", cancelled_by=cancelled_by, updated_at=now)
         )
         result = await self.session.execute(stmt)
-        affected = rowcount(result)
-        if affected == 0:
-            return 0
-
-        await self.session.flush()
-        res = await self.session.execute(select(Task).where(Task.task_id == task_id))
-        cancelling_task = res.scalar_one()
-        task_data = _task_to_dict(cancelling_task)
-        self._record_terminal_event(
-            task_id=task_id,
-            project_name=cancelling_task.project_name,
-            status="cancelling",
-            data=task_data,
-        )
-        return affected
+        return rowcount(result)
 
     async def _cascade_cancel_dependents(
         self,
@@ -789,12 +759,11 @@ class TaskRepository(BaseRepository):
                 select(Task).where(Task.task_id.in_(task_ids), Task.status == "cancelled")
             )
             for updated_task in refreshed.scalars().all():
-                task_data = _task_to_dict(updated_task)
                 self._record_terminal_event(
                     task_id=updated_task.task_id,
                     project_name=project_name,
                     status="cancelled",
-                    data=task_data,
+                    task_type=updated_task.task_type,
                 )
 
         await self.session.commit()

--- a/lib/generation_queue.py
+++ b/lib/generation_queue.py
@@ -302,39 +302,6 @@ class GenerationQueue:
         async with self._task_repo() as repo:
             return await repo.get_stats(project_name=project_name)
 
-    async def get_recent_tasks_snapshot(
-        self,
-        *,
-        project_name: str | None = None,
-        limit: int = 200,
-    ) -> list[dict[str, Any]]:
-
-        async with self._task_repo() as repo:
-            return await repo.get_recent_tasks_snapshot(
-                project_name=project_name,
-                limit=limit,
-            )
-
-    async def get_events_since(
-        self,
-        *,
-        last_event_id: int,
-        project_name: str | None = None,
-        limit: int = 200,
-    ) -> list[dict[str, Any]]:
-
-        async with self._task_repo() as repo:
-            return await repo.get_events_since(
-                last_event_id=last_event_id,
-                project_name=project_name,
-                limit=limit,
-            )
-
-    async def get_latest_event_id(self, *, project_name: str | None = None) -> int:
-
-        async with self._task_repo() as repo:
-            return await repo.get_latest_event_id(project_name=project_name)
-
     async def acquire_or_renew_worker_lease(
         self,
         *,

--- a/scripts/migrate_sqlite_to_orm.py
+++ b/scripts/migrate_sqlite_to_orm.py
@@ -2,7 +2,7 @@
 """One-time migration script: copy data from old hand-written SQLite DBs to new ORM DB.
 
 Old files:
-  projects/.task_queue.db       → tasks, task_events, worker_lease tables
+  projects/.task_queue.db       → tasks, worker_lease tables
   projects/.api_usage.db        → api_calls table
   projects/.agent_data/sessions.db → agent_sessions table
 
@@ -40,7 +40,7 @@ sys.modules.setdefault("lib", lib_stub)
 from lib.app_data_dir import app_data_dir  # noqa: E402
 from lib.db import init_db  # noqa: E402
 from lib.db.engine import async_session_factory  # noqa: E402
-from lib.db.models import AgentSession, ApiCall, Task, TaskEvent, WorkerLease  # noqa: E402
+from lib.db.models import AgentSession, ApiCall, Task, WorkerLease  # noqa: E402
 
 PROJECTS_DIR = app_data_dir()
 OLD_TASK_DB = PROJECTS_DIR / ".task_queue.db"
@@ -48,20 +48,17 @@ OLD_USAGE_DB = PROJECTS_DIR / ".api_usage.db"
 OLD_SESSIONS_DB = PROJECTS_DIR / ".agent_data" / "sessions.db"
 
 
-def _read_old_tasks(conn: sqlite3.Connection) -> tuple[list, list, list]:
+def _read_old_tasks(conn: sqlite3.Connection) -> tuple[list, list]:
     conn.row_factory = sqlite3.Row
     cur = conn.cursor()
 
     cur.execute("SELECT * FROM tasks")
     tasks = [dict(r) for r in cur.fetchall()]
 
-    cur.execute("SELECT * FROM task_events")
-    events = [dict(r) for r in cur.fetchall()]
-
     cur.execute("SELECT * FROM worker_lease")
     leases = [dict(r) for r in cur.fetchall()]
 
-    return tasks, events, leases
+    return tasks, leases
 
 
 def _read_old_usage(conn: sqlite3.Connection) -> list:
@@ -82,11 +79,11 @@ async def _migrate(dry_run: bool) -> dict[str, int]:
     stats: dict[str, int] = {}
 
     # --- Read old data ---
-    tasks, events, leases = [], [], []
+    tasks, leases = [], []
     if OLD_TASK_DB.exists():
         with sqlite3.connect(OLD_TASK_DB) as conn:
-            tasks, events, leases = _read_old_tasks(conn)
-        print(f"  读取旧任务队列: tasks={len(tasks)}, events={len(events)}, leases={len(leases)}")
+            tasks, leases = _read_old_tasks(conn)
+        print(f"  读取旧任务队列: tasks={len(tasks)}, leases={len(leases)}")
     else:
         print(f"  跳过（不存在）: {OLD_TASK_DB}")
 
@@ -110,7 +107,6 @@ async def _migrate(dry_run: bool) -> dict[str, int]:
         print("\n[DRY RUN] 不写入数据库，不重命名旧文件。")
         return {
             "tasks": len(tasks),
-            "events": len(events),
             "leases": len(leases),
             "api_calls": len(api_calls),
             "sessions": len(sessions),
@@ -142,19 +138,6 @@ async def _migrate(dry_run: bool) -> dict[str, int]:
                     started_at=row.get("started_at"),
                     finished_at=row.get("finished_at"),
                     updated_at=row["updated_at"],
-                )
-            )
-
-        # Task events
-        for row in events:
-            session.add(
-                TaskEvent(
-                    task_id=row["task_id"],
-                    project_name=row["project_name"],
-                    event_type=row["event_type"],
-                    status=row["status"],
-                    data_json=row.get("data_json"),
-                    created_at=row["created_at"],
                 )
             )
 
@@ -211,7 +194,6 @@ async def _migrate(dry_run: bool) -> dict[str, int]:
 
     stats = {
         "tasks": len(tasks),
-        "task_events": len(events),
         "worker_leases": len(leases),
         "api_calls": len(api_calls),
         "agent_sessions": len(sessions),

--- a/tests/test_alembic_drop_task_events_downgrade.py
+++ b/tests/test_alembic_drop_task_events_downgrade.py
@@ -1,0 +1,61 @@
+"""Alembic 迁移 3649100774fa（drop task_events）的降级回归测试。
+
+该迁移的 downgrade 需重建 task_events，且 FK 必须与建表迁移同名
+（``fk_task_events_task_id``）：更早一级迁移 b942e8c5d545 的 downgrade 按名 drop 该约束，
+名字对不上时整条下行链断在那里，而只测 ``upgrade head`` 的用例发现不了。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.config import Config
+
+from alembic import command
+
+#: 建表迁移 b942e8c5d545 使用的 FK 约束名，downgrade 重建时必须一致。
+_FK_NAME = "fk_task_events_task_id"
+
+#: b942e8c5d545 的父 revision——下行到这里就跨过了按名 drop 约束的那一步。
+_BELOW_FK_MIGRATION = "ecbb53758daa"
+
+
+@pytest.fixture
+def alembic_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Config:
+    """指向项目 alembic 脚本，DB 用临时 sqlite（通过 DATABASE_URL，env.py 会读取）。"""
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = Config()
+    cfg.set_main_option("script_location", str(repo_root / "alembic"))
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    cfg.attributes["_test_db_path"] = str(db_path)
+    return cfg
+
+
+def test_downgrade_rebuilds_task_events_with_named_fk(alembic_cfg: Config):
+    """降级重建的 task_events 带具名 FK，且能继续下行跨过按名 drop 约束的迁移。"""
+    command.upgrade(alembic_cfg, "head")
+
+    engine = sa.create_engine(f"sqlite:///{alembic_cfg.attributes['_test_db_path']}")
+    try:
+        inspector = sa.inspect(engine)
+        assert "task_events" not in inspector.get_table_names()
+
+        command.downgrade(alembic_cfg, "b41d7c5e9a02")
+
+        inspector = sa.inspect(engine)
+        assert "task_events" in inspector.get_table_names()
+        fk_names = {fk["name"] for fk in inspector.get_foreign_keys("task_events")}
+        assert _FK_NAME in fk_names
+        assert "idx_task_events_project_id" in {idx["name"] for idx in inspector.get_indexes("task_events")}
+    finally:
+        engine.dispose()
+
+    # 继续下行跨过 b942e8c5d545（按名 drop 该 FK）——名字对不上时这里抛
+    # ValueError: No such constraint。
+    command.downgrade(alembic_cfg, _BELOW_FK_MIGRATION)
+
+    # 重新升到 head 不应因重建过的表残留报错
+    command.upgrade(alembic_cfg, "head")

--- a/tests/test_db_models.py
+++ b/tests/test_db_models.py
@@ -32,7 +32,6 @@ class TestModelsCreateTables:
         async with engine.connect() as conn:
             table_names = await conn.run_sync(lambda sync_conn: inspect(sync_conn).get_table_names())
         assert "tasks" in table_names
-        assert "task_events" in table_names
         assert "worker_lease" in table_names
         assert "api_calls" in table_names
         assert "agent_sessions" in table_names
@@ -162,14 +161,6 @@ class TestMixinApplicationToModels:
         assert "created_at" in columns
         assert "updated_at" in columns
         assert "user_id" in columns
-
-    async def test_task_event_no_user_id(self, engine):
-        """TaskEvent should NOT have user_id — it was not given UserOwnedMixin."""
-        async with engine.connect() as conn:
-            columns = await conn.run_sync(
-                lambda sync_conn: {c["name"] for c in inspect(sync_conn).get_columns("task_events")}
-            )
-        assert "user_id" not in columns
 
     async def test_worker_lease_no_user_id(self, engine):
         """WorkerLease should NOT have user_id — it was not given UserOwnedMixin."""

--- a/tests/test_generation_queue.py
+++ b/tests/test_generation_queue.py
@@ -73,33 +73,6 @@ class TestGenerationQueue:
         assert not second["deduped"]
         assert second["task_id"] != first["task_id"]
 
-    async def test_event_sequence_and_incremental_read(self, queue):
-        task = await queue.enqueue_task(
-            project_name="demo",
-            task_type="video",
-            media_type="video",
-            resource_id="E1S01",
-            payload={"prompt": "video"},
-            script_file="episode_01.json",
-            source="skill",
-        )
-        await queue.claim_next_task(media_type="video")
-        await queue.mark_task_failed(task["task_id"], "mock error")
-
-        all_events = await queue.get_events_since(last_event_id=0)
-        assert len(all_events) >= 3
-        assert all_events[0]["event_type"] == "queued"
-        assert all_events[1]["event_type"] == "running"
-        assert all_events[2]["event_type"] == "failed"
-
-        last_seen_id = all_events[1]["id"]
-        incremental = await queue.get_events_since(last_event_id=last_seen_id)
-        assert all(event["id"] > last_seen_id for event in incremental)
-        assert any(event["event_type"] == "failed" for event in incremental)
-
-        latest_id = await queue.get_latest_event_id()
-        assert latest_id == all_events[-1]["id"]
-
     async def test_worker_lease_takeover(self, queue):
         first_ok = await queue.acquire_or_renew_worker_lease(
             name="default",
@@ -265,9 +238,6 @@ class TestGenerationQueue:
         claimed_again = await queue.claim_next_task(media_type="video")
         assert claimed_again is not None
         assert claimed_again["task_id"] == task["task_id"]
-
-        events = await queue.get_events_since(last_event_id=0)
-        assert any(event["event_type"] == "requeued" for event in events)
 
     async def test_cancel_task(self, queue):
         result = await queue.enqueue_task(

--- a/tests/test_task_repo.py
+++ b/tests/test_task_repo.py
@@ -105,25 +105,6 @@ class TestTaskRepository:
         assert character_edit_again["deduped"]
         assert character_edit_again["task_id"] == character_edit["task_id"]
 
-    async def test_event_sequence(self, db_session):
-        repo = TaskRepository(db_session)
-
-        task = await repo.enqueue(
-            project_name="demo",
-            task_type="video",
-            media_type="video",
-            resource_id="E1S01",
-            payload={},
-            script_file="ep1.json",
-        )
-        await repo.claim_next("video")
-        await repo.mark_failed(task["task_id"], "mock error")
-
-        events = await repo.get_events_since(last_event_id=0)
-        assert len(events) >= 3
-        types = [e["event_type"] for e in events]
-        assert types == ["queued", "running", "failed"]
-
     async def test_dependency_cascade_failure(self, db_session):
         repo = TaskRepository(db_session)
 
@@ -688,11 +669,11 @@ class TestCancelCascadeAcrossCancelling:
         assert (await repo.get(c))["status"] == "cancelled"
         assert (await repo.get(c))["cancelled_by"] == "cascade"
 
-    async def test_cancel_cascade_event_data_carries_cancelled_by(self, db_session):
-        """前端通过 SSE 事件 data 中的 cancelled_by 字段区分级联取消。
+    async def test_cancel_cascade_task_rows_carry_cancelled_by(self, db_session):
+        """级联取消的下游任务与发起方在 cancelled_by 字段上须能区分。
 
-        本测试断言：finalize_cancelled(A) 触发的 B/C cancelled 事件 data 中
-        cancelled_by="cascade"；A 自己的事件 data cancelled_by="user"。
+        本测试断言：finalize_cancelled(A) 落库后，B/C 的 cancelled_by="cascade"；
+        A 自己的 cancelled_by="user"。
         """
         repo = TaskRepository(db_session)
         a, b, c = await self._chain_3(repo)
@@ -700,28 +681,22 @@ class TestCancelCascadeAcrossCancelling:
         await repo.cancel_task(a)
         await repo.finalize_cancelled(a)
 
-        events = await repo.get_events_since(last_event_id=0)
-        cancelled_events = [e for e in events if e["event_type"] == "cancelled"]
-        by_task = {e["task_id"]: e for e in cancelled_events}
+        assert (await repo.get(a))["cancelled_by"] == "user"
+        assert (await repo.get(b))["cancelled_by"] == "cascade"
+        assert (await repo.get(c))["cancelled_by"] == "cascade"
 
-        assert by_task[a]["data"]["cancelled_by"] == "user"
-        assert by_task[b]["data"]["cancelled_by"] == "cascade"
-        assert by_task[c]["data"]["cancelled_by"] == "cascade"
-
-    async def test_cancel_emits_each_event_at_most_twice(self, db_session):
-        """每个 task 的 cancelling/cancelled 事件不超过 1 次/各 1 次（不重复 emit）。"""
+    async def test_cancel_records_each_terminal_event_at_most_once(self, db_session):
+        """每个 task 的终态推送（project_events SSE 依赖的 terminal_events）不重复记账。"""
         repo = TaskRepository(db_session)
         a, b, c = await self._chain_3(repo)
         await repo.claim_next("image")
         await repo.cancel_task(a)
         await repo.finalize_cancelled(a)
 
-        events = await repo.get_events_since(last_event_id=0)
-        cancel_events = [e for e in events if e["event_type"] in ("cancelling", "cancelled")]
-        # 计数每个 task 的 cancel-related events
+        cancelled_events = [e for e in repo.terminal_events if e["status"] == "cancelled"]
         by_task: dict[str, int] = {}
-        for e in cancel_events:
+        for e in cancelled_events:
             tid = e["task_id"]
             by_task[tid] = by_task.get(tid, 0) + 1
         for tid in (a, b, c):
-            assert by_task.get(tid, 0) <= 2, f"{tid} 有重复 cancel 事件: {by_task.get(tid)}"
+            assert by_task.get(tid, 0) <= 1, f"{tid} 有重复终态推送: {by_task.get(tid)}"

--- a/tests/test_task_terminal_events.py
+++ b/tests/test_task_terminal_events.py
@@ -175,14 +175,14 @@ class TestQueueEmitsTerminalEvents:
         task_id = await self._enqueue_running(queue)
         captured_batches.clear()
 
-        original_append = TaskRepository._append_event
+        original_record = TaskRepository._record_terminal_event
 
-        async def raise_after_collecting(self, **kwargs):
-            await original_append(self, **kwargs)
-            assert self.terminal_events, "前置条件：终态已被 _append_event 收集"
+        def raise_after_collecting(self, **kwargs):
+            original_record(self, **kwargs)
+            assert self.terminal_events, "前置条件：终态已被 _record_terminal_event 收集"
             raise RuntimeError("commit 前炸了")
 
-        monkeypatch.setattr(TaskRepository, "_append_event", raise_after_collecting)
+        monkeypatch.setattr(TaskRepository, "_record_terminal_event", raise_after_collecting)
 
         with pytest.raises(RuntimeError, match="commit 前炸了"):
             await queue.mark_task_succeeded(task_id, {"file_path": "videos/E1S01.mp4"})
@@ -190,7 +190,7 @@ class TestQueueEmitsTerminalEvents:
         assert _task_changes(captured_batches) == []
 
     async def test_cascade_failure_emits_event_for_dependent(self, queue, captured_batches):
-        """级联失败的下游任务同样进事件——终态收口在 _append_event，一处覆盖全路径。"""
+        """级联失败的下游任务同样进事件——终态收口在 _record_terminal_event，一处覆盖全路径。"""
         parent = await queue.enqueue_task(
             project_name="demo",
             task_type="storyboard",

--- a/tests/test_tasks_router_smoke.py
+++ b/tests/test_tasks_router_smoke.py
@@ -1,4 +1,4 @@
-"""Tests for task router endpoints and SSE events."""
+"""Smoke tests for task router endpoints against a real generation queue."""
 
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -17,8 +17,8 @@ def _build_app():
     return app
 
 
-class TestTaskRouterAndEvents:
-    async def test_task_router_endpoints_and_incremental_events(self, generation_queue):
+class TestTaskRouterEndpoints:
+    async def test_task_router_endpoints_after_enqueue_claim_fail(self, generation_queue):
         queue = generation_queue
         task = await queue.enqueue_task(
             project_name="demo",
@@ -46,11 +46,3 @@ class TestTaskRouterAndEvents:
             assert stats_resp.status_code == 200
             stats = stats_resp.json()["stats"]
             assert stats["failed"] == 1
-
-        events = await queue.get_events_since(last_event_id=0, project_name="demo")
-        assert len(events) >= 3
-
-        last_running_id = events[1]["id"]
-        incremental = await queue.get_events_since(last_event_id=last_running_id, project_name="demo")
-        assert all(event["id"] > last_running_id for event in incremental)
-        assert any(event["event_type"] == "failed" for event in incremental)


### PR DESCRIPTION
Closes #1438

`/tasks/stream` 端点移除后，`task_events` 表只写不读。本 PR 整链删除这条死代码：三个读取接口（`get_recent_tasks_snapshot` / `get_events_since` / `get_latest_event_id`）及 repo 层实现、事件写入点、ORM 表模型，并新增 alembic 迁移 drop 该表。事件属短生命周期数据，存量直接丢弃。

任务终态推送改由独立的同步方法 `_record_terminal_event` 收集，经 project_events SSE 发布，行为不变。

## 验证

- `uv run python -m pytest`：6711 passed
- `uv run ruff check .`：全部通过；`uv run basedpyright`：0 errors
- `alembic heads` 单 head 无分叉；SQLite 下 `upgrade head` 通过
- `upgrade head → downgrade base` 下行链与 origin/main 齐平：两者均止步于同一 revision `156fe0aa0414`（`no such index: idx_tasks_dedupe_active`，main 上的既有问题，不在本票范围）

## 本地审查修复

- **downgrade 重建 task_events 的 FK 未具名**，与建表迁移的 `fk_task_events_task_id` 对不上，导致上一级迁移按名 `drop_constraint` 时整条下行链断裂（实测 `ValueError: No such constraint`）。已改为具名 `ForeignKeyConstraint`，并补 `tests/test_alembic_drop_task_events_downgrade.py` 回归覆盖（反向验证过：去掉具名 FK 该测试即失败）
- **删除三处恒为 no-op 的终态事件调用**：`enqueue`(queued) / `claim_next`(running) / `_mark_cancelling`(cancelling) 传的都是非终态，删表后调用整体空转，连带去掉仅为此白做的 `flush` + 重查 + 整行 dict 构造
- **`_record_terminal_event` 参数收窄**：由全量 `data: dict` 改为 `task_type: str | None`，方法本就只取这一个字段
- 清理两处迁移 docstring：移除 issue 编号引用（项目规范：编号写在 commit/PR 里），修正一处已失效的 `task_events` 表述

## 已知限制

PostgreSQL 方言未实测（本机无 PG 环境）。upgrade 仅 `drop_index` + `drop_table`，无其他表引用该表，无方言特定语法，风险低。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **变更**
  * 任务事件历史不再持久化，任务状态查询与增量事件读取能力已移除。
  * 任务迁移流程不再导入旧事件数据。
  * 新增工作进程租约管理能力，可获取、续期、释放租约并检查在线状态。

* **改进**
  * 任务取消、失败等终态信息记录更加可靠，避免重复记录。
  * 任务接口与统计信息继续支持失败任务状态查询。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->