### PR TITLE
fix(reference-video): 审阅门时长档位解析覆盖自定义供应商，清理死回退分支

### DIFF
--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -473,23 +473,20 @@ def _resolution_for_constraints(
 
 
 def resolve_raw_supported_durations(project: dict, caps: dict | None = None) -> list[int] | None:
-    """收窄前的时长全集：caps → project.json ``_supported_durations`` → registry 三级解析。
+    """收窄前的时长全集：caps → registry 两级解析。
 
-    三级都取不到时返回 None，表示「该项目尚未配置可解析的视频型号」。同步可用是本函数的存在
-    理由：存量时长迁移的三个入口里只有 step2 生成是 async 且已持有 caps，审阅门与归档导入都在
-    同步路径上，靠后两级回退拿到同一份档位表——迁移是幂等一次性的，谁先跑谁定终局，入口之间
-    传参不一致就会让先跑的那个把非档位秒数固化到盘上。
+    两级都取不到时返回 None，表示「该项目尚未配置可解析的视频型号」。``caps`` 是自定义供应商
+    （``custom-`` 前缀）唯一的档位来源——registry 只收录内建供应商，故能 await 的调用方都应
+    先解析 caps 再调本函数，不带 caps 调用对这类项目恒为 None。本函数本身保持同步，供仍在
+    同步路径上的调用方（归档导入）复用同一份 registry 解析。
 
-    最后一级的项目自报身份按 generation_mode 定桶取（``project_video_backend_ids``），不直取
+    registry 级的项目自报身份按 generation_mode 定桶取（``project_video_backend_ids``），不直取
     项目默认层——降级掉的只是 DB，桶键就在同一个 project.json 里。
 
     返回值不含「分辨率↔时长」「参考图↔时长」联动约束，收窄见 ``constrain_durations_for_project``。
     """
     if caps and caps.get("supported_durations"):
         return list(caps["supported_durations"])
-    durations = project.get("_supported_durations")
-    if durations and isinstance(durations, list):
-        return list(durations)
     ids = project_video_backend_ids(project)
     if ids is not None:
         provider_meta = PROVIDER_REGISTRY.get(ids[0])

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -462,8 +462,8 @@ class ScriptGenerator:
         合并（LLM 只出书写层正文，见 ``_merge_reference_visual``）；两者皆 None 时走单段解析
         （drama/ad）。``reference_unit_durations`` 非 None 时（reference_video 路径）按 unit_id
         机械覆盖 ``duration_seconds``（取档用最终输出的 references 状态重算，见 ``_add_metadata``）；
-        ``caps`` 可一并传入，为 None 时 ``_add_metadata`` 仍按 caps → project.json → registry
-        三级回退解析每个 unit 的生效档位，不会因此跳过取档校验。
+        ``caps`` 可一并传入，为 None 时 ``_add_metadata`` 仍按 caps → registry 两级回退解析每个
+        unit 的生效档位，不会因此跳过取档校验。
         """
         assert self.generator is not None  # generate() 入口已检查
         # 调用 TextBackend
@@ -681,7 +681,7 @@ class ScriptGenerator:
     def _resolve_supported_durations(
         self, caps: dict | None = None, *, gen_mode: str, uses_reference_images: bool | None = None
     ) -> list[int]:
-        """从 caps → project.json → registry 三级解析，再按联动约束收窄；都拿不到抛 ValueError。
+        """从 caps → registry 两级解析，再按联动约束收窄；都拿不到抛 ValueError。
 
         收窄发生在交给 prompt / 动态 schema 之前：``supported_durations`` 是型号的时长全集，
         不含「分辨率↔时长」「参考图↔时长」两条联动约束。不收窄的话 Veo 项目（兜底分辨率即
@@ -731,7 +731,7 @@ class ScriptGenerator:
         """收窄前的时长全集：委托共享解析器，取不到时抛 ValueError。
 
         本路径的下游是 prompt 与动态枚举 schema，缺档位就无从生成，故把解析器的 None 提升为
-        异常；同步入口（审阅门 / 归档导入）对 None 的处置是退回结构 clamp，不共用这道提升。
+        异常；其余入口（审阅门 / 归档导入）对 None 的处置是退回结构 clamp，不共用这道提升。
         """
         durations = resolve_raw_supported_durations(self.project_json, caps)
         if durations is None:
@@ -1376,8 +1376,8 @@ class ScriptGenerator:
             reference_unit_durations: reference_video 路径按 unit_id（改写后）机械覆盖 LLM
                 输出的 unit 时长——step1 确认的原始值，未经取档；取档按下方逐 unit 重算，
                 见 ``generate`` 内的构造处注释
-            caps: 逐 unit 解析生效档位的能力值；为 None 时按 caps → project.json → registry
-                三级回退解析，不跳过取档校验
+            caps: 逐 unit 解析生效档位的能力值；为 None 时按 caps → registry 两级回退解析，
+                不跳过取档校验
 
         Returns:
             补充元数据后的剧本数据
@@ -1426,7 +1426,7 @@ class ScriptGenerator:
                 # 取档按这个 unit 最终落地的 references 状态算，不是 step1 拆分时的状态：
                 # references 由 LLM 在 step2 输出时决定，可能与 step1 机械派生的不同（见
                 # generate() 内的构造处注释）。caps 为 None 也不短路——
-                # _resolve_supported_durations 自带 caps → project.json → registry 三级回退。
+                # _resolve_supported_durations 自带 caps → registry 两级回退。
                 unit_tiers = self._unit_duration_off_tier(
                     target_duration, has_references=bool(s.get("references")), caps=caps, gen_mode=gen_mode
                 )

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -396,7 +396,7 @@ def confirm_script_review_tool(ctx: ToolContext):
 
             service = ScriptReviewService(ctx.pm)
             try:
-                state = service.confirm(ctx.project_name, episode)
+                state = await service.confirm(ctx.project_name, episode)
             except ScriptReviewError as exc:
                 return {
                     "content": [

--- a/server/routers/script_review.py
+++ b/server/routers/script_review.py
@@ -5,7 +5,6 @@ step2 视觉生成（step2 由 agent 的 generate_episode_script 执行，读时
 drama（utterances + source_text）与 narration（结构化 novel_text）共用本机制。
 """
 
-import asyncio
 import logging
 
 from fastapi import APIRouter, Body, HTTPException
@@ -51,10 +50,9 @@ async def _attach_duration_tiers(service: ScriptReviewService, project_name: str
     都要走这一步——否则保存 / 确认后 ``adopt()`` 用不带 ``duration_tiers`` 的响应覆盖 GET
     读到的收窄结果，面板退回未收窄的 ``supported_durations``，与 GET 首次加载时的呈现不一致。
 
-    是否调用交给 ``get_reference_duration_tiers`` 自己按 step1_kind 判断，不能靠
-    ``state["supported_durations"] is not None`` 这个同步信号短路——自定义供应商项目的
-    该字段恒为 None（同步路径没有 DB 能力查询可用），靠它短路会让这类项目永远拿不到
-    ``duration_tiers``。
+    是否调用交给 ``get_reference_duration_tiers`` 自己按 step1_kind 判断，不靠
+    ``state["supported_durations"] is not None`` 短路——那是另一个方法的返回值，型号解析
+    不到时同样为 None，靠它短路会让这类项目连未收窄的档位都拿不到。
     """
     state["duration_tiers"] = await service.get_reference_duration_tiers(project_name, episode)
     return state
@@ -79,8 +77,8 @@ def _localize_quarantine_violations(quarantine: dict | None, _t: Translator) -> 
 async def get_script_review(project_name: str, episode: int, _t: Translator):
     """读取该集 step1 结构化中间态 + 审核状态（供 web 渲染与编辑）。
 
-    ``quarantine`` 字段单独合并（reference_video 变体、隔离草稿在场时才非 None）：它要 await
-    视频能力解析做读时重算，不能挂在 ``get_state`` 那个纯同步的 ``asyncio.to_thread`` 调用上。
+    ``quarantine`` 字段单独合并（reference_video 变体、隔离草稿在场时才非 None）：它按产出时
+    那套校验器做读时重算，与 ``get_state`` 的落盘读写彼此独立。
     先取 ``quarantine`` 再取 ``state``：agent 的晋升工具在两次读之间把隔离草稿清掉、正式
     step1 写成新内容时，这个顺序让响应落在「content 已是新的、quarantine 却还带着晋升前的
     违约报告」这一侧——面板会误判成仍在隔离态、阻塞确认，下一轮轮询自然纠正；反过来的顺序会
@@ -90,7 +88,7 @@ async def get_script_review(project_name: str, episode: int, _t: Translator):
     try:
         service = ScriptReviewService(get_project_manager())
         quarantine = await service.get_quarantine_info(project_name, episode)
-        state = await asyncio.to_thread(service.get_state, project_name, episode)
+        state = await service.get_state(project_name, episode)
         await _attach_duration_tiers(service, project_name, episode, state)
         state["quarantine"] = _localize_quarantine_violations(quarantine, _t)
         return state
@@ -121,7 +119,7 @@ async def update_script_review_content(
     """
     try:
         service = ScriptReviewService(get_project_manager())
-        state = await asyncio.to_thread(service.save_content, project_name, episode, content)
+        state = await service.save_content(project_name, episode, content)
         quarantine = await service.get_quarantine_info(project_name, episode)
         await _attach_duration_tiers(service, project_name, episode, state)
         state["quarantine"] = _localize_quarantine_violations(quarantine, _t)
@@ -142,7 +140,7 @@ async def confirm_script_review(project_name: str, episode: int, _t: Translator)
     """
     try:
         service = ScriptReviewService(get_project_manager())
-        state = await asyncio.to_thread(service.confirm, project_name, episode)
+        state = await service.confirm(project_name, episode)
         await _attach_duration_tiers(service, project_name, episode, state)
         state["quarantine"] = _localize_quarantine_violations(
             await service.get_quarantine_info(project_name, episode), _t

--- a/server/services/project_archive.py
+++ b/server/services/project_archive.py
@@ -1021,9 +1021,10 @@ class ProjectArchiveService:
         # 下游的结构校验（DataValidator）要求 unit 级 duration_seconds 落在结构区间内，
         # 修复须先跑这道迁移再校验——本方法在 validate_project_tree 之前执行、写回结果
         # 由调用方按 script_changed 落盘，与其它字段修复共用同一次写盘。
-        # 档位表取归档自带的 project.json（同步回退链，无 DB 访问——导入跑在 to_thread 里），
-        # 与生成侧、审阅门同源：迁移一次落盘，三处口径不一致会让先跑的把非档位秒数固化。
-        # 归档未声明视频型号时为 None，退回结构区间 clamp。
+        # 档位表按归档自带 project.json 的自报身份查 registry（无 DB 访问——导入跑在 to_thread
+        # 里，且此刻自定义供应商的凭证/能力可能尚未导入本机）：迁移一次落盘，与生成侧、审阅门
+        # 口径不一致会让先跑的把非档位秒数固化。查不到（未声明型号、或自定义供应商不在 registry）
+        # 时为 None，退回结构区间 clamp。
         # provider 先在副本上归一化：本方法跑在 migrate_project_dir 之前，存量归档里可能还是
         # legacy 别名（如 gemini/…），registry 查不到会让档位解析落空，而迁移幂等、归一化之后
         # 再无机会取档。归一化是纯函数且幂等，不影响随后的正式迁移。

--- a/server/services/script_review.py
+++ b/server/services/script_review.py
@@ -108,7 +108,21 @@ class ScriptReviewService:
 
         return self.pm.update_project(project_name, _mutate)
 
-    async def _resolve_supported_durations(self, project: dict[str, Any], episode: int) -> list[int] | None:
+    async def _resolve_caps_best_effort(self, project_name: str, project: dict[str, Any], episode: int) -> dict:
+        """视频能力查询，解析失败时退回空 caps 而非冒穿。
+
+        缺 caps 只是让下游退到 registry / 不收窄这两个既有降级口径，而解析异常直接冒穿会让用户
+        连草稿都加载不了。档位表与档位收窄两条链共用本方法，降级语义因此不会在两处各自漂移。
+        """
+        try:
+            return await resolve_video_caps(project, episode)
+        except Exception as exc:  # noqa: BLE001 - best-effort：解析失败退回空 caps，不阻断 gate
+            logger.warning("video_capabilities 解析异常，审阅门退回不带 caps 的解析 project=%s：%s", project_name, exc)
+            return {}
+
+    async def _resolve_supported_durations(
+        self, project_name: str, project: dict[str, Any], episode: int
+    ) -> list[int] | None:
         """该集收窄前的时长档位全集；非 reference_video 变体或解析不到型号时 None。
 
         caps 先解析、再交 ``resolve_raw_supported_durations``：registry 那一级只收录内建供应商，
@@ -116,19 +130,15 @@ class ScriptReviewService:
         调用会让这类项目恒为 None——读时迁移退回结构区间 clamp、gate 面板也拿不到可选档位，
         存量草稿的收编对其整体失效。
 
-        caps 解析失败（DB / 迁移故障）时退回不带 caps 的 registry 解析，不阻断 gate：缺档位表
-        只是回到结构区间 clamp，而解析异常直接冒穿会让用户连草稿都加载不了。
+        caps 解析失败（DB / 迁移故障）时退回不带 caps 的 registry 解析，不阻断 gate（降级见
+        ``_resolve_caps_best_effort``）：缺档位表只是回到结构区间 clamp。
 
         调用方须在取 ``self.pm.file_lock`` **之前** await 本方法：那把锁是阻塞式文件锁，跨
         await 持有会连带把事件循环上的其它协程挡在锁外。
         """
         if script_review.step1_kind(project, episode) != "reference_video":
             return None
-        try:
-            caps = await resolve_video_caps(project, episode)
-        except Exception as exc:  # noqa: BLE001 - best-effort：解析失败退回 registry 解析，不阻断 gate
-            logger.warning("video_capabilities 解析异常，审阅门档位表退回 registry 解析：%s", exc)
-            caps = {}
+        caps = await self._resolve_caps_best_effort(project_name, project, episode)
         return resolve_raw_supported_durations(project, caps)
 
     def _read_step1_migrated(
@@ -183,7 +193,7 @@ class ScriptReviewService:
         不能跨 await 持有，而档位解析本身要 await 视频能力查询。
         """
         project = await asyncio.to_thread(self.pm.load_project, project_name)
-        supported_durations = await self._resolve_supported_durations(project, episode)
+        supported_durations = await self._resolve_supported_durations(project_name, project, episode)
         return await asyncio.to_thread(self._get_state_sync, project_name, project, episode, supported_durations)
 
     def _get_state_sync(
@@ -231,8 +241,8 @@ class ScriptReviewService:
 
         读时按产出时那套校验器全量重算（``revalidate_reference_step1_draft``，晋升工具同一份
         代码），不信任草稿里 ``violations`` 的上一轮快照——隔离期间源文或模型配置可能已变，
-        报告要对现值负责。``get_state`` 保持同步（无需 await 视频能力解析），故本方法独立于
-        它，由 router 在同一次请求内合并两者的返回。
+        报告要对现值负责。本方法与 ``get_state`` 各自读盘、互不依赖，由 router 在同一次请求内
+        合并两者的返回。
 
         ``content`` 校验通过时返回收编后的扁平产出（时长已按当前档位收编），未通过时返回草稿
         原样内容 + 违约列表，供呈现层原样展示 agent 手改的那份文本。meta 被改坏以致无从重算
@@ -241,8 +251,8 @@ class ScriptReviewService:
 
         项目 / 隔离草稿的同步文件读取经 ``asyncio.to_thread`` 卸到线程——本方法整体是
         ``async``（内部要 ``await`` 重算里的能力解析），若前半截同步 I/O 直接跑在事件循环上，
-        源文越大越占用循环时间，拖慢并发的其它请求；GET 端点已经把 ``get_state`` 包了
-        ``asyncio.to_thread``，这里保持同一纪律。
+        源文越大越占用循环时间，拖慢并发的其它请求；``get_state`` 把同步主体整段卸到线程，
+        这里保持同一纪律。
         """
         project = await asyncio.to_thread(self.pm.load_project, project_name)
         if script_review.step1_kind(project, episode) != "reference_video":
@@ -313,7 +323,8 @@ class ScriptReviewService:
         当短路条件：那是另一个方法的返回值，两者各自判 step1_kind，不互相依赖。
 
         caps 与收窄用的模型身份在本方法内单独解析：``reference_unit_duration_tiers`` 要按
-        caps 里的 provider/model 求联动约束，光有档位表不够。
+        caps 里的 provider/model 求联动约束，光有档位表不够；解析失败的降级与档位表那条链
+        共用 ``_resolve_caps_best_effort``，缺 caps 时收窄回退为不收窄。
 
         项目读取同 ``get_quarantine_info`` 卸到线程——本方法同样是 ``async`` 且由请求协程
         直接 ``await``，同步的 ``project.json`` 读取直接跑在事件循环上会阻塞并发的其它请求。
@@ -321,11 +332,7 @@ class ScriptReviewService:
         project = await asyncio.to_thread(self.pm.load_project, project_name)
         if script_review.step1_kind(project, episode) != "reference_video":
             return None
-        try:
-            caps = await resolve_video_caps(project, episode)
-        except Exception as exc:  # noqa: BLE001 - best-effort：解析失败时收窄回退为不收窄，不阻塞面板
-            logger.warning("video_capabilities 解析异常，时长档下拉退回未收窄集合 project=%s：%s", project_name, exc)
-            caps = {}
+        caps = await self._resolve_caps_best_effort(project_name, project, episode)
         raw = resolve_raw_supported_durations(project, caps)
         if raw is None:
             return None
@@ -375,7 +382,7 @@ class ScriptReviewService:
         用的档位表须与 gate 面板呈现的那份同源，否则确认会把面板上选不到的秒数固化到盘上。
         """
         project = await asyncio.to_thread(self.pm.load_project, project_name)
-        supported_durations = await self._resolve_supported_durations(project, episode)
+        supported_durations = await self._resolve_supported_durations(project_name, project, episode)
         await asyncio.to_thread(self._confirm_sync, project_name, project, episode, supported_durations)
         return await self.get_state(project_name, episode)
 

--- a/server/services/script_review.py
+++ b/server/services/script_review.py
@@ -108,8 +108,36 @@ class ScriptReviewService:
 
         return self.pm.update_project(project_name, _mutate)
 
+    async def _resolve_supported_durations(self, project: dict[str, Any], episode: int) -> list[int] | None:
+        """该集收窄前的时长档位全集；非 reference_video 变体或解析不到型号时 None。
+
+        caps 先解析、再交 ``resolve_raw_supported_durations``：registry 那一级只收录内建供应商，
+        自定义供应商（``custom-`` 前缀）的档位表只有 caps（DB 驱动的能力查询）给得出。不带 caps
+        调用会让这类项目恒为 None——读时迁移退回结构区间 clamp、gate 面板也拿不到可选档位，
+        存量草稿的收编对其整体失效。
+
+        caps 解析失败（DB / 迁移故障）时退回不带 caps 的 registry 解析，不阻断 gate：缺档位表
+        只是回到结构区间 clamp，而解析异常直接冒穿会让用户连草稿都加载不了。
+
+        调用方须在取 ``self.pm.file_lock`` **之前** await 本方法：那把锁是阻塞式文件锁，跨
+        await 持有会连带把事件循环上的其它协程挡在锁外。
+        """
+        if script_review.step1_kind(project, episode) != "reference_video":
+            return None
+        try:
+            caps = await resolve_video_caps(project, episode)
+        except Exception as exc:  # noqa: BLE001 - best-effort：解析失败退回 registry 解析，不阻断 gate
+            logger.warning("video_capabilities 解析异常，审阅门档位表退回 registry 解析：%s", exc)
+            caps = {}
+        return resolve_raw_supported_durations(project, caps)
+
     def _read_step1_migrated(
-        self, project_name: str, project: dict[str, Any], episode: int, path: Path
+        self,
+        project_name: str,
+        project: dict[str, Any],
+        episode: int,
+        path: Path,
+        supported_durations: list[int] | None,
     ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
         """读结构化 step1，并对参考生视频草稿做一次性时长收编迁移；返回 ``(内容, 最新 project)``。
 
@@ -118,11 +146,11 @@ class ScriptReviewService:
         存量草稿若不在读时迁移，保存与确认都会撞结构校验，用户在 gate 里既改不了也确认不了。
         剧集脚本的迁移在 ``ProjectManager.load_script``，草稿的在这里，两处共用同一迁移器。
 
-        档位表走 ``resolve_raw_supported_durations`` 的同步回退链（project.json → registry），
-        与 step2 生成侧同源：迁移幂等一次性、谁先跑谁定终局，两侧口径不一致时先跑的审阅门会
-        把落在结构区间内但非档位成员的秒数固化到盘上，step2 的枚举 schema 随后硬拒，用户在
-        gate 里既看不出问题也改不动。解析不到（项目未配置视频型号）时传 None 退回结构区间
-        clamp——缺配置不该阻断草稿加载，档位偏移仍由执行时取档兜底。
+        ``supported_durations`` 由调用方经 ``_resolve_supported_durations`` 解析后传入（本函数
+        跑在锁内，不能自行 await），与 step2 生成侧同源：迁移幂等一次性、谁先跑谁定终局，两侧
+        口径不一致时先跑的审阅门会把落在结构区间内但非档位成员的秒数固化到盘上，step2 的枚举
+        schema 随后硬拒，用户在 gate 里既看不出问题也改不动。为 None（项目未配置视频型号）时
+        退回结构区间 clamp——缺配置不该阻断草稿加载，档位偏移仍由执行时取档兜底。
 
         调用方须已持有 ``self.pm.file_lock(path)``——本函数只做读改写，不自行加锁，避免与
         调用方（如 ``confirm``）已持有的同一把锁发生同线程二次获取的死锁。
@@ -136,22 +164,40 @@ class ScriptReviewService:
             content,
             episode=episode,
             update_project=lambda mutate: self.pm.update_project(project_name, mutate),
-            supported_durations=resolve_raw_supported_durations(project),
+            supported_durations=supported_durations,
         )
         return content, updated or project
 
-    def get_state(self, project_name: str, episode: int) -> dict[str, Any]:
+    async def get_state(self, project_name: str, episode: int) -> dict[str, Any]:
         """返回该集审核状态 + 结构化中间态内容（供 web 渲染）。
 
         ``content`` 为解析后的结构化 step1（drama: {title, scenes[]}；narration: {segments[]}；
         reference_video: {units[]}）；不适用 gate 或 step1 缺失 / 损坏时为 None。
 
         ``supported_durations`` 只在 reference_video 变体下非 None：unit 时长是档位枚举而非
-        自由秒数，web 侧要按它渲染选择项。取值走与读时迁移同一个 ``resolve_raw_supported_durations``
-        （project.json → registry 同步回退链），两处不同源的话，gate 里能选的档位会与迁移
-        收编到的档位不一致。项目未配置视频型号而解析不到时为 None，呈现层退回只读秒数。
+        自由秒数，web 侧要按它渲染选择项。取值与读时迁移同源（同一次
+        ``_resolve_supported_durations``），两处不同源的话，gate 里能选的档位会与迁移收编到的
+        档位不一致。项目未配置视频型号而解析不到时为 None，呈现层退回只读秒数。
+
+        档位解析先于落盘读写完成，其余同步 I/O 整段卸到线程：``file_lock`` 是阻塞式文件锁，
+        不能跨 await 持有，而档位解析本身要 await 视频能力查询。
         """
-        project = self.pm.load_project(project_name)
+        project = await asyncio.to_thread(self.pm.load_project, project_name)
+        supported_durations = await self._resolve_supported_durations(project, episode)
+        return await asyncio.to_thread(self._get_state_sync, project_name, project, episode, supported_durations)
+
+    def _get_state_sync(
+        self,
+        project_name: str,
+        project: dict[str, Any],
+        episode: int,
+        supported_durations: list[int] | None,
+    ) -> dict[str, Any]:
+        """``get_state`` 的同步主体：分集自愈、读时迁移、状态与指纹派生，全部在一个线程内完成。
+
+        ``project`` 与 ``supported_durations`` 由 ``get_state`` 预先取好传入——迁移不改动视频
+        型号配置，档位表在迁移前后描述的是同一件事，无需在锁内重算。
+        """
         project_path = self.pm.get_project_path(project_name)
         path = script_review.step1_path(project_path, project, episode)
         if path is not None:
@@ -164,7 +210,7 @@ class ScriptReviewService:
             # 迁移可能回写 step1 与确认记录；指纹与状态在同一把锁内、迁移之后取，三者才据
             # 同一份落盘内容派生——锁外取则并发 save_content 会让指纹描述另一份内容。
             with self.pm.file_lock(path):
-                content, project = self._read_step1_migrated(project_name, project, episode, path)
+                content, project = self._read_step1_migrated(project_name, project, episode, path, supported_durations)
                 fingerprint = script_review.content_fingerprint(path)
                 status = script_review.review_status(project_path, project, episode)
         else:
@@ -176,11 +222,7 @@ class ScriptReviewService:
             "fingerprint": fingerprint,
             "confirmed_at": script_review.stored_review(project, episode).get("confirmed_at"),
             "content": content,
-            "supported_durations": (
-                resolve_raw_supported_durations(project)
-                if script_review.step1_kind(project, episode) == "reference_video"
-                else None
-            ),
+            "supported_durations": supported_durations,
         }
 
     async def get_quarantine_info(self, project_name: str, episode: int) -> dict[str, Any] | None:
@@ -258,25 +300,20 @@ class ScriptReviewService:
     async def get_reference_duration_tiers(self, project_name: str, episode: int) -> dict[str, list[int]] | None:
         """reference_video 变体逐 unit 生效时长档位：``{with_references, without_references}``。
 
-        与 ``get_state.supported_durations``（``resolve_raw_supported_durations`` 的结构区间
-        全集，供 ``_read_step1_migrated`` 的存量草稿 clamp）不同源：那个决定「这个秒数结构上
-        合不合法」，这个决定「现在选它，``_assert_reference_step1_ready`` 会不会接受」——分辨率
-        / 参考图联动约束只影响后者。clamp 保持用全集，避免收窄后把结构合法但当前档位表之外
-        的存量秒数误判非法；这里单独给下拉提供收窄后的可选项，同一把尺来自
-        ``reference_unit_duration_tiers``（拆分工具校验用的同一份）。无法解析到型号时返回
+        与 ``get_state.supported_durations``（收窄前的结构区间全集，供 ``_read_step1_migrated``
+        的存量草稿 clamp）取自同一份 ``resolve_raw_supported_durations`` 结果，但用途不同源：
+        那个决定「这个秒数结构上合不合法」，这个决定「现在选它，``_assert_reference_step1_ready``
+        会不会接受」——分辨率 / 参考图联动约束只影响后者。clamp 保持用全集，避免收窄后把结构
+        合法但当前档位表之外的存量秒数误判非法；这里单独给下拉提供收窄后的可选项，同一把尺
+        来自 ``reference_unit_duration_tiers``（拆分工具校验用的同一份）。无法解析到型号时返回
         None，呈现层退回未收窄的 ``supported_durations``。
 
         非 reference_video 变体直接返回 None，不做 caps 解析——调用方（router）按此方法自身
-        的 step1_kind 判断决定是否调用，不再依赖 ``get_state.supported_durations`` 是否非
-        None 这个同步信号：那个信号在自定义供应商（``custom-`` 前缀，caps 是唯一档位来源，
-        同步路径拿不到）下恒为 None，会让本方法永远没机会跑，越档校验随之失效。
+        的 step1_kind 判断决定是否调用，不拿 ``get_state.supported_durations`` 是否非 None
+        当短路条件：那是另一个方法的返回值，两者各自判 step1_kind，不互相依赖。
 
-        caps 先解析：``resolve_raw_supported_durations`` 的三级回退链（caps → project.json
-        ``_supported_durations`` → registry）里，registry 那一级查不到自定义供应商，存量
-        项目也不落 ``_supported_durations``——caps 是自定义供应商唯一能拿到时长表的来源
-        （DB 驱动的能力查询）。caps 若排在 raw 之后解析，自定义供应商项目会在 caps 都没试
-        就因 raw 为 None 提前退出，面板退回只读秒数、越档校验也随之失效，即便 caps 原本能
-        给出正确答案。
+        caps 与收窄用的模型身份在本方法内单独解析：``reference_unit_duration_tiers`` 要按
+        caps 里的 provider/model 求联动约束，光有档位表不够。
 
         项目读取同 ``get_quarantine_info`` 卸到线程——本方法同样是 ``async`` 且由请求协程
         直接 ``await``，同步的 ``project.json`` 读取直接跑在事件循环上会阻塞并发的其它请求。
@@ -295,11 +332,19 @@ class ScriptReviewService:
         with_refs, without_refs = reference_unit_duration_tiers(project, caps, raw)
         return {"with_references": sorted(set(with_refs)), "without_references": sorted(set(without_refs))}
 
-    def save_content(self, project_name: str, episode: int, content: object) -> dict[str, Any]:
+    async def save_content(self, project_name: str, episode: int, content: object) -> dict[str, Any]:
         """校验并落盘编辑后的结构化中间态（手动或 agent 编辑后回写），返回最新状态（重新待审）。
 
         内容变更使指纹漂移，``get_state`` 据此自动回到 pending_review——保存即重新需要确认。
+
+        落盘本身全同步（不做时长收编，无需档位表），整段卸到线程；随后的 ``get_state`` 自行
+        解析档位表，保存的响应与 GET 首次加载因此同源。
         """
+        await asyncio.to_thread(self._save_content_sync, project_name, episode, content)
+        return await self.get_state(project_name, episode)
+
+    def _save_content_sync(self, project_name: str, episode: int, content: object) -> None:
+        """``save_content`` 的同步主体：结构校验、references 重派生、落盘。"""
         project = self.pm.load_project(project_name)
         project_path = self.pm.get_project_path(project_name)
         path = script_review.step1_path(project_path, project, episode)
@@ -319,15 +364,29 @@ class ScriptReviewService:
         # 与 _read_step1_migrated 共享同一把 per-path 锁：保存与迁移的读改写相互互斥。
         with self.pm.file_lock(path):
             atomic_write_json(path, validated)
-        return self.get_state(project_name, episode)
 
-    def confirm(self, project_name: str, episode: int) -> dict[str, Any]:
+    async def confirm(self, project_name: str, episode: int) -> dict[str, Any]:
         """把该集审核状态翻到 confirmed（记录当前 step1 内容指纹），放行 step2。
 
         无 step1 / 不适用 / 集条目缺失 / step1 内容结构非法 / 有违约产物待处置（隔离草稿在场）时
         抛 ScriptReviewError，由 router 映射 4xx。
+
+        档位表先于加锁解析（同 ``get_state``）：确认路径同样要对存量草稿做一次读时收编，收编
+        用的档位表须与 gate 面板呈现的那份同源，否则确认会把面板上选不到的秒数固化到盘上。
         """
-        project = self.pm.load_project(project_name)
+        project = await asyncio.to_thread(self.pm.load_project, project_name)
+        supported_durations = await self._resolve_supported_durations(project, episode)
+        await asyncio.to_thread(self._confirm_sync, project_name, project, episode, supported_durations)
+        return await self.get_state(project_name, episode)
+
+    def _confirm_sync(
+        self,
+        project_name: str,
+        project: dict[str, Any],
+        episode: int,
+        supported_durations: list[int] | None,
+    ) -> None:
+        """``confirm`` 的同步主体：隔离态校验、读时收编、结构校验、指纹落盘。"""
         project_path = self.pm.get_project_path(project_name)
         path = script_review.step1_path(project_path, project, episode)
         if path is None:
@@ -343,7 +402,7 @@ class ScriptReviewService:
         # per-path 锁覆盖读改写全程（含下方 reference_video 分支自己的落盘），避免中途被
         # save_content 或迁移的写入插队——_read_step1_migrated 要求调用方已持锁。
         with self.pm.file_lock(path):
-            content, project = self._read_step1_migrated(project_name, project, episode, path)
+            content, project = self._read_step1_migrated(project_name, project, episode, path, supported_durations)
             if content is None and not path.exists():
                 raise ScriptReviewError("no_step1")
             # 确认前按 step1 变体模型校验 step1 结构：content 为 None（非法 JSON / 非对象）同样会
@@ -373,7 +432,6 @@ class ScriptReviewService:
                 raise ScriptReviewError("episode_not_found")
 
         self.pm.update_project(project_name, _mutate)
-        return self.get_state(project_name, episode)
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:

--- a/tests/lib/test_script_generator_reference_branch.py
+++ b/tests/lib/test_script_generator_reference_branch.py
@@ -61,7 +61,7 @@ def reference_project(tmp_path: Path) -> Path:
           "title": "t",
           "content_mode": "narration",
           "generation_mode": "reference_video",
-          "_supported_durations": [4, 8],
+          "video_backend": "vidu/vidu2.0",
           "overview": {"synopsis": "s", "genre": "g", "theme": "th", "world_setting": "w"},
           "style": "国漫",
           "style_description": "水墨",
@@ -288,13 +288,13 @@ async def test_script_generator_takes_duration_tier_from_final_output_references
 @pytest.mark.integration
 async def test_script_generator_reclamps_duration_even_when_caps_unavailable(reference_project: Path):
     """caps 解析失败（``_fetch_video_capabilities`` 按其文档在这种情况下返回 None）不代表
-    取不到任何档位——``_resolve_supported_durations`` 自带 caps → project.json → registry
-    三级回退，project.json 的 ``_supported_durations`` 仍能兜底。回填逻辑须无条件取档，
+    取不到任何档位——``_resolve_supported_durations`` 自带 caps → registry 两级回退，
+    project.json 自报的模型身份仍能兜底。回填逻辑须无条件取档，
     不能因为 caps 是 None 就保留一个未经取档的值。
 
     与其它同类测试一样另 mock ``_resolve_supported_durations`` 本身（而非验证真实回退链
-    ——那是 config resolver 层的测试范畴）：本 fixture 未注册模型，caps=None 时的回退结果
-    与 caps 非 None 时一样都是 project.json 全量声明的 [4, 8]，raw 值只要合法就不会触发
+    ——那是 config resolver 层的测试范畴）：caps=None 时的回退结果与 caps 非 None 时一样
+    都是 registry 声明的 [4, 8]，raw 值只要合法就不会触发
     任何取档，测不出「取档有没有被跳过」这个真正要验证的行为；只有固定取档结果本身，
     才能构造出「已确认值不在生效档位内」的场景来证明重取档确实执行了——如今这种不合法
     直接 fail-loud，执行了就必抛错，不执行就会静默用未取档的 4 落盘成功。
@@ -418,7 +418,7 @@ async def test_script_generator_reference_branch_inherits_drama_content_mode(tmp
           "title": "t",
           "content_mode": "drama",
           "generation_mode": "reference_video",
-          "_supported_durations": [4, 8],
+          "video_backend": "vidu/vidu2.0",
           "overview": {"synopsis": "s", "genre": "g", "theme": "th", "world_setting": "w"},
           "style": "国漫", "style_description": "水墨",
           "characters": {"主角": {"description": "d"}},
@@ -513,9 +513,9 @@ def test_resolve_max_refs_from_registry_fallback(tmp_path: Path, video_backend, 
 
 @pytest.mark.asyncio
 async def test_build_prompt_no_video_backend_raises_value_error(tmp_path: Path):
-    """project.json 缺 video_backend 且无 _supported_durations 且 caps 不可解析时，build_prompt 应抛 ValueError。
+    """project.json 缺 video_backend 且 caps 不可解析时，build_prompt 应抛 ValueError。
 
-    设计意图：supported_durations 是单一真相源，必须由 caps（DB 全局默认）或 project.json 显式声明提供；
+    设计意图：supported_durations 是单一真相源，必须由 caps（DB 全局默认）或 project.json 自报身份查 registry 提供；
     都拿不到才 fail loud，避免向 LLM 注入兜底 [4, 8] 误导生成。
     用 mock 把 _fetch_video_capabilities 强制返 None，模拟无任何 model 配置的环境。
     """
@@ -584,7 +584,7 @@ async def test_effective_generation_mode_honors_episode_override(tmp_path: Path)
                 "title": "t",
                 "content_mode": "narration",
                 "generation_mode": "storyboard",  # 项目级是 storyboard
-                "_supported_durations": [4, 8],
+                "video_backend": "vidu/vidu2.0",
                 "overview": {"synopsis": "s", "genre": "g", "theme": "t", "world_setting": "w"},
                 "style": "s",
                 "style_description": "d",
@@ -658,7 +658,7 @@ async def test_reference_step1_rejects_out_of_enum_duration(reference_project: P
     )
 
     gen = ScriptGenerator(reference_project)
-    # 固定能力来源为 project.json 的 _supported_durations=[4,8]，隔离 DB 全局默认干扰
+    # 固定能力来源为 project.json 自报身份查 registry（vidu2.0 → [4, 8]），隔离 DB 全局默认干扰
     with patch(
         "lib.script_generator.ScriptGenerator._fetch_video_capabilities",
         new=AsyncMock(return_value=None),

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -9,6 +9,7 @@ from lib.config.resolver import (
     VideoBucketCapabilityError,
     caps_generation_mode,
     constrain_durations_for_project,
+    resolve_raw_supported_durations,
     video_bucket_for_generation_mode,
 )
 from lib.config.service import ProviderStatus
@@ -1931,3 +1932,40 @@ class TestEpisodeEffectiveGenerationMode:
         caps = await self._caps(project, 2)
         assert caps["generation_mode"] == "reference_video"
         assert caps["max_reference_images"] == 1
+
+
+class TestResolveRawSupportedDurations:
+    """收窄前的时长全集：caps → registry 两级解析。"""
+
+    _VEO_PROJECT = {"video_backend": "gemini-aistudio/veo-3.1-generate-preview"}
+
+    @pytest.mark.unit
+    def test_caps_take_precedence_over_registry(self):
+        """caps 是 DB 驱动的当下真相，压过 project.json 自报身份查到的静态声明。"""
+        caps = {"supported_durations": [5, 10]}
+        assert resolve_raw_supported_durations(dict(self._VEO_PROJECT), caps) == [5, 10]
+
+    @pytest.mark.unit
+    def test_falls_back_to_registry_identity_without_caps(self):
+        assert resolve_raw_supported_durations(dict(self._VEO_PROJECT)) == [4, 6, 8]
+
+    @pytest.mark.unit
+    def test_custom_provider_resolves_only_through_caps(self):
+        """``custom-`` 前缀不在 registry：不带 caps 时无从解析，带 caps 时取 caps 的档位表。
+
+        这条是审阅门必须先解析 caps 的原因——同步两级链对自定义供应商恒为 None。
+        """
+        project = {"video_backend": "custom-7/acme-video"}
+        assert resolve_raw_supported_durations(project) is None
+        assert resolve_raw_supported_durations(project, {"supported_durations": [5, 10]}) == [5, 10]
+
+    @pytest.mark.unit
+    def test_project_json_duration_field_is_not_a_source(self):
+        """project.json 不是档位来源：无生产写入者的字段不得再被当作一级回退读取，
+        否则伪造 / 陈旧的项目字段会盖过 registry 的真实声明。"""
+        project = dict(self._VEO_PROJECT) | {"_supported_durations": [99]}
+        assert resolve_raw_supported_durations(project) == [4, 6, 8]
+
+    @pytest.mark.unit
+    def test_none_when_no_resolvable_model(self):
+        assert resolve_raw_supported_durations({}) is None

--- a/tests/test_project_archive_reference_video.py
+++ b/tests/test_project_archive_reference_video.py
@@ -93,7 +93,6 @@ def _create_reference_video_project(
     unit: dict | None = None,
     write_clip: bool = True,
     write_thumbnail: bool = True,
-    supported_durations: list[int] | None = None,
 ) -> Path:
     pm.create_project(name)
     pm.create_project_metadata(name, "RefDemo", "Anime", "narration")
@@ -101,8 +100,6 @@ def _create_reference_video_project(
     project_dir = pm.get_project_path(name)
     project = pm.load_project(name)
     project["generation_mode"] = "reference_video"
-    if supported_durations is not None:
-        project["_supported_durations"] = supported_durations
     project["style_image"] = "style_reference.png"
     project["episodes"] = [
         {
@@ -191,43 +188,6 @@ class TestProjectArchiveReferenceVideo:
         assert "duration" not in unit["shots"][0]
 
     @pytest.mark.integration
-    def test_import_takes_slot_from_archived_supported_durations(self, tmp_path):
-        """归档导入的迁移与生成侧、审阅门取同一份档位表（此处经归档自带 project.json 的
-        同步回退链）：迁移一次落盘，口径不一致会让导入把非档位秒数固化进剧本。
-        """
-        pm = ProjectManager(tmp_path / "projects")
-        legacy_unit = {
-            "unit_id": "E1U1",
-            # 求和 10s：落在结构区间内、不是档位成员，只做结构 clamp 时会原样固化。
-            "shots": [{"duration": 6, "text": "镜头一"}, {"duration": 4, "text": "镜头二"}],
-            "references": [],
-            "transition_to_next": "cut",
-            "generated_assets": {
-                "storyboard_image": None,
-                "storyboard_last_image": None,
-                "video_clip": "reference_videos/E1U1.mp4",
-                "video_thumbnail": "reference_videos/thumbnails/E1U1.jpg",
-                "video_uri": REMOTE_VIDEO_URI,
-                "grid_id": None,
-                "grid_cell_index": None,
-                "status": "completed",
-            },
-        }
-        project_dir = _create_reference_video_project(pm, unit=legacy_unit, supported_durations=[4, 8, 12])
-        service = ProjectArchiveService(pm)
-
-        archive_path = tmp_path / "legacy-slot.zip"
-        _make_manual_zip(project_dir, archive_path)
-        shutil.rmtree(project_dir)
-
-        result = service.import_project_archive(archive_path, uploaded_filename="legacy-slot.zip")
-
-        imported = json.loads(
-            (pm.get_project_path(result.project_name) / "scripts" / "episode_1.json").read_text(encoding="utf-8")
-        )
-        assert imported["video_units"][0]["duration_seconds"] == 12
-
-    @pytest.mark.integration
     def test_import_resolves_tiers_for_legacy_provider_alias(self, tmp_path):
         """归档修复跑在 provider 归一化之前：video_backend 仍是 legacy 别名时也要解析出档位。
 
@@ -252,7 +212,7 @@ class TestProjectArchiveReferenceVideo:
             },
         }
         project_dir = _create_reference_video_project(pm, unit=legacy_unit)
-        # legacy 别名 + 未落 _supported_durations：档位只能靠归一化后查 registry 得到。
+        # legacy 别名：档位只能靠归一化后查 registry 得到。
         project_file = project_dir / "project.json"
         payload = json.loads(project_file.read_text(encoding="utf-8"))
         payload["video_backend"] = "gemini/veo-3.1-generate-preview"

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -180,6 +180,7 @@ class TestScriptGenerator:
         _write_step1_json(project_path, 1, [_step1_seg("E1S01", "第一段原文，逐字保留。", duration=4)])
 
         generator = ScriptGenerator(project_path)  # 无 client
+        generator._fetch_video_capabilities = _fixed_caps_468
         prompt = await generator.build_prompt(1)
 
         assert "E1S01" in prompt
@@ -206,6 +207,7 @@ class TestScriptGenerator:
         _write_step1_json(project_path, 1, [_step1_seg("E1S01", "verbatim source line.", duration=4)])
 
         generator = ScriptGenerator(project_path)
+        generator._fetch_video_capabilities = _fixed_caps_468
         prompt = await generator.build_prompt(1)
 
         # 输出语言锁定为项目 source_language，不回落默认中文
@@ -545,6 +547,7 @@ class TestScriptGenerator:
         # drama 两段式：step2 LLM 只出视觉层，后端按 scene_id 合并回 step1 内容
         fake = _FakeTextGenerator(json.dumps(_drama_visual_response(), ensure_ascii=False))
         generator = ScriptGenerator(project_path, generator=fake)
+        generator._fetch_video_capabilities = _fixed_caps_468
         output = await generator.generate(1)
 
         payload = json.loads(output.read_text(encoding="utf-8"))
@@ -629,6 +632,7 @@ class TestScriptGenerator:
 
         fake = _FakeTextGenerator(json.dumps(_drama_visual_response(), ensure_ascii=False))
         generator = ScriptGenerator(project_path, generator=fake)
+        generator._fetch_video_capabilities = _fixed_caps_468
         await generator.generate(1)
 
         schema = fake.backend.last_request.response_schema
@@ -655,6 +659,7 @@ class TestScriptGenerator:
         # 空视觉响应 → 合并时 step1 场景缺视觉，fail-loud；但模型调用已发生，仍可断言请求参数
         fake = _FakeTextGenerator(json.dumps({"foo": "bar"}))
         generator = ScriptGenerator(project_path, generator=fake)
+        generator._fetch_video_capabilities = _fixed_caps_468
         with pytest.raises(DramaVisualMergeError):
             await generator.generate(1)
 
@@ -1638,6 +1643,7 @@ class TestAdScriptGeneration:
         _write_ad_project(project_path)
 
         generator = ScriptGenerator(project_path)
+        generator._fetch_video_capabilities = _fixed_caps_468
         prompt = await generator.build_prompt(1)
 
         assert "带货八段框架" in prompt
@@ -1668,6 +1674,7 @@ class TestAdScriptGeneration:
         _write_json(project_json_path, payload)
 
         generator = ScriptGenerator(project_path)
+        generator._fetch_video_capabilities = _fixed_caps_468
         prompt = await generator.build_prompt(1)
 
         # 口播语速折算按 en 口径（约 2.5 词/秒），不得回落默认 zh 口径（约 5 字/秒）
@@ -1701,6 +1708,7 @@ class TestAdScriptGeneration:
         )
 
         generator = ScriptGenerator(project_path)
+        generator._fetch_video_capabilities = _fixed_caps_468
         prompt = await generator.build_prompt(1)
 
         # products 归一化为空 → 自动分流通用短片 prompt，不落带货框架

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -63,7 +63,6 @@ def _write_drama_ledger_project(project_path: Path, episodes: list[dict], charac
             "characters": characters or {},
             "style": "古风",
             "style_description": "cinematic",
-            "_supported_durations": [4, 6, 8],
             "episodes": episodes,
         },
     )
@@ -74,7 +73,6 @@ def _drama_project_with_backend(
     *,
     backend: str,
     resolution: str,
-    supported_durations: list[int] | None = None,
 ):
     """造一个指定视频后端 + 分辨率的最小 drama 项目，返回项目路径。
 
@@ -88,8 +86,6 @@ def _drama_project_with_backend(
     project = json.loads((project_path / "project.json").read_text(encoding="utf-8"))
     project["video_backend"] = backend
     project["model_settings"] = {backend: {"resolution": resolution}}
-    if supported_durations is not None:
-        project["_supported_durations"] = supported_durations
     _write_json(project_path / "project.json", project)
     return project_path
 
@@ -179,7 +175,6 @@ class TestScriptGenerator:
                 "clues": {"玉佩": {}},
                 "style": "古风",
                 "style_description": "cinematic",
-                "_supported_durations": [4, 6, 8],
             },
         )
         _write_step1_json(project_path, 1, [_step1_seg("E1S01", "第一段原文，逐字保留。", duration=4)])
@@ -206,7 +201,6 @@ class TestScriptGenerator:
                 "style": "古风",
                 "style_description": "cinematic",
                 "source_language": "English",
-                "_supported_durations": [4, 6, 8],
             },
         )
         _write_step1_json(project_path, 1, [_step1_seg("E1S01", "verbatim source line.", duration=4)])
@@ -369,9 +363,7 @@ class TestScriptGenerator:
 
         海螺 1080p 只接受 6 秒，而 DramaSceneContent 的默认是 8 秒，故该场景须被拦下。
         """
-        project_path = _drama_project_with_backend(
-            tmp_path, backend="minimax/MiniMax-Hailuo-2.3", resolution="1080p", supported_durations=[6, 10]
-        )
+        project_path = _drama_project_with_backend(tmp_path, backend="minimax/MiniMax-Hailuo-2.3", resolution="1080p")
 
         content = _drama_step1_content()
         del content["scenes"][0]["duration_seconds"]
@@ -386,9 +378,7 @@ class TestScriptGenerator:
         `dict.get` 的默认值只在缺键时生效，显式 null 会取到 None；不特判的话该场景跳过校验，
         要等 step2 跑完、落盘时才被 Pydantic 拒，白耗一次完整的剧本生成调用。
         """
-        project_path = _drama_project_with_backend(
-            tmp_path, backend="minimax/MiniMax-Hailuo-2.3", resolution="1080p", supported_durations=[6, 10]
-        )
+        project_path = _drama_project_with_backend(tmp_path, backend="minimax/MiniMax-Hailuo-2.3", resolution="1080p")
 
         content = _drama_step1_content()
         content["scenes"][0]["duration_seconds"] = None
@@ -505,7 +495,6 @@ class TestScriptGenerator:
                 "clues": {"玉佩": {}},
                 "style": "古风",
                 "style_description": "cinematic",
-                "_supported_durations": [4, 6, 8],
             },
         )
         _write_step1_json(
@@ -579,7 +568,6 @@ class TestScriptGenerator:
                 "characters": {"姜月茴": {}},
                 "style": "古风",
                 "style_description": "cinematic",
-                "_supported_durations": [4, 6, 8],
                 "episodes": [
                     {"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"},
                 ],
@@ -611,7 +599,6 @@ class TestScriptGenerator:
                 "clues": {"玉佩": {}},
                 "style": "古风",
                 "style_description": "cinematic",
-                "_supported_durations": [4, 6, 8],
             },
         )
         # step1 误写集号前缀 E1（应为 E10）
@@ -719,7 +706,6 @@ class TestAddMetadataRewritesEpisodePrefix:
             {
                 "title": "项目",
                 "content_mode": content_mode,
-                "_supported_durations": [4, 6, 8],
             },
         )
         return ScriptGenerator(project_path)
@@ -757,7 +743,6 @@ class TestAddMetadataRewritesEpisodePrefix:
                 "title": "项目",
                 "content_mode": "narration",
                 "generation_mode": "reference_video",
-                "_supported_durations": [8],
             },
         )
         sg = ScriptGenerator(project_path)
@@ -803,7 +788,6 @@ class TestAddMetadataInjectsHiddenFields:
             {
                 "title": "项目标题",
                 "content_mode": content_mode,
-                "_supported_durations": [4, 6, 8],
             },
         )
         return ScriptGenerator(project_path)
@@ -1619,7 +1603,6 @@ def _write_ad_project(project_path: Path, *, generation_mode: str = "storyboard"
         "style": "实拍",
         "style_description": "真实质感",
         "aspect_ratio": "9:16",
-        "_supported_durations": [4, 6, 8],
         "episodes": [{"episode": 1, "title": "", "script_file": "scripts/episode_1.json"}],
     }
     _write_json(project_path / "project.json", payload)
@@ -1713,7 +1696,6 @@ class TestAdScriptGeneration:
                 "style": None,
                 "style_description": None,
                 "aspect_ratio": "9:16",
-                "_supported_durations": [4, 6, 8],
                 "episodes": [{"episode": 1, "title": "", "script_file": "scripts/episode_1.json"}],
             },
         )

--- a/tests/test_script_review.py
+++ b/tests/test_script_review.py
@@ -81,27 +81,56 @@ def _rv_step1() -> dict:
     }
 
 
+def _stub_video_caps(
+    monkeypatch: pytest.MonkeyPatch,
+    supported_durations: list[int] | None,
+    *,
+    provider_id: str = "custom-acme",
+    model: str = "acme-video",
+) -> None:
+    """替身审阅门的视频能力查询，按给定档位表作答。
+
+    档位表经 caps 注入而非项目字段：caps（DB 驱动的能力查询）是自定义供应商唯一的档位来源，
+    也是审阅门实际走的那条路径。``supported_durations`` 为 None 时返回空 caps，等价于
+    「解析不到型号」。默认身份取自定义供应商——它不在 ``PROVIDER_REGISTRY``，不带联动约束，
+    档位表因而原样生效。
+    """
+    from server.services import script_review as mod
+
+    async def _fake_caps(_project, _episode=None):
+        if supported_durations is None:
+            return {}
+        return {"provider_id": provider_id, "model": model, "supported_durations": list(supported_durations)}
+
+    monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
+
+
+@pytest.fixture(autouse=True)
+def _unresolvable_video_caps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """本模块默认让能力查询解析不到型号：不碰 DB，也不让系统级默认模型的档位漂进断言。
+
+    需要具体档位表的用例用 ``_stub_video_caps`` 就地覆盖。
+    """
+    _stub_video_caps(monkeypatch, None)
+
+
 def _make_project(
     tmp_path: Path,
     content_mode: str,
     *,
     generation_mode: str | None = None,
-    supported_durations: list[int] | None = None,
 ) -> ProjectManager:
-    """建测试项目；``supported_durations`` 落到 ``_supported_durations``，供审阅门的档位解析取用。"""
+    """建测试项目；档位表另经 ``_stub_video_caps`` 注入。"""
     pm = ProjectManager(tmp_path / "projects")
     pm.create_project("demo")
     pm.create_project_metadata("demo", "Demo", "Anime", content_mode)
     pm.add_character("demo", "阿离", "少女")
     pm.add_character("demo", "裴与", "将军")
     pm.add_episode("demo", 1, "第一集", "scripts/episode_1.json")
-    if generation_mode is not None or supported_durations is not None:
+    if generation_mode is not None:
 
         def _set_mode(p: dict) -> None:
-            if generation_mode is not None:
-                p["generation_mode"] = generation_mode
-            if supported_durations is not None:
-                p["_supported_durations"] = supported_durations
+            p["generation_mode"] = generation_mode
 
         pm.update_project("demo", _set_mode)
     return pm
@@ -168,16 +197,16 @@ def _write_source_text(pm: ProjectManager, filename: str, text: str) -> Path:
 
 
 class TestDramaGateFlow:
-    def test_no_step1_then_pending_then_confirmed(self, tmp_path):
+    async def test_no_step1_then_pending_then_confirmed(self, tmp_path):
         pm = _make_project(tmp_path, "drama")
         svc = ScriptReviewService(pm)
 
         # step1 未产出
-        assert svc.get_state("demo", 1)["status"] == "no_step1"
+        assert (await svc.get_state("demo", 1))["status"] == "no_step1"
 
         # step1 产出 → 可审中间态、阻塞
         _write_step1(pm, "drama", _drama_step1())
-        state = svc.get_state("demo", 1)
+        state = await svc.get_state("demo", 1)
         assert state["status"] == "pending_review"
         assert state["content"]["scenes"][0]["scene_id"] == "E1S01"
         assert state["content"]["scenes"][0]["utterances"][1]["speaker"] == "阿离"
@@ -186,38 +215,38 @@ class TestDramaGateFlow:
         assert script_review.gate_blocks_step2(project_path, project, 1) is True
 
         # 确认 → 放行
-        confirmed = svc.confirm("demo", 1)
+        confirmed = await svc.confirm("demo", 1)
         assert confirmed["status"] == "confirmed"
         assert confirmed["confirmed_at"]
         project = pm.load_project("demo")
         assert script_review.gate_blocks_step2(project_path, project, 1) is False
 
-    def test_editing_step1_after_confirm_repends(self, tmp_path):
+    async def test_editing_step1_after_confirm_repends(self, tmp_path):
         pm = _make_project(tmp_path, "drama")
         svc = ScriptReviewService(pm)
         _write_step1(pm, "drama", _drama_step1())
-        svc.confirm("demo", 1)
-        assert svc.get_state("demo", 1)["status"] == "confirmed"
+        await svc.confirm("demo", 1)
+        assert (await svc.get_state("demo", 1))["status"] == "confirmed"
 
         # 内容变更（指纹漂移）→ 自动重新待审
         edited = _drama_step1()
         edited["scenes"][0]["utterances"][1]["text"] = "你怎么才回来。"
-        svc.save_content("demo", 1, edited)
+        await svc.save_content("demo", 1, edited)
 
-        state = svc.get_state("demo", 1)
+        state = await svc.get_state("demo", 1)
         assert state["status"] == "pending_review"
         assert state["content"]["scenes"][0]["utterances"][1]["text"] == "你怎么才回来。"
 
-    def test_whitespace_reformat_keeps_confirmed(self, tmp_path):
+    async def test_whitespace_reformat_keeps_confirmed(self, tmp_path):
         """纯键序 / 空白重排不改语义 → 指纹不变、保持 confirmed。"""
         pm = _make_project(tmp_path, "drama")
         svc = ScriptReviewService(pm)
         path = _write_step1(pm, "drama", _drama_step1())
-        svc.confirm("demo", 1)
+        await svc.confirm("demo", 1)
 
         # 同内容、不同缩进 / 键序重写
         path.write_text(json.dumps(_drama_step1(), ensure_ascii=False, indent=4), encoding="utf-8")
-        assert svc.get_state("demo", 1)["status"] == "confirmed"
+        assert (await svc.get_state("demo", 1))["status"] == "confirmed"
 
 
 # ---------------------------------------------------------------------------
@@ -226,27 +255,27 @@ class TestDramaGateFlow:
 
 
 class TestNarrationGateFlow:
-    def test_pending_then_confirm(self, tmp_path):
+    async def test_pending_then_confirm(self, tmp_path):
         pm = _make_project(tmp_path, "narration")
         svc = ScriptReviewService(pm)
         _write_step1(pm, "narration", _narration_step1())
 
-        state = svc.get_state("demo", 1)
+        state = await svc.get_state("demo", 1)
         assert state["status"] == "pending_review"
         assert state["content"]["segments"][0]["novel_text"].startswith("裴与")
 
-        assert svc.confirm("demo", 1)["status"] == "confirmed"
+        assert (await svc.confirm("demo", 1))["status"] == "confirmed"
 
-    def test_edit_novel_text_repends(self, tmp_path):
+    async def test_edit_novel_text_repends(self, tmp_path):
         pm = _make_project(tmp_path, "narration")
         svc = ScriptReviewService(pm)
         _write_step1(pm, "narration", _narration_step1())
-        svc.confirm("demo", 1)
+        await svc.confirm("demo", 1)
 
         edited = _narration_step1()
         edited["segments"][0]["novel_text"] = "裴与出征后的第三年。"
-        svc.save_content("demo", 1, edited)
-        assert svc.get_state("demo", 1)["status"] == "pending_review"
+        await svc.save_content("demo", 1, edited)
+        assert (await svc.get_state("demo", 1))["status"] == "pending_review"
 
 
 # ---------------------------------------------------------------------------
@@ -255,48 +284,48 @@ class TestNarrationGateFlow:
 
 
 class TestReferenceVideoGateFlow:
-    def test_no_step1_then_pending_then_confirmed(self, tmp_path):
+    async def test_no_step1_then_pending_then_confirmed(self, tmp_path):
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
         project_path = pm.get_project_path("demo")
 
         # step1 未产出
-        assert svc.get_state("demo", 1)["status"] == "no_step1"
+        assert (await svc.get_state("demo", 1))["status"] == "no_step1"
 
         # step1 产出 → 可审中间态、阻塞 step2
         _write_rv_step1(pm, _rv_step1())
-        state = svc.get_state("demo", 1)
+        state = await svc.get_state("demo", 1)
         assert state["status"] == "pending_review"
         assert state["content"]["units"][0]["unit_id"] == "E1U01"
         assert state["content"]["units"][0]["shots"][0]["text"].startswith("@[阿离]")
         assert script_review.gate_blocks_step2(project_path, pm.load_project("demo"), 1) is True
 
         # 确认 → 放行
-        confirmed = svc.confirm("demo", 1)
+        confirmed = await svc.confirm("demo", 1)
         assert confirmed["status"] == "confirmed"
         assert confirmed["confirmed_at"]
         assert script_review.gate_blocks_step2(project_path, pm.load_project("demo"), 1) is False
 
-    def test_editing_shot_text_repends_and_rederives_references(self, tmp_path):
+    async def test_editing_shot_text_repends_and_rederives_references(self, tmp_path):
         """编辑 shot 文本 → 重新待审；references 随正文 @ 引用机械重派生（不采用入参陈旧值）。"""
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         pm.add_scenes_batch("demo", {"屋檐": {"description": "雨夜屋檐"}})
         svc = ScriptReviewService(pm)
         _write_rv_step1(pm, _rv_step1())
-        svc.confirm("demo", 1)
-        assert svc.get_state("demo", 1)["status"] == "confirmed"
+        await svc.confirm("demo", 1)
+        assert (await svc.get_state("demo", 1))["status"] == "confirmed"
 
         # 正文引用从 @[裴与] 改为 @[屋檐]，同时故意保留陈旧 references（应被重派生覆盖）。
         edited = _rv_step1()
         edited["units"][0]["shots"][1]["text"] = "镜头扫过 @[屋檐]。"
-        svc.save_content("demo", 1, edited)
+        await svc.save_content("demo", 1, edited)
 
-        state = svc.get_state("demo", 1)
+        state = await svc.get_state("demo", 1)
         assert state["status"] == "pending_review"
         refs = state["content"]["units"][0]["references"]
         assert [(r["type"], r["name"]) for r in refs] == [("character", "阿离"), ("scene", "屋檐")]
 
-    def test_quarantined_step1_blocks_confirm_and_step2(self, tmp_path):
+    async def test_quarantined_step1_blocks_confirm_and_step2(self, tmp_path):
         """隔离草稿在场 → 确认被拒、step2 被阻塞，即使正式 step1 早已确认过。
 
         隔离态与「正式 step1 的内容指纹」是两件事：重拆分违约时正式文件原封不动，只看指纹
@@ -306,8 +335,8 @@ class TestReferenceVideoGateFlow:
         svc = ScriptReviewService(pm)
         project_path = pm.get_project_path("demo")
         _write_rv_step1(pm, _rv_step1())
-        svc.confirm("demo", 1)
-        assert svc.get_state("demo", 1)["status"] == "confirmed"
+        await svc.confirm("demo", 1)
+        assert (await svc.get_state("demo", 1))["status"] == "confirmed"
 
         write_quarantine(
             project_path,
@@ -317,15 +346,15 @@ class TestReferenceVideoGateFlow:
             violations=[DraftViolation("坏", code="empty_text", label="unit E1U01")],
         )
 
-        assert svc.get_state("demo", 1)["status"] == "pending_review"
+        assert (await svc.get_state("demo", 1))["status"] == "pending_review"
         assert script_review.gate_blocks_step2(project_path, pm.load_project("demo"), 1) is True
         with pytest.raises(ScriptReviewError) as exc:
-            svc.confirm("demo", 1)
+            await svc.confirm("demo", 1)
         assert exc.value.code == "quarantined"
 
         # 草稿清除后回到既有的指纹判定（内容未变，确认仍然有效）
         clear_quarantine(project_path, 1, QUARANTINE_KIND_STEP1)
-        assert svc.get_state("demo", 1)["status"] == "confirmed"
+        assert (await svc.get_state("demo", 1))["status"] == "confirmed"
 
     def test_quarantine_not_applicable_to_non_reference_paths(self, tmp_path):
         """drama / narration 无隔离草稿概念：路径解析返回 None，状态判定不受影响。"""
@@ -334,7 +363,7 @@ class TestReferenceVideoGateFlow:
         assert script_review.step1_quarantine_path(project_path, pm.load_project("demo"), 1) is None
         assert script_review.step1_quarantined(project_path, pm.load_project("demo"), 1) is False
 
-    def test_confirm_rejects_unit_duration_out_of_range(self, tmp_path):
+    async def test_confirm_rejects_unit_duration_out_of_range(self, tmp_path):
         """损坏的 step1（unit 时长越界）→ 确认被结构校验拒绝，不放行 step2。"""
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
@@ -342,10 +371,10 @@ class TestReferenceVideoGateFlow:
         bad["units"][0]["duration_seconds"] = 9999  # 超出 unit 时长的结构合理性区间
         _write_rv_step1(pm, bad)
         with pytest.raises(ScriptReviewError) as exc:
-            svc.confirm("demo", 1)
+            await svc.confirm("demo", 1)
         assert exc.value.code == "invalid_content"
 
-    def test_confirm_rederives_references_when_step1_edited_outside_save_content(self, tmp_path):
+    async def test_confirm_rederives_references_when_step1_edited_outside_save_content(self, tmp_path):
         """confirm 前直改 step1 文件（绕过 save_content，如 agent Write/Edit 直改 drafts/）→
         确认时按当前正文重派生 references 并落盘，不放行陈旧引用。"""
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
@@ -357,7 +386,7 @@ class TestReferenceVideoGateFlow:
         stale["units"][0]["shots"][1]["text"] = "镜头扫过 @[屋檐]。"
         path = _write_rv_step1(pm, stale)
 
-        confirmed = svc.confirm("demo", 1)
+        confirmed = await svc.confirm("demo", 1)
         assert confirmed["status"] == "confirmed"
         refs = confirmed["content"]["units"][0]["references"]
         assert [(r["type"], r["name"]) for r in refs] == [("character", "阿离"), ("scene", "屋檐")]
@@ -379,7 +408,8 @@ class TestReferenceVideoGateFlow:
         """
         from server.services import script_review as mod
 
-        pm = _make_project(tmp_path, "drama", generation_mode="reference_video", supported_durations=[4, 6, 8])
+        _stub_video_caps(monkeypatch, [4, 6, 8])
+        pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
 
         async def _fake_caps(_project, _episode=None):
@@ -395,7 +425,7 @@ class TestReferenceVideoGateFlow:
 
     @pytest.mark.integration
     async def test_reference_duration_tiers_none_when_caps_and_raw_both_unresolved(self, tmp_path, monkeypatch):
-        """caps 解析失败、且 ``_supported_durations`` 与 registry 身份都拿不到时为 None，
+        """caps 解析失败、且 registry 身份也拿不到时为 None，
         呈现层退回未收窄的 ``supported_durations``（同 clamp 的回退口径）。
 
         项目完全未配置视频型号也不代表 caps 会失败——``resolve_video_caps`` 内部的
@@ -432,10 +462,9 @@ class TestReferenceVideoGateFlow:
 
     @pytest.mark.integration
     async def test_reference_duration_tiers_uses_caps_for_custom_provider(self, tmp_path, monkeypatch):
-        """自定义供应商（``custom-`` 前缀）不在 ``PROVIDER_REGISTRY``、也不落
-        ``_supported_durations``：档位表唯一来源是 caps（DB 驱动的能力查询）。caps 必须先于
-        ``resolve_raw_supported_durations`` 解析，否则 raw 会因取不到而提前返回 None，
-        永远不会用上 caps 本能给出的答案。
+        """自定义供应商（``custom-`` 前缀）不在 ``PROVIDER_REGISTRY``：档位表唯一来源是 caps
+        （DB 驱动的能力查询）。caps 必须先于 ``resolve_raw_supported_durations`` 解析，否则
+        raw 会因取不到而提前返回 None，永远不会用上 caps 本能给出的答案。
         """
         from server.services import script_review as mod
 
@@ -466,14 +495,15 @@ class TestReferenceVideoStep1Migration:
         legacy["units"][0]["shots"][1]["duration"] = 3
         return legacy
 
-    def test_migration_takes_slot_so_step2_never_sees_a_non_member_duration(self, tmp_path):
+    async def test_migration_takes_slot_so_step2_never_sees_a_non_member_duration(self, tmp_path, monkeypatch):
         """审阅门迁移落盘的秒数必是档位成员，不能只是「落在结构区间内」。
 
         迁移幂等一次性、谁先跑谁定终局，而正常产品流程是先开审阅门再生成：审阅门若按结构
         区间落一个非档位秒数，step2 的枚举 schema 随后硬拒，用户在 gate 里看不出问题也改不动。
         故审阅门与生成侧取同一份档位表。
         """
-        pm = _make_project(tmp_path, "drama", generation_mode="reference_video", supported_durations=[4, 8, 12])
+        _stub_video_caps(monkeypatch, [4, 8, 12])
+        pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
         legacy = self._legacy_step1()
         # 求和 10s：落在结构区间内，但不是档位成员——只做结构 clamp 时会原样固化。
@@ -481,10 +511,72 @@ class TestReferenceVideoStep1Migration:
         legacy["units"][0]["shots"][1]["duration"] = 4
         path = _write_rv_step1(pm, legacy)
 
-        assert svc.get_state("demo", 1)["content"]["units"][0]["duration_seconds"] == 12
+        assert (await svc.get_state("demo", 1))["content"]["units"][0]["duration_seconds"] == 12
         assert json.loads(path.read_text(encoding="utf-8"))["units"][0]["duration_seconds"] == 12
 
-    def test_migration_falls_back_to_structural_clamp_without_video_backend(self, tmp_path):
+    async def test_custom_provider_draft_migration_takes_slot_from_caps(self, tmp_path, monkeypatch):
+        """自定义供应商（``custom-`` 前缀）不在 ``PROVIDER_REGISTRY``：档位表只有 caps 给得出。
+
+        审阅门若不解析 caps，这类项目的读时收编只能退回结构区间 clamp——落盘的秒数不是档位
+        成员，step2 的枚举 schema 随后硬拒。``supported_durations`` 也要一并带出真实档位，
+        面板的可选项才与收编到的值同源。
+        """
+        _stub_video_caps(monkeypatch, [5, 10], provider_id="custom-acme", model="acme-video")
+        pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
+        svc = ScriptReviewService(pm)
+        legacy = self._legacy_step1()
+        # 求和 7s：结构区间内，但不是 [5, 10] 的成员。
+        legacy["units"][0]["shots"][0]["duration"] = 4
+        legacy["units"][0]["shots"][1]["duration"] = 3
+        path = _write_rv_step1(pm, legacy)
+
+        state = await svc.get_state("demo", 1)
+        assert state["content"]["units"][0]["duration_seconds"] == 10
+        assert state["supported_durations"] == [5, 10]
+        assert json.loads(path.read_text(encoding="utf-8"))["units"][0]["duration_seconds"] == 10
+
+    async def test_custom_provider_direct_confirm_takes_slot_from_caps(self, tmp_path, monkeypatch):
+        """agent / API 绕过 get_state 直接 confirm 时同样按 caps 档位收编——两个入口口径不一致
+        的话，先跑的那个会把非档位秒数固化到盘上（迁移幂等一次性）。"""
+        _stub_video_caps(monkeypatch, [5, 10])
+        pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
+        svc = ScriptReviewService(pm)
+        legacy = self._legacy_step1()
+        legacy["units"][0]["shots"][0]["duration"] = 4
+        legacy["units"][0]["shots"][1]["duration"] = 3
+        _write_rv_step1(pm, legacy)
+
+        state = await svc.confirm("demo", 1)
+        assert state["status"] == "confirmed"
+        assert state["content"]["units"][0]["duration_seconds"] == 10
+
+    async def test_builtin_provider_falls_back_to_registry_when_caps_unavailable(self, tmp_path, monkeypatch):
+        """内建供应商在 caps 解析失败时仍按 registry 声明的档位收编，不因缺 caps 退到结构 clamp。"""
+        from server.services import script_review as mod
+
+        pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
+
+        def _set_backend(p: dict) -> None:
+            p["video_backend"] = "gemini-aistudio/veo-3.1-generate-preview"
+
+        pm.update_project("demo", _set_backend)
+
+        async def _raise(_project, _episode=None):
+            raise RuntimeError("video_capabilities backend unreachable")
+
+        monkeypatch.setattr(mod, "resolve_video_caps", _raise)
+        svc = ScriptReviewService(pm)
+        legacy = self._legacy_step1()
+        # 求和 7s：结构区间内，但不是 registry 档位 [4, 6, 8] 的成员。
+        legacy["units"][0]["shots"][0]["duration"] = 4
+        legacy["units"][0]["shots"][1]["duration"] = 3
+        _write_rv_step1(pm, legacy)
+
+        state = await svc.get_state("demo", 1)
+        assert state["supported_durations"] == [4, 6, 8]
+        assert state["content"]["units"][0]["duration_seconds"] == 8
+
+    async def test_migration_falls_back_to_structural_clamp_without_video_backend(self, tmp_path):
         """项目未配置可解析的视频型号：档位表取不到，退回结构区间 clamp 而非阻断草稿加载。"""
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
@@ -493,15 +585,15 @@ class TestReferenceVideoStep1Migration:
         legacy["units"][0]["shots"][1]["duration"] = 4
 
         _write_rv_step1(pm, legacy)
-        assert svc.get_state("demo", 1)["content"]["units"][0]["duration_seconds"] == 10
+        assert (await svc.get_state("demo", 1))["content"]["units"][0]["duration_seconds"] == 10
 
-    def test_legacy_draft_is_migrated_on_read_and_written_back(self, tmp_path):
+    async def test_legacy_draft_is_migrated_on_read_and_written_back(self, tmp_path):
         """读状态即收编：unit 拿到求和时长、shot 不再带时长，且一次落盘、二次读不再改写。"""
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
         path = _write_rv_step1(pm, self._legacy_step1())
 
-        unit = svc.get_state("demo", 1)["content"]["units"][0]
+        unit = (await svc.get_state("demo", 1))["content"]["units"][0]
         assert unit["duration_seconds"] == 8
         assert all("duration" not in s for s in unit["shots"])
 
@@ -511,23 +603,23 @@ class TestReferenceVideoStep1Migration:
 
         # 幂等：二次读不再改写落盘内容。
         before = path.read_bytes()
-        svc.get_state("demo", 1)
+        await svc.get_state("demo", 1)
         assert path.read_bytes() == before
 
-    def test_legacy_draft_can_be_confirmed_and_saved(self, tmp_path):
+    async def test_legacy_draft_can_be_confirmed_and_saved(self, tmp_path):
         """收编后存量草稿在 gate 里可确认、可保存——迁移前两者都撞结构校验（unit 缺必填时长）。"""
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
         _write_rv_step1(pm, self._legacy_step1())
 
-        confirmed = svc.confirm("demo", 1)
+        confirmed = await svc.confirm("demo", 1)
         assert confirmed["status"] == "confirmed"
 
         edited = confirmed["content"]
         edited["units"][0]["shots"][0]["text"] = "@[阿离] 收伞。"
-        assert svc.save_content("demo", 1, edited)["status"] == "pending_review"
+        assert (await svc.save_content("demo", 1, edited))["status"] == "pending_review"
 
-    def test_confirm_survives_migration_without_reopening_review(self, tmp_path):
+    async def test_confirm_survives_migration_without_reopening_review(self, tmp_path):
         """迁移是机械收编、不是内容编辑：已确认的分集不因加载被回退到待审。"""
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
@@ -539,18 +631,19 @@ class TestReferenceVideoStep1Migration:
             script_review.apply_confirmation(p, 1, script_review.content_fingerprint(path), "2026-01-01T00:00:00Z")
 
         pm.update_project("demo", _confirm_legacy)
-        assert svc.get_state("demo", 1)["status"] == "confirmed"
+        assert (await svc.get_state("demo", 1))["status"] == "confirmed"
 
-        state = svc.get_state("demo", 1)
+        state = await svc.get_state("demo", 1)
         assert state["status"] == "confirmed"
         assert state["confirmed_at"] == "2026-01-01T00:00:00Z"
         assert state["content"]["units"][0]["duration_seconds"] == 8
 
-    def test_confirm_reopens_review_when_migration_clamps_duration(self, tmp_path):
+    async def test_confirm_reopens_review_when_migration_clamps_duration(self, tmp_path, monkeypatch):
         """迁移带 warnings（时长被 clamp 改写）不是纯格式收编：已确认分集须退回待审，
         不能像纯结构收编那样平移确认——clamp 后的秒数不是用户确认时看到的值。
         """
-        pm = _make_project(tmp_path, "drama", generation_mode="reference_video", supported_durations=[4, 8, 12])
+        _stub_video_caps(monkeypatch, [4, 8, 12])
+        pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
         legacy = self._legacy_step1()
         # 求和 90s 超出最大档位（12s），迁移会取档改写并记 warning。
@@ -563,16 +656,17 @@ class TestReferenceVideoStep1Migration:
 
         pm.update_project("demo", _confirm_legacy)
 
-        state = svc.get_state("demo", 1)
+        state = await svc.get_state("demo", 1)
         assert state["status"] == "pending_review"
         assert state["content"]["units"][0]["duration_seconds"] == 12
 
-    def test_clamping_migration_reopens_review_for_grandfathered_episode(self, tmp_path):
+    async def test_clamping_migration_reopens_review_for_grandfathered_episode(self, tmp_path, monkeypatch):
         """从未存过确认指纹、靠 grandfather 判据（step2 已存在）放行的存量集：迁移 clamp
         改写时长后须退回待审——迁移幂等落盘，重试不再产生 warnings，不落失配标记的话
         后续生成会静默采用用户从未过目的取值。
         """
-        pm = _make_project(tmp_path, "drama", generation_mode="reference_video", supported_durations=[4, 8, 12])
+        _stub_video_caps(monkeypatch, [4, 8, 12])
+        pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
         legacy = self._legacy_step1()
         legacy["units"][0]["shots"][0]["duration"] = 60
@@ -580,18 +674,19 @@ class TestReferenceVideoStep1Migration:
         _write_rv_step1(pm, legacy)
         _write_step2(pm)
 
-        state = svc.get_state("demo", 1)
+        state = await svc.get_state("demo", 1)
         assert state["status"] == "pending_review"
         # 幂等重读不会把状态放回 grandfather 放行：失配标记已持久化。
-        assert svc.get_state("demo", 1)["status"] == "pending_review"
+        assert (await svc.get_state("demo", 1))["status"] == "pending_review"
 
-    def test_clamping_migration_marker_survives_interrupted_project_write(self, tmp_path, monkeypatch):
+    async def test_clamping_migration_marker_survives_interrupted_project_write(self, tmp_path, monkeypatch):
         """迁移是「project 失配标记 + 草稿」两次写：project 那次失败后重试仍须收敛到待审。
 
         草稿先落盘则重试判 changed=False、标记再也补不上，grandfather 存量集会带着被 clamp
         的时长停在 confirmed；标记先落盘时草稿仍是迁移前内容，重试重跑迁移即自愈。
         """
-        pm = _make_project(tmp_path, "drama", generation_mode="reference_video", supported_durations=[4, 8, 12])
+        _stub_video_caps(monkeypatch, [4, 8, 12])
+        pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
         legacy = self._legacy_step1()
         legacy["units"][0]["shots"][0]["duration"] = 60
@@ -611,27 +706,28 @@ class TestReferenceVideoStep1Migration:
         monkeypatch.setattr(pm, "update_project", _fail_first_project_write)
 
         with pytest.raises(OSError):
-            svc.get_state("demo", 1)
+            await svc.get_state("demo", 1)
 
         monkeypatch.setattr(pm, "update_project", original_update)
-        assert svc.get_state("demo", 1)["status"] == "pending_review"
+        assert (await svc.get_state("demo", 1))["status"] == "pending_review"
 
-    def test_confirm_direct_call_confirms_migrated_content(self, tmp_path):
+    async def test_confirm_direct_call_confirms_migrated_content(self, tmp_path, monkeypatch):
         """agent / API 可能绕过 get_state 直接调用 confirm：迁移在 confirm 内部触发并 clamp
         时（枚举外 clamp + warning 的宽容口径），confirm 按迁移后的落盘内容确认放行。
         """
-        pm = _make_project(tmp_path, "drama", generation_mode="reference_video", supported_durations=[4, 8, 12])
+        _stub_video_caps(monkeypatch, [4, 8, 12])
+        pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
         legacy = self._legacy_step1()
         legacy["units"][0]["shots"][0]["duration"] = 60
         legacy["units"][0]["shots"][1]["duration"] = 30
         _write_rv_step1(pm, legacy)
 
-        state = svc.confirm("demo", 1)
+        state = await svc.confirm("demo", 1)
         assert state["status"] == "confirmed"
         assert state["content"]["units"][0]["duration_seconds"] == 12
 
-    def test_confirmation_carry_uses_written_content_not_post_write_reread(self, tmp_path, monkeypatch):
+    async def test_confirmation_carry_uses_written_content_not_post_write_reread(self, tmp_path, monkeypatch):
         """迁移写回后平移确认指纹须用刚写入的内容直接算，不能再读一次磁盘——写回与该次读取
         之间若有并发编辑落下，读到的会是并发内容的指纹，把确认记录错误地平移到一份未经审阅
         的内容上。
@@ -660,7 +756,7 @@ class TestReferenceVideoStep1Migration:
 
         monkeypatch.setattr(script_review, "atomic_write_json", _write_then_concurrent_edit)
 
-        svc.get_state("demo", 1)
+        await svc.get_state("demo", 1)
 
         migrated_fingerprint = script_review.content_fingerprint_of_data(written[0])
         concurrent_fingerprint = script_review.content_fingerprint_of_data(concurrent_edit)
@@ -670,7 +766,7 @@ class TestReferenceVideoStep1Migration:
         assert stored["fingerprint"] == migrated_fingerprint
         assert stored["fingerprint"] != concurrent_fingerprint
 
-    def test_migration_carries_confirmation_that_lands_after_project_snapshot_loaded(self, tmp_path, monkeypatch):
+    async def test_migration_carries_confirmation_that_lands_after_project_snapshot_loaded(self, tmp_path, monkeypatch):
         """get_state 在迁移前加载的 project 快照此后不再刷新：若确认发生在这份快照加载
         之后、迁移写回完成之前，携带确认的判断不能依赖这份陈旧快照——那样会把刚发生的
         确认误判成"未确认"而跳过搬移，永久丢失它（迁移幂等，往后重试也补不回来）。
@@ -693,10 +789,10 @@ class TestReferenceVideoStep1Migration:
 
         monkeypatch.setattr(script_review, "migrate_unit_durations", _migrate_with_concurrent_confirm)
 
-        state = svc.get_state("demo", 1)
+        state = await svc.get_state("demo", 1)
         assert state["status"] == "confirmed"
 
-    def test_migration_does_not_confirm_an_unconfirmed_episode(self, tmp_path):
+    async def test_migration_does_not_confirm_an_unconfirmed_episode(self, tmp_path):
         """指纹本就对不上（step1 确实改过）时不平移确认记录，照常按待审处理。"""
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
@@ -706,7 +802,7 @@ class TestReferenceVideoStep1Migration:
             script_review.apply_confirmation(p, 1, "0" * 64, "2026-01-01T00:00:00Z")
 
         pm.update_project("demo", _stale_confirm)
-        assert svc.get_state("demo", 1)["status"] == "pending_review"
+        assert (await svc.get_state("demo", 1))["status"] == "pending_review"
 
 
 class TestReferenceVideoStep2Enforcement:
@@ -739,22 +835,22 @@ class TestReferenceVideoStep2Enforcement:
 
 
 class TestApplicability:
-    def test_reference_video_applicable(self, tmp_path):
+    async def test_reference_video_applicable(self, tmp_path):
         """reference_video（跨 content_mode）纳入 gate，step1 变体判为 reference_video。"""
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         project = pm.load_project("demo")
         assert script_review.step1_kind(project, 1) == "reference_video"
         assert script_review.is_applicable(project, 1) is True
         # 未产 step1 → no_step1（区别于 ad 的 not_applicable）。
-        assert ScriptReviewService(pm).get_state("demo", 1)["status"] == "no_step1"
+        assert (await ScriptReviewService(pm).get_state("demo", 1))["status"] == "no_step1"
 
-    def test_ad_not_applicable(self, tmp_path):
+    async def test_ad_not_applicable(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("addemo")
         pm.create_project_metadata("addemo", "Ad", "Anime", "ad")
         svc = ScriptReviewService(pm)
         assert script_review.step1_kind(svc.pm.load_project("addemo"), 1) is None
-        assert svc.get_state("addemo", 1)["status"] == "not_applicable"
+        assert (await svc.get_state("addemo", 1))["status"] == "not_applicable"
 
 
 # ---------------------------------------------------------------------------
@@ -763,7 +859,7 @@ class TestApplicability:
 
 
 class TestErrors:
-    def test_save_invalid_content_rejected(self, tmp_path):
+    async def test_save_invalid_content_rejected(self, tmp_path):
         pm = _make_project(tmp_path, "drama")
         svc = ScriptReviewService(pm)
         _write_step1(pm, "drama", _drama_step1())
@@ -772,49 +868,49 @@ class TestErrors:
         # dialogue 缺 speaker → kind ⇄ speaker 约束失败
         bad["scenes"][0]["utterances"][1] = {"kind": "dialogue", "speaker": None, "text": "无人"}
         with pytest.raises(ScriptReviewError) as exc:
-            svc.save_content("demo", 1, bad)
+            await svc.save_content("demo", 1, bad)
         assert exc.value.code == "invalid_content"
 
-    def test_confirm_without_step1_rejected(self, tmp_path):
+    async def test_confirm_without_step1_rejected(self, tmp_path):
         pm = _make_project(tmp_path, "drama")
         svc = ScriptReviewService(pm)
         with pytest.raises(ScriptReviewError) as exc:
-            svc.confirm("demo", 1)
+            await svc.confirm("demo", 1)
         assert exc.value.code == "no_step1"
 
-    def test_save_not_applicable_rejected(self, tmp_path):
+    async def test_save_not_applicable_rejected(self, tmp_path):
         pm = _make_project(tmp_path, "ad")  # ad 无结构化 step1，gate 不适用
         svc = ScriptReviewService(pm)
         with pytest.raises(ScriptReviewError) as exc:
-            svc.save_content("demo", 1, _drama_step1())
+            await svc.save_content("demo", 1, _drama_step1())
         assert exc.value.code == "not_applicable"
 
-    def test_get_state_unregistered_episode_rejected(self, tmp_path):
+    async def test_get_state_unregistered_episode_rejected(self, tmp_path):
         """适用 gate 但分集未登记 project.json → episode_not_found（而非误报 no_step1）。"""
         pm = _make_project(tmp_path, "drama")  # 仅登记第 1 集
         svc = ScriptReviewService(pm)
         with pytest.raises(ScriptReviewError) as exc:
-            svc.get_state("demo", 99)
+            await svc.get_state("demo", 99)
         assert exc.value.code == "episode_not_found"
 
-    def test_save_unregistered_episode_writes_no_orphan(self, tmp_path):
+    async def test_save_unregistered_episode_writes_no_orphan(self, tmp_path):
         """给未登记分集保存 → episode_not_found，且不落 drafts/episode_99 孤儿 step1 文件。"""
         pm = _make_project(tmp_path, "drama")
         svc = ScriptReviewService(pm)
         with pytest.raises(ScriptReviewError) as exc:
-            svc.save_content("demo", 99, _drama_step1())
+            await svc.save_content("demo", 99, _drama_step1())
         assert exc.value.code == "episode_not_found"
         orphan = pm.get_project_path("demo") / "drafts" / "episode_99" / "step1_normalized_script.json"
         assert not orphan.exists()
 
-    def test_confirm_corrupt_step1_rejected(self, tmp_path):
+    async def test_confirm_corrupt_step1_rejected(self, tmp_path):
         """step1 文件损坏（非法 JSON，但 content_fingerprint 仍产哈希）→ 确认被结构校验拒绝。"""
         pm = _make_project(tmp_path, "drama")
         svc = ScriptReviewService(pm)
         path = _write_step1(pm, "drama", _drama_step1())
         path.write_bytes(b"\x00\x01 not json at all {")
         with pytest.raises(ScriptReviewError) as exc:
-            svc.confirm("demo", 1)
+            await svc.confirm("demo", 1)
         assert exc.value.code == "invalid_content"
 
 
@@ -862,42 +958,42 @@ class TestStep2Enforcement:
 
 
 class TestLegacyEnumeration:
-    def test_no_step1(self, tmp_path):
+    async def test_no_step1(self, tmp_path):
         pm = _make_project(tmp_path, "drama")
-        assert ScriptReviewService(pm).get_state("demo", 1)["status"] == "no_step1"
+        assert (await ScriptReviewService(pm).get_state("demo", 1))["status"] == "no_step1"
 
-    def test_step1_no_step2_no_review_pending(self, tmp_path):
+    async def test_step1_no_step2_no_review_pending(self, tmp_path):
         """feature 后首次产 step1（未产 step2、无确认）→ 待审、阻塞。"""
         pm = _make_project(tmp_path, "drama")
         _write_step1(pm, "drama", _drama_step1())
-        assert ScriptReviewService(pm).get_state("demo", 1)["status"] == "pending_review"
+        assert (await ScriptReviewService(pm).get_state("demo", 1))["status"] == "pending_review"
 
-    def test_step1_step2_no_review_grandfathered_confirmed(self, tmp_path):
+    async def test_step1_step2_no_review_grandfathered_confirmed(self, tmp_path):
         """存量项目（已产 step1 + step2、无 step1_review 字段）→ grandfather 放行，不阻塞重跑。"""
         pm = _make_project(tmp_path, "drama")
         _write_step1(pm, "drama", _drama_step1())
         _write_step2(pm)
         project_path = pm.get_project_path("demo")
-        assert ScriptReviewService(pm).get_state("demo", 1)["status"] == "confirmed"
+        assert (await ScriptReviewService(pm).get_state("demo", 1))["status"] == "confirmed"
         assert script_review.gate_blocks_step2(project_path, pm.load_project("demo"), 1) is False
 
-    def test_step1_step2_review_matching_confirmed(self, tmp_path):
+    async def test_step1_step2_review_matching_confirmed(self, tmp_path):
         pm = _make_project(tmp_path, "drama")
         _write_step1(pm, "drama", _drama_step1())
         _write_step2(pm)
-        ScriptReviewService(pm).confirm("demo", 1)
-        assert ScriptReviewService(pm).get_state("demo", 1)["status"] == "confirmed"
+        await ScriptReviewService(pm).confirm("demo", 1)
+        assert (await ScriptReviewService(pm).get_state("demo", 1))["status"] == "confirmed"
 
-    def test_step1_step2_review_mismatch_pending(self, tmp_path):
+    async def test_step1_step2_review_mismatch_pending(self, tmp_path):
         """已确认后 step1 又被改（即便 step2 在）→ 重新待审，指纹优先于 grandfather。"""
         pm = _make_project(tmp_path, "drama")
         _write_step1(pm, "drama", _drama_step1())
         _write_step2(pm)
-        ScriptReviewService(pm).confirm("demo", 1)
+        await ScriptReviewService(pm).confirm("demo", 1)
         edited = _drama_step1()
         edited["scenes"][0]["source_text"] = "改写后的原文锚"
-        ScriptReviewService(pm).save_content("demo", 1, edited)
-        assert ScriptReviewService(pm).get_state("demo", 1)["status"] == "pending_review"
+        await ScriptReviewService(pm).save_content("demo", 1, edited)
+        assert (await ScriptReviewService(pm).get_state("demo", 1))["status"] == "pending_review"
 
 
 # ---------------------------------------------------------------------------
@@ -907,13 +1003,13 @@ class TestLegacyEnumeration:
 
 
 class TestManualSplitSelfHeal:
-    def test_get_state_self_heals_orphan_without_source_range(self, tmp_path):
+    async def test_get_state_self_heals_orphan_without_source_range(self, tmp_path):
         """孤儿派生文件 → 自愈登记条目（不写 source_range），get_state 不再 episode_not_found。"""
         pm = _make_manual_split_project(tmp_path, "narration")
         _write_source_text(pm, "episode_1.txt", "裴与出征后的第二年。")
         _write_step1(pm, "narration", _narration_step1())
 
-        state = ScriptReviewService(pm).get_state("demo", 1)
+        state = await ScriptReviewService(pm).get_state("demo", 1)
         assert state["status"] == "pending_review"
 
         ep = script_review.find_episode(pm.load_project("demo"), 1)
@@ -921,44 +1017,44 @@ class TestManualSplitSelfHeal:
         assert ep["ledger_status"] == "consumed"  # 已有 step1 中间文件
         assert "source_range" not in ep
 
-    def test_confirm_self_heals_and_unblocks_step2(self, tmp_path):
+    async def test_confirm_self_heals_and_unblocks_step2(self, tmp_path):
         """confirm（web 与 agent 工具共用同一 service）在空账本下不再 episode_not_found，且放行 step2。"""
         pm = _make_manual_split_project(tmp_path, "drama")
         _write_source_text(pm, "episode_1.txt", "任意派生内容")
         _write_step1(pm, "drama", _drama_step1())
 
-        confirmed = ScriptReviewService(pm).confirm("demo", 1)
+        confirmed = await ScriptReviewService(pm).confirm("demo", 1)
         assert confirmed["status"] == "confirmed"
 
         project_path = pm.get_project_path("demo")
         assert script_review.gate_blocks_step2(project_path, pm.load_project("demo"), 1) is False
 
-    def test_self_heal_never_anchors_even_when_source_text_matches(self, tmp_path):
+    async def test_self_heal_never_anchors_even_when_source_text_matches(self, tmp_path):
         """派生文件内容即使能在原文中精确匹配，自愈也只登记不锚定：位置记录只由规划工具写入。"""
         pm = _make_manual_split_project(tmp_path, "narration")
         original = "裴与出征后的第二年，送回一个襁褓中的婴儿。后续内容在此。"
         _write_source_text(pm, "novel.txt", original)
         _write_source_text(pm, "episode_1.txt", "裴与出征后的第二年，送回一个襁褓中的婴儿。")
 
-        ScriptReviewService(pm).get_state("demo", 1)
+        await ScriptReviewService(pm).get_state("demo", 1)
 
         ep = script_review.find_episode(pm.load_project("demo"), 1)
         assert ep is not None
         assert "source_range" not in ep
 
-    def test_self_heal_registers_all_orphans_not_just_requested(self, tmp_path):
+    async def test_self_heal_registers_all_orphans_not_just_requested(self, tmp_path):
         """自愈一次登记账本中所有孤儿集号的派生文件，不只是当前请求的那一集。"""
         pm = _make_manual_split_project(tmp_path, "narration")
         _write_source_text(pm, "episode_1.txt", "第一集内容")
         _write_source_text(pm, "episode_2.txt", "第二集内容")
 
-        ScriptReviewService(pm).get_state("demo", 1)
+        await ScriptReviewService(pm).get_state("demo", 1)
 
         project = pm.load_project("demo")
         assert script_review.find_episode(project, 1) is not None
         assert script_review.find_episode(project, 2) is not None
 
-    def test_self_heal_preserves_existing_ledger_status_entries(self, tmp_path):
+    async def test_self_heal_preserves_existing_ledger_status_entries(self, tmp_path):
         """已带 ledger_status 的条目（规划工具写入）不因其他集号的自愈触发被改写。"""
         pm = _make_manual_split_project(tmp_path, "narration")
         pm.add_episode("demo", 1, "第一集", "scripts/episode_1.json")
@@ -972,7 +1068,7 @@ class TestManualSplitSelfHeal:
         _write_source_text(pm, "episode_2.txt", "第二集派生内容")
 
         # 触发对孤儿集（episode 2）的自愈请求，不涉及 episode 1。
-        ScriptReviewService(pm).get_state("demo", 2)
+        await ScriptReviewService(pm).get_state("demo", 2)
 
         project = pm.load_project("demo")
         ep1 = script_review.find_episode(project, 1)
@@ -981,25 +1077,25 @@ class TestManualSplitSelfHeal:
         assert ep1["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": 5}
         assert script_review.find_episode(project, 2) is not None
 
-    def test_self_heal_does_not_apply_when_derivative_file_missing(self, tmp_path):
+    async def test_self_heal_does_not_apply_when_derivative_file_missing(self, tmp_path):
         """账本为空且该集派生文件也不存在（真正缺失的集号）→ 仍抛 episode_not_found，不自愈。"""
         pm = _make_manual_split_project(tmp_path, "narration")
         with pytest.raises(ScriptReviewError) as exc:
-            ScriptReviewService(pm).get_state("demo", 1)
+            await ScriptReviewService(pm).get_state("demo", 1)
         assert exc.value.code == "episode_not_found"
         assert pm.load_project("demo")["episodes"] == []
 
-    def test_self_heal_idempotent_no_duplicate_entries(self, tmp_path):
+    async def test_self_heal_idempotent_no_duplicate_entries(self, tmp_path):
         """重复触发自愈（同集反复读状态）不产生重复集号条目，也不重复改写已登记条目。"""
         pm = _make_manual_split_project(tmp_path, "narration")
         _write_source_text(pm, "episode_1.txt", "第一集派生内容")
 
         svc = ScriptReviewService(pm)
-        svc.get_state("demo", 1)
+        await svc.get_state("demo", 1)
         first = script_review.find_episode(pm.load_project("demo"), 1)
 
-        svc.get_state("demo", 1)
-        svc.get_state("demo", 1)
+        await svc.get_state("demo", 1)
+        await svc.get_state("demo", 1)
 
         project = pm.load_project("demo")
         matches = [e for e in project["episodes"] if e.get("episode") == 1]

--- a/tests/test_script_review_router.py
+++ b/tests/test_script_review_router.py
@@ -423,10 +423,13 @@ class TestReferenceVideoRouter:
             assert "duration_tiers" in confirm_body
 
     @pytest.mark.integration
-    def test_duration_tiers_populated_for_custom_provider_despite_null_supported_durations(self, tmp_path, monkeypatch):
-        """自定义供应商项目：``get_state`` 的同步 ``supported_durations`` 恒为 None（DB 能力查询
-        拿不到，只有异步 caps 能给出答案），路由不能拿这个字段短路是否调用
-        ``get_reference_duration_tiers``，否则这类项目永远拿不到收窄后的档位表。"""
+    def test_duration_tiers_and_supported_durations_resolved_for_custom_provider(self, tmp_path, monkeypatch):
+        """自定义供应商（``custom-`` 前缀）不在 ``PROVIDER_REGISTRY``：caps 是它唯一的档位来源。
+
+        ``supported_durations``（未收窄全集，供存量草稿的读时收编 clamp）与 ``duration_tiers``
+        （收窄后的逐 unit 可选项）都要经 caps 解析出真实档位，否则这类项目的审阅门只能退回
+        结构区间 clamp，读时迁移的收编对其整体失效。
+        """
         from server.services import script_review as mod
 
         client, pm = _client(monkeypatch, tmp_path, generation_mode="reference_video")
@@ -439,7 +442,7 @@ class TestReferenceVideoRouter:
         with client:
             _write_rv_step1(pm, _rv_step1())
             body = client.get("/api/v1/projects/demo/episodes/1/script-review").json()
-            assert body["supported_durations"] is None
+            assert body["supported_durations"] == [5, 10]
             assert body["duration_tiers"] == {"with_references": [5, 10], "without_references": [5, 10]}
 
     @pytest.mark.integration


### PR DESCRIPTION
Closes #1549

## 变更

审阅门（`ScriptReviewService`）的时长档位解析改为 async，先解析视频能力（caps）再交 `resolve_raw_supported_durations`。自定义供应商（`custom-` 前缀）不在 `PROVIDER_REGISTRY` 内，caps 是其档位表的唯一来源——此前审阅门走同步路径不传 caps，这类项目的读时收编只能退回结构区间 clamp，落盘秒数不是档位成员，step2 的枚举 schema 随后硬拒，用户在 gate 里看不出问题也改不动。

同时清理 `project.json` 的 `_supported_durations` 字段：全仓无生产写入者，只有测试 fixture 在写，三级回退链因此收敛为 caps → registry 两级。

`get_state` / `save_content` / `confirm` 拆成「async 外壳（load_project + caps 解析）+ 同步主体（`asyncio.to_thread`）」两段——`file_lock` 是阻塞式文件锁，跨 await 持有会把事件循环上的其它协程一起挡在锁外，故 caps 必须在取锁之前解析完。

## 验证

- `uv run ruff check .` + `ruff format --check` 通过
- `uv run basedpyright` 0 error
- `uv run python -m pytest` 全量 7563 passed
- 新增回归：自定义供应商经 caps 取到真实档位并完成收编（`get_state` 与直接 `confirm` 两个入口各一条）；内建供应商在 caps 失效时仍按 registry 档位收编，不退到结构 clamp
- `tests/test_config_resolver.py` 新增两级链的正反向锁：caps 优先、registry 兜底、自定义供应商只有 caps 这一条路、`_supported_durations` 不再是来源
- 无前端改动（响应形状未变）

## 审查修复

- `_resolve_caps_best_effort` 收敛档位表与档位收窄两条链各自的 caps 降级 try/except：此前两处结构同构、日志格式却不一致（档位表那条还漏了 `project_name`，排障定位不到项目），降级语义有各自漂移的风险
- 修订 `get_quarantine_info` 被本次改动作废的注释（它仍在描述 `get_state` 是同步的、router 用 `asyncio.to_thread` 包装）

## 已知未收敛

一次 GET `/script-review` 会解析两次 caps（`get_state` 一次、`get_reference_duration_tiers` 一次，后者还要 caps 里的 provider/model 求联动约束），`ConfigResolver` 无缓存即两次 DB 会话。归档导入路径（`project_archive._repair_video_units_payload`）对自定义供应商仍拿不到真实档位——它跑在 `to_thread` 里，且要先定夺「导入时用源环境还是本机的能力表」，贯通面超出本 issue 验收范围。两项均记 follow-up。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能优化**
  - 视频时长档位优先使用能力信息，缺失时通过模型注册信息解析。
  - 不再读取项目配置中的旧版自定义时长字段；无法解析时将安全降级。
  - 脚本审核、保存和确认流程改为异步处理，提升响应效率与并发稳定性。
  - 自定义供应商可通过能力信息提供支持的时长档位。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->