### PR TITLE
feat(agent): 智能体入队参考视频时先就时长取档向用户确认

### DIFF
--- a/agent_runtime_profile/.claude/skills/generate-video/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/generate-video/SKILL.md
@@ -54,6 +54,21 @@ ad 剧本骨架唯一（平铺 `shots[]`，不存在 `video_units`）。项目 `
 > 集号从 script 顶层 `episode` 或文件名推导，无需手动传。
 > `reference_video` 模式下 `scene_id` / `scene_ids` 会被忽略，转整集生成。
 
+### reference_video 模式的时长确认
+
+`video_units` / ad 派生 unit 的申请时长按模型支持的档位取整（容量语义：申请能装下
+剧本总时长的最小档位，成片不裁剪；超过最大档位时按最大档位申请）。申请秒数与剧本
+编排的总时长不一致时，`generate_video_episode` / `generate_video_scene` /
+`generate_video_all` / `generate_video_selected` 四个工具在 reference_video 路径下
+**首次调用不会入队任何任务**，只返回待确认清单（每个 unit 的剧本总时长、将申请的
+秒数、成片会更长还是更短）。据此如实转述给用户，用户同意后带 `confirm_duration:
+true` 重新调用同一工具完成入队；不带该参数的重复调用仍不入队。总时长本身就是档位
+成员、或模型能力当前不可解析时，单次调用直接入队，行为与不启用取档时一致。
+
+```
+mcp__arcreel__generate_video_episode({"script": "episode_1.json", "confirm_duration": true})
+```
+
 ## 工作流程
 
 1. **加载项目和剧本** — 确认所有场景都有 `storyboard_image`

--- a/agent_runtime_profile/.claude/skills/generate-video/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/generate-video/SKILL.md
@@ -65,7 +65,7 @@ ad 剧本骨架唯一（平铺 `shots[]`，不存在 `video_units`）。项目 `
 true` 重新调用同一工具完成入队；不带该参数的重复调用仍不入队。总时长本身就是档位
 成员、或模型能力当前不可解析时，单次调用直接入队，行为与不启用取档时一致。
 
-```
+```text
 mcp__arcreel__generate_video_episode({"script": "episode_1.json", "confirm_duration": true})
 ```
 

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -52,16 +52,21 @@ class DurationConfirmationPending:
     items: list[dict[str, Any]]
 
 
-def _format_duration_confirmation(items: list[dict[str, Any]]) -> str:
-    lines = ["以下 unit 申请时长与剧本编排不一致，需先向用户确认，本次未入队任何任务："]
-    for item in items:
+def _duration_confirmation_response(pending: DurationConfirmationPending, log: list[str]) -> dict[str, Any]:
+    """把待确认清单连同本次已产生的 log 一并交给调用方转述。
+
+    log 携带的是同样影响本次生成范围的事实（如 scene_id 被忽略转整集、ad 派生出的 unit 数），
+    确认时一并呈现，用户才知道自己同意的是什么范围。
+    """
+    lines = [*log, "以下 unit 申请时长与剧本编排不一致，需先向用户确认，本次未入队任何任务："]
+    for item in pending.items:
         longer_or_shorter = "更长" if item["adjustment"] == "up" else "更短"
         lines.append(
             f"- {item['unit_id']}：剧本总时长 {item['script_duration']}s，"
             f"将申请 {item['request_duration']}s（成片{longer_or_shorter}）"
         )
     lines.append("用户同意后，带 confirm_duration=true 再次调用本工具完成入队。")
-    return "\n".join(lines)
+    return {"content": [{"type": "text", "text": "\n".join(lines)}]}
 
 
 async def _pending_duration_confirmations(
@@ -414,7 +419,7 @@ async def _generate_reference_units(
     （见 :func:`server.services.reference_video_tasks.resolve_duration_slot`），本次
     调用不产生任何任务，返回 :class:`DurationConfirmationPending` 供调用方转述给用户；
     用户同意后调用方带 ``confirm_duration=True`` 重新调用完成入队（与 Web 端
-    ``duration-precheck`` 预检共用同一取档规则，见 issue #1440/#1441）。
+    ``duration-precheck`` 预检共用同一取档规则）。
     """
     project_dir = ctx.project_path
     ckpt_path = _episode_checkpoint_path(project_dir, episode)
@@ -508,7 +513,7 @@ async def _run_reference_episode(
         confirm_duration=confirm_duration,
     )
     if isinstance(result, DurationConfirmationPending):
-        return {"content": [{"type": "text", "text": _format_duration_confirmation(result.items)}]}
+        return _duration_confirmation_response(result, log)
     header = f"第 {episode} 集参考视频生成完成，共 {len(result)} 个 unit"
     return {"content": [{"type": "text", "text": "\n".join([header, *log])}]}
 
@@ -563,7 +568,7 @@ async def _run_ad_reference_episode(
         ad_shots_for=lambda u: resolve_ad_unit_shots(script, u),
     )
     if isinstance(result, DurationConfirmationPending):
-        return {"content": [{"type": "text", "text": _format_duration_confirmation(result.items)}]}
+        return _duration_confirmation_response(result, log)
     header = f"参考直出生成完成，共 {len(result)} 个 unit"
     return {"content": [{"type": "text", "text": "\n".join([header, *log])}]}
 

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -79,7 +79,9 @@ async def _pending_duration_confirmations(
     """收集本批将入队的 unit 中，申请时长与剧本编排不一致的清单。
 
     悬空索引 / 结构异常的 unit 在此静默跳过（留给 ``build_specs`` 阶段捕获并记 log），
-    不在预检阶段重复报错。
+    不在预检阶段重复报错；没有 shots 的 unit 同样跳过——``build_specs`` 会以同一理由
+    拒绝它，若仍纳入确认清单，会让批次卡在一个注定不会入队的 unit 上，且申请时长的
+    转述本身就是失实的（该 unit 根本不会被生成）。
     """
     items: list[dict[str, Any]] = []
     for unit in units:
@@ -88,6 +90,8 @@ async def _pending_duration_confirmations(
             continue
         try:
             ad_shots = ad_shots_for(unit) if ad_shots_for else None
+            if not (ad_shots if ad_shots_for else unit.get("shots")):
+                continue
             slot = await precheck_unit_duration_slot(project, unit, ad_shots)
         except ValueError:
             continue

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import json
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -33,7 +34,68 @@ from server.agent_runtime.sdk_tools._context import (
     tool_error,
     validate_script_filename,
 )
-from server.services.reference_video_tasks import resolve_max_unit_duration
+from server.services.reference_video_tasks import precheck_unit_duration_slot, resolve_max_unit_duration
+
+_CONFIRM_DURATION_SCHEMA_PROPERTY = {
+    "type": "boolean",
+    "description": (
+        "参考生视频时长确认：unit 申请时长与剧本编排不一致时首次调用不入队，"
+        "返回待确认清单；用户同意后带 confirm_duration=true 再次调用完成入队。"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class DurationConfirmationPending:
+    """待确认的 unit 时长清单：申请秒数与剧本编排不一致，尚未入队任何任务。"""
+
+    items: list[dict[str, Any]]
+
+
+def _format_duration_confirmation(items: list[dict[str, Any]]) -> str:
+    lines = ["以下 unit 申请时长与剧本编排不一致，需先向用户确认，本次未入队任何任务："]
+    for item in items:
+        longer_or_shorter = "更长" if item["adjustment"] == "up" else "更短"
+        lines.append(
+            f"- {item['unit_id']}：剧本总时长 {item['script_duration']}s，"
+            f"将申请 {item['request_duration']}s（成片{longer_or_shorter}）"
+        )
+    lines.append("用户同意后，带 confirm_duration=true 再次调用本工具完成入队。")
+    return "\n".join(lines)
+
+
+async def _pending_duration_confirmations(
+    *,
+    project: dict[str, Any],
+    units: list[dict[str, Any]],
+    skip_ids: set[str],
+    ad_shots_for: Callable[[dict[str, Any]], list[dict[str, Any]]] | None,
+) -> list[dict[str, Any]]:
+    """收集本批将入队的 unit 中，申请时长与剧本编排不一致的清单。
+
+    悬空索引 / 结构异常的 unit 在此静默跳过（留给 ``build_specs`` 阶段捕获并记 log），
+    不在预检阶段重复报错。
+    """
+    items: list[dict[str, Any]] = []
+    for unit in units:
+        unit_id = str(unit.get("unit_id") or "")
+        if not unit_id or unit_id in skip_ids:
+            continue
+        try:
+            ad_shots = ad_shots_for(unit) if ad_shots_for else None
+            slot = await precheck_unit_duration_slot(project, unit, ad_shots)
+        except ValueError:
+            continue
+        if slot.needs_confirmation:
+            items.append(
+                {
+                    "unit_id": unit_id,
+                    "script_duration": slot.total_seconds,
+                    "request_duration": slot.seconds,
+                    "adjustment": slot.adjustment,
+                }
+            )
+    return items
 
 
 def _get_video_prompt(item: dict[str, Any]) -> str:
@@ -333,16 +395,26 @@ async def _generate_reference_units(
     resume: bool,
     log: list[str],
     build_specs: Callable[[list[dict[str, Any]], list[str], list[str]], tuple[list[TaskSpec], dict[str, int]]],
+    project: dict[str, Any],
+    confirm_duration: bool,
     reuse_existing: Callable[[dict[str, Any]], bool] | None = None,
-) -> list[Path]:
-    """unit 批量生成的共享骨架：checkpoint 续传 + 已产出扫描 + 入队等待。
+    ad_shots_for: Callable[[dict[str, Any]], list[dict[str, Any]]] | None = None,
+) -> list[Path] | DurationConfirmationPending:
+    """unit 批量生成的共享骨架：时长确认 + checkpoint 续传 + 已产出扫描 + 入队等待。
 
     narration/drama（video_units 内容自包含）与 ad（reference_units 派生索引）
-    仅 spec 构造不同，经 ``build_specs(units, skip_ids, log)`` 注入。
+    仅 spec 构造不同，经 ``build_specs(units, skip_ids, log)`` 注入；ad 的每 unit
+    剧本时长需要成员镜头（``ad_shots_for``）才能算出，narration/drama 不传。
 
     ``reuse_existing`` 决定磁盘上已存在的 ``{unit_id}.mp4`` 能否当作该 unit 的
     现行产物复用（None 表示仅凭文件存在即复用）。ad 派生索引在成员/参考集变化
     时会重置 unit 的 generated_assets，同名旧文件已不可信，须由该判定排除。
+
+    ``confirm_duration`` 为 false 时，若待入队 unit 中有申请时长与剧本编排不一致的
+    （见 :func:`server.services.reference_video_tasks.resolve_duration_slot`），本次
+    调用不产生任何任务，返回 :class:`DurationConfirmationPending` 供调用方转述给用户；
+    用户同意后调用方带 ``confirm_duration=True`` 重新调用完成入队（与 Web 端
+    ``duration-precheck`` 预检共用同一取档规则，见 issue #1440/#1441）。
     """
     project_dir = ctx.project_path
     ckpt_path = _episode_checkpoint_path(project_dir, episode)
@@ -369,6 +441,16 @@ async def _generate_reference_units(
                 completed.append(unit_id)
         elif unit_id in completed:
             completed.remove(unit_id)
+
+    if not confirm_duration:
+        pending = await _pending_duration_confirmations(
+            project=project,
+            units=units,
+            skip_ids=set(already_done),
+            ad_shots_for=ad_shots_for,
+        )
+        if pending:
+            return DurationConfirmationPending(items=pending)
 
     specs, order_map = build_specs(units, already_done, log)
     if specs:
@@ -399,6 +481,7 @@ async def _run_reference_episode(
     script: dict[str, Any],
     script_filename: str,
     resume: bool,
+    confirm_duration: bool,
     log: list[str],
 ) -> dict[str, Any]:
     """Run reference_video-mode generation and format the tool response.
@@ -411,7 +494,8 @@ async def _run_reference_episode(
     units = script.get("video_units") or []
     if not units:
         raise ValueError(f"第 {episode} 集 video_units 为空：{script_filename}")
-    paths = await _generate_reference_units(
+    project = ctx.pm.load_project(ctx.project_name)
+    result = await _generate_reference_units(
         ctx=ctx,
         units=units,
         episode=episode,
@@ -420,8 +504,12 @@ async def _run_reference_episode(
         build_specs=lambda u, skip, lg: _build_reference_specs(
             units=u, script_filename=script_filename, skip_ids=skip, log=lg
         ),
+        project=project,
+        confirm_duration=confirm_duration,
     )
-    header = f"第 {episode} 集参考视频生成完成，共 {len(paths)} 个 unit"
+    if isinstance(result, DurationConfirmationPending):
+        return {"content": [{"type": "text", "text": _format_duration_confirmation(result.items)}]}
+    header = f"第 {episode} 集参考视频生成完成，共 {len(result)} 个 unit"
     return {"content": [{"type": "text", "text": "\n".join([header, *log])}]}
 
 
@@ -430,6 +518,7 @@ async def _run_ad_reference_episode(
     ctx: ToolContext,
     script_filename: str,
     resume: bool,
+    confirm_duration: bool,
     log: list[str],
 ) -> dict[str, Any]:
     """ad + reference_video：先（重新）派生分组索引并持久化，再按 unit 批量直出。
@@ -452,7 +541,7 @@ async def _run_ad_reference_episode(
     log.append(f"已派生 {len(units)} 个 video_unit（连续镜头分组，索引已写入剧本）")
 
     style = project.get("style")
-    paths = await _generate_reference_units(
+    result = await _generate_reference_units(
         ctx=ctx,
         units=units,
         episode=episode,
@@ -466,11 +555,16 @@ async def _run_ad_reference_episode(
             skip_ids=skip,
             log=lg,
         ),
+        project=project,
+        confirm_duration=confirm_duration,
         # sync 把成员/参考集变化的 unit 重置为待生成；旧同名产物不可复用，
         # 仅 generated_assets 仍指向产物的 unit 才按磁盘文件跳过
         reuse_existing=lambda u: bool(get_generated_assets(u).get("video_clip")),
+        ad_shots_for=lambda u: resolve_ad_unit_shots(script, u),
     )
-    header = f"参考直出生成完成，共 {len(paths)} 个 unit"
+    if isinstance(result, DurationConfirmationPending):
+        return {"content": [{"type": "text", "text": _format_duration_confirmation(result.items)}]}
+    header = f"参考直出生成完成，共 {len(result)} 个 unit"
     return {"content": [{"type": "text", "text": "\n".join([header, *log])}]}
 
 
@@ -487,6 +581,7 @@ def generate_video_episode_tool(ctx: ToolContext):
                     "description": "剧本文件名（如 episode_1.json），必须是纯文件名，禁止任何路径分隔符",
                 },
                 "resume": {"type": "boolean", "description": "是否从上次中断处继续"},
+                "confirm_duration": _CONFIRM_DURATION_SCHEMA_PROPERTY,
             },
             "required": ["script"],
         },
@@ -496,16 +591,28 @@ def generate_video_episode_tool(ctx: ToolContext):
         try:
             script_filename = validate_script_filename(args["script"])
             resume = bool(args.get("resume"))
+            confirm_duration = bool(args.get("confirm_duration"))
 
             project_dir = ctx.project_path
             script = ctx.pm.load_script(ctx.project_name, script_filename)
 
             if _is_reference_script(script):
                 return await _run_reference_episode(
-                    ctx=ctx, script=script, script_filename=script_filename, resume=resume, log=log
+                    ctx=ctx,
+                    script=script,
+                    script_filename=script_filename,
+                    resume=resume,
+                    confirm_duration=confirm_duration,
+                    log=log,
                 )
             if _is_ad_reference(ctx, script):
-                return await _run_ad_reference_episode(ctx=ctx, script_filename=script_filename, resume=resume, log=log)
+                return await _run_ad_reference_episode(
+                    ctx=ctx,
+                    script_filename=script_filename,
+                    resume=resume,
+                    confirm_duration=confirm_duration,
+                    log=log,
+                )
 
             episode = ProjectManager.resolve_episode_from_script(script, script_filename)
             items, id_field, _chars, _scenes, _props = get_storyboard_items(script)
@@ -575,6 +682,7 @@ def generate_video_scene_tool(ctx: ToolContext):
                     "description": "剧本文件名（如 episode_1.json），必须是纯文件名，禁止任何路径分隔符",
                 },
                 "scene_id": {"type": "string", "description": "场景或片段 ID"},
+                "confirm_duration": _CONFIRM_DURATION_SCHEMA_PROPERTY,
             },
             "required": ["script", "scene_id"],
         },
@@ -583,6 +691,7 @@ def generate_video_scene_tool(ctx: ToolContext):
         try:
             script_filename = validate_script_filename(args["script"])
             scene_id = args["scene_id"]
+            confirm_duration = bool(args.get("confirm_duration"))
 
             project_dir = ctx.project_path
             script = ctx.pm.load_script(ctx.project_name, script_filename)
@@ -592,14 +701,23 @@ def generate_video_scene_tool(ctx: ToolContext):
                     f"⚠️  reference_video 模式暂不支持单 unit 精确选择；scene_id={scene_id} 被忽略，转整集生成。"
                 ]
                 return await _run_reference_episode(
-                    ctx=ctx, script=script, script_filename=script_filename, resume=False, log=log
+                    ctx=ctx,
+                    script=script,
+                    script_filename=script_filename,
+                    resume=False,
+                    confirm_duration=confirm_duration,
+                    log=log,
                 )
             if _is_ad_reference(ctx, script):
                 ad_log: list[str] = [
                     f"⚠️  reference_video 模式暂不支持单 unit 精确选择；scene_id={scene_id} 被忽略，转整集生成。"
                 ]
                 return await _run_ad_reference_episode(
-                    ctx=ctx, script_filename=script_filename, resume=False, log=ad_log
+                    ctx=ctx,
+                    script_filename=script_filename,
+                    resume=False,
+                    confirm_duration=confirm_duration,
+                    log=ad_log,
                 )
 
             items, id_field, _chars, _scenes, _props = get_storyboard_items(script)
@@ -667,7 +785,8 @@ def generate_video_all_tool(ctx: ToolContext):
                 "script": {
                     "type": "string",
                     "description": "剧本文件名（如 episode_1.json），必须是纯文件名，禁止任何路径分隔符",
-                }
+                },
+                "confirm_duration": _CONFIRM_DURATION_SCHEMA_PROPERTY,
             },
             "required": ["script"],
         },
@@ -676,15 +795,27 @@ def generate_video_all_tool(ctx: ToolContext):
         log: list[str] = []
         try:
             script_filename = validate_script_filename(args["script"])
+            confirm_duration = bool(args.get("confirm_duration"))
             project_dir = ctx.project_path
             script = ctx.pm.load_script(ctx.project_name, script_filename)
 
             if _is_reference_script(script):
                 return await _run_reference_episode(
-                    ctx=ctx, script=script, script_filename=script_filename, resume=False, log=log
+                    ctx=ctx,
+                    script=script,
+                    script_filename=script_filename,
+                    resume=False,
+                    confirm_duration=confirm_duration,
+                    log=log,
                 )
             if _is_ad_reference(ctx, script):
-                return await _run_ad_reference_episode(ctx=ctx, script_filename=script_filename, resume=False, log=log)
+                return await _run_ad_reference_episode(
+                    ctx=ctx,
+                    script_filename=script_filename,
+                    resume=False,
+                    confirm_duration=confirm_duration,
+                    log=log,
+                )
 
             items, id_field, _chars, _scenes, _props = get_storyboard_items(script)
             content_mode = script.get("content_mode", "narration")
@@ -739,6 +870,7 @@ def generate_video_selected_tool(ctx: ToolContext):
                     "description": "场景或片段 ID 列表",
                 },
                 "resume": {"type": "boolean", "description": "是否从上次中断处继续"},
+                "confirm_duration": _CONFIRM_DURATION_SCHEMA_PROPERTY,
             },
             "required": ["script", "scene_ids"],
         },
@@ -751,6 +883,7 @@ def generate_video_selected_tool(ctx: ToolContext):
             # checkpoint hash 再单独排序（见下方 ``canonical_scene_ids``）。
             scene_ids: list[str] = list(dict.fromkeys(args["scene_ids"]))
             resume = bool(args.get("resume"))
+            confirm_duration = bool(args.get("confirm_duration"))
 
             project_dir = ctx.project_path
             script = ctx.pm.load_script(ctx.project_name, script_filename)
@@ -760,13 +893,24 @@ def generate_video_selected_tool(ctx: ToolContext):
                     f"⚠️  reference_video 模式暂不支持多 unit 精确选择；scene_ids={','.join(scene_ids)} 被忽略，转整集生成。"
                 )
                 return await _run_reference_episode(
-                    ctx=ctx, script=script, script_filename=script_filename, resume=resume, log=log
+                    ctx=ctx,
+                    script=script,
+                    script_filename=script_filename,
+                    resume=resume,
+                    confirm_duration=confirm_duration,
+                    log=log,
                 )
             if _is_ad_reference(ctx, script):
                 log.append(
                     f"⚠️  reference_video 模式暂不支持多 unit 精确选择；scene_ids={','.join(scene_ids)} 被忽略，转整集生成。"
                 )
-                return await _run_ad_reference_episode(ctx=ctx, script_filename=script_filename, resume=resume, log=log)
+                return await _run_ad_reference_episode(
+                    ctx=ctx,
+                    script_filename=script_filename,
+                    resume=resume,
+                    confirm_duration=confirm_duration,
+                    log=log,
+                )
 
             items, id_field, _chars, _scenes, _props = get_storyboard_items(script)
             content_mode = script.get("content_mode", "narration")

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -960,6 +960,190 @@ async def test_generate_video_episode_error(fake_ctx: ToolContext) -> None:
     assert out.get("is_error") is True
 
 
+def _reference_video_script(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "content_mode": "narration",
+        "generation_mode": "reference_video",
+        "episode": 1,
+        "video_units": [
+            {
+                "unit_id": "E1U1",
+                "shots": [{"duration": 5, "text": "@张三 推门"}],
+                "references": [{"type": "character", "name": "张三"}],
+                "duration_seconds": 5,
+            }
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def test_generate_video_episode_reference_duration_needs_confirmation(fake_ctx: ToolContext, monkeypatch) -> None:
+    """申请秒数与剧本总时长不一致时，首次调用不入队，返回内容含总时长/申请秒数/差异说明。"""
+    from lib.reference_video.duration_slots import UP, DurationSlot
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+
+    async def fake_precheck(project, unit, ad_shots):
+        return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
+
+    enqueued: list[Any] = []
+
+    async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
+        enqueued.extend(specs)
+        return [], []
+
+    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+
+    tool_obj = generate_video_episode_tool(fake_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json"})
+
+    assert out.get("is_error") is not True
+    text = out["content"][0]["text"]
+    assert "E1U1" in text
+    assert "5" in text and "8" in text
+    assert "confirm_duration" in text
+    assert enqueued == []
+
+
+async def test_generate_video_episode_reference_duration_confirm_enqueues(fake_ctx: ToolContext, monkeypatch) -> None:
+    """带 confirm_duration=true 的再次调用按取档结果入队并生成成功。"""
+    from lib.generation_queue_client import BatchTaskResult
+    from lib.reference_video.duration_slots import UP, DurationSlot
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+
+    async def fake_precheck(project, unit, ad_shots):
+        return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
+
+    enqueued: list[Any] = []
+
+    async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
+        for spec in specs:
+            enqueued.append(spec)
+            if on_success:
+                on_success(
+                    BatchTaskResult(
+                        resource_id=spec.resource_id,
+                        task_id="t1",
+                        status="succeeded",
+                        result={"file_path": f"reference_videos/{spec.resource_id}.mp4"},
+                    )
+                )
+        return [], []
+
+    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+
+    tool_obj = generate_video_episode_tool(fake_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json", "confirm_duration": True})
+
+    assert out.get("is_error") is not True, out
+    assert [s.resource_id for s in enqueued] == ["E1U1"]
+
+
+async def test_generate_video_episode_reference_duration_repeat_without_confirm_still_blocked(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """不带确认参数的重复调用仍不入队。"""
+    from lib.reference_video.duration_slots import UP, DurationSlot
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+
+    async def fake_precheck(project, unit, ad_shots):
+        return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
+
+    enqueued: list[Any] = []
+
+    async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
+        enqueued.extend(specs)
+        return [], []
+
+    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+
+    tool_obj = generate_video_episode_tool(fake_ctx)
+    await _call(tool_obj, {"script": "episode_1.json"})
+    out = await _call(tool_obj, {"script": "episode_1.json"})
+
+    assert out.get("is_error") is not True
+    assert enqueued == []
+
+
+async def test_generate_video_episode_reference_duration_exact_enqueues_directly(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """总时长为档位成员时单次调用直接入队，行为与现状一致。"""
+    from lib.reference_video.duration_slots import EXACT, DurationSlot
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+
+    async def fake_precheck(project, unit, ad_shots):
+        return DurationSlot(seconds=5, total_seconds=5, adjustment=EXACT)
+
+    enqueued: list[Any] = []
+
+    async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
+        from lib.generation_queue_client import BatchTaskResult
+
+        for spec in specs:
+            enqueued.append(spec)
+            if on_success:
+                on_success(
+                    BatchTaskResult(
+                        resource_id=spec.resource_id,
+                        task_id="t1",
+                        status="succeeded",
+                        result={"file_path": f"reference_videos/{spec.resource_id}.mp4"},
+                    )
+                )
+        return [], []
+
+    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+
+    tool_obj = generate_video_episode_tool(fake_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json"})
+
+    assert out.get("is_error") is not True, out
+    assert [s.resource_id for s in enqueued] == ["E1U1"]
+
+
+async def test_generate_video_episode_ad_reference_duration_needs_confirmation(
+    ad_reference_ctx: ToolContext, monkeypatch
+) -> None:
+    """ad 参考直出走同一条确认闸门，且预检拿到的是水合后的成员镜头（ad_shots 非空）。"""
+    from lib.reference_video.duration_slots import UP, DurationSlot
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    seen_ad_shots: list[Any] = []
+
+    async def fake_precheck(project, unit, ad_shots):
+        seen_ad_shots.append(ad_shots)
+        return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
+
+    enqueued: list[Any] = []
+
+    async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
+        enqueued.extend(specs)
+        return [], []
+
+    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+
+    tool_obj = generate_video_episode_tool(ad_reference_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json"})
+
+    assert out.get("is_error") is not True, out
+    assert enqueued == []
+    assert seen_ad_shots and seen_ad_shots[0]
+
+
 async def test_generate_video_scene_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
 

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -978,6 +978,7 @@ def _reference_video_script(**overrides: Any) -> dict[str, Any]:
     return payload
 
 
+@pytest.mark.integration
 async def test_generate_video_episode_reference_duration_needs_confirmation(fake_ctx: ToolContext, monkeypatch) -> None:
     """申请秒数与剧本总时长不一致时，首次调用不入队，返回内容含总时长/申请秒数/差异说明。"""
     from lib.reference_video.duration_slots import UP, DurationSlot
@@ -1008,6 +1009,7 @@ async def test_generate_video_episode_reference_duration_needs_confirmation(fake
     assert enqueued == []
 
 
+@pytest.mark.integration
 async def test_generate_video_episode_reference_duration_confirm_enqueues(fake_ctx: ToolContext, monkeypatch) -> None:
     """带 confirm_duration=true 的再次调用按取档结果入队并生成成功。"""
     from lib.generation_queue_client import BatchTaskResult
@@ -1045,6 +1047,7 @@ async def test_generate_video_episode_reference_duration_confirm_enqueues(fake_c
     assert [s.resource_id for s in enqueued] == ["E1U1"]
 
 
+@pytest.mark.integration
 async def test_generate_video_episode_reference_duration_repeat_without_confirm_still_blocked(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -1074,6 +1077,7 @@ async def test_generate_video_episode_reference_duration_repeat_without_confirm_
     assert enqueued == []
 
 
+@pytest.mark.integration
 async def test_generate_video_episode_reference_duration_exact_enqueues_directly(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -1114,6 +1118,7 @@ async def test_generate_video_episode_reference_duration_exact_enqueues_directly
     assert [s.resource_id for s in enqueued] == ["E1U1"]
 
 
+@pytest.mark.integration
 async def test_generate_video_episode_ad_reference_duration_needs_confirmation(
     ad_reference_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -1142,6 +1147,68 @@ async def test_generate_video_episode_ad_reference_duration_needs_confirmation(
     assert out.get("is_error") is not True, out
     assert enqueued == []
     assert seen_ad_shots and seen_ad_shots[0]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("make_tool", "extra_args"),
+    [
+        (generate_video_scene_tool, {"scene_id": "E1S01"}),
+        (generate_video_all_tool, {}),
+        (generate_video_selected_tool, {"scene_ids": ["E1S01"]}),
+    ],
+    ids=["scene", "all", "selected"],
+)
+async def test_generate_video_reference_duration_confirmation_across_entries(
+    fake_ctx: ToolContext, monkeypatch, make_tool, extra_args: dict[str, Any]
+) -> None:
+    """四个入口在 reference 路径下共用同一条确认闸门：未确认不入队、确认后入队。
+
+    确认文本必须保留本次已产生的 log——scene / selected 的「scene_id 被忽略，转整集生成」
+    正是靠它告诉用户，他同意的是整集而非所选的那个 scene。
+    """
+    from lib.generation_queue_client import BatchTaskResult
+    from lib.reference_video.duration_slots import UP, DurationSlot
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+
+    async def fake_precheck(project, unit, ad_shots):
+        return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
+
+    enqueued: list[Any] = []
+
+    async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
+        for spec in specs:
+            enqueued.append(spec)
+            if on_success:
+                on_success(
+                    BatchTaskResult(
+                        resource_id=spec.resource_id,
+                        task_id="t1",
+                        status="succeeded",
+                        result={"file_path": f"reference_videos/{spec.resource_id}.mp4"},
+                    )
+                )
+        return [], []
+
+    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+
+    tool_obj = make_tool(fake_ctx)
+    pending = await _call(tool_obj, {"script": "episode_1.json", **extra_args})
+
+    assert pending.get("is_error") is not True, pending
+    assert enqueued == []
+    text = pending["content"][0]["text"]
+    assert "confirm_duration" in text
+    if make_tool is not generate_video_all_tool:
+        assert "转整集生成" in text
+
+    confirmed = await _call(tool_obj, {"script": "episode_1.json", **extra_args, "confirm_duration": True})
+
+    assert confirmed.get("is_error") is not True, confirmed
+    assert [s.resource_id for s in enqueued] == ["E1U1"]
 
 
 async def test_generate_video_scene_happy(fake_ctx: ToolContext, monkeypatch) -> None:

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1119,6 +1119,59 @@ async def test_generate_video_episode_reference_duration_exact_enqueues_directly
 
 
 @pytest.mark.integration
+async def test_generate_video_episode_reference_duration_skips_unit_without_shots(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """没有 shots 的 unit 不进入确认清单，不阻塞其余合法 unit 直接入队。
+
+    build_specs 本就会跳过没有 shots 的 unit（见 test_build_reference_specs_*）；
+    预检若不做同一过滤，会把这个注定不会入队的 unit 纳入确认清单，阻塞整批，
+    且申请时长的转述本身失实。
+    """
+    from lib.reference_video.duration_slots import EXACT, DurationSlot
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    script = _reference_video_script()
+    script["video_units"].append({"unit_id": "E1U2", "duration_seconds": 5})
+    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+
+    precheck_calls: list[str] = []
+
+    async def fake_precheck(project, unit, ad_shots):
+        precheck_calls.append(unit["unit_id"])
+        return DurationSlot(seconds=5, total_seconds=5, adjustment=EXACT)
+
+    enqueued: list[Any] = []
+
+    async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
+        from lib.generation_queue_client import BatchTaskResult
+
+        for spec in specs:
+            enqueued.append(spec)
+            if on_success:
+                on_success(
+                    BatchTaskResult(
+                        resource_id=spec.resource_id,
+                        task_id="t1",
+                        status="succeeded",
+                        result={"file_path": f"reference_videos/{spec.resource_id}.mp4"},
+                    )
+                )
+        return [], []
+
+    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+
+    tool_obj = generate_video_episode_tool(fake_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json"})
+
+    assert out.get("is_error") is not True, out
+    assert precheck_calls == ["E1U1"]
+    assert [s.resource_id for s in enqueued] == ["E1U1"]
+    assert "E1U2" in out["content"][0]["text"]
+
+
+@pytest.mark.integration
 async def test_generate_video_episode_ad_reference_duration_needs_confirmation(
     ad_reference_ctx: ToolContext, monkeypatch
 ) -> None:


### PR DESCRIPTION
Closes #1441

## 变更

reference_video / ad 参考直出路径下，四个 `generate_video_*` sdk_tool 复用 #1440 的取档纯函数 `precheck_unit_duration_slot`：unit 申请时长与剧本编排不一致时首次调用不入队，返回待确认清单（剧本总时长、将申请秒数、成片更长还是更短）供智能体转述；用户同意后带 `confirm_duration=true` 再次调用完成入队。总时长本身为档位成员、或模型能力不可解析时，单次调用直接入队，行为与现状一致。

确认粒度落在批量调用整体：批内任一 unit 需确认则整批不入队，确认后一次性提交，避免部分入队、部分待确认的中间态。四个工具都接线而非只接参考视频专用工具——它们在参考路径下都会转发到同一条批量骨架，只接一个会让另外三个绕过闸门。

同步更新 `generate-video` SKILL.md 的确认流程说明。

## 本地审查修复

- 确认分支原先只返回清单、丢弃已积累的 log，`generate_video_scene` / `generate_video_selected` 的「scene_id 被忽略，转整集生成」警告与 ad 路径的派生 unit 数随之丢失——用户被问是否同意某个申请秒数时并不知道确认后生成的是整集。改为 log 与清单一并返回，两处重复分支收敛到同一 helper
- 补四个入口共用确认闸门的参数化用例（未确认不入队 + 确认文本保留范围警告 + 确认后入队）
- 本轮新增测试补 pytest marker；清理代码注释中的 issue 编号

## 验证

- `uv run python -m pytest -q -m "not e2e"` — 6760 passed
- `uv run ruff check` / `ruff format` — 通过
- `uv run basedpyright` — 0 errors
- 与 origin/main 的 merge-base 即当前 main HEAD，无需 rebase

## 已知边界

- 预检按项目当前配置近似取档，实际档位以执行时解析的 model 能力为准；确认与执行之间若配置被改，成片时长可能与确认时展示的不同（与 #1440 同源，执行层 warning 兜底）
- ad 路径未确认的首次调用仍会派生 unit 索引并写回剧本（不产生任务，符合验收标准，但首次调用非只读）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 视频生成工具新增 `confirm_duration` 参数。
  * 在 reference_video 模式下，若申请时长与剧本编排不一致，会返回待确认清单并阻止首次入队；再次在同一工具调用中传入 `confirm_duration: true` 后才会入队并继续生成。
  * 集数、场景、全量与选定入口均支持该确认流程。
* **文档**
  * 补充 reference_video 模式时长档位取整与“首次需确认/二次确认入队”的说明与示例。
* **测试**
  * 新增门控与多入口一致性用例，并覆盖无 shots unit 不触发确认预检。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->