### PR TITLE
chore(issue-tracker): 看板 Status 由 repo 侧事实单向派生，事件驱动加每日对账

### DIFF
--- a/.agents/skills/afk-team-workflow/SKILL.md
+++ b/.agents/skills/afk-team-workflow/SKILL.md
@@ -26,7 +26,7 @@ batch-poll 只产出 gh/git 事实与机械汇总，不做语义判断。取得�
 ## 第二步：制定计划，主动请求一次前置授权
 
 1. 依赖顺序按 batch-poll 的 `blocked_by` / `ready_to_start` 排；并发槽位优先给改动域互不相交的 issue，同域或足迹重叠者靠依赖序或补位串行——冲突事前避而非事后解；`stage_hint` 已起的 issue（恢复场景）按 [references/recovery.md](references/recovery.md) 处置
-2. 分流：`ready-for-agent` 进批次；`ready-for-human` 跳过——它与下游被阻塞链都不启动；无标签的读正文判断归类（batch-poll 的 `ready_to_start` 只算依赖与未起，triage 由你定）
+2. 分流：`ready-for-agent` 进批次；`ready-for-human` 跳过——它与下游被阻塞链都不启动；已被他人 assign 的 issue 是其他会话的认领标记，同样跳过（batch-poll 不含 assignee 字段，逐个通读时用 `gh issue view <N> --json assignees` 核对）；无标签的读正文判断归类（batch-poll 的 `ready_to_start` 只算依赖与未起，triage 由你定）
 3. 向用户展示批次计划：成员清单、依赖顺序、每个 issue 的实现路线与模型（**各附一句选择理由**，见第三步「实现路线与模型」）、跳过项及连带不启动的下游、并发上限（默认 3，用户可覆盖）
 4. **主动请求一次性前置授权**：向用户明确提出两项预批——本批所有 PR 的合并（含清尾轮立项的 PR）；清尾立项权限（对满足收尾节判据的缺陷类 follow-up，team-lead 可自行 /to-tickets 立项并在清尾轮跑到合并，被拒则清尾降级为收尾转呈）。连同流程将自动执行的动作边界（修改 triage 标签、PR 转 draft、在 Spec 发 QA 验收 comment；清尾授权之外不创建新 issue，gap 立项仍须用户中途指令）。这是本流程唯一的同步确认点；前置授权在此落入 team-lead 的 transcript，后续不再逐笔请示
 5. 用户确认后建账本（首条 append，记录计划裁决与所得授权，见「账本」），进入无人值守执行，不再中途请示
@@ -83,7 +83,7 @@ teammate 的一切暂停请示先到你这里。分四类处置：
 
 1. **故障类**（bot 报错、quota 耗尽、长时间无响应）：自行裁决，不升级用户。按 /pr-ai-review-loop 故障节的建议重试一次；仍失败则本 PR 停用该 reviewer 并记录，收尾前可做一次补审尝试。即时 append 账本 `fault`（崩溃恢复需据此 replay），并纳入收尾汇报
 2. **已答复又被重复提出的意见**：同一主题已有 pushback 在案、又被同一 reviewer 重复提出——不算真冲突、不搁置：裁决维持 pushback，令 looper 回评引用在案结论后继续循环；浮现出值得升级 ADR 的原则则记入收尾转呈，不当场写 ADR
-3. **收敛类**（`round_estimate` ≥ 5 且每轮都是新出现的小意见、没有单一争点；或 looper 报连续 2 轮无实质收益）：先判断成因再选处置——①收益递减：剩余意见确无实质收益时，令 looper 逐条驳回留痕后走终核，超范围项记入 handoff 的 follow-up 候选；仍有实质意见则令其继续；②注意力漂移：令 looper 把本轮修复交由子代理在干净上下文中执行，自己继续负责轮询；③防御堆积：令 looper 从严执行可达性门槛——指不出触发路径的防御类意见一律驳回，指得出的照常修复；驳回项按 follow-up 候选记入 handoff，交清尾轮分拣；④issue 拆分过粗：按 needs-human 搁置并转呈。裁决 append 账本 `decision`
+3. **收敛类**（`round_estimate` ≥ 5 且每轮都是新出现的小意见、没有单一争点；或 looper 报连续 2 轮无实质收益）：先判断成因再选处置——①收益递减：剩余意见确无实质收益时，令 looper 逐条驳回留痕后走终核，超范围项记入 handoff 的 follow-up 候选；仍有实质意见则令其继续；②注意力漂移：令 looper 把本轮修复交由子代理在干净上下文中执行，自己继续负责轮询；③防御堆积：令 looper 从严执行可达性门槛——指不出触发路径的防御类意见一律驳回，指得出的照常修复；驳回项按 follow-up 候选记入 handoff，交清尾轮分拣；④issue 拆分过粗：按第 4 类的搁置流程处置（含移除 assignee 取消认领）并转呈。裁决 append 账本 `decision`
 4. **reviewer 真实冲突 / 业务取舍**：不选边，按 needs-human 搁置：PR 转 draft（draft 下 CodeRabbit 不审，冻结循环消除重审噪音）、issue 改 `ready-for-human` 并移除 assignee（取消认领，交还人工）、PR 评论写明争点与双方立场、teammate 退役并清理 worktree（分支与 PR 留在远端待人工接手）、append 账本 `shelve`（含争点）并归入收尾清单
 
 ## 健康检查与替补

--- a/.agents/skills/afk-team-workflow/SKILL.md
+++ b/.agents/skills/afk-team-workflow/SKILL.md
@@ -67,7 +67,7 @@ spawn 时按 [references/spawn-prompts.md](references/spawn-prompts.md) 的模�
 
    分拣结果 append 账本 `decision`；`--issues` 批次扩员后补一条带 scope 的行。轮中新增的候选转呈
 2. **在 Spec issue 发人工 QA 验收清单 comment，不关闭 Spec 本体**。清单按已合并子 issue（含清尾轮）组织：每项给 PR 链接与面向用户可感知行为的验收步骤（实际操作路径，不复读技术验收标准）；末尾列 needs-human 搁置项、跳过与未启动项、发现的缺口。纯 issue 列表批次没有共同 Spec 时，清单并入收尾汇报
-3. 解散团队，删除全部 worktree 与本地分支（远端分支合并后自动删除）
+3. 解散团队，移除已合并 issue 的 assignee（认领标记只表示进行中，不作完成归属，残留会让 reopen 后的 issue 被投影成 In progress），删除全部 worktree 与本地分支（远端分支合并后自动删除）
 4. 向用户汇报三份清单：已合并（issue 与 PR 对照）、needs-human 搁置（含争点）、跳过与未启动（含原因）；另附转呈事项：缺口立项建议、故障裁决记录、清尾分拣中转呈的候选，以及**聚合复盘**——从账本 `retrospective` 行与 handoff 目录聚合四类复盘候选（ADR / CONTEXT.md / CLAUDE.md / follow-up），一次性呈用户裁决。多数批次干净收敛，四类候选常为空；空是预期结果，照实呈报，无需为"没有候选"补叙
 5. 账本 append 一条 `closed` 收尾行（`bash .agents/skills/afk-team-workflow/scripts/ledger.sh <batch-id> closed`）——账本不删除，留作复盘源与审计，并供下次触发时的恢复探测器据此判定本批次已终态。批准后的复盘落地方式（写 ADR / 改 CONTEXT.md / 补 CLAUDE.md / 立 follow-up issue）不在此指定，由用户与后续会话决定
 

--- a/.agents/skills/afk-team-workflow/SKILL.md
+++ b/.agents/skills/afk-team-workflow/SKILL.md
@@ -26,7 +26,7 @@ batch-poll 只产出 gh/git 事实与机械汇总，不做语义判断。取得�
 ## 第二步：制定计划，主动请求一次前置授权
 
 1. 依赖顺序按 batch-poll 的 `blocked_by` / `ready_to_start` 排；并发槽位优先给改动域互不相交的 issue，同域或足迹重叠者靠依赖序或补位串行——冲突事前避而非事后解；`stage_hint` 已起的 issue（恢复场景）按 [references/recovery.md](references/recovery.md) 处置
-2. 分流：`ready-for-agent` 进批次；`ready-for-human` 跳过——它与下游被阻塞链都不启动；已被他人 assign 的 issue 是其他会话的认领标记，同样跳过（batch-poll 不含 assignee 字段，逐个通读时用 `gh issue view <N> --json assignees` 核对）；无标签的读正文判断归类（batch-poll 的 `ready_to_start` 只算依赖与未起，triage 由你定）
+2. 分流：`ready-for-agent` 进批次；`ready-for-human` 跳过——它与下游被阻塞链都不启动；已被他人 assign 的 issue 视为已认领，同样跳过（batch-poll 不含 assignee，用 `gh issue view <N> --json assignees` 核对）；无标签的读正文判断归类（batch-poll 的 `ready_to_start` 只算依赖与未起，triage 由你定）
 3. 向用户展示批次计划：成员清单、依赖顺序、每个 issue 的实现路线与模型（**各附一句选择理由**，见第三步「实现路线与模型」）、跳过项及连带不启动的下游、并发上限（默认 3，用户可覆盖）
 4. **主动请求一次性前置授权**：向用户明确提出两项预批——本批所有 PR 的合并（含清尾轮立项的 PR）；清尾立项权限（对满足收尾节判据的缺陷类 follow-up，team-lead 可自行 /to-tickets 立项并在清尾轮跑到合并，被拒则清尾降级为收尾转呈）。连同流程将自动执行的动作边界（修改 triage 标签、PR 转 draft、在 Spec 发 QA 验收 comment；清尾授权之外不创建新 issue，gap 立项仍须用户中途指令）。这是本流程唯一的同步确认点；前置授权在此落入 team-lead 的 transcript，后续不再逐笔请示
 5. 用户确认后建账本（首条 append，记录计划裁决与所得授权，见「账本」），进入无人值守执行，不再中途请示
@@ -35,7 +35,7 @@ batch-poll 只产出 gh/git 事实与机械汇总，不做语义判断。取得�
 
 TeamCreate 建团队。并发上限指同时进行的 issue 数（处于任一阶段都算）：并发越高，每次合并引发的重审与并发请示越多。
 
-issue 的启动条件：全部 blocker 已合入 main。启动时将 issue assign 给自己作为认领标记（`gh issue edit <N> --add-assignee @me`）。worktree 一律从最新 main 创建，不做跨分支依赖；blocker 被搁置时下游不启动，归入收尾清单。
+issue 的启动条件：全部 blocker 已合入 main。启动时将 issue assign 给自己（`gh issue edit <N> --add-assignee @me`）。worktree 一律从最新 main 创建，不做跨分支依赖；blocker 被搁置时下游不启动，归入收尾清单。
 
 每个 issue 由三个阶段接力，每个阶段使用干净上下文（实现阶段可由 codex 后台任务而非 teammate 承担，见「实现路线与模型」）：
 
@@ -67,7 +67,7 @@ spawn 时按 [references/spawn-prompts.md](references/spawn-prompts.md) 的模�
 
    分拣结果 append 账本 `decision`；`--issues` 批次扩员后补一条带 scope 的行。轮中新增的候选转呈
 2. **在 Spec issue 发人工 QA 验收清单 comment，不关闭 Spec 本体**。清单按已合并子 issue（含清尾轮）组织：每项给 PR 链接与面向用户可感知行为的验收步骤（实际操作路径，不复读技术验收标准）；末尾列 needs-human 搁置项、跳过与未启动项、发现的缺口。纯 issue 列表批次没有共同 Spec 时，清单并入收尾汇报
-3. 解散团队，移除已合并 issue 的 assignee（认领标记只表示进行中，不作完成归属，残留会让 reopen 后的 issue 被投影成 In progress），删除全部 worktree 与本地分支（远端分支合并后自动删除）
+3. 解散团队，移除已合并 issue 的 assignee（避免 reopen 后仍显示为处理中），删除全部 worktree 与本地分支（远端分支合并后自动删除）
 4. 向用户汇报三份清单：已合并（issue 与 PR 对照）、needs-human 搁置（含争点）、跳过与未启动（含原因）；另附转呈事项：缺口立项建议、故障裁决记录、清尾分拣中转呈的候选，以及**聚合复盘**——从账本 `retrospective` 行与 handoff 目录聚合四类复盘候选（ADR / CONTEXT.md / CLAUDE.md / follow-up），一次性呈用户裁决。多数批次干净收敛，四类候选常为空；空是预期结果，照实呈报，无需为"没有候选"补叙
 5. 账本 append 一条 `closed` 收尾行（`bash .agents/skills/afk-team-workflow/scripts/ledger.sh <batch-id> closed`）——账本不删除，留作复盘源与审计，并供下次触发时的恢复探测器据此判定本批次已终态。批准后的复盘落地方式（写 ADR / 改 CONTEXT.md / 补 CLAUDE.md / 立 follow-up issue）不在此指定，由用户与后续会话决定
 
@@ -83,8 +83,8 @@ teammate 的一切暂停请示先到你这里。分四类处置：
 
 1. **故障类**（bot 报错、quota 耗尽、长时间无响应）：自行裁决，不升级用户。按 /pr-ai-review-loop 故障节的建议重试一次；仍失败则本 PR 停用该 reviewer 并记录，收尾前可做一次补审尝试。即时 append 账本 `fault`（崩溃恢复需据此 replay），并纳入收尾汇报
 2. **已答复又被重复提出的意见**：同一主题已有 pushback 在案、又被同一 reviewer 重复提出——不算真冲突、不搁置：裁决维持 pushback，令 looper 回评引用在案结论后继续循环；浮现出值得升级 ADR 的原则则记入收尾转呈，不当场写 ADR
-3. **收敛类**（`round_estimate` ≥ 5 且每轮都是新出现的小意见、没有单一争点；或 looper 报连续 2 轮无实质收益）：先判断成因再选处置——①收益递减：剩余意见确无实质收益时，令 looper 逐条驳回留痕后走终核，超范围项记入 handoff 的 follow-up 候选；仍有实质意见则令其继续；②注意力漂移：令 looper 把本轮修复交由子代理在干净上下文中执行，自己继续负责轮询；③防御堆积：令 looper 从严执行可达性门槛——指不出触发路径的防御类意见一律驳回，指得出的照常修复；驳回项按 follow-up 候选记入 handoff，交清尾轮分拣；④issue 拆分过粗：按第 4 类的搁置流程处置（含移除 assignee 取消认领）并转呈。裁决 append 账本 `decision`
-4. **reviewer 真实冲突 / 业务取舍**：不选边，按 needs-human 搁置：PR 转 draft（draft 下 CodeRabbit 不审，冻结循环消除重审噪音）、issue 改 `ready-for-human` 并移除 assignee（取消认领，交还人工）、PR 评论写明争点与双方立场、teammate 退役并清理 worktree（分支与 PR 留在远端待人工接手）、append 账本 `shelve`（含争点）并归入收尾清单
+3. **收敛类**（`round_estimate` ≥ 5 且每轮都是新出现的小意见、没有单一争点；或 looper 报连续 2 轮无实质收益）：先判断成因再选处置——①收益递减：剩余意见确无实质收益时，令 looper 逐条驳回留痕后走终核，超范围项记入 handoff 的 follow-up 候选；仍有实质意见则令其继续；②注意力漂移：令 looper 把本轮修复交由子代理在干净上下文中执行，自己继续负责轮询；③防御堆积：令 looper 从严执行可达性门槛——指不出触发路径的防御类意见一律驳回，指得出的照常修复；驳回项按 follow-up 候选记入 handoff，交清尾轮分拣；④issue 拆分过粗：按第 4 类的搁置流程处置并转呈。裁决 append 账本 `decision`
+4. **reviewer 真实冲突 / 业务取舍**：不选边，按 needs-human 搁置：PR 转 draft（draft 下 CodeRabbit 不审，冻结循环消除重审噪音）、issue 改 `ready-for-human` 并移除 assignee、PR 评论写明争点与双方立场、teammate 退役并清理 worktree（分支与 PR 留在远端待人工接手）、append 账本 `shelve`（含争点）并归入收尾清单
 
 ## 健康检查与替补
 

--- a/.agents/skills/afk-team-workflow/SKILL.md
+++ b/.agents/skills/afk-team-workflow/SKILL.md
@@ -35,7 +35,7 @@ batch-poll 只产出 gh/git 事实与机械汇总，不做语义判断。取得�
 
 TeamCreate 建团队。并发上限指同时进行的 issue 数（处于任一阶段都算）：并发越高，每次合并引发的重审与并发请示越多。
 
-issue 的启动条件：全部 blocker 已合入 main。worktree 一律从最新 main 创建，不做跨分支依赖；blocker 被搁置时下游不启动，归入收尾清单。
+issue 的启动条件：全部 blocker 已合入 main。启动时将 issue assign 给自己作为认领标记（`gh issue edit <N> --add-assignee @me`）。worktree 一律从最新 main 创建，不做跨分支依赖；blocker 被搁置时下游不启动，归入收尾清单。
 
 每个 issue 由三个阶段接力，每个阶段使用干净上下文（实现阶段可由 codex 后台任务而非 teammate 承担，见「实现路线与模型」）：
 
@@ -84,7 +84,7 @@ teammate 的一切暂停请示先到你这里。分四类处置：
 1. **故障类**（bot 报错、quota 耗尽、长时间无响应）：自行裁决，不升级用户。按 /pr-ai-review-loop 故障节的建议重试一次；仍失败则本 PR 停用该 reviewer 并记录，收尾前可做一次补审尝试。即时 append 账本 `fault`（崩溃恢复需据此 replay），并纳入收尾汇报
 2. **已答复又被重复提出的意见**：同一主题已有 pushback 在案、又被同一 reviewer 重复提出——不算真冲突、不搁置：裁决维持 pushback，令 looper 回评引用在案结论后继续循环；浮现出值得升级 ADR 的原则则记入收尾转呈，不当场写 ADR
 3. **收敛类**（`round_estimate` ≥ 5 且每轮都是新出现的小意见、没有单一争点；或 looper 报连续 2 轮无实质收益）：先判断成因再选处置——①收益递减：剩余意见确无实质收益时，令 looper 逐条驳回留痕后走终核，超范围项记入 handoff 的 follow-up 候选；仍有实质意见则令其继续；②注意力漂移：令 looper 把本轮修复交由子代理在干净上下文中执行，自己继续负责轮询；③防御堆积：令 looper 从严执行可达性门槛——指不出触发路径的防御类意见一律驳回，指得出的照常修复；驳回项按 follow-up 候选记入 handoff，交清尾轮分拣；④issue 拆分过粗：按 needs-human 搁置并转呈。裁决 append 账本 `decision`
-4. **reviewer 真实冲突 / 业务取舍**：不选边，按 needs-human 搁置：PR 转 draft（draft 下 CodeRabbit 不审，冻结循环消除重审噪音）、issue 改 `ready-for-human`、PR 评论写明争点与双方立场、teammate 退役并清理 worktree（分支与 PR 留在远端待人工接手）、append 账本 `shelve`（含争点）并归入收尾清单
+4. **reviewer 真实冲突 / 业务取舍**：不选边，按 needs-human 搁置：PR 转 draft（draft 下 CodeRabbit 不审，冻结循环消除重审噪音）、issue 改 `ready-for-human` 并移除 assignee（取消认领，交还人工）、PR 评论写明争点与双方立场、teammate 退役并清理 worktree（分支与 PR 留在远端待人工接手）、append 账本 `shelve`（含争点）并归入收尾清单
 
 ## 健康检查与替补
 

--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -1,7 +1,7 @@
 name: project-status-sync
 
-# org Project 看板 Status 单向派生：labels/assignee/linked PR/closed → Status。
-# 事件驱动单 issue 投影 + 每日全量对账兜底；规则见 docs/agents/triage-labels.md。
+# 同步 org Project 看板的 Status 字段：由 triage 标签、assignee、关联 PR、开闭状态单向派生。
+# issue/PR 事件触发单 issue 同步，每日定时全量对账；规则实现在 scripts/project_status_sync.py。
 on:
   issues:
     types: [opened, reopened, closed, labeled, unlabeled, assigned, unassigned]

--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -8,35 +8,45 @@ on:
   # 用 pull_request_target 而非 pull_request：workflow 与脚本都取 base 分支版本执行，
   # PR 分支的代码接触不到 PROJECT_STATUS_SYNC_TOKEN
   pull_request_target:
-    types: [opened, closed, reopened, ready_for_review, edited]
+    types: [opened, closed, reopened, ready_for_review, converted_to_draft, edited]
   schedule:
     - cron: "30 21 * * *" # 北京时间 05:30 全量对账
   workflow_dispatch:
 
 concurrency:
-  # issue 与 PR 编号各自独立，group 含事件类型避免同号跨类型互相取消
-  group: project-status-sync-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number || 'all' }}
+  # 全量对账（schedule / dispatch / PR body 编辑）共用一个 group 串行；
+  # 单实体运行按事件类型+编号分组，issue 与 PR 同号互不取消
+  group: project-status-sync-${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.action == 'edited') && 'all' || format('{0}-{1}', github.event_name, github.event.issue.number || github.event.pull_request.number) }}
   cancel-in-progress: true
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Dependabot 触发的运行拿不到仓库 Actions secrets
     if: github.actor != 'dependabot[bot]'
     steps:
+      # pull_request_target 的默认 checkout 是 PR 的 base 分支，而 base 可以是任意分支；
+      # 钉死默认分支，token 只与默认分支上的脚本同场
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
       - name: Sync project status
         env:
           GH_TOKEN: ${{ secrets.PROJECT_STATUS_SYNC_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          case "${{ github.event_name }}" in
-            issues) python3 scripts/project_status_sync.py --issue "${{ github.event.issue.number }}" ;;
+          case "$EVENT_NAME" in
+            issues) python3 scripts/project_status_sync.py --issue "$ISSUE_NUMBER" ;;
             pull_request_target)
               # body 编辑可能移除 closing reference，当前引用列表看不到被移除的 issue，改跑全量对账
-              if [ "${{ github.event.action }}" = "edited" ]; then
+              if [ "$EVENT_ACTION" = "edited" ]; then
                 python3 scripts/project_status_sync.py --all
               else
-                python3 scripts/project_status_sync.py --pr "${{ github.event.pull_request.number }}"
+                python3 scripts/project_status_sync.py --pr "$PR_NUMBER"
               fi ;;
             *) python3 scripts/project_status_sync.py --all ;;
           esac

--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -1,0 +1,33 @@
+name: project-status-sync
+
+# org Project 看板 Status 单向派生：labels/assignee/linked PR/closed → Status。
+# 事件驱动单 issue 投影 + 每日全量对账兜底；规则见 docs/agents/triage-labels.md。
+on:
+  issues:
+    types: [opened, reopened, closed, labeled, unlabeled, assigned, unassigned]
+  pull_request:
+    types: [opened, closed, reopened, ready_for_review, edited]
+  schedule:
+    - cron: "30 21 * * *" # 北京时间 05:30 全量对账
+  workflow_dispatch:
+
+concurrency:
+  group: project-status-sync-${{ github.event.issue.number || github.event.pull_request.number || 'all' }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    # fork PR 拿不到 secrets；本仓库 PR 均为同仓分支
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v7
+      - name: Sync project status
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_STATUS_SYNC_TOKEN }}
+        run: |
+          case "${{ github.event_name }}" in
+            issues) python3 scripts/project_status_sync.py --issue "${{ github.event.issue.number }}" ;;
+            pull_request) python3 scripts/project_status_sync.py --pr "${{ github.event.pull_request.number }}" ;;
+            *) python3 scripts/project_status_sync.py --all ;;
+          esac

--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -5,21 +5,24 @@ name: project-status-sync
 on:
   issues:
     types: [opened, reopened, closed, labeled, unlabeled, assigned, unassigned]
-  pull_request:
+  # 用 pull_request_target 而非 pull_request：workflow 与脚本都取 base 分支版本执行，
+  # PR 分支的代码接触不到 PROJECT_STATUS_SYNC_TOKEN
+  pull_request_target:
     types: [opened, closed, reopened, ready_for_review, edited]
   schedule:
     - cron: "30 21 * * *" # 北京时间 05:30 全量对账
   workflow_dispatch:
 
 concurrency:
-  group: project-status-sync-${{ github.event.issue.number || github.event.pull_request.number || 'all' }}
+  # issue 与 PR 编号各自独立，group 含事件类型避免同号跨类型互相取消
+  group: project-status-sync-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number || 'all' }}
   cancel-in-progress: true
 
 jobs:
   sync:
     runs-on: ubuntu-latest
-    # fork PR 拿不到 secrets；本仓库 PR 均为同仓分支
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # Dependabot 触发的运行拿不到仓库 Actions secrets
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v7
       - name: Sync project status
@@ -28,6 +31,12 @@ jobs:
         run: |
           case "${{ github.event_name }}" in
             issues) python3 scripts/project_status_sync.py --issue "${{ github.event.issue.number }}" ;;
-            pull_request) python3 scripts/project_status_sync.py --pr "${{ github.event.pull_request.number }}" ;;
+            pull_request_target)
+              # body 编辑可能移除 closing reference，当前引用列表看不到被移除的 issue，改跑全量对账
+              if [ "${{ github.event.action }}" = "edited" ]; then
+                python3 scripts/project_status_sync.py --all
+              else
+                python3 scripts/project_status_sync.py --pr "${{ github.event.pull_request.number }}"
+              fi ;;
             *) python3 scripts/project_status_sync.py --all ;;
           esac

--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     steps:
       # pull_request_target 的默认 checkout 是 PR 的 base 分支，而 base 可以是任意分支；
-      # 钉死默认分支，token 只与默认分支上的脚本同场
+      # 固定为默认分支，避免在持有 token 的环境中执行其他分支的脚本
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -37,7 +37,7 @@ gh api repos/{owner}/{repo}/issues/<父编号>/sub_issues -F sub_issue_id=$sub_i
 
 `to-tickets` 拆分 Spec 时，每个 issue 创建后都要补这两步（标题尾缀在创建时直接写入标题）。
 
-## 认领（claim）
+## 认领
 
 - 开始处理某个 issue 时，先将它 assign 给自己：`gh issue edit <n> --add-assignee @me`。triage 标签保持不变
 - 检索可认领的 issue 时排除已被认领的：`gh issue list --label ready-for-agent --state open --search "no:assignee"`

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -37,11 +37,10 @@ gh api repos/{owner}/{repo}/issues/<父编号>/sub_issues -F sub_issue_id=$sub_i
 
 `to-tickets` 拆分 Spec 时，每个 issue 创建后都要补这两步（标题尾缀在创建时直接写入标题）。
 
-## 派活（dispatch）
+## 认领（claim）
 
-- 派活时 assign 给自己：`gh issue edit <n> --add-assignee @me`；`ready-for-*` 标签保留不摘
-- 挑活查询加 `no:assignee` 防重复派活：`gh issue list --label ready-for-agent --state open --search "no:assignee"`
-- assignee 是看板 In progress 列的判定信号；PR 开出后该 issue 自动进 In review，合并关闭后进 Done（派生规则见 `triage-labels.md`）
+- 开始处理某个 issue 时，先将它 assign 给自己：`gh issue edit <n> --add-assignee @me`。triage 标签保持不变
+- 检索可认领的 issue 时排除已被认领的：`gh issue list --label ready-for-agent --state open --search "no:assignee"`
 
 ## When a skill says "publish to the issue tracker"
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -37,6 +37,12 @@ gh api repos/{owner}/{repo}/issues/<父编号>/sub_issues -F sub_issue_id=$sub_i
 
 `to-tickets` 拆分 Spec 时，每个 issue 创建后都要补这两步（标题尾缀在创建时直接写入标题）。
 
+## 派活（dispatch）
+
+- 派活时 assign 给自己：`gh issue edit <n> --add-assignee @me`；`ready-for-*` 标签保留不摘
+- 挑活查询加 `no:assignee` 防重复派活：`gh issue list --label ready-for-agent --state open --search "no:assignee"`
+- assignee 是看板 In progress 列的判定信号；PR 开出后该 issue 自动进 In review，合并关闭后进 Done（派生规则见 `triage-labels.md`）
+
 ## When a skill says "publish to the issue tracker"
 
 Create a GitHub issue.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -14,17 +14,3 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
 Edit the right-hand column to match whatever vocabulary you actually use.
-
-## 看板投影
-
-[org Project「ArcReel」](https://github.com/orgs/ArcReel/projects/2)的 Status 字段由 repo 侧事实**单向派生**，板上拖卡不作数（事件触发 + 每日对账纠正，实现在 `scripts/project_status_sync.py` 与 `.github/workflows/project-status-sync.yml`）。派生优先级从高到低：
-
-| 条件                                  | Status                                    |
-| ------------------------------------- | ----------------------------------------- |
-| 带 `Spec` / `parked` 标签             | 不占列（Status 清空，主视图 filter 排除） |
-| issue 已关闭                          | Done                                      |
-| 存在 open 的 closing PR               | In review                                 |
-| 有 assignee                           | In progress                               |
-| `ready-for-agent` / `ready-for-human` | Ready · agent / Ready · human             |
-| `needs-info`                          | Needs info                                |
-| `needs-triage` 或无任何匹配（兜底）   | Inbox                                     |

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -14,3 +14,17 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
 Edit the right-hand column to match whatever vocabulary you actually use.
+
+## 看板投影
+
+[org Project「ArcReel」](https://github.com/orgs/ArcReel/projects/2)的 Status 字段由 repo 侧事实**单向派生**，板上拖卡不作数（事件触发 + 每日对账纠正，实现在 `scripts/project_status_sync.py` 与 `.github/workflows/project-status-sync.yml`）。派生优先级从高到低：
+
+| 条件                                  | Status                                    |
+| ------------------------------------- | ----------------------------------------- |
+| 带 `Spec` / `parked` 标签             | 不占列（Status 清空，主视图 filter 排除） |
+| issue 已关闭                          | Done                                      |
+| 存在 open 的 closing PR               | In review                                 |
+| 有 assignee                           | In progress                               |
+| `ready-for-agent` / `ready-for-human` | Ready · agent / Ready · human             |
+| `needs-info`                          | Needs info                                |
+| `needs-triage` 或无任何匹配（兜底）   | Inbox                                     |

--- a/scripts/project_status_sync.py
+++ b/scripts/project_status_sync.py
@@ -111,7 +111,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
       id state
       labels(first: 50) { nodes { name } }
       assignees(first: 1) { totalCount }
-      closedByPullRequestsReferences(first: 20, includeClosedPrs: true) { nodes { state } }
+      closedByPullRequestsReferences(first: 20) { nodes { state } }
       projectItems(first: 10, includeArchived: true) {
         nodes {
           id isArchived
@@ -195,9 +195,13 @@ query($org: String!, $projectNumber: Int!, $cursor: String) {
           content {
             ... on Issue {
               number state
+              repository { nameWithOwner }
               labels(first: 50) { nodes { name } }
               assignees(first: 1) { totalCount }
-              closedByPullRequestsReferences(first: 20, includeClosedPrs: true) { nodes { state } }
+              closedByPullRequestsReferences(first: 20) { nodes { state } }
+            }
+            ... on PullRequest {
+              repository { nameWithOwner }
             }
           }
         }
@@ -206,6 +210,31 @@ query($org: String!, $projectNumber: Int!, $cursor: String) {
   }
 }
 """
+
+
+OPEN_ISSUES_QUERY = """
+query($owner: String!, $repo: String!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    issues(states: OPEN, first: 100, after: $cursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes { number }
+    }
+  }
+}
+"""
+
+
+def _open_issue_numbers() -> set[int]:
+    numbers: set[int] = set()
+    cursor: str | None = None
+    while True:
+        data = gql(OPEN_ISSUES_QUERY, {"owner": OWNER, "repo": REPO, "cursor": cursor})
+        page = data["repository"]["issues"]
+        numbers.update(n["number"] for n in page["nodes"])
+        if not page["pageInfo"]["hasNextPage"]:
+            break
+        cursor = page["pageInfo"]["endCursor"]
+    return numbers
 
 
 def sync_all() -> None:
@@ -219,9 +248,15 @@ def sync_all() -> None:
             break
         cursor = page["pageInfo"]["endCursor"]
 
+    repo_full = f"{OWNER}/{REPO}"
+    board_numbers: set[int] = set()
     parts: list[str] = []
     changed = deleted = 0
     for item in items:
+        content = item.get("content") or {}
+        # 本仓库之外的 item（含 DraftIssue）不做投影也不清除
+        if (content.get("repository") or {}).get("nameWithOwner") != repo_full:
+            continue
         if item["type"] == "PULL_REQUEST":
             # 看板不收 PR item，对账时清除误入项
             parts.append(
@@ -230,18 +265,24 @@ def sync_all() -> None:
             )
             deleted += 1
             continue
-        if item["type"] != "ISSUE":
-            continue
-        state, labels, has_assignee, has_open_pr = _issue_signals(item["content"])
+        board_numbers.add(content["number"])
+        state, labels, has_assignee, has_open_pr = _issue_signals(content)
         desired = derive_status(state, labels, has_assignee, has_open_pr)
         current = (item.get("status") or {}).get("name")
         if current != desired:
             parts.append(_set_status_part(item["id"], desired))
             changed += 1
-            print(f"#{item['content']['number']}: {current} -> {desired}")
+            print(f"#{content['number']}: {current} -> {desired}")
 
     _run_mutation_parts(parts)
-    print(f"对账完成：{len(items)} 个 item，纠正 {changed} 个 Status，清除 {deleted} 个 PR item")
+
+    # auto-add 或事件同步失败会让 open issue 缺席看板，对账时补入
+    missing = _open_issue_numbers() - board_numbers
+    for number in sorted(missing):
+        sync_issue(number)
+    print(
+        f"对账完成：{len(items)} 个 item，纠正 {changed} 个 Status，清除 {deleted} 个 PR item，补入 {len(missing)} 个 issue"
+    )
 
 
 def main() -> None:

--- a/scripts/project_status_sync.py
+++ b/scripts/project_status_sync.py
@@ -279,7 +279,7 @@ def sync_all() -> None:
 
     _run_mutation_parts(parts)
 
-    # auto-add 或事件同步失败会让 open issue 缺席看板，对账时补入
+    # auto-add 或事件同步失败时 open issue 可能不在看板上，对账时补入
     missing = _open_issue_numbers() - board_numbers
     for number in sorted(missing):
         sync_issue(number)

--- a/scripts/project_status_sync.py
+++ b/scripts/project_status_sync.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""org Project 看板 Status 单向同步。
+"""同步 org Project 看板的 Status 字段。
 
-真相源在 repo 侧（triage labels、assignee、linked PR、closed 状态），看板 Status 只是投影；
-板上拖卡不作数，由本脚本在事件触发或全量对账时纠正。派生规则见 docs/agents/triage-labels.md。
+Status 由 repo 侧状态（triage 标签、assignee、关联 PR、开闭状态）单向派生，
+派生规则见 derive_status。看板上的手动改动不保留，同步时按派生结果覆盖。
 
 用法：
     GH_TOKEN=<org Projects RW token> python3 scripts/project_status_sync.py --issue 123 [456 ...]
@@ -36,7 +36,7 @@ STATUS_OPTIONS = {
     "Done": "98236657",
 }
 
-# 不占列的 issue：上板但 Status 清空，主视图靠 filter 排除
+# 带这些标签的 issue 不参与状态流转：Status 置空，视图用 filter 排除
 OFF_BOARD_LABELS = {"Spec", "parked"}
 
 MUTATION_BATCH = 20
@@ -60,7 +60,7 @@ def gql(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
 
 
 def derive_status(state: str, labels: set[str], has_assignee: bool, has_open_closing_pr: bool) -> str | None:
-    """按优先级派生 Status；返回 None 表示清空（Spec/parked 不占列）。"""
+    """按优先级派生 Status；返回 None 表示置空。"""
     if labels & OFF_BOARD_LABELS:
         return None
     if state == "CLOSED":
@@ -138,7 +138,7 @@ def sync_issue(number: int) -> None:
         if state != "OPEN":
             print(f"#{number}: 已关闭且不在板上，跳过")
             return
-        # 内置 auto-add 有延迟/漏网时兜底补录
+        # 内置 auto-add 未覆盖时补充添加
         added = gql(
             "mutation($pid: ID!, $cid: ID!) {"
             " addProjectV2ItemById(input: {projectId: $pid, contentId: $cid}) { item { id } } }",
@@ -223,7 +223,7 @@ def sync_all() -> None:
     changed = deleted = 0
     for item in items:
         if item["type"] == "PULL_REQUEST":
-            # PR 不上板；auto-add 过滤外的漏网在对账时清除
+            # 看板不收 PR item，对账时清除误入项
             parts.append(
                 f'deleteProjectV2Item(input: {{projectId: "{PROJECT_ID}", itemId: "{item["id"]}"}})'
                 " { clientMutationId }"

--- a/scripts/project_status_sync.py
+++ b/scripts/project_status_sync.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""org Project 看板 Status 单向同步。
+
+真相源在 repo 侧（triage labels、assignee、linked PR、closed 状态），看板 Status 只是投影；
+板上拖卡不作数，由本脚本在事件触发或全量对账时纠正。派生规则见 docs/agents/triage-labels.md。
+
+用法：
+    GH_TOKEN=<org Projects RW token> python3 scripts/project_status_sync.py --issue 123 [456 ...]
+    GH_TOKEN=... python3 scripts/project_status_sync.py --pr 789
+    GH_TOKEN=... python3 scripts/project_status_sync.py --all
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+from typing import Any
+
+API = "https://api.github.com/graphql"
+OWNER = "ArcReel"
+REPO = "ArcReel"
+PROJECT_NUMBER = 2
+PROJECT_ID = "PVT_kwDOD3-zC84BQUFK"
+STATUS_FIELD_ID = "PVTSSF_lADOD3-zC84BQUFKzg-eFX8"
+
+STATUS_OPTIONS = {
+    "Inbox": "f75ad846",
+    "Needs info": "ad9eec1f",
+    "Ready · agent": "61e4505c",
+    "Ready · human": "22a5fcab",
+    "In progress": "47fc9ee4",
+    "In review": "df73e18b",
+    "Done": "98236657",
+}
+
+# 不占列的 issue：上板但 Status 清空，主视图靠 filter 排除
+OFF_BOARD_LABELS = {"Spec", "parked"}
+
+MUTATION_BATCH = 20
+
+
+def gql(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        sys.exit("GH_TOKEN 未设置")
+    payload = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = urllib.request.Request(
+        API,
+        data=payload,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req) as resp:
+        body: dict[str, Any] = json.load(resp)
+    if body.get("errors"):
+        raise RuntimeError(f"GraphQL 错误: {json.dumps(body['errors'], ensure_ascii=False)}")
+    return body["data"]
+
+
+def derive_status(state: str, labels: set[str], has_assignee: bool, has_open_closing_pr: bool) -> str | None:
+    """按优先级派生 Status；返回 None 表示清空（Spec/parked 不占列）。"""
+    if labels & OFF_BOARD_LABELS:
+        return None
+    if state == "CLOSED":
+        return "Done"
+    if has_open_closing_pr:
+        return "In review"
+    if has_assignee:
+        return "In progress"
+    if "ready-for-agent" in labels:
+        return "Ready · agent"
+    if "ready-for-human" in labels:
+        return "Ready · human"
+    if "needs-info" in labels:
+        return "Needs info"
+    return "Inbox"
+
+
+def _issue_signals(issue: dict[str, Any]) -> tuple[str, set[str], bool, bool]:
+    labels = {n["name"] for n in issue["labels"]["nodes"]}
+    has_assignee = issue["assignees"]["totalCount"] > 0
+    has_open_pr = any(n["state"] == "OPEN" for n in issue["closedByPullRequestsReferences"]["nodes"])
+    return issue["state"], labels, has_assignee, has_open_pr
+
+
+def _set_status_part(item_id: str, status: str | None) -> str:
+    if status is None:
+        return (
+            f'clearProjectV2ItemFieldValue(input: {{projectId: "{PROJECT_ID}", '
+            f'itemId: "{item_id}", fieldId: "{STATUS_FIELD_ID}"}}) {{ clientMutationId }}'
+        )
+    option_id = STATUS_OPTIONS[status]
+    return (
+        f'updateProjectV2ItemFieldValue(input: {{projectId: "{PROJECT_ID}", itemId: "{item_id}", '
+        f'fieldId: "{STATUS_FIELD_ID}", value: {{singleSelectOptionId: "{option_id}"}}}}) {{ clientMutationId }}'
+    )
+
+
+def _run_mutation_parts(parts: list[str]) -> None:
+    for start in range(0, len(parts), MUTATION_BATCH):
+        chunk = parts[start : start + MUTATION_BATCH]
+        gql("mutation { " + " ".join(f"m{i}: {p}" for i, p in enumerate(chunk)) + " }")
+
+
+ISSUE_QUERY = """
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      id state
+      labels(first: 50) { nodes { name } }
+      assignees(first: 1) { totalCount }
+      closedByPullRequestsReferences(first: 20, includeClosedPrs: true) { nodes { state } }
+      projectItems(first: 10, includeArchived: true) {
+        nodes {
+          id isArchived
+          project { id }
+          status: fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def sync_issue(number: int) -> None:
+    data = gql(ISSUE_QUERY, {"owner": OWNER, "repo": REPO, "number": number})
+    issue = data["repository"]["issue"]
+    state, labels, has_assignee, has_open_pr = _issue_signals(issue)
+    desired = derive_status(state, labels, has_assignee, has_open_pr)
+
+    item = next((n for n in issue["projectItems"]["nodes"] if n["project"]["id"] == PROJECT_ID), None)
+    if item is None:
+        if state != "OPEN":
+            print(f"#{number}: 已关闭且不在板上，跳过")
+            return
+        # 内置 auto-add 有延迟/漏网时兜底补录
+        added = gql(
+            "mutation($pid: ID!, $cid: ID!) {"
+            " addProjectV2ItemById(input: {projectId: $pid, contentId: $cid}) { item { id } } }",
+            {"pid": PROJECT_ID, "cid": issue["id"]},
+        )
+        item = {"id": added["addProjectV2ItemById"]["item"]["id"], "isArchived": False, "status": None}
+    elif item["isArchived"] and state == "OPEN":
+        gql(
+            "mutation($pid: ID!, $iid: ID!) {"
+            " unarchiveProjectV2Item(input: {projectId: $pid, itemId: $iid}) { item { id } } }",
+            {"pid": PROJECT_ID, "iid": item["id"]},
+        )
+
+    current = (item.get("status") or {}).get("name")
+    if current == desired:
+        print(f"#{number}: Status 已是 {desired}，无需变更")
+        return
+    _run_mutation_parts([_set_status_part(item["id"], desired)])
+    print(f"#{number}: {current} -> {desired}")
+
+
+PR_QUERY = """
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      closingIssuesReferences(first: 20) { nodes { number } }
+    }
+  }
+}
+"""
+
+
+def sync_pr(number: int) -> None:
+    data = gql(PR_QUERY, {"owner": OWNER, "repo": REPO, "number": number})
+    numbers = [n["number"] for n in data["repository"]["pullRequest"]["closingIssuesReferences"]["nodes"]]
+    if not numbers:
+        print(f"PR #{number}: 无 closing reference，跳过")
+        return
+    for n in numbers:
+        sync_issue(n)
+
+
+ALL_ITEMS_QUERY = """
+query($org: String!, $projectNumber: Int!, $cursor: String) {
+  organization(login: $org) {
+    projectV2(number: $projectNumber) {
+      items(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id type
+          status: fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+          content {
+            ... on Issue {
+              number state
+              labels(first: 50) { nodes { name } }
+              assignees(first: 1) { totalCount }
+              closedByPullRequestsReferences(first: 20, includeClosedPrs: true) { nodes { state } }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def sync_all() -> None:
+    items: list[dict[str, Any]] = []
+    cursor: str | None = None
+    while True:
+        data = gql(ALL_ITEMS_QUERY, {"org": OWNER, "projectNumber": PROJECT_NUMBER, "cursor": cursor})
+        page = data["organization"]["projectV2"]["items"]
+        items.extend(page["nodes"])
+        if not page["pageInfo"]["hasNextPage"]:
+            break
+        cursor = page["pageInfo"]["endCursor"]
+
+    parts: list[str] = []
+    changed = deleted = 0
+    for item in items:
+        if item["type"] == "PULL_REQUEST":
+            # PR 不上板；auto-add 过滤外的漏网在对账时清除
+            parts.append(
+                f'deleteProjectV2Item(input: {{projectId: "{PROJECT_ID}", itemId: "{item["id"]}"}})'
+                " { clientMutationId }"
+            )
+            deleted += 1
+            continue
+        if item["type"] != "ISSUE":
+            continue
+        state, labels, has_assignee, has_open_pr = _issue_signals(item["content"])
+        desired = derive_status(state, labels, has_assignee, has_open_pr)
+        current = (item.get("status") or {}).get("name")
+        if current != desired:
+            parts.append(_set_status_part(item["id"], desired))
+            changed += 1
+            print(f"#{item['content']['number']}: {current} -> {desired}")
+
+    _run_mutation_parts(parts)
+    print(f"对账完成：{len(items)} 个 item，纠正 {changed} 个 Status，清除 {deleted} 个 PR item")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--issue", type=int, nargs="+", help="同步指定 issue")
+    group.add_argument("--pr", type=int, help="同步该 PR closing reference 指向的 issue")
+    group.add_argument("--all", action="store_true", help="全量对账")
+    args = parser.parse_args()
+
+    if args.all:
+        sync_all()
+    elif args.pr is not None:
+        sync_pr(args.pr)
+    else:
+        for number in args.issue:
+            sync_issue(number)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/project_status_sync.py
+++ b/scripts/project_status_sync.py
@@ -52,7 +52,7 @@ def gql(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
         data=payload,
         headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
     )
-    with urllib.request.urlopen(req) as resp:
+    with urllib.request.urlopen(req, timeout=30) as resp:
         body: dict[str, Any] = json.load(resp)
     if body.get("errors"):
         raise RuntimeError(f"GraphQL 错误: {json.dumps(body['errors'], ensure_ascii=False)}")
@@ -81,7 +81,10 @@ def derive_status(state: str, labels: set[str], has_assignee: bool, has_open_clo
 def _issue_signals(issue: dict[str, Any]) -> tuple[str, set[str], bool, bool]:
     labels = {n["name"] for n in issue["labels"]["nodes"]}
     has_assignee = issue["assignees"]["totalCount"] > 0
-    has_open_pr = any(n["state"] == "OPEN" for n in issue["closedByPullRequestsReferences"]["nodes"])
+    # draft PR 尚未进入审阅，不计入 In review 信号
+    has_open_pr = any(
+        n["state"] == "OPEN" and not n["isDraft"] for n in issue["closedByPullRequestsReferences"]["nodes"]
+    )
     return issue["state"], labels, has_assignee, has_open_pr
 
 
@@ -111,7 +114,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
       id state
       labels(first: 50) { nodes { name } }
       assignees(first: 1) { totalCount }
-      closedByPullRequestsReferences(first: 20) { nodes { state } }
+      closedByPullRequestsReferences(first: 20) { nodes { state isDraft } }
       projectItems(first: 10, includeArchived: true) {
         nodes {
           id isArchived
@@ -198,7 +201,7 @@ query($org: String!, $projectNumber: Int!, $cursor: String) {
               repository { nameWithOwner }
               labels(first: 50) { nodes { name } }
               assignees(first: 1) { totalCount }
-              closedByPullRequestsReferences(first: 20) { nodes { state } }
+              closedByPullRequestsReferences(first: 20) { nodes { state isDraft } }
             }
             ... on PullRequest {
               repository { nameWithOwner }

--- a/tests/scripts/test_project_status_sync.py
+++ b/tests/scripts/test_project_status_sync.py
@@ -1,0 +1,28 @@
+import pytest
+
+from scripts.project_status_sync import derive_status
+
+
+@pytest.mark.parametrize(
+    ("state", "labels", "has_assignee", "has_open_closing_pr", "expected"),
+    [
+        # Spec / parked 置空，优先于其余一切信号
+        ("OPEN", {"Spec", "ready-for-agent"}, True, True, None),
+        ("CLOSED", {"parked"}, False, False, None),
+        # closed → Done，优先于 open PR 与 assignee
+        ("CLOSED", {"needs-triage"}, True, True, "Done"),
+        # open closing PR → In review，优先于 assignee 与 ready 标签
+        ("OPEN", {"ready-for-agent"}, True, True, "In review"),
+        # assignee → In progress，优先于 ready / needs-info 标签
+        ("OPEN", {"ready-for-human", "needs-info"}, True, False, "In progress"),
+        # ready-for-agent 优先于 ready-for-human，ready-for-human 优先于 needs-info
+        ("OPEN", {"ready-for-agent", "ready-for-human"}, False, False, "Ready · agent"),
+        ("OPEN", {"ready-for-human", "needs-info"}, False, False, "Ready · human"),
+        ("OPEN", {"needs-info", "needs-triage"}, False, False, "Needs info"),
+        # needs-triage 与无标签一律兜底 Inbox
+        ("OPEN", {"needs-triage"}, False, False, "Inbox"),
+        ("OPEN", set(), False, False, "Inbox"),
+    ],
+)
+def test_derive_status_priority(state, labels, has_assignee, has_open_closing_pr, expected):
+    assert derive_status(state, labels, has_assignee, has_open_closing_pr) == expected


### PR DESCRIPTION
## 背景

决议见 #1515：org Project 看板定位为个人驾驶舱，Status 字段不再手工维护，由 repo 侧状态单向派生。

## 改动

- `scripts/project_status_sync.py`：Status 派生同步脚本，三种模式——`--issue`（事件驱动单 issue）、`--pr`（按 closing reference 定位 issue）、`--all`（全量对账，并清除误入的 PR item）。派生优先级：closed → Done；open closing PR → In review；有 assignee → In progress；`ready-for-*` → Ready · agent/human；`needs-info` → Needs info；其余 → Inbox；`Spec`/`parked` 置空 Status，不参与状态流转
- `.github/workflows/project-status-sync.yml`：issues / pull_request 事件触发 + 每日 05:30（北京时间）全量对账 + workflow_dispatch；凭证为 `PROJECT_STATUS_SYNC_TOKEN` secret（org 级 fine-grained PAT，仅 Projects 读写）
- `docs/agents/issue-tracker.md`：新增「认领」一节——开始处理 issue 时 assign 给自己，检索可认领 issue 时用 `no:assignee` 排除已认领项
- `.agents/skills/afk-team-workflow/SKILL.md`：issue 启动时认领，搁置为 needs-human 时取消认领

## 依赖

合并前需在 repo secrets 配置 `PROJECT_STATUS_SYNC_TOKEN`，否则 workflow 首跑失败（不影响其他 CI）。

Part of #1515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增项目状态自动同步，支持响应 Issue、PR 事件及定时执行。
  - 自动维护项目看板中的状态、归档项目及关联条目。
- **改进**
  - Issue 认领规则更加明确，已被认领的 Issue 将自动跳过。
  - 处理过程中新增认领标记，拆分过粗或存在冲突的 Issue 可转人工处理并解除认领。
- **文档**
  - 补充 Issue 认领流程与筛选规则说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->