### PR TITLE
fix(assets): 从项目导入资产失败时按界面语言显示资产类型名

### DIFF
--- a/lib/asset_types.py
+++ b/lib/asset_types.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 
@@ -108,6 +109,16 @@ ILLEGAL_ASSET_NAME_CHARS: tuple[str, ...] = ("/", "\\", "\0", ":", "*", "?", '"'
 WINDOWS_RESERVED_BASENAMES: frozenset[str] = frozenset(
     {"CON", "PRN", "AUX", "NUL", *(f"COM{i}" for i in range(1, 10)), *(f"LPT{i}" for i in range(1, 10))}
 )
+
+
+def localize_asset_type(value: str, translate: Callable[..., str]) -> str:
+    """把资产类型内部标识（如 ``"product"``）替换为当前语言显示名。
+
+    未登记的类型值（不在 ``ASSET_SPECS`` 中）原样透传，不做语义映射。
+    """
+    if value not in ASSET_SPECS:
+        return value
+    return translate(f"asset_type_{value}")
 
 
 def validate_asset_name(name: object) -> str:

--- a/lib/asset_types.py
+++ b/lib/asset_types.py
@@ -6,6 +6,9 @@
 
 旧常量 ASSET_TYPES / BUCKET_KEY / SHEET_KEY 保留为 ASSET_SPECS 的派生，现有 18 处
 引用零修改。
+
+面向用户的显示名不落在 spec 里：``localize_asset_type`` 以注入的 translate 把类型标识
+映射到 ``lib/i18n`` 的 ``asset_type_*`` key，本模块因而不反向依赖 i18n。
 """
 
 from __future__ import annotations

--- a/server/routers/assets.py
+++ b/server/routers/assets.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 
 from lib.api_errors import NotFoundError
-from lib.asset_types import BUCKET_KEY, GLOBAL_LIBRARY_ASSET_TYPES, SHEET_KEY, validate_asset_name
+from lib.asset_types import BUCKET_KEY, GLOBAL_LIBRARY_ASSET_TYPES, SHEET_KEY, localize_asset_type, validate_asset_name
 from lib.db import async_session_factory
 from lib.db.repositories.asset_repo import AssetRepository
 from lib.i18n import Translator
@@ -272,7 +272,7 @@ async def from_project(
             detail=_t(
                 "asset_source_resource_not_found",
                 project=req.project_name,
-                kind=req.resource_type,
+                kind=localize_asset_type(req.resource_type, _t),
                 name=req.resource_id,
             ),
         )

--- a/server/routers/tasks.py
+++ b/server/routers/tasks.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 from fastapi import APIRouter, Query
 
 from lib.api_errors import BadRequestError, NotFoundError
-from lib.asset_types import ASSET_SPECS
+from lib.asset_types import localize_asset_type
 from lib.generation_queue import get_generation_queue
 from lib.i18n import Translator
 from lib.task_failure import render_failure
@@ -30,17 +30,17 @@ _ASSET_TYPE_PARAM_BY_WARNING: dict[str, str] = {"ref_ad_reference_skipped": "typ
 def _localize_warning_params(key: str, params: dict[str, Any], translate: Callable[..., str]) -> dict[str, Any]:
     """把 params 中裸的资产类型标识（如 ``"product"``）替换为当前语言显示名。
 
-    只处理已登记 warning key 的已知字段；未登记的类型值（非字符串，或不在
-    ``ASSET_SPECS`` 中）原样透传，不做语义映射——``isinstance`` 守卫同时挡住
-    畸形持久化值（如 list）落进 ``in ASSET_SPECS`` 抛 ``TypeError``。
+    只处理已登记 warning key 的已知字段；非字符串值（畸形持久化值，如 list）原样
+    透传，不做转换——``isinstance`` 守卫挡住其落进 ``localize_asset_type`` 的
+    ``in ASSET_SPECS`` 抛 ``TypeError``。
     """
     field = _ASSET_TYPE_PARAM_BY_WARNING.get(key)
     if field is None:
         return params
     value = params.get(field)
-    if not isinstance(value, str) or value not in ASSET_SPECS:
+    if not isinstance(value, str):
         return params
-    return {**params, field: translate(f"asset_type_{value}")}
+    return {**params, field: localize_asset_type(value, translate)}
 
 
 def _render_warnings(warnings: Any, translate: Callable[..., str]) -> list[str]:

--- a/tests/lib/test_asset_type_localization.py
+++ b/tests/lib/test_asset_type_localization.py
@@ -7,6 +7,15 @@ from lib.i18n import _ as translate_message
 
 pytestmark = pytest.mark.unit
 
+# 独立于被测 helper 与 translate_message 内部实现的显式期望值——若某个 asset_type_*
+# key 缺失，translate_message 会回退成 key 本身，用它自己再算一遍期望值会让测试对
+# 漏翻译失明，因此这里手写字面量作为 oracle。
+_EXPECTED_DISPLAY_NAMES = {
+    "zh": {"character": "角色", "scene": "场景", "prop": "道具", "product": "产品"},
+    "en": {"character": "character", "scene": "scene", "prop": "prop", "product": "product"},
+    "vi": {"character": "nhân vật", "scene": "cảnh", "prop": "đạo cụ", "product": "sản phẩm"},
+}
+
 
 def _translator(locale: str):
     def translate(key: str, **kwargs: object) -> str:
@@ -21,7 +30,7 @@ class TestLocalizeAssetType:
     def test_registered_type_renders_display_name(self, asset_type: str, locale: str):
         rendered = localize_asset_type(asset_type, _translator(locale))
 
-        assert rendered == translate_message(f"asset_type_{asset_type}", locale=locale)
+        assert rendered == _EXPECTED_DISPLAY_NAMES[locale][asset_type]
 
     def test_unregistered_type_passes_through_unmapped(self):
         """未登记值原样透传，不做语义映射，也不回落成 ``asset_type_widget`` 这样的 key。"""

--- a/tests/lib/test_asset_type_localization.py
+++ b/tests/lib/test_asset_type_localization.py
@@ -1,0 +1,28 @@
+"""共享 helper ``lib.asset_types.localize_asset_type`` 的映射与降级语义单测。"""
+
+import pytest
+
+from lib.asset_types import ASSET_SPECS, localize_asset_type
+from lib.i18n import _ as translate_message
+
+pytestmark = pytest.mark.unit
+
+
+def _translator(locale: str):
+    def translate(key: str, **kwargs: object) -> str:
+        return translate_message(key, locale=locale, **kwargs)
+
+    return translate
+
+
+class TestLocalizeAssetType:
+    @pytest.mark.parametrize("asset_type", sorted(ASSET_SPECS))
+    @pytest.mark.parametrize("locale", ["zh", "en", "vi"])
+    def test_registered_type_renders_display_name(self, asset_type: str, locale: str):
+        rendered = localize_asset_type(asset_type, _translator(locale))
+
+        assert rendered == translate_message(f"asset_type_{asset_type}", locale=locale)
+
+    def test_unregistered_type_passes_through_unmapped(self):
+        """未登记值原样透传，不做语义映射，也不回落成 ``asset_type_widget`` 这样的 key。"""
+        assert localize_asset_type("widget", _translator("zh")) == "widget"

--- a/tests/test_assets_router.py
+++ b/tests/test_assets_router.py
@@ -284,6 +284,7 @@ class TestFromProject:
         )
         assert r.status_code == 404
 
+    @pytest.mark.integration
     def test_from_project_missing_resource_error_localizes_kind(self, _assets_env):
         client = _assets_env["client"]
         pm = _assets_env["pm"]
@@ -293,6 +294,7 @@ class TestFromProject:
         zh = client.post(
             "/api/v1/assets/from-project",
             json={"project_name": "demo", "resource_type": "character", "resource_id": "ghost"},
+            headers={"Accept-Language": "zh"},
         )
         en = client.post(
             "/api/v1/assets/from-project",
@@ -314,7 +316,7 @@ class TestFromProject:
             kind=translate_message("asset_type_character", locale="en"),
             name="ghost",
         )
-        assert "nhân vật" in vi.json()["detail"]
+        assert "nhân vật" in vi.json()["detail"] and "character" not in vi.json()["detail"]
 
     def test_from_project_without_sheet_has_null_image_path(self, _assets_env):
         client = _assets_env["client"]

--- a/tests/test_assets_router.py
+++ b/tests/test_assets_router.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.db.base import Base
+from lib.i18n import _ as translate_message
 from lib.project_manager import ProjectManager
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
@@ -305,15 +306,15 @@ class TestFromProject:
         )
 
         assert "角色" in zh.json()["detail"] and "character" not in zh.json()["detail"]
-        assert "character" in en.json()["detail"]
+        # en 显示名与内部标识同形，区分不了裸透传，只能断言整句按 asset_type_* 渲染
+        assert en.json()["detail"] == translate_message(
+            "asset_source_resource_not_found",
+            locale="en",
+            project="demo",
+            kind=translate_message("asset_type_character", locale="en"),
+            name="ghost",
+        )
         assert "nhân vật" in vi.json()["detail"]
-
-    def test_from_project_missing_resource_unregistered_type_passthrough(self, _assets_env):
-        """resource_type 经 GLOBAL_LIBRARY_ASSET_TYPES 白名单校验，理论上不会命中未登记值；
-        本用例校验 localize_asset_type 透传语义未被破坏（防守性覆盖）。"""
-        from lib.asset_types import localize_asset_type
-
-        assert localize_asset_type("widget", lambda key, **_: key) == "widget"
 
     def test_from_project_without_sheet_has_null_image_path(self, _assets_env):
         client = _assets_env["client"]

--- a/tests/test_assets_router.py
+++ b/tests/test_assets_router.py
@@ -283,6 +283,38 @@ class TestFromProject:
         )
         assert r.status_code == 404
 
+    def test_from_project_missing_resource_error_localizes_kind(self, _assets_env):
+        client = _assets_env["client"]
+        pm = _assets_env["pm"]
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo")
+
+        zh = client.post(
+            "/api/v1/assets/from-project",
+            json={"project_name": "demo", "resource_type": "character", "resource_id": "ghost"},
+        )
+        en = client.post(
+            "/api/v1/assets/from-project",
+            json={"project_name": "demo", "resource_type": "character", "resource_id": "ghost"},
+            headers={"Accept-Language": "en"},
+        )
+        vi = client.post(
+            "/api/v1/assets/from-project",
+            json={"project_name": "demo", "resource_type": "character", "resource_id": "ghost"},
+            headers={"Accept-Language": "vi"},
+        )
+
+        assert "角色" in zh.json()["detail"] and "character" not in zh.json()["detail"]
+        assert "character" in en.json()["detail"]
+        assert "nhân vật" in vi.json()["detail"]
+
+    def test_from_project_missing_resource_unregistered_type_passthrough(self, _assets_env):
+        """resource_type 经 GLOBAL_LIBRARY_ASSET_TYPES 白名单校验，理论上不会命中未登记值；
+        本用例校验 localize_asset_type 透传语义未被破坏（防守性覆盖）。"""
+        from lib.asset_types import localize_asset_type
+
+        assert localize_asset_type("widget", lambda key, **_: key) == "widget"
+
     def test_from_project_without_sheet_has_null_image_path(self, _assets_env):
         client = _assets_env["client"]
         pm = _assets_env["pm"]


### PR DESCRIPTION
Closes #1479

## 变更

- 新增共享 helper `lib/asset_types.localize_asset_type(value, translate)`：把资产类型内部标识映射为当前语言显示名，未登记值原样透传（不做语义映射）。translate 以 `Callable` 注入，`lib` 层不反向依赖 `lib/i18n`。
- `server/routers/assets.py` 的 `asset_source_resource_not_found` 用它渲染 `{kind}`，不再把 `character`/`scene`/`prop` 裸透传进用户可见文案。
- `server/routers/tasks.py::_localize_warning_params` 改为消费同一 helper；非字符串畸形持久化值的 `isinstance` 守卫保留在调用侧（helper 入参契约是 `str`）。

未新增翻译 key（复用已有 `asset_type_*`），未触碰 `AssetSpec.label_zh` 及其消费方。

## 验证

- `uv run python -m pytest` — 6862 passed
- `uv run ruff check` / `ruff format` — clean；`uv run basedpyright` — 0 errors
- 新增覆盖：assets 路由 404 文案的 zh/en/vi 显示名（en 与内部标识同形，故用整句等值断言而非子串包含）；`tests/lib/test_asset_type_localization.py` 覆盖全部资产类型 × 三语映射与未登记值透传
- 对 `kind=` 做过变异验证：还原为裸透传时新增用例失败

## 说明

验收标准第 3 条的「未登记值透传」在 assets 路由层物理不可达——`resource_type` 先被 `GLOBAL_LIBRARY_ASSET_TYPES` 白名单拦成 400。该语义改由 helper 层单测覆盖。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 资产类型名称现支持按当前语言显示；已登记类型将自动使用本地化显示名，未登记类型保持原值。
* **错误修复**
  * 从项目导入资产时，“资源未找到”错误的 `detail` 中资产类型现本地化展示，避免暴露内部标识。
  * 任务警告中的资产类型本地化更稳健：仅在参数为字符串时进行转换，异常值保持透传。
* **测试**
  * 新增本地化工具与多语言断言用例，覆盖注册/未注册类型及接口返回文案。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->