### PR TITLE
fix(archive): 归档自动修复处理 generated_assets 损坏值，读站点收敛到统一归一化入口

### DIFF
--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -1236,12 +1236,10 @@ class ProjectManager:
         # video_units，不会静默落到 drama 兜底丢失 reference 数据。
         items = _resolve_items_or_warn(script, script_filename=script_filename)
 
-        # item.generated_assets 缺失 / null / 非 dict 一律视为"未生成"——读取侧脏数据容错：
-        # `.get("generated_assets", {}).get(...)` 只挡 key 缺失，None 与非 dict 仍会抛 AttributeError。
-        # 与写入侧 update_scene_asset 的 isinstance check mirror。
+        # item.generated_assets 缺失 / null / 非 dict 一律视为"未生成"——读取侧脏数据容错，
+        # 经 get_generated_assets 归一化，与写入侧 update_scene_asset 的 isinstance check mirror。
         def _missing(item: dict) -> bool:
-            assets = item.get("generated_assets")
-            return not isinstance(assets, dict) or not assets.get(asset_type)
+            return not get_generated_assets(item).get(asset_type)
 
         # 损坏脚本的非 dict 元素直接剔除（镜像 script_editor._existing_ids 的过滤），UI 不渲染垃圾项。
         return [item for item in items if isinstance(item, dict) and _missing(item)]
@@ -1282,12 +1280,11 @@ class ProjectManager:
         script = self.load_script(project_name, script_filename)
 
         # 同 get_pending_scenes：resolve_items 三模式判别 + warn-and-skip 降级 +
-        # generated_assets 容错 isinstance check。
+        # get_generated_assets 归一化容错。
         items = _resolve_items_or_warn(script, script_filename=script_filename)
 
         def _missing_storyboard(item: dict) -> bool:
-            assets = item.get("generated_assets")
-            return not isinstance(assets, dict) or not assets.get("storyboard_image")
+            return not get_generated_assets(item).get("storyboard_image")
 
         # 同 get_pending_scenes：非 dict 元素剔除，镜像 script_editor._existing_ids。
         return [item for item in items if isinstance(item, dict) and _missing_storyboard(item)]

--- a/lib/reference_video/ad_units.py
+++ b/lib/reference_video/ad_units.py
@@ -10,7 +10,7 @@ ad 剧本骨架唯一（shots 是内容唯一真相，见 docs/adr/0033）；ref
 
 from __future__ import annotations
 
-from lib.script_models import GeneratedAssets, ad_shot_duration_seconds
+from lib.script_models import GeneratedAssets, ad_shot_duration_seconds, get_generated_assets
 
 #: 单个 video_unit 最多容纳的镜头数，与 ``ReferenceVideoUnit.shots`` 的
 #: ``max_length=4`` 同口径（一个 unit 是一次视频生成调用的最小粒度）。
@@ -123,9 +123,9 @@ def merge_ad_reference_units(existing: object, derived: list[dict]) -> list[dict
             isinstance(prev, dict)
             and prev.get("shot_ids") == unit["shot_ids"]
             and prev.get("references") == unit["references"]
-            and isinstance(prev.get("generated_assets"), dict)
         ):
-            assets = dict(prev["generated_assets"])
+            # 损坏值经 get_generated_assets 归一化为空 dict，与下面的 `assets or 模板` 汇合到同一结果。
+            assets = dict(get_generated_assets(prev))
         merged.append({**unit, "generated_assets": assets or GeneratedAssets().model_dump()})
     return merged
 

--- a/lib/status_calculator.py
+++ b/lib/status_calculator.py
@@ -162,7 +162,7 @@ class StatusCalculator:
                 "reference_units 形状损坏（期望 dict 数组），按未派生计分 episode=%s",
                 script.get("episode"),
             )
-        video_done = sum(1 for u in units if (u.get("generated_assets") or {}).get("video_clip"))
+        video_done = sum(1 for u in units if get_generated_assets(u).get("video_clip"))
         total_units = len(units)
 
         if total_units == 0:

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -16,6 +16,7 @@ from lib.grid.layout import calculate_grid_layout
 from lib.pricing.strategies import PricingParams
 from lib.project_manager import effective_mode
 from lib.script_editor import ScriptEditError
+from lib.script_models import get_generated_assets
 from lib.storyboard_sequence import get_storyboard_items, group_scenes_by_segment_break
 
 logger = logging.getLogger(__name__)
@@ -182,10 +183,7 @@ class CostEstimationService:
             # Map grid_id → [scene_ids] from each segment's generated_assets
             grid_to_scenes: dict[str, list[str]] = {}
             for seg in raw_segments:
-                assets = seg.get("generated_assets")
-                if not isinstance(assets, dict):
-                    continue
-                gid = assets.get("grid_id")
+                gid = get_generated_assets(seg).get("grid_id")
                 sid = seg.get(id_key, "")
                 if gid and sid:
                     grid_to_scenes.setdefault(gid, []).append(sid)

--- a/server/services/image_edit_tasks.py
+++ b/server/services/image_edit_tasks.py
@@ -19,6 +19,7 @@ from lib.asset_types import ASSET_SPECS
 from lib.db.base import DEFAULT_USER_ID
 from lib.path_safety import safe_exists
 from lib.resource_paths import resource_relative_path
+from lib.script_models import get_generated_assets
 from lib.storyboard_sequence import find_storyboard_item, get_storyboard_items
 from server.services.generation_context import ImageLaneRequest, resolve_generation_context
 from server.services.generation_tasks import (
@@ -59,8 +60,7 @@ def resolve_current_image_rel(
         resolved = find_storyboard_item(items, id_field, resource_id)
         if resolved is None:
             raise KeyError(f"segment not found: {resource_id}")
-        assets = resolved[0].get("generated_assets") or {}
-        pointer = assets.get("storyboard_image") if isinstance(assets, dict) else None
+        pointer = get_generated_assets(resolved[0]).get("storyboard_image")
         if isinstance(pointer, str) and pointer:
             return pointer
         return resource_relative_path("storyboards", resource_id)

--- a/server/services/jianying_draft_service.py
+++ b/server/services/jianying_draft_service.py
@@ -207,8 +207,7 @@ class JianyingDraftService:
         for unit in units if isinstance(units, list) else []:
             if not isinstance(unit, dict):
                 continue
-            assets = unit.get("generated_assets") or {}
-            video_clip = assets.get("video_clip") if isinstance(assets, dict) else None
+            video_clip = get_generated_assets(unit).get("video_clip")
             if not video_clip:
                 continue
             abs_path = safe_resolve(project_dir, video_clip)

--- a/server/services/project_archive.py
+++ b/server/services/project_archive.py
@@ -914,17 +914,7 @@ class ProjectArchiveService:
         """补全 item.generated_assets 的缺失字段，返回 (assets, changed)。"""
         assets = item.get("generated_assets")
         changed = False
-        if assets is None:
-            item["generated_assets"] = self.project_manager.create_generated_assets(content_mode)
-            changed = True
-            diagnostics.add(
-                "auto_fixed",
-                "missing_generated_assets",
-                f"{label}[{index}]: 补全缺失字段 generated_assets",
-                location=f"{location_prefix}.generated_assets",
-            )
-            assets = item["generated_assets"]
-        elif isinstance(assets, dict):
+        if isinstance(assets, dict):
             template = self.project_manager.create_generated_assets(content_mode)
             missing_keys = [key for key in template if key not in assets]
             if missing_keys:
@@ -941,12 +931,20 @@ class ProjectArchiveService:
                         location=f"{location_prefix}.generated_assets",
                     )
         else:
+            # None = 字段缺失，其余非 dict = 外部编辑损坏（list/str 等）；两者同样重置为模板结构，
+            # 只在诊断上区分，让导入方知道是补齐还是丢弃了脏数据。
+            if assets is None:
+                code = "missing_generated_assets"
+                message = f"{label}[{index}]: 补全缺失字段 generated_assets"
+            else:
+                code = "invalid_generated_assets"
+                message = f"{label}[{index}]: generated_assets 形态异常（{type(assets).__name__}），已重置为默认结构"
             item["generated_assets"] = self.project_manager.create_generated_assets(content_mode)
             changed = True
             diagnostics.add(
                 "auto_fixed",
-                "invalid_generated_assets",
-                f"{label}[{index}]: generated_assets 形态异常（{type(assets).__name__}），已重置为默认结构",
+                code,
+                message,
                 location=f"{location_prefix}.generated_assets",
             )
             assets = item["generated_assets"]

--- a/server/services/project_archive.py
+++ b/server/services/project_archive.py
@@ -940,6 +940,16 @@ class ProjectArchiveService:
                         (f"{label}[{index}].generated_assets: 补全默认字段 {', '.join(non_null_keys)}"),
                         location=f"{location_prefix}.generated_assets",
                     )
+        else:
+            item["generated_assets"] = self.project_manager.create_generated_assets(content_mode)
+            changed = True
+            diagnostics.add(
+                "auto_fixed",
+                "invalid_generated_assets",
+                f"{label}[{index}]: generated_assets 形态异常（{type(assets).__name__}），已重置为默认结构",
+                location=f"{location_prefix}.generated_assets",
+            )
+            assets = item["generated_assets"]
         return assets, changed
 
     def _add_placeholder_character(

--- a/tests/test_project_archive_reference_video.py
+++ b/tests/test_project_archive_reference_video.py
@@ -236,6 +236,31 @@ class TestProjectArchiveReferenceVideo:
         assert assets["status"] == "pending"
         assert any(item["code"] == "invalid_generated_assets" for item in result.diagnostics["auto_fixed"])
 
+    def test_export_resets_invalid_generated_assets(self, tmp_path):
+        # 导出与导入共用 _repair_project_tree，但导出修的是快照副本：包内是干净结构，
+        # 源项目磁盘上的脏值保持原样（导出不改用户数据）。
+        pm = ProjectManager(tmp_path / "projects")
+        unit = _build_unit(video_clip=None, generated_assets="corrupted-value")
+        project_dir = _create_reference_video_project(pm, unit=unit, write_clip=False, write_thumbnail=False)
+        service = ProjectArchiveService(pm)
+
+        diagnostics = service.get_export_diagnostics("refdemo")
+        assert any(item["code"] == "invalid_generated_assets" for item in diagnostics["auto_fixed"])
+
+        archive_path, _ = service.export_project("refdemo")
+        try:
+            with zipfile.ZipFile(archive_path) as archive:
+                exported = json.loads(archive.read("refdemo/scripts/episode_1.json").decode("utf-8"))
+        finally:
+            archive_path.unlink(missing_ok=True)
+
+        assets = exported["video_units"][0]["generated_assets"]
+        assert isinstance(assets, dict)
+        assert assets["status"] == "pending"
+
+        on_disk = json.loads((project_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8"))
+        assert on_disk["video_units"][0]["generated_assets"] == "corrupted-value"
+
     def test_import_adds_placeholder_for_missing_character_reference(self, tmp_path):
         # 与 narration/drama 对齐：references 引用了 project.json 缺失的角色 → 自动补占位定义
         pm = ProjectManager(tmp_path / "projects")

--- a/tests/test_project_archive_reference_video.py
+++ b/tests/test_project_archive_reference_video.py
@@ -216,6 +216,26 @@ class TestProjectArchiveReferenceVideo:
         assert "video_thumbnail" in assets
         assert assets["status"] == "pending"
 
+    def test_import_resets_invalid_generated_assets(self, tmp_path):
+        pm = ProjectManager(tmp_path / "projects")
+        unit = _build_unit(video_clip=None, generated_assets="corrupted-value")
+        project_dir = _create_reference_video_project(pm, unit=unit, write_clip=False, write_thumbnail=False)
+        service = ProjectArchiveService(pm)
+
+        archive_path = tmp_path / "invalid-assets.zip"
+        _make_manual_zip(project_dir, archive_path)
+        shutil.rmtree(project_dir)
+
+        result = service.import_project_archive(archive_path, uploaded_filename="invalid-assets.zip")
+
+        imported = json.loads(
+            (pm.get_project_path(result.project_name) / "scripts" / "episode_1.json").read_text(encoding="utf-8")
+        )
+        assets = imported["video_units"][0]["generated_assets"]
+        assert isinstance(assets, dict)
+        assert assets["status"] == "pending"
+        assert any(item["code"] == "invalid_generated_assets" for item in result.diagnostics["auto_fixed"])
+
     def test_import_adds_placeholder_for_missing_character_reference(self, tmp_path):
         # 与 narration/drama 对齐：references 引用了 project.json 缺失的角色 → 自动补占位定义
         pm = ProjectManager(tmp_path / "projects")


### PR DESCRIPTION
Closes #1458

## 改动

1. **归档自动修复补齐损坏值分支**：`_backfill_generated_assets` 此前只处理 `None` 与 `dict`，`generated_assets` 为 list/字符串等损坏值时两分支都不命中、原样返回且不记 diagnostics。现将「非 dict」统一为一个分支重置为模板结构，诊断 code 按 `None`（`missing_generated_assets`，补齐缺失）与损坏值（`invalid_generated_assets`，丢弃脏数据）区分。
2. **读站点收编 `get_generated_assets`**：`status_calculator` / `project_manager`（`get_pending_scenes`、`get_scenes_needing_storyboard`）/ `cost_estimation` / `image_edit_tasks` / `jianying_draft_service` / `reference_video/ad_units` 共 7 处纯读取的内联 `isinstance` 守卫替换为归一化 helper，行为等价。

## 刻意未收编

以下三处的 `isinstance` 判断承载单纯取默认值之外的语义，收编会改变行为，保持现状：

- `project_manager.update_scene_asset` / `batch_update_scene_assets` — 写路径的重置语义（issue「明确不动」范围）
- `status_calculator._calculate_ad_reference_stats._wellformed` — 服务于「索引形状损坏」检测与 WARN 日志；收编会从「整集按未派生计分」退化为部分计数
- `script_editor.split_segment` — 区分 `None`（正常无资产）与非 dict（脏数据）并对后者单独 `logger.warning`

## 验证

- 新增 `test_import_resets_invalid_generated_assets`（导入路径）与 `test_export_resets_invalid_generated_assets`（导出路径，对应验收条款原文）；后者同时锁定导出只修快照副本、源项目磁盘上的脏值不被改写
- `uv run python -m pytest` 全量 6788 passed
- `uv run ruff check` / `ruff format` 通过；`uv run basedpyright` 0 error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 改进生成资源数据的异常处理，避免空值或无效格式导致状态、素材路径和费用统计异常。
  * 导入或导出项目时，自动将损坏的生成资源数据重置为默认结构，并正确标记为待处理。
  * 提升参考视频、分镜图、视频片段及网格素材处理的一致性。

* **测试**
  * 新增项目归档导入和导出场景的异常数据修复验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->