### PR TITLE
feat(music): add MiniMax music-3.0 generation backend

### DIFF
--- a/lib/minimax_shared.py
+++ b/lib/minimax_shared.py
@@ -69,6 +69,11 @@ def minimax_video_base_url(configured: str | None = None) -> str:
     return f"{_minimax_host(configured)}{_V1_SUFFIX}"
 
 
+def minimax_music_base_url(configured: str | None = None) -> str:
+    """原生音乐生成端点 base：{host}/v1。与文本/视频共用单一 /v1 base，仅命名区分用途。"""
+    return f"{_minimax_host(configured)}{_V1_SUFFIX}"
+
+
 def minimax_headers(api_key: str) -> dict[str, str]:
     """Bearer 鉴权头。"""
     return {
@@ -132,6 +137,50 @@ def minimax_failure_reason(payload: object) -> str | None:
     if status is not None and status != 0:
         msg = base.get("status_msg") or ""
         return f"MiniMax 图像生成失败 status_code={status}: {msg}".strip()
+    return None
+
+
+# ── 单步 music_generation 响应工具 ────────────────────────────────────────────
+
+# music_generation 响应 data.status：1=生成中，2=已完成。单步端点无 task_id / 查询接口，
+# 完成即从 data.audio 取结果（output_format=url 为链接，hex 为十六进制音频）。
+
+
+def minimax_music_status(payload: object) -> int | None:
+    """music_generation 响应 data.status（1=生成中，2=已完成）；缺失/非整数返回 None。
+
+    顶层 / data 非 dict、字段缺失或非整数一律回 None，由 caller 决定是否放行（部分成功响应
+    可能省略 status 但携带 data.audio）。bool 是 int 子类，故显式排除 True/False。
+    """
+    status = _as_dict(_as_dict(payload).get("data")).get("status")
+    if isinstance(status, bool):
+        return None
+    return status if isinstance(status, int) else None
+
+
+def extract_music_audio(payload: object) -> str | None:
+    """从 music_generation 响应 data.audio 取音频（output_format=url 为链接，hex 为十六进制音频）。
+
+    无可用音频（顶层 / data 非 dict、字段缺失、空串）返回 None，由 caller 报错。
+    """
+    audio = _as_dict(_as_dict(payload).get("data")).get("audio")
+    if isinstance(audio, str) and audio:
+        return audio
+    return None
+
+
+def minimax_music_failure_reason(payload: object) -> str | None:
+    """base_resp.status_code 非零时返回错误描述；成功（0）或缺失 base_resp 返回 None。
+
+    与 minimax_failure_reason 对称：MiniMax 业务错误以 HTTP 200 + base_resp.status_code 非零
+    承载（鉴权失败等可能另走 4xx，由 submit_post/raise_for_status 兜住），故同步音乐响应须先查
+    base_resp 再取音频。
+    """
+    base = _as_dict(_as_dict(payload).get("base_resp"))
+    status = base.get("status_code")
+    if status is not None and status != 0:
+        msg = base.get("status_msg") or ""
+        return f"MiniMax 音乐生成失败 status_code={status}: {msg}".strip()
     return None
 
 

--- a/lib/music_backends/__init__.py
+++ b/lib/music_backends/__init__.py
@@ -1,0 +1,28 @@
+"""音乐生成服务层公共 API。"""
+
+from lib.music_backends.base import (
+    MusicBackend,
+    MusicCapability,
+    MusicCapabilityError,
+    MusicGenerationRequest,
+    MusicGenerationResult,
+)
+from lib.music_backends.registry import create_backend, get_registered_backends, register_backend
+
+__all__ = [
+    "MusicBackend",
+    "MusicCapability",
+    "MusicCapabilityError",
+    "MusicGenerationRequest",
+    "MusicGenerationResult",
+    "create_backend",
+    "get_registered_backends",
+    "register_backend",
+]
+
+# Backend auto-registration
+# MiniMax 海螺 — music-3.0 音乐生成（单步同步 /music_generation 端点）
+from lib.music_backends.minimax import MiniMaxMusicBackend  # noqa: E402
+from lib.providers import PROVIDER_MINIMAX  # noqa: E402
+
+register_backend(PROVIDER_MINIMAX, MiniMaxMusicBackend)

--- a/lib/music_backends/base.py
+++ b/lib/music_backends/base.py
@@ -1,0 +1,92 @@
+"""音乐生成服务层核心接口定义与共享工具。"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Protocol
+
+import httpx
+
+
+async def download_audio_to_path(url: str, output_path: Path, *, timeout: int = 120) -> None:
+    """从 URL 异步下载音频到本地文件。"""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, timeout=timeout)
+        resp.raise_for_status()
+        content = resp.content
+
+    def _save() -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(content)
+
+    await asyncio.to_thread(_save)
+
+
+class MusicCapability(StrEnum):
+    """音乐后端支持的能力枚举。"""
+
+    MUSIC_GENERATION = "music_generation"
+    MUSIC_COVER = "music_cover"
+
+
+@dataclass
+class MusicGenerationRequest:
+    """通用音乐生成请求。各 Backend 忽略不支持的字段。"""
+
+    prompt: str
+    output_path: Path
+    # 唱词：None = 不带词（由 prompt 驱动）；空串与非空串一律原样透传。
+    lyrics: str | None = None
+    # 纯乐器伴奏（无人声）。
+    is_instrumental: bool = False
+    # 供应商侧改写 / 优化唱词。
+    lyrics_optimizer: bool = False
+    # 音频参数（采样率、比特率、format=mp3/wav/pcm 等）；空 dict = 用供应商默认。
+    audio_setting: dict[str, Any] = field(default_factory=dict)
+    # 输出格式：url（下载 24h 有效链接）或 hex（响应内嵌十六进制音频）。
+    output_format: str = "url"
+    project_name: str | None = None
+    # 翻唱（music-cover）：二选一提供源音频；同时提供以 audio_url 优先。
+    audio_url: str | None = None
+    audio_base64: str | None = None
+    cover_feature_id: str | None = None
+
+
+@dataclass
+class MusicGenerationResult:
+    """通用音乐生成结果。"""
+
+    music_path: Path
+    provider: str
+    model: str
+    # 远端结果 URL（output_format=url）；hex 直落本地时为 None。
+    audio_uri: str | None = None
+
+
+class MusicBackend(Protocol):
+    """音乐生成后端协议。"""
+
+    @property
+    def name(self) -> str: ...
+    @property
+    def model(self) -> str: ...
+    @property
+    def capabilities(self) -> set[MusicCapability]: ...
+    async def generate(self, request: MusicGenerationRequest) -> MusicGenerationResult: ...
+
+
+class MusicCapabilityError(RuntimeError):
+    """音乐后端能力不匹配 / 输入不合规。
+
+    与 ImageCapabilityError / VideoCapabilityError 对称：不携带本地化字符串，只带稳定 code +
+    上下文 params；路由层直接 _t(code, **params) 渲染，Worker 则按 code + params 落
+    task.error_message，文案留到读侧按 Accept-Language 渲染。
+    """
+
+    def __init__(self, code: str, **params: Any) -> None:
+        self.code = code
+        self.params = params
+        super().__init__(code)

--- a/lib/music_backends/minimax.py
+++ b/lib/music_backends/minimax.py
@@ -1,0 +1,210 @@
+"""MiniMaxMusicBackend — MiniMax（海螺）music-3.0 音乐生成后端（单步同步）。
+
+走 OpenAI 兼容 base 上的原生 /music_generation 同步端点：单次 POST 直接返回音频 URL
+（24h 有效）或 hex 编码音频，立即落地为本地资产。prompt + 可选 lyrics 驱动带唱词生成，
+is_instrumental 生成纯乐器伴奏；翻唱（music-cover）经 audio_url / audio_base64 提供源音频。
+响应无 task_id / 查询端点：data.status=2 即完成、data.audio 承载结果，base_resp.status_code
+非零为业务失败。国内站默认连 api.minimaxi.com，海外经 base_url 覆盖切到 api.minimax.io。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import binascii
+import logging
+from pathlib import Path
+
+import httpx
+
+from lib.logging_utils import format_kwargs_for_log
+from lib.minimax_shared import (
+    extract_music_audio,
+    minimax_headers,
+    minimax_music_base_url,
+    minimax_music_failure_reason,
+    minimax_music_status,
+    resolve_minimax_api_key,
+    safe_body_for_log,
+)
+from lib.music_backends.base import (
+    MusicCapability,
+    MusicCapabilityError,
+    MusicGenerationRequest,
+    MusicGenerationResult,
+    download_audio_to_path,
+)
+from lib.providers import PROVIDER_MINIMAX
+from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
+from lib.video_backends.base import should_retry_download, should_retry_submit, submit_post
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "music-3.0"
+
+_MUSIC_ENDPOINT = "/music_generation"
+
+# music_generation 响应 data.status：1=生成中，2=已完成。单步端点无查询接口，完成即取 data.audio。
+_STATUS_COMPLETED = 2
+
+# 输出格式：url（下载 24h 有效链接）/ hex（响应内嵌十六进制音频，解码写盘）。
+_OUTPUT_URL = "url"
+_OUTPUT_HEX = "hex"
+_SUPPORTED_OUTPUT_FORMATS = frozenset({_OUTPUT_URL, _OUTPUT_HEX})
+
+
+class MiniMaxMusicBackend:
+    """MiniMax 音乐后端（单步同步 music_generation 端点）。"""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        http_timeout: float = 120.0,
+    ) -> None:
+        self._api_key = resolve_minimax_api_key(api_key)
+        self._base_url = minimax_music_base_url(base_url)
+        self._model = model or DEFAULT_MODEL
+        self._http_timeout = http_timeout
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_MINIMAX
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def capabilities(self) -> set[MusicCapability]:
+        # music_generation 端点同时承载文生音乐与翻唱（music-cover 走同一 POST，源音频经
+        # audio_url / audio_base64 提供）。
+        return {MusicCapability.MUSIC_GENERATION, MusicCapability.MUSIC_COVER}
+
+    async def generate(self, request: MusicGenerationRequest) -> MusicGenerationResult:
+        # 编排层不带重试：把非幂等的「生成 + 计费」submit 与幂等的结果下载隔离到各自的重试
+        # 范围（_submit / _download_result），避免下载失败回退到重跑生成 POST 造成重复计费。
+        output_format = request.output_format or _OUTPUT_URL
+        if output_format not in _SUPPORTED_OUTPUT_FORMATS:
+            raise MusicCapabilityError(
+                "music_output_format_unsupported", model=self._model, output_format=output_format
+            )
+
+        payload = self._build_payload(request, output_format)
+        data = await self._submit(payload)
+        audio_uri = await self._persist_audio(data, request.output_path, output_format)
+        logger.info("MiniMax 音乐生成完成: %s", request.output_path)
+
+        return MusicGenerationResult(
+            music_path=request.output_path,
+            provider=PROVIDER_MINIMAX,
+            model=self._model,
+            audio_uri=audio_uri,
+        )
+
+    def _build_payload(self, request: MusicGenerationRequest, output_format: str) -> dict:
+        """按官方 request_fields 组装请求体；未提供的可选字段一律省略（用供应商默认）。
+
+        required_fields 仅 model；prompt 为空亦不写入（翻唱由源音频驱动）。翻唱源音频二选一，
+        同时提供时 audio_url 优先。
+        """
+        payload: dict = {"model": self._model, "output_format": output_format}
+        if request.prompt:
+            payload["prompt"] = request.prompt
+        if request.lyrics is not None:
+            payload["lyrics"] = request.lyrics
+        if request.is_instrumental:
+            payload["is_instrumental"] = True
+        if request.lyrics_optimizer:
+            payload["lyrics_optimizer"] = True
+        if request.audio_setting:
+            payload["audio_setting"] = request.audio_setting
+        # 翻唱：二选一源音频（同时提供以 audio_url 优先），可选 cover_feature_id。
+        if request.audio_url:
+            payload["audio_url"] = request.audio_url
+        elif request.audio_base64:
+            payload["audio_base64"] = request.audio_base64
+        if request.cover_feature_id is not None:
+            payload["cover_feature_id"] = request.cover_feature_id
+        return payload
+
+    @with_retry_async(retry_if=should_retry_submit)
+    async def _submit(self, payload: dict) -> dict:
+        """单步音乐生成 POST（非幂等「生成 + 计费」），返回解析后的响应体。
+
+        重试范围严格限定在本方法内、不含下载——下载失败不会触发整流程重试导致重复生成与
+        重复计费。submit_post 把歧义传输错误转 AmbiguousSubmitError 终态失败避免重复计费；
+        >=400 落 body 日志 + 抛 HTTPStatusError，交 should_retry_submit 按状态码分流。日志经
+        safe_body_for_log 白名单化：仅 model + prompt 长度进日志，lyrics / audio_base64 / URL
+        一律不展开。
+        """
+        logger.info(
+            "调用 %s 音乐 API model=%s body=%s",
+            self.name,
+            self._model,
+            format_kwargs_for_log(safe_body_for_log(payload)),
+        )
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            resp = await submit_post(
+                lambda: client.post(
+                    f"{self._base_url}{_MUSIC_ENDPOINT}",
+                    json=payload,
+                    headers=minimax_headers(self._api_key),
+                ),
+                provider=PROVIDER_MINIMAX,
+            )
+            return resp.json()
+
+    async def _persist_audio(self, data: dict, output_path: Path, output_format: str) -> str | None:
+        """把 music_generation 响应落地为本地文件，返回远端 URL（hex 路径返回 None）。
+
+        先查 base_resp 业务错误（200 + 非零 status_code），再确认 data.status 为已完成（单步
+        端点无查询接口，非完成态无法轮询，直接报错），最后按 output_format 取 data.audio：
+        url 立即下载（24h 失效前落地），hex 解码十六进制写盘。
+        """
+        reason = minimax_music_failure_reason(data)
+        if reason:
+            raise RuntimeError(reason)
+
+        status = minimax_music_status(data)
+        if status is not None and status != _STATUS_COMPLETED:
+            raise RuntimeError(f"MiniMax 音乐生成未完成 data.status={status}")
+
+        audio = extract_music_audio(data)
+        if not audio:
+            # data.audio 缺失时可安全记全响应体（此分支无音频负载）；不嵌进异常消息避免
+            # body 里的 "503"/"timeout" 子串被字符串兜底误判为可重试。
+            logger.error("MiniMax 音乐响应缺少 data.audio: %s", data)
+            raise RuntimeError("MiniMax 音乐响应缺少 data.audio")
+
+        if output_format == _OUTPUT_URL:
+            await self._download_result(audio, output_path)
+            return audio
+
+        await _write_hex_audio(audio, output_path)
+        return None
+
+    @with_retry_async(
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
+        retry_if=should_retry_download,
+    )
+    async def _download_result(self, url: str, output_path: Path) -> None:
+        """下载已签发的结果音频 URL（幂等 GET），独立的下载重试范围。
+
+        瞬态失败在本层重试，绝不回退到重跑非幂等的生成 POST；4xx（URL 失效等确定性错误）
+        快速失败。下载比生成更宽容（失败不浪费生成额度），故用 DOWNLOAD_* 重试配置。
+        """
+        await download_audio_to_path(url, output_path)
+
+
+async def _write_hex_audio(hex_audio: str, output_path: Path) -> None:
+    """解码 hex 编码音频并写盘（解码 + 写盘 offload 到线程，避免事件循环内做 CPU 密集解码）。"""
+
+    def _decode_and_save() -> None:
+        audio_bytes = binascii.unhexlify(hex_audio)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(audio_bytes)
+
+    await asyncio.to_thread(_decode_and_save)

--- a/lib/music_backends/registry.py
+++ b/lib/music_backends/registry.py
@@ -1,0 +1,27 @@
+"""音乐后端注册与工厂。"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from lib.music_backends.base import MusicBackend
+
+_BACKEND_FACTORIES: dict[str, Callable[..., MusicBackend]] = {}
+
+
+def register_backend(name: str, factory: Callable[..., MusicBackend]) -> None:
+    """注册一个音乐后端工厂函数。"""
+    _BACKEND_FACTORIES[name] = factory
+
+
+def create_backend(name: str, **kwargs: Any) -> MusicBackend:
+    """根据名称创建音乐后端实例。"""
+    if name not in _BACKEND_FACTORIES:
+        raise ValueError(f"Unknown music backend: {name}")
+    return _BACKEND_FACTORIES[name](**kwargs)
+
+
+def get_registered_backends() -> list[str]:
+    """返回所有已注册的后端名称。"""
+    return list(_BACKEND_FACTORIES.keys())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ exclude_lines = [
 root_packages = ["lib"]
 
 # lib.config < lib.*_backends < lib.custom_provider：config 是配置解析的基础层，backends
-# 在其上组装出各供应商实现，custom_provider 再在 backends 之上拼装自定义供应商。四个 backend
+# 在其上组装出各供应商实现，custom_provider 再在 backends 之上拼装自定义供应商。五个 backend
 # 包为同层 sibling（`:` 分隔），彼此复用 video_backends.base 的工具不算方向违规。
 # ignore_imports 是存量违规的 baseline，逐条掐的是**违规链的终端边**而非首跳，这样中间模块
 # （project_manager / cost_calculator / usage_repo 等）后续新增的反向依赖仍会被契约拦下。
@@ -95,7 +95,7 @@ name = "lib.config / lib.*_backends / lib.custom_provider 分层契约"
 type = "layers"
 layers = [
     "custom_provider",
-    "image_backends : video_backends : audio_backends : text_backends",
+    "image_backends : video_backends : audio_backends : text_backends : music_backends",
     "config",
 ]
 containers = ["lib"]

--- a/tests/test_minimax_music_backend.py
+++ b/tests/test_minimax_music_backend.py
@@ -1,0 +1,351 @@
+"""MiniMaxMusicBackend 单元测试（mock httpx，单步同步端点，不打真实 HTTP）。"""
+
+from __future__ import annotations
+
+import binascii
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from lib.music_backends.base import MusicCapability, MusicCapabilityError, MusicGenerationRequest
+from lib.providers import PROVIDER_MINIMAX
+
+
+def _url_response(url: str = "https://x/out.mp3", status: int = 2) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "data": {"status": status, "audio": url},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    return resp
+
+
+def _hex_response(hex_audio: str, status: int = 2) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "data": {"status": status, "audio": hex_audio},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    return resp
+
+
+def _biz_error_response(status_code: int = 1004, msg: str = "invalid api key") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"base_resp": {"status_code": status_code, "status_msg": msg}}
+    return resp
+
+
+def _mock_client(resp: MagicMock) -> AsyncMock:
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+def _http_error(status_code: int, message: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://x/v1/music_generation")
+    response = httpx.Response(status_code, request=request, text=message)
+    return httpx.HTTPStatusError(f"error {status_code}", request=request, response=response)
+
+
+def _error_response(status_code: int) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = "Request Entity Too Large"
+    resp.raise_for_status = MagicMock(side_effect=_http_error(status_code, "Request Entity Too Large"))
+    return resp
+
+
+def _patches(client: AsyncMock, download: AsyncMock):
+    return (
+        patch("httpx.AsyncClient", return_value=client),
+        patch("lib.music_backends.minimax.download_audio_to_path", download),
+    )
+
+
+class TestCapabilities:
+    def test_generation_and_cover(self):
+        from lib.music_backends.minimax import MiniMaxMusicBackend
+
+        b = MiniMaxMusicBackend(api_key="sk", model="music-3.0")
+        assert b.name == PROVIDER_MINIMAX
+        assert b.model == "music-3.0"
+        assert b.capabilities == {MusicCapability.MUSIC_GENERATION, MusicCapability.MUSIC_COVER}
+
+    def test_default_model_when_unset(self):
+        from lib.music_backends.minimax import MiniMaxMusicBackend
+
+        assert MiniMaxMusicBackend(api_key="sk").model == "music-3.0"
+
+    def test_registered_in_factory(self):
+        from lib.music_backends import create_backend, get_registered_backends
+        from lib.music_backends.minimax import MiniMaxMusicBackend
+
+        assert PROVIDER_MINIMAX in get_registered_backends()
+        assert isinstance(create_backend(PROVIDER_MINIMAX, api_key="sk"), MiniMaxMusicBackend)
+
+
+class TestGeneration:
+    async def test_request_build_and_endpoint(self, tmp_path: Path):
+        client = _mock_client(_url_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk", model="music-3.0", base_url="https://api.minimax.io")
+            result = await b.generate(
+                MusicGenerationRequest(prompt="an upbeat pop song", output_path=tmp_path / "o.mp3")
+            )
+
+        body = client.post.call_args.kwargs["json"]
+        assert body["model"] == "music-3.0"
+        assert body["prompt"] == "an upbeat pop song"
+        assert body["output_format"] == "url"
+        # global 站：host 派生 /v1 + /music_generation
+        assert client.post.call_args.args[0] == "https://api.minimax.io/v1/music_generation"
+        assert client.post.call_args.kwargs["headers"]["Authorization"] == "Bearer sk"
+        assert result.provider == PROVIDER_MINIMAX
+        assert result.model == "music-3.0"
+        assert result.audio_uri == "https://x/out.mp3"
+        download.assert_called_once()
+
+    async def test_default_endpoint_is_domestic(self, tmp_path: Path):
+        client = _mock_client(_url_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk")
+            await b.generate(MusicGenerationRequest(prompt="x", output_path=tmp_path / "o.mp3"))
+
+        assert client.post.call_args.args[0] == "https://api.minimaxi.com/v1/music_generation"
+
+    async def test_optional_fields_passthrough(self, tmp_path: Path):
+        client = _mock_client(_url_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk")
+            await b.generate(
+                MusicGenerationRequest(
+                    prompt="ballad",
+                    output_path=tmp_path / "o.mp3",
+                    lyrics="[verse]\nhello world",
+                    is_instrumental=True,
+                    lyrics_optimizer=True,
+                    audio_setting={"sample_rate": 44100, "format": "mp3"},
+                )
+            )
+
+        body = client.post.call_args.kwargs["json"]
+        assert body["lyrics"] == "[verse]\nhello world"
+        assert body["is_instrumental"] is True
+        assert body["lyrics_optimizer"] is True
+        assert body["audio_setting"] == {"sample_rate": 44100, "format": "mp3"}
+
+    async def test_omits_unset_optionals(self, tmp_path: Path):
+        client = _mock_client(_url_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk")
+            await b.generate(MusicGenerationRequest(prompt="x", output_path=tmp_path / "o.mp3"))
+
+        body = client.post.call_args.kwargs["json"]
+        for absent in ("lyrics", "is_instrumental", "lyrics_optimizer", "audio_setting", "audio_url", "audio_base64"):
+            assert absent not in body
+
+
+class TestCover:
+    async def test_audio_url_passthrough(self, tmp_path: Path):
+        client = _mock_client(_url_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk", model="music-cover")
+            await b.generate(
+                MusicGenerationRequest(
+                    prompt="",
+                    output_path=tmp_path / "o.mp3",
+                    audio_url="https://src/song.mp3",
+                    cover_feature_id="feat-1",
+                )
+            )
+
+        body = client.post.call_args.kwargs["json"]
+        assert body["audio_url"] == "https://src/song.mp3"
+        assert body["cover_feature_id"] == "feat-1"
+        # 空 prompt 不写入
+        assert "prompt" not in body
+
+    async def test_audio_url_precedence_over_base64(self, tmp_path: Path):
+        client = _mock_client(_url_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk", model="music-cover")
+            await b.generate(
+                MusicGenerationRequest(
+                    prompt="x",
+                    output_path=tmp_path / "o.mp3",
+                    audio_url="https://src/song.mp3",
+                    audio_base64="deadbeef",
+                )
+            )
+
+        body = client.post.call_args.kwargs["json"]
+        assert body["audio_url"] == "https://src/song.mp3"
+        assert "audio_base64" not in body
+
+    async def test_audio_base64_when_no_url(self, tmp_path: Path):
+        client = _mock_client(_url_response())
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk", model="music-cover")
+            await b.generate(
+                MusicGenerationRequest(prompt="x", output_path=tmp_path / "o.mp3", audio_base64="deadbeef")
+            )
+
+        body = client.post.call_args.kwargs["json"]
+        assert body["audio_base64"] == "deadbeef"
+        assert "audio_url" not in body
+
+
+class TestResponseHandling:
+    async def test_hex_response_decoded_and_saved(self, tmp_path: Path):
+        raw = b"ID3fake-audio-bytes"
+        hex_audio = binascii.hexlify(raw).decode("ascii")
+        client = _mock_client(_hex_response(hex_audio))
+        out = tmp_path / "o.mp3"
+        # 不 patch download：hex 路径独立落盘
+        with patch("httpx.AsyncClient", return_value=client):
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk")
+            result = await b.generate(MusicGenerationRequest(prompt="x", output_path=out, output_format="hex"))
+
+        assert out.read_bytes() == raw
+        # hex 路径无远端 URL
+        assert result.audio_uri is None
+        assert client.post.call_args.kwargs["json"]["output_format"] == "hex"
+
+    async def test_business_error_raises_runtime(self, tmp_path: Path):
+        client = _mock_client(_biz_error_response(1004, "invalid api key"))
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk")
+            with pytest.raises(RuntimeError) as ei:
+                await b.generate(MusicGenerationRequest(prompt="x", output_path=tmp_path / "o.mp3"))
+        assert "1004" in str(ei.value)
+        # 业务错误不重试、不下载
+        assert client.post.call_count == 1
+        download.assert_not_called()
+
+    async def test_in_progress_status_raises(self, tmp_path: Path):
+        client = _mock_client(_url_response(status=1))
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk")
+            with pytest.raises(RuntimeError) as ei:
+                await b.generate(MusicGenerationRequest(prompt="x", output_path=tmp_path / "o.mp3"))
+        assert "status=1" in str(ei.value)
+        download.assert_not_called()
+
+    async def test_missing_audio_raises(self, tmp_path: Path):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"data": {"status": 2}, "base_resp": {"status_code": 0}}
+        client = _mock_client(resp)
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk")
+            with pytest.raises(RuntimeError):
+                await b.generate(MusicGenerationRequest(prompt="x", output_path=tmp_path / "o.mp3"))
+
+    async def test_unsupported_output_format_raises(self, tmp_path: Path):
+        from lib.music_backends.minimax import MiniMaxMusicBackend
+
+        b = MiniMaxMusicBackend(api_key="sk")
+        with pytest.raises(MusicCapabilityError) as ei:
+            await b.generate(MusicGenerationRequest(prompt="x", output_path=tmp_path / "o.mp3", output_format="ogg"))
+        assert ei.value.code == "music_output_format_unsupported"
+        assert ei.value.params["output_format"] == "ogg"
+
+
+class TestHttpErrors:
+    async def test_400_surfaces_httpstatuserror_single_call(self, tmp_path: Path):
+        client = _mock_client(_error_response(400))
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk")
+            with pytest.raises(httpx.HTTPStatusError) as ei:
+                await b.generate(MusicGenerationRequest(prompt="p", output_path=tmp_path / "o.mp3"))
+        assert ei.value.response.status_code == 400
+        assert client.post.call_count == 1
+        download.assert_not_called()
+
+    async def test_413_surfaces_httpstatuserror_no_retry(self, tmp_path: Path):
+        client = _mock_client(_error_response(413))
+        download = AsyncMock()
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk")
+            with pytest.raises(httpx.HTTPStatusError) as ei:
+                await b.generate(MusicGenerationRequest(prompt="p", output_path=tmp_path / "o.mp3"))
+        assert ei.value.response.status_code == 413
+        assert client.post.call_count == 1
+        download.assert_not_called()
+
+
+class TestRetryScope:
+    async def test_download_failure_does_not_retrigger_generation(self, tmp_path: Path, monkeypatch):
+        # 下载阶段瞬态失败只在下载层重试，绝不回退到重跑非幂等的生成 POST（防重复生成 + 重复计费）。
+        # 退避 sleep 打桩跳过，避免下载层重试真的等 DOWNLOAD_BACKOFF 秒级时间。
+        from lib.retry import DOWNLOAD_MAX_ATTEMPTS
+
+        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
+        client = _mock_client(_url_response())
+        download = AsyncMock(side_effect=httpx.ConnectError("conn reset"))
+        p1, p2 = _patches(client, download)
+        with p1, p2:
+            from lib.music_backends.minimax import MiniMaxMusicBackend
+
+            b = MiniMaxMusicBackend(api_key="sk")
+            with pytest.raises(httpx.ConnectError):
+                await b.generate(MusicGenerationRequest(prompt="x", output_path=tmp_path / "o.mp3"))
+        # 生成 POST 恰好一次（计费一次）；重试全部发生在下载层
+        assert client.post.call_count == 1
+        assert download.call_count == DOWNLOAD_MAX_ATTEMPTS

--- a/tests/test_minimax_shared.py
+++ b/tests/test_minimax_shared.py
@@ -16,10 +16,14 @@ from lib.minimax_shared import (
     extract_minimax_download_url,
     extract_minimax_file_id,
     extract_minimax_video_task_id,
+    extract_music_audio,
     image_to_data_uri,
     is_minimax_video_terminal,
     minimax_failure_reason,
     minimax_headers,
+    minimax_music_base_url,
+    minimax_music_failure_reason,
+    minimax_music_status,
     minimax_text_base_url,
     minimax_video_base_url,
     minimax_video_failure_reason,
@@ -254,3 +258,72 @@ class TestImageToDataUri:
         img = tmp_path / "x.jpg"
         img.write_bytes(b"\xff\xd8\xff")
         assert image_to_data_uri(img).startswith("data:image/jpeg;base64,")
+
+
+class TestMusicBaseUrl:
+    def test_shares_v1_base_with_text(self):
+        assert minimax_music_base_url() == MINIMAX_BASE_URL
+        assert minimax_music_base_url("https://api.minimax.io") == MINIMAX_INTL_BASE_URL
+
+    def test_host_only_gets_v1_suffix(self):
+        assert minimax_music_base_url("https://api.minimaxi.com") == "https://api.minimaxi.com/v1"
+
+    def test_full_v1_base_is_idempotent(self):
+        assert minimax_music_base_url("https://api.minimax.io/v1") == "https://api.minimax.io/v1"
+
+
+class TestMusicStatus:
+    def test_completed_status_returned(self):
+        assert minimax_music_status({"data": {"status": 2, "audio": "x"}}) == 2
+
+    def test_in_progress_status_returned(self):
+        assert minimax_music_status({"data": {"status": 1}}) == 1
+
+    def test_missing_status_returns_none(self):
+        assert minimax_music_status({"data": {"audio": "x"}}) is None
+
+    def test_non_int_status_returns_none(self):
+        assert minimax_music_status({"data": {"status": "done"}}) is None
+
+    def test_bool_status_returns_none(self):
+        # bool 是 int 子类，显式排除避免 True 被当成 status=1
+        assert minimax_music_status({"data": {"status": True}}) is None
+
+    def test_non_dict_payload_tolerated(self):
+        assert minimax_music_status(None) is None
+        assert minimax_music_status([]) is None
+
+
+class TestExtractMusicAudio:
+    def test_url_audio(self):
+        assert extract_music_audio({"data": {"audio": "https://x/o.mp3"}}) == "https://x/o.mp3"
+
+    def test_hex_audio(self):
+        assert extract_music_audio({"data": {"audio": "deadbeef"}}) == "deadbeef"
+
+    def test_missing_returns_none(self):
+        assert extract_music_audio({"data": {}}) is None
+
+    def test_empty_string_returns_none(self):
+        assert extract_music_audio({"data": {"audio": ""}}) is None
+
+    def test_non_dict_payload_tolerated(self):
+        assert extract_music_audio(None) is None
+        assert extract_music_audio({"data": "oops"}) is None
+
+
+class TestMusicFailureReason:
+    def test_success_status_zero_returns_none(self):
+        assert minimax_music_failure_reason({"base_resp": {"status_code": 0}}) is None
+
+    def test_missing_base_resp_returns_none(self):
+        assert minimax_music_failure_reason({"data": {"audio": "x"}}) is None
+
+    def test_non_dict_payload_returns_none(self):
+        assert minimax_music_failure_reason(None) is None
+
+    def test_nonzero_status_returns_reason(self):
+        reason = minimax_music_failure_reason({"base_resp": {"status_code": 1004, "status_msg": "bad key"}})
+        assert reason is not None
+        assert "1004" in reason
+        assert "bad key" in reason


### PR DESCRIPTION
Reason: The multimodal backend registry exposed text, image and video generation but had no music generation backend, so music-3.0 could not be reached through the global or China `/v1/music_generation` endpoints.

## What this adds

A self-contained `lib/music_backends/` package that mirrors the existing image/video/audio backend families (base protocol + request/result dataclasses + registry + auto-registration), plus a MiniMax music generation backend.

### `lib/music_backends/`
- `base.py` — `MusicBackend` protocol, `MusicGenerationRequest` / `MusicGenerationResult` dataclasses, `MusicCapability` enum (`music_generation`, `music_cover`), `MusicCapabilityError`, and a `download_audio_to_path` helper.
- `registry.py` — `register_backend` / `create_backend` / `get_registered_backends`, matching the other backend registries.
- `minimax.py` — `MiniMaxMusicBackend`: single-step synchronous POST to `/music_generation`. Builds the request body from the documented fields (`model`, `prompt`, `lyrics`, `is_instrumental`, `lyrics_optimizer`, `audio_setting`, `output_format`, and the cover inputs `audio_url` / `audio_base64` / `cover_feature_id`), omitting unset optionals. Parses the response by checking `base_resp.status_code`, requiring `data.status == 2` (completed), and reading `data.audio` — downloading the URL (`output_format=url`, 24h link) or decoding the hex payload (`output_format=hex`). Submit and download use isolated retry scopes so a download retry never re-triggers the non-idempotent generation POST.
- `__init__.py` — public API and auto-registration of the MiniMax backend under the existing provider id.

### Endpoint / region handling
- `lib/minimax_shared.py` — adds `minimax_music_base_url` (normalises `{host}/v1`, defaulting to the China host and switching to the global host when `base_url` is overridden) plus `minimax_music_status`, `extract_music_audio`, and `minimax_music_failure_reason`, mirroring the existing image/video helpers.

### Layering
- `pyproject.toml` — registers `music_backends` as a sibling of the other backend packages in the Import Linter layers contract.

## Tests
- `tests/test_minimax_music_backend.py` — capabilities and factory registration, request-body assembly, default (China) vs overridden (global) endpoint, optional-field passthrough and omission, cover inputs and precedence, URL download and hex decode, business-error / in-progress / missing-audio / unsupported-format failures, HTTP 400/413 fail-fast, and download-retry isolation.
- `tests/test_minimax_shared.py` — the four new shared helpers.

## Checks run
- `uv run ruff format --check` and `uv run ruff check` — clean.
- `uv run basedpyright` on the changed files — 0 errors.
- `uv run lint-imports` — layers contract kept.
- `uv run python -m pytest tests/test_minimax_music_backend.py tests/test_minimax_shared.py` — 77 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增音乐生成与翻唱能力，支持 MiniMax 后端。
  * 支持通过提示词、歌词及音频输入生成音乐。
  * 支持 URL 或 Hex 音频输出并保存至本地。
  * 新增后端注册与自动创建机制，便于扩展音乐服务。

* **错误处理**
  * 增强业务状态、音频缺失及无效输出格式的错误提示。
  * 优化生成与下载重试，避免重复提交生成请求。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->