### PR TITLE
docs(agents): 补全注释规范、发布约定与 AI 审查流程现状

### DIFF
--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -101,7 +101,7 @@ GitHub code scanning 两家(quality / security)的评论并入同一批,处置�
 
 - **某家 reviewer(含 CodeQL 分析)超过 25 分钟未响应**:bot 可能服务异常或配额已满,暂停说明现状。Gemini fix-up 顺延导致的"未审"不算无响应——那是设计内跳过
 - **bot 报错**(如 "Internal error"、"Token limit exceeded"):贴出错误内容,按 reviewers.md 该家的触发约束询问是否重跑
-- **`quota_alerts` 非空**:bot 留下了 quota / rate limit 报错,贴出 `body_head`,询问停用该家继续其他家,还是等 quota 恢复后再 push
+- **`quota_alerts` 非空**:reviewers.md 对该家定义了专项配额处置的(如 CodeRabbit「配额」段)按其规则自行处置,不暂停;其余家贴出 `body_head`,询问停用该家继续其他家,还是等 quota 恢复后再 push
 - **`codeql_checks.failing` 非空**(失败态集合见 poll.sh header `checks_failing` 条):分析失败,alerts 数据停留在上次成功分析,不能做终核;询问是否重跑失败的 workflow
 - **`security_alerts.available == false`**:贴出 `unavailable_hint`,按 reviewers.md「仓库未接入」段判别权限问题与未接入——两种情形都需用户确认,不得自动跳过 security 门槛
 - **`gh` 401/403**:请用户运行 `gh auth refresh -s repo`

--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -101,7 +101,7 @@ GitHub code scanning 两家(quality / security)的评论并入同一批,处置�
 
 - **某家 reviewer(含 CodeQL 分析)超过 25 分钟未响应**:bot 可能服务异常或配额已满,暂停说明现状。Gemini fix-up 顺延导致的"未审"不算无响应——那是设计内跳过
 - **bot 报错**(如 "Internal error"、"Token limit exceeded"):贴出错误内容,按 reviewers.md 该家的触发约束询问是否重跑
-- **`quota_alerts` 非空**:reviewers.md 该家有专项配额处置段的(如 CodeRabbit)按其规则自行处置,不暂停;其余家贴出 `body_head`,询问停用该家继续其他家,还是等 quota 恢复后再 push
+- **`quota_alerts` 非空**:alert 之后该家已有成功审查(更晚的 review 或 walkthrough 更新)的视为已恢复,忽略残留 banner;真实受阻时,reviewers.md 该家有专项配额处置段的(如 CodeRabbit)按其规则自行处置,不暂停;其余家贴出 `body_head`,询问停用该家继续其他家,还是等 quota 恢复后再 push
 - **`codeql_checks.failing` 非空**(失败态集合见 poll.sh header `checks_failing` 条):分析失败,alerts 数据停留在上次成功分析,不能做终核;询问是否重跑失败的 workflow
 - **`security_alerts.available == false`**:贴出 `unavailable_hint`,按 reviewers.md「仓库未接入」段判别权限问题与未接入——两种情形都需用户确认,不得自动跳过 security 门槛
 - **`gh` 401/403**:请用户运行 `gh auth refresh -s repo`

--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -101,7 +101,7 @@ GitHub code scanning 两家(quality / security)的评论并入同一批,处置�
 
 - **某家 reviewer(含 CodeQL 分析)超过 25 分钟未响应**:bot 可能服务异常或配额已满,暂停说明现状。Gemini fix-up 顺延导致的"未审"不算无响应——那是设计内跳过
 - **bot 报错**(如 "Internal error"、"Token limit exceeded"):贴出错误内容,按 reviewers.md 该家的触发约束询问是否重跑
-- **`quota_alerts` 非空**:reviewers.md 对该家定义了专项配额处置的(如 CodeRabbit「配额」段)按其规则自行处置,不暂停;其余家贴出 `body_head`,询问停用该家继续其他家,还是等 quota 恢复后再 push
+- **`quota_alerts` 非空**:reviewers.md 该家有专项配额处置段的(如 CodeRabbit)按其规则自行处置,不暂停;其余家贴出 `body_head`,询问停用该家继续其他家,还是等 quota 恢复后再 push
 - **`codeql_checks.failing` 非空**(失败态集合见 poll.sh header `checks_failing` 条):分析失败,alerts 数据停留在上次成功分析,不能做终核;询问是否重跑失败的 workflow
 - **`security_alerts.available == false`**:贴出 `unavailable_hint`,按 reviewers.md「仓库未接入」段判别权限问题与未接入——两种情形都需用户确认,不得自动跳过 security 门槛
 - **`gh` 401/403**:请用户运行 `gh auth refresh -s repo`

--- a/.agents/skills/pr-ai-review-loop/references/reviewers.md
+++ b/.agents/skills/pr-ai-review-loop/references/reviewers.md
@@ -7,7 +7,7 @@
 - **本轮新评论**:索引中 `is_new == true` 的条目(inline 走 `inline_new_by_user`,评论走 `comments_new`)。口径与陷阱见 poll.sh PITFALL 2
 - **Acknowledgment 例外**:`is_ack == true` 的条目是 reviewer 对上一次修复或 inline 回复的确认,一律**不算** actionable;review state 为 `APPROVED` 也不算
 - **flag 以正文为准**:索引 flags(`is_ack` / `cr_markers` / `has_pass_marker` / `severity_alt`)是脚本解析结果,预览观感与 flag 冲突时用 `query.sh details` 取全文核实,以正文为准
-- **unacked 兜底假阳性**:终核 unacked 非空时逐条核对,对应修复已落地或回复为在案 pushback 的不算遗漏。快照不含非 bot 的 inline 回复,核对回复串用 `gh api repos/<owner>/<repo>/pulls/<pr>/comments` 按 `in_reply_to_id` 关联
+- **unacked 兜底假阳性**:终核 unacked 非空时逐条核对,对应修复已落地或回复为在案 pushback 的不算遗漏。快照不含非 bot 的 inline 回复,核对回复串用 `gh api --paginate repos/<owner>/<repo>/pulls/<pr>/comments` 按 `in_reply_to_id` 关联
 - **fix-up 顺延(仅 Gemini)**:Gemini 对上一已审 HEAD 已通过,且其后的 push 全为 fix-up 形状(nit、format、typo、单字段调整、小 bug 修复)时,沿用该通过结论参与目标判定,不触发重审;CodeRabbit 与 Codex 均以实际审过最终 HEAD 为目标状态。**「上一已审 HEAD」指 Gemini 最近一次实际审过的 commit,不是最近一次通过的 commit**——若最近审的 HEAD 未通过,或 `query.sh unacked gemini-code-assist[bot]` 仍有未解决评论,均不得顺延
 - **触发去重**:同一 HEAD 上每种触发命令只发一次。在 `own_trigger_comments` 中按 `command` 字段取该命令最大 `createdAt`,晚于 `last_push_at` 即视为本轮已触发,跳过(`@coderabbitai resume` 例外:以 CodeRabbit 节的 `updated_at` 口径为准)。发触发命令时只写命令本身,且命令必须在评论最开头(匹配细则见 poll.sh PITFALL 4)
 - **纯指标类 bot 不纳入循环**:`codecov[bot]` 等纯指标类 bot 没有意见可实施,也没有等待或重审的概念

--- a/.agents/skills/pr-ai-review-loop/references/reviewers.md
+++ b/.agents/skills/pr-ai-review-loop/references/reviewers.md
@@ -7,7 +7,7 @@
 - **本轮新评论**:索引中 `is_new == true` 的条目(inline 走 `inline_new_by_user`,评论走 `comments_new`)。口径与陷阱见 poll.sh PITFALL 2
 - **Acknowledgment 例外**:`is_ack == true` 的条目是 reviewer 对上一次修复或 inline 回复的确认,一律**不算** actionable;review state 为 `APPROVED` 也不算
 - **flag 以正文为准**:索引 flags(`is_ack` / `cr_markers` / `has_pass_marker` / `severity_alt`)是脚本解析结果,预览观感与 flag 冲突时用 `query.sh details` 取全文核实,以正文为准
-- **unacked 兜底假阳性**:终核 unacked 非空时先逐条核对自己的回复记录与 bot 的后续回复串,确认无对应修复记录或回复时才视为遗漏
+- **unacked 兜底假阳性**:终核 unacked 非空时逐条核对——对应修复已落地,或回复是在案 pushback,均不算遗漏;仅有承诺性回复而修复未落地的仍算遗漏
 - **fix-up 顺延(仅 Gemini)**:Gemini 对上一已审 HEAD 已通过,且其后的 push 全为 fix-up 形状(nit、format、typo、单字段调整、小 bug 修复)时,沿用该通过结论参与目标判定,不触发重审;CodeRabbit 与 Codex 均以实际审过最终 HEAD 为目标状态。**「上一已审 HEAD」指 Gemini 最近一次实际审过的 commit,不是最近一次通过的 commit**——若最近审的 HEAD 未通过,或 `query.sh unacked gemini-code-assist[bot]` 仍有未解决评论,均不得顺延
 - **触发去重**:同一 HEAD 上每种触发命令只发一次。在 `own_trigger_comments` 中按 `command` 字段取该命令最大 `createdAt`,晚于 `last_push_at` 即视为本轮已触发,跳过(`@coderabbitai resume` 例外:以 CodeRabbit 节的 `updated_at` 口径为准)。发触发命令时只写命令本身,且命令必须在评论最开头(匹配细则见 poll.sh PITFALL 4)
 - **纯指标类 bot 不纳入循环**:`codecov[bot]` 等纯指标类 bot 没有意见可实施,也没有等待或重审的概念
@@ -43,7 +43,7 @@
 
 ## Gemini Code Assist
 
-**现状**:Gemini Code Assist 消费者版已停止服务,PR 上会出现官方 CAUTION 通知(「The consumer version of Gemini Code Assist on GitHub has been sunset. All code review activity has officially ceased.」)。命中该通知即按 SKILL.md 的能力证伪自裁决处理:本 PR 不参审、不再触发,无需查证历史。以下规则在其服务可用时适用。
+**现状**:Gemini Code Assist 消费者版已停止服务,PR 上会出现官方 CAUTION 通知(「The consumer version of Gemini Code Assist on GitHub has been sunset. All code review activity has officially ceased.」)。命中该通知即按 SKILL.md 的能力证伪自裁决处理:本 PR 按不参审处理、不再触发,无需另行查证服务状态;通知出现前已收集的 Gemini actionable 评论仍按目标状态处置。以下规则在其服务可用时适用。
 
 **触发**(按 `pr_created_at` 与 `gemini.reviews` 判别,均受触发去重约束):
 

--- a/.agents/skills/pr-ai-review-loop/references/reviewers.md
+++ b/.agents/skills/pr-ai-review-loop/references/reviewers.md
@@ -7,7 +7,7 @@
 - **本轮新评论**:索引中 `is_new == true` 的条目(inline 走 `inline_new_by_user`,评论走 `comments_new`)。口径与陷阱见 poll.sh PITFALL 2
 - **Acknowledgment 例外**:`is_ack == true` 的条目是 reviewer 对上一次修复或 inline 回复的确认,一律**不算** actionable;review state 为 `APPROVED` 也不算
 - **flag 以正文为准**:索引 flags(`is_ack` / `cr_markers` / `has_pass_marker` / `severity_alt`)是脚本解析结果,预览观感与 flag 冲突时用 `query.sh details` 取全文核实,以正文为准
-- **unacked 兜底假阳性**:终核 unacked 非空时逐条核对——对应修复已落地,或回复是在案 pushback,均不算遗漏;仅有承诺性回复而修复未落地的仍算遗漏
+- **unacked 兜底假阳性**:终核 unacked 非空时逐条核对,对应修复已落地或回复为在案 pushback 的不算遗漏
 - **fix-up 顺延(仅 Gemini)**:Gemini 对上一已审 HEAD 已通过,且其后的 push 全为 fix-up 形状(nit、format、typo、单字段调整、小 bug 修复)时,沿用该通过结论参与目标判定,不触发重审;CodeRabbit 与 Codex 均以实际审过最终 HEAD 为目标状态。**「上一已审 HEAD」指 Gemini 最近一次实际审过的 commit,不是最近一次通过的 commit**——若最近审的 HEAD 未通过,或 `query.sh unacked gemini-code-assist[bot]` 仍有未解决评论,均不得顺延
 - **触发去重**:同一 HEAD 上每种触发命令只发一次。在 `own_trigger_comments` 中按 `command` 字段取该命令最大 `createdAt`,晚于 `last_push_at` 即视为本轮已触发,跳过(`@coderabbitai resume` 例外:以 CodeRabbit 节的 `updated_at` 口径为准)。发触发命令时只写命令本身,且命令必须在评论最开头(匹配细则见 poll.sh PITFALL 4)
 - **纯指标类 bot 不纳入循环**:`codecov[bot]` 等纯指标类 bot 没有意见可实施,也没有等待或重审的概念
@@ -39,11 +39,11 @@
 
 **outside diff range 意见**:CodeRabbit 对 diff 之外代码的建议内嵌在 review body(`coderabbit.reviews` 一行,source `coderabbit_review`)里,没有独立 inline comment id。索引只给出这条 review 的存在与 `is_new`、不含正文,`unacked coderabbitai[bot]` 兜底只扫 `inline_*_by_user`,同样看不见它——只靠 inline 口径会漏。发现靠 `query.sh <PR> history`(按 400 字 head 扫出该 review),全文用 `query.sh <PR> details <该 review 的 id>` 取;因无 inline 锚点,回复只能走 PR 顶层评论,不能回 inline。
 
-**配额**:本仓库使用 CodeRabbit 免费开源方案。配额/限流受阻时的处置为等待自恢复 + 手动 `@coderabbitai review` 重试;重试仍失败则本 PR 停用该 reviewer,记入退出汇报。按量计费附加包不开通,不向用户转呈。
+**配额**:本仓库使用 CodeRabbit 免费开源方案,配额/限流受阻时等待自恢复并手动 `@coderabbitai review` 重试一次;仍失败则本 PR 停用该家,记入退出汇报。全程不询问用户,也不提议付费扩容。
 
 ## Gemini Code Assist
 
-**现状**:Gemini Code Assist 消费者版已停止服务,PR 上会出现官方 CAUTION 通知(「The consumer version of Gemini Code Assist on GitHub has been sunset. All code review activity has officially ceased.」)。命中该通知即按 SKILL.md 的能力证伪自裁决处理:本 PR 按不参审处理、不再触发,无需另行查证服务状态;通知出现前已收集的 Gemini actionable 评论仍按目标状态处置。以下规则在其服务可用时适用。
+**现状**:Gemini Code Assist 消费者版已停止服务,PR 上会出现官方 CAUTION 通知(「The consumer version of Gemini Code Assist on GitHub has been sunset.」)。命中该通知即按 SKILL.md 能力证伪自裁决处理,无需另行查证;通知出现前已收集的 actionable 评论仍按目标状态处置。以下规则在其服务可用时适用。
 
 **触发**(按 `pr_created_at` 与 `gemini.reviews` 判别,均受触发去重约束):
 

--- a/.agents/skills/pr-ai-review-loop/references/reviewers.md
+++ b/.agents/skills/pr-ai-review-loop/references/reviewers.md
@@ -7,6 +7,7 @@
 - **本轮新评论**:索引中 `is_new == true` 的条目(inline 走 `inline_new_by_user`,评论走 `comments_new`)。口径与陷阱见 poll.sh PITFALL 2
 - **Acknowledgment 例外**:`is_ack == true` 的条目是 reviewer 对上一次修复或 inline 回复的确认,一律**不算** actionable;review state 为 `APPROVED` 也不算
 - **flag 以正文为准**:索引 flags(`is_ack` / `cr_markers` / `has_pass_marker` / `severity_alt`)是脚本解析结果,预览观感与 flag 冲突时用 `query.sh details` 取全文核实,以正文为准
+- **unacked 兜底假阳性**:终核 unacked 非空时先逐条核对自己的回复记录与 bot 的后续回复串,确认无对应修复记录或回复时才视为遗漏
 - **fix-up 顺延(仅 Gemini)**:Gemini 对上一已审 HEAD 已通过,且其后的 push 全为 fix-up 形状(nit、format、typo、单字段调整、小 bug 修复)时,沿用该通过结论参与目标判定,不触发重审;CodeRabbit 与 Codex 均以实际审过最终 HEAD 为目标状态。**「上一已审 HEAD」指 Gemini 最近一次实际审过的 commit,不是最近一次通过的 commit**——若最近审的 HEAD 未通过,或 `query.sh unacked gemini-code-assist[bot]` 仍有未解决评论,均不得顺延
 - **触发去重**:同一 HEAD 上每种触发命令只发一次。在 `own_trigger_comments` 中按 `command` 字段取该命令最大 `createdAt`,晚于 `last_push_at` 即视为本轮已触发,跳过(`@coderabbitai resume` 例外:以 CodeRabbit 节的 `updated_at` 口径为准)。发触发命令时只写命令本身,且命令必须在评论最开头(匹配细则见 poll.sh PITFALL 4)
 - **纯指标类 bot 不纳入循环**:`codecov[bot]` 等纯指标类 bot 没有意见可实施,也没有等待或重审的概念
@@ -38,7 +39,11 @@
 
 **outside diff range 意见**:CodeRabbit 对 diff 之外代码的建议内嵌在 review body(`coderabbit.reviews` 一行,source `coderabbit_review`)里,没有独立 inline comment id。索引只给出这条 review 的存在与 `is_new`、不含正文,`unacked coderabbitai[bot]` 兜底只扫 `inline_*_by_user`,同样看不见它——只靠 inline 口径会漏。发现靠 `query.sh <PR> history`(按 400 字 head 扫出该 review),全文用 `query.sh <PR> details <该 review 的 id>` 取;因无 inline 锚点,回复只能走 PR 顶层评论,不能回 inline。
 
+**配额**:本仓库使用 CodeRabbit 免费开源方案。配额/限流受阻时的处置为等待自恢复 + 手动 `@coderabbitai review` 重试;重试仍失败则本 PR 停用该 reviewer,记入退出汇报。按量计费附加包不开通,不向用户转呈。
+
 ## Gemini Code Assist
+
+**现状**:Gemini Code Assist 消费者版已停止服务,PR 上会出现官方 CAUTION 通知(「The consumer version of Gemini Code Assist on GitHub has been sunset. All code review activity has officially ceased.」)。命中该通知即按 SKILL.md 的能力证伪自裁决处理:本 PR 不参审、不再触发,无需查证历史。以下规则在其服务可用时适用。
 
 **触发**(按 `pr_created_at` 与 `gemini.reviews` 判别,均受触发去重约束):
 

--- a/.agents/skills/pr-ai-review-loop/references/reviewers.md
+++ b/.agents/skills/pr-ai-review-loop/references/reviewers.md
@@ -7,7 +7,7 @@
 - **本轮新评论**:索引中 `is_new == true` 的条目(inline 走 `inline_new_by_user`,评论走 `comments_new`)。口径与陷阱见 poll.sh PITFALL 2
 - **Acknowledgment 例外**:`is_ack == true` 的条目是 reviewer 对上一次修复或 inline 回复的确认,一律**不算** actionable;review state 为 `APPROVED` 也不算
 - **flag 以正文为准**:索引 flags(`is_ack` / `cr_markers` / `has_pass_marker` / `severity_alt`)是脚本解析结果,预览观感与 flag 冲突时用 `query.sh details` 取全文核实,以正文为准
-- **unacked 兜底假阳性**:终核 unacked 非空时逐条核对,对应修复已落地或回复为在案 pushback 的不算遗漏
+- **unacked 兜底假阳性**:终核 unacked 非空时逐条核对,对应修复已落地或回复为在案 pushback 的不算遗漏。快照不含非 bot 的 inline 回复,核对回复串用 `gh api repos/<owner>/<repo>/pulls/<pr>/comments` 按 `in_reply_to_id` 关联
 - **fix-up 顺延(仅 Gemini)**:Gemini 对上一已审 HEAD 已通过,且其后的 push 全为 fix-up 形状(nit、format、typo、单字段调整、小 bug 修复)时,沿用该通过结论参与目标判定,不触发重审;CodeRabbit 与 Codex 均以实际审过最终 HEAD 为目标状态。**「上一已审 HEAD」指 Gemini 最近一次实际审过的 commit,不是最近一次通过的 commit**——若最近审的 HEAD 未通过,或 `query.sh unacked gemini-code-assist[bot]` 仍有未解决评论,均不得顺延
 - **触发去重**:同一 HEAD 上每种触发命令只发一次。在 `own_trigger_comments` 中按 `command` 字段取该命令最大 `createdAt`,晚于 `last_push_at` 即视为本轮已触发,跳过(`@coderabbitai resume` 例外:以 CodeRabbit 节的 `updated_at` 口径为准)。发触发命令时只写命令本身,且命令必须在评论最开头(匹配细则见 poll.sh PITFALL 4)
 - **纯指标类 bot 不纳入循环**:`codecov[bot]` 等纯指标类 bot 没有意见可实施,也没有等待或重审的概念
@@ -49,7 +49,7 @@
 
 - `gemini.reviews` 完全为空,`pr_created_at` 距今**不足 5 分钟** → cold-start 窗口内,等待——此时抢跑触发既耗 quota,也容易引入第一次未提及的边缘建议
 - `gemini.reviews` 完全为空,`pr_created_at` 距今**已超 5 分钟** → cold-start fallback:自动 review 未在窗口内出现(可能失败或被跳过),发送 `/gemini review`。**此行不受 fix-up 顺延限制**——否则 Gemini 永远不会审本 PR。阈值宽松不必精确——误发代价只是一次受去重约束的额外触发
-- `gemini.reviews` 非空但无 `is_new == true` 条目 → 发送 `/gemini review`(受 fix-up 顺延限制)
+- `gemini.reviews` 非空但无 `is_new == true` 条目 → 先用 `query.sh gemini-latest-body` 核对最新 review 正文,含停服通知则按上方「现状」段处理;否则发送 `/gemini review`(受 fix-up 顺延限制)——停服通知可能包裹在带 pass marker 的历史 review 里,索引不暴露正文
 
 **已审当前 HEAD**:`gemini.reviews` 至少一条 `is_new == true`。
 

--- a/.claude/rules/frontend-design-first.md
+++ b/.claude/rules/frontend-design-first.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "frontend/**"
+---
+
+# 前端设计工具链
+
+前端任务（新建 UI 或重塑既有界面）动手写组件前先调用 `/frontend-design` 确立视觉与交互方向；涉及性能时调用 `/vercel-react-best-practices`，涉及可访问性时调用 `/web-design-guidelines`。spawn 前端实现 teammate 时把这条工具链要求写进 prompt。

--- a/.claude/rules/frontend-design-first.md
+++ b/.claude/rules/frontend-design-first.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "frontend/**"
----
-
 # 前端设计工具链
 
 前端任务（新建 UI 或重塑既有界面）动手写组件前先调用 `/frontend-design` 确立视觉与交互方向；涉及性能时调用 `/vercel-react-best-practices`，涉及可访问性时调用 `/web-design-guidelines`。spawn 前端实现 teammate 时把这条工具链要求写进 prompt。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ pnpm build       # 生产构建，含 typecheck
 
 ### 供应商能力数据
 
-能力数字（时长、参考图上限、分辨率约束）、默认 model、文档链接等供应商数据的单一真相源是 `lib/config/registry.py` 的 `PROVIDER_REGISTRY`。自定义供应商（`custom-` 前缀）不纳入注册表，无逐模型能力事实，校验交由供应商 API 把关（见 `server/routers/_validators.py`）。prompt 模板与 agent 文档不硬编码具体数值，用占位符由编排层动态注入；配置界面的此类字段不预填。
+生成模型供应商（图像/视频/音频/文本档位）的能力数字（时长、参考图上限、分辨率约束）、默认 model 等数据的单一真相源是 `lib/config/registry.py` 的 `PROVIDER_REGISTRY`。自定义供应商（`custom-` 前缀）不纳入注册表，无逐模型能力事实，校验交由供应商 API 把关（见 `server/routers/_validators.py`）；智能体供应商的预设（`default_model` / `docs_url`）维护在 `lib/agent_provider_catalog.py` 的 `PRESET_PROVIDERS`，不在此注册表。prompt 模板与 agent 文档不硬编码具体数值，用占位符由编排层动态注入；配置界面的此类字段不预填。
 
 ### 内容模式 (content_mode) 与生成模式 (generation_mode)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ pnpm build       # 生产构建，含 typecheck
 
 ### 供应商能力数据
 
-生成模型供应商（图像/视频/音频/文本档位）的能力数字（时长、参考图上限、分辨率约束）、默认 model 等数据的单一真相源是 `lib/config/registry.py` 的 `PROVIDER_REGISTRY`。自定义供应商（`custom-` 前缀）不纳入注册表，无逐模型能力事实，校验交由供应商 API 把关（见 `server/routers/_validators.py`）；智能体供应商的预设（`default_model` / `docs_url`）维护在 `lib/agent_provider_catalog.py` 的 `PRESET_PROVIDERS`，不在此注册表。prompt 模板与 agent 文档不硬编码具体数值，用占位符由编排层动态注入；配置界面的此类字段不预填。
+生成模型供应商的能力数字（时长、参考图上限、分辨率约束）与默认 model，以 `lib/config/registry.py` 的 `PROVIDER_REGISTRY` 为单一真相源。自定义供应商（`custom-` 前缀）与智能体供应商预设（`lib/agent_provider_catalog.py::PRESET_PROVIDERS`）不在其内，自定义供应商的能力校验交由供应商 API。prompt 模板与 agent 文档不硬编码具体数值，用占位符由编排层动态注入；配置界面的此类字段不预填。
 
 ### 内容模式 (content_mode) 与生成模式 (generation_mode)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ pnpm build       # 生产构建，含 typecheck
 
 ### 供应商能力数据
 
-能力数字（时长、参考图上限、分辨率约束）、默认 model、文档链接等供应商数据的单一真相源是 `lib/config/registry.py` 的 `PROVIDER_REGISTRY`。prompt 模板与 agent 文档不硬编码具体数值，用占位符由编排层动态注入；配置界面的此类字段不预填。
+能力数字（时长、参考图上限、分辨率约束）、默认 model、文档链接等供应商数据的单一真相源是 `lib/config/registry.py` 的 `PROVIDER_REGISTRY`。自定义供应商（`custom-` 前缀）不纳入注册表，无逐模型能力事实，校验交由供应商 API 把关（见 `server/routers/_validators.py`）。prompt 模板与 agent 文档不硬编码具体数值，用占位符由编排层动态注入；配置界面的此类字段不预填。
 
 ### 内容模式 (content_mode) 与生成模式 (generation_mode)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,10 @@ pnpm build       # 生产构建，含 typecheck
 
 `lib/data_validator.py` 验证 `project.json` 和剧集 JSON 的结构与引用完整性。
 
+### 供应商能力数据
+
+能力数字（时长、参考图上限、分辨率约束）、默认 model、文档链接等供应商数据的单一真相源是 `lib/config/registry.py` 的 `PROVIDER_REGISTRY`。prompt 模板与 agent 文档不硬编码具体数值，用占位符由编排层动态注入；配置界面的此类字段不预填。
+
 ### 内容模式 (content_mode) 与生成模式 (generation_mode)
 
 两个独立维度，分别承载"内容类型"与"视频来源"：
@@ -135,7 +139,8 @@ API Key、后端选择、模型配置等通过 WebUI 配置页（`/settings`）�
 - **basedpyright**：standard 模式 + `reportMissingTypeStubs = false`，CI 强制 0 error，pre-push hook 跑全量扫描；本地可随时执行 `uv run basedpyright` 校验。tests/ 内 `reportOptional*` 和 `unknown*` 系列降级为 warning，避免大量使用 mock 的测试产生噪声；第三方 untyped 库（ffmpeg-python、pyJianYingDraft、volcenginesdkarkruntime、xai_sdk.chat、docx2txt/mammoth/ebooklib）通过行级 `# pyright: ignore[...]` 处理
 - **pytest**：`asyncio_mode = "auto"`，CI 覆盖率 ≥80%，共用 fixtures 在 `tests/conftest.py`
 - **依赖管理**：前后端新增/升级依赖一律用 `uv add` / `pnpm add`（不手写版本号到 pyproject.toml / package.json）；新增依赖后同步 `.github/dependabot.yml` 的 patterns 归入对应分组
-- **提交与 PR**：标题遵循 Conventional Commits（`type(scope): 摘要`，type 取值与 changelog 分类见 `CONTRIBUTING.md` / `.release-please-config.json`）。squash 合并下标题即 changelog 条目——写用户可感知的收益、范围词用产品术语，不写实现术语（status_code、内部类名等）且如实限定范围
+- **注释**：代码与测试注释只描述当下行为与约束，不写 issue/PR/Spec 编号，也不用时间性措辞（「最近」「本次」「实测」）——这些信息写在 commit message / PR 描述；修改文件时顺带清除已有的此类引用。`docs/` 下专门文档之间互引 spec 不受此限
+- **提交与 PR**：标题遵循 Conventional Commits（`type(scope): 摘要`，type 取值与 changelog 分类见 `CONTRIBUTING.md` / `.release-please-config.json`）。squash 合并下标题即 changelog 条目——写用户可感知的收益、范围词用产品术语，不写实现术语（status_code、内部类名等）且如实限定范围。前后端同仓一体发布，后端 API 无外部消费者：接口删改按 `fix`/`refactor` 正常分类，不加 `!` 后缀、不写 `BREAKING CHANGE:` footer
 
 ## Agent skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ pnpm build       # 生产构建，含 typecheck
 
 ### 供应商能力数据
 
-生成模型供应商的能力数字（时长、参考图上限、分辨率约束）与默认 model，以 `lib/config/registry.py` 的 `PROVIDER_REGISTRY` 为单一真相源。自定义供应商（`custom-` 前缀）与智能体供应商预设（`lib/agent_provider_catalog.py::PRESET_PROVIDERS`）不在其内。prompt 模板与智能体运行配置（`agent_runtime_profile/`）不硬编码具体数值，用占位符由编排层动态注入；供应商 API 文档镜像（如 `docs/vidu-docs/`）保留原始数值，不受此约束。配置界面的此类字段不预填。
+生成模型供应商的能力数字（时长、参考图上限、分辨率约束）与默认 model，以 `lib/config/registry.py` 的 `PROVIDER_REGISTRY` 为单一真相源。自定义供应商（`custom-` 前缀）与智能体供应商预设（`lib/agent_provider_catalog.py::PRESET_PROVIDERS`）不在其内。新增或修改 prompt 模板与智能体运行配置（`agent_runtime_profile/`）时不硬编码具体数值，用占位符由编排层动态注入；供应商 API 文档镜像（如 `docs/vidu-docs/`）保留原始数值，不受此约束。配置界面的此类字段不预填。
 
 ### 内容模式 (content_mode) 与生成模式 (generation_mode)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ pnpm build       # 生产构建，含 typecheck
 
 ### 供应商能力数据
 
-生成模型供应商的能力数字（时长、参考图上限、分辨率约束）与默认 model，以 `lib/config/registry.py` 的 `PROVIDER_REGISTRY` 为单一真相源。自定义供应商（`custom-` 前缀）与智能体供应商预设（`lib/agent_provider_catalog.py::PRESET_PROVIDERS`）不在其内，自定义供应商的能力校验交由供应商 API。prompt 模板与 agent 文档不硬编码具体数值，用占位符由编排层动态注入；配置界面的此类字段不预填。
+生成模型供应商的能力数字（时长、参考图上限、分辨率约束）与默认 model，以 `lib/config/registry.py` 的 `PROVIDER_REGISTRY` 为单一真相源。自定义供应商（`custom-` 前缀）与智能体供应商预设（`lib/agent_provider_catalog.py::PRESET_PROVIDERS`）不在其内。prompt 模板与智能体运行配置（`agent_runtime_profile/`）不硬编码具体数值，用占位符由编排层动态注入；供应商 API 文档镜像（如 `docs/vidu-docs/`）保留原始数值，不受此约束。配置界面的此类字段不预填。
 
 ### 内容模式 (content_mode) 与生成模式 (generation_mode)
 
@@ -140,7 +140,7 @@ API Key、后端选择、模型配置等通过 WebUI 配置页（`/settings`）�
 - **pytest**：`asyncio_mode = "auto"`，CI 覆盖率 ≥80%，共用 fixtures 在 `tests/conftest.py`
 - **依赖管理**：前后端新增/升级依赖一律用 `uv add` / `pnpm add`（不手写版本号到 pyproject.toml / package.json）；新增依赖后同步 `.github/dependabot.yml` 的 patterns 归入对应分组
 - **注释**：代码与测试注释只描述当下行为与约束，不写 issue/PR/Spec 编号，也不用时间性措辞（「最近」「本次」「实测」）——这些信息写在 commit message / PR 描述；修改文件时顺带清除已有的此类引用。`docs/` 下专门文档之间互引 spec 不受此限
-- **提交与 PR**：标题遵循 Conventional Commits（`type(scope): 摘要`，type 取值与 changelog 分类见 `CONTRIBUTING.md` / `.release-please-config.json`）。squash 合并下标题即 changelog 条目——写用户可感知的收益、范围词用产品术语，不写实现术语（status_code、内部类名等）且如实限定范围。前后端同仓一体发布，后端 API 无外部消费者：接口删改按 `fix`/`refactor` 正常分类，不加 `!` 后缀、不写 `BREAKING CHANGE:` footer
+- **提交与 PR**：标题遵循 Conventional Commits（`type(scope): 摘要`，type 取值与 changelog 分类见 `CONTRIBUTING.md` / `.release-please-config.json`）。squash 合并下标题即 changelog 条目——写用户可感知的收益、范围词用产品术语，不写实现术语（status_code、内部类名等）且如实限定范围。前后端同仓一体发布，后端 API 不做版本化对外承诺（外部集成经 `/skill.md` 运行时拉取契约，删改 `public/skill.md.template` 引用的端点时同步更新该模板）：接口删改按 `fix`/`refactor` 正常分类，不加 `!` 后缀、不写 `BREAKING CHANGE:` footer
 
 ## Agent skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,9 @@ feat(grid): 支持 grid_12 布局
 将宫格系统扩展到 12 宫格，适用于长篇剧集的批量预览。
 ```
 
-**破坏性变更**有两种等价写法：
+**本仓库约定：不使用破坏性变更标记。** 前后端同仓一体发布，后端 API 的唯一消费者是自带前端，接口删改不构成对外破坏性变更——按 `fix`/`refactor` 正常分类，不加 `!` 后缀、不写 `BREAKING CHANGE:` footer。误标时有两道补救：0.x 阶段 `bump-minor-pre-major` 约束版本只升 minor；已合并的误标可编辑该 PR 正文追加 `BEGIN_COMMIT_OVERRIDE`/`END_COMMIT_OVERRIDE` 块，release-please 会按 override 重算 changelog 与版本号（需 squash 合并，本仓库满足）。
+
+以下为该机制的通用说明。**破坏性变更**有两种等价写法：
 
 ```
 # 写法 1：type 后加 !

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ feat(grid): 支持 grid_12 布局
 将宫格系统扩展到 12 宫格，适用于长篇剧集的批量预览。
 ```
 
-**本仓库不使用破坏性变更标记。** 前后端同仓一体发布，后端 API 的唯一消费者是自带前端，接口删改不构成对外破坏性变更，按 `fix`/`refactor` 正常分类，不加 `!` 后缀、不写 `BREAKING CHANGE:` footer。误标合并后的纠正方式：编辑该 PR 正文追加 `BEGIN_COMMIT_OVERRIDE`/`END_COMMIT_OVERRIDE` 块，release-please 按 override 重算 changelog 与版本号（需 squash 合并，本仓库满足）；0.x 阶段的 `bump-minor-pre-major` 仅把误标的版本跃迁限制为 minor，不修正 changelog。
+**本仓库不使用破坏性变更标记。** 前后端同仓一体发布，后端 API 不做版本化对外承诺——自带前端随版本同步演进，外部集成（OpenClaw 等）经 `/skill.md` 运行时拉取最新契约、不依赖版本号，删改 `public/skill.md.template` 引用的端点时同步更新该模板。接口删改按 `fix`/`refactor` 正常分类，不加 `!` 后缀、不写 `BREAKING CHANGE:` footer。误标合并后的纠正方式：编辑该 PR 正文追加 `BEGIN_COMMIT_OVERRIDE`/`END_COMMIT_OVERRIDE` 块，release-please 按 override 重算 changelog 与版本号（需 squash 合并，本仓库满足）；workflow 仅在 main push 时运行，编辑后需等下一次 main push 或手动重跑 release-please workflow 才生效。0.x 阶段的 `bump-minor-pre-major` 仅把误标的版本跃迁限制为 minor，不修正 changelog。
 
 以下语法说明仅用于识别误标。**破坏性变更**有两种等价写法：
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,9 +190,9 @@ feat(grid): 支持 grid_12 布局
 将宫格系统扩展到 12 宫格，适用于长篇剧集的批量预览。
 ```
 
-**本仓库约定：不使用破坏性变更标记。** 前后端同仓一体发布，后端 API 的唯一消费者是自带前端，接口删改不构成对外破坏性变更——按 `fix`/`refactor` 正常分类，不加 `!` 后缀、不写 `BREAKING CHANGE:` footer。误标的纠正手段是编辑该 PR 正文追加 `BEGIN_COMMIT_OVERRIDE`/`END_COMMIT_OVERRIDE` 块，release-please 会按 override 重算 changelog 与版本号（需 squash 合并，本仓库满足）；0.x 阶段的 `bump-minor-pre-major` 只起限损作用——版本仍会升 minor 而非本应的 patch，changelog 仍出现破坏性变更区块，不能替代 override 纠正。
+**本仓库不使用破坏性变更标记。** 前后端同仓一体发布，后端 API 的唯一消费者是自带前端，接口删改不构成对外破坏性变更，按 `fix`/`refactor` 正常分类，不加 `!` 后缀、不写 `BREAKING CHANGE:` footer。误标合并后的纠正方式：编辑该 PR 正文追加 `BEGIN_COMMIT_OVERRIDE`/`END_COMMIT_OVERRIDE` 块，release-please 按 override 重算 changelog 与版本号（需 squash 合并，本仓库满足）；0.x 阶段的 `bump-minor-pre-major` 仅把误标的版本跃迁限制为 minor，不修正 changelog。
 
-以下语法说明仅用于识别误标，本仓库不使用这两种写法。**破坏性变更**有两种等价写法：
+以下语法说明仅用于识别误标。**破坏性变更**有两种等价写法：
 
 ```
 # 写法 1：type 后加 !

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ feat(grid): 支持 grid_12 布局
 将宫格系统扩展到 12 宫格，适用于长篇剧集的批量预览。
 ```
 
-**本仓库约定：不使用破坏性变更标记。** 前后端同仓一体发布，后端 API 的唯一消费者是自带前端，接口删改不构成对外破坏性变更——按 `fix`/`refactor` 正常分类，不加 `!` 后缀、不写 `BREAKING CHANGE:` footer。误标时有两道补救：0.x 阶段 `bump-minor-pre-major` 约束版本只升 minor；已合并的误标可编辑该 PR 正文追加 `BEGIN_COMMIT_OVERRIDE`/`END_COMMIT_OVERRIDE` 块，release-please 会按 override 重算 changelog 与版本号（需 squash 合并，本仓库满足）。
+**本仓库约定：不使用破坏性变更标记。** 前后端同仓一体发布，后端 API 的唯一消费者是自带前端，接口删改不构成对外破坏性变更——按 `fix`/`refactor` 正常分类，不加 `!` 后缀、不写 `BREAKING CHANGE:` footer。误标的纠正手段是编辑该 PR 正文追加 `BEGIN_COMMIT_OVERRIDE`/`END_COMMIT_OVERRIDE` 块，release-please 会按 override 重算 changelog 与版本号（需 squash 合并，本仓库满足）；0.x 阶段的 `bump-minor-pre-major` 只起限损作用——版本仍会升 minor 而非本应的 patch，changelog 仍出现破坏性变更区块，不能替代 override 纠正。
 
 以下语法说明仅用于识别误标，本仓库不使用这两种写法。**破坏性变更**有两种等价写法：
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ feat(grid): 支持 grid_12 布局
 
 **本仓库约定：不使用破坏性变更标记。** 前后端同仓一体发布，后端 API 的唯一消费者是自带前端，接口删改不构成对外破坏性变更——按 `fix`/`refactor` 正常分类，不加 `!` 后缀、不写 `BREAKING CHANGE:` footer。误标时有两道补救：0.x 阶段 `bump-minor-pre-major` 约束版本只升 minor；已合并的误标可编辑该 PR 正文追加 `BEGIN_COMMIT_OVERRIDE`/`END_COMMIT_OVERRIDE` 块，release-please 会按 override 重算 changelog 与版本号（需 squash 合并，本仓库满足）。
 
-以下为该机制的通用说明。**破坏性变更**有两种等价写法：
+以下语法说明仅用于识别误标，本仓库不使用这两种写法。**破坏性变更**有两种等价写法：
 
 ```
 # 写法 1：type 后加 !


### PR DESCRIPTION
## 变更内容

- **AGENTS.md**
  - 「代码质量」新增注释规范：代码与测试注释只描述当下行为，不写 issue/PR/Spec 编号与时间性措辞，修改文件时顺带清除已有引用
  - 「关键设计模式」新增「供应商能力数据」小节：单一真相源为 `lib/config/registry.py` 的 `PROVIDER_REGISTRY`，prompt 模板与配置界面不硬编码、不预填
  - 「提交与 PR」补充：前后端同仓一体发布，接口删改不使用 `!` 后缀与 `BREAKING CHANGE:` footer
- **CONTRIBUTING.md**：在破坏性变更说明前补本仓库约定（不使用破坏性变更标记）与误标的两道补救方式（`bump-minor-pre-major`、`BEGIN_COMMIT_OVERRIDE` 块）
- **reviewers.md**（pr-ai-review-loop）
  - 通用约定补「unacked 兜底假阳性」核对规则：终核先核对回复串再判遗漏
  - CodeRabbit 节补配额处置：免费开源方案，受阻走等待+手动重试，不开通按量计费
  - Gemini 节补消费者版停服现状：命中官方 CAUTION 通知即按能力证伪自裁决处理
- **新增 `.claude/rules/frontend-design-first.md`**：前端任务动手前先调用 /frontend-design，按需 /vercel-react-best-practices 与 /web-design-guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 更新贡献指南，明确提交信息、发布流程及误标处理规范。
  * 补充供应商能力数据、默认模型和文档链接的统一维护规则。
  * 新增前端开发规范，完善设计、性能与可访问性检查要求。
  * 更新自动审查规则，明确遗漏判定、配额限流、自动恢复、重试失败及服务停用处理方式。
  * 补充 Gemini 服务停服及官方提醒的处理流程。
  * 完善配额告警处理，区分已完成审查与需等待恢复的情况。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->