### PR TITLE
fix(reference-video): 参考音频未设置与不可用的提示语义区分

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -255,6 +255,9 @@ MESSAGES = {
     "ref_warn_speaker_without_audio": (
         "Character '{name}' has no reference audio: the model decides the dialogue voice"
     ),
+    "ref_warn_speaker_audio_file_missing": (
+        "Character '{name}' has reference audio set, but the file is missing: the model decides the dialogue voice"
+    ),
     "ref_warn_reference_audio_overflow": (
         "At most {limit} reference audio clips: the model decides the dialogue voice for character '{name}'"
     ),

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -255,8 +255,9 @@ MESSAGES = {
     "ref_warn_speaker_without_audio": (
         "Character '{name}' has no reference audio: the model decides the dialogue voice"
     ),
-    "ref_warn_speaker_audio_file_missing": (
-        "Character '{name}' has reference audio set, but the file is missing: the model decides the dialogue voice"
+    "ref_warn_speaker_audio_unavailable": (
+        "Character '{name}' has reference audio set, but it is currently unavailable: "
+        "the model decides the dialogue voice"
     ),
     "ref_warn_reference_audio_overflow": (
         "At most {limit} reference audio clips: the model decides the dialogue voice for character '{name}'"

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -256,8 +256,8 @@ MESSAGES = {
     "ref_warn_speaker_without_audio": (
         "Nhân vật '{name}' chưa đặt âm thanh tham chiếu: giọng của lời thoại sẽ do mô hình tự quyết định"
     ),
-    "ref_warn_speaker_audio_file_missing": (
-        "Nhân vật '{name}' đã đặt âm thanh tham chiếu nhưng tệp âm thanh bị thiếu: "
+    "ref_warn_speaker_audio_unavailable": (
+        "Nhân vật '{name}' đã đặt âm thanh tham chiếu nhưng hiện không dùng được: "
         "giọng của lời thoại sẽ do mô hình tự quyết định"
     ),
     "ref_warn_reference_audio_overflow": (

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -256,6 +256,10 @@ MESSAGES = {
     "ref_warn_speaker_without_audio": (
         "Nhân vật '{name}' chưa đặt âm thanh tham chiếu: giọng của lời thoại sẽ do mô hình tự quyết định"
     ),
+    "ref_warn_speaker_audio_file_missing": (
+        "Nhân vật '{name}' đã đặt âm thanh tham chiếu nhưng tệp âm thanh bị thiếu: "
+        "giọng của lời thoại sẽ do mô hình tự quyết định"
+    ),
     "ref_warn_reference_audio_overflow": (
         "Tối đa {limit} đoạn âm thanh tham chiếu: giọng lời thoại của nhân vật '{name}' sẽ do mô hình tự quyết định"
     ),

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -230,7 +230,7 @@ MESSAGES = {
     ),
     "ref_warn_unregistered_speaker": "@[{name}] 未在角色中登记：无法确认说话人，该行按原文发送",
     "ref_warn_speaker_without_audio": "角色「{name}」未设置参考音频：台词声音将由模型自行决定",
-    "ref_warn_speaker_audio_file_missing": "角色「{name}」已设置参考音频，但音频文件缺失：台词声音将由模型自行决定",
+    "ref_warn_speaker_audio_unavailable": "角色「{name}」已设置参考音频，但该音频当前不可用：台词声音将由模型自行决定",
     "ref_warn_reference_audio_overflow": "参考音频最多 {limit} 段：角色「{name}」的台词声音将由模型自行决定",
     "ref_warn_speaker_audio_needs_image": "角色「{name}」没有参考图（纯画外）：当前视频模型要求参考音频逐段挂在参考图上，该角色的台词声音将由模型自行决定",
     "ref_warn_silent_model": "当前视频模型「{model}」不生成音频，台词仅用于提示词参考",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -230,6 +230,7 @@ MESSAGES = {
     ),
     "ref_warn_unregistered_speaker": "@[{name}] 未在角色中登记：无法确认说话人，该行按原文发送",
     "ref_warn_speaker_without_audio": "角色「{name}」未设置参考音频：台词声音将由模型自行决定",
+    "ref_warn_speaker_audio_file_missing": "角色「{name}」已设置参考音频，但音频文件缺失：台词声音将由模型自行决定",
     "ref_warn_reference_audio_overflow": "参考音频最多 {limit} 段：角色「{name}」的台词声音将由模型自行决定",
     "ref_warn_speaker_audio_needs_image": "角色「{name}」没有参考图（纯画外）：当前视频模型要求参考音频逐段挂在参考图上，该角色的台词声音将由模型自行决定",
     "ref_warn_silent_model": "当前视频模型「{model}」不生成音频，台词仅用于提示词参考",

--- a/lib/reference_video/script_preview.py
+++ b/lib/reference_video/script_preview.py
@@ -164,7 +164,8 @@ def derive_voice_bindings(
         image_names = speakers_with_reference_image or ()
         # 音频编号 = dialogue speaker 首现顺序，受 max_reference_audio 上限截断。
         for speaker in registered:
-            audio_field_set = bool((characters.get(speaker) or {}).get("reference_audio"))
+            char_data = characters.get(speaker)
+            audio_field_set = bool(char_data.get("reference_audio")) if isinstance(char_data, dict) else False
             has_audio = speaker in audio_ready if audio_ready is not None else audio_field_set
             if not has_audio:
                 if audio_ready is not None and audio_field_set:

--- a/lib/reference_video/script_preview.py
+++ b/lib/reference_video/script_preview.py
@@ -37,7 +37,7 @@ WARN_UNCLOSED_BRACE = "ref_warn_unclosed_brace"
 WARN_DIALOGUE_INLINE = "ref_warn_dialogue_inline"
 WARN_UNREGISTERED_SPEAKER = "ref_warn_unregistered_speaker"
 WARN_SPEAKER_WITHOUT_AUDIO = "ref_warn_speaker_without_audio"
-WARN_SPEAKER_AUDIO_FILE_MISSING = "ref_warn_speaker_audio_file_missing"
+WARN_SPEAKER_AUDIO_UNAVAILABLE = "ref_warn_speaker_audio_unavailable"
 WARN_REFERENCE_AUDIO_OVERFLOW = "ref_warn_reference_audio_overflow"
 WARN_SILENT_MODEL = "ref_warn_silent_model"
 WARN_SPEAKER_AUDIO_NEEDS_IMAGE = "ref_warn_speaker_audio_needs_image"
@@ -130,9 +130,12 @@ def derive_voice_bindings(
     让编号与实际随请求发出的音频段数严格等长——字段指向已删文件时编号若不同步，``@音频N``
     会指向不存在的段。两条路径共用本函数，避免预览承诺的绑定与生成实际发出的绑定分叉。
     ``audio_ready`` 非 None 时降级原因区分两种：角色 ``reference_audio`` 字段未设置发
-    ``WARN_SPEAKER_WITHOUT_AUDIO``；字段有值但不在 ``audio_ready`` 内（文件已被删除或迁移）
-    发 ``WARN_SPEAKER_AUDIO_FILE_MISSING``——前者该去角色设置里补音频，后者该去检查文件是否
-    还在，排查方向不同，不能合并成一条 warning。
+    ``WARN_SPEAKER_WITHOUT_AUDIO``；字段有值但不在 ``audio_ready`` 内发
+    ``WARN_SPEAKER_AUDIO_UNAVAILABLE``——前者该去角色设置里补音频，后者字段已填好，该去查
+    它指向的音频本身，排查方向不同，不能合并成一条 warning。后者的成因不止一种（文件被删、
+    字段值指到 ``characters/refs_audio`` 之外都会被
+    :func:`lib.reference_video.prompt_render.resolve_reference_audio_paths` 排除），故文案
+    只说「不可用」，不断言具体是哪一种。
 
     ``require_reference_image``：目标 backend 的音频必须逐段挂在具体参考素材项上（如
     wan2.7-r2v）时传 True，此时纯画外（无参考图）speaker 即使有可用音频也不绑定——绑定后
@@ -165,7 +168,7 @@ def derive_voice_bindings(
             has_audio = speaker in audio_ready if audio_ready is not None else audio_field_set
             if not has_audio:
                 if audio_ready is not None and audio_field_set:
-                    warnings.append(_warning(WARN_SPEAKER_AUDIO_FILE_MISSING, name=speaker))
+                    warnings.append(_warning(WARN_SPEAKER_AUDIO_UNAVAILABLE, name=speaker))
                 else:
                     warnings.append(_warning(WARN_SPEAKER_WITHOUT_AUDIO, name=speaker))
             elif require_reference_image and speaker not in image_names:

--- a/lib/reference_video/script_preview.py
+++ b/lib/reference_video/script_preview.py
@@ -37,6 +37,7 @@ WARN_UNCLOSED_BRACE = "ref_warn_unclosed_brace"
 WARN_DIALOGUE_INLINE = "ref_warn_dialogue_inline"
 WARN_UNREGISTERED_SPEAKER = "ref_warn_unregistered_speaker"
 WARN_SPEAKER_WITHOUT_AUDIO = "ref_warn_speaker_without_audio"
+WARN_SPEAKER_AUDIO_FILE_MISSING = "ref_warn_speaker_audio_file_missing"
 WARN_REFERENCE_AUDIO_OVERFLOW = "ref_warn_reference_audio_overflow"
 WARN_SILENT_MODEL = "ref_warn_silent_model"
 WARN_SPEAKER_AUDIO_NEEDS_IMAGE = "ref_warn_speaker_audio_needs_image"
@@ -128,6 +129,10 @@ def derive_voice_bindings(
     资产的 ``reference_audio`` 字段非空判定；执行层传入已解析且确实存在的文件对应的角色名，
     让编号与实际随请求发出的音频段数严格等长——字段指向已删文件时编号若不同步，``@音频N``
     会指向不存在的段。两条路径共用本函数，避免预览承诺的绑定与生成实际发出的绑定分叉。
+    ``audio_ready`` 非 None 时降级原因区分两种：角色 ``reference_audio`` 字段未设置发
+    ``WARN_SPEAKER_WITHOUT_AUDIO``；字段有值但不在 ``audio_ready`` 内（文件已被删除或迁移）
+    发 ``WARN_SPEAKER_AUDIO_FILE_MISSING``——前者该去角色设置里补音频，后者该去检查文件是否
+    还在，排查方向不同，不能合并成一条 warning。
 
     ``require_reference_image``：目标 backend 的音频必须逐段挂在具体参考素材项上（如
     wan2.7-r2v）时传 True，此时纯画外（无参考图）speaker 即使有可用音频也不绑定——绑定后
@@ -156,13 +161,13 @@ def derive_voice_bindings(
         image_names = speakers_with_reference_image or ()
         # 音频编号 = dialogue speaker 首现顺序，受 max_reference_audio 上限截断。
         for speaker in registered:
-            has_audio = (
-                speaker in audio_ready
-                if audio_ready is not None
-                else bool((characters.get(speaker) or {}).get("reference_audio"))
-            )
+            audio_field_set = bool((characters.get(speaker) or {}).get("reference_audio"))
+            has_audio = speaker in audio_ready if audio_ready is not None else audio_field_set
             if not has_audio:
-                warnings.append(_warning(WARN_SPEAKER_WITHOUT_AUDIO, name=speaker))
+                if audio_ready is not None and audio_field_set:
+                    warnings.append(_warning(WARN_SPEAKER_AUDIO_FILE_MISSING, name=speaker))
+                else:
+                    warnings.append(_warning(WARN_SPEAKER_WITHOUT_AUDIO, name=speaker))
             elif require_reference_image and speaker not in image_names:
                 warnings.append(_warning(WARN_SPEAKER_AUDIO_NEEDS_IMAGE, name=speaker))
             elif len(audio_speakers) >= max_reference_audio:

--- a/tests/lib/test_reference_video_prompt_render.py
+++ b/tests/lib/test_reference_video_prompt_render.py
@@ -356,6 +356,7 @@ def test_out_of_bounds_audio_path_also_degrades_as_unavailable(tmp_path):
         model_id="doubao-seedance-2-0",
         audio_ready=set(audio_ready),
     )
+    assert rendered.audio_speakers == []
     assert {"key": WARN_SPEAKER_AUDIO_UNAVAILABLE, "params": {"name": "张三"}} in rendered.warnings
     assert {"key": WARN_SPEAKER_WITHOUT_AUDIO, "params": {"name": "张三"}} not in rendered.warnings
 

--- a/tests/lib/test_reference_video_prompt_render.py
+++ b/tests/lib/test_reference_video_prompt_render.py
@@ -229,7 +229,7 @@ def test_legacy_script_without_dialogue_still_renders_three_segments():
 
 def test_audio_ready_overrides_field_presence(tmp_path):
     """字段指向已删文件时不绑定：编号与实际发出的音频段数严格等长，且降级 warning 指向
-    「文件缺失」而非「未设置」——张三字段有值，只是不在 audio_ready 内。"""
+    「音频不可用」而非「未设置」——张三字段有值，只是不在 audio_ready 内。"""
     rendered = render_unit_prompt(
         _TEXT,
         _project(),
@@ -241,6 +241,7 @@ def test_audio_ready_overrides_field_presence(tmp_path):
     assert rendered.audio_speakers == ["李四"]
     assert "<李四>的台词音色参考 @音频1" in rendered.prompt
     assert {"key": WARN_SPEAKER_AUDIO_UNAVAILABLE, "params": {"name": "张三"}} in rendered.warnings
+    assert {"key": WARN_SPEAKER_WITHOUT_AUDIO, "params": {"name": "张三"}} not in rendered.warnings
 
 
 def test_audio_speaker_reference_index_tracks_image_slot_by_name_not_position():
@@ -356,6 +357,7 @@ def test_out_of_bounds_audio_path_also_degrades_as_unavailable(tmp_path):
         audio_ready=set(audio_ready),
     )
     assert {"key": WARN_SPEAKER_AUDIO_UNAVAILABLE, "params": {"name": "张三"}} in rendered.warnings
+    assert {"key": WARN_SPEAKER_WITHOUT_AUDIO, "params": {"name": "张三"}} not in rendered.warnings
 
 
 def test_resolve_reference_audio_paths_ignores_non_dict_characters_bucket(tmp_path):

--- a/tests/lib/test_reference_video_prompt_render.py
+++ b/tests/lib/test_reference_video_prompt_render.py
@@ -11,8 +11,8 @@ from lib.reference_video.prompt_render import (
 from lib.reference_video.script_preview import (
     WARN_REFERENCE_AUDIO_OVERFLOW,
     WARN_SILENT_MODEL,
-    WARN_SPEAKER_AUDIO_FILE_MISSING,
     WARN_SPEAKER_AUDIO_NEEDS_IMAGE,
+    WARN_SPEAKER_AUDIO_UNAVAILABLE,
     WARN_SPEAKER_WITHOUT_AUDIO,
     WARN_UNCLOSED_BRACE,
     WARN_UNREGISTERED_MENTION,
@@ -240,7 +240,7 @@ def test_audio_ready_overrides_field_presence(tmp_path):
     )
     assert rendered.audio_speakers == ["李四"]
     assert "<李四>的台词音色参考 @音频1" in rendered.prompt
-    assert {"key": WARN_SPEAKER_AUDIO_FILE_MISSING, "params": {"name": "张三"}} in rendered.warnings
+    assert {"key": WARN_SPEAKER_AUDIO_UNAVAILABLE, "params": {"name": "张三"}} in rendered.warnings
 
 
 def test_audio_speaker_reference_index_tracks_image_slot_by_name_not_position():
@@ -332,6 +332,30 @@ def test_resolve_reference_audio_paths_only_returns_existing_files_under_refs_au
     resolved = resolve_reference_audio_paths(project, tmp_path)
     assert set(resolved) == {"张三"}
     assert resolved["张三"] == refs_audio / "张三.wav"
+
+
+def test_out_of_bounds_audio_path_also_degrades_as_unavailable(tmp_path):
+    """字段指到 ``refs_audio`` 之外时文件本身可能好端端存在，只是路径不合法——同样被
+    ``resolve_reference_audio_paths`` 排除。这条 warning 因此只说「不可用」，不能断言是
+    文件缺失，否则又把用户导向错误的排查方向。"""
+    refs_audio = tmp_path / "characters" / "refs_audio"
+    refs_audio.mkdir(parents=True)
+    (tmp_path / "project.json").write_text("{}", encoding="utf-8")
+    project = _project(characters={"张三": {"reference_audio": "project.json"}})
+
+    audio_ready = resolve_reference_audio_paths(project, tmp_path)
+    assert audio_ready == {}
+
+    rendered = render_unit_prompt(
+        "镜头1：开场。\n@[张三]：{我来了}",
+        project,
+        _refs(("character", "张三")),
+        voice_consistency="native",
+        max_reference_audio=3,
+        model_id="doubao-seedance-2-0",
+        audio_ready=set(audio_ready),
+    )
+    assert {"key": WARN_SPEAKER_AUDIO_UNAVAILABLE, "params": {"name": "张三"}} in rendered.warnings
 
 
 def test_resolve_reference_audio_paths_ignores_non_dict_characters_bucket(tmp_path):

--- a/tests/lib/test_reference_video_prompt_render.py
+++ b/tests/lib/test_reference_video_prompt_render.py
@@ -11,6 +11,7 @@ from lib.reference_video.prompt_render import (
 from lib.reference_video.script_preview import (
     WARN_REFERENCE_AUDIO_OVERFLOW,
     WARN_SILENT_MODEL,
+    WARN_SPEAKER_AUDIO_FILE_MISSING,
     WARN_SPEAKER_AUDIO_NEEDS_IMAGE,
     WARN_SPEAKER_WITHOUT_AUDIO,
     WARN_UNCLOSED_BRACE,
@@ -227,7 +228,8 @@ def test_legacy_script_without_dialogue_still_renders_three_segments():
 
 
 def test_audio_ready_overrides_field_presence(tmp_path):
-    """字段指向已删文件时不绑定：编号与实际发出的音频段数严格等长。"""
+    """字段指向已删文件时不绑定：编号与实际发出的音频段数严格等长，且降级 warning 指向
+    「文件缺失」而非「未设置」——张三字段有值，只是不在 audio_ready 内。"""
     rendered = render_unit_prompt(
         _TEXT,
         _project(),
@@ -238,7 +240,7 @@ def test_audio_ready_overrides_field_presence(tmp_path):
     )
     assert rendered.audio_speakers == ["李四"]
     assert "<李四>的台词音色参考 @音频1" in rendered.prompt
-    assert {"key": WARN_SPEAKER_WITHOUT_AUDIO, "params": {"name": "张三"}} in rendered.warnings
+    assert {"key": WARN_SPEAKER_AUDIO_FILE_MISSING, "params": {"name": "张三"}} in rendered.warnings
 
 
 def test_audio_speaker_reference_index_tracks_image_slot_by_name_not_position():

--- a/tests/lib/test_reference_video_script_preview.py
+++ b/tests/lib/test_reference_video_script_preview.py
@@ -7,12 +7,14 @@ from lib.reference_video.script_preview import (
     WARN_DIALOGUE_INLINE,
     WARN_REFERENCE_AUDIO_OVERFLOW,
     WARN_SILENT_MODEL,
+    WARN_SPEAKER_AUDIO_FILE_MISSING,
     WARN_SPEAKER_AUDIO_NEEDS_IMAGE,
     WARN_SPEAKER_WITHOUT_AUDIO,
     WARN_UNCLOSED_BRACE,
     WARN_UNREGISTERED_MENTION,
     WARN_UNREGISTERED_SPEAKER,
     build_script_preview,
+    derive_voice_bindings,
 )
 from lib.reference_video.shot_parser import (
     extract_mentions,
@@ -176,6 +178,22 @@ def test_warn_speaker_without_reference_audio_only_on_native():
     assert keys(native) == [WARN_SPEAKER_WITHOUT_AUDIO]
     soft = build_script_preview(text, PROJECT, voice_consistency="soft")
     assert keys(soft) == []
+
+
+def test_warn_speaker_audio_file_missing_distinguished_from_unset():
+    """``audio_ready`` 非 None 时，字段有值但文件缺失（不在 audio_ready 内）与字段未设置
+    要发不同的 warning：前者该去检查文件，后者该去角色设置里补音频。"""
+    text = "镜头1：开场。\n@[张三]：{我来了}\n@[李四]：{你迟到了}"
+    preview = build_script_preview(text, PROJECT, voice_consistency="native", max_reference_audio=3)
+    bindings = derive_voice_bindings(
+        preview.utterances,
+        PROJECT["characters"],
+        voice_consistency="native",
+        max_reference_audio=3,
+        audio_ready=set(),  # 两人字段都有值/无值，但文件系统上一段都不可用
+    )
+    assert {"key": WARN_SPEAKER_AUDIO_FILE_MISSING, "params": {"name": "张三"}} in bindings.warnings
+    assert {"key": WARN_SPEAKER_WITHOUT_AUDIO, "params": {"name": "李四"}} in bindings.warnings
 
 
 def test_warn_speaker_audio_needs_image_when_backend_requires_per_image_attachment():

--- a/tests/lib/test_reference_video_script_preview.py
+++ b/tests/lib/test_reference_video_script_preview.py
@@ -1,4 +1,4 @@
-"""分镜文稿台词规范行的派生与七条降级可见性 warning。"""
+"""分镜文稿台词规范行的派生与降级可见性 warning。"""
 
 import pytest
 
@@ -7,8 +7,8 @@ from lib.reference_video.script_preview import (
     WARN_DIALOGUE_INLINE,
     WARN_REFERENCE_AUDIO_OVERFLOW,
     WARN_SILENT_MODEL,
-    WARN_SPEAKER_AUDIO_FILE_MISSING,
     WARN_SPEAKER_AUDIO_NEEDS_IMAGE,
+    WARN_SPEAKER_AUDIO_UNAVAILABLE,
     WARN_SPEAKER_WITHOUT_AUDIO,
     WARN_UNCLOSED_BRACE,
     WARN_UNREGISTERED_MENTION,
@@ -146,7 +146,7 @@ def test_dialogue_on_shot_header_line_derives_utterance_without_reference():
     assert extract_mentions(text) == []
 
 
-# ---------- 七条 warning ----------
+# ---------- 降级可见性 warning ----------
 
 
 def test_warn_unregistered_mention():
@@ -180,9 +180,9 @@ def test_warn_speaker_without_reference_audio_only_on_native():
     assert keys(soft) == []
 
 
-def test_warn_speaker_audio_file_missing_distinguished_from_unset():
-    """``audio_ready`` 非 None 时，字段有值但文件缺失（不在 audio_ready 内）与字段未设置
-    要发不同的 warning：前者该去检查文件，后者该去角色设置里补音频。"""
+def test_warn_speaker_audio_unavailable_distinguished_from_unset():
+    """``audio_ready`` 非 None 时，字段有值但音频不可用（不在 audio_ready 内）与字段未设置
+    要发不同的 warning：前者字段已填好、该去查它指向的音频，后者该去角色设置里补音频。"""
     text = "镜头1：开场。\n@[张三]：{我来了}\n@[李四]：{你迟到了}"
     preview = build_script_preview(text, PROJECT, voice_consistency="native", max_reference_audio=3)
     bindings = derive_voice_bindings(
@@ -190,9 +190,10 @@ def test_warn_speaker_audio_file_missing_distinguished_from_unset():
         PROJECT["characters"],
         voice_consistency="native",
         max_reference_audio=3,
-        audio_ready=set(),  # 两人字段都有值/无值，但文件系统上一段都不可用
+        # 张三字段有值、李四未设置；audio_ready 为空表示执行层一段都没解析出来。
+        audio_ready=set(),
     )
-    assert {"key": WARN_SPEAKER_AUDIO_FILE_MISSING, "params": {"name": "张三"}} in bindings.warnings
+    assert {"key": WARN_SPEAKER_AUDIO_UNAVAILABLE, "params": {"name": "张三"}} in bindings.warnings
     assert {"key": WARN_SPEAKER_WITHOUT_AUDIO, "params": {"name": "李四"}} in bindings.warnings
 
 

--- a/tests/lib/test_reference_video_script_preview.py
+++ b/tests/lib/test_reference_video_script_preview.py
@@ -194,7 +194,24 @@ def test_warn_speaker_audio_unavailable_distinguished_from_unset():
         audio_ready=set(),
     )
     assert {"key": WARN_SPEAKER_AUDIO_UNAVAILABLE, "params": {"name": "张三"}} in bindings.warnings
+    assert {"key": WARN_SPEAKER_WITHOUT_AUDIO, "params": {"name": "张三"}} not in bindings.warnings
     assert {"key": WARN_SPEAKER_WITHOUT_AUDIO, "params": {"name": "李四"}} in bindings.warnings
+    assert {"key": WARN_SPEAKER_AUDIO_UNAVAILABLE, "params": {"name": "李四"}} not in bindings.warnings
+
+
+def test_derive_voice_bindings_degrades_on_malformed_character_entry():
+    """执行层传入 ``audio_ready`` 时，角色条目非 dict（外部写坏 project.json）不得崩溃——
+    只是 audio_field_set 判定不到值，按「未设置」降级，而不是让 ``.get`` 抛 AttributeError。"""
+    text = "镜头1：开场。\n@[张三]：{我来了}"
+    preview = build_script_preview(text, {"characters": {"张三": "bad"}}, voice_consistency="native")
+    bindings = derive_voice_bindings(
+        preview.utterances,
+        {"张三": "bad"},
+        voice_consistency="native",
+        max_reference_audio=3,
+        audio_ready=set(),
+    )
+    assert {"key": WARN_SPEAKER_WITHOUT_AUDIO, "params": {"name": "张三"}} in bindings.warnings
 
 
 def test_warn_speaker_audio_needs_image_when_backend_requires_per_image_attachment():


### PR DESCRIPTION
Closes #1551

## 问题

`derive_voice_bindings` 在 `has_audio=False` 时统一发 `ref_warn_speaker_without_audio`（三语文案语义为「未设置参考音频」）。但执行路径的 `audio_ready` 来自 `resolve_reference_audio_paths`，它只收录字段有值**且音频确实可用**的角色——字段已填好、只是音频取不到的角色同样落进这条 warning，用户会去角色设置里检查字段，而问题不在字段。

## 改动

- 新增 `ref_warn_speaker_audio_unavailable`（zh/en/vi 三语）：字段有值但不在 `audio_ready` 内时发这条，与「未设置参考音频」区分开。
- 文案只说「该音频当前不可用」，不断言具体成因。`resolve_reference_audio_paths` 排除条目有两种原因：文件被删，以及字段值指到 `characters/refs_audio` 之外（此时文件可能仍在，只是路径不合法，见 `lib/audio_utils.py::resolve_audio_ref_path`）。断言「文件缺失」会在后一种情形下重新制造本 issue 要修的错误排查方向。
- 绑定与降级行为本身未动：`audio_speakers` 组装、上限截断（`ref_warn_reference_audio_overflow`）、需要参考图（`ref_warn_speaker_audio_needs_image`）三条分支的顺序与判定完全不变，仅新增一次告知语义的分叉。

## 范围说明

新分支只在执行路径生效。预览路径（`build_script_preview` 不传 `audio_ready`）按既有约定不碰文件系统，只能按字段非空判定，因此仍显示「未设置参考音频」——这是 `derive_voice_bindings` 既有的设计边界，本次未改。

## 验证

- `uv run python -m pytest` → 7541 passed（含 `tests/test_i18n_consistency.py` 三语 key 一致性）
- `uv run ruff check . && uv run ruff format --check .` → 0
- `uv run basedpyright` → 0 errors
- 新增测试：`test_warn_speaker_audio_unavailable_distinguished_from_unset`（两种降级原因发不同 warning）、`test_out_of_bounds_audio_path_also_degrades_as_unavailable`（越界路径这条成因端到端覆盖）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化参考音频不可用时的提示信息，明确区分“未配置音频”和“已配置但当前不可用”。
  - 参考音频无法使用时，提示对白声音将由模型决定。

- **本地化**
  - 新增英文、越南文和中文提示消息。

- **测试**
  - 补充无效路径、文件缺失及不同警告场景的验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->