### PR TITLE
fix(events): 项目变更不再因快照重建时序而漏播或误报删除

### DIFF
--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import logging
 import uuid
+from collections import Counter
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -55,13 +56,24 @@ def _fingerprint(value: Any) -> str:
     return hashlib.sha1(_stable_json(value).encode("utf-8")).hexdigest()
 
 
+# 同一件事在发布方与快照差分两侧的 action 命名差异：参考视频任务完成时，发布方按 task_type
+# 映射为 ``reference_video_ready``（见 generation_tasks._SKELETON_DRIVEN_TASK_ACTIONS），而同一次
+# 落盘在 ``_diff_reference_units`` 里表示为 ``video_ready``。两侧 entity_type/entity_id 相同，
+# 只有 action 不同，不归一会让同一次完成广播成两条。
+_EQUIVALENT_ACTIONS: dict[str, str] = {"reference_video_ready": "video_ready"}
+
+
 def _change_identity(change: dict[str, Any]) -> tuple[Any, Any, Any]:
     """变更去重身份。
 
     只取 entity_type/action/entity_id：script_file 与 episode 由发布方按 task_type 选择性
-    附带，纳入身份会让同一件事因一侧为 None 而判成两条。
+    附带，纳入身份会让同一件事因一侧为 None 而判成两条。action 经 ``_EQUIVALENT_ACTIONS``
+    归一，抹平发布方与快照差分对同一件事的命名差异。
     """
-    return (change.get("entity_type"), change.get("action"), change.get("entity_id"))
+    action = change.get("action")
+    if isinstance(action, str):
+        action = _EQUIVALENT_ACTIONS.get(action, action)
+    return (change.get("entity_type"), action, change.get("entity_id"))
 
 
 @dataclass
@@ -73,6 +85,9 @@ class _ProjectChannel:
     # 不同会让先读到旧盘的一方后结算，把陈旧快照写回基线并 diff 出反向变更（实际存在的
     # 实体被广播成 deleted）。不重置该锁——重建 task 可能跨 watch task 重启仍持有它。
     rebuild_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    # 已发布、尚未广播的显式批次各自描述的变更身份。重建读盘会捎带其它批次已落盘的产物，
+    # 补扫需把它们让给自己那一批去广播，否则同一件事先被补扫发一次、再被本批发一次。
+    inflight_batch_identities: Counter[tuple[Any, Any, Any]] = field(default_factory=Counter)
     pending_sources: set[ProjectChangeSource] = field(default_factory=set)
     task: asyncio.Task | None = None
     snapshot: dict[str, Any] | None = None
@@ -311,9 +326,13 @@ class ProjectEventService:
 
         channel.scan_now.clear()
 
+        # 在册时机必须早于本批重建读盘，其它批次的补扫才让得掉这些身份
+        identities = Counter(_change_identity(change) for change in changes)
+        channel.inflight_batch_identities.update(identities)
+
         # 文件 I/O 下沉到线程池，状态更新和广播留在事件循环
         task = asyncio.create_task(
-            self._async_rebuild_and_broadcast(project_name, channel, source, changes),
+            self._async_rebuild_and_broadcast(project_name, channel, source, changes, identities),
             name=f"batch-rebuild-{project_name}",
         )
         self._pending_batch_tasks.add(task)
@@ -325,38 +344,56 @@ class ProjectEventService:
         channel: _ProjectChannel,
         source: ProjectChangeSource,
         changes: tuple[ProjectChangeBatch, ...],
+        identities: Counter[tuple[Any, Any, Any]],
     ) -> None:
         """文件 I/O 在线程中执行，状态更新和广播在事件循环线程中执行。"""
-        async with channel.rebuild_lock:
-            # 读盘前在册的来源标记：写回时只退这些，读盘期间新增的标记留给下一轮扫描结算
-            covered_sources = set(channel.pending_sources)
-            try:
-                snapshot, fingerprint = await asyncio.to_thread(self._rebuild_snapshot, project_name)
-            except FileNotFoundError:
-                await self._handle_scan_file_not_found(
-                    project_name, channel, log_message="构建显式项目事件快照失败 project=%s"
+        try:
+            async with channel.rebuild_lock:
+                # 读盘前在册的来源标记整体换出：读盘期间新增的 hint 落进新集合，留给下一轮扫描
+                # 结算。若改为读盘后减去旧集合，同一来源在窗口内重复到达会被一并减掉，那条新
+                # 变更会在下一轮扫描被 _resolve_batch_source 误标成 filesystem。
+                covered_sources = channel.pending_sources
+                channel.pending_sources = set()
+                try:
+                    snapshot, fingerprint = await asyncio.to_thread(self._rebuild_snapshot, project_name)
+                except FileNotFoundError:
+                    channel.pending_sources |= covered_sources
+                    await self._handle_scan_file_not_found(
+                        project_name, channel, log_message="构建显式项目事件快照失败 project=%s"
+                    )
+                    return
+                except Exception:
+                    channel.pending_sources |= covered_sources
+                    logger.exception("构建显式项目事件快照失败 project=%s", project_name)
+                    return
+
+                # 以下在事件循环线程中执行，线程安全
+                previous = channel.snapshot
+                channel.snapshot = snapshot
+                channel.fingerprint = fingerprint
+
+                self._broadcast_changes(
+                    project_name,
+                    channel,
+                    fingerprint=fingerprint,
+                    source=source,
+                    changes=[dict(change) for change in changes],
                 )
-                return
-            except Exception:
-                logger.exception("构建显式项目事件快照失败 project=%s", project_name)
-                return
 
-            # 以下在事件循环线程中执行，线程安全
-            previous = channel.snapshot
-            channel.snapshot = snapshot
-            channel.fingerprint = fingerprint
-            channel.pending_sources -= covered_sources
-
-            self._broadcast_changes(
-                project_name,
-                channel,
-                fingerprint=fingerprint,
-                source=source,
-                changes=[
-                    *(dict(change) for change in changes),
-                    *self._sweep_uncovered_changes(previous, snapshot, changes),
-                ],
-            )
+                swept = self._sweep_uncovered_changes(previous, snapshot, channel.inflight_batch_identities)
+                if swept:
+                    # 补扫的变更不属于本批，来源按自己的 hint 标记解析，与轮询扫描同一口径：
+                    # 沿用本批 source 会让 WebUI 自身的编辑被标成 worker（前端据此弹通知并自动
+                    # 导航），或反之漏掉 worker 产物的通知。
+                    self._broadcast_changes(
+                        project_name,
+                        channel,
+                        fingerprint=fingerprint,
+                        source=self._resolve_batch_source(covered_sources),
+                        changes=swept,
+                    )
+        finally:
+            channel.inflight_batch_identities -= identities
 
     def _broadcast_changes(
         self,
@@ -382,18 +419,20 @@ class ProjectEventService:
         self,
         previous: dict[str, Any] | None,
         snapshot: dict[str, Any],
-        changes: tuple[ProjectChangeBatch, ...],
+        covered: Counter[tuple[Any, Any, Any]],
     ) -> list[dict[str, Any]]:
-        """新快照相对基线多出、而本批 changes 未覆盖的变更。
+        """新快照相对基线多出、而任何在途显式批次都未描述的变更。
 
         重建读盘会捎带任何已落盘的变更，而本批 changes 只描述发布方自己那一件事。
         新快照被无条件写回基线，捎带进来的变更若不在本次广播里，后续扫描与基线已无
-        差异，就再没有任何机制为它补发——故在此对基线做一次 diff，把未覆盖的部分并入
-        本次广播。它们的 source 随本批标注（source 是 payload 级字段，非逐条）。
+        差异，就再没有任何机制为它补发——故在此对基线做一次 diff 补发未覆盖的部分。
+
+        ``covered`` 是在途批次身份登记表（含本批自己），这些身份让给各自那一批广播，
+        免得同一件事被补扫先发一次、再被它自己的批次发一次。残留窗口：某批次的产物已
+        落盘、而它的 emit 调用晚于本次读盘返回，此时该身份尚未在册，仍会重复一次。
         """
         if previous is None:
             return []
-        covered = {_change_identity(change) for change in changes}
         return [
             change for change in self._diff_snapshots(previous, snapshot) if _change_identity(change) not in covered
         ]

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -69,6 +69,10 @@ class _ProjectChannel:
     sse: SseChannel
     ready_event: asyncio.Event = field(default_factory=asyncio.Event)
     scan_now: asyncio.Event = field(default_factory=asyncio.Event)
+    # 串行化「读盘 → 结算基线 → 广播」这段读-改-写：轮询扫描与显式重建并发时，读盘耗时
+    # 不同会让先读到旧盘的一方后结算，把陈旧快照写回基线并 diff 出反向变更（实际存在的
+    # 实体被广播成 deleted）。不重置该锁——重建 task 可能跨 watch task 重启仍持有它。
+    rebuild_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     pending_sources: set[ProjectChangeSource] = field(default_factory=set)
     task: asyncio.Task | None = None
     snapshot: dict[str, Any] | None = None
@@ -323,36 +327,54 @@ class ProjectEventService:
         changes: tuple[ProjectChangeBatch, ...],
     ) -> None:
         """文件 I/O 在线程中执行，状态更新和广播在事件循环线程中执行。"""
-        # 读盘前在册的来源标记：写回时只退这些，读盘期间新增的标记留给下一轮扫描结算
-        covered_sources = set(channel.pending_sources)
-        try:
-            snapshot, fingerprint = await asyncio.to_thread(self._rebuild_snapshot, project_name)
-        except FileNotFoundError:
-            await self._handle_scan_file_not_found(
-                project_name, channel, log_message="构建显式项目事件快照失败 project=%s"
+        async with channel.rebuild_lock:
+            # 读盘前在册的来源标记：写回时只退这些，读盘期间新增的标记留给下一轮扫描结算
+            covered_sources = set(channel.pending_sources)
+            try:
+                snapshot, fingerprint = await asyncio.to_thread(self._rebuild_snapshot, project_name)
+            except FileNotFoundError:
+                await self._handle_scan_file_not_found(
+                    project_name, channel, log_message="构建显式项目事件快照失败 project=%s"
+                )
+                return
+            except Exception:
+                logger.exception("构建显式项目事件快照失败 project=%s", project_name)
+                return
+
+            # 以下在事件循环线程中执行，线程安全
+            previous = channel.snapshot
+            channel.snapshot = snapshot
+            channel.fingerprint = fingerprint
+            channel.pending_sources -= covered_sources
+
+            self._broadcast_changes(
+                project_name,
+                channel,
+                fingerprint=fingerprint,
+                source=source,
+                changes=[
+                    *(dict(change) for change in changes),
+                    *self._sweep_uncovered_changes(previous, snapshot, changes),
+                ],
             )
-            return
-        except Exception:
-            logger.exception("构建显式项目事件快照失败 project=%s", project_name)
-            return
 
-        # 以下在事件循环线程中执行，线程安全
-        # 基线取重建返回后的现值：读盘期间轮询扫描可能已推进过基线，用现值才不会重发它已广播的变更
-        previous = channel.snapshot
-        channel.snapshot = snapshot
-        channel.fingerprint = fingerprint
-        channel.pending_sources -= covered_sources
-
+    def _broadcast_changes(
+        self,
+        project_name: str,
+        channel: _ProjectChannel,
+        *,
+        fingerprint: str,
+        source: ProjectChangeSource,
+        changes: list[dict[str, Any]],
+    ) -> None:
+        """向订阅者广播一批变更（轮询扫描与显式重建两条路径共用同一 payload 形状）。"""
         payload = {
             "project_name": project_name,
             "batch_id": uuid.uuid4().hex,
             "fingerprint": fingerprint,
             "generated_at": _utc_now_iso(),
             "source": source,
-            "changes": [
-                *(dict(change) for change in changes),
-                *self._sweep_uncovered_changes(previous, snapshot, changes),
-            ],
+            "changes": changes,
         }
         channel.sse.broadcast(("changes", payload))
 
@@ -433,10 +455,11 @@ class ProjectEventService:
         try:
             while channel.sse.has_subscribers:
                 try:
-                    # 仅文件 I/O 在线程中执行
-                    snapshot, fingerprint = await asyncio.to_thread(self._rebuild_snapshot, project_name)
-                    # 状态更新和广播在事件循环线程中执行（线程安全）
-                    self._apply_scan_result(project_name, channel, snapshot, fingerprint)
+                    async with channel.rebuild_lock:
+                        # 仅文件 I/O 在线程中执行
+                        snapshot, fingerprint = await asyncio.to_thread(self._rebuild_snapshot, project_name)
+                        # 状态更新和广播在事件循环线程中执行（线程安全）
+                        self._apply_scan_result(project_name, channel, snapshot, fingerprint)
                 except asyncio.CancelledError:
                     raise
                 except FileNotFoundError:
@@ -484,15 +507,13 @@ class ProjectEventService:
         if not changes:
             return
 
-        payload = {
-            "project_name": project_name,
-            "batch_id": uuid.uuid4().hex,
-            "fingerprint": fingerprint,
-            "generated_at": _utc_now_iso(),
-            "source": source,
-            "changes": changes,
-        }
-        channel.sse.broadcast(("changes", payload))
+        self._broadcast_changes(
+            project_name,
+            channel,
+            fingerprint=fingerprint,
+            source=source,
+            changes=changes,
+        )
 
     def _build_snapshot_payload(
         self,

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -55,6 +55,15 @@ def _fingerprint(value: Any) -> str:
     return hashlib.sha1(_stable_json(value).encode("utf-8")).hexdigest()
 
 
+def _change_identity(change: dict[str, Any]) -> tuple[Any, Any, Any]:
+    """变更去重身份。
+
+    只取 entity_type/action/entity_id：script_file 与 episode 由发布方按 task_type 选择性
+    附带，纳入身份会让同一件事因一侧为 None 而判成两条。
+    """
+    return (change.get("entity_type"), change.get("action"), change.get("entity_id"))
+
+
 @dataclass
 class _ProjectChannel:
     sse: SseChannel
@@ -314,6 +323,8 @@ class ProjectEventService:
         changes: tuple[ProjectChangeBatch, ...],
     ) -> None:
         """文件 I/O 在线程中执行，状态更新和广播在事件循环线程中执行。"""
+        # 读盘前在册的来源标记：写回时只退这些，读盘期间新增的标记留给下一轮扫描结算
+        covered_sources = set(channel.pending_sources)
         try:
             snapshot, fingerprint = await asyncio.to_thread(self._rebuild_snapshot, project_name)
         except FileNotFoundError:
@@ -326,9 +337,11 @@ class ProjectEventService:
             return
 
         # 以下在事件循环线程中执行，线程安全
+        # 基线取重建返回后的现值：读盘期间轮询扫描可能已推进过基线，用现值才不会重发它已广播的变更
+        previous = channel.snapshot
         channel.snapshot = snapshot
         channel.fingerprint = fingerprint
-        channel.pending_sources.clear()
+        channel.pending_sources -= covered_sources
 
         payload = {
             "project_name": project_name,
@@ -336,9 +349,32 @@ class ProjectEventService:
             "fingerprint": fingerprint,
             "generated_at": _utc_now_iso(),
             "source": source,
-            "changes": [dict(change) for change in changes],
+            "changes": [
+                *(dict(change) for change in changes),
+                *self._sweep_uncovered_changes(previous, snapshot, changes),
+            ],
         }
         channel.sse.broadcast(("changes", payload))
+
+    def _sweep_uncovered_changes(
+        self,
+        previous: dict[str, Any] | None,
+        snapshot: dict[str, Any],
+        changes: tuple[ProjectChangeBatch, ...],
+    ) -> list[dict[str, Any]]:
+        """新快照相对基线多出、而本批 changes 未覆盖的变更。
+
+        重建读盘会捎带任何已落盘的变更，而本批 changes 只描述发布方自己那一件事。
+        新快照被无条件写回基线，捎带进来的变更若不在本次广播里，后续扫描与基线已无
+        差异，就再没有任何机制为它补发——故在此对基线做一次 diff，把未覆盖的部分并入
+        本次广播。它们的 source 随本批标注（source 是 payload 级字段，非逐条）。
+        """
+        if previous is None:
+            return []
+        covered = {_change_identity(change) for change in changes}
+        return [
+            change for change in self._diff_snapshots(previous, snapshot) if _change_identity(change) not in covered
+        ]
 
     def _rebuild_snapshot(self, project_name: str) -> tuple[dict[str, Any], str]:
         """同步方法（在线程池中执行）：重建快照并返回 (snapshot, fingerprint)。"""

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import json
 import logging
 
@@ -318,6 +319,7 @@ class TestProjectEventService:
                 original_rebuild = service._rebuild_snapshot
                 calls = 0
                 first_read_done = asyncio.Event()
+                second_read_done = asyncio.Event()
                 loop = asyncio.get_running_loop()
 
                 def _rebuild_holding_first(project_name: str):
@@ -329,6 +331,8 @@ class TestProjectEventService:
                         # 首次读盘已完成但尚未结算：交还控制权，等编排放行
                         loop.call_soon_threadsafe(first_read_done.set)
                         asyncio.run_coroutine_threadsafe(release_first.wait(), loop).result(timeout=5)
+                    else:
+                        loop.call_soon_threadsafe(second_read_done.set)
                     return result
 
                 monkeypatch.setattr(service, "_rebuild_snapshot", _rebuild_holding_first)
@@ -342,9 +346,12 @@ class TestProjectEventService:
                 data.setdefault("characters", {})["新角色"] = {"name": "新角色", "description": "d"}
                 project_json.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
 
-                # 第二次重建：留出窗口让它抢先读盘并结算（无锁时它会先于首次广播）
+                # 第二次重建：无锁时它能在此期间读到新盘并抢先结算，等它的读盘完成信号，
+                # 不用固定 sleep（调度慢于 sleep 时第二次重建还没开始，摘掉锁也测不出回归）。
+                # 有锁时它被挡在锁外、信号必然等不到，这时超时本身就是锁生效的证据。
                 emit_project_change_batch("demo", [_terminal_task_change("task-2")], source="worker")
-                await asyncio.sleep(0.2)
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(second_read_done.wait(), timeout=1.0)
                 release_first.set()
 
                 # 两次重建各自的批次广播与可能的补扫广播都要收齐，再看角色变更的全貌
@@ -441,6 +448,7 @@ class TestProjectEventService:
         finally:
             await service.shutdown()
 
+    @pytest.mark.integration
     @pytest.mark.asyncio
     async def test_emitted_batch_does_not_duplicate_change_it_already_describes(self, tmp_path):
         """资产已落盘再发本批事件（worker 成功路径的真实次序）时，补扫不重复广播同一条变更。"""
@@ -509,6 +517,7 @@ class TestProjectEventService:
         finally:
             await service.shutdown()
 
+    @pytest.mark.unit
     def test_change_identity_normalizes_equivalent_ready_actions(self):
         """参考视频完成在发布方与快照差分两侧的 action 命名不同，但去重身份相同。
 

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -293,7 +293,7 @@ class TestProjectEventService:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
-    async def test_stale_rebuild_does_not_broadcast_reverse_diff(self, tmp_path):
+    async def test_stale_rebuild_does_not_broadcast_reverse_diff(self, tmp_path, monkeypatch):
         """两次显式重建读盘耗时不同而乱序结算时，先读到旧盘的一方不广播反向变更。
 
         补扫对基线做 diff，故陈旧快照被写回基线会把实际存在的实体 diff 成 ``deleted``。
@@ -307,53 +307,58 @@ class TestProjectEventService:
         service = ProjectEventService(tmp_path, poll_interval=30.0)
         await service.start()
 
-        async with service.stream_events("demo", idle_timeout=0.1) as stream:
-            event_name, _snapshot = await anext(stream)
-            assert event_name == "snapshot"
+        release_first = asyncio.Event()
 
-            original_rebuild = service._rebuild_snapshot
-            calls = 0
-            first_read_done = asyncio.Event()
-            release_first = asyncio.Event()
-            loop = asyncio.get_running_loop()
+        try:
+            async with service.stream_events("demo", idle_timeout=0.1) as stream:
+                event_name, _snapshot = await anext(stream)
+                assert event_name == "snapshot"
 
-            def _rebuild_holding_first(project_name: str):
-                nonlocal calls
-                calls += 1
-                index = calls
-                result = original_rebuild(project_name)
-                if index == 1:
-                    # 首次读盘已完成但尚未结算：交还控制权，等编排放行
-                    loop.call_soon_threadsafe(first_read_done.set)
-                    asyncio.run_coroutine_threadsafe(release_first.wait(), loop).result(timeout=5)
-                return result
+                original_rebuild = service._rebuild_snapshot
+                calls = 0
+                first_read_done = asyncio.Event()
+                loop = asyncio.get_running_loop()
 
-            service._rebuild_snapshot = _rebuild_holding_first
+                def _rebuild_holding_first(project_name: str):
+                    nonlocal calls
+                    calls += 1
+                    index = calls
+                    result = original_rebuild(project_name)
+                    if index == 1:
+                        # 首次读盘已完成但尚未结算：交还控制权，等编排放行
+                        loop.call_soon_threadsafe(first_read_done.set)
+                        asyncio.run_coroutine_threadsafe(release_first.wait(), loop).result(timeout=5)
+                    return result
 
-            emit_project_change_batch("demo", [_terminal_task_change("task-1")], source="worker")
-            await asyncio.wait_for(first_read_done.wait(), timeout=5.0)
+                monkeypatch.setattr(service, "_rebuild_snapshot", _rebuild_holding_first)
 
-            # 首次读盘之后落盘一个新角色：直接改写 project.json，不发 hint
-            project_json = pm.get_project_path("demo") / "project.json"
-            data = json.loads(project_json.read_text(encoding="utf-8"))
-            data.setdefault("characters", {})["新角色"] = {"name": "新角色", "description": "d"}
-            project_json.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+                emit_project_change_batch("demo", [_terminal_task_change("task-1")], source="worker")
+                await asyncio.wait_for(first_read_done.wait(), timeout=5.0)
 
-            # 第二次重建：留出窗口让它抢先读盘并结算（无锁时它会先于首次广播）
-            emit_project_change_batch("demo", [_terminal_task_change("task-2")], source="worker")
-            await asyncio.sleep(0.2)
+                # 首次读盘之后落盘一个新角色：直接改写 project.json，不发 hint
+                project_json = pm.get_project_path("demo") / "project.json"
+                data = json.loads(project_json.read_text(encoding="utf-8"))
+                data.setdefault("characters", {})["新角色"] = {"name": "新角色", "description": "d"}
+                project_json.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+                # 第二次重建：留出窗口让它抢先读盘并结算（无锁时它会先于首次广播）
+                emit_project_change_batch("demo", [_terminal_task_change("task-2")], source="worker")
+                await asyncio.sleep(0.2)
+                release_first.set()
+
+                broadcast_changes = []
+                for _ in range(2):
+                    event_name, payload = await _next_event(stream, timeout=5.0)
+                    assert event_name == "changes"
+                    broadcast_changes.extend(payload["changes"])
+
+                character_changes = [change for change in broadcast_changes if change["entity_type"] == "character"]
+                assert [change["action"] for change in character_changes] == ["created"]
+        finally:
+            # 断言或 _next_event 提前失败时，被刻意挂起的重建线程仍卡在 release_first 上，
+            # 放行后 shutdown 才收得掉 watch task 与 project_change_hints 的全局监听注册。
             release_first.set()
-
-            broadcast_changes = []
-            for _ in range(2):
-                event_name, payload = await _next_event(stream, timeout=5.0)
-                assert event_name == "changes"
-                broadcast_changes.extend(payload["changes"])
-
-            character_changes = [change for change in broadcast_changes if change["entity_type"] == "character"]
-            assert [change["action"] for change in character_changes] == ["created"]
-
-        await service.shutdown()
+            await service.shutdown()
 
     @pytest.mark.integration
     @pytest.mark.asyncio

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -15,6 +15,7 @@ from lib.script_skeleton import (
 from server.services.project_events import (
     PROJECT_DELETED_EVENT,
     ProjectEventService,
+    _change_identity,
 )
 
 
@@ -346,9 +347,17 @@ class TestProjectEventService:
                 await asyncio.sleep(0.2)
                 release_first.set()
 
+                # 两次重建各自的批次广播与可能的补扫广播都要收齐，再看角色变更的全貌
                 broadcast_changes = []
                 for _ in range(2):
                     event_name, payload = await _next_event(stream, timeout=5.0)
+                    assert event_name == "changes"
+                    broadcast_changes.extend(payload["changes"])
+                while True:
+                    try:
+                        event_name, payload = await _next_event(stream, timeout=0.5)
+                    except TimeoutError:
+                        break
                     assert event_name == "changes"
                     broadcast_changes.extend(payload["changes"])
 
@@ -363,11 +372,14 @@ class TestProjectEventService:
     @pytest.mark.integration
     @pytest.mark.asyncio
     async def test_emitted_batch_broadcasts_concurrent_change_swept_into_rebuild(self, tmp_path):
-        """显式重建读盘捎带了不属于本批的文件变更时，该变更随本次广播发出。
+        """显式重建读盘捎带了不属于本批的文件变更时，该变更由紧随其后的补扫广播发出。
 
         显式重建把新快照写回基线。若某个变更落盘于读盘之前却不在本批 changes 里，
         它会被并入基线而从未广播——后续轮询扫描与基线已无差异，再没有任何机制
         为它补发。这里用「与该变更无关的终态事件」触发重建来覆盖这条路径。
+
+        补扫走独立 payload：source 是 payload 级字段，捎带进来的变更来源与本批未必
+        相同，并入本批会让前端的 webui 抑制判断落到错误的一侧。
 
         并发变更取「原地改写已索引的剧本文件」：这类变更不触发剧集索引同步，
         因而不会顺带发出 hint 唤醒轮询扫描，丢失是终局的。
@@ -411,14 +423,19 @@ class TestProjectEventService:
 
             emit_project_change_batch("demo", [_terminal_task_change("task-1")], source="worker")
 
+            # 本批自身的终态事件独占一条 payload（正常路径的时序与结构不受补扫影响）
             event_name, payload = await _next_event(stream, timeout=2.0)
             assert event_name == "changes"
-            # 本批自身的终态事件仍在，且列在最前（正常路径 payload 结构不受影响）
-            assert payload["changes"][0]["action"] == "task_succeeded"
+            assert [change["action"] for change in payload["changes"]] == ["task_succeeded"]
+            assert payload["source"] == "worker"
+
+            # 捎带进来的变更随后单独广播，来源按自己的 hint 标记解析
+            event_name, swept = await _next_event(stream, timeout=2.0)
+            assert event_name == "changes"
             assert any(
-                change["action"] == "storyboard_ready" and change["entity_id"] == "E1S01"
-                for change in payload["changes"]
+                change["action"] == "storyboard_ready" and change["entity_id"] == "E1S01" for change in swept["changes"]
             )
+            assert swept["source"] == "filesystem"
 
         await service.shutdown()
 
@@ -488,6 +505,186 @@ class TestProjectEventService:
             assert len(ready) == 1
 
         await service.shutdown()
+
+    def test_change_identity_normalizes_equivalent_ready_actions(self):
+        """参考视频完成在发布方与快照差分两侧的 action 命名不同，但去重身份相同。
+
+        发布方按 task_type 映射为 ``reference_video_ready``，同一次落盘在 unit 差分里是
+        ``video_ready``；不归一会让同一次完成既由本批广播、又被补扫广播一次。
+        """
+        common = {"entity_type": "reference_unit", "entity_id": "E1U01"}
+        assert _change_identity({**common, "action": "reference_video_ready"}) == _change_identity(
+            {**common, "action": "video_ready"}
+        )
+        # 归一只覆盖这一对等价 action，不牵连其它动作
+        assert _change_identity({**common, "action": "storyboard_ready"}) != _change_identity(
+            {**common, "action": "video_ready"}
+        )
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_sweep_leaves_change_described_by_another_inflight_batch(self, tmp_path, monkeypatch):
+        """另一批次的产物被本次重建读盘捎带时，补扫让给该批次广播，同一件事只发一次。
+
+        两个生成任务几乎同时完成时，先取得重建锁的一方会读到对方已落盘的产物。补扫若把它
+        一并广播，对方自己排队的批次仍会无条件再发一次，前端不跨批去重，用户看到两次完成。
+        """
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        script = {
+            "episode": 1,
+            "title": "第一集",
+            "content_mode": "narration",
+            "segments": [
+                {
+                    "segment_id": "E1S01",
+                    "narration_text": "开场",
+                    "image_prompt": "p",
+                    "video_prompt": "v",
+                    "characters_in_scene": [],
+                    "scenes": [],
+                    "props": [],
+                    "generated_assets": _pending_assets(),
+                }
+            ],
+        }
+        with project_change_source("filesystem"):
+            pm.save_script("demo", script, "episode_1.json", validate=False)
+
+        service = ProjectEventService(tmp_path, poll_interval=30.0)
+        await service.start()
+
+        release_first = asyncio.Event()
+
+        try:
+            async with service.stream_events("demo", idle_timeout=0.1) as stream:
+                event_name, _snapshot = await anext(stream)
+                assert event_name == "snapshot"
+
+                original_rebuild = service._rebuild_snapshot
+                calls = 0
+                first_read_done = asyncio.Event()
+                loop = asyncio.get_running_loop()
+
+                def _rebuild_holding_first(project_name: str):
+                    nonlocal calls
+                    calls += 1
+                    index = calls
+                    if index == 1:
+                        # 读盘前停一次：让编排先把 B 的产物落盘并发出 B 的批次，
+                        # 本次读盘因而必然捎带 B 的产物
+                        loop.call_soon_threadsafe(first_read_done.set)
+                        asyncio.run_coroutine_threadsafe(release_first.wait(), loop).result(timeout=5)
+                    return original_rebuild(project_name)
+
+                monkeypatch.setattr(service, "_rebuild_snapshot", _rebuild_holding_first)
+
+                # 批次 A：与分镜无关的终态事件，只为触发重建
+                emit_project_change_batch("demo", [_terminal_task_change("task-a")], source="worker")
+                await asyncio.wait_for(first_read_done.wait(), timeout=5.0)
+
+                # 批次 B 的产物先落盘，再发 B 自己的批次（worker 成功路径的真实次序）
+                script["segments"][0]["generated_assets"]["storyboard_image"] = "storyboards/E1S01.png"
+                script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
+                script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
+                emit_project_change_batch(
+                    "demo",
+                    [
+                        {
+                            "entity_type": "segment",
+                            "action": "storyboard_ready",
+                            "entity_id": "E1S01",
+                            "label": "分镜「E1S01」",
+                            "focus": None,
+                            "important": True,
+                            "script_file": "episode_1.json",
+                            "episode": 1,
+                        }
+                    ],
+                    source="worker",
+                )
+                release_first.set()
+
+                broadcast_changes = []
+                while True:
+                    try:
+                        event_name, payload = await _next_event(stream, timeout=1.0)
+                    except TimeoutError:
+                        break
+                    assert event_name == "changes"
+                    broadcast_changes.extend(payload["changes"])
+
+                ready = [
+                    change
+                    for change in broadcast_changes
+                    if change["action"] == "storyboard_ready" and change["entity_id"] == "E1S01"
+                ]
+                assert len(ready) == 1
+                # 广播它的是 B 自己那一批：补扫的副本不带 asset_fingerprints
+                assert "script_file" in ready[0]
+        finally:
+            release_first.set()
+            await service.shutdown()
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_hint_source_repeated_during_rebuild_read_is_not_dropped(self, tmp_path, monkeypatch):
+        """重建读盘期间重复到达的来源标记不被写回时清掉，下一轮扫描仍据它解析来源。
+
+        读盘前在册的标记整体换出而非事后减去：同一来源在窗口内再次 hint 时，集合语义下
+        「减去旧集合」会把新标记一并抹掉，那条变更会在下一轮扫描被误标成 filesystem，
+        绕过前端对 WebUI 自身编辑的通知抑制。
+        """
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        service = ProjectEventService(tmp_path, poll_interval=30.0)
+        await service.start()
+
+        release_read = asyncio.Event()
+
+        try:
+            async with service.stream_events("demo", idle_timeout=0.1) as stream:
+                event_name, _snapshot = await anext(stream)
+                assert event_name == "snapshot"
+
+                channel = service._channels["demo"]
+                # 订阅时的首轮扫描会清空标记，等它落定再预置，否则重建捕获到的是空集合
+                await asyncio.sleep(0.1)
+                assert channel.pending_sources == set()
+                # 重建发起前已在册的标记
+                channel.pending_sources.add("webui")
+
+                original_rebuild = service._rebuild_snapshot
+                read_started = asyncio.Event()
+                loop = asyncio.get_running_loop()
+
+                def _rebuild_waiting(project_name: str):
+                    loop.call_soon_threadsafe(read_started.set)
+                    asyncio.run_coroutine_threadsafe(release_read.wait(), loop).result(timeout=5)
+                    return original_rebuild(project_name)
+
+                monkeypatch.setattr(service, "_rebuild_snapshot", _rebuild_waiting)
+
+                emit_project_change_batch("demo", [_terminal_task_change("task-1")], source="worker")
+                await asyncio.wait_for(read_started.wait(), timeout=5.0)
+
+                # 读盘窗口内同一来源再次 hint
+                channel.pending_sources.add("webui")
+                release_read.set()
+
+                event_name, _payload = await _next_event(stream, timeout=5.0)
+                assert event_name == "changes"
+
+                # 窗口内的标记留存，下一轮扫描据它解析出 webui 而非 filesystem
+                assert channel.pending_sources == {"webui"}
+                assert service._resolve_batch_source(channel.pending_sources) == "webui"
+        finally:
+            release_read.set()
+            await service.shutdown()
 
     @pytest.mark.integration
     @pytest.mark.asyncio

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -506,11 +506,23 @@ class TestProjectEventService:
                     source="worker",
                 )
 
+                # 排空所有 payload 再统计：补扫走独立 payload，去重回归时重复的那条会落在
+                # 紧随其后的另一条 payload 里，只看第一条的话护栏形同虚设
+                broadcast_changes = []
                 event_name, payload = await _next_event(stream, timeout=2.0)
                 assert event_name == "changes"
+                broadcast_changes.extend(payload["changes"])
+                while True:
+                    try:
+                        event_name, payload = await _next_event(stream, timeout=0.5)
+                    except TimeoutError:
+                        break
+                    assert event_name == "changes"
+                    broadcast_changes.extend(payload["changes"])
+
                 ready = [
                     change
-                    for change in payload["changes"]
+                    for change in broadcast_changes
                     if change["action"] == "storyboard_ready" and change["entity_id"] == "E1S01"
                 ]
                 assert len(ready) == 1

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -412,32 +412,34 @@ class TestProjectEventService:
         service = ProjectEventService(tmp_path, poll_interval=30.0)
         await service.start()
 
-        async with service.stream_events("demo", idle_timeout=0.1) as stream:
-            event_name, _snapshot = await anext(stream)
-            assert event_name == "snapshot"
+        try:
+            async with service.stream_events("demo", idle_timeout=0.1) as stream:
+                event_name, _snapshot = await anext(stream)
+                assert event_name == "snapshot"
 
-            # 直接落盘、不发 hint：模拟变更早于本次重建读盘抵达磁盘
-            script["segments"][0]["generated_assets"]["storyboard_image"] = "storyboards/E1S01.png"
-            script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
-            script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
+                # 直接落盘、不发 hint：模拟变更早于本次重建读盘抵达磁盘
+                script["segments"][0]["generated_assets"]["storyboard_image"] = "storyboards/E1S01.png"
+                script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
+                script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-            emit_project_change_batch("demo", [_terminal_task_change("task-1")], source="worker")
+                emit_project_change_batch("demo", [_terminal_task_change("task-1")], source="worker")
 
-            # 本批自身的终态事件独占一条 payload（正常路径的时序与结构不受补扫影响）
-            event_name, payload = await _next_event(stream, timeout=2.0)
-            assert event_name == "changes"
-            assert [change["action"] for change in payload["changes"]] == ["task_succeeded"]
-            assert payload["source"] == "worker"
+                # 本批自身的终态事件独占一条 payload（正常路径的时序与结构不受补扫影响）
+                event_name, payload = await _next_event(stream, timeout=2.0)
+                assert event_name == "changes"
+                assert [change["action"] for change in payload["changes"]] == ["task_succeeded"]
+                assert payload["source"] == "worker"
 
-            # 捎带进来的变更随后单独广播，来源按自己的 hint 标记解析
-            event_name, swept = await _next_event(stream, timeout=2.0)
-            assert event_name == "changes"
-            assert any(
-                change["action"] == "storyboard_ready" and change["entity_id"] == "E1S01" for change in swept["changes"]
-            )
-            assert swept["source"] == "filesystem"
-
-        await service.shutdown()
+                # 捎带进来的变更随后单独广播，来源按自己的 hint 标记解析
+                event_name, swept = await _next_event(stream, timeout=2.0)
+                assert event_name == "changes"
+                assert any(
+                    change["action"] == "storyboard_ready" and change["entity_id"] == "E1S01"
+                    for change in swept["changes"]
+                )
+                assert swept["source"] == "filesystem"
+        finally:
+            await service.shutdown()
 
     @pytest.mark.asyncio
     async def test_emitted_batch_does_not_duplicate_change_it_already_describes(self, tmp_path):
@@ -469,42 +471,43 @@ class TestProjectEventService:
         service = ProjectEventService(tmp_path, poll_interval=30.0)
         await service.start()
 
-        async with service.stream_events("demo", idle_timeout=0.1) as stream:
-            event_name, _snapshot = await anext(stream)
-            assert event_name == "snapshot"
+        try:
+            async with service.stream_events("demo", idle_timeout=0.1) as stream:
+                event_name, _snapshot = await anext(stream)
+                assert event_name == "snapshot"
 
-            # worker 次序：先落盘资产，再发对应的完成事件
-            script["segments"][0]["generated_assets"]["storyboard_image"] = "storyboards/E1S01.png"
-            script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
-            script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
+                # worker 次序：先落盘资产，再发对应的完成事件
+                script["segments"][0]["generated_assets"]["storyboard_image"] = "storyboards/E1S01.png"
+                script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
+                script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-            emit_project_change_batch(
-                "demo",
-                [
-                    {
-                        "entity_type": "segment",
-                        "action": "storyboard_ready",
-                        "entity_id": "E1S01",
-                        "label": "分镜「E1S01」",
-                        "focus": None,
-                        "important": True,
-                        "script_file": "episode_1.json",
-                        "episode": 1,
-                    }
-                ],
-                source="worker",
-            )
+                emit_project_change_batch(
+                    "demo",
+                    [
+                        {
+                            "entity_type": "segment",
+                            "action": "storyboard_ready",
+                            "entity_id": "E1S01",
+                            "label": "分镜「E1S01」",
+                            "focus": None,
+                            "important": True,
+                            "script_file": "episode_1.json",
+                            "episode": 1,
+                        }
+                    ],
+                    source="worker",
+                )
 
-            event_name, payload = await _next_event(stream, timeout=2.0)
-            assert event_name == "changes"
-            ready = [
-                change
-                for change in payload["changes"]
-                if change["action"] == "storyboard_ready" and change["entity_id"] == "E1S01"
-            ]
-            assert len(ready) == 1
-
-        await service.shutdown()
+                event_name, payload = await _next_event(stream, timeout=2.0)
+                assert event_name == "changes"
+                ready = [
+                    change
+                    for change in payload["changes"]
+                    if change["action"] == "storyboard_ready" and change["entity_id"] == "E1S01"
+                ]
+                assert len(ready) == 1
+        finally:
+            await service.shutdown()
 
     def test_change_identity_normalizes_equivalent_ready_actions(self):
         """参考视频完成在发布方与快照差分两侧的 action 命名不同，但去重身份相同。
@@ -622,8 +625,8 @@ class TestProjectEventService:
                     if change["action"] == "storyboard_ready" and change["entity_id"] == "E1S01"
                 ]
                 assert len(ready) == 1
-                # 广播它的是 B 自己那一批：补扫的副本不带 asset_fingerprints
-                assert "script_file" in ready[0]
+                # 广播它的是 B 自己那一批：B 批显式传 focus=None，补扫副本的 focus 由差分构造
+                assert ready[0]["focus"] is None
         finally:
             release_first.set()
             await service.shutdown()
@@ -700,47 +703,48 @@ class TestProjectEventService:
         service = ProjectEventService(tmp_path, poll_interval=0.05)
         await service.start()
 
-        async with service.stream_events("demo", idle_timeout=0.1) as stream:
-            event_name, _snapshot = await anext(stream)
-            assert event_name == "snapshot"
+        try:
+            async with service.stream_events("demo", idle_timeout=0.1) as stream:
+                event_name, _snapshot = await anext(stream)
+                assert event_name == "snapshot"
 
-            original_rebuild = service._rebuild_snapshot
-            armed = False
+                original_rebuild = service._rebuild_snapshot
+                armed = False
 
-            def _rebuild_then_land(project_name: str):
-                nonlocal armed
-                result = original_rebuild(project_name)
-                if armed:
-                    armed = False
-                    script_path = pm.get_project_path("demo") / "scripts" / "episode_2.json"
-                    script_path.write_text(
-                        json.dumps(
-                            {"episode": 2, "title": "第二集", "content_mode": "narration", "segments": []},
-                            ensure_ascii=False,
-                        ),
-                        encoding="utf-8",
-                    )
-                return result
+                def _rebuild_then_land(project_name: str):
+                    nonlocal armed
+                    result = original_rebuild(project_name)
+                    if armed:
+                        armed = False
+                        script_path = pm.get_project_path("demo") / "scripts" / "episode_2.json"
+                        script_path.write_text(
+                            json.dumps(
+                                {"episode": 2, "title": "第二集", "content_mode": "narration", "segments": []},
+                                ensure_ascii=False,
+                            ),
+                            encoding="utf-8",
+                        )
+                    return result
 
-            monkeypatch.setattr(service, "_rebuild_snapshot", _rebuild_then_land)
-            armed = True
+                monkeypatch.setattr(service, "_rebuild_snapshot", _rebuild_then_land)
+                armed = True
 
-            emit_project_change_batch("demo", [_terminal_task_change("task-1")], source="worker")
+                emit_project_change_batch("demo", [_terminal_task_change("task-1")], source="worker")
 
-            # 窗口内落盘的变更最终仍要广播（本次重建未覆盖它，兜底扫描须补上）
-            deadline = 3.0
-            for _ in range(10):
-                event_name, payload = await _next_event(stream, timeout=deadline)
-                assert event_name == "changes"
-                if any(
-                    change["entity_type"] == "episode" and change["action"] == "created" and change["episode"] == 2
-                    for change in payload["changes"]
-                ):
-                    break
-            else:
-                raise AssertionError("窗口内落盘的 episode 2 变更从未广播")
-
-        await service.shutdown()
+                # 窗口内落盘的变更最终仍要广播（本次重建未覆盖它，兜底扫描须补上）
+                deadline = 3.0
+                for _ in range(10):
+                    event_name, payload = await _next_event(stream, timeout=deadline)
+                    assert event_name == "changes"
+                    if any(
+                        change["entity_type"] == "episode" and change["action"] == "created" and change["episode"] == 2
+                        for change in payload["changes"]
+                    ):
+                        break
+                else:
+                    raise AssertionError("窗口内落盘的 episode 2 变更从未广播")
+        finally:
+            await service.shutdown()
 
     @pytest.mark.asyncio
     async def test_subscribe_cancellation_cleans_up_subscriber(self, tmp_path, monkeypatch):

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -279,6 +279,217 @@ class TestProjectEventService:
         await service.shutdown()
 
     @pytest.mark.asyncio
+    async def test_emitted_batch_broadcasts_concurrent_change_swept_into_rebuild(self, tmp_path):
+        """显式重建读盘捎带了不属于本批的文件变更时，该变更随本次广播发出。
+
+        显式重建把新快照写回基线。若某个变更落盘于读盘之前却不在本批 changes 里，
+        它会被并入基线而从未广播——后续轮询扫描与基线已无差异，再没有任何机制
+        为它补发。这里用「与该变更无关的终态事件」触发重建来覆盖这条路径。
+
+        并发变更取「原地改写已索引的剧本文件」：这类变更不触发剧集索引同步，
+        因而不会顺带发出 hint 唤醒轮询扫描，丢失是终局的。
+        """
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        script = {
+            "episode": 1,
+            "title": "第一集",
+            "content_mode": "narration",
+            "segments": [
+                {
+                    "segment_id": "E1S01",
+                    "narration_text": "开场",
+                    "image_prompt": "p",
+                    "video_prompt": "v",
+                    "characters_in_scene": [],
+                    "scenes": [],
+                    "props": [],
+                    "generated_assets": _pending_assets(),
+                }
+            ],
+        }
+        with project_change_source("filesystem"):
+            pm.save_script("demo", script, "episode_1.json", validate=False)
+
+        # poll_interval 远超用例时长：隔离显式重建路径，排除轮询扫描抢先广播该变更
+        service = ProjectEventService(tmp_path, poll_interval=30.0)
+        await service.start()
+
+        async with service.stream_events("demo", idle_timeout=0.1) as stream:
+            event_name, _snapshot = await anext(stream)
+            assert event_name == "snapshot"
+
+            # 直接落盘、不发 hint：模拟变更早于本次重建读盘抵达磁盘
+            script["segments"][0]["generated_assets"]["storyboard_image"] = "storyboards/E1S01.png"
+            script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
+            script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
+
+            emit_project_change_batch(
+                "demo",
+                [
+                    {
+                        "entity_type": "task",
+                        "action": "task_succeeded",
+                        "entity_id": "task-1",
+                        "label": "task-1",
+                        "focus": None,
+                        "important": False,
+                        "task_type": "video",
+                    }
+                ],
+                source="worker",
+            )
+
+            event_name, payload = await _next_event(stream, timeout=2.0)
+            assert event_name == "changes"
+            # 本批自身的终态事件仍在，且列在最前（正常路径 payload 结构不受影响）
+            assert payload["changes"][0]["action"] == "task_succeeded"
+            assert any(
+                change["action"] == "storyboard_ready" and change["entity_id"] == "E1S01"
+                for change in payload["changes"]
+            )
+
+        await service.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_emitted_batch_does_not_duplicate_change_it_already_describes(self, tmp_path):
+        """资产已落盘再发本批事件（worker 成功路径的真实次序）时，补扫不重复广播同一条变更。"""
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        script = {
+            "episode": 1,
+            "title": "第一集",
+            "content_mode": "narration",
+            "segments": [
+                {
+                    "segment_id": "E1S01",
+                    "narration_text": "开场",
+                    "image_prompt": "p",
+                    "video_prompt": "v",
+                    "characters_in_scene": [],
+                    "scenes": [],
+                    "props": [],
+                    "generated_assets": _pending_assets(),
+                }
+            ],
+        }
+        with project_change_source("filesystem"):
+            pm.save_script("demo", script, "episode_1.json", validate=False)
+
+        service = ProjectEventService(tmp_path, poll_interval=30.0)
+        await service.start()
+
+        async with service.stream_events("demo", idle_timeout=0.1) as stream:
+            event_name, _snapshot = await anext(stream)
+            assert event_name == "snapshot"
+
+            # worker 次序：先落盘资产，再发对应的完成事件
+            script["segments"][0]["generated_assets"]["storyboard_image"] = "storyboards/E1S01.png"
+            script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
+            script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
+
+            emit_project_change_batch(
+                "demo",
+                [
+                    {
+                        "entity_type": "segment",
+                        "action": "storyboard_ready",
+                        "entity_id": "E1S01",
+                        "label": "分镜「E1S01」",
+                        "focus": None,
+                        "important": True,
+                        "script_file": "episode_1.json",
+                        "episode": 1,
+                    }
+                ],
+                source="worker",
+            )
+
+            event_name, payload = await _next_event(stream, timeout=2.0)
+            assert event_name == "changes"
+            ready = [
+                change
+                for change in payload["changes"]
+                if change["action"] == "storyboard_ready" and change["entity_id"] == "E1S01"
+            ]
+            assert len(ready) == 1
+
+        await service.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_change_landing_after_rebuild_read_is_still_broadcast(self, tmp_path, monkeypatch):
+        """变更落盘于「重建读盘完成之后、状态写回之前」时，仍能广播到订阅者。
+
+        注入点是 ``_rebuild_snapshot``：真实重建返回后再落盘，精确构造该时序窗口。
+        """
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        service = ProjectEventService(tmp_path, poll_interval=0.05)
+        await service.start()
+
+        async with service.stream_events("demo", idle_timeout=0.1) as stream:
+            event_name, _snapshot = await anext(stream)
+            assert event_name == "snapshot"
+
+            original_rebuild = service._rebuild_snapshot
+            armed = False
+
+            def _rebuild_then_land(project_name: str):
+                nonlocal armed
+                result = original_rebuild(project_name)
+                if armed:
+                    armed = False
+                    script_path = pm.get_project_path("demo") / "scripts" / "episode_2.json"
+                    script_path.write_text(
+                        json.dumps(
+                            {"episode": 2, "title": "第二集", "content_mode": "narration", "segments": []},
+                            ensure_ascii=False,
+                        ),
+                        encoding="utf-8",
+                    )
+                return result
+
+            monkeypatch.setattr(service, "_rebuild_snapshot", _rebuild_then_land)
+            armed = True
+
+            emit_project_change_batch(
+                "demo",
+                [
+                    {
+                        "entity_type": "task",
+                        "action": "task_succeeded",
+                        "entity_id": "task-1",
+                        "label": "task-1",
+                        "focus": None,
+                        "important": False,
+                        "task_type": "video",
+                    }
+                ],
+                source="worker",
+            )
+
+            # 窗口内落盘的变更最终仍要广播（本次重建未覆盖它，兜底扫描须补上）
+            deadline = 3.0
+            for _ in range(10):
+                event_name, payload = await _next_event(stream, timeout=deadline)
+                assert event_name == "changes"
+                if any(
+                    change["entity_type"] == "episode" and change["action"] == "created" and change["episode"] == 2
+                    for change in payload["changes"]
+                ):
+                    break
+            else:
+                raise AssertionError("窗口内落盘的 episode 2 变更从未广播")
+
+        await service.shutdown()
+
+    @pytest.mark.asyncio
     async def test_subscribe_cancellation_cleans_up_subscriber(self, tmp_path, monkeypatch):
         """客户端在首次扫描期间断开 → _subscribe 被取消 → 订阅者与 watch task 不泄漏。"""
         pm = ProjectManager(tmp_path / "projects")

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -27,6 +27,19 @@ def _pending_assets() -> dict:
     }
 
 
+def _terminal_task_change(task_id: str) -> dict:
+    """任务终态事件：触发显式重建，且不描述任何文件侧实体变更。"""
+    return {
+        "entity_type": "task",
+        "action": "task_succeeded",
+        "entity_id": task_id,
+        "label": task_id,
+        "focus": None,
+        "important": False,
+        "task_type": "video",
+    }
+
+
 async def _next_event(stream, *, timeout: float) -> tuple[str, dict]:
     """Pull the next real (event_name, payload) tuple, skipping ``_idle`` sentinels."""
 
@@ -278,6 +291,71 @@ class TestProjectEventService:
 
         await service.shutdown()
 
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_stale_rebuild_does_not_broadcast_reverse_diff(self, tmp_path):
+        """两次显式重建读盘耗时不同而乱序结算时，先读到旧盘的一方不广播反向变更。
+
+        补扫对基线做 diff，故陈旧快照被写回基线会把实际存在的实体 diff 成 ``deleted``。
+        重建锁把「读盘 → 结算基线 → 广播」串成一段读-改-写，后发起的一方等到前一方
+        结算完才读盘，读到的必然更新。
+        """
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+
+        service = ProjectEventService(tmp_path, poll_interval=30.0)
+        await service.start()
+
+        async with service.stream_events("demo", idle_timeout=0.1) as stream:
+            event_name, _snapshot = await anext(stream)
+            assert event_name == "snapshot"
+
+            original_rebuild = service._rebuild_snapshot
+            calls = 0
+            first_read_done = asyncio.Event()
+            release_first = asyncio.Event()
+            loop = asyncio.get_running_loop()
+
+            def _rebuild_holding_first(project_name: str):
+                nonlocal calls
+                calls += 1
+                index = calls
+                result = original_rebuild(project_name)
+                if index == 1:
+                    # 首次读盘已完成但尚未结算：交还控制权，等编排放行
+                    loop.call_soon_threadsafe(first_read_done.set)
+                    asyncio.run_coroutine_threadsafe(release_first.wait(), loop).result(timeout=5)
+                return result
+
+            service._rebuild_snapshot = _rebuild_holding_first
+
+            emit_project_change_batch("demo", [_terminal_task_change("task-1")], source="worker")
+            await asyncio.wait_for(first_read_done.wait(), timeout=5.0)
+
+            # 首次读盘之后落盘一个新角色：直接改写 project.json，不发 hint
+            project_json = pm.get_project_path("demo") / "project.json"
+            data = json.loads(project_json.read_text(encoding="utf-8"))
+            data.setdefault("characters", {})["新角色"] = {"name": "新角色", "description": "d"}
+            project_json.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+            # 第二次重建：留出窗口让它抢先读盘并结算（无锁时它会先于首次广播）
+            emit_project_change_batch("demo", [_terminal_task_change("task-2")], source="worker")
+            await asyncio.sleep(0.2)
+            release_first.set()
+
+            broadcast_changes = []
+            for _ in range(2):
+                event_name, payload = await _next_event(stream, timeout=5.0)
+                assert event_name == "changes"
+                broadcast_changes.extend(payload["changes"])
+
+            character_changes = [change for change in broadcast_changes if change["entity_type"] == "character"]
+            assert [change["action"] for change in character_changes] == ["created"]
+
+        await service.shutdown()
+
+    @pytest.mark.integration
     @pytest.mark.asyncio
     async def test_emitted_batch_broadcasts_concurrent_change_swept_into_rebuild(self, tmp_path):
         """显式重建读盘捎带了不属于本批的文件变更时，该变更随本次广播发出。
@@ -326,21 +404,7 @@ class TestProjectEventService:
             script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
             script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-            emit_project_change_batch(
-                "demo",
-                [
-                    {
-                        "entity_type": "task",
-                        "action": "task_succeeded",
-                        "entity_id": "task-1",
-                        "label": "task-1",
-                        "focus": None,
-                        "important": False,
-                        "task_type": "video",
-                    }
-                ],
-                source="worker",
-            )
+            emit_project_change_batch("demo", [_terminal_task_change("task-1")], source="worker")
 
             event_name, payload = await _next_event(stream, timeout=2.0)
             assert event_name == "changes"
@@ -420,6 +484,7 @@ class TestProjectEventService:
 
         await service.shutdown()
 
+    @pytest.mark.integration
     @pytest.mark.asyncio
     async def test_change_landing_after_rebuild_read_is_still_broadcast(self, tmp_path, monkeypatch):
         """变更落盘于「重建读盘完成之后、状态写回之前」时，仍能广播到订阅者。
@@ -458,21 +523,7 @@ class TestProjectEventService:
             monkeypatch.setattr(service, "_rebuild_snapshot", _rebuild_then_land)
             armed = True
 
-            emit_project_change_batch(
-                "demo",
-                [
-                    {
-                        "entity_type": "task",
-                        "action": "task_succeeded",
-                        "entity_id": "task-1",
-                        "label": "task-1",
-                        "focus": None,
-                        "important": False,
-                        "task_type": "video",
-                    }
-                ],
-                source="worker",
-            )
+            emit_project_change_batch("demo", [_terminal_task_change("task-1")], source="worker")
 
             # 窗口内落盘的变更最终仍要广播（本次重建未覆盖它，兜底扫描须补上）
             deadline = 3.0


### PR DESCRIPTION
Closes #1439

## issue 背景前提校正

issue 正文把窗口描述为「变更落盘晚于线程读盘、早于 `clear()`」，并断言「待扫描标记与加速扫描信号又已被清掉，后续没有任何机制再为它触发广播」。实测这条推断有缺口：

- `scan_now.clear()` 发生在 `_apply_emitted_batch` 里，即读盘**之前**。窗口内的 hint 调用 `scan_now.set()` 在其之后，信号存活，轮询循环会立刻醒来重扫；即便信号丢了还有 `poll_interval`（默认 0.5s）兜底。这一半最坏只是延迟一轮，不是丢失。
- 永久丢失的是同一入口的**另一半**：变更落盘**早于**读盘、且不属于本批 `changes`。此时新快照含该变更并被无条件写回基线，本次广播却只带本批那几条——此后扫描与基线再无差异，永远不补发。

本 PR 覆盖两半。

## 改动

1. **补扫（修复真正丢失的那一半）** — 显式重建写回基线前先对旧基线做一次 `_diff_snapshots`，把新快照捎带进来、而任何在途批次都未描述的变更**单独广播一条 payload**。去重身份只取 `entity_type/action/entity_id`（`script_file`/`episode` 由发布方按 `task_type` 选择性附带，纳入身份会让同一件事因一侧为 None 判成两条），并按 `_EQUIVALENT_ACTIONS` 归一发布方与快照差分对同一件事的命名差异（参考视频完成两侧分别是 `reference_video_ready` 与 `video_ready`）。
2. **`pending_sources` 在读盘前整体换出、失败时恢复** — 读盘期间新增的来源标记不再被吞，留给下一轮扫描结算。事后「减去发起时已在册的集合」不够：集合语义下同一来源在窗口内重复到达会被一并抹掉，那条变更会在下一轮扫描被降级成 filesystem。
5. **在途批次身份登记表** — `_apply_emitted_batch` 建 task 前登记本批身份、广播后退掉；补扫排除整张在册表，把别的批次已发布尚未广播的产物让给它自己那一批，避免同一件事先被补扫发一次、再被它自己的批次发一次。残留窗口（某批次产物已落盘、其 `emit` 晚于本次读盘返回）已在 `_sweep_uncovered_changes` docstring 写明。
3. **channel 级重建锁** — 把「读盘 → 结算基线 → 广播」串成一段读-改-写，轮询扫描与显式重建两条路径共用。没有这把锁时，两次重建读盘耗时不同会让先读到旧盘的一方后结算，把陈旧快照写回基线；补扫对基线做 diff，于是实际存在的实体被广播成 `deleted`。锁只包住读-改-写，`ready_event` 与轮询等待留在锁外，不持锁 sleep。
4. 两条广播路径的 payload 构造提取为 `_broadcast_changes`，形状不再各维护一份。

补扫的变更不沿用触发批次的 `source`：`source` 是 payload 级字段而非逐条，故补扫走独立 payload，来源用既有的 `_resolve_batch_source()` 按本次重建摘走的 `pending_sources` 解析，与轮询扫描同一口径。这一点是必需的——`frontend/src/hooks/useProjectEventsSSE.ts:278,287` 按 `payload.source !== "webui"` 决定是否弹通知与自动导航，错标会给用户自己的编辑误弹通知，或漏掉 worker 产物的通知与导航。无并发变更时补扫为空，不产生额外 payload。

## 验收标准第 3 条：终态事件与实体 ready 合并广播的评估

**结论：不实施，维持现状。**

成功路径的两次广播来自两个不同层：实体 ready 由 `server/services/generation_tasks.py` 的 `emit_generation_success_batch` 发出，任务终态由 `lib/generation_queue.py` 在 task repo 上下文退出时经 `emit_task_terminal_events` 发出。合并需二者之一：

1. 把实体变更缓冲到队列标记终态时一起发 —— 要让 `lib/generation_queue`（队列/DB 层）接手 server 服务层构造的实体变更 payload，属依赖倒置，改动面远超本 issue；
2. 在 `_apply_emitted_batch` 做时间窗口合并 —— 改变所有路径的广播时序，与验收标准第 2 条「正常路径的广播时序不变」直接冲突。

两条都不属于「改动代价小」。附带一点：本次修复后第二次重建的 diff 恒为空（第一次广播已推进基线），故合并的收益只剩「省一次全项目快照重建」，不含正确性收益。

## 验证

- `tests/test_project_events_service.py` 36 passed，既有 32 条断言未改。
- 新增用例与变异校验：
  - `test_emitted_batch_broadcasts_concurrent_change_swept_into_rebuild` —— 修复前红、修复后绿，覆盖真正丢失的那一半。并发变更取「原地改写已索引的剧本文件」：写新剧集文件会被 `_ensure_script_index_synced` 顺带发 hint 唤醒轮询，场景自愈、测不出缺陷。
  - `test_emitted_batch_does_not_duplicate_change_it_already_describes` —— worker 成功路径（先落盘资产、再发事件）下补扫不重复广播；把 `covered` 置空可使其转红。
  - `test_change_landing_after_rebuild_read_is_still_broadcast` —— 按 issue 字面时序注入 `_rebuild_snapshot` 构造。**该用例修复前即为绿灯**（原因见上方前提校正），作为回归护栏保留。
  - `test_stale_rebuild_does_not_broadcast_reverse_diff` —— 摘掉重建锁即转红（多出一条 `character deleted`，而该角色实际存在）。
  - `test_sweep_leaves_change_described_by_another_inflight_batch` —— 两个批次几乎同时完成时同一件事只广播一次；补扫的排除集合改回仅本批身份即转红。
  - `test_hint_source_repeated_during_rebuild_read_is_not_dropped` —— 读盘窗口内重复到达的来源标记留存；改回「事后减去旧集合」即转红。
  - `test_change_identity_normalizes_equivalent_ready_actions` —— 参考视频完成在两侧的等价 action 归一为同一去重身份，且不牵连其它 action。
- 正常路径的广播时序与 payload 结构不变：无并发时锁不阻塞；`_broadcast_changes` 构造的字段与此前逐处构造完全一致。
- `uv run ruff check` / `ruff format` 通过；`uv run basedpyright` 0 errors；全量 `pytest` 通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进项目事件 SSE 的去重/覆盖判定：对等价“就绪”动作进行归一化，避免重复或错乱广播。
  * 加固重建与轮询扫描的并发一致性：串行化重建并优化补扫归属，确保重建窗口内到达/落盘的变更能被正确纳入并广播。
  * 统一批量广播载荷结构，降低并发下的表现差异。
* **Tests**
  * 新增并扩展竞态、乱序重建与补扫相关边界用例，覆盖不重复广播、补扫归属与窗口内新增事件触达等场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
