### PR TITLE
refactor(reference-video): 参考视频入队前的时长预检不再逐个单元重复查询项目配置

### DIFF
--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -34,7 +34,11 @@ from server.agent_runtime.sdk_tools._context import (
     tool_error,
     validate_script_filename,
 )
-from server.services.reference_video_tasks import precheck_unit_duration_slot, resolve_max_unit_duration
+from server.services.reference_video_tasks import (
+    precheck_unit,
+    resolve_max_unit_duration,
+    resolve_project_duration_context,
+)
 
 _CONFIRM_DURATION_SCHEMA_PROPERTY = {
     "type": "boolean",
@@ -78,11 +82,16 @@ async def _pending_duration_confirmations(
 ) -> list[dict[str, Any]]:
     """收集本批将入队的 unit 中，申请时长与剧本编排不一致的清单。
 
+    项目视频能力（档位 + 分辨率）只解析一次（:func:`resolve_project_duration_context`），
+    批内逐 unit 取档改用纯函数 :func:`precheck_unit`——避免整批 N 个 unit 各自触发一轮
+    DB 往返。
+
     悬空索引 / 结构异常的 unit 在此静默跳过（留给 ``build_specs`` 阶段捕获并记 log），
     不在预检阶段重复报错；没有 shots 的 unit 同样跳过——``build_specs`` 会以同一理由
     拒绝它，若仍纳入确认清单，会让批次卡在一个注定不会入队的 unit 上，且申请时长的
     转述本身就是失实的（该 unit 根本不会被生成）。
     """
+    ctx = await resolve_project_duration_context(project)
     items: list[dict[str, Any]] = []
     for unit in units:
         unit_id = str(unit.get("unit_id") or "")
@@ -92,7 +101,7 @@ async def _pending_duration_confirmations(
             ad_shots = ad_shots_for(unit) if ad_shots_for else None
             if not (ad_shots if ad_shots_for else unit.get("shots")):
                 continue
-            slot = await precheck_unit_duration_slot(project, unit, ad_shots)
+            slot = precheck_unit(ctx, unit, ad_shots)
         except ValueError:
             continue
         if slot.needs_confirmation:

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -35,6 +35,7 @@ from server.agent_runtime.sdk_tools._context import (
     validate_script_filename,
 )
 from server.services.reference_video_tasks import (
+    ProjectDurationContext,
     precheck_unit,
     resolve_max_unit_duration,
     resolve_project_duration_context,
@@ -82,16 +83,16 @@ async def _pending_duration_confirmations(
 ) -> list[dict[str, Any]]:
     """收集本批将入队的 unit 中，申请时长与剧本编排不一致的清单。
 
-    项目视频能力（档位 + 分辨率）只解析一次（:func:`resolve_project_duration_context`），
+    项目视频能力（档位 + 分辨率）至多解析一次（:func:`resolve_project_duration_context`），
     批内逐 unit 取档改用纯函数 :func:`precheck_unit`——避免整批 N 个 unit 各自触发一轮
-    DB 往返。
+    DB 往返。解析推迟到第一个真正需要取档的 unit：整批都已完成或都被跳过时不触发任何 IO。
 
     悬空索引 / 结构异常的 unit 在此静默跳过（留给 ``build_specs`` 阶段捕获并记 log），
     不在预检阶段重复报错；没有 shots 的 unit 同样跳过——``build_specs`` 会以同一理由
     拒绝它，若仍纳入确认清单，会让批次卡在一个注定不会入队的 unit 上，且申请时长的
     转述本身就是失实的（该 unit 根本不会被生成）。
     """
-    ctx = await resolve_project_duration_context(project)
+    ctx: ProjectDurationContext | None = None
     items: list[dict[str, Any]] = []
     for unit in units:
         unit_id = str(unit.get("unit_id") or "")
@@ -99,8 +100,14 @@ async def _pending_duration_confirmations(
             continue
         try:
             ad_shots = ad_shots_for(unit) if ad_shots_for else None
-            if not (ad_shots if ad_shots_for else unit.get("shots")):
-                continue
+            has_shots = bool(ad_shots if ad_shots_for else unit.get("shots"))
+        except ValueError:
+            continue
+        if not has_shots:
+            continue
+        if ctx is None:
+            ctx = await resolve_project_duration_context(project)
+        try:
             slot = precheck_unit(ctx, unit, ad_shots)
         except ValueError:
             continue

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -79,6 +79,7 @@ async def _pending_duration_confirmations(
     project: dict[str, Any],
     units: list[dict[str, Any]],
     skip_ids: set[str],
+    spec_for: Callable[[dict[str, Any]], TaskSpec],
     ad_shots_for: Callable[[dict[str, Any]], list[dict[str, Any]]] | None,
 ) -> list[dict[str, Any]]:
     """收集本批将入队的 unit 中，申请时长与剧本编排不一致的清单。
@@ -87,10 +88,10 @@ async def _pending_duration_confirmations(
     批内逐 unit 取档改用纯函数 :func:`precheck_unit`——避免整批 N 个 unit 各自触发一轮
     DB 往返。解析推迟到第一个真正需要取档的 unit：整批都已完成或都被跳过时不触发任何 IO。
 
-    悬空索引 / 结构异常的 unit 在此静默跳过（留给 ``build_specs`` 阶段捕获并记 log），
-    不在预检阶段重复报错；没有 shots 的 unit 同样跳过——``build_specs`` 会以同一理由
-    拒绝它，若仍纳入确认清单，会让批次卡在一个注定不会入队的 unit 上，且申请时长的
-    转述本身就是失实的（该 unit 根本不会被生成）。
+    悬空索引 / 结构异常 / 空提示词的 unit 在此复用与 ``build_specs`` 同一份 spec 构造
+    （``spec_for``）判定可入队性并静默跳过，不在预检阶段重复报错——不合法的 unit
+    ``build_specs`` 阶段本就会拒绝，若仍纳入确认清单或触发 ctx 解析，会让批次卡在一个
+    注定不会入队的 unit 上，且申请时长的转述本身就是失实的（该 unit 根本不会被生成）。
     """
     ctx: ProjectDurationContext | None = None
     items: list[dict[str, Any]] = []
@@ -99,11 +100,12 @@ async def _pending_duration_confirmations(
         if not unit_id or unit_id in skip_ids:
             continue
         try:
-            ad_shots = ad_shots_for(unit) if ad_shots_for else None
-            has_shots = bool(ad_shots if ad_shots_for else unit.get("shots"))
+            spec_for(unit)
         except ValueError:
             continue
-        if not has_shots:
+        try:
+            ad_shots = ad_shots_for(unit) if ad_shots_for else None
+        except ValueError:
             continue
         if ctx is None:
             ctx = await resolve_project_duration_context(project)
@@ -256,6 +258,25 @@ def _build_video_specs(
     return specs, order_map
 
 
+def _reference_unit_spec(unit: dict[str, Any], script_filename: str) -> TaskSpec:
+    """单 unit 的 narration/drama TaskSpec 构造，供批量入队与时长预检共用同一份结构校验
+    （见 ADR-0001）——``TaskSpec.from_request`` 是「是否可入队」的唯一真相源，两处判断
+    不能各自维护一份、由此产生分歧（如预检放行了 build_specs 会拒绝的空提示词 unit）。
+    """
+    # 用 .get 归一化：缺失 unit_id 的坏数据（Agent 可裸写 script JSON）会被 from_request
+    # 当作空 resource_id 拒绝，而不是在此抛 KeyError 中断整批。
+    unit_id = str(unit.get("unit_id") or "")
+    if not unit.get("shots"):
+        raise ValueError("没有 shots")
+    return TaskSpec.from_request(
+        task_type="reference_video",
+        media_type="video",
+        resource_id=unit_id,
+        prompt=assemble_shots_text(unit["shots"]),
+        script_file=script_filename,
+    )
+
+
 def _build_reference_specs(
     *,
     units: list[dict[str, Any]],
@@ -267,26 +288,14 @@ def _build_reference_specs(
     specs: list[TaskSpec] = []
     order_map: dict[str, int] = {}
     for idx, unit in enumerate(units):
-        # 用 .get 归一化：缺失 unit_id 的坏数据（Agent 可裸写 script JSON）会被 from_request
-        # 当作空 resource_id 拒绝并走下面的跳过分支，而不是在此抛 KeyError 中断整批。
         unit_id = str(unit.get("unit_id") or "")
         if unit_id in skip_set:
             continue
-        if not unit.get("shots"):
-            log.append(f"⚠️  {unit_id} 没有 shots，跳过")
-            continue
-        # prompt 由 shots[*].text 拼接，经统一守卫点做空提示词结构校验（见 ADR-0001）；
-        # 任一 unit 不合法（空提示词、或 from_request 对空 resource_id 抛的裸 ValueError）
-        # 都跳过并告警，与「没有 shots」一致，不让一个坏 unit 中断整批。
-        # 注意 TaskSpecValidationError 是 ValueError 子类，捕 ValueError 同时覆盖两者。
+        # 任一 unit 不合法（没有 shots、空提示词、或 from_request 对空 resource_id 抛的
+        # 裸 ValueError）都跳过并告警，不让一个坏 unit 中断整批。TaskSpecValidationError
+        # 是 ValueError 子类，捕 ValueError 同时覆盖两者。
         try:
-            spec = TaskSpec.from_request(
-                task_type="reference_video",
-                media_type="video",
-                resource_id=unit_id,
-                prompt=assemble_shots_text(unit["shots"]),
-                script_file=script_filename,
-            )
+            spec = _reference_unit_spec(unit, script_filename)
         except ValueError as exc:
             log.append(f"⚠️  {unit_id} 入队校验未通过，跳过：{exc}")
             continue
@@ -376,6 +385,22 @@ async def _submit_with_checkpoint(
     return failures
 
 
+def _ad_reference_unit_spec(
+    script: dict[str, Any], unit: dict[str, Any], script_filename: str, style: str | None
+) -> TaskSpec:
+    """单 unit 的 ad TaskSpec 构造，供批量入队与时长预检共用同一份结构校验（同
+    ``_reference_unit_spec``）。成员镜头从 shots（内容唯一真相）水合后渲染 prompt。"""
+    unit_id = str(unit.get("unit_id") or "")
+    shots = resolve_ad_unit_shots(script, unit)
+    return TaskSpec.from_request(
+        task_type="reference_video",
+        media_type="video",
+        resource_id=unit_id,
+        prompt=render_ad_unit_prompt(shots, style=style),
+        script_file=script_filename,
+    )
+
+
 def _build_ad_reference_specs(
     *,
     script: dict[str, Any],
@@ -385,9 +410,8 @@ def _build_ad_reference_specs(
     skip_ids: list[str] | None,
     log: list[str],
 ) -> tuple[list[TaskSpec], dict[str, int]]:
-    """ad 派生索引 → TaskSpec。成员镜头从 shots（内容唯一真相）水合后渲染 prompt；
-    索引悬空 / 空画面提示词的 unit 跳过并告警，不让一个坏 unit 中断整批
-    （与 ``_build_reference_specs`` 同口径）。"""
+    """ad 派生索引 → TaskSpec。索引悬空 / 空画面提示词的 unit 跳过并告警，不让一个坏
+    unit 中断整批（与 ``_build_reference_specs`` 同口径）。"""
     skip_set = set(skip_ids or [])
     specs: list[TaskSpec] = []
     order_map: dict[str, int] = {}
@@ -396,14 +420,7 @@ def _build_ad_reference_specs(
         if unit_id in skip_set:
             continue
         try:
-            shots = resolve_ad_unit_shots(script, unit)
-            spec = TaskSpec.from_request(
-                task_type="reference_video",
-                media_type="video",
-                resource_id=unit_id,
-                prompt=render_ad_unit_prompt(shots, style=style),
-                script_file=script_filename,
-            )
+            spec = _ad_reference_unit_spec(script, unit, script_filename, style)
         except ValueError as exc:
             log.append(f"⚠️  {unit_id} 入队校验未通过，跳过：{exc}")
             continue
@@ -420,6 +437,7 @@ async def _generate_reference_units(
     resume: bool,
     log: list[str],
     build_specs: Callable[[list[dict[str, Any]], list[str], list[str]], tuple[list[TaskSpec], dict[str, int]]],
+    spec_for: Callable[[dict[str, Any]], TaskSpec],
     project: dict[str, Any],
     confirm_duration: bool,
     reuse_existing: Callable[[dict[str, Any]], bool] | None = None,
@@ -428,8 +446,10 @@ async def _generate_reference_units(
     """unit 批量生成的共享骨架：时长确认 + checkpoint 续传 + 已产出扫描 + 入队等待。
 
     narration/drama（video_units 内容自包含）与 ad（reference_units 派生索引）
-    仅 spec 构造不同，经 ``build_specs(units, skip_ids, log)`` 注入；ad 的每 unit
-    剧本时长需要成员镜头（``ad_shots_for``）才能算出，narration/drama 不传。
+    仅 spec 构造不同，经 ``build_specs(units, skip_ids, log)`` 注入；``spec_for``
+    是同一份单 unit 构造逻辑，供时长预检判定可入队性，与 ``build_specs`` 不能有
+    第二份校验口径。ad 的每 unit 剧本时长需要成员镜头（``ad_shots_for``）才能
+    算出，narration/drama 不传。
 
     ``reuse_existing`` 决定磁盘上已存在的 ``{unit_id}.mp4`` 能否当作该 unit 的
     现行产物复用（None 表示仅凭文件存在即复用）。ad 派生索引在成员/参考集变化
@@ -472,6 +492,7 @@ async def _generate_reference_units(
             project=project,
             units=units,
             skip_ids=set(already_done),
+            spec_for=spec_for,
             ad_shots_for=ad_shots_for,
         )
         if pending:
@@ -529,6 +550,7 @@ async def _run_reference_episode(
         build_specs=lambda u, skip, lg: _build_reference_specs(
             units=u, script_filename=script_filename, skip_ids=skip, log=lg
         ),
+        spec_for=lambda u: _reference_unit_spec(u, script_filename),
         project=project,
         confirm_duration=confirm_duration,
     )
@@ -579,6 +601,9 @@ async def _run_ad_reference_episode(
             style=style if isinstance(style, str) else None,
             skip_ids=skip,
             log=lg,
+        ),
+        spec_for=lambda u: _ad_reference_unit_spec(
+            script, u, script_filename, style if isinstance(style, str) else None
         ),
         project=project,
         confirm_duration=confirm_duration,

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -38,8 +38,9 @@ from server.routers._reorder import full_permutation_error
 from server.services.generation_tasks import emit_generation_success_batch
 from server.services.reference_video_tasks import (
     _finalize_reference_video_unit,
-    precheck_unit_duration_slot,
+    precheck_unit,
     resolve_max_unit_duration,
+    resolve_project_duration_context,
 )
 from server.services.upload_finalize import (
     UploadValidationError,
@@ -428,7 +429,7 @@ async def precheck_unit_duration(
         unit = _find_unit(script, unit_id, _t)
         ad_shots = None
 
-    slot = await precheck_unit_duration_slot(project, unit, ad_shots)
+    slot = precheck_unit(await resolve_project_duration_context(project), unit, ad_shots)
     return {
         "needs_confirmation": slot.needs_confirmation,
         "script_duration": slot.total_seconds,

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -204,7 +204,7 @@ class ProjectDurationContext:
     unit 反复调用而不重新触发 DB IO——批量预检 N 个 unit 时项目能力/分辨率解析各只发生一次。
     """
 
-    supported_durations: list[int]
+    supported_durations: tuple[int, ...]
     resolution: str | None
     provider_id: str
     model_name: str | None
@@ -217,7 +217,7 @@ async def resolve_project_duration_context(project: dict) -> ProjectDurationCont
     空档位下分辨率约束无意义。
     """
     caps = await _project_video_caps(project, degraded_to="时长取档不施加档位约束")
-    durations = [int(d) for d in caps.get("supported_durations") or []]
+    durations = tuple(int(d) for d in caps.get("supported_durations") or [])
     provider_id = str(caps.get("provider_id") or "")
     model = caps.get("model")
     model_name = str(model) if model else None
@@ -235,7 +235,7 @@ def precheck_unit(ctx: ProjectDurationContext, unit: dict, ad_shots: list[dict] 
     :func:`resolve_project_duration_context` 后对每个 unit 反复调用，不重复 DB 往返。
 
     provider 按 ADR-0001 在执行时才解析，故 ``ctx`` 只是近似：实际档位以执行时的 model
-    能力为准（见 :func:`precheck_unit_duration_slot` 的等价单 unit 用法）。
+    能力为准。
 
     「是否带参考图」按 unit 声明的 references 近似——执行层按解析后的实际图判定，而 ad 路径
     的资产缺图退化为纯文本要读盘才知道。近似方向保守：声明了参考却缺图的异常单元会多收窄
@@ -245,7 +245,7 @@ def precheck_unit(ctx: ProjectDurationContext, unit: dict, ad_shots: list[dict] 
         effective_reference_durations(
             ctx.provider_id,
             ctx.model_name,
-            ctx.supported_durations,
+            list(ctx.supported_durations),
             ctx.resolution,
             with_reference_images=bool(unit.get("references")),
         )
@@ -253,16 +253,6 @@ def precheck_unit(ctx: ProjectDurationContext, unit: dict, ad_shots: list[dict] 
         else []
     )
     return resolve_duration_slot(unit_script_duration(unit, ad_shots), durations)
-
-
-async def precheck_unit_duration_slot(project: dict, unit: dict, ad_shots: list[dict] | None) -> DurationSlot:
-    """单 unit 入队前取档：解析项目能力 + 取档合并成一次调用，供只需查一个 unit 的调用方使用。
-
-    批量场景改用 :func:`resolve_project_duration_context` 一次性解析 + :func:`precheck_unit`
-    逐 unit 纯计算，避免每 unit 重复 IO。
-    """
-    ctx = await resolve_project_duration_context(project)
-    return precheck_unit(ctx, unit, ad_shots)
 
 
 async def _project_video_caps(project: dict, *, degraded_to: str) -> dict:

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -195,20 +196,73 @@ def effective_reference_durations(
     )
 
 
-async def precheck_unit_duration_slot(project: dict, unit: dict, ad_shots: list[dict] | None) -> DurationSlot:
-    """入队前按项目当前配置近似取档，供 Web 在生成入口确认「将按与剧本不一致的时长生成」。
+@dataclass(frozen=True)
+class ProjectDurationContext:
+    """项目视频能力的一次性 IO 解析结果：档位全集（未按单个 unit 条件收窄）+ 分辨率 + provider/model 身份。
 
-    provider 按 ADR-0001 在执行时才解析，故这里只是近似：能力解析失败按空档位处理
-    （沿用现状放行，不弹确认），实际档位以执行时的 model 能力为准。
+    由 :func:`resolve_project_duration_context` 产出，供 :func:`precheck_unit` 对批次内每个
+    unit 反复调用而不重新触发 DB IO——批量预检 N 个 unit 时项目能力/分辨率解析各只发生一次。
+    """
+
+    supported_durations: list[int]
+    resolution: str | None
+    provider_id: str
+    model_name: str | None
+
+
+async def resolve_project_duration_context(project: dict) -> ProjectDurationContext:
+    """一次性解析项目视频能力（档位全集 + 分辨率 + provider/model 身份）。
+
+    解析失败按空档位处理（沿用现状放行，不弹确认）；分辨率仅在档位非空时才解析，
+    空档位下分辨率约束无意义。
+    """
+    caps = await _project_video_caps(project, degraded_to="时长取档不施加档位约束")
+    durations = [int(d) for d in caps.get("supported_durations") or []]
+    provider_id = str(caps.get("provider_id") or "")
+    model = caps.get("model")
+    model_name = str(model) if model else None
+    resolution = await _project_video_resolution(project, provider_id, model_name) if durations else None
+    return ProjectDurationContext(
+        supported_durations=durations,
+        resolution=resolution,
+        provider_id=provider_id,
+        model_name=model_name,
+    )
+
+
+def precheck_unit(ctx: ProjectDurationContext, unit: dict, ad_shots: list[dict] | None) -> DurationSlot:
+    """按已解析的项目能力 context 为单个 unit 取档。纯函数，无 IO——批量调用方一次
+    :func:`resolve_project_duration_context` 后对每个 unit 反复调用，不重复 DB 往返。
+
+    provider 按 ADR-0001 在执行时才解析，故 ``ctx`` 只是近似：实际档位以执行时的 model
+    能力为准（见 :func:`precheck_unit_duration_slot` 的等价单 unit 用法）。
 
     「是否带参考图」按 unit 声明的 references 近似——执行层按解析后的实际图判定，而 ad 路径
     的资产缺图退化为纯文本要读盘才知道。近似方向保守：声明了参考却缺图的异常单元会多收窄
     一档、至多多问一次确认，不会漏掉需要确认的情形。
     """
-    return resolve_duration_slot(
-        unit_script_duration(unit, ad_shots),
-        await resolve_project_supported_durations(project, with_reference_images=bool(unit.get("references"))),
+    durations = (
+        effective_reference_durations(
+            ctx.provider_id,
+            ctx.model_name,
+            ctx.supported_durations,
+            ctx.resolution,
+            with_reference_images=bool(unit.get("references")),
+        )
+        if ctx.supported_durations
+        else []
     )
+    return resolve_duration_slot(unit_script_duration(unit, ad_shots), durations)
+
+
+async def precheck_unit_duration_slot(project: dict, unit: dict, ad_shots: list[dict] | None) -> DurationSlot:
+    """单 unit 入队前取档：解析项目能力 + 取档合并成一次调用，供只需查一个 unit 的调用方使用。
+
+    批量场景改用 :func:`resolve_project_duration_context` 一次性解析 + :func:`precheck_unit`
+    逐 unit 纯计算，避免每 unit 重复 IO。
+    """
+    ctx = await resolve_project_duration_context(project)
+    return precheck_unit(ctx, unit, ad_shots)
 
 
 async def _project_video_caps(project: dict, *, degraded_to: str) -> dict:
@@ -222,29 +276,6 @@ async def _project_video_caps(project: dict, *, degraded_to: str) -> dict:
     except (ValueError, SQLAlchemyError) as exc:
         logger.info("无法解析 video_capabilities，%s：%s", degraded_to, exc)
         return {}
-
-
-async def resolve_project_supported_durations(project: dict, *, with_reference_images: bool) -> list[int]:
-    """解析项目视频后端在参考视频路径下可申请的时长档位集。
-
-    档位已按本次调用的条件收窄（见 :func:`effective_reference_durations`），与执行层取档
-    同口径——否则预检展示的申请秒数会是执行期拿不到的值。解析失败返回空列表（与执行层
-    空集放行同口径）。
-    """
-    caps = await _project_video_caps(project, degraded_to="时长取档不施加档位约束")
-    durations = [int(d) for d in caps.get("supported_durations") or []]
-    if not durations:
-        return []
-    provider_id = str(caps.get("provider_id") or "")
-    model = caps.get("model")
-    model_name = str(model) if model else None
-    return effective_reference_durations(
-        provider_id,
-        model_name,
-        durations,
-        await _project_video_resolution(project, provider_id, model_name),
-        with_reference_images=with_reference_images,
-    )
 
 
 async def _project_video_resolution(project: dict, provider_id: str, model_id: str | None) -> str | None:

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -986,7 +986,7 @@ async def test_generate_video_episode_reference_duration_needs_confirmation(fake
 
     fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
 
-    async def fake_precheck(project, unit, ad_shots):
+    def fake_precheck(ctx, unit, ad_shots):
         return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
 
     enqueued: list[Any] = []
@@ -995,7 +995,11 @@ async def test_generate_video_episode_reference_duration_needs_confirmation(fake
         enqueued.extend(specs)
         return [], []
 
-    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    async def fake_duration_context(_project):
+        return None
+
+    monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
+    monkeypatch.setattr(mod, "precheck_unit", fake_precheck)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = generate_video_episode_tool(fake_ctx)
@@ -1018,7 +1022,7 @@ async def test_generate_video_episode_reference_duration_confirm_enqueues(fake_c
 
     fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
 
-    async def fake_precheck(project, unit, ad_shots):
+    def fake_precheck(ctx, unit, ad_shots):
         return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
 
     enqueued: list[Any] = []
@@ -1037,7 +1041,11 @@ async def test_generate_video_episode_reference_duration_confirm_enqueues(fake_c
                 )
         return [], []
 
-    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    async def fake_duration_context(_project):
+        return None
+
+    monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
+    monkeypatch.setattr(mod, "precheck_unit", fake_precheck)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = generate_video_episode_tool(fake_ctx)
@@ -1057,7 +1065,7 @@ async def test_generate_video_episode_reference_duration_repeat_without_confirm_
 
     fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
 
-    async def fake_precheck(project, unit, ad_shots):
+    def fake_precheck(ctx, unit, ad_shots):
         return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
 
     enqueued: list[Any] = []
@@ -1066,7 +1074,11 @@ async def test_generate_video_episode_reference_duration_repeat_without_confirm_
         enqueued.extend(specs)
         return [], []
 
-    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    async def fake_duration_context(_project):
+        return None
+
+    monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
+    monkeypatch.setattr(mod, "precheck_unit", fake_precheck)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = generate_video_episode_tool(fake_ctx)
@@ -1087,7 +1099,7 @@ async def test_generate_video_episode_reference_duration_exact_enqueues_directly
 
     fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
 
-    async def fake_precheck(project, unit, ad_shots):
+    def fake_precheck(ctx, unit, ad_shots):
         return DurationSlot(seconds=5, total_seconds=5, adjustment=EXACT)
 
     enqueued: list[Any] = []
@@ -1108,7 +1120,11 @@ async def test_generate_video_episode_reference_duration_exact_enqueues_directly
                 )
         return [], []
 
-    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    async def fake_duration_context(_project):
+        return None
+
+    monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
+    monkeypatch.setattr(mod, "precheck_unit", fake_precheck)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = generate_video_episode_tool(fake_ctx)
@@ -1137,7 +1153,7 @@ async def test_generate_video_episode_reference_duration_skips_unit_without_shot
 
     precheck_calls: list[str] = []
 
-    async def fake_precheck(project, unit, ad_shots):
+    def fake_precheck(ctx, unit, ad_shots):
         precheck_calls.append(unit["unit_id"])
         return DurationSlot(seconds=5, total_seconds=5, adjustment=EXACT)
 
@@ -1159,7 +1175,11 @@ async def test_generate_video_episode_reference_duration_skips_unit_without_shot
                 )
         return [], []
 
-    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    async def fake_duration_context(_project):
+        return None
+
+    monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
+    monkeypatch.setattr(mod, "precheck_unit", fake_precheck)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = generate_video_episode_tool(fake_ctx)
@@ -1172,6 +1192,57 @@ async def test_generate_video_episode_reference_duration_skips_unit_without_shot
 
 
 @pytest.mark.integration
+async def test_generate_video_episode_reference_duration_resolves_project_context_once(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """批量预检 N 个 unit 时项目视频能力/分辨率只解析一次，逐 unit 取档改走纯函数 precheck_unit。
+
+    重构前 ``_pending_duration_confirmations`` 对每个待确认 unit 各自触发一轮 DB 往返
+    （``resolve_project_supported_durations``）；重构后项目级 IO 收口到批次开始时的
+    一次 ``resolve_project_duration_context`` 调用，逐 unit 只做纯计算。
+    """
+    from lib.reference_video.duration_slots import UP, DurationSlot
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    script = _reference_video_script()
+    script["video_units"].append(
+        {
+            "unit_id": "E1U2",
+            "shots": [{"duration": 5, "text": "@张三 转身"}],
+            "references": [{"type": "character", "name": "张三"}],
+            "duration_seconds": 5,
+        }
+    )
+    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+
+    context_calls: list[dict[str, Any]] = []
+
+    async def fake_duration_context(project):
+        context_calls.append(project)
+        return None
+
+    def fake_precheck(ctx, unit, ad_shots):
+        return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
+
+    enqueued: list[Any] = []
+
+    async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
+        enqueued.extend(specs)
+        return [], []
+
+    monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
+    monkeypatch.setattr(mod, "precheck_unit", fake_precheck)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+
+    tool_obj = generate_video_episode_tool(fake_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json"})
+
+    assert out.get("is_error") is not True, out
+    assert len(context_calls) == 1
+    assert enqueued == []
+
+
+@pytest.mark.integration
 async def test_generate_video_episode_ad_reference_duration_needs_confirmation(
     ad_reference_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -1181,7 +1252,7 @@ async def test_generate_video_episode_ad_reference_duration_needs_confirmation(
 
     seen_ad_shots: list[Any] = []
 
-    async def fake_precheck(project, unit, ad_shots):
+    def fake_precheck(ctx, unit, ad_shots):
         seen_ad_shots.append(ad_shots)
         return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
 
@@ -1191,7 +1262,11 @@ async def test_generate_video_episode_ad_reference_duration_needs_confirmation(
         enqueued.extend(specs)
         return [], []
 
-    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    async def fake_duration_context(_project):
+        return None
+
+    monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
+    monkeypatch.setattr(mod, "precheck_unit", fake_precheck)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = generate_video_episode_tool(ad_reference_ctx)
@@ -1226,7 +1301,7 @@ async def test_generate_video_reference_duration_confirmation_across_entries(
 
     fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
 
-    async def fake_precheck(project, unit, ad_shots):
+    def fake_precheck(ctx, unit, ad_shots):
         return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
 
     enqueued: list[Any] = []
@@ -1245,7 +1320,11 @@ async def test_generate_video_reference_duration_confirmation_across_entries(
                 )
         return [], []
 
-    monkeypatch.setattr(mod, "precheck_unit_duration_slot", fake_precheck)
+    async def fake_duration_context(_project):
+        return None
+
+    monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
+    monkeypatch.setattr(mod, "precheck_unit", fake_precheck)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = make_tool(fake_ctx)

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1271,6 +1271,38 @@ async def test_generate_video_episode_reference_skips_duration_context_when_noth
 
 
 @pytest.mark.integration
+async def test_generate_video_episode_reference_skips_duration_context_when_prompt_blank(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """shots 非空但拼接后提示词全空白时，build_specs 会拒绝该 unit——预检须复用同一份
+    结构校验提前判定，不能先触发项目能力解析再让 build_specs 事后跳过（见 Codex review）。"""
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    script = _reference_video_script()
+    for unit in script["video_units"]:
+        unit["shots"] = [{"duration": 3, "text": "   "}]
+    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+
+    context_calls: list[dict[str, Any]] = []
+
+    async def fake_duration_context(project):
+        context_calls.append(project)
+        raise AssertionError("整批提示词均空白时不应解析项目视频能力")
+
+    async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
+        return [], []
+
+    monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+
+    tool_obj = generate_video_episode_tool(fake_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json"})
+
+    assert context_calls == []
+    assert "E1U1" in out["content"][0]["text"]
+
+
+@pytest.mark.integration
 async def test_generate_video_episode_ad_reference_duration_needs_confirmation(
     ad_reference_ctx: ToolContext, monkeypatch
 ) -> None:

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1201,8 +1201,8 @@ async def test_generate_video_episode_reference_duration_resolves_project_contex
     （``resolve_project_supported_durations``）；重构后项目级 IO 收口到批次开始时的
     一次 ``resolve_project_duration_context`` 调用，逐 unit 只做纯计算。
     """
-    from lib.reference_video.duration_slots import UP, DurationSlot
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
+    from server.services.reference_video_tasks import ProjectDurationContext
 
     script = _reference_video_script()
     script["video_units"].append(
@@ -1219,10 +1219,7 @@ async def test_generate_video_episode_reference_duration_resolves_project_contex
 
     async def fake_duration_context(project):
         context_calls.append(project)
-        return None
-
-    def fake_precheck(ctx, unit, ad_shots):
-        return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
+        return ProjectDurationContext(supported_durations=(4, 8, 12), resolution=None, provider_id="", model_name=None)
 
     enqueued: list[Any] = []
 
@@ -1231,15 +1228,46 @@ async def test_generate_video_episode_reference_duration_resolves_project_contex
         return [], []
 
     monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
-    monkeypatch.setattr(mod, "precheck_unit", fake_precheck)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = generate_video_episode_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json"})
 
+    # 两个 unit 均 5 秒、档位无 5 → 都需确认，本批不入队；解析只发生一次。
     assert out.get("is_error") is not True, out
     assert len(context_calls) == 1
     assert enqueued == []
+
+
+@pytest.mark.integration
+async def test_generate_video_episode_reference_skips_duration_context_when_nothing_to_precheck(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """整批都没有可预检的 unit 时不解析项目能力——解析推迟到第一个真正要取档的 unit，
+    重构不能让「全部已完成/全部被跳过」的批次凭空多付一轮 DB 往返。"""
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    script = _reference_video_script()
+    for unit in script["video_units"]:
+        unit["shots"] = []
+    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+
+    context_calls: list[dict[str, Any]] = []
+
+    async def fake_duration_context(project):
+        context_calls.append(project)
+        raise AssertionError("无可预检 unit 时不应解析项目视频能力")
+
+    async def fake_batch(*, project_name, specs, on_success=None, on_failure=None):
+        return [], []
+
+    monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+
+    tool_obj = generate_video_episode_tool(fake_ctx)
+    await _call(tool_obj, {"script": "episode_1.json"})
+
+    assert context_calls == []
 
 
 @pytest.mark.integration

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -11,10 +11,12 @@ import pytest
 
 from lib.reference_video.errors import MissingReferenceError
 from server.services.reference_video_tasks import (
+    ProjectDurationContext,
     _apply_provider_constraints,
     _render_unit_prompt,
     _resolve_unit_references,
     effective_reference_durations,
+    precheck_unit,
 )
 
 
@@ -273,6 +275,106 @@ async def test_project_video_resolution_falls_back_like_executor(monkeypatch: py
 
     monkeypatch.setattr(rvt, "ConfigResolver", _FakeResolver)
     assert await rvt._project_video_resolution({}, "gemini-aistudio", "veo-3.1-generate-preview") == "1080p"
+
+
+@pytest.mark.unit
+async def test_resolve_project_duration_context_resolves_caps_and_resolution_once(monkeypatch: pytest.MonkeyPatch):
+    """项目能力与分辨率各只解析一次：批量预检把这次结果复用给每个 unit（见 precheck_unit）。"""
+    from server.services import reference_video_tasks as rvt
+
+    caps_calls = 0
+    resolution_calls = 0
+
+    async def fake_caps(_project, *, degraded_to):
+        nonlocal caps_calls
+        caps_calls += 1
+        return {"provider_id": "gemini-aistudio", "model": "veo-3.1-generate-preview", "supported_durations": [4, 6, 8]}
+
+    async def fake_resolution(_project, _provider_id, _model_id):
+        nonlocal resolution_calls
+        resolution_calls += 1
+        return "720p"
+
+    monkeypatch.setattr(rvt, "_project_video_caps", fake_caps)
+    monkeypatch.setattr(rvt, "_project_video_resolution", fake_resolution)
+
+    ctx = await rvt.resolve_project_duration_context({})
+
+    assert caps_calls == 1
+    assert resolution_calls == 1
+    assert ctx == ProjectDurationContext(
+        supported_durations=[4, 6, 8],
+        resolution="720p",
+        provider_id="gemini-aistudio",
+        model_name="veo-3.1-generate-preview",
+    )
+
+
+@pytest.mark.unit
+async def test_resolve_project_duration_context_skips_resolution_when_no_durations(monkeypatch: pytest.MonkeyPatch):
+    """档位不可解析时分辨率也不解析——空档位下分辨率约束无意义，省一趟 IO。"""
+    from server.services import reference_video_tasks as rvt
+
+    resolution_calls = 0
+
+    async def fake_caps(_project, *, degraded_to):
+        return {}
+
+    async def fake_resolution(*_a, **_kw):
+        nonlocal resolution_calls
+        resolution_calls += 1
+        return "720p"
+
+    monkeypatch.setattr(rvt, "_project_video_caps", fake_caps)
+    monkeypatch.setattr(rvt, "_project_video_resolution", fake_resolution)
+
+    ctx = await rvt.resolve_project_duration_context({})
+
+    assert resolution_calls == 0
+    assert ctx.supported_durations == []
+    assert ctx.resolution is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("total_seconds", "with_references", "expected_seconds", "expected_adjustment"),
+    [
+        (8, True, 8, "exact"),
+        (5, True, 8, "up"),
+        (20, True, 8, "down"),
+        (5, False, 6, "up"),
+    ],
+)
+def test_precheck_unit_is_pure_and_matches_slot_semantics(
+    total_seconds, with_references, expected_seconds, expected_adjustment
+):
+    """precheck_unit 不触 DB，按 ctx 里已解析好的档位/分辨率为单个 unit 取档；带图/不带图
+    条件档位求交（Veo 3.1 720p 带图仅 8 秒、不带图仍是全集）与容量语义（exact/up/down）
+    行为与重构前一致。"""
+    ctx = ProjectDurationContext(
+        supported_durations=[4, 6, 8],
+        resolution="720p",
+        provider_id="gemini-aistudio",
+        model_name="veo-3.1-generate-preview",
+    )
+    unit = {
+        "duration_seconds": total_seconds,
+        "references": [{"type": "character", "name": "张三"}] if with_references else [],
+    }
+    slot = precheck_unit(ctx, unit, None)
+    assert slot.seconds == expected_seconds
+    assert slot.adjustment == expected_adjustment
+
+
+@pytest.mark.unit
+def test_precheck_unit_unconstrained_when_context_has_no_durations():
+    """能力不可解析（ctx.supported_durations 为空）时原样透传，沿用现状放行不弹确认。"""
+    ctx = ProjectDurationContext(supported_durations=[], resolution=None, provider_id="", model_name=None)
+    unit = {"duration_seconds": 7, "references": []}
+    slot = precheck_unit(ctx, unit, None)
+    assert slot.seconds == 7
+    assert slot.adjustment == "unconstrained"
+    assert slot.needs_confirmation is False
 
 
 @pytest.mark.unit

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -303,7 +303,7 @@ async def test_resolve_project_duration_context_resolves_caps_and_resolution_onc
     assert caps_calls == 1
     assert resolution_calls == 1
     assert ctx == ProjectDurationContext(
-        supported_durations=[4, 6, 8],
+        supported_durations=(4, 6, 8),
         resolution="720p",
         provider_id="gemini-aistudio",
         model_name="veo-3.1-generate-preview",
@@ -331,7 +331,7 @@ async def test_resolve_project_duration_context_skips_resolution_when_no_duratio
     ctx = await rvt.resolve_project_duration_context({})
 
     assert resolution_calls == 0
-    assert ctx.supported_durations == []
+    assert ctx.supported_durations == ()
     assert ctx.resolution is None
 
 
@@ -352,7 +352,7 @@ def test_precheck_unit_is_pure_and_matches_slot_semantics(
     条件档位求交（Veo 3.1 720p 带图仅 8 秒、不带图仍是全集）与容量语义（exact/up/down）
     行为与重构前一致。"""
     ctx = ProjectDurationContext(
-        supported_durations=[4, 6, 8],
+        supported_durations=(4, 6, 8),
         resolution="720p",
         provider_id="gemini-aistudio",
         model_name="veo-3.1-generate-preview",
@@ -369,7 +369,7 @@ def test_precheck_unit_is_pure_and_matches_slot_semantics(
 @pytest.mark.unit
 def test_precheck_unit_unconstrained_when_context_has_no_durations():
     """能力不可解析（ctx.supported_durations 为空）时原样透传，沿用现状放行不弹确认。"""
-    ctx = ProjectDurationContext(supported_durations=[], resolution=None, provider_id="", model_name=None)
+    ctx = ProjectDurationContext(supported_durations=(), resolution=None, provider_id="", model_name=None)
     unit = {"duration_seconds": 7, "references": []}
     slot = precheck_unit(ctx, unit, None)
     assert slot.seconds == 7

--- a/tests/server/test_reference_videos_router.py
+++ b/tests/server/test_reference_videos_router.py
@@ -240,10 +240,11 @@ def test_generate_unit_missing_returns_404(client: TestClient):
 
 
 def _patch_supported_durations(monkeypatch: pytest.MonkeyPatch, durations: list[int]) -> None:
-    from server.services import reference_video_tasks as rvt
+    from server.routers import reference_videos as router_mod
+    from server.services.reference_video_tasks import ProjectDurationContext
 
-    ctx = rvt.ProjectDurationContext(supported_durations=durations, resolution=None, provider_id="", model_name=None)
-    monkeypatch.setattr(rvt, "resolve_project_duration_context", AsyncMock(return_value=ctx))
+    ctx = ProjectDurationContext(supported_durations=tuple(durations), resolution=None, provider_id="", model_name=None)
+    monkeypatch.setattr(router_mod, "resolve_project_duration_context", AsyncMock(return_value=ctx))
 
 
 def _precheck(client: TestClient, unit_id: str):

--- a/tests/server/test_reference_videos_router.py
+++ b/tests/server/test_reference_videos_router.py
@@ -242,7 +242,8 @@ def test_generate_unit_missing_returns_404(client: TestClient):
 def _patch_supported_durations(monkeypatch: pytest.MonkeyPatch, durations: list[int]) -> None:
     from server.services import reference_video_tasks as rvt
 
-    monkeypatch.setattr(rvt, "resolve_project_supported_durations", AsyncMock(return_value=durations))
+    ctx = rvt.ProjectDurationContext(supported_durations=durations, resolution=None, provider_id="", model_name=None)
+    monkeypatch.setattr(rvt, "resolve_project_duration_context", AsyncMock(return_value=ctx))
 
 
 def _precheck(client: TestClient, unit_id: str):

--- a/tests/server/test_reference_videos_router_ad.py
+++ b/tests/server/test_reference_videos_router_ad.py
@@ -235,12 +235,11 @@ class TestAdGenerate:
     @pytest.mark.integration
     def test_precheck_rounds_up_group_total(self, ad_client: TestClient, monkeypatch: pytest.MonkeyPatch):
         """ad 与通用路径共用取档规则：分组成员镜头求和（3+2=5）非档位成员 → 按 8 秒申请，需确认。"""
-        from server.services import reference_video_tasks as rvt
+        from server.routers import reference_videos as router_mod
+        from server.services.reference_video_tasks import ProjectDurationContext
 
-        ctx = rvt.ProjectDurationContext(
-            supported_durations=[4, 8, 12], resolution=None, provider_id="", model_name=None
-        )
-        monkeypatch.setattr(rvt, "resolve_project_duration_context", AsyncMock(return_value=ctx))
+        ctx = ProjectDurationContext(supported_durations=(4, 8, 12), resolution=None, provider_id="", model_name=None)
+        monkeypatch.setattr(router_mod, "resolve_project_duration_context", AsyncMock(return_value=ctx))
         ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/derive-units")
 
         body = ad_client.get("/api/v1/projects/ad-demo/reference-videos/episodes/1/units/E1U1/duration-precheck").json()

--- a/tests/server/test_reference_videos_router_ad.py
+++ b/tests/server/test_reference_videos_router_ad.py
@@ -237,7 +237,10 @@ class TestAdGenerate:
         """ad 与通用路径共用取档规则：分组成员镜头求和（3+2=5）非档位成员 → 按 8 秒申请，需确认。"""
         from server.services import reference_video_tasks as rvt
 
-        monkeypatch.setattr(rvt, "resolve_project_supported_durations", AsyncMock(return_value=[4, 8, 12]))
+        ctx = rvt.ProjectDurationContext(
+            supported_durations=[4, 8, 12], resolution=None, provider_id="", model_name=None
+        )
+        monkeypatch.setattr(rvt, "resolve_project_duration_context", AsyncMock(return_value=ctx))
         ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/derive-units")
 
         body = ad_client.get("/api/v1/projects/ad-demo/reference-videos/episodes/1/units/E1U1/duration-precheck").json()


### PR DESCRIPTION
Closes #1455

## 变更

参考视频入队前的时长预检，把「项目级能力解析」的 IO 与「逐 unit 取档」的纯计算拆开：

- 新增 `ProjectDurationContext` + `resolve_project_duration_context(project)`：一次 IO 聚合档位全集、分辨率与 provider/model 身份；档位为空时不再解析分辨率（空档位下该约束无意义）
- `precheck_unit(ctx, unit, ad_shots)` 为纯函数，不触 DB，可直接单测无需 mock；带图/不带图的条件档位求交仍按 unit 逐个施加
- sdk_tools 批量入队预检（`_pending_duration_confirmations`）由「每 unit 两次 DB 往返」改为整批至多解析一次，且推迟到第一个真正需要取档的 unit——整批已完成或被跳过时不触发任何 IO
- Web `duration-precheck` 端点与批量路径收敛到同一 context 形状，原 `resolve_project_supported_durations` / `precheck_unit_duration_slot` 一并删除

取档语义（exact/up/down/unconstrained、条件档位求交、fallback 分辨率约束、解析失败放行不弹确认）与重构前一致，无用户可见行为变化。

执行层 `_apply_provider_constraints` 与 `ScriptGenerator._fetch_video_capabilities` 按 issue 授权分步收编，本次未改动。

## 验证

- `uv run python -m pytest`：6795 passed
- `uv run ruff check` / `ruff format --check`：全绿
- `uv run basedpyright`：0 errors
- 新增断言：整批 N unit 只解析一次 context（`test_..._resolves_project_context_once`，走真实纯函数取档）；无待检 unit 时零解析（`test_..._skips_duration_context_when_nothing_to_precheck`）；`resolve_project_duration_context` 的 caps/resolution 各只调用一次、空档位时跳过分辨率解析；`precheck_unit` 纯函数取档语义参数化覆盖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化参考视频/广告视频时长预检：批量时复用项目级时长配置，减少重复解析与不必要的预检计算。
  - 仅对需要的单元执行预检；无镜头或结构异常等情况会自动跳过，降低等待与噪声。
  - 时长不匹配时的确认流程及接口返回字段保持不变。  
- **测试**
  - 更新并扩展预检与入队相关用例，覆盖项目级配置触发/跳过、无可用时长档位、以及多场景入队确认。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->