### PR TITLE
fix(reference-video): 编辑正文后调整引用标签，仅作说话人的角色不再残留参考图

### DIFF
--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
@@ -243,6 +243,58 @@ describe("ReferenceVideoCanvas", () => {
     expect((ta as HTMLTextAreaElement).value).toContain("x");
   });
 
+  // chip 操作（拖拽/移除/新增）与未保存文本编辑交错时，原子 flush 按新草稿重新派生
+  // references：仅作说话人的角色被剔除，其余条目沿用 chip 操作请求的顺序而非按
+  // 文本中的提及顺序重排。
+  it("re-derives references from the pending draft on a chip flush, keeping the chip-requested order", async () => {
+    useProjectsStore.setState({
+      currentProjectName: "proj",
+      currentProjectData: {
+        ...STUB_PROJECT,
+        characters: { 张三: { description: "" }, 李四: { description: "" }, 王五: { description: "" } },
+      } as ProjectData,
+    });
+    const unit: ReferenceVideoUnit = {
+      ...mkUnit("E1U1", "@[张三] 和 @[李四] 和 @[王五] 出现。"),
+      // 保存时的 chip 顺序刻意与文本中的提及顺序（张三→李四→王五）相反，
+      // 用来区分「保留 chip 顺序」与「按提及顺序重排」两种可能实现。
+      references: [
+        { type: "character", name: "王五" },
+        { type: "character", name: "李四" },
+        { type: "character", name: "张三" },
+      ],
+    };
+    vi.spyOn(API, "listReferenceVideoUnits").mockResolvedValue({ units: [unit] });
+    const patchSpy = vi
+      .spyOn(API, "patchReferenceVideoUnit")
+      .mockResolvedValue({ unit: { ...unit, references: [] } });
+
+    render(<ReferenceVideoCanvas projectName="proj" episode={1} />);
+    const ta = await screen.findByRole("combobox");
+
+    // 未保存的文本编辑：张三改为仅作说话人（规范台词行），派生规则下不应再进 references。
+    fireEvent.change(ta, {
+      target: { value: "@[李四] 和 @[王五] 在场。\n@[张三]：{你好}" },
+    });
+
+    // 交错的 chip 操作：移除与说话人变更无关的王五 chip。移除请求本身不涉及张三——
+    // 若原子 flush 不按新草稿重新派生，张三会残留在落盘 references 里（本 issue 的缺陷）；
+    // 重新派生后张三应被剔除，王五因仍被文本提及而补回，且顺序沿用 chip 侧剩余顺序
+    // （李四、王五），而非文本中的提及顺序（王五、李四）。
+    fireEvent.click(
+      screen.getByRole("button", { name: /Remove reference @王五|移除引用 @王五/ }),
+    );
+
+    await waitFor(() => expect(patchSpy).toHaveBeenCalled());
+    expect(patchSpy).toHaveBeenCalledWith("proj", 1, "E1U1", {
+      prompt: "@[李四] 和 @[王五] 在场。\n@[张三]：{你好}",
+      references: [
+        { type: "character", name: "李四" },
+        { type: "character", name: "王五" },
+      ],
+    });
+  });
+
   // 时长是 unit 级单一真相：下拉档位来自模型能力声明，选中即单独 PATCH（不牵连正文草稿）
   it("renders the unit duration dropdown from the model's declared slots and patches on change", async () => {
     vi.spyOn(API, "listReferenceVideoUnits").mockResolvedValue({ units: [mkUnit("E1U1")] });

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
@@ -278,7 +278,7 @@ describe("ReferenceVideoCanvas", () => {
     });
 
     // 交错的 chip 操作：移除与说话人变更无关的王五 chip。移除请求本身不涉及张三——
-    // 若原子 flush 不按新草稿重新派生，张三会残留在落盘 references 里（本 issue 的缺陷）；
+    // 不按新草稿重新派生的话，张三会残留在落盘 references 里；
     // 重新派生后张三应被剔除，王五因仍被文本提及而补回，且顺序沿用 chip 侧剩余顺序
     // （李四、王五），而非文本中的提及顺序（王五、李四）。
     fireEvent.click(

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -476,6 +476,17 @@ export function ReferenceVideoCanvas({
 
   const hasAnyDraft = Object.keys(drafts).length > 0;
 
+  // 草稿已落盘 → 丢弃本地草稿。若这期间用户又敲了字（草稿值已变），保留新草稿不动，
+  // 否则落盘响应回来时会把用户刚输入的内容抹掉。
+  const clearFlushedDraft = useCallback((key: string, flushed: string) => {
+    setDrafts((d) => {
+      if (d[key] !== flushed) return d;
+      const copy = { ...d };
+      delete copy[key];
+      return copy;
+    });
+  }, []);
+
   const handleSave = useCallback(async () => {
     if (!selected) return;
     const unitId = selected.unit_id;
@@ -489,18 +500,13 @@ export function ReferenceVideoCanvas({
         prompt: draftText,
         references: nextRefs,
       });
-      setDrafts((d) => {
-        if (d[key] !== draftText) return d;
-        const copy = { ...d };
-        delete copy[key];
-        return copy;
-      });
+      clearFlushedDraft(key, draftText);
     } catch (e) {
       toastError(e);
     } finally {
       setSaving(false);
     }
-  }, [selected, drafts, project, patchUnit, projectName, episode]);
+  }, [selected, drafts, project, patchUnit, projectName, episode, clearFlushedDraft]);
 
   // Reference reorder/add/remove flushes immediately, carrying any pending prompt draft.
   const patchReferencesAtomic = useCallback(
@@ -513,27 +519,18 @@ export function ReferenceVideoCanvas({
       // draftText 未落盘时，chip 操作请求的 nextRefs 仍基于旧 prompt 状态；按新 draftText
       // 重新派生，同时把 nextRefs 作为 mergeReferences 的 existing 基准——保留本次 chip
       // 操作请求的顺序（拖拽结果），只补丢弃/新增仅由文本变化引起的部分。
-      const finalRefs = hasDraft
-        ? mergeReferences(draftText, nextRefs, project ?? null)
-        : nextRefs;
       const body: { prompt?: string; references: ReferenceResource[] } = hasDraft
-        ? { prompt: draftText, references: finalRefs }
+        ? { prompt: draftText, references: mergeReferences(draftText, nextRefs, project ?? null) }
         : { references: nextRefs };
       void patchUnit(projectName, episode, unitId, body)
         .then(() => {
-          if (!hasDraft) return;
-          setDrafts((d) => {
-            if (d[key] !== draftText) return d;
-            const copy = { ...d };
-            delete copy[key];
-            return copy;
-          });
+          if (hasDraft) clearFlushedDraft(key, draftText);
         })
         .catch((e) => {
           toastError(e);
         });
     },
-    [drafts, units, patchUnit, projectName, episode, project],
+    [drafts, units, patchUnit, projectName, episode, project, clearFlushedDraft],
   );
 
   const handleReorderRefs = useCallback(

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -510,8 +510,14 @@ export function ReferenceVideoCanvas({
       const unit = units.find((u) => u.unit_id === unitId);
       const hasDraft =
         draftText !== undefined && unit !== undefined && draftText !== unitPromptText(unit);
+      // draftText 未落盘时，chip 操作请求的 nextRefs 仍基于旧 prompt 状态；按新 draftText
+      // 重新派生，同时把 nextRefs 作为 mergeReferences 的 existing 基准——保留本次 chip
+      // 操作请求的顺序（拖拽结果），只补丢弃/新增仅由文本变化引起的部分。
+      const finalRefs = hasDraft
+        ? mergeReferences(draftText, nextRefs, project ?? null)
+        : nextRefs;
       const body: { prompt?: string; references: ReferenceResource[] } = hasDraft
-        ? { prompt: draftText, references: nextRefs }
+        ? { prompt: draftText, references: finalRefs }
         : { references: nextRefs };
       void patchUnit(projectName, episode, unitId, body)
         .then(() => {
@@ -527,7 +533,7 @@ export function ReferenceVideoCanvas({
           toastError(e);
         });
     },
-    [drafts, units, patchUnit, projectName, episode],
+    [drafts, units, patchUnit, projectName, episode, project],
   );
 
   const handleReorderRefs = useCallback(


### PR DESCRIPTION
Closes #1548

## 问题

参考生视频画布里，「仅作台词说话人的角色不附参考图」这条规则由文本派生保证，但派生只发生在纯文本保存路径。用户把某角色改成纯说话人后，若在保存前顺手拖拽/移除/新增了任一引用标签，该角色就会残留在落盘的引用列表里，生成时照常附上它的参考图。

## 改动

引用标签的即时落盘（`patchReferencesAtomic`）在携带未保存正文草稿时，改为按草稿文本重新派生引用列表，并把标签操作请求的顺序作为 `mergeReferences` 的基准传入——拖拽出来的顺序不会因重新派生而丢失。无未保存草稿的纯标签操作路径不变。

顺带把 `handleSave` 与 `patchReferencesAtomic` 中形状相同的草稿清理块抽成 `clearFlushedDraft`（两条 flush 路径共用），并收敛 `patchReferencesAtomic` 里重复的条件分支。

## 验证

- `pnpm lint` 通过
- `pnpm check`（typecheck + eslint + vitest 142 files / 1635 tests）通过
- 新增回归用例 `re-derives references from the pending draft on a chip flush, keeping the chip-requested order`：构造「文本提及顺序」与「标签顺序」相反的用例，同时验证说话人被剔除与标签顺序被保留。已确认回退修复后该用例失败（说话人残留），修复后通过
- 后端未改动，未跑后端质量门

## 审查备注

确认过「只改前端、不加后端一致性校验」这个取舍成立：`PATCH .../units/{unit_id}` 在整个仓库只有 `reference-video-store` 一个调用方，其上游只有本画布组件；`public/skill.md.template` 未暴露该端点，无外部集成契约。所有会写 prompt 或 references 的请求都成对写入，不存在只写其中一个字段的路径。智能体侧是直接改剧集 JSON 文件、绕过该端点，后端加校验也拦不到。

follow-up 候选（本 PR 未处理，超出本票范围）：存在未保存草稿时，从选择器新增一个草稿文本未提及的资产会被静默丢弃，而同一手势在无草稿时会生效——同一操作的结果随「是否有未保存草稿」分叉且无任何提示。这与既有纯文本保存路径的行为一致（下次保存时同样会被撤销），属既有不变量的表现，但选择器的可选项或提示可以做得更诚实。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复编辑未保存文本期间调整引用内容时，提交结果未及时同步最新草稿的问题。
  * 避免清理草稿时覆盖用户随后输入的内容。
  * 优化引用更新逻辑，自动移除仅作为说话人的角色，并保持引用顺序。

* **测试**
  * 新增相关场景测试，覆盖文本编辑与引用操作交错进行时的数据一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->