### PR TITLE
refactor(media-generator): 费用记账 segment_id 判定收敛为单点函数

### DIFF
--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -63,6 +63,22 @@ def _is_413(exc: BaseException) -> bool:
     return "request entity too large" in msg or "payload too large" in msg
 
 
+# 记账 segment_id 判定：resource_id 可否作 segment_id 按 call_type 各自的 resource_type
+# 白名单收敛于此单点，image/video/audio 三条记账路径均经由它。
+_SEGMENT_ID_ALLOWED_RESOURCE_TYPES: dict[str, frozenset[str]] = {
+    "image": frozenset({"storyboards", "videos", "grids"}),
+    "video": frozenset({"storyboards", "videos", "reference_videos"}),
+}
+
+
+def segment_id_for(call_type: str, resource_type: str, resource_id: str) -> str | None:
+    """按记账调用类型与资源类型判定 segment_id；audio 无白名单，无条件透传。"""
+    if call_type == "audio":
+        return resource_id
+    allowed = _SEGMENT_ID_ALLOWED_RESOURCE_TYPES.get(call_type)
+    return resource_id if allowed is not None and resource_type in allowed else None
+
+
 class MediaGenerator:
     """
     媒体生成器中间层
@@ -342,7 +358,7 @@ class MediaGenerator:
             # 记账 provider 取解析层 provider_id；成对不变量保证 backend 非 None 时 provider_id 亦非 None。
             provider=cast(str, self._image_provider_id),
             user_id=self._user_id,
-            segment_id=resource_id if resource_type in ("storyboards", "videos", "grids") else None,
+            segment_id=segment_id_for("image", resource_type, resource_id),
             output_path=str(output_path),
         ) as call:
             from lib.reference_compression import ReferenceSpec, RefRole
@@ -436,7 +452,7 @@ class MediaGenerator:
             # 记账 provider 取解析层 provider_id；成对不变量保证 backend 非 None 时 provider_id 亦非 None。
             provider=cast(str, self._audio_provider_id),
             user_id=self._user_id,
-            segment_id=resource_id,
+            segment_id=segment_id_for("audio", resource_type, resource_id),
             output_path=str(output_path),
         ) as call:
             request = AudioSynthesisRequest(
@@ -621,7 +637,7 @@ class MediaGenerator:
             # 记账 provider 取解析层 provider_id；成对不变量保证 backend 非 None 时 provider_id 亦非 None。
             provider=cast(str, self._video_provider_id),
             user_id=self._user_id,
-            segment_id=resource_id if resource_type in ("storyboards", "videos", "reference_videos") else None,
+            segment_id=segment_id_for("video", resource_type, resource_id),
             service_tier=version_metadata.get("service_tier", "default"),
             output_path=str(output_path),
         ) as call:

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -31,7 +31,7 @@ from lib.db.base import DEFAULT_USER_ID
 from lib.gemini_shared import RateLimiter
 from lib.ledger import Ledger
 from lib.path_safety import PathTraversalError, safe_join
-from lib.providers import require_provider_pair
+from lib.providers import CallType, require_provider_pair
 from lib.resource_paths import resource_relative_path
 from lib.version_manager import VersionManager
 
@@ -65,18 +65,20 @@ def _is_413(exc: BaseException) -> bool:
 
 # 记账 segment_id 判定：resource_id 可否作 segment_id 按 call_type 各自的 resource_type
 # 白名单收敛于此单点，image/video/audio 三条记账路径均经由它。
-_SEGMENT_ID_ALLOWED_RESOURCE_TYPES: dict[str, frozenset[str]] = {
+_SEGMENT_ID_ALLOWED_RESOURCE_TYPES: dict[CallType, frozenset[str]] = {
     "image": frozenset({"storyboards", "videos", "grids"}),
     "video": frozenset({"storyboards", "videos", "reference_videos"}),
 }
 
 
-def segment_id_for(call_type: str, resource_type: str, resource_id: str) -> str | None:
+def segment_id_for(call_type: CallType, resource_type: str, resource_id: str) -> str | None:
     """按记账调用类型与资源类型判定 segment_id；audio 无白名单，无条件透传。"""
     if call_type == "audio":
         return resource_id
     allowed = _SEGMENT_ID_ALLOWED_RESOURCE_TYPES.get(call_type)
-    return resource_id if allowed is not None and resource_type in allowed else None
+    if allowed is None:
+        raise ValueError(f"unknown ledger channel: {call_type!r}")
+    return resource_id if resource_type in allowed else None
 
 
 class MediaGenerator:

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from lib.image_backends.base import ImageCapability, ImageGenerationResult
-from lib.media_generator import MediaGenerator
+from lib.media_generator import MediaGenerator, segment_id_for
 
 
 class _FakeImageBackend:
@@ -156,6 +156,38 @@ def _build_generator(tmp_path: Path) -> MediaGenerator:
     gen.versions = _FakeVersions()
     gen.ledger = _FakeLedger()
     return gen
+
+
+class TestSegmentIdFor:
+    """segment_id_for 是 image/video/audio 三条记账路径共用的单点判定函数。"""
+
+    @pytest.mark.parametrize(
+        "resource_type",
+        ["storyboards", "videos", "grids"],
+    )
+    def test_image_whitelist_hit(self, resource_type):
+        assert segment_id_for("image", resource_type, "E1S01") == "E1S01"
+
+    def test_image_whitelist_miss(self):
+        assert segment_id_for("image", "characters", "Alice") is None
+
+    @pytest.mark.parametrize(
+        "resource_type",
+        ["storyboards", "videos", "reference_videos"],
+    )
+    def test_video_whitelist_hit(self, resource_type):
+        assert segment_id_for("video", resource_type, "E1S01") == "E1S01"
+
+    def test_video_whitelist_miss(self):
+        # grids 只在图片记账白名单内，视频记账应落 None。
+        assert segment_id_for("video", "grids", "E1G1") is None
+
+    @pytest.mark.parametrize(
+        "resource_type",
+        ["audio", "storyboards", "characters"],
+    )
+    def test_audio_unconditional(self, resource_type):
+        assert segment_id_for("audio", resource_type, "E1S01") == "E1S01"
 
 
 class TestMediaGenerator:

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -158,6 +158,7 @@ def _build_generator(tmp_path: Path) -> MediaGenerator:
     return gen
 
 
+@pytest.mark.unit
 class TestSegmentIdFor:
     """segment_id_for 是 image/video/audio 三条记账路径共用的单点判定函数。"""
 
@@ -188,6 +189,11 @@ class TestSegmentIdFor:
     )
     def test_audio_unconditional(self, resource_type):
         assert segment_id_for("audio", resource_type, "E1S01") == "E1S01"
+
+    def test_unknown_call_type_raises(self):
+        # 未接入记账白名单的通道显式报错，避免 segment_id 静默丢失。
+        with pytest.raises(ValueError, match="unknown ledger channel"):
+            segment_id_for("text", "storyboards", "E1S01")
 
 
 class TestMediaGenerator:


### PR DESCRIPTION
Closes #1475

## 改动

「哪些 resource_type 的 resource_id 可作 segment_id 记账」原先内联在 `lib/media_generator.py` 的三处记账调用里，两份白名单相距约 280 行，新增 resource_type 时需记住同步多处。现收敛为模块级单点函数 `segment_id_for(call_type, resource_type, resource_id)`，图片/视频/音频三条记账路径均经由它。

签名按 `call_type` 分叉，因为同一 resource_type 在不同通道下归属不同（`grids` 仅在图片白名单内），只按 resource_type 判定无法表达这一差异。audio 原逻辑无白名单、无条件透传，保留为独立分支。

白名单成员与各 resource_type 的 segment_id 行为均保持不变，纯重构。记账通道参数复用 `lib.providers.CallType`，与 `lib/ledger.py` 全族签名口径一致；未接入白名单的通道显式报错，避免 segment_id 静默丢失。

## 验证

- `uv run python -m pytest tests/test_media_generator_module.py` — 39 passed，`TestSegmentIdFor` 覆盖三条路径的白名单内/外用例及未知通道；原有 `test_generate_video_async_segment_id_by_resource_type` 集成测试未改动仍通过
- `uv run ruff check` + `ruff format --check` — 通过
- `uv run basedpyright lib/media_generator.py tests/test_media_generator_module.py` — 0 error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化图像、视频和音频生成记录的资源关联判断，确保账务记录使用正确的资源标识。
  * 对不同生成类型支持明确的资源范围校验，避免无关资源被错误关联。
  * 对未知的生成类型提供明确的错误提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->