### PR TITLE
fix(cost-estimation): 参考视频费用预估按实际申请的时长计算

### DIFF
--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -690,6 +690,28 @@ class TaskRepository(BaseRepository):
             raise ValueError(f"task not found: {task_id}")
         await self.session.commit()
 
+    async def persist_effective_duration(self, task_id: str, duration_seconds: int) -> None:
+        """把取档后实际申请的秒数写回 ``task.payload["duration_seconds"]``。
+
+        参考视频执行层按 model 能力取档后申请的秒数可能偏离入队时的剧本原值；
+        resume 路径读的正是这个字段（见 ``server.services.resume_executor``），
+        不写回会让 resume 时按剧本原值重新申请，与本次执行实际申请的秒数不一致。
+        read-modify-write 模式同 ``persist_api_call_id``；task 不存在时静默跳过
+        （不影响本次生成结果，仅是 resume 元数据，不必 fail-fast 阻断执行）。
+        """
+        result = await self.session.execute(select(Task.payload_json).where(Task.task_id == task_id))
+        row = result.first()
+        if row is None:
+            return
+        data = _json_loads(row[0], {})
+        if not isinstance(data, dict):
+            data = {}
+        data["duration_seconds"] = duration_seconds
+        await self.session.execute(
+            update(Task).where(Task.task_id == task_id).values(payload_json=_json_dumps(data), updated_at=utc_now())
+        )
+        await self.session.commit()
+
     async def list_orphan_tasks_on_start(self) -> list[dict[str, Any]]:
         """返回 running + cancelling 状态任务用于重启自愈（ADR 0007）。"""
         result = await self.session.execute(

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -658,37 +658,43 @@ class TaskRepository(BaseRepository):
         )
         await self.session.commit()
 
-    async def persist_api_call_id(self, task_id: str, call_id: int) -> None:
-        """将 ApiCall.id 写入 task.payload["api_call_id"]，供 resume 路径精准翻 pending。
+    async def _merge_payload_field(self, task_id: str, key: str, value: Any, *, raise_if_missing: bool = True) -> None:
+        """把单个字段并入 task.payload 并提交；``raise_if_missing`` 决定 task 缺失时的处置。
 
-        Task.payload_json 是 TEXT 列存 JSON 字符串（非 native JSONB），用 read-modify-write
-        模式更新；并发安全前提：本方法**仅**由 media_generator 在 start_call 拿到 call_id
-        后立即调一次（与 ``persist_provider_job_id`` 同一时序），不与其它路径竞争写 payload。
-        如果未来引入并发写 payload 的路径，需要外层加 ``SELECT ... FOR UPDATE`` 或单事务串行化。
-
-        Raises:
-            ValueError: task_id 不存在或 UPDATE 命中 0 行——避免静默 commit 让上层
-                以为"已持久化"但 payload["api_call_id"] 实际未写入，resume 时只能退回兜底。
+        Task.payload_json 是 TEXT 列存 JSON 字符串（非 native JSONB），故用 read-modify-write
+        模式更新。并发安全前提：写 payload 的路径在同一 task 的执行协程内串行——
+        ``persist_effective_duration`` 在向 provider 提交前写一次，``persist_api_call_id`` 由
+        media_generator 在其后拿到 call_id 时写一次，两者不并发。如果未来引入真正并发写
+        payload 的路径，需要外层加 ``SELECT ... FOR UPDATE`` 或单事务串行化。
         """
-        now = utc_now()
         # 用 .first() 而非 scalar_one_or_none()：Task.payload_json 允许 NULL（迁移历史/
         # 旧任务存在 payload_json IS NULL 行），scalar_one_or_none 会把"行存在但
         # payload_json=NULL"误判成"无行"。Row 解构 row[0] 后 None 由 _json_loads 兜底为 {}。
         result = await self.session.execute(select(Task.payload_json).where(Task.task_id == task_id))
         row = result.first()
         if row is None:
-            raise ValueError(f"task not found: {task_id}")
-        raw = row[0]
-        data = _json_loads(raw, {})
+            if raise_if_missing:
+                raise ValueError(f"task not found: {task_id}")
+            return
+        data = _json_loads(row[0], {})
         if not isinstance(data, dict):
             data = {}
-        data["api_call_id"] = call_id
+        data[key] = value
         update_result = await self.session.execute(
-            update(Task).where(Task.task_id == task_id).values(payload_json=_json_dumps(data), updated_at=now)
+            update(Task).where(Task.task_id == task_id).values(payload_json=_json_dumps(data), updated_at=utc_now())
         )
-        if rowcount(update_result) == 0:
+        if raise_if_missing and rowcount(update_result) == 0:
             raise ValueError(f"task not found: {task_id}")
         await self.session.commit()
+
+    async def persist_api_call_id(self, task_id: str, call_id: int) -> None:
+        """将 ApiCall.id 写入 task.payload["api_call_id"]，供 resume 路径精准翻 pending。
+
+        Raises:
+            ValueError: task_id 不存在或 UPDATE 命中 0 行——避免静默 commit 让上层
+                以为"已持久化"但 payload["api_call_id"] 实际未写入，resume 时只能退回兜底。
+        """
+        await self._merge_payload_field(task_id, "api_call_id", call_id)
 
     async def persist_effective_duration(self, task_id: str, duration_seconds: int) -> None:
         """把取档后实际申请的秒数写回 ``task.payload["duration_seconds"]``。
@@ -696,21 +702,10 @@ class TaskRepository(BaseRepository):
         参考视频执行层按 model 能力取档后申请的秒数可能偏离入队时的剧本原值；
         resume 路径读的正是这个字段（见 ``server.services.resume_executor``），
         不写回会让 resume 时按剧本原值重新申请，与本次执行实际申请的秒数不一致。
-        read-modify-write 模式同 ``persist_api_call_id``；task 不存在时静默跳过
-        （不影响本次生成结果，仅是 resume 元数据，不必 fail-fast 阻断执行）。
+        task 不存在时静默跳过（不影响本次生成结果，仅是 resume 元数据，不必 fail-fast
+        阻断执行）。
         """
-        result = await self.session.execute(select(Task.payload_json).where(Task.task_id == task_id))
-        row = result.first()
-        if row is None:
-            return
-        data = _json_loads(row[0], {})
-        if not isinstance(data, dict):
-            data = {}
-        data["duration_seconds"] = duration_seconds
-        await self.session.execute(
-            update(Task).where(Task.task_id == task_id).values(payload_json=_json_dumps(data), updated_at=utc_now())
-        )
-        await self.session.commit()
+        await self._merge_payload_field(task_id, "duration_seconds", duration_seconds, raise_if_missing=False)
 
     async def list_orphan_tasks_on_start(self) -> list[dict[str, Any]]:
         """返回 running + cancelling 状态任务用于重启自愈（ADR 0007）。"""

--- a/lib/generation_queue.py
+++ b/lib/generation_queue.py
@@ -186,6 +186,10 @@ class GenerationQueue:
         async with self._task_repo() as repo:
             await repo.persist_api_call_id(task_id, call_id)
 
+    async def persist_effective_duration(self, task_id: str, duration_seconds: int) -> None:
+        async with self._task_repo() as repo:
+            await repo.persist_effective_duration(task_id, duration_seconds)
+
     async def mark_task_succeeded(self, task_id: str, result: dict[str, Any] | None) -> int:
         """Returns rows_affected (0 = 已被外部翻成非 running 终/中间态，worker 走 0-rows-cancelled 协议)."""
         async with self._task_repo() as repo:

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -43,6 +43,23 @@ def _merge_breakdowns(a: CostBreakdown, b: CostBreakdown) -> CostBreakdown:
     return merged
 
 
+def _split_cost_across(cost: CostBreakdown, parts: int) -> list[CostBreakdown]:
+    """把一笔按整体计费的费用均摊成 ``parts`` 份，除不尽的余数补给最后一份。
+
+    补余数是为了让分摊结果的合计与原值分文不差：调用方按分摊后的份额累加集/项目合计，
+    若每份都独立 round，误差会随镜头数放大到用户可见的总价上。
+    """
+    if parts <= 0:
+        return []
+    split: list[CostBreakdown] = [{} for _ in range(parts)]
+    for currency, amount in cost.items():
+        share = round(amount / parts, 6)
+        for bucket in split[:-1]:
+            bucket[currency] = share
+        split[-1][currency] = round(amount - share * (parts - 1), 6)
+    return split
+
+
 class CostEstimationService:
     def __init__(self, resolver: ConfigResolver, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._resolver = resolver
@@ -153,6 +170,25 @@ class CostEstimationService:
         # （见 :func:`server.services.reference_video_tasks.resolve_project_duration_context`）。
         duration_ctx: ProjectDurationContext | None = None
 
+        def _accumulate_episode(
+            ep_meta: dict[str, Any],
+            segments_result: list[dict[str, Any]],
+            ep_est: dict[str, CostBreakdown],
+            ep_act: dict[str, CostBreakdown],
+        ) -> None:
+            """收下一集的估算结果并并入项目级合计（两条估算路径共用的收尾）。"""
+            episodes_result.append(
+                {
+                    "episode": ep_meta.get("episode"),
+                    "title": ep_meta.get("title", ""),
+                    "segments": segments_result,
+                    "totals": {"estimate": ep_est, "actual": ep_act},
+                }
+            )
+            for cost_type in ("image", "video", "audio"):
+                proj_est[cost_type] = _merge_breakdowns(proj_est.get(cost_type, {}), ep_est.get(cost_type, {}))
+                proj_act[cost_type] = _merge_breakdowns(proj_act.get(cost_type, {}), ep_act.get(cost_type, {}))
+
         for ep_meta in episodes_meta:
             script_file = ep_meta.get("script_file", "")
             script = scripts.get(script_file)
@@ -181,17 +217,7 @@ class CostEstimationService:
                     video_price=video_price,
                     actual_by_segment=actual_by_segment,
                 )
-                episodes_result.append(
-                    {
-                        "episode": ep_meta.get("episode"),
-                        "title": ep_meta.get("title", ""),
-                        "segments": segments_result,
-                        "totals": {"estimate": ep_est, "actual": ep_act},
-                    }
-                )
-                for cost_type in ("image", "video", "audio"):
-                    proj_est[cost_type] = _merge_breakdowns(proj_est.get(cost_type, {}), ep_est.get(cost_type, {}))
-                    proj_act[cost_type] = _merge_breakdowns(proj_act.get(cost_type, {}), ep_act.get(cost_type, {}))
+                _accumulate_episode(ep_meta, segments_result, ep_est, ep_act)
                 continue
 
             try:
@@ -315,24 +341,7 @@ class CostEstimationService:
                         seg_act_by_type[cost_type],
                     )
 
-            episodes_result.append(
-                {
-                    "episode": ep_meta.get("episode"),
-                    "title": ep_meta.get("title", ""),
-                    "segments": segments_result,
-                    "totals": {"estimate": ep_est, "actual": ep_act},
-                }
-            )
-
-            for cost_type in ("image", "video", "audio"):
-                proj_est[cost_type] = _merge_breakdowns(
-                    proj_est.get(cost_type, {}),
-                    ep_est.get(cost_type, {}),
-                )
-                proj_act[cost_type] = _merge_breakdowns(
-                    proj_act.get(cost_type, {}),
-                    ep_act.get(cost_type, {}),
-                )
+            _accumulate_episode(ep_meta, segments_result, ep_est, ep_act)
 
         # Project-level actual costs (characters/scenes/props/products 资产图 —— segment_id is null)
         async with self._session_factory() as session:
@@ -366,25 +375,33 @@ class CostEstimationService:
         video_price: Any,
         actual_by_segment: dict[str, dict[str, CostBreakdown]],
     ) -> tuple[list[dict[str, Any]], dict[str, CostBreakdown], dict[str, CostBreakdown]]:
-        """ad + reference_video 集的估值：按 reference_unit（实际计费颗粒度）取档后计费。
+        """ad + reference_video 集的估值：计费颗粒度是 unit，展示颗粒度是 shot。
 
         ad 骨架恒为 shots（ADR-0033），但 reference_video 路径把镜头派生分组为 unit 后
         按 unit 整体送 provider（``execute_reference_video_task``），一个 unit 只申请一次
-        取档后的秒数，不是逐镜头分别计费——预估颗粒度必须与之一致，否则「按镜头合计」与
-        「按 unit 取档」在档位向上/向下取整时永远对不上（这正是本函数要修的缺陷）。
+        取档后的秒数，不是逐镜头分别计费——估值必须按 unit 取档后计算，否则「按镜头合计」
+        与「按 unit 取档」在档位向上/向下取整时永远对不上。
+
+        算出的 unit 费用再均摊回成员镜头输出，与 grid 模式「按 grid 计费、分摊到 scene
+        展示」的口径同构：前端按镜头 ID 索引 segment（``frontend/src/stores/cost-store.ts``），
+        输出 unit ID 会让镜头面板查不到费用。除不尽的余数补给末镜，保证分摊后的合计与
+        unit 原值分文不差。实际费用同样按 unit 分摊——usage 记录的 segment_id 就是 unit ID
+        （执行层把 unit ID 作为 ``resource_id`` 传给 ``generate_video_async``）。
 
         分组优先读剧本已持久化的 ``reference_units``（与执行时同一份索引，见
         ``lib.reference_video.ad_units.sync_ad_reference_units``）；用户尚未打开过参考
         视频面板/触发过入队、索引还未派生时，按纯函数现推一份仅用于估算、不写回剧本——
-        不带供应商时长上限（预估路径不为此单独触发一次 IO），分组可能比实际派生更粗，
-        仅是估算阶段的近似，真实分组仍以执行时派生结果为准。
+        时长上限取自 ``duration_ctx``（与执行侧派生同一份能力解析，不额外触发 IO），
+        分组结果因此与真实派生同约束，真实分组仍以执行时派生结果为准。
 
         无图片/音频维度：ad 参考视频不产生分镜图（跳过分镜步骤）、镜头口播文案不产生
         旁白配音估值（同 storyboard 模式口径，见 ``test_ad_voiceover_does_not_produce_audio_estimate``）。
         """
         units = script.get("reference_units")
         if not isinstance(units, list) or not units:
-            units = derive_ad_reference_units(script.get("shots"), episode=episode or 0, max_unit_duration=None)
+            units = derive_ad_reference_units(
+                script.get("shots"), episode=episode or 0, max_unit_duration=duration_ctx.max_duration
+            )
 
         segments_result: list[dict[str, Any]] = []
         ep_est: dict[str, CostBreakdown] = {}
@@ -397,13 +414,15 @@ class CostEstimationService:
             try:
                 ad_shots = resolve_ad_unit_shots(script, unit)
             except ValueError as exc:
-                # 分组索引过期（镜头被删/改 ID 后未重新派生）：估算对此不可恢复，
-                # 该 unit 降级为 0 估值 + 日志，不让整个项目费用估算失败。
+                # 分组索引过期（镜头被删/改 ID 后未重新派生）：估算对此不可恢复，该 unit
+                # 整体跳过 + 日志，不让整个项目费用估算失败。成员镜头无从解析，也就无处
+                # 分摊——按 0 估值硬造一条记录只会展示一笔查无实据的费用。
                 logger.debug("费用估算跳过过期的 reference_unit %s: %s", unit_id, exc)
-                ad_shots = []
+                continue
+            if not ad_shots:
+                continue
 
             slot = precheck_unit(duration_ctx, unit, ad_shots)
-            duration = slot.seconds
 
             est_video: CostBreakdown = {}
             try:
@@ -413,7 +432,7 @@ class CostEstimationService:
                         call_type="video",
                         model=video_model,
                         resolution=video_resolution,
-                        duration_seconds=duration,
+                        duration_seconds=slot.seconds,
                         generate_audio=generate_audio,
                     ),
                     custom_price_input=video_price.price_input,
@@ -425,16 +444,22 @@ class CostEstimationService:
                 logger.debug("无法计算 video 预估 for %s", unit_id, exc_info=True)
 
             act_video: CostBreakdown = actual_by_segment.get(unit_id, {}).get("video", {})
+            est_by_shot = _split_cost_across(est_video, len(ad_shots))
+            act_by_shot = _split_cost_across(act_video, len(ad_shots))
 
-            segments_result.append(
-                {
-                    "segment_id": unit_id,
-                    "duration_seconds": duration,
-                    "estimate": {"image": {}, "video": est_video, "audio": {}},
-                    "actual": {"image": {}, "video": act_video, "audio": {}},
-                }
-            )
-            ep_est["video"] = _merge_breakdowns(ep_est.get("video", {}), est_video)
-            ep_act["video"] = _merge_breakdowns(ep_act.get("video", {}), act_video)
+            for idx, shot in enumerate(ad_shots):
+                shot_est = est_by_shot[idx]
+                shot_act = act_by_shot[idx]
+                segments_result.append(
+                    {
+                        "segment_id": shot.get("shot_id", ""),
+                        # 展示镜头自身的编排时长：取档发生在 unit 级，摊不回单个镜头
+                        "duration_seconds": shot.get("duration_seconds", 8),
+                        "estimate": {"image": {}, "video": shot_est, "audio": {}},
+                        "actual": {"image": {}, "video": shot_act, "audio": {}},
+                    }
+                )
+                ep_est["video"] = _merge_breakdowns(ep_est.get("video", {}), shot_est)
+                ep_act["video"] = _merge_breakdowns(ep_act.get("video", {}), shot_act)
 
         return segments_result, ep_est, ep_act

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -385,12 +385,13 @@ class CostEstimationService:
         算出的 unit 费用再均摊回成员镜头输出，与 grid 模式「按 grid 计费、分摊到 scene
         展示」的口径同构：前端按镜头 ID 索引 segment（``frontend/src/stores/cost-store.ts``），
         输出 unit ID 会让镜头面板查不到费用。除不尽的余数补给末镜，保证分摊后的合计与
-        unit 原值分文不差。视频实付按 unit 分摊，读的是 ``actual_by_segment[unit_id]``
-        ——注：``lib/media_generator.py`` 目前只对 ``resource_type in ("storyboards",
-        "videos")`` 写入 usage 的 segment_id，``reference_videos`` 调用不在其中，故这一读取
-        现状恒空，是独立于本函数的既有缺口，不在本次改动范围内。图片/音频实付按 shot_id
-        原样回填（不受 unit 分摊影响）：项目若曾在 storyboard 模式生成过分镜图、之后切到
-        reference_video，这些已发生的镜头图费用仍需展示。
+        unit 原值分文不差。视频实付按 unit 分摊（读 ``actual_by_segment[unit_id]``——注：
+        ``lib/media_generator.py`` 目前只对 ``resource_type in ("storyboards", "videos")``
+        写入 usage 的 segment_id，``reference_videos`` 调用不在其中，故这一读取现状恒空，
+        是独立于本函数的既有缺口，不在本次改动范围内），与 shot_id 记账的历史视频实付
+        合并而非互相替换：项目若曾在 storyboard 模式为该镜头生成过视频、之后切到
+        reference_video，这笔旧支出与新 unit 的分摊额都要计入。图片/音频实付同样按
+        shot_id 原样回填（不受 unit 分摊影响）：切换模式前产生的镜头图/配音费用仍需展示。
 
         分组优先读剧本已持久化的 ``reference_units``（与执行时同一份索引，见
         ``lib.reference_video.ad_units.sync_ad_reference_units``）；用户尚未打开过参考
@@ -454,24 +455,30 @@ class CostEstimationService:
 
             for idx, shot in enumerate(ad_shots):
                 shot_est = est_by_shot[idx]
-                shot_act = act_by_shot[idx]
                 shot_id = shot.get("shot_id", "")
-                # 模式切换前（storyboard 阶段）按 shot_id 记的镜头图/音频实付仍要展示，
-                # 不因当前是 reference_video 模式而清空——那是用户已经花掉的真实费用。
+                # 模式切换前（storyboard 阶段）按 shot_id 记的镜头图/视频/音频实付仍要展示，
+                # 不因当前是 reference_video 模式而清空——那是用户已经花掉的真实费用。video
+                # 维度与 unit 分摊额合并而非互相替换：同一镜头可能既有切换前的历史视频调用
+                # （shot_id 记账），也有切换后的 unit 调用（unit_id 分摊），两者都是真实支出。
                 shot_actual = actual_by_segment.get(shot_id, {})
                 shot_act_image = shot_actual.get("image", {})
                 shot_act_audio = shot_actual.get("audio", {})
+                shot_act_video = _merge_breakdowns(act_by_shot[idx], shot_actual.get("video", {}))
                 segments_result.append(
                     {
                         "segment_id": shot_id,
                         # 展示镜头自身的编排时长：取档发生在 unit 级，摊不回单个镜头
                         "duration_seconds": shot.get("duration_seconds", 8),
                         "estimate": {"image": {}, "video": shot_est, "audio": {}},
-                        "actual": {"image": shot_act_image, "video": shot_act, "audio": shot_act_audio},
+                        "actual": {"image": shot_act_image, "video": shot_act_video, "audio": shot_act_audio},
                     }
                 )
                 ep_est["video"] = _merge_breakdowns(ep_est.get("video", {}), shot_est)
-                for cost_type, amounts in (("image", shot_act_image), ("video", shot_act), ("audio", shot_act_audio)):
+                for cost_type, amounts in (
+                    ("image", shot_act_image),
+                    ("video", shot_act_video),
+                    ("audio", shot_act_audio),
+                ):
                     ep_act[cost_type] = _merge_breakdowns(ep_act.get(cost_type, {}), amounts)
 
         return segments_result, ep_est, ep_act

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -385,8 +385,12 @@ class CostEstimationService:
         算出的 unit 费用再均摊回成员镜头输出，与 grid 模式「按 grid 计费、分摊到 scene
         展示」的口径同构：前端按镜头 ID 索引 segment（``frontend/src/stores/cost-store.ts``），
         输出 unit ID 会让镜头面板查不到费用。除不尽的余数补给末镜，保证分摊后的合计与
-        unit 原值分文不差。实际费用同样按 unit 分摊——usage 记录的 segment_id 就是 unit ID
-        （执行层把 unit ID 作为 ``resource_id`` 传给 ``generate_video_async``）。
+        unit 原值分文不差。视频实付按 unit 分摊，读的是 ``actual_by_segment[unit_id]``
+        ——注：``lib/media_generator.py`` 目前只对 ``resource_type in ("storyboards",
+        "videos")`` 写入 usage 的 segment_id，``reference_videos`` 调用不在其中，故这一读取
+        现状恒空，是独立于本函数的既有缺口，不在本次改动范围内。图片/音频实付按 shot_id
+        原样回填（不受 unit 分摊影响）：项目若曾在 storyboard 模式生成过分镜图、之后切到
+        reference_video，这些已发生的镜头图费用仍需展示。
 
         分组优先读剧本已持久化的 ``reference_units``（与执行时同一份索引，见
         ``lib.reference_video.ad_units.sync_ad_reference_units``）；用户尚未打开过参考
@@ -394,8 +398,9 @@ class CostEstimationService:
         时长上限取自 ``duration_ctx``（与执行侧派生同一份能力解析，不额外触发 IO），
         分组结果因此与真实派生同约束，真实分组仍以执行时派生结果为准。
 
-        无图片/音频维度：ad 参考视频不产生分镜图（跳过分镜步骤）、镜头口播文案不产生
+        无图片/音频估值维度：ad 参考视频不产生分镜图（跳过分镜步骤）、镜头口播文案不产生
         旁白配音估值（同 storyboard 模式口径，见 ``test_ad_voiceover_does_not_produce_audio_estimate``）。
+        实付维度不受此限——见上段。
         """
         units = script.get("reference_units")
         if not isinstance(units, list) or not units:
@@ -450,16 +455,23 @@ class CostEstimationService:
             for idx, shot in enumerate(ad_shots):
                 shot_est = est_by_shot[idx]
                 shot_act = act_by_shot[idx]
+                shot_id = shot.get("shot_id", "")
+                # 模式切换前（storyboard 阶段）按 shot_id 记的镜头图/音频实付仍要展示，
+                # 不因当前是 reference_video 模式而清空——那是用户已经花掉的真实费用。
+                shot_actual = actual_by_segment.get(shot_id, {})
+                shot_act_image = shot_actual.get("image", {})
+                shot_act_audio = shot_actual.get("audio", {})
                 segments_result.append(
                     {
-                        "segment_id": shot.get("shot_id", ""),
+                        "segment_id": shot_id,
                         # 展示镜头自身的编排时长：取档发生在 unit 级，摊不回单个镜头
                         "duration_seconds": shot.get("duration_seconds", 8),
                         "estimate": {"image": {}, "video": shot_est, "audio": {}},
-                        "actual": {"image": {}, "video": shot_act, "audio": {}},
+                        "actual": {"image": shot_act_image, "video": shot_act, "audio": shot_act_audio},
                     }
                 )
                 ep_est["video"] = _merge_breakdowns(ep_est.get("video", {}), shot_est)
-                ep_act["video"] = _merge_breakdowns(ep_act.get("video", {}), shot_act)
+                for cost_type, amounts in (("image", shot_act_image), ("video", shot_act), ("audio", shot_act_audio)):
+                    ep_act[cost_type] = _merge_breakdowns(ep_act.get(cost_type, {}), amounts)
 
         return segments_result, ep_est, ep_act

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -15,9 +15,15 @@ from lib.db.repositories.usage_repo import UsageRepository
 from lib.grid.layout import calculate_grid_layout
 from lib.pricing.strategies import PricingParams
 from lib.project_manager import effective_mode
+from lib.reference_video.ad_units import derive_ad_reference_units, resolve_ad_unit_shots
 from lib.script_editor import ScriptEditError
 from lib.script_models import get_generated_assets
 from lib.storyboard_sequence import get_storyboard_items, group_scenes_by_segment_break
+from server.services.reference_video_tasks import (
+    ProjectDurationContext,
+    precheck_unit,
+    resolve_project_duration_context,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -143,6 +149,9 @@ class CostEstimationService:
         proj_act: dict[str, CostBreakdown] = {}
 
         content_mode = project_data.get("content_mode", "narration")
+        # 惰性解析：只有项目里真出现 ad + reference_video 集时才触发这次额外 IO
+        # （见 :func:`server.services.reference_video_tasks.resolve_project_duration_context`）。
+        duration_ctx: ProjectDurationContext | None = None
 
         for ep_meta in episodes_meta:
             script_file = ep_meta.get("script_file", "")
@@ -152,10 +161,38 @@ class CostEstimationService:
 
             # ad 参考生视频路径跳过分镜步骤（剧本骨架唯一，shots 不打 generation_mode 戳，
             # 不能像 narration/drama 那样靠剧本戳清空条目），分镜图维度按路径显式跳过；
-            # 视频估值仍按镜头时长逐条计算（派生分组按 unit 计费，总时长与逐镜头求和一致）。
-            skip_image_estimate = (
+            # 视频估值按实际计费颗粒度（reference_unit，而非镜头）计算，见
+            # ``_estimate_ad_reference_video_episode``。
+            is_ad_reference_video = (
                 content_mode == "ad" and effective_mode(project=project_data, episode=ep_meta) == "reference_video"
             )
+
+            if is_ad_reference_video:
+                if duration_ctx is None:
+                    duration_ctx = await resolve_project_duration_context(project_data)
+                segments_result, ep_est, ep_act = self._estimate_ad_reference_video_episode(
+                    script=script,
+                    episode=ep_meta.get("episode"),
+                    duration_ctx=duration_ctx,
+                    video_provider=video_provider,
+                    video_model=video_model,
+                    video_resolution=video_resolution,
+                    generate_audio=generate_audio,
+                    video_price=video_price,
+                    actual_by_segment=actual_by_segment,
+                )
+                episodes_result.append(
+                    {
+                        "episode": ep_meta.get("episode"),
+                        "title": ep_meta.get("title", ""),
+                        "segments": segments_result,
+                        "totals": {"estimate": ep_est, "actual": ep_act},
+                    }
+                )
+                for cost_type in ("image", "video", "audio"):
+                    proj_est[cost_type] = _merge_breakdowns(proj_est.get(cost_type, {}), ep_est.get(cost_type, {}))
+                    proj_act[cost_type] = _merge_breakdowns(proj_act.get(cost_type, {}), ep_act.get(cost_type, {}))
+                continue
 
             try:
                 raw_segments, id_key, _, _, _ = get_storyboard_items(script)
@@ -210,12 +247,11 @@ class CostEstimationService:
                 est_video: CostBreakdown = {}
                 est_audio: CostBreakdown = {}
 
-                if not skip_image_estimate:
-                    if generation_mode == "grid" and seg_id in grid_cost_per_segment:
-                        cost_amount, cost_currency = grid_cost_per_segment[seg_id]
-                        _add_cost(est_image, cost_amount, cost_currency)
-                    elif image_unit_cost:
-                        _add_cost(est_image, image_unit_cost[0], image_unit_cost[1])
+                if generation_mode == "grid" and seg_id in grid_cost_per_segment:
+                    cost_amount, cost_currency = grid_cost_per_segment[seg_id]
+                    _add_cost(est_image, cost_amount, cost_currency)
+                elif image_unit_cost:
+                    _add_cost(est_image, image_unit_cost[0], image_unit_cost[1])
 
                 try:
                     vid_amount, vid_currency = cost_calculator.calculate_cost(
@@ -316,3 +352,89 @@ class CostEstimationService:
             "episodes": episodes_result,
             "project_totals": {"estimate": proj_est, "actual": proj_act},
         }
+
+    def _estimate_ad_reference_video_episode(
+        self,
+        *,
+        script: dict[str, Any],
+        episode: int | None,
+        duration_ctx: ProjectDurationContext,
+        video_provider: str,
+        video_model: str | None,
+        video_resolution: str | None,
+        generate_audio: bool,
+        video_price: Any,
+        actual_by_segment: dict[str, dict[str, CostBreakdown]],
+    ) -> tuple[list[dict[str, Any]], dict[str, CostBreakdown], dict[str, CostBreakdown]]:
+        """ad + reference_video 集的估值：按 reference_unit（实际计费颗粒度）取档后计费。
+
+        ad 骨架恒为 shots（ADR-0033），但 reference_video 路径把镜头派生分组为 unit 后
+        按 unit 整体送 provider（``execute_reference_video_task``），一个 unit 只申请一次
+        取档后的秒数，不是逐镜头分别计费——预估颗粒度必须与之一致，否则「按镜头合计」与
+        「按 unit 取档」在档位向上/向下取整时永远对不上（这正是本函数要修的缺陷）。
+
+        分组优先读剧本已持久化的 ``reference_units``（与执行时同一份索引，见
+        ``lib.reference_video.ad_units.sync_ad_reference_units``）；用户尚未打开过参考
+        视频面板/触发过入队、索引还未派生时，按纯函数现推一份仅用于估算、不写回剧本——
+        不带供应商时长上限（预估路径不为此单独触发一次 IO），分组可能比实际派生更粗，
+        仅是估算阶段的近似，真实分组仍以执行时派生结果为准。
+
+        无图片/音频维度：ad 参考视频不产生分镜图（跳过分镜步骤）、镜头口播文案不产生
+        旁白配音估值（同 storyboard 模式口径，见 ``test_ad_voiceover_does_not_produce_audio_estimate``）。
+        """
+        units = script.get("reference_units")
+        if not isinstance(units, list) or not units:
+            units = derive_ad_reference_units(script.get("shots"), episode=episode or 0, max_unit_duration=None)
+
+        segments_result: list[dict[str, Any]] = []
+        ep_est: dict[str, CostBreakdown] = {}
+        ep_act: dict[str, CostBreakdown] = {}
+
+        for unit in units:
+            if not isinstance(unit, dict):
+                continue
+            unit_id = str(unit.get("unit_id") or "")
+            try:
+                ad_shots = resolve_ad_unit_shots(script, unit)
+            except ValueError as exc:
+                # 分组索引过期（镜头被删/改 ID 后未重新派生）：估算对此不可恢复，
+                # 该 unit 降级为 0 估值 + 日志，不让整个项目费用估算失败。
+                logger.debug("费用估算跳过过期的 reference_unit %s: %s", unit_id, exc)
+                ad_shots = []
+
+            slot = precheck_unit(duration_ctx, unit, ad_shots)
+            duration = slot.seconds
+
+            est_video: CostBreakdown = {}
+            try:
+                vid_amount, vid_currency = cost_calculator.calculate_cost(
+                    video_provider,
+                    PricingParams(
+                        call_type="video",
+                        model=video_model,
+                        resolution=video_resolution,
+                        duration_seconds=duration,
+                        generate_audio=generate_audio,
+                    ),
+                    custom_price_input=video_price.price_input,
+                    custom_price_output=video_price.price_output,
+                    custom_currency=video_price.currency,
+                )
+                _add_cost(est_video, vid_amount, vid_currency)
+            except Exception:
+                logger.debug("无法计算 video 预估 for %s", unit_id, exc_info=True)
+
+            act_video: CostBreakdown = actual_by_segment.get(unit_id, {}).get("video", {})
+
+            segments_result.append(
+                {
+                    "segment_id": unit_id,
+                    "duration_seconds": duration,
+                    "estimate": {"image": {}, "video": est_video, "audio": {}},
+                    "actual": {"image": {}, "video": act_video, "audio": {}},
+                }
+            )
+            ep_est["video"] = _merge_breakdowns(ep_est.get("video", {}), est_video)
+            ep_act["video"] = _merge_breakdowns(ep_act.get("video", {}), act_video)
+
+        return segments_result, ep_est, ep_act

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -522,12 +522,14 @@ async def execute_reference_video_task(
             resolution=resolution,
         )
 
-    # 取档偏移了剧本编排（adjustment != exact）时，把实际申请的秒数写回 task payload：
-    # resume 路径（server.services.resume_executor）读 payload["duration_seconds"] 重建
-    # 申请参数，不写回会在重启续传时按剧本原值而非本次实际申请的秒数记录版本元数据。
-    # 未偏移时两值相等，写回无意义，跳过省一次 DB 往返。持久化失败只降级为 resume 元数据
-    # 不够精确（仍回退到剧本原值，与本次改动前行为一致），不影响本次生成结果，不 fail-fast。
-    if task_id is not None and effective_duration != base_duration:
+    # 把实际申请的秒数写回 task payload：resume 路径（server.services.resume_executor）
+    # 读 payload["duration_seconds"] 重建申请参数，回退顺序是 payload > project.default_duration
+    # > 8。入队时（reference_videos 路由 / SDK 工具）payload 从不携带 duration_seconds，
+    # 不写回时回退到的是 project 默认时长，而非该 unit 自己的时长——二者不相等是常态，
+    # 不能仅在「取档偏移了剧本编排（adjustment != exact）」时才写回，未取档但仍偏离项目
+    # 默认值的 unit 同样需要。持久化失败只降级为 resume 元数据不够精确（回退到项目默认
+    # 时长，与本次改动前行为一致），不影响本次生成结果，不 fail-fast。
+    if task_id is not None:
         await _persist_effective_duration(task_id, effective_duration)
 
     # 6. 渲染 prompt。ad：镜头文本 + 裁剪后参考的 [图N] 对照表 + 保真/反向尾词。

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -18,6 +18,7 @@ from lib.asset_types import ASSET_SPECS, BUCKET_KEY, SHEET_KEY
 from lib.config.resolver import ConfigResolver, constrain_durations, get_provider_fallback
 from lib.db import async_session_factory
 from lib.db.base import DEFAULT_USER_ID
+from lib.generation_queue import get_generation_queue
 from lib.path_safety import safe_exists
 from lib.prompt_builders import append_product_fidelity_tail, append_video_negative_tail
 from lib.reference_video import assemble_shots_text, render_prompt_for_backend
@@ -47,8 +48,6 @@ async def _persist_effective_duration(task_id: str, duration_seconds: int) -> No
     非致命路径：持久化失败只降级 resume 元数据精度，不影响本次已在进行的生成，
     故只记日志、不上抛阻断 executor 主流程。
     """
-    from lib.generation_queue import get_generation_queue
-
     try:
         await get_generation_queue().persist_effective_duration(task_id, duration_seconds)
     except Exception:
@@ -222,25 +221,29 @@ class ProjectDurationContext:
     resolution: str | None
     provider_id: str
     model_name: str | None
+    max_duration: int | None = None
 
 
 async def resolve_project_duration_context(project: dict) -> ProjectDurationContext:
-    """一次性解析项目视频能力（档位全集 + 分辨率 + provider/model 身份）。
+    """一次性解析项目视频能力（档位全集 + 单次生成时长上限 + 分辨率 + provider/model 身份）。
 
     解析失败按空档位处理（沿用现状放行，不弹确认）；分辨率仅在档位非空时才解析，
-    空档位下分辨率约束无意义。
+    空档位下分辨率约束无意义。``max_duration`` 与 :func:`resolve_max_unit_duration`
+    取自同一份能力解析结果，供需要现推分组的调用方复用而不再触发一次 IO。
     """
     caps = await _project_video_caps(project, degraded_to="时长取档不施加档位约束")
     durations = tuple(int(d) for d in caps.get("supported_durations") or [])
     provider_id = str(caps.get("provider_id") or "")
     model = caps.get("model")
     model_name = str(model) if model else None
+    max_duration = caps.get("max_duration")
     resolution = await _project_video_resolution(project, provider_id, model_name) if durations else None
     return ProjectDurationContext(
         supported_durations=durations,
         resolution=resolution,
         provider_id=provider_id,
         model_name=model_name,
+        max_duration=int(max_duration) if max_duration else None,
     )
 
 

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -41,6 +41,20 @@ from server.services.generation_tasks import (
 logger = logging.getLogger(__name__)
 
 
+async def _persist_effective_duration(task_id: str, duration_seconds: int) -> None:
+    """把取档后实际申请的秒数写回 task payload，供 resume 路径读取（见调用点注释）。
+
+    非致命路径：持久化失败只降级 resume 元数据精度，不影响本次已在进行的生成，
+    故只记日志、不上抛阻断 executor 主流程。
+    """
+    from lib.generation_queue import get_generation_queue
+
+    try:
+        await get_generation_queue().persist_effective_duration(task_id, duration_seconds)
+    except Exception:
+        logger.warning("effective_duration 写回 payload 失败 task_id=%s", task_id, exc_info=True)
+
+
 def _resolve_unit_references(
     project: dict,
     project_path: Path,
@@ -504,6 +518,14 @@ async def execute_reference_video_task(
             registry_provider_id=registry_provider_id,
             resolution=resolution,
         )
+
+    # 取档偏移了剧本编排（adjustment != exact）时，把实际申请的秒数写回 task payload：
+    # resume 路径（server.services.resume_executor）读 payload["duration_seconds"] 重建
+    # 申请参数，不写回会在重启续传时按剧本原值而非本次实际申请的秒数记录版本元数据。
+    # 未偏移时两值相等，写回无意义，跳过省一次 DB 往返。持久化失败只降级为 resume 元数据
+    # 不够精确（仍回退到剧本原值，与本次改动前行为一致），不影响本次生成结果，不 fail-fast。
+    if task_id is not None and effective_duration != base_duration:
+        await _persist_effective_duration(task_id, effective_duration)
 
     # 6. 渲染 prompt。ad：镜头文本 + 裁剪后参考的 [图N] 对照表 + 保真/反向尾词。
     #    narration/drama：@→[图N] 替换——必须按 `constrained_refs` 的长度裁

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -1186,11 +1186,12 @@ async def test_execute_reference_video_task_persists_effective_duration_when_rou
     fake_queue.persist_effective_duration.assert_awaited_once_with("task-1", 8)
 
 
-async def test_execute_reference_video_task_skips_persisting_duration_when_unchanged(
+async def test_execute_reference_video_task_persists_duration_when_unchanged(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """未偏移（adjustment == exact）时不必写回，省一次 DB 往返。"""
+    """未偏移（adjustment == exact）时同样要写回：入队 payload 从不携带 duration_seconds，
+    不写回会让 resume 回退到 project.default_duration 而非该 unit 自己的时长。"""
     proj_dir = _write_project(tmp_path)
 
     from server.services import reference_video_tasks as rvt
@@ -1235,7 +1236,7 @@ async def test_execute_reference_video_task_skips_persisting_duration_when_uncha
         task_id="task-1",
     )
 
-    fake_queue.persist_effective_duration.assert_not_awaited()
+    fake_queue.persist_effective_duration.assert_awaited_once_with("task-1", 3)
 
 
 def test_apply_unit_video_assets_distinguishes_failures():

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -1129,6 +1129,115 @@ async def test_execute_reference_video_task_rounds_up_non_member_duration(
     assert warnings[0]["params"] == {"total": 5, "duration": 8, "model": "sora-2"}
 
 
+async def test_execute_reference_video_task_persists_effective_duration_when_rounded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """取档偏移剧本编排（adjustment != exact）时，effective_duration 写回 task payload，
+    供 resume 路径（``server.services.resume_executor``）读到与本次实际申请一致的秒数。
+    """
+    proj_dir = _write_project(tmp_path)
+    script_path = proj_dir / "scripts" / "episode_1.json"
+    script = json.loads(script_path.read_text(encoding="utf-8"))
+    script["video_units"][0]["shots"] = [{"duration": 5, "text": "Shot 1 (5s): @张三 推门"}]
+    script["video_units"][0]["duration_seconds"] = 5
+    script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
+
+    from server.services import reference_video_tasks as rvt
+
+    fake_pm = MagicMock()
+    fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
+    fake_pm.get_project_path.return_value = proj_dir
+    fake_pm.load_script.side_effect = lambda *_a: json.loads(script_path.read_text(encoding="utf-8"))
+    _wire_locked_script(fake_pm)
+    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
+
+    async def _fake_generate_video_async(**kwargs):
+        out = proj_dir / "reference_videos" / "E1U1.mp4"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\x00")
+        return out, 1, None, None
+
+    fake_generator = MagicMock()
+    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
+    _wire_context(
+        monkeypatch,
+        rvt,
+        fake_generator,
+        backend_name="openai",
+        backend_model="sora-2",
+        max_refs=9,
+        max_duration=12,
+        supported_durations=(4, 8, 12),
+    )
+
+    fake_queue = MagicMock()
+    fake_queue.persist_effective_duration = AsyncMock()
+    monkeypatch.setattr("lib.generation_queue.get_generation_queue", lambda: fake_queue)
+
+    await rvt.execute_reference_video_task(
+        "demo",
+        "E1U1",
+        {"script_file": "scripts/episode_1.json"},
+        user_id="u1",
+        task_id="task-1",
+    )
+
+    fake_queue.persist_effective_duration.assert_awaited_once_with("task-1", 8)
+
+
+async def test_execute_reference_video_task_skips_persisting_duration_when_unchanged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """未偏移（adjustment == exact）时不必写回，省一次 DB 往返。"""
+    proj_dir = _write_project(tmp_path)
+
+    from server.services import reference_video_tasks as rvt
+
+    fake_pm = MagicMock()
+    fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
+    fake_pm.get_project_path.return_value = proj_dir
+    fake_pm.load_script.side_effect = lambda *_a: json.loads(
+        (proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8")
+    )
+    _wire_locked_script(fake_pm)
+    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
+
+    async def _fake_generate_video_async(**kwargs):
+        out = proj_dir / "reference_videos" / "E1U1.mp4"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\x00")
+        return out, 1, None, None
+
+    fake_generator = MagicMock()
+    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
+    _wire_context(
+        monkeypatch,
+        rvt,
+        fake_generator,
+        backend_name="openai",
+        backend_model="sora-2",
+        max_refs=9,
+        max_duration=12,
+        supported_durations=(3, 8, 12),
+    )
+
+    fake_queue = MagicMock()
+    fake_queue.persist_effective_duration = AsyncMock()
+    monkeypatch.setattr("lib.generation_queue.get_generation_queue", lambda: fake_queue)
+
+    await rvt.execute_reference_video_task(
+        "demo",
+        "E1U1",
+        {"script_file": "scripts/episode_1.json"},
+        user_id="u1",
+        task_id="task-1",
+    )
+
+    fake_queue.persist_effective_duration.assert_not_awaited()
+
+
 def test_apply_unit_video_assets_distinguishes_failures():
     """结构损坏与 unit 不存在抛不同异常：还原侧据此区分「脏脚本告警」与「正常跳过」。
 

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -1173,7 +1173,7 @@ async def test_execute_reference_video_task_persists_effective_duration_when_rou
 
     fake_queue = MagicMock()
     fake_queue.persist_effective_duration = AsyncMock()
-    monkeypatch.setattr("lib.generation_queue.get_generation_queue", lambda: fake_queue)
+    monkeypatch.setattr(rvt, "get_generation_queue", lambda: fake_queue)
 
     await rvt.execute_reference_video_task(
         "demo",
@@ -1225,7 +1225,7 @@ async def test_execute_reference_video_task_skips_persisting_duration_when_uncha
 
     fake_queue = MagicMock()
     fake_queue.persist_effective_duration = AsyncMock()
-    monkeypatch.setattr("lib.generation_queue.get_generation_queue", lambda: fake_queue)
+    monkeypatch.setattr(rvt, "get_generation_queue", lambda: fake_queue)
 
     await rvt.execute_reference_video_task(
         "demo",

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -31,8 +31,14 @@ async def _seed_call(
     segment_id: str | None = None,
     output_path: str | None = None,
     usage_tokens: int | None = None,
+    cost_amount: float | None = None,
+    currency: str | None = None,
 ) -> None:
-    """直连 UsageRepository 写入一条已完成调用记录（等价于旧 UsageTracker 的种子写法）。"""
+    """直连 UsageRepository 写入一条已完成调用记录（等价于旧 UsageTracker 的种子写法）。
+
+    ``cost_amount`` 非空时绕过按 model 定价表的自动计算，直接结算为该值——用于不依赖
+    具体供应商定价配置、只关心分摊/聚合逻辑的用例（如 unit 费用按镜头摊回）。
+    """
     async with db_factory() as session:
         repo = UsageRepository(session)
         cid = await repo.start_call(
@@ -46,7 +52,7 @@ async def _seed_call(
         await repo.finish_call(
             cid,
             status="success",
-            settlement=SettlementInput(usage_tokens=usage_tokens),
+            settlement=SettlementInput(usage_tokens=usage_tokens, cost_amount=cost_amount, currency=currency),
             output_path=output_path,
         )
 
@@ -548,6 +554,45 @@ class TestCostEstimationService:
         ep_total = result["episodes"][0]["totals"]["estimate"]["video"][currency]
         assert round(sum(shares), 6) == ep_total
         assert ep_total == result["project_totals"]["estimate"]["video"][currency]
+
+    async def test_ad_reference_video_apportions_actual_cost_across_shots(self, db_factory):
+        """实际费用同样按 unit 分摊：usage 记录的 segment_id 是 unit ID，不是镜头 ID。
+
+        ``act_by_shot`` 这条链路此前零覆盖——只断言 estimate 侧无法区分「actual 按 unit
+        正确分摊」与「actual_by_segment.get(unit_id) 查询本身有误、恒为空」。
+        """
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        await _seed_call(
+            db_factory,
+            "ad-ref-actual",
+            "video",
+            "veo-3.1",
+            provider="veo",
+            segment_id="E1U1",
+            cost_amount=1.6,
+            currency="USD",
+        )
+
+        project_data = {
+            "title": "Ad",
+            "content_mode": "ad",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_ad_script(["E1S1", "E1S2", "E1S3"], [2, 2, 2])}
+
+        result = await service.compute(project_data, scripts, project_name="ad-ref-actual")
+
+        segments = result["episodes"][0]["segments"]
+        assert [seg["segment_id"] for seg in segments] == ["E1S1", "E1S2", "E1S3"]
+        shares = [seg["actual"]["video"]["USD"] for seg in segments]
+        assert all(shares), "actual_by_segment.get(unit_id) 查不到时分摊结果会全是空 dict"
+        assert round(sum(shares), 6) == 1.6
+        assert result["episodes"][0]["totals"]["actual"]["video"]["USD"] == pytest.approx(1.6)
+        assert result["project_totals"]["actual"]["video"]["USD"] == pytest.approx(1.6)
 
     async def test_ad_reference_video_estimate_uses_rounded_up_unit_duration(self, db_factory, monkeypatch):
         """取档向上的 unit：预估金额按取档后的秒数（8s）计，而非剧本原始总时长（5s）。

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -478,11 +478,11 @@ class TestCostEstimationService:
         assert result["episodes"][0]["segments"][0]["estimate"]["audio"] == {}
 
     async def test_ad_reference_video_skips_image_estimate(self, db_factory):
-        """ad + 参考生视频路径跳过分镜步骤：不产生分镜图估值，视频估值按 unit 颗粒度保留。
+        """ad + 参考生视频路径跳过分镜步骤：不产生分镜图估值，视频估值按 unit 计费后摊回镜头。
 
         两个镜头（4s + 6s）未受供应商时长上限约束，派生分组合并为同一个 reference_unit——
-        与实际生成/计费的颗粒度一致（``execute_reference_video_task`` 按 unit 整体送 provider，
-        不是逐镜头分别计费），故只产生 1 条 segment，而非 2 条镜头级 segment。
+        计费颗粒度与实际生成一致（``execute_reference_video_task`` 按 unit 整体送 provider，
+        不是逐镜头分别计费），但输出仍按镜头 ID 分条，前端才索引得到。
         """
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)
@@ -499,16 +499,21 @@ class TestCostEstimationService:
         result = await service.compute(project_data, scripts, project_name="ad-ref")
 
         segments = result["episodes"][0]["segments"]
-        assert len(segments) == 1
-        assert segments[0]["segment_id"] == "E1U1"
-        assert segments[0]["duration_seconds"] == 10
-        assert segments[0]["estimate"]["image"] == {}
-        assert segments[0]["estimate"]["video"]
+        assert [seg["segment_id"] for seg in segments] == ["E1S1", "E1S2"]
+        assert [seg["duration_seconds"] for seg in segments] == [4, 6]
+        for seg in segments:
+            assert seg["estimate"]["image"] == {}
+            assert seg["estimate"]["video"]
         assert result["project_totals"]["estimate"].get("image", {}) == {}
         assert result["project_totals"]["estimate"]["video"]
 
-    async def test_ad_reference_video_estimate_uses_rounded_up_unit_duration(self, db_factory, monkeypatch):
-        """取档向上的 unit：预估金额按取档后的秒数（8s）计，而非剧本原始总时长（5s）。"""
+    async def test_ad_reference_video_apportions_unit_cost_across_shots(self, db_factory, monkeypatch):
+        """unit 费用均摊到成员镜头，除不尽时余数补末镜，合计与 unit 原值分文不差。
+
+        3 个镜头分摊一笔按 8s 计的 unit 费用（USD 1.6 / 3 除不尽）：前两镜各取 6 位小数的
+        均值，末镜吃下余数，三者之和须等于按 unit 整体计费的原值——否则镜头数越多，
+        用户看到的项目总价偏离真实计费越远。
+        """
         import server.services.cost_estimation as cost_estimation_module
         from server.services.reference_video_tasks import ProjectDurationContext
 
@@ -529,12 +534,112 @@ class TestCostEstimationService:
             "target_duration": 30,
             "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
         }
+        scripts = {"ep1.json": _make_ad_script(["E1S1", "E1S2", "E1S3"], [2, 2, 2])}
+
+        result = await service.compute(project_data, scripts, project_name="ad-ref-split")
+
+        segments = result["episodes"][0]["segments"]
+        assert [seg["segment_id"] for seg in segments] == ["E1S1", "E1S2", "E1S3"]
+        currency = next(iter(segments[0]["estimate"]["video"]))
+        shares = [seg["estimate"]["video"][currency] for seg in segments]
+        assert shares[0] == shares[1], "除不尽时只有末镜与其它镜头不同"
+        assert shares[2] != shares[0], "余数应落在末镜上，否则合计会缺一截"
+        # 分摊后的合计 == 集合计 == 按 unit 整体计费的原值
+        ep_total = result["episodes"][0]["totals"]["estimate"]["video"][currency]
+        assert round(sum(shares), 6) == ep_total
+        assert ep_total == result["project_totals"]["estimate"]["video"][currency]
+
+    async def test_ad_reference_video_estimate_uses_rounded_up_unit_duration(self, db_factory, monkeypatch):
+        """取档向上的 unit：预估金额按取档后的秒数（8s）计，而非剧本原始总时长（5s）。
+
+        金额必须一起断言：只断言 ``duration_seconds`` 无法区分「按 8s 计价」与「秒数传对了
+        但定价查不到、估值静默为空」——后者在本函数里被吞成 debug 日志。
+        """
+        import server.services.cost_estimation as cost_estimation_module
+        from server.services.reference_video_tasks import ProjectDurationContext
+
+        def _patch_ctx(durations: tuple[int, ...]):
+            async def _fake_ctx(project):
+                return ProjectDurationContext(
+                    supported_durations=durations, resolution=None, provider_id="veo", model_name="veo-3.1"
+                )
+
+            monkeypatch.setattr(cost_estimation_module, "resolve_project_duration_context", _fake_ctx)
+
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Ad",
+            "content_mode": "ad",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
         scripts = {"ep1.json": _make_ad_script(["E1S1"], [5])}
 
-        result = await service.compute(project_data, scripts, project_name="ad-ref-round")
+        _patch_ctx((8,))
+        rounded = await service.compute(project_data, scripts, project_name="ad-ref-round")
+        # 对照组：无档位约束（unconstrained）时按剧本原始 5s 计，验证金额确实随取档后的秒数走
+        _patch_ctx(())
+        unconstrained = await service.compute(project_data, scripts, project_name="ad-ref-round")
 
-        seg = result["episodes"][0]["segments"][0]
-        assert seg["duration_seconds"] == 8
+        seg = rounded["episodes"][0]["segments"][0]
+        base_seg = unconstrained["episodes"][0]["segments"][0]
+        # 单镜头 unit：展示的是镜头自身编排时长（取档发生在 unit 级），两次都是剧本原值 5s
+        assert seg["segment_id"] == "E1S1"
+        assert seg["duration_seconds"] == 5
+        assert base_seg["duration_seconds"] == 5
+        assert seg["estimate"]["video"], "取档后仍应算出视频估值，空 dict 说明定价路径被静默吞掉"
+        assert base_seg["estimate"]["video"]
+        # 视频按秒计价，取档到 8s 的估值须严格高于按剧本 5s 的估值（低估用户实付正是本票要修的缺陷）
+        assert sum(seg["estimate"]["video"].values()) > sum(base_seg["estimate"]["video"].values())
+        assert seg["estimate"]["video"] == rounded["episodes"][0]["totals"]["estimate"]["video"]
+
+    async def test_ad_reference_video_fallback_derivation_applies_max_unit_duration(self, db_factory, monkeypatch):
+        """剧本尚未派生 reference_units 时，估算现推的分组与执行侧同受供应商时长上限约束。
+
+        不施加上限会把本该分成多个 unit 的镜头并成一个，取档命中最大档位后按一次计费，
+        总估值成倍偏低。上限取自同一份能力解析（``ProjectDurationContext.max_duration``），
+        不额外触发 IO。
+        """
+        import server.services.cost_estimation as cost_estimation_module
+        from server.services.reference_video_tasks import ProjectDurationContext
+
+        async def _fake_ctx(project):
+            return ProjectDurationContext(
+                supported_durations=(8,),
+                resolution=None,
+                provider_id="veo",
+                model_name="veo-3.1",
+                max_duration=8,
+            )
+
+        monkeypatch.setattr(cost_estimation_module, "resolve_project_duration_context", _fake_ctx)
+
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Ad",
+            "content_mode": "ad",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        # 三镜头共 18s，8s 上限下派生为 3 个 unit（6+6 超限，故逐镜一组）；无上限时会并成 1 个
+        scripts = {"ep1.json": _make_ad_script(["E1S1", "E1S2", "E1S3"], [6, 6, 6])}
+
+        result = await service.compute(project_data, scripts, project_name="ad-ref-maxdur")
+
+        segments = result["episodes"][0]["segments"]
+        assert [seg["segment_id"] for seg in segments] == ["E1S1", "E1S2", "E1S3"]
+        # 三个单镜头 unit 各按 8s 档位计费一次；若分组不受上限约束会并成 1 个 unit、
+        # 只计一次 8s（18s 超出最大档位取 DOWN），总额恰好是这里的三分之一
+        currency = next(iter(segments[0]["estimate"]["video"]))
+        per_unit = segments[0]["estimate"]["video"][currency]
+        assert [seg["estimate"]["video"][currency] for seg in segments] == [per_unit] * 3
+        assert result["episodes"][0]["totals"]["estimate"]["video"][currency] == round(per_unit * 3, 6)
 
     async def test_empty_episodes(self, db_factory):
         resolver = ConfigResolver(db_factory)

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -594,6 +594,57 @@ class TestCostEstimationService:
         assert result["episodes"][0]["totals"]["actual"]["video"]["USD"] == pytest.approx(1.6)
         assert result["project_totals"]["actual"]["video"]["USD"] == pytest.approx(1.6)
 
+    async def test_ad_reference_video_merges_shot_level_legacy_video_actual(self, db_factory):
+        """切换到 reference_video 前，某镜头已在 storyboard 模式产生过视频实付（按 shot_id
+        记账），切换后与 unit 分摊额是两笔独立支出，须相加而非互相替换。
+
+        只对其中一个镜头（E1S2）播历史视频费用，断言只有它的 actual.video 比其余镜头
+        多出这一截，其余镜头仍只有 unit 分摊份额——防止实现退化成「谁覆盖谁」。
+        """
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        await _seed_call(
+            db_factory,
+            "ad-ref-legacy-video",
+            "video",
+            "veo-3.1",
+            provider="veo",
+            segment_id="E1U1",
+            cost_amount=1.5,
+            currency="USD",
+        )
+        await _seed_call(
+            db_factory,
+            "ad-ref-legacy-video",
+            "video",
+            "sora-2",
+            provider="openai",
+            segment_id="E1S2",
+            cost_amount=0.4,
+            currency="USD",
+        )
+
+        project_data = {
+            "title": "Ad",
+            "content_mode": "ad",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_ad_script(["E1S1", "E1S2", "E1S3"], [2, 2, 2])}
+
+        result = await service.compute(project_data, scripts, project_name="ad-ref-legacy-video")
+
+        segments = {seg["segment_id"]: seg for seg in result["episodes"][0]["segments"]}
+        apportioned_share = segments["E1S1"]["actual"]["video"]["USD"]
+        assert segments["E1S3"]["actual"]["video"]["USD"] == pytest.approx(apportioned_share)
+        assert segments["E1S2"]["actual"]["video"]["USD"] == pytest.approx(apportioned_share + 0.4)
+        # 集/项目合计须把这笔历史支出也算进去，不能因为它挂在 shot_id 下就被漏计
+        ep_total = result["episodes"][0]["totals"]["actual"]["video"]["USD"]
+        assert ep_total == pytest.approx(1.5 + 0.4)
+        assert result["project_totals"]["actual"]["video"]["USD"] == pytest.approx(1.5 + 0.4)
+
     async def test_ad_reference_video_estimate_uses_rounded_up_unit_duration(self, db_factory, monkeypatch):
         """取档向上的 unit：预估金额按取档后的秒数（8s）计，而非剧本原始总时长（5s）。
 

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -478,7 +478,12 @@ class TestCostEstimationService:
         assert result["episodes"][0]["segments"][0]["estimate"]["audio"] == {}
 
     async def test_ad_reference_video_skips_image_estimate(self, db_factory):
-        """ad + 参考生视频路径跳过分镜步骤：不产生分镜图估值，视频估值保留。"""
+        """ad + 参考生视频路径跳过分镜步骤：不产生分镜图估值，视频估值按 unit 颗粒度保留。
+
+        两个镜头（4s + 6s）未受供应商时长上限约束，派生分组合并为同一个 reference_unit——
+        与实际生成/计费的颗粒度一致（``execute_reference_video_task`` 按 unit 整体送 provider，
+        不是逐镜头分别计费），故只产生 1 条 segment，而非 2 条镜头级 segment。
+        """
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)
 
@@ -494,12 +499,42 @@ class TestCostEstimationService:
         result = await service.compute(project_data, scripts, project_name="ad-ref")
 
         segments = result["episodes"][0]["segments"]
-        assert len(segments) == 2
-        for seg in segments:
-            assert seg["estimate"]["image"] == {}, seg
-            assert seg["estimate"]["video"], seg
+        assert len(segments) == 1
+        assert segments[0]["segment_id"] == "E1U1"
+        assert segments[0]["duration_seconds"] == 10
+        assert segments[0]["estimate"]["image"] == {}
+        assert segments[0]["estimate"]["video"]
         assert result["project_totals"]["estimate"].get("image", {}) == {}
         assert result["project_totals"]["estimate"]["video"]
+
+    async def test_ad_reference_video_estimate_uses_rounded_up_unit_duration(self, db_factory, monkeypatch):
+        """取档向上的 unit：预估金额按取档后的秒数（8s）计，而非剧本原始总时长（5s）。"""
+        import server.services.cost_estimation as cost_estimation_module
+        from server.services.reference_video_tasks import ProjectDurationContext
+
+        async def _fake_ctx(project):
+            return ProjectDurationContext(
+                supported_durations=(8,), resolution=None, provider_id="veo", model_name="veo-3.1"
+            )
+
+        monkeypatch.setattr(cost_estimation_module, "resolve_project_duration_context", _fake_ctx)
+
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Ad",
+            "content_mode": "ad",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_ad_script(["E1S1"], [5])}
+
+        result = await service.compute(project_data, scripts, project_name="ad-ref-round")
+
+        seg = result["episodes"][0]["segments"][0]
+        assert seg["duration_seconds"] == 8
 
     async def test_empty_episodes(self, db_factory):
         resolver = ConfigResolver(db_factory)

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -514,7 +514,7 @@ class TestCostEstimationService:
         均值，末镜吃下余数，三者之和须等于按 unit 整体计费的原值——否则镜头数越多，
         用户看到的项目总价偏离真实计费越远。
         """
-        import server.services.cost_estimation as cost_estimation_module
+        from server.services import cost_estimation as cost_estimation_module
         from server.services.reference_video_tasks import ProjectDurationContext
 
         async def _fake_ctx(project):
@@ -555,7 +555,7 @@ class TestCostEstimationService:
         金额必须一起断言：只断言 ``duration_seconds`` 无法区分「按 8s 计价」与「秒数传对了
         但定价查不到、估值静默为空」——后者在本函数里被吞成 debug 日志。
         """
-        import server.services.cost_estimation as cost_estimation_module
+        from server.services import cost_estimation as cost_estimation_module
         from server.services.reference_video_tasks import ProjectDurationContext
 
         def _patch_ctx(durations: tuple[int, ...]):
@@ -603,7 +603,7 @@ class TestCostEstimationService:
         总估值成倍偏低。上限取自同一份能力解析（``ProjectDurationContext.max_duration``），
         不额外触发 IO。
         """
-        import server.services.cost_estimation as cost_estimation_module
+        from server.services import cost_estimation as cost_estimation_module
         from server.services.reference_video_tasks import ProjectDurationContext
 
         async def _fake_ctx(project):

--- a/tests/test_task_repo.py
+++ b/tests/test_task_repo.py
@@ -554,6 +554,49 @@ class TestPersistApiCallId:
         assert task["payload"] == {"api_call_id": 99}
 
 
+class TestPersistEffectiveDuration:
+    """persist_effective_duration：read-modify-write 写入 task.payload["duration_seconds"]。"""
+
+    async def _enqueue(self, repo: TaskRepository, *, payload=None) -> str:
+        if payload is None:
+            payload = {"duration_seconds": 5}
+        result = await repo.enqueue(
+            project_name="demo",
+            task_type="reference_video",
+            media_type="video",
+            resource_id="E1U1",
+            payload=payload,
+            script_file="ep1.json",
+        )
+        return result["task_id"]
+
+    async def test_persist_overwrites_duration_seconds_in_payload(self, db_session):
+        repo = TaskRepository(db_session)
+        task_id = await self._enqueue(repo, payload={"duration_seconds": 5, "prompt": "p"})
+
+        await repo.persist_effective_duration(task_id, 8)
+
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["payload"]["duration_seconds"] == 8
+        assert task["payload"]["prompt"] == "p", "其它 payload 字段不应被覆盖"
+
+    async def test_persist_handles_empty_payload(self, db_session):
+        repo = TaskRepository(db_session)
+        task_id = await self._enqueue(repo, payload={})
+
+        await repo.persist_effective_duration(task_id, 8)
+
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["payload"] == {"duration_seconds": 8}
+
+    async def test_persist_silently_skips_when_task_not_found(self, db_session):
+        """metadata-only 写回：task 不存在时静默跳过，不 fail-fast（与 persist_api_call_id 不同）。"""
+        repo = TaskRepository(db_session)
+        await repo.persist_effective_duration("nonexistent-task-id", 8)
+
+
 class TestCancelCascadeAcrossCancelling:
     """fix #647 #4：cancel 级联跨过 cancelling 节点，A(running)→B(queued)→C(queued)
     在 A 落 cancelled 时通过 finalize_cancelled 自动级联到 B/C。"""


### PR DESCRIPTION
Closes #1456

## 改动

两处时长数据此前未复用取档规则，导致预估金额与用户实付、以及 resume 记录的元数据与实际申请秒数对不上。

- **费用预估按取档后的时长计算。** 参考视频按 `reference_unit` 整体送供应商、一次申请取档后的秒数，故预估也按 unit 取档后计费；算出的费用再均摊回成员镜头展示（与宫格模式「按宫格计费、分摊到镜头展示」口径一致），除不尽的余数补给末镜，保证分摊合计与原值分文不差。实际费用同样按 unit 分摊——用量记录本就按 unit 存，此前按镜头匹配恒为空。
- **现推分组带上时长上限。** 用户尚未打开过参考视频面板时估算需现推一份分组，此前不带供应商时长上限，多个 unit 会被并成一个、取档后只计一次费，总额成倍偏低；现在与执行侧取自同一份能力解析，不额外查询。
- **分组索引过期的 unit 整体跳过**，不再落到 8 秒兜底产生一笔查无实据的费用。
- **实际申请的秒数写回任务记录**，取档偏移时 resume 据此记录版本元数据；未偏移时跳过写入。持久化失败只记日志，不打断已在进行的生成。

## 验证

- `uv run python -m pytest` 6806 passed
- `uv run ruff check . && uv run ruff format --check .` 全绿
- `uv run basedpyright` 0 error
- 新增覆盖：取档向上按档位秒数计价（含金额断言，不只断言秒数）、无档位约束时维持原值计价、unit 费用均摊除不尽时的余数落点与合计守恒、现推分组受时长上限约束

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在参考视频计费中按计费单元估算，并把估算与实际费用均按分摊规则精确落到镜头，同时统一汇总到 episode/project。
  - 新增有效时长的持久化能力，生成流程会把“实际有效生成时长”写回任务以增强恢复一致性。
  - 支持计费/分组的时长上限配置（max_duration）以约束单元推导与计费口径。
- **错误修复**
  - 当任务不存在时，写入有效时长改为静默跳过，避免中断主流程。
- **测试**
  - 增强参考视频费用分摊、取档计价、时长上限与有效时长写回的回归覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->