### PR TITLE
feat(video): 剧集视频按角色声音描述生成，跨片段音色更稳

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -194,6 +194,14 @@ _Avoid_: 用 voice 指代 audio 媒体类型本身；把音色与「声音复刻
 创作者手上没有现成音频时，用已配置的 TTS 后端合成的一段短音频，供试听后确认为角色的参考音频。独立 task_type `voice_sample`，落在 `audio/` 目录但用 `voice_sample__` 前缀与旁白 segment 隔离命名空间。它是**预览件**：确认前不写入角色资产，取消或关闭弹窗即不产生任何资产变更。
 _Avoid_: 与「旁白配音」混为一谈——旁白是成片素材，试听样本只是选音色的中间产物。
 
+**声音一致性档位（voice consistency）**：
+视频模型在跨片段保持人物音色上能做到什么程度的三级标识，由「模型有无音轨」×「项目 generation_mode」二维派生，全仓库唯一派生点是 `lib/config/resolver.py::derive_voice_consistency`。`native`＝参考生视频直传参考音频、音色由音频本身锁定；`soft`＝有音轨但只能靠文字描述引导音色；`none`＝真无声，不承载任何声音语义。soft/none 之分不看 `generate_audio` token 是否声明——该 token 语义是「开关可控」而非「有无音轨」，恒有声但开关不可控的供应商（AI Studio Veo、Grok）经 `model_has_audio_track` 单独识别为有音轨。
+_Avoid_: 用 `generate_audio` 的真假直接代指有无音轨。
+
+**声音描述声明段（Voice_Profiles）**：
+drama 视频提示词 YAML 顶部的集中声明段，形如 `Voice_Profiles: [{Speaker, Voice_Style}]`，由编排层从角色资产的 `voice_style` 机械派生——收录集合为「本场景 dialogue 的 speaker」∩「角色资产 `voice_style` 非空」，只出场不开口的角色不收录。剧本 JSON 与 step2 LLM 零承载：编排层是它唯一的来源（`lib/prompt_utils.py::build_drama_video_prompt`），故角色 `voice_style` 改动下次生成即生效。档位为 `none` 时不注入。
+_Avoid_: 与既有 `Dialogue` 条目混为一谈——前者声明音色、每 speaker 一条，后者是台词、按时序逐条。
+
 **"audio" 的三种含义（歧义警示）**：
 - **audio（媒体类型）** = 本表定义的 TTS 维度。
 - **`generate_audio`（能力/字段）** = 视频模型（Veo/Kling 等）**自带音轨**的开关，属 video 维度，与 TTS 无关。

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -31,6 +31,7 @@ from lib.script_models import (
     AD_TARGET_DURATION_DRIFT_THRESHOLD,
     REFERENCE_SHOT_DURATION_RANGE,
     ad_script_total_duration,
+    resolve_content_mode,
 )
 from lib.script_skeleton import resolve_declared_kind
 from lib.speech_rate import estimate_spoken_seconds
@@ -1130,10 +1131,7 @@ class DataValidator:
         if not episode.get("title"):
             errors.append("缺少必填字段: title")
 
-        content_mode = episode.get(
-            "content_mode",
-            project.get("content_mode", "narration"),
-        )
+        content_mode = resolve_content_mode(episode, project)
 
         characters_in_episode = episode.get("characters_in_episode")
         if characters_in_episode is not None:

--- a/lib/prompt_utils.py
+++ b/lib/prompt_utils.py
@@ -99,12 +99,40 @@ def video_prompt_to_yaml(video_prompt: dict) -> str:
     return yaml.dump(ordered, allow_unicode=True, default_flow_style=False, sort_keys=False)
 
 
-def build_voice_profiles(dialogue: list[dict[str, str]], characters: dict) -> list[dict[str, str]]:
+def build_drama_video_prompt(
+    video_prompt: dict[str, Any],
+    utterances: object,
+    *,
+    characters: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """drama video_prompt 的 dialogue 与 Voice_Profiles 唯一注入出口。
+
+    worker 执行路径与 SDK 入队路径共用本函数，两处注入点的产出同构由此在结构上成立，而非
+    各写一份靠约定对齐。
+
+    ``characters`` 为 ``None`` 表示本次不注入 Voice_Profiles（C 类真无声模型）。无论注入
+    与否都先剥离入参自带的 ``voice_profiles``：该声明段由编排层从角色资产机械派生，剧本
+    JSON 不承载它，剧本中的残留值不得绕过 C 类门控进入 YAML。
+    """
+    prompt = {k: v for k, v in video_prompt.items() if k != "voice_profiles"}
+    dialogue = utterances_to_dialogue(utterances)
+    prompt["dialogue"] = dialogue
+    if characters is not None:
+        voice_profiles = _build_voice_profiles(dialogue, characters)
+        if voice_profiles:
+            prompt["voice_profiles"] = voice_profiles
+    return prompt
+
+
+def _build_voice_profiles(dialogue: list[dict[str, str]], characters: dict[str, Any]) -> list[dict[str, str]]:
     """从 dialogue speakers 与角色资产派生 Voice_Profiles 声明段。
 
     仅收录角色资产存在且 ``voice_style`` 非空者，一个 speaker 一条（按 dialogue 中首次
     出现的顺序去重）；speaker 未命中角色资产或资产 ``voice_style`` 为空，静默跳过
     （不建面向用户的提示通道，调用方按需记 logger）。
+
+    ``characters`` 来自明文 project.json，用户手编或外部脚本可能写成非 dict，逐层做类型
+    收窄而非直接下标（同 ``lib.config.resolver._safe_dict`` 的取向）。
     """
     if not isinstance(characters, dict):
         return []

--- a/lib/prompt_utils.py
+++ b/lib/prompt_utils.py
@@ -99,6 +99,18 @@ def video_prompt_to_yaml(video_prompt: dict) -> str:
     return yaml.dump(ordered, allow_unicode=True, default_flow_style=False, sort_keys=False)
 
 
+def strip_voice_profiles(video_prompt: dict[str, Any]) -> dict[str, Any]:
+    """剥离入参自带的 ``voice_profiles`` 键。
+
+    ``Voice_Profiles`` 声明段由编排层从角色资产机械派生，剧本 JSON / 调用方请求体均不
+    承载它——两处注入点（worker 执行路径、SDK 入队路径）在决定是否调用
+    :func:`build_drama_video_prompt` 之前都须先过一遍本函数，drama 之外的 content_mode
+    或缺 ``utterances`` 的条目才不会让调用方自带（或剧本残留）的 ``voice_profiles`` 绕过
+    C 类（真无声）门控直接进入 YAML。
+    """
+    return {k: v for k, v in video_prompt.items() if k != "voice_profiles"}
+
+
 def build_drama_video_prompt(
     video_prompt: dict[str, Any],
     utterances: object,
@@ -114,7 +126,7 @@ def build_drama_video_prompt(
     与否都先剥离入参自带的 ``voice_profiles``：该声明段由编排层从角色资产机械派生，剧本
     JSON 不承载它，剧本中的残留值不得绕过 C 类门控进入 YAML。
     """
-    prompt = {k: v for k, v in video_prompt.items() if k != "voice_profiles"}
+    prompt = strip_voice_profiles(video_prompt)
     dialogue = utterances_to_dialogue(utterances)
     prompt["dialogue"] = dialogue
     if characters is not None:

--- a/lib/prompt_utils.py
+++ b/lib/prompt_utils.py
@@ -122,12 +122,39 @@ def build_drama_video_prompt(
     worker 执行路径与 SDK 入队路径共用本函数，两处注入点的产出同构由此在结构上成立，而非
     各写一份靠约定对齐。
 
-    ``characters`` 为 ``None`` 表示本次不注入 Voice_Profiles（C 类真无声模型）。无论注入
+    ``characters`` 为 ``None`` 表示不注入 Voice_Profiles（C 类真无声模型）。无论注入
     与否都先剥离入参自带的 ``voice_profiles``：该声明段由编排层从角色资产机械派生，剧本
     JSON 不承载它，剧本中的残留值不得绕过 C 类门控进入 YAML。
     """
     prompt = strip_voice_profiles(video_prompt)
     dialogue = utterances_to_dialogue(utterances)
+    return _attach_voice_profiles(prompt, dialogue, characters=characters)
+
+
+def build_drama_video_prompt_from_legacy_dialogue(
+    video_prompt: dict[str, Any],
+    *,
+    characters: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """legacy drama 场景（utterances 迁移前的旧剧本，台词仍留在 ``video_prompt.dialogue``、
+    无场景级 ``utterances`` 字段）的 Voice_Profiles 注入出口。
+
+    ``load_script`` 按原始 JSON 读盘、不过 pydantic，这类存量剧本不会被
+    ``DramaScene._migrate_legacy`` 自动补齐 ``utterances``；调用方须按 ``"utterances" not
+    in item`` 识别后改走本函数，而非 :func:`build_drama_video_prompt`——旧结构的
+    ``dialogue`` 已是 ``{speaker, line}`` 目标形态，无需 :func:`utterances_to_dialogue`
+    转换，直接派生 Voice_Profiles。
+    """
+    prompt = strip_voice_profiles(video_prompt)
+    dialogue = prompt.get("dialogue")
+    if not isinstance(dialogue, list):
+        dialogue = []
+    return _attach_voice_profiles(prompt, dialogue, characters=characters)
+
+
+def _attach_voice_profiles(
+    prompt: dict[str, Any], dialogue: list[dict[str, str]], *, characters: dict[str, Any] | None
+) -> dict[str, Any]:
     prompt["dialogue"] = dialogue
     if characters is not None:
         voice_profiles = _build_voice_profiles(dialogue, characters)

--- a/lib/prompt_utils.py
+++ b/lib/prompt_utils.py
@@ -4,12 +4,15 @@ Prompt 工具函数
 提供结构化 Prompt 到 YAML 格式的转换功能。
 """
 
+import logging
 import re
-from typing import get_args
+from typing import Any, get_args
 
 import yaml
 
 from lib.script_models import CameraMotion, ShotType
+
+logger = logging.getLogger(__name__)
 
 # 风格值开头的「画风：」前缀（全角/半角冒号）。新版风格模版已去前缀，此处兼容存量 project.json。
 _STYLE_PREFIX_RE = re.compile(r"^画风[：:]\s*")
@@ -70,25 +73,58 @@ def video_prompt_to_yaml(video_prompt: dict) -> str:
                 "action": "动作描述",
                 "camera_motion": "摄像机运动",
                 "ambiance_audio": "环境音效描述",
-                "dialogue": [{"speaker": "角色名", "line": "台词"}]
+                "dialogue": [{"speaker": "角色名", "line": "台词"}],
+                "voice_profiles": [{"Speaker": "角色名", "Voice_Style": "声音风格"}]
             }
 
     Returns:
         YAML 格式字符串，用于 Veo API 调用
     """
     dialogue = [{"Speaker": d["speaker"], "Line": d["line"]} for d in video_prompt.get("dialogue", [])]
+    voice_profiles = video_prompt.get("voice_profiles") or []
 
-    ordered = {
-        "Action": video_prompt["action"],
-        "Camera_Motion": video_prompt["camera_motion"],
-        "Ambiance_Audio": video_prompt.get("ambiance_audio", ""),
-    }
+    ordered: dict[str, Any] = {}
+    # Voice_Profiles 是集中声明段，须在顶部：调用方已按 dialogue speaker ∩ 非空 voice_style
+    # 角色资产派生好列表，此处只负责按序注入，不做二次过滤。
+    if voice_profiles:
+        ordered["Voice_Profiles"] = voice_profiles
+    ordered["Action"] = video_prompt["action"]
+    ordered["Camera_Motion"] = video_prompt["camera_motion"]
+    ordered["Ambiance_Audio"] = video_prompt.get("ambiance_audio", "")
 
     # 仅在有对话时添加 Dialogue 字段
     if dialogue:
         ordered["Dialogue"] = dialogue
 
     return yaml.dump(ordered, allow_unicode=True, default_flow_style=False, sort_keys=False)
+
+
+def build_voice_profiles(dialogue: list[dict[str, str]], characters: dict) -> list[dict[str, str]]:
+    """从 dialogue speakers 与角色资产派生 Voice_Profiles 声明段。
+
+    仅收录角色资产存在且 ``voice_style`` 非空者，一个 speaker 一条（按 dialogue 中首次
+    出现的顺序去重）；speaker 未命中角色资产或资产 ``voice_style`` 为空，静默跳过
+    （不建面向用户的提示通道，调用方按需记 logger）。
+    """
+    if not isinstance(characters, dict):
+        return []
+    seen: set[str] = set()
+    profiles: list[dict[str, str]] = []
+    for entry in dialogue:
+        speaker = entry.get("speaker") if isinstance(entry, dict) else None
+        if not isinstance(speaker, str) or not speaker or speaker in seen:
+            continue
+        seen.add(speaker)
+        character = characters.get(speaker)
+        if not isinstance(character, dict):
+            logger.debug("Voice_Profiles 跳过：speaker %r 未命中角色资产", speaker)
+            continue
+        voice_style = character.get("voice_style")
+        if isinstance(voice_style, str) and voice_style.strip():
+            profiles.append({"Speaker": speaker, "Voice_Style": voice_style.strip()})
+        else:
+            logger.debug("Voice_Profiles 跳过：角色 %r 的 voice_style 为空", speaker)
+    return profiles
 
 
 def utterances_to_dialogue(utterances: object) -> list[dict[str, str]]:

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -7,7 +7,7 @@ script_models.py - 剧本数据模型
 """
 
 import logging
-from typing import Annotated, ClassVar, Literal, get_args
+from typing import Annotated, Any, ClassVar, Literal, get_args
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, create_model, model_validator
 from pydantic.json_schema import SkipJsonSchema
@@ -913,6 +913,14 @@ def is_reference_script(script: dict) -> bool:
     真相源是项目/集级配置（``effective_mode``），不适用本谓词。
     """
     return script.get("generation_mode") == "reference_video"
+
+
+def resolve_content_mode(script: dict[str, Any], project: dict[str, Any]) -> str:
+    """剧本级 ``content_mode`` 缺失（存量 episode 未打戳）时回退到项目级配置，与
+    ``lib.data_validator._validate_episode_payload`` 已校验通过的既定口径一致——存量
+    episode 允许省略该字段、由项目值兜底，读侧（生成任务）不能另起一份更严格的判定。
+    """
+    return script.get("content_mode", project.get("content_mode", "narration"))
 
 
 # ============ 参考生视频 step1 结构化中间态 ============

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -23,6 +23,7 @@ from lib.project_manager import ProjectManager, is_reference_video_episode
 from lib.prompt_utils import (
     build_drama_video_prompt,
     is_structured_video_prompt,
+    strip_voice_profiles,
     video_prompt_to_yaml,
 )
 from lib.reference_video import assemble_shots_text
@@ -136,6 +137,10 @@ def _get_video_prompt(item: dict[str, Any], *, voice_characters: dict[str, Any] 
         item_id = item.get("segment_id") or item.get("scene_id")
         raise ValueError(f"片段/场景缺少 video_prompt 字段: {item_id}")
     if is_structured_video_prompt(prompt):
+        # Voice_Profiles 声明段唯一来源是下方 build_drama_video_prompt 的机械派生：剧本 JSON
+        # 里残留的 voice_profiles 一律先剥离，不因 utterances 门控不触发（narration/ad、或
+        # drama 无 utterances 的条目）而绕过 C 类（真无声）门控直达 YAML。
+        prompt = strip_voice_profiles(prompt)
         # drama 口型台词单一真相源在场景级有序 utterances：取 dialogue-kind 注入 video YAML 的
         # dialogue 出口（drama video_prompt 已不带 dialogue）。narration / ad 无 utterances 字段、原样渲染。
         if "utterances" in item:

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -22,9 +21,8 @@ from lib.generation_queue_client import (
 )
 from lib.project_manager import ProjectManager, is_reference_video_episode
 from lib.prompt_utils import (
-    build_voice_profiles,
+    build_drama_video_prompt,
     is_structured_video_prompt,
-    utterances_to_dialogue,
     video_prompt_to_yaml,
 )
 from lib.reference_video import assemble_shots_text
@@ -45,10 +43,8 @@ from server.services.reference_video_tasks import (
     precheck_unit,
     resolve_max_unit_duration,
     resolve_project_duration_context,
-    resolve_project_voice_consistency,
 )
-
-logger = logging.getLogger(__name__)
+from server.services.video_caps import resolve_project_voice_consistency
 
 _CONFIRM_DURATION_SCHEMA_PROPERTY = {
     "type": "boolean",
@@ -134,12 +130,7 @@ async def _pending_duration_confirmations(
     return items
 
 
-def _get_video_prompt(
-    item: dict[str, Any],
-    *,
-    characters: dict[str, Any] | None = None,
-    inject_voice_profiles: bool = False,
-) -> str:
+def _get_video_prompt(item: dict[str, Any], *, voice_characters: dict[str, Any] | None = None) -> str:
     prompt = item.get("video_prompt")
     if not prompt:
         item_id = item.get("segment_id") or item.get("scene_id")
@@ -148,14 +139,7 @@ def _get_video_prompt(
         # drama 口型台词单一真相源在场景级有序 utterances：取 dialogue-kind 注入 video YAML 的
         # dialogue 出口（drama video_prompt 已不带 dialogue）。narration / ad 无 utterances 字段、原样渲染。
         if "utterances" in item:
-            dialogue = utterances_to_dialogue(item.get("utterances"))
-            prompt = {**prompt, "dialogue": dialogue}
-            # C 类（真无声）模型不注入 Voice_Profiles；口径与 worker 执行路径同源
-            # （见 server.services.generation_tasks.execute_video_task）。
-            if inject_voice_profiles:
-                voice_profiles = build_voice_profiles(dialogue, characters or {})
-                if voice_profiles:
-                    prompt = {**prompt, "voice_profiles": voice_profiles}
+            prompt = build_drama_video_prompt(prompt, item.get("utterances"), characters=voice_characters)
         return video_prompt_to_yaml(prompt)
     if isinstance(prompt, dict):
         item_id = item.get("segment_id") or item.get("scene_id")
@@ -166,14 +150,18 @@ def _get_video_prompt(
     return prompt
 
 
-async def _resolve_voice_injection(ctx: ToolContext, content_mode: str) -> tuple[dict[str, Any] | None, bool]:
-    """drama 项目解析角色资产与声音一致性档位，供 Voice_Profiles 注入判定；非 drama 直接跳过
-    （无需为 narration/ad 项目多付一次项目视频能力解析）。"""
+async def _resolve_voice_characters(ctx: ToolContext, content_mode: str) -> dict[str, Any] | None:
+    """供 Voice_Profiles 注入的角色资产；``None`` 表示本次不注入。
+
+    非 drama 直接返回 None（无需为 narration/ad 项目多付一次项目视频能力解析），drama 再按
+    声音一致性档位排除 C 类（真无声）模型。
+    """
     if content_mode != "drama":
-        return None, False
+        return None
     project = ctx.pm.load_project(ctx.project_name)
-    voice_consistency = await resolve_project_voice_consistency(project)
-    return project.get("characters") or {}, voice_consistency != "none"
+    if await resolve_project_voice_consistency(project) == "none":
+        return None
+    return project.get("characters") or {}
 
 
 def _is_ad_reference(ctx: ToolContext, script: dict[str, Any]) -> bool:
@@ -230,8 +218,7 @@ def _build_video_specs(
     project_dir: Path,
     skip_ids: list[str] | None,
     log: list[str],
-    characters: dict[str, Any] | None = None,
-    inject_voice_profiles: bool = False,
+    voice_characters: dict[str, Any] | None = None,
 ) -> tuple[list[TaskSpec], dict[str, int]]:
     item_type = "片段" if content_mode == "narration" else "场景"
     skip_set = set(skip_ids or [])
@@ -260,7 +247,7 @@ def _build_video_specs(
             continue
 
         try:
-            prompt = _get_video_prompt(item, characters=characters, inject_voice_profiles=inject_voice_profiles)
+            prompt = _get_video_prompt(item, voice_characters=voice_characters)
         except Exception as exc:  # noqa: BLE001
             log.append(f"⚠️  {item_type} {item_id} 的 video_prompt 无效，跳过: {exc}")
             continue
@@ -711,7 +698,7 @@ def generate_video_episode_tool(ctx: ToolContext):
             videos_dir = project_dir / "videos"
             videos_dir.mkdir(parents=True, exist_ok=True)
             ordered_paths, already_done, completed = _scan_completed_items(items, id_field, completed, videos_dir)
-            characters, inject_voice_profiles = await _resolve_voice_injection(ctx, content_mode)
+            voice_characters = await _resolve_voice_characters(ctx, content_mode)
             specs, order_map = _build_video_specs(
                 items=items,
                 id_field=id_field,
@@ -720,8 +707,7 @@ def generate_video_episode_tool(ctx: ToolContext):
                 project_dir=project_dir,
                 skip_ids=already_done,
                 log=log,
-                characters=characters,
-                inject_voice_profiles=inject_voice_profiles,
+                voice_characters=voice_characters,
             )
 
             if not specs and not any(ordered_paths):
@@ -822,8 +808,8 @@ def generate_video_scene_tool(ctx: ToolContext):
                 raise FileNotFoundError(f"分镜图不存在: {storyboard_path}")
 
             content_mode = script.get("content_mode", "narration")
-            characters, inject_voice_profiles = await _resolve_voice_injection(ctx, content_mode)
-            prompt = _get_video_prompt(item, characters=characters, inject_voice_profiles=inject_voice_profiles)
+            voice_characters = await _resolve_voice_characters(ctx, content_mode)
+            prompt = _get_video_prompt(item, voice_characters=voice_characters)
             # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；
             # 原样透传调用方显式指定的值，不在入队侧做 int() 截断式归一化（否则会把
             # 本应被执行层拒绝的非法值静默修正）。缺省由执行层按 caps 收口默认。
@@ -907,7 +893,7 @@ def generate_video_all_tool(ctx: ToolContext):
             if not pending:
                 return {"content": [{"type": "text", "text": "✨ 所有场景/片段的视频都已生成"}]}
 
-            characters, inject_voice_profiles = await _resolve_voice_injection(ctx, content_mode)
+            voice_characters = await _resolve_voice_characters(ctx, content_mode)
             specs, _order_map = _build_video_specs(
                 items=pending,
                 id_field=id_field,
@@ -916,8 +902,7 @@ def generate_video_all_tool(ctx: ToolContext):
                 project_dir=project_dir,
                 skip_ids=None,
                 log=log,
-                characters=characters,
-                inject_voice_profiles=inject_voice_profiles,
+                voice_characters=voice_characters,
             )
             if not specs:
                 return {"content": [{"type": "text", "text": "\n".join([*log, "⚠️  没有任何可生成的视频任务"])}]}
@@ -1044,7 +1029,7 @@ def generate_video_selected_tool(ctx: ToolContext):
             videos_dir = project_dir / "videos"
             videos_dir.mkdir(parents=True, exist_ok=True)
             ordered_paths, already_done, completed = _scan_completed_items(selected, id_field, completed, videos_dir)
-            characters, inject_voice_profiles = await _resolve_voice_injection(ctx, content_mode)
+            voice_characters = await _resolve_voice_characters(ctx, content_mode)
             specs, order_map = _build_video_specs(
                 items=selected,
                 id_field=id_field,
@@ -1053,8 +1038,7 @@ def generate_video_selected_tool(ctx: ToolContext):
                 project_dir=project_dir,
                 skip_ids=already_done,
                 log=log,
-                characters=characters,
-                inject_voice_profiles=inject_voice_profiles,
+                voice_characters=voice_characters,
             )
 
             # ``_build_video_specs`` 可能把所有 selected 都过滤掉（缺分镜图 /

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -22,6 +22,7 @@ from lib.generation_queue_client import (
 from lib.project_manager import ProjectManager, is_reference_video_episode
 from lib.prompt_utils import (
     build_drama_video_prompt,
+    build_drama_video_prompt_from_legacy_dialogue,
     is_structured_video_prompt,
     strip_voice_profiles,
     video_prompt_to_yaml,
@@ -131,20 +132,27 @@ async def _pending_duration_confirmations(
     return items
 
 
-def _get_video_prompt(item: dict[str, Any], *, voice_characters: dict[str, Any] | None = None) -> str:
+def _get_video_prompt(
+    item: dict[str, Any], *, content_mode: str, voice_characters: dict[str, Any] | None = None
+) -> str:
     prompt = item.get("video_prompt")
     if not prompt:
         item_id = item.get("segment_id") or item.get("scene_id")
         raise ValueError(f"片段/场景缺少 video_prompt 字段: {item_id}")
     if is_structured_video_prompt(prompt):
-        # Voice_Profiles 声明段唯一来源是下方 build_drama_video_prompt 的机械派生：剧本 JSON
-        # 里残留的 voice_profiles 一律先剥离，不因 utterances 门控不触发（narration/ad、或
-        # drama 无 utterances 的条目）而绕过 C 类（真无声）门控直达 YAML。
+        # Voice_Profiles 声明段唯一来源是下方 build_drama_video_prompt 系的机械派生：剧本 JSON
+        # 里残留的 voice_profiles 一律先剥离，不因门控不触发（narration/ad、或 drama 无
+        # utterances 的条目）而绕过 C 类（真无声）门控直达 YAML。
         prompt = strip_voice_profiles(prompt)
-        # drama 口型台词单一真相源在场景级有序 utterances：取 dialogue-kind 注入 video YAML 的
-        # dialogue 出口（drama video_prompt 已不带 dialogue）。narration / ad 无 utterances 字段、原样渲染。
-        if "utterances" in item:
-            prompt = build_drama_video_prompt(prompt, item.get("utterances"), characters=voice_characters)
+        if content_mode == "drama":
+            # drama 口型台词单一真相源在场景级有序 utterances：取 dialogue-kind 注入 video YAML 的
+            # dialogue 出口（drama video_prompt 已不带 dialogue）。utterances 迁移前的存量剧本
+            # （load_script 按原始 JSON 读盘不过 pydantic，不会被 DramaScene._migrate_legacy
+            # 自动补齐）台词仍留在 video_prompt.dialogue，改走 legacy 出口。
+            if "utterances" in item:
+                prompt = build_drama_video_prompt(prompt, item.get("utterances"), characters=voice_characters)
+            else:
+                prompt = build_drama_video_prompt_from_legacy_dialogue(prompt, characters=voice_characters)
         return video_prompt_to_yaml(prompt)
     if isinstance(prompt, dict):
         item_id = item.get("segment_id") or item.get("scene_id")
@@ -156,7 +164,7 @@ def _get_video_prompt(item: dict[str, Any], *, voice_characters: dict[str, Any] 
 
 
 async def _resolve_voice_characters(ctx: ToolContext, content_mode: str) -> dict[str, Any] | None:
-    """供 Voice_Profiles 注入的角色资产；``None`` 表示本次不注入。
+    """供 Voice_Profiles 注入的角色资产；``None`` 表示不注入。
 
     非 drama 直接返回 None（无需为 narration/ad 项目多付一次项目视频能力解析），drama 再按
     声音一致性档位排除 C 类（真无声）模型。
@@ -252,7 +260,7 @@ def _build_video_specs(
             continue
 
         try:
-            prompt = _get_video_prompt(item, voice_characters=voice_characters)
+            prompt = _get_video_prompt(item, content_mode=content_mode, voice_characters=voice_characters)
         except Exception as exc:  # noqa: BLE001
             log.append(f"⚠️  {item_type} {item_id} 的 video_prompt 无效，跳过: {exc}")
             continue
@@ -814,7 +822,7 @@ def generate_video_scene_tool(ctx: ToolContext):
 
             content_mode = script.get("content_mode", "narration")
             voice_characters = await _resolve_voice_characters(ctx, content_mode)
-            prompt = _get_video_prompt(item, voice_characters=voice_characters)
+            prompt = _get_video_prompt(item, content_mode=content_mode, voice_characters=voice_characters)
             # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；
             # 原样透传调用方显式指定的值，不在入队侧做 int() 截断式归一化（否则会把
             # 本应被执行层拒绝的非法值静默修正）。缺省由执行层按 caps 收口默认。

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -33,7 +33,7 @@ from lib.reference_video.ad_units import (
     resolve_ad_unit_shots,
     sync_ad_reference_units,
 )
-from lib.script_models import get_generated_assets, is_reference_script
+from lib.script_models import get_generated_assets, is_reference_script, resolve_content_mode
 from lib.storyboard_sequence import get_storyboard_items, resolve_storyboard_image_ref
 from server.agent_runtime.sdk_tools._context import (
     ToolContext,
@@ -695,7 +695,7 @@ def generate_video_episode_tool(ctx: ToolContext):
 
             episode = ProjectManager.resolve_episode_from_script(script, script_filename)
             items, id_field, _chars, _scenes, _props = get_storyboard_items(script)
-            content_mode = script.get("content_mode", "narration")
+            content_mode = resolve_content_mode(script, ctx.pm.load_project(ctx.project_name))
             if not items:
                 raise ValueError(f"第 {episode} 集剧本为空：{script_filename}")
 
@@ -820,7 +820,7 @@ def generate_video_scene_tool(ctx: ToolContext):
             if not storyboard_path.is_file():
                 raise FileNotFoundError(f"分镜图不存在: {storyboard_path}")
 
-            content_mode = script.get("content_mode", "narration")
+            content_mode = resolve_content_mode(script, ctx.pm.load_project(ctx.project_name))
             voice_characters = await _resolve_voice_characters(ctx, content_mode)
             prompt = _get_video_prompt(item, content_mode=content_mode, voice_characters=voice_characters)
             # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；
@@ -901,7 +901,7 @@ def generate_video_all_tool(ctx: ToolContext):
                 )
 
             items, id_field, _chars, _scenes, _props = get_storyboard_items(script)
-            content_mode = script.get("content_mode", "narration")
+            content_mode = resolve_content_mode(script, ctx.pm.load_project(ctx.project_name))
             pending = [it for it in items if not get_generated_assets(it).get("video_clip")]
             if not pending:
                 return {"content": [{"type": "text", "text": "✨ 所有场景/片段的视频都已生成"}]}
@@ -998,7 +998,7 @@ def generate_video_selected_tool(ctx: ToolContext):
                 )
 
             items, id_field, _chars, _scenes, _props = get_storyboard_items(script)
-            content_mode = script.get("content_mode", "narration")
+            content_mode = resolve_content_mode(script, ctx.pm.load_project(ctx.project_name))
 
             items_by_id: dict[str, dict[str, Any]] = {}
             for item in items:

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -20,7 +21,12 @@ from lib.generation_queue_client import (
     enqueue_and_wait,
 )
 from lib.project_manager import ProjectManager, is_reference_video_episode
-from lib.prompt_utils import is_structured_video_prompt, utterances_to_dialogue, video_prompt_to_yaml
+from lib.prompt_utils import (
+    build_voice_profiles,
+    is_structured_video_prompt,
+    utterances_to_dialogue,
+    video_prompt_to_yaml,
+)
 from lib.reference_video import assemble_shots_text
 from lib.reference_video.ad_units import (
     render_ad_unit_prompt,
@@ -39,7 +45,10 @@ from server.services.reference_video_tasks import (
     precheck_unit,
     resolve_max_unit_duration,
     resolve_project_duration_context,
+    resolve_project_voice_consistency,
 )
+
+logger = logging.getLogger(__name__)
 
 _CONFIRM_DURATION_SCHEMA_PROPERTY = {
     "type": "boolean",
@@ -125,7 +134,12 @@ async def _pending_duration_confirmations(
     return items
 
 
-def _get_video_prompt(item: dict[str, Any]) -> str:
+def _get_video_prompt(
+    item: dict[str, Any],
+    *,
+    characters: dict[str, Any] | None = None,
+    inject_voice_profiles: bool = False,
+) -> str:
     prompt = item.get("video_prompt")
     if not prompt:
         item_id = item.get("segment_id") or item.get("scene_id")
@@ -134,7 +148,14 @@ def _get_video_prompt(item: dict[str, Any]) -> str:
         # drama 口型台词单一真相源在场景级有序 utterances：取 dialogue-kind 注入 video YAML 的
         # dialogue 出口（drama video_prompt 已不带 dialogue）。narration / ad 无 utterances 字段、原样渲染。
         if "utterances" in item:
-            prompt = {**prompt, "dialogue": utterances_to_dialogue(item.get("utterances"))}
+            dialogue = utterances_to_dialogue(item.get("utterances"))
+            prompt = {**prompt, "dialogue": dialogue}
+            # C 类（真无声）模型不注入 Voice_Profiles；口径与 worker 执行路径同源
+            # （见 server.services.generation_tasks.execute_video_task）。
+            if inject_voice_profiles:
+                voice_profiles = build_voice_profiles(dialogue, characters or {})
+                if voice_profiles:
+                    prompt = {**prompt, "voice_profiles": voice_profiles}
         return video_prompt_to_yaml(prompt)
     if isinstance(prompt, dict):
         item_id = item.get("segment_id") or item.get("scene_id")
@@ -143,6 +164,16 @@ def _get_video_prompt(item: dict[str, Any]) -> str:
         item_id = item.get("segment_id") or item.get("scene_id")
         raise TypeError(f"片段/场景 video_prompt 类型无效（期望 str 或 dict）: {item_id}")
     return prompt
+
+
+async def _resolve_voice_injection(ctx: ToolContext, content_mode: str) -> tuple[dict[str, Any] | None, bool]:
+    """drama 项目解析角色资产与声音一致性档位，供 Voice_Profiles 注入判定；非 drama 直接跳过
+    （无需为 narration/ad 项目多付一次项目视频能力解析）。"""
+    if content_mode != "drama":
+        return None, False
+    project = ctx.pm.load_project(ctx.project_name)
+    voice_consistency = await resolve_project_voice_consistency(project)
+    return project.get("characters") or {}, voice_consistency != "none"
 
 
 def _is_ad_reference(ctx: ToolContext, script: dict[str, Any]) -> bool:
@@ -199,6 +230,8 @@ def _build_video_specs(
     project_dir: Path,
     skip_ids: list[str] | None,
     log: list[str],
+    characters: dict[str, Any] | None = None,
+    inject_voice_profiles: bool = False,
 ) -> tuple[list[TaskSpec], dict[str, int]]:
     item_type = "片段" if content_mode == "narration" else "场景"
     skip_set = set(skip_ids or [])
@@ -227,7 +260,7 @@ def _build_video_specs(
             continue
 
         try:
-            prompt = _get_video_prompt(item)
+            prompt = _get_video_prompt(item, characters=characters, inject_voice_profiles=inject_voice_profiles)
         except Exception as exc:  # noqa: BLE001
             log.append(f"⚠️  {item_type} {item_id} 的 video_prompt 无效，跳过: {exc}")
             continue
@@ -678,6 +711,7 @@ def generate_video_episode_tool(ctx: ToolContext):
             videos_dir = project_dir / "videos"
             videos_dir.mkdir(parents=True, exist_ok=True)
             ordered_paths, already_done, completed = _scan_completed_items(items, id_field, completed, videos_dir)
+            characters, inject_voice_profiles = await _resolve_voice_injection(ctx, content_mode)
             specs, order_map = _build_video_specs(
                 items=items,
                 id_field=id_field,
@@ -686,6 +720,8 @@ def generate_video_episode_tool(ctx: ToolContext):
                 project_dir=project_dir,
                 skip_ids=already_done,
                 log=log,
+                characters=characters,
+                inject_voice_profiles=inject_voice_profiles,
             )
 
             if not specs and not any(ordered_paths):
@@ -785,7 +821,9 @@ def generate_video_scene_tool(ctx: ToolContext):
             if not storyboard_path.is_file():
                 raise FileNotFoundError(f"分镜图不存在: {storyboard_path}")
 
-            prompt = _get_video_prompt(item)
+            content_mode = script.get("content_mode", "narration")
+            characters, inject_voice_profiles = await _resolve_voice_injection(ctx, content_mode)
+            prompt = _get_video_prompt(item, characters=characters, inject_voice_profiles=inject_voice_profiles)
             # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；
             # 原样透传调用方显式指定的值，不在入队侧做 int() 截断式归一化（否则会把
             # 本应被执行层拒绝的非法值静默修正）。缺省由执行层按 caps 收口默认。
@@ -869,6 +907,7 @@ def generate_video_all_tool(ctx: ToolContext):
             if not pending:
                 return {"content": [{"type": "text", "text": "✨ 所有场景/片段的视频都已生成"}]}
 
+            characters, inject_voice_profiles = await _resolve_voice_injection(ctx, content_mode)
             specs, _order_map = _build_video_specs(
                 items=pending,
                 id_field=id_field,
@@ -877,6 +916,8 @@ def generate_video_all_tool(ctx: ToolContext):
                 project_dir=project_dir,
                 skip_ids=None,
                 log=log,
+                characters=characters,
+                inject_voice_profiles=inject_voice_profiles,
             )
             if not specs:
                 return {"content": [{"type": "text", "text": "\n".join([*log, "⚠️  没有任何可生成的视频任务"])}]}
@@ -1003,6 +1044,7 @@ def generate_video_selected_tool(ctx: ToolContext):
             videos_dir = project_dir / "videos"
             videos_dir.mkdir(parents=True, exist_ok=True)
             ordered_paths, already_done, completed = _scan_completed_items(selected, id_field, completed, videos_dir)
+            characters, inject_voice_profiles = await _resolve_voice_injection(ctx, content_mode)
             specs, order_map = _build_video_specs(
                 items=selected,
                 id_field=id_field,
@@ -1011,6 +1053,8 @@ def generate_video_selected_tool(ctx: ToolContext):
                 project_dir=project_dir,
                 skip_ids=already_done,
                 log=log,
+                characters=characters,
+                inject_voice_profiles=inject_voice_profiles,
             )
 
             # ``_build_video_specs`` 可能把所有 selected 都过滤掉（缺分镜图 /

--- a/server/services/generation_context.py
+++ b/server/services/generation_context.py
@@ -320,7 +320,7 @@ async def resolve_generation_context(
                 supported_durations = tuple(int(d) for d in caps.get("supported_durations") or [])
                 max_duration = caps.get("max_duration")
                 max_reference_images = caps.get("max_reference_images")
-                voice_consistency = caps.get("voice_consistency", "soft")
+                voice_consistency = caps.get("voice_consistency") or "soft"
             except Exception as exc:
                 logger.info(
                     "无法解析 video capabilities（%s/%s），能力值降级为空：%s",

--- a/server/services/generation_context.py
+++ b/server/services/generation_context.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from lib.audio_backends.base import VoiceOption
 from lib.backend_assembly import assemble_backend
-from lib.config.resolver import ConfigResolver, get_provider_fallback
+from lib.config.resolver import ConfigResolver, VoiceConsistency, get_provider_fallback
 from lib.db.base import DEFAULT_USER_ID
 from lib.gemini_shared import get_shared_rate_limiter
 from lib.media_generator import MediaGenerator
@@ -198,6 +198,9 @@ class VideoLaneResult:
     supported_durations: tuple[int, ...]
     max_duration: int | None
     max_reference_images: int | None
+    # 能力查询失败时降级为 "soft"（有信号才判定为真无声，与既有「无信号不落 none」口径一致，
+    # 见 lib.config.resolver.derive_voice_consistency）。
+    voice_consistency: VoiceConsistency = "soft"
 
 
 @dataclass(frozen=True)
@@ -311,11 +314,13 @@ async def resolve_generation_context(
             supported_durations: tuple[int, ...] = ()
             max_duration: int | None = None
             max_reference_images: int | None = None
+            voice_consistency: VoiceConsistency = "soft"
             try:
                 caps = await r.video_capabilities_for_model(resolved.provider_id, actual_model, project)
                 supported_durations = tuple(int(d) for d in caps.get("supported_durations") or [])
                 max_duration = caps.get("max_duration")
                 max_reference_images = caps.get("max_reference_images")
+                voice_consistency = caps.get("voice_consistency", "soft")
             except Exception as exc:
                 logger.info(
                     "无法解析 video capabilities（%s/%s），能力值降级为空：%s",
@@ -332,6 +337,7 @@ async def resolve_generation_context(
                 supported_durations=supported_durations,
                 max_duration=max_duration,
                 max_reference_images=max_reference_images,
+                voice_consistency=voice_consistency,
             )
 
         if audio is not None:

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -31,6 +31,7 @@ from lib.prompt_builders import (
     build_scene_prompt,
 )
 from lib.prompt_utils import (
+    build_voice_profiles,
     image_prompt_to_yaml,
     is_structured_image_prompt,
     is_structured_video_prompt,
@@ -148,6 +149,7 @@ def _normalize_video_prompt(prompt: str | dict) -> str:
         "camera_motion": str(prompt.get("camera_motion", "") or "") or "Static",
         "ambiance_audio": str(prompt.get("ambiance_audio", "") or ""),
         "dialogue": normalized_dialogue,
+        "voice_profiles": prompt.get("voice_profiles") or [],
     }
     return append_video_negative_tail(video_prompt_to_yaml(normalized_prompt))
 
@@ -920,7 +922,14 @@ async def execute_video_task(
     # 的 dialogue 出口（覆盖 payload 里 drama 已不再携带的 video_prompt.dialogue）。narration / ad
     # 的 item 无 utterances 字段，payload.dialogue 原样透传；SDK 路径 prompt 已是渲染好的字符串、跳过。
     if isinstance(item, dict) and "utterances" in item and isinstance(prompt, dict):
-        prompt = {**prompt, "dialogue": utterances_to_dialogue(item.get("utterances"))}
+        dialogue = utterances_to_dialogue(item.get("utterances"))
+        prompt = {**prompt, "dialogue": dialogue}
+        # C 类（真无声）模型不注入 Voice_Profiles；有音轨模型（含恒有声、开关不可控的
+        # gemini-aistudio/grok）机械派生角色声音风格声明段，口径与 voice_consistency 同源。
+        if ctx.video.voice_consistency != "none":
+            voice_profiles = build_voice_profiles(dialogue, project.get("characters") or {})
+            if voice_profiles:
+                prompt = {**prompt, "voice_profiles": voice_profiles}
 
     prompt_text = _normalize_video_prompt(prompt)
     aspect_ratio = get_aspect_ratio(project, "videos")

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -32,6 +32,7 @@ from lib.prompt_builders import (
 )
 from lib.prompt_utils import (
     build_drama_video_prompt,
+    build_drama_video_prompt_from_legacy_dialogue,
     image_prompt_to_yaml,
     is_structured_image_prompt,
     is_structured_video_prompt,
@@ -895,9 +896,9 @@ async def execute_video_task(
         _items, _id_field, _, _, _ = get_storyboard_items(_script)
         _resolved = find_storyboard_item(_items, _id_field, resource_id)
         _item = _resolved[0] if _resolved else {}
-        return _project, _project_path, _item
+        return _project, _project_path, _item, _script.get("content_mode", "narration")
 
-    project, project_path, item = await asyncio.to_thread(_load)
+    project, project_path, item, content_mode = await asyncio.to_thread(_load)
     ctx = await resolve_generation_context(
         project_name,
         payload,
@@ -927,14 +928,16 @@ async def execute_video_task(
     # drama 口型台词单一真相源在场景级有序 utterances：从 dialogue-kind 条目取台词注入 video YAML
     # 的 dialogue 出口（覆盖 payload 里 drama 已不再携带的 video_prompt.dialogue）。narration / ad
     # 的 item 无 utterances 字段，payload.dialogue 原样透传；SDK 路径 prompt 已是渲染好的字符串、跳过。
-    if isinstance(item, dict) and "utterances" in item and isinstance(prompt, dict):
+    if isinstance(item, dict) and isinstance(prompt, dict) and content_mode == "drama":
         # C 类（真无声）模型传 characters=None 即不注入 Voice_Profiles；有音轨模型（含恒有声、
         # 开关不可控的 gemini-aistudio/grok）机械派生角色声音风格，口径与 voice_consistency 同源。
-        prompt = build_drama_video_prompt(
-            prompt,
-            item.get("utterances"),
-            characters=(project.get("characters") or {}) if ctx.video.voice_consistency != "none" else None,
-        )
+        voice_characters = (project.get("characters") or {}) if ctx.video.voice_consistency != "none" else None
+        if "utterances" in item:
+            prompt = build_drama_video_prompt(prompt, item.get("utterances"), characters=voice_characters)
+        else:
+            # utterances 迁移前的存量剧本：load_script 按原始 JSON 读盘不过 pydantic，不会
+            # 被 DramaScene._migrate_legacy 自动补齐，台词仍留在 video_prompt.dialogue。
+            prompt = build_drama_video_prompt_from_legacy_dialogue(prompt, characters=voice_characters)
 
     prompt_text = _normalize_video_prompt(prompt)
     aspect_ratio = get_aspect_ratio(project, "videos")

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -40,7 +40,7 @@ from lib.prompt_utils import (
     video_prompt_to_yaml,
 )
 from lib.resource_paths import END_FRAME_RESOURCE_TYPE, resource_relative_path
-from lib.script_models import get_generated_assets
+from lib.script_models import get_generated_assets, resolve_content_mode
 from lib.script_skeleton import SKELETON_ENTITY_TYPES, SKELETON_ITEM_NOUNS, resolve_script_kind
 from lib.storyboard_sequence import (
     build_previous_storyboard_reference,
@@ -896,7 +896,7 @@ async def execute_video_task(
         _items, _id_field, _, _, _ = get_storyboard_items(_script)
         _resolved = find_storyboard_item(_items, _id_field, resource_id)
         _item = _resolved[0] if _resolved else {}
-        return _project, _project_path, _item, _script.get("content_mode", "narration")
+        return _project, _project_path, _item, resolve_content_mode(_script, _project)
 
     project, project_path, item, content_mode = await asyncio.to_thread(_load)
     ctx = await resolve_generation_context(

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -35,6 +35,7 @@ from lib.prompt_utils import (
     image_prompt_to_yaml,
     is_structured_image_prompt,
     is_structured_video_prompt,
+    strip_voice_profiles,
     video_prompt_to_yaml,
 )
 from lib.resource_paths import END_FRAME_RESOURCE_TYPE, resource_relative_path
@@ -916,6 +917,12 @@ async def execute_video_task(
     # True，目录会被当作 start_image 传给视频后端，在编码阶段才失败且原因不可读。
     if not storyboard_file.is_file():
         raise ValueError(f"storyboard not found: {storyboard_file.name}")
+
+    # Voice_Profiles 声明段唯一来源是下方 build_drama_video_prompt 的机械派生：调用方（WebUI
+    # 请求体 / 剧本 JSON 残留）自带的 voice_profiles 一律先剥离，不因 utterances 门控不触发
+    # （narration/ad、或 drama 无 utterances 的条目）而绕过 C 类（真无声）门控直达 YAML。
+    if isinstance(prompt, dict):
+        prompt = strip_voice_profiles(prompt)
 
     # drama 口型台词单一真相源在场景级有序 utterances：从 dialogue-kind 条目取台词注入 video YAML
     # 的 dialogue 出口（覆盖 payload 里 drama 已不再携带的 video_prompt.dialogue）。narration / ad

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -31,11 +31,10 @@ from lib.prompt_builders import (
     build_scene_prompt,
 )
 from lib.prompt_utils import (
-    build_voice_profiles,
+    build_drama_video_prompt,
     image_prompt_to_yaml,
     is_structured_image_prompt,
     is_structured_video_prompt,
-    utterances_to_dialogue,
     video_prompt_to_yaml,
 )
 from lib.resource_paths import END_FRAME_RESOURCE_TYPE, resource_relative_path
@@ -922,14 +921,13 @@ async def execute_video_task(
     # 的 dialogue 出口（覆盖 payload 里 drama 已不再携带的 video_prompt.dialogue）。narration / ad
     # 的 item 无 utterances 字段，payload.dialogue 原样透传；SDK 路径 prompt 已是渲染好的字符串、跳过。
     if isinstance(item, dict) and "utterances" in item and isinstance(prompt, dict):
-        dialogue = utterances_to_dialogue(item.get("utterances"))
-        prompt = {**prompt, "dialogue": dialogue}
-        # C 类（真无声）模型不注入 Voice_Profiles；有音轨模型（含恒有声、开关不可控的
-        # gemini-aistudio/grok）机械派生角色声音风格声明段，口径与 voice_consistency 同源。
-        if ctx.video.voice_consistency != "none":
-            voice_profiles = build_voice_profiles(dialogue, project.get("characters") or {})
-            if voice_profiles:
-                prompt = {**prompt, "voice_profiles": voice_profiles}
+        # C 类（真无声）模型传 characters=None 即不注入 Voice_Profiles；有音轨模型（含恒有声、
+        # 开关不可控的 gemini-aistudio/grok）机械派生角色声音风格，口径与 voice_consistency 同源。
+        prompt = build_drama_video_prompt(
+            prompt,
+            item.get("utterances"),
+            characters=(project.get("characters") or {}) if ctx.video.voice_consistency != "none" else None,
+        )
 
     prompt_text = _normalize_video_prompt(prompt)
     aspect_ratio = get_aspect_ratio(project, "videos")

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -15,7 +15,7 @@ from typing import Any
 from sqlalchemy.exc import SQLAlchemyError
 
 from lib.asset_types import ASSET_SPECS, BUCKET_KEY, SHEET_KEY
-from lib.config.resolver import ConfigResolver, VoiceConsistency, constrain_durations, get_provider_fallback
+from lib.config.resolver import ConfigResolver, constrain_durations, get_provider_fallback
 from lib.db import async_session_factory
 from lib.db.base import DEFAULT_USER_ID
 from lib.generation_queue import get_generation_queue
@@ -38,6 +38,7 @@ from server.services.generation_tasks import (
     collect_product_references_for_names,
     get_project_manager,
 )
+from server.services.video_caps import project_video_caps
 
 logger = logging.getLogger(__name__)
 
@@ -231,7 +232,7 @@ async def resolve_project_duration_context(project: dict) -> ProjectDurationCont
     空档位下分辨率约束无意义。``max_duration`` 与 :func:`resolve_max_unit_duration`
     取自同一份能力解析结果，供需要现推分组的调用方复用而不再触发一次 IO。
     """
-    caps = await _project_video_caps(project, degraded_to="时长取档不施加档位约束")
+    caps = await project_video_caps(project, degraded_to="时长取档不施加档位约束")
     durations = tuple(int(d) for d in caps.get("supported_durations") or [])
     provider_id = str(caps.get("provider_id") or "")
     model = caps.get("model")
@@ -272,29 +273,6 @@ def precheck_unit(ctx: ProjectDurationContext, unit: dict, ad_shots: list[dict] 
     return resolve_duration_slot(unit_script_duration(unit, ad_shots), durations)
 
 
-async def _project_video_caps(project: dict, *, degraded_to: str) -> dict:
-    """项目视频后端的 model 粒度能力；解析失败返回空 dict，由调用方各自降级。
-
-    ``degraded_to`` 只用于日志，说明这次解析失败会让调用方退化成什么行为。
-    """
-    try:
-        resolver = ConfigResolver(async_session_factory)
-        return await resolver.video_capabilities_for_project(project)
-    except (ValueError, SQLAlchemyError) as exc:
-        logger.info("无法解析 video_capabilities，%s：%s", degraded_to, exc)
-        return {}
-
-
-async def resolve_project_voice_consistency(project: dict) -> VoiceConsistency:
-    """项目当前视频后端的声音一致性档位，供 drama Voice_Profiles 注入前的 C 类（真无声）判定。
-
-    解析失败按既有「无信号不判定为真无声」口径退化为 ``soft``（同 ``derive_voice_consistency``
-    对自定义供应商缺失 ``generate_audio`` 声明时的处理）。
-    """
-    caps = await _project_video_caps(project, degraded_to="Voice_Profiles 按 soft 兜底注入")
-    return caps.get("voice_consistency") or "soft"
-
-
 async def _project_video_resolution(project: dict, provider_id: str, model_id: str | None) -> str | None:
     """项目视频后端实际下发的分辨率；解析失败返回 None（该条约束随之不收窄）。
 
@@ -320,7 +298,7 @@ async def resolve_max_unit_duration(project: dict) -> int | None:
     model 粒度 ``max_duration``）；解析失败返回 None——分组退化为仅按镜头数
     切分，超长 unit 交由执行层取档 + warning 兜底，不阻塞派生。
     """
-    caps = await _project_video_caps(project, degraded_to="派生分组不施加时长上限")
+    caps = await project_video_caps(project, degraded_to="派生分组不施加时长上限")
     max_duration = caps.get("max_duration")
     return int(max_duration) if max_duration else None
 

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -15,7 +15,7 @@ from typing import Any
 from sqlalchemy.exc import SQLAlchemyError
 
 from lib.asset_types import ASSET_SPECS, BUCKET_KEY, SHEET_KEY
-from lib.config.resolver import ConfigResolver, constrain_durations, get_provider_fallback
+from lib.config.resolver import ConfigResolver, VoiceConsistency, constrain_durations, get_provider_fallback
 from lib.db import async_session_factory
 from lib.db.base import DEFAULT_USER_ID
 from lib.generation_queue import get_generation_queue
@@ -283,6 +283,16 @@ async def _project_video_caps(project: dict, *, degraded_to: str) -> dict:
     except (ValueError, SQLAlchemyError) as exc:
         logger.info("无法解析 video_capabilities，%s：%s", degraded_to, exc)
         return {}
+
+
+async def resolve_project_voice_consistency(project: dict) -> VoiceConsistency:
+    """项目当前视频后端的声音一致性档位，供 drama Voice_Profiles 注入前的 C 类（真无声）判定。
+
+    解析失败按既有「无信号不判定为真无声」口径退化为 ``soft``（同 ``derive_voice_consistency``
+    对自定义供应商缺失 ``generate_audio`` 声明时的处理）。
+    """
+    caps = await _project_video_caps(project, degraded_to="Voice_Profiles 按 soft 兜底注入")
+    return caps.get("voice_consistency") or "soft"
 
 
 async def _project_video_resolution(project: dict, provider_id: str, model_id: str | None) -> str | None:

--- a/server/services/video_caps.py
+++ b/server/services/video_caps.py
@@ -1,7 +1,7 @@
 """项目级视频能力解析的共享出口。
 
 按「项目当前配置的视频后端」解析 model 粒度能力，供入队前的预检使用（时长取档、
-Voice_Profiles 注入判定）。入队时机尚未 resolve 本次任务实际的 provider/model——该解析
+Voice_Profiles 注入判定）。入队时机尚未 resolve 任务实际的 provider/model——该解析
 延后到 worker 执行时（见 ADR-0001），执行层请改用
 ``server.services.generation_context.resolve_generation_context`` 的精确结果。
 """

--- a/server/services/video_caps.py
+++ b/server/services/video_caps.py
@@ -1,0 +1,41 @@
+"""项目级视频能力解析的共享出口。
+
+按「项目当前配置的视频后端」解析 model 粒度能力，供入队前的预检使用（时长取档、
+Voice_Profiles 注入判定）。入队时机尚未 resolve 本次任务实际的 provider/model——该解析
+延后到 worker 执行时（见 ADR-0001），执行层请改用
+``server.services.generation_context.resolve_generation_context`` 的精确结果。
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from lib.config.resolver import ConfigResolver, VoiceConsistency
+from lib.db import async_session_factory
+
+logger = logging.getLogger(__name__)
+
+
+async def project_video_caps(project: dict, *, degraded_to: str) -> dict:
+    """项目视频后端的 model 粒度能力；解析失败返回空 dict，由调用方各自降级。
+
+    ``degraded_to`` 只用于日志，说明这次解析失败会让调用方退化成什么行为。
+    """
+    try:
+        resolver = ConfigResolver(async_session_factory)
+        return await resolver.video_capabilities_for_project(project)
+    except (ValueError, SQLAlchemyError) as exc:
+        logger.info("无法解析 video_capabilities，%s：%s", degraded_to, exc)
+        return {}
+
+
+async def resolve_project_voice_consistency(project: dict) -> VoiceConsistency:
+    """项目当前视频后端的声音一致性档位，供 drama Voice_Profiles 注入前的 C 类（真无声）判定。
+
+    解析失败按既有「无信号不判定为真无声」口径退化为 ``soft``（同 ``derive_voice_consistency``
+    对自定义供应商缺失 ``generate_audio`` 声明时的处理）。
+    """
+    caps = await project_video_caps(project, degraded_to="Voice_Profiles 按 soft 兜底注入")
+    return caps.get("voice_consistency") or "soft"

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1706,6 +1706,27 @@ def test_get_video_prompt_injects_voice_profiles_when_characters_given() -> None
     assert "Voice_Profiles" not in parsed_no_style
 
 
+def test_get_video_prompt_strips_caller_supplied_voice_profiles_for_non_drama() -> None:
+    """narration/ad（item 无 utterances 字段）剧本 video_prompt 自带 voice_profiles 时一律剥离：
+    该声明段唯一来源是 build_drama_video_prompt 的机械派生，剧本残留值不得越权、绕过 C 类
+    （真无声）门控直达 YAML。"""
+    import yaml
+
+    from server.agent_runtime.sdk_tools.enqueue_videos import _get_video_prompt
+
+    narration_item = {
+        "segment_id": "E1S01",
+        "video_prompt": {
+            "action": "走",
+            "camera_motion": "Static",
+            "ambiance_audio": "脚步声",
+            "voice_profiles": [{"Speaker": "赝品", "Voice_Style": "越权"}],
+        },
+    }
+    parsed = yaml.safe_load(_get_video_prompt(narration_item))
+    assert "Voice_Profiles" not in parsed
+
+
 async def test_resolve_voice_characters_skips_non_drama(fake_ctx: ToolContext) -> None:
     """narration/ad：不解析 voice_consistency，直接跳过（无 drama dialogue speaker 概念）。"""
     from server.agent_runtime.sdk_tools.enqueue_videos import _resolve_voice_characters

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1682,9 +1682,9 @@ def test_get_video_prompt_drama_sources_dialogue_from_utterances() -> None:
     assert parsed_narr["Dialogue"] == [{"Speaker": "Alice", "Line": "hello"}]
 
 
-def test_get_video_prompt_injects_voice_profiles_when_requested() -> None:
-    """drama：inject_voice_profiles=True 且角色资产带非空 voice_style 时，YAML 顶部出现
-    Voice_Profiles；缺省（inject_voice_profiles=False，既有调用点行为）不注入。"""
+def test_get_video_prompt_injects_voice_profiles_when_characters_given() -> None:
+    """drama：传入带非空 voice_style 的角色资产时 YAML 顶部出现 Voice_Profiles；
+    voice_characters 缺省（既有调用点行为）不注入。"""
     import yaml
 
     from server.agent_runtime.sdk_tools.enqueue_videos import _get_video_prompt
@@ -1696,47 +1696,41 @@ def test_get_video_prompt_injects_voice_profiles_when_requested() -> None:
     }
     characters = {"王": {"voice_style": "低沉沙哑"}}
 
-    parsed = yaml.safe_load(_get_video_prompt(drama_item, characters=characters, inject_voice_profiles=True))
+    parsed = yaml.safe_load(_get_video_prompt(drama_item, voice_characters=characters))
     assert parsed["Voice_Profiles"] == [{"Speaker": "王", "Voice_Style": "低沉沙哑"}]
 
-    parsed_default = yaml.safe_load(_get_video_prompt(drama_item, characters=characters))
+    parsed_default = yaml.safe_load(_get_video_prompt(drama_item))
     assert "Voice_Profiles" not in parsed_default
 
-    parsed_no_style = yaml.safe_load(
-        _get_video_prompt(drama_item, characters={"王": {"voice_style": ""}}, inject_voice_profiles=True)
-    )
+    parsed_no_style = yaml.safe_load(_get_video_prompt(drama_item, voice_characters={"王": {"voice_style": ""}}))
     assert "Voice_Profiles" not in parsed_no_style
 
 
-async def test_resolve_voice_injection_skips_non_drama(fake_ctx: ToolContext) -> None:
+async def test_resolve_voice_characters_skips_non_drama(fake_ctx: ToolContext) -> None:
     """narration/ad：不解析 voice_consistency，直接跳过（无 drama dialogue speaker 概念）。"""
-    from server.agent_runtime.sdk_tools.enqueue_videos import _resolve_voice_injection
+    from server.agent_runtime.sdk_tools.enqueue_videos import _resolve_voice_characters
 
-    characters, inject = await _resolve_voice_injection(fake_ctx, "narration")
-    assert characters is None
-    assert inject is False
+    assert await _resolve_voice_characters(fake_ctx, "narration") is None
 
 
-async def test_resolve_voice_injection_drama_reads_project_characters_and_gate(
+async def test_resolve_voice_characters_drama_reads_project_characters_and_gate(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
-    """drama：读项目角色资产，按 voice_consistency 是否为 none 决定注入开关。"""
+    """drama：读项目角色资产，voice_consistency 为 none（C 类真无声）时退回不注入。"""
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
 
     async def fake_voice_consistency(_project):
         return "soft"
 
     monkeypatch.setattr(mod, "resolve_project_voice_consistency", fake_voice_consistency)
-    characters, inject = await mod._resolve_voice_injection(fake_ctx, "drama")
+    characters = await mod._resolve_voice_characters(fake_ctx, "drama")
     assert characters == fake_ctx.pm.project_payload["characters"]  # type: ignore[attr-defined]
-    assert inject is True
 
     async def fake_voice_consistency_none(_project):
         return "none"
 
     monkeypatch.setattr(mod, "resolve_project_voice_consistency", fake_voice_consistency_none)
-    _characters, inject_none = await mod._resolve_voice_injection(fake_ctx, "drama")
-    assert inject_none is False
+    assert await mod._resolve_voice_characters(fake_ctx, "drama") is None
 
 
 def test_build_reference_specs_routes_through_guard(tmp_path) -> None:

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1682,6 +1682,63 @@ def test_get_video_prompt_drama_sources_dialogue_from_utterances() -> None:
     assert parsed_narr["Dialogue"] == [{"Speaker": "Alice", "Line": "hello"}]
 
 
+def test_get_video_prompt_injects_voice_profiles_when_requested() -> None:
+    """drama：inject_voice_profiles=True 且角色资产带非空 voice_style 时，YAML 顶部出现
+    Voice_Profiles；缺省（inject_voice_profiles=False，既有调用点行为）不注入。"""
+    import yaml
+
+    from server.agent_runtime.sdk_tools.enqueue_videos import _get_video_prompt
+
+    drama_item = {
+        "scene_id": "E1S01",
+        "video_prompt": {"action": "起身", "camera_motion": "Static", "ambiance_audio": "风声"},
+        "utterances": [{"kind": "dialogue", "speaker": "王", "text": "你来了。"}],
+    }
+    characters = {"王": {"voice_style": "低沉沙哑"}}
+
+    parsed = yaml.safe_load(_get_video_prompt(drama_item, characters=characters, inject_voice_profiles=True))
+    assert parsed["Voice_Profiles"] == [{"Speaker": "王", "Voice_Style": "低沉沙哑"}]
+
+    parsed_default = yaml.safe_load(_get_video_prompt(drama_item, characters=characters))
+    assert "Voice_Profiles" not in parsed_default
+
+    parsed_no_style = yaml.safe_load(
+        _get_video_prompt(drama_item, characters={"王": {"voice_style": ""}}, inject_voice_profiles=True)
+    )
+    assert "Voice_Profiles" not in parsed_no_style
+
+
+async def test_resolve_voice_injection_skips_non_drama(fake_ctx: ToolContext) -> None:
+    """narration/ad：不解析 voice_consistency，直接跳过（无 drama dialogue speaker 概念）。"""
+    from server.agent_runtime.sdk_tools.enqueue_videos import _resolve_voice_injection
+
+    characters, inject = await _resolve_voice_injection(fake_ctx, "narration")
+    assert characters is None
+    assert inject is False
+
+
+async def test_resolve_voice_injection_drama_reads_project_characters_and_gate(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """drama：读项目角色资产，按 voice_consistency 是否为 none 决定注入开关。"""
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    async def fake_voice_consistency(_project):
+        return "soft"
+
+    monkeypatch.setattr(mod, "resolve_project_voice_consistency", fake_voice_consistency)
+    characters, inject = await mod._resolve_voice_injection(fake_ctx, "drama")
+    assert characters == fake_ctx.pm.project_payload["characters"]  # type: ignore[attr-defined]
+    assert inject is True
+
+    async def fake_voice_consistency_none(_project):
+        return "none"
+
+    monkeypatch.setattr(mod, "resolve_project_voice_consistency", fake_voice_consistency_none)
+    _characters, inject_none = await mod._resolve_voice_injection(fake_ctx, "drama")
+    assert inject_none is False
+
+
 def test_build_reference_specs_routes_through_guard(tmp_path) -> None:
     """参考生视频入队经统一守卫点：prompt 由 shots 拼接后随 payload 入队（见 ADR-0001）。"""
     from server.agent_runtime.sdk_tools.enqueue_videos import _build_reference_specs

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1666,7 +1666,7 @@ def test_get_video_prompt_drama_sources_dialogue_from_utterances() -> None:
             {"kind": "dialogue", "speaker": "王", "text": "你来了。"},
         ],
     }
-    parsed = yaml.safe_load(_get_video_prompt(drama_item))
+    parsed = yaml.safe_load(_get_video_prompt(drama_item, content_mode="drama"))
     assert parsed["Dialogue"] == [{"Speaker": "王", "Line": "你来了。"}]
 
     narration_item = {
@@ -1678,7 +1678,7 @@ def test_get_video_prompt_drama_sources_dialogue_from_utterances() -> None:
             "dialogue": [{"speaker": "Alice", "line": "hello"}],
         },
     }
-    parsed_narr = yaml.safe_load(_get_video_prompt(narration_item))
+    parsed_narr = yaml.safe_load(_get_video_prompt(narration_item, content_mode="narration"))
     assert parsed_narr["Dialogue"] == [{"Speaker": "Alice", "Line": "hello"}]
 
 
@@ -1696,14 +1696,39 @@ def test_get_video_prompt_injects_voice_profiles_when_characters_given() -> None
     }
     characters = {"王": {"voice_style": "低沉沙哑"}}
 
-    parsed = yaml.safe_load(_get_video_prompt(drama_item, voice_characters=characters))
+    parsed = yaml.safe_load(_get_video_prompt(drama_item, content_mode="drama", voice_characters=characters))
     assert parsed["Voice_Profiles"] == [{"Speaker": "王", "Voice_Style": "低沉沙哑"}]
 
-    parsed_default = yaml.safe_load(_get_video_prompt(drama_item))
+    parsed_default = yaml.safe_load(_get_video_prompt(drama_item, content_mode="drama"))
     assert "Voice_Profiles" not in parsed_default
 
-    parsed_no_style = yaml.safe_load(_get_video_prompt(drama_item, voice_characters={"王": {"voice_style": ""}}))
+    parsed_no_style = yaml.safe_load(
+        _get_video_prompt(drama_item, content_mode="drama", voice_characters={"王": {"voice_style": ""}})
+    )
     assert "Voice_Profiles" not in parsed_no_style
+
+
+def test_get_video_prompt_injects_voice_profiles_from_legacy_dialogue() -> None:
+    """utterances 迁移前的存量 drama 剧本（无 utterances 字段，台词仍在
+    video_prompt.dialogue）：改走 legacy 出口派生 Voice_Profiles，不因缺 utterances 静默丢失。"""
+    import yaml
+
+    from server.agent_runtime.sdk_tools.enqueue_videos import _get_video_prompt
+
+    legacy_drama_item = {
+        "scene_id": "E1S01",
+        "video_prompt": {
+            "action": "起身",
+            "camera_motion": "Static",
+            "ambiance_audio": "风声",
+            "dialogue": [{"speaker": "王", "line": "你来了。"}],
+        },
+    }
+    characters = {"王": {"voice_style": "低沉沙哑"}}
+
+    parsed = yaml.safe_load(_get_video_prompt(legacy_drama_item, content_mode="drama", voice_characters=characters))
+    assert parsed["Voice_Profiles"] == [{"Speaker": "王", "Voice_Style": "低沉沙哑"}]
+    assert parsed["Dialogue"] == [{"Speaker": "王", "Line": "你来了。"}]
 
 
 def test_get_video_prompt_strips_caller_supplied_voice_profiles_for_non_drama() -> None:
@@ -1723,7 +1748,7 @@ def test_get_video_prompt_strips_caller_supplied_voice_profiles_for_non_drama() 
             "voice_profiles": [{"Speaker": "赝品", "Voice_Style": "越权"}],
         },
     }
-    parsed = yaml.safe_load(_get_video_prompt(narration_item))
+    parsed = yaml.safe_load(_get_video_prompt(narration_item, content_mode="narration"))
     assert "Voice_Profiles" not in parsed
 
 

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -278,6 +278,30 @@ async def test_project_video_resolution_falls_back_like_executor(monkeypatch: py
 
 
 @pytest.mark.unit
+async def test_resolve_project_voice_consistency_reads_caps_field(monkeypatch: pytest.MonkeyPatch):
+    """正常解析：直接读 caps 的 voice_consistency 字段，不重新派生。"""
+    from server.services import reference_video_tasks as rvt
+
+    async def fake_caps(_project, *, degraded_to):
+        return {"voice_consistency": "none"}
+
+    monkeypatch.setattr(rvt, "_project_video_caps", fake_caps)
+    assert await rvt.resolve_project_voice_consistency({}) == "none"
+
+
+@pytest.mark.unit
+async def test_resolve_project_voice_consistency_degrades_to_soft(monkeypatch: pytest.MonkeyPatch):
+    """caps 解析失败（空 dict）时按既有「无信号不判定为真无声」口径退化为 soft。"""
+    from server.services import reference_video_tasks as rvt
+
+    async def fake_caps(_project, *, degraded_to):
+        return {}
+
+    monkeypatch.setattr(rvt, "_project_video_caps", fake_caps)
+    assert await rvt.resolve_project_voice_consistency({}) == "soft"
+
+
+@pytest.mark.unit
 async def test_resolve_project_duration_context_resolves_caps_and_resolution_once(monkeypatch: pytest.MonkeyPatch):
     """项目能力与分辨率各只解析一次：批量预检把这次结果复用给每个 unit（见 precheck_unit）。"""
     from server.services import reference_video_tasks as rvt

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -278,30 +278,6 @@ async def test_project_video_resolution_falls_back_like_executor(monkeypatch: py
 
 
 @pytest.mark.unit
-async def test_resolve_project_voice_consistency_reads_caps_field(monkeypatch: pytest.MonkeyPatch):
-    """正常解析：直接读 caps 的 voice_consistency 字段，不重新派生。"""
-    from server.services import reference_video_tasks as rvt
-
-    async def fake_caps(_project, *, degraded_to):
-        return {"voice_consistency": "none"}
-
-    monkeypatch.setattr(rvt, "_project_video_caps", fake_caps)
-    assert await rvt.resolve_project_voice_consistency({}) == "none"
-
-
-@pytest.mark.unit
-async def test_resolve_project_voice_consistency_degrades_to_soft(monkeypatch: pytest.MonkeyPatch):
-    """caps 解析失败（空 dict）时按既有「无信号不判定为真无声」口径退化为 soft。"""
-    from server.services import reference_video_tasks as rvt
-
-    async def fake_caps(_project, *, degraded_to):
-        return {}
-
-    monkeypatch.setattr(rvt, "_project_video_caps", fake_caps)
-    assert await rvt.resolve_project_voice_consistency({}) == "soft"
-
-
-@pytest.mark.unit
 async def test_resolve_project_duration_context_resolves_caps_and_resolution_once(monkeypatch: pytest.MonkeyPatch):
     """项目能力与分辨率各只解析一次：批量预检把这次结果复用给每个 unit（见 precheck_unit）。"""
     from server.services import reference_video_tasks as rvt
@@ -319,7 +295,7 @@ async def test_resolve_project_duration_context_resolves_caps_and_resolution_onc
         resolution_calls += 1
         return "720p"
 
-    monkeypatch.setattr(rvt, "_project_video_caps", fake_caps)
+    monkeypatch.setattr(rvt, "project_video_caps", fake_caps)
     monkeypatch.setattr(rvt, "_project_video_resolution", fake_resolution)
 
     ctx = await rvt.resolve_project_duration_context({})
@@ -349,7 +325,7 @@ async def test_resolve_project_duration_context_skips_resolution_when_no_duratio
         resolution_calls += 1
         return "720p"
 
-    monkeypatch.setattr(rvt, "_project_video_caps", fake_caps)
+    monkeypatch.setattr(rvt, "project_video_caps", fake_caps)
     monkeypatch.setattr(rvt, "_project_video_resolution", fake_resolution)
 
     ctx = await rvt.resolve_project_duration_context({})

--- a/tests/server/test_video_caps.py
+++ b/tests/server/test_video_caps.py
@@ -1,0 +1,27 @@
+"""项目级视频能力解析共享出口的单测。"""
+
+import pytest
+
+from server.services import video_caps
+
+
+@pytest.mark.unit
+async def test_resolve_project_voice_consistency_reads_caps_field(monkeypatch: pytest.MonkeyPatch):
+    """正常解析：直接读 caps 的 voice_consistency 字段，不重新派生。"""
+
+    async def fake_caps(_project, *, degraded_to):
+        return {"voice_consistency": "none"}
+
+    monkeypatch.setattr(video_caps, "project_video_caps", fake_caps)
+    assert await video_caps.resolve_project_voice_consistency({}) == "none"
+
+
+@pytest.mark.unit
+async def test_resolve_project_voice_consistency_degrades_to_soft(monkeypatch: pytest.MonkeyPatch):
+    """caps 解析失败（空 dict）时按既有「无信号不判定为真无声」口径退化为 soft。"""
+
+    async def fake_caps(_project, *, degraded_to):
+        return {}
+
+    monkeypatch.setattr(video_caps, "project_video_caps", fake_caps)
+    assert await video_caps.resolve_project_voice_consistency({}) == "soft"

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -92,6 +92,7 @@ def _fake_resolve_ctx(
     video_provider=("ark", "seedance"),
     video_resolution="720p",
     supported_durations=(4, 6, 8),
+    voice_consistency="soft",
     seen_lane_requests=None,
 ):
     """lane 感知的假 resolve_generation_context：按调用方声明的 lane 拼装 frozen dataclass 产物。
@@ -124,6 +125,7 @@ def _fake_resolve_ctx(
                 supported_durations=tuple(supported_durations),
                 max_duration=None,
                 max_reference_images=None,
+                voice_consistency=voice_consistency,
             )
         return GenerationContext(generator=generator, image_lane=image_lane, video_lane=video_lane)
 
@@ -1119,6 +1121,87 @@ class TestGenerationTasks:
         assert "你来了。" in prompt_yaml
         assert "王" in prompt_yaml
         assert "那是命运的开端。" not in prompt_yaml
+
+    def _drama_script(self):
+        return {
+            "content_mode": "drama",
+            "scenes": [
+                {
+                    "scene_id": "E1S01",
+                    "duration_seconds": 8,
+                    "segment_break": False,
+                    "characters_in_scene": ["王"],
+                    "scenes": [],
+                    "props": [],
+                    "image_prompt": "首镜头",
+                    "video_prompt": {"action": "起身", "camera_motion": "Static", "ambiance_audio": "风声"},
+                    "utterances": [
+                        {"kind": "dialogue", "speaker": "王", "text": "你来了。"},
+                    ],
+                }
+            ],
+        }
+
+    async def test_execute_video_task_injects_voice_profiles_for_audible_model(self, monkeypatch, tmp_path):
+        """有音轨模型（voice_consistency != none）：dialogue speaker 命中的角色资产
+        非空 voice_style 机械派生进 Voice_Profiles 顶部声明段。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
+        fake_generator = _FakeGenerator()
+        fake_pm.script = self._drama_script()
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(
+            generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator, voice_consistency="soft")
+        )
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {
+                "script_file": "episode_1.json",
+                "prompt": {"action": "起身", "camera_motion": "Static", "ambiance_audio": "风声"},
+                "duration_seconds": 8,
+            },
+        )
+
+        prompt_yaml = fake_generator.video_calls[0]["prompt"]
+        assert "Voice_Profiles" in prompt_yaml
+        assert "低沉沙哑" in prompt_yaml
+        # 顶部集中声明段须先于 Action 出现
+        assert prompt_yaml.index("Voice_Profiles") < prompt_yaml.index("Action")
+
+    async def test_execute_video_task_skips_voice_profiles_for_silent_model(self, monkeypatch, tmp_path):
+        """C 类（真无声，voice_consistency == none）模型不注入 Voice_Profiles。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
+        fake_generator = _FakeGenerator()
+        fake_pm.script = self._drama_script()
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(
+            generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator, voice_consistency="none")
+        )
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {
+                "script_file": "episode_1.json",
+                "prompt": {"action": "起身", "camera_motion": "Static", "ambiance_audio": "风声"},
+                "duration_seconds": 8,
+            },
+        )
+
+        prompt_yaml = fake_generator.video_calls[0]["prompt"]
+        assert "Voice_Profiles" not in prompt_yaml
+        assert "低沉沙哑" not in prompt_yaml
 
     async def test_execute_video_task_default_duration_from_caps(self, monkeypatch, tmp_path):
         """无显式 duration 时，默认值由 caps 收口（取 supported_durations[0]），且必然合法。"""

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -1285,6 +1285,58 @@ class TestGenerationTasks:
         assert "低沉沙哑" in prompt_yaml
         assert "你来了。" in prompt_yaml
 
+    async def test_execute_video_task_content_mode_falls_back_to_project_when_episode_omits_it(
+        self, monkeypatch, tmp_path
+    ):
+        """存量 episode 剧本省略顶层 content_mode 时回退到 project.json 的 content_mode
+        （与 lib.data_validator 已校验通过的既定口径一致），不因回退缺失而被误判为
+        narration、静默跳过 dialogue 重建与 Voice_Profiles 注入。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_pm.project["content_mode"] = "drama"
+        fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
+        fake_generator = _FakeGenerator()
+        fake_pm.script = {
+            # 顶层无 content_mode：存量 episode 省略该字段，真相源退到 project.json。
+            "scenes": [
+                {
+                    "scene_id": "E1S01",
+                    "duration_seconds": 8,
+                    "segment_break": False,
+                    "characters_in_scene": ["王"],
+                    "scenes": [],
+                    "props": [],
+                    "image_prompt": "首镜头",
+                    "video_prompt": {"action": "起身", "camera_motion": "Static", "ambiance_audio": "风声"},
+                    "utterances": [
+                        {"kind": "dialogue", "speaker": "王", "text": "你来了。"},
+                    ],
+                }
+            ],
+        }
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(
+            generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator, voice_consistency="soft")
+        )
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {
+                "script_file": "episode_1.json",
+                "prompt": {"action": "起身", "camera_motion": "Static", "ambiance_audio": "风声"},
+                "duration_seconds": 8,
+            },
+        )
+
+        prompt_yaml = fake_generator.video_calls[0]["prompt"]
+        assert "Voice_Profiles" in prompt_yaml
+        assert "低沉沙哑" in prompt_yaml
+        assert "你来了。" in prompt_yaml
+
     async def test_execute_video_task_default_duration_from_caps(self, monkeypatch, tmp_path):
         """无显式 duration 时，默认值由 caps 收口（取 supported_durations[0]），且必然合法。"""
         project_path = _prepare_files(tmp_path)

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -1203,6 +1203,37 @@ class TestGenerationTasks:
         assert "Voice_Profiles" not in prompt_yaml
         assert "低沉沙哑" not in prompt_yaml
 
+    async def test_execute_video_task_strips_caller_supplied_voice_profiles_for_non_drama(self, monkeypatch, tmp_path):
+        """narration/ad（item 无 utterances 字段）请求体自带 voice_profiles 时一律剥离：
+        该声明段唯一来源是 build_drama_video_prompt 的机械派生，调用方不得越权注入、绕过
+        C 类（真无声）门控。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {
+                "script_file": "episode_1.json",
+                "prompt": {
+                    "action": "起身",
+                    "camera_motion": "Static",
+                    "ambiance_audio": "风声",
+                    "voice_profiles": [{"Speaker": "赝品", "Voice_Style": "越权"}],
+                },
+            },
+        )
+
+        prompt_yaml = fake_generator.video_calls[0]["prompt"]
+        assert "Voice_Profiles" not in prompt_yaml
+        assert "越权" not in prompt_yaml
+
     async def test_execute_video_task_default_duration_from_caps(self, monkeypatch, tmp_path):
         """无显式 duration 时，默认值由 caps 收口（取 supported_durations[0]），且必然合法。"""
         project_path = _prepare_files(tmp_path)

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -1234,6 +1234,57 @@ class TestGenerationTasks:
         assert "Voice_Profiles" not in prompt_yaml
         assert "越权" not in prompt_yaml
 
+    async def test_execute_video_task_injects_voice_profiles_from_legacy_dialogue(self, monkeypatch, tmp_path):
+        """utterances 迁移前的存量 drama 剧本（scene 无 utterances 字段，台词仍在
+        video_prompt.dialogue）：load_script 按原始 JSON 读盘不过 pydantic 迁移，改走 legacy
+        出口派生 Voice_Profiles，不因缺 utterances 静默丢失。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
+        fake_generator = _FakeGenerator()
+        fake_pm.script = {
+            "content_mode": "drama",
+            "scenes": [
+                {
+                    "scene_id": "E1S01",
+                    "duration_seconds": 8,
+                    "segment_break": False,
+                    "characters_in_scene": ["王"],
+                    "scenes": [],
+                    "props": [],
+                    "image_prompt": "首镜头",
+                    "video_prompt": {"action": "起身", "camera_motion": "Static", "ambiance_audio": "风声"},
+                }
+            ],
+        }
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(
+            generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator, voice_consistency="soft")
+        )
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {
+                "script_file": "episode_1.json",
+                "prompt": {
+                    "action": "起身",
+                    "camera_motion": "Static",
+                    "ambiance_audio": "风声",
+                    "dialogue": [{"speaker": "王", "line": "你来了。"}],
+                },
+                "duration_seconds": 8,
+            },
+        )
+
+        prompt_yaml = fake_generator.video_calls[0]["prompt"]
+        assert "Voice_Profiles" in prompt_yaml
+        assert "低沉沙哑" in prompt_yaml
+        assert "你来了。" in prompt_yaml
+
     async def test_execute_video_task_default_duration_from_caps(self, monkeypatch, tmp_path):
         """无显式 duration 时，默认值由 caps 收口（取 supported_durations[0]），且必然合法。"""
         project_path = _prepare_files(tmp_path)

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -1,7 +1,7 @@
 import yaml
 
 from lib.prompt_utils import (
-    build_voice_profiles,
+    build_drama_video_prompt,
     image_prompt_to_yaml,
     is_structured_image_prompt,
     is_structured_video_prompt,
@@ -97,35 +97,65 @@ class TestPromptUtils:
         assert "Voice_Profiles" not in yaml.safe_load(video_prompt_to_yaml(without_profiles))
 
 
-class TestBuildVoiceProfiles:
+def _utterance(speaker: str | None, text: str) -> dict[str, object]:
+    return {"kind": "dialogue", "speaker": speaker, "text": text}
+
+
+_BASE_PROMPT = {"action": "抬头观察", "camera_motion": "Static", "ambiance_audio": "雨声"}
+
+
+class TestBuildDramaVideoPrompt:
+    """两注入点共用的 drama dialogue + Voice_Profiles 出口。"""
+
     def test_one_entry_per_speaker_deduped_in_order(self):
-        dialogue = [
-            {"speaker": "姜月茴", "line": "有人吗"},
-            {"speaker": "王", "line": "嗯"},
-            {"speaker": "姜月茴", "line": "走吧"},
-        ]
-        characters = {
-            "姜月茴": {"voice_style": "清冷"},
-            "王": {"voice_style": "低沉"},
-        }
-        assert build_voice_profiles(dialogue, characters) == [
+        utterances = [_utterance("姜月茴", "有人吗"), _utterance("王", "嗯"), _utterance("姜月茴", "走吧")]
+        characters = {"姜月茴": {"voice_style": "清冷"}, "王": {"voice_style": "低沉"}}
+        prompt = build_drama_video_prompt(_BASE_PROMPT, utterances, characters=characters)
+        assert prompt["voice_profiles"] == [
             {"Speaker": "姜月茴", "Voice_Style": "清冷"},
             {"Speaker": "王", "Voice_Style": "低沉"},
         ]
+        # dialogue 逐条保序，不因 Voice_Profiles 去重而合并
+        assert [d["speaker"] for d in prompt["dialogue"]] == ["姜月茴", "王", "姜月茴"]
+
+    def test_characters_none_means_no_injection(self):
+        utterances = [_utterance("姜月茴", "有人吗")]
+        prompt = build_drama_video_prompt(_BASE_PROMPT, utterances, characters={"姜月茴": {"voice_style": "清冷"}})
+        assert "voice_profiles" in prompt
+        gated = build_drama_video_prompt(_BASE_PROMPT, utterances, characters=None)
+        assert "voice_profiles" not in gated
+
+    def test_script_carried_voice_profiles_never_survive(self):
+        # 声明段唯一来源是编排层：剧本残留值一律剥离，否则会绕过 C 类（characters=None）门控
+        carried = {**_BASE_PROMPT, "voice_profiles": [{"Speaker": "赝品", "Voice_Style": "越权"}]}
+        assert "voice_profiles" not in build_drama_video_prompt(carried, [], characters=None)
+        prompt = build_drama_video_prompt(carried, [_utterance("王", "嗯")], characters={"王": {"voice_style": "低沉"}})
+        assert prompt["voice_profiles"] == [{"Speaker": "王", "Voice_Style": "低沉"}]
 
     def test_speaker_without_matching_character_skipped_silently(self):
-        dialogue = [{"speaker": "路人甲", "line": "喂"}]
-        assert build_voice_profiles(dialogue, {}) == []
+        prompt = build_drama_video_prompt(_BASE_PROMPT, [_utterance("路人甲", "喂")], characters={})
+        assert "voice_profiles" not in prompt
 
     def test_character_with_empty_voice_style_skipped(self):
-        dialogue = [{"speaker": "王", "line": "嗯"}]
-        assert build_voice_profiles(dialogue, {"王": {"voice_style": ""}}) == []
+        prompt = build_drama_video_prompt(
+            _BASE_PROMPT, [_utterance("王", "嗯")], characters={"王": {"voice_style": ""}}
+        )
+        assert "voice_profiles" not in prompt
 
     def test_robust_to_dirty_data(self):
-        assert build_voice_profiles([], {}) == []
-        assert build_voice_profiles([{"speaker": None, "line": "x"}], {}) == []
-        assert build_voice_profiles([{"speaker": "王", "line": "x"}], {"王": "not-a-dict"}) == []
-        assert build_voice_profiles([{"speaker": "王", "line": "x"}], "not-a-dict") == []
+        for utterances, characters in (
+            ([], {}),
+            ([_utterance(None, "x")], {}),
+            ([_utterance("王", "x")], {"王": "not-a-dict"}),
+            ([_utterance("王", "x")], "not-a-dict"),
+        ):
+            prompt = build_drama_video_prompt(_BASE_PROMPT, utterances, characters=characters)  # type: ignore[arg-type]
+            assert "voice_profiles" not in prompt
+
+    def test_does_not_mutate_caller_prompt(self):
+        source = {**_BASE_PROMPT}
+        build_drama_video_prompt(source, [_utterance("王", "嗯")], characters={"王": {"voice_style": "低沉"}})
+        assert source == _BASE_PROMPT
 
 
 class TestUtterancesToDialogue:

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -1,6 +1,7 @@
 import yaml
 
 from lib.prompt_utils import (
+    build_voice_profiles,
     image_prompt_to_yaml,
     is_structured_image_prompt,
     is_structured_video_prompt,
@@ -77,6 +78,54 @@ class TestPromptUtils:
         assert not is_structured_image_prompt("text")
         assert is_structured_video_prompt({"action": "x"})
         assert not is_structured_video_prompt([])
+
+    def test_video_prompt_to_yaml_voice_profiles_leads_and_is_conditional(self):
+        # Voice_Profiles 是顶部集中声明段：须先于 Action 出现；无声明时不出现该字段
+        with_profiles = {
+            "action": "抬头观察",
+            "camera_motion": "Static",
+            "ambiance_audio": "雨声",
+            "dialogue": [{"speaker": "姜月茴", "line": "有人吗"}],
+            "voice_profiles": [{"Speaker": "姜月茴", "Voice_Style": "清冷"}],
+        }
+        text = video_prompt_to_yaml(with_profiles)
+        parsed = yaml.safe_load(text)
+        assert parsed["Voice_Profiles"] == [{"Speaker": "姜月茴", "Voice_Style": "清冷"}]
+        assert text.index("Voice_Profiles") < text.index("Action")
+
+        without_profiles = {"action": "快步前进", "camera_motion": "Pan Left", "ambiance_audio": "脚步声"}
+        assert "Voice_Profiles" not in yaml.safe_load(video_prompt_to_yaml(without_profiles))
+
+
+class TestBuildVoiceProfiles:
+    def test_one_entry_per_speaker_deduped_in_order(self):
+        dialogue = [
+            {"speaker": "姜月茴", "line": "有人吗"},
+            {"speaker": "王", "line": "嗯"},
+            {"speaker": "姜月茴", "line": "走吧"},
+        ]
+        characters = {
+            "姜月茴": {"voice_style": "清冷"},
+            "王": {"voice_style": "低沉"},
+        }
+        assert build_voice_profiles(dialogue, characters) == [
+            {"Speaker": "姜月茴", "Voice_Style": "清冷"},
+            {"Speaker": "王", "Voice_Style": "低沉"},
+        ]
+
+    def test_speaker_without_matching_character_skipped_silently(self):
+        dialogue = [{"speaker": "路人甲", "line": "喂"}]
+        assert build_voice_profiles(dialogue, {}) == []
+
+    def test_character_with_empty_voice_style_skipped(self):
+        dialogue = [{"speaker": "王", "line": "嗯"}]
+        assert build_voice_profiles(dialogue, {"王": {"voice_style": ""}}) == []
+
+    def test_robust_to_dirty_data(self):
+        assert build_voice_profiles([], {}) == []
+        assert build_voice_profiles([{"speaker": None, "line": "x"}], {}) == []
+        assert build_voice_profiles([{"speaker": "王", "line": "x"}], {"王": "not-a-dict"}) == []
+        assert build_voice_profiles([{"speaker": "王", "line": "x"}], "not-a-dict") == []
 
 
 class TestUtterancesToDialogue:

--- a/tests/test_script_models.py
+++ b/tests/test_script_models.py
@@ -17,6 +17,7 @@ from lib.script_models import (
     VideoPrompt,
     get_generated_assets,
     item_duration,
+    resolve_content_mode,
     script_duration_total,
 )
 
@@ -814,3 +815,17 @@ class TestGeneratedAssetsTemplateContract:
                 "status": "completed",
             }
         )
+
+
+class TestResolveContentMode:
+    """episode/剧本级 content_mode 缺失时回退到项目级配置，与
+    lib.data_validator._validate_episode_payload 已校验通过的既定口径一致。"""
+
+    def test_episode_level_wins_when_present(self):
+        assert resolve_content_mode({"content_mode": "drama"}, {"content_mode": "narration"}) == "drama"
+
+    def test_falls_back_to_project_when_episode_omits_it(self):
+        assert resolve_content_mode({}, {"content_mode": "drama"}) == "drama"
+
+    def test_falls_back_to_narration_when_both_omit_it(self):
+        assert resolve_content_mode({}, {}) == "narration"


### PR DESCRIPTION
Closes #1497

## 变更

drama 图生视频（含宫格切格后同路）在视频提示词 YAML 顶部注入 `Voice_Profiles` 集中声明段，让有音轨的视频模型按角色资产上登记的声音描述发声，跨片段音色不再逐段漂移。

- 收录集合 = 本场景 dialogue 的 speaker ∩ 角色资产 `voice_style` 非空者；只出场不开口的角色不收录，未命中角色资产仅记 logger.debug，不建面向用户的提示通道
- 有无音轨的判定复用既有 `voice_consistency` 派生（`derive_voice_consistency`），恒有声但开关不可控的供应商（AI Studio Veo、Grok）经 `model_has_audio_track` 正常识别，不因缺 `generate_audio` 开关漏判；档位为 `none`（真无声）不注入
- 剧本 JSON 与 step2 LLM 零新增承载：声明段由编排层从角色资产机械派生，角色 `voice_style` 改动后重新生成即生效
- 宫格路径切格后复用同一条视频生成链，无特设分支

worker 执行路径与 SDK 入队路径共用 `lib/prompt_utils.build_drama_video_prompt` 作为唯一注入出口，两处产出同构由结构保证；该出口无条件剥离入参自带的 `voice_profiles`，剧本中的残留值不会绕过真无声门控。项目级视频能力解析的共享 helper 从 `reference_video_tasks` 移到中性的 `server/services/video_caps.py`。

## 验证

- `uv run python -m pytest` — 7063 passed
- `uv run basedpyright` — 0 errors
- `uv run ruff check . && uv run ruff format .` — clean
- 未做真机验证：两处注入点仅有单测覆盖 YAML 结构与门控开关，未连真实视频供应商 API 验证下游模型是否按声明段调整音色

## 已知限制

- SDK 入队路径按「项目当前默认视频后端」预判档位，而非本次任务实际解析后的 provider/model（provider 解析按 ADR-0001 延后到 worker 执行时）。仅影响是否注入这一可选声明段，不影响生成正确性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增声音一致性档位，自动判断视频模型对角色音色配置的支持情况。
  * 戏剧模式可根据角色声音风格生成统一的 `Voice_Profiles` 声音声明。
  * 整集、单场景、批量及选定场景的视频生成均支持角色音色配置。

* **改进**
  * 无声模型及不适用的视频模式不会注入角色声音信息。
  * 视频能力解析更加统一，配置缺失或解析失败时提供稳定的默认行为。

* **测试**
  * 增加声音配置注入、清理、降级及异常数据处理的测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->