### PR TITLE
fix(cost-estimation): 参考视频的实付费用可按镜头查看

### DIFF
--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -621,7 +621,7 @@ class MediaGenerator:
             # 记账 provider 取解析层 provider_id；成对不变量保证 backend 非 None 时 provider_id 亦非 None。
             provider=cast(str, self._video_provider_id),
             user_id=self._user_id,
-            segment_id=resource_id if resource_type in ("storyboards", "videos") else None,
+            segment_id=resource_id if resource_type in ("storyboards", "videos", "reference_videos") else None,
             service_tier=version_metadata.get("service_tier", "default"),
             output_path=str(output_path),
         ) as call:

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -385,12 +385,11 @@ class CostEstimationService:
         算出的 unit 费用再均摊回成员镜头输出，与 grid 模式「按 grid 计费、分摊到 scene
         展示」的口径同构：前端按镜头 ID 索引 segment（``frontend/src/stores/cost-store.ts``），
         输出 unit ID 会让镜头面板查不到费用。除不尽的余数补给末镜，保证分摊后的合计与
-        unit 原值分文不差。视频实付按 unit 分摊（读 ``actual_by_segment[unit_id]``——注：
-        ``lib/media_generator.py`` 目前只对 ``resource_type in ("storyboards", "videos")``
-        写入 usage 的 segment_id，``reference_videos`` 调用不在其中，故这一读取现状恒空，
-        是独立于本函数的既有缺口，不在本次改动范围内），与 shot_id 记账的历史视频实付
-        合并而非互相替换：项目若曾在 storyboard 模式为该镜头生成过视频、之后切到
-        reference_video，这笔旧支出与新 unit 的分摊额都要计入。图片/音频实付同样按
+        unit 原值分文不差。视频实付按 unit 分摊（读 ``actual_by_segment[unit_id]``，
+        ``lib/media_generator.py`` 对 ``resource_type == "reference_videos"`` 的记账
+        以 unit_id 写入 usage 的 segment_id，与本函数的分摊口径一致），与 shot_id 记账的
+        历史视频实付合并而非互相替换：项目若曾在 storyboard 模式为该镜头生成过视频、之后
+        切到 reference_video，这笔旧支出与新 unit 的分摊额都要计入。图片/音频实付同样按
         shot_id 原样回填（不受 unit 分摊影响）：切换模式前产生的镜头图/配音费用仍需展示。
 
         分组优先读剧本已持久化的 ``reference_units``（与执行时同一份索引，见

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -218,6 +218,7 @@ class TestMediaGenerator:
         assert version2 == 2
         assert gen.ledger.started[-1]["call_type"] == "video"
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_generate_video_async_segment_id_by_resource_type(self, tmp_path):
         """视频记账 segment_id 白名单覆盖 storyboards/videos/reference_videos，其余落 None。"""
@@ -228,6 +229,11 @@ class TestMediaGenerator:
 
         await gen.generate_video_async(prompt="p", resource_type="reference_videos", resource_id="E1U1")
         assert gen.ledger.started[-1]["segment_id"] == "E1U1"
+
+        # 负向边界：白名单外的 resource_type 仍落 None——守住"白名单"语义，
+        # 避免日后被改成无条件透传而无人察觉。grids 只在图片记账白名单内。
+        await gen.generate_video_async(prompt="p", resource_type="grids", resource_id="E1G1")
+        assert gen.ledger.started[-1]["segment_id"] is None
 
     @pytest.mark.asyncio
     async def test_video_billed_duration_passed_to_finish_call(self, tmp_path):

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -219,6 +219,17 @@ class TestMediaGenerator:
         assert gen.ledger.started[-1]["call_type"] == "video"
 
     @pytest.mark.asyncio
+    async def test_generate_video_async_segment_id_by_resource_type(self, tmp_path):
+        """视频记账 segment_id 白名单覆盖 storyboards/videos/reference_videos，其余落 None。"""
+        gen = _build_generator(tmp_path)
+
+        await gen.generate_video_async(prompt="p", resource_type="videos", resource_id="E1S01")
+        assert gen.ledger.started[-1]["segment_id"] == "E1S01"
+
+        await gen.generate_video_async(prompt="p", resource_type="reference_videos", resource_id="E1U1")
+        assert gen.ledger.started[-1]["segment_id"] == "E1U1"
+
+    @pytest.mark.asyncio
     async def test_video_billed_duration_passed_to_finish_call(self, tmp_path):
         """backend 返回与请求不同的实际计费时长时，视频路径透传给 finish_call。"""
         gen = _build_generator(tmp_path)


### PR DESCRIPTION
Closes #1467

## 问题

参考视频生成的实付记账没写 `segment_id`，导致费用预估页里参考视频模式的逐镜头「实际费用」恒为空——这笔支出既不落在任何镜头上，也不进项目总额，等于在页面上完全不可见。

## 改动

- `lib/media_generator.py` 视频记账的 `segment_id` 白名单纳入 `reference_videos`。其 `resource_id` 即 unit_id（`reference_video_tasks.py` 在调用前用 `unit_id` 反查单元并对不上时报错，键相等由代码保证而非仅靠注释），与费用预估按 unit 匹配再分摊回成员镜头的口径天然一致，无需转换。
- 同步更新 `server/services/cost_estimation.py` 中一段过时注释——它记录的正是本次补上的缺口，不再保留失效描述。
- 记账 schema、`ledger.record` 其余参数、既有 `storyboards`/`videos` 路径均未改动；存量记录不回填。

## 验证

- 新增 `tests/test_media_generator_module.py::test_generate_video_async_segment_id_by_resource_type`：覆盖 `videos`/`reference_videos` 正向落 segment_id，以及白名单外类型仍落 `None` 的负向边界（防止日后被改成无条件透传而无人察觉）。
- 费用预估侧的读取分摊由既有 `tests/test_cost_estimation_service.py` 覆盖，全绿。
- 质量门：`ruff check` + `ruff format --check` 通过；`basedpyright` 0 error；`pytest` 6821 passed。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 视频与参考视频的用量记录现可正确关联对应资源，提升成本分摊数据的准确性。
  * 其他资源类型仍按原有规则处理，不受影响。

* **测试**
  * 新增多种资源类型的覆盖测试，验证关联标识记录及边界行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->