### PR TITLE
refactor(reference-video): 收敛剧本 reference_video 戳判定为单一谓词

### DIFF
--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -906,6 +906,15 @@ class ReferenceVideoScript(BaseModel):
     video_units: list[ReferenceVideoUnit] = Field(description="视频单元列表")
 
 
+def is_reference_script(script: dict) -> bool:
+    """判定剧本自身的 ``generation_mode`` 戳是否为 ``reference_video``。
+
+    仅适用于 narration/drama：剧本自身携带 generation_mode 戳。ad 骨架不打此戳，
+    真相源是项目/集级配置（``effective_mode``），不适用本谓词。
+    """
+    return script.get("generation_mode") == "reference_video"
+
+
 # ============ 参考生视频 step1 结构化中间态 ============
 #
 # 两段式职责切分（与 narration / drama 同机制，见 ADR 0041）：step1（video_unit 拆分）产出

--- a/lib/storyboard_sequence.py
+++ b/lib/storyboard_sequence.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from lib.path_safety import safe_join, try_safe_join
 from lib.script_editor import resolve_items
+from lib.script_models import is_reference_script
 from lib.script_skeleton import SKELETONS
 
 
@@ -45,7 +46,7 @@ def get_storyboard_items(script: dict) -> tuple[list[dict], str, str | None, str
     ``ScriptEditError``——读取侧的调用方（``cost_estimation`` / 路由 / enqueue 工具）应让
     异常上冒，避免脏数据被静默吞成 ``TypeError: 'NoneType' is not iterable``。
     """
-    if script.get("generation_mode") == "reference_video":
+    if is_reference_script(script):
         unit = SKELETONS["video_units"]
         return ([], unit.id_field, unit.chars_field, "scenes", "props")
 

--- a/server/agent_runtime/sdk_tools/enqueue_narration_audio.py
+++ b/server/agent_runtime/sdk_tools/enqueue_narration_audio.py
@@ -15,7 +15,7 @@ from lib.generation_queue_client import (
     batch_enqueue_and_wait,
 )
 from lib.resource_paths import resource_relative_path
-from lib.script_models import get_generated_assets
+from lib.script_models import get_generated_assets, is_reference_script
 from lib.storyboard_sequence import get_storyboard_items
 from server.agent_runtime.sdk_tools._context import ToolContext, tool_error, validate_script_filename
 
@@ -72,7 +72,7 @@ def generate_narration_audio_tool(ctx: ToolContext):
             if not items:
                 # reference_video 模式 get_storyboard_items 硬返回空列表；空剧本同样
                 # 无可配音项。两者都不能落进"✨ 已全部生成"的假成功分支。
-                if script.get("generation_mode") == "reference_video":
+                if is_reference_script(script):
                     raise ValueError("参考生视频（reference_video）模式剧本没有 segments，不适用旁白配音")
                 raise ValueError("剧本没有可配音的片段")
 

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -27,7 +27,7 @@ from lib.reference_video.ad_units import (
     resolve_ad_unit_shots,
     sync_ad_reference_units,
 )
-from lib.script_models import get_generated_assets
+from lib.script_models import get_generated_assets, is_reference_script
 from lib.storyboard_sequence import get_storyboard_items, resolve_storyboard_image_ref
 from server.agent_runtime.sdk_tools._context import (
     ToolContext,
@@ -143,10 +143,6 @@ def _get_video_prompt(item: dict[str, Any]) -> str:
         item_id = item.get("segment_id") or item.get("scene_id")
         raise TypeError(f"片段/场景 video_prompt 类型无效（期望 str 或 dict）: {item_id}")
     return prompt
-
-
-def _is_reference_script(script: dict[str, Any]) -> bool:
-    return script.get("generation_mode") == "reference_video"
 
 
 def _is_ad_reference(ctx: ToolContext, script: dict[str, Any]) -> bool:
@@ -533,7 +529,7 @@ async def _run_reference_episode(
     """Run reference_video-mode generation and format the tool response.
 
     All 4 video handlers fall through to whole-episode reference generation
-    when ``_is_reference_script`` returns True; this captures the shared tail
+    when ``is_reference_script`` returns True; this captures the shared tail
     (resolve episode → generate units → header + log).
     """
     episode = ProjectManager.resolve_episode_from_script(script, script_filename)
@@ -646,7 +642,7 @@ def generate_video_episode_tool(ctx: ToolContext):
             project_dir = ctx.project_path
             script = ctx.pm.load_script(ctx.project_name, script_filename)
 
-            if _is_reference_script(script):
+            if is_reference_script(script):
                 return await _run_reference_episode(
                     ctx=ctx,
                     script=script,
@@ -746,7 +742,7 @@ def generate_video_scene_tool(ctx: ToolContext):
             project_dir = ctx.project_path
             script = ctx.pm.load_script(ctx.project_name, script_filename)
 
-            if _is_reference_script(script):
+            if is_reference_script(script):
                 log: list[str] = [
                     f"⚠️  reference_video 模式暂不支持单 unit 精确选择；scene_id={scene_id} 被忽略，转整集生成。"
                 ]
@@ -849,7 +845,7 @@ def generate_video_all_tool(ctx: ToolContext):
             project_dir = ctx.project_path
             script = ctx.pm.load_script(ctx.project_name, script_filename)
 
-            if _is_reference_script(script):
+            if is_reference_script(script):
                 return await _run_reference_episode(
                     ctx=ctx,
                     script=script,
@@ -938,7 +934,7 @@ def generate_video_selected_tool(ctx: ToolContext):
             project_dir = ctx.project_path
             script = ctx.pm.load_script(ctx.project_name, script_filename)
 
-            if _is_reference_script(script):
+            if is_reference_script(script):
                 log.append(
                     f"⚠️  reference_video 模式暂不支持多 unit 精确选择；scene_ids={','.join(scene_ids)} 被忽略，转整集生成。"
                 )

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -19,7 +19,7 @@ from lib.project_manager import effective_mode
 from lib.reference_video import assemble_shots_text
 from lib.reference_video.ad_units import derive_ad_reference_units, resolve_ad_unit_shots
 from lib.script_editor import ScriptEditError
-from lib.script_models import get_generated_assets
+from lib.script_models import get_generated_assets, is_reference_script
 from lib.storyboard_sequence import get_storyboard_items, group_scenes_by_segment_break
 from server.services.reference_video_tasks import (
     ProjectDurationContext,
@@ -263,7 +263,7 @@ class CostEstimationService:
             #
             # ad 骨架唯一、shots 不打 generation_mode 戳，生成路径以项目级/集级戳为真相源，故
             # 只按 ``effective_mode`` 判定；narration/drama 的生成侧只认剧本自身的 generation_mode
-            # 戳（``server/agent_runtime/sdk_tools/enqueue_videos.py::_is_reference_script``），从不
+            # 戳（``lib.script_models.is_reference_script``），从不
             # 读 ``effective_mode``，估算须跟同一口径——项目/集事后经 PATCH 把 effective_mode 改回
             # storyboard、但该集剧本仍保留切换前的 reference_video 戳时，实际入队仍按剧本戳走 unit
             # 路径，估算若再叠加 ``effective_mode`` 门槛会误判回落分镜，与实际生成对不上。
@@ -273,7 +273,7 @@ class CostEstimationService:
             if content_mode == "ad":
                 estimate_by_unit = is_reference_video
             else:
-                estimate_by_unit = script.get("generation_mode") == "reference_video"
+                estimate_by_unit = is_reference_script(script)
 
             if estimate_by_unit:
                 if duration_ctx is None:

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -1206,7 +1206,7 @@ class TestCostEstimationService:
     async def test_narration_reference_video_estimate_follows_script_stamp_over_effective_mode(self, db_factory):
         """项目级 ``generation_mode`` 事后回退到 storyboard，但该集剧本仍保留切换前的
         ``reference_video`` 戳时，估算须跟随剧本戳走 unit 路径，不因项目级戳回退而误判回落
-        分镜——实际入队（``_is_reference_script``）只认剧本自身的戳，从不读 ``effective_mode``。
+        分镜——实际入队（``is_reference_script``）只认剧本自身的戳，从不读 ``effective_mode``。
         """
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)


### PR DESCRIPTION
Closes #1478

## 改动

把 `script.get("generation_mode") == "reference_video"` 这一剧本戳判定提为 lib 级单一谓词 `lib/script_models.py::is_reference_script`，消费方改为调用它：

- `server/agent_runtime/sdk_tools/enqueue_videos.py`（原文件内私有函数 `_is_reference_script` 删除，4 处调用改名）
- `server/services/cost_estimation.py`
- `lib/storyboard_sequence.py`
- `server/agent_runtime/sdk_tools/enqueue_narration_audio.py`（issue 背景段未枚举，本地审查补入：同为剧本戳判定，且紧邻已收敛的 `get_storyboard_items` 空返回分支）

谓词 docstring 就地记录适用域：仅 narration/drama 的剧本自身戳；ad 骨架不打此戳、真相源是项目/集级 `effective_mode`，不适用本谓词。原先散在私有函数与跨文件注释指针里的这条口径，现收进单一定义点。

未收编 `lib/status_calculator.py:93`：该处比较的是已解出的局部变量 `generation_mode`（与同函数内 `resolve_declared_kind(content_mode, generation_mode)` 共用），不是剧本 dict 谓词，改写会让同一函数混用两种取值方式。

按 issue 范围边界，未统一 ad 与 narration/drama 的模式真相源，未改 `get_storyboard_items` 对 reference_video 返回空列表的语义。

## 验证

纯重构，表达式逐字等价，无行为变化。

- `uv run ruff check` + `ruff format --check`（改动文件）通过
- `uv run basedpyright` 全量 0 error
- `uv run python -m pytest` 全量 6891 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 统一参考视频脚本的识别逻辑，确保分镜、配音、视频生成及费用估算流程采用一致的判断结果。
  * 改善参考视频脚本缺少可处理片段时的错误提示。

* **测试**
  * 更新相关测试说明，反映新的参考视频判定方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->