### PR TITLE
fix(reference-video): 视频能力按剧集生效模式解析，被单集覆盖的那一集不再丢参考音频

### DIFF
--- a/agent_runtime_profile/.claude/agents/normalize-drama-script.md
+++ b/agent_runtime_profile/.claude/agents/normalize-drama-script.md
@@ -37,7 +37,7 @@ description: "剧集动画模式单集规范化剧本 subagent（drama 模式专
 通过 MCP 工具查询：
 
 ```text
-mcp__arcreel__get_video_capabilities({})
+mcp__arcreel__get_video_capabilities({"episode": N})
 ```
 
 解析返回的 JSON，记录：

--- a/agent_runtime_profile/.claude/agents/split-narration-segments.md
+++ b/agent_runtime_profile/.claude/agents/split-narration-segments.md
@@ -37,7 +37,7 @@ description: "说书模式单集片段拆分 subagent（narration 模式专用�
 通过 MCP 工具查询：
 
 ```text
-mcp__arcreel__get_video_capabilities({})
+mcp__arcreel__get_video_capabilities({"episode": N})
 ```
 
 解析返回的 JSON，记录：

--- a/agent_runtime_profile/.claude/agents/split-reference-video-units.md
+++ b/agent_runtime_profile/.claude/agents/split-reference-video-units.md
@@ -35,7 +35,7 @@ description: "参考生视频模式单集视频单元拆分 subagent（reference
 通过 MCP 工具查询：
 
 ```text
-mcp__arcreel__get_video_capabilities({})
+mcp__arcreel__get_video_capabilities({"episode": N})
 ```
 
 解析返回的 JSON，记录：

--- a/agent_runtime_profile/.claude/skills/manage-project/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/manage-project/SKILL.md
@@ -13,7 +13,7 @@ user-invocable: false
 | 工具 | 功能 | 调用者 |
 |------|------|--------|
 | `mcp__arcreel__patch_project`（SDK tool） | 新增/修改 project.json 的角色/场景/道具（按 table+name upsert）、顶层 settings 字段或项目概述（overview 分支） | subagent / 主 agent |
-| `mcp__arcreel__get_video_capabilities`（SDK tool） | 查当前项目视频模型能力（model 粒度，所有生成模式通用） | **subagent**（执行任务时自行查询） |
+| `mcp__arcreel__get_video_capabilities`（SDK tool） | 查视频模型能力（model 粒度，所有生成模式通用；带 `episode` 按该集生效模式解析） | **subagent**（执行任务时自行查询） |
 
 > 分集规划（拆集/调整）由服务端工具 `mcp__arcreel__plan_episodes` / `mcp__arcreel__reset_episode_planning` 完成，调整已规划内容走「重置 + 重新规划」，流程见 manga-workflow 阶段 2。
 
@@ -57,8 +57,11 @@ description）时不落盘并返回 `is_error: true`。
 通过 MCP 工具查询（项目名由 session 绑定，无需传参）：
 
 ```text
-mcp__arcreel__get_video_capabilities({})
+mcp__arcreel__get_video_capabilities({"episode": N})
 ```
+
+`episode` 必传于按集查询：生成模式可被单集覆盖，省略集号拿到的是项目级口径，
+与该集实际执行的模型可能不是同一个。项目整体设置层面的查询才可省略。
 
 **返回**：JSON 文本，含 `provider_id` / `model` / `supported_durations[]` / `max_duration` / `max_reference_images` / `source` / `default_duration` / `content_mode` / `generation_mode`。
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
@@ -123,7 +123,7 @@ description: 将小说转换为短视频的端到端工作流编排器。当用�
 dispatch prompt 通用参数：项目名称、项目路径、集数、本集小说文件路径。
 
 （两个预处理 subagent 会自行读 project.json + 调用
-`mcp__arcreel__get_video_capabilities({})`
+`mcp__arcreel__get_video_capabilities({"episode": N})`
 拿到模型能力与用户偏好；主 agent 不需要预先注入角色/场景/道具列表或
 `supported_durations` / `max_duration` / `max_reference_images` / `default_duration` 等数据。）
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
@@ -127,7 +127,7 @@ description: 将小说转换为短视频的端到端工作流编排器。当用�
 dispatch prompt 通用参数：项目名称、项目路径、集数、本集小说文件路径。
 
 （两个预处理 subagent 会自行读 project.json + 调用
-`mcp__arcreel__get_video_capabilities({})`
+`mcp__arcreel__get_video_capabilities({"episode": N})`
 拿到模型能力与用户偏好；主 agent 不需要预先注入角色/场景/道具列表或
 `supported_durations` / `max_duration` / `max_reference_images` / `default_duration` 等数据。）
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -535,15 +535,19 @@ class API {
    * 三级解析（项目 > 系统设置 > 系统默认）后的视频模型能力。
    *
    * `videoBackend`（"provider/model"）用于设置表单里尚未保存的候选模型：不传按已落盘配置
-   * 解析，传了则按该候选模型 × 本项目 generation_mode 解析。
+   * 解析，传了则按该候选模型 × 本项目生效 generation_mode 解析。
+   *
+   * `episode` 用于按集查看的界面：生成模式可被单集覆盖，传集号则能力按该集生效模式解析，
+   * 与执行层同口径；不传只解析到项目级（设置页等无集号上下文的调用）。
    */
   static async getVideoCapabilities(
     name: string,
-    options: { signal?: AbortSignal; videoBackend?: string } = {}
+    options: { signal?: AbortSignal; videoBackend?: string; episode?: number } = {}
   ): Promise<VideoCapabilities> {
-    const qs = options.videoBackend
-      ? `?video_backend=${encodeURIComponent(options.videoBackend)}`
-      : "";
+    const params = new URLSearchParams();
+    if (options.videoBackend) params.set("video_backend", options.videoBackend);
+    if (options.episode !== undefined) params.set("episode", String(options.episode));
+    const qs = params.size > 0 ? `?${params.toString()}` : "";
     return this.request(`/projects/${encodeURIComponent(name)}/video-capabilities${qs}`, {
       signal: options.signal,
     });

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { errMsg, voidPromise } from "@/utils/async";
-import { Route, Switch, Redirect } from "wouter";
+import { Route, Switch, Redirect, useRoute } from "wouter";
 import {
   WORKSPACE_ROUTE_LOREBOOK,
   WORKSPACE_ROUTE_CLUES,
@@ -140,10 +140,20 @@ export function StudioCanvasRouter() {
   //
   // 收窄放在下方按集的 Route 渲染里：generation_mode 可被单集覆盖，「是否走参考图路径」因此
   // 是按集的值，而能力查询只在组件顶层做一次。此处只取不随上下文变化的两项。
+  //
+  // 服务端侧则把当前集号一并带上：同一个覆盖也让 voiceConsistency / firstFrame 等二维派生值
+  // 按该集生效模式解析，与执行层同口径。集号在顶层从路由取（下方 Route 的同一份 path），
+  // 能力查询因此仍只发生一次、随切集重取。
+  const [, episodeRouteParams] = useRoute<{ episodeId: string }>(
+    `/${WORKSPACE_ROUTE_EPISODES}/:episodeId`,
+  );
+  const routeEpisode = episodeRouteParams ? parseInt(episodeRouteParams.episodeId, 10) : NaN;
+  const currentEpisode = Number.isFinite(routeEpisode) ? routeEpisode : undefined;
   const effectiveVideoBackend = currentProjectData?.video_backend || globalVideoBackend;
   const { rawDurations, durationConstraints, resolvedVideoBackend } = useModelCapabilities({
     projectName: currentProjectName,
     videoBackend: effectiveVideoBackend,
+    episode: currentEpisode,
     providers,
     customProviders,
     enabled: capabilitiesEnabled,

--- a/frontend/src/components/canvas/StudioCanvasRouter.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { errMsg, voidPromise } from "@/utils/async";
-import { Route, Switch, Redirect, useRoute } from "wouter";
+import { Route, Switch, Redirect } from "wouter";
 import {
   WORKSPACE_ROUTE_LOREBOOK,
   WORKSPACE_ROUTE_CLUES,
@@ -9,7 +9,6 @@ import {
   WORKSPACE_ROUTE_SCENES,
   WORKSPACE_ROUTE_PROPS,
   WORKSPACE_ROUTE_PRODUCTS,
-  WORKSPACE_ROUTE_EPISODES,
 } from "@/app-routes";
 import { useTranslation } from "react-i18next";
 import { useProjectsStore } from "@/stores/projects-store";
@@ -20,6 +19,7 @@ import { useAppStore } from "@/stores/app-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
 import { useCapabilitiesStore } from "@/stores/capabilities-store";
 import { useActiveResourceIds } from "@/stores/tasks-store";
+import { useCurrentEpisode, EPISODE_ROUTE_PATH } from "@/hooks/useCurrentEpisode";
 import { TimelineCanvas } from "./timeline/TimelineCanvas";
 import { OverviewCanvas } from "./OverviewCanvas";
 import { SourceFileViewer } from "./SourceFileViewer";
@@ -142,13 +142,9 @@ export function StudioCanvasRouter() {
   // 是按集的值，而能力查询只在组件顶层做一次。此处只取不随上下文变化的两项。
   //
   // 服务端侧则把当前集号一并带上：同一个覆盖也让 voiceConsistency / firstFrame 等二维派生值
-  // 按该集生效模式解析，与执行层同口径。集号在顶层从路由取（下方 Route 的同一份 path），
-  // 能力查询因此仍只发生一次、随切集重取。
-  const [, episodeRouteParams] = useRoute<{ episodeId: string }>(
-    `/${WORKSPACE_ROUTE_EPISODES}/:episodeId`,
-  );
-  const routeEpisode = episodeRouteParams ? parseInt(episodeRouteParams.episodeId, 10) : NaN;
-  const currentEpisode = Number.isFinite(routeEpisode) ? routeEpisode : undefined;
+  // 按该集生效模式解析，与执行层同口径。集号在顶层从路由取（`useCurrentEpisode` 与下方 Route
+  // 共用同一份 path），能力查询因此仍只发生一次、随切集重取。
+  const currentEpisode = useCurrentEpisode();
   const effectiveVideoBackend = currentProjectData?.video_backend || globalVideoBackend;
   const { rawDurations, durationConstraints, resolvedVideoBackend } = useModelCapabilities({
     projectName: currentProjectName,
@@ -670,7 +666,7 @@ export function StudioCanvasRouter() {
         }
       </Route>
 
-      <Route path={`/${WORKSPACE_ROUTE_EPISODES}/:episodeId`}>
+      <Route path={EPISODE_ROUTE_PATH}>
         {(params) => {
           const epNum = parseInt(params.episodeId, 10);
           const episode = currentProjectData?.episodes?.find((e) => e.episode === epNum);

--- a/frontend/src/components/canvas/timeline/EndFrameRow.tsx
+++ b/frontend/src/components/canvas/timeline/EndFrameRow.tsx
@@ -5,6 +5,7 @@ import { API } from "@/api";
 import { AspectFrame } from "@/components/ui/AspectFrame";
 import { InlineWarning } from "@/components/ui/InlineWarning";
 import { useModelCapabilities } from "@/hooks/useModelCapabilities";
+import { useCurrentEpisode } from "@/hooks/useCurrentEpisode";
 import { useDemoWorkbench } from "@/onboarding/use-demo-workbench";
 import { useAppStore } from "@/stores/app-store";
 import { useProjectsStore } from "@/stores/projects-store";
@@ -63,7 +64,14 @@ export function EndFrameRow({
   const [submitting, setSubmitting] = useState(false);
   const viewOnly = useDemoWorkbench() || readOnly;
 
-  const { lastFrame, loading: capsLoading } = useModelCapabilities({ projectName, videoBackend });
+  // 带上当前集号：生成模式可被单集覆盖，`lastFrame` 是随 caps 定桶而变的 model 粒度能力，
+  // 不传集号会拿项目级桶的模型去判尾帧支持，与执行层错位（也与工作台顶层的能力查询串成两份口径）。
+  const episode = useCurrentEpisode();
+  const { lastFrame, loading: capsLoading } = useModelCapabilities({
+    projectName,
+    videoBackend,
+    episode,
+  });
   // 未查到能力（加载中 / 失败）时不谎报不支持：仅明确的 false 才门控。
   const unsupported = lastFrame === false;
 

--- a/frontend/src/hooks/useCurrentEpisode.ts
+++ b/frontend/src/hooks/useCurrentEpisode.ts
@@ -1,0 +1,18 @@
+import { useRoute } from "wouter";
+import { WORKSPACE_ROUTE_EPISODES } from "@/app-routes";
+
+/** 集级路由 path，与渲染该集的 `<Route>` 共用一份，避免两处字面量各自漂移。 */
+export const EPISODE_ROUTE_PATH = `/${WORKSPACE_ROUTE_EPISODES}/:episodeId`;
+
+/**
+ * 当前路由所在的集号；不在集级路由下（或集号段不是数字）时为 undefined。
+ *
+ * 能力查询的集号出口：生成模式可被单集覆盖，服务端要拿到集号才会按该集生效模式解析
+ * `voiceConsistency` / `lastFrame` 等二维派生值。各消费方共用本 hook，不各自解析路由——
+ * 否则同一页的几个能力出口会因集号口径不同而拿到互相矛盾的能力。
+ */
+export function useCurrentEpisode(): number | undefined {
+  const [, params] = useRoute<{ episodeId: string }>(EPISODE_ROUTE_PATH);
+  const parsed = params ? parseInt(params.episodeId, 10) : NaN;
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/frontend/src/hooks/useModelCapabilities.test.tsx
+++ b/frontend/src/hooks/useModelCapabilities.test.tsx
@@ -8,7 +8,8 @@ import {
   useModelCapabilities,
 } from "@/hooks/useModelCapabilities";
 import { useCapabilitiesStore } from "@/stores/capabilities-store";
-import type { ProviderInfo, VideoCapabilities } from "@/types";
+import { useProjectsStore } from "@/stores/projects-store";
+import type { ProjectData, ProviderInfo, VideoCapabilities } from "@/types";
 
 const PROJECT = "demo-project";
 const BACKEND = "gemini/veo-3";
@@ -57,8 +58,17 @@ function caps(overrides: Partial<VideoCapabilities> = {}): VideoCapabilities {
   };
 }
 
+/** 只含能力 key 关心的字段：集级 generation_mode 覆盖与其回退到的项目级值。 */
+function projectData(episodeMode: string | null): ProjectData {
+  return {
+    generation_mode: "storyboard",
+    episodes: [{ episode: 1, ...(episodeMode ? { generation_mode: episodeMode } : {}) }],
+  } as ProjectData;
+}
+
 beforeEach(() => {
   useCapabilitiesStore.setState({ revision: 0 });
+  useProjectsStore.setState({ currentProjectName: null, currentProjectData: null });
 });
 
 afterEach(() => {
@@ -305,6 +315,20 @@ describe("useModelCapabilities 失效时机", () => {
 
     spy.mockResolvedValue(caps({ last_frame: false }));
     act(() => useCapabilitiesStore.getState().invalidate());
+    await waitFor(() => expect(result.current.lastFrame).toBe(false));
+  });
+
+  it("集级 generation_mode 覆盖变更后自动重取，不等切集或重新挂载", async () => {
+    // 覆盖经 PATCH /projects/{name} 写入、项目事件 SSE 刷进 store：集号没变，能力却已换桶。
+    useProjectsStore.setState({ currentProjectName: PROJECT, currentProjectData: projectData(null) });
+    const spy = vi.spyOn(API, "getVideoCapabilities").mockResolvedValue(caps({ last_frame: true }));
+    const { result } = renderHook(() =>
+      useModelCapabilities({ projectName: PROJECT, videoBackend: BACKEND, episode: 1 }),
+    );
+    await waitFor(() => expect(result.current.lastFrame).toBe(true));
+
+    spy.mockResolvedValue(caps({ last_frame: false }));
+    act(() => useProjectsStore.setState({ currentProjectData: projectData("reference_video") }));
     await waitFor(() => expect(result.current.lastFrame).toBe(false));
   });
 

--- a/frontend/src/hooks/useModelCapabilities.ts
+++ b/frontend/src/hooks/useModelCapabilities.ts
@@ -58,6 +58,11 @@ export interface ModelCapabilitiesInput extends DurationContext {
    * 模型的时长摆成本候选的选项，用户能存下新模型不支持的值。
    */
   unsavedBackend?: boolean;
+  /**
+   * 当前查看的集号；生成模式可被单集覆盖，传了服务端才按该集生效模式解析
+   * `voiceConsistency` / `firstFrame` 等二维派生值。设置页等无集号上下文的调用不传。
+   */
+  episode?: number | null;
   providers?: ProviderInfo[];
   customProviders?: CustomProviderInfo[];
   /** 置 false 时既不查服务端也不查目录（演示态等）。 */
@@ -164,6 +169,7 @@ export function durationOutOfRangeReason(
 function useResolvedCapabilities(
   projectName: string | undefined | null,
   videoBackend: string | undefined | null,
+  episode: number | undefined | null,
   enabled: boolean,
 ): { caps: VideoCapabilities | null; loading: boolean } {
   const revision = useCapabilitiesStore((s) => s.revision);
@@ -176,7 +182,7 @@ function useResolvedCapabilities(
   const active = enabled && !!projectName && !isDemoProject(projectName);
   // 元组编码而非拼接：拼接的分隔符可能出现在字段内，("a b", "c") 与 ("a", "b c") 会撞成同一 key，
   // 切换时把前一组的结果当作本组已落地。
-  const key = active ? JSON.stringify([projectName, videoBackend ?? ""]) : null;
+  const key = active ? JSON.stringify([projectName, videoBackend ?? "", episode ?? null]) : null;
 
   useEffect(() => {
     // 接管方轮换 controller：新一轮先作废前任，避免慢响应回写覆盖新值。
@@ -190,7 +196,11 @@ function useResolvedCapabilities(
     const { signal } = controller;
     // 带上 videoBackend：表单里编辑中的候选模型也要拿到它自己的能力，否则服务端按已落盘
     // 配置解析，档位等二维派生值会停留在上一次保存的模型上。
-    API.getVideoCapabilities(projectName, { signal, videoBackend: videoBackend || undefined })
+    API.getVideoCapabilities(projectName, {
+      signal,
+      videoBackend: videoBackend || undefined,
+      episode: episode ?? undefined,
+    })
       .then((next) => {
         // 网络 await 之后的写 state 断点：abort 可能发生在响应已 resolve 之后。
         if (signal.aborted) return;
@@ -204,8 +214,8 @@ function useResolvedCapabilities(
     return () => {
       controller.abort();
     };
-    // videoBackend 已编码进 key，列出只为满足 exhaustive-deps，不引入额外请求。
-  }, [key, projectName, videoBackend, revision]);
+    // videoBackend / episode 已编码进 key，列出只为满足 exhaustive-deps，不引入额外请求。
+  }, [key, projectName, videoBackend, episode, revision]);
 
   const settled = key !== null && result?.key === key;
   return { caps: settled ? result.caps : null, loading: key !== null && !settled };
@@ -215,13 +225,14 @@ export function useModelCapabilities({
   projectName,
   videoBackend,
   unsavedBackend = false,
+  episode,
   providers = EMPTY_PROVIDERS,
   customProviders = EMPTY_CUSTOM_PROVIDERS,
   videoResolution,
   usesReferenceImages,
   enabled = true,
 }: ModelCapabilitiesInput): ModelCapabilities {
-  const { caps, loading } = useResolvedCapabilities(projectName, videoBackend, enabled);
+  const { caps, loading } = useResolvedCapabilities(projectName, videoBackend, episode, enabled);
 
   // 时长连同它出自哪个模型一起解析：联动约束要按同一个模型查，否则走服务端回退时会拿传入的
   // 后端（留空，或已不在目录中的存值）去查约束，得到空约束、把未收窄的时长当作可选项。

--- a/frontend/src/hooks/useModelCapabilities.ts
+++ b/frontend/src/hooks/useModelCapabilities.ts
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { API } from "@/api";
 import { isDemoProject } from "@/onboarding/demo-project";
 import { useCapabilitiesStore } from "@/stores/capabilities-store";
+import { useProjectsStore } from "@/stores/projects-store";
+import { effectiveMode, type GenerationMode } from "@/utils/generation-mode";
 import {
   constrainDurations,
   lookupDurationConstraints,
@@ -157,11 +159,30 @@ export function durationOutOfRangeReason(
 }
 
 /**
+ * 该集生效 generation_mode；无集号上下文（设置页等）或项目数据未加载时为 null。
+ *
+ * 只参与请求 key，不进请求参数——服务端已按集号自行解析。集级覆盖经
+ * `PATCH /projects/{name}` 写入、再由项目事件 SSE 刷进 store，工作台挂载期间就会变；
+ * 而集号本身不变，key 不含模式的话该覆盖变了也不重取，能力停在上一模式。
+ */
+function useEpisodeGenerationMode(
+  projectName: string | undefined | null,
+  episode: number | undefined | null,
+): GenerationMode | null {
+  const project = useProjectsStore((s) =>
+    projectName && s.currentProjectName === projectName ? s.currentProjectData : null,
+  );
+  if (episode === null || episode === undefined || !project) return null;
+  return effectiveMode(project, project.episodes?.find((e) => e.episode === episode));
+}
+
+/**
  * 服务端能力查询。
  *
- * 请求 key 只含「决定结果是否仍可用」的上下文：项目与后端。项目 / 后端一变必须立刻丢弃旧
- * 能力，避免按过期值门控；revision 则单独驱动重取而不进 key——能力覆盖改的是供应商配置，
- * 旧值在新值到达前仍是当前最优估计，进 key 会让每次覆盖变更都闪一次加载态、短暂灰掉控件。
+ * 请求 key 只含「决定结果是否仍可用」的上下文：项目、后端、集号与该集生效模式。这几项一变
+ * 必须立刻丢弃旧能力，避免按过期值门控；revision 则单独驱动重取而不进 key——能力覆盖改的是
+ * 供应商配置，旧值在新值到达前仍是当前最优估计，进 key 会让每次覆盖变更都闪一次加载态、
+ * 短暂灰掉控件。
  *
  * 加载态由「已落地结果的 key 是否等于当前 key」派生，而非 effect 内同步 setState：
  * 后者会触发级联渲染（react-hooks/set-state-in-effect）。
@@ -182,7 +203,10 @@ function useResolvedCapabilities(
   const active = enabled && !!projectName && !isDemoProject(projectName);
   // 元组编码而非拼接：拼接的分隔符可能出现在字段内，("a b", "c") 与 ("a", "b c") 会撞成同一 key，
   // 切换时把前一组的结果当作本组已落地。
-  const key = active ? JSON.stringify([projectName, videoBackend ?? "", episode ?? null]) : null;
+  const episodeMode = useEpisodeGenerationMode(projectName, episode);
+  const key = active
+    ? JSON.stringify([projectName, videoBackend ?? "", episode ?? null, episodeMode])
+    : null;
 
   useEffect(() => {
     // 接管方轮换 controller：新一轮先作废前任，避免慢响应回写覆盖新值。

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -39,7 +39,7 @@ from lib.config.service import (
 from lib.custom_provider import is_custom_provider, parse_provider_id
 from lib.db.repositories.credential_repository import CredentialRepository
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
-from lib.project_manager import get_project_manager
+from lib.project_manager import effective_mode, find_episode, get_project_manager
 from lib.text_backends.base import TEXT_TASK_TIERS, VISION_REQUIRED_TASKS, TextTaskTier, TextTaskType
 from lib.video_backends.registry import (
     effective_generate_audio_for_model as builtin_effective_generate_audio_for_model,
@@ -233,6 +233,27 @@ def video_bucket_for_generation_mode(generation_mode: str | None) -> VideoCapabi
     if not isinstance(generation_mode, str):
         return _DEFAULT_VIDEO_BUCKET
     return VIDEO_BUCKET_BY_GENERATION_MODE.get(generation_mode, _DEFAULT_VIDEO_BUCKET)
+
+
+def caps_generation_mode(project: dict | None, episode: int | None) -> str | None:
+    """能力查询口径的生效 generation_mode：集级覆盖 > 项目级，两级都未声明时为 None。
+
+    模式排序委托 ``lib.project_manager.effective_mode``（生效模式的唯一真相源），能力解析不
+    另立一份项目级口径：剧集覆盖生成模式后，定桶、声音一致性、以及下游按 caps
+    ``generation_mode`` 求值的分辨率与参考图约束一并跟着该集走。
+
+    与 ``effective_mode`` 的唯一差别是两级都没声明时返回 None 而非默认档——``generation_mode``
+    是 caps 的对外字段（回前端与智能体），「未声明」不该渲染成用户显式选过 storyboard。
+
+    ``episode`` 为 None（无集号上下文，如设置页与目录查询）时只解析到项目级。
+    """
+    if project is None:
+        return None
+    episode_entry = find_episode(project, episode) or {}
+    declared = (episode_entry.get("generation_mode"), project.get("generation_mode"))
+    if not any(isinstance(value, str) and value for value in declared):
+        return None
+    return effective_mode(project=project, episode=episode_entry)
 
 
 def project_video_backend_ids(project: dict) -> tuple[str, str] | None:
@@ -778,12 +799,15 @@ class ConfigResolver:
                         return speed_from_str
             return await svc.get_narration_speed()
 
-    async def video_capabilities(self, project_name: str | None = None) -> dict:
+    async def video_capabilities(self, project_name: str | None = None, episode: int | None = None) -> dict:
         """解析当前项目视频 model 的综合能力 + 用户项目偏好。
 
-        model 按项目 ``generation_mode`` 定桶（图生视频 / 宫格 → i2v，参考生视频 → r2v）后走与
+        model 按生效 ``generation_mode`` 定桶（图生视频 / 宫格 → i2v，参考生视频 → r2v）后走与
         执行相同的解析入口，回答的始终是「当前配置真正会执行的那个模型」；切换 generation_mode
         后返回值随桶变化（``docs/adr/0054``）。
+
+        ``episode`` 给出集号时按该集生效模式解析（``caps_generation_mode``），项目级模式被单集
+        覆盖时能力随该集走；不给则只解析到项目级。
 
         Returns:
             {
@@ -800,7 +824,7 @@ class ConfigResolver:
               "source": "registry" | "custom",
               "default_duration": int | None,      # 用户在 project.json 里设置的偏好
               "content_mode": str | None,
-              "generation_mode": str | None,
+              "generation_mode": str | None,       # 该集生效模式（集级覆盖 > 项目级）
               "voice_consistency": "native" | "soft" | "none",  # 模型能力 × generation_mode 二维派生
             }
 
@@ -810,9 +834,9 @@ class ConfigResolver:
                 引用已不可用。
         """
         async with self._open_session() as (session, svc):
-            return await self._resolve_video_capabilities(svc, session, project_name)
+            return await self._resolve_video_capabilities(svc, session, project_name, episode)
 
-    async def video_capabilities_for_project(self, project: dict) -> dict:
+    async def video_capabilities_for_project(self, project: dict, episode: int | None = None) -> dict:
         """同 `video_capabilities`，但使用调用方已加载的 project dict。
 
         优先用此变体，可避免按名称二次加载、也不依赖 `PROJECT_ROOT/projects/<name>` 目录结构
@@ -820,9 +844,15 @@ class ConfigResolver:
         与全局项目碰撞读到错误能力）。
         """
         async with self._open_session() as (session, svc):
-            return await self._resolve_video_capabilities_from_project(svc, session, project)
+            return await self._resolve_video_capabilities_from_project(svc, session, project, episode)
 
-    async def video_capabilities_for_model(self, provider_id: str, model_id: str, project: dict | None = None) -> dict:
+    async def video_capabilities_for_model(
+        self,
+        provider_id: str,
+        model_id: str,
+        project: dict | None = None,
+        episode: int | None = None,
+    ) -> dict:
         """读取指定 provider/model 的视频能力，不再二次解析 provider。
 
         供执行层使用：调用方已通过 `resolve_video_backend(project, payload)` 解析出实际
@@ -832,15 +862,19 @@ class ConfigResolver:
 
         入参身份仍会再收敛一次（口径同 ``resolve_video_backend``），因此直接传字面配置也能
         拿到有效身份的能力；自定义 provider 无可用默认 model 时抛 ``ValueError``。
+
+        ``episode`` 同 ``video_capabilities``：给出集号时按该集生效 ``generation_mode`` 派生
+        声音一致性等二维值，主链路因此不会拿项目级模式去判定被单集覆盖的那一集。
         """
         async with self._open_session() as (session, svc):
-            return await self._resolve_video_caps_for_model(svc, session, provider_id, model_id, project)
+            return await self._resolve_video_caps_for_model(svc, session, provider_id, model_id, project, episode)
 
     async def video_pricing_generate_audio(
         self,
         provider_id: str,
         model_id: str,
         project: dict | None = None,
+        episode: int | None = None,
     ) -> bool:
         """费用预估用的有效 ``generate_audio``：读能力接口，解析不出时降级，绝不抛错。
 
@@ -851,7 +885,7 @@ class ConfigResolver:
         会被按静音档低估。
         """
         try:
-            caps = await self.video_capabilities_for_model(provider_id, model_id, project)
+            caps = await self.video_capabilities_for_model(provider_id, model_id, project, episode)
         except Exception as exc:
             logger.info(
                 "视频能力解析失败（%s/%s），计价 generate_audio 降级到 provider 级规则与请求值：%s",
@@ -1200,18 +1234,20 @@ class ConfigResolver:
         svc: ConfigService,
         session: AsyncSession,
         project_name: str | None,
+        episode: int | None = None,
     ) -> dict:
         """按两步解析：先选 model，再读 model 能力。"""
         project = get_project_manager().load_project(project_name) if project_name else None
-        return await self._resolve_video_capabilities_from_project(svc, session, project)
+        return await self._resolve_video_capabilities_from_project(svc, session, project, episode)
 
     async def _resolve_video_capabilities_from_project(
         self,
         svc: ConfigService,
         session: AsyncSession,
         project: dict | None,
+        episode: int | None = None,
     ) -> dict:
-        """按项目 generation_mode 定桶解析出会执行的那个模型，再读它的能力。
+        """按生效 generation_mode 定桶解析出会执行的那个模型，再读它的能力。
 
         与执行路径共用 ``_resolve_video_provider_model``（含能力闸），读侧不留第二种口径：切换
         generation_mode 后能力查询随桶变化，模型缺该桶所需能力或引用已失效时报错、不静默换模型
@@ -1220,9 +1256,11 @@ class ConfigResolver:
         只传选择身份：有效身份收敛由 ``_resolve_video_caps_for_model`` 统一做，在此先做一遍会让
         自定义 provider 多跑一轮 model 查询。
         """
-        capability = video_bucket_for_generation_mode(project.get("generation_mode") if project else None)
+        capability = video_bucket_for_generation_mode(caps_generation_mode(project, episode))
         selected = await self._resolve_video_provider_model(svc, session, project, None, capability)
-        return await self._resolve_video_caps_for_model(svc, session, selected.provider_id, selected.model_id, project)
+        return await self._resolve_video_caps_for_model(
+            svc, session, selected.provider_id, selected.model_id, project, episode
+        )
 
     async def _resolve_video_caps_for_model(
         self,
@@ -1231,6 +1269,7 @@ class ConfigResolver:
         provider_id: str,
         model_id: str,
         project: dict | None,
+        episode: int | None = None,
     ) -> dict:
         effective = await self._resolve_effective_video_provider_model(session, ProviderModel(provider_id, model_id))
         provider_id, model_id = effective.provider_id, effective.model_id
@@ -1334,7 +1373,6 @@ class ConfigResolver:
 
         default_duration: int | None = None
         content_mode: str | None = None
-        generation_mode: str | None = None
         if project is not None:
             raw_default = project.get("default_duration")
             if isinstance(raw_default, int):
@@ -1344,9 +1382,7 @@ class ConfigResolver:
             cm = project.get("content_mode")
             if isinstance(cm, str) and cm:
                 content_mode = cm
-            gm = project.get("generation_mode")
-            if isinstance(gm, str) and gm:
-                generation_mode = gm
+        generation_mode = caps_generation_mode(project, episode)
 
         voice_consistency = derive_voice_consistency(
             reference_audio_mode=reference_audio_mode,

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -340,7 +340,7 @@ def derive_voice_consistency(
     generation_mode: str | None,
     has_audio: bool,
 ) -> VoiceConsistency:
-    """三级声音一致性标识派生（native / soft / none），模型能力 × 项目 generation_mode 二维。
+    """三级声音一致性标识派生（native / soft / none），模型能力 × 生效 generation_mode 二维。
 
     全仓库唯一派生点：项目内场景经 `_resolve_video_caps_for_model` 走这里，无项目上下文的
     目录场景由 `server/routers/providers.py` 以 ``generation_mode=None`` 调同一函数，前端不

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -817,14 +817,31 @@ class ProjectManager:
         `episode[-_\\s]*(\\d+)`（支持下划线/空格/连字符分隔）；两者都无则抛 ValueError。
 
         用于替代调用方重复传入 `--episode` CLI 参数造成的错配风险。
+
+        `bool` 是 `int` 的子类，故显式排除：剧本 `episode: true`（脏数据）当作字段缺失走文件名，
+        不静默当成第 1 集。
         """
         ep = script.get("episode")
-        if isinstance(ep, int):
+        if isinstance(ep, int) and not isinstance(ep, bool):
             return ep
         match = re.search(r"episode[-_\s]*(\d+)", script_filename, re.IGNORECASE)
         if match:
             return int(match.group(1))
         raise ValueError(f"无法确定集号：剧本缺少 episode 字段且文件名 {script_filename} 不含 episodeN 模式")
+
+    @staticmethod
+    def resolve_episode_from_script_or_none(script: dict, script_filename: str) -> int | None:
+        """同 `resolve_episode_from_script`，解析不出时返回 None 而非抛错。
+
+        供能力解析用：集号只决定按哪一集的生效 `generation_mode` 取能力，解析不出时回落项目级
+        口径即可，不该让一次能力解析打断整条入队 / 执行链路。与硬口径共用同一份解析，调用方
+        不各写一份「只认剧本字段」的简化版——那会让集号出自文件名的剧本一边按第 N 集入队、
+        一边按项目级口径解析能力。
+        """
+        try:
+            return ProjectManager.resolve_episode_from_script(script, script_filename)
+        except ValueError:
+            return None
 
     def sync_episode_from_script(self, project_name: str, script_filename: str) -> dict:
         """

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -242,7 +242,7 @@ class ScriptGenerator:
         if gen_mode != "reference_video" and self.content_mode != "narration":
             return await self._generate_drama_step2(episode, output_filename, gen_mode=gen_mode)
 
-        caps = await self._fetch_video_capabilities()
+        caps = await self._fetch_video_capabilities(episode)
 
         characters = self.project_json.get("characters")
         characters = characters if isinstance(characters, dict) else {}
@@ -344,7 +344,7 @@ class ScriptGenerator:
         content = self._load_drama_step1_content(episode)
         raw_scenes = content.get("scenes")
         content_scenes: list = raw_scenes if isinstance(raw_scenes, list) else []
-        await self._assert_drama_step1_durations(content_scenes, gen_mode=gen_mode)
+        await self._assert_drama_step1_durations(content_scenes, episode=episode, gen_mode=gen_mode)
 
         logger.info("正在生成第 %d 集剧本（drama step2 视觉层）...", episode)
         result = await self.generator.generate(
@@ -370,7 +370,7 @@ class ScriptGenerator:
         logger.info("剧本已保存至 %s", output_path)
         return output_path
 
-    async def _assert_drama_step1_durations(self, content_scenes: list, *, gen_mode: str) -> None:
+    async def _assert_drama_step1_durations(self, content_scenes: list, *, episode: int, gen_mode: str) -> None:
         """校验 drama step1 已定场景时长在当前能力集合内，越界 fail-loud。
 
         与 narration（``_load_narration_step1``）、reference_video（``_load_reference_step1``）
@@ -384,7 +384,7 @@ class ScriptGenerator:
         ``null`` 同取该字段的声明默认值——不填不代表不校验，落盘时补的正是这个默认值。归一化
         失败（如 ``"abc"``）不在此报错，交给落盘前的静态校验统一 fail-loud。
         """
-        supported = self._resolve_supported_durations(await self._fetch_video_capabilities(), gen_mode=gen_mode)
+        supported = self._resolve_supported_durations(await self._fetch_video_capabilities(episode), gen_mode=gen_mode)
         allowed = {int(d) for d in supported}
         seen: set[int] = set()
         for scene in content_scenes:
@@ -530,7 +530,7 @@ class ScriptGenerator:
             supported = None
             schema: type = build_ad_reference_episode_script_model()
         else:
-            caps = await self._fetch_video_capabilities()
+            caps = await self._fetch_video_capabilities(episode)
             supported = self._resolve_supported_durations(caps, gen_mode=gen_mode)
             schema = build_episode_script_model("ad", supported)
         return self._build_ad_prompt(episode, gen_mode, supported), schema
@@ -599,7 +599,7 @@ class ScriptGenerator:
             content_scenes: list = raw_scenes if isinstance(raw_scenes, list) else []
             return self._build_drama_step2_prompt(content_scenes, episode)
 
-        caps = await self._fetch_video_capabilities()
+        caps = await self._fetch_video_capabilities(episode)
         characters = self.project_json.get("characters")
         characters = characters if isinstance(characters, dict) else {}
         scenes = self.project_json.get("scenes")
@@ -641,12 +641,13 @@ class ScriptGenerator:
             target_language=self.project_json.get("source_language") or "中文",
         )
 
-    async def _fetch_video_capabilities(self) -> dict | None:
+    async def _fetch_video_capabilities(self, episode: int | None = None) -> dict | None:
         """从 ConfigResolver 解析视频模型能力；失败时返 None，由 _resolve_* fallback 到 project.json 直读。
 
         使用 `video_capabilities_for_project` 传入已加载的 project.json，不再按 `self.project_path.name`
         重新全局加载——避免 ScriptGenerator 在非标准路径（如测试 tmp_path）实例化时目录名与
-        全局项目碰撞读到错误能力。
+        全局项目碰撞读到错误能力。``episode`` 给出集号时按该集生效 ``generation_mode`` 定桶，
+        与 ``_resolve_supported_durations`` 收窄所用的 ``gen_mode`` 同口径。
 
         宽松捕获：除 ValueError 外，DB 未 migration / 连接失败等 SQLAlchemy 异常也走 fallback，
         保证在缺能力元数据的环境（如裸 CI 测试容器）中 generate() 仍能跑通。
@@ -657,7 +658,7 @@ class ScriptGenerator:
         """
         resolver = ConfigResolver(async_session_factory)
         try:
-            return await resolver.video_capabilities_for_project(self.project_json)
+            return await resolver.video_capabilities_for_project(self.project_json, episode)
         except VideoBucketCapabilityError:
             raise
         except (ValueError, SQLAlchemyError) as exc:
@@ -1206,7 +1207,7 @@ class ScriptGenerator:
                 f"（{quarantine_path(self.project_path, episode, QUARANTINE_KIND_STEP2)} 缺失或内容不是合法信封）"
             )
 
-        caps = await self._fetch_video_capabilities()
+        caps = await self._fetch_video_capabilities(episode)
         step1_units = self._load_reference_step1(episode, self._resolve_raw_supported_durations(caps))
         # 与产出路径同一份 step1 预判：隔离期间 Web 端可能改过 step1（编辑器对人写正文只出
         # warning），不复判就会让改短时长后念不完的台词、或未登记的 @[名称] 借晋升一路落盘。

--- a/server/agent_runtime/sdk_tools/_context.py
+++ b/server/agent_runtime/sdk_tools/_context.py
@@ -36,16 +36,19 @@ def tool_error(name: str, exc: BaseException, log: list[str] | None = None) -> d
     return {"content": [{"type": "text", "text": text}], "is_error": True}
 
 
-async def resolve_video_caps(project: dict[str, Any]) -> dict[str, Any]:
+async def resolve_video_caps(project: dict[str, Any], episode: int | None = None) -> dict[str, Any]:
     """Resolve the full video capability dict for an MCP tool call.
 
     Single source of truth for video model capability lookup across SDK MCP
     tools. Callers that only need durations should use :func:`fetch_video_caps`;
     this variant exposes the model identity so the caller can evaluate the
     duration linkage constraints declared on it.
+
+    ``episode`` 给出集号时按该集生效 ``generation_mode`` 解析——生成模式可被单集覆盖，
+    智能体拿到的能力须与该集执行层同口径。
     """
     resolver = ConfigResolver(async_session_factory)
-    return await resolver.video_capabilities_for_project(project)
+    return await resolver.video_capabilities_for_project(project, episode)
 
 
 def constrained_caps_durations(
@@ -100,7 +103,7 @@ def reference_unit_duration_tiers(
 
 
 async def fetch_video_caps(
-    project: dict[str, Any], *, generation_mode: str | None = None
+    project: dict[str, Any], *, episode: int | None = None, generation_mode: str | None = None
 ) -> tuple[int | None, list[int]]:
     """Resolve ``(default_duration, supported_durations)`` for an MCP tool call.
 
@@ -110,7 +113,7 @@ async def fetch_video_caps(
     Callers decide whether an empty result is a hard error (video generation) or
     a soft fallback (script normalization).
     """
-    caps = await resolve_video_caps(project)
+    caps = await resolve_video_caps(project, episode)
     durations = [int(d) for d in caps.get("supported_durations") or []]
     durations = constrained_caps_durations(project, caps, durations, generation_mode=generation_mode)
     default = caps.get("default_duration")

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -84,6 +84,7 @@ def _duration_confirmation_response(pending: DurationConfirmationPending, log: l
 async def _pending_duration_confirmations(
     *,
     project: dict[str, Any],
+    episode: int | None,
     units: list[dict[str, Any]],
     skip_ids: set[str],
     spec_for: Callable[[dict[str, Any]], TaskSpec],
@@ -115,7 +116,7 @@ async def _pending_duration_confirmations(
         except ValueError:
             continue
         if ctx is None:
-            ctx = await resolve_project_duration_context(project)
+            ctx = await resolve_project_duration_context(project, episode)
         try:
             slot = precheck_unit(ctx, unit, ad_shots)
         except ValueError:
@@ -163,16 +164,36 @@ def _get_video_prompt(
     return prompt
 
 
-async def _resolve_voice_characters(ctx: ToolContext, content_mode: str) -> dict[str, Any] | None:
+def _script_episode(script: dict[str, Any]) -> int | None:
+    """剧本自报的集号，供能力解析按该集生效 ``generation_mode`` 取值。
+
+    缺 ``episode`` 字段（脏数据）时返回 None，能力回落到项目级口径。
+    """
+    episode = script.get("episode")
+    return episode if isinstance(episode, int) else None
+
+
+def _script_filename_episode(script_filename: str) -> int | None:
+    """剧本尚未读入时按文件名解析集号，解析不出返回 None。"""
+    try:
+        return ProjectManager.resolve_episode_from_script({}, script_filename)
+    except ValueError:
+        return None
+
+
+async def _resolve_voice_characters(
+    ctx: ToolContext, content_mode: str, episode: int | None = None
+) -> dict[str, Any] | None:
     """供 Voice_Profiles 注入的角色资产；``None`` 表示不注入。
 
-    非 drama 直接返回 None（无需为 narration/ad 项目多付一次项目视频能力解析），drama 再按
-    声音一致性档位排除 C 类（真无声）模型。
+    非 drama 直接返回 None（无需为 narration/ad 项目多付一次视频能力解析），drama 再按
+    声音一致性档位排除 C 类（真无声）模型。``episode`` 给出集号时按该集生效
+    ``generation_mode`` 解析声音一致性。
     """
     if content_mode != "drama":
         return None
     project = ctx.pm.load_project(ctx.project_name)
-    if await resolve_project_voice_consistency(project) == "none":
+    if await resolve_project_voice_consistency(project, episode) == "none":
         return None
     return project.get("characters") or {}
 
@@ -519,6 +540,7 @@ async def _generate_reference_units(
     if not confirm_duration:
         pending = await _pending_duration_confirmations(
             project=project,
+            episode=episode,
             units=units,
             skip_ids=set(already_done),
             spec_for=spec_for,
@@ -603,7 +625,7 @@ async def _run_ad_reference_episode(
     的 unit 保留 generated_assets，已有产物经磁盘扫描跳过重复入队。
     """
     project = ctx.pm.load_project(ctx.project_name)
-    max_unit_duration = await resolve_max_unit_duration(project)
+    max_unit_duration = await resolve_max_unit_duration(project, _script_filename_episode(script_filename))
 
     def _sync() -> tuple[dict[str, Any], list[dict[str, Any]], int]:
         with ctx.pm.locked_script(ctx.project_name, script_filename) as script:
@@ -711,7 +733,7 @@ def generate_video_episode_tool(ctx: ToolContext):
             videos_dir = project_dir / "videos"
             videos_dir.mkdir(parents=True, exist_ok=True)
             ordered_paths, already_done, completed = _scan_completed_items(items, id_field, completed, videos_dir)
-            voice_characters = await _resolve_voice_characters(ctx, content_mode)
+            voice_characters = await _resolve_voice_characters(ctx, content_mode, _script_episode(script))
             specs, order_map = _build_video_specs(
                 items=items,
                 id_field=id_field,
@@ -821,7 +843,7 @@ def generate_video_scene_tool(ctx: ToolContext):
                 raise FileNotFoundError(f"分镜图不存在: {storyboard_path}")
 
             content_mode = resolve_content_mode(script, ctx.pm.load_project(ctx.project_name))
-            voice_characters = await _resolve_voice_characters(ctx, content_mode)
+            voice_characters = await _resolve_voice_characters(ctx, content_mode, _script_episode(script))
             prompt = _get_video_prompt(item, content_mode=content_mode, voice_characters=voice_characters)
             # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；
             # 原样透传调用方显式指定的值，不在入队侧做 int() 截断式归一化（否则会把
@@ -906,7 +928,7 @@ def generate_video_all_tool(ctx: ToolContext):
             if not pending:
                 return {"content": [{"type": "text", "text": "✨ 所有场景/片段的视频都已生成"}]}
 
-            voice_characters = await _resolve_voice_characters(ctx, content_mode)
+            voice_characters = await _resolve_voice_characters(ctx, content_mode, _script_episode(script))
             specs, _order_map = _build_video_specs(
                 items=pending,
                 id_field=id_field,
@@ -1042,7 +1064,7 @@ def generate_video_selected_tool(ctx: ToolContext):
             videos_dir = project_dir / "videos"
             videos_dir.mkdir(parents=True, exist_ok=True)
             ordered_paths, already_done, completed = _scan_completed_items(selected, id_field, completed, videos_dir)
-            voice_characters = await _resolve_voice_characters(ctx, content_mode)
+            voice_characters = await _resolve_voice_characters(ctx, content_mode, _script_episode(script))
             specs, order_map = _build_video_specs(
                 items=selected,
                 id_field=id_field,

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -164,13 +164,21 @@ def _get_video_prompt(
     return prompt
 
 
-def _script_episode(script: dict[str, Any]) -> int | None:
-    """剧本自报的集号，供能力解析按该集生效 ``generation_mode`` 取值。
+def _script_episode(script: dict[str, Any], script_filename: str) -> int | None:
+    """剧本归属的集号，供能力解析按该集生效 ``generation_mode`` 取值。
 
-    缺 ``episode`` 字段（脏数据）时返回 None，能力回落到项目级口径。
+    与入队 / checkpoint / UI header 用的 ``resolve_episode_from_script`` 是同一份解析（剧本
+    ``episode`` 字段优先，缺则文件名 ``episodeN``），本文件不留第二份集号口径——只靠剧本字段
+    的话，集号出自文件名的剧本会一边按第 N 集入队、一边按项目级口径解析能力，被单集覆盖的
+    那一集又静默丢回项目级模式。
+
+    唯一差别是集号确实解析不出（既无字段也无文件名模式）时返回 None 让能力回落项目级，而不是
+    让一次能力解析把整个入队打断。
     """
-    episode = script.get("episode")
-    return episode if isinstance(episode, int) else None
+    try:
+        return ProjectManager.resolve_episode_from_script(script, script_filename)
+    except ValueError:
+        return None
 
 
 async def _resolve_voice_characters(
@@ -730,7 +738,9 @@ def generate_video_episode_tool(ctx: ToolContext):
             videos_dir = project_dir / "videos"
             videos_dir.mkdir(parents=True, exist_ok=True)
             ordered_paths, already_done, completed = _scan_completed_items(items, id_field, completed, videos_dir)
-            voice_characters = await _resolve_voice_characters(ctx, content_mode, _script_episode(script))
+            voice_characters = await _resolve_voice_characters(
+                ctx, content_mode, _script_episode(script, script_filename)
+            )
             specs, order_map = _build_video_specs(
                 items=items,
                 id_field=id_field,
@@ -840,7 +850,9 @@ def generate_video_scene_tool(ctx: ToolContext):
                 raise FileNotFoundError(f"分镜图不存在: {storyboard_path}")
 
             content_mode = resolve_content_mode(script, ctx.pm.load_project(ctx.project_name))
-            voice_characters = await _resolve_voice_characters(ctx, content_mode, _script_episode(script))
+            voice_characters = await _resolve_voice_characters(
+                ctx, content_mode, _script_episode(script, script_filename)
+            )
             prompt = _get_video_prompt(item, content_mode=content_mode, voice_characters=voice_characters)
             # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；
             # 原样透传调用方显式指定的值，不在入队侧做 int() 截断式归一化（否则会把
@@ -925,7 +937,9 @@ def generate_video_all_tool(ctx: ToolContext):
             if not pending:
                 return {"content": [{"type": "text", "text": "✨ 所有场景/片段的视频都已生成"}]}
 
-            voice_characters = await _resolve_voice_characters(ctx, content_mode, _script_episode(script))
+            voice_characters = await _resolve_voice_characters(
+                ctx, content_mode, _script_episode(script, script_filename)
+            )
             specs, _order_map = _build_video_specs(
                 items=pending,
                 id_field=id_field,
@@ -1061,7 +1075,9 @@ def generate_video_selected_tool(ctx: ToolContext):
             videos_dir = project_dir / "videos"
             videos_dir.mkdir(parents=True, exist_ok=True)
             ordered_paths, already_done, completed = _scan_completed_items(selected, id_field, completed, videos_dir)
-            voice_characters = await _resolve_voice_characters(ctx, content_mode, _script_episode(script))
+            voice_characters = await _resolve_voice_characters(
+                ctx, content_mode, _script_episode(script, script_filename)
+            )
             specs, order_map = _build_video_specs(
                 items=selected,
                 id_field=id_field,

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -173,14 +173,6 @@ def _script_episode(script: dict[str, Any]) -> int | None:
     return episode if isinstance(episode, int) else None
 
 
-def _script_filename_episode(script_filename: str) -> int | None:
-    """剧本尚未读入时按文件名解析集号，解析不出返回 None。"""
-    try:
-        return ProjectManager.resolve_episode_from_script({}, script_filename)
-    except ValueError:
-        return None
-
-
 async def _resolve_voice_characters(
     ctx: ToolContext, content_mode: str, episode: int | None = None
 ) -> dict[str, Any] | None:
@@ -625,7 +617,12 @@ async def _run_ad_reference_episode(
     的 unit 保留 generated_assets，已有产物经磁盘扫描跳过重复入队。
     """
     project = ctx.pm.load_project(ctx.project_name)
-    max_unit_duration = await resolve_max_unit_duration(project, _script_filename_episode(script_filename))
+    # 集号取剧本自报字段（缺失才回落文件名），与锁内 `_sync` 是同一次 `resolve_episode_from_script`：
+    # 能力解析与分组派生因此不会各拿一个集号，覆盖集的能力不会静默回落项目级。
+    episode_for_caps = ProjectManager.resolve_episode_from_script(
+        ctx.pm.load_script(ctx.project_name, script_filename), script_filename
+    )
+    max_unit_duration = await resolve_max_unit_duration(project, episode_for_caps)
 
     def _sync() -> tuple[dict[str, Any], list[dict[str, Any]], int]:
         with ctx.pm.locked_script(ctx.project_name, script_filename) as script:

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -164,23 +164,6 @@ def _get_video_prompt(
     return prompt
 
 
-def _script_episode(script: dict[str, Any], script_filename: str) -> int | None:
-    """剧本归属的集号，供能力解析按该集生效 ``generation_mode`` 取值。
-
-    与入队 / checkpoint / UI header 用的 ``resolve_episode_from_script`` 是同一份解析（剧本
-    ``episode`` 字段优先，缺则文件名 ``episodeN``），本文件不留第二份集号口径——只靠剧本字段
-    的话，集号出自文件名的剧本会一边按第 N 集入队、一边按项目级口径解析能力，被单集覆盖的
-    那一集又静默丢回项目级模式。
-
-    唯一差别是集号确实解析不出（既无字段也无文件名模式）时返回 None 让能力回落项目级，而不是
-    让一次能力解析把整个入队打断。
-    """
-    try:
-        return ProjectManager.resolve_episode_from_script(script, script_filename)
-    except ValueError:
-        return None
-
-
 async def _resolve_voice_characters(
     ctx: ToolContext, content_mode: str, episode: int | None = None
 ) -> dict[str, Any] | None:
@@ -739,7 +722,7 @@ def generate_video_episode_tool(ctx: ToolContext):
             videos_dir.mkdir(parents=True, exist_ok=True)
             ordered_paths, already_done, completed = _scan_completed_items(items, id_field, completed, videos_dir)
             voice_characters = await _resolve_voice_characters(
-                ctx, content_mode, _script_episode(script, script_filename)
+                ctx, content_mode, ProjectManager.resolve_episode_from_script_or_none(script, script_filename)
             )
             specs, order_map = _build_video_specs(
                 items=items,
@@ -851,7 +834,7 @@ def generate_video_scene_tool(ctx: ToolContext):
 
             content_mode = resolve_content_mode(script, ctx.pm.load_project(ctx.project_name))
             voice_characters = await _resolve_voice_characters(
-                ctx, content_mode, _script_episode(script, script_filename)
+                ctx, content_mode, ProjectManager.resolve_episode_from_script_or_none(script, script_filename)
             )
             prompt = _get_video_prompt(item, content_mode=content_mode, voice_characters=voice_characters)
             # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；
@@ -938,7 +921,7 @@ def generate_video_all_tool(ctx: ToolContext):
                 return {"content": [{"type": "text", "text": "✨ 所有场景/片段的视频都已生成"}]}
 
             voice_characters = await _resolve_voice_characters(
-                ctx, content_mode, _script_episode(script, script_filename)
+                ctx, content_mode, ProjectManager.resolve_episode_from_script_or_none(script, script_filename)
             )
             specs, _order_map = _build_video_specs(
                 items=pending,
@@ -1076,7 +1059,7 @@ def generate_video_selected_tool(ctx: ToolContext):
             videos_dir.mkdir(parents=True, exist_ok=True)
             ordered_paths, already_done, completed = _scan_completed_items(selected, id_field, completed, videos_dir)
             voice_characters = await _resolve_voice_characters(
-                ctx, content_mode, _script_episode(script, script_filename)
+                ctx, content_mode, ProjectManager.resolve_episode_from_script_or_none(script, script_filename)
             )
             specs, order_map = _build_video_specs(
                 items=selected,

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -156,9 +156,9 @@ def _load_novel_source(project_path: Path, source: str | None) -> str:
 # ---------------------------------------------------------------------------
 
 
-async def _resolve_video_capabilities(project_name: str) -> dict[str, Any]:
+async def _resolve_video_capabilities(project_name: str, episode: int | None) -> dict[str, Any]:
     resolver = ConfigResolver(async_session_factory)
-    return await resolver.video_capabilities(project_name)
+    return await resolver.video_capabilities(project_name, episode)
 
 
 def _annotate_reference_unit_tiers(payload: dict[str, Any], project: dict[str, Any]) -> None:
@@ -186,13 +186,24 @@ def _annotate_reference_unit_tiers(payload: dict[str, Any], project: dict[str, A
 def get_video_capabilities_tool(ctx: ToolContext):
     @tool(
         "get_video_capabilities",
-        "查当前项目的视频模型能力（model 粒度）+ 用户项目偏好。返回 JSON；"
-        "参考生视频项目另含 reference_unit_durations（按 unit 有无 @ 引用分开的两套生效档位）。",
-        {"type": "object", "properties": {}},
+        "查视频模型能力（model 粒度）+ 用户项目偏好。返回 JSON；"
+        "参考生视频项目另含 reference_unit_durations（按 unit 有无 @ 引用分开的两套生效档位）。"
+        "生成模式可被单集覆盖，为某一集取能力时必须带 episode，否则拿到的是项目级口径。",
+        {
+            "type": "object",
+            "properties": {
+                "episode": {
+                    "type": "integer",
+                    "description": "剧集编号；省略则按项目级生成模式解析",
+                }
+            },
+        },
     )
-    async def _handler(_args: dict[str, Any]) -> dict[str, Any]:
+    async def _handler(args: dict[str, Any]) -> dict[str, Any]:
         try:
-            payload = await _resolve_video_capabilities(ctx.project_name)
+            raw_episode = args.get("episode")
+            episode = int(raw_episode) if raw_episode is not None else None
+            payload = await _resolve_video_capabilities(ctx.project_name, episode)
             _annotate_reference_unit_tiers(payload, ctx.pm.load_project(ctx.project_name))
             return {"content": [{"type": "text", "text": json.dumps(payload, ensure_ascii=False, indent=2)}]}
         except FileNotFoundError as exc:
@@ -412,7 +423,7 @@ def confirm_script_review_tool(ctx: ToolContext):
 # ---------------------------------------------------------------------------
 
 
-async def _fetch_caps_with_fallback(project: dict[str, Any]) -> tuple[int | None, list[int]]:
+async def _fetch_caps_with_fallback(project: dict[str, Any], episode: int) -> tuple[int | None, list[int]]:
     """Script normalization is best-effort: prompt生成 不该被能力查询失败堵住。
 
     Soft-fallbacks to ``duration_presets.DEFAULT_FALLBACK`` so the LLM still
@@ -429,7 +440,7 @@ async def _fetch_caps_with_fallback(project: dict[str, Any]) -> tuple[int | None
     越界默认时长」变成整个工具的硬失败。与 ``_fetch_reference_caps_with_fallback`` 同口径。
     """
     try:
-        default_int, durations = await fetch_video_caps(project, generation_mode=None)
+        default_int, durations = await fetch_video_caps(project, episode=episode, generation_mode=None)
     except (FileNotFoundError, ValueError) as exc:
         logger.info("video_capabilities 不可解析，使用 fallback %s：%s", DEFAULT_FALLBACK, exc)
         return None, list(DEFAULT_FALLBACK)
@@ -477,7 +488,7 @@ def normalize_drama_script_tool(ctx: ToolContext):
             except ValueError as exc:
                 return {"content": [{"type": "text", "text": f"❌ {exc}"}], "is_error": True}
 
-            default_duration, supported_durations = await _fetch_caps_with_fallback(project)
+            default_duration, supported_durations = await _fetch_caps_with_fallback(project, episode)
             # 分集大纲（故事节点 / 钩子）随内容抽取前移到 step1，驱动内容覆盖与末场落地（见 ADR 0041）。
             episode_outline, next_episode_outline = episode_outline_context(project, episode)
             prompt = build_normalize_prompt(
@@ -585,7 +596,7 @@ class ReferenceSplitCaps(NamedTuple):
         return self.reference_durations if has_references else self.text_durations
 
 
-async def _fetch_reference_caps_with_fallback(project: dict[str, Any]) -> ReferenceSplitCaps:
+async def _fetch_reference_caps_with_fallback(project: dict[str, Any], episode: int) -> ReferenceSplitCaps:
     """解析 rv 拆分所需的视频能力（见 ``ReferenceSplitCaps``）。
 
     与 ``_fetch_caps_with_fallback`` 同口径 best-effort：resolver 故障时回退
@@ -603,7 +614,7 @@ async def _fetch_reference_caps_with_fallback(project: dict[str, Any]) -> Refere
     ``default_duration`` 非并集成员（用户配置漂移）按 None 处理，避免 prompt 自相矛盾。
     """
     try:
-        caps = await resolve_video_caps(project)
+        caps = await resolve_video_caps(project, episode)
     except Exception as exc:  # noqa: BLE001
         logger.warning("video_capabilities 查询异常，使用 fallback %s：%s", DEFAULT_FALLBACK, exc)
         caps = {}
@@ -837,7 +848,7 @@ async def revalidate_reference_step1_draft(
     # 事件循环——晋升工具走的是独立会话线程不敏感，但 web 审核 gate 的读时重算（同一份代码）
     # 在请求协程里跑，卸到线程避免拖慢并发的其它请求。
     novel_text = await asyncio.to_thread(_load_novel_source, project_path, draft.meta["source"])
-    split_caps = await _fetch_reference_caps_with_fallback(project)
+    split_caps = await _fetch_reference_caps_with_fallback(project, episode)
 
     # 手改过的草稿先过产出时那份 schema：拆分侧由 response_schema 与 _parse_step1_json 卡住时长
     # 枚举与字段非空，晋升侧漏掉这一层的话，把 duration_seconds 改成非档位值、或整个删掉（收成
@@ -982,7 +993,7 @@ def split_reference_video_units_tool(ctx: ToolContext):
             props = project.get("props")
             props = props if isinstance(props, dict) else {}
 
-            split_caps = await _fetch_reference_caps_with_fallback(project)
+            split_caps = await _fetch_reference_caps_with_fallback(project, episode)
             episode_outline, next_episode_outline = episode_outline_context(project, episode)
             prompt = build_reference_units_split_prompt(
                 novel_text=novel_text,
@@ -1288,7 +1299,7 @@ def split_narration_segments_tool(ctx: ToolContext):
 
             # narration 仅需 (default_duration, supported_durations)：无 unit 总时长 / references 概念，
             # 复用与 drama normalize 同口径的 best-effort 能力查询（resolver 故障软回退 [4,6,8]）。
-            default_duration, supported_durations = await _fetch_caps_with_fallback(project)
+            default_duration, supported_durations = await _fetch_caps_with_fallback(project, episode)
             prompt = build_narration_split_prompt(
                 novel_text=novel_text,
                 project_overview=project.get("overview", {}),

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -573,6 +573,7 @@ async def get_video_capabilities(
     name: str,
     _t: Translator,
     video_backend: Annotated[str | None, Query()] = None,
+    episode: Annotated[int | None, Query()] = None,
 ):
     """解析当前项目视频模型能力 + 用户项目偏好。
 
@@ -581,9 +582,12 @@ async def get_video_capabilities(
     所有 generation_mode（storyboard/grid/reference_video）都可复用。
 
     `video_backend`（"provider/model"）用于设置表单里尚未保存的候选模型：不带该参数时按已
-    落盘配置解析，带上则按候选模型 × 本项目的 generation_mode 解析，使 voice_consistency 等
+    落盘配置解析，带上则按候选模型 × 本项目的生效 generation_mode 解析，使 voice_consistency 等
     二维派生值对应用户当前选中的模型而非上一次保存的模型。裸 provider（无 "/"）按其 registry
     默认视频 model 补全，与 project.json 存量裸 provider 覆盖同口径（见 `_parse_project_provider`）。
+
+    `episode` 用于按集查看的界面：生成模式可被单集覆盖，带上集号时能力按该集生效模式解析，
+    与执行层同口径；不带则只解析到项目级（设置页等无集号上下文的调用）。
     """
     resolver = ConfigResolver(async_session_factory)
     try:
@@ -594,8 +598,8 @@ async def get_video_capabilities(
             if not provider_id or not model_id:
                 raise BadRequestError("video_backend_malformed", value=video_backend)
             project = get_project_manager().load_project(name)
-            return await resolver.video_capabilities_for_model(provider_id, model_id, project)
-        return await resolver.video_capabilities(name)
+            return await resolver.video_capabilities_for_model(provider_id, model_id, project, episode)
+        return await resolver.video_capabilities(name, episode)
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=name) from exc
     except VideoBucketCapabilityError as exc:

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -252,7 +252,7 @@ async def derive_units(
     project, _script, _sf = _load_episode_script(project_name, episode, _t)
     _require_ad_project(project, True, _t)
     # 供应商时长上限在锁外解析（异步 I/O 不进项目锁临界区）
-    max_unit_duration = await resolve_max_unit_duration(project)
+    max_unit_duration = await resolve_max_unit_duration(project, episode)
 
     with _locked_episode_script(project_name, _episode_script_resolver(episode, _t, require_ad=True), _t) as script:
         units = sync_ad_reference_units(script, episode=episode, max_unit_duration=max_unit_duration)
@@ -273,7 +273,7 @@ async def add_unit(
     if duration_seconds is None:
         project, _script, _sf = _load_episode_script(project_name, episode, _t)
         duration_seconds = default_unit_duration(
-            await resolve_project_duration_context(project), project, with_references=bool(refs)
+            await resolve_project_duration_context(project, episode), project, with_references=bool(refs)
         )
 
     with _locked_episode_script(
@@ -430,7 +430,7 @@ async def precheck_unit_duration(
         unit = _find_unit(script, unit_id, _t)
         ad_shots = None
 
-    slot = precheck_unit(await resolve_project_duration_context(project), unit, ad_shots)
+    slot = precheck_unit(await resolve_project_duration_context(project, episode), unit, ad_shots)
     return {
         "needs_confirmation": slot.needs_confirmation,
         "script_duration": slot.total_seconds,
@@ -449,11 +449,11 @@ async def preview_script(
     """分镜文稿的读时派生预览：shots / references / utterances + 降级可见性 warning。
 
     只读、不落盘——文稿是唯一真相，utterances 与 references 都是机械派生物。声音相关的
-    三条 warning 依赖项目当前视频后端的能力（``voice_consistency`` 与参考音频段数上限），
+    三条 warning 依赖该集视频后端的能力（``voice_consistency`` 与参考音频段数上限），
     与执行层同一份解析出口；能力解析失败时按 ``soft`` 降级，只是少发这几条提示。
     """
     project, _script, _sf = _load_episode_script(project_name, episode, _t)
-    caps = await project_video_caps(project, degraded_to="解析预览不发声音相关提示")
+    caps = await project_video_caps(project, degraded_to="解析预览不发声音相关提示", episode=episode)
     preview = build_script_preview(
         req.prompt,
         project,

--- a/server/services/generation_context.py
+++ b/server/services/generation_context.py
@@ -278,6 +278,7 @@ async def resolve_generation_context(
     *,
     project: dict,
     user_id: str = DEFAULT_USER_ID,
+    episode: int | None = None,
     image: ImageLaneRequest | None = None,
     video: VideoLaneRequest | None = None,
     audio: AudioLaneRequest | None = None,
@@ -287,6 +288,10 @@ async def resolve_generation_context(
     lane 传即声明、None 跳过，任务只为用到的 lane 付出配置要求与构造成本。任一声明 lane
     的解析或构造失败即原样上抛、整次调用失败——无部分结果、无跨 provider 兜底；仅能力
     查询失败降级空值放行。``project`` 是调用方已加载的项目快照，本函数不读盘。
+
+    ``episode`` 传本次任务所属集号时，video lane 的能力按该集生效 ``generation_mode`` 解析
+    （见 ``lib.config.resolver.caps_generation_mode``）：项目级模式被单集覆盖时，声音一致性
+    等二维派生值跟着该集走，而不是拿项目级口径去判定这一集。
     """
     from lib.db import async_session_factory
 
@@ -333,7 +338,7 @@ async def resolve_generation_context(
             max_reference_audio_count = 0
             reference_audio_per_image = False
             try:
-                caps = await r.video_capabilities_for_model(resolved.provider_id, actual_model, project)
+                caps = await r.video_capabilities_for_model(resolved.provider_id, actual_model, project, episode)
                 supported_durations = tuple(int(d) for d in caps.get("supported_durations") or [])
                 max_duration = caps.get("max_duration")
                 max_reference_images = caps.get("max_reference_images")

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -22,7 +22,7 @@ from lib.config.resolver import constrain_durations
 from lib.db.base import DEFAULT_USER_ID
 from lib.path_safety import safe_exists, safe_join, try_safe_join
 from lib.project_change_hints import emit_project_change_batch, project_change_source
-from lib.project_manager import get_project_manager
+from lib.project_manager import ProjectManager, get_project_manager
 from lib.prompt_builders import (
     append_product_fidelity_tail,
     build_character_prompt,
@@ -896,15 +896,14 @@ async def execute_video_task(
         _items, _id_field, _, _, _ = get_storyboard_items(_script)
         _resolved = find_storyboard_item(_items, _id_field, resource_id)
         _item = _resolved[0] if _resolved else {}
-        # 集号供能力解析按该集生效 generation_mode 取值；剧本缺 episode 字段（脏数据）时
-        # 传 None，能力回落到项目级口径。
-        _episode = _script.get("episode")
+        # 集号供能力解析按该集生效 generation_mode 取值，与入队侧共用同一份解析（剧本 episode
+        # 字段优先，缺则文件名 episodeN）；两者都解析不出时传 None，能力回落到项目级口径。
         return (
             _project,
             _project_path,
             _item,
             resolve_content_mode(_script, _project),
-            _episode if isinstance(_episode, int) else None,
+            ProjectManager.resolve_episode_from_script_or_none(_script, script_file),
         )
 
     project, project_path, item, content_mode, episode = await asyncio.to_thread(_load)

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -896,14 +896,24 @@ async def execute_video_task(
         _items, _id_field, _, _, _ = get_storyboard_items(_script)
         _resolved = find_storyboard_item(_items, _id_field, resource_id)
         _item = _resolved[0] if _resolved else {}
-        return _project, _project_path, _item, resolve_content_mode(_script, _project)
+        # 集号供能力解析按该集生效 generation_mode 取值；剧本缺 episode 字段（脏数据）时
+        # 传 None，能力回落到项目级口径。
+        _episode = _script.get("episode")
+        return (
+            _project,
+            _project_path,
+            _item,
+            resolve_content_mode(_script, _project),
+            _episode if isinstance(_episode, int) else None,
+        )
 
-    project, project_path, item, content_mode = await asyncio.to_thread(_load)
+    project, project_path, item, content_mode, episode = await asyncio.to_thread(_load)
     ctx = await resolve_generation_context(
         project_name,
         payload,
         project=project,
         user_id=user_id,
+        episode=episode,
         video=VideoLaneRequest(capability="i2v"),
     )
     generator = ctx.generator

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -18,6 +18,7 @@ from lib.db import async_session_factory
 from lib.db.base import DEFAULT_USER_ID
 from lib.generation_queue import get_generation_queue
 from lib.path_safety import safe_exists
+from lib.project_manager import ProjectManager
 from lib.prompt_builders import append_product_fidelity_tail
 from lib.reference_video import assemble_shots_text, assemble_shots_text_for_render
 from lib.reference_video.ad_units import resolve_ad_unit_shots
@@ -539,10 +540,10 @@ async def execute_reference_video_task(
             raise ValueError(f"unit not found: {resource_id}")
         # 索引悬空（镜头被删/改 ID 后未重新派生）在此 fail-loud，提示重新派生
         ad_shots = resolve_ad_unit_shots(script, unit) if is_ad else None
-        # 集号供能力解析按该集生效 generation_mode 取值；剧本缺 episode 字段（脏数据）时
-        # 传 None，能力回落到项目级口径。
-        script_episode = script.get("episode")
-        return project, project_path, unit, ad_shots, script_episode if isinstance(script_episode, int) else None
+        # 集号供能力解析按该集生效 generation_mode 取值，与入队侧共用同一份解析（剧本 episode
+        # 字段优先，缺则文件名 episodeN）；两者都解析不出时传 None，能力回落到项目级口径。
+        script_episode = ProjectManager.resolve_episode_from_script_or_none(script, script_file)
+        return project, project_path, unit, ad_shots, script_episode
 
     project, project_path, unit, ad_shots, episode = await asyncio.to_thread(_load)
     is_ad = ad_shots is not None

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -254,14 +254,17 @@ class ProjectDurationContext:
     max_duration: int | None = None
 
 
-async def resolve_project_duration_context(project: dict) -> ProjectDurationContext:
-    """一次性解析项目视频能力（档位全集 + 单次生成时长上限 + 分辨率 + provider/model 身份）。
+async def resolve_project_duration_context(project: dict, episode: int | None = None) -> ProjectDurationContext:
+    """一次性解析视频能力（档位全集 + 单次生成时长上限 + 分辨率 + provider/model 身份）。
 
     解析失败按空档位处理（沿用现状放行，不弹确认）；分辨率仅在档位非空时才解析，
     空档位下分辨率约束无意义。``max_duration`` 与 :func:`resolve_max_unit_duration`
     取自同一份能力解析结果，供需要现推分组的调用方复用而不再触发一次 IO。
+
+    ``episode`` 给出集号时按该集生效 ``generation_mode`` 定桶：项目层仍是分镜、该集覆盖为
+    参考生视频时，档位与分辨率取的才是这集实际会执行的那个模型。
     """
-    caps = await project_video_caps(project, degraded_to="时长取档不施加档位约束")
+    caps = await project_video_caps(project, degraded_to="时长取档不施加档位约束", episode=episode)
     durations = tuple(int(d) for d in caps.get("supported_durations") or [])
     provider_id = str(caps.get("provider_id") or "")
     model = caps.get("model")
@@ -345,14 +348,14 @@ async def _project_video_resolution(project: dict, provider_id: str, model_id: s
     return resolution or get_provider_fallback(provider_id)
 
 
-async def resolve_max_unit_duration(project: dict) -> int | None:
-    """解析项目视频后端的单次生成时长上限（秒），供派生分组约束 unit 总长。
+async def resolve_max_unit_duration(project: dict, episode: int | None = None) -> int | None:
+    """解析该集视频后端的单次生成时长上限（秒），供派生分组约束 unit 总长。
 
     单一真相源与 executor 取档同口径（``video_capabilities_for_project`` 的
     model 粒度 ``max_duration``）；解析失败返回 None——分组退化为仅按镜头数
     切分，超长 unit 交由执行层取档 + warning 兜底，不阻塞派生。
     """
-    caps = await project_video_caps(project, degraded_to="派生分组不施加时长上限")
+    caps = await project_video_caps(project, degraded_to="派生分组不施加时长上限", episode=episode)
     max_duration = caps.get("max_duration")
     return int(max_duration) if max_duration else None
 
@@ -536,9 +539,12 @@ async def execute_reference_video_task(
             raise ValueError(f"unit not found: {resource_id}")
         # 索引悬空（镜头被删/改 ID 后未重新派生）在此 fail-loud，提示重新派生
         ad_shots = resolve_ad_unit_shots(script, unit) if is_ad else None
-        return project, project_path, unit, ad_shots
+        # 集号供能力解析按该集生效 generation_mode 取值；剧本缺 episode 字段（脏数据）时
+        # 传 None，能力回落到项目级口径。
+        script_episode = script.get("episode")
+        return project, project_path, unit, ad_shots, script_episode if isinstance(script_episode, int) else None
 
-    project, project_path, unit, ad_shots = await asyncio.to_thread(_load)
+    project, project_path, unit, ad_shots, episode = await asyncio.to_thread(_load)
     is_ad = ad_shots is not None
 
     # 2. 解析 references（narration/drama 缺图直接失败；ad 软口径跳过 + warning）
@@ -557,7 +563,12 @@ async def execute_reference_video_task(
     #    （docs/adr/0049）——executor 不再触碰 MediaGenerator 私有属性、不再手工重建
     #    registry provider_id。
     ctx = await resolve_generation_context(
-        project_name, payload, project=project, user_id=user_id, video=VideoLaneRequest(capability="r2v")
+        project_name,
+        payload,
+        project=project,
+        user_id=user_id,
+        episode=episode,
+        video=VideoLaneRequest(capability="r2v"),
     )
     generator = ctx.generator
     video = ctx.video

--- a/server/services/script_review.py
+++ b/server/services/script_review.py
@@ -285,7 +285,7 @@ class ScriptReviewService:
         if script_review.step1_kind(project, episode) != "reference_video":
             return None
         try:
-            caps = await resolve_video_caps(project)
+            caps = await resolve_video_caps(project, episode)
         except Exception as exc:  # noqa: BLE001 - best-effort：解析失败时收窄回退为不收窄，不阻塞面板
             logger.warning("video_capabilities 解析异常，时长档下拉退回未收窄集合 project=%s：%s", project_name, exc)
             caps = {}

--- a/server/services/video_caps.py
+++ b/server/services/video_caps.py
@@ -18,24 +18,25 @@ from lib.db import async_session_factory
 logger = logging.getLogger(__name__)
 
 
-async def project_video_caps(project: dict, *, degraded_to: str) -> dict:
+async def project_video_caps(project: dict, *, degraded_to: str, episode: int | None = None) -> dict:
     """项目视频后端的 model 粒度能力；解析失败返回空 dict，由调用方各自降级。
 
     ``degraded_to`` 只用于日志，说明这次解析失败会让调用方退化成什么行为。
+    ``episode`` 给出集号时按该集生效 ``generation_mode`` 解析（生成模式可被单集覆盖）。
     """
     try:
         resolver = ConfigResolver(async_session_factory)
-        return await resolver.video_capabilities_for_project(project)
+        return await resolver.video_capabilities_for_project(project, episode)
     except (ValueError, SQLAlchemyError) as exc:
         logger.info("无法解析 video_capabilities，%s：%s", degraded_to, exc)
         return {}
 
 
-async def resolve_project_voice_consistency(project: dict) -> VoiceConsistency:
-    """项目当前视频后端的声音一致性档位，供 drama Voice_Profiles 注入前的 C 类（真无声）判定。
+async def resolve_project_voice_consistency(project: dict, episode: int | None = None) -> VoiceConsistency:
+    """该集视频后端的声音一致性档位，供 drama Voice_Profiles 注入前的 C 类（真无声）判定。
 
     解析失败按既有「无信号不判定为真无声」口径退化为 ``soft``（同 ``derive_voice_consistency``
     对自定义供应商缺失 ``generate_audio`` 声明时的处理）。
     """
-    caps = await project_video_caps(project, degraded_to="Voice_Profiles 按 soft 兜底注入")
+    caps = await project_video_caps(project, degraded_to="Voice_Profiles 按 soft 兜底注入", episode=episode)
     return caps.get("voice_consistency") or "soft"

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1004,7 +1004,7 @@ async def test_generate_video_episode_reference_duration_needs_confirmation(fake
         enqueued.extend(specs)
         return [], []
 
-    async def fake_duration_context(_project):
+    async def fake_duration_context(_project, _episode=None):
         return None
 
     monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
@@ -1050,7 +1050,7 @@ async def test_generate_video_episode_reference_duration_confirm_enqueues(fake_c
                 )
         return [], []
 
-    async def fake_duration_context(_project):
+    async def fake_duration_context(_project, _episode=None):
         return None
 
     monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
@@ -1083,7 +1083,7 @@ async def test_generate_video_episode_reference_duration_repeat_without_confirm_
         enqueued.extend(specs)
         return [], []
 
-    async def fake_duration_context(_project):
+    async def fake_duration_context(_project, _episode=None):
         return None
 
     monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
@@ -1129,7 +1129,7 @@ async def test_generate_video_episode_reference_duration_exact_enqueues_directly
                 )
         return [], []
 
-    async def fake_duration_context(_project):
+    async def fake_duration_context(_project, _episode=None):
         return None
 
     monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
@@ -1184,7 +1184,7 @@ async def test_generate_video_episode_reference_duration_skips_unit_without_shot
                 )
         return [], []
 
-    async def fake_duration_context(_project):
+    async def fake_duration_context(_project, _episode=None):
         return None
 
     monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
@@ -1226,7 +1226,7 @@ async def test_generate_video_episode_reference_duration_resolves_project_contex
 
     context_calls: list[dict[str, Any]] = []
 
-    async def fake_duration_context(project):
+    async def fake_duration_context(project, _episode=None):
         context_calls.append(project)
         return ProjectDurationContext(supported_durations=(4, 8, 12), resolution=None, provider_id="", model_name=None)
 
@@ -1263,7 +1263,7 @@ async def test_generate_video_episode_reference_skips_duration_context_when_noth
 
     context_calls: list[dict[str, Any]] = []
 
-    async def fake_duration_context(project):
+    async def fake_duration_context(project, _episode=None):
         context_calls.append(project)
         raise AssertionError("无可预检 unit 时不应解析项目视频能力")
 
@@ -1294,7 +1294,7 @@ async def test_generate_video_episode_reference_skips_duration_context_when_prom
 
     context_calls: list[dict[str, Any]] = []
 
-    async def fake_duration_context(project):
+    async def fake_duration_context(project, _episode=None):
         context_calls.append(project)
         raise AssertionError("整批提示词均空白时不应解析项目视频能力")
 
@@ -1331,7 +1331,7 @@ async def test_generate_video_episode_ad_reference_duration_needs_confirmation(
         enqueued.extend(specs)
         return [], []
 
-    async def fake_duration_context(_project):
+    async def fake_duration_context(_project, _episode=None):
         return None
 
     monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
@@ -1389,7 +1389,7 @@ async def test_generate_video_reference_duration_confirmation_across_entries(
                 )
         return [], []
 
-    async def fake_duration_context(_project):
+    async def fake_duration_context(_project, _episode=None):
         return None
 
     monkeypatch.setattr(mod, "resolve_project_duration_context", fake_duration_context)
@@ -1774,14 +1774,14 @@ async def test_resolve_voice_characters_drama_reads_project_characters_and_gate(
     """drama：读项目角色资产，voice_consistency 为 none（C 类真无声）时退回不注入。"""
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
 
-    async def fake_voice_consistency(_project):
+    async def fake_voice_consistency(_project, _episode=None):
         return "soft"
 
     monkeypatch.setattr(mod, "resolve_project_voice_consistency", fake_voice_consistency)
     characters = await mod._resolve_voice_characters(fake_ctx, "drama")
     assert characters == fake_ctx.pm.project_payload["characters"]  # type: ignore[attr-defined]
 
-    async def fake_voice_consistency_none(_project):
+    async def fake_voice_consistency_none(_project, _episode=None):
         return "none"
 
     monkeypatch.setattr(mod, "resolve_project_voice_consistency", fake_voice_consistency_none)
@@ -1863,7 +1863,7 @@ def test_build_reference_specs_handles_malformed_shots(tmp_path) -> None:
 async def test_get_video_capabilities_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def fake_resolve(_project):
+    async def fake_resolve(_project, _episode=None):
         return {"provider_id": "fake", "supported_durations": [4, 6, 8]}
 
     monkeypatch.setattr(mod, "_resolve_video_capabilities", fake_resolve)
@@ -1878,7 +1878,7 @@ async def test_get_video_capabilities_annotates_reference_unit_tiers(fake_ctx: T
     """参考路径项目另返回两套逐 unit 生效档位，供手工改 step1 时与生成侧对同一份数字。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def fake_resolve(_project):
+    async def fake_resolve(_project, _episode=None):
         return {
             "provider_id": "gemini-aistudio",
             "model": "veo-3.1-generate-preview",
@@ -1909,7 +1909,7 @@ async def test_get_video_capabilities_skips_tiers_off_episode_reference_path(
     """非剧集参考路径不补该字段：其它路径没有逐 unit 引用状态，ad 镜头时长也不受档位枚举管辖。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def fake_resolve(_project):
+    async def fake_resolve(_project, _episode=None):
         return {
             "provider_id": "gemini-aistudio",
             "model": "veo-3.1-generate-preview",
@@ -1933,7 +1933,7 @@ async def test_get_video_capabilities_shares_rest_resolution_entry(fake_ctx: Too
 
     seen: list[str] = []
 
-    async def fake_video_capabilities(_self, project_name=None):
+    async def fake_video_capabilities(_self, project_name=None, episode=None):
         seen.append(project_name)
         return {"provider_id": "kling", "model": "kling-v3-omni", "supported_durations": [5]}
 
@@ -1947,7 +1947,7 @@ async def test_get_video_capabilities_shares_rest_resolution_entry(fake_ctx: Too
 async def test_get_video_capabilities_error(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def fake_resolve(_project):
+    async def fake_resolve(_project, _episode=None):
         raise FileNotFoundError("missing project.json")
 
     monkeypatch.setattr(mod, "_resolve_video_capabilities", fake_resolve)
@@ -2082,11 +2082,11 @@ async def test_fetch_caps_with_fallback_uses_write_layer_default(monkeypatch) ->
     from lib.custom_provider.duration_presets import DEFAULT_FALLBACK
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def raising_caps(_p, *, generation_mode=None):
+    async def raising_caps(_p, *, episode=None, generation_mode=None):
         raise ValueError("no provider configured")
 
     monkeypatch.setattr(mod, "fetch_video_caps", raising_caps)
-    default, durations = await mod._fetch_caps_with_fallback({})
+    default, durations = await mod._fetch_caps_with_fallback({}, 1)
     assert default is None
     assert durations == DEFAULT_FALLBACK
 
@@ -2100,19 +2100,19 @@ async def test_fetch_caps_with_fallback_drops_out_of_range_default(monkeypatch) 
     """
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _narrowed_caps(_p, *, generation_mode=None):
+    async def _narrowed_caps(_p, *, episode=None, generation_mode=None):
         return 4, [8]
 
     monkeypatch.setattr(mod, "fetch_video_caps", _narrowed_caps)
-    default, durations = await mod._fetch_caps_with_fallback({})
+    default, durations = await mod._fetch_caps_with_fallback({}, 1)
     assert default is None
     assert durations == [8]
 
-    async def _in_range_caps(_p, *, generation_mode=None):
+    async def _in_range_caps(_p, *, episode=None, generation_mode=None):
         return 8, [4, 6, 8]
 
     monkeypatch.setattr(mod, "fetch_video_caps", _in_range_caps)
-    default, durations = await mod._fetch_caps_with_fallback({})
+    default, durations = await mod._fetch_caps_with_fallback({}, 1)
     assert default == 8
     assert durations == [4, 6, 8]
 
@@ -2126,7 +2126,7 @@ async def test_fetch_video_caps_narrows_durations_by_constraints(monkeypatch) ->
     """
     from server.agent_runtime.sdk_tools import _context as ctx_mod
 
-    async def _fake_caps(_project):
+    async def _fake_caps(_project, _episode=None):
         return {
             "provider_id": "gemini-aistudio",
             "model": "veo-3.1-generate-preview",
@@ -2165,7 +2165,7 @@ async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext, monkeypatch
     src.mkdir(parents=True)
     (src / "chapter1.txt").write_text("从前有座山", encoding="utf-8")
 
-    async def fake_caps(_p):
+    async def fake_caps(_p, _episode=None):
         return 4, [4, 6, 8]
 
     monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
@@ -2187,7 +2187,7 @@ async def test_normalize_drama_script_wires_target_language(fake_ctx: ToolContex
     src.mkdir(parents=True)
     (src / "chapter1.txt").write_text("once upon a time", encoding="utf-8")
 
-    async def fake_caps(_p):
+    async def fake_caps(_p, _episode=None):
         return 4, [4, 6, 8]
 
     monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
@@ -2206,7 +2206,7 @@ async def test_normalize_drama_script_rejects_empty_scenes(fake_ctx: ToolContext
     src.mkdir(parents=True)
     (src / "chapter1.txt").write_text("从前有座山", encoding="utf-8")
 
-    async def fake_caps(_p):
+    async def fake_caps(_p, _episode=None):
         return 4, [4, 6, 8]
 
     class _EmptyGenerator:
@@ -2238,7 +2238,7 @@ async def test_normalize_drama_script_injects_episode_into_prompt(fake_ctx: Tool
     src.mkdir(parents=True)
     (src / "chapter2.txt").write_text("第二集开场", encoding="utf-8")
 
-    async def fake_caps(_p):
+    async def fake_caps(_p, _episode=None):
         return 4, [4, 6, 8]
 
     monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
@@ -2268,7 +2268,7 @@ async def test_normalize_drama_script_injects_episode_outline(fake_ctx: ToolCont
         }
     ]
 
-    async def fake_caps(_p):
+    async def fake_caps(_p, _episode=None):
         return 4, [4, 6, 8]
 
     monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
@@ -2290,7 +2290,7 @@ async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: T
     src.mkdir(parents=True)
     (src / "chapter1.txt").write_text("从前有座山", encoding="utf-8")
 
-    async def fake_caps(_p):
+    async def fake_caps(_p, _episode=None):
         return 4, [4, 6, 8]
 
     captured: dict[str, Any] = {}
@@ -2804,7 +2804,7 @@ def ad_reference_ctx(fake_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch) -> 
 
     pm.locked_script = _locked  # type: ignore[attr-defined]
 
-    async def _fake_max_duration(_project: dict[str, Any]) -> int | None:
+    async def _fake_max_duration(_project: dict[str, Any], _episode: int | None = None) -> int | None:
         return 15
 
     monkeypatch.setattr(mod, "resolve_max_unit_duration", _fake_max_duration)
@@ -2969,7 +2969,7 @@ async def test_generate_video_all_ad_reference_falls_through_to_episode(
 def _rv_caps(default=4, durations=(4, 6, 8), reference_durations=None, max_duration=12, max_refs=3, caps=None):
     from server.agent_runtime.sdk_tools.text_generation import ReferenceSplitCaps
 
-    async def fake_caps(_p):
+    async def fake_caps(_p, _episode=None):
         return ReferenceSplitCaps(
             default_duration=default,
             durations=list(durations),
@@ -2987,12 +2987,12 @@ async def test_fetch_reference_caps_with_fallback_returns_declared_slots(monkeyp
     """unit 时长就是发给供应商的那个值，档位原样取自模型声明（不与任何静态区间求交）。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _fake_caps(_project):
+    async def _fake_caps(_project, _episode=None):
         return {"supported_durations": [1, 8, 16, 18], "max_duration": 18, "default_duration": 16}
 
     monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
 
-    caps = await mod._fetch_reference_caps_with_fallback({})
+    caps = await mod._fetch_reference_caps_with_fallback({}, 1)
 
     assert caps.durations == [1, 8, 16, 18]
     assert caps.reference_durations == [1, 8, 16, 18]
@@ -3010,7 +3010,7 @@ async def test_fetch_reference_caps_with_fallback_narrows_unit_duration_cap(monk
     """
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _fake_caps(_project):
+    async def _fake_caps(_project, _episode=None):
         return {
             "provider_id": "minimax",
             "model": "MiniMax-Hailuo-2.3",
@@ -3022,7 +3022,7 @@ async def test_fetch_reference_caps_with_fallback_narrows_unit_duration_cap(monk
     monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
 
     project = {"model_settings": {"minimax/MiniMax-Hailuo-2.3": {"resolution": "1080p"}}}
-    caps = await mod._fetch_reference_caps_with_fallback(project)
+    caps = await mod._fetch_reference_caps_with_fallback(project, 1)
     assert caps.durations == [6]
     assert caps.max_duration == 6
 
@@ -3032,7 +3032,7 @@ async def test_fetch_reference_caps_with_fallback_narrows_slots_by_resolution(mo
     """分辨率联动约束同样收窄 unit 档位：Veo 1080p 下只接受 8 秒。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _fake_caps(_project):
+    async def _fake_caps(_project, _episode=None):
         return {
             "provider_id": "gemini-aistudio",
             "model": "veo-3.1-generate-preview",
@@ -3044,7 +3044,7 @@ async def test_fetch_reference_caps_with_fallback_narrows_slots_by_resolution(mo
     monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
 
     project = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}}
-    caps = await mod._fetch_reference_caps_with_fallback(project)
+    caps = await mod._fetch_reference_caps_with_fallback(project, 1)
     assert caps.durations == [8]
     assert caps.max_duration == 8
 
@@ -3086,7 +3086,7 @@ async def test_fetch_reference_caps_with_fallback_splits_tiers_by_reference_stat
     """
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _fake_caps(_project):
+    async def _fake_caps(_project, _episode=None):
         return {
             "provider_id": "gemini-aistudio",
             "model": "veo-3.1-generate-preview",
@@ -3098,7 +3098,7 @@ async def test_fetch_reference_caps_with_fallback_splits_tiers_by_reference_stat
     monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
 
     project = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}}}
-    caps = await mod._fetch_reference_caps_with_fallback(project)
+    caps = await mod._fetch_reference_caps_with_fallback(project, 1)
     assert caps.reference_durations == [8]
     assert caps.text_durations == [4, 6, 8]
     assert caps.durations == [4, 6, 8]
@@ -3116,7 +3116,7 @@ async def test_fetch_reference_caps_with_fallback_uses_write_layer_default(monke
         raise ValueError("no provider configured")
 
     monkeypatch.setattr(mod, "resolve_video_caps", _raising_caps)
-    caps = await mod._fetch_reference_caps_with_fallback({})
+    caps = await mod._fetch_reference_caps_with_fallback({}, 1)
     assert caps.default_duration is None
     assert caps.durations == DEFAULT_FALLBACK
     assert caps.max_duration == max(DEFAULT_FALLBACK)
@@ -3814,7 +3814,7 @@ async def test_generate_episode_script_ignores_quarantine_after_mode_switch(fake
 
 
 def _nr_caps(default=4, durations=(4, 6, 8)):
-    async def fake_caps(_p):
+    async def fake_caps(_p, _episode=None):
         return default, list(durations)
 
     return fake_caps

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1788,20 +1788,6 @@ async def test_resolve_voice_characters_drama_reads_project_characters_and_gate(
     assert await mod._resolve_voice_characters(fake_ctx, "drama") is None
 
 
-def test_script_episode_matches_enqueue_episode_resolution() -> None:
-    """能力解析的集号与入队 / checkpoint 用的是同一份解析，不各拿一个集号。
-
-    剧本字段优先；字段缺失（存量脏数据）时同样回落文件名，否则集号出自文件名的剧本会按第 N 集
-    入队、却按项目级口径解析能力，被单集覆盖的那一集静默丢回项目级模式。
-    """
-    from server.agent_runtime.sdk_tools.enqueue_videos import _script_episode
-
-    assert _script_episode({"episode": 2}, "episode_7.json") == 2
-    assert _script_episode({}, "episode_3.json") == 3
-    # 既无字段也无文件名模式：能力回落项目级，而不是让一次能力解析打断整个入队。
-    assert _script_episode({}, "draft.json") is None
-
-
 def test_build_reference_specs_routes_through_guard(tmp_path) -> None:
     """参考生视频入队经统一守卫点：prompt 由 shots 拼接后随 payload 入队（见 ADR-0001）。"""
     from server.agent_runtime.sdk_tools.enqueue_videos import _build_reference_specs

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1874,6 +1874,25 @@ async def test_get_video_capabilities_happy(fake_ctx: ToolContext, monkeypatch) 
 
 
 @pytest.mark.unit
+async def test_get_video_capabilities_passes_episode_through(fake_ctx: ToolContext, monkeypatch) -> None:
+    """带 episode 时集号传到解析入口：生成模式可被单集覆盖，智能体须拿该集口径的能力。"""
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    seen: list[int | None] = []
+
+    async def fake_resolve(_project, episode=None):
+        seen.append(episode)
+        return {"provider_id": "fake", "supported_durations": [4, 6, 8]}
+
+    monkeypatch.setattr(mod, "_resolve_video_capabilities", fake_resolve)
+    tool_obj = get_video_capabilities_tool(fake_ctx)
+    assert (await _call(tool_obj, {"episode": 3})).get("is_error") is not True
+    # 省略集号仍按项目级解析
+    assert (await _call(tool_obj, {})).get("is_error") is not True
+    assert seen == [3, None]
+
+
+@pytest.mark.unit
 async def test_get_video_capabilities_annotates_reference_unit_tiers(fake_ctx: ToolContext, monkeypatch) -> None:
     """参考路径项目另返回两套逐 unit 生效档位，供手工改 step1 时与生成侧对同一份数字。"""
     from server.agent_runtime.sdk_tools import text_generation as mod

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1788,6 +1788,20 @@ async def test_resolve_voice_characters_drama_reads_project_characters_and_gate(
     assert await mod._resolve_voice_characters(fake_ctx, "drama") is None
 
 
+def test_script_episode_matches_enqueue_episode_resolution() -> None:
+    """能力解析的集号与入队 / checkpoint 用的是同一份解析，不各拿一个集号。
+
+    剧本字段优先；字段缺失（存量脏数据）时同样回落文件名，否则集号出自文件名的剧本会按第 N 集
+    入队、却按项目级口径解析能力，被单集覆盖的那一集静默丢回项目级模式。
+    """
+    from server.agent_runtime.sdk_tools.enqueue_videos import _script_episode
+
+    assert _script_episode({"episode": 2}, "episode_7.json") == 2
+    assert _script_episode({}, "episode_3.json") == 3
+    # 既无字段也无文件名模式：能力回落项目级，而不是让一次能力解析打断整个入队。
+    assert _script_episode({}, "draft.json") is None
+
+
 def test_build_reference_specs_routes_through_guard(tmp_path) -> None:
     """参考生视频入队经统一守卫点：prompt 由 shots 拼接后随 payload 入队（见 ADR-0001）。"""
     from server.agent_runtime.sdk_tools.enqueue_videos import _build_reference_specs
@@ -3131,7 +3145,7 @@ async def test_fetch_reference_caps_with_fallback_uses_write_layer_default(monke
     from lib.custom_provider.duration_presets import DEFAULT_FALLBACK
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _raising_caps(_project):
+    async def _raising_caps(_project, _episode=None):
         raise ValueError("no provider configured")
 
     monkeypatch.setattr(mod, "resolve_video_caps", _raising_caps)

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -607,6 +607,59 @@ async def test_execute_reference_video_task_success(tmp_path: Path, monkeypatch:
 
 
 @pytest.mark.asyncio
+async def test_execute_reference_video_task_resolves_episode_like_enqueue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """执行层集号与入队侧共用同一份解析：剧本缺 episode 字段时同样回落文件名。
+
+    只认剧本字段的话，这类剧本会在预检 / 派生阶段按第 1 集取能力、执行阶段却回落项目级口径，
+    被单集覆盖的那一集因此拿到另一套档位与模型。
+    """
+    proj_dir = _write_project(tmp_path)
+    from server.services import reference_video_tasks as rvt
+
+    script_path = proj_dir / "scripts" / "episode_1.json"
+    script = json.loads(script_path.read_text(encoding="utf-8"))
+    script.pop("episode")
+    script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
+
+    fake_pm = MagicMock()
+    fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
+    fake_pm.get_project_path.return_value = proj_dir
+    fake_pm.load_script.side_effect = lambda _n, _f: json.loads(script_path.read_text(encoding="utf-8"))
+    _wire_locked_script(fake_pm)
+    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
+
+    async def _fake_generate_video_async(**_kwargs):
+        out = proj_dir / "reference_videos" / "E1U1.mp4"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\x00\x00\x00 ftypmp42")
+        return out, 1, None, None
+
+    fake_generator = MagicMock()
+    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
+    fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-17T10:00:00"}]}
+    _wire_context(monkeypatch, rvt, fake_generator, backend_name="ark", backend_model="doubao-seedance-2-0-260128")
+
+    seen: list[int | None] = []
+    inner = rvt.resolve_generation_context
+
+    async def _recording(*args, episode=None, **kwargs):
+        seen.append(episode)
+        return await inner(*args, episode=episode, **kwargs)
+
+    monkeypatch.setattr(rvt, "resolve_generation_context", _recording)
+
+    async def _fake_extract(*_a, **_k):
+        return True
+
+    monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
+
+    await rvt.execute_reference_video_task("demo", "E1U1", {"script_file": "scripts/episode_1.json"}, user_id="u1")
+    assert seen == [1]
+
+
+@pytest.mark.asyncio
 async def test_execute_reference_video_task_sends_reference_audio_in_prompt_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -330,7 +330,7 @@ async def test_resolve_project_duration_context_resolves_caps_and_resolution_onc
     caps_calls = 0
     resolution_calls = 0
 
-    async def fake_caps(_project, *, degraded_to):
+    async def fake_caps(_project, *, degraded_to, episode=None):
         nonlocal caps_calls
         caps_calls += 1
         return {"provider_id": "gemini-aistudio", "model": "veo-3.1-generate-preview", "supported_durations": [4, 6, 8]}
@@ -362,7 +362,7 @@ async def test_resolve_project_duration_context_skips_resolution_when_no_duratio
 
     resolution_calls = 0
 
-    async def fake_caps(_project, *, degraded_to):
+    async def fake_caps(_project, *, degraded_to, episode=None):
         return {}
 
     async def fake_resolution(*_a, **_kw):

--- a/tests/server/test_video_caps.py
+++ b/tests/server/test_video_caps.py
@@ -9,7 +9,7 @@ from server.services import video_caps
 async def test_resolve_project_voice_consistency_reads_caps_field(monkeypatch: pytest.MonkeyPatch):
     """正常解析：直接读 caps 的 voice_consistency 字段，不重新派生。"""
 
-    async def fake_caps(_project, *, degraded_to):
+    async def fake_caps(_project, *, degraded_to, episode=None):
         return {"voice_consistency": "none"}
 
     monkeypatch.setattr(video_caps, "project_video_caps", fake_caps)
@@ -20,7 +20,7 @@ async def test_resolve_project_voice_consistency_reads_caps_field(monkeypatch: p
 async def test_resolve_project_voice_consistency_degrades_to_soft(monkeypatch: pytest.MonkeyPatch):
     """caps 解析失败（空 dict）时按既有「无信号不判定为真无声」口径退化为 soft。"""
 
-    async def fake_caps(_project, *, degraded_to):
+    async def fake_caps(_project, *, degraded_to, episode=None):
         return {}
 
     monkeypatch.setattr(video_caps, "project_video_caps", fake_caps)

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from lib.config.resolver import (
     ConfigResolver,
     VideoBucketCapabilityError,
+    caps_generation_mode,
     constrain_durations_for_project,
     video_bucket_for_generation_mode,
 )
@@ -1833,3 +1834,73 @@ class TestStyleAnalysisVisionGuard:
         )
         result = await resolver._resolve_text_backend(fake_svc, MagicMock(), TextTaskType.SCRIPT, None)
         assert result == ("gemini-aistudio", "gemini-3.1-flash-lite-preview")
+
+
+class TestEpisodeEffectiveGenerationMode:
+    """能力解析按剧集生效 generation_mode 收敛：生成模式可被单集覆盖，能力须跟着该集走。"""
+
+    async def _caps(self, project: dict, episode: int | None) -> dict:
+        factory, engine = await _make_session()
+        try:
+            with patch("lib.config.resolver.get_project_manager"):
+                return await ConfigResolver(factory).video_capabilities_for_project(project, episode)
+        finally:
+            await engine.dispose()
+
+    @pytest.mark.unit
+    def test_caps_generation_mode_prefers_episode_override(self):
+        project = {
+            "generation_mode": "storyboard",
+            "episodes": [{"episode": 1}, {"episode": 2, "generation_mode": "reference_video"}],
+        }
+        assert caps_generation_mode(project, 2) == "reference_video"
+        # 未覆盖的集、无集号上下文、以及集号不存在时都回落项目级
+        assert caps_generation_mode(project, 1) == "storyboard"
+        assert caps_generation_mode(project, None) == "storyboard"
+        assert caps_generation_mode(project, 99) == "storyboard"
+
+    @pytest.mark.unit
+    def test_caps_generation_mode_none_when_nothing_declared(self):
+        """两级都未声明时为 None（未声明 ≠ 显式选了 storyboard），与无项目上下文同口径。"""
+        assert caps_generation_mode({"episodes": [{"episode": 1}]}, 1) is None
+        assert caps_generation_mode({}, None) is None
+        assert caps_generation_mode(None, 1) is None
+
+    @pytest.mark.integration
+    async def test_bucket_follows_episode_override(self):
+        """项目级分镜、某集覆盖为参考生视频：定桶随该集换到 r2v 桶的模型。"""
+        project = {
+            "generation_mode": "storyboard",
+            "video_provider_i2v": "kling/kling-v3",
+            "video_provider_r2v": "minimax/S2V-01",
+            "episodes": [{"episode": 1}, {"episode": 2, "generation_mode": "reference_video"}],
+        }
+        assert (await self._caps(project, 1))["model"] == "kling-v3"
+        assert (await self._caps(project, 2))["model"] == "S2V-01"
+
+    @pytest.mark.integration
+    async def test_voice_consistency_follows_episode_override(self):
+        """覆盖集的声音一致性按该集解析为 native——按项目级会降格 soft，该集将永远不发参考音频。"""
+        project = {
+            "generation_mode": "storyboard",
+            "video_provider_r2v": "ark/doubao-seedance-2-0-260128",
+            "video_backend": "ark/doubao-seedance-2-0-260128",
+            "episodes": [{"episode": 1}, {"episode": 2, "generation_mode": "reference_video"}],
+        }
+        assert (await self._caps(project, 2))["voice_consistency"] == "native"
+        assert (await self._caps(project, 2))["generation_mode"] == "reference_video"
+        # 未覆盖的集与不带集号的查询保持项目级口径
+        assert (await self._caps(project, 1))["voice_consistency"] == "soft"
+        assert (await self._caps(project, None))["voice_consistency"] == "soft"
+
+    @pytest.mark.integration
+    async def test_uses_reference_images_constraint_follows_episode_override(self):
+        """caps 的 generation_mode 是下游时长约束的入参，覆盖集据此施加「参考图↔时长」约束。"""
+        project = {
+            "generation_mode": "storyboard",
+            "video_provider_r2v": "minimax/S2V-01",
+            "episodes": [{"episode": 2, "generation_mode": "reference_video"}],
+        }
+        caps = await self._caps(project, 2)
+        assert caps["generation_mode"] == "reference_video"
+        assert caps["max_reference_images"] == 1

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -1866,6 +1866,33 @@ class TestEpisodeEffectiveGenerationMode:
         assert caps_generation_mode({}, None) is None
         assert caps_generation_mode(None, 1) is None
 
+    @pytest.mark.unit
+    def test_caps_generation_mode_normalizes_out_of_table_values(self):
+        """表外脏字符串归一到默认档，不原样外泄给前端与智能体。
+
+        归一后与定桶口径一致（``video_bucket_for_generation_mode`` 对表外值同样落默认桶），
+        载荷里因此不会出现一个「模式说 bogus、能力按 storyboard 算」的自相矛盾快照。
+        """
+        assert caps_generation_mode({"generation_mode": "bogus"}, None) == "storyboard"
+        assert (
+            caps_generation_mode(
+                {"episodes": [{"episode": 1, "generation_mode": "bogus"}]},
+                1,
+            )
+            == "storyboard"
+        )
+        # 集级脏值不吃掉项目级的有效声明
+        assert (
+            caps_generation_mode(
+                {
+                    "generation_mode": "reference_video",
+                    "episodes": [{"episode": 1, "generation_mode": "bogus"}],
+                },
+                1,
+            )
+            == "reference_video"
+        )
+
     @pytest.mark.integration
     async def test_bucket_follows_episode_override(self):
         """项目级分镜、某集覆盖为参考生视频：定桶随该集换到 r2v 桶的模型。"""

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -1628,7 +1628,7 @@ class TestCostEstimationService:
 
         # 取档解析走全局 session factory（真实部署的库），测试库换成 db_factory 后照常做真实
         # 桶解析——被观察的是它拿到哪个模型的档位，不是它怎么连库。
-        async def _caps_from_test_db(project, *, degraded_to):
+        async def _caps_from_test_db(project, *, degraded_to, episode=None):
             return await ConfigResolver(db_factory).video_capabilities_for_project(project)
 
         monkeypatch.setattr(reference_video_tasks, "project_video_caps", _caps_from_test_db)

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -101,7 +101,9 @@ def _fake_resolve_ctx(
     自己用到的 lane。
     """
 
-    async def _resolve(project_name, payload, *, project, user_id="default", image=None, video=None, audio=None):
+    async def _resolve(
+        project_name, payload, *, project, user_id="default", episode=None, image=None, video=None, audio=None
+    ):
         if seen_lane_requests is not None:
             seen_lane_requests.append({"image": image, "video": video, "audio": audio})
         image_lane = None

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -1364,6 +1364,36 @@ class TestGenerationTasks:
         assert result["resource_type"] == "videos"
         assert fake_generator.video_calls[0]["duration_seconds"] == 6
 
+    async def test_execute_video_task_passes_script_episode_to_context(self, monkeypatch, tmp_path):
+        """执行层把剧本集号交给能力解析：生成模式可被单集覆盖，按项目级解析会漏掉该覆盖。
+
+        剧本缺 episode 字段（脏数据）时传 None，能力回落项目级口径。
+        """
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_generator = _FakeGenerator()
+        seen: list[int | None] = []
+        inner = _fake_resolve_ctx(fake_generator, supported_durations=(6, 10))
+
+        async def _recording_resolve(*args, episode=None, **kwargs):
+            seen.append(episode)
+            return await inner(*args, episode=episode, **kwargs)
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _recording_resolve)
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        payload = {
+            "script_file": "episode_1.json",
+            "prompt": {"action": "跑", "camera_motion": "Static", "dialogue": []},
+        }
+        fake_pm.script["episode"] = 2
+        await generation_tasks.execute_video_task("demo", "E1S01", payload)
+        fake_pm.script.pop("episode")
+        await generation_tasks.execute_video_task("demo", "E1S01", payload)
+        assert seen == [2, None]
+
     async def test_execute_video_task_default_duration_respects_resolution_constraint(self, monkeypatch, tmp_path):
         """Auto（无显式 duration）在受约束分辨率下取约束内的时长，而非 supported_durations 首项。
 

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -1367,7 +1367,8 @@ class TestGenerationTasks:
     async def test_execute_video_task_passes_script_episode_to_context(self, monkeypatch, tmp_path):
         """执行层把剧本集号交给能力解析：生成模式可被单集覆盖，按项目级解析会漏掉该覆盖。
 
-        剧本缺 episode 字段（脏数据）时传 None，能力回落项目级口径。
+        集号与入队侧共用一份解析：剧本 episode 字段优先，缺字段（存量脏数据）时回落文件名，
+        两者都解析不出才传 None 让能力回落项目级口径。
         """
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -1392,7 +1393,9 @@ class TestGenerationTasks:
         await generation_tasks.execute_video_task("demo", "E1S01", payload)
         fake_pm.script.pop("episode")
         await generation_tasks.execute_video_task("demo", "E1S01", payload)
-        assert seen == [2, None]
+        payload_unresolvable = {**payload, "script_file": "draft.json"}
+        await generation_tasks.execute_video_task("demo", "E1S01", payload_unresolvable)
+        assert seen == [2, 1, None]
 
     async def test_execute_video_task_default_duration_respects_resolution_constraint(self, monkeypatch, tmp_path):
         """Auto（无显式 duration）在受约束分辨率下取约束内的时长，而非 supported_durations 首项。

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -837,9 +837,27 @@ class TestResolveEpisodeFromScript:
         ep = ProjectManager.resolve_episode_from_script({"episode": "1"}, "episode_9.json")
         assert ep == 9
 
+    def test_ignores_bool_episode_field(self):
+        """bool 是 int 子类：episode: true 当作字段缺失走文件名，不静默算成第 1 集。"""
+        assert ProjectManager.resolve_episode_from_script({"episode": True}, "episode_9.json") == 9
+
     def test_raises_when_unresolvable(self):
         with pytest.raises(ValueError, match="无法确定集号"):
             ProjectManager.resolve_episode_from_script({}, "random_name.json")
+
+
+class TestResolveEpisodeFromScriptOrNone:
+    """能力解析用的软口径：与硬口径共用同一份解析，只把解析不出降为 None。"""
+
+    def test_shares_resolution_with_strict_variant(self):
+        assert ProjectManager.resolve_episode_from_script_or_none({"episode": 7}, "episode_9.json") == 7
+        # 字段缺失回落文件名——只认剧本字段的话，这类剧本会按第 3 集入队却按项目级口径解析能力。
+        assert ProjectManager.resolve_episode_from_script_or_none({}, "episode_3.json") == 3
+        assert ProjectManager.resolve_episode_from_script_or_none({"episode": True}, "episode_3.json") == 3
+
+    def test_returns_none_instead_of_raising(self):
+        """解析不出时能力回落项目级，而不是让一次能力解析打断整条入队 / 执行链路。"""
+        assert ProjectManager.resolve_episode_from_script_or_none({}, "random_name.json") is None
 
 
 class TestScenePropLifecycle:

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1610,6 +1610,41 @@ class TestGetVideoCapabilities:
         assert resolver_instance.video_capabilities_for_model.await_args.args[:2] == ("openai", "sora-2")
 
     @pytest.mark.integration
+    def test_episode_param_reaches_resolver(self, tmp_path, monkeypatch):
+        """带 episode 时集号传到 resolver：生成模式可被单集覆盖，按集查看的界面须同口径。"""
+        from unittest.mock import AsyncMock, MagicMock
+
+        resolver_instance = MagicMock()
+        resolver_instance.video_capabilities = AsyncMock(return_value={"model": "saved-model"})
+        resolver_instance.video_capabilities_for_model = AsyncMock(return_value={"model": "candidate"})
+        monkeypatch.setattr(projects, "ConfigResolver", lambda _factory: resolver_instance)
+
+        client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
+        with client:
+            assert client.get("/api/v1/projects/ready/video-capabilities", params={"episode": 3}).status_code == 200
+            resp = client.get(
+                "/api/v1/projects/ready/video-capabilities",
+                params={"video_backend": "openai/sora-2", "episode": 3},
+            )
+        assert resp.status_code == 200
+        assert resolver_instance.video_capabilities.await_args.args == ("ready", 3)
+        assert resolver_instance.video_capabilities_for_model.await_args.args[3] == 3
+
+    @pytest.mark.integration
+    def test_video_capabilities_without_episode_stays_project_level(self, tmp_path, monkeypatch):
+        """不带 episode 的调用（设置页等无集号上下文）仍按项目级解析。"""
+        from unittest.mock import AsyncMock, MagicMock
+
+        resolver_instance = MagicMock()
+        resolver_instance.video_capabilities = AsyncMock(return_value={"model": "saved-model"})
+        monkeypatch.setattr(projects, "ConfigResolver", lambda _factory: resolver_instance)
+
+        client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
+        with client:
+            assert client.get("/api/v1/projects/ready/video-capabilities").status_code == 200
+        assert resolver_instance.video_capabilities.await_args.args == ("ready", None)
+
+    @pytest.mark.integration
     def test_malformed_video_backend_returns_400(self, tmp_path, monkeypatch):
         self._patch_resolver(monkeypatch, return_value={})
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -340,7 +340,7 @@ class TestScriptGenerator:
         content["scenes"][0]["duration_seconds"] = 4
         generator = ScriptGenerator(project_path)
         with pytest.raises(ValueError, match="step1 已定场景时长非法"):
-            await generator._assert_drama_step1_durations(content["scenes"], gen_mode="storyboard")
+            await generator._assert_drama_step1_durations(content["scenes"], episode=1, gen_mode="storyboard")
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
@@ -361,7 +361,7 @@ class TestScriptGenerator:
         content["scenes"][0]["duration_seconds"] = raw
         generator = ScriptGenerator(project_path)
         with pytest.raises(ValueError, match="step1 已定场景时长非法"):
-            await generator._assert_drama_step1_durations(content["scenes"], gen_mode="storyboard")
+            await generator._assert_drama_step1_durations(content["scenes"], episode=1, gen_mode="storyboard")
 
     @pytest.mark.integration
     async def test_drama_step2_checks_declared_default_when_duration_absent(self, tmp_path):
@@ -377,7 +377,7 @@ class TestScriptGenerator:
         del content["scenes"][0]["duration_seconds"]
         generator = ScriptGenerator(project_path)
         with pytest.raises(ValueError, match="step1 已定场景时长非法"):
-            await generator._assert_drama_step1_durations(content["scenes"], gen_mode="storyboard")
+            await generator._assert_drama_step1_durations(content["scenes"], episode=1, gen_mode="storyboard")
 
     @pytest.mark.integration
     async def test_drama_step2_checks_declared_default_when_duration_null(self, tmp_path):
@@ -394,7 +394,7 @@ class TestScriptGenerator:
         content["scenes"][0]["duration_seconds"] = None
         generator = ScriptGenerator(project_path)
         with pytest.raises(ValueError, match="step1 已定场景时长非法"):
-            await generator._assert_drama_step1_durations(content["scenes"], gen_mode="storyboard")
+            await generator._assert_drama_step1_durations(content["scenes"], episode=1, gen_mode="storyboard")
 
     @pytest.mark.integration
     async def test_drama_step2_accepts_step1_duration_within_constrained_set(self, tmp_path):
@@ -404,7 +404,9 @@ class TestScriptGenerator:
         )
 
         generator = ScriptGenerator(project_path)
-        await generator._assert_drama_step1_durations(_drama_step1_content()["scenes"], gen_mode="storyboard")
+        await generator._assert_drama_step1_durations(
+            _drama_step1_content()["scenes"], episode=1, gen_mode="storyboard"
+        )
 
     async def test_drama_step2_build_prompt_renders_step1_content(self, tmp_path):
         """drama step2（视觉层）build_prompt 须把 step1 已定稿内容渲染入 prompt，仅求视觉字段。"""
@@ -932,7 +934,7 @@ class TestFetchVideoCapabilitiesErrorHandling:
         上限写剧本，写出来的镜头执行期照样被同一道闸拒掉。"""
         from lib.config.resolver import VideoBucketCapabilityError
 
-        async def _raise(_self, _project):
+        async def _raise(_self, _project, _episode=None):
             raise VideoBucketCapabilityError(
                 code="video_capability_missing_r2v",
                 capability="r2v",
@@ -950,7 +952,7 @@ class TestFetchVideoCapabilitiesErrorHandling:
     async def test_other_resolution_failures_still_fall_back(self, tmp_path, monkeypatch):
         """DB 未 migration / 缺能力元数据等环境故障仍走 fallback，裸环境下 generate() 照常跑通。"""
 
-        async def _raise(_self, _project):
+        async def _raise(_self, _project, _episode=None):
             raise ValueError("no video provider configured")
 
         monkeypatch.setattr(ConfigResolver, "video_capabilities_for_project", _raise)
@@ -1297,7 +1299,7 @@ def _narration_visual_response(segment_ids: list[str], *, title: str = "第一�
     return {"title": title, "segments": [_visual_seg(sid) for sid in segment_ids]}
 
 
-async def _fixed_caps_468() -> dict:
+async def _fixed_caps_468(_episode=None) -> dict:
     return {"supported_durations": [4, 6, 8]}
 
 
@@ -1738,7 +1740,7 @@ class TestAdScriptGeneration:
         fake = _FakeTextGenerator(json.dumps(response, ensure_ascii=False))
         generator = ScriptGenerator(project_path, generator=fake)
 
-        async def _fixed_caps():
+        async def _fixed_caps(_episode=None):
             return {"supported_durations": [4, 6, 8]}
 
         generator._fetch_video_capabilities = _fixed_caps
@@ -1762,7 +1764,7 @@ class TestAdScriptGeneration:
         fake = _FakeTextGenerator(json.dumps({"foo": "bar"}))
         generator = ScriptGenerator(project_path, generator=fake)
 
-        async def _fixed_caps():
+        async def _fixed_caps(_episode=None):
             return {"supported_durations": [4, 6, 8]}
 
         generator._fetch_video_capabilities = _fixed_caps
@@ -1811,7 +1813,7 @@ class TestAdScriptGeneration:
         fake = _FakeTextGenerator(json.dumps(response, ensure_ascii=False))
         generator = ScriptGenerator(project_path, generator=fake)
 
-        async def _fixed_caps():
+        async def _fixed_caps(_episode=None):
             return {"supported_durations": [4, 6, 8]}
 
         generator._fetch_video_capabilities = _fixed_caps
@@ -1934,7 +1936,7 @@ class TestAdQualityProbe:
         fake = _FakeTextGenerator(json.dumps(response, ensure_ascii=False))
         generator = ScriptGenerator(project_path, generator=fake)
 
-        async def _fixed_caps():
+        async def _fixed_caps(_episode=None):
             return {"supported_durations": [4, 6, 8]}
 
         generator._fetch_video_capabilities = _fixed_caps

--- a/tests/test_script_review.py
+++ b/tests/test_script_review.py
@@ -382,7 +382,7 @@ class TestReferenceVideoGateFlow:
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video", supported_durations=[4, 6, 8])
         svc = ScriptReviewService(pm)
 
-        async def _fake_caps(_project):
+        async def _fake_caps(_project, _episode=None):
             return {
                 "provider_id": "gemini-aistudio",
                 "model": "veo-3.1-generate-preview",
@@ -408,7 +408,7 @@ class TestReferenceVideoGateFlow:
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
 
-        async def _raise(_project):
+        async def _raise(_project, _episode=None):
             raise RuntimeError("video_capabilities backend unreachable")
 
         monkeypatch.setattr(mod, "resolve_video_caps", _raise)
@@ -424,7 +424,7 @@ class TestReferenceVideoGateFlow:
         pm = _make_project(tmp_path, "drama")  # generation_mode 缺省，非 reference_video
         svc = ScriptReviewService(pm)
 
-        async def _fake_caps(_project):
+        async def _fake_caps(_project, _episode=None):
             return {"provider_id": "custom-acme", "model": "acme-video", "supported_durations": [5, 10]}
 
         monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
@@ -442,7 +442,7 @@ class TestReferenceVideoGateFlow:
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
 
-        async def _fake_caps(_project):
+        async def _fake_caps(_project, _episode=None):
             return {"provider_id": "custom-acme", "model": "acme-video", "supported_durations": [5, 10]}
 
         monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)

--- a/tests/test_script_review_router.py
+++ b/tests/test_script_review_router.py
@@ -196,7 +196,7 @@ class TestReferenceVideoRouter:
         (project_path / "source").mkdir(parents=True, exist_ok=True)
         (project_path / "source" / "episode_1.txt").write_text(novel, encoding="utf-8")
 
-        async def _fake_caps(_project):
+        async def _fake_caps(_project, _episode=None):
             return mod.ReferenceSplitCaps(
                 default_duration=4,
                 durations=[4, 6, 8],
@@ -246,7 +246,7 @@ class TestReferenceVideoRouter:
         (project_path / "source").mkdir(parents=True, exist_ok=True)
         (project_path / "source" / "episode_1.txt").write_text("阿离站在屋檐下。", encoding="utf-8")
 
-        async def _fake_caps(_project):
+        async def _fake_caps(_project, _episode=None):
             return mod.ReferenceSplitCaps(
                 default_duration=4,
                 durations=[4, 6, 8],
@@ -431,7 +431,7 @@ class TestReferenceVideoRouter:
 
         client, pm = _client(monkeypatch, tmp_path, generation_mode="reference_video")
 
-        async def _fake_caps(_project):
+        async def _fake_caps(_project, _episode=None):
             return {"provider_id": "custom-acme", "model": "acme-video", "supported_durations": [5, 10]}
 
         monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)


### PR DESCRIPTION
Closes #1533

## 问题

生成模式可以按集覆盖（`effective_mode` 是 `project_manager` 的一等概念），但视频能力解析读的是项目级 `generation_mode`。项目整体不是参考生视频、而某一集单独覆盖成参考生视频时：

- 声音一致性拿项目级值算出来被降格，**该集永远不发参考音频**，主链路对这类配置静默失效；
- 同一入口的分辨率约束与「是否走参考图路径」也同为项目级口径，存在同形偏差。

## 改动

能力解析收敛到 resolver 单点：新增 `caps_generation_mode(project, episode)`，模式排序委托 `project_manager.effective_mode`（生效模式的唯一真相源），不另立一份项目级口径。`video_capabilities` / `video_capabilities_for_project` / `video_capabilities_for_model` 一律加可选集号入参，并贯通全部调用方——执行路径、参考视频派生与预览、SDK 工具、剧本生成与审核、前端能力出口。没有集号上下文的调用方（设置页、供应商目录）保持项目级口径，不为了统一硬造集号。

`get_video_capabilities` 工具补上 `episode` 参数：它此前全部字段都不感知剧集级覆盖。

与 `effective_mode` 的唯一差别是两级都未声明时返回未声明而非默认档——`generation_mode` 是回给前端与智能体的对外字段，「没声明」不该渲染成用户显式选过分镜模式；定桶两者都落同一个桶，无行为差。

前端：能力查询在工作台顶层仍只发一次、随切集重取；集号出口抽成共享 hook，工作台与尾帧行共用同一份集号，缓存键含集号故不串集。

## 验证

- 新增按集解析的能力回归：定桶随覆盖集换桶、声音一致性在覆盖集解析为原生档（按项目级会降格，该集将永远不发参考音频）、参考图时长约束随覆盖集施加，以及未覆盖集与不带集号的查询保持项目级口径。
- 回归口径「项目级与集级一致时行为逐字不变」经逐条核对成立：定桶键集与合法模式键集完全相同、下游判定均只比对参考生视频一项、前端无该字段消费者。唯一变化是表外脏字符串归一到默认档（归一后与定桶口径一致），已加测试锁住三条边界。
- 全量 `pytest` 7549 passed；`basedpyright` 0 error；`ruff check` / `format --check` 全绿；前端 `pnpm lint` 通过、`pnpm check` 1634 tests passed。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 视频能力查询支持按剧集查看实际生效的生成模式、模型能力、时长及声音一致性设置。
  * 剧集级配置覆盖项目级配置时，视频生成、参考视频和脚本预览将自动使用对应设置。
  * 分集页面及尾帧能力检查会根据当前剧集显示准确结果。

* **问题修复**
  * 修复不同剧集配置下能力、时长限制和生成流程判断不一致的问题。

* **测试**
  * 增加剧集级配置、能力解析及生成流程的覆盖验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->