### PR TITLE
chore(config): 时长约束声明矛盾时输出告警，收窄入口形参名对齐 registry id

### DIFF
--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -243,7 +243,7 @@ def constrain_durations(
         allowed = [d for d in allowed if d in by_resolution]
     if not allowed:
         logger.warning(
-            "duration constraints for %s/%s are mutually contradictory "
+            "duration constraints for %s/%s have no overlap with candidate durations "
             "(resolution=%r, uses_reference_images=%r), falling back to unconstrained candidates %r",
             provider_id,
             model_id,

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -241,7 +241,18 @@ def constrain_durations(
     by_resolution = model_info.duration_resolution_constraints.get(resolution.strip().lower()) if resolution else None
     if by_resolution:
         allowed = [d for d in allowed if d in by_resolution]
-    return allowed or list(durations)
+    if not allowed:
+        logger.warning(
+            "duration constraints for %s/%s are mutually contradictory "
+            "(resolution=%r, uses_reference_images=%r), falling back to unconstrained candidates %r",
+            provider_id,
+            model_id,
+            resolution,
+            uses_reference_images,
+            durations,
+        )
+        return list(durations)
+    return allowed
 
 
 def _resolution_for_constraints(

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -169,7 +169,7 @@ def unit_script_duration(unit: dict, ad_shots: list[dict] | None) -> int:
 
 
 def effective_reference_durations(
-    provider: str,
+    provider_id: str,
     model: str | None,
     durations: list[int],
     resolution: str | None,
@@ -186,12 +186,12 @@ def effective_reference_durations(
     缺图会退化为纯文本，backend 同样只在 ``reference_images`` 非空时施加该约束——无图单元
     套用它会把 720p 下本可申请的 4 秒错误抬到 8 秒。
 
-    ``provider`` 必须是规范 registry provider id（backend 族名不是 registry key）。两条约束
+    ``provider_id`` 必须是规范 registry provider id（backend 族名不是 registry key）。两条约束
     都遵循「无声明或交集为空时不收窄」的降级口径（见 :func:`lib.config.resolver.constrain_durations`），
     故本函数在能力声明缺位时退化为原全集，不比收窄前更严。
     """
     return constrain_durations(
-        provider, model, durations, resolution=resolution, uses_reference_images=with_reference_images
+        provider_id, model, durations, resolution=resolution, uses_reference_images=with_reference_images
     )
 
 


### PR DESCRIPTION
## 范围

仅后端两个文件的日志与命名清理：`lib/config/resolver.py`、`server/services/reference_video_tasks.py`。不改任何行为语义、不动 API、不动前端。

## 变更

- `constrain_durations` 时长约束交集为空、回退原候选全集时补 `logger.warning`（带 provider/model 与约束上下文）——此前该数据问题静默，要等执行期 backend 拒绝才暴露
- `effective_reference_durations` 形参 `provider` 改名 `provider_id`，与 docstring「必须是规范 registry provider id」的约束对齐；调用点全部按位置传参，零波及

## 验收清单

- [x] 本地已跑相关测试：`uv run python -m pytest tests/test_config_resolver_resolution.py tests/server/test_reference_video_tasks.py`（61 passed）
- [x] 手动验证了改动所声称的行为（日志分支有单测覆盖回退路径；`uv run ruff check` / `uv run basedpyright` 干净，后者 0 error，`reference_video_tasks.py:301` warning 为既有代码）
- [x] 新增面向用户文案已加 zh/en 翻译（如适用）——不适用，logger 消息仅面向 agent，按 i18n 规范豁免
- [x] 无新增 ESLint disable；若有，已在本 PR 底部以表格列出 `rule | file:line | 理由`——未触及前端
- [x] CODEOWNERS 要求的 review 已请求

## 已知 defer

- 无。相关的架构级收敛（能力查询统一入口）已另行立项 #1453，非本 PR defer 项。

## 出处

batch-20260728 收尾架构重估中判定的顺手清理项（不立项级别）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 当按分辨率与参考图条件收窄时若筛选结果为空，系统会记录包含模型与分辨率等关键信息的告警，并回退为保留原始候选时长，避免候选列表为空。
* **改进**
  * 优化参考视频任务的时长能力匹配：使用规范的注册表标识进行能力收窄与降级，确保在缺少能力声明时仍按既有集合退化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->