### PR TITLE
feat(settings): 文生图/图生图未单独配置时回退默认图片模型，存量重复配置自动收敛

### DIFF
--- a/alembic/versions/b7f2c41d9a30_collapse_image_backend_buckets_to_default.py
+++ b/alembic/versions/b7f2c41d9a30_collapse_image_backend_buckets_to_default.py
@@ -1,0 +1,108 @@
+"""collapse image backend buckets into the default layer
+
+Revision ID: b7f2c41d9a30
+Revises: d10f1df40f96
+Create Date: 2026-08-02 20:10:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TypeGuard
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b7f2c41d9a30"
+down_revision: str | Sequence[str] | None = "d10f1df40f96"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_DEFAULT_KEY = "default_image_backend"
+_BUCKET_KEYS = ("default_image_backend_t2i", "default_image_backend_i2i")
+
+
+def _read(bind: sa.Connection, key: str) -> str | None:
+    row = bind.execute(sa.text("SELECT value FROM system_setting WHERE key = :k").bindparams(k=key)).fetchone()
+    return None if row is None else row[0]
+
+
+def _write(bind: sa.Connection, key: str, value: str) -> None:
+    updated = bind.execute(
+        sa.text("UPDATE system_setting SET value = :v, updated_at = CURRENT_TIMESTAMP WHERE key = :k").bindparams(
+            k=key, v=value
+        )
+    ).rowcount
+    if not updated:
+        bind.execute(
+            sa.text(
+                "INSERT INTO system_setting (key, value, updated_at) VALUES (:k, :v, CURRENT_TIMESTAMP)"
+            ).bindparams(k=key, v=value)
+        )
+
+
+def _delete(bind: sa.Connection, key: str) -> None:
+    bind.execute(sa.text("DELETE FROM system_setting WHERE key = :k").bindparams(k=key))
+
+
+def _configured(value: str | None) -> TypeGuard[str]:
+    """有效配置值 = 形如 ``provider/model``；空串与无斜杠的残值都不构成配置。"""
+    return value is not None and "/" in value
+
+
+def upgrade() -> None:
+    """把图片 t2i / i2i 从强制槽位收敛为可选覆盖桶，默认层升为 default_image_backend。
+
+    存量键组合逐一处置（``docs/adr/0054``）：
+
+    - 桶值无效（空串 / 无斜杠）：删除。旧语义下它表示「显式清空 → 跟随自动推断」，新语义
+      下桶无值即回退默认层——删除后两者同形，配置面不再留下会被误读为「已配置」的空桶。
+    - 两桶同值且默认层未配置：桶值升为默认层、删除两桶。拆分前只配过一个图片模型的用户
+      由此回到「只配默认」的规范形态。
+    - 两桶同值且与默认层相同：删除两桶。这是拆分迁移复制出的冗余副本。
+    - 其余（两桶取值不同，或同值但默认层另有配置）：原样保留，桶继续作为覆盖生效。
+    """
+    bind = op.get_bind()
+    default = _read(bind, _DEFAULT_KEY)
+    buckets = {key: _read(bind, key) for key in _BUCKET_KEYS}
+
+    for key, value in buckets.items():
+        if value is not None and not _configured(value):
+            _delete(bind, key)
+            buckets[key] = None
+
+    t2i, i2i = (buckets[key] for key in _BUCKET_KEYS)
+    if not _configured(t2i) or t2i != i2i:
+        return
+    if not _configured(default):
+        _write(bind, _DEFAULT_KEY, t2i)
+    elif default != t2i:
+        return
+    for key in _BUCKET_KEYS:
+        _delete(bind, key)
+
+
+def downgrade() -> None:
+    """还原「桶即权威」形态：默认层有配置而两桶皆无有效值时，把默认值复制回两桶。
+
+    先按 upgrade 的同一口径规范化无效桶行再判断：配置面清空某个桶写入的是空串行而非删行
+    （见 ``server/routers/system_config.py`` 的 backend 键写入），若按「行存在即有效覆盖」判定，
+    降级后旧语义会把这个空桶当权威、跳过默认层，使该能力从用户配置的默认层静默落到自动推断。
+
+    无法逐条还原被删除的无效桶值（旧语义的「显式清空」与「从未配置」在降级后同形），
+    降级后这类配置按未配置处理。
+    """
+    bind = op.get_bind()
+    default = _read(bind, _DEFAULT_KEY)
+    if not _configured(default):
+        return
+    for key in _BUCKET_KEYS:
+        if not _configured(_read(bind, key)):
+            _delete(bind, key)
+    if any(_read(bind, key) is not None for key in _BUCKET_KEYS):
+        return
+    for key in _BUCKET_KEYS:
+        _write(bind, key, default)

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -165,21 +165,19 @@ class _LayeredBackendKeys:
     project_default_key: str | None = None
     global_bucket_key: str | None = None
     global_default_key: str | None = None
-    # True（docs/adr/0054 描述的语义）：全局桶键存在但无有效值时回退全局默认层。
-    # False：全局桶键存在即权威——值无效（含显式清空）直接跳到自动推断，不读全局默认键。
-    empty_global_bucket_follows_default: bool = True
 
 
-# 图片桶（t2i / i2i）键位。图片的空桶语义是「用户显式清空 → 跟随自动推断」，故
-# empty_global_bucket_follows_default 取 False，与 docs/adr/0054 的「空桶回退默认层」不同。
+# 图片桶（t2i / i2i）键位。桶为可选覆盖，空桶回退默认层：项目默认层用 project.json 的
+# default_image_backend 字段（与文本档位的 default_text_backend 同名同位），全局默认层用
+# default_image_backend 设置键。
 _IMAGE_LAYERED_KEYS: dict[str, _LayeredBackendKeys] = {
     cap: _LayeredBackendKeys(
         media_type="image",
         parse_fallback=_DEFAULT_IMAGE_BACKEND,
         project_bucket_key=f"image_provider_{cap}",
+        project_default_key="default_image_backend",
         global_bucket_key=f"default_image_backend_{cap}",
         global_default_key="default_image_backend",
-        empty_global_bucket_follows_default=False,
     )
     for cap in ("t2i", "i2i")
 }
@@ -616,9 +614,9 @@ class ConfigResolver:
     ) -> ProviderModel:
         """解析图片任务应使用的 ProviderModel。
 
-        优先级：payload > 项目桶（``image_provider_<cap>``）> 全局桶（``default_image_backend_<cap>``）
-        > 全局默认（``default_image_backend``）> 自动推断。全局桶键存在但值为空 = 显式清空，
-        跳过全局默认直达自动推断。图片无项目默认层。
+        优先级：payload > 项目桶（``image_provider_<cap>``）> 项目默认（``default_image_backend``）
+        > 全局桶（``default_image_backend_<cap>``）> 全局默认（``default_image_backend``）> 自动推断。
+        桶是可选覆盖，无值（含显式清空）回退默认层（``docs/adr/0054``）。
         capability 决定走 t2i 还是 i2i 槽（见 ``docs/adr/0001``）。不做任何 provider 归一化。
         """
         async with self._open_session() as (session, svc):
@@ -934,13 +932,10 @@ class ConfigResolver:
                 if parsed is not None:
                     return parsed
         settings = await svc.get_all_settings()
-        if keys.global_bucket_key is not None and keys.global_bucket_key in settings:
-            raw = settings[keys.global_bucket_key]
+        if keys.global_bucket_key is not None:
+            raw = settings.get(keys.global_bucket_key, "")
             if "/" in raw:
                 return ConfigService._parse_backend(raw, keys.parse_fallback)
-            if not keys.empty_global_bucket_follows_default:
-                # 桶键存在但无有效值 = 显式清空 = 跟随自动推断，不读全局默认键
-                return await self._auto_resolve_backend(svc, session, keys.media_type)
         if keys.global_default_key is not None:
             raw = settings.get(keys.global_default_key, "")
             if "/" in raw:
@@ -960,7 +955,7 @@ class ConfigResolver:
         payload 层保留 ``payload>project>global`` 的规范骨架，接受 ``image_provider_<cap>``
         与旧的 ``image_provider`` / ``image_model`` 键——队列里按旧格式序列化的任务据此解析。
         payload provider 须是已知 provider（见 ``_trusted_payload_provider``），否则不予信任、
-        回退骨架（``_resolve_layered_backend``，键位见 ``_IMAGE_LAYERED_KEYS``；图片无项目默认层）。
+        回退骨架（``_resolve_layered_backend``，键位见 ``_IMAGE_LAYERED_KEYS``）。
         """
         cap_key = f"image_provider_{capability}"
         if payload:
@@ -1323,8 +1318,7 @@ class ConfigResolver:
     ) -> tuple[str, str]:
         """仅全局层解析图片默认 backend：全局桶 > 全局默认键 > 自动推断。
 
-        走四级骨架但不带项目（project=None 跳过项目层）。全局桶键存在但值为空 = 用户显式
-        清空 = 跟随自动选择，不回退全局默认键（由 ``_IMAGE_LAYERED_KEYS`` 的键位声明决定）。
+        走四级骨架但不带项目（project=None 跳过项目层）。全局桶无值时回退全局默认键。
         """
         return await self._resolve_layered_backend(svc, session, None, _IMAGE_LAYERED_KEYS[capability])
 

--- a/lib/config/service.py
+++ b/lib/config/service.py
@@ -207,20 +207,6 @@ class ConfigService:
         raw = await self._setting_repo.get("default_video_backend", _DEFAULT_VIDEO_BACKEND)
         return self._parse_backend(raw, _DEFAULT_VIDEO_BACKEND)
 
-    async def get_default_image_backend(self) -> tuple[str, str]:
-        """图像默认 backend 的真实解析路径在 ConfigResolver.default_image_backend_t2i / _i2i；
-        此方法保留为公共 API，仅作为 T2I 兜底（外部调用方极少；Resolver 不调用此方法）。
-
-        与 resolver._resolve_default_image_backend 语义一致：新 key 存在但为空 = 显式清空，
-        不再回退 legacy；新 key 不存在才尝试 legacy。
-        """
-        settings = await self._setting_repo.get_all()
-        if "default_image_backend_t2i" in settings:
-            raw = settings["default_image_backend_t2i"]
-        else:
-            raw = settings.get("default_image_backend", _DEFAULT_IMAGE_BACKEND)
-        return self._parse_backend(raw or _DEFAULT_IMAGE_BACKEND, _DEFAULT_IMAGE_BACKEND)
-
     async def get_default_text_backend(self) -> tuple[str, str]:
         raw = await self._setting_repo.get("default_text_backend", _DEFAULT_TEXT_BACKEND)
         return self._parse_backend(raw, _DEFAULT_TEXT_BACKEND)

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -98,12 +98,16 @@ _BACKEND_SETTING_KEYS = (
 )
 
 # project.json 中的项目级覆盖键（与全局键名不同：resolver 按媒体读 video_backend /
-# audio_backend / image_provider_*，文本档位键与项目默认模型键与全局同名），清理项目悬空引用时用此集合
+# audio_backend / image_provider_*，文本档位键与项目默认模型键与全局同名），清理项目悬空引用时用此集合。
+# 刻意不含视频桶键（video_provider_i2v / video_provider_r2v）：视频桶的悬空引用由解析闸
+# _ensure_video_bucket_capability 报错兜底，写入侧不级联清理（docs/adr/0054）；图片桶无对应能力闸，
+# 故仍在此清理
 _PROJECT_BACKEND_KEYS = (
     "video_backend",
     "audio_backend",
     "image_provider_t2i",
     "image_provider_i2i",
+    "default_image_backend",
     "text_backend_simple",
     "text_backend_complex",
     "default_text_backend",

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -67,6 +67,21 @@ def get_archive_service() -> ProjectArchiveService:
     return ProjectArchiveService(get_project_manager())
 
 
+# 项目级模型字段：创建时逐一校验并写入 project.json，PATCH 时另加 audio_backend。
+# 值形如 provider/model 或裸 provider，空值 = 清除该层、回退下一层。
+_PROJECT_BACKEND_FIELDS = (
+    "video_backend",
+    "video_provider_i2v",
+    "video_provider_r2v",
+    "image_provider_t2i",
+    "image_provider_i2i",
+    "default_image_backend",
+    "text_backend_simple",
+    "text_backend_complex",
+    "default_text_backend",
+)
+
+
 class CreateProjectRequest(BaseModel):
     name: str | None = None
     title: str | None = None
@@ -90,8 +105,11 @@ class CreateProjectRequest(BaseModel):
     video_provider_i2v: str | None = None
     video_provider_r2v: str | None = None
     image_backend: str | None = None
+    # 图片能力桶（docs/adr/0054）项目级覆盖 + 项目默认模型：t2i = 文生图，i2i = 图生图；
+    # 桶为空 = 回退项目默认（default_image_backend）与全局层
     image_provider_t2i: str | None = None
     image_provider_i2i: str | None = None
+    default_image_backend: str | None = None
     # 文本任务档位（docs/adr/0051）项目级覆盖 + 项目默认模型；空值 = 继承全局
     text_backend_simple: str | None = None
     text_backend_complex: str | None = None
@@ -131,6 +149,7 @@ class UpdateProjectRequest(BaseModel):
     image_backend: str | None = None
     image_provider_t2i: str | None = None
     image_provider_i2i: str | None = None
+    default_image_backend: str | None = None
     video_generate_audio: bool | None = None
     # 旁白配音（TTS）项目级覆盖：音频后端 / 音色 / 语速；留空 = 跟随全局默认
     audio_backend: str | None = None
@@ -504,16 +523,7 @@ async def create_project(
                     raise HTTPException(status_code=400, detail=_t("ad_only_field", field="brief"))
 
             # 与 update 路径对称：校验所有 backend 字段
-            for field_name in (
-                "video_backend",
-                "video_provider_i2v",
-                "video_provider_r2v",
-                "image_provider_t2i",
-                "image_provider_i2i",
-                "text_backend_simple",
-                "text_backend_complex",
-                "default_text_backend",
-            ):
+            for field_name in _PROJECT_BACKEND_FIELDS:
                 value = getattr(req, field_name)
                 if value:
                     validate_backend_value(value, field_name, _t)
@@ -522,20 +532,7 @@ async def create_project(
                 manager.create_project(project_name, content_mode=req.content_mode or "narration")
             except FileExistsError:
                 raise HTTPException(status_code=400, detail=_t("project_exists", name=project_name))
-            extras = {
-                field: value
-                for field in (
-                    "video_backend",
-                    "video_provider_i2v",
-                    "video_provider_r2v",
-                    "image_provider_t2i",
-                    "image_provider_i2i",
-                    "text_backend_simple",
-                    "text_backend_complex",
-                    "default_text_backend",
-                )
-                if (value := getattr(req, field))
-            }
+            extras = {field: value for field in _PROJECT_BACKEND_FIELDS if (value := getattr(req, field))}
             if req.model_settings is not None:
                 extras["model_settings"] = req.model_settings
             # generation_mode 并入 extras 一次性写入，避免 create 后再 load-save 的额外 RMW
@@ -696,17 +693,7 @@ async def update_project(name: str, req: UpdateProjectRequest, _user: CurrentUse
                     project["title"] = req.title
                 if req.style is not None:
                     project["style"] = req.style
-                for field in (
-                    "video_backend",
-                    "video_provider_i2v",
-                    "video_provider_r2v",
-                    "image_provider_t2i",
-                    "image_provider_i2i",
-                    "audio_backend",
-                    "text_backend_simple",
-                    "text_backend_complex",
-                    "default_text_backend",
-                ):
+                for field in (*_PROJECT_BACKEND_FIELDS, "audio_backend"):
                     if field in req.model_fields_set:
                         value = getattr(req, field)
                         if value:

--- a/tests/test_alembic_collapse_image_backend_buckets.py
+++ b/tests/test_alembic_collapse_image_backend_buckets.py
@@ -1,0 +1,283 @@
+"""Alembic collapse_image_backend_buckets_to_default 迁移测试：存量键组合穷举。
+
+图片 t2i / i2i 由强制槽位降级为可选覆盖桶后，默认层 default_image_backend 升为用户可见
+配置。本文件按「默认层 × t2i × i2i」的取值形态穷举存量组合，锁定迁移后的键状态与解析结果。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.config import Config
+
+from alembic import command
+from lib.config.resolver import _IMAGE_LAYERED_KEYS, ConfigResolver
+
+pytestmark = pytest.mark.integration
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+_PREV_REVISION = "d10f1df40f96"
+_KEYS = ("default_image_backend", "default_image_backend_t2i", "default_image_backend_i2i")
+
+
+@pytest.fixture
+def alembic_cfg(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    import logging.config
+
+    real_file_config = logging.config.fileConfig
+
+    monkeypatch.setattr(
+        logging.config,
+        "fileConfig",
+        lambda *args, **kwargs: real_file_config(*args, **{**kwargs, "disable_existing_loggers": False}),
+    )
+    cfg = Config(str(PROJECT_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(PROJECT_ROOT / "alembic"))
+    return cfg, db_path
+
+
+def _sync_engine(db_path: Path) -> sa.Engine:
+    return sa.create_engine(f"sqlite:///{db_path}")
+
+
+def _seed(engine: sa.Engine, settings: dict[str, str]) -> None:
+    if not settings:
+        return
+    with engine.begin() as conn:
+        for key, value in settings.items():
+            conn.execute(
+                sa.text(
+                    "INSERT INTO system_setting (key, value, updated_at) VALUES (:k, :v, CURRENT_TIMESTAMP)"
+                ).bindparams(k=key, v=value)
+            )
+
+
+def _read_image_settings(engine: sa.Engine) -> dict[str, str]:
+    with engine.connect() as conn:
+        rows = conn.execute(
+            sa.text("SELECT key, value FROM system_setting WHERE key IN :keys").bindparams(
+                sa.bindparam("keys", value=_KEYS, expanding=True)
+            )
+        ).fetchall()
+    return {row.key: row.value for row in rows}
+
+
+# (用例名, 迁移前键状态, 迁移后键状态)
+#
+# 语义变更只发生在「桶无有效值 + 默认层有配置」的两行（empty_buckets_with_default、
+# mixed_empty_bucket 的 i2i 侧）：迁移前空桶表示「跟随自动推断」，迁移后回退默认层。
+# 其余各行迁移前后解析结果一致，迁移只做键形态归一。
+_CASES = [
+    ("all_absent", {}, {}),
+    (
+        "default_only",
+        {"default_image_backend": "grok/grok-2-image"},
+        {"default_image_backend": "grok/grok-2-image"},
+    ),
+    (
+        "equal_buckets_without_default",
+        {"default_image_backend_t2i": "openai/gpt-image-2", "default_image_backend_i2i": "openai/gpt-image-2"},
+        {"default_image_backend": "openai/gpt-image-2"},
+    ),
+    (
+        "equal_buckets_matching_default",
+        {
+            "default_image_backend": "openai/gpt-image-2",
+            "default_image_backend_t2i": "openai/gpt-image-2",
+            "default_image_backend_i2i": "openai/gpt-image-2",
+        },
+        {"default_image_backend": "openai/gpt-image-2"},
+    ),
+    (
+        "equal_buckets_diverging_from_default",
+        {
+            "default_image_backend": "grok/grok-2-image",
+            "default_image_backend_t2i": "openai/gpt-image-2",
+            "default_image_backend_i2i": "openai/gpt-image-2",
+        },
+        {
+            "default_image_backend": "grok/grok-2-image",
+            "default_image_backend_t2i": "openai/gpt-image-2",
+            "default_image_backend_i2i": "openai/gpt-image-2",
+        },
+    ),
+    (
+        "distinct_buckets_without_default",
+        {"default_image_backend_t2i": "openai/gpt-image-2", "default_image_backend_i2i": "ark/kolors-img2img"},
+        {"default_image_backend_t2i": "openai/gpt-image-2", "default_image_backend_i2i": "ark/kolors-img2img"},
+    ),
+    (
+        "distinct_buckets_with_default",
+        {
+            "default_image_backend": "grok/grok-2-image",
+            "default_image_backend_t2i": "openai/gpt-image-2",
+            "default_image_backend_i2i": "ark/kolors-img2img",
+        },
+        {
+            "default_image_backend": "grok/grok-2-image",
+            "default_image_backend_t2i": "openai/gpt-image-2",
+            "default_image_backend_i2i": "ark/kolors-img2img",
+        },
+    ),
+    (
+        "empty_buckets_with_default",
+        {
+            "default_image_backend": "grok/grok-2-image",
+            "default_image_backend_t2i": "",
+            "default_image_backend_i2i": "",
+        },
+        {"default_image_backend": "grok/grok-2-image"},
+    ),
+    (
+        "empty_buckets_without_default",
+        {"default_image_backend_t2i": "", "default_image_backend_i2i": ""},
+        {},
+    ),
+    (
+        "mixed_empty_bucket",
+        {
+            "default_image_backend": "grok/grok-2-image",
+            "default_image_backend_t2i": "openai/gpt-image-2",
+            "default_image_backend_i2i": "",
+        },
+        {"default_image_backend": "grok/grok-2-image", "default_image_backend_t2i": "openai/gpt-image-2"},
+    ),
+    (
+        "empty_default_with_equal_buckets",
+        {
+            "default_image_backend": "",
+            "default_image_backend_t2i": "openai/gpt-image-2",
+            "default_image_backend_i2i": "openai/gpt-image-2",
+        },
+        {"default_image_backend": "openai/gpt-image-2"},
+    ),
+    (
+        "bucket_without_slash_dropped",
+        {"default_image_backend": "grok/grok-2-image", "default_image_backend_t2i": "openai"},
+        {"default_image_backend": "grok/grok-2-image"},
+    ),
+]
+
+
+@pytest.mark.parametrize(("name", "before", "after"), _CASES, ids=[case[0] for case in _CASES])
+def test_upgrade_exhausts_legacy_key_combinations(alembic_cfg, name, before, after):
+    cfg, db_path = alembic_cfg
+    command.upgrade(cfg, _PREV_REVISION)
+    engine = _sync_engine(db_path)
+    _seed(engine, before)
+
+    command.upgrade(cfg, "head")
+
+    assert _read_image_settings(engine) == after
+
+
+# 迁移后各组合的生效模型（t2i, i2i）；None = 无配置可落、留给自动推断。
+_RESOLVED_AFTER: dict[str, tuple[str | None, str | None]] = {
+    "all_absent": (None, None),
+    "default_only": ("grok/grok-2-image", "grok/grok-2-image"),
+    "equal_buckets_without_default": ("openai/gpt-image-2", "openai/gpt-image-2"),
+    "equal_buckets_matching_default": ("openai/gpt-image-2", "openai/gpt-image-2"),
+    "equal_buckets_diverging_from_default": ("openai/gpt-image-2", "openai/gpt-image-2"),
+    "distinct_buckets_without_default": ("openai/gpt-image-2", "ark/kolors-img2img"),
+    "distinct_buckets_with_default": ("openai/gpt-image-2", "ark/kolors-img2img"),
+    # 语义变更行：迁移前空桶跟随自动推断，迁移后落默认层
+    "empty_buckets_with_default": ("grok/grok-2-image", "grok/grok-2-image"),
+    "empty_buckets_without_default": (None, None),
+    # 语义变更行：i2i 侧同上
+    "mixed_empty_bucket": ("openai/gpt-image-2", "grok/grok-2-image"),
+    "empty_default_with_equal_buckets": ("openai/gpt-image-2", "openai/gpt-image-2"),
+    "bucket_without_slash_dropped": ("grok/grok-2-image", "grok/grok-2-image"),
+}
+
+
+@pytest.mark.parametrize(("name", "before", "after"), _CASES, ids=[case[0] for case in _CASES])
+async def test_resolution_after_upgrade(name, before, after):
+    """迁移产物经真实解析骨架求值，锁定各组合升级后的生效模型。"""
+    resolver = ConfigResolver.__new__(ConfigResolver)
+
+    class _Settings:
+        async def get_all_settings(self) -> dict[str, str]:
+            return dict(after)
+
+    for capability, expected in zip(("t2i", "i2i"), _RESOLVED_AFTER[name], strict=True):
+        if expected is None:
+            # 无配置可落：解析必然走自动推断（需真实供应商表，此处不求值），
+            # 断言其前提——迁移后该桶与默认层都无有效值
+            assert not any("/" in after.get(key, "") for key in (f"default_image_backend_{capability}", _KEYS[0]))
+            continue
+        resolved = await resolver._resolve_layered_backend(
+            _Settings(),  # pyright: ignore[reportArgumentType]
+            None,
+            None,
+            _IMAGE_LAYERED_KEYS[capability],
+        )
+        assert resolved == tuple(expected.split("/", 1))
+
+
+def test_downgrade_restores_buckets_from_default(alembic_cfg):
+    """降级把默认层复制回两桶，还原「桶即权威」形态。"""
+    cfg, db_path = alembic_cfg
+    command.upgrade(cfg, "head")
+    engine = _sync_engine(db_path)
+    _seed(engine, {"default_image_backend": "grok/grok-2-image"})
+
+    command.downgrade(cfg, _PREV_REVISION)
+
+    assert _read_image_settings(engine) == {
+        "default_image_backend": "grok/grok-2-image",
+        "default_image_backend_t2i": "grok/grok-2-image",
+        "default_image_backend_i2i": "grok/grok-2-image",
+    }
+
+
+def test_downgrade_restores_default_over_emptied_bucket(alembic_cfg):
+    """升级后经配置面清空的桶（留下空串行）在降级时不算有效覆盖，仍还原默认层。
+
+    否则旧语义会把这个空桶当权威、跳过默认层，该能力静默落到自动推断。
+    """
+    cfg, db_path = alembic_cfg
+    command.upgrade(cfg, "head")
+    engine = _sync_engine(db_path)
+    _seed(
+        engine,
+        {
+            "default_image_backend": "grok/grok-2-image",
+            "default_image_backend_t2i": "",
+        },
+    )
+
+    command.downgrade(cfg, _PREV_REVISION)
+
+    assert _read_image_settings(engine) == {
+        "default_image_backend": "grok/grok-2-image",
+        "default_image_backend_t2i": "grok/grok-2-image",
+        "default_image_backend_i2i": "grok/grok-2-image",
+    }
+
+
+def test_downgrade_keeps_existing_buckets(alembic_cfg):
+    """已有桶配置时降级不覆盖。"""
+    cfg, db_path = alembic_cfg
+    command.upgrade(cfg, "head")
+    engine = _sync_engine(db_path)
+    _seed(
+        engine,
+        {
+            "default_image_backend": "grok/grok-2-image",
+            "default_image_backend_t2i": "openai/gpt-image-2",
+            "default_image_backend_i2i": "ark/kolors-img2img",
+        },
+    )
+
+    command.downgrade(cfg, _PREV_REVISION)
+
+    assert _read_image_settings(engine) == {
+        "default_image_backend": "grok/grok-2-image",
+        "default_image_backend_t2i": "openai/gpt-image-2",
+        "default_image_backend_i2i": "ark/kolors-img2img",
+    }

--- a/tests/test_alembic_split_default_image_backend.py
+++ b/tests/test_alembic_split_default_image_backend.py
@@ -12,6 +12,9 @@ from alembic import command
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
+# 本文件只覆盖拆分迁移本身，停在该 revision——后续 revision 会把两桶重新收敛回默认层。
+_SPLIT_REVISION = "5b87accc10dd"
+
 
 @pytest.fixture
 def alembic_cfg(tmp_path, monkeypatch):
@@ -49,7 +52,7 @@ def test_upgrade_copies_legacy_setting_to_two_new_keys(alembic_cfg):
             )
         )
 
-    command.upgrade(cfg, "head")
+    command.upgrade(cfg, _SPLIT_REVISION)
 
     with engine.connect() as conn:
         rows = conn.execute(
@@ -79,7 +82,7 @@ def test_upgrade_preserves_already_set_new_keys(alembic_cfg):
             )
         )
 
-    command.upgrade(cfg, "head")
+    command.upgrade(cfg, _SPLIT_REVISION)
 
     with engine.connect() as conn:
         rows = conn.execute(
@@ -98,7 +101,7 @@ def test_upgrade_preserves_already_set_new_keys(alembic_cfg):
 def test_upgrade_no_op_when_no_legacy(alembic_cfg):
     """前置：未写入旧 default_image_backend；迁移应无副作用。"""
     cfg, db_path = alembic_cfg
-    command.upgrade(cfg, "head")
+    command.upgrade(cfg, _SPLIT_REVISION)
 
     engine = _sync_engine(db_path)
     with engine.connect() as conn:
@@ -113,7 +116,7 @@ def test_upgrade_no_op_when_no_legacy(alembic_cfg):
 
 def test_downgrade_drops_only_new_keys(alembic_cfg):
     cfg, db_path = alembic_cfg
-    command.upgrade(cfg, "head")
+    command.upgrade(cfg, _SPLIT_REVISION)
 
     engine = _sync_engine(db_path)
     with engine.begin() as conn:

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -52,9 +52,6 @@ class _FakeConfigService:
     async def get_default_video_backend(self) -> tuple[str, str]:
         return ("gemini-aistudio", "veo-3.1-fast-generate-preview")
 
-    async def get_default_image_backend(self) -> tuple[str, str]:
-        return ("gemini-aistudio", "gemini-3.1-flash-image-preview")
-
     async def get_provider_config(self, provider: str) -> dict[str, str]:
         return {"api_key": f"key-{provider}"}
 
@@ -204,8 +201,9 @@ class TestDefaultBackends:
         finally:
             await engine.dispose()
 
-    async def test_default_image_backend_t2i_reads_dedicated_setting(self):
-        """新 setting key default_image_backend_t2i 优先于旧 default_image_backend。"""
+    @pytest.mark.unit
+    async def test_default_image_backend_t2i_bucket_overrides_default_layer(self):
+        """全局桶 default_image_backend_t2i 覆盖全局默认层 default_image_backend。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(
             settings={
@@ -216,8 +214,9 @@ class TestDefaultBackends:
         result = await resolver._resolve_default_image_backend(fake_svc, None, "t2i")
         assert result == ("ark", "stable-diffusion-3")
 
-    async def test_default_image_backend_t2i_falls_back_to_legacy(self):
-        """只设旧 default_image_backend，新 _t2i 未设时回退到旧值。"""
+    @pytest.mark.unit
+    async def test_default_image_backend_t2i_falls_back_to_default_layer(self):
+        """只设默认层 default_image_backend、t2i 桶未配时回退到默认层。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(
             settings={"default_image_backend": "grok/grok-2-image"},
@@ -225,8 +224,9 @@ class TestDefaultBackends:
         result = await resolver._resolve_default_image_backend(fake_svc, None, "t2i")
         assert result == ("grok", "grok-2-image")
 
-    async def test_default_image_backend_i2i_reads_dedicated_setting(self):
-        """对称测试 i2i：新 key default_image_backend_i2i 优先于旧 default_image_backend。"""
+    @pytest.mark.unit
+    async def test_default_image_backend_i2i_bucket_overrides_default_layer(self):
+        """对称测试 i2i：全局桶覆盖全局默认层。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(
             settings={
@@ -237,8 +237,9 @@ class TestDefaultBackends:
         result = await resolver._resolve_default_image_backend(fake_svc, None, "i2i")
         assert result == ("ark", "kolors-img2img")
 
-    async def test_default_image_backend_i2i_falls_back_to_legacy(self):
-        """只设旧 default_image_backend，_i2i 未设时回退到旧值。"""
+    @pytest.mark.unit
+    async def test_default_image_backend_i2i_falls_back_to_default_layer(self):
+        """只设默认层 default_image_backend、i2i 桶未配时回退到默认层。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(
             settings={"default_image_backend": "grok/grok-2-image"},
@@ -246,12 +247,13 @@ class TestDefaultBackends:
         result = await resolver._resolve_default_image_backend(fake_svc, None, "i2i")
         assert result == ("grok", "grok-2-image")
 
-    async def test_default_image_backend_t2i_explicit_empty_does_not_fall_back(self):
-        """split key 显式置为空字符串时，不应回退到 legacy default_image_backend。
+    @pytest.mark.unit
+    @pytest.mark.parametrize("capability", ["t2i", "i2i"])
+    async def test_default_image_backend_empty_bucket_falls_back_to_default_layer(self, capability: str):
+        """桶键为空字符串时回退默认层（docs/adr/0054）。
 
-        语义锁：用户主动把 default_image_backend_t2i="" 表示「不设默认 / 自动选择」，
-        必须走 _auto_resolve_backend；这里 ready_providers=[] 让 auto 路径抛错，
-        以此区分"走了 auto 路径"（期望）和"被 legacy 静默回退"（被锁住的 bug）。
+        语义锁：桶是可选覆盖，空值不再表示「不设默认 / 自动选择」。ready_providers=[] 让
+        自动推断路径抛错，以此区分「回退到默认层」（期望）与「跳到自动推断」。
         """
         factory, engine = await _make_session()
         try:
@@ -259,33 +261,24 @@ class TestDefaultBackends:
             fake_svc = _FakeConfigService(
                 settings={
                     "default_image_backend": "grok/grok-2-image",
-                    "default_image_backend_t2i": "",
+                    f"default_image_backend_{capability}": "",
                 },
                 ready_providers=[],
             )
             async with factory() as session:
-                with pytest.raises(ValueError, match="未找到可用的 image 供应商"):
-                    await resolver._resolve_default_image_backend(fake_svc, session, "t2i")
+                result = await resolver._resolve_default_image_backend(fake_svc, session, capability)
+            assert result == ("grok", "grok-2-image")
         finally:
             await engine.dispose()
 
-    async def test_default_image_backend_i2i_explicit_empty_does_not_fall_back(self):
-        """对称：default_image_backend_i2i="" 不应回退到 legacy。"""
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver.__new__(ConfigResolver)
-            fake_svc = _FakeConfigService(
-                settings={
-                    "default_image_backend": "grok/grok-2-image",
-                    "default_image_backend_i2i": "",
-                },
-                ready_providers=[],
-            )
-            async with factory() as session:
-                with pytest.raises(ValueError, match="未找到可用的 image 供应商"):
-                    await resolver._resolve_default_image_backend(fake_svc, session, "i2i")
-        finally:
-            await engine.dispose()
+    @pytest.mark.unit
+    @pytest.mark.parametrize("capability", ["t2i", "i2i"])
+    async def test_default_image_backend_only_default_layer_covers_all_buckets(self, capability: str):
+        """只配 default_image_backend、两个桶都不配时，全部图片路径解析到该默认模型。"""
+        resolver = ConfigResolver.__new__(ConfigResolver)
+        fake_svc = _FakeConfigService(settings={"default_image_backend": "grok/grok-2-image"})
+        result = await resolver._resolve_default_image_backend(fake_svc, None, capability)
+        assert result == ("grok", "grok-2-image")
 
 
 class TestProviderConfig:
@@ -978,7 +971,7 @@ class TestVideoPricingGenerateAudio:
 
 
 class TestResolveImageBackend:
-    """resolve_image_backend：payload > project > 全局默认，capability=t2i/i2i 各覆盖。"""
+    """resolve_image_backend：payload > 项目桶 > 项目默认 > 全局桶 > 全局默认 > 自动推断。"""
 
     async def test_payload_capability_slot_wins(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -1006,8 +999,50 @@ class TestResolveImageBackend:
         assert (t2i.provider_id, t2i.model_id) == ("ark", "proj-t2i")
         assert (i2i.provider_id, i2i.model_id) == ("ark", "proj-i2i")
 
+    @pytest.mark.unit
+    async def test_project_bucket_wins_over_project_default(self):
+        """项目桶优先于项目默认（default_image_backend）。"""
+        resolver = ConfigResolver.__new__(ConfigResolver)
+        fake_svc = _FakeConfigService(settings={})
+        project = {"image_provider_t2i": "ark/proj-t2i", "default_image_backend": "openai/proj-default"}
+        resolved = await resolver._resolve_image_provider_model(fake_svc, None, project, {}, "t2i")
+        assert (resolved.provider_id, resolved.model_id) == ("ark", "proj-t2i")
+
+    @pytest.mark.unit
+    async def test_project_default_wins_over_global_layers(self):
+        """项目桶未配时落项目默认，遮蔽全局桶与全局默认。"""
+        resolver = ConfigResolver.__new__(ConfigResolver)
+        fake_svc = _FakeConfigService(
+            settings={
+                "default_image_backend_t2i": "grok/global-t2i",
+                "default_image_backend": "grok/global-default",
+            }
+        )
+        project = {"default_image_backend": "openai/proj-default"}
+        for capability in ("t2i", "i2i"):
+            resolved = await resolver._resolve_image_provider_model(fake_svc, None, project, {}, capability)
+            assert (resolved.provider_id, resolved.model_id) == ("openai", "proj-default")
+
+    @pytest.mark.unit
+    async def test_empty_project_bucket_falls_through_to_project_default(self):
+        """项目桶为空字符串 → 回退项目默认，不跳过默认层。"""
+        resolver = ConfigResolver.__new__(ConfigResolver)
+        fake_svc = _FakeConfigService(settings={})
+        project = {"image_provider_i2i": "", "default_image_backend": "openai/proj-default"}
+        resolved = await resolver._resolve_image_provider_model(fake_svc, None, project, {}, "i2i")
+        assert (resolved.provider_id, resolved.model_id) == ("openai", "proj-default")
+
+    @pytest.mark.unit
+    async def test_only_global_default_covers_both_capabilities(self):
+        """只配全局默认层、两桶皆空 → t2i / i2i 都解析到该模型。"""
+        resolver = ConfigResolver.__new__(ConfigResolver)
+        fake_svc = _FakeConfigService(settings={"default_image_backend": "grok/grok-2-image"})
+        for capability in ("t2i", "i2i"):
+            resolved = await resolver._resolve_image_provider_model(fake_svc, None, None, None, capability)
+            assert (resolved.provider_id, resolved.model_id) == ("grok", "grok-2-image")
+
     async def test_falls_through_to_global_default(self):
-        """payload/project 都缺 → 落到全局默认（显式 default_image_backend_t2i）。"""
+        """payload/project 都缺 → 落到全局桶（显式 default_image_backend_t2i）。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={"default_image_backend_t2i": "grok/grok-2-image"})
         resolved = await resolver._resolve_image_provider_model(fake_svc, None, None, None, "t2i")
@@ -1068,8 +1103,8 @@ class TestResolveImageBackend:
 class TestLayeredBackendSkeleton:
     """「默认 + 能力桶」四级解析骨架：项目桶 > 项目默认 > 全局桶 > 全局默认 > 自动推断。
 
-    用带全部四层键位的合成声明直测骨架契约——图片键位不声明项目默认层，该层的行为
-    由此处锁定；媒体桶接入只补键位声明、不改骨架本身。
+    用带全部四层键位的合成声明直测骨架契约，与各媒体的具体键位无关；媒体桶接入只补
+    键位声明、不改骨架本身。
     """
 
     @staticmethod
@@ -1127,20 +1162,13 @@ class TestLayeredBackendSkeleton:
         result = await resolver._resolve_layered_backend(fake_svc, None, project, keys)
         assert result == ("g-def", "m")
 
-    async def test_empty_global_bucket_follows_default_when_enabled(self):
-        """开关为 True 时：全局桶键存在但为空 → 回退全局默认层。"""
+    @pytest.mark.unit
+    async def test_empty_global_bucket_follows_default(self):
+        """全局桶键存在但无有效值 → 回退全局默认层（docs/adr/0054）。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={"global_bucket": "", "global_default": "g-def/m"})
         result = await resolver._resolve_layered_backend(fake_svc, None, None, self._keys())
         assert result == ("g-def", "m")
-
-    async def test_empty_global_bucket_authoritative_when_disabled(self):
-        """开关为 False 时：全局桶键存在但为空 = 显式清空 → 跳过全局默认直达自动推断。"""
-        resolver = ConfigResolver.__new__(ConfigResolver)
-        fake_svc = _FakeConfigService(settings={"global_bucket": "", "global_default": "g-def/m"})
-        keys = self._keys(empty_global_bucket_follows_default=False)
-        result = await resolver._resolve_layered_backend(fake_svc, None, None, keys)
-        assert result[0] == "gemini-aistudio"
 
     async def test_project_bare_provider_supported(self):
         """项目层兼容裸 provider 覆盖（补该 provider 默认 model），与既有图片/视频项目字段语义一致。"""

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1006,6 +1006,53 @@ class TestProjectsRouter:
             assert data["default_text_backend"] == "gemini-aistudio/gemini-2.5"
             assert data["default_duration"] == 8
 
+    @pytest.mark.unit
+    def test_create_project_with_image_default_layer(self, tmp_path, monkeypatch):
+        """项目默认图片模型（default_image_backend）可在创建时写入，不必配桶。"""
+        fake_pm = _FakePM(tmp_path)
+        client = _client(monkeypatch, fake_pm, _FakeCalc())
+
+        with client:
+            resp = client.post(
+                "/api/v1/projects",
+                json={
+                    "title": "只配默认",
+                    "name": "img-default",
+                    "default_image_backend": "gemini-aistudio/nano-banana",
+                },
+            )
+            assert resp.status_code == 200
+            data = fake_pm.project_data["img-default"]
+            assert data["default_image_backend"] == "gemini-aistudio/nano-banana"
+            assert "image_provider_t2i" not in data
+            assert "image_provider_i2i" not in data
+
+    @pytest.mark.unit
+    def test_patch_image_default_layer_set_and_clear(self, tmp_path, monkeypatch):
+        """项目默认图片模型可设置 / 清除；格式非法与非图片模型均 400。"""
+        fake_pm = _FakePM(tmp_path)
+        client = _client(monkeypatch, fake_pm, _FakeCalc())
+        with client:
+            updated = client.patch(
+                "/api/v1/projects/ready",
+                json={"default_image_backend": "gemini-aistudio/nano-banana"},
+            )
+            assert updated.status_code == 200
+            assert fake_pm.project_data["ready"]["default_image_backend"] == "gemini-aistudio/nano-banana"
+
+            cleared = client.patch("/api/v1/projects/ready", json={"default_image_backend": ""})
+            assert cleared.status_code == 200
+            assert "default_image_backend" not in fake_pm.project_data["ready"]
+
+            rejected = client.patch("/api/v1/projects/ready", json={"default_image_backend": "no-slash"})
+            assert rejected.status_code == 400
+
+            wrong_media = client.patch(
+                "/api/v1/projects/ready",
+                json={"default_image_backend": "gemini-aistudio/veo-3.1-generate-preview"},
+            )
+            assert wrong_media.status_code == 400
+
     def test_patch_text_tier_fields_set_and_clear(self, tmp_path, monkeypatch):
         """项目级档位 / 默认模型三字段可设置；空值 = 清除、继承全局。"""
         fake_pm = _FakePM(tmp_path)


### PR DESCRIPTION
Closes #1511

## 改动

图片模型解析改为五级回退：项目细分 > 项目默认 > 全局细分 > 全局默认 > 自动推断（`docs/adr/0054`）。

- **细分项（文生图 / 图生图）降为可选覆盖**：留空不再表示「跟随自动推断」，而是回退默认图片模型。解析骨架上编码旧语义的 `empty_global_bucket_follows_default` 开关随之删除。
- **项目层新增默认图片模型**：`project.json` 的 `default_image_backend` 字段，与文本档位的 `default_text_backend` 同名同位；创建 / PATCH 两条路径可读写并校验，自定义供应商删除时纳入项目级引用清理。
- **存量全局配置迁移**（`b7f2c41d9a30`）：两处细分同值 → 收敛为默认模型并删冗余副本；无效值（空串 / 缺斜杠）→ 清除；取值不同 → 原样保留继续生效。
- 删除 `ConfigService.get_default_image_backend`——它复刻的正是本次推翻的「新键存在即权威、空值不回退」语义，全仓无调用方。

## 验证

- `pytest -m "not e2e"` 7429 passed
- `basedpyright` 0 errors；`ruff check` / `format --check` clean；`lint-imports` 契约 KEPT
- 迁移测试 `tests/test_alembic_collapse_image_backend_buckets.py` 按「默认层 × 文生图 × 图生图」穷举 12 组存量键状态，逐组锁定迁移后的键形态与经真实解析骨架求值的生效模型；升降级均覆盖
- 行为变更仅落在「细分项无有效值 + 默认层有配置」两组：升级后生效模型由自动推断改为默认模型，是本次要求的语义变更本身

## 范围

设置界面的默认层入口（含穿透演算占位）属 #1514，本 PR 仅后端解析与迁移；后端新字段已可经 API 读写。

## 本地审查修复

- commit 标题原承诺「只配一个默认即可覆盖全部路径」，但全局设置页尚无默认层输入框，该收益此 PR 未交付——标题改为如实限定范围
- `server/routers/projects.py` 三处重复的项目级模型字段名列表收敛为单一常量 `_PROJECT_BACKEND_FIELDS`
- 迁移测试中「无配置可落」的两组原先跳过断言，补上「迁移后该细分项与默认层皆无有效值」的前提断言

## Follow-up 候选（未立项）

- 项目层两处细分同值时收敛进 `default_image_backend`（需 `schema_version` 抬升的项目文件迁移）
- `alembic/versions/3c6d6152046e` 的供应商改名未覆盖两个细分键，存量库可能仍留旧供应商名
- `CreateProjectRequest.image_backend`（已退役字段）在创建路径被静默忽略，而 PATCH 路径返回 400，两侧不对称
- `custom_providers._BACKEND_SETTING_KEYS` 对细分键仍做删除时级联清理，与 `docs/adr/0054`「桶引用不级联清理」相悖（沿用 #1508 / #1510 已记）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增项目级默认图片后端配置，支持创建、更新、清除及有效性校验。
  * 优化图片后端分层解析，明确项目级与全局配置的优先级和回退行为。
* **改进**
  * 删除供应商或模型时，自动清理相关无效配置引用。
  * 平滑迁移旧图片桶配置，减少重复设置。
* **缺陷修复**
  * 修复无效或空图片配置下的回退及降级恢复问题。
* **测试**
  * 增加迁移、配置解析和项目接口的全面测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->