### PR TITLE
fix(agnes): 修复视频完成后失败与时长误记

### DIFF
--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -1,8 +1,9 @@
 """AgnesVideoBackend — Agnes 视频生成后端（裸 base64 + 异步轮询 + resume）。
 
 走 apihub 网关上的 OpenAI 风格异步端点：submit ``POST /v1/videos``（JSON）取 task_id →
-轮询 ``GET /v1/videos/{task_id}`` 至 ``status=completed`` → 从响应 ``remixed_from_video_id``
-字段取成片 mp4 URL → 下载本地。状态机 ``queued → in_progress → completed / failed``。
+轮询 ``GET /v1/videos/{task_id}`` 至 ``status=completed`` → 取 ``video_id`` 请求
+``GET /agnesapi?video_id=...`` 获得成片 mp4 URL → 下载本地。旧响应若已直接携带 URL 则兼容使用。
+状态机 ``queued → in_progress → completed / failed``。
 
 能力约束：fps 固定 24；时长 1–18s（内部 ``num_frames = 最近的 8n+1``，由秒 × fps 取整对齐，
 上限 441 帧）；分辨率经 aspect_size 精确算出并显式下发 ``height`` × ``width``（不显式下发时
@@ -55,6 +56,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL = "agnes-video-v2.0"
 
 _VIDEOS_ENDPOINT = "/videos"
+_VIDEO_RESULT_ENDPOINT = "/agnesapi"
 
 # fps 固定 24；num_frames 必须形如 8n+1，上限 441（≈18.4s @24fps）。时长按秒 × fps 取整后
 # 对齐到最近的 8n+1。1–3s 会落到 81 帧以下（25/49/73），文档允许的合法值。
@@ -145,13 +147,21 @@ def _extract_task_id(body: dict) -> str:
     raise RuntimeError(f"Agnes 视频提交返回体缺少 task_id（字段: {sorted(body)}）")
 
 
+def _extract_video_url(body: dict) -> str | None:
+    """兼容 Agnes 新旧响应中的成片 URL 字段；remixed 字段仅作旧网关兼容。"""
+    for key in ("url", "video_url", "remixed_from_video_id"):
+        value = body.get(key)
+        if isinstance(value, str) and value.startswith(("https://", "http://")):
+            return value
+    return None
+
+
 def _extract_duration_seconds(final: dict, fallback: int) -> int:
-    """从轮询终态取实际计费时长（``usage.duration_seconds`` 优先，回落顶层 ``seconds``，再回落请求值）。"""
-    usage = final.get("usage")
-    if isinstance(usage, dict):
-        parsed = _coerce_duration(usage.get("duration_seconds"))
-        if parsed is not None:
-            return parsed
+    """从轮询终态顶层 ``seconds`` 取成片时长，缺失时回落请求值。
+
+    Agnes 的 ``usage.duration_seconds`` 是任务处理耗时，并非成片时长；用于结果元数据或按秒计费
+    会把数分钟的生成耗时误记为视频长度。
+    """
     parsed = _coerce_duration(final.get("seconds"))
     if parsed is not None:
         return parsed
@@ -391,6 +401,34 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
         resp.raise_for_status()
         return resp.json()
 
+    @with_retry_async(
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+        retry_if=should_retry_poll,
+    )
+    async def _fetch_video_result(self, client: httpx.AsyncClient, video_id: str) -> dict:
+        result_base = self._base_url.removesuffix("/v1")
+        resp = await client.get(
+            f"{result_base}{_VIDEO_RESULT_ENDPOINT}",
+            params={"video_id": video_id},
+            headers=agnes_headers(self._api_key),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _resolve_video_url(self, client: httpx.AsyncClient, final: dict) -> str:
+        if video_url := _extract_video_url(final):
+            return video_url
+
+        video_id = final.get("video_id")
+        if not isinstance(video_id, str) or not video_id:
+            raise RuntimeError(f"Agnes 任务完成但缺少 video_id 或成片 URL（字段: {sorted(final)}）")
+
+        result = await self._fetch_video_result(client, video_id)
+        if video_url := _extract_video_url(result):
+            return video_url
+        raise RuntimeError(f"Agnes 成片查询缺少 URL（字段: {sorted(result)}）")
+
     async def _poll_and_build(
         self,
         client: httpx.AsyncClient,
@@ -426,11 +464,7 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
             ),
         )
 
-        video_url = final.get("remixed_from_video_id")
-        if not isinstance(video_url, str) or not video_url:
-            # 仅暴露字段名，不回显整串响应（可能含签名 URL 等敏感字段，与 _safe_body_for_log 同口径）。
-            raise RuntimeError(f"Agnes 任务完成但缺少 remixed_from_video_id 成片 URL（字段: {sorted(final)}）")
-
+        video_url = await self._resolve_video_url(client, final)
         await self._download_with_retry(video_url, request.output_path)
         logger.info("Agnes 视频下载完成: %s", request.output_path)
 

--- a/tests/test_agnes_video_backend.py
+++ b/tests/test_agnes_video_backend.py
@@ -45,7 +45,7 @@ def _completed(task_id: str = "task-1", url: str = "https://cdn.agnes/out.mp4", 
         "task_id": task_id,
         "status": "completed",
         "size": "720x1280",
-        "remixed_from_video_id": url,
+        "url": url,
     }
     body.update(extra)
     return body
@@ -134,14 +134,12 @@ class TestDurationCoercion:
 
         assert _coerce_duration(value) == expected
 
-    def test_extract_duration_falls_back_when_usage_zero(self):
+    def test_extract_duration_uses_media_seconds_not_processing_time(self):
         from lib.video_backends.agnes import _extract_duration_seconds
 
-        # usage.duration_seconds=0 不应落到结果对象，回落请求时长
-        assert _extract_duration_seconds({"usage": {"duration_seconds": 0}}, fallback=5) == 5
-        # 优先 usage，其次顶层 seconds，再回落
-        assert _extract_duration_seconds({"usage": {"duration_seconds": "9.6"}}, fallback=5) == 10
+        assert _extract_duration_seconds({"seconds": "8.0", "usage": {"duration_seconds": 184}}, fallback=5) == 8
         assert _extract_duration_seconds({"seconds": "7"}, fallback=5) == 7
+        assert _extract_duration_seconds({"usage": {"duration_seconds": 184}}, fallback=5) == 5
         assert _extract_duration_seconds({}, fallback=5) == 5
 
 
@@ -202,9 +200,89 @@ class TestTextToVideo:
         # submit 用长超时覆盖上游长阻塞
         assert post_call.kwargs["timeout"] == 300.0
 
-        # 下载从 remixed_from_video_id 成片 URL，不带 auth
+        # 完成态直接带 URL 时无需二次查询，下载不带 auth
         fake_download.assert_called_once()
         assert fake_download.call_args.args[0] == "https://cdn.agnes/out.mp4"
+
+    async def test_completed_video_id_resolves_url_from_agnesapi(self, tmp_path: Path):
+        """当前 Agnes 响应：remixed 字段为空，须用 video_id 查询成片 URL。"""
+        create_resp = _make_response(200, {"task_id": "task-current", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "id": "task-current",
+                "status": "completed",
+                "video_id": "video_encoded-result-id",
+                "remixed_from_video_id": None,
+                "seconds": "5",
+            },
+        )
+        result_resp = _make_response(
+            200,
+            {
+                "id": "video-result",
+                "status": "completed",
+                "url": "https://cdn.agnes/current.mp4",
+                "remixed_from_video_id": None,
+            },
+        )
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(side_effect=[poll_resp, result_resp]),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"current-video"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://api.agnes-ai.cn/v1")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "current.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        result_call = client.get.call_args_list[1]
+        assert result_call.args[0] == "https://api.agnes-ai.cn/agnesapi"
+        assert result_call.kwargs["params"] == {"video_id": "video_encoded-result-id"}
+        assert result_call.kwargs["headers"]["Authorization"] == "Bearer k"
+        assert result.video_uri == "https://cdn.agnes/current.mp4"
+        assert (tmp_path / "current.mp4").read_bytes() == b"current-video"
+        fake_download.assert_awaited_once_with("https://cdn.agnes/current.mp4", tmp_path / "current.mp4")
+
+    async def test_legacy_remixed_url_remains_supported(self, tmp_path: Path):
+        create_resp = _make_response(200, {"task_id": "task-legacy", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "id": "task-legacy",
+                "status": "completed",
+                "remixed_from_video_id": "https://cdn.agnes/legacy.mp4",
+            },
+        )
+        client = _mock_client(post=AsyncMock(return_value=create_resp), get=AsyncMock(return_value=poll_resp))
+        fake_download = AsyncMock(side_effect=_fake_download_factory())
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "legacy.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert client.get.call_count == 1
+        assert result.video_uri == "https://cdn.agnes/legacy.mp4"
 
     async def test_polls_through_in_progress(self, tmp_path: Path):
         create_resp = _make_response(200, {"task_id": "t3", "status": "queued"})
@@ -570,7 +648,44 @@ class TestFailureAndTimeout:
             from lib.video_backends.agnes import AgnesVideoBackend
 
             backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            with pytest.raises(RuntimeError, match="remixed_from_video_id"):
+            with pytest.raises(RuntimeError, match="video_id"):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                    )
+                )
+        fake_download.assert_not_called()
+
+    async def test_result_lookup_without_url_raises(self, tmp_path: Path):
+        create_resp = _make_response(200, {"task_id": "t-no-result", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "t-no-result",
+                "status": "completed",
+                "video_id": "video-result-id",
+                "remixed_from_video_id": None,
+            },
+        )
+        result_resp = _make_response(
+            200,
+            {"status": "completed", "remixed_from_video_id": "video-source-id"},
+        )
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(side_effect=[poll_resp, result_resp]),
+        )
+        fake_download = AsyncMock()
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(RuntimeError, match="成片查询缺少 URL"):
                 await backend.generate(
                     VideoGenerationRequest(
                         prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5


### PR DESCRIPTION
## 范围

修复 Agnes `agnes-video-v2.0` 完成态的成片 URL 与时长解析。仅修改 Agnes 视频后端和专项测试，不改其他供应商、配置或 schema。

Closes #1505

## 变更

- 完成态已有 `url` / `video_url` 时直接下载，并兼容旧网关曾在 `remixed_from_video_id` 返回 URL 的响应
- 完成态只有 `video_id` 时请求 `GET /agnesapi?video_id=...`，从结果响应的 `url` 获取并下载成片；查询沿用幂等 GET 重试策略
- 仅把 `http(s)` 字段视为成片 URL，避免将真正的 remix 来源 ID 当成下载地址
- 成片时长改用顶层 `seconds`，缺失时回退请求值，不再把 `usage.duration_seconds` 的任务处理耗时误记为视频长度和按秒计费时长
- 增加当前真实响应形态、旧响应兼容、缺失字段与处理耗时语义的回归测试

## 验收清单

- [x] 本地已跑相关测试：`uv run pytest tests/test_agnes_video_backend.py tests/test_agnes_shared.py tests/test_backend_assembly_specs.py -q`（102 passed）；全量非 e2e：`uv run pytest -m 'not e2e' -q`（6894 passed）
- [x] 手动验证了改动所声称的行为：本地 Docker 重部署后，使用已完成 Agnes task 走 `resume_video`，未重新 submit；通过 `/agnesapi` 获得 URL 并下载 1,334,057 字节有效 MP4（`ffprobe` 8.041667s），结果对象时长为 8 秒；`/health` 正常
- [x] 新增面向用户文案已加 zh/en 翻译（不适用：无新增用户文案）
- [x] 无新增 ESLint disable
- [ ] CODEOWNERS 要求的 review 已请求（Draft 阶段，转为 Ready 后请求）

补充检查：Ruff check、Ruff format check、basedpyright（0 errors）及 `git diff --check` 均通过。

## 已知 defer

无
