### PR TITLE
fix(video): 能力查询与费用估算改按项目生成模式取真正会执行的视频模型

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -1177,7 +1177,8 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             # S2V-01：单张人脸驱动整段视频角色一致性（subject_reference 单脸 R2V）。固定输出
             # 720P/6s，请求不接受 resolution/duration（MiniMaxVideoBackend 走专门的 subject_reference
             # 路径，忽略这两项）；supported_durations=[6] 仅供编排层时长守卫与档价口径。
-            # max_reference_images=1：编排层解析器读 registry ModelInfo.max_reference_images，据此只取 1 张参考图。
+            # max_reference_images=1：与 MiniMaxVideoBackend 声明同值的并行声明，不参与解析
+            # （编排层裁剪与能力桶判定读 backend 的 VideoCapabilities）。
             # 定价单档约 ¥3（资源包 1.5 积分近似，半核实）；键到 minimax 缺省档 768P/6s 求精确命中，
             # 任意分辨率漂移由 per_video_bucket 最近档回落到唯一档。
             "S2V-01": ModelInfo(

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -237,6 +237,25 @@ def video_bucket_for_generation_mode(generation_mode: str | None) -> VideoCapabi
     return VIDEO_BUCKET_BY_GENERATION_MODE.get(generation_mode, _DEFAULT_VIDEO_BUCKET)
 
 
+def project_video_backend_ids(project: dict) -> tuple[str, str] | None:
+    """project.json 自报的视频模型身份：按 generation_mode 定桶取桶键，缺则取项目默认键。
+
+    纯读 project.json、不查 DB，供 caps 解析失败（DB / migration 故障等）时的降级路径复用：
+    桶键与默认键都在同一个明文文件里，降级只该丢掉 DB 那部分，不该顺带把桶口径也降成项目
+    默认层——否则配了 ``video_provider_r2v`` 的参考视频项目会拿 ``video_backend`` 的档位与
+    参考图上限写剧本。层内取值口径与 ``_resolve_layered_backend`` 的项目层一致（含裸 provider
+    覆盖）。
+    """
+    keys = _VIDEO_LAYERED_KEYS[video_bucket_for_generation_mode(project.get("generation_mode"))]
+    for key in (keys.project_bucket_key, keys.project_default_key):
+        if key is None:
+            continue
+        parsed = _parse_project_provider(project.get(key), "video")
+        if parsed is not None:
+            return parsed
+    return None
+
+
 def video_capability_satisfied(*, capability: VideoCapability, first_frame: bool, max_reference_images: int) -> bool:
     """一组视频能力声明是否满足某个桶——桶归属判定的唯一口径。
 
@@ -442,6 +461,9 @@ def resolve_raw_supported_durations(project: dict, caps: dict | None = None) -> 
     同步路径上，靠后两级回退拿到同一份档位表——迁移是幂等一次性的，谁先跑谁定终局，入口之间
     传参不一致就会让先跑的那个把非档位秒数固化到盘上。
 
+    最后一级的项目自报身份按 generation_mode 定桶取（``project_video_backend_ids``），不直取
+    项目默认层——降级掉的只是 DB，桶键就在同一个 project.json 里。
+
     返回值不含「分辨率↔时长」「参考图↔时长」联动约束，收窄见 ``constrain_durations_for_project``。
     """
     if caps and caps.get("supported_durations"):
@@ -449,12 +471,11 @@ def resolve_raw_supported_durations(project: dict, caps: dict | None = None) -> 
     durations = project.get("_supported_durations")
     if durations and isinstance(durations, list):
         return list(durations)
-    video_backend = project.get("video_backend")
-    if video_backend and isinstance(video_backend, str) and "/" in video_backend:
-        provider_id, model_id = video_backend.split("/", 1)
-        provider_meta = PROVIDER_REGISTRY.get(provider_id)
+    ids = project_video_backend_ids(project)
+    if ids is not None:
+        provider_meta = PROVIDER_REGISTRY.get(ids[0])
         if provider_meta:
-            model_info = provider_meta.models.get(model_id)
+            model_info = provider_meta.models.get(ids[1])
             if model_info and model_info.supported_durations:
                 return list(model_info.supported_durations)
     return None

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -213,6 +213,29 @@ VIDEO_BUCKET_BY_TASK_TYPE: dict[str, VideoCapability] = {
     "reference_video": "r2v",
 }
 
+#: 生成模式 → 能力桶。与 ``VIDEO_BUCKET_BY_TASK_TYPE`` 描述同一套映射的两个入口：执行路径按
+#: 已成形任务的 task_type 定桶，读侧（能力查询 / 费用估算 / 时长约束收窄）在任务成形前只有项目
+#: 的 generation_mode，按它定同一个桶，两侧因此回答同一个「当前配置真正会执行的模型」。
+VIDEO_BUCKET_BY_GENERATION_MODE: dict[str, VideoCapability] = {
+    "storyboard": "i2v",
+    "grid": "i2v",
+    "reference_video": "r2v",
+}
+
+#: 表外 generation_mode（含缺省与脏数据）落的桶。与 ``lib.project_manager.effective_mode``
+#: 对未知模式回退 ``storyboard`` 的口径一致。
+_DEFAULT_VIDEO_BUCKET: VideoCapability = "i2v"
+
+
+def video_bucket_for_generation_mode(generation_mode: str | None) -> VideoCapability:
+    """项目 / 剧集的 generation_mode 归到哪个视频能力桶——读侧定桶的唯一入口。
+
+    project.json 是明文文件，``generation_mode`` 可能被写成非字符串，一并落默认桶。
+    """
+    if not isinstance(generation_mode, str):
+        return _DEFAULT_VIDEO_BUCKET
+    return VIDEO_BUCKET_BY_GENERATION_MODE.get(generation_mode, _DEFAULT_VIDEO_BUCKET)
+
 
 def video_capability_satisfied(*, capability: VideoCapability, first_frame: bool, max_reference_images: int) -> bool:
     """一组视频能力声明是否满足某个桶——桶归属判定的唯一口径。
@@ -739,13 +762,17 @@ class ConfigResolver:
     async def video_capabilities(self, project_name: str | None = None) -> dict:
         """解析当前项目视频 model 的综合能力 + 用户项目偏好。
 
+        model 按项目 ``generation_mode`` 定桶（图生视频 / 宫格 → i2v，参考生视频 → r2v）后走与
+        执行相同的解析入口，回答的始终是「当前配置真正会执行的那个模型」；切换 generation_mode
+        后返回值随桶变化（``docs/adr/0054``）。
+
         Returns:
             {
               "provider_id": str,
               "model": str,
               "supported_durations": list[int],    # 来自 model (单一真相源)
               "max_duration": int,                 # max(supported_durations) 派生
-              "max_reference_images": int,         # registry: model.max_reference_images；custom: 合成后的生效值
+              "max_reference_images": int,         # backend 声明；custom: 合成后的生效值
               "first_frame": bool,                 # 生效值（系统判定 ⊕ 用户覆盖），与执行层同源
               "last_frame": bool,                  # 同上
               "generate_audio": bool,              # backend 默认执行档生效后的计价参数
@@ -760,6 +787,8 @@ class ConfigResolver:
 
         Raises:
             ValueError: 当 video_backend 解析失败 / model 找不到 / supported_durations 为空。
+            VideoBucketCapabilityError: （ValueError 子类）解析出的模型缺该桶所需能力，或配置
+                引用已不可用。
         """
         async with self._open_session() as (session, svc):
             return await self._resolve_video_capabilities(svc, session, project_name)
@@ -1166,10 +1195,18 @@ class ConfigResolver:
         session: AsyncSession,
         project: dict | None,
     ) -> dict:
-        # 只传选择身份：有效身份收敛由 `_resolve_video_caps_for_model` 统一做，
-        # 在此先做一遍会让自定义 provider 多跑一轮 model 查询。
-        provider_id, model_id = await self._resolve_video_backend_from_project(svc, session, project)
-        return await self._resolve_video_caps_for_model(svc, session, provider_id, model_id, project)
+        """按项目 generation_mode 定桶解析出会执行的那个模型，再读它的能力。
+
+        与执行路径共用 ``_resolve_video_provider_model``（含能力闸），读侧不留第二种口径：切换
+        generation_mode 后能力查询随桶变化，模型缺该桶所需能力或引用已失效时报错、不静默换模型
+        （``docs/adr/0054``）。payload 传 None——能力查询回答的是当前配置，不排空历史任务。
+
+        只传选择身份：有效身份收敛由 ``_resolve_video_caps_for_model`` 统一做，在此先做一遍会让
+        自定义 provider 多跑一轮 model 查询。
+        """
+        capability = video_bucket_for_generation_mode(project.get("generation_mode") if project else None)
+        selected = await self._resolve_video_provider_model(svc, session, project, None, capability)
+        return await self._resolve_video_caps_for_model(svc, session, selected.provider_id, selected.model_id, project)
 
     async def _resolve_video_caps_for_model(
         self,
@@ -1241,14 +1278,15 @@ class ConfigResolver:
             if model_info is None:
                 raise ValueError(f"model not found in registry: {provider_id}/{model_id}")
             supported_durations = list(model_info.supported_durations or [])
-            max_reference_images = model_info.max_reference_images
-            # 布尔能力位读 backend 声明，不复制进 ModelInfo：backend 是这几位的唯一真相源。
-            # max_reference_images 维持读 ModelInfo（注册表按 model 分档，backend 侧不区分）。
+            # 能力位一律读 backend 声明，不读 ModelInfo 的并行声明：backend 是执行期真正构造
+            # 请求的一方，也是能力闸（`_ensure_video_bucket_capability`）与桶候选下拉
+            # （`lib.capability_buckets`）的口径，展示层与执行层因此严格同源。
             try:
                 spec = get_provider_spec(provider_id, "video")
                 builtin_caps = builtin_video_capabilities_for_model(spec.registry_backend, model_id)
             except ValueError as exc:
                 raise ValueError(f"cannot resolve video capabilities for {provider_id}/{model_id}: {exc}") from exc
+            max_reference_images = builtin_caps.max_reference_images
             first_frame = builtin_caps.first_frame
             last_frame = builtin_caps.last_frame
             reference_audio_mode = builtin_caps.reference_audio_mode

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -21,6 +21,7 @@ from lib.config.resolver import (
     ConfigResolver,
     VideoBucketCapabilityError,
     constrain_durations_for_project,
+    project_video_backend_ids,
     resolve_raw_supported_durations,
 )
 from lib.db import async_session_factory
@@ -655,19 +656,17 @@ class ScriptGenerator:
             return None
 
     def _resolve_backend_ids(self, caps: dict | None) -> tuple[str | None, str | None]:
-        """当前视频模型身份：caps → project.json.video_backend；都拿不到为 (None, None)。
+        """当前视频模型身份：caps → project.json 自报身份；都拿不到为 (None, None)。
 
         联动约束按型号声明查，故身份要与时长的来源同一个模型：caps 在手时以它为准
         （后端留空走全局默认、或存值已不在注册表被 resolver 回退时，实际生效的是 caps 里的），
-        否则退到 project.json 自报的 ``video_backend``（与时长的 fallback 链同一层）。
+        否则退到 project.json 按 generation_mode 定桶取的身份（``project_video_backend_ids``，
+        与时长的 fallback 链同一层）。
         """
         if caps and caps.get("provider_id") and caps.get("model"):
             return str(caps["provider_id"]), str(caps["model"])
-        video_backend = self.project_json.get("video_backend")
-        if video_backend and isinstance(video_backend, str) and "/" in video_backend:
-            provider_id, model_id = video_backend.split("/", 1)
-            return provider_id, model_id
-        return None, None
+        ids = project_video_backend_ids(self.project_json)
+        return ids if ids is not None else (None, None)
 
     def _resolve_supported_durations(
         self, caps: dict | None = None, *, gen_mode: str, uses_reference_images: bool | None = None
@@ -756,12 +755,13 @@ class ScriptGenerator:
         return "9:16" if self.content_mode in ("narration", "ad") else "16:9"
 
     def _resolve_max_refs(self, caps: dict | None = None) -> int | None:
-        """解析当前视频模型的最大参考图数；caps → project.json.video_backend → registry 两级回退。
+        """解析当前视频模型的最大参考图数；caps → project.json 自报身份 → registry 两级回退。
 
         语义约定：仅 None 视为「未声明上限」（上层不在 prompt 写硬性数量约束，且 executor 跳过裁剪）；
         caps 来源的 0 是显式上限（如不接受参考图的 endpoint），会原样下传触发裁剪为 0 张。
-        caps 解析失败（DB/migration 故障等）时退到项目配置的 video_backend 直查 backend 声明——
-        与 _resolve_supported_durations 同构，避免丢失上限导致后端按多张参考图发出而被上游拒。
+        caps 解析失败（DB/migration 故障等）时退到 project.json 按 generation_mode 定桶取的身份
+        （``project_video_backend_ids``）直查 backend 声明——与 _resolve_supported_durations
+        同构，避免丢失上限导致后端按多张参考图发出而被上游拒。
         取 backend 而非 registry ModelInfo 的并行声明：两者在若干 model 上已漂移，而 backend 是
         执行期构造请求的一方。注册表身份仍要查——backend 的 caps 函数不都校验 model 存在性与
         media_type，对任意 id 返回静态能力。0 在这条降级路径上按未声明处理（下传 0 会把降级前
@@ -771,9 +771,9 @@ class ScriptGenerator:
             cached = caps.get("max_reference_images")
             if cached is not None:
                 return int(cached)
-        video_backend = self.project_json.get("video_backend")
-        if video_backend and isinstance(video_backend, str) and "/" in video_backend:
-            provider_id, model_id = video_backend.split("/", 1)
+        ids = project_video_backend_ids(self.project_json)
+        if ids is not None:
+            provider_id, model_id = ids
             provider_meta = PROVIDER_REGISTRY.get(provider_id)
             model_info = provider_meta.models.get(model_id) if provider_meta else None
             if model_info is not None and model_info.media_type == "video":

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -17,7 +17,12 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from lib.backend_assembly.specs import get_provider_spec
 from lib.config.registry import PROVIDER_REGISTRY
-from lib.config.resolver import ConfigResolver, constrain_durations_for_project, resolve_raw_supported_durations
+from lib.config.resolver import (
+    ConfigResolver,
+    VideoBucketCapabilityError,
+    constrain_durations_for_project,
+    resolve_raw_supported_durations,
+)
 from lib.db import async_session_factory
 from lib.episode_paths import (
     REFERENCE_VIDEO_STEP1_FILENAME,
@@ -635,10 +640,16 @@ class ScriptGenerator:
 
         宽松捕获：除 ValueError 外，DB 未 migration / 连接失败等 SQLAlchemy 异常也走 fallback，
         保证在缺能力元数据的环境（如裸 CI 测试容器）中 generate() 仍能跑通。
+
+        能力桶解析闸的报错例外，原样上抛：那是配置指向的模型缺该桶所需能力或引用已失效
+        （``docs/adr/0054``），fallback 会拿项目默认模型的档位去写剧本，写出来的时长 / 参考图
+        数量执行期照样被拒。报错带 code 与修复指引，比先写一份必败的剧本更省事。
         """
         resolver = ConfigResolver(async_session_factory)
         try:
             return await resolver.video_capabilities_for_project(self.project_json)
+        except VideoBucketCapabilityError:
+            raise
         except (ValueError, SQLAlchemyError) as exc:
             logger.info("video_capabilities 解析失败，将走 project.json fallback：%s", exc)
             return None

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -15,6 +15,7 @@ from typing import Optional
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 
+from lib.backend_assembly.specs import get_provider_spec
 from lib.config.registry import PROVIDER_REGISTRY
 from lib.config.resolver import ConfigResolver, constrain_durations_for_project, resolve_raw_supported_durations
 from lib.db import async_session_factory
@@ -65,6 +66,7 @@ from lib.script_skeleton import SKELETONS, resolve_declared_kind
 from lib.text_backends.base import DEFAULT_MAX_OUTPUT_TOKENS, TextGenerationRequest, TextTaskType
 from lib.text_generator import TextGenerator
 from lib.text_utils import strip_json_code_fences
+from lib.video_backends.registry import video_capabilities_for_model as builtin_video_capabilities_for_model
 
 logger = logging.getLogger(__name__)
 
@@ -747,9 +749,12 @@ class ScriptGenerator:
 
         语义约定：仅 None 视为「未声明上限」（上层不在 prompt 写硬性数量约束，且 executor 跳过裁剪）；
         caps 来源的 0 是显式上限（如不接受参考图的 endpoint），会原样下传触发裁剪为 0 张。
-        caps 解析失败（DB/migration 故障等）时退到 registry 的 ModelInfo.max_reference_images——
+        caps 解析失败（DB/migration 故障等）时退到项目配置的 video_backend 直查 backend 声明——
         与 _resolve_supported_durations 同构，避免丢失上限导致后端按多张参考图发出而被上游拒。
-        registry 里 0 是字段默认值（图像/文本模型或视频模型未声明），用 truthy 守卫当作未声明跳过。
+        取 backend 而非 registry ModelInfo 的并行声明：两者在若干 model 上已漂移，而 backend 是
+        执行期构造请求的一方。注册表身份仍要查——backend 的 caps 函数不都校验 model 存在性与
+        media_type，对任意 id 返回静态能力。0 在这条降级路径上按未声明处理（下传 0 会把降级前
+        本可申请的参考图整批裁掉，而执行期仍有 backend 校验兜底）。
         """
         if caps:
             cached = caps.get("max_reference_images")
@@ -759,10 +764,15 @@ class ScriptGenerator:
         if video_backend and isinstance(video_backend, str) and "/" in video_backend:
             provider_id, model_id = video_backend.split("/", 1)
             provider_meta = PROVIDER_REGISTRY.get(provider_id)
-            if provider_meta:
-                model_info = provider_meta.models.get(model_id)
-                if model_info and model_info.max_reference_images:
-                    return int(model_info.max_reference_images)
+            model_info = provider_meta.models.get(model_id) if provider_meta else None
+            if model_info is not None and model_info.media_type == "video":
+                try:
+                    spec = get_provider_spec(provider_id, "video")
+                    backend_caps = builtin_video_capabilities_for_model(spec.registry_backend, model_id)
+                except ValueError:
+                    return None
+                if backend_caps.max_reference_images:
+                    return int(backend_caps.max_reference_images)
         return None
 
     def _load_project_json(self) -> dict:

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -66,8 +66,9 @@ _MAX_NUM_FRAMES = 441
 _MIN_DURATION_SECONDS = 1
 _MAX_DURATION_SECONDS = 18
 
-# 参考图（多图主体）上限——保守值，与 registry ModelInfo.max_reference_images 同值（编排层裁剪读
-# registry、backend 生成时防御读此处）。待 Agnes console / 实测核对，不硬编当既成事实。
+# 参考图（多图主体）上限——保守值，编排层裁剪与 backend 生成时防御同读此处（registry
+# ModelInfo.max_reference_images 另有一份同值的并行声明，不再被读取）。待 Agnes console / 实测
+# 核对，不硬编当既成事实。
 _MAX_REFERENCE_IMAGES = 4
 
 # 尺寸约束：长宽被 8 整除、长边收口 1920（保守值，覆盖上游 480p/720p/1080p 三档标准化）。

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -67,7 +67,7 @@ _MIN_DURATION_SECONDS = 1
 _MAX_DURATION_SECONDS = 18
 
 # 参考图（多图主体）上限——保守值，编排层裁剪与 backend 生成时防御同读此处（registry
-# ModelInfo.max_reference_images 另有一份同值的并行声明，不再被读取）。待 Agnes console / 实测
+# ModelInfo.max_reference_images 另有一份同值的并行声明，不参与解析）。取值未经 Agnes console
 # 核对，不硬编当既成事实。
 _MAX_REFERENCE_IMAGES = 4
 

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -219,7 +219,7 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         # first_frame 恒真（各档均支持 i2v 首帧）；last_frame / reference_images / 上限按 model 从
         # _KLING_VIDEO_CAPS 读（_lookup_video_caps 归一化前缀/大小写后精确命中，未登记回落保守默认）。
         # max_reference_images 以此处为准（编排层裁剪与生成时防御同读它；registry ModelInfo 另有一份
-        # 并行声明，不再被读取），取保守值、待 app.klingai.com 控制台核对。纯函数（不构造 client /
+        # 并行声明，不参与解析），取保守值、未经 app.klingai.com 控制台核对。纯函数（不构造 client /
         # 不需 api_key），供 custom endpoint resolver 按 model_id 读上限复用。
         #
         # last_frame_requires_pro 为真的 model（kling-v2-5-turbo、kling-v2-6）：该位不按 service_tier

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -218,9 +218,9 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
         # first_frame 恒真（各档均支持 i2v 首帧）；last_frame / reference_images / 上限按 model 从
         # _KLING_VIDEO_CAPS 读（_lookup_video_caps 归一化前缀/大小写后精确命中，未登记回落保守默认）。
-        # max_reference_images 同时声明于 registry ModelInfo（编排层裁剪读它）与此处（生成时防御），取保守
-        # 值、待 app.klingai.com 控制台核对。纯函数（不构造 client / 不需 api_key），供 custom endpoint
-        # resolver 按 model_id 读上限复用。
+        # max_reference_images 以此处为准（编排层裁剪与生成时防御同读它；registry ModelInfo 另有一份
+        # 并行声明，不再被读取），取保守值、待 app.klingai.com 控制台核对。纯函数（不构造 client /
+        # 不需 api_key），供 custom endpoint resolver 按 model_id 读上限复用。
         #
         # last_frame_requires_pro 为真的 model（kling-v2-5-turbo、kling-v2-6）：该位不按 service_tier
         # 分档——service_tier 是逐请求字段（generation_tasks 入队时选定），本函数只按 model 声明、

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -206,7 +206,7 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
     def _build_s2v_payload(self, request: VideoGenerationRequest) -> dict:
         """S2V-01：把 reference_images[0] 映射成单脸 subject_reference。
 
-        编排层已按 registry max_reference_images=1 裁剪，此处防御性仅取首张人脸图。
+        编排层已按本 backend 声明的 max_reference_images=1 裁剪，此处防御性仅取首张人脸图。
         fail-loud：未提供参考图 → required；声明的参考图缺失/不可读 → unreadable，
         不静默退化为无参考生成（会产出错误结果且照常计费）。
         """

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 from lib.api_errors import ApiError, BadRequestError, NotFoundError
 from lib.asset_fingerprints import compute_asset_fingerprints
 from lib.config.registry import default_model_for_provider
-from lib.config.resolver import ConfigResolver
+from lib.config.resolver import ConfigResolver, VideoBucketCapabilityError
 from lib.db import async_session_factory
 from lib.i18n import Translator
 from lib.json_io import domain_error_on_value_error
@@ -600,6 +600,10 @@ async def get_video_capabilities(
         return await resolver.video_capabilities(name)
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=name) from exc
+    except VideoBucketCapabilityError as exc:
+        # 能力桶解析闸的报错自带 errors 目录 key 与渲染参数，转成结构化 400 让用户看到修复指引，
+        # 不被下面的通用 422 文案吞掉（ValueError 子类，须先于其捕获）
+        raise BadRequestError(exc.code, **exc.params) from exc
     except ValueError as exc:
         # 异常原文只进日志：str(exc) 混英文技术细节，直接插进翻译文案会让 en/vi 界面混入未译原文
         logger.warning("项目 '%s' 视频模型能力解析失败: %s", name, exc)

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 import logging
 import math
 import re
+from dataclasses import dataclass
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from lib.config.resolver import ConfigResolver, get_provider_fallback, video_bucket_for_generation_mode
+from lib.config.resolver import (
+    ConfigResolver,
+    VideoCapability,
+    get_provider_fallback,
+    video_bucket_for_generation_mode,
+)
 from lib.cost_calculator import cost_calculator
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.db.repositories.usage_repo import PROJECT_LEVEL_SEGMENT_KEY, UsageRepository
@@ -33,6 +39,27 @@ CostBreakdown = dict[str, float]
 ActualBySegment = dict[str, dict[str, CostBreakdown]]
 # 费用页展示的记账类型；text 类调用不写 segment_id，只会落在项目级汇总里。
 ACTUAL_COST_TYPES = ("image", "video", "audio")
+
+
+#: 读侧定桶要枚举的全部视频能力桶。两个桶都预解析：同一项目里逐集的生效路径可以不同
+#: （集级 generation_mode 覆盖、或剧本自带 r2v 戳），而解析需要 resolver session，不能推迟到
+#: 已关闭 session 的估算循环里逐集去做。桶只有两个，代价有界。
+_VIDEO_BUCKETS: tuple[VideoCapability, ...] = ("i2v", "r2v")
+
+
+@dataclass(frozen=True)
+class _VideoPricing:
+    """一个能力桶下的视频计价参数——解析出的模型身份、分辨率、有效 generate_audio 与自定义单价。
+
+    五项总是结伴传给三条估算路径，且必须同源于一次解析：分辨率与 generate_audio 都按模型身份
+    求值，混用不同桶的分项会算出任何一个模型都不会产生的价。
+    """
+
+    provider: str
+    model: str | None
+    resolution: str | None
+    generate_audio: bool
+    price: Any
 
 
 def _add_cost(target: CostBreakdown, amount: float, currency: str) -> None:
@@ -94,11 +121,7 @@ def _estimate_unit_video_cost(
     *,
     unit_id: str,
     duration_seconds: int,
-    video_provider: str,
-    video_model: str | None,
-    video_resolution: str | None,
-    generate_audio: bool,
-    video_price: Any,
+    video: _VideoPricing,
 ) -> CostBreakdown:
     """一个参考视频 unit 取档后秒数的视频估值。计价失败返回空 breakdown（该 unit 不计费）。
 
@@ -108,17 +131,17 @@ def _estimate_unit_video_cost(
     est_video: CostBreakdown = {}
     try:
         amount, currency = cost_calculator.calculate_cost(
-            video_provider,
+            video.provider,
             PricingParams(
                 call_type="video",
-                model=video_model,
-                resolution=video_resolution,
+                model=video.model,
+                resolution=video.resolution,
                 duration_seconds=duration_seconds,
-                generate_audio=generate_audio,
+                generate_audio=video.generate_audio,
             ),
-            custom_price_input=video_price.price_input,
-            custom_price_output=video_price.price_output,
-            custom_currency=video_price.currency,
+            custom_price_input=video.price.price_input,
+            custom_price_output=video.price.price_output,
+            custom_currency=video.price.currency,
             estimate_only=True,
         )
         _add_cost(est_video, amount, currency)
@@ -152,20 +175,28 @@ class CostEstimationService:
             except Exception:
                 image_provider, image_model = "unknown", "unknown"
 
-            # 视频按项目 generation_mode 定桶解析（``docs/adr/0054``），与执行扣费同一个模型：
-            # 参考生视频项目算 r2v 桶的价、图生视频 / 宫格算 i2v 桶的价。
-            try:
-                resolved_video = await r.resolve_video_backend(
-                    project_data,
-                    None,
-                    capability=video_bucket_for_generation_mode(project_data.get("generation_mode")),
+            # 视频按能力桶解析（``docs/adr/0054``），与执行扣费同一个模型：参考生视频路径算 r2v
+            # 桶的价、图生视频 / 宫格算 i2v 桶的价。逐集选桶，故两个桶都在这里解析出来（见
+            # ``_VIDEO_BUCKETS``），分辨率与 generate_audio 随各自的模型身份求值。
+            video_identity: dict[VideoCapability, tuple[str, str, str | None, bool]] = {}
+            for capability in _VIDEO_BUCKETS:
+                try:
+                    resolved_video = await r.resolve_video_backend(project_data, None, capability=capability)
+                    bucket_provider, bucket_model = resolved_video.provider_id, resolved_video.model_id
+                except Exception:
+                    bucket_provider, bucket_model = "unknown", "unknown"
+                # 有效 generate_audio 是 backend 实现内知识，此处只消费解析结果、不自行推断。
+                bucket_audio = await r.video_pricing_generate_audio(bucket_provider, bucket_model, project_data)
+                try:
+                    bucket_resolution = await r.resolve_resolution(project_data, bucket_provider, bucket_model or "")
+                except Exception:
+                    bucket_resolution = None
+                video_identity[capability] = (
+                    bucket_provider,
+                    bucket_model,
+                    bucket_resolution or get_provider_fallback(bucket_provider),
+                    bucket_audio,
                 )
-                video_provider, video_model = resolved_video.provider_id, resolved_video.model_id
-            except Exception:
-                video_provider, video_model = "unknown", "unknown"
-
-            # 有效 generate_audio 是 backend 实现内知识，此处只消费解析结果、不自行推断。
-            generate_audio = await r.video_pricing_generate_audio(video_provider, video_model, project_data)
 
             # 旁白配音（TTS）模型：project 覆盖 > 全局默认 > auto-resolve；
             # 未配置任何 audio 供应商时回落 unknown，该维度预估为空
@@ -175,19 +206,38 @@ class CostEstimationService:
             except Exception:
                 audio_provider, audio_model = "unknown", "unknown"
 
-            try:
-                _resolved_resolution = await r.resolve_resolution(project_data, video_provider, video_model or "")
-            except Exception:
-                _resolved_resolution = None
-        video_resolution = _resolved_resolution or get_provider_fallback(video_provider)
-
         # Get actual costs + 自定义供应商价格（缺则预估恒为零，需与实际记账同源预查 DB 单价）
         async with self._session_factory() as session:
             actual_by_segment = await UsageRepository(session).get_actual_costs_by_segment(project_name)
             custom_repo = CustomProviderRepository(session)
             image_price = await custom_repo.resolve_price(image_provider, image_model)
-            video_price = await custom_repo.resolve_price(video_provider, video_model)
             audio_price = await custom_repo.resolve_price(audio_provider, audio_model)
+            # 两个桶常解析到同一个模型，按身份去重后再查单价，不重复打 DB。
+            video_prices: dict[tuple[str, str], Any] = {}
+            for bucket_provider, bucket_model, _, _ in video_identity.values():
+                if (bucket_provider, bucket_model) not in video_prices:
+                    video_prices[(bucket_provider, bucket_model)] = await custom_repo.resolve_price(
+                        bucket_provider, bucket_model
+                    )
+
+        video_pricing: dict[VideoCapability, _VideoPricing] = {
+            capability: _VideoPricing(
+                provider=bucket_provider,
+                model=bucket_model,
+                resolution=bucket_resolution,
+                generate_audio=bucket_audio,
+                price=video_prices[(bucket_provider, bucket_model)],
+            )
+            for capability, (
+                bucket_provider,
+                bucket_model,
+                bucket_resolution,
+                bucket_audio,
+            ) in video_identity.items()
+        }
+        # 项目层展示的视频模型按项目自身 generation_mode 定桶：``models`` 回答的是「当前项目配置」，
+        # 不随某一集的覆盖而变；逐集算价另按该集的生效桶取（见循环内 ``episode_video``）。
+        project_video = video_pricing[video_bucket_for_generation_mode(project_data.get("generation_mode"))]
 
         generation_mode = project_data.get("generation_mode", "single")
         # 规范化 aspect_ratio：可能是 str 或 dict，复用生成任务的解析逻辑
@@ -281,6 +331,11 @@ class CostEstimationService:
             else:
                 estimate_by_unit = is_reference_script(script)
 
+            # 算价的桶跟着上面判出的生效路径走，不另按项目级 generation_mode 定：走 unit 路径的集
+            # 实际入队的是参考视频任务（r2v 桶），项目层仍是 storyboard 时按项目级定桶会拿 i2v 桶
+            # 模型的价目去算 r2v 的量。判定与算价共用同一个谓词，同一函数里就不留第二种口径。
+            episode_video = video_pricing["r2v" if estimate_by_unit else "i2v"]
+
             if estimate_by_unit:
                 if duration_ctx is None:
                     duration_ctx = await resolve_project_duration_context(project_data)
@@ -289,11 +344,7 @@ class CostEstimationService:
                         script=script,
                         episode=ep_meta.get("episode"),
                         duration_ctx=duration_ctx,
-                        video_provider=video_provider,
-                        video_model=video_model,
-                        video_resolution=video_resolution,
-                        generate_audio=generate_audio,
-                        video_price=video_price,
+                        video=episode_video,
                         actual_by_segment=actual_by_segment,
                         claimed_actual=claimed_actual,
                     )
@@ -301,11 +352,7 @@ class CostEstimationService:
                     segments_result, ep_est, ep_act = self._estimate_unit_reference_video_episode(
                         units=video_units,
                         duration_ctx=duration_ctx,
-                        video_provider=video_provider,
-                        video_model=video_model,
-                        video_resolution=video_resolution,
-                        generate_audio=generate_audio,
-                        video_price=video_price,
+                        video=episode_video,
                         actual_by_segment=actual_by_segment,
                         claimed_actual=claimed_actual,
                     )
@@ -373,17 +420,17 @@ class CostEstimationService:
 
                 try:
                     vid_amount, vid_currency = cost_calculator.calculate_cost(
-                        video_provider,
+                        episode_video.provider,
                         PricingParams(
                             call_type="video",
-                            model=video_model,
-                            resolution=video_resolution,
+                            model=episode_video.model,
+                            resolution=episode_video.resolution,
                             duration_seconds=duration,
-                            generate_audio=generate_audio,
+                            generate_audio=episode_video.generate_audio,
                         ),
-                        custom_price_input=video_price.price_input,
-                        custom_price_output=video_price.price_output,
-                        custom_currency=video_price.currency,
+                        custom_price_input=episode_video.price.price_input,
+                        custom_price_output=episode_video.price.price_output,
+                        custom_currency=episode_video.price.currency,
                     )
                     _add_cost(est_video, vid_amount, vid_currency)
                 except Exception:
@@ -502,7 +549,7 @@ class CostEstimationService:
             "project_name": project_name,
             "models": {
                 "image": {"provider": image_provider, "model": image_model},
-                "video": {"provider": video_provider, "model": video_model},
+                "video": {"provider": project_video.provider, "model": project_video.model},
                 "audio": {"provider": audio_provider, "model": audio_model},
             },
             "episodes": episodes_result,
@@ -515,11 +562,7 @@ class CostEstimationService:
         script: dict[str, Any],
         episode: int | None,
         duration_ctx: ProjectDurationContext,
-        video_provider: str,
-        video_model: str | None,
-        video_resolution: str | None,
-        generate_audio: bool,
-        video_price: Any,
+        video: _VideoPricing,
         actual_by_segment: ActualBySegment,
         claimed_actual: set[tuple[str, str]],
     ) -> tuple[list[dict[str, Any]], dict[str, CostBreakdown], dict[str, CostBreakdown]]:
@@ -583,11 +626,7 @@ class CostEstimationService:
             est_video = _estimate_unit_video_cost(
                 unit_id=unit_id,
                 duration_seconds=slot.seconds,
-                video_provider=video_provider,
-                video_model=video_model,
-                video_resolution=video_resolution,
-                generate_audio=generate_audio,
-                video_price=video_price,
+                video=video,
             )
 
             act_video: CostBreakdown = _claim_actual(
@@ -634,11 +673,7 @@ class CostEstimationService:
         *,
         units: list[Any],
         duration_ctx: ProjectDurationContext,
-        video_provider: str,
-        video_model: str | None,
-        video_resolution: str | None,
-        generate_audio: bool,
-        video_price: Any,
+        video: _VideoPricing,
         actual_by_segment: ActualBySegment,
         claimed_actual: set[tuple[str, str]],
     ) -> tuple[list[dict[str, Any]], dict[str, CostBreakdown], dict[str, CostBreakdown]]:
@@ -707,11 +742,7 @@ class CostEstimationService:
                     est_video = _estimate_unit_video_cost(
                         unit_id=unit_id,
                         duration_seconds=slot.seconds,
-                        video_provider=video_provider,
-                        video_model=video_model,
-                        video_resolution=video_resolution,
-                        generate_audio=generate_audio,
-                        video_price=video_price,
+                        video=video,
                     )
 
             unit_actual = _claim_actual(actual_by_segment, claimed_actual, unit_id)

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from lib.config.resolver import ConfigResolver, get_provider_fallback
+from lib.config.resolver import ConfigResolver, get_provider_fallback, video_bucket_for_generation_mode
 from lib.cost_calculator import cost_calculator
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.db.repositories.usage_repo import PROJECT_LEVEL_SEGMENT_KEY, UsageRepository
@@ -152,8 +152,14 @@ class CostEstimationService:
             except Exception:
                 image_provider, image_model = "unknown", "unknown"
 
+            # 视频按项目 generation_mode 定桶解析（``docs/adr/0054``），与执行扣费同一个模型：
+            # 参考生视频项目算 r2v 桶的价、图生视频 / 宫格算 i2v 桶的价。
             try:
-                resolved_video = await r.resolve_video_backend(project_data, None)
+                resolved_video = await r.resolve_video_backend(
+                    project_data,
+                    None,
+                    capability=video_bucket_for_generation_mode(project_data.get("generation_mode")),
+                )
                 video_provider, video_model = resolved_video.provider_id, resolved_video.model_id
             except Exception:
                 video_provider, video_model = "unknown", "unknown"

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -284,7 +284,11 @@ class CostEstimationService:
         content_mode = project_data.get("content_mode", "narration")
         # 惰性解析：只有项目里真出现按 unit 计费的参考视频集时才触发这次额外 IO
         # （见 :func:`server.services.reference_video_tasks.resolve_project_duration_context`）。
+        # 走 unit 路径的集按定义落 r2v 桶（入队的是参考视频任务），取档要与算价读同一个模型，
+        # 故按 reference_video 视图解析：项目层是 storyboard 时直接用 project_data 会拿 i2v 桶
+        # 模型的档位取整，再按 r2v 桶模型的单价算钱，估算与实际扣费对不上。
         duration_ctx: ProjectDurationContext | None = None
+        r2v_project_view = {**project_data, "generation_mode": "reference_video"}
 
         def _accumulate_episode(
             ep_meta: dict[str, Any],
@@ -338,7 +342,7 @@ class CostEstimationService:
 
             if estimate_by_unit:
                 if duration_ctx is None:
-                    duration_ctx = await resolve_project_duration_context(project_data)
+                    duration_ctx = await resolve_project_duration_context(r2v_project_view)
                 if content_mode == "ad":
                     segments_result, ep_est, ep_act = self._estimate_ad_reference_video_episode(
                         script=script,

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1914,6 +1914,27 @@ async def test_get_video_capabilities_skips_tiers_off_episode_reference_path(
     assert "reference_unit_durations" not in json.loads(out["content"][0]["text"])
 
 
+@pytest.mark.unit
+async def test_get_video_capabilities_shares_rest_resolution_entry(fake_ctx: ToolContext, monkeypatch) -> None:
+    """agent 工具与 REST 能力查询走同一个解析入口 ``ConfigResolver.video_capabilities``。
+
+    两侧各自解析会让 agent 写剧本时看到的时长 / 参考图上限与界面显示的不是同一个模型。
+    """
+    from lib.config.resolver import ConfigResolver
+
+    seen: list[str] = []
+
+    async def fake_video_capabilities(_self, project_name=None):
+        seen.append(project_name)
+        return {"provider_id": "kling", "model": "kling-v3-omni", "supported_durations": [5]}
+
+    monkeypatch.setattr(ConfigResolver, "video_capabilities", fake_video_capabilities)
+    out = await _call(get_video_capabilities_tool(fake_ctx), {})
+    assert out.get("is_error") is not True, out
+    assert json.loads(out["content"][0]["text"])["model"] == "kling-v3-omni"
+    assert seen == [fake_ctx.project_name]
+
+
 async def test_get_video_capabilities_error(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import text_generation as mod
 

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -445,6 +445,7 @@ class TestVideoCapabilitiesBucketing:
         finally:
             await engine.dispose()
 
+    @pytest.mark.unit
     def test_generation_mode_maps_to_bucket(self):
         assert video_bucket_for_generation_mode("storyboard") == "i2v"
         assert video_bucket_for_generation_mode("grid") == "i2v"
@@ -454,6 +455,7 @@ class TestVideoCapabilitiesBucketing:
         assert video_bucket_for_generation_mode("bogus") == "i2v"
         assert video_bucket_for_generation_mode(cast(str, ["reference_video"])) == "i2v"
 
+    @pytest.mark.integration
     async def test_i2v_bucket_shadows_project_default(self):
         """图生视频项目读 i2v 桶，遮蔽项目默认层。"""
         caps = await self._caps(
@@ -465,6 +467,7 @@ class TestVideoCapabilitiesBucketing:
         )
         assert (caps["provider_id"], caps["model"]) == ("kling", "kling-v3")
 
+    @pytest.mark.integration
     async def test_r2v_bucket_shadows_project_default(self):
         """参考生视频项目读 r2v 桶，遮蔽项目默认层。"""
         caps = await self._caps(
@@ -476,6 +479,7 @@ class TestVideoCapabilitiesBucketing:
         )
         assert (caps["provider_id"], caps["model"]) == ("minimax", "S2V-01")
 
+    @pytest.mark.integration
     async def test_same_config_follows_generation_mode(self):
         """同一份配置下切 generation_mode，能力查询随桶换到另一个模型。"""
         project = {
@@ -490,6 +494,7 @@ class TestVideoCapabilitiesBucketing:
         assert i2v_caps["max_reference_images"] == 0
         assert r2v_caps["max_reference_images"] == 1
 
+    @pytest.mark.integration
     async def test_reference_video_project_errors_when_model_lacks_reference_support(self):
         """参考生视频项目解析到无参考图能力的模型时报结构化错误，不静默换模型。"""
         with pytest.raises(VideoBucketCapabilityError) as excinfo:
@@ -497,12 +502,14 @@ class TestVideoCapabilitiesBucketing:
         assert excinfo.value.code == "video_capability_missing_r2v"
         assert excinfo.value.params == {"provider": "kling", "model": "kling-v3"}
 
+    @pytest.mark.integration
     async def test_storyboard_project_errors_when_model_lacks_first_frame(self):
         """图生视频项目解析到无首帧能力的模型时同样报错（桶换成 i2v）。"""
         with pytest.raises(VideoBucketCapabilityError) as excinfo:
             await self._caps({"video_backend": "minimax/S2V-01", "generation_mode": "storyboard"})
         assert excinfo.value.code == "video_capability_missing_i2v"
 
+    @pytest.mark.integration
     async def test_duration_constraints_evaluate_on_bucket_model(self):
         """时长收窄按桶生效模型求值：参考生视频项目落 r2v 桶模型声明的「参考图↔时长」约束。"""
         project = {
@@ -522,6 +529,7 @@ class TestVideoCapabilitiesBucketing:
         )
         assert constrained == [8]
 
+    @pytest.mark.integration
     async def test_max_reference_images_follows_backend_declaration(self):
         """viduq3-pro 不在 /reference2video 白名单：能力查询报 0，不报 registry 的并行声明。"""
         caps = await self._caps({"video_backend": "vidu/viduq3-pro", "generation_mode": "storyboard"})

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -1,9 +1,15 @@
+from typing import cast
 from unittest.mock import patch
 
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.config.resolver import ConfigResolver
+from lib.config.resolver import (
+    ConfigResolver,
+    VideoBucketCapabilityError,
+    constrain_durations_for_project,
+    video_bucket_for_generation_mode,
+)
 from lib.config.service import ProviderStatus
 from lib.db.base import Base
 
@@ -428,6 +434,100 @@ class TestVideoBackendThreeLevelPriority:
         assert result == ("ark", "doubao-seedance-2-0-260128")
 
 
+class TestVideoCapabilitiesBucketing:
+    """读侧按 generation_mode 定桶：能力查询回答的是当前配置真正会执行的那个模型。"""
+
+    async def _caps(self, project: dict) -> dict:
+        factory, engine = await _make_session()
+        try:
+            with patch("lib.config.resolver.get_project_manager"):
+                return await ConfigResolver(factory).video_capabilities_for_project(project)
+        finally:
+            await engine.dispose()
+
+    def test_generation_mode_maps_to_bucket(self):
+        assert video_bucket_for_generation_mode("storyboard") == "i2v"
+        assert video_bucket_for_generation_mode("grid") == "i2v"
+        assert video_bucket_for_generation_mode("reference_video") == "r2v"
+        # 缺省、未知值与非字符串脏数据一律落默认桶
+        assert video_bucket_for_generation_mode(None) == "i2v"
+        assert video_bucket_for_generation_mode("bogus") == "i2v"
+        assert video_bucket_for_generation_mode(cast(str, ["reference_video"])) == "i2v"
+
+    async def test_i2v_bucket_shadows_project_default(self):
+        """图生视频项目读 i2v 桶，遮蔽项目默认层。"""
+        caps = await self._caps(
+            {
+                "video_backend": "grok/grok-imagine-video",
+                "video_provider_i2v": "kling/kling-v3",
+                "generation_mode": "storyboard",
+            }
+        )
+        assert (caps["provider_id"], caps["model"]) == ("kling", "kling-v3")
+
+    async def test_r2v_bucket_shadows_project_default(self):
+        """参考生视频项目读 r2v 桶，遮蔽项目默认层。"""
+        caps = await self._caps(
+            {
+                "video_backend": "grok/grok-imagine-video",
+                "video_provider_r2v": "minimax/S2V-01",
+                "generation_mode": "reference_video",
+            }
+        )
+        assert (caps["provider_id"], caps["model"]) == ("minimax", "S2V-01")
+
+    async def test_same_config_follows_generation_mode(self):
+        """同一份配置下切 generation_mode，能力查询随桶换到另一个模型。"""
+        project = {
+            "video_provider_i2v": "kling/kling-v3",
+            "video_provider_r2v": "minimax/S2V-01",
+        }
+        i2v_caps = await self._caps({**project, "generation_mode": "storyboard"})
+        r2v_caps = await self._caps({**project, "generation_mode": "reference_video"})
+        assert i2v_caps["model"] == "kling-v3"
+        assert r2v_caps["model"] == "S2V-01"
+        # 能力字典本身随之变：i2v 桶的型号不接受参考图
+        assert i2v_caps["max_reference_images"] == 0
+        assert r2v_caps["max_reference_images"] == 1
+
+    async def test_reference_video_project_errors_when_model_lacks_reference_support(self):
+        """参考生视频项目解析到无参考图能力的模型时报结构化错误，不静默换模型。"""
+        with pytest.raises(VideoBucketCapabilityError) as excinfo:
+            await self._caps({"video_backend": "kling/kling-v3", "generation_mode": "reference_video"})
+        assert excinfo.value.code == "video_capability_missing_r2v"
+        assert excinfo.value.params == {"provider": "kling", "model": "kling-v3"}
+
+    async def test_storyboard_project_errors_when_model_lacks_first_frame(self):
+        """图生视频项目解析到无首帧能力的模型时同样报错（桶换成 i2v）。"""
+        with pytest.raises(VideoBucketCapabilityError) as excinfo:
+            await self._caps({"video_backend": "minimax/S2V-01", "generation_mode": "storyboard"})
+        assert excinfo.value.code == "video_capability_missing_i2v"
+
+    async def test_duration_constraints_evaluate_on_bucket_model(self):
+        """时长收窄按桶生效模型求值：参考生视频项目落 r2v 桶模型声明的「参考图↔时长」约束。"""
+        project = {
+            "video_provider_i2v": "kling/kling-v3",
+            "video_provider_r2v": "gemini-aistudio/veo-3.1-generate-preview",
+            "generation_mode": "reference_video",
+        }
+        caps = await self._caps(project)
+        assert caps["model"] == "veo-3.1-generate-preview"
+        assert caps["supported_durations"] == [4, 6, 8]
+        constrained = constrain_durations_for_project(
+            project,
+            list(caps["supported_durations"]),
+            provider_id=caps["provider_id"],
+            model_id=caps["model"],
+            generation_mode="reference_video",
+        )
+        assert constrained == [8]
+
+    async def test_max_reference_images_follows_backend_declaration(self):
+        """viduq3-pro 不在 /reference2video 白名单：能力查询报 0，不报 registry 的并行声明。"""
+        caps = await self._caps({"video_backend": "vidu/viduq3-pro", "generation_mode": "storyboard"})
+        assert caps["max_reference_images"] == 0
+
+
 class TestVideoCapabilities:
     """验证 video_capabilities：第一步模型选择 + 第二步 model 能力查询。"""
 
@@ -469,7 +569,7 @@ class TestVideoCapabilities:
         assert caps["source"] == "registry"
         assert caps["supported_durations"] == [4, 6, 8]
         assert caps["max_duration"] == 8
-        # max_reference_images 来源：registry 中该 veo 视频模型的 ModelInfo.max_reference_images
+        # max_reference_images 来源：backend 的 VideoCapabilities 声明（与执行层同源）
         assert caps["max_reference_images"] == 3
 
     async def test_reads_project_default_duration_and_modes(self):
@@ -508,6 +608,7 @@ class TestVideoCapabilities:
         assert caps["default_duration"] is None
 
     async def test_unknown_model_raises(self):
+        """悬空模型引用在能力桶解析闸即报错，携带可本地化的 code。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
         factory, engine = await _make_session()
@@ -517,10 +618,12 @@ class TestVideoCapabilities:
                     mock_pm.return_value.load_project.return_value = {
                         "video_backend": "grok/nonexistent-model",
                     }
-                    with pytest.raises(ValueError, match="model not found"):
+                    with pytest.raises(VideoBucketCapabilityError) as excinfo:
                         await resolver._resolve_video_capabilities(fake_svc, session, "demo")
         finally:
             await engine.dispose()
+        assert excinfo.value.code == "video_capability_reference_unavailable"
+        assert excinfo.value.capability == "i2v"
 
     async def test_unknown_provider_raises(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -532,7 +635,7 @@ class TestVideoCapabilities:
                     mock_pm.return_value.load_project.return_value = {
                         "video_backend": "bogus-provider/some-model",
                     }
-                    with pytest.raises(ValueError, match="provider not in PROVIDER_REGISTRY"):
+                    with pytest.raises(VideoBucketCapabilityError):
                         await resolver._resolve_video_capabilities(fake_svc, session, "demo")
         finally:
             await engine.dispose()
@@ -572,22 +675,25 @@ class TestVideoCapabilities:
             await engine.dispose()
         assert caps["max_reference_images"] == 1
 
-    async def test_max_reference_images_reads_model_info_for_minimax_s2v(self):
-        """minimax S2V-01 的 max_reference_images 来自 registry ModelInfo（=1）；
+    async def test_max_reference_images_reads_backend_caps_for_minimax_s2v(self):
+        """minimax S2V-01 的 max_reference_images 来自 backend 声明（=1）；
 
-        编排层据此只取 1 张参考图，不会向只吃单脸的 S2V-01 拼多张。
+        编排层据此只取 1 张参考图，不会向只吃单脸的 S2V-01 拼多张。S2V-01 不支持首帧，
+        项目须是参考生视频模式才落进它所属的 r2v 桶。
         """
         factory, engine = await _make_session()
         try:
             resolver = ConfigResolver(factory)
             with patch("lib.config.resolver.get_project_manager"):
-                caps = await resolver.video_capabilities_for_project({"video_backend": "minimax/S2V-01"})
+                caps = await resolver.video_capabilities_for_project(
+                    {"video_backend": "minimax/S2V-01", "generation_mode": "reference_video"}
+                )
         finally:
             await engine.dispose()
         assert caps["max_reference_images"] == 1
 
-    async def test_max_reference_images_reads_model_info_for_ark_seedance(self):
-        """ark seedance 的 max_reference_images 来自 registry ModelInfo（=9）。"""
+    async def test_max_reference_images_reads_backend_caps_for_ark_seedance(self):
+        """ark seedance 的 max_reference_images 来自 backend 声明（=9）。"""
         factory, engine = await _make_session()
         try:
             resolver = ConfigResolver(factory)
@@ -599,10 +705,10 @@ class TestVideoCapabilities:
             await engine.dispose()
         assert caps["max_reference_images"] == 9
 
-    async def test_max_reference_images_reads_model_info_for_kling_v3_omni(self):
-        """kling-v3-omni（多图主体 R2V）的 max_reference_images 来自 registry ModelInfo（=4，保守值）；
+    async def test_max_reference_images_reads_backend_caps_for_kling_v3_omni(self):
+        """kling-v3-omni（多图主体 R2V）的 max_reference_images 来自 backend 声明（=4，保守值）；
 
-        编排层据此裁剪参考图数量——内置 provider 经此值而非 backend caps 拿到上限。
+        编排层据此裁剪参考图数量，与执行期 gate_video_request 依据的是同一个数。
         """
         factory, engine = await _make_session()
         try:
@@ -613,8 +719,8 @@ class TestVideoCapabilities:
             await engine.dispose()
         assert caps["max_reference_images"] == 4
 
-    async def test_max_reference_images_reads_model_info_for_kling_video_o1(self):
-        """kling-video-o1（多图主体 R2V）的 max_reference_images 来自 registry ModelInfo（=4，保守值）。"""
+    async def test_max_reference_images_reads_backend_caps_for_kling_video_o1(self):
+        """kling-video-o1（多图主体 R2V）的 max_reference_images 来自 backend 声明（=4，保守值）。"""
         factory, engine = await _make_session()
         try:
             resolver = ConfigResolver(factory)
@@ -715,9 +821,11 @@ class TestVideoCapabilities:
         assert caps["max_reference_images"] == 1
 
     @pytest.mark.integration
-    async def test_custom_disabled_model_falls_back_to_default_like_execution_layer(self):
-        """project 仍指向已禁用的 model 时，能力解析须与 loader.load_custom_backend 同一条回退
-        规则改读默认启用 model——否则会宣称执行层实际不会兑现的 first_frame/last_frame。"""
+    async def test_custom_disabled_model_errors_like_execution_layer(self):
+        """project 仍指向已禁用的 model 时，能力解析与执行路径同样在能力桶解析闸报悬空引用。
+
+        不静默换成该供应商的默认启用 model（``docs/adr/0054``）：宣称一个用户没选过的模型的能力，
+        与执行期直接报错的行为对不上。"""
         from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -759,13 +867,11 @@ class TestVideoCapabilities:
                     mock_pm.return_value.load_project.return_value = {
                         "video_backend": project_backend,
                     }
-                    caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
+                    with pytest.raises(VideoBucketCapabilityError) as excinfo:
+                        await resolver._resolve_video_capabilities(fake_svc, session, "demo")
         finally:
             await engine.dispose()
-        assert caps["model"] == "default-model"
-        assert caps["supported_durations"] == [5, 10]
-        # newapi-video 不接受尾帧覆盖；已禁用 model 的 last_frame=True 覆盖不应残留
-        assert caps["last_frame"] is False
+        assert excinfo.value.code == "video_capability_reference_unavailable"
 
 
 @pytest.mark.integration
@@ -904,7 +1010,13 @@ class TestVoiceConsistency:
                     display_name="Seedance-like",
                     endpoint="ark-seedance",
                     supported_durations="[4, 8]",
-                    capability_overrides={"reference_audio_mode": "direct", "max_reference_audio_count": 2},
+                    # max_reference_images 覆盖是让该 model 落进 r2v 桶的前提：参考生视频项目按
+                    # r2v 定桶解析，ark-seedance 对未上表型号保守判 0，不覆盖会被解析闸挡在能力查询前
+                    capability_overrides={
+                        "reference_audio_mode": "direct",
+                        "max_reference_audio_count": 2,
+                        "max_reference_images": 4,
+                    },
                 )
                 session.add(model)
                 await session.flush()

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -1583,6 +1583,7 @@ class TestCostEstimationService:
         assert video_estimate.get("USD") != pytest.approx(0.6)
         assert video_estimate.get("USD") != pytest.approx(54.0)
 
+    @pytest.mark.integration
     @pytest.mark.parametrize(
         ("generation_mode", "expected_model"),
         [("storyboard", "kling-v3"), ("reference_video", "kling-v3-omni")],

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.config.resolver import ConfigResolver
+from lib.cost_calculator import cost_calculator
 from lib.db.base import Base
 from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
 from lib.providers import PROVIDER_GEMINI
@@ -1603,6 +1604,90 @@ class TestCostEstimationService:
         result = await service.compute(project_data, {}, project_name="test-video-bucket")
 
         assert result["models"]["video"] == {"provider": "kling", "model": expected_model}
+
+    @pytest.mark.integration
+    async def test_episode_priced_by_its_own_effective_bucket(self, db_factory, monkeypatch):
+        """逐集算价按该集实际走的那条路径定桶，不按项目级 generation_mode 一刀切。
+
+        同一项目里两集的生效路径可以不同：项目层是 storyboard，而剧本仍带 reference_video 戳的
+        集实际入队的是参考视频任务（``is_reference_script``，见
+        ``test_narration_reference_video_estimate_follows_script_stamp_over_effective_mode``）。
+        按项目级定桶会拿 i2v 桶模型的价目去算 r2v 的量，与执行扣费对不上。
+        """
+        priced_models: list[str | None] = []
+        original = cost_calculator.calculate_cost
+
+        def _spy(provider, params, **kwargs):
+            if params.call_type == "video":
+                priced_models.append(params.model)
+            return original(provider, params, **kwargs)
+
+        monkeypatch.setattr(cost_calculator, "calculate_cost", _spy)
+
+        service = CostEstimationService(ConfigResolver(db_factory), db_factory)
+        project_data = {
+            "title": "Narration",
+            "content_mode": "narration",
+            "generation_mode": "storyboard",
+            "target_duration": 30,
+            "video_provider_i2v": "kling/kling-v3",
+            "video_provider_r2v": "kling/kling-v3-omni",
+            "episodes": [
+                {"episode": 1, "title": "", "script_file": "ep1.json"},
+                {"episode": 2, "title": "", "script_file": "ep2.json"},
+            ],
+        }
+        scripts = {
+            "ep1.json": _make_script(1, ["E1S001"], [6]),
+            "ep2.json": _make_reference_video_script(2, "narration", [("E2U1", 6)]),
+        }
+
+        result = await service.compute(project_data, scripts, project_name="per-episode-bucket")
+
+        # 分镜集走 i2v 桶模型，参考视频集走 r2v 桶模型——两集在同一次估算里取不同的价目。
+        assert priced_models == ["kling-v3", "kling-v3-omni"]
+        # 项目层展示仍按项目自身 generation_mode 定桶，不随某一集的路径改变。
+        assert result["models"]["video"] == {"provider": "kling", "model": "kling-v3"}
+
+    @pytest.mark.integration
+    async def test_ad_episode_level_mode_override_prices_by_r2v_bucket(self, db_factory, monkeypatch):
+        """ad 集级 ``generation_mode`` 覆盖项目级时按 r2v 桶模型算价。
+
+        ad 骨架的镜头不打 generation_mode 戳，生效路径以 ``effective_mode``（集级优先于项目级）
+        为真相源；集级覆盖成 reference_video 的集实际入队参考视频任务，算价须跟着换桶。
+        """
+        priced_models: list[str | None] = []
+        original = cost_calculator.calculate_cost
+
+        def _spy(provider, params, **kwargs):
+            if params.call_type == "video":
+                priced_models.append(params.model)
+            return original(provider, params, **kwargs)
+
+        monkeypatch.setattr(cost_calculator, "calculate_cost", _spy)
+
+        service = CostEstimationService(ConfigResolver(db_factory), db_factory)
+        project_data = {
+            "title": "Ad",
+            "content_mode": "ad",
+            "generation_mode": "storyboard",
+            "target_duration": 30,
+            "video_provider_i2v": "kling/kling-v3",
+            "video_provider_r2v": "kling/kling-v3-omni",
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json", "generation_mode": "reference_video"}],
+        }
+        scripts = {
+            "ep1.json": {
+                "episode": 1,
+                "title": "Episode 1",
+                "content_mode": "ad",
+                "shots": [{"shot_id": "E1S001", "duration_seconds": 6, "visual": "v", "voiceover": ""}],
+            }
+        }
+
+        await service.compute(project_data, scripts, project_name="ad-episode-override-bucket")
+
+        assert priced_models == ["kling-v3-omni"]
 
     async def test_custom_provider_estimates_use_db_prices(self, db_factory):
         """自定义供应商预估：image/video/audio 单价来自 DB（与实际记账同源），估值按配置价格非零。"""

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -1528,8 +1528,9 @@ class TestCostEstimationService:
         assert result["episodes"][0]["segments"][0]["estimate"]["video"]["CNY"] == pytest.approx(3.0)
 
     @pytest.mark.integration
-    async def test_disabled_custom_video_model_estimate_uses_runtime_fallback_price(self, db_factory):
-        """估算模型身份与 backend 构造一致：禁用项目模型后按默认启用模型的价格估算。"""
+    async def test_disabled_custom_video_model_estimate_reports_unknown(self, db_factory):
+        """估算模型身份与执行同口径：项目模型被禁用后按能力桶解析闸算悬空引用，不改按该供应商
+        默认启用模型出价——那个模型用户没选过，执行期也不会用它（``docs/adr/0054``）。"""
         from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 
         async with db_factory() as session:
@@ -1574,8 +1575,34 @@ class TestCostEstimationService:
             project_data, {"ep1.json": _make_script(1, ["E1S001"], [6])}, project_name="test-custom-fallback"
         )
 
-        assert result["models"]["video"] == {"provider": "custom-1", "model": "runtime"}
-        assert result["episodes"][0]["segments"][0]["estimate"]["video"]["USD"] == pytest.approx(0.6)
+        assert result["models"]["video"] == {"provider": "unknown", "model": "unknown"}
+        # 身份解析不出时退到通用目录价，既不按被禁用模型（9.0/s → 54.0）也不按该供应商默认
+        # 启用模型（0.1/s → 0.6）的 DB 单价出数
+        video_estimate = result["episodes"][0]["segments"][0]["estimate"]["video"]
+        assert video_estimate.get("USD") != pytest.approx(0.6)
+        assert video_estimate.get("USD") != pytest.approx(54.0)
+
+    @pytest.mark.parametrize(
+        ("generation_mode", "expected_model"),
+        [("storyboard", "kling-v3"), ("reference_video", "kling-v3-omni")],
+    )
+    async def test_estimate_resolves_video_model_by_generation_mode_bucket(
+        self, db_factory, generation_mode, expected_model
+    ):
+        """估算按 generation_mode 定桶取模型，与执行扣费同源：切模式即换到另一个桶的价目。"""
+        service = CostEstimationService(ConfigResolver(db_factory), db_factory)
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": generation_mode,
+            "video_provider_i2v": "kling/kling-v3",
+            "video_provider_r2v": "kling/kling-v3-omni",
+            "episodes": [],
+        }
+
+        result = await service.compute(project_data, {}, project_name="test-video-bucket")
+
+        assert result["models"]["video"] == {"provider": "kling", "model": expected_model}
 
     async def test_custom_provider_estimates_use_db_prices(self, db_factory):
         """自定义供应商预估：image/video/audio 单价来自 DB（与实际记账同源），估值按配置价格非零。"""

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -8,6 +8,7 @@ from lib.cost_calculator import cost_calculator
 from lib.db.base import Base
 from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
 from lib.providers import PROVIDER_GEMINI
+from server.services import reference_video_tasks
 from server.services.cost_estimation import CostEstimationService
 
 
@@ -1605,6 +1606,48 @@ class TestCostEstimationService:
         result = await service.compute(project_data, {}, project_name="test-video-bucket")
 
         assert result["models"]["video"] == {"provider": "kling", "model": expected_model}
+
+    @pytest.mark.integration
+    async def test_unit_duration_slots_come_from_the_r2v_bucket_model(self, db_factory, monkeypatch):
+        """unit 取档与算价读同一个模型：档位来自 r2v 桶，不来自项目级 generation_mode 定的桶。
+
+        项目层是 storyboard、某集剧本仍带 reference_video 戳时，该集按 unit 计费（入队参考视频
+        任务）。若取档沿用项目级视图，5 秒的 unit 会按 i2v 桶 kling 的 [5, 10] 停在 5 秒，再按
+        r2v 桶 Veo 的单价算钱；而执行期按 Veo 的档位（未配分辨率走 1080p 兜底，只接受 8 秒）
+        申请 8 秒——估算量与扣费量对不上。
+        """
+        priced: list[tuple[str | None, int | None]] = []
+        original = cost_calculator.calculate_cost
+
+        def _spy(provider, params, **kwargs):
+            if params.call_type == "video":
+                priced.append((params.model, params.duration_seconds))
+            return original(provider, params, **kwargs)
+
+        monkeypatch.setattr(cost_calculator, "calculate_cost", _spy)
+
+        # 取档解析走全局 session factory（真实部署的库），测试库换成 db_factory 后照常做真实
+        # 桶解析——被观察的是它拿到哪个模型的档位，不是它怎么连库。
+        async def _caps_from_test_db(project, *, degraded_to):
+            return await ConfigResolver(db_factory).video_capabilities_for_project(project)
+
+        monkeypatch.setattr(reference_video_tasks, "project_video_caps", _caps_from_test_db)
+
+        service = CostEstimationService(ConfigResolver(db_factory), db_factory)
+        project_data = {
+            "title": "Narration",
+            "content_mode": "narration",
+            "generation_mode": "storyboard",
+            "target_duration": 30,
+            "video_provider_i2v": "kling/kling-v3",
+            "video_provider_r2v": "gemini-aistudio/veo-3.1-generate-preview",
+            "episodes": [{"episode": 1, "title": "", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_reference_video_script(1, "narration", [("E1U1", 5)])}
+
+        await service.compute(project_data, scripts, project_name="r2v-duration-slots")
+
+        assert priced == [("veo-3.1-generate-preview", 8)]
 
     @pytest.mark.integration
     async def test_episode_priced_by_its_own_effective_bucket(self, db_factory, monkeypatch):

--- a/tests/test_custom_provider_resolution.py
+++ b/tests/test_custom_provider_resolution.py
@@ -110,12 +110,11 @@ async def test_endpoint_field_stores_gemini_image(db_session: AsyncSession):
 
 @pytest.mark.asyncio
 async def test_video_capabilities_endpoint_mismatch_raises(db_session: AsyncSession):
-    """配 endpoint=openai-chat 但被当作 video_backend 使用，且该 provider 没有任何默认启用的
-    video model 可回退 → ValueError。与 loader.load_custom_backend 同一条回退规则：media_type
-    不符视为该 model 失效，先尝试回退默认 video model，回退也找不到才报错——不是原样报
-    「media_type 不符」（那会让展示层与仍能静默回退成功的执行层不一致，见 resolver.py 中
-    is_enabled/media_type 回退分支的注释）。"""
-    from lib.config.resolver import ConfigResolver
+    """配 endpoint=openai-chat 但被当作 video_backend 使用 → 能力桶解析闸判悬空引用并报错。
+
+    与执行路径同一条口径：media_type 不符的引用已不可兑现，报错让用户重选，不静默换成该供应商
+    的其它 model（``docs/adr/0054``）。"""
+    from lib.config.resolver import ConfigResolver, VideoBucketCapabilityError
 
     provider = CustomProvider(
         display_name="MismatchProv",
@@ -151,28 +150,30 @@ async def test_video_capabilities_endpoint_mismatch_raises(db_session: AsyncSess
     svc = ConfigService(db_session)
     resolver = ConfigResolver(factory, _bound_session=db_session)
 
-    with pytest.raises(ValueError, match="custom model not found"):
+    with pytest.raises(VideoBucketCapabilityError) as excinfo:
         await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
+    assert excinfo.value.code == "video_capability_reference_unavailable"
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "endpoint, model_id, expected_max_refs",
+    "endpoint, model_id, expected_max_refs, generation_mode",
     [
         # 显式 int：直接用 endpoint cap（行为零变化）
-        ("openai-video", "vid-model", 1),
-        ("newapi-video", "vid-model", 0),
+        ("openai-video", "vid-model", 1, "storyboard"),
+        ("newapi-video", "vid-model", 0, "storyboard"),
         # 未声明（None）：按 model_id 调 backend 纯 caps 函数读上限，不构造 backend
-        ("ark-seedance", "doubao-seedance-2-0", 9),
-        ("ark-seedance", "doubao-seedance-1-0", 0),  # 非 seedance-2 → 0，证明纯函数仍按 model 分支
-        ("vidu-video", "viduq3-turbo", 7),
-        # minimax-video：S2V-01 单脸参考 → 1；海螺系列走首帧无参考 → 0
-        ("minimax-video", "S2V-01", 1),
-        ("minimax-video", "MiniMax-Hailuo-2.3", 0),
+        ("ark-seedance", "doubao-seedance-2-0", 9, "storyboard"),
+        ("ark-seedance", "doubao-seedance-1-0", 0, "storyboard"),  # 非 seedance-2 → 0，证明纯函数仍按 model 分支
+        ("vidu-video", "viduq3-turbo", 7, "storyboard"),
+        # minimax-video：S2V-01 单脸参考 → 1；海螺系列走首帧无参考 → 0。S2V-01 无首帧能力，
+        # 只能落 r2v 桶，项目须是参考生视频模式才解析得到它
+        ("minimax-video", "S2V-01", 1, "reference_video"),
+        ("minimax-video", "MiniMax-Hailuo-2.3", 0, "storyboard"),
     ],
 )
 async def test_custom_video_max_reference_images_from_endpoint(
-    db_session: AsyncSession, endpoint: str, model_id: str, expected_max_refs: int
+    db_session: AsyncSession, endpoint: str, model_id: str, expected_max_refs: int, generation_mode: str
 ):
     """custom 视频 model 的 max_reference_images 经 ENDPOINT_REGISTRY 派生：endpoint cap
     为显式 int 时直接用；为 None 时按 model_id 调 backend 纯 caps 函数读上限，均不静默落默认值。
@@ -208,7 +209,7 @@ async def test_custom_video_max_reference_images_from_endpoint(
     await db_session.flush()
 
     provider_id_str = make_provider_id(provider.id)
-    project = {"video_backend": f"{provider_id_str}/{model_id}"}
+    project = {"video_backend": f"{provider_id_str}/{model_id}", "generation_mode": generation_mode}
 
     factory = async_sessionmaker(bind=db_session.get_bind(), class_=AsyncSession, expire_on_commit=False)  # type: ignore[call-overload]
     svc = ConfigService(db_session)
@@ -265,13 +266,13 @@ async def test_custom_video_caps_resolved_without_api_key(db_session: AsyncSessi
 
 @pytest.mark.asyncio
 async def test_custom_video_max_refs_missing_caps_fn_raises(db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch):
-    """endpoint cap=None 且 video_caps_for_model 也缺失（misconfig）→ resolver raise ValueError。
+    """endpoint cap=None 且 video_caps_for_model 也缺失（misconfig）→ 能力桶解析闸报悬空引用。
 
     EndpointSpec 是 frozen dataclass，用 dataclasses.replace 造 misconfig spec 再 setitem 临时替换
     （module-load 不变式仅 import 期生效，不拦运行时 monkeypatch）。"""
     import dataclasses
 
-    from lib.config.resolver import ConfigResolver
+    from lib.config.resolver import ConfigResolver, VideoBucketCapabilityError
     from lib.config.service import ConfigService
     from lib.custom_provider import make_provider_id
     from lib.custom_provider.endpoints import ENDPOINT_REGISTRY
@@ -309,8 +310,11 @@ async def test_custom_video_max_refs_missing_caps_fn_raises(db_session: AsyncSes
     svc = ConfigService(db_session)
     resolver = ConfigResolver(factory, _bound_session=db_session)
 
-    with pytest.raises(ValueError, match="declares neither video_max_reference_images"):
+    with pytest.raises(VideoBucketCapabilityError) as excinfo:
         await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
+    assert excinfo.value.code == "video_capability_reference_unavailable"
+    # 具体成因留在异常链上供日志定位，不进面向用户的报错文案
+    assert "declares neither video_max_reference_images" in str(excinfo.value.__cause__)
 
 
 @pytest.mark.asyncio
@@ -318,7 +322,7 @@ async def test_custom_video_max_refs_negative_caps_raises(db_session: AsyncSessi
     """endpoint cap=None，caps 函数返回负数 → raise ValueError（不静默下传坏值）。"""
     import dataclasses
 
-    from lib.config.resolver import ConfigResolver
+    from lib.config.resolver import ConfigResolver, VideoBucketCapabilityError
     from lib.config.service import ConfigService
     from lib.custom_provider import make_provider_id
     from lib.custom_provider.endpoints import ENDPOINT_REGISTRY
@@ -358,5 +362,7 @@ async def test_custom_video_max_refs_negative_caps_raises(db_session: AsyncSessi
     svc = ConfigService(db_session)
     resolver = ConfigResolver(factory, _bound_session=db_session)
 
-    with pytest.raises(ValueError, match="invalid backend max_reference_images"):
+    with pytest.raises(VideoBucketCapabilityError) as excinfo:
         await resolver._resolve_video_capabilities_from_project(svc, db_session, project)
+    assert excinfo.value.code == "video_capability_reference_unavailable"
+    assert "invalid backend max_reference_images" in str(excinfo.value.__cause__)

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1614,6 +1614,28 @@ class TestGetVideoCapabilities:
             assert "model not found" not in detail
             assert detail == zh_errors.MESSAGES["video_capabilities_unresolved"].format(name="ready")
 
+    def test_capability_bucket_error_returns_localized_400(self, tmp_path, monkeypatch):
+        """能力桶解析闸的报错转成结构化 400，带上修复指引，不被通用 422 文案吞掉。"""
+        from lib.config.resolver import VideoBucketCapabilityError
+
+        self._patch_resolver(
+            monkeypatch,
+            side_effect=VideoBucketCapabilityError(
+                code="video_capability_missing_r2v",
+                capability="r2v",
+                provider_id="kling",
+                model_id="kling-v3",
+                message="video model kling/kling-v3 lacks the capability required by the r2v bucket",
+            ),
+        )
+        client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
+        with client:
+            resp = client.get("/api/v1/projects/ready/video-capabilities")
+            assert resp.status_code == 400
+            assert resp.json()["detail"] == zh_errors.MESSAGES["video_capability_missing_r2v"].format(
+                provider="kling", model="kling-v3"
+            )
+
 
 class TestModelSettingsApi:
     def test_create_project_with_model_settings(self, tmp_path, monkeypatch):

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1614,6 +1614,7 @@ class TestGetVideoCapabilities:
             assert "model not found" not in detail
             assert detail == zh_errors.MESSAGES["video_capabilities_unresolved"].format(name="ready")
 
+    @pytest.mark.integration
     def test_capability_bucket_error_returns_localized_400(self, tmp_path, monkeypatch):
         """能力桶解析闸的报错转成结构化 400，带上修复指引，不被通用 422 文案吞掉。"""
         from lib.config.resolver import VideoBucketCapabilityError

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from lib.config.resolver import ConfigResolver
 from lib.script_generator import ScriptGenerator, _units_use_references
 from lib.script_structure_validator import ScriptStructureValidationError
 
@@ -914,6 +915,46 @@ def test_resolve_supported_durations_raises_when_unset(tmp_path):
 
     with pytest.raises(ValueError, match="supported_durations"):
         sg._resolve_supported_durations(None, gen_mode="storyboard")
+
+
+class TestFetchVideoCapabilitiesErrorHandling:
+    """能力桶解析闸的报错不被 fallback 吞掉——写剧本与执行读同一个模型的档位。"""
+
+    def _sg(self, tmp_path) -> ScriptGenerator:
+        sg = ScriptGenerator.__new__(ScriptGenerator)
+        sg.project_path = tmp_path
+        sg.project_json = {"video_backend": "kling/kling-v3", "generation_mode": "reference_video"}
+        return sg
+
+    @pytest.mark.unit
+    async def test_bucket_capability_error_propagates(self, tmp_path, monkeypatch):
+        """桶模型缺能力 / 引用失效时上抛：退到 project.json 会拿项目默认模型的时长与参考图
+        上限写剧本，写出来的镜头执行期照样被同一道闸拒掉。"""
+        from lib.config.resolver import VideoBucketCapabilityError
+
+        async def _raise(_self, _project):
+            raise VideoBucketCapabilityError(
+                code="video_capability_missing_r2v",
+                capability="r2v",
+                provider_id="kling",
+                model_id="kling-v3",
+                message="video model kling/kling-v3 lacks the capability required by the r2v bucket",
+            )
+
+        monkeypatch.setattr(ConfigResolver, "video_capabilities_for_project", _raise)
+        with pytest.raises(VideoBucketCapabilityError) as excinfo:
+            await self._sg(tmp_path)._fetch_video_capabilities()
+        assert excinfo.value.code == "video_capability_missing_r2v"
+
+    @pytest.mark.unit
+    async def test_other_resolution_failures_still_fall_back(self, tmp_path, monkeypatch):
+        """DB 未 migration / 缺能力元数据等环境故障仍走 fallback，裸环境下 generate() 照常跑通。"""
+
+        async def _raise(_self, _project):
+            raise ValueError("no video provider configured")
+
+        monkeypatch.setattr(ConfigResolver, "video_capabilities_for_project", _raise)
+        assert await self._sg(tmp_path)._fetch_video_capabilities() is None
 
 
 def _sg_with_project(tmp_path, project: dict) -> ScriptGenerator:

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -957,6 +957,32 @@ class TestFetchVideoCapabilitiesErrorHandling:
         assert await self._sg(tmp_path)._fetch_video_capabilities() is None
 
 
+class TestDegradedResolutionKeepsBucket:
+    """caps 解析失败后的降级路径仍按 generation_mode 定桶读 project.json，只丢 DB 那一层。"""
+
+    _PROJECT = {
+        "video_backend": "kling/kling-v3",
+        "video_provider_r2v": "gemini-aistudio/veo-3.1-generate-preview",
+        "generation_mode": "reference_video",
+    }
+
+    @pytest.mark.unit
+    def test_backend_ids_fall_back_to_bucket_key(self, tmp_path):
+        sg = _sg_with_project(tmp_path, dict(self._PROJECT))
+        assert sg._resolve_backend_ids(None) == ("gemini-aistudio", "veo-3.1-generate-preview")
+
+    @pytest.mark.unit
+    def test_max_refs_falls_back_to_bucket_model(self, tmp_path):
+        """参考视频项目降级后仍按 r2v 桶模型报上限；取项目默认层会拿到不接受参考图的 kling-v3。"""
+        sg = _sg_with_project(tmp_path, dict(self._PROJECT))
+        assert sg._resolve_max_refs(None) == 3
+
+    @pytest.mark.unit
+    def test_supported_durations_fall_back_to_bucket_model(self, tmp_path):
+        sg = _sg_with_project(tmp_path, dict(self._PROJECT))
+        assert sg._resolve_raw_supported_durations(None) == [4, 6, 8]
+
+
 def _sg_with_project(tmp_path, project: dict) -> ScriptGenerator:
     """只为 _resolve_* 系列造一个不走 __init__ 的 ScriptGenerator（不需要 TextGenerator）。"""
     project_dir = tmp_path / "p"


### PR DESCRIPTION
Closes #1512

## 改了什么

能力查询、费用估算、时长 / 分辨率约束收窄三处读侧，一律先按项目 `generation_mode` 定能力桶（图生视频 / 宫格 → i2v，参考生视频 → r2v），再走与执行相同的解析函数，回答「按当前配置真正会执行的那个模型」。

- `lib/config/resolver.py` 新增 `VIDEO_BUCKET_BY_GENERATION_MODE` 与 `video_bucket_for_generation_mode()`，与既有 `VIDEO_BUCKET_BY_TASK_TYPE` 并置——同一套映射的两个入口：执行按 task_type，读侧按 generation_mode
- 读侧收敛到唯一一条链：`_resolve_video_capabilities_from_project` 改调带能力闸的 `_resolve_video_provider_model`。REST、agent 工具 `get_video_capabilities`、`ScriptGenerator`、`video_caps.py`、`reference_video_tasks` 全部经 `video_capabilities*` 汇入这一条
- 费用估算按桶生效模型算价，且逐集按该集**实际生效的生成路径**定桶——项目层是 storyboard 而剧本带 r2v 戳、或 ad 集级 `generation_mode` 覆盖项目级时，该集按 r2v 桶模型的价目算，与实际入队的任务同源。五项计价参数收进 `_VideoPricing`，避免混用不同桶的分项
- `max_reference_images` 改读 backend 声明：registry `ModelInfo` 与 backend 在 `vidu/viduq3-pro` 上漂移（registry=7、backend=0，该 model 不在 `/reference2video` 白名单），展示层与执行层、能力闸、桶候选下拉因此四处同源
- REST 侧 `VideoBucketCapabilityError` 先于通用 `ValueError` 捕获，转 400 结构化错误，保住修复指引

## 行为变更

按 ADR 0054「不静默换模型」，桶路径不做自定义 provider 的有效身份收敛。以下场景由「静默换成该供应商的默认启用模型」变为报结构化错误：项目指向的自定义模型被禁用 / 删除 / endpoint 改成非 video；内置模型被注册表升级删除。费用估算在这些场景下落 `unknown/unknown`（退到通用目录价），与执行期该项目被生成入口预检拦下相符。

## 验证

- pytest `-m "not e2e"`：7410 passed（新增 2 个逐集定桶用例，均已反证在项目级一刀切口径下变红）
- ruff check + format 干净；basedpyright 0 errors；lint-imports 分层契约 KEPT
- 未改前端，未跑前端检查

## 已知边界

能力查询（`video_capabilities*` / REST / agent 工具）的定桶仍取项目级 `generation_mode`，剧集级覆盖时会答错桶（执行侧按 task_type 定桶，逐任务正确）。穿到剧集级需给 `video_capabilities*` 加 episode 上下文、REST 加查询参数、agent 工具补入参，作为 follow-up。费用估算不在此列——它的 episode 上下文本就在同一函数内，已按逐集生效路径定桶。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 视频能力会根据项目生成模式自动选择对应能力范围，支持 storyboard、grid 和 reference_video。
  * 视频模型的参考图数量上限改为读取实际后端能力声明，提升配置准确性。
  * 成本估算现可按生成模式匹配正确的视频模型与计价能力。

* **错误修复**
  * 能力不匹配、模型无效或配置错误时，视频能力接口返回结构化的本地化 400 错误信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->