### PR TITLE
refactor(frontend): 资源占用判定的 kind 参数收紧为联合类型

### DIFF
--- a/frontend/src/actions/generation.test.ts
+++ b/frontend/src/actions/generation.test.ts
@@ -13,6 +13,7 @@ import {
   selectActiveResourceIds,
   selectHasActiveTaskForScriptFile,
   useTasksStore,
+  type ResourceKind,
 } from "@/stores/tasks-store";
 import {
   enqueueCharacter,
@@ -32,7 +33,7 @@ import {
 const SINGLE_OK = { success: true, task_id: "t1", deduped: false, message: "ok" };
 
 /** 该资源是否被占用（真实任务行或乐观标记）。 */
-function occupied(projectName: string, resourceKind: string, resourceId: string): boolean {
+function occupied(projectName: string, resourceKind: ResourceKind, resourceId: string): boolean {
   const { tasks, optimisticActive } = useTasksStore.getState();
   return selectActiveResourceIds(tasks, resourceKind, projectName, optimisticActive).has(resourceId);
 }
@@ -136,42 +137,42 @@ describe("单资源入队动作的乐观标记 kind / taskType", () => {
       label: "video",
       run: () => enqueueVideo("demo", "seg-1", "p", "episode_1.json", 4),
       method: "generateVideo" as const,
-      kind: "video",
+      kind: "video" as const,
       resourceId: "seg-1",
     },
     {
       label: "tts",
       run: () => enqueueNarration("demo", "seg-1", "episode_1.json"),
       method: "generateNarrationAudio" as const,
-      kind: "tts",
+      kind: "tts" as const,
       resourceId: "seg-1",
     },
     {
       label: "character",
       run: () => enqueueCharacter("demo", "Hero", "p"),
       method: "generateCharacter" as const,
-      kind: "character",
+      kind: "character" as const,
       resourceId: "Hero",
     },
     {
       label: "scene",
       run: () => enqueueScene("demo", "Temple", "p"),
       method: "generateProjectScene" as const,
-      kind: "scene",
+      kind: "scene" as const,
       resourceId: "Temple",
     },
     {
       label: "prop",
       run: () => enqueueProp("demo", "Sword", "p"),
       method: "generateProjectProp" as const,
-      kind: "prop",
+      kind: "prop" as const,
       resourceId: "Sword",
     },
     {
       label: "product",
       run: () => enqueueProduct("demo", "Phone", "p"),
       method: "generateProjectProduct" as const,
-      kind: "product",
+      kind: "product" as const,
       resourceId: "Phone",
     },
   ])("$label：成功后按资源类型打标并归一化 task_id", async ({ run, method, kind, resourceId }) => {

--- a/frontend/src/actions/generation.ts
+++ b/frontend/src/actions/generation.ts
@@ -17,7 +17,12 @@
 import { API } from "@/api";
 import i18n from "@/i18n";
 import { useAppStore } from "@/stores/app-store";
-import { useTasksStore, type OptimisticHandle } from "@/stores/tasks-store";
+import {
+  useTasksStore,
+  type ImageEditResourceKind,
+  type OptimisticHandle,
+  type ResourceKind,
+} from "@/stores/tasks-store";
 
 export interface EnqueueResult {
   taskIds: string[];
@@ -44,7 +49,7 @@ function notifyEnqueued(
 /** 资源粒度乐观标记的简写（请求发出前调用）。 */
 function markResource(
   projectName: string,
-  resourceKind: string,
+  resourceKind: ResourceKind,
   resourceId: string,
   pendingTaskType: string,
 ): OptimisticHandle {
@@ -210,7 +215,7 @@ export async function enqueueProduct(
 export async function enqueueImageEdit(
   projectName: string,
   params: {
-    resourceType: "character" | "scene" | "prop" | "product" | "storyboard";
+    resourceType: ImageEditResourceKind;
     resourceId: string;
     instruction: string;
     scriptFile?: string | null;

--- a/frontend/src/components/canvas/lorebook/assetBusyGuard.ts
+++ b/frontend/src/components/canvas/lorebook/assetBusyGuard.ts
@@ -1,6 +1,6 @@
 import type { TFunction } from "i18next";
 import { useAppStore } from "@/stores/app-store";
-import { isResourceBusy } from "@/stores/tasks-store";
+import { isResourceBusy, type ResourceKind } from "@/stores/tasks-store";
 
 /**
  * 立绘上传的提交时刻复核：从点击上传按钮到文件选完之间，该资源可能已被别处（另一标签页、
@@ -10,7 +10,7 @@ import { isResourceBusy } from "@/stores/tasks-store";
  * `generating` 的口径同源，不另立判据。
  */
 export function rejectIfAssetBusy(
-  kind: string,
+  kind: ResourceKind,
   projectName: string,
   name: string,
   t: TFunction,

--- a/frontend/src/components/canvas/timeline/ImageEditButton.tsx
+++ b/frontend/src/components/canvas/timeline/ImageEditButton.tsx
@@ -4,15 +4,18 @@ import { Wand2 } from "lucide-react";
 import { enqueueImageEdit } from "@/actions/generation";
 import { GlassModal } from "@/components/ui/GlassModal";
 import { useAppStore } from "@/stores/app-store";
-import { isResourceBusy, selectHasActiveTaskForScriptFile, useTasksStore } from "@/stores/tasks-store";
+import {
+  isResourceBusy,
+  selectHasActiveTaskForScriptFile,
+  useTasksStore,
+  type ResourceKind,
+} from "@/stores/tasks-store";
 import { errMsg } from "@/utils/async";
 
-export type ImageEditResourceType =
-  | "character"
-  | "scene"
-  | "prop"
-  | "product"
-  | "storyboard";
+export type ImageEditResourceType = Extract<
+  ResourceKind,
+  "character" | "scene" | "prop" | "product" | "storyboard"
+>;
 
 interface ImageEditButtonProps {
   projectName: string;

--- a/frontend/src/components/canvas/timeline/ImageEditButton.tsx
+++ b/frontend/src/components/canvas/timeline/ImageEditButton.tsx
@@ -8,14 +8,11 @@ import {
   isResourceBusy,
   selectHasActiveTaskForScriptFile,
   useTasksStore,
-  type ResourceKind,
+  type ImageEditResourceKind,
 } from "@/stores/tasks-store";
 import { errMsg } from "@/utils/async";
 
-export type ImageEditResourceType = Extract<
-  ResourceKind,
-  "character" | "scene" | "prop" | "product" | "storyboard"
->;
+export type ImageEditResourceType = ImageEditResourceKind;
 
 interface ImageEditButtonProps {
   projectName: string;

--- a/frontend/src/hooks/useTaskRefresh.test.tsx
+++ b/frontend/src/hooks/useTaskRefresh.test.tsx
@@ -250,7 +250,7 @@ describe("useTaskRefresh", () => {
       expect(listSpy).toHaveBeenCalledTimes(1);
 
       await act(async () => {
-        useTasksStore.getState().beginOptimisticActive("demo", "segment", "segment-1", "storyboard");
+        useTasksStore.getState().beginOptimisticActive("demo", "storyboard", "segment-1", "storyboard");
       });
       // 不等 30 秒空闲间隔，当场取一次状态。
       expect(listSpy).toHaveBeenCalledTimes(2);

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -430,13 +430,27 @@ export function isTerminalStatus(status: TaskStatus): boolean {
   return status === "succeeded" || status === "failed" || status === "cancelled";
 }
 
+/** 占用判定关心的全量资源种类（不含 image_edit——它按 resource_type 归入其中之一）。 */
+export type ResourceKind =
+  | "character"
+  | "scene"
+  | "prop"
+  | "product"
+  | "storyboard"
+  | "video"
+  | "tts"
+  | "reference_video"
+  | "grid";
+
 /**
  * 任务占用的「资源种类」。除 image_edit 外，task_type 本身即资源种类；image_edit 跨
  * character/scene/prop/product/storyboard 共用一个 task_type，真正的种类在 resource_type，
  * 故按 resource_type 归槽——编辑任务与同资源的生成任务落入同一占用集、彼此互斥。
  */
-export function taskResourceKind(task: TaskItem): string {
-  return task.task_type === "image_edit" ? (task.resource_type ?? "") : task.task_type;
+export function taskResourceKind(task: TaskItem): ResourceKind | "" {
+  return task.task_type === "image_edit"
+    ? ((task.resource_type as ResourceKind | null) ?? "")
+    : (task.task_type as ResourceKind);
 }
 
 /**
@@ -482,7 +496,7 @@ export function selectLatestTaskByResource(
  */
 export function selectActiveResourceIds(
   tasks: TaskItem[],
-  taskType: string,
+  taskType: ResourceKind,
   projectName: string,
   optimisticActive: ReadonlySet<string> = EMPTY_OPTIMISTIC,
 ): Set<string> {
@@ -514,7 +528,7 @@ const EMPTY_OPTIMISTIC: ReadonlySet<string> = new Set();
  * 提交时刻复核占用态的统一入口：封装 `getState()` 新鲜读 + {@link selectActiveResourceIds} +
  * key 拼装，供各写入控件在提交那一刻直接判定，不必各自重复这三步。
  */
-export function isResourceBusy(kind: string, projectName: string, resourceId: string): boolean {
+export function isResourceBusy(kind: ResourceKind, projectName: string, resourceId: string): boolean {
   const { tasks, optimisticActive } = useTasksStore.getState();
   return selectActiveResourceIds(tasks, kind, projectName, optimisticActive).has(resourceId);
 }
@@ -614,7 +628,7 @@ const EMPTY_ACTIVE_IDS: Set<string> = new Set();
 
 /** hook 版 {@link selectActiveResourceIds}；projectName 缺失时返回稳定空集。 */
 export function useActiveResourceIds(
-  taskType: string,
+  taskType: ResourceKind,
   projectName: string | undefined | null,
 ): Set<string> {
   return useTasksStore(

--- a/frontend/src/stores/tasks-store.ts
+++ b/frontend/src/stores/tasks-store.ts
@@ -8,6 +8,30 @@ import type { TaskItem, TaskStats, TaskStatus } from "@/types";
 const TASKS_PAGE_SIZE = 200;
 
 /**
+ * 占用判定关心的全量资源种类（不含 image_edit——它按 resource_type 归入其中之一）。
+ *
+ * 占用集的读写两侧共用这一个真相源：写侧 {@link TasksState.beginOptimisticActive} 打标、
+ * 读侧 {@link selectActiveResourceIds} 过滤，两侧的 kind 拼写必须一致才能匹配上同一个槽。
+ * 收紧为联合类型即为把「拼错就静默不占用」的失败模式提前到编译期。
+ */
+export type ResourceKind =
+  | "character"
+  | "scene"
+  | "prop"
+  | "product"
+  | "storyboard"
+  | "video"
+  | "tts"
+  | "reference_video"
+  | "grid";
+
+/** 可做指令式编辑的资源种类；`image_edit` 任务按此归入对应资源槽。 */
+export type ImageEditResourceKind = Extract<
+  ResourceKind,
+  "character" | "scene" | "prop" | "product" | "storyboard"
+>;
+
+/**
  * 刷新作用域：`projectName === null` 表示「不按项目过滤」（拉全局任务），整个 scope 为
  * `null` 表示「未启用」——此时 {@link TasksState.refreshTasks} 不发请求。作用域由
  * `useTaskRefresh` 单点登记，其余入口（项目事件 SSE 推来的任务终态）只调 refreshTasks、
@@ -57,7 +81,7 @@ interface TasksState {
   refreshTasks: () => Promise<void>;
   beginOptimisticActive: (
     projectName: string,
-    resourceKind: string,
+    resourceKind: ResourceKind,
     resourceId: string,
     pendingTaskType: string,
   ) => OptimisticHandle;
@@ -110,7 +134,7 @@ function markTaskIds(key: string): string[] {
 
 function optimisticKey(
   projectName: string,
-  resourceKind: string,
+  resourceKind: ResourceKind,
   resourceId: string,
   pendingTaskType: string,
   seq: number,
@@ -430,22 +454,14 @@ export function isTerminalStatus(status: TaskStatus): boolean {
   return status === "succeeded" || status === "failed" || status === "cancelled";
 }
 
-/** 占用判定关心的全量资源种类（不含 image_edit——它按 resource_type 归入其中之一）。 */
-export type ResourceKind =
-  | "character"
-  | "scene"
-  | "prop"
-  | "product"
-  | "storyboard"
-  | "video"
-  | "tts"
-  | "reference_video"
-  | "grid";
-
 /**
  * 任务占用的「资源种类」。除 image_edit 外，task_type 本身即资源种类；image_edit 跨
  * character/scene/prop/product/storyboard 共用一个 task_type，真正的种类在 resource_type，
  * 故按 resource_type 归槽——编辑任务与同资源的生成任务落入同一占用集、彼此互斥。
+ *
+ * 两处断言是数据边界：{@link TaskItem} 的字段来自后端、TS 管不到其值域。后端若出现未在
+ * {@link ResourceKind} 登记的种类，该行匹配不上任何占用槽（退化为不参与占用判定），
+ * 与收紧前的行为一致；真正被联合类型堵住的是前端调用方自己拼错 kind。
  */
 export function taskResourceKind(task: TaskItem): ResourceKind | "" {
   return task.task_type === "image_edit"


### PR DESCRIPTION
Closes #1457

## 改动

`tasks-store` 新增并导出全量 `ResourceKind` 联合类型作为单一真相源，占用判定链条上的 `kind` 参数依次收紧：

- 读路径：`taskResourceKind` 返回值、`selectActiveResourceIds` / `isResourceBusy` / `useActiveResourceIds` / `rejectIfAssetBusy` 参数
- 写路径：`beginOptimisticActive` / `optimisticKey` / `markResource` 的 `resourceKind` 参数（本地审查补齐——读路径单独收紧会让类型系统给出「已防护」的假象，而打标 kind 拼错同样落到匹配不上的槽，占用防护一样静默失效）
- `ImageEditResourceKind = Extract<ResourceKind, ...>` 从 `ResourceKind` 派生并导出；`ImageEditButton` 的 `ImageEditResourceType` 与 `enqueueImageEdit` 的 `resourceType` 都改为引用它，消掉两处等价字面量联合

`taskResourceKind` 里对 `TaskItem.task_type` / `resource_type` 的两处断言是数据边界（字段来自后端、TS 管不到值域），已在 docstring 写明：后端出现未登记种类时该行匹配不上任何占用槽，与收紧前行为一致。

纯类型层改动，零运行时 diff。

## 验证

- `pnpm lint` 通过
- `pnpm check` 通过：typecheck + eslint + vitest 132 文件 / 1459 测试全绿
- 验收标准专项：临时探针文件传入 `isResourceBusy("charater", ...)` 与 `beginOptimisticActive("p", "segment", ...)`，`tsc --noEmit` 均报 TS2345 拒绝，读写两路都被编译期拦下（探针已删除）
- 审查中修正：`useTaskRefresh.test.tsx` 原先给 `beginOptimisticActive` 传的 `"segment"` 并非合法资源种类，收紧后暴露并改正为 `"storyboard"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 统一资源类型约束，提升任务状态、图像编辑和资源占用判断的一致性与可靠性。
  * 优化资源忙碌状态及乐观占用处理，减少无效或不匹配的资源类型传递。

* **测试**
  * 更新相关测试用例以匹配新的资源类型定义和任务类型约定，确保任务轮询、入队及占用状态逻辑正常运行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->