### PR TITLE
fix(video): 视频能力声明收敛为单一真相，参考音频随请求直传

### DIFF
--- a/frontend/src/components/pages/settings/customProviderHelpers.test.ts
+++ b/frontend/src/components/pages/settings/customProviderHelpers.test.ts
@@ -308,8 +308,9 @@ describe("capabilityFieldsFor", () => {
   const SYSTEM: VideoCapabilityFlags = {
     first_frame: true,
     last_frame: false,
-    reference_images: false,
     max_reference_images: 0,
+    reference_audio_mode: "none",
+    max_reference_audio_count: 0,
   };
   const snapshot: CapabilitySnapshotRow = {
     original_model_id: "kling-v2",

--- a/frontend/src/types/custom-provider.ts
+++ b/frontend/src/types/custom-provider.ts
@@ -47,21 +47,27 @@ export interface CustomProviderModelInfo {
   currency: string | null;
   supported_durations: number[] | null;
   resolution: string | null;
-  /** 系统判定的视频能力（四字段全量）；非视频模型为 null。 */
+  /** 系统判定的视频能力（全字段）；非视频模型为 null。 */
   system_capabilities: VideoCapabilityFlags | null;
   /** 用户覆盖（稀疏），与 system_capabilities 合并即为生效值；无覆盖为 null。 */
   capability_overrides: CapabilityOverrides | null;
 }
 
-/** 与后端 VideoCapabilities 字段对齐。 */
+/** 后端接受参考音频的运输形态；none 表示该模型没有音色输入通道。 */
+export type ReferenceAudioMode = "none" | "direct";
+
+/** 与后端 VideoCapabilities 字段对齐。参考图路径以 max_reference_images > 0 表达，
+ *  不另设布尔位——两份声明会漂移出「称支持但上限为 0」这类自相矛盾的状态。 */
 export interface VideoCapabilityFlags {
   first_frame: boolean;
   last_frame: boolean;
-  reference_images: boolean;
   max_reference_images: number;
+  reference_audio_mode: ReferenceAudioMode;
+  max_reference_audio_count: number;
 }
 
-/** 稀疏覆盖字典：键缺席 = 跟随系统判定。当前后端只开放 last_frame。 */
+/** 稀疏覆盖字典：键缺席 = 跟随系统判定。
+ *  当前后端开放 last_frame / reference_audio_mode / max_reference_audio_count。 */
 export type CapabilityOverrides = Partial<VideoCapabilityFlags>;
 
 export interface DiscoveredModel {

--- a/lib/custom_provider/backends.py
+++ b/lib/custom_provider/backends.py
@@ -13,7 +13,6 @@ from lib.text_backends.base import TextBackend, TextCapability, TextGenerationRe
 from lib.video_backends.base import (
     VideoBackend,
     VideoCapabilities,
-    VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
 )
@@ -139,10 +138,6 @@ class CustomVideoBackend:
     @property
     def model(self) -> str:
         return self._model
-
-    @property
-    def capabilities(self) -> set[VideoCapability]:
-        return self._delegate.capabilities
 
     @property
     def video_capabilities(self) -> VideoCapabilities:

--- a/lib/custom_provider/backends.py
+++ b/lib/custom_provider/backends.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
-
 from lib.audio_backends.base import AudioBackend, AudioCapability, AudioSynthesisRequest, AudioSynthesisResult
 from lib.image_backends.base import ImageBackend, ImageCapability, ImageGenerationRequest, ImageGenerationResult
 from lib.text_backends.base import TextBackend, TextCapability, TextGenerationRequest, TextGenerationResult
@@ -162,7 +160,15 @@ class CustomVideoBackend:
             else self._delegate.video_capabilities
         )
         if self._capability_overrides:
-            return replace(base, **self._capability_overrides)
+            # 合并后不变式与 synthesize 同口径：本路径也是一次「基底 ⊕ 稀疏覆盖」合并，
+            # 漏掉就会让档位查询产出 direct ⊕ 上限 0 这种合成侧已挡住的组合。
+            from lib.custom_provider.capabilities import enforce_audio_capability_invariant, merge_overrides
+
+            return enforce_audio_capability_invariant(
+                merge_overrides(base, self._capability_overrides),
+                endpoint=self._delegate.name,
+                model_id=self._model,
+            )
         return base
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:

--- a/lib/custom_provider/capabilities.py
+++ b/lib/custom_provider/capabilities.py
@@ -178,8 +178,64 @@ def synthesize_video_capabilities_with_overrides(
     """
     caps = system_video_capabilities(endpoint=endpoint, model_id=model_id)
     applied = filter_valid_overrides(endpoint=endpoint, model_id=model_id, overrides=overrides)
-    merged = replace(caps, **applied) if applied else caps
-    return merged, applied
+    merged = merge_overrides(caps, applied)
+    return enforce_audio_capability_invariant(merged, endpoint=endpoint, model_id=model_id), applied
+
+
+def merge_overrides(caps: VideoCapabilities, applied: dict[str, object]) -> VideoCapabilities:
+    """把稀疏覆盖并进能力对象，枚举维度还原成枚举成员。
+
+    覆盖字典从 JSON 列读出，枚举维度到这里还是字面量字符串；直接 ``replace`` 会让声明为
+    枚举类型的字段实际持有 ``str``。当前枚举都是 ``StrEnum``，``==`` 侥幸仍成立，但
+    ``is`` 比较与 ``.value`` 取值会分别静默判否和抛 ``AttributeError``——差别只在调用方
+    碰巧用了哪种写法。还原是纯机械的：值已由 :func:`capability_value_matches` 按精确字面量
+    校验过，这里不做任何二次判定。
+    """
+    if not applied:
+        return caps
+    coerced: dict[str, object] = {}
+    for key, value in applied.items():
+        expected = CAPABILITY_OVERRIDE_FIELDS.get(key)
+        if isinstance(expected, type) and issubclass(expected, Enum) and not isinstance(value, expected):
+            coerced[key] = expected(value)
+        else:
+            coerced[key] = value
+    return replace(caps, **coerced)
+
+
+def audio_capability_pair_is_coherent(*, mode: object, count: int) -> bool:
+    """音频两维的合并后不变式：声明支持音色输入就必须给出正的段数上限。
+
+    两维各自合法、合起来无意义的组合只有这一种（``direct`` ⊕ 上限 0）：稀疏覆盖只写其中
+    一维就能凑出——覆盖 ``reference_audio_mode=direct`` 而不动系统判定的 0，或反过来把
+    ``max_reference_audio_count`` 压成 0 而模式仍是系统判定的 ``direct``。反向组合
+    （``none`` ⊕ 正上限）不算违约：模式为 ``none`` 时上限本就不参与判定，且"关掉音色输入"
+    是正当意图，判违约反会把用户明确关掉的能力顶回开启。
+
+    不修正这组的后果是 ``gate_video_request`` 先过模式判定、再撞上限 0，把"该模型不支持
+    参考音频"报成"最多支持 0 段参考音频"——用户按提示去减角色数量，减到零段也过不了。
+
+    写入侧（``server/routers/custom_providers.py``）与合成侧共用此判定，两边不得各写一份。
+    """
+    return mode == ReferenceAudioMode.NONE.value or mode == ReferenceAudioMode.NONE or count > 0
+
+
+def enforce_audio_capability_invariant(caps: VideoCapabilities, *, endpoint: str, model_id: str) -> VideoCapabilities:
+    """把违反 :func:`audio_capability_pair_is_coherent` 的合并结果降到 ``none``。
+
+    写入侧已挡住新配置，这里兜住存量行与非 API 写入路径。降级方向取"不支持"而非"补一个
+    上限"：上限该是多少属供应商事实，系统无从替用户猜。
+    """
+    if audio_capability_pair_is_coherent(mode=caps.reference_audio_mode, count=caps.max_reference_audio_count):
+        return caps
+    logger.warning(
+        "%s/%s 的合并能力 reference_audio_mode=%s 但 max_reference_audio_count=%d，按不支持参考音频处理",
+        endpoint,
+        model_id,
+        caps.reference_audio_mode.value,
+        caps.max_reference_audio_count,
+    )
+    return replace(caps, reference_audio_mode=ReferenceAudioMode.NONE)
 
 
 def capability_value_matches(value: object, expected: type) -> bool:

--- a/lib/custom_provider/capabilities.py
+++ b/lib/custom_provider/capabilities.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 
 import logging
 from dataclasses import fields, replace
+from enum import Enum
 from typing import get_type_hints
 
 from lib.custom_provider.endpoints import get_endpoint_spec
-from lib.video_backends.base import VideoCapabilities
+from lib.video_backends.base import ReferenceAudioMode, VideoCapabilities
 
 logger = logging.getLogger(__name__)
 
@@ -32,8 +33,8 @@ def system_video_capabilities(*, endpoint: str, model_id: str) -> VideoCapabilit
 
     两条声明形式（注册表不变式保证恰填其一）：
     - ``video_caps_for_model``：backend 的 per-model 纯函数，四字段全量由 backend 声明；
-    - ``video_max_reference_images``：endpoint 维度硬上限，参考图布尔位由上限推出（>0 即
-      支持），首帧/尾帧取 ``VideoCapabilities`` 默认。
+    - ``video_max_reference_images``：endpoint 维度硬上限，其余维度（首帧/尾帧/参考音频）
+      取 ``VideoCapabilities`` 默认。
 
     不构造 SDK client、不查 DB，故 api_key 缺失也可调用。
 
@@ -61,7 +62,7 @@ def system_video_capabilities(*, endpoint: str, model_id: str) -> VideoCapabilit
         )
     if endpoint_cap < 0:
         raise ValueError(f"invalid video_max_reference_images on endpoint {endpoint!r}: {endpoint_cap!r}")
-    return VideoCapabilities(reference_images=endpoint_cap > 0, max_reference_images=endpoint_cap)
+    return VideoCapabilities(max_reference_images=endpoint_cap)
 
 
 def filter_valid_overrides(*, endpoint: str, model_id: str, overrides: object | None) -> dict[str, object]:
@@ -122,6 +123,20 @@ def filter_valid_overrides(*, endpoint: str, model_id: str, overrides: object | 
                     model_id,
                 )
                 continue
+        # 同构于上：endpoint 的 delegate 不会把 reference_audio_files 组装进请求时，把模式
+        # 覆盖成 direct 只会让合成层宣称支持音色输入，执行层照样生成随机音色的视频。
+        if key == "reference_audio_mode" and value == ReferenceAudioMode.DIRECT.value:
+            try:
+                audio_capable = get_endpoint_spec(endpoint).reference_audio_capable
+            except ValueError:
+                audio_capable = False
+            if not audio_capable:
+                logger.warning(
+                    "忽略 %s/%s 的能力覆盖 reference_audio_mode=direct：endpoint 不下传参考音频，该维度回退系统判定",
+                    endpoint,
+                    model_id,
+                )
+                continue
         applied[key] = value
 
     return applied
@@ -173,6 +188,9 @@ def capability_value_matches(value: object, expected: type) -> bool:
     bool 是 int 的子类，两个方向都要显式排除，否则 ``True`` 会被当成 1 张参考图上限、
     ``1`` 会被当成布尔真——这类宽松真值是语义猜测，不做。数值维度另拒负数。
 
+    枚举维度只认该枚举的合法取值字面量（覆盖字典从 JSON 列读出，成员本身不会跨序列化存活），
+    不做大小写归一或近义词映射：词表外的值一律判否、回退系统判定，而不是猜一个最像的成员。
+
     写入侧校验（API 层白名单）与此处的合成必须用同一判定：两边一旦漂移，写入放行的值会被
     合成静默忽略，正是本模块要消灭的「界面允许、执行反悔」。故此函数公开供 API 层复用。
     """
@@ -180,4 +198,6 @@ def capability_value_matches(value: object, expected: type) -> bool:
         return isinstance(value, bool)
     if expected is int:
         return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+    if isinstance(expected, type) and issubclass(expected, Enum):
+        return any(value == member.value for member in expected)
     return isinstance(value, expected)

--- a/lib/custom_provider/capabilities.py
+++ b/lib/custom_provider/capabilities.py
@@ -203,6 +203,49 @@ def merge_overrides(caps: VideoCapabilities, applied: dict[str, object]) -> Vide
     return replace(caps, **coerced)
 
 
+AUDIO_OVERRIDE_KEYS = ("reference_audio_mode", "max_reference_audio_count")
+
+
+def resolve_audio_pair(overrides: dict[str, object], *, endpoint: str, model_id: str) -> tuple[object, int]:
+    """把稀疏的音频覆盖补齐成完整的（模式, 段数上限）二元组，未覆盖的维度取系统判定。
+
+    不变式判定要的是合并后的两维，而覆盖字典只带用户显式改过的那些键；写入侧与回显侧都需要
+    这一步补齐，故收在一处而不是各写一份 ``overrides.get(..., system_caps...)`` 级联。
+    endpoint / model_id 不可解析时按最保守的"不支持音色输入"补齐。
+    """
+    try:
+        system_caps = system_video_capabilities(endpoint=endpoint, model_id=model_id)
+    except ValueError:
+        system_caps = None
+    mode = overrides.get(
+        "reference_audio_mode",
+        system_caps.reference_audio_mode if system_caps is not None else ReferenceAudioMode.NONE,
+    )
+    count = overrides.get(
+        "max_reference_audio_count",
+        system_caps.max_reference_audio_count if system_caps is not None else 0,
+    )
+    return mode, int(count) if isinstance(count, int) else 0
+
+
+def strip_incoherent_audio_overrides(
+    overrides: dict[str, object], *, endpoint: str, model_id: str
+) -> dict[str, object]:
+    """剔除合并后违反音频两维不变式的覆盖键。
+
+    :func:`enforce_audio_capability_invariant` 只把执行期能力降到 ``none``，覆盖字典本身仍
+    留着被降级的值。存量行或手工改库留下的 ``direct`` ⊕ 上限 0 若原样回显，界面会显示"直传
+    音色已生效"而生成其实不带音色输入；客户端把它随一次与音频无关的编辑原样回传，还会撞上
+    写入侧的同一条不变式，把整次保存拒成 422。两处后果与 ``last_frame`` 的既有过滤同源。
+    """
+    if not any(key in overrides for key in AUDIO_OVERRIDE_KEYS):
+        return overrides
+    mode, count = resolve_audio_pair(overrides, endpoint=endpoint, model_id=model_id)
+    if audio_capability_pair_is_coherent(mode=mode, count=count):
+        return overrides
+    return {key: value for key, value in overrides.items() if key not in AUDIO_OVERRIDE_KEYS}
+
+
 def audio_capability_pair_is_coherent(*, mode: object, count: int) -> bool:
     """音频两维的合并后不变式：声明支持音色输入就必须给出正的段数上限。
 

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -75,6 +75,10 @@ class EndpointSpec:
     # 尾帧约束。仅 video 类有意义；False 时即便系统判定或用户覆盖把 last_frame 置为 True，执行层
     # 也会静默丢弃尾帧、按无约束生成——写入侧 last_frame 覆盖据此收窄可开启的 endpoint 范围。
     end_image_capable: bool = False
+    # 同构于 end_image_capable：该 endpoint 的 delegate.generate() 是否真的读取
+    # VideoGenerationRequest.reference_audio_files 并组装进供应商请求。仅 video 类有意义；
+    # False 时把 reference_audio_mode 覆盖为 direct 只会让能力声明失真，执行层照旧不带音色输入。
+    reference_audio_capable: bool = False
 
 
 # ── 各 endpoint 的 build_backend 闭包 ──────────────────────────────
@@ -333,6 +337,8 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         build_backend=_build_ark_seedance,
         video_caps_for_model=ArkVideoBackend.video_capabilities_for_model,
         end_image_capable=True,
+        # _create_task 为 reference_audio_files 逐段组装 audio_url + role: reference_audio
+        reference_audio_capable=True,
     ),
     "vidu-video": EndpointSpec(
         key="vidu-video",
@@ -375,6 +381,8 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         # 多 model（happyhorse-r2v=9 / wan2.7-r2v=5）容量不同 → endpoint 维度不声明 int cap，
         # 按 model 读 backend caps（不构造 client）。
         video_caps_for_model=DashScopeVideoBackend.video_capabilities_for_model,
+        # _build_media 把 reference_audio_files 逐段挂到参考素材项的 reference_voice 上
+        reference_audio_capable=True,
     ),
     "minimax-image": EndpointSpec(
         key="minimax-image",
@@ -446,6 +454,8 @@ def _validate_video_caps_declarations() -> None:
         if caps_fn is not None and not callable(caps_fn):
             raise ValueError(f"endpoint {key!r} declares non-callable video_caps_for_model: {caps_fn!r}")
         has_fn = callable(caps_fn)
+        if spec.media_type != "video" and spec.reference_audio_capable:
+            raise ValueError(f"non-video endpoint {key!r} must not declare reference_audio_capable")
         if spec.media_type == "video":
             if has_int == has_fn:
                 raise ValueError(

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -154,6 +154,10 @@ MESSAGES = {
         "Endpoint {endpoint} of model {model_id} does not send reference audio; "
         "reference_audio_mode cannot be overridden to direct"
     ),
+    "capability_override_audio_pair_incoherent": (
+        "Model {model_id} must have max_reference_audio_count greater than 0 when reference audio is supported; "
+        "override reference_audio_mode to none to turn voice reference off"
+    ),
     # Projects
     "unknown_style_template": "Unknown style template: {template_id}",
     "ad_only_field": "{field} is only available for ad/short-video projects (content_mode=ad)",
@@ -255,6 +259,7 @@ MESSAGES = {
     "video_last_frame_unsupported": "{provider}/{model} does not support a last frame under the current configuration; generation aborted. Remove the shot's last frame, or switch to a model or tier that supports it",
     "video_reference_audio_unsupported": "{provider}/{model} does not support reference audio; generation aborted. Remove the character's reference audio, or switch to a model that supports voice reference",
     "video_reference_audio_exceeded": "Model {model} supports at most {limit} reference audio clips but received {count}; reduce the number of characters with reference audio",
+    "video_reference_audio_slots_insufficient": "Model {model} attaches each reference audio clip to a reference asset, but only {slots} reference assets are available for {count} clips; add reference images for those characters, or reduce the number of characters with reference audio",
     "video_reference_audio_unreadable": "Model {model} has reference audio that is missing or unreadable; generation aborted: {names}; check the reference audio paths",
     "video_reference_audio_format_unsupported": "Reference audio {name} has an unsupported format (only {supported}); use a different audio file",
     # Agent credentials

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -150,6 +150,10 @@ MESSAGES = {
         "Endpoint {endpoint} of model {model_id} does not support last-frame generation; "
         "last_frame cannot be overridden to true"
     ),
+    "capability_override_reference_audio_unsupported": (
+        "Endpoint {endpoint} of model {model_id} does not send reference audio; "
+        "reference_audio_mode cannot be overridden to direct"
+    ),
     # Projects
     "unknown_style_template": "Unknown style template: {template_id}",
     "ad_only_field": "{field} is only available for ad/short-video projects (content_mode=ad)",
@@ -249,6 +253,10 @@ MESSAGES = {
     "video_end_image_requires_start_image": "Model {model} does not support a standalone last frame; also provide a first frame (first+last keyframes) or remove the last frame",
     "video_last_frame_requires_pro": "{provider}/{model} only supports first+last frame at the pro tier; switch to the pro tier or remove the last frame",
     "video_last_frame_unsupported": "{provider}/{model} does not support a last frame under the current configuration; generation aborted. Remove the shot's last frame, or switch to a model or tier that supports it",
+    "video_reference_audio_unsupported": "{provider}/{model} does not support reference audio; generation aborted. Remove the character's reference audio, or switch to a model that supports voice reference",
+    "video_reference_audio_exceeded": "Model {model} supports at most {limit} reference audio clips but received {count}; reduce the number of characters with reference audio",
+    "video_reference_audio_unreadable": "Model {model} has reference audio that is missing or unreadable; generation aborted: {names}; check the reference audio paths",
+    "video_reference_audio_format_unsupported": "Reference audio {name} has an unsupported format (only {supported}); use a different audio file",
     # Agent credentials
     "agent_preset_unknown": "Unknown preset provider: {preset_id}",
     "agent_base_url_required_custom": "base_url is required for custom configuration",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -146,6 +146,10 @@ MESSAGES = {
     "capability_override_invalid_value": (
         "Năng lực {capability} của mô hình {model_id} có kiểu giá trị không hợp lệ; cần {expected}"
     ),
+    "capability_override_reference_audio_unsupported": (
+        "Endpoint {endpoint} của mô hình {model_id} không gửi âm thanh tham chiếu; "
+        "không thể ghi đè reference_audio_mode thành direct"
+    ),
     "capability_override_last_frame_unsupported": (
         "Endpoint {endpoint} của mô hình {model_id} không hỗ trợ tạo khung hình cuối; "
         "không thể ghi đè last_frame thành true"
@@ -249,6 +253,10 @@ MESSAGES = {
     "video_end_image_requires_start_image": "Mô hình {model} không hỗ trợ khung hình cuối độc lập; hãy cung cấp thêm khung hình đầu (chế độ khung đầu+cuối) hoặc bỏ khung hình cuối",
     "video_last_frame_requires_pro": "{provider}/{model} chỉ hỗ trợ khung đầu+cuối ở gói pro; hãy chuyển sang gói pro hoặc bỏ khung hình cuối",
     "video_last_frame_unsupported": "{provider}/{model} không hỗ trợ khung hình cuối với cấu hình hiện tại; đã hủy tạo. Hãy bỏ khung hình cuối của cảnh quay này, hoặc chuyển sang mô hình hoặc gói có hỗ trợ",
+    "video_reference_audio_unsupported": "{provider}/{model} không hỗ trợ âm thanh tham chiếu; đã hủy tạo. Hãy bỏ âm thanh tham chiếu của nhân vật, hoặc chuyển sang mô hình có hỗ trợ tham chiếu giọng nói",
+    "video_reference_audio_exceeded": "Mô hình {model} hỗ trợ tối đa {limit} đoạn âm thanh tham chiếu nhưng nhận được {count}; hãy giảm số nhân vật có âm thanh tham chiếu",
+    "video_reference_audio_unreadable": "Mô hình {model} có âm thanh tham chiếu bị thiếu hoặc không đọc được; đã hủy tạo: {names}; hãy kiểm tra đường dẫn âm thanh tham chiếu",
+    "video_reference_audio_format_unsupported": "Âm thanh tham chiếu {name} có định dạng không được hỗ trợ (chỉ {supported}); hãy dùng tệp âm thanh khác",
     # Agent credentials
     "agent_preset_unknown": "Nhà cung cấp đặt sẵn không xác định: {preset_id}",
     "agent_base_url_required_custom": "Cấu hình tuỳ chỉnh yêu cầu base_url",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -150,6 +150,10 @@ MESSAGES = {
         "Endpoint {endpoint} của mô hình {model_id} không gửi âm thanh tham chiếu; "
         "không thể ghi đè reference_audio_mode thành direct"
     ),
+    "capability_override_audio_pair_incoherent": (
+        "Mô hình {model_id} phải có max_reference_audio_count lớn hơn 0 khi hỗ trợ âm thanh tham chiếu; "
+        "hãy ghi đè reference_audio_mode thành none để tắt tham chiếu giọng nói"
+    ),
     "capability_override_last_frame_unsupported": (
         "Endpoint {endpoint} của mô hình {model_id} không hỗ trợ tạo khung hình cuối; "
         "không thể ghi đè last_frame thành true"
@@ -255,6 +259,7 @@ MESSAGES = {
     "video_last_frame_unsupported": "{provider}/{model} không hỗ trợ khung hình cuối với cấu hình hiện tại; đã hủy tạo. Hãy bỏ khung hình cuối của cảnh quay này, hoặc chuyển sang mô hình hoặc gói có hỗ trợ",
     "video_reference_audio_unsupported": "{provider}/{model} không hỗ trợ âm thanh tham chiếu; đã hủy tạo. Hãy bỏ âm thanh tham chiếu của nhân vật, hoặc chuyển sang mô hình có hỗ trợ tham chiếu giọng nói",
     "video_reference_audio_exceeded": "Mô hình {model} hỗ trợ tối đa {limit} đoạn âm thanh tham chiếu nhưng nhận được {count}; hãy giảm số nhân vật có âm thanh tham chiếu",
+    "video_reference_audio_slots_insufficient": "Mô hình {model} gắn mỗi đoạn âm thanh tham chiếu vào một tư liệu tham chiếu, nhưng chỉ có {slots} tư liệu cho {count} đoạn; hãy bổ sung ảnh tham chiếu cho các nhân vật đó, hoặc giảm số nhân vật có âm thanh tham chiếu",
     "video_reference_audio_unreadable": "Mô hình {model} có âm thanh tham chiếu bị thiếu hoặc không đọc được; đã hủy tạo: {names}; hãy kiểm tra đường dẫn âm thanh tham chiếu",
     "video_reference_audio_format_unsupported": "Âm thanh tham chiếu {name} có định dạng không được hỗ trợ (chỉ {supported}); hãy dùng tệp âm thanh khác",
     # Agent credentials

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -140,6 +140,9 @@ MESSAGES = {
     "capability_overrides_video_only": "模型 {model_id} 的 endpoint {endpoint} 不是视频类，不支持能力覆盖",
     "capability_override_invalid_value": "模型 {model_id} 的能力项 {capability} 取值类型不正确，应为 {expected}",
     "capability_override_last_frame_unsupported": "模型 {model_id} 的 endpoint {endpoint} 不支持尾帧生成，无法覆盖 last_frame 为开启",
+    "capability_override_reference_audio_unsupported": (
+        "模型 {model_id} 的 endpoint {endpoint} 不会下发参考音频，无法把 reference_audio_mode 覆盖为 direct"
+    ),
     # Projects
     "unknown_style_template": "未知的风格模版: {template_id}",
     "ad_only_field": "{field} 仅广告/短片项目（content_mode=ad）可用",
@@ -239,6 +242,10 @@ MESSAGES = {
     "video_end_image_requires_start_image": "模型 {model} 不支持单独的尾帧；请同时提供首帧（首尾帧模式），或移除尾帧",
     "video_last_frame_requires_pro": "{provider}/{model} 的首尾帧仅在 pro 档生效；请切换到 pro 档，或移除尾帧",
     "video_last_frame_unsupported": "{provider}/{model} 当前配置不支持尾帧，已中止生成；请移除该镜头的尾帧，或改用支持尾帧的模型/档位",
+    "video_reference_audio_unsupported": "{provider}/{model} 不支持参考音频，已中止生成；请移除角色的参考音频，或改用支持音色参考的模型",
+    "video_reference_audio_exceeded": "模型 {model} 最多支持 {limit} 段参考音频，收到 {count} 段；请减少带参考音频的角色数量",
+    "video_reference_audio_unreadable": "模型 {model} 有参考音频缺失或无法读取，已中止生成：{names}；请检查参考音频路径",
+    "video_reference_audio_format_unsupported": "参考音频 {name} 的格式不受支持（仅支持 {supported}）；请更换音频文件",
     # Agent credentials
     "agent_preset_unknown": "未知预设供应商: {preset_id}",
     "agent_base_url_required_custom": "自定义配置需要填写 base_url",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -143,6 +143,10 @@ MESSAGES = {
     "capability_override_reference_audio_unsupported": (
         "模型 {model_id} 的 endpoint {endpoint} 不会下发参考音频，无法把 reference_audio_mode 覆盖为 direct"
     ),
+    "capability_override_audio_pair_incoherent": (
+        "模型 {model_id} 支持参考音频时 max_reference_audio_count 必须大于 0；"
+        "如需关闭音色参考，请把 reference_audio_mode 覆盖为 none"
+    ),
     # Projects
     "unknown_style_template": "未知的风格模版: {template_id}",
     "ad_only_field": "{field} 仅广告/短片项目（content_mode=ad）可用",
@@ -244,6 +248,7 @@ MESSAGES = {
     "video_last_frame_unsupported": "{provider}/{model} 当前配置不支持尾帧，已中止生成；请移除该镜头的尾帧，或改用支持尾帧的模型/档位",
     "video_reference_audio_unsupported": "{provider}/{model} 不支持参考音频，已中止生成；请移除角色的参考音频，或改用支持音色参考的模型",
     "video_reference_audio_exceeded": "模型 {model} 最多支持 {limit} 段参考音频，收到 {count} 段；请减少带参考音频的角色数量",
+    "video_reference_audio_slots_insufficient": "模型 {model} 的参考音频需逐段挂在参考素材上，当前只有 {slots} 个参考素材却收到 {count} 段音频；请为这些角色补齐参考图，或减少带参考音频的角色数量",
     "video_reference_audio_unreadable": "模型 {model} 有参考音频缺失或无法读取，已中止生成：{names}；请检查参考音频路径",
     "video_reference_audio_format_unsupported": "参考音频 {name} 的格式不受支持（仅支持 {supported}）；请更换音频文件",
     # Agent credentials

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -485,6 +485,7 @@ class MediaGenerator:
         start_image: str | Path | Image.Image | None = None,
         end_image: Path | None = None,
         reference_images: list[Path] | None = None,
+        reference_audio_files: list[Path] | None = None,
         aspect_ratio: str = "9:16",
         duration_seconds: str | int = "8",
         resolution: str | None = None,
@@ -500,6 +501,7 @@ class MediaGenerator:
             start_image: 起始帧图片（image-to-video 模式）
             end_image: 结束帧图片（first_last 模式）
             reference_images: 参考图片列表（multi-reference 模式）
+            reference_audio_files: 参考音频列表（音色复刻），顺序即 prompt 中「音频N」的指认顺序
             aspect_ratio: 宽高比，默认 9:16（竖屏）
             duration_seconds: 视频时长，可选 "4", "6", "8"
             resolution: 分辨率，默认不传（由 backend/SDK 决定）
@@ -516,6 +518,7 @@ class MediaGenerator:
                 start_image=start_image,
                 end_image=end_image,
                 reference_images=reference_images,
+                reference_audio_files=reference_audio_files,
                 aspect_ratio=aspect_ratio,
                 duration_seconds=duration_seconds,
                 resolution=resolution,
@@ -531,6 +534,7 @@ class MediaGenerator:
         start_image: str | Path | Image.Image | None = None,
         end_image: Path | None = None,
         reference_images: list[Path] | None = None,
+        reference_audio_files: list[Path] | None = None,
         aspect_ratio: str = "9:16",
         duration_seconds: str | int = "8",
         resolution: str | None = None,
@@ -547,6 +551,7 @@ class MediaGenerator:
             start_image: 起始帧图片（image-to-video 模式）
             end_image: 结束帧图片（first_last 模式）
             reference_images: 参考图片列表（multi-reference 模式）
+            reference_audio_files: 参考音频列表（音色复刻），顺序即 prompt 中「音频N」的指认顺序
             aspect_ratio: 宽高比，默认 9:16（竖屏）
             duration_seconds: 视频时长，可选 "4", "6", "8"
             resolution: 分辨率，默认不传（由 backend/SDK 决定）
@@ -591,25 +596,31 @@ class MediaGenerator:
 
         model_name = self._video_backend.model
 
-        # 能力 gating 与槽位组装先于记账括号：尾帧不被支持时硬失败要"不扣费"，
-        # 在括号内抛虽也不结算，却会留一条 failed ApiCall 行；纯函数无副作用，前置最干净。
-        from lib.video_frame_slots import plan_frame_slots, resolve_video_capabilities
+        # 能力校验与槽位组装先于记账括号：能力不被支持时硬失败要"不扣费"，
+        # 在括号内抛虽也不结算，却会留一条 failed ApiCall 行；两者均无副作用，前置最干净。
+        from lib.video_frame_slots import gate_video_request, plan_frame_slots, resolve_video_capabilities
 
-        # 能力查询保持惰性：不带尾帧的请求不触发 gating，无谓查询只会给无尾帧路径
-        # 新增一层后端属性依赖；未查询即传 None，不伪造一份占位能力声明。
+        # 能力查询保持惰性：三条可选路径都不走的请求不触发校验，无谓查询只会给最常见的
+        # 纯首帧路径新增一层后端属性依赖；未查询即传 None，不伪造一份占位能力声明。
+        needs_caps = end_image is not None or bool(reference_images) or bool(reference_audio_files)
         video_caps = (
             resolve_video_capabilities(
                 self._video_backend,
                 service_tier=version_metadata.get("service_tier", "default"),
                 resolution=resolution,
             )
-            if end_image is not None
+            if needs_caps
             else None
         )
-        slot_plan = plan_frame_slots(
+        gate_video_request(
             caps=video_caps,
             provider=self._video_backend.name,
             model=model_name,
+            end_image=end_image,
+            reference_images=reference_images,
+            reference_audio_files=reference_audio_files,
+        )
+        slot_plan = plan_frame_slots(
             start_image=start_image,
             end_image=end_image,
             reference_images=reference_images,

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -691,6 +691,9 @@ class MediaGenerator:
                         start_image=start_arg,
                         end_image=end_arg,
                         reference_images=ref_arg,
+                        # 音频不进压缩器（specs 只收图片），故直接透传原列表：顺序即 prompt
+                        # 「音频N」的指认顺序，任何重排都会把 A 角色的音色安到 B 角色头上。
+                        reference_audio_files=reference_audio_files,
                         generate_audio=effective_generate_audio,
                         project_name=self.project_name,
                         task_id=task_id,

--- a/lib/task_failure.py
+++ b/lib/task_failure.py
@@ -47,6 +47,7 @@ CAPABILITY_FAILURE_CODES: frozenset[str] = frozenset(
         "video_reference_images_with_frames_unsupported",
         "video_reference_audio_exceeded",
         "video_reference_audio_format_unsupported",
+        "video_reference_audio_slots_insufficient",
         "video_reference_audio_unreadable",
         "video_reference_audio_unsupported",
         "video_resolution_duration_unsupported",

--- a/lib/task_failure.py
+++ b/lib/task_failure.py
@@ -45,6 +45,10 @@ CAPABILITY_FAILURE_CODES: frozenset[str] = frozenset(
         "video_reference_images_unreadable",
         "video_reference_images_unsupported",
         "video_reference_images_with_frames_unsupported",
+        "video_reference_audio_exceeded",
+        "video_reference_audio_format_unsupported",
+        "video_reference_audio_unreadable",
+        "video_reference_audio_unsupported",
         "video_resolution_duration_unsupported",
         "video_start_image_unreadable",
     }

--- a/lib/video_backends/__init__.py
+++ b/lib/video_backends/__init__.py
@@ -9,8 +9,8 @@ from lib.providers import (
     PROVIDER_OPENAI,
 )
 from lib.video_backends.base import (
+    ReferenceAudioMode,
     VideoBackend,
-    VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
 )
@@ -22,8 +22,8 @@ __all__ = [
     "PROVIDER_GROK",
     "PROVIDER_NEWAPI",
     "PROVIDER_OPENAI",
+    "ReferenceAudioMode",
     "VideoBackend",
-    "VideoCapability",
     "VideoGenerationRequest",
     "VideoGenerationResult",
     "create_backend",

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -38,7 +38,6 @@ from lib.video_backends.base import (
     ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
     VideoCapabilities,
-    VideoCapability,
     VideoCapabilityError,
     VideoGenerationRequest,
     VideoGenerationResult,
@@ -204,10 +203,6 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
         self._base_url = agnes_base_url(base_url)
         self._model = model or DEFAULT_MODEL
         self._http_timeout = http_timeout
-        self._capabilities: set[VideoCapability] = {
-            VideoCapability.TEXT_TO_VIDEO,
-            VideoCapability.IMAGE_TO_VIDEO,
-        }
 
     @property
     def name(self) -> str:
@@ -216,10 +211,6 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
     @property
     def model(self) -> str:
         return self._model
-
-    @property
-    def capabilities(self) -> set[VideoCapability]:
-        return self._capabilities
 
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
@@ -232,7 +223,6 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
         return VideoCapabilities(
             first_frame=True,
             last_frame=True,
-            reference_images=True,
             max_reference_images=_MAX_REFERENCE_IMAGES,
         )
 

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -32,6 +32,9 @@ logger = logging.getLogger(__name__)
 # Seedance 2.0 系列每请求最多 3 段参考音频（官方《创建视频生成任务 API》音频信息章节）。
 _SEEDANCE_2_MAX_REFERENCE_AUDIO = 3
 
+# Seedance 1.5 pro 的参考图上限，与 lib/config/registry.py 的同名 ModelInfo 字段同值。
+_SEEDANCE_1_5_MAX_REFERENCE_IMAGES = 9
+
 # 参考音频的 data URI MIME：官方接受 wav / mp3 两种格式，要求 `data:audio/<格式>;base64,<内容>`
 # 且格式小写。资产上传期已按同一组格式收窄，此处按扩展名回填，未知扩展名不猜测直接拒绝。
 # 与 dashscope 侧的同名表刻意各存一份：mp3 在这里按官方示例写 audio/mp3，dashscope 走标准
@@ -129,6 +132,13 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
     # 被误判为继承已验证型号的尾帧能力，绕过本模块新增的硬拒绝。
     _KNOWN_MODEL_SUFFIX_RE = re.compile(r"^(-\d+)?$")
 
+    # 非 2.0 系列里支持参考生视频的型号：1.5 pro 的参考图上限与 registry ModelInfo 声明
+    # （doubao-seedance-1-5-pro-251215 / doubao-seedance-1.5-pro 均为 9）一致。两处必须同值——
+    # 编排层按 registry 决定给一个 unit 派几张参考图，请求期按本声明校验，声明低于 registry
+    # 会让编排层正常派图的请求在 gate 上被拒。守卫见 tests/test_video_backend_ark.py 的
+    # registry 一致性用例。
+    _REFERENCE_IMAGE_ALLOW_SUBSTRINGS = ("seedance-1-5-pro", "seedance-1.5-pro")
+
     # Seedance 2.0 系列已验证支持首尾帧的三个变体（lib/config/registry.py 内建型号：
     # doubao-seedance-2-0-260128 / -2-0-fast-260128 / -2-0-mini-260615，及无日期戳的
     # doubao-seedance-2.0 / -2.0-fast / -2.0-mini）。同样走边界匹配，未知后缀（如
@@ -188,8 +198,17 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
             model_lower, ArkVideoBackend._LAST_FRAME_ALLOW_SUBSTRINGS
         )
         denied_last_frame = any(sub in model_lower for sub in ArkVideoBackend._NO_LAST_FRAME_SUBSTRINGS)
+        # _create_task 对任何 model 都会把 reference_images 序列化成 role="reference_image"，
+        # 参考生视频在 1.5 pro 上是既有可用路径；此处不声明容量会让 gate_video_request 把编排层
+        # 按 registry 正常派好参考图的请求整批拒掉。未上表的型号仍保守判 0。
         return VideoCapabilities(
-            first_frame=not no_first_frame, last_frame=allowed_last_frame and not denied_last_frame
+            first_frame=not no_first_frame,
+            last_frame=allowed_last_frame and not denied_last_frame,
+            max_reference_images=(
+                _SEEDANCE_1_5_MAX_REFERENCE_IMAGES
+                if ArkVideoBackend._matches_known_model(model_lower, ArkVideoBackend._REFERENCE_IMAGE_ALLOW_SUBSTRINGS)
+                else 0
+            ),
         )
 
     @property

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -34,6 +34,8 @@ _SEEDANCE_2_MAX_REFERENCE_AUDIO = 3
 
 # 参考音频的 data URI MIME：官方接受 wav / mp3 两种格式，要求 `data:audio/<格式>;base64,<内容>`
 # 且格式小写。资产上传期已按同一组格式收窄，此处按扩展名回填，未知扩展名不猜测直接拒绝。
+# 与 dashscope 侧的同名表刻意各存一份：mp3 在这里按官方示例写 audio/mp3，dashscope 走标准
+# 的 audio/mpeg——供应商各自的接受口径，合并成一张共享表会让其中一家收到没验证过的 MIME。
 _REFERENCE_AUDIO_MIME_TYPES = {".wav": "audio/wav", ".mp3": "audio/mp3"}
 
 
@@ -165,16 +167,16 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
             # 族群识别（供 service_tier 剔除复用），未验证的 2.0 系列未来变体不应继承这两项
             # 能力。两者当前覆盖同一组已上表型号（2.0 / 2.0-fast / 2.0-mini 三档官方均声明
             # 支持音频参考），故共用同一份白名单常量而非维护两份同内容清单。
-            verified = ArkVideoBackend._matches_known_model(
+            on_verified_allowlist = ArkVideoBackend._matches_known_model(
                 model.lower(), ArkVideoBackend._SEEDANCE_2_LAST_FRAME_ALLOW_SUBSTRINGS
             )
             return VideoCapabilities(
-                last_frame=verified,
+                last_frame=on_verified_allowlist,
                 max_reference_images=9,
-                reference_audio_mode=(ReferenceAudioMode.DIRECT if verified else ReferenceAudioMode.NONE),
+                reference_audio_mode=(ReferenceAudioMode.DIRECT if on_verified_allowlist else ReferenceAudioMode.NONE),
                 # 官方限制：每请求最多 3 段参考音频，且总时长不超过 15 秒。总时长约束由
                 # 资产上传期的单段时长校验（2–10 秒）间接收敛，本层只声明段数上限。
-                max_reference_audio_count=_SEEDANCE_2_MAX_REFERENCE_AUDIO if verified else 0,
+                max_reference_audio_count=_SEEDANCE_2_MAX_REFERENCE_AUDIO if on_verified_allowlist else 0,
             )
         # 非 2.0 系列：DEFAULT_MODEL 1.5 pro 实测正常下发 role="last_frame"（见
         # test_first_last_frame_role_fields），此前统一按 VideoCapabilities() 默认

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 import re
 from pathlib import Path
@@ -16,9 +17,10 @@ from lib.providers import PROVIDER_ARK
 from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
 from lib.video_backends.base import (
     ProviderJobIdPersistenceMixin,
+    ReferenceAudioMode,
     ResumeExpiredError,
     VideoCapabilities,
-    VideoCapability,
+    VideoCapabilityError,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
@@ -27,18 +29,40 @@ from lib.video_backends.base import (
 
 logger = logging.getLogger(__name__)
 
+# Seedance 2.0 系列每请求最多 3 段参考音频（官方《创建视频生成任务 API》音频信息章节）。
+_SEEDANCE_2_MAX_REFERENCE_AUDIO = 3
+
+# 参考音频的 data URI MIME：官方接受 wav / mp3 两种格式，要求 `data:audio/<格式>;base64,<内容>`
+# 且格式小写。资产上传期已按同一组格式收窄，此处按扩展名回填，未知扩展名不猜测直接拒绝。
+_REFERENCE_AUDIO_MIME_TYPES = {".wav": "audio/wav", ".mp3": "audio/mp3"}
+
+
+def _reference_audio_to_data_uri(path: Path, *, model: str) -> str:
+    """参考音频 → base64 data URI；格式不受支持或文件不可读一律抛错。
+
+    与参考图的「缺失即跳过」不同，音频不能静默跳过：prompt 里的「音频N」按 content 数组中
+    音频条目的出现顺序编号，跳过一段会让其后所有编号整体前移，把某个角色的音色安到另一个
+    角色头上——错得无声无息，且照常扣费。
+    """
+    mime = _REFERENCE_AUDIO_MIME_TYPES.get(path.suffix.lower())
+    if mime is None:
+        raise VideoCapabilityError(
+            "video_reference_audio_format_unsupported",
+            model=model,
+            name=path.name,
+            supported=", ".join(sorted(_REFERENCE_AUDIO_MIME_TYPES)),
+        )
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise VideoCapabilityError("video_reference_audio_unreadable", model=model, names=path.name) from exc
+    return f"data:{mime};base64,{base64.b64encode(raw).decode('ascii')}"
+
 
 class ArkVideoBackend(ProviderJobIdPersistenceMixin):
     """Ark (火山方舟) 视频生成后端。"""
 
     DEFAULT_MODEL = "doubao-seedance-1-5-pro-251215"
-
-    _BASE_CAPABILITIES: set[VideoCapability] = {
-        VideoCapability.TEXT_TO_VIDEO,
-        VideoCapability.IMAGE_TO_VIDEO,
-        VideoCapability.GENERATE_AUDIO,
-        VideoCapability.SEED_CONTROL,
-    }
 
     def __init__(
         self,
@@ -49,13 +73,12 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
     ):
         self._client = create_ark_client(api_key=api_key, base_url=base_url)
         self._model = model or self.DEFAULT_MODEL
-        # FLEX_TIER（service_tier 参数）仅 seedance-1.x 等老模型支持；seedance-2-0/2.0 系列
-        # 上游在 r2v 下会 400 拒绝该参数，必须从能力集中剔除。判定见 _is_seedance_2：用 `in`
-        # 子串兼容多套前缀命名（doubao-/dreamina-），但版本号收窄到已验证的 2-0/2.0，
-        # 不对未发布版本（如 seedance-2.5）过早假设。
-        self._capabilities = set(self._BASE_CAPABILITIES)
-        if not self._is_seedance_2(self._model):
-            self._capabilities.add(VideoCapability.FLEX_TIER)
+        # service_tier 参数仅 seedance-1.x 等老模型支持；seedance-2-0/2.0 系列上游在 r2v 下会
+        # 400 拒绝该参数，必须不下传。判定见 _is_seedance_2：用 `in` 子串兼容多套前缀命名
+        # （doubao-/dreamina-），但版本号收窄到已验证的 2-0/2.0，不对未发布版本（如
+        # seedance-2.5）过早假设。这是 backend 内部的运输细节，不进 VideoCapabilities——
+        # 后者只声明调用方需要据以取舍的输入路径。
+        self._supports_service_tier = not self._is_seedance_2(self._model)
 
     @property
     def name(self) -> str:
@@ -65,17 +88,13 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
     def model(self) -> str:
         return self._model
 
-    @property
-    def capabilities(self) -> set[VideoCapability]:
-        return self._capabilities
-
     @staticmethod
     def _is_seedance_2(model: str) -> bool:
         """按 model_id 子串识别已验证的 seedance-2-0 / seedance-2.0 系列（含 fast 变体）。
 
         只匹配已验证不支持 service_tier 的版本号（2-0 与 2.0 两种写法），不对未发布的未来版本
         （如 seedance-2.5）过早假设。用 `in` 子串而非前缀匹配，以兼容上游多套前缀命名
-        （doubao- 火山国内站 / dreamina- BytePlus 国际站）。FLEX_TIER 剔除与参考图能力共用
+        （doubao- 火山国内站 / dreamina- BytePlus 国际站）。service_tier 剔除与参考图能力共用
         本判定，避免两条路径口径漂移。
         """
         model_lower = model.lower()
@@ -142,12 +161,21 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
             # API 拒绝首帧/尾帧与参考素材混合请求（InvalidParameter: first/last frame content
             # cannot be mixed with reference media content，实测）——参考图是与首尾帧互斥的
             # 参考生视频模式，故不声明首帧叠加参考能力；若上游后续放开混合可重新开启。
-            # last_frame 单独走边界校验的已验证型号白名单：_is_seedance_2 本身只做宽松族群
-            # 识别（供 FLEX_TIER 剔除复用），未验证的 2.0 系列未来变体不应继承尾帧能力。
-            verified_last_frame = ArkVideoBackend._matches_known_model(
+            # 尾帧与参考音频都单独走边界校验的已验证型号白名单：_is_seedance_2 本身只做宽松
+            # 族群识别（供 service_tier 剔除复用），未验证的 2.0 系列未来变体不应继承这两项
+            # 能力。两者当前覆盖同一组已上表型号（2.0 / 2.0-fast / 2.0-mini 三档官方均声明
+            # 支持音频参考），故共用同一份白名单常量而非维护两份同内容清单。
+            verified = ArkVideoBackend._matches_known_model(
                 model.lower(), ArkVideoBackend._SEEDANCE_2_LAST_FRAME_ALLOW_SUBSTRINGS
             )
-            return VideoCapabilities(last_frame=verified_last_frame, reference_images=True, max_reference_images=9)
+            return VideoCapabilities(
+                last_frame=verified,
+                max_reference_images=9,
+                reference_audio_mode=(ReferenceAudioMode.DIRECT if verified else ReferenceAudioMode.NONE),
+                # 官方限制：每请求最多 3 段参考音频，且总时长不超过 15 秒。总时长约束由
+                # 资产上传期的单段时长校验（2–10 秒）间接收敛，本层只声明段数上限。
+                max_reference_audio_count=_SEEDANCE_2_MAX_REFERENCE_AUDIO if verified else 0,
+            )
         # 非 2.0 系列：DEFAULT_MODEL 1.5 pro 实测正常下发 role="last_frame"（见
         # test_first_last_frame_role_fields），此前统一按 VideoCapabilities() 默认
         # last_frame=False 处理是误判；白名单覆盖能力表已验证支持首尾帧的三个型号，
@@ -232,6 +260,20 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
                         }
                     )
 
+        if request.reference_audio_files:
+            # 音频条目与图片条目同列 content 数组，各自按类型独立编号：prompt 里的「音频N」
+            # 指的是第 N 个 type="audio_url" 条目（官方《快速入门》提示词规则）。故这里必须
+            # 保持 reference_audio_files 的原始顺序、不跳过任何一段——跳过会让编排层拼好的
+            # 指认文本整体错位，把 A 角色的音色安到 B 角色头上。
+            for audio_path in request.reference_audio_files:
+                content.append(
+                    {
+                        "type": "audio_url",
+                        "audio_url": {"url": _reference_audio_to_data_uri(Path(audio_path), model=self._model)},
+                        "role": "reference_audio",
+                    }
+                )
+
         # 2. Build API params
         # 比例优先：ratio 是独立 SDK 字段，由 aspect_ratio 直接决定；resolution 仅清晰度档位，
         # 与比例正交（SDK 内部按 ratio×resolution 算像素），不把比例压进像素 size，故无尺寸 bug。
@@ -245,8 +287,8 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
         }
         if request.resolution is not None:
             create_params["resolution"] = request.resolution
-        # seedance-2.0 等模型不接受 service_tier，仅在声明 FLEX_TIER 能力时传入
-        if VideoCapability.FLEX_TIER in self._capabilities:
+        # seedance-2.0 等模型不接受 service_tier
+        if self._supports_service_tier:
             create_params["service_tier"] = request.service_tier
         if request.seed is not None:
             create_params["seed"] = request.seed

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -42,6 +42,33 @@ _SEEDANCE_1_5_MAX_REFERENCE_IMAGES = 9
 _REFERENCE_AUDIO_MIME_TYPES = {".wav": "audio/wav", ".mp3": "audio/mp3"}
 
 
+def _safe_create_params_for_log(create_params: dict[str, Any]) -> dict[str, Any]:
+    """请求参数的安全日志视图：content 数组按条目类型折叠成计数，不展开内嵌素材。
+
+    content 里的图片与音频都是 base64 data URI。``format_kwargs_for_log`` 只截断长字符串、
+    不认识这层结构，直接交给它会把每个素材的 base64 前缀写进 info 日志（音频还可能带上
+    mp3 文件头的 ID3 元数据）。dashscope / vidu / minimax 三家均已各有同名的安全视图并在
+    注释里点明对齐 CodeQL clear-text-logging，Ark 此前是唯一漏网的一家。
+
+    prompt 是用户文本、不是素材，仍按 ``format_kwargs_for_log`` 的既有截断规则输出，
+    以保留排查生成效果时最常用的那一项。
+    """
+    view = {key: value for key, value in create_params.items() if key != "content"}
+    content = create_params.get("content")
+    if isinstance(content, list):
+        counts: dict[str, int] = {}
+        for item in content:
+            kind = item.get("type", "unknown") if isinstance(item, dict) else "unknown"
+            counts[kind] = counts.get(kind, 0) + 1
+        view["content"] = "<" + ", ".join(f"{n} {kind}" for kind, n in sorted(counts.items())) + ">"
+        prompt = next(
+            (item.get("text") for item in content if isinstance(item, dict) and item.get("type") == "text"), None
+        )
+        if isinstance(prompt, str):
+            view["prompt"] = prompt
+    return view
+
+
 def _reference_audio_to_data_uri(path: Path, *, model: str) -> str:
     """参考音频 → base64 data URI；格式不受支持或文件不可读一律抛错。
 
@@ -184,8 +211,12 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
                 last_frame=on_verified_allowlist,
                 max_reference_images=9,
                 reference_audio_mode=(ReferenceAudioMode.DIRECT if on_verified_allowlist else ReferenceAudioMode.NONE),
-                # 官方限制：每请求最多 3 段参考音频，且总时长不超过 15 秒。总时长约束由
-                # 资产上传期的单段时长校验（2–10 秒）间接收敛，本层只声明段数上限。
+                # 官方限制：每请求最多 3 段参考音频，单段时长 2–15 秒，且总时长不超过 15 秒。
+                # 本层只声明段数上限——总时长是逐段时长之和，`VideoCapabilities` 没有承载它的
+                # 维度，且判定需要读音频元数据（本层拿到的只是路径）。单段上限也推不出总时长：
+                # 两段各 10 秒都合法，合起来已经超。该约束须在能拿到时长的位置施加，即音频资产
+                # 的上传/选取期，与「哪个角色用哪段音频」的填充同处一层。
+                # 出处：《创建视频生成任务 API》音频信息章节。
                 max_reference_audio_count=_SEEDANCE_2_MAX_REFERENCE_AUDIO if on_verified_allowlist else 0,
             )
         # 非 2.0 系列：DEFAULT_MODEL 1.5 pro 实测正常下发 role="last_frame"（见
@@ -315,7 +346,9 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
             create_params["seed"] = request.seed
 
         # 3. Create task (sync SDK call, run in executor)
-        logger.info("调用 %s 视频 SDK kwargs=%s", self.name, format_kwargs_for_log(create_params))
+        logger.info(
+            "调用 %s 视频 SDK kwargs=%s", self.name, format_kwargs_for_log(_safe_create_params_for_log(create_params))
+        )
         create_result = await asyncio.to_thread(
             self._client.content_generation.tasks.create,
             **create_params,

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -376,34 +376,41 @@ class VideoCapabilityError(RuntimeError):
         super().__init__(code)
 
 
+class ReferenceAudioMode(StrEnum):
+    """后端接受参考音频的运输形态。
+
+    ``DIRECT`` 表示随生成请求直传音频文件，模型据其复刻音色（Seedance 2.0 的
+    ``role: reference_audio`` content 条目、Wan2.7 r2v 挂在参考素材项上的
+    ``reference_voice``）。``NONE`` 表示该后端没有音色输入通道——带音频的请求在
+    ``gate_video_request`` 处硬失败，不静默丢弃。
+    """
+
+    NONE = "none"
+    DIRECT = "direct"
+
+
 @dataclass
 class VideoCapabilities:
     """Declares what a video backend supports.
 
     ``first_frame`` / ``last_frame`` 描述图生视频路径的首帧与尾帧槽位。
-    ``reference_images`` / ``max_reference_images`` 描述参考生视频路径：后端接受
-    ``reference_images`` 请求字段及其数量上限。两条路径是否可叠加（同一请求同时带
-    首帧与参考图）因后端而异，不是统一契约：部分后端拒绝叠加（如 Agnes 抛
-    ``VideoCapabilityError``），部分静默叠加（如 v2 中转、Grok、Sora 首帧与参考共享
-    单槽）。调用方不应假设某种统一行为，需按具体后端核实。
+    ``max_reference_images`` 描述参考生视频路径：后端接受 ``reference_images`` 请求字段
+    的数量上限，``> 0`` 即该路径可用（不另设布尔位——两份声明会漂移出「称支持但上限为 0」
+    这类自相矛盾的状态）。两条路径是否可叠加（同一请求同时带首帧与参考图）因后端而异，
+    不是统一契约：部分后端拒绝叠加（如 Agnes 抛 ``VideoCapabilityError``），部分静默叠加
+    （如 v2 中转、Grok、Sora 首帧与参考共享单槽）。调用方不应假设某种统一行为，需按具体
+    后端核实。
+
+    ``reference_audio_mode`` / ``max_reference_audio_count`` 描述参考音频路径，与参考图
+    同构：模式非 ``NONE`` 时后端接受 ``reference_audio_files`` 请求字段，段数受上限约束。
+    上限按 backend 各自的供应商约束声明，不取各家交集。
     """
 
     first_frame: bool = True
     last_frame: bool = False
-    reference_images: bool = False
     max_reference_images: int = 0
-
-
-class VideoCapability(StrEnum):
-    """视频后端支持的能力枚举。"""
-
-    TEXT_TO_VIDEO = "text_to_video"
-    IMAGE_TO_VIDEO = "image_to_video"
-    GENERATE_AUDIO = "generate_audio"
-    NEGATIVE_PROMPT = "negative_prompt"
-    VIDEO_EXTEND = "video_extend"
-    SEED_CONTROL = "seed_control"
-    FLEX_TIER = "flex_tier"
+    reference_audio_mode: ReferenceAudioMode = ReferenceAudioMode.NONE
+    max_reference_audio_count: int = 0
 
 
 @dataclass
@@ -418,6 +425,10 @@ class VideoGenerationRequest:
     start_image: Path | None = None
     end_image: Path | None = None  # For first_last mode
     reference_images: list[Path] | None = None  # For multi-reference mode
+    # 参考音频（音色复刻）。列表顺序即 prompt 中「音频N」的指认契约：编排层按该顺序拼指认
+    # 文本，后端按同一顺序下发，故任何一侧都不得重排或跳过。哪个角色对应哪段音频不进请求
+    # ——绑定由 prompt 文本表达，供应商 API 均无结构化的「角色-音频」字段。
+    reference_audio_files: list[Path] | None = None
     generate_audio: bool = True
 
     # 项目上下文（用于构建文件服务 URL 等）
@@ -457,9 +468,6 @@ class VideoBackend(Protocol):
 
     @property
     def model(self) -> str: ...
-
-    @property
-    def capabilities(self) -> set[VideoCapability]: ...
 
     @property
     def video_capabilities(self) -> VideoCapabilities: ...

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -237,6 +237,7 @@ class DashScopeVideoBackend(ProviderJobIdPersistenceMixin):
             if uri is None:
                 raise VideoCapabilityError("video_start_image_unreadable", model=self._model, name=p.name)
             media.append({"type": "first_frame", "url": uri})
+        reference_items: list[dict] = []
         if caps.max_reference_images > 0:
             # r2v 必须有参考图。fail-loud：未提供 → required；任一声明的参考图缺失/不可读（is_file 不过
             # 或 read_bytes 抛 OSError）→ 报错列出文件名中止。不静默退化为无参考/子集生成（会产出错误
@@ -267,8 +268,12 @@ class DashScopeVideoBackend(ProviderJobIdPersistenceMixin):
                 )
                 data_uris = data_uris[:limit]
             reference_items = [{"type": "reference_image", "url": uri} for uri in data_uris]
-            self._attach_reference_voices(reference_items, request)
-            media.extend(reference_items)
+        # 音频挂载在参考素材循环之外：无参考素材可挂时也要走一遍判定，否则 wan2.7-i2v 这类
+        # 无参考图能力的 model 收到音频会静默丢弃、照常扣费——正是本 issue 第 4 条要堵的路径。
+        # 自定义供应商可把 endpoint 级的 reference_audio_mode 覆盖成 direct，而 delegate 的
+        # model profile 仍是真相源，故这条路径实际可达。
+        self._attach_reference_voices(reference_items, request)
+        media.extend(reference_items)
         return media
 
     def _attach_reference_voices(self, reference_items: list[dict], request: VideoGenerationRequest) -> None:

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -287,11 +287,14 @@ class DashScopeVideoBackend(ProviderJobIdPersistenceMixin):
         if self._video_capabilities.reference_audio_mode == ReferenceAudioMode.NONE:
             raise VideoCapabilityError("video_reference_audio_unsupported", provider=self.name, model=self._model)
         if len(audio_files) > len(reference_items):
+            # 与 gate 的 video_reference_audio_exceeded 分成两个 code：那条的 limit 是模型的
+            # 能力上限（减角色数就能过），这条的上限是本次请求实际有几个可挂载的参考素材
+            # （加参考图也能过）。共用一个 code 会让文案给出与实际卡点不符的处置建议。
             raise VideoCapabilityError(
-                "video_reference_audio_exceeded",
+                "video_reference_audio_slots_insufficient",
                 provider=self.name,
                 model=self._model,
-                limit=len(reference_items),
+                slots=len(reference_items),
                 count=len(audio_files),
             )
         unreadable: list[str] = []

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -10,6 +10,7 @@ GET /tasks/{id} 至 SUCCEEDED → 下载 video_url。覆盖 happyhorse-1.0 与 w
 
 from __future__ import annotations
 
+import base64
 import logging
 from pathlib import Path
 
@@ -40,9 +41,9 @@ from lib.retry import (
 )
 from lib.video_backends.base import (
     ProviderJobIdPersistenceMixin,
+    ReferenceAudioMode,
     ResumeExpiredError,
     VideoCapabilities,
-    VideoCapability,
     VideoCapabilityError,
     VideoGenerationRequest,
     VideoGenerationResult,
@@ -68,6 +69,23 @@ def _read_image_or_none(path: Path) -> str | None:
         return None
 
 
+# wan2.7 的 reference_voice 接受 wav / mp3（官方《万相2.7-参考生视频》reference_voice 章节），
+# URL 形态与 media.url 同为 http / oss / base64 data URI。
+_REFERENCE_AUDIO_MIME_TYPES = {".wav": "audio/wav", ".mp3": "audio/mpeg"}
+
+
+def _read_reference_audio_or_none(path: Path) -> str | None:
+    """参考音频 → base64 data URI；文件缺失或 IO 失败返回 None（格式另由调用方先行拒绝）。"""
+    mime = _REFERENCE_AUDIO_MIME_TYPES[path.suffix.lower()]
+    if not path.is_file():
+        return None
+    try:
+        return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode('ascii')}"
+    except OSError as exc:
+        logger.warning("DashScope 参考音频读取失败: %s (%s)", path, exc)
+        return None
+
+
 DEFAULT_MODEL = "happyhorse-1.0-i2v"
 
 _VIDEO_ENDPOINT = "/services/aigc/video-generation/video-synthesis"
@@ -75,44 +93,38 @@ _VIDEO_ENDPOINT = "/services/aigc/video-generation/video-synthesis"
 _MIN_POLL_TIMEOUT_SECONDS = 900.0
 _POLL_TIMEOUT_PER_SECOND = 60.0
 
-_TV = VideoCapability.TEXT_TO_VIDEO
-_IV = VideoCapability.IMAGE_TO_VIDEO
-_AUDIO = VideoCapability.GENERATE_AUDIO
-_SEED = VideoCapability.SEED_CONTROL
+# wan2.7-r2v 的 reference_voice 逐段挂在参考素材项上，故音频段数上限等同参考素材总数上限
+# （官方：参考图像 + 参考视频 ≤ 5）。
+_WAN27_R2V_MAX_REFERENCE = 5
 
-# 按 model id 派发：(VideoCapability 集合, VideoCapabilities)。
-# happyhorse-r2v 仅 reference_image（无 first_frame）；wan2.7-r2v 额外支持首帧。
-# 音频恒开（无开关参数），统一声明 GENERATE_AUDIO。
-_MODEL_PROFILES: dict[str, tuple[set[VideoCapability], VideoCapabilities]] = {
-    "happyhorse-1.0-t2v": ({_TV, _AUDIO, _SEED}, VideoCapabilities(first_frame=False)),
-    "happyhorse-1.0-i2v": ({_IV, _AUDIO, _SEED}, VideoCapabilities(first_frame=True)),
-    "happyhorse-1.0-r2v": (
-        {_IV, _AUDIO, _SEED},
-        VideoCapabilities(first_frame=False, reference_images=True, max_reference_images=9),
-    ),
-    "wan2.7-t2v": ({_TV, _AUDIO, _SEED}, VideoCapabilities(first_frame=False)),
-    "wan2.7-i2v": ({_IV, _AUDIO, _SEED}, VideoCapabilities(first_frame=True)),
-    "wan2.7-r2v": (
-        {_IV, _AUDIO, _SEED},
-        # 带首帧的参考生视频是 wan2.7-r2v 的官方形态（_build_media 同请求组装
-        # first_frame + reference_image）。
-        VideoCapabilities(first_frame=True, reference_images=True, max_reference_images=5),
+# 按 model id 派发能力声明。happyhorse-r2v 仅 reference_image（无 first_frame）；
+# wan2.7-r2v 额外支持首帧与参考音色。
+_MODEL_PROFILES: dict[str, VideoCapabilities] = {
+    "happyhorse-1.0-t2v": VideoCapabilities(first_frame=False),
+    "happyhorse-1.0-i2v": VideoCapabilities(first_frame=True),
+    "happyhorse-1.0-r2v": VideoCapabilities(first_frame=False, max_reference_images=9),
+    "wan2.7-t2v": VideoCapabilities(first_frame=False),
+    "wan2.7-i2v": VideoCapabilities(first_frame=True),
+    # 带首帧的参考生视频是 wan2.7-r2v 的官方形态（_build_media 同请求组装
+    # first_frame + reference_image）。
+    "wan2.7-r2v": VideoCapabilities(
+        first_frame=True,
+        max_reference_images=_WAN27_R2V_MAX_REFERENCE,
+        reference_audio_mode=ReferenceAudioMode.DIRECT,
+        max_reference_audio_count=_WAN27_R2V_MAX_REFERENCE,
     ),
 }
 
 # 未知 model（如代理中转自定义命名）按通用 i2v/t2v 处理，VideoCapabilities() 默认支持首帧。
-_DEFAULT_PROFILE: tuple[set[VideoCapability], VideoCapabilities] = (
-    {_TV, _IV, _AUDIO, _SEED},
-    VideoCapabilities(),
-)
+_DEFAULT_PROFILE = VideoCapabilities()
 
 
-def _profile_for_model(model: str | None) -> tuple[set[VideoCapability], VideoCapabilities]:
+def _profile_for_model(model: str | None) -> VideoCapabilities:
     """按 model_id 解析能力档：先精确命中，再容忍代理中转的前后缀装饰。
 
     infer_endpoint 用子串（"happyhorse" / "wan2."）路由到 dashscope-async-video，故此处也须
     子串容忍，否则 "proxy/happyhorse-1.0-r2v" / "wan2.7-r2v-0715" 这类装饰名会退回 _DEFAULT_PROFILE、
-    丢掉 r2v 的 reference_images/max_reference_images，_build_media 据此构造出错误 payload。
+    丢掉 r2v 的 max_reference_images，_build_media 据此构造出错误 payload。
     仅带系列名而无变体后缀（如裸 "happyhorse"）无法判别 t2v/i2v/r2v，按设计回落通用默认。
     __init__ 与 video_capabilities_for_model 共用本函数，保持单一真相源。
     """
@@ -143,7 +155,7 @@ class DashScopeVideoBackend(ProviderJobIdPersistenceMixin):
         self._base_url = dashscope_native_base_url(base_url)
         self._model = model or DEFAULT_MODEL
         self._http_timeout = http_timeout
-        self._capabilities, self._video_capabilities = _profile_for_model(self._model)
+        self._video_capabilities = _profile_for_model(self._model)
 
     @property
     def name(self) -> str:
@@ -153,10 +165,6 @@ class DashScopeVideoBackend(ProviderJobIdPersistenceMixin):
     def model(self) -> str:
         return self._model
 
-    @property
-    def capabilities(self) -> set[VideoCapability]:
-        return self._capabilities
-
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
         """按 model_id 纯计算参考图等 caps —— 不构造 SDK client（无需 api_key）。
@@ -164,7 +172,7 @@ class DashScopeVideoBackend(ProviderJobIdPersistenceMixin):
         resolver 解析参考图上限时调本方法即可，不必构造整个 backend；instance property 委托至此，
         保持 backend 为单一真相源。
         """
-        return _profile_for_model(model)[1]
+        return _profile_for_model(model)
 
     @property
     def video_capabilities(self) -> VideoCapabilities:
@@ -229,7 +237,7 @@ class DashScopeVideoBackend(ProviderJobIdPersistenceMixin):
             if uri is None:
                 raise VideoCapabilityError("video_start_image_unreadable", model=self._model, name=p.name)
             media.append({"type": "first_frame", "url": uri})
-        if caps.reference_images:
+        if caps.max_reference_images > 0:
             # r2v 必须有参考图。fail-loud：未提供 → required；任一声明的参考图缺失/不可读（is_file 不过
             # 或 read_bytes 抛 OSError）→ 报错列出文件名中止。不静默退化为无参考/子集生成（会产出错误
             # 结果且照常计费），让用户感知到有图未被使用。
@@ -258,8 +266,55 @@ class DashScopeVideoBackend(ProviderJobIdPersistenceMixin):
                     limit,
                 )
                 data_uris = data_uris[:limit]
-            media.extend({"type": "reference_image", "url": uri} for uri in data_uris)
+            reference_items = [{"type": "reference_image", "url": uri} for uri in data_uris]
+            self._attach_reference_voices(reference_items, request)
+            media.extend(reference_items)
         return media
+
+    def _attach_reference_voices(self, reference_items: list[dict], request: VideoGenerationRequest) -> None:
+        """把参考音频逐段挂到参考素材项的 ``reference_voice`` 字段上（就地修改）。
+
+        wan2.7 的音色不是独立的 media 条目，而是某个参考素材（角色）身上的一个属性，故第 N 段
+        音频挂到第 N 个参考素材上——这与 ``reference_audio_files`` 的顺序契约（顺序即编排层拼
+        指认文本的顺序）是同一个序，两侧不得各自重排。
+
+        音频段数多于可挂载的参考素材时硬失败而非丢弃多余段：丢弃会让某个角色的音色声明无声
+        失效，用户直到成片才发现该角色声音仍是随机的，且已照常扣费。
+        """
+        audio_files = list(request.reference_audio_files or [])
+        if not audio_files:
+            return
+        if self._video_capabilities.reference_audio_mode == ReferenceAudioMode.NONE:
+            raise VideoCapabilityError("video_reference_audio_unsupported", provider=self.name, model=self._model)
+        if len(audio_files) > len(reference_items):
+            raise VideoCapabilityError(
+                "video_reference_audio_exceeded",
+                provider=self.name,
+                model=self._model,
+                limit=len(reference_items),
+                count=len(audio_files),
+            )
+        unreadable: list[str] = []
+        uris: list[str] = []
+        for audio in audio_files:
+            path = Path(audio)
+            if path.suffix.lower() not in _REFERENCE_AUDIO_MIME_TYPES:
+                raise VideoCapabilityError(
+                    "video_reference_audio_format_unsupported",
+                    name=path.name,
+                    supported=", ".join(sorted(_REFERENCE_AUDIO_MIME_TYPES)),
+                )
+            uri = _read_reference_audio_or_none(path)
+            if uri is None:
+                unreadable.append(path.name)
+            else:
+                uris.append(uri)
+        if unreadable:
+            raise VideoCapabilityError(
+                "video_reference_audio_unreadable", model=self._model, names=", ".join(unreadable)
+            )
+        for item, uri in zip(reference_items, uris, strict=False):
+            item["reference_voice"] = uri
 
     # ── HTTP submit / poll / download ───────────────────────────────────
 

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -21,7 +21,6 @@ from lib.video_backends.base import (
     ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
     VideoCapabilities,
-    VideoCapability,
     VideoCapabilityError,
     VideoGenerationRequest,
     VideoGenerationResult,
@@ -93,16 +92,6 @@ class GeminiVideoBackend(ProviderJobIdPersistenceMixin):
             http_options = {"base_url": effective_base_url} if effective_base_url else None
             self._client = _genai.Client(api_key=api_key, http_options=http_options)  # type: ignore[arg-type]
 
-        # 缓存 capabilities，避免每次访问创建新 set
-        self._capabilities: set[VideoCapability] = {
-            VideoCapability.TEXT_TO_VIDEO,
-            VideoCapability.IMAGE_TO_VIDEO,
-            VideoCapability.NEGATIVE_PROMPT,
-            VideoCapability.VIDEO_EXTEND,
-        }
-        if self._backend_type == "vertex":
-            self._capabilities.add(VideoCapability.GENERATE_AUDIO)
-
     @property
     def name(self) -> str:
         return f"gemini-{self._backend_type}"
@@ -110,10 +99,6 @@ class GeminiVideoBackend(ProviderJobIdPersistenceMixin):
     @property
     def model(self) -> str:
         return self._video_model
-
-    @property
-    def capabilities(self) -> set[VideoCapability]:
-        return self._capabilities
 
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
@@ -123,7 +108,7 @@ class GeminiVideoBackend(ProviderJobIdPersistenceMixin):
         列为并列模式，带参考图时 durationSeconds 必须为 8。当前全系模型能力一致，不按
         model_id 分支；instance property 委托至此，保持 backend 为单一真相源。
         """
-        return VideoCapabilities(last_frame=True, reference_images=True, max_reference_images=3)
+        return VideoCapabilities(last_frame=True, max_reference_images=3)
 
     @property
     def video_capabilities(self) -> VideoCapabilities:

--- a/lib/video_backends/grok.py
+++ b/lib/video_backends/grok.py
@@ -16,7 +16,6 @@ from lib.retry import with_retry_async
 from lib.video_backends.base import (
     IMAGE_MIME_TYPES,
     VideoCapabilities,
-    VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
@@ -38,10 +37,6 @@ class GrokVideoBackend:
     ):
         self._client = create_grok_client(api_key=api_key)
         self._model = model or self.DEFAULT_MODEL
-        self._capabilities: set[VideoCapability] = {
-            VideoCapability.TEXT_TO_VIDEO,
-            VideoCapability.IMAGE_TO_VIDEO,
-        }
 
     @property
     def name(self) -> str:
@@ -51,10 +46,6 @@ class GrokVideoBackend:
     def model(self) -> str:
         return self._model
 
-    @property
-    def capabilities(self) -> set[VideoCapability]:
-        return self._capabilities
-
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
         """按 model_id 纯计算 caps —— 不构造 SDK client（无需 api_key）。
@@ -62,7 +53,7 @@ class GrokVideoBackend:
         当前全系模型能力一致，不按 model_id 分支；instance property 委托至此，
         保持 backend 为单一真相源。
         """
-        return VideoCapabilities(reference_images=True, max_reference_images=7)
+        return VideoCapabilities(max_reference_images=7)
 
     @property
     def video_capabilities(self) -> VideoCapabilities:

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -40,7 +40,6 @@ from lib.retry import (
 from lib.video_backends.base import (
     ProviderJobIdPersistenceMixin,
     VideoCapabilities,
-    VideoCapability,
     VideoCapabilityError,
     VideoGenerationRequest,
     VideoGenerationResult,
@@ -215,17 +214,6 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         # 按 model 取能力位（归一化前缀/大小写后精确命中）；未登记 model（bearer 透传）回落保守默认。
         self._caps = _lookup_video_caps(self._model)
 
-    @property
-    def capabilities(self) -> set[VideoCapability]:
-        caps: set[VideoCapability] = set()
-        if self._caps.text_to_video:
-            caps.add(VideoCapability.TEXT_TO_VIDEO)
-        if self._caps.image_to_video:
-            caps.add(VideoCapability.IMAGE_TO_VIDEO)
-        if self._caps.generate_audio:
-            caps.add(VideoCapability.GENERATE_AUDIO)
-        return caps
-
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
         # first_frame 恒真（各档均支持 i2v 首帧）；last_frame / reference_images / 上限按 model 从
@@ -245,7 +233,6 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         return VideoCapabilities(
             first_frame=True,
             last_frame=caps.last_frame and not caps.last_frame_requires_pro,
-            reference_images=caps.reference_images,
             max_reference_images=caps.max_reference_images,
         )
 
@@ -280,7 +267,6 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         return VideoCapabilities(
             first_frame=True,
             last_frame=last_frame,
-            reference_images=caps.reference_images,
             max_reference_images=caps.max_reference_images,
         )
 

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -42,7 +42,6 @@ from lib.retry import (
 from lib.video_backends.base import (
     ProviderJobIdPersistenceMixin,
     VideoCapabilities,
-    VideoCapability,
     VideoCapabilityError,
     VideoGenerationRequest,
     VideoGenerationResult,
@@ -71,18 +70,10 @@ _RETRIEVE_ENDPOINT = "/files/retrieve"
 _MIN_POLL_TIMEOUT_SECONDS = 900.0
 _POLL_TIMEOUT_PER_SECOND = 60.0
 
-_TV = VideoCapability.TEXT_TO_VIDEO
-_IV = VideoCapability.IMAGE_TO_VIDEO
-
-# 按 model id 派发能力：Hailuo 2.3 文+图生视频；2.3-Fast 仅图生视频；S2V-01 既非 t2v 也非
-# i2v（subject_reference 驱动，能力经 VideoCapabilities.reference_images 表达），故为空集。
-_MODEL_CAPABILITIES: dict[str, set[VideoCapability]] = {
-    _HAILUO: {_TV, _IV},
-    _HAILUO_FAST: {_IV},
-    _S2V: set(),
-}
-# 未知 model（代理中转自定义命名）按通用文+图生视频处理。
-_DEFAULT_CAPABILITIES: set[VideoCapability] = {_TV, _IV}
+# 无首帧的文生视频不是各档通用：2.3-Fast 仅图生视频；S2V-01 由 subject_reference 驱动
+# （参考图路径经 VideoCapabilities.max_reference_images 表达），两者都不接受纯文本请求。
+# 未登记 model（代理中转自定义命名）按支持处理，与其余能力维度的「未知即通用默认」一致。
+_NO_TEXT_TO_VIDEO_MODELS: frozenset[str] = frozenset({_HAILUO_FAST, _S2V})
 
 # (分辨率小写 → 允许的时长集合)：1080P 仅 6s，768P 支持 6s/10s（两代 Hailuo 同此矩阵）。
 _RESOLUTION_DURATIONS: dict[str, set[int]] = {"768p": {6, 10}, "1080p": {6}}
@@ -91,9 +82,8 @@ _RESOLUTION_DURATIONS: dict[str, set[int]] = {"768p": {6, 10}, "1080p": {6}}
 _SAFE_LOG_KEYS: frozenset[str] = frozenset({"model", "resolution", "duration"})
 
 
-def _capabilities_for_model(model: str | None) -> set[VideoCapability]:
-    normalized = (model or "").strip()
-    return _MODEL_CAPABILITIES.get(normalized, _DEFAULT_CAPABILITIES)
+def _supports_text_to_video(model: str | None) -> bool:
+    return (model or "").strip() not in _NO_TEXT_TO_VIDEO_MODELS
 
 
 def _safe_body_for_log(body: dict) -> dict:
@@ -124,7 +114,7 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
         self._base_url = minimax_video_base_url(base_url)
         self._model = model or DEFAULT_MODEL
         self._http_timeout = http_timeout
-        self._capabilities = _capabilities_for_model(self._model)
+        self._supports_text_to_video = _supports_text_to_video(self._model)
 
     @property
     def name(self) -> str:
@@ -134,19 +124,15 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
     def model(self) -> str:
         return self._model
 
-    @property
-    def capabilities(self) -> set[VideoCapability]:
-        return self._capabilities
-
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
         """海螺图生视频走 first_frame_image 首帧；S2V-01 走 subject_reference 单脸参考生视频。
 
-        S2V-01 仅接受单张人脸参考、不接受首帧图，故 first_frame=False + reference_images=True
-        + max_reference_images=1。Hailuo 系列首批不建模尾帧/参考图。
+        S2V-01 仅接受单张人脸参考、不接受首帧图，故 first_frame=False + max_reference_images=1。
+        Hailuo 系列首批不建模尾帧/参考图。
         """
         if model == _S2V:
-            return VideoCapabilities(first_frame=False, reference_images=True, max_reference_images=1)
+            return VideoCapabilities(first_frame=False, max_reference_images=1)
         return VideoCapabilities(first_frame=True)
 
     @property
@@ -184,7 +170,7 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
         has_start_image = isinstance(request.start_image, (str, Path)) and str(request.start_image)
 
         # 无首帧 = 文生视频意图；模型不支持 t2v（如 Fast）即拒绝。
-        if not has_start_image and _TV not in self._capabilities:
+        if not has_start_image and not self._supports_text_to_video:
             raise VideoCapabilityError("video_capability_missing_t2v", provider=self.name, model=self._model)
 
         allowed_durations = _RESOLUTION_DURATIONS.get(resolution, set())

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -25,7 +25,6 @@ from lib.video_backends.base import (
     ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
     VideoCapabilities,
-    VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
@@ -77,10 +76,6 @@ class NewAPIVideoBackend(ProviderJobIdPersistenceMixin):
         self._base_url = base_url.rstrip("/")
         self._model = model or DEFAULT_MODEL
         self._http_timeout = http_timeout
-        self._capabilities: set[VideoCapability] = {
-            VideoCapability.TEXT_TO_VIDEO,
-            VideoCapability.IMAGE_TO_VIDEO,
-        }
 
     @property
     def name(self) -> str:
@@ -90,10 +85,6 @@ class NewAPIVideoBackend(ProviderJobIdPersistenceMixin):
     def model(self) -> str:
         return self._model
 
-    @property
-    def capabilities(self) -> set[VideoCapability]:
-        return self._capabilities
-
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
         """按 model_id 纯计算 caps —— 不构造 SDK client（无需 api_key）。
@@ -101,7 +92,7 @@ class NewAPIVideoBackend(ProviderJobIdPersistenceMixin):
         中转端点不接受参考图；当前全系模型能力一致，不按 model_id 分支。
         instance property 委托至此，保持 backend 为单一真相源。
         """
-        return VideoCapabilities(reference_images=False, max_reference_images=0)
+        return VideoCapabilities(max_reference_images=0)
 
     @property
     def video_capabilities(self) -> VideoCapabilities:

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -16,7 +16,6 @@ from lib.video_backends.base import (
     ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
     VideoCapabilities,
-    VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
     poll_with_retry,
@@ -94,10 +93,6 @@ class OpenAIVideoBackend(ProviderJobIdPersistenceMixin):
     def __init__(self, *, api_key: str | None = None, model: str | None = None, base_url: str | None = None):
         self._client = create_openai_client(api_key=api_key, base_url=base_url)
         self._model = model or DEFAULT_MODEL
-        self._capabilities: set[VideoCapability] = {
-            VideoCapability.TEXT_TO_VIDEO,
-            VideoCapability.IMAGE_TO_VIDEO,
-        }
 
     @property
     def name(self) -> str:
@@ -107,10 +102,6 @@ class OpenAIVideoBackend(ProviderJobIdPersistenceMixin):
     def model(self) -> str:
         return self._model
 
-    @property
-    def capabilities(self) -> set[VideoCapability]:
-        return self._capabilities
-
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
         """按 model_id 纯计算 caps —— 不构造 SDK client（无需 api_key）。
@@ -119,7 +110,7 @@ class OpenAIVideoBackend(ProviderJobIdPersistenceMixin):
         当前全系模型能力一致，不按 model_id 分支；instance property 委托至此，
         保持 backend 为单一真相源。
         """
-        return VideoCapabilities(reference_images=True, max_reference_images=1)
+        return VideoCapabilities(max_reference_images=1)
 
     @property
     def video_capabilities(self) -> VideoCapabilities:

--- a/lib/video_backends/v2_video_generations.py
+++ b/lib/video_backends/v2_video_generations.py
@@ -34,7 +34,6 @@ from lib.video_backends.base import (
     ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
     VideoCapabilities,
-    VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
@@ -269,11 +268,6 @@ class V2VideoGenerationsBackend(ProviderJobIdPersistenceMixin):
         self._root = _normalize_root(base_url)
         self._model = model
         self._http_timeout = http_timeout
-        self._capabilities: set[VideoCapability] = {
-            VideoCapability.TEXT_TO_VIDEO,
-            VideoCapability.IMAGE_TO_VIDEO,
-            VideoCapability.SEED_CONTROL,
-        }
 
     @property
     def name(self) -> str:
@@ -283,10 +277,6 @@ class V2VideoGenerationsBackend(ProviderJobIdPersistenceMixin):
     def model(self) -> str:
         return self._model
 
-    @property
-    def capabilities(self) -> set[VideoCapability]:
-        return self._capabilities
-
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
         """按 model_id 纯计算 caps —— 不构造 client。保留 `model` 形参仅为跨 backend 接口统一，
@@ -295,7 +285,6 @@ class V2VideoGenerationsBackend(ProviderJobIdPersistenceMixin):
         return VideoCapabilities(
             first_frame=True,
             last_frame=True,
-            reference_images=True,
             max_reference_images=_DEFAULT_MAX_REFERENCE_IMAGES,
         )
 

--- a/lib/video_backends/vidu.py
+++ b/lib/video_backends/vidu.py
@@ -17,7 +17,6 @@ from lib.providers import PROVIDER_VIDU
 from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
 from lib.video_backends.base import (
     VideoCapabilities,
-    VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
@@ -162,15 +161,6 @@ class ViduVideoBackend:
         self._base_url = base_url
         self._model = model or DEFAULT_MODEL
 
-        caps: set[VideoCapability] = {
-            VideoCapability.TEXT_TO_VIDEO,
-            VideoCapability.IMAGE_TO_VIDEO,
-            VideoCapability.SEED_CONTROL,
-        }
-        if self._model in _Q3_MODELS:
-            caps.add(VideoCapability.GENERATE_AUDIO)
-        self._capabilities = caps
-
     @property
     def name(self) -> str:
         return PROVIDER_VIDU
@@ -178,10 +168,6 @@ class ViduVideoBackend:
     @property
     def model(self) -> str:
         return self._model
-
-    @property
-    def capabilities(self) -> set[VideoCapability]:
-        return self._capabilities
 
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
@@ -198,7 +184,6 @@ class ViduVideoBackend:
         return VideoCapabilities(
             first_frame=model in _ENDPOINT_MODELS["/img2video"],
             last_frame=model in _ENDPOINT_MODELS["/start-end2video"],
-            reference_images=reference_images,
             max_reference_images=_MAX_REFERENCE_IMAGES if reference_images else 0,
             # 参考图与首帧在 Vidu 上是互斥模式：_select_endpoint 见参考图即切 /reference2video，
             # start_image 不进请求体（首帧被丢弃）。

--- a/lib/video_frame_slots.py
+++ b/lib/video_frame_slots.py
@@ -1,4 +1,4 @@
-"""视频生成的帧槽位规划：能力 gating + 参考图槽位组装。
+"""视频生成的请求期能力校验（``gate_video_request``）与帧槽位组装（``plan_frame_slots``）。
 
 从 ``MediaGenerator.generate_video_async`` 抽出的纯函数，不触碰记账、版本管理与
 provider 调用，可独立导入并直接单测各能力组合分支。
@@ -13,14 +13,20 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
-from lib.video_backends.base import VideoCapabilities, VideoCapabilityError
+from lib.video_backends.base import ReferenceAudioMode, VideoCapabilities, VideoCapabilityError
 
 if TYPE_CHECKING:
     from PIL import Image
 
     from lib.reference_compression import ReferenceSpec
 
-__all__ = ["FrameSlotPlan", "VideoCapabilityProbe", "plan_frame_slots", "resolve_video_capabilities"]
+__all__ = [
+    "FrameSlotPlan",
+    "VideoCapabilityProbe",
+    "gate_video_request",
+    "plan_frame_slots",
+    "resolve_video_capabilities",
+]
 
 
 class VideoCapabilityProbe(Protocol):
@@ -68,31 +74,76 @@ class FrameSlotPlan:
     reference_start_index: int | None = None
 
 
-def plan_frame_slots(
+def gate_video_request(
     *,
     caps: VideoCapabilities | None,
     provider: str,
     model: str,
-    start_image: "str | Path | Image.Image | None" = None,
     end_image: Path | None = None,
     reference_images: "list[Path] | None" = None,
-) -> FrameSlotPlan:
-    """按后端能力组装帧/参考图槽位，能力不支持尾帧时硬失败。
+    reference_audio_files: "list[Path] | None" = None,
+) -> None:
+    """统一的请求期能力前置校验：违约抛 ``VideoCapabilityError``，通过则静默返回。
 
-    尾帧不做降级：参考图是与首帧互斥的独立路径，把尾帧转投参考图会丢掉首帧语义；
-    静默丢弃尾帧则会照常生成并扣费、产出与用户意图不符的视频。故 ``caps.last_frame``
-    为假而请求携带尾帧时抛 ``VideoCapabilityError``，由上层渲染成用户可读错误。
+    三条可选输入路径（尾帧 / 参考图 / 参考音频）在这里一处判定，而不是散在各 backend 的
+    payload 组装里各写一套——散写的后果是同一种违约在不同供应商下有的硬失败、有的静默截断，
+    用户拿到照常扣费但与意图不符的结果却无从得知。故本函数只做拒绝，不做降级：
+    能力不支持一律抛错，由上层渲染成用户可读错误（文案见 ``lib/i18n/*/errors.py``）。
 
-    ``caps`` 为 None 表示调用方未查询后端能力——无尾帧诉求时能力声明不影响任何槽位，
-    调用方可省去这次查询。传 None 却带尾帧一律按不支持拒绝，而不是放行：占位一份
-    "支持尾帧"的假能力会让未经能力核实的尾帧下发出去，正是本函数要堵的降级。
+    ``caps`` 为 None 表示调用方未查询后端能力——三条路径都不走时能力声明不影响任何结果，
+    调用方可省去这次查询。传 None 却带任一路径的输入一律按不支持拒绝，而不是放行：占位一份
+    "支持"的假能力会让未经能力核实的请求下发出去，正是本函数要堵的降级。
 
-    ``start_image`` 仅 ``str`` / ``Path`` 文件源进压缩器；``PIL.Image`` 与 None 不入
-    specs（对应请求字段保持 None），维持原有行为。
+    与 :func:`plan_frame_slots` 分离是有意的：校验会抛、组装是纯函数，两者调用时机不同——
+    校验须先于记账括号（硬失败要不扣费、不留 failed ApiCall 行），组装则可在其后按需进行。
     """
     if end_image is not None and (caps is None or not caps.last_frame):
         raise VideoCapabilityError("video_last_frame_unsupported", provider=provider, model=model)
 
+    if reference_images:
+        limit = 0 if caps is None else caps.max_reference_images
+        if limit <= 0:
+            raise VideoCapabilityError("video_reference_images_unsupported", provider=provider, model=model)
+        if len(reference_images) > limit:
+            raise VideoCapabilityError(
+                "video_reference_images_exceeded",
+                provider=provider,
+                model=model,
+                limit=limit,
+                count=len(reference_images),
+            )
+
+    if reference_audio_files:
+        # 不支持音色输入的模型收到音频不静默丢弃：静默丢弃会生成一段音色随机的视频并照常
+        # 扣费，用户以为角色声音已受控，直到成片拼接才发现跨片段音色不一致。
+        mode = ReferenceAudioMode.NONE if caps is None else caps.reference_audio_mode
+        if mode == ReferenceAudioMode.NONE:
+            raise VideoCapabilityError("video_reference_audio_unsupported", provider=provider, model=model)
+        audio_limit = 0 if caps is None else caps.max_reference_audio_count
+        if len(reference_audio_files) > audio_limit:
+            raise VideoCapabilityError(
+                "video_reference_audio_exceeded",
+                provider=provider,
+                model=model,
+                limit=audio_limit,
+                count=len(reference_audio_files),
+            )
+
+
+def plan_frame_slots(
+    *,
+    start_image: "str | Path | Image.Image | None" = None,
+    end_image: Path | None = None,
+    reference_images: "list[Path] | None" = None,
+) -> FrameSlotPlan:
+    """按输入组装帧/参考图槽位——纯函数，不判定能力、不抛异常。
+
+    能力判定归 :func:`gate_video_request`；本函数只负责把三个请求字段铺进压缩器的 specs
+    序列并记下各自序位。
+
+    ``start_image`` 仅 ``str`` / ``Path`` 文件源进压缩器；``PIL.Image`` 与 None 不入
+    specs（对应请求字段保持 None）。
+    """
     from lib.reference_compression import ReferenceSpec, RefRole
 
     specs: list[ReferenceSpec] = []

--- a/scripts/verify_reference_video_sdks.py
+++ b/scripts/verify_reference_video_sdks.py
@@ -191,7 +191,7 @@ async def run_once(
 
 def clamp_refs_for_backend(*, requested: int, caps: VideoCapabilities) -> tuple[int, str]:
     """把 requested 夹到 backend 上限；若 backend 不支持 reference_images 则直接抛 ValueError。"""
-    if not caps.reference_images:
+    if caps.max_reference_images <= 0:
         raise ValueError("Backend does not support reference_images")
     if requested <= caps.max_reference_images:
         return requested, ""

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -11,7 +11,7 @@ import json
 import logging
 from collections.abc import Callable
 from dataclasses import asdict
-from typing import Annotated, Literal, cast
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import AfterValidator, BaseModel, Field, field_validator
@@ -21,10 +21,13 @@ from lib.api_errors import BadRequestError
 from lib.config.repository import mask_secret
 from lib.custom_provider import make_provider_id
 from lib.custom_provider.capabilities import (
+    AUDIO_OVERRIDE_KEYS,
     CAPABILITY_OVERRIDE_FIELDS,
     audio_capability_pair_is_coherent,
     capability_value_matches,
     filter_valid_overrides,
+    resolve_audio_pair,
+    strip_incoherent_audio_overrides,
     system_video_capabilities,
 )
 from lib.custom_provider.endpoints import (
@@ -311,8 +314,13 @@ def _effective_overrides_for_response(
     再经 :func:`_narrow_to_allowlist` 收窄：DB 遗留的白名单外键（同样只能来自手工改库）若原样
     回显，与写入落库的键集合不一致，调用方需要额外知道"回显可能含脏键但写回会被剔除"。收窄与
     写入侧走同一个函数，两处集合同源。
+
+    音频两维另经 :func:`strip_incoherent_audio_overrides`：单维合法而合起来无意义的组合
+    （direct ⊕ 上限 0）过得了 :func:`filter_valid_overrides`，执行层却会把它降到 ``none``，
+    回显原值同样落进本函数要消灭的"界面显示已生效、执行其实忽略"。
     """
     filtered = _narrow_to_allowlist(filter_valid_overrides(endpoint=endpoint, model_id=model_id, overrides=overrides))
+    filtered = strip_incoherent_audio_overrides(filtered, endpoint=endpoint, model_id=model_id)
     return filtered or None
 
 
@@ -447,20 +455,9 @@ def _check_capability_overrides(
     # 合并后不变式：两维各自合法、合起来无意义的组合（支持音色输入却限 0 段）在这里拒，
     # 而不是留给执行期静默降级——降级后用户会拿到「最多支持 0 段」这种无从遵循的提示。
     # 稀疏覆盖只写其中一维也能凑出该组合，故按系统判定补齐未覆盖的那一维再判。
-    if "reference_audio_mode" in overrides or "max_reference_audio_count" in overrides:
-        try:
-            system_caps = system_video_capabilities(endpoint=endpoint, model_id=model_id)
-        except ValueError:
-            system_caps = None
-        mode = overrides.get(
-            "reference_audio_mode",
-            system_caps.reference_audio_mode if system_caps is not None else ReferenceAudioMode.NONE,
-        )
-        count = overrides.get(
-            "max_reference_audio_count",
-            system_caps.max_reference_audio_count if system_caps is not None else 0,
-        )
-        if not audio_capability_pair_is_coherent(mode=mode, count=cast(int, count)):
+    if any(key in overrides for key in AUDIO_OVERRIDE_KEYS):
+        mode, count = resolve_audio_pair(overrides, endpoint=endpoint, model_id=model_id)
+        if not audio_capability_pair_is_coherent(mode=mode, count=count):
             raise HTTPException(
                 status_code=422,
                 detail=_t("capability_override_audio_pair_incoherent", model_id=model_id),

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -11,7 +11,7 @@ import json
 import logging
 from collections.abc import Callable
 from dataclasses import asdict
-from typing import Annotated, Literal
+from typing import Annotated, Literal, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import AfterValidator, BaseModel, Field, field_validator
@@ -22,6 +22,7 @@ from lib.config.repository import mask_secret
 from lib.custom_provider import make_provider_id
 from lib.custom_provider.capabilities import (
     CAPABILITY_OVERRIDE_FIELDS,
+    audio_capability_pair_is_coherent,
     capability_value_matches,
     filter_valid_overrides,
     system_video_capabilities,
@@ -441,6 +442,28 @@ def _check_capability_overrides(
                     model_id=model_id,
                     endpoint=endpoint,
                 ),
+            )
+
+    # 合并后不变式：两维各自合法、合起来无意义的组合（支持音色输入却限 0 段）在这里拒，
+    # 而不是留给执行期静默降级——降级后用户会拿到「最多支持 0 段」这种无从遵循的提示。
+    # 稀疏覆盖只写其中一维也能凑出该组合，故按系统判定补齐未覆盖的那一维再判。
+    if "reference_audio_mode" in overrides or "max_reference_audio_count" in overrides:
+        try:
+            system_caps = system_video_capabilities(endpoint=endpoint, model_id=model_id)
+        except ValueError:
+            system_caps = None
+        mode = overrides.get(
+            "reference_audio_mode",
+            system_caps.reference_audio_mode if system_caps is not None else ReferenceAudioMode.NONE,
+        )
+        count = overrides.get(
+            "max_reference_audio_count",
+            system_caps.max_reference_audio_count if system_caps is not None else 0,
+        )
+        if not audio_capability_pair_is_coherent(mode=mode, count=cast(int, count)):
+            raise HTTPException(
+                status_code=422,
+                detail=_t("capability_override_audio_pair_incoherent", model_id=model_id),
             )
 
 

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -38,6 +38,7 @@ from lib.db.base import dt_to_iso
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.i18n import Translator
 from lib.image_backends.base import ImageCapability
+from lib.video_backends.base import ReferenceAudioMode
 from server.auth import CurrentUser
 
 
@@ -58,7 +59,7 @@ MaxWorkers = Annotated[int | None, Field(default=None, ge=1)]
 
 # 开放给用户覆盖的能力维度。DB 列与合成函数对 VideoCapabilities 全字段通用，写入侧在此收窄：
 # 未列入的维度即便是合法字段名也不落库，扩容只需往这里加键名，无需 DB 迁移或改合成语义。
-CAPABILITY_OVERRIDE_ALLOWLIST = frozenset({"last_frame"})
+CAPABILITY_OVERRIDE_ALLOWLIST = frozenset({"last_frame", "reference_audio_mode", "max_reference_audio_count"})
 
 # 白名单必须是 VideoCapabilities 字段名的子集：值类型校验直接按字段名取期望类型，键名写错
 # 要在导入期炸掉，而不是等到一次真实写入才 KeyError 成 500。
@@ -423,6 +424,20 @@ def _check_capability_overrides(
                 status_code=422,
                 detail=_t(
                     "capability_override_last_frame_unsupported",
+                    model_id=model_id,
+                    endpoint=endpoint,
+                ),
+            )
+        # 同构：把音色模式覆盖成 direct 要求 endpoint 真的会下传 reference_audio_files。
+        if (
+            key == "reference_audio_mode"
+            and value == ReferenceAudioMode.DIRECT.value
+            and not get_endpoint_spec(endpoint).reference_audio_capable
+        ):
+            raise HTTPException(
+                status_code=422,
+                detail=_t(
+                    "capability_override_reference_audio_unsupported",
                     model_id=model_id,
                     endpoint=endpoint,
                 ),

--- a/tests/scripts/test_verify_reference_video_sdks.py
+++ b/tests/scripts/test_verify_reference_video_sdks.py
@@ -6,7 +6,6 @@ import pytest
 import scripts.verify_reference_video_sdks as mod
 from lib.video_backends.base import (
     VideoCapabilities,
-    VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
 )
@@ -122,8 +121,7 @@ def test_render_report_empty_results_still_emits_header():
 class _FakeBackend:
     name = "fake"
     model = "fake-v1"
-    capabilities = {VideoCapability.TEXT_TO_VIDEO, VideoCapability.IMAGE_TO_VIDEO}
-    video_capabilities = VideoCapabilities(reference_images=True, max_reference_images=9)
+    video_capabilities = VideoCapabilities(max_reference_images=9)
     _calls: list[VideoGenerationRequest] = []
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
@@ -227,7 +225,7 @@ async def test_run_once_failure_captures_error(tmp_path: Path):
 def test_clamp_refs_respects_backend_max():
     from scripts.verify_reference_video_sdks import clamp_refs_for_backend
 
-    caps = VideoCapabilities(reference_images=True, max_reference_images=3)
+    caps = VideoCapabilities(max_reference_images=3)
     clamped, note = clamp_refs_for_backend(requested=7, caps=caps)
     assert clamped == 3
     assert "clamped" in note.lower()
@@ -236,7 +234,7 @@ def test_clamp_refs_respects_backend_max():
 def test_clamp_refs_under_limit_passthrough():
     from scripts.verify_reference_video_sdks import clamp_refs_for_backend
 
-    caps = VideoCapabilities(reference_images=True, max_reference_images=9)
+    caps = VideoCapabilities(max_reference_images=9)
     clamped, note = clamp_refs_for_backend(requested=3, caps=caps)
     assert clamped == 3
     assert note == ""
@@ -245,7 +243,7 @@ def test_clamp_refs_under_limit_passthrough():
 def test_clamp_refs_backend_without_reference_support():
     from scripts.verify_reference_video_sdks import clamp_refs_for_backend
 
-    caps = VideoCapabilities(reference_images=False, max_reference_images=0)
+    caps = VideoCapabilities(max_reference_images=0)
     with pytest.raises(ValueError, match="does not support reference_images"):
         clamp_refs_for_backend(requested=1, caps=caps)
 
@@ -307,7 +305,7 @@ async def test_run_with_backend_returns_2_on_failure(tmp_path: Path, monkeypatch
 class _CappedFakeBackend(_FakeBackend):
     """max_reference_images=2，会触发 clamp note 分支。"""
 
-    video_capabilities = VideoCapabilities(reference_images=True, max_reference_images=2)
+    video_capabilities = VideoCapabilities(max_reference_images=2)
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -770,7 +770,7 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
 
         @property
         def video_capabilities(self):
-            return VideoCapabilities(reference_images=True, max_reference_images=9)
+            return VideoCapabilities(max_reference_images=9)
 
         async def generate(self, request):
             captured_requests.append(request)

--- a/tests/test_accounting_characterization.py
+++ b/tests/test_accounting_characterization.py
@@ -44,7 +44,6 @@ from lib.text_generator import TextGenerator
 from lib.video_backends.base import (
     ResumeExpiredError,
     VideoCapabilities,
-    VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
 )
@@ -288,10 +287,6 @@ class _FakeVideoBackend:
     @property
     def model(self) -> str:
         return self._model
-
-    @property
-    def capabilities(self) -> set[VideoCapability]:
-        return {VideoCapability.TEXT_TO_VIDEO, VideoCapability.IMAGE_TO_VIDEO}
 
     @property
     def video_capabilities(self) -> VideoCapabilities:

--- a/tests/test_agnes_video_backend.py
+++ b/tests/test_agnes_video_backend.py
@@ -12,7 +12,6 @@ import pytest
 from lib.providers import PROVIDER_AGNES
 from lib.video_backends.base import (
     ResumeExpiredError,
-    VideoCapability,
     VideoCapabilityError,
     VideoGenerationRequest,
 )
@@ -79,16 +78,13 @@ class TestCapabilities:
         backend = AgnesVideoBackend(api_key="sk-test")
         assert backend.model == "agnes-video-v2.0"
 
-    def test_capabilities_and_video_capabilities(self):
+    def test_video_capabilities(self):
         from lib.video_backends.agnes import AgnesVideoBackend
 
         backend = AgnesVideoBackend(api_key="sk-test")
-        assert VideoCapability.TEXT_TO_VIDEO in backend.capabilities
-        assert VideoCapability.IMAGE_TO_VIDEO in backend.capabilities
         caps = backend.video_capabilities
         assert caps.first_frame is True
         assert caps.last_frame is True
-        assert caps.reference_images is True
         assert caps.max_reference_images == 4
 
 

--- a/tests/test_ark_video_resolution.py
+++ b/tests/test_ark_video_resolution.py
@@ -12,7 +12,7 @@ def _make_backend():
     backend = ArkVideoBackend.__new__(ArkVideoBackend)
     backend._client = MagicMock()
     backend._model = "doubao-seedance-1-5-pro-251215"
-    backend._capabilities = set()
+    backend._supports_service_tier = False
     return backend
 
 

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -25,7 +25,7 @@ from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import custom_providers
 
-# 系统判定 last_frame=False、reference_images=True/max=1 —— 覆盖前后差异可断言
+# 系统判定 last_frame=False、max_reference_images=1 —— 覆盖前后差异可断言
 VIDEO_ENDPOINT = "openai-video"
 VIDEO_MODEL = "sora-2"
 
@@ -136,8 +136,9 @@ class TestModelListExposesCapabilities:
         assert models[0]["system_capabilities"] == {
             "first_frame": True,
             "last_frame": False,
-            "reference_images": True,
             "max_reference_images": 1,
+            "reference_audio_mode": "none",
+            "max_reference_audio_count": 0,
         }
         assert models[0]["capability_overrides"] is None
 
@@ -151,8 +152,9 @@ class TestModelListExposesCapabilities:
         assert models[0]["system_capabilities"] == {
             "first_frame": expected.first_frame,
             "last_frame": expected.last_frame,
-            "reference_images": expected.reference_images,
             "max_reference_images": expected.max_reference_images,
+            "reference_audio_mode": expected.reference_audio_mode.value,
+            "max_reference_audio_count": expected.max_reference_audio_count,
         }
 
     @pytest.mark.integration
@@ -404,6 +406,52 @@ class TestSaveValidatesOpenOverrides:
         resp = _post_provider(client, [_video_model(capability_overrides={"last_frame": True})])
         assert resp.status_code == 422
         assert "last_frame" in resp.json()["detail"]
+
+    @pytest.mark.integration
+    def test_reference_audio_direct_rejected_on_endpoint_without_audio_support(self, client: TestClient):
+        """openai-video 的 delegate 不下传 reference_audio_files：开启覆盖只会让 UI 宣称支持
+        音色输入，执行层照旧生成随机音色的视频。"""
+        resp = _post_provider(client, [_video_model(capability_overrides={"reference_audio_mode": "direct"})])
+        assert resp.status_code == 422
+        assert "reference_audio_mode" in resp.json()["detail"]
+
+    @pytest.mark.integration
+    def test_reference_audio_none_accepted_on_endpoint_without_audio_support(self, client: TestClient):
+        """守卫只拦「宣称支持」的方向：关掉音色能力无需运输能力背书。"""
+        pid = _create_provider(client, [_video_model(capability_overrides={"reference_audio_mode": "none"})])
+
+        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        assert models[0]["capability_overrides"] == {"reference_audio_mode": "none"}
+
+    @pytest.mark.integration
+    def test_reference_audio_direct_accepted_on_audio_capable_endpoint(self, client: TestClient):
+        resp = _post_provider(
+            client,
+            [
+                _video_model(
+                    endpoint=LAST_FRAME_ENDPOINT,
+                    model_id=LAST_FRAME_MODEL,
+                    capability_overrides={"reference_audio_mode": "direct", "max_reference_audio_count": 2},
+                )
+            ],
+        )
+        assert resp.status_code == 201
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("bad_value", ["DIRECT", "native", True, 1, None])
+    def test_invalid_reference_audio_mode_rejected(self, client: TestClient, bad_value):
+        """枚举值两侧同判定：写入侧拒的与合成层忽略的必须是同一集合，否则「界面允许、执行反悔」。"""
+        resp = _post_provider(
+            client,
+            [
+                _video_model(
+                    endpoint=LAST_FRAME_ENDPOINT,
+                    model_id=LAST_FRAME_MODEL,
+                    capability_overrides={"reference_audio_mode": bad_value},
+                )
+            ],
+        )
+        assert resp.status_code == 422
 
     @pytest.mark.integration
     def test_non_video_endpoint_rejected(self, client: TestClient):

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -207,6 +207,32 @@ class TestModelListExposesCapabilities:
         assert models[0]["capability_overrides"] is None
 
     @pytest.mark.integration
+    async def test_stale_incoherent_audio_override_filtered_from_response(self, client: TestClient, session_factory):
+        """存量行的 direct ⊕ 上限 0：两维各自合法，故过得了逐键过滤，但执行层会降级到 none。
+
+        原样回显有两个后果，与 last_frame 那条同源：界面显示"直传音色已生效"而生成其实不带
+        音色输入；客户端把它随一次与音频无关的编辑原样回传，会撞上写入侧的同一条不变式，
+        把整次保存拒成 422。
+        """
+        pid = await _seed_provider_with_raw_models(
+            session_factory,
+            [
+                {
+                    "model_id": LAST_FRAME_MODEL,
+                    "display_name": "Seedance",
+                    "endpoint": LAST_FRAME_ENDPOINT,
+                    "is_enabled": True,
+                    "is_default": True,
+                    "capability_overrides": {"last_frame": True, "reference_audio_mode": "direct"},
+                }
+            ],
+        )
+
+        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        # 音频两维整组剔除，与音频无关的 last_frame 覆盖原样保留
+        assert models[0]["capability_overrides"] == {"last_frame": True}
+
+    @pytest.mark.integration
     async def test_corrupted_non_dict_override_does_not_500_response(self, client: TestClient, session_factory):
         """存量行 / 手工 SQL 可能让 JSON 列存了非字典值（字符串、列表等）：执行层的
         synthesize_video_capabilities 按容错设计忽略它，响应边界须同样容错，不能把原值

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -438,6 +438,26 @@ class TestSaveValidatesOpenOverrides:
         assert resp.status_code == 201
 
     @pytest.mark.integration
+    def test_direct_without_positive_count_rejected(self, client: TestClient):
+        """合并后不变式：宣称支持音色输入却限 0 段的组合在写入侧就拒。
+
+        放行则执行期只能静默降级，用户拿到的是「最多支持 0 段」这种无从遵循的提示。
+        该 endpoint 的系统判定上限为 0，只覆盖模式即凑出该组合。
+        """
+        resp = _post_provider(
+            client,
+            [
+                _video_model(
+                    endpoint=LAST_FRAME_ENDPOINT,
+                    model_id=LAST_FRAME_MODEL,
+                    capability_overrides={"reference_audio_mode": "direct"},
+                )
+            ],
+        )
+        assert resp.status_code == 422
+        assert "max_reference_audio_count" in resp.json()["detail"]
+
+    @pytest.mark.integration
     @pytest.mark.parametrize("bad_value", ["DIRECT", "native", True, 1, None])
     def test_invalid_reference_audio_mode_rejected(self, client: TestClient, bad_value):
         """枚举值两侧同判定：写入侧拒的与合成层忽略的必须是同一集合，否则「界面允许、执行反悔」。"""

--- a/tests/test_custom_backends.py
+++ b/tests/test_custom_backends.py
@@ -18,7 +18,6 @@ from lib.image_backends.base import ImageCapability, ImageGenerationRequest, Ima
 from lib.text_backends.base import TextCapability, TextGenerationRequest, TextGenerationResult
 from lib.video_backends.base import (
     VideoCapabilities,
-    VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
 )
@@ -147,19 +146,10 @@ class TestCustomImageBackend:
 class TestCustomVideoBackend:
     def test_properties(self):
         delegate = AsyncMock()
-        delegate.capabilities = {VideoCapability.TEXT_TO_VIDEO}
         backend = CustomVideoBackend(provider_id="custom-vid", delegate=delegate, model="wan-pro")
 
         assert backend.name == "custom-vid"
         assert backend.model == "wan-pro"
-        assert backend.capabilities == {VideoCapability.TEXT_TO_VIDEO}
-
-    def test_capabilities_delegated(self):
-        delegate = AsyncMock()
-        delegate.capabilities = {VideoCapability.TEXT_TO_VIDEO, VideoCapability.IMAGE_TO_VIDEO}
-        backend = CustomVideoBackend(provider_id="vid-provider", delegate=delegate, model="kling-v2")
-
-        assert backend.capabilities is delegate.capabilities
 
     async def test_generate_delegates(self, tmp_path: Path):
         output_path = tmp_path / "output.mp4"
@@ -171,7 +161,6 @@ class TestCustomVideoBackend:
         )
         delegate = AsyncMock()
         delegate.generate = AsyncMock(return_value=expected_result)
-        delegate.capabilities = {VideoCapability.TEXT_TO_VIDEO}
 
         backend = CustomVideoBackend(provider_id="custom-vid", delegate=delegate, model="wan-pro")
         request = VideoGenerationRequest(prompt="A flying eagle", output_path=output_path)
@@ -186,7 +175,6 @@ class TestCustomVideoBackend:
         delegate.generate = AsyncMock(
             return_value=VideoGenerationResult(video_path=output_path, provider="x", model="y", duration_seconds=5)
         )
-        delegate.capabilities = set()
 
         backend = CustomVideoBackend(provider_id="p", delegate=delegate, model="m")
         request = VideoGenerationRequest(prompt="test", output_path=output_path, duration_seconds=8)
@@ -195,20 +183,12 @@ class TestCustomVideoBackend:
         call_args = delegate.generate.call_args[0]
         assert call_args[0] is request
 
-    async def test_multiple_capabilities(self):
-        delegate = AsyncMock()
-        all_caps = {VideoCapability.TEXT_TO_VIDEO, VideoCapability.IMAGE_TO_VIDEO, VideoCapability.GENERATE_AUDIO}
-        delegate.capabilities = all_caps
-        backend = CustomVideoBackend(provider_id="full-provider", delegate=delegate, model="veo-3")
-
-        assert backend.capabilities == all_caps
-
     @pytest.mark.unit
     def test_video_capabilities_for_tier_delegates_when_delegate_supports_it(self):
         """delegate 实现 tier-aware 查询（如 Kling）时，按请求档位透传其结果，而不是回落
         context-free 的 video_capabilities——否则 media_generator 的 getattr 探测会命中一个
         总是保守拒绝的空壳方法,起不到收窄效果。"""
-        pro_caps = VideoCapabilities(first_frame=True, last_frame=True, reference_images=False)
+        pro_caps = VideoCapabilities(first_frame=True, last_frame=True)
         delegate = AsyncMock()
         delegate.video_capabilities_for_tier = MagicMock(return_value=pro_caps)
         backend = CustomVideoBackend(provider_id="vid-provider", delegate=delegate, model="kling-v2-5-turbo")
@@ -221,7 +201,7 @@ class TestCustomVideoBackend:
     @pytest.mark.unit
     def test_video_capabilities_for_tier_falls_back_without_tier_support(self):
         """delegate 未实现 tier-aware 查询时,回落到 context-free 的 video_capabilities。"""
-        static_caps = VideoCapabilities(first_frame=True, last_frame=False, reference_images=False)
+        static_caps = VideoCapabilities(first_frame=True, last_frame=False)
         delegate = AsyncMock(spec=["video_capabilities", "capabilities"])
         delegate.video_capabilities = static_caps
         backend = CustomVideoBackend(provider_id="vid-provider", delegate=delegate, model="wan-pro")
@@ -235,8 +215,8 @@ class TestCustomVideoBackend:
         """工厂注入的完整合成能力（`with_video_capabilities` 不带 overrides,如 factory.py 未
         配置用户覆盖时的调用形状）不得短路档位查询——那是 context-free 的系统判定,对 Kling 等
         档位敏感 backend 是保守声明;短路会让本方法在生产环境等价于未实现档位感知。"""
-        static_merged = VideoCapabilities(first_frame=True, last_frame=False, reference_images=False)
-        pro_caps = VideoCapabilities(first_frame=True, last_frame=True, reference_images=False)
+        static_merged = VideoCapabilities(first_frame=True, last_frame=False)
+        pro_caps = VideoCapabilities(first_frame=True, last_frame=True)
         delegate = AsyncMock()
         delegate.video_capabilities_for_tier = MagicMock(return_value=pro_caps)
         backend = CustomVideoBackend(
@@ -253,7 +233,7 @@ class TestCustomVideoBackend:
         """稀疏用户覆盖（`with_video_capabilities` 的 `overrides` 参数）叠加到 delegate 的档位
         感知基底上,未覆盖字段跟随基底——覆盖必须能翻转执行层看到的能力,但不能整体替换基底,
         否则档位切换时未覆盖字段会冻结在覆盖注入时刻的值。"""
-        base_caps = VideoCapabilities(first_frame=True, last_frame=False, reference_images=False)
+        base_caps = VideoCapabilities(first_frame=True, last_frame=False)
         delegate = AsyncMock()
         delegate.video_capabilities_for_tier = MagicMock(return_value=base_caps)
         backend = CustomVideoBackend(
@@ -264,7 +244,7 @@ class TestCustomVideoBackend:
 
         assert result.first_frame is True
         assert result.last_frame is True
-        assert result.reference_images is False
+        assert result.max_reference_images == 0
         delegate.video_capabilities_for_tier.assert_called_once_with("pro", resolution=None)
 
 

--- a/tests/test_custom_provider_capabilities.py
+++ b/tests/test_custom_provider_capabilities.py
@@ -259,3 +259,42 @@ class TestReferenceAudioOverrideGuards:
 
         assert caps.reference_audio_mode is ReferenceAudioMode.DIRECT  # 系统判定本身即 direct
         assert "reference_audio_mode" in caplog.text
+
+    @pytest.mark.unit
+    def test_direct_without_positive_count_falls_back_to_none(self, caplog: pytest.LogCaptureFixture):
+        """稀疏覆盖只写模式：合并后是 direct ⊕ 上限 0，两维各自合法而合起来无意义。
+
+        不修正就会让 gate 先过模式判定再撞上限 0，把「不支持参考音频」报成「最多支持 0 段」，
+        用户按提示减角色数量减到零段也过不了。
+        """
+        with caplog.at_level(logging.WARNING, logger="lib.custom_provider.capabilities"):
+            caps = synthesize_video_capabilities(
+                endpoint="ark-seedance",
+                model_id="doubao-seedance-1-0-pro-fast-251015",
+                overrides={"reference_audio_mode": "direct"},
+            )
+
+        assert caps.reference_audio_mode is ReferenceAudioMode.NONE
+        assert caps.max_reference_audio_count == 0
+        assert "max_reference_audio_count" in caplog.text
+
+    @pytest.mark.unit
+    def test_zero_count_override_disables_audio_on_capable_model(self):
+        """反向凑法同样收敛：系统判定 direct，用户把上限压成 0，模式随之降到 none。"""
+        caps = synthesize_video_capabilities(
+            endpoint="ark-seedance",
+            model_id="doubao-seedance-2-0-260128",
+            overrides={"max_reference_audio_count": 0},
+        )
+        assert caps.reference_audio_mode is ReferenceAudioMode.NONE
+
+    @pytest.mark.unit
+    def test_none_mode_with_positive_count_is_not_a_violation(self):
+        """反向组合不算违约：模式为 none 时上限不参与判定，判违约反会把用户关掉的能力顶回开启。"""
+        caps = synthesize_video_capabilities(
+            endpoint="ark-seedance",
+            model_id="doubao-seedance-2-0-260128",
+            overrides={"reference_audio_mode": "none"},
+        )
+        assert caps.reference_audio_mode is ReferenceAudioMode.NONE
+        assert caps.max_reference_audio_count == 3  # 系统判定原样保留，不被连坐清零

--- a/tests/test_custom_provider_capabilities.py
+++ b/tests/test_custom_provider_capabilities.py
@@ -8,11 +8,12 @@ import pytest
 
 from lib.custom_provider.capabilities import (
     CAPABILITY_OVERRIDE_FIELDS,
+    capability_value_matches,
     filter_valid_overrides,
     synthesize_video_capabilities,
     system_video_capabilities,
 )
-from lib.video_backends.base import VideoCapabilities
+from lib.video_backends.base import ReferenceAudioMode, VideoCapabilities
 
 
 class TestOverrideFieldSchema:
@@ -22,26 +23,26 @@ class TestOverrideFieldSchema:
         assert set(CAPABILITY_OVERRIDE_FIELDS) == {
             "first_frame",
             "last_frame",
-            "reference_images",
             "max_reference_images",
+            "reference_audio_mode",
+            "max_reference_audio_count",
         }
         assert CAPABILITY_OVERRIDE_FIELDS["last_frame"] is bool
         assert CAPABILITY_OVERRIDE_FIELDS["max_reference_images"] is int
+        assert CAPABILITY_OVERRIDE_FIELDS["reference_audio_mode"] is ReferenceAudioMode
+        assert CAPABILITY_OVERRIDE_FIELDS["max_reference_audio_count"] is int
 
 
 class TestSystemCapabilities:
     @pytest.mark.unit
     def test_endpoint_declaring_int_cap_rebuilds_capabilities(self):
-        """endpoint 维度声明硬上限时，参考图布尔位由上限推出（>0 即支持）。"""
+        """endpoint 维度声明硬上限时原样落到 max_reference_images，其余维度取默认。"""
         caps = system_video_capabilities(endpoint="openai-video", model_id="sora-2")
-        assert caps == VideoCapabilities(
-            first_frame=True, last_frame=False, reference_images=True, max_reference_images=1
-        )
+        assert caps == VideoCapabilities(first_frame=True, last_frame=False, max_reference_images=1)
 
     @pytest.mark.unit
     def test_endpoint_declaring_zero_cap_yields_no_reference_images(self):
         caps = system_video_capabilities(endpoint="newapi-video", model_id="whatever")
-        assert caps.reference_images is False
         assert caps.max_reference_images == 0
 
     @pytest.mark.unit
@@ -87,18 +88,17 @@ class TestSynthesize:
         caps = synthesize_video_capabilities(
             endpoint="ark-seedance",
             model_id="doubao-seedance-1-0-pro-fast-251015",
-            overrides={"last_frame": True, "reference_images": True},
+            overrides={"last_frame": True, "max_reference_images": 4},
         )
         assert caps.last_frame is True
-        assert caps.reference_images is True
+        assert caps.max_reference_images == 4
 
     @pytest.mark.unit
     def test_force_off(self):
         caps = synthesize_video_capabilities(
-            endpoint="openai-video", model_id="sora-2", overrides={"first_frame": False, "reference_images": False}
+            endpoint="openai-video", model_id="sora-2", overrides={"first_frame": False}
         )
         assert caps.first_frame is False
-        assert caps.reference_images is False
         # 未覆盖的数值维度不受布尔覆盖牵连
         assert caps.max_reference_images == 1
 
@@ -150,9 +150,7 @@ class TestTolerance:
                 overrides={"last_frame": True, "audio_track": True},
             )
         assert caps.last_frame is True
-        assert caps == VideoCapabilities(
-            first_frame=True, last_frame=True, reference_images=False, max_reference_images=0
-        )
+        assert caps == VideoCapabilities(first_frame=True, last_frame=True, max_reference_images=0)
         assert "audio_track" in caplog.text
 
     @pytest.mark.unit
@@ -205,3 +203,59 @@ class TestTolerance:
             )
         assert applied == {}
         assert "last_frame" in caplog.text
+
+
+class TestReferenceAudioOverrideGuards:
+    """音频维度的三守卫：EndpointSpec 运输声明、合并后不变式、枚举值两侧同判定。"""
+
+    @pytest.mark.unit
+    def test_enum_value_matches_accepts_declared_literal(self):
+        assert capability_value_matches("direct", ReferenceAudioMode)
+        assert capability_value_matches("none", ReferenceAudioMode)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("value", ["DIRECT", "Direct", "native", "", True, 1, None])
+    def test_enum_value_matches_rejects_everything_else(self, value):
+        """词表外的值一律判否——不做大小写归一，也不猜近义词。"""
+        assert not capability_value_matches(value, ReferenceAudioMode)
+
+    @pytest.mark.unit
+    def test_direct_override_applies_on_audio_capable_endpoint(self):
+        caps = synthesize_video_capabilities(
+            endpoint="ark-seedance",
+            model_id="doubao-seedance-1-0-pro-fast-251015",
+            overrides={"reference_audio_mode": "direct", "max_reference_audio_count": 2},
+        )
+        assert caps.reference_audio_mode == ReferenceAudioMode.DIRECT
+        assert caps.max_reference_audio_count == 2
+
+    @pytest.mark.unit
+    def test_direct_override_ignored_when_endpoint_cannot_send_audio(self, caplog: pytest.LogCaptureFixture):
+        """endpoint 的 delegate 不下传参考音频时，覆盖只会让声明失真，须降级跟随系统判定。"""
+        with caplog.at_level(logging.WARNING, logger="lib.custom_provider.capabilities"):
+            caps = synthesize_video_capabilities(
+                endpoint="openai-video", model_id="sora-2", overrides={"reference_audio_mode": "direct"}
+            )
+
+        assert caps.reference_audio_mode is ReferenceAudioMode.NONE
+        assert "reference_audio_mode=direct" in caplog.text
+
+    @pytest.mark.unit
+    def test_none_override_needs_no_endpoint_support(self):
+        """关掉音色能力不需要运输能力背书：守卫只拦「宣称支持」的方向。"""
+        caps = synthesize_video_capabilities(
+            endpoint="openai-video", model_id="sora-2", overrides={"reference_audio_mode": "none"}
+        )
+        assert caps.reference_audio_mode == ReferenceAudioMode.NONE
+
+    @pytest.mark.unit
+    def test_invalid_enum_value_falls_back_to_system_judgement(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING, logger="lib.custom_provider.capabilities"):
+            caps = synthesize_video_capabilities(
+                endpoint="ark-seedance",
+                model_id="doubao-seedance-2-0-260128",
+                overrides={"reference_audio_mode": "DIRECT"},
+            )
+
+        assert caps.reference_audio_mode is ReferenceAudioMode.DIRECT  # 系统判定本身即 direct
+        assert "reference_audio_mode" in caplog.text

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -62,6 +62,7 @@ class TestRegistry:
             # 未声明的 endpoint cap 序列化为 None（resolver fallthrough 到 backend caps）
             "video_max_reference_images": None,
             "end_image_capable": False,
+            "reference_audio_capable": False,
         }
 
     def test_new_video_endpoints_have_unset_cap(self):
@@ -113,7 +114,7 @@ class TestRegistry:
         caps_fn = ENDPOINT_REGISTRY["minimax-video"].video_caps_for_model
         assert caps_fn is not None
         s2v = caps_fn("S2V-01")
-        assert s2v.reference_images is True
+        assert s2v.max_reference_images > 0
         assert s2v.max_reference_images == 1
         hailuo = caps_fn("MiniMax-Hailuo-2.3")
         assert hailuo.first_frame is True
@@ -126,24 +127,24 @@ class TestRegistry:
         caps_fn = ENDPOINT_REGISTRY["kling-video"].video_caps_for_model
         assert caps_fn is not None
         omni = caps_fn("kling-v3-omni")
-        assert omni.reference_images is True
+        assert omni.max_reference_images > 0
         assert omni.max_reference_images == 4
         o1 = caps_fn("kling-video-o1")
-        assert o1.reference_images is True
+        assert o1.max_reference_images > 0
         assert o1.max_reference_images == 4
         turbo = caps_fn("kling-v2-5-turbo")
         assert turbo.first_frame is True
-        assert turbo.reference_images is False
+        assert turbo.max_reference_images == 0
         assert turbo.max_reference_images == 0
         # 中转 model_id 带厂商前缀（仓库既有约定 / 与 :）+ 非规范大小写：归一化后仍能精确命中已登记档
         for prefixed_id in ("vendor/Kling-V3-Omni", "provider:kling-v3-omni"):
             prefixed = caps_fn(prefixed_id)
-            assert prefixed.reference_images is True
+            assert prefixed.max_reference_images > 0
             assert prefixed.max_reference_images == 4
         # 未登记 model（未来版本 kling-v4 / 归一化后仍不匹配的中转自定义 id）→ 保守默认，不按子串猜能力
         for unknown_id in ("kling-v4", "vendor/some-unknown-model"):
             unknown = caps_fn(unknown_id)
-            assert unknown.reference_images is False
+            assert unknown.max_reference_images == 0
             assert unknown.max_reference_images == 0
 
     def test_negative_int_cap_rejected_at_validation(self, monkeypatch: pytest.MonkeyPatch):
@@ -175,6 +176,22 @@ class TestRegistry:
         monkeypatch.setitem(ENDPOINT_REGISTRY, "ark-seedance", bad)
         with pytest.raises(ValueError, match="non-callable video_caps_for_model"):
             _validate_video_caps_declarations()
+
+    def test_non_video_endpoint_declaring_reference_audio_rejected(self, monkeypatch: pytest.MonkeyPatch):
+        """import 期不变式：reference_audio_capable 只对 video 类有意义，非 video 类声明即 misconfig。"""
+        import dataclasses
+
+        from lib.custom_provider.endpoints import _validate_video_caps_declarations
+
+        bad = dataclasses.replace(ENDPOINT_REGISTRY["openai-chat"], reference_audio_capable=True)
+        monkeypatch.setitem(ENDPOINT_REGISTRY, "openai-chat", bad)
+        with pytest.raises(ValueError, match="must not declare reference_audio_capable"):
+            _validate_video_caps_declarations()
+
+    def test_audio_capable_endpoints_match_backends_that_send_audio(self):
+        """运输声明与 backend 实现同步：声明 True 的 endpoint 必须真的组装参考音频。"""
+        audio_capable = {k for k, s in ENDPOINT_REGISTRY.items() if s.reference_audio_capable}
+        assert audio_capable == {"ark-seedance", "dashscope-async-video"}
 
     def test_audio_endpoint_spec(self):
         spec = ENDPOINT_REGISTRY["openai-tts"]

--- a/tests/test_custom_provider_loader.py
+++ b/tests/test_custom_provider_loader.py
@@ -130,8 +130,8 @@ class TestVideoCapabilityOverridesReachExecution:
     @pytest.mark.integration
     @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
     async def test_override_forces_capability_off(self, _mock_cls, session):
-        backend = await self._load_video_backend(session, overrides={"reference_images": False})
-        assert backend.video_capabilities.reference_images is False
+        backend = await self._load_video_backend(session, overrides={"max_reference_images": 0})
+        assert backend.video_capabilities.max_reference_images == 0
         assert backend.video_capabilities.first_frame is True
 
     @pytest.mark.integration

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -10,8 +10,8 @@ import pytest
 
 from lib.providers import PROVIDER_DASHSCOPE
 from lib.video_backends.base import (
+    ReferenceAudioMode,
     ResumeExpiredError,
-    VideoCapability,
     VideoCapabilityError,
     VideoGenerationRequest,
 )
@@ -95,7 +95,7 @@ class TestCapabilities:
 
         b = DashScopeVideoBackend(api_key="sk", model="happyhorse-1.0-r2v")
         vc = b.video_capabilities
-        assert vc.reference_images is True
+        assert vc.max_reference_images > 0
         assert vc.max_reference_images == 9
         assert vc.first_frame is False
 
@@ -111,15 +111,13 @@ class TestCapabilities:
         from lib.video_backends.dashscope import DashScopeVideoBackend
 
         b = DashScopeVideoBackend(api_key="sk", model="happyhorse-1.0-t2v")
-        assert VideoCapability.TEXT_TO_VIDEO in b.capabilities
         assert b.video_capabilities.first_frame is False
-        assert b.video_capabilities.reference_images is False
+        assert b.video_capabilities.max_reference_images == 0
 
     def test_i2v_caps(self):
         from lib.video_backends.dashscope import DashScopeVideoBackend
 
         b = DashScopeVideoBackend(api_key="sk", model="wan2.7-i2v")
-        assert VideoCapability.IMAGE_TO_VIDEO in b.capabilities
         assert b.video_capabilities.first_frame is True
 
     def test_decorated_model_name_resolves_r2v_caps(self):
@@ -135,7 +133,7 @@ class TestCapabilities:
         ):
             # 实例侧（_build_media 据此构造 media）
             b = DashScopeVideoBackend(api_key="sk", model=model)
-            assert b.video_capabilities.reference_images is True
+            assert b.video_capabilities.max_reference_images > 0
             assert b.video_capabilities.max_reference_images == expected_max
             # resolver 侧（纯函数，不构造 backend）
             assert DashScopeVideoBackend.video_capabilities_for_model(model).max_reference_images == expected_max
@@ -145,7 +143,7 @@ class TestCapabilities:
         from lib.video_backends.dashscope import DashScopeVideoBackend
 
         b = DashScopeVideoBackend(api_key="sk", model="happyhorse")
-        assert b.video_capabilities.reference_images is False
+        assert b.video_capabilities.max_reference_images == 0
 
 
 class TestReferenceToVideo:
@@ -593,3 +591,133 @@ class TestRetryStatusGating:
             )
         assert get.call_count == 2
         assert result.task_id == "t-poll"
+
+
+class TestWan27ReferenceVoice:
+    """wan2.7-r2v 的音色不是独立 media 条目，而是挂在参考素材项上的 reference_voice 字段。"""
+
+    @staticmethod
+    def _backend():
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        return DashScopeVideoBackend(api_key="sk", model="wan2.7-r2v")
+
+    @staticmethod
+    def _refs(tmp_path, count: int) -> list:
+        out = []
+        for i in range(count):
+            p = tmp_path / f"r{i}.png"
+            p.write_bytes(b"\x89PNG\r\n")
+            out.append(p)
+        return out
+
+    @staticmethod
+    def _audio(tmp_path, name: str) -> Path:
+        p = tmp_path / name
+        p.write_bytes(b"riff-audio")
+        return p
+
+    @pytest.mark.unit
+    def test_r2v_declares_audio_capability(self):
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        caps = DashScopeVideoBackend.video_capabilities_for_model("wan2.7-r2v")
+        assert caps.reference_audio_mode is ReferenceAudioMode.DIRECT
+        # 音频逐段挂参考素材项，段数上限即参考素材总数上限
+        assert caps.max_reference_audio_count == 5
+
+    @pytest.mark.unit
+    def test_i2v_declares_no_audio_capability(self):
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        caps = DashScopeVideoBackend.video_capabilities_for_model("wan2.7-i2v")
+        assert caps.reference_audio_mode is ReferenceAudioMode.NONE
+
+    @pytest.mark.unit
+    def test_audio_attached_to_reference_items_in_order(self, tmp_path):
+        payload = self._backend()._build_payload(
+            VideoGenerationRequest(
+                prompt="两人对话",
+                output_path=tmp_path / "o.mp4",
+                reference_images=self._refs(tmp_path, 2),
+                reference_audio_files=[self._audio(tmp_path, "a.mp3"), self._audio(tmp_path, "b.wav")],
+            )
+        )
+
+        refs = [m for m in payload["input"]["media"] if m["type"] == "reference_image"]
+        assert len(refs) == 2
+        assert refs[0]["reference_voice"].startswith("data:audio/mpeg;base64,")
+        assert refs[1]["reference_voice"].startswith("data:audio/wav;base64,")
+
+    @pytest.mark.unit
+    def test_fewer_audios_than_references_leaves_rest_unvoiced(self, tmp_path):
+        payload = self._backend()._build_payload(
+            VideoGenerationRequest(
+                prompt="一人说话",
+                output_path=tmp_path / "o.mp4",
+                reference_images=self._refs(tmp_path, 3),
+                reference_audio_files=[self._audio(tmp_path, "a.mp3")],
+            )
+        )
+
+        refs = [m for m in payload["input"]["media"] if m["type"] == "reference_image"]
+        assert "reference_voice" in refs[0]
+        assert all("reference_voice" not in r for r in refs[1:])
+
+    @pytest.mark.unit
+    def test_no_audio_leaves_reference_items_untouched(self, tmp_path):
+        payload = self._backend()._build_payload(
+            VideoGenerationRequest(
+                prompt="无对白",
+                output_path=tmp_path / "o.mp4",
+                reference_images=self._refs(tmp_path, 2),
+            )
+        )
+
+        refs = [m for m in payload["input"]["media"] if m["type"] == "reference_image"]
+        assert all("reference_voice" not in r for r in refs)
+
+    @pytest.mark.unit
+    def test_more_audios_than_references_raises(self, tmp_path):
+        """挂不上的音频不丢弃：静默丢弃会让某个角色的音色声明无声失效，且照常扣费。"""
+        with pytest.raises(VideoCapabilityError) as exc:
+            self._backend()._build_payload(
+                VideoGenerationRequest(
+                    prompt="三人对话",
+                    output_path=tmp_path / "o.mp4",
+                    reference_images=self._refs(tmp_path, 1),
+                    reference_audio_files=[self._audio(tmp_path, "a.mp3"), self._audio(tmp_path, "b.mp3")],
+                )
+            )
+
+        assert exc.value.code == "video_reference_audio_exceeded"
+        assert exc.value.params["limit"] == 1
+        assert exc.value.params["count"] == 2
+
+    @pytest.mark.unit
+    def test_missing_audio_file_raises(self, tmp_path):
+        with pytest.raises(VideoCapabilityError) as exc:
+            self._backend()._build_payload(
+                VideoGenerationRequest(
+                    prompt="x",
+                    output_path=tmp_path / "o.mp4",
+                    reference_images=self._refs(tmp_path, 1),
+                    reference_audio_files=[tmp_path / "missing.mp3"],
+                )
+            )
+
+        assert exc.value.code == "video_reference_audio_unreadable"
+
+    @pytest.mark.unit
+    def test_unsupported_audio_format_raises(self, tmp_path):
+        with pytest.raises(VideoCapabilityError) as exc:
+            self._backend()._build_payload(
+                VideoGenerationRequest(
+                    prompt="x",
+                    output_path=tmp_path / "o.mp4",
+                    reference_images=self._refs(tmp_path, 1),
+                    reference_audio_files=[self._audio(tmp_path, "a.ogg")],
+                )
+            )
+
+        assert exc.value.code == "video_reference_audio_format_unsupported"

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -679,7 +679,11 @@ class TestWan27ReferenceVoice:
 
     @pytest.mark.unit
     def test_more_audios_than_references_raises(self, tmp_path):
-        """挂不上的音频不丢弃：静默丢弃会让某个角色的音色声明无声失效，且照常扣费。"""
+        """挂不上的音频不丢弃：静默丢弃会让某个角色的音色声明无声失效，且照常扣费。
+
+        卡点是"可挂载的参考素材不够"，与 gate 的"超出模型能力上限"是两回事，故各用一个
+        code：两者的处置建议相反（补参考图 vs 减角色），共用会给出与实际卡点不符的提示。
+        """
         with pytest.raises(VideoCapabilityError) as exc:
             self._backend()._build_payload(
                 VideoGenerationRequest(
@@ -690,8 +694,8 @@ class TestWan27ReferenceVoice:
                 )
             )
 
-        assert exc.value.code == "video_reference_audio_exceeded"
-        assert exc.value.params["limit"] == 1
+        assert exc.value.code == "video_reference_audio_slots_insufficient"
+        assert exc.value.params["slots"] == 1
         assert exc.value.params["count"] == 2
 
     @pytest.mark.unit

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -699,6 +699,28 @@ class TestWan27ReferenceVoice:
         assert exc.value.params["count"] == 2
 
     @pytest.mark.unit
+    def test_model_without_reference_images_rejects_audio_instead_of_dropping(self, tmp_path):
+        """无参考图能力的 model 收到音频要报错，不静默丢弃。
+
+        可达路径：自定义供应商把 endpoint 级的 reference_audio_mode 覆盖成 direct（该 endpoint
+        的 delegate 确实会下传音频），但具体 model 走 wan2.7-i2v 这类无参考素材的档位——
+        音频无处挂载。丢弃会生成一段音色随机的视频并照常扣费。
+        """
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        with pytest.raises(VideoCapabilityError) as exc:
+            DashScopeVideoBackend(api_key="sk", model="wan2.7-i2v")._build_payload(
+                VideoGenerationRequest(
+                    prompt="独白",
+                    output_path=tmp_path / "o.mp4",
+                    start_image=self._refs(tmp_path, 1)[0],
+                    reference_audio_files=[self._audio(tmp_path, "a.mp3")],
+                )
+            )
+
+        assert exc.value.code == "video_reference_audio_unsupported"
+
+    @pytest.mark.unit
     def test_missing_audio_file_raises(self, tmp_path):
         with pytest.raises(VideoCapabilityError) as exc:
             self._backend()._build_payload(

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -5,7 +5,7 @@ import pytest
 
 from lib.config.resolver import ProviderModel
 from lib.video_backends.base import VideoCapabilities, VideoCapabilityError
-from lib.video_frame_slots import plan_frame_slots
+from lib.video_frame_slots import gate_video_request
 from server.services import generation_tasks
 from server.services.generation_context import GenerationContext, ImageLaneResult, VideoLaneResult
 from server.services.generation_tasks import assert_duration_supported
@@ -1001,7 +1001,7 @@ class TestGenerationTasks:
     async def test_execute_video_task_end_frame_capability_unsupported_propagates(self, monkeypatch, tmp_path):
         """后端不支持尾帧能力时硬失败，不降级为参考图、不静默丢帧。
 
-        替身只替换 provider 调用，能力判定交给生产代码 plan_frame_slots 跑真值（caps
+        替身只替换 provider 调用，能力判定交给生产代码 gate_video_request 跑真值（caps
         last_frame=False）——否则替身按自己的条件抛异常，验的是替身而非接线是否真能触达
         gating。能力组合的各分支另见 tests/test_video_frame_slots.py。"""
         project_path = _prepare_files(tmp_path)
@@ -1015,14 +1015,13 @@ class TestGenerationTasks:
 
         async def _plan_with_real_gating(**kwargs):
             fake_generator.video_calls.append(kwargs)
-            plan_frame_slots(
+            gate_video_request(
                 caps=VideoCapabilities(first_frame=True, last_frame=False),
                 provider="ark",
                 model="seedance",
-                start_image=kwargs.get("start_image"),
                 end_image=kwargs.get("end_image"),
             )
-            raise AssertionError("plan_frame_slots 应在 end_image 非空且 caps.last_frame 为假时硬失败")
+            raise AssertionError("gate_video_request 应在 end_image 非空且 caps.last_frame 为假时硬失败")
 
         fake_generator.generate_video_async = _plan_with_real_gating
 

--- a/tests/test_grok_video_backend.py
+++ b/tests/test_grok_video_backend.py
@@ -8,10 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from lib.providers import PROVIDER_GROK
-from lib.video_backends.base import (
-    VideoCapability,
-    VideoGenerationRequest,
-)
+from lib.video_backends.base import VideoGenerationRequest
 
 
 @pytest.fixture
@@ -33,11 +30,7 @@ class TestGrokVideoBackend:
         from lib.video_backends.grok import GrokVideoBackend
 
         backend = GrokVideoBackend(api_key="test-key")
-        assert VideoCapability.TEXT_TO_VIDEO in backend.capabilities
-        assert VideoCapability.IMAGE_TO_VIDEO in backend.capabilities
-        assert VideoCapability.GENERATE_AUDIO not in backend.capabilities
-        assert VideoCapability.NEGATIVE_PROMPT not in backend.capabilities
-        assert VideoCapability.SEED_CONTROL not in backend.capabilities
+        assert backend.video_capabilities.max_reference_images == 7
 
     @patch("lib.video_backends.grok.create_grok_client")
     def test_custom_model(self, mock_create):

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -13,7 +13,7 @@ import jwt
 import pytest
 
 from lib.providers import PROVIDER_KLING
-from lib.video_backends.base import VideoCapability, VideoCapabilityError, VideoGenerationRequest
+from lib.video_backends.base import VideoCapabilityError, VideoGenerationRequest
 from lib.video_backends.kling import KlingVideoBackend
 from lib.video_backends.registry import effective_generate_audio_for_model
 
@@ -87,18 +87,13 @@ class TestConstructionAndCapabilities:
         with pytest.raises(ValueError):
             KlingVideoBackend(auth_mode="oauth", api_key="k")
 
-    def test_capabilities_t2v_and_i2v(self):
-        caps = _jwt_backend().capabilities
-        assert VideoCapability.TEXT_TO_VIDEO in caps
-        assert VideoCapability.IMAGE_TO_VIDEO in caps
-
     def test_video_capabilities_first_and_last_frame(self):
         caps = _jwt_backend().video_capabilities
         assert caps.first_frame is True
         # turbo 尾帧仅 pro 档生效，声明按默认档保守为 False（std 档提交会被 _build_payload 拒绝）
         assert caps.last_frame is False
         # turbo 不建模参考图（多图主体留 v3-omni/o1）
-        assert caps.reference_images is False
+        assert caps.max_reference_images == 0
         assert caps.max_reference_images == 0
 
 
@@ -144,31 +139,25 @@ class TestVideoCapabilitiesForTier:
 class TestPerModelCapabilities:
     def test_v3_t2v_i2v_no_audio_no_reference(self):
         b = _jwt_backend("kling-v3")
-        assert b.capabilities == {VideoCapability.TEXT_TO_VIDEO, VideoCapability.IMAGE_TO_VIDEO}
         vc = b.video_capabilities
         assert vc.first_frame is True and vc.last_frame is True
-        assert vc.reference_images is False and vc.max_reference_images == 0
+        assert vc.max_reference_images == 0
 
     def test_v3_omni_declares_reference_images(self):
         b = _jwt_backend("kling-v3-omni")
-        assert b.capabilities == {VideoCapability.TEXT_TO_VIDEO, VideoCapability.IMAGE_TO_VIDEO}
         vc = b.video_capabilities
-        assert vc.reference_images is True
         assert vc.max_reference_images == 4  # 保守值，待控制台核对
 
     def test_v2_6_declares_generate_audio_no_reference(self):
         b = _jwt_backend("kling-v2-6")
-        assert VideoCapability.GENERATE_AUDIO in b.capabilities
-        assert VideoCapability.TEXT_TO_VIDEO in b.capabilities
-        assert b.video_capabilities.reference_images is False
+        assert b.video_capabilities.max_reference_images == 0
 
     def test_video_o1_i2v_only_with_reference_images(self):
         b = _jwt_backend("kling-video-o1")
-        # 仅图生（无 t2v），多图主体 R2V
-        assert b.capabilities == {VideoCapability.IMAGE_TO_VIDEO}
+        # 多图主体 R2V
         vc = b.video_capabilities
         assert vc.last_frame is True
-        assert vc.reference_images is True and vc.max_reference_images == 4
+        assert vc.max_reference_images == 4
 
     def test_video_o1_pricing_audio_matches_effective_request(self, tmp_path):
         """预估消费的 backend 能力接口与真实请求的 `_effective_audio` 对参考模型给出同一静音档。"""
@@ -182,24 +171,23 @@ class TestPerModelCapabilities:
         # bearer 透传原生 model_name：未登记 → 保守默认（t2v+i2v、尾帧仅 pro 档，声明按 std 档保守
         # 为 False；无音频/参考）
         b = _bearer_backend("kling-some-passthrough")
-        assert b.capabilities == {VideoCapability.TEXT_TO_VIDEO, VideoCapability.IMAGE_TO_VIDEO}
         vc = b.video_capabilities
         assert vc.last_frame is False
-        assert vc.reference_images is False and vc.max_reference_images == 0
+        assert vc.max_reference_images == 0
 
     def test_prefixed_and_cased_model_normalizes_to_registered_caps(self):
         # 中转 model_id 带厂商前缀（仓库既有约定 / 与 :）+ 非规范大小写/空白：归一化后实例 caps 仍精确命中
         # 已登记档，生成时防御与 resolver 裁剪同源——否则编排层放 4 张参考图、backend 却按默认 0 拒收。
         for model in ("vendor/Kling-V3-Omni", "provider:kling-v3-omni", "  provider:kling-v3-omni  "):
             vc = _bearer_backend(model).video_capabilities
-            assert vc.reference_images is True and vc.max_reference_images == 4
+            assert vc.max_reference_images > 0 and vc.max_reference_images == 4
 
     def test_future_version_does_not_inherit_caps_by_substring(self):
         # kling-v4 含子串 "kling-v3"？不含——但即便形如 kling-v3-omni-pro 也不得被子串误判继承能力；
         # 未登记一律保守默认，不猜未知 model 的参考图上限。
         for model in ("kling-v4", "kling-v3-omni-pro"):
             vc = _bearer_backend(model).video_capabilities
-            assert vc.reference_images is False and vc.max_reference_images == 0
+            assert vc.max_reference_images == 0 and vc.max_reference_images == 0
 
 
 class TestModeAndResolution:

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -705,3 +705,50 @@ class TestReferenceCompressionSeam:
 
         assert backend.start_dims == (3000, 2000)  # FRAME 尺寸保持
         assert max(backend.ref_dims[0]) == 2048  # ARRAY 缩到长边 2048
+
+    async def test_reference_audio_reaches_backend_unreordered(self, tmp_path):
+        """参考音频原样透传到请求：gate 放行后若不下传，音频会在校验之后被静默丢弃。
+
+        音频不进压缩器（specs 只收图片），故也不能跟着压缩结果重排——顺序即 prompt 里
+        「音频N」的指认顺序，重排会把 A 角色的音色安到 B 角色头上。
+        """
+        gen = _build_generator(tmp_path)
+
+        from lib.video_backends.base import ReferenceAudioMode, VideoCapabilities
+
+        class _AudioCapturingVideoBackend:
+            name = "fake-video"
+            model = "video-model"
+            video_capabilities = VideoCapabilities(
+                max_reference_images=9,
+                reference_audio_mode=ReferenceAudioMode.DIRECT,
+                max_reference_audio_count=3,
+            )
+
+            def __init__(self):
+                self.received_audio: list[Path] | None = None
+
+            async def generate(self, request):
+                self.received_audio = request.reference_audio_files
+                request.output_path.parent.mkdir(parents=True, exist_ok=True)
+                request.output_path.write_bytes(b"v")
+                return _FakeVideoResult()
+
+        backend = _AudioCapturingVideoBackend()
+        gen._video_backend = backend
+
+        ref = _solid_png(tmp_path, "ref.png", 3000, 3000)
+        first = tmp_path / "alice.wav"
+        second = tmp_path / "bob.wav"
+        first.write_bytes(b"a")
+        second.write_bytes(b"b")
+
+        await gen.generate_video_async(
+            prompt="p",
+            resource_type="videos",
+            resource_id="E1S01",
+            reference_images=[ref],
+            reference_audio_files=[first, second],
+        )
+
+        assert backend.received_audio == [first, second]

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -665,9 +665,14 @@ class TestReferenceCompressionSeam:
     async def test_video_frame_not_resized_array_laddered(self, tmp_path):
         gen = _build_generator(tmp_path)
 
+        from lib.video_backends.base import VideoCapabilities
+
         class _CapturingVideoBackend:
             name = "fake-video"
             model = "video-model"
+            # 带参考图的请求会先过 gate_video_request，替身须声明足够的参考图容量，
+            # 否则请求在触达 generate 之前就被能力校验拒掉。
+            video_capabilities = VideoCapabilities(max_reference_images=9)
 
             def __init__(self):
                 self.start_dims = None

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from lib.providers import PROVIDER_MINIMAX
-from lib.video_backends.base import VideoCapability, VideoCapabilityError, VideoGenerationRequest
+from lib.video_backends.base import VideoCapabilityError, VideoGenerationRequest
 from lib.video_backends.minimax import MiniMaxVideoBackend
 
 
@@ -71,16 +71,6 @@ class TestConstructionAndCapabilities:
         assert b.name == PROVIDER_MINIMAX
         assert b.model == "MiniMax-Hailuo-2.3"
 
-    def test_hailuo_supports_t2v_and_i2v(self):
-        caps = _backend("MiniMax-Hailuo-2.3").capabilities
-        assert VideoCapability.TEXT_TO_VIDEO in caps
-        assert VideoCapability.IMAGE_TO_VIDEO in caps
-
-    def test_fast_supports_only_i2v(self):
-        caps = _backend("MiniMax-Hailuo-2.3-Fast").capabilities
-        assert VideoCapability.TEXT_TO_VIDEO not in caps
-        assert VideoCapability.IMAGE_TO_VIDEO in caps
-
     def test_video_capabilities_first_frame(self):
         assert _backend().video_capabilities.first_frame is True
 
@@ -142,15 +132,9 @@ class TestS2V01SubjectReference:
 
     def test_caps_reference_single_no_first_frame(self):
         caps = _backend("S2V-01").video_capabilities
-        assert caps.reference_images is True
         assert caps.max_reference_images == 1
         # S2V-01 仅 subject_reference 驱动，不接受首帧图。
         assert caps.first_frame is False
-
-    def test_capability_set_excludes_t2v_and_i2v(self):
-        caps = _backend("S2V-01").capabilities
-        assert VideoCapability.TEXT_TO_VIDEO not in caps
-        assert VideoCapability.IMAGE_TO_VIDEO not in caps
 
     def test_payload_maps_reference_to_subject_reference(self, tmp_path):
         face = tmp_path / "face.png"

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -10,10 +10,7 @@ import httpx
 import pytest
 
 from lib.providers import PROVIDER_NEWAPI
-from lib.video_backends.base import (
-    VideoCapability,
-    VideoGenerationRequest,
-)
+from lib.video_backends.base import VideoGenerationRequest
 
 
 def _make_response(status_code: int, json_body: dict) -> MagicMock:
@@ -53,9 +50,6 @@ class TestNewAPIVideoBackend:
         from lib.video_backends.newapi import NewAPIVideoBackend
 
         backend = NewAPIVideoBackend(api_key="sk-test", base_url="https://x/v1", model="m")
-        assert VideoCapability.TEXT_TO_VIDEO in backend.capabilities
-        assert VideoCapability.IMAGE_TO_VIDEO in backend.capabilities
-        assert backend.video_capabilities.reference_images is False
         assert backend.video_capabilities.max_reference_images == 0
 
     async def test_text_to_video_happy_path(self, tmp_path: Path):

--- a/tests/test_openai_video_backend.py
+++ b/tests/test_openai_video_backend.py
@@ -9,10 +9,7 @@ import pytest
 from openai import InternalServerError
 
 from lib.providers import PROVIDER_OPENAI
-from lib.video_backends.base import (
-    VideoCapability,
-    VideoGenerationRequest,
-)
+from lib.video_backends.base import VideoGenerationRequest
 
 
 def _make_mock_video(status="completed", seconds="8", video_id="vid_123"):
@@ -62,11 +59,7 @@ class TestOpenAIVideoBackend:
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key")
-            assert VideoCapability.TEXT_TO_VIDEO in backend.capabilities
-            assert VideoCapability.IMAGE_TO_VIDEO in backend.capabilities
-            assert VideoCapability.GENERATE_AUDIO not in backend.capabilities
-            assert VideoCapability.NEGATIVE_PROMPT not in backend.capabilities
-            assert VideoCapability.SEED_CONTROL not in backend.capabilities
+            assert backend.video_capabilities.max_reference_images == 1
 
     async def test_text_to_video(self, tmp_path: Path):
         video_data = b"mp4-video-content"

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -14,7 +14,6 @@ import pytest
 from lib.video_backends.base import (
     AmbiguousSubmitError,
     ResumeExpiredError,
-    VideoCapability,
     VideoGenerationRequest,
 )
 from lib.video_backends.v2_video_generations import (
@@ -323,14 +322,12 @@ class TestV2BackendHttp:
     def _backend() -> _V2Backend:
         return _V2Backend(api_key="sk-test", base_url="https://api.aimlapi.com", model="seedance-1.0")
 
-    def test_name_model_capabilities(self):
+    def test_name_model_and_video_capabilities(self):
         b = self._backend()
         assert b.name == PROVIDER_V2_VIDEO
         assert b.model == "seedance-1.0"
-        assert VideoCapability.TEXT_TO_VIDEO in b.capabilities
-        assert VideoCapability.IMAGE_TO_VIDEO in b.capabilities
         caps = b.video_capabilities
-        assert caps.first_frame and caps.last_frame and caps.reference_images
+        assert caps.first_frame and caps.last_frame
         assert caps.max_reference_images == 4
 
     def test_constructor_requires_api_key(self):

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -7,7 +7,8 @@ import pytest
 
 from lib.video_backends.ark import ArkVideoBackend
 from lib.video_backends.base import (
-    VideoCapability,
+    ReferenceAudioMode,
+    VideoCapabilityError,
     VideoGenerationRequest,
     VideoGenerationResult,
 )
@@ -59,15 +60,6 @@ def _mock_httpx_stream(data: bytes = b"fake-mp4-data"):
 class TestArkProperties:
     def test_name(self, backend):
         assert backend.name == "ark"
-
-    def test_capabilities(self, backend):
-        caps = backend.capabilities
-        assert VideoCapability.TEXT_TO_VIDEO in caps
-        assert VideoCapability.IMAGE_TO_VIDEO in caps
-        assert VideoCapability.GENERATE_AUDIO in caps
-        assert VideoCapability.SEED_CONTROL in caps
-        assert VideoCapability.FLEX_TIER in caps
-        assert VideoCapability.NEGATIVE_PROMPT not in caps
 
 
 class TestArkGenerate:
@@ -374,33 +366,6 @@ class TestArkRetryBehavior:
 class TestArkModelCapabilities:
     """测试不同模型的能力映射。"""
 
-    def test_seedance_2_no_flex_tier(self):
-        with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
-            b = ArkVideoBackend(api_key="test", model="doubao-seedance-2-0-260128")
-        caps = b.capabilities
-        assert VideoCapability.FLEX_TIER not in caps
-        assert VideoCapability.VIDEO_EXTEND not in caps
-
-    def test_seedance_2_fast_no_flex_tier(self):
-        with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
-            b = ArkVideoBackend(api_key="test", model="doubao-seedance-2-0-fast-260128")
-        caps = b.capabilities
-        assert VideoCapability.FLEX_TIER not in caps
-        assert VideoCapability.VIDEO_EXTEND not in caps
-
-    def test_seedance_1_5_has_flex_tier(self):
-        with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
-            b = ArkVideoBackend(api_key="test", model="doubao-seedance-1-5-pro-251215")
-        caps = b.capabilities
-        assert VideoCapability.FLEX_TIER in caps
-        assert VideoCapability.VIDEO_EXTEND not in caps
-
-    def test_unknown_model_gets_default_capabilities(self):
-        with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
-            b = ArkVideoBackend(api_key="test", model="some-future-model")
-        caps = b.capabilities
-        assert VideoCapability.FLEX_TIER in caps
-
     @pytest.mark.unit
     def test_seedance_1_5_pro_default_model_supports_last_frame(self):
         """DEFAULT_MODEL：能力表标首尾帧 ✅，实测 generate() 正常下发 role=last_frame。"""
@@ -478,35 +443,21 @@ class TestArkModelCapabilities:
         caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-2-0-future")
         assert caps.last_frame is False
 
-    def test_seedance_2_dot_format_no_flex_tier(self):
-        """ark-agent-plan 用 dot 命名（doubao-seedance-2.0），同样不该带 FLEX_TIER。"""
-        with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
-            b = ArkVideoBackend(api_key="test", model="doubao-seedance-2.0")
-        assert VideoCapability.FLEX_TIER not in b.capabilities
-
-    def test_seedance_2_fast_dot_format_no_flex_tier(self):
-        with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
-            b = ArkVideoBackend(api_key="test", model="doubao-seedance-2.0-fast")
-        assert VideoCapability.FLEX_TIER not in b.capabilities
-
-    def test_seedance_2_dreamina_prefix_no_flex_tier(self):
-        """BytePlus 国际站用 dreamina- 前缀（dreamina-seedance-2-0-260128），同族不该带 FLEX_TIER。"""
-        with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
-            b = ArkVideoBackend(api_key="test", model="dreamina-seedance-2-0-260128")
-        assert VideoCapability.FLEX_TIER not in b.capabilities
-
-    def test_seedance_2_dreamina_fast_prefix_no_flex_tier(self):
-        with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
-            b = ArkVideoBackend(api_key="test", model="dreamina-seedance-2-0-fast-260128")
-        assert VideoCapability.FLEX_TIER not in b.capabilities
-
 
 class TestArkServiceTierParam:
-    """service_tier 只对声明了 FLEX_TIER 能力的模型传入，否则 API 会报错。"""
+    """service_tier 只对支持该参数的模型传入，否则 API 会报错。"""
 
     @pytest.mark.parametrize(
         "model",
-        ["doubao-seedance-2-0-260128", "dreamina-seedance-2-0-260128"],
+        [
+            "doubao-seedance-2-0-260128",
+            # ark-agent-plan 用点号命名，BytePlus 国际站用 dreamina- 前缀：同族的各种命名
+            # 变体都必须被 _is_seedance_2 识别，漏掉任一种都会让 r2v 请求被上游 400 拒。
+            "doubao-seedance-2.0",
+            "doubao-seedance-2.0-fast",
+            "dreamina-seedance-2-0-260128",
+            "dreamina-seedance-2-0-fast-260128",
+        ],
     )
     async def test_seedance_2_does_not_send_service_tier(self, tmp_path, model):
         """seedance-2 系列（含 dreamina- 前缀的自定义供应商命名）不得发 service_tier，否则 r2v 上游 400。"""
@@ -610,3 +561,108 @@ class TestIsArkNotFound:
         exc = RuntimeError("any")
         exc.status_code = 404  # type: ignore[attr-defined]
         assert _is_ark_not_found(exc) is True
+
+
+class TestArkReferenceAudio:
+    """Seedance 2.0 参考音频：content 数组条目 + 顺序契约。"""
+
+    @staticmethod
+    def _seedance_2_backend():
+        with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
+            return ArkVideoBackend(api_key="test", model="doubao-seedance-2-0-260128")
+
+    @pytest.mark.unit
+    def test_seedance_2_declares_audio_capability(self):
+        caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-2-0-260128")
+        assert caps.reference_audio_mode is ReferenceAudioMode.DIRECT
+        assert caps.max_reference_audio_count == 3
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "model",
+        ["doubao-seedance-2.0-fast", "doubao-seedance-2-0-mini-260615", "dreamina-seedance-2-0-260128"],
+    )
+    def test_seedance_2_variants_declare_audio_capability(self, model):
+        assert ArkVideoBackend.video_capabilities_for_model(model).reference_audio_mode is ReferenceAudioMode.DIRECT
+
+    @pytest.mark.unit
+    def test_unverified_seedance_2_variant_does_not_inherit_audio(self):
+        """未上表的 2.0 变体不得因子串包含关系继承音频参考能力（与尾帧同一白名单口径）。"""
+        caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-2-0-future")
+        assert caps.reference_audio_mode is ReferenceAudioMode.NONE
+        assert caps.max_reference_audio_count == 0
+
+    @pytest.mark.unit
+    def test_seedance_1_5_declares_no_audio_capability(self):
+        caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-5-pro-251215")
+        assert caps.reference_audio_mode is ReferenceAudioMode.NONE
+
+    async def test_reference_audio_sent_as_audio_url_entries(self, tmp_path):
+        """每段音频发一条 type=audio_url + role=reference_audio，且顺序与请求字段一致。"""
+        backend = self._seedance_2_backend()
+        first_audio = tmp_path / "a.mp3"
+        first_audio.write_bytes(b"id3-first")
+        second_audio = tmp_path / "b.wav"
+        second_audio.write_bytes(b"riff-second")
+        ref = tmp_path / "r.png"
+        ref.write_bytes(b"fake-ref")
+
+        backend._client.content_generation.tasks.create = MagicMock(side_effect=RuntimeError("stop"))
+
+        request = VideoGenerationRequest(
+            prompt="两人对话",
+            output_path=tmp_path / "out.mp4",
+            reference_images=[ref],
+            reference_audio_files=[first_audio, second_audio],
+        )
+        with pytest.raises(RuntimeError):
+            await backend._create_task(request)
+
+        content = backend._client.content_generation.tasks.create.call_args.kwargs["content"]
+        audio_items = [c for c in content if c["type"] == "audio_url"]
+        assert len(audio_items) == 2
+        assert [c["role"] for c in audio_items] == ["reference_audio", "reference_audio"]
+        # 顺序即 prompt 中「音频N」的编号：第一段必须是请求里的第一段
+        assert audio_items[0]["audio_url"]["url"].startswith("data:audio/mp3;base64,")
+        assert audio_items[1]["audio_url"]["url"].startswith("data:audio/wav;base64,")
+
+    async def test_no_audio_entries_when_request_has_none(self, tmp_path):
+        backend = self._seedance_2_backend()
+        ref = tmp_path / "r.png"
+        ref.write_bytes(b"fake-ref")
+        backend._client.content_generation.tasks.create = MagicMock(side_effect=RuntimeError("stop"))
+
+        with pytest.raises(RuntimeError):
+            await backend._create_task(
+                VideoGenerationRequest(prompt="x", output_path=tmp_path / "o.mp4", reference_images=[ref])
+            )
+
+        content = backend._client.content_generation.tasks.create.call_args.kwargs["content"]
+        assert not [c for c in content if c["type"] == "audio_url"]
+
+    async def test_unsupported_audio_format_raises(self, tmp_path):
+        """格式不受支持时抛错而非跳过：跳过会让其后所有音频编号整体前移、错绑角色音色。"""
+        backend = self._seedance_2_backend()
+        bad = tmp_path / "a.ogg"
+        bad.write_bytes(b"ogg")
+
+        with pytest.raises(VideoCapabilityError) as exc:
+            await backend._create_task(
+                VideoGenerationRequest(prompt="x", output_path=tmp_path / "o.mp4", reference_audio_files=[bad])
+            )
+
+        assert exc.value.code == "video_reference_audio_format_unsupported"
+
+    async def test_missing_audio_file_raises(self, tmp_path):
+        backend = self._seedance_2_backend()
+
+        with pytest.raises(VideoCapabilityError) as exc:
+            await backend._create_task(
+                VideoGenerationRequest(
+                    prompt="x",
+                    output_path=tmp_path / "o.mp4",
+                    reference_audio_files=[tmp_path / "missing.mp3"],
+                )
+            )
+
+        assert exc.value.code == "video_reference_audio_unreadable"

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -1,5 +1,6 @@
 """ArkVideoBackend 单元测试 — mock Ark SDK。"""
 
+import json
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -607,6 +608,28 @@ class TestArkReferenceAudio:
     def _seedance_2_backend():
         with patch("lib.video_backends.ark.create_ark_client", return_value=MagicMock()):
             return ArkVideoBackend(api_key="test", model="doubao-seedance-2-0-260128")
+
+    @pytest.mark.unit
+    def test_request_log_view_collapses_media_without_base64(self):
+        """素材不进日志：content 内的图片与音频都是 base64 data URI，原样交给日志格式化
+        只会截断成前缀而非剔除，等于把素材内容（音频还可能带 mp3 的 ID3 元数据）写进 info 日志。
+        prompt 是用户文本、排查生成效果要用，保留。"""
+        from lib.video_backends.ark import _safe_create_params_for_log
+
+        view = _safe_create_params_for_log(
+            {
+                "model": "doubao-seedance-2-0-260128",
+                "content": [
+                    {"type": "text", "text": "两人对话"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                    {"type": "audio_url", "audio_url": {"url": "data:audio/mp3;base64,BBBB"}},
+                ],
+            }
+        )
+
+        assert "base64" not in json.dumps(view, ensure_ascii=False)
+        assert view["content"] == "<1 audio_url, 1 image_url, 1 text>"
+        assert view["prompt"] == "两人对话"
 
     @pytest.mark.unit
     def test_seedance_2_declares_audio_capability(self):

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -407,6 +407,43 @@ class TestArkModelCapabilities:
         assert caps.last_frame is False
 
     @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "model", ["doubao-seedance-1-5-pro-251215", "doubao-seedance-1.5-pro", "dreamina-seedance-1-5-pro"]
+    )
+    def test_seedance_1_5_pro_declares_reference_images(self, model: str):
+        """1.5 pro 是既有的参考生视频可用路径：_create_task 对任何 model 都序列化 role=reference_image，
+        编排层按 registry 的 9 张派图。此处声明 0 会让 gate_video_request 把这些请求整批拒掉。"""
+        caps = ArkVideoBackend.video_capabilities_for_model(model)
+        assert caps.max_reference_images == 9
+
+    @pytest.mark.unit
+    def test_unknown_model_declares_no_reference_images(self):
+        """未上表型号保守判 0：与尾帧同口径，不为未知型号假设参考图容量。"""
+        assert (
+            ArkVideoBackend.video_capabilities_for_model("doubao-seedance-9-9-ultra-future").max_reference_images == 0
+        )
+        assert ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-5-pro-future").max_reference_images == 0
+
+    @pytest.mark.unit
+    def test_backend_reference_capacity_matches_registry(self):
+        """registry 与 backend 的参考图上限必须同值。
+
+        编排层按 registry.ModelInfo.max_reference_images 决定给一个 unit 派几张参考图，
+        gate_video_request 按 backend 声明校验；backend 声明低于 registry 时，编排层正常派好
+        图的请求会在 gate 上被拒——两侧漂移没有别的守卫能发现。
+        """
+        from lib.config.registry import PROVIDER_REGISTRY
+
+        for provider_id in ("ark", "ark-agent-plan"):
+            for model_id, info in PROVIDER_REGISTRY[provider_id].models.items():
+                if info.media_type != "video":
+                    continue
+                declared = ArkVideoBackend.video_capabilities_for_model(model_id).max_reference_images
+                assert declared == info.max_reference_images, (
+                    f"{provider_id}/{model_id}: registry={info.max_reference_images} backend={declared}"
+                )
+
+    @pytest.mark.unit
     def test_seedance_1_0_lite_t2v_no_last_frame(self):
         """纯文生视频型号，能力表「图生视频-首帧」「图生视频-首尾帧」均标 "-"，不接受任何图片输入。"""
         caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-0-lite-t2v-250428")

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -10,7 +10,6 @@ from lib.video_backends.base import (
     AmbiguousSubmitError,
     ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
-    VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
     is_retryable_http_status,
@@ -31,20 +30,6 @@ def _http_status_error(status_code: int, *, text: str = "boom") -> httpx.HTTPSta
     return httpx.HTTPStatusError(f"error '{status_code}'", request=request, response=response)
 
 
-class TestVideoCapability:
-    def test_enum_values(self):
-        assert VideoCapability.TEXT_TO_VIDEO == "text_to_video"
-        assert VideoCapability.IMAGE_TO_VIDEO == "image_to_video"
-        assert VideoCapability.GENERATE_AUDIO == "generate_audio"
-        assert VideoCapability.NEGATIVE_PROMPT == "negative_prompt"
-        assert VideoCapability.VIDEO_EXTEND == "video_extend"
-        assert VideoCapability.SEED_CONTROL == "seed_control"
-        assert VideoCapability.FLEX_TIER == "flex_tier"
-
-    def test_enum_is_str(self):
-        assert isinstance(VideoCapability.TEXT_TO_VIDEO, str)
-
-
 class TestVideoGenerationRequest:
     def test_defaults(self):
         req = VideoGenerationRequest(prompt="test", output_path=Path("/tmp/out.mp4"))
@@ -53,6 +38,7 @@ class TestVideoGenerationRequest:
         assert req.resolution is None
         assert req.start_image is None
         assert req.generate_audio is True
+        assert req.reference_audio_files is None
         assert req.service_tier == "default"
         assert req.seed is None
 

--- a/tests/test_video_backend_capabilities.py
+++ b/tests/test_video_backend_capabilities.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from lib.video_backends.base import VideoCapabilities, VideoGenerationRequest
+from lib.video_backends.base import ReferenceAudioMode, VideoCapabilities, VideoGenerationRequest
 
 
 class TestVideoCapabilities:
@@ -10,18 +10,25 @@ class TestVideoCapabilities:
         caps = VideoCapabilities()
         assert caps.first_frame is True
         assert caps.last_frame is False
-        assert caps.reference_images is False
         assert caps.max_reference_images == 0
+        assert caps.reference_audio_mode is ReferenceAudioMode.NONE
+        assert caps.max_reference_audio_count == 0
 
     def test_first_last(self):
         caps = VideoCapabilities(last_frame=True)
         assert caps.last_frame is True
 
     def test_custom_values(self):
-        caps = VideoCapabilities(last_frame=True, reference_images=True, max_reference_images=9)
+        caps = VideoCapabilities(
+            last_frame=True,
+            max_reference_images=9,
+            reference_audio_mode=ReferenceAudioMode.DIRECT,
+            max_reference_audio_count=3,
+        )
         assert caps.last_frame is True
-        assert caps.reference_images is True
         assert caps.max_reference_images == 9
+        assert caps.reference_audio_mode is ReferenceAudioMode.DIRECT
+        assert caps.max_reference_audio_count == 3
 
 
 class TestVideoGenerationRequestNewFields:
@@ -77,7 +84,7 @@ class TestGrokVideoCapabilities:
 
         with patch("lib.video_backends.grok.create_grok_client"):
             caps = GrokVideoBackend(api_key="test-key").video_capabilities
-        assert caps.reference_images is True
+        assert caps.max_reference_images > 0
         assert caps.max_reference_images == 7
         assert not hasattr(caps, "reference_images_with_start_frame")
 
@@ -93,7 +100,7 @@ class TestVideoCapabilitiesForModel:
         # 不构造实例（即不构造 Ark SDK client、不需 api_key）即可取得 caps
         caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-2-0")
         assert caps.max_reference_images == 9
-        assert caps.reference_images is True
+        assert caps.max_reference_images > 0
 
     def test_ark_non_seedance_2_returns_zero(self):
         from lib.video_backends.ark import ArkVideoBackend

--- a/tests/test_video_backend_gemini.py
+++ b/tests/test_video_backend_gemini.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from lib.video_backends.base import (
-    VideoCapability,
     VideoGenerationRequest,
     VideoGenerationResult,
 )
@@ -42,15 +41,12 @@ class TestGeminiVideoBackendProperties:
     def test_name(self, backend):
         assert backend.name == "gemini-aistudio"
 
-    def test_capabilities_aistudio(self, backend):
-        caps = backend.capabilities
-        assert VideoCapability.TEXT_TO_VIDEO in caps
-        assert VideoCapability.IMAGE_TO_VIDEO in caps
-        assert VideoCapability.NEGATIVE_PROMPT in caps
-        assert VideoCapability.VIDEO_EXTEND in caps
-        assert VideoCapability.GENERATE_AUDIO not in caps
+    def test_video_capabilities_aistudio(self, backend):
+        caps = backend.video_capabilities
+        assert caps.last_frame is True
+        assert caps.max_reference_images == 3
 
-    def test_capabilities_vertex(self, mock_rate_limiter, tmp_path):
+    def test_vertex_backend_constructs_from_credentials_file(self, mock_rate_limiter, tmp_path):
         # 准备 mock vertex 凭证文件
         creds_file = tmp_path / "vertex_credentials.json"
         creds_file.write_text('{"project_id": "test-project"}')
@@ -70,7 +66,7 @@ class TestGeminiVideoBackendProperties:
                 backend_type="vertex",
                 rate_limiter=mock_rate_limiter,
             )
-            assert VideoCapability.GENERATE_AUDIO in b.capabilities
+            assert b.name == "gemini-vertex"
 
 
 # ── 生成测试 ──────────────────────────────────────────────

--- a/tests/test_video_backend_registry.py
+++ b/tests/test_video_backend_registry.py
@@ -1,6 +1,5 @@
 import pytest
 
-from lib.video_backends.base import VideoCapability
 from lib.video_backends.registry import (
     _BACKEND_FACTORIES,
     create_backend,
@@ -11,7 +10,6 @@ from lib.video_backends.registry import (
 
 class _FakeBackend:
     name = "fake"
-    capabilities = {VideoCapability.TEXT_TO_VIDEO}
 
     def __init__(self, api_key: str = "default"):
         self.api_key = api_key

--- a/tests/test_video_frame_slots.py
+++ b/tests/test_video_frame_slots.py
@@ -1,25 +1,34 @@
-"""帧槽位规划纯函数的直接单测：能力 gating × 槽位组装各组合分支。"""
+"""请求期能力校验（gate_video_request）与帧槽位组装（plan_frame_slots）的直接单测。"""
 
 from pathlib import Path
 
 import pytest
 
 from lib.reference_compression import RefRole
-from lib.video_backends.base import VideoCapabilities, VideoCapabilityError
-from lib.video_frame_slots import plan_frame_slots, resolve_video_capabilities
+from lib.video_backends.base import ReferenceAudioMode, VideoCapabilities, VideoCapabilityError
+from lib.video_frame_slots import gate_video_request, plan_frame_slots, resolve_video_capabilities
 
 pytestmark = pytest.mark.unit
 
-CAPS_WITH_LAST_FRAME = VideoCapabilities(
-    first_frame=True, last_frame=True, reference_images=True, max_reference_images=4
+CAPS_WITH_LAST_FRAME = VideoCapabilities(first_frame=True, last_frame=True, max_reference_images=4)
+CAPS_NO_LAST_FRAME = VideoCapabilities(first_frame=True, last_frame=False, max_reference_images=4)
+CAPS_WITH_AUDIO = VideoCapabilities(
+    first_frame=True,
+    max_reference_images=4,
+    reference_audio_mode=ReferenceAudioMode.DIRECT,
+    max_reference_audio_count=3,
 )
-CAPS_NO_LAST_FRAME = VideoCapabilities(
-    first_frame=True, last_frame=False, reference_images=True, max_reference_images=4
-)
+
+
+def _gate(caps: VideoCapabilities | None, **kwargs):
+    gate_video_request(caps=caps, provider="acme", model="acme-v1", **kwargs)
 
 
 def _plan(caps: VideoCapabilities | None, **kwargs):
-    return plan_frame_slots(caps=caps, provider="acme", model="acme-v1", **kwargs)
+    """沿用「先校验再组装」的生产调用序：组装是纯函数，不再自行判定能力。"""
+    gate_kwargs = {k: v for k, v in kwargs.items() if k != "start_image"}
+    _gate(caps, **gate_kwargs)
+    return plan_frame_slots(**kwargs)
 
 
 class TestLastFrameGating:
@@ -64,10 +73,8 @@ class TestLastFrameGating:
         assert plan.end_index == 0
 
     def test_uncharted_caps_without_end_image_passes(self):
-        """caps=None（调用方未查询能力）× 不携带尾帧：能力不影响任何槽位，正常放行。"""
-        plan = _plan(None, start_image=Path("start.png"), reference_images=[Path("r1.png")])
-
-        assert (plan.start_index, plan.end_index, plan.reference_start_index) == (0, None, 1)
+        """caps=None（调用方未查询能力）× 三条路径都不走：无需能力声明即可放行。"""
+        _gate(None)
 
     def test_uncharted_caps_with_end_image_raises(self):
         """caps=None × 携带尾帧：未经能力核实的尾帧一律拒绝，不按"支持"放行。"""
@@ -142,3 +149,70 @@ class TestResolveVideoCapabilities:
             video_capabilities = CAPS_NO_LAST_FRAME
 
         assert resolve_video_capabilities(PlainBackend()).last_frame is False
+
+
+class TestReferenceImageGating:
+    def test_reference_images_beyond_limit_raise(self):
+        """超出上限硬失败：静默截断会让用户以为所有参考图都生效了。"""
+        with pytest.raises(VideoCapabilityError) as exc:
+            _gate(CAPS_WITH_LAST_FRAME, reference_images=[Path(f"r{i}.png") for i in range(5)])
+
+        assert exc.value.code == "video_reference_images_exceeded"
+        assert exc.value.params == {"provider": "acme", "model": "acme-v1", "limit": 4, "count": 5}
+
+    def test_reference_images_at_limit_pass(self):
+        _gate(CAPS_WITH_LAST_FRAME, reference_images=[Path(f"r{i}.png") for i in range(4)])
+
+    def test_reference_images_on_zero_capacity_model_raise(self):
+        with pytest.raises(VideoCapabilityError) as exc:
+            _gate(VideoCapabilities(), reference_images=[Path("r.png")])
+
+        assert exc.value.code == "video_reference_images_unsupported"
+
+    def test_uncharted_caps_with_reference_images_raise(self):
+        """caps=None × 携带参考图：与尾帧同理，未经能力核实不放行。"""
+        with pytest.raises(VideoCapabilityError) as exc:
+            _gate(None, reference_images=[Path("r.png")])
+
+        assert exc.value.code == "video_reference_images_unsupported"
+
+
+class TestReferenceAudioGating:
+    def test_audio_on_model_without_capability_raises(self):
+        """无音色输入能力的模型收到音频：硬失败，不静默丢弃后照常扣费生成随机音色。"""
+        with pytest.raises(VideoCapabilityError) as exc:
+            _gate(CAPS_WITH_LAST_FRAME, reference_audio_files=[Path("a.mp3")])
+
+        assert exc.value.code == "video_reference_audio_unsupported"
+        assert exc.value.params == {"provider": "acme", "model": "acme-v1"}
+
+    def test_audio_within_limit_passes(self):
+        _gate(CAPS_WITH_AUDIO, reference_audio_files=[Path("a.mp3"), Path("b.wav")])
+
+    def test_audio_at_limit_passes(self):
+        _gate(CAPS_WITH_AUDIO, reference_audio_files=[Path(f"a{i}.mp3") for i in range(3)])
+
+    def test_audio_beyond_limit_raises(self):
+        with pytest.raises(VideoCapabilityError) as exc:
+            _gate(CAPS_WITH_AUDIO, reference_audio_files=[Path(f"a{i}.mp3") for i in range(4)])
+
+        assert exc.value.code == "video_reference_audio_exceeded"
+        assert exc.value.params == {"provider": "acme", "model": "acme-v1", "limit": 3, "count": 4}
+
+    def test_uncharted_caps_with_audio_raises(self):
+        with pytest.raises(VideoCapabilityError) as exc:
+            _gate(None, reference_audio_files=[Path("a.mp3")])
+
+        assert exc.value.code == "video_reference_audio_unsupported"
+
+    def test_empty_audio_list_passes_on_incapable_model(self):
+        """空列表与 None 同义：没有音频诉求就不该被音频能力挡住。"""
+        _gate(CAPS_WITH_LAST_FRAME, reference_audio_files=[])
+
+
+class TestGateAndAssemblySeparation:
+    def test_plan_frame_slots_does_not_gate(self):
+        """组装是纯函数：即便尾帧不被支持也照常铺槽位，拒绝的责任全在 gate。"""
+        plan = plan_frame_slots(start_image=Path("start.png"), end_image=Path("end.png"))
+
+        assert (plan.start_index, plan.end_index) == (0, 1)

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -9,7 +9,6 @@ import pytest
 
 from lib.providers import PROVIDER_VIDU
 from lib.video_backends.base import (
-    VideoCapability,
     VideoGenerationRequest,
 )
 from lib.video_backends.vidu import (
@@ -36,14 +35,6 @@ class TestBackendBasics:
         assert backend.name == PROVIDER_VIDU
         assert backend.model == DEFAULT_MODEL == "viduq3-turbo"
 
-    def test_q3_models_have_audio_capability(self):
-        backend = ViduVideoBackend(api_key="test-key", model="viduq3-turbo")
-        assert VideoCapability.GENERATE_AUDIO in backend.capabilities
-
-    def test_non_q3_models_lack_audio_capability(self):
-        backend = ViduVideoBackend(api_key="test-key", model="vidu2.0")
-        assert VideoCapability.GENERATE_AUDIO not in backend.capabilities
-
     def test_max_reference_images_seven(self):
         backend = ViduVideoBackend(api_key="test-key")
         assert backend.video_capabilities.max_reference_images == 7
@@ -57,7 +48,7 @@ class TestBackendBasics:
         caps = backend.video_capabilities
         assert caps.first_frame is True
         assert caps.last_frame is False
-        assert caps.reference_images is False
+        assert caps.max_reference_images == 0
         assert caps.max_reference_images == 0
 
     @pytest.mark.unit


### PR DESCRIPTION
Closes #1488

## 做了什么

视频能力声明收敛为单一真相，并接通参考音频直传。

**收敛**：删除零消费方的 `VideoCapability` 枚举与 `VideoBackend.capabilities` 协议属性（ark 的 service_tier、minimax 的 t2v 判定内部化为 backend 私有布尔），删除冗余的 `reference_images` 布尔，消费方一律判 `max_reference_images > 0`；`plan_frame_slots` 拆为 `gate_video_request`（统一前置校验）与纯组装两个函数。

**扩展**：`VideoCapabilities` 新增 `reference_audio_mode`（`none | direct`）与 `max_reference_audio_count`；`VideoGenerationRequest` 新增 `reference_audio_files`（列表顺序即 prompt 音频编号指认契约）；Seedance 组装 `audio_url` + `role: reference_audio`，Wan2.7 r2v 把音频挂到参考素材项的 `reference_voice` 上；自定义供应商覆盖白名单开放两个新字段，配齐三守卫。

## 用户可感知的行为变化

参考图数量超限由 dashscope 原有的「截断 + warning」改为硬失败（`video_reference_images_exceeded`）。收编到统一 gate 后两种语义互斥，取硬失败依 Spec #1486「降级全程明示、不静默丢弃」的口径。dashscope 内部的截断分支保留，兜底未经 media_generator 的调用方。

## 验证

- `uv run python -m pytest`：6936 passed
- `uv run ruff check` / `ruff format --check`：clean
- `uv run basedpyright`：0 error
- 前端 `pnpm lint` + `pnpm check`：136 files / 1482 tests passed

未真机调用两家供应商 API——Spec 已把真机效果实测列为 Out of Scope，但请求形状被上游拒绝这类错误同样未验证。

## 已知边界

`reference_audio_files` 的上游填充（哪个角色对应哪段音频、编号如何与 prompt 指认文本对齐）属 Spec #1486 第 21/32 条，另票处理。本 PR 到 `MediaGenerator.generate_video_async` 的形参为止，生产路径上该字段目前恒为 None。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 视频生成支持参考音频输入，并按原始顺序传递多个音频文件。
  * 自定义视频提供商支持配置参考音频模式及数量上限。
  * 支持对参考音频格式、数量和可读性进行校验。
* **错误修复**
  * 优化视频能力判断，避免不支持或超限的参考图、参考音频请求被提交。
  * 新增中文、英文和越南语的参考音频错误提示。
* **改进**
  * 视频能力信息统一以参考素材数量上限和音频模式呈现，提升配置准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->