### PR TITLE
fix(cost-estimation): 说书/剧集模式参考生视频的费用预估补上视频项

### DIFF
--- a/lib/cost_calculator.py
+++ b/lib/cost_calculator.py
@@ -60,6 +60,10 @@ class CostCalculator:
         # estimate_reference_video_cost，传真实累计时长（可为 0），不经此默认。
         if isinstance(pricing, (PerSecondMatrix, PerSecondTiered)) and not params.duration_seconds:
             params = replace(params, duration_seconds=8)
+        # 按 token 计费的视频（Ark/Seedance）：调用方只传了时长、未预先换算 token 时按估算
+        # 近似值换算，否则该模型的预估恒为 0（实际调用仍由生成回调覆盖为真实 token 用量）。
+        if isinstance(pricing, PerTokenVideo) and params.usage_tokens is None and params.duration_seconds:
+            params = replace(params, usage_tokens=params.duration_seconds * self._ARK_TOKENS_PER_SECOND_ESTIMATE)
         return calculate_pricing(pricing, params)
 
     def estimate_reference_video_cost(

--- a/lib/cost_calculator.py
+++ b/lib/cost_calculator.py
@@ -33,11 +33,17 @@ class CostCalculator:
         custom_price_input: float | None = None,
         custom_price_output: float | None = None,
         custom_currency: str | None = None,
+        estimate_only: bool = False,
     ) -> tuple[float, str]:
         """统一费用计算入口。调用方直接构造 ``PricingParams`` 传入，返回 ``(amount, currency)``。
 
         自定义供应商的价格信息通过 ``custom_price_*`` 参数传入（调用方需预先查询 DB）；
         它们是 DB 侧的价格来源、非定价形状维度，故不并入 ``PricingParams``。
+
+        ``estimate_only``：调用方明确只是预估（非真实调用结算）时置 True，允许对缺失的
+        ``usage_tokens`` 做近似换算兜底。真实调用的费用结算（``UsageRepository._settle``）
+        必须保持默认 False——provider 成功响应但漏报 usage 是真实的数据缺陷，结算侧应如实
+        按 0 处理，不能用估算近似值掩盖，否则会把预估口径的近似值悄悄写成实际支出记录。
         """
         if is_custom_provider(provider):
             return self._calculate_custom_cost(
@@ -60,9 +66,15 @@ class CostCalculator:
         # estimate_reference_video_cost，传真实累计时长（可为 0），不经此默认。
         if isinstance(pricing, (PerSecondMatrix, PerSecondTiered)) and not params.duration_seconds:
             params = replace(params, duration_seconds=8)
-        # 按 token 计费的视频（Ark/Seedance）：调用方只传了时长、未预先换算 token 时按估算
-        # 近似值换算，否则该模型的预估恒为 0（实际调用仍由生成回调覆盖为真实 token 用量）。
-        if isinstance(pricing, PerTokenVideo) and params.usage_tokens is None and params.duration_seconds:
+        # 按 token 计费的视频（Ark/Seedance）：仅预估场景下，调用方只传了时长、未预先换算
+        # token 时按估算近似值换算，否则该模型的预估恒为 0。真实结算场景不做这层兜底，见
+        # ``estimate_only`` 参数说明。
+        if (
+            estimate_only
+            and isinstance(pricing, PerTokenVideo)
+            and params.usage_tokens is None
+            and params.duration_seconds
+        ):
             params = replace(params, usage_tokens=params.duration_seconds * self._ARK_TOKENS_PER_SECOND_ESTIMATE)
         return calculate_pricing(pricing, params)
 

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -238,14 +238,19 @@ class CostEstimationService:
             # 颗粒度（``_estimate_unit_reference_video_episode``）。
             #
             # ad 骨架唯一、shots 不打 generation_mode 戳，生成路径以项目级/集级戳为真相源，故
-            # 只按 ``effective_mode`` 判定；narration/drama 的生成侧按剧本戳判定（见
-            # ``server/agent_runtime/sdk_tools/enqueue_videos.py``），项目已切到 reference_video
-            # 但该集剧本仍是分镜骨架时实际入队的还是分镜任务，估算随之沿用分镜路径，不按尚不
-            # 存在的 units 归零。
+            # 只按 ``effective_mode`` 判定；narration/drama 的生成侧按剧本自身的 generation_mode
+            # 戳判定（``server/agent_runtime/sdk_tools/enqueue_videos.py::_is_reference_script``），
+            # 项目已切到 reference_video 但该集剧本仍是分镜骨架（戳缺失/非 reference_video）时
+            # 实际入队的还是分镜任务，估算须按同一戳回落分镜路径——不能只看 video_units 是否
+            # 非空：剧本可能残留切换前/迁移中间态的 video_units，戳仍是分镜骨架时那份数据不是
+            # 真相源，若照旧估值会与实际入队的分镜任务对不上。
             is_reference_video = effective_mode(project=project_data, episode=ep_meta) == "reference_video"
             raw_units = script.get("video_units")
             video_units: list[Any] = raw_units if isinstance(raw_units, list) else []
-            estimate_by_unit = is_reference_video and (content_mode == "ad" or bool(video_units))
+            if content_mode == "ad":
+                estimate_by_unit = is_reference_video
+            else:
+                estimate_by_unit = is_reference_video and script.get("generation_mode") == "reference_video"
 
             if estimate_by_unit:
                 if duration_ctx is None:

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -238,19 +238,18 @@ class CostEstimationService:
             # 颗粒度（``_estimate_unit_reference_video_episode``）。
             #
             # ad 骨架唯一、shots 不打 generation_mode 戳，生成路径以项目级/集级戳为真相源，故
-            # 只按 ``effective_mode`` 判定；narration/drama 的生成侧按剧本自身的 generation_mode
-            # 戳判定（``server/agent_runtime/sdk_tools/enqueue_videos.py::_is_reference_script``），
-            # 项目已切到 reference_video 但该集剧本仍是分镜骨架（戳缺失/非 reference_video）时
-            # 实际入队的还是分镜任务，估算须按同一戳回落分镜路径——不能只看 video_units 是否
-            # 非空：剧本可能残留切换前/迁移中间态的 video_units，戳仍是分镜骨架时那份数据不是
-            # 真相源，若照旧估值会与实际入队的分镜任务对不上。
+            # 只按 ``effective_mode`` 判定；narration/drama 的生成侧只认剧本自身的 generation_mode
+            # 戳（``server/agent_runtime/sdk_tools/enqueue_videos.py::_is_reference_script``），从不
+            # 读 ``effective_mode``，估算须跟同一口径——项目/集事后经 PATCH 把 effective_mode 改回
+            # storyboard、但该集剧本仍保留切换前的 reference_video 戳时，实际入队仍按剧本戳走 unit
+            # 路径，估算若再叠加 ``effective_mode`` 门槛会误判回落分镜，与实际生成对不上。
             is_reference_video = effective_mode(project=project_data, episode=ep_meta) == "reference_video"
             raw_units = script.get("video_units")
             video_units: list[Any] = raw_units if isinstance(raw_units, list) else []
             if content_mode == "ad":
                 estimate_by_unit = is_reference_video
             else:
-                estimate_by_unit = is_reference_video and script.get("generation_mode") == "reference_video"
+                estimate_by_unit = script.get("generation_mode") == "reference_video"
 
             if estimate_by_unit:
                 if duration_ctx is None:

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -477,6 +477,9 @@ class CostEstimationService:
         for unit in units:
             if not isinstance(unit, dict):
                 continue
+            # ad 的 unit_id 由 derive_ad_reference_units 内部拼接（f"E{episode}U{n}"），
+            # 恒为字符串，不是 agent/外部可裸写的剧本字段，无需像 narration/drama 路径那样
+            # 防非字符串 unit_id（见 _estimate_unit_reference_video_episode 同名判断的说明）。
             unit_id = str(unit.get("unit_id") or "")
             try:
                 ad_shots = resolve_ad_unit_shots(script, unit)
@@ -582,9 +585,13 @@ class CostEstimationService:
         for unit in units:
             if not isinstance(unit, dict):
                 continue
-            unit_id = str(unit.get("unit_id") or "")
-            if not unit_id:
+            # unit_id 必须原本就是字符串：入队执行时按该字符串与剧本原始（未转型）值比较定位
+            # unit（``execute_reference_video_task``），数字/布尔等裸写 truthy 值 str() 后能通过
+            # 这里的估算，但执行时永远因类型不等找不到 unit——估算不能展示一笔实际跑不起来的费用。
+            raw_unit_id = unit.get("unit_id")
+            if not isinstance(raw_unit_id, str) or not raw_unit_id:
                 continue
+            unit_id = raw_unit_id
 
             # shots 非 list（如裸写 "shots": true/1）会让 assemble_shots_text 的遍历抛
             # TypeError；先做类型检查再拼接，与下方 duration 解析同样不能让单条脏数据中断

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -586,18 +586,22 @@ class CostEstimationService:
             if not unit_id:
                 continue
 
+            # shots 非 list（如裸写 "shots": true/1）会让 assemble_shots_text 的遍历抛
+            # TypeError；先做类型检查再拼接，与下方 duration 解析同样不能让单条脏数据中断
+            # 整次估算。
             shots = unit.get("shots")
-            enqueueable = bool(shots) and bool(assemble_shots_text(shots).strip())
+            enqueueable = isinstance(shots, list) and bool(shots) and bool(assemble_shots_text(shots).strip())
 
             est_video: CostBreakdown = {}
             if enqueueable:
-                # agent/外部编辑过的剧本可能写入非数值 duration_seconds（如 "bad"）；
+                # agent/外部编辑过的剧本可能写入非数值 duration_seconds（如 "bad"/列表/字典）；
                 # SDK 侧入队预检（enqueue_videos.py）对每个 unit 单独 catch ValueError 跳过，
                 # 此处须跟随同一容错口径——否则一个 unit 的脏时长会让整个项目估算 500，
-                # 拖累其余正常集。
+                # 拖累其余正常集。int() 转换对非数值字符串抛 ValueError，对 list/dict 抛
+                # TypeError，两者都要接住。
                 try:
                     slot = precheck_unit(duration_ctx, unit, None)
-                except ValueError:
+                except (ValueError, TypeError):
                     logger.warning("费用估算跳过时长非法的 unit %s", unit_id, exc_info=True)
                     slot = None
                 if slot is not None:

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -199,24 +199,34 @@ class CostEstimationService:
             # 不能像 narration/drama 那样靠剧本戳清空条目），分镜图维度按路径显式跳过；
             # 视频估值按实际计费颗粒度（reference_unit，而非镜头）计算，见
             # ``_estimate_ad_reference_video_episode``。
-            is_ad_reference_video = (
-                content_mode == "ad" and effective_mode(project=project_data, episode=ep_meta) == "reference_video"
-            )
+            is_reference_video = effective_mode(project=project_data, episode=ep_meta) == "reference_video"
 
-            if is_ad_reference_video:
+            if is_reference_video:
                 if duration_ctx is None:
                     duration_ctx = await resolve_project_duration_context(project_data)
-                segments_result, ep_est, ep_act = self._estimate_ad_reference_video_episode(
-                    script=script,
-                    episode=ep_meta.get("episode"),
-                    duration_ctx=duration_ctx,
-                    video_provider=video_provider,
-                    video_model=video_model,
-                    video_resolution=video_resolution,
-                    generate_audio=generate_audio,
-                    video_price=video_price,
-                    actual_by_segment=actual_by_segment,
-                )
+                if content_mode == "ad":
+                    segments_result, ep_est, ep_act = self._estimate_ad_reference_video_episode(
+                        script=script,
+                        episode=ep_meta.get("episode"),
+                        duration_ctx=duration_ctx,
+                        video_provider=video_provider,
+                        video_model=video_model,
+                        video_resolution=video_resolution,
+                        generate_audio=generate_audio,
+                        video_price=video_price,
+                        actual_by_segment=actual_by_segment,
+                    )
+                else:
+                    segments_result, ep_est, ep_act = self._estimate_reference_video_episode(
+                        script=script,
+                        duration_ctx=duration_ctx,
+                        video_provider=video_provider,
+                        video_model=video_model,
+                        video_resolution=video_resolution,
+                        generate_audio=generate_audio,
+                        video_price=video_price,
+                        actual_by_segment=actual_by_segment,
+                    )
                 _accumulate_episode(ep_meta, segments_result, ep_est, ep_act)
                 continue
 
@@ -479,5 +489,90 @@ class CostEstimationService:
                     ("audio", shot_act_audio),
                 ):
                     ep_act[cost_type] = _merge_breakdowns(ep_act.get(cost_type, {}), amounts)
+
+        return segments_result, ep_est, ep_act
+
+    def _estimate_reference_video_episode(
+        self,
+        *,
+        script: dict[str, Any],
+        duration_ctx: ProjectDurationContext,
+        video_provider: str,
+        video_model: str | None,
+        video_resolution: str | None,
+        generate_audio: bool,
+        video_price: Any,
+        actual_by_segment: dict[str, dict[str, CostBreakdown]],
+    ) -> tuple[list[dict[str, Any]], dict[str, CostBreakdown], dict[str, CostBreakdown]]:
+        """narration/drama + reference_video 集的估值：unit 本身就是展示颗粒度，无需分摊。
+
+        与 ad 路径不同——``AdShot`` 自带 ``shot_id``，``reference_units`` 只是把镜头分组的
+        轻量索引，unit 费用要摊回成员镜头才能被前端按镜头 ID 查到；narration/drama 的
+        ``video_units[*].shots``（``Shot``）没有独立 ID，unit 本身就是最小可寻址单位，
+        前端画布与费用面板均按 ``unit_id`` 索引（见 ``ReferenceVideoCanvas`` 读
+        ``cost-store`` 的 ``_segmentIndex.get(unit.unit_id)``），故此处不需要
+        ``_split_cost_across`` 这一步。
+
+        取档口径与 ad 路径同构：按 ``duration_ctx`` 解析的项目视频能力对 unit 剧本时长
+        （``unit.duration_seconds``，各 shot 之和）取档后计费，而非原始剧本时长——
+        与 ``execute_reference_video_task`` 实际申请的秒数对齐。
+
+        无图片/音频估值维度：该模式跳过分镜步骤（无分镜图），``Shot`` 没有独立的旁白/口播
+        文案字段可供计价，同 ad 参考视频口径（见 ``_estimate_ad_reference_video_episode``
+        docstring）。实付维度不受此限——直接透传 ``actual_by_segment[unit_id]`` 的三个维度，
+        供切换模式前留下的历史支出（若曾按其它 ID 记账）与本次分辨。
+        """
+        units = script.get("video_units")
+        if not isinstance(units, list):
+            units = []
+
+        segments_result: list[dict[str, Any]] = []
+        ep_est: dict[str, CostBreakdown] = {}
+        ep_act: dict[str, CostBreakdown] = {}
+
+        for unit in units:
+            if not isinstance(unit, dict):
+                continue
+            unit_id = str(unit.get("unit_id") or "")
+            if not unit_id:
+                continue
+
+            slot = precheck_unit(duration_ctx, unit, None)
+
+            est_video: CostBreakdown = {}
+            try:
+                vid_amount, vid_currency = cost_calculator.calculate_cost(
+                    video_provider,
+                    PricingParams(
+                        call_type="video",
+                        model=video_model,
+                        resolution=video_resolution,
+                        duration_seconds=slot.seconds,
+                        generate_audio=generate_audio,
+                    ),
+                    custom_price_input=video_price.price_input,
+                    custom_price_output=video_price.price_output,
+                    custom_currency=video_price.currency,
+                )
+                _add_cost(est_video, vid_amount, vid_currency)
+            except Exception:
+                logger.debug("无法计算 video 预估 for %s", unit_id, exc_info=True)
+
+            unit_actual = actual_by_segment.get(unit_id, {})
+            act_image: CostBreakdown = unit_actual.get("image", {})
+            act_video: CostBreakdown = unit_actual.get("video", {})
+            act_audio: CostBreakdown = unit_actual.get("audio", {})
+
+            segments_result.append(
+                {
+                    "segment_id": unit_id,
+                    "duration_seconds": unit.get("duration_seconds", 8),
+                    "estimate": {"image": {}, "video": est_video, "audio": {}},
+                    "actual": {"image": act_image, "video": act_video, "audio": act_audio},
+                }
+            )
+            ep_est["video"] = _merge_breakdowns(ep_est.get("video", {}), est_video)
+            for cost_type, amounts in (("image", act_image), ("video", act_video), ("audio", act_audio)):
+                ep_act[cost_type] = _merge_breakdowns(ep_act.get(cost_type, {}), amounts)
 
         return segments_result, ep_est, ep_act

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -591,16 +591,25 @@ class CostEstimationService:
 
             est_video: CostBreakdown = {}
             if enqueueable:
-                slot = precheck_unit(duration_ctx, unit, None)
-                est_video = _estimate_unit_video_cost(
-                    unit_id=unit_id,
-                    duration_seconds=slot.seconds,
-                    video_provider=video_provider,
-                    video_model=video_model,
-                    video_resolution=video_resolution,
-                    generate_audio=generate_audio,
-                    video_price=video_price,
-                )
+                # agent/外部编辑过的剧本可能写入非数值 duration_seconds（如 "bad"）；
+                # SDK 侧入队预检（enqueue_videos.py）对每个 unit 单独 catch ValueError 跳过，
+                # 此处须跟随同一容错口径——否则一个 unit 的脏时长会让整个项目估算 500，
+                # 拖累其余正常集。
+                try:
+                    slot = precheck_unit(duration_ctx, unit, None)
+                except ValueError:
+                    logger.warning("费用估算跳过时长非法的 unit %s", unit_id, exc_info=True)
+                    slot = None
+                if slot is not None:
+                    est_video = _estimate_unit_video_cost(
+                        unit_id=unit_id,
+                        duration_seconds=slot.seconds,
+                        video_provider=video_provider,
+                        video_model=video_model,
+                        video_resolution=video_resolution,
+                        generate_audio=generate_audio,
+                        video_price=video_price,
+                    )
 
             unit_actual = actual_by_segment.get(unit_id, {})
             act_image: CostBreakdown = unit_actual.get("image", {})

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -15,6 +15,7 @@ from lib.db.repositories.usage_repo import UsageRepository
 from lib.grid.layout import calculate_grid_layout
 from lib.pricing.strategies import PricingParams
 from lib.project_manager import effective_mode
+from lib.reference_video import assemble_shots_text
 from lib.reference_video.ad_units import derive_ad_reference_units, resolve_ad_unit_shots
 from lib.script_editor import ScriptEditError
 from lib.script_models import get_generated_assets
@@ -89,6 +90,7 @@ def _estimate_unit_video_cost(
             custom_price_input=video_price.price_input,
             custom_price_output=video_price.price_output,
             custom_currency=video_price.currency,
+            estimate_only=True,
         )
         _add_cost(est_video, amount, currency)
     except Exception:
@@ -564,6 +566,11 @@ class CostEstimationService:
         对 ``resource_type == "reference_videos"`` 的记账以 unit_id 写入 usage 的 segment_id，
         与本函数的输出 identity 一致。切换模式前按分镜 ID（``E1S1`` 等）记的历史支出不在此
         呈现：unit 与分镜之间没有映射关系，无处归属。
+
+        跳过没有 shots 或拼接文本为空的 unit：这类 unit 不可入队（``enqueue_videos.py::_reference_unit_spec``
+        对没有 shots 的 unit 直接拒绝、``TaskSpec.from_request`` 对空提示词同样拒绝），估值给出
+        非零金额会展示一笔查无实据的费用；判空标准与入队侧同一份 ``assemble_shots_text``，
+        不能自行另起一套字符串处理否则两处会漂移。
         """
         segments_result: list[dict[str, Any]] = []
         ep_est: dict[str, CostBreakdown] = {}
@@ -574,6 +581,9 @@ class CostEstimationService:
                 continue
             unit_id = str(unit.get("unit_id") or "")
             if not unit_id:
+                continue
+            shots = unit.get("shots")
+            if not shots or not assemble_shots_text(shots).strip():
                 continue
 
             slot = precheck_unit(duration_ctx, unit, None)

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -60,6 +60,42 @@ def _split_cost_across(cost: CostBreakdown, parts: int) -> list[CostBreakdown]:
     return split
 
 
+def _estimate_unit_video_cost(
+    *,
+    unit_id: str,
+    duration_seconds: int,
+    video_provider: str,
+    video_model: str | None,
+    video_resolution: str | None,
+    generate_audio: bool,
+    video_price: Any,
+) -> CostBreakdown:
+    """一个参考视频 unit 取档后秒数的视频估值。计价失败返回空 breakdown（该 unit 不计费）。
+
+    两条参考视频估算路径（ad 摊回镜头、narration/drama 按 unit 展示）的展示颗粒度不同，
+    但「按取档后秒数向 provider 询价」这一步与颗粒度无关，共用同一实现避免两处漂移。
+    """
+    est_video: CostBreakdown = {}
+    try:
+        amount, currency = cost_calculator.calculate_cost(
+            video_provider,
+            PricingParams(
+                call_type="video",
+                model=video_model,
+                resolution=video_resolution,
+                duration_seconds=duration_seconds,
+                generate_audio=generate_audio,
+            ),
+            custom_price_input=video_price.price_input,
+            custom_price_output=video_price.price_output,
+            custom_currency=video_price.currency,
+        )
+        _add_cost(est_video, amount, currency)
+    except Exception:
+        logger.debug("无法计算 video 预估 for %s", unit_id, exc_info=True)
+    return est_video
+
+
 class CostEstimationService:
     def __init__(self, resolver: ConfigResolver, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._resolver = resolver
@@ -166,7 +202,7 @@ class CostEstimationService:
         proj_act: dict[str, CostBreakdown] = {}
 
         content_mode = project_data.get("content_mode", "narration")
-        # 惰性解析：只有项目里真出现 ad + reference_video 集时才触发这次额外 IO
+        # 惰性解析：只有项目里真出现按 unit 计费的参考视频集时才触发这次额外 IO
         # （见 :func:`server.services.reference_video_tasks.resolve_project_duration_context`）。
         duration_ctx: ProjectDurationContext | None = None
 
@@ -195,13 +231,23 @@ class CostEstimationService:
             if not script:
                 continue
 
-            # ad 参考生视频路径跳过分镜步骤（剧本骨架唯一，shots 不打 generation_mode 戳，
-            # 不能像 narration/drama 那样靠剧本戳清空条目），分镜图维度按路径显式跳过；
-            # 视频估值按实际计费颗粒度（reference_unit，而非镜头）计算，见
-            # ``_estimate_ad_reference_video_episode``。
+            # 参考生视频路径跳过分镜步骤，分镜图维度按路径显式跳过；视频估值按实际计费颗粒度
+            # （reference_unit，而非镜头）计算。两条子路径的展示颗粒度不同：ad 的 unit 只是
+            # 镜头分组索引，费用要摊回自带 ``shot_id`` 的成员镜头（``_estimate_ad_reference_video_episode``）；
+            # narration/drama 的 unit 自带 ``unit_id`` 且成员 shot 无独立 ID，unit 本身即展示
+            # 颗粒度（``_estimate_unit_reference_video_episode``）。
+            #
+            # ad 骨架唯一、shots 不打 generation_mode 戳，生成路径以项目级/集级戳为真相源，故
+            # 只按 ``effective_mode`` 判定；narration/drama 的生成侧按剧本戳判定（见
+            # ``server/agent_runtime/sdk_tools/enqueue_videos.py``），项目已切到 reference_video
+            # 但该集剧本仍是分镜骨架时实际入队的还是分镜任务，估算随之沿用分镜路径，不按尚不
+            # 存在的 units 归零。
             is_reference_video = effective_mode(project=project_data, episode=ep_meta) == "reference_video"
+            raw_units = script.get("video_units")
+            video_units: list[Any] = raw_units if isinstance(raw_units, list) else []
+            estimate_by_unit = is_reference_video and (content_mode == "ad" or bool(video_units))
 
-            if is_reference_video:
+            if estimate_by_unit:
                 if duration_ctx is None:
                     duration_ctx = await resolve_project_duration_context(project_data)
                 if content_mode == "ad":
@@ -217,8 +263,8 @@ class CostEstimationService:
                         actual_by_segment=actual_by_segment,
                     )
                 else:
-                    segments_result, ep_est, ep_act = self._estimate_reference_video_episode(
-                        script=script,
+                    segments_result, ep_est, ep_act = self._estimate_unit_reference_video_episode(
+                        units=video_units,
                         duration_ctx=duration_ctx,
                         video_provider=video_provider,
                         video_model=video_model,
@@ -439,24 +485,15 @@ class CostEstimationService:
 
             slot = precheck_unit(duration_ctx, unit, ad_shots)
 
-            est_video: CostBreakdown = {}
-            try:
-                vid_amount, vid_currency = cost_calculator.calculate_cost(
-                    video_provider,
-                    PricingParams(
-                        call_type="video",
-                        model=video_model,
-                        resolution=video_resolution,
-                        duration_seconds=slot.seconds,
-                        generate_audio=generate_audio,
-                    ),
-                    custom_price_input=video_price.price_input,
-                    custom_price_output=video_price.price_output,
-                    custom_currency=video_price.currency,
-                )
-                _add_cost(est_video, vid_amount, vid_currency)
-            except Exception:
-                logger.debug("无法计算 video 预估 for %s", unit_id, exc_info=True)
+            est_video = _estimate_unit_video_cost(
+                unit_id=unit_id,
+                duration_seconds=slot.seconds,
+                video_provider=video_provider,
+                video_model=video_model,
+                video_resolution=video_resolution,
+                generate_audio=generate_audio,
+                video_price=video_price,
+            )
 
             act_video: CostBreakdown = actual_by_segment.get(unit_id, {}).get("video", {})
             est_by_shot = _split_cost_across(est_video, len(ad_shots))
@@ -492,10 +529,10 @@ class CostEstimationService:
 
         return segments_result, ep_est, ep_act
 
-    def _estimate_reference_video_episode(
+    def _estimate_unit_reference_video_episode(
         self,
         *,
-        script: dict[str, Any],
+        units: list[Any],
         duration_ctx: ProjectDurationContext,
         video_provider: str,
         video_model: str | None,
@@ -519,13 +556,11 @@ class CostEstimationService:
 
         无图片/音频估值维度：该模式跳过分镜步骤（无分镜图），``Shot`` 没有独立的旁白/口播
         文案字段可供计价，同 ad 参考视频口径（见 ``_estimate_ad_reference_video_episode``
-        docstring）。实付维度不受此限——直接透传 ``actual_by_segment[unit_id]`` 的三个维度，
-        供切换模式前留下的历史支出（若曾按其它 ID 记账）与本次分辨。
+        docstring）。实付按 ``actual_by_segment[unit_id]`` 三个维度原样透传——``lib/media_generator.py``
+        对 ``resource_type == "reference_videos"`` 的记账以 unit_id 写入 usage 的 segment_id，
+        与本函数的输出 identity 一致。切换模式前按分镜 ID（``E1S1`` 等）记的历史支出不在此
+        呈现：unit 与分镜之间没有映射关系，无处归属。
         """
-        units = script.get("video_units")
-        if not isinstance(units, list):
-            units = []
-
         segments_result: list[dict[str, Any]] = []
         ep_est: dict[str, CostBreakdown] = {}
         ep_act: dict[str, CostBreakdown] = {}
@@ -539,24 +574,15 @@ class CostEstimationService:
 
             slot = precheck_unit(duration_ctx, unit, None)
 
-            est_video: CostBreakdown = {}
-            try:
-                vid_amount, vid_currency = cost_calculator.calculate_cost(
-                    video_provider,
-                    PricingParams(
-                        call_type="video",
-                        model=video_model,
-                        resolution=video_resolution,
-                        duration_seconds=slot.seconds,
-                        generate_audio=generate_audio,
-                    ),
-                    custom_price_input=video_price.price_input,
-                    custom_price_output=video_price.price_output,
-                    custom_currency=video_price.currency,
-                )
-                _add_cost(est_video, vid_amount, vid_currency)
-            except Exception:
-                logger.debug("无法计算 video 预估 for %s", unit_id, exc_info=True)
+            est_video = _estimate_unit_video_cost(
+                unit_id=unit_id,
+                duration_seconds=slot.seconds,
+                video_provider=video_provider,
+                video_model=video_model,
+                video_resolution=video_resolution,
+                generate_audio=generate_audio,
+                video_price=video_price,
+            )
 
             unit_actual = actual_by_segment.get(unit_id, {})
             act_image: CostBreakdown = unit_actual.get("image", {})

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -567,10 +567,13 @@ class CostEstimationService:
         与本函数的输出 identity 一致。切换模式前按分镜 ID（``E1S1`` 等）记的历史支出不在此
         呈现：unit 与分镜之间没有映射关系，无处归属。
 
-        跳过没有 shots 或拼接文本为空的 unit：这类 unit 不可入队（``enqueue_videos.py::_reference_unit_spec``
+        没有 shots 或拼接文本为空的 unit 不产生预估：这类 unit 不可入队（``enqueue_videos.py::_reference_unit_spec``
         对没有 shots 的 unit 直接拒绝、``TaskSpec.from_request`` 对空提示词同样拒绝），估值给出
         非零金额会展示一笔查无实据的费用；判空标准与入队侧同一份 ``assemble_shots_text``，
-        不能自行另起一套字符串处理否则两处会漂移。
+        不能自行另起一套字符串处理否则两处会漂移。但该 unit 仍要整条保留、纳入汇总——不可入队
+        只影响能否产生新预估，不影响该 unit 是否曾经成功生成过（``actual_by_segment[unit_id]``
+        记的是历史实付，与 unit 当前编辑状态无关）：unit 曾成功生成、随后剧本被编辑成空 shots，
+        其历史支出不能因此从段级/集级/项目级合计里消失。
         """
         segments_result: list[dict[str, Any]] = []
         ep_est: dict[str, CostBreakdown] = {}
@@ -582,21 +585,22 @@ class CostEstimationService:
             unit_id = str(unit.get("unit_id") or "")
             if not unit_id:
                 continue
+
             shots = unit.get("shots")
-            if not shots or not assemble_shots_text(shots).strip():
-                continue
+            enqueueable = bool(shots) and bool(assemble_shots_text(shots).strip())
 
-            slot = precheck_unit(duration_ctx, unit, None)
-
-            est_video = _estimate_unit_video_cost(
-                unit_id=unit_id,
-                duration_seconds=slot.seconds,
-                video_provider=video_provider,
-                video_model=video_model,
-                video_resolution=video_resolution,
-                generate_audio=generate_audio,
-                video_price=video_price,
-            )
+            est_video: CostBreakdown = {}
+            if enqueueable:
+                slot = precheck_unit(duration_ctx, unit, None)
+                est_video = _estimate_unit_video_cost(
+                    unit_id=unit_id,
+                    duration_seconds=slot.seconds,
+                    video_provider=video_provider,
+                    video_model=video_model,
+                    video_resolution=video_resolution,
+                    generate_audio=generate_audio,
+                    video_price=video_price,
+                )
 
             unit_actual = actual_by_segment.get(unit_id, {})
             act_image: CostBreakdown = unit_actual.get("image", {})

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -1031,6 +1031,31 @@ class TestCostEstimationService:
         assert result["project_totals"]["actual"]["video"] == {"USD": 1.23}
 
     @pytest.mark.integration
+    async def test_narration_reference_video_estimate_skips_unit_with_malformed_duration(self, db_factory):
+        """agent/外部编辑过的剧本可能写入非数值 ``duration_seconds``（如 ``"bad"``）。
+        SDK 侧入队预检（``enqueue_videos.py``）对每个 unit 单独 catch ``ValueError`` 跳过，
+        估算须跟随同一容错口径——一个 unit 的脏时长不能让整个项目估算 500，拖累其余正常集。
+        """
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Narration",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        script = _make_reference_video_script(1, "narration", [("E1U1", 6)])
+        script["video_units"][0]["duration_seconds"] = "bad"
+
+        result = await service.compute(project_data, {"ep1.json": script}, project_name="narration-bad-duration")
+
+        segments = result["episodes"][0]["segments"]
+        assert [seg["segment_id"] for seg in segments] == ["E1U1"]
+        assert segments[0]["estimate"]["video"] == {}
+
+    @pytest.mark.integration
     async def test_narration_reference_video_estimate_handles_token_priced_video_model(self, db_factory):
         """按 token 计费的视频模型（Ark/Seedance）也要能算出非零视频预估。
 

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -1086,6 +1086,32 @@ class TestCostEstimationService:
         assert segments[1]["estimate"]["video"]
 
     @pytest.mark.integration
+    async def test_narration_reference_video_estimate_rejects_non_string_unit_id(self, db_factory):
+        """agent/外部编辑过的剧本可能把 ``unit_id`` 裸写成非字符串 truthy 值（如数字/布尔）。
+        入队执行时（``execute_reference_video_task``）按字符串 resource_id 与剧本原始
+        （未转型）值比较定位 unit，类型不等会导致 "unit not found"；估算侧若把该值
+        str() 强转后正常计费，会展示一笔实际跑不起来的费用，必须原本就是字符串才计价。
+        """
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Narration",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        script = _make_reference_video_script(1, "narration", [("E1U1", 6), ("E1U2", 8)])
+        script["video_units"][0]["unit_id"] = 1
+
+        result = await service.compute(project_data, {"ep1.json": script}, project_name="narration-non-str-unit-id")
+
+        segments = result["episodes"][0]["segments"]
+        assert [seg["segment_id"] for seg in segments] == ["E1U2"]
+        assert segments[0]["estimate"]["video"]
+
+    @pytest.mark.integration
     async def test_narration_reference_video_estimate_handles_token_priced_video_model(self, db_factory):
         """按 token 计费的视频模型（Ark/Seedance）也要能算出非零视频预估。
 

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -971,8 +971,10 @@ class TestCostEstimationService:
     @pytest.mark.integration
     async def test_narration_reference_video_estimate_skips_unenqueueable_units(self, db_factory):
         """没有 shots 或拼接文本为空的 unit 不可入队（``enqueue_videos.py::_reference_unit_spec``
-        对没有 shots 的 unit 直接拒绝，``TaskSpec.from_request`` 对空提示词同样拒绝），估算须
-        跳过这类 unit，不展示一笔查无实据的费用。
+        对没有 shots 的 unit 直接拒绝，``TaskSpec.from_request`` 对空提示词同样拒绝），这类 unit
+        不产生新预估——但 unit 整条仍要保留在结果里、纳入汇总：不可入队只影响能否产生新预估，
+        不影响该 unit 是否曾经成功生成过。已有实付的 unit（曾成功生成、之后被编辑成空 shots）
+        其历史支出不能因此从合计里消失。
         """
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)
@@ -1008,11 +1010,25 @@ class TestCostEstimationService:
             }
         )
         scripts = {"ep1.json": script}
+        await _seed_call(
+            db_factory,
+            "narration-unenqueueable-units",
+            "video",
+            "veo-3.1-lite-generate-preview",
+            segment_id="E1U2",
+            cost_amount=1.23,
+            currency="USD",
+        )
 
         result = await service.compute(project_data, scripts, project_name="narration-unenqueueable-units")
 
         segments = result["episodes"][0]["segments"]
-        assert [seg["segment_id"] for seg in segments] == ["E1U1"]
+        assert [seg["segment_id"] for seg in segments] == ["E1U1", "E1U2", "E1U3"]
+        by_id = {seg["segment_id"]: seg for seg in segments}
+        assert by_id["E1U2"]["estimate"]["video"] == {}
+        assert by_id["E1U2"]["actual"]["video"] == {"USD": 1.23}
+        assert by_id["E1U3"]["estimate"]["video"] == {}
+        assert result["project_totals"]["actual"]["video"] == {"USD": 1.23}
 
     @pytest.mark.integration
     async def test_narration_reference_video_estimate_handles_token_priced_video_model(self, db_factory):

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -763,6 +763,7 @@ class TestCostEstimationService:
         assert [seg["estimate"]["video"][currency] for seg in segments] == [per_unit] * 3
         assert result["episodes"][0]["totals"]["estimate"]["video"][currency] == round(per_unit * 3, 6)
 
+    @pytest.mark.integration
     async def test_narration_reference_video_produces_nonzero_video_estimate(self, db_factory):
         """narration + reference_video 集的视频估值不应恒为 0（`get_storyboard_items` 对该
         generation_mode 恒返回空列表，之前的估算循环遍历它，等于永远算不出视频费用）。
@@ -794,6 +795,7 @@ class TestCostEstimationService:
         assert result["project_totals"]["estimate"].get("image", {}) == {}
         assert result["project_totals"]["estimate"]["video"]
 
+    @pytest.mark.integration
     async def test_drama_reference_video_actual_cost_matches_unit_id(self, db_factory):
         """actual 侧直接按 unit_id 匹配，不需要摊分——reference_videos 的记账 resource_id
         即 unit_id，与本路径输出的 segment_id 同一 identity。
@@ -829,6 +831,7 @@ class TestCostEstimationService:
         assert result["episodes"][0]["totals"]["actual"]["video"]["USD"] == pytest.approx(0.8)
         assert result["project_totals"]["actual"]["video"]["USD"] == pytest.approx(0.8)
 
+    @pytest.mark.integration
     async def test_narration_reference_video_estimate_uses_rounded_up_unit_duration(self, db_factory, monkeypatch):
         """取档向上的 unit：预估金额按取档后的秒数（8s）计，而非剧本原始总时长（5s）。"""
         from server.services import cost_estimation as cost_estimation_module
@@ -869,6 +872,7 @@ class TestCostEstimationService:
         assert sum(seg["estimate"]["video"].values()) > sum(base_seg["estimate"]["video"].values())
         assert seg["estimate"]["video"] == rounded["episodes"][0]["totals"]["estimate"]["video"]
 
+    @pytest.mark.integration
     async def test_narration_reference_video_falls_back_when_script_still_storyboard(self, db_factory):
         """项目已切到 reference_video、该集剧本还是分镜骨架时，估算沿用分镜路径而非归零。
 
@@ -904,6 +908,66 @@ class TestCostEstimationService:
         segments = result["episodes"][0]["segments"]
         assert [seg["segment_id"] for seg in segments] == ["E1S1", "E1S2"]
         assert result["project_totals"]["estimate"]["image"]
+        assert result["project_totals"]["estimate"]["video"]
+
+    @pytest.mark.integration
+    async def test_narration_reference_video_falls_back_when_video_units_stale(self, db_factory):
+        """剧本残留切换前/迁移中间态的 ``video_units``、自身戳非 reference_video 时，
+        估算仍按分镜路径走，不因 units 非空而误判为 unit 路径。
+
+        与 ``test_narration_reference_video_falls_back_when_script_still_storyboard`` 的区别：
+        该用例的剧本没有 video_units；本用例剧本残留了非空 video_units，验证判定看的是剧本
+        自身的 ``generation_mode`` 戳而非 ``bool(video_units)``。
+        """
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Narration",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        script = _make_reference_video_script(1, "narration", [("E1U1", 6)])
+        script.pop("generation_mode")
+        script["segments"] = [
+            {"segment_id": "E1S1", "duration_seconds": 5, "narration": "n1", "visual_prompt": "v1"},
+        ]
+        scripts = {"ep1.json": script}
+
+        result = await service.compute(project_data, scripts, project_name="narration-stale-units")
+
+        segments = result["episodes"][0]["segments"]
+        assert [seg["segment_id"] for seg in segments] == ["E1S1"]
+        assert result["project_totals"]["estimate"]["image"]
+        assert result["project_totals"]["estimate"]["video"]
+
+    @pytest.mark.integration
+    async def test_narration_reference_video_estimate_handles_token_priced_video_model(self, db_factory):
+        """按 token 计费的视频模型（Ark/Seedance）也要能算出非零视频预估。
+
+        ``_estimate_unit_video_cost`` 只传 ``duration_seconds``，若不换算 usage_tokens，
+        ``PerTokenVideo`` 定价形状会因 ``usage_tokens`` 缺失恒算出 0。
+        """
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Narration",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "video_backend": "ark",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_reference_video_script(1, "narration", [("E1U1", 6)])}
+
+        result = await service.compute(project_data, scripts, project_name="narration-ark-token")
+
+        segments = result["episodes"][0]["segments"]
+        assert segments[0]["segment_id"] == "E1U1"
+        assert segments[0]["estimate"]["video"]
         assert result["project_totals"]["estimate"]["video"]
 
     async def test_empty_episodes(self, db_factory):

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -944,6 +944,31 @@ class TestCostEstimationService:
         assert result["project_totals"]["estimate"]["video"]
 
     @pytest.mark.integration
+    async def test_narration_reference_video_estimate_follows_script_stamp_over_effective_mode(self, db_factory):
+        """项目级 ``generation_mode`` 事后回退到 storyboard，但该集剧本仍保留切换前的
+        ``reference_video`` 戳时，估算须跟随剧本戳走 unit 路径，不因项目级戳回退而误判回落
+        分镜——实际入队（``_is_reference_script``）只认剧本自身的戳，从不读 ``effective_mode``。
+        """
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Narration",
+            "content_mode": "narration",
+            "generation_mode": "storyboard",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_reference_video_script(1, "narration", [("E1U1", 6)])}
+
+        result = await service.compute(project_data, scripts, project_name="narration-reverted-project-mode")
+
+        segments = result["episodes"][0]["segments"]
+        assert segments[0]["segment_id"] == "E1U1"
+        assert segments[0]["estimate"]["video"]
+        assert result["project_totals"]["estimate"]["video"]
+
+    @pytest.mark.integration
     async def test_narration_reference_video_estimate_handles_token_priced_video_model(self, db_factory):
         """按 token 计费的视频模型（Ark/Seedance）也要能算出非零视频预估。
 

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -130,6 +130,32 @@ def _make_ad_script(shot_ids: list[str], durations: list[int]) -> dict:
     }
 
 
+def _make_reference_video_script(episode: int, content_mode: str, unit_specs: list[tuple[str, int]]) -> dict:
+    """Helper to create a narration/drama + reference_video episode script dict (video_units[])."""
+    units = []
+    for unit_id, duration in unit_specs:
+        units.append(
+            {
+                "unit_id": unit_id,
+                "shots": [{"duration": duration, "text": "t"}],
+                "references": [],
+                "duration_seconds": duration,
+                "duration_override": False,
+                "transition_to_next": "cut",
+                "generated_assets": {"video_clip": None, "status": "pending"},
+            }
+        )
+    return {
+        "episode": episode,
+        "title": f"Episode {episode}",
+        "content_mode": content_mode,
+        "generation_mode": "reference_video",
+        "duration_seconds": sum(d for _, d in unit_specs),
+        "novel": {"title": "t", "chapter": "c"},
+        "video_units": units,
+    }
+
+
 class TestCostEstimationService:
     async def test_estimate_single_episode(self, db_factory):
         resolver = ConfigResolver(db_factory)
@@ -736,6 +762,112 @@ class TestCostEstimationService:
         per_unit = segments[0]["estimate"]["video"][currency]
         assert [seg["estimate"]["video"][currency] for seg in segments] == [per_unit] * 3
         assert result["episodes"][0]["totals"]["estimate"]["video"][currency] == round(per_unit * 3, 6)
+
+    async def test_narration_reference_video_produces_nonzero_video_estimate(self, db_factory):
+        """narration + reference_video 集的视频估值不应恒为 0（`get_storyboard_items` 对该
+        generation_mode 恒返回空列表，之前的估算循环遍历它，等于永远算不出视频费用）。
+
+        unit 本身就是展示颗粒度（``Shot`` 无独立 ID），故 segment_id 直接是 unit_id，
+        不像 ad 路径那样需要摊回成员镜头。
+        """
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Narration",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_reference_video_script(1, "narration", [("E1U1", 6), ("E1U2", 8)])}
+
+        result = await service.compute(project_data, scripts, project_name="narration-ref")
+
+        segments = result["episodes"][0]["segments"]
+        assert [seg["segment_id"] for seg in segments] == ["E1U1", "E1U2"]
+        assert [seg["duration_seconds"] for seg in segments] == [6, 8]
+        for seg in segments:
+            assert seg["estimate"]["image"] == {}
+            assert seg["estimate"]["audio"] == {}
+            assert seg["estimate"]["video"]
+        assert result["project_totals"]["estimate"].get("image", {}) == {}
+        assert result["project_totals"]["estimate"]["video"]
+
+    async def test_drama_reference_video_actual_cost_matches_unit_id(self, db_factory):
+        """actual 侧直接按 unit_id 匹配，不需要摊分（依赖 #1470 把 reference_videos 记账
+        纳入 segment_id 白名单：resource_id 即 unit_id）。
+        """
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        await _seed_call(
+            db_factory,
+            "drama-ref-actual",
+            "video",
+            "veo-3.1",
+            provider="veo",
+            segment_id="E1U1",
+            cost_amount=0.8,
+            currency="USD",
+        )
+
+        project_data = {
+            "title": "Drama",
+            "content_mode": "drama",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_reference_video_script(1, "drama", [("E1U1", 8)])}
+
+        result = await service.compute(project_data, scripts, project_name="drama-ref-actual")
+
+        segments = result["episodes"][0]["segments"]
+        assert segments[0]["segment_id"] == "E1U1"
+        assert segments[0]["actual"]["video"]["USD"] == pytest.approx(0.8)
+        assert result["episodes"][0]["totals"]["actual"]["video"]["USD"] == pytest.approx(0.8)
+        assert result["project_totals"]["actual"]["video"]["USD"] == pytest.approx(0.8)
+
+    async def test_narration_reference_video_estimate_uses_rounded_up_unit_duration(self, db_factory, monkeypatch):
+        """取档向上的 unit：预估金额按取档后的秒数（8s）计，而非剧本原始总时长（5s）。"""
+        from server.services import cost_estimation as cost_estimation_module
+        from server.services.reference_video_tasks import ProjectDurationContext
+
+        def _patch_ctx(durations: tuple[int, ...]):
+            async def _fake_ctx(project):
+                return ProjectDurationContext(
+                    supported_durations=durations, resolution=None, provider_id="veo", model_name="veo-3.1"
+                )
+
+            monkeypatch.setattr(cost_estimation_module, "resolve_project_duration_context", _fake_ctx)
+
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Narration",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_reference_video_script(1, "narration", [("E1U1", 5)])}
+
+        _patch_ctx((8,))
+        rounded = await service.compute(project_data, scripts, project_name="narration-ref-round")
+        _patch_ctx(())
+        unconstrained = await service.compute(project_data, scripts, project_name="narration-ref-round")
+
+        seg = rounded["episodes"][0]["segments"][0]
+        base_seg = unconstrained["episodes"][0]["segments"][0]
+        assert seg["segment_id"] == "E1U1"
+        assert seg["duration_seconds"] == 5
+        assert base_seg["duration_seconds"] == 5
+        assert seg["estimate"]["video"]
+        assert base_seg["estimate"]["video"]
+        assert sum(seg["estimate"]["video"].values()) > sum(base_seg["estimate"]["video"].values())
+        assert seg["estimate"]["video"] == rounded["episodes"][0]["totals"]["estimate"]["video"]
 
     async def test_empty_episodes(self, db_factory):
         resolver = ConfigResolver(db_factory)

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -1047,16 +1047,17 @@ class TestCostEstimationService:
             "target_duration": 30,
             "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
         }
-        script = _make_reference_video_script(1, "narration", [("E1U1", 6), ("E1U2", 8)])
+        script = _make_reference_video_script(1, "narration", [("E1U1", 6), ("E1U2", 8), ("E1U3", 8)])
         script["video_units"][0]["duration_seconds"] = "bad"
         script["video_units"][1]["duration_seconds"] = ["not", "a", "number"]
 
         result = await service.compute(project_data, {"ep1.json": script}, project_name="narration-bad-duration")
 
         segments = result["episodes"][0]["segments"]
-        assert [seg["segment_id"] for seg in segments] == ["E1U1", "E1U2"]
+        assert [seg["segment_id"] for seg in segments] == ["E1U1", "E1U2", "E1U3"]
         assert segments[0]["estimate"]["video"] == {}
         assert segments[1]["estimate"]["video"] == {}
+        assert segments[2]["estimate"]["video"]
 
     @pytest.mark.integration
     async def test_narration_reference_video_estimate_skips_unit_with_non_list_shots(self, db_factory):

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -1032,9 +1032,10 @@ class TestCostEstimationService:
 
     @pytest.mark.integration
     async def test_narration_reference_video_estimate_skips_unit_with_malformed_duration(self, db_factory):
-        """agent/外部编辑过的剧本可能写入非数值 ``duration_seconds``（如 ``"bad"``）。
+        """agent/外部编辑过的剧本可能写入非数值 ``duration_seconds``（字符串、list、dict 等）。
         SDK 侧入队预检（``enqueue_videos.py``）对每个 unit 单独 catch ``ValueError`` 跳过，
-        估算须跟随同一容错口径——一个 unit 的脏时长不能让整个项目估算 500，拖累其余正常集。
+        估算须跟随同一容错口径——一个 unit 的脏时长不能让整个项目估算 500，拖累其余正常集，
+        其余正常 unit 仍要继续产生预估。
         """
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)
@@ -1046,14 +1047,42 @@ class TestCostEstimationService:
             "target_duration": 30,
             "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
         }
-        script = _make_reference_video_script(1, "narration", [("E1U1", 6)])
+        script = _make_reference_video_script(1, "narration", [("E1U1", 6), ("E1U2", 8)])
         script["video_units"][0]["duration_seconds"] = "bad"
+        script["video_units"][1]["duration_seconds"] = ["not", "a", "number"]
 
         result = await service.compute(project_data, {"ep1.json": script}, project_name="narration-bad-duration")
 
         segments = result["episodes"][0]["segments"]
-        assert [seg["segment_id"] for seg in segments] == ["E1U1"]
+        assert [seg["segment_id"] for seg in segments] == ["E1U1", "E1U2"]
         assert segments[0]["estimate"]["video"] == {}
+        assert segments[1]["estimate"]["video"] == {}
+
+    @pytest.mark.integration
+    async def test_narration_reference_video_estimate_skips_unit_with_non_list_shots(self, db_factory):
+        """agent/外部编辑过的剧本可能把 ``shots`` 裸写成非 list 的 truthy 值（如 ``true``/``1``）。
+        ``assemble_shots_text`` 对非 list 输入遍历会抛 ``TypeError``，该异常发生在时长解析
+        之前，必须在拼接前先做类型检查，否则同样会让整个项目估算 500。
+        """
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Narration",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        script = _make_reference_video_script(1, "narration", [("E1U1", 6), ("E1U2", 8)])
+        script["video_units"][0]["shots"] = True
+
+        result = await service.compute(project_data, {"ep1.json": script}, project_name="narration-non-list-shots")
+
+        segments = result["episodes"][0]["segments"]
+        assert [seg["segment_id"] for seg in segments] == ["E1U1", "E1U2"]
+        assert segments[0]["estimate"]["video"] == {}
+        assert segments[1]["estimate"]["video"]
 
     @pytest.mark.integration
     async def test_narration_reference_video_estimate_handles_token_priced_video_model(self, db_factory):

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -795,8 +795,8 @@ class TestCostEstimationService:
         assert result["project_totals"]["estimate"]["video"]
 
     async def test_drama_reference_video_actual_cost_matches_unit_id(self, db_factory):
-        """actual 侧直接按 unit_id 匹配，不需要摊分（依赖 #1470 把 reference_videos 记账
-        纳入 segment_id 白名单：resource_id 即 unit_id）。
+        """actual 侧直接按 unit_id 匹配，不需要摊分——reference_videos 的记账 resource_id
+        即 unit_id，与本路径输出的 segment_id 同一 identity。
         """
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)
@@ -868,6 +868,43 @@ class TestCostEstimationService:
         assert base_seg["estimate"]["video"]
         assert sum(seg["estimate"]["video"].values()) > sum(base_seg["estimate"]["video"].values())
         assert seg["estimate"]["video"] == rounded["episodes"][0]["totals"]["estimate"]["video"]
+
+    async def test_narration_reference_video_falls_back_when_script_still_storyboard(self, db_factory):
+        """项目已切到 reference_video、该集剧本还是分镜骨架时，估算沿用分镜路径而非归零。
+
+        narration/drama 的生成侧按剧本自身的 generation_mode 戳判定，此状态下实际入队的
+        仍是分镜任务；若估算只看项目级戳就会找不到 video_units 而给出一份全零预估。
+        """
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Narration",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        scripts = {
+            "ep1.json": {
+                "episode": 1,
+                "title": "Episode 1",
+                "content_mode": "narration",
+                "duration_seconds": 10,
+                "novel": {"title": "t", "chapter": "c"},
+                "segments": [
+                    {"segment_id": "E1S1", "duration": 5, "narration": "n1", "visual_prompt": "v1"},
+                    {"segment_id": "E1S2", "duration": 5, "narration": "n2", "visual_prompt": "v2"},
+                ],
+            }
+        }
+
+        result = await service.compute(project_data, scripts, project_name="narration-transitional")
+
+        segments = result["episodes"][0]["segments"]
+        assert [seg["segment_id"] for seg in segments] == ["E1S1", "E1S2"]
+        assert result["project_totals"]["estimate"]["image"]
+        assert result["project_totals"]["estimate"]["video"]
 
     async def test_empty_episodes(self, db_factory):
         resolver = ConfigResolver(db_factory)

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -969,6 +969,52 @@ class TestCostEstimationService:
         assert result["project_totals"]["estimate"]["video"]
 
     @pytest.mark.integration
+    async def test_narration_reference_video_estimate_skips_unenqueueable_units(self, db_factory):
+        """没有 shots 或拼接文本为空的 unit 不可入队（``enqueue_videos.py::_reference_unit_spec``
+        对没有 shots 的 unit 直接拒绝，``TaskSpec.from_request`` 对空提示词同样拒绝），估算须
+        跳过这类 unit，不展示一笔查无实据的费用。
+        """
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        project_data = {
+            "title": "Narration",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "target_duration": 30,
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        script = _make_reference_video_script(1, "narration", [("E1U1", 6)])
+        script["video_units"].append(
+            {
+                "unit_id": "E1U2",
+                "shots": [],
+                "references": [],
+                "duration_seconds": 5,
+                "duration_override": False,
+                "transition_to_next": "cut",
+                "generated_assets": {"video_clip": None, "status": "pending"},
+            }
+        )
+        script["video_units"].append(
+            {
+                "unit_id": "E1U3",
+                "shots": [{"duration": 5, "text": "   "}],
+                "references": [],
+                "duration_seconds": 5,
+                "duration_override": False,
+                "transition_to_next": "cut",
+                "generated_assets": {"video_clip": None, "status": "pending"},
+            }
+        )
+        scripts = {"ep1.json": script}
+
+        result = await service.compute(project_data, scripts, project_name="narration-unenqueueable-units")
+
+        segments = result["episodes"][0]["segments"]
+        assert [seg["segment_id"] for seg in segments] == ["E1U1"]
+
+    @pytest.mark.integration
     async def test_narration_reference_video_estimate_handles_token_priced_video_model(self, db_factory):
         """按 token 计费的视频模型（Ark/Seedance）也要能算出非零视频预估。
 

--- a/tests/test_usage_repo.py
+++ b/tests/test_usage_repo.py
@@ -200,6 +200,27 @@ class TestFinalizePendingByCallId:
         calls = await repo.get_calls(project_name="demo")
         assert calls["items"][0]["usage_tokens"] == 12345, "usage_tokens 必须 UPDATE 写回 ApiCall 行"
 
+    async def test_settlement_does_not_approximate_missing_usage_tokens(self, db_session):
+        """provider 成功响应但漏报 usage（``usage_tokens`` 为 None）时，实付结算必须如实按
+        0 计费，不能借费用预估侧的 token 近似换算兜底把估算近似值当成真实支出记录——
+        该兜底只应在 ``CostCalculator.calculate_cost(estimate_only=True)`` 时生效
+        （见 ``server/services/cost_estimation.py::_estimate_unit_video_cost``），
+        ``UsageRepository._settle`` 走真实结算，不传 ``estimate_only``。"""
+        repo = UsageRepository(db_session)
+        call_id = await repo.start_call(
+            project_name="demo",
+            call_type="video",
+            model="doubao-seedance-1-0-pro",
+            duration_seconds=8,
+            provider="ark",
+        )
+
+        affected = await repo.finalize_pending_by_call_id(call_id=call_id, settlement=SettlementInput())
+        assert affected == 1
+
+        calls = await repo.get_calls(project_name="demo")
+        assert calls["items"][0]["cost_amount"] == 0.0, "usage_tokens 缺失时实付结算不得伪造近似金额"
+
     async def test_billed_duration_passed_to_cost_calculator_and_ledger(self, db_session, monkeypatch):
         """provider 回报的实际计费时长必须透传到 cost_calculator 并回写 ApiCall.duration_seconds，
         与 finish_call 的 billed_duration_seconds 覆盖语义一致（resume 路径不分叉）。"""

--- a/tests/test_usage_repo.py
+++ b/tests/test_usage_repo.py
@@ -200,6 +200,7 @@ class TestFinalizePendingByCallId:
         calls = await repo.get_calls(project_name="demo")
         assert calls["items"][0]["usage_tokens"] == 12345, "usage_tokens 必须 UPDATE 写回 ApiCall 行"
 
+    @pytest.mark.integration
     async def test_settlement_does_not_approximate_missing_usage_tokens(self, db_session):
         """provider 成功响应但漏报 usage（``usage_tokens`` 为 None）时，实付结算必须如实按
         0 计费，不能借费用预估侧的 token 近似换算兜底把估算近似值当成真实支出记录——


### PR DESCRIPTION
Closes #1469

## 改动

说书/剧集 + 参考生视频模式的视频费用预估此前恒为 0——估算循环遍历的分镜列表在该模式下恒为空，用户在生成前看到的预估完全不含视频成本。现改为遍历剧本的视频单元，按项目视频能力对单元时长取档后按档位计费，与实际申请的秒数对齐。

展示颗粒度按单元输出：说书/剧集的单元内镜头没有独立标识，单元本身就是前端画布与费用面板的最小可寻址单位，故不做费用摊回（广告模式的单元只是镜头分组索引，仍按既有口径摊回成员镜头）。实付按同一单元标识匹配，与记账侧写入的标识同源。

本地审查另修一处相关缺陷：项目已切到参考生视频、但某一集剧本还是分镜骨架时，实际入队的仍是分镜任务，估算却按尚不存在的视频单元走参考视频路径给出全零预估——该状态下现沿用分镜估算口径。

两条参考视频估算路径共用的询价步骤已抽出共用实现，避免后续两处漂移。

## 验证

- `uv run pytest`：6840 passed
- `uv run ruff check .` + `uv run ruff format --check .`：通过
- `uv run basedpyright`：0 error
- 新增服务层用例覆盖：视频估值非零、实付按单元标识匹配、单元时长偏离档位时按取档后档位计价、剧本未切换骨架时回落分镜口径。回落用例已实证在修复前会失败。
- 未做端到端（真实数据库 + 前端）验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在 narration/drama 的 `reference_video` 场景中，按视频单元生成视频预估并归并到集级/项目级；无有效时长素材的单元会保留但不生成视频预估。
  - 预估模式下，若视频按 token 计费且缺失 `usage_tokens`，会基于时长进行估算，避免预估为零。
- **Bug 修复**
  - 优化取档与脚本标记/回退的触发与映射逻辑，修复部分边界情况下的视频预估异常。
  - 结算时缺失 `usage_tokens` 不再触发 token 近似补算，避免误计非零费用。
- **测试**
  - 扩展 `reference_video` 路径集成回归与异常跳过用例；新增结算缺失用量不近似补算的验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->