### PR TITLE
fix(files): 上传接口按资产名规则校验 name，拒绝越界路径写入

### DIFF
--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -73,15 +73,15 @@ _IMAGE_EXTS: tuple[str, ...] = (".png", ".jpg", ".jpeg", ".webp")
 #   stable_png — 稳定单图名 `{name}.png`（实际后缀由图片归一化结果决定）
 #   keep_ext   — 稳定单图名，保留上传的原扩展名（音频不转码）
 #   sequenced  — 多图累积，按序号取唯一名
-#   original   — 原样保留上传文件名
-Naming = Literal["stable_png", "keep_ext", "sequenced", "original"]
+#   delegated  — 主流程不参与命名，由该类型的专用分支决定
+Naming = Literal["stable_png", "keep_ext", "sequenced", "delegated"]
 
 # 落盘前的内容处理
 #   normalize_image — 校验并按阈值压缩，可能改写扩展名
 #   validate_image  — 仅校验可解码，保留原件字节
-#   audio           — 校验体积与时长，不转码
-#   none            — 不处理，由专用分支接管
-ContentCheck = Literal["normalize_image", "validate_image", "audio", "none"]
+#   audio           — 校验时长，不转码（体积由 max_bytes 独立把关）
+#   delegated       — 主流程不处理内容，由该类型的专用分支决定
+ContentCheck = Literal["normalize_image", "validate_image", "audio", "delegated"]
 
 MetadataSetter = Callable[[ProjectManager, str, str, str], object]
 
@@ -99,6 +99,7 @@ class UploadSpec:
     naming: Naming
     content_check: ContentCheck
     unsupported_ext_key: str = "unsupported_image_type"
+    # 请求体上限，None 表示不限；对所有类型生效，与 content_check 无关
     max_bytes: int | None = None
     metadata_setter: MetadataSetter | None = None
     # 非空表示文件挂在宿主资产的字段下、该字段是文件的唯一指针：宿主不存在就拒收
@@ -109,13 +110,18 @@ class UploadSpec:
     # 替换参考音频时先解析旧文件路径，等新文件与字段写入成功后再删除
     tracks_stale_audio: bool = False
 
+    def __post_init__(self) -> None:
+        # 宿主约束与其 404 文案必须成对登记，否则拒收路径会拿空 key 去取翻译
+        if (self.host_bucket is None) != (not self.host_not_found_key):
+            raise ValueError("host_bucket 与 host_not_found_key 必须成对登记")
+
 
 UPLOAD_SPECS: dict[str, UploadSpec] = {
     "source": UploadSpec(
         allowed_exts=(".txt", ".md", ".docx", ".epub", ".pdf"),
         subdir=("source",),
-        naming="original",
-        content_check="none",
+        naming="delegated",
+        content_check="delegated",
     ),
     "character": UploadSpec(
         allowed_exts=_IMAGE_EXTS,
@@ -287,12 +293,13 @@ async def upload_file(
     try:
         content = await file.read()
 
+        if spec.max_bytes is not None and len(content) > spec.max_bytes:
+            raise HTTPException(
+                status_code=400,
+                detail=_t("upload_too_large", max_mb=spec.max_bytes // (1024 * 1024)),
+            )
+
         if spec.content_check == "audio":
-            if spec.max_bytes is not None and len(content) > spec.max_bytes:
-                raise HTTPException(
-                    status_code=400,
-                    detail=_t("upload_too_large", max_mb=spec.max_bytes // (1024 * 1024)),
-                )
             try:
                 duration = await probe_audio_duration_seconds(content, ext)
             except ValueError:

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -10,7 +10,9 @@ import logging
 import shutil
 import tempfile
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +20,7 @@ from fastapi import APIRouter, Body, File, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, PlainTextResponse
 
 from lib.api_errors import NotFoundError
-from lib.asset_types import GLOBAL_LIBRARY_ASSET_TYPES
+from lib.asset_types import ASSET_SPECS, GLOBAL_LIBRARY_ASSET_TYPES, validate_asset_name
 from lib.audio_utils import (
     AUDIO_REFERENCE_MAX_BYTES,
     AUDIO_REFERENCE_MAX_SECONDS,
@@ -40,7 +42,7 @@ from lib.i18n import Translator
 from lib.image_utils import normalize_uploaded_image, validate_image_bytes
 from lib.path_safety import PathTraversalError, safe_join
 from lib.project_change_hints import emit_project_change_batch, project_change_source
-from lib.project_manager import effective_mode, get_project_manager
+from lib.project_manager import ProjectManager, effective_mode, get_project_manager
 from lib.source_loader import (
     ConflictError,
     CorruptFileError,
@@ -65,17 +67,116 @@ def _require_filename(file: UploadFile, _t: Callable[..., str]) -> str:
     return file.filename
 
 
-# 允许的文件类型
-ALLOWED_EXTENSIONS = {
-    "source": [".txt", ".md", ".docx", ".epub", ".pdf"],
-    "character": [".png", ".jpg", ".jpeg", ".webp"],
-    "character_ref": [".png", ".jpg", ".jpeg", ".webp"],
-    "character_audio_ref": [".wav", ".mp3"],
-    "scene": [".png", ".jpg", ".jpeg", ".webp"],
-    "prop": [".png", ".jpg", ".jpeg", ".webp"],
-    "product": [".png", ".jpg", ".jpeg", ".webp"],
-    "product_ref": [".png", ".jpg", ".jpeg", ".webp"],
+_IMAGE_EXTS: tuple[str, ...] = (".png", ".jpg", ".jpeg", ".webp")
+
+# 落盘文件名策略
+#   stable_png — 稳定单图名 `{name}.png`（实际后缀由图片归一化结果决定）
+#   keep_ext   — 稳定单图名，保留上传的原扩展名（音频不转码）
+#   sequenced  — 多图累积，按序号取唯一名
+#   original   — 原样保留上传文件名
+Naming = Literal["stable_png", "keep_ext", "sequenced", "original"]
+
+# 落盘前的内容处理
+#   normalize_image — 校验并按阈值压缩，可能改写扩展名
+#   validate_image  — 仅校验可解码，保留原件字节
+#   audio           — 校验体积与时长，不转码
+#   none            — 不处理，由专用分支接管
+ContentCheck = Literal["normalize_image", "validate_image", "audio", "none"]
+
+MetadataSetter = Callable[[ProjectManager, str, str, str], object]
+
+
+@dataclass(frozen=True)
+class UploadSpec:
+    """单个 upload_type 的落盘规则：目标目录、扩展名白名单、体积上限、后处理与元数据回写。
+
+    新增上传类型只在 ``UPLOAD_SPECS`` 登记表项，不复制分支逻辑。``source`` 是唯一例外：
+    它由 ``_handle_source_upload`` 全权接管，表项只提供类型校验与扩展名白名单。
+    """
+
+    allowed_exts: tuple[str, ...]
+    subdir: tuple[str, ...]
+    naming: Naming
+    content_check: ContentCheck
+    unsupported_ext_key: str = "unsupported_image_type"
+    max_bytes: int | None = None
+    metadata_setter: MetadataSetter | None = None
+    # 非空表示文件挂在宿主资产的字段下、该字段是文件的唯一指针：宿主不存在就拒收
+    # （含并发删除的窗口期），避免落下界面上不可见的孤儿文件。单图类型路径确定、
+    # 可容忍资产后建，不设此约束。
+    host_bucket: str | None = None
+    host_not_found_key: str = ""
+    # 替换参考音频时先解析旧文件路径，等新文件与字段写入成功后再删除
+    tracks_stale_audio: bool = False
+
+
+UPLOAD_SPECS: dict[str, UploadSpec] = {
+    "source": UploadSpec(
+        allowed_exts=(".txt", ".md", ".docx", ".epub", ".pdf"),
+        subdir=("source",),
+        naming="original",
+        content_check="none",
+    ),
+    "character": UploadSpec(
+        allowed_exts=_IMAGE_EXTS,
+        subdir=(ASSET_SPECS["character"].subdir,),
+        naming="stable_png",
+        content_check="normalize_image",
+        metadata_setter=ProjectManager.update_project_character_sheet,
+    ),
+    "character_ref": UploadSpec(
+        allowed_exts=_IMAGE_EXTS,
+        subdir=(ASSET_SPECS["character"].subdir, "refs"),
+        naming="stable_png",
+        content_check="normalize_image",
+        metadata_setter=ProjectManager.update_character_reference_image,
+    ),
+    "character_audio_ref": UploadSpec(
+        allowed_exts=(".wav", ".mp3"),
+        subdir=(ASSET_SPECS["character"].subdir, "refs_audio"),
+        naming="keep_ext",
+        content_check="audio",
+        unsupported_ext_key="unsupported_audio_type",
+        max_bytes=AUDIO_REFERENCE_MAX_BYTES,
+        metadata_setter=ProjectManager.update_character_reference_audio,
+        tracks_stale_audio=True,
+    ),
+    "scene": UploadSpec(
+        allowed_exts=_IMAGE_EXTS,
+        subdir=(ASSET_SPECS["scene"].subdir,),
+        naming="stable_png",
+        content_check="normalize_image",
+        metadata_setter=ProjectManager.update_scene_sheet,
+    ),
+    "prop": UploadSpec(
+        allowed_exts=_IMAGE_EXTS,
+        subdir=(ASSET_SPECS["prop"].subdir,),
+        naming="stable_png",
+        content_check="normalize_image",
+        metadata_setter=ProjectManager.update_prop_sheet,
+    ),
+    "product": UploadSpec(
+        allowed_exts=_IMAGE_EXTS,
+        subdir=(ASSET_SPECS["product"].subdir,),
+        naming="stable_png",
+        content_check="normalize_image",
+        metadata_setter=ProjectManager.update_product_sheet,
+    ),
+    "product_ref": UploadSpec(
+        allowed_exts=_IMAGE_EXTS,
+        subdir=(ASSET_SPECS["product"].subdir, "refs"),
+        naming="sequenced",
+        # 产品原图是保真验收锚点（ADR 0034）：仅校验可解码，保留原件字节与扩展名，
+        # 不做阈值压缩/重编码。请求体上限由生成发送前的参考压缩环节独立保障。
+        content_check="validate_image",
+        metadata_setter=ProjectManager.add_product_reference_image,
+        host_bucket=ASSET_SPECS["product"].bucket_key,
+        host_not_found_key="product_not_found",
+    ),
 }
+
+# 允许的文件类型（前端 frontend/src/utils/source-files.ts 镜像了 source 一项）
+ALLOWED_EXTENSIONS = {upload_type: list(spec.allowed_exts) for upload_type, spec in UPLOAD_SPECS.items()}
 
 
 @public_router.get("/files/{project_name}/{path:path}")
@@ -152,19 +253,27 @@ async def upload_file(
             分镜/视频上传走 shot_uploads 路由
         on_conflict: source 类型独有 — fail / replace / rename
     """
-    if upload_type not in ALLOWED_EXTENSIONS:
+    spec = UPLOAD_SPECS.get(upload_type)
+    if spec is None:
         raise HTTPException(status_code=400, detail=_t("invalid_upload_type", upload_type=upload_type))
 
     original_filename = _require_filename(file, _t)
 
     # 检查文件扩展名
     ext = Path(original_filename).suffix.lower()
-    if ext not in ALLOWED_EXTENSIONS[upload_type]:
-        error_key = "unsupported_audio_type" if upload_type == "character_audio_ref" else "unsupported_image_type"
+    if ext not in spec.allowed_exts:
         raise HTTPException(
             status_code=400,
-            detail=_t(error_key, ext=ext, allowed=", ".join(ALLOWED_EXTENSIONS[upload_type])),
+            detail=_t(spec.unsupported_ext_key, ext=ext, allowed=", ".join(spec.allowed_exts)),
         )
+
+    # name 会被拼进落盘路径，路径不安全的名字（分隔符 / .. / 控制字符）在边界即拒绝；
+    # 未提供时按原文件名 stem 回落，不做校验。
+    if name:
+        try:
+            name = validate_asset_name(name)
+        except ValueError:
+            raise HTTPException(status_code=400, detail=_t("asset_invalid_name", name=name))
 
     # Source 分支早返 — 走 SourceLoader 规范化
     if upload_type == "source":
@@ -178,11 +287,11 @@ async def upload_file(
     try:
         content = await file.read()
 
-        if upload_type == "character_audio_ref":
-            if len(content) > AUDIO_REFERENCE_MAX_BYTES:
+        if spec.content_check == "audio":
+            if spec.max_bytes is not None and len(content) > spec.max_bytes:
                 raise HTTPException(
                     status_code=400,
-                    detail=_t("upload_too_large", max_mb=AUDIO_REFERENCE_MAX_BYTES // (1024 * 1024)),
+                    detail=_t("upload_too_large", max_mb=spec.max_bytes // (1024 * 1024)),
                 )
             try:
                 duration = await probe_audio_duration_seconds(content, ext)
@@ -199,89 +308,41 @@ async def upload_file(
                 )
 
         def _sync():
-            project_dir = get_project_manager().get_project_path(project_name)
+            manager = get_project_manager()
+            project_dir = manager.get_project_path(project_name)
 
-            # 产品原图列表是这些文件的唯一指针：产品不存在就拒收，避免落下不可见的孤儿文件
-            # （character_ref 等单图类型路径确定、可容忍资产后建，不受此约束）。
-            if upload_type == "product_ref":
-                products = get_project_manager().load_project(project_name).get("products") or {}
-                if not name or name not in products:
-                    raise HTTPException(status_code=404, detail=_t("product_not_found", name=name or ""))
+            if spec.host_bucket is not None:
+                hosts = manager.load_project(project_name).get(spec.host_bucket) or {}
+                if not name or name not in hosts:
+                    raise HTTPException(status_code=404, detail=_t(spec.host_not_found_key, name=name or ""))
 
-            # 确定目标目录
-            if upload_type == "source":
-                target_dir = project_dir / "source"
-                filename = original_filename
-            elif upload_type == "character":
-                target_dir = project_dir / "characters"
-                # 统一保存为 PNG，且使用稳定文件名（避免 jpg/png 不一致导致版本还原/引用异常）
-                if name:
-                    filename = f"{name}.png"
-                else:
-                    filename = f"{Path(original_filename).stem}.png"
-            elif upload_type == "character_ref":
-                target_dir = project_dir / "characters" / "refs"
-                if name:
-                    filename = f"{name}.png"
-                else:
-                    filename = f"{Path(original_filename).stem}.png"
-            elif upload_type == "character_audio_ref":
-                target_dir = project_dir / "characters" / "refs_audio"
-                # 音频不转码，保留原扩展名（wav/mp3 二选一，替换时新旧扩展名可能不同）；
-                # `ext` 在下方图片分支被重新赋值而变成 `_sync` 的局部变量，此处不能引用外层同名值
-                audio_ext = Path(original_filename).suffix.lower()
-                if name:
-                    filename = f"{name}{audio_ext}"
-                else:
-                    filename = f"{Path(original_filename).stem}{audio_ext}"
-            elif upload_type == "scene":
-                target_dir = project_dir / "scenes"
-                if name:
-                    filename = f"{name}.png"
-                else:
-                    filename = f"{Path(original_filename).stem}.png"
-            elif upload_type == "prop":
-                target_dir = project_dir / "props"
-                if name:
-                    filename = f"{name}.png"
-                else:
-                    filename = f"{Path(original_filename).stem}.png"
-            elif upload_type == "product":
-                target_dir = project_dir / "products"
-                if name:
-                    filename = f"{name}.png"
-                else:
-                    filename = f"{Path(original_filename).stem}.png"
-            elif upload_type == "product_ref":
-                target_dir = project_dir / "products" / "refs"
-                filename = ""  # 多图累积，唯一文件名在目录就绪后按序号计算
-            else:
-                target_dir = project_dir / upload_type
-                filename = original_filename
+            target_dir = project_dir.joinpath(*spec.subdir)
+            # 稳定文件名（避免 jpg/png 不一致导致版本还原/引用异常）；未指定 name 时用原文件名主干
+            stem = name or Path(original_filename).stem
+            filename = f"{stem}.png" if spec.naming == "stable_png" else f"{stem}{ext}"
 
             target_dir.mkdir(parents=True, exist_ok=True)
 
             # 保存文件（大于 2MB 时压缩为 JPEG，否则校验后原样保存）
             nonlocal content
-            if upload_type in ("character", "character_ref", "scene", "prop", "product"):
+            if spec.content_check == "normalize_image":
                 try:
-                    content, ext = normalize_uploaded_image(content, Path(original_filename).suffix.lower())
+                    content, normalized_ext = normalize_uploaded_image(content, ext)
                 except ValueError:
                     raise HTTPException(status_code=400, detail=_t("invalid_image_file"))
-                filename = Path(filename).with_suffix(ext).name
-            elif upload_type == "product_ref":
-                # 产品原图是保真验收锚点（ADR 0034）：仅校验可解码，保留原件字节与扩展名，
-                # 不做阈值压缩/重编码。请求体上限由生成发送前的参考压缩环节独立保障。
+                filename = Path(filename).with_suffix(normalized_ext).name
+            elif spec.content_check == "validate_image":
                 try:
                     validate_image_bytes(content)
                 except ValueError:
                     raise HTTPException(status_code=400, detail=_t("invalid_image_file"))
-                ref_ext = Path(original_filename).suffix.lower() or ".png"
-                # 按序号取唯一文件名，用原子独占创建占位：并发上传同一产品时
+
+            if spec.naming == "sequenced":
+                # 按序号取唯一文件名，用原子独占创建占位：并发上传同一宿主资产时
                 # 两个请求各拿到不同序号，避免静默互相覆盖。
                 seq = 1
                 while True:
-                    candidate = target_dir / f"{name}_{seq}{ref_ext}"
+                    candidate = target_dir / f"{stem}_{seq}{ext or '.png'}"
                     try:
                         candidate.touch(exist_ok=False)
                         break
@@ -290,9 +351,9 @@ async def upload_file(
                 filename = candidate.name
 
             stale_audio_path: Path | None = None
-            if upload_type == "character_audio_ref" and name:
+            if spec.tracks_stale_audio and name:
                 # 实际删除推迟到新文件与字段写入成功之后（见 discard_stale_reference_audio）。
-                old_audio = (get_project_manager().load_project(project_name).get("characters", {}).get(name, {})).get(
+                old_audio = (manager.load_project(project_name).get("characters", {}).get(name, {})).get(
                     "reference_audio"
                 )
                 stale_audio_path = resolve_stale_reference_audio(
@@ -303,101 +364,23 @@ async def upload_file(
             with open(target_path, "wb") as f:
                 f.write(content)
 
+            relative_path = "/".join((*spec.subdir, filename))
+
             # 更新元数据
-            if upload_type == "source":
-                relative_path = f"source/{filename}"
-            elif upload_type == "character":
-                relative_path = f"characters/{filename}"
-            elif upload_type == "character_ref":
-                relative_path = f"characters/refs/{filename}"
-            elif upload_type == "character_audio_ref":
-                relative_path = f"characters/refs_audio/{filename}"
-            elif upload_type == "scene":
-                relative_path = f"scenes/{filename}"
-            elif upload_type == "prop":
-                relative_path = f"props/{filename}"
-            elif upload_type == "product":
-                relative_path = f"products/{filename}"
-            elif upload_type == "product_ref":
-                relative_path = f"products/refs/{filename}"
-            else:
-                relative_path = f"{upload_type}/{filename}"
-
-            if upload_type == "character" and name:
+            if spec.metadata_setter is not None and name:
                 try:
                     with project_change_source("webui"):
-                        get_project_manager().update_project_character_sheet(
-                            project_name, name, f"characters/{filename}"
-                        )
+                        spec.metadata_setter(manager, project_name, name, relative_path)
                 except KeyError:
-                    pass  # 角色不存在，忽略
-
-            if upload_type == "character_ref" and name:
-                try:
-                    with project_change_source("webui"):
-                        get_project_manager().update_character_reference_image(
-                            project_name, name, f"characters/refs/{filename}"
-                        )
-                except KeyError:
-                    pass  # 角色不存在，忽略
-
-            if upload_type == "character_audio_ref" and name:
-                try:
-                    with project_change_source("webui"):
-                        get_project_manager().update_character_reference_audio(
-                            project_name, name, f"characters/refs_audio/{filename}"
-                        )
-                except KeyError:
-                    pass  # 角色不存在，忽略
+                    if spec.host_bucket is not None:
+                        # 入口已校验宿主存在；并发删除导致的窗口期竞态按 404 处理，
+                        # 已落盘的文件一并清理避免孤儿
+                        target_path.unlink(missing_ok=True)
+                        raise HTTPException(status_code=404, detail=_t(spec.host_not_found_key, name=name))
+                    # 单图类型：资产不存在时忽略，文件路径确定，资产后建仍可引用
                 else:
-                    discard_stale_reference_audio(stale_audio_path)
-
-            if upload_type == "scene" and name:
-                try:
-                    with project_change_source("webui"):
-                        get_project_manager().update_scene_sheet(
-                            project_name,
-                            name,
-                            f"scenes/{filename}",
-                        )
-                except KeyError:
-                    pass  # 场景不存在，忽略
-
-            if upload_type == "prop" and name:
-                try:
-                    with project_change_source("webui"):
-                        get_project_manager().update_prop_sheet(
-                            project_name,
-                            name,
-                            f"props/{filename}",
-                        )
-                except KeyError:
-                    pass  # 道具不存在，忽略
-
-            if upload_type == "product" and name:
-                try:
-                    with project_change_source("webui"):
-                        get_project_manager().update_product_sheet(
-                            project_name,
-                            name,
-                            f"products/{filename}",
-                        )
-                except KeyError:
-                    pass  # 产品不存在，忽略
-
-            if upload_type == "product_ref" and name:
-                try:
-                    with project_change_source("webui"):
-                        get_project_manager().add_product_reference_image(
-                            project_name,
-                            name,
-                            f"products/refs/{filename}",
-                        )
-                except KeyError:
-                    # 入口已校验产品存在；并发删除导致的窗口期竞态按 404 处理，
-                    # 已落盘的文件一并清理避免孤儿
-                    target_path.unlink(missing_ok=True)
-                    raise HTTPException(status_code=404, detail=_t("product_not_found", name=name))
+                    if spec.tracks_stale_audio:
+                        discard_stale_reference_audio(stale_audio_path)
 
             return {
                 "success": True,

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -651,9 +651,14 @@ class TestFilesRouter:
         def _snapshot() -> dict[Path, bytes]:
             return {p.relative_to(tmp_path): p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
 
-        # 预置 "../existing" 会解析到的既有文件：没有真实的覆写目标时，内容快照验证不到覆写这一维
-        for ext in (".png", ".jpg", ".wav", ".txt"):
-            (tmp_path / "projects" / "demo" / f"existing{ext}").write_bytes(b"original")
+        # 预置 "../existing" 会解析到的既有文件：没有真实的覆写目标时，内容快照验证不到覆写这一维。
+        # 逐 subdir 铺哨兵——嵌套类型（characters/refs 等）的 ".." 落在 characters/ 而非项目根
+        project_dir = tmp_path / "projects" / "demo"
+        for spec in files.UPLOAD_SPECS.values():
+            parent = project_dir.joinpath(*spec.subdir).parent
+            parent.mkdir(parents=True, exist_ok=True)
+            for ext in (".png", ".jpg", ".wav", ".txt"):
+                (parent / f"existing{ext}").write_bytes(b"original")
 
         before = _snapshot()
         unsafe_names = [

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -645,8 +645,13 @@ class TestFilesRouter:
     def test_upload_rejects_unsafe_name_for_every_type(self, tmp_path, monkeypatch):
         """name 会被拼进落盘路径：含分隔符 / .. / 控制字符的名字在所有上传类型下都应被 400 拒绝。"""
         client, _ = _client(monkeypatch, tmp_path)
-        # 快照范围取 tmp_path 而非 projects 根：越界名的目标本就在 projects 之外，只扫项目内看不见
-        before = sorted(p for p in tmp_path.rglob("*") if p.is_file())
+
+        # 快照范围取 tmp_path 而非 projects 根：越界名的目标本就在 projects 之外，只扫项目内看不见。
+        # 连同内容一起快照：越界写入若命中既有文件（如 ../project.json），路径集合不变，只比路径发现不了
+        def _snapshot() -> dict[Path, bytes]:
+            return {p.relative_to(tmp_path): p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+
+        before = _snapshot()
         unsafe_names = [
             "../../evil",
             "../../../evil",
@@ -676,8 +681,8 @@ class TestFilesRouter:
                     assert resp.status_code == 400, (upload_type, unsafe, resp.status_code)
                     assert resp.json()["detail"] == zh_assets.MESSAGES["asset_invalid_name"].format(name=unsafe)
 
-            # 越界名字不得留下任何落盘产物（项目内与项目外都不得新增文件）
-            assert sorted(p for p in tmp_path.rglob("*") if p.is_file()) == before
+            # 越界名字不得留下任何落盘产物：项目内外都不得新增文件，既有文件的内容也不得被改写
+            assert _snapshot() == before
 
     @pytest.mark.integration
     def test_upload_unsafe_name_message_is_localized(self, tmp_path, monkeypatch):

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -651,8 +651,13 @@ class TestFilesRouter:
         def _snapshot() -> dict[Path, bytes]:
             return {p.relative_to(tmp_path): p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
 
+        # 预置 "../existing" 会解析到的既有文件：没有真实的覆写目标时，内容快照验证不到覆写这一维
+        for ext in (".png", ".jpg", ".wav", ".txt"):
+            (tmp_path / "projects" / "demo" / f"existing{ext}").write_bytes(b"original")
+
         before = _snapshot()
         unsafe_names = [
+            "../existing",
             "../../evil",
             "../../../evil",
             str(tmp_path / "absolute-escape"),

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -644,10 +644,20 @@ class TestFilesRouter:
     @pytest.mark.integration
     def test_upload_rejects_unsafe_name_for_every_type(self, tmp_path, monkeypatch):
         """name 会被拼进落盘路径：含分隔符 / .. / 控制字符的名字在所有上传类型下都应被 400 拒绝。"""
-        client, pm = _client(monkeypatch, tmp_path)
-        projects_root = pm.get_project_path("demo").parent
-        before = sorted(p for p in projects_root.rglob("*") if p.is_file())
-        unsafe_names = ["../../evil", "sub/dir", "back\\slash", "..", "trailing.", "CON", "ctrl\x01char"]
+        client, _ = _client(monkeypatch, tmp_path)
+        # 快照范围取 tmp_path 而非 projects 根：越界名的目标本就在 projects 之外，只扫项目内看不见
+        before = sorted(p for p in tmp_path.rglob("*") if p.is_file())
+        unsafe_names = [
+            "../../evil",
+            "../../../evil",
+            str(tmp_path / "absolute-escape"),
+            "sub/dir",
+            "back\\slash",
+            "..",
+            "trailing.",
+            "CON",
+            "ctrl\x01char",
+        ]
         payloads = {
             "character_audio_ref": ("v.wav", _wav_bytes(3), "audio/wav"),
             # source 不使用 name，但校验在其早返分支之前，同样应拒
@@ -667,7 +677,7 @@ class TestFilesRouter:
                     assert resp.json()["detail"] == zh_assets.MESSAGES["asset_invalid_name"].format(name=unsafe)
 
             # 越界名字不得留下任何落盘产物（项目内与项目外都不得新增文件）
-            assert sorted(p for p in projects_root.rglob("*") if p.is_file()) == before
+            assert sorted(p for p in tmp_path.rglob("*") if p.is_file()) == before
 
     @pytest.mark.integration
     def test_upload_unsafe_name_message_is_localized(self, tmp_path, monkeypatch):
@@ -702,6 +712,19 @@ class TestFilesRouter:
             assert resp.status_code == 200
             assert resp.json()["path"] == "characters/Alice.jpg"
             assert pm.load_project("demo")["characters"]["Alice"]["character_sheet"] == "characters/Alice.jpg"
+
+    @pytest.mark.integration
+    def test_upload_empty_name_falls_back_to_filename(self, tmp_path, monkeypatch):
+        """空串 name 等同未提供：校验只对真值生效，落盘仍回退到原文件名 stem。"""
+        client, _ = _client(monkeypatch, tmp_path)
+        with client:
+            resp = client.post(
+                "/api/v1/projects/demo/upload/character",
+                params={"name": ""},
+                files={"file": ("x.jpg", _img_bytes("JPEG"), "image/jpeg")},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["path"] == "characters/x.jpg"
 
     @pytest.mark.unit
     def test_upload_spec_table_drives_extensions(self):

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -641,6 +641,7 @@ class TestFilesRouter:
             assert character_missing_entity.status_code == 200
             assert character_missing_entity.json()["path"] == "characters/不存在角色.jpg"
 
+    @pytest.mark.integration
     def test_upload_rejects_unsafe_name_for_every_type(self, tmp_path, monkeypatch):
         """name 会被拼进落盘路径：含分隔符 / .. / 控制字符的名字在所有上传类型下都应被 400 拒绝。"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -668,6 +669,7 @@ class TestFilesRouter:
             # 越界名字不得留下任何落盘产物（项目内与项目外都不得新增文件）
             assert sorted(p for p in projects_root.rglob("*") if p.is_file()) == before
 
+    @pytest.mark.integration
     def test_upload_unsafe_name_message_is_localized(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         expected = {
@@ -687,6 +689,7 @@ class TestFilesRouter:
                 assert resp.status_code == 400
                 assert resp.json()["detail"] == template.format(name="../evil")
 
+    @pytest.mark.integration
     def test_upload_name_is_stripped_before_use(self, tmp_path, monkeypatch):
         """校验谓词会 strip 名字，落盘路径与元数据都应使用规范化后的值。"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -700,6 +703,7 @@ class TestFilesRouter:
             assert resp.json()["path"] == "characters/Alice.jpg"
             assert pm.load_project("demo")["characters"]["Alice"]["character_sheet"] == "characters/Alice.jpg"
 
+    @pytest.mark.unit
     def test_upload_spec_table_drives_extensions(self):
         """ALLOWED_EXTENSIONS 由 UPLOAD_SPECS 派生，两者不得漂移。"""
         assert set(files.ALLOWED_EXTENSIONS) == set(files.UPLOAD_SPECS)
@@ -708,6 +712,7 @@ class TestFilesRouter:
         # source 一项被 frontend/src/utils/source-files.ts 镜像，取值变动需同步前端
         assert files.ALLOWED_EXTENSIONS["source"] == [".txt", ".md", ".docx", ".epub", ".pdf"]
 
+    @pytest.mark.unit
     def test_upload_spec_host_fields_must_be_paired(self):
         """登记宿主约束却漏配 404 文案时，构造期即失败，而非拒收时取到空翻译 key。"""
         with pytest.raises(ValueError):
@@ -718,23 +723,35 @@ class TestFilesRouter:
                 content_check="validate_image",
                 host_bucket="products",
             )
+        # 反方向同样是配置错误：登记了文案却没有宿主约束，该文案永远取不到
+        with pytest.raises(ValueError):
+            files.UploadSpec(
+                allowed_exts=(".png",),
+                subdir=("x",),
+                naming="stable_png",
+                content_check="validate_image",
+                host_not_found_key="product_not_found",
+            )
 
+    @pytest.mark.integration
     def test_upload_rejects_oversized_payload_for_any_type(self, tmp_path, monkeypatch):
         """max_bytes 是通用请求体闸门：登记了上限的类型无论 content_check 为何都应拒收超限请求。"""
         client, _ = _client(monkeypatch, tmp_path)
+        limit = 1024 * 1024
         monkeypatch.setitem(
             files.UPLOAD_SPECS,
             "prop",
-            dataclasses.replace(files.UPLOAD_SPECS["prop"], max_bytes=16),
+            dataclasses.replace(files.UPLOAD_SPECS["prop"], max_bytes=limit),
         )
         with client:
             resp = client.post(
                 "/api/v1/projects/demo/upload/prop",
                 params={"name": "道具"},
-                files={"file": ("x.jpg", _img_bytes("JPEG"), "image/jpeg")},
+                files={"file": ("x.jpg", b"\x00" * (limit + 1), "image/jpeg")},
             )
             assert resp.status_code == 400
-            assert resp.json()["detail"] == zh_errors.MESSAGES["upload_too_large"].format(max_mb=0)
+            # 上限取整 MB，文案里的 max_mb 才是对用户有意义的数字
+            assert resp.json()["detail"] == zh_errors.MESSAGES["upload_too_large"].format(max_mb=1)
 
     def test_source_decode_and_draft_mode_helpers(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -1,8 +1,10 @@
+import dataclasses
 import json
 import shutil
 from io import BytesIO
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from PIL import Image
@@ -647,19 +649,13 @@ class TestFilesRouter:
         unsafe_names = ["../../evil", "sub/dir", "back\\slash", "..", "trailing.", "CON", "ctrl\x01char"]
         payloads = {
             "character_audio_ref": ("v.wav", _wav_bytes(3), "audio/wav"),
+            # source 不使用 name，但校验在其早返分支之前，同样应拒
+            "source": ("novel.txt", b"chapter one", "text/plain"),
         }
         default_payload = ("x.jpg", _img_bytes("JPEG"), "image/jpeg")
 
         with client:
-            for upload_type in (
-                "character",
-                "character_ref",
-                "character_audio_ref",
-                "scene",
-                "prop",
-                "product",
-                "product_ref",
-            ):
+            for upload_type in files.UPLOAD_SPECS:
                 for unsafe in unsafe_names:
                     resp = client.post(
                         f"/api/v1/projects/demo/upload/{upload_type}",
@@ -709,6 +705,36 @@ class TestFilesRouter:
         assert set(files.ALLOWED_EXTENSIONS) == set(files.UPLOAD_SPECS)
         for upload_type, spec in files.UPLOAD_SPECS.items():
             assert files.ALLOWED_EXTENSIONS[upload_type] == list(spec.allowed_exts)
+        # source 一项被 frontend/src/utils/source-files.ts 镜像，取值变动需同步前端
+        assert files.ALLOWED_EXTENSIONS["source"] == [".txt", ".md", ".docx", ".epub", ".pdf"]
+
+    def test_upload_spec_host_fields_must_be_paired(self):
+        """登记宿主约束却漏配 404 文案时，构造期即失败，而非拒收时取到空翻译 key。"""
+        with pytest.raises(ValueError):
+            files.UploadSpec(
+                allowed_exts=(".png",),
+                subdir=("x",),
+                naming="stable_png",
+                content_check="validate_image",
+                host_bucket="products",
+            )
+
+    def test_upload_rejects_oversized_payload_for_any_type(self, tmp_path, monkeypatch):
+        """max_bytes 是通用请求体闸门：登记了上限的类型无论 content_check 为何都应拒收超限请求。"""
+        client, _ = _client(monkeypatch, tmp_path)
+        monkeypatch.setitem(
+            files.UPLOAD_SPECS,
+            "prop",
+            dataclasses.replace(files.UPLOAD_SPECS["prop"], max_bytes=16),
+        )
+        with client:
+            resp = client.post(
+                "/api/v1/projects/demo/upload/prop",
+                params={"name": "道具"},
+                files={"file": ("x.jpg", _img_bytes("JPEG"), "image/jpeg")},
+            )
+            assert resp.status_code == 400
+            assert resp.json()["detail"] == zh_errors.MESSAGES["upload_too_large"].format(max_mb=0)
 
     def test_source_decode_and_draft_mode_helpers(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -7,6 +7,9 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from PIL import Image
 
+from lib.i18n.en import assets as en_assets
+from lib.i18n.vi import assets as vi_assets
+from lib.i18n.zh import assets as zh_assets
 from lib.i18n.zh import errors as zh_errors
 from lib.project_manager import ProjectManager
 from server.auth import CurrentUserInfo, get_current_user
@@ -635,6 +638,77 @@ class TestFilesRouter:
             )
             assert character_missing_entity.status_code == 200
             assert character_missing_entity.json()["path"] == "characters/不存在角色.jpg"
+
+    def test_upload_rejects_unsafe_name_for_every_type(self, tmp_path, monkeypatch):
+        """name 会被拼进落盘路径：含分隔符 / .. / 控制字符的名字在所有上传类型下都应被 400 拒绝。"""
+        client, pm = _client(monkeypatch, tmp_path)
+        projects_root = pm.get_project_path("demo").parent
+        before = sorted(p for p in projects_root.rglob("*") if p.is_file())
+        unsafe_names = ["../../evil", "sub/dir", "back\\slash", "..", "trailing.", "CON", "ctrl\x01char"]
+        payloads = {
+            "character_audio_ref": ("v.wav", _wav_bytes(3), "audio/wav"),
+        }
+        default_payload = ("x.jpg", _img_bytes("JPEG"), "image/jpeg")
+
+        with client:
+            for upload_type in (
+                "character",
+                "character_ref",
+                "character_audio_ref",
+                "scene",
+                "prop",
+                "product",
+                "product_ref",
+            ):
+                for unsafe in unsafe_names:
+                    resp = client.post(
+                        f"/api/v1/projects/demo/upload/{upload_type}",
+                        params={"name": unsafe},
+                        files={"file": payloads.get(upload_type, default_payload)},
+                    )
+                    assert resp.status_code == 400, (upload_type, unsafe, resp.status_code)
+                    assert resp.json()["detail"] == zh_assets.MESSAGES["asset_invalid_name"].format(name=unsafe)
+
+            # 越界名字不得留下任何落盘产物（项目内与项目外都不得新增文件）
+            assert sorted(p for p in projects_root.rglob("*") if p.is_file()) == before
+
+    def test_upload_unsafe_name_message_is_localized(self, tmp_path, monkeypatch):
+        client, _ = _client(monkeypatch, tmp_path)
+        expected = {
+            "en": en_assets.MESSAGES["asset_invalid_name"],
+            "vi": vi_assets.MESSAGES["asset_invalid_name"],
+            "zh": zh_assets.MESSAGES["asset_invalid_name"],
+        }
+
+        with client:
+            for locale, template in expected.items():
+                resp = client.post(
+                    "/api/v1/projects/demo/upload/character",
+                    params={"name": "../evil"},
+                    files={"file": ("x.jpg", _img_bytes("JPEG"), "image/jpeg")},
+                    headers={"Accept-Language": locale},
+                )
+                assert resp.status_code == 400
+                assert resp.json()["detail"] == template.format(name="../evil")
+
+    def test_upload_name_is_stripped_before_use(self, tmp_path, monkeypatch):
+        """校验谓词会 strip 名字，落盘路径与元数据都应使用规范化后的值。"""
+        client, pm = _client(monkeypatch, tmp_path)
+        with client:
+            resp = client.post(
+                "/api/v1/projects/demo/upload/character",
+                params={"name": "  Alice  "},
+                files={"file": ("x.jpg", _img_bytes("JPEG"), "image/jpeg")},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["path"] == "characters/Alice.jpg"
+            assert pm.load_project("demo")["characters"]["Alice"]["character_sheet"] == "characters/Alice.jpg"
+
+    def test_upload_spec_table_drives_extensions(self):
+        """ALLOWED_EXTENSIONS 由 UPLOAD_SPECS 派生，两者不得漂移。"""
+        assert set(files.ALLOWED_EXTENSIONS) == set(files.UPLOAD_SPECS)
+        for upload_type, spec in files.UPLOAD_SPECS.items():
+            assert files.ALLOWED_EXTENSIONS[upload_type] == list(spec.allowed_exts)
 
     def test_source_decode_and_draft_mode_helpers(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)


### PR DESCRIPTION
Closes #1584

## 问题

`upload_file` 的 `name` 查询参数直接参与落盘路径拼接，无任何资产名校验。认证后的调用可用含路径分隔符或 `..` 的 `name` 拼出项目目录外的写入路径——`character_audio_ref`（`f"{name}{ext}"` 直接拼进目标目录）与 `product_ref`（`candidate.touch()` 在取 `.name` 之前就按 `name` 写盘）是真正可越界的两条；图片类型因 `Path(...).with_suffix(...).name` 顺带塌缩成单段而侥幸未越界。

## 改动

**安全修复** — 路由边界对 `name` 调用 `lib.asset_types.validate_asset_name`，非法名返回 400 `asset_invalid_name`，与 `assets.py::_validate_asset_name` 和音色确认端点同一谓词、同一 i18n key（三语文案已存在，未新增 key）。校验前置于 `try:` 块，避免与尾部 `except Exception` 兜底 500 耦合。`?name=`（空串）此前等同「未提供」并回落到原文件名 stem，该语义未改（前后端既有测试依赖）。

**分支收编** — 新增 `UploadSpec` frozen dataclass + `UPLOAD_SPECS` 表（8 个 upload_type），消掉四段并列 if/elif 链：目标目录+文件名、内容后处理、`relative_path` 拼接、元数据回写。`ALLOWED_EXTENSIONS` 保留但改为由表派生。`source` 由 `_handle_source_upload` 全权接管，是表外的唯一例外（已在 docstring 注明）。

## 验证

- `uv run python -m pytest`：7620 passed
- `uv run ruff check` / `ruff format`：通过，无改写
- `uv run basedpyright`：0 errors
- 新增 7 个用例：全 8 类 upload_type × 7 种非法名（`../../evil`、`sub/dir`、`back\slash`、`..`、`trailing.`、`CON`、控制字符）全部 400 且文案匹配，并快照比对 projects 根目录断言无任何新增落盘文件；三语文案；strip 语义；体积闸门对非音频类型生效；表字段成对不变量；`ALLOWED_EXTENSIONS` 与 `UPLOAD_SPECS` 不漂移
- 未动前端源码

## 已知边界

`upload_file` 仍无通用请求体上限：`UploadSpec.max_bytes` 现已对所有类型生效，但只有 `character_audio_ref` 登记了数值——图片类型只在 >2MB 时压缩、从不拒绝，`product_ref` 按保真锚点取舍完全无上限（ADR 0034）。要加统一体积闸门，登记数值即可。`shot_uploads.py` 是另一条独立上传路由，本次未纳入。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 统一支持图片、音频及产品参考图上传，并自动进行格式、内容和大小校验。
  * 文件名支持安全检查、首尾空白清理及规范化处理；参考图可自动生成唯一名称。
  * 上传成功后，相关资产与元数据会自动同步更新。

* **问题修复**
  * 拒绝不安全文件名和超出大小限制的文件，避免生成无效文件。
  * 上传错误信息支持多语言显示。
  * 改善图片处理、音频替换及旧文件清理流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->