### PR TITLE
fix(cost-estimation): 已产生费用合计与真实支出一致，未归属的历史支出单列

### DIFF
--- a/frontend/src/components/canvas/OverviewCanvas.test.tsx
+++ b/frontend/src/components/canvas/OverviewCanvas.test.tsx
@@ -426,6 +426,37 @@ describe("OverviewCanvas", () => {
     expect(screen.getAllByText("$1.25").length).toBeGreaterThanOrEqual(2);
   });
 
+  // 集级合计（totalBreakdown）会把 unassigned 一起算进去，明细必须同步列出这一项，
+  // 否则集行上会出现「各项相加 ≠ 合计」的无标签差额。
+  it("shows an episode-level historical spend row so its total stays explainable", () => {
+    const episodeCost = {
+      episode: 1,
+      title: "EP1",
+      segments: [],
+      totals: {
+        estimate: {},
+        actual: { video: { USD: 2 }, unassigned: { USD: 1.25 } },
+      },
+    };
+    useCostStore.setState({
+      costData: {
+        project_name: "real-project",
+        models: { image: { provider: "p", model: "m" }, video: { provider: "p", model: "m" } },
+        episodes: [episodeCost],
+        project_totals: {
+          estimate: {},
+          actual: { video: { USD: 2 }, unassigned: { USD: 1.25 } },
+        },
+      },
+      _episodeIndex: new Map([[1, episodeCost]]),
+    });
+
+    render(<OverviewCanvas projectName="real-project" projectData={makeProjectData()} />);
+
+    expect(screen.getAllByText("历史支出").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("$3.25").length).toBeGreaterThanOrEqual(1);
+  });
+
   it("cancels a real project's queued cost request when switching to the read-only demo project", async () => {
     vi.useFakeTimers();
     const getCostEstimateSpy = vi.spyOn(API, "getCostEstimate");

--- a/frontend/src/components/canvas/OverviewCanvas.test.tsx
+++ b/frontend/src/components/canvas/OverviewCanvas.test.tsx
@@ -407,6 +407,25 @@ describe("OverviewCanvas", () => {
     expect(getCostEstimateSpy).not.toHaveBeenCalled();
   });
 
+  it("shows historical spend that no longer belongs to the current script", () => {
+    useCostStore.setState({
+      costData: {
+        project_name: "real-project",
+        models: { image: { provider: "p", model: "m" }, video: { provider: "p", model: "m" } },
+        episodes: [],
+        project_totals: {
+          estimate: {},
+          actual: { unassigned: { USD: 1.25 } },
+        },
+      },
+    });
+
+    render(<OverviewCanvas projectName="real-project" projectData={makeProjectData()} />);
+
+    expect(screen.getByText("历史支出（未归属当前剧本）")).toBeInTheDocument();
+    expect(screen.getAllByText("$1.25").length).toBeGreaterThanOrEqual(2);
+  });
+
   it("cancels a real project's queued cost request when switching to the read-only demo project", async () => {
     vi.useFakeTimers();
     const getCostEstimateSpy = vi.spyOn(API, "getCostEstimate");

--- a/frontend/src/components/canvas/OverviewCanvas.tsx
+++ b/frontend/src/components/canvas/OverviewCanvas.tsx
@@ -821,6 +821,12 @@ export function OverviewCanvas({
                                   ? formatCost(epCost.totals.actual.audio)
                                   : undefined
                               }
+                              unassignedLabel={t("actual_unassigned_history_short")}
+                              unassignedValue={
+                                costEntries(epCost.totals.actual.unassigned).length > 0
+                                  ? formatCost(epCost.totals.actual.unassigned)
+                                  : undefined
+                              }
                               total={formatCost(totalBreakdown(epCost.totals.actual))}
                               totalLabel={t("total")}
                               accent="good"
@@ -941,6 +947,8 @@ function CostInline({
   videoValue,
   audioLabel,
   audioValue,
+  unassignedLabel,
+  unassignedValue,
   total,
   totalLabel,
   accent,
@@ -952,6 +960,8 @@ function CostInline({
   videoValue: string;
   audioLabel?: string;
   audioValue?: string;
+  unassignedLabel?: string;
+  unassignedValue?: string;
   total: string;
   totalLabel: string;
   accent: "warm" | "good";
@@ -973,6 +983,14 @@ function CostInline({
             {audioLabel}{" "}
           </span>
           <span style={{ color: "var(--color-text-2)" }}>{audioValue}</span>
+        </>
+      )}
+      {unassignedLabel != null && unassignedValue != null && (
+        <>
+          <span className="ml-2" style={{ color: "var(--color-text-4)" }}>
+            {unassignedLabel}{" "}
+          </span>
+          <span style={{ color: "var(--color-text-2)" }}>{unassignedValue}</span>
         </>
       )}
       <span className="ml-2" style={{ color: "var(--color-text-4)" }}>

--- a/frontend/src/components/canvas/OverviewCanvas.tsx
+++ b/frontend/src/components/canvas/OverviewCanvas.tsx
@@ -705,6 +705,14 @@ export function OverviewCanvas({
                           };
                         })
                         .filter((r): r is { label: string; value: string } => r !== null),
+                      ...(costEntries(projectTotals.actual.unassigned).length > 0
+                        ? [
+                            {
+                              label: t("actual_unassigned_history"),
+                              value: formatCost(projectTotals.actual.unassigned),
+                            },
+                          ]
+                        : []),
                     ]}
                     total={formatCost(totalBreakdown(projectTotals.actual))}
                     totalLabel={t("cost_total_short")}

--- a/frontend/src/components/canvas/reference/EpisodeHeader.test.tsx
+++ b/frontend/src/components/canvas/reference/EpisodeHeader.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useCostStore } from "@/stores/cost-store";
+import type { CostByType } from "@/types";
+import { EpisodeHeader } from "./EpisodeHeader";
+
+const UNITS = [{ duration_seconds: 5, generated_assets: { video_clip: "a.mp4" } }];
+
+function seedEpisodeCost(actual: CostByType) {
+  useCostStore.setState({
+    _episodeIndex: new Map([
+      [
+        1,
+        {
+          episode: 1,
+          title: "EP1",
+          segments: [],
+          totals: { estimate: { video: { USD: 8 } }, actual },
+        },
+      ],
+    ]),
+  });
+}
+
+afterEach(() => {
+  useCostStore.setState(useCostStore.getInitialState(), true);
+});
+
+describe("reference EpisodeHeader", () => {
+  it("counts history and audio spend in the episode actual", () => {
+    seedEpisodeCost({ video: { USD: 2 }, audio: { USD: 0.5 }, unassigned: { USD: 1.25 } });
+
+    render(<EpisodeHeader episode={1} title="EP1" units={UNITS} />);
+
+    expect(screen.getByText("$3.75")).toBeInTheDocument();
+  });
+
+  it("shows history spend even when the current units have none", () => {
+    seedEpisodeCost({ unassigned: { USD: 1.25 } });
+
+    render(<EpisodeHeader episode={1} title="EP1" units={UNITS} />);
+
+    expect(screen.getByText("$1.25")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/canvas/reference/EpisodeHeader.tsx
+++ b/frontend/src/components/canvas/reference/EpisodeHeader.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { EditableEpisodeTitle } from "@/components/canvas/EditableEpisodeTitle";
 import { useCostStore } from "@/stores/cost-store";
-import { formatCost } from "@/utils/cost-format";
+import { formatCost, totalBreakdown } from "@/utils/cost-format";
 
 /**
  * 头部统计只需要时长与成片两项，故按结构约束而非绑定具体单元类型：
@@ -35,8 +35,10 @@ export function EpisodeHeader({ episode, title, units, onSaveTitle, canEditTitle
       ready,
       totalDur,
       percent,
-      estimated: formatCost(epCost?.totals.estimate.video),
-      actual: formatCost(epCost?.totals.actual.video),
+      // 按全部费用类型聚合，而不是只取 video：参考视频集也会有旁白音频，以及已删改单元
+      // 留下的历史支出，只看 video 桶会让这一集显示得比实际花的少。
+      estimated: formatCost(totalBreakdown(epCost?.totals.estimate ?? {})),
+      actual: formatCost(totalBreakdown(epCost?.totals.actual ?? {})),
     };
   }, [units, epCost]);
 

--- a/frontend/src/components/canvas/timeline/EpisodeHeader.test.tsx
+++ b/frontend/src/components/canvas/timeline/EpisodeHeader.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { EpisodeCost, EpisodeMeta } from "@/types";
+import { EpisodeHeader } from "./EpisodeHeader";
+
+const EP: EpisodeMeta = { episode: 1, title: "Ep1", script_file: "episode_1.json" };
+
+function episodeCost(actual: EpisodeCost["totals"]["actual"]): EpisodeCost {
+  return {
+    episode: 1,
+    title: "Ep1",
+    segments: [],
+    totals: { estimate: { video: { USD: 10 } }, actual },
+  };
+}
+
+describe("EpisodeHeader", () => {
+  it("counts history spend as spent but not against the remaining estimate", () => {
+    render(
+      <EpisodeHeader
+        ep={EP}
+        segmentCount={1}
+        totalDuration={5}
+        episodeCost={episodeCost({ unassigned: { USD: 10 } })}
+      />,
+    );
+
+    // 已花含历史支出；剩余仍是整笔预估——那 $10 花在已被替换掉的旧剧本上，
+    // 当前剧本的工作一件也没做。
+    expect(screen.getAllByText("$10.00")).toHaveLength(3);
+  });
+
+  it("deducts current-script spend from the remaining estimate", () => {
+    render(
+      <EpisodeHeader
+        ep={EP}
+        segmentCount={1}
+        totalDuration={5}
+        episodeCost={episodeCost({ video: { USD: 4 } })}
+      />,
+    );
+
+    expect(screen.getByText("$4.00")).toBeInTheDocument();
+    expect(screen.getByText("$6.00")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/canvas/timeline/EpisodeHeader.tsx
+++ b/frontend/src/components/canvas/timeline/EpisodeHeader.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import { EditableEpisodeTitle } from "@/components/canvas/EditableEpisodeTitle";
 import type { EpisodeMeta } from "@/types";
 import type { EpisodeCost } from "@/types";
-import { totalBreakdown, formatCost } from "@/utils/cost-format";
+import { totalBreakdown, currentScriptBreakdown, formatCost } from "@/utils/cost-format";
 
 interface EpisodeHeaderProps {
   ep: EpisodeMeta;
@@ -31,12 +31,14 @@ export function EpisodeHeader({
       ? Math.round((ep.videos.completed / ep.scenes_count) * 100)
       : 0;
 
-  // 费用：取 estimate / actual 总和（按货币聚合）
+  // 费用：取 estimate / actual 总和（按货币聚合）。「已花」含历史支出，「剩余」只对当前剧本
+  // 结算，故按当前剧本口径扣减。
   const estimateBreakdown = episodeCost ? totalBreakdown(episodeCost.totals.estimate) : {};
   const actualBreakdown = episodeCost ? totalBreakdown(episodeCost.totals.actual) : {};
+  const currentScriptActual = episodeCost ? currentScriptBreakdown(episodeCost.totals.actual) : {};
   const remainingBreakdown: Record<string, number> = {};
   for (const [c, v] of Object.entries(estimateBreakdown)) {
-    remainingBreakdown[c] = Math.max(0, v - (actualBreakdown[c] ?? 0));
+    remainingBreakdown[c] = Math.max(0, v - (currentScriptActual[c] ?? 0));
   }
 
   return (

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -509,6 +509,7 @@ export default {
   'actual_props': 'Props',
   'actual_products': 'Products',
   'actual_unassigned_history': 'Historical spend (not assigned to the current script)',
+  'actual_unassigned_history_short': 'Historical spend',
   'regenerate_failed': 'Regeneration failed: {{message}}',
   'upload_failed': 'Upload failed: {{message}}',
   'delete_failed': 'Delete failed: {{message}}',

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -508,6 +508,7 @@ export default {
   'actual_scenes': 'Scenes',
   'actual_props': 'Props',
   'actual_products': 'Products',
+  'actual_unassigned_history': 'Historical spend (not assigned to the current script)',
   'regenerate_failed': 'Regeneration failed: {{message}}',
   'upload_failed': 'Upload failed: {{message}}',
   'delete_failed': 'Delete failed: {{message}}',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -498,6 +498,7 @@ export default {
   'actual_scenes': 'Cảnh',
   'actual_props': 'Đạo cụ',
   'actual_products': 'Sản phẩm',
+  'actual_unassigned_history': 'Chi phí trước đây (không thuộc kịch bản hiện tại)',
   'regenerate_failed': 'Tạo lại thất bại: {{message}}',
   'upload_failed': 'Tải lên thất bại: {{message}}',
   'delete_failed': 'Xóa thất bại: {{message}}',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -499,6 +499,7 @@ export default {
   'actual_props': 'Đạo cụ',
   'actual_products': 'Sản phẩm',
   'actual_unassigned_history': 'Chi phí trước đây (không thuộc kịch bản hiện tại)',
+  'actual_unassigned_history_short': 'Chi phí trước đây',
   'regenerate_failed': 'Tạo lại thất bại: {{message}}',
   'upload_failed': 'Tải lên thất bại: {{message}}',
   'delete_failed': 'Xóa thất bại: {{message}}',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -509,6 +509,7 @@ export default {
   'actual_props': '道具',
   'actual_products': '产品',
   'actual_unassigned_history': '历史支出（未归属当前剧本）',
+  'actual_unassigned_history_short': '历史支出',
   'regenerate_failed': '重新生成失败: {{message}}',
   'upload_failed': '上传失败: {{message}}',
   'delete_failed': '删除失败: {{message}}',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -508,6 +508,7 @@ export default {
   'actual_scenes': '场景',
   'actual_props': '道具',
   'actual_products': '产品',
+  'actual_unassigned_history': '历史支出（未归属当前剧本）',
   'regenerate_failed': '重新生成失败: {{message}}',
   'upload_failed': '上传失败: {{message}}',
   'delete_failed': '删除失败: {{message}}',

--- a/frontend/src/types/cost.ts
+++ b/frontend/src/types/cost.ts
@@ -10,6 +10,7 @@ export interface CostByType {
   scenes?: CostBreakdown;
   props?: CostBreakdown;
   products?: CostBreakdown;
+  unassigned?: CostBreakdown;
 }
 
 /** 单个 segment 的费用 */

--- a/frontend/src/utils/cost-format.test.ts
+++ b/frontend/src/utils/cost-format.test.ts
@@ -5,6 +5,7 @@ import {
   formatCostOrZero,
   formatCurrencyAmount,
   totalBreakdown,
+  currentScriptBreakdown,
 } from "./cost-format";
 
 describe("cost-format", () => {
@@ -50,5 +51,12 @@ describe("cost-format", () => {
         video: { CNY: 3 },
       }),
     ).toEqual({ CNY: 4.1112, USD: 2 });
+  });
+
+  it("excludes unassigned history from the current-script total", () => {
+    const actual = { video: { USD: 2 }, unassigned: { USD: 10 } };
+    expect(totalBreakdown(actual)).toEqual({ USD: 12 });
+    expect(currentScriptBreakdown(actual)).toEqual({ USD: 2 });
+    expect(currentScriptBreakdown({ unassigned: { USD: 10 } })).toEqual({});
   });
 });

--- a/frontend/src/utils/cost-format.ts
+++ b/frontend/src/utils/cost-format.ts
@@ -81,6 +81,18 @@ export function formatCostOrZero(breakdown: CostBreakdown | undefined): string {
   return formatCost(breakdown);
 }
 
+/**
+ * 当前剧本口径的合计：排除「历史支出（未归属当前剧本）」。
+ *
+ * 该项是已删改条目留下的真实支出，不对应当前剧本的任何工作量。算「剩余」时若把它当作
+ * 已完成部分从预估里扣掉，剩余会凭空变少——预估 $10、历史支出 $10 时会显示已无待付。
+ */
+export function currentScriptBreakdown(byType: CostByType): CostBreakdown {
+  const withoutHistory: CostByType = { ...byType };
+  delete withoutHistory.unassigned;
+  return totalBreakdown(withoutHistory);
+}
+
 export function totalBreakdown(byType: CostByType): CostBreakdown {
   const result: CostBreakdown = {};
   for (const costs of Object.values(byType) as (CostBreakdown | undefined)[]) {

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -944,6 +944,26 @@ class DataValidator:
                 f"超过 {AD_TARGET_DURATION_DRIFT_THRESHOLD:.0%} 观察阈值（仅提示，不阻塞保存）"
             )
 
+    @staticmethod
+    def _check_unit_id_unique(
+        unit_id: Any,
+        seen_unit_ids: set[str],
+        prefix: str,
+        errors: list[str],
+        *,
+        missing_message: str,
+    ) -> None:
+        """校验单个 unit_id 的存在性与唯一性。
+
+        video_units 与 reference_units 两处判重规则一致，共用此实现，避免规则调整时漏改一处。
+        """
+        if not unit_id or not isinstance(unit_id, str):
+            errors.append(f"{prefix}: {missing_message}")
+            return
+        if unit_id in seen_unit_ids:
+            errors.append(f"{prefix}: unit_id 重复 '{unit_id}'")
+        seen_unit_ids.add(unit_id)
+
     def _validate_reference_video_script(
         self,
         video_units: list[dict[str, Any]] | Any,
@@ -973,13 +993,13 @@ class DataValidator:
                 errors.append(f"{prefix}: 必须是对象")
                 continue
 
-            unit_id = unit.get("unit_id")
-            if not unit_id or not isinstance(unit_id, str):
-                errors.append(f"{prefix}: 缺少 unit_id")
-            else:
-                if unit_id in seen_unit_ids:
-                    errors.append(f"{prefix}: unit_id 重复 '{unit_id}'")
-                seen_unit_ids.add(unit_id)
+            self._check_unit_id_unique(
+                unit.get("unit_id"),
+                seen_unit_ids,
+                prefix,
+                errors,
+                missing_message="缺少 unit_id",
+            )
 
             shots = unit.get("shots")
             if not isinstance(shots, list) or not shots:
@@ -1055,13 +1075,13 @@ class DataValidator:
                 errors.append(f"{prefix}: 必须是对象")
                 continue
 
-            unit_id = unit.get("unit_id")
-            if not unit_id or not isinstance(unit_id, str):
-                errors.append(f"{prefix}: 缺少必填字段 unit_id")
-            else:
-                if unit_id in seen_unit_ids:
-                    errors.append(f"{prefix}: unit_id 重复 '{unit_id}'")
-                seen_unit_ids.add(unit_id)
+            self._check_unit_id_unique(
+                unit.get("unit_id"),
+                seen_unit_ids,
+                prefix,
+                errors,
+                missing_message="缺少必填字段 unit_id",
+            )
 
             ids = unit.get("shot_ids")
             if not isinstance(ids, list) or not ids:

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -965,6 +965,7 @@ class DataValidator:
             "scene": project_scenes,
             "prop": project_props,
         }
+        seen_unit_ids: set[str] = set()
 
         for index, unit in enumerate(video_units):
             prefix = f"video_units[{index}]"
@@ -972,8 +973,13 @@ class DataValidator:
                 errors.append(f"{prefix}: 必须是对象")
                 continue
 
-            if not unit.get("unit_id"):
+            unit_id = unit.get("unit_id")
+            if not unit_id or not isinstance(unit_id, str):
                 errors.append(f"{prefix}: 缺少 unit_id")
+            else:
+                if unit_id in seen_unit_ids:
+                    errors.append(f"{prefix}: unit_id 重复 '{unit_id}'")
+                seen_unit_ids.add(unit_id)
 
             shots = unit.get("shots")
             if not isinstance(shots, list) or not shots:
@@ -1042,6 +1048,7 @@ class DataValidator:
             return
 
         shot_ids = {s.get("shot_id") for s in shots if isinstance(s, dict)} if isinstance(shots, list) else set()
+        seen_unit_ids: set[str] = set()
         for index, unit in enumerate(units):
             prefix = f"reference_units[{index}]"
             if not isinstance(unit, dict):
@@ -1051,6 +1058,10 @@ class DataValidator:
             unit_id = unit.get("unit_id")
             if not unit_id or not isinstance(unit_id, str):
                 errors.append(f"{prefix}: 缺少必填字段 unit_id")
+            else:
+                if unit_id in seen_unit_ids:
+                    errors.append(f"{prefix}: unit_id 重复 '{unit_id}'")
+                seen_unit_ids.add(unit_id)
 
             ids = unit.get("shot_ids")
             if not isinstance(ids, list) or not ids:

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -23,8 +23,10 @@ from lib.providers import PROVIDER_GEMINI, CallType
 MAX_BILLED_DURATION_SECONDS = 86400
 
 # segment_id 为 NULL（资产图、文本调用等非分镜维度）的记账在按 segment 汇总时归入的哨兵键。
-# 消费方按此键把项目级支出与分镜级支出分开，故键名在生产/消费两侧共用同一常量。
-PROJECT_LEVEL_SEGMENT_KEY = "__project__"
+# 消费方按此键把项目级支出与分镜级支出分开，故键名在生产/消费两侧共用同一常量。前导 NUL 保证
+# 它撞不上任何真实 segment_id——后者取自 resource_id（分镜/单元 ID、资产名），不含控制字符。
+# 撞键会让剧本里同名的那个单元的支出既算进集合计、又作为项目级支出再算一次。
+PROJECT_LEVEL_SEGMENT_KEY = "\x00__project__"
 
 # 存量裸 provider 值的报表显示兜底：身份反转前，文本 gemini 调用以 backend.name 落账为裸
 # "gemini"（图像/视频侧已是 "gemini-aistudio"）。这些历史行不迁移，仅在分组报表按此表补一个

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -22,6 +22,10 @@ from lib.providers import PROVIDER_GEMINI, CallType
 # 解析侧（grok / dashscope extractor）的 clamp 引用同一常量，保持口径一致。
 MAX_BILLED_DURATION_SECONDS = 86400
 
+# segment_id 为 NULL（资产图、文本调用等非分镜维度）的记账在按 segment 汇总时归入的哨兵键。
+# 消费方按此键把项目级支出与分镜级支出分开，故键名在生产/消费两侧共用同一常量。
+PROJECT_LEVEL_SEGMENT_KEY = "__project__"
+
 # 存量裸 provider 值的报表显示兜底：身份反转前，文本 gemini 调用以 backend.name 落账为裸
 # "gemini"（图像/视频侧已是 "gemini-aistudio"）。这些历史行不迁移，仅在分组报表按此表补一个
 # 友好显示名；registry 只登记新格式 key（gemini-aistudio / gemini-vertex），故裸值查不到 meta。
@@ -639,7 +643,7 @@ class UsageRepository(BaseRepository):
 
         Returns:
             {segment_id: {call_type: {currency: total_amount}}}
-            segment_id 为 None 的记录归入 "__project__" 键。
+            segment_id 为 None 的记录归入 ``PROJECT_LEVEL_SEGMENT_KEY`` 键。
         """
         stmt = (
             select(
@@ -660,7 +664,7 @@ class UsageRepository(BaseRepository):
 
         result: dict[str, dict[str, dict[str, float]]] = {}
         for seg_id, call_type, currency, total in rows:
-            key = seg_id if seg_id is not None else "__project__"
+            key = seg_id if seg_id is not None else PROJECT_LEVEL_SEGMENT_KEY
             result.setdefault(key, {}).setdefault(call_type, {})[currency] = round(total, 6)
         return result
 

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from lib.config.resolver import ConfigResolver, get_provider_fallback
 from lib.cost_calculator import cost_calculator
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
-from lib.db.repositories.usage_repo import UsageRepository
+from lib.db.repositories.usage_repo import PROJECT_LEVEL_SEGMENT_KEY, UsageRepository
 from lib.grid.layout import calculate_grid_layout
 from lib.pricing.strategies import PricingParams
 from lib.project_manager import effective_mode
@@ -31,6 +31,8 @@ logger = logging.getLogger(__name__)
 
 CostBreakdown = dict[str, float]
 ActualBySegment = dict[str, dict[str, CostBreakdown]]
+# 费用页展示的记账类型；text 类调用不写 segment_id，只会落在项目级汇总里。
+ACTUAL_COST_TYPES = ("image", "video", "audio")
 
 
 def _add_cost(target: CostBreakdown, amount: float, currency: str) -> None:
@@ -48,14 +50,27 @@ def _merge_breakdowns(a: CostBreakdown, b: CostBreakdown) -> CostBreakdown:
 
 def _claim_actual(
     actual_by_segment: ActualBySegment,
-    claimed_ids: set[str],
+    claimed: set[tuple[str, str]],
     segment_id: str,
+    cost_types: tuple[str, ...] = ACTUAL_COST_TYPES,
 ) -> dict[str, CostBreakdown]:
-    """认领一份 segment 实付；同一记账 key 在一次估算中最多返回一次。"""
-    if not segment_id or segment_id in claimed_ids:
+    """认领一份 segment 实付；同一 (记账 key, 类型) 在一次估算中最多返回一次。
+
+    认领粒度到类型而非整条 key：调用方只消费其中一部分类型时，剩下的仍是未认领状态，
+    由兜底聚合收进「未归属」，不会被整条认领吞掉。
+    """
+    if not segment_id:
         return {}
-    claimed_ids.add(segment_id)
-    return actual_by_segment.get(segment_id, {})
+    actual = actual_by_segment.get(segment_id, {})
+    claimed_now: dict[str, CostBreakdown] = {}
+    for cost_type in cost_types:
+        if (segment_id, cost_type) in claimed:
+            continue
+        claimed.add((segment_id, cost_type))
+        amounts = actual.get(cost_type)
+        if amounts:
+            claimed_now[cost_type] = amounts
+    return claimed_now
 
 
 def _split_cost_across(cost: CostBreakdown, parts: int) -> list[CostBreakdown]:
@@ -216,7 +231,7 @@ class CostEstimationService:
         episodes_result = []
         proj_est: dict[str, CostBreakdown] = {}
         proj_act: dict[str, CostBreakdown] = {}
-        claimed_actual_ids: set[str] = set()
+        claimed_actual: set[tuple[str, str]] = set()
 
         content_mode = project_data.get("content_mode", "narration")
         # 惰性解析：只有项目里真出现按 unit 计费的参考视频集时才触发这次额外 IO
@@ -282,7 +297,7 @@ class CostEstimationService:
                         generate_audio=generate_audio,
                         video_price=video_price,
                         actual_by_segment=actual_by_segment,
-                        claimed_actual_ids=claimed_actual_ids,
+                        claimed_actual=claimed_actual,
                     )
                 else:
                     segments_result, ep_est, ep_act = self._estimate_unit_reference_video_episode(
@@ -294,7 +309,7 @@ class CostEstimationService:
                         generate_audio=generate_audio,
                         video_price=video_price,
                         actual_by_segment=actual_by_segment,
-                        claimed_actual_ids=claimed_actual_ids,
+                        claimed_actual=claimed_actual,
                     )
                 _accumulate_episode(ep_meta, segments_result, ep_est, ep_act)
                 continue
@@ -333,7 +348,7 @@ class CostEstimationService:
             # Compute per-scene share of each grid's actual cost
             grid_actual_per_scene: dict[str, CostBreakdown] = {}
             for gid, sids in grid_to_scenes.items():
-                grid_cost = _claim_actual(actual_by_segment, claimed_actual_ids, gid).get("image", {})
+                grid_cost = _claim_actual(actual_by_segment, claimed_actual, gid, ("image",)).get("image", {})
                 if grid_cost:
                     n = len(sids)
                     per_scene: CostBreakdown = {cur: round(amt / n, 6) for cur, amt in grid_cost.items()}
@@ -392,7 +407,7 @@ class CostEstimationService:
                     except Exception:
                         logger.debug("无法计算 audio 预估 for %s", seg_id, exc_info=True)
 
-                seg_actual = _claim_actual(actual_by_segment, claimed_actual_ids, seg_id)
+                seg_actual = _claim_actual(actual_by_segment, claimed_actual, seg_id)
                 act_image: CostBreakdown = seg_actual.get("image", {})
                 if seg_id in grid_actual_per_scene:
                     act_image = _merge_breakdowns(act_image, grid_actual_per_scene[seg_id])
@@ -426,12 +441,13 @@ class CostEstimationService:
         # 前缀，可回填对应集；无法识别或对应集已不存在的记录仍纳入项目合计。
         episodes_by_number = {ep["episode"]: ep for ep in episodes_result}
         for segment_id, actual_by_type in actual_by_segment.items():
-            if segment_id == "__project__" or segment_id in claimed_actual_ids:
+            if segment_id == PROJECT_LEVEL_SEGMENT_KEY:
                 continue
             match = re.match(r"^E(\d+)(?:S|U)", segment_id)
             episode_result = episodes_by_number.get(int(match.group(1))) if match else None
-            for amounts in (actual_by_type.get(cost_type, {}) for cost_type in ("image", "video", "audio")):
-                if not amounts:
+            for cost_type in ACTUAL_COST_TYPES:
+                amounts = actual_by_type.get(cost_type, {})
+                if not amounts or (segment_id, cost_type) in claimed_actual:
                     continue
                 proj_act["unassigned"] = _merge_breakdowns(proj_act.get("unassigned", {}), amounts)
                 if episode_result is not None:
@@ -472,7 +488,7 @@ class CostEstimationService:
         generate_audio: bool,
         video_price: Any,
         actual_by_segment: ActualBySegment,
-        claimed_actual_ids: set[str],
+        claimed_actual: set[tuple[str, str]],
     ) -> tuple[list[dict[str, Any]], dict[str, CostBreakdown], dict[str, CostBreakdown]]:
         """ad + reference_video 集的估值：计费颗粒度是 unit，展示颗粒度是 shot。
 
@@ -543,8 +559,9 @@ class CostEstimationService:
 
             act_video: CostBreakdown = _claim_actual(
                 actual_by_segment,
-                claimed_actual_ids,
+                claimed_actual,
                 unit_id,
+                ("video",),
             ).get("video", {})
             est_by_shot = _split_cost_across(est_video, len(ad_shots))
             act_by_shot = _split_cost_across(act_video, len(ad_shots))
@@ -556,7 +573,7 @@ class CostEstimationService:
                 # 不因当前是 reference_video 模式而清空——那是用户已经花掉的真实费用。video
                 # 维度与 unit 分摊额合并而非互相替换：同一镜头可能既有切换前的历史视频调用
                 # （shot_id 记账），也有切换后的 unit 调用（unit_id 分摊），两者都是真实支出。
-                shot_actual = _claim_actual(actual_by_segment, claimed_actual_ids, shot_id)
+                shot_actual = _claim_actual(actual_by_segment, claimed_actual, shot_id)
                 shot_act_image = shot_actual.get("image", {})
                 shot_act_audio = shot_actual.get("audio", {})
                 shot_act_video = _merge_breakdowns(act_by_shot[idx], shot_actual.get("video", {}))
@@ -590,7 +607,7 @@ class CostEstimationService:
         generate_audio: bool,
         video_price: Any,
         actual_by_segment: ActualBySegment,
-        claimed_actual_ids: set[str],
+        claimed_actual: set[tuple[str, str]],
     ) -> tuple[list[dict[str, Any]], dict[str, CostBreakdown], dict[str, CostBreakdown]]:
         """narration/drama + reference_video 集的估值：unit 本身就是展示颗粒度，无需分摊。
 
@@ -664,7 +681,7 @@ class CostEstimationService:
                         video_price=video_price,
                     )
 
-            unit_actual = _claim_actual(actual_by_segment, claimed_actual_ids, unit_id)
+            unit_actual = _claim_actual(actual_by_segment, claimed_actual, unit_id)
             act_image: CostBreakdown = unit_actual.get("image", {})
             act_video: CostBreakdown = unit_actual.get("video", {})
             act_audio: CostBreakdown = unit_actual.get("audio", {})

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -440,22 +440,46 @@ class CostEstimationService:
         # 当前剧本没有认领到的历史记账仍是真实支出。规范 segment/unit ID 自带 E{n}
         # 前缀，可回填对应集；无法识别或对应集已不存在的记录仍纳入项目合计。
         episodes_by_number = {ep["episode"]: ep for ep in episodes_result}
+        # 剧本文件缺失或尚未生成的集不进入估算结果，但它的历史支出仍属于这一集。按需补一条
+        # 只含实付的集结果，让这笔钱显示在集行上，而不是静默退到项目合计。
+        meta_by_number = {ep_meta.get("episode"): ep_meta for ep_meta in episodes_meta}
+
+        def _attribution_target(episode_number: int) -> dict[str, Any] | None:
+            existing = episodes_by_number.get(episode_number)
+            if existing is not None:
+                return existing
+            ep_meta = meta_by_number.get(episode_number)
+            if ep_meta is None:
+                return None
+            created: dict[str, Any] = {
+                "episode": episode_number,
+                "title": ep_meta.get("title", ""),
+                "segments": [],
+                "totals": {"estimate": {}, "actual": {}},
+            }
+            episodes_result.append(created)
+            episodes_by_number[episode_number] = created
+            return created
+
         for segment_id, actual_by_type in actual_by_segment.items():
             if segment_id == PROJECT_LEVEL_SEGMENT_KEY:
                 continue
             match = re.match(r"^E(\d+)(?:S|U)", segment_id)
-            episode_result = episodes_by_number.get(int(match.group(1))) if match else None
             for cost_type in ACTUAL_COST_TYPES:
                 amounts = actual_by_type.get(cost_type, {})
                 if not amounts or (segment_id, cost_type) in claimed_actual:
                     continue
                 proj_act["unassigned"] = _merge_breakdowns(proj_act.get("unassigned", {}), amounts)
+                episode_result = _attribution_target(int(match.group(1))) if match else None
                 if episode_result is not None:
                     episode_actual = episode_result["totals"]["actual"]
                     episode_actual["unassigned"] = _merge_breakdowns(
                         episode_actual.get("unassigned", {}),
                         amounts,
                     )
+        # 补出来的集结果追加在末尾，重排回 project.json 的集顺序，让费用页集行不跳序。
+        meta_order = {ep_meta.get("episode"): i for i, ep_meta in enumerate(episodes_meta)}
+        episodes_result.sort(key=lambda ep: meta_order.get(ep["episode"], len(meta_order)))
 
         # Project-level actual costs (characters/scenes/props/products 资产图 —— segment_id is null)
         async with self._session_factory() as session:
@@ -464,6 +488,17 @@ class CostEstimationService:
             bucket = project_image_by_type.get(asset_type)
             if bucket:
                 proj_act[asset_type] = bucket
+        # segment_id 为空的记账里，资产图已按类型单列，剩下的仍是真实支出：无法按 output_path
+        # 归类的图，以及 segment_id 列回填前的历史 video/audio 行。它们没有集归属线索，只并入
+        # 项目级「未归属」。
+        project_level_actual = actual_by_segment.get(PROJECT_LEVEL_SEGMENT_KEY, {})
+        for amounts in (
+            project_image_by_type.get("other", {}),
+            project_level_actual.get("video", {}),
+            project_level_actual.get("audio", {}),
+        ):
+            if amounts:
+                proj_act["unassigned"] = _merge_breakdowns(proj_act.get("unassigned", {}), amounts)
 
         return {
             "project_name": project_name,

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import math
+import re
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -29,6 +30,7 @@ from server.services.reference_video_tasks import (
 logger = logging.getLogger(__name__)
 
 CostBreakdown = dict[str, float]
+ActualBySegment = dict[str, dict[str, CostBreakdown]]
 
 
 def _add_cost(target: CostBreakdown, amount: float, currency: str) -> None:
@@ -42,6 +44,18 @@ def _merge_breakdowns(a: CostBreakdown, b: CostBreakdown) -> CostBreakdown:
     for cur, amt in b.items():
         merged[cur] = round(merged.get(cur, 0) + amt, 6)
     return merged
+
+
+def _claim_actual(
+    actual_by_segment: ActualBySegment,
+    claimed_ids: set[str],
+    segment_id: str,
+) -> dict[str, CostBreakdown]:
+    """认领一份 segment 实付；同一记账 key 在一次估算中最多返回一次。"""
+    if not segment_id or segment_id in claimed_ids:
+        return {}
+    claimed_ids.add(segment_id)
+    return actual_by_segment.get(segment_id, {})
 
 
 def _split_cost_across(cost: CostBreakdown, parts: int) -> list[CostBreakdown]:
@@ -202,6 +216,7 @@ class CostEstimationService:
         episodes_result = []
         proj_est: dict[str, CostBreakdown] = {}
         proj_act: dict[str, CostBreakdown] = {}
+        claimed_actual_ids: set[str] = set()
 
         content_mode = project_data.get("content_mode", "narration")
         # 惰性解析：只有项目里真出现按 unit 计费的参考视频集时才触发这次额外 IO
@@ -267,6 +282,7 @@ class CostEstimationService:
                         generate_audio=generate_audio,
                         video_price=video_price,
                         actual_by_segment=actual_by_segment,
+                        claimed_actual_ids=claimed_actual_ids,
                     )
                 else:
                     segments_result, ep_est, ep_act = self._estimate_unit_reference_video_episode(
@@ -278,6 +294,7 @@ class CostEstimationService:
                         generate_audio=generate_audio,
                         video_price=video_price,
                         actual_by_segment=actual_by_segment,
+                        claimed_actual_ids=claimed_actual_ids,
                     )
                 _accumulate_episode(ep_meta, segments_result, ep_est, ep_act)
                 continue
@@ -316,7 +333,7 @@ class CostEstimationService:
             # Compute per-scene share of each grid's actual cost
             grid_actual_per_scene: dict[str, CostBreakdown] = {}
             for gid, sids in grid_to_scenes.items():
-                grid_cost = actual_by_segment.get(gid, {}).get("image", {})
+                grid_cost = _claim_actual(actual_by_segment, claimed_actual_ids, gid).get("image", {})
                 if grid_cost:
                     n = len(sids)
                     per_scene: CostBreakdown = {cur: round(amt / n, 6) for cur, amt in grid_cost.items()}
@@ -375,7 +392,7 @@ class CostEstimationService:
                     except Exception:
                         logger.debug("无法计算 audio 预估 for %s", seg_id, exc_info=True)
 
-                seg_actual = actual_by_segment.get(seg_id, {})
+                seg_actual = _claim_actual(actual_by_segment, claimed_actual_ids, seg_id)
                 act_image: CostBreakdown = seg_actual.get("image", {})
                 if seg_id in grid_actual_per_scene:
                     act_image = _merge_breakdowns(act_image, grid_actual_per_scene[seg_id])
@@ -404,6 +421,25 @@ class CostEstimationService:
                     )
 
             _accumulate_episode(ep_meta, segments_result, ep_est, ep_act)
+
+        # 当前剧本没有认领到的历史记账仍是真实支出。规范 segment/unit ID 自带 E{n}
+        # 前缀，可回填对应集；无法识别或对应集已不存在的记录仍纳入项目合计。
+        episodes_by_number = {ep["episode"]: ep for ep in episodes_result}
+        for segment_id, actual_by_type in actual_by_segment.items():
+            if segment_id == "__project__" or segment_id in claimed_actual_ids:
+                continue
+            match = re.match(r"^E(\d+)(?:S|U)", segment_id)
+            episode_result = episodes_by_number.get(int(match.group(1))) if match else None
+            for amounts in (actual_by_type.get(cost_type, {}) for cost_type in ("image", "video", "audio")):
+                if not amounts:
+                    continue
+                proj_act["unassigned"] = _merge_breakdowns(proj_act.get("unassigned", {}), amounts)
+                if episode_result is not None:
+                    episode_actual = episode_result["totals"]["actual"]
+                    episode_actual["unassigned"] = _merge_breakdowns(
+                        episode_actual.get("unassigned", {}),
+                        amounts,
+                    )
 
         # Project-level actual costs (characters/scenes/props/products 资产图 —— segment_id is null)
         async with self._session_factory() as session:
@@ -435,7 +471,8 @@ class CostEstimationService:
         video_resolution: str | None,
         generate_audio: bool,
         video_price: Any,
-        actual_by_segment: dict[str, dict[str, CostBreakdown]],
+        actual_by_segment: ActualBySegment,
+        claimed_actual_ids: set[str],
     ) -> tuple[list[dict[str, Any]], dict[str, CostBreakdown], dict[str, CostBreakdown]]:
         """ad + reference_video 集的估值：计费颗粒度是 unit，展示颗粒度是 shot。
 
@@ -504,7 +541,11 @@ class CostEstimationService:
                 video_price=video_price,
             )
 
-            act_video: CostBreakdown = actual_by_segment.get(unit_id, {}).get("video", {})
+            act_video: CostBreakdown = _claim_actual(
+                actual_by_segment,
+                claimed_actual_ids,
+                unit_id,
+            ).get("video", {})
             est_by_shot = _split_cost_across(est_video, len(ad_shots))
             act_by_shot = _split_cost_across(act_video, len(ad_shots))
 
@@ -515,7 +556,7 @@ class CostEstimationService:
                 # 不因当前是 reference_video 模式而清空——那是用户已经花掉的真实费用。video
                 # 维度与 unit 分摊额合并而非互相替换：同一镜头可能既有切换前的历史视频调用
                 # （shot_id 记账），也有切换后的 unit 调用（unit_id 分摊），两者都是真实支出。
-                shot_actual = actual_by_segment.get(shot_id, {})
+                shot_actual = _claim_actual(actual_by_segment, claimed_actual_ids, shot_id)
                 shot_act_image = shot_actual.get("image", {})
                 shot_act_audio = shot_actual.get("audio", {})
                 shot_act_video = _merge_breakdowns(act_by_shot[idx], shot_actual.get("video", {}))
@@ -548,7 +589,8 @@ class CostEstimationService:
         video_resolution: str | None,
         generate_audio: bool,
         video_price: Any,
-        actual_by_segment: dict[str, dict[str, CostBreakdown]],
+        actual_by_segment: ActualBySegment,
+        claimed_actual_ids: set[str],
     ) -> tuple[list[dict[str, Any]], dict[str, CostBreakdown], dict[str, CostBreakdown]]:
         """narration/drama + reference_video 集的估值：unit 本身就是展示颗粒度，无需分摊。
 
@@ -622,7 +664,7 @@ class CostEstimationService:
                         video_price=video_price,
                     )
 
-            unit_actual = actual_by_segment.get(unit_id, {})
+            unit_actual = _claim_actual(actual_by_segment, claimed_actual_ids, unit_id)
             act_image: CostBreakdown = unit_actual.get("image", {})
             act_video: CostBreakdown = unit_actual.get("video", {})
             act_audio: CostBreakdown = unit_actual.get("audio", {})

--- a/tests/lib/test_data_validator_reference.py
+++ b/tests/lib/test_data_validator_reference.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from lib.data_validator import DataValidator
 
 
@@ -124,6 +126,7 @@ def test_validator_rejects_invalid_shot_duration(tmp_path: Path):
     assert any("duration 必须是 1-15" in e for e in result.errors)
 
 
+@pytest.mark.integration
 def test_validator_rejects_duplicate_reference_video_unit_ids(tmp_path: Path):
     project = _reference_project()
     script = _valid_reference_script()
@@ -137,6 +140,7 @@ def test_validator_rejects_duplicate_reference_video_unit_ids(tmp_path: Path):
     assert any("unit_id 重复 'E1U1'" in error for error in result.errors)
 
 
+@pytest.mark.integration
 def test_validator_rejects_duplicate_ad_reference_unit_ids(tmp_path: Path):
     project = _reference_project()
     project.update({"content_mode": "ad", "target_duration": 10})

--- a/tests/lib/test_data_validator_reference.py
+++ b/tests/lib/test_data_validator_reference.py
@@ -124,6 +124,49 @@ def test_validator_rejects_invalid_shot_duration(tmp_path: Path):
     assert any("duration 必须是 1-15" in e for e in result.errors)
 
 
+def test_validator_rejects_duplicate_reference_video_unit_ids(tmp_path: Path):
+    project = _reference_project()
+    script = _valid_reference_script()
+    script["video_units"].append({**script["video_units"][0]})
+    _write(tmp_path, "project.json", project)
+    _write(tmp_path, "scripts/episode_1.json", script)
+
+    result = DataValidator().validate_project_tree(tmp_path)
+
+    assert not result.valid
+    assert any("unit_id 重复 'E1U1'" in error for error in result.errors)
+
+
+def test_validator_rejects_duplicate_ad_reference_unit_ids(tmp_path: Path):
+    project = _reference_project()
+    project.update({"content_mode": "ad", "target_duration": 10})
+    script = {
+        "episode": 1,
+        "title": "Ad",
+        "content_mode": "ad",
+        "shots": [
+            {
+                "shot_id": "E1S1",
+                "duration_seconds": 10,
+                "voiceover_text": "",
+                "image_prompt": "image",
+                "video_prompt": "video",
+            }
+        ],
+        "reference_units": [
+            {"unit_id": "E1U1", "shot_ids": ["E1S1"], "references": []},
+            {"unit_id": "E1U1", "shot_ids": ["E1S1"], "references": []},
+        ],
+    }
+    _write(tmp_path, "project.json", project)
+    _write(tmp_path, "scripts/episode_1.json", script)
+
+    result = DataValidator().validate_project_tree(tmp_path)
+
+    assert not result.valid
+    assert any("unit_id 重复 'E1U1'" in error for error in result.errors)
+
+
 def test_validator_rejects_reference_video_in_content_mode(tmp_path: Path):
     """content_mode 严格只允许 narration / drama；reference_video 属于 generation_mode
     维度。UI 不可达该值，无需兼容迁移，直接拒绝即可。

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -205,6 +205,98 @@ class TestCostEstimationService:
 
         seg = result["episodes"][0]["segments"][0]
         assert seg["actual"]["image"]["USD"] == pytest.approx(0.067)
+        assert "unassigned" not in result["episodes"][0]["totals"]["actual"]
+        assert "unassigned" not in result["project_totals"]["actual"]
+
+    async def test_duplicate_unit_id_does_not_double_count_actual_cost(self, db_factory):
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+        await _seed_call(
+            db_factory,
+            "duplicate-unit",
+            "video",
+            "veo-3.1",
+            provider="veo",
+            segment_id="E1U1",
+            cost_amount=1.25,
+            currency="USD",
+        )
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {
+            "ep1.json": _make_reference_video_script(
+                1,
+                "narration",
+                [("E1U1", 5), ("E1U1", 5)],
+            )
+        }
+
+        result = await service.compute(project_data, scripts, project_name="duplicate-unit")
+
+        assert result["episodes"][0]["totals"]["actual"]["video"]["USD"] == pytest.approx(1.25)
+        assert result["project_totals"]["actual"]["video"]["USD"] == pytest.approx(1.25)
+
+    async def test_deleted_unit_actual_cost_is_reconciled_as_unassigned(self, db_factory):
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+        await _seed_call(
+            db_factory,
+            "deleted-unit",
+            "video",
+            "veo-3.1",
+            provider="veo",
+            segment_id="E1U1",
+            cost_amount=1.25,
+            currency="USD",
+        )
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_reference_video_script(1, "narration", [("E1U2", 5)])}
+
+        result = await service.compute(project_data, scripts, project_name="deleted-unit")
+
+        episode = result["episodes"][0]
+        assert episode["totals"]["actual"]["unassigned"]["USD"] == pytest.approx(1.25)
+        assert result["project_totals"]["actual"]["unassigned"]["USD"] == pytest.approx(1.25)
+
+    async def test_replaced_script_reconciles_all_historical_actual_costs(self, db_factory):
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+        for unit_id, amount, call_type in (
+            ("E1U1", 0.4, "image"),
+            ("E1U2", 1.6, "video"),
+            ("E1U3", 0.2, "audio"),
+        ):
+            await _seed_call(
+                db_factory,
+                "replaced-script",
+                call_type,
+                "historical-model",
+                segment_id=unit_id,
+                cost_amount=amount,
+                currency="USD",
+            )
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_reference_video_script(1, "narration", [("E1U9", 5)])}
+
+        result = await service.compute(project_data, scripts, project_name="replaced-script")
+
+        episode = result["episodes"][0]
+        assert episode["totals"]["actual"]["unassigned"]["USD"] == pytest.approx(2.2)
+        assert result["project_totals"]["actual"]["unassigned"]["USD"] == pytest.approx(2.2)
 
     async def test_grid_actual_costs_apportioned_to_scenes(self, db_factory):
         """Grid actual cost should be split evenly among scenes sharing the grid_id."""

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -301,6 +301,100 @@ class TestCostEstimationService:
         assert episode["totals"]["actual"]["unassigned"]["USD"] == pytest.approx(2.2)
         assert result["project_totals"]["actual"]["unassigned"]["USD"] == pytest.approx(2.2)
 
+    @pytest.mark.integration
+    async def test_missing_script_episode_still_gets_history_row(self, db_factory):
+        """剧本文件缺失的集不进入估算，但它的历史支出仍要落在该集行上。"""
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+        await _seed_call(
+            db_factory,
+            "missing-script",
+            "video",
+            "historical-model",
+            segment_id="E2U1",
+            cost_amount=1.5,
+            currency="USD",
+        )
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "episodes": [
+                {"episode": 1, "title": "Ep1", "script_file": "ep1.json"},
+                {"episode": 2, "title": "Ep2", "script_file": "ep2.json"},
+            ],
+        }
+        # ep2.json 不在 scripts 里：模拟剧本文件已丢失、集元数据仍在 project.json 的状态
+        scripts = {"ep1.json": _make_reference_video_script(1, "narration", [("E1U1", 5)])}
+
+        result = await service.compute(project_data, scripts, project_name="missing-script")
+
+        episodes = result["episodes"]
+        assert [ep["episode"] for ep in episodes] == [1, 2]
+        assert episodes[1]["title"] == "Ep2"
+        assert episodes[1]["segments"] == []
+        assert episodes[1]["totals"]["actual"]["unassigned"]["USD"] == pytest.approx(1.5)
+        assert result["project_totals"]["actual"]["unassigned"]["USD"] == pytest.approx(1.5)
+
+    @pytest.mark.integration
+    async def test_null_segment_history_counts_as_unassigned(self, db_factory):
+        """segment_id 为空的历史 video/audio 与无法归类的图，同样是真实支出。"""
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+        await _seed_call(
+            db_factory,
+            "null-segment",
+            "video",
+            "historical-model",
+            segment_id=None,
+            cost_amount=2.0,
+            currency="USD",
+        )
+        await _seed_call(
+            db_factory,
+            "null-segment",
+            "audio",
+            "historical-model",
+            segment_id=None,
+            cost_amount=0.5,
+            currency="USD",
+        )
+        await _seed_call(
+            db_factory,
+            "null-segment",
+            "image",
+            "historical-model",
+            segment_id=None,
+            output_path="misc/legacy.png",
+            cost_amount=0.3,
+            currency="USD",
+        )
+        await _seed_call(
+            db_factory,
+            "null-segment",
+            "image",
+            "historical-model",
+            segment_id=None,
+            output_path="characters/hero.png",
+            cost_amount=0.7,
+            currency="USD",
+        )
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_reference_video_script(1, "narration", [("E1U1", 5)])}
+
+        result = await service.compute(project_data, scripts, project_name="null-segment")
+
+        project_actual = result["project_totals"]["actual"]
+        # 资产图按类型单列，其余（other 图 + video + audio）归入未归属
+        assert project_actual["characters"]["USD"] == pytest.approx(0.7)
+        assert project_actual["unassigned"]["USD"] == pytest.approx(2.8)
+        assert "unassigned" not in result["episodes"][0]["totals"]["actual"]
+
     async def test_grid_actual_costs_apportioned_to_scenes(self, db_factory):
         """Grid actual cost should be split evenly among scenes sharing the grid_id."""
         resolver = ConfigResolver(db_factory)

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -208,6 +208,7 @@ class TestCostEstimationService:
         assert "unassigned" not in result["episodes"][0]["totals"]["actual"]
         assert "unassigned" not in result["project_totals"]["actual"]
 
+    @pytest.mark.integration
     async def test_duplicate_unit_id_does_not_double_count_actual_cost(self, db_factory):
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)
@@ -240,6 +241,7 @@ class TestCostEstimationService:
         assert result["episodes"][0]["totals"]["actual"]["video"]["USD"] == pytest.approx(1.25)
         assert result["project_totals"]["actual"]["video"]["USD"] == pytest.approx(1.25)
 
+    @pytest.mark.integration
     async def test_deleted_unit_actual_cost_is_reconciled_as_unassigned(self, db_factory):
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)
@@ -267,6 +269,7 @@ class TestCostEstimationService:
         assert episode["totals"]["actual"]["unassigned"]["USD"] == pytest.approx(1.25)
         assert result["project_totals"]["actual"]["unassigned"]["USD"] == pytest.approx(1.25)
 
+    @pytest.mark.integration
     async def test_replaced_script_reconciles_all_historical_actual_costs(self, db_factory):
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)
@@ -342,6 +345,48 @@ class TestCostEstimationService:
         assert "grid" not in result["project_totals"]["actual"]
         # But should have the cost under "image"
         assert result["project_totals"]["actual"]["image"]["USD"] == pytest.approx(0.101, abs=1e-4)
+
+    @pytest.mark.integration
+    async def test_claimed_key_keeps_unconsumed_cost_types_as_unassigned(self, db_factory):
+        """认领粒度到 (记账 key, 类型)：宫格 key 上只消费 image，同 key 的 video 仍须计入未归属。"""
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        grid_id = "grid_mixed"
+        seg_ids = ["E1S001", "E1S002"]
+        await _seed_call(
+            db_factory,
+            "mixed-key",
+            "image",
+            "historical-model",
+            segment_id=grid_id,
+            cost_amount=0.6,
+            currency="USD",
+        )
+        await _seed_call(
+            db_factory,
+            "mixed-key",
+            "video",
+            "historical-model",
+            segment_id=grid_id,
+            cost_amount=1.4,
+            currency="USD",
+        )
+
+        overrides = [{"grid_id": grid_id, "grid_cell_index": i} for i in range(2)]
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "grid",
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_script(1, seg_ids, [6, 6], generated_assets_overrides=overrides)}
+
+        result = await service.compute(project_data, scripts, project_name="mixed-key")
+
+        project_actual = result["project_totals"]["actual"]
+        assert project_actual["image"]["USD"] == pytest.approx(0.6)
+        assert project_actual["unassigned"]["USD"] == pytest.approx(1.4)
 
     async def test_grid_partial_generation_some_without_grid_id(self, db_factory):
         """Scenes without grid_id should have empty actual image cost."""

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -395,6 +395,34 @@ class TestCostEstimationService:
         assert project_actual["unassigned"]["USD"] == pytest.approx(2.8)
         assert "unassigned" not in result["episodes"][0]["totals"]["actual"]
 
+    @pytest.mark.integration
+    async def test_unit_id_named_like_project_sentinel_is_not_double_counted(self, db_factory):
+        """剧本用哨兵键字面量作 unit_id 时，它的支出只算一次（哨兵键不与真实 ID 共用取值）。"""
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+        await _seed_call(
+            db_factory,
+            "sentinel-unit",
+            "video",
+            "historical-model",
+            segment_id="__project__",
+            cost_amount=3.0,
+            currency="USD",
+        )
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "reference_video",
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_reference_video_script(1, "narration", [("__project__", 5)])}
+
+        result = await service.compute(project_data, scripts, project_name="sentinel-unit")
+
+        project_actual = result["project_totals"]["actual"]
+        assert project_actual["video"]["USD"] == pytest.approx(3.0)
+        assert "unassigned" not in project_actual
+
     async def test_grid_actual_costs_apportioned_to_scenes(self, db_factory):
         """Grid actual cost should be split evenly among scenes sharing the grid_id."""
         resolver = ConfigResolver(db_factory)


### PR DESCRIPTION
Closes #1476

## 改动

费用预估页的「已产生费用」此前按当前剧本快照的 unit_id 与记账数据 join，有两类口径缺陷：剧本含重复 unit_id 时同一笔实付被累加多次；unit 被删除或剧本被替换后，历史记账不被任何当前条目命中而从合计中消失。

- 一次估算内按 (记账 key, 费用类型) 认领实付，同一笔最多计入一次
- 当前剧本未认领到的历史记账并入集与项目的「已产生费用」合计，并在项目卡片与集行各单列一项「历史支出（未归属当前剧本）」；能从 ID 前缀解析出集号的回填到对应集
- `lib/data_validator.py` 校验剧本内 unit_id 唯一性，覆盖 ad 派生单元与 narration/drama video_units
- 三语 i18n

未改记账 schema，未引入新的 unit 身份方案。

## 已知限制

无法解析集号或对应集已删除的历史记账只能纳入项目总计，现有 schema 无法可靠恢复其原集归属。

## 验证

- 后端全量 `pytest`：6880 passed
- `ruff check .` 通过；`basedpyright` 0 errors
- 前端 `pnpm lint` 通过；`pnpm check` 1477 passed
- 新增测试按状态组合覆盖：正常命中 / 重复 unit_id / 已删 unit / 剧本整体替换 / 同 key 上未被消费的费用类型；前端覆盖项目级与集级的单列行展示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 费用总览与分集卡片新增“历史支出（未归属当前剧本）/未分配历史”展示（满足条件时渲染相应金额行）。
  - 补充英语/越南语/中文仪表盘文案以支持未分配历史内容。
- **问题修复**
  - 修复历史费用在重复/变更/缺失/归类等情况下的重复计入与汇总不一致；未认领历史将回填至“未分配”口径。
  - 调整剩余费用按当前剧本口径计算；并校正“实际费用”展示范围。
- **测试**
  - 新增单元去重校验集成测试，扩展历史费用对账与回填、剩余/实际渲染场景覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->