### PR TITLE
build(release): 0.x 阶段 breaking change 只升 minor，不再跃迁大版本

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,6 +4,7 @@
   "bootstrap-sha": "dc19732ece340d651d55fd7c93d2674ba1f1e155",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
+  "bump-minor-pre-major": true,
   "packages": {
     ".": {
       "package-name": "arcreel",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,5 +207,3 @@ BREAKING CHANGE: /api/v1/api-keys 的返回结构改为 { items: [...] }，
 - 将版本号 bump 为 major；当前版本 <1.0.0 时受 `bump-minor-pre-major` 配置约束，只 bump minor
 - 在 changelog 顶部插入独立的 **⚠️ BREAKING CHANGES** 区块，把每条破坏性变更的描述汇总展示
 - 在对应 type section（如 `✨ 新功能`）下保留该 commit 的常规条目
-
-> 本项目前后端同仓同发布，后端 API 的唯一消费者是自家前端，接口删改随版本原子生效，不构成对外契约变更。此类改动按 `fix`/`refactor` 正常分类，不加 `!` 或 `BREAKING CHANGE:` footer。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ chore: 构建/工具变更
 |-------------|---------|-----------|
 | `feat`      | minor   | ✨ 新功能 |
 | `fix`       | patch   | 🐛 Bug 修复 |
-| `feat!` / 任意 type + `!` / footer 含 `BREAKING CHANGE:` | **major** | ⚠️ BREAKING CHANGES（changelog 置顶） |
+| `feat!` / 任意 type + `!` / footer 含 `BREAKING CHANGE:` | **major**（版本 <1.0.0 时为 minor） | ⚠️ BREAKING CHANGES（changelog 置顶） |
 | `perf` / `refactor` / `docs` / `revert` | 不步进 | 显示（⚡ / ♻️ / 📚 / ↩️） |
 | `chore` / `ci` / `build` / `test` / `style` | 不步进 | 隐藏 |
 
@@ -190,7 +190,7 @@ feat(grid): 支持 grid_12 布局
 将宫格系统扩展到 12 宫格，适用于长篇剧集的批量预览。
 ```
 
-**破坏性变更**有两种等价写法，release-please 均会自动 bump 到 major：
+**破坏性变更**有两种等价写法：
 
 ```
 # 写法 1：type 后加 !
@@ -204,6 +204,8 @@ BREAKING CHANGE: /api/v1/api-keys 的返回结构改为 { items: [...] }，
 ```
 
 两种写法 release-please 都会：
-- 将版本号 bump 为 major
+- 将版本号 bump 为 major；当前版本 <1.0.0 时受 `bump-minor-pre-major` 配置约束，只 bump minor
 - 在 changelog 顶部插入独立的 **⚠️ BREAKING CHANGES** 区块，把每条破坏性变更的描述汇总展示
 - 在对应 type section（如 `✨ 新功能`）下保留该 commit 的常规条目
+
+> 本项目前后端同仓同发布，后端 API 的唯一消费者是自家前端，接口删改随版本原子生效，不构成对外契约变更。此类改动按 `fix`/`refactor` 正常分类，不加 `!` 或 `BREAKING CHANGE:` footer。


### PR DESCRIPTION
## 背景

PR #1310 的 release 版本被算成 1.0.0：commit c1faafa（#1401）带 `BREAKING CHANGE` footer，而 release-please 配置未开 `bump-minor-pre-major`，0.x 阶段的 breaking change 默认直升 major。

## 变更

`.release-please-config.json` 增加 `"bump-minor-pre-major": true`：版本 <1.0.0 时 breaking change 只升 minor。feat 仍升 minor、fix 仍升 patch（`bump-patch-for-minor-pre-major` 未开启，不受影响）。

合入后 release-please 下次运行会把 release PR 重算为 0.24.0。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **版本发布**
  - 优化预发布阶段的版本递增策略：在满足“破坏性变更”条件时，新增对主版本前的 minor 处理规则，使版本号在正式发布前更贴合实际变更范围。
  - 提升版本发布流程的一致性与可预测性。
- **文档**
  - 更新贡献指南中对版本步进与破坏性变更触发条件的说明与示例，补充当前版本低于 1.0.0 时的例外规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->