### PR TITLE
feat(reference-video): 拆分按单元有无参考图分别给可选时长，无引用单元不再被收窄

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -143,7 +143,8 @@ _Avoid_: `VALID_DURATIONS` / 全局时长白名单（已删除的硬编码 `[4,6
 
 **时长联动约束（duration_resolution_constraints / reference_image_durations）**：
 在 `supported_durations` 全集之上按上下文收窄的两个 per-model 声明：前者是 `{分辨率: 允许时长}`（如 Veo `{"1080p": [8], "4k": [8]}`），后者是走参考图路径时的允许时长（如 Veo `[8]`）。两条各自独立触发、可同时生效、取交集；与 `supported_durations` 同为 registry 单一真相源。后端唯一收窄入口是 `lib/config/resolver.constrain_durations`：剧本生成的 prompt 与动态 schema、SDK MCP 工具交给 LLM 的候选、执行期未显式指定时长时的取值，都在下传前经它收窄；前端时长选择器（项目级默认与逐镜头 pill）按同一份声明过滤候选。约束求值用的生效分辨率（`_resolution_for_constraints`）取项目已保存的档位，前后端同口径；未保存时不施加分辨率约束——普通视频路径此时省略 SDK 的 resolution 参数，供应商按自己的默认档位处理（Veo 是 720p），该档位下全集本就合法。参考视频路径例外：它执行期下发 `resolution_or_fallback`，故未保存时按 provider 兜底档位求值，与实际下发的档位保持同一集合。已保存的越界时长一律给「警告 + 引导重选」，不静默改写。backend 侧另有模块级兜底常量，只在型号未登记于 registry 时生效（中转站、自定义供应商包装、已下线型号）。
-_Avoid_: 把它当通用「条件→约束」DSL 的雏形去扩展——只表达已有官方明文的联动维度；在 backend 里另写一份与 registry 平行的约束表。
+**参考图约束逐 unit 生效，不按集一刀切**：参考路径允许 unit 不带任何引用，执行层与 backend 都只在 `reference_images` 非空时施加它，故一个 unit 的生效档位取决于它自己有没有 `@[名称]` 引用。全链路同此判据——step1 拆分把「带图 / 不带图」两套档位一并注入 prompt、schema 枚举取其并集、references 从正文机械派生后逐 unit 判归属（`sdk_tools/_context.reference_unit_duration_tiers`），step2 按**最终**产出的 references 重算（`_unit_duration_off_tier`），预检与执行按落盘 references 重算（`precheck_unit` / `effective_reference_durations`），前端下拉按选中 unit 的 references 切换候选。两套档位之间不假定包含关系：`constrain_durations` 在交集为空时回退到未收窄候选，型号声明自相矛盾时带图那套反而更宽，故并集须显式求。
+_Avoid_: 把它当通用「条件→约束」DSL 的雏形去扩展——只表达已有官方明文的联动维度；在 backend 里另写一份与 registry 平行的约束表；拿「带图」那套当整集的上界（会收掉无引用 unit 本可申请的短档）。
 
 **default_duration**：
 项目级偏好时长（int）；为 null 或缺失时是一个有语义的「auto」档——由 AI 按内容节奏在 supported_durations 内自行决定，**不是**「未设置 / 待填」。

--- a/agent_runtime_profile/.claude/agents/split-reference-video-units.md
+++ b/agent_runtime_profile/.claude/agents/split-reference-video-units.md
@@ -79,7 +79,7 @@ mcp__arcreel__split_reference_video_units({"episode": N, "source": "source/episo
 
 使用 Read 工具读取现有 JSON，按修改要求用 Edit 工具直接修改，遵循**修改口径**：
 
-- unit `duration_seconds` 必须取 Step 0 查得的 `reference_unit_durations` 中**该 unit 引用状态对应**的那套：正文含 `@` 引用取 `with_references`，不含则取 `without_references`。一个 unit 一个时长，镜头不单独承载时长。内容装不下所选档位时把该 unit 按叙事顺序重拆为多个 unit，不得违约时长；台词念不完所选档位时同样重拆，不压进短档。两套档位不同时，带引用的 unit 想用更短档位只有一条路——把次要资产融入描述文字、不用 `@` 引用
+- unit `duration_seconds` 必须取 Step 0 查得的 `reference_unit_durations` 中**该 unit 引用状态对应**的那套：镜头描述行含 `@` 引用取 `with_references`，不含则取 `without_references`（规范台词行 `@[角色]：{台词}` 的说话人位不计入——它不生成参考图，只驱动音色声明，判据与下方 `references` 派生口径同源）。一个 unit 一个时长，镜头不单独承载时长。内容装不下所选档位时把该 unit 按叙事顺序重拆为多个 unit，不得违约时长；台词念不完所选档位时同样重拆，不压进短档。两套档位不同、且想要的时长不在该 unit 当前引用状态对应的档位内时，两条出路二选一：改取该状态档位内的值，或调整引用状态使其落入另一档位——两套档位之间不假定包含关系，调整方向（去引用变宽还是变窄）以该型号实际两套档位为准，不预设「去引用」必然更宽
 - shot `text` 用 `@[名称]` 引用资产，名称必须逐字取自 `project.json` 三张表（不确定就 Read `project.json` 确认）；不写外貌 / 服装 / 场景细节
 - `source_text` 必须是本集源文的逐字片段（可截断首尾，中间不得删改）；改动 unit 边界时同步改锚
 - 修改 shot 文本中的 `@` 引用后，同步更新该 unit 的 `references`：各 shot 引用的并集、按首次出现顺序（顺序决定参考图编号），去重后数量不超过 `max_reference_images`；规范台词行的说话人位不计入参考图

--- a/agent_runtime_profile/.claude/agents/split-reference-video-units.md
+++ b/agent_runtime_profile/.claude/agents/split-reference-video-units.md
@@ -39,8 +39,11 @@ mcp__arcreel__get_video_capabilities({})
 ```
 
 解析返回的 JSON，记录：
-- `supported_durations`：unit 时长允许的取值集合（档位枚举）
-- `max_duration`：单次生成的时长上限（unit 时长不得超过）
+- `reference_unit_durations`：按 unit 有无 `@` 引用分开的两套**生效**档位，形如
+  `{"with_references": [...], "without_references": [...]}`。unit 时长必须取自其引用状态对应的那套——
+  部分型号对带参考图的生成另有时长限制，无引用的 unit 不受此限
+- `supported_durations`：型号声明的时长全集，**未**施加「分辨率↔时长」「参考图↔时长」联动约束；
+  仅作参考，取值一律以 `reference_unit_durations` 为准
 - `max_reference_images`：单 unit references 上限
 - `default_duration`：用户在项目设置中指定的默认秒数（可能为 null）
 
@@ -76,7 +79,7 @@ mcp__arcreel__split_reference_video_units({"episode": N, "source": "source/episo
 
 使用 Read 工具读取现有 JSON，按修改要求用 Edit 工具直接修改，遵循**修改口径**：
 
-- unit `duration_seconds` 必须取 Step 0 查得的 `supported_durations` 中的值，且不超过 `max_duration`；一个 unit 一个时长，镜头不单独承载时长。内容装不下所选档位时把该 unit 按叙事顺序重拆为多个 unit，不得违约时长；台词念不完所选档位时同样重拆，不压进短档
+- unit `duration_seconds` 必须取 Step 0 查得的 `reference_unit_durations` 中**该 unit 引用状态对应**的那套：正文含 `@` 引用取 `with_references`，不含则取 `without_references`。一个 unit 一个时长，镜头不单独承载时长。内容装不下所选档位时把该 unit 按叙事顺序重拆为多个 unit，不得违约时长；台词念不完所选档位时同样重拆，不压进短档。两套档位不同时，带引用的 unit 想用更短档位只有一条路——把次要资产融入描述文字、不用 `@` 引用
 - shot `text` 用 `@[名称]` 引用资产，名称必须逐字取自 `project.json` 三张表（不确定就 Read `project.json` 确认）；不写外貌 / 服装 / 场景细节
 - `source_text` 必须是本集源文的逐字片段（可截断首尾，中间不得删改）；改动 unit 边界时同步改锚
 - 修改 shot 文本中的 `@` 引用后，同步更新该 unit 的 `references`：各 shot 引用的并集、按首次出现顺序（顺序决定参考图编号），去重后数量不超过 `max_reference_images`；规范台词行的说话人位不计入参考图
@@ -109,7 +112,7 @@ mcp__arcreel__split_reference_video_units({"episode": N, "source": "source/episo
 }
 ```
 
-> 填值规则：`<duration>` 必须取自 Step 0 查得的 `supported_durations` 且 ≤ `max_duration`，宜贴近内容实际需要的长度。
+> 填值规则：`<duration>` 必须取自 Step 0 查得的 `reference_unit_durations` 中该 unit 引用状态对应的那套，宜贴近内容实际需要的长度。
 > `<集号>` 由 `mcp__arcreel__split_reference_video_units` 工具在调用时按当前 episode 注入；本示例用占位符避免误把 `E1` 当硬编码值。
 
 ### 返回摘要

--- a/agent_runtime_profile/.claude/references/generation-modes.md
+++ b/agent_runtime_profile/.claude/references/generation-modes.md
@@ -54,7 +54,7 @@ Step 8 旁白配音（仅 narration 内容模式）
 
 - **分辨率**：图片 1K，视频 1080p
 - **单片段时长**（storyboard / grid）：取值必须在模型 `supported_durations` 内；项目 `default_duration` 非 null 时作默认值（项目创建时按 content_mode 写入 project.json），为 null 时由预处理按内容节奏自行取值
-- **单 unit 时长**（reference_video）：unit 是一次生成调用的单元，一个 unit 一个时长——取值必须在模型 `supported_durations` 列表中且 ≤ `max_duration`，镜头不单独承载时长；内容装不下所选档位时重拆 unit，不违约时长。具体数值由 subagent 在执行时通过 `mcp__arcreel__get_video_capabilities` 工具查得，**不在本文档固化**
+- **单 unit 时长**（reference_video）：unit 是一次生成调用的单元，一个 unit 一个时长——取值必须在该 unit **引用状态对应**的生效档位内（`get_video_capabilities` 返回的 `reference_unit_durations.with_references` / `.without_references`；部分型号对带参考图的生成另有时长限制），镜头不单独承载时长；内容装不下所选档位时重拆 unit，不违约时长。具体数值由 subagent 在执行时通过 `mcp__arcreel__get_video_capabilities` 工具查得，**不在本文档固化**
 - **拼接**：全部模式用 ffmpeg concat；Veo extend 仅用于**单片段延长**，不串联不同镜头
 - **BGM**：生成端已在视频 prompt 末尾自动追加"禁止出现：BGM、文字字幕、水印"，无需手动追加，prompt 里也不要描述 BGM / 配乐
 

--- a/lib/prompt_builders_reference.py
+++ b/lib/prompt_builders_reference.py
@@ -72,6 +72,7 @@ def build_reference_units_split_prompt(
     props: dict,
     supported_durations: list[int],
     reference_supported_durations: list[int] | None = None,
+    text_supported_durations: list[int] | None = None,
     max_duration: int,
     max_reference_images: int | None,
     default_duration: int | None,
@@ -91,8 +92,10 @@ def build_reference_units_split_prompt(
     Args:
         supported_durations: unit 允许的时长取值集合（秒），即两种引用状态下档位的并集，
             与 response_schema 的枚举同集合。
-        reference_supported_durations: 带 ``@`` 引用的 unit 才适用的更窄档位；None 或与
-            ``supported_durations`` 等价时不写入该联动约束（多数型号不声明「参考图↔时长」）。
+        reference_supported_durations: 带 ``@`` 引用的 unit 适用的档位。
+        text_supported_durations: 不带 ``@`` 引用的 unit 适用的档位。两套档位相同（或任一为
+            None）时不写入该联动约束——多数型号不声明「参考图↔时长」，多写一条无效约束只挤占
+            注意力；两套不同时**两套都写**，不假定谁包含谁。
         max_duration: 单次视频生成的时长上限（秒），即档位最大值。
         max_reference_images: 单 unit 参考图上限；None 时不写入硬性数量约束。
         default_duration: 用户项目偏好的默认秒数；须为 supported_durations 成员或 None。
@@ -106,26 +109,46 @@ def build_reference_units_split_prompt(
     if default_duration is not None and int(default_duration) not in normalized_durations:
         raise ValueError(f"default_duration={default_duration} 不在 supported_durations={normalized_durations} 内")
     normalized_reference_durations = sorted({int(d) for d in reference_supported_durations or []})
-    if not set(normalized_reference_durations) <= set(normalized_durations):
-        raise ValueError(
-            f"reference_supported_durations={normalized_reference_durations} 不是 "
-            f"supported_durations={normalized_durations} 的子集"
-        )
+    normalized_text_durations = sorted({int(d) for d in text_supported_durations or []})
+    for name, tier in (
+        ("reference_supported_durations", normalized_reference_durations),
+        ("text_supported_durations", normalized_text_durations),
+    ):
+        if not set(tier) <= set(normalized_durations):
+            raise ValueError(f"{name}={tier} 不是 supported_durations={normalized_durations} 的子集")
 
     durations_str = ", ".join(str(d) for d in normalized_durations)
     # 「参考图↔时长」联动约束只在型号真的声明它、且两套档位不同时才写进 prompt：多数型号两者
-    # 等价，多写一条无效约束只会挤占模型注意力。约束的落地判定在工具侧按机械派生的 references
-    # 逐 unit 做，prompt 这段是教学，不是唯一防线。
+    # 等价，多写一条无效约束只会挤占模型注意力。两套不同时两套都写全，不写成「并集 + 带图收窄」
+    # ——`constrain_durations` 在交集为空时回退到未收窄候选，带图那套反而可能更宽，此时无引用
+    # unit 才是被收窄的一方，只讲带图会让它照并集取到自己申请不到的档位。
+    # 约束的落地判定在工具侧按机械派生的 references 逐 unit 做，prompt 这段是教学，不是唯一防线。
+    tiers_differ = (
+        bool(normalized_reference_durations and normalized_text_durations)
+        and normalized_reference_durations != normalized_text_durations
+    )
     reference_rule = (
-        "\n     该 unit 正文里带 `@` 资产引用时，档位进一步收窄为（"
-        + ", ".join(str(d) for d in normalized_reference_durations)
-        + "）——本型号对带参考图的生成另有时长限制。引用与时长两者取其一：要么改取该收窄档位内的值，"
-        "要么把次要资产融入描述文字、不用 `@` 引用，从而适用完整档位。"
-        if normalized_reference_durations and normalized_reference_durations != normalized_durations
+        "\n     本型号下该档位还随「有无参考图」分两套，按该 unit **正文里有没有 `@` 资产引用**取用："
+        f"带 `@` 引用取（{', '.join(str(d) for d in normalized_reference_durations)}），"
+        f"不带取（{', '.join(str(d) for d in normalized_text_durations)}）。"
+        "两者取其一：要么改取该 unit 引用状态对应档位内的值，要么调整引用——"
+        "把次要资产融入描述文字、不用 `@` 引用，从而适用不带引用的那套档位。"
+        if tiers_differ
         else ""
     )
+    # 默认偏好只是第 3 优先级、在第 1 条硬约束内做优化，但两套档位不同时它可能只对其中一种
+    # 引用状态合法（Veo 3.1 在 720p 下带图仅 8s，而项目默认可能是 4s）。此时点明它的适用范围，
+    # 免得模型把「默认 4 秒」套到带引用的 unit 上、拆出执行期申请不到的时长。
+    default_scope = ""
+    if default_duration is not None and tiers_differ:
+        in_reference = int(default_duration) in normalized_reference_durations
+        in_text = int(default_duration) in normalized_text_durations
+        if in_reference != in_text:
+            applies = "带 `@` 引用的" if in_reference else "不带 `@` 引用的"
+            default_scope = f"（该默认值只落在{applies} unit 的档位内，另一种状态的 unit 按上面的硬约束取值）"
     default_rule = (
-        f"unit 默认取 {default_duration} 秒，叙事需要更长时可取更长档（偏好可被内容需要覆盖，硬约束不可）"
+        f"unit 默认取 {default_duration} 秒{default_scope}，"
+        "叙事需要更长时可取更长档（偏好可被内容需要覆盖，硬约束不可）"
         if default_duration is not None
         else "按叙事需要从档位中取值，不强制默认值"
     )

--- a/lib/prompt_builders_reference.py
+++ b/lib/prompt_builders_reference.py
@@ -71,6 +71,7 @@ def build_reference_units_split_prompt(
     scenes: dict,
     props: dict,
     supported_durations: list[int],
+    reference_supported_durations: list[int] | None = None,
     max_duration: int,
     max_reference_images: int | None,
     default_duration: int | None,
@@ -88,7 +89,10 @@ def build_reference_units_split_prompt(
     枚举硬约束）约束；unit_id / shots / references / utterances 全部机器派生，不进 LLM 输出。
 
     Args:
-        supported_durations: unit 允许的时长取值集合（秒），即模型档位。
+        supported_durations: unit 允许的时长取值集合（秒），即两种引用状态下档位的并集，
+            与 response_schema 的枚举同集合。
+        reference_supported_durations: 带 ``@`` 引用的 unit 才适用的更窄档位；None 或与
+            ``supported_durations`` 等价时不写入该联动约束（多数型号不声明「参考图↔时长」）。
         max_duration: 单次视频生成的时长上限（秒），即档位最大值。
         max_reference_images: 单 unit 参考图上限；None 时不写入硬性数量约束。
         default_duration: 用户项目偏好的默认秒数；须为 supported_durations 成员或 None。
@@ -101,8 +105,25 @@ def build_reference_units_split_prompt(
         raise ValueError("supported_durations 不能为空：必须提供模型支持的秒数集合")
     if default_duration is not None and int(default_duration) not in normalized_durations:
         raise ValueError(f"default_duration={default_duration} 不在 supported_durations={normalized_durations} 内")
+    normalized_reference_durations = sorted({int(d) for d in reference_supported_durations or []})
+    if not set(normalized_reference_durations) <= set(normalized_durations):
+        raise ValueError(
+            f"reference_supported_durations={normalized_reference_durations} 不是 "
+            f"supported_durations={normalized_durations} 的子集"
+        )
 
     durations_str = ", ".join(str(d) for d in normalized_durations)
+    # 「参考图↔时长」联动约束只在型号真的声明它、且两套档位不同时才写进 prompt：多数型号两者
+    # 等价，多写一条无效约束只会挤占模型注意力。约束的落地判定在工具侧按机械派生的 references
+    # 逐 unit 做，prompt 这段是教学，不是唯一防线。
+    reference_rule = (
+        "\n     该 unit 正文里带 `@` 资产引用时，档位进一步收窄为（"
+        + ", ".join(str(d) for d in normalized_reference_durations)
+        + "）——本型号对带参考图的生成另有时长限制。引用与时长两者取其一：要么改取该收窄档位内的值，"
+        "要么把次要资产融入描述文字、不用 `@` 引用，从而适用完整档位。"
+        if normalized_reference_durations and normalized_reference_durations != normalized_durations
+        else ""
+    )
     default_rule = (
         f"unit 默认取 {default_duration} 秒，叙事需要更长时可取更长档（偏好可被内容需要覆盖，硬约束不可）"
         if default_duration is not None
@@ -169,7 +190,7 @@ def build_reference_units_split_prompt(
   它是追溯锚，用于把生成结果对回原文；不逐字复制会被机械校验拒绝。
 - **时长决策序**（自上而下，高优先级是硬边界，低优先级在其内做优化）：
   1. 硬约束：`duration_seconds` 是 unit 时长（一次生成调用一个时长），必须取支持档位（{durations_str}）中的值。
-     叙事需要的时长放不下时，把该 unit 按叙事顺序重拆为多个 unit，**不得违约时长**。
+     叙事需要的时长放不下时，把该 unit 按叙事顺序重拆为多个 unit，**不得违约时长**。{reference_rule}
   2. 台词下界：先估算该 unit 全部台词与画外音念完约需的秒数（口播语速约 {speech_rate:g} {unit_label}/秒），
      取**不低于**这个秒数的档位。这是单向下界——台词永不压进念不完的短档；无台词的 unit 没有此下界。
      台词量超过最长档（{max_duration} 秒）时把该 unit 拆开，不要把台词硬塞进一个 unit。

--- a/lib/prompt_builders_reference.py
+++ b/lib/prompt_builders_reference.py
@@ -128,7 +128,8 @@ def build_reference_units_split_prompt(
         and normalized_reference_durations != normalized_text_durations
     )
     reference_rule = (
-        "\n     本型号下该档位还随「有无参考图」分两套，按该 unit **正文里有没有 `@` 资产引用**取用："
+        "\n     本型号下该档位还随「有无参考图」分两套，按该 unit **镜头描述行里有没有 `@` 资产引用**"
+        "取用（台词行 `@[角色]：{台词}` 的说话人不计入——它不生成参考图，只驱动音色声明）："
         f"带 `@` 引用取（{', '.join(str(d) for d in normalized_reference_durations)}），"
         f"不带取（{', '.join(str(d) for d in normalized_text_durations)}）。"
         "两者取其一：要么改取该 unit 引用状态对应档位内的值，要么调整引用——"

--- a/lib/reference_video/duration_migration.py
+++ b/lib/reference_video/duration_migration.py
@@ -12,6 +12,16 @@ read-modify-write 回写——迁移一次落盘、谁先跑谁定终局，二�
 ``supported_durations`` 为 None 的两种情形只做结构区间 clamp：项目尚未配置可解析的视频型号，
 以及 ``migrate_script_unit_durations`` 这条剧集脚本同步加载链。此时档位偏移仍由预检 / 执行时的
 取档（``resolve_duration_slot``）承担并记 warning，与迁移前语义一致。
+
+**剧集脚本侧不做档位收敛（enforcement 回写），这是终局分工，不是待补的缺口**：
+
+- 落盘时刻已必然在档——``ScriptGenerator._add_metadata`` 按最终 references 逐 unit 取档，出档直接
+  报错。偏移只可能来自事后改模型 / 改分辨率。
+- 偏移后也没有脏值能到供应商——预检（``precheck_unit``）与执行（``_apply_provider_constraints``）
+  都会重新取档并出 warning，执行期实际申请的秒数写回 task payload 供 resume 读取，脚本本身不动。
+- 回写会与全仓策略冲突：出档一律「fail-loud 或 warning + 引导重选」，从不静默改写用户编排真相；
+  且预检是 GET 读路径，在其上写盘不可接受，执行期写盘则会与用户编辑竞争。
+- 加载期回写另有硬阻：``load_script`` 是同步调用、无 DB 会话，拿不到档位表。
 """
 
 from __future__ import annotations

--- a/server/agent_runtime/sdk_tools/_context.py
+++ b/server/agent_runtime/sdk_tools/_context.py
@@ -54,11 +54,15 @@ def constrained_caps_durations(
     durations: list[int],
     *,
     generation_mode: str | None,
+    uses_reference_images: bool | None = None,
 ) -> list[int]:
     """按 caps 里的模型身份对 ``durations`` 施加时长联动约束（见 ``constrain_durations_for_project``）。
 
     ``durations`` 单独传入而非从 caps 取：调用方对该集合做过自己的软回退 / 过滤，收窄要作用在
     那个结果上，不能绕回 caps 的原始集合。
+
+    ``uses_reference_images`` 缺省时按生成模式近似判定；调用方能区分「这次求的是带参考图还是
+    不带参考图的档位」时应显式传入。
     """
     return constrain_durations_for_project(
         project,
@@ -66,7 +70,33 @@ def constrained_caps_durations(
         provider_id=caps.get("provider_id"),
         model_id=caps.get("model"),
         generation_mode=generation_mode,
+        uses_reference_images=uses_reference_images,
     )
+
+
+def reference_unit_duration_tiers(
+    project: dict[str, Any],
+    caps: dict[str, Any],
+    durations: list[int],
+) -> tuple[list[int], list[int]]:
+    """参考视频路径逐 unit 的两套生效档位：``(带参考图, 不带参考图)``。
+
+    「参考图↔时长」约束只对实际带参考图的请求生效（执行层 ``effective_reference_durations``
+    与 backend 同此判据），故 unit 的生效档位取决于该 unit 正文里有没有 ``@[名称]`` 引用。
+    整集按其中一套一刀切都有代价：一律按带图算会收掉无引用 unit 本可申请的短档，一律按不带图
+    算则会让带引用的 unit 拆出执行期申请不到的时长。
+
+    两套集合之间**不假定包含关系**：``constrain_durations`` 在交集为空时回退到未收窄的候选，
+    带图集因而可能反过来比不带图集宽（型号同时声明「带图仅 8s」与「1080p 仅 6s」即是）。
+    需要「任一状态下合法」的并集时由调用方对两个返回值取并，不要拿其中一个当上界。
+    """
+    with_references = constrained_caps_durations(
+        project, caps, durations, generation_mode="reference_video", uses_reference_images=True
+    )
+    without_references = constrained_caps_durations(
+        project, caps, durations, generation_mode="reference_video", uses_reference_images=False
+    )
+    return with_references, without_references
 
 
 async def fetch_video_caps(

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -495,8 +495,8 @@ class ReferenceSplitCaps(NamedTuple):
 
     ``reference_durations`` / ``text_durations`` 是带 / 不带 ``@`` 引用的 unit 各自的生效档位，
     ``durations`` 是二者的并集——schema 枚举与 prompt 候选集合取并集，因为落在任一套内的时长都
-    可能合法；归属哪一套要等正文派生出 references 才知道。三者相等即该型号未声明「参考图↔时长」
-    联动约束（注册表现状即如此，除 Veo 3.1 系列在 720p 下之外）。
+    可能合法；归属哪一套要等正文派生出 references 才知道。三者相等即该型号在当前分辨率下未声明
+    生效的「参考图↔时长」联动约束，多数型号如此。
     """
 
     default_duration: int | None
@@ -671,6 +671,7 @@ def split_reference_video_units_tool(ctx: ToolContext):
                 props=props,
                 supported_durations=split_caps.durations,
                 reference_supported_durations=split_caps.reference_durations,
+                text_supported_durations=split_caps.text_durations,
                 max_duration=split_caps.max_duration,
                 max_reference_images=split_caps.max_refs,
                 default_duration=split_caps.default_duration,

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -12,7 +12,7 @@ import logging
 import re
 from collections import Counter
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from claude_agent_sdk import tool
 from pydantic import BaseModel, ValidationError
@@ -50,8 +50,8 @@ from lib.text_generator import TextGenerator
 from lib.text_utils import strip_json_code_fences
 from server.agent_runtime.sdk_tools._context import (
     ToolContext,
-    constrained_caps_durations,
     fetch_video_caps,
+    reference_unit_duration_tiers,
     resolve_video_caps,
     tool_error,
 )
@@ -126,15 +126,36 @@ async def _resolve_video_capabilities(project_name: str) -> dict[str, Any]:
     return await resolver.video_capabilities(project_name)
 
 
+def _annotate_reference_unit_tiers(payload: dict[str, Any], project: dict[str, Any]) -> None:
+    """就地补上参考视频路径逐 unit 的两套生效档位（非该路径的项目不补）。
+
+    ``supported_durations`` 是型号声明的全集，不含「分辨率↔时长」「参考图↔时长」两条联动约束。
+    参考路径的 unit 时长就是发给供应商的那个值，手工改 step1 时照全集取值会写出执行期申请不到
+    的秒数——故把服务端拆分工具用的同两套档位一并返回，让改写方与生成方对同一份数字。
+    """
+    if payload.get("generation_mode") != "reference_video":
+        return
+    durations = [int(d) for d in payload.get("supported_durations") or []]
+    if not durations:
+        return
+    with_refs, without_refs = reference_unit_duration_tiers(project, payload, durations)
+    payload["reference_unit_durations"] = {
+        "with_references": with_refs,
+        "without_references": without_refs,
+    }
+
+
 def get_video_capabilities_tool(ctx: ToolContext):
     @tool(
         "get_video_capabilities",
-        "查当前项目的视频模型能力（model 粒度）+ 用户项目偏好。返回 JSON。",
+        "查当前项目的视频模型能力（model 粒度）+ 用户项目偏好。返回 JSON；"
+        "参考生视频项目另含 reference_unit_durations（按 unit 有无 @ 引用分开的两套生效档位）。",
         {"type": "object", "properties": {}},
     )
     async def _handler(_args: dict[str, Any]) -> dict[str, Any]:
         try:
             payload = await _resolve_video_capabilities(ctx.project_name)
+            _annotate_reference_unit_tiers(payload, ctx.pm.load_project(ctx.project_name))
             return {"content": [{"type": "text", "text": json.dumps(payload, ensure_ascii=False, indent=2)}]}
         except FileNotFoundError as exc:
             return {
@@ -466,16 +487,43 @@ def normalize_drama_script_tool(ctx: ToolContext):
 # ---------------------------------------------------------------------------
 
 
-async def _fetch_reference_caps_with_fallback(project: dict[str, Any]) -> tuple[int | None, list[int], int, int | None]:
-    """解析 rv 拆分所需的视频能力：``(default_duration, supported_durations, max_duration, max_refs)``。
+class ReferenceSplitCaps(NamedTuple):
+    """rv 拆分用的视频能力：两套逐 unit 档位 + 派生上限 + 用户偏好。
+
+    ``reference_durations`` / ``text_durations`` 是带 / 不带 ``@`` 引用的 unit 各自的生效档位，
+    ``durations`` 是二者的并集——schema 枚举与 prompt 候选集合取并集，因为落在任一套内的时长都
+    可能合法；归属哪一套要等正文派生出 references 才知道。三者相等即该型号未声明「参考图↔时长」
+    联动约束（注册表现状即如此，除 Veo 3.1 系列在 720p 下之外）。
+    """
+
+    default_duration: int | None
+    durations: list[int]
+    reference_durations: list[int]
+    text_durations: list[int]
+    max_duration: int
+    max_refs: int | None
+
+    def tiers_for(self, *, has_references: bool) -> list[int]:
+        """该引用状态下的生效档位。"""
+        return self.reference_durations if has_references else self.text_durations
+
+
+async def _fetch_reference_caps_with_fallback(project: dict[str, Any]) -> ReferenceSplitCaps:
+    """解析 rv 拆分所需的视频能力（见 ``ReferenceSplitCaps``）。
 
     与 ``_fetch_caps_with_fallback`` 同口径 best-effort：resolver 故障时回退
     ``duration_presets.DEFAULT_FALLBACK``、``max_refs`` 视为未声明。
 
     unit 是一次生成调用的单元，拆分阶段定的时长就是真正发给供应商的那个值，故档位取**经时长
     联动约束收窄后**的集合：不收窄的话（海螺 1080p 只接受 6 秒）step1 会按全集拆出超标的 unit，
-    step2 的枚举 schema 再把它判非法。``max_duration`` 随之是该集合的最大值。
-    ``default_duration`` 非收窄后集合成员（用户配置漂移）按 None 处理，避免 prompt 自相矛盾。
+    step2 的枚举 schema 再把它判非法。
+
+    收窄逐 unit 分两套（``reference_unit_duration_tiers``）：「参考图↔时长」约束只对真的带参考图
+    的请求生效，整集一律按带图收窄会把无引用 unit 本可申请的短档也收掉。schema 枚举与 prompt
+    候选取两套的并集——落在任一套内的时长都可能合法，具体归属由该 unit 的 references 决定，
+    在正文派生出 references 之后逐 unit 判（见 ``_build_reference_units_from_flat``）。
+    ``max_duration`` 随之是并集的最大值。
+    ``default_duration`` 非并集成员（用户配置漂移）按 None 处理，避免 prompt 自相矛盾。
     """
     try:
         caps = await resolve_video_caps(project)
@@ -485,7 +533,8 @@ async def _fetch_reference_caps_with_fallback(project: dict[str, Any]) -> tuple[
     durations = [int(d) for d in caps.get("supported_durations") or []]
     if not durations:
         durations = list(DEFAULT_FALLBACK)
-    unit_durations = constrained_caps_durations(project, caps, durations, generation_mode="reference_video")
+    with_refs, without_refs = reference_unit_duration_tiers(project, caps, durations)
+    unit_durations = sorted(set(with_refs) | set(without_refs))
     max_duration = max(unit_durations)
     raw_refs = caps.get("max_reference_images")
     max_refs = int(raw_refs) if isinstance(raw_refs, int | float) else None
@@ -493,7 +542,33 @@ async def _fetch_reference_caps_with_fallback(project: dict[str, Any]) -> tuple[
     default = int(raw_default) if isinstance(raw_default, int | float) else None
     if default is not None and default not in unit_durations:
         default = None
-    return default, unit_durations, max_duration, max_refs
+    return ReferenceSplitCaps(
+        default_duration=default,
+        durations=unit_durations,
+        reference_durations=sorted(set(with_refs)),
+        text_durations=sorted(set(without_refs)),
+        max_duration=max_duration,
+        max_refs=max_refs,
+    )
+
+
+def _validate_unit_duration_tier(label: str, duration: int, *, has_references: bool, caps: ReferenceSplitCaps) -> None:
+    """按该 unit 的引用状态判时长是否落在生效档位内，出档 fail-loud。
+
+    schema 的枚举卡的是两套档位的并集，一个带引用的 unit 因此仍可能取到只有无引用 unit 才
+    合法的秒数——那样的 unit 执行期申请不到，等到入队才失败已无统一纠正入口。错误消息给出
+    两条出路（换档位 / 去引用），与 prompt 里的教学同一口径。
+    """
+    tiers = caps.tiers_for(has_references=has_references)
+    if duration in tiers:
+        return
+    state = "带 `@` 资产引用" if has_references else "无 `@` 资产引用"
+    remedy = (
+        "；请改取该档位内的时长，或把次要资产融入描述文字、不用 `@` 引用"
+        if has_references
+        else "；请改取该档位内的时长"
+    )
+    raise ValueError(f"{label} 时长 {duration}s 不在{state}的 unit 的生效档位 {tiers} 内{remedy}")
 
 
 def _build_reference_units_from_flat(
@@ -502,8 +577,7 @@ def _build_reference_units_from_flat(
     *,
     episode: int,
     novel_text: str,
-    max_duration: int,
-    max_refs: int | None,
+    caps: ReferenceSplitCaps,
     source_language: str | None,
 ) -> list[dict]:
     """把 LLM 的扁平产出（时长 + 原文锚 + 书写层正文）校验并派生为落盘的结构化 unit 表。
@@ -511,22 +585,24 @@ def _build_reference_units_from_flat(
     LLM 只写内容，机器写结构：``unit_id`` 按数组序号编号、``shots`` 由 ``镜头N：`` 切分、
     ``references`` 由 ``@[名称]`` 派生（首现顺序即参考图编号），三者都没有让模型写错的余地。
     schema 已卡死时长枚举与外层形状；此处补依赖运行时能力值 / 项目登记表 / 源文的约束——
-    时长 ≤ max_duration、原文锚是源文逐字子串、正文语法与资产引用合法、台词量念得完。
-    任一违约 fail-loud 抛错，不把违规拆分当成功产物写盘。
+    时长落在该 unit 引用状态对应的生效档位内、原文锚是源文逐字子串、正文语法与资产引用合法、
+    台词量念得完。任一违约 fail-loud 抛错，不把违规拆分当成功产物写盘。
+
+    时长判在 ``validate_unit_text`` **之后**：适用哪套档位取决于该 unit 有没有 references，
+    而 references 正是从正文机械派生的——模型没有直接写它的余地，也就无从提前判定。
     """
     units: list[dict] = []
     for index, flat in enumerate(flat_units, start=1):
         unit_id = f"E{episode}U{index:02d}"
         label = f"unit {unit_id}"
         duration = int(flat.get("duration_seconds") or 0)
-        if duration > max_duration:
-            raise ValueError(f"{label} 时长 {duration}s 超过单次生成上限 {max_duration}s；请改取更短的档位")
 
         source_text = str(flat.get("source_text") or "")
         validate_source_text_anchor(label, source_text, novel_text)
 
         text = str(flat.get("text") or "")
-        shots, refs = validate_unit_text(label, text, project, max_refs=max_refs)
+        shots, refs = validate_unit_text(label, text, project, max_refs=caps.max_refs)
+        _validate_unit_duration_tier(label, duration, has_references=bool(refs), caps=caps)
         validate_dialogue_load(label, text, duration, source_language)
 
         units.append(
@@ -582,9 +658,7 @@ def split_reference_video_units_tool(ctx: ToolContext):
             props = project.get("props")
             props = props if isinstance(props, dict) else {}
 
-            default_duration, supported_durations, max_duration, max_refs = await _fetch_reference_caps_with_fallback(
-                project
-            )
+            split_caps = await _fetch_reference_caps_with_fallback(project)
             episode_outline, next_episode_outline = episode_outline_context(project, episode)
             prompt = build_reference_units_split_prompt(
                 novel_text=novel_text,
@@ -592,10 +666,11 @@ def split_reference_video_units_tool(ctx: ToolContext):
                 characters=characters,
                 scenes=scenes,
                 props=props,
-                supported_durations=supported_durations,
-                max_duration=max_duration,
-                max_reference_images=max_refs,
-                default_duration=default_duration,
+                supported_durations=split_caps.durations,
+                reference_supported_durations=split_caps.reference_durations,
+                max_duration=split_caps.max_duration,
+                max_reference_images=split_caps.max_refs,
+                default_duration=split_caps.default_duration,
                 episode=episode,
                 # 输出语言取项目 source_language（生成内容语言的唯一真相源），与 normalize 同口径。
                 target_language=project.get("source_language") or "中文",
@@ -619,7 +694,7 @@ def split_reference_video_units_tool(ctx: ToolContext):
             # 结构化输出：response_schema 按 supported_durations 卡死 unit 时长枚举，产出扁平
             # unit → 时长 + 原文锚 + 书写层正文；unit_id / shots / references 不进 LLM 输出、
             # 由下方机械派生（正文内的语法则由 parser 后校验兜底，schema 管不到）。
-            schema = build_reference_units_step1_model(supported_durations)
+            schema = build_reference_units_step1_model(split_caps.durations)
             generator = await TextGenerator.create(TextTaskType.SCRIPT, project_name=ctx.project_name)
             result = await generator.generate(
                 TextGenerationRequest(
@@ -639,8 +714,7 @@ def split_reference_video_units_tool(ctx: ToolContext):
                 project,
                 episode=episode,
                 novel_text=novel_text,
-                max_duration=max_duration,
-                max_refs=max_refs,
+                caps=split_caps,
                 source_language=project.get("source_language"),
             )
             content = {"units": raw_units}

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -132,8 +132,11 @@ def _annotate_reference_unit_tiers(payload: dict[str, Any], project: dict[str, A
     ``supported_durations`` 是型号声明的全集，不含「分辨率↔时长」「参考图↔时长」两条联动约束。
     参考路径的 unit 时长就是发给供应商的那个值，手工改 step1 时照全集取值会写出执行期申请不到
     的秒数——故把服务端拆分工具用的同两套档位一并返回，让改写方与生成方对同一份数字。
+
+    ad 例外：该路径的 unit 是从 ``shots[]`` 派生的轻量索引、镜头时长不受档位枚举管辖，返回这
+    两套档位只会诱导按剧集路径的口径去改 ad 镜头。
     """
-    if payload.get("generation_mode") != "reference_video":
+    if payload.get("generation_mode") != "reference_video" or payload.get("content_mode") == "ad":
         return
     durations = [int(d) for d in payload.get("supported_durations") or []]
     if not durations:

--- a/tests/lib/test_prompt_builders_reference.py
+++ b/tests/lib/test_prompt_builders_reference.py
@@ -174,6 +174,22 @@ def test_build_reference_units_split_prompt_rejects_bad_inputs():
         _split_prompt(supported_durations=[])
     with pytest.raises(ValueError, match="default_duration"):
         _split_prompt(supported_durations=[4, 8], default_duration=5)
+    with pytest.raises(ValueError, match="reference_supported_durations"):
+        _split_prompt(supported_durations=[4, 8], reference_supported_durations=[6])
+
+
+def test_build_reference_units_split_prompt_writes_reference_duration_linkage():
+    """带参考图档位更窄时，prompt 写明联动约束与两条出路（换档位 / 去引用）。"""
+    prompt = _split_prompt(supported_durations=[4, 6, 8], reference_supported_durations=[8], default_duration=None)
+    assert "`@` 资产引用时，档位进一步收窄为（8）" in prompt
+    assert "不用 `@` 引用" in prompt
+
+
+def test_build_reference_units_split_prompt_omits_linkage_when_tiers_equal():
+    """多数型号未声明「参考图↔时长」约束：两套档位相同时不写这条，避免无效约束占注意力。"""
+    for reference_durations in ([4, 6, 8], None):
+        prompt = _split_prompt(supported_durations=[4, 6, 8], reference_supported_durations=reference_durations)
+        assert "档位进一步收窄" not in prompt
 
 
 def test_render_reference_units_for_step2_mechanical():

--- a/tests/lib/test_prompt_builders_reference.py
+++ b/tests/lib/test_prompt_builders_reference.py
@@ -210,6 +210,23 @@ def test_build_reference_units_split_prompt_states_both_tiers_without_containmen
     assert "不带取（6）" in prompt
 
 
+def test_build_reference_units_split_prompt_excludes_dialogue_speaker_from_reference_rule():
+    """联动约束按镜头描述行判定，台词行 `@[角色]：{台词}` 的说话人不计入。
+
+    ``extract_mentions`` 派生 references 时整行剔除规范台词行的说话人（画外说话不生成参考图，
+    见 shot_parser 同函数 docstring）；prompt 若只说「正文里有没有 `@`」，模型会把只在台词行
+    出现说话人的 unit 误判为「带引用」、选进更窄的档位——落盘派生时 references 却是空，
+    与模型的选择依据不一致。
+    """
+    prompt = _split_prompt(
+        supported_durations=[4, 6, 8],
+        reference_supported_durations=[8],
+        text_supported_durations=[4, 6, 8],
+        default_duration=None,
+    )
+    assert "台词行 `@[角色]：{台词}` 的说话人不计入" in prompt
+
+
 def test_build_reference_units_split_prompt_scopes_default_to_its_tier():
     """默认值只对一种引用状态合法时点明适用范围，免得模型把它套到另一种状态的 unit 上。"""
     prompt = _split_prompt(
@@ -232,7 +249,7 @@ def test_build_reference_units_split_prompt_omits_linkage_when_tiers_equal():
             reference_supported_durations=reference_durations,
             text_supported_durations=text_durations,
         )
-        assert "按该 unit **正文里有没有 `@` 资产引用**取用" not in prompt
+        assert "按该 unit **镜头描述行里有没有 `@` 资产引用**取用" not in prompt
 
 
 def test_render_reference_units_for_step2_mechanical():

--- a/tests/lib/test_prompt_builders_reference.py
+++ b/tests/lib/test_prompt_builders_reference.py
@@ -176,20 +176,63 @@ def test_build_reference_units_split_prompt_rejects_bad_inputs():
         _split_prompt(supported_durations=[4, 8], default_duration=5)
     with pytest.raises(ValueError, match="reference_supported_durations"):
         _split_prompt(supported_durations=[4, 8], reference_supported_durations=[6])
+    with pytest.raises(ValueError, match="text_supported_durations"):
+        _split_prompt(supported_durations=[4, 8], text_supported_durations=[6])
 
 
 def test_build_reference_units_split_prompt_writes_reference_duration_linkage():
-    """带参考图档位更窄时，prompt 写明联动约束与两条出路（换档位 / 去引用）。"""
-    prompt = _split_prompt(supported_durations=[4, 6, 8], reference_supported_durations=[8], default_duration=None)
-    assert "`@` 资产引用时，档位进一步收窄为（8）" in prompt
+    """两套档位不同时，prompt 写明各自的档位与两条出路（换档位 / 去引用）。"""
+    prompt = _split_prompt(
+        supported_durations=[4, 6, 8],
+        reference_supported_durations=[8],
+        text_supported_durations=[4, 6, 8],
+        default_duration=None,
+    )
+    assert "带 `@` 引用取（8）" in prompt
+    assert "不带取（4, 6, 8）" in prompt
     assert "不用 `@` 引用" in prompt
+
+
+def test_build_reference_units_split_prompt_states_both_tiers_without_containment():
+    """带图档位反而更宽时，被收窄的是无引用 unit——prompt 必须照样写全，不能只讲带图那套。
+
+    `constrain_durations` 在交集为空时回退到未收窄候选，故两套档位之间不假定包含关系
+    （与 `_context.reference_unit_duration_tiers` 同一判据）。只讲带图会让无引用 unit
+    照并集取到自己申请不到的档位。
+    """
+    prompt = _split_prompt(
+        supported_durations=[4, 6, 8],
+        reference_supported_durations=[4, 6, 8],
+        text_supported_durations=[6],
+        default_duration=None,
+    )
+    assert "带 `@` 引用取（4, 6, 8）" in prompt
+    assert "不带取（6）" in prompt
+
+
+def test_build_reference_units_split_prompt_scopes_default_to_its_tier():
+    """默认值只对一种引用状态合法时点明适用范围，免得模型把它套到另一种状态的 unit 上。"""
+    prompt = _split_prompt(
+        supported_durations=[4, 6, 8],
+        reference_supported_durations=[8],
+        text_supported_durations=[4, 6, 8],
+        default_duration=4,
+    )
+    assert "unit 默认取 4 秒（该默认值只落在不带 `@` 引用的 unit 的档位内" in prompt
+    # 两套档位都含该默认值时不加这段限定，避免无效措辞。
+    plain = _split_prompt(supported_durations=[4, 6, 8], default_duration=4)
+    assert "该默认值只落在" not in plain
 
 
 def test_build_reference_units_split_prompt_omits_linkage_when_tiers_equal():
     """多数型号未声明「参考图↔时长」约束：两套档位相同时不写这条，避免无效约束占注意力。"""
-    for reference_durations in ([4, 6, 8], None):
-        prompt = _split_prompt(supported_durations=[4, 6, 8], reference_supported_durations=reference_durations)
-        assert "档位进一步收窄" not in prompt
+    for reference_durations, text_durations in (([4, 6, 8], [4, 6, 8]), (None, None), ([4, 6, 8], None)):
+        prompt = _split_prompt(
+            supported_durations=[4, 6, 8],
+            reference_supported_durations=reference_durations,
+            text_supported_durations=text_durations,
+        )
+        assert "按该 unit **正文里有没有 `@` 资产引用**取用" not in prompt
 
 
 def test_render_reference_units_for_step2_mechanical():

--- a/tests/lib/test_prompt_builders_reference.py
+++ b/tests/lib/test_prompt_builders_reference.py
@@ -243,7 +243,12 @@ def test_build_reference_units_split_prompt_scopes_default_to_its_tier():
 
 def test_build_reference_units_split_prompt_omits_linkage_when_tiers_equal():
     """多数型号未声明「参考图↔时长」约束：两套档位相同时不写这条，避免无效约束占注意力。"""
-    for reference_durations, text_durations in (([4, 6, 8], [4, 6, 8]), (None, None), ([4, 6, 8], None)):
+    for reference_durations, text_durations in (
+        ([4, 6, 8], [4, 6, 8]),
+        (None, None),
+        ([4, 6, 8], None),
+        (None, [4, 6, 8]),
+    ):
         prompt = _split_prompt(
             supported_durations=[4, 6, 8],
             reference_supported_durations=reference_durations,

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1890,12 +1890,24 @@ async def test_get_video_capabilities_annotates_reference_unit_tiers(fake_ctx: T
 
 
 @pytest.mark.unit
-async def test_get_video_capabilities_skips_tiers_off_reference_path(fake_ctx: ToolContext, monkeypatch) -> None:
-    """非参考路径项目不补该字段：逐 unit 引用状态在其它路径上没有意义。"""
+@pytest.mark.parametrize(
+    ("generation_mode", "content_mode"),
+    [("storyboard", "drama"), ("reference_video", "ad")],
+)
+async def test_get_video_capabilities_skips_tiers_off_episode_reference_path(
+    fake_ctx: ToolContext, monkeypatch, generation_mode: str, content_mode: str
+) -> None:
+    """非剧集参考路径不补该字段：其它路径没有逐 unit 引用状态，ad 镜头时长也不受档位枚举管辖。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
 
     async def fake_resolve(_project):
-        return {"provider_id": "fake", "supported_durations": [4, 6, 8], "generation_mode": "storyboard"}
+        return {
+            "provider_id": "gemini-aistudio",
+            "model": "veo-3.1-generate-preview",
+            "supported_durations": [4, 6, 8],
+            "generation_mode": generation_mode,
+            "content_mode": content_mode,
+        }
 
     monkeypatch.setattr(mod, "_resolve_video_capabilities", fake_resolve)
     out = await _call(get_video_capabilities_tool(fake_ctx), {})

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1864,6 +1864,44 @@ async def test_get_video_capabilities_happy(fake_ctx: ToolContext, monkeypatch) 
     assert json.loads(out["content"][0]["text"])["provider_id"] == "fake"
 
 
+@pytest.mark.unit
+async def test_get_video_capabilities_annotates_reference_unit_tiers(fake_ctx: ToolContext, monkeypatch) -> None:
+    """参考路径项目另返回两套逐 unit 生效档位，供手工改 step1 时与生成侧对同一份数字。"""
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    async def fake_resolve(_project):
+        return {
+            "provider_id": "gemini-aistudio",
+            "model": "veo-3.1-generate-preview",
+            "supported_durations": [4, 6, 8],
+            "generation_mode": "reference_video",
+        }
+
+    fake_ctx.pm.project_payload["model_settings"] = {  # type: ignore[attr-defined]
+        "gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}
+    }
+    monkeypatch.setattr(mod, "_resolve_video_capabilities", fake_resolve)
+    out = await _call(get_video_capabilities_tool(fake_ctx), {})
+    assert out.get("is_error") is not True, out
+    payload = json.loads(out["content"][0]["text"])
+    assert payload["reference_unit_durations"] == {"with_references": [8], "without_references": [4, 6, 8]}
+    # 全集原样保留：它是型号声明，不是生效档位
+    assert payload["supported_durations"] == [4, 6, 8]
+
+
+@pytest.mark.unit
+async def test_get_video_capabilities_skips_tiers_off_reference_path(fake_ctx: ToolContext, monkeypatch) -> None:
+    """非参考路径项目不补该字段：逐 unit 引用状态在其它路径上没有意义。"""
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    async def fake_resolve(_project):
+        return {"provider_id": "fake", "supported_durations": [4, 6, 8], "generation_mode": "storyboard"}
+
+    monkeypatch.setattr(mod, "_resolve_video_capabilities", fake_resolve)
+    out = await _call(get_video_capabilities_tool(fake_ctx), {})
+    assert "reference_unit_durations" not in json.loads(out["content"][0]["text"])
+
+
 async def test_get_video_capabilities_error(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
@@ -2886,9 +2924,18 @@ async def test_generate_video_all_ad_reference_falls_through_to_episode(
 # ---------------------------------------------------------------------------
 
 
-def _rv_caps(default=4, durations=(4, 6, 8), max_duration=12, max_refs=3):
+def _rv_caps(default=4, durations=(4, 6, 8), reference_durations=None, max_duration=12, max_refs=3):
+    from server.agent_runtime.sdk_tools.text_generation import ReferenceSplitCaps
+
     async def fake_caps(_p):
-        return default, list(durations), max_duration, max_refs
+        return ReferenceSplitCaps(
+            default_duration=default,
+            durations=list(durations),
+            reference_durations=list(durations if reference_durations is None else reference_durations),
+            text_durations=list(durations),
+            max_duration=max_duration,
+            max_refs=max_refs,
+        )
 
     return fake_caps
 
@@ -2902,12 +2949,14 @@ async def test_fetch_reference_caps_with_fallback_returns_declared_slots(monkeyp
 
     monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
 
-    default, durations, max_duration, max_refs = await mod._fetch_reference_caps_with_fallback({})
+    caps = await mod._fetch_reference_caps_with_fallback({})
 
-    assert durations == [1, 8, 16, 18]
-    assert max_duration == 18
-    assert default == 16  # 是档位成员，照常采信
-    assert max_refs is None
+    assert caps.durations == [1, 8, 16, 18]
+    assert caps.reference_durations == [1, 8, 16, 18]
+    assert caps.text_durations == [1, 8, 16, 18]
+    assert caps.max_duration == 18
+    assert caps.default_duration == 16  # 是档位成员，照常采信
+    assert caps.max_refs is None
 
 
 @pytest.mark.unit
@@ -2930,9 +2979,9 @@ async def test_fetch_reference_caps_with_fallback_narrows_unit_duration_cap(monk
     monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
 
     project = {"model_settings": {"minimax/MiniMax-Hailuo-2.3": {"resolution": "1080p"}}}
-    _default, unit_durations, max_duration, _max_refs = await mod._fetch_reference_caps_with_fallback(project)
-    assert unit_durations == [6]
-    assert max_duration == 6
+    caps = await mod._fetch_reference_caps_with_fallback(project)
+    assert caps.durations == [6]
+    assert caps.max_duration == 6
 
 
 @pytest.mark.unit
@@ -2952,9 +3001,67 @@ async def test_fetch_reference_caps_with_fallback_narrows_slots_by_resolution(mo
     monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
 
     project = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}}
-    _default, unit_durations, max_duration, _max_refs = await mod._fetch_reference_caps_with_fallback(project)
-    assert unit_durations == [8]
-    assert max_duration == 8
+    caps = await mod._fetch_reference_caps_with_fallback(project)
+    assert caps.durations == [8]
+    assert caps.max_duration == 8
+
+
+@pytest.mark.unit
+def test_reference_unit_duration_tiers_does_not_assume_containment(monkeypatch) -> None:
+    """两套档位之间无包含关系可假定：两条约束自相矛盾时带图那套反而更宽。
+
+    ``constrain_durations`` 在交集为空时回退到未收窄候选，故型号同时声明「带图仅 8s」与
+    「1080p 仅 6s」时，带图集回退成全集、不带图集收成 [6]。调用方须显式取并集当枚举。
+    """
+    from lib.config import resolver as resolver_mod
+    from lib.config.registry import ModelInfo
+    from server.agent_runtime.sdk_tools._context import reference_unit_duration_tiers
+
+    contradictory = ModelInfo(
+        display_name="contradictory",
+        media_type="video",
+        capabilities=[],
+        supported_durations=[4, 6, 8],
+        duration_resolution_constraints={"1080p": [6]},
+        reference_image_durations=[8],
+    )
+    monkeypatch.setattr(resolver_mod, "model_info_for", lambda *_args: contradictory)
+
+    project = {"model_settings": {"p/m": {"resolution": "1080p"}}}
+    with_refs, without_refs = reference_unit_duration_tiers(project, {"provider_id": "p", "model": "m"}, [4, 6, 8])
+
+    assert with_refs == [4, 6, 8]
+    assert without_refs == [6]
+    assert not set(with_refs) <= set(without_refs)
+
+
+@pytest.mark.unit
+async def test_fetch_reference_caps_with_fallback_splits_tiers_by_reference_state(monkeypatch) -> None:
+    """「参考图↔时长」约束逐 unit 生效：Veo 720p 下带引用只剩 8 秒，无引用仍有 4/6/8。
+
+    枚举与 prompt 候选取并集——一律按带图收窄会把无引用 unit 本可申请的短档也收掉。
+    """
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    async def _fake_caps(_project):
+        return {
+            "provider_id": "gemini-aistudio",
+            "model": "veo-3.1-generate-preview",
+            "supported_durations": [4, 6, 8],
+            "max_duration": 8,
+            "default_duration": None,
+        }
+
+    monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
+
+    project = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}}}
+    caps = await mod._fetch_reference_caps_with_fallback(project)
+    assert caps.reference_durations == [8]
+    assert caps.text_durations == [4, 6, 8]
+    assert caps.durations == [4, 6, 8]
+    assert caps.max_duration == 8
+    assert caps.tiers_for(has_references=True) == [8]
+    assert caps.tiers_for(has_references=False) == [4, 6, 8]
 
 
 async def test_fetch_reference_caps_with_fallback_uses_write_layer_default(monkeypatch) -> None:
@@ -2966,11 +3073,11 @@ async def test_fetch_reference_caps_with_fallback_uses_write_layer_default(monke
         raise ValueError("no provider configured")
 
     monkeypatch.setattr(mod, "resolve_video_caps", _raising_caps)
-    default, durations, max_duration, max_refs = await mod._fetch_reference_caps_with_fallback({})
-    assert default is None
-    assert durations == DEFAULT_FALLBACK
-    assert max_duration == max(DEFAULT_FALLBACK)
-    assert max_refs is None
+    caps = await mod._fetch_reference_caps_with_fallback({})
+    assert caps.default_duration is None
+    assert caps.durations == DEFAULT_FALLBACK
+    assert caps.max_duration == max(DEFAULT_FALLBACK)
+    assert caps.max_refs is None
 
 
 def _rv_generator_returning(units: list[dict], captured: dict[str, Any] | None = None):
@@ -3114,13 +3221,43 @@ async def test_split_reference_video_units_rejects_over_max_refs(fake_ctx: ToolC
     assert not _rv_step1_path(fake_ctx).exists()
 
 
-async def test_split_reference_video_units_rejects_over_max_duration(fake_ctx: ToolContext, monkeypatch) -> None:
-    """unit 时长是枚举成员但超单次生成上限（能力声明与联动约束不一致时）→ 工具后校验 fail-loud。"""
+@pytest.mark.integration
+async def test_split_reference_video_units_rejects_duration_off_reference_tier(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """带 `@` 引用的 unit 取了只有无引用 unit 才合法的时长 → fail-loud，不写盘。
+
+    枚举卡的是两套档位的并集，这类越界过得了 schema；不在此拦，执行期才会申请不到。
+    """
     _rv_source(fake_ctx)
-    out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("镜头1：@[张三] 起身")], max_duration=6)
+    out = await _run_rv_split(
+        fake_ctx,
+        monkeypatch,
+        [_rv_unit("镜头1：@[张三] 起身", duration=4)],
+        reference_durations=(8,),
+    )
     assert out.get("is_error") is True
-    assert "超过单次生成上限" in out["content"][0]["text"]
+    text = out["content"][0]["text"]
+    assert "生效档位" in text and "[8]" in text
     assert not _rv_step1_path(fake_ctx).exists()
+
+
+@pytest.mark.integration
+async def test_split_reference_video_units_accepts_wide_tier_without_references(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """无 `@` 引用的 unit 不受「参考图↔时长」约束，仍可取更短的档位。"""
+    _rv_source(fake_ctx)
+    out = await _run_rv_split(
+        fake_ctx,
+        monkeypatch,
+        [_rv_unit("镜头1：门被风吹开", duration=4)],
+        reference_durations=(8,),
+    )
+    assert out.get("is_error") is not True, out
+    saved = json.loads(_rv_step1_path(fake_ctx).read_text(encoding="utf-8"))
+    assert saved["units"][0]["duration_seconds"] == 4
+    assert saved["units"][0]["references"] == []
 
 
 async def test_split_reference_video_units_rejects_out_of_enum_duration(fake_ctx: ToolContext, monkeypatch) -> None:


### PR DESCRIPTION
Closes #1530

## 背景更正

issue 正文说 step1 拆分侧「还没有这层联动，LLM 可能为带引用的 unit 拆出执行时申请不到的时长」。代码事实相反：step1 传 `generation_mode="reference_video"`，`uses_reference_images` 缺省即 `True`，所以拿到的是**整集一律按「带参考图」收窄**的单一集合（Veo 3.1 @720p 即 `[8]`）。真实缺陷是**过度收窄**——无引用 unit 本可申请的 4/6 秒被整集收掉——且这层保证并非逐 unit，只是恰好取了最窄的那套。

本 PR 按验收标准的字面落地：让每个 unit 的时长落在**其引用状态对应**的生效档位内。

## 改动

- **两套档位 + 并集枚举 + 派生后逐 unit 判**。拆分工具注入 `with_references` / `without_references` 两套档位（`sdk_tools/_context.reference_unit_duration_tiers`），response_schema 枚举与 prompt 候选取二者**并集**，落盘前在 `references` 从正文机械派生**之后**按该 unit 的引用状态判档位成员性、fail-loud。放弃的替代方案是让 LLM 自报引用状态——引用是从正文派生的，模型没有直接写它的余地，自报只会引入新的漂移面。
- **并集显式求，不拿其中一套当上界**。`constrain_durations` 在交集为空时回退到未收窄候选，型号同时声明「带图仅 8s」与「1080p 仅 6s」时带图那套反而更宽。注册表现状没有这种型号，但代码与 CONTEXT.md 都不写这条包含关系假设。
- **prompt 在两套档位不同时把两套都写全**，并在项目默认时长只对一种引用状态合法时点明其适用范围（如带图仅 8s 而项目默认 4s，避免模型把默认值套到带引用的 unit 上）。两套相同时整条不写——多数型号如此，多写一条无效约束只挤占注意力。
- **`get_video_capabilities` 补 `reference_unit_durations` 字段**。`split-reference-video-units` 的「手工改 step1」分支此前被指引按 `supported_durations`（**未**收窄的型号全集）取值，是既存的契约漂移；改后把服务端拆分工具用的同两套档位一并返回，让改写方与生成方对同一份数字。ad 项目不补该字段——其 unit 是从 `shots[]` 派生的轻量索引、镜头时长不受档位枚举管辖。
- **原 `duration > max_duration` 检查被档位成员性判定取代**：`max_duration` 现在派生自并集最大值，不可能小于任一并集成员，那条检查已不可达；档位成员性是更强的判定。

## 待决设计项定论：剧集脚本侧档位收敛 —— 保持现状

与 #1518 既有口径（存量走取档保护 + warning、从不静默改写用户编排真相）同构，不构成新取舍。论证写进 `lib/reference_video/duration_migration.py` 模块 docstring，四条依据：

1. 落盘时刻已必然在档——`ScriptGenerator._add_metadata` 按最终 references 逐 unit 取档，出档直接报错；偏移只可能来自事后改模型 / 改分辨率。
2. 偏移后没有脏值能到供应商——预检与执行都会重新取档并出 warning，执行期实际申请的秒数写回 task payload 供 resume 读取，脚本本身不动。
3. 回写与全仓策略冲突——出档一律「fail-loud 或 warning + 引导重选」；且预检是 GET 读路径，在其上写盘不可接受。
4. 加载期回写另有硬阻——`load_script` 同步、无 DB 会话，拿不到档位表。

即：结构区间 clamp 负责脏数据兜底，档位级偏移由消费点取档保护承担，两者分工是终局。

## 验证

- `uv run ruff check .` / `ruff format --check` 通过
- `uv run basedpyright` 0 error
- `uv run python -m pytest` 7343 passed
- 新增测试覆盖：两套档位的求取与不假定包含关系、并集枚举、按引用状态的逐 unit 校验（含带引用 unit 取到仅无引用合法的秒数时 fail-loud）、非包含情形下 prompt 写全两套、默认时长的适用范围限定、ad 项目不返回该字段
- 未起 server、未写数据库，全程单测

## 已知薄弱点

- step2 被明确允许给 unit 新增 `@` 引用。一个 step1 无引用、取了较短档的 unit 若在 step2 获得引用，会在 `_add_metadata` 的逐 unit 取档处失败。该失效路径不是本 PR 新引入的——`_unit_duration_off_every_tier` 的 docstring 已声明这是既定取舍（提前判死会拦掉本会成功的生成），手工编辑 step1 同样可构造。
- 联动约束在注册表里只有 Veo 3.1 系列声明，且只在 720p 下与不带图档位不同；新 prompt 措辞的真机效果（模型是否真能按引用状态选档）未验收。
- `reference_unit_durations` 是新字段，subagent 是否照新 doc 改用它只能实跑才知道；旧 `supported_durations` 仍在返回值里（它是型号声明，不能删）。

## 改动面

只动 step1 拆分侧的档位注入与后校验，外加 `get_video_capabilities` 的字段增补。与 #1499 的同函数分工：本 PR 在 `split_reference_video_units` 内只碰 caps 解析段、prompt 构造段、`_build_reference_units_from_flat` 的校验器本体；`except` 失败分支与 `pm.file_lock` / `atomic_write_json` 写盘段一行未动。后合并者需注意的唯一接触点是 `_build_reference_units_from_flat` 的调用参数由 `max_duration` / `max_refs` 两个标量改为单个 `caps: ReferenceSplitCaps`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 参考视频拆分支持按单个 unit 是否包含参考图，分别应用对应的时长候选与约束。
  - 无参考图的 unit 不再受参考图时长限制影响。
  - 预检、执行及前端候选选择会根据各 unit 的最终引用状态重新计算可用时长。
  - 当两类时长约束没有交集时，自动回退至未收窄的候选范围。

- **文档**
  - 补充参考图时长规则、提示词约束及使用限制说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->