### PR TITLE
fix(tasks): 参考图跳过警示中的资产类型显示本地化名称

### DIFF
--- a/lib/asset_types.py
+++ b/lib/asset_types.py
@@ -29,6 +29,9 @@ class AssetSpec:
 
     ``in_global_library`` 控制该类型是否进入跨项目全局资产库（assets 表）：库的
     单图列模型只兼容「一资产一图」的类型，多图列表型资产（product）暂不进入。
+
+    ``label_zh`` 服务 logger 与 agent 侧字符串（两者按 i18n 规范豁免翻译）；
+    面向用户的资产类型显示名走 ``lib/i18n`` 的 ``asset_type_*`` key，不复用此字段。
     """
 
     asset_type: str

--- a/lib/i18n/en/assets.py
+++ b/lib/i18n/en/assets.py
@@ -9,4 +9,8 @@ MESSAGES = {
     "asset_load_project_failed": "failed to load target project",
     "asset_invalid_conflict_policy": "conflict_policy must be skip / overwrite / rename",
     "asset_invalid_name": "Asset name '{name}' is invalid: characters like / \\ : * ? \" < > |, control characters, .., a trailing dot, or Windows reserved names (e.g. CON) are not allowed",
+    "asset_type_character": "character",
+    "asset_type_scene": "scene",
+    "asset_type_prop": "prop",
+    "asset_type_product": "product",
 }

--- a/lib/i18n/vi/assets.py
+++ b/lib/i18n/vi/assets.py
@@ -9,4 +9,8 @@ MESSAGES = {
     "asset_load_project_failed": "Không tải được dự án đích",
     "asset_invalid_conflict_policy": "conflict_policy phải là skip / overwrite / rename",
     "asset_invalid_name": "Tên tài nguyên '{name}' không hợp lệ: không cho phép các ký tự như / \\ : * ? \" < > |, ký tự điều khiển, .., dấu chấm ở cuối hoặc tên dành riêng của Windows (ví dụ CON)",
+    "asset_type_character": "nhân vật",
+    "asset_type_scene": "cảnh",
+    "asset_type_prop": "đạo cụ",
+    "asset_type_product": "sản phẩm",
 }

--- a/lib/i18n/zh/assets.py
+++ b/lib/i18n/zh/assets.py
@@ -9,4 +9,8 @@ MESSAGES = {
     "asset_load_project_failed": "加载目标项目失败",
     "asset_invalid_conflict_policy": "冲突策略必须为 skip / overwrite / rename",
     "asset_invalid_name": '资产名「{name}」无效：不允许 / \\ : * ? " < > | 等字符、控制字符、..、以点结尾或 Windows 保留名（如 CON）',
+    "asset_type_character": "角色",
+    "asset_type_scene": "场景",
+    "asset_type_prop": "道具",
+    "asset_type_product": "产品",
 }

--- a/server/routers/tasks.py
+++ b/server/routers/tasks.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 from fastapi import APIRouter, Query
 
 from lib.api_errors import BadRequestError, NotFoundError
+from lib.asset_types import ASSET_SPECS
 from lib.generation_queue import get_generation_queue
 from lib.i18n import Translator
 from lib.task_failure import render_failure
@@ -20,6 +21,22 @@ router = APIRouter()
 
 def get_task_queue():
     return get_generation_queue()
+
+
+# warning key -> 其 params 中需要把内部资产类型标识替换为本地化显示名的字段名。
+_WARNING_ASSET_TYPE_PARAMS: dict[str, str] = {"ref_ad_reference_skipped": "type"}
+
+
+def _localize_warning_params(key: str, params: dict[str, Any], translate: Callable[..., str]) -> dict[str, Any]:
+    """把 params 中裸的资产类型标识（如 ``"product"``）替换为当前语言显示名。
+
+    只处理已登记 warning key 的已知字段；未登记的类型值（不在 ``ASSET_SPECS`` 中）
+    原样透传，不做语义映射。
+    """
+    field = _WARNING_ASSET_TYPE_PARAMS.get(key)
+    if field is None or params.get(field) not in ASSET_SPECS:
+        return params
+    return {**params, field: translate(f"asset_type_{params[field]}")}
 
 
 def _render_warnings(warnings: Any, translate: Callable[..., str]) -> list[str]:
@@ -39,6 +56,8 @@ def _render_warnings(warnings: Any, translate: Callable[..., str]) -> list[str]:
         if not isinstance(key, str):
             continue
         params = entry.get("params")
+        if isinstance(params, dict):
+            params = _localize_warning_params(key, cast(dict[str, Any], params), translate)
         try:
             text = translate(key, **cast(dict[str, Any], params)) if isinstance(params, dict) else translate(key)
         except TypeError:

--- a/server/routers/tasks.py
+++ b/server/routers/tasks.py
@@ -24,19 +24,23 @@ def get_task_queue():
 
 
 # warning key -> 其 params 中需要把内部资产类型标识替换为本地化显示名的字段名。
-_WARNING_ASSET_TYPE_PARAMS: dict[str, str] = {"ref_ad_reference_skipped": "type"}
+_ASSET_TYPE_PARAM_BY_WARNING: dict[str, str] = {"ref_ad_reference_skipped": "type"}
 
 
 def _localize_warning_params(key: str, params: dict[str, Any], translate: Callable[..., str]) -> dict[str, Any]:
     """把 params 中裸的资产类型标识（如 ``"product"``）替换为当前语言显示名。
 
-    只处理已登记 warning key 的已知字段；未登记的类型值（不在 ``ASSET_SPECS`` 中）
-    原样透传，不做语义映射。
+    只处理已登记 warning key 的已知字段；未登记的类型值（非字符串，或不在
+    ``ASSET_SPECS`` 中）原样透传，不做语义映射——``isinstance`` 守卫同时挡住
+    畸形持久化值（如 list）落进 ``in ASSET_SPECS`` 抛 ``TypeError``。
     """
-    field = _WARNING_ASSET_TYPE_PARAMS.get(key)
-    if field is None or params.get(field) not in ASSET_SPECS:
+    field = _ASSET_TYPE_PARAM_BY_WARNING.get(key)
+    if field is None:
         return params
-    return {**params, field: translate(f"asset_type_{params[field]}")}
+    value = params.get(field)
+    if not isinstance(value, str) or value not in ASSET_SPECS:
+        return params
+    return {**params, field: translate(f"asset_type_{value}")}
 
 
 def _render_warnings(warnings: Any, translate: Callable[..., str]) -> list[str]:

--- a/tests/server/test_task_localization.py
+++ b/tests/server/test_task_localization.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from lib.asset_types import ASSET_SPECS
 from lib.i18n import _ as translate_message
 from lib.task_failure import encode_failure
 from server.routers.tasks import _localize_task
@@ -83,8 +84,17 @@ class TestWarningRendering:
         vi = _localize_task(task, _translator("vi"))["result"]["warnings"][0]
 
         assert "产品" in zh and "product" not in zh
-        assert "product" in en
+        # en 显示名与内部标识同形，只能断言整句渲染结果，不能靠 "product" 是否出现区分
+        assert en == translate_message("ref_ad_reference_skipped", locale="en", name="小美", type="product")
         assert "sản phẩm" in vi
+
+    @pytest.mark.parametrize("asset_type", sorted(ASSET_SPECS))
+    @pytest.mark.parametrize("locale", ["zh", "en", "vi"])
+    def test_every_asset_type_has_a_display_name(self, asset_type: str, locale: str):
+        """新增资产类型时若漏加 ``asset_type_*``，i18n 会回落成 key 本身，比原样透传更糟。"""
+        rendered = translate_message(f"asset_type_{asset_type}", locale=locale)
+
+        assert rendered != f"asset_type_{asset_type}"
 
     def test_unregistered_asset_type_falls_through_unmapped(self):
         task = _task(
@@ -94,6 +104,16 @@ class TestWarningRendering:
         rendered = _localize_task(task, _translator("zh"))["result"]["warnings"][0]
 
         assert "widget" in rendered
+
+    def test_malformed_asset_type_value_does_not_raise(self):
+        """畸形持久化值（非字符串）不该让整个任务列表 500，与本模块其余容错口径一致。"""
+        task = _task(
+            result={"warnings": [{"key": "ref_ad_reference_skipped", "params": {"type": ["product"], "name": "小美"}}]}
+        )
+
+        rendered = _localize_task(task, _translator("zh"))["result"]["warnings"][0]
+
+        assert "product" in rendered
 
     def test_input_task_is_not_mutated(self):
         warnings = [{"key": "ref_sora_single_ref", "params": {}}]

--- a/tests/server/test_task_localization.py
+++ b/tests/server/test_task_localization.py
@@ -73,6 +73,28 @@ class TestWarningRendering:
         assert rendered[0].startswith("Sora")
         assert "小美" in rendered[1]
 
+    def test_asset_type_in_skipped_reference_warning_is_localized(self):
+        task = _task(
+            result={"warnings": [{"key": "ref_ad_reference_skipped", "params": {"type": "product", "name": "小美"}}]}
+        )
+
+        zh = _localize_task(task, _translator("zh"))["result"]["warnings"][0]
+        en = _localize_task(task, _translator("en"))["result"]["warnings"][0]
+        vi = _localize_task(task, _translator("vi"))["result"]["warnings"][0]
+
+        assert "产品" in zh and "product" not in zh
+        assert "product" in en
+        assert "sản phẩm" in vi
+
+    def test_unregistered_asset_type_falls_through_unmapped(self):
+        task = _task(
+            result={"warnings": [{"key": "ref_ad_reference_skipped", "params": {"type": "widget", "name": "小美"}}]}
+        )
+
+        rendered = _localize_task(task, _translator("zh"))["result"]["warnings"][0]
+
+        assert "widget" in rendered
+
     def test_input_task_is_not_mutated(self):
         warnings = [{"key": "ref_sora_single_ref", "params": {}}]
         task = _task(result={"warnings": warnings})


### PR DESCRIPTION
Closes #1468

## 变更

参考视频「缺少可用参考图」警示中的资产类型不再显示内部标识：中文用户看到「（产品）」而非「（product）」。

- `lib/i18n/{zh,en,vi}/assets.py` 新增 `asset_type_character/scene/prop/product` 三语显示名
- `server/routers/tasks.py` 在响应本地化层把 `ref_ad_reference_skipped` 的 `type` 参数替换为当前语言显示名；未登记的类型值原样透传
- `lib/asset_types.py` 补注 `label_zh` 与 i18n 显示名的职责边界（agent/日志侧 vs 用户侧），避免后续再复制一份中文标签

warnings 的 `{key, params}` 持久化结构、渲染管道与 `ASSET_SPECS.label_zh` 的现有消费方均未改动。

## 验证

- `uv run python -m pytest` — 6835 passed（含 `tests/test_i18n_consistency.py` 三语 key 一致性）
- `uv run ruff check . && uv run ruff format .`、`uv run basedpyright` — 0 error
- 新增测试：三语渲染结果、未登记类型透传、每个 `ASSET_SPECS` 类型在三语下均有显示名（防止将来新增类型漏配 key 时回落成 `asset_type_xxx`）、畸形参数值不中断整页渲染


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 任务警告中的资产类型现在会根据当前语言显示本地化名称。
  * 支持中文、英文和越南文的角色、场景、道具及产品等资产类型名称。
* **错误修复**
  * 改善异常或未知资产类型参数的兼容性，避免影响警告信息展示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->