### PR TITLE
fix(cost-estimation): 视频费用预估按运行时实际生效的模型与音频档位计算

### DIFF
--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -417,6 +417,9 @@ class ConfigResolver:
 
         优先级：项目级 `project.json.video_backend` > 系统设置 `default_video_backend` >
         系统默认 `_DEFAULT_VIDEO_BACKEND` > auto-resolve（按 registry 顺序挑第一个 ready）。
+
+        返回字面配置结果，不做自定义 provider 的身份收敛——供配置展示与「当前选的是哪个」类
+        判断使用；要拿运行时实际执行的身份请用 ``resolve_video_backend()``。
         """
         async with self._open_session() as (session, svc):
             return await self._resolve_video_backend(svc, session, project_name)
@@ -444,7 +447,12 @@ class ConfigResolver:
         """解析视频任务应使用的 ProviderModel。
 
         优先级：payload（历史任务携带的 ``video_provider``）> project（``video_backend``）> 全局默认。
-        视频任务无 capability 维度。不做任何 provider 归一化。
+        视频任务无 capability 维度；provider id 不做归一化。
+
+        返回的是**运行时有效身份**：自定义 provider 的 model 不存在、已禁用或 endpoint 的
+        media_type 不是 video 时，收敛到该 provider 默认启用的 video model，无可用默认则抛
+        ``ValueError``。能力查询与价格查询因此拿到同一身份。只要字面配置结果（不经收敛）
+        请改用 ``video_backend()``。
         """
         async with self._open_session() as (session, svc):
             return await self._resolve_video_provider_model(svc, session, project, payload)
@@ -575,6 +583,9 @@ class ConfigResolver:
         要调用的 ProviderModel（含历史任务 payload 覆盖），用此变体取能力可保证 duration
         守卫所依据的 supported_durations 与实际调用的 model 一致，避免「按项目默认 model
         的能力去校验 payload 解析出的 model」的错配。
+
+        入参身份仍会再收敛一次（口径同 ``resolve_video_backend``），因此直接传字面配置也能
+        拿到有效身份的能力；自定义 provider 无可用默认 model 时抛 ``ValueError``。
         """
         async with self._open_session() as (session, svc):
             return await self._resolve_video_caps_for_model(svc, session, provider_id, model_id, project)
@@ -588,19 +599,24 @@ class ConfigResolver:
         """费用预估用的有效 ``generate_audio``：读能力接口，解析不出时降级，绝不抛错。
 
         能力解析会对注册表里已下线的 model id 抛错，而价目查询对同一 id 仍会回落到该 provider
-        的默认模型出价（见 ``lib/pricing/lookup.py``）——此时估算仍要出数，且不能丢掉恒含音
-        出账的 provider 级规则，否则这些 provider 的历史 model 会被按静音档低估。
+        的默认模型出价（见 ``lib/pricing/lookup.py``）——此时估算仍要出数。降级口径分两层：
+        恒含音出账的 provider 按 provider 级规则取 True；其余 provider 没有默认执行档的信息，
+        只能回到请求值（backend 也正是照请求值下发并结算），若一律取 False，这些历史 model
+        会被按静音档低估。
         """
         try:
             caps = await self.video_capabilities_for_model(provider_id, model_id, project)
         except Exception as exc:
             logger.info(
-                "视频能力解析失败（%s/%s），计价 generate_audio 降级到 provider 级规则：%s",
+                "视频能力解析失败（%s/%s），计价 generate_audio 降级到 provider 级规则与请求值：%s",
                 provider_id,
                 model_id,
                 exc,
             )
-            return _video_audio_always_billed(provider_id)
+            if _video_audio_always_billed(provider_id):
+                return True
+            async with self._open_session() as (_session, svc):
+                return await self._resolve_video_generate_audio_from_project(svc, project)
         return bool(caps["generate_audio"])
 
     async def default_image_backend_t2i(self) -> tuple[str, str]:

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -36,6 +36,9 @@ from lib.db.repositories.credential_repository import CredentialRepository
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.project_manager import get_project_manager
 from lib.text_backends.base import TEXT_TASK_TIERS, VISION_REQUIRED_TASKS, TextTaskTier, TextTaskType
+from lib.video_backends.registry import (
+    effective_generate_audio_for_model as builtin_effective_generate_audio_for_model,
+)
 from lib.video_backends.registry import video_capabilities_for_model as builtin_video_capabilities_for_model
 
 logger = logging.getLogger(__name__)
@@ -168,6 +171,21 @@ def get_provider_fallback(provider_id: str | None, default: str = "1080p") -> st
         return PROVIDER_FALLBACK_RESOLUTION[provider_id]
     short = provider_id.split("-", 1)[0]
     return PROVIDER_FALLBACK_RESOLUTION.get(short, default)
+
+
+#: 请求里不下发 ``generate_audio`` 开关、供应商恒按含音档出账的 video provider。
+_VIDEO_AUDIO_ALWAYS_BILLED_PROVIDERS = frozenset({"gemini-aistudio"})
+
+
+def _video_audio_always_billed(provider_id: str) -> bool:
+    """该 provider 是否无视请求值恒按含音档出账。
+
+    AI Studio 的 Veo 请求不下发 ``generate_audio``（该开关仅存在于 Vertex 定价页，AI Studio
+    定价页无 audio-off 档），``GeminiVideoBackend`` 结算时对 ``backend_type != "vertex"`` 强制
+    True；这是 provider 级出账规则，registry 名 ``gemini`` 同时映射 aistudio / vertex，故按
+    provider_id 而非 backend 静态接口判定。
+    """
+    return provider_id in _VIDEO_AUDIO_ALWAYS_BILLED_PROVIDERS
 
 
 def _safe_dict(value: object, *, field: str) -> dict:
@@ -527,6 +545,7 @@ class ConfigResolver:
               "max_reference_images": int,         # registry: model.max_reference_images；custom: 合成后的生效值
               "first_frame": bool,                 # 生效值（系统判定 ⊕ 用户覆盖），与执行层同源
               "last_frame": bool,                  # 同上
+              "generate_audio": bool,              # backend 默认执行档生效后的计价参数
               "source": "registry" | "custom",
               "default_duration": int | None,      # 用户在 project.json 里设置的偏好
               "content_mode": str | None,
@@ -559,6 +578,30 @@ class ConfigResolver:
         """
         async with self._open_session() as (session, svc):
             return await self._resolve_video_caps_for_model(svc, session, provider_id, model_id, project)
+
+    async def video_pricing_generate_audio(
+        self,
+        provider_id: str,
+        model_id: str,
+        project: dict | None = None,
+    ) -> bool:
+        """费用预估用的有效 ``generate_audio``：读能力接口，解析不出时降级，绝不抛错。
+
+        能力解析会对注册表里已下线的 model id 抛错，而价目查询对同一 id 仍会回落到该 provider
+        的默认模型出价（见 ``lib/pricing/lookup.py``）——此时估算仍要出数，且不能丢掉恒含音
+        出账的 provider 级规则，否则这些 provider 的历史 model 会被按静音档低估。
+        """
+        try:
+            caps = await self.video_capabilities_for_model(provider_id, model_id, project)
+        except Exception as exc:
+            logger.info(
+                "视频能力解析失败（%s/%s），计价 generate_audio 降级到 provider 级规则：%s",
+                provider_id,
+                model_id,
+                exc,
+            )
+            return _video_audio_always_billed(provider_id)
+        return bool(caps["generate_audio"])
 
     async def default_image_backend_t2i(self) -> tuple[str, str]:
         """返回 (provider_id, model_id)，T2I 默认。"""
@@ -603,11 +646,18 @@ class ConfigResolver:
         svc: ConfigService,
         project_name: str | None,
     ) -> bool:
+        project = get_project_manager().load_project(project_name) if project_name else None
+        return await self._resolve_video_generate_audio_from_project(svc, project)
+
+    async def _resolve_video_generate_audio_from_project(
+        self,
+        svc: ConfigService,
+        project: dict | None,
+    ) -> bool:
         raw = await svc.get_setting("video_generate_audio", "")
         value = _parse_bool(raw) if raw else self._DEFAULT_VIDEO_GENERATE_AUDIO
 
-        if project_name:
-            project = get_project_manager().load_project(project_name)
+        if project is not None:
             override = project.get("video_generate_audio")
             if override is not None:
                 if isinstance(override, str):
@@ -693,6 +743,7 @@ class ConfigResolver:
         ``video_provider_settings.model``）的排空。payload provider 须是已知 provider（见
         ``_trusted_payload_provider``），否则不予信任、回退 project/global。
         """
+        selected: ProviderModel | None = None
         if payload:
             provider_id = _trusted_payload_provider(payload.get("video_provider"))
             if provider_id is not None:
@@ -700,9 +751,48 @@ class ConfigResolver:
                 settings_model = settings.get("model") if isinstance(settings, dict) else None
                 model = _payload_model_or_default(payload.get("video_model") or settings_model, provider_id, "video")
                 if model is not None:
-                    return ProviderModel(provider_id, model)
-        provider_id, model_id = await self._resolve_video_backend_from_project(svc, session, project)
-        return ProviderModel(provider_id, model_id)
+                    selected = ProviderModel(provider_id, model)
+        if selected is None:
+            provider_id, model_id = await self._resolve_video_backend_from_project(svc, session, project)
+            selected = ProviderModel(provider_id, model_id)
+        return await self._resolve_effective_video_provider_model(session, selected)
+
+    async def _resolve_effective_video_provider_model(
+        self,
+        session: AsyncSession,
+        selected: ProviderModel,
+    ) -> ProviderModel:
+        """把选择身份收敛为 backend 构造时会实际使用的视频身份。
+
+        内置 provider 的 registry 身份已是有效身份；自定义 provider 需与 loader 共用同一规则：
+        model 不存在、禁用或 endpoint 已改成其它 media_type 时，回退到默认启用 video model。
+        """
+        if not is_custom_provider(selected.provider_id):
+            return selected
+
+        # 延迟导入：分层契约（pyproject.toml [tool.importlinter]）以 lib.config 为下层，
+        # 而该符号所在的装配层反过来依赖 lib.config，模块级导入会成环；内置分支不用它，
+        # 也就不必为此拉起整个装配层。
+        from lib.custom_provider.endpoints import endpoint_to_media_type
+
+        try:
+            db_pid = parse_provider_id(selected.provider_id)
+        except ValueError as exc:
+            raise ValueError(f"invalid custom provider_id: {selected.provider_id}") from exc
+        repo = CustomProviderRepository(session)
+        model = await repo.get_model_by_ids(db_pid, selected.model_id)
+        if model is not None and model.is_enabled and endpoint_to_media_type(model.endpoint) == "video":
+            return selected
+
+        logger.warning(
+            "自定义模型 %s/%s 已不存在 / 已禁用 / 媒体类型不符（期望 video），身份解析回退到默认模型",
+            selected.provider_id,
+            selected.model_id,
+        )
+        default_model = await repo.get_default_model(db_pid, "video")
+        if default_model is None:
+            raise ValueError(f"custom model not found: {selected.provider_id}/{selected.model_id}")
+        return ProviderModel(selected.provider_id, default_model.model_id)
 
     async def _resolve_default_audio_backend(self, svc: ConfigService, session: AsyncSession) -> tuple[str, str]:
         raw = await svc.get_setting("default_audio_backend", "")
@@ -759,6 +849,8 @@ class ConfigResolver:
         session: AsyncSession,
         project: dict | None,
     ) -> dict:
+        # 只传选择身份：有效身份收敛由 `_resolve_video_caps_for_model` 统一做，
+        # 在此先做一遍会让自定义 provider 多跑一轮 model 查询。
         provider_id, model_id = await self._resolve_video_backend_from_project(svc, session, project)
         return await self._resolve_video_caps_for_model(svc, session, provider_id, model_id, project)
 
@@ -770,12 +862,13 @@ class ConfigResolver:
         model_id: str,
         project: dict | None,
     ) -> dict:
+        effective = await self._resolve_effective_video_provider_model(session, ProviderModel(provider_id, model_id))
+        provider_id, model_id = effective.provider_id, effective.model_id
         if is_custom_provider(provider_id):
             # 延迟导入：分层契约（pyproject.toml [tool.importlinter]）以 lib.config 为下层，
-            # 而这两个符号所在的装配层反过来依赖 lib.config，模块级导入会成环；注册表分支不用
-            # 它们，也就不必为此拉起整个装配层。
+            # 而该符号所在的装配层反过来依赖 lib.config，模块级导入会成环；注册表分支不用它，
+            # 也就不必为此拉起整个装配层。
             from lib.custom_provider.capabilities import synthesize_video_capabilities
-            from lib.custom_provider.endpoints import endpoint_to_media_type
 
             source = "custom"
             try:
@@ -784,19 +877,8 @@ class ConfigResolver:
                 raise ValueError(f"invalid custom provider_id: {provider_id}") from exc
             repo = CustomProviderRepository(session)
             model = await repo.get_model_by_ids(db_pid, model_id)
-            if model is not None and (not model.is_enabled or endpoint_to_media_type(model.endpoint) != "video"):
-                # 与 loader.load_custom_backend 同一条回退规则：请求 model 已禁用或 endpoint 媒体
-                # 类型不再是 video（用户在设置里改了该模型的 endpoint）时执行层改派默认启用 model，
-                # 展示的能力必须与执行层一致，否则这里要么按已失效的 model 合成能力，要么直接报错，
-                # 而执行层其实静默回退成功了。
-                logger.warning("自定义模型 %s/%s 已禁用或媒体类型不符，能力解析回退到默认模型", provider_id, model_id)
-                model = None
             if model is None:
-                default_model = await repo.get_default_model(db_pid, "video")
-                if default_model is None:
-                    raise ValueError(f"custom model not found: {provider_id}/{model_id}")
-                model = default_model
-                model_id = default_model.model_id
+                raise ValueError(f"custom model not found after identity resolution: {provider_id}/{model_id}")
 
             # 生效能力（系统判定 ⊕ 用户覆盖）只此一个合成点：工厂给执行层注入的也是它的返回值，
             # 展示层与执行层因此严格同源，不在此处自行合并覆盖或重算系统判定。纯函数不查
@@ -813,6 +895,9 @@ class ConfigResolver:
             max_reference_images = caps.max_reference_images
             first_frame = caps.first_frame
             last_frame = caps.last_frame
+            # 自定义供应商按声明单价计费（`CustomProviderPrice` 无音频维度），计价参数不因
+            # 默认执行档收窄，故沿用项目请求值。
+            default_tier_generates_audio = True
             raw_durations = model.supported_durations
             supported_durations: list[int] = []
             if raw_durations:
@@ -843,11 +928,28 @@ class ConfigResolver:
                 raise ValueError(f"cannot resolve video capabilities for {provider_id}/{model_id}: {exc}") from exc
             first_frame = builtin_caps.first_frame
             last_frame = builtin_caps.last_frame
+            try:
+                default_tier_generates_audio = builtin_effective_generate_audio_for_model(
+                    spec.registry_backend, model_id
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    f"cannot resolve video pricing capabilities for {provider_id}/{model_id}: {exc}"
+                ) from exc
 
         if not supported_durations:
             raise ValueError(f"supported_durations is empty for {provider_id}/{model_id}; cannot derive capabilities")
 
         max_duration = max(supported_durations)
+
+        requested_generate_audio = await self._resolve_video_generate_audio_from_project(svc, project)
+        # 恒含音出账的 provider 无视请求值；其余 backend 只有在项目请求开启、且无上下文能力
+        # 接口确认默认执行档会产出人声时，计价参数才为 True。
+        generate_audio = (
+            True
+            if _video_audio_always_billed(provider_id)
+            else requested_generate_audio and default_tier_generates_audio
+        )
 
         default_duration: int | None = None
         content_mode: str | None = None
@@ -873,6 +975,7 @@ class ConfigResolver:
             "max_reference_images": max_reference_images,
             "first_frame": first_frame,
             "last_frame": last_frame,
+            "generate_audio": generate_audio,
             "source": source,
             "default_duration": default_duration,
             "content_mode": content_mode,

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -249,6 +249,15 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
             max_reference_images=caps.max_reference_images,
         )
 
+    @staticmethod
+    def effective_generate_audio_for_model(model: str) -> bool:
+        """无逐请求档位上下文时，返回默认执行档真正生效的音频计价参数。
+
+        可灵默认档为 std，而官方仅 kling-v2-6 pro 能产出人声，因此这条供预估使用的
+        无上下文接口对所有 model 都返回 False；执行期仍由 ``_effective_audio`` 按请求档决定。
+        """
+        return False
+
     @property
     def video_capabilities(self) -> VideoCapabilities:
         return self.video_capabilities_for_model(self._model)

--- a/lib/video_backends/registry.py
+++ b/lib/video_backends/registry.py
@@ -44,3 +44,21 @@ def video_capabilities_for_model(name: str, model_id: str) -> VideoCapabilities:
     if not isinstance(caps, VideoCapabilities):
         raise ValueError(f"video backend {name!r} video_capabilities_for_model returned {type(caps).__name__}")
     return caps
+
+
+def effective_generate_audio_for_model(name: str, model_id: str) -> bool:
+    """读 backend 对默认执行档声明的有效 ``generate_audio`` 计价参数。
+
+    未声明专属规则的 backend 沿用请求值；需要按 model / 默认档收窄的 backend 通过同名
+    静态方法提供纯查询，避免估算侧复制执行实现。
+    """
+    factory = _BACKEND_FACTORIES.get(name)
+    if factory is None:
+        raise ValueError(f"Unknown video backend: {name}")
+    effective_fn = getattr(factory, "effective_generate_audio_for_model", None)
+    if effective_fn is None:
+        return True
+    result = effective_fn(model_id)
+    if not isinstance(result, bool):
+        raise ValueError(f"video backend {name!r} effective_generate_audio_for_model returned {type(result).__name__}")
+    return result

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -158,16 +158,8 @@ class CostEstimationService:
             except Exception:
                 video_provider, video_model = "unknown", "unknown"
 
-            try:
-                generate_audio = await r.video_generate_audio(project_name)
-            except Exception:
-                generate_audio = False
-            # AI Studio 的 Veo 请求不下发 generate_audio 参数（该开关仅存在于 Vertex 定价页，
-            # AI Studio 定价页无 audio-off 档），供应商恒按含音价出账；真实生成时
-            # GeminiVideoBackend 已按此结算实际用量（backend_type != "vertex" 强制 True，见
-            # lib/video_backends/gemini.py），此处对齐纯预估路径，避免二者口径分叉。
-            if video_provider == "gemini-aistudio":
-                generate_audio = True
+            # 有效 generate_audio 是 backend 实现内知识，此处只消费解析结果、不自行推断。
+            generate_audio = await r.video_pricing_generate_audio(video_provider, video_model, project_data)
 
             # 旁白配音（TTS）模型：project 覆盖 > 全局默认 > auto-resolve；
             # 未配置任何 audio 供应商时回落 unknown，该维度预估为空

--- a/tests/server/test_generation_context.py
+++ b/tests/server/test_generation_context.py
@@ -255,7 +255,8 @@ class TestActualIdentityQueries:
             "demo", None, project={"video_backend": f"{provider_id}/m-dead"}, video=VideoLaneRequest()
         )
 
-        assert ctx.video.provider_model == ProviderModel(provider_id, "m-dead")
+        # 身份解析链本身已收敛到运行时有效 model，不再把 m-dead 留给构造层二次修正。
+        assert ctx.video.provider_model == ProviderModel(provider_id, "m-live")
         assert ctx.video.backend_model == "m-live"
         # resolution 命中 m-live（实际身份）的 DB 默认，而非按解析意图 m-dead 落空
         assert ctx.video.resolution == "540p"

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -768,6 +768,33 @@ class TestVideoCapabilities:
         assert caps["last_frame"] is False
 
 
+class TestVideoPricingGenerateAudio:
+    """video_pricing_generate_audio：能力接口解析不出时的计价降级口径。"""
+
+    @pytest.mark.integration
+    async def test_falls_back_to_provider_rule_for_registry_unknown_model(self):
+        """注册表已下线的 veo model id 仍按含音档出价，不因能力解析失败被低估为静音档。"""
+        factory, engine = await _make_session()
+        try:
+            resolver = ConfigResolver(factory)
+            # veo-3.1-generate-001 只留在 gemini-vertex 注册表：能力查询抛错，而价目查询
+            # 仍会回落到 Gemini 家族费率出价。
+            result = await resolver.video_pricing_generate_audio("gemini-aistudio", "veo-3.1-generate-001")
+        finally:
+            await engine.dispose()
+        assert result is True
+
+    @pytest.mark.integration
+    async def test_falls_back_to_false_for_unknown_provider(self):
+        factory, engine = await _make_session()
+        try:
+            resolver = ConfigResolver(factory)
+            result = await resolver.video_pricing_generate_audio("unknown", "unknown")
+        finally:
+            await engine.dispose()
+        assert result is False
+
+
 class TestResolveImageBackend:
     """resolve_image_backend：payload > project > 全局默认，capability=t2i/i2i 各覆盖。"""
 
@@ -872,6 +899,52 @@ class TestResolveVideoBackend:
         project = {"video_backend": "ark/seedance-1-0-pro"}
         resolved = await resolver._resolve_video_provider_model(fake_svc, None, project, {})
         assert (resolved.provider_id, resolved.model_id) == ("ark", "seedance-1-0-pro")
+
+    @pytest.mark.integration
+    async def test_disabled_custom_model_resolves_to_runtime_default(self):
+        """身份解析直接交付执行层会实际调用的 model，不把禁用身份留给后续构造层修正。"""
+        from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
+
+        factory, engine = await _make_session()
+        try:
+            async with factory() as session:
+                provider = CustomProvider(
+                    display_name="Custom Fallback",
+                    discovery_format="openai",
+                    base_url="https://example.com",
+                    api_key="xxx",
+                )
+                session.add(provider)
+                await session.flush()
+                session.add_all(
+                    [
+                        CustomProviderModel(
+                            provider_id=provider.id,
+                            model_id="disabled-model",
+                            display_name="Disabled",
+                            endpoint="openai-video",
+                            is_enabled=False,
+                        ),
+                        CustomProviderModel(
+                            provider_id=provider.id,
+                            model_id="runtime-model",
+                            display_name="Runtime",
+                            endpoint="openai-video",
+                            is_enabled=True,
+                            is_default=True,
+                        ),
+                    ]
+                )
+                await session.commit()
+
+                resolver = ConfigResolver(factory)
+                resolved = await resolver.resolve_video_backend(
+                    {"video_backend": f"custom-{provider.id}/disabled-model"}, None
+                )
+        finally:
+            await engine.dispose()
+
+        assert (resolved.provider_id, resolved.model_id) == (f"custom-{provider.id}", "runtime-model")
 
     async def test_falls_through_to_global_default(self):
         resolver = ConfigResolver.__new__(ConfigResolver)

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -785,11 +785,40 @@ class TestVideoPricingGenerateAudio:
         assert result is True
 
     @pytest.mark.integration
-    async def test_falls_back_to_false_for_unknown_provider(self):
+    async def test_falls_back_to_requested_value_for_unknown_provider(self):
+        """非恒含音 provider 解析不出能力时保留请求值——价目仍回落 Gemini 家族的含音费率。"""
         factory, engine = await _make_session()
         try:
             resolver = ConfigResolver(factory)
             result = await resolver.video_pricing_generate_audio("unknown", "unknown")
+        finally:
+            await engine.dispose()
+        assert result is True
+
+    @pytest.mark.integration
+    async def test_keeps_requested_audio_for_vertex_unknown_model(self):
+        """gemini-vertex 上注册表没有的 model：backend 照请求值下发并结算，估算不得降为静音档。"""
+        factory, engine = await _make_session()
+        try:
+            resolver = ConfigResolver(factory)
+            # lite 只登记在 gemini-aistudio：把 backend 切到 vertex 却留着旧 model id 时，
+            # 能力查询抛 model not found，而价目查询仍按 Gemini 家族含音费率出价。
+            result = await resolver.video_pricing_generate_audio("gemini-vertex", "veo-3.1-lite-generate-preview")
+        finally:
+            await engine.dispose()
+        assert result is True
+
+    @pytest.mark.integration
+    async def test_project_audio_off_survives_capability_failure(self):
+        """项目关掉音频时降级路径同样按静音档出价，不凭空补成含音。"""
+        factory, engine = await _make_session()
+        try:
+            resolver = ConfigResolver(factory)
+            result = await resolver.video_pricing_generate_audio(
+                "gemini-vertex",
+                "veo-3.1-lite-generate-preview",
+                {"video_generate_audio": False},
+            )
         finally:
             await engine.dispose()
         assert result is False

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -1487,18 +1487,12 @@ class TestCostEstimationService:
         ],
     )
     async def test_video_estimate_generate_audio_by_provider(
-        self, db_factory, monkeypatch, video_backend, configured_generate_audio, expected_usd
+        self, db_factory, video_backend, configured_generate_audio, expected_usd
     ):
         """费用预估在所有 (provider, audio 开关) 组合下与供应商实际出账口径一致。
 
-        经 ``ConfigResolver.video_generate_audio`` 直接 monkeypatch 配置开关的解析结果，
-        绕开该方法内部对项目文件是否存在于磁盘的依赖（预估路径本不该受此约束）。
+        直接在已加载 project dict 中给出项目开关，验证能力解析不二次依赖磁盘项目文件。
         """
-
-        async def _fake_video_generate_audio(self, project_name=None):
-            return configured_generate_audio
-
-        monkeypatch.setattr(ConfigResolver, "video_generate_audio", _fake_video_generate_audio)
 
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)
@@ -1507,6 +1501,7 @@ class TestCostEstimationService:
             "title": "Test",
             "content_mode": "narration",
             "video_backend": video_backend,
+            "video_generate_audio": configured_generate_audio,
             "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
         }
         scripts = {"ep1.json": _make_script(1, ["E1S001"], [1])}
@@ -1515,6 +1510,75 @@ class TestCostEstimationService:
 
         seg = result["episodes"][0]["segments"][0]
         assert seg["estimate"]["video"]["USD"] == pytest.approx(expected_usd)
+
+    @pytest.mark.integration
+    async def test_kling_reference_model_estimate_uses_effective_silent_tier(self, db_factory):
+        """参考能力 model 不产出人声；即使项目开关为真，预估也应与 backend 结算的静音档一致。"""
+        service = CostEstimationService(ConfigResolver(db_factory), db_factory)
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "video_backend": "kling/kling-video-o1",
+            "video_generate_audio": True,
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+
+        result = await service.compute(
+            project_data, {"ep1.json": _make_script(1, ["E1S001"], [5])}, project_name="test"
+        )
+
+        # kling-video-o1 默认 std：静音 ¥0.6/s；错误沿用项目开关会走有声 ¥0.8/s。
+        assert result["episodes"][0]["segments"][0]["estimate"]["video"]["CNY"] == pytest.approx(3.0)
+
+    @pytest.mark.integration
+    async def test_disabled_custom_video_model_estimate_uses_runtime_fallback_price(self, db_factory):
+        """估算模型身份与 backend 构造一致：禁用项目模型后按默认启用模型的价格估算。"""
+        from lib.db.repositories.custom_provider_repo import CustomProviderRepository
+
+        async with db_factory() as session:
+            await CustomProviderRepository(session).create_provider(
+                display_name="Custom",
+                discovery_format="openai",
+                base_url="https://api.example.com",
+                api_key="k",
+                models=[
+                    {
+                        "model_id": "disabled",
+                        "display_name": "Disabled",
+                        "endpoint": "openai-video",
+                        "is_enabled": False,
+                        "price_unit": "second",
+                        "price_input": 9.0,
+                        "currency": "USD",
+                    },
+                    {
+                        "model_id": "runtime",
+                        "display_name": "Runtime",
+                        "endpoint": "openai-video",
+                        "is_enabled": True,
+                        "is_default": True,
+                        "price_unit": "second",
+                        "price_input": 0.1,
+                        "currency": "USD",
+                    },
+                ],
+            )
+            await session.commit()
+
+        service = CostEstimationService(ConfigResolver(db_factory), db_factory)
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "video_backend": "custom-1/disabled",
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+
+        result = await service.compute(
+            project_data, {"ep1.json": _make_script(1, ["E1S001"], [6])}, project_name="test-custom-fallback"
+        )
+
+        assert result["models"]["video"] == {"provider": "custom-1", "model": "runtime"}
+        assert result["episodes"][0]["segments"][0]["estimate"]["video"]["USD"] == pytest.approx(0.6)
 
     async def test_custom_provider_estimates_use_db_prices(self, db_factory):
         """自定义供应商预估：image/video/audio 单价来自 DB（与实际记账同源），估值按配置价格非零。"""

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -15,6 +15,7 @@ import pytest
 from lib.providers import PROVIDER_KLING
 from lib.video_backends.base import VideoCapability, VideoCapabilityError, VideoGenerationRequest
 from lib.video_backends.kling import KlingVideoBackend
+from lib.video_backends.registry import effective_generate_audio_for_model
 
 _SECRET = "s" * 40
 
@@ -168,6 +169,14 @@ class TestPerModelCapabilities:
         vc = b.video_capabilities
         assert vc.last_frame is True
         assert vc.reference_images is True and vc.max_reference_images == 4
+
+    def test_video_o1_pricing_audio_matches_effective_request(self, tmp_path):
+        """预估消费的 backend 能力接口与真实请求的 `_effective_audio` 对参考模型给出同一静音档。"""
+        backend = _jwt_backend("kling-video-o1")
+        request = _request(tmp_path, generate_audio=True)
+
+        assert effective_generate_audio_for_model("kling", "kling-video-o1") is False
+        assert backend._effective_audio(request) is False
 
     def test_unknown_model_falls_back_to_default_caps(self):
         # bearer 透传原生 model_name：未登记 → 保守默认（t2v+i2v、尾帧仅 pro 档，声明按 std 档保守


### PR DESCRIPTION
Closes #1477

## 变更

「本项目运行时实际使用哪个视频模型、哪些计价参数生效」收敛为单一 owner，费用预估侧不再各自复制一份：

- 自定义模型的失效回退（不存在 / 已禁用 / endpoint 已改成其它 media_type）提前到 `resolve_video_backend` 身份解析链本体，能力查询与价格查询两个消费方拿到同一「运行时有效身份」。backend loader 原有回退保留为防御层，实际调用与结算行为不变。
- 有效 `generate_audio` 经视频能力接口暴露（`video_capabilities` 新增同名字段），估算侧消费该结果。可灵按 `effective_generate_audio_for_model` 声明默认执行档不产出人声，与 `_effective_audio` 的结算口径一致；AI Studio 恒含音出账规则一并收归解析结果，估算服务不再保留供应商特判。
- 记账/结算侧行为不变：仍按实际调用模型与 `result.generate_audio` 计费。

## 本地审查中的修正

- **AI Studio 降级路径回归**：原实现把 `generate_audio` 整体挪进 `try`，能力解析一旦抛错就降级为 `False`。该场景可达——`gemini-aistudio` + 已下线的 `veo-3.1-generate-001` 这类历史 model id 在注册表能力查询会抛错，而价目查询仍会回落到 Gemini 家族费率出价，结果是含音模型被按静音档低估。新增 `ConfigResolver.video_pricing_generate_audio()`：读能力接口，解析不出时降级到 provider 级出账规则且不抛错；provider 级规则收敛到单一谓词，估算服务侧不再自行判定。
- 去掉能力解析路径上重复的一次有效身份收敛（自定义 provider 曾因此多跑一轮 model 查询）。
- 命名与注释：`backend_generate_audio` → `default_tier_generates_audio`；延迟导入的分层理由随符号迁移同步修正；补充自定义供应商按声明单价计费、计价参数不收窄的理由。

## 验证

- `pytest` 全量 6889 passed
- `basedpyright` 0 errors
- `ruff check` / `ruff format --check` 通过
- 新增回归测试：注册表已下线 model id 的计价降级口径、未知 provider 降级为静音档
- 前端未改动，未跑前端检查


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 视频能力信息新增“是否生成音频（generate_audio）”标识。
  * 提供视频计价预估获取生效“是否生成音频”的能力解析接口。
  * 计价预估可依据供应商/模型与后端规则推导生效口径。
* **问题修复**
  * 能力解析失败时按供应商/项目开关与默认规则进行降级，避免误判为静音。
  * 当请求的自定义模型被禁用或不可用时，自动回退到运行时默认启用模型，并按其价格计费。
* **测试**
  * 补充并调整视频生成计价与模型回退相关用例验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->